### PR TITLE
[ports/stm32]: Added generic MP IRQ callback and example for UART.

### DIFF
--- a/ports/stm32/Makefile
+++ b/ports/stm32/Makefile
@@ -227,6 +227,7 @@ SRC_C = \
 	dma.c \
 	i2c.c \
 	pyb_i2c.c \
+	pyb_irq.c \
 	spi.c \
 	qspi.c \
 	uart.c \

--- a/ports/stm32/modmachine.c
+++ b/ports/stm32/modmachine.c
@@ -41,6 +41,7 @@
 #include "extmod/vfs_fat.h"
 #include "gccollect.h"
 #include "irq.h"
+#include "pyb_irq.h"
 #include "pybthread.h"
 #include "rng.h"
 #include "storage.h"
@@ -638,6 +639,7 @@ STATIC const mp_rom_map_elem_t machine_module_globals_table[] = {
 
     { MP_ROM_QSTR(MP_QSTR_Pin),                 MP_ROM_PTR(&pin_type) },
     { MP_ROM_QSTR(MP_QSTR_Signal),              MP_ROM_PTR(&machine_signal_type) },
+    { MP_ROM_QSTR(MP_QSTR_IRQ),                 MP_ROM_PTR(&pyb_irq_type) },
 
 #if 0
     { MP_ROM_QSTR(MP_QSTR_RTC),                 MP_ROM_PTR(&pyb_rtc_type) },

--- a/ports/stm32/pyb_irq.c
+++ b/ports/stm32/pyb_irq.c
@@ -1,0 +1,103 @@
+/*
+ * This file is part of the MicroPython project, http://micropython.org/
+ *
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2018 Tobias Badertscher
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#include <stdio.h>
+#include <string.h>
+#include <stdarg.h>
+
+
+#include "py/runtime.h"
+#include "py/gc.h"
+#include "py/mphal.h"
+#include "py/mperrno.h"
+#include "pyb_irq.h"
+
+
+void irq_dispatch(pyb_irq_obj_t *self) {
+    if (self->handler != mp_const_none) {
+        mp_sched_lock();
+        // When executing code within a handler we must lock the GC to prevent
+        // any memory allocations.  We must also catch any exceptions.
+        gc_lock();
+        nlr_buf_t nlr;
+        if (nlr_push(&nlr) == 0) {//mp_obj_t
+            mp_call_function_1(self->handler, (mp_obj_t*)self->base.type);
+            nlr_pop();
+        } else {
+            // Uncaught exception; disable the callback so it doesn't run again.
+            self->handler = mp_const_none;
+            printf("uncaught exception in %s interrupt handler\n", qstr_str(self->base.type->name));
+            mp_obj_print_exception(&mp_plat_print, (mp_obj_t)nlr.ret_val);
+        }
+        gc_unlock();
+        mp_sched_unlock();
+    }
+    self->flags = IRQ_FLAG_NONE;
+}
+
+STATIC mp_obj_t pyb_irq_call(mp_obj_t self_in, size_t n_args, size_t n_kw, const mp_obj_t *args) {
+    pyb_irq_obj_t *self = self_in;
+    mp_arg_check_num(n_args, n_kw, 0, 0, false);
+    if (self->handler != mp_const_none) {
+        mp_call_function_1(self->handler, (mp_obj_t*)self->base.type);
+    }
+    return mp_const_none;
+}
+
+/// \method trigger()
+/// Get the enabled IRQ trigger bitmask:
+///
+///   - Return or-ed bitmask of IRQ_?? values defined in the main class.
+///
+STATIC mp_obj_t pyb_irq_trigger(mp_obj_t self_in) {
+    pyb_irq_obj_t *self = self_in;
+    return MP_OBJ_NEW_SMALL_INT(self->enable);
+}
+STATIC MP_DEFINE_CONST_FUN_OBJ_1(pyb_irq_trigger_obj, pyb_irq_trigger);
+
+/// \method irq_flags()
+/// Return the reason executing the callback as or-ed ??_IRQ values.
+/// Before leaving the IRQ these flags are cleared (see irq_dispatch).
+///
+STATIC mp_obj_t pyb_irq_flags(mp_obj_t self_in) {
+    pyb_irq_obj_t *self = self_in;
+    return MP_OBJ_NEW_SMALL_INT(self->flags);
+}
+STATIC MP_DEFINE_CONST_FUN_OBJ_1(pyb_irq_flags_obj, pyb_irq_flags);
+
+STATIC const mp_rom_map_elem_t pyb_irq_locals_dict_table[] = {
+        { MP_ROM_QSTR(MP_QSTR_trigger),  MP_ROM_PTR(&pyb_irq_trigger_obj) },
+        { MP_ROM_QSTR(MP_QSTR_flags),  MP_ROM_PTR(&pyb_irq_flags_obj) },
+        { MP_ROM_QSTR(MP_QSTR_NO_IRQ), MP_ROM_INT(IRQ_FLAG_NONE) },
+};
+STATIC MP_DEFINE_CONST_DICT(pyb_irq_locals_dict, pyb_irq_locals_dict_table);
+
+const mp_obj_type_t pyb_irq_type = {
+    { &mp_type_type },
+    .name = MP_QSTR_IRQ,
+    .call = pyb_irq_call,
+    .locals_dict = (mp_obj_dict_t*)&pyb_irq_locals_dict,
+};

--- a/ports/stm32/pyb_irq.h
+++ b/ports/stm32/pyb_irq.h
@@ -1,0 +1,45 @@
+/*
+ * This file is part of the MicroPython project, http://micropython.org/
+ *
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2018 Tobias Badertscher
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+#ifndef MICROPY_INCLUDED_STM32_PYB_IRQ_H
+#define MICROPY_INCLUDED_STM32_PYB_IRQ_H
+
+typedef enum {
+    IRQ_FLAG_NONE = 0x00,
+} irq_flag_t;
+
+typedef struct _pyb_irq_obj_t {
+    mp_obj_base_t base;
+    mp_obj_t parent;          // Source for interrupt
+    uint8_t  enable;          // Enable IRQ for calling the MP callback
+    irq_flag_t flags;         // Reason for executing the callback
+    mp_obj_t handler;         // MP function to call
+} pyb_irq_obj_t;
+
+extern const mp_obj_type_t pyb_irq_type;
+
+void irq_dispatch(pyb_irq_obj_t *self);
+
+#endif // MICROPY_INCLUDED_STM32_PYB_IRQ_H

--- a/ports/stm32/uart.c
+++ b/ports/stm32/uart.c
@@ -35,6 +35,7 @@
 #include "lib/utils/interrupt_char.h"
 #include "uart.h"
 #include "irq.h"
+#include "pyb_irq.h"
 #include "pendsv.h"
 
 /// \moduleref pyb
@@ -75,8 +76,13 @@
 #define CHAR_WIDTH_8BIT (0)
 #define CHAR_WIDTH_9BIT (1)
 
+typedef enum {
+    IRQ_FLAG_RX_IDLE= 1<<0,
+} uart_irq_flag_t;
+
 struct _pyb_uart_obj_t {
     mp_obj_base_t base;
+    pyb_irq_obj_t irq;
     UART_HandleTypeDef uart;            // this is 17 words big
     IRQn_Type irqn;
     pyb_uart_t uart_id : 8;
@@ -112,7 +118,6 @@ void uart_init0(void) {
         __fatal_error("HAL_RCCEx_PeriphCLKConfig");
     }
     #endif
-
     for (int i = 0; i < MP_ARRAY_SIZE(MP_STATE_PORT(pyb_uart_obj_all)); i++) {
         MP_STATE_PORT(pyb_uart_obj_all)[i] = NULL;
     }
@@ -498,7 +503,6 @@ void uart_tx_strn(pyb_uart_obj_t *uart_obj, const char *str, uint len) {
     uart_tx_data(uart_obj, str, len, &errcode);
 }
 
-// this IRQ handler is set up to handle RXNE interrupts only
 void uart_irq_handler(mp_uint_t uart_id) {
     // get the uart object
     pyb_uart_obj_t *self = MP_STATE_PORT(pyb_uart_obj_all)[uart_id - 1];
@@ -509,6 +513,7 @@ void uart_irq_handler(mp_uint_t uart_id) {
         return;
     }
 
+    self->irq.flags = IRQ_FLAG_NONE;
     if (__HAL_UART_GET_FLAG(&self->uart, UART_FLAG_RXNE) != RESET) {
         if (self->read_buf_len != 0) {
             uint16_t next_head = (self->read_buf_head + 1) % self->read_buf_len;
@@ -536,6 +541,15 @@ void uart_irq_handler(mp_uint_t uart_id) {
             }
         }
     }
+    if (__HAL_UART_GET_FLAG(&self->uart, UART_FLAG_IDLE) != RESET) {
+        __HAL_UART_CLEAR_IDLEFLAG(&self->uart);
+        self->irq.flags |= IRQ_FLAG_RX_IDLE;
+    }
+    self->irq.flags &= self->irq.enable;
+    if (self->irq.flags != IRQ_FLAG_NONE) {
+        irq_dispatch(&self->irq);
+    }
+
 }
 
 /******************************************************************************/
@@ -577,6 +591,10 @@ STATIC void pyb_uart_print(const mp_print_t *print, mp_obj_t self_in, mp_print_k
             self->uart.Init.StopBits == UART_STOPBITS_1 ? 1 : 2,
             self->timeout, self->timeout_char,
             self->read_buf_len == 0 ? 0 : self->read_buf_len - 1); // -1 to adjust for usable length of buffer
+        if (self->irq.enable != IRQ_FLAG_NONE) {
+            mp_printf(print, " IRQ callback on%s",
+                      (self->irq.enable&IRQ_FLAG_RX_IDLE)?" RX_IDLE_IRQ":"");
+        }
     }
 }
 
