### PR TITLE
extmod/ure: Fix handling of '-' at the end of classes.

### DIFF
--- a/extmod/re1.5/compilecode.c
+++ b/extmod/re1.5/compilecode.c
@@ -56,6 +56,14 @@ static const char *_compilecode(const char *re, ByteProg *prog, int sizecode)
                 if (!*re) return NULL;
                 EMIT(PC++, *re);
                 if (re[1] == '-') {
+                    if (re[2] == ']') {
+                        EMIT(PC++, *re);
+                        re += 1;
+                        cnt += 1;
+                        EMIT(PC++, *re);
+                        EMIT(PC++, *re);
+                        break;
+                    }
                     re += 2;
                 }
                 EMIT(PC++, *re);

--- a/tests/extmod/ure1.py
+++ b/tests/extmod/ure1.py
@@ -39,6 +39,18 @@ m = r.match("A")
 print(m)
 print("===")
 
+
+r = re.compile("[a-cu-z-]")
+m = r.match("-")
+print(m.group(0))
+m = r.match("]")
+print(m)
+r = re.compile("[-a-cu-z]")
+m = r.match("-")
+print(m.group(0))
+print("===")
+
+
 r = re.compile("[^a-cu-z]")
 m = r.match("a")
 print(m)


### PR DESCRIPTION
Fix #3178

When '-' appears at the end of a class, treat it as literal '-'.