### PR TITLE
[RFC] docs/pyb.Pin: Add "(legacy)" marker to the title.

### DIFF
--- a/docs/library/pyb.Pin.rst
+++ b/docs/library/pyb.Pin.rst
@@ -1,8 +1,8 @@
 .. currentmodule:: pyb
 .. _pyb.Pin:
 
-class Pin -- control I/O pins
-=============================
+class Pin -- control I/O pins (legacy)
+======================================
 
 A pin is the basic object to control I/O pins.  It has methods to set
 the mode of the pin (input, output, etc) and methods to get and set the


### PR DESCRIPTION
Currently, both machine.Pin and pyb.Pin (and other classes too) have
the same document title, and the document title is what shown
(standing out) while searching the docs. In other words, seaching for
"Pin" will show (among other results) two same-looking entries:

http://docs.micropython.org/en/latest/pyboard/search.html?q=Pin

class Pin – control I/O pins
class Pin – control I/O pins

If a user is not careful enough to check less standing-out details,
they may click on on wrong module's docs, and then read something
unrelated to what they expected (or should).

As "pyb" module clearly a legacy one, mark its classes as such. If
acked, can be propagated to other classes too.