### PR TITLE
py/runtime: Fix qstr assumptions when handling "import *".

### DIFF
--- a/py/runtime.c
+++ b/py/runtime.c
@@ -1379,9 +1379,13 @@ void mp_import_all(mp_obj_t module) {
     mp_map_t *map = &mp_obj_module_get_globals(module)->map;
     for (size_t i = 0; i < map->alloc; i++) {
         if (MP_MAP_SLOT_IS_FILLED(map, i)) {
-            qstr name = MP_OBJ_QSTR_VALUE(map->table[i].key);
-            if (*qstr_str(name) != '_') {
-                mp_store_name(name, map->table[i].value);
+            // Entry in module global scope may be generated programmatically
+            // (and thus be not a qstr for longer names). Avoid turning it in
+            // qstr if it has '_' and was used exactly to save memory.
+            const char *name = mp_obj_str_get_str(map->table[i].key);
+            if (*name != '_') {
+                qstr qname = mp_obj_str_get_qstr(map->table[i].key);
+                mp_store_name(qname, map->table[i].value);
             }
         }
     }

--- a/tests/import/import_long_dyn.py
+++ b/tests/import/import_long_dyn.py
@@ -1,0 +1,1 @@
+from import_long_dyn2 import *

--- a/tests/import/import_long_dyn2.py
+++ b/tests/import/import_long_dyn2.py
@@ -1,0 +1,1 @@
+globals()["long_long_very_long_long_name"] = 1


### PR DESCRIPTION
There was an assumption that all names in a module dict are qstr's.
However, they can be dynamically generated (by assigning to globals()),
and in case of a long name, it won't be a qstr. Handle this situation
properly, including taking care of not creating superfluous qstr's for
names starting with "_" (which aren't imported by "import *").