### PR TITLE
extmod/modussl_axtls: socket_read: Handle EAGAIN.

### DIFF
--- a/extmod/modussl_axtls.c
+++ b/extmod/modussl_axtls.c
@@ -117,6 +117,9 @@ STATIC mp_uint_t socket_read(mp_obj_t o_in, void *buf, mp_uint_t size, int *errc
                 // EOF
                 return 0;
             }
+            if (r == SSL_EAGAIN) {
+                r = MP_EAGAIN;
+            }
             *errcode = r;
             return MP_STREAM_ERROR;
         }


### PR DESCRIPTION
If SSL_EAGAIN is returned (which is a feature of MicroPython's axTLS fork),
return EAGAIN.

Original axTLS returns SSL_OK both when there's no data to return to user
yet and when the underlying stream returns EAGAIN. That's not distinctive
enough, for example, original module code works well for blocking stream,
but will infinite-loop for non-blocking socket with EAGAIN. But if we fix
non-blocking case, blocking calls to .read() will return few None's initially
(while axTLS progresses thru handshake).

Using SSL_EAGAIN allows to fix non-blocking case without regressing the
blocking one.

Note that this only handles case of non-blocking reads of application data.
Initial handshake and writes still don't support non-blocking mode and must
be done in the blocking way.