### PR TITLE
py: Option to reduce GC stack integer size.

### DIFF
--- a/py/mpconfig.h
+++ b/py/mpconfig.h
@@ -106,6 +106,14 @@
 #define MICROPY_ALLOC_GC_STACK_SIZE (64)
 #endif
 
+// Use uint16_t instead of size_t in the GC stack. This saves about 128
+// bytes of .bss. It can be used when the heap has less than 2**16 blocks,
+// which is normally the case when it is smaller than 1MB in size (see
+// MICROPY_BYTES_PER_GC_BLOCK).
+#ifndef MICROPY_GC_SMALL_HEAP
+#define MICROPY_GC_SMALL_HEAP (0)
+#endif
+
 // Be conservative and always clear to zero newly (re)allocated memory in the GC.
 // This helps eliminate stray pointers that hold on to memory that's no longer
 // used.  It decreases performance due to unnecessary memory clearing.

--- a/py/mpstate.h
+++ b/py/mpstate.h
@@ -77,7 +77,11 @@ typedef struct _mp_state_mem_t {
     byte *gc_pool_end;
 
     int gc_stack_overflow;
+    #if MICROPY_GC_SMALL_HEAP
+    uint16_t gc_stack[MICROPY_ALLOC_GC_STACK_SIZE];
+    #else
     size_t gc_stack[MICROPY_ALLOC_GC_STACK_SIZE];
+    #endif
     uint16_t gc_lock_depth;
 
     // This variable controls auto garbage collection.  If set to 0 then the


### PR DESCRIPTION
Option to use `uint16_t` instead of `size_t` for `gc_stack`. This can be beneficial for small devices, especially those that are low on memory anyway.

This does not appear to affect code size (tested thumb2 and esp32) but reduces .bss size by (usually) 128 bytes if enabled.

On very low-end devices (<4kB heap) we might even go as far as making it `uint8_t`, which would reduce `gc_stack` even further. I'm thinking of the nrf51822, which has _very_ little RAM and may get below 4kB in some configurations. But that's not included in this PR for simplicity. (We have already set `MICROPY_ALLOC_GC_STACK_SIZE` to 32).

I think most ports could enable this, certainly esp8266 and esp32 and probably stm32 - although it won't make such a difference for those ports. I haven't enabled that yet but I can add the commits to this branch if needed.