### PR TITLE
docs/library/machine.I2C.rst: Extend writeto to support a list of bufs.

### DIFF
--- a/docs/library/machine.I2C.rst
+++ b/docs/library/machine.I2C.rst
@@ -123,10 +123,15 @@ operations that target a given slave device.
 
    The method returns ``None``.
 
-.. method:: I2C.writeto(addr, buf, stop=True)
+.. method:: I2C.writeto(addr, data, stop=True)
 
-   Write the bytes from *buf* to the slave specified by *addr*.  If a
-   NACK is received following the write of a byte from *buf* then the
+   Write the bytes from *data* to the slave specified by *addr*.
+   *data* can be an object with the buffer protocol (eg ``bytes`` or ``bytearray``),
+   or a tuple or list of objects with the buffer protocol.  In the latter case the
+   *addr* is sent once and then the bytes from each object are written out
+   sequentially.
+
+   If a NACK is received following the write of a byte from *data* then the
    remaining bytes are not sent.  If *stop* is true then a STOP condition is
    generated at the end of the transfer, even if a NACK is received.
    The function returns the number of ACKs that were received.


### PR DESCRIPTION
As it currently stands, the `machine.I2C` API cannot efficiently write out to a device data that is made up of multiple buffers.  For example if you need to send out `cmd` and `data` in one transaction then it must be done via `i2c.writeto(addr, cmd + data)`.  This is not ideal because it needs to create a temporary buffer.  If there are lots of bytes to send then that means allocating a big buffer, which should be avoided.

For further discussion about this problem see #3482, which is in the context of the ssd1306 display driver.

The proposal in this PR (which is just an update of the docs, implementation would follow later) is to extend `i2c.writeto()` to allow to pass in a list of buffers to write.  For example it would allow:
```python
i2c.writeto(addr, [cmd, data])
```
which would send the address, then cmd, then data (ie address is only sent at the start of the entire transaction).

The reasons for going for this approach are:
1. It's a backwards compatible extension.
2. It's convenient for the user.
3. It's efficient because there is only one Python call, then the C code can do everything in one go.
4. It's efficient on the I2C bus because the implementation can do everything in one go without pauses between blocks of bytes.
5. It should be possible to implement this extension in all ports, for hardware and software I2C.

Alternative approaches, like using `start`/`write`/`stop`, or splitting it into multiple `writeto` calls, don't satisfy points 2-5 above.

There could be an equivalent extension to `i2c.readfrom_into()` but I don't think it's as necessary as for `writeto`, so I didn't add it but it could be added in the future if needed.