### PR TITLE
stm32/usb: Restructured initialisation to support any mix of configurations

### DIFF
--- a/ports/stm32/boards/STM32F429DISC/mpconfigboard.h
+++ b/ports/stm32/boards/STM32F429DISC/mpconfigboard.h
@@ -72,3 +72,4 @@
 #define MICROPY_HW_USB_HS_IN_FS        (1)
 #define MICROPY_HW_USB_VBUS_DETECT_PIN (pin_B13)
 #define MICROPY_HW_USB_OTG_ID_PIN      (pin_B12)
+#define MICROPY_HW_USB_NUM_CDC         (1)

--- a/ports/stm32/main.c
+++ b/ports/stm32/main.c
@@ -666,7 +666,7 @@ soft_reset:
     #if MICROPY_HW_ENABLE_USB
     // init USB device to default setting if it was not already configured
     if (!(pyb_usb_flags & PYB_USB_FLAG_USB_MODE_CALLED)) {
-        pyb_usb_dev_init(USBD_VID, USBD_PID_CDC_MSC, USBD_MODE_CDC_MSC, NULL);
+        pyb_usb_dev_init(USBD_VID, USBD_PID_CDC_MSC, 1, true, false, false, NULL);
     }
     #endif
 

--- a/ports/stm32/usb.h
+++ b/ports/stm32/usb.h
@@ -60,7 +60,7 @@ MP_DECLARE_CONST_FUN_OBJ_0(pyb_have_cdc_obj); // deprecated
 MP_DECLARE_CONST_FUN_OBJ_1(pyb_hid_send_report_obj); // deprecated
 
 void pyb_usb_init0(void);
-bool pyb_usb_dev_init(uint16_t vid, uint16_t pid, usb_device_mode_t mode, USBD_HID_ModeInfoTypeDef *hid_info);
+bool pyb_usb_dev_init(uint16_t vid, uint16_t pid, uint8_t cdc, bool msc, bool hid, bool high_speed, USBD_HID_ModeInfoTypeDef *hid_info);
 void pyb_usb_dev_deinit(void);
 bool usb_vcp_is_enabled(void);
 int usb_vcp_recv_byte(uint8_t *c); // if a byte is available, return 1 and put the byte in *c, else return 0

--- a/ports/stm32/usbd_cdc_interface.h
+++ b/ports/stm32/usbd_cdc_interface.h
@@ -51,6 +51,7 @@ typedef struct _usbd_cdc_itf_t {
 
     volatile uint8_t dev_is_connected; // indicates if we are connected
     uint8_t attached_to_repl; // indicates if interface is connected to REPL
+    uint8_t interface; // the interface index this represents
 } usbd_cdc_itf_t;
 
 // This is implemented in usb.c

