### PR TITLE
py/gc: Reduce code size.

### DIFF
--- a/py/gc.c
+++ b/py/gc.c
@@ -209,6 +209,7 @@ bool gc_is_locked(void) {
 // topmost block on the stack and repeat with that one.
 STATIC void gc_mark_subtree(size_t block) {
     // Start with the block passed in the argument.
+    size_t sp = 0; // stack pointer
     for (;;) {
         // work out number of consecutive blocks in the chain starting with this one
         size_t n_blocks = 0;
@@ -227,8 +228,8 @@ STATIC void gc_mark_subtree(size_t block) {
                     // an unmarked head, mark it, and push it on gc stack
                     TRACE_MARK(childblock, ptr);
                     ATB_HEAD_TO_MARK(childblock);
-                    if (MP_STATE_MEM(gc_sp) < &MP_STATE_MEM(gc_stack)[MICROPY_ALLOC_GC_STACK_SIZE]) {
-                        *MP_STATE_MEM(gc_sp)++ = childblock;
+                    if (sp < MICROPY_ALLOC_GC_STACK_SIZE) {
+                        MP_STATE_MEM(gc_stack)[sp++] = childblock;
                     } else {
                         MP_STATE_MEM(gc_stack_overflow) = 1;
                     }
@@ -237,19 +238,18 @@ STATIC void gc_mark_subtree(size_t block) {
         }
 
         // Are there any blocks on the stack?
-        if (MP_STATE_MEM(gc_sp) <= MP_STATE_MEM(gc_stack)) {
+        if (sp == 0) {
             break; // No, stack is empty, we're done.
         }
 
         // pop the next block off the stack
-        block = *--MP_STATE_MEM(gc_sp);
+        block = MP_STATE_MEM(gc_stack)[--sp];
     }
 }
 
 STATIC void gc_deal_with_stack_overflow(void) {
     while (MP_STATE_MEM(gc_stack_overflow)) {
         MP_STATE_MEM(gc_stack_overflow) = 0;
-        MP_STATE_MEM(gc_sp) = MP_STATE_MEM(gc_stack);
 
         // scan entire memory looking for blocks which have been marked but not their children
         for (size_t block = 0; block < MP_STATE_MEM(gc_alloc_table_byte_len) * BLOCKS_PER_ATB; block++) {
@@ -323,7 +323,6 @@ void gc_collect_start(void) {
     MP_STATE_MEM(gc_alloc_amount) = 0;
     #endif
     MP_STATE_MEM(gc_stack_overflow) = 0;
-    MP_STATE_MEM(gc_sp) = MP_STATE_MEM(gc_stack);
 
     // Trace root pointers.  This relies on the root pointers being organised
     // correctly in the mp_state_ctx structure.  We scan nlr_top, dict_locals,

--- a/py/mpstate.h
+++ b/py/mpstate.h
@@ -78,7 +78,6 @@ typedef struct _mp_state_mem_t {
 
     int gc_stack_overflow;
     size_t gc_stack[MICROPY_ALLOC_GC_STACK_SIZE];
-    size_t *gc_sp;
     uint16_t gc_lock_depth;
 
     // This variable controls auto garbage collection.  If set to 0 then the


### PR DESCRIPTION
I've found a way to reduce the code size slightly.

The reason it is smaller is because the stack pointer check in `gc_collect_root()` is unnecessary: the stack will always be empty when entering `gc_collect_root()`, so the check for an overflow is superfluous.

Code size reductions from when I tested this (a few weeks ago):
```
unix:            -48
minimal CROSS=1: -32
stm32:           -32
```