### PR TITLE
nrf: Do not use one past last ADC/PWM/RTCounter instance

### DIFF
--- a/ports/nrf/modules/machine/adc.c
+++ b/ports/nrf/modules/machine/adc.c
@@ -96,7 +96,7 @@ STATIC int adc_find(mp_obj_t id) {
 
     int adc_idx = adc_id;
 
-    if (adc_idx >= 0 && adc_idx <= MP_ARRAY_SIZE(machine_adc_obj)
+    if (adc_idx >= 0 && adc_idx < MP_ARRAY_SIZE(machine_adc_obj)
         && machine_adc_obj[adc_idx].id != (uint8_t)-1) {
         return adc_idx;
     }

--- a/ports/nrf/modules/machine/pwm.c
+++ b/ports/nrf/modules/machine/pwm.c
@@ -95,7 +95,7 @@ STATIC int hard_pwm_find(mp_obj_t id) {
     if (MP_OBJ_IS_INT(id)) {
         // given an integer id
         int pwm_id = mp_obj_get_int(id);
-        if (pwm_id >= 0 && pwm_id <= MP_ARRAY_SIZE(machine_hard_pwm_obj)) {
+        if (pwm_id >= 0 && pwm_id < MP_ARRAY_SIZE(machine_hard_pwm_obj)) {
             return pwm_id;
         }
         nlr_raise(mp_obj_new_exception_msg_varg(&mp_type_ValueError,

--- a/ports/nrf/modules/machine/rtcounter.c
+++ b/ports/nrf/modules/machine/rtcounter.c
@@ -113,7 +113,7 @@ void rtc_init0(void) {
 STATIC int rtc_find(mp_obj_t id) {
     // given an integer id
     int rtc_id = mp_obj_get_int(id);
-    if (rtc_id >= 0 && rtc_id <= MP_ARRAY_SIZE(machine_rtc_obj)) {
+    if (rtc_id >= 0 && rtc_id < MP_ARRAY_SIZE(machine_rtc_obj)) {
         return rtc_id;
     }
     nlr_raise(mp_obj_new_exception_msg_varg(&mp_type_ValueError,


### PR DESCRIPTION
Avoid trying to use ADC, PWM and RTCounter instances which is
one past last available, because this will give a HardFault.