### PR TITLE
lib/libm/math: Add fabsf function.

### DIFF
--- a/lib/libm/math.c
+++ b/lib/libm/math.c
@@ -34,6 +34,7 @@ typedef union {
         uint64_t e : 8;
         uint64_t s : 1;
     };
+    uint32_t i;
 } float_s_t;
 
 #ifndef NDEBUG
@@ -56,6 +57,18 @@ float tanhf(float x) {
         return copysignf(1, x);
     }
     return sinhf(x) / coshf(x);
+}
+
+float fabsf(float x) {
+    float_s_t u = {x};
+    u.i &= 0x7ffffffful; // remove sign bit
+    return u.f;
+}
+
+float nanf(const char *tagp) {
+    float_s_t u;
+    u.i = 0x7fc00000ul; // quiet NaN
+    return u.f;
 }
 
 /*****************************************************************************/


### PR DESCRIPTION
See: https://github.com/tralamazza/micropython/issues/122

This translates to this very short sequence (ARM Cortex M0):

```
00007b2c <fabs_funcf>:
    7b2c:       0040            lsls    r0, r0, #1
    7b2e:       0840            lsrs    r0, r0, #1
    7b30:       4770            bx      lr
```

Some background: https://www.doc.ic.ac.uk/~eedwards/compsys/float/nan.html