### PR TITLE
py/mpconfig: Move MICROPY_VERSION macros to static ones in mpconfig.h.

### DIFF
--- a/extmod/modwebrepl.c
+++ b/extmod/modwebrepl.c
@@ -35,7 +35,6 @@
 #include "py/mphal.h"
 #endif
 #include "extmod/modwebsocket.h"
-#include "genhdr/mpversion.h"
 
 #if MICROPY_PY_WEBREPL
 

--- a/py/makeversionhdr.py
+++ b/py/makeversionhdr.py
@@ -46,15 +46,7 @@ def get_version_info_from_git():
     except OSError:
         return None
 
-    # Try to extract MicroPython version from git tag
-    if git_tag.startswith("v"):
-        ver = git_tag[1:].split("-")[0].split(".")
-        if len(ver) == 2:
-            ver.append("0")
-    else:
-        ver = ["0", "0", "1"]
-
-    return git_tag, git_hash, ver
+    return git_tag, git_hash
 
 def get_version_info_from_docs_conf():
     with open(os.path.join(os.path.dirname(sys.argv[0]), "..", "docs", "conf.py")) as f:
@@ -62,10 +54,7 @@ def get_version_info_from_docs_conf():
             if line.startswith("version = release = '"):
                 ver = line.strip().split(" = ")[2].strip("'")
                 git_tag = "v" + ver
-                ver = ver.split(".")
-                if len(ver) == 2:
-                    ver.append("0")
-                return git_tag, "<no hash>", ver
+                return git_tag, "<no hash>"
     return None
 
 def make_version_header(filename):
@@ -74,7 +63,7 @@ def make_version_header(filename):
     if info is None:
         info = get_version_info_from_docs_conf()
 
-    git_tag, git_hash, ver = info
+    git_tag, git_hash = info
 
     # Generate the file with the git and version info
     file_data = """\
@@ -82,12 +71,7 @@ def make_version_header(filename):
 #define MICROPY_GIT_TAG "%s"
 #define MICROPY_GIT_HASH "%s"
 #define MICROPY_BUILD_DATE "%s"
-#define MICROPY_VERSION_MAJOR (%s)
-#define MICROPY_VERSION_MINOR (%s)
-#define MICROPY_VERSION_MICRO (%s)
-#define MICROPY_VERSION_STRING "%s.%s.%s"
-""" % (git_tag, git_hash, datetime.date.today().strftime("%Y-%m-%d"),
-    ver[0], ver[1], ver[2], ver[0], ver[1], ver[2])
+""" % (git_tag, git_hash, datetime.date.today().strftime("%Y-%m-%d"))
 
     # Check if the file contents changed from last time
     write_file = True

--- a/py/modsys.c
+++ b/py/modsys.c
@@ -37,8 +37,6 @@
 
 #if MICROPY_PY_SYS
 
-#include "genhdr/mpversion.h"
-
 // defined per port; type of these is irrelevant, just need pointer
 extern struct _mp_dummy_t mp_sys_stdin_obj;
 extern struct _mp_dummy_t mp_sys_stdout_obj;

--- a/py/mpconfig.h
+++ b/py/mpconfig.h
@@ -26,6 +26,23 @@
 #ifndef MICROPY_INCLUDED_PY_MPCONFIG_H
 #define MICROPY_INCLUDED_PY_MPCONFIG_H
 
+// Current version of MicroPython
+#define MICROPY_VERSION_MAJOR (1)
+#define MICROPY_VERSION_MINOR (9)
+#define MICROPY_VERSION_MICRO (4)
+
+// Combined version as a 32-bit number for convenience
+#define MICROPY_VERSION ( \
+    MICROPY_VERSION_MAJOR << 16 \
+    | MICROPY_VERSION_MINOR << 8 \
+    | MICROPY_VERSION_MICRO)
+
+// String version
+#define MICROPY_VERSION_STRING \
+    MP_STRINGIFY(MICROPY_VERSION_MAJOR) "." \
+    MP_STRINGIFY(MICROPY_VERSION_MINOR) "." \
+    MP_STRINGIFY(MICROPY_VERSION_MICRO)
+
 // This file contains default configuration settings for MicroPython.
 // You can override any of the options below using mpconfigport.h file
 // located in a directory of your port.


### PR DESCRIPTION
It's more robust to have the version defined statically in a header file, rather than dynamically generating it via git using a git tag.  In case git doesn't exist, or a different source control tool is used, it's important to still have the uPy version number available.