### PR TITLE
unix/modos: Rename unlink() to remove() to be consistent with other ports.

### DIFF
--- a/ports/unix/modos.c
+++ b/ports/unix/modos.c
@@ -107,16 +107,21 @@ STATIC mp_obj_t mod_os_statvfs(mp_obj_t path_in) {
 STATIC MP_DEFINE_CONST_FUN_OBJ_1(mod_os_statvfs_obj, mod_os_statvfs);
 #endif
 
-STATIC mp_obj_t mod_os_unlink(mp_obj_t path_in) {
+STATIC mp_obj_t mod_os_remove(mp_obj_t path_in) {
     const char *path = mp_obj_str_get_str(path_in);
 
+    // Note that POSIX requires remove() to be able to delete a directory
+    // too (act as rmdir()). This is POSIX extenstion to ANSI C semantics
+    // of that function. But Python remove() follows ANSI C, and explicitly
+    // required to raise exception on attempt to remove a directory. Thus,
+    // call POSIX unlink() here.
     int r = unlink(path);
 
     RAISE_ERRNO(r, errno);
 
     return mp_const_none;
 }
-STATIC MP_DEFINE_CONST_FUN_OBJ_1(mod_os_unlink_obj, mod_os_unlink);
+STATIC MP_DEFINE_CONST_FUN_OBJ_1(mod_os_remove_obj, mod_os_remove);
 
 STATIC mp_obj_t mod_os_system(mp_obj_t cmd_in) {
     const char *cmd = mp_obj_str_get_str(cmd_in);
@@ -230,7 +235,7 @@ STATIC const mp_rom_map_elem_t mp_module_os_globals_table[] = {
     { MP_ROM_QSTR(MP_QSTR_statvfs), MP_ROM_PTR(&mod_os_statvfs_obj) },
     #endif
     { MP_ROM_QSTR(MP_QSTR_system), MP_ROM_PTR(&mod_os_system_obj) },
-    { MP_ROM_QSTR(MP_QSTR_unlink), MP_ROM_PTR(&mod_os_unlink_obj) },
+    { MP_ROM_QSTR(MP_QSTR_remove), MP_ROM_PTR(&mod_os_remove_obj) },
     { MP_ROM_QSTR(MP_QSTR_getenv), MP_ROM_PTR(&mod_os_getenv_obj) },
     { MP_ROM_QSTR(MP_QSTR_mkdir), MP_ROM_PTR(&mod_os_mkdir_obj) },
     { MP_ROM_QSTR(MP_QSTR_ilistdir), MP_ROM_PTR(&mod_os_ilistdir_obj) },

--- a/tests/io/open_append.py
+++ b/tests/io/open_append.py
@@ -3,13 +3,13 @@ try:
 except ImportError:
     import os
 
-if not hasattr(os, "unlink"):
+if not hasattr(os, "remove"):
     print("SKIP")
     raise SystemExit
 
 # cleanup in case testfile exists
 try:
-    os.unlink("testfile")
+    os.remove("testfile")
 except OSError:
     pass
 
@@ -32,6 +32,6 @@ f.close()
 
 # cleanup
 try:
-    os.unlink("testfile")
+    os.remove("testfile")
 except OSError:
     pass

--- a/tests/io/open_plus.py
+++ b/tests/io/open_plus.py
@@ -3,13 +3,13 @@ try:
 except ImportError:
     import os
 
-if not hasattr(os, "unlink"):
+if not hasattr(os, "remove"):
     print("SKIP")
     raise SystemExit
 
 # cleanup in case testfile exists
 try:
-    os.unlink("testfile")
+    os.remove("testfile")
 except OSError:
     pass
 
@@ -42,6 +42,6 @@ f.close()
 
 # cleanup
 try:
-    os.unlink("testfile")
+    os.remove("testfile")
 except OSError:
     pass


### PR DESCRIPTION
We standardized to provide uos.remove(), as more obvious and user-friendly
name. That's what written in the docs. The Unix port implementation predates
this convention, so update it now.