### PR TITLE
a2b_base64: Ignore invalid chars like CPython

### DIFF
--- a/docs/library/ubinascii.rst
+++ b/docs/library/ubinascii.rst
@@ -29,8 +29,12 @@ Functions
 
 .. function:: a2b_base64(data)
 
-   Convert Base64-encoded data to binary representation. Returns bytes string.
+   Decode base64-encoded data, ignoring invalid characters in the input.
+   Conforms to `RFC 3548 <https://tools.ietf.org/html/rfc3548.html>`_. Returns
+   a bytes object.
 
 .. function:: b2a_base64(data)
 
-   Encode binary data in Base64 format. Returns string.
+   Encode binary data in base64 format, as in `RFC 3548
+   <https://tools.ietf.org/html/rfc3548.html>`_. Returns the encoded data
+   followed by a newline character, as a bytes object.

--- a/tests/extmod/ubinascii_a2b_base64.py
+++ b/tests/extmod/ubinascii_a2b_base64.py
@@ -21,6 +21,13 @@ print(binascii.a2b_base64(b'f4D/'))
 print(binascii.a2b_base64(b'f4D+')) # convert '+'
 print(binascii.a2b_base64(b'MTIzNEFCQ0RhYmNk'))
 
+# Ignore invalid characters and pad sequences
+print(binascii.a2b_base64(b'Zm9v\n'))
+print(binascii.a2b_base64(b'Zm\x009v\n'))
+print(binascii.a2b_base64(b'Zm9v=='))
+print(binascii.a2b_base64(b'Zm9v==='))
+print(binascii.a2b_base64(b'Zm9v===YmFy'))
+
 try:
     print(binascii.a2b_base64(b'abc'))
 except ValueError:


### PR DESCRIPTION
Like CPython, MicroPython's `b2a_base64` function adds a `'\n'` to the encoded data. For *decoding*, however, CPython's `a2b_base64` ignores invalid characters in its input, while MicroPython's does not. Besides hurting compatibility with CPython, this means that MicroPython cannot decode its own Base64-encoded data; `a2b_base64(b2a_base64(b'foo'))` fails.

In this patch I completely rewrote the `a2b_base64` function to ignore invalid characters, basing it heavily on CPython's implementation. It is intended to work identically; if anyone finds any discrepancies, that'd be worth mentioning.

This change reduces code size on my 64-bit Unix platform by 160 bytes.