### PR TITLE
 py/objstr: format: Return bytes result for bytes format string.

### DIFF
--- a/py/objstr.c
+++ b/py/objstr.c
@@ -1387,7 +1387,7 @@ mp_obj_t mp_obj_str_format(size_t n_args, const mp_obj_t *args, mp_map_t *kwargs
     GET_STR_DATA_LEN(args[0], str, len);
     int arg_i = 0;
     vstr_t vstr = mp_obj_str_format_helper((const char*)str, (const char*)str + len, &arg_i, n_args, args, kwargs);
-    return mp_obj_new_str_from_vstr(&mp_type_str, &vstr);
+    return mp_obj_new_str_from_vstr(mp_obj_get_type(args[0]), &vstr);
 }
 MP_DEFINE_CONST_FUN_OBJ_KW(str_format_obj, 1, mp_obj_str_format);
 

--- a/tests/cpydiff/types_bytes_format.py
+++ b/tests/cpydiff/types_bytes_format.py
@@ -1,0 +1,7 @@
+"""
+categories: Types,bytes
+description: bytes objects support .format() method
+cause: MicroPython strives to be a more regular implementation, so if both `str` and `bytes` support ``__mod__()`` (the % operator), it makes sense to support ``format()`` for both too. Support for ``__mod__`` can also be compiled out, which leaves only ``format()`` for bytes formatting.
+workaround: If you are interested in CPython compatibility, don't use ``.format()`` on bytes objects.
+"""
+print(b'{}'.format(1))


### PR DESCRIPTION
~~~
This is an improvement over previous behavior when str was returned for
both str and bytes input format. This is also consistent with how % operator and
many other str/bytes methods work.

It should be noted that it's not how current versions of CPython work,
where there's a gap in the  functionality and bytes.format() is not
supported.
~~~