### PR TITLE
Unix threading: cleanup

### DIFF
--- a/ports/unix/main.c
+++ b/ports/unix/main.c
@@ -647,6 +647,10 @@ MP_NOINLINE int main_(int argc, char **argv) {
     }
     #endif
 
+    #if MICROPY_PY_THREAD
+    mp_thread_deinit();
+    #endif
+
     #if defined(MICROPY_UNIX_COVERAGE)
     gc_sweep_all();
     #endif

--- a/ports/unix/mpthreadport.c
+++ b/ports/unix/mpthreadport.c
@@ -175,6 +175,11 @@ void mp_thread_create(void *(*entry)(void*), void *arg, size_t *stack_size) {
         goto er;
     }
 
+    ret = pthread_attr_setdetachstate(&attr, PTHREAD_CREATE_DETACHED);
+    if (ret != 0) {
+        goto er;
+    }
+
     pthread_mutex_lock(&thread_mutex);
 
     // create thread
@@ -207,12 +212,18 @@ er:
 
 void mp_thread_finish(void) {
     pthread_mutex_lock(&thread_mutex);
-    // TODO unlink from list
+    thread_t * prev = NULL;
     for (thread_t *th = thread; th != NULL; th = th->next) {
         if (th->id == pthread_self()) {
-            th->ready = 0;
+            if (prev == NULL) {
+                thread = th->next;
+            } else {
+                prev->next = th->next;
+            }
+            free(th);
             break;
         }
+        prev = th;
     }
     pthread_mutex_unlock(&thread_mutex);
 }

--- a/ports/unix/mpthreadport.c
+++ b/ports/unix/mpthreadport.c
@@ -36,6 +36,7 @@
 
 #include <signal.h>
 #include <sched.h>
+#include <semaphore.h>
 
 // this structure forms a linked list, one node per active thread
 typedef struct _thread_t {
@@ -53,7 +54,7 @@ STATIC thread_t *thread;
 
 // this is used to synchronise the signal handler of the thread
 // it's needed because we can't use any pthread calls in a signal handler
-STATIC volatile int thread_signal_done;
+STATIC sem_t thread_signal_done;
 
 // this signal handler is used to scan the regs and stack of a thread
 STATIC void mp_thread_gc(int signo, siginfo_t *info, void *context) {
@@ -70,7 +71,7 @@ STATIC void mp_thread_gc(int signo, siginfo_t *info, void *context) {
         void **ptrs = (void**)(void*)MP_STATE_THREAD(pystack_start);
         gc_collect_root(ptrs, (MP_STATE_THREAD(pystack_cur) - MP_STATE_THREAD(pystack_start)) / sizeof(void*));
         #endif
-        thread_signal_done = 1;
+        sem_post(&thread_signal_done);
     }
 }
 
@@ -84,6 +85,7 @@ void mp_thread_init(void) {
     thread->ready = 1;
     thread->arg = NULL;
     thread->next = NULL;
+    sem_init(&thread_signal_done, 0, 0);
 
     // enable signal handler for garbage collection
     struct sigaction sa;
@@ -124,11 +126,8 @@ void mp_thread_gc_others(void) {
         if (!th->ready) {
             continue;
         }
-        thread_signal_done = 0;
         pthread_kill(th->id, SIGUSR1);
-        while (thread_signal_done == 0) {
-            sched_yield();
-        }
+        sem_wait(&thread_signal_done);
     }
     pthread_mutex_unlock(&thread_mutex);
 }

--- a/ports/unix/mpthreadport.c
+++ b/ports/unix/mpthreadport.c
@@ -93,6 +93,21 @@ void mp_thread_init(void) {
     sigaction(SIGUSR1, &sa, NULL);
 }
 
+void mp_thread_deinit(void)
+{
+    pthread_mutex_lock(&thread_mutex);
+    while (thread->next != NULL) {
+        thread_t * th = thread;
+       thread = thread->next;
+        pthread_cancel(th->id);
+        free(th);
+    }
+    pthread_mutex_unlock(&thread_mutex);
+    assert(thread->id == pthread_self());
+    free(thread);
+}
+
+
 // This function scans all pointers that are external to the current thread.
 // It does this by signalling all other threads and getting them to scan their
 // own registers and stack.  Note that there may still be some edge cases left
@@ -127,6 +142,7 @@ void mp_thread_set_state(void *state) {
 }
 
 void mp_thread_start(void) {
+    pthread_setcanceltype(PTHREAD_CANCEL_ASYNCHRONOUS, NULL);
     pthread_mutex_lock(&thread_mutex);
     for (thread_t *th = thread; th != NULL; th = th->next) {
         if (th->id == pthread_self()) {

--- a/ports/unix/mpthreadport.h
+++ b/ports/unix/mpthreadport.h
@@ -29,4 +29,5 @@
 typedef pthread_mutex_t mp_thread_mutex_t;
 
 void mp_thread_init(void);
+void mp_thread_deinit(void);
 void mp_thread_gc_others(void);


### PR DESCRIPTION
1. remove busy waitloop in grabage collection
2. cleanup used memory on thread exit. Make valgrind happy
3. add thread deinit() code. -> cleanup used memory and cancel outstanding threads to avoid segmentation fault