### PR TITLE
nrf: Use mp_raise_ValueError instead of nlr_raise(...)

### DIFF
--- a/ports/nrf/boards/microbit/modules/microbitdisplay.c
+++ b/ports/nrf/boards/microbit/modules/microbitdisplay.c
@@ -499,10 +499,10 @@ MP_DEFINE_CONST_FUN_OBJ_1(microbit_display_clear_obj, microbit_display_clear_fun
 
 void microbit_display_set_pixel(microbit_display_obj_t *display, mp_int_t x, mp_int_t y, mp_int_t bright) {
     if (x < 0 || y < 0 || x > 4 || y > 4) {
-        nlr_raise(mp_obj_new_exception_msg(&mp_type_ValueError, "index out of bounds."));
+        mp_raise_ValueError("index out of bounds.");
     }
     if (bright < 0 || bright > MAX_BRIGHTNESS) {
-        nlr_raise(mp_obj_new_exception_msg(&mp_type_ValueError, "brightness out of bounds."));
+        mp_raise_ValueError("brightness out of bounds.");
     }
     display->image_buffer[x][y] = bright;
     display->brightnesses |= (1 << bright);
@@ -518,7 +518,7 @@ MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(microbit_display_set_pixel_obj, 4, 4, microb
 
 mp_int_t microbit_display_get_pixel(microbit_display_obj_t *display, mp_int_t x, mp_int_t y) {
     if (x < 0 || y < 0 || x > 4 || y > 4) {
-        nlr_raise(mp_obj_new_exception_msg(&mp_type_ValueError, "index out of bounds."));
+        mp_raise_ValueError("index out of bounds.");
     }
     return display->image_buffer[x][y];
 }

--- a/ports/nrf/boards/microbit/modules/microbitimage.c
+++ b/ports/nrf/boards/microbit/modules/microbitimage.c
@@ -162,8 +162,7 @@ STATIC microbit_image_obj_t *image_from_parsed_str(const char *s, mp_int_t len) 
         } else if ('c' >= '0' && c <= '9') {
             ++line_len;
         } else {
-            nlr_raise(mp_obj_new_exception_msg(&mp_type_ValueError,
-                "Unexpected character in Image definition."));
+            mp_raise_ValueError("Unexpected character in Image definition.");
         }
     }
     if (line_len) {
@@ -245,8 +244,7 @@ STATIC mp_obj_t microbit_image_make_new(const mp_obj_type_t *type_in, mp_uint_t 
                 mp_get_buffer_raise(args[2], &bufinfo, MP_BUFFER_READ);
 
                 if (w < 0 || h < 0 || (size_t)(w * h) != bufinfo.len) {
-                    nlr_raise(mp_obj_new_exception_msg(&mp_type_ValueError,
-                        "image data is incorrect size"));
+                    mp_raise_ValueError("image data is incorrect size");
                 }
                 mp_int_t i = 0;
                 for (mp_int_t y = 0; y < h; y++) {
@@ -355,13 +353,12 @@ mp_obj_t microbit_image_get_pixel(mp_obj_t self_in, mp_obj_t x_in, mp_obj_t y_in
     mp_int_t x = mp_obj_get_int(x_in);
     mp_int_t y = mp_obj_get_int(y_in);
     if (x < 0 || y < 0) {
-        nlr_raise(mp_obj_new_exception_msg(&mp_type_ValueError,
-            "index cannot be negative"));
+        mp_raise_ValueError("index cannot be negative");
     }
     if (x < imageWidth(self) && y < imageHeight(self)) {
         return MP_OBJ_NEW_SMALL_INT(imageGetPixelValue(self, x, y));
     }
-    nlr_raise(mp_obj_new_exception_msg(&mp_type_ValueError, "index too large"));
+    mp_raise_ValueError("index too large");
 }
 MP_DEFINE_CONST_FUN_OBJ_3(microbit_image_get_pixel_obj, microbit_image_get_pixel);
 
@@ -380,17 +377,16 @@ mp_obj_t microbit_image_set_pixel(mp_uint_t n_args, const mp_obj_t *args) {
     mp_int_t x = mp_obj_get_int(args[1]);
     mp_int_t y = mp_obj_get_int(args[2]);
     if (x < 0 || y < 0) {
-        nlr_raise(mp_obj_new_exception_msg(&mp_type_ValueError,
-            "index cannot be negative"));
+        mp_raise_ValueError("index cannot be negative");
     }
     mp_int_t bright = mp_obj_get_int(args[3]);
     if (bright < 0 || bright > MAX_BRIGHTNESS) 
-        nlr_raise(mp_obj_new_exception_msg(&mp_type_ValueError, "brightness out of bounds."));
+        mp_raise_ValueError("brightness out of bounds.");
     if (x < imageWidth(self) && y < imageHeight(self)) {
         greyscaleSetPixelValue(&(self->greyscale), x, y, bright);
         return mp_const_none;
     }
-    nlr_raise(mp_obj_new_exception_msg(&mp_type_ValueError, "index too large"));
+    mp_raise_ValueError("index too large");
 }
 MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(microbit_image_set_pixel_obj, 4, 4, microbit_image_set_pixel);
 
@@ -399,7 +395,7 @@ mp_obj_t microbit_image_fill(mp_obj_t self_in, mp_obj_t n_in) {
     check_mutability(self);
     mp_int_t n = mp_obj_get_int(n_in);
     if (n < 0 || n > MAX_BRIGHTNESS) {
-        nlr_raise(mp_obj_new_exception_msg(&mp_type_ValueError, "brightness out of bounds."));
+        mp_raise_ValueError("brightness out of bounds.");
     }
     greyscaleFill(&self->greyscale, n);
     return mp_const_none;
@@ -423,8 +419,7 @@ mp_obj_t microbit_image_blit(mp_uint_t n_args, const mp_obj_t *args) {
     mp_int_t w = mp_obj_get_int(args[4]);
     mp_int_t h = mp_obj_get_int(args[5]);
     if (w < 0 || h < 0) {
-        nlr_raise(mp_obj_new_exception_msg(&mp_type_ValueError,
-            "size cannot be negative"));
+        mp_raise_ValueError("size cannot be negative");
     }
     mp_int_t xdest;
     mp_int_t ydest;
@@ -616,7 +611,7 @@ microbit_image_obj_t *microbit_image_dim(microbit_image_obj_t *lhs, mp_float_t f
 microbit_image_obj_t *microbit_image_dim(microbit_image_obj_t *lhs, mp_int_t fval) {
 #endif
     if (fval < 0) 
-        nlr_raise(mp_obj_new_exception_msg(&mp_type_ValueError, "Brightness multiplier must not be negative."));
+        mp_raise_ValueError("Brightness multiplier must not be negative.");
     greyscale_t *result = greyscale_new(imageWidth(lhs), imageHeight(lhs));
     for (int x = 0; x < imageWidth(lhs); ++x) {
         for (int y = 0; y < imageWidth(lhs); ++y) {
@@ -636,7 +631,7 @@ microbit_image_obj_t *microbit_image_sum(microbit_image_obj_t *lhs, microbit_ima
     mp_int_t w = imageWidth(lhs);
     if (imageHeight(rhs) != h || imageWidth(lhs) != w) {
 // TODO: verify that image width in test above should really test (lhs != w)
-        nlr_raise(mp_obj_new_exception_msg(&mp_type_ValueError, "Images must be the same size."));
+        mp_raise_ValueError("Images must be the same size.");
     }
     greyscale_t *result = greyscale_new(w, h);
     for (int x = 0; x < w; ++x) {

--- a/ports/nrf/boards/microbit/modules/modmicrobit.c
+++ b/ports/nrf/boards/microbit/modules/modmicrobit.c
@@ -24,7 +24,6 @@
  * THE SOFTWARE.
  */
 
-#include "py/nlr.h"
 #include "py/obj.h"
 #include "py/mphal.h"
 #include "modmicrobit.h"

--- a/ports/nrf/modules/random/modrandom.c
+++ b/ports/nrf/modules/random/modrandom.c
@@ -91,7 +91,7 @@ static inline int randbelow(int n) {
 STATIC mp_obj_t mod_random_getrandbits(mp_obj_t num_in) {
     int n = mp_obj_get_int(num_in);
     if (n > 30 || n == 0) {
-        nlr_raise(mp_obj_new_exception(&mp_type_ValueError));
+        mp_raise_ValueError(NULL);
     }
     uint32_t mask = ~0;
     // Beware of C undefined behavior when shifting by >= than bit size
@@ -107,7 +107,7 @@ STATIC mp_obj_t mod_random_randrange(size_t n_args, const mp_obj_t *args) {
         if (start > 0) {
             return mp_obj_new_int(randbelow(start));
         } else {
-            nlr_raise(mp_obj_new_exception(&mp_type_ValueError));
+            mp_raise_ValueError(NULL);
         }
     } else {
         mp_int_t stop = mp_obj_get_int(args[1]);
@@ -116,7 +116,7 @@ STATIC mp_obj_t mod_random_randrange(size_t n_args, const mp_obj_t *args) {
             if (start < stop) {
                 return mp_obj_new_int(start + randbelow(stop - start));
             } else {
-                nlr_raise(mp_obj_new_exception(&mp_type_ValueError));
+                mp_raise_ValueError(NULL);
             }
         } else {
             // range(start, stop, step)
@@ -127,12 +127,12 @@ STATIC mp_obj_t mod_random_randrange(size_t n_args, const mp_obj_t *args) {
             } else if (step < 0) {
                 n = (stop - start + step + 1) / step;
             } else {
-                nlr_raise(mp_obj_new_exception(&mp_type_ValueError));
+                mp_raise_ValueError(NULL);
             }
             if (n > 0) {
                 return mp_obj_new_int(start + step * randbelow(n));
             } else {
-                nlr_raise(mp_obj_new_exception(&mp_type_ValueError));
+                mp_raise_ValueError(NULL);
             }
         }
     }
@@ -145,7 +145,7 @@ STATIC mp_obj_t mod_random_randint(mp_obj_t a_in, mp_obj_t b_in) {
     if (a <= b) {
         return mp_obj_new_int(a + randbelow(b - a + 1));
     } else {
-        nlr_raise(mp_obj_new_exception(&mp_type_ValueError));
+        mp_raise_ValueError(NULL);
     }
 }
 STATIC MP_DEFINE_CONST_FUN_OBJ_2(mod_random_randint_obj, mod_random_randint);

--- a/ports/nrf/modules/ubluepy/ubluepy_characteristic.c
+++ b/ports/nrf/modules/ubluepy/ubluepy_characteristic.c
@@ -63,8 +63,7 @@ STATIC mp_obj_t ubluepy_characteristic_make_new(const mp_obj_type_t *type, size_
         s->p_uuid = MP_OBJ_TO_PTR(uuid_obj);
         // (void)sd_characterstic_add(s);
     } else {
-        nlr_raise(mp_obj_new_exception_msg_varg(&mp_type_ValueError,
-                  "Invalid UUID parameter"));
+        mp_raise_ValueError("Invalid UUID parameter");
     }
 
     if (args[1].u_int > 0) {

--- a/ports/nrf/modules/ubluepy/ubluepy_service.c
+++ b/ports/nrf/modules/ubluepy/ubluepy_service.c
@@ -68,15 +68,13 @@ STATIC mp_obj_t ubluepy_service_make_new(const mp_obj_type_t *type, size_t n_arg
         if (type > 0 &&  type <= UBLUEPY_SERVICE_PRIMARY) {
             s->type = type;
         } else {
-            nlr_raise(mp_obj_new_exception_msg_varg(&mp_type_ValueError,
-                      "Invalid Service type"));
+            mp_raise_ValueError("Invalid Service type");
         }
 
         (void)ble_drv_service_add(s);
 
     } else {
-        nlr_raise(mp_obj_new_exception_msg_varg(&mp_type_ValueError,
-                  "Invalid UUID parameter"));
+        mp_raise_ValueError("Invalid UUID parameter");
     }
 
     // clear reference to peripheral
@@ -127,8 +125,7 @@ STATIC mp_obj_t service_get_characteristic(mp_obj_t self_in, mp_obj_t uuid) {
 
     // validate that there is an UUID object passed in as parameter
     if (!(MP_OBJ_IS_TYPE(uuid, &ubluepy_uuid_type))) {
-        nlr_raise(mp_obj_new_exception_msg_varg(&mp_type_ValueError,
-                  "Invalid UUID parameter"));
+        mp_raise_ValueError("Invalid UUID parameter");
     }
 
     mp_obj_t * chars     = NULL;

--- a/ports/nrf/modules/ubluepy/ubluepy_uuid.c
+++ b/ports/nrf/modules/ubluepy/ubluepy_uuid.c
@@ -122,8 +122,7 @@ STATIC mp_obj_t ubluepy_uuid_make_new(const mp_obj_type_t *type, size_t n_args, 
 
             ble_drv_uuid_add_vs(buffer, &s->uuid_vs_idx);
         } else {
-            nlr_raise(mp_obj_new_exception_msg_varg(&mp_type_ValueError,
-                      "Invalid UUID string length"));
+            mp_raise_ValueError("Invalid UUID string length");
         }
     } else if (MP_OBJ_IS_TYPE(uuid_obj, &ubluepy_uuid_type)) {
         // deep copy instance
@@ -132,8 +131,7 @@ STATIC mp_obj_t ubluepy_uuid_make_new(const mp_obj_type_t *type, size_t n_args, 
         s->value[0] = p_old->value[0];
         s->value[1] = p_old->value[1];
     } else {
-        nlr_raise(mp_obj_new_exception_msg_varg(&mp_type_ValueError,
-                  "Invalid UUID parameter"));
+        mp_raise_ValueError("Invalid UUID parameter");
     }
 
     return MP_OBJ_FROM_PTR(s);

--- a/ports/nrf/modules/uos/microbitfs.c
+++ b/ports/nrf/modules/uos/microbitfs.c
@@ -32,7 +32,6 @@
 #include "microbitfs.h"
 #include "drivers/flash.h"
 #include "modrandom.h"
-#include "py/nlr.h"
 #include "py/obj.h"
 #include "py/stream.h"
 #include "py/runtime.h"
@@ -390,7 +389,7 @@ STATIC mp_obj_t microbit_remove(mp_obj_t filename) {
 
 STATIC void check_file_open(file_descriptor_obj *self) {
     if (!self->open) {
-        nlr_raise(mp_obj_new_exception_msg(&mp_type_ValueError, "I/O operation on closed file"));
+        mp_raise_ValueError("I/O operation on closed file");
     }
 }
 
@@ -680,7 +679,7 @@ mp_obj_t uos_mbfs_open(size_t n_args, const mp_obj_t *args) {
     }
     return res;
 mode_error:
-    nlr_raise(mp_obj_new_exception_msg(&mp_type_ValueError, "illegal mode"));
+    mp_raise_ValueError("illegal mode");
 }
 
 STATIC mp_obj_t uos_mbfs_stat(mp_obj_t filename) {

--- a/ports/nrf/mphalport.c
+++ b/ports/nrf/mphalport.c
@@ -29,6 +29,7 @@
 #include "py/mpstate.h"
 #include "py/mphal.h"
 #include "py/mperrno.h"
+#include "py/runtime.h"
 #include "uart.h"
 #include "nrfx_errors.h"
 #include "nrfx_config.h"
@@ -42,7 +43,7 @@ const byte mp_hal_status_to_errno_table[4] = {
 };
 
 NORETURN void mp_hal_raise(HAL_StatusTypeDef status) {
-    nlr_raise(mp_obj_new_exception_arg1(&mp_type_OSError, MP_OBJ_NEW_SMALL_INT(mp_hal_status_to_errno_table[status])));
+    mp_raise_OSError(mp_hal_status_to_errno_table[status]);
 }
 
 #if !MICROPY_KBD_EXCEPTION


### PR DESCRIPTION
Saves 60 bytes on the nRF52 with SD disabled. There will be a bigger saving with SD enabled and/or on the micro:bit board.

Tested on pca10040, with and without SD. Compiled micro:bit target but did not run it (as I don't have the board).