### PR TITLE
extmod/moduhashlib: Add md5 implementation, using axTLS.

### DIFF
--- a/py/mpconfig.h
+++ b/py/mpconfig.h
@@ -1172,6 +1172,10 @@ typedef double mp_float_t;
 #define MICROPY_PY_UHASHLIB (0)
 #endif
 
+#ifndef MICROPY_PY_UHASHLIB_MD5
+#define MICROPY_PY_UHASHLIB_MD5  (0)
+#endif
+
 #ifndef MICROPY_PY_UHASHLIB_SHA1
 #define MICROPY_PY_UHASHLIB_SHA1  (0)
 #endif

--- a/tests/extmod/uhashlib_md5.py
+++ b/tests/extmod/uhashlib_md5.py
@@ -1,0 +1,21 @@
+try:
+    import uhashlib as hashlib
+except ImportError:
+    try:
+        import hashlib
+    except ImportError:
+        # This is neither uPy, nor cPy, so must be uPy with
+        # uhashlib module disabled.
+        print("SKIP")
+        raise SystemExit
+
+try:
+    hashlib.md5
+except AttributeError:
+    # MD5 is only available on some ports
+    print("SKIP")
+    raise SystemExit
+
+md5 = hashlib.md5(b'hello')
+md5.update(b'world')
+print(md5.digest())


### PR DESCRIPTION
MD5 is still widely used, and may be important in some cases for networking
interoperability, e.g. HTTP Digest authentication.