### PR TITLE
py/gc.c fix crash caused by consecutive heap_unlock calls.

### DIFF
--- a/py/gc.c
+++ b/py/gc.c
@@ -180,7 +180,9 @@ void gc_lock(void) {
 
 void gc_unlock(void) {
     GC_ENTER();
-    MP_STATE_MEM(gc_lock_depth)--;
+    if (MP_STATE_MEM(gc_lock_depth) > 0) {
+        MP_STATE_MEM(gc_lock_depth)--;
+    }
     GC_EXIT();
 }
 


### PR DESCRIPTION
The following caused a memory failure:
```python
micropython.heap_unlock()
micropython.heap_unlock()
```