### PR TITLE
#3542- PWM - set duty with negative number leads to full PWM

### DIFF
--- a/docs/esp8266/tutorial/pins.rst
+++ b/docs/esp8266/tutorial/pins.rst
@@ -17,7 +17,8 @@ it.  To make an input pin use::
     >>> pin = machine.Pin(0, machine.Pin.IN, machine.Pin.PULL_UP)
 
 You can either use PULL_UP or None for the input pull-mode.  If it's
-not specified then it defaults to None, which is no pull resistor.
+not specified then it defaults to None, which is no pull resistor. GPIO16
+has no pull-up mode.
 You can read the value on the pin using::
 
     >>> pin.value()

--- a/docs/esp8266/tutorial/pwm.rst
+++ b/docs/esp8266/tutorial/pwm.rst
@@ -28,8 +28,8 @@ You can set the frequency and duty cycle using::
     >>> pwm12.duty(512)
 
 Note that the duty cycle is between 0 (all off) and 1023 (all on), with 512
-being a 50% duty.  If you print the PWM object then it will tell you its current
-configuration::
+being a 50% duty. Values beyond this min/max will be clipped. If you
+print the PWM object then it will tell you its current configuration::
 
     >>> pwm12
     PWM(12, freq=500, duty=512)

--- a/ports/esp8266/README.md
+++ b/ports/esp8266/README.md
@@ -49,7 +49,7 @@ $ make -C mpy-cross
 
 Then, to build MicroPython for the ESP8266, just run:
 ```bash
-$ cd esp8266
+$ cd ports/esp8266
 $ make axtls
 $ make
 ```

--- a/ports/esp8266/esppwm.c
+++ b/ports/esp8266/esppwm.c
@@ -210,12 +210,12 @@ pwm_start(void)
 /******************************************************************************
  * FunctionName : pwm_set_duty
  * Description  : set each channel's duty params
- * Parameters   : uint8 duty    : 0 ~ PWM_DEPTH
+ * Parameters   : int16_t duty  : 0 ~ PWM_DEPTH
  *                uint8 channel : channel index
  * Returns      : NONE
 *******************************************************************************/
 void ICACHE_FLASH_ATTR
-pwm_set_duty(uint16 duty, uint8 channel)
+pwm_set_duty(int16_t duty, uint8 channel)
 {
     uint8 i;
     for(i=0;i<pwm_channel_num;i++){

--- a/ports/esp8266/esppwm.h
+++ b/ports/esp8266/esppwm.h
@@ -7,7 +7,7 @@
 void pwm_init(void);
 void pwm_start(void);
 
-void pwm_set_duty(uint16_t duty, uint8_t channel);
+void pwm_set_duty(int16_t duty, uint8_t channel);
 uint16_t pwm_get_duty(uint8_t channel);
 void pwm_set_freq(uint16_t freq, uint8_t channel);
 uint16_t pwm_get_freq(uint8_t channel);


### PR DESCRIPTION
Changed duty parameter to signed integer, we are now able to clip negatives values to 0.

Adding some minor doc updates.