### PR TITLE
makefiles README.md: All programs and Makefiles can run under Windows.

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,6 +163,37 @@ does not work it may be because you don't have the correct permissions, and
 need to use `sudo make deploy`.
 See the README.md file in the ports/stm32/ directory for further details.
 
+Building under Windows
+----------------------
+
+MicroPython is built using gnu make and requires various gnu utilities ported
+to Windows. MSYS2 should be installed to provide these gnu utilities.
+
+To use frozen bytecode (.mpy modules) you must build mpy-cross for your host OS.
+This requires mingw32 gcc and it dependancies.
+
+Install MSYS2 64 bit from msys2.org
+Run the installer msys2-x86_64-xxxxxxxx.exe
+Follow the instructions on the msys2.org home page to update the package
+database and core modules.
+
+Install the compiler and make:
+
+    pacman -S mingw-w64-i686-gcc 
+    pacman -S make
+
+This will install gcc.exe which is identical to i686-w64-mingw32-gcc
+If you already have MSYS2 / Mingw installed run "gcc -dumpmachine"
+from a command prompt to ensure you have the correct gcc installed.
+Response should be "i686-w64-mingw32"
+
+MicroPython can then be built by running make from a Windows command prompt
+without needing a bash shell.
+
+Alternatively you can use Windows 10 WSL (Windows Subsystem for Linux).
+This provides a Ubuntu bash shell with access to the Windows file system.
+Follow the instructions for Debian / Ubuntu.
+
 Contributing
 ------------
 

--- a/mpy-cross/Makefile
+++ b/mpy-cross/Makefile
@@ -11,10 +11,12 @@ override undefine BUILD
 override undefine PROG
 endif
 
-include ../py/mkenv.mk
-
-# define main target
+# PROG is used in py/mkenv.mk. Define first.
+# define main target. Compile to run on Host (Linux, OSX or Windows),
+# do not include .exe in PROG.
 PROG = mpy-cross
+
+include ../py/mkenv.mk
 
 # qstr definitions (must come before including py.mk)
 QSTR_DEFS = qstrdefsport.h

--- a/ports/windows/Makefile
+++ b/ports/windows/Makefile
@@ -1,8 +1,15 @@
+# PROG and CROSS_COMPILE are used in py/mkenv.mk Define first.
+
+# define main target. Always compile to run on Windows, include .exe in PROG.
+PROG = micropython.exe
+
+# define a default cross compiler if host is not native Windows
+ifneq ($(OS),Windows_NT)
+CROSS_COMPILE ?= i686-w64-mingw32-
+endif
+
 include ../../py/mkenv.mk
 -include mpconfigport.mk
-
-# define main target
-PROG = micropython.exe
 
 # qstr definitions (must come before including py.mk)
 QSTR_DEFS = ../unix/qstrdefsport.h

--- a/ports/windows/README.md
+++ b/ports/windows/README.md
@@ -5,9 +5,12 @@ consider to contribute.
 
 
 Building on Debian/Ubuntu Linux system
+Building on Windows 10 with WSL (Windows Subsystem for Linux) Ubuntu Bash shell
 ---------------------------------------
 
     sudo apt-get install gcc-mingw-w64
+    make
+or
     make CROSS_COMPILE=i686-w64-mingw32-
 
 If for some reason the mingw-w64 crosscompiler is not available, you can try
@@ -29,12 +32,36 @@ Install following packages using cygwin's setup.exe:
 
 Build using:
 
+    make
+or
     make CROSS_COMPILE=i686-w64-mingw32-
 
 Or for 64bit:
 
     make CROSS_COMPILE=x86_64-w64-mingw32-
 
+
+Building using MSYS2 / Mingw on Windows
+---------------------------------------
+
+Install MSYS2 64 bit from msys2.org
+Run the installer msys2-x86_64-xxxxxxxx.exe
+Follow the instructions on the msys2.org home page to update the package
+database and core modules.
+
+Install the compiler and make:
+
+    pacman -S mingw-w64-i686-gcc 
+    pacman -S make
+
+This will install gcc.exe which is identical to i686-w64-mingw32-gcc
+If you already have MSYS2 / Mingw installed run "gcc -dumpmachine"
+from a command prompt to ensure you have the correct gcc installed.
+Response should be "i686-w64-mingw32"
+
+Build using:
+
+    make
 
 Building using MS Visual Studio 2013 (or higher)
 ------------------------------------------------

--- a/py/mkenv.mk
+++ b/py/mkenv.mk
@@ -59,14 +59,23 @@ LD += -m32
 endif
 
 MAKE_FROZEN = $(TOP)/tools/make-frozen.py
-# allow mpy-cross (for WSL) and mpy-cross.exe (for cygwin) to coexist
+# allow mpy-cross (for WSL, Cygwin or Linux) and mpy-cross.exe (for Windows / MSYS2 / mingw) to coexist
 ifeq ($(OS),Windows_NT)
 MPY_CROSS = $(TOP)/mpy-cross/mpy-cross.exe
-PROG_EXT = .exe
 else
 MPY_CROSS = $(TOP)/mpy-cross/mpy-cross
 endif
 MPY_TOOL = $(TOP)/tools/mpy-tool.py
+
+# When compiling mpy-cross or Windows port determine whether the target will be a native Windows executable.
+ifeq ($(suffix $(PROG)),.exe)
+	PROG_EXT = .exe
+endif
+COMPILER_TARGET := $(shell $(CC) -dumpmachine)
+ifneq (,$(findstring mingw,$(COMPILER_TARGET)))
+	PROG_EXT = .exe
+endif
+PROG_BASE = $(basename $(PROG))
 
 all:
 .PHONY: all
