### PR TITLE
docs/esp8266_index: Drop "Indices and tables" pseudo-section.

### DIFF
--- a/docs/esp8266_index.rst
+++ b/docs/esp8266_index.rst
@@ -10,10 +10,3 @@ MicroPython documentation and references
     reference/index.rst
     genrst/index.rst
     license.rst
-
-Indices and tables
-==================
-
-* :ref:`genindex`
-* :ref:`modindex`
-* :ref:`search`


### PR DESCRIPTION
This pseudo-section causes artifacts with latexpdf generation (almost
empty page with list containing literal "genindex", "modeindex", "search"
items). For HTML docs, these sections can be accessed from "home" page.