### PR TITLE
stm32: fix compilation issue with usbd

### DIFF
--- a/ports/stm32/usbd_conf.h
+++ b/ports/stm32/usbd_conf.h
@@ -34,6 +34,7 @@
 #define __USBD_CONF_H
 
 /* Includes ------------------------------------------------------------------*/
+#include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>


### PR DESCRIPTION
Working on another pull request, I ran into compilation trouble because `stdint.h` was missing from the include chain, and some of the USB code references its types (e.g., `uint8_t`).

I need to improve my build platform (currently a text-only VirtualBox VM with limited integration to my host system), but I'm surprised no one else sees this when they try to build the PYBV11 target.