### PR TITLE
py/mperrno: Define MP_EWOULDBLOCK as EWOULDBLOCK, not EAGAIN.

### DIFF
--- a/py/mperrno.h
+++ b/py/mperrno.h
@@ -122,7 +122,7 @@
 #define MP_EPIPE            EPIPE
 #define MP_EDOM             EDOM
 #define MP_ERANGE           ERANGE
-#define MP_EWOULDBLOCK      EAGAIN
+#define MP_EWOULDBLOCK      EWOULDBLOCK
 #define MP_EOPNOTSUPP       EOPNOTSUPP
 #define MP_EAFNOSUPPORT     EAFNOSUPPORT
 #define MP_EADDRINUSE       EADDRINUSE


### PR DESCRIPTION
Most modern systems have EWOULDBLOCK aliased to EAGAIN, ie they have the
same value.  But some systems use different values for these errnos and if
a uPy port is using the system errno values (ie not the internal uPy
values) then it's important to be able to distinguish EWOULDBLOCK from
EAGAIN.  Eg if a system call returned EWOULDBLOCK it must be possible to
check for this return value, and this patch makes this now possible.