### PR TITLE
Correct compiler error (unused static) if no I2C ports defined by port

### DIFF
--- a/ports/stm32/i2c.c
+++ b/ports/stm32/i2c.c
@@ -100,7 +100,10 @@ I2C_HandleTypeDef I2CHandle3 = {.Instance = NULL};
 I2C_HandleTypeDef I2CHandle4 = {.Instance = NULL};
 #endif
 
+#if defined(MICROPY_HW_I2C1_SCL) || defined(MICROPY_HW_I2C2_SCL) \
+    || defined(MICROPY_HW_I2C3_SCL) || defined(MICROPY_HW_I2C3_SCL)
 STATIC bool pyb_i2c_use_dma[4];
+#endif
 
 const pyb_i2c_obj_t pyb_i2c_obj[] = {
     #if defined(MICROPY_HW_I2C1_SCL)


### PR DESCRIPTION
Not sure if this patch is a good idea, but I needed to be able to build on my board with no I2C bus.

I would prefer to remove all the I2C code using a single define, but there wasn't such a define ready to go, and that change would impact more files.