### PR TITLE
extmod/modlwip: Commit TCP out data to lower layers if buffer gets full.

### DIFF
--- a/extmod/modlwip.c
+++ b/extmod/modlwip.c
@@ -498,6 +498,11 @@ STATIC mp_uint_t lwip_tcp_send(lwip_socket_obj_t *socket, const byte *buf, mp_ui
 
     err_t err = tcp_write(socket->pcb.tcp, buf, write_len, TCP_WRITE_FLAG_COPY);
 
+    // If the output buffer is getting full then send the data to the lower layers
+    if (err == ERR_OK && tcp_sndbuf(socket->pcb.tcp) < TCP_SND_BUF / 4) {
+        err = tcp_output(socket->pcb.tcp);
+    }
+
     if (err != ERR_OK) {
         *_errno = error_lookup_table[-err];
         return MP_STREAM_ERROR;


### PR DESCRIPTION
This PR dramatically improves TCP sending throughput because without an explicit call to tcp_output() the data is only sent to the lower layers via the lwIP slow timer which (by default) ticks every 500ms.

Note that this is conservative way of improving performance, at least throughput.  To reduce latency it might be desirable to call `tcp_output()` after every `tcp_write()` call, to commit the TCP data straightaway.  But that may end up sending too many small (Ethernet) packets instead of waiting to bunch them together into one.  Further testing would be required, and also investigating how the netconn API of lwIP does it.

For now, this PR here seems like a good comprimise to improve performance without calling `tcp_output()` too often.