### PR TITLE
extmod/moductypes: Remove BITFIELD from aggregate types enum.

### DIFF
--- a/extmod/moductypes.c
+++ b/extmod/moductypes.c
@@ -92,7 +92,7 @@ enum {
 #define AGG_TYPE_BITS 2
 
 enum {
-    STRUCT, PTR, ARRAY, BITFIELD,
+    STRUCT, PTR, ARRAY,
 };
 
 // Here we need to set sign bit right


### PR DESCRIPTION
This value is unused. It was an artifact of early draft design, but
bitfields were optimized to use scalar one-word encoding, to allow
compact encoding of typical multiple bitfields in MCU control
registers.