### PR TITLE
Change base class of PyboardError to Exception

### DIFF
--- a/ports/esp32/modules/neopixel.py
+++ b/ports/esp32/modules/neopixel.py
@@ -25,6 +25,12 @@ class NeoPixel:
         return tuple(self.buf[offset + self.ORDER[i]]
                      for i in range(self.bpp))
 
+    def __len__(self):
+        return self.n
+
+    def __str__(self):
+        return str([self[i] for i in range(self.n)])
+
     def fill(self, color):
         for i in range(self.n):
             self[i] = color

--- a/tools/pyboard.py
+++ b/tools/pyboard.py
@@ -81,7 +81,7 @@ def stdout_write_bytes(b):
     stdout.write(b)
     stdout.flush()
 
-class PyboardError(BaseException):
+class PyboardError(Exception):
     pass
 
 class TelnetToSerial:


### PR DESCRIPTION
Currently the PyboardError-class derives from BaseException, which goes against the recommended practice. The common "except Exception as ex:" will not catch it.

From the docs: "The base class for all built-in exceptions. It is not meant to be directly inherited by user-defined classes (for that, use Exception)."
https://docs.python.org/3/library/exceptions.html