### PR TITLE
mp_float_hash: Fix undefined behavior hashing float number

### DIFF
--- a/py/objfloat.c
+++ b/py/objfloat.c
@@ -88,7 +88,7 @@ typedef uint32_t mp_float_uint_t;
         if (adj_exp <= MP_FLOAT_FRAC_BITS) {
             // number may have a fraction; xor the integer part with the fractional part
             val = (frc >> (MP_FLOAT_FRAC_BITS - adj_exp))
-                ^ (frc & ((1 << (MP_FLOAT_FRAC_BITS - adj_exp)) - 1));
+                ^ (frc & (((mp_float_uint_t)1 << (MP_FLOAT_FRAC_BITS - adj_exp)) - 1));
         } else if ((unsigned int)adj_exp < BITS_PER_BYTE * sizeof(mp_int_t) - 1) {
             // the number is a (big) whole integer and will fit in val's signed-width
             val = (mp_int_t)frc << (adj_exp - MP_FLOAT_FRAC_BITS);


### PR DESCRIPTION
When computing e.g. hash(0.4e3) with ubsan enabled, a diagnostic like the following would occur:
```
../../py/objfloat.c:91:30: runtime error: shift exponent 44 is too large for 32-bit type 'int'
```

by casting a constant "1" to the right type, the intended value is preserved.

This likely only affected platforms with MICROPY_FLOAT_IMPL_DOUBLE.