### PR TITLE
Add gc_sweep_all() to run all remaining finalisers

### DIFF
--- a/ports/esp32/main.c
+++ b/ports/esp32/main.c
@@ -116,6 +116,8 @@ soft_reset:
     mp_thread_deinit();
     #endif
 
+    gc_sweep_all();
+
     mp_hal_stdout_tx_str("PYB: soft reboot\r\n");
 
     // deinitialise peripherals

--- a/ports/esp8266/main.c
+++ b/ports/esp8266/main.c
@@ -88,6 +88,7 @@ STATIC void mp_reset(void) {
 }
 
 void soft_reset(void) {
+    gc_sweep_all();
     mp_hal_stdout_tx_str("PYB: soft reboot\r\n");
     mp_hal_delay_us(10000); // allow UART to flush output
     mp_reset();

--- a/ports/stm32/main.c
+++ b/ports/stm32/main.c
@@ -756,5 +756,7 @@ soft_reset_exit:
     pyb_thread_deinit();
     #endif
 
+    gc_sweep_all();
+
     goto soft_reset;
 }

--- a/py/gc.c
+++ b/py/gc.c
@@ -362,6 +362,13 @@ void gc_collect_end(void) {
     GC_EXIT();
 }
 
+void gc_sweep_all(void) {
+    GC_ENTER();
+    MP_STATE_MEM(gc_lock_depth)++;
+    MP_STATE_MEM(gc_stack_overflow) = 0;
+    gc_collect_end();
+}
+
 void gc_info(gc_info_t *info) {
     GC_ENTER();
     info->total = MP_STATE_MEM(gc_pool_end) - MP_STATE_MEM(gc_pool_start);

--- a/py/gc.h
+++ b/py/gc.h
@@ -44,6 +44,7 @@ void gc_collect(void);
 void gc_collect_start(void);
 void gc_collect_root(void **ptrs, size_t len);
 void gc_collect_end(void);
+void gc_sweep_all(void);
 
 void *gc_alloc(size_t n_bytes, bool has_finaliser);
 void gc_free(void *ptr); // does not call finaliser


### PR DESCRIPTION
This PR adds the `gc_sweep_all()` function which does a garbage collection without tracing any root pointers, so frees all the memory, and most importantly runs any remaining finalisers.

This helps mainly for soft reset: it will close any open files, any open sockets, and help to get the system back to a clean state upon soft reset.

For example, before this patch if you open a new file for writing (eg `open('test', 'w')`) and then immediately do a soft reset, then the file is not there on the filesystem..  Similarly any final data may not be written to the file if it's not closed.  After this patch the file will be closed automatically upon soft reset.

It also closes any remaining open sockets, and should go a long way to fixing soft reset issues on esp8266/esp32 such as #1896 and #3828