### PR TITLE
docs/pyboard: Move hardware info into General Info chapter.

### DIFF
--- a/docs/pyboard/general.rst
+++ b/docs/pyboard/general.rst
@@ -1,6 +1,8 @@
 General information about the pyboard
 =====================================
 
+.. contents::
+
 Local filesystem and SD card
 ----------------------------
 
@@ -67,3 +69,4 @@ There are currently 2 kinds of errors that you might see:
 2. If all 4 LEDs cycle on and off slowly, then there was a hard fault.
    This cannot be recovered from and you need to do a hard reset.
 
+.. include:: hardware/index.rst

--- a/docs/pyboard/hardware/index.rst
+++ b/docs/pyboard/hardware/index.rst
@@ -1,7 +1,7 @@
 .. _hardware_index:
 
 The pyboard hardware
-====================
+--------------------
 
 For the pyboard:
 
@@ -16,14 +16,14 @@ For the official skin modules:
 * LCD160CRv1.0: see :mod:`lcd160cr`
 
 Datasheets for the components on the pyboard
-============================================
+--------------------------------------------
 
 * The microcontroller: `STM32F405RGT6 <http://www.st.com/web/catalog/mmc/FM141/SC1169/SS1577/LN1035/PF252144>`_ (link to manufacturer's site)
 * The accelerometer: `Freescale MMA7660 <http://micropython.org/resources/datasheets/MMA7660FC.pdf>`_ (800kiB PDF)
 * The LDO voltage regulator: `Microchip MCP1802 <http://micropython.org/resources/datasheets/MCP1802-22053C.pdf>`_ (400kiB PDF)
 
 Datasheets for other components
-===============================
+-------------------------------
 
 * The LCD display on the LCD touch-sensor skin: `Newhaven Display NHD-C12832A1Z-FSW-FBW-3V3 <http://micropython.org/resources/datasheets/NHD-C12832A1Z-FSW-FBW-3V3.pdf>`_ (460KiB PDF)
 * The touch sensor chip on the LCD touch-sensor skin: `Freescale MPR121 <http://micropython.org/resources/datasheets/MPR121.pdf>`_ (280KiB PDF)

--- a/docs/pyboard/tutorial/index.rst
+++ b/docs/pyboard/tutorial/index.rst
@@ -1,7 +1,7 @@
 .. _tutorial-index:
 
-MicroPython tutorial
-====================
+MicroPython tutorial for the pyboard
+====================================
 
 This tutorial is intended to get you started with your pyboard.
 All you need is a pyboard and a micro-USB cable to connect it to

--- a/docs/pyboard_index.rst
+++ b/docs/pyboard_index.rst
@@ -6,7 +6,6 @@ MicroPython documentation and references
     pyboard/quickref.rst
     pyboard/general.rst
     pyboard/tutorial/index.rst
-    pyboard/hardware/index.rst
     library/index.rst
     reference/index.rst
     genrst/index.rst


### PR DESCRIPTION
This makes top-level ToC of the pyboard docs consistent with other ports
(consisting of 3 chapters: QuickRef, General Info, and Tutorial).

Also, some other minor tweaks applied, like local ToC for General Info and
headings mentioning pyboard.