### PR TITLE
parsenum: avoid undefined behavior parsing floats

### DIFF
--- a/py/parsenum.c
+++ b/py/parsenum.c
@@ -234,7 +234,8 @@ mp_obj_t mp_parse_num_decimal(const char *str, size_t len, bool allow_imag, bool
             if ('0' <= dig && dig <= '9') {
                 dig -= '0';
                 if (in == PARSE_DEC_IN_EXP) {
-                    exp_val = 10 * exp_val + dig;
+                    if(exp_val < (INT_MAX-9)/10)
+                        exp_val = 10 * exp_val + dig;
                 } else {
                     if (dec_val < DEC_VAL_MAX) {
                         // dec_val won't overflow so keep accumulating


### PR DESCRIPTION
Fuzz testing combined with the undefined behavior sanitizer found that parsing unreasonable float literals like `1e+9999999999999` resulted in undefined behavior due to overflow in signed integer arithmetic.

Many compilers actually implement "wrapping" arithmetic on signed integers.  This leads to a concrete, wrong result:
```
>>> 1e18446744073709551623
10000000.0
```
note that the exponent value is just 2**64+7, and the incorrect result is 10e7