### PR TITLE
nrf/bluetooth: Update stack download script

### DIFF
--- a/ports/nrf/drivers/bluetooth/download_ble_stack.sh
+++ b/ports/nrf/drivers/bluetooth/download_ble_stack.sh
@@ -10,9 +10,11 @@ function download_s110_nrf51_8_0_0
 
     mkdir -p $1/s110_nrf51_8.0.0
     cd $1/s110_nrf51_8.0.0
-    wget https://www.nordicsemi.com/eng/nordic/download_resource/45846/3/78153065/80234
-    mv 80234 temp.zip
+    wget --post-data="fileName=DeviceDownload&ids=DBBEB2467E4A4EBCB791C2E7BE3FC7A8" https://www.nordicsemi.com/api/sitecore/Products/MedialibraryZipDownload2
+    mv MedialibraryZipDownload2 temp.zip
     unzip -u temp.zip
+    unzip -u s110nrf51800.zip
+    rm s110nrf51800.zip
     rm temp.zip
     cd -
 }
@@ -28,10 +30,11 @@ function download_s132_nrf52_6_0_0
 
     mkdir -p $1/s132_nrf52_6.0.0
     cd $1/s132_nrf52_6.0.0
-
-    wget http://www.nordicsemi.com/eng/nordic/download_resource/67248/3/62916494/141008
-    mv 141008 temp.zip
+    wget --post-data="fileName=DeviceDownload&ids=C44AF08D58934BDB98F1EE7C4B8D2815" https://www.nordicsemi.com/api/sitecore/Products/MedialibraryZipDownload2
+    mv MedialibraryZipDownload2 temp.zip
     unzip -u temp.zip
+    unzip -u s132nrf52600.zip
+    rm s132nrf52600.zip
     rm temp.zip
     cd -
 }
@@ -47,10 +50,11 @@ function download_s140_nrf52_6_0_0
 
     mkdir -p $1/s140_nrf52_6.0.0
     cd $1/s140_nrf52_6.0.0
-
-    wget http://www.nordicsemi.com/eng/nordic/download_resource/60624/19/81980817/116072
-    mv 116072 temp.zip
+    wget --post-data="fileName=DeviceDownload&ids=D631FCC10C9741A49135BC0450E42B19" https://www.nordicsemi.com/api/sitecore/Products/MedialibraryZipDownload2
+    mv MedialibraryZipDownload2 temp.zip
     unzip -u temp.zip
+    unzip -u s140nrf52600.zip
+    rm s140nrf52600.zip
     rm temp.zip
     cd -
 }


### PR DESCRIPTION
Due to new webpages download links were broken.
This patch updates the links to new locations for the current
targets.