### PR TITLE
tests/run-tests: Support ESP32.

### DIFF
--- a/tests/run-tests
+++ b/tests/run-tests
@@ -514,7 +514,7 @@ the last matching regex is used:
     cmd_parser.add_argument('files', nargs='*', help='input test files')
     args = cmd_parser.parse_args()
 
-    EXTERNAL_TARGETS = ('pyboard', 'wipy', 'esp8266', 'minimal')
+    EXTERNAL_TARGETS = ('pyboard', 'wipy', 'esp8266', 'esp32', 'minimal')
     if args.target == 'unix' or args.list_tests:
         pyb = None
     elif args.target in EXTERNAL_TARGETS:
@@ -529,7 +529,7 @@ the last matching regex is used:
             if args.target == 'pyboard':
                 # run pyboard tests
                 test_dirs = ('basics', 'micropython', 'float', 'misc', 'stress', 'extmod', 'pyb', 'pybnative', 'inlineasm')
-            elif args.target in ('esp8266', 'minimal'):
+            elif args.target in ('esp8266', 'esp32', 'minimal'):
                 test_dirs = ('basics', 'micropython', 'float', 'misc', 'extmod')
             elif args.target == 'wipy':
                 # run WiPy tests


### PR DESCRIPTION
Adding this device to the list of testable devices.

There is one test that crashes (`extmod/ussl_basic.py`), I haven't investigated why yet.