### PR TITLE
nrf/ubluepy: Add support for characteristic descriptors.

### DIFF
--- a/ports/nrf/drivers/bluetooth/ble_drv.h
+++ b/ports/nrf/drivers/bluetooth/ble_drv.h
@@ -3,7 +3,7 @@
  *
  * The MIT License (MIT)
  *
- * Copyright (c) 2016 Glenn Ruben Bakke
+ * Copyright (c) 2016 - 2018 Glenn Ruben Bakke
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -64,12 +64,19 @@ typedef struct {
     uint16_t value_handle;
 } ble_drv_char_data_t;
 
+typedef struct {
+    uint16_t uuid;
+    uint8_t  uuid_type;
+    uint16_t handle;
+} ble_drv_desc_data_t;
+
 typedef void (*ble_drv_gap_evt_callback_t)(mp_obj_t self, uint16_t event_id, uint16_t conn_handle, uint16_t length, uint8_t * data);
 typedef void (*ble_drv_gatts_evt_callback_t)(mp_obj_t self, uint16_t event_id, uint16_t attr_handle, uint16_t length, uint8_t * data);
 typedef void (*ble_drv_gattc_evt_callback_t)(mp_obj_t self, uint16_t event_id, uint16_t attr_handle, uint16_t length, uint8_t * data);
 typedef void (*ble_drv_adv_evt_callback_t)(mp_obj_t self, uint16_t event_id, ble_drv_adv_data_t * data);
 typedef void (*ble_drv_disc_add_service_callback_t)(mp_obj_t self, ble_drv_service_data_t * p_service_data);
-typedef void (*ble_drv_disc_add_char_callback_t)(mp_obj_t self, ble_drv_char_data_t * p_desc_data);
+typedef void (*ble_drv_disc_add_char_callback_t)(mp_obj_t self, ble_drv_char_data_t * p_char_data);
+typedef void (*ble_drv_disc_add_desc_callback_t)(mp_obj_t self, ble_drv_desc_data_t * p_desc_data);
 typedef void (*ble_drv_gattc_char_data_callback_t)(mp_obj_t self, uint16_t length, uint8_t * p_data);
 
 uint32_t ble_drv_stack_enable(void);
@@ -122,7 +129,11 @@ bool ble_drv_discover_characteristic(mp_obj_t obj,
                                      uint16_t end_handle,
                                      ble_drv_disc_add_char_callback_t cb);
 
-void ble_drv_discover_descriptors(void);
+bool ble_drv_discover_descriptor(mp_obj_t obj,
+                                 uint16_t conn_handle,
+                                 uint16_t start_handle,
+                                 uint16_t end_handle,
+                                 ble_drv_disc_add_desc_callback_t cb);
 
 #endif // BLUETOOTH_SD
 

--- a/ports/nrf/modules/ubluepy/modubluepy.c
+++ b/ports/nrf/modules/ubluepy/modubluepy.c
@@ -3,7 +3,7 @@
  *
  * The MIT License (MIT)
  *
- * Copyright (c) 2017 Glenn Ruben Bakke
+ * Copyright (c) 2017 - 2018 Glenn Ruben Bakke
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -32,6 +32,7 @@ extern const mp_obj_type_t ubluepy_peripheral_type;
 extern const mp_obj_type_t ubluepy_service_type;
 extern const mp_obj_type_t ubluepy_uuid_type;
 extern const mp_obj_type_t ubluepy_characteristic_type;
+extern const mp_obj_type_t ubluepy_descriptor_type;
 extern const mp_obj_type_t ubluepy_delegate_type;
 extern const mp_obj_type_t ubluepy_constants_type;
 extern const mp_obj_type_t ubluepy_scanner_type;
