### PR TITLE
Remove extra spaces from JSON output.

### DIFF
--- a/py/objdict.c
+++ b/py/objdict.c
@@ -58,6 +58,10 @@ STATIC void dict_print(const mp_print_t *print, mp_obj_t self_in, mp_print_kind_
     if (!(MICROPY_PY_UJSON && kind == PRINT_JSON)) {
         kind = PRINT_REPR;
     }
+
+    char * const comma = (kind == PRINT_JSON)?",":", ";
+    char * const colon = (kind == PRINT_JSON)?":":": ";
+
     if (MICROPY_PY_COLLECTIONS_ORDEREDDICT && self->base.type != &mp_type_dict) {
         mp_printf(print, "%q(", self->base.type->name);
     }
@@ -66,11 +70,11 @@ STATIC void dict_print(const mp_print_t *print, mp_obj_t self_in, mp_print_kind_
     mp_map_elem_t *next = NULL;
     while ((next = dict_iter_next(self, &cur)) != NULL) {
         if (!first) {
-            mp_print_str(print, ", ");
+            mp_print_str(print, comma);
         }
         first = false;
         mp_obj_print_helper(print, next->key, kind);
-        mp_print_str(print, ": ");
+        mp_print_str(print, colon);
         mp_obj_print_helper(print, next->value, kind);
     }
     mp_print_str(print, "}");

--- a/py/objlist.c
+++ b/py/objlist.c
@@ -47,10 +47,13 @@ STATIC void list_print(const mp_print_t *print, mp_obj_t o_in, mp_print_kind_t k
     if (!(MICROPY_PY_UJSON && kind == PRINT_JSON)) {
         kind = PRINT_REPR;
     }
+
+    char * const comma = (kind == PRINT_JSON)?",":", ";
+
     mp_print_str(print, "[");
     for (size_t i = 0; i < o->len; i++) {
         if (i > 0) {
-            mp_print_str(print, ", ");
+            mp_print_str(print, comma);
         }
         mp_obj_print_helper(print, o->items[i], kind);
     }

--- a/py/objtuple.c
+++ b/py/objtuple.c
@@ -41,9 +41,12 @@ void mp_obj_tuple_print(const mp_print_t *print, mp_obj_t o_in, mp_print_kind_t 
         mp_print_str(print, "(");
         kind = PRINT_REPR;
     }
+
+    char * const comma = (kind == PRINT_JSON)?",":", ";
+
     for (size_t i = 0; i < o->len; i++) {
         if (i > 0) {
-            mp_print_str(print, ", ");
+            mp_print_str(print, comma);
         }
         mp_obj_print_helper(print, o->items[i], kind);
     }


### PR DESCRIPTION
The JSON us mainly used for storage or network communications. Since micropython aims to be as unbloated as possible to be used for small applications like IoT, the JSON output should be as compact as possible.