### PR TITLE
docs/machine: Specify new class machine.PWM.

### DIFF
--- a/docs/library/machine.PWM.rst
+++ b/docs/library/machine.PWM.rst
@@ -61,12 +61,35 @@ Methods
 
    Disable the PWM output.
 
+.. method:: PWM.freq([value])
+
+   Get or set the current frequency of the PWM output.
+
+   With no arguments the frequency in Hz is returned.
+
+   With a single *value* argument the frequency is set to that value in Hz.  The
+   method may raise a ``ValueError`` if the frequency is outside the valid range.
+
 .. method:: PWM.duty_ticks(ticks)
 
    Change the duty cycle of the output, with the argument *ticks* measured in
    ``ticks_hz`` as set by the constructor or ``PWM.init``.  For example, if
    ``ticks_hz`` is 1000 then *ticks* is measured in milliseconds.
 
-.. method:: PWM.duty_u16(u16)
+.. method:: PWM.duty_u16([value])
 
-   Change the duty cycle of the output, measured as the ratio ``u16 / 65535``.
+   Get or set the current duty cycle of the PWM output, as an unsigned 16-bit
+   value in the range 0 to 65535 inclusive.
+
+   With no arguments the duty cycle is returned.
+
+   With a single *value* argument the duty cycle is set to that value, measured
+   as the ratio ``value / 65535``.
+
+.. method:: PWM.duty_ns([value])
+
+   Get or set the current duty cycle of the PWM output, as a value in nanoseconds.
+
+   With no arguments the duty cycle in nanoseconds is returned.
+
+   With a single *value* argument the duty cycle is set to that value.

--- a/docs/library/machine.PWM.rst
+++ b/docs/library/machine.PWM.rst
@@ -16,7 +16,7 @@ Example usage::
     # reinitialise with a period of 200us, duty of 5us
     pwm.init(freq=5000, duty_ns=5000)
 
-    pwm.duty_ns(3000)       # set duty to 3us
+    pwm.duty_ns(3000)       # set pulse width to 3us
 
     pwm.deinit()
 
@@ -33,7 +33,7 @@ Constructors
       - *freq* should be an integer which sets the frequency in Hz for the
         PWM cycle.
       - *duty_u16* sets the duty cycle as a ratio ``duty_u16 / 65535``.
-      - *duty_ns* sets the duty cycle in nanoseconds.
+      - *duty_ns* sets the pulse width in nanoseconds.
 
    Setting *freq* may affect other PWM objects if the objects share the same
    underlying PWM generator (this is hardware specific).
@@ -72,8 +72,8 @@ Methods
 
 .. method:: PWM.duty_ns([value])
 
-   Get or set the current duty cycle of the PWM output, as a value in nanoseconds.
+   Get or set the current pulse width of the PWM output, as a value in nanoseconds.
 
-   With no arguments the duty cycle in nanoseconds is returned.
+   With no arguments the pulse width in nanoseconds is returned.
 
-   With a single *value* argument the duty cycle is set to that value.
+   With a single *value* argument the pulse width is set to that value.

--- a/docs/library/machine.PWM.rst
+++ b/docs/library/machine.PWM.rst
@@ -13,46 +13,36 @@ Example usage::
     pwm = PWM(pin)          # create a PWM object on a pin
     pwm.duty_u16(32768)     # set duty to 50%
 
-    # reinitialise with a period of 20ms, duty of 2ms
-    pwm.init(period=20, tick_hz=1000, duty_ticks=2)
+    # reinitialise with a period of 200us, duty of 5us
+    pwm.init(freq=5000, duty_ns=5000)
 
-    pwm.duty_ticks(3)       # set duty to 3ms
+    pwm.duty_ns(3000)       # set duty to 3us
 
     pwm.deinit()
 
 Constructors
 ------------
 
-.. class:: PWM.init(dest, \*, freq, period, tick_hz, duty_ticks, duty_u16, block)
+.. class:: PWM(dest, \*, freq, duty_u16, duty_ns)
 
    Construct and return a new PWM object using the following parameters:
 
       - *dest* is the entity on which the PWM is output, which is usually a
-        `machine.Pin <machine.Pin>` object, but a port may allow other values,
+        :ref:`machine.Pin <machine.Pin>` object, but a port may allow other values,
         like integers.
-      - *freq* should be an integer which sets the frequency in Hz for the 
+      - *freq* should be an integer which sets the frequency in Hz for the
         PWM cycle.
-      - *period* should be an integer which sets the period of the PWM cycle.
-        The units of this are given by *tick_hz*.
-      - *tick_hz* gives the base unit by which *period* and *duty_ticks*
-        are measured.
-      - *duty_ticks* sets the duty cycle in ticks.
       - *duty_u16* sets the duty cycle as a ratio ``duty_u16 / 65535``.
-      - *block* allows for finer control over the underlying PWM generator
-        that is used for this PWM object, and the values it takes are port
-        specific (this parameter may or may not be supported by a port).
+      - *duty_ns* sets the duty cycle in nanoseconds.
 
-   Only one of *freq* and *period* should be specified at a time.  Setting these
-   values may affect other PWM objects if the objects share the same underlying
-   PWM generator (this is hardware specific).
-
-   The value of *tick_hz* will be saved and reused by the ``PWM.duty_ticks``
-   method.  This value is unique to each PWM object.
+   Setting *freq* may affect other PWM objects if the objects share the same
+   underlying PWM generator (this is hardware specific).
+   Only one of *duty_u16* and *duty_ns* should be specified at a time.
 
 Methods
 -------
 
