### PR TITLE
drivers/display/ssd1306.py Improve performance of graphics methods.

### DIFF
--- a/drivers/display/ssd1306.py
+++ b/drivers/display/ssd1306.py
@@ -34,6 +34,9 @@ class SSD1306:
         self.buffer = bytearray(self.pages * self.width)
         fb = framebuf.FrameBuffer(self.buffer, self.width, self.height, framebuf.MVLSB)
         self.framebuf = fb
+        # Provide methods for accessing FrameBuffer graphics primitives. This is a workround
+        # because inheritance from a native class is currently unsupported.
+        # http://docs.micropython.org/en/latest/pyboard/library/framebuf.html
         self.fill = fb.fill  # (col)
         self.pixel = fb.pixel # (x, y[, c])
         self.hline = fb.hline  # (x, y, w, col)

--- a/drivers/display/ssd1306.py
+++ b/drivers/display/ssd1306.py
@@ -34,6 +34,8 @@ class SSD1306:
         self.buffer = bytearray(self.pages * self.width)
         fb = framebuf.FrameBuffer(self.buffer, self.width, self.height, framebuf.MVLSB)
         self.framebuf = fb
+        # Provide methods for accessing FrameBuffer graphics primitives
+        # http://docs.micropython.org/en/latest/pyboard/library/framebuf.html
         self.fill = fb.fill  # (col)
         self.pixel = fb.pixel # (x, y[, c])
         self.hline = fb.hline  # (x, y, w, col)

--- a/drivers/display/ssd1306.py
+++ b/drivers/display/ssd1306.py
@@ -32,7 +32,18 @@ class SSD1306:
         self.external_vcc = external_vcc
         self.pages = self.height // 8
         self.buffer = bytearray(self.pages * self.width)
-        self.framebuf = framebuf.FrameBuffer(self.buffer, self.width, self.height, framebuf.MVLSB)
+        fb = framebuf.FrameBuffer(self.buffer, self.width, self.height, framebuf.MVLSB)
+        self.framebuf = fb
+        self.fill = fb.fill  # (col)
+        self.pixel = fb.pixel # (x, y[, c])
+        self.hline = fb.hline  # (x, y, w, col)
+        self.vline = fb.vline  # (x, y, h, col)
+        self.line = fb.line  # (x1, y1, x2, y2, col)
+        self.rect = fb.rect  # (x, y, w, h, col)
+        self.fill_rect = fb.fill_rect  # (x, y, w, h, col)
+        self.text = fb.text  # (string, x, y, col=1)
+        self.scroll = fb.scroll  # (dx, dy)
+        self.blit = fb.blit  # (fbuf, x, y[, key])
         self.poweron()
         self.init_display()
 
@@ -87,18 +98,6 @@ class SSD1306:
         self.write_cmd(0)
         self.write_cmd(self.pages - 1)
         self.write_data(self.buffer)
-
-    def fill(self, col):
-        self.framebuf.fill(col)
-
-    def pixel(self, x, y, col):
-        self.framebuf.pixel(x, y, col)
-
-    def scroll(self, dx, dy):
-        self.framebuf.scroll(dx, dy)
-
-    def text(self, string, x, y, col=1):
-        self.framebuf.text(string, x, y, col)
 
 
 class SSD1306_I2C(SSD1306):


### PR DESCRIPTION
This simplifies code, improves the speed of the graphics methods and exposes all framebuf graphics methods rather than a subset.

The speed of the pixel method is improved from 30.4μs to 11.4μs. To avoid loop overheads and to reduce time measurement overhead this was measured as below:
```python
t = ticks_us()
ssd.pixel(2, 2, 1)
ssd.pixel(2, 3, 1)
ssd.pixel(2, 4, 1)
ssd.pixel(2, 5, 1)
ssd.pixel(2, 6, 1)
ssd.pixel(2, 7, 1)
ssd.pixel(2, 8, 1)
ssd.pixel(2, 9, 1)
ssd.pixel(2, 10, 1)
ssd.pixel(2, 11, 1)
ssd.pixel(3, 2, 1)
ssd.pixel(3, 3, 1)
ssd.pixel(3, 4, 1)
ssd.pixel(3, 5, 1)
ssd.pixel(3, 6, 1)
ssd.pixel(3, 7, 1)
ssd.pixel(3, 8, 1)
ssd.pixel(3, 9, 1)
ssd.pixel(3, 10, 1)
ssd.pixel(3, 11, 1)
ssd.pixel(4, 2, 1)
ssd.pixel(4, 3, 1)
ssd.pixel(4, 4, 1)
ssd.pixel(4, 5, 1)
ssd.pixel(4, 6, 1)
ssd.pixel(4, 7, 1)
ssd.pixel(4, 8, 1)
ssd.pixel(4, 9, 1)
ssd.pixel(4, 10, 1)
ssd.pixel(4, 11, 1)
d = ticks_diff(ticks_us(), t)
print(d / 30)
```