### PR TITLE
esp8266/modmachine: improve Timer's API

### DIFF
--- a/esp8266/modmachine.c
+++ b/esp8266/modmachine.c
@@ -176,10 +176,6 @@ STATIC mp_obj_t esp_timer_init_helper(esp_timer_obj_t *self, mp_uint_t n_args, c
     self->period = args[0].u_int;
     self->mode = args[1].u_int;
     self->callback = args[2].u_obj;
-    // Be sure to disarm timer before making any changes
-    os_timer_disarm(&self->timer);
-    os_timer_setfn(&self->timer, esp_timer_cb, self);
-    os_timer_arm(&self->timer, self->period, self->mode);
 
     return mp_const_none;
 }
@@ -195,6 +191,27 @@ STATIC mp_obj_t esp_timer_deinit(mp_obj_t self_in) {
     return mp_const_none;
 }
 STATIC MP_DEFINE_CONST_FUN_OBJ_1(esp_timer_deinit_obj, esp_timer_deinit);
+
+STATIC mp_obj_t esp_timer_start(mp_obj_t self_in) {
+    esp_timer_obj_t *self = self_in;
+
+    // Be sure to disarm timer before making any changes
+    os_timer_disarm(&self->timer);
+    os_timer_setfn(&self->timer, esp_timer_cb, self);
+    os_timer_arm(&self->timer, self->period, self->mode);
+
+    return mp_const_none;
+}
+STATIC MP_DEFINE_CONST_FUN_OBJ_1(esp_timer_start_obj, esp_timer_start);
+
+STATIC mp_obj_t esp_timer_stop(mp_obj_t self_in) {
+    esp_timer_obj_t *self = self_in;
+
+    os_timer_disarm(&self->timer);
+
+    return mp_const_none;
+}
+STATIC MP_DEFINE_CONST_FUN_OBJ_1(esp_timer_stop_obj, esp_timer_stop);
 
 STATIC mp_obj_t esp_timer_period(mp_uint_t n_args, const mp_obj_t *args) {
     esp_timer_obj_t *self = args[0];
@@ -215,6 +232,8 @@ STATIC MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(esp_timer_period_obj, 1, 2, esp_timer
 STATIC const mp_rom_map_elem_t esp_timer_locals_dict_table[] = {
     { MP_ROM_QSTR(MP_QSTR_deinit), MP_ROM_PTR(&esp_timer_deinit_obj) },
     { MP_ROM_QSTR(MP_QSTR_init), MP_ROM_PTR(&esp_timer_init_obj) },
+    { MP_ROM_QSTR(MP_QSTR_start), MP_ROM_PTR(&esp_timer_start_obj) },
+    { MP_ROM_QSTR(MP_QSTR_stop), MP_ROM_PTR(&esp_timer_stop_obj) },
     { MP_ROM_QSTR(MP_QSTR_period), MP_ROM_PTR(&esp_timer_period_obj) },
 //    { MP_OBJ_NEW_QSTR(MP_QSTR_callback), MP_ROM_PTR(&esp_timer_callback_obj) },
     { MP_ROM_QSTR(MP_QSTR_ONE_SHOT), MP_ROM_INT(false) },

--- a/esp8266/modmachine.c
+++ b/esp8266/modmachine.c
@@ -185,13 +185,6 @@ STATIC mp_obj_t esp_timer_init(mp_uint_t n_args, const mp_obj_t *args, mp_map_t 
 }
 STATIC MP_DEFINE_CONST_FUN_OBJ_KW(esp_timer_init_obj, 1, esp_timer_init);
 
-STATIC mp_obj_t esp_timer_deinit(mp_obj_t self_in) {
-    esp_timer_obj_t *self = self_in;
-    os_timer_disarm(&self->timer);
-    return mp_const_none;
-}
-STATIC MP_DEFINE_CONST_FUN_OBJ_1(esp_timer_deinit_obj, esp_timer_deinit);
-
 STATIC mp_obj_t esp_timer_start(mp_obj_t self_in) {
     esp_timer_obj_t *self = self_in;
 
@@ -230,7 +223,6 @@ STATIC mp_obj_t esp_timer_period(mp_uint_t n_args, const mp_obj_t *args) {
 STATIC MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(esp_timer_period_obj, 1, 2, esp_timer_period);
 
 STATIC const mp_rom_map_elem_t esp_timer_locals_dict_table[] = {
-    { MP_ROM_QSTR(MP_QSTR_deinit), MP_ROM_PTR(&esp_timer_deinit_obj) },
     { MP_ROM_QSTR(MP_QSTR_init), MP_ROM_PTR(&esp_timer_init_obj) },
     { MP_ROM_QSTR(MP_QSTR_start), MP_ROM_PTR(&esp_timer_start_obj) },
     { MP_ROM_QSTR(MP_QSTR_stop), MP_ROM_PTR(&esp_timer_stop_obj) },

--- a/esp8266/modmachine.c
+++ b/esp8266/modmachine.c
@@ -145,18 +145,6 @@ typedef struct _esp_timer_obj_t {
 
 const mp_obj_type_t esp_timer_type;
 
-STATIC void esp_timer_print(const mp_print_t *print, mp_obj_t self_in, mp_print_kind_t kind) {
-    esp_timer_obj_t *self = self_in;
-    mp_printf(print, "Timer(%p)", &self->timer);
-}
-
-STATIC mp_obj_t esp_timer_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *args) {
-    mp_arg_check_num(n_args, n_kw, 1, 1, false);
-    esp_timer_obj_t *tim = m_new_obj(esp_timer_obj_t);
-    tim->base.type = &esp_timer_type;
-    return tim;
-}
-
 STATIC void esp_timer_irq_helper(void *arg) {
     esp_timer_obj_t *self = arg;
     mp_sched_schedule(self->irq, self);
@@ -178,6 +166,26 @@ STATIC mp_obj_t esp_timer_init_helper(esp_timer_obj_t *self, mp_uint_t n_args, c
     self->irq = args[2].u_obj;
 
     return mp_const_none;
+}
+
+STATIC void esp_timer_print(const mp_print_t *print, mp_obj_t self_in, mp_print_kind_t kind) {
+    esp_timer_obj_t *self = self_in;
+    mp_printf(print, "Timer(%p)", &self->timer);
+}
+
+STATIC mp_obj_t esp_timer_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *args) {
+    mp_arg_check_num(n_args, n_kw, 1, 1, true);
+    esp_timer_obj_t *self = m_new_obj(esp_timer_obj_t);
+    self->base.type = &esp_timer_type;
+
+    if (n_kw > 0) {
+        // init the peripheral
+        mp_map_t kw_args;
+        mp_map_init_fixed_table(&kw_args, n_kw, args + n_args);
+        esp_timer_init_helper(self, n_args-1, args+1, &kw_args);
+    }
+
+    return MP_OBJ_FROM_PTR(self);
 }
 
 STATIC mp_obj_t esp_timer_init(mp_uint_t n_args, const mp_obj_t *args, mp_map_t *kw_args) {


### PR DESCRIPTION
This PR is the result of a discussion in #2971. I've tried to keep the API as similar as possible to other peripherals such as SPI or I2C. The result is:

```python
Timer(id, period=val, mode=Timer.PERIODIC, irq=handler) # constructor
Timer.init(period=val, mode=Timer.PERIODIC, irq=handler) # reinitialise all parameters
Timer.start() # start timer
Timer.stop() # stop timer
Timer.period([period]) # get the period/set new period
```

Usually the other peripherals include a `deinit()` method, but in this case, I found it reasonable to call it `stop()`.