### PR TITLE
Move to correct capitalization of HAL_SD_CardStateTypedef (not TypeDef).

### DIFF
--- a/ports/stm32/sdcard.c
+++ b/ports/stm32/sdcard.c
@@ -251,7 +251,7 @@ STATIC HAL_StatusTypeDef sdcard_wait_finished(SD_HandleTypeDef *sd, uint32_t tim
     }
     // Wait for SD card to complete the operation
     for (;;) {
-        HAL_SD_CardStateTypeDef state = HAL_SD_GetCardState(sd);
+        HAL_SD_CardStateTypedef state = HAL_SD_GetCardState(sd);
         if (state == HAL_SD_CARD_TRANSFER) {
             return HAL_OK;
         }


### PR DESCRIPTION
- stm32lib has fixes in `stm32_hal_legacy.h` for MCU series other than STM32L4
- althoght only needed for L4, this change is harmless and forward-looking for all the variants.