### PR TITLE
extmod/moductypes: Make sizeof() accept "layout" parameter.

### DIFF
--- a/extmod/moductypes.c
+++ b/extmod/moductypes.c
@@ -269,7 +269,8 @@ STATIC mp_uint_t uctypes_struct_size(mp_obj_t desc_in, int layout_type, mp_uint_
     return total_size;
 }
 
-STATIC mp_obj_t uctypes_struct_sizeof(mp_obj_t obj_in) {
+STATIC mp_obj_t uctypes_struct_sizeof(size_t n_args, const mp_obj_t *args) {
+    mp_obj_t obj_in = args[0];
     mp_uint_t max_field_size = 0;
     if (MP_OBJ_IS_TYPE(obj_in, &mp_type_bytearray)) {
         return mp_obj_len(obj_in);
@@ -278,15 +279,22 @@ STATIC mp_obj_t uctypes_struct_sizeof(mp_obj_t obj_in) {
     // We can apply sizeof either to structure definition (a dict)
     // or to instantiated structure
     if (MP_OBJ_IS_TYPE(obj_in, &uctypes_struct_type)) {
+        if (n_args != 1) {
+            mp_raise_TypeError(NULL);
+        }
         // Extract structure definition
         mp_obj_uctypes_struct_t *obj = MP_OBJ_TO_PTR(obj_in);
         obj_in = obj->desc;
         layout_type = obj->flags;
+    } else {
+        if (n_args == 2) {
+            layout_type = mp_obj_get_int(args[1]);
+        }
     }
     mp_uint_t size = uctypes_struct_size(obj_in, layout_type, &max_field_size);
     return MP_OBJ_NEW_SMALL_INT(size);
 }
-STATIC MP_DEFINE_CONST_FUN_OBJ_1(uctypes_struct_sizeof_obj, uctypes_struct_sizeof);
+STATIC MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(uctypes_struct_sizeof_obj, 1, 2, uctypes_struct_sizeof);
 
 static inline mp_obj_t get_unaligned(uint val_type, byte *p, int big_endian) {
     char struct_type = big_endian ? '>' : '<';

--- a/tests/extmod/uctypes_sizeof_layout.py
+++ b/tests/extmod/uctypes_sizeof_layout.py
@@ -1,0 +1,27 @@
+try:
+    import uctypes
+except ImportError:
+    print("SKIP")
+    raise SystemExit
+
+desc = {
+    "f1": 0 | uctypes.UINT32,
+    "f2": 4 | uctypes.UINT8,
+}
+
+
+# uctypes.NATIVE is default
+print(uctypes.sizeof(desc) == uctypes.sizeof(desc, uctypes.NATIVE))
+
+# Here we assume that that we run on a platform with convential ABI
+# (which rounds up structure size based on max alignment). For platforms
+# where that doesn't hold, this tests should be just disabled in the runner.
+print(uctypes.sizeof(desc, uctypes.NATIVE) > uctypes.sizeof(desc, uctypes.LITTLE_ENDIAN))
+
+# When taking sizeof of instantiated structure, layout type param
+# is prohibited (because structure already has its layout type).
+s = uctypes.struct(0, desc, uctypes.LITTLE_ENDIAN)
+try:
+    uctypes.sizeof(s, uctypes.LITTLE_ENDIAN)
+except TypeError:
+    print("TypeError")

--- a/tests/extmod/uctypes_sizeof_layout.py.exp
+++ b/tests/extmod/uctypes_sizeof_layout.py.exp
@@ -1,0 +1,3 @@
+True
+True
+TypeError


### PR DESCRIPTION
    sizeof() can work in two ways: a) calculate size of already instantiated
    structure ("sizeof variable") - in this case we already no layout; b) size
    of structure decsription ("sizeof type"). In the latter case, LAYOUT_NATIVE
    was assumed, but there should possibility to calculate size for other
    layouts too. So, with this patch, there're now 2 forms:
    
    uctypes.sizeof(struct)
    uctypes.sizeof(struct_desc, layout)
