### PR TITLE
Added ADC calibration for L4 to increase precision of ADC measurements.

### DIFF
--- a/ports/stm32/adc.c
+++ b/ports/stm32/adc.c
@@ -263,6 +263,9 @@ STATIC void adcx_init_periph(ADC_HandleTypeDef *adch, uint32_t resolution) {
     #if defined(STM32H7)
     HAL_ADCEx_Calibration_Start(adch, ADC_CALIB_OFFSET, ADC_SINGLE_ENDED);
     #endif
+    #if defined(STM32L4)
+    HAL_ADCEx_Calibration_Start(adch, ADC_SINGLE_ENDED);
+    #endif
 }
 
 STATIC void adc_init_single(pyb_obj_adc_t *adc_obj) {


### PR DESCRIPTION
To increase the precision of ADC measurements on the L4 I'd like to introduce the ADC calibration which increases as well the temperature measurement (before fix ~5C: after fix ~22 C which is about the room temperature ).

I still have another PR open #3854 which would offer a way to unify IRQ handling over all ports. It is a pity, I do not received a feed back on this updated Generic IRQ handling. I would really be glad to go forward with it...