### PR TITLE
py/nlrthumb: Do not mark nlr_push as not returning anything.

### DIFF
--- a/py/nlrthumb.c
+++ b/py/nlrthumb.c
@@ -76,9 +76,9 @@ __attribute__((naked)) unsigned int nlr_push(nlr_buf_t *nlr) {
 #endif
     );
 
-    #if defined(__GNUC__)
+    #if defined(__GNUC__) && (__GNUC__ < 4 || (__GNUC__ == 4 && __GNUC_MINOR__ < 8))
     // Older versions of gcc give an error when naked functions don't return a value
-    __builtin_unreachable();
+    return 0;
     #endif
 }
 


### PR DESCRIPTION
By adding `__builtin_unreachable()` at the end of `nlr_push`, we're essentially telling the compiler that this function will never return. When GCC link-time optimisation is in use, this means that any time `nlr_push()` is called (which is often), the compiler thinks this function will never return and thus eliminates all code following the call. It breaks the [nrf port](https://github.com/tralamazza/micropython/tree/master/ports/nrf), which uses -flto to reduce code size. When the port compiles with https://github.com/micropython/micropython/commit/97cc48553828ed091325d0d3922eb4cd6c377221, the code size is reduced by about 10K so it was easy to see there's some invalid code elimination going on.

Note: older GCC versions might complain about a missing return statement, but at least version 5.4.1 (Debian stretch) doesn't. If there are any versions that complain, I would propose inserting a return statement anyway for that GCC version and lower as a workaround.

See also:
https://github.com/micropython/micropython/issues/3484
https://github.com/micropython/micropython/pull/3492
https://github.com/micropython/micropython/commit/97cc48553828ed091325d0d3922eb4cd6c377221 (introducing the issue)