### PR TITLE
Extend audio playback documentation

### DIFF
--- a/docs/pyboard/tutorial/amp_skin.rst
+++ b/docs/pyboard/tutorial/amp_skin.rst
@@ -69,4 +69,4 @@ Then you can do::
     >>> f = wave.open('test.wav')
     >>> dac.write_timed(f.readframes(f.getnframes()), f.getframerate())
 
-This should play the WAV file.
+This should play the WAV file. Note that this will read the whole file into RAM so it has to be small enough to fit in it.

--- a/docs/pyboard/tutorial/amp_skin.rst
+++ b/docs/pyboard/tutorial/amp_skin.rst
@@ -60,8 +60,10 @@ on your pyboard (either on the flash or the SD card in the top-level directory).
 or to convert any file you have with the command::
 
     avconv -i original.wav -ar 22050 -codec pcm_u8 test.wav
-    
-Then you can do::
+
+Or by using online converters like http://audio.online-convert.com/convert-to-wav
+
+When you have converted a wave file you can play it::
 
     >>> import wave
     >>> from pyb import DAC

--- a/docs/pyboard/tutorial/amp_skin.rst
+++ b/docs/pyboard/tutorial/amp_skin.rst
@@ -69,10 +69,12 @@ Then you can do::
     >>> f = wave.open('test.wav')
     >>> dac.write_timed(f.readframes(f.getnframes()), f.getframerate())
 
-This should play the WAV file. Note that this will read the whole file into RAM so it has to be small enough to fit in it.
+This should play the WAV file. Note that this will read the whole file into RAM so it has to be small
+enough to fit in it.
 
-To play larger wave files you will have to use the microSD card to store it. Also the file must be read and sent in small chunks that will
-fit the RAM limit of the microcontroler. Here is an example function that can play 8 bit wave files with up to 16 kHz sampling::
+To play larger wave files you will have to use the microSD card to store it. Also the file must be read
+and sent in small chunks that will fit the RAM limit of the microcontroller. Here is an example function
+that can play 8 bit wave files with up to 16 kHz sampling::
 
     import wave
     from pyb import DAC
@@ -90,5 +92,6 @@ fit the RAM limit of the microcontroler. Here is an example function that can pl
             dac.write_timed(f.readframes(framerate), framerate)
             delay(1000)
 
-This function reads one second worth of data (which is the sample rate), sends it to DAC, waits one second and moves the file cursor to new position
-to read next second of data in the next for-loop run. It plays one second of audio at a time every one second.
+This function reads one second worth of data (which is the sample rate), sends it to DAC, waits one
+second and moves the file cursor to new position to read next second of data in the next for-loop run.
+It plays one second of audio at a time every one second.

--- a/docs/pyboard/tutorial/amp_skin.rst
+++ b/docs/pyboard/tutorial/amp_skin.rst
@@ -70,3 +70,25 @@ Then you can do::
     >>> dac.write_timed(f.readframes(f.getnframes()), f.getframerate())
 
 This should play the WAV file. Note that this will read the whole file into RAM so it has to be small enough to fit in it.
+
+To play larger wave files you will have to use the microSD card to store it. Also the file must be read and sent in small chunks that will
+fit the RAM limit of the microcontroler. Here is an example function that can play 8 bit wave files with up to 16 kHz sampling::
+
+    import wave
+    from pyb import DAC
+    from pyb import delay
+    dac = DAC(1)
+
+
+    def play(filename):
+        f = wave.open(filename, 'r')
+        total_frames = f.getnframes()
+        framerate = f.getframerate()
+
+        for position in range(0, total_frames, framerate):
+            f.setpos(position)
+            dac.write_timed(f.readframes(framerate), framerate)
+            delay(1000)
+
+This function reads one second worth of data (which is the sample rate), sends it to DAC, waits one second and moves the file cursor to new position
+to read next second of data in the next for-loop run. It plays one second of audio at a time every one second.

--- a/docs/pyboard/tutorial/amp_skin.rst
+++ b/docs/pyboard/tutorial/amp_skin.rst
@@ -60,10 +60,8 @@ on your pyboard (either on the flash or the SD card in the top-level directory).
 or to convert any file you have with the command::
 
     avconv -i original.wav -ar 22050 -codec pcm_u8 test.wav
-
-Or by using online converters like http://audio.online-convert.com/convert-to-wav
-
-When you have converted a wave file you can play it::
+    
+Then you can do::
 
     >>> import wave
     >>> from pyb import DAC


### PR DESCRIPTION
Also the http://micropython.org/resources/examples/wave.py file imports:

```
from _collections import namedtuple
```

which isn't compatible with latest pyboard micropython firmware. Should be without the "_"