### PR TITLE
[ports/stm32]: Added generic MP IRQ callback and example for UART (Version II).

### DIFF
--- a/lib/utils/mpirq.c
+++ b/lib/utils/mpirq.c
@@ -1,0 +1,158 @@
+/*
+ * This file is part of the MicroPython project, http://micropython.org/
+ *
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2015 Daniel Campora
+ *               2018 Tobias Badertscher
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#include <stdio.h>
+
+#include "py/mpconfig.h"
+#include "py/obj.h"
+#include "py/runtime.h"
+#include "py/gc.h"
+#include "mpirq.h"
+
+
+/******************************************************************************
+ DECLARE PUBLIC DATA
+ ******************************************************************************/
+const mp_arg_t mp_irq_init_args[] = {
+    { MP_QSTR_handler,      MP_ARG_OBJ, {.u_obj = mp_const_none} },
+    { MP_QSTR_trigger,      MP_ARG_INT, {.u_obj = mp_const_none} },
+    { MP_QSTR_hard,         MP_ARG_BOOL,{.u_bool = false} },
+};
+/******************************************************************************
+ DECLARE PRIVATE DATA
+ ******************************************************************************/
+/******************************************************************************
+ DEFINE PUBLIC FUNCTIONS
+ ******************************************************************************/
+void mp_irq_init0 (void) {
+    // initialize the callback objects list
+    mp_obj_list_init(&MP_STATE_PORT(mp_irq_obj_list), 0);
+}
+
+mp_obj_t mp_irq_new (mp_obj_t parent, mp_obj_t handler, bool hard, const mp_irq_methods_t *methods) {
+    mp_irq_obj_t *self = mp_irq_find (parent);
+    if (self==mp_const_none) {
+        /*
+         * We only add an IRQ object to an UART but never delete it
+         * to avoid fragmentation of the heap.
+         */
+        self = m_new0(mp_irq_obj_t, 1);
+        self->base.type = &mp_irq_type;
+        self->parent = parent;
+        self->methods = (mp_irq_methods_t *)methods;
+        mp_obj_list_append(&MP_STATE_PORT(mp_irq_obj_list), self);
+    }
+    self->handler = handler;
+    self->ishard = hard;
+    return self;
+}
+
+mp_irq_obj_t *mp_irq_find (mp_obj_t parent) {
+    for (mp_uint_t i = 0; i < MP_STATE_PORT(mp_irq_obj_list).len; i++) {
+        mp_irq_obj_t *callback_obj = ((mp_irq_obj_t *)(MP_STATE_PORT(mp_irq_obj_list).items[i]));
+        if (callback_obj->parent == parent) {
+            return callback_obj;
+        }
+    }
+    return mp_const_none;
+}
+
+void mp_irq_deactivate_all (void) {
+    // deactivate all active callback objects one by one
+    for (mp_uint_t i = 0; i < MP_STATE_PORT(mp_irq_obj_list).len; i++) {
+        mp_irq_obj_t *callback_obj = ((mp_irq_obj_t *)(MP_STATE_PORT(mp_irq_obj_list).items[i]));
+        callback_obj->methods->trigger(callback_obj->parent, 0);
+    }
+}
+
+void mp_irq_handler (mp_obj_t self_in) {
+    mp_irq_obj_t *self = MP_OBJ_TO_PTR(self_in);
+    if ((self != mp_const_none) && (self->handler != mp_const_none)) {
+        if (self->ishard) {
+            // when executing code within a handler we must lock the GC to prevent
+            // any memory allocations.
+            gc_lock();
+            nlr_buf_t nlr;
+            if (nlr_push(&nlr) == 0) {
+                mp_call_function_1(self->handler, self->parent);
+                nlr_pop();
+            } else {
+                // uncaught exception; disable the callback so that it doesn't run again
+                self->methods->trigger(self->parent, 0);
+                self->handler = mp_const_none;
+                printf("Uncaught exception in IRQ callback handler\n");
+                mp_obj_print_exception(&mp_plat_print, (mp_obj_t)nlr.ret_val);
+            }
+            gc_unlock();
+        } else {
+            // Schedule call to MP function
+            mp_sched_schedule(self->handler, self->parent);
+        }
+    }
+}
+
+/******************************************************************************/
+// MicroPython bindings
+
+STATIC mp_obj_t mp_irq_flags (mp_obj_t self_in) {
+    mp_irq_obj_t *self = MP_OBJ_TO_PTR(self_in);
+    return mp_obj_new_int(self->methods->info(self->parent, IRQ_INFO_FLAGS));
+}
+STATIC MP_DEFINE_CONST_FUN_OBJ_1(mp_irq_flags_obj, mp_irq_flags);
+
+STATIC mp_obj_t mp_irq_trigger (size_t n_args, const mp_obj_t *args) {
+    mp_irq_obj_t *self = MP_OBJ_TO_PTR(args[0]);
+    mp_obj_t ret_obj = mp_obj_new_int(self->methods->info(self->parent, IRQ_INFO_TRIGGERS));
+    if (n_args == 2) {
+        // set trigger
+        self->methods->trigger(self->parent, mp_obj_get_int(args[1]));
+    }
+    return ret_obj;
+}
+STATIC MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(mp_irq_trigger_obj, 1, 2, mp_irq_trigger);
+
+STATIC mp_obj_t mp_irq_call(mp_obj_t self_in, size_t n_args, size_t n_kw, const mp_obj_t *args) {
+    mp_arg_check_num(n_args, n_kw, 0, 0, false);
+    mp_irq_handler (self_in);
+    return mp_const_none;
+}
+
+STATIC const mp_rom_map_elem_t mp_irq_locals_dict_table[] = {
+    // instance methods
+    { MP_ROM_QSTR(MP_QSTR_flags),               MP_ROM_PTR(&mp_irq_flags_obj) },
+    { MP_ROM_QSTR(MP_QSTR_trigger),             MP_ROM_PTR(&mp_irq_trigger_obj) },
+};
+
+STATIC MP_DEFINE_CONST_DICT(mp_irq_locals_dict, mp_irq_locals_dict_table);
+
+const mp_obj_type_t mp_irq_type = {
+    { &mp_type_type },
+    .name = MP_QSTR_irq,
+    .call = mp_irq_call,
+    .locals_dict = (mp_obj_t)&mp_irq_locals_dict,
+};
+

