### PR TITLE
Check eval()/exec() args

### DIFF
--- a/py/builtinevex.c
+++ b/py/builtinevex.c
@@ -113,12 +113,16 @@ STATIC mp_obj_t eval_exec_helper(size_t n_args, const mp_obj_t *args, mp_parse_i
     // work out the context
     mp_obj_dict_t *globals = mp_globals_get();
     mp_obj_dict_t *locals = mp_locals_get();
-    if (n_args > 1) {
-        globals = MP_OBJ_TO_PTR(args[1]);
-        if (n_args > 2) {
-            locals = MP_OBJ_TO_PTR(args[2]);
-        } else {
-            locals = globals;
+    
+    for (int i = 1; i < 3 && i < n_args; ++i) {
+        if (args[i] != mp_const_none) {
+            if (!MP_OBJ_IS_TYPE(args[i], &mp_type_dict)) {
+                mp_raise_TypeError(NULL);
+            }
+            locals = MP_OBJ_TO_PTR(args[i]);
+            if (i == 1) {
+                globals = locals;
+            }
         }
     }
 

--- a/tests/basics/exec_args.py
+++ b/tests/basics/exec_args.py
@@ -1,0 +1,21 @@
+# test various globals and locals arguments to exec()
+
+try:
+	exec('print(1)', 'foo')
+except TypeError:
+	print('TypeError')
+
+foo = 11
+exec('print(foo)')
+exec('print(foo)', None)
+exec('print(foo)', {'foo':3}, None)
+exec('print(foo)', None, {'foo':3})
+exec('print(foo)', {'bar':3}, locals())
+
+try:
+	exec('print(foo)', {'bar':3}, None)
+except NameError:
+	print('NameError')
+
+exec('print(foo)', None, {'foo':3})
+exec('print(foo)', None, {'bar':3})


### PR DESCRIPTION
During some fuzz testing, a co-worker found that eval() and exec() weren't type checking the second and third arguments (globals and locals).  This typically results in a crash when you pass anything other than a dict.

In addition, you can pass "None" to specify globals or locals from the callers environment.

I've added a test and updated MicroPython so its behavior matches Python3.  Because of the added functionality, I expect to see an increase in code size.