### PR TITLE
ports/esp8266: optionally include local Makefile settings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,7 @@ user.props
 # Generated rst files
 ######################
 genrst/
+
+# Local Make settings
+######################
+local.mk

--- a/ports/esp8266/Makefile
+++ b/ports/esp8266/Makefile
@@ -48,6 +48,8 @@ LIBS = -L$(ESP_SDK)/lib -lmain -ljson -llwip_open -lpp -lnet80211 -lwpa -lphy -l
 LIBGCC_FILE_NAME = $(shell $(CC) $(CFLAGS) -print-libgcc-file-name)
 LIBS += -L$(dir $(LIBGCC_FILE_NAME)) -lgcc
 
+-include local.mk
+
 # Debugging/Optimization
 ifeq ($(DEBUG), 1)
 CFLAGS += -g


### PR DESCRIPTION
This commit modifies the Makefile so that it will load the file
`local.mk` if it exists. This permits one to persistently set things
like port, speed, and flash mode.

I'm always forgetting to add `FLASH_MODE=dio` when I run `make deploy`.
Being able to set these things persistently leads to fewer things to
remember and a smoother developer workflow.  It also means that I
don't need to edit the `Makefile` to make these persistent.