### PR TITLE
py/nlr: Remove useless include

### DIFF
--- a/py/nlr.h
+++ b/py/nlr.h
@@ -29,7 +29,6 @@
 // non-local return
 // exception handling, basically a stack of setjmp/longjmp buffers
 
-#include <limits.h>
 #include <setjmp.h>
 #include <assert.h>
 


### PR DESCRIPTION
I think nlr.h doesn't actually use anything from limits.h