### PR TITLE
ports/esp8266/modules/webrepl.py: Make except statment more specific.

### DIFF
--- a/ports/esp8266/modules/webrepl.py
+++ b/ports/esp8266/modules/webrepl.py
@@ -65,7 +65,7 @@ def start(port=8266, password=None):
             _webrepl.password(webrepl_cfg.PASS)
             setup_conn(port, accept_conn)
             print("Started webrepl in normal mode")
-        except:
+        except (ImportError, NameError):
             print("WebREPL is not configured, run 'import webrepl_setup'")
     else:
         _webrepl.password(password)


### PR DESCRIPTION
This doesn't fix #2659, but it should make things less confusing by only catching exceptions that are raised when WebREPL isn't configured. ImportError is raised if webrepl_cfg.py doesn't exist, NameError is raise if it does exist but it doesn't contain the variable PASS.