### PR TITLE
py/binary.c: Bugfix for struct.pack('>Q', 16)

### DIFF
--- a/py/binary.c
+++ b/py/binary.c
@@ -303,7 +303,12 @@ void mp_binary_set_val(char struct_type, char val_type, mp_obj_t val_in, byte **
                 // zero/sign extend if needed
                 if (BYTES_PER_WORD < 8 && size > sizeof(val)) {
                     int c = (is_signed(val_type) && (mp_int_t)val < 0) ? 0xff : 0x00;
-                    memset(p + sizeof(val), c, size - sizeof(val));
+                    if (struct_type == '>') {
+                        memset(p, c, size - sizeof(val));
+                        p += size - sizeof(val);
+                    } else {
+                        memset(p + sizeof(val), c, size - sizeof(val));
+                    }
                 }
             }
     }

--- a/py/binary.c
+++ b/py/binary.c
@@ -303,12 +303,13 @@ void mp_binary_set_val(char struct_type, char val_type, mp_obj_t val_in, byte **
                 // zero/sign extend if needed
                 if (BYTES_PER_WORD < 8 && size > sizeof(val)) {
                     int c = (is_signed(val_type) && (mp_int_t)val < 0) ? 0xff : 0x00;
+                    byte *p_memset = p;
                     if (struct_type == '>') {
-                        memset(p, c, size - sizeof(val));
                         p += size - sizeof(val);
                     } else {
-                        memset(p + sizeof(val), c, size - sizeof(val));
+                        p_memset += sizeof(val);
                     }
+                    memset(p_memset, c, size - sizeof(val));
                 }
             }
     }

--- a/py/binary.c
+++ b/py/binary.c
@@ -303,13 +303,10 @@ void mp_binary_set_val(char struct_type, char val_type, mp_obj_t val_in, byte **
                 // zero/sign extend if needed
                 if (BYTES_PER_WORD < 8 && size > sizeof(val)) {
                     int c = (is_signed(val_type) && (mp_int_t)val < 0) ? 0xff : 0x00;
-                    byte *p_memset = p;
+                    memset(p, c, size);
                     if (struct_type == '>') {
                         p += size - sizeof(val);
-                    } else {
-                        p_memset += sizeof(val);
                     }
-                    memset(p_memset, c, size - sizeof(val));
                 }
             }
     }

--- a/tests/basics/struct1.py
+++ b/tests/basics/struct1.py
@@ -23,8 +23,6 @@ print(struct.pack("<h", 1))
 print(struct.pack(">h", 1))
 print(struct.pack("<b", 1))
 print(struct.pack(">b", 1))
-print(struct.pack("<Q", 1))
-print(struct.pack(">Q", 1))
 
 print(struct.pack("<bI", -128, 256))
 print(struct.pack(">bI", -128, 256))

--- a/tests/basics/struct1.py
+++ b/tests/basics/struct1.py
@@ -23,6 +23,8 @@ print(struct.pack("<h", 1))
 print(struct.pack(">h", 1))
 print(struct.pack("<b", 1))
 print(struct.pack(">b", 1))
+print(struct.pack("<Q", 1))
+print(struct.pack(">Q", 1))
 
 print(struct.pack("<bI", -128, 256))
 print(struct.pack(">bI", -128, 256))

--- a/tests/basics/struct1_intbig.py
+++ b/tests/basics/struct1_intbig.py
@@ -12,6 +12,8 @@ print(struct.pack("<I", 2**32 - 1))
 print(struct.pack("<I", 0xffffffff))
 
 # long long ints
+print(struct.pack("<Q", 1))
+print(struct.pack(">Q", 1))
 print(struct.pack("<Q", 2**64 - 1))
 print(struct.pack(">Q", 2**64 - 1))
 print(struct.pack("<Q", 0xffffffffffffffff))


### PR DESCRIPTION
Without bugfix:

    struct.pack('>Q', 16)
    b'\x00\x00\x00\x10\x00\x00\x00\x00'

With bugfix:

    struct.pack('>Q', 16)
    b'\x00\x00\x00\x00\x00\x00\x00\x10'

Also added test-case to tests/basics/struct1_intbig.py; without this merge-request the test will fail on 32-bit platforms.