### PR TITLE
[STM32L4] Make STM32L4 port boot again

### DIFF
--- a/stmhal/system_stm32.c
+++ b/stmhal/system_stm32.c
@@ -331,12 +331,8 @@ void SystemClock_Config(void)
      regarding system frequency refer to product datasheet.  */
   __HAL_PWR_VOLTAGESCALING_CONFIG(PWR_REGULATOR_VOLTAGE_SCALE1);
     #elif defined(MCU_SERIES_L4)
-    /* Enable the LSE Oscillator */
-    RCC_OscInitStruct.OscillatorType = RCC_OSCILLATORTYPE_LSE;
-    RCC_OscInitStruct.LSEState = RCC_LSE_ON;
-    if (HAL_RCC_OscConfig(&RCC_OscInitStruct) != HAL_OK) {
-        __fatal_error("HAL_RCC_OscConfig");
-    }
+    /* Configure LSE Drive Capability  */
+  __HAL_RCC_LSEDRIVE_CONFIG(RCC_LSEDRIVE_LOW);
     #endif
 
     /* Enable HSE Oscillator and activate PLL with HSE as source */
@@ -464,6 +460,8 @@ void SystemClock_Config(void)
     PeriphClkInitStruct.UsbClockSelection = RCC_USBCLKSOURCE_PLLSAI1;
     PeriphClkInitStruct.RTCClockSelection = RCC_RTCCLKSOURCE_LSE;
     PeriphClkInitStruct.RngClockSelection = RCC_RNGCLKSOURCE_PLLSAI1;
+    PeriphClkInitStruct.PLLSAI1.PLLSAI1Source = RCC_PLLSOURCE_MSI;
+    PeriphClkInitStruct.PLLSAI1.PLLSAI1M = 1;
     PeriphClkInitStruct.PLLSAI1.PLLSAI1N = 24;
     PeriphClkInitStruct.PLLSAI1.PLLSAI1P = RCC_PLLP_DIV7;
     PeriphClkInitStruct.PLLSAI1.PLLSAI1Q = RCC_PLLQ_DIV2;


### PR DESCRIPTION
The aim of this fix is:
1. Remove the first  HAL_RCC_OscConfig config as there is no reason to do it twice. If run MXCube in verisn 4.22 this remaining MACRO (__HAL_RCC_LSEDRIVE_CONFIG) is introduced which I keep here.
2. Due to the update of the STM32L4 HAL from version 1.3.0 to 1.8.1. additional new defined members in the struct RCC_PLLSAI1InitTypeDef have to be defined (PLLSAI1Source and PLLSAI1M). Otherwise the program will wait forever in the fatal error on Line 475.