### PR TITLE
pydfu: fix windows stdout.flush issue on python 3.6

### DIFF
--- a/tools/pydfu.py
+++ b/tools/pydfu.py
@@ -482,7 +482,10 @@ def cli_progress(addr, offset, size):
     print("\r0x{:08x} {:7d} [{}{}] {:3d}% "
           .format(addr, size, '=' * done, ' ' * (width - done),
                   offset * 100 // size), end="")
-    sys.stdout.flush()
+    try:
+        sys.stdout.flush()
+    except OSError:
+        pass # Windows CLI error on python 3.6
     if offset == size:
         print("")
 


### PR DESCRIPTION
There appears to be an issue with cpython >= 3.6 `sys.stdout.flush()` on windows as used in pydfu.
```
File: firmware.dfu
    b'DfuSe' v1, image size: 1751517, targets: 1
    b'Target' 0, alt setting: 0, name: "ST...", size: 1751232, elements: 2
      0, address: 0x08000000, size: 15736
      1, address: 0x08020000, size: 1735480
    usb: 0483:df11, device: 0x0000, dfu: 0x011a, b'UFD', 16, 0x61194f1d
Writing memory...
0x08000000   15736 [                         ]   0% Traceback (most recent call last):
  File "src\micropython\tools\pydfu.py", line 548, in <module>
    main()
  File "src\micropython\tools\pydfu.py", line 539, in main
    write_elements(elements, args.mass_erase, progress=cli_progress)
  File "src\micropython\tools\pydfu.py", line 454, in write_elements
    progress(elem_addr, 0, elem_size)
  File "src\micropython\tools\pydfu.py", line 485, in cli_progress
    sys.stdout.flush()
OSError: [WinError 87] The parameter is incorrect
```
I think it's the same as described in: https://github.com/pytest-dev/py/issues/103

Their workaround appears to be fairly long winded and I'm not sure it's really necessary here (https://github.com/pytest-dev/pytest/pull/2462/files)

I've found it works just fine to catch and ignore the error on the flush line.

Tested: 
Windows 10 x64 1803 (Build 17134.228)
Python 3.6.4 amd64


