### PR TITLE
stm32/usb_cdc: Add VCP support to uos.dupterm

### DIFF
--- a/docs/library/pyb.rst
+++ b/docs/library/pyb.rst
@@ -243,10 +243,6 @@ Miscellaneous functions
    If ``mkfs`` is ``True``, then a new filesystem is created if one does not
    already exist.
 
-.. function:: repl_uart(uart)
-
-   Get or set the UART object where the REPL is repeated on.
-
 .. function:: rng()
 
    Return a 30-bit hardware generated random number.

--- a/docs/library/uos.rst
+++ b/docs/library/uos.rst
@@ -123,10 +123,10 @@ Terminal redirection and duplication
    After calling this function all terminal output is repeated on this stream,
    and any input that is available on the stream is passed on to the terminal input.
 
-   The *index* parameter should be a non-negative integer and specifies which
-   duplication slot is set.  A given port may implement more than one slot (slot 0
-   will always be available) and in that case terminal input and output is
-   duplicated on all the slots that are set.
+   The *index* parameter should be a non-negative integer to specify which
+   duplication slot is set, or ``None`` to use first free slot.  
+   A given port may implement more than one slot (slot 0 will always be available) and 
+   in that case terminal input and output is duplicated on all the slots that are set.
 
    If ``None`` is passed as the *stream_object* then duplication is cancelled on
    the slot given by *index*.

--- a/docs/pyboard/quickref.rst
+++ b/docs/pyboard/quickref.rst
@@ -36,7 +36,6 @@ See :mod:`pyb`. ::
 
     import pyb
 
-    pyb.repl_uart(pyb.UART(1, 9600)) # duplicate REPL on UART(1)
     pyb.wfi() # pause CPU, waiting for interrupt
     pyb.freq() # get CPU and bus frequencies
     pyb.freq(60000000) # set CPU freq to 60MHz

--- a/docs/pyboard/tutorial/lcd160cr_skin.rst
+++ b/docs/pyboard/tutorial/lcd160cr_skin.rst
@@ -121,7 +121,8 @@ use ``uart = pyb.UART('YA', 115200)`` instead.
 
 Now, connect the REPL output to this UART::
 
-    >>> pyb.repl_uart(uart)
+    >>> import uos
+    >>> uos.dupterm(uart, None)
 
 From now on anything you type at the MicroPython prompt, and any output you
 receive, will appear on the display.

--- a/ports/stm32/modpyb.c
+++ b/ports/stm32/modpyb.c
@@ -86,32 +86,6 @@ STATIC MP_DEFINE_CONST_FUN_OBJ_1(pyb_elapsed_micros_obj, pyb_elapsed_micros);
 
 MP_DECLARE_CONST_FUN_OBJ_KW(pyb_main_obj); // defined in main.c
 
