### PR TITLE
[STM32H743xx] Configure USB PLL3 in mpconfigboard

### DIFF
--- a/ports/stm32/boards/NUCLEO_H743ZI/mpconfigboard.h
+++ b/ports/stm32/boards/NUCLEO_H743ZI/mpconfigboard.h
@@ -21,11 +21,11 @@ void NUCLEO_H743ZI_board_early_init(void);
 #define MICROPY_HW_CLK_PLLR (2)
 
 // The USB clock is set using PLL3
-#define MICROPY_HW_PLL3_PLL3M (4)
-#define MICROPY_HW_PLL3_PLL3N (120)
-#define MICROPY_HW_PLL3_PLL3P (2)
-#define MICROPY_HW_PLL3_PLL3Q (5)
-#define MICROPY_HW_PLL3_PLL3R (2)
+#define MICROPY_HW_CLK_PLL3M (4)
+#define MICROPY_HW_CLK_PLL3N (120)
+#define MICROPY_HW_CLK_PLL3P (2)
+#define MICROPY_HW_CLK_PLL3Q (5)
+#define MICROPY_HW_CLK_PLL3R (2)
 
 // 4 wait states
 #define MICROPY_HW_FLASH_LATENCY    FLASH_LATENCY_4

--- a/ports/stm32/boards/NUCLEO_H743ZI/mpconfigboard.h
+++ b/ports/stm32/boards/NUCLEO_H743ZI/mpconfigboard.h
@@ -20,6 +20,13 @@ void NUCLEO_H743ZI_board_early_init(void);
 #define MICROPY_HW_CLK_PLLQ (4)
 #define MICROPY_HW_CLK_PLLR (2)
 
+// The USB clock is set using PLL3
+#define MICROPY_HW_PLL3_PLL3M (4)
+#define MICROPY_HW_PLL3_PLL3N (120)
+#define MICROPY_HW_PLL3_PLL3P (2)
+#define MICROPY_HW_PLL3_PLL3Q (5)
+#define MICROPY_HW_PLL3_PLL3R (2)
+
 // 4 wait states
 #define MICROPY_HW_FLASH_LATENCY    FLASH_LATENCY_4
 

--- a/ports/stm32/system_stm32.c
+++ b/ports/stm32/system_stm32.c
@@ -517,11 +517,11 @@ void SystemClock_Config(void)
     /* PLL3 for USB Clock */
     PeriphClkInitStruct.PeriphClockSelection = RCC_PERIPHCLK_USB;
     PeriphClkInitStruct.UsbClockSelection = RCC_USBCLKSOURCE_PLL3;
-    PeriphClkInitStruct.PLL3.PLL3M = 4;
-    PeriphClkInitStruct.PLL3.PLL3N = 120;
-    PeriphClkInitStruct.PLL3.PLL3P = 2;
-    PeriphClkInitStruct.PLL3.PLL3Q = 5;
-    PeriphClkInitStruct.PLL3.PLL3R = 2;
+    PeriphClkInitStruct.PLL3.PLL3M = MICROPY_HW_PLL3_PLL3M;
+    PeriphClkInitStruct.PLL3.PLL3N = MICROPY_HW_PLL3_PLL3N;
+    PeriphClkInitStruct.PLL3.PLL3P = MICROPY_HW_PLL3_PLL3P;
+    PeriphClkInitStruct.PLL3.PLL3Q = MICROPY_HW_PLL3_PLL3Q;
+    PeriphClkInitStruct.PLL3.PLL3R = MICROPY_HW_PLL3_PLL3R;
     PeriphClkInitStruct.PLL3.PLL3RGE = RCC_PLL3VCIRANGE_1;
     PeriphClkInitStruct.PLL3.PLL3VCOSEL = RCC_PLL3VCOWIDE;
     PeriphClkInitStruct.PLL3.PLL3FRACN = 0;

--- a/ports/stm32/system_stm32.c
+++ b/ports/stm32/system_stm32.c
@@ -517,11 +517,11 @@ void SystemClock_Config(void)
     /* PLL3 for USB Clock */
     PeriphClkInitStruct.PeriphClockSelection = RCC_PERIPHCLK_USB;
     PeriphClkInitStruct.UsbClockSelection = RCC_USBCLKSOURCE_PLL3;
-    PeriphClkInitStruct.PLL3.PLL3M = MICROPY_HW_PLL3_PLL3M;
-    PeriphClkInitStruct.PLL3.PLL3N = MICROPY_HW_PLL3_PLL3N;
-    PeriphClkInitStruct.PLL3.PLL3P = MICROPY_HW_PLL3_PLL3P;
-    PeriphClkInitStruct.PLL3.PLL3Q = MICROPY_HW_PLL3_PLL3Q;
-    PeriphClkInitStruct.PLL3.PLL3R = MICROPY_HW_PLL3_PLL3R;
+    PeriphClkInitStruct.PLL3.PLL3M = MICROPY_HW_CLK_PLL3M;
+    PeriphClkInitStruct.PLL3.PLL3N = MICROPY_HW_CLK_PLL3N;
+    PeriphClkInitStruct.PLL3.PLL3P = MICROPY_HW_CLK_PLL3P;
+    PeriphClkInitStruct.PLL3.PLL3Q = MICROPY_HW_CLK_PLL3Q;
+    PeriphClkInitStruct.PLL3.PLL3R = MICROPY_HW_CLK_PLL3R;
     PeriphClkInitStruct.PLL3.PLL3RGE = RCC_PLL3VCIRANGE_1;
     PeriphClkInitStruct.PLL3.PLL3VCOSEL = RCC_PLL3VCOWIDE;
     PeriphClkInitStruct.PLL3.PLL3FRACN = 0;


### PR DESCRIPTION
If (and I do) use a different crystal like 25MHz instead of 8MHz, I need to edit the PLL3 settings in `system_stm32.c`. To make this variable without the need to change the core code for the STM32 the PLL configuration settings are moved to `mpconfigboard.h`.
