### PR TITLE
stm32: Add basic support for STM32F765xx

### DIFF
--- a/ports/stm32/Makefile
+++ b/ports/stm32/Makefile
@@ -57,7 +57,7 @@ INC += -I$(USBDEV_DIR)/core/inc -I$(USBDEV_DIR)/class/inc
 CFLAGS_CORTEX_M = -mthumb
 
 # Select hardware floating-point support
-ifeq ($(CMSIS_MCU),$(filter $(CMSIS_MCU),STM32F767xx STM32F769xx STM32H743xx))
+ifeq ($(CMSIS_MCU),$(filter $(CMSIS_MCU),STM32F767xx STM32F765xx STM32F769xx STM32H743xx))
 CFLAGS_CORTEX_M += -mfpu=fpv5-d16 -mfloat-abi=hard
 else
 ifeq ($(MCU_SERIES),f0)

--- a/ports/stm32/adc.c
+++ b/ports/stm32/adc.c
@@ -124,7 +124,8 @@
       defined(STM32F722xx) || defined(STM32F723xx) || \
       defined(STM32F732xx) || defined(STM32F733xx) || \
       defined(STM32F746xx) || defined(STM32F767xx) || \
-      defined(STM32F769xx) || defined(STM32F446xx)
+      defined(STM32F769xx) || defined(STM32F446xx) || \
+      defined(STM32F765xx)
 #define VBAT_DIV (4)
 #elif defined(STM32H743xx)
 #define VBAT_DIV (4)

--- a/ports/stm32/flashbdev.c
+++ b/ports/stm32/flashbdev.c
@@ -76,7 +76,7 @@ STATIC byte flash_cache_mem[0x4000] __attribute__((aligned(4))); // 16k
 #define FLASH_MEM_SEG2_START_ADDR (0x08140000) // sector 18
 #define FLASH_MEM_SEG2_NUM_BLOCKS (128) // sector 18: 64k(of 128k)
 
-#elif defined(STM32F746xx) || defined(STM32F767xx) || defined(STM32F769xx)
+#elif defined(STM32F746xx) || defined(STM32F765xx) || defined(STM32F767xx) || defined(STM32F769xx)
 
 // The STM32F746 doesn't really have CCRAM, so we use the 64K DTCM for this.
 

--- a/ports/stm32/mboot/main.c
+++ b/ports/stm32/mboot/main.c
@@ -354,7 +354,8 @@ static const flash_layout_t flash_layout[] = {
     #endif
 };
 
-#elif defined(STM32F767xx)
+#elif defined(STM32F767xx) \
+    || defined(STM32F765xx)
 
 #define FLASH_LAYOUT_STR "@Internal Flash  /0x08000000/04*032Kg,01*128Kg,07*256Kg" MBOOT_SPIFLASH_LAYOUT MBOOT_SPIFLASH2_LAYOUT
 

--- a/ports/stm32/pyb_i2c.c
+++ b/ports/stm32/pyb_i2c.c
@@ -149,7 +149,8 @@ const pyb_i2c_obj_t pyb_i2c_obj[] = {
 
 #elif defined(STM32F722xx) || defined(STM32F723xx) \
     || defined(STM32F732xx) || defined(STM32F733xx) \
-    || defined(STM32F767xx) || defined(STM32F769xx)
+    || defined(STM32F767xx) || defined(STM32F769xx) \
+    || defined(STM32F765xx)
 
 // These timing values are for f_I2CCLK=54MHz and are only approximate
 #define MICROPY_HW_I2C_BAUDRATE_TIMING { \


### PR DESCRIPTION
This part is functionally similar to STM32F767xx (they share a datasheet) so support is generally comparable.