@@ -74,3 +83,4 @@ all:
 .DELETE_ON_ERROR:
 
 MKENV_INCLUDED = 1
+

--- a/py/mkrules.mk
+++ b/py/mkrules.mk
@@ -103,7 +103,7 @@ endif
 
 ifneq ($(FROZEN_MPY_DIR),)
 # to build the MicroPython cross compiler
-$(TOP)/mpy-cross/mpy-cross: $(TOP)/py/*.[ch] $(TOP)/mpy-cross/*.[ch] $(TOP)/ports/windows/fmode.c
+$(MPY_CROSS): $(TOP)/py/*.[ch] $(TOP)/mpy-cross/*.[ch] $(TOP)/ports/windows/fmode.c
 	$(Q)$(MAKE) -C $(TOP)/mpy-cross
 
 # make a list of all the .py files that need compiling and freezing
@@ -122,25 +122,25 @@ $(BUILD)/frozen_mpy.c: $(FROZEN_MPY_MPY_FILES) $(BUILD)/genhdr/qstrdefs.generate
 	$(Q)$(PYTHON) $(MPY_TOOL) -f -q $(BUILD)/genhdr/qstrdefs.preprocessed.h $(FROZEN_MPY_MPY_FILES) > $@
 endif
 
-ifneq ($(PROG),)
+ifneq ($(PROG_BASE),)
 # Build a standalone executable (unix does this)
 
-all: $(PROG)
+all: $(PROG_BASE)$(PROG_EXT)
 
-$(PROG): $(OBJ)
+$(PROG_BASE)$(PROG_EXT): $(OBJ)
 	$(ECHO) "LINK $@"
 # Do not pass COPT here - it's *C* compiler optimizations. For example,
 # we may want to compile using Thumb, but link with non-Thumb libc.
 	$(Q)$(CC) -o $@ $^ $(LIB) $(LDFLAGS)
 ifndef DEBUG
-	$(Q)$(STRIP) $(STRIPFLAGS_EXTRA) $(PROG)$(PROG_EXT)
+	$(Q)$(STRIP) $(STRIPFLAGS_EXTRA) $(PROG_BASE)$(PROG_EXT)
 endif
-	$(Q)$(SIZE) $$(find $(BUILD) -path "$(BUILD)/build/frozen*.o") $(PROG)$(PROG_EXT)
+	$(Q)$(SIZE) $$(find $(BUILD) -path "$(BUILD)/build/frozen*.o") $(PROG_BASE)$(PROG_EXT)
 
 clean: clean-prog
 clean-prog:
-	$(RM) -f $(PROG)$(PROG_EXT)
-	$(RM) -f $(PROG).map
+	$(RM) -f $(PROG_BASE)$(PROG_EXT)
+	$(RM) -f $(PROG_BASE).map
 
 .PHONY: clean-prog
 endif

--- a/tools/mpy_cross_all.py
+++ b/tools/mpy_cross_all.py
@@ -6,6 +6,7 @@ import os.path
 argparser = argparse.ArgumentParser(description="Compile all .py files to .mpy recursively")
 argparser.add_argument("-o", "--out", help="output directory (default: input dir)")
 argparser.add_argument("--target", help="select MicroPython target config")
+argparser.add_argument("--mpy_cross", help="full path/name of the mpy-cross compiler: $(MPY-CROSS) in mkenv.mk")
 argparser.add_argument("-mcache-lookup-bc", action="store_true", help="cache map lookups in the bytecode")
 argparser.add_argument("dir", help="input directory")
 args = argparser.parse_args()
@@ -31,8 +32,11 @@ for path, subdirs, files in os.walk(args.dir):
             out_dir = os.path.dirname(out_fpath)
             if not os.path.isdir(out_dir):
                 os.makedirs(out_dir)
-            cmd = "mpy-cross -v -v %s -s %s %s -o %s" % (TARGET_OPTS.get(args.target, ""),
+            cmd = '"' + args.mpy_cross + '" -v -v %s -s %s %s -o %s' % (TARGET_OPTS.get(args.target, ''),
                 fpath[path_prefix_len:], fpath, out_fpath)
+            if args.mpy_cross.endswith(".exe"):
+                # Windows cmd expects backslash
+                cmd = cmd.replace("/", "\\")
             #print(cmd)
             res = os.system(cmd)
             assert res == 0


### PR DESCRIPTION
Continuation of #3310

py/mkenv.mk: Select whether to add .exe dependant of Target OS instead
    of Host OS
    This allows Windows port to be cross compiled under Linux and
    build micropython.exe to run under Windows. Fixes #3361.

py/mkrules.mk: Fix rule to build mpy-cross / mpy-cross.exe.

windows/Makefile: Add a default CROSS_COMPILE for Windows port.
                  Move PROG and CROSS_COMPILE before #include mkenv.mk

mpy-cross/Makefile: Move PROG before #include mkenv.mk

tools/mpy_cross_all.py: pass full mpy-cross path/name including .exe
    as argument from makefile. Use $(MPY-CROSS) from mkenv.mk.
    Convert slash to backslash for Windows cmd.

Document how to install and build with MSYS2 / Mingw under Windows.
Update README.md and windows/README.md for changes above.

With these changes all programs (mpy-cross and micropython.exe) and all
    Makefiles will run from a Windows cmd prompt. They don't need to be
    run from the MSYS cmd shell. Requires MSYS2 and Mingw to be
    installed as documented in the README.md files.