@@ -53,6 +54,7 @@ STATIC const mp_rom_map_elem_t mp_module_ubluepy_globals_table[] = {
     { MP_ROM_QSTR(MP_QSTR_UUID),            MP_ROM_PTR(&ubluepy_uuid_type) },
     { MP_ROM_QSTR(MP_QSTR_Service),         MP_ROM_PTR(&ubluepy_service_type) },
     { MP_ROM_QSTR(MP_QSTR_Characteristic),  MP_ROM_PTR(&ubluepy_characteristic_type) },
+    { MP_ROM_QSTR(MP_QSTR_Descriptor),      MP_ROM_PTR(&ubluepy_descriptor_type) },
     { MP_ROM_QSTR(MP_QSTR_constants),       MP_ROM_PTR(&ubluepy_constants_type) },
 #if MICROPY_PY_UBLUEPY_DESCRIPTOR
     { MP_ROM_QSTR(MP_QSTR_Descriptor),      MP_ROM_PTR(&ubluepy_descriptor_type) },

--- a/ports/nrf/modules/ubluepy/modubluepy.h
+++ b/ports/nrf/modules/ubluepy/modubluepy.h
@@ -3,7 +3,7 @@
  *
  * The MIT License (MIT)
  *
- * Copyright (c) 2017 Glenn Ruben Bakke
+ * Copyright (c) 2017 - 2018 Glenn Ruben Bakke
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -76,6 +76,7 @@ p.advertise(device_name="micr", services=[s])
 extern const mp_obj_type_t ubluepy_uuid_type;
 extern const mp_obj_type_t ubluepy_service_type;
 extern const mp_obj_type_t ubluepy_characteristic_type;
+extern const mp_obj_type_t ubluepy_descriptor_type;
 extern const mp_obj_type_t ubluepy_peripheral_type;
 extern const mp_obj_type_t ubluepy_scanner_type;
 extern const mp_obj_type_t ubluepy_scan_entry_type;
@@ -145,13 +146,17 @@ typedef struct _ubluepy_characteristic_obj_t {
     uint8_t                 props;
     uint8_t                 attrs;
     ubluepy_service_obj_t * p_service;
+    mp_obj_t                desc_list;
     mp_obj_t                value_data;
 } ubluepy_characteristic_obj_t;
 
 typedef struct _ubluepy_descriptor_obj_t {
-    mp_obj_base_t           base;
-    uint16_t                handle;
-    ubluepy_uuid_obj_t    * p_uuid;
+    mp_obj_base_t                  base;
+    uint16_t                       handle;
+    ubluepy_uuid_obj_t    *        p_uuid;
+    uint16_t                       char_handle;
+    ubluepy_characteristic_obj_t * p_char;
+    mp_obj_t                       value_data;
 } ubluepy_descriptor_obj_t;
 
 typedef struct _ubluepy_delegate_obj_t {

--- a/ports/nrf/modules/ubluepy/ubluepy_characteristic.c
+++ b/ports/nrf/modules/ubluepy/ubluepy_characteristic.c
@@ -3,7 +3,7 @@
  *
  * The MIT License (MIT)
  *
- * Copyright (c) 2017 Glenn Ruben Bakke
+ * Copyright (c) 2017 - 2018 Glenn Ruben Bakke
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -176,14 +176,33 @@ STATIC mp_obj_t char_uuid(mp_obj_t self_in) {
 }
 STATIC MP_DEFINE_CONST_FUN_OBJ_1(ubluepy_characteristic_get_uuid_obj, char_uuid);
 
+/// \method getDescriptors()
+/// Return list with all descriptors registered in the Characteristic.
+///
+STATIC mp_obj_t characteristic_get_descs(mp_obj_t self_in) {
+    ubluepy_characteristic_obj_t * self = MP_OBJ_TO_PTR(self_in);
+
+    return self->desc_list;
+}
+STATIC MP_DEFINE_CONST_FUN_OBJ_1(ubluepy_characteristic_get_descs_obj, characteristic_get_descs);
+
+/// \method getHandle()
+/// Get handle of the characteristic.
+///
+STATIC mp_obj_t char_handle(mp_obj_t self_in) {
+    ubluepy_characteristic_obj_t * self = MP_OBJ_TO_PTR(self_in);
+    return MP_OBJ_NEW_SMALL_INT(self->handle);
+}
+STATIC MP_DEFINE_CONST_FUN_OBJ_1(ubluepy_characteristic_get_handle_obj, char_handle);
 
 STATIC const mp_rom_map_elem_t ubluepy_characteristic_locals_dict_table[] = {
     { MP_ROM_QSTR(MP_QSTR_read),                MP_ROM_PTR(&ubluepy_characteristic_read_obj) },
     { MP_ROM_QSTR(MP_QSTR_write),               MP_ROM_PTR(&ubluepy_characteristic_write_obj) },
+    { MP_ROM_QSTR(MP_QSTR_getDescriptors),      MP_ROM_PTR(&ubluepy_characteristic_get_descs_obj) },
+    { MP_ROM_QSTR(MP_QSTR_getHandle),           MP_ROM_PTR(&ubluepy_characteristic_get_handle_obj) },
 #if 0
     { MP_ROM_QSTR(MP_QSTR_supportsRead),        MP_ROM_PTR(&ubluepy_characteristic_supports_read_obj) },
     { MP_ROM_QSTR(MP_QSTR_propertiesToString),  MP_ROM_PTR(&ubluepy_characteristic_properties_to_str_obj) },
-    { MP_ROM_QSTR(MP_QSTR_getHandle),           MP_ROM_PTR(&ubluepy_characteristic_get_handle_obj) },
 
     // Properties
     { MP_ROM_QSTR(MP_QSTR_peripheral),          MP_ROM_PTR(&ubluepy_characteristic_get_peripheral_obj) },

--- a/ports/nrf/modules/ubluepy/ubluepy_constants.c
+++ b/ports/nrf/modules/ubluepy/ubluepy_constants.c
@@ -3,7 +3,7 @@
  *
  * The MIT License (MIT)
  *
- * Copyright (c) 2017 Glenn Ruben Bakke
+ * Copyright (c) 2017 - 2018 Glenn Ruben Bakke
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -79,6 +79,10 @@ STATIC const mp_rom_map_elem_t ubluepy_constants_locals_dict_table[] = {
     // GAP events
     { MP_ROM_QSTR(MP_QSTR_EVT_GAP_CONNECTED),       MP_ROM_INT(16) },
     { MP_ROM_QSTR(MP_QSTR_EVT_GAP_DISCONNECTED),    MP_ROM_INT(17) },
+#if MICROPY_PY_UBLUEPY_CENTRAL
+    { MP_ROM_QSTR(MP_QSTR_EVT_GATTC_HVX),           MP_ROM_INT(57) },
+    { MP_ROM_QSTR(MP_QSTR_EVT_GATTC_WRITE_CMD_TX_COMPLETE), MP_ROM_INT(60) },
+#endif
     { MP_ROM_QSTR(MP_QSTR_EVT_GATTS_WRITE),         MP_ROM_INT(80) },
     { MP_ROM_QSTR(MP_QSTR_UUID_CCCD),               MP_ROM_INT(0x2902) },
 

--- a/ports/nrf/modules/ubluepy/ubluepy_descriptor.c
+++ b/ports/nrf/modules/ubluepy/ubluepy_descriptor.c
@@ -3,7 +3,7 @@
  *
  * The MIT License (MIT)
  *
- * Copyright (c) 2017 Glenn Ruben Bakke
+ * Copyright (c) 2017 - 2018 Glenn Ruben Bakke
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -63,7 +63,75 @@ STATIC mp_obj_t ubluepy_descriptor_make_new(const mp_obj_type_t *type, size_t n_
     return MP_OBJ_FROM_PTR(s);
 }
 
+void desc_data_callback(mp_obj_t self_in, uint16_t length, uint8_t * p_data) {
+    ubluepy_descriptor_obj_t * self = MP_OBJ_TO_PTR(self_in);
+    self->value_data = mp_obj_new_bytearray(length, p_data);
+}
+
+/// \method read()
+/// Read Descriptor value.
+///
+STATIC mp_obj_t desc_read(mp_obj_t self_in) {
+    ubluepy_descriptor_obj_t * self = MP_OBJ_TO_PTR(self_in);
+
+#if MICROPY_PY_UBLUEPY_CENTRAL
+    ble_drv_attr_c_read(self->p_char->p_service->p_periph->conn_handle,
+                        self->handle,
+                        self_in,
+                        desc_data_callback);
+
+    return self->value_data;
+#else
+    (void)self;
+    return mp_const_none;
+#endif
+}
+STATIC MP_DEFINE_CONST_FUN_OBJ_1(ubluepy_descriptor_read_obj, desc_read);
+
+/// \method write(data)
+/// Write Descriptor value.
+///
+STATIC mp_obj_t desc_write(mp_obj_t self_in, mp_obj_t data) {
+#if MICROPY_PY_UBLUEPY_CENTRAL
+    ubluepy_descriptor_obj_t *self = MP_OBJ_TO_PTR(self_in);
+
+    mp_buffer_info_t bufinfo;
+    mp_get_buffer_raise(data, &bufinfo, MP_BUFFER_READ);
+
+    ble_drv_attr_c_write(self->p_char->p_service->p_periph->conn_handle,
+                         self->handle,
+                         bufinfo.len,
+                         bufinfo.buf,
+                         false);
+#endif
+
+    return mp_const_none;
+}
+STATIC MP_DEFINE_CONST_FUN_OBJ_2(ubluepy_descriptor_write_obj, desc_write);
+
+/// \method uuid()
+/// Get UUID instance of the descriptor.
+///
+STATIC mp_obj_t desc_uuid(mp_obj_t self_in) {
+    ubluepy_descriptor_obj_t * self = MP_OBJ_TO_PTR(self_in);
+    return MP_OBJ_FROM_PTR(self->p_uuid);
+}
+STATIC MP_DEFINE_CONST_FUN_OBJ_1(ubluepy_descriptor_get_uuid_obj, desc_uuid);
+
+/// \method getHandle()
+/// Get handle of the characteristic.
+///
+STATIC mp_obj_t desc_handle(mp_obj_t self_in) {
+    ubluepy_descriptor_obj_t * self = MP_OBJ_TO_PTR(self_in);
+    return MP_OBJ_NEW_SMALL_INT(self->handle);
+}
+STATIC MP_DEFINE_CONST_FUN_OBJ_1(ubluepy_descriptor_get_handle_obj, desc_handle);
+
 STATIC const mp_rom_map_elem_t ubluepy_descriptor_locals_dict_table[] = {
+    { MP_ROM_QSTR(MP_QSTR_read),                MP_ROM_PTR(&ubluepy_descriptor_read_obj) },
+    { MP_ROM_QSTR(MP_QSTR_write),               MP_ROM_PTR(&ubluepy_descriptor_write_obj) },
+    { MP_ROM_QSTR(MP_QSTR_uuid),                MP_ROM_PTR(&ubluepy_descriptor_get_uuid_obj) },
+    { MP_ROM_QSTR(MP_QSTR_getHandle),           MP_ROM_PTR(&ubluepy_descriptor_get_handle_obj) },
 #if 0
     { MP_ROM_QSTR(MP_QSTR_binVal), MP_ROM_PTR(&ubluepy_descriptor_bin_val_obj) },
 #endif

--- a/ports/nrf/modules/ubluepy/ubluepy_service.c
+++ b/ports/nrf/modules/ubluepy/ubluepy_service.c
@@ -3,7 +3,7 @@
  *
  * The MIT License (MIT)
  *
- * Copyright (c) 2017 Glenn Ruben Bakke
+ * Copyright (c) 2017 - 2018 Glenn Ruben Bakke
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -99,6 +99,8 @@ STATIC mp_obj_t service_add_characteristic(mp_obj_t self_in, mp_obj_t characteri
         p_char->p_service = self;
     }
 
+    p_char->desc_list = mp_obj_new_list(0, NULL);
+
     mp_obj_list_append(self->char_list, characteristic);
 
     // return mp_obj_new_bool(retval);
@@ -157,6 +159,16 @@ STATIC mp_obj_t service_uuid(mp_obj_t self_in) {
 }
 STATIC MP_DEFINE_CONST_FUN_OBJ_1(ubluepy_service_get_uuid_obj, service_uuid);
 
+/// \method getHandle()
+/// Get handle of the service.
+///
+STATIC mp_obj_t service_handle(mp_obj_t self_in) {
+    ubluepy_service_obj_t * self = MP_OBJ_TO_PTR(self_in);
+    return MP_OBJ_NEW_SMALL_INT(self->handle);
+}
+STATIC MP_DEFINE_CONST_FUN_OBJ_1(ubluepy_service_get_handle_obj, service_handle);
+
+
 STATIC const mp_rom_map_elem_t ubluepy_service_locals_dict_table[] = {
     { MP_ROM_QSTR(MP_QSTR_getCharacteristic),  MP_ROM_PTR(&ubluepy_service_get_char_obj) },
     { MP_ROM_QSTR(MP_QSTR_addCharacteristic),  MP_ROM_PTR(&ubluepy_service_add_char_obj) },
@@ -166,6 +178,7 @@ STATIC const mp_rom_map_elem_t ubluepy_service_locals_dict_table[] = {
     { MP_ROM_QSTR(MP_QSTR_peripheral), MP_ROM_PTR(&ubluepy_service_get_peripheral_obj) },
 #endif
     { MP_ROM_QSTR(MP_QSTR_uuid),       MP_ROM_PTR(&ubluepy_service_get_uuid_obj) },
+    { MP_ROM_QSTR(MP_QSTR_getHandle),  MP_ROM_PTR(&ubluepy_service_get_handle_obj) },
     { MP_ROM_QSTR(MP_QSTR_PRIMARY),    MP_ROM_INT(UBLUEPY_SERVICE_PRIMARY) },
     { MP_ROM_QSTR(MP_QSTR_SECONDARY),  MP_ROM_INT(UBLUEPY_SERVICE_SECONDARY) },
 };


### PR DESCRIPTION
This patch adds support for enabling notifications from
remote peripheral in case of Central GATT client.

Added implementation of Characteristic Descriptor objects which
are populated during service discovery (Central GATT client).
For GATT server (most likely Peripheral) the list is kept empty
for now. The list returned can be used to locate the for example
the CCCD descriptor and enabling the notifications by writing
[0x01, 0x00] to it.

Added method for retrieving the handle value of the Service,
Characteristic and Descriptor in case a python application wants
to match on handle value (typically in the python registered event
handler) where characteristic handle is passed instead of connection
handle.

In case of Central, the notification and indication events will be
propagated to the gattc handler registered in the ubluepy_peripheral.c.
Indications will be auto-replied on the return of event handler call.