### PR TITLE
docs/library/framebuf.rst: Constructor <format> parameter no longer references deprecated MVLSB name.

### DIFF
--- a/docs/library/framebuf.rst
+++ b/docs/library/framebuf.rst
@@ -38,11 +38,11 @@ Constructors
         - *width* is the width of the FrameBuffer in pixels
         - *height* is the height of the FrameBuffer in pixels
         - *format* specifies the type of pixel used in the FrameBuffer;
-          valid values are ``framebuf.MVLSB``, ``framebuf.RGB565``
-          and ``framebuf.GS4_HMSB``. MVLSB is monochrome 1-bit color,
-          RGB565 is RGB 16-bit color, and GS4_HMSB is grayscale 4-bit color.
-          Where a color value c is passed to a method, c is a small integer
-          with an encoding that is dependent on the format of the FrameBuffer.
+          permissible values are listed under Constants below. These set the
+          number of bits used to encode a color value and the mapping of
+          these bits to physical memory locations. Where a color value c is
+          passed to a method, c is a small integer with an encoding that is
+          dependent on the format of the FrameBuffer.
         - *stride* is the number of pixels between each horizontal line
           of pixels in the FrameBuffer. This defaults to *width* but may
           need adjustments when implementing a FrameBuffer within another
@@ -110,8 +110,9 @@ Other methods
     corresponding color will be considered transparent: all pixels with that
     color value will not be drawn.
 
-    This method works between FrameBuffer's utilising different formats, but the
-    resulting colors may be unexpected due to the mismatch in color formats.
+    This method works between FrameBuffer instances utilising different formats,
+    but the resulting colors may be unexpected due to the mismatch in color
+    formats.
 
 Constants
 ---------


### PR DESCRIPTION
Now written in a more generic style accommodating all approved mapping names and facilitating the future addition of new mappings.