### PR TITLE
nrf/timer: Fix disabling Timer 1 when using soft PWM.

### DIFF
--- a/ports/nrf/modules/machine/timer.c
+++ b/ports/nrf/modules/machine/timer.c
@@ -53,7 +53,9 @@ STATIC mp_obj_t machine_timer_callbacks[] = {
 
 STATIC const machine_timer_obj_t machine_timer_obj[] = {
     {{&machine_timer_type}, NRFX_TIMER_INSTANCE(0)},
-#if !defined(MICROPY_PY_MACHINE_SOFT_PWM) || (MICROPY_PY_MACHINE_SOFT_PWM == 0)
+#if MICROPY_PY_MACHINE_SOFT_PWM
+    { },
+#else
     {{&machine_timer_type}, NRFX_TIMER_INSTANCE(1)},
 #endif
     {{&machine_timer_type}, NRFX_TIMER_INSTANCE(2)},


### PR DESCRIPTION
The timer instance 1 which is used for soft PWM is already excluded
from machine_timer_obj[], so timer_id 1 is actually timer instance 2.
Don't exclude this from being used.

Also reduce the size of machine_timer_callbacks[] when having soft PWM.