### PR TITLE
Add fuzzing target to ports/unix

### DIFF
--- a/ports/unix/.gitignore
+++ b/ports/unix/.gitignore
@@ -4,8 +4,10 @@ build-minimal
 build-coverage
 build-nanbox
 build-freedos
+build-fuzzing
 micropython
 micropython_fast
+micropython_fuzzing
 micropython_minimal
 micropython_coverage
 micropython_nanbox

--- a/ports/unix/Makefile
+++ b/ports/unix/Makefile
@@ -215,6 +215,17 @@ minimal:
 	    MICROPY_PY_TERMIOS=0 MICROPY_PY_USSL=0 \
 	    MICROPY_USE_READLINE=0
 
+# build an interpreter for fuzz testing, particularly with afl-fuzz.
+# Generally, this will be invoked with CC= set to the fuzzer's compiler
+# wrapper, e.g.,
+#    make CC=/path/to/afl-clang/fast fuzzing
+fuzzing:
+	$(MAKE) COPT="-Os -g -fsanitize=undefined -fno-sanitize-recover=undefined" LDFLAGS_EXTRA='-fsanitize=undefined -fno-sanitize-recover=undefined' CFLAGS_EXTRA='-DMP_CONFIGFILE="<mpconfigport_fuzzing.h>"' \
+	    BUILD=build-fuzzing PROG=micropython_fuzzing FROZEN_DIR= FROZEN_MPY_DIR= \
+	    MICROPY_PY_BTREE=0 MICROPY_PY_FFI=0 MICROPY_PY_SOCKET=0 MICROPY_PY_THREAD=0 \
+	    MICROPY_PY_TERMIOS=0 MICROPY_PY_USSL=0 \
+	    MICROPY_USE_READLINE=0 STRIP=true
+
 # build interpreter with nan-boxing as object model
 nanbox:
 	$(MAKE) \

--- a/ports/unix/main.c
+++ b/ports/unix/main.c
@@ -520,6 +520,9 @@ MP_NOINLINE int main_(int argc, char **argv) {
     printf("    cur   %d\n", m_get_current_bytes_allocated());
     printf("    peak  %d\n", m_get_peak_bytes_allocated());
     */
+#ifdef __AFL_HAVE_MANUAL_CONTROL
+    __AFL_INIT();
+#endif
 
     const int NOTHING_EXECUTED = -2;
     int ret = NOTHING_EXECUTED;

--- a/ports/unix/mpconfigport_fuzzing.h
+++ b/ports/unix/mpconfigport_fuzzing.h
@@ -1,0 +1,65 @@
+/*
+ * This file is part of the MicroPython project, http://micropython.org/
+ *
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2018 Jeff Epler
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#include <mpconfigport.h>
+
+#define MICROPY_FLOAT_HIGH_QUALITY_HASH (1)
+
+#undef MICROPY_PY_IO_FILEIO
+#define MICROPY_PY_IO_FILEIO        (0)
+
+#undef MICROPY_PY_BUILTINS_INPUT
+#define MICROPY_PY_BUILTINS_INPUT   (0)
+
+#undef MICROPY_PY_IO_FILEIO
+#define MICROPY_PY_IO_FILEIO        (0)
+
+#undef MICROPY_PY_UCTYPES
+#define MICROPY_PY_UCTYPES          (0)
+
+#undef MICROPY_PY_UZLIB
+#define MICROPY_PY_UZLIB            (0)
+
+#undef MICROPY_PY_UBINASCII_CRC32
+#define MICROPY_PY_UBINASCII_CRC32  (0)
+
+#undef MICROPY_PY_USELECT_POSIX
+#define MICROPY_PY_USELECT_POSIX    (0)
+
+#undef MICROPY_PY_USELECT_DEF
+#define MICROPY_PY_USELECT_DEF /* nothing */
+
+#undef MICROPY_PY_STRUCT
+#define MICROPY_PY_STRUCT           (0)
+
+#undef MICROPY_PY_ARRAY
+#define MICROPY_PY_ARRAY            (0)
+
+#undef MICROPY_MODULE_FROZEN_STR
+#define MICROPY_MODULE_FROZEN_STR   (0)
+
+#undef MICROPY_PORT_BUILTINS
+#define MICROPY_PORT_BUILTINS /* nothing */


### PR DESCRIPTION
This allows micropython to be built with the most efficient mode for afl-fuzz (afl-clang-fast + __AFL_INIT) and disables several built in modules for reasons discussed in that commit.