### PR TITLE
cc3200: Enable the micropython.kbd_intr() method

### DIFF
--- a/cc3200/mpconfigport.h
+++ b/cc3200/mpconfigport.h
@@ -120,6 +120,7 @@
 
 #define MICROPY_ENABLE_EMERGENCY_EXCEPTION_BUF      (1)
 #define MICROPY_EMERGENCY_EXCEPTION_BUF_SIZE        (0)
+#define MICROPY_KBD_EXCEPTION                       (1)
 
 // We define our own list of errno constants to include in uerrno module
 #define MICROPY_PY_UERRNO_LIST \


### PR DESCRIPTION
The code was present, enabling it just required setting a flag in mpconfigport.h. It is now compatible to the PyBoard, ESP8266 and ESP32 variants, and anyhow useful.
