### PR TITLE
py/runtime: Add mp_raise_RuntimeError function.

### DIFF
--- a/py/runtime.c
+++ b/py/runtime.c
@@ -1454,6 +1454,10 @@ NORETURN void mp_raise_TypeError(const char *msg) {
     mp_raise_msg(&mp_type_TypeError, msg);
 }
 
+NORETURN void mp_raise_RuntimeError(const char *msg) {
+    mp_raise_msg(&mp_type_RuntimeError, msg);
+}
+
 NORETURN void mp_raise_OSError(int errno_) {
     nlr_raise(mp_obj_new_exception_arg1(&mp_type_OSError, MP_OBJ_NEW_SMALL_INT(errno_)));
 }

--- a/py/runtime.h
+++ b/py/runtime.h
@@ -148,6 +148,7 @@ NORETURN void mp_raise_msg(const mp_obj_type_t *exc_type, const char *msg);
 //NORETURN void nlr_raise_msg_varg(const mp_obj_type_t *exc_type, const char *fmt, ...);
 NORETURN void mp_raise_ValueError(const char *msg);
 NORETURN void mp_raise_TypeError(const char *msg);
+NORETURN void mp_raise_RuntimeError(const char *msg);
 NORETURN void mp_raise_NotImplementedError(const char *msg);
 NORETURN void mp_raise_OSError(int errno_);
 NORETURN void mp_exc_recursion_depth(void);


### PR DESCRIPTION
Add a new mp_raise_RuntimeError function to the runtime.