### PR TITLE
py/objdict: Disallow possible modifications to fixed dicts.

### DIFF
--- a/tests/basics/dict_fixed.py
+++ b/tests/basics/dict_fixed.py
@@ -1,0 +1,48 @@
+# test that fixed dictionaries cannot be modified
+
+try:
+    import uerrno
+except ImportError:
+    print("SKIP")
+    raise SystemExit
+
+# Save a copy of uerrno.errorcode, so we can check later
+# that it hasn't been modified.
+errorcode_copy = uerrno.errorcode.copy()
+
+try:
+    uerrno.errorcode.popitem()
+except TypeError:
+    print("TypeError")
+
+try:
+    uerrno.errorcode.pop(0)
+except TypeError:
+    print("TypeError")
+
+try:
+    uerrno.errorcode.setdefault(0, 0)
+except TypeError:
+    print("TypeError")
+
+try:
+    uerrno.errorcode.update([(1, 2)])
+except TypeError:
+    print("TypeError")
+
+try:
+    del uerrno.errorcode[1]
+except TypeError:
+    print("TypeError")
+
+try:
+    uerrno.errorcode[1] = 'foo'
+except TypeError:
+    print("TypeError")
+
+try:
+    uerrno.errorcode.clear()
+except TypeError:
+    print("TypeError")
+
+assert uerrno.errorcode == errorcode_copy

--- a/tests/basics/dict_fixed.py.exp
+++ b/tests/basics/dict_fixed.py.exp
@@ -1,0 +1,7 @@
+TypeError
+TypeError
+TypeError
+TypeError
+TypeError
+TypeError
+TypeError


### PR DESCRIPTION
Example of bad code when running a non-debug Unix build:

```python
>>> import uerrno
>>> uerrno.errorcode.setdefault(7777, 1)
zsh: segmentation fault (core dumped)  ./micropython
```

`mp_map_lookup` does assert if it is called with a fixed map and lookup_kind other than MP_MAP_LOOKUP, but asserts don't stop bad code paths from executing when asserts are disabled (i.e. "release" builds).

On an embedded system, the `setdefault` call above does not cause any crashes, and in fact will eventually lead to a MemoryError when we detect that the map in question is not in the GC pool, but not before updating `map->alloc` (see py/map.c line 194). On a Unix build, this line leads to a segmentation fault.

`uerrno.errorcode` was the only obvious "fixed" dictionary I could find in the MicroPython core and mainline ports that is directly user-accessible (all others are things like the globals and locals tables for various modules), but any port could conceivably add their own constant dict to a module's table, where `setdefault` would lead to this same bad behavior.