### PR TITLE
Add uio.IOBase class to allow user-defined streams

### DIFF
--- a/ports/esp32/mpconfigport.h
+++ b/ports/esp32/mpconfigport.h
@@ -98,6 +98,7 @@
 #define MICROPY_PY_CMATH                    (1)
 #define MICROPY_PY_GC                       (1)
 #define MICROPY_PY_IO                       (1)
+#define MICROPY_PY_IO_IOBASE                (1)
 #define MICROPY_PY_IO_FILEIO                (1)
 #define MICROPY_PY_IO_BYTESIO               (1)
 #define MICROPY_PY_IO_BUFFEREDWRITER        (1)

--- a/ports/esp8266/mpconfigport.h
+++ b/ports/esp8266/mpconfigport.h
@@ -55,6 +55,7 @@
 #define MICROPY_PY_MATH             (1)
 #define MICROPY_PY_CMATH            (0)
 #define MICROPY_PY_IO               (1)
+#define MICROPY_PY_IO_IOBASE        (1)
 #define MICROPY_PY_IO_FILEIO        (1)
 #define MICROPY_PY_STRUCT           (1)
 #define MICROPY_PY_SYS              (1)

--- a/ports/stm32/mpconfigport.h
+++ b/ports/stm32/mpconfigport.h
@@ -105,6 +105,7 @@
 #define MICROPY_PY_MATH_SPECIAL_FUNCTIONS (1)
 #define MICROPY_PY_CMATH            (1)
 #define MICROPY_PY_IO               (1)
+#define MICROPY_PY_IO_IOBASE        (1)
 #define MICROPY_PY_IO_FILEIO        (MICROPY_VFS_FAT) // because mp_type_fileio/textio point to fatfs impl
 #define MICROPY_PY_SYS_MAXSIZE      (1)
 #define MICROPY_PY_SYS_EXIT         (1)

--- a/ports/unix/mpconfigport.h
+++ b/ports/unix/mpconfigport.h
@@ -104,6 +104,7 @@
 #define MICROPY_PY_MATH_SPECIAL_FUNCTIONS (1)
 #endif
 #define MICROPY_PY_CMATH            (1)
+#define MICROPY_PY_IO_IOBASE        (1)
 #define MICROPY_PY_IO_FILEIO        (1)
 #define MICROPY_PY_GC_COLLECT_RETVAL (1)
 #define MICROPY_MODULE_FROZEN_STR   (1)

--- a/py/mpconfig.h
+++ b/py/mpconfig.h
@@ -996,6 +996,11 @@ typedef double mp_float_t;
 #define MICROPY_PY_IO (1)
 #endif
 
+// Whether to provide "io.IOBase" class to support user streams
+#ifndef MICROPY_PY_IO_IOBASE
+#define MICROPY_PY_IO_IOBASE (0)
+#endif
+
 // Whether to provide "uio.resource_stream()" function with
 // the semantics of CPython's pkg_resources.resource_stream()
 // (allows to access binary resources in frozen source packages).

