### PR TITLE
docs/library/machine.UART.rst: Specify optional txbuf and rxbuf args.

### DIFF
--- a/docs/library/machine.UART.rst
+++ b/docs/library/machine.UART.rst
@@ -56,6 +56,8 @@ Methods
 
      - *tx* specifies the TX pin to use.
      - *rx* specifies the RX pin to use.
+     - *txbuf* specifies the length in characters of the TX buffer.
+     - *rxbuf* specifies the length in characters of the RX buffer.
 
    On the WiPy only the following keyword-only parameter is supported:
 


### PR DESCRIPTION
If a port would like to expose the configuration of transmit and/or receive buffers then it can use these arguments: `txbuf` and `rxbuf`.

See #3934 for discussion.