### PR TITLE
py/obj: Add support for __int__ special method.

### DIFF
--- a/py/obj.c
+++ b/py/obj.c
@@ -235,12 +235,8 @@ mp_int_t mp_obj_get_int(mp_const_obj_t arg) {
     } else if (MP_OBJ_IS_TYPE(arg, &mp_type_int)) {
         return mp_obj_int_get_checked(arg);
     } else {
-        if (MICROPY_ERROR_REPORTING == MICROPY_ERROR_REPORTING_TERSE) {
-            mp_raise_TypeError("can't convert to int");
-        } else {
-            nlr_raise(mp_obj_new_exception_msg_varg(&mp_type_TypeError,
-                "can't convert %s to int", mp_obj_get_type_str(arg)));
-        }
+        mp_obj_t res = mp_unary_op(MP_UNARY_OP_INT, (mp_obj_t)arg);
+        return mp_obj_int_get_checked(res);
     }
 }
 

--- a/py/objint.c
+++ b/py/objint.c
@@ -62,8 +62,7 @@ STATIC mp_obj_t mp_obj_int_make_new(const mp_obj_type_t *type_in, size_t n_args,
                 return mp_obj_new_int_from_float(mp_obj_float_get(args[0]));
 #endif
             } else {
-                // try to convert to small int (eg from bool)
-                return MP_OBJ_NEW_SMALL_INT(mp_obj_get_int(args[0]));
+                return mp_unary_op(MP_UNARY_OP_INT, args[0]);
             }
 
         case 2:

--- a/py/runtime.c
+++ b/py/runtime.c
@@ -228,6 +228,7 @@ mp_obj_t mp_unary_op(mp_unary_op_t op, mp_obj_t arg) {
             case MP_UNARY_OP_HASH:
                 return arg;
             case MP_UNARY_OP_POSITIVE:
+            case MP_UNARY_OP_INT:
                 return arg;
             case MP_UNARY_OP_NEGATIVE:
                 // check for overflow
@@ -268,9 +269,17 @@ mp_obj_t mp_unary_op(mp_unary_op_t op, mp_obj_t arg) {
         if (MICROPY_ERROR_REPORTING == MICROPY_ERROR_REPORTING_TERSE) {
             mp_raise_TypeError("unsupported type for operator");
         } else {
-            nlr_raise(mp_obj_new_exception_msg_varg(&mp_type_TypeError,
-                "unsupported type for %q: '%s'",
-                mp_unary_op_method_name[op], mp_obj_get_type_str(arg)));
+            // mp_unary_op() becomes a fallback for mp_obj_get_int() in this
+            // case. Provide a more focused error message to not confuse
+            // novices e.g. on chr(1.0)
+            if (op == MP_UNARY_OP_INT) {
+                nlr_raise(mp_obj_new_exception_msg_varg(&mp_type_TypeError,
+                    "can't convert %s to int", mp_obj_get_type_str(arg)));
+            } else {
+                nlr_raise(mp_obj_new_exception_msg_varg(&mp_type_TypeError,
+                    "unsupported type for %q: '%s'",
+                    mp_unary_op_method_name[op], mp_obj_get_type_str(arg)));
+            }
         }
     }
 }

--- a/py/runtime0.h
+++ b/py/runtime0.h
@@ -61,6 +61,7 @@ typedef enum {
     MP_UNARY_OP_LEN, // __len__
     MP_UNARY_OP_HASH, // __hash__; must return a small int
     MP_UNARY_OP_ABS, // __abs__
+    MP_UNARY_OP_INT, // __int__
     MP_UNARY_OP_SIZEOF, // for sys.getsizeof()
 
     MP_UNARY_OP_NUM_RUNTIME,

--- a/tests/basics/special_methods.py
+++ b/tests/basics/special_methods.py
@@ -93,6 +93,9 @@ class Cud():
         print("__isub__ called")
         return self
 
+    def __int__(self):
+        return 42
+
 cud1 = Cud()
 cud2 = Cud()
 
@@ -104,5 +107,16 @@ cud1 >= cud2
 cud1 > cud2
 cud1 + cud2
 cud1 - cud2
+print(int(cud1))
+
+class BadInt:
+    def __int__(self):
+        print("__int__ called")
+        return None
+
+try:
+    int(BadInt())
+except TypeError:
+    print("TypeError")
 
 # more in special_methods2.py


### PR DESCRIPTION
Depends on existing MICROPY_PY_ALL_SPECIAL_METHODS.