### PR TITLE
tools/mpy-tool.py: Fix missing argument in dump() function

### DIFF
--- a/tools/mpy-tool.py
+++ b/tools/mpy-tool.py
@@ -239,7 +239,7 @@ class RawCode:
     def dump(self):
         # dump children first
         for rc in self.raw_codes:
-            rc.freeze()
+            rc.freeze('')
         # TODO
 
     def freeze(self, parent_name):


### PR DESCRIPTION
This makes the -d commandline argument usable again.
Pass empty string as parent name as listing starts from the root.