### PR TITLE
ports/esp8266/modules/websocket_helper: Improve client handshake's compliance with RFC6455.

### DIFF
--- a/ports/esp8266/modules/websocket_helper.py
+++ b/ports/esp8266/modules/websocket_helper.py
@@ -1,4 +1,5 @@
 import sys
+import urandom
 try:
     import ubinascii as binascii
 except:
@@ -15,31 +16,13 @@ def server_handshake(sock):
     l = clr.readline()
     #sys.stdout.write(repr(l))
 
-    webkey = None
-
-    while 1:
-        l = clr.readline()
-        if not l:
-            raise OSError("EOF in headers")
-        if l == b"\r\n":
-            break
-    #    sys.stdout.write(l)
-        h, v = [x.strip() for x in l.split(b":", 1)]
-        if DEBUG:
-            print((h, v))
-        if h == b'Sec-WebSocket-Key':
-            webkey = v
-
+    webkey = _extract_header_values(clr, (b'sec-websocket-key',))[0]
     if not webkey:
         raise OSError("Not a websocket request")
-
     if DEBUG:
         print("Sec-WebSocket-Key:", webkey, len(webkey))
 
-    d = hashlib.sha1(webkey)
-    d.update(b"258EAFA5-E914-47DA-95CA-C5AB0DC85B11")
-    respkey = d.digest()
-    respkey = binascii.b2a_base64(respkey)[:-1]
+    respkey = _calc_respkey(webkey)
     if DEBUG:
         print("respkey:", respkey)
 
@@ -49,26 +32,78 @@ Upgrade: websocket\r
 Connection: Upgrade\r
 Sec-WebSocket-Accept: """)
     sock.send(respkey)
-    sock.send("\r\n\r\n")
+    sock.send(b"\r\n\r\n")
 
+def client_handshake(sock, host, path=b'/', sps=None):
+    webkey = bytearray(16)
+    for i in range(len(webkey)):
+        webkey[i] = urandom.getrandbits(8)
+    webkey = binascii.b2a_base64(webkey)[:-1]
+    if DEBUG:
+        print("Sec-WebSocket-Key:", webkey, len(webkey))
 
-# Very simplified client handshake, works for MicroPython's
-# websocket server implementation, but probably not for other
-# servers.
-def client_handshake(sock):
-    cl = sock.makefile("rwb", 0)
-    cl.write(b"""\
-GET / HTTP/1.1\r
-Host: echo.websocket.org\r
+    sock.write(b"""\
+GET """)
+    sock.write(path)
+    sock.write(b""" HTTP/1.1\r
+Host: """)
+    sock.write(host)
+    sock.write(b"""\r
 Connection: Upgrade\r
 Upgrade: websocket\r
-Sec-WebSocket-Key: foo\r
+Sec-WebSocket-Key: """)
+    sock.write(webkey)
+    if sps:
+        sock.write(b"""\r
+Sec-WebSocket-Protocol: """)
+        sock.write(sps)
+    sock.write(b"""\r
+Sec-WebSocket-Version: 13\r
 \r
 """)
-    l = cl.readline()
-#    print(l)
-    while 1:
-        l = cl.readline()
+
+    l = sock.readline()
+    #sys.stdout.write(repr(l))
+
+    respkey, sel_sp = _extract_header_values(sock, (b'sec-websocket-accept', b'sec-websocket-protocol'))
+    if not respkey:
+        raise OSError("Handshake failed")
+    if DEBUG:
+        print("respkey:", respkey, len(respkey))
+
+    exp_respkey = _calc_respkey(webkey)
+    if DEBUG:
+        print("exp_respkey:", exp_respkey, len(exp_respkey))
+    if respkey != exp_respkey:
+        raise OSError("Handshake failed")
+
+    return sel_sp
+
+def _extract_header_values(sock, dhs):
+    dvs = [None] * len(dhs)
+
+    while True:
+        l = sock.readline()
+        if not l:
+            raise OSError("EOF in headers")
         if l == b"\r\n":
             break
-#        sys.stdout.write(l)
+        #sys.stdout.write(repr(l))
+        h, v = [x.strip() for x in l.split(b":", 1)]
+        if DEBUG:
+            print((h, v))
+        h = h.lower()
+        try:
+            dvs[dhs.index(h)] = v
+        except ValueError:
+            pass
+
+    return dvs
+
+def _calc_respkey(webkey):
+    d = hashlib.sha1(webkey)
+    d.update(b"258EAFA5-E914-47DA-95CA-C5AB0DC85B11")
+    respkey = d.digest()
+    respkey = binascii.b2a_base64(respkey)[:-1]
+
+    return respkey


### PR DESCRIPTION
The existing client handshake implementation is non-compliant with RFC6455
Sections 1.3 and 4.1, and is only sufficient for use with the existing server
handshake implementation.  This change increases the client handshake's
compliance with the RFC by fully supporting the "Sec-WebSocket-Key",
"Sec-WebSocket-Protocol", "Sec-WebSocket-Version", and "Sec-WebSocket-Accept"
HTTP headers.  The value of the "Sec-WebSocket-Protocol" response header is
returned to the caller for further handling.  To minimize the code footprint,
if a server returns a "Sec-WebSocket-Accept" response header and it has the
expected value, it is assumed that the HTTP connection has been successfully
upgraded to a websocket connection.  Other aspects of the HTTP response are
not validated (i.e. the response code, the "Upgrade" header, and the
"Connection" header).