### PR TITLE
tools/upip.py Fix changed PyPi URL (issue #274).

### DIFF
--- a/ports/unix/modules/upip.py
+++ b/ports/unix/modules/upip.py
@@ -1,1 +1,0 @@
-../../../tools/upip.py

--- a/tools/upip.py
+++ b/tools/upip.py
@@ -147,9 +147,8 @@ def url_open(url):
 
     return s
 
-
 def get_pkg_metadata(name):
-    f = url_open("https://pypi.python.org/pypi/%s/json" % name)
+    f = url_open("https://pypi.org/pypi/%s/json" % name)
     try:
         return json.load(f)
     finally:


### PR DESCRIPTION
Fixes fail caused by changed PyPi URL https://github.com/micropython/micropython-lib/issues/274