### PR TITLE
adjust sys.platform for various C linkers

### DIFF
--- a/ports/unix/mpconfigport.h
+++ b/ports/unix/mpconfigport.h
@@ -92,7 +92,11 @@
 #if defined(__APPLE__) && defined(__MACH__)
     #define MICROPY_PY_SYS_PLATFORM  "darwin"
 #else
-    #define MICROPY_PY_SYS_PLATFORM  "linux"
+    #ifdef __ANDROID__
+        #define MICROPY_PY_SYS_PLATFORM  "android"
+    #else
+        #define MICROPY_PY_SYS_PLATFORM  "linux"
+    #endif
 #endif
 #define MICROPY_PY_SYS_MAXSIZE      (1)
 #define MICROPY_PY_SYS_STDFILES     (1)

--- a/ports/unix/mpconfigport.h
+++ b/ports/unix/mpconfigport.h
@@ -93,7 +93,7 @@
     #define MICROPY_PY_SYS_PLATFORM  "darwin"
 #else
     #ifdef __ANDROID__
-        #define MICROPY_PY_SYS_PLATFORM  "android"
+        #define MICROPY_PY_SYS_PLATFORM  "bionic"
     #else
         #define MICROPY_PY_SYS_PLATFORM  "linux"
     #endif

--- a/ports/unix/mpconfigport.h
+++ b/ports/unix/mpconfigport.h
@@ -93,9 +93,13 @@
     #define MICROPY_PY_SYS_PLATFORM  "darwin"
 #else
     #ifdef __ANDROID__
-        #define MICROPY_PY_SYS_PLATFORM  "bionic"
+        #define MICROPY_PY_SYS_PLATFORM  "android"
     #else
-        #define MICROPY_PY_SYS_PLATFORM  "linux"
+        #ifdef __EMSCRIPTEN__
+            #define MICROPY_PY_SYS_PLATFORM  "wasm"
+        #else
+            #define MICROPY_PY_SYS_PLATFORM  "linux"
+        #endif
     #endif
 #endif
 #define MICROPY_PY_SYS_MAXSIZE      (1)


### PR DESCRIPTION
android ffi modules require identification of platform as they use a different model.

ffilib.py would load unversionned lib*.so because android are not versionned like linux assumed default.

wasm platform use .wasm files for dlopen()


sys.platform would give ```'android'``` and at REPL:  ```MicroPython v1.9.3-240-ga275cb0-dirty on 2018-01-14; android version```

sys.platform would give ```'wasm'``` and at REPL:  ```MicroPython v1.9.3-240-ga275cb0-dirty on 2018-01-14; wasm version```

use case: https://github.com/pmp-p/micropython-ffigen

android => android

emscripten ( that's just the compiler)  => wasm ( is the standard )