### PR TITLE
build: Quiet some compiler warnings.

### DIFF
--- a/extmod/utime_mphal.c
+++ b/extmod/utime_mphal.c
@@ -38,7 +38,7 @@
 
 STATIC mp_obj_t time_sleep(mp_obj_t seconds_o) {
     #if MICROPY_PY_BUILTINS_FLOAT
-    mp_hal_delay_ms(1000 * mp_obj_get_float(seconds_o));
+    mp_hal_delay_ms((mp_uint_t)(1000 * mp_obj_get_float(seconds_o)));
     #else
     mp_hal_delay_ms(1000 * mp_obj_get_int(seconds_o));
     #endif

--- a/py/builtinimport.c
+++ b/py/builtinimport.c
@@ -227,10 +227,11 @@ STATIC void do_load(mp_obj_t module_obj, vstr_t *file) {
         do_load_from_lexer(module_obj, lex);
         return;
     }
-    #endif
+    #else
 
     // If we get here then the file was not frozen and we can't compile scripts.
     mp_raise_msg(&mp_type_ImportError, "script compilation not supported");
+    #endif
 }
 
 STATIC void chop_component(const char *start, const char **end) {

--- a/py/emitbc.c
+++ b/py/emitbc.c
@@ -902,7 +902,7 @@ void mp_emit_bc_make_closure(emit_t *emit, scope_t *scope, mp_uint_t n_closed_ov
         emit_write_bytecode_byte(emit, n_closed_over);
     } else {
         assert(n_closed_over <= 255);
-        emit_bc_pre(emit, -2 - n_closed_over + 1);
+        emit_bc_pre(emit, -2 - (mp_int_t) n_closed_over + 1);
         emit_write_bytecode_byte_raw_code(emit, MP_BC_MAKE_CLOSURE_DEFARGS, scope->raw_code);
         emit_write_bytecode_byte(emit, n_closed_over);
     }

--- a/py/formatfloat.c
+++ b/py/formatfloat.c
@@ -332,7 +332,7 @@ int mp_format_float(FPTYPE f, char *buf, size_t buf_size, char fmt, int prec, ch
 
     // Print the digits of the mantissa
     for (int i = 0; i < num_digits; ++i, --dec) {
-        int32_t d = f;
+        int32_t d = (int32_t)f;
         *s++ = '0' + d;
         if (dec == 0 && prec > 0) {
             *s++ = '.';

--- a/py/lexer.c
+++ b/py/lexer.c
@@ -672,7 +672,7 @@ mp_lexer_t *mp_lexer_new(qstr src_name, mp_reader_t reader) {
     lex->source_name = src_name;
     lex->reader = reader;
     lex->line = 1;
-    lex->column = -2;   // account for 3 dummy bytes
+    lex->column = (size_t)-2;   // account for 3 dummy bytes
     lex->emit_dent = 0;
     lex->nested_bracket_level = 0;
     lex->alloc_indent_level = MICROPY_ALLOC_LEXER_INDENT_INIT;

--- a/py/modbuiltins.c
+++ b/py/modbuiltins.c
@@ -109,10 +109,10 @@ STATIC mp_obj_t mp_builtin_abs(mp_obj_t o_in) {
         return mp_obj_new_float(MICROPY_FLOAT_C_FUN(sqrt)(real*real + imag*imag));
 #endif
 #endif
-    } else {
-        // this will raise a TypeError if the argument is not integral
-        return mp_obj_int_abs(o_in);
     }
+
+    // this will raise a TypeError if the argument is not integral
+    return mp_obj_int_abs(o_in);
 }
 MP_DEFINE_CONST_FUN_OBJ_1(mp_builtin_abs_obj, mp_builtin_abs);
 

--- a/py/objint.c
+++ b/py/objint.c
@@ -106,7 +106,7 @@ STATIC mp_fp_as_int_class_t mp_classify_fp_as_int(mp_float_t val) {
 #define MP_FLOAT_SIGN_SHIFT_I32 ((MP_FLOAT_FRAC_BITS + MP_FLOAT_EXP_BITS) % 32)
 #define MP_FLOAT_EXP_SHIFT_I32 (MP_FLOAT_FRAC_BITS % 32)
 
-    if (e & (1 << MP_FLOAT_SIGN_SHIFT_I32)) {
+    if (e & (1U << MP_FLOAT_SIGN_SHIFT_I32)) {
 #if MICROPY_FLOAT_IMPL == MICROPY_FLOAT_IMPL_DOUBLE
         e |= u.i[MP_ENDIANNESS_BIG] != 0;
 #endif

--- a/py/runtime.c
+++ b/py/runtime.c
@@ -1410,16 +1410,13 @@ mp_obj_t mp_parse_compile_execute(mp_lexer_t *lex, mp_parse_input_kind_t parse_i
 
 NORETURN void *m_malloc_fail(size_t num_bytes) {
     DEBUG_printf("memory allocation failed, allocating %u bytes\n", (uint)num_bytes);
-    if (0) {
-        // dummy
     #if MICROPY_ENABLE_GC
-    } else if (gc_is_locked()) {
+    if (gc_is_locked()) {
         mp_raise_msg(&mp_type_MemoryError, "memory allocation failed, heap is locked");
-    #endif
-    } else {
-        nlr_raise(mp_obj_new_exception_msg_varg(&mp_type_MemoryError,
-            "memory allocation failed, allocating %u bytes", (uint)num_bytes));
     }
+    #endif
+    nlr_raise(mp_obj_new_exception_msg_varg(&mp_type_MemoryError,
+        "memory allocation failed, allocating %u bytes", (uint)num_bytes));
 }
 
 NORETURN void mp_raise_msg(const mp_obj_type_t *exc_type, const char *msg) {

--- a/py/vstr.c
+++ b/py/vstr.c
@@ -34,7 +34,7 @@
 #include "py/mpprint.h"
 
 // returned value is always at least 1 greater than argument
-#define ROUND_ALLOC(a) (((a) & ((~0) - 7)) + 8)
+#define ROUND_ALLOC(a) (((a) & ((~0U) - 7)) + 8)
 
 // Init the vstr so it allocs exactly given number of bytes.  Set length to zero.
 void vstr_init(vstr_t *vstr, size_t alloc) {


### PR DESCRIPTION
Not sure if there's any interest in these changes, but they quiet some of the compiler warnings I see when building with IAR's ARM compiler.  Some of the warnings are about implicit typecasts (fixed with explicitly casting to acknowledge the change is intentional) or sign conversions (fixed with the `U` suffix on numeric values).

Others are related to unreachable code or functions that don't return a value.  In those cases I made slight changes to the end of the function so it's clear what's happening in the function.  Might even shave off a few bytes in the final binary with the `builtinimport.c` change.