### PR TITLE
esp8266/main: Activate UART(0) on dupterm for REPL before boot.py runs.

### DIFF
--- a/ports/esp8266/modules/inisetup.py
+++ b/ports/esp8266/modules/inisetup.py
@@ -45,7 +45,7 @@ def setup():
 #import esp
 #esp.osdebug(None)
 import uos, machine
-uos.dupterm(machine.UART(0, 115200), 1)
+#uos.dupterm(None, 1) # disable REPL on UART(0)
 import gc
 #import webrepl
 #webrepl.start()


### PR DESCRIPTION
So that the user can explicitly deactivate UART(0) if needed.  See issue #4314.