### PR TITLE
Compile-time MICROPY_DEBUG_VERBOSE-flag

### DIFF
--- a/py/bc.c
+++ b/py/bc.c
@@ -35,7 +35,7 @@
 #include "py/bc0.h"
 #include "py/bc.h"
 
-#if 0 // print debugging info
+#if MICROPY_DEBUG_VERBOSE // print debugging info
 #define DEBUG_PRINT (1)
 #else // don't print debugging info
 #define DEBUG_PRINT (0)

--- a/py/builtinimport.c
+++ b/py/builtinimport.c
@@ -37,7 +37,7 @@
 #include "py/builtin.h"
 #include "py/frozenmod.h"
 
-#if 0 // print debugging info
+#if MICROPY_DEBUG_VERBOSE // print debugging info
 #define DEBUG_PRINT (1)
 #define DEBUG_printf DEBUG_printf
 #else // don't print debugging info

--- a/py/emitglue.c
+++ b/py/emitglue.c
@@ -35,7 +35,7 @@
 #include "py/runtime0.h"
 #include "py/bc.h"
 
-#if 0 // print debugging info
+#if MICROPY_DEBUG_VERBOSE // print debugging info
 #define DEBUG_PRINT (1)
 #define WRITE_CODE (1)
 #define DEBUG_printf DEBUG_printf

--- a/py/emitnative.c
+++ b/py/emitnative.c
@@ -50,7 +50,7 @@
 #include "py/emit.h"
 #include "py/bc.h"
 
-#if 0 // print debugging info
+#if MICROPY_DEBUG_VERBOSE // print debugging info
 #define DEBUG_PRINT (1)
 #define DEBUG_printf DEBUG_printf
 #else // don't print debugging info

--- a/py/gc.c
+++ b/py/gc.c
@@ -35,7 +35,7 @@
 
 #if MICROPY_ENABLE_GC
 
-#if 0 // print debugging info
+#if MICROPY_DEBUG_VERBOSE // print debugging info
 #define DEBUG_PRINT (1)
 #define DEBUG_printf DEBUG_printf
 #else // don't print debugging info

--- a/py/malloc.c
+++ b/py/malloc.c
@@ -32,7 +32,7 @@
 #include "py/misc.h"
 #include "py/mpstate.h"
 
-#if 0 // print debugging info
+#if MICROPY_DEBUG_VERBOSE // print debugging info
 #define DEBUG_printf DEBUG_printf
 #else // don't print debugging info
 #define DEBUG_printf(...) (void)0

--- a/py/modthread.c
+++ b/py/modthread.c
@@ -34,7 +34,7 @@
 
 #include "py/mpthread.h"
 
-#if 0 // print debugging info
+#if MICROPY_DEBUG_VERBOSE // print debugging info
 #define DEBUG_PRINT (1)
 #define DEBUG_printf DEBUG_printf
 #else // don't print debugging info

--- a/py/mpconfig.h
+++ b/py/mpconfig.h
@@ -373,6 +373,11 @@
 #define MICROPY_DEBUG_PRINTERS (0)
 #endif
 
+// Debug information will be extremely verbose (enables all debug-outputs)
+#ifndef MICROPY_DEBUG_VERBOSE
+#define MICROPY_DEBUG_VERBOSE       (0)
+#endif
+
 /*****************************************************************************/
 /* Optimisations                                                             */
 

--- a/py/nativeglue.c
+++ b/py/nativeglue.c
@@ -34,7 +34,7 @@
 #include "py/emitglue.h"
 #include "py/bc.h"
 
-#if 0 // print debugging info
+#if MICROPY_DEBUG_VERBOSE // print debugging info
 #define DEBUG_printf DEBUG_printf
 #else // don't print debugging info
 #define DEBUG_printf(...) (void)0

--- a/py/objfun.c
+++ b/py/objfun.c
@@ -36,7 +36,7 @@
 #include "py/bc.h"
 #include "py/stackctrl.h"
 
-#if 0 // print debugging info
+#if MICROPY_DEBUG_VERBOSE // print debugging info
 #define DEBUG_PRINT (1)
 #else // don't print debugging info
 #define DEBUG_PRINT (0)

--- a/py/objtype.c
+++ b/py/objtype.c
@@ -35,7 +35,7 @@
 #include "py/runtime0.h"
 #include "py/runtime.h"
 
-#if 0 // print debugging info
+#if MICROPY_DEBUG_VERBOSE // print debugging info
 #define DEBUG_PRINT (1)
 #define DEBUG_printf DEBUG_printf
 #else // don't print debugging info

--- a/py/qstr.c
+++ b/py/qstr.c
@@ -36,7 +36,7 @@
 // ultimately we will replace this with a static hash table of some kind
 // also probably need to include the length in the string data, to allow null bytes in the string
 
-#if 0 // print debugging info
+#if MICROPY_DEBUG_VERBOSE // print debugging info
 #define DEBUG_printf DEBUG_printf
 #else // don't print debugging info
 #define DEBUG_printf(...) (void)0

--- a/py/runtime.c
+++ b/py/runtime.c
@@ -44,7 +44,7 @@
 #include "py/stackctrl.h"
 #include "py/gc.h"
 
-#if 0 // print debugging info
+#if MICROPY_DEBUG_VERBOSE // print debugging info
 #define DEBUG_PRINT (1)
 #define DEBUG_printf DEBUG_printf
 #define DEBUG_OP_printf(...) DEBUG_printf(__VA_ARGS__)


### PR DESCRIPTION
Added a compile-time flag usable in `mpconfigport.h` for making the interpreter extremely talkative. When MICROPY_DEBUG_VERBOSE is set to 1 the interpreter will actually execute every DEBUG_printf-statement inside it's code, therefore print loads of information, like garbage-collector calls. This makes debugging a new port a bit easier.