### PR TITLE
esp32: Fix int overflow in machine.sleep/deepsleep functions.

### DIFF
--- a/ports/esp32/modmachine.c
+++ b/ports/esp32/modmachine.c
@@ -89,7 +89,7 @@ STATIC mp_obj_t machine_sleep_helper(wake_type_t wake_type, size_t n_args, const
     mp_int_t expiry = args[ARG_sleep_ms].u_int;
 
     if (expiry != 0) {
-        esp_sleep_enable_timer_wakeup(expiry * 1000);
+        esp_sleep_enable_timer_wakeup(((uint64_t)expiry) * 1000);
     }
 
     if (machine_rtc_config.ext0_pin != -1 && (machine_rtc_config.ext0_wake_types & wake_type)) {


### PR DESCRIPTION
Currently, `machine.deepsleep()` function in esp32 port wakes up device immediately if the value of `sleep_ms` argument to the function exceed some value. 

Thus, if I call `machine.deepsleep(10000)`, esp32 device sleeps 10 seconds and then wakes up.
However, if I call `machine.deepsleep(7200000)`, the device wakes up immediately instead of sleeping for 2 hours (2 * 3600 * 1000 ms).

The issue is introduced by operation which converts sleep interval in ms to microseconds, resulting to int overflow in some conditions.

This Pull Request adds type casting to the operation, and as result fixes the issue.