### PR TITLE
docs/library/network: Enhance AbstractNIC.status to take an optional argument.

### DIFF
--- a/docs/library/network.rst
+++ b/docs/library/network.rst
@@ -99,10 +99,20 @@ parameter should be `id`.
        duration and other parameters. Where possible, parameter names
        should match those in connect().
 
-    .. method:: status()
+    .. method:: status([param])
 
-       Return detailed status of the interface, values are dependent
-       on the network medium/technology.
+       Query dynamic status information of the interface.  When called with no
+       argument the return value describes the network link status.  Otherwise
+       *param* should be a string naming the particular status parameter to
+       retrieve.
+
+       The return types and values are dependent on the network
+       medium/technology.  Some of the parameters that may be supported are:
+
+       * WiFi STA: use ``'rssi'`` to retrieve the RSSI of the AP signal
+       * WiFi AP: use ``'stations'`` to retrieve a list of all the STAs
+         connected to the AP.  The list contains tuples of the form
+         (MAC, RSSI).
 
     .. method:: ifconfig([(ip, subnet, gateway, dns)])
 
@@ -119,7 +129,7 @@ parameter should be `id`.
        Get or set general network interface parameters. These methods allow to work
        with additional parameters beyond standard IP configuration (as dealt with by
        `ifconfig()`). These include network-specific and hardware-specific
-       parameters and status values. For setting parameters, the keyword argument
+       parameters. For setting parameters, the keyword argument
        syntax should be used, and multiple parameters can be set at once. For
        querying, a parameter name should be quoted as a string, and only one
        parameter can be queried at a time::
@@ -129,8 +139,6 @@ parameter should be `id`.
         # Query params one by one
         print(ap.config('essid'))
         print(ap.config('channel'))
-        # Extended status information also available this way
-        print(sta.config('rssi'))
 
 .. only:: port_pyboard
 


### PR DESCRIPTION
This PR aims to further refine the spec of the AbstractNIC class so that it has a clear way to query arbitrary status variables.

In it's current form AbstractNIC.status() is quite vague in what it returns.  A general wifi interface can have multiple status values and it's useful to be able to query many of them.  So the proposal is to add an optional parameter to status() that can specify which value to query.  The parameter is a string naming the status variable.

The existing AbstractNIC.config() can handle querying paramaters, but querying something like the list of connected stations is not really a configuration parameter.  It makes more sense to use status() for that.

The distinction between status() and config() would then be:
- status() is for querying only, and in general the return values will dynamically change between calls (like RSSI).  That change happens "asynchronously", ie it's out of the control of the network interface.
- config() is for setting and getting configuration values which are in general assumed to be static, ie they don't change between calls.

See #2998 for initial discussion on specifying AbstractNIC, and #2785 for a discussion on being able to query the RSSI.