### PR TITLE
stm32: Add method of registering polling c functions

### DIFF
--- a/ports/stm32/Makefile
+++ b/ports/stm32/Makefile
@@ -266,6 +266,7 @@ SRC_C = \
 	servo.c \
 	dac.c \
 	adc.c \
+	pollfunctions.c \
 	$(wildcard $(BOARD_DIR)/*.c)
 
 ifeq ($(MCU_SERIES),f0)

--- a/ports/stm32/modnetwork.c
+++ b/ports/stm32/modnetwork.c
@@ -42,6 +42,7 @@
 #include "lwip/timeouts.h"
 #include "lwip/dns.h"
 #include "lwip/dhcp.h"
+#include "pollfunctions.h"
 
 u32_t sys_now(void) {
     return mp_hal_ticks_ms();
@@ -59,6 +60,8 @@ void pyb_lwip_poll(void) {
     sys_check_timeouts();
 }
 
+DEFINE_POLL_FUNCTION(pyb_lwip_poll);
+
 #endif
 
 /// \module network - network configuration
@@ -66,6 +69,9 @@ void pyb_lwip_poll(void) {
 /// This module provides network drivers and routing configuration.
 
 void mod_network_init(void) {
+    #if MICROPY_PY_LWIP
+    register_poll_function(pyb_lwip_poll);
+    #endif
     mp_obj_list_init(&MP_STATE_PORT(mod_network_nic_list), 0);
 }
 

--- a/ports/stm32/mpconfigport.h
+++ b/ports/stm32/mpconfigport.h
@@ -31,6 +31,8 @@
 #include "mpconfigboard.h"
 #include "mpconfigboard_common.h"
 
+#include "pollfunctions.h"
+
 // memory allocation policies
 #define MICROPY_ALLOC_PATH_MAX      (128)
 
@@ -204,17 +206,14 @@ extern const struct _mp_obj_module_t mp_module_onewire;
 // usocket implementation provided by lwIP
 #define SOCKET_BUILTIN_MODULE               { MP_ROM_QSTR(MP_QSTR_usocket), MP_ROM_PTR(&mp_module_lwip) },
 #define SOCKET_BUILTIN_MODULE_WEAK_LINKS    { MP_ROM_QSTR(MP_QSTR_socket), MP_ROM_PTR(&mp_module_lwip) },
-#define SOCKET_POLL extern void pyb_lwip_poll(void); pyb_lwip_poll();
 #elif MICROPY_PY_USOCKET
 // usocket implementation provided by skeleton wrapper
 #define SOCKET_BUILTIN_MODULE               { MP_ROM_QSTR(MP_QSTR_usocket), MP_ROM_PTR(&mp_module_usocket) },
 #define SOCKET_BUILTIN_MODULE_WEAK_LINKS    { MP_ROM_QSTR(MP_QSTR_socket), MP_ROM_PTR(&mp_module_usocket) },
-#define SOCKET_POLL
 #else
 // no usocket module
 #define SOCKET_BUILTIN_MODULE
 #define SOCKET_BUILTIN_MODULE_WEAK_LINKS
-#define SOCKET_POLL
 #endif
 
 #if MICROPY_PY_NETWORK
@@ -330,7 +329,7 @@ static inline mp_uint_t disable_irq(void) {
     do { \
         extern void mp_handle_pending(void); \
         mp_handle_pending(); \
-        SOCKET_POLL \
+        poll_functions(); \
         if (pyb_thread_enabled) { \
             MP_THREAD_GIL_EXIT(); \
             pyb_thread_yield(); \
@@ -346,7 +345,7 @@ static inline mp_uint_t disable_irq(void) {
     do { \
         extern void mp_handle_pending(void); \
         mp_handle_pending(); \
-        SOCKET_POLL \
+        poll_functions(); \
         __WFI(); \
     } while (0);
 

--- a/ports/stm32/pollfunctions.c
+++ b/ports/stm32/pollfunctions.c
@@ -1,0 +1,47 @@
+/*
+ * This file is part of the MicroPython project, http://micropython.org/
+ *
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2018 Damien P. George
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#include <string.h>
+#include "pollfunctions.h"
+
+static poll_function_t * event_poll_hooks = NULL;
+static poll_function_t ** event_poll_tail = &event_poll_hooks;
+
+void _register_poll_function(poll_function_t *pf) {
+    if (!pf->registered) {
+        *event_poll_tail = pf;
+        event_poll_tail = &pf->next;
+        pf->registered = true;
+    }
+}
+
+void poll_functions() {
+    poll_function_t * event_poll_hook = event_poll_hooks;
+    while (event_poll_hook != NULL) {
+        event_poll_hook->function();
+        event_poll_hook = event_poll_hook->next;
+    }
+}

--- a/ports/stm32/pollfunctions.h
+++ b/ports/stm32/pollfunctions.h
@@ -1,0 +1,46 @@
+/*
+ * This file is part of the MicroPython project, http://micropython.org/
+ *
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2018 Damien P. George
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+#ifndef MICROPY_POLL_FUNCTIONS_H
+#define MICROPY_POLL_FUNCTIONS_H
+
+#include <stdbool.h>
+
+typedef struct _poll_function{
+    void (*function)(void);
+    bool registered;
+    struct _poll_function *next;
+} poll_function_t;
+
+#define DEFINE_POLL_FUNCTION(fn) \
+  static poll_function_t _pf_##fn  = {fn, false, NULL}
+
+#define register_poll_function(fn) \
+  _register_poll_function(&_pf_##fn)
+
+void _register_poll_function(poll_function_t *pf);
+void poll_functions();
+
+#endif // MICROPY_POLL_FUNCTIONS_H


### PR DESCRIPTION
A c modules I"m currently working on has a couple of functions that need to be polled, preferably in the main thread (rather than interrupts) 

**background**:
We're adding BLE to our stm product via an external nrf52 chip running nordic's serialization library.  This requires incoming data on the uart to be pushed to their library, as well as a background processing function in the library stack to be called to handing data in both directions.
http://infocenter.nordicsemi.com/index.jsp?topic=%2Fcom.nordic.infocenter.sdk5.v12.2.0%2Fnrf51_setups_serialization.html&cp=4_0_1_1_4

**this pr**
With the long term aim of not needing to touch the micropython codebase to add this or similar modules to my build, I needed some way of getting my function to be run in the background in the polling loop.

This PR achieves this goal by using a simple linked list of statically allocated function pointers to declare and register functions that are to be run sequentially by the event loop when idle. I've converted the existing SOCKET_POLL handler over to this by way of example.

This method also has the advantage of the moving the declaration of a function being polled by the system to where the function is defined, I feel this makes the it clearer to follow.

It does add a little in flash/ram (to declare the linked list elements) and will have a slight runtime hit (as it iterates through the linked list to run functions) so I'm very open to discussion about whether this is appropriate to add here or alternative means of achieving this.