--- a/lib/utils/mpirq.h
+++ b/lib/utils/mpirq.h
@@ -1,0 +1,77 @@
+/*
+ * This file is part of the MicroPython project, http://micropython.org/
+ *
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2015 Daniel Campora
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+#ifndef MICROPY_INCLUDED_LIB_UTILS_MPIRQ_H
+#define MICROPY_INCLUDED_LIB_UTILS_MPIRQ_H
+
+/******************************************************************************
+ DEFINE CONSTANTS
+ ******************************************************************************/
+enum { IRQ_ARG_INIT_handler=0, IRQ_ARG_INIT_trigger, IRQ_ARG_INIT_hard, IRQ_ARG_INIT_NUM_ARGS };
+/******************************************************************************
+ DEFINE TYPES
+ ******************************************************************************/
+typedef mp_obj_t (*mp_irq_init_t) (size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args);
+typedef void (*mp_irq_void_method_t) (mp_obj_t self);
+typedef mp_uint_t (*mp_irq_uint_method_one_uint_para_t) (mp_obj_t self, mp_uint_t trigger);
+typedef mp_uint_t (*mp_irq_int_method_one_para_t)  (mp_obj_t self, mp_uint_t info_type);
+
+typedef enum {
+    IRQ_INFO_FLAGS,
+    IRQ_INFO_TRIGGERS,
+    IRQ_INFO_CNT
+} irq_info_t;
+
+typedef struct {
+    mp_irq_init_t init;
+    mp_irq_uint_method_one_uint_para_t trigger;
+    mp_irq_int_method_one_para_t info;
+} mp_irq_methods_t;
+
+typedef struct {
+    mp_obj_base_t base;
+    mp_obj_t parent;
+    mp_obj_t handler;
+    mp_irq_methods_t *methods;
+    bool ishard;
+} mp_irq_obj_t;
+
+/******************************************************************************
+ DECLARE EXPORTED DATA
+ ******************************************************************************/
+extern const mp_arg_t mp_irq_init_args[];
+extern const mp_obj_type_t mp_irq_type;
+
+/******************************************************************************
+ DECLARE PUBLIC FUNCTIONS
+ ******************************************************************************/
+void mp_irq_init0 (void);
+mp_obj_t mp_irq_new (mp_obj_t parent, mp_obj_t handler, bool hard, const mp_irq_methods_t *methods);
+mp_irq_obj_t *mp_irq_find (mp_obj_t parent);
+void mp_irq_deactivate_all (void);
+void mp_irq_remove (const mp_obj_t parent);
+void mp_irq_handler (mp_obj_t self_in);
+
+#endif // MICROPY_INCLUDED_LIB_UTILS_MPIRQ_H

