### PR TITLE
stm32/sdram: Add board configuration to enable/disable gc heap on sdram

### DIFF
--- a/ports/stm32/boards/STM32F429DISC/mpconfigboard.h
+++ b/ports/stm32/boards/STM32F429DISC/mpconfigboard.h
@@ -76,6 +76,8 @@
 // SDRAM
 #define MICROPY_HW_SDRAM_SIZE  (64 / 8 * 1024 * 1024)  // 64 Mbit
 #define MICROPY_HW_SDRAM_STARTUP_TEST             (1)
+#define MICROPY_HEAP_START              sdram_start()
+#define MICROPY_HEAP_END                sdram_end()
 
 // Timing configuration for 90 Mhz (11.90ns) of SD clock frequency (180Mhz/2)
 #define MICROPY_HW_SDRAM_TIMING_TMRD        (2)

--- a/ports/stm32/boards/STM32F769DISC/mpconfigboard.h
+++ b/ports/stm32/boards/STM32F769DISC/mpconfigboard.h
@@ -83,6 +83,8 @@
 // Optional SDRAM configuration; requires SYSCLK <= 200MHz
 #define MICROPY_HW_SDRAM_SIZE (128 * 1024 * 1024 / 8) // 128 Mbit
 #define MICROPY_HW_SDRAM_STARTUP_TEST (0)
+#define MICROPY_HEAP_START sdram_start()
+#define MICROPY_HEAP_END sdram_end()
 
 // Timing configuration for 90 Mhz (11.90ns) of SD clock frequency (180Mhz/2)
 #define MICROPY_HW_SDRAM_TIMING_TMRD        (2)

--- a/ports/stm32/boards/STM32F7DISC/mpconfigboard.h
+++ b/ports/stm32/boards/STM32F7DISC/mpconfigboard.h
@@ -84,6 +84,8 @@ void STM32F7DISC_board_early_init(void);
 // SDRAM
 #define MICROPY_HW_SDRAM_SIZE  (64 / 8 * 1024 * 1024)  // 64 Mbit
 #define MICROPY_HW_SDRAM_STARTUP_TEST             (1)
+#define MICROPY_HEAP_START              sdram_start()
+#define MICROPY_HEAP_END                sdram_end()
 
 // Timing configuration for 90 Mhz (11.90ns) of SD clock frequency (180Mhz/2)
 #define MICROPY_HW_SDRAM_TIMING_TMRD        (2)

--- a/ports/stm32/main.c
+++ b/ports/stm32/main.c
@@ -498,6 +498,12 @@ void stm32_main(uint32_t reset_mode) {
     #endif
 
     // basic sub-system init
+    #if MICROPY_HW_SDRAM_SIZE
+    sdram_init();
+    #if MICROPY_HW_SDRAM_STARTUP_TEST
+    sdram_test(true);
+    #endif
+    #endif
     #if MICROPY_PY_THREAD
     pyb_thread_init(&pyb_thread_main);
     #endif
@@ -556,16 +562,7 @@ soft_reset:
     mp_stack_set_limit((char*)&_estack - (char*)&_heap_end - 1024);
 
     // GC init
-    #if MICROPY_HW_SDRAM_SIZE
-    sdram_init();
-    #if MICROPY_HW_SDRAM_STARTUP_TEST
-    sdram_test(true);
-    #endif
-
-    gc_init(sdram_start(), sdram_end());
-    #else
-    gc_init(&_heap_start, &_heap_end);
-    #endif
+    gc_init(MICROPY_HEAP_START, MICROPY_HEAP_END);
 
     #if MICROPY_ENABLE_PYSTACK
     static mp_obj_t pystack[384];

--- a/ports/stm32/mpconfigboard_common.h
+++ b/ports/stm32/mpconfigboard_common.h
@@ -221,3 +221,11 @@
 #endif
 
 #define MICROPY_HW_USES_BOOTLOADER (MICROPY_HW_VTOR != 0x08000000)
+
+// Heap start / end definitions
+#ifndef MICROPY_HEAP_START
+#define MICROPY_HEAP_START &_heap_start
+#endif
+#ifndef MICROPY_HEAP_END
+#define MICROPY_HEAP_END &_heap_end
+#endif


### PR DESCRIPTION
Enable `MICROPY_HW_SDRAM_USE_FOR_HEAP` in `mpconfigboard.h` for the python heap to be placed in sdram, else linker heap_start/heap_end will be preferentially used.

If `MICROPY_HW_SDRAM_USE_FOR_HEAP` is disabled the linker defined values can also be overridden by defining `MICROPY_HEAP_START` and `MICROPY_HEAP_END` for a completely custom heap range.

This PR also moves the sdram init much earlier in `main()` to potentially make it available to other peripherals and avoid re-initialisation on soft-reboot.