### PR TITLE
py/nlrthumb: Fix Clang support.

### DIFF
--- a/py/nlrthumb.c
+++ b/py/nlrthumb.c
@@ -76,8 +76,9 @@ __attribute__((naked)) unsigned int nlr_push(nlr_buf_t *nlr) {
 #endif
     );
 
-    #if defined(__GNUC__) && (__GNUC__ < 4 || (__GNUC__ == 4 && __GNUC_MINOR__ < 8))
+    #if !defined(__clang__) && defined(__GNUC__) && (__GNUC__ < 4 || (__GNUC__ == 4 && __GNUC_MINOR__ < 8))
     // Older versions of gcc give an error when naked functions don't return a value
+    // Additionally exclude Clang as it also defines __GNUC__.
     return 0;
     #endif
 }


### PR DESCRIPTION
Clang defines `__GNUC__` so we have to check for it specifically.

See: #3612.