### PR TITLE
Docs: pyb module. Include deprecation warnings for mount.

### DIFF
--- a/docs/library/pyb.rst
+++ b/docs/library/pyb.rst
@@ -212,8 +212,13 @@ Miscellaneous functions
 
 .. function:: mount(device, mountpoint, \*, readonly=False, mkfs=False)
 
+   This function is deprecated. Mounting and unmounting devices should be
+   performed by the uos library.
+
    Mount a block device and make it available as part of the filesystem.
-   ``device`` must be an object that provides the block protocol:
+   ``device`` must be an object that provides the block protocol. (The
+   following is also deprecated. See the uos library docs for the correct
+   way to create a block device).
 
     - ``readblocks(self, blocknum, buf)``
     - ``writeblocks(self, blocknum, buf)`` (optional)
@@ -237,9 +242,6 @@ Miscellaneous functions
 
    If ``mkfs`` is ``True``, then a new filesystem is created if one does not
    already exist.
-
-   To unmount a device, pass ``None`` as the device and the mount location
-   as ``mountpoint``.
 
 .. function:: repl_uart(uart)
 


### PR DESCRIPTION
Remove reference to broken `mount(None, mountpoint)` option. Include deprecation warnings for **mount** and for superseded block protocol description (sync/ioctl).