### PR TITLE
Shorten some error strings to save a bit of code size

### DIFF
--- a/py/argcheck.c
+++ b/py/argcheck.c
@@ -36,7 +36,7 @@ void mp_arg_check_num(size_t n_args, size_t n_kw, size_t n_args_min, size_t n_ar
         if (MICROPY_ERROR_REPORTING == MICROPY_ERROR_REPORTING_TERSE) {
             mp_arg_error_terse_mismatch();
         } else {
-            mp_raise_TypeError("function does not take keyword arguments");
+            mp_raise_TypeError("function doesn't take keyword arguments");
         }
     }
 

--- a/py/argcheck.c
+++ b/py/argcheck.c
@@ -46,7 +46,7 @@ void mp_arg_check_num(size_t n_args, size_t n_kw, size_t n_args_min, size_t n_ar
                 mp_arg_error_terse_mismatch();
             } else {
                 nlr_raise(mp_obj_new_exception_msg_varg(&mp_type_TypeError,
-                    "function takes %d positional arguments but %d were given",
+                    "function takes %d positional args but %d were given",
                     n_args_min, n_args));
             }
         }
@@ -56,7 +56,7 @@ void mp_arg_check_num(size_t n_args, size_t n_kw, size_t n_args_min, size_t n_ar
                 mp_arg_error_terse_mismatch();
             } else {
                 nlr_raise(mp_obj_new_exception_msg_varg(&mp_type_TypeError,
-                    "function missing %d required positional arguments",
+                    "function missing %d required positional args",
                     n_args_min - n_args));
             }
         } else if (n_args > n_args_max) {
@@ -64,7 +64,7 @@ void mp_arg_check_num(size_t n_args, size_t n_kw, size_t n_args_min, size_t n_ar
                 mp_arg_error_terse_mismatch();
             } else {
                 nlr_raise(mp_obj_new_exception_msg_varg(&mp_type_TypeError,
-                    "function expected at most %d arguments, got %d",
+                    "function expected at most %d args, got %d",
                     n_args_max, n_args));
             }
         }
@@ -89,7 +89,7 @@ void mp_arg_parse_all(size_t n_pos, const mp_obj_t *pos, mp_map_t *kws, size_t n
                         mp_arg_error_terse_mismatch();
                     } else {
                         nlr_raise(mp_obj_new_exception_msg_varg(&mp_type_TypeError,
-                            "'%q' argument required", allowed[i].qst));
+                            "'%q' arg required", allowed[i].qst));
                     }
                 }
                 out_vals[i] = allowed[i].defval;
@@ -114,7 +114,7 @@ void mp_arg_parse_all(size_t n_pos, const mp_obj_t *pos, mp_map_t *kws, size_t n
             mp_arg_error_terse_mismatch();
         } else {
             // TODO better error message
-            mp_raise_TypeError("extra positional arguments given");
+            mp_raise_TypeError("extra positional args given");
         }
     }
     if (kws_found < kws->used) {
@@ -122,7 +122,7 @@ void mp_arg_parse_all(size_t n_pos, const mp_obj_t *pos, mp_map_t *kws, size_t n
             mp_arg_error_terse_mismatch();
         } else {
             // TODO better error message
-            mp_raise_TypeError("extra keyword arguments given");
+            mp_raise_TypeError("extra keyword args given");
         }
     }
 }
@@ -134,11 +134,11 @@ void mp_arg_parse_all_kw_array(size_t n_pos, size_t n_kw, const mp_obj_t *args, 
 }
 
 NORETURN void mp_arg_error_terse_mismatch(void) {
-    mp_raise_TypeError("argument num/types mismatch");
+    mp_raise_TypeError("arg num/types mismatch");
 }
 
 #if MICROPY_CPYTHON_COMPAT
 NORETURN void mp_arg_error_unimpl_kw(void) {
-    mp_raise_NotImplementedError("keyword argument(s) not yet implemented - use normal args instead");
+    mp_raise_NotImplementedError("keyword arg(s) not yet implemented - use normal args instead");
 }
 #endif

