### PR TITLE
mp_float_hash: Fix undefined behavior hashing negative zero

### DIFF
--- a/py/objfloat.c
+++ b/py/objfloat.c
@@ -99,7 +99,7 @@ typedef uint32_t mp_float_uint_t;
     }
 
     if (u.p.sgn) {
-        val = -val;
+        val = -(mp_uint_t)val;
     }
 
     return val;


### PR DESCRIPTION
Under ubsan, the when evaluating `hash(-0.)`, the following diagnostic occurs:
```
../../py/objfloat.c:102:15: runtime error: negation of -9223372036854775808 cannot be represented in type 'mp_int_t' (aka 'long'); cast to an unsigned type to negate this value to itself
```

.. do just that, to tell the compiler that we want to perform this operation using modulo arithmetic rules.

Note that this is a different problem than #3801, it just occurs in the same function.