### PR TITLE
Port may specify a subset of UART's to run in half-duplex (all the time)

### DIFF
--- a/ports/stm32/mpconfigboard_common.h
+++ b/ports/stm32/mpconfigboard_common.h
@@ -97,6 +97,11 @@
 #define MICROPY_HW_HAS_LCD (0)
 #endif
 
+// Defines which UART ports are to be half-duplex
+#ifndef MICROPY_HW_UARTn_IS_HALF_DUPLEX
+#define MICROPY_HW_UARTn_IS_HALF_DUPLEX(n)    (0)
+#endif
+
 /*****************************************************************************/
 // General configuration
 

--- a/ports/stm32/uart.c
+++ b/ports/stm32/uart.c
@@ -314,8 +314,13 @@ STATIC bool uart_init2(pyb_uart_obj_t *uart_obj) {
     uart_obj->irqn = irqn;
     uart_obj->uart.Instance = UARTx;
 
-    // init UARTx
-    HAL_UART_Init(&uart_obj->uart);
+    if(MICROPY_HW_UARTn_IS_HALF_DUPLEX(uart_obj->uart_id)) {
+        // init in half-duplex mode
+        HAL_HalfDuplex_Init(&uart_obj->uart);
+    } else {
+        // init UARTx
+        HAL_UART_Init(&uart_obj->uart);
+    }
 
     uart_obj->is_enabled = true;
 
@@ -553,6 +558,9 @@ STATIC void pyb_uart_print(const mp_print_t *print, mp_obj_t self_in, mp_print_k
             if (self->uart.Init.HwFlowCtl & UART_HWCONTROL_CTS) {
                 mp_printf(print, "CTS");
             }
+        }
+        if(MICROPY_HW_UARTn_IS_HALF_DUPLEX(self->uart_id)) {
+            mp_printf(print, ", half=1");
         }
         mp_printf(print, ", stop=%u, timeout=%u, timeout_char=%u, read_buf_len=%u)",
             self->uart.Init.StopBits == UART_STOPBITS_1 ? 1 : 2,


### PR DESCRIPTION
- introduce new port config value, a macro: `MICROPY_HW_UARTn_IS_HALF_DUPLEX(n)`
- if true for a specific port, we call a different HAL init function that configures HALF duplex mode

`ports/stm32/mpconfigport.h`: provide a default value (False) for the macro
`ports/stm32/uart.c`: implement the change and provide readback

This change should be have no size impact to boards not using this feature. I didn't make it runtime configurable, but that could be a useful addition for some users.