### PR TITLE
py/modbuiltins: add missing TimeoutError

### DIFF
--- a/py/modbuiltins.c
+++ b/py/modbuiltins.c
@@ -728,6 +728,9 @@ STATIC const mp_rom_map_elem_t mp_module_builtins_globals_table[] = {
     { MP_ROM_QSTR(MP_QSTR_NameError), MP_ROM_PTR(&mp_type_NameError) },
     { MP_ROM_QSTR(MP_QSTR_NotImplementedError), MP_ROM_PTR(&mp_type_NotImplementedError) },
     { MP_ROM_QSTR(MP_QSTR_OSError), MP_ROM_PTR(&mp_type_OSError) },
+    #if MICROPY_PY_BUILTINS_TIMEOUTERROR
+    { MP_ROM_QSTR(MP_QSTR_TimeoutError), MP_ROM_PTR(&mp_type_TimeoutError) },
+    #endif
     { MP_ROM_QSTR(MP_QSTR_OverflowError), MP_ROM_PTR(&mp_type_OverflowError) },
     { MP_ROM_QSTR(MP_QSTR_RuntimeError), MP_ROM_PTR(&mp_type_RuntimeError) },
     #if MICROPY_PY_ASYNC_AWAIT


### PR DESCRIPTION
Even if `MICROPY_PY_BUILTINS_TIMEOUTERROR` is defined, `TimeoutError` would not be available as builtin.

I ran `git log -GTimeoutError py/modbuiltins.c` to see if it had been deleted accidentally, but did not find anything, so I guess it was forgotten entirely when `TimeoutError` had been added by @danicampora ?

I'm happy to add a test case, but some guidance on where to add it would be appreciated. In particular, I'm not sure how features are tested that are behind a `#define`'d feature flag.