### PR TITLE
stm32: Incorporate lwip stack and use Wiznet in MACRAW mode

### DIFF
--- a/drivers/wiznet5k/ethernet/w5200/w5200.c
+++ b/drivers/wiznet5k/ethernet/w5200/w5200.c
@@ -52,10 +52,10 @@
 
 #include "w5200.h"
 
-#define SMASK (0x7ff) /* tx buffer mask */
-#define RMASK (0x7ff) /* rx buffer mask */
-#define SSIZE (2048) /* max tx buffer size */
-#define RSIZE (2048) /* max rx buffer size */
+#define SMASK (16*1024-1) /* tx buffer mask */
+#define RMASK (16*1024-1) /* rx buffer mask */
+#define SSIZE (16*1024) /* max tx buffer size */
+#define RSIZE (16*1024) /* max rx buffer size */
 
 #define TXBUF_BASE (0x8000)
 #define RXBUF_BASE (0xc000)

--- a/ports/stm32/Makefile
+++ b/ports/stm32/Makefile
@@ -15,6 +15,10 @@ include boards/$(BOARD)/mpconfigboard.mk
 # qstr definitions (must come before including py.mk)
 QSTR_DEFS = qstrdefsport.h $(BUILD)/pins_qstr.h $(BUILD)/modstm_qstr.h
 
+# extmod modules
+MICROPY_PY_USSL = 1
+MICROPY_SSL_AXTLS = 1
+
 # directory containing scripts to be frozen as bytecode
 FROZEN_MPY_DIR ?= modules
 
@@ -86,8 +90,14 @@ CFLAGS += -DMICROPY_FLOAT_IMPL=MICROPY_FLOAT_IMPL_FLOAT
 CFLAGS += -fsingle-precision-constant -Wdouble-promotion
 endif
 
+ifeq ($(MICROPY_PY_USSL),1)
+ifeq ($(MICROPY_SSL_AXTLS),1)
+LIBS += -L$(BUILD) -laxtls
+endif
+endif
+
 LDFLAGS = -nostdlib -L $(LD_DIR) $(addprefix -T,$(LD_FILES)) -Map=$(@:.elf=.map) --cref
-LIBS = $(shell $(CC) $(CFLAGS) -print-libgcc-file-name)
+LIBS += $(shell $(CC) $(CFLAGS) -print-libgcc-file-name)
 
 # Remove uncalled code from the final image.
 CFLAGS += -fdata-sections -ffunction-sections
@@ -429,7 +439,7 @@ $(PY_BUILD)/formatfloat.o: COPT += -Os
 $(PY_BUILD)/parsenum.o: COPT += -Os
 $(PY_BUILD)/mpprint.o: COPT += -Os
 
-all: $(TOP)/lib/stm32lib/README.md $(BUILD)/firmware.dfu $(BUILD)/firmware.hex
+all: $(TOP)/lib/stm32lib/README.md $(BUILD)/libaxtls.a $(BUILD)/firmware.dfu $(BUILD)/firmware.hex
 
 # For convenience, automatically fetch required submodules if they don't exist
 $(TOP)/lib/stm32lib/README.md:
@@ -583,5 +593,12 @@ $(GEN_CDCINF_HEADER): $(GEN_CDCINF_FILE) $(FILE2H) | $(HEADER_BUILD)
 $(GEN_CDCINF_FILE): $(CDCINF_TEMPLATE) $(INSERT_USB_IDS) $(USB_IDS_FILE) | $(HEADER_BUILD)
 	$(ECHO) "GEN $@"
 	$(Q)$(PYTHON) $(INSERT_USB_IDS) $(USB_IDS_FILE) $< > $@
+
+$(BUILD)/libaxtls.a: | $(BUILD)/
+	cd $(TOP)/lib/axtls; cp config/upyconfig config/.config
+	cd $(TOP)/lib/axtls; $(MAKE) oldconfig -B
+	cd $(TOP)/lib/axtls; $(MAKE) clean
+	cd $(TOP)/lib/axtls; $(MAKE) all CC="$(CC)" LD="$(LD)" AR="$(AR)" CFLAGS_EXTRA="$(CFLAGS_MCU_$(MCU_SERIES)) -I../../../ports/stm32"
+	cp $(TOP)/lib/axtls/_stage/libaxtls.a $@
 
 include $(TOP)/py/mkrules.mk

--- a/ports/stm32/arpa/inet.h
+++ b/ports/stm32/arpa/inet.h
@@ -1,0 +1,1 @@
+// empty, for axtls

--- a/ports/stm32/modules/uasyncio/__init__.py
+++ b/ports/stm32/modules/uasyncio/__init__.py
@@ -1,0 +1,1 @@
+../../../../../micropython-lib/uasyncio/uasyncio/__init__.py

