### PR TITLE
If MICROPY_HW_SPIn_MISO undefined, do not claim corresponding pin.

### DIFF
--- a/ports/stm32/spi.c
+++ b/ports/stm32/spi.c
@@ -243,8 +243,7 @@ STATIC void spi_set_params(SPI_HandleTypeDef *spi, uint32_t prescale, int32_t ba
 // TODO allow to take a list of pins to use
 void spi_init(SPI_HandleTypeDef *spi, bool enable_nss_pin) {
     const pyb_spi_obj_t *self;
-    const pin_obj_t *pins[4];
-    pins[0] = NULL;
+    const pin_obj_t *pins[4] = { NULL, NULL, NULL, NULL };
 
     if (0) {
     #if defined(MICROPY_HW_SPI1_SCK)
@@ -339,7 +338,8 @@ void spi_init(SPI_HandleTypeDef *spi, bool enable_nss_pin) {
     // init the GPIO lines
     uint32_t mode = MP_HAL_PIN_MODE_ALT;
     uint32_t pull = spi->Init.CLKPolarity == SPI_POLARITY_LOW ? MP_HAL_PIN_PULL_DOWN : MP_HAL_PIN_PULL_UP;
-    for (uint i = (enable_nss_pin && pins[0] ? 0 : 1); i < 4; i++) {
+    for (uint i = (enable_nss_pin ? 0 : 1); i < 4; i++) {
+        if(!pins[i]) continue;
         mp_hal_pin_config_alt(pins[i], mode, pull, AF_FN_SPI, (self - &pyb_spi_obj[0]) + 1);
     }
 

--- a/ports/stm32/spi.c
+++ b/ports/stm32/spi.c
@@ -254,7 +254,9 @@ void spi_init(SPI_HandleTypeDef *spi, bool enable_nss_pin) {
         pins[0] = &MICROPY_HW_SPI1_NSS;
         #endif
         pins[1] = &MICROPY_HW_SPI1_SCK;
+        #if defined(MICROPY_HW_SPI1_MISO)
         pins[2] = &MICROPY_HW_SPI1_MISO;
+        #endif
         pins[3] = &MICROPY_HW_SPI1_MOSI;
         // enable the SPI clock
         __SPI1_CLK_ENABLE();
@@ -266,7 +268,9 @@ void spi_init(SPI_HandleTypeDef *spi, bool enable_nss_pin) {
         pins[0] = &MICROPY_HW_SPI2_NSS;
         #endif
         pins[1] = &MICROPY_HW_SPI2_SCK;
+        #if defined(MICROPY_HW_SPI2_MISO)
         pins[2] = &MICROPY_HW_SPI2_MISO;
+        #endif
         pins[3] = &MICROPY_HW_SPI2_MOSI;
         // enable the SPI clock
         __SPI2_CLK_ENABLE();
@@ -278,7 +282,9 @@ void spi_init(SPI_HandleTypeDef *spi, bool enable_nss_pin) {
         pins[0] = &MICROPY_HW_SPI3_NSS;
         #endif
         pins[1] = &MICROPY_HW_SPI3_SCK;
+        #if defined(MICROPY_HW_SPI3_MISO)
         pins[2] = &MICROPY_HW_SPI3_MISO;
+        #endif
         pins[3] = &MICROPY_HW_SPI3_MOSI;
         // enable the SPI clock
         __SPI3_CLK_ENABLE();
@@ -290,7 +296,9 @@ void spi_init(SPI_HandleTypeDef *spi, bool enable_nss_pin) {
         pins[0] = &MICROPY_HW_SPI4_NSS;
         #endif
         pins[1] = &MICROPY_HW_SPI4_SCK;
+        #if defined(MICROPY_HW_SPI4_MISO)
         pins[2] = &MICROPY_HW_SPI4_MISO;
+        #endif
         pins[3] = &MICROPY_HW_SPI4_MOSI;
         // enable the SPI clock
         __SPI4_CLK_ENABLE();
@@ -302,7 +310,9 @@ void spi_init(SPI_HandleTypeDef *spi, bool enable_nss_pin) {
         pins[0] = &MICROPY_HW_SPI5_NSS;
         #endif
         pins[1] = &MICROPY_HW_SPI5_SCK;
+        #if defined(MICROPY_HW_SPI5_MISO)
         pins[2] = &MICROPY_HW_SPI5_MISO;
+        #endif
         pins[3] = &MICROPY_HW_SPI5_MOSI;
         // enable the SPI clock
         __SPI5_CLK_ENABLE();
@@ -314,7 +324,9 @@ void spi_init(SPI_HandleTypeDef *spi, bool enable_nss_pin) {
         pins[0] = &MICROPY_HW_SPI6_NSS;
         #endif
         pins[1] = &MICROPY_HW_SPI6_SCK;
+        #if defined(MICROPY_HW_SPI6_MISO)
         pins[2] = &MICROPY_HW_SPI6_MISO;
+        #endif
         pins[3] = &MICROPY_HW_SPI6_MOSI;
         // enable the SPI clock
         __SPI6_CLK_ENABLE();


### PR DESCRIPTION
This allows boards to re-use the MOSI pin for other purposes. 