### PR TITLE
py/py.mk: Don't hardcode path to libaxtls.a.

### DIFF
--- a/ports/unix/Makefile
+++ b/ports/unix/Makefile
@@ -249,7 +249,7 @@ coverage:
 	    -DMICROPY_UNIX_COVERAGE' \
 	    LDFLAGS_EXTRA='-fprofile-arcs -ftest-coverage' \
 	    FROZEN_DIR=coverage-frzstr FROZEN_MPY_DIR=coverage-frzmpy \
-	    BUILD=build-coverage PROG=micropython_coverage
+	    BUILD=build-coverage PROG=micropython_coverage axtls all
 
 coverage_test: coverage
 	$(eval DIRNAME=ports/$(notdir $(CURDIR)))

--- a/py/py.mk
+++ b/py/py.mk
@@ -26,7 +26,7 @@ ifeq ($(MICROPY_PY_USSL),1)
 CFLAGS_MOD += -DMICROPY_PY_USSL=1
 ifeq ($(MICROPY_SSL_AXTLS),1)
 CFLAGS_MOD += -DMICROPY_SSL_AXTLS=1 -I$(TOP)/lib/axtls/ssl -I$(TOP)/lib/axtls/crypto -I$(TOP)/lib/axtls/config
-LDFLAGS_MOD += -Lbuild -laxtls
+LDFLAGS_MOD += -L$(BUILD) -laxtls
 else ifeq ($(MICROPY_SSL_MBEDTLS),1)
 # Can be overridden by ports which have "builtin" mbedTLS
 MICROPY_SSL_MBEDTLS_INCLUDE ?= $(TOP)/lib/mbedtls/include


### PR DESCRIPTION
Use -L$(BUILD), not -Lbuild. Otherwise, builds for different archs/subarchs
using different values of BUILD may fail.