### PR TITLE
py: Make micropython.opt_level() optional.

### DIFF
--- a/ports/bare-arm/mpconfigport.h
+++ b/ports/bare-arm/mpconfigport.h
@@ -7,6 +7,7 @@
 #define MICROPY_EMIT_X64            (0)
 #define MICROPY_EMIT_THUMB          (0)
 #define MICROPY_EMIT_INLINE_THUMB   (0)
+#define MICROPY_ENABLE_OPTIMISER    (0)
 #define MICROPY_COMP_MODULE_CONST   (0)
 #define MICROPY_COMP_CONST          (0)
 #define MICROPY_COMP_DOUBLE_TUPLE_ASSIGN (0)

--- a/ports/minimal/mpconfigport.h
+++ b/ports/minimal/mpconfigport.h
@@ -14,6 +14,7 @@
 #define MICROPY_EMIT_X64            (0)
 #define MICROPY_EMIT_THUMB          (0)
 #define MICROPY_EMIT_INLINE_THUMB   (0)
+#define MICROPY_ENABLE_OPTIMISER    (0)
 #define MICROPY_COMP_MODULE_CONST   (0)
 #define MICROPY_COMP_CONST          (0)
 #define MICROPY_COMP_DOUBLE_TUPLE_ASSIGN (0)

--- a/py/compile.c
+++ b/py/compile.c
@@ -1221,9 +1221,13 @@ STATIC void compile_nonlocal_stmt(compiler_t *comp, mp_parse_node_struct_t *pns)
 
 STATIC void compile_assert_stmt(compiler_t *comp, mp_parse_node_struct_t *pns) {
     // with optimisations enabled we don't compile assertions
+    #if MICROPY_ENABLE_OPTIMISER
     if (MP_STATE_VM(mp_optimise_value) != 0) {
         return;
     }
+    #else
+    return;
+    #endif
 
     uint l_end = comp_next_label(comp);
     c_if_cond(comp, pns->nodes[0], true, l_end);

--- a/py/emitbc.c
+++ b/py/emitbc.c
@@ -471,10 +471,12 @@ static inline void emit_bc_pre(emit_t *emit, mp_int_t stack_size_delta) {
 void mp_emit_bc_set_source_line(emit_t *emit, mp_uint_t source_line) {
     //printf("source: line %d -> %d  offset %d -> %d\n", emit->last_source_line, source_line, emit->last_source_line_offset, emit->bytecode_offset);
 #if MICROPY_ENABLE_SOURCE_LINE
+#if MICROPY_ENABLE_OPTIMISER
     if (MP_STATE_VM(mp_optimise_value) >= 3) {
         // If we compile with -O3, don't store line numbers.
         return;
     }
+#endif // MICROPY_ENABLE_OPTIMISER
     if (source_line > emit->last_source_line) {
         mp_uint_t bytes_to_skip = emit->bytecode_offset - emit->last_source_line_offset;
         mp_uint_t lines_to_skip = source_line - emit->last_source_line;

--- a/py/lexer.c
+++ b/py/lexer.c
@@ -550,7 +550,11 @@ void mp_lexer_to_next(mp_lexer_t *lex) {
             if (cmp == 0) {
                 lex->tok_kind = MP_TOKEN_KW_FALSE + i;
                 if (lex->tok_kind == MP_TOKEN_KW___DEBUG__) {
+                    #if MICROPY_ENABLE_OPTIMISER
                     lex->tok_kind = (MP_STATE_VM(mp_optimise_value) == 0 ? MP_TOKEN_KW_TRUE : MP_TOKEN_KW_FALSE);
+                    #else
+                    lex->tok_kind = MP_TOKEN_KW_TRUE;
+                    #endif
                 }
                 break;
             } else if (cmp < 0) {

--- a/py/modmicropython.c
+++ b/py/modmicropython.c
@@ -35,6 +35,7 @@
 // Various builtins specific to MicroPython runtime,
 // living in micropython module
 
+#if MICROPY_ENABLE_OPTIMISER
 STATIC mp_obj_t mp_micropython_opt_level(size_t n_args, const mp_obj_t *args) {
     if (n_args == 0) {
         return MP_OBJ_NEW_SMALL_INT(MP_STATE_VM(mp_optimise_value));
@@ -44,6 +45,7 @@ STATIC mp_obj_t mp_micropython_opt_level(size_t n_args, const mp_obj_t *args) {
     }
 }
 STATIC MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(mp_micropython_opt_level_obj, 0, 1, mp_micropython_opt_level);
+#endif // MICROPY_ENABLE_OPTIMISER
 
 #if MICROPY_PY_MICROPYTHON_MEM_INFO
 
@@ -158,7 +160,9 @@ STATIC MP_DEFINE_CONST_FUN_OBJ_2(mp_micropython_schedule_obj, mp_micropython_sch
 STATIC const mp_rom_map_elem_t mp_module_micropython_globals_table[] = {
     { MP_ROM_QSTR(MP_QSTR___name__), MP_ROM_QSTR(MP_QSTR_micropython) },
     { MP_ROM_QSTR(MP_QSTR_const), MP_ROM_PTR(&mp_identity_obj) },
+#if MICROPY_ENABLE_OPTIMISER
     { MP_ROM_QSTR(MP_QSTR_opt_level), MP_ROM_PTR(&mp_micropython_opt_level_obj) },
+#endif
 #if MICROPY_PY_MICROPYTHON_MEM_INFO
 #if MICROPY_MEM_STATS
     { MP_ROM_QSTR(MP_QSTR_mem_total), MP_ROM_PTR(&mp_micropython_mem_total_obj) },

--- a/py/mpconfig.h
+++ b/py/mpconfig.h
@@ -358,6 +358,11 @@
 #define MICROPY_COMP_RETURN_IF_EXPR (0)
 #endif
 
+// Whether to enable micropython.opt_level()
+#ifndef MICROPY_ENABLE_OPTIMISER
+#define MICROPY_ENABLE_OPTIMISER (1)
+#endif
+
 /*****************************************************************************/
 /* Internal debugging stuff                                                  */
 

--- a/py/mpstate.h
+++ b/py/mpstate.h
@@ -195,7 +195,9 @@ typedef struct _mp_state_vm_t {
     mp_thread_mutex_t qstr_mutex;
     #endif
 
+    #if MICROPY_ENABLE_OPTIMISER
     mp_uint_t mp_optimise_value;
+    #endif
 
     // size of the emergency exception buf, if it's dynamically allocated
     #if MICROPY_ENABLE_EMERGENCY_EXCEPTION_BUF && MICROPY_EMERGENCY_EXCEPTION_BUF_SIZE == 0

--- a/py/runtime.c
+++ b/py/runtime.c
@@ -83,8 +83,10 @@ void mp_init(void) {
     MICROPY_PORT_INIT_FUNC;
 #endif
 
+    #if MICROPY_ENABLE_OPTIMISER
     // optimization disabled by default
     MP_STATE_VM(mp_optimise_value) = 0;
+    #endif
 
     // init global module dict
     mp_obj_dict_init(&MP_STATE_VM(mp_loaded_modules_dict), 3);


### PR DESCRIPTION
When disabled, reduces code size (thumb2) by about 180 bytes and .bss size by 4 bytes.