### PR TITLE
docs: clarify relationship between machine and port-specific libraries.

### DIFF
--- a/docs/library/index.rst
+++ b/docs/library/index.rst
@@ -115,6 +115,15 @@ the following libraries.
    uctypes.rst
 
 
+Port-specific libraries
+-----------------------
+
+In some cases these libraries have functions or classes similar to those in the
+``machine`` library. Where this occurs, the entry in the port specific library
+exposes hardware functionality unique to that platform. To write portable code
+use ``machine``. To access platform-specific hardware use the appropriate
+library (e.g. ``pyb`` in the case of the Pyboard).
+
 Libraries specific to the pyboard
 ---------------------------------
 


### PR DESCRIPTION
This may seem obvious to us, but it causes endless confusion to newcomers particularly in regard to **machine** and **pyb**. It has resulted in repeated queries on the forum. 