### PR TITLE
tests/extmod: Skip uselect test when CPython doesn't have poll().

### DIFF
--- a/tests/extmod/uselect_poll_basic.py
+++ b/tests/extmod/uselect_poll_basic.py
@@ -3,7 +3,8 @@ try:
 except ImportError:
     try:
         import socket, select, errno
-    except ImportError:
+        select.poll  # Raises AttributeError for CPython implementations without poll()
+    except (ImportError, AttributeError):
         print("SKIP")
         raise SystemExit
 


### PR DESCRIPTION
CPython does not have an implementation of select.poll() on some
operating systems (Windows, OSX depending on version) so skip the
test in those cases instead of failing it.

Note this also fixes the Appveyor build for MingW: that broke because even though the uPy test gets skipped, the Python test still runs first and prints it's errors to stderr causing the build to be considered as failed. Arguably that can be fixed as well, though it never has been a problem before and it seems better to be consistent in skipping anyway.
