### PR TITLE
Profiling: sys.settrace implementation.

### DIFF
--- a/ports/unix/main.c
+++ b/ports/unix/main.c
@@ -642,7 +642,12 @@ MP_NOINLINE int main_(int argc, char **argv) {
         }
     }
 
+    #if MICROPY_PY_SYS_SETTRACE
+        MP_STATE_THREAD(prof_trace_callback) = NULL;
+    #endif
+
     #if MICROPY_PY_SYS_ATEXIT
+    // Beware, the sys.settrace callback should be disabled before running sys.atexit.
     if (mp_obj_is_callable(MP_STATE_VM(sys_exitfunc))) {
         mp_call_function_0(MP_STATE_VM(sys_exitfunc));
     }

--- a/ports/unix/mpconfigport.h
+++ b/ports/unix/mpconfigport.h
@@ -91,6 +91,11 @@
 #define MICROPY_PY_BUILTINS_SLICE_ATTRS (1)
 #define MICROPY_PY_SYS_EXIT         (1)
 #define MICROPY_PY_SYS_ATEXIT       (1)
+#define MICROPY_PY_SYS_SETTRACE     (0)
+#if MICROPY_PY_SYS_SETTRACE
+#define MICROPY_PERSISTENT_CODE_SAVE (1)
+#define MICROPY_COMP_CONST (0)
+#endif
 #if defined(__APPLE__) && defined(__MACH__)
     #define MICROPY_PY_SYS_PLATFORM  "darwin"
 #else

