### PR TITLE
Improve dir() and REPL autocomplete by using "qstr probing" to find names

### DIFF
--- a/py/modbuiltins.c
+++ b/py/modbuiltins.c
@@ -173,46 +173,24 @@ STATIC mp_obj_t mp_builtin_chr(mp_obj_t o_in) {
 MP_DEFINE_CONST_FUN_OBJ_1(mp_builtin_chr_obj, mp_builtin_chr);
 
 STATIC mp_obj_t mp_builtin_dir(size_t n_args, const mp_obj_t *args) {
-    // TODO make this function more general and less of a hack
-
-    mp_obj_dict_t *dict = NULL;
-    mp_map_t *members = NULL;
-    if (n_args == 0) {
-        // make a list of names in the local name space
-        dict = mp_locals_get();
-    } else { // n_args == 1
-        // make a list of names in the given object
-        if (MP_OBJ_IS_TYPE(args[0], &mp_type_module)) {
-            dict = mp_obj_module_get_globals(args[0]);
-        } else {
-            mp_obj_type_t *type;
-            if (MP_OBJ_IS_TYPE(args[0], &mp_type_type)) {
-                type = MP_OBJ_TO_PTR(args[0]);
-            } else {
-                type = mp_obj_get_type(args[0]);
-            }
-            if (type->locals_dict != NULL && type->locals_dict->base.type == &mp_type_dict) {
-                dict = type->locals_dict;
-            }
-        }
-        if (mp_obj_is_instance_type(mp_obj_get_type(args[0]))) {
-            mp_obj_instance_t *inst = MP_OBJ_TO_PTR(args[0]);
-            members = &inst->members;
-        }
-    }
-
     mp_obj_t dir = mp_obj_new_list(0, NULL);
-    if (dict != NULL) {
+    if (n_args == 0) {
+        // Make a list of names in the local namespace
+        mp_obj_dict_t *dict = mp_locals_get();
         for (size_t i = 0; i < dict->map.alloc; i++) {
             if (MP_MAP_SLOT_IS_FILLED(&dict->map, i)) {
                 mp_obj_list_append(dir, dict->map.table[i].key);
             }
         }
-    }
-    if (members != NULL) {
-        for (size_t i = 0; i < members->alloc; i++) {
-            if (MP_MAP_SLOT_IS_FILLED(members, i)) {
-                mp_obj_list_append(dir, members->table[i].key);
+    } else { // n_args == 1
+        // Make a list of names in the given object
+        // Implemented by probing all possible qstrs with mp_load_method_maybe
+        size_t nqstr = QSTR_TOTAL();
+        for (size_t i = 1; i < nqstr; ++i) {
+            mp_obj_t dest[2];
+            mp_load_method_maybe(args[0], i, dest);
+            if (dest[0] != MP_OBJ_NULL) {
+                mp_obj_list_append(dir, MP_OBJ_NEW_QSTR(i));
             }
         }
     }

--- a/py/qstr.h
+++ b/py/qstr.h
@@ -56,6 +56,7 @@ typedef struct _qstr_pool_t {
 } qstr_pool_t;
 
 #define QSTR_FROM_STR_STATIC(s) (qstr_from_strn((s), strlen(s)))
+#define QSTR_TOTAL() (MP_STATE_VM(last_pool)->total_prev_len + MP_STATE_VM(last_pool)->len)
 
 void qstr_init(void);
 

--- a/py/repl.c
+++ b/py/repl.c
@@ -27,6 +27,7 @@
 #include <string.h>
 #include "py/obj.h"
 #include "py/runtime.h"
+#include "py/builtin.h"
 #include "py/repl.h"
 
 #if MICROPY_HELPER_REPL
@@ -136,8 +137,11 @@ size_t mp_repl_autocomplete(const char *str, size_t len, const mp_print_t *print
         }
     }
 
-    // begin search in locals dict
-    mp_obj_dict_t *dict = mp_locals_get();
+    size_t nqstr = QSTR_TOTAL();
+
+    // begin search in outer global dict which is accessed from __main__
+    mp_obj_t obj = MP_OBJ_FROM_PTR(&mp_module___main__);
+    mp_obj_t dest[2];
 
     for (;;) {
         // get next word in string to complete
@@ -148,41 +152,18 @@ size_t mp_repl_autocomplete(const char *str, size_t len, const mp_print_t *print
         size_t s_len = str - s_start;
 
         if (str < top) {
-            // a complete word, lookup in current dict
-
-            mp_obj_t obj = MP_OBJ_NULL;
-            for (size_t i = 0; i < dict->map.alloc; i++) {
-                if (MP_MAP_SLOT_IS_FILLED(&dict->map, i)) {
-                    size_t d_len;
-                    const char *d_str = mp_obj_str_get_data(dict->map.table[i].key, &d_len);
-                    if (s_len == d_len && strncmp(s_start, d_str, d_len) == 0) {
-                        obj = dict->map.table[i].value;
-                        break;
-                    }
-                }
+            // a complete word, lookup in current object
+            qstr q = qstr_find_strn(s_start, s_len);
+            if (q == MP_QSTR_NULL) {
+                // lookup will fail
+                return 0;
             }
+            mp_load_method_maybe(obj, q, dest);
+            obj = dest[0]; // attribute, method, or MP_OBJ_NULL if nothing found
 
             if (obj == MP_OBJ_NULL) {
                 // lookup failed
                 return 0;
-            }
-
-            // found an object of this name; try to get its dict
-            if (MP_OBJ_IS_TYPE(obj, &mp_type_module)) {
-                dict = mp_obj_module_get_globals(obj);
-            } else {
-                mp_obj_type_t *type;
-                if (MP_OBJ_IS_TYPE(obj, &mp_type_type)) {
-                    type = MP_OBJ_TO_PTR(obj);
-                } else {
-                    type = mp_obj_get_type(obj);
-                }
-                if (type->locals_dict != NULL && type->locals_dict->base.type == &mp_type_dict) {
-                    dict = type->locals_dict;
-                } else {
-                    // obj has no dict
-                    return 0;
-                }
             }
 
             // skip '.' to move to next word
@@ -192,14 +173,15 @@ size_t mp_repl_autocomplete(const char *str, size_t len, const mp_print_t *print
             // end of string, do completion on this partial name
 
             // look for matches
-            int n_found = 0;
             const char *match_str = NULL;
             size_t match_len = 0;
-            for (size_t i = 0; i < dict->map.alloc; i++) {
-                if (MP_MAP_SLOT_IS_FILLED(&dict->map, i)) {
-                    size_t d_len;
-                    const char *d_str = mp_obj_str_get_data(dict->map.table[i].key, &d_len);
-                    if (s_len <= d_len && strncmp(s_start, d_str, s_len) == 0) {
+            qstr q_first = 0, q_last;
+            for (qstr q = 1; q < nqstr; ++q) {
+                size_t d_len;
+                const char *d_str = (const char*)qstr_data(q, &d_len);
+                if (s_len <= d_len && strncmp(s_start, d_str, s_len) == 0) {
+                    mp_load_method_maybe(obj, q, dest);
+                    if (dest[0] != MP_OBJ_NULL) {
                         if (match_str == NULL) {
                             match_str = d_str;
                             match_len = d_len;
@@ -213,13 +195,16 @@ size_t mp_repl_autocomplete(const char *str, size_t len, const mp_print_t *print
                                 }
                             }
                         }
-                        ++n_found;
+                        if (q_first == 0) {
+                            q_first = q;
+                        }
+                        q_last = q;
                     }
                 }
             }
 
             // nothing found
-            if (n_found == 0) {
+            if (q_first == 0) {
                 // If there're no better alternatives, and if it's first word
                 // in the line, try to complete "import".
                 if (s_start == org_str) {
@@ -234,7 +219,7 @@ size_t mp_repl_autocomplete(const char *str, size_t len, const mp_print_t *print
             }
 
             // 1 match found, or multiple matches with a common prefix
-            if (n_found == 1 || match_len > s_len) {
+            if (q_first == q_last || match_len > s_len) {
                 *compl_str = match_str + s_len;
                 return match_len - s_len;
             }
@@ -245,11 +230,12 @@ size_t mp_repl_autocomplete(const char *str, size_t len, const mp_print_t *print
             #define MAX_LINE_LEN  (4 * WORD_SLOT_LEN)
 
             int line_len = MAX_LINE_LEN; // force a newline for first word
-            for (size_t i = 0; i < dict->map.alloc; i++) {
-                if (MP_MAP_SLOT_IS_FILLED(&dict->map, i)) {
-                    size_t d_len;
-                    const char *d_str = mp_obj_str_get_data(dict->map.table[i].key, &d_len);
-                    if (s_len <= d_len && strncmp(s_start, d_str, s_len) == 0) {
+            for (qstr q = q_first; q <= q_last; ++q) {
+                size_t d_len;
+                const char *d_str = (const char*)qstr_data(q, &d_len);
+                if (s_len <= d_len && strncmp(s_start, d_str, s_len) == 0) {
+                    mp_load_method_maybe(obj, q, dest);
+                    if (dest[0] != MP_OBJ_NULL) {
                         int gap = (line_len + WORD_SLOT_LEN - 1) / WORD_SLOT_LEN * WORD_SLOT_LEN - line_len;
                         if (gap < 2) {
                             gap += WORD_SLOT_LEN;

--- a/tests/basics/builtin_dir.py
+++ b/tests/basics/builtin_dir.py
@@ -17,3 +17,22 @@ foo = Foo()
 print('__init__' in dir(foo))
 print('x' in dir(foo))
 
+# dir of subclass
+class A:
+    def a():
+        pass
+class B(A):
+    def b():
+        pass
+d = dir(B())
+print(d.count('a'), d.count('b'))
+
+# dir of class with multiple bases and a common parent
+class C(A):
+    def c():
+        pass
+class D(B, C):
+    def d():
+        pass
+d = dir(D())
+print(d.count('a'), d.count('b'), d.count('c'), d.count('d'))

--- a/tests/cmdline/repl_autocomplete.py
+++ b/tests/cmdline/repl_autocomplete.py
@@ -6,5 +6,4 @@ x = '123'
 1, x.isdi	()
 i = str
 i.lowe	('ABC')
-j = None
-j.	
+None.	

--- a/tests/cmdline/repl_autocomplete.py.exp
+++ b/tests/cmdline/repl_autocomplete.py.exp
@@ -10,6 +10,5 @@ Use \.\+
 >>> i = str
 >>> i.lower('ABC')
 'abc'
->>> j = None
->>> j.[K[K
+>>> None.[K[K[K[K[K
 >>> 

--- a/tests/unix/extra_coverage.py.exp
+++ b/tests/unix/extra_coverage.py.exp
@@ -24,11 +24,11 @@ RuntimeError:
 # repl
 ame__
 
-__name__        path            argv            version
-version_info    implementation  platform        byteorder
-maxsize         exit            stdin           stdout
-stderr          modules         exc_info        getsizeof
-print_exception
+__class__       __name__        argv            byteorder
+exc_info        exit            getsizeof       implementation
+maxsize         modules         path            platform
+print_exception                 stderr          stdin
+stdout          version         version_info
 ementation
 # attrtuple
 (start=1, stop=2, step=3)


### PR DESCRIPTION
This set of patches improves builtin dir() and REPL autocomplete by "probing" the target object with all qstrs in order to do the search for valid attributes for that object.  Basically it goes through all known names and checks if that name is an attribute of the object.

This is of course slower than the previous implementation which just iterated through the relevant dictionaries, but it allows for a much more complete search of names.  In particular this new algorithm allows to list all attributes of a user-defined class, including those attributes in all its parents (and works correctly even with multiple inheritance and with a shared common parent).

This improves the REPL experience quite a bit because now you get completion for objects even if they have methods/members in a base class.  Also dir() is much more complete and much closer to the CPython version.  The slow-down is considered reasonable given the increase in functionality.

This set of patches combined also reduces code size by the following amount:
```
   bare-arm:   -80 
minimal x86:  -208
   unix x64:  -184 
unix nanbox:  -272 
      stm32:  -168 
     cc3200:  -160 
    esp8266:  -196 
      esp32:  -148 
```

Please see comments of the individual commits for further info.

Fixes #3376.