### PR TITLE
windows: Add Appveyor CI builds for windows mingw port

### DIFF
--- a/ports/windows/.appveyor.yml
+++ b/ports/windows/.appveyor.yml
@@ -24,6 +24,26 @@ test_script:
 
     %MICROPY_CPYTHON3% run-tests
 
+# After the build/test phase for the MSVC build completes,
+# build and test with mingw-w64, release versions only.
+after_test:
+- ps: |
+    if ($env:configuration -eq 'Debug') {
+      return
+    }
+    $env:MSYSTEM = if ($platform -eq 'x86') {'MINGW32'} else {'MINGW64'}
+    $env:CHERE_INVOKING = 'enabled_from_arguments'
+    cd (Join-Path $env:APPVEYOR_BUILD_FOLDER 'ports/windows')
+    C:\msys64\usr\bin\bash.exe -l -c "make -B -j4 V=1"
+    if ($LASTEXITCODE -ne 0) {
+      throw "$env:MSYSTEM build exited with code $LASTEXITCODE"
+    }
+    cd (Join-Path $env:APPVEYOR_BUILD_FOLDER 'tests')
+    & $env:MICROPY_CPYTHON3 run-tests -e math_fun -e float2int_double -e float_parse -e math_domain_special
+    if ($LASTEXITCODE -ne 0) {
+      throw "$env:MSYSTEM tests exited with code $LASTEXITCODE"
+    }
+
 skip_tags: true
 
 deploy: off


### PR DESCRIPTION
Build and test 32bit and 64bit versions of the windows port using gcc
from mingw-w64. Note a bunch of tests which rely on floating point
math/printing have been disabled for now since they fail.