### PR TITLE
Symlinks, modules improvements for WINDOWS

### DIFF
--- a/ports/modules4/empty4.py
+++ b/ports/modules4/empty4.py
@@ -1,0 +1,1 @@
+print("empty4")

--- a/ports/stm32/modules/empty.py
+++ b/ports/stm32/modules/empty.py
@@ -1,0 +1,1 @@
+print("empty")

--- a/ports/stm32/modules/frzmpy1.py
+++ b/ports/stm32/modules/frzmpy1.py
@@ -1,0 +1,1 @@
+print('frzmpy1')

--- a/ports/stm32/modules/frzmpy2.py
+++ b/ports/stm32/modules/frzmpy2.py
@@ -1,0 +1,1 @@
+raise ZeroDivisionError

--- a/ports/stm32/modules/frzmpy_pkg1/__init__.py
+++ b/ports/stm32/modules/frzmpy_pkg1/__init__.py
@@ -1,0 +1,3 @@
+# test frozen package with __init__.py
+print('frzmpy_pkg1.__init__')
+x = 1

--- a/ports/stm32/modules/frzmpy_pkg2/mod.py
+++ b/ports/stm32/modules/frzmpy_pkg2/mod.py
@@ -1,0 +1,4 @@
+# test frozen package without __init__.py
+print('frzmpy_pkg2.mod')
+class Foo:
+    x = 1

--- a/ports/stm32/modules/modules.lst
+++ b/ports/stm32/modules/modules.lst
@@ -1,0 +1,7 @@
+#frozen test is courtesy od Adafruit CircuitPyhton
+../modules2/frozentest2.py
+
+# 1
+../modules2/from_list1.py
+    #2
+../modules2/from_list2.py

--- a/ports/stm32/modules/test_pkg/empty2.py
+++ b/ports/stm32/modules/test_pkg/empty2.py
@@ -1,0 +1,1 @@
+../../modules2/empty2.py

--- a/ports/stm32/modules/test_pkg/modules.lst
+++ b/ports/stm32/modules/test_pkg/modules.lst
@@ -1,0 +1,5 @@
+
+# 3
+../../modules2/from_list3.py
+    #4
+../../modules2/from_list4.py

--- a/ports/stm32/modules/test_pkg/test.py
+++ b/ports/stm32/modules/test_pkg/test.py
@@ -1,0 +1,1 @@
+print("test")

--- a/ports/stm32/modules2/empty2.py
+++ b/ports/stm32/modules2/empty2.py
@@ -1,0 +1,1 @@
+print("empty2")

--- a/ports/stm32/modules2/from_list1.py
+++ b/ports/stm32/modules2/from_list1.py
@@ -1,0 +1,1 @@
+print("from_list1")

--- a/ports/stm32/modules2/from_list2.py
+++ b/ports/stm32/modules2/from_list2.py
@@ -1,0 +1,1 @@
+print("from_list2")

--- a/ports/stm32/modules2/from_list3.py
+++ b/ports/stm32/modules2/from_list3.py
@@ -1,0 +1,1 @@
+print("testmod from_list3")

--- a/ports/stm32/modules2/from_list4.py
+++ b/ports/stm32/modules2/from_list4.py
@@ -1,0 +1,1 @@
+print("testmod from_list4")

--- a/ports/stm32/modules2/frozentest2.py
+++ b/ports/stm32/modules2/frozentest2.py
@@ -1,0 +1,7 @@
+print('uPy')
+print('a long string that is not interned')
+print('a string that has unicode αβγ chars')
+print(b'bytes 1234\x01')
+print(123456789)
+for i in range(4):
+    print(i)

--- a/ports/stm32/projects/modules3/empty3.py
+++ b/ports/stm32/projects/modules3/empty3.py
@@ -1,0 +1,1 @@
+print("empty3")

--- a/ports/stm32/projects/modules3/frozentest3.py
+++ b/ports/stm32/projects/modules3/frozentest3.py
@@ -1,0 +1,7 @@
+print('uPy')
+print('a long string that is not interned')
+print('a string that has unicode αβγ chars')
+print(b'bytes 1234\x01')
+print(123456789)
+for i in range(4):
+    print(i)

--- a/py/mkenv.mk
+++ b/py/mkenv.mk
@@ -67,6 +67,7 @@ else
 MPY_CROSS = $(TOP)/mpy-cross/mpy-cross
 endif
 MPY_TOOL = $(TOP)/tools/mpy-tool.py
