### PR TITLE
Implement yield and yield-from in native emitter

### DIFF
--- a/py/asmx64.c
+++ b/py/asmx64.c
@@ -579,10 +579,9 @@ void asm_x64_mov_local_addr_to_r64(asm_x64_t *as, int local_num, int dest_r64) {
 }
 
 void asm_x64_mov_reg_pcrel(asm_x64_t *as, int dest_r64, mp_uint_t label) {
-    assert(dest_r64 < 8);
     mp_uint_t dest = get_label_dest(as, label);
     mp_int_t rel = dest - (as->base.code_offset + 7);
-    asm_x64_write_byte_3(as, REX_PREFIX | REX_W, OPCODE_LEA_MEM_TO_R64, MODRM_R64(dest_r64) | MODRM_RM_R64(5));
+    asm_x64_write_byte_3(as, REX_PREFIX | REX_W | REX_R_FROM_R64(dest_r64), OPCODE_LEA_MEM_TO_R64, MODRM_R64(dest_r64) | MODRM_RM_R64(5));
     asm_x64_write_word32(as, rel);
 }
 

--- a/py/asmx86.c
+++ b/py/asmx86.c
@@ -153,9 +153,11 @@ STATIC void asm_x86_generic_r32_r32(asm_x86_t *as, int dest_r32, int src_r32, in
     asm_x86_write_byte_2(as, op, MODRM_R32(src_r32) | MODRM_RM_REG | MODRM_RM_R32(dest_r32));
 }
 
+#if 0
 STATIC void asm_x86_nop(asm_x86_t *as) {
     asm_x86_write_byte_1(as, OPCODE_NOP);
 }
