### PR TITLE
zephyr: add support for 2 sensors

### DIFF
--- a/ports/zephyr/Makefile
+++ b/ports/zephyr/Makefile
@@ -38,6 +38,7 @@ INC += -I$(ZEPHYR_BASE)/net/ip/contiki/os
 
 SRC_C = main.c \
 	help.c \
+	modtmp006.c \
 	modusocket.c \
 	modutime.c \
 	modzephyr.c \

--- a/ports/zephyr/Makefile
+++ b/ports/zephyr/Makefile
@@ -39,6 +39,7 @@ INC += -I$(ZEPHYR_BASE)/net/ip/contiki/os
 SRC_C = main.c \
 	help.c \
 	modtmp006.c \
+	modhts221.c \
 	modusocket.c \
 	modutime.c \
 	modzephyr.c \

--- a/ports/zephyr/modhts221.c
+++ b/ports/zephyr/modhts221.c
@@ -1,0 +1,96 @@
+/*
+ * This file is part of the MicroPython project, http://micropython.org/
+ *
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2018 Linaro Limited
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#include <sensor.h>
+
+#include "py/mpconfig.h"
+#if MICROPY_PY_HTS221
+
+#include <zephyr.h>
+#include <misc/stack.h>
+
+#include "py/runtime.h"
+
+static struct device *hts221_dev = NULL;
+
+static double get_temp(struct device *temp_dev)
+{
+	int r;
+	struct sensor_value temp_value;
+	double temp = 0.0;
+
+	r = sensor_sample_fetch(temp_dev);
+	if (r) {
+		printf("sensor_sample_fetch failed return: %d\n", r);
+	}
+
+	r = sensor_channel_get(temp_dev, SENSOR_CHAN_TEMP,
+			       &temp_value);
+	if (r) {
+		printf("sensor_channel_get failed return: %d\n", r);
+	}
+
+	temp = sensor_value_to_double(&temp_value);
+
+	return(temp);
+}
+
+STATIC mp_obj_t hts221_read_temp(void) {
+	float temp;
+
+	if (!hts221_dev) {
+		/* Initialize driver. */
+		hts221_dev = device_get_binding("HTS221");
+		if (!hts221_dev) {
+			return -1;
+		}
+	}
+
+	/* Get temp in degrees F */
+	temp = get_temp(hts221_dev);
+
+#if MICROPY_PY_BUILTINS_FLOAT
+	return mp_obj_new_float(temp);
+#else
+	return mp_obj_new_int((int)temp);
+#endif
+}
+
+STATIC MP_DEFINE_CONST_FUN_OBJ_0(hts221_read_temp_obj, hts221_read_temp);
+
+STATIC const mp_rom_map_elem_t mp_module_time_globals_table[] = {
+    { MP_ROM_QSTR(MP_QSTR___name__), MP_ROM_QSTR(MP_QSTR_hts221) },
+    { MP_ROM_QSTR(MP_QSTR_read_temp), MP_ROM_PTR(&hts221_read_temp_obj) },
+};
+
+STATIC MP_DEFINE_CONST_DICT(mp_module_time_globals, mp_module_time_globals_table);
+
+const mp_obj_module_t mp_module_hts221 = {
+    .base = { &mp_type_module },
+    .globals = (mp_obj_dict_t*)&mp_module_time_globals,
+};
+
+#endif // MICROPY_PY_TMP006

--- a/ports/zephyr/modtmp006.c
+++ b/ports/zephyr/modtmp006.c
@@ -1,0 +1,97 @@
+/*
+ * This file is part of the MicroPython project, http://micropython.org/
+ *
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2017 Texas Instruments, Inc
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#include <sensor.h>
+
+#include "py/mpconfig.h"
+#if MICROPY_PY_TMP006
+
+#include <zephyr.h>
+#include <misc/stack.h>
+
+#include "py/runtime.h"
+
+static struct device *tmp006_dev = NULL;
+
+static double get_temp(struct device *temp_dev)
+{
+	int r;
+	struct sensor_value temp_value;
+	double temp = 0.0;
+
+	r = sensor_sample_fetch(temp_dev);
+	if (r) {
+		printf("sensor_sample_fetch failed return: %d\n", r);
+	}
+
+	r = sensor_channel_get(temp_dev, SENSOR_CHAN_TEMP,
+			       &temp_value);
+	if (r) {
+		printf("sensor_channel_get failed return: %d\n", r);
+	}
+
+	temp = sensor_value_to_double(&temp_value);
+	temp = (temp * 9.0 / 5.0) + 32.0;
+
+	return(temp);
+}
+
+STATIC mp_obj_t tmp006_read_temp(void) {
+	float temp;
+
+	if (!tmp006_dev) {
+		/* Initialize driver. */
+		tmp006_dev = device_get_binding("TEMP_0");
+		if (!tmp006_dev) {
+			return -1;
+		}
+	}
+	
+	/* Get temp in degrees F */
+	temp = get_temp(tmp006_dev);
+ 
+#if MICROPY_PY_BUILTINS_FLOAT
+	return mp_obj_new_float(temp);
+#else
+	return mp_obj_new_int((int)temp);
+#endif
+}
+
+STATIC MP_DEFINE_CONST_FUN_OBJ_0(tmp006_read_temp_obj, tmp006_read_temp);
+
+STATIC const mp_rom_map_elem_t mp_module_time_globals_table[] = {
+    { MP_ROM_QSTR(MP_QSTR___name__), MP_ROM_QSTR(MP_QSTR_tmp006) },
+    { MP_ROM_QSTR(MP_QSTR_read_temp), MP_ROM_PTR(&tmp006_read_temp_obj) },
+};
+
+STATIC MP_DEFINE_CONST_DICT(mp_module_time_globals, mp_module_time_globals_table);
+
+const mp_obj_module_t mp_module_tmp006 = {
+    .base = { &mp_type_module },
+    .globals = (mp_obj_dict_t*)&mp_module_time_globals,
+};
+
+#endif // MICROPY_PY_TMP006

