### PR TITLE
Make calling Python tools from make more consistent, platform-independent and user-configurable

### DIFF
--- a/py/mkenv.mk
+++ b/py/mkenv.mk
@@ -58,9 +58,9 @@ CXX += -m32
 LD += -m32
 endif
 
-MAKE_FROZEN = $(TOP)/tools/make-frozen.py
+MAKE_FROZEN = $(PYTHON) $(TOP)/tools/make-frozen.py
 MPY_CROSS = $(TOP)/mpy-cross/mpy-cross
-MPY_TOOL = $(TOP)/tools/mpy-tool.py
+MPY_TOOL = $(PYTHON) $(TOP)/tools/mpy-tool.py
 
 all:
 .PHONY: all

--- a/py/mkrules.mk
+++ b/py/mkrules.mk
@@ -119,7 +119,7 @@ $(BUILD)/frozen_mpy/%.mpy: $(FROZEN_MPY_DIR)/%.py $(TOP)/mpy-cross/mpy-cross
 # to build frozen_mpy.c from all .mpy files
 $(BUILD)/frozen_mpy.c: $(FROZEN_MPY_MPY_FILES) $(BUILD)/genhdr/qstrdefs.generated.h
 	@$(ECHO) "Creating $@"
-	$(Q)$(PYTHON) $(MPY_TOOL) -f -q $(BUILD)/genhdr/qstrdefs.preprocessed.h $(FROZEN_MPY_MPY_FILES) > $@
+	$(Q)$(MPY_TOOL) -f -q $(BUILD)/genhdr/qstrdefs.preprocessed.h $(FROZEN_MPY_MPY_FILES) > $@
 endif
 
 ifneq ($(PROG),)


### PR DESCRIPTION
Rationale:

* When calling Python build tool scripts from makefiles, we should be consistent on how to call them. IMHO it is better to call them via `python </path/to/script>` directly, instead of relying on the correct she-bang line in the script [1] and the executable bit on the script being set. This is more platform-independent.
* The name/path of the Python executable should always be used via the makefile variable `PYTHON` (set in `py/mkenv.mk`. This way it can be easily overwritten by the user (i.e. with `make PYTHON=/path/to/my/python`), which currently doesn't work for the `make-frozen.py` tool as it should (see Damien's [comment here](https://github.com/micropython/micropython/issues/1616#issuecomment-156456904))
* The Python executable name should be part of the value of the makefile variable, which stands for the build tool command (e.g. `MAKE_FROZEN` and `MPY_TOOL`), not part of the command line where it is used. If a Python tool is substituted by another (non-python) program, no change to the Makefiles is necessary, except in `py/mkenv.mk`.
* This also solves #3369 and #1616.

[1] There are systems, where even the assumption that `/usr/bin/env` always exists, doesn't hold true, for example on Android (where otherwise the unix port compiles perfectly well).

Signed-off-by: Christopher Arndt <chris@chrisarndt.de>