### PR TITLE
(unix): Add support for uos.urandom(n)

### DIFF
--- a/ports/unix/modos.c
+++ b/ports/unix/modos.c
@@ -47,22 +47,22 @@
 #if defined(__GLIBC__) && defined(__GLIBC_PREREQ)
 #  if __GLIBC_PREREQ(2, 25)
 #    include <sys/random.h>
-#  else
-#    define _USE_DEV_URANDOM	"/dev/urandom"
+#    define _HAVE_GETRANDOM
 #  endif 
 #endif
+
 
 STATIC mp_obj_t mod_os_urandom(mp_obj_t num) {
     mp_int_t n = mp_obj_get_int(num);
     vstr_t vstr;
     vstr_init_len(&vstr, n);
-#ifdef _USE_DEV_URANDOM
+#ifdef _HAVE_GETRANDOM
+    RAISE_ERRNO(getrandom(vstr.buf, n, 0), errno);
+#else
     int fd = open(_USE_DEV_URANDOM, O_RDONLY);
     RAISE_ERRNO(fd, errno);
     RAISE_ERRNO(read(fd, vstr.buf, n), errno);
     close(fd);
-#else
-    RAISE_ERRNO(getrandom(vstr.buf, n, 0), errno);
 #endif
     return mp_obj_new_str_from_vstr(&mp_type_bytes, &vstr);
 }

--- a/ports/unix/modos.c
+++ b/ports/unix/modos.c
@@ -62,7 +62,7 @@ STATIC mp_obj_t mod_os_urandom(mp_obj_t num) {
     RAISE_ERRNO(read(fd, vstr.buf, n), errno);
     close(fd);
 #else
-    getrandom(vstr.buf, n, 0);
+    RAISE_ERRNO(getrandom(vstr.buf, n, 0), errno);
 #endif
     return mp_obj_new_str_from_vstr(&mp_type_bytes, &vstr);
 }

--- a/ports/unix/modos.c
+++ b/ports/unix/modos.c
@@ -51,7 +51,6 @@
 #    define _USE_DEV_URANDOM	"/dev/urandom"
 #  endif 
 #endif
-#    define _USE_DEV_URANDOM	"/dev/urandom"
 
 STATIC mp_obj_t mod_os_urandom(mp_obj_t num) {
     mp_int_t n = mp_obj_get_int(num);

--- a/ports/unix/modos.c
+++ b/ports/unix/modos.c
@@ -59,7 +59,7 @@ STATIC mp_obj_t mod_os_urandom(mp_obj_t num) {
 #ifdef _HAVE_GETRANDOM
     RAISE_ERRNO(getrandom(vstr.buf, n, 0), errno);
 #else
-    int fd = open(_USE_DEV_URANDOM, O_RDONLY);
+    int fd = open("/dev/urandom", O_RDONLY);
     RAISE_ERRNO(fd, errno);
     RAISE_ERRNO(read(fd, vstr.buf, n), errno);
     close(fd);

--- a/ports/unix/modos.c
+++ b/ports/unix/modos.c
@@ -25,6 +25,7 @@
  * THE SOFTWARE.
  */
 
+#include <sys/random.h>
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <unistd.h>
@@ -42,6 +43,16 @@
 #ifdef __ANDROID__
 #define USE_STATFS 1
 #endif
+
+STATIC mp_obj_t mod_os_urandom(mp_obj_t num) {
+    mp_int_t n = mp_obj_get_int(num);
+    vstr_t vstr;
+    vstr_init_len(&vstr, n);
+    getrandom(vstr.buf, n, 0);
+    return mp_obj_new_str_from_vstr(&mp_type_bytes, &vstr);
+}
+STATIC MP_DEFINE_CONST_FUN_OBJ_1(mod_os_urandom_obj, mod_os_urandom);
+
 
 STATIC mp_obj_t mod_os_stat(mp_obj_t path_in) {
     struct stat sb;
@@ -225,6 +236,7 @@ STATIC const mp_rom_map_elem_t mp_module_os_globals_table[] = {
     { MP_ROM_QSTR(MP_QSTR___name__), MP_ROM_QSTR(MP_QSTR_uos) },
     { MP_ROM_QSTR(MP_QSTR_errno), MP_ROM_PTR(&mod_os_errno_obj) },
     { MP_ROM_QSTR(MP_QSTR_stat), MP_ROM_PTR(&mod_os_stat_obj) },
+    { MP_ROM_QSTR(MP_QSTR_urandom), MP_ROM_PTR(&mod_os_urandom_obj) },
     #if MICROPY_PY_OS_STATVFS
     { MP_ROM_QSTR(MP_QSTR_statvfs), MP_ROM_PTR(&mod_os_statvfs_obj) },
     #endif

--- a/ports/unix/modos.c
+++ b/ports/unix/modos.c
@@ -69,7 +69,6 @@ STATIC mp_obj_t mod_os_urandom(mp_obj_t num) {
 }
 STATIC MP_DEFINE_CONST_FUN_OBJ_1(mod_os_urandom_obj, mod_os_urandom);
 
-
 STATIC mp_obj_t mod_os_stat(mp_obj_t path_in) {
     struct stat sb;
     const char *path = mp_obj_str_get_str(path_in);


### PR DESCRIPTION
Use getrandom function if available, otherwise read from /dev/urandom