### PR TITLE
unix/modjni: Update .getiter signature to include mp_obj_iter_buf_t* .

### DIFF
--- a/ports/unix/modjni.c
+++ b/ports/unix/modjni.c
@@ -316,9 +316,9 @@ MP_DEFINE_CONST_FUN_OBJ_2(subscr_load_adaptor_obj, subscr_load_adaptor);
 
 // .getiter special method which returns iterator which works in terms
 // of object subscription.
-STATIC mp_obj_t subscr_getiter(mp_obj_t self_in) {
+STATIC mp_obj_t subscr_getiter(mp_obj_t self_in, mp_obj_iter_buf_t *iter_buf) {
     mp_obj_t dest[2] = {(mp_obj_t)&subscr_load_adaptor_obj, self_in};
-    return mp_obj_new_getitem_iter(dest);
+    return mp_obj_new_getitem_iter(dest, iter_buf);
 }
 
 STATIC const mp_obj_type_t jobject_type = {


### PR DESCRIPTION
And thus be buildable again.