### PR TITLE
cc3200: Use the name MicroPython consistently in code

### DIFF
--- a/cc3200/ftp/ftp.c
+++ b/cc3200/ftp/ftp.c
@@ -335,7 +335,7 @@ void ftp_run (void) {
                     ftp_data.loggin.uservalid = false;
                     ftp_data.loggin.passvalid = false;
                     strcpy (ftp_path, "/");
-                    ftp_send_reply (220, "Micropython FTP Server");
+                    ftp_send_reply (220, "MicroPython FTP Server");
                     break;
                 }
             }

--- a/cc3200/main.c
+++ b/cc3200/main.c
@@ -89,7 +89,7 @@ int main (void) {
 #ifndef DEBUG
     OsiTaskHandle mpTaskHandle;
 #endif
-    mpTaskHandle = xTaskCreateStatic(TASK_Micropython, "MicroPy",
+    mpTaskHandle = xTaskCreateStatic(TASK_MicroPython, "MicroPy",
         MICROPY_TASK_STACK_LEN, NULL, MICROPY_TASK_PRIORITY, mpTaskStack, &mpTaskTCB);
     ASSERT(mpTaskHandle != NULL);
 

--- a/cc3200/mptask.c
+++ b/cc3200/mptask.c
@@ -112,7 +112,7 @@ static const char fresh_boot_py[] = "# boot.py -- run on boot-up\r\n"
  DECLARE PUBLIC FUNCTIONS
  ******************************************************************************/
 
-void TASK_Micropython (void *pvParameters) {
+void TASK_MicroPython (void *pvParameters) {
     // get the top of the stack to initialize the garbage collector
     uint32_t sp = gc_helper_get_sp();
 

--- a/cc3200/mptask.h
+++ b/cc3200/mptask.h
@@ -42,6 +42,6 @@ extern StackType_t mpTaskStack[];
 /******************************************************************************
  DECLARE PUBLIC FUNCTIONS
  ******************************************************************************/
-extern void TASK_Micropython (void *pvParameters);
+extern void TASK_MicroPython (void *pvParameters);
 
 #endif /* MPTASK_H_ */


### PR DESCRIPTION
In a few places the cc3200 port uses the incorrect spelling Micropython
instead of MicroPython.

Split off from #3181.