### PR TITLE
nrf/drivers/flash: Fix incorrect page alignment check.

### DIFF
--- a/ports/nrf/drivers/flash.h
+++ b/ports/nrf/drivers/flash.h
@@ -38,7 +38,7 @@
 #error Unknown chip
 #endif
 
-#define FLASH_IS_PAGE_ALIGNED(addr) ((uint32_t)(addr) & (FLASH_PAGESIZE - 1))
+#define FLASH_IS_PAGE_ALIGNED(addr) (((uint32_t)(addr) & (FLASH_PAGESIZE - 1)) == 0)
 
 #if BLUETOOTH_SD
 


### PR DESCRIPTION
for comparison: https://github.com/bbcmicrobit/micropython/blob/master/source/microbit/persistent.c#L109

For some reason the filesystem worked anyway.