--- a/ports/stm32/usbd_conf.c
+++ b/ports/stm32/usbd_conf.c
@@ -418,7 +418,7 @@ void USBD_LL_SetFifo(PCD_HandleTypeDef *pcd_handle, USBD_HandleTypeDef *pdev) {
   * @retval USBD Status
   */
 USBD_StatusTypeDef USBD_LL_Init(USBD_HandleTypeDef *pdev, int high_speed) {
-
+    usbd_cdc_msc_hid_state_t *usbd = (usbd_cdc_msc_hid_state_t *)pdev->pClassData;
     #if MICROPY_HW_USB_FS
     
     if (pdev->id ==  USB_PHY_FS_ID) {
@@ -458,7 +458,7 @@ USBD_StatusTypeDef USBD_LL_Init(USBD_HandleTypeDef *pdev, int high_speed) {
 
         // Set LL Driver parameters
         pcd_hs_handle.Instance = USB_OTG_HS;
-        pcd_hs_handle.Init.dev_endpoints = 6;
+        pcd_hs_handle.Init.dev_endpoints = usbd->used_endpoints;
         pcd_hs_handle.Init.use_dedicated_ep1 = 0;
         pcd_hs_handle.Init.ep0_mps = 0x40;
         pcd_hs_handle.Init.dma_enable = 0;
@@ -496,7 +496,7 @@ USBD_StatusTypeDef USBD_LL_Init(USBD_HandleTypeDef *pdev, int high_speed) {
 
         // Set LL Driver parameters
         pcd_hs_handle.Instance = USB_OTG_HS;
-        pcd_hs_handle.Init.dev_endpoints = 6;
+        pcd_hs_handle.Init.dev_endpoints = usbd->used_endpoints;
         pcd_hs_handle.Init.use_dedicated_ep1 = 0;
         pcd_hs_handle.Init.ep0_mps = 0x40;
 

--- a/ports/stm32/usbd_conf.h
+++ b/ports/stm32/usbd_conf.h
@@ -36,8 +36,9 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include "py/mpconfig.h"
 
-#define USBD_MAX_NUM_INTERFACES               4
+#define USBD_MAX_NUM_INTERFACES               (2 + (MICROPY_HW_USB_NUM_CDC * 2))
 #define USBD_MAX_NUM_CONFIGURATION            1
 #define USBD_MAX_STR_DESC_SIZ                 0x100
 #define USBD_SELF_POWERED                     0

--- a/ports/stm32/usbdev/class/inc/usbd_cdc_msc_hid0.h
+++ b/ports/stm32/usbdev/class/inc/usbd_cdc_msc_hid0.h
@@ -29,19 +29,6 @@
 // these are exports for the CDC/MSC/HID interface that are independent
 // from any other definitions/declarations
 
-// only CDC_MSC and CDC_HID are available
-typedef enum {
-    USBD_MODE_CDC = 0x01,
-    USBD_MODE_MSC = 0x02,
-    USBD_MODE_HID = 0x04,
-    USBD_MODE_CDC2 = 0x08,
-    USBD_MODE_CDC_MSC = USBD_MODE_CDC | USBD_MODE_MSC,
-    USBD_MODE_CDC_HID = USBD_MODE_CDC | USBD_MODE_HID,
-    USBD_MODE_MSC_HID = USBD_MODE_MSC | USBD_MODE_HID,
-    USBD_MODE_CDC2_MSC = USBD_MODE_CDC | USBD_MODE_MSC | USBD_MODE_CDC2,
-    USBD_MODE_HIGH_SPEED = 0x80, // or with one of the above
-} usb_device_mode_t;
-
 typedef struct _USBD_HID_ModeInfoTypeDef {
     uint8_t subclass; // 0=no sub class, 1=boot
     uint8_t protocol; // 0=none, 1=keyboard, 2=mouse

--- a/ports/stm32/usbdev/class/src/usbd_msc_bot.c
+++ b/ports/stm32/usbdev/class/src/usbd_msc_bot.c
@@ -114,12 +114,12 @@ void MSC_BOT_Init (USBD_HandleTypeDef  *pdev)
 
   hmsc->bdev_ops->Init(0);
 
-  USBD_LL_FlushEP(pdev, MSC_OUT_EP);
-  USBD_LL_FlushEP(pdev, MSC_IN_EP);
+  USBD_LL_FlushEP(pdev, hmsc->out_ep);
+  USBD_LL_FlushEP(pdev, hmsc->in_ep);
 
   /* Prapare EP to Receive First BOT Cmd */
   USBD_LL_PrepareReceive (pdev,
-                          MSC_OUT_EP,
+                          hmsc->out_ep,
                           (uint8_t *)&hmsc->cbw,
                           USBD_BOT_CBW_LENGTH);
 }
@@ -139,7 +139,7 @@ void MSC_BOT_Reset (USBD_HandleTypeDef  *pdev)
 
   /* Prapare EP to Receive First BOT Cmd */
   USBD_LL_PrepareReceive (pdev,
-                          MSC_OUT_EP,
+                          hmsc->out_ep,
                           (uint8_t *)&hmsc->cbw,
                           USBD_BOT_CBW_LENGTH);
 }
@@ -236,7 +236,7 @@ static void  MSC_BOT_CBW_Decode (USBD_HandleTypeDef  *pdev)
   hmsc->csw.dTag = hmsc->cbw.dTag;
   hmsc->csw.dDataResidue = hmsc->cbw.dDataLength;
 
-  if ((USBD_LL_GetRxDataSize (pdev ,MSC_OUT_EP) != USBD_BOT_CBW_LENGTH) ||
+  if ((USBD_LL_GetRxDataSize (pdev, hmsc->out_ep) != USBD_BOT_CBW_LENGTH) ||
       (hmsc->cbw.dSignature != USBD_BOT_CBW_SIGNATURE)||
         (hmsc->cbw.bLUN > 1) ||
           (hmsc->cbw.bCBLength < 1) ||
@@ -307,7 +307,7 @@ static void  MSC_BOT_SendData(USBD_HandleTypeDef  *pdev,
   hmsc->csw.bStatus = USBD_CSW_CMD_PASSED;
   hmsc->bot_state = USBD_BOT_SEND_DATA;
 
-  USBD_LL_Transmit (pdev, MSC_IN_EP, buf, len);
+  USBD_LL_Transmit (pdev, hmsc->in_ep, buf, len);
 }
 
 /**
@@ -327,13 +327,13 @@ void  MSC_BOT_SendCSW (USBD_HandleTypeDef  *pdev,
   hmsc->bot_state = USBD_BOT_IDLE;
 
   USBD_LL_Transmit (pdev,
-             MSC_IN_EP,
+             hmsc->in_ep,
              (uint8_t *)&hmsc->csw,
              USBD_BOT_CSW_LENGTH);
 
   /* Prapare EP to Receive next Cmd */
   USBD_LL_PrepareReceive (pdev,
-                    MSC_OUT_EP,
+                    hmsc->out_ep,
                     (uint8_t *)&hmsc->cbw,
                     USBD_BOT_CBW_LENGTH);
 
@@ -354,14 +354,14 @@ static void  MSC_BOT_Abort (USBD_HandleTypeDef  *pdev)
       (hmsc->cbw.dDataLength != 0) &&
       (hmsc->bot_status == USBD_BOT_STATUS_NORMAL) )
   {
-    USBD_LL_StallEP(pdev, MSC_OUT_EP );
+    USBD_LL_StallEP(pdev, hmsc->out_ep );
   }
-  USBD_LL_StallEP(pdev, MSC_IN_EP);
+  USBD_LL_StallEP(pdev, hmsc->in_ep);
 
   if(hmsc->bot_status == USBD_BOT_STATUS_ERROR)
   {
     USBD_LL_PrepareReceive (pdev,
-                      MSC_OUT_EP,
+                      hmsc->out_ep,
                       (uint8_t *)&hmsc->cbw,
                       USBD_BOT_CBW_LENGTH);
   }
@@ -381,7 +381,7 @@ void  MSC_BOT_CplClrFeature (USBD_HandleTypeDef  *pdev, uint8_t epnum)
 
   if(hmsc->bot_status == USBD_BOT_STATUS_ERROR )/* Bad CBW Signature */
   {
-    USBD_LL_StallEP(pdev, MSC_IN_EP);
+    USBD_LL_StallEP(pdev, hmsc->in_ep);
     hmsc->bot_status = USBD_BOT_STATUS_NORMAL;
   }
   else if(((epnum & 0x80) == 0x80) && ( hmsc->bot_status != USBD_BOT_STATUS_RECOVERY))

--- a/ports/stm32/usbdev/class/src/usbd_msc_scsi.c
+++ b/ports/stm32/usbdev/class/src/usbd_msc_scsi.c
@@ -630,7 +630,7 @@ static int8_t SCSI_Write10 (USBD_HandleTypeDef  *pdev, uint8_t lun , uint8_t *pa
     /* Prepare EP to receive first data packet */
     hmsc->bot_state = USBD_BOT_DATA_OUT;
     USBD_LL_PrepareReceive (pdev,
-                      MSC_OUT_EP,
+                      hmsc->out_ep,
                       hmsc->bot_data,
                       MIN (hmsc->scsi_blk_len, MSC_MEDIA_PACKET));
   }
@@ -728,7 +728,7 @@ static int8_t SCSI_ProcessRead (USBD_HandleTypeDef  *pdev, uint8_t lun)
 
 
   USBD_LL_Transmit (pdev,
-             MSC_IN_EP,
+             hmsc->in_ep,
              hmsc->bot_data,
              len);
 
@@ -787,7 +787,7 @@ static int8_t SCSI_ProcessWrite (USBD_HandleTypeDef  *pdev, uint8_t lun)
   {
     /* Prapare EP to Receive next packet */
     USBD_LL_PrepareReceive (pdev,
-                            MSC_OUT_EP,
+                            hmsc->out_ep,
                             hmsc->bot_data,
                             MIN (hmsc->scsi_blk_len, MSC_MEDIA_PACKET));
   }


### PR DESCRIPTION
This stm32 port change allows an arbitrary number of USB CDC ports at compile time with new optional 'mpconfigboard.h' entry: 
```
#define MICROPY_HW_USB_NUM_CDC         (2)
```
It also provides at-boot configuration of any combination of 0 to `MICROPY_HW_USB_NUM_CDC` com ports on their own or with a HID and / or MSC interface. 
HID has been tested in the default mouse mode simultaneously with mass storage and vcp port.

Repl access can be (simultaneously) enabled/disabled on any CDC, with it enabled on just the first one by default.

This changeset has been finished and tested on F429I-DISCO though it started on an OPENMV STM32F765 board.
It has been used on a Windows 10 PC with no driver issues present.

This is my first time working on the micropython codebase so I've probably missed some conventions or restrictions, please don't hold back with any issues in my changeset.

I realise this replaces a decent chunk of 47ecbbbecbad117820e1c37282e7e61528e5d969 and related commits. I initially developed this against the OpenMV fork thinking it was much closer to mainline than it was, so unfortunately I ended up duplicating effort. Hopefully this is seen as useful enough enhancements to take on.
