### PR TITLE
all: Use the name MicroPython consistently

### DIFF
--- a/bare-arm/mpconfigport.h
+++ b/bare-arm/mpconfigport.h
@@ -1,6 +1,6 @@
 #include <stdint.h>
 
-// options to control how Micro Python is built
+// options to control how MicroPython is built
 
 #define MICROPY_QSTR_BYTES_IN_HASH  (1)
 #define MICROPY_ALLOC_PATH_MAX      (512)

--- a/cc3200/application.lds
+++ b/cc3200/application.lds
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Micro Python project, http://micropython.org/
+ * This file is part of the MicroPython project, http://micropython.org/
  *
  * The MIT License (MIT)
  *
@@ -37,7 +37,7 @@ ENTRY(ResetISR)
 
 SECTIONS
 {  
-    /* place the FreeRTOS heap (the micropython stack will live here) */
+    /* place the FreeRTOS heap (the MicroPython stack will live here) */
     .rtos_heap (NOLOAD) :
     {
         . = ALIGN(8);
@@ -83,7 +83,7 @@ SECTIONS
     } > SRAM
 
     /* place here functions that are only called during boot up, */
-    /* that way, we can re-use this area for the micropython heap */
+    /* that way, we can re-use this area for the MicroPython heap */
     .boot :
     {
         . = ALIGN(8);
@@ -93,7 +93,7 @@ SECTIONS
         _eboot = .;
     } > SRAM
      
-    /* allocate the micropython heap */
+    /* allocate the MicroPython heap */
     .heap :
     {
         . = ALIGN(8);

--- a/cc3200/boards/LAUNCHXL/mpconfigboard.h
+++ b/cc3200/boards/LAUNCHXL/mpconfigboard.h
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Micro Python project, http://micropython.org/
+ * This file is part of the MicroPython project, http://micropython.org/
  *
  * The MIT License (MIT)
  *

--- a/cc3200/boards/WIPY/mpconfigboard.h
+++ b/cc3200/boards/WIPY/mpconfigboard.h
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Micro Python project, http://micropython.org/
+ * This file is part of the MicroPython project, http://micropython.org/
  *
  * The MIT License (MIT)
  *

--- a/cc3200/boards/cc3200_prefix.c
+++ b/cc3200/boards/cc3200_prefix.c
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Micro Python project, http://micropython.org/
+ * This file is part of the MicroPython project, http://micropython.org/
  *
  * The MIT License (MIT)
  *

--- a/cc3200/bootmgr/bootmgr.h
+++ b/cc3200/bootmgr/bootmgr.h
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Micro Python project, http://micropython.org/
+ * This file is part of the MicroPython project, http://micropython.org/
  *
  * The MIT License (MIT)
  *

--- a/cc3200/bootmgr/bootmgr.lds
+++ b/cc3200/bootmgr/bootmgr.lds
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Micro Python project, http://micropython.org/
+ * This file is part of the MicroPython project, http://micropython.org/
  *
  * The MIT License (MIT)
  *

--- a/cc3200/bootmgr/flc.h
+++ b/cc3200/bootmgr/flc.h
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Micro Python project, http://micropython.org/
+ * This file is part of the MicroPython project, http://micropython.org/
  *
  * The MIT License (MIT)
  *

--- a/cc3200/bootmgr/main.c
+++ b/cc3200/bootmgr/main.c
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Micro Python project, http://micropython.org/
+ * This file is part of the MicroPython project, http://micropython.org/
  *
  * The MIT License (MIT)
  *

--- a/cc3200/ftp/ftp.c
+++ b/cc3200/ftp/ftp.c
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Micro Python project, http://micropython.org/
+ * This file is part of the MicroPython project, http://micropython.org/
  *
  * The MIT License (MIT)
  *

--- a/cc3200/ftp/ftp.h
+++ b/cc3200/ftp/ftp.h
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Micro Python project, http://micropython.org/
+ * This file is part of the MicroPython project, http://micropython.org/
  *
  * The MIT License (MIT)
  *

--- a/cc3200/ftp/updater.c
+++ b/cc3200/ftp/updater.c
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Micro Python project, http://micropython.org/
+ * This file is part of the MicroPython project, http://micropython.org/
  *
  * The MIT License (MIT)
  *

--- a/cc3200/ftp/updater.h
+++ b/cc3200/ftp/updater.h
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Micro Python project, http://micropython.org/
+ * This file is part of the MicroPython project, http://micropython.org/
  *
  * The MIT License (MIT)
  *

--- a/cc3200/hal/cc3200_asm.h
+++ b/cc3200/hal/cc3200_asm.h
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Micro Python project, http://micropython.org/
+ * This file is part of the MicroPython project, http://micropython.org/
  *
  * The MIT License (MIT)
  *

--- a/cc3200/hal/cc3200_hal.c
+++ b/cc3200/hal/cc3200_hal.c
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Micro Python project, http://micropython.org/
+ * This file is part of the MicroPython project, http://micropython.org/
  *
  * The MIT License (MIT)
  *

--- a/cc3200/hal/cc3200_hal.h
+++ b/cc3200/hal/cc3200_hal.h
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Micro Python project, http://micropython.org/
+ * This file is part of the MicroPython project, http://micropython.org/
  *
  * The MIT License (MIT)
  *

--- a/cc3200/hal/fault_registers.h
+++ b/cc3200/hal/fault_registers.h
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Micro Python project, http://micropython.org/
+ * This file is part of the MicroPython project, http://micropython.org/
  *
  * The MIT License (MIT)
  *

--- a/cc3200/main.c
+++ b/cc3200/main.c
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Micro Python project, http://micropython.org/
+ * This file is part of the MicroPython project, http://micropython.org/
  *
  * The MIT License (MIT)
  *

--- a/cc3200/misc/FreeRTOSHooks.c
+++ b/cc3200/misc/FreeRTOSHooks.c
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Micro Python project, http://micropython.org/
+ * This file is part of the MicroPython project, http://micropython.org/
  *
  * The MIT License (MIT)
  *

--- a/cc3200/misc/antenna.c
+++ b/cc3200/misc/antenna.c
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Micro Python project, http://micropython.org/
+ * This file is part of the MicroPython project, http://micropython.org/
  *
  * The MIT License (MIT)
  *

--- a/cc3200/misc/antenna.h
+++ b/cc3200/misc/antenna.h
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Micro Python project, http://micropython.org/
+ * This file is part of the MicroPython project, http://micropython.org/
  *
  * The MIT License (MIT)
  *

--- a/cc3200/misc/help.c
+++ b/cc3200/misc/help.c
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Micro Python project, http://micropython.org/
+ * This file is part of the MicroPython project, http://micropython.org/
  *
  * The MIT License (MIT)
  *

--- a/cc3200/misc/mperror.c
+++ b/cc3200/misc/mperror.c
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Micro Python project, http://micropython.org/
+ * This file is part of the MicroPython project, http://micropython.org/
  *
  * The MIT License (MIT)
  *

--- a/cc3200/misc/mperror.h
+++ b/cc3200/misc/mperror.h
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Micro Python project, http://micropython.org/
+ * This file is part of the MicroPython project, http://micropython.org/
  *
  * The MIT License (MIT)
  *

--- a/cc3200/misc/mpexception.c
+++ b/cc3200/misc/mpexception.c
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Micro Python project, http://micropython.org/
+ * This file is part of the MicroPython project, http://micropython.org/
  *
  * The MIT License (MIT)
  *

--- a/cc3200/misc/mpexception.h
+++ b/cc3200/misc/mpexception.h
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Micro Python project, http://micropython.org/
+ * This file is part of the MicroPython project, http://micropython.org/
  *
  * The MIT License (MIT)
  *

--- a/cc3200/misc/mpirq.c
+++ b/cc3200/misc/mpirq.c
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Micro Python project, http://micropython.org/
+ * This file is part of the MicroPython project, http://micropython.org/
  *
  * The MIT License (MIT)
  *
@@ -143,7 +143,7 @@ void mp_irq_handler (mp_obj_t self_in) {
 }
 
 /******************************************************************************/
-// Micro Python bindings
+// MicroPython bindings
 
 STATIC mp_obj_t mp_irq_init (mp_uint_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
     mp_irq_obj_t *self = pos_args[0];

--- a/cc3200/misc/mpirq.h
+++ b/cc3200/misc/mpirq.h
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Micro Python project, http://micropython.org/
+ * This file is part of the MicroPython project, http://micropython.org/
  *
  * The MIT License (MIT)
  *

--- a/cc3200/mods/modmachine.c
+++ b/cc3200/mods/modmachine.c
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Micro Python project, http://micropython.org/
+ * This file is part of the MicroPython project, http://micropython.org/
  *
  * The MIT License (MIT)
  *
@@ -72,7 +72,7 @@ extern OsiTaskHandle    xSimpleLinkSpawnTaskHndl;
 ///
 
 /******************************************************************************/
-// Micro Python bindings;
+// MicroPython bindings;
 
 STATIC mp_obj_t machine_reset(void) {
     // disable wlan

--- a/cc3200/mods/modnetwork.c
+++ b/cc3200/mods/modnetwork.c
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Micro Python project, http://micropython.org/
+ * This file is part of the MicroPython project, http://micropython.org/
  *
  * The MIT License (MIT)
  *

--- a/cc3200/mods/modnetwork.h
+++ b/cc3200/mods/modnetwork.h
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Micro Python project, http://micropython.org/
+ * This file is part of the MicroPython project, http://micropython.org/
  *
  * The MIT License (MIT)
  *

--- a/cc3200/mods/modubinascii.c
+++ b/cc3200/mods/modubinascii.c
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Micro Python project, http://micropython.org/
+ * This file is part of the MicroPython project, http://micropython.org/
  *
  * The MIT License (MIT)
  *
@@ -44,7 +44,7 @@
 
 
 /******************************************************************************/
-// Micro Python bindings
+// MicroPython bindings
 
 STATIC const mp_map_elem_t mp_module_binascii_globals_table[] = {
     { MP_OBJ_NEW_QSTR(MP_QSTR___name__),        MP_OBJ_NEW_QSTR(MP_QSTR_ubinascii) },

--- a/cc3200/mods/modubinascii.h
+++ b/cc3200/mods/modubinascii.h
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Micro Python project, http://micropython.org/
+ * This file is part of the MicroPython project, http://micropython.org/
  *
  * The MIT License (MIT)
  *

--- a/cc3200/mods/moduhashlib.c
+++ b/cc3200/mods/moduhashlib.c
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Micro Python project, http://micropython.org/
+ * This file is part of the MicroPython project, http://micropython.org/
  *
  * The MIT License (MIT)
  *
@@ -117,7 +117,7 @@ STATIC mp_obj_t hash_read (mp_obj_t self_in) {
 }
 
 /******************************************************************************/
-// Micro Python bindings
+// MicroPython bindings
 
 /// \classmethod \constructor([data[, block_size]])
 /// initial data must be given if block_size wants to be passed

--- a/cc3200/mods/moduos.c
+++ b/cc3200/mods/moduos.c
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Micro Python project, http://micropython.org/
+ * This file is part of the MicroPython project, http://micropython.org/
  *
  * The MIT License (MIT)
  *
@@ -78,7 +78,7 @@ void osmount_unmount_all (void) {
 }
 
 /******************************************************************************/
-// Micro Python bindings
+// MicroPython bindings
 //
 
 STATIC const qstr os_uname_info_fields[] = {

--- a/cc3200/mods/moduos.h
+++ b/cc3200/mods/moduos.h
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Micro Python project, http://micropython.org/
+ * This file is part of the MicroPython project, http://micropython.org/
  *
  * The MIT License (MIT)
  *

--- a/cc3200/mods/modusocket.c
+++ b/cc3200/mods/modusocket.c
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Micro Python project, http://micropython.org/
+ * This file is part of the MicroPython project, http://micropython.org/
  *
  * The MIT License (MIT)
  *

--- a/cc3200/mods/modusocket.h
+++ b/cc3200/mods/modusocket.h
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Micro Python project, http://micropython.org/
+ * This file is part of the MicroPython project, http://micropython.org/
  *
  * The MIT License (MIT)
  *

--- a/cc3200/mods/modussl.c
+++ b/cc3200/mods/modussl.c
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Micro Python project, http://micropython.org/
+ * This file is part of the MicroPython project, http://micropython.org/
  *
  * The MIT License (MIT)
  *
@@ -57,7 +57,7 @@ typedef struct _mp_obj_ssl_socket_t {
 STATIC const mp_obj_type_t ssl_socket_type;
 
 /******************************************************************************/
-// Micro Python bindings; SSL class
+// MicroPython bindings; SSL class
 
 // ssl sockets inherit from normal socket, so we take its
 // locals and stream methods

--- a/cc3200/mods/modutime.c
+++ b/cc3200/mods/modutime.c
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Micro Python project, http://micropython.org/
+ * This file is part of the MicroPython project, http://micropython.org/
  *
  * The MIT License (MIT)
  *
@@ -51,7 +51,7 @@
 /// and for sleeping.
 
 /******************************************************************************/
-// Micro Python bindings
+// MicroPython bindings
 
 /// \function localtime([secs])
 /// Convert a time expressed in seconds since Jan 1, 2000 into an 8-tuple which

--- a/cc3200/mods/modwipy.c
+++ b/cc3200/mods/modwipy.c
@@ -5,7 +5,7 @@
 
 
 /******************************************************************************/
-// Micro Python bindings
+// MicroPython bindings
 
 STATIC mp_obj_t mod_wipy_heartbeat (mp_uint_t n_args, const mp_obj_t *args) {
     if (n_args) {

--- a/cc3200/mods/modwlan.c
+++ b/cc3200/mods/modwlan.c
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Micro Python project, http://micropython.org/
+ * This file is part of the MicroPython project, http://micropython.org/
  *
  * The MIT License (MIT)
  *
@@ -763,7 +763,7 @@ STATIC bool wlan_scan_result_is_unique (const mp_obj_list_t *nets, _u8 *bssid) {
 }
 
 /******************************************************************************/
-// Micro Python bindings; WLAN class
+// MicroPython bindings; WLAN class
 
 /// \class WLAN - WiFi driver
 

--- a/cc3200/mods/modwlan.h
+++ b/cc3200/mods/modwlan.h
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Micro Python project, http://micropython.org/
+ * This file is part of the MicroPython project, http://micropython.org/
  *
  * The MIT License (MIT)
  *

--- a/cc3200/mods/pybadc.c
+++ b/cc3200/mods/pybadc.c
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Micro Python project, http://micropython.org/
+ * This file is part of the MicroPython project, http://micropython.org/
  *
  * The MIT License (MIT)
  *
@@ -126,7 +126,7 @@ STATIC void pyb_adc_deinit_all_channels (void) {
 }
 
 /******************************************************************************/
-/* Micro Python bindings : adc object                                         */
+/* MicroPython bindings : adc object                                         */
 
 STATIC void adc_print(const mp_print_t *print, mp_obj_t self_in, mp_print_kind_t kind) {
     pyb_adc_obj_t *self = self_in;

--- a/cc3200/mods/pybadc.h
+++ b/cc3200/mods/pybadc.h
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Micro Python project, http://micropython.org/
+ * This file is part of the MicroPython project, http://micropython.org/
  *
  * The MIT License (MIT)
  *

--- a/cc3200/mods/pybi2c.c
+++ b/cc3200/mods/pybi2c.c
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Micro Python project, http://micropython.org/
+ * This file is part of the MicroPython project, http://micropython.org/
  *
  * The MIT License (MIT)
  *
@@ -281,7 +281,7 @@ STATIC void pyb_i2c_readmem_into (mp_arg_val_t *args, vstr_t *vstr) {
 }
 
 /******************************************************************************/
-/* Micro Python bindings                                                      */
+/* MicroPython bindings                                                      */
 /******************************************************************************/
 STATIC void pyb_i2c_print(const mp_print_t *print, mp_obj_t self_in, mp_print_kind_t kind) {
     pyb_i2c_obj_t *self = self_in;

--- a/cc3200/mods/pybi2c.h
+++ b/cc3200/mods/pybi2c.h
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Micro Python project, http://micropython.org/
+ * This file is part of the MicroPython project, http://micropython.org/
  *
  * The MIT License (MIT)
  *

--- a/cc3200/mods/pybpin.c
+++ b/cc3200/mods/pybpin.c
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Micro Python project, http://micropython.org/
+ * This file is part of the MicroPython project, http://micropython.org/
  *
  * The MIT License (MIT)
  *
@@ -519,7 +519,7 @@ STATIC void EXTI_Handler(uint port) {
 
 
 /******************************************************************************/
-// Micro Python bindings
+// MicroPython bindings
 
 STATIC const mp_arg_t pin_init_args[] = {
     { MP_QSTR_mode,                        MP_ARG_OBJ, {.u_obj = MP_OBJ_NULL} },

--- a/cc3200/mods/pybpin.h
+++ b/cc3200/mods/pybpin.h
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Micro Python project, http://micropython.org/
+ * This file is part of the MicroPython project, http://micropython.org/
  *
  * The MIT License (MIT)
  *

--- a/cc3200/mods/pybrtc.c
+++ b/cc3200/mods/pybrtc.c
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Micro Python project, http://micropython.org/
+ * This file is part of the MicroPython project, http://micropython.org/
  *
  * The MIT License (MIT)
  *
@@ -278,7 +278,7 @@ STATIC void rtc_msec_add (uint16_t msecs_1, uint32_t *secs, uint16_t *msecs_2) {
 }
 
 /******************************************************************************/
-// Micro Python bindings
+// MicroPython bindings
 
 STATIC const mp_arg_t pyb_rtc_init_args[] = {
     { MP_QSTR_id,                             MP_ARG_INT, {.u_int = 0} },

--- a/cc3200/mods/pybrtc.h
+++ b/cc3200/mods/pybrtc.h
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Micro Python project, http://micropython.org/
+ * This file is part of the MicroPython project, http://micropython.org/
  *
  * The MIT License (MIT)
  *

--- a/cc3200/mods/pybsd.c
+++ b/cc3200/mods/pybsd.c
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Micro Python project, http://micropython.org/
+ * This file is part of the MicroPython project, http://micropython.org/
  *
  * The MIT License (MIT)
  *
@@ -118,7 +118,7 @@ STATIC mp_obj_t pyb_sd_init_helper (pybsd_obj_t *self, const mp_arg_val_t *args)
 }
 
 /******************************************************************************/
-// Micro Python bindings
+// MicroPython bindings
 //
 
 STATIC const mp_arg_t pyb_sd_init_args[] = {

--- a/cc3200/mods/pybsd.h
+++ b/cc3200/mods/pybsd.h
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Micro Python project, http://micropython.org/
+ * This file is part of the MicroPython project, http://micropython.org/
  *
  * The MIT License (MIT)
  *

--- a/cc3200/mods/pybsleep.c
+++ b/cc3200/mods/pybsleep.c
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Micro Python project, http://micropython.org/
+ * This file is part of the MicroPython project, http://micropython.org/
  *
  * The MIT License (MIT)
  *

--- a/cc3200/mods/pybsleep.h
+++ b/cc3200/mods/pybsleep.h
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Micro Python project, http://micropython.org/
+ * This file is part of the MicroPython project, http://micropython.org/
  *
  * The MIT License (MIT)
  *

--- a/cc3200/mods/pybspi.c
+++ b/cc3200/mods/pybspi.c
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Micro Python project, http://micropython.org/
+ * This file is part of the MicroPython project, http://micropython.org/
  *
  * The MIT License (MIT)
  *
@@ -144,7 +144,7 @@ STATIC void pybspi_transfer (pyb_spi_obj_t *self, const char *txdata, char *rxda
 }
 
 /******************************************************************************/
-/* Micro Python bindings                                                      */
+/* MicroPython bindings                                                      */
 /******************************************************************************/
 STATIC void pyb_spi_print(const mp_print_t *print, mp_obj_t self_in, mp_print_kind_t kind) {
     pyb_spi_obj_t *self = self_in;

--- a/cc3200/mods/pybspi.h
+++ b/cc3200/mods/pybspi.h
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Micro Python project, http://micropython.org/
+ * This file is part of the MicroPython project, http://micropython.org/
  *
  * The MIT License (MIT)
  *

--- a/cc3200/mods/pybtimer.c
+++ b/cc3200/mods/pybtimer.c
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Micro Python project, http://micropython.org/
+ * This file is part of the MicroPython project, http://micropython.org/
  *
  * The MIT License (MIT)
  *
@@ -264,7 +264,7 @@ STATIC void timer_channel_init (pyb_timer_channel_obj_t *ch) {
 }
 
 /******************************************************************************/
-/* Micro Python bindings                                                      */
+/* MicroPython bindings                                                      */
 
 STATIC void pyb_timer_print(const mp_print_t *print, mp_obj_t self_in, mp_print_kind_t kind) {
     pyb_timer_obj_t *tim = self_in;

--- a/cc3200/mods/pybtimer.h
+++ b/cc3200/mods/pybtimer.h
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Micro Python project, http://micropython.org/
+ * This file is part of the MicroPython project, http://micropython.org/
  *
  * The MIT License (MIT)
  *

--- a/cc3200/mods/pybuart.c
+++ b/cc3200/mods/pybuart.c
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Micro Python project, http://micropython.org/
+ * This file is part of the MicroPython project, http://micropython.org/
  *
  * The MIT License (MIT)
  *
@@ -311,7 +311,7 @@ STATIC int uart_irq_flags (mp_obj_t self_in) {
 }
 
 /******************************************************************************/
-/* Micro Python bindings                                                      */
+/* MicroPython bindings                                                      */
 
 STATIC void pyb_uart_print(const mp_print_t *print, mp_obj_t self_in, mp_print_kind_t kind) {
     pyb_uart_obj_t *self = self_in;

--- a/cc3200/mods/pybuart.h
+++ b/cc3200/mods/pybuart.h
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Micro Python project, http://micropython.org/
+ * This file is part of the MicroPython project, http://micropython.org/
  *
  * The MIT License (MIT)
  *

--- a/cc3200/mods/pybwdt.c
+++ b/cc3200/mods/pybwdt.c
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Micro Python project, http://micropython.org/
+ * This file is part of the MicroPython project, http://micropython.org/
  *
  * The MIT License (MIT)
  *
@@ -87,7 +87,7 @@ void pybwdt_sl_alive (void) {
 }
 
 /******************************************************************************/
-// Micro Python bindings
+// MicroPython bindings
 
 STATIC const mp_arg_t pyb_wdt_init_args[] = {
     { MP_QSTR_id,                             MP_ARG_OBJ,  {.u_obj = mp_const_none} },

--- a/cc3200/mods/pybwdt.h
+++ b/cc3200/mods/pybwdt.h
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Micro Python project, http://micropython.org/
+ * This file is part of the MicroPython project, http://micropython.org/
  *
  * The MIT License (MIT)
  *

--- a/cc3200/mpconfigport.h
+++ b/cc3200/mpconfigport.h
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Micro Python project, http://micropython.org/
+ * This file is part of the MicroPython project, http://micropython.org/
  *
  * The MIT License (MIT)
  *
@@ -32,7 +32,7 @@
 #include "semphr.h"
 #endif
 
-// options to control how Micro Python is built
+// options to control how MicroPython is built
 
 #define MICROPY_ALLOC_PATH_MAX                      (128)
 #define MICROPY_PERSISTENT_CODE_LOAD                (1)

--- a/cc3200/mptask.c
+++ b/cc3200/mptask.c
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Micro Python project, http://micropython.org/
+ * This file is part of the MicroPython project, http://micropython.org/
  *
  * The MIT License (MIT)
  *

--- a/cc3200/mptask.h
+++ b/cc3200/mptask.h
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Micro Python project, http://micropython.org/
+ * This file is part of the MicroPython project, http://micropython.org/
  *
  * The MIT License (MIT)
  *

--- a/cc3200/qstrdefsport.h
+++ b/cc3200/qstrdefsport.h
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Micro Python project, http://micropython.org/
+ * This file is part of the MicroPython project, http://micropython.org/
  *
  * The MIT License (MIT)
  *

--- a/cc3200/serverstask.c
+++ b/cc3200/serverstask.c
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Micro Python project, http://micropython.org/
+ * This file is part of the MicroPython project, http://micropython.org/
  *
  * The MIT License (MIT)
  *

--- a/cc3200/serverstask.h
+++ b/cc3200/serverstask.h
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Micro Python project, http://micropython.org/
+ * This file is part of the MicroPython project, http://micropython.org/
  *
  * The MIT License (MIT)
  *

--- a/cc3200/telnet/telnet.c
+++ b/cc3200/telnet/telnet.c
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Micro Python project, http://micropython.org/
+ * This file is part of the MicroPython project, http://micropython.org/
  *
  * The MIT License (MIT)
  *

--- a/cc3200/telnet/telnet.h
+++ b/cc3200/telnet/telnet.h
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Micro Python project, http://micropython.org/
+ * This file is part of the MicroPython project, http://micropython.org/
  *
  * The MIT License (MIT)
  *

--- a/cc3200/util/cryptohash.c
+++ b/cc3200/util/cryptohash.c
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Micro Python project, http://micropython.org/
+ * This file is part of the MicroPython project, http://micropython.org/
  *
  * The MIT License (MIT)
  *

--- a/cc3200/util/cryptohash.h
+++ b/cc3200/util/cryptohash.h
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Micro Python project, http://micropython.org/
+ * This file is part of the MicroPython project, http://micropython.org/
  *
  * The MIT License (MIT)
  *

--- a/cc3200/util/fifo.c
+++ b/cc3200/util/fifo.c
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Micro Python project, http://micropython.org/
+ * This file is part of the MicroPython project, http://micropython.org/
  *
  * The MIT License (MIT)
  *

--- a/cc3200/util/fifo.h
+++ b/cc3200/util/fifo.h
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Micro Python project, http://micropython.org/
+ * This file is part of the MicroPython project, http://micropython.org/
  *
  * The MIT License (MIT)
  *

--- a/cc3200/util/gccollect.c
+++ b/cc3200/util/gccollect.c
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Micro Python project, http://micropython.org/
+ * This file is part of the MicroPython project, http://micropython.org/
  *
  * The MIT License (MIT)
  *

--- a/cc3200/util/gccollect.h
+++ b/cc3200/util/gccollect.h
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Micro Python project, http://micropython.org/
+ * This file is part of the MicroPython project, http://micropython.org/
  *
  * The MIT License (MIT)
  *

--- a/cc3200/util/gchelper.h
+++ b/cc3200/util/gchelper.h
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Micro Python project, http://micropython.org/
+ * This file is part of the MicroPython project, http://micropython.org/
  *
  * The MIT License (MIT)
  *

--- a/cc3200/util/random.c
+++ b/cc3200/util/random.c
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Micro Python project, http://micropython.org/
+ * This file is part of the MicroPython project, http://micropython.org/
  *
  * The MIT License (MIT)
  *
@@ -67,7 +67,7 @@ STATIC uint32_t lfsr (uint32_t input) {
 }
 
 /******************************************************************************/
-// Micro Python bindings;
+// MicroPython bindings;
 
 STATIC mp_obj_t machine_rng_get(void) {
     return mp_obj_new_int(rng_get());

--- a/cc3200/util/random.h
+++ b/cc3200/util/random.h
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Micro Python project, http://micropython.org/
+ * This file is part of the MicroPython project, http://micropython.org/
  *
  * The MIT License (MIT)
  *

--- a/cc3200/util/sleeprestore.h
+++ b/cc3200/util/sleeprestore.h
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Micro Python project, http://micropython.org/
+ * This file is part of the MicroPython project, http://micropython.org/
  *
  * The MIT License (MIT)
  *

--- a/cc3200/util/socketfifo.c
+++ b/cc3200/util/socketfifo.c
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Micro Python project, http://micropython.org/
+ * This file is part of the MicroPython project, http://micropython.org/
  *
  * The MIT License (MIT)
  *

--- a/cc3200/util/socketfifo.h
+++ b/cc3200/util/socketfifo.h
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Micro Python project, http://micropython.org/
+ * This file is part of the MicroPython project, http://micropython.org/
  *
  * The MIT License (MIT)
  *

--- a/cc3200/version.h
+++ b/cc3200/version.h
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Micro Python project, http://micropython.org/
+ * This file is part of the MicroPython project, http://micropython.org/
  *
  * The MIT License (MIT)
  *

--- a/drivers/nrf24l01/nrf24l01.py
+++ b/drivers/nrf24l01/nrf24l01.py
@@ -1,4 +1,4 @@
-"""NRF24L01 driver for Micro Python
+"""NRF24L01 driver for MicroPython
 """
 
 from micropython import const

--- a/drivers/sdcard/sdcard.py
+++ b/drivers/sdcard/sdcard.py
@@ -1,5 +1,5 @@
 """
-Micro Python driver for SD cards using SPI bus.
+MicroPython driver for SD cards using SPI bus.
 
 Requires an SPI bus and a CS pin.  Provides readblocks and writeblocks
 methods so the device can be mounted as a filesystem.

--- a/drivers/wiznet5k/README.md
+++ b/drivers/wiznet5k/README.md
@@ -1,6 +1,6 @@
 This is the driver for the WIZnet5x00 series of Ethernet controllers.
 
-Adapted for Micro Python.
+Adapted for MicroPython.
 
 Original source: https://github.com/Wiznet/W5500_EVB/tree/master/ioLibrary
 Taken on: 30 August 2014

--- a/esp8266/esp_mphal.c
+++ b/esp8266/esp_mphal.c
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Micro Python project, http://micropython.org/
+ * This file is part of the MicroPython project, http://micropython.org/
  *
  * The MIT License (MIT)
  *

--- a/esp8266/esp_mphal.h
+++ b/esp8266/esp_mphal.h
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Micro Python project, http://micropython.org/
+ * This file is part of the MicroPython project, http://micropython.org/
  *
  * The MIT License (MIT)
  *

--- a/esp8266/fatfs_port.c
+++ b/esp8266/fatfs_port.c
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Micro Python project, http://micropython.org/
+ * This file is part of the MicroPython project, http://micropython.org/
  *
  * The MIT License (MIT)
  *

--- a/esp8266/gccollect.c
+++ b/esp8266/gccollect.c
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Micro Python project, http://micropython.org/
+ * This file is part of the MicroPython project, http://micropython.org/
  *
  * The MIT License (MIT)
  *

--- a/esp8266/gccollect.h
+++ b/esp8266/gccollect.h
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Micro Python project, http://micropython.org/
+ * This file is part of the MicroPython project, http://micropython.org/
  *
  * The MIT License (MIT)
  *

--- a/esp8266/hspi.c
+++ b/esp8266/hspi.c
@@ -28,7 +28,7 @@
 /*
 Wrapper to setup HSPI/SPI GPIO pins and default SPI clock
     spi_no - SPI (0) or HSPI (1)
-Not used in Micropython.
+Not used in MicroPython.
 */
 void spi_init(uint8_t spi_no) {
     spi_init_gpio(spi_no, SPI_CLK_USE_DIV);
@@ -48,7 +48,7 @@ Configures SPI mode parameters for clock edge and clock polarity.
                (1) Data is valid on clock trailing edge
     spi_cpol - (0) Clock is low when inactive
                (1) Clock is high when inactive
-For Micropython this version is different from original.
+For MicroPython this version is different from original.
 */
 void spi_mode(uint8_t spi_no, uint8_t spi_cpha, uint8_t spi_cpol) {
     if (spi_cpol) {
@@ -99,7 +99,7 @@ void spi_init_gpio(uint8_t spi_no, uint8_t sysclk_as_spiclk) {
         // GPIO14 is HSPI CLK pin (Clock)
         PIN_FUNC_SELECT(PERIPHS_IO_MUX_MTMS_U, 2);
         // GPIO15 is HSPI CS pin (Chip Select / Slave Select)
-        // In Micropython, we are handling CS ourself in drivers.
+        // In MicroPython, we are handling CS ourself in drivers.
         // PIN_FUNC_SELECT(PERIPHS_IO_MUX_MTDO_U, 2);
     }
 }

--- a/esp8266/machine_adc.c
+++ b/esp8266/machine_adc.c
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Micro Python project, http://micropython.org/
+ * This file is part of the MicroPython project, http://micropython.org/
  *
  * The MIT License (MIT)
  *

--- a/esp8266/machine_pin.c
+++ b/esp8266/machine_pin.c
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Micro Python project, http://micropython.org/
+ * This file is part of the MicroPython project, http://micropython.org/
  *
  * The MIT License (MIT)
  *

--- a/esp8266/machine_pwm.c
+++ b/esp8266/machine_pwm.c
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Micro Python project, http://micropython.org/
+ * This file is part of the MicroPython project, http://micropython.org/
  *
  * The MIT License (MIT)
  *

--- a/esp8266/machine_rtc.c
+++ b/esp8266/machine_rtc.c
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Micro Python project, http://micropython.org/
+ * This file is part of the MicroPython project, http://micropython.org/
  *
  * The MIT License (MIT)
  *

--- a/esp8266/main.c
+++ b/esp8266/main.c
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Micro Python project, http://micropython.org/
+ * This file is part of the MicroPython project, http://micropython.org/
  *
  * The MIT License (MIT)
  *

--- a/esp8266/modesp.c
+++ b/esp8266/modesp.c
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Micro Python project, http://micropython.org/
+ * This file is part of the MicroPython project, http://micropython.org/
  *
  * The MIT License (MIT)
  *

--- a/esp8266/modnetwork.c
+++ b/esp8266/modnetwork.c
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Micro Python project, http://micropython.org/
+ * This file is part of the MicroPython project, http://micropython.org/
  *
  * The MIT License (MIT)
  *

--- a/esp8266/modpyb.c
+++ b/esp8266/modpyb.c
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Micro Python project, http://micropython.org/
+ * This file is part of the MicroPython project, http://micropython.org/
  *
  * The MIT License (MIT)
  *

--- a/esp8266/moduos.c
+++ b/esp8266/moduos.c
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Micro Python project, http://micropython.org/
+ * This file is part of the MicroPython project, http://micropython.org/
  *
  * The MIT License (MIT)
  *

--- a/esp8266/modutime.c
+++ b/esp8266/modutime.c
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Micro Python project, http://micropython.org/
+ * This file is part of the MicroPython project, http://micropython.org/
  *
  * The MIT License (MIT)
  *

--- a/esp8266/mpconfigport.h
+++ b/esp8266/mpconfigport.h
@@ -1,6 +1,6 @@
 #include <stdint.h>
 
-// options to control how Micro Python is built
+// options to control how MicroPython is built
 
 #define MICROPY_OBJ_REPR            (MICROPY_OBJ_REPR_C)
 #define MICROPY_ALLOC_PATH_MAX      (128)

--- a/esp8266/qstrdefsport.h
+++ b/esp8266/qstrdefsport.h
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Micro Python project, http://micropython.org/
+ * This file is part of the MicroPython project, http://micropython.org/
  *
  * The MIT License (MIT)
  *

--- a/examples/embedding/Makefile.upylib
+++ b/examples/embedding/Makefile.upylib
@@ -55,7 +55,7 @@ CFLAGS += -U _FORTIFY_SOURCE
 endif
 
 # On OSX, 'gcc' is a symlink to clang unless a real gcc is installed.
-# The unix port of micropython on OSX must be compiled with clang,
+# The unix port of MicroPython on OSX must be compiled with clang,
 # while cross-compile ports require gcc, so we test here for OSX and
 # if necessary override the value of 'CC' set in py/mkenv.mk
 ifeq ($(UNAME_S),Darwin)

--- a/examples/embedding/hello-embed.c
+++ b/examples/embedding/hello-embed.c
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Micro Python project, http://micropython.org/
+ * This file is part of the MicroPython project, http://micropython.org/
  *
  * The MIT License (MIT)
  *

--- a/examples/embedding/mpconfigport_minimal.h
+++ b/examples/embedding/mpconfigport_minimal.h
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Micro Python project, http://micropython.org/
+ * This file is part of the MicroPython project, http://micropython.org/
  *
  * The MIT License (MIT)
  *
@@ -24,7 +24,7 @@
  * THE SOFTWARE.
  */
 
-// options to control how Micro Python is built
+// options to control how MicroPython is built
 
 #define MICROPY_ALLOC_PATH_MAX      (PATH_MAX)
 #define MICROPY_ENABLE_GC           (1)

--- a/examples/switch.py
+++ b/examples/switch.py
@@ -6,7 +6,7 @@ Light up some leds when the USR switch on the pyboard is pressed.
 
 Example Usage::
 
-    Micro Python v1.0.1 on 2014-05-12; PYBv1.0 with STM32F405RG
+    MicroPython v1.0.1 on 2014-05-12; PYBv1.0 with STM32F405RG
     Type "help()" for more information.
     >>> import switch
     >>> switch.run_loop()

--- a/extmod/machine_mem.c
+++ b/extmod/machine_mem.c
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Micro Python project, http://micropython.org/
+ * This file is part of the MicroPython project, http://micropython.org/
  *
  * The MIT License (MIT)
  *

--- a/extmod/machine_mem.h
+++ b/extmod/machine_mem.h
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Micro Python project, http://micropython.org/
+ * This file is part of the MicroPython project, http://micropython.org/
  *
  * The MIT License (MIT)
  *

--- a/extmod/modubinascii.c
+++ b/extmod/modubinascii.c
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Micro Python project, http://micropython.org/
+ * This file is part of the MicroPython project, http://micropython.org/
  *
  * The MIT License (MIT)
  *

--- a/extmod/modubinascii.h
+++ b/extmod/modubinascii.h
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Micro Python project, http://micropython.org/
+ * This file is part of the MicroPython project, http://micropython.org/
  *
  * The MIT License (MIT)
  *

--- a/extmod/moductypes.c
+++ b/extmod/moductypes.c
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Micro Python project, http://micropython.org/
+ * This file is part of the MicroPython project, http://micropython.org/
  *
  * The MIT License (MIT)
  *

--- a/extmod/moduhashlib.c
+++ b/extmod/moduhashlib.c
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Micro Python project, http://micropython.org/
+ * This file is part of the MicroPython project, http://micropython.org/
  *
  * The MIT License (MIT)
  *

--- a/extmod/moduheapq.c
+++ b/extmod/moduheapq.c
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Micro Python project, http://micropython.org/
+ * This file is part of the MicroPython project, http://micropython.org/
  *
  * The MIT License (MIT)
  *

--- a/extmod/modure.c
+++ b/extmod/modure.c
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Micro Python project, http://micropython.org/
+ * This file is part of the MicroPython project, http://micropython.org/
  *
  * The MIT License (MIT)
  *

--- a/extmod/moduselect.c
+++ b/extmod/moduselect.c
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Micro Python project, http://micropython.org/
+ * This file is part of the MicroPython project, http://micropython.org/
  *
  * The MIT License (MIT)
  *

--- a/extmod/modussl_axtls.c
+++ b/extmod/modussl_axtls.c
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Micro Python project, http://micropython.org/
+ * This file is part of the MicroPython project, http://micropython.org/
  *
  * The MIT License (MIT)
  *

--- a/extmod/moduzlib.c
+++ b/extmod/moduzlib.c
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Micro Python project, http://micropython.org/
+ * This file is part of the MicroPython project, http://micropython.org/
  *
  * The MIT License (MIT)
  *

--- a/extmod/vfs_fat.h
+++ b/extmod/vfs_fat.h
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Micro Python project, http://micropython.org/
+ * This file is part of the MicroPython project, http://micropython.org/
  *
  * The MIT License (MIT)
  *

--- a/extmod/vfs_fat_diskio.c
+++ b/extmod/vfs_fat_diskio.c
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Micro Python project, http://micropython.org/
+ * This file is part of the MicroPython project, http://micropython.org/
  *
  * Original template for this file comes from:
  * Low level disk I/O module skeleton for FatFs, (C)ChaN, 2013

--- a/extmod/vfs_fat_file.c
+++ b/extmod/vfs_fat_file.c
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Micro Python project, http://micropython.org/
+ * This file is part of the MicroPython project, http://micropython.org/
  *
  * The MIT License (MIT)
  *

--- a/lib/libc/string0.c
+++ b/lib/libc/string0.c
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Micro Python project, http://micropython.org/
+ * This file is part of the MicroPython project, http://micropython.org/
  *
  * The MIT License (MIT)
  *

--- a/lib/libm/ef_rem_pio2.c
+++ b/lib/libm/ef_rem_pio2.c
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Micro Python project, http://micropython.org/
+ * This file is part of the MicroPython project, http://micropython.org/
  *
  * These math functions are taken from newlib-nano-2, the newlib/libm/math
  * directory, available from https://github.com/32bitmicro/newlib-nano-2.

--- a/lib/libm/erf_lgamma.c
+++ b/lib/libm/erf_lgamma.c
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Micro Python project, http://micropython.org/
+ * This file is part of the MicroPython project, http://micropython.org/
  *
  * These math functions are taken from newlib-nano-2, the newlib/libm/math
  * directory, available from https://github.com/32bitmicro/newlib-nano-2.

--- a/lib/libm/fdlibm.h
+++ b/lib/libm/fdlibm.h
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Micro Python project, http://micropython.org/
+ * This file is part of the MicroPython project, http://micropython.org/
  *
  * This file is adapted from from newlib-nano-2, the newlib/libm/common/fdlib.h,
  * available from https://github.com/32bitmicro/newlib-nano-2.  The main change

--- a/lib/libm/kf_cos.c
+++ b/lib/libm/kf_cos.c
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Micro Python project, http://micropython.org/
+ * This file is part of the MicroPython project, http://micropython.org/
  *
  * These math functions are taken from newlib-nano-2, the newlib/libm/math
  * directory, available from https://github.com/32bitmicro/newlib-nano-2.

--- a/lib/libm/kf_rem_pio2.c
+++ b/lib/libm/kf_rem_pio2.c
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Micro Python project, http://micropython.org/
+ * This file is part of the MicroPython project, http://micropython.org/
  *
  * These math functions are taken from newlib-nano-2, the newlib/libm/math
  * directory, available from https://github.com/32bitmicro/newlib-nano-2.

--- a/lib/libm/kf_sin.c
+++ b/lib/libm/kf_sin.c
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Micro Python project, http://micropython.org/
+ * This file is part of the MicroPython project, http://micropython.org/
  *
  * These math functions are taken from newlib-nano-2, the newlib/libm/math
  * directory, available from https://github.com/32bitmicro/newlib-nano-2.

--- a/lib/libm/kf_tan.c
+++ b/lib/libm/kf_tan.c
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Micro Python project, http://micropython.org/
+ * This file is part of the MicroPython project, http://micropython.org/
  *
  * These math functions are taken from newlib-nano-2, the newlib/libm/math
  * directory, available from https://github.com/32bitmicro/newlib-nano-2.

--- a/lib/libm/math.c
+++ b/lib/libm/math.c
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Micro Python project, http://micropython.org/
+ * This file is part of the MicroPython project, http://micropython.org/
  *
  * The MIT License (MIT)
  *

--- a/lib/libm/sf_cos.c
+++ b/lib/libm/sf_cos.c
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Micro Python project, http://micropython.org/
+ * This file is part of the MicroPython project, http://micropython.org/
  *
  * These math functions are taken from newlib-nano-2, the newlib/libm/math
  * directory, available from https://github.com/32bitmicro/newlib-nano-2.

--- a/lib/libm/sf_erf.c
+++ b/lib/libm/sf_erf.c
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Micro Python project, http://micropython.org/
+ * This file is part of the MicroPython project, http://micropython.org/
  *
  * These math functions are taken from newlib-nano-2, the newlib/libm/math
  * directory, available from https://github.com/32bitmicro/newlib-nano-2.

--- a/lib/libm/sf_frexp.c
+++ b/lib/libm/sf_frexp.c
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Micro Python project, http://micropython.org/
+ * This file is part of the MicroPython project, http://micropython.org/
  *
  * These math functions are taken from newlib-nano-2, the newlib/libm/math
  * directory, available from https://github.com/32bitmicro/newlib-nano-2.

--- a/lib/libm/sf_ldexp.c
+++ b/lib/libm/sf_ldexp.c
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Micro Python project, http://micropython.org/
+ * This file is part of the MicroPython project, http://micropython.org/
  *
  * These math functions are taken from newlib-nano-2, the newlib/libm/math
  * directory, available from https://github.com/32bitmicro/newlib-nano-2.

--- a/lib/libm/sf_modf.c
+++ b/lib/libm/sf_modf.c
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Micro Python project, http://micropython.org/
+ * This file is part of the MicroPython project, http://micropython.org/
  *
  * These math functions are taken from newlib-nano-2, the newlib/libm/common
  * directory, available from https://github.com/32bitmicro/newlib-nano-2.

--- a/lib/libm/sf_sin.c
+++ b/lib/libm/sf_sin.c
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Micro Python project, http://micropython.org/
+ * This file is part of the MicroPython project, http://micropython.org/
  *
  * These math functions are taken from newlib-nano-2, the newlib/libm/math
  * directory, available from https://github.com/32bitmicro/newlib-nano-2.

--- a/lib/libm/sf_tan.c
+++ b/lib/libm/sf_tan.c
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Micro Python project, http://micropython.org/
+ * This file is part of the MicroPython project, http://micropython.org/
  *
  * These math functions are taken from newlib-nano-2, the newlib/libm/math
  * directory, available from https://github.com/32bitmicro/newlib-nano-2.

--- a/lib/libm/wf_lgamma.c
+++ b/lib/libm/wf_lgamma.c
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Micro Python project, http://micropython.org/
+ * This file is part of the MicroPython project, http://micropython.org/
  *
  * These math functions are taken from newlib-nano-2, the newlib/libm/math
  * directory, available from https://github.com/32bitmicro/newlib-nano-2.

--- a/lib/libm/wf_tgamma.c
+++ b/lib/libm/wf_tgamma.c
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Micro Python project, http://micropython.org/
+ * This file is part of the MicroPython project, http://micropython.org/
  *
  * These math functions are taken from newlib-nano-2, the newlib/libm/math
  * directory, available from https://github.com/32bitmicro/newlib-nano-2.

--- a/lib/mp-readline/readline.c
+++ b/lib/mp-readline/readline.c
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Micro Python project, http://micropython.org/
+ * This file is part of the MicroPython project, http://micropython.org/
  *
  * The MIT License (MIT)
  *

--- a/lib/mp-readline/readline.h
+++ b/lib/mp-readline/readline.h
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Micro Python project, http://micropython.org/
+ * This file is part of the MicroPython project, http://micropython.org/
  *
  * The MIT License (MIT)
  *

--- a/lib/netutils/netutils.c
+++ b/lib/netutils/netutils.c
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Micro Python project, http://micropython.org/
+ * This file is part of the MicroPython project, http://micropython.org/
  *
  * The MIT License (MIT)
  *

--- a/lib/netutils/netutils.h
+++ b/lib/netutils/netutils.h
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Micro Python project, http://micropython.org/
+ * This file is part of the MicroPython project, http://micropython.org/
  *
  * The MIT License (MIT)
  *

--- a/lib/timeutils/timeutils.c
+++ b/lib/timeutils/timeutils.c
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Micro Python project, http://micropython.org/
+ * This file is part of the MicroPython project, http://micropython.org/
  *
  * The MIT License (MIT)
  *
@@ -67,7 +67,7 @@ mp_uint_t timeutils_year_day(mp_uint_t year, mp_uint_t month, mp_uint_t date) {
 
 void timeutils_seconds_since_2000_to_struct_time(mp_uint_t t, timeutils_struct_time_t *tm) {
     // The following algorithm was adapted from musl's __secs_to_tm and adapted
-    // for differences in Micro Python's timebase.
+    // for differences in MicroPython's timebase.
 
     mp_int_t seconds = t - LEAPOCH;
 

--- a/lib/timeutils/timeutils.h
+++ b/lib/timeutils/timeutils.h
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Micro Python project, http://micropython.org/
+ * This file is part of the MicroPython project, http://micropython.org/
  *
  * The MIT License (MIT)
  *

--- a/lib/utils/printf.c
+++ b/lib/utils/printf.c
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Micro Python project, http://micropython.org/
+ * This file is part of the MicroPython project, http://micropython.org/
  *
  * The MIT License (MIT)
  *

--- a/lib/utils/pyexec.c
+++ b/lib/utils/pyexec.c
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Micro Python project, http://micropython.org/
+ * This file is part of the MicroPython project, http://micropython.org/
  *
  * The MIT License (MIT)
  *

--- a/lib/utils/pyexec.h
+++ b/lib/utils/pyexec.h
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Micro Python project, http://micropython.org/
+ * This file is part of the MicroPython project, http://micropython.org/
  *
  * The MIT License (MIT)
  *

--- a/logo/FONT-LICENSE.txt
+++ b/logo/FONT-LICENSE.txt
@@ -1,4 +1,4 @@
-The font used for the Micro Python logo is "Exo",
+The font used for the MicroPython logo is "Exo",
 http://www.google.com/fonts/specimen/Exo.
 
 Copyright (c) 2013, Natanael Gama (https://plus.google.com/u/0/+NatanaelGama),

--- a/minimal/mpconfigport.h
+++ b/minimal/mpconfigport.h
@@ -1,6 +1,6 @@
 #include <stdint.h>
 
-// options to control how Micro Python is built
+// options to control how MicroPython is built
 
 // You can disable the built-in MicroPython compiler by setting the following
 // config option to 0.  If you do this then you won't get a REPL prompt, but you

--- a/mpy-cross/Makefile
+++ b/mpy-cross/Makefile
@@ -44,7 +44,7 @@ COPT = -Os #-DNDEBUG
 endif
 
 # On OSX, 'gcc' is a symlink to clang unless a real gcc is installed.
-# The unix port of micropython on OSX must be compiled with clang,
+# The unix port of MicroPython on OSX must be compiled with clang,
 # while cross-compile ports require gcc, so we test here for OSX and
 # if necessary override the value of 'CC' set in py/mkenv.mk
 ifeq ($(UNAME_S),Darwin)

--- a/pic16bit/board.c
+++ b/pic16bit/board.c
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Micro Python project, http://micropython.org/
+ * This file is part of the MicroPython project, http://micropython.org/
  *
  * The MIT License (MIT)
  *

--- a/pic16bit/board.h
+++ b/pic16bit/board.h
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Micro Python project, http://micropython.org/
+ * This file is part of the MicroPython project, http://micropython.org/
  *
  * The MIT License (MIT)
  *

--- a/pic16bit/main.c
+++ b/pic16bit/main.c
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Micro Python project, http://micropython.org/
+ * This file is part of the MicroPython project, http://micropython.org/
  *
  * The MIT License (MIT)
  *

--- a/pic16bit/modpyb.c
+++ b/pic16bit/modpyb.c
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Micro Python project, http://micropython.org/
+ * This file is part of the MicroPython project, http://micropython.org/
  *
  * The MIT License (MIT)
  *

--- a/pic16bit/modpyb.h
+++ b/pic16bit/modpyb.h
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Micro Python project, http://micropython.org/
+ * This file is part of the MicroPython project, http://micropython.org/
  *
  * The MIT License (MIT)
  *

--- a/pic16bit/modpybled.c
+++ b/pic16bit/modpybled.c
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Micro Python project, http://micropython.org/
+ * This file is part of the MicroPython project, http://micropython.org/
  *
  * The MIT License (MIT)
  *

--- a/pic16bit/modpybswitch.c
+++ b/pic16bit/modpybswitch.c
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Micro Python project, http://micropython.org/
+ * This file is part of the MicroPython project, http://micropython.org/
  *
  * The MIT License (MIT)
  *

--- a/pic16bit/mpconfigport.h
+++ b/pic16bit/mpconfigport.h
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Micro Python project, http://micropython.org/
+ * This file is part of the MicroPython project, http://micropython.org/
  *
  * The MIT License (MIT)
  *

--- a/pic16bit/pic16bit_mphal.c
+++ b/pic16bit/pic16bit_mphal.c
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Micro Python project, http://micropython.org/
+ * This file is part of the MicroPython project, http://micropython.org/
  *
  * The MIT License (MIT)
  *

--- a/pic16bit/pic16bit_mphal.h
+++ b/pic16bit/pic16bit_mphal.h
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Micro Python project, http://micropython.org/
+ * This file is part of the MicroPython project, http://micropython.org/
  *
  * The MIT License (MIT)
  *

--- a/py/argcheck.c
+++ b/py/argcheck.c
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Micro Python project, http://micropython.org/
+ * This file is part of the MicroPython project, http://micropython.org/
  *
  * The MIT License (MIT)
  *

--- a/py/asmarm.c
+++ b/py/asmarm.c
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Micro Python project, http://micropython.org/
+ * This file is part of the MicroPython project, http://micropython.org/
  *
  * The MIT License (MIT)
  *

--- a/py/asmarm.h
+++ b/py/asmarm.h
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Micro Python project, http://micropython.org/
+ * This file is part of the MicroPython project, http://micropython.org/
  *
  * The MIT License (MIT)
  *

--- a/py/asmthumb.c
+++ b/py/asmthumb.c
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Micro Python project, http://micropython.org/
+ * This file is part of the MicroPython project, http://micropython.org/
  *
  * The MIT License (MIT)
  *

--- a/py/asmthumb.h
+++ b/py/asmthumb.h
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Micro Python project, http://micropython.org/
+ * This file is part of the MicroPython project, http://micropython.org/
  *
  * The MIT License (MIT)
  *

--- a/py/asmx64.c
+++ b/py/asmx64.c
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Micro Python project, http://micropython.org/
+ * This file is part of the MicroPython project, http://micropython.org/
  *
  * The MIT License (MIT)
  *

--- a/py/asmx64.h
+++ b/py/asmx64.h
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Micro Python project, http://micropython.org/
+ * This file is part of the MicroPython project, http://micropython.org/
  *
  * The MIT License (MIT)
  *

--- a/py/asmx86.c
+++ b/py/asmx86.c
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Micro Python project, http://micropython.org/
+ * This file is part of the MicroPython project, http://micropython.org/
  *
  * The MIT License (MIT)
  *

--- a/py/asmx86.h
+++ b/py/asmx86.h
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Micro Python project, http://micropython.org/
+ * This file is part of the MicroPython project, http://micropython.org/
  *
  * The MIT License (MIT)
  *

--- a/py/bc.c
+++ b/py/bc.c
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Micro Python project, http://micropython.org/
+ * This file is part of the MicroPython project, http://micropython.org/
  *
  * The MIT License (MIT)
  *

--- a/py/bc.h
+++ b/py/bc.h
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Micro Python project, http://micropython.org/
+ * This file is part of the MicroPython project, http://micropython.org/
  *
  * The MIT License (MIT)
  *

--- a/py/bc0.h
+++ b/py/bc0.h
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Micro Python project, http://micropython.org/
+ * This file is part of the MicroPython project, http://micropython.org/
  *
  * The MIT License (MIT)
  *
@@ -26,7 +26,7 @@
 #ifndef MICROPY_INCLUDED_PY_BC0_H
 #define MICROPY_INCLUDED_PY_BC0_H
 
-// Micro Python byte-codes.
+// MicroPython byte-codes.
 // The comment at the end of the line (if it exists) tells the arguments to the byte-code.
 
 #define MP_BC_LOAD_CONST_FALSE   (0x10)

--- a/py/binary.c
+++ b/py/binary.c
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Micro Python project, http://micropython.org/
+ * This file is part of the MicroPython project, http://micropython.org/
  *
  * The MIT License (MIT)
  *

--- a/py/binary.h
+++ b/py/binary.h
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Micro Python project, http://micropython.org/
+ * This file is part of the MicroPython project, http://micropython.org/
  *
  * The MIT License (MIT)
  *

--- a/py/builtin.h
+++ b/py/builtin.h
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Micro Python project, http://micropython.org/
+ * This file is part of the MicroPython project, http://micropython.org/
  *
  * The MIT License (MIT)
  *

--- a/py/builtinevex.c
+++ b/py/builtinevex.c
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Micro Python project, http://micropython.org/
+ * This file is part of the MicroPython project, http://micropython.org/
  *
  * The MIT License (MIT)
  *

--- a/py/builtinimport.c
+++ b/py/builtinimport.c
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Micro Python project, http://micropython.org/
+ * This file is part of the MicroPython project, http://micropython.org/
  *
  * The MIT License (MIT)
  *

--- a/py/compile.c
+++ b/py/compile.c
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Micro Python project, http://micropython.org/
+ * This file is part of the MicroPython project, http://micropython.org/
  *
  * The MIT License (MIT)
  *
@@ -569,7 +569,7 @@ STATIC void close_over_variables_etc(compiler_t *comp, scope_t *this_scope, int 
                 for (int j = 0; j < this_scope->id_info_len; j++) {
                     id_info_t *id2 = &this_scope->id_info[j];
                     if (id2->kind == ID_INFO_KIND_FREE && id->qst == id2->qst) {
-                        // in Micro Python we load closures using LOAD_FAST
+                        // in MicroPython we load closures using LOAD_FAST
                         EMIT_LOAD_FAST(id->qst, id->local_num);
                         nfree += 1;
                     }
@@ -654,9 +654,9 @@ STATIC void compile_funcdef_lambdef_param(compiler_t *comp, mp_parse_node_t pn) 
 
             if (comp->have_star) {
                 comp->num_dict_params += 1;
-                // in Micro Python we put the default dict parameters into a dictionary using the bytecode
+                // in MicroPython we put the default dict parameters into a dictionary using the bytecode
                 if (comp->num_dict_params == 1) {
-                    // in Micro Python we put the default positional parameters into a tuple using the bytecode
+                    // in MicroPython we put the default positional parameters into a tuple using the bytecode
                     // we need to do this here before we start building the map for the default keywords
                     if (comp->num_default_params > 0) {
                         EMIT_ARG(build_tuple, comp->num_default_params);
@@ -700,7 +700,7 @@ STATIC void compile_funcdef_lambdef(compiler_t *comp, scope_t *scope, mp_parse_n
         return;
     }
 
-    // in Micro Python we put the default positional parameters into a tuple using the bytecode
+    // in MicroPython we put the default positional parameters into a tuple using the bytecode
     // the default keywords args may have already made the tuple; if not, do it now
     if (comp->num_default_params > 0 && comp->num_dict_params == 0) {
         EMIT_ARG(build_tuple, comp->num_default_params);
@@ -3275,7 +3275,7 @@ STATIC void compile_scope_inline_asm(compiler_t *comp, scope_t *scope, pass_kind
 #endif
 
 STATIC void scope_compute_things(scope_t *scope) {
-    // in Micro Python we put the *x parameter after all other parameters (except **y)
+    // in MicroPython we put the *x parameter after all other parameters (except **y)
     if (scope->scope_flags & MP_SCOPE_FLAG_VARARGS) {
         id_info_t *id_param = NULL;
         for (int i = scope->id_info_len - 1; i >= 0; i--) {
@@ -3313,7 +3313,7 @@ STATIC void scope_compute_things(scope_t *scope) {
     // compute the index of cell vars
     for (int i = 0; i < scope->id_info_len; i++) {
         id_info_t *id = &scope->id_info[i];
-        // in Micro Python the cells come right after the fast locals
+        // in MicroPython the cells come right after the fast locals
         // parameters are not counted here, since they remain at the start
         // of the locals, even if they are cell vars
         if (id->kind == ID_INFO_KIND_CELL && !(id->flags & ID_FLAG_IS_PARAM)) {
@@ -3333,14 +3333,14 @@ STATIC void scope_compute_things(scope_t *scope) {
                     id_info_t *id2 = &scope->id_info[j];
                     if (id2->kind == ID_INFO_KIND_FREE && id->qst == id2->qst) {
                         assert(!(id2->flags & ID_FLAG_IS_PARAM)); // free vars should not be params
-                        // in Micro Python the frees come first, before the params
+                        // in MicroPython the frees come first, before the params
                         id2->local_num = num_free;
                         num_free += 1;
                     }
                 }
             }
         }
-        // in Micro Python shift all other locals after the free locals
+        // in MicroPython shift all other locals after the free locals
         if (num_free > 0) {
             for (int i = 0; i < scope->id_info_len; i++) {
                 id_info_t *id = &scope->id_info[i];

--- a/py/compile.h
+++ b/py/compile.h
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Micro Python project, http://micropython.org/
+ * This file is part of the MicroPython project, http://micropython.org/
  *
  * The MIT License (MIT)
  *

--- a/py/emit.h
+++ b/py/emit.h
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Micro Python project, http://micropython.org/
+ * This file is part of the MicroPython project, http://micropython.org/
  *
  * The MIT License (MIT)
  *

--- a/py/emitbc.c
+++ b/py/emitbc.c
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Micro Python project, http://micropython.org/
+ * This file is part of the MicroPython project, http://micropython.org/
  *
  * The MIT License (MIT)
  *

--- a/py/emitcommon.c
+++ b/py/emitcommon.c
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Micro Python project, http://micropython.org/
+ * This file is part of the MicroPython project, http://micropython.org/
  *
  * The MIT License (MIT)
  *

--- a/py/emitglue.c
+++ b/py/emitglue.c
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Micro Python project, http://micropython.org/
+ * This file is part of the MicroPython project, http://micropython.org/
  *
  * The MIT License (MIT)
  *

--- a/py/emitglue.h
+++ b/py/emitglue.h
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Micro Python project, http://micropython.org/
+ * This file is part of the MicroPython project, http://micropython.org/
  *
  * The MIT License (MIT)
  *

--- a/py/emitinlinethumb.c
+++ b/py/emitinlinethumb.c
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Micro Python project, http://micropython.org/
+ * This file is part of the MicroPython project, http://micropython.org/
  *
  * The MIT License (MIT)
  *

--- a/py/emitnative.c
+++ b/py/emitnative.c
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Micro Python project, http://micropython.org/
+ * This file is part of the MicroPython project, http://micropython.org/
  *
  * The MIT License (MIT)
  *

--- a/py/formatfloat.c
+++ b/py/formatfloat.c
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Micro Python project, http://micropython.org/
+ * This file is part of the MicroPython project, http://micropython.org/
  *
  * The MIT License (MIT)
  *

--- a/py/formatfloat.h
+++ b/py/formatfloat.h
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Micro Python project, http://micropython.org/
+ * This file is part of the MicroPython project, http://micropython.org/
  *
  * The MIT License (MIT)
  *

--- a/py/frozenmod.c
+++ b/py/frozenmod.c
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Micro Python project, http://micropython.org/
+ * This file is part of the MicroPython project, http://micropython.org/
  *
  * The MIT License (MIT)
  *

--- a/py/frozenmod.h
+++ b/py/frozenmod.h
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Micro Python project, http://micropython.org/
+ * This file is part of the MicroPython project, http://micropython.org/
  *
  * The MIT License (MIT)
  *

--- a/py/gc.c
+++ b/py/gc.c
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Micro Python project, http://micropython.org/
+ * This file is part of the MicroPython project, http://micropython.org/
  *
  * The MIT License (MIT)
  *

--- a/py/gc.h
+++ b/py/gc.h
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Micro Python project, http://micropython.org/
+ * This file is part of the MicroPython project, http://micropython.org/
  *
  * The MIT License (MIT)
  *

--- a/py/grammar.h
+++ b/py/grammar.h
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Micro Python project, http://micropython.org/
+ * This file is part of the MicroPython project, http://micropython.org/
  *
  * The MIT License (MIT)
  *
@@ -32,7 +32,7 @@
 // #       single_input is a single interactive statement;
 // #       file_input is a module or sequence of commands read from an input file;
 // #       eval_input is the input for the eval() functions.
-// # NB: compound_stmt in single_input is followed by extra NEWLINE! --> not in Micro Python
+// # NB: compound_stmt in single_input is followed by extra NEWLINE! --> not in MicroPython
 // single_input: NEWLINE | simple_stmt | compound_stmt
 // file_input: (NEWLINE | stmt)* ENDMARKER
 // eval_input: testlist NEWLINE* ENDMARKER

--- a/py/lexer.c
+++ b/py/lexer.c
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Micro Python project, http://micropython.org/
+ * This file is part of the MicroPython project, http://micropython.org/
  *
  * The MIT License (MIT)
  *

--- a/py/lexer.h
+++ b/py/lexer.h
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Micro Python project, http://micropython.org/
+ * This file is part of the MicroPython project, http://micropython.org/
  *
  * The MIT License (MIT)
  *
@@ -32,7 +32,7 @@
 #include "py/qstr.h"
 #include "py/reader.h"
 
-/* lexer.h -- simple tokeniser for Micro Python
+/* lexer.h -- simple tokeniser for MicroPython
  *
  * Uses (byte) length instead of null termination.
  * Tokens are the same - UTF-8 with (byte) length.

--- a/py/malloc.c
+++ b/py/malloc.c
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Micro Python project, http://micropython.org/
+ * This file is part of the MicroPython project, http://micropython.org/
  *
  * The MIT License (MIT)
  *
@@ -46,7 +46,7 @@
 #include "py/gc.h"
 
 // We redirect standard alloc functions to GC heap - just for the rest of
-// this module. In the rest of micropython source, system malloc can be
+// this module. In the rest of MicroPython source, system malloc can be
 // freely accessed - for interfacing with system and 3rd-party libs for
 // example. On the other hand, some (e.g. bare-metal) ports may use GC
 // heap as system heap, so, to avoid warnings, we do undef's first.

--- a/py/map.c
+++ b/py/map.c
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Micro Python project, http://micropython.org/
+ * This file is part of the MicroPython project, http://micropython.org/
  *
  * The MIT License (MIT)
  *

--- a/py/misc.h
+++ b/py/misc.h
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Micro Python project, http://micropython.org/
+ * This file is part of the MicroPython project, http://micropython.org/
  *
  * The MIT License (MIT)
  *

--- a/py/mkrules.mk
+++ b/py/mkrules.mk
@@ -47,7 +47,7 @@ $(BUILD)/%.o: %.c
 	$(call compile_c)
 
 # List all native flags since the current build system doesn't have
-# the micropython configuration available. However, these flags are
+# the MicroPython configuration available. However, these flags are
 # needed to extract all qstrings
 QSTR_GEN_EXTRA_CFLAGS += -DNO_QSTR -DN_X64 -DN_X86 -DN_THUMB -DN_ARM -DN_XTENSA
 QSTR_GEN_EXTRA_CFLAGS += -I$(BUILD)/tmp

--- a/py/modarray.c
+++ b/py/modarray.c
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Micro Python project, http://micropython.org/
+ * This file is part of the MicroPython project, http://micropython.org/
  *
  * The MIT License (MIT)
  *

--- a/py/modbuiltins.c
+++ b/py/modbuiltins.c
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Micro Python project, http://micropython.org/
+ * This file is part of the MicroPython project, http://micropython.org/
  *
  * The MIT License (MIT)
  *

--- a/py/modcmath.c
+++ b/py/modcmath.c
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Micro Python project, http://micropython.org/
+ * This file is part of the MicroPython project, http://micropython.org/
  *
  * The MIT License (MIT)
  *

--- a/py/modcollections.c
+++ b/py/modcollections.c
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Micro Python project, http://micropython.org/
+ * This file is part of the MicroPython project, http://micropython.org/
  *
  * The MIT License (MIT)
  *

--- a/py/modgc.c
+++ b/py/modgc.c
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Micro Python project, http://micropython.org/
+ * This file is part of the MicroPython project, http://micropython.org/
  *
  * The MIT License (MIT)
  *

--- a/py/modio.c
+++ b/py/modio.c
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Micro Python project, http://micropython.org/
+ * This file is part of the MicroPython project, http://micropython.org/
  *
  * The MIT License (MIT)
  *

--- a/py/modmath.c
+++ b/py/modmath.c
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Micro Python project, http://micropython.org/
+ * This file is part of the MicroPython project, http://micropython.org/
  *
  * The MIT License (MIT)
  *

--- a/py/modmicropython.c
+++ b/py/modmicropython.c
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Micro Python project, http://micropython.org/
+ * This file is part of the MicroPython project, http://micropython.org/
  *
  * The MIT License (MIT)
  *

--- a/py/modstruct.c
+++ b/py/modstruct.c
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Micro Python project, http://micropython.org/
+ * This file is part of the MicroPython project, http://micropython.org/
  *
  * The MIT License (MIT)
  *

--- a/py/modsys.c
+++ b/py/modsys.c
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Micro Python project, http://micropython.org/
+ * This file is part of the MicroPython project, http://micropython.org/
  *
  * The MIT License (MIT)
  *
@@ -87,7 +87,7 @@ STATIC const mp_rom_obj_tuple_t mp_sys_implementation_obj = {
 #undef I
 
 #ifdef MICROPY_PY_SYS_PLATFORM
-/// \constant platform - the platform that Micro Python is running on
+/// \constant platform - the platform that MicroPython is running on
 STATIC const MP_DEFINE_STR_OBJ(platform_obj, MICROPY_PY_SYS_PLATFORM);
 #endif
 

--- a/py/mphal.h
+++ b/py/mphal.h
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Micro Python project, http://micropython.org/
+ * This file is part of the MicroPython project, http://micropython.org/
  *
  * The MIT License (MIT)
  *

--- a/py/mpprint.c
+++ b/py/mpprint.c
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Micro Python project, http://micropython.org/
+ * This file is part of the MicroPython project, http://micropython.org/
  *
  * The MIT License (MIT)
  *

--- a/py/mpprint.h
+++ b/py/mpprint.h
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Micro Python project, http://micropython.org/
+ * This file is part of the MicroPython project, http://micropython.org/
  *
  * The MIT License (MIT)
  *

--- a/py/mpstate.c
+++ b/py/mpstate.c
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Micro Python project, http://micropython.org/
+ * This file is part of the MicroPython project, http://micropython.org/
  *
  * The MIT License (MIT)
  *

--- a/py/mpstate.h
+++ b/py/mpstate.h
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Micro Python project, http://micropython.org/
+ * This file is part of the MicroPython project, http://micropython.org/
  *
  * The MIT License (MIT)
  *
@@ -36,7 +36,7 @@
 #include "py/objlist.h"
 #include "py/objexcept.h"
 
-// This file contains structures defining the state of the Micro Python
+// This file contains structures defining the state of the MicroPython
 // memory system, runtime and virtual machine.  The state is a global
 // variable, but in the future it is hoped that the state can become local.
 

--- a/py/mpz.c
+++ b/py/mpz.c
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Micro Python project, http://micropython.org/
+ * This file is part of the MicroPython project, http://micropython.org/
  *
  * The MIT License (MIT)
  *

--- a/py/mpz.h
+++ b/py/mpz.h
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Micro Python project, http://micropython.org/
+ * This file is part of the MicroPython project, http://micropython.org/
  *
  * The MIT License (MIT)
  *

--- a/py/nativeglue.c
+++ b/py/nativeglue.c
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Micro Python project, http://micropython.org/
+ * This file is part of the MicroPython project, http://micropython.org/
  *
  * The MIT License (MIT)
  *
@@ -42,7 +42,7 @@
 
 #if MICROPY_EMIT_NATIVE
 
-// convert a Micro Python object to a valid native value based on type
+// convert a MicroPython object to a valid native value based on type
 mp_uint_t mp_convert_obj_to_native(mp_obj_t obj, mp_uint_t type) {
     DEBUG_printf("mp_convert_obj_to_native(%p, " UINT_FMT ")\n", obj, type);
     switch (type & 0xf) {
@@ -66,7 +66,7 @@ mp_uint_t mp_convert_obj_to_native(mp_obj_t obj, mp_uint_t type) {
 
 #if MICROPY_EMIT_NATIVE || MICROPY_EMIT_INLINE_ASM
 
-// convert a native value to a Micro Python object based on type
+// convert a native value to a MicroPython object based on type
 mp_obj_t mp_convert_native_to_obj(mp_uint_t val, mp_uint_t type) {
     DEBUG_printf("mp_convert_native_to_obj(" UINT_FMT ", " UINT_FMT ")\n", val, type);
     switch (type & 0xf) {

--- a/py/nlr.h
+++ b/py/nlr.h
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Micro Python project, http://micropython.org/
+ * This file is part of the MicroPython project, http://micropython.org/
  *
  * The MIT License (MIT)
  *

--- a/py/nlrsetjmp.c
+++ b/py/nlrsetjmp.c
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Micro Python project, http://micropython.org/
+ * This file is part of the MicroPython project, http://micropython.org/
  *
  * The MIT License (MIT)
  *

--- a/py/obj.c
+++ b/py/obj.c
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Micro Python project, http://micropython.org/
+ * This file is part of the MicroPython project, http://micropython.org/
  *
  * The MIT License (MIT)
  *

--- a/py/obj.h
+++ b/py/obj.h
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Micro Python project, http://micropython.org/
+ * This file is part of the MicroPython project, http://micropython.org/
  *
  * The MIT License (MIT)
  *

--- a/py/objarray.c
+++ b/py/objarray.c
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Micro Python project, http://micropython.org/
+ * This file is part of the MicroPython project, http://micropython.org/
  *
  * The MIT License (MIT)
  *

--- a/py/objattrtuple.c
+++ b/py/objattrtuple.c
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Micro Python project, http://micropython.org/
+ * This file is part of the MicroPython project, http://micropython.org/
  *
  * The MIT License (MIT)
  *

--- a/py/objbool.c
+++ b/py/objbool.c
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Micro Python project, http://micropython.org/
+ * This file is part of the MicroPython project, http://micropython.org/
  *
  * The MIT License (MIT)
  *

--- a/py/objboundmeth.c
+++ b/py/objboundmeth.c
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Micro Python project, http://micropython.org/
+ * This file is part of the MicroPython project, http://micropython.org/
  *
  * The MIT License (MIT)
  *

--- a/py/objcell.c
+++ b/py/objcell.c
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Micro Python project, http://micropython.org/
+ * This file is part of the MicroPython project, http://micropython.org/
  *
  * The MIT License (MIT)
  *

--- a/py/objclosure.c
+++ b/py/objclosure.c
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Micro Python project, http://micropython.org/
+ * This file is part of the MicroPython project, http://micropython.org/
  *
  * The MIT License (MIT)
  *

--- a/py/objcomplex.c
+++ b/py/objcomplex.c
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Micro Python project, http://micropython.org/
+ * This file is part of the MicroPython project, http://micropython.org/
  *
  * The MIT License (MIT)
  *

--- a/py/objdict.c
+++ b/py/objdict.c
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Micro Python project, http://micropython.org/
+ * This file is part of the MicroPython project, http://micropython.org/
  *
  * The MIT License (MIT)
  *

--- a/py/objenumerate.c
+++ b/py/objenumerate.c
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Micro Python project, http://micropython.org/
+ * This file is part of the MicroPython project, http://micropython.org/
  *
  * The MIT License (MIT)
  *

--- a/py/objexcept.c
+++ b/py/objexcept.c
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Micro Python project, http://micropython.org/
+ * This file is part of the MicroPython project, http://micropython.org/
  *
  * The MIT License (MIT)
  *

--- a/py/objexcept.h
+++ b/py/objexcept.h
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Micro Python project, http://micropython.org/
+ * This file is part of the MicroPython project, http://micropython.org/
  *
  * The MIT License (MIT)
  *

--- a/py/objfilter.c
+++ b/py/objfilter.c
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Micro Python project, http://micropython.org/
+ * This file is part of the MicroPython project, http://micropython.org/
  *
  * The MIT License (MIT)
  *

--- a/py/objfloat.c
+++ b/py/objfloat.c
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Micro Python project, http://micropython.org/
+ * This file is part of the MicroPython project, http://micropython.org/
  *
  * The MIT License (MIT)
  *

--- a/py/objfun.c
+++ b/py/objfun.c
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Micro Python project, http://micropython.org/
+ * This file is part of the MicroPython project, http://micropython.org/
  *
  * The MIT License (MIT)
  *
@@ -480,7 +480,7 @@ typedef mp_uint_t (*inline_asm_fun_2_t)(mp_uint_t, mp_uint_t);
 typedef mp_uint_t (*inline_asm_fun_3_t)(mp_uint_t, mp_uint_t, mp_uint_t);
 typedef mp_uint_t (*inline_asm_fun_4_t)(mp_uint_t, mp_uint_t, mp_uint_t, mp_uint_t);
 
-// convert a Micro Python object to a sensible value for inline asm
+// convert a MicroPython object to a sensible value for inline asm
 STATIC mp_uint_t convert_obj_for_inline_asm(mp_obj_t obj) {
     // TODO for byte_array, pass pointer to the array
     if (MP_OBJ_IS_SMALL_INT(obj)) {

--- a/py/objfun.h
+++ b/py/objfun.h
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Micro Python project, http://micropython.org/
+ * This file is part of the MicroPython project, http://micropython.org/
  *
  * The MIT License (MIT)
  *

--- a/py/objgenerator.c
+++ b/py/objgenerator.c
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Micro Python project, http://micropython.org/
+ * This file is part of the MicroPython project, http://micropython.org/
  *
  * The MIT License (MIT)
  *

--- a/py/objgenerator.h
+++ b/py/objgenerator.h
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Micro Python project, http://micropython.org/
+ * This file is part of the MicroPython project, http://micropython.org/
  *
  * The MIT License (MIT)
  *

--- a/py/objgetitemiter.c
+++ b/py/objgetitemiter.c
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Micro Python project, http://micropython.org/
+ * This file is part of the MicroPython project, http://micropython.org/
  *
  * The MIT License (MIT)
  *

--- a/py/objint.c
+++ b/py/objint.c
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Micro Python project, http://micropython.org/
+ * This file is part of the MicroPython project, http://micropython.org/
  *
  * The MIT License (MIT)
  *

--- a/py/objint.h
+++ b/py/objint.h
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Micro Python project, http://micropython.org/
+ * This file is part of the MicroPython project, http://micropython.org/
  *
  * The MIT License (MIT)
  *

--- a/py/objint_longlong.c
+++ b/py/objint_longlong.c
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Micro Python project, http://micropython.org/
+ * This file is part of the MicroPython project, http://micropython.org/
  *
  * The MIT License (MIT)
  *

--- a/py/objint_mpz.c
+++ b/py/objint_mpz.c
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Micro Python project, http://micropython.org/
+ * This file is part of the MicroPython project, http://micropython.org/
  *
  * The MIT License (MIT)
  *

--- a/py/objlist.c
+++ b/py/objlist.c
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Micro Python project, http://micropython.org/
+ * This file is part of the MicroPython project, http://micropython.org/
  *
  * The MIT License (MIT)
  *

--- a/py/objlist.h
+++ b/py/objlist.h
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Micro Python project, http://micropython.org/
+ * This file is part of the MicroPython project, http://micropython.org/
  *
  * The MIT License (MIT)
  *

--- a/py/objmap.c
+++ b/py/objmap.c
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Micro Python project, http://micropython.org/
+ * This file is part of the MicroPython project, http://micropython.org/
  *
  * The MIT License (MIT)
  *

--- a/py/objmodule.c
+++ b/py/objmodule.c
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Micro Python project, http://micropython.org/
+ * This file is part of the MicroPython project, http://micropython.org/
  *
  * The MIT License (MIT)
  *

--- a/py/objmodule.h
+++ b/py/objmodule.h
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Micro Python project, http://micropython.org/
+ * This file is part of the MicroPython project, http://micropython.org/
  *
  * The MIT License (MIT)
  *

--- a/py/objnamedtuple.c
+++ b/py/objnamedtuple.c
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Micro Python project, http://micropython.org/
+ * This file is part of the MicroPython project, http://micropython.org/
  *
  * The MIT License (MIT)
  *

--- a/py/objnone.c
+++ b/py/objnone.c
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Micro Python project, http://micropython.org/
+ * This file is part of the MicroPython project, http://micropython.org/
  *
  * The MIT License (MIT)
  *

--- a/py/objobject.c
+++ b/py/objobject.c
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Micro Python project, http://micropython.org/
+ * This file is part of the MicroPython project, http://micropython.org/
  *
  * The MIT License (MIT)
  *

--- a/py/objproperty.c
+++ b/py/objproperty.c
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Micro Python project, http://micropython.org/
+ * This file is part of the MicroPython project, http://micropython.org/
  *
  * The MIT License (MIT)
  *

--- a/py/objrange.c
+++ b/py/objrange.c
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Micro Python project, http://micropython.org/
+ * This file is part of the MicroPython project, http://micropython.org/
  *
  * The MIT License (MIT)
  *

--- a/py/objreversed.c
+++ b/py/objreversed.c
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Micro Python project, http://micropython.org/
+ * This file is part of the MicroPython project, http://micropython.org/
  *
  * The MIT License (MIT)
  *

--- a/py/objset.c
+++ b/py/objset.c
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Micro Python project, http://micropython.org/
+ * This file is part of the MicroPython project, http://micropython.org/
  *
  * The MIT License (MIT)
  *

--- a/py/objsingleton.c
+++ b/py/objsingleton.c
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Micro Python project, http://micropython.org/
+ * This file is part of the MicroPython project, http://micropython.org/
  *
  * The MIT License (MIT)
  *

--- a/py/objslice.c
+++ b/py/objslice.c
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Micro Python project, http://micropython.org/
+ * This file is part of the MicroPython project, http://micropython.org/
  *
  * The MIT License (MIT)
  *

--- a/py/objstr.c
+++ b/py/objstr.c
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Micro Python project, http://micropython.org/
+ * This file is part of the MicroPython project, http://micropython.org/
  *
  * The MIT License (MIT)
  *

--- a/py/objstr.h
+++ b/py/objstr.h
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Micro Python project, http://micropython.org/
+ * This file is part of the MicroPython project, http://micropython.org/
  *
  * The MIT License (MIT)
  *

--- a/py/objstringio.c
+++ b/py/objstringio.c
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Micro Python project, http://micropython.org/
+ * This file is part of the MicroPython project, http://micropython.org/
  *
  * The MIT License (MIT)
  *

--- a/py/objstrunicode.c
+++ b/py/objstrunicode.c
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Micro Python project, http://micropython.org/
+ * This file is part of the MicroPython project, http://micropython.org/
  *
  * The MIT License (MIT)
  *

--- a/py/objtuple.c
+++ b/py/objtuple.c
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Micro Python project, http://micropython.org/
+ * This file is part of the MicroPython project, http://micropython.org/
  *
  * The MIT License (MIT)
  *

--- a/py/objtuple.h
+++ b/py/objtuple.h
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Micro Python project, http://micropython.org/
+ * This file is part of the MicroPython project, http://micropython.org/
  *
  * The MIT License (MIT)
  *

--- a/py/objtype.c
+++ b/py/objtype.c
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Micro Python project, http://micropython.org/
+ * This file is part of the MicroPython project, http://micropython.org/
  *
  * The MIT License (MIT)
  *
@@ -917,8 +917,8 @@ const mp_obj_type_t mp_type_type = {
 };
 
 mp_obj_t mp_obj_new_type(qstr name, mp_obj_t bases_tuple, mp_obj_t locals_dict) {
-    assert(MP_OBJ_IS_TYPE(bases_tuple, &mp_type_tuple)); // Micro Python restriction, for now
-    assert(MP_OBJ_IS_TYPE(locals_dict, &mp_type_dict)); // Micro Python restriction, for now
+    assert(MP_OBJ_IS_TYPE(bases_tuple, &mp_type_tuple)); // MicroPython restriction, for now
+    assert(MP_OBJ_IS_TYPE(locals_dict, &mp_type_dict)); // MicroPython restriction, for now
 
     // TODO might need to make a copy of locals_dict; at least that's how CPython does it
 

--- a/py/objtype.h
+++ b/py/objtype.h
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Micro Python project, http://micropython.org/
+ * This file is part of the MicroPython project, http://micropython.org/
  *
  * The MIT License (MIT)
  *

--- a/py/objzip.c
+++ b/py/objzip.c
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Micro Python project, http://micropython.org/
+ * This file is part of the MicroPython project, http://micropython.org/
  *
  * The MIT License (MIT)
  *

--- a/py/opmethods.c
+++ b/py/opmethods.c
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Micro Python project, http://micropython.org/
+ * This file is part of the MicroPython project, http://micropython.org/
  *
  * The MIT License (MIT)
  *

--- a/py/parse.c
+++ b/py/parse.c
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Micro Python project, http://micropython.org/
+ * This file is part of the MicroPython project, http://micropython.org/
  *
  * The MIT License (MIT)
  *

--- a/py/parse.h
+++ b/py/parse.h
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Micro Python project, http://micropython.org/
+ * This file is part of the MicroPython project, http://micropython.org/
  *
  * The MIT License (MIT)
  *

--- a/py/parsenum.c
+++ b/py/parsenum.c
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Micro Python project, http://micropython.org/
+ * This file is part of the MicroPython project, http://micropython.org/
  *
  * The MIT License (MIT)
  *

--- a/py/parsenum.h
+++ b/py/parsenum.h
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Micro Python project, http://micropython.org/
+ * This file is part of the MicroPython project, http://micropython.org/
  *
  * The MIT License (MIT)
  *

--- a/py/parsenumbase.c
+++ b/py/parsenumbase.c
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Micro Python project, http://micropython.org/
+ * This file is part of the MicroPython project, http://micropython.org/
  *
  * The MIT License (MIT)
  *

--- a/py/parsenumbase.h
+++ b/py/parsenumbase.h
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Micro Python project, http://micropython.org/
+ * This file is part of the MicroPython project, http://micropython.org/
  *
  * The MIT License (MIT)
  *

--- a/py/qstr.c
+++ b/py/qstr.c
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Micro Python project, http://micropython.org/
+ * This file is part of the MicroPython project, http://micropython.org/
  *
  * The MIT License (MIT)
  *

--- a/py/qstr.h
+++ b/py/qstr.h
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Micro Python project, http://micropython.org/
+ * This file is part of the MicroPython project, http://micropython.org/
  *
  * The MIT License (MIT)
  *

--- a/py/qstrdefs.h
+++ b/py/qstrdefs.h
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Micro Python project, http://micropython.org/
+ * This file is part of the MicroPython project, http://micropython.org/
  *
  * The MIT License (MIT)
  *

--- a/py/repl.c
+++ b/py/repl.c
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Micro Python project, http://micropython.org/
+ * This file is part of the MicroPython project, http://micropython.org/
  *
  * The MIT License (MIT)
  *

--- a/py/repl.h
+++ b/py/repl.h
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Micro Python project, http://micropython.org/
+ * This file is part of the MicroPython project, http://micropython.org/
  *
  * The MIT License (MIT)
  *

--- a/py/runtime.c
+++ b/py/runtime.c
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Micro Python project, http://micropython.org/
+ * This file is part of the MicroPython project, http://micropython.org/
  *
  * The MIT License (MIT)
  *
@@ -1038,7 +1038,7 @@ void mp_load_method_maybe(mp_obj_t obj, qstr attr, mp_obj_t *dest) {
     } else if (type->locals_dict != NULL) {
         // generic method lookup
         // this is a lookup in the object (ie not class or type)
-        assert(type->locals_dict->base.type == &mp_type_dict); // Micro Python restriction, for now
+        assert(type->locals_dict->base.type == &mp_type_dict); // MicroPython restriction, for now
         mp_map_t *locals_map = &type->locals_dict->map;
         mp_map_elem_t *elem = mp_map_lookup(locals_map, MP_OBJ_NEW_QSTR(attr), MP_MAP_LOOKUP);
         if (elem != NULL) {

--- a/py/runtime.h
+++ b/py/runtime.h
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Micro Python project, http://micropython.org/
+ * This file is part of the MicroPython project, http://micropython.org/
  *
  * The MIT License (MIT)
  *

--- a/py/runtime0.h
+++ b/py/runtime0.h
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Micro Python project, http://micropython.org/
+ * This file is part of the MicroPython project, http://micropython.org/
  *
  * The MIT License (MIT)
  *

--- a/py/runtime_utils.c
+++ b/py/runtime_utils.c
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Micro Python project, http://micropython.org/
+ * This file is part of the MicroPython project, http://micropython.org/
  *
  * The MIT License (MIT)
  *

--- a/py/scope.c
+++ b/py/scope.c
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Micro Python project, http://micropython.org/
+ * This file is part of the MicroPython project, http://micropython.org/
  *
  * The MIT License (MIT)
  *

--- a/py/scope.h
+++ b/py/scope.h
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Micro Python project, http://micropython.org/
+ * This file is part of the MicroPython project, http://micropython.org/
  *
  * The MIT License (MIT)
  *

--- a/py/sequence.c
+++ b/py/sequence.c
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Micro Python project, http://micropython.org/
+ * This file is part of the MicroPython project, http://micropython.org/
  *
  * The MIT License (MIT)
  *

--- a/py/showbc.c
+++ b/py/showbc.c
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Micro Python project, http://micropython.org/
+ * This file is part of the MicroPython project, http://micropython.org/
  *
  * The MIT License (MIT)
  *

--- a/py/smallint.c
+++ b/py/smallint.c
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Micro Python project, http://micropython.org/
+ * This file is part of the MicroPython project, http://micropython.org/
  *
  * The MIT License (MIT)
  *

--- a/py/smallint.h
+++ b/py/smallint.h
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Micro Python project, http://micropython.org/
+ * This file is part of the MicroPython project, http://micropython.org/
  *
  * The MIT License (MIT)
  *

--- a/py/stackctrl.c
+++ b/py/stackctrl.c
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Micro Python project, http://micropython.org/
+ * This file is part of the MicroPython project, http://micropython.org/
  *
  * The MIT License (MIT)
  *

--- a/py/stackctrl.h
+++ b/py/stackctrl.h
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Micro Python project, http://micropython.org/
+ * This file is part of the MicroPython project, http://micropython.org/
  *
  * The MIT License (MIT)
  *

--- a/py/stream.c
+++ b/py/stream.c
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Micro Python project, http://micropython.org/
+ * This file is part of the MicroPython project, http://micropython.org/
  *
  * The MIT License (MIT)
  *

--- a/py/stream.h
+++ b/py/stream.h
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Micro Python project, http://micropython.org/
+ * This file is part of the MicroPython project, http://micropython.org/
  *
  * The MIT License (MIT)
  *

--- a/py/unicode.c
+++ b/py/unicode.c
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Micro Python project, http://micropython.org/
+ * This file is part of the MicroPython project, http://micropython.org/
  *
  * The MIT License (MIT)
  *

--- a/py/unicode.h
+++ b/py/unicode.h
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Micro Python project, http://micropython.org/
+ * This file is part of the MicroPython project, http://micropython.org/
  *
  * The MIT License (MIT)
  *

--- a/py/vm.c
+++ b/py/vm.c
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Micro Python project, http://micropython.org/
+ * This file is part of the MicroPython project, http://micropython.org/
  *
  * The MIT License (MIT)
  *

--- a/py/vmentrytable.h
+++ b/py/vmentrytable.h
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Micro Python project, http://micropython.org/
+ * This file is part of the MicroPython project, http://micropython.org/
  *
  * The MIT License (MIT)
  *

--- a/py/vstr.c
+++ b/py/vstr.c
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Micro Python project, http://micropython.org/
+ * This file is part of the MicroPython project, http://micropython.org/
  *
  * The MIT License (MIT)
  *

--- a/py/warning.c
+++ b/py/warning.c
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Micro Python project, http://micropython.org/
+ * This file is part of the MicroPython project, http://micropython.org/
  *
  * The MIT License (MIT)
  *

--- a/qemu-arm/mpconfigport.h
+++ b/qemu-arm/mpconfigport.h
@@ -1,6 +1,6 @@
 #include <stdint.h>
 
-// options to control how Micro Python is built
+// options to control how MicroPython is built
 
 #define MICROPY_ALLOC_PATH_MAX      (512)
 #define MICROPY_EMIT_X64            (0)

--- a/stmhal/accel.c
+++ b/stmhal/accel.c
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Micro Python project, http://micropython.org/
+ * This file is part of the MicroPython project, http://micropython.org/
  *
  * The MIT License (MIT)
  *
@@ -102,7 +102,7 @@ STATIC void accel_start(void) {
 }
 
 /******************************************************************************/
-/* Micro Python bindings                                                      */
+/* MicroPython bindings                                                      */
 
 #define NUM_AXIS (3)
 #define FILT_DEPTH (4)

--- a/stmhal/accel.h
+++ b/stmhal/accel.h
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Micro Python project, http://micropython.org/
+ * This file is part of the MicroPython project, http://micropython.org/
  *
  * The MIT License (MIT)
  *

--- a/stmhal/adc.c
+++ b/stmhal/adc.c
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Micro Python project, http://micropython.org/
+ * This file is part of the MicroPython project, http://micropython.org/
  *
  * The MIT License (MIT)
  *
@@ -263,7 +263,7 @@ STATIC uint32_t adc_read_channel(ADC_HandleTypeDef *adcHandle) {
 }
 
 /******************************************************************************/
-/* Micro Python bindings : adc object (single channel)                        */
+/* MicroPython bindings : adc object (single channel)                        */
 
 STATIC void adc_print(const mp_print_t *print, mp_obj_t self_in, mp_print_kind_t kind) {
     pyb_obj_adc_t *self = self_in;
@@ -596,7 +596,7 @@ float adc_read_core_vref(ADC_HandleTypeDef *adcHandle) {
 #endif
 
 /******************************************************************************/
-/* Micro Python bindings : adc_all object                                     */
+/* MicroPython bindings : adc_all object                                     */
 
 STATIC mp_obj_t adc_all_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *args) {
     // check number of arguments

--- a/stmhal/adc.h
+++ b/stmhal/adc.h
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Micro Python project, http://micropython.org/
+ * This file is part of the MicroPython project, http://micropython.org/
  *
  * The MIT License (MIT)
  *

--- a/stmhal/bufhelper.c
+++ b/stmhal/bufhelper.c
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Micro Python project, http://micropython.org/
+ * This file is part of the MicroPython project, http://micropython.org/
  *
  * The MIT License (MIT)
  *

--- a/stmhal/bufhelper.h
+++ b/stmhal/bufhelper.h
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Micro Python project, http://micropython.org/
+ * This file is part of the MicroPython project, http://micropython.org/
  *
  * The MIT License (MIT)
  *

--- a/stmhal/can.c
+++ b/stmhal/can.c
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Micro Python project, http://micropython.org/
+ * This file is part of the MicroPython project, http://micropython.org/
  *
  * The MIT License (MIT)
  *
@@ -262,7 +262,7 @@ STATIC HAL_StatusTypeDef CAN_Transmit(CAN_HandleTypeDef *hcan, uint32_t Timeout)
 }
 
 /******************************************************************************/
-// Micro Python bindings
+// MicroPython bindings
 
 STATIC void pyb_can_print(const mp_print_t *print, mp_obj_t self_in, mp_print_kind_t kind) {
     pyb_can_obj_t *self = self_in;

--- a/stmhal/can.h
+++ b/stmhal/can.h
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Micro Python project, http://micropython.org/
+ * This file is part of the MicroPython project, http://micropython.org/
  *
  * The MIT License (MIT)
  *

--- a/stmhal/dac.c
+++ b/stmhal/dac.c
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Micro Python project, http://micropython.org/
+ * This file is part of the MicroPython project, http://micropython.org/
  *
  * The MIT License (MIT)
  *
@@ -124,7 +124,7 @@ STATIC uint32_t TIMx_Config(mp_obj_t timer) {
 }
 
 /******************************************************************************/
-// Micro Python bindings
+// MicroPython bindings
 
 typedef enum {
     DAC_STATE_RESET,

--- a/stmhal/dac.h
+++ b/stmhal/dac.h
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Micro Python project, http://micropython.org/
+ * This file is part of the MicroPython project, http://micropython.org/
  *
  * The MIT License (MIT)
  *

--- a/stmhal/dma.c
+++ b/stmhal/dma.c
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Micro Python project, http://micropython.org/
+ * This file is part of the MicroPython project, http://micropython.org/
  *
  * The MIT License (MIT)
  *

--- a/stmhal/dma.h
+++ b/stmhal/dma.h
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Micro Python project, http://micropython.org/
+ * This file is part of the MicroPython project, http://micropython.org/
  *
  * The MIT License (MIT)
  *

--- a/stmhal/extint.c
+++ b/stmhal/extint.c
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Micro Python project, http://micropython.org/
+ * This file is part of the MicroPython project, http://micropython.org/
  *
  * The MIT License (MIT)
  *

--- a/stmhal/extint.h
+++ b/stmhal/extint.h
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Micro Python project, http://micropython.org/
+ * This file is part of the MicroPython project, http://micropython.org/
  *
  * The MIT License (MIT)
  *

--- a/stmhal/flash.c
+++ b/stmhal/flash.c
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Micro Python project, http://micropython.org/
+ * This file is part of the MicroPython project, http://micropython.org/
  *
  * The MIT License (MIT)
  *

--- a/stmhal/flash.h
+++ b/stmhal/flash.h
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Micro Python project, http://micropython.org/
+ * This file is part of the MicroPython project, http://micropython.org/
  *
  * The MIT License (MIT)
  *

--- a/stmhal/font_petme128_8x8.h
+++ b/stmhal/font_petme128_8x8.h
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Micro Python project, http://micropython.org/
+ * This file is part of the MicroPython project, http://micropython.org/
  *
  * The MIT License (MIT)
  *

--- a/stmhal/gccollect.c
+++ b/stmhal/gccollect.c
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Micro Python project, http://micropython.org/
+ * This file is part of the MicroPython project, http://micropython.org/
  *
  * The MIT License (MIT)
  *

--- a/stmhal/gccollect.h
+++ b/stmhal/gccollect.h
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Micro Python project, http://micropython.org/
+ * This file is part of the MicroPython project, http://micropython.org/
  *
  * The MIT License (MIT)
  *

--- a/stmhal/hal/l4/inc/stm32l4xx_hal_uart.h
+++ b/stmhal/hal/l4/inc/stm32l4xx_hal_uart.h
@@ -1370,7 +1370,7 @@ void UART_AdvFeatureConfig(UART_HandleTypeDef *huart);
 /**
   * @}
   */
-/* Functions added by micropython */
+/* Functions added by MicroPython */
 uint32_t HAL_UART_CalcBrr(uint32_t fck, uint32_t baud);
 
 #ifdef __cplusplus

--- a/stmhal/hal/l4/src/stm32l4xx_hal_uart.c
+++ b/stmhal/hal/l4/src/stm32l4xx_hal_uart.c
@@ -2104,7 +2104,7 @@ static HAL_StatusTypeDef UART_Receive_IT(UART_HandleTypeDef *huart)
 
 /**
   * @brief Calculate register BRR value without using uint64.
-  * @note   This function is added by the micropython project.
+  * @note   This function is added by the MicroPython project.
   * @param  fck: Input clock frequency to the uart block in Hz.
   * @param  baud: baud rate should be one of {300, 600, 1200, 2400, 4800, 9600, 19200, 57600, 115200}.
   * @retval BRR value

--- a/stmhal/help.c
+++ b/stmhal/help.c
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Micro Python project, http://micropython.org/
+ * This file is part of the MicroPython project, http://micropython.org/
  *
  * The MIT License (MIT)
  *

--- a/stmhal/i2c.c
+++ b/stmhal/i2c.c
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Micro Python project, http://micropython.org/
+ * This file is part of the MicroPython project, http://micropython.org/
  *
  * The MIT License (MIT)
  *
@@ -511,7 +511,7 @@ STATIC HAL_StatusTypeDef i2c_wait_dma_finished(I2C_HandleTypeDef *i2c, uint32_t 
 }
 
 /******************************************************************************/
-/* Micro Python bindings                                                      */
+/* MicroPython bindings                                                      */
 
 STATIC inline bool in_master_mode(pyb_i2c_obj_t *self) { return self->i2c->Init.OwnAddress1 == PYB_I2C_MASTER_ADDRESS; }
 

--- a/stmhal/i2c.h
+++ b/stmhal/i2c.h
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Micro Python project, http://micropython.org/
+ * This file is part of the MicroPython project, http://micropython.org/
  *
  * The MIT License (MIT)
  *

--- a/stmhal/irq.c
+++ b/stmhal/irq.c
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Micro Python project, http://micropython.org/
+ * This file is part of the MicroPython project, http://micropython.org/
  *
  * The MIT License (MIT)
  *

--- a/stmhal/irq.h
+++ b/stmhal/irq.h
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Micro Python project, http://micropython.org/
+ * This file is part of the MicroPython project, http://micropython.org/
  *
  * The MIT License (MIT)
  *

--- a/stmhal/lcd.c
+++ b/stmhal/lcd.c
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Micro Python project, http://micropython.org/
+ * This file is part of the MicroPython project, http://micropython.org/
  *
  * The MIT License (MIT)
  *

--- a/stmhal/lcd.h
+++ b/stmhal/lcd.h
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Micro Python project, http://micropython.org/
+ * This file is part of the MicroPython project, http://micropython.org/
  *
  * The MIT License (MIT)
  *

--- a/stmhal/led.c
+++ b/stmhal/led.c
@@ -279,7 +279,7 @@ void led_debug(int n, int delay) {
 }
 
 /******************************************************************************/
-/* Micro Python bindings                                                      */
+/* MicroPython bindings                                                      */
 
 void led_obj_print(const mp_print_t *print, mp_obj_t self_in, mp_print_kind_t kind) {
     pyb_led_obj_t *self = self_in;

--- a/stmhal/led.h
+++ b/stmhal/led.h
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Micro Python project, http://micropython.org/
+ * This file is part of the MicroPython project, http://micropython.org/
  *
  * The MIT License (MIT)
  *

--- a/stmhal/main.c
+++ b/stmhal/main.c
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Micro Python project, http://micropython.org/
+ * This file is part of the MicroPython project, http://micropython.org/
  *
  * The MIT License (MIT)
  *
@@ -511,7 +511,7 @@ soft_reset:
     // GC init
     gc_init(&_heap_start, &_heap_end);
 
-    // Micro Python init
+    // MicroPython init
     mp_init();
     mp_obj_list_init(mp_sys_path, 0);
     mp_obj_list_append(mp_sys_path, MP_OBJ_NEW_QSTR(MP_QSTR_)); // current dir (or base dir of the script)

--- a/stmhal/modnetwork.c
+++ b/stmhal/modnetwork.c
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Micro Python project, http://micropython.org/
+ * This file is part of the MicroPython project, http://micropython.org/
  *
  * The MIT License (MIT)
  *

--- a/stmhal/modnetwork.h
+++ b/stmhal/modnetwork.h
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Micro Python project, http://micropython.org/
+ * This file is part of the MicroPython project, http://micropython.org/
  *
  * The MIT License (MIT)
  *

--- a/stmhal/modnwcc3k.c
+++ b/stmhal/modnwcc3k.c
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Micro Python project, http://micropython.org/
+ * This file is part of the MicroPython project, http://micropython.org/
  *
  * The MIT License (MIT)
  *
@@ -412,7 +412,7 @@ STATIC int cc3k_socket_ioctl(mod_network_socket_obj_t *socket, mp_uint_t request
 }
 
 /******************************************************************************/
-// Micro Python bindings; CC3K class
+// MicroPython bindings; CC3K class
 
 typedef struct _cc3k_obj_t {
     mp_obj_base_t base;

--- a/stmhal/modnwwiznet5k.c
+++ b/stmhal/modnwwiznet5k.c
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Micro Python project, http://micropython.org/
+ * This file is part of the MicroPython project, http://micropython.org/
  *
  * The MIT License (MIT)
  *
@@ -314,7 +314,7 @@ STATIC mp_obj_t wiznet5k_socket_disconnect(mp_obj_t self_in) {
 #endif
 
 /******************************************************************************/
-// Micro Python bindings
+// MicroPython bindings
 
 /// \classmethod \constructor(spi, pin_cs, pin_rst)
 /// Create and return a WIZNET5K object.

--- a/stmhal/modpyb.c
+++ b/stmhal/modpyb.c
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Micro Python project, http://micropython.org/
+ * This file is part of the MicroPython project, http://micropython.org/
  *
  * The MIT License (MIT)
  *

--- a/stmhal/modstm.c
+++ b/stmhal/modstm.c
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Micro Python project, http://micropython.org/
+ * This file is part of the MicroPython project, http://micropython.org/
  *
  * The MIT License (MIT)
  *

--- a/stmhal/moduos.c
+++ b/stmhal/moduos.c
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Micro Python project, http://micropython.org/
+ * This file is part of the MicroPython project, http://micropython.org/
  *
  * The MIT License (MIT)
  *

--- a/stmhal/modusocket.c
+++ b/stmhal/modusocket.c
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Micro Python project, http://micropython.org/
+ * This file is part of the MicroPython project, http://micropython.org/
  *
  * The MIT License (MIT)
  *

--- a/stmhal/modutime.c
+++ b/stmhal/modutime.c
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Micro Python project, http://micropython.org/
+ * This file is part of the MicroPython project, http://micropython.org/
  *
  * The MIT License (MIT)
  *

--- a/stmhal/pendsv.c
+++ b/stmhal/pendsv.c
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Micro Python project, http://micropython.org/
+ * This file is part of the MicroPython project, http://micropython.org/
  *
  * The MIT License (MIT)
  *

--- a/stmhal/pendsv.h
+++ b/stmhal/pendsv.h
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Micro Python project, http://micropython.org/
+ * This file is part of the MicroPython project, http://micropython.org/
  *
  * The MIT License (MIT)
  *

--- a/stmhal/pin.c
+++ b/stmhal/pin.c
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Micro Python project, http://micropython.org/
+ * This file is part of the MicroPython project, http://micropython.org/
  *
  * The MIT License (MIT)
  *

--- a/stmhal/pin.h
+++ b/stmhal/pin.h
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Micro Python project, http://micropython.org/
+ * This file is part of the MicroPython project, http://micropython.org/
  *
  * The MIT License (MIT)
  *

--- a/stmhal/pin_defs_stmhal.h
+++ b/stmhal/pin_defs_stmhal.h
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Micro Python project, http://micropython.org/
+ * This file is part of the MicroPython project, http://micropython.org/
  *
  * The MIT License (MIT)
  *

--- a/stmhal/pin_named_pins.c
+++ b/stmhal/pin_named_pins.c
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Micro Python project, http://micropython.org/
+ * This file is part of the MicroPython project, http://micropython.org/
  *
  * The MIT License (MIT)
  *

--- a/stmhal/portmodules.h
+++ b/stmhal/portmodules.h
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Micro Python project, http://micropython.org/
+ * This file is part of the MicroPython project, http://micropython.org/
  *
  * The MIT License (MIT)
  *

--- a/stmhal/qstrdefsport.h
+++ b/stmhal/qstrdefsport.h
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Micro Python project, http://micropython.org/
+ * This file is part of the MicroPython project, http://micropython.org/
  *
  * The MIT License (MIT)
  *

--- a/stmhal/rng.c
+++ b/stmhal/rng.c
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Micro Python project, http://micropython.org/
+ * This file is part of the MicroPython project, http://micropython.org/
  *
  * The MIT License (MIT)
  *

--- a/stmhal/rng.h
+++ b/stmhal/rng.h
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Micro Python project, http://micropython.org/
+ * This file is part of the MicroPython project, http://micropython.org/
  *
  * The MIT License (MIT)
  *

--- a/stmhal/rtc.c
+++ b/stmhal/rtc.c
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Micro Python project, http://micropython.org/
+ * This file is part of the MicroPython project, http://micropython.org/
  *
  * The MIT License (MIT)
  *
@@ -412,7 +412,7 @@ STATIC void RTC_CalendarConfig(void) {
 }
 
 /******************************************************************************/
-// Micro Python bindings
+// MicroPython bindings
 
 typedef struct _pyb_rtc_obj_t {
     mp_obj_base_t base;

--- a/stmhal/rtc.h
+++ b/stmhal/rtc.h
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Micro Python project, http://micropython.org/
+ * This file is part of the MicroPython project, http://micropython.org/
  *
  * The MIT License (MIT)
  *

--- a/stmhal/sdcard.c
+++ b/stmhal/sdcard.c
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Micro Python project, http://micropython.org/
+ * This file is part of the MicroPython project, http://micropython.org/
  *
  * The MIT License (MIT)
  *
@@ -356,7 +356,7 @@ mp_uint_t sdcard_write_blocks(const uint8_t *src, uint32_t block_num, uint32_t n
 }
 
 /******************************************************************************/
-// Micro Python bindings
+// MicroPython bindings
 //
 // Expose the SD card as an object with the block protocol.
 

--- a/stmhal/sdcard.h
+++ b/stmhal/sdcard.h
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Micro Python project, http://micropython.org/
+ * This file is part of the MicroPython project, http://micropython.org/
  *
  * The MIT License (MIT)
  *

--- a/stmhal/servo.c
+++ b/stmhal/servo.c
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Micro Python project, http://micropython.org/
+ * This file is part of the MicroPython project, http://micropython.org/
  *
  * The MIT License (MIT)
  *
@@ -147,7 +147,7 @@ STATIC void servo_init_channel(pyb_servo_obj_t *s) {
 }
 
 /******************************************************************************/
-// Micro Python bindings
+// MicroPython bindings
 
 STATIC mp_obj_t pyb_servo_set(mp_obj_t port, mp_obj_t value) {
     int p = mp_obj_get_int(port);

--- a/stmhal/servo.h
+++ b/stmhal/servo.h
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Micro Python project, http://micropython.org/
+ * This file is part of the MicroPython project, http://micropython.org/
  *
  * The MIT License (MIT)
  *

--- a/stmhal/spi.c
+++ b/stmhal/spi.c
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Micro Python project, http://micropython.org/
+ * This file is part of the MicroPython project, http://micropython.org/
  *
  * The MIT License (MIT)
  *

--- a/stmhal/spi.h
+++ b/stmhal/spi.h
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Micro Python project, http://micropython.org/
+ * This file is part of the MicroPython project, http://micropython.org/
  *
  * The MIT License (MIT)
  *

--- a/stmhal/stm32_it.c
+++ b/stmhal/stm32_it.c
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Micro Python project, http://micropython.org/
+ * This file is part of the MicroPython project, http://micropython.org/
  *
  * Original template from ST Cube library.  See below for header.
  *

--- a/stmhal/stm32_it.h
+++ b/stmhal/stm32_it.h
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Micro Python project, http://micropython.org/
+ * This file is part of the MicroPython project, http://micropython.org/
  *
  * Original template from ST Cube library.  See below for header.
  *

--- a/stmhal/storage.c
+++ b/stmhal/storage.c
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Micro Python project, http://micropython.org/
+ * This file is part of the MicroPython project, http://micropython.org/
  *
  * The MIT License (MIT)
  *

--- a/stmhal/storage.h
+++ b/stmhal/storage.h
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Micro Python project, http://micropython.org/
+ * This file is part of the MicroPython project, http://micropython.org/
  *
  * The MIT License (MIT)
  *

--- a/stmhal/system_stm32.c
+++ b/stmhal/system_stm32.c
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Micro Python project, http://micropython.org/
+ * This file is part of the MicroPython project, http://micropython.org/
  *
  * Taken from ST Cube library and modified.  See below for original header.
  *

--- a/stmhal/systick.c
+++ b/stmhal/systick.c
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Micro Python project, http://micropython.org/
+ * This file is part of the MicroPython project, http://micropython.org/
  *
  * The MIT License (MIT)
  *

--- a/stmhal/systick.h
+++ b/stmhal/systick.h
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Micro Python project, http://micropython.org/
+ * This file is part of the MicroPython project, http://micropython.org/
  *
  * The MIT License (MIT)
  *

--- a/stmhal/timer.c
+++ b/stmhal/timer.c
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Micro Python project, http://micropython.org/
+ * This file is part of the MicroPython project, http://micropython.org/
  *
  * The MIT License (MIT)
  *
@@ -247,7 +247,7 @@ uint32_t timer_get_source_freq(uint32_t tim_id) {
 }
 
 /******************************************************************************/
-/* Micro Python bindings                                                      */
+/* MicroPython bindings                                                      */
 
 STATIC const mp_obj_type_t pyb_timer_channel_type;
 

--- a/stmhal/timer.h
+++ b/stmhal/timer.h
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Micro Python project, http://micropython.org/
+ * This file is part of the MicroPython project, http://micropython.org/
  *
  * The MIT License (MIT)
  *

--- a/stmhal/uart.c
+++ b/stmhal/uart.c
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Micro Python project, http://micropython.org/
+ * This file is part of the MicroPython project, http://micropython.org/
  *
  * The MIT License (MIT)
  *
@@ -509,7 +509,7 @@ void uart_irq_handler(mp_uint_t uart_id) {
 }
 
 /******************************************************************************/
-/* Micro Python bindings                                                      */
+/* MicroPython bindings                                                      */
 
 STATIC void pyb_uart_print(const mp_print_t *print, mp_obj_t self_in, mp_print_kind_t kind) {
     pyb_uart_obj_t *self = self_in;

--- a/stmhal/uart.h
+++ b/stmhal/uart.h
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Micro Python project, http://micropython.org/
+ * This file is part of the MicroPython project, http://micropython.org/
  *
  * The MIT License (MIT)
  *

--- a/stmhal/usb.c
+++ b/stmhal/usb.c
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Micro Python project, http://micropython.org/
+ * This file is part of the MicroPython project, http://micropython.org/
  *
  * The MIT License (MIT)
  *
@@ -169,7 +169,7 @@ void usb_vcp_send_strn_cooked(const char *str, int len) {
 }
 
 /******************************************************************************/
-// Micro Python bindings for USB
+// MicroPython bindings for USB
 
 /*
   Philosophy of USB driver and Python API: pyb.usb_mode(...) configures the USB
@@ -324,7 +324,7 @@ bad_mode:
 MP_DEFINE_CONST_FUN_OBJ_KW(pyb_usb_mode_obj, 0, pyb_usb_mode);
 
 /******************************************************************************/
-// Micro Python bindings for USB VCP
+// MicroPython bindings for USB VCP
 
 /// \moduleref pyb
 /// \class USB_VCP - USB virtual comm port
@@ -525,7 +525,7 @@ const mp_obj_type_t pyb_usb_vcp_type = {
 };
 
 /******************************************************************************/
-// Micro Python bindings for USB HID
+// MicroPython bindings for USB HID
 
 typedef struct _pyb_usb_hid_obj_t {
     mp_obj_base_t base;

--- a/stmhal/usb.h
+++ b/stmhal/usb.h
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Micro Python project, http://micropython.org/
+ * This file is part of the MicroPython project, http://micropython.org/
  *
  * The MIT License (MIT)
  *

--- a/stmhal/usbd_cdc_interface.h
+++ b/stmhal/usbd_cdc_interface.h
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Micro Python project, http://micropython.org/
+ * This file is part of the MicroPython project, http://micropython.org/
  */
 #ifndef MICROPY_INCLUDED_STMHAL_USBD_CDC_INTERFACE_H
 #define MICROPY_INCLUDED_STMHAL_USBD_CDC_INTERFACE_H

--- a/stmhal/usbd_conf.c
+++ b/stmhal/usbd_conf.c
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Micro Python project, http://micropython.org/
+ * This file is part of the MicroPython project, http://micropython.org/
  */
 
 /**

--- a/stmhal/usbd_conf.h
+++ b/stmhal/usbd_conf.h
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Micro Python project, http://micropython.org/
+ * This file is part of the MicroPython project, http://micropython.org/
  */
 
 /**

--- a/stmhal/usbd_desc.c
+++ b/stmhal/usbd_desc.c
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Micro Python project, http://micropython.org/
+ * This file is part of the MicroPython project, http://micropython.org/
  */
 
 /**

--- a/stmhal/usbd_desc.h
+++ b/stmhal/usbd_desc.h
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Micro Python project, http://micropython.org/
+ * This file is part of the MicroPython project, http://micropython.org/
  *
  * The MIT License (MIT)
  *

--- a/stmhal/usbd_msc_storage.h
+++ b/stmhal/usbd_msc_storage.h
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Micro Python project, http://micropython.org/
+ * This file is part of the MicroPython project, http://micropython.org/
  *
  * The MIT License (MIT)
  *

--- a/stmhal/usbdev/class/inc/usbd_cdc_msc_hid0.h
+++ b/stmhal/usbdev/class/inc/usbd_cdc_msc_hid0.h
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Micro Python project, http://micropython.org/
+ * This file is part of the MicroPython project, http://micropython.org/
  *
  * The MIT License (MIT)
  *

--- a/stmhal/usbdev/class/src/usbd_cdc_msc_hid.c
+++ b/stmhal/usbdev/class/src/usbd_cdc_msc_hid.c
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Micro Python project, http://micropython.org/
+ * This file is part of the MicroPython project, http://micropython.org/
  *
  * The MIT License (MIT)
  *

--- a/stmhal/usrsw.c
+++ b/stmhal/usrsw.c
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Micro Python project, http://micropython.org/
+ * This file is part of the MicroPython project, http://micropython.org/
  *
  * The MIT License (MIT)
  *
@@ -63,7 +63,7 @@ int switch_get(void) {
 }
 
 /******************************************************************************/
-// Micro Python bindings
+// MicroPython bindings
 
 typedef struct _pyb_switch_obj_t {
     mp_obj_base_t base;

--- a/stmhal/usrsw.h
+++ b/stmhal/usrsw.h
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Micro Python project, http://micropython.org/
+ * This file is part of the MicroPython project, http://micropython.org/
  *
  * The MIT License (MIT)
  *

--- a/teensy/hal_ftm.c
+++ b/teensy/hal_ftm.c
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Micro Python project, http://micropython.org/
+ * This file is part of the MicroPython project, http://micropython.org/
  *
  * The MIT License (MIT)
  *

--- a/teensy/hal_ftm.h
+++ b/teensy/hal_ftm.h
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Micro Python project, http://micropython.org/
+ * This file is part of the MicroPython project, http://micropython.org/
  *
  * The MIT License (MIT)
  *

--- a/teensy/help.c
+++ b/teensy/help.c
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Micro Python project, http://micropython.org/
+ * This file is part of the MicroPython project, http://micropython.org/
  *
  * The MIT License (MIT)
  *

--- a/teensy/led.c
+++ b/teensy/led.c
@@ -81,7 +81,7 @@ void led_toggle(pyb_led_t led) {
 }
 
 /******************************************************************************/
-/* Micro Python bindings                                                      */
+/* MicroPython bindings                                                      */
 
 void led_obj_print(const mp_print_t *print, mp_obj_t self_in, mp_print_kind_t kind) {
     pyb_led_obj_t *self = self_in;

--- a/teensy/main.c
+++ b/teensy/main.c
@@ -266,7 +266,7 @@ soft_reset:
     // GC init
     gc_init(&_heap_start, (void*)HEAP_END);
 
-    // Micro Python init
+    // MicroPython init
     mp_init();
     mp_obj_list_init(mp_sys_path, 0);
     mp_obj_list_append(mp_sys_path, MP_OBJ_NEW_QSTR(MP_QSTR_)); // current dir (or base dir of the script)

--- a/teensy/modpyb.c
+++ b/teensy/modpyb.c
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Micro Python project, http://micropython.org/
+ * This file is part of the MicroPython project, http://micropython.org/
  *
  * The MIT License (MIT)
  *
@@ -154,7 +154,7 @@ STATIC MP_DEFINE_CONST_FUN_OBJ_0(pyb_sync_obj, pyb_sync);
 /// \function millis()
 /// Returns the number of milliseconds since the board was last reset.
 ///
-/// The result is always a micropython smallint (31-bit signed number), so
+/// The result is always a MicroPython smallint (31-bit signed number), so
 /// after 2^30 milliseconds (about 12.4 days) this will start to return
 /// negative numbers.
 STATIC mp_obj_t pyb_millis(void) {
@@ -185,7 +185,7 @@ STATIC MP_DEFINE_CONST_FUN_OBJ_1(pyb_elapsed_millis_obj, pyb_elapsed_millis);
 /// \function micros()
 /// Returns the number of microseconds since the board was last reset.
 ///
-/// The result is always a micropython smallint (31-bit signed number), so
+/// The result is always a MicroPython smallint (31-bit signed number), so
 /// after 2^30 microseconds (about 17.8 minutes) this will start to return
 /// negative numbers.
 STATIC mp_obj_t pyb_micros(void) {

--- a/teensy/mpconfigport.h
+++ b/teensy/mpconfigport.h
@@ -1,6 +1,6 @@
 #include <stdint.h>
 
-// options to control how Micro Python is built
+// options to control how MicroPython is built
 
 #define MICROPY_ALLOC_PATH_MAX      (128)
 #define MICROPY_EMIT_THUMB          (1)

--- a/teensy/timer.c
+++ b/teensy/timer.c
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Micro Python project, http://micropython.org/
+ * This file is part of the MicroPython project, http://micropython.org/
  *
  * The MIT License (MIT)
  *
@@ -119,7 +119,7 @@ mp_uint_t get_prescaler_shift(mp_int_t prescaler) {
 }
 
 /******************************************************************************/
-/* Micro Python bindings                                                      */
+/* MicroPython bindings                                                      */
 
 STATIC const mp_obj_type_t pyb_timer_channel_type;
 

--- a/teensy/timer.h
+++ b/teensy/timer.h
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Micro Python project, http://micropython.org/
+ * This file is part of the MicroPython project, http://micropython.org/
  *
  * The MIT License (MIT)
  *

--- a/teensy/uart.c
+++ b/teensy/uart.c
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Micro Python project, http://micropython.org/
+ * This file is part of the MicroPython project, http://micropython.org/
  *
  * The MIT License (MIT)
  *
@@ -221,7 +221,7 @@ void uart_tx_strn_cooked(pyb_uart_obj_t *uart_obj, const char *str, uint len) {
 }
 
 /******************************************************************************/
-/* Micro Python bindings                                                      */
+/* MicroPython bindings                                                      */
 
 STATIC void pyb_uart_print(const mp_print_t *print, mp_obj_t self_in, mp_print_kind_t kind) {
     pyb_uart_obj_t *self = self_in;

--- a/tests/basics/bytearray_slice_assign.py
+++ b/tests/basics/bytearray_slice_assign.py
@@ -4,7 +4,7 @@ except TypeError:
     print("SKIP")
     raise SystemExit
 
-# test slices; only 2 argument version supported by Micro Python at the moment
+# test slices; only 2 argument version supported by MicroPython at the moment
 x = bytearray(range(10))
 
 # Assignment

--- a/tests/basics/list_slice_assign.py
+++ b/tests/basics/list_slice_assign.py
@@ -1,4 +1,4 @@
-# test slices; only 2 argument version supported by Micro Python at the moment
+# test slices; only 2 argument version supported by MicroPython at the moment
 x = list(range(10))
 
 # Assignment

--- a/tests/io/stringio1.py
+++ b/tests/io/stringio1.py
@@ -36,7 +36,7 @@ print(a.read())
 a = io.StringIO()
 a.close()
 for f in [a.read, a.getvalue, lambda:a.write("")]:
-    # CPython throws for operations on closed I/O, micropython makes
+    # CPython throws for operations on closed I/O, MicroPython makes
     # the underlying string empty unless MICROPY_CPYTHON_COMPAT defined
     try:
         f()

--- a/tests/run-bench-tests
+++ b/tests/run-bench-tests
@@ -26,7 +26,7 @@ def run_tests(pyb, test_dict):
         print(base_test + ":")
         for test_file in tests:
 
-            # run Micro Python
+            # run MicroPython
             if pyb is None:
                 # run on PC
                 try:

--- a/tests/run-tests
+++ b/tests/run-tests
@@ -388,7 +388,7 @@ def run_tests(pyb, tests, args, base_path="."):
         if args.write_exp:
             continue
 
-        # run Micro Python
+        # run MicroPython
         output_mupy = run_micropython(pyb, args, test_file)
 
         if output_mupy == b'SKIP\n':

--- a/tools/gen-cpydiff.py
+++ b/tools/gen-cpydiff.py
@@ -33,7 +33,7 @@ import time
 import re
 from collections import namedtuple
 
-# Micropython supports syntax of CPython 3.4 with some features from 3.5, and
+# MicroPython supports syntax of CPython 3.4 with some features from 3.5, and
 # such version should be used to test for differences. If your default python3
 # executable is of lower version, you can point MICROPY_CPYTHON3 environment var
 # to the correct executable.

--- a/unix/Makefile
+++ b/unix/Makefile
@@ -59,7 +59,7 @@ CFLAGS += -U _FORTIFY_SOURCE
 endif
 
 # On OSX, 'gcc' is a symlink to clang unless a real gcc is installed.
-# The unix port of micropython on OSX must be compiled with clang,
+# The unix port of MicroPython on OSX must be compiled with clang,
 # while cross-compile ports require gcc, so we test here for OSX and
 # if necessary override the value of 'CC' set in py/mkenv.mk
 ifeq ($(UNAME_S),Darwin)

--- a/unix/alloc.c
+++ b/unix/alloc.c
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Micro Python project, http://micropython.org/
+ * This file is part of the MicroPython project, http://micropython.org/
  *
  * The MIT License (MIT)
  *

--- a/unix/fdfile.h
+++ b/unix/fdfile.h
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Micro Python project, http://micropython.org/
+ * This file is part of the MicroPython project, http://micropython.org/
  *
  * The MIT License (MIT)
  *

--- a/unix/file.c
+++ b/unix/file.c
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Micro Python project, http://micropython.org/
+ * This file is part of the MicroPython project, http://micropython.org/
  *
  * The MIT License (MIT)
  *

--- a/unix/gccollect.c
+++ b/unix/gccollect.c
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Micro Python project, http://micropython.org/
+ * This file is part of the MicroPython project, http://micropython.org/
  *
  * The MIT License (MIT)
  *

--- a/unix/input.c
+++ b/unix/input.c
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Micro Python project, http://micropython.org/
+ * This file is part of the MicroPython project, http://micropython.org/
  *
  * The MIT License (MIT)
  *

--- a/unix/main.c
+++ b/unix/main.c
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Micro Python project, http://micropython.org/
+ * This file is part of the MicroPython project, http://micropython.org/
  *
  * The MIT License (MIT)
  *

--- a/unix/modffi.c
+++ b/unix/modffi.c
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Micro Python project, http://micropython.org/
+ * This file is part of the MicroPython project, http://micropython.org/
  *
  * The MIT License (MIT)
  *

--- a/unix/modjni.c
+++ b/unix/modjni.c
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Micro Python project, http://micropython.org/
+ * This file is part of the MicroPython project, http://micropython.org/
  *
  * The MIT License (MIT)
  *

--- a/unix/modmachine.c
+++ b/unix/modmachine.c
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Micro Python project, http://micropython.org/
+ * This file is part of the MicroPython project, http://micropython.org/
  *
  * The MIT License (MIT)
  *

--- a/unix/modos.c
+++ b/unix/modos.c
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Micro Python project, http://micropython.org/
+ * This file is part of the MicroPython project, http://micropython.org/
  *
  * The MIT License (MIT)
  *

--- a/unix/modsocket.c
+++ b/unix/modsocket.c
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Micro Python project, http://micropython.org/
+ * This file is part of the MicroPython project, http://micropython.org/
  *
  * The MIT License (MIT)
  *

--- a/unix/modtermios.c
+++ b/unix/modtermios.c
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Micro Python project, http://micropython.org/
+ * This file is part of the MicroPython project, http://micropython.org/
  *
  * The MIT License (MIT)
  *

--- a/unix/modtime.c
+++ b/unix/modtime.c
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Micro Python project, http://micropython.org/
+ * This file is part of the MicroPython project, http://micropython.org/
  *
  * The MIT License (MIT)
  *

--- a/unix/moduselect.c
+++ b/unix/moduselect.c
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Micro Python project, http://micropython.org/
+ * This file is part of the MicroPython project, http://micropython.org/
  *
  * The MIT License (MIT)
  *

--- a/unix/mpconfigport.h
+++ b/unix/mpconfigport.h
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Micro Python project, http://micropython.org/
+ * This file is part of the MicroPython project, http://micropython.org/
  *
  * The MIT License (MIT)
  *
@@ -24,7 +24,7 @@
  * THE SOFTWARE.
  */
 
-// options to control how Micro Python is built
+// options to control how MicroPython is built
 
 #define MICROPY_ALLOC_PATH_MAX      (PATH_MAX)
 #define MICROPY_PERSISTENT_CODE_LOAD (1)

--- a/unix/mpconfigport_fast.h
+++ b/unix/mpconfigport_fast.h
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Micro Python project, http://micropython.org/
+ * This file is part of the MicroPython project, http://micropython.org/
  *
  * The MIT License (MIT)
  *

--- a/unix/mpconfigport_minimal.h
+++ b/unix/mpconfigport_minimal.h
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Micro Python project, http://micropython.org/
+ * This file is part of the MicroPython project, http://micropython.org/
  *
  * The MIT License (MIT)
  *
@@ -24,7 +24,7 @@
  * THE SOFTWARE.
  */
 
-// options to control how Micro Python is built
+// options to control how MicroPython is built
 
 #define MICROPY_ALLOC_QSTR_CHUNK_INIT (64)
 #define MICROPY_ALLOC_PARSE_RULE_INIT (8)

--- a/unix/mphalport.h
+++ b/unix/mphalport.h
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Micro Python project, http://micropython.org/
+ * This file is part of the MicroPython project, http://micropython.org/
  *
  * The MIT License (MIT)
  *

--- a/unix/qstrdefsport.h
+++ b/unix/qstrdefsport.h
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Micro Python project, http://micropython.org/
+ * This file is part of the MicroPython project, http://micropython.org/
  *
  * The MIT License (MIT)
  *

--- a/unix/unix_mphal.c
+++ b/unix/unix_mphal.c
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Micro Python project, http://micropython.org/
+ * This file is part of the MicroPython project, http://micropython.org/
  *
  * The MIT License (MIT)
  *

--- a/windows/init.c
+++ b/windows/init.c
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Micro Python project, http://micropython.org/
+ * This file is part of the MicroPython project, http://micropython.org/
  *
  * The MIT License (MIT)
  *

--- a/windows/init.h
+++ b/windows/init.h
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Micro Python project, http://micropython.org/
+ * This file is part of the MicroPython project, http://micropython.org/
  *
  * The MIT License (MIT)
  *

--- a/windows/mpconfigport.h
+++ b/windows/mpconfigport.h
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Micro Python project, http://micropython.org/
+ * This file is part of the MicroPython project, http://micropython.org/
  *
  * The MIT License (MIT)
  *
@@ -24,7 +24,7 @@
  * THE SOFTWARE.
  */
 
-// options to control how Micro Python is built
+// options to control how MicroPython is built
 
 // Linking with GNU readline (MICROPY_USE_READLINE == 2) causes binary to be licensed under GPL
 #ifndef MICROPY_USE_READLINE

--- a/windows/msvc/gettimeofday.c
+++ b/windows/msvc/gettimeofday.c
@@ -1,5 +1,5 @@
 /*
-* This file is part of the Micro Python project, http://micropython.org/
+* This file is part of the MicroPython project, http://micropython.org/
 *
 * The MIT License (MIT)
 *

--- a/windows/msvc/sys/time.h
+++ b/windows/msvc/sys/time.h
@@ -1,5 +1,5 @@
 /*
-* This file is part of the Micro Python project, http://micropython.org/
+* This file is part of the MicroPython project, http://micropython.org/
 *
 * The MIT License (MIT)
 *

--- a/windows/msvc/unistd.h
+++ b/windows/msvc/unistd.h
@@ -1,5 +1,5 @@
 /*
-* This file is part of the Micro Python project, http://micropython.org/
+* This file is part of the MicroPython project, http://micropython.org/
 *
 * The MIT License (MIT)
 *

--- a/windows/realpath.c
+++ b/windows/realpath.c
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Micro Python project, http://micropython.org/
+ * This file is part of the MicroPython project, http://micropython.org/
  *
  * The MIT License (MIT)
  *

--- a/windows/realpath.h
+++ b/windows/realpath.h
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Micro Python project, http://micropython.org/
+ * This file is part of the MicroPython project, http://micropython.org/
  *
  * The MIT License (MIT)
  *

--- a/windows/sleep.c
+++ b/windows/sleep.c
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Micro Python project, http://micropython.org/
+ * This file is part of the MicroPython project, http://micropython.org/
  *
  * The MIT License (MIT)
  *

--- a/windows/sleep.h
+++ b/windows/sleep.h
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Micro Python project, http://micropython.org/
+ * This file is part of the MicroPython project, http://micropython.org/
  *
  * The MIT License (MIT)
  *

--- a/windows/windows_mphal.c
+++ b/windows/windows_mphal.c
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Micro Python project, http://micropython.org/
+ * This file is part of the MicroPython project, http://micropython.org/
  *
  * The MIT License (MIT)
  *

--- a/windows/windows_mphal.h
+++ b/windows/windows_mphal.h
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Micro Python project, http://micropython.org/
+ * This file is part of the MicroPython project, http://micropython.org/
  *
  * The MIT License (MIT)
  *

--- a/zephyr/machine_pin.c
+++ b/zephyr/machine_pin.c
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Micro Python project, http://micropython.org/
+ * This file is part of the MicroPython project, http://micropython.org/
  *
  * The MIT License (MIT)
  *

--- a/zephyr/modutime.c
+++ b/zephyr/modutime.c
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Micro Python project, http://micropython.org/
+ * This file is part of the MicroPython project, http://micropython.org/
  *
  * The MIT License (MIT)
  *


### PR DESCRIPTION
There were several different spellings of MicroPython present in the code,
when there should be only one.