### PR TITLE
ports/unix/Makefile: make float() constistent across cpu architectures

### DIFF
--- a/ports/unix/Makefile
+++ b/ports/unix/Makefile
@@ -30,7 +30,7 @@ ifdef DEBUG
 CFLAGS += -g
 COPT = -O0
 else
-COPT = -Os -fdata-sections -ffunction-sections -DNDEBUG
+COPT = -Os -ffp-contract=off -fdata-sections -ffunction-sections -DNDEBUG
 # _FORTIFY_SOURCE is a feature in gcc/glibc which is intended to provide extra
 # security for detecting buffer overflows. Some distros (Ubuntu at the very least)
 # have it enabled by default.


### PR DESCRIPTION
As discussed in forum thread https://forum.micropython.org/viewtopic.php?f=3&t=5332&p=30692#p30692

Because of the -Os optimization setting, the float() return values for ppc64le and x86_64 are calculated slightly differently because of the use of the Fuse Multiply-Add instructions. Adding the -ffp-contract=off compilation option will disable the use of the FMA instructions and make the values returned consistent across architectures(and generations) as desired under https://en.wikipedia.org/wiki/IEEE_754  