### PR TITLE
tools/pyboard: Run exec: command as a string.

### DIFF
--- a/tools/pyboard.py
+++ b/tools/pyboard.py
@@ -152,7 +152,7 @@ class ProcessToSerial:
 
     def __init__(self, cmd):
         import subprocess
-        self.subp = subprocess.Popen(cmd.split(), bufsize=0, shell=True, preexec_fn=os.setsid,
+        self.subp = subprocess.Popen(cmd, bufsize=0, shell=True, preexec_fn=os.setsid,
             stdin=subprocess.PIPE, stdout=subprocess.PIPE)
 
         # Initially was implemented with selectors, but that adds Python3


### PR DESCRIPTION
The Python documentation recommends to pass the command as a string when using Popen(..., shell=True).
https://docs.python.org/3.5/library/subprocess.html#subprocess.Popen

> The _shell_ argument (which defaults to `False`) specifies whether to use the shell as the program to execute. If _shell_ is `True`, it is recommended to pass `args` as a string rather than as a sequence.

I noticed this problem because I tried running tests with `exec:cmd...` and I passed some arguments (which somehow didn't end up in the argv of the called process without this change).
