### PR TITLE
Docs: mchine.pin.rst Add note re. handler argument.

### DIFF
--- a/docs/library/machine.Pin.rst
+++ b/docs/library/machine.Pin.rst
@@ -191,7 +191,8 @@ Methods
    The arguments are:
 
      - ``handler`` is an optional function to be called when the interrupt
-       triggers.
+       triggers. The handler must take exactly one argument which is the
+       ``Pin`` instance.
 
      - ``trigger`` configures the event which can generate an interrupt.
        Possible values are:


### PR DESCRIPTION
The need for the interrupt handler to take an arg was undocumented.