-// Get or set the UART object that the REPL is repeated on.
-// This is a legacy function, use of uos.dupterm is preferred.
-STATIC mp_obj_t pyb_repl_uart(size_t n_args, const mp_obj_t *args) {
-    if (n_args == 0) {
-        if (MP_STATE_PORT(pyb_stdio_uart) == NULL) {
-            return mp_const_none;
-        } else {
-            return MP_OBJ_FROM_PTR(MP_STATE_PORT(pyb_stdio_uart));
-        }
-    } else {
-        if (args[0] == mp_const_none) {
-            if (MP_STATE_PORT(pyb_stdio_uart) != NULL) {
-                uart_attach_to_repl(MP_STATE_PORT(pyb_stdio_uart), false);
-                MP_STATE_PORT(pyb_stdio_uart) = NULL;
-            }
-        } else if (mp_obj_get_type(args[0]) == &pyb_uart_type) {
-            MP_STATE_PORT(pyb_stdio_uart) = MP_OBJ_TO_PTR(args[0]);
-            uart_attach_to_repl(MP_STATE_PORT(pyb_stdio_uart), true);
-        } else {
-            mp_raise_ValueError("need a UART object");
-        }
-        return mp_const_none;
-    }
-}
-STATIC MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(pyb_repl_uart_obj, 0, 1, pyb_repl_uart);
-
 STATIC const mp_rom_map_elem_t pyb_module_globals_table[] = {
     { MP_ROM_QSTR(MP_QSTR___name__), MP_ROM_QSTR(MP_QSTR_pyb) },
 
@@ -138,7 +112,6 @@ STATIC const mp_rom_map_elem_t pyb_module_globals_table[] = {
     { MP_ROM_QSTR(MP_QSTR_standby), MP_ROM_PTR(&machine_deepsleep_obj) },
     #endif
     { MP_ROM_QSTR(MP_QSTR_main), MP_ROM_PTR(&pyb_main_obj) },
-    { MP_ROM_QSTR(MP_QSTR_repl_uart), MP_ROM_PTR(&pyb_repl_uart_obj) },
 
     #if MICROPY_HW_ENABLE_USB
     { MP_ROM_QSTR(MP_QSTR_usb_mode), MP_ROM_PTR(&pyb_usb_mode_obj) },

--- a/ports/stm32/moduos.c
+++ b/ports/stm32/moduos.c
@@ -38,6 +38,7 @@
 #include "extmod/vfs_fat.h"
 #include "genhdr/mpversion.h"
 #include "rng.h"
+#include "usb.h"
 #include "uart.h"
 #include "portmodules.h"
 
@@ -108,13 +109,26 @@ STATIC mp_obj_t os_urandom(mp_obj_t num) {
 STATIC MP_DEFINE_CONST_FUN_OBJ_1(os_urandom_obj, os_urandom);
 #endif
 
+uint8_t mp_uos_dupterm_is_builtin_stream(const mp_obj_t stream) {
+
+    return (mp_obj_get_type(stream) == &pyb_uart_type ||
+            mp_obj_get_type(stream) == &pyb_usb_vcp_type );
+}
+
 STATIC mp_obj_t uos_dupterm(size_t n_args, const mp_obj_t *args) {
     mp_obj_t prev_obj = mp_uos_dupterm_obj.fun.var(n_args, args);
     if (mp_obj_get_type(prev_obj) == &pyb_uart_type) {
         uart_attach_to_repl(MP_OBJ_TO_PTR(prev_obj), false);
     }
+    if (mp_obj_get_type(prev_obj) == &pyb_usb_vcp_type) {
+        usb_vcp_attach_to_repl(MP_OBJ_TO_PTR(prev_obj), false);
+    }
+
     if (mp_obj_get_type(args[0]) == &pyb_uart_type) {
         uart_attach_to_repl(MP_OBJ_TO_PTR(args[0]), true);
+    }
+    if (mp_obj_get_type(args[0]) == &pyb_usb_vcp_type) {
+        usb_vcp_attach_to_repl(MP_OBJ_TO_PTR(args[0]), true);
     }
     return prev_obj;
 }

--- a/ports/stm32/mpconfigport.h
+++ b/ports/stm32/mpconfigport.h
@@ -145,7 +145,7 @@
 #define MICROPY_PY_USELECT          (1)
 #define MICROPY_PY_UTIMEQ           (1)
 #define MICROPY_PY_UTIME_MP_HAL     (1)
-#define MICROPY_PY_OS_DUPTERM       (1)
+#define MICROPY_PY_OS_DUPTERM       (3)
 #define MICROPY_PY_MACHINE          (1)
 #define MICROPY_PY_MACHINE_PULSE    (1)
 #define MICROPY_PY_MACHINE_PIN_MAKE_NEW mp_pin_make_new
@@ -282,9 +282,6 @@ extern const struct _mp_obj_module_t mp_module_onewire;
     \
     /* pointers to all Timer objects (if they have been created) */ \
     struct _pyb_timer_obj_t *pyb_timer_obj_all[MICROPY_HW_MAX_TIMER]; \
-    \
-    /* stdio is repeated on this UART object if it's not null */ \
-    struct _pyb_uart_obj_t *pyb_stdio_uart; \
     \
     /* pointers to all UART objects (if they have been created) */ \
     struct _pyb_uart_obj_t *pyb_uart_obj_all[MICROPY_HW_MAX_UART]; \

--- a/ports/stm32/mphalport.c
+++ b/ports/stm32/mphalport.c
@@ -30,16 +30,6 @@ MP_WEAK int mp_hal_stdin_rx_chr(void) {
         }
 #endif
 #endif
-
-        #if MICROPY_HW_ENABLE_USB
-        byte c;
-        if (usb_vcp_recv_byte(&c) != 0) {
-            return c;
-        }
-        #endif
-        if (MP_STATE_PORT(pyb_stdio_uart) != NULL && uart_rx_any(MP_STATE_PORT(pyb_stdio_uart))) {
-            return uart_rx_char(MP_STATE_PORT(pyb_stdio_uart));
-        }
         int dupterm_c = mp_uos_dupterm_rx_chr();
         if (dupterm_c >= 0) {
             return dupterm_c;
@@ -53,17 +43,9 @@ void mp_hal_stdout_tx_str(const char *str) {
 }
 
 MP_WEAK void mp_hal_stdout_tx_strn(const char *str, size_t len) {
-    if (MP_STATE_PORT(pyb_stdio_uart) != NULL) {
-        uart_tx_strn(MP_STATE_PORT(pyb_stdio_uart), str, len);
-    }
 #if 0 && defined(USE_HOST_MODE) && MICROPY_HW_HAS_LCD
     lcd_print_strn(str, len);
 #endif
-    #if MICROPY_HW_ENABLE_USB
-    if (usb_vcp_is_enabled()) {
-        usb_vcp_send_strn(str, len);
-    }
-    #endif
     mp_uos_dupterm_tx_strn(str, len);
 }
 

--- a/ports/stm32/portmodules.h
+++ b/ports/stm32/portmodules.h
@@ -38,6 +38,6 @@ MP_DECLARE_CONST_FUN_OBJ_1(time_sleep_ms_obj);
 MP_DECLARE_CONST_FUN_OBJ_1(time_sleep_us_obj);
 
 MP_DECLARE_CONST_FUN_OBJ_0(mod_os_sync_obj);
-MP_DECLARE_CONST_FUN_OBJ_VAR_BETWEEN(mod_os_dupterm_obj);
+MP_DECLARE_CONST_FUN_OBJ_VAR_BETWEEN(uos_dupterm_obj);
 
 #endif // MICROPY_INCLUDED_STM32_PORTMODULES_H

--- a/ports/stm32/usb.c
+++ b/ports/stm32/usb.c
@@ -130,8 +130,10 @@ bool pyb_usb_dev_init(uint16_t vid, uint16_t pid, usb_device_mode_t mode, USBD_H
         usbd->pClass = &USBD_CDC_MSC_HID;
         usb_dev->usbd_cdc_msc_hid_state.pdev = usbd;
         usb_dev->usbd_cdc_msc_hid_state.cdc = &usb_dev->usbd_cdc_itf.base;
+        usbd_cdc_defaults(usb_dev->usbd_cdc_msc_hid_state.cdc);
         #if MICROPY_HW_USB_ENABLE_CDC2
         usb_dev->usbd_cdc_msc_hid_state.cdc2 = &usb_dev->usbd_cdc2_itf.base;
+        usbd_cdc_defaults(usb_dev->usbd_cdc_msc_hid_state.cdc2);
         #endif
         usb_dev->usbd_cdc_msc_hid_state.hid = &usb_dev->usbd_hid_itf.base;
         usbd->pClassData = &usb_dev->usbd_cdc_msc_hid_state;
@@ -390,6 +392,11 @@ STATIC void pyb_usb_vcp_print(const mp_print_t *print, mp_obj_t self_in, mp_prin
     mp_printf(print, "USB_VCP(%u)", id);
 }
 
+void usb_vcp_attach_to_repl(mp_obj_t self_in, bool attached) {
+    pyb_usb_vcp_obj_t *self = MP_OBJ_TO_PTR(self_in);
+    self->cdc_itf->attached_to_repl = attached;
+}
+
 /// \classmethod \constructor()
 /// Create a new USB_VCP object.
 STATIC mp_obj_t pyb_usb_vcp_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *args) {
@@ -549,6 +556,7 @@ STATIC const mp_rom_map_elem_t pyb_usb_vcp_locals_dict_table[] = {
 
     // class constants
     { MP_ROM_QSTR(MP_QSTR_RTS), MP_ROM_INT(USBD_CDC_FLOWCONTROL_RTS) },
+    { MP_ROM_QSTR(MP_QSTR_CTS), MP_ROM_INT(USBD_CDC_FLOWCONTROL_CTS) },
 };
 
 STATIC MP_DEFINE_CONST_DICT(pyb_usb_vcp_locals_dict, pyb_usb_vcp_locals_dict_table);
@@ -566,13 +574,18 @@ STATIC mp_uint_t pyb_usb_vcp_read(mp_obj_t self_in, void *buf, mp_uint_t size, i
 
 STATIC mp_uint_t pyb_usb_vcp_write(mp_obj_t self_in, const void *buf, mp_uint_t size, int *errcode) {
     pyb_usb_vcp_obj_t *self = MP_OBJ_TO_PTR(self_in);
-    int ret = usbd_cdc_tx(self->cdc_itf, (const byte*)buf, size, 0);
-    if (ret == 0) {
-        // return EAGAIN error to indicate non-blocking
-        *errcode = MP_EAGAIN;
-        return MP_STREAM_ERROR;
+    if (self->cdc_itf->flow && USBD_CDC_FLOWCONTROL_CTS) {
+        usbd_cdc_tx_always(self->cdc_itf, (const byte*)buf, size);
+        return size;
+    } else {
+        int ret = usbd_cdc_tx(self->cdc_itf, (const byte*)buf, size, 0);
+        if (ret == 0) {
+            // return EAGAIN error to indicate non-blocking
+            *errcode = MP_EAGAIN;
+            return MP_STREAM_ERROR;
+        }
+        return ret;
     }
-    return ret;
 }
 
 STATIC mp_uint_t pyb_usb_vcp_ioctl(mp_obj_t self_in, mp_uint_t request, uintptr_t arg, int *errcode) {

--- a/ports/stm32/usb.h
+++ b/ports/stm32/usb.h
@@ -65,6 +65,7 @@ void pyb_usb_dev_deinit(void);
 bool usb_vcp_is_enabled(void);
 int usb_vcp_recv_byte(uint8_t *c); // if a byte is available, return 1 and put the byte in *c, else return 0
 void usb_vcp_send_strn(const char* str, int len);
+void usb_vcp_attach_to_repl(mp_obj_t self_in, bool attached);
 
 void pyb_usb_host_init(void);
 void pyb_usb_host_process(void);

--- a/ports/stm32/usbd_cdc_interface.c
+++ b/ports/stm32/usbd_cdc_interface.c
@@ -61,6 +61,13 @@
 // Used to control the connect_state variable when USB host opens the serial port
 static uint8_t usbd_cdc_connect_tx_timer;
 
+
+void usbd_cdc_defaults(usbd_cdc_state_t *cdc_in) {
+    usbd_cdc_itf_t *cdc = (usbd_cdc_itf_t*)cdc_in;
+    cdc->flow = USBD_CDC_FLOWCONTROL_CTS;
+    usbd_cdc_init(cdc_in);
+}
+
 uint8_t *usbd_cdc_init(usbd_cdc_state_t *cdc_in) {
     usbd_cdc_itf_t *cdc = (usbd_cdc_itf_t*)cdc_in;
 
@@ -74,11 +81,6 @@ uint8_t *usbd_cdc_init(usbd_cdc_state_t *cdc_in) {
     cdc->tx_buf_ptr_out_shadow = 0;
     cdc->tx_need_empty_packet = 0;
     cdc->connect_state = USBD_CDC_CONNECT_STATE_DISCONNECTED;
-    #if MICROPY_HW_USB_ENABLE_CDC2
-    cdc->attached_to_repl = &cdc->base == cdc->base.usbd->cdc;
-    #else
-    cdc->attached_to_repl = 1;
-    #endif
 
     // Return the buffer to place the first USB OUT packet
     return cdc->rx_packet_buf;

--- a/ports/stm32/usbd_cdc_interface.h
+++ b/ports/stm32/usbd_cdc_interface.h
@@ -42,6 +42,7 @@
 // Flow control settings
 #define USBD_CDC_FLOWCONTROL_NONE (0)
 #define USBD_CDC_FLOWCONTROL_RTS (1)
+#define USBD_CDC_FLOWCONTROL_CTS (2)
 
 typedef struct _usbd_cdc_itf_t {
     usbd_cdc_state_t base; // state for the base CDC layer

--- a/ports/stm32/usbdev/class/inc/usbd_cdc_msc_hid.h
+++ b/ports/stm32/usbdev/class/inc/usbd_cdc_msc_hid.h
@@ -184,6 +184,7 @@ uint8_t USBD_HID_SetNAK(usbd_hid_state_t *usbd);
 uint8_t USBD_HID_ClearNAK(usbd_hid_state_t *usbd);
 
 // These are provided externally to implement the CDC interface
+void usbd_cdc_defaults(usbd_cdc_state_t *cdc);
 uint8_t *usbd_cdc_init(usbd_cdc_state_t *cdc);
 void usbd_cdc_deinit(usbd_cdc_state_t *cdc);
 void usbd_cdc_tx_ready(usbd_cdc_state_t *cdc);


### PR DESCRIPTION
Use `uos.dupterm` for all repl configuration in main (vcp(0) or uart if enabled).
This means `dupterm` can also be used to disable the boot repl port if desired.