### PR TITLE
nrf/nrfx_glue.h: Use standard error codes in nrfx.

### DIFF
--- a/ports/nrf/nrfx_glue.h
+++ b/ports/nrf/nrfx_glue.h
@@ -28,9 +28,31 @@
 #define NRFX_GLUE_H
 
 #include <soc/nrfx_irqs.h>
+#include "py/mperrno.h"
 
 #define NRFX_ASSERT(expression)  do { bool res = expression; (void)res; } while (0)
 #define NRFX_DELAY_US            mp_hal_delay_us
+#define NRFX_CUSTOM_ERROR_CODES  (1)
+
+typedef enum {
+    NRFX_SUCCESS                    = 0,             // Operation performed successfully.
+    NRFX_ERROR_INTERNAL             = MP_EPERM,      // Internal error.
+    NRFX_ERROR_NO_MEM               = MP_ENOMEM,     // No memory for operation.
+    NRFX_ERROR_NOT_SUPPORTED        = MP_EOPNOTSUPP, // Not supported.
+    NRFX_ERROR_INVALID_PARAM        = MP_EINVAL,     // Invalid parameter.
+    NRFX_ERROR_INVALID_STATE        = MP_EBADF,      // Invalid state, operation disallowed in this state.
+    NRFX_ERROR_INVALID_LENGTH       = MP_E2BIG,      // Invalid length.
+    NRFX_ERROR_TIMEOUT              = MP_ETIMEDOUT,  // Operation timed out.
+    NRFX_ERROR_FORBIDDEN            = MP_EACCES,     // Operation is forbidden.
+    NRFX_ERROR_NULL                 = MP_EFAULT,     // Null pointer.
+    NRFX_ERROR_INVALID_ADDR         = MP_EFAULT,     // Bad memory address.
+    NRFX_ERROR_BUSY                 = MP_EBUSY,      // Busy.
+    NRFX_ERROR_ALREADY_INITIALIZED  = MP_EMFILE,     // Module already initialized.
+
+    NRFX_ERROR_DRV_TWI_ERR_OVERRUN  = MP_ENOBUFS,      // TWI error: Overrun.
+    NRFX_ERROR_DRV_TWI_ERR_ANACK    = MP_EHOSTUNREACH, // TWI error: Address not acknowledged.
+    NRFX_ERROR_DRV_TWI_ERR_DNACK    = MP_EIO,          // TWI error: Data not acknowledged.
+} nrfx_err_t;
 
 #if BLUETOOTH_SD
 


### PR DESCRIPTION
This probably saves code size because the error numbers are much smaller (see `NRFX_ERROR_BASE_NUM` in lib/nrfx/drivers/nrfx_errors.h). Additionally, it may be possible to return nrfx errors directly in some places.

I tried to match the error codes as closely as possible but not all nrfx errors have a good POSIX errno replacement (for example NRFX_ERROR_INTERNAL and MP_E2BIG).

Code size reductions:
nrf51: -192
nrf52: -204

**EDIT**: now I realize this will break error logging in mphalport.c (see `NRFX_LOG_ENABLED`), so we may need to just set `NRFX_ERROR_BASE_NUM` to zero.