### PR TITLE
extmod/moduhashlib: Enable SHA1 hashing when using "mbedtls" library.

### DIFF
--- a/ports/unix/mpconfigport.h
+++ b/ports/unix/mpconfigport.h
@@ -121,7 +121,7 @@
 #define MICROPY_PY_UHEAPQ           (1)
 #define MICROPY_PY_UTIMEQ           (1)
 #define MICROPY_PY_UHASHLIB         (1)
-#if MICROPY_PY_USSL && MICROPY_SSL_AXTLS
+#if MICROPY_PY_USSL
 #define MICROPY_PY_UHASHLIB_SHA1    (1)
 #endif
 #define MICROPY_PY_UBINASCII        (1)


### PR DESCRIPTION
The SHA1 hashing functionality is provided via the "axtls" library's
implementation, and hence is unavailable when the "axtls" library is not being
used.  This change provides the same SHA1 hashing functionality when using the
"mbedtls" library by using its implementation instead.