### PR TITLE
mpy-cross/Makefile: Also undefine MICROPY_FORCE_32BIT and CROSS_COMPILE.

### DIFF
--- a/mpy-cross/Makefile
+++ b/mpy-cross/Makefile
@@ -5,6 +5,8 @@ ifneq ($(findstring undefine,$(.FEATURES)),)
 override undefine COPT
 override undefine CFLAGS_EXTRA
 override undefine LDFLAGS_EXTRA
+override undefine MICROPY_FORCE_32BIT
+override undefine CROSS_COMPILE
 override undefine FROZEN_DIR
 override undefine FROZEN_MPY_DIR
 override undefine BUILD


### PR DESCRIPTION
mpy-cross is a host, not target binary. It should not be build with the
target compiler, compiler options and other settings. For example,

If someone currently tries to build from pristine checkout the unix port
with the following command:

    make CROSS_COMPILE=arm-linux-gnueabihf-

then mpy-cross will be built with arm-linux-gnueabihf-gcc and of course
won't run on the host, leading to overall build failure.

This situation was worked around for some options in 1d8c3f4cff1, so add
MICROPY_FORCE_32BIT and CROSS_COMPILE to that set too.