--- a/py/bc.c
+++ b/py/bc.c
@@ -80,10 +80,10 @@ STATIC NORETURN void fun_pos_args_mismatch(mp_obj_fun_bc_t *f, size_t expected, 
 #elif MICROPY_ERROR_REPORTING == MICROPY_ERROR_REPORTING_NORMAL
     (void)f;
     nlr_raise(mp_obj_new_exception_msg_varg(&mp_type_TypeError,
-        "function takes %d positional arguments but %d were given", expected, given));
+        "function takes %d positional args but %d were given", expected, given));
 #elif MICROPY_ERROR_REPORTING == MICROPY_ERROR_REPORTING_DETAILED
     nlr_raise(mp_obj_new_exception_msg_varg(&mp_type_TypeError,
-        "%q() takes %d positional arguments but %d were given",
+        "%q() takes %d positional args but %d were given",
         mp_obj_fun_get_name(MP_OBJ_FROM_PTR(f)), expected, given));
 #endif
 }
@@ -194,7 +194,7 @@ void mp_setup_code_state(mp_code_state_t *code_state, size_t n_args, size_t n_kw
                 if (wanted_arg_name == arg_names[j]) {
                     if (code_state->state[n_state - 1 - j] != MP_OBJ_NULL) {
                         nlr_raise(mp_obj_new_exception_msg_varg(&mp_type_TypeError,
-                            "function got multiple values for argument '%q'", MP_OBJ_QSTR_VALUE(wanted_arg_name)));
+                            "function got multiple values for arg '%q'", MP_OBJ_QSTR_VALUE(wanted_arg_name)));
                     }
                     code_state->state[n_state - 1 - j] = kwargs[2 * i + 1];
                     goto continue2;
@@ -203,10 +203,10 @@ void mp_setup_code_state(mp_code_state_t *code_state, size_t n_args, size_t n_kw
             // Didn't find name match with positional args
             if ((scope_flags & MP_SCOPE_FLAG_VARKEYWORDS) == 0) {
                 if (MICROPY_ERROR_REPORTING == MICROPY_ERROR_REPORTING_TERSE) {
-                    mp_raise_TypeError("unexpected keyword argument");
+                    mp_raise_TypeError("unexpected keyword arg");
                 } else {
                     nlr_raise(mp_obj_new_exception_msg_varg(&mp_type_TypeError,
-                        "unexpected keyword argument '%q'", MP_OBJ_QSTR_VALUE(wanted_arg_name)));
+                        "unexpected keyword arg '%q'", MP_OBJ_QSTR_VALUE(wanted_arg_name)));
                 }
             }
             mp_obj_dict_store(dict, kwargs[2 * i], kwargs[2 * i + 1]);
@@ -232,7 +232,7 @@ continue2:;
         while (d < &code_state->state[n_state]) {
             if (*d++ == MP_OBJ_NULL) {
                 nlr_raise(mp_obj_new_exception_msg_varg(&mp_type_TypeError,
-                    "function missing required positional argument #%d", &code_state->state[n_state] - d));
+                    "function missing required positional arg #%d", &code_state->state[n_state] - d));
             }
         }
 
@@ -248,7 +248,7 @@ continue2:;
                     code_state->state[n_state - 1 - n_pos_args - i] = elem->value;
                 } else {
                     nlr_raise(mp_obj_new_exception_msg_varg(&mp_type_TypeError,
-                        "function missing required keyword argument '%q'", MP_OBJ_QSTR_VALUE(arg_names[n_pos_args + i])));
+                        "function missing required keyword arg '%q'", MP_OBJ_QSTR_VALUE(arg_names[n_pos_args + i])));
                 }
             }
         }
