### PR TITLE
stm32/main: allow override of init_flash_fs() and file contents

### DIFF
--- a/ports/stm32/main.c
+++ b/ports/stm32/main.c
@@ -140,7 +140,7 @@ MP_WEAK MP_NOINLINE bool init_flash_fs(uint reset_mode) {
     "import pyb\r\n"
     "#pyb.main('main.py') # main script to run after this one\r\n"
     #if MICROPY_HW_ENABLE_USB
-    "pyb.usb_mode('VCP+MSC') # act as a serial and a storage device\r\n"
+    "#pyb.usb_mode('VCP+MSC') # act as a serial and a storage device\r\n"
     "#pyb.usb_mode('VCP+HID') # act as a serial device and a mouse\r\n"
     #endif
     ;

--- a/ports/stm32/main.c
+++ b/ports/stm32/main.c
@@ -129,42 +129,45 @@ STATIC mp_obj_t pyb_main(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_a
 }
 MP_DEFINE_CONST_FUN_OBJ_KW(pyb_main_obj, 1, pyb_main);
 
-static const char fresh_boot_py[] =
-"# boot.py -- run on boot-up\r\n"
-"# can run arbitrary Python, but best to keep it minimal\r\n"
-"\r\n"
-"import machine\r\n"
-"import pyb\r\n"
-"#pyb.main('main.py') # main script to run after this one\r\n"
-"#pyb.usb_mode('VCP+MSC') # act as a serial and a storage device\r\n"
-"#pyb.usb_mode('VCP+HID') # act as a serial device and a mouse\r\n"
-;
-
-static const char fresh_main_py[] =
-"# main.py -- put your code here!\r\n"
-;
-
-static const char fresh_pybcdc_inf[] =
-#include "genhdr/pybcdc_inf.h"
-;
-
-static const char fresh_readme_txt[] =
-"This is a MicroPython board\r\n"
-"\r\n"
-"You can get started right away by writing your Python code in 'main.py'.\r\n"
-"\r\n"
-"For a serial prompt:\r\n"
-" - Windows: you need to go to 'Device manager', right click on the unknown device,\r\n"
-"   then update the driver software, using the 'pybcdc.inf' file found on this drive.\r\n"
-"   Then use a terminal program like Hyperterminal or putty.\r\n"
-" - Mac OS X: use the command: screen /dev/tty.usbmodem*\r\n"
-" - Linux: use the command: screen /dev/ttyACM0\r\n"
-"\r\n"
-"Please visit http://micropython.org/help/ for further help.\r\n"
-;
-
 // avoid inlining to avoid stack usage within main()
-MP_NOINLINE STATIC bool init_flash_fs(uint reset_mode) {
+MP_WEAK MP_NOINLINE bool init_flash_fs(uint reset_mode) {
+
+    static const char fresh_boot_py[] =
+    "# boot.py -- run on boot-up\r\n"
+    "# can run arbitrary Python, but best to keep it minimal\r\n"
+    "\r\n"
+    "import machine\r\n"
+    "import pyb\r\n"
+    "#pyb.main('main.py') # main script to run after this one\r\n"
+    #if MICROPY_HW_ENABLE_USB
+    "pyb.usb_mode('VCP+MSC') # act as a serial and a storage device\r\n"
+    "#pyb.usb_mode('VCP+HID') # act as a serial device and a mouse\r\n"
+    #endif
+    ;
+
+    static const char fresh_main_py[] =
+    "# main.py -- put your code here!\r\n"
+    ;
+
+    static const char fresh_pybcdc_inf[] =
+#include "genhdr/pybcdc_inf.h"
+    ;
+
+    static const char fresh_readme_txt[] =
+    "This is a MicroPython board\r\n"
+    "\r\n"
+    "You can get started right away by writing your Python code in 'main.py'.\r\n"
+    "\r\n"
+    "For a serial prompt:\r\n"
+    " - Windows: you need to go to 'Device manager', right click on the unknown device,\r\n"
+    "   then update the driver software, using the 'pybcdc.inf' file found on this drive.\r\n"
+    "   Then use a terminal program like Hyperterminal or putty.\r\n"
+    " - Mac OS X: use the command: screen /dev/tty.usbmodem*\r\n"
+    " - Linux: use the command: screen /dev/ttyACM0\r\n"
+    "\r\n"
+    "Please visit http://micropython.org/help/ for further help.\r\n"
+    ;
+
     // init the vfs object
     fs_user_mount_t *vfs_fat = &fs_user_mount_flash;
     vfs_fat->flags = 0;


### PR DESCRIPTION
As proposed in #3688 

- make `init_flash_fs()` weak linkage
- move "fresh" file content strings into that function