--- a/ports/stm32/Makefile
+++ b/ports/stm32/Makefile
@@ -114,6 +114,7 @@ SRC_LIB = $(addprefix lib/,\
 	utils/pyexec.c \
 	utils/interrupt_char.c \
 	utils/sys_stdio_mphal.c \
+	utils/mpirq.c \
 	)
 
 ifeq ($(MICROPY_FLOAT_IMPL),double)

--- a/ports/stm32/main.c
+++ b/ports/stm32/main.c
@@ -33,6 +33,7 @@
 #include "py/mphal.h"
 #include "lib/mp-readline/readline.h"
 #include "lib/utils/pyexec.h"
+#include "lib/utils/mpirq.h"
 #include "lib/oofatfs/ff.h"
 #include "lwip/init.h"
 #include "extmod/vfs.h"
@@ -552,6 +553,10 @@ soft_reset:
     reset_mode = update_reset_mode(1);
     #endif
 
+    // deactivate all callbacks to avoid undefined behaviour
+    // when coming out of a soft reset
+    mp_irq_deactivate_all();
+
     // Python threading init
     #if MICROPY_PY_THREAD
     mp_thread_init();
@@ -581,7 +586,7 @@ soft_reset:
     // zeroing out memory and resetting any of the sub-systems.  Following this
     // we can run Python scripts (eg boot.py), but anything that is configurable
     // by boot.py must be set after boot.py is run.
-
+    mp_irq_init0();
     readline_init0();
     pin_init0();
     extint_init0();

--- a/ports/stm32/mpconfigport.h
+++ b/ports/stm32/mpconfigport.h
@@ -297,6 +297,9 @@ extern const struct _mp_obj_module_t mp_module_onewire;
     \
     /* list of registered NICs */ \
     mp_obj_list_t mod_network_nic_list; \
+    \
+    /* list of all interrupt handler (if they been created) */ \
+    mp_obj_list_t mp_irq_obj_list; \
 
 // type definitions for the specific machine
 


### PR DESCRIPTION
# Rework of PR #3854
This is a rework of PR #3854 (which is kept for reference) which is more in sync with the existing solution for CC3200 (thanks to Daniel Campora). For general remarks see the old PR. I think this solution is much better than my PR #3854 . All credits go to Daniel. I kept the code for the STM port in a separate subfolder (`misc`) as he does.

# Aim of PR
At several locations in the stm32/port (maybe in other ports too) there is a call from the interrupt context to a user defined micropython routine/method. As a result we have some duplicated code (see Handle_EXTI_Irq, timer_handle_irq_channel) and some ToDo (se eg. pin_irq method). Further the way in timer the callback is set-up should be unified to the way it is done elsewhere.

There are some discussions in the forum on this topic(Event/IRQ callback):
https://forum.micropython.org/viewtopic.php?f=2&t=1448
https://forum.micropython.org/viewtopic.php?f=6&t=4414
https://forum.micropython.org/viewtopic.php?f=6&t=1312
https://forum.micropython.org/viewtopic.php?f=2&t=194