--- a/tests/extmod/vfs_userfs.py
+++ b/tests/extmod/vfs_userfs.py
@@ -1,0 +1,68 @@
+# test VFS functionality with a user-defined filesystem
+# also tests parts of uio.IOBase implementation
+
+import sys, uio
+
+try:
+    uio.IOBase
+    import uos
+    uos.mount
+except (ImportError, AttributeError):
+    print("SKIP")
+    raise SystemExit
+
+
+class UserFile(uio.IOBase):
+    def __init__(self, data):
+        self.data = data
+        self.pos = 0
+    def read(self):
+        return self.data
+    def readinto(self, buf):
+        n = 0
+        while n < len(buf) and self.pos < len(self.data):
+            buf[n] = self.data[self.pos]
+            n += 1
+            self.pos += 1
+        return n
+    def ioctl(self, req, arg):
+        print('ioctl', req, arg)
+        return 0
+
+
+class UserFS:
+    def __init__(self, files):
+        self.files = files
+    def mount(self, readonly, mksfs):
+        pass
+    def umount(self):
+        pass
+    def stat(self, path):
+        print('stat', path)
+        if path in self.files:
+            return (32768, 0, 0, 0, 0, 0, 0, 0, 0, 0)
+        raise OSError
+    def open(self, path, mode):
+        print('open', path, mode)
+        return UserFile(self.files[path])
+
+
+# create and mount a user filesystem
+user_files = {
+    '/data.txt': b"some data in a text file\n",
+    '/usermod1.py': b"print('in usermod1')\nimport usermod2",
+    '/usermod2.py': b"print('in usermod2')",
+}
+uos.mount(UserFS(user_files), '/userfs')
+
+# open and read a file
+f = open('/userfs/data.txt')
+print(f.read())
+
+# import files from the user filesystem
+sys.path.append('/userfs')
+import usermod1
+
+# unmount and undo path addition
+uos.umount('/userfs')
+sys.path.pop()

--- a/tests/extmod/vfs_userfs.py.exp
+++ b/tests/extmod/vfs_userfs.py.exp
@@ -1,0 +1,12 @@
+open /data.txt r
+b'some data in a text file\n'
+stat /usermod1
+stat /usermod1.py
+open /usermod1.py r
+ioctl 4 0
+in usermod1
+stat /usermod2
+stat /usermod2.py
+open /usermod2.py r
+ioctl 4 0
+in usermod2

--- a/tests/io/iobase.py
+++ b/tests/io/iobase.py
@@ -1,0 +1,19 @@
+try:
+    import uio as io
+except:
+    import io
+
+try:
+    io.IOBase
+except AttributeError:
+    print('SKIP')
+    raise SystemExit
+
+
+class MyIO(io.IOBase):
+    def write(self, buf):
+        # CPython and uPy pass in different types for buf (str vs bytearray)
+        print('write', len(buf))
+        return len(buf)
+
+print('test', file=MyIO())

--- a/tests/run-tests
+++ b/tests/run-tests
@@ -364,6 +364,7 @@ def run_tests(pyb, tests, args, base_path="."):
         skip_tests.add('micropython/schedule.py') # native code doesn't check pending events
         skip_tests.add('stress/gc_trace.py') # requires yield
         skip_tests.add('stress/recursive_gen.py') # requires yield
+        skip_tests.add('extmod/vfs_userfs.py') # because native doesn't properly handle globals across different modules
 
     for test_file in tests:
         test_file = test_file.replace('\\', '/')


### PR DESCRIPTION
This PR adds the `uio.IOBase` class which can be used to define user streams, which can then be passed into code that expects native stream support.  The mapping from C to Python is:
```
stream_p->read  --> readinto(buf)
stream_p->write --> write(buf)
stream_p->ioctl --> ioctl(request, arg)
```
Among other things it allows the user to:
- create an object which can be passed as the file arg to print: `print(..., file=myobj)`, and then print will pass all the data to the object via the objects `write` method (same as CPython)
- pass a user object to `uio.BufferedWriter` to buffer the writes (same as CPython)
- use `select.select` on a user object
- register user objects with `select.poll`
- create user files that can be returned from user filesystems, and `import` can import scripts from these user files

For example, polling to "user space" is done via:
```python
import io, select

class MyIO(io.IOBase):
    def ioctl(self, req, arg):
        print("IOCTL", req, arg)
        if req == 3: # MP_STREAM_POLL
            return 1 # I'm readable
        return 0

myio = MyIO()

print(select.select([myio], [], [], 0))

poller = select.poll()
poller.register(myio)
print(poller.poll(0))
```
I haven't tried it, but this should now allow to hook user objects into uasyncio, to allow waiting on user objects (eg, which fires when an external event happens, like a switch is pressed).

See the added test for an example of how to import from a user defined file.

This PR takes some code from #3034.