### PR TITLE
unix: moduselect: poll.mofify: Raise OSError(ENOENT) if object is not in poller

### DIFF
--- a/docs/library/uselect.rst
+++ b/docs/library/uselect.rst
@@ -45,13 +45,18 @@ Methods
 
    *eventmask* defaults to ``uselect.POLLIN | uselect.POLLOUT``.
 
+   It is OK to call this function multiple times for the same *obj*.
+   Successive calls will update *obj*'s eventmask to the value of
+   *eventmask* (i.e. will behave as `modify()`).
+
 .. method:: poll.unregister(obj)
 
    Unregister *obj* from polling.
 
 .. method:: poll.modify(obj, eventmask)
 
-   Modify the *eventmask* for *obj*.
+   Modify the *eventmask* for *obj*. If *obj* is not registered, `OSError`
+   is raised with error of ENOENT.
 
 .. method:: poll.poll(timeout=-1)
 

--- a/ports/unix/moduselect.c
+++ b/ports/unix/moduselect.c
@@ -158,13 +158,13 @@ STATIC mp_obj_t poll_modify(mp_obj_t self_in, mp_obj_t obj_in, mp_obj_t eventmas
     for (int i = self->len - 1; i >= 0; i--) {
         if (entries->fd == fd) {
             entries->events = mp_obj_get_int(eventmask_in);
-            break;
+            return mp_const_none;
         }
         entries++;
     }
 
-    // TODO raise KeyError if obj didn't exist in map
-    return mp_const_none;
+    // obj doesn't exist in poller
+    mp_raise_OSError(MP_ENOENT);
 }
 MP_DEFINE_CONST_FUN_OBJ_3(poll_modify_obj, poll_modify);
 

--- a/tests/extmod/uselect_poll_basic.py
+++ b/tests/extmod/uselect_poll_basic.py
@@ -1,0 +1,34 @@
+try:
+    import usocket as socket, uselect as select, uerrno as errno
+except ImportError:
+    try:
+        import socket, select, errno
+    except ImportError:
+        print("SKIP")
+        raise SystemExit
+
+
+poller = select.poll()
+
+s = socket.socket()
+
+poller.register(s)
+# https://docs.python.org/3/library/select.html#select.poll.register
+# "Registering a file descriptor that’s already registered is not an error,
+# and has the same effect as registering the descriptor exactly once."
+poller.register(s)
+
+# 2 args are mandatory unlike register()
+try:
+    poller.modify(s)
+except TypeError:
+    print("modify:TypeError")
+
+poller.modify(s, select.POLLIN)
+
+poller.unregister(s)
+
+try:
+    poller.modify(s, select.POLLIN)
+except OSError as e:
+    assert e.args[0] == errno.ENOENT


### PR DESCRIPTION
Previously, the function silently succeeded. The new behavior is consistent
with both baremetal uselect implementation and CPython3.