### PR TITLE
stm32/dcmi: Add F4/F7/H7 hal and dma definitions for DCMI peripheral

### DIFF
--- a/ports/stm32/Makefile
+++ b/ports/stm32/Makefile
@@ -319,6 +319,8 @@ endif
 ifeq ($(MCU_SERIES),$(filter $(MCU_SERIES),f4 f7 h7))
 SRC_HAL += $(addprefix $(HAL_DIR)/Src/stm32$(MCU_SERIES)xx_,\
 	hal_sdram.c \
+	hal_dma_ex.c \
+    hal_dcmi.c \
 	)
 endif
 

--- a/ports/stm32/dma.c
+++ b/ports/stm32/dma.c
@@ -140,6 +140,27 @@ static const DMA_InitTypeDef dma_init_struct_dac = {
 };
 #endif
 
+#if defined(MICROPY_HW_ENABLE_DCMI) && MICROPY_HW_ENABLE_DCMI
+static const DMA_InitTypeDef dma_init_struct_dcmi = {
+    #if defined(STM32H7)
+    .Request             = DMA_REQUEST_DCMI,
+    #else
+    .Channel             = DMA_CHANNEL_1,
+    #endif
+    .Direction           = DMA_PERIPH_TO_MEMORY,
+    .PeriphInc           = DMA_PINC_DISABLE,
+    .MemInc              = DMA_MINC_ENABLE,
+    .PeriphDataAlignment = DMA_PDATAALIGN_WORD,
+    .MemDataAlignment    = DMA_MDATAALIGN_WORD,
+    .Mode                = DMA_NORMAL,
+    .Priority            = DMA_PRIORITY_HIGH,
+    .FIFOMode            = DMA_FIFOMODE_ENABLE,
+    .FIFOThreshold       = DMA_FIFO_THRESHOLD_FULL,
+    .MemBurst            = DMA_MBURST_INC4,
+    .PeriphBurst         = DMA_PBURST_SINGLE
+};
+#endif
+
 #if defined(STM32F0)
 
 #define NCONTROLLERS            (2)
@@ -225,6 +246,9 @@ const dma_descr_t dma_I2C_1_TX = { DMA1_Stream6, DMA_CHANNEL_1, dma_id_6,   &dma
 // DMA2 streams
 #if defined(STM32F7) && defined(SDMMC2) && MICROPY_HW_HAS_SDCARD
 const dma_descr_t dma_SDMMC_2 = { DMA2_Stream0, DMA_CHANNEL_11, dma_id_8,  &dma_init_struct_sdio };
+#endif
+#if defined(MICROPY_HW_ENABLE_DCMI) && MICROPY_HW_ENABLE_DCMI
+const dma_descr_t dma_DCMI_0 = { DMA2_Stream1, DMA_CHANNEL_1, dma_id_9,  &dma_init_struct_dcmi };
 #endif
 const dma_descr_t dma_SPI_1_RX = { DMA2_Stream2, DMA_CHANNEL_3, dma_id_10,  &dma_init_struct_spi_i2c };
 const dma_descr_t dma_SPI_5_RX = { DMA2_Stream3, DMA_CHANNEL_2, dma_id_11,  &dma_init_struct_spi_i2c };
@@ -380,6 +404,9 @@ const dma_descr_t dma_I2C_1_TX = { DMA1_Stream7, DMA_REQUEST_I2C1_TX, dma_id_7, 
 const dma_descr_t dma_I2C_2_TX = { DMA1_Stream7, DMA_REQUEST_I2C2_TX, dma_id_7,   &dma_init_struct_spi_i2c };
 
 // DMA2 streams
+#if defined(MICROPY_HW_ENABLE_DCMI) && MICROPY_HW_ENABLE_DCMI
+const dma_descr_t dma_DCMI_0 = { DMA2_Stream1, DMA_REQUEST_DCMI, dma_id_9,  &dma_init_struct_dcmi };
+#endif
 const dma_descr_t dma_SPI_1_RX = { DMA2_Stream2, DMA_REQUEST_SPI1_RX, dma_id_10,  &dma_init_struct_spi_i2c };
 const dma_descr_t dma_SPI_5_RX = { DMA2_Stream3, DMA_REQUEST_SPI5_RX, dma_id_11,  &dma_init_struct_spi_i2c };
 const dma_descr_t dma_SPI_4_RX = { DMA2_Stream3, DMA_REQUEST_SPI4_RX, dma_id_11,  &dma_init_struct_spi_i2c };

--- a/ports/stm32/mpconfigboard_common.h
+++ b/ports/stm32/mpconfigboard_common.h
@@ -67,6 +67,11 @@
 #define MICROPY_HW_ENABLE_DAC (0)
 #endif
 
+// Whether to enable the DCMI peripheral
+#ifndef MICROPY_HW_ENABLE_DCMI
+#define MICROPY_HW_ENABLE_DCMI (0)
+#endif
+
 // Whether to enable USB support
 #ifndef MICROPY_HW_ENABLE_USB
 #define MICROPY_HW_ENABLE_USB (0)


### PR DESCRIPTION
This PR just adds the DCMI peripheral (camera interface) stm hal support to the build if enabled in mpconfigboard.

I've got a proof of concept of the openmv imaging libraries building against an (almost pristine) official micropython with just a couple of things like this enabled in micropython. 

This usage of omv as a module with official micropython will be published elsewhere with instructions for use once it's cleaned up a bit more, it makes a great example of customizing a micropython system without necessarily needing (yet another) repo fork.

This shouldn't add any code size to builds without DCMI enabled & used in board / external C modules.