### PR TITLE
esp8266: add support for WiFi radio sleep

### DIFF
--- a/ports/esp8266/ets_alt_task.c
+++ b/ports/esp8266/ets_alt_task.c
@@ -166,6 +166,11 @@ bool ets_loop_iter(void) {
         }
         ets_intr_unlock();
     }
+
+    if (!progress && idle_cb) {
+        idle_cb(idle_arg);
+    }
+
     return progress;
 }
 

--- a/ports/esp8266/main.c
+++ b/ports/esp8266/main.c
@@ -102,6 +102,13 @@ void soft_reset(void) {
 }
 
 void init_done(void) {
+    // Configure sleep, and put the radio to sleep if no interfaces are active
+    wifi_fpm_set_sleep_type(MODEM_SLEEP_T);
+    if (wifi_get_opmode() == NULL_MODE) {
+        wifi_fpm_open();
+        wifi_fpm_do_sleep(0xfffffff);
+    }
+
     #if MICROPY_REPL_EVENT_DRIVEN
     uart_task_init();
     #endif

--- a/ports/esp8266/modnetwork.c
+++ b/ports/esp8266/modnetwork.c
@@ -83,7 +83,15 @@ STATIC mp_obj_t esp_active(size_t n_args, const mp_obj_t *args) {
         } else {
             mode &= ~mask;
         }
+        if (mode != NULL_MODE) {
+            wifi_fpm_do_wakeup();
+            wifi_fpm_close();
+        }
         error_check(wifi_set_opmode(mode), "Cannot update i/f status");
+        if (mode == NULL_MODE) {
+            wifi_fpm_open();
+            wifi_fpm_do_sleep(0xfffffff);
+        }
         return mp_const_none;
     }
 


### PR DESCRIPTION
If/when no WLAN interfaces are active (ie both STA and AP are inactive), the device will automatically go into radio sleep mode, which reduces current of the device by about 55mA.  Addresses #4295