### PR TITLE
extmod/lwip: Fix select.poll crash when socket closed / in error state.

### DIFF
--- a/extmod/modlwip.c
+++ b/extmod/modlwip.c
@@ -1132,11 +1132,11 @@ STATIC mp_uint_t lwip_socket_ioctl(mp_obj_t self_in, mp_uint_t request, uintptr_
             ret |= MP_STREAM_POLL_RD;
         }
 
-        if (flags & MP_STREAM_POLL_WR && tcp_sndbuf(socket->pcb.tcp) > 0) {
+        if (flags & MP_STREAM_POLL_WR && socket->pcb.tcp != NULL && tcp_sndbuf(socket->pcb.tcp) > 0) {
             ret |= MP_STREAM_POLL_WR;
         }
 
-        if (socket->state == STATE_PEER_CLOSED) {
+        if (socket->state == STATE_PEER_CLOSED || socket->pcb.tcp == NULL) {
             // Peer-closed socket is both readable and writable: read will
             // return EOF, write - error. Without this poll will hang on a
             // socket which was closed by peer.


### PR DESCRIPTION
Fixes #3164 

This probably not a comprehensive fix (kind of workaround), however it is better than have a frequent crash.

As a different way - `POLLERR` can be used, but I haven't found any place where it is in use. So assuming that not all user programs handle it - I decided to follow existing way.