### PR TITLE
esp32/modnetwork.c: Fix for isconnected() for static IP config.

### DIFF
--- a/ports/esp32/modnetwork.c
+++ b/ports/esp32/modnetwork.c
@@ -123,6 +123,9 @@ static bool wifi_started = false;
 
 // Set to "true" if the STA interface is requested to be connected by the
 // user, used for automatic reassociation.
+static bool wifi_sta_connect_requested = false;
+
+// Set to "true" if the STA interface is connected to wifi and has IP address.
 static bool wifi_sta_connected = false;
 
 // This function is called by the system-event task and so runs in a different
@@ -134,6 +137,7 @@ static esp_err_t event_handler(void *ctx, system_event_t *event) {
         break;
     case SYSTEM_EVENT_STA_GOT_IP:
         ESP_LOGI("network", "GOT_IP");
+	wifi_sta_connected = true;
         break;
     case SYSTEM_EVENT_STA_DISCONNECTED: {
         // This is a workaround as ESP32 WiFi libs don't currently
@@ -151,7 +155,7 @@ static esp_err_t event_handler(void *ctx, system_event_t *event) {
                 break;
             case WIFI_REASON_AUTH_FAIL:
                 message = "\nauthentication failed";
-                wifi_sta_connected = false;
+                wifi_sta_connect_requested = false;
                 break;
             default:
                 // Let other errors through and try to reconnect.
@@ -159,7 +163,8 @@ static esp_err_t event_handler(void *ctx, system_event_t *event) {
         }
         ESP_LOGI("wifi", "STA_DISCONNECTED, reason:%d%s", disconn->reason, message);
 
-        if (wifi_sta_connected) {
+	bool reconnected = false;
+        if (wifi_sta_connect_requested) {
             wifi_mode_t mode;
             if (esp_wifi_get_mode(&mode) == ESP_OK) {
                 if (mode & WIFI_MODE_STA) {
@@ -167,10 +172,13 @@ static esp_err_t event_handler(void *ctx, system_event_t *event) {
                     esp_err_t e = esp_wifi_connect();
                     if (e != ESP_OK) {
                         ESP_LOGI("wifi", "error attempting to reconnect: 0x%04x", e);
-                    }
+                    } else {
+			reconnected = true;
+		    }
                 }
             }
         }
+	wifi_sta_connected = reconnected;
         break;
     }
     default:
@@ -283,7 +291,7 @@ STATIC mp_obj_t esp_connect(size_t n_args, const mp_obj_t *args) {
     MP_THREAD_GIL_EXIT();
     ESP_EXCEPTIONS( esp_wifi_connect() );
     MP_THREAD_GIL_ENTER();
-    wifi_sta_connected = true;
+    wifi_sta_connect_requested = true;
 
     return mp_const_none;
 }
@@ -291,7 +299,7 @@ STATIC mp_obj_t esp_connect(size_t n_args, const mp_obj_t *args) {
 STATIC MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(esp_connect_obj, 1, 7, esp_connect);
 
 STATIC mp_obj_t esp_disconnect(mp_obj_t self_in) {
-    wifi_sta_connected = false;
+    wifi_sta_connect_requested = false;
     ESP_EXCEPTIONS( esp_wifi_disconnect() );
     return mp_const_none;
 }
@@ -370,9 +378,7 @@ STATIC MP_DEFINE_CONST_FUN_OBJ_1(esp_scan_obj, esp_scan);
 STATIC mp_obj_t esp_isconnected(mp_obj_t self_in) {
     wlan_if_obj_t *self = MP_OBJ_TO_PTR(self_in);
     if (self->if_id == WIFI_IF_STA) {
-        tcpip_adapter_ip_info_t info;
-        tcpip_adapter_get_ip_info(WIFI_IF_STA, &info);
-        return mp_obj_new_bool(info.ip.addr != 0);
+        return mp_obj_new_bool(wifi_sta_connected);
     } else {
         wifi_sta_list_t sta;
         esp_wifi_ap_get_sta_list(&sta);

--- a/ports/esp32/modnetwork.c
+++ b/ports/esp32/modnetwork.c
@@ -135,9 +135,13 @@ static esp_err_t event_handler(void *ctx, system_event_t *event) {
     case SYSTEM_EVENT_STA_START:
         ESP_LOGI("wifi", "STA_START");
         break;
+    case SYSTEM_EVENT_STA_CONNECTED:
+        ESP_LOGI("network", "CONNECTED");
+        //wifi_isconnected = true;
+        break;
     case SYSTEM_EVENT_STA_GOT_IP:
         ESP_LOGI("network", "GOT_IP");
-	wifi_sta_connected = true;
+        wifi_sta_connected = true;
         break;
     case SYSTEM_EVENT_STA_DISCONNECTED: {
         // This is a workaround as ESP32 WiFi libs don't currently
@@ -163,7 +167,7 @@ static esp_err_t event_handler(void *ctx, system_event_t *event) {
         }
         ESP_LOGI("wifi", "STA_DISCONNECTED, reason:%d%s", disconn->reason, message);
 
-	bool reconnected = false;
+        bool reconnected = false;
         if (wifi_sta_connect_requested) {
             wifi_mode_t mode;
             if (esp_wifi_get_mode(&mode) == ESP_OK) {
@@ -173,12 +177,15 @@ static esp_err_t event_handler(void *ctx, system_event_t *event) {
                     if (e != ESP_OK) {
                         ESP_LOGI("wifi", "error attempting to reconnect: 0x%04x", e);
                     } else {
-			reconnected = true;
-		    }
+                        reconnected = true;
+                    }
                 }
             }
         }
-	wifi_sta_connected = reconnected;
+        if (wifi_sta_connected && !reconnected) {
+            // If already connected and we fail to reconnect
+            wifi_sta_connected = false;
+        }
         break;
     }
     default:


### PR DESCRIPTION
Currently `<WLAN>.isconnected()` always returns True if a static
IP is set, regardless of the state of the connection. This breaks
the commonly documented wifi connection workflow:

```python
    import network
    sta_if = network.WLAN(network.STA_IF)
    sta_if.active(True)
    sta_if.ifconfig(
        ('192.168.1.101', '255.255.255.0', '192.168.1.1', '8.8.8.8'))
    sta_if.connect('ssid', 'password')
    while not sta_if.isconnected():
        pass
```
This patch introduces a new flag `wifi_sta_connected` which is set in
`event_handler()` when GOT_IP event is received and reset when
DISCONNECTED event is received (unless re-connect is successful).
`<WLAN>.isconnected()` now simply returns the status of this flag (for STA_IF).

The pre-existing flag misleadingly named `wifi_sta_connected` is also
renamed to `wifi_sta_connect_requested`.

Fixes issue #3837