@@ -822,11 +840,17 @@ STATIC mp_obj_t pyb_uart_make_new(const mp_obj_type_t *type, size_t n_args, size
         self = m_new0(pyb_uart_obj_t, 1);
         self->base.type = &pyb_uart_type;
         self->uart_id = uart_id;
+        self->irq.base.type = &pyb_irq_type;
+        self->irq.parent = (mp_obj_t*)&self;
         MP_STATE_PORT(pyb_uart_obj_all)[uart_id - 1] = self;
     } else {
         // reference existing UART object
         self = MP_STATE_PORT(pyb_uart_obj_all)[uart_id - 1];
     }
+    // Clear IRQs
+    self->irq.enable = IRQ_FLAG_NONE;
+    self->irq.flags = IRQ_FLAG_NONE;
+    self->irq.handler = mp_const_none;
 
     if (n_args > 1 || n_kw > 0) {
         // start the peripheral
@@ -968,6 +992,53 @@ STATIC mp_obj_t pyb_uart_sendbreak(mp_obj_t self_in) {
 }
 STATIC MP_DEFINE_CONST_FUN_OBJ_1(pyb_uart_sendbreak_obj, pyb_uart_sendbreak);
 
+/// \method irq(handler=None, trigger=RX_IDLE_IRQ )
+/// Set the function to be called when the uart receives an interrrupt.
+/// `handler` is passed 1 argument, the uart object.
+/// If `handler` is `None` then the callback will be disabled.
+/// Further set the enabled intterrrupts which can trigger the callback to the
+/// value of the supplied trigger variable.
+STATIC mp_obj_t pyb_uart_irq(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
+    enum { ARG_handler, ARG_trigger };
+    static const mp_arg_t allowed_args[] = {
+        { MP_QSTR_handler, MP_ARG_OBJ, {.u_obj = mp_const_none} },
+        { MP_QSTR_trigger, MP_ARG_INT, {.u_int = IRQ_FLAG_NONE } },
+    };
+    pyb_uart_obj_t *self = MP_OBJ_TO_PTR(pos_args[0]);
+    mp_arg_val_t args[MP_ARRAY_SIZE(allowed_args)];
+    mp_arg_parse_all(n_args - 1, pos_args + 1, kw_args, MP_ARRAY_SIZE(allowed_args), allowed_args, args);
+
+    if (n_args > 1 || kw_args->used != 0) {
+        if (args[ARG_handler].u_obj == mp_const_none) {
+            // Disable IRQs which can be triggered here
+            __HAL_UART_DISABLE_IT(&self->uart, UART_IT_IDLE);
+            self->irq.handler = mp_const_none;
+        } else if (mp_obj_is_callable(args[ARG_handler].u_obj)) {
+            self->irq.handler = args[ARG_handler].u_obj;
+        } else {
+            mp_raise_ValueError("IRQ handler must be None or a callable object");
+        }
+        if (self->irq.handler != mp_const_none) {
+            uint32_t trigger = args[ARG_trigger].u_int;
+            self->irq.enable = IRQ_FLAG_NONE;
+            // Enable IRQ to be triggered here with if .. clauses and remove
+            // it from 'trigger' variable
+            if (trigger&IRQ_FLAG_RX_IDLE) {
+                self->irq.enable |=  IRQ_FLAG_RX_IDLE;
+                __HAL_UART_ENABLE_IT(&self->uart, UART_IT_IDLE);
+                trigger &= ~IRQ_FLAG_RX_IDLE;
+            }
+            // All triggers should be consumed
+            if (trigger != IRQ_FLAG_NONE) {
+                nlr_raise(mp_obj_new_exception_msg_varg(&mp_type_ValueError,"IRQ trigger(s) %d unknown", trigger));
+            }
+        }
+    }
+
+    return MP_OBJ_FROM_PTR(&self->irq);
+ }
+STATIC MP_DEFINE_CONST_FUN_OBJ_KW(pyb_uart_irq_obj, 1, pyb_uart_irq);
+
 STATIC const mp_rom_map_elem_t pyb_uart_locals_dict_table[] = {
     // instance methods
 
@@ -988,9 +1059,14 @@ STATIC const mp_rom_map_elem_t pyb_uart_locals_dict_table[] = {
     { MP_ROM_QSTR(MP_QSTR_readchar), MP_ROM_PTR(&pyb_uart_readchar_obj) },
     { MP_ROM_QSTR(MP_QSTR_sendbreak), MP_ROM_PTR(&pyb_uart_sendbreak_obj) },
 
+    // \method irq(handler=None, trigger=)
+    { MP_ROM_QSTR(MP_QSTR_irq), MP_ROM_PTR(&pyb_uart_irq_obj) },
+
     // class constants
     { MP_ROM_QSTR(MP_QSTR_RTS), MP_ROM_INT(UART_HWCONTROL_RTS) },
     { MP_ROM_QSTR(MP_QSTR_CTS), MP_ROM_INT(UART_HWCONTROL_CTS) },
+    // IRQ flags NO irq is defined in pyb_irq
+    { MP_ROM_QSTR(MP_QSTR_RX_IDLE_IRQ), MP_ROM_INT(IRQ_FLAG_RX_IDLE) },
 };
 
 STATIC MP_DEFINE_CONST_DICT(pyb_uart_locals_dict, pyb_uart_locals_dict_table);


### PR DESCRIPTION
# Reworked see #3971 

# Aim of PR
At several locations in the stm32/port (maybe in other ports too) there is a call from the interrupt context to a user defined micropython routine/method. As a result we have some duplicated code (see Handle_EXTI_Irq, timer_handle_irq_channel) and some ToDo (se eg. pin_irq method). Further the way in timer the callback is set-up should be unified to the way it is done elsewhere.

There are some discussions in the forum on this topic(Event/IRQ callback):
https://forum.micropython.org/viewtopic.php?f=2&t=1448
https://forum.micropython.org/viewtopic.php?f=6&t=4414
https://forum.micropython.org/viewtopic.php?f=6&t=1312
https://forum.micropython.org/viewtopic.php?f=2&t=194

Issues #1642 and the discussion in the Hardware API (https://github.com/micropython/micropython/wiki/Hardware-API) on IRQ

My proposed MP irq module tries to keep close to the API of pin.irq.
# Example implementation of IDLE IRQ for UART
See implementation in the 2nd commit. To use this feature create a class:
```
import micropython

class UART_IDLE:
    
    def __init__(self, uart):
        self._uart = uart
        self._uart.write("Hi there\n\r")
        self._buffer = bytearray(64)
        self._answer = b"Ready \r\n"
        self._normal_context_ref = self.normal_context
        
    def set_up_cb(self):
        self._uart.irq(self.irq_idle_callback, self._uart.RX_IDLE_IRQ)
        
    def irq_idle_callback(self, other):
        print("IRQ ", self._uart.irq().flags())
        micropython.schedule(self._normal_context_ref, 0)
    
    def normal_context(self, value):
        print("Get UART data in normal context")
        cnt=self._uart.readinto(self._buffer)
        data = "".join([chr(i) if 32<=i<128 else "."  for i in self._buffer[:cnt] ])
        self._uart.write("Received: \"%s\"\r\n" % data)
    
```
and instantiate it:
```
uart = pyb.UART(2, baudrate = 115200, timeout=1)
dut=UART_IDLE(uart)
dut.set_up_cb()
callback= uart.irq()
callback()    # call the callback
print("Trigger flag %d " % uart.irq().trigger()) # Print active set triggers
```
The idle callback is fired on my L476Disco every time when after the start of a transfer there is no data on the UART RX for one character. 

# Cons
I know that @Damien once said he does not like the idea (https://forum.micropython.org/viewtopic.php?f=17&t=3747&p=21669&hilit=Event+callback#p21669). However  we would like to have a fast reacting system which returns within a few ms an answer on the UART. I could imaging as well to automatically schedule  the callback in the normal context (as in the class shown with ```micropython.schedule```) but within the C code (Don't know yet how to do it, but it is probably possible).

@dhylands (https://forum.micropython.org/viewtopic.php?f=2&t=194&p=825&hilit=IRQ+callback#p925)

I would be happy for any feedback to improve this PR to make it merge-able.
# Further steps
I would be glad to adapt other (can, timer .. which?) modules with this modification.