### PR TITLE
unix/Makefile: allow override of mpconfigport.mk

### DIFF
--- a/ports/unix/Makefile
+++ b/ports/unix/Makefile
@@ -1,4 +1,6 @@
 -include mpconfigport.mk
+MPCONFIGPORT_MK ?= mpconfigport.mk
+-include $(MPCONFIGPORT_MK)
 include ../../py/mkenv.mk
 
 FROZEN_DIR = scripts


### PR DESCRIPTION
I needed to make my own "board" version of Unix port, so I added this.