Issues #1642 and the discussion in the Hardware API (https://github.com/micropython/micropython/wiki/Hardware-API) on IRQ

My proposed MP irq module tries to keep close to the API of pin.irq.

# Improvements to PR 3854
IRQs are stored in a global list (modifications in `mpconfigport.h`) which is initialized in main. In contrast to Daniels solution, I do not reallocate an IRQ if a new handler or trigger is registered on it. I allocate a `mp_irq_obj_t` and keep it in the global list forever (or till the next reboot) to avoid memory fragmentation. 

Further in contrast to Daniels solution I do not support the `priority` and the `wake` parameter on the irq function call. However I do introduce a `hard` parameter which allows to decide if the the call to a micropython function (`hard=false`) is scheduled in the C code in the IRQ or a if the call to a micropython callback is executed in the IRQ context with all its constraints (No allocation ...). Schedule a micropyton call in C only takes 2us which is much faster than schedule a call from uPy (of course...).

Further I added a `trigger()` function on irq to obtain the currently active IRQs and therefore I renamed the `flags` callback to the IRQ generating module to `info` and added a parameter to get a certain property from the IRQ-generating module. 

An IRQ has to be explicitly enabled. Adding a handler and a trigger as parameter to the irq call does not enable it. I think this allows a better control *when* you'd like to start processing IRQ.

In the uart MP module I had to add a `mp_irq_map` as enable the IRQ on L4 is distributed over several registers and on F4 it is uint32_t wide. So in my opinion this was the most obvious way. 

In my opinion it would be possible to unit the two solutions (CC3200, STM) into a single one where there is no code duplication (duplication is not good). The `mp_irq_priorities` in Daniels could be introduced by injection, we have to settle on a reallocation schema for the IRQ struct (`mp_irq_obj_t`) and if we need a separate file for error strings.

# Example usage of IDLE IRQ for UART
On STM32 the UART RX IDLE IRQ is fired if after receiving a stream of input data there is for the duration of 1 Byte no new data received (RX signal is idle). This feature can be used to answer fast to a command received from a communication partner and therefore avoid  the other side to run into a TIMEOUT.

Further (artificial) MicroPython IRQ could be added: Eg Testing the RX or TX buffer on the filling level to fire a call to the callback for Buffer nearly empty or full. This feature is not implemented however. Fire the MP callback on the HW generated TX Empty is not recommend as such high rate IRQ would stall MicroPython.

Add following class:
```
import micropython

class UART_IDLE:
    
    USE_HARD = False
    
    def __init__(self, uart):
        self._uart = uart
        self._uart.write("Hi there\n\r")
        self._buffer = bytearray(64)
        self._answer = b"Ready \r\n"
        self._normal_context_ref = self.normal_context
        
    def set_up_cb(self):
        flags = self._uart.IRQ_RX_IDLE
        if UART_IDLE.USE_HARD:
            self._uart.irq(self.irq_idle_callback, flags, UART_IDLE.USE_HARD)
        else:
            self._uart.irq(self.normal_context, self._uart.IRQ_RX_IDLE, UART_IDLE.USE_HARD)
        
    def irq_idle_callback(self, other):
        micropython.schedule(self._normal_context_ref, 0)
    
    def normal_context(self, value):
        cnt=self._uart.readinto(self._buffer)
        self._uart.write(self._answer)
        data = "".join([chr(i) if 32<=i<128 else "."  for i in self._buffer[:cnt] ])
        print("Get UART data in normal context: %s" % data)
        self._uart.write("Received: \"%s\"\r\n" % data)
```
... and use following code:
```
uart = pyb.UART(2, baudrate = 115200, timeout=1)
dut=UART_IDLE(uart)
dut.set_up_cb()
callback= uart.irq()
callback()    # call the callback
print("Trigger flag %d " % uart.irq().trigger()) # Print active set triggers
# Enable IRQ
uart.irq().enable()
```
I am looking for feedback for this improved solution.