### PR TITLE
tools/mpy-tool.py - fix error when no qstrs present

### DIFF
--- a/tools/mpy-tool.py
+++ b/tools/mpy-tool.py
@@ -509,13 +509,14 @@ def freeze_mpy(base_qstrs, raw_codes):
     print('#endif')
     print()
 
-    print('enum {')
-    for i in range(len(new)):
-        if i == 0:
-            print('    MP_QSTR_%s = MP_QSTRnumber_of,' % new[i][1])
-        else:
-            print('    MP_QSTR_%s,' % new[i][1])
-    print('};')
+    if (len(new) > 0):
+        print('enum {')
+        for i in range(len(new)):
+            if i == 0:
+                print('    MP_QSTR_%s = MP_QSTRnumber_of,' % new[i][1])
+            else:
+                print('    MP_QSTR_%s,' % new[i][1])
+        print('};')
 
     # As in qstr.c, set so that the first dynamically allocated pool is twice this size; must be <= the len
     qstr_pool_alloc = min(len(new), 10)


### PR DESCRIPTION
If you happen to only have a really simple frozen file, i.e. remove
all of the existing frozen files and create a single file with the
contents:
```
print('Executing foo.py')
```
then the generated frozen_mpy.c file contains an empty enumeration
which causes a compile time error.