### PR TITLE
Building mpy-cross under WINDOWS & cygwin fails.

### DIFF
--- a/py/mkenv.mk
+++ b/py/mkenv.mk
@@ -59,7 +59,13 @@ LD += -m32
 endif
 
 MAKE_FROZEN = $(TOP)/tools/make-frozen.py
+# allow mpy-cross (for WSL) and mpy-cross.exe (for cygwin) to coexist
+ifeq ($(OS),Windows_NT)
+MPY_CROSS = $(TOP)/mpy-cross/mpy-cross.exe
+PROG_EXT = .exe
+else
 MPY_CROSS = $(TOP)/mpy-cross/mpy-cross
+endif
 MPY_TOOL = $(TOP)/tools/mpy-tool.py
 
 all:

--- a/py/mkrules.mk
+++ b/py/mkrules.mk
@@ -111,7 +111,7 @@ FROZEN_MPY_PY_FILES := $(shell find -L $(FROZEN_MPY_DIR) -type f -name '*.py' | 
 FROZEN_MPY_MPY_FILES := $(addprefix $(BUILD)/frozen_mpy/,$(FROZEN_MPY_PY_FILES:.py=.mpy))
 
 # to build .mpy files from .py files
-$(BUILD)/frozen_mpy/%.mpy: $(FROZEN_MPY_DIR)/%.py $(TOP)/mpy-cross/mpy-cross
+$(BUILD)/frozen_mpy/%.mpy: $(FROZEN_MPY_DIR)/%.py $(MPY_CROSS)
 	@$(ECHO) "MPY $<"
 	$(Q)$(MKDIR) -p $(dir $@)
 	$(Q)$(MPY_CROSS) -o $@ -s $(<:$(FROZEN_MPY_DIR)/%=%) $(MPY_CROSS_FLAGS) $<
@@ -133,13 +133,13 @@ $(PROG): $(OBJ)
 # we may want to compile using Thumb, but link with non-Thumb libc.
 	$(Q)$(CC) -o $@ $^ $(LIB) $(LDFLAGS)
 ifndef DEBUG
-	$(Q)$(STRIP) $(STRIPFLAGS_EXTRA) $(PROG)
+	$(Q)$(STRIP) $(STRIPFLAGS_EXTRA) $(PROG)$(PROG_EXT)
 endif
-	$(Q)$(SIZE) $$(find $(BUILD) -path "$(BUILD)/build/frozen*.o") $(PROG)
+	$(Q)$(SIZE) $$(find $(BUILD) -path "$(BUILD)/build/frozen*.o") $(PROG)$(PROG_EXT)
 
 clean: clean-prog
 clean-prog:
-	$(RM) -f $(PROG)
+	$(RM) -f $(PROG)$(PROG_EXT)
 	$(RM) -f $(PROG).map
 
 .PHONY: clean-prog


### PR DESCRIPTION
Building mpy-cross under WINDOWS & cygwin fails because STRIP, SIZE and RM expect to be passed a .exe file.

py/mkrules.mk, mpy-cross/Makefile: Use mpy-cross.exe instead of mpy-cross for the binary name in WINDOWS.

py/mkenv.mk: Allow mpy-cross.exe and mpy-cross to coexist so you can use cygwin and WSL without rebuilding mpy-cross.