### PR TITLE
Fix starting up  boot.py/main.py from frozen flash

### DIFF
--- a/ports/stm32/boards/NUCLEO_F091RC/modules/boot.py
+++ b/ports/stm32/boards/NUCLEO_F091RC/modules/boot.py
@@ -1,0 +1,25 @@
+# frozen boot.py
+#
+# By having a standard location like `boards/<board>/modules` the `boot`, `main` and other python scripts can be
+# conveniently stored.
+# Setting a different path for the `modules` allow easy recompilation of only the relevant files and allows for
+# quick compilation of a new `firmware.*` to upload to your device
+#
+# In this case: `make BOARD=NUCLEO_F091RC FROZEN_MPY_DIR=boards/NUCLEO_F091RC/modules`
+
+import pyb
+
+
+def pins():
+    for pin_name in dir(pyb.Pin.board):
+        pin = pyb.Pin(pin_name)
+        print('{:10s} {:s}'.format(pin_name, str(pin)))
+
+
+def af():
+    for pin_name in dir(pyb.Pin.board):
+        pin = pyb.Pin(pin_name)
+        print('{:10s} {:s}'.format(pin_name, str(pin.af_list())))
+
+
+print("boot: added `af()` and `pins()` and running from flash")

--- a/ports/stm32/boards/NUCLEO_F091RC/modules/boot.py
+++ b/ports/stm32/boards/NUCLEO_F091RC/modules/boot.py
@@ -1,0 +1,27 @@
+# frozen boot.py
+#
+# By having a standard location like `boards/<board>/modules` the `boot`, `main` and other python scripts can be
+# conveniently stored.
+# Setting a different path for the `modules` allow easy recompilation of only the relevant files and allows for
+# quick compilation of a new `firmware.*` to upload to your device
+#
+# In this case: `make BOARD=NUCLEO_F091RC FROZEN_MPY_DIR=boards/NUCLEO_F091RC/modules`
+
+import pyb
+
+
+def pins():
+    for pin_name in dir(pyb.Pin.board):
+        if not(pin_name == "__class__" or pin_name == "__name__"):
+            pin = pyb.Pin(pin_name)
+            print('{:10s} {:s}'.format(pin_name, str(pin)))
+
+
+def af():
+    for pin_name in dir(pyb.Pin.board):
+        if not(pin_name == "__class__" or pin_name == "__name__"):
+            pin = pyb.Pin(pin_name)
+            print('{:10s} {:s}'.format(pin_name, str(pin.af_list())))
+
+
+print("boot: added `af()` and `pins()` and running from flash")

--- a/ports/stm32/boards/NUCLEO_F091RC/modules/boot.py
+++ b/ports/stm32/boards/NUCLEO_F091RC/modules/boot.py
@@ -12,14 +12,16 @@ import pyb
 
 def pins():
     for pin_name in dir(pyb.Pin.board):
-        pin = pyb.Pin(pin_name)
-        print('{:10s} {:s}'.format(pin_name, str(pin)))
+        if not(pin_name == "__class__" or pin_name == "__name__"):
+            pin = pyb.Pin(pin_name)
+            print('{:10s} {:s}'.format(pin_name, str(pin)))
 
 
 def af():
     for pin_name in dir(pyb.Pin.board):
-        pin = pyb.Pin(pin_name)
-        print('{:10s} {:s}'.format(pin_name, str(pin.af_list())))
+        if not(pin_name == "__class__" or pin_name == "__name__"):
+            pin = pyb.Pin(pin_name)
+            print('{:10s} {:s}'.format(pin_name, str(pin.af_list())))
 
 
 print("boot: added `af()` and `pins()` and running from flash")

--- a/ports/stm32/boards/NUCLEO_F091RC/modules/main.py
+++ b/ports/stm32/boards/NUCLEO_F091RC/modules/main.py
@@ -1,0 +1,11 @@
+# frozen main.py
+#
+# By having a standard location like `boards/<board>/modules` the `boot`, `main` and other python scripts can be
+# conveniently stored.
+# Setting a different path for the `modules` allow easy recompilation of only the relevant files and allows for
+# quick compilation of a new `firmware.*` to upload to your device
+#
+# In this case: `make BOARD=NUCLEO_F091RC FROZEN_MPY_DIR=boards/NUCLEO_F091RC/modules`
+
+print("main: running from flash")
+

--- a/ports/stm32/boards/NUCLEO_F091RC/mpconfigboard.h
+++ b/ports/stm32/boards/NUCLEO_F091RC/mpconfigboard.h
@@ -1,6 +1,8 @@
 #define MICROPY_HW_BOARD_NAME       "NUCLEO-F091RC"
 #define MICROPY_HW_MCU_NAME         "STM32F091RCT6"
 
+#define MICROPY_MODULE_FROZEN		(1)
+
 #define MICROPY_EMIT_THUMB          (0)
 #define MICROPY_EMIT_INLINE_THUMB   (0)
 #define MICROPY_PY_USOCKET          (0)


### PR DESCRIPTION
Fix starting up  boot.py/main.py from frozen flash rather than from a file system

The `NUCLEO_F091RC` port has little memory and therefore no internal `/flash`. Adding frozen modules works fine, however starting `boot.py` and `main.py` is not supported.

So I added `pyexec_frozen_module()` on two places. Although it works, I cannot oversee all the side effects and omissions so I expects some more changes. 

The patch can be switched out with a `#define MICROPY_MODULE_FROZEN (1)` in `mpconfigboard.h`.
Also added a `modules` directory and a default `boot.py` and `main.py`.

In the line below it is easy to see how to change the origin of the modules directory to your project.

```
make BOARD=NUCLEO_F091RC FROZEN_MPY_DIR=boards/NUCLEO_F091RC/modules
```

