### PR TITLE
py/objfun: Store/allow to access code state structure of current code.

### DIFF
--- a/py/mpconfig.h
+++ b/py/mpconfig.h
@@ -242,6 +242,13 @@
 #define alloca(x) m_malloc(x)
 #endif
 
+// Various features may need to access code state of the currently
+// running function/generator. This is an internal setting, automatically
+// enabled as needed.
+#ifndef MICROPY_ACCESS_CODE_STATE
+#define MICROPY_ACCESS_CODE_STATE (0)
+#endif
+
 /*****************************************************************************/
 /* MicroPython emitters                                                     */
 

--- a/py/mpstate.h
+++ b/py/mpstate.h
@@ -217,6 +217,9 @@ typedef struct _mp_state_vm_t {
     #endif
 } mp_state_vm_t;
 
+// Can't include bc.h due to circular dependency.
+struct _mp_code_state_t;
+
 // This structure holds state that is specific to a given thread.
 // Everything in this structure is scanned for root pointers.
 typedef struct _mp_state_thread_t {
@@ -231,6 +234,11 @@ typedef struct _mp_state_thread_t {
     uint8_t *pystack_start;
     uint8_t *pystack_end;
     uint8_t *pystack_cur;
+    #endif
+
+    #if MICROPY_ACCESS_CODE_STATE
+    // code_state structure of the currently running function.
+    struct _mp_code_state_t *code_state;
     #endif
 
     ////////////////////////////////////////////////////////////

--- a/py/objfun.c
+++ b/py/objfun.c
@@ -4,7 +4,7 @@
  * The MIT License (MIT)
  *
  * Copyright (c) 2013, 2014 Damien P. George
- * Copyright (c) 2014 Paul Sokolovsky
+ * Copyright (c) 2014-2018 Paul Sokolovsky
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -240,6 +240,10 @@ mp_code_state_t *mp_obj_fun_bc_prepare_codestate(mp_obj_t self_in, size_t n_args
     }
     #endif
 
+    #if MICROPY_ACCESS_CODE_STATE
+    MP_STATE_THREAD(code_state) = code_state;
+    #endif
+
     INIT_CODESTATE(code_state, self, n_args, n_kw, args);
 
     // execute the byte code with the correct globals context
@@ -275,6 +279,10 @@ STATIC mp_obj_t fun_bc_call(mp_obj_t self_in, size_t n_args, size_t n_kw, const 
         code_state = alloca(sizeof(mp_code_state_t) + state_size);
         state_size = 0; // indicate that we allocated using alloca
     }
+    #endif
+
+    #if MICROPY_ACCESS_CODE_STATE
+    MP_STATE_THREAD(code_state) = code_state;
     #endif
 
     INIT_CODESTATE(code_state, self, n_args, n_kw, args);


### PR DESCRIPTION
Store pointer to mp_code_state_t of the currently running function/generator
in MP_STATE_THREAD, thus allowing to access it outside the VM mainloop.

The immediate usecase for this is implementing line number reporting for
warnings, but it has more usages, e.g. introspection of bytecode execution
(profiling, etc).