### PR TITLE
docs/library/machine.SPI.rst Add note about baudrate imprecision.

### DIFF
--- a/docs/library/machine.SPI.rst
+++ b/docs/library/machine.SPI.rst
@@ -47,6 +47,10 @@ Methods
      - ``pins`` - WiPy port doesn't ``sck``, ``mosi``, ``miso`` arguments, and instead allows to
        specify them as a tuple of ``pins`` parameter.
 
+   In the case of hardware SPI the actual clock frequency may be lower than the
+   requested baudrate. This is dependant on the platform hardware. The actual
+   rate may be determined by printing the spi object.
+
 .. method:: SPI.deinit()
 
    Turn off the SPI bus.


### PR DESCRIPTION
This is explained in the **pyb** docs but not in **machine** - see #4147.