### PR TITLE
Fixes for assertion failures in py/objtypes.c

### DIFF
--- a/py/objtype.c
+++ b/py/objtype.c
@@ -1114,6 +1114,9 @@ STATIC mp_obj_t super_make_new(const mp_obj_type_t *type_in, size_t n_args, size
     // 0 arguments are turned into 2 in the compiler
     // 1 argument is not yet implemented
     mp_arg_check_num(n_args, n_kw, 2, 2, false);
+    if(!MP_OBJ_IS_TYPE(args[0], &mp_type_type)) {
+        mp_raise_TypeError("first argument to super() must be type");
+    }
     mp_obj_super_t *o = m_new_obj(mp_obj_super_t);
     *o = (mp_obj_super_t){{type_in}, args[0], args[1]};
     return MP_OBJ_FROM_PTR(o);

--- a/py/objtype.c
+++ b/py/objtype.c
@@ -1006,8 +1006,14 @@ const mp_obj_type_t mp_type_type = {
 };
 
 mp_obj_t mp_obj_new_type(qstr name, mp_obj_t bases_tuple, mp_obj_t locals_dict) {
-    assert(MP_OBJ_IS_TYPE(bases_tuple, &mp_type_tuple)); // MicroPython restriction, for now
-    assert(MP_OBJ_IS_TYPE(locals_dict, &mp_type_dict)); // MicroPython restriction, for now
+    if(!MP_OBJ_IS_TYPE(bases_tuple, &mp_type_tuple)) {
+        // MicroPython restriction, for now
+        mp_raise_TypeError("type() argument 2 must be tuple");
+    }
+    if(!MP_OBJ_IS_TYPE(locals_dict, &mp_type_dict)) {
+        // MicroPython restriction, for now
+        mp_raise_TypeError("type() argument 3 must be dict");
+    }
 
     // TODO might need to make a copy of locals_dict; at least that's how CPython does it
 
@@ -1016,7 +1022,9 @@ mp_obj_t mp_obj_new_type(qstr name, mp_obj_t bases_tuple, mp_obj_t locals_dict) 
     mp_obj_t *bases_items;
     mp_obj_tuple_get(bases_tuple, &bases_len, &bases_items);
     for (size_t i = 0; i < bases_len; i++) {
-        assert(MP_OBJ_IS_TYPE(bases_items[i], &mp_type_type));
+        if(!MP_OBJ_IS_TYPE(bases_items[i], &mp_type_type)) {
+            mp_raise_TypeError("type is not an acceptable base type");
+        }
         mp_obj_type_t *t = MP_OBJ_TO_PTR(bases_items[i]);
         // TODO: Verify with CPy, tested on function type
         if (t->make_new == NULL) {

--- a/tests/basics/class_super.py
+++ b/tests/basics/class_super.py
@@ -34,3 +34,10 @@ class B(A):
         print(super().bar) # accessing attribute after super()
         return super().foo().count(2) # calling a subsequent method
 print(B().foo())
+
+try:
+    super(1, 1).x
+except TypeError:
+    print(True)
+else:
+    print(False)

--- a/tests/basics/types3.py
+++ b/tests/basics/types3.py
@@ -1,0 +1,20 @@
+try:
+    type('abc', None, None)
+except TypeError:
+    print(True)
+else:
+    print(False)
+
+try:
+    type('abc', (), None)
+except TypeError:
+    print(True)
+else:
+    print(False)
+
+try:
+    type('abc', (1,), {})
+except TypeError:
+    print(True)
+else:
+    print(False)


### PR DESCRIPTION
These are both cherry-picked from circuitpython, with minor conflicts fixed.  Testcases are added.