### PR TITLE
drivers: add hts221 support

### DIFF
--- a/drivers/i2c/hts221.py
+++ b/drivers/i2c/hts221.py
@@ -1,0 +1,95 @@
+"""
+HTS221 - STMicro I2C temperature and humidity sensor driver for MicroPython
+Example usage:
+>>> from hts221 import HTS221
+>>> hts = HTS221(I2C(1))
+>>> hts.measure()
+>>> hts.get_humidity()
+62.07
+>>> hts.get_temperature()
+27.046
+"""
+import uctypes
+import time
+
+class HTS221:    
+    HTS_WHO_AM_I = const(0xf) 
+    def __init__(self, i2c, addr=95, fixed=False):
+        self.i2c = i2c
+        self.addr = addr
+        self.fixed = fixed
+        if (self.i2c.readfrom_mem(addr, HTS_WHO_AM_I, 1) != b'\xbc'):
+            raise OSError("No HTS221 device on address {} found".format(addr))
+        self.cal_buf = bytearray(16)
+        self.calib = uctypes.struct(uctypes.addressof(self.cal_buf), {
+                'h0_rh':(uctypes.UINT8 | 0), 
+                'h1_rh':(uctypes.UINT8 | 1), 
+                't0_deg':(uctypes.UINT8 | 2), 
+                't1_deg':(uctypes.UINT8 | 3), 
+                'res':(uctypes.UINT8 | 4),
+                't1t0msb':(uctypes.UINT8 | 5),
+                'h0_out':(uctypes.INT16 | 6),
+                'res1':(uctypes.INT16 | 8),
+                'h1_out':(uctypes.INT16 | 10),
+                't0_out':(uctypes.INT16 | 12),
+                't1_out':(uctypes.INT16 | 14)})
+        self.val_buf = bytearray(5)
+        self.raw_val = uctypes.struct(uctypes.addressof(self.val_buf), {
+                'status':(uctypes.UINT8 | 0), 
+                'h_out':(uctypes.INT16 | 1), 
+                't_out':(uctypes.INT16 | 3)})        
+        # enable sensor, one-shot
+        i2c.writeto_mem(addr, 0x20, b'\x84')
+        i2c.readfrom_mem_into(95, 0x30|0x80, self.cal_buf)
+        # add 2 bits from reg 0x35 -> 10bit unsigned values)
+        self.t0_deg = (self.calib.t0_deg | ((self.calib.t1t0msb & 0x3) << 8))
+        self.t1_deg = (self.calib.t1_deg | ((self.calib.t1t0msb & 0xc) << 6))
+        # multiply with large base to keep it accurate for fixed point division
+        self.t_slope = (1000 * (self.t1_deg - self.t0_deg)) // (self.calib.t1_out - self.calib.t0_out)
+        self.h_slope = (10000 * (self.calib.h1_rh - self.calib.h0_rh)) // (self.calib.h1_out - self.calib.h0_out)
+        
+    def measure(self):
+        # enable one-shot measurement
+        self.i2c.writeto_mem(self.addr, 0x21, b'\x01')
+        self.measure_done = False
+
+    def measure_end(self):
+        # blocking, timeout after 0.2sec
+        delay_cntr = 0
+        while (delay_cntr < 20):
+            self.i2c.readfrom_mem_into(self.addr, 0x27|0x80, self.val_buf)
+            if (self.raw_val.status & 0x3):
+                break
+            time.sleep_ms(10)
+            delay_cntr += 1
+        else:
+            raise OSError("Timeout Sensor")
+        self.temperature = (1000 * self.t0_deg + self.t_slope * (self.raw_val.t_out - self.calib.t0_out)) // 8
+        self.humidity = (10000 * self.calib.h0_rh + self.h_slope * (self.raw_val.h_out - self.calib.h0_out)) // 200
+        if self.fixed:
+            self.temperature = (self.temperature << 8 ) | (-3 + 128)
+            self.humidity = (self.humidity << 8) | (-2 + 128)
+        else:
+            self.temperature = self.temperature / 1000.
+            self.humidity = self.humidity / 100.
+        self.measure_done = True
+
+    def set_heater(self, switch_on):
+        if switch_on: 
+            self.i2c.writeto_mem(self.addr, 0x21, b'\x02')
+        else:
+            self.i2c.writeto_mem(self.addr, 0x21, b'\x00')
+
+    def fixed_to_float(self,fx):
+        # may be moved to a generic location
+        return (fx >> 8) * 10**((fx & 0xff) - 128)
+
+    def get_humidity(self):
+        if not self.measure_done:
+            self.measure_end()
+        return self.humidity
+
+    def get_temperature(self):
+        if not self.measure_done:
+            self.measure_end()
+        return self.temperature


### PR DESCRIPTION
This is my attempt of an "API compatible" sensor driver which may serve as a discussion base for #3218. It's a dual sensor device that measures humidity and temperature and can be configured in various ways. It has even an in-built heater. I believe it serves as a good test and discussion base for the new API. The datasheet is located here http://www.st.com/en/mems-and-sensors/hts221.html. 

The HTS221 sensor is present on the SenseHat board for the raspberry Pi (which can be easily reused to work with the pyboard).

The driver supports fixed and floating point targets, with the conversion functions that was proposed in #2093. I specifically paid attention to the precision of the output values (e.g. so that temperature are not returned with 10 digits precision). 

The buffer is preallocated in the constructor, so that during runtime there should be no memory allocation necessary.

I have not completly followed the guidelines in #2093, for the following reasons:
- the `fixed`statement that was proposed to be present for every `get_xxx`accessor method is replaced by an equivalent argument for the constructor of the driver (hence the method definiton is slightly shorter). This makes sense, since the user hardly wants to use both fixed and floating point support of the same driver for a given Platform
- the `get_temperature`and `get_humidity`accessor functions are included (not inherited from a `Sensor Base` class) since this allows introspection at the REPL and in general makes the code more readable IMO
-  I omitted the generic `config` method and just used e.g. a `set_heater`function - for the same reasons given above
 
The reasoning above is of course subject for discussing and just my point of view. Any feedback is very much welcome. I will upgrade my other drivers for the SenseHat once the Sensor API is considered stable.