### PR TITLE
py/nlr: Fix nlr functions for ports built with gcc on Windows

### DIFF
--- a/ports/windows/Makefile
+++ b/ports/windows/Makefile
@@ -50,10 +50,6 @@ CFLAGS_MOD += -DMICROPY_USE_READLINE=2
 LDFLAGS_MOD += -lreadline
 endif
 
-ifeq ($(CROSS_COMPILE),x86_64-w64-mingw32-)
-CFLAGS_MOD += -DMICROPY_NLR_SETJMP=1
-endif
-
 LIB += -lws2_32
 
 # List of sources for qstr extraction

--- a/py/nlr.c
+++ b/py/nlr.c
@@ -37,7 +37,7 @@
 
 #if !MICROPY_NLR_SETJMP
 // When not using setjmp, nlr_push_tail is called from inline asm so needs special care
-#if MICROPY_NLR_X86 && (defined(_WIN32) || defined(__CYGWIN__))
+#if MICROPY_NLR_X86 && MICROPY_NLR_OS_WINDOWS
 // On these 32-bit platforms make sure nlr_push_tail doesn't have a leading underscore
 unsigned int nlr_push_tail(nlr_buf_t *nlr) asm("nlr_push_tail");
 #else

--- a/py/nlr.h
+++ b/py/nlr.h
@@ -37,13 +37,20 @@
 // If MICROPY_NLR_SETJMP is not enabled then auto-detect the machine arch
 // Allow a port to set MICROPY_NLR_NUM_REGS to define their own implementation
 #if !MICROPY_NLR_SETJMP && !defined(MICROPY_NLR_NUM_REGS)
+// Registers used on Windows are different than for other archs so
+// everything nlr-related needs different treatment
+#if defined(_WIN32) || defined(__CYGWIN__)
+#define MICROPY_NLR_OS_WINDOWS 1
+#else
+#define MICROPY_NLR_OS_WINDOWS 0
+#endif
 #if defined(__i386__)
     #define MICROPY_NLR_X86 (1)
     #define MICROPY_NLR_NUM_REGS (6)
 #elif defined(__x86_64__)
     #define MICROPY_NLR_X64 (1)
-    #if defined(__CYGWIN__)
-        #define MICROPY_NLR_NUM_REGS (12)
+    #if MICROPY_NLR_OS_WINDOWS
+        #define MICROPY_NLR_NUM_REGS (10)
     #else
         #define MICROPY_NLR_NUM_REGS (8)
     #endif

--- a/py/nlrx64.c
+++ b/py/nlrx64.c
@@ -33,16 +33,10 @@
 // x86-64 callee-save registers are:
 //  rbx, rbp, rsp, r12, r13, r14, r15
 
-#if defined(_WIN32) || defined(__CYGWIN__)
-#define NLR_OS_WINDOWS 1
-#else
-#define NLR_OS_WINDOWS 0
-#endif
-
 unsigned int nlr_push(nlr_buf_t *nlr) {
     (void)nlr;
 
-    #if NLR_OS_WINDOWS
+    #if MICROPY_NLR_OS_WINDOWS
 
     __asm volatile (
     "movq   (%rsp), %rax        \n" // load return %rip
@@ -90,7 +84,7 @@ NORETURN void nlr_jump_tail(nlr_buf_t *top) {
     (void)top;
 
     __asm volatile (
-    #if NLR_OS_WINDOWS
+    #if MICROPY_NLR_OS_WINDOWS
     "movq   88(%rcx), %rsi      \n" // load saved %rsi
     "movq   80(%rcx), %rdi      \n" // load saved %rdr
     "movq   72(%rcx), %r15      \n" // load saved %r15

--- a/py/nlrx86.c
+++ b/py/nlrx86.c
@@ -62,6 +62,10 @@ NORETURN void nlr_jump_tail(nlr_buf_t *top) {
     (void)top;
 
     __asm volatile (
+    #if MICROPY_NLR_OS_WINDOWS
+    "pop    %ebp                \n" // undo function's prelude
+    "mov    4(%esp), %edx       \n" // load nlr_buf
+    #endif
     "mov    28(%edx), %esi      \n" // load saved %esi
     "mov    24(%edx), %edi      \n" // load saved %edi
     "mov    20(%edx), %ebx      \n" // load saved %ebx


### PR DESCRIPTION
This is a follow-up to commit [6a3a742] and makes the nlr functions work
for ports built with gcc and targetting Windows. The fix for 64bit is
simply setting MICROPY_NLR_NUM_REGS to the actual number of registers
used in nlrx64.c, namely 10 instead of 12. For the 32bit version the
argument needs to be loaded into EDX, it's not there because of the
difference in calling conventions,

Verified with:
- unix port built with gcc on Cygwin (i686-pc-cygwin-gcc and
  x86_64-pc-cygwin-gcc, version 6.4.0)
- windows port built with mingw-w64's gcc from Cygwin
 (i686-w64-mingw32-gcc and x86_64-w64-mingw32-gcc, version 6.4.0)
 and MSYS2 (like the ones on Cygwin but version 7.2.0)

Notes:
a) getting the unix port built with gcc on Cygwin is rather fiddly and I had to disable a bunch of features which don't compile, both in mpconfigport.mk and mpconfigport.h. For instance there is some discrepancy between those 2 for disabling frozen str/module which I disabled because mpy-cross doesn't seem to work properly; 32bit build:
```
MPY modules/upip.py
Traceback (most recent call last):
  File "modules/upip.py", line 1
SyntaxError: invalid syntax
make: *** [../../py/mkrules.mk:117: build/frozen_mpy/upip.mpy] Error 1
```
64bit build:
```
MPY modules/upip.py
make: *** [../../py/mkrules.mk:117: build/frozen_mpy/upip.mpy] Error 127
```

b) micropython doesn't run properly on the MSYS2 shell (while the same executable, built with gcc on MSYS2 does work on cmd.ex/powershell.exe). Starting it just gives a blank prompt without intro text. Removing __USE_MINGW_ANSI_STDIO from the Makefile fixes that, but then `isatty(0)` in main.c returns false so still no repl. Removing that as well does show the `>>>` prompt but does that a million times.
