### PR TITLE
DFU Byte alignment for L476

### DIFF
--- a/py/mkenv.mk
+++ b/py/mkenv.mk
@@ -42,7 +42,7 @@ ECHO = @echo
 CP = cp
 MKDIR = mkdir
 SED = sed
-PYTHON = python
+PYTHON = python3
 
 AS = $(CROSS_COMPILE)as
 CC = $(CROSS_COMPILE)gcc

--- a/tools/dfu.py
+++ b/tools/dfu.py
@@ -60,6 +60,10 @@ def build(file,targets,device=DEFAULT_DEVICE):
   for t,target in enumerate(targets):
     tdata = b''
     for image in target:
+      # fixing L476 8-byte align
+      pad = (8 - len(image['data']) % 8 ) % 8
+      image['data'] = image['data'] + bytes(bytearray(8)[0:pad])
+      #
       tdata += struct.pack('<2I',image['address'],len(image['data']))+image['data']
     tdata = struct.pack('<6sBI255s2I',b'Target',0,1, b'ST...',len(tdata),len(target)) + tdata
     data += tdata

--- a/tools/pydfu.py
+++ b/tools/pydfu.py
@@ -62,7 +62,9 @@ __verbose = None
 __DFU_INTERFACE = 0
 
 import inspect
-if 'length' in inspect.getargspec(usb.util.get_string).args:
+getargspec = getattr(inspect, 'getfullargspec', inspect.getargspec)
+# PyUSB 1.0.2 depreciates getargspec() with python3
+if 'length' in getargspec(usb.util.get_string).args:
     # PyUSB 1.0.0.b1 has the length argument
     def get_string(dev, index):
         return usb.util.get_string(dev, 255, index)


### PR DESCRIPTION
(1) Some time ago I experienced problems while loading the `STM32L496RG` using `dfu`. In search of a solution (see also [stm forum](https://community.st.com/thread/37026-dfu-fail-verify-8-byte-align-magic) more people had this experience using `dfu-util`. Thanks to @dhylands who provided me with a patch for `../tools/dfu.py` which is included in this PR.

(2) In `..py/mkenv.mk` the setting `PYTHON=python` enforces the use of the system wide `python 2.xx` (PEP394). I suggest to change this to `python3` instead as "we" would like to move away for python2 and it is the preferred way to call `python3` and not rely on setting a __link__ yourself or use __virtual environments__.

(3) The `pydfu.py` reports an used function as depreciated, so I changed it to use the new one.

As they are related I put them together in this PR.