+MPY_FIND = $(TOP)/tools/find-modules.py
 
 all:
 .PHONY: all

--- a/tools/find-modules.py
+++ b/tools/find-modules.py
@@ -1,0 +1,159 @@
+#!/usr/bin/env python
+#
+# Create a list of modules to be frozen for MicroPython.
+# Multiple modules directories can be specified eg for port, board and project.
+# Modules can be specified three ways.
+#
+# 1. Linux Symlinks as used in MicroPython master on GitHub.
+# #########################################################
+# When running under WINDOWS the path and filename are read from the simlink
+#   to find the module. Otherwise the simlink is used normally.
+#
+# 2. Fake symlinks.
+# ################
+# On any OS including WINDOWS fake symlinks can be create as follows:
+#
+#   1. File name must match the module to be frozen, eg foo.py
+#   2. File must contain the path and name of the module, eg:
+#       frozen/foo.py
+#       ../frozen/foo.py
+#       ..\frozen\foo.py<CR><LF>
+#       Note \ is changed to /, <CR> and <LF> are removed.
+#   3. Files must contain only one line.
+#
+# For files conforming to these rules the file contents are used.
+#
+# any .py files not conforming to these rules are treated a valid MicroPython
+#    modules and their path and filename are used.
+#
+# 3. modules.lst file in any modules directory.
+# ############################################
+#
+# A list of modules can be placed in a modules.lst file. Rules are:
+#
+#   1. Comments must be on separate lines starting with #.
+#       leading whitespace is stripped.
+#   2. Blank lines are ignored.
+#   3. Modules must be specified with path and filename, one per line.
+#   4. Modules listed in modules.lst must not reside in the same directory
+#       as modules.lst or they willl be processed twice.
+#   5. Paths may use / or \
+# eg:
+#   +----------------------------------------+
+#   |# This is a list of modules to freeze   |
+#   |                                        |
+#   |    # first file is - foo.py            |
+#   |../modules2/foo.py                      |
+#   |../modules2/bar.py                      |
+#   |pkg/my_pkg.py                           |
+#   +----------------------------------------+
+#
+# Usage:
+# ######
+#
+# Have one or more directories with modules or links to modules to be frozen.
+#
+# Multiple module directories are supported,eg for the port, board and project.
+# When setting the FROZEN_MPY_DIR variable:
+#   Modules lists with spaces must be enclosed in quotes.
+#   Paths must use forward slash.
+#   Alternatively spaces and backslashes must be escaped.
+# eg:
+#
+# Build port modules. (this is the same as the default make).
+# make FROZEN_MPY_DIR=modules
+#
+# Builds board specific modules.
+# make FROZEN_MPY_DIR=boards/PYBV10/modules
+#
+# Build port and board modules.
+# make FROZEN_MPY_DIR="modules boards/PYBV10/modules"
+#
+# Build port, board and project modules.
+# This allows users to incororate the standard port modules, eg onewire.py
+#   and add board or project modules in differnt directories
+#   in their own project tree.
+# make FROZEN_MPY_DIR="modules boards/PYBV10/modules boards/PROJECT1/modules"
+#
+# Usage:
+# ######
+#
+# A temporary makefile (frozen.mk) is created in the build directory.
+# The build directory (eg build-PYBV10) must be specified as the first
+#   argument, followed by one or more module directories.
+#
+# python find-modules.py build modules > frozen-mpy-list
+#
+# The output is frozen.mk in the build directory and a list of modules
+#   printed to stdout.
+#
+# frozen.mk compiles each .py file to .mpy file with mpy-cross.
+# Because there are an unknown number of source directories each module is
+#   built by a separate rule in frozen.mk.
+#
+# The output list is formatted for mpy-tool.
+#
+
+from __future__ import print_function
+import sys
+import os
+import ntpath
+
+
+def module_name(f):
+    return f
+
+modules = []
+mpy_list = ""
+
+# cmd line requires BUILD directory and at least one MODULES directory
+if (len(sys.argv) < 3):
+    sys.exit("find-modules.py Not enough arguments")
+
+build = sys.argv[1].rstrip("/").rstrip("\\")
+for i in range(2, len(sys.argv)):
+    root = sys.argv[i].replace("\\", "/").rstrip("/")
+    root_len = len(root)
+
+    for dirpath, dirnames, filenames in os.walk(root):
+        for filename in filenames:
+            fullpath = dirpath + "/" + filename
+            pkg = dirpath[root_len + 1:]
+            if filename == "modules.lst":
+                with open(fullpath, "r") as lstfile:
+                    for line in lstfile:
+                        # Windows users may have backslash, CR and/or LF.
+                        line = line.replace("\r", '').replace("\n", '').replace("\\", "/")
+                        if ((line.lstrip()[:1] != "#") and (line[-3:] == ".py")):
+                            # not a comment, is valid link, use link contents.
+                            modules.append([root, pkg, line])
+
+            if filename[-3:] == ".py":
+                pyfile = open(fullpath, "r")
+                # Windows users may have backslash, CR and/or LF.
+                line_1 = pyfile.readline().replace("\r", '').replace("\n", '').replace("\\", "/")
+                if ((ntpath.basename(filename) == ntpath.basename(line_1)) &(pyfile.readline() == '')):
+                    # valid one line link, use the link contents.
+                    modules.append([root, pkg, line_1])
+                else:
+                    # not a valid link, point to the file.
+                    modules.append([root, pkg, filename])
+try:
+    os.makedirs(build)
+except OSError:
+    if not os.path.isdir(build):
+        raise
+mkfile = open(build + "/frozen.mk", "w")
+mkfile.write('# to build .mpy files from .py files\n\n')
+for root, pkg, module in modules:
+    if(pkg != ""):
+        pkg += "/"
+    name = os.path.basename(module)[:-3]
+    mpy_list += build + "/frozen_mpy/" + pkg + name + ".mpy "
+    mkfile.write('$(BUILD)/frozen_mpy/' + pkg + name + '.mpy: ' + root + '/' + pkg + module + ' $(MPY_CROSS)\n')
+    mkfile.write('\t$(Q)$(MKDIR) -p $(dir $@)\n')
+    mkfile.write('\t@$(ECHO) "MPY $<"\n')
+    mkfile.write('\t$(Q)$(MPY_CROSS) -o $@ -s ' + pkg + os.path.basename(module) + ' $(MPY_CROSS_FLAGS) $<\n')
+    mkfile.write('\n')
+mkfile.close
+print(mpy_list)


