### PR TITLE
esp32: Add I2S peripheral support.

### DIFF
--- a/ports/esp32/Makefile
+++ b/ports/esp32/Makefile
@@ -146,6 +146,7 @@ SRC_C = \
 	moduhashlib.c \
 	espneopixel.c \
 	machine_hw_spi.c \
+	machine_i2s.c \
 	machine_wdt.c \
 	mpthreadport.c \
 	$(SRC_MOD)
@@ -214,6 +215,7 @@ ESPIDF_DRIVER_O = $(addprefix $(ESPCOMP)/driver/,\
 	timer.o \
 	spi_master.o \
 	spi_common.o \
+	i2s.o \
 	rtc_module.o \
 	)
 

--- a/ports/esp32/machine_i2s.c
+++ b/ports/esp32/machine_i2s.c
@@ -1,0 +1,141 @@
+/*
+ * This file is part of the MicroPython project, http://micropython.org/
+ *
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2017 Ayke van Laethem
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#include "machine_i2s.h"
+#include "py/runtime.h"
+#include "py/mperrno.h"
+
+STATIC const machine_i2s_obj_t machine_i2s_obj_0 = {
+    { &machine_i2s_type },
+    .port = I2S_NUM_0,
+};
+
+STATIC const machine_i2s_obj_t machine_i2s_obj_1 = {
+    { &machine_i2s_type },
+    .port = I2S_NUM_1,
+};
+
+STATIC void machine_i2s_obj_init_helper(const machine_i2s_obj_t *self, size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
+    enum { ARG_bclk, ARG_ws, ARG_data_out, ARG_data_in, ARG_samplerate, ARG_bitdepth };
+    static const mp_arg_t allowed_args[] = {
+        { MP_QSTR_bclk, MP_ARG_REQUIRED | MP_ARG_INT },
+        { MP_QSTR_ws, MP_ARG_REQUIRED | MP_ARG_INT },
+        { MP_QSTR_data_out, MP_ARG_REQUIRED | MP_ARG_INT },
+        { MP_QSTR_data_in, MP_ARG_REQUIRED | MP_ARG_INT },
+        { MP_QSTR_samplerate, MP_ARG_KW_ONLY | MP_ARG_INT, {.u_int = 48000} },
+        { MP_QSTR_bitdepth, MP_ARG_KW_ONLY | MP_ARG_INT, {.u_int = 16} },
+    };
+    mp_arg_val_t args[MP_ARRAY_SIZE(allowed_args)];
+    mp_arg_parse_all(n_args, pos_args, kw_args, MP_ARRAY_SIZE(allowed_args), allowed_args, args);
+
+    i2s_config_t config = {
+        .mode = I2S_MODE_MASTER | I2S_MODE_TX,
+        .sample_rate = args[ARG_samplerate].u_int,
+        .bits_per_sample = args[ARG_bitdepth].u_int,
+        .channel_format = I2S_CHANNEL_FMT_RIGHT_LEFT,
+        .communication_format = I2S_COMM_FORMAT_I2S | I2S_COMM_FORMAT_I2S_MSB,
+        .intr_alloc_flags = ESP_INTR_FLAG_LEVEL1,
+        .dma_buf_count = 8,
+        .dma_buf_len = 64,
+        .use_apll = 0,
+    };
+    if (i2s_driver_install(self->port, &config, 0, NULL) != ESP_OK) {
+        mp_raise_ValueError("I2S: failed to enable");
+    }
+
+    i2s_pin_config_t pin_config = {
+        .bck_io_num = args[ARG_bclk].u_int,
+        .ws_io_num = args[ARG_ws].u_int,
+        .data_out_num = args[ARG_data_out].u_int,
+        .data_in_num = args[ARG_data_in].u_int,
+    };
+    if (i2s_set_pin(self->port, &pin_config) != ESP_OK) {
+        i2s_driver_uninstall(self->port);
+        mp_raise_ValueError("I2S: failed to set pins in");
+    }
+}
+
+STATIC mp_obj_t machine_i2s_obj_init(size_t n_args, const mp_obj_t *args, mp_map_t *kw_args) {
+    machine_i2s_obj_init_helper(args[0], n_args - 1, args + 1, kw_args);
+    return mp_const_none;
+}
+MP_DEFINE_CONST_FUN_OBJ_KW(machine_i2s_init_obj, 1, machine_i2s_obj_init);
+
+STATIC mp_obj_t machine_i2s_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *args) {
+    mp_int_t id = 0;
+    if (n_args > 0) {
+        id = mp_obj_get_int(args[0]);
+        n_args--;
+        args++;
+    }
+    const machine_i2s_obj_t *self;
+    if (id == 0) {
+        self = &machine_i2s_obj_0;
+    } else if (id == 1) {
+        self = &machine_i2s_obj_1;
+    } else {
+        mp_raise_ValueError("invalid I2S peripheral");
+    }
+    mp_map_t kw_args;
+    mp_map_init_fixed_table(&kw_args, n_kw, args + n_args);
+    machine_i2s_obj_init_helper(self, n_args, args, &kw_args);
+    return (machine_i2s_obj_t*)self; // discard const
+}
+
+STATIC mp_obj_t machine_i2s_obj_deinit(mp_obj_t self_in) {
+    const machine_i2s_obj_t *self = MP_OBJ_TO_PTR(self_in);
+    i2s_driver_uninstall(self->port);
+    return mp_const_none;
+}
+MP_DEFINE_CONST_FUN_OBJ_1(machine_i2s_deinit_obj, machine_i2s_obj_deinit);
+
+STATIC mp_obj_t machine_i2s_obj_write(mp_obj_t self_in, mp_obj_t buf_in) {
+    const machine_i2s_obj_t *self = MP_OBJ_TO_PTR(self_in);
+
+    mp_buffer_info_t bufinfo;
+    mp_get_buffer_raise(buf_in, &bufinfo, MP_BUFFER_READ);
+
+    if (i2s_write_bytes(self->port, bufinfo.buf, bufinfo.len, portMAX_DELAY) == ESP_FAIL) {
+        mp_raise_OSError(MP_EIO);
+    }
+    return mp_const_none;
+}
+MP_DEFINE_CONST_FUN_OBJ_2(machine_i2s_write_obj, machine_i2s_obj_write);
+
+STATIC const mp_rom_map_elem_t machine_i2s_locals_dict_table[] = {
+    { MP_ROM_QSTR(MP_QSTR_init), MP_ROM_PTR(&machine_i2s_init_obj) },
+    { MP_ROM_QSTR(MP_QSTR_deinit), MP_ROM_PTR(&machine_i2s_deinit_obj) },
+    { MP_ROM_QSTR(MP_QSTR_write), MP_ROM_PTR(&machine_i2s_write_obj) },
+};
+
+STATIC MP_DEFINE_CONST_DICT(machine_i2s_locals_dict, machine_i2s_locals_dict_table);
+
+const mp_obj_type_t machine_i2s_type = {
+    { &mp_type_type },
+    .name = MP_QSTR_I2S,
+    .make_new = machine_i2s_make_new,
+    .locals_dict = (mp_obj_dict_t*)&machine_i2s_locals_dict,
+};

--- a/ports/esp32/machine_i2s.h
+++ b/ports/esp32/machine_i2s.h
@@ -1,0 +1,40 @@
+/*
+ * This file is part of the MicroPython project, http://micropython.org/
+ *
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2017 Ayke van Laethem
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#ifndef MICROPY_INCLUDED_ESP32_MACHINE_I2S_H
+#define MICROPY_INCLUDED_ESP32_MACHINE_I2S_H
+
+#include "py/obj.h"
+#include "driver/i2s.h"
+
+typedef struct {
+    mp_obj_base_t base;
+    i2s_port_t port;
+} machine_i2s_obj_t;
+
+extern const mp_obj_type_t machine_i2s_type;
+
+#endif // MICROPY_INCLUDED_ESP32_MACHINE_I2S_H

--- a/ports/esp32/modmachine.c
+++ b/ports/esp32/modmachine.c
@@ -121,6 +121,7 @@ STATIC const mp_rom_map_elem_t machine_module_globals_table[] = {
     { MP_ROM_QSTR(MP_QSTR_ADC), MP_ROM_PTR(&machine_adc_type) },
     { MP_ROM_QSTR(MP_QSTR_DAC), MP_ROM_PTR(&machine_dac_type) },
     { MP_ROM_QSTR(MP_QSTR_I2C), MP_ROM_PTR(&machine_i2c_type) },
+    { MP_ROM_QSTR(MP_QSTR_I2S), MP_ROM_PTR(&machine_i2s_type) },
     { MP_ROM_QSTR(MP_QSTR_PWM), MP_ROM_PTR(&machine_pwm_type) },
     { MP_ROM_QSTR(MP_QSTR_SPI), MP_ROM_PTR(&mp_machine_soft_spi_type) },
     { MP_ROM_QSTR(MP_QSTR_UART), MP_ROM_PTR(&machine_uart_type) },

--- a/ports/esp32/modmachine.h
+++ b/ports/esp32/modmachine.h
@@ -11,6 +11,7 @@ extern const mp_obj_type_t machine_adc_type;
 extern const mp_obj_type_t machine_dac_type;
 extern const mp_obj_type_t machine_pwm_type;
 extern const mp_obj_type_t machine_hw_spi_type;
+extern const mp_obj_type_t machine_i2s_type;
 extern const mp_obj_type_t machine_uart_type;
 
 void machine_pins_init(void);


### PR DESCRIPTION
Implementation of hardware I2S for the ESP32.

This appears to be the first I2S implementation for MicroPython. I've followed the proposed [I2S `machine` API](https://github.com/micropython/micropython/wiki/Hardware-API#the-i2s-class) mostly, but did not follow it exactly. This is the current API / example code:

```python
import machine
i2s = machine.I2S([0,] bclk=4, ws=15, data_out=2, data_in=22, [samplerate=48000,] [bitdepth=16])
buffer = ... # generate sine wave or something
while True:
    i2s.write(buffer)

# also implemented
i2s.deinit()
i2s.init(...) # throws an error if initialized already
```

Not yet implemented, mostly due to lacking hardware:

 * communication format, e.g. MSB/LSB.
 * clock: the ESP32 has an APLL clock, but I'm not sure what it's purpose is
 * callbacks (for now, `i2s.write()` blocks if the buffer is full)
 * reading from the I2S bus
 * not setting the `data_in` pin (not sure if this is possible)
 * [change parameters](https://esp-idf.readthedocs.io/en/latest/api-reference/peripherals/i2s.html#_CPPv211i2s_set_clk10i2s_port_t8uint32_t21i2s_bits_per_sample_t13i2s_channel_t)
 * stop/start (without deinit) - by default it keeps looping existing data if the buffer isn't filled fast enough
 * internal ADC

Which of these (if any) should be implemented before it can be merged?

Documentation: https://esp-idf.readthedocs.io/en/latest/api-reference/peripherals/i2s.html