### PR TITLE
unix: Use a global uncaught exception handler object.

### DIFF
--- a/ports/unix/mpconfigport.h
+++ b/ports/unix/mpconfigport.h
@@ -155,6 +155,7 @@
 #define MICROPY_PY_STR_BYTES_CMP_WARN (1)
 
 extern const struct _mp_print_t mp_stderr_print;
+extern struct _mp_handle_exception_t mp_uncaught_exception;
 
 // Define to 1 to use undertested inefficient GC helper implementation
 // (if more efficient arch-specific one is not available).

--- a/ports/unix/mpexception.h
+++ b/ports/unix/mpexception.h
@@ -1,0 +1,38 @@
+/*
+ * This file is part of the Micro Python project, http://micropython.org/
+ *
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2018 Damien P. George
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+#ifndef __MICROPY_INCLUDED_MPEXCEPTION_H__
+#define __MICROPY_INCLUDED_MPEXCEPTION_H__
+
+#include "py/obj.h"
+
+typedef void (*mp_handle_exception_fun_t)(void *data, mp_obj_t ex);
+
+typedef struct _mp_handle_exception_t {
+    void *data;
+    mp_handle_exception_fun_t handle;
+} mp_handle_exception_t;
+
+#endif // __MICROPY_INCLUDED_MPEXCEPTION_H__

--- a/ports/windows/mpconfigport.h
+++ b/ports/windows/mpconfigport.h
@@ -118,6 +118,7 @@
 #define MICROPY_PY_STR_BYTES_CMP_WARN (1)
 
 extern const struct _mp_print_t mp_stderr_print;
+extern struct _mp_handle_exception_t mp_uncaught_exception;
 
 #ifdef _MSC_VER
 #define MICROPY_GCREGS_SETJMP       (1)


### PR DESCRIPTION
This allows embedders to have control over exception handling instead
of hardcoding a strategy.
The default is still to print the exception to stderr.

We're using this because priting to stderr using write() doesn't mix well with writing to standard output through the standard C++ library or with other custom logging facilities.
This is a relatively small changes which could be useful for others as well, hence the PR.