--- a/ports/zephyr/mpconfigport.h
+++ b/ports/zephyr/mpconfigport.h
@@ -69,6 +69,7 @@
 #endif
 #define MICROPY_PY_UTIME            (1)
 #define MICROPY_PY_UTIME_MP_HAL     (1)
+#define MICROPY_PY_TMP006           (1)
 #define MICROPY_PY_ZEPHYR           (1)
 #define MICROPY_PY_SYS_MODULES      (0)
 #define MICROPY_LONGINT_IMPL (MICROPY_LONGINT_IMPL_LONGLONG)
@@ -107,6 +108,7 @@ typedef long mp_off_t;
 
 extern const struct _mp_obj_module_t mp_module_machine;
 extern const struct _mp_obj_module_t mp_module_time;
+extern const struct _mp_obj_module_t mp_module_tmp006;
 extern const struct _mp_obj_module_t mp_module_usocket;
 extern const struct _mp_obj_module_t mp_module_zephyr;
 
@@ -130,10 +132,17 @@ extern const struct _mp_obj_module_t mp_module_zephyr;
 #define MICROPY_PY_ZEPHYR_DEF
 #endif
 
+#if MICROPY_PY_TMP006
+#define MICROPY_PY_TMP006_DEF { MP_ROM_QSTR(MP_QSTR_tmp006), MP_ROM_PTR(&mp_module_tmp006) },
+#else
+#define MICROPY_PY_TMP006_DEF
+#endif
+
 #define MICROPY_PORT_BUILTIN_MODULES \
     { MP_ROM_QSTR(MP_QSTR_machine), MP_ROM_PTR(&mp_module_machine) }, \
     MICROPY_PY_USOCKET_DEF \
     MICROPY_PY_UTIME_DEF \
+    MICROPY_PY_TMP006_DEF \
     MICROPY_PY_ZEPHYR_DEF \
 
 #define MICROPY_PORT_BUILTIN_MODULE_WEAK_LINKS \

--- a/ports/zephyr/mpconfigport.h
+++ b/ports/zephyr/mpconfigport.h
@@ -70,6 +70,7 @@
 #define MICROPY_PY_UTIME            (1)
 #define MICROPY_PY_UTIME_MP_HAL     (1)
 #define MICROPY_PY_TMP006           (1)
+#define MICROPY_PY_HTS221           (1)
 #define MICROPY_PY_ZEPHYR           (1)
 #define MICROPY_PY_SYS_MODULES      (0)
 #define MICROPY_LONGINT_IMPL (MICROPY_LONGINT_IMPL_LONGLONG)
@@ -109,6 +110,7 @@ typedef long mp_off_t;
 extern const struct _mp_obj_module_t mp_module_machine;
 extern const struct _mp_obj_module_t mp_module_time;
 extern const struct _mp_obj_module_t mp_module_tmp006;
+extern const struct _mp_obj_module_t mp_module_hts221;
 extern const struct _mp_obj_module_t mp_module_usocket;
 extern const struct _mp_obj_module_t mp_module_zephyr;
 
@@ -138,11 +140,18 @@ extern const struct _mp_obj_module_t mp_module_zephyr;
 #define MICROPY_PY_TMP006_DEF
 #endif
 
+#if MICROPY_PY_HTS221
+#define MICROPY_PY_HTS221_DEF { MP_ROM_QSTR(MP_QSTR_hts221), MP_ROM_PTR(&mp_module_hts221) },
+#else
+#define MICROPY_PY_HTS221_DEF
+#endif
+
 #define MICROPY_PORT_BUILTIN_MODULES \
     { MP_ROM_QSTR(MP_QSTR_machine), MP_ROM_PTR(&mp_module_machine) }, \
     MICROPY_PY_USOCKET_DEF \
     MICROPY_PY_UTIME_DEF \
     MICROPY_PY_TMP006_DEF \
+    MICROPY_PY_HTS221_DEF \
     MICROPY_PY_ZEPHYR_DEF \
 
 #define MICROPY_PORT_BUILTIN_MODULE_WEAK_LINKS \
@@ -151,4 +160,3 @@ extern const struct _mp_obj_module_t mp_module_zephyr;
 
 // extra built in names to add to the global namespace
 #define MICROPY_PORT_BUILTINS \
-


### PR DESCRIPTION
This pull request provides support for 2 sensors TMP006 and HTS221.

Sensor support will be helpful to demonstrate more use cases using micropython on zephyr
