### PR TITLE
py/nlr: Factor out common NLR code to generic functions.

### DIFF
--- a/ports/qemu-arm/test_main.c
+++ b/ports/qemu-arm/test_main.c
@@ -3,6 +3,7 @@
 #include <stdio.h>
 #include <string.h>
 #include <malloc.h>
+#include <setjmp.h>
 
 #include "py/obj.h"
 #include "py/compile.h"

--- a/py/nlr.c
+++ b/py/nlr.c
@@ -35,11 +35,15 @@
 #define MP_NLR_RESTORE_PYSTACK(nlr_buf) (void)nlr_buf
 #endif
 
+#if !MICROPY_NLR_SETJMP
+// When not using setjmp, nlr_push_tail is called from inline asm so needs special care
 #if MICROPY_NLR_X86 && (defined(_WIN32) || defined(__CYGWIN__))
 // On these 32-bit platforms make sure nlr_push_tail doesn't have a leading underscore
 unsigned int nlr_push_tail(nlr_buf_t *nlr) asm("nlr_push_tail");
 #else
+// LTO can't see inside inline asm functions so explicitly mark nlr_push_tail as used
 __attribute__((used)) unsigned int nlr_push_tail(nlr_buf_t *nlr);
+#endif
 #endif
 
 unsigned int nlr_push_tail(nlr_buf_t *nlr) {

--- a/py/nlr.c
+++ b/py/nlr.c
@@ -35,17 +35,12 @@
 #define MP_NLR_RESTORE_PYSTACK(nlr_buf) (void)nlr_buf
 #endif
 
-#if defined(_WIN32) || defined(__CYGWIN__)
-#define NLR_OS_WINDOWS 1
+#if MICROPY_NLR_X86 && (defined(_WIN32) || defined(__CYGWIN__))
+// On these 32-bit platforms make sure nlr_push_tail doesn't have a leading underscore
+unsigned int nlr_push_tail(nlr_buf_t *nlr) asm("nlr_push_tail");
 #else
-#define NLR_OS_WINDOWS 0
-#endif
-
-//#if NLR_OS_WINDOWS
-//unsigned int nlr_push_tail(nlr_buf_t *nlr) asm("nlr_push_tail");
-//#else
 __attribute__((used)) unsigned int nlr_push_tail(nlr_buf_t *nlr);
-//#endif
+#endif
 
 unsigned int nlr_push_tail(nlr_buf_t *nlr) {
     nlr_buf_t **top = &MP_STATE_THREAD(nlr_top);

--- a/py/nlr.c
+++ b/py/nlr.c
@@ -41,11 +41,11 @@
 #define NLR_OS_WINDOWS 0
 #endif
 
-#if NLR_OS_WINDOWS
-unsigned int nlr_push_tail(nlr_buf_t *nlr) asm("nlr_push_tail");
-#else
+//#if NLR_OS_WINDOWS
+//unsigned int nlr_push_tail(nlr_buf_t *nlr) asm("nlr_push_tail");
+//#else
 __attribute__((used)) unsigned int nlr_push_tail(nlr_buf_t *nlr);
-#endif
+//#endif
 
 unsigned int nlr_push_tail(nlr_buf_t *nlr) {
     nlr_buf_t **top = &MP_STATE_THREAD(nlr_top);

--- a/py/nlr.c
+++ b/py/nlr.c
@@ -1,0 +1,75 @@
+/*
+ * This file is part of the MicroPython project, http://micropython.org/
+ *
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2013-2017 Damien P. George
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#include "py/mpstate.h"
+
+// Helper macros to save/restore the pystack state
+#if MICROPY_ENABLE_PYSTACK
+#define MP_NLR_SAVE_PYSTACK(nlr_buf) (nlr_buf)->pystack = MP_STATE_THREAD(pystack_cur)
+#define MP_NLR_RESTORE_PYSTACK(nlr_buf) MP_STATE_THREAD(pystack_cur) = (nlr_buf)->pystack
+#else
+#define MP_NLR_SAVE_PYSTACK(nlr_buf) (void)nlr_buf
+#define MP_NLR_RESTORE_PYSTACK(nlr_buf) (void)nlr_buf
+#endif
+
+#if defined(_WIN32) || defined(__CYGWIN__)
+#define NLR_OS_WINDOWS 1
+#else
+#define NLR_OS_WINDOWS 0
+#endif
+
+#if NLR_OS_WINDOWS
+unsigned int nlr_push_tail(nlr_buf_t *nlr) asm("nlr_push_tail");
+#else
+__attribute__((used)) unsigned int nlr_push_tail(nlr_buf_t *nlr);
+#endif
+
+unsigned int nlr_push_tail(nlr_buf_t *nlr) {
+    nlr_buf_t **top = &MP_STATE_THREAD(nlr_top);
+    nlr->prev = *top;
+    MP_NLR_SAVE_PYSTACK(nlr);
+    *top = nlr;
+    return 0; // normal return
+}
+
+void nlr_pop(void) {
+    nlr_buf_t **top = &MP_STATE_THREAD(nlr_top);
+    *top = (*top)->prev;
+}
+
+NORETURN void nlr_jump(void *val) {
+    nlr_buf_t **top_ptr = &MP_STATE_THREAD(nlr_top);
+    nlr_buf_t *top = *top_ptr;
+    if (top == NULL) {
+        nlr_jump_fail(val);
+    }
+
+    top->ret_val = val;
+    MP_NLR_RESTORE_PYSTACK(top);
+    *top_ptr = top->prev;
+
+    nlr_jump_tail(top);
+}

--- a/py/nlr.h
+++ b/py/nlr.h
@@ -30,29 +30,29 @@
 // exception handling, basically a stack of setjmp/longjmp buffers
 
 #include <limits.h>
-#include <setjmp.h>
 #include <assert.h>
 
 #include "py/mpconfig.h"
 
-typedef struct _nlr_buf_t nlr_buf_t;
-struct _nlr_buf_t {
-    // the entries here must all be machine word size
-    nlr_buf_t *prev;
-    void *ret_val; // always a concrete object (an exception instance)
-#if !defined(MICROPY_NLR_SETJMP) || !MICROPY_NLR_SETJMP
+// If MICROPY_NLR_SETJMP is not enabled then auto-detect the machine arch
+// Allow a port to set MICROPY_NLR_NUM_REGS to define their own implementation
+#if !MICROPY_NLR_SETJMP && !defined(MICROPY_NLR_NUM_REGS)
 #if defined(__i386__)
-    void *regs[6];
+    #define MICROPY_NLR_X86 (1)
+    #define MICROPY_NLR_NUM_REGS (6)
 #elif defined(__x86_64__)
-  #if defined(__CYGWIN__)
-    void *regs[12];
-  #else
-    void *regs[8];
-  #endif
+    #define MICROPY_NLR_X64 (1)
+    #if defined(__CYGWIN__)
+        #define MICROPY_NLR_NUM_REGS (12)
+    #else
+        #define MICROPY_NLR_NUM_REGS (8)
+    #endif
 #elif defined(__thumb2__) || defined(__thumb__) || defined(__arm__)
-    void *regs[10];
+    #define MICROPY_NLR_THUMB (1)
+    #define MICROPY_NLR_NUM_REGS (10)
 #elif defined(__xtensa__)
-    void *regs[10];
+    #define MICROPY_NLR_XTENSA (1)
+    #define MICROPY_NLR_NUM_REGS (10)
 #else
     #define MICROPY_NLR_SETJMP (1)
     //#warning "No native NLR support for this arch, using setjmp implementation"
@@ -60,41 +60,39 @@ struct _nlr_buf_t {
 #endif
 
 #if MICROPY_NLR_SETJMP
-    jmp_buf jmpbuf;
+#include <setjmp.h>
 #endif
+
+typedef struct _nlr_buf_t nlr_buf_t;
+struct _nlr_buf_t {
+    // the entries here must all be machine word size
+    nlr_buf_t *prev;
+    void *ret_val; // always a concrete object (an exception instance)
+
+    #if MICROPY_NLR_SETJMP
+    jmp_buf jmpbuf;
+    #else
+    void *regs[MICROPY_NLR_NUM_REGS];
+    #endif
 
     #if MICROPY_ENABLE_PYSTACK
     void *pystack;
     #endif
 };
 
-// Helper macros to save/restore the pystack state
-#if MICROPY_ENABLE_PYSTACK
-#define MP_NLR_SAVE_PYSTACK(nlr_buf) (nlr_buf)->pystack = MP_STATE_THREAD(pystack_cur)
-#define MP_NLR_RESTORE_PYSTACK(nlr_buf) MP_STATE_THREAD(pystack_cur) = (nlr_buf)->pystack
-#else
-#define MP_NLR_SAVE_PYSTACK(nlr_buf) (void)nlr_buf
-#define MP_NLR_RESTORE_PYSTACK(nlr_buf) (void)nlr_buf
-#endif
-
 #if MICROPY_NLR_SETJMP
-#include "py/mpstate.h"
-
-NORETURN void nlr_setjmp_jump(void *val);
 // nlr_push() must be defined as a macro, because "The stack context will be
 // invalidated if the function which called setjmp() returns."
-#define nlr_push(buf) ( \
-    (buf)->prev = MP_STATE_THREAD(nlr_top), \
-    MP_NLR_SAVE_PYSTACK(buf), \
-    MP_STATE_THREAD(nlr_top) = (buf), \
-    setjmp((buf)->jmpbuf))
-#define nlr_pop() { MP_STATE_THREAD(nlr_top) = MP_STATE_THREAD(nlr_top)->prev; }
-#define nlr_jump(val) nlr_setjmp_jump(val)
+// For this case it is safe to call nlr_push_tail() first.
+#define nlr_push(buf) (nlr_push_tail(buf), setjmp((buf)->jmpbuf))
 #else
 unsigned int nlr_push(nlr_buf_t *);
+#endif
+
+unsigned int nlr_push_tail(nlr_buf_t *top);
 void nlr_pop(void);
 NORETURN void nlr_jump(void *val);
-#endif
+NORETURN void nlr_jump_tail(nlr_buf_t *top);
 
 // This must be implemented by a port.  It's called by nlr_jump
 // if no nlr buf has been pushed.  It must not return, but rather
@@ -123,7 +121,6 @@ NORETURN void nlr_jump_fail(void *val);
 /*
 #define nlr_push(val) \
     printf("nlr_push: before: nlr_top=%p, val=%p\n", MP_STATE_THREAD(nlr_top), val),assert(MP_STATE_THREAD(nlr_top) != val),nlr_push(val)
-#endif
 */
 #endif
 

--- a/py/nlrsetjmp.c
+++ b/py/nlrsetjmp.c
@@ -28,15 +28,7 @@
 
 #if MICROPY_NLR_SETJMP
 
-void nlr_setjmp_jump(void *val) {
-    nlr_buf_t **top_ptr = &MP_STATE_THREAD(nlr_top);
-    nlr_buf_t *top = *top_ptr;
-    if (top == NULL) {
-        nlr_jump_fail(val);
-    }
-    top->ret_val = val;
-    MP_NLR_RESTORE_PYSTACK(top);
-    *top_ptr = top->prev;
+NORETURN void nlr_jump_tail(nlr_buf_t *top) {
     longjmp(top->jmpbuf, 1);
 }
 

--- a/py/nlrthumb.c
+++ b/py/nlrthumb.c
@@ -26,7 +26,7 @@
 
 #include "py/mpstate.h"
 
-#if (!defined(MICROPY_NLR_SETJMP) || !MICROPY_NLR_SETJMP) && (defined(__thumb2__) || defined(__thumb__) || defined(__arm__))
+#if MICROPY_NLR_THUMB
 
 #undef nlr_push
 
@@ -37,7 +37,6 @@
 //      r4-r11, r13=sp
 
 __attribute__((naked)) unsigned int nlr_push(nlr_buf_t *nlr) {
-
     __asm volatile (
     "str    r4, [r0, #12]       \n" // store r4 into nlr_buf
     "str    r5, [r0, #16]       \n" // store r5 into nlr_buf
@@ -75,36 +74,10 @@ __attribute__((naked)) unsigned int nlr_push(nlr_buf_t *nlr) {
     "b      nlr_push_tail       \n" // do the rest in C
 #endif
     );
-
-    return 0; // needed to silence compiler warning
 }
 
-__attribute__((used)) unsigned int nlr_push_tail(nlr_buf_t *nlr) {
-    nlr_buf_t **top = &MP_STATE_THREAD(nlr_top);
-    nlr->prev = *top;
-    MP_NLR_SAVE_PYSTACK(nlr);
-    *top = nlr;
-    return 0; // normal return
-}
-
-void nlr_pop(void) {
-    nlr_buf_t **top = &MP_STATE_THREAD(nlr_top);
-    *top = (*top)->prev;
-}
-
-NORETURN __attribute__((naked)) void nlr_jump(void *val) {
-    nlr_buf_t **top_ptr = &MP_STATE_THREAD(nlr_top);
-    nlr_buf_t *top = *top_ptr;
-    if (top == NULL) {
-        nlr_jump_fail(val);
-    }
-
-    top->ret_val = val;
-    MP_NLR_RESTORE_PYSTACK(top);
-    *top_ptr = top->prev;
-
+NORETURN __attribute__((naked)) void nlr_jump_tail(nlr_buf_t *top) {
     __asm volatile (
-    "mov    r0, %0              \n" // r0 points to nlr_buf
     "ldr    r4, [r0, #12]       \n" // load r4 from nlr_buf
     "ldr    r5, [r0, #16]       \n" // load r5 from nlr_buf
     "ldr    r6, [r0, #20]       \n" // load r6 from nlr_buf
@@ -133,12 +106,7 @@ NORETURN __attribute__((naked)) void nlr_jump(void *val) {
 #endif
     "movs   r0, #1              \n" // return 1, non-local return
     "bx     lr                  \n" // return
-    :                               // output operands
-    : "r"(top)                      // input operands
-    :                               // clobbered registers
     );
-
-    for (;;); // needed to silence compiler warning
 }
 
-#endif // (!defined(MICROPY_NLR_SETJMP) || !MICROPY_NLR_SETJMP) && (defined(__thumb2__) || defined(__thumb__) || defined(__arm__))
+#endif // MICROPY_NLR_THUMB

--- a/py/nlrxtensa.c
+++ b/py/nlrxtensa.c
@@ -26,7 +26,7 @@
 
 #include "py/mpstate.h"
 
-#if !MICROPY_NLR_SETJMP && defined(__xtensa__)
+#if MICROPY_NLR_XTENSA
 
 #undef nlr_push
 
@@ -37,6 +37,7 @@
 //  a3-a7 = rest of args
 
 unsigned int nlr_push(nlr_buf_t *nlr) {
+    (void)nlr;
 
     __asm volatile (
     "s32i.n  a0, a2, 8          \n" // save regs...
@@ -55,32 +56,10 @@ unsigned int nlr_push(nlr_buf_t *nlr) {
     return 0; // needed to silence compiler warning
 }
 
-__attribute__((used)) unsigned int nlr_push_tail(nlr_buf_t *nlr) {
-    nlr_buf_t **top = &MP_STATE_THREAD(nlr_top);
-    nlr->prev = *top;
-    MP_NLR_SAVE_PYSTACK(nlr);
-    *top = nlr;
-    return 0; // normal return
-}
-
-void nlr_pop(void) {
-    nlr_buf_t **top = &MP_STATE_THREAD(nlr_top);
-    *top = (*top)->prev;
-}
-
-NORETURN void nlr_jump(void *val) {
-    nlr_buf_t **top_ptr = &MP_STATE_THREAD(nlr_top);
-    nlr_buf_t *top = *top_ptr;
-    if (top == NULL) {
-        nlr_jump_fail(val);
-    }
-
-    top->ret_val = val;
-    MP_NLR_RESTORE_PYSTACK(top);
-    *top_ptr = top->prev;
+NORETURN void nlr_jump_tail(nlr_buf_t *top) {
+    (void)top;
 
     __asm volatile (
-    "mov.n   a2, %0             \n" // a2 points to nlr_buf
     "l32i.n  a0, a2, 8          \n" // restore regs...
     "l32i.n  a1, a2, 12         \n"
     "l32i.n  a8, a2, 16         \n"
@@ -93,12 +72,9 @@ NORETURN void nlr_jump(void *val) {
     "l32i.n  a15, a2, 44        \n"
     "movi.n a2, 1               \n" // return 1, non-local return
     "ret.n                      \n" // return
-    :                               // output operands
-    : "r"(top)                      // input operands
-    :                               // clobbered registers
     );
 
     for (;;); // needed to silence compiler warning
 }
 
-#endif // !MICROPY_NLR_SETJMP && defined(__xtensa__)
+#endif // MICROPY_NLR_XTENSA

--- a/py/py.mk
+++ b/py/py.mk
@@ -103,6 +103,7 @@ endif
 # py object files
 PY_O_BASENAME = \
 	mpstate.o \
+	nlr.o \
 	nlrx86.o \
 	nlrx64.o \
 	nlrthumb.o \


### PR DESCRIPTION
Each NLR implementation (Thumb, x86, x64, xtensa, setjmp) duplicates a lot
of the NLR code, specifically that dealing with pushing and popping the NLR
pointer to maintain the linked-list of NLR buffers.  This patch factors all
of that code out of the specific implementations into generic functions in
nlr.c.  This eliminates duplicated code.

The factoring also allows to make the machine-specific NLR code pure
assembler code, thus allowing nlrthumb.c to use naked function attributes
in the correct way (naked functions can only have basic inline assembler
code in them).

There is a small overhead introduced (typically 1 machine instruction)
because now the generic nlr_jump() must call nlr_jump_tail() rather than
them being one combined function.

Should fix #3484