### PR TITLE
docs/conf.py: Use https for link to docs.python.org.

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -298,4 +298,4 @@ texinfo_documents = [
 
 
 # Example configuration for intersphinx: refer to the Python standard library.
-intersphinx_mapping = {'python': ('http://docs.python.org/3.5', None)}
+intersphinx_mapping = {'python': ('https://docs.python.org/3.5', None)}


### PR DESCRIPTION
To get rid of warning saying there's redirect from http: to https:.