--- a/py/bc.c
+++ b/py/bc.c
@@ -119,6 +119,11 @@ void mp_setup_code_state(mp_code_state_t *code_state, size_t n_args, size_t n_kw
     code_state->prev = NULL;
     #endif
 
+    #if MICROPY_PY_SYS_SETTRACE
+    code_state->prev_state = NULL;
+    code_state->frame = NULL;
+    #endif
+
     // get params
     size_t n_state = mp_decode_uint(&code_state->ip);
     code_state->ip = mp_decode_uint_skip(code_state->ip); // skip n_exc_stack

--- a/py/bc.h
+++ b/py/bc.h
@@ -84,6 +84,10 @@ typedef struct _mp_code_state_t {
     #if MICROPY_STACKLESS
     struct _mp_code_state_t *prev;
     #endif
+    #if MICROPY_PY_SYS_SETTRACE
+    struct _mp_code_state_t *prev_state;
+    struct _mp_obj_frame_t *frame;
+    #endif
     // Variable-length
     mp_obj_t state[0];
     // Variable-length, never accessed by name, only as (void*)(state + n_state)

--- a/py/compile.c
+++ b/py/compile.c
@@ -1608,7 +1608,9 @@ STATIC void compile_try_except(compiler_t *comp, mp_parse_node_t pn_body, int n_
 
         qstr qstr_exception_local = 0;
         uint end_finally_label = comp_next_label(comp);
-
+#if MICROPY_PY_SYS_SETTRACE
+        EMIT_ARG(set_source_line, pns_except->source_line);
+#endif
         if (MP_PARSE_NODE_IS_NULL(pns_except->nodes[0])) {
             // this is a catch all exception handler
             if (i + 1 != n_except) {
@@ -3154,6 +3156,9 @@ STATIC void compile_scope(compiler_t *comp, scope_t *scope, pass_kind_t pass) {
             scope_find_or_add_id(scope, MP_QSTR___class__, ID_INFO_KIND_LOCAL);
         }
 
+#if MICROPY_PY_SYS_SETTRACE
+        EMIT_ARG(set_source_line, pns->source_line);
+#endif
         compile_load_id(comp, MP_QSTR___name__);
         compile_store_id(comp, MP_QSTR___module__);
         EMIT_ARG(load_const_str, MP_PARSE_NODE_LEAF_ARG(pns->nodes[0])); // 0 is class name

--- a/py/emitbc.c
+++ b/py/emitbc.c
@@ -276,6 +276,9 @@ STATIC void emit_write_bytecode_byte_raw_code(emit_t *emit, byte b, mp_raw_code_
     assert(c == MP_ALIGN(c, sizeof(void*)));
     *c = rc;
     #endif
+    #if MICROPY_PY_SYS_SETTRACE
+    rc->line_of_definition = emit->last_source_line;
+    #endif
 }
 
 // unsigned labels are relative to ip following this instruction, stored as 16 bits

--- a/py/emitglue.c
+++ b/py/emitglue.c
@@ -34,6 +34,7 @@
 #include "py/emitglue.h"
 #include "py/runtime0.h"
 #include "py/bc.h"
+#include "py/profiling.h"
 
 #if MICROPY_DEBUG_VERBOSE // print debugging info
 #define DEBUG_PRINT (1)
@@ -52,6 +53,9 @@ mp_uint_t mp_verbose_flag = 0;
 mp_raw_code_t *mp_emit_glue_new_raw_code(void) {
     mp_raw_code_t *rc = m_new0(mp_raw_code_t, 1);
     rc->kind = MP_CODE_RESERVED;
+    #if MICROPY_PY_SYS_SETTRACE
+    rc->line_of_definition = 0;
+    #endif
     return rc;
 }
 
@@ -73,6 +77,11 @@ void mp_emit_glue_assign_bytecode(mp_raw_code_t *rc, const byte *code,
     rc->fun_data_len = len;
     rc->n_obj = n_obj;
     rc->n_raw_code = n_raw_code;
+    #endif
+
+    #if MICROPY_PY_SYS_SETTRACE
+    mp_bytecode_prelude_t *prelude = &rc->prelude;
+    prof_extract_prelude(code, prelude);
     #endif
 
 #ifdef DEBUG_PRINT
@@ -172,6 +181,12 @@ mp_obj_t mp_make_function_from_raw_code(const mp_raw_code_t *rc, mp_obj_t def_ar
             if ((rc->scope_flags & MP_SCOPE_FLAG_GENERATOR) != 0) {
                 ((mp_obj_base_t*)MP_OBJ_TO_PTR(fun))->type = &mp_type_gen_wrap;
             }
+
+            #if MICROPY_PY_SYS_SETTRACE
+            mp_obj_fun_bc_t *self_fun = (mp_obj_fun_bc_t *)MP_OBJ_TO_PTR(fun);
+            self_fun->rc = rc;
+            #endif
+
             break;
     }
 

--- a/py/emitglue.h
+++ b/py/emitglue.h
@@ -28,6 +28,26 @@
 
 #include "py/obj.h"
 
+#if MICROPY_PY_SYS_SETTRACE
+typedef struct _mp_bytecode_prelude_t {
+    uint n_state;
+    uint n_exc_stack;
+    uint scope_flags;
+    uint n_pos_args;
+    uint n_kwonly_args;
+    uint n_def_pos_args;
+    // const char* source_file;
+    qstr qstr_source_file;
+    // const char* block_name;
+    qstr qstr_block_name;
+    const byte* code_info;
+    size_t code_info_size;
+    const byte* line_info;
+    const byte* locals;
+    const byte* bytecode;
+} mp_bytecode_prelude_t;
+#endif
+
 // These variables and functions glue the code emitters to the runtime.
 
 // These must fit in 8 bits; see scope.h
@@ -63,6 +83,14 @@ typedef struct _mp_raw_code_t {
     size_t fun_data_len;
     uint16_t n_obj;
     uint16_t n_raw_code;
+    #if MICROPY_PY_SYS_SETTRACE
+    mp_bytecode_prelude_t prelude;
+    // `line_of_definition` is a Python source line where the raw_code was
+    // created e.g. MP_BC_MAKE_FUNCTION. This is different from lineno info
+    // stored in prelude, which provides line number for first statement of
+    // a function. Required to properly implement "call" trace event.
+    mp_uint_t line_of_definition;
+    #endif
     #if MICROPY_EMIT_MACHINE_CODE
     uint16_t prelude_offset;
     uint16_t n_qstr;

--- a/py/modsys.c
+++ b/py/modsys.c
@@ -35,6 +35,13 @@
 #include "py/smallint.h"
 #include "py/runtime.h"
 
+#if MICROPY_PY_SYS_SETTRACE
+#include "py/objmodule.h"
+#include "py/profiling.h"
+
+STATIC mp_obj_t mp_sys_settrace(mp_obj_t obj);
+#endif
+
 #if MICROPY_PY_SYS
 
 // defined per port; type of these is irrelevant, just need pointer
@@ -156,6 +163,15 @@ STATIC mp_obj_t mp_sys_atexit(mp_obj_t obj) {
 STATIC MP_DEFINE_CONST_FUN_OBJ_1(mp_sys_atexit_obj, mp_sys_atexit);
 #endif
 
+#if MICROPY_PY_SYS_SETTRACE
+// settrace(tracefunc): Set the system’s trace function.
+STATIC mp_obj_t mp_sys_settrace(mp_obj_t obj) {
+    return prof_settrace(obj);
+}
+MP_DEFINE_CONST_FUN_OBJ_1(mp_sys_settrace_obj, mp_sys_settrace);
+
+#endif // MICROPY_PY_SYS_SETTRACE
+
 STATIC const mp_rom_map_elem_t mp_module_sys_globals_table[] = {
     { MP_ROM_QSTR(MP_QSTR___name__), MP_ROM_QSTR(MP_QSTR_sys) },
 
@@ -188,6 +204,10 @@ STATIC const mp_rom_map_elem_t mp_module_sys_globals_table[] = {
 
     #if MICROPY_PY_SYS_EXIT
     { MP_ROM_QSTR(MP_QSTR_exit), MP_ROM_PTR(&mp_sys_exit_obj) },
+    #endif
+
+    #if MICROPY_PY_SYS_SETTRACE
+    { MP_ROM_QSTR(MP_QSTR_settrace), MP_ROM_PTR(&mp_sys_settrace_obj) },
     #endif
 
     #if MICROPY_PY_SYS_STDFILES

--- a/py/mpconfig.h
+++ b/py/mpconfig.h
@@ -1171,6 +1171,11 @@ typedef double mp_float_t;
 #define MICROPY_PY_SYS_ATEXIT (0)
 #endif
 
+// Whether to provide "sys.settrace" function
+#ifndef MICROPY_PY_SYS_SETTRACE
+#define MICROPY_PY_SYS_SETTRACE (0)
+#endif
+
 // Whether to provide "sys.getsizeof" function
 #ifndef MICROPY_PY_SYS_GETSIZEOF
 #define MICROPY_PY_SYS_GETSIZEOF (0)
@@ -1569,6 +1574,16 @@ typedef double mp_float_t;
 #else
 # undef MP_WARN_CAT
 # define MP_WARN_CAT(x) (NULL)
+#endif
+
+// Feature dependency check.
+#if MICROPY_PY_SYS_SETTRACE
+#if !MICROPY_PERSISTENT_CODE_SAVE
+#error "MICROPY_PY_SYS_SETTRACE requires MICROPY_PERSISTENT_CODE_SAVE to be enabled!"
+#endif
+#if MICROPY_COMP_CONST
+#error "MICROPY_PY_SYS_SETTRACE requires MICROPY_COMP_CONST to be disabled!"
+#endif
 #endif
 
 #endif // MICROPY_INCLUDED_PY_MPCONFIG_H

--- a/py/mpstate.h
+++ b/py/mpstate.h
@@ -250,6 +250,12 @@ typedef struct _mp_state_thread_t {
     mp_obj_dict_t *dict_globals;
 
     nlr_buf_t *nlr_top;
+
+    #if MICROPY_PY_SYS_SETTRACE
+    mp_obj_t prof_trace_callback;
+    bool prof_callback_is_executing;
+    struct _mp_code_state_t *current_code_state;
+    #endif // MICROPY_PY_SYS_SETTRACE
 } mp_state_thread_t;
 
 // This structure combines the above 3 structures.

--- a/py/objfun.h
+++ b/py/objfun.h
@@ -28,11 +28,18 @@
 
 #include "py/obj.h"
 
+#if MICROPY_PY_SYS_SETTRACE
+#include "py/emitglue.h"
+#endif
+
 typedef struct _mp_obj_fun_bc_t {
     mp_obj_base_t base;
     mp_obj_dict_t *globals;         // the context within which this function was defined
     const byte *bytecode;           // bytecode for the function
     const mp_uint_t *const_table;   // constant table
+#if MICROPY_PY_SYS_SETTRACE
+    const mp_raw_code_t *rc;
+#endif
     // the following extra_args array is allocated space to take (in order):
     //  - values of positional default args (if any)
     //  - a single slot for default kw args dict (if it has them)

--- a/py/profiling.c
+++ b/py/profiling.c
@@ -1,0 +1,483 @@
+
+/*
+ * This file is part of the MicroPython project, http://micropython.org/
+ *
+ * The MIT License (MIT)
+ *
+ * Copyright (c) SatoshiLabs
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#include "py/runtime.h"
+
+#if MICROPY_PY_SYS_SETTRACE
+
+#include "py/profiling.h"
+#include "py/objstr.h"
+#include "py/objfun.h"
+#include "py/emitglue.h"
+#include "py/bc0.h"
+#include "py/gc.h"
+
+#include <assert.h>
+
+#define prof_trace_cb MP_STATE_THREAD(prof_trace_callback)
+
+STATIC uint prof_bytecode_lineno(const mp_raw_code_t *rc, size_t bc) {
+    const mp_bytecode_prelude_t *prelude = &rc->prelude;
+    const byte *ip = prelude->line_info;
+    size_t source_line = 1;
+    size_t c;
+
+    bc = (bc + (prelude->bytecode - prelude->code_info)) - prelude->code_info_size;
+
+    // The following loop was taken from vm.c
+    while ((c = *ip)) {
+        size_t b, l;
+        if ((c & 0x80) == 0) {
+            // 0b0LLBBBBB encoding
+            b = c & 0x1f;
+            l = c >> 5;
+            ip += 1;
+        } else {
+            // 0b1LLLBBBB 0bLLLLLLLL encoding (l's LSB in second byte)
+            b = c & 0xf;
+            l = ((c << 4) & 0x700) | ip[1];
+            ip += 2;
+        }
+        if (bc >= b) {
+            bc -= b;
+            source_line += l;
+        } else {
+            // found source line corresponding to bytecode offset
+            break;
+        }
+    }
+
+    return source_line;
+}
+
+void prof_extract_prelude(const byte *bytecode, mp_bytecode_prelude_t *prelude) {
+    const byte *ip = bytecode;
+
+    prelude->n_state = mp_decode_uint(&ip); // ip++
+    prelude->n_exc_stack = mp_decode_uint(&ip); // ip++
+    prelude->scope_flags = *ip++;
+    prelude->n_pos_args = *ip++;
+    prelude->n_kwonly_args = *ip++;
+    prelude->n_def_pos_args = *ip++;
+
+    prelude->code_info = ip;
+    size_t code_info_size = mp_decode_uint(&ip); // ip++
+    prelude->code_info_size = code_info_size;
+
+    #if MICROPY_PERSISTENT_CODE
+    qstr block_name = ip[0] | (ip[1] << 8);
+    qstr source_file = ip[2] | (ip[3] << 8);
+    ip += 4;
+    #else
+    qstr block_name = mp_decode_uint(&ip); // ip++
+    qstr source_file = mp_decode_uint(&ip); // ip++
+    #endif
+    prelude->qstr_block_name = block_name;
+    prelude->qstr_source_file = source_file;
+
+    prelude->line_info = ip;
+
+    prelude->locals = (void*)(
+        (size_t)(prelude->code_info + code_info_size)
+         & (~(sizeof(uint)-1)) // word align
+    );
+
+    ip = prelude->locals;
+    while (*ip++ != 255);
+    prelude->bytecode = ip;
+}
+
+
+/******************************************************************************/
+// code object
+
+STATIC void code_print(const mp_print_t *print, mp_obj_t o_in, mp_print_kind_t kind) {
+    (void)kind;
+    mp_obj_code_t *o = MP_OBJ_TO_PTR(o_in);
+    const mp_raw_code_t *rc = o->rc;
+    const mp_bytecode_prelude_t *prelude = &rc->prelude;
+    mp_printf(print,
+        "<code object %q at 0x%p, file \"%q\", line %d>",
+        prelude->qstr_block_name,
+        o,
+        prelude->qstr_source_file,
+        rc->line_of_definition
+    );
+}
+
+STATIC mp_obj_tuple_t* code_consts(const mp_raw_code_t *rc) {
+
+    const mp_bytecode_prelude_t *prelude = &rc->prelude;
+    int start = prelude->n_pos_args + prelude->n_kwonly_args + rc->n_obj;
+    int stop  = prelude->n_pos_args + prelude->n_kwonly_args + rc->n_obj + rc->n_raw_code;
+    mp_obj_tuple_t *consts = mp_obj_new_tuple(stop - start + 1, NULL);
+    size_t const_no = 0;
+    int i = 0;
+
+    for (i = start; i < stop; i++ ) {
+        consts->items[const_no++] = mp_obj_new_code((const mp_raw_code_t*)rc->const_table[i]);
+    }
+
+    consts->items[const_no++] = mp_const_none;
+
+    return consts;
+}
+
+STATIC mp_obj_t raw_code_lnotab(const mp_raw_code_t *rc) {
+    // const mp_bytecode_prelude_t *prelude = &rc->prelude;
+    uint start = 0;
+    uint stop = rc->fun_data_len - start;
+
+    uint last_lineno = prof_bytecode_lineno(rc, start);
+    uint lasti = 0;
+
+    const uint buffer_chunk_size = (stop-start) >> 2; // heuristic magic
+    uint buffer_size = buffer_chunk_size;
+    byte *buffer = m_new(byte, buffer_size);
+    uint buffer_index = 0;
+
+    int i;
+    for (i = start; i < stop; i ++) {
+        uint lineno = prof_bytecode_lineno(rc, i);
+        size_t line_diff = lineno - last_lineno;
+        if (line_diff > 0) {
+            uint instr_diff = (i - start) - lasti;
+
+            assert(instr_diff < 256);
+            assert(line_diff < 256);
+
+            if (buffer_index + 2 > buffer_size) {
+                #if MICROPY_MALLOC_USES_ALLOCATED_SIZE
+                buffer = m_renew(byte, buffer, buffer_size, buffer_size + buffer_chunk_size);
+                #else
+                buffer = m_realloc(buffer, buffer_size, buffer_size + buffer_chunk_size);
+                #endif
+                buffer_size = buffer_size + buffer_chunk_size;
+            }
+            last_lineno = lineno;
+            lasti = i - start;
+            buffer[buffer_index++] = instr_diff;
+            buffer[buffer_index++] = line_diff;
+        }
+    }
+
+    mp_obj_t o = mp_obj_new_bytes(buffer, buffer_index);
+    m_del(byte, buffer, buffer_size);
+    return o;
+}
+
+STATIC void code_attr(mp_obj_t self_in, qstr attr, mp_obj_t *dest) {
+    if (dest[0] != MP_OBJ_NULL) {
+        // not load attribute
+        return;
+    }
+    mp_obj_code_t *o = MP_OBJ_TO_PTR(self_in);
+    const mp_raw_code_t *rc = o->rc;
+    const mp_bytecode_prelude_t *prelude = &rc->prelude;
+    switch(attr) {
+        case MP_QSTR_co_code:
+            dest[0] = mp_obj_new_bytes(
+                (void*)prelude->bytecode,
+                rc->fun_data_len - (prelude->bytecode - (const byte*)rc->fun_data)
+            );
+            break;
+        case MP_QSTR_co_consts:
+            dest[0] = MP_OBJ_FROM_PTR(code_consts(rc));
+            break;
+        case MP_QSTR_co_filename:
+            dest[0] = MP_OBJ_NEW_QSTR(prelude->qstr_source_file);
+            break;
+        case MP_QSTR_co_firstlineno:
+            dest[0] = MP_OBJ_NEW_SMALL_INT(prof_bytecode_lineno(rc, 0));
+            break;
+        case MP_QSTR_co_name:
+            dest[0] = MP_OBJ_NEW_QSTR(prelude->qstr_block_name);
+            break;
+        case MP_QSTR_co_names:
+            dest[0] = MP_OBJ_FROM_PTR(o->dict_locals);
+            break;
+        case MP_QSTR_co_lnotab:
+            if (!o->lnotab) {
+                 o->lnotab = raw_code_lnotab(rc);
+            }
+            dest[0] = o->lnotab;
+            break;
+    }
+}
+
+const mp_obj_type_t mp_type_code = {
+    { &mp_type_type },
+    .name = MP_QSTR_code,
+    .print = code_print,
+    .unary_op = mp_generic_unary_op,
+    .attr = code_attr,
+};
+
+mp_obj_t mp_obj_new_code(const mp_raw_code_t *rc) {
+    mp_obj_code_t *o = m_new_obj(mp_obj_code_t);
+    o->base.type = &mp_type_code;
+    o->rc = rc;
+    o->dict_locals = mp_locals_get(); // this is a wrong! how to do this properly?
+    o->lnotab = NULL;
+    return MP_OBJ_FROM_PTR(o);
+}
+
+/******************************************************************************/
+// frame object
+
+STATIC void frame_print(const mp_print_t *print, mp_obj_t o_in, mp_print_kind_t kind) {
+    (void)kind;
+    mp_obj_frame_t *frame = MP_OBJ_TO_PTR(o_in);
+    mp_obj_code_t *code = frame->code;
+    const mp_raw_code_t *rc = code->rc;
+    const mp_bytecode_prelude_t *prelude = &rc->prelude;
+    mp_printf(print,
+        "<frame at 0x%p, file '%q', line %d, code %q>",
+        frame,
+        prelude->qstr_source_file,
+        frame->lineno,
+        prelude->qstr_block_name
+    );
+}
+
+STATIC void frame_attr(mp_obj_t self_in, qstr attr, mp_obj_t *dest) {
+    if (dest[0] != MP_OBJ_NULL) {
+        // not load attribute
+        return;
+    }
+
+    mp_obj_frame_t *o = MP_OBJ_TO_PTR(self_in);
+
+    switch(attr) {
+        case MP_QSTR_f_back:
+            dest[0] = mp_const_none;
+            if (o->code_state->prev_state) {
+                dest[0] = o->code_state->prev_state->frame;
+            }
+            break;
+        case MP_QSTR_f_code:
+            dest[0] = o->code;
+            break;
+        case MP_QSTR_f_globals:
+            dest[0] = o->code_state->fun_bc->globals;
+            break;
+        case MP_QSTR_f_lasti:
+            dest[0] = MP_OBJ_NEW_SMALL_INT(o->lasti);
+            break;
+        case MP_QSTR_f_lineno:
+            dest[0] = MP_OBJ_NEW_SMALL_INT(o->lineno);
+            break;
+    }
+}
+
+const mp_obj_type_t mp_type_frame = {
+    { &mp_type_type },
+    .name = MP_QSTR_frame,
+    .print = frame_print,
+    .unary_op = mp_generic_unary_op,
+    .attr = frame_attr,
+};
+
+mp_obj_t mp_obj_new_frame(const mp_code_state_t *code_state) {
+
+    bool gc_is_locked_tmp = gc_is_locked();
+    if (gc_is_locked_tmp) {
+        gc_unlock();
+    }
+
+    mp_obj_frame_t *o = m_new_obj(mp_obj_frame_t);
+    mp_obj_code_t *code = o->code = mp_obj_new_code(code_state->fun_bc->rc);
+    const mp_raw_code_t *rc = code->rc;
+    const mp_bytecode_prelude_t *prelude = &rc->prelude;
+    o->code_state = code_state;
+    o->base.type = &mp_type_frame;
+    o->back = NULL;
+    o->code = code;
+    o->lasti = code_state->ip - prelude->bytecode;
+    o->lineno = prof_bytecode_lineno(rc, o->lasti);
+    o->trace_opcodes = false;
+    o->callback = NULL;
+
+    if (gc_is_locked_tmp) {
+        gc_lock();
+    }
+
+    return MP_OBJ_FROM_PTR(o);
+}
+
+
+/******************************************************************************/
+// trace logic
+
+typedef struct {
+    struct _mp_obj_frame_t * frame;
+    mp_obj_t event;
+    mp_obj_t arg;
+} prof_callback_args_t;
+
+STATIC mp_obj_t prof_callback_invoke(mp_obj_t callback, prof_callback_args_t *args) {
+
+    assert(mp_obj_is_callable(callback));
+
+    prof_is_executing = true;
+
+    mp_obj_t a[3] = {args->frame, args->event, args->arg};
+    mp_obj_t top = mp_call_function_n_kw(callback, 3, 0, a);
+
+    prof_is_executing = false;
+
+    if (MP_STATE_VM(mp_pending_exception) != MP_OBJ_NULL) {
+        mp_obj_t obj = MP_STATE_VM(mp_pending_exception);
+        MP_STATE_VM(mp_pending_exception) = MP_OBJ_NULL;
+        nlr_raise(obj);
+    }
+    return top;
+}
+
+mp_obj_t prof_settrace(mp_obj_t callback) {
+    if (mp_obj_is_callable(callback)) {
+        prof_trace_cb = callback;
+    } else {
+        prof_trace_cb = NULL;
+    }
+    return mp_const_none;
+}
+
+mp_obj_t prof_frame_enter(mp_code_state_t *code_state) {
+
+    assert(!prof_is_executing);
+
+    mp_obj_frame_t *frame = MP_OBJ_TO_PTR(mp_obj_new_frame(code_state));
+    if (code_state->prev_state && code_state->frame == NULL) {
+        // We are entering not-yet-traced frame
+        // which means it's a CALL event (not a GENERATOR)
+        // so set the function definition line.
+        const mp_raw_code_t *rc = code_state->fun_bc->rc;
+        frame->lineno = rc->line_of_definition;
+        if (!rc->line_of_definition) {
+            frame->lineno = prof_bytecode_lineno(rc, 0);
+        }
+    }
+    code_state->frame = MP_OBJ_FROM_PTR(frame);
+
+    if (!prof_trace_cb) {
+        return NULL;
+    }
+
+    mp_obj_t top;
+    prof_callback_args_t _args, *args=&_args;
+    args->frame = code_state->frame;
+
+    // SETTRACE event CALL
+    args->event = MP_ROM_QSTR(MP_QSTR_call);
+    args->arg = mp_const_none;
+    top = prof_callback_invoke(prof_trace_cb, args);
+
+    code_state->frame->callback = mp_obj_is_callable(top) ? top : NULL;
+
+    // Invalidate the last executed line number so the LINE trace can trigger after this CALL.
+    frame->lineno = 0;
+
+    return top;
+}
+
+mp_obj_t prof_frame_update(const mp_code_state_t *code_state) {
+
+    mp_obj_frame_t *frame = code_state->frame;
+    assert(frame != NULL);
+
+    mp_obj_frame_t *o = frame;
+    mp_obj_code_t *code = o->code;
+    const mp_raw_code_t *rc = code->rc;
+    const mp_bytecode_prelude_t *prelude = &rc->prelude;
+
+    assert(o->code_state == code_state);
+
+    o->lasti = code_state->ip - prelude->bytecode;
+    o->lineno = prof_bytecode_lineno(rc, o->lasti);
+
+    return MP_OBJ_FROM_PTR(o);
+}
+
+mp_obj_t prof_instr_tick(mp_code_state_t *code_state, bool is_exception) {
+
+    // Detecet execution recursion.
+    assert(!prof_is_executing);
+    assert(code_state->frame);
+    assert(mp_obj_get_type(code_state->frame) == &mp_type_frame);
+
+    // Detecet data recursion.
+    assert(code_state != code_state->prev_state);
+
+    mp_obj_t top = mp_const_none;
+    mp_obj_t callback = code_state->frame->callback;
+
+    prof_callback_args_t _args, *args=&_args;
+    args->frame = code_state->frame;
+    args->event = mp_const_none;
+    args->arg = mp_const_none;
+
+    // Call event's are handled inside prof_frame_enter
+
+    // SETTRACE event EXCEPTION
+    if (is_exception) {
+        args->event = MP_ROM_QSTR(MP_QSTR_exception);
+        top = prof_callback_invoke(callback, args);
+        return top;
+    }
+
+    // SETTRACE event LINE
+    const mp_raw_code_t *rc = code_state->fun_bc->rc;
+    const mp_bytecode_prelude_t *prelude = &rc->prelude;
+    size_t prev_line_no = args->frame->lineno;
+    size_t current_line_no = prof_bytecode_lineno(rc, code_state->ip - prelude->bytecode);
+    if (prev_line_no != current_line_no) {
+        args->frame->lineno = current_line_no;
+        args->event = MP_ROM_QSTR(MP_QSTR_line);
+        top = prof_callback_invoke(callback, args);
+    }
+
+    // SETTRACE event RETURN
+    const byte *ip = code_state->ip;
+    if (*ip == MP_BC_RETURN_VALUE || *ip == MP_BC_YIELD_VALUE) {
+        args->event = MP_ROM_QSTR(MP_QSTR_return);
+        top = prof_callback_invoke(callback, args);
+        if (code_state->prev_state && *ip == MP_BC_RETURN_VALUE) {
+            code_state->frame->callback = NULL;
+        }
+    }
+
+    // SETTRACE event OPCODE
+    // TODO: frame.f_trace_opcodes=True
+    if (false) {
+        args->event = MP_ROM_QSTR(MP_QSTR_opcode);
+    }
+
+    return top;
+}
+
+#endif // MICROPY_PY_SYS_SETTRACE

--- a/py/profiling.c
+++ b/py/profiling.c
@@ -480,4 +480,552 @@ mp_obj_t prof_instr_tick(mp_code_state_t *code_state, bool is_exception) {
     return top;
 }
 
+
+/******************************************************************************/
+// DEBUG
+
+// This section is for debugging the settrace feature itself
+// and should never make it in to any public build.
+// The code structure for this block was taken from the showbc.c
+// so don't even use this as a reference.
+// To enable this find the definition
+// enable `PROF_INSTR_DEBUG_PRINT_ENABLE` in the header file `profiling.h`.
+#if PROF_INSTR_DEBUG_PRINT_ENABLE
+
+#include <stdio.h>
+#include <string.h>
+
+#define DECODE_UINT { \
+    unum = 0; \
+    do { \
+        unum = (unum << 7) + (*ip & 0x7f); \
+    } while ((*ip++ & 0x80) != 0); \
+}
+#define DECODE_ULABEL do { unum = (ip[0] | (ip[1] << 8)); ip += 2; } while (0)
+#define DECODE_SLABEL do { unum = (ip[0] | (ip[1] << 8)) - 0x8000; ip += 2; } while (0)
+
+#define DECODE_QSTR \
+    qst = ip[0] | ip[1] << 8; \
+    ip += 2;
+#define DECODE_PTR \
+    DECODE_UINT; \
+    ptr = (const byte*)const_table[unum]
+#define DECODE_OBJ \
+    DECODE_UINT; \
+    obj = (mp_obj_t)const_table[unum]
+
+
+const byte *prof_opcode_decode(const byte *ip, const mp_uint_t *const_table, mp_dis_instruction_t *instruction) {
+    mp_uint_t unum;
+    const byte* ptr;
+    mp_obj_t obj;
+    qstr qst;
+
+    instruction->qstr_opname = MP_QSTR_;
+    instruction->arg = 0;
+    instruction->argobj= mp_const_none;
+    instruction->argobjex_cache = mp_const_none;
+
+    switch (*ip++) {
+        case MP_BC_LOAD_CONST_FALSE:
+            instruction->qstr_opname = MP_QSTR_LOAD_CONST_FALSE;
+            break;
+
+        case MP_BC_LOAD_CONST_NONE:
+            instruction->qstr_opname = MP_QSTR_LOAD_CONST_NONE;
+            break;
+
+        case MP_BC_LOAD_CONST_TRUE:
+            instruction->qstr_opname = MP_QSTR_LOAD_CONST_TRUE;
+            break;
+
+        case MP_BC_LOAD_CONST_SMALL_INT: {
+            mp_int_t num = 0;
+            if ((ip[0] & 0x40) != 0) {
+                // Number is negative
+                num--;
+            }
+            do {
+                num = (num << 7) | (*ip & 0x7f);
+            } while ((*ip++ & 0x80) != 0);
+            instruction->qstr_opname = MP_QSTR_LOAD_CONST_SMALL_INT;
+            instruction->arg = num;
+            break;
+        }
+
+        case MP_BC_LOAD_CONST_STRING:
+            DECODE_QSTR;
+            instruction->qstr_opname = MP_QSTR_LOAD_CONST_STRING;
+            instruction->arg = qst;
+            instruction->argobj= MP_OBJ_NEW_QSTR(qst);
+            break;
+
+        case MP_BC_LOAD_CONST_OBJ:
+            DECODE_OBJ;
+            instruction->qstr_opname = MP_QSTR_LOAD_CONST_OBJ;
+            instruction->arg = unum;
+            instruction->argobj= obj;
+            break;
+
+        case MP_BC_LOAD_NULL:
+            instruction->qstr_opname = MP_QSTR_LOAD_NULL;
+            break;
+
+        case MP_BC_LOAD_FAST_N:
+            DECODE_UINT;
+            instruction->qstr_opname = MP_QSTR_LOAD_FAST_N;
+            instruction->arg = unum;
+            break;
+
+        case MP_BC_LOAD_DEREF:
+            DECODE_UINT;
+            instruction->qstr_opname = MP_QSTR_LOAD_DEREF;
+            instruction->arg = unum;
+            break;
+
+        case MP_BC_LOAD_NAME:
+            DECODE_QSTR;
+            instruction->qstr_opname = MP_QSTR_LOAD_NAME;
+            instruction->arg = qst;
+            instruction->argobj= MP_OBJ_NEW_QSTR(qst);
+            if (MICROPY_OPT_CACHE_MAP_LOOKUP_IN_BYTECODE) {
+                instruction->argobjex_cache = MP_OBJ_NEW_SMALL_INT(*ip++);
+            }
+            break;
+
+        case MP_BC_LOAD_GLOBAL:
+            DECODE_QSTR;
+            instruction->qstr_opname = MP_QSTR_LOAD_GLOBAL;
+            instruction->arg = qst;
+            instruction->argobj= MP_OBJ_NEW_QSTR(qst);
+            if (MICROPY_OPT_CACHE_MAP_LOOKUP_IN_BYTECODE) {
+                instruction->argobjex_cache = MP_OBJ_NEW_SMALL_INT(*ip++);
+            }
+            break;
+
+        case MP_BC_LOAD_ATTR:
+            DECODE_QSTR;
+            instruction->qstr_opname = MP_QSTR_LOAD_ATTR;
+            instruction->arg = qst;
+            instruction->argobj= MP_OBJ_NEW_QSTR(qst);
+            if (MICROPY_OPT_CACHE_MAP_LOOKUP_IN_BYTECODE) {
+                instruction->argobjex_cache = MP_OBJ_NEW_SMALL_INT(*ip++);
+            }
+            break;
+
+        case MP_BC_LOAD_METHOD:
+            DECODE_QSTR;
+            instruction->qstr_opname = MP_QSTR_LOAD_METHOD;
+            instruction->arg = qst;
+            instruction->argobj= MP_OBJ_NEW_QSTR(qst);
+            break;
+
+        case MP_BC_LOAD_SUPER_METHOD:
+            DECODE_QSTR;
+            instruction->qstr_opname = MP_QSTR_LOAD_SUPER_METHOD;
+            instruction->arg = qst;
+            instruction->argobj= MP_OBJ_NEW_QSTR(qst);
+            break;
+
+        case MP_BC_LOAD_BUILD_CLASS:
+            instruction->qstr_opname = MP_QSTR_LOAD_BUILD_CLASS;
+            break;
+
+        case MP_BC_LOAD_SUBSCR:
+            instruction->qstr_opname = MP_QSTR_LOAD_SUBSCR;
+            break;
+
+        case MP_BC_STORE_FAST_N:
+            DECODE_UINT;
+            instruction->qstr_opname = MP_QSTR_STORE_FAST_N;
+            instruction->arg = unum;
+            break;
+
+        case MP_BC_STORE_DEREF:
+            DECODE_UINT;
+            instruction->qstr_opname = MP_QSTR_STORE_DEREF;
+            instruction->arg = unum;
+            break;
+
+        case MP_BC_STORE_NAME:
+            DECODE_QSTR;
+            instruction->qstr_opname = MP_QSTR_STORE_NAME;
+            instruction->arg = qst;
+            instruction->argobj= MP_OBJ_NEW_QSTR(qst);
+            break;
+
+        case MP_BC_STORE_GLOBAL:
+            DECODE_QSTR;
+            instruction->qstr_opname = MP_QSTR_STORE_GLOBAL;
+            instruction->arg = qst;
+            instruction->argobj= MP_OBJ_NEW_QSTR(qst);
+            break;
+
+        case MP_BC_STORE_ATTR:
+            DECODE_QSTR;
+            instruction->qstr_opname = MP_QSTR_STORE_ATTR;
+            instruction->arg = qst;
+            instruction->argobj= MP_OBJ_NEW_QSTR(qst);
+            if (MICROPY_OPT_CACHE_MAP_LOOKUP_IN_BYTECODE) {
+                instruction->argobjex_cache = MP_OBJ_NEW_SMALL_INT(*ip++);
+            }
+            break;
+
+        case MP_BC_STORE_SUBSCR:
+            instruction->qstr_opname = MP_QSTR_STORE_SUBSCR;
+            break;
+
+        case MP_BC_DELETE_FAST:
+            DECODE_UINT;
+            instruction->qstr_opname = MP_QSTR_DELETE_FAST;
+            instruction->arg = unum;
+            break;
+
+        case MP_BC_DELETE_DEREF:
+            DECODE_UINT;
+            instruction->qstr_opname = MP_QSTR_DELETE_DEREF;
+            instruction->arg = unum;
+            break;
+
+        case MP_BC_DELETE_NAME:
+            DECODE_QSTR;
+            instruction->qstr_opname = MP_QSTR_DELETE_NAME;
+            instruction->arg = qst;
+            instruction->argobj= MP_OBJ_NEW_QSTR(qst);
+            break;
+
+        case MP_BC_DELETE_GLOBAL:
+            DECODE_QSTR;
+            instruction->qstr_opname = MP_QSTR_DELETE_GLOBAL;
+            instruction->arg = qst;
+            instruction->argobj= MP_OBJ_NEW_QSTR(qst);
+            break;
+
+        case MP_BC_DUP_TOP:
+            instruction->qstr_opname = MP_QSTR_DUP_TOP;
+            break;
+
+        case MP_BC_DUP_TOP_TWO:
+            instruction->qstr_opname = MP_QSTR_DUP_TOP_TWO;
+            break;
+
+        case MP_BC_POP_TOP:
+            instruction->qstr_opname = MP_QSTR_POP_TOP;
+            break;
+
+        case MP_BC_ROT_TWO:
+            instruction->qstr_opname = MP_QSTR_ROT_TWO;
+            break;
+
+        case MP_BC_ROT_THREE:
+            instruction->qstr_opname = MP_QSTR_ROT_THREE;
+            break;
+
+        case MP_BC_JUMP:
+            DECODE_SLABEL;
+            instruction->qstr_opname = MP_QSTR_JUMP;
+            instruction->arg = unum;
+            break;
+
+        case MP_BC_POP_JUMP_IF_TRUE:
+            DECODE_SLABEL;
+            instruction->qstr_opname = MP_QSTR_POP_JUMP_IF_TRUE;
+            instruction->arg = unum;
+            break;
+
+        case MP_BC_POP_JUMP_IF_FALSE:
+            DECODE_SLABEL;
+            instruction->qstr_opname = MP_QSTR_POP_JUMP_IF_FALSE;
+            instruction->arg = unum;
+            break;
+
+        case MP_BC_JUMP_IF_TRUE_OR_POP:
+            DECODE_SLABEL;
+            instruction->qstr_opname = MP_QSTR_JUMP_IF_TRUE_OR_POP;
+            instruction->arg = unum;
+            break;
+
+        case MP_BC_JUMP_IF_FALSE_OR_POP:
+            DECODE_SLABEL;
+            instruction->qstr_opname = MP_QSTR_JUMP_IF_FALSE_OR_POP;
+            instruction->arg = unum;
+            break;
+
+        case MP_BC_SETUP_WITH:
+            DECODE_ULABEL; // loop-like labels are always forward
+            instruction->qstr_opname = MP_QSTR_SETUP_WITH;
+            instruction->arg = unum;
+            break;
+
+        case MP_BC_WITH_CLEANUP:
+            instruction->qstr_opname = MP_QSTR_WITH_CLEANUP;
+            break;
+
+        case MP_BC_UNWIND_JUMP:
+            DECODE_SLABEL;
+            instruction->qstr_opname = MP_QSTR_UNWIND_JUMP;
+            instruction->arg = unum;
+            break;
+
+        case MP_BC_SETUP_EXCEPT:
+            DECODE_ULABEL; // except labels are always forward
+            instruction->qstr_opname = MP_QSTR_SETUP_EXCEPT;
+            instruction->arg = unum;
+            break;
+
+        case MP_BC_SETUP_FINALLY:
+            DECODE_ULABEL; // except labels are always forward
+            instruction->qstr_opname = MP_QSTR_SETUP_FINALLY;
+            instruction->arg = unum;
+            break;
+
+        case MP_BC_END_FINALLY:
+            // if TOS is an exception, reraises the exception (3 values on TOS)
+            // if TOS is an integer, does something else
+            // if TOS is None, just pops it and continues
+            // else error
+            instruction->qstr_opname = MP_QSTR_END_FINALLY;
+            break;
+
+        case MP_BC_GET_ITER:
+            instruction->qstr_opname = MP_QSTR_GET_ITER;
+            break;
+
+        case MP_BC_GET_ITER_STACK:
+            instruction->qstr_opname = MP_QSTR_GET_ITER_STACK;
+            break;
+
+        case MP_BC_FOR_ITER:
+            DECODE_ULABEL; // the jump offset if iteration finishes; for labels are always forward
+            instruction->qstr_opname = MP_QSTR_FOR_ITER;
+            instruction->arg = unum;
+            break;
+
+        case MP_BC_BUILD_TUPLE:
+            DECODE_UINT;
+            instruction->qstr_opname = MP_QSTR_BUILD_TUPLE;
+            instruction->arg = unum;
+            break;
+
+        case MP_BC_BUILD_LIST:
+            DECODE_UINT;
+            instruction->qstr_opname = MP_QSTR_BUILD_LIST;
+            instruction->arg = unum;
+            break;
+
+        case MP_BC_BUILD_MAP:
+            DECODE_UINT;
+            instruction->qstr_opname = MP_QSTR_BUILD_MAP;
+            instruction->arg = unum;
+            break;
+
+        case MP_BC_STORE_MAP:
+            instruction->qstr_opname = MP_QSTR_STORE_MAP;
+            break;
+
+        case MP_BC_BUILD_SET:
+            DECODE_UINT;
+            instruction->qstr_opname = MP_QSTR_BUILD_SET;
+            instruction->arg = unum;
+            break;
+
+#if MICROPY_PY_BUILTINS_SLICE
+        case MP_BC_BUILD_SLICE:
+            DECODE_UINT;
+            instruction->qstr_opname = MP_QSTR_BUILD_SLICE;
+            instruction->arg = unum;
+            break;
+#endif
+
+        case MP_BC_STORE_COMP:
+            DECODE_UINT;
+            instruction->qstr_opname = MP_QSTR_STORE_COMP;
+            instruction->arg = unum;
+            break;
+
+        case MP_BC_UNPACK_SEQUENCE:
+            DECODE_UINT;
+            instruction->qstr_opname = MP_QSTR_UNPACK_SEQUENCE;
+            instruction->arg = unum;
+            break;
+
+        case MP_BC_UNPACK_EX:
+            DECODE_UINT;
+            instruction->qstr_opname = MP_QSTR_UNPACK_EX;
+            instruction->arg = unum;
+            break;
+
+        case MP_BC_MAKE_FUNCTION:
+            DECODE_PTR;
+            instruction->qstr_opname = MP_QSTR_MAKE_FUNCTION;
+            instruction->arg = unum;
+            instruction->argobj= mp_obj_new_int_from_ull((uint64_t)ptr);
+            break;
+
+        case MP_BC_MAKE_FUNCTION_DEFARGS:
+            DECODE_PTR;
+            instruction->qstr_opname = MP_QSTR_MAKE_FUNCTION_DEFARGS;
+            instruction->arg = unum;
+            instruction->argobj= mp_obj_new_int_from_ull((uint64_t)ptr);
+            break;
+
+        case MP_BC_MAKE_CLOSURE: {
+            DECODE_PTR;
+            mp_uint_t n_closed_over = *ip++;
+            instruction->qstr_opname = MP_QSTR_MAKE_CLOSURE;
+            instruction->arg = unum;
+            instruction->argobj= mp_obj_new_int_from_ull((uint64_t)ptr);
+            instruction->argobjex_cache = MP_OBJ_NEW_SMALL_INT(n_closed_over);
+            break;
+        }
+
+        case MP_BC_MAKE_CLOSURE_DEFARGS: {
+            DECODE_PTR;
+            mp_uint_t n_closed_over = *ip++;
+            instruction->qstr_opname = MP_QSTR_MAKE_CLOSURE_DEFARGS;
+            instruction->arg = unum;
+            instruction->argobj= mp_obj_new_int_from_ull((uint64_t)ptr);
+            instruction->argobjex_cache = MP_OBJ_NEW_SMALL_INT(n_closed_over);
+            break;
+        }
+
+        case MP_BC_CALL_FUNCTION:
+            DECODE_UINT;
+            instruction->qstr_opname = MP_QSTR_CALL_FUNCTION;
+            instruction->arg = unum & 0xff;
+            instruction->argobjex_cache = MP_OBJ_NEW_SMALL_INT((unum >> 8) & 0xff);
+            break;
+
+        case MP_BC_CALL_FUNCTION_VAR_KW:
+            DECODE_UINT;
+            instruction->qstr_opname = MP_QSTR_CALL_FUNCTION_VAR_KW;
+            instruction->arg = unum & 0xff;
+            instruction->argobjex_cache = MP_OBJ_NEW_SMALL_INT((unum >> 8) & 0xff);
+            break;
+
+        case MP_BC_CALL_METHOD:
+            DECODE_UINT;
+            instruction->qstr_opname = MP_QSTR_CALL_METHOD;
+            instruction->arg = unum & 0xff;
+            instruction->argobjex_cache = MP_OBJ_NEW_SMALL_INT((unum >> 8) & 0xff);
+            break;
+
+        case MP_BC_CALL_METHOD_VAR_KW:
+            DECODE_UINT;
+            instruction->qstr_opname = MP_QSTR_CALL_METHOD_VAR_KW;
+            instruction->arg = unum & 0xff;
+            instruction->argobjex_cache = MP_OBJ_NEW_SMALL_INT((unum >> 8) & 0xff);
+            break;
+
+        case MP_BC_RETURN_VALUE:
+            instruction->qstr_opname = MP_QSTR_RETURN_VALUE;
+            break;
+
+        case MP_BC_RAISE_VARARGS:
+            unum = *ip++;
+            instruction->qstr_opname = MP_QSTR_RAISE_VARARGS;
+            instruction->arg = unum;
+            break;
+
+        case MP_BC_YIELD_VALUE:
+            instruction->qstr_opname = MP_QSTR_YIELD_VALUE;
+            break;
+
+        case MP_BC_YIELD_FROM:
+            instruction->qstr_opname = MP_QSTR_YIELD_FROM;
+            break;
+
+        case MP_BC_IMPORT_NAME:
+            DECODE_QSTR;
+            instruction->qstr_opname = MP_QSTR_IMPORT_NAME;
+            instruction->arg = qst;
+            instruction->argobj= MP_OBJ_NEW_QSTR(qst);
+            break;
+
+        case MP_BC_IMPORT_FROM:
+            DECODE_QSTR;
+            instruction->qstr_opname = MP_QSTR_IMPORT_FROM;
+            instruction->arg = qst;
+            instruction->argobj= MP_OBJ_NEW_QSTR(qst);
+            break;
+
+        case MP_BC_IMPORT_STAR:
+            instruction->qstr_opname = MP_QSTR_IMPORT_STAR;
+            break;
+
+        default:
+            if (ip[-1] < MP_BC_LOAD_CONST_SMALL_INT_MULTI + 64) {
+                instruction->qstr_opname = MP_QSTR_LOAD_CONST_SMALL_INT;
+                instruction->arg = (mp_int_t)ip[-1] - MP_BC_LOAD_CONST_SMALL_INT_MULTI - 16;
+            } else if (ip[-1] < MP_BC_LOAD_FAST_MULTI + 16) {
+                instruction->qstr_opname = MP_QSTR_LOAD_FAST;
+                instruction->arg = (mp_uint_t)ip[-1] - MP_BC_LOAD_FAST_MULTI;
+            } else if (ip[-1] < MP_BC_STORE_FAST_MULTI + 16) {
+                instruction->qstr_opname = MP_QSTR_STORE_FAST;
+                instruction->arg = (mp_uint_t)ip[-1] - MP_BC_STORE_FAST_MULTI;
+            } else if (ip[-1] < MP_BC_UNARY_OP_MULTI + MP_UNARY_OP_NUM_BYTECODE) {
+                instruction->qstr_opname = MP_QSTR_UNARY_OP;
+                instruction->arg = (mp_uint_t)ip[-1] - MP_BC_UNARY_OP_MULTI;
+            } else if (ip[-1] < MP_BC_BINARY_OP_MULTI + MP_BINARY_OP_NUM_BYTECODE) {
+                mp_uint_t op = ip[-1] - MP_BC_BINARY_OP_MULTI;
+                instruction->qstr_opname = MP_QSTR_BINARY_OP;
+                instruction->arg = op;
+            } else {
+                printf("code %p, byte code 0x%02x not implemented\n", ip-1, ip[-1]);
+                assert(0);
+                return ip;
+            }
+            break;
+    }
+
+    return ip;
+}
+
+void prof_print_instr(const byte* ip, mp_code_state_t *code_state) {
+    mp_dis_instruction_t _instruction, *instruction = &_instruction;
+    prof_opcode_decode(ip, code_state->fun_bc->rc->const_table, instruction);
+    const mp_raw_code_t *rc = code_state->fun_bc->rc;
+    const mp_bytecode_prelude_t *prelude = &rc->prelude;
+
+    mp_uint_t offset = (ip) - prelude->bytecode;
+    mp_printf(&mp_plat_print, "instr");
+    
+    /* long path */ if (1) {
+        mp_printf(&mp_plat_print,
+            "@0x%p:%q:%q+0x%04x:%d",
+            ip,
+            prelude->qstr_source_file,
+            prelude->qstr_block_name,
+            offset,
+            prof_bytecode_lineno(rc, offset)
+        );
+    }
+    
+    /* bytecode */ if (0) {
+        mp_printf(&mp_plat_print,
+            " %02x %02x %02x %02x",
+            ip[0], ip[1], ip[2], ip[3], ip[4]
+        );
+    }
+    
+    mp_printf(&mp_plat_print,
+        " 0x%02x %q [%d]",
+        *(byte*)(ip),
+        instruction->qstr_opname,
+        instruction->arg
+    );
+    if (instruction->argobj != mp_const_none) {
+        mp_printf(&mp_plat_print, " $");
+        mp_obj_print_helper(&mp_plat_print, instruction->argobj, PRINT_REPR);
+    }
+    if (instruction->argobjex_cache != mp_const_none) {
+        mp_printf(&mp_plat_print, " #");
+        mp_obj_print_helper(&mp_plat_print, instruction->argobjex_cache, PRINT_REPR);
+    }
+
+    mp_printf(&mp_plat_print, "\n");
+}
+
+#endif // PROF_PRINT_INSTR
+
 #endif // MICROPY_PY_SYS_SETTRACE

--- a/py/profiling.h
+++ b/py/profiling.h
@@ -69,5 +69,27 @@ mp_obj_t prof_frame_update(const mp_code_state_t *code_state);
 
 void prof_extract_prelude(const byte *bytecode, mp_bytecode_prelude_t *prelude);
 
+
+// This section is for debugging the settrace feature itself
+// and should never make it in to any public build.
+#define PROF_INSTR_DEBUG_PRINT_ENABLE 0
+#if PROF_INSTR_DEBUG_PRINT_ENABLE
+
+    // If you really want to use this feature comment the following line.
+    #error "Compiling with internal debug features enabled! Comment out this line if you know what you are doing."
+
+    typedef struct _mp_dis_instruction_t {
+        mp_uint_t qstr_opname;
+        mp_uint_t arg;
+        mp_obj_t argobj;
+        mp_obj_t argobjex_cache;
+    } mp_dis_instruction_t;
+
+    void prof_print_instr(const byte* ip, mp_code_state_t *code_state);
+    #define PROF_INSTR_DEBUG_PRINT(current_ip) prof_print_instr((current_ip), code_state)
+#else
+    #define PROF_INSTR_DEBUG_PRINT(current_ip)
+#endif // PROF_INSTR_DEBUG_PRINT_ENABLE
+
 #endif // MICROPY_PY_SYS_SETTRACE
 #endif // MICROPY_INCLUDED_PY_PROFILING_H

--- a/py/profiling.h
+++ b/py/profiling.h
@@ -1,0 +1,73 @@
+/*
+ * This file is part of the MicroPython project, http://micropython.org/
+ *
+ * The MIT License (MIT)
+ *
+ * Copyright (c) SatoshiLabs
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#ifndef MICROPY_INCLUDED_PY_PROFILING_H
+#define MICROPY_INCLUDED_PY_PROFILING_H
+
+#include "py/objtype.h"
+#include "py/objgenerator.h"
+#include "py/objfun.h"
+#include "py/bc.h"
+
+#if MICROPY_PY_SYS_SETTRACE
+
+#define prof_is_executing MP_STATE_THREAD(prof_callback_is_executing)
+
+// This is the implementation for the sys.settrace
+mp_obj_t prof_settrace(mp_obj_t callback);
+
+// For every VM instruction tick this function deduces events from the state.
+mp_obj_t prof_instr_tick(mp_code_state_t *code_state, bool is_exception);
+
+
+typedef struct _mp_obj_code_t {
+    mp_obj_base_t base;
+    const mp_raw_code_t *rc;
+    mp_obj_dict_t *dict_locals;
+    mp_obj_t lnotab;
+} mp_obj_code_t;
+
+typedef struct _mp_obj_frame_t {
+    mp_obj_base_t base;
+    const mp_code_state_t *code_state;
+    struct _mp_obj_frame_t *back;
+    mp_obj_t callback;
+    mp_obj_code_t *code;
+    mp_uint_t lasti;
+    mp_uint_t lineno;
+    bool trace_opcodes;
+} mp_obj_frame_t;
+
+mp_obj_t mp_obj_new_code(const mp_raw_code_t *rc);
+mp_obj_t mp_obj_new_frame(const mp_code_state_t *code_state);
+
+mp_obj_t prof_frame_enter(mp_code_state_t *code_state);
+mp_obj_t prof_frame_update(const mp_code_state_t *code_state);
+
+void prof_extract_prelude(const byte *bytecode, mp_bytecode_prelude_t *prelude);
+
+#endif // MICROPY_PY_SYS_SETTRACE
+#endif // MICROPY_INCLUDED_PY_PROFILING_H

--- a/py/py.mk
+++ b/py/py.mk
@@ -86,6 +86,7 @@ PY_CORE_O_BASENAME = $(addprefix py/,\
 	stackctrl.o \
 	argcheck.o \
 	warning.o \
+	profiling.o \
 	map.o \
 	obj.o \
 	objarray.o \

--- a/py/runtime.c
+++ b/py/runtime.c
@@ -122,6 +122,12 @@ void mp_init(void) {
     MP_STATE_VM(sys_exitfunc) = mp_const_none;
     #endif
 
+    #if MICROPY_PY_SYS_SETTRACE
+    MP_STATE_THREAD(prof_trace_callback) = NULL;
+    MP_STATE_THREAD(prof_callback_is_executing) = false;
+    MP_STATE_THREAD(current_code_state) = NULL;
+    #endif
+
     #if MICROPY_PY_THREAD_GIL
     mp_thread_mutex_init(&MP_STATE_VM(gil_mutex));
     #endif

--- a/py/vm.c
+++ b/py/vm.c
@@ -34,6 +34,7 @@
 #include "py/runtime.h"
 #include "py/bc0.h"
 #include "py/bc.h"
+#include "py/profiling.h"
 
 #if 0
 #define TRACE(ip) printf("sp=%d ", (int)(sp - &code_state->state[0] + 1)); mp_bytecode_print2(ip, 1, code_state->fun_bc->const_table);
@@ -108,6 +109,55 @@
     exc_sp--; /* pop back to previous exception handler */ \
     CLEAR_SYS_EXC_INFO() /* just clear sys.exc_info(), not compliant, but it shouldn't be used in 1st place */
 
+#if MICROPY_PY_SYS_SETTRACE
+
+#define FRAME_SETUP() do { \
+    assert(code_state != code_state->prev_state); \
+    MP_STATE_THREAD(current_code_state) = code_state; \
+    assert(code_state != code_state->prev_state); \
+} while(0)
+
+#define FRAME_ENTER() do { \
+    assert(code_state != code_state->prev_state); \
+    code_state->prev_state = MP_STATE_THREAD(current_code_state); \
+    assert(code_state != code_state->prev_state); \
+    if (!prof_is_executing) { \
+        prof_frame_enter(code_state); \
+    } \
+} while(0)
+
+#define FRAME_LEAVE() do { \
+    assert(code_state != code_state->prev_state); \
+    MP_STATE_THREAD(current_code_state) = code_state->prev_state; \
+    assert(code_state != code_state->prev_state); \
+} while(0)
+
+#define FRAME_UPDATE() do { \
+    assert(MP_STATE_THREAD(current_code_state) == code_state); \
+    if (!prof_is_executing) { \
+        code_state->frame = MP_OBJ_TO_PTR(prof_frame_update(code_state)); \
+    } \
+} while(0)
+
+#define TRACE_TICK(current_ip, current_sp, is_exception) do { \
+    assert(code_state != code_state->prev_state); \
+    assert(MP_STATE_THREAD(current_code_state) == code_state); \
+    if (!prof_is_executing && code_state->frame && MP_STATE_THREAD(prof_trace_callback)) { \
+        PROF_INSTR_DEBUG_PRINT(code_state->ip); \
+    } \
+    if (!prof_is_executing && code_state->frame && code_state->frame->callback) { \
+        prof_instr_tick(code_state, is_exception); \
+    } \
+} while(0)
+
+#else // MICROPY_PY_SYS_SETTRACE
+#define FRAME_SETUP()
+#define FRAME_ENTER()
+#define FRAME_LEAVE()
+#define FRAME_UPDATE()
+#define TRACE_TICK(current_ip, current_sp, is_exception)
+#endif // MICROPY_PY_SYS_SETTRACE
+
 // fastn has items in reverse order (fastn[0] is local[0], fastn[-1] is local[1], etc)
 // sp points to bottom of stack which grows up
 // returns:
@@ -128,6 +178,7 @@ mp_vm_return_kind_t mp_execute_bytecode(mp_code_state_t *code_state, volatile mp
     #define DISPATCH() do { \
         TRACE(ip); \
         MARK_EXC_IP_GLOBAL(); \
+        TRACE_TICK(ip, sp, false); \
         goto *entry_table[*ip++]; \
     } while (0)
     #define DISPATCH_WITH_PEND_EXC_CHECK() goto pending_exception_check
@@ -148,7 +199,14 @@ mp_vm_return_kind_t mp_execute_bytecode(mp_code_state_t *code_state, volatile mp
 
 #if MICROPY_STACKLESS
 run_code_state: ;
-#endif
+#endif // MICROPY_STACKLESS
+FRAME_ENTER();
+
+#if MICROPY_STACKLESS
+run_code_state_from_return: ;
+#endif // MICROPY_STACKLESS
+FRAME_SETUP();
+
     // Pointers which are constant for particular invocation of mp_execute_bytecode()
     mp_obj_t * /*const*/ fastn;
     mp_exc_stack_t * /*const*/ exc_stack;
@@ -198,6 +256,7 @@ dispatch_loop:
 #else
                 TRACE(ip);
                 MARK_EXC_IP_GLOBAL();
+                TRACE_TICK(ip, sp, false);
                 switch (*ip++) {
 #endif
 
@@ -323,6 +382,7 @@ dispatch_loop:
 
                 #if !MICROPY_OPT_CACHE_MAP_LOOKUP_IN_BYTECODE
                 ENTRY(MP_BC_LOAD_ATTR): {
+                    FRAME_UPDATE();
                     MARK_EXC_IP_SELECTIVE();
                     DECODE_QSTR;
                     SET_TOP(mp_load_attr(TOP(), qst));
@@ -330,6 +390,7 @@ dispatch_loop:
                 }
                 #else
                 ENTRY(MP_BC_LOAD_ATTR): {
+                    FRAME_UPDATE();
                     MARK_EXC_IP_SELECTIVE();
                     DECODE_QSTR;
                     mp_obj_t top = TOP();
@@ -415,6 +476,7 @@ dispatch_loop:
 
                 #if !MICROPY_OPT_CACHE_MAP_LOOKUP_IN_BYTECODE
                 ENTRY(MP_BC_STORE_ATTR): {
+                    FRAME_UPDATE();
                     MARK_EXC_IP_SELECTIVE();
                     DECODE_QSTR;
                     mp_store_attr(sp[0], qst, sp[-1]);
@@ -428,6 +490,7 @@ dispatch_loop:
                 // consequence of this is that we can't use MP_MAP_LOOKUP_ADD_IF_NOT_FOUND
                 // in the fast-path below, because that store could override a property.
                 ENTRY(MP_BC_STORE_ATTR): {
+                    FRAME_UPDATE();
                     MARK_EXC_IP_SELECTIVE();
                     DECODE_QSTR;
                     mp_obj_t top = TOP();
@@ -738,6 +801,7 @@ unwind_jump:;
                 }
 
                 ENTRY(MP_BC_FOR_ITER): {
+                    FRAME_UPDATE();
                     MARK_EXC_IP_SELECTIVE();
                     DECODE_ULABEL; // the jump offset if iteration finishes; for labels are always forward
                     code_state->sp = sp;
@@ -753,6 +817,13 @@ unwind_jump:;
                         ip += ulab; // jump to after for-block
                     } else {
                         PUSH(value); // push the next iteration value
+                        #if MICROPY_PY_SYS_SETTRACE
+                        // LINE event should trigger for every iteration
+                        // so invalidate the last trigger.
+                        if (code_state->frame) {
+                            code_state->frame->lineno = 0;
+                        }
+                        #endif
                     }
                     DISPATCH();
                 }
@@ -887,6 +958,7 @@ unwind_jump:;
                 }
 
                 ENTRY(MP_BC_CALL_FUNCTION): {
+                    FRAME_UPDATE();
                     MARK_EXC_IP_SELECTIVE();
                     DECODE_UINT;
                     // unum & 0xff == n_positional
@@ -921,6 +993,7 @@ unwind_jump:;
                 }
 
                 ENTRY(MP_BC_CALL_FUNCTION_VAR_KW): {
+                    FRAME_UPDATE();
                     MARK_EXC_IP_SELECTIVE();
                     DECODE_UINT;
                     // unum & 0xff == n_positional
@@ -966,6 +1039,7 @@ unwind_jump:;
                 }
 
                 ENTRY(MP_BC_CALL_METHOD): {
+                    FRAME_UPDATE();
                     MARK_EXC_IP_SELECTIVE();
                     DECODE_UINT;
                     // unum & 0xff == n_positional
@@ -1004,6 +1078,7 @@ unwind_jump:;
                 }
 
                 ENTRY(MP_BC_CALL_METHOD_VAR_KW): {
+                    FRAME_UPDATE();
                     MARK_EXC_IP_SELECTIVE();
                     DECODE_UINT;
                     // unum & 0xff == n_positional
@@ -1096,9 +1171,10 @@ unwind_return:
                         #endif
                         code_state = new_code_state;
                         *code_state->sp = res;
-                        goto run_code_state;
+                        goto run_code_state_from_return;
                     }
                     #endif
+                    FRAME_LEAVE();
                     return MP_VM_RETURN_NORMAL;
 
                 ENTRY(MP_BC_RAISE_VARARGS): {
@@ -1136,6 +1212,7 @@ yield:
                     code_state->ip = ip;
                     code_state->sp = sp;
                     code_state->exc_sp = MP_TAGPTR_MAKE(exc_sp, 0);
+                    FRAME_LEAVE();
                     return MP_VM_RETURN_YIELD;
 
                 ENTRY(MP_BC_YIELD_FROM): {
@@ -1192,6 +1269,7 @@ yield:
                 }
 
                 ENTRY(MP_BC_IMPORT_NAME): {
+                    FRAME_UPDATE();
                     MARK_EXC_IP_SELECTIVE();
                     DECODE_QSTR;
                     mp_obj_t obj = POP();
@@ -1200,6 +1278,7 @@ yield:
                 }
 
                 ENTRY(MP_BC_IMPORT_FROM): {
+                    FRAME_UPDATE();
                     MARK_EXC_IP_SELECTIVE();
                     DECODE_QSTR;
                     mp_obj_t obj = mp_import_from(TOP(), qst);
@@ -1265,6 +1344,7 @@ yield:
                     mp_obj_t obj = mp_obj_new_exception_msg(&mp_type_NotImplementedError, "byte code not implemented");
                     nlr_pop();
                     code_state->state[0] = obj;
+                    FRAME_LEAVE();
                     return MP_VM_RETURN_EXCEPTION;
                 }
 
@@ -1354,6 +1434,13 @@ exception_handler:
                     }
                 }
             }
+
+            #if MICROPY_PY_SYS_SETTRACE
+            // Exceotions are traced here.
+            if (mp_obj_is_subclass_fast(MP_OBJ_FROM_PTR(((mp_obj_base_t*)nlr.ret_val)->type), MP_OBJ_FROM_PTR(&mp_type_Exception))) {
+                TRACE_TICK(code_state->ip, code_state->sp, true /* yes, it's an exception */);
+            }
+            #endif
 
 #if MICROPY_STACKLESS
 unwind_loop:
@@ -1456,6 +1543,7 @@ unwind_loop:
                 // propagate exception to higher level
                 // Note: ip and sp don't have usable values at this point
                 code_state->state[0] = MP_OBJ_FROM_PTR(nlr.ret_val); // put exception here because sp is invalid
+                FRAME_LEAVE();
                 return MP_VM_RETURN_EXCEPTION;
             }
         }

--- a/tests/cmdline/cmd_showbc.py.exp
+++ b/tests/cmdline/cmd_showbc.py.exp
@@ -417,6 +417,7 @@ arg names:
 (N_STATE 1)
 (N_EXC_STACK 0)
   bc=-1 line=1
+########
   bc=13 line=149
 00 LOAD_NAME __name__ (cache=0)
 04 STORE_NAME __module__
@@ -450,6 +451,7 @@ arg names: * * *
 (N_EXC_STACK 0)
   bc=-\\d\+ line=1
   bc=0 line=59
+########
 00 LOAD_NULL
 01 LOAD_FAST 2
 02 LOAD_NULL
@@ -473,6 +475,7 @@ arg names: * * *
 (N_EXC_STACK 0)
   bc=-\\d\+ line=1
   bc=0 line=60
+########
 00 BUILD_LIST 0
 02 LOAD_FAST 2
 03 GET_ITER_STACK

--- a/tests/misc/trace_profiling.py
+++ b/tests/misc/trace_profiling.py
@@ -1,0 +1,109 @@
+import sys
+
+try:
+    import micropython
+except:
+    pass
+
+if not 'settrace' in dir(sys):
+    print("SKIP")
+    raise SystemExit
+
+if 'micropython' in globals():
+    print('this is micropython')
+    from uio import open
+else:
+    print('this is other python')
+
+def print_stacktrace(frame, level = 0):
+    # Ignore CPython specific helpers.
+    if frame.f_globals['__name__'].startswith('importlib.'):
+        print_stacktrace(frame.f_back, level)
+        return
+
+    print("%2d: %s@%s:%s => %s:%d"%(
+        level, "  ",
+        frame.f_globals['__name__'],
+        frame.f_code.co_name,
+        # hack to reduce full path to some pseudo-relative
+        'misc'+''.join(frame.f_code.co_filename.split('tests/misc')[-1:]),
+        frame.f_lineno,
+    ))
+
+    if (frame.f_back):
+        print_stacktrace(frame.f_back, level + 1)
+
+class _Prof:
+    trace_count = 0;
+
+    def trace_tick(self, frame, event, arg):
+        self.trace_count += 1
+        print_stacktrace(frame)
+
+global __prof__
+if not '__prof__' in globals():
+    __prof__ = _Prof()
+
+alice_handler_set = False
+def trace_tick_handler_alice(frame, event, arg):
+    print("### trace_handler::Alice event:", event)
+    __prof__.trace_tick(frame, event, arg)
+    return trace_tick_handler_alice
+
+bob_handler_set = False
+def trace_tick_handler_bob(frame, event, arg):
+    print("### trace_handler::Bob event:", event)
+    __prof__.trace_tick(frame, event, arg)
+    return trace_tick_handler_bob
+
+def trace_tick_handler(frame, event, arg):
+    # Ignore CPython specific helpers.
+    if frame.f_globals['__name__'].startswith('importlib.'):
+        return
+
+    print("### trace_handler::main event:", event)
+    __prof__.trace_tick(frame, event, arg)
+
+    if frame.f_code.co_name != 'factorial':
+        return trace_tick_handler
+
+    global alice_handler_set
+    if event == 'call' and not alice_handler_set:
+        alice_handler_set = True
+        return trace_tick_handler_alice
+
+    global bob_handler_set
+    if event == 'call' and  not bob_handler_set:
+        bob_handler_set = True
+        return trace_tick_handler_bob
+
+    return trace_tick_handler
+
+def atexit_summary():
+    print("\n------------------ script exited ------------------")
+    print("Total traces executed: ", __prof__.trace_count)
+
+def factorial(n):
+    if n == 0:
+        return 1
+    else:
+        return n * factorial(n-1)
+
+def do():
+    # These commands are here to demonstrate some execution being traced.
+    print("Who loves the sun?")
+    print("Not every-", factorial(3))
+
+    from trace_subdir import trace_generic
+    trace_generic.run_tests()
+    return
+
+
+sys.settrace(trace_tick_handler)
+do()
+sys.settrace(None)
+
+print('nothing to trace here')
+
+atexit_summary()
+

--- a/tests/misc/trace_profiling.py.exp
+++ b/tests/misc/trace_profiling.py.exp
@@ -1,0 +1,1193 @@
+this is micropython
+### trace_handler::main event: call
+ 0:   @__main__:do => miscmisc/trace_profiling.py:92
+ 1:   @__main__:<module> => miscmisc/trace_profiling.py:103
+### trace_handler::main event: line
+ 0:   @__main__:do => miscmisc/trace_profiling.py:94
+ 1:   @__main__:<module> => miscmisc/trace_profiling.py:103
+Who loves the sun?
+### trace_handler::main event: line
+ 0:   @__main__:do => miscmisc/trace_profiling.py:95
+ 1:   @__main__:<module> => miscmisc/trace_profiling.py:103
+### trace_handler::main event: call
+ 0:   @__main__:factorial => miscmisc/trace_profiling.py:86
+ 1:   @__main__:do => miscmisc/trace_profiling.py:95
+ 2:   @__main__:<module> => miscmisc/trace_profiling.py:103
+### trace_handler::Alice event: line
+ 0:   @__main__:factorial => miscmisc/trace_profiling.py:87
+ 1:   @__main__:do => miscmisc/trace_profiling.py:95
+ 2:   @__main__:<module> => miscmisc/trace_profiling.py:103
+### trace_handler::Alice event: line
+ 0:   @__main__:factorial => miscmisc/trace_profiling.py:90
+ 1:   @__main__:do => miscmisc/trace_profiling.py:95
+ 2:   @__main__:<module> => miscmisc/trace_profiling.py:103
+### trace_handler::main event: call
+ 0:   @__main__:factorial => miscmisc/trace_profiling.py:86
+ 1:   @__main__:factorial => miscmisc/trace_profiling.py:90
+ 2:   @__main__:do => miscmisc/trace_profiling.py:95
+ 3:   @__main__:<module> => miscmisc/trace_profiling.py:103
+### trace_handler::Bob event: line
+ 0:   @__main__:factorial => miscmisc/trace_profiling.py:87
+ 1:   @__main__:factorial => miscmisc/trace_profiling.py:90
+ 2:   @__main__:do => miscmisc/trace_profiling.py:95
+ 3:   @__main__:<module> => miscmisc/trace_profiling.py:103
+### trace_handler::Bob event: line
+ 0:   @__main__:factorial => miscmisc/trace_profiling.py:90
+ 1:   @__main__:factorial => miscmisc/trace_profiling.py:90
+ 2:   @__main__:do => miscmisc/trace_profiling.py:95
+ 3:   @__main__:<module> => miscmisc/trace_profiling.py:103
+### trace_handler::main event: call
+ 0:   @__main__:factorial => miscmisc/trace_profiling.py:86
+ 1:   @__main__:factorial => miscmisc/trace_profiling.py:90
+ 2:   @__main__:factorial => miscmisc/trace_profiling.py:90
+ 3:   @__main__:do => miscmisc/trace_profiling.py:95
+ 4:   @__main__:<module> => miscmisc/trace_profiling.py:103
+### trace_handler::main event: line
+ 0:   @__main__:factorial => miscmisc/trace_profiling.py:87
+ 1:   @__main__:factorial => miscmisc/trace_profiling.py:90
+ 2:   @__main__:factorial => miscmisc/trace_profiling.py:90
+ 3:   @__main__:do => miscmisc/trace_profiling.py:95
+ 4:   @__main__:<module> => miscmisc/trace_profiling.py:103
+### trace_handler::main event: line
+ 0:   @__main__:factorial => miscmisc/trace_profiling.py:90
+ 1:   @__main__:factorial => miscmisc/trace_profiling.py:90
+ 2:   @__main__:factorial => miscmisc/trace_profiling.py:90
+ 3:   @__main__:do => miscmisc/trace_profiling.py:95
+ 4:   @__main__:<module> => miscmisc/trace_profiling.py:103
+### trace_handler::main event: call
+ 0:   @__main__:factorial => miscmisc/trace_profiling.py:86
+ 1:   @__main__:factorial => miscmisc/trace_profiling.py:90
+ 2:   @__main__:factorial => miscmisc/trace_profiling.py:90
+ 3:   @__main__:factorial => miscmisc/trace_profiling.py:90
+ 4:   @__main__:do => miscmisc/trace_profiling.py:95
+ 5:   @__main__:<module> => miscmisc/trace_profiling.py:103
+### trace_handler::main event: line
+ 0:   @__main__:factorial => miscmisc/trace_profiling.py:87
+ 1:   @__main__:factorial => miscmisc/trace_profiling.py:90
+ 2:   @__main__:factorial => miscmisc/trace_profiling.py:90
+ 3:   @__main__:factorial => miscmisc/trace_profiling.py:90
+ 4:   @__main__:do => miscmisc/trace_profiling.py:95
+ 5:   @__main__:<module> => miscmisc/trace_profiling.py:103
+### trace_handler::main event: line
+ 0:   @__main__:factorial => miscmisc/trace_profiling.py:88
+ 1:   @__main__:factorial => miscmisc/trace_profiling.py:90
+ 2:   @__main__:factorial => miscmisc/trace_profiling.py:90
+ 3:   @__main__:factorial => miscmisc/trace_profiling.py:90
+ 4:   @__main__:do => miscmisc/trace_profiling.py:95
+ 5:   @__main__:<module> => miscmisc/trace_profiling.py:103
+### trace_handler::main event: return
+ 0:   @__main__:factorial => miscmisc/trace_profiling.py:88
+ 1:   @__main__:factorial => miscmisc/trace_profiling.py:90
+ 2:   @__main__:factorial => miscmisc/trace_profiling.py:90
+ 3:   @__main__:factorial => miscmisc/trace_profiling.py:90
+ 4:   @__main__:do => miscmisc/trace_profiling.py:95
+ 5:   @__main__:<module> => miscmisc/trace_profiling.py:103
+### trace_handler::main event: return
+ 0:   @__main__:factorial => miscmisc/trace_profiling.py:90
+ 1:   @__main__:factorial => miscmisc/trace_profiling.py:90
+ 2:   @__main__:factorial => miscmisc/trace_profiling.py:90
+ 3:   @__main__:do => miscmisc/trace_profiling.py:95
+ 4:   @__main__:<module> => miscmisc/trace_profiling.py:103
+### trace_handler::Bob event: return
+ 0:   @__main__:factorial => miscmisc/trace_profiling.py:90
+ 1:   @__main__:factorial => miscmisc/trace_profiling.py:90
+ 2:   @__main__:do => miscmisc/trace_profiling.py:95
+ 3:   @__main__:<module> => miscmisc/trace_profiling.py:103
+### trace_handler::Alice event: return
+ 0:   @__main__:factorial => miscmisc/trace_profiling.py:90
+ 1:   @__main__:do => miscmisc/trace_profiling.py:95
+ 2:   @__main__:<module> => miscmisc/trace_profiling.py:103
+Not every- 6
+### trace_handler::main event: line
+ 0:   @__main__:do => miscmisc/trace_profiling.py:97
+ 1:   @__main__:<module> => miscmisc/trace_profiling.py:103
+### trace_handler::main event: call
+ 0:   @trace_subdir.trace_generic:<module> => misc/trace_subdir/trace_generic.py:1
+ 1:   @__main__:do => miscmisc/trace_profiling.py:97
+ 2:   @__main__:<module> => miscmisc/trace_profiling.py:103
+### trace_handler::main event: line
+ 0:   @trace_subdir.trace_generic:<module> => misc/trace_subdir/trace_generic.py:1
+ 1:   @__main__:do => miscmisc/trace_profiling.py:97
+ 2:   @__main__:<module> => miscmisc/trace_profiling.py:103
+Now comes the language constructions tests.
+### trace_handler::main event: line
+ 0:   @trace_subdir.trace_generic:<module> => misc/trace_subdir/trace_generic.py:4
+ 1:   @__main__:do => miscmisc/trace_profiling.py:97
+ 2:   @__main__:<module> => miscmisc/trace_profiling.py:103
+### trace_handler::main event: line
+ 0:   @trace_subdir.trace_generic:<module> => misc/trace_subdir/trace_generic.py:11
+ 1:   @__main__:do => miscmisc/trace_profiling.py:97
+ 2:   @__main__:<module> => miscmisc/trace_profiling.py:103
+### trace_handler::main event: line
+ 0:   @trace_subdir.trace_generic:<module> => misc/trace_subdir/trace_generic.py:19
+ 1:   @__main__:do => miscmisc/trace_profiling.py:97
+ 2:   @__main__:<module> => miscmisc/trace_profiling.py:103
+### trace_handler::main event: line
+ 0:   @trace_subdir.trace_generic:<module> => misc/trace_subdir/trace_generic.py:35
+ 1:   @__main__:do => miscmisc/trace_profiling.py:97
+ 2:   @__main__:<module> => miscmisc/trace_profiling.py:103
+### trace_handler::main event: line
+ 0:   @trace_subdir.trace_generic:<module> => misc/trace_subdir/trace_generic.py:46
+ 1:   @__main__:do => miscmisc/trace_profiling.py:97
+ 2:   @__main__:<module> => miscmisc/trace_profiling.py:103
+### trace_handler::main event: line
+ 0:   @trace_subdir.trace_generic:<module> => misc/trace_subdir/trace_generic.py:50
+ 1:   @__main__:do => miscmisc/trace_profiling.py:97
+ 2:   @__main__:<module> => miscmisc/trace_profiling.py:103
+### trace_handler::main event: line
+ 0:   @trace_subdir.trace_generic:<module> => misc/trace_subdir/trace_generic.py:77
+ 1:   @__main__:do => miscmisc/trace_profiling.py:97
+ 2:   @__main__:<module> => miscmisc/trace_profiling.py:103
+### trace_handler::main event: line
+ 0:   @trace_subdir.trace_generic:<module> => misc/trace_subdir/trace_generic.py:82
+ 1:   @__main__:do => miscmisc/trace_profiling.py:97
+ 2:   @__main__:<module> => miscmisc/trace_profiling.py:103
+### trace_handler::main event: line
+ 0:   @trace_subdir.trace_generic:<module> => misc/trace_subdir/trace_generic.py:88
+ 1:   @__main__:do => miscmisc/trace_profiling.py:97
+ 2:   @__main__:<module> => miscmisc/trace_profiling.py:103
+### trace_handler::main event: call
+ 0:   @trace_subdir.trace_generic:TLClass => misc/trace_subdir/trace_generic.py:88
+ 1:   @trace_subdir.trace_generic:<module> => misc/trace_subdir/trace_generic.py:88
+ 2:   @__main__:do => miscmisc/trace_profiling.py:97
+ 3:   @__main__:<module> => miscmisc/trace_profiling.py:103
+### trace_handler::main event: line
+ 0:   @trace_subdir.trace_generic:TLClass => misc/trace_subdir/trace_generic.py:88
+ 1:   @trace_subdir.trace_generic:<module> => misc/trace_subdir/trace_generic.py:88
+ 2:   @__main__:do => miscmisc/trace_profiling.py:97
+ 3:   @__main__:<module> => miscmisc/trace_profiling.py:103
+### trace_handler::main event: line
+ 0:   @trace_subdir.trace_generic:TLClass => misc/trace_subdir/trace_generic.py:89
+ 1:   @trace_subdir.trace_generic:<module> => misc/trace_subdir/trace_generic.py:88
+ 2:   @__main__:do => miscmisc/trace_profiling.py:97
+ 3:   @__main__:<module> => miscmisc/trace_profiling.py:103
+### trace_handler::main event: line
+ 0:   @trace_subdir.trace_generic:TLClass => misc/trace_subdir/trace_generic.py:91
+ 1:   @trace_subdir.trace_generic:<module> => misc/trace_subdir/trace_generic.py:88
+ 2:   @__main__:do => miscmisc/trace_profiling.py:97
+ 3:   @__main__:<module> => miscmisc/trace_profiling.py:103
+### trace_handler::main event: return
+ 0:   @trace_subdir.trace_generic:TLClass => misc/trace_subdir/trace_generic.py:91
+ 1:   @trace_subdir.trace_generic:<module> => misc/trace_subdir/trace_generic.py:88
+ 2:   @__main__:do => miscmisc/trace_profiling.py:97
+ 3:   @__main__:<module> => miscmisc/trace_profiling.py:103
+### trace_handler::main event: line
+ 0:   @trace_subdir.trace_generic:<module> => misc/trace_subdir/trace_generic.py:93
+ 1:   @__main__:do => miscmisc/trace_profiling.py:97
+ 2:   @__main__:<module> => miscmisc/trace_profiling.py:103
+### trace_handler::main event: line
+ 0:   @trace_subdir.trace_generic:<module> => misc/trace_subdir/trace_generic.py:115
+ 1:   @__main__:do => miscmisc/trace_profiling.py:97
+ 2:   @__main__:<module> => miscmisc/trace_profiling.py:103
+### trace_handler::main event: line
+ 0:   @trace_subdir.trace_generic:<module> => misc/trace_subdir/trace_generic.py:127
+ 1:   @__main__:do => miscmisc/trace_profiling.py:97
+ 2:   @__main__:<module> => miscmisc/trace_profiling.py:103
+And it's done!
+### trace_handler::main event: return
+ 0:   @trace_subdir.trace_generic:<module> => misc/trace_subdir/trace_generic.py:127
+ 1:   @__main__:do => miscmisc/trace_profiling.py:97
+ 2:   @__main__:<module> => miscmisc/trace_profiling.py:103
+### trace_handler::main event: line
+ 0:   @__main__:do => miscmisc/trace_profiling.py:98
+ 1:   @__main__:<module> => miscmisc/trace_profiling.py:103
+### trace_handler::main event: call
+ 0:   @trace_subdir.trace_generic:run_tests => misc/trace_subdir/trace_generic.py:115
+ 1:   @__main__:do => miscmisc/trace_profiling.py:98
+ 2:   @__main__:<module> => miscmisc/trace_profiling.py:103
+### trace_handler::main event: line
+ 0:   @trace_subdir.trace_generic:run_tests => misc/trace_subdir/trace_generic.py:116
+ 1:   @__main__:do => miscmisc/trace_profiling.py:98
+ 2:   @__main__:<module> => miscmisc/trace_profiling.py:103
+### trace_handler::main event: call
+ 0:   @trace_subdir.trace_generic:test_func => misc/trace_subdir/trace_generic.py:4
+ 1:   @trace_subdir.trace_generic:run_tests => misc/trace_subdir/trace_generic.py:116
+ 2:   @__main__:do => miscmisc/trace_profiling.py:98
+ 3:   @__main__:<module> => miscmisc/trace_profiling.py:103
+### trace_handler::main event: line
+ 0:   @trace_subdir.trace_generic:test_func => misc/trace_subdir/trace_generic.py:5
+ 1:   @trace_subdir.trace_generic:run_tests => misc/trace_subdir/trace_generic.py:116
+ 2:   @__main__:do => miscmisc/trace_profiling.py:98
+ 3:   @__main__:<module> => miscmisc/trace_profiling.py:103
+### trace_handler::main event: line
+ 0:   @trace_subdir.trace_generic:test_func => misc/trace_subdir/trace_generic.py:8
+ 1:   @trace_subdir.trace_generic:run_tests => misc/trace_subdir/trace_generic.py:116
+ 2:   @__main__:do => miscmisc/trace_profiling.py:98
+ 3:   @__main__:<module> => miscmisc/trace_profiling.py:103
+### trace_handler::main event: call
+ 0:   @trace_subdir.trace_generic:test_sub_func => misc/trace_subdir/trace_generic.py:5
+ 1:   @trace_subdir.trace_generic:test_func => misc/trace_subdir/trace_generic.py:8
+ 2:   @trace_subdir.trace_generic:run_tests => misc/trace_subdir/trace_generic.py:116
+ 3:   @__main__:do => miscmisc/trace_profiling.py:98
+ 4:   @__main__:<module> => miscmisc/trace_profiling.py:103
+### trace_handler::main event: line
+ 0:   @trace_subdir.trace_generic:test_sub_func => misc/trace_subdir/trace_generic.py:6
+ 1:   @trace_subdir.trace_generic:test_func => misc/trace_subdir/trace_generic.py:8
+ 2:   @trace_subdir.trace_generic:run_tests => misc/trace_subdir/trace_generic.py:116
+ 3:   @__main__:do => miscmisc/trace_profiling.py:98
+ 4:   @__main__:<module> => miscmisc/trace_profiling.py:103
+test_function
+### trace_handler::main event: return
+ 0:   @trace_subdir.trace_generic:test_sub_func => misc/trace_subdir/trace_generic.py:6
+ 1:   @trace_subdir.trace_generic:test_func => misc/trace_subdir/trace_generic.py:8
+ 2:   @trace_subdir.trace_generic:run_tests => misc/trace_subdir/trace_generic.py:116
+ 3:   @__main__:do => miscmisc/trace_profiling.py:98
+ 4:   @__main__:<module> => miscmisc/trace_profiling.py:103
+### trace_handler::main event: return
+ 0:   @trace_subdir.trace_generic:test_func => misc/trace_subdir/trace_generic.py:8
+ 1:   @trace_subdir.trace_generic:run_tests => misc/trace_subdir/trace_generic.py:116
+ 2:   @__main__:do => miscmisc/trace_profiling.py:98
+ 3:   @__main__:<module> => miscmisc/trace_profiling.py:103
+### trace_handler::main event: line
+ 0:   @trace_subdir.trace_generic:run_tests => misc/trace_subdir/trace_generic.py:117
+ 1:   @__main__:do => miscmisc/trace_profiling.py:98
+ 2:   @__main__:<module> => miscmisc/trace_profiling.py:103
+### trace_handler::main event: call
+ 0:   @trace_subdir.trace_generic:test_closure => misc/trace_subdir/trace_generic.py:11
+ 1:   @trace_subdir.trace_generic:run_tests => misc/trace_subdir/trace_generic.py:117
+ 2:   @__main__:do => miscmisc/trace_profiling.py:98
+ 3:   @__main__:<module> => miscmisc/trace_profiling.py:103
+### trace_handler::main event: line
+ 0:   @trace_subdir.trace_generic:test_closure => misc/trace_subdir/trace_generic.py:13
+ 1:   @trace_subdir.trace_generic:run_tests => misc/trace_subdir/trace_generic.py:117
+ 2:   @__main__:do => miscmisc/trace_profiling.py:98
+ 3:   @__main__:<module> => miscmisc/trace_profiling.py:103
+### trace_handler::main event: line
+ 0:   @trace_subdir.trace_generic:test_closure => misc/trace_subdir/trace_generic.py:16
+ 1:   @trace_subdir.trace_generic:run_tests => misc/trace_subdir/trace_generic.py:117
+ 2:   @__main__:do => miscmisc/trace_profiling.py:98
+ 3:   @__main__:<module> => miscmisc/trace_profiling.py:103
+### trace_handler::main event: return
+ 0:   @trace_subdir.trace_generic:test_closure => misc/trace_subdir/trace_generic.py:16
+ 1:   @trace_subdir.trace_generic:run_tests => misc/trace_subdir/trace_generic.py:117
+ 2:   @__main__:do => miscmisc/trace_profiling.py:98
+ 3:   @__main__:<module> => miscmisc/trace_profiling.py:103
+### trace_handler::main event: line
+ 0:   @trace_subdir.trace_generic:run_tests => misc/trace_subdir/trace_generic.py:118
+ 1:   @__main__:do => miscmisc/trace_profiling.py:98
+ 2:   @__main__:<module> => miscmisc/trace_profiling.py:103
+### trace_handler::main event: call
+ 0:   @trace_subdir.trace_generic:make_closure => misc/trace_subdir/trace_generic.py:13
+ 1:   @trace_subdir.trace_generic:run_tests => misc/trace_subdir/trace_generic.py:118
+ 2:   @__main__:do => miscmisc/trace_profiling.py:98
+ 3:   @__main__:<module> => miscmisc/trace_profiling.py:103
+### trace_handler::main event: line
+ 0:   @trace_subdir.trace_generic:make_closure => misc/trace_subdir/trace_generic.py:14
+ 1:   @trace_subdir.trace_generic:run_tests => misc/trace_subdir/trace_generic.py:118
+ 2:   @__main__:do => miscmisc/trace_profiling.py:98
+ 3:   @__main__:<module> => miscmisc/trace_profiling.py:103
+test_closure
+### trace_handler::main event: return
+ 0:   @trace_subdir.trace_generic:make_closure => misc/trace_subdir/trace_generic.py:14
+ 1:   @trace_subdir.trace_generic:run_tests => misc/trace_subdir/trace_generic.py:118
+ 2:   @__main__:do => miscmisc/trace_profiling.py:98
+ 3:   @__main__:<module> => miscmisc/trace_profiling.py:103
+### trace_handler::main event: line
+ 0:   @trace_subdir.trace_generic:run_tests => misc/trace_subdir/trace_generic.py:119
+ 1:   @__main__:do => miscmisc/trace_profiling.py:98
+ 2:   @__main__:<module> => miscmisc/trace_profiling.py:103
+### trace_handler::main event: call
+ 0:   @trace_subdir.trace_generic:test_loop => misc/trace_subdir/trace_generic.py:19
+ 1:   @trace_subdir.trace_generic:run_tests => misc/trace_subdir/trace_generic.py:119
+ 2:   @__main__:do => miscmisc/trace_profiling.py:98
+ 3:   @__main__:<module> => miscmisc/trace_profiling.py:103
+### trace_handler::main event: line
+ 0:   @trace_subdir.trace_generic:test_loop => misc/trace_subdir/trace_generic.py:21
+ 1:   @trace_subdir.trace_generic:run_tests => misc/trace_subdir/trace_generic.py:119
+ 2:   @__main__:do => miscmisc/trace_profiling.py:98
+ 3:   @__main__:<module> => miscmisc/trace_profiling.py:103
+### trace_handler::main event: line
+ 0:   @trace_subdir.trace_generic:test_loop => misc/trace_subdir/trace_generic.py:22
+ 1:   @trace_subdir.trace_generic:run_tests => misc/trace_subdir/trace_generic.py:119
+ 2:   @__main__:do => miscmisc/trace_profiling.py:98
+ 3:   @__main__:<module> => miscmisc/trace_profiling.py:103
+### trace_handler::main event: line
+ 0:   @trace_subdir.trace_generic:test_loop => misc/trace_subdir/trace_generic.py:23
+ 1:   @trace_subdir.trace_generic:run_tests => misc/trace_subdir/trace_generic.py:119
+ 2:   @__main__:do => miscmisc/trace_profiling.py:98
+ 3:   @__main__:<module> => miscmisc/trace_profiling.py:103
+### trace_handler::main event: line
+ 0:   @trace_subdir.trace_generic:test_loop => misc/trace_subdir/trace_generic.py:22
+ 1:   @trace_subdir.trace_generic:run_tests => misc/trace_subdir/trace_generic.py:119
+ 2:   @__main__:do => miscmisc/trace_profiling.py:98
+ 3:   @__main__:<module> => miscmisc/trace_profiling.py:103
+### trace_handler::main event: line
+ 0:   @trace_subdir.trace_generic:test_loop => misc/trace_subdir/trace_generic.py:23
+ 1:   @trace_subdir.trace_generic:run_tests => misc/trace_subdir/trace_generic.py:119
+ 2:   @__main__:do => miscmisc/trace_profiling.py:98
+ 3:   @__main__:<module> => miscmisc/trace_profiling.py:103
+### trace_handler::main event: line
+ 0:   @trace_subdir.trace_generic:test_loop => misc/trace_subdir/trace_generic.py:22
+ 1:   @trace_subdir.trace_generic:run_tests => misc/trace_subdir/trace_generic.py:119
+ 2:   @__main__:do => miscmisc/trace_profiling.py:98
+ 3:   @__main__:<module> => miscmisc/trace_profiling.py:103
+### trace_handler::main event: line
+ 0:   @trace_subdir.trace_generic:test_loop => misc/trace_subdir/trace_generic.py:23
+ 1:   @trace_subdir.trace_generic:run_tests => misc/trace_subdir/trace_generic.py:119
+ 2:   @__main__:do => miscmisc/trace_profiling.py:98
+ 3:   @__main__:<module> => miscmisc/trace_profiling.py:103
+### trace_handler::main event: line
+ 0:   @trace_subdir.trace_generic:test_loop => misc/trace_subdir/trace_generic.py:22
+ 1:   @trace_subdir.trace_generic:run_tests => misc/trace_subdir/trace_generic.py:119
+ 2:   @__main__:do => miscmisc/trace_profiling.py:98
+ 3:   @__main__:<module> => miscmisc/trace_profiling.py:103
+### trace_handler::main event: line
+ 0:   @trace_subdir.trace_generic:test_loop => misc/trace_subdir/trace_generic.py:23
+ 1:   @trace_subdir.trace_generic:run_tests => misc/trace_subdir/trace_generic.py:119
+ 2:   @__main__:do => miscmisc/trace_profiling.py:98
+ 3:   @__main__:<module> => miscmisc/trace_profiling.py:103
+### trace_handler::main event: line
+ 0:   @trace_subdir.trace_generic:test_loop => misc/trace_subdir/trace_generic.py:24
+ 1:   @trace_subdir.trace_generic:run_tests => misc/trace_subdir/trace_generic.py:119
+ 2:   @__main__:do => miscmisc/trace_profiling.py:98
+ 3:   @__main__:<module> => miscmisc/trace_profiling.py:103
+test_for_loop 3
+### trace_handler::main event: line
+ 0:   @trace_subdir.trace_generic:test_loop => misc/trace_subdir/trace_generic.py:27
+ 1:   @trace_subdir.trace_generic:run_tests => misc/trace_subdir/trace_generic.py:119
+ 2:   @__main__:do => miscmisc/trace_profiling.py:98
+ 3:   @__main__:<module> => miscmisc/trace_profiling.py:103
+### trace_handler::main event: line
+ 0:   @trace_subdir.trace_generic:test_loop => misc/trace_subdir/trace_generic.py:28
+ 1:   @trace_subdir.trace_generic:run_tests => misc/trace_subdir/trace_generic.py:119
+ 2:   @__main__:do => miscmisc/trace_profiling.py:98
+ 3:   @__main__:<module> => miscmisc/trace_profiling.py:103
+### trace_handler::main event: line
+ 0:   @trace_subdir.trace_generic:test_loop => misc/trace_subdir/trace_generic.py:29
+ 1:   @trace_subdir.trace_generic:run_tests => misc/trace_subdir/trace_generic.py:119
+ 2:   @__main__:do => miscmisc/trace_profiling.py:98
+ 3:   @__main__:<module> => miscmisc/trace_profiling.py:103
+### trace_handler::main event: line
+ 0:   @trace_subdir.trace_generic:test_loop => misc/trace_subdir/trace_generic.py:31
+ 1:   @trace_subdir.trace_generic:run_tests => misc/trace_subdir/trace_generic.py:119
+ 2:   @__main__:do => miscmisc/trace_profiling.py:98
+ 3:   @__main__:<module> => miscmisc/trace_profiling.py:103
+### trace_handler::main event: line
+ 0:   @trace_subdir.trace_generic:test_loop => misc/trace_subdir/trace_generic.py:30
+ 1:   @trace_subdir.trace_generic:run_tests => misc/trace_subdir/trace_generic.py:119
+ 2:   @__main__:do => miscmisc/trace_profiling.py:98
+ 3:   @__main__:<module> => miscmisc/trace_profiling.py:103
+### trace_handler::main event: line
+ 0:   @trace_subdir.trace_generic:test_loop => misc/trace_subdir/trace_generic.py:31
+ 1:   @trace_subdir.trace_generic:run_tests => misc/trace_subdir/trace_generic.py:119
+ 2:   @__main__:do => miscmisc/trace_profiling.py:98
+ 3:   @__main__:<module> => miscmisc/trace_profiling.py:103
+### trace_handler::main event: line
+ 0:   @trace_subdir.trace_generic:test_loop => misc/trace_subdir/trace_generic.py:30
+ 1:   @trace_subdir.trace_generic:run_tests => misc/trace_subdir/trace_generic.py:119
+ 2:   @__main__:do => miscmisc/trace_profiling.py:98
+ 3:   @__main__:<module> => miscmisc/trace_profiling.py:103
+### trace_handler::main event: line
+ 0:   @trace_subdir.trace_generic:test_loop => misc/trace_subdir/trace_generic.py:31
+ 1:   @trace_subdir.trace_generic:run_tests => misc/trace_subdir/trace_generic.py:119
+ 2:   @__main__:do => miscmisc/trace_profiling.py:98
+ 3:   @__main__:<module> => miscmisc/trace_profiling.py:103
+### trace_handler::main event: line
+ 0:   @trace_subdir.trace_generic:test_loop => misc/trace_subdir/trace_generic.py:30
+ 1:   @trace_subdir.trace_generic:run_tests => misc/trace_subdir/trace_generic.py:119
+ 2:   @__main__:do => miscmisc/trace_profiling.py:98
+ 3:   @__main__:<module> => miscmisc/trace_profiling.py:103
+### trace_handler::main event: line
+ 0:   @trace_subdir.trace_generic:test_loop => misc/trace_subdir/trace_generic.py:31
+ 1:   @trace_subdir.trace_generic:run_tests => misc/trace_subdir/trace_generic.py:119
+ 2:   @__main__:do => miscmisc/trace_profiling.py:98
+ 3:   @__main__:<module> => miscmisc/trace_profiling.py:103
+### trace_handler::main event: line
+ 0:   @trace_subdir.trace_generic:test_loop => misc/trace_subdir/trace_generic.py:32
+ 1:   @trace_subdir.trace_generic:run_tests => misc/trace_subdir/trace_generic.py:119
+ 2:   @__main__:do => miscmisc/trace_profiling.py:98
+ 3:   @__main__:<module> => miscmisc/trace_profiling.py:103
+test_while_loop 3
+### trace_handler::main event: return
+ 0:   @trace_subdir.trace_generic:test_loop => misc/trace_subdir/trace_generic.py:32
+ 1:   @trace_subdir.trace_generic:run_tests => misc/trace_subdir/trace_generic.py:119
+ 2:   @__main__:do => miscmisc/trace_profiling.py:98
+ 3:   @__main__:<module> => miscmisc/trace_profiling.py:103
+### trace_handler::main event: line
+ 0:   @trace_subdir.trace_generic:run_tests => misc/trace_subdir/trace_generic.py:120
+ 1:   @__main__:do => miscmisc/trace_profiling.py:98
+ 2:   @__main__:<module> => miscmisc/trace_profiling.py:103
+### trace_handler::main event: call
+ 0:   @trace_subdir.trace_generic:test_exception => misc/trace_subdir/trace_generic.py:35
+ 1:   @trace_subdir.trace_generic:run_tests => misc/trace_subdir/trace_generic.py:120
+ 2:   @__main__:do => miscmisc/trace_profiling.py:98
+ 3:   @__main__:<module> => miscmisc/trace_profiling.py:103
+### trace_handler::main event: line
+ 0:   @trace_subdir.trace_generic:test_exception => misc/trace_subdir/trace_generic.py:36
+ 1:   @trace_subdir.trace_generic:run_tests => misc/trace_subdir/trace_generic.py:120
+ 2:   @__main__:do => miscmisc/trace_profiling.py:98
+ 3:   @__main__:<module> => miscmisc/trace_profiling.py:103
+### trace_handler::main event: line
+ 0:   @trace_subdir.trace_generic:test_exception => misc/trace_subdir/trace_generic.py:37
+ 1:   @trace_subdir.trace_generic:run_tests => misc/trace_subdir/trace_generic.py:120
+ 2:   @__main__:do => miscmisc/trace_profiling.py:98
+ 3:   @__main__:<module> => miscmisc/trace_profiling.py:103
+### trace_handler::main event: exception
+ 0:   @trace_subdir.trace_generic:test_exception => misc/trace_subdir/trace_generic.py:37
+ 1:   @trace_subdir.trace_generic:run_tests => misc/trace_subdir/trace_generic.py:120
+ 2:   @__main__:do => miscmisc/trace_profiling.py:98
+ 3:   @__main__:<module> => miscmisc/trace_profiling.py:103
+### trace_handler::main event: line
+ 0:   @trace_subdir.trace_generic:test_exception => misc/trace_subdir/trace_generic.py:39
+ 1:   @trace_subdir.trace_generic:run_tests => misc/trace_subdir/trace_generic.py:120
+ 2:   @__main__:do => miscmisc/trace_profiling.py:98
+ 3:   @__main__:<module> => miscmisc/trace_profiling.py:103
+### trace_handler::main event: line
+ 0:   @trace_subdir.trace_generic:test_exception => misc/trace_subdir/trace_generic.py:40
+ 1:   @trace_subdir.trace_generic:run_tests => misc/trace_subdir/trace_generic.py:120
+ 2:   @__main__:do => miscmisc/trace_profiling.py:98
+ 3:   @__main__:<module> => miscmisc/trace_profiling.py:103
+### trace_handler::main event: line
+ 0:   @trace_subdir.trace_generic:test_exception => misc/trace_subdir/trace_generic.py:43
+ 1:   @trace_subdir.trace_generic:run_tests => misc/trace_subdir/trace_generic.py:120
+ 2:   @__main__:do => miscmisc/trace_profiling.py:98
+ 3:   @__main__:<module> => miscmisc/trace_profiling.py:103
+### trace_handler::main event: return
+ 0:   @trace_subdir.trace_generic:test_exception => misc/trace_subdir/trace_generic.py:43
+ 1:   @trace_subdir.trace_generic:run_tests => misc/trace_subdir/trace_generic.py:120
+ 2:   @__main__:do => miscmisc/trace_profiling.py:98
+ 3:   @__main__:<module> => miscmisc/trace_profiling.py:103
+### trace_handler::main event: line
+ 0:   @trace_subdir.trace_generic:run_tests => misc/trace_subdir/trace_generic.py:121
+ 1:   @__main__:do => miscmisc/trace_profiling.py:98
+ 2:   @__main__:<module> => miscmisc/trace_profiling.py:103
+### trace_handler::main event: call
+ 0:   @trace_subdir.trace_generic:test_listcomp => misc/trace_subdir/trace_generic.py:46
+ 1:   @trace_subdir.trace_generic:run_tests => misc/trace_subdir/trace_generic.py:121
+ 2:   @__main__:do => miscmisc/trace_profiling.py:98
+ 3:   @__main__:<module> => miscmisc/trace_profiling.py:103
+### trace_handler::main event: line
+ 0:   @trace_subdir.trace_generic:test_listcomp => misc/trace_subdir/trace_generic.py:47
+ 1:   @trace_subdir.trace_generic:run_tests => misc/trace_subdir/trace_generic.py:121
+ 2:   @__main__:do => miscmisc/trace_profiling.py:98
+ 3:   @__main__:<module> => miscmisc/trace_profiling.py:103
+### trace_handler::main event: call
+ 0:   @trace_subdir.trace_generic:<listcomp> => misc/trace_subdir/trace_generic.py:47
+ 1:   @trace_subdir.trace_generic:test_listcomp => misc/trace_subdir/trace_generic.py:47
+ 2:   @trace_subdir.trace_generic:run_tests => misc/trace_subdir/trace_generic.py:121
+ 3:   @__main__:do => miscmisc/trace_profiling.py:98
+ 4:   @__main__:<module> => miscmisc/trace_profiling.py:103
+### trace_handler::main event: line
+ 0:   @trace_subdir.trace_generic:<listcomp> => misc/trace_subdir/trace_generic.py:47
+ 1:   @trace_subdir.trace_generic:test_listcomp => misc/trace_subdir/trace_generic.py:47
+ 2:   @trace_subdir.trace_generic:run_tests => misc/trace_subdir/trace_generic.py:121
+ 3:   @__main__:do => miscmisc/trace_profiling.py:98
+ 4:   @__main__:<module> => miscmisc/trace_profiling.py:103
+### trace_handler::main event: line
+ 0:   @trace_subdir.trace_generic:<listcomp> => misc/trace_subdir/trace_generic.py:47
+ 1:   @trace_subdir.trace_generic:test_listcomp => misc/trace_subdir/trace_generic.py:47
+ 2:   @trace_subdir.trace_generic:run_tests => misc/trace_subdir/trace_generic.py:121
+ 3:   @__main__:do => miscmisc/trace_profiling.py:98
+ 4:   @__main__:<module> => miscmisc/trace_profiling.py:103
+### trace_handler::main event: line
+ 0:   @trace_subdir.trace_generic:<listcomp> => misc/trace_subdir/trace_generic.py:47
+ 1:   @trace_subdir.trace_generic:test_listcomp => misc/trace_subdir/trace_generic.py:47
+ 2:   @trace_subdir.trace_generic:run_tests => misc/trace_subdir/trace_generic.py:121
+ 3:   @__main__:do => miscmisc/trace_profiling.py:98
+ 4:   @__main__:<module> => miscmisc/trace_profiling.py:103
+### trace_handler::main event: line
+ 0:   @trace_subdir.trace_generic:<listcomp> => misc/trace_subdir/trace_generic.py:47
+ 1:   @trace_subdir.trace_generic:test_listcomp => misc/trace_subdir/trace_generic.py:47
+ 2:   @trace_subdir.trace_generic:run_tests => misc/trace_subdir/trace_generic.py:121
+ 3:   @__main__:do => miscmisc/trace_profiling.py:98
+ 4:   @__main__:<module> => miscmisc/trace_profiling.py:103
+### trace_handler::main event: return
+ 0:   @trace_subdir.trace_generic:<listcomp> => misc/trace_subdir/trace_generic.py:47
+ 1:   @trace_subdir.trace_generic:test_listcomp => misc/trace_subdir/trace_generic.py:47
+ 2:   @trace_subdir.trace_generic:run_tests => misc/trace_subdir/trace_generic.py:121
+ 3:   @__main__:do => miscmisc/trace_profiling.py:98
+ 4:   @__main__:<module> => miscmisc/trace_profiling.py:103
+test_listcomp [0, 1, 2]
+### trace_handler::main event: return
+ 0:   @trace_subdir.trace_generic:test_listcomp => misc/trace_subdir/trace_generic.py:47
+ 1:   @trace_subdir.trace_generic:run_tests => misc/trace_subdir/trace_generic.py:121
+ 2:   @__main__:do => miscmisc/trace_profiling.py:98
+ 3:   @__main__:<module> => miscmisc/trace_profiling.py:103
+### trace_handler::main event: line
+ 0:   @trace_subdir.trace_generic:run_tests => misc/trace_subdir/trace_generic.py:122
+ 1:   @__main__:do => miscmisc/trace_profiling.py:98
+ 2:   @__main__:<module> => miscmisc/trace_profiling.py:103
+### trace_handler::main event: call
+ 0:   @trace_subdir.trace_generic:test_generator => misc/trace_subdir/trace_generic.py:50
+ 1:   @trace_subdir.trace_generic:run_tests => misc/trace_subdir/trace_generic.py:122
+ 2:   @__main__:do => miscmisc/trace_profiling.py:98
+ 3:   @__main__:<module> => miscmisc/trace_profiling.py:103
+### trace_handler::main event: line
+ 0:   @trace_subdir.trace_generic:test_generator => misc/trace_subdir/trace_generic.py:51
+ 1:   @trace_subdir.trace_generic:run_tests => misc/trace_subdir/trace_generic.py:122
+ 2:   @__main__:do => miscmisc/trace_profiling.py:98
+ 3:   @__main__:<module> => miscmisc/trace_profiling.py:103
+### trace_handler::main event: line
+ 0:   @trace_subdir.trace_generic:test_generator => misc/trace_subdir/trace_generic.py:57
+ 1:   @trace_subdir.trace_generic:run_tests => misc/trace_subdir/trace_generic.py:122
+ 2:   @__main__:do => miscmisc/trace_profiling.py:98
+ 3:   @__main__:<module> => miscmisc/trace_profiling.py:103
+### trace_handler::main event: line
+ 0:   @trace_subdir.trace_generic:test_generator => misc/trace_subdir/trace_generic.py:58
+ 1:   @trace_subdir.trace_generic:run_tests => misc/trace_subdir/trace_generic.py:122
+ 2:   @__main__:do => miscmisc/trace_profiling.py:98
+ 3:   @__main__:<module> => miscmisc/trace_profiling.py:103
+### trace_handler::main event: line
+ 0:   @trace_subdir.trace_generic:test_generator => misc/trace_subdir/trace_generic.py:59
+ 1:   @trace_subdir.trace_generic:run_tests => misc/trace_subdir/trace_generic.py:122
+ 2:   @__main__:do => miscmisc/trace_profiling.py:98
+ 3:   @__main__:<module> => miscmisc/trace_profiling.py:103
+### trace_handler::main event: line
+ 0:   @trace_subdir.trace_generic:test_generator => misc/trace_subdir/trace_generic.py:61
+ 1:   @trace_subdir.trace_generic:run_tests => misc/trace_subdir/trace_generic.py:122
+ 2:   @__main__:do => miscmisc/trace_profiling.py:98
+ 3:   @__main__:<module> => miscmisc/trace_profiling.py:103
+### trace_handler::main event: call
+ 0:   @trace_subdir.trace_generic:make_gen => misc/trace_subdir/trace_generic.py:51
+ 1:   @trace_subdir.trace_generic:test_generator => misc/trace_subdir/trace_generic.py:61
+ 2:   @trace_subdir.trace_generic:run_tests => misc/trace_subdir/trace_generic.py:122
+ 3:   @__main__:do => miscmisc/trace_profiling.py:98
+ 4:   @__main__:<module> => miscmisc/trace_profiling.py:103
+### trace_handler::main event: line
+ 0:   @trace_subdir.trace_generic:make_gen => misc/trace_subdir/trace_generic.py:52
+ 1:   @trace_subdir.trace_generic:test_generator => misc/trace_subdir/trace_generic.py:61
+ 2:   @trace_subdir.trace_generic:run_tests => misc/trace_subdir/trace_generic.py:122
+ 3:   @__main__:do => miscmisc/trace_profiling.py:98
+ 4:   @__main__:<module> => miscmisc/trace_profiling.py:103
+### trace_handler::main event: return
+ 0:   @trace_subdir.trace_generic:make_gen => misc/trace_subdir/trace_generic.py:52
+ 1:   @trace_subdir.trace_generic:test_generator => misc/trace_subdir/trace_generic.py:61
+ 2:   @trace_subdir.trace_generic:run_tests => misc/trace_subdir/trace_generic.py:122
+ 3:   @__main__:do => miscmisc/trace_profiling.py:98
+ 4:   @__main__:<module> => miscmisc/trace_profiling.py:103
+### trace_handler::main event: line
+ 0:   @trace_subdir.trace_generic:test_generator => misc/trace_subdir/trace_generic.py:65
+ 1:   @trace_subdir.trace_generic:run_tests => misc/trace_subdir/trace_generic.py:122
+ 2:   @__main__:do => miscmisc/trace_profiling.py:98
+ 3:   @__main__:<module> => miscmisc/trace_profiling.py:103
+### trace_handler::main event: call
+ 0:   @trace_subdir.trace_generic:make_gen => misc/trace_subdir/trace_generic.py:52
+ 1:   @trace_subdir.trace_generic:test_generator => misc/trace_subdir/trace_generic.py:65
+ 2:   @trace_subdir.trace_generic:run_tests => misc/trace_subdir/trace_generic.py:122
+ 3:   @__main__:do => miscmisc/trace_profiling.py:98
+ 4:   @__main__:<module> => miscmisc/trace_profiling.py:103
+### trace_handler::main event: line
+ 0:   @trace_subdir.trace_generic:make_gen => misc/trace_subdir/trace_generic.py:52
+ 1:   @trace_subdir.trace_generic:test_generator => misc/trace_subdir/trace_generic.py:65
+ 2:   @trace_subdir.trace_generic:run_tests => misc/trace_subdir/trace_generic.py:122
+ 3:   @__main__:do => miscmisc/trace_profiling.py:98
+ 4:   @__main__:<module> => miscmisc/trace_profiling.py:103
+### trace_handler::main event: line
+ 0:   @trace_subdir.trace_generic:make_gen => misc/trace_subdir/trace_generic.py:53
+ 1:   @trace_subdir.trace_generic:test_generator => misc/trace_subdir/trace_generic.py:65
+ 2:   @trace_subdir.trace_generic:run_tests => misc/trace_subdir/trace_generic.py:122
+ 3:   @__main__:do => miscmisc/trace_profiling.py:98
+ 4:   @__main__:<module> => miscmisc/trace_profiling.py:103
+### trace_handler::main event: return
+ 0:   @trace_subdir.trace_generic:make_gen => misc/trace_subdir/trace_generic.py:53
+ 1:   @trace_subdir.trace_generic:test_generator => misc/trace_subdir/trace_generic.py:65
+ 2:   @trace_subdir.trace_generic:run_tests => misc/trace_subdir/trace_generic.py:122
+ 3:   @__main__:do => miscmisc/trace_profiling.py:98
+ 4:   @__main__:<module> => miscmisc/trace_profiling.py:103
+### trace_handler::main event: call
+ 0:   @trace_subdir.trace_generic:make_gen => misc/trace_subdir/trace_generic.py:53
+ 1:   @trace_subdir.trace_generic:test_generator => misc/trace_subdir/trace_generic.py:65
+ 2:   @trace_subdir.trace_generic:run_tests => misc/trace_subdir/trace_generic.py:122
+ 3:   @__main__:do => miscmisc/trace_profiling.py:98
+ 4:   @__main__:<module> => miscmisc/trace_profiling.py:103
+### trace_handler::main event: line
+ 0:   @trace_subdir.trace_generic:make_gen => misc/trace_subdir/trace_generic.py:53
+ 1:   @trace_subdir.trace_generic:test_generator => misc/trace_subdir/trace_generic.py:65
+ 2:   @trace_subdir.trace_generic:run_tests => misc/trace_subdir/trace_generic.py:122
+ 3:   @__main__:do => miscmisc/trace_profiling.py:98
+ 4:   @__main__:<module> => miscmisc/trace_profiling.py:103
+### trace_handler::main event: line
+ 0:   @trace_subdir.trace_generic:make_gen => misc/trace_subdir/trace_generic.py:54
+ 1:   @trace_subdir.trace_generic:test_generator => misc/trace_subdir/trace_generic.py:65
+ 2:   @trace_subdir.trace_generic:run_tests => misc/trace_subdir/trace_generic.py:122
+ 3:   @__main__:do => miscmisc/trace_profiling.py:98
+ 4:   @__main__:<module> => miscmisc/trace_profiling.py:103
+### trace_handler::main event: return
+ 0:   @trace_subdir.trace_generic:make_gen => misc/trace_subdir/trace_generic.py:54
+ 1:   @trace_subdir.trace_generic:test_generator => misc/trace_subdir/trace_generic.py:65
+ 2:   @trace_subdir.trace_generic:run_tests => misc/trace_subdir/trace_generic.py:122
+ 3:   @__main__:do => miscmisc/trace_profiling.py:98
+ 4:   @__main__:<module> => miscmisc/trace_profiling.py:103
+### trace_handler::main event: call
+ 0:   @trace_subdir.trace_generic:make_gen => misc/trace_subdir/trace_generic.py:54
+ 1:   @trace_subdir.trace_generic:test_generator => misc/trace_subdir/trace_generic.py:65
+ 2:   @trace_subdir.trace_generic:run_tests => misc/trace_subdir/trace_generic.py:122
+ 3:   @__main__:do => miscmisc/trace_profiling.py:98
+ 4:   @__main__:<module> => miscmisc/trace_profiling.py:103
+### trace_handler::main event: line
+ 0:   @trace_subdir.trace_generic:make_gen => misc/trace_subdir/trace_generic.py:54
+ 1:   @trace_subdir.trace_generic:test_generator => misc/trace_subdir/trace_generic.py:65
+ 2:   @trace_subdir.trace_generic:run_tests => misc/trace_subdir/trace_generic.py:122
+ 3:   @__main__:do => miscmisc/trace_profiling.py:98
+ 4:   @__main__:<module> => miscmisc/trace_profiling.py:103
+### trace_handler::main event: line
+ 0:   @trace_subdir.trace_generic:make_gen => misc/trace_subdir/trace_generic.py:55
+ 1:   @trace_subdir.trace_generic:test_generator => misc/trace_subdir/trace_generic.py:65
+ 2:   @trace_subdir.trace_generic:run_tests => misc/trace_subdir/trace_generic.py:122
+ 3:   @__main__:do => miscmisc/trace_profiling.py:98
+ 4:   @__main__:<module> => miscmisc/trace_profiling.py:103
+### trace_handler::main event: return
+ 0:   @trace_subdir.trace_generic:make_gen => misc/trace_subdir/trace_generic.py:55
+ 1:   @trace_subdir.trace_generic:test_generator => misc/trace_subdir/trace_generic.py:65
+ 2:   @trace_subdir.trace_generic:run_tests => misc/trace_subdir/trace_generic.py:122
+ 3:   @__main__:do => miscmisc/trace_profiling.py:98
+ 4:   @__main__:<module> => miscmisc/trace_profiling.py:103
+### trace_handler::main event: exception
+ 0:   @trace_subdir.trace_generic:test_generator => misc/trace_subdir/trace_generic.py:65
+ 1:   @trace_subdir.trace_generic:run_tests => misc/trace_subdir/trace_generic.py:122
+ 2:   @__main__:do => miscmisc/trace_profiling.py:98
+ 3:   @__main__:<module> => miscmisc/trace_profiling.py:103
+### trace_handler::main event: line
+ 0:   @trace_subdir.trace_generic:test_generator => misc/trace_subdir/trace_generic.py:67
+ 1:   @trace_subdir.trace_generic:run_tests => misc/trace_subdir/trace_generic.py:122
+ 2:   @__main__:do => miscmisc/trace_profiling.py:98
+ 3:   @__main__:<module> => miscmisc/trace_profiling.py:103
+### trace_handler::main event: line
+ 0:   @trace_subdir.trace_generic:test_generator => misc/trace_subdir/trace_generic.py:68
+ 1:   @trace_subdir.trace_generic:run_tests => misc/trace_subdir/trace_generic.py:122
+ 2:   @__main__:do => miscmisc/trace_profiling.py:98
+ 3:   @__main__:<module> => miscmisc/trace_profiling.py:103
+test_generator 7 8
+### trace_handler::main event: line
+ 0:   @trace_subdir.trace_generic:test_generator => misc/trace_subdir/trace_generic.py:70
+ 1:   @trace_subdir.trace_generic:run_tests => misc/trace_subdir/trace_generic.py:122
+ 2:   @__main__:do => miscmisc/trace_profiling.py:98
+ 3:   @__main__:<module> => miscmisc/trace_profiling.py:103
+### trace_handler::main event: line
+ 0:   @trace_subdir.trace_generic:test_generator => misc/trace_subdir/trace_generic.py:71
+ 1:   @trace_subdir.trace_generic:run_tests => misc/trace_subdir/trace_generic.py:122
+ 2:   @__main__:do => miscmisc/trace_profiling.py:98
+ 3:   @__main__:<module> => miscmisc/trace_profiling.py:103
+### trace_handler::main event: line
+ 0:   @trace_subdir.trace_generic:test_generator => misc/trace_subdir/trace_generic.py:72
+ 1:   @trace_subdir.trace_generic:run_tests => misc/trace_subdir/trace_generic.py:122
+ 2:   @__main__:do => miscmisc/trace_profiling.py:98
+ 3:   @__main__:<module> => miscmisc/trace_profiling.py:103
+### trace_handler::main event: call
+ 0:   @trace_subdir.trace_generic:make_gen => misc/trace_subdir/trace_generic.py:51
+ 1:   @trace_subdir.trace_generic:test_generator => misc/trace_subdir/trace_generic.py:72
+ 2:   @trace_subdir.trace_generic:run_tests => misc/trace_subdir/trace_generic.py:122
+ 3:   @__main__:do => miscmisc/trace_profiling.py:98
+ 4:   @__main__:<module> => miscmisc/trace_profiling.py:103
+### trace_handler::main event: line
+ 0:   @trace_subdir.trace_generic:make_gen => misc/trace_subdir/trace_generic.py:52
+ 1:   @trace_subdir.trace_generic:test_generator => misc/trace_subdir/trace_generic.py:72
+ 2:   @trace_subdir.trace_generic:run_tests => misc/trace_subdir/trace_generic.py:122
+ 3:   @__main__:do => miscmisc/trace_profiling.py:98
+ 4:   @__main__:<module> => miscmisc/trace_profiling.py:103
+### trace_handler::main event: return
+ 0:   @trace_subdir.trace_generic:make_gen => misc/trace_subdir/trace_generic.py:52
+ 1:   @trace_subdir.trace_generic:test_generator => misc/trace_subdir/trace_generic.py:72
+ 2:   @trace_subdir.trace_generic:run_tests => misc/trace_subdir/trace_generic.py:122
+ 3:   @__main__:do => miscmisc/trace_profiling.py:98
+ 4:   @__main__:<module> => miscmisc/trace_profiling.py:103
+### trace_handler::main event: line
+ 0:   @trace_subdir.trace_generic:test_generator => misc/trace_subdir/trace_generic.py:72
+ 1:   @trace_subdir.trace_generic:run_tests => misc/trace_subdir/trace_generic.py:122
+ 2:   @__main__:do => miscmisc/trace_profiling.py:98
+ 3:   @__main__:<module> => miscmisc/trace_profiling.py:103
+### trace_handler::main event: line
+ 0:   @trace_subdir.trace_generic:test_generator => misc/trace_subdir/trace_generic.py:73
+ 1:   @trace_subdir.trace_generic:run_tests => misc/trace_subdir/trace_generic.py:122
+ 2:   @__main__:do => miscmisc/trace_profiling.py:98
+ 3:   @__main__:<module> => miscmisc/trace_profiling.py:103
+### trace_handler::main event: line
+ 0:   @trace_subdir.trace_generic:test_generator => misc/trace_subdir/trace_generic.py:72
+ 1:   @trace_subdir.trace_generic:run_tests => misc/trace_subdir/trace_generic.py:122
+ 2:   @__main__:do => miscmisc/trace_profiling.py:98
+ 3:   @__main__:<module> => miscmisc/trace_profiling.py:103
+### trace_handler::main event: call
+ 0:   @trace_subdir.trace_generic:make_gen => misc/trace_subdir/trace_generic.py:52
+ 1:   @trace_subdir.trace_generic:test_generator => misc/trace_subdir/trace_generic.py:72
+ 2:   @trace_subdir.trace_generic:run_tests => misc/trace_subdir/trace_generic.py:122
+ 3:   @__main__:do => miscmisc/trace_profiling.py:98
+ 4:   @__main__:<module> => miscmisc/trace_profiling.py:103
+### trace_handler::main event: line
+ 0:   @trace_subdir.trace_generic:make_gen => misc/trace_subdir/trace_generic.py:52
+ 1:   @trace_subdir.trace_generic:test_generator => misc/trace_subdir/trace_generic.py:72
+ 2:   @trace_subdir.trace_generic:run_tests => misc/trace_subdir/trace_generic.py:122
+ 3:   @__main__:do => miscmisc/trace_profiling.py:98
+ 4:   @__main__:<module> => miscmisc/trace_profiling.py:103
+### trace_handler::main event: line
+ 0:   @trace_subdir.trace_generic:make_gen => misc/trace_subdir/trace_generic.py:53
+ 1:   @trace_subdir.trace_generic:test_generator => misc/trace_subdir/trace_generic.py:72
+ 2:   @trace_subdir.trace_generic:run_tests => misc/trace_subdir/trace_generic.py:122
+ 3:   @__main__:do => miscmisc/trace_profiling.py:98
+ 4:   @__main__:<module> => miscmisc/trace_profiling.py:103
+### trace_handler::main event: return
+ 0:   @trace_subdir.trace_generic:make_gen => misc/trace_subdir/trace_generic.py:53
+ 1:   @trace_subdir.trace_generic:test_generator => misc/trace_subdir/trace_generic.py:72
+ 2:   @trace_subdir.trace_generic:run_tests => misc/trace_subdir/trace_generic.py:122
+ 3:   @__main__:do => miscmisc/trace_profiling.py:98
+ 4:   @__main__:<module> => miscmisc/trace_profiling.py:103
+### trace_handler::main event: line
+ 0:   @trace_subdir.trace_generic:test_generator => misc/trace_subdir/trace_generic.py:72
+ 1:   @trace_subdir.trace_generic:run_tests => misc/trace_subdir/trace_generic.py:122
+ 2:   @__main__:do => miscmisc/trace_profiling.py:98
+ 3:   @__main__:<module> => miscmisc/trace_profiling.py:103
+### trace_handler::main event: line
+ 0:   @trace_subdir.trace_generic:test_generator => misc/trace_subdir/trace_generic.py:73
+ 1:   @trace_subdir.trace_generic:run_tests => misc/trace_subdir/trace_generic.py:122
+ 2:   @__main__:do => miscmisc/trace_profiling.py:98
+ 3:   @__main__:<module> => miscmisc/trace_profiling.py:103
+### trace_handler::main event: line
+ 0:   @trace_subdir.trace_generic:test_generator => misc/trace_subdir/trace_generic.py:72
+ 1:   @trace_subdir.trace_generic:run_tests => misc/trace_subdir/trace_generic.py:122
+ 2:   @__main__:do => miscmisc/trace_profiling.py:98
+ 3:   @__main__:<module> => miscmisc/trace_profiling.py:103
+### trace_handler::main event: call
+ 0:   @trace_subdir.trace_generic:make_gen => misc/trace_subdir/trace_generic.py:53
+ 1:   @trace_subdir.trace_generic:test_generator => misc/trace_subdir/trace_generic.py:72
+ 2:   @trace_subdir.trace_generic:run_tests => misc/trace_subdir/trace_generic.py:122
+ 3:   @__main__:do => miscmisc/trace_profiling.py:98
+ 4:   @__main__:<module> => miscmisc/trace_profiling.py:103
+### trace_handler::main event: line
+ 0:   @trace_subdir.trace_generic:make_gen => misc/trace_subdir/trace_generic.py:53
+ 1:   @trace_subdir.trace_generic:test_generator => misc/trace_subdir/trace_generic.py:72
+ 2:   @trace_subdir.trace_generic:run_tests => misc/trace_subdir/trace_generic.py:122
+ 3:   @__main__:do => miscmisc/trace_profiling.py:98
+ 4:   @__main__:<module> => miscmisc/trace_profiling.py:103
+### trace_handler::main event: line
+ 0:   @trace_subdir.trace_generic:make_gen => misc/trace_subdir/trace_generic.py:54
+ 1:   @trace_subdir.trace_generic:test_generator => misc/trace_subdir/trace_generic.py:72
+ 2:   @trace_subdir.trace_generic:run_tests => misc/trace_subdir/trace_generic.py:122
+ 3:   @__main__:do => miscmisc/trace_profiling.py:98
+ 4:   @__main__:<module> => miscmisc/trace_profiling.py:103
+### trace_handler::main event: return
+ 0:   @trace_subdir.trace_generic:make_gen => misc/trace_subdir/trace_generic.py:54
+ 1:   @trace_subdir.trace_generic:test_generator => misc/trace_subdir/trace_generic.py:72
+ 2:   @trace_subdir.trace_generic:run_tests => misc/trace_subdir/trace_generic.py:122
+ 3:   @__main__:do => miscmisc/trace_profiling.py:98
+ 4:   @__main__:<module> => miscmisc/trace_profiling.py:103
+### trace_handler::main event: line
+ 0:   @trace_subdir.trace_generic:test_generator => misc/trace_subdir/trace_generic.py:72
+ 1:   @trace_subdir.trace_generic:run_tests => misc/trace_subdir/trace_generic.py:122
+ 2:   @__main__:do => miscmisc/trace_profiling.py:98
+ 3:   @__main__:<module> => miscmisc/trace_profiling.py:103
+### trace_handler::main event: line
+ 0:   @trace_subdir.trace_generic:test_generator => misc/trace_subdir/trace_generic.py:73
+ 1:   @trace_subdir.trace_generic:run_tests => misc/trace_subdir/trace_generic.py:122
+ 2:   @__main__:do => miscmisc/trace_profiling.py:98
+ 3:   @__main__:<module> => miscmisc/trace_profiling.py:103
+### trace_handler::main event: line
+ 0:   @trace_subdir.trace_generic:test_generator => misc/trace_subdir/trace_generic.py:72
+ 1:   @trace_subdir.trace_generic:run_tests => misc/trace_subdir/trace_generic.py:122
+ 2:   @__main__:do => miscmisc/trace_profiling.py:98
+ 3:   @__main__:<module> => miscmisc/trace_profiling.py:103
+### trace_handler::main event: call
+ 0:   @trace_subdir.trace_generic:make_gen => misc/trace_subdir/trace_generic.py:54
+ 1:   @trace_subdir.trace_generic:test_generator => misc/trace_subdir/trace_generic.py:72
+ 2:   @trace_subdir.trace_generic:run_tests => misc/trace_subdir/trace_generic.py:122
+ 3:   @__main__:do => miscmisc/trace_profiling.py:98
+ 4:   @__main__:<module> => miscmisc/trace_profiling.py:103
+### trace_handler::main event: line
+ 0:   @trace_subdir.trace_generic:make_gen => misc/trace_subdir/trace_generic.py:54
+ 1:   @trace_subdir.trace_generic:test_generator => misc/trace_subdir/trace_generic.py:72
+ 2:   @trace_subdir.trace_generic:run_tests => misc/trace_subdir/trace_generic.py:122
+ 3:   @__main__:do => miscmisc/trace_profiling.py:98
+ 4:   @__main__:<module> => miscmisc/trace_profiling.py:103
+### trace_handler::main event: line
+ 0:   @trace_subdir.trace_generic:make_gen => misc/trace_subdir/trace_generic.py:55
+ 1:   @trace_subdir.trace_generic:test_generator => misc/trace_subdir/trace_generic.py:72
+ 2:   @trace_subdir.trace_generic:run_tests => misc/trace_subdir/trace_generic.py:122
+ 3:   @__main__:do => miscmisc/trace_profiling.py:98
+ 4:   @__main__:<module> => miscmisc/trace_profiling.py:103
+### trace_handler::main event: return
+ 0:   @trace_subdir.trace_generic:make_gen => misc/trace_subdir/trace_generic.py:55
+ 1:   @trace_subdir.trace_generic:test_generator => misc/trace_subdir/trace_generic.py:72
+ 2:   @trace_subdir.trace_generic:run_tests => misc/trace_subdir/trace_generic.py:122
+ 3:   @__main__:do => miscmisc/trace_profiling.py:98
+ 4:   @__main__:<module> => miscmisc/trace_profiling.py:103
+### trace_handler::main event: line
+ 0:   @trace_subdir.trace_generic:test_generator => misc/trace_subdir/trace_generic.py:74
+ 1:   @trace_subdir.trace_generic:run_tests => misc/trace_subdir/trace_generic.py:122
+ 2:   @__main__:do => miscmisc/trace_profiling.py:98
+ 3:   @__main__:<module> => miscmisc/trace_profiling.py:103
+7
+### trace_handler::main event: return
+ 0:   @trace_subdir.trace_generic:test_generator => misc/trace_subdir/trace_generic.py:74
+ 1:   @trace_subdir.trace_generic:run_tests => misc/trace_subdir/trace_generic.py:122
+ 2:   @__main__:do => miscmisc/trace_profiling.py:98
+ 3:   @__main__:<module> => miscmisc/trace_profiling.py:103
+### trace_handler::main event: line
+ 0:   @trace_subdir.trace_generic:run_tests => misc/trace_subdir/trace_generic.py:123
+ 1:   @__main__:do => miscmisc/trace_profiling.py:98
+ 2:   @__main__:<module> => miscmisc/trace_profiling.py:103
+### trace_handler::main event: call
+ 0:   @trace_subdir.trace_generic:test_lambda => misc/trace_subdir/trace_generic.py:77
+ 1:   @trace_subdir.trace_generic:run_tests => misc/trace_subdir/trace_generic.py:123
+ 2:   @__main__:do => miscmisc/trace_profiling.py:98
+ 3:   @__main__:<module> => miscmisc/trace_profiling.py:103
+### trace_handler::main event: line
+ 0:   @trace_subdir.trace_generic:test_lambda => misc/trace_subdir/trace_generic.py:78
+ 1:   @trace_subdir.trace_generic:run_tests => misc/trace_subdir/trace_generic.py:123
+ 2:   @__main__:do => miscmisc/trace_profiling.py:98
+ 3:   @__main__:<module> => miscmisc/trace_profiling.py:103
+### trace_handler::main event: line
+ 0:   @trace_subdir.trace_generic:test_lambda => misc/trace_subdir/trace_generic.py:79
+ 1:   @trace_subdir.trace_generic:run_tests => misc/trace_subdir/trace_generic.py:123
+ 2:   @__main__:do => miscmisc/trace_profiling.py:98
+ 3:   @__main__:<module> => miscmisc/trace_profiling.py:103
+### trace_handler::main event: call
+ 0:   @trace_subdir.trace_generic:<lambda> => misc/trace_subdir/trace_generic.py:78
+ 1:   @trace_subdir.trace_generic:test_lambda => misc/trace_subdir/trace_generic.py:79
+ 2:   @trace_subdir.trace_generic:run_tests => misc/trace_subdir/trace_generic.py:123
+ 3:   @__main__:do => miscmisc/trace_profiling.py:98
+ 4:   @__main__:<module> => miscmisc/trace_profiling.py:103
+### trace_handler::main event: line
+ 0:   @trace_subdir.trace_generic:<lambda> => misc/trace_subdir/trace_generic.py:78
+ 1:   @trace_subdir.trace_generic:test_lambda => misc/trace_subdir/trace_generic.py:79
+ 2:   @trace_subdir.trace_generic:run_tests => misc/trace_subdir/trace_generic.py:123
+ 3:   @__main__:do => miscmisc/trace_profiling.py:98
+ 4:   @__main__:<module> => miscmisc/trace_profiling.py:103
+### trace_handler::main event: return
+ 0:   @trace_subdir.trace_generic:<lambda> => misc/trace_subdir/trace_generic.py:78
+ 1:   @trace_subdir.trace_generic:test_lambda => misc/trace_subdir/trace_generic.py:79
+ 2:   @trace_subdir.trace_generic:run_tests => misc/trace_subdir/trace_generic.py:123
+ 3:   @__main__:do => miscmisc/trace_profiling.py:98
+ 4:   @__main__:<module> => miscmisc/trace_profiling.py:103
+30
+### trace_handler::main event: return
+ 0:   @trace_subdir.trace_generic:test_lambda => misc/trace_subdir/trace_generic.py:79
+ 1:   @trace_subdir.trace_generic:run_tests => misc/trace_subdir/trace_generic.py:123
+ 2:   @__main__:do => miscmisc/trace_profiling.py:98
+ 3:   @__main__:<module> => miscmisc/trace_profiling.py:103
+### trace_handler::main event: line
+ 0:   @trace_subdir.trace_generic:run_tests => misc/trace_subdir/trace_generic.py:124
+ 1:   @__main__:do => miscmisc/trace_profiling.py:98
+ 2:   @__main__:<module> => miscmisc/trace_profiling.py:103
+### trace_handler::main event: call
+ 0:   @trace_subdir.trace_generic:test_class => misc/trace_subdir/trace_generic.py:93
+ 1:   @trace_subdir.trace_generic:run_tests => misc/trace_subdir/trace_generic.py:124
+ 2:   @__main__:do => miscmisc/trace_profiling.py:98
+ 3:   @__main__:<module> => miscmisc/trace_profiling.py:103
+### trace_handler::main event: line
+ 0:   @trace_subdir.trace_generic:test_class => misc/trace_subdir/trace_generic.py:94
+ 1:   @trace_subdir.trace_generic:run_tests => misc/trace_subdir/trace_generic.py:124
+ 2:   @__main__:do => miscmisc/trace_profiling.py:98
+ 3:   @__main__:<module> => miscmisc/trace_profiling.py:103
+### trace_handler::main event: call
+ 0:   @trace_subdir.trace_generic:TestClass => misc/trace_subdir/trace_generic.py:94
+ 1:   @trace_subdir.trace_generic:test_class => misc/trace_subdir/trace_generic.py:94
+ 2:   @trace_subdir.trace_generic:run_tests => misc/trace_subdir/trace_generic.py:124
+ 3:   @__main__:do => miscmisc/trace_profiling.py:98
+ 4:   @__main__:<module> => miscmisc/trace_profiling.py:103
+### trace_handler::main event: line
+ 0:   @trace_subdir.trace_generic:TestClass => misc/trace_subdir/trace_generic.py:94
+ 1:   @trace_subdir.trace_generic:test_class => misc/trace_subdir/trace_generic.py:94
+ 2:   @trace_subdir.trace_generic:run_tests => misc/trace_subdir/trace_generic.py:124
+ 3:   @__main__:do => miscmisc/trace_profiling.py:98
+ 4:   @__main__:<module> => miscmisc/trace_profiling.py:103
+### trace_handler::main event: line
+ 0:   @trace_subdir.trace_generic:TestClass => misc/trace_subdir/trace_generic.py:95
+ 1:   @trace_subdir.trace_generic:test_class => misc/trace_subdir/trace_generic.py:94
+ 2:   @trace_subdir.trace_generic:run_tests => misc/trace_subdir/trace_generic.py:124
+ 3:   @__main__:do => miscmisc/trace_profiling.py:98
+ 4:   @__main__:<module> => miscmisc/trace_profiling.py:103
+### trace_handler::main event: line
+ 0:   @trace_subdir.trace_generic:TestClass => misc/trace_subdir/trace_generic.py:96
+ 1:   @trace_subdir.trace_generic:test_class => misc/trace_subdir/trace_generic.py:94
+ 2:   @trace_subdir.trace_generic:run_tests => misc/trace_subdir/trace_generic.py:124
+ 3:   @__main__:do => miscmisc/trace_profiling.py:98
+ 4:   @__main__:<module> => miscmisc/trace_profiling.py:103
+### trace_handler::main event: line
+ 0:   @trace_subdir.trace_generic:TestClass => misc/trace_subdir/trace_generic.py:100
+ 1:   @trace_subdir.trace_generic:test_class => misc/trace_subdir/trace_generic.py:94
+ 2:   @trace_subdir.trace_generic:run_tests => misc/trace_subdir/trace_generic.py:124
+ 3:   @__main__:do => miscmisc/trace_profiling.py:98
+ 4:   @__main__:<module> => miscmisc/trace_profiling.py:103
+### trace_handler::main event: line
+ 0:   @trace_subdir.trace_generic:TestClass => misc/trace_subdir/trace_generic.py:103
+ 1:   @trace_subdir.trace_generic:test_class => misc/trace_subdir/trace_generic.py:94
+ 2:   @trace_subdir.trace_generic:run_tests => misc/trace_subdir/trace_generic.py:124
+ 3:   @__main__:do => miscmisc/trace_profiling.py:98
+ 4:   @__main__:<module> => miscmisc/trace_profiling.py:103
+### trace_handler::main event: line
+ 0:   @trace_subdir.trace_generic:TestClass => misc/trace_subdir/trace_generic.py:106
+ 1:   @trace_subdir.trace_generic:test_class => misc/trace_subdir/trace_generic.py:94
+ 2:   @trace_subdir.trace_generic:run_tests => misc/trace_subdir/trace_generic.py:124
+ 3:   @__main__:do => miscmisc/trace_profiling.py:98
+ 4:   @__main__:<module> => miscmisc/trace_profiling.py:103
+### trace_handler::main event: return
+ 0:   @trace_subdir.trace_generic:TestClass => misc/trace_subdir/trace_generic.py:106
+ 1:   @trace_subdir.trace_generic:test_class => misc/trace_subdir/trace_generic.py:94
+ 2:   @trace_subdir.trace_generic:run_tests => misc/trace_subdir/trace_generic.py:124
+ 3:   @__main__:do => miscmisc/trace_profiling.py:98
+ 4:   @__main__:<module> => miscmisc/trace_profiling.py:103
+### trace_handler::main event: line
+ 0:   @trace_subdir.trace_generic:test_class => misc/trace_subdir/trace_generic.py:108
+ 1:   @trace_subdir.trace_generic:run_tests => misc/trace_subdir/trace_generic.py:124
+ 2:   @__main__:do => miscmisc/trace_profiling.py:98
+ 3:   @__main__:<module> => miscmisc/trace_profiling.py:103
+### trace_handler::main event: line
+ 0:   @trace_subdir.trace_generic:test_class => misc/trace_subdir/trace_generic.py:109
+ 1:   @trace_subdir.trace_generic:run_tests => misc/trace_subdir/trace_generic.py:124
+ 2:   @__main__:do => miscmisc/trace_profiling.py:98
+ 3:   @__main__:<module> => miscmisc/trace_profiling.py:103
+### trace_handler::main event: call
+ 0:   @trace_subdir.trace_generic:method => misc/trace_subdir/trace_generic.py:96
+ 1:   @trace_subdir.trace_generic:test_class => misc/trace_subdir/trace_generic.py:109
+ 2:   @trace_subdir.trace_generic:run_tests => misc/trace_subdir/trace_generic.py:124
+ 3:   @__main__:do => miscmisc/trace_profiling.py:98
+ 4:   @__main__:<module> => miscmisc/trace_profiling.py:103
+### trace_handler::main event: line
+ 0:   @trace_subdir.trace_generic:method => misc/trace_subdir/trace_generic.py:97
+ 1:   @trace_subdir.trace_generic:test_class => misc/trace_subdir/trace_generic.py:109
+ 2:   @trace_subdir.trace_generic:run_tests => misc/trace_subdir/trace_generic.py:124
+ 3:   @__main__:do => miscmisc/trace_profiling.py:98
+ 4:   @__main__:<module> => miscmisc/trace_profiling.py:103
+test_class_method
+### trace_handler::main event: line
+ 0:   @trace_subdir.trace_generic:method => misc/trace_subdir/trace_generic.py:98
+ 1:   @trace_subdir.trace_generic:test_class => misc/trace_subdir/trace_generic.py:109
+ 2:   @trace_subdir.trace_generic:run_tests => misc/trace_subdir/trace_generic.py:124
+ 3:   @__main__:do => miscmisc/trace_profiling.py:98
+ 4:   @__main__:<module> => miscmisc/trace_profiling.py:103
+### trace_handler::main event: return
+ 0:   @trace_subdir.trace_generic:method => misc/trace_subdir/trace_generic.py:98
+ 1:   @trace_subdir.trace_generic:test_class => misc/trace_subdir/trace_generic.py:109
+ 2:   @trace_subdir.trace_generic:run_tests => misc/trace_subdir/trace_generic.py:124
+ 3:   @__main__:do => miscmisc/trace_profiling.py:98
+ 4:   @__main__:<module> => miscmisc/trace_profiling.py:103
+### trace_handler::main event: line
+ 0:   @trace_subdir.trace_generic:test_class => misc/trace_subdir/trace_generic.py:110
+ 1:   @trace_subdir.trace_generic:run_tests => misc/trace_subdir/trace_generic.py:124
+ 2:   @__main__:do => miscmisc/trace_profiling.py:98
+ 3:   @__main__:<module> => miscmisc/trace_profiling.py:103
+### trace_handler::main event: call
+ 0:   @trace_subdir.trace_generic:prprty_getter => misc/trace_subdir/trace_generic.py:100
+ 1:   @trace_subdir.trace_generic:test_class => misc/trace_subdir/trace_generic.py:110
+ 2:   @trace_subdir.trace_generic:run_tests => misc/trace_subdir/trace_generic.py:124
+ 3:   @__main__:do => miscmisc/trace_profiling.py:98
+ 4:   @__main__:<module> => miscmisc/trace_profiling.py:103
+### trace_handler::main event: line
+ 0:   @trace_subdir.trace_generic:prprty_getter => misc/trace_subdir/trace_generic.py:101
+ 1:   @trace_subdir.trace_generic:test_class => misc/trace_subdir/trace_generic.py:110
+ 2:   @trace_subdir.trace_generic:run_tests => misc/trace_subdir/trace_generic.py:124
+ 3:   @__main__:do => miscmisc/trace_profiling.py:98
+ 4:   @__main__:<module> => miscmisc/trace_profiling.py:103
+### trace_handler::main event: return
+ 0:   @trace_subdir.trace_generic:prprty_getter => misc/trace_subdir/trace_generic.py:101
+ 1:   @trace_subdir.trace_generic:test_class => misc/trace_subdir/trace_generic.py:110
+ 2:   @trace_subdir.trace_generic:run_tests => misc/trace_subdir/trace_generic.py:124
+ 3:   @__main__:do => miscmisc/trace_profiling.py:98
+ 4:   @__main__:<module> => miscmisc/trace_profiling.py:103
+test_class_property -8
+### trace_handler::main event: line
+ 0:   @trace_subdir.trace_generic:test_class => misc/trace_subdir/trace_generic.py:111
+ 1:   @trace_subdir.trace_generic:run_tests => misc/trace_subdir/trace_generic.py:124
+ 2:   @__main__:do => miscmisc/trace_profiling.py:98
+ 3:   @__main__:<module> => miscmisc/trace_profiling.py:103
+### trace_handler::main event: call
+ 0:   @trace_subdir.trace_generic:prprty_setter => misc/trace_subdir/trace_generic.py:103
+ 1:   @trace_subdir.trace_generic:test_class => misc/trace_subdir/trace_generic.py:111
+ 2:   @trace_subdir.trace_generic:run_tests => misc/trace_subdir/trace_generic.py:124
+ 3:   @__main__:do => miscmisc/trace_profiling.py:98
+ 4:   @__main__:<module> => miscmisc/trace_profiling.py:103
+### trace_handler::main event: line
+ 0:   @trace_subdir.trace_generic:prprty_setter => misc/trace_subdir/trace_generic.py:104
+ 1:   @trace_subdir.trace_generic:test_class => misc/trace_subdir/trace_generic.py:111
+ 2:   @trace_subdir.trace_generic:run_tests => misc/trace_subdir/trace_generic.py:124
+ 3:   @__main__:do => miscmisc/trace_profiling.py:98
+ 4:   @__main__:<module> => miscmisc/trace_profiling.py:103
+### trace_handler::main event: return
+ 0:   @trace_subdir.trace_generic:prprty_setter => misc/trace_subdir/trace_generic.py:104
+ 1:   @trace_subdir.trace_generic:test_class => misc/trace_subdir/trace_generic.py:111
+ 2:   @trace_subdir.trace_generic:run_tests => misc/trace_subdir/trace_generic.py:124
+ 3:   @__main__:do => miscmisc/trace_profiling.py:98
+ 4:   @__main__:<module> => miscmisc/trace_profiling.py:103
+### trace_handler::main event: line
+ 0:   @trace_subdir.trace_generic:test_class => misc/trace_subdir/trace_generic.py:112
+ 1:   @trace_subdir.trace_generic:run_tests => misc/trace_subdir/trace_generic.py:124
+ 2:   @__main__:do => miscmisc/trace_profiling.py:98
+ 3:   @__main__:<module> => miscmisc/trace_profiling.py:103
+### trace_handler::main event: call
+ 0:   @trace_subdir.trace_generic:prprty_getter => misc/trace_subdir/trace_generic.py:100
+ 1:   @trace_subdir.trace_generic:test_class => misc/trace_subdir/trace_generic.py:112
+ 2:   @trace_subdir.trace_generic:run_tests => misc/trace_subdir/trace_generic.py:124
+ 3:   @__main__:do => miscmisc/trace_profiling.py:98
+ 4:   @__main__:<module> => miscmisc/trace_profiling.py:103
+### trace_handler::main event: line
+ 0:   @trace_subdir.trace_generic:prprty_getter => misc/trace_subdir/trace_generic.py:101
+ 1:   @trace_subdir.trace_generic:test_class => misc/trace_subdir/trace_generic.py:112
+ 2:   @trace_subdir.trace_generic:run_tests => misc/trace_subdir/trace_generic.py:124
+ 3:   @__main__:do => miscmisc/trace_profiling.py:98
+ 4:   @__main__:<module> => miscmisc/trace_profiling.py:103
+### trace_handler::main event: return
+ 0:   @trace_subdir.trace_generic:prprty_getter => misc/trace_subdir/trace_generic.py:101
+ 1:   @trace_subdir.trace_generic:test_class => misc/trace_subdir/trace_generic.py:112
+ 2:   @trace_subdir.trace_generic:run_tests => misc/trace_subdir/trace_generic.py:124
+ 3:   @__main__:do => miscmisc/trace_profiling.py:98
+ 4:   @__main__:<module> => miscmisc/trace_profiling.py:103
+test_class_property 12
+### trace_handler::main event: return
+ 0:   @trace_subdir.trace_generic:test_class => misc/trace_subdir/trace_generic.py:112
+ 1:   @trace_subdir.trace_generic:run_tests => misc/trace_subdir/trace_generic.py:124
+ 2:   @__main__:do => miscmisc/trace_profiling.py:98
+ 3:   @__main__:<module> => miscmisc/trace_profiling.py:103
+### trace_handler::main event: line
+ 0:   @trace_subdir.trace_generic:run_tests => misc/trace_subdir/trace_generic.py:125
+ 1:   @__main__:do => miscmisc/trace_profiling.py:98
+ 2:   @__main__:<module> => miscmisc/trace_profiling.py:103
+### trace_handler::main event: call
+ 0:   @trace_subdir.trace_generic:test_import => misc/trace_subdir/trace_generic.py:82
+ 1:   @trace_subdir.trace_generic:run_tests => misc/trace_subdir/trace_generic.py:125
+ 2:   @__main__:do => miscmisc/trace_profiling.py:98
+ 3:   @__main__:<module> => miscmisc/trace_profiling.py:103
+### trace_handler::main event: line
+ 0:   @trace_subdir.trace_generic:test_import => misc/trace_subdir/trace_generic.py:83
+ 1:   @trace_subdir.trace_generic:run_tests => misc/trace_subdir/trace_generic.py:125
+ 2:   @__main__:do => miscmisc/trace_profiling.py:98
+ 3:   @__main__:<module> => miscmisc/trace_profiling.py:103
+### trace_handler::main event: call
+ 0:   @trace_subdir.trace_importme:<module> => misc/trace_subdir/trace_importme.py:1
+ 1:   @trace_subdir.trace_generic:test_import => misc/trace_subdir/trace_generic.py:83
+ 2:   @trace_subdir.trace_generic:run_tests => misc/trace_subdir/trace_generic.py:125
+ 3:   @__main__:do => miscmisc/trace_profiling.py:98
+ 4:   @__main__:<module> => miscmisc/trace_profiling.py:103
+### trace_handler::main event: line
+ 0:   @trace_subdir.trace_importme:<module> => misc/trace_subdir/trace_importme.py:1
+ 1:   @trace_subdir.trace_generic:test_import => misc/trace_subdir/trace_generic.py:83
+ 2:   @trace_subdir.trace_generic:run_tests => misc/trace_subdir/trace_generic.py:125
+ 3:   @__main__:do => miscmisc/trace_profiling.py:98
+ 4:   @__main__:<module> => miscmisc/trace_profiling.py:103
+Yep, I got imported.
+### trace_handler::main event: line
+ 0:   @trace_subdir.trace_importme:<module> => misc/trace_subdir/trace_importme.py:3
+ 1:   @trace_subdir.trace_generic:test_import => misc/trace_subdir/trace_generic.py:83
+ 2:   @trace_subdir.trace_generic:run_tests => misc/trace_subdir/trace_generic.py:125
+ 3:   @__main__:do => miscmisc/trace_profiling.py:98
+ 4:   @__main__:<module> => miscmisc/trace_profiling.py:103
+### trace_handler::main event: line
+ 0:   @trace_subdir.trace_importme:<module> => misc/trace_subdir/trace_importme.py:4
+ 1:   @trace_subdir.trace_generic:test_import => misc/trace_subdir/trace_generic.py:83
+ 2:   @trace_subdir.trace_generic:run_tests => misc/trace_subdir/trace_generic.py:125
+ 3:   @__main__:do => miscmisc/trace_profiling.py:98
+ 4:   @__main__:<module> => miscmisc/trace_profiling.py:103
+### trace_handler::main event: line
+ 0:   @trace_subdir.trace_importme:<module> => misc/trace_subdir/trace_importme.py:5
+ 1:   @trace_subdir.trace_generic:test_import => misc/trace_subdir/trace_generic.py:83
+ 2:   @trace_subdir.trace_generic:run_tests => misc/trace_subdir/trace_generic.py:125
+ 3:   @__main__:do => miscmisc/trace_profiling.py:98
+ 4:   @__main__:<module> => miscmisc/trace_profiling.py:103
+### trace_handler::main event: line
+ 0:   @trace_subdir.trace_importme:<module> => misc/trace_subdir/trace_importme.py:7
+ 1:   @trace_subdir.trace_generic:test_import => misc/trace_subdir/trace_generic.py:83
+ 2:   @trace_subdir.trace_generic:run_tests => misc/trace_subdir/trace_generic.py:125
+ 3:   @__main__:do => miscmisc/trace_profiling.py:98
+ 4:   @__main__:<module> => miscmisc/trace_profiling.py:103
+### trace_handler::main event: line
+ 0:   @trace_subdir.trace_importme:<module> => misc/trace_subdir/trace_importme.py:8
+ 1:   @trace_subdir.trace_generic:test_import => misc/trace_subdir/trace_generic.py:83
+ 2:   @trace_subdir.trace_generic:run_tests => misc/trace_subdir/trace_generic.py:125
+ 3:   @__main__:do => miscmisc/trace_profiling.py:98
+ 4:   @__main__:<module> => miscmisc/trace_profiling.py:103
+### trace_handler::main event: line
+ 0:   @trace_subdir.trace_importme:<module> => misc/trace_subdir/trace_importme.py:9
+ 1:   @trace_subdir.trace_generic:test_import => misc/trace_subdir/trace_generic.py:83
+ 2:   @trace_subdir.trace_generic:run_tests => misc/trace_subdir/trace_generic.py:125
+ 3:   @__main__:do => miscmisc/trace_profiling.py:98
+ 4:   @__main__:<module> => miscmisc/trace_profiling.py:103
+### trace_handler::main event: line
+ 0:   @trace_subdir.trace_importme:<module> => misc/trace_subdir/trace_importme.py:10
+ 1:   @trace_subdir.trace_generic:test_import => misc/trace_subdir/trace_generic.py:83
+ 2:   @trace_subdir.trace_generic:run_tests => misc/trace_subdir/trace_generic.py:125
+ 3:   @__main__:do => miscmisc/trace_profiling.py:98
+ 4:   @__main__:<module> => miscmisc/trace_profiling.py:103
+### trace_handler::main event: line
+ 0:   @trace_subdir.trace_importme:<module> => misc/trace_subdir/trace_importme.py:14
+ 1:   @trace_subdir.trace_generic:test_import => misc/trace_subdir/trace_generic.py:83
+ 2:   @trace_subdir.trace_generic:run_tests => misc/trace_subdir/trace_generic.py:125
+ 3:   @__main__:do => miscmisc/trace_profiling.py:98
+ 4:   @__main__:<module> => miscmisc/trace_profiling.py:103
+### trace_handler::main event: line
+ 0:   @trace_subdir.trace_importme:<module> => misc/trace_subdir/trace_importme.py:17
+ 1:   @trace_subdir.trace_generic:test_import => misc/trace_subdir/trace_generic.py:83
+ 2:   @trace_subdir.trace_generic:run_tests => misc/trace_subdir/trace_generic.py:125
+ 3:   @__main__:do => miscmisc/trace_profiling.py:98
+ 4:   @__main__:<module> => miscmisc/trace_profiling.py:103
+### trace_handler::main event: line
+ 0:   @trace_subdir.trace_importme:<module> => misc/trace_subdir/trace_importme.py:20
+ 1:   @trace_subdir.trace_generic:test_import => misc/trace_subdir/trace_generic.py:83
+ 2:   @trace_subdir.trace_generic:run_tests => misc/trace_subdir/trace_generic.py:125
+ 3:   @__main__:do => miscmisc/trace_profiling.py:98
+ 4:   @__main__:<module> => miscmisc/trace_profiling.py:103
+### trace_handler::main event: line
+ 0:   @trace_subdir.trace_importme:<module> => misc/trace_subdir/trace_importme.py:23
+ 1:   @trace_subdir.trace_generic:test_import => misc/trace_subdir/trace_generic.py:83
+ 2:   @trace_subdir.trace_generic:run_tests => misc/trace_subdir/trace_generic.py:125
+ 3:   @__main__:do => miscmisc/trace_profiling.py:98
+ 4:   @__main__:<module> => miscmisc/trace_profiling.py:103
+Yep, got here
+### trace_handler::main event: return
+ 0:   @trace_subdir.trace_importme:<module> => misc/trace_subdir/trace_importme.py:23
+ 1:   @trace_subdir.trace_generic:test_import => misc/trace_subdir/trace_generic.py:83
+ 2:   @trace_subdir.trace_generic:run_tests => misc/trace_subdir/trace_generic.py:125
+ 3:   @__main__:do => miscmisc/trace_profiling.py:98
+ 4:   @__main__:<module> => miscmisc/trace_profiling.py:103
+### trace_handler::main event: line
+ 0:   @trace_subdir.trace_generic:test_import => misc/trace_subdir/trace_generic.py:84
+ 1:   @trace_subdir.trace_generic:run_tests => misc/trace_subdir/trace_generic.py:125
+ 2:   @__main__:do => miscmisc/trace_profiling.py:98
+ 3:   @__main__:<module> => miscmisc/trace_profiling.py:103
+### trace_handler::main event: call
+ 0:   @trace_subdir.trace_importme:dummy => misc/trace_subdir/trace_importme.py:14
+ 1:   @trace_subdir.trace_generic:test_import => misc/trace_subdir/trace_generic.py:84
+ 2:   @trace_subdir.trace_generic:run_tests => misc/trace_subdir/trace_generic.py:125
+ 3:   @__main__:do => miscmisc/trace_profiling.py:98
+ 4:   @__main__:<module> => miscmisc/trace_profiling.py:103
+### trace_handler::main event: line
+ 0:   @trace_subdir.trace_importme:dummy => misc/trace_subdir/trace_importme.py:15
+ 1:   @trace_subdir.trace_generic:test_import => misc/trace_subdir/trace_generic.py:84
+ 2:   @trace_subdir.trace_generic:run_tests => misc/trace_subdir/trace_generic.py:125
+ 3:   @__main__:do => miscmisc/trace_profiling.py:98
+ 4:   @__main__:<module> => miscmisc/trace_profiling.py:103
+### trace_handler::main event: return
+ 0:   @trace_subdir.trace_importme:dummy => misc/trace_subdir/trace_importme.py:15
+ 1:   @trace_subdir.trace_generic:test_import => misc/trace_subdir/trace_generic.py:84
+ 2:   @trace_subdir.trace_generic:run_tests => misc/trace_subdir/trace_generic.py:125
+ 3:   @__main__:do => miscmisc/trace_profiling.py:98
+ 4:   @__main__:<module> => miscmisc/trace_profiling.py:103
+### trace_handler::main event: line
+ 0:   @trace_subdir.trace_generic:test_import => misc/trace_subdir/trace_generic.py:85
+ 1:   @trace_subdir.trace_generic:run_tests => misc/trace_subdir/trace_generic.py:125
+ 2:   @__main__:do => miscmisc/trace_profiling.py:98
+ 3:   @__main__:<module> => miscmisc/trace_profiling.py:103
+### trace_handler::main event: call
+ 0:   @trace_subdir.trace_importme:saysomething => misc/trace_subdir/trace_importme.py:17
+ 1:   @trace_subdir.trace_generic:test_import => misc/trace_subdir/trace_generic.py:85
+ 2:   @trace_subdir.trace_generic:run_tests => misc/trace_subdir/trace_generic.py:125
+ 3:   @__main__:do => miscmisc/trace_profiling.py:98
+ 4:   @__main__:<module> => miscmisc/trace_profiling.py:103
+### trace_handler::main event: line
+ 0:   @trace_subdir.trace_importme:saysomething => misc/trace_subdir/trace_importme.py:18
+ 1:   @trace_subdir.trace_generic:test_import => misc/trace_subdir/trace_generic.py:85
+ 2:   @trace_subdir.trace_generic:run_tests => misc/trace_subdir/trace_generic.py:125
+ 3:   @__main__:do => miscmisc/trace_profiling.py:98
+ 4:   @__main__:<module> => miscmisc/trace_profiling.py:103
+There, I said it.
+### trace_handler::main event: return
+ 0:   @trace_subdir.trace_importme:saysomething => misc/trace_subdir/trace_importme.py:18
+ 1:   @trace_subdir.trace_generic:test_import => misc/trace_subdir/trace_generic.py:85
+ 2:   @trace_subdir.trace_generic:run_tests => misc/trace_subdir/trace_generic.py:125
+ 3:   @__main__:do => miscmisc/trace_profiling.py:98
+ 4:   @__main__:<module> => miscmisc/trace_profiling.py:103
+### trace_handler::main event: return
+ 0:   @trace_subdir.trace_generic:test_import => misc/trace_subdir/trace_generic.py:85
+ 1:   @trace_subdir.trace_generic:run_tests => misc/trace_subdir/trace_generic.py:125
+ 2:   @__main__:do => miscmisc/trace_profiling.py:98
+ 3:   @__main__:<module> => miscmisc/trace_profiling.py:103
+### trace_handler::main event: return
+ 0:   @trace_subdir.trace_generic:run_tests => misc/trace_subdir/trace_generic.py:125
+ 1:   @__main__:do => miscmisc/trace_profiling.py:98
+ 2:   @__main__:<module> => miscmisc/trace_profiling.py:103
+### trace_handler::main event: line
+ 0:   @__main__:do => miscmisc/trace_profiling.py:99
+ 1:   @__main__:<module> => miscmisc/trace_profiling.py:103
+### trace_handler::main event: return
+ 0:   @__main__:do => miscmisc/trace_profiling.py:99
+ 1:   @__main__:<module> => miscmisc/trace_profiling.py:103
+nothing to trace here
+
+------------------ script exited ------------------
+Total traces executed:  224

--- a/tests/misc/trace_subdir/trace_generic.py
+++ b/tests/misc/trace_subdir/trace_generic.py
@@ -1,0 +1,127 @@
+print("Now comes the language constructions tests.")
+
+# function
+def test_func():
+    def test_sub_func():
+        print("test_function")
+
+    test_sub_func()
+
+# closure
+def test_closure(msg):
+
+    def make_closure():
+        print(msg)
+
+    return make_closure
+
+# loop
+def test_loop():
+    # for loop
+    r = 0
+    for i in range(3):
+        r += i
+    print("test_for_loop", r)
+
+    # while loop
+    r = 0
+    i = 0
+    while i < 3:
+        r += i
+        i += 1
+    print("test_while_loop", i)
+
+# exception
+def test_exception():
+    try:
+        raise Exception("test_exception")
+
+    except Exception:
+        pass
+    
+    finally:
+        pass
+
+# listcomp
+def test_listcomp():
+    print("test_listcomp", [x for x in range(3)])
+
+# generator
+def test_generator():
+    def make_gen():
+        yield 1<<0
+        yield 1<<1
+        yield 1<<2
+        return 1<<3
+
+    gen = make_gen()
+    r = 0
+    try:
+
+        r += gen.send(None)
+
+        while True:
+
+            r += gen.send(None)
+
+    except StopIteration as e:
+        print("test_generator", r, e)
+
+    gen = make_gen()
+    r = 0
+    for i in gen:
+        r += i
+    print(r)
+
+# lambda
+def test_lambda():
+    func_obj_1 = lambda a, b: a + b
+    print(func_obj_1(10, 20))
+
+# import
+def test_import():
+    from trace_subdir import trace_importme
+    trace_importme.dummy()
+    trace_importme.saysomething()
+
+# class
+class TLClass():
+    def method():
+        pass
+    pass
+
+def test_class():
+    class TestClass:
+        __anynum = -9
+        def method(self):
+            print("test_class_method")
+            self.__anynum += 1
+        
+        def prprty_getter(self):
+            return self.__anynum
+        
+        def prprty_setter(self, what):
+            self.__anynum = what
+
+        prprty = property(prprty_getter, prprty_setter)
+
+    cls = TestClass()
+    cls.method()
+    print("test_class_property", cls.prprty)
+    cls.prprty = 12
+    print("test_class_property", cls.prprty)
+
+
+def run_tests():
+    test_func()
+    test_closure_inst = test_closure("test_closure")
+    test_closure_inst()
+    test_loop()
+    test_exception()
+    test_listcomp()
+    test_generator()
+    test_lambda()
+    test_class()
+    test_import()
+
+print("And it's done!")

--- a/tests/misc/trace_subdir/trace_importme.py
+++ b/tests/misc/trace_subdir/trace_importme.py
@@ -1,0 +1,23 @@
+print("Yep, I got imported.")
+
+try:
+    from micropython import const
+    import micropython
+
+    _CNT01 = "CONST01"
+    _CNT02 = const(123)
+    A123 = const(123)
+    a123 = const(123)
+except Exception as e:
+    pass
+
+def dummy():
+    return False
+
+def saysomething():
+    print("There, I said it.")
+
+def neverexecuted():
+    print("Never got here!")
+
+print("Yep, got here")

--- a/tests/run-tests
+++ b/tests/run-tests
@@ -53,6 +53,7 @@ def run_micropython(pyb, args, test_file, is_special=False):
     special_tests = (
         'micropython/meminfo.py', 'basics/bytes_compare3.py',
         'basics/builtin_help.py', 'thread/thread_exc2.py',
+        'misc/trace_profiling.py',
     )
     had_crash = False
     if pyb is None:


### PR DESCRIPTION
This is a working concept of profiling API related to issue #3864.

Please review this pull-request and comment especially on the overall integration into the Micropython.

So far the main concern of the profiler is runtime instruction tracing used to create detailed code coverage reports. To achieve this the analogue of [sys.settrace](
https://docs.python.org/3/library/sys.html#sys.settrace) was implemented and puts Micropython closer to feature a debugger #3009.

### Building and Running

So far only the Unix port is concerned.

Enable profiling in ```ports/unix/mpconfigport.h``` like so:
```c
#define MICROPY_PY_SYS_SETTRACE (1)
```

```MICROPY_PERSISTENT_CODE_SAVE``` is required by the ```MICROPY_PY_SYS_TRACE```.

### Python API

#### ```sys.settrace(tracefunc)```
As defined in original Python3 documentation [sys.settrace(tracefunc)](
https://docs.python.org/3/library/sys.html#sys.settrace). The Frame object and Code objects are only partially implemented.