### PR TITLE
stm32/main: Add boardconfig option to enable/disable booting from sdcard

### DIFF
--- a/ports/stm32/main.c
+++ b/ports/stm32/main.c
@@ -268,7 +268,7 @@ MP_NOINLINE STATIC bool init_flash_fs(uint reset_mode) {
 }
 #endif
 
-#if MICROPY_HW_HAS_SDCARD
+#if MICROPY_HW_HAS_SDCARD && MICROPY_HW_BOOT_SDCARD
 STATIC bool init_sdcard_fs(void) {
     bool first_part = true;
     for (int part_num = 1; part_num <= 4; ++part_num) {
@@ -620,7 +620,7 @@ soft_reset:
     #endif
 
     bool mounted_sdcard = false;
-    #if MICROPY_HW_HAS_SDCARD
+    #if MICROPY_HW_HAS_SDCARD && MICROPY_HW_BOOT_SDCARD
     // if an SD card is present then mount it on /sd/
     if (sdcard_is_present()) {
         // if there is a file in the flash called "SKIPSD", then we don't mount the SD card

--- a/ports/stm32/mpconfigboard_common.h
+++ b/ports/stm32/mpconfigboard_common.h
@@ -197,6 +197,13 @@
 #define MICROPY_HW_ENABLE_STORAGE (0)
 #endif
 
+// IF the SD card is present it will be booted from by default
+#if defined(MICROPY_HW_HAS_SDCARD) && !defined(MICROPY_HW_BOOT_SDCARD)
+#define MICROPY_HW_BOOT_SDCARD (1)
+#endif
+
+
+
 // Enable hardware I2C if there are any peripherals defined
 #if defined(MICROPY_HW_I2C1_SCL) || defined(MICROPY_HW_I2C2_SCL) \
     || defined(MICROPY_HW_I2C3_SCL) || defined(MICROPY_HW_I2C4_SCL)


### PR DESCRIPTION
With this PR `MICROPY_HW_BOOT_SDCARD` can be defined to (0) in mpconfigboard.h to allow SD hardware to be enabled but not auto-mounted at boot.

Previously, if an SD card is enabled in hardware it is also used to boot from.

While booting from SD card can be disabled with a `SKIPSD` file on internal flash, this wont be available at first boot after flashing or if the internal flash gets corrupted.

We're working on a product that uses an SD card for bulk storage, however we don't want code to be stored or run from the card. This PR allows us to enforce this from first boot of a fresh DFU image.