### PR TITLE
unix/modos: Include extmod/vfs.h for MP_S_IFDIR, etc.

### DIFF
--- a/ports/unix/modos.c
+++ b/ports/unix/modos.c
@@ -37,6 +37,7 @@
 #include "py/runtime.h"
 #include "py/objtuple.h"
 #include "py/mphal.h"
+#include "extmod/vfs.h"
 #include "extmod/misc.h"
 
 #ifdef __ANDROID__


### PR DESCRIPTION
If DTTOIF() macro is not defined, the code refers to MP_S_IFDIR, etc.
symbols defined in extmod/vfs.h, so should include it.

This fixes build for Android.