--- a/ports/stm32/modules/uasyncio/core.py
+++ b/ports/stm32/modules/uasyncio/core.py
@@ -1,0 +1,1 @@
+../../../../../micropython-lib/uasyncio.core/uasyncio/core.py

--- a/ports/stm32/modules/upip.py
+++ b/ports/stm32/modules/upip.py
@@ -1,0 +1,1 @@
+../../../tools/upip.py

--- a/ports/stm32/modules/upip_utarfile.py
+++ b/ports/stm32/modules/upip_utarfile.py
@@ -1,0 +1,1 @@
+../../../tools/upip_utarfile.py

--- a/ports/stm32/modules/urequests.py
+++ b/ports/stm32/modules/urequests.py
@@ -1,0 +1,1 @@
+../../../../micropython-lib/urequests/urequests.py

--- a/ports/stm32/mpconfigport.h
+++ b/ports/stm32/mpconfigport.h
@@ -70,6 +70,7 @@
 #define MICROPY_FLOAT_IMPL          (MICROPY_FLOAT_IMPL_FLOAT)
 #endif
 #define MICROPY_STREAMS_NON_BLOCK   (1)
+#define MICROPY_STREAMS_POSIX_API   (1)
 #define MICROPY_MODULE_WEAK_LINKS   (1)
 #define MICROPY_CAN_OVERRIDE_BUILTINS (1)
 #define MICROPY_USE_INTERNAL_ERRNO  (1)
@@ -297,6 +298,10 @@ extern const struct _mp_obj_module_t mp_module_onewire;
 typedef int mp_int_t; // must be pointer size
 typedef unsigned int mp_uint_t; // must be pointer size
 typedef long mp_off_t;
+
+// ssize_t, off_t as required by POSIX-signatured functions in stream.h
+typedef int ssize_t;
+typedef mp_off_t off_t;
 
 #define MP_PLAT_PRINT_STRN(str, len) mp_hal_stdout_tx_strn_cooked(str, len)
 

--- a/ports/stm32/mpconfigport.h
+++ b/ports/stm32/mpconfigport.h
@@ -132,6 +132,7 @@
 #define MICROPY_PY_UTIMEQ           (1)
 #define MICROPY_PY_UTIME_MP_HAL     (1)
 #define MICROPY_PY_OS_DUPTERM       (1)
+#define MICROPY_PY_LWIP             (1)
 #define MICROPY_PY_MACHINE          (1)
 #define MICROPY_PY_MACHINE_PULSE    (1)
 #define MICROPY_PY_MACHINE_PIN_MAKE_NEW mp_pin_make_new

--- a/ports/stm32/mpconfigport.mk
+++ b/ports/stm32/mpconfigport.mk
@@ -4,7 +4,7 @@
 #   0    : no Wiznet support
 #   5200 : support for W5200 module
 #   5500 : support for W5500 module
-MICROPY_PY_WIZNET5K ?= 0
+MICROPY_PY_WIZNET5K ?= 5500
 
 # cc3k module for wifi support
 MICROPY_PY_CC3K ?= 0

--- a/ports/stm32/wiznet_connect.py
+++ b/ports/stm32/wiznet_connect.py
@@ -1,0 +1,8 @@
+import time, network
+nic = network.WIZNET5K(pyb.SPI(1), pyb.Pin.board.X5, pyb.Pin.board.X4)
+nic.active(1)
+while not nic.isconnected():
+    time.sleep_ms(50) # needed to poll the NIC
+print(nic.ifconfig())
+import socket
+print(socket.getaddrinfo('micropython.org', 80))


### PR DESCRIPTION
This PR is work-in-progress and the main aim is to begin incorporating the lwIP stack into the stm32 port, along with ussl and other networking components.

As a proof-of-concept in uses the Wiznet Ethernet module in MACRAW mode which allows to send and receive raw Ethernet frames.  This send/recv is hooked into the back of lwIP so that the TCP/IP stack is provided by lwIP itself (as opposed to the internal TCP/IP stack in the Wiznet module).

The benefits are that the Wiznet module now supports the full socket module interface and behaves exactly the same as esp8266.  The downside is reduced TCP throughput because the Wiznet doesn't have large enough Ethernet buffers to buffer the incoming frames before they get processed by lwIP.  But the performance loss is not that bad (roughly a third of the throughput) and the benefits outweight the reduced performance.

The PR also enables the ussl module for stm32, and adds some useful modules to the frozen bytecode.  The Wiznet W5500 chipset is enabled by default but can be changed to W5200 in stm32/mpconfigport.mk.

upip, urequests and uasyncio are all tested to work and are included in the frozen bytecode.

There is a script stm32/wiznet_connect.py which shows how to bring up the network.