### PR TITLE
py/stream: Use MicroPython errno instead of system errno.h.

### DIFF
--- a/py/stream.c
+++ b/py/stream.c
@@ -32,13 +32,6 @@
 #include "py/stream.h"
 #include "py/runtime.h"
 
-#if MICROPY_STREAMS_NON_BLOCK
-#include <errno.h>
-#if defined(__MINGW32__) && !defined(__MINGW64_VERSION_MAJOR)
-#define EWOULDBLOCK 140
-#endif
-#endif
-
 // This file defines generic Python stream read/write methods which
 // dispatch to the underlying stream interface of an object.
 

--- a/py/stream.h
+++ b/py/stream.h
@@ -107,7 +107,7 @@ int mp_stream_posix_fsync(mp_obj_t stream);
 #endif
 
 #if MICROPY_STREAMS_NON_BLOCK
-#define mp_is_nonblocking_error(errno) ((errno) == EAGAIN || (errno) == EWOULDBLOCK)
+#define mp_is_nonblocking_error(errno) ((errno) == MP_EAGAIN || (errno) == MP_EWOULDBLOCK)
 #else
 #define mp_is_nonblocking_error(errno) (0)
 #endif


### PR DESCRIPTION
This makes compatibility with Clang a bit better and seems a bit more correct to me.