### PR TITLE
Change PYB prefix to MPY

### DIFF
--- a/docs/pyboard/tutorial/repl.rst
+++ b/docs/pyboard/tutorial/repl.rst
@@ -96,8 +96,8 @@ If something goes wrong, you can reset the board in two ways. The first is to pr
 at the MicroPython prompt, which performs a soft reset.  You will see a message something like ::
 
     >>> 
-    PYB: sync filesystems
-    PYB: soft reboot
+    MPY: sync filesystems
+    MPY: soft reboot
     Micro Python v1.0 on 2014-05-03; PYBv1.0 with STM32F405RG
     Type "help()" for more information.
     >>>

--- a/docs/reference/repl.rst
+++ b/docs/reference/repl.rst
@@ -174,8 +174,8 @@ variables no longer exist:
 
 .. code-block:: python
 
-    PYB: sync filesystems
-    PYB: soft reboot
+    MPY: sync filesystems
+    MPY: soft reboot
     MicroPython v1.5-51-g6f70283-dirty on 2015-10-30; PYBv1.0 with STM32F405RG
     Type "help()" for more information.
     >>> dir()

--- a/docs/wipy/tutorial/repl.rst
+++ b/docs/wipy/tutorial/repl.rst
@@ -120,7 +120,7 @@ If something goes wrong, you can reset the board in two ways. The first is to pr
 at the MicroPython prompt, which performs a soft reset.  You will see a message something like::
 
     >>> 
-    PYB: soft reboot
+    MPY: soft reboot
     MicroPython v1.4.6-146-g1d8b5e5 on 2015-10-21; WiPy with CC3200
     Type "help()" for more information.
     >>>

--- a/lib/utils/pyexec.c
+++ b/lib/utils/pyexec.c
@@ -414,7 +414,7 @@ friendly_repl_reset:
             // do the user a favor and reenable interrupts.
             if (query_irq() == IRQ_STATE_DISABLED) {
                 enable_irq(IRQ_STATE_ENABLED);
-                mp_hal_stdout_tx_str("PYB: enabling IRQs\r\n");
+                mp_hal_stdout_tx_str("MPY: enabling IRQs\r\n");
             }
         }
         #endif

--- a/ports/cc3200/mptask.c
+++ b/ports/cc3200/mptask.c
@@ -234,7 +234,7 @@ soft_reset_exit:
 
     // soft reset
     pyb_sleep_signal_soft_reset();
-    mp_printf(&mp_plat_print, "PYB: soft reboot\n");
+    mp_printf(&mp_plat_print, "MPY: soft reboot\n");
 
     // disable all callbacks to avoid undefined behaviour
     // when coming out of a soft reset

--- a/ports/esp32/main.c
+++ b/ports/esp32/main.c
@@ -115,7 +115,7 @@ soft_reset:
 
     gc_sweep_all();
 
-    mp_hal_stdout_tx_str("PYB: soft reboot\r\n");
+    mp_hal_stdout_tx_str("MPY: soft reboot\r\n");
 
     // deinitialise peripherals
     machine_pins_deinit();

--- a/ports/esp8266/main.c
+++ b/ports/esp8266/main.c
@@ -86,7 +86,7 @@ STATIC void mp_reset(void) {
 
 void soft_reset(void) {
     gc_sweep_all();
-    mp_hal_stdout_tx_str("PYB: soft reboot\r\n");
+    mp_hal_stdout_tx_str("MPY: soft reboot\r\n");
     mp_hal_delay_us(10000); // allow UART to flush output
     mp_reset();
     #if MICROPY_REPL_EVENT_DRIVEN

--- a/ports/pic16bit/main.c
+++ b/ports/pic16bit/main.c
@@ -84,7 +84,7 @@ soft_reset:
         }
     }
 
-    printf("PYB: soft reboot\n");
+    printf("MPY: soft reboot\n");
     mp_deinit();
     goto soft_reset;
 }

--- a/ports/stm32/main.c
+++ b/ports/stm32/main.c
@@ -195,7 +195,7 @@ MP_NOINLINE STATIC bool init_flash_fs(uint reset_mode) {
         if (res == FR_OK) {
             // success creating fresh LFS
         } else {
-            printf("PYB: can't create flash filesystem\n");
+            printf("MPY: can't create flash filesystem\n");
             return false;
         }
 
@@ -227,7 +227,7 @@ MP_NOINLINE STATIC bool init_flash_fs(uint reset_mode) {
         // mount sucessful
     } else {
     fail:
-        printf("PYB: can't mount flash\n");
+        printf("MPY: can't mount flash\n");
         return false;
     }
 
@@ -341,7 +341,7 @@ STATIC bool init_sdcard_fs(void) {
     }
 
     if (first_part) {
-        printf("PYB: can't mount SD card\n");
+        printf("MPY: can't mount SD card\n");
         return false;
     } else {
         return true;
@@ -751,11 +751,11 @@ soft_reset_exit:
     // soft reset
 
     #if MICROPY_HW_ENABLE_STORAGE
-    printf("PYB: sync filesystems\n");
+    printf("MPY: sync filesystems\n");
     storage_flush();
     #endif
 
-    printf("PYB: soft reboot\n");
+    printf("MPY: soft reboot\n");
     #if MICROPY_PY_NETWORK
     mod_network_deinit();
     #endif

--- a/ports/teensy/main.c
+++ b/ports/teensy/main.c
@@ -343,7 +343,7 @@ soft_reset:
         }
     }
 
-    printf("PYB: soft reboot\n");
+    printf("MPY: soft reboot\n");
 
 //    first_soft_reset = false;
     goto soft_reset;


### PR DESCRIPTION
Replaces "PYB: soft reboot" with "MPY: soft reboot" in all ports and docs.

As per https://github.com/micropython/micropython/issues/3274