### PR TITLE
emitbc: Avoid undefined behavior calling memset()

### DIFF
--- a/py/emitbc.c
+++ b/py/emitbc.c
@@ -315,7 +315,7 @@ void mp_emit_bc_start_pass(emit_t *emit, pass_kind_t pass, scope_t *scope) {
     emit->last_source_line = 1;
     #ifndef NDEBUG
     // With debugging enabled labels are checked for unique assignment
-    if (pass < MP_PASS_EMIT) {
+    if (pass < MP_PASS_EMIT && emit->label_offsets) {
         memset(emit->label_offsets, -1, emit->max_num_labels * sizeof(mp_uint_t));
     }
     #endif


### PR DESCRIPTION
When micropython is built with 'clang -fsanitize=undefined', a diagnostic like the following will occur:
```
$ UBSAN_OPTIONS=abort_on_error=1 ./micropython_fuzzing  -c 'print(1)'
../../py/emitbc.c:319:16: runtime error: null pointer passed as argument 1, which is declared to never be null
/usr/include/string.h:62:62: note: nonnull attribute specified here
Aborted
```
Traditionally, memset(NULL, value, 0) has been accepted without causing problems.  However, it is not standards-compliant behavior; and for instance Ted Unangst of the OpenBSD project notes that "A smart C compiler may observe a call to memcpy, flag both pointers as valid, and then delete any null checks. Forwards and backwards."
    https://www.tedunangst.com/flak/post/zero-size-objects

Since micropython is using -fdelete-null-pointer-checks ("enabled by default on most targets") and it is probably giving good code size improvements, we have to pay a modest price and add a few checks.