### PR TITLE
extmod/moductypes: Accept OrderedDict as a structure description.

### DIFF
--- a/extmod/moductypes.c
+++ b/extmod/moductypes.c
@@ -3,7 +3,7 @@
  *
  * The MIT License (MIT)
  *
- * Copyright (c) 2014 Paul Sokolovsky
+ * Copyright (c) 2014-2018 Paul Sokolovsky
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -137,7 +137,11 @@ STATIC void uctypes_struct_print(const mp_print_t *print, mp_obj_t self_in, mp_p
     (void)kind;
     mp_obj_uctypes_struct_t *self = MP_OBJ_TO_PTR(self_in);
     const char *typen = "unk";
-    if (MP_OBJ_IS_TYPE(self->desc, &mp_type_dict)) {
+    if (MP_OBJ_IS_TYPE(self->desc, &mp_type_dict)
+      #if MICROPY_PY_COLLECTIONS_ORDEREDDICT
+        || MP_OBJ_IS_TYPE(self->desc, &mp_type_ordereddict)
+      #endif
+      ) {
         typen = "STRUCT";
     } else if (MP_OBJ_IS_TYPE(self->desc, &mp_type_tuple)) {
         mp_obj_tuple_t *t = MP_OBJ_TO_PTR(self->desc);
@@ -206,7 +210,11 @@ STATIC mp_uint_t uctypes_struct_agg_size(mp_obj_tuple_t *t, int layout_type, mp_
 }
 
 STATIC mp_uint_t uctypes_struct_size(mp_obj_t desc_in, int layout_type, mp_uint_t *max_field_size) {
-    if (!MP_OBJ_IS_TYPE(desc_in, &mp_type_dict)) {
+    if (!MP_OBJ_IS_TYPE(desc_in, &mp_type_dict)
+      #if MICROPY_PY_COLLECTIONS_ORDEREDDICT
+        && !MP_OBJ_IS_TYPE(desc_in, &mp_type_ordereddict)
+      #endif
+      ) {
         if (MP_OBJ_IS_TYPE(desc_in, &mp_type_tuple)) {
             return uctypes_struct_agg_size((mp_obj_tuple_t*)MP_OBJ_TO_PTR(desc_in), layout_type, max_field_size);
         } else if (MP_OBJ_IS_SMALL_INT(desc_in)) {
@@ -390,8 +398,11 @@ STATIC void set_aligned(uint val_type, void *p, mp_int_t index, mp_obj_t val) {
 STATIC mp_obj_t uctypes_struct_attr_op(mp_obj_t self_in, qstr attr, mp_obj_t set_val) {
     mp_obj_uctypes_struct_t *self = MP_OBJ_TO_PTR(self_in);
 
-    // TODO: Support at least OrderedDict in addition
-    if (!MP_OBJ_IS_TYPE(self->desc, &mp_type_dict)) {
+    if (!MP_OBJ_IS_TYPE(self->desc, &mp_type_dict)
+      #if MICROPY_PY_COLLECTIONS_ORDEREDDICT
+        && !MP_OBJ_IS_TYPE(self->desc, &mp_type_ordereddict)
+      #endif
+      ) {
             mp_raise_TypeError("struct: no fields");
     }
 

--- a/tests/extmod/uctypes_sizeof_od.py
+++ b/tests/extmod/uctypes_sizeof_od.py
@@ -1,0 +1,48 @@
+try:
+    from ucollections import OrderedDict
+    import uctypes
+except ImportError:
+    print("SKIP")
+    raise SystemExit
+
+desc = OrderedDict({
+    # arr is array at offset 0, of UINT8 elements, array size is 2
+    "arr": (uctypes.ARRAY | 0, uctypes.UINT8 | 2),
+    # arr2 is array at offset 0, size 2, of structures defined recursively
+    "arr2": (uctypes.ARRAY | 0, 2, {"b": uctypes.UINT8 | 0}),
+    "arr3": (uctypes.ARRAY | 2, uctypes.UINT16 | 2),
+    "arr4": (uctypes.ARRAY | 0, 2, {"b": uctypes.UINT8 | 0, "w": uctypes.UINT16 | 1}),
+    "sub": (0, {
+        'b1': uctypes.BFUINT8 | 0 | 4 << uctypes.BF_POS | 4 << uctypes.BF_LEN,
+        'b2': uctypes.BFUINT8 | 0 | 0 << uctypes.BF_POS | 4 << uctypes.BF_LEN,
+    }),
+})
+
+data = bytearray(b"01234567")
+
+S = uctypes.struct(uctypes.addressof(data), desc, uctypes.LITTLE_ENDIAN)
+
+print(uctypes.sizeof(S.arr))
+assert uctypes.sizeof(S.arr) == 2
+
+print(uctypes.sizeof(S.arr2))
+assert uctypes.sizeof(S.arr2) == 2
+
+print(uctypes.sizeof(S.arr3))
+
+try:
+    print(uctypes.sizeof(S.arr3[0]))
+except TypeError:
+    print("TypeError")
+
+print(uctypes.sizeof(S.arr4))
+assert uctypes.sizeof(S.arr4) == 6
+
+print(uctypes.sizeof(S.sub))
+assert uctypes.sizeof(S.sub) == 1
+
+# invalid descriptor
+try:
+    print(uctypes.sizeof([]))
+except TypeError:
+    print("TypeError")

--- a/tests/extmod/uctypes_sizeof_od.py.exp
+++ b/tests/extmod/uctypes_sizeof_od.py.exp
@@ -1,0 +1,7 @@
+2
+2
+4
+TypeError
+6
+1
+TypeError


### PR DESCRIPTION
    Using OrderedDict (i.e. stable order of fields) would for example allow
    to automatically calculate field offsets in structures.
