### PR TITLE
examples/embedding: Fix reference to freed memory

### DIFF
--- a/examples/embedding/hello-embed.c
+++ b/examples/embedding/hello-embed.c
@@ -38,9 +38,10 @@ static char heap[16384];
 mp_obj_t execute_from_str(const char *str) {
     nlr_buf_t nlr;
     if (nlr_push(&nlr) == 0) {
-        mp_lexer_t *lex = mp_lexer_new_from_str_len(0/*MP_QSTR_*/, str, strlen(str), false);
+        qstr src_name = 0/*MP_QSTR_*/;
+        mp_lexer_t *lex = mp_lexer_new_from_str_len(src_name, str, strlen(str), false);
         mp_parse_tree_t pt = mp_parse(lex, MP_PARSE_FILE_INPUT);
-        mp_obj_t module_fun = mp_compile(&pt, lex->source_name, MP_EMIT_OPT_NONE, false);
+        mp_obj_t module_fun = mp_compile(&pt, src_name, MP_EMIT_OPT_NONE, false);
         mp_call_function_0(module_fun);
         nlr_pop();
         return 0;


### PR DESCRIPTION
This issue in one of the examples was brought up by
BramPeters in the forum:
https://forum.micropython.org/viewtopic.php?p=30066