### PR TITLE
[esp8266/esp32] Add optional frozensetup call during inisetup for derivatives

### DIFF
--- a/ports/esp32/modules/inisetup.py
+++ b/ports/esp32/modules/inisetup.py
@@ -24,6 +24,16 @@ by firmware programming).
 """)
         time.sleep(3)
 
+def frozensetup():
+    # The "frozensetup" module may be frozen in the executable by
+    # derivatives to perform additional first-run setup without
+    # needing to modify core MicroPython code.
+    try:
+        import frozensetup
+    except ImportError:
+        return
+    frozensetup.setup()
+
 def setup():
     check_bootsec()
     print("Performing initial setup")
@@ -35,4 +45,5 @@ def setup():
         f.write("""\
 # This file is executed on every boot (including wake-boot from deepsleep)
 """)
+    frozensetup()
     return vfs

--- a/ports/esp8266/modules/inisetup.py
+++ b/ports/esp8266/modules/inisetup.py
@@ -32,6 +32,16 @@ programming).
 """ % (bdev.START_SEC, bdev.blocks))
         time.sleep(3)
 
+def frozensetup():
+    # The "frozensetup" module may be frozen in the executable by
+    # derivatives to perform additional first-run setup without
+    # needing to modify core MicroPython code.
+    try:
+        import frozensetup
+    except ImportError:
+        return
+    frozensetup.setup()
+
 def setup():
     check_bootsec()
     print("Performing initial setup")
@@ -49,4 +59,5 @@ import gc
 #webrepl.start()
 gc.collect()
 """)
+    frozensetup()
     return vfs


### PR DESCRIPTION
When building derivations of MicroPython containing additional frozen modules, there is no way to call a first-run setup function in a "clean" source way.  main.c has pyexec_frozen_module("_boot.py") which calls inisetup, which builds boot.py.  And even if you were to try to include main.py, it's called as pyexec_file(), not pyexec_frozen_module().  So the only way to extend a first-run setup is to either edit inisetup.py or add an additional pyexec_frozen_module() to main.c.

This patch makes the derivation process easier by having inisetup try to import frozensetup, and if it exists, call frozensetup.setup().  The derivation can then use this function to do first-run tasks, append to boot.py to perform every-run tasks, etc, etc.