### PR TITLE
ports/esp32 : ucrypto module to implement RSA signature from mbed_tls

### DIFF
--- a/ports/esp32/Makefile
+++ b/ports/esp32/Makefile
@@ -153,6 +153,7 @@ SRC_C = \
 	esp32_ulp.c \
 	modesp32.c \
 	moduhashlib.c \
+	moducrypto.c \
 	espneopixel.c \
 	machine_hw_spi.c \
 	machine_wdt.c \

--- a/ports/esp32/moducrypto.c
+++ b/ports/esp32/moducrypto.c
@@ -89,6 +89,7 @@ STATIC mp_obj_t mod_crypto_rsa_sign(mp_obj_t key, mp_obj_t message) {
 STATIC MP_DEFINE_CONST_FUN_OBJ_2(mod_crypto_rsa_sign_obj, mod_crypto_rsa_sign);
 //20180505 MHE-end--------------------------------------------------------------------------------------
 
+
 STATIC const mp_rom_map_elem_t mp_module_crypto_globals_table[] = {
     { MP_ROM_QSTR(MP_QSTR___name__), MP_ROM_QSTR(MP_QSTR_ucrypto) },
     { MP_ROM_QSTR(MP_QSTR_rsa_sign), MP_ROM_PTR(&mod_crypto_rsa_sign_obj) }, //20180505 MHE

--- a/ports/esp32/moducrypto.c
+++ b/ports/esp32/moducrypto.c
@@ -1,0 +1,104 @@
+/*
+ * This file is part of the Micro Python project, http://micropython.org/
+ *
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2014 Paul Sokolovsky
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#include "py/runtime.h"
+#include "mbedtls/platform.h"
+#include "mbedtls/pk.h"
+#include "mbedtls/rsa.h"  // 20180505 MHE add rsa_sign
+
+//20180505 MHE------------------------------------------------------------------------------------------
+STATIC mp_obj_t mod_crypto_rsa_sign(mp_obj_t key, mp_obj_t message) {
+
+   
+    int ret;
+    mbedtls_pk_context pk;
+    mbedtls_rsa_context *rsa;
+    unsigned char hash[32];
+    mbedtls_pk_init( &pk );
+
+    // get the buffer to send from
+    mp_buffer_info_t bufkey;
+    mp_get_buffer_raise(key, &bufkey, MP_BUFFER_READ);
+    
+    // get the buffer to send from
+    mp_buffer_info_t bufmessage;
+    mp_get_buffer_raise(message, &bufmessage, MP_BUFFER_READ);
+   
+    ret = mbedtls_pk_parse_key(&pk, bufkey.buf, bufkey.len + 1, NULL, 0);
+    if ( ret != 0 ) {
+        mp_raise_ValueError("Unable to parse key");
+        goto exit;
+    }
+
+    if( !mbedtls_pk_can_do( &pk, MBEDTLS_PK_RSA ) )
+    {
+        mp_raise_ValueError("Not an RSA key");
+        goto exit;
+    }
+    
+    if( ( ret = mbedtls_md(
+                    mbedtls_md_info_from_type( MBEDTLS_MD_SHA256 ),
+                    bufmessage.buf, bufmessage.len, hash ) ) != 0 )
+    {
+        mp_raise_ValueError("Unable to hash message");
+        goto exit;
+    }
+
+    rsa = mbedtls_pk_rsa( pk );
+
+    vstr_t signature;
+    vstr_init_len(&signature, rsa->len);
+
+    if( ( ret = mbedtls_rsa_pkcs1_sign(rsa , NULL, NULL, MBEDTLS_RSA_PRIVATE, MBEDTLS_MD_SHA256,
+                                0, hash, (byte*)signature.buf ) ) != 0 )
+    {
+        mp_raise_ValueError("Unable to sign message");
+        goto exit;
+    }
+
+    exit:
+    // free all variables
+    mbedtls_pk_free( &pk );
+    mbedtls_rsa_free( rsa );
+
+    return mp_obj_new_str_from_vstr(&mp_type_bytes, &signature);
+}
+STATIC MP_DEFINE_CONST_FUN_OBJ_2(mod_crypto_rsa_sign_obj, mod_crypto_rsa_sign);
+//20180505 MHE-end--------------------------------------------------------------------------------------
+
+STATIC const mp_rom_map_elem_t mp_module_crypto_globals_table[] = {
+    { MP_ROM_QSTR(MP_QSTR___name__), MP_ROM_QSTR(MP_QSTR_ucrypto) },
+    { MP_ROM_QSTR(MP_QSTR_rsa_sign), MP_ROM_PTR(&mod_crypto_rsa_sign_obj) }, //20180505 MHE
+};
+
+STATIC MP_DEFINE_CONST_DICT(mp_module_crypto_globals,
+    mp_module_crypto_globals_table);
+
+const mp_obj_module_t mp_module_ucrypto = {
+    .base = { &mp_type_module },
+    .globals = (mp_obj_dict_t*)&mp_module_crypto_globals,
+};
+

--- a/ports/esp32/mpconfigport.h
+++ b/ports/esp32/mpconfigport.h
@@ -122,6 +122,7 @@
 #define MICROPY_PY_UHEAPQ                   (1)
 #define MICROPY_PY_UTIMEQ                   (1)
 #define MICROPY_PY_UHASHLIB                 (0) // We use the ESP32 version
+#define MICROPY_PY_UCRYPTO                  (0) // We use the ESP32 version
 #define MICROPY_PY_UHASHLIB_SHA1            (MICROPY_PY_USSL && MICROPY_SSL_AXTLS)
 #define MICROPY_PY_UBINASCII                (1)
 #define MICROPY_PY_UBINASCII_CRC32          (1)

--- a/ports/esp32/mpconfigport.h
+++ b/ports/esp32/mpconfigport.h
@@ -185,6 +185,7 @@ extern const struct _mp_obj_module_t mp_module_onewire;
     { MP_OBJ_NEW_QSTR(MP_QSTR_network), (mp_obj_t)&mp_module_network }, \
     { MP_OBJ_NEW_QSTR(MP_QSTR__onewire), (mp_obj_t)&mp_module_onewire }, \
     { MP_OBJ_NEW_QSTR(MP_QSTR_uhashlib), (mp_obj_t)&mp_module_uhashlib }, \
+    { MP_OBJ_NEW_QSTR(MP_QSTR_ucrypto), (mp_obj_t)&mp_module_ucrypto }, \
 
 #define MICROPY_PORT_BUILTIN_MODULE_WEAK_LINKS \
     { MP_OBJ_NEW_QSTR(MP_QSTR_binascii), (mp_obj_t)&mp_module_ubinascii }, \

--- a/py/builtin.h
+++ b/py/builtin.h
@@ -106,6 +106,7 @@ extern const mp_obj_module_t mp_module_ujson;
 extern const mp_obj_module_t mp_module_ure;
 extern const mp_obj_module_t mp_module_uheapq;
 extern const mp_obj_module_t mp_module_uhashlib;
+extern const mp_obj_module_t mp_module_ucrypto;
 extern const mp_obj_module_t mp_module_ubinascii;
 extern const mp_obj_module_t mp_module_urandom;
 extern const mp_obj_module_t mp_module_uselect;

--- a/py/mpconfig.h
+++ b/py/mpconfig.h
@@ -1133,6 +1133,10 @@ typedef double mp_float_t;
 #define MICROPY_PY_UHASHLIB (0)
 #endif
 
+#ifndef MICROPY_PY_UCRYPTO
+#define MICROPY_PY_UCRYPTO (0)
+#endif
+
 #ifndef MICROPY_PY_UBINASCII
 #define MICROPY_PY_UBINASCII (0)
 #endif

--- a/py/objmodule.c
+++ b/py/objmodule.c
@@ -193,6 +193,9 @@ STATIC const mp_rom_map_elem_t mp_builtin_module_table[] = {
 #if MICROPY_PY_UHASHLIB
     { MP_ROM_QSTR(MP_QSTR_uhashlib), MP_ROM_PTR(&mp_module_uhashlib) },
 #endif
+#if MICROPY_PY_UCRYPTO
+    { MP_ROM_QSTR(MP_QSTR_ucrypto), MP_ROM_PTR(&mp_module_ucrypto) },
+#endif
 #if MICROPY_PY_UBINASCII
     { MP_ROM_QSTR(MP_QSTR_ubinascii), MP_ROM_PTR(&mp_module_ubinascii) },
 #endif


### PR DESCRIPTION
First of all I love micropython and I want to thank you for this great job.
With this module it's easy to compute JWT token and then connect the ESP32 to Google Cloud Platform (IoT Core) over MQTT.
Usage : 
```
import ucrypto
signature = ucrypto.rsa_sign(pivateKey, message)
```
I did it simple and efficient but if you need some changes on the API ask me.
This module implement mbedtls_rsa_pkcs1_sign()
I can test it only on ESP32 platform and it works but I don't know if it can impact other ports and I don't know if we can deploy on other ports.

If this pull request is accepted I will submit a pull request to "micropython-lib" to add a new module who  help to connect to Google Cloud platform over MQTT.

Matthieu
