### PR TITLE
esp32/network_lan: Zero config eth_config_t.

### DIFF
--- a/ports/esp32/network_lan.c
+++ b/ports/esp32/network_lan.c
@@ -26,6 +26,8 @@
  * THE SOFTWARE.
  */
 
+#include <string.h>
+
 #include "py/runtime.h"
 #include "py/mphal.h"
 
@@ -126,6 +128,7 @@ STATIC mp_obj_t get_lan(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_ar
     }
 
     eth_config_t config;
+    memset(&config, 0, sizeof(config));
 
     switch (args[ARG_phy_type].u_int) {
         case PHY_TLK110:


### PR DESCRIPTION
Some fields will have undefined data otherwise, possibly leading to problems later on.

I discovered this potential problem while working on https://github.com/espressif/esp-idf/pull/1378. I don't have the actual hardware to test it, though, but initializing `network.LAN` works.