-.. method:: PWM.init(\*, freq, period, tick_hz, duty_ticks, duty_u16)
+.. method:: PWM.init(\*, freq, duty_u16, duty_ns)
 
    Modify settings for the PWM object.  See the above constructor for details
    about the parameters.
@@ -69,12 +59,6 @@ Methods
 
    With a single *value* argument the frequency is set to that value in Hz.  The
    method may raise a ``ValueError`` if the frequency is outside the valid range.
-
-.. method:: PWM.duty_ticks(ticks)
-
-   Change the duty cycle of the output, with the argument *ticks* measured in
-   ``ticks_hz`` as set by the constructor or ``PWM.init``.  For example, if
-   ``ticks_hz`` is 1000 then *ticks* is measured in milliseconds.
 
 .. method:: PWM.duty_u16([value])
 

--- a/docs/library/machine.PWM.rst
+++ b/docs/library/machine.PWM.rst
@@ -1,0 +1,72 @@
+.. currentmodule:: machine
+.. _machine.PWM:
+
+class PWM -- pulse width modulation
+===================================
+
+This class provides pulse width modulation output.
+
+Example usage::
+
+    from machine import PWM
+
+    pwm = PWM(pin)          # create a PWM object on a pin
+    pwm.duty_u16(32768)     # set duty to 50%
+
+    # reinitialise with a period of 20ms, duty of 2ms
+    pwm.init(period=20, tick_hz=1000, duty_ticks=2)
+
+    pwm.duty_ticks(3)       # set duty to 3ms
+
+    pwm.deinit()
+
+Constructors
+------------
+
+.. class:: PWM.init(dest, \*, freq, period, tick_hz, duty_ticks, duty_u16, block)
+
+   Construct and return a new PWM object using the following parameters:
+
+      - *dest* is the entity on which the PWM is output, which is usually a
+        `machine.Pin <machine.Pin>` object, but a port may allow other values,
+        like integers.
+      - *freq* should be an integer which sets the frequency in Hz for the 
+        PWM cycle.
+      - *period* should be an integer which sets the period of the PWM cycle.
+        The units of this are given by *tick_hz*.
+      - *tick_hz* gives the base unit by which *period* and *duty_ticks*
+        are measured.
+      - *duty_ticks* sets the duty cycle in ticks.
+      - *duty_u16* sets the duty cycle as a ratio ``duty_u16 / 65535``.
+      - *block* allows for finer control over the underlying PWM generator
+        that is used for this PWM object, and the values it takes are port
+        specific (this parameter may or may not be supported by a port).
+
+   Only one of *freq* and *period* should be specified at a time.  Setting these
+   values may affect other PWM objects if the objects share the same underlying
+   PWM generator (this is hardware specific).
+
+   The value of *tick_hz* will be saved and reused by the ``PWM.duty_ticks``
+   method.  This value is unique to each PWM object.
+
+Methods
+-------
+
+.. method:: PWM.init(\*, freq, period, tick_hz, duty_ticks, duty_u16)
+
+   Modify settings for the PWM object.  See the above constructor for details
+   about the parameters.
+
+.. method:: PWM.deinit()
+
+   Disable the PWM output.
+
+.. method:: PWM.duty_ticks(ticks)
+
+   Change the duty cycle of the output, with the argument *ticks* measured in
+   ``ticks_hz`` as set by the constructor or ``PWM.init``.  For example, if
+   ``ticks_hz`` is 1000 then *ticks* is measured in milliseconds.
+
+.. method:: PWM.duty_u16(u16)
+
+   Change the duty cycle of the output, measured as the ratio ``u16 / 65535``.

--- a/docs/library/machine.rst
+++ b/docs/library/machine.rst
@@ -167,6 +167,7 @@ Classes
    machine.Pin.rst
    machine.Signal.rst
    machine.ADC.rst
+   machine.PWM.rst
    machine.UART.rst
    machine.SPI.rst
    machine.I2C.rst


### PR DESCRIPTION
As discussed previously in #2283, it would be good to have a simple PWM class in the machine module to allow for generating PWM output in a way that is portable across the different ports.  Such functionality may already be available in one way or another (eg through a Timer object), but because configuring PWM via a Timer is very port-specific, and because it's a common thing to do, it's beneficial to have a top-level construct for it.

The proposal here aims to provide all required functionality in a minimal way.  Some points about it:
- you can set frequency, or period of the PWM output
- you can set the duty in time (eg microseconds for the pulse width) or as a percentage ratio (eg 50%)
- because for most PWM implementations, changing the frequency/period will alter the duty cycle, changing the frequency/period on the object also allows to re-set the duty cycle in one call, namely `pwm.init(freq=..., duty_u16=...)`; counter to this, there's no way to just change the frequency/period.

It might be interesting to compare this with the proposal for ADC, #4213, because in a way they are related.  With the PWM class I didn't go the route of adding a PWMBlock for further configuration, but instead showed an alternative to this, by having a `block` parameter to the constructor which would allow to have finer control over which underlying hardware generator was used for the PWM object.