### PR TITLE
stm32: Add implementation of copysign() for DEBUG builds.

### DIFF
--- a/lib/libm_dbl/README
+++ b/lib/libm_dbl/README
@@ -4,6 +4,10 @@ functions.
 The files lgamma.c, log10.c and tanh.c are too small to have a meaningful
 copyright or license.
 
+The file copysign.c contains a double version of the float copysignf provided
+in libm/math.c for use in DEBUG builds where the standard library copy is 
+not available.
+
 The rest of the files in this directory are copied from the musl library,
 v1.1.16, and, unless otherwise stated in the individual file, have the
 following copyright and MIT license:

--- a/lib/libm_dbl/copysign.c
+++ b/lib/libm_dbl/copysign.c
@@ -1,0 +1,48 @@
+/*
+ * This file is part of the MicroPython project, http://micropython.org/
+ *
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2013, 2014 Damien P. George
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#include "libm.h"
+
+#ifndef NDEBUG
+typedef union {
+    double d;
+    struct {
+        uint64_t m : 52;
+        uint64_t e : 11;
+        uint64_t s : 1;
+    };
+} double_s_t;
+
+double copysign(double x, double y) {
+    double_s_t dx={.d = x};
+    double_s_t dy={.d = y};
+
+    // copy sign bit;
+    dx.s = dy.s;
+
+    return dx.d;
+}
+#endif

--- a/ports/stm32/Makefile
+++ b/ports/stm32/Makefile
@@ -136,6 +136,7 @@ SRC_LIBM = $(addprefix lib/libm_dbl/,\
 	ceil.c \
 	cos.c \
 	cosh.c \
+	copysign.c \
 	erf.c \
 	exp.c \
 	expm1.c \


### PR DESCRIPTION
This provides a double variant of the float copysignf from libm/math.c which is required for `DEBUG=1` builds when `MICROPY_FLOAT_IMPL=double`