### PR TITLE
Optimise instance load/store/delete by skipping special accessors when possible

### DIFF
--- a/py/obj.h
+++ b/py/obj.h
@@ -465,8 +465,12 @@ struct _mp_obj_type_t {
     // A type is an object so must start with this entry, which points to mp_type_type.
     mp_obj_base_t base;
 
-    // The name of this type.
-    qstr name;
+    // Flags associated with this type.
+    #define MP_OBJ_TYPE_FLAG_xyz (0x0001)
+    uint16_t flags;
+
+    // The name of this type, a qstr.
+    uint16_t name;
 
     // Corresponds to __repr__ and __str__ special methods.
     mp_print_fun_t print;

--- a/py/objtype.c
+++ b/py/objtype.c
@@ -3,7 +3,7 @@
  *
  * The MIT License (MIT)
  *
- * Copyright (c) 2013, 2014 Damien P. George
+ * Copyright (c) 2013-2018 Damien P. George
  * Copyright (c) 2014-2016 Paul Sokolovsky
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
@@ -40,6 +40,12 @@
 #define DEBUG_PRINT (0)
 #define DEBUG_printf(...) (void)0
 #endif
+
+#define ENABLE_SPECIAL_ACCESSORS \
+    (MICROPY_PY_DESCRIPTORS  || MICROPY_PY_DELATTR_SETATTR || MICROPY_PY_BUILTINS_PROPERTY)
+
+#define TYPE_FLAG_IS_SUBCLASSED (0x0001)
+#define TYPE_FLAG_HAS_SPECIAL_ACCESSORS (0x0002)
 
 STATIC mp_obj_t static_class_method_make_new(const mp_obj_type_t *self_in, size_t n_args, size_t n_kw, const mp_obj_t *args);
 
@@ -591,6 +597,11 @@ STATIC void mp_obj_instance_load_attr(mp_obj_t self_in, qstr attr, mp_obj_t *des
     mp_obj_class_lookup(&lookup, self->base.type);
     mp_obj_t member = dest[0];
     if (member != MP_OBJ_NULL) {
+        if (!(self->base.type->flags & TYPE_FLAG_HAS_SPECIAL_ACCESSORS)) {
+            // Class doesn't have any special accessors to check so return straightaway
+            return;
+        }
+
         #if MICROPY_PY_BUILTINS_PROPERTY
         if (MP_OBJ_IS_TYPE(member, &mp_type_property)) {
             // object member is a property; delegate the load to the property
@@ -652,11 +663,15 @@ STATIC void mp_obj_instance_load_attr(mp_obj_t self_in, qstr attr, mp_obj_t *des
 STATIC bool mp_obj_instance_store_attr(mp_obj_t self_in, qstr attr, mp_obj_t value) {
     mp_obj_instance_t *self = MP_OBJ_TO_PTR(self_in);
 
+    if (!(self->base.type->flags & TYPE_FLAG_HAS_SPECIAL_ACCESSORS)) {
+        // Class doesn't have any special accessors so skip their checks
+        goto skip_special_accessors;
+    }
+
     #if MICROPY_PY_BUILTINS_PROPERTY || MICROPY_PY_DESCRIPTORS
     // With property and/or descriptors enabled we need to do a lookup
     // first in the class dict for the attribute to see if the store should
     // be delegated.
-    // Note: this makes all stores slow... how to fix?
     mp_obj_t member[2] = {MP_OBJ_NULL};
     struct class_lookup_data lookup = {
         .obj = self,
@@ -728,9 +743,9 @@ STATIC bool mp_obj_instance_store_attr(mp_obj_t self_in, qstr attr, mp_obj_t val
     }
     #endif
 
+    #if MICROPY_PY_DELATTR_SETATTR
     if (value == MP_OBJ_NULL) {
         // delete attribute
-        #if MICROPY_PY_DELATTR_SETATTR
         // try __delattr__ first
         mp_obj_t attr_delattr_method[3];
         mp_load_method_maybe(self_in, MP_QSTR___delattr__, attr_delattr_method);
@@ -740,13 +755,8 @@ STATIC bool mp_obj_instance_store_attr(mp_obj_t self_in, qstr attr, mp_obj_t val
             mp_call_method_n_kw(1, 0, attr_delattr_method);
             return true;
         }
-        #endif
-
-        mp_map_elem_t *elem = mp_map_lookup(&self->members, MP_OBJ_NEW_QSTR(attr), MP_MAP_LOOKUP_REMOVE_IF_FOUND);
-        return elem != NULL;
     } else {
         // store attribute
-        #if MICROPY_PY_DELATTR_SETATTR
         // try __setattr__ first
         mp_obj_t attr_setattr_method[4];
         mp_load_method_maybe(self_in, MP_QSTR___setattr__, attr_setattr_method);
@@ -757,8 +767,17 @@ STATIC bool mp_obj_instance_store_attr(mp_obj_t self_in, qstr attr, mp_obj_t val
             mp_call_method_n_kw(2, 0, attr_setattr_method);
             return true;
         }
-        #endif
+    }
+    #endif
 
+skip_special_accessors:
+
+    if (value == MP_OBJ_NULL) {
+        // delete attribute
+        mp_map_elem_t *elem = mp_map_lookup(&self->members, MP_OBJ_NEW_QSTR(attr), MP_MAP_LOOKUP_REMOVE_IF_FOUND);
+        return elem != NULL;
+    } else {
+        // store attribute
         mp_map_lookup(&self->members, MP_OBJ_NEW_QSTR(attr), MP_MAP_LOOKUP_ADD_IF_NOT_FOUND)->value = value;
         return true;
     }
@@ -899,6 +918,34 @@ STATIC mp_int_t instance_get_buffer(mp_obj_t self_in, mp_buffer_info_t *bufinfo,
 //  - there is a constant mp_obj_type_t (called mp_type_type) for the 'type' object
 //  - creating a new class (a new type) creates a new mp_obj_type_t
 
+#if ENABLE_SPECIAL_ACCESSORS
+STATIC bool check_for_special_accessors(mp_obj_t key, mp_obj_t value) {
+    #if MICROPY_PY_DELATTR_SETATTR
+    if (key == MP_OBJ_NEW_QSTR(MP_QSTR___setattr__) || key == MP_OBJ_NEW_QSTR(MP_QSTR___delattr__)) {
+        return true;
+    }
+    #endif
+    #if MICROPY_PY_BUILTINS_PROPERTY
+    if (MP_OBJ_IS_TYPE(value, &mp_type_property)) {
+        return true;
+    }
+    #endif
+    #if MICROPY_PY_DESCRIPTORS
+    static const uint8_t to_check[] = {
+        MP_QSTR___get__, MP_QSTR___set__, MP_QSTR___delete__,
+    };
+    for (size_t i = 0; i < MP_ARRAY_SIZE(to_check); ++i) {
+        mp_obj_t dest_temp[2];
+        mp_load_method_protected(value, to_check[i], dest_temp, true);
+        if (dest_temp[0] != MP_OBJ_NULL) {
+            return true;
+        }
+    }
+    #endif
+    return false;
+}
+#endif
+
 STATIC void type_print(const mp_print_t *print, mp_obj_t self_in, mp_print_kind_t kind) {
     (void)kind;
     mp_obj_type_t *self = MP_OBJ_TO_PTR(self_in);
@@ -985,6 +1032,19 @@ STATIC void type_attr(mp_obj_t self_in, qstr attr, mp_obj_t *dest) {
                     dest[0] = MP_OBJ_NULL; // indicate success
                 }
             } else {
+                #if ENABLE_SPECIAL_ACCESSORS
+                // Check if we add any special accessor methods with this store
+                if (!(self->flags & TYPE_FLAG_HAS_SPECIAL_ACCESSORS)) {
+                    if (check_for_special_accessors(MP_OBJ_NEW_QSTR(attr), dest[1])) {
+                        if (self->flags & TYPE_FLAG_IS_SUBCLASSED) {
+                            // This class is already subclassed so can't have special accessors added
+                            mp_raise_msg(&mp_type_AttributeError, "can't add special method to already-subclassed class");
+                        }
+                        self->flags |= TYPE_FLAG_HAS_SPECIAL_ACCESSORS;
+                    }
+                }
+                #endif
+
                 // store attribute
                 mp_map_elem_t *elem = mp_map_lookup(locals_map, MP_OBJ_NEW_QSTR(attr), MP_MAP_LOOKUP_ADD_IF_NOT_FOUND);
                 elem->value = dest[1];
@@ -1016,6 +1076,7 @@ mp_obj_t mp_obj_new_type(qstr name, mp_obj_t bases_tuple, mp_obj_t locals_dict) 
     // TODO might need to make a copy of locals_dict; at least that's how CPython does it
 
     // Basic validation of base classes
+    uint16_t base_flags = 0;
     size_t bases_len;
     mp_obj_t *bases_items;
     mp_obj_tuple_get(bases_tuple, &bases_len, &bases_items);
@@ -1033,10 +1094,17 @@ mp_obj_t mp_obj_new_type(qstr name, mp_obj_t bases_tuple, mp_obj_t locals_dict) 
                     "type '%q' is not an acceptable base type", t->name));
             }
         }
+        #if ENABLE_SPECIAL_ACCESSORS
+        if (mp_obj_is_instance_type(t)) {
+            t->flags |= TYPE_FLAG_IS_SUBCLASSED;
+            base_flags |= t->flags & TYPE_FLAG_HAS_SPECIAL_ACCESSORS;
+        }
+        #endif
     }
 
     mp_obj_type_t *o = m_new0(mp_obj_type_t, 1);
     o->base.type = &mp_type_type;
+    o->flags = base_flags;
     o->name = name;
     o->print = instance_print;
     o->make_new = mp_obj_instance_make_new;
@@ -1068,6 +1136,21 @@ mp_obj_t mp_obj_new_type(qstr name, mp_obj_t bases_tuple, mp_obj_t locals_dict) 
     }
 
     o->locals_dict = MP_OBJ_TO_PTR(locals_dict);
+
+    #if ENABLE_SPECIAL_ACCESSORS
+    // Check if the class has any special accessor methods
+    if (!(o->flags & TYPE_FLAG_HAS_SPECIAL_ACCESSORS)) {
+        for (size_t i = 0; i < o->locals_dict->map.alloc; i++) {
+            if (MP_MAP_SLOT_IS_FILLED(&o->locals_dict->map, i)) {
+                const mp_map_elem_t *elem = &o->locals_dict->map.table[i];
+                if (check_for_special_accessors(elem->key, elem->value)) {
+                    o->flags |= TYPE_FLAG_HAS_SPECIAL_ACCESSORS;
+                    break;
+                }
+            }
+        }
+    }
+    #endif
 
     const mp_obj_type_t *native_base;
     size_t num_native_bases = instance_count_native_bases(o, &native_base);

--- a/py/objtype.c
+++ b/py/objtype.c
@@ -764,7 +764,7 @@ STATIC bool mp_obj_instance_store_attr(mp_obj_t self_in, qstr attr, mp_obj_t val
     }
 }
 
-void mp_obj_instance_attr(mp_obj_t self_in, qstr attr, mp_obj_t *dest) {
+STATIC void mp_obj_instance_attr(mp_obj_t self_in, qstr attr, mp_obj_t *dest) {
     if (dest[0] == MP_OBJ_NULL) {
         mp_obj_instance_load_attr(self_in, attr, dest);
     } else {

--- a/py/objtype.h
+++ b/py/objtype.h
@@ -42,9 +42,6 @@ typedef struct _mp_obj_instance_t {
 mp_obj_instance_t *mp_obj_new_instance(const mp_obj_type_t *cls, const mp_obj_type_t **native_base);
 #endif
 
-// this needs to be exposed for MICROPY_OPT_CACHE_MAP_LOOKUP_IN_BYTECODE to work
-void mp_obj_instance_attr(mp_obj_t self_in, qstr attr, mp_obj_t *dest);
-
 // these need to be exposed so mp_obj_is_callable can work correctly
 bool mp_obj_instance_is_callable(mp_obj_t self_in);
 mp_obj_t mp_obj_instance_call(mp_obj_t self_in, size_t n_args, size_t n_kw, const mp_obj_t *args);

--- a/py/vm.c
+++ b/py/vm.c
@@ -336,7 +336,7 @@ dispatch_loop:
                     MARK_EXC_IP_SELECTIVE();
                     DECODE_QSTR;
                     mp_obj_t top = TOP();
-                    if (mp_obj_get_type(top)->attr == mp_obj_instance_attr) {
+                    if (mp_obj_is_instance_type(mp_obj_get_type(top))) {
                         mp_obj_instance_t *self = MP_OBJ_TO_PTR(top);
                         mp_uint_t x = *ip;
                         mp_obj_t key = MP_OBJ_NEW_QSTR(qst);
@@ -434,7 +434,7 @@ dispatch_loop:
                     MARK_EXC_IP_SELECTIVE();
                     DECODE_QSTR;
                     mp_obj_t top = TOP();
-                    if (mp_obj_get_type(top)->attr == mp_obj_instance_attr && sp[-1] != MP_OBJ_NULL) {
+                    if (mp_obj_is_instance_type(mp_obj_get_type(top)) && sp[-1] != MP_OBJ_NULL) {
                         mp_obj_instance_t *self = MP_OBJ_TO_PTR(top);
                         mp_uint_t x = *ip;
                         mp_obj_t key = MP_OBJ_NEW_QSTR(qst);

--- a/tests/basics/builtin_property_inherit.py
+++ b/tests/basics/builtin_property_inherit.py
@@ -1,0 +1,53 @@
+# test builtin property combined with inheritance
+try:
+    property
+except:
+    print("SKIP")
+    raise SystemExit
+
+# test property in a base class works for derived classes
+class A:
+    @property
+    def x(self):
+        print('A x')
+        return 123
+class B(A):
+    pass
+class C(B):
+    pass
+class D:
+    pass
+class E(C, D):
+    pass
+print(A().x)
+print(B().x)
+print(C().x)
+print(E().x)
+
+# test that we can add a property to base class after creation
+class F:
+    pass
+F.foo = property(lambda self: print('foo get'))
+class G(F):
+    pass
+F().foo
+G().foo
+
+# should be able to add a property to already-subclassed class because it already has one
+F.bar = property(lambda self: print('bar get'))
+F().bar
+G().bar
+
+# test case where class (H here) is already subclassed before adding attributes
+class H:
+    pass
+class I(H):
+    pass
+
+# should be able to add a normal member to already-subclassed class
+H.val = 2
+print(I().val)
+
+# should be able to add a property to the derived class
+I.baz = property(lambda self: print('baz get'))
+I().baz

--- a/tests/misc/non_compliant.py
+++ b/tests/misc/non_compliant.py
@@ -139,3 +139,13 @@ class A:
 class B(object, A):
     pass
 B().foo()
+
+# can't assign property (or other special accessors) to already-subclassed class
+class A:
+    pass
+class B(A):
+    pass
+try:
+    A.bar = property()
+except AttributeError:
+    print('AttributeError')

--- a/tests/misc/non_compliant.py.exp
+++ b/tests/misc/non_compliant.py.exp
@@ -20,3 +20,4 @@ NotImplementedError
 AttributeError
 TypeError
 A.foo
+AttributeError


### PR DESCRIPTION
This PR aims to optimise load/store/delete of attributes in user defined classes by not looking up special accessors (property, `__get__`, `__delete__`, `__set__`, `__setattr__` and `__getattr_`) if they are guaranteed not to exist in the class.

Currently, if you do `my_obj.foo()` then the runtime has to do a few checks to see if `foo` is a property or has `__get__`, and if so delegate the call.  And for stores things like `my_obj.foo = 1` has to first check if `foo` is a property or has `__set__` defined on it.

Doing all those checks each and every time the attribute is accessed has a performance penalty.  This PR eliminates all those checks for cases when it's guaranteed that the checks will always fail, ie no attributes are properties nor have any special accessor methods defined on them.

To make this guarantee it checks all attributes of a user-defined class when it is first created.  If any of the attributes of the user class are properties or have special accessors, or any of the base classes of the user class have them, then it sets a flag in the class to indicate that special accessors must be checked for.  Then in the load/store/delete code it checks this flag to see if it can take the short cut and optimise the lookup.

Code size increase with this PR is:
```
   bare-arm:   +16 
minimal x86:   +32 
   unix x64:  +200 
unix nanbox:  +256 
      stm32:   +80 
     cc3200:   +80 
    esp8266:  +436 
      esp32:  +108 
```
Bare-arm and minimal increase because of the introduction of a `flags` entry in `mp_obj_type_t`, which will be generally useful for other things in the future as well.  esp8266 increases by more than the others because it has overhead for loading non-32-bit values from RAM.

With this PR performance increases by about 6%, which is quite an improvement.  More importantly, MICROPY_PY_DESCRIPTORS can now be enabled without any additional overhead (see related discussion in #3644).

Performance tests that were done:
- on unix x86-64, pystone improved by about 5%
- on pyboard, pystone improved by about 6.5%, from 1683 up to 1794
- on pyboard, bm_chaos (from CPython benchmark suite) improved by about 5%
- on esp32, pystone improved by about 30%, but caching effects probably play a role here
- on esp32, bm_chaos improved by about 11%

**One important downside of this PR**: because checks for properties and special accessors is done at the time of creation of a user-defined class, the optimisation trick here will fail if classes have properties or special methods added after they are created.  For example
```python
class A:
    pass
def getter(self):
    print('get')
    return 1
A.foo = property(getter) # dynamically add property to the class
print(A().foo) # won't work with this PR, just returns a property object
```
The reason it doesn't work now is because properties/special accessors are only checked for during class creation.  It would be possible to check when attributes are added to a class if they are a property/special accessor, but that only solves part of the problem: there's still the chance that a *base class* is changed dynamically, and the derived class has no way of knowing this.

In summary: this PR gives a really great performance boost and allows to enable descriptors with no cost to classes that don't use them.  But is it worth giving up on the ability to dynamically add properties/special accessors to a class (does anyone ever do that)?