### PR TITLE
Enable available RTC XTAL for the RTC to work

### DIFF
--- a/ports/stm32/boards/STM32L476DISC/mpconfigboard.h
+++ b/ports/stm32/boards/STM32L476DISC/mpconfigboard.h
@@ -36,6 +36,9 @@ extern struct _spi_bdev_t spi_bdev;
 #define MICROPY_HW_CLK_PLLR (RCC_PLLR_DIV2)
 #define MICROPY_HW_CLK_PLLQ (RCC_PLLQ_DIV2)
 
+// The board has an external 32kHz crystal
+#define MICROPY_HW_RTC_USE_LSE      (1)
+
 #define MICROPY_HW_FLASH_LATENCY    FLASH_LATENCY_4
 
 // USART config


### PR DESCRIPTION
The RTC on the L476 DISCO is not starting unless the external LSE is enabled. Quick verify: second rtc.datetime() will show changed values...

import pyb
rtc=pyb.RTC()
rtc.datetime()
rtc.init()
rtc.datetime()
