### PR TITLE
ports/esp32: silence ESP-IDF log messages when in raw REPL mode

### DIFF
--- a/ports/esp32/main.c
+++ b/ports/esp32/main.c
@@ -28,6 +28,7 @@
 
 #include <stdio.h>
 #include <string.h>
+#include <stdarg.h>
 
 #include "freertos/FreeRTOS.h"
 #include "freertos/task.h"
@@ -35,6 +36,7 @@
 #include "nvs_flash.h"
 #include "esp_task.h"
 #include "soc/cpu.h"
+#include "esp_log.h"
 
 #include "py/stackctrl.h"
 #include "py/nlr.h"
@@ -57,6 +59,11 @@
 
 STATIC StaticTask_t mp_task_tcb;
 STATIC StackType_t mp_task_stack[MP_TASK_STACK_LEN] __attribute__((aligned (8)));
+
+int vprintf_null(const char *format, va_list ap) {
+    // do nothing: this is used as a log target during raw repl mode
+    return 0;
+}
 
 void mp_task(void *pvParameter) {
     volatile uint32_t sp = (uint32_t)get_sp();
@@ -93,9 +100,11 @@ soft_reset:
 
     for (;;) {
         if (pyexec_mode_kind == PYEXEC_MODE_RAW_REPL) {
+	    vprintf_like_t vprintf_log = esp_log_set_vprintf(vprintf_null);
             if (pyexec_raw_repl() != 0) {
                 break;
             }
+	    esp_log_set_vprintf(vprintf_log);
         } else {
             if (pyexec_friendly_repl() != 0) {
                 break;

--- a/ports/esp32/modnetwork.c
+++ b/ports/esp32/modnetwork.c
@@ -139,24 +139,26 @@ static esp_err_t event_handler(void *ctx, system_event_t *event) {
         // This is a workaround as ESP32 WiFi libs don't currently
         // auto-reassociate.
         system_event_sta_disconnected_t *disconn = &event->event_info.disconnected;
-        ESP_LOGI("wifi", "STA_DISCONNECTED, reason:%d", disconn->reason);
+        char *message = "";
         switch (disconn->reason) {
             case WIFI_REASON_BEACON_TIMEOUT:
-                mp_printf(MP_PYTHON_PRINTER, "beacon timeout\n");
                 // AP has dropped out; try to reconnect.
+		message = "\nbeacon timeout";
                 break;
             case WIFI_REASON_NO_AP_FOUND:
-                mp_printf(MP_PYTHON_PRINTER, "no AP found\n");
                 // AP may not exist, or it may have momentarily dropped out; try to reconnect.
+		message = "\nno AP found";
                 break;
             case WIFI_REASON_AUTH_FAIL:
-                mp_printf(MP_PYTHON_PRINTER, "authentication failed\n");
+		message = "\nauthentication failed";
                 wifi_sta_connected = false;
                 break;
             default:
                 // Let other errors through and try to reconnect.
                 break;
         }
+        ESP_LOGI("wifi", "STA_DISCONNECTED, reason:%d%s", disconn->reason, message);
+
         if (wifi_sta_connected) {
             wifi_mode_t mode;
             if (esp_wifi_get_mode(&mode) == ESP_OK) {
@@ -164,7 +166,7 @@ static esp_err_t event_handler(void *ctx, system_event_t *event) {
                     // STA is active so attempt to reconnect.
                     esp_err_t e = esp_wifi_connect();
                     if (e != ESP_OK) {
-                        mp_printf(MP_PYTHON_PRINTER, "error attempting to reconnect: 0x%04x", e);
+			ESP_LOGI("wifi", "error attempting to reconnect: 0x%04x", e);
                     }
                 }
             }


### PR DESCRIPTION
This prevents clients such as ampy, mpy-utils, etc getting confused
by extraneous data.