### PR TITLE
stm32/adc.c Provide ADC.read_timed_with() method.

### DIFF
--- a/docs/library/pyb.ADC.rst
+++ b/docs/library/pyb.ADC.rst
@@ -76,6 +76,49 @@ Methods
 
        This function does not allocate any memory.
 
+    .. method:: ADC.read_timed_with(buf, (adcx, ...), (bufx, ...), timer)
+
+       Read analog values into from the ADC into ``buf`` at a rate set by the
+       ``timer`` object. After each sample is read, a sample is read from each
+       of N other adc's. This can be used to extract relative timing or phase
+       data.
+
+       The additional ADC and buffer instances are passed in tuples with each ADC
+       having an associated buffer. All buffers must be of the same type and
+       length.
+
+       Buffers can be bytearray or array.array for example. The ADC values have
+       12-bit resolution and are stored directly into ``buf`` if its element size
+       is 16 bits or greater.  If buffers have only 8-bit elements (eg a bytearray)
+       then the sample resolution will be reduced to 8 bits.
+
+       ``timer`` must be a Timer object, and a sample from each ADC is read each
+       time the timer triggers.  The timer must already be initialised and running
+       at the desired sampling frequency.
+
+       Return value: 1 (success) if the timer was never triggered before all samples
+       were completed. A value of 0 indicates that an overrun occurred. An overrun
+       does not neccessarily imply a missing sample, merely a loss of precision in
+       the acquisition time of at least one sample. Severe overruns do result in
+       missed samples. As a rough guide sample rates above 15KHz may result in
+       overruns. Rates above 120KHz are likely to lead to missed samples.
+
+       Example reading 3 ADC's::
+
+           adc0 = pyb.ADC(pyb.Pin.board.X1)    # Create ADC's
+           adc1 = pyb.ADC(pyb.Pin.board.X2)
+           adc2 = pyb.ADC(pyb.Pin.board.X3)
+           tim = pyb.Timer(8, freq=100)        # Create timer
+           rx0 = array.array('H', (0 for i in range(100)))  # ADC buffers of
+           rx1 = array.array('H', (0 for i in range(100)))  # 100 16-bit words
+           rx2 = array.array('H', (0 for i in range(100)))
+           # read analog values into buf at 100Hz (takes one second)
+           adc0.read_timed_with(rx0, (adc1, adc2), (rx1, rx2), tim)
+           for n in range(len(rx0)):
+               print(rx0[n], rx1[n], rx2[n])
+
+       This function does not allocate any memory.
+
 The ADCAll Object
 -----------------
 

--- a/docs/library/pyb.ADC.rst
+++ b/docs/library/pyb.ADC.rst
@@ -74,7 +74,8 @@ Methods
            for val in buf:                     # loop over all values
                print(val)                      # print the value out
 
-       This function does not allocate any memory.
+       This function does not allocate any memory. It has blocking behaviour: it
+       does not return to the calling program until the buffer is full.
 
     .. method:: ADC.read_timed_with(buf, (adcx, ...), (bufx, ...), timer)
 
@@ -117,7 +118,8 @@ Methods
            for n in range(len(rx0)):
                print(rx0[n], rx1[n], rx2[n])
 
-       This function does not allocate any memory.
+       This function does not allocate any memory. It has blocking behaviour: it
+       does not return to the calling program until the buffer is full.
 
 The ADCAll Object
 -----------------

