### PR TITLE
ports/esp8266/fatfs_port: get_fattime was optimized.

### DIFF
--- a/ports/esp8266/fatfs_port.c
+++ b/ports/esp8266/fatfs_port.c
@@ -33,7 +33,7 @@ DWORD get_fattime(void) {
 
     // TODO: Optimize division (there's no HW division support on ESP8266,
     // so it's expensive).
-    uint32_t secs = (uint32_t)(pyb_rtc_get_us_since_2000() / 1000000);
+    uint32_t secs = (uint32_t)(pyb_rtc_get_us_since_2000() * 0.000001);
 
     timeutils_struct_time_t tm;
     timeutils_seconds_since_2000_to_struct_time(secs, &tm);


### PR DESCRIPTION
Division by 1000000 was replaced by multiplication by 0.000001 .

* Benchmark is needed.  