### PR TITLE
stm32/flashbdev.c: Bugfix: dereferencing 0x800 rather than using as literal

### DIFF
--- a/ports/stm32/boards/stm32l476xe.ld
+++ b/ports/stm32/boards/stm32l476xe.ld
@@ -25,7 +25,7 @@ _estack = ORIGIN(RAM) + LENGTH(RAM);
 
 /* RAM extents for the garbage collector */
 _ram_fs_cache_start = ORIGIN(FS_CACHE);
-_ram_fs_cache_block_size = LENGTH(FS_CACHE);
+_ram_fs_cache_end = ORIGIN(FS_CACHE) + LENGTH(FS_CACHE);
 _ram_start = ORIGIN(RAM);
 _ram_end = ORIGIN(RAM) + LENGTH(RAM);
 _heap_start = _ebss; /* heap starts just after statically allocated memory */

--- a/ports/stm32/boards/stm32l476xg.ld
+++ b/ports/stm32/boards/stm32l476xg.ld
@@ -25,7 +25,7 @@ _estack = ORIGIN(RAM) + LENGTH(RAM);
 
 /* RAM extents for the garbage collector */
 _ram_fs_cache_start = ORIGIN(FS_CACHE);
-_ram_fs_cache_block_size = LENGTH(FS_CACHE);
+_ram_fs_cache_end = ORIGIN(FS_CACHE) + LENGTH(FS_CACHE);
 _ram_start = ORIGIN(RAM);
 _ram_end = ORIGIN(RAM) + LENGTH(RAM);
 _heap_start = _ebss; /* heap starts just after statically allocated memory */

--- a/ports/stm32/boards/stm32l496xg.ld
+++ b/ports/stm32/boards/stm32l496xg.ld
@@ -25,7 +25,7 @@ _estack = ORIGIN(RAM) + LENGTH(RAM) + LENGTH(SRAM2);
 
 /* RAM extents for the garbage collector */
 _ram_fs_cache_start = ORIGIN(FS_CACHE);
-_ram_fs_cache_block_size = LENGTH(FS_CACHE);
+_ram_fs_cache_end = ORIGIN(FS_CACHE) + LENGTH(FS_CACHE);
 _ram_start = ORIGIN(RAM);
 _ram_end = ORIGIN(RAM) + LENGTH(RAM) + LENGTH(SRAM2);
 _heap_start = _ebss; /* heap starts just after statically allocated memory */

--- a/ports/stm32/flashbdev.c
+++ b/ports/stm32/flashbdev.c
@@ -95,14 +95,15 @@ STATIC byte flash_cache_mem[0x4000] __attribute__((aligned(4))); // 16k
 
 #elif defined(STM32L475xx) || defined(STM32L476xx) || defined(STM32L496xx)
 
+// The STM32L475/6 doesn't have CCRAM, so we use the 32K SRAM2 for this, although
+// actual location and size is defined by the linker script.
 extern uint8_t _flash_fs_start;
 extern uint8_t _flash_fs_end;
 extern uint32_t _ram_fs_cache_start[2048 / 4];
 extern uint32_t _ram_fs_cache_block_size;
 
-// The STM32L475/6 doesn't have CCRAM, so we use the 32K SRAM2 for this.
-#define CACHE_MEM_START_ADDR (&_ram_fs_cache_start)       // End of SRAM2 RAM segment-2k
-#define FLASH_SECTOR_SIZE_MAX (_ram_fs_cache_block_size)  // 2k max
+#define CACHE_MEM_START_ADDR (&_ram_fs_cache_start)
+#define FLASH_SECTOR_SIZE_MAX ((uint32_t)(&_ram_fs_cache_block_size))   // 2k max
 #define FLASH_MEM_SEG1_START_ADDR ((long)&_flash_fs_start)
 #define FLASH_MEM_SEG1_NUM_BLOCKS ((&_flash_fs_end - &_flash_fs_start) / 512)
 

--- a/ports/stm32/flashbdev.c
+++ b/ports/stm32/flashbdev.c
@@ -103,7 +103,7 @@ extern uint8_t _ram_fs_cache_start[0];      // size determined by linker file
 extern uint8_t _ram_fs_cache_end[0];
 
 #define CACHE_MEM_START_ADDR (&_ram_fs_cache_start)
-#define FLASH_SECTOR_SIZE_MAX (&_ram_fs_cache_end - &_ram_fs_cache_start)   // 2k max
+#define FLASH_SECTOR_SIZE_MAX (_ram_fs_cache_end - _ram_fs_cache_start)   // 2k max
 #define FLASH_MEM_SEG1_START_ADDR ((long)&_flash_fs_start)
 #define FLASH_MEM_SEG1_NUM_BLOCKS ((&_flash_fs_end - &_flash_fs_start) / 512)
 

--- a/ports/stm32/flashbdev.c
+++ b/ports/stm32/flashbdev.c
@@ -99,11 +99,11 @@ STATIC byte flash_cache_mem[0x4000] __attribute__((aligned(4))); // 16k
 // actual location and size is defined by the linker script.
 extern uint8_t _flash_fs_start;
 extern uint8_t _flash_fs_end;
-extern uint32_t _ram_fs_cache_start[2048 / 4];
-extern uint32_t _ram_fs_cache_block_size;
+extern uint8_t _ram_fs_cache_start[0];      // size determined by linker file
+extern uint8_t _ram_fs_cache_end[0];
 
 #define CACHE_MEM_START_ADDR (&_ram_fs_cache_start)
-#define FLASH_SECTOR_SIZE_MAX ((uint32_t)(&_ram_fs_cache_block_size))   // 2k max
+#define FLASH_SECTOR_SIZE_MAX (&_ram_fs_cache_end - &_ram_fs_cache_start)   // 2k max
 #define FLASH_MEM_SEG1_START_ADDR ((long)&_flash_fs_start)
 #define FLASH_MEM_SEG1_NUM_BLOCKS ((&_flash_fs_end - &_flash_fs_start) / 512)
 


### PR DESCRIPTION
On my STM32L475 board, I found the code to be dereferencing 0x800 and loading a value from there. Problem access occurs in `flash_cache_get_addr_for_write()` on line 162, which looks like a comparison with a constant.

It was trying to use a literal value (not address) defined in the linker script (`_ram_fs_cache_block_size`) which was 0x800. Will only be an issue on stm32L4 boards.

