### PR TITLE
Added function ticks_timer exposing full 64 bits of cpu timer

### DIFF
--- a/ports/esp32/Makefile
+++ b/ports/esp32/Makefile
@@ -64,6 +64,7 @@ INC_ESPCOMP += -I$(ESPCOMP)/driver/include/driver
 INC_ESPCOMP += -I$(ESPCOMP)/nghttp/port/include
 INC_ESPCOMP += -I$(ESPCOMP)/nghttp/nghttp2/lib/includes
 INC_ESPCOMP += -I$(ESPCOMP)/esp32/include
+INC_ESPCOMP += -I$(ESPCOMP)/esp32/
 INC_ESPCOMP += -I$(ESPCOMP)/soc/include
 INC_ESPCOMP += -I$(ESPCOMP)/soc/esp32/include
 INC_ESPCOMP += -I$(ESPCOMP)/ethernet/include

--- a/ports/esp32/modutime.c
+++ b/ports/esp32/modutime.c
@@ -84,11 +84,18 @@ STATIC mp_obj_t time_time(void) {
 }
 MP_DEFINE_CONST_FUN_OBJ_0(time_time_obj, time_time);
 
-STATIC mp_obj_t time_ticks_timer(void) {
-    uint64_t us = esp_timer_impl_get_time();
-    return mp_obj_new_int_from_ull(us);
+STATIC mp_obj_t time_ticks_ms(void) {
+    uint32_t result = esp_timer_impl_get_time() / 1000;
+    return mp_obj_new_int( result & 0xFFFFFFFF );
 }
-MP_DEFINE_CONST_FUN_OBJ_0(mp_utime_ticks_timer_obj, time_ticks_timer);
+MP_DEFINE_CONST_FUN_OBJ_0(mp_esp32_utime_ticks_ms_obj, time_ticks_ms);
+
+STATIC mp_obj_t time_ticks_us(void) {
+    uint64_t us = esp_timer_impl_get_time();
+    return mp_obj_new_int_from_ull(us);    
+}
+MP_DEFINE_CONST_FUN_OBJ_0(mp_esp32_utime_ticks_us_obj, time_ticks_us);
+
 
 STATIC const mp_rom_map_elem_t time_module_globals_table[] = {
     { MP_ROM_QSTR(MP_QSTR___name__), MP_ROM_QSTR(MP_QSTR_utime) },
@@ -99,10 +106,9 @@ STATIC const mp_rom_map_elem_t time_module_globals_table[] = {
     { MP_ROM_QSTR(MP_QSTR_sleep), MP_ROM_PTR(&mp_utime_sleep_obj) },
     { MP_ROM_QSTR(MP_QSTR_sleep_ms), MP_ROM_PTR(&mp_utime_sleep_ms_obj) },
     { MP_ROM_QSTR(MP_QSTR_sleep_us), MP_ROM_PTR(&mp_utime_sleep_us_obj) },
-    { MP_ROM_QSTR(MP_QSTR_ticks_ms), MP_ROM_PTR(&mp_utime_ticks_ms_obj) },
-    { MP_ROM_QSTR(MP_QSTR_ticks_us), MP_ROM_PTR(&mp_utime_ticks_us_obj) },
-    { MP_ROM_QSTR(MP_QSTR_ticks_cpu), MP_ROM_PTR(&mp_utime_ticks_cpu_obj) },
-    { MP_ROM_QSTR(MP_QSTR_ticks_timer), MP_ROM_PTR(&mp_utime_ticks_timer_obj) },    
+    { MP_ROM_QSTR(MP_QSTR_ticks_ms),  MP_ROM_PTR(&mp_esp32_utime_ticks_ms_obj) },
+    { MP_ROM_QSTR(MP_QSTR_ticks_us),  MP_ROM_PTR(&mp_esp32_utime_ticks_us_obj) },
+    { MP_ROM_QSTR(MP_QSTR_ticks_cpu), MP_ROM_PTR(&mp_esp32_utime_ticks_us_obj) },
     { MP_ROM_QSTR(MP_QSTR_ticks_add), MP_ROM_PTR(&mp_utime_ticks_add_obj) },
     { MP_ROM_QSTR(MP_QSTR_ticks_diff), MP_ROM_PTR(&mp_utime_ticks_diff_obj) },
 };

--- a/ports/esp32/modutime.c
+++ b/ports/esp32/modutime.c
@@ -33,6 +33,8 @@
 #include "py/runtime.h"
 #include "lib/timeutils/timeutils.h"
 #include "extmod/utime_mphal.h"
+#include "esp_timer_impl.h"
+
 
 STATIC mp_obj_t time_localtime(size_t n_args, const mp_obj_t *args) {
     timeutils_struct_time_t tm;
@@ -82,6 +84,12 @@ STATIC mp_obj_t time_time(void) {
 }
 MP_DEFINE_CONST_FUN_OBJ_0(time_time_obj, time_time);
 
+STATIC mp_obj_t time_ticks_timer(void) {
+    uint64_t us = esp_timer_impl_get_time();
+    return mp_obj_new_int_from_ull(us);
+}
+MP_DEFINE_CONST_FUN_OBJ_0(mp_utime_ticks_timer_obj, time_ticks_timer);
+
 STATIC const mp_rom_map_elem_t time_module_globals_table[] = {
     { MP_ROM_QSTR(MP_QSTR___name__), MP_ROM_QSTR(MP_QSTR_utime) },
 
@@ -94,6 +102,7 @@ STATIC const mp_rom_map_elem_t time_module_globals_table[] = {
     { MP_ROM_QSTR(MP_QSTR_ticks_ms), MP_ROM_PTR(&mp_utime_ticks_ms_obj) },
     { MP_ROM_QSTR(MP_QSTR_ticks_us), MP_ROM_PTR(&mp_utime_ticks_us_obj) },
     { MP_ROM_QSTR(MP_QSTR_ticks_cpu), MP_ROM_PTR(&mp_utime_ticks_cpu_obj) },
+    { MP_ROM_QSTR(MP_QSTR_ticks_timer), MP_ROM_PTR(&mp_utime_ticks_timer_obj) },    
     { MP_ROM_QSTR(MP_QSTR_ticks_add), MP_ROM_PTR(&mp_utime_ticks_add_obj) },
     { MP_ROM_QSTR(MP_QSTR_ticks_diff), MP_ROM_PTR(&mp_utime_ticks_diff_obj) },
 };


### PR DESCRIPTION
Herby I propose to add a ticks_timer function, for esp32 port. 

The implementation is based on **esp_timer_impl_get_time()**, a 64 bit microsecond counter.
uint64_t with microseconds will overflow in 2^64 / (1e6 * 60 * 60 * 24 * 365) = 292471,21 year.

Note that nothing is changed to the current implementation.

With this implementation there is no need anymore to calculate time diffs with ticks_diff.
And far less cpu cycles is spend in calculating the ticks, and ticks diffs

Another advantage is that the value of ticks_timer will not make a jump in case one changes the date of the system. 

Note that ticks_ms and ticks_us will make a jump in case one changes the date of the system.

Testing of the microseconds timer can be done with next code:

```
import utime as time

def showtime(us):
	useconds = us % 1000000
	tseconds  = us // 1000000

	tminutes = tseconds // 60
	seconds  = tseconds % 60

	thours   = tminutes // 60
	minutes  = tminutes % 60

	tdays    = thours // 24
	hours    = thours % 24

	tyears   = tdays // 365
	days     = tdays %  365

	print ("years:%s  days:%s  h:%2s  m:%2s  s:%2s  us:%s  raw:%s"%(tyears, days,hours,minutes,seconds,useconds,us) )

while (True):
	us = time.ticks_timer()
	showtime(us)
	time.sleep(10)

```