@@ -256,7 +256,7 @@ continue2:;
     } else {
         // no keyword arguments given
         if (n_kwonly_args != 0) {
-            mp_raise_TypeError("function missing keyword-only argument");
+            mp_raise_TypeError("function missing keyword-only arg");
         }
         if ((scope_flags & MP_SCOPE_FLAG_VARKEYWORDS) != 0) {
             *var_pos_kw_args = mp_obj_new_dict(0);

--- a/py/compile.c
+++ b/py/compile.c
@@ -637,7 +637,7 @@ STATIC void compile_funcdef_lambdef_param(compiler_t *comp, mp_parse_node_t pn) 
 
             // check for non-default parameters given after default parameters (allowed by parser, but not syntactically valid)
             if (!comp->have_star && comp->num_default_params != 0) {
-                compile_syntax_error(comp, pn, "non-default argument follows default argument");
+                compile_syntax_error(comp, pn, "non-default arg follows default arg");
                 return;
             }
 
@@ -3210,7 +3210,7 @@ STATIC void compile_scope_inline_asm(compiler_t *comp, scope_t *scope, pass_kind
         // emit instructions
         if (op == MP_QSTR_label) {
             if (!(n_args == 1 && MP_PARSE_NODE_IS_ID(pn_arg[0]))) {
-                compile_syntax_error(comp, nodes[i], "'label' requires 1 argument");
+                compile_syntax_error(comp, nodes[i], "'label' requires 1 arg");
                 return;
             }
             uint lab = comp_next_label(comp);
@@ -3222,7 +3222,7 @@ STATIC void compile_scope_inline_asm(compiler_t *comp, scope_t *scope, pass_kind
             }
         } else if (op == MP_QSTR_align) {
             if (!(n_args == 1 && MP_PARSE_NODE_IS_SMALL_INT(pn_arg[0]))) {
-                compile_syntax_error(comp, nodes[i], "'align' requires 1 argument");
+                compile_syntax_error(comp, nodes[i], "'align' requires 1 arg");
                 return;
             }
             if (pass > MP_PASS_SCOPE) {
@@ -3231,14 +3231,14 @@ STATIC void compile_scope_inline_asm(compiler_t *comp, scope_t *scope, pass_kind
             }
         } else if (op == MP_QSTR_data) {
             if (!(n_args >= 2 && MP_PARSE_NODE_IS_SMALL_INT(pn_arg[0]))) {
-                compile_syntax_error(comp, nodes[i], "'data' requires at least 2 arguments");
+                compile_syntax_error(comp, nodes[i], "'data' requires at least 2 args");
                 return;
             }
             if (pass > MP_PASS_SCOPE) {
                 mp_int_t bytesize = MP_PARSE_NODE_LEAF_SMALL_INT(pn_arg[0]);
                 for (uint j = 1; j < n_args; j++) {
                     if (!MP_PARSE_NODE_IS_SMALL_INT(pn_arg[j])) {
-                        compile_syntax_error(comp, nodes[i], "'data' requires integer arguments");
+                        compile_syntax_error(comp, nodes[i], "'data' requires integer args");
                         return;
                     }
                     mp_asm_base_data((mp_asm_base_t*)comp->emit_inline_asm,

--- a/py/compile.c
+++ b/py/compile.c
@@ -2800,7 +2800,7 @@ STATIC void compile_scope_func_lambda_param(compiler_t *comp, mp_parse_node_t pn
         bool added;
         id_info_t *id_info = scope_find_or_add_id(comp->scope_cur, param_name, &added);
         if (!added) {
-            compile_syntax_error(comp, pn, "name reused for argument");
+            compile_syntax_error(comp, pn, "argument name reused");
             return;
         }
         id_info->kind = ID_INFO_KIND_LOCAL;

--- a/py/emitinlinethumb.c
+++ b/py/emitinlinethumb.c
@@ -301,7 +301,7 @@ STATIC uint32_t get_arg_i(emit_inline_asm_t *emit, const char *op, mp_parse_node
     }
     uint32_t i = mp_obj_get_int_truncated(o);
     if ((i & (~fit_mask)) != 0) {
-        emit_inline_thumb_error_exc(emit, mp_obj_new_exception_msg_varg(&mp_type_SyntaxError, "'%s' integer 0x%x does not fit in mask 0x%x", op, i, fit_mask));
+        emit_inline_thumb_error_exc(emit, mp_obj_new_exception_msg_varg(&mp_type_SyntaxError, "'%s' integer 0x%x doesn't fit in mask 0x%x", op, i, fit_mask));
         return 0;
     }
     return i;

--- a/py/emitinlinethumb.c
+++ b/py/emitinlinethumb.c
@@ -803,7 +803,7 @@ STATIC void emit_inline_thumb_op(emit_inline_asm_t *emit, qstr op, mp_uint_t n_a
     return;
 
 unknown_op:
-    emit_inline_thumb_error_exc(emit, mp_obj_new_exception_msg_varg(&mp_type_SyntaxError, "unsupported Thumb instruction '%s' with %d arguments", op_str, n_args));
+    emit_inline_thumb_error_exc(emit, mp_obj_new_exception_msg_varg(&mp_type_SyntaxError, "unsupported Thumb instruction '%s' with %d args", op_str, n_args));
     return;
 
 branch_not_in_range:

--- a/py/emitinlinextensa.c
+++ b/py/emitinlinextensa.c
@@ -171,7 +171,7 @@ STATIC uint32_t get_arg_i(emit_inline_asm_t *emit, const char *op, mp_parse_node
     }
     uint32_t i = mp_obj_get_int_truncated(o);
     if (min != max && ((int)i < min || (int)i > max)) {
-        emit_inline_xtensa_error_exc(emit, mp_obj_new_exception_msg_varg(&mp_type_SyntaxError, "'%s' integer %d is not within range %d..%d", op, i, min, max));
+        emit_inline_xtensa_error_exc(emit, mp_obj_new_exception_msg_varg(&mp_type_SyntaxError, "'%s' integer %d isn't within range %d..%d", op, i, min, max));
         return 0;
     }
     return i;

--- a/py/emitinlinextensa.c
+++ b/py/emitinlinextensa.c
@@ -324,7 +324,7 @@ STATIC void emit_inline_xtensa_op(emit_inline_asm_t *emit, qstr op, mp_uint_t n_
     return;
 
 unknown_op:
-    emit_inline_xtensa_error_exc(emit, mp_obj_new_exception_msg_varg(&mp_type_SyntaxError, "unsupported Xtensa instruction '%s' with %d arguments", op_str, n_args));
+    emit_inline_xtensa_error_exc(emit, mp_obj_new_exception_msg_varg(&mp_type_SyntaxError, "unsupported Xtensa instruction '%s' with %d args", op_str, n_args));
     return;
 
     /*

--- a/py/emitnative.c
+++ b/py/emitnative.c
@@ -255,7 +255,7 @@ STATIC void emit_native_start_pass(emit_t *emit, pass_kind_t pass, scope_t *scop
 
         // right now we have a restriction of maximum of 4 arguments
         if (scope->num_pos_args >= 5) {
-            EMIT_NATIVE_VIPER_TYPE_ERROR(emit, "Viper functions don't currently support more than 4 arguments");
+            EMIT_NATIVE_VIPER_TYPE_ERROR(emit, "Viper functions don't currently support more than 4 args");
             return;
         }
 

--- a/py/modbuiltins.c
+++ b/py/modbuiltins.c
@@ -512,7 +512,7 @@ MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(mp_builtin_sum_obj, 1, 2, mp_builtin_sum);
 
 STATIC mp_obj_t mp_builtin_sorted(size_t n_args, const mp_obj_t *args, mp_map_t *kwargs) {
     if (n_args > 1) {
-        mp_raise_TypeError("must use keyword argument for key function");
+        mp_raise_TypeError("must use keyword arg for key function");
     }
     mp_obj_t self = mp_type_list.make_new(&mp_type_list, 1, 0, args);
     mp_obj_list_sort(1, &self, kwargs);

--- a/py/modmath.c
+++ b/py/modmath.c
@@ -187,7 +187,7 @@ STATIC mp_obj_t mp_math_log(size_t n_args, const mp_obj_t *args) {
         if (base <= (mp_float_t)0.0) {
             math_error();
         } else if (base == (mp_float_t)1.0) {
-            mp_raise_msg(&mp_type_ZeroDivisionError, "division by zero");
+            mp_raise_msg(&mp_type_ZeroDivisionError, "divide by zero");
         }
         return mp_obj_new_float(l / MICROPY_FLOAT_C_FUN(log)(base));
     }

--- a/py/obj.c
+++ b/py/obj.c
@@ -353,7 +353,7 @@ void mp_obj_get_array(mp_obj_t o, size_t *len, mp_obj_t **items) {
             mp_raise_TypeError("expected tuple/list");
         } else {
             nlr_raise(mp_obj_new_exception_msg_varg(&mp_type_TypeError,
-                "object '%s' is not a tuple or list", mp_obj_get_type_str(o)));
+                "object '%s' isn't a tuple or list", mp_obj_get_type_str(o)));
         }
     }
 }
@@ -475,24 +475,24 @@ mp_obj_t mp_obj_subscr(mp_obj_t base, mp_obj_t index, mp_obj_t value) {
     }
     if (value == MP_OBJ_NULL) {
         if (MICROPY_ERROR_REPORTING == MICROPY_ERROR_REPORTING_TERSE) {
-            mp_raise_TypeError("object does not support item deletion");
+            mp_raise_TypeError("object doesn't support item deletion");
         } else {
             nlr_raise(mp_obj_new_exception_msg_varg(&mp_type_TypeError,
-                "'%s' object does not support item deletion", mp_obj_get_type_str(base)));
+                "'%s' object doesn't support item deletion", mp_obj_get_type_str(base)));
         }
     } else if (value == MP_OBJ_SENTINEL) {
         if (MICROPY_ERROR_REPORTING == MICROPY_ERROR_REPORTING_TERSE) {
-            mp_raise_TypeError("object is not subscriptable");
+            mp_raise_TypeError("object isn't subscriptable");
         } else {
             nlr_raise(mp_obj_new_exception_msg_varg(&mp_type_TypeError,
-                "'%s' object is not subscriptable", mp_obj_get_type_str(base)));
+                "'%s' object isn't subscriptable", mp_obj_get_type_str(base)));
         }
     } else {
         if (MICROPY_ERROR_REPORTING == MICROPY_ERROR_REPORTING_TERSE) {
-            mp_raise_TypeError("object does not support item assignment");
+            mp_raise_TypeError("object doesn't support item assignment");
         } else {
             nlr_raise(mp_obj_new_exception_msg_varg(&mp_type_TypeError,
-                "'%s' object does not support item assignment", mp_obj_get_type_str(base)));
+                "'%s' object doesn't support item assignment", mp_obj_get_type_str(base)));
         }
     }
 }

--- a/py/objcomplex.c
+++ b/py/objcomplex.c
@@ -195,13 +195,13 @@ mp_obj_t mp_obj_complex_binary_op(mp_binary_op_t op, mp_float_t lhs_real, mp_flo
         }
         case MP_BINARY_OP_FLOOR_DIVIDE:
         case MP_BINARY_OP_INPLACE_FLOOR_DIVIDE:
-            mp_raise_TypeError("can't do truncated division of a complex number");
+            mp_raise_TypeError("can't truncate-divide a complex number");
 
         case MP_BINARY_OP_TRUE_DIVIDE:
         case MP_BINARY_OP_INPLACE_TRUE_DIVIDE:
             if (rhs_imag == 0) {
                 if (rhs_real == 0) {
-                    mp_raise_msg(&mp_type_ZeroDivisionError, "complex division by zero");
+                    mp_raise_msg(&mp_type_ZeroDivisionError, "complex divide by zero");
                 }
                 lhs_real /= rhs_real;
                 lhs_imag /= rhs_real;

--- a/py/objfloat.c
+++ b/py/objfloat.c
@@ -262,7 +262,7 @@ mp_obj_t mp_obj_float_binary_op(mp_binary_op_t op, mp_float_t lhs_val, mp_obj_t 
         case MP_BINARY_OP_INPLACE_FLOOR_DIVIDE:
             if (rhs_val == 0) {
                 zero_division_error:
-                mp_raise_msg(&mp_type_ZeroDivisionError, "division by zero");
+                mp_raise_msg(&mp_type_ZeroDivisionError, "divide by zero");
             }
             // Python specs require that x == (x//y)*y + (x%y) so we must
             // call divmod to compute the correct floor division, which

--- a/py/objint_longlong.c
+++ b/py/objint_longlong.c
@@ -217,7 +217,7 @@ mp_obj_t mp_obj_int_binary_op(mp_binary_op_t op, mp_obj_t lhs_in, mp_obj_t rhs_i
     }
 
 zero_division:
-    mp_raise_msg(&mp_type_ZeroDivisionError, "division by zero");
+    mp_raise_msg(&mp_type_ZeroDivisionError, "divide by zero");
 }
 
 mp_obj_t mp_obj_new_int(mp_int_t value) {

--- a/py/objint_mpz.c
+++ b/py/objint_mpz.c
@@ -225,7 +225,7 @@ mp_obj_t mp_obj_int_binary_op(mp_binary_op_t op, mp_obj_t lhs_in, mp_obj_t rhs_i
             case MP_BINARY_OP_INPLACE_FLOOR_DIVIDE: {
                 if (mpz_is_zero(zrhs)) {
                     zero_division_error:
-                    mp_raise_msg(&mp_type_ZeroDivisionError, "division by zero");
+                    mp_raise_msg(&mp_type_ZeroDivisionError, "divide by zero");
                 }
                 mpz_t rem; mpz_init_zero(&rem);
                 mpz_divmod_inpl(&res->mpz, &rem, zlhs, zrhs);

--- a/py/objint_mpz.c
+++ b/py/objint_mpz.c
@@ -331,7 +331,7 @@ STATIC mpz_t *mp_mpz_for_int(mp_obj_t arg, mpz_t *temp) {
 
 mp_obj_t mp_obj_int_pow3(mp_obj_t base, mp_obj_t exponent,  mp_obj_t modulus) {
     if (!MP_OBJ_IS_INT(base) || !MP_OBJ_IS_INT(exponent) || !MP_OBJ_IS_INT(modulus)) {
-        mp_raise_TypeError("pow() with 3 arguments requires integers");
+        mp_raise_TypeError("pow() with 3 args requires integers");
     } else {
         mp_obj_t result = mp_obj_new_int_from_ull(0); // Use the _from_ull version as this forces an mpz int
         mp_obj_int_t *res_p = (mp_obj_int_t *) MP_OBJ_TO_PTR(result);

--- a/py/objnamedtuple.c
+++ b/py/objnamedtuple.c
@@ -99,11 +99,11 @@ STATIC mp_obj_t namedtuple_make_new(const mp_obj_type_t *type_in, size_t n_args,
             mp_arg_error_terse_mismatch();
         } else if (MICROPY_ERROR_REPORTING == MICROPY_ERROR_REPORTING_NORMAL) {
             nlr_raise(mp_obj_new_exception_msg_varg(&mp_type_TypeError,
-                "function takes %d positional arguments but %d were given",
+                "function takes %d positional args but %d were given",
                 num_fields, n_args + n_kw));
         } else if (MICROPY_ERROR_REPORTING == MICROPY_ERROR_REPORTING_DETAILED) {
             nlr_raise(mp_obj_new_exception_msg_varg(&mp_type_TypeError,
-                "%q() takes %d positional arguments but %d were given",
+                "%q() takes %d positional args but %d were given",
                 type->base.name, num_fields, n_args + n_kw));
         }
     }
@@ -125,7 +125,7 @@ STATIC mp_obj_t namedtuple_make_new(const mp_obj_type_t *type_in, size_t n_args,
                 mp_arg_error_terse_mismatch();
             } else {
                 nlr_raise(mp_obj_new_exception_msg_varg(&mp_type_TypeError,
-                    "unexpected keyword argument '%q'", kw));
+                    "unexpected keyword arg '%q'", kw));
             }
         }
         if (tuple->items[id] != MP_OBJ_NULL) {
@@ -133,7 +133,7 @@ STATIC mp_obj_t namedtuple_make_new(const mp_obj_type_t *type_in, size_t n_args,
                 mp_arg_error_terse_mismatch();
             } else {
                 nlr_raise(mp_obj_new_exception_msg_varg(&mp_type_TypeError,
-                    "function got multiple values for argument '%q'", kw));
+                    "function got multiple values for arg '%q'", kw));
             }
         }
         tuple->items[id] = args[i + 1];

--- a/py/objstr.c
+++ b/py/objstr.c
@@ -1411,7 +1411,7 @@ STATIC mp_obj_t str_modulo_format(mp_obj_t pattern, size_t n_args, const mp_obj_
         // Dictionary value lookup
         if (*str == '(') {
             if (dict == MP_OBJ_NULL) {
-                mp_raise_TypeError("format requires a dict");
+                mp_raise_TypeError("format needs a dict");
             }
             arg_i = 1; // we used up the single dict argument
             const byte *key = ++str;
@@ -1486,7 +1486,7 @@ incomplete_format:
         if (arg == MP_OBJ_NULL) {
             if (arg_i >= n_args) {
 not_enough_args:
-                mp_raise_TypeError("not enough arguments for format string");
+                mp_raise_TypeError("format string needs more arguments");
             }
             arg = args[arg_i++];
         }
@@ -1496,14 +1496,14 @@ not_enough_args:
                     size_t slen;
                     const char *s = mp_obj_str_get_data(arg, &slen);
                     if (slen != 1) {
-                        mp_raise_TypeError("%%c requires int or char");
+                        mp_raise_TypeError("%%c needs int or char");
                     }
                     mp_print_strn(&print, s, 1, flags, ' ', width);
                 } else if (arg_looks_integer(arg)) {
                     char ch = mp_obj_get_int(arg);
                     mp_print_strn(&print, &ch, 1, flags, ' ', width);
                 } else {
-                    mp_raise_TypeError("integer required");
+                    mp_raise_TypeError("integer needed");
                 }
                 break;
 
@@ -1573,7 +1573,7 @@ not_enough_args:
     }
 
     if (arg_i != n_args) {
-        mp_raise_TypeError("not all arguments converted during string formatting");
+        mp_raise_TypeError("format string didn't convert all arguments");
     }
 
     return mp_obj_new_str_from_vstr(is_bytes ? &mp_type_bytes : &mp_type_str, &vstr);

--- a/py/objstr.c
+++ b/py/objstr.c
@@ -265,7 +265,7 @@ STATIC mp_obj_t bytes_make_new(const mp_obj_type_t *type_in, size_t n_args, size
     return mp_obj_new_str_from_vstr(&mp_type_bytes, &vstr);
 
 wrong_args:
-    mp_raise_TypeError("wrong number of arguments");
+    mp_raise_TypeError("wrong number of args");
 }
 
 // like strstr but with specified length and allows \0 bytes

--- a/py/objtype.c
+++ b/py/objtype.c
@@ -861,7 +861,7 @@ mp_obj_t mp_obj_instance_call(mp_obj_t self_in, size_t n_args, size_t n_kw, cons
             mp_raise_TypeError("object not callable");
         } else {
             nlr_raise(mp_obj_new_exception_msg_varg(&mp_type_TypeError,
-                "'%s' object is not callable", mp_obj_get_type_str(self_in)));
+                "'%s' object isn't callable", mp_obj_get_type_str(self_in)));
         }
     }
     mp_obj_instance_t *self = MP_OBJ_TO_PTR(self_in);
@@ -1088,10 +1088,10 @@ mp_obj_t mp_obj_new_type(qstr name, mp_obj_t bases_tuple, mp_obj_t locals_dict) 
         // TODO: Verify with CPy, tested on function type
         if (t->make_new == NULL) {
             if (MICROPY_ERROR_REPORTING == MICROPY_ERROR_REPORTING_TERSE) {
-                mp_raise_TypeError("type is not an acceptable base type");
+                mp_raise_TypeError("type isn't an acceptable base type");
             } else {
                 nlr_raise(mp_obj_new_exception_msg_varg(&mp_type_TypeError,
-                    "type '%q' is not an acceptable base type", t->name));
+                    "type '%q' isn't an acceptable base type", t->name));
             }
         }
         #if ENABLE_SPECIAL_ACCESSORS

--- a/py/objtype.c
+++ b/py/objtype.c
@@ -968,7 +968,7 @@ STATIC mp_obj_t type_make_new(const mp_obj_type_t *type_in, size_t n_args, size_
             return mp_obj_new_type(mp_obj_str_get_qstr(args[0]), args[1], args[2]);
 
         default:
-            mp_raise_TypeError("type takes 1 or 3 arguments");
+            mp_raise_TypeError("type takes 1 or 3 args");
     }
 }
 

--- a/py/parse.c
+++ b/py/parse.c
@@ -1145,7 +1145,7 @@ mp_parse_tree_t mp_parse(mp_lexer_t *lex, mp_parse_input_kind_t input_kind) {
                 "unexpected indent");
         } else if (lex->tok_kind == MP_TOKEN_DEDENT_MISMATCH) {
             exc = mp_obj_new_exception_msg(&mp_type_IndentationError,
-                "unindent does not match any outer indentation level");
+                "unindent doesn't match any outer indent level");
         } else {
             exc = mp_obj_new_exception_msg(&mp_type_SyntaxError,
                 "invalid syntax");

--- a/py/runtime.c
+++ b/py/runtime.c
@@ -171,7 +171,7 @@ mp_obj_t mp_load_global(qstr qst) {
                 mp_raise_msg(&mp_type_NameError, "name not defined");
             } else {
                 nlr_raise(mp_obj_new_exception_msg_varg(&mp_type_NameError,
-                    "name '%q' is not defined", qst));
+                    "name '%q' isn't defined", qst));
             }
         }
     }
@@ -581,7 +581,7 @@ unsupported_op:
     }
 
 zero_division:
-    mp_raise_msg(&mp_type_ZeroDivisionError, "division by zero");
+    mp_raise_msg(&mp_type_ZeroDivisionError, "divide by zero");
 }
 
 mp_obj_t mp_call_function_0(mp_obj_t fun) {
@@ -618,7 +618,7 @@ mp_obj_t mp_call_function_n_kw(mp_obj_t fun_in, size_t n_args, size_t n_kw, cons
         mp_raise_TypeError("object not callable");
     } else {
         nlr_raise(mp_obj_new_exception_msg_varg(&mp_type_TypeError,
-            "'%s' object is not callable", mp_obj_get_type_str(fun_in)));
+            "'%s' object isn't callable", mp_obj_get_type_str(fun_in)));
     }
 }
 
@@ -1157,7 +1157,7 @@ mp_obj_t mp_getiter(mp_obj_t o_in, mp_obj_iter_buf_t *iter_buf) {
         mp_raise_TypeError("object not iterable");
     } else {
         nlr_raise(mp_obj_new_exception_msg_varg(&mp_type_TypeError,
-            "'%s' object is not iterable", mp_obj_get_type_str(o_in)));
+            "'%s' object isn't iterable", mp_obj_get_type_str(o_in)));
     }
 }
 
@@ -1179,7 +1179,7 @@ mp_obj_t mp_iternext_allow_raise(mp_obj_t o_in) {
                 mp_raise_TypeError("object not an iterator");
             } else {
                 nlr_raise(mp_obj_new_exception_msg_varg(&mp_type_TypeError,
-                    "'%s' object is not an iterator", mp_obj_get_type_str(o_in)));
+                    "'%s' object isn't an iterator", mp_obj_get_type_str(o_in)));
             }
         }
     }
@@ -1215,7 +1215,7 @@ mp_obj_t mp_iternext(mp_obj_t o_in) {
                 mp_raise_TypeError("object not an iterator");
             } else {
                 nlr_raise(mp_obj_new_exception_msg_varg(&mp_type_TypeError,
-                    "'%s' object is not an iterator", mp_obj_get_type_str(o_in)));
+                    "'%s' object isn't an iterator", mp_obj_get_type_str(o_in)));
             }
         }
     }

--- a/py/runtime.c
+++ b/py/runtime.c
@@ -947,10 +947,10 @@ STATIC mp_obj_t checked_fun_call(mp_obj_t self_in, size_t n_args, size_t n_kw, c
         const mp_obj_type_t *arg0_type = mp_obj_get_type(args[0]);
         if (arg0_type != self->type) {
             if (MICROPY_ERROR_REPORTING != MICROPY_ERROR_REPORTING_DETAILED) {
-                mp_raise_TypeError("argument has wrong type");
+                mp_raise_TypeError("arg has wrong type");
             } else {
                 nlr_raise(mp_obj_new_exception_msg_varg(&mp_type_TypeError,
-                    "argument should be a '%q' not a '%q'", self->type->name, arg0_type->name));
+                    "arg should be a '%q' not a '%q'", self->type->name, arg0_type->name));
             }
         }
     }


### PR DESCRIPTION
I did a quick pass over the error messages in the core to see if they could be made shorter without loss of meaning.

In the first commit here I made messages use contractions consistently (eg don't instead of do not, isn't instead of is not), changed "division by zero" to "divide by zero", and reworded a few others.  The code size reduction is:
```
   bare-arm:   -36 
minimal x86:   -64 
   unix x64:   -64 
unix nanbox:   -32 
      stm32:   -56 
     cc3200:   -24 
    esp8266:   -52 
      esp32:   -48
```

In the second commit I change all occurrences of "argument" to "arg", since in some places "arg" is already used and it's much shorter.  I don't really like this change because it makes some of the error messages less readable, but I thought I'd submit it for comments anyway.  Reduction in code size for the second commit alone is:
```
   bare-arm:   -56 
minimal x86:   -64 
   unix x64:  -128 
unix nanbox:   -64 
      stm32:  -116 
     cc3200:   -72 
    esp8266:  -124 
      esp32:   -96
```

Comments welcome.