### PR TITLE
NeoPixel timing fix

### DIFF
--- a/ports/esp32/espneopixel.c
+++ b/ports/esp32/espneopixel.c
@@ -22,7 +22,7 @@ void IRAM_ATTR esp_neopixel_write(uint8_t pin, uint8_t *pixels, uint32_t numByte
 
     uint32_t fcpu = ets_get_cpu_frequency() * 1000000;
 
-    if (timing == 1) {
+    if (timing == 0) {
         // 800 KHz
         time0 = (fcpu * 0.35) / 1000000; // 0.35us
         time1 = (fcpu * 0.8) / 1000000; // 0.8us

--- a/ports/esp32/espneopixel.c
+++ b/ports/esp32/espneopixel.c
@@ -22,7 +22,7 @@ void IRAM_ATTR esp_neopixel_write(uint8_t pin, uint8_t *pixels, uint32_t numByte
 
     uint32_t fcpu = ets_get_cpu_frequency() * 1000000;
 
-    if (timing == 0) {
+    if (timing == 1) {
         // 800 KHz
         time0 = (fcpu * 0.35) / 1000000; // 0.35us
         time1 = (fcpu * 0.8) / 1000000; // 0.8us

--- a/ports/esp32/modules/neopixel.py
+++ b/ports/esp32/modules/neopixel.py
@@ -7,7 +7,7 @@ from esp import neopixel_write
 class NeoPixel:
     ORDER = (1, 0, 2, 3)
     
-    def __init__(self, pin, n, bpp=3, timing=0):
+    def __init__(self, pin, n, bpp=3, timing=1):
         self.pin = pin
         self.n = n
         self.bpp = bpp


### PR DESCRIPTION
Resolves #4396. 

Note that this is a breaking change! It changes the default behaviour of `NeoPixel` so the default timing is suitable for 800KHz devices instead of 400KHz 