### PR TITLE
py/stream: Introduce and use efficient mp_get_stream to access stream_p

### DIFF
--- a/extmod/modujson.c
+++ b/extmod/modujson.c
@@ -35,9 +35,7 @@
 #if MICROPY_PY_UJSON
 
 STATIC mp_obj_t mod_ujson_dump(mp_obj_t obj, mp_obj_t stream) {
-    if (!MP_OBJ_IS_OBJ(stream)) {
-        mp_raise_TypeError(NULL);
-    }
+    mp_get_stream_raise(stream, MP_STREAM_OP_WRITE);
     mp_print_t print = {MP_OBJ_TO_PTR(stream), mp_stream_write_adaptor};
     mp_obj_print_helper(&print, obj, PRINT_JSON);
     return mp_const_none;

--- a/extmod/modussl_mbedtls.c
+++ b/extmod/modussl_mbedtls.c
@@ -76,7 +76,7 @@ STATIC void mbedtls_debug(void *ctx, int level, const char *file, int line, cons
 STATIC int _mbedtls_ssl_send(void *ctx, const byte *buf, size_t len) {
     mp_obj_t sock = *(mp_obj_t*)ctx;
 
-    const mp_stream_p_t *sock_stream = mp_get_stream_raise(sock, MP_STREAM_OP_WRITE);
+    const mp_stream_p_t *sock_stream = mp_get_stream(sock);
     int err;
 
     mp_uint_t out_sz = sock_stream->write(sock, buf, len, &err);
@@ -93,7 +93,7 @@ STATIC int _mbedtls_ssl_send(void *ctx, const byte *buf, size_t len) {
 STATIC int _mbedtls_ssl_recv(void *ctx, byte *buf, size_t len) {
     mp_obj_t sock = *(mp_obj_t*)ctx;
 
-    const mp_stream_p_t *sock_stream = mp_get_stream_raise(sock, MP_STREAM_OP_READ);
+    const mp_stream_p_t *sock_stream = mp_get_stream(sock);
     int err;
 
     mp_uint_t out_sz = sock_stream->read(sock, buf, len, &err);
@@ -109,6 +109,9 @@ STATIC int _mbedtls_ssl_recv(void *ctx, byte *buf, size_t len) {
 
 
 STATIC mp_obj_ssl_socket_t *socket_new(mp_obj_t sock, struct ssl_args *args) {
+    // Verify the socket object has the full stream protocol
+    mp_get_stream_raise(sock, MP_STREAM_OP_READ | MP_STREAM_OP_WRITE | MP_STREAM_OP_IOCTL);
+
 #if MICROPY_PY_USSL_FINALISER
     mp_obj_ssl_socket_t *o = m_new_obj_with_finaliser(mp_obj_ssl_socket_t);
 #else

--- a/extmod/moduzlib.c
+++ b/extmod/moduzlib.c
@@ -53,7 +53,7 @@ STATIC unsigned char read_src_stream(TINF_DATA *data) {
     p -= offsetof(mp_obj_decompio_t, decomp);
     mp_obj_decompio_t *self = (mp_obj_decompio_t*)p;
 
-    const mp_stream_p_t *stream = mp_get_stream_raise(self->src_stream, MP_STREAM_OP_READ);
+    const mp_stream_p_t *stream = mp_get_stream(self->src_stream);
     int err;
     byte c;
     mp_uint_t out_sz = stream->read(self->src_stream, &c, 1, &err);
@@ -68,6 +68,7 @@ STATIC unsigned char read_src_stream(TINF_DATA *data) {
 
 STATIC mp_obj_t decompio_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *args) {
     mp_arg_check_num(n_args, n_kw, 1, 2, false);
+    mp_get_stream_raise(args[0], MP_STREAM_OP_READ);
     mp_obj_decompio_t *o = m_new_obj(mp_obj_decompio_t);
     o->base.type = type;
     memset(&o->decomp, 0, sizeof(o->decomp));

--- a/extmod/modwebrepl.c
+++ b/extmod/modwebrepl.c
@@ -76,7 +76,7 @@ STATIC char denied_prompt[] = "\r\nAccess denied\r\n";
 STATIC char webrepl_passwd[10];
 
 STATIC void write_webrepl(mp_obj_t websock, const void *buf, size_t len) {
-    const mp_stream_p_t *sock_stream = mp_get_stream_raise(websock, MP_STREAM_OP_WRITE | MP_STREAM_OP_IOCTL);
+    const mp_stream_p_t *sock_stream = mp_get_stream(websock);
     int err;
     int old_opts = sock_stream->ioctl(websock, MP_STREAM_SET_DATA_OPTS, FRAME_BIN, &err);
     sock_stream->write(websock, buf, len, &err);
@@ -86,7 +86,7 @@ STATIC void write_webrepl(mp_obj_t websock, const void *buf, size_t len) {
 #define SSTR(s) s, sizeof(s) - 1
 STATIC void write_webrepl_str(mp_obj_t websock, const char *str, int sz) {
     int err;
-    const mp_stream_p_t *sock_stream = mp_get_stream_raise(websock, MP_STREAM_OP_WRITE | MP_STREAM_OP_IOCTL);
+    const mp_stream_p_t *sock_stream = mp_get_stream(websock);
     sock_stream->write(websock, str, sz, &err);
 }
 
@@ -110,8 +110,7 @@ STATIC mp_obj_t webrepl_make_new(const mp_obj_type_t *type, size_t n_args, size_
 }
 
 STATIC int write_file_chunk(mp_obj_webrepl_t *self) {
-    const mp_stream_p_t *file_stream =
-        mp_get_stream_raise(self->cur_file, MP_STREAM_OP_READ | MP_STREAM_OP_WRITE | MP_STREAM_OP_IOCTL);
+    const mp_stream_p_t *file_stream = mp_get_stream(self->cur_file);
     byte readbuf[2 + 256];
     int err;
     mp_uint_t out_sz = file_stream->read(self->cur_file, readbuf + 2, sizeof(readbuf) - 2, &err);
@@ -181,7 +180,7 @@ STATIC mp_uint_t _webrepl_read(mp_obj_t self_in, void *buf, mp_uint_t size, int 
     // We know that os.dupterm always calls with size = 1
     assert(size == 1);
     mp_obj_webrepl_t *self = self_in;
-    const mp_stream_p_t *sock_stream = mp_get_stream_raise(self->sock, MP_STREAM_OP_READ);
+    const mp_stream_p_t *sock_stream = mp_get_stream(self->sock);
     mp_uint_t out_sz = sock_stream->read(self->sock, buf, size, errcode);
     //DEBUG_printf("webrepl: Read %d initial bytes from websocket\n", out_sz);
     if (out_sz == 0 || out_sz == MP_STREAM_ERROR) {
@@ -293,7 +292,7 @@ STATIC mp_uint_t webrepl_write(mp_obj_t self_in, const void *buf, mp_uint_t size
         // Don't forward output until passwd is entered
         return size;
     }
-    const mp_stream_p_t *stream_p = mp_get_stream_raise(self->sock, MP_STREAM_OP_WRITE);
+    const mp_stream_p_t *stream_p = mp_get_stream(self->sock);
     return stream_p->write(self->sock, buf, size, errcode);
 }
 

--- a/extmod/modwebsocket.c
+++ b/extmod/modwebsocket.c
@@ -59,6 +59,7 @@ STATIC mp_uint_t websocket_write(mp_obj_t self_in, const void *buf, mp_uint_t si
 
 STATIC mp_obj_t websocket_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *args) {
     mp_arg_check_num(n_args, n_kw, 1, 2, false);
+    mp_get_stream_raise(args[0], MP_STREAM_OP_READ | MP_STREAM_OP_WRITE | MP_STREAM_OP_IOCTL);
     mp_obj_websocket_t *o = m_new_obj(mp_obj_websocket_t);
     o->base.type = type;
     o->sock = args[0];
@@ -75,7 +76,7 @@ STATIC mp_obj_t websocket_make_new(const mp_obj_type_t *type, size_t n_args, siz
 
 STATIC mp_uint_t websocket_read(mp_obj_t self_in, void *buf, mp_uint_t size, int *errcode) {
     mp_obj_websocket_t *self =  MP_OBJ_TO_PTR(self_in);
-    const mp_stream_p_t *stream_p = mp_get_stream_raise(self->sock, MP_STREAM_OP_READ);
+    const mp_stream_p_t *stream_p = mp_get_stream(self->sock);
     while (1) {
         if (self->to_recv != 0) {
             mp_uint_t out_sz = stream_p->read(self->sock, self->buf + self->buf_pos, self->to_recv, errcode);

--- a/extmod/uos_dupterm.c
+++ b/extmod/uos_dupterm.c
@@ -62,7 +62,7 @@ int mp_uos_dupterm_rx_chr(void) {
         if (nlr_push(&nlr) == 0) {
             byte buf[1];
             int errcode;
-            const mp_stream_p_t *stream_p = mp_get_stream_raise(MP_STATE_VM(dupterm_objs[idx]), MP_STREAM_OP_READ);
+            const mp_stream_p_t *stream_p = mp_get_stream(MP_STATE_VM(dupterm_objs[idx]));
             mp_uint_t out_sz = stream_p->read(MP_STATE_VM(dupterm_objs[idx]), buf, 1, &errcode);
             if (out_sz == 0) {
                 nlr_pop();
@@ -125,6 +125,7 @@ STATIC mp_obj_t mp_uos_dupterm(size_t n_args, const mp_obj_t *args) {
     if (args[0] == mp_const_none) {
         MP_STATE_VM(dupterm_objs[idx]) = MP_OBJ_NULL;
     } else {
+        mp_get_stream_raise(args[0], MP_STREAM_OP_READ | MP_STREAM_OP_WRITE | MP_STREAM_OP_IOCTL);
         MP_STATE_VM(dupterm_objs[idx]) = args[0];
     }
 

--- a/ports/unix/coverage.c
+++ b/ports/unix/coverage.c
@@ -118,7 +118,6 @@ STATIC mp_uint_t stest_read2(mp_obj_t o_in, void *buf, mp_uint_t size, int *errc
 
 STATIC const mp_rom_map_elem_t rawfile_locals_dict_table2[] = {
     { MP_ROM_QSTR(MP_QSTR_read), MP_ROM_PTR(&mp_stream_read_obj) },
-    { MP_ROM_QSTR(MP_QSTR_write), MP_ROM_PTR(&mp_stream_write_obj) },
 };
 
 STATIC MP_DEFINE_CONST_DICT(rawfile_locals_dict2, rawfile_locals_dict_table2);

--- a/py/stream.c
+++ b/py/stream.c
@@ -1,3 +1,4 @@
+
 /*
  * This file is part of the MicroPython project, http://micropython.org/
  *
@@ -47,10 +48,9 @@ STATIC mp_obj_t stream_readall(mp_obj_t self_in);
 // be equal to input size).
 mp_uint_t mp_stream_rw(mp_obj_t stream, void *buf_, mp_uint_t size, int *errcode, byte flags) {
     byte *buf = buf_;
-    mp_obj_base_t* s = (mp_obj_base_t*)MP_OBJ_TO_PTR(stream);
     typedef mp_uint_t (*io_func_t)(mp_obj_t obj, void *buf, mp_uint_t size, int *errcode);
     io_func_t io_func;
-    const mp_stream_p_t *stream_p = s->type->protocol;
+    const mp_stream_p_t *stream_p = mp_get_stream(stream);
     if (flags & MP_STREAM_RW_WRITE) {
         io_func = (io_func_t)stream_p->write;
     } else {
@@ -99,8 +99,6 @@ const mp_stream_p_t *mp_get_stream_raise(mp_obj_t self_in, int flags) {
 }
 
 STATIC mp_obj_t stream_read_generic(size_t n_args, const mp_obj_t *args, byte flags) {
-    const mp_stream_p_t *stream_p = mp_get_stream_raise(args[0], MP_STREAM_OP_READ);
-
     // What to do if sz < -1?  Python docs don't specify this case.
     // CPython does a readall, but here we silently let negatives through,
     // and they will cause a MemoryError.
@@ -108,6 +106,8 @@ STATIC mp_obj_t stream_read_generic(size_t n_args, const mp_obj_t *args, byte fl
     if (n_args == 1 || ((sz = mp_obj_get_int(args[1])) == -1)) {
         return stream_readall(args[0]);
     }
+
+    const mp_stream_p_t *stream_p = mp_get_stream(args[0]);
 
     #if MICROPY_PY_BUILTINS_STR_UNICODE
     if (stream_p->is_text) {
@@ -227,8 +227,6 @@ STATIC mp_obj_t stream_read1(size_t n_args, const mp_obj_t *args) {
 MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(mp_stream_read1_obj, 1, 2, stream_read1);
 
 mp_obj_t mp_stream_write(mp_obj_t self_in, const void *buf, size_t len, byte flags) {
-    mp_get_stream_raise(self_in, MP_STREAM_OP_WRITE);
-
     int error;
     mp_uint_t out_sz = mp_stream_rw(self_in, (void*)buf, len, &error, flags);
     if (error != 0) {
@@ -276,7 +274,6 @@ STATIC mp_obj_t stream_write1_method(mp_obj_t self_in, mp_obj_t arg) {
 MP_DEFINE_CONST_FUN_OBJ_2(mp_stream_write1_obj, stream_write1_method);
 
 STATIC mp_obj_t stream_readinto(size_t n_args, const mp_obj_t *args) {
-    mp_get_stream_raise(args[0], MP_STREAM_OP_READ);
     mp_buffer_info_t bufinfo;
     mp_get_buffer_raise(args[1], &bufinfo, MP_BUFFER_WRITE);
 
@@ -305,7 +302,7 @@ STATIC mp_obj_t stream_readinto(size_t n_args, const mp_obj_t *args) {
 MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(mp_stream_readinto_obj, 2, 3, stream_readinto);
 
 STATIC mp_obj_t stream_readall(mp_obj_t self_in) {
-    const mp_stream_p_t *stream_p = mp_get_stream_raise(self_in, MP_STREAM_OP_READ);
+    const mp_stream_p_t *stream_p = mp_get_stream(self_in);
 
     mp_uint_t total_size = 0;
     vstr_t vstr;
@@ -346,7 +343,7 @@ STATIC mp_obj_t stream_readall(mp_obj_t self_in) {
 
 // Unbuffered, inefficient implementation of readline() for raw I/O files.
 STATIC mp_obj_t stream_unbuffered_readline(size_t n_args, const mp_obj_t *args) {
-    const mp_stream_p_t *stream_p = mp_get_stream_raise(args[0], MP_STREAM_OP_READ);
+    const mp_stream_p_t *stream_p = mp_get_stream(args[0]);
 
     mp_int_t max_size = -1;
     if (n_args > 1) {
@@ -421,7 +418,7 @@ mp_obj_t mp_stream_unbuffered_iter(mp_obj_t self) {
 }
 
 mp_obj_t mp_stream_close(mp_obj_t stream) {
-    const mp_stream_p_t *stream_p = mp_get_stream_raise(stream, MP_STREAM_OP_IOCTL);
+    const mp_stream_p_t *stream_p = mp_get_stream(stream);
     int error;
     mp_uint_t res = stream_p->ioctl(stream, MP_STREAM_CLOSE, 0, &error);
     if (res == MP_STREAM_ERROR) {
@@ -432,8 +429,6 @@ mp_obj_t mp_stream_close(mp_obj_t stream) {
 MP_DEFINE_CONST_FUN_OBJ_1(mp_stream_close_obj, mp_stream_close);
 
 STATIC mp_obj_t stream_seek(size_t n_args, const mp_obj_t *args) {
-    const mp_stream_p_t *stream_p = mp_get_stream_raise(args[0], MP_STREAM_OP_IOCTL);
-
     struct mp_stream_seek_t seek_s;
     // TODO: Could be uint64
     seek_s.offset = mp_obj_get_int(args[1]);
@@ -447,6 +442,7 @@ STATIC mp_obj_t stream_seek(size_t n_args, const mp_obj_t *args) {
         mp_raise_OSError(MP_EINVAL);
     }
 
+    const mp_stream_p_t *stream_p = mp_get_stream(args[0]);
     int error;
     mp_uint_t res = stream_p->ioctl(args[0], MP_STREAM_SEEK, (mp_uint_t)(uintptr_t)&seek_s, &error);
     if (res == MP_STREAM_ERROR) {
@@ -467,7 +463,7 @@ STATIC mp_obj_t stream_tell(mp_obj_t self) {
 MP_DEFINE_CONST_FUN_OBJ_1(mp_stream_tell_obj, stream_tell);
 
 STATIC mp_obj_t stream_flush(mp_obj_t self) {
-    const mp_stream_p_t *stream_p = mp_get_stream_raise(self, MP_STREAM_OP_IOCTL);
+    const mp_stream_p_t *stream_p = mp_get_stream(self);
     int error;
     mp_uint_t res = stream_p->ioctl(self, MP_STREAM_FLUSH, 0, &error);
     if (res == MP_STREAM_ERROR) {
@@ -478,8 +474,6 @@ STATIC mp_obj_t stream_flush(mp_obj_t self) {
 MP_DEFINE_CONST_FUN_OBJ_1(mp_stream_flush_obj, stream_flush);
 
 STATIC mp_obj_t stream_ioctl(size_t n_args, const mp_obj_t *args) {
-    const mp_stream_p_t *stream_p = mp_get_stream_raise(args[0], MP_STREAM_OP_IOCTL);
-
     mp_buffer_info_t bufinfo;
     uintptr_t val = 0;
     if (n_args > 2) {
@@ -490,6 +484,7 @@ STATIC mp_obj_t stream_ioctl(size_t n_args, const mp_obj_t *args) {
         }
     }
 
+    const mp_stream_p_t *stream_p = mp_get_stream(args[0]);
     int error;
     mp_uint_t res = stream_p->ioctl(args[0], mp_obj_get_int(args[1]), val, &error);
     if (res == MP_STREAM_ERROR) {

--- a/py/stream.h
+++ b/py/stream.h
@@ -90,6 +90,11 @@ MP_DECLARE_CONST_FUN_OBJ_VAR_BETWEEN(mp_stream_ioctl_obj);
 #define MP_STREAM_OP_WRITE (2)
 #define MP_STREAM_OP_IOCTL (4)
 
+// Object is assumed to have a non-NULL stream protocol with valid r/w/ioctl methods
+static inline const mp_stream_p_t *mp_get_stream(mp_const_obj_t self) {
+    return (const mp_stream_p_t*)((const mp_obj_base_t*)MP_OBJ_TO_PTR(self))->type->protocol;
+}
+
 const mp_stream_p_t *mp_get_stream_raise(mp_obj_t self_in, int flags);
 mp_obj_t mp_stream_close(mp_obj_t stream);
 

--- a/tests/extmod/ujson_dump.py
+++ b/tests/extmod/ujson_dump.py
@@ -16,3 +16,15 @@ print(s.getvalue())
 s = StringIO()
 json.dump({"a": (2, [3, None])}, s)
 print(s.getvalue())
+
+# dump to a small-int not allowed
+try:
+    json.dump(123, 1)
+except (AttributeError, OSError): # CPython and uPy have different errors
+    print('Exception')
+
+# dump to an object not allowed
+try:
+    json.dump(123, {})
+except (AttributeError, OSError): # CPython and uPy have different errors
+    print('Exception')

--- a/tests/extmod/ujson_dump_iobase.py
+++ b/tests/extmod/ujson_dump_iobase.py
@@ -1,0 +1,32 @@
+# test ujson.dump in combination with uio.IOBase
+
+try:
+    import uio as io
+    import ujson as json
+except ImportError:
+    try:
+        import io, json
+    except ImportError:
+        print('SKIP')
+        raise SystemExit
+
+if not hasattr(io, 'IOBase'):
+    print('SKIP')
+    raise SystemExit
+
+
+# a user stream that only has the write method
+class S(io.IOBase):
+    def __init__(self):
+        self.buf = ''
+    def write(self, buf):
+        if type(buf) == bytearray:
+            # uPy passes a bytearray, CPython passes a str
+            buf = str(buf, 'ascii')
+        self.buf += buf
+
+
+# dump to the user stream
+s = S()
+json.dump([123, {}], s) 
+print(s.buf)

--- a/tests/unix/extra_coverage.py
+++ b/tests/unix/extra_coverage.py
@@ -38,11 +38,7 @@ except OSError:
 stream.set_error(0)
 print(stream.ioctl(0, bytearray(10))) # successful ioctl call
 
-stream2 = data[3] # is textio and sets .write = NULL
-try:
-    print(stream2.write(b'1')) # attempt to call NULL implementation
-except OSError:
-    print('OSError')
+stream2 = data[3] # is textio
 print(stream2.read(1)) # read 1 byte encounters non-blocking error with textio stream
 
 # test BufferedWriter with stream errors

--- a/tests/unix/extra_coverage.py.exp
+++ b/tests/unix/extra_coverage.py.exp
@@ -90,7 +90,6 @@ b'123'
 b'123'
 OSError
 0
-OSError
 None
 None
 frzstr1


### PR DESCRIPTION
The existing mp_get_stream_raise() helper does explicit checks that the input object is a real pointer object, has a non-NULL stream protocol, and has the desired stream C method (read/write/ioctl).  In most cases it is not necessary to do these checks because it is guaranteed that the input object has the stream protocol and desired C methods.  For example, native objects that use the stream wrappers (eg mp_stream_readinto_obj) in their locals dict always have the stream protocol (or else they shouldn't have these wrappers in their locals dict).

This PR introduces an efficient mp_get_stream() which doesn't do any checks and just extracts the stream protocol struct.  This should be used in all cases where the argument object is known to be a stream.  The existing mp_get_stream_raise() should be used primarily to verify that an object does have the correct stream protocol methods.

All uses of mp_get_stream_raise() have been checked and converted where appropriate to use mp_get_stream(). 

This set of patches improves efficiency of stream operations and reduces code size, the total change being:
```
   bare-arm:   -72 
minimal x86:    +0 
   unix x64:  -160 
unix nanbox:  -100 
      stm32:   -60 
     cc3200:   -64 
    esp8266:  -120 
      esp32:   -36 
```