+#endif
 
 STATIC void asm_x86_push_r32(asm_x86_t *as, int src_r32) {
     asm_x86_write_byte_1(as, OPCODE_PUSH_R32 | src_r32);

--- a/py/asmxtensa.c
+++ b/py/asmxtensa.c
@@ -161,7 +161,8 @@ void asm_xtensa_mov_reg_i32(asm_xtensa_t *as, uint reg_dest, uint32_t i32) {
         asm_xtensa_op_movi(as, reg_dest, i32);
     } else {
         // load the constant
-        asm_xtensa_op_l32r(as, reg_dest, as->base.code_offset, 4 + as->cur_const * WORD_SIZE);
+        uint32_t const_table_offset = (uint8_t*)as->const_table - as->base.code_base;
+        asm_xtensa_op_l32r(as, reg_dest, as->base.code_offset, const_table_offset + as->cur_const * WORD_SIZE);
         // store the constant in the table
         if (as->const_table != NULL) {
             as->const_table[as->cur_const] = i32;

--- a/py/compile.c
+++ b/py/compile.c
@@ -1703,6 +1703,7 @@ STATIC void compile_yield_from(compiler_t *comp) {
     EMIT_ARG(get_iter, false);
     EMIT_ARG(load_const_tok, MP_TOKEN_KW_NONE);
     EMIT_ARG(yield, MP_EMIT_YIELD_FROM);
+    reserve_labels_for_native(comp, 3);
 }
 
 #if MICROPY_PY_ASYNC_AWAIT
@@ -2634,6 +2635,7 @@ STATIC void compile_yield_expr(compiler_t *comp, mp_parse_node_struct_t *pns) {
     if (MP_PARSE_NODE_IS_NULL(pns->nodes[0])) {
         EMIT_ARG(load_const_tok, MP_TOKEN_KW_NONE);
         EMIT_ARG(yield, MP_EMIT_YIELD_VALUE);
+        reserve_labels_for_native(comp, 1);
     } else if (MP_PARSE_NODE_IS_STRUCT_KIND(pns->nodes[0], PN_yield_arg_from)) {
         pns = (mp_parse_node_struct_t*)pns->nodes[0];
         compile_node(comp, pns->nodes[0]);
@@ -2641,6 +2643,7 @@ STATIC void compile_yield_expr(compiler_t *comp, mp_parse_node_struct_t *pns) {
     } else {
         compile_node(comp, pns->nodes[0]);
         EMIT_ARG(yield, MP_EMIT_YIELD_VALUE);
+        reserve_labels_for_native(comp, 1);
     }
 }
 
@@ -2873,6 +2876,7 @@ STATIC void compile_scope_comp_iter(compiler_t *comp, mp_parse_node_struct_t *pn
         compile_node(comp, pn_inner_expr);
         if (comp->scope_cur->kind == SCOPE_GEN_EXPR) {
             EMIT_ARG(yield, MP_EMIT_YIELD_VALUE);
+            reserve_labels_for_native(comp, 1);
             EMIT(pop_top);
         } else {
             EMIT_ARG(store_comp, comp->scope_cur->kind, 4 * for_depth + 5);

--- a/py/emitglue.c
+++ b/py/emitglue.c
@@ -136,6 +136,10 @@ mp_obj_t mp_make_function_from_raw_code(const mp_raw_code_t *rc, mp_obj_t def_ar
         case MP_CODE_NATIVE_PY:
         case MP_CODE_NATIVE_VIPER:
             fun = mp_obj_new_fun_native(def_args, def_kw_args, rc->data.u_native.fun_data, rc->data.u_native.const_table);
+            // check for generator functions and if so change the type of the object
+            if ((rc->scope_flags & MP_SCOPE_FLAG_GENERATOR) != 0) {
+                ((mp_obj_base_t*)MP_OBJ_TO_PTR(fun))->type = &mp_type_native_gen_wrap;
+            }
             break;
         #endif
         #if MICROPY_EMIT_INLINE_ASM

--- a/py/emitnative.c
+++ b/py/emitnative.c
@@ -65,6 +65,13 @@
 //  emit->stack_start:          Python object stack             | emit->n_state
 //                              locals (reversed, L0 at end)    |
 //
+// C stack layout for native generator functions:
+//  0=emit->stack_start:        nlr_buf_t
+//  REG_GENERATOR_STATE points to:
+//  0=emit->code_state_start:   mp_code_state_t
+//  emit->stack_start:          Python object stack             | emit->n_state
+//                              locals (reversed, L0 at end)    |
+//
 // C stack layout for viper functions:
 //  0:                          nlr_buf_t [optional]
 //  emit->code_state_start:     fun_obj, old_globals [optional]
@@ -81,12 +88,12 @@
 
 // Whether the native/viper function needs to be wrapped in an exception handler
 #define NEED_GLOBAL_EXC_HANDLER(emit) ((emit)->scope->exc_stack_size > 0 \
-    || ((emit)->scope->scope_flags & MP_SCOPE_FLAG_REFGLOBALS))
+    || ((emit)->scope->scope_flags & (MP_SCOPE_FLAG_GENERATOR | MP_SCOPE_FLAG_REFGLOBALS)))
 
 // Whether registers can be used to store locals (only true if there are no
 // exception handlers, because otherwise an nlr_jump will restore registers to
 // their state at the start of the function and updates to locals will be lost)
-#define CAN_USE_REGS_FOR_LOCALS(emit) ((emit)->scope->exc_stack_size == 0)
+#define CAN_USE_REGS_FOR_LOCALS(emit) ((emit)->scope->exc_stack_size == 0 && !(emit->scope->scope_flags & MP_SCOPE_FLAG_GENERATOR))
 
 // Indices within the local C stack for various variables
 #define LOCAL_IDX_EXC_VAL(emit) (NLR_BUF_IDX_RET_VAL)
@@ -95,17 +102,13 @@
 #define LOCAL_IDX_RET_VAL(emit) (NLR_BUF_IDX_LOCAL_3)
 #define LOCAL_IDX_FUN_OBJ(emit) ((emit)->code_state_start + offsetof(mp_code_state_t, fun_bc) / sizeof(uintptr_t))
 #define LOCAL_IDX_OLD_GLOBALS(emit) ((emit)->code_state_start + offsetof(mp_code_state_t, ip) / sizeof(uintptr_t))
+#define LOCAL_IDX_GEN_PC(emit) ((emit)->code_state_start + offsetof(mp_code_state_t, ip) / sizeof(uintptr_t))
 #define LOCAL_IDX_LOCAL_VAR(emit, local_num) ((emit)->stack_start + (emit)->n_state - 1 - (local_num))
+
+#define REG_GENERATOR_STATE (REG_LOCAL_3)
 
 // number of arguments to viper functions are limited to this value
 #define REG_ARG_NUM (4)
-
-// define additional generic helper macros
-#define ASM_MOV_LOCAL_IMM_VIA(as, local_num, imm, reg_temp) \
-    do { \
-        ASM_MOV_REG_IMM((as), (reg_temp), (imm)); \
-        ASM_MOV_LOCAL_REG((as), (local_num), (reg_temp)); \
-    } while (false)
 
 #define EMIT_NATIVE_VIPER_TYPE_ERROR(emit, ...) do { \
         *emit->error_slot = mp_obj_new_exception_msg_varg(&mp_type_ViperTypeError, __VA_ARGS__); \
@@ -201,6 +204,7 @@ struct _emit_t {
     size_t exc_stack_size;
     exc_stack_entry_t *exc_stack;
 
+    int start_offset;
     int prelude_offset;
     int n_state;
     uint16_t code_state_start;
@@ -251,6 +255,37 @@ STATIC void emit_post_push_reg(emit_t *emit, vtype_kind_t vtype, int reg);
 STATIC void emit_call_with_imm_arg(emit_t *emit, mp_fun_kind_t fun_kind, mp_int_t arg_val, int arg_reg);
 STATIC void emit_native_load_fast(emit_t *emit, qstr qst, mp_uint_t local_num);
 STATIC void emit_native_store_fast(emit_t *emit, qstr qst, mp_uint_t local_num);
+
+STATIC void emit_native_mov_state_reg(emit_t *emit, int local_num, int reg_src) {
+    if (emit->scope->scope_flags & MP_SCOPE_FLAG_GENERATOR) {
+        ASM_STORE_REG_REG_OFFSET(emit->as, reg_src, REG_GENERATOR_STATE, local_num);
+    } else {
+        ASM_MOV_LOCAL_REG(emit->as, local_num, reg_src);
+    }
+}
+
+STATIC void emit_native_mov_reg_state(emit_t *emit, int reg_dest, int local_num) {
+    if (emit->scope->scope_flags & MP_SCOPE_FLAG_GENERATOR) {
+        ASM_LOAD_REG_REG_OFFSET(emit->as, reg_dest, REG_GENERATOR_STATE, local_num);
+    } else {
+        ASM_MOV_REG_LOCAL(emit->as, reg_dest, local_num);
+    }
+}
+
+STATIC void emit_native_mov_reg_state_addr(emit_t *emit, int reg_dest, int local_num) {
+    if (emit->scope->scope_flags & MP_SCOPE_FLAG_GENERATOR) {
+        ASM_MOV_REG_IMM(emit->as, reg_dest, local_num * ASM_WORD_SIZE);
+        ASM_ADD_REG_REG(emit->as, reg_dest, REG_GENERATOR_STATE);
+    } else {
+        ASM_MOV_REG_LOCAL_ADDR(emit->as, reg_dest, local_num);
+    }
+}
+
+#define emit_native_mov_local_imm_via(emit, local_num, imm, reg_temp) \
+    do { \
+        ASM_MOV_REG_IMM((emit)->as, (reg_temp), (imm)); \
+        emit_native_mov_state_reg((emit), (local_num), (reg_temp)); \
+    } while (false)
 
 STATIC void emit_native_start_pass(emit_t *emit, pass_kind_t pass, scope_t *scope) {
     DEBUG_printf("start_pass(pass=%u, scope=%p)\n", pass, scope);
@@ -392,7 +427,7 @@ STATIC void emit_native_start_pass(emit_t *emit, pass_kind_t pass, scope_t *scop
             if (i < REG_LOCAL_NUM && CAN_USE_REGS_FOR_LOCALS(emit) && (i != 2 || emit->scope->num_pos_args == 3)) {
                 ASM_MOV_REG_REG(emit->as, reg_local_table[i], r);
             } else {
-                ASM_MOV_LOCAL_REG(emit->as, LOCAL_IDX_LOCAL_VAR(emit, i), r);
+                emit_native_mov_state_reg(emit, LOCAL_IDX_LOCAL_VAR(emit, i), r);
             }
         }
         // Get 3rd local from the stack back into REG_LOCAL_3 if this reg couldn't be written to above
@@ -406,11 +441,34 @@ STATIC void emit_native_start_pass(emit_t *emit, pass_kind_t pass, scope_t *scop
         // work out size of state (locals plus stack)
         emit->n_state = scope->num_locals + scope->stack_size;
 
+        if (emit->scope->scope_flags & MP_SCOPE_FLAG_GENERATOR) {
+            emit->code_state_start = 0;
+            emit->stack_start = sizeof(mp_code_state_t) / sizeof(mp_uint_t);
+            mp_asm_base_data(&emit->as->base, ASM_WORD_SIZE, (uintptr_t)emit->prelude_offset);
+            mp_asm_base_data(&emit->as->base, ASM_WORD_SIZE, (uintptr_t)emit->start_offset);
+            ASM_ENTRY(emit->as, sizeof(nlr_buf_t) / sizeof(uintptr_t));
+
+            // Put address of code_state into REG_GENERATOR_STATE
+            #if N_X86
+            asm_x86_mov_arg_to_r32(emit->as, 0, REG_GENERATOR_STATE);
+            #else
+            ASM_MOV_REG_REG(emit->as, REG_GENERATOR_STATE, REG_ARG_1);
+            #endif
+
+            // Put throw value into LOCAL_IDX_EXC_VAL slot, for yield/yield-from
+            #if N_X86
+            asm_x86_mov_arg_to_r32(emit->as, 1, REG_ARG_2);
+            #endif
+            ASM_MOV_LOCAL_REG(emit->as, LOCAL_IDX_EXC_VAL(emit), REG_ARG_2);
+
+        } else {
+
         // the locals and stack start after the code_state structure
         emit->stack_start = emit->code_state_start + sizeof(mp_code_state_t) / sizeof(mp_uint_t);
 
         // allocate space on C-stack for code_state structure, which includes state
         ASM_ENTRY(emit->as, emit->stack_start + emit->n_state);
+        }
 
         // TODO don't load r7 if we don't need it
         #if N_THUMB
@@ -421,6 +479,7 @@ STATIC void emit_native_start_pass(emit_t *emit, pass_kind_t pass, scope_t *scop
         ASM_MOV_REG_IMM(emit->as, ASM_XTENSA_REG_A15, (uint32_t)mp_fun_table);
         #endif
 
+        if (!(emit->scope->scope_flags & MP_SCOPE_FLAG_GENERATOR)) {
         // prepare incoming arguments for call to mp_setup_code_state
 
         #if N_X86
@@ -435,7 +494,7 @@ STATIC void emit_native_start_pass(emit_t *emit, pass_kind_t pass, scope_t *scop
 
         // set code_state.ip (offset from start of this function to prelude info)
         // XXX this encoding may change size
-        ASM_MOV_LOCAL_IMM_VIA(emit->as, emit->code_state_start + offsetof(mp_code_state_t, ip) / sizeof(uintptr_t), emit->prelude_offset, REG_ARG_1);
+        emit_native_mov_local_imm_via(emit, emit->code_state_start + offsetof(mp_code_state_t, ip) / sizeof(uintptr_t), emit->prelude_offset, REG_ARG_1);
 
         // put address of code_state into first arg
         ASM_MOV_REG_LOCAL_ADDR(emit->as, REG_ARG_1, emit->code_state_start);
@@ -448,6 +507,7 @@ STATIC void emit_native_start_pass(emit_t *emit, pass_kind_t pass, scope_t *scop
         #else
         ASM_CALL_IND(emit->as, mp_fun_table[MP_F_SETUP_CODE_STATE], MP_F_SETUP_CODE_STATE);
         #endif
+        }
 
         emit_native_global_exc_entry(emit);
 
@@ -631,7 +691,7 @@ STATIC void need_reg_single(emit_t *emit, int reg_needed, int skip_stack_pos) {
             stack_info_t *si = &emit->stack_info[i];
             if (si->kind == STACK_REG && si->data.u_reg == reg_needed) {
                 si->kind = STACK_VALUE;
-                ASM_MOV_LOCAL_REG(emit->as, emit->stack_start + i, si->data.u_reg);
+                emit_native_mov_state_reg(emit, emit->stack_start + i, si->data.u_reg);
             }
         }
     }
@@ -642,7 +702,7 @@ STATIC void need_reg_all(emit_t *emit) {
         stack_info_t *si = &emit->stack_info[i];
         if (si->kind == STACK_REG) {
             si->kind = STACK_VALUE;
-            ASM_MOV_LOCAL_REG(emit->as, emit->stack_start + i, si->data.u_reg);
+            emit_native_mov_state_reg(emit, emit->stack_start + i, si->data.u_reg);
         }
     }
 }
@@ -654,7 +714,7 @@ STATIC void need_stack_settled(emit_t *emit) {
         if (si->kind == STACK_REG) {
             DEBUG_printf("    reg(%u) to local(%u)\n", si->data.u_reg, emit->stack_start + i);
             si->kind = STACK_VALUE;
-            ASM_MOV_LOCAL_REG(emit->as, emit->stack_start + i, si->data.u_reg);
+            emit_native_mov_state_reg(emit, emit->stack_start + i, si->data.u_reg);
         }
     }
     for (int i = 0; i < emit->stack_size; i++) {
@@ -662,7 +722,7 @@ STATIC void need_stack_settled(emit_t *emit) {
         if (si->kind == STACK_IMM) {
             DEBUG_printf("    imm(" INT_FMT ") to local(%u)\n", si->data.u_imm, emit->stack_start + i);
             si->kind = STACK_VALUE;
-            ASM_MOV_LOCAL_IMM_VIA(emit->as, emit->stack_start + i, si->data.u_imm, REG_TEMP0);
+            emit_native_mov_local_imm_via(emit, emit->stack_start + i, si->data.u_imm, REG_TEMP0);
         }
     }
 }
@@ -674,7 +734,7 @@ STATIC void emit_access_stack(emit_t *emit, int pos, vtype_kind_t *vtype, int re
     *vtype = si->vtype;
     switch (si->kind) {
         case STACK_VALUE:
-            ASM_MOV_REG_LOCAL(emit->as, reg_dest, emit->stack_start + emit->stack_size - pos);
+            emit_native_mov_reg_state(emit, reg_dest, emit->stack_start + emit->stack_size - pos);
             break;
 
         case STACK_REG:
@@ -696,7 +756,7 @@ STATIC void emit_fold_stack_top(emit_t *emit, int reg_dest) {
     si[0] = si[1];
     if (si->kind == STACK_VALUE) {
         // if folded element was on the stack we need to put it in a register
-        ASM_MOV_REG_LOCAL(emit->as, reg_dest, emit->stack_start + emit->stack_size - 1);
+        emit_native_mov_reg_state(emit, reg_dest, emit->stack_start + emit->stack_size - 1);
         si->kind = STACK_REG;
         si->data.u_reg = reg_dest;
     }
@@ -819,19 +879,19 @@ STATIC void emit_get_stack_pointer_to_reg_for_pop(emit_t *emit, mp_uint_t reg_de
             si->kind = STACK_VALUE;
             switch (si->vtype) {
                 case VTYPE_PYOBJ:
-                    ASM_MOV_LOCAL_IMM_VIA(emit->as, emit->stack_start + emit->stack_size - 1 - i, si->data.u_imm, reg_dest);
+                    emit_native_mov_local_imm_via(emit, emit->stack_start + emit->stack_size - 1 - i, si->data.u_imm, reg_dest);
                     break;
                 case VTYPE_BOOL:
                     if (si->data.u_imm == 0) {
-                        ASM_MOV_LOCAL_IMM_VIA(emit->as, emit->stack_start + emit->stack_size - 1 - i, (mp_uint_t)mp_const_false, reg_dest);
+                        emit_native_mov_local_imm_via(emit, emit->stack_start + emit->stack_size - 1 - i, (mp_uint_t)mp_const_false, reg_dest);
                     } else {
-                        ASM_MOV_LOCAL_IMM_VIA(emit->as, emit->stack_start + emit->stack_size - 1 - i, (mp_uint_t)mp_const_true, reg_dest);
+                        emit_native_mov_local_imm_via(emit, emit->stack_start + emit->stack_size - 1 - i, (mp_uint_t)mp_const_true, reg_dest);
                     }
                     si->vtype = VTYPE_PYOBJ;
                     break;
                 case VTYPE_INT:
                 case VTYPE_UINT:
-                    ASM_MOV_LOCAL_IMM_VIA(emit->as, emit->stack_start + emit->stack_size - 1 - i, (uintptr_t)MP_OBJ_NEW_SMALL_INT(si->data.u_imm), reg_dest);
+                    emit_native_mov_local_imm_via(emit, emit->stack_start + emit->stack_size - 1 - i, (uintptr_t)MP_OBJ_NEW_SMALL_INT(si->data.u_imm), reg_dest);
                     si->vtype = VTYPE_PYOBJ;
                     break;
                 default:
@@ -849,9 +909,9 @@ STATIC void emit_get_stack_pointer_to_reg_for_pop(emit_t *emit, mp_uint_t reg_de
         stack_info_t *si = &emit->stack_info[emit->stack_size - 1 - i];
         if (si->vtype != VTYPE_PYOBJ) {
             mp_uint_t local_num = emit->stack_start + emit->stack_size - 1 - i;
-            ASM_MOV_REG_LOCAL(emit->as, REG_ARG_1, local_num);
+            emit_native_mov_reg_state(emit, REG_ARG_1, local_num);
             emit_call_with_imm_arg(emit, MP_F_CONVERT_NATIVE_TO_OBJ, si->vtype, REG_ARG_2); // arg2 = type
-            ASM_MOV_LOCAL_REG(emit->as, local_num, REG_RET);
+            emit_native_mov_state_reg(emit, local_num, REG_RET);
             si->vtype = VTYPE_PYOBJ;
             DEBUG_printf("  convert_native_to_obj(local_num=" UINT_FMT ")\n", local_num);
         }
@@ -859,7 +919,7 @@ STATIC void emit_get_stack_pointer_to_reg_for_pop(emit_t *emit, mp_uint_t reg_de
 
     // Adujust the stack for a pop of n_pop items, and load the stack pointer into reg_dest.
     adjust_stack(emit, -n_pop);
-    ASM_MOV_REG_LOCAL_ADDR(emit->as, reg_dest, emit->stack_start + emit->stack_size);
+    emit_native_mov_reg_state_addr(emit, reg_dest, emit->stack_start + emit->stack_size);
 }
 
 // vtype of all n_push objects is VTYPE_PYOBJ
@@ -870,7 +930,7 @@ STATIC void emit_get_stack_pointer_to_reg_for_push(emit_t *emit, mp_uint_t reg_d
         emit->stack_info[emit->stack_size + i].kind = STACK_VALUE;
         emit->stack_info[emit->stack_size + i].vtype = VTYPE_PYOBJ;
     }
-    ASM_MOV_REG_LOCAL_ADDR(emit->as, reg_dest, emit->stack_start + emit->stack_size);
+    emit_native_mov_reg_state_addr(emit, reg_dest, emit->stack_start + emit->stack_size);
     adjust_stack(emit, n_push);
 }
 
@@ -932,7 +992,7 @@ STATIC void emit_load_reg_with_ptr(emit_t *emit, int reg, mp_uint_t ptr, size_t 
     if (emit->pass == MP_PASS_EMIT) {
         emit->const_table[table_off] = ptr;
     }
-    ASM_MOV_REG_LOCAL(emit->as, REG_TEMP0, LOCAL_IDX_FUN_OBJ(emit));
+    emit_native_mov_reg_state(emit, REG_TEMP0, LOCAL_IDX_FUN_OBJ(emit));
     ASM_LOAD_REG_REG_OFFSET(emit->as, REG_TEMP0, REG_TEMP0, offsetof(mp_obj_fun_bc_t, const_table) / sizeof(uintptr_t));
     ASM_LOAD_REG_REG_OFFSET(emit->as, reg, REG_TEMP0, table_off);
 }
@@ -985,17 +1045,21 @@ STATIC void emit_native_global_exc_entry(emit_t *emit) {
         mp_uint_t start_label = *emit->label_slot + 2;
         mp_uint_t global_except_label = *emit->label_slot + 3;
 
+        if (!(emit->scope->scope_flags & MP_SCOPE_FLAG_GENERATOR)) {
         // Set new globals
-        ASM_MOV_REG_LOCAL(emit->as, REG_ARG_1, LOCAL_IDX_FUN_OBJ(emit));
+        emit_native_mov_reg_state(emit, REG_ARG_1, LOCAL_IDX_FUN_OBJ(emit));
         ASM_LOAD_REG_REG_OFFSET(emit->as, REG_ARG_1, REG_ARG_1, offsetof(mp_obj_fun_bc_t, globals) / sizeof(uintptr_t));
         emit_call(emit, MP_F_NATIVE_SWAP_GLOBALS);
 
         // Save old globals (or NULL if globals didn't change)
-        ASM_MOV_LOCAL_REG(emit->as, LOCAL_IDX_OLD_GLOBALS(emit), REG_RET);
+        emit_native_mov_state_reg(emit, LOCAL_IDX_OLD_GLOBALS(emit), REG_RET);
+        }
 
         if (emit->scope->exc_stack_size == 0) {
             // Optimisation: if globals didn't change don't push the nlr context
+            if (!(emit->scope->scope_flags & MP_SCOPE_FLAG_GENERATOR)) {
             ASM_JUMP_IF_REG_ZERO(emit->as, REG_RET, start_label, false);
+            }
 
             // Wrap everything in an nlr context
             ASM_MOV_REG_LOCAL_ADDR(emit->as, REG_ARG_1, 0);
@@ -1028,16 +1092,41 @@ STATIC void emit_native_global_exc_entry(emit_t *emit) {
             ASM_JUMP_IF_REG_NONZERO(emit->as, REG_LOCAL_1, nlr_label, false);
         }
 
+        if (!(emit->scope->scope_flags & MP_SCOPE_FLAG_GENERATOR)) {
         // Restore old globals
-        ASM_MOV_REG_LOCAL(emit->as, REG_ARG_1, LOCAL_IDX_OLD_GLOBALS(emit));
+        emit_native_mov_reg_state(emit, REG_ARG_1, LOCAL_IDX_OLD_GLOBALS(emit));
         emit_call(emit, MP_F_NATIVE_SWAP_GLOBALS);
+        }
 
+        if (emit->scope->scope_flags & MP_SCOPE_FLAG_GENERATOR) {
+            // Store return value in state[0]
+            ASM_MOV_REG_LOCAL(emit->as, REG_TEMP0, LOCAL_IDX_EXC_VAL(emit));
+            ASM_STORE_REG_REG_OFFSET(emit->as, REG_TEMP0, REG_GENERATOR_STATE, offsetof(mp_code_state_t, state) / sizeof(uintptr_t));
+
+            // Load return kind
+            ASM_MOV_REG_IMM(emit->as, REG_RET, MP_VM_RETURN_EXCEPTION);
+
+            ASM_EXIT(emit->as);
+        } else {
         // Re-raise exception out to caller
         ASM_MOV_REG_LOCAL(emit->as, REG_ARG_1, LOCAL_IDX_EXC_VAL(emit));
         emit_call(emit, MP_F_NATIVE_RAISE);
+        }
 
         // Label for start of function
         emit_native_label_assign(emit, start_label);
+
+        if (emit->scope->scope_flags & MP_SCOPE_FLAG_GENERATOR) {
+            emit_native_mov_reg_state(emit, REG_TEMP0, LOCAL_IDX_GEN_PC(emit));
+            ASM_JUMP_REG(emit->as, REG_TEMP0);
+            emit->start_offset = mp_asm_base_get_code_pos(&emit->as->base);
+
+            // This is the first entry of the generator
+
+            // Check LOCAL_IDX_EXC_VAL for any injected value
+            ASM_MOV_REG_LOCAL(emit->as, REG_ARG_1, LOCAL_IDX_EXC_VAL(emit));
+            emit_call(emit, MP_F_NATIVE_RAISE);
+        }
     }
 }
 
@@ -1047,8 +1136,11 @@ STATIC void emit_native_global_exc_exit(emit_t *emit) {
 
     if (NEED_GLOBAL_EXC_HANDLER(emit)) {
         // Get old globals
-        ASM_MOV_REG_LOCAL(emit->as, REG_ARG_1, LOCAL_IDX_OLD_GLOBALS(emit));
+        if (!(emit->scope->scope_flags & MP_SCOPE_FLAG_GENERATOR)) {
+        emit_native_mov_reg_state(emit, REG_ARG_1, LOCAL_IDX_OLD_GLOBALS(emit));
 
+        if (emit->scope->scope_flags & MP_SCOPE_FLAG_GENERATOR) {
+        } else
         if (emit->scope->exc_stack_size == 0) {
             // Optimisation: if globals didn't change then don't restore them and don't do nlr_pop
             ASM_JUMP_IF_REG_ZERO(emit->as, REG_ARG_1, emit->exit_label + 1, false);
@@ -1056,10 +1148,13 @@ STATIC void emit_native_global_exc_exit(emit_t *emit) {
 
         // Restore old globals
         emit_call(emit, MP_F_NATIVE_SWAP_GLOBALS);
+        }
 
         // Pop the nlr context
         emit_call(emit, MP_F_NLR_POP);
 
+        if (emit->scope->scope_flags & MP_SCOPE_FLAG_GENERATOR) {
+        } else
         if (emit->scope->exc_stack_size == 0) {
             // Destination label for above optimisation
             emit_native_label_assign(emit, emit->exit_label + 1);
@@ -1067,6 +1162,11 @@ STATIC void emit_native_global_exc_exit(emit_t *emit) {
 
         // Load return value
         ASM_MOV_REG_LOCAL(emit->as, REG_RET, LOCAL_IDX_RET_VAL(emit));
+
+        if (emit->scope->scope_flags & MP_SCOPE_FLAG_GENERATOR) {
+            // Store return kind in ip (need to do it here because LOCAL_IDX_OLD_GLOBALS uses ip)
+            //ASM_STORE_REG_REG_OFFSET(emit->as, REG_LOCAL_2, REG_LOCAL_1, offsetof(mp_code_state_t, ip) / sizeof(uintptr_t));
+        }
     }
 
     ASM_EXIT(emit->as);
@@ -1212,7 +1312,7 @@ STATIC void emit_native_load_fast(emit_t *emit, qstr qst, mp_uint_t local_num) {
         emit_post_push_reg(emit, vtype, reg_local_table[local_num]);
     } else {
         need_reg_single(emit, REG_TEMP0, 0);
-        ASM_MOV_REG_LOCAL(emit->as, REG_TEMP0, LOCAL_IDX_LOCAL_VAR(emit, local_num));
+        emit_native_mov_reg_state(emit, REG_TEMP0, LOCAL_IDX_LOCAL_VAR(emit, local_num));
         emit_post_push_reg(emit, vtype, REG_TEMP0);
     }
 }
@@ -1431,7 +1531,7 @@ STATIC void emit_native_store_fast(emit_t *emit, qstr qst, mp_uint_t local_num) 
         emit_pre_pop_reg(emit, &vtype, reg_local_table[local_num]);
     } else {
         emit_pre_pop_reg(emit, &vtype, REG_TEMP0);
-        ASM_MOV_LOCAL_REG(emit->as, LOCAL_IDX_LOCAL_VAR(emit, local_num), REG_TEMP0);
+        emit_native_mov_state_reg(emit, LOCAL_IDX_LOCAL_VAR(emit, local_num), REG_TEMP0);
     }
     emit_post(emit);
 
@@ -2464,6 +2564,20 @@ STATIC void emit_native_call_method(emit_t *emit, mp_uint_t n_positional, mp_uin
 
 STATIC void emit_native_return_value(emit_t *emit) {
     DEBUG_printf("return_value\n");
+    if (emit->scope->scope_flags & MP_SCOPE_FLAG_GENERATOR) {
+        // Save pointer to current stack position for caller to access return value
+        emit_get_stack_pointer_to_reg_for_pop(emit, REG_TEMP0, 1);
+        emit_native_mov_state_reg(emit, offsetof(mp_code_state_t, sp) / sizeof(uintptr_t), REG_TEMP0);
+
+        // Put return type in return value slot
+        ASM_MOV_REG_IMM(emit->as, REG_TEMP0, MP_VM_RETURN_NORMAL);
+        ASM_MOV_LOCAL_REG(emit->as, LOCAL_IDX_RET_VAL(emit), REG_TEMP0);
+
+        // Do the unwinding jump to get to the return handler
+        emit_native_unwind_jump(emit, emit->exit_label, emit->exc_stack_size);
+        emit->last_emit_was_return_value = true;
+        return;
+    }
     if (emit->do_viper_types) {
         vtype_kind_t return_vtype = emit->scope->scope_flags >> MP_SCOPE_FLAG_VIPERRET_POS;
         if (peek_vtype(emit, 0) == VTYPE_PTR_NONE) {
@@ -2510,10 +2624,87 @@ STATIC void emit_native_raise_varargs(emit_t *emit, mp_uint_t n_args) {
 }
 
 STATIC void emit_native_yield(emit_t *emit, int kind) {
-    // not supported (for now)
-    (void)emit;
-    (void)kind;
-    mp_raise_NotImplementedError("native yield");
+    // Note: 1 (yield) or 3 (yield from) labels are reserved for this function, starting at *emit->label_slot
+
+    if (emit->do_viper_types) {
+        mp_raise_NotImplementedError("native yield");
+    }
+    emit->scope->scope_flags |= MP_SCOPE_FLAG_GENERATOR;
+
+    vtype_kind_t vtype;
+
+    if (kind == MP_EMIT_YIELD_FROM) {
+
+        // Top of yield-from loop, implementing:
+        //     for item in generator:
+        //         yield item
+
+        // Jump to start of loop
+        emit_native_jump(emit, *emit->label_slot + 2);
+
+        // Label for top of loop
+        emit_native_label_assign(emit, *emit->label_slot + 1);
+    }
+
+    // Yield the value from the delegate generator
+    need_stack_settled(emit); // TODO is this needed?
+
+    // Save return value for the global exception handler to use
+    emit_get_stack_pointer_to_reg_for_pop(emit, REG_TEMP0, 1);
+    emit_native_mov_state_reg(emit, offsetof(mp_code_state_t, sp) / sizeof(uintptr_t), REG_TEMP0);
+
+    // Put return type in REG_LOCAL_2 (to be put in ip by emit_native_global_exc_exit)
+    ASM_MOV_REG_IMM(emit->as, REG_TEMP0, MP_VM_RETURN_YIELD);
+    ASM_MOV_LOCAL_REG(emit->as, LOCAL_IDX_RET_VAL(emit), REG_TEMP0);
+
+    // Save re-entry PC
+    ASM_MOV_REG_PCREL(emit->as, REG_TEMP1, *emit->label_slot);
+    emit_native_mov_state_reg(emit, LOCAL_IDX_GEN_PC(emit), REG_TEMP1);
+
+    // Jump to exit handler
+    ASM_JUMP(emit->as, emit->exit_label);
+
+    // Label re-entry point
+    mp_asm_base_label_assign(&emit->as->base, *emit->label_slot);
+
+    // Re-open any active exception handler
+    if (emit->exc_stack_size > 0) {
+        // Find innermost active exception handler, to restore as current handler
+        exc_stack_entry_t *e = &emit->exc_stack[emit->exc_stack_size - 1];
+        for (; e >= emit->exc_stack; --e) {
+            if (e->is_active) {
+                // Found active handler, get its PC
+                ASM_MOV_REG_PCREL(emit->as, REG_RET, e->label);
+                ASM_MOV_LOCAL_REG(emit->as, LOCAL_IDX_EXC_HANDLER_PC(emit), REG_RET);
+            }
+        }
+    }
+
+    emit_native_adjust_stack_size(emit, 1); // send value
+
+    if (kind == MP_EMIT_YIELD_VALUE) {
+        // Check LOCAL_IDX_EXC_VAL for any injected value
+        ASM_MOV_REG_LOCAL(emit->as, REG_ARG_1, LOCAL_IDX_EXC_VAL(emit));
+        emit_call(emit, MP_F_NATIVE_RAISE);
+    } else {
+        // Label for loop entry
+        emit_native_label_assign(emit, *emit->label_slot + 2);
+
+        // Get the next item from the delegate generator
+        emit_pre_pop_reg(emit, &vtype, REG_ARG_2); // send_value
+        emit_access_stack(emit, 1, &vtype, REG_ARG_1); // generator
+        ASM_MOV_REG_LOCAL(emit->as, REG_ARG_3, LOCAL_IDX_EXC_VAL(emit)); // throw_value
+        emit_post_push_reg(emit, VTYPE_PYOBJ, REG_ARG_3);
+        emit_get_stack_pointer_to_reg_for_pop(emit, REG_ARG_3, 1); // ret_value
+        emit_call(emit, MP_F_NATIVE_YIELD_FROM);
+
+        // If returned non-zero then generator continues
+        ASM_JUMP_IF_REG_NONZERO(emit->as, REG_RET, *emit->label_slot + 1, true);
+
+        // Pop exhausted gen, replace with ret_value
+        emit_native_adjust_stack_size(emit, 1); // ret_value
+        emit_fold_stack_top(emit, REG_ARG_1);
+    }
 }
 
 STATIC void emit_native_start_except_handler(emit_t *emit) {

--- a/py/emitnx86.c
+++ b/py/emitnx86.c
@@ -66,6 +66,7 @@ STATIC byte mp_f_n_args[MP_F_NUMBER_OF] = {
     [MP_F_SETUP_CODE_STATE] = 4,
     [MP_F_SMALL_INT_FLOOR_DIVIDE] = 2,
     [MP_F_SMALL_INT_MODULO] = 2,
+    [MP_F_NATIVE_YIELD_FROM] = 3,
 };
 
 #define N_X86 (1)

--- a/py/obj.h
+++ b/py/obj.h
@@ -558,6 +558,7 @@ extern const mp_obj_type_t mp_type_zip;
 extern const mp_obj_type_t mp_type_array;
 extern const mp_obj_type_t mp_type_super;
 extern const mp_obj_type_t mp_type_gen_wrap;
+extern const mp_obj_type_t mp_type_native_gen_wrap;
 extern const mp_obj_type_t mp_type_gen_instance;
 extern const mp_obj_type_t mp_type_fun_builtin_0;
 extern const mp_obj_type_t mp_type_fun_builtin_1;

--- a/py/objfun.c
+++ b/py/objfun.c
@@ -154,7 +154,7 @@ STATIC const mp_obj_type_t mp_type_fun_native;
 qstr mp_obj_fun_get_name(mp_const_obj_t fun_in) {
     const mp_obj_fun_bc_t *fun = MP_OBJ_TO_PTR(fun_in);
     #if MICROPY_EMIT_NATIVE
-    if (fun->base.type == &mp_type_fun_native) {
+    if (fun->base.type == &mp_type_fun_native || fun->base.type == &mp_type_native_gen_wrap) {
         // TODO native functions don't have name stored
         return MP_QSTR_;
     }

--- a/py/objgenerator.c
+++ b/py/objgenerator.c
@@ -74,6 +74,47 @@ const mp_obj_type_t mp_type_gen_wrap = {
 };
 
 /******************************************************************************/
+// native generator wrapper
+
+#if MICROPY_EMIT_NATIVE
+
+STATIC mp_obj_t native_gen_wrap_call(mp_obj_t self_in, size_t n_args, size_t n_kw, const mp_obj_t *args) {
+    // A native generating function is just a bytecode function with type mp_type_native_gen_wrap
+    mp_obj_fun_bc_t *self_fun = MP_OBJ_TO_PTR(self_in);
+
+    const byte *ip = (const byte*)((uintptr_t*)self_fun->bytecode)[0];
+    size_t n_state = mp_decode_uint_value(self_fun->bytecode + (size_t)ip);
+    size_t n_exc_stack = 0;
+
+    // allocate the generator object, with room for local stack and exception stack
+    mp_obj_gen_instance_t *o = m_new_obj_var(mp_obj_gen_instance_t, byte,
+        n_state * sizeof(mp_obj_t) + n_exc_stack * sizeof(mp_exc_stack_t));
+    o->base.type = &mp_type_gen_instance;
+
+    o->globals = self_fun->globals;
+    o->code_state.fun_bc = self_fun;
+    o->code_state.ip = ip;
+    mp_setup_code_state(&o->code_state, n_args, n_kw, args);
+
+    o->code_state.exc_sp = NULL; // indicate we are a native function, which doesn't use this variable
+    o->code_state.ip = MICROPY_MAKE_POINTER_CALLABLE((void*)(self_fun->bytecode + ((uintptr_t*)self_fun->bytecode)[1]));
+
+    return MP_OBJ_FROM_PTR(o);
+}
+
+const mp_obj_type_t mp_type_native_gen_wrap = {
+    { &mp_type_type },
+    .name = MP_QSTR_generator,
+    .call = native_gen_wrap_call,
+    .unary_op = mp_generic_unary_op,
+    #if MICROPY_PY_FUNCTION_ATTRS
+    .attr = mp_obj_fun_bc_attr,
+    #endif
+};
+
+#endif // MICROPY_EMIT_NATIVE
+
+/******************************************************************************/
 /* generator instance                                                         */
 
 STATIC void gen_instance_print(const mp_print_t *print, mp_obj_t self_in, mp_print_kind_t kind) {
@@ -118,7 +159,21 @@ mp_vm_return_kind_t mp_obj_gen_resume(mp_obj_t self_in, mp_obj_t send_value, mp_
     self->code_state.old_globals = mp_globals_get();
     mp_globals_set(self->globals);
     self->globals = NULL;
-    mp_vm_return_kind_t ret_kind = mp_execute_bytecode(&self->code_state, throw_value);
+
+    mp_vm_return_kind_t ret_kind;
+
+    #if MICROPY_EMIT_NATIVE
+    if (self->code_state.exc_sp == NULL) {
+        // A native generator
+        typedef uintptr_t (*mp_fun_native_gen_t)(void*, mp_obj_t);
+        mp_fun_native_gen_t fun = MICROPY_MAKE_POINTER_CALLABLE((const void*)(self->code_state.fun_bc->bytecode + 2 * sizeof(uintptr_t)));
+        ret_kind = fun((void*)&self->code_state, throw_value);
+    } else
+    #endif
+    {
+        ret_kind = mp_execute_bytecode(&self->code_state, throw_value);
+    }
+
     self->globals = mp_globals_get();
     mp_globals_set(self->code_state.old_globals);
 

--- a/py/runtime0.h
+++ b/py/runtime0.h
@@ -197,6 +197,7 @@ typedef enum {
     MP_F_SETUP_CODE_STATE,
     MP_F_SMALL_INT_FLOOR_DIVIDE,
     MP_F_SMALL_INT_MODULO,
+    MP_F_NATIVE_YIELD_FROM,
     MP_F_NUMBER_OF,
 } mp_fun_kind_t;
 

--- a/tests/run-tests
+++ b/tests/run-tests
@@ -352,30 +352,20 @@ def run_tests(pyb, tests, args, base_path="."):
     # Some tests are known to fail with native emitter
     # Remove them from the below when they work
     if args.emit == 'native':
-        skip_tests.update({'basics/%s.py' % t for t in 'gen_yield_from gen_yield_from_close gen_yield_from_ducktype gen_yield_from_exc gen_yield_from_executing gen_yield_from_iter gen_yield_from_send gen_yield_from_stopped gen_yield_from_throw gen_yield_from_throw2 gen_yield_from_throw3 generator1 generator2 generator_args generator_close generator_closure generator_exc generator_name generator_pend_throw generator_return generator_send generator_throw generator_pep479'.split()}) # require yield
-        skip_tests.update({'basics/%s.py' % t for t in 'bytes_gen class_store_class globals_del string_join'.split()}) # require yield
-        skip_tests.update({'basics/async_%s.py' % t for t in 'def await await2 for for2 with with2 with_break with_return'.split()}) # require yield
+        skip_tests.update({'basics/%s.py' % t for t in 'gen_yield_from_close generator_name'.split()}) # require raise_varargs, generator name
+        skip_tests.update({'basics/async_%s.py' % t for t in 'with with2 with_break with_return'.split()}) # require async_with
         skip_tests.update({'basics/%s.py' % t for t in 'try_reraise try_reraise2'.split()}) # require raise_varargs
-        skip_tests.add('basics/array_construct2.py') # requires generators
-        skip_tests.add('basics/builtin_hash_gen.py') # requires yield
-        skip_tests.add('basics/class_bind_self.py') # requires yield
         skip_tests.add('basics/del_deref.py') # requires checking for unbound local
         skip_tests.add('basics/del_local.py') # requires checking for unbound local
         skip_tests.add('basics/exception_chain.py') # raise from is not supported
-        skip_tests.add('basics/for_range.py') # requires yield_value
         skip_tests.add('basics/try_finally_return2.py') # requires raise_varargs
         skip_tests.add('basics/unboundlocal.py') # requires checking for unbound local
-        skip_tests.add('import/gen_context.py') # requires yield_value
         skip_tests.add('misc/features.py') # requires raise_varargs
-        skip_tests.add('misc/rge_sm.py') # requires yield
         skip_tests.add('misc/print_exception.py') # because native doesn't have proper traceback info
         skip_tests.add('misc/sys_exc_info.py') # sys.exc_info() is not supported for native
         skip_tests.add('micropython/emg_exc.py') # because native doesn't have proper traceback info
         skip_tests.add('micropython/heapalloc_traceback.py') # because native doesn't have proper traceback info
-        skip_tests.add('micropython/heapalloc_iter.py') # requires generators
         skip_tests.add('micropython/schedule.py') # native code doesn't check pending events
-        skip_tests.add('stress/gc_trace.py') # requires yield
-        skip_tests.add('stress/recursive_gen.py') # requires yield
 
     for test_file in tests:
         test_file = test_file.replace('\\', '/')


### PR DESCRIPTION
This PR adds first class support for yield and yield-from in the native emitter, including send and throw support, and yields enclosed in exception handlers (highly non trivial because the native code needs to pull down the NLR stack before yielding, then rebuild it when resuming).

This has been fully tested and is working on unix x86 and x86-64, and stm32.  Also basic tests done on esp8266 port.  Performance of existing native code is unchanged.

Async support is almost complete as well, the only thing not working there is async-with statements.

Remaining things to do here:
- tidy up some incorrect comments
- correctly indent the code (to minimise the diff, existing code put in new if-statements was not indented, but should be)