### PR TITLE
py/objarray: bytearray: Allow 2nd/3rd arg to constructor.

### DIFF
--- a/py/objarray.c
+++ b/py/objarray.c
@@ -175,7 +175,8 @@ STATIC mp_obj_t array_make_new(const mp_obj_type_t *type_in, size_t n_args, size
 #if MICROPY_PY_BUILTINS_BYTEARRAY
 STATIC mp_obj_t bytearray_make_new(const mp_obj_type_t *type_in, size_t n_args, size_t n_kw, const mp_obj_t *args) {
     (void)type_in;
-    mp_arg_check_num(n_args, n_kw, 0, 1, false);
+    // Can take 2nd/3rd arg if constructs from str
+    mp_arg_check_num(n_args, n_kw, 0, 3, false);
 
     if (n_args == 0) {
         // no args: construct an empty bytearray

--- a/tests/basics/bytearray_construct.py
+++ b/tests/basics/bytearray_construct.py
@@ -1,6 +1,7 @@
 # test construction of bytearray from different objects
 
-# bytes, tuple, list
 print(bytearray(b'123'))
+print(bytearray('1234', 'utf-8'))
+print(bytearray('12345', 'utf-8', 'strict'))
 print(bytearray((1, 2)))
 print(bytearray([1, 2]))


### PR DESCRIPTION
If bytearray is constructed from str, a second argument of encoding is
required (in CPython), and third arg of Unicode error handling is allowed,
e.g.:

bytearray("str", "utf-8", "strict")

This is similar to bytes:

bytes("str", "utf-8", "strict")

This patch just allows to pass 2nd/3rd arguments to bytearray, but
doesn't try to validate them to not impact code size. (This is also
similar to how bytes constructor is handled, though it does a bit
more validation, e.g. check that in case of str arg, encoding argument
is passed.)