### PR TITLE
esp8266/modnetwork.c: teach modnetwork how to get essid of station interface

### DIFF
--- a/ports/esp8266/modnetwork.c
+++ b/ports/esp8266/modnetwork.c
@@ -422,8 +422,12 @@ STATIC mp_obj_t esp_config(size_t n_args, const mp_obj_t *args, mp_map_t *kwargs
             return mp_obj_new_bytes(mac, sizeof(mac));
         }
         case MP_QSTR_essid:
-            req_if = SOFTAP_IF;
-            val = mp_obj_new_str((char*)cfg.ap.ssid, cfg.ap.ssid_len);
+            if (self->if_id == STATION_IF) {
+                char *essid = (char *)cfg.sta.ssid;
+                val = mp_obj_new_str(essid, strlen(essid));
+            } else {
+                val = mp_obj_new_str((char*)cfg.ap.ssid, cfg.ap.ssid_len);
+            }
             break;
         case MP_QSTR_hidden:
             req_if = SOFTAP_IF;


### PR DESCRIPTION
This patch enables iface.config('essid') to work for both AP and
Station interfaces.