### PR TITLE
Fixup of  incorrect displaying the result of tests

### DIFF
--- a/ports/qemu-arm/Makefile.test
+++ b/ports/qemu-arm/Makefile.test
@@ -19,6 +19,4 @@ $(BUILD)/firmware-test.elf: $(OBJ_COMMON) $(OBJ_TEST)
 	$(Q)$(SIZE) $@
 
 test: $(BUILD)/firmware-test.elf
-	qemu-system-arm -machine integratorcp -cpu cortex-m3 -nographic -monitor null -serial null -semihosting -kernel $(BUILD)/firmware-test.elf > $(BUILD)/console.out
-	$(Q)tail -n2 $(BUILD)/console.out
-	$(Q)tail -n1 $(BUILD)/console.out | grep -q "status: 0"
+	qemu-system-arm -machine integratorcp -cpu cortex-m3 -nographic -monitor null -serial null -semihosting -kernel $(BUILD)/firmware-test.elf > $(BUILD)/console.out; tail -n2 $(BUILD)/console.out


### PR DESCRIPTION
On unknown reason qemu returns number one as successful result. This patch enable displaying the right test result.