### PR TITLE
drivers/sdcard/sdtest.py Fix unmount bug caused by regression in pyb module

### DIFF
--- a/drivers/sdcard/sdtest.py
+++ b/drivers/sdcard/sdtest.py
@@ -1,10 +1,13 @@
 # Test for sdcard block protocol
 # Peter hinch 30th Jan 2016
-import os, sdcard, pyb
+import os, sdcard, machine
 
 def sdtest():
-    sd = sdcard.SDCard(pyb.SPI(1), pyb.Pin.board.X21) # Compatible with PCB
-    pyb.mount(sd, '/fc')
+    spi = machine.SPI(1)
+    spi.init()  # Ensure right baudrate
+    sd = sdcard.SDCard(spi, machine.Pin.board.X21) # Compatible with PCB
+    vfs = os.VfsFat(sd)
+    os.mount(vfs, '/fc')
     print('Filesystem check')
     print(os.listdir('/fc'))
 
@@ -38,7 +41,7 @@ def sdtest():
         result2 = f.read()
         print(len(result2), 'bytes read')
 
-    pyb.mount(None, '/fc')
+    os.umount('/fc')
 
     print()
     print('Verifying data read back')


### PR DESCRIPTION
```python
pyb.mount(None, mountpoint)
```
no longer works, causing the script to fail.

The code now uses **os.VfsFat**. I also took the opportunity to replace **pyb** with **machine** and to initialise the SPI bus explicitly.