### PR TITLE
travis: Revert ".travis.yml: Pin cpp-coveralls at 0.3.12."

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,9 +19,8 @@ before_script:
   - sudo apt-get install -y --force-yes gcc-arm-none-eabi
   # For teensy build
   - sudo apt-get install realpath
-  # For coverage testing
-  # cpp-coveralls 0.4 conflicts with urllib3 preinstalled in Travis VM
-  - sudo pip install cpp-coveralls==0.3.12
+  # For coverage testing (upgrade is used to get latest urllib3 version)
+  - sudo pip install --upgrade cpp-coveralls
   - gcc --version
   - arm-none-eabi-gcc --version
   - python3 --version


### PR DESCRIPTION
This reverts commit f578947ae3fee5610c5bc1123baf878b92eaa248.

The issue with incompatible urllib3 is fixed upstream.