### PR TITLE
Implementing high resolution timers on ESP32 and ESP8266

### DIFF
--- a/ports/esp32/machine_timer.c
+++ b/ports/esp32/machine_timer.c
@@ -153,19 +153,11 @@ STATIC mp_obj_t machine_timer_init_helper(machine_timer_obj_t *self, mp_uint_t n
 
 #if MICROPY_PY_MACHINE_HI_RES_TIMER
     if (args[3].u_obj != mp_const_none) {
-        mp_float_t freq;
-        if (mp_obj_get_float_maybe(args[3].u_obj, &freq)) {
-	    self->period = (uint64_t) (TIMER_SCALE / freq);
-        } else {
-            mp_raise_TypeError("Frequency must be a number");
-        }
+        mp_float_t freq = mp_obj_get_float(args[3].u_obj);
+	self->period = (uint64_t) (TIMER_SCALE / freq);
     } else {
-        mp_float_t period;
-        if (mp_obj_get_float_maybe(args[2].u_obj, &period)) {
-	    self->period = (uint64_t) (period * TIMER_SCALE / 1000);
-	} else {
-	    mp_raise_TypeError("Period must be a number");
-        }
+        mp_float_t period = mp_obj_get_float(args[2].u_obj);
+	self->period = (uint64_t) (period * TIMER_SCALE / 1000);
     }
 #else
     // Timer uses an 80MHz base clock, which is divided by the divider/scalar, we then convert to ms.

--- a/ports/esp32/machine_timer.c
+++ b/ports/esp32/machine_timer.c
@@ -36,11 +36,8 @@
 #include "modmachine.h"
 
 #define TIMER_INTR_SEL TIMER_INTR_LEVEL
-#if MICROPY_PY_MACHINE_HI_RES_TIMER
 #define TIMER_DIVIDER  40
-#else
-#define TIMER_DIVIDER  40000
-#endif
+
 // TIMER_BASE_CLK is normally 80MHz. TIMER_DIVIDER ought to divide this exactly
 #define TIMER_SCALE    (TIMER_BASE_CLK / TIMER_DIVIDER)
 
@@ -138,11 +135,14 @@ STATIC mp_obj_t machine_timer_init_helper(machine_timer_obj_t *self, mp_uint_t n
     static const mp_arg_t allowed_args[] = {
         { MP_QSTR_mode,         MP_ARG_KW_ONLY | MP_ARG_INT, {.u_int = 1} },
         { MP_QSTR_callback,     MP_ARG_KW_ONLY | MP_ARG_OBJ, {.u_obj = mp_const_none} },
-#if MICROPY_PY_MACHINE_HI_RES_TIMER
+#if MICROPY_PY_BUILTINS_FLOAT
         { MP_QSTR_period,       MP_ARG_KW_ONLY | MP_ARG_OBJ, {.u_obj = mp_const_none} },
         { MP_QSTR_freq,         MP_ARG_KW_ONLY | MP_ARG_OBJ, {.u_obj = mp_const_none} },
+        { MP_QSTR_period_us,    MP_ARG_KW_ONLY | MP_ARG_OBJ, {.u_obj = mp_const_none} },
 #else
         { MP_QSTR_period,       MP_ARG_KW_ONLY | MP_ARG_INT, {.u_int = 0xffffffff} },
+        { MP_QSTR_freq,         MP_ARG_KW_ONLY | MP_ARG_INT, {.u_int = 0xffffffff} },
+        { MP_QSTR_period_us,    MP_ARG_KW_ONLY | MP_ARG_INT, {.u_int = 0xffffffff} },
 #endif
     };
 
@@ -151,17 +151,27 @@ STATIC mp_obj_t machine_timer_init_helper(machine_timer_obj_t *self, mp_uint_t n
     mp_arg_val_t args[MP_ARRAY_SIZE(allowed_args)];
     mp_arg_parse_all(n_args, pos_args, kw_args, MP_ARRAY_SIZE(allowed_args), allowed_args, args);
 
-#if MICROPY_PY_MACHINE_HI_RES_TIMER
-    if (args[3].u_obj != mp_const_none) {
-        mp_float_t freq = mp_obj_get_float(args[3].u_obj);
-	self->period = (uint64_t) (TIMER_SCALE / freq);
+#if MICROPY_PY_BUILTINS_FLOAT
+    if (args[2].u_obj != mp_const_none) {
+	self->period = (uint64_t) (mp_obj_get_float(args[2].u_obj) * TIMER_SCALE / 1000);
+    } else if (args[3].u_obj != mp_const_none) {
+	self->period = (uint64_t) (TIMER_SCALE / mp_obj_get_float(args[3].u_obj));
+    } else if (args[4].u_obj != mp_const_none) {
+	self->period = (uint64_t) (mp_obj_get_float(args[4].u_obj) * TIMER_SCALE / 1000000);
     } else {
-        mp_float_t period = mp_obj_get_float(args[2].u_obj);
-	self->period = (uint64_t) (period * TIMER_SCALE / 1000);
+	mp_raise_ValueError("Need period or freq value");
     }
 #else
-    // Timer uses an 80MHz base clock, which is divided by the divider/scalar, we then convert to ms.
-    self->period = (args[2].u_int * TIMER_BASE_CLK) / (1000 * TIMER_DIVIDER);
+    // Timer uses an 80MHz base clock, which is divided by the divider/scalar.
+    if (args[2].u_int != 0xffffffff) {
+	self->period = ((uint64_t) args[2].u_int) * TIMER_SCALE / 1000;
+    } else if (args[3].u_int != 0xffffffff) {
+	self->period = TIMER_SCALE / ((uint64_t) args[3].u_int);
+    } else if (args[4].u_int != 0xffffffff) {
+	self->period = ((uint64_t) args[4].u_int) * TIMER_SCALE / 1000000;
+    } else {
+	mp_raise_ValueError("Need period or freq value");
+    }
 #endif
 
     self->repeat = args[0].u_int;

--- a/ports/esp32/machine_timer.c
+++ b/ports/esp32/machine_timer.c
@@ -36,7 +36,12 @@
 #include "modmachine.h"
 
 #define TIMER_INTR_SEL TIMER_INTR_LEVEL
+#if MICROPY_PY_MACHINE_HI_RES_TIMER
+#define TIMER_DIVIDER  40
+#else
 #define TIMER_DIVIDER  40000
+#endif
+// TIMER_BASE_CLK is normally 80MHz. TIMER_DIVIDER ought to divide this exactly
 #define TIMER_SCALE    (TIMER_BASE_CLK / TIMER_DIVIDER)
 
 #define TIMER_FLAGS    0
@@ -47,7 +52,8 @@ typedef struct _machine_timer_obj_t {
     mp_uint_t index;
 
     mp_uint_t repeat;
-    mp_uint_t period;
+    // ESP32 timers are 64-bit
+    uint64_t period;
 
     mp_obj_t callback;
 
@@ -130,9 +136,14 @@ STATIC void machine_timer_enable(machine_timer_obj_t *self) {
 
 STATIC mp_obj_t machine_timer_init_helper(machine_timer_obj_t *self, mp_uint_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
     static const mp_arg_t allowed_args[] = {
-        { MP_QSTR_period,       MP_ARG_KW_ONLY | MP_ARG_INT, {.u_int = 0xffffffff} },
         { MP_QSTR_mode,         MP_ARG_KW_ONLY | MP_ARG_INT, {.u_int = 1} },
         { MP_QSTR_callback,     MP_ARG_KW_ONLY | MP_ARG_OBJ, {.u_obj = mp_const_none} },
+#if MICROPY_PY_MACHINE_HI_RES_TIMER
+        { MP_QSTR_period,       MP_ARG_KW_ONLY | MP_ARG_OBJ, {.u_obj = mp_const_none} },
+        { MP_QSTR_freq,         MP_ARG_KW_ONLY | MP_ARG_OBJ, {.u_obj = mp_const_none} },
+#else
+        { MP_QSTR_period,       MP_ARG_KW_ONLY | MP_ARG_INT, {.u_int = 0xffffffff} },
+#endif
     };
 
     machine_timer_disable(self);
@@ -140,10 +151,29 @@ STATIC mp_obj_t machine_timer_init_helper(machine_timer_obj_t *self, mp_uint_t n
     mp_arg_val_t args[MP_ARRAY_SIZE(allowed_args)];
     mp_arg_parse_all(n_args, pos_args, kw_args, MP_ARRAY_SIZE(allowed_args), allowed_args, args);
 
+#if MICROPY_PY_MACHINE_HI_RES_TIMER
+    if (args[3].u_obj != mp_const_none) {
+        mp_float_t freq;
+        if (mp_obj_get_float_maybe(args[3].u_obj, &freq)) {
+	    self->period = (uint64_t) (TIMER_SCALE / freq);
+        } else {
+            mp_raise_TypeError("Frequency must be a number");
+        }
+    } else {
+        mp_float_t period;
+        if (mp_obj_get_float_maybe(args[2].u_obj, &period)) {
+	    self->period = (uint64_t) (period * TIMER_SCALE / 1000);
+	} else {
+	    mp_raise_TypeError("Period must be a number");
+        }
+    }
+#else
     // Timer uses an 80MHz base clock, which is divided by the divider/scalar, we then convert to ms.
-    self->period = (args[0].u_int * TIMER_BASE_CLK) / (1000 * TIMER_DIVIDER);
-    self->repeat = args[1].u_int;
-    self->callback = args[2].u_obj;
+    self->period = (args[2].u_int * TIMER_BASE_CLK) / (1000 * TIMER_DIVIDER);
+#endif
+
+    self->repeat = args[0].u_int;
+    self->callback = args[1].u_obj;
     self->handle = NULL;
 
     machine_timer_enable(self);

--- a/ports/esp8266/main.c
+++ b/ports/esp8266/main.c
@@ -33,6 +33,12 @@
 #include "py/mperrno.h"
 #include "py/mphal.h"
 #include "py/gc.h"
+
+/* This needs to be defined before any ESP SDK headers are included */
+#if MICROPY_PY_MACHINE_HI_RES_TIMER
+#define USE_US_TIMER 1
+#endif
+
 #include "extmod/misc.h"
 #include "lib/mp-readline/readline.h"
 #include "lib/utils/pyexec.h"
@@ -126,6 +132,9 @@ soft_reset:
 }
 
 void user_init(void) {
+#if MICROPY_PY_MACHINE_HI_RES_TIMER
+    system_timer_reinit();
+#endif
     system_init_done_cb(init_done);
 }
 

--- a/ports/esp8266/main.c
+++ b/ports/esp8266/main.c
@@ -35,9 +35,7 @@
 #include "py/gc.h"
 
 /* This needs to be defined before any ESP SDK headers are included */
-#if MICROPY_PY_MACHINE_HI_RES_TIMER
 #define USE_US_TIMER 1
-#endif
 
 #include "extmod/misc.h"
 #include "lib/mp-readline/readline.h"
@@ -132,9 +130,7 @@ soft_reset:
 }
 
 void user_init(void) {
-#if MICROPY_PY_MACHINE_HI_RES_TIMER
     system_timer_reinit();
-#endif
     system_init_done_cb(init_done);
 }
 

--- a/ports/esp8266/modmachine.c
+++ b/ports/esp8266/modmachine.c
@@ -190,16 +190,10 @@ STATIC mp_obj_t esp_timer_init_helper(esp_timer_obj_t *self, size_t n_args, cons
     os_timer_setfn(&self->timer, esp_timer_cb, self);
 #if MICROPY_PY_MACHINE_HI_RES_TIMER
     if (args[3].u_obj != mp_const_none) {
-        mp_float_t freq;
-        if (mp_obj_get_float_maybe(args[3].u_obj, &freq)) {
-            period = 1000.0 / freq;
-        } else {
-            mp_raise_TypeError("Frequency must be a number");
-        }
+        mp_float_t freq = mp_obj_get_float(args[3].u_obj);
+	period = 1000.0 / freq;
     } else {
-        if (!mp_obj_get_float_maybe(args[2].u_obj, &period)) {
-	    mp_raise_TypeError("Period must be a number");
-        }
+        period = mp_obj_get_float(args[2].u_obj);
     }
 
     p_set_value = (mp_int_t) period;

--- a/ports/esp8266/modmachine.c
+++ b/ports/esp8266/modmachine.c
@@ -30,6 +30,11 @@
 
 #include "py/obj.h"
 #include "py/runtime.h"
+
+#if MICROPY_PY_MACHINE_HI_RES_TIMER
+#define USE_US_TIMER 1
+#endif
+
 #include "extmod/machine_mem.h"
 #include "extmod/machine_signal.h"
 #include "extmod/machine_pulse.h"
@@ -161,21 +166,52 @@ STATIC void esp_timer_cb(void *arg) {
 
 STATIC mp_obj_t esp_timer_init_helper(esp_timer_obj_t *self, size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
     static const mp_arg_t allowed_args[] = {
-//        { MP_QSTR_freq,         MP_ARG_KW_ONLY | MP_ARG_OBJ, {.u_obj = mp_const_none} },
-        { MP_QSTR_period,       MP_ARG_KW_ONLY | MP_ARG_INT, {.u_int = 0xffffffff} },
         { MP_QSTR_mode,         MP_ARG_KW_ONLY | MP_ARG_INT, {.u_int = 1} },
         { MP_QSTR_callback,     MP_ARG_KW_ONLY | MP_ARG_OBJ, {.u_obj = mp_const_none} },
+#if MICROPY_PY_MACHINE_HI_RES_TIMER
+        { MP_QSTR_period,       MP_ARG_KW_ONLY | MP_ARG_OBJ, {.u_obj = mp_const_none} },
+        { MP_QSTR_freq,         MP_ARG_KW_ONLY | MP_ARG_OBJ, {.u_obj = mp_const_none} },
+#else
+        { MP_QSTR_period,       MP_ARG_KW_ONLY | MP_ARG_INT, {.u_int = 0xffffffff} },
+#endif
     };
+#if MICROPY_PY_MACHINE_HI_RES_TIMER
+    mp_float_t period;
+    mp_int_t p_set_value;
+#endif
 
     // parse args
     mp_arg_val_t args[MP_ARRAY_SIZE(allowed_args)];
     mp_arg_parse_all(n_args, pos_args, kw_args, MP_ARRAY_SIZE(allowed_args), allowed_args, args);
 
-    self->callback = args[2].u_obj;
+    self->callback = args[1].u_obj;
     // Be sure to disarm timer before making any changes
     os_timer_disarm(&self->timer);
     os_timer_setfn(&self->timer, esp_timer_cb, self);
-    os_timer_arm(&self->timer, args[0].u_int, args[1].u_int);
+#if MICROPY_PY_MACHINE_HI_RES_TIMER
+    if (args[3].u_obj != mp_const_none) {
+        mp_float_t freq;
+        if (mp_obj_get_float_maybe(args[3].u_obj, &freq)) {
+            period = 1000.0 / freq;
+        } else {
+            mp_raise_TypeError("Frequency must be a number");
+        }
+    } else {
+        if (!mp_obj_get_float_maybe(args[2].u_obj, &period)) {
+	    mp_raise_TypeError("Period must be a number");
+        }
+    }
+
+    p_set_value = (mp_int_t) period;
+    if (((mp_float_t) p_set_value) == period) {
+        os_timer_arm(&self->timer, p_set_value, args[0].u_int);
+    } else {
+        p_set_value = (mp_int_t) (period * 1000);
+        os_timer_arm_us(&self->timer, p_set_value, args[0].u_int);
+    }
+#else
+    os_timer_arm(&self->timer, args[2].u_int, args[0].u_int);
+#endif
 
     return mp_const_none;
 }

--- a/ports/esp8266/modmachine.c
+++ b/ports/esp8266/modmachine.c
@@ -31,9 +31,8 @@
 #include "py/obj.h"
 #include "py/runtime.h"
 
-#if MICROPY_PY_MACHINE_HI_RES_TIMER
+// This needs to be set before we include the RTOS headers
 #define USE_US_TIMER 1
-#endif
 
 #include "extmod/machine_mem.h"
 #include "extmod/machine_signal.h"
@@ -168,17 +167,16 @@ STATIC mp_obj_t esp_timer_init_helper(esp_timer_obj_t *self, size_t n_args, cons
     static const mp_arg_t allowed_args[] = {
         { MP_QSTR_mode,         MP_ARG_KW_ONLY | MP_ARG_INT, {.u_int = 1} },
         { MP_QSTR_callback,     MP_ARG_KW_ONLY | MP_ARG_OBJ, {.u_obj = mp_const_none} },
-#if MICROPY_PY_MACHINE_HI_RES_TIMER
+#if MICROPY_PY_BUILTINS_FLOAT
         { MP_QSTR_period,       MP_ARG_KW_ONLY | MP_ARG_OBJ, {.u_obj = mp_const_none} },
         { MP_QSTR_freq,         MP_ARG_KW_ONLY | MP_ARG_OBJ, {.u_obj = mp_const_none} },
+        { MP_QSTR_period_us,    MP_ARG_KW_ONLY | MP_ARG_OBJ, {.u_obj = mp_const_none} },
 #else
         { MP_QSTR_period,       MP_ARG_KW_ONLY | MP_ARG_INT, {.u_int = 0xffffffff} },
+        { MP_QSTR_freq,         MP_ARG_KW_ONLY | MP_ARG_INT, {.u_int = 0xffffffff} },
+        { MP_QSTR_period_us,    MP_ARG_KW_ONLY | MP_ARG_INT, {.u_int = 0xffffffff} },
 #endif
     };
-#if MICROPY_PY_MACHINE_HI_RES_TIMER
-    mp_float_t period;
-    mp_int_t p_set_value;
-#endif
 
     // parse args
     mp_arg_val_t args[MP_ARRAY_SIZE(allowed_args)];
@@ -188,23 +186,35 @@ STATIC mp_obj_t esp_timer_init_helper(esp_timer_obj_t *self, size_t n_args, cons
     // Be sure to disarm timer before making any changes
     os_timer_disarm(&self->timer);
     os_timer_setfn(&self->timer, esp_timer_cb, self);
-#if MICROPY_PY_MACHINE_HI_RES_TIMER
-    if (args[3].u_obj != mp_const_none) {
-        mp_float_t freq = mp_obj_get_float(args[3].u_obj);
-	period = 1000.0 / freq;
-    } else {
+
+#if MICROPY_PY_BUILTINS_FLOAT
+    mp_float_t period;
+    if (args[2].u_obj != mp_const_none) {
         period = mp_obj_get_float(args[2].u_obj);
+    } else if (args[3].u_obj != mp_const_none) {
+	period = 1000.0 / mp_obj_get_float(args[3].u_obj);
+    } else if (args[4].u_obj != mp_const_none) {
+        period = mp_obj_get_float(args[4].u_obj) / 1000.0;
+    } else {
+	mp_raise_ValueError("Need period or freq value");
     }
 
-    p_set_value = (mp_int_t) period;
-    if (((mp_float_t) p_set_value) == period) {
-        os_timer_arm(&self->timer, p_set_value, args[0].u_int);
+    // If the period is small enough then use the microsecond timer
+    if (period < 2000000.0) {
+	os_timer_arm_us(&self->timer, (mp_int_t) (period * 1000), args[0].u_int);
     } else {
-        p_set_value = (mp_int_t) (period * 1000);
-        os_timer_arm_us(&self->timer, p_set_value, args[0].u_int);
+	os_timer_arm(&self->timer, (mp_int_t) (period), args[0].u_int);
     }
 #else
-    os_timer_arm(&self->timer, args[2].u_int, args[0].u_int);
+    if (args[2].u_int != 0xffffffff) {
+	os_timer_arm(&self->timer, args[2].u_int, args[0].u_int);
+    } else if (args[3].u_int != 0xffffffff) {
+	os_timer_arm_us(&self->timer, 1000000 / args[3].u_int, args[0].u_int);
+    } else if (args[4].u_int != 0xffffffff) {
+	os_timer_arm_us(&self->timer, args[4].u_int, args[0].u_int);
+    } else {
+	mp_raise_ValueError("Need period or freq value");
+    }
 #endif
 
     return mp_const_none;

--- a/py/mpconfig.h
+++ b/py/mpconfig.h
@@ -1198,6 +1198,16 @@ typedef double mp_float_t;
 #define MICROPY_PY_MACHINE_SPI (0)
 #endif
 
+// High resolution machine timers require floating point support
+#ifndef MICROPY_PY_MACHINE_HI_RES_TIMER
+#define MICROPY_PY_MACHINE_HI_RES_TIMER MICROPY_PY_BUILTINS_FLOAT
+#else
+#if MICROPY_PY_MACHINE_HI_RES_TIMER && (MICROPY_PY_BUILTINS_FLOAT == 0)
+#undef MICROPY_PY_MACHINE_HI_RES_TIMER
+#define MICROPY_PY_MACHINE_HI_RES_TIMER (0)
+#endif
+#endif
+
 #ifndef MICROPY_PY_USSL
 #define MICROPY_PY_USSL (0)
 // Whether to add finaliser code to ussl objects

--- a/py/mpconfig.h
+++ b/py/mpconfig.h
@@ -1198,16 +1198,6 @@ typedef double mp_float_t;
 #define MICROPY_PY_MACHINE_SPI (0)
 #endif
 
-// High resolution machine timers require floating point support
-#ifndef MICROPY_PY_MACHINE_HI_RES_TIMER
-#define MICROPY_PY_MACHINE_HI_RES_TIMER MICROPY_PY_BUILTINS_FLOAT
-#else
-#if MICROPY_PY_MACHINE_HI_RES_TIMER && (MICROPY_PY_BUILTINS_FLOAT == 0)
-#undef MICROPY_PY_MACHINE_HI_RES_TIMER
-#define MICROPY_PY_MACHINE_HI_RES_TIMER (0)
-#endif
-#endif
-
 #ifndef MICROPY_PY_USSL
 #define MICROPY_PY_USSL (0)
 // Whether to add finaliser code to ussl objects


### PR DESCRIPTION
This patch allows the `machine.Timer` class to support timing with microsecond resolution (or better, on the ESP32) rather than the current millisecond resolution.

For one-shot timers this simply provides much better resolution when specifying times. For periodic timers it also provides support for representing frequencies that could not be represented before. For example the old implementation would allow for a 111.11Hz cycle (with a 9ms period) or 125Hz (with an 8ms period) but could not offer a 120Hz cycle; this can now be specified with an 8.3333ms period. It also allows for frequencies that exceed 1KHz.

In addition to supporting floating point values for the existing `period` parameter to the `init()` method this patch adds a floating point `freq` parameter to specify the frequency of a timer in Hz.

The patch is backward API compatible.

The new functionality is conditionally enabled using the new `MICROPY_PY_MACHINE_HI_RES_TIMER` port configuration option. If this is not explicitly set in the then `py/mpconfig.h` sets this to the same value as `MICROPY_PY_BUILTINS_FLOAT` and if floating point support is disabled then the feature is automatically disabled. This PR does not currently explicitly set the `MICROPY_PY_MACHINE_HI_RES_TIMER` in either of the supported ports.