### PR TITLE
(esp8266) make it possible to set the OS UART from the make commandline

### DIFF
--- a/ports/esp8266/Makefile
+++ b/ports/esp8266/Makefile
@@ -31,7 +31,7 @@ INC += -I$(ESP_SDK)/include
 
 # UART for "os" messages. 0 is normal UART as used by MicroPython REPL,
 # 1 is debug UART (tx only), -1 to disable.
-UART_OS = 0
+UART_OS ?= 0
 
 CFLAGS_XTENSA = -fsingle-precision-constant -Wdouble-promotion \
 	-D__ets__ -DICACHE_FLASH \


### PR DESCRIPTION
This way I can do `make UART_OS=-1` and not get all the wifi spew on the console when I'm running a custom build.