### PR TITLE
esp8266: make DHT more reliable by reverting to open-drain mode of the GPIO

### DIFF
--- a/drivers/dht/dht.c
+++ b/drivers/dht/dht.c
@@ -32,6 +32,11 @@
 #include "extmod/machine_pulse.h"
 #include "drivers/dht/dht.h"
 
+// Allow the open-drain-high call to be DHT specific for ports that need it
+#ifndef mp_hal_pin_od_high_dht
+#define mp_hal_pin_od_high_dht mp_hal_pin_od_high
+#endif
+
 STATIC mp_obj_t dht_readinto(mp_obj_t pin_in, mp_obj_t buf_in) {
     mp_hal_pin_obj_t pin = mp_hal_get_pin_obj(pin_in);
     mp_hal_pin_open_drain(pin);
@@ -44,7 +49,7 @@ STATIC mp_obj_t dht_readinto(mp_obj_t pin_in, mp_obj_t buf_in) {
     }
 
     // issue start command
-    mp_hal_pin_od_high(pin);
+    mp_hal_pin_od_high_dht(pin);
     mp_hal_delay_ms(250);
     mp_hal_pin_od_low(pin);
     mp_hal_delay_ms(18);
@@ -52,7 +57,7 @@ STATIC mp_obj_t dht_readinto(mp_obj_t pin_in, mp_obj_t buf_in) {
     mp_uint_t irq_state = mp_hal_quiet_timing_enter();
 
     // release the line so the device can respond
-    mp_hal_pin_od_high(pin);
+    mp_hal_pin_od_high_dht(pin);
     mp_hal_delay_us_fast(10);
 
     // wait for device to respond

--- a/ports/esp8266/esp_mphal.h
+++ b/ports/esp8266/esp_mphal.h
@@ -91,6 +91,11 @@ void mp_hal_pin_open_drain(mp_hal_pin_obj_t pin);
         if ((p) == 16) { WRITE_PERI_REG(RTC_GPIO_ENABLE, (READ_PERI_REG(RTC_GPIO_ENABLE) & ~1)); } \
         else { gpio_output_set(0, 0, 0, 1 << (p)); /* set as input to avoid glitches */ } \
     } while (0)
+// The DHT driver requires using the open-drain feature of the GPIO to get it to work reliably
+#define mp_hal_pin_od_high_dht(p) do { \
+        if ((p) == 16) { WRITE_PERI_REG(RTC_GPIO_ENABLE, (READ_PERI_REG(RTC_GPIO_ENABLE) & ~1)); } \
+        else { gpio_output_set(1 << (p), 0, 1 << (p), 0); } \
+    } while (0)
 #define mp_hal_pin_read(p) pin_get(p)
 #define mp_hal_pin_write(p, v) pin_set((p), (v))
 


### PR DESCRIPTION
This should fix issue #4233: the pin IO behaviour for the esp8266 DHT driver is reverted to before the change made in 033c32e694199bbb68816883a857a77711d68a13, which should get DHT working more reliably (since it gets back the old behaviour).  It also retains the current IO behaviour for all other uses of pins in open-drain mode (eg I2C), so shouldn't break anything else.

