### PR TITLE
Resolve #3967: set connected false once disconnected

### DIFF
--- a/ports/esp32/modnetwork.c
+++ b/ports/esp32/modnetwork.c
@@ -169,6 +169,7 @@ static esp_err_t event_handler(void *ctx, system_event_t *event) {
         ESP_LOGI("wifi", "STA_DISCONNECTED, reason:%d%s", disconn->reason, message);
 
         bool reconnected = false;
+        wifi_sta_connected = false;
         if (wifi_sta_connect_requested) {
             wifi_mode_t mode;
             if (esp_wifi_get_mode(&mode) == ESP_OK) {
@@ -182,10 +183,6 @@ static esp_err_t event_handler(void *ctx, system_event_t *event) {
                     }
                 }
             }
-        }
-        if (wifi_sta_connected && !reconnected) {
-            // If already connected and we fail to reconnect
-            wifi_sta_connected = false;
         }
         break;
     }


### PR DESCRIPTION
Have tested this and it appears to behave as expected, am not sure if there is historical reason why connected was never set to false, however after:
1. creating and connecting to a hotspot
2. disabling hotspot for 3-5 seconds (such that it tries to reconnect and spews logs)
3. re-enable hotspot

I can confirm the device reconnects with a proper ifconfig (which was 0.0.0.0 during the hotspot downtime). Can also confirm during step 2, that the status is connecting (1001).

@dpgeorge issue was created for discussion, however this seems to retain the auto-reconnect while providing a status() that returns STAT_CONNECTING while it is reconnecting instead of STAT_GOT_IP.

[wifi_reconnect_fix_log.log](https://github.com/micropython/micropython/files/2216783/wifi_reconnect_fix_log.log)


*logs attached*