### PR TITLE
nrf/bluetooth: Set GAP_ADV_MAX_SIZE to 31 (s132/s140).

### DIFF
--- a/ports/nrf/drivers/bluetooth/ble_drv.c
+++ b/ports/nrf/drivers/bluetooth/ble_drv.c
@@ -106,7 +106,7 @@ static mp_obj_t mp_gattc_char_data_observer;
 
 #if (BLUETOOTH_SD == 132) || (BLUETOOTH_SD == 140)
 #include "nrf_nvic.h"
-#define BLE_GAP_ADV_MAX_SIZE BLE_GATT_ATT_MTU_DEFAULT
+#define BLE_GAP_ADV_MAX_SIZE 31
 #define BLE_DRV_CONN_CONFIG_TAG 1
 
 static uint8_t m_adv_handle;


### PR DESCRIPTION
For s132 and s140, GAP_ADV_MAX_SIZE was currently set to
BLE_GATT_ATT_MTU_DEFAULT, which is 23. The correct value
should have been 31, but there are no define for this in
the s132/s140 header files as for s110.

Updating define in ble_drv.c to the correct value of 31.