### PR DESCRIPTION
This PR provides a solution for building MicroPython with symlinks under WINDOWS.

As cloned or forked from GitHub MicroPython STM32 port has symlinks to the lcd160cr driver and onewire driver which fail to compile and break the build. This PR, which builds on #3310 allows MicroPython to be built out of the box on Windows with no warnings or errors.

It is particularly aimed at WINDOWS users who just want to add their own frozen modules, without having to debug and learn why build fails. It allows Python programmers to freeze modules without having to learn about make or symlinks. I will be writing a tutorial on how to build MicroPython under WINDOWS.

Under WINDOWS a Linux symlinks looks like a text file named after the module and containing one line with the path and module name, eg:

onewire.py contains ../../../drivers/onewire/onewire.py

I have replaced SHELL(FIND and SED) with a python script - tools/find-modules.py - which parses the symlinks, searches for modules in the modules directory and creates a list of path/file.py to compile. Since these files have different source directories it builds a temporary makefile, frozen.mk in the BUILD directory, with a separate rule for each module. It outputs a module list for mpy-tool.

As a result of the way it parses symlinks users can also create fake symlinks (eg under WINDOWS). These are one line files with the path/filename.py link to the module. An extension of this is to search for frozen.lst in the modules directory which can contain multiple lines of links and comments.

Currently all STM32 ports inherit the LCD drivers for the LCD160CR modules. A final addition to the search capability is to handle multiple modules directories, eg one each for the port, board and project. This would permit onewire.py to be included with all boards (in stm32/modules), lcd160cr.py to be included only with pyboards (in PYBV10/modules, etc) and user modules to be added in stm32/projects/modules.

I have included a set of module directories and test files in a second commit which I will remove and squash after testing.

To test all the features run:

make FROZEN_MPY_DIR="modules projects/modules3"

Note that the quotes are required if there is more than one module.

This has been tested for clean and incremental builds on:
Cygwin and Python 3.6
Windows 10 Bash (WSL) and Python 2.7
ChaletOS with Python 2.7. ChaletOS is Debian based with a Windows style shell. Run under VMWARE.

As far as I can tell this has no impact on Linux users, but makes life much easier for Windows users. Linux users can also take advantage of modules.lst and multiple module directories.

The changes to building and using mpy-cross.exe under WINDOWS are discussed in #3310 

find-modules.py is based in part on tools/make-frozen.py which has no copyright or license. The rest is my original work and MIT licensed.
