### PR TITLE
py/gc: Change gc_alloc() to be able to accept multiple flags.

### DIFF
--- a/py/gc.c
+++ b/py/gc.c
@@ -433,7 +433,8 @@ void gc_info(gc_info_t *info) {
     GC_EXIT();
 }
 
-void *gc_alloc(size_t n_bytes, bool has_finaliser) {
+void *gc_alloc(size_t n_bytes, unsigned alloc_flags) {
+    bool has_finaliser = alloc_flags & GC_ALLOC_FLAG_HAS_FINALISER;
     size_t n_blocks = ((n_bytes + BYTES_PER_BLOCK - 1) & (~(BYTES_PER_BLOCK - 1))) / BYTES_PER_BLOCK;
     DEBUG_printf("gc_alloc(" UINT_FMT " bytes -> " UINT_FMT " blocks)\n", n_bytes, n_blocks);
 

--- a/py/gc.h
+++ b/py/gc.h
@@ -48,7 +48,11 @@ void gc_collect_end(void);
 // Use this function to sweep the whole heap and run all finalisers
 void gc_sweep_all(void);
 
-void *gc_alloc(size_t n_bytes, bool has_finaliser);
+enum {
+    GC_ALLOC_FLAG_HAS_FINALISER = 1,
+};
+
+void *gc_alloc(size_t n_bytes, unsigned alloc_flags);
 void gc_free(void *ptr); // does not call finaliser
 size_t gc_nbytes(const void *ptr);
 void *gc_realloc(void *ptr, size_t n_bytes, bool allow_move);


### PR DESCRIPTION
Older "bool has_finaliser" gets recast as ALLOC_HAS_FINALIZER = 1. Bool
gets implicitly converted to 1, so this patch doesn't include conversion
of all calls for now.