### PR TITLE
stm32/fatfs_port.c: Bugfix when MICROPY_HW_ENABLE_RTC not set

### DIFF
--- a/ports/stm32/fatfs_port.c
+++ b/ports/stm32/fatfs_port.c
@@ -28,11 +28,16 @@
 #include "lib/oofatfs/ff.h"
 #include "rtc.h"
 
-DWORD get_fattime(void) {
+MP_WEAK DWORD get_fattime(void) {
+#if MICROPY_HW_ENABLE_RTC
     rtc_init_finalise();
     RTC_TimeTypeDef time;
     RTC_DateTypeDef date;
     HAL_RTC_GetTime(&RTCHandle, &time, RTC_FORMAT_BIN);
     HAL_RTC_GetDate(&RTCHandle, &date, RTC_FORMAT_BIN);
     return ((2000 + date.Year - 1980) << 25) | ((date.Month) << 21) | ((date.Date) << 16) | ((time.Hours) << 11) | ((time.Minutes) << 5) | (time.Seconds / 2);
+#else
+    // Jan 1st, 2018 at midnight. Not sure what timezone.
+    return ((2018 - 1980) << 25) | ((1) << 21) | ((1) << 16) | ((0) << 11) | ((0) << 5) | (0 / 2);
+#endif
 }


### PR DESCRIPTION
`get_fattime()` was calling a HAL RTC function with the HW instance pointer as null because `rtc_init_start()` was never called, because MICROPY_HW_ENABLE_RTC was not set for my board.

I also marked it as a weak function, because it's easy to imagine a board that would have some other RTC chip and this is all they would need to override. Some might not like my random choice for a hard-coded date.