### PR TITLE
ports/stm32/modmachine.c: handle case of no MICROPY_PY_MACHINE_I2C

### DIFF
--- a/ports/stm32/modmachine.c
+++ b/ports/stm32/modmachine.c
@@ -558,7 +558,9 @@ STATIC const mp_rom_map_elem_t machine_module_globals_table[] = {
     { MP_ROM_QSTR(MP_QSTR_RTC),                 MP_ROM_PTR(&pyb_rtc_type) },
     { MP_ROM_QSTR(MP_QSTR_ADC),                 MP_ROM_PTR(&pyb_adc_type) },
 #endif
+#if MICROPY_PY_MACHINE_I2C
     { MP_ROM_QSTR(MP_QSTR_I2C),                 MP_ROM_PTR(&machine_i2c_type) },
+#endif
     { MP_ROM_QSTR(MP_QSTR_SPI),                 MP_ROM_PTR(&machine_hard_spi_type) },
     { MP_ROM_QSTR(MP_QSTR_UART),                MP_ROM_PTR(&pyb_uart_type) },
     { MP_ROM_QSTR(MP_QSTR_WDT),                 MP_ROM_PTR(&pyb_wdt_type) },


### PR DESCRIPTION
Without this fix, if `MICROPY_PY_MACHINE_I2C==0` then `machine_i2c_type` is undefined here.