### PR TITLE
Fix incorrect example in utime.rst

### DIFF
--- a/docs/library/utime.rst
+++ b/docs/library/utime.rst
@@ -189,9 +189,9 @@ Functions
         scheduled_time = task.scheduled_time()
         if ticks_diff(scheduled_time, now) > 0:
             print("Too early, let's nap")
-            sleep_ms(ticks_diff(now, scheduled_time))
+            sleep_ms(ticks_diff(scheduled_time, now))
             task.run()
-        elif ticks_diff(now, scheduled_time) == 0:
+        elif ticks_diff(scheduled_time, now) == 0:
             print("Right at time!")
             task.run()
         elif ticks_diff(scheduled_time, now) < 0:

--- a/docs/library/utime.rst
+++ b/docs/library/utime.rst
@@ -187,14 +187,14 @@ Functions
         # This code snippet is not optimized
         now = time.ticks_ms()
         scheduled_time = task.scheduled_time()
-        if ticks_diff(now, scheduled_time) > 0:
+        if ticks_diff(scheduled_time, now) > 0:
             print("Too early, let's nap")
             sleep_ms(ticks_diff(now, scheduled_time))
             task.run()
         elif ticks_diff(now, scheduled_time) == 0:
             print("Right at time!")
             task.run()
-        elif ticks_diff(now, scheduled_time) < 0:
+        elif ticks_diff(scheduled_time, now) < 0:
             print("Oops, running late, tell task to run faster!")
             task.run(run_faster=true)
 


### PR DESCRIPTION
The parameter order in the example for ticks_diff is incorrect. If it's "too early" that means that scheduled time is greater than current time and if it's "running late" then scheduled time would be less than current time.