### PR TITLE
nrf: Improve nrf52840 support

### DIFF
--- a/ports/nrf/modules/machine/modmachine.c
+++ b/ports/nrf/modules/machine/modmachine.c
@@ -82,7 +82,7 @@ void machine_init(void) {
         reset_cause = PYB_RESET_LPCOMP;
     } else if (state & POWER_RESETREAS_DIF_Msk) {
         reset_cause = PYB_RESET_DIF;
-#if NRF52
+#if defined(NRF52_SERIES)
     } else if (state & POWER_RESETREAS_NFC_Msk) {
         reset_cause = PYB_RESET_NFC;
 #endif
@@ -232,7 +232,7 @@ STATIC const mp_rom_map_elem_t machine_module_globals_table[] = {
     { MP_ROM_QSTR(MP_QSTR_PWRON_RESET),        MP_ROM_INT(PYB_RESET_POWER_ON) },
     { MP_ROM_QSTR(MP_QSTR_LPCOMP_RESET),       MP_ROM_INT(PYB_RESET_LPCOMP) },
     { MP_ROM_QSTR(MP_QSTR_DEBUG_IF_RESET),     MP_ROM_INT(PYB_RESET_DIF) },
-#if NRF52
+#if defined(NRF52_SERIES)
     { MP_ROM_QSTR(MP_QSTR_NFC_RESET),          MP_ROM_INT(PYB_RESET_NFC) },
 #endif
 };

--- a/ports/nrf/modules/machine/pwm.c
+++ b/ports/nrf/modules/machine/pwm.c
@@ -63,12 +63,13 @@ typedef struct _machine_hard_pwm_obj_t {
 } machine_hard_pwm_obj_t;
 
 STATIC const nrfx_pwm_t machine_hard_pwm_instances[] = {
-#if NRF52
+#if defined(NRF52_SERIES)
     NRFX_PWM_INSTANCE(0),
     NRFX_PWM_INSTANCE(1),
     NRFX_PWM_INSTANCE(2),
-#elif NRF52840
+#if NRF52840
     NRFX_PWM_INSTANCE(3),
+#endif
 #else
     NULL
 #endif
@@ -77,13 +78,14 @@ STATIC const nrfx_pwm_t machine_hard_pwm_instances[] = {
 STATIC machine_pwm_config_t hard_configs[MP_ARRAY_SIZE(machine_hard_pwm_instances)];
 
 STATIC const machine_hard_pwm_obj_t machine_hard_pwm_obj[] = {
-#if NRF52
+#if defined(NRF52_SERIES)
     {{&machine_hard_pwm_type}, .p_pwm = &machine_hard_pwm_instances[0], .p_config = &hard_configs[0]},
 
     {{&machine_hard_pwm_type}, .p_pwm = &machine_hard_pwm_instances[1], .p_config = &hard_configs[0]},
     {{&machine_hard_pwm_type}, .p_pwm = &machine_hard_pwm_instances[2], .p_config = &hard_configs[0]},
-#elif NRF52840
+#if NRF52840
     {{&machine_hard_pwm_type}, .p_pwm = &machine_hard_pwm_instances[3], .p_config = &hard_configs[0]},
+#endif
 #endif
 };
 

--- a/ports/nrf/modules/machine/rtcounter.c
+++ b/ports/nrf/modules/machine/rtcounter.c
@@ -58,7 +58,7 @@ typedef struct _machine_rtc_obj_t {
 STATIC const nrfx_rtc_t machine_rtc_instances[] = {
     NRFX_RTC_INSTANCE(0),
     NRFX_RTC_INSTANCE(1),
-#if NRF52
+#if defined(NRF52_SERIES)
     NRFX_RTC_INSTANCE(2),
 #endif
 };
@@ -67,14 +67,14 @@ STATIC machine_rtc_config_t configs[MP_ARRAY_SIZE(machine_rtc_instances)];
 
 STATIC void interrupt_handler0(nrfx_rtc_int_type_t int_type);
 STATIC void interrupt_handler1(nrfx_rtc_int_type_t int_type);
-#if NRF52
+#if defined(NRF52_SERIES)
 STATIC void interrupt_handler2(nrfx_rtc_int_type_t int_type);
 #endif
 
 STATIC const machine_rtc_obj_t machine_rtc_obj[] = {
     {{&machine_rtcounter_type}, .p_rtc = &machine_rtc_instances[0], .handler=interrupt_handler0, .config=&configs[0]},
     {{&machine_rtcounter_type}, .p_rtc = &machine_rtc_instances[1], .handler=interrupt_handler1, .config=&configs[1]},
-#if NRF52
+#if defined(NRF52_SERIES)
     {{&machine_rtcounter_type}, .p_rtc = &machine_rtc_instances[2], .handler=interrupt_handler2, .config=&configs[2]},
 #endif
 };
@@ -101,7 +101,7 @@ STATIC void interrupt_handler1(nrfx_rtc_int_type_t int_type) {
     interrupt_handler(1);
 }
 
-#if NRF52
+#if defined(NRF52_SERIES)
 STATIC void interrupt_handler2(nrfx_rtc_int_type_t int_type) {
     interrupt_handler(2);
 }

--- a/ports/nrf/modules/machine/timer.c
+++ b/ports/nrf/modules/machine/timer.c
@@ -45,7 +45,7 @@ STATIC mp_obj_t machine_timer_callbacks[] = {
     NULL,
     NULL,
     NULL,
-#if NRF52
+#if defined(NRF52_SERIES)
     NULL,
     NULL,
 #endif
@@ -57,7 +57,7 @@ STATIC const machine_timer_obj_t machine_timer_obj[] = {
     {{&machine_timer_type}, NRFX_TIMER_INSTANCE(1)},
 #endif
     {{&machine_timer_type}, NRFX_TIMER_INSTANCE(2)},
-#if NRF52
+#if defined(NRF52_SERIES)
     {{&machine_timer_type}, NRFX_TIMER_INSTANCE(3)},
     {{&machine_timer_type}, NRFX_TIMER_INSTANCE(4)},
 #endif


### PR DESCRIPTION
The NRF52 define only covers nrf52832, so update the define checks
to use NRF52_SERIES to cover both nrf52832 and nrf52840.

Fixed machine_hard_pwm_instances table in modules/machine/pwm.c