### PR TITLE
windows/msvc: Implement file/directory type query.

### DIFF
--- a/ports/windows/msvc/dirent.c
+++ b/ports/windows/msvc/dirent.c
@@ -42,8 +42,8 @@ DIR *opendir(const char *name) {
 
     DIR *dir = malloc(sizeof(DIR));
     if (!dir) {
-      errno = ENOMEM;
-      return NULL;
+        errno = ENOMEM;
+        return NULL;
     }
     dir->result.d_ino = 0;
     dir->result.d_name = NULL;
@@ -52,9 +52,9 @@ DIR *opendir(const char *name) {
     const size_t nameLen = strlen(name);
     char *path = malloc(nameLen + 3); // allocate enough for adding "/*"
     if (!path) {
-      free(dir);
-      errno = ENOMEM;
-      return NULL;
+        free(dir);
+        errno = ENOMEM;
+        return NULL;
     }
     strcpy(path, name);
 
@@ -69,9 +69,9 @@ DIR *opendir(const char *name) {
     dir->findHandle = FindFirstFile(path, &dir->findData);
     free(path);
     if (dir->findHandle == INVALID_HANDLE_VALUE) {
-      free(dir);
-      errno = ENOENT;
-      return NULL;
+        free(dir);
+        errno = ENOENT;
+        return NULL;
     }
     return dir;
 }

--- a/ports/windows/msvc/dirent.h
+++ b/ports/windows/msvc/dirent.h
@@ -31,18 +31,24 @@
 // for ino_t
 #include <sys/types.h>
 
+#define _DIRENT_HAVE_D_TYPE (1)
+#define DTTOIF dttoif
+
 // opaque DIR structure
 typedef struct DIR DIR;
 
 // the dirent structure
 // d_ino is always 0 - if ever needed use GetFileInformationByHandle
+// d_type can be converted using DTTOIF, into 0 (unknown) or MP_S_IFDIR or MP_S_IFREG
 typedef struct dirent {
     ino_t d_ino;
+    int d_type;
     char *d_name;
 } dirent;
 
 DIR *opendir(const char *name);
 int closedir(DIR *dir);
 struct dirent *readdir(DIR *dir);
+int dttoif(int d_type);
 
 #endif // MICROPY_INCLUDED_WINDOWS_MSVC_DIRENT_H


### PR DESCRIPTION
Add some more POSIX compatibility by adding a d_type field to the
dirent structure and defining corresponding macros so listdir_next
in the unix' port modos.c can use it, end result being uos.ilistdir
now reports the file type.

Note I fixed some whitespace issues; I recently started using clang-format for MicroPython as well and it matches the default syle pretty well (only changes indentation of the license comment) so no more worries about getting all indentation and whatnot right. If anyone is interested, this is the .clang-format file I have now:
```
---
BasedOnStyle: LLVM
IndentWidth: 4
TabWidth: 4
Language: Cpp
PointerAlignment: Right
ColumnLimit: 100
```
Ideally this would be part of the repository and everybody would use it pre-commit.