### PR TITLE
Fix compilation on Windows host

### DIFF
--- a/mpy-cross/Makefile
+++ b/mpy-cross/Makefile
@@ -52,10 +52,10 @@ endif
 ifeq ($(UNAME_S),Darwin)
 CC = clang
 # Use clang syntax for map file
-LDFLAGS_ARCH = -Wl,-map,$@.map -Wl,-dead_strip
+LDFLAGS_ARCH = -Wl,-map,$(addsuffix .map,$(basename $@)) -Wl,-dead_strip
 else
 # Use gcc syntax for map file
-LDFLAGS_ARCH = -Wl,-Map=$@.map,--cref -Wl,--gc-sections
+LDFLAGS_ARCH = -Wl,-Map=$(addsuffix .map,$(basename $@)),--cref -Wl,--gc-sections
 endif
 LDFLAGS = $(LDFLAGS_MOD) $(LDFLAGS_ARCH) -lm $(LDFLAGS_EXTRA)
 

--- a/mpy-cross/Makefile
+++ b/mpy-cross/Makefile
@@ -68,6 +68,7 @@ SRC_C = \
 COMPILER_TARGET := $(shell $(CC) -dumpmachine)
 ifneq (,$(findstring mingw,$(COMPILER_TARGET)))
 	SRC_C += ports/windows/fmode.c
+	PROG := $(PROG).exe
 endif
 
 OBJ = $(PY_CORE_O)

--- a/ports/stm32/Makefile
+++ b/ports/stm32/Makefile
@@ -521,7 +521,8 @@ $(BUILD)/firmware.hex: $(BUILD)/firmware.elf
 
 $(BUILD)/firmware.elf: $(OBJ)
 	$(ECHO) "LINK $@"
-	$(Q)$(LD) $(LDFLAGS) -o $@ $^ $(LIBS)
+	$(Q)$(file > lnkcmd.log,$^ $(LIBS))
+	$(Q)$(LD) $(LDFLAGS) -o $@ @lnkcmd.log
 	$(Q)$(SIZE) $@
 
 PLLVALUES = boards/pllvalues.py

--- a/ports/stm32/Makefile
+++ b/ports/stm32/Makefile
@@ -521,8 +521,8 @@ $(BUILD)/firmware.hex: $(BUILD)/firmware.elf
 
 $(BUILD)/firmware.elf: $(OBJ)
 	$(ECHO) "LINK $@"
-	$(Q)$(file > lnkcmd.log,$^ $(LIBS))
-	$(Q)$(LD) $(LDFLAGS) -o $@ @lnkcmd.log
+	$(Q)$(file > $(BUILD)/lnkcmd.log,$^ $(LIBS))
+	$(Q)$(LD) $(LDFLAGS) -o $@ @$(BUILD)/lnkcmd.log
 	$(Q)$(SIZE) $@
 
 PLLVALUES = boards/pllvalues.py

--- a/ports/stm32/Makefile
+++ b/ports/stm32/Makefile
@@ -90,7 +90,7 @@ CFLAGS += -fsingle-precision-constant -Wdouble-promotion
 endif
 
 LDFLAGS = -nostdlib -L $(LD_DIR) $(addprefix -T,$(LD_FILES)) -Map=$(@:.elf=.map) --cref
-LIBS = $(shell $(CC) $(CFLAGS) -print-libgcc-file-name)
+LIBS = "$(shell $(CC) $(CFLAGS) -print-libgcc-file-name)"
 
 # Remove uncalled code from the final image.
 CFLAGS += -fdata-sections -ffunction-sections

--- a/ports/stm32/Makefile
+++ b/ports/stm32/Makefile
@@ -519,11 +519,23 @@ $(BUILD)/firmware.hex: $(BUILD)/firmware.elf
 	$(ECHO) "GEN $@"
 	$(Q)$(OBJCOPY) -O ihex $< $@
 
+# Work-around command line limitations on Windows host
+ifeq ($(OS),Windows_NT)
+
 $(BUILD)/firmware.elf: $(OBJ)
 	$(ECHO) "LINK $@"
 	$(Q)$(file > $(BUILD)/lnkcmd.log,$^ $(LIBS))
 	$(Q)$(LD) $(LDFLAGS) -o $@ @$(BUILD)/lnkcmd.log
 	$(Q)$(SIZE) $@
+
+else
+
+$(BUILD)/firmware.elf: $(OBJ)
+	$(ECHO) "LINK $@"
+	$(Q)$(LD) $(LDFLAGS) -o $@ $^ $(LIBS)
+	$(Q)$(SIZE) $@
+
+endif
 
 PLLVALUES = boards/pllvalues.py
 MAKE_PINS = boards/make-pins.py


### PR DESCRIPTION
The native target "mpy-cross" is missing the ".exe" filename extension on Windows.
Building the default STM32 port fails with a truncated command line during the link phase, due to the long list of object files in the stm32lib.
The proposed fix writes the linker input files to a response file. An alternative might be using a static library archive.

Tools used for Windows build:
* TDM-GCC (5.1.0 - MINGW64)
* GNU Arm Embedded Toolchain (7-2018-q2-update - 32bit)
* Git for Windows (2.1.7 - MINGW64)