### PR TITLE
Fixed pin assignment for I2C with Nucleo-F446RE + stlink config

### DIFF
--- a/ports/stm32/boards/NUCLEO_F446RE/mpconfigboard.h
+++ b/ports/stm32/boards/NUCLEO_F446RE/mpconfigboard.h
@@ -24,12 +24,12 @@
 #define MICROPY_HW_UART_REPL_BAUD   115200
 
 // I2C busses
-#define MICROPY_HW_I2C1_SCL (pin_B6)        // Arduino D10, pin 17 on CN10
-#define MICROPY_HW_I2C1_SDA (pin_B7)        //              pin 21 on CN7
+#define MICROPY_HW_I2C1_SCL (pin_B8)        // Arduino D15, pin 3 on CN10
+#define MICROPY_HW_I2C1_SDA (pin_B9)        //         D14, pin 5 on CN10
 #define MICROPY_HW_I2C2_SCL (pin_B10)       // Arduino D6,  pin 25 on CN10
 #define MICROPY_HW_I2C2_SDA (pin_B3)        // Arduino D3,  pin 31 on CN10
 #define MICROPY_HW_I2C3_SCL (pin_A8)        // Arduino D7,  pin 23 on CN10
-#define MICROPY_HW_I2C3_SDA (pin_C9)        //              pin  1 on CN10
+#define MICROPY_HW_I2C3_SDA (pin_B4)        // Arduino D5,  pin 27 on CN10
 
 // SPI busses
 #define MICROPY_HW_SPI1_NSS     (pin_A15)   //              pin 17 on CN7

--- a/ports/stm32/boards/openocd_stm32f4.cfg
+++ b/ports/stm32/boards/openocd_stm32f4.cfg
@@ -11,7 +11,7 @@
 #    $ openocd -f openocd_stm32f4.cfg
 
 
-source [find interface/stlink-v2.cfg]
+source [find interface/stlink-v2-1.cfg]
 transport select hla_swd
 source [find target/stm32f4x.cfg]
 reset_config srst_only


### PR DESCRIPTION
I had to change the stlink version to get openocd to talk to my board but I don't know if this change has to be done for all the users.

I2C is working with the fixed pin assignments.