### PR TITLE
stm32/main: Allow freezing boot.py and main.py into firmware image

### DIFF
--- a/lib/utils/pyexec.c
+++ b/lib/utils/pyexec.c
@@ -542,8 +542,12 @@ int pyexec_file(const char *filename) {
 }
 
 int pyexec_file_if_exists(const char *filename) {
-    mp_import_stat_t stat = mp_import_stat(filename);
-    if (stat != MP_IMPORT_STAT_FILE) {
+    #if MICROPY_MODULE_FROZEN
+    if (mp_frozen_stat(filename) == MP_IMPORT_STAT_FILE) {
+        return pyexec_frozen_module(filename);
+    }
+    #endif
+    if (mp_import_stat(filename) != MP_IMPORT_STAT_FILE) {
         return 1; // success (no file is the same as an empty file executing without fail)
     }
     return pyexec_file(filename);

--- a/ports/stm32/main.c
+++ b/ports/stm32/main.c
@@ -148,6 +148,7 @@ STATIC mp_obj_t pyb_main(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_a
 MP_DEFINE_CONST_FUN_OBJ_KW(pyb_main_obj, 1, pyb_main);
 
 #if MICROPY_HW_ENABLE_STORAGE
+#if !MICROPY_HW_NO_FS_TEMPLATE
 static const char fresh_boot_py[] =
 "# boot.py -- run on boot-up\r\n"
 "# can run arbitrary Python, but best to keep it minimal\r\n"
@@ -183,6 +184,7 @@ static const char fresh_readme_txt[] =
 "\r\n"
 "Please visit http://micropython.org/help/ for further help.\r\n"
 ;
+#endif // !MICROPY_HW_NO_FS_TEMPLATE
 
 // avoid inlining to avoid stack usage within main()
 MP_NOINLINE STATIC bool init_flash_fs(uint reset_mode) {
@@ -213,6 +215,7 @@ MP_NOINLINE STATIC bool init_flash_fs(uint reset_mode) {
         // set label
         f_setlabel(&vfs_fat->fatfs, MICROPY_HW_FLASH_FS_LABEL);
 
+        #if !MICROPY_HW_NO_FS_TEMPLATE
         // create empty main.py
         FIL fp;
         f_open(&vfs_fat->fatfs, &fp, "/main.py", FA_WRITE | FA_CREATE_ALWAYS);
@@ -230,7 +233,7 @@ MP_NOINLINE STATIC bool init_flash_fs(uint reset_mode) {
         f_open(&vfs_fat->fatfs, &fp, "/README.txt", FA_WRITE | FA_CREATE_ALWAYS);
         f_write(&fp, fresh_readme_txt, sizeof(fresh_readme_txt) - 1 /* don't count null terminator */, &n);
         f_close(&fp);
-
+        #endif
         // keep LED on for at least 200ms
         systick_wait_at_least(start_tick, 200);
         led_state(PYB_LED_GREEN, 0);
@@ -258,6 +261,7 @@ MP_NOINLINE STATIC bool init_flash_fs(uint reset_mode) {
     // It is set to the internal flash filesystem by default.
     MP_STATE_PORT(vfs_cur) = vfs;
 
+    #if !MICROPY_HW_NO_FS_TEMPLATE
     // Make sure we have a /flash/boot.py.  Create it if needed.
     FILINFO fno;
     res = f_stat(&vfs_fat->fatfs, "/boot.py", &fno);
@@ -279,7 +283,7 @@ MP_NOINLINE STATIC bool init_flash_fs(uint reset_mode) {
         systick_wait_at_least(start_tick, 200);
         led_state(PYB_LED_GREEN, 0);
     }
-
+    #endif
     return true;
 }
 #endif


### PR DESCRIPTION
If boot.py and/or main.py are in frozen scripts, use them rather than the static copy in code for creating initial files on filesystem.

This was originally inspired by #4248, however taking a different direction.

Currently, the template for `main.py` and `boot.py` is just contained in char string in code. When a new filesystem is being created the initial files are created from these templates.

The PR allows a firmware board developer to use their own copies of boot.py or main.py instead of the code templates by putting those files into a separate folder for frozen scripts, eg:
```
make FROZEN_DIR=src/boot_scripts all
```

Doing it this way allows the end user to still make modifications to those files during development, etc and the modified copies will be used. However if something goes wrong they can erase the filesystem and go back to the frozen templates.

This PR combined with the existing FROZEN_DIR / FROZEN_MPY_DIR system allows us to have our entire micropython application frozen into the rom dfu image for easy deployment without needing to manually copy any files onto the filesystem afterwards.