### PR TITLE
py/objarray: Introduce "memview_offset" alias for "free" field of the…

### DIFF
--- a/py/objarray.h
+++ b/py/objarray.h
@@ -32,11 +32,18 @@
 // Used only for memoryview types, set in "typecode" to indicate a writable memoryview
 #define MP_OBJ_ARRAY_TYPECODE_FLAG_RW (0x80)
 
+// This structure is used for all of bytearray, array.array, memoryview
+// objects. Tote that memoryview has different meaning for some fields,
+// see comment at the beginning of objarray.c.
 typedef struct _mp_obj_array_t {
     mp_obj_base_t base;
     size_t typecode : 8;
     // free is number of unused elements after len used elements
     // alloc size = len + free
+    // But for memoryview, 'free' is reused as offset (in elements) into the
+    // parent object. (Union is not used to not go into a complication of
+    // union-of-bitfields with different toolchains). See comments in
+    // objarray.c.
     size_t free : (8 * sizeof(size_t) - 8);
     size_t len; // in elements
     void *items;


### PR DESCRIPTION
… object.

Both mp_type_array and mp_type_memoryview use the same obejct structure,
mp_obj_array_t, but for the case of memoryview, some fields, e.g. "free",
have different meaning. As the "free" field is also a bitfield, assume
that (anonymous) union can't be uses here, and just a field alieas using
a #define. As it's a define, it should be a selective identifier, so use
verbose "memview_offset" to avoid any clashes.