### PR TITLE
ports/minimal/Makefile: Compile file 'frozentest.py' before build to …

### DIFF
--- a/ports/minimal/Makefile
+++ b/ports/minimal/Makefile
@@ -56,6 +56,11 @@ else
 all: $(BUILD)/firmware.elf
 endif
 
+# Update frozentest.mpy
+frozentest.mpy:frozentest.py
+	$(ECHO) "Compile frozentest.py"
+	$(TOP)/mpy-cross/mpy-cross frozentest.py
+
 $(BUILD)/_frozen_mpy.c: frozentest.mpy $(BUILD)/genhdr/qstrdefs.generated.h
 	$(ECHO) "MISC freezing bytecode"
 	$(Q)$(TOP)/tools/mpy-tool.py -f -q $(BUILD)/genhdr/qstrdefs.preprocessed.h -mlongint-impl=none $< > $@


### PR DESCRIPTION
 Compile file 'frozentest.py' before build to keep  'frozentestfile.mpy' and 'frozentestfile.py' in sync
