### PR TITLE
py: Remove calls to file reader functions when these are disabled

### DIFF
--- a/py/builtinimport.c
+++ b/py/builtinimport.c
@@ -131,7 +131,7 @@ STATIC mp_import_stat_t find_file(const char *file_str, uint file_len, vstr_t *d
 #endif
 }
 
-#if MICROPY_ENABLE_COMPILER
+#if MICROPY_MODULE_FROZEN_STR || MICROPY_ENABLE_COMPILER
 STATIC void do_load_from_lexer(mp_obj_t module_obj, mp_lexer_t *lex) {
     #if MICROPY_PY___FILE__
     qstr source_name = lex->source_name;
@@ -182,7 +182,7 @@ STATIC void do_execute_raw_code(mp_obj_t module_obj, mp_raw_code_t *raw_code) {
 #endif
 
 STATIC void do_load(mp_obj_t module_obj, vstr_t *file) {
-    #if MICROPY_MODULE_FROZEN || MICROPY_PERSISTENT_CODE_LOAD || MICROPY_ENABLE_COMPILER
+    #if MICROPY_MODULE_FROZEN || MICROPY_ENABLE_COMPILER || (MICROPY_PERSISTENT_CODE_LOAD && MICROPY_HAS_FILE_READER)
     char *file_str = vstr_null_terminated_str(file);
     #endif
 
@@ -213,7 +213,7 @@ STATIC void do_load(mp_obj_t module_obj, vstr_t *file) {
 
     // If we support loading .mpy files then check if the file extension is of
     // the correct format and, if so, load and execute the file.
-    #if MICROPY_PERSISTENT_CODE_LOAD
+    #if MICROPY_HAS_FILE_READER && MICROPY_PERSISTENT_CODE_LOAD
     if (file_str[file->len - 3] == 'm') {
         mp_raw_code_t *raw_code = mp_raw_code_load_file(file_str);
         do_execute_raw_code(module_obj, raw_code);
@@ -229,7 +229,6 @@ STATIC void do_load(mp_obj_t module_obj, vstr_t *file) {
         return;
     }
     #else
-
     // If we get here then the file was not frozen and we can't compile scripts.
     mp_raise_msg(&mp_type_ImportError, "script compilation not supported");
     #endif

--- a/py/mpconfig.h
+++ b/py/mpconfig.h
@@ -442,6 +442,11 @@
 #define MICROPY_READER_VFS (0)
 #endif
 
+// Whether any readers have been defined
+#ifndef MICROPY_HAS_FILE_READER
+#define MICROPY_HAS_FILE_READER (MICROPY_READER_POSIX || MICROPY_READER_VFS)
+#endif
+
 // Hook for the VM at the start of the opcode loop (can contain variable
 // definitions usable by the other hook functions)
 #ifndef MICROPY_VM_HOOK_INIT

--- a/py/persistentcode.c
+++ b/py/persistentcode.c
@@ -232,11 +232,15 @@ mp_raw_code_t *mp_raw_code_load_mem(const byte *buf, size_t len) {
     return mp_raw_code_load(&reader);
 }
 
+#if MICROPY_HAS_FILE_READER
+
 mp_raw_code_t *mp_raw_code_load_file(const char *filename) {
     mp_reader_t reader;
     mp_reader_new_file(&reader, filename);
     return mp_raw_code_load(&reader);
 }
+
+#endif // MICROPY_HAS_FILE_READER
 
 #endif // MICROPY_PERSISTENT_CODE_LOAD
 


### PR DESCRIPTION
If `MICROPY_PERSISTENT_CODE_LOAD` or `MICROPY_ENABLE_COMPILER` are enabled then code gets enabled that calls file reading functions which are disabled if neither `MICROPY_READER_POSIX` or `MICROPY_READER_VFS` is set. These calls should also be disabled if neither of these is set.

Specifically, this happens in 3 instances:

1. In `persistentcode.c` if `MICROPY_PERSISTENT_CODE_LOAD` is set then the function `mp_raw_code_load_file` gets defined regardless of whether `MICROPY_READER_POSIX` or `MICROPY_READER_VFS` is set, but then tries to call `mp_reader_new_file` which will only be defined if one of these is set.
2. In `builtinimport.c`, if `MICROPY_PERSISTENT_CODE_LOAD` is set, the `do_load` function tries to call the `mp_raw_code_load_file` mentioned above.
3. In `builtinimport.c` if `MICROPY_ENABLE_COMPILER` is set the `do_load` function tries to call the `mp_lexer_new_from_file` function without checking whether `MICROPY_READER_POSIX` or `MICROPY_READER_VFS` is set. But in `lexer.c` the  function is disabled if neither of these is set.

This change simply adds extra `#if MICROPY_READER_POSIX || MICROPY_READER_VFS` checks around these sections to disable them when necessary.