### PR TITLE
docs/conf: Reference CPython 3.5 docs.

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -322,7 +322,7 @@ texinfo_documents = [
 
 
 # Example configuration for intersphinx: refer to the Python standard library.
-intersphinx_mapping = {'python': ('http://docs.python.org/3', None)}
+intersphinx_mapping = {'python': ('http://docs.python.org/3.5', None)}
 
 # Append the other ports' specific folders/files to the exclude pattern
 exclude_patterns.extend([port + '*' for port in ports if port != micropy_port])


### PR DESCRIPTION
CPython 3.6 contains some backward incompatible changes, and further
version(s) are expected to have more. As we anyway 3.4 with some
features of 3.5, refer to 3.5 docs to avoid confusion.