### PR TITLE
tools/pyboard.py: "except:"-block should mention exception explicitly

### DIFF
--- a/tools/pyboard.py
+++ b/tools/pyboard.py
@@ -111,7 +111,7 @@ class TelnetToSerial:
     def close(self):
         try:
             self.tn.close()
-        except:
+        except Exception:
             # the telnet object might not exist yet, so ignore this one
             pass
 

--- a/tools/pyboard.py
+++ b/tools/pyboard.py
@@ -86,6 +86,7 @@ class PyboardError(Exception):
 
 class TelnetToSerial:
     def __init__(self, ip, user, password, read_timeout=None):
+        self.tn = None
         import telnetlib
         self.tn = telnetlib.Telnet(ip, timeout=15)
         self.read_timeout = read_timeout
@@ -109,11 +110,8 @@ class TelnetToSerial:
         self.close()
 
     def close(self):
-        try:
+        if self.tn:
             self.tn.close()
-        except Exception:
-            # the telnet object might not exist yet, so ignore this one
-            pass
 
     def read(self, size=1):
         while len(self.fifo) < size:


### PR DESCRIPTION
The main reason for this small change is that pyboard.py introduces a warning in our code over at [Mu-editor](https://github.com/mu-editor/) project, where I'm are working on adding MicroPython support. 