### PR TITLE
RFC: Add _asdict for namedtuple and add some field name checks

### DIFF
--- a/ports/unix/mpconfigport_coverage.h
+++ b/ports/unix/mpconfigport_coverage.h
@@ -44,3 +44,4 @@
 #undef MICROPY_VFS_FAT
 #define MICROPY_VFS_FAT                (1)
 #define MICROPY_PY_FRAMEBUF            (1)
+#define MICROPY_PY_COLLECTIONS_NAMEDTUPLE__ASDICT (1)

--- a/py/mpconfig.h
+++ b/py/mpconfig.h
@@ -894,6 +894,12 @@ typedef double mp_float_t;
 #define MICROPY_PY_COLLECTIONS_ORDEREDDICT (0)
 #endif
 
+// Whether to provide the _asdict function for namedtuple
+#if !defined(MICROPY_PY_COLLECTIONS_NAMEDTUPLE__ASDICT) || !MICROPY_PY_COLLECTIONS_ORDEREDDICT
+#undef MICROPY_PY_COLLECTIONS_NAMEDTUPLE__ASDICT
+#define MICROPY_PY_COLLECTIONS_NAMEDTUPLE__ASDICT (0)
+#endif
+
 // Whether to provide "math" module
 #ifndef MICROPY_PY_MATH
 #define MICROPY_PY_MATH (1)

--- a/py/objnamedtuple.c
+++ b/py/objnamedtuple.c
@@ -52,6 +52,23 @@ STATIC size_t namedtuple_find_field(const mp_obj_namedtuple_type_t *type, qstr n
     return (size_t)-1;
 }
 
+#if MICROPY_PY_COLLECTIONS_NAMEDTUPLE__ASDICT
+STATIC mp_obj_t namedtuple_asdict(mp_obj_t self_in) {
+    mp_obj_namedtuple_t *self = MP_OBJ_TO_PTR(self_in);
+    const qstr *fields = ((mp_obj_namedtuple_type_t*)self->tuple.base.type)->fields;
+    mp_obj_t dict = mp_obj_new_dict(self->tuple.len);
+    //make it an OrderedDict
+    mp_obj_dict_t *dictObj = MP_OBJ_TO_PTR(dict);
+    dictObj->base.type = &mp_type_ordereddict;
+    dictObj->map.is_ordered = 1;
+    for (size_t i = 0; i < self->tuple.len; ++i) {
+        mp_obj_dict_store(dict, MP_OBJ_NEW_QSTR(fields[i]), self->tuple.items[i]);
+    }
+    return dict;
+}
+MP_DEFINE_CONST_FUN_OBJ_1(namedtuple_asdict_obj, namedtuple_asdict);
+#endif
+
 STATIC void namedtuple_print(const mp_print_t *print, mp_obj_t o_in, mp_print_kind_t kind) {
     (void)kind;
     mp_obj_namedtuple_t *o = MP_OBJ_TO_PTR(o_in);
@@ -64,6 +81,13 @@ STATIC void namedtuple_attr(mp_obj_t self_in, qstr attr, mp_obj_t *dest) {
     if (dest[0] == MP_OBJ_NULL) {
         // load attribute
         mp_obj_namedtuple_t *self = MP_OBJ_TO_PTR(self_in);
+        #if MICROPY_PY_COLLECTIONS_NAMEDTUPLE__ASDICT
+        if (attr == MP_QSTR__asdict) {
+            dest[0] = MP_OBJ_FROM_PTR(&namedtuple_asdict_obj);
+            dest[1] = self_in;
+            return;
+        }
+        #endif
         size_t id = namedtuple_find_field((mp_obj_namedtuple_type_t*)self->tuple.base.type, attr);
         if (id == (size_t)-1) {
             return;

--- a/tests/basics/namedtuple1.py
+++ b/tests/basics/namedtuple1.py
@@ -82,3 +82,13 @@ print(t.foo, t.bar)
 # Not implemented so far
 #T2 = namedtuple("TupComma", "foo,bar")
 #t = T2(1, 2)
+
+try:
+    namedtuple("Empty", [""])
+except ValueError:
+    print("ValueError")
+
+try:
+    namedtuple("Underscore", ["_foo"])
+except ValueError:
+    print("ValueError")

--- a/tests/basics/namedtuple2.py
+++ b/tests/basics/namedtuple2.py
@@ -1,0 +1,20 @@
+try:
+    try:
+        from collections import namedtuple
+    except ImportError:
+        from ucollections import namedtuple
+except ImportError:
+    print("SKIP")
+    raise SystemExit
+
+t = namedtuple("Tup", ["baz", "foo", "bar"])(3, 2, 5)
+
+try:
+    t._asdict
+except AttributeError:
+    print("SKIP")
+    raise SystemExit
+
+d = t._asdict()
+print(list(d.keys()))
+print(list(d.values()))


### PR DESCRIPTION
Add the _asdict function when MICROPY_CPYTHON_COMPAT and MICROPY_PY_COLLECTIONS_ORDEREDDICT are both set. While testing this I wondered what would happen in CPython if I'd define a field named '_asdict' and found out no names starting with underscores are allowed. Nor empty names, which makes sense, so I added checks for both.
This is RFC because:
- could break some existing code which uses namedtuples with field names starting with underscores; on the other hand it doesn't seem worth makeing such an option configurable
- should the empty name check always be on? It really doesn't make sense using an empty field name
- there's no API to make an OrderedDict from within the C code so I did it manually but that's a bit dirty, should we have a seperate function for that?
