### PR TITLE
py/nlrthumb: Add returns_twice attribute to nlr_push

### DIFF
--- a/py/nlrthumb.c
+++ b/py/nlrthumb.c
@@ -36,7 +36,7 @@
 // For reference, arm/thumb callee save regs are:
 //      r4-r11, r13=sp
 
-__attribute__((naked)) unsigned int nlr_push(nlr_buf_t *nlr) {
+__attribute__((naked)) __attribute__((returns_twice)) unsigned int nlr_push(nlr_buf_t *nlr) {
 
     __asm volatile (
     "str    r4, [r0, #12]       \n" // store r4 into nlr_buf


### PR DESCRIPTION
After the change of using mp_load_method_protected in
7241d90272f4dfe4100723393cc2f348f5d32c0a it looks like the code
change triggered an issue with nlr_push when using -flto. How
related this specific commit is to the issue is unclear. At least
it is the commit that has been tracked down to be the first which
made the issue visible.

The reason for the behaviour is unknown and is only triggered
when using LTO. The strange thing about the issue is that it is
not consistent accross build targets. The code have been tested
on both cortex-m0 (nrf51822) and cortex-m4 (nrf52832/nrf52840),
and it only fails on cortex-m4.

Adding the attribute "returns_twice" on the declaration of
nlr_push seems to resolve the issue seen on cortex-m4.

Toolchain used, arm-none-eabi-gcc 7.2.1.

Also, a thanks to @aykevl for proposing to try this attribute.