### PR TITLE
docs: Specify new machine.ADC and machine.ADCBlock classes

### DIFF
--- a/docs/library/machine.ADC.rst
+++ b/docs/library/machine.ADC.rst
@@ -8,28 +8,59 @@ The ADC class provides an interface to analog-to-digital convertors, and
 represents a single endpoint that can sample a continuous voltage and
 convert it to a discretised value.
 
+For extra control over ADC sampling see :ref:`machine.ADCBlock <machine.ADCBlock>`.
+
 Example usage::
 
-   import machine
+   from machine import ADC
 
-   adc = machine.ADC(pin)   # create an ADC object acting on a pin
-   val = adc.read_u16()     # read a raw analog value in the range 0-65535
+   adc = ADC(pin)        # create an ADC object acting on a pin
+   val = adc.read_u16()  # read a raw analog value in the range 0-65535
+   val = adc.read_uv()   # read an analog value in microvolts
 
 Constructors
 ------------
 
-.. class:: ADC(id)
+.. class:: ADC(id, *, sample_ns, atten)
 
    Access the ADC associated with a source identified by *id*.  This
    *id* may be an integer (usually specifying a channel number), a
    :ref:`Pin <machine.Pin>` object, or other value supported by the
    underlying machine.
 
+   If additional keyword-arguments are given then they will configure
+   various aspects of the ADC.  If not given, these settings will take
+   previous or default values.  The settings are:
+
+     - *sample_ns* is the sampling time in nanoseconds.
+
+     - *atten* specifies the input attenuation.
+
 Methods
 -------
+
+.. method:: ADC.init(*, sample_ns, atten)
+
+   Apply the given settings to the ADC.  Only those arguments that are
+   specified will be changed.  See the ADC constructor above for what the
+   arguments are.
+
+.. method:: ADC.block()
+
+   Return the :ref:`ADCBlock <machine.ADCBlock>` instance associated with
+   this ADC object.
+
+   This method only exists if the port supports the
+   :ref:`ADCBlock <machine.ADCBlock>` class.
 
 .. method:: ADC.read_u16()
 
    Take an analog reading and return an integer in the range 0-65535.
    The return value represents the raw reading taken by the ADC, scaled
    such that the minimum value is 0 and the maximum value is 65535.
+
+.. method:: ADC.read_uv()
+
+   Take an analog reading and return an integer value with units of
+   microvolts.  It is up to the particular port whether or not this value
+   is calibrated, and how calibration is done.

--- a/docs/library/machine.ADCBlock.rst
+++ b/docs/library/machine.ADCBlock.rst
@@ -1,0 +1,58 @@
+.. currentmodule:: machine
+.. _machine.ADCBlock:
+
+class ADCBlock -- control ADC peripherals
+=========================================
+
+The ADCBlock class provides access to an ADC peripheral which has a
+number of channels that can be used to sample analog values.  It allows
+finer control over configuration of :ref:`machine.ADC <machine.ADC>`
+objects, which do the actual sampling.
+
+This class is not always available.
+
+Example usage::
+
+   from machine import ADCBlock
+
+   block = ADCBlock(id, bits=12)  # create an ADCBlock with 12-bit resolution
+   adc = block.connect(4, pin)    # connect channel 4 to the given pin
+   val = adc.read_uv()            # read an analog value
+
+Constructors
+------------
+
+.. class:: ADCBlock(id, *, bits)
+
+   Access the ADC peripheral identified by *id*, which may be an integer
+   or string.
+   
+   The *bits* argument, if given, sets the resolution in bits of the
+   conversion process.  If not specified then the previous or default
+   resolution is used.
+
+Methods
+-------
+
+.. method:: ADCBlock.init(*, bits)
+
+   Configure the ADC peripheral.  *bits* will set the resolution of the
+   conversion process.
+
+.. method:: ADCBlock.connect(channel)
+            ADCBlock.connect(source)
+            ADCBlock.connect(channel, source)
+
+   Connect up a channel on the ADC peripheral so it is ready for sampling,
+   and return an :ref:`ADC <machine.ADC>` object that represents that connection.
+
+   The *channel* argument must be an integer, and *source* must be an object
+   (for example a :ref:`Pin <machine.Pin>`) which can be connected up for sampling.
+
+   If only *channel* is given then it is configured for sampling.
+
+   If only *source* is given then that object is connected to a default
+   channel ready for sampling.
+
+   If both *channel* and *source* are given then they are connected together
+   and made ready for sampling.

--- a/docs/library/machine.rst
+++ b/docs/library/machine.rst
@@ -199,6 +199,7 @@ Classes
    machine.Pin.rst
    machine.Signal.rst
    machine.ADC.rst
+   machine.ADCBlock.rst
    machine.PWM.rst
    machine.UART.rst
    machine.SPI.rst


### PR DESCRIPTION
Based on the discussion in #3943 here is my proposal for a revised `machine.ADC` class which is intended to be implemented by all ports to make the ADC class more standardised.  The changes here include a new `machine.ADCBlock` class as well, which is used to allow further configuration of ADC if a port supports it.

In summary the new interface is:
```python
ADC(id, *, sample_ns, gain_mult, gain_div) # create ADC object
ADC.init(sample_ns, gain_mult, gain_div) # initialise
val = ADC.read_u16() # read value between 0-65535
val = ADC.read_v() # read voltage, float
val = ADC.read_mv() # read mV, integer

ADCBlock(id, *, bits) # create ADC peripheral object
ADCBlock.init(bits) # initialise
adc = ADCBlock.connect(channel) # connect to a channel
adc = ADCBlock.connect(source) # connect up a pin or other object
adc = ADCBlock.connect(channel, source) # connect a channel to a pin
```

The API is split up this way into two classes (ADC and ADCBlock) so that basic and common functionality is easily available in the ADC class, and extended functionality is in ADCBlock.  A given port only needs to implement ADC if that is all it can do, and already that gives 80% of the functionality.  The ADC class is the one that would be used most of the time.

If a port wants to expose more control, and the user needs to use it, then the ADCBlock class is there for that.  It allows to specify the resolution, and which channels are connected to which pins.

All existing ports should be able to fit into this model without a problem.  In particular the gain settings can be used by nrf and esp32.  stm32 can use the sample time.

It should be possible to update the ports in a backwards-compatible way to this new API because most of the methods are new and don't clash with existing ones.  ADCBlock is completely new so won't clash with anything.

There is room for extensions to this API: ADC can have additional methods like `read_u24()` and `read_uv()`, and ADCBlock might get methods to read internal channels, like voltage references and temperature.

Note: it might be easier to read the diff of this PR in split view.