### PR TITLE
unix/moduselect: poll.unregister: Add optional throw=True param.

### DIFF
--- a/ports/unix/moduselect.c
+++ b/ports/unix/moduselect.c
@@ -130,7 +130,10 @@ STATIC mp_obj_t poll_register(size_t n_args, const mp_obj_t *args) {
 MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(poll_register_obj, 2, 3, poll_register);
 
 /// \method unregister(obj)
-STATIC mp_obj_t poll_unregister(mp_obj_t self_in, mp_obj_t obj_in) {
+STATIC mp_obj_t poll_unregister(size_t n_args, const mp_obj_t *args) {
+    mp_obj_t self_in = args[0];
+    mp_obj_t obj_in = args[1];
+
     mp_obj_poll_t *self = MP_OBJ_TO_PTR(self_in);
     struct pollfd *entries = self->entries;
     int fd = get_fd(obj_in);
@@ -140,15 +143,19 @@ STATIC mp_obj_t poll_unregister(mp_obj_t self_in, mp_obj_t obj_in) {
             if (self->obj_map) {
                 self->obj_map[entries - self->entries] = MP_OBJ_NULL;
             }
-            break;
+            return mp_const_true;
         }
         entries++;
     }
 
-    // TODO raise KeyError if obj didn't exist in map
-    return mp_const_none;
+    // If "throw" arg if False, don't raise exception.
+    if (n_args > 2 && args[2] == mp_const_false) {
+        return mp_const_false;
+    }
+
+    mp_raise_msg(&mp_type_KeyError, NULL);
 }
-MP_DEFINE_CONST_FUN_OBJ_2(poll_unregister_obj, poll_unregister);
+MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(poll_unregister_obj, 2, 3, poll_unregister);
 
 /// \method modify(obj, eventmask)
 STATIC mp_obj_t poll_modify(mp_obj_t self_in, mp_obj_t obj_in, mp_obj_t eventmask_in) {

--- a/tests/extmod/uselect_poll_basic.py
+++ b/tests/extmod/uselect_poll_basic.py
@@ -32,3 +32,8 @@ try:
     poller.modify(s, select.POLLIN)
 except OSError as e:
     assert e.args[0] == errno.ENOENT
+
+try:
+    poller.unregister(s)
+except KeyError:
+    print("KeyError")

--- a/tests/extmod/uselect_poll_unreg.py
+++ b/tests/extmod/uselect_poll_unreg.py
@@ -1,0 +1,19 @@
+# Test MicroPython's idempotent extension to poll.unregister().
+try:
+    import usocket as socket, uselect as select, uerrno as errno
+except ImportError:
+    print("SKIP")
+    raise SystemExit
+
+
+poller = select.poll()
+
+s = socket.socket()
+
+poller.register(s)
+
+print(poller.unregister(s, False))
+
+# Can unregister multiple times
+print(poller.unregister(s, False))
+print(poller.unregister(s, False))

--- a/tests/extmod/uselect_poll_unreg.py.exp
+++ b/tests/extmod/uselect_poll_unreg.py.exp
@@ -1,0 +1,3 @@
+True
+False
+False


### PR DESCRIPTION
If 2nd, positional only argument of False is passed to poll.unregister()
method, then it won't throw exception if passed a stream object not
registered with the poller, which was the previous behavior. Then default
behavior is made compatible with CPython's, which is to throw exception
in this case.