### PR TITLE
stm32/sdcard: sdcard_wait_finished() bugfix: remove WFI for STM32L4 case

### DIFF
--- a/ports/stm32/sdcard.c
+++ b/ports/stm32/sdcard.c
@@ -275,7 +275,9 @@ STATIC HAL_StatusTypeDef sdcard_wait_finished(SD_HandleTypeDef *sd, uint32_t tim
             enable_irq(irq_state);
             break;
         }
+#if !defined(STM32L4)
         __WFI();
+#endif
         enable_irq(irq_state);
         if (HAL_GetTick() - start >= timeout) {
             return HAL_TIMEOUT;
@@ -294,7 +296,9 @@ STATIC HAL_StatusTypeDef sdcard_wait_finished(SD_HandleTypeDef *sd, uint32_t tim
         if (HAL_GetTick() - start >= timeout) {
             return HAL_TIMEOUT;
         }
+#if !defined(STM32L4)
         __WFI();
+#endif
     }
     return HAL_OK;
 }


### PR DESCRIPTION
This change was needed to get SD card interface to work on the STM32L4. 

I'm not 100% sure why this is needed, because I would expect SysTick to occur, however there is code in `read/write_blocks` that elevates the irq priority to `IRQ_PRI_OTG_FS` level and I think that may preclude the delivery of other interrupts such as SysTick.

The issue only occurs during **write** to the SD card, I suspect because there is no timely interrupt during the sequence of DMA into the card. It's very possible there are other paths that could lead to a lockup.