--- a/ports/stm32/adc.c
+++ b/ports/stm32/adc.c
@@ -400,7 +400,6 @@ STATIC mp_obj_t adc_read_timed(mp_obj_t self_in, mp_obj_t buf_in, mp_obj_t freq_
     // TODO use DMA
 
     uint nelems = bufinfo.len / typesize;
-
     for (uint index = 0; index < nelems; index++) {
         // Wait for the timer to trigger so we sample at the correct frequency
         while (__HAL_TIM_GET_FLAG(tim, TIM_FLAG_UPDATE) == RESET) {

--- a/tests/pyb/adc.py
+++ b/tests/pyb/adc.py
@@ -1,33 +1,62 @@
-from pyb import ADC
-from pyb import Pin
+from pyb import ADC, Timer
 
-pin = Pin('X22', mode=Pin.IN, pull=Pin.PULL_DOWN)
-adc = ADC('X22')
-print(adc)
+adct = ADC(16)  # Temperature 930 -> 20C
+print(adct)
+adcv = ADC(17)  # Voltage 1500 -> 3.3V
+print(adcv)
 
-# read single sample
-val = adc.read()
-assert val < 500
+# read single sample. 2.5V-5V is pass range.
+val = adcv.read()
+assert val > 1000 and val < 2000
 
 # timer for read_timed
-tim = pyb.Timer(5, freq=500)
+tim = Timer(5, freq=500)
 
 # read into bytearray
-buf = bytearray(50)
-adc.read_timed(buf, tim)
+buf = bytearray(b'\xff'*50)
+adcv.read_timed(buf, tim)
 print(len(buf))
 for i in buf:
-    assert i < 500
+    assert i > 50 and i < 150
 
 # read into arrays with different element sizes
 import array
-ar = array.array('h', 25 * [0])
-adc.read_timed(ar, tim)
-print(len(ar))
-for i in buf:
-    assert i < 500
-ar = array.array('i', 30 * [0])
-adc.read_timed(ar, tim)
-print(len(ar))
-for i in buf:
-    assert i < 500
+arv = array.array('h', 25 * [0x7fff])
+adcv.read_timed(arv, tim)
+print(len(arv))
+for i in arv:
+    assert i > 1000 and i < 2000
+
+arv = array.array('i', 30 * [-1])
+adcv.read_timed(arv, tim)
+print(len(arv))
+for i in arv:
+    assert i > 1000 and i < 2000
+
+# Test read_timed_multi
+arv = bytearray(b'\xff'*50)
+art = bytearray(b'\xff'*50)
+ADC.read_timed_multi((adcv, adct), (arv, art), tim)
+for i in arv:
+    assert i > 60 and i < 125
+# Wide range: unsure of accuracy of temp sensor.
+for i in art:
+    assert i > 15 and i < 200
+
+arv = array.array('i', 25 * [-1])
+art = array.array('i', 25 * [-1])
+ADC.read_timed_multi((adcv, adct), (arv, art), tim)
+for i in arv:
+    assert i > 1000 and i < 2000
+# Wide range: unsure of accuracy of temp sensor.
+for i in art:
+    assert i > 50 and i < 2000
+
+arv = array.array('h', 25 * [0x7fff])
+art = array.array('h', 25 * [0x7fff])
+ADC.read_timed_multi((adcv, adct), (arv, art), tim)
+for i in arv:
+    assert i > 1000 and i < 2000
+# Wide range: unsure of accuracy of temp sensor.
+for i in art:
+    assert i > 50 and i < 2000

--- a/tests/pyb/adc.py.exp
+++ b/tests/pyb/adc.py.exp
@@ -1,4 +1,5 @@
-<ADC on X22 channel=13>
+<ADC on 16 channel=16>
+<ADC on 17 channel=17>
 50
 25
 30


### PR DESCRIPTION
The current implementation makes it difficult to extract timing/phase information from multiple ADC channels if the sample frequency is high enough to require a timed read.

This patch provides a means of performing a timed read on an arbitrary number of ADC channels. On a timer tick each assigned channel is read into its own buffer. This occurs in quick succession before awaiting the next tick. Like **timed_read** it is a blocking method.

There are a number of use cases in the audio frequency range including echo location, determining the position of an external sound source and electronic test and measurement. Seismic applications are another possible use where readings from a pair of geophones might provide vector results.

Docs are updated. The test program is not changed pending a resolution of https://github.com/micropython/micropython/issues/3655.