### PR TITLE
extmod/vfs_fat: Mount FatFS on creation so VFS methods can be used.

### DIFF
--- a/extmod/vfs_fat.h
+++ b/extmod/vfs_fat.h
@@ -35,6 +35,7 @@
 #define FSUSER_NATIVE       (0x0001) // readblocks[2]/writeblocks[2] contain native func
 #define FSUSER_FREE_OBJ     (0x0002) // fs_user_mount_t obj should be freed on umount
 #define FSUSER_HAVE_IOCTL   (0x0004) // new protocol with ioctl
+#define FSUSER_NO_FILESYSTEM (0x0008) // the block device has no filesystem on it
 
 typedef struct _fs_user_mount_t {
     mp_obj_base_t base;


### PR DESCRIPTION
It's possible to use the methods (eg ilistdir) of a VFS FatFS object
without it being mounted in the VFS itself.  This previously worked but
only because FatFS was "mounting" the filesystem automatically when any
function (eg f_opendir) was called.  But it didn't work for ports that used
synchronisation objects (_FS_REENTRANT) because they are only initialised
via a call to f_mount.  So, call f_mount explicitly when creating a new
FatFS object so that everything is set up correctly.  Then also provide a
finaliser to do the f_umount call, but only if synchronisation objects are
enabled (since otherwise the f_umount call does nothing).

Should fix #3424.