### PR TITLE
py/mpconfig: Update invalid qstr representation in object type D.

### DIFF
--- a/py/mpconfig.h
+++ b/py/mpconfig.h
@@ -65,13 +65,11 @@
 
 // A MicroPython object is a machine word having the following form (called R):
 //  - iiiiiiii iiiiiiii iiiiiiii iiiiiii1 small int with 31-bit signed value
-//  - 01111111 1qqqqqqq qqqqqqqq qqqqq110 str with 20-bit qstr value
+//  - 00000000 0qqqqqqq qqqqqqqq qqqqq110 str with 20-bit qstr value
 //  - s1111111 10000000 00000000 00000010 +/- inf
 //  - s1111111 1xxxxxxx xxxxxxxx xxxxx010 nan, x != 0
 //  - seeeeeee efffffff ffffffff ffffff10 30-bit fp, e != 0xff
 //  - pppppppp pppppppp pppppppp pppppp00 ptr (4 byte alignment)
-// Str and float stored as O = R + 0x80800000, retrieved as R = O - 0x80800000.
-// This makes strs easier to encode/decode as they have zeros in the top 9 bits.
 // This scheme only works with 32-bit word size and float enabled.
 #define MICROPY_OBJ_REPR_C (2)
 


### PR DESCRIPTION
The high bits of qstr objects are all zeroes, not `01111111 1`.

I've also removed the other two lines. The part about strs is certainly wrong and the part about float is not entirely complete (it misses setting the lowest 2 bits). I'm not sure what should be there as a replacement, if any.

Stumbled upon this while investigating how different data types are encoded exactly in MicroPython.