### PR TITLE
tools/pydfu.py - fix regression in last commit

### DIFF
--- a/tools/pydfu.py
+++ b/tools/pydfu.py
@@ -85,7 +85,7 @@ def find_dfu_cfg_descr(descr):
         nt = collections.namedtuple('CfgDescr',
             ['bLength', 'bDescriptorType', 'bmAttributes',
             'wDetachTimeOut', 'wTransferSize', 'bcdDFUVersion'])
-        return nt(*struct.unpack('<BBBHHH', bytes(descr)))
+        return nt(*struct.unpack('<BBBHHH', bytearray(descr)))
     return None
 
 


### PR DESCRIPTION
Under python3 (tested with 3.6.7) bytes returns a different
result that under python 2.7 (tested with 2.7.15rc1) which
causes pydfu.py to crash when run under 2.7.

I see the following error when trying to flash my pyboard v1.1:
```
792 >make BOARD=PYBV11 deploy
Executing GNUmakefile
BOARD = PYBV11
Use make V=1 or set BUILD_VERBOSE in your environment to increase build verbosity.
Writing build-PYBV11/firmware.dfu to the board
Traceback (most recent call last):
  File "../../tools/pydfu.py", line 586, in <module>
    main()
  File "../../tools/pydfu.py", line 566, in main
    init()
  File "../../tools/pydfu.py", line 113, in init
    __cfg_descr = find_dfu_cfg_descr(itf.extra_descriptors)
  File "../../tools/pydfu.py", line 88, in find_dfu_cfg_descr
    return nt(*struct.unpack('<BBBHHH', bytes(descr)))
struct.error: unpack requires a string argument of length 9
Makefile:474: recipe for target 'deploy' failed
make: *** [deploy] Error 1
```
This was also reported by another user on the forum:
https://forum.micropython.org/viewtopic.php?f=6&t=5718

Under python3:
```
Python 3.6.7 (default, Oct 22 2018, 11:32:17)
[GCC 8.2.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> descr = [1, 2, 3, 4]
>>> bytes(descr)
b'\x01\x02\x03\x04'
>>>
```

Under python2:
```
Python 2.7.15rc1 (default, Nov 12 2018, 14:31:15)
[GCC 7.3.0] on linux2
Type "help", "copyright", "credits" or "license" for more information.
>>> descr = [1, 2, 3, 4]
>>> bytes(descr)
'[1, 2, 3, 4]'
>>>
```

Changing bytes to bytearray makes pydfu work properly under both
Python 2.7 and Python 3.6