### PR TITLE
moduselect.c Fix bug where in single shot mode Poll instance clears all flags

### DIFF
--- a/extmod/moduselect.c
+++ b/extmod/moduselect.c
@@ -275,7 +275,7 @@ STATIC mp_obj_t poll_poll(uint n_args, const mp_obj_t *args) {
             ret_list->items[n_ready++] = mp_obj_new_tuple(2, tuple);
             if (self->flags & FLAG_ONESHOT) {
                 // Don't poll next time, until new event flags will be set explicitly
-                poll_obj->flags = 0;
+                poll_obj->flags &= ~(poll_obj->flags_ret & (MP_STREAM_POLL_RD | MP_STREAM_POLL_WR));
             }
         }
     }
@@ -319,7 +319,7 @@ STATIC mp_obj_t poll_iternext(mp_obj_t self_in) {
             t->items[1] = MP_OBJ_NEW_SMALL_INT(poll_obj->flags_ret);
             if (self->flags & FLAG_ONESHOT) {
                 // Don't poll next time, until new event flags will be set explicitly
-                poll_obj->flags = 0;
+                poll_obj->flags &= ~(poll_obj->flags_ret & (MP_STREAM_POLL_RD | MP_STREAM_POLL_WR));
             }
             return MP_OBJ_FROM_PTR(t);
         }


### PR DESCRIPTION
This behaviour is incorrect for bidirectional devices. This patch ensures that only the flag which was raised is cleared. This is applied to the poll() method and the ipoll() iterator.

@dpgeorge Implements your suggestion.

Tested for regression with the following script (On Pyboard with X1-X2 linked)
```python
import uasyncio as asyncio
from pyb import UART
uart = UART(4, 9600)

async def sender():
    swriter = asyncio.StreamWriter(uart, {})
    while True:
        await swriter.awrite('Hello uart\n')
        await asyncio.sleep(2)

async def receiver():
    sreader = asyncio.StreamReader(uart)
    while True:
        res = await sreader.readline()
        print('Recieved', res)

loop = asyncio.get_event_loop()
loop.create_task(sender())
loop.create_task(receiver())
loop.run_forever()
```