### PR TITLE
Add len() and str() methods to NeoPixel module in ESP32 port

### DIFF
--- a/ports/esp32/modules/neopixel.py
+++ b/ports/esp32/modules/neopixel.py
@@ -25,6 +25,12 @@ class NeoPixel:
         return tuple(self.buf[offset + self.ORDER[i]]
                      for i in range(self.bpp))
 
+    def __len__(self):
+        return self.n
+
+    def __str__(self):
+        return str([self[i] for i in range(self.n)])
+
     def fill(self, color):
         for i in range(self.n):
             self[i] = color


### PR DESCRIPTION
Make programming with NeoPixels feel more like operating on an array.