### PR TITLE
tools/mpy_bin2res: Tools to convert binary resources to Python module.

### DIFF
--- a/tools/mpy_bin2res.py
+++ b/tools/mpy_bin2res.py
@@ -1,0 +1,18 @@
+#!/usr/bin/env python3
+#
+# This tool converts binary resource files passed on the command line
+# into a Python source file containing data from these files, which can
+# be accessed using standard pkg_resources.resource_stream() function
+# from micropython-lib:
+# https://github.com/micropython/micropython-lib/tree/master/pkg_resources
+#
+import sys
+
+print("R = {")
+
+for fname in sys.argv[1:]:
+    with open(fname, "rb") as f:
+        b = f.read()
+        print("%r: %r," % (fname, b))
+
+print("}")


### PR DESCRIPTION
Afterwards, they can be access using pkg_resource module from
micropython-lib.