### PR TITLE
Print unhandled exception in thread on stderr

### DIFF
--- a/ports/unix/mpconfigport.h
+++ b/ports/unix/mpconfigport.h
@@ -145,7 +145,10 @@
 // names in exception messages (may require more RAM).
 #define MICROPY_ERROR_REPORTING     (MICROPY_ERROR_REPORTING_DETAILED)
 #define MICROPY_WARNINGS            (1)
+#define MICROPY_ERROR_PRINTER       (&mp_stderr_print)
 #define MICROPY_PY_STR_BYTES_CMP_WARN (1)
+
+extern const struct _mp_print_t mp_stderr_print;
 
 // Define to 1 to use undertested inefficient GC helper implementation
 // (if more efficient arch-specific one is not available).

--- a/py/modthread.c
+++ b/py/modthread.c
@@ -192,10 +192,10 @@ STATIC void *thread_entry(void *args_in) {
             // swallow exception silently
         } else {
             // print exception out
-            mp_printf(&mp_plat_print, "Unhandled exception in thread started by ");
-            mp_obj_print_helper(&mp_plat_print, args->fun, PRINT_REPR);
-            mp_printf(&mp_plat_print, "\n");
-            mp_obj_print_exception(&mp_plat_print, MP_OBJ_FROM_PTR(exc));
+            mp_printf(MICROPY_ERROR_PRINTER, "Unhandled exception in thread started by ");
+            mp_obj_print_helper(MICROPY_ERROR_PRINTER, args->fun, PRINT_REPR);
+            mp_printf(MICROPY_ERROR_PRINTER, "\n");
+            mp_obj_print_exception(MICROPY_ERROR_PRINTER, MP_OBJ_FROM_PTR(exc));
         }
     }
 

--- a/py/mpconfig.h
+++ b/py/mpconfig.h
@@ -533,6 +533,11 @@ typedef long long mp_longint_impl_t;
 #define MICROPY_WARNINGS (0)
 #endif
 
+// This macro is used when printing runtime warnings and errors
+#ifndef MICROPY_ERROR_PRINTER
+#define MICROPY_ERROR_PRINTER (&mp_plat_print)
+#endif
+
 // Float and complex implementation
 #define MICROPY_FLOAT_IMPL_NONE (0)
 #define MICROPY_FLOAT_IMPL_FLOAT (1)

--- a/py/warning.c
+++ b/py/warning.c
@@ -35,9 +35,9 @@
 void mp_warning(const char *msg, ...) {
     va_list args;
     va_start(args, msg);
-    mp_print_str(&mp_plat_print, "Warning: ");
-    mp_vprintf(&mp_plat_print, msg, args);
-    mp_print_str(&mp_plat_print, "\n");
+    mp_print_str(MICROPY_ERROR_PRINTER, "Warning: ");
+    mp_vprintf(MICROPY_ERROR_PRINTER, msg, args);
+    mp_print_str(MICROPY_ERROR_PRINTER, "\n");
     va_end(args);
 }
 

--- a/tests/run-tests
+++ b/tests/run-tests
@@ -103,7 +103,7 @@ def run_micropython(pyb, args, test_file, is_special=False):
                         os.close(master)
                         os.close(slave)
                 else:
-                    output_mupy = subprocess.check_output(args + [test_file])
+                    output_mupy = subprocess.check_output(args + [test_file], stderr=subprocess.STDOUT)
             except subprocess.CalledProcessError:
                 return b'CRASH'
 
@@ -124,7 +124,7 @@ def run_micropython(pyb, args, test_file, is_special=False):
 
             # run the actual test
             try:
-                output_mupy = subprocess.check_output(cmdlist)
+                output_mupy = subprocess.check_output(cmdlist, stderr=subprocess.STDOUT)
             except subprocess.CalledProcessError:
                 output_mupy = b'CRASH'
 


### PR DESCRIPTION
Regular unhandled exceptions are already printed on stderr. It seems
expected that unhandled exceptions in threads should also print to stderr.