### PR TITLE
C API: downcase all MP_OBJ_IS_xxx macros and MP_xxx_SLOT_IS_FILLED functions

### DIFF
--- a/extmod/machine_signal.c
+++ b/extmod/machine_signal.c
@@ -49,7 +49,7 @@ STATIC mp_obj_t signal_make_new(const mp_obj_type_t *type, size_t n_args, size_t
     #if defined(MICROPY_PY_MACHINE_PIN_MAKE_NEW)
     mp_pin_p_t *pin_p = NULL;
 
-    if (MP_OBJ_IS_OBJ(pin)) {
+    if (mp_obj_is_obj(pin)) {
         mp_obj_base_t *pin_base = (mp_obj_base_t*)MP_OBJ_TO_PTR(args[0]);
         pin_p = (mp_pin_p_t*)pin_base->type->protocol;
     }

--- a/extmod/moduheapq.c
+++ b/extmod/moduheapq.c
@@ -32,7 +32,7 @@
 // the algorithm here is modelled on CPython's heapq.py
 
 STATIC mp_obj_list_t *get_heap(mp_obj_t heap_in) {
-    if (!MP_OBJ_IS_TYPE(heap_in, &mp_type_list)) {
+    if (!mp_obj_is_type(heap_in, &mp_type_list)) {
         mp_raise_TypeError("heap must be a list");
     }
     return MP_OBJ_TO_PTR(heap_in);

--- a/extmod/moduselect.c
+++ b/extmod/moduselect.c
@@ -77,7 +77,7 @@ STATIC void poll_map_add(mp_map_t *poll_map, const mp_obj_t *obj, mp_uint_t obj_
 STATIC mp_uint_t poll_map_poll(mp_map_t *poll_map, size_t *rwx_num) {
     mp_uint_t n_ready = 0;
     for (mp_uint_t i = 0; i < poll_map->alloc; ++i) {
-        if (!MP_MAP_SLOT_IS_FILLED(poll_map, i)) {
+        if (!mp_map_slot_is_filled(poll_map, i)) {
             continue;
         }
 
@@ -155,7 +155,7 @@ STATIC mp_obj_t select_select(uint n_args, const mp_obj_t *args) {
             list_array[2] = mp_obj_new_list(rwx_len[2], NULL);
             rwx_len[0] = rwx_len[1] = rwx_len[2] = 0;
             for (mp_uint_t i = 0; i < poll_map.alloc; ++i) {
-                if (!MP_MAP_SLOT_IS_FILLED(&poll_map, i)) {
+                if (!mp_map_slot_is_filled(&poll_map, i)) {
                     continue;
                 }
                 poll_obj_t *poll_obj = MP_OBJ_TO_PTR(poll_map.table[i].value);
@@ -266,7 +266,7 @@ STATIC mp_obj_t poll_poll(size_t n_args, const mp_obj_t *args) {
     mp_obj_list_t *ret_list = MP_OBJ_TO_PTR(mp_obj_new_list(n_ready, NULL));
     n_ready = 0;
     for (mp_uint_t i = 0; i < self->poll_map.alloc; ++i) {
-        if (!MP_MAP_SLOT_IS_FILLED(&self->poll_map, i)) {
+        if (!mp_map_slot_is_filled(&self->poll_map, i)) {
             continue;
         }
         poll_obj_t *poll_obj = MP_OBJ_TO_PTR(self->poll_map.table[i].value);
@@ -309,7 +309,7 @@ STATIC mp_obj_t poll_iternext(mp_obj_t self_in) {
 
     for (mp_uint_t i = self->iter_idx; i < self->poll_map.alloc; ++i) {
         self->iter_idx++;
-        if (!MP_MAP_SLOT_IS_FILLED(&self->poll_map, i)) {
+        if (!mp_map_slot_is_filled(&self->poll_map, i)) {
             continue;
         }
         poll_obj_t *poll_obj = MP_OBJ_TO_PTR(self->poll_map.table[i].value);

--- a/extmod/modutimeq.c
+++ b/extmod/modutimeq.c
@@ -145,7 +145,7 @@ STATIC mp_obj_t mod_utimeq_heappop(mp_obj_t heap_in, mp_obj_t list_ref) {
         nlr_raise(mp_obj_new_exception_msg(&mp_type_IndexError, "empty heap"));
     }
     mp_obj_list_t *ret = MP_OBJ_TO_PTR(list_ref);
-    if (!MP_OBJ_IS_TYPE(list_ref, &mp_type_list) || ret->len < 3) {
+    if (!mp_obj_is_type(list_ref, &mp_type_list) || ret->len < 3) {
         mp_raise_TypeError(NULL);
     }
 

--- a/extmod/vfs.c
+++ b/extmod/vfs.c
@@ -227,7 +227,7 @@ mp_obj_t mp_vfs_umount(mp_obj_t mnt_in) {
     mp_vfs_mount_t *vfs = NULL;
     size_t mnt_len;
     const char *mnt_str = NULL;
-    if (MP_OBJ_IS_STR(mnt_in)) {
+    if (mp_obj_is_str(mnt_in)) {
         mnt_str = mp_obj_str_get_data(mnt_in, &mnt_len);
     }
     for (mp_vfs_mount_t **vfsp = &MP_STATE_VM(vfs_mount_table); *vfsp != NULL; vfsp = &(*vfsp)->next) {
@@ -270,7 +270,7 @@ mp_obj_t mp_vfs_open(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args)
 
     #if MICROPY_VFS_POSIX
     // If the file is an integer then delegate straight to the POSIX handler
-    if (MP_OBJ_IS_SMALL_INT(args[ARG_file].u_obj)) {
+    if (mp_obj_is_small_int(args[ARG_file].u_obj)) {
         return mp_vfs_posix_file_open(&mp_type_textio, args[ARG_file].u_obj, args[ARG_mode].u_obj);
     }
     #endif

--- a/extmod/vfs_posix.c
+++ b/extmod/vfs_posix.c
@@ -130,7 +130,7 @@ STATIC mp_obj_t vfs_posix_open(mp_obj_t self_in, mp_obj_t path_in, mp_obj_t mode
         && (strchr(mode, 'w') != NULL || strchr(mode, 'a') != NULL || strchr(mode, '+') != NULL)) {
         mp_raise_OSError(MP_EROFS);
     }
-    if (!MP_OBJ_IS_SMALL_INT(path_in)) {
+    if (!mp_obj_is_small_int(path_in)) {
         path_in = vfs_posix_get_path_obj(self, path_in);
     }
     return mp_vfs_posix_file_open(&mp_type_textio, path_in, mode_in);

--- a/extmod/vfs_posix_file.c
+++ b/extmod/vfs_posix_file.c
@@ -94,7 +94,7 @@ mp_obj_t mp_vfs_posix_file_open(const mp_obj_type_t *type, mp_obj_t file_in, mp_
 
     mp_obj_t fid = file_in;
 
-    if (MP_OBJ_IS_SMALL_INT(fid)) {
+    if (mp_obj_is_small_int(fid)) {
         o->fd = MP_OBJ_SMALL_INT_VALUE(fid);
         return MP_OBJ_FROM_PTR(o);
     }

--- a/ports/cc3200/hal/cc3200_hal.c
+++ b/ports/cc3200/hal/cc3200_hal.c
@@ -148,7 +148,7 @@ void mp_hal_stdout_tx_str(const char *str) {
 
 void mp_hal_stdout_tx_strn(const char *str, size_t len) {
     if (MP_STATE_PORT(os_term_dup_obj)) {
-        if (MP_OBJ_IS_TYPE(MP_STATE_PORT(os_term_dup_obj)->stream_o, &pyb_uart_type)) {
+        if (mp_obj_is_type(MP_STATE_PORT(os_term_dup_obj)->stream_o, &pyb_uart_type)) {
             uart_tx_strn(MP_STATE_PORT(os_term_dup_obj)->stream_o, str, len);
         } else {
             MP_STATE_PORT(os_term_dup_obj)->write[2] = mp_obj_new_str_of_type(&mp_type_str, (const byte *)str, len);
@@ -184,7 +184,7 @@ int mp_hal_stdin_rx_chr(void) {
         if (telnet_rx_any()) {
             return telnet_rx_char();
         } else if (MP_STATE_PORT(os_term_dup_obj)) { // then the stdio_dup
-            if (MP_OBJ_IS_TYPE(MP_STATE_PORT(os_term_dup_obj)->stream_o, &pyb_uart_type)) {
+            if (mp_obj_is_type(MP_STATE_PORT(os_term_dup_obj)->stream_o, &pyb_uart_type)) {
                 if (uart_rx_any(MP_STATE_PORT(os_term_dup_obj)->stream_o)) {
                     return uart_rx_char(MP_STATE_PORT(os_term_dup_obj)->stream_o);
                 }

--- a/ports/cc3200/mods/modmachine.c
+++ b/ports/cc3200/mods/modmachine.c
@@ -122,7 +122,7 @@ STATIC mp_obj_t machine_unique_id(void) {
 STATIC MP_DEFINE_CONST_FUN_OBJ_0(machine_unique_id_obj, machine_unique_id);
 
 STATIC mp_obj_t machine_main(mp_obj_t main) {
-    if (MP_OBJ_IS_STR(main)) {
+    if (mp_obj_is_str(main)) {
         MP_STATE_PORT(machine_config_main) = main;
     } else {
         mp_raise_ValueError(mpexception_value_invalid_arguments);

--- a/ports/cc3200/mods/moduos.c
+++ b/ports/cc3200/mods/moduos.c
@@ -133,7 +133,7 @@ STATIC mp_obj_t os_dupterm(uint n_args, const mp_obj_t *args) {
         if (stream_o == mp_const_none) {
             MP_STATE_PORT(os_term_dup_obj) = MP_OBJ_NULL;
         } else {
-            if (!MP_OBJ_IS_TYPE(stream_o, &pyb_uart_type)) {
+            if (!mp_obj_is_type(stream_o, &pyb_uart_type)) {
                 // must be a stream-like object providing at least read and write methods
                 mp_load_method(stream_o, MP_QSTR_read, os_term_dup_obj.read);
                 mp_load_method(stream_o, MP_QSTR_write, os_term_dup_obj.write);

--- a/ports/cc3200/mods/modwlan.c
+++ b/ports/cc3200/mods/modwlan.c
@@ -1012,7 +1012,7 @@ STATIC mp_obj_t wlan_ifconfig(size_t n_args, const mp_obj_t *pos_args, mp_map_t 
         };
         return mp_obj_new_tuple(4, ifconfig);
     } else { // set the configuration
-        if (MP_OBJ_IS_TYPE(args[1].u_obj, &mp_type_tuple)) {
+        if (mp_obj_is_type(args[1].u_obj, &mp_type_tuple)) {
             // set a static ip
             mp_obj_t *items;
             mp_obj_get_array_fixed_n(args[1].u_obj, 4, &items);

--- a/ports/cc3200/mods/pybpin.c
+++ b/ports/cc3200/mods/pybpin.c
@@ -131,7 +131,7 @@ pin_obj_t *pin_find(mp_obj_t user_obj) {
     pin_obj_t *pin_obj;
 
     // if a pin was provided, use it
-    if (MP_OBJ_IS_TYPE(user_obj, &pin_type)) {
+    if (mp_obj_is_type(user_obj, &pin_type)) {
         pin_obj = user_obj;
         return pin_obj;
     }

--- a/ports/cc3200/mods/pybrtc.c
+++ b/ports/cc3200/mods/pybrtc.c
@@ -367,7 +367,7 @@ STATIC mp_obj_t pyb_rtc_alarm(size_t n_args, const mp_obj_t *pos_args, mp_map_t 
     uint32_t f_seconds;
     uint16_t f_mseconds;
     bool repeat = args[2].u_bool;
-    if (MP_OBJ_IS_TYPE(args[1].u_obj, &mp_type_tuple)) { // datetime tuple given
+    if (mp_obj_is_type(args[1].u_obj, &mp_type_tuple)) { // datetime tuple given
         // repeat cannot be used with a datetime tuple
         if (repeat) {
             mp_raise_ValueError(mpexception_value_invalid_arguments);

--- a/ports/esp32/modnetwork.c
+++ b/ports/esp32/modnetwork.c
@@ -461,7 +461,7 @@ STATIC mp_obj_t esp_ifconfig(size_t n_args, const mp_obj_t *args) {
         return mp_obj_new_tuple(4, tuple);
     } else {
         // set
-        if (MP_OBJ_IS_TYPE(args[1], &mp_type_tuple) || MP_OBJ_IS_TYPE(args[1], &mp_type_list)) {
+        if (mp_obj_is_type(args[1], &mp_type_tuple) || mp_obj_is_type(args[1], &mp_type_list)) {
             mp_obj_t *items;
             mp_obj_get_array_fixed_n(args[1], 4, &items);
             netutils_parse_ipv4_addr(items[0], (void*)&info.ip, NETUTILS_BIG);
@@ -518,7 +518,7 @@ STATIC mp_obj_t esp_config(size_t n_args, const mp_obj_t *args, mp_map_t *kwargs
     if (kwargs->used != 0) {
 
         for (size_t i = 0; i < kwargs->alloc; i++) {
-            if (MP_MAP_SLOT_IS_FILLED(kwargs, i)) {
+            if (mp_map_slot_is_filled(kwargs, i)) {
                 int req_if = -1;
 
                 #define QS(x) (uintptr_t)MP_OBJ_NEW_QSTR(x)

--- a/ports/esp32/modsocket.c
+++ b/ports/esp32/modsocket.c
@@ -157,7 +157,7 @@ static int _socket_getaddrinfo2(const mp_obj_t host, const mp_obj_t portx, struc
     };
 
     mp_obj_t port = portx;
-    if (MP_OBJ_IS_SMALL_INT(port)) {
+    if (mp_obj_is_small_int(port)) {
         // This is perverse, because lwip_getaddrinfo promptly converts it back to an int, but
         // that's the API we have to work with ...
         port = mp_obj_str_binary_op(MP_BINARY_OP_MODULO, mp_obj_new_str_via_qstr("%s", 2), port);

--- a/ports/esp8266/modesp.c
+++ b/ports/esp8266/modesp.c
@@ -87,7 +87,7 @@ STATIC mp_obj_t esp_flash_read(mp_obj_t offset_in, mp_obj_t len_or_buf_in) {
 
     mp_int_t len;
     byte *buf;
-    bool alloc_buf = MP_OBJ_IS_INT(len_or_buf_in);
+    bool alloc_buf = mp_obj_is_int(len_or_buf_in);
 
     if (alloc_buf) {
         len = mp_obj_get_int(len_or_buf_in);

--- a/ports/esp8266/modnetwork.c
+++ b/ports/esp8266/modnetwork.c
@@ -347,7 +347,7 @@ STATIC mp_obj_t esp_config(size_t n_args, const mp_obj_t *args, mp_map_t *kwargs
     if (kwargs->used != 0) {
 
         for (mp_uint_t i = 0; i < kwargs->alloc; i++) {
-            if (MP_MAP_SLOT_IS_FILLED(kwargs, i)) {
+            if (mp_map_slot_is_filled(kwargs, i)) {
                 #define QS(x) (uintptr_t)MP_OBJ_NEW_QSTR(x)
                 switch ((uintptr_t)kwargs->table[i].key) {
                     case QS(MP_QSTR_mac): {

--- a/ports/nrf/boards/microbit/modules/microbitdisplay.c
+++ b/ports/nrf/boards/microbit/modules/microbitdisplay.c
@@ -88,7 +88,7 @@ mp_obj_t microbit_display_show_func(mp_uint_t n_args, const mp_obj_t *pos_args, 
     bool wait = args[3].u_bool;
     bool loop = args[4].u_bool;
 
-    if (MP_OBJ_IS_STR(image)) {
+    if (mp_obj_is_str(image)) {
         // arg is a string object
         mp_uint_t len;
         const char *str = mp_obj_str_get_data(image, &len);
@@ -296,7 +296,7 @@ static void draw_object(mp_obj_t obj) {
         }
     } else if (mp_obj_get_type(obj) == &microbit_image_type) {
         microbit_display_show(display, (microbit_image_obj_t *)obj);
-    } else if (MP_OBJ_IS_STR(obj)) {
+    } else if (mp_obj_is_str(obj)) {
         mp_uint_t len;
         const char *str = mp_obj_str_get_data(obj, &len);
         if (len == 1) {

--- a/ports/nrf/boards/microbit/modules/microbitimage.c
+++ b/ports/nrf/boards/microbit/modules/microbitimage.c
@@ -214,7 +214,7 @@ STATIC mp_obj_t microbit_image_make_new(const mp_obj_type_t *type_in, mp_uint_t 
         }
 
         case 1: {
-            if (MP_OBJ_IS_STR(args[0])) {
+            if (mp_obj_is_str(args[0])) {
                 // arg is a string object
                 mp_uint_t len;
                 const char *str = mp_obj_str_get_data(args[0], &len);

--- a/ports/nrf/modules/machine/pin.c
+++ b/ports/nrf/modules/machine/pin.c
@@ -126,7 +126,7 @@ void pin_init0(void) {
 const pin_obj_t *pin_find(mp_obj_t user_obj) {
     const pin_obj_t *pin_obj;
     // If pin is SMALL_INT
-    if (MP_OBJ_IS_SMALL_INT(user_obj)) {
+    if (mp_obj_is_small_int(user_obj)) {
 	uint8_t value = MP_OBJ_SMALL_INT_VALUE(user_obj);
         for (uint8_t i = 0; i < machine_pin_num_of_pins; i++) {
             if (machine_pin_obj[i].pin == value) {
@@ -136,7 +136,7 @@ const pin_obj_t *pin_find(mp_obj_t user_obj) {
     }
 
     // If a pin was provided, then use it
-    if (MP_OBJ_IS_TYPE(user_obj, &pin_type)) {
+    if (mp_obj_is_type(user_obj, &pin_type)) {
         pin_obj = user_obj;
         if (pin_class_debug) {
             printf("Pin map passed pin ");
@@ -149,7 +149,7 @@ const pin_obj_t *pin_find(mp_obj_t user_obj) {
     if (MP_STATE_PORT(pin_class_mapper) != mp_const_none) {
         pin_obj = mp_call_function_1(MP_STATE_PORT(pin_class_mapper), user_obj);
         if (pin_obj != mp_const_none) {
-            if (!MP_OBJ_IS_TYPE(pin_obj, &pin_type)) {
+            if (!mp_obj_is_type(pin_obj, &pin_type)) {
                 mp_raise_ValueError("Pin.mapper didn't return a Pin object");
             }
             if (pin_class_debug) {

--- a/ports/nrf/modules/machine/pwm.c
+++ b/ports/nrf/modules/machine/pwm.c
@@ -93,7 +93,7 @@ void pwm_init0(void) {
 
 
 STATIC int hard_pwm_find(mp_obj_t id) {
-    if (MP_OBJ_IS_INT(id)) {
+    if (mp_obj_is_int(id)) {
         // given an integer id
         int pwm_id = mp_obj_get_int(id);
         if (pwm_id >= 0 && pwm_id < MP_ARRAY_SIZE(machine_hard_pwm_obj)) {

--- a/ports/nrf/modules/machine/rtcounter.c
+++ b/ports/nrf/modules/machine/rtcounter.c
@@ -160,7 +160,7 @@ STATIC mp_obj_t machine_rtc_make_new(const mp_obj_type_t *type, size_t n_args, s
 
     if (args[ARG_callback].u_obj == mp_const_none) {
         config->callback = NULL;
-    } else if (MP_OBJ_IS_FUN(args[ARG_callback].u_obj)) {
+    } else if (mp_obj_is_fun(args[ARG_callback].u_obj)) {
         config->callback = args[ARG_callback].u_obj;
     } else {
         mp_raise_ValueError("callback must be a function");

--- a/ports/nrf/modules/machine/spi.c
+++ b/ports/nrf/modules/machine/spi.c
@@ -131,7 +131,7 @@ void spi_init0(void) {
 }
 
 STATIC int spi_find(mp_obj_t id) {
-    if (MP_OBJ_IS_STR(id)) {
+    if (mp_obj_is_str(id)) {
         // given a string id
         const char *port = mp_obj_str_get_str(id);
         if (0) {

--- a/ports/nrf/modules/machine/timer.c
+++ b/ports/nrf/modules/machine/timer.c
@@ -127,7 +127,7 @@ STATIC mp_obj_t machine_timer_make_new(const mp_obj_type_t *type, size_t n_args,
 
     machine_timer_obj_t *self = (machine_timer_obj_t*)&machine_timer_obj[timer_id];
 
-    if (MP_OBJ_IS_FUN(args[ARG_callback].u_obj)) {
+    if (mp_obj_is_fun(args[ARG_callback].u_obj)) {
         machine_timer_callbacks[timer_id] = args[ARG_callback].u_obj;
     } else if (args[ARG_callback].u_obj == mp_const_none) {
         machine_timer_callbacks[timer_id] = NULL;

--- a/ports/nrf/modules/music/modmusic.c
+++ b/ports/nrf/modules/music/modmusic.c
@@ -320,7 +320,7 @@ STATIC mp_obj_t microbit_music_play(mp_uint_t n_args, const mp_obj_t *pos_args, 
     // get either a single note or a list of notes
     mp_uint_t len;
     mp_obj_t *items;
-    if (MP_OBJ_IS_STR_OR_BYTES(args[0].u_obj)) {
+    if (mp_obj_is_str_or_bytes(args[0].u_obj)) {
         len = 1;
         items = &args[0].u_obj;
     } else {

--- a/ports/nrf/modules/ubluepy/ubluepy_characteristic.c
+++ b/ports/nrf/modules/ubluepy/ubluepy_characteristic.c
@@ -59,7 +59,7 @@ STATIC mp_obj_t ubluepy_characteristic_make_new(const mp_obj_type_t *type, size_
         return MP_OBJ_FROM_PTR(s);
     }
 
-    if (MP_OBJ_IS_TYPE(uuid_obj, &ubluepy_uuid_type)) {
+    if (mp_obj_is_type(uuid_obj, &ubluepy_uuid_type)) {
         s->p_uuid = MP_OBJ_TO_PTR(uuid_obj);
         // (void)sd_characterstic_add(s);
     } else {

--- a/ports/nrf/modules/ubluepy/ubluepy_peripheral.c
+++ b/ports/nrf/modules/ubluepy/ubluepy_peripheral.c
@@ -193,7 +193,7 @@ STATIC mp_obj_t peripheral_advertise(mp_uint_t n_args, const mp_obj_t *pos_args,
     ubluepy_advertise_data_t adv_data;
     memset(&adv_data, 0, sizeof(ubluepy_advertise_data_t));
 
-    if (device_name_obj != mp_const_none && MP_OBJ_IS_STR(device_name_obj)) {
+    if (device_name_obj != mp_const_none && mp_obj_is_str(device_name_obj)) {
         GET_STR_DATA_LEN(device_name_obj, str_data, str_len);
 
         adv_data.p_device_name = (uint8_t *)str_data;
@@ -361,7 +361,7 @@ STATIC mp_obj_t peripheral_connect(mp_uint_t n_args, const mp_obj_t *pos_args, m
 
     ble_drv_gap_event_handler_set(MP_OBJ_FROM_PTR(self), gap_event_handler);
 
-    if (MP_OBJ_IS_STR(dev_addr)) {
+    if (mp_obj_is_str(dev_addr)) {
         GET_STR_DATA_LEN(dev_addr, str_data, str_len);
         if (str_len == 17) { // Example "11:22:33:aa:bb:cc"
 

--- a/ports/nrf/modules/ubluepy/ubluepy_service.c
+++ b/ports/nrf/modules/ubluepy/ubluepy_service.c
@@ -61,7 +61,7 @@ STATIC mp_obj_t ubluepy_service_make_new(const mp_obj_type_t *type, size_t n_arg
         return MP_OBJ_FROM_PTR(s);
     }
 
-    if (MP_OBJ_IS_TYPE(uuid_obj, &ubluepy_uuid_type)) {
+    if (mp_obj_is_type(uuid_obj, &ubluepy_uuid_type)) {
         s->p_uuid = MP_OBJ_TO_PTR(uuid_obj);
 
         uint8_t type = args[ARG_NEW_TYPE].u_int;
@@ -124,7 +124,7 @@ STATIC mp_obj_t service_get_characteristic(mp_obj_t self_in, mp_obj_t uuid) {
     ubluepy_uuid_obj_t    * p_uuid = MP_OBJ_TO_PTR(uuid);
 
     // validate that there is an UUID object passed in as parameter
-    if (!(MP_OBJ_IS_TYPE(uuid, &ubluepy_uuid_type))) {
+    if (!(mp_obj_is_type(uuid, &ubluepy_uuid_type))) {
         mp_raise_ValueError("Invalid UUID parameter");
     }
 

--- a/ports/nrf/modules/ubluepy/ubluepy_uuid.c
+++ b/ports/nrf/modules/ubluepy/ubluepy_uuid.c
@@ -66,11 +66,11 @@ STATIC mp_obj_t ubluepy_uuid_make_new(const mp_obj_type_t *type, size_t n_args, 
         return MP_OBJ_FROM_PTR(s);
     }
 
-    if (MP_OBJ_IS_INT(uuid_obj)) {
+    if (mp_obj_is_int(uuid_obj)) {
         s->type = UBLUEPY_UUID_16_BIT;
         s->value[1] = (((uint16_t)mp_obj_get_int(uuid_obj)) >> 8) & 0xFF;
         s->value[0] = ((uint8_t)mp_obj_get_int(uuid_obj)) & 0xFF;
-    } else if (MP_OBJ_IS_STR(uuid_obj)) {
+    } else if (mp_obj_is_str(uuid_obj)) {
         GET_STR_DATA_LEN(uuid_obj, str_data, str_len);
         if (str_len == 6) { // Assume hex digit prefixed with 0x
             s->type = UBLUEPY_UUID_16_BIT;
@@ -124,7 +124,7 @@ STATIC mp_obj_t ubluepy_uuid_make_new(const mp_obj_type_t *type, size_t n_args, 
         } else {
             mp_raise_ValueError("Invalid UUID string length");
         }
-    } else if (MP_OBJ_IS_TYPE(uuid_obj, &ubluepy_uuid_type)) {
+    } else if (mp_obj_is_type(uuid_obj, &ubluepy_uuid_type)) {
         // deep copy instance
         ubluepy_uuid_obj_t * p_old = MP_OBJ_TO_PTR(uuid_obj);
         s->type     = p_old->type;

--- a/ports/stm32/adc.c
+++ b/ports/stm32/adc.c
@@ -389,7 +389,7 @@ STATIC mp_obj_t adc_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_
 
     uint32_t channel;
 
-    if (MP_OBJ_IS_INT(pin_obj)) {
+    if (mp_obj_is_int(pin_obj)) {
         channel = adc_get_internal_channel(mp_obj_get_int(pin_obj));
     } else {
         const pin_obj_t *pin = pin_find(pin_obj);

--- a/ports/stm32/bufhelper.c
+++ b/ports/stm32/bufhelper.c
@@ -28,7 +28,7 @@
 #include "bufhelper.h"
 
 void pyb_buf_get_for_send(mp_obj_t o, mp_buffer_info_t *bufinfo, byte *tmp_data) {
-    if (MP_OBJ_IS_INT(o)) {
+    if (mp_obj_is_int(o)) {
         tmp_data[0] = mp_obj_get_int(o);
         bufinfo->buf = tmp_data;
         bufinfo->len = 1;
@@ -39,7 +39,7 @@ void pyb_buf_get_for_send(mp_obj_t o, mp_buffer_info_t *bufinfo, byte *tmp_data)
 }
 
 mp_obj_t pyb_buf_get_for_recv(mp_obj_t o, vstr_t *vstr) {
-    if (MP_OBJ_IS_INT(o)) {
+    if (mp_obj_is_int(o)) {
         // allocate a new bytearray of given length
         vstr_init_len(vstr, mp_obj_get_int(o));
         return MP_OBJ_NULL;

--- a/ports/stm32/can.c
+++ b/ports/stm32/can.c
@@ -409,7 +409,7 @@ STATIC mp_obj_t pyb_can_make_new(const mp_obj_type_t *type, size_t n_args, size_
 
     // work out port
     mp_uint_t can_idx;
-    if (MP_OBJ_IS_STR(args[0])) {
+    if (mp_obj_is_str(args[0])) {
         const char *port = mp_obj_str_get_str(args[0]);
         if (0) {
         #ifdef MICROPY_HW_CAN1_NAME
@@ -540,7 +540,7 @@ STATIC mp_obj_t pyb_can_info(size_t n_args, const mp_obj_t *args) {
     if (n_args == 1) {
         list = MP_OBJ_TO_PTR(mp_obj_new_list(8, NULL));
     } else {
-        if (!MP_OBJ_IS_TYPE(args[1], &mp_type_list)) {
+        if (!mp_obj_is_type(args[1], &mp_type_list)) {
             mp_raise_TypeError(NULL);
         }
         list = MP_OBJ_TO_PTR(args[1]);
@@ -709,7 +709,7 @@ STATIC mp_obj_t pyb_can_recv(size_t n_args, const mp_obj_t *pos_args, mp_map_t *
         items[3] = mp_obj_new_bytes(&rx_msg.Data[0], rx_msg.DLC);
     } else {
         // User should provide a list of length at least 4 to hold the values
-        if (!MP_OBJ_IS_TYPE(ret_obj, &mp_type_list)) {
+        if (!mp_obj_is_type(ret_obj, &mp_type_list)) {
             mp_raise_TypeError(NULL);
         }
         mp_obj_list_t *list = MP_OBJ_TO_PTR(ret_obj);
@@ -719,7 +719,7 @@ STATIC mp_obj_t pyb_can_recv(size_t n_args, const mp_obj_t *pos_args, mp_map_t *
         items = list->items;
         // Fourth element must be a memoryview which we assume points to a
         // byte-like array which is large enough, and then we resize it inplace
-        if (!MP_OBJ_IS_TYPE(items[3], &mp_type_memoryview)) {
+        if (!mp_obj_is_type(items[3], &mp_type_memoryview)) {
             mp_raise_TypeError(NULL);
         }
         mp_obj_array_t *mv = MP_OBJ_TO_PTR(items[3]);

--- a/ports/stm32/dac.c
+++ b/ports/stm32/dac.c
@@ -238,7 +238,7 @@ STATIC mp_obj_t pyb_dac_make_new(const mp_obj_type_t *type, size_t n_args, size_
 
     // get pin/channel to output on
     mp_int_t dac_id;
-    if (MP_OBJ_IS_INT(args[0])) {
+    if (mp_obj_is_int(args[0])) {
         dac_id = mp_obj_get_int(args[0]);
     } else {
         const pin_obj_t *pin = pin_find(args[0]);

--- a/ports/stm32/extint.c
+++ b/ports/stm32/extint.c
@@ -163,7 +163,7 @@ uint extint_register(mp_obj_t pin_obj, uint32_t mode, uint32_t pull, mp_obj_t ca
     const pin_obj_t *pin = NULL;
     uint v_line;
 
-    if (MP_OBJ_IS_INT(pin_obj)) {
+    if (mp_obj_is_int(pin_obj)) {
         // If an integer is passed in, then use it to identify lines 16 thru 22
         // We expect lines 0 thru 15 to be passed in as a pin, so that we can
         // get both the port number and line number.
@@ -234,7 +234,7 @@ void extint_register_pin(const pin_obj_t *pin, uint32_t mode, bool hard_irq, mp_
     // Check if the ExtInt line is already in use by another Pin/ExtInt
     mp_obj_t *cb = &MP_STATE_PORT(pyb_extint_callback)[line];
     if (*cb != mp_const_none && MP_OBJ_FROM_PTR(pin) != pyb_extint_callback_arg[line]) {
-        if (MP_OBJ_IS_SMALL_INT(pyb_extint_callback_arg[line])) {
+        if (mp_obj_is_small_int(pyb_extint_callback_arg[line])) {
             nlr_raise(mp_obj_new_exception_msg_varg(&mp_type_OSError,
                 "ExtInt vector %d is already in use", line));
         } else {

--- a/ports/stm32/machine_i2c.c
+++ b/ports/stm32/machine_i2c.c
@@ -197,7 +197,7 @@ mp_obj_t machine_hard_i2c_make_new(const mp_obj_type_t *type, size_t n_args, siz
 
     // work out i2c bus
     int i2c_id = 0;
-    if (MP_OBJ_IS_STR(args[ARG_id].u_obj)) {
+    if (mp_obj_is_str(args[ARG_id].u_obj)) {
         const char *port = mp_obj_str_get_str(args[ARG_id].u_obj);
         if (0) {
         #ifdef MICROPY_HW_I2C1_NAME

--- a/ports/stm32/machine_uart.c
+++ b/ports/stm32/machine_uart.c
@@ -350,7 +350,7 @@ STATIC mp_obj_t pyb_uart_make_new(const mp_obj_type_t *type, size_t n_args, size
 
     // work out port
     int uart_id = 0;
-    if (MP_OBJ_IS_STR(args[0])) {
+    if (mp_obj_is_str(args[0])) {
         const char *port = mp_obj_str_get_str(args[0]);
         if (0) {
         #ifdef MICROPY_HW_UART1_NAME

--- a/ports/stm32/main.c
+++ b/ports/stm32/main.c
@@ -132,7 +132,7 @@ STATIC mp_obj_t pyb_main(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_a
         { MP_QSTR_opt, MP_ARG_INT, {.u_int = 0} }
     };
 
-    if (MP_OBJ_IS_STR(pos_args[0])) {
+    if (mp_obj_is_str(pos_args[0])) {
         MP_STATE_PORT(pyb_config_main) = pos_args[0];
 
         // parse args

--- a/ports/stm32/pin.c
+++ b/ports/stm32/pin.c
@@ -105,7 +105,7 @@ const pin_obj_t *pin_find(mp_obj_t user_obj) {
     const pin_obj_t *pin_obj;
 
     // If a pin was provided, then use it
-    if (MP_OBJ_IS_TYPE(user_obj, &pin_type)) {
+    if (mp_obj_is_type(user_obj, &pin_type)) {
         pin_obj = MP_OBJ_TO_PTR(user_obj);
         if (pin_class_debug) {
             printf("Pin map passed pin ");
@@ -118,7 +118,7 @@ const pin_obj_t *pin_find(mp_obj_t user_obj) {
     if (MP_STATE_PORT(pin_class_mapper) != mp_const_none) {
         mp_obj_t o = mp_call_function_1(MP_STATE_PORT(pin_class_mapper), user_obj);
         if (o != mp_const_none) {
-            if (!MP_OBJ_IS_TYPE(o, &pin_type)) {
+            if (!mp_obj_is_type(o, &pin_type)) {
                 mp_raise_ValueError("Pin.mapper didn't return a Pin object");
             }
             if (pin_class_debug) {

--- a/ports/stm32/pyb_i2c.c
+++ b/ports/stm32/pyb_i2c.c
@@ -636,7 +636,7 @@ STATIC mp_obj_t pyb_i2c_make_new(const mp_obj_type_t *type, size_t n_args, size_
 
     // work out i2c bus
     int i2c_id = 0;
-    if (MP_OBJ_IS_STR(args[0])) {
+    if (mp_obj_is_str(args[0])) {
         const char *port = mp_obj_str_get_str(args[0]);
         if (0) {
         #ifdef MICROPY_HW_I2C1_NAME

--- a/ports/stm32/spi.c
+++ b/ports/stm32/spi.c
@@ -121,7 +121,7 @@ void spi_init0(void) {
 }
 
 int spi_find_index(mp_obj_t id) {
-    if (MP_OBJ_IS_STR(id)) {
+    if (mp_obj_is_str(id)) {
         // given a string id
         const char *port = mp_obj_str_get_str(id);
         if (0) {
@@ -583,10 +583,10 @@ void spi_print(const mp_print_t *print, const spi_t *spi_obj, bool legacy) {
 }
 
 const spi_t *spi_from_mp_obj(mp_obj_t o) {
-    if (MP_OBJ_IS_TYPE(o, &pyb_spi_type)) {
+    if (mp_obj_is_type(o, &pyb_spi_type)) {
         pyb_spi_obj_t *self = MP_OBJ_TO_PTR(o);
         return self->spi;
-    } else if (MP_OBJ_IS_TYPE(o, &machine_hard_spi_type)) {
+    } else if (mp_obj_is_type(o, &machine_hard_spi_type)) {
         machine_hard_spi_obj_t *self = MP_OBJ_TO_PTR(o);
         return self->spi;
     } else {

--- a/ports/stm32/timer.c
+++ b/ports/stm32/timer.c
@@ -275,7 +275,7 @@ STATIC uint32_t compute_prescaler_period_from_freq(pyb_timer_obj_t *self, mp_obj
     uint32_t period;
     if (0) {
     #if MICROPY_PY_BUILTINS_FLOAT
-    } else if (MP_OBJ_IS_TYPE(freq_in, &mp_type_float)) {
+    } else if (mp_obj_is_type(freq_in, &mp_type_float)) {
         float freq = mp_obj_get_float(freq_in);
         if (freq <= 0) {
             goto bad_freq;
@@ -370,7 +370,7 @@ STATIC uint32_t compute_pwm_value_from_percent(uint32_t period, mp_obj_t percent
     uint32_t cmp;
     if (0) {
     #if MICROPY_PY_BUILTINS_FLOAT
-    } else if (MP_OBJ_IS_TYPE(percent_in, &mp_type_float)) {
+    } else if (mp_obj_is_type(percent_in, &mp_type_float)) {
         mp_float_t percent = mp_obj_get_float(percent_in);
         if (percent <= 0.0) {
             cmp = 0;
@@ -988,7 +988,7 @@ STATIC mp_obj_t pyb_timer_channel(size_t n_args, const mp_obj_t *pos_args, mp_ma
 
     mp_obj_t pin_obj = args[2].u_obj;
     if (pin_obj != mp_const_none) {
-        if (!MP_OBJ_IS_TYPE(pin_obj, &pin_type)) {
+        if (!mp_obj_is_type(pin_obj, &pin_type)) {
             mp_raise_ValueError("pin argument needs to be be a Pin type");
         }
         const pin_obj_t *pin = MP_OBJ_TO_PTR(pin_obj);

--- a/ports/teensy/main.c
+++ b/ports/teensy/main.c
@@ -194,7 +194,7 @@ STATIC mp_obj_t pyb_config_main = MP_OBJ_NULL;
 STATIC mp_obj_t pyb_config_usb_mode = MP_OBJ_NULL;
 
 mp_obj_t pyb_source_dir(mp_obj_t source_dir) {
-    if (MP_OBJ_IS_STR(source_dir)) {
+    if (mp_obj_is_str(source_dir)) {
         pyb_config_source_dir = source_dir;
     }
     return mp_const_none;
@@ -203,7 +203,7 @@ mp_obj_t pyb_source_dir(mp_obj_t source_dir) {
 MP_DEFINE_CONST_FUN_OBJ_1(pyb_source_dir_obj, pyb_source_dir);
 
 mp_obj_t pyb_main(mp_obj_t main) {
-    if (MP_OBJ_IS_STR(main)) {
+    if (mp_obj_is_str(main)) {
         pyb_config_main = main;
     }
     return mp_const_none;
@@ -212,7 +212,7 @@ mp_obj_t pyb_main(mp_obj_t main) {
 MP_DEFINE_CONST_FUN_OBJ_1(pyb_main_obj, pyb_main);
 
 STATIC mp_obj_t pyb_usb_mode(mp_obj_t usb_mode) {
-    if (MP_OBJ_IS_STR(usb_mode)) {
+    if (mp_obj_is_str(usb_mode)) {
         pyb_config_usb_mode = usb_mode;
     }
     return mp_const_none;

--- a/ports/teensy/reg.c
+++ b/ports/teensy/reg.c
@@ -18,7 +18,7 @@ mp_obj_t reg_cmd(void *base, reg_t *reg, mp_uint_t num_regs, uint n_args, const 
 
     mp_uint_t addr = 0;
 
-    if (MP_OBJ_IS_STR(args[0])) {
+    if (mp_obj_is_str(args[0])) {
         const char *name = mp_obj_str_get_str(args[0]);
         mp_uint_t reg_idx;
         for (reg_idx = 0; reg_idx < num_regs; reg_idx++, reg++) {

--- a/ports/teensy/timer.c
+++ b/ports/teensy/timer.c
@@ -142,7 +142,7 @@ STATIC uint32_t compute_pwm_value_from_percent(uint32_t period, mp_obj_t percent
     uint32_t cmp;
     if (0) {
     #if MICROPY_PY_BUILTINS_FLOAT
-    } else if (MP_OBJ_IS_TYPE(percent_in, &mp_type_float)) {
+    } else if (mp_obj_is_type(percent_in, &mp_type_float)) {
         float percent = mp_obj_get_float(percent_in);
         if (percent <= 0.0) {
             cmp = 0;
@@ -496,7 +496,7 @@ STATIC mp_obj_t pyb_timer_channel(size_t n_args, const mp_obj_t *args, mp_map_t 
 
     mp_obj_t pin_obj = vals[1].u_obj;
     if (pin_obj != mp_const_none) {
-        if (!MP_OBJ_IS_TYPE(pin_obj, &pin_type)) {
+        if (!mp_obj_is_type(pin_obj, &pin_type)) {
             mp_raise_ValueError("pin argument needs to be be a Pin type");
         }
         const pin_obj_t *pin = pin_obj;

--- a/ports/teensy/uart.c
+++ b/ports/teensy/uart.c
@@ -316,7 +316,7 @@ STATIC mp_obj_t pyb_uart_make_new(const mp_obj_type_t *type, uint n_args, uint n
     // work out port
     o->uart_id = 0;
 #if 0
-    if (MP_OBJ_IS_STR(args[0])) {
+    if (mp_obj_is_str(args[0])) {
         const char *port = mp_obj_str_get_str(args[0]);
         if (0) {
 #if defined(PYBV10)

--- a/ports/unix/coverage.c
+++ b/ports/unix/coverage.c
@@ -250,7 +250,7 @@ STATIC mp_obj_t extra_coverage(void) {
         mp_printf(&mp_plat_print, "# str\n");
 
         // intern string
-        mp_printf(&mp_plat_print, "%d\n", MP_OBJ_IS_QSTR(mp_obj_str_intern(mp_obj_new_str("intern me", 9))));
+        mp_printf(&mp_plat_print, "%d\n", mp_obj_is_qstr(mp_obj_str_intern(mp_obj_new_str("intern me", 9))));
     }
 
     // bytearray

--- a/ports/unix/file.c
+++ b/ports/unix/file.c
@@ -192,7 +192,7 @@ STATIC mp_obj_t fdfile_open(const mp_obj_type_t *type, mp_arg_val_t *args) {
 
     mp_obj_t fid = args[0].u_obj;
 
-    if (MP_OBJ_IS_SMALL_INT(fid)) {
+    if (mp_obj_is_small_int(fid)) {
         o->fd = MP_OBJ_SMALL_INT_VALUE(fid);
         return MP_OBJ_FROM_PTR(o);
     }

--- a/ports/unix/modffi.c
+++ b/ports/unix/modffi.c
@@ -126,7 +126,7 @@ STATIC ffi_type *char2ffi_type(char c)
 
 STATIC ffi_type *get_ffi_type(mp_obj_t o_in)
 {
-    if (MP_OBJ_IS_STR(o_in)) {
+    if (mp_obj_is_str(o_in)) {
         const char *s = mp_obj_str_get_str(o_in);
         ffi_type *t = char2ffi_type(*s);
         if (t != NULL) {
@@ -370,9 +370,9 @@ STATIC mp_obj_t ffifunc_call(mp_obj_t self_in, size_t n_args, size_t n_kw, const
         #endif
         } else if (a == mp_const_none) {
             values[i] = 0;
-        } else if (MP_OBJ_IS_INT(a)) {
+        } else if (mp_obj_is_int(a)) {
             values[i] = mp_obj_int_get_truncated(a);
-        } else if (MP_OBJ_IS_STR(a)) {
+        } else if (mp_obj_is_str(a)) {
             const char *s = mp_obj_str_get_str(a);
             values[i] = (ffi_arg)(intptr_t)s;
         } else if (((mp_obj_base_t*)MP_OBJ_TO_PTR(a))->type->buffer_p.get_buffer != NULL) {
@@ -383,7 +383,7 @@ STATIC mp_obj_t ffifunc_call(mp_obj_t self_in, size_t n_args, size_t n_kw, const
                 goto error;
             }
             values[i] = (ffi_arg)(intptr_t)bufinfo.buf;
-        } else if (MP_OBJ_IS_TYPE(a, &fficallback_type)) {
+        } else if (mp_obj_is_type(a, &fficallback_type)) {
             mp_obj_fficallback_t *p = MP_OBJ_TO_PTR(a);
             values[i] = (ffi_arg)(intptr_t)p->func;
         } else {

--- a/ports/unix/modjni.c
+++ b/ports/unix/modjni.c
@@ -658,12 +658,12 @@ STATIC mp_obj_t mod_jni_array(mp_obj_t type_in, mp_obj_t size_in) {
     mp_int_t size = mp_obj_get_int(size_in);
     jobject res = NULL;
 
-    if (MP_OBJ_IS_TYPE(type_in, &jclass_type)) {
+    if (mp_obj_is_type(type_in, &jclass_type)) {
 
         mp_obj_jclass_t *jcls = MP_OBJ_TO_PTR(type_in);
         res = JJ(NewObjectArray, size, jcls->cls, NULL);
 
-    } else if (MP_OBJ_IS_STR(type_in)) {
+    } else if (mp_obj_is_str(type_in)) {
         const char *type = mp_obj_str_get_str(type_in);
         switch (*type) {
             case 'Z':

--- a/ports/unix/modtermios.c
+++ b/ports/unix/modtermios.c
@@ -77,7 +77,7 @@ STATIC mp_obj_t mod_termios_tcsetattr(mp_obj_t fd_in, mp_obj_t when_in, mp_obj_t
         when = TCSANOW;
     }
 
-    assert(MP_OBJ_IS_TYPE(attrs_in, &mp_type_list));
+    assert(mp_obj_is_type(attrs_in, &mp_type_list));
     mp_obj_list_t *attrs = MP_OBJ_TO_PTR(attrs_in);
 
     term.c_iflag = mp_obj_get_int(attrs->items[0]);

--- a/ports/unix/moduselect.c
+++ b/ports/unix/moduselect.c
@@ -66,7 +66,7 @@ typedef struct _mp_obj_poll_t {
 } mp_obj_poll_t;
 
 STATIC int get_fd(mp_obj_t fdlike) {
-    if (MP_OBJ_IS_OBJ(fdlike)) {
+    if (mp_obj_is_obj(fdlike)) {
         const mp_stream_p_t *stream_p = mp_get_stream_raise(fdlike, MP_STREAM_OP_IOCTL);
         int err;
         mp_uint_t res = stream_p->ioctl(fdlike, MP_STREAM_GET_FILENO, 0, &err);
@@ -80,7 +80,7 @@ STATIC int get_fd(mp_obj_t fdlike) {
 /// \method register(obj[, eventmask])
 STATIC mp_obj_t poll_register(size_t n_args, const mp_obj_t *args) {
     mp_obj_poll_t *self = MP_OBJ_TO_PTR(args[0]);
-    bool is_fd = MP_OBJ_IS_INT(args[1]);
+    bool is_fd = mp_obj_is_int(args[1]);
     int fd = get_fd(args[1]);
 
     mp_uint_t flags;

--- a/ports/unix/modusocket.c
+++ b/ports/unix/modusocket.c
@@ -299,7 +299,7 @@ STATIC mp_obj_t socket_setsockopt(size_t n_args, const mp_obj_t *args) {
     const void *optval;
     socklen_t optlen;
     int val;
-    if (MP_OBJ_IS_INT(args[3])) {
+    if (mp_obj_is_int(args[3])) {
         val = mp_obj_int_get_truncated(args[3]);
         optval = &val;
         optlen = sizeof(val);
@@ -391,13 +391,13 @@ STATIC mp_obj_t socket_make_new(const mp_obj_type_t *type_in, size_t n_args, siz
     int proto = 0;
 
     if (n_args > 0) {
-        assert(MP_OBJ_IS_SMALL_INT(args[0]));
+        assert(mp_obj_is_small_int(args[0]));
         family = MP_OBJ_SMALL_INT_VALUE(args[0]);
         if (n_args > 1) {
-            assert(MP_OBJ_IS_SMALL_INT(args[1]));
+            assert(mp_obj_is_small_int(args[1]));
             type = MP_OBJ_SMALL_INT_VALUE(args[1]);
             if (n_args > 2) {
-                assert(MP_OBJ_IS_SMALL_INT(args[2]));
+                assert(mp_obj_is_small_int(args[2]));
                 proto = MP_OBJ_SMALL_INT_VALUE(args[2]);
             }
         }
@@ -494,7 +494,7 @@ STATIC mp_obj_t mod_socket_getaddrinfo(size_t n_args, const mp_obj_t *args) {
     memset(&hints, 0, sizeof(hints));
     // getaddrinfo accepts port in string notation, so however
     // it may seem stupid, we need to convert int to str
-    if (MP_OBJ_IS_SMALL_INT(args[1])) {
+    if (mp_obj_is_small_int(args[1])) {
         unsigned port = (unsigned short)MP_OBJ_SMALL_INT_VALUE(args[1]);
         snprintf(buf, sizeof(buf), "%u", port);
         serv = buf;

--- a/ports/zephyr/machine_pin.c
+++ b/ports/zephyr/machine_pin.c
@@ -84,7 +84,7 @@ mp_obj_t mp_pin_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, 
     mp_arg_check_num(n_args, n_kw, 1, MP_OBJ_FUN_ARGS_MAX, true);
 
     // get the wanted port
-    if (!MP_OBJ_IS_TYPE(args[0], &mp_type_tuple)) {
+    if (!mp_obj_is_type(args[0], &mp_type_tuple)) {
         mp_raise_ValueError("Pin id must be tuple of (\"GPIO_x\", pin#)");
     }
     mp_obj_t *items;

--- a/py/binary.c
+++ b/py/binary.c
@@ -293,7 +293,7 @@ void mp_binary_set_val(char struct_type, char val_type, mp_obj_t val_in, byte **
 #endif
         default:
             #if MICROPY_LONGINT_IMPL != MICROPY_LONGINT_IMPL_NONE
-            if (MP_OBJ_IS_TYPE(val_in, &mp_type_int)) {
+            if (mp_obj_is_type(val_in, &mp_type_int)) {
                 mp_obj_int_to_bytes_impl(val_in, struct_type == '>', size, p);
                 return;
             } else
@@ -330,7 +330,7 @@ void mp_binary_set_val_array(char typecode, void *p, mp_uint_t index, mp_obj_t v
             break;
         default:
             #if MICROPY_LONGINT_IMPL != MICROPY_LONGINT_IMPL_NONE
-            if (MP_OBJ_IS_TYPE(val_in, &mp_type_int)) {
+            if (mp_obj_is_type(val_in, &mp_type_int)) {
                 size_t size = mp_binary_get_size('@', typecode, NULL);
                 mp_obj_int_to_bytes_impl(val_in, MP_ENDIANNESS_BIG,
                     size, (uint8_t*)p + index * size);

--- a/py/builtinevex.c
+++ b/py/builtinevex.c
@@ -52,7 +52,7 @@ STATIC mp_obj_t code_execute(mp_obj_code_t *self, mp_obj_dict_t *globals, mp_obj
 
     // a bit of a hack: fun_bc will re-set globals, so need to make sure it's
     // the correct one
-    if (MP_OBJ_IS_TYPE(self->module_fun, &mp_type_fun_bc)) {
+    if (mp_obj_is_type(self->module_fun, &mp_type_fun_bc)) {
         mp_obj_fun_bc_t *fun_bc = MP_OBJ_TO_PTR(self->module_fun);
         fun_bc->globals = globals;
     }
@@ -114,7 +114,7 @@ STATIC mp_obj_t eval_exec_helper(size_t n_args, const mp_obj_t *args, mp_parse_i
     mp_obj_dict_t *locals = mp_locals_get();
     for (size_t i = 1; i < 3 && i < n_args; ++i) {
         if (args[i] != mp_const_none) {
-            if (!MP_OBJ_IS_TYPE(args[i], &mp_type_dict)) {
+            if (!mp_obj_is_type(args[i], &mp_type_dict)) {
                 mp_raise_TypeError(NULL);
             }
             locals = MP_OBJ_TO_PTR(args[i]);
@@ -125,7 +125,7 @@ STATIC mp_obj_t eval_exec_helper(size_t n_args, const mp_obj_t *args, mp_parse_i
     }
 
     #if MICROPY_PY_BUILTINS_COMPILE
-    if (MP_OBJ_IS_TYPE(args[0], &mp_type_code)) {
+    if (mp_obj_is_type(args[0], &mp_type_code)) {
         return code_execute(MP_OBJ_TO_PTR(args[0]), globals, locals);
     }
     #endif

--- a/py/builtinhelp.c
+++ b/py/builtinhelp.c
@@ -58,7 +58,7 @@ STATIC void mp_help_print_info_about_object(mp_obj_t name_o, mp_obj_t value) {
 #if MICROPY_PY_BUILTINS_HELP_MODULES
 STATIC void mp_help_add_from_map(mp_obj_t list, const mp_map_t *map) {
     for (size_t i = 0; i < map->alloc; i++) {
-        if (MP_MAP_SLOT_IS_FILLED(map, i)) {
+        if (mp_map_slot_is_filled(map, i)) {
             mp_obj_list_append(list, map->table[i].key);
         }
     }

--- a/py/compile.c
+++ b/py/compile.c
@@ -2939,7 +2939,7 @@ STATIC void check_for_doc_string(compiler_t *comp, mp_parse_node_t pn) {
         if ((MP_PARSE_NODE_IS_LEAF(pns->nodes[0])
                 && MP_PARSE_NODE_LEAF_KIND(pns->nodes[0]) == MP_PARSE_NODE_STRING)
             || (MP_PARSE_NODE_IS_STRUCT_KIND(pns->nodes[0], PN_const_object)
-                && MP_OBJ_IS_STR(get_const_object((mp_parse_node_struct_t*)pns->nodes[0])))) {
+                && mp_obj_is_str(get_const_object((mp_parse_node_struct_t*)pns->nodes[0])))) {
                 // compile the doc string
                 compile_node(comp, pns->nodes[0]);
                 // store the doc string

--- a/py/emitglue.c
+++ b/py/emitglue.c
@@ -124,10 +124,10 @@ mp_obj_t mp_make_function_from_raw_code(const mp_raw_code_t *rc, mp_obj_t def_ar
     assert(rc != NULL);
 
     // def_args must be MP_OBJ_NULL or a tuple
-    assert(def_args == MP_OBJ_NULL || MP_OBJ_IS_TYPE(def_args, &mp_type_tuple));
+    assert(def_args == MP_OBJ_NULL || mp_obj_is_type(def_args, &mp_type_tuple));
 
     // def_kw_args must be MP_OBJ_NULL or a dict
-    assert(def_kw_args == MP_OBJ_NULL || MP_OBJ_IS_TYPE(def_kw_args, &mp_type_dict));
+    assert(def_kw_args == MP_OBJ_NULL || mp_obj_is_type(def_kw_args, &mp_type_dict));
 
     // make the function, depending on the raw code kind
     mp_obj_t fun;

--- a/py/map.c
+++ b/py/map.c
@@ -150,9 +150,9 @@ mp_map_elem_t *mp_map_lookup(mp_map_t *map, mp_obj_t index, mp_map_lookup_kind_t
     // Work out if we can compare just pointers
     bool compare_only_ptrs = map->all_keys_are_qstrs;
     if (compare_only_ptrs) {
-        if (MP_OBJ_IS_QSTR(index)) {
+        if (mp_obj_is_qstr(index)) {
             // Index is a qstr, so can just do ptr comparison.
-        } else if (MP_OBJ_IS_TYPE(index, &mp_type_str)) {
+        } else if (mp_obj_is_type(index, &mp_type_str)) {
             // Index is a non-interned string.
             // We can either intern the string, or force a full equality comparison.
             // We chose the latter, since interning costs time and potentially RAM,
@@ -197,7 +197,7 @@ mp_map_elem_t *mp_map_lookup(mp_map_t *map, mp_obj_t index, mp_map_lookup_kind_t
         }
         mp_map_elem_t *elem = map->table + map->used++;
         elem->key = index;
-        if (!MP_OBJ_IS_QSTR(index)) {
+        if (!mp_obj_is_qstr(index)) {
             map->all_keys_are_qstrs = 0;
         }
         return elem;
@@ -218,7 +218,7 @@ mp_map_elem_t *mp_map_lookup(mp_map_t *map, mp_obj_t index, mp_map_lookup_kind_t
 
     // get hash of index, with fast path for common case of qstr
     mp_uint_t hash;
-    if (MP_OBJ_IS_QSTR(index)) {
+    if (mp_obj_is_qstr(index)) {
         hash = qstr_hash(MP_OBJ_QSTR_VALUE(index));
     } else {
         hash = MP_OBJ_SMALL_INT_VALUE(mp_unary_op(MP_UNARY_OP_HASH, index));
@@ -238,7 +238,7 @@ mp_map_elem_t *mp_map_lookup(mp_map_t *map, mp_obj_t index, mp_map_lookup_kind_t
                 }
                 avail_slot->key = index;
                 avail_slot->value = MP_OBJ_NULL;
-                if (!MP_OBJ_IS_QSTR(index)) {
+                if (!mp_obj_is_qstr(index)) {
                     map->all_keys_are_qstrs = 0;
                 }
                 return avail_slot;
@@ -278,7 +278,7 @@ mp_map_elem_t *mp_map_lookup(mp_map_t *map, mp_obj_t index, mp_map_lookup_kind_t
                     map->used++;
                     avail_slot->key = index;
                     avail_slot->value = MP_OBJ_NULL;
-                    if (!MP_OBJ_IS_QSTR(index)) {
+                    if (!mp_obj_is_qstr(index)) {
                         map->all_keys_are_qstrs = 0;
                     }
                     return avail_slot;

--- a/py/map.c
+++ b/py/map.c
@@ -395,7 +395,7 @@ mp_obj_t mp_set_lookup(mp_set_t *set, mp_obj_t index, mp_map_lookup_kind_t looku
 
 mp_obj_t mp_set_remove_first(mp_set_t *set) {
     for (size_t pos = 0; pos < set->alloc; pos++) {
-        if (MP_SET_SLOT_IS_FILLED(set, pos)) {
+        if (mp_set_slot_is_filled(set, pos)) {
             mp_obj_t elem = set->table[pos];
             // delete element
             set->used--;

--- a/py/modbuiltins.c
+++ b/py/modbuiltins.c
@@ -178,7 +178,7 @@ STATIC mp_obj_t mp_builtin_dir(size_t n_args, const mp_obj_t *args) {
         // Make a list of names in the local namespace
         mp_obj_dict_t *dict = mp_locals_get();
         for (size_t i = 0; i < dict->map.alloc; i++) {
-            if (MP_MAP_SLOT_IS_FILLED(&dict->map, i)) {
+            if (mp_map_slot_is_filled(&dict->map, i)) {
                 mp_obj_list_append(dir, dict->map.table[i].key);
             }
         }

--- a/py/modbuiltins.c
+++ b/py/modbuiltins.c
@@ -357,7 +357,7 @@ STATIC mp_obj_t mp_builtin_ord(mp_obj_t o_in) {
     size_t len;
     const byte *str = (const byte*)mp_obj_str_get_data(o_in, &len);
     #if MICROPY_PY_BUILTINS_STR_UNICODE
-    if (MP_OBJ_IS_STR(o_in)) {
+    if (mp_obj_is_str(o_in)) {
         len = utf8_charlen(str, len);
         if (len == 1) {
             return mp_obj_new_int(utf8_get_char(str));
@@ -471,7 +471,7 @@ MP_DEFINE_CONST_FUN_OBJ_1(mp_builtin_repr_obj, mp_builtin_repr);
 
 STATIC mp_obj_t mp_builtin_round(size_t n_args, const mp_obj_t *args) {
     mp_obj_t o_in = args[0];
-    if (MP_OBJ_IS_INT(o_in)) {
+    if (mp_obj_is_int(o_in)) {
         if (n_args <= 1) {
             return o_in;
         }

--- a/py/modthread.c
+++ b/py/modthread.c
@@ -242,7 +242,7 @@ STATIC mp_obj_t mod_thread_start_new_thread(size_t n_args, const mp_obj_t *args)
         th_args->n_kw = map->used;
         // copy across the keyword arguments
         for (size_t i = 0, n = pos_args_len; i < map->alloc; ++i) {
-            if (MP_MAP_SLOT_IS_FILLED(map, i)) {
+            if (mp_map_slot_is_filled(map, i)) {
                 th_args->args[n++] = map->table[i].key;
                 th_args->args[n++] = map->table[i].value;
             }

--- a/py/mpprint.c
+++ b/py/mpprint.c
@@ -207,7 +207,7 @@ int mp_print_mp_int(const mp_print_t *print, mp_obj_t x, int base, int base_char
     // If needed this function could be generalised to handle other values.
     assert(base == 2 || base == 8 || base == 10 || base == 16);
 
-    if (!MP_OBJ_IS_INT(x)) {
+    if (!mp_obj_is_int(x)) {
         // This will convert booleans to int, or raise an error for
         // non-integer types.
         x = MP_OBJ_NEW_SMALL_INT(mp_obj_get_int(x));

--- a/py/obj.c
+++ b/py/obj.c
@@ -38,9 +38,9 @@
 #include "py/stream.h" // for mp_obj_print
 
 mp_obj_type_t *mp_obj_get_type(mp_const_obj_t o_in) {
-    if (MP_OBJ_IS_SMALL_INT(o_in)) {
+    if (mp_obj_is_small_int(o_in)) {
         return (mp_obj_type_t*)&mp_type_int;
-    } else if (MP_OBJ_IS_QSTR(o_in)) {
+    } else if (mp_obj_is_qstr(o_in)) {
         return (mp_obj_type_t*)&mp_type_str;
     #if MICROPY_PY_BUILTINS_FLOAT
     } else if (mp_obj_is_float(o_in)) {
@@ -112,7 +112,7 @@ bool mp_obj_is_true(mp_obj_t arg) {
         return 1;
     } else if (arg == mp_const_none) {
         return 0;
-    } else if (MP_OBJ_IS_SMALL_INT(arg)) {
+    } else if (mp_obj_is_small_int(arg)) {
         if (MP_OBJ_SMALL_INT_VALUE(arg) == 0) {
             return 0;
         } else {
@@ -167,7 +167,7 @@ bool mp_obj_equal(mp_obj_t o1, mp_obj_t o2) {
         && !mp_obj_is_float(o1)
         #endif
         #if MICROPY_PY_BUILTINS_COMPLEX
-        && !MP_OBJ_IS_TYPE(o1, &mp_type_complex)
+        && !mp_obj_is_type(o1, &mp_type_complex)
         #endif
         ) {
         return true;
@@ -177,8 +177,8 @@ bool mp_obj_equal(mp_obj_t o1, mp_obj_t o2) {
     }
 
     // fast path for small ints
-    if (MP_OBJ_IS_SMALL_INT(o1)) {
-        if (MP_OBJ_IS_SMALL_INT(o2)) {
+    if (mp_obj_is_small_int(o1)) {
+        if (mp_obj_is_small_int(o2)) {
             // both SMALL_INT, and not equal if we get here
             return false;
         } else {
@@ -189,19 +189,19 @@ bool mp_obj_equal(mp_obj_t o1, mp_obj_t o2) {
     }
 
     // fast path for strings
-    if (MP_OBJ_IS_STR(o1)) {
-        if (MP_OBJ_IS_STR(o2)) {
+    if (mp_obj_is_str(o1)) {
+        if (mp_obj_is_str(o2)) {
             // both strings, use special function
             return mp_obj_str_equal(o1, o2);
         } else {
             // a string is never equal to anything else
             goto str_cmp_err;
         }
-    } else if (MP_OBJ_IS_STR(o2)) {
+    } else if (mp_obj_is_str(o2)) {
         // o1 is not a string (else caught above), so the objects are not equal
     str_cmp_err:
         #if MICROPY_PY_STR_BYTES_CMP_WARN
-        if (MP_OBJ_IS_TYPE(o1, &mp_type_bytes) || MP_OBJ_IS_TYPE(o2, &mp_type_bytes)) {
+        if (mp_obj_is_type(o1, &mp_type_bytes) || mp_obj_is_type(o2, &mp_type_bytes)) {
             mp_warning("Comparison between bytes and str");
         }
         #endif
@@ -230,9 +230,9 @@ mp_int_t mp_obj_get_int(mp_const_obj_t arg) {
         return 0;
     } else if (arg == mp_const_true) {
         return 1;
-    } else if (MP_OBJ_IS_SMALL_INT(arg)) {
+    } else if (mp_obj_is_small_int(arg)) {
         return MP_OBJ_SMALL_INT_VALUE(arg);
-    } else if (MP_OBJ_IS_TYPE(arg, &mp_type_int)) {
+    } else if (mp_obj_is_type(arg, &mp_type_int)) {
         return mp_obj_int_get_checked(arg);
     } else {
         mp_obj_t res = mp_unary_op(MP_UNARY_OP_INT, (mp_obj_t)arg);
@@ -241,7 +241,7 @@ mp_int_t mp_obj_get_int(mp_const_obj_t arg) {
 }
 
 mp_int_t mp_obj_get_int_truncated(mp_const_obj_t arg) {
-    if (MP_OBJ_IS_INT(arg)) {
+    if (mp_obj_is_int(arg)) {
         return mp_obj_int_get_truncated(arg);
     } else {
         return mp_obj_get_int(arg);
@@ -256,9 +256,9 @@ bool mp_obj_get_int_maybe(mp_const_obj_t arg, mp_int_t *value) {
         *value = 0;
     } else if (arg == mp_const_true) {
         *value = 1;
-    } else if (MP_OBJ_IS_SMALL_INT(arg)) {
+    } else if (mp_obj_is_small_int(arg)) {
         *value = MP_OBJ_SMALL_INT_VALUE(arg);
-    } else if (MP_OBJ_IS_TYPE(arg, &mp_type_int)) {
+    } else if (mp_obj_is_type(arg, &mp_type_int)) {
         *value = mp_obj_int_get_checked(arg);
     } else {
         return false;
@@ -274,10 +274,10 @@ bool mp_obj_get_float_maybe(mp_obj_t arg, mp_float_t *value) {
         val = 0;
     } else if (arg == mp_const_true) {
         val = 1;
-    } else if (MP_OBJ_IS_SMALL_INT(arg)) {
+    } else if (mp_obj_is_small_int(arg)) {
         val = MP_OBJ_SMALL_INT_VALUE(arg);
     #if MICROPY_LONGINT_IMPL != MICROPY_LONGINT_IMPL_NONE
-    } else if (MP_OBJ_IS_TYPE(arg, &mp_type_int)) {
+    } else if (mp_obj_is_type(arg, &mp_type_int)) {
         val = mp_obj_int_as_float_impl(arg);
     #endif
     } else if (mp_obj_is_float(arg)) {
@@ -313,18 +313,18 @@ void mp_obj_get_complex(mp_obj_t arg, mp_float_t *real, mp_float_t *imag) {
     } else if (arg == mp_const_true) {
         *real = 1;
         *imag = 0;
-    } else if (MP_OBJ_IS_SMALL_INT(arg)) {
+    } else if (mp_obj_is_small_int(arg)) {
         *real = MP_OBJ_SMALL_INT_VALUE(arg);
         *imag = 0;
     #if MICROPY_LONGINT_IMPL != MICROPY_LONGINT_IMPL_NONE
-    } else if (MP_OBJ_IS_TYPE(arg, &mp_type_int)) {
+    } else if (mp_obj_is_type(arg, &mp_type_int)) {
         *real = mp_obj_int_as_float_impl(arg);
         *imag = 0;
     #endif
     } else if (mp_obj_is_float(arg)) {
         *real = mp_obj_float_get(arg);
         *imag = 0;
-    } else if (MP_OBJ_IS_TYPE(arg, &mp_type_complex)) {
+    } else if (mp_obj_is_type(arg, &mp_type_complex)) {
         mp_obj_complex_get(arg, real, imag);
     } else {
         if (MICROPY_ERROR_REPORTING == MICROPY_ERROR_REPORTING_TERSE) {
@@ -340,9 +340,9 @@ void mp_obj_get_complex(mp_obj_t arg, mp_float_t *real, mp_float_t *imag) {
 
 // note: returned value in *items may point to the interior of a GC block
 void mp_obj_get_array(mp_obj_t o, size_t *len, mp_obj_t **items) {
-    if (MP_OBJ_IS_TYPE(o, &mp_type_tuple)) {
+    if (mp_obj_is_type(o, &mp_type_tuple)) {
         mp_obj_tuple_get(o, len, items);
-    } else if (MP_OBJ_IS_TYPE(o, &mp_type_list)) {
+    } else if (mp_obj_is_type(o, &mp_type_list)) {
         mp_obj_list_get(o, len, items);
     } else {
         if (MICROPY_ERROR_REPORTING == MICROPY_ERROR_REPORTING_TERSE) {
@@ -371,7 +371,7 @@ void mp_obj_get_array_fixed_n(mp_obj_t o, size_t len, mp_obj_t **items) {
 // is_slice determines whether the index is a slice index
 size_t mp_get_index(const mp_obj_type_t *type, size_t len, mp_obj_t index, bool is_slice) {
     mp_int_t i;
-    if (MP_OBJ_IS_SMALL_INT(index)) {
+    if (mp_obj_is_small_int(index)) {
         i = MP_OBJ_SMALL_INT_VALUE(index);
     } else if (!mp_obj_get_int_maybe(index, &i)) {
         if (MICROPY_ERROR_REPORTING == MICROPY_ERROR_REPORTING_TERSE) {
@@ -409,7 +409,7 @@ size_t mp_get_index(const mp_obj_type_t *type, size_t len, mp_obj_t index, bool 
 
 mp_obj_t mp_obj_id(mp_obj_t o_in) {
     mp_int_t id = (mp_int_t)o_in;
-    if (!MP_OBJ_IS_OBJ(o_in)) {
+    if (!mp_obj_is_obj(o_in)) {
         return mp_obj_new_int(id);
     } else if (id >= 0) {
         // Many OSes and CPUs have affinity for putting "user" memories
@@ -445,9 +445,9 @@ mp_obj_t mp_obj_len_maybe(mp_obj_t o_in) {
     if (
 #if !MICROPY_PY_BUILTINS_STR_UNICODE
         // It's simple - unicode is slow, non-unicode is fast
-        MP_OBJ_IS_STR(o_in) ||
+        mp_obj_is_str(o_in) ||
 #endif
-        MP_OBJ_IS_TYPE(o_in, &mp_type_bytes)) {
+        mp_obj_is_type(o_in, &mp_type_bytes)) {
         GET_STR_LEN(o_in, l);
         return MP_OBJ_NEW_SMALL_INT(l);
     } else {

--- a/py/obj.h
+++ b/py/obj.h
@@ -362,7 +362,7 @@ typedef enum _mp_map_lookup_kind_t {
 
 extern const mp_map_t mp_const_empty_map;
 
-static inline bool MP_MAP_SLOT_IS_FILLED(const mp_map_t *map, size_t pos) { return ((map)->table[pos].key != MP_OBJ_NULL && (map)->table[pos].key != MP_OBJ_SENTINEL); }
+static inline bool mp_map_slot_is_filled(const mp_map_t *map, size_t pos) { return ((map)->table[pos].key != MP_OBJ_NULL && (map)->table[pos].key != MP_OBJ_SENTINEL); }
 
 void mp_map_init(mp_map_t *map, size_t n);
 void mp_map_init_fixed_table(mp_map_t *map, size_t n, const mp_obj_t *table);
@@ -381,7 +381,7 @@ typedef struct _mp_set_t {
     mp_obj_t *table;
 } mp_set_t;
 
-static inline bool MP_SET_SLOT_IS_FILLED(const mp_set_t *set, size_t pos) { return ((set)->table[pos] != MP_OBJ_NULL && (set)->table[pos] != MP_OBJ_SENTINEL); }
+static inline bool mp_set_slot_is_filled(const mp_set_t *set, size_t pos) { return ((set)->table[pos] != MP_OBJ_NULL && (set)->table[pos] != MP_OBJ_SENTINEL); }
 
 void mp_set_init(mp_set_t *set, size_t n);
 mp_obj_t mp_set_lookup(mp_set_t *set, mp_obj_t index, mp_map_lookup_kind_t lookup_kind);
@@ -872,5 +872,7 @@ mp_obj_t mp_seq_extract_slice(size_t len, const mp_obj_t *seq, mp_bound_slice_t 
 #define MP_OBJ_IS_STR mp_obj_is_str
 #define MP_OBJ_IS_STR_OR_BYTES mp_obj_is_str_or_bytes
 #define MP_OBJ_IS_FUN mp_obj_is_fun
+#define MP_MAP_SLOT_IS_FILLED mp_map_slot_is_filled
+#define MP_SET_SLOT_IS_FILLED mp_set_slot_is_filled
 
 #endif // MICROPY_INCLUDED_PY_OBJ_H

--- a/py/obj.h
+++ b/py/obj.h
@@ -81,12 +81,12 @@ typedef struct _mp_obj_base_t mp_obj_base_t;
 
 #if MICROPY_OBJ_REPR == MICROPY_OBJ_REPR_A
 
-static inline bool MP_OBJ_IS_SMALL_INT(mp_const_obj_t o)
+static inline bool mp_obj_is_small_int(mp_const_obj_t o)
     { return ((((mp_int_t)(o)) & 1) != 0); }
 #define MP_OBJ_SMALL_INT_VALUE(o) (((mp_int_t)(o)) >> 1)
 #define MP_OBJ_NEW_SMALL_INT(small_int) ((mp_obj_t)((((mp_uint_t)(small_int)) << 1) | 1))
 
-static inline bool MP_OBJ_IS_QSTR(mp_const_obj_t o)
+static inline bool mp_obj_is_qstr(mp_const_obj_t o)
     { return ((((mp_int_t)(o)) & 3) == 2); }
 #define MP_OBJ_QSTR_VALUE(o) (((mp_uint_t)(o)) >> 2)
 #define MP_OBJ_NEW_QSTR(qst) ((mp_obj_t)((((mp_uint_t)(qst)) << 2) | 2))
@@ -97,22 +97,22 @@ static inline bool MP_OBJ_IS_QSTR(mp_const_obj_t o)
 extern const struct _mp_obj_float_t mp_const_float_e_obj;
 extern const struct _mp_obj_float_t mp_const_float_pi_obj;
 
-#define mp_obj_is_float(o) MP_OBJ_IS_TYPE((o), &mp_type_float)
+#define mp_obj_is_float(o) mp_obj_is_type((o), &mp_type_float)
 mp_float_t mp_obj_float_get(mp_obj_t self_in);
 mp_obj_t mp_obj_new_float(mp_float_t value);
 #endif
 
-static inline bool MP_OBJ_IS_OBJ(mp_const_obj_t o)
+static inline bool mp_obj_is_obj(mp_const_obj_t o)
     { return ((((mp_int_t)(o)) & 3) == 0); }
 
 #elif MICROPY_OBJ_REPR == MICROPY_OBJ_REPR_B
 
-static inline bool MP_OBJ_IS_SMALL_INT(mp_const_obj_t o)
+static inline bool mp_obj_is_small_int(mp_const_obj_t o)
     { return ((((mp_int_t)(o)) & 3) == 1); }
 #define MP_OBJ_SMALL_INT_VALUE(o) (((mp_int_t)(o)) >> 2)
 #define MP_OBJ_NEW_SMALL_INT(small_int) ((mp_obj_t)((((mp_uint_t)(small_int)) << 2) | 1))
 
-static inline bool MP_OBJ_IS_QSTR(mp_const_obj_t o)
+static inline bool mp_obj_is_qstr(mp_const_obj_t o)
     { return ((((mp_int_t)(o)) & 3) == 3); }
 #define MP_OBJ_QSTR_VALUE(o) (((mp_uint_t)(o)) >> 2)
 #define MP_OBJ_NEW_QSTR(qst) ((mp_obj_t)((((mp_uint_t)(qst)) << 2) | 3))
@@ -123,17 +123,17 @@ static inline bool MP_OBJ_IS_QSTR(mp_const_obj_t o)
 extern const struct _mp_obj_float_t mp_const_float_e_obj;
 extern const struct _mp_obj_float_t mp_const_float_pi_obj;
 
-#define mp_obj_is_float(o) MP_OBJ_IS_TYPE((o), &mp_type_float)
+#define mp_obj_is_float(o) mp_obj_is_type((o), &mp_type_float)
 mp_float_t mp_obj_float_get(mp_obj_t self_in);
 mp_obj_t mp_obj_new_float(mp_float_t value);
 #endif
 
-static inline bool MP_OBJ_IS_OBJ(mp_const_obj_t o)
+static inline bool mp_obj_is_obj(mp_const_obj_t o)
     { return ((((mp_int_t)(o)) & 1) == 0); }
 
 #elif MICROPY_OBJ_REPR == MICROPY_OBJ_REPR_C
 
-static inline bool MP_OBJ_IS_SMALL_INT(mp_const_obj_t o)
+static inline bool mp_obj_is_small_int(mp_const_obj_t o)
     { return ((((mp_int_t)(o)) & 1) != 0); }
 #define MP_OBJ_SMALL_INT_VALUE(o) (((mp_int_t)(o)) >> 1)
 #define MP_OBJ_NEW_SMALL_INT(small_int) ((mp_obj_t)((((mp_uint_t)(small_int)) << 1) | 1))
@@ -160,22 +160,22 @@ static inline mp_obj_t mp_obj_new_float(mp_float_t f) {
 }
 #endif
 
-static inline bool MP_OBJ_IS_QSTR(mp_const_obj_t o)
+static inline bool mp_obj_is_qstr(mp_const_obj_t o)
     { return (((mp_uint_t)(o)) & 0xff800007) == 0x00000006; }
 #define MP_OBJ_QSTR_VALUE(o) (((mp_uint_t)(o)) >> 3)
 #define MP_OBJ_NEW_QSTR(qst) ((mp_obj_t)((((mp_uint_t)(qst)) << 3) | 0x00000006))
 
-static inline bool MP_OBJ_IS_OBJ(mp_const_obj_t o)
+static inline bool mp_obj_is_obj(mp_const_obj_t o)
     { return ((((mp_int_t)(o)) & 3) == 0); }
 
 #elif MICROPY_OBJ_REPR == MICROPY_OBJ_REPR_D
 
-static inline bool MP_OBJ_IS_SMALL_INT(mp_const_obj_t o)
+static inline bool mp_obj_is_small_int(mp_const_obj_t o)
     { return ((((uint64_t)(o)) & 0xffff000000000000) == 0x0001000000000000); }
 #define MP_OBJ_SMALL_INT_VALUE(o) (((mp_int_t)((o) << 16)) >> 17)
 #define MP_OBJ_NEW_SMALL_INT(small_int) (((((uint64_t)(small_int)) & 0x7fffffffffff) << 1) | 0x0001000000000001)
 
-static inline bool MP_OBJ_IS_QSTR(mp_const_obj_t o)
+static inline bool mp_obj_is_qstr(mp_const_obj_t o)
     { return ((((uint64_t)(o)) & 0xffff000000000000) == 0x0002000000000000); }
 #define MP_OBJ_QSTR_VALUE(o) ((((uint32_t)(o)) >> 1) & 0xffffffff)
 #define MP_OBJ_NEW_QSTR(qst) ((mp_obj_t)((((mp_uint_t)(qst)) << 1) | 0x0002000000000001))
@@ -208,7 +208,7 @@ static inline mp_obj_t mp_obj_new_float(mp_float_t f) {
 }
 #endif
 
-static inline bool MP_OBJ_IS_OBJ(mp_const_obj_t o)
+static inline bool mp_obj_is_obj(mp_const_obj_t o)
     { return ((((uint64_t)(o)) & 0xffff000000000000) == 0x0000000000000000); }
 #define MP_OBJ_TO_PTR(o) ((void*)(uintptr_t)(o))
 #define MP_OBJ_FROM_PTR(p) ((mp_obj_t)((uintptr_t)(p)))
@@ -254,17 +254,6 @@ typedef struct _mp_rom_obj_t { mp_const_obj_t o; } mp_rom_obj_t;
 #define MP_ROM_PTR(p) {.o = p}
 */
 #endif
-
-// The macros below are derived from the ones above and are used to
-// check for more specific object types.
-// Note: these are kept as macros because inline functions sometimes use much
-// more code space than the equivalent macros, depending on the compiler.
-
-#define MP_OBJ_IS_TYPE(o, t) (MP_OBJ_IS_OBJ(o) && (((mp_obj_base_t*)MP_OBJ_TO_PTR(o))->type == (t))) // this does not work for checking int, str or fun; use below macros for that
-#define MP_OBJ_IS_INT(o) (MP_OBJ_IS_SMALL_INT(o) || MP_OBJ_IS_TYPE(o, &mp_type_int))
-#define MP_OBJ_IS_STR(o) (MP_OBJ_IS_QSTR(o) || MP_OBJ_IS_TYPE(o, &mp_type_str))
-#define MP_OBJ_IS_STR_OR_BYTES(o) (MP_OBJ_IS_QSTR(o) || (MP_OBJ_IS_OBJ(o) && ((mp_obj_base_t*)MP_OBJ_TO_PTR(o))->type->binary_op == mp_obj_str_binary_op))
-#define MP_OBJ_IS_FUN(o) (MP_OBJ_IS_OBJ(o) && (((mp_obj_base_t*)MP_OBJ_TO_PTR(o))->type->name == MP_QSTR_function))
 
 // These macros are used to declare and define constant function objects
 // You can put "static" in front of the definitions to make them local
@@ -625,6 +614,16 @@ extern const struct _mp_obj_exception_t mp_const_GeneratorExit_obj;
 
 // General API for objects
 
+// These macros are derived from more primitive ones and are used to
+// check for more specific object types.
+// Note: these are kept as macros because inline functions sometimes use much
+// more code space than the equivalent macros, depending on the compiler.
+#define mp_obj_is_type(o, t) (mp_obj_is_obj(o) && (((mp_obj_base_t*)MP_OBJ_TO_PTR(o))->type == (t))) // this does not work for checking int, str or fun; use below macros for that
+#define mp_obj_is_int(o) (mp_obj_is_small_int(o) || mp_obj_is_type(o, &mp_type_int))
+#define mp_obj_is_str(o) (mp_obj_is_qstr(o) || mp_obj_is_type(o, &mp_type_str))
+#define mp_obj_is_str_or_bytes(o) (mp_obj_is_qstr(o) || (mp_obj_is_obj(o) && ((mp_obj_base_t*)MP_OBJ_TO_PTR(o))->type->binary_op == mp_obj_str_binary_op))
+#define mp_obj_is_fun(o) (mp_obj_is_obj(o) && (((mp_obj_base_t*)MP_OBJ_TO_PTR(o))->type->name == MP_QSTR_function))
+
 mp_obj_t mp_obj_new_type(qstr name, mp_obj_t bases_tuple, mp_obj_t locals_dict);
 static inline mp_obj_t mp_obj_new_bool(mp_int_t x) { return x ? mp_const_true : mp_const_false; }
 mp_obj_t mp_obj_new_cell(mp_obj_t obj);
@@ -677,7 +676,7 @@ bool mp_obj_is_true(mp_obj_t arg);
 bool mp_obj_is_callable(mp_obj_t o_in);
 bool mp_obj_equal(mp_obj_t o1, mp_obj_t o2);
 
-static inline bool mp_obj_is_integer(mp_const_obj_t o) { return MP_OBJ_IS_INT(o) || MP_OBJ_IS_TYPE(o, &mp_type_bool); } // returns true if o is bool, small int or long int
+static inline bool mp_obj_is_integer(mp_const_obj_t o) { return mp_obj_is_int(o) || mp_obj_is_type(o, &mp_type_bool); } // returns true if o is bool, small int or long int
 mp_int_t mp_obj_get_int(mp_const_obj_t arg);
 mp_int_t mp_obj_get_int_truncated(mp_const_obj_t arg);
 bool mp_obj_get_int_maybe(mp_const_obj_t arg, mp_int_t *value);
@@ -863,5 +862,15 @@ mp_obj_t mp_seq_extract_slice(size_t len, const mp_obj_t *seq, mp_bound_slice_t 
     /*printf("memmove(%p, %p, %d)\n", dest + beg + len_adj, dest + beg, (dest_len - beg) * (item_sz));*/ \
     memmove(((char*)dest) + (beg + slice_len) * (item_sz), ((char*)dest) + (end) * (item_sz), ((dest_len) + (len_adj) - ((beg) + (slice_len))) * (item_sz)); \
     memmove(((char*)dest) + (beg) * (item_sz), slice, slice_len * (item_sz));
+
+// Provide translation for legacy API
+#define MP_OBJ_IS_SMALL_INT mp_obj_is_small_int
+#define MP_OBJ_IS_QSTR mp_obj_is_qstr
+#define MP_OBJ_IS_OBJ mp_obj_is_obj
+#define MP_OBJ_IS_INT mp_obj_is_int
+#define MP_OBJ_IS_TYPE mp_obj_is_type
+#define MP_OBJ_IS_STR mp_obj_is_str
+#define MP_OBJ_IS_STR_OR_BYTES mp_obj_is_str_or_bytes
+#define MP_OBJ_IS_FUN mp_obj_is_fun
 
 #endif // MICROPY_INCLUDED_PY_OBJ_H

--- a/py/objcomplex.c
+++ b/py/objcomplex.c
@@ -79,12 +79,12 @@ STATIC mp_obj_t complex_make_new(const mp_obj_type_t *type_in, size_t n_args, si
             return mp_obj_new_complex(0, 0);
 
         case 1:
-            if (MP_OBJ_IS_STR(args[0])) {
+            if (mp_obj_is_str(args[0])) {
                 // a string, parse it
                 size_t l;
                 const char *s = mp_obj_str_get_data(args[0], &l);
                 return mp_parse_num_decimal(s, l, true, true, NULL);
-            } else if (MP_OBJ_IS_TYPE(args[0], &mp_type_complex)) {
+            } else if (mp_obj_is_type(args[0], &mp_type_complex)) {
                 // a complex, just return it
                 return args[0];
             } else {
@@ -95,13 +95,13 @@ STATIC mp_obj_t complex_make_new(const mp_obj_type_t *type_in, size_t n_args, si
         case 2:
         default: {
             mp_float_t real, imag;
-            if (MP_OBJ_IS_TYPE(args[0], &mp_type_complex)) {
+            if (mp_obj_is_type(args[0], &mp_type_complex)) {
                 mp_obj_complex_get(args[0], &real, &imag);
             } else {
                 real = mp_obj_get_float(args[0]);
                 imag = 0;
             }
-            if (MP_OBJ_IS_TYPE(args[1], &mp_type_complex)) {
+            if (mp_obj_is_type(args[1], &mp_type_complex)) {
                 mp_float_t real2, imag2;
                 mp_obj_complex_get(args[1], &real2, &imag2);
                 real -= imag2;
@@ -164,7 +164,7 @@ mp_obj_t mp_obj_new_complex(mp_float_t real, mp_float_t imag) {
 }
 
 void mp_obj_complex_get(mp_obj_t self_in, mp_float_t *real, mp_float_t *imag) {
-    assert(MP_OBJ_IS_TYPE(self_in, &mp_type_complex));
+    assert(mp_obj_is_type(self_in, &mp_type_complex));
     mp_obj_complex_t *self = MP_OBJ_TO_PTR(self_in);
     *real = self->real;
     *imag = self->imag;

--- a/py/objdict.c
+++ b/py/objdict.c
@@ -43,7 +43,7 @@ STATIC mp_map_elem_t *dict_iter_next(mp_obj_dict_t *dict, size_t *cur) {
     mp_map_t *map = &dict->map;
 
     for (size_t i = *cur; i < max; i++) {
-        if (MP_MAP_SLOT_IS_FILLED(map, i)) {
+        if (mp_map_slot_is_filled(map, i)) {
             *cur = i + 1;
             return &(map->table[i]);
         }
@@ -364,7 +364,7 @@ STATIC mp_obj_t dict_update(size_t n_args, const mp_obj_t *args, mp_map_t *kwarg
 
     // update the dict with any keyword args
     for (size_t i = 0; i < kwargs->alloc; i++) {
-        if (MP_MAP_SLOT_IS_FILLED(kwargs, i)) {
+        if (mp_map_slot_is_filled(kwargs, i)) {
             mp_map_lookup(&self->map, kwargs->table[i].key, MP_MAP_LOOKUP_ADD_IF_NOT_FOUND)->value = kwargs->table[i].value;
         }
     }

--- a/py/objdict.c
+++ b/py/objdict.c
@@ -31,7 +31,7 @@
 #include "py/builtin.h"
 #include "py/objtype.h"
 
-#define MP_OBJ_IS_DICT_TYPE(o) (MP_OBJ_IS_OBJ(o) && ((mp_obj_base_t*)MP_OBJ_TO_PTR(o))->type->make_new == dict_make_new)
+#define mp_obj_is_dict_type(o) (mp_obj_is_obj(o) && ((mp_obj_base_t*)MP_OBJ_TO_PTR(o))->type->make_new == dict_make_new)
 
 STATIC mp_obj_t dict_update(size_t n_args, const mp_obj_t *args, mp_map_t *kwargs);
 
@@ -121,7 +121,7 @@ STATIC mp_obj_t dict_binary_op(mp_binary_op_t op, mp_obj_t lhs_in, mp_obj_t rhs_
         }
         case MP_BINARY_OP_EQUAL: {
             #if MICROPY_PY_COLLECTIONS_ORDEREDDICT
-            if (MP_UNLIKELY(MP_OBJ_IS_TYPE(lhs_in, &mp_type_ordereddict) && MP_OBJ_IS_TYPE(rhs_in, &mp_type_ordereddict))) {
+            if (MP_UNLIKELY(mp_obj_is_type(lhs_in, &mp_type_ordereddict) && mp_obj_is_type(rhs_in, &mp_type_ordereddict))) {
                 // Iterate through both dictionaries simultaneously and compare keys and values.
                 mp_obj_dict_t *rhs = MP_OBJ_TO_PTR(rhs_in);
                 size_t c1 = 0, c2 = 0;
@@ -134,7 +134,7 @@ STATIC mp_obj_t dict_binary_op(mp_binary_op_t op, mp_obj_t lhs_in, mp_obj_t rhs_
                 return e1 == NULL && e2 == NULL ? mp_const_true : mp_const_false;
             } else
             #endif
-            if (MP_OBJ_IS_TYPE(rhs_in, &mp_type_dict)) {
+            if (mp_obj_is_type(rhs_in, &mp_type_dict)) {
                 mp_obj_dict_t *rhs = MP_OBJ_TO_PTR(rhs_in);
                 if (o->map.used != rhs->map.used) {
                     return mp_const_false;
@@ -202,7 +202,7 @@ STATIC void mp_ensure_not_fixed(const mp_obj_dict_t *dict) {
 }
 
 STATIC mp_obj_t dict_clear(mp_obj_t self_in) {
-    mp_check_self(MP_OBJ_IS_DICT_TYPE(self_in));
+    mp_check_self(mp_obj_is_dict_type(self_in));
     mp_obj_dict_t *self = MP_OBJ_TO_PTR(self_in);
     mp_ensure_not_fixed(self);
 
@@ -213,7 +213,7 @@ STATIC mp_obj_t dict_clear(mp_obj_t self_in) {
 STATIC MP_DEFINE_CONST_FUN_OBJ_1(dict_clear_obj, dict_clear);
 
 STATIC mp_obj_t dict_copy(mp_obj_t self_in) {
-    mp_check_self(MP_OBJ_IS_DICT_TYPE(self_in));
+    mp_check_self(mp_obj_is_dict_type(self_in));
     mp_obj_dict_t *self = MP_OBJ_TO_PTR(self_in);
     mp_obj_t other_out = mp_obj_new_dict(self->map.alloc);
     mp_obj_dict_t *other = MP_OBJ_TO_PTR(other_out);
@@ -260,7 +260,7 @@ STATIC MP_DEFINE_CONST_CLASSMETHOD_OBJ(dict_fromkeys_obj, MP_ROM_PTR(&dict_fromk
 #endif
 
 STATIC mp_obj_t dict_get_helper(size_t n_args, const mp_obj_t *args, mp_map_lookup_kind_t lookup_kind) {
-    mp_check_self(MP_OBJ_IS_DICT_TYPE(args[0]));
+    mp_check_self(mp_obj_is_dict_type(args[0]));
     mp_obj_dict_t *self = MP_OBJ_TO_PTR(args[0]);
     if (lookup_kind != MP_MAP_LOOKUP) {
         mp_ensure_not_fixed(self);
@@ -305,7 +305,7 @@ STATIC mp_obj_t dict_setdefault(size_t n_args, const mp_obj_t *args) {
 STATIC MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(dict_setdefault_obj, 2, 3, dict_setdefault);
 
 STATIC mp_obj_t dict_popitem(mp_obj_t self_in) {
-    mp_check_self(MP_OBJ_IS_DICT_TYPE(self_in));
+    mp_check_self(mp_obj_is_dict_type(self_in));
     mp_obj_dict_t *self = MP_OBJ_TO_PTR(self_in);
     mp_ensure_not_fixed(self);
     size_t cur = 0;
@@ -324,7 +324,7 @@ STATIC mp_obj_t dict_popitem(mp_obj_t self_in) {
 STATIC MP_DEFINE_CONST_FUN_OBJ_1(dict_popitem_obj, dict_popitem);
 
 STATIC mp_obj_t dict_update(size_t n_args, const mp_obj_t *args, mp_map_t *kwargs) {
-    mp_check_self(MP_OBJ_IS_DICT_TYPE(args[0]));
+    mp_check_self(mp_obj_is_dict_type(args[0]));
     mp_obj_dict_t *self = MP_OBJ_TO_PTR(args[0]);
     mp_ensure_not_fixed(self);
 
@@ -333,7 +333,7 @@ STATIC mp_obj_t dict_update(size_t n_args, const mp_obj_t *args, mp_map_t *kwarg
     if (n_args == 2) {
         // given a positional argument
 
-        if (MP_OBJ_IS_DICT_TYPE(args[1])) {
+        if (mp_obj_is_dict_type(args[1])) {
             // update from other dictionary (make sure other is not self)
             if (args[1] != args[0]) {
                 size_t cur = 0;
@@ -402,7 +402,7 @@ typedef struct _mp_obj_dict_view_t {
 } mp_obj_dict_view_t;
 
 STATIC mp_obj_t dict_view_it_iternext(mp_obj_t self_in) {
-    mp_check_self(MP_OBJ_IS_TYPE(self_in, &dict_view_it_type));
+    mp_check_self(mp_obj_is_type(self_in, &dict_view_it_type));
     mp_obj_dict_view_it_t *self = MP_OBJ_TO_PTR(self_in);
     mp_map_elem_t *next = dict_iter_next(MP_OBJ_TO_PTR(self->dict), &self->cur);
 
@@ -432,7 +432,7 @@ STATIC const mp_obj_type_t dict_view_it_type = {
 
 STATIC mp_obj_t dict_view_getiter(mp_obj_t view_in, mp_obj_iter_buf_t *iter_buf) {
     assert(sizeof(mp_obj_dict_view_it_t) <= sizeof(mp_obj_iter_buf_t));
-    mp_check_self(MP_OBJ_IS_TYPE(view_in, &dict_view_type));
+    mp_check_self(mp_obj_is_type(view_in, &dict_view_type));
     mp_obj_dict_view_t *view = MP_OBJ_TO_PTR(view_in);
     mp_obj_dict_view_it_t *o = (mp_obj_dict_view_it_t*)iter_buf;
     o->base.type = &dict_view_it_type;
@@ -444,7 +444,7 @@ STATIC mp_obj_t dict_view_getiter(mp_obj_t view_in, mp_obj_iter_buf_t *iter_buf)
 
 STATIC void dict_view_print(const mp_print_t *print, mp_obj_t self_in, mp_print_kind_t kind) {
     (void)kind;
-    mp_check_self(MP_OBJ_IS_TYPE(self_in, &dict_view_type));
+    mp_check_self(mp_obj_is_type(self_in, &dict_view_type));
     mp_obj_dict_view_t *self = MP_OBJ_TO_PTR(self_in);
     bool first = true;
     mp_print_str(print, mp_dict_view_names[self->kind]);
@@ -491,7 +491,7 @@ STATIC mp_obj_t mp_obj_new_dict_view(mp_obj_t dict, mp_dict_view_kind_t kind) {
 }
 
 STATIC mp_obj_t dict_view(mp_obj_t self_in, mp_dict_view_kind_t kind) {
-    mp_check_self(MP_OBJ_IS_DICT_TYPE(self_in));
+    mp_check_self(mp_obj_is_dict_type(self_in));
     return mp_obj_new_dict_view(self_in, kind);
 }
 
@@ -515,7 +515,7 @@ STATIC MP_DEFINE_CONST_FUN_OBJ_1(dict_values_obj, dict_values);
 
 STATIC mp_obj_t dict_getiter(mp_obj_t self_in, mp_obj_iter_buf_t *iter_buf) {
     assert(sizeof(mp_obj_dict_view_it_t) <= sizeof(mp_obj_iter_buf_t));
-    mp_check_self(MP_OBJ_IS_DICT_TYPE(self_in));
+    mp_check_self(mp_obj_is_dict_type(self_in));
     mp_obj_dict_view_it_t *o = (mp_obj_dict_view_it_t*)iter_buf;
     o->base.type = &dict_view_it_type;
     o->kind = MP_DICT_VIEW_KEYS;
@@ -592,7 +592,7 @@ size_t mp_obj_dict_len(mp_obj_t self_in) {
 }
 
 mp_obj_t mp_obj_dict_store(mp_obj_t self_in, mp_obj_t key, mp_obj_t value) {
-    mp_check_self(MP_OBJ_IS_DICT_TYPE(self_in));
+    mp_check_self(mp_obj_is_dict_type(self_in));
     mp_obj_dict_t *self = MP_OBJ_TO_PTR(self_in);
     mp_ensure_not_fixed(self);
     mp_map_lookup(&self->map, key, MP_MAP_LOOKUP_ADD_IF_NOT_FOUND)->value = value;

--- a/py/objenumerate.c
+++ b/py/objenumerate.c
@@ -78,7 +78,7 @@ const mp_obj_type_t mp_type_enumerate = {
 };
 
 STATIC mp_obj_t enumerate_iternext(mp_obj_t self_in) {
-    assert(MP_OBJ_IS_TYPE(self_in, &mp_type_enumerate));
+    assert(mp_obj_is_type(self_in, &mp_type_enumerate));
     mp_obj_enumerate_t *self = MP_OBJ_TO_PTR(self_in);
     mp_obj_t next = mp_iternext(self->iter);
     if (next == MP_OBJ_STOP_ITERATION) {

--- a/py/objexcept.c
+++ b/py/objexcept.c
@@ -123,7 +123,7 @@ void mp_obj_exception_print(const mp_print_t *print, mp_obj_t o_in, mp_print_kin
         } else if (o->args->len == 1) {
             #if MICROPY_PY_UERRNO
             // try to provide a nice OSError error message
-            if (o->base.type == &mp_type_OSError && MP_OBJ_IS_SMALL_INT(o->args->items[0])) {
+            if (o->base.type == &mp_type_OSError && mp_obj_is_small_int(o->args->items[0])) {
                 qstr qst = mp_errno_to_str(o->args->items[0]);
                 if (qst != MP_QSTR_NULL) {
                     mp_printf(print, "[Errno " INT_FMT "] %q", MP_OBJ_SMALL_INT_VALUE(o->args->items[0]), qst);
@@ -447,7 +447,7 @@ mp_obj_t mp_obj_new_exception_msg_varg(const mp_obj_type_t *exc_type, const char
 
 // return true if the given object is an exception type
 bool mp_obj_is_exception_type(mp_obj_t self_in) {
-    if (MP_OBJ_IS_TYPE(self_in, &mp_type_type)) {
+    if (mp_obj_is_type(self_in, &mp_type_type)) {
         // optimisation when self_in is a builtin exception
         mp_obj_type_t *self = MP_OBJ_TO_PTR(self_in);
         if (self->make_new == mp_obj_exception_make_new) {

--- a/py/objfilter.c
+++ b/py/objfilter.c
@@ -44,7 +44,7 @@ STATIC mp_obj_t filter_make_new(const mp_obj_type_t *type, size_t n_args, size_t
 }
 
 STATIC mp_obj_t filter_iternext(mp_obj_t self_in) {
-    mp_check_self(MP_OBJ_IS_TYPE(self_in, &mp_type_filter));
+    mp_check_self(mp_obj_is_type(self_in, &mp_type_filter));
     mp_obj_filter_t *self = MP_OBJ_TO_PTR(self_in);
     mp_obj_t next;
     while ((next = mp_iternext(self->iter)) != MP_OBJ_STOP_ITERATION) {

--- a/py/objfloat.c
+++ b/py/objfloat.c
@@ -174,7 +174,7 @@ STATIC mp_obj_t float_unary_op(mp_unary_op_t op, mp_obj_t o_in) {
 STATIC mp_obj_t float_binary_op(mp_binary_op_t op, mp_obj_t lhs_in, mp_obj_t rhs_in) {
     mp_float_t lhs_val = mp_obj_float_get(lhs_in);
 #if MICROPY_PY_BUILTINS_COMPLEX
-    if (MP_OBJ_IS_TYPE(rhs_in, &mp_type_complex)) {
+    if (mp_obj_is_type(rhs_in, &mp_type_complex)) {
         return mp_obj_complex_binary_op(op, lhs_val, 0, rhs_in);
     } else
 #endif

--- a/py/objfun.c
+++ b/py/objfun.c
@@ -50,7 +50,7 @@
 
 STATIC mp_obj_t fun_builtin_0_call(mp_obj_t self_in, size_t n_args, size_t n_kw, const mp_obj_t *args) {
     (void)args;
-    assert(MP_OBJ_IS_TYPE(self_in, &mp_type_fun_builtin_0));
+    assert(mp_obj_is_type(self_in, &mp_type_fun_builtin_0));
     mp_obj_fun_builtin_fixed_t *self = MP_OBJ_TO_PTR(self_in);
     mp_arg_check_num(n_args, n_kw, 0, 0, false);
     return self->fun._0();
@@ -64,7 +64,7 @@ const mp_obj_type_t mp_type_fun_builtin_0 = {
 };
 
 STATIC mp_obj_t fun_builtin_1_call(mp_obj_t self_in, size_t n_args, size_t n_kw, const mp_obj_t *args) {
-    assert(MP_OBJ_IS_TYPE(self_in, &mp_type_fun_builtin_1));
+    assert(mp_obj_is_type(self_in, &mp_type_fun_builtin_1));
     mp_obj_fun_builtin_fixed_t *self = MP_OBJ_TO_PTR(self_in);
     mp_arg_check_num(n_args, n_kw, 1, 1, false);
     return self->fun._1(args[0]);
@@ -78,7 +78,7 @@ const mp_obj_type_t mp_type_fun_builtin_1 = {
 };
 
 STATIC mp_obj_t fun_builtin_2_call(mp_obj_t self_in, size_t n_args, size_t n_kw, const mp_obj_t *args) {
-    assert(MP_OBJ_IS_TYPE(self_in, &mp_type_fun_builtin_2));
+    assert(mp_obj_is_type(self_in, &mp_type_fun_builtin_2));
     mp_obj_fun_builtin_fixed_t *self = MP_OBJ_TO_PTR(self_in);
     mp_arg_check_num(n_args, n_kw, 2, 2, false);
     return self->fun._2(args[0], args[1]);
@@ -92,7 +92,7 @@ const mp_obj_type_t mp_type_fun_builtin_2 = {
 };
 
 STATIC mp_obj_t fun_builtin_3_call(mp_obj_t self_in, size_t n_args, size_t n_kw, const mp_obj_t *args) {
-    assert(MP_OBJ_IS_TYPE(self_in, &mp_type_fun_builtin_3));
+    assert(mp_obj_is_type(self_in, &mp_type_fun_builtin_3));
     mp_obj_fun_builtin_fixed_t *self = MP_OBJ_TO_PTR(self_in);
     mp_arg_check_num(n_args, n_kw, 3, 3, false);
     return self->fun._3(args[0], args[1], args[2]);
@@ -106,7 +106,7 @@ const mp_obj_type_t mp_type_fun_builtin_3 = {
 };
 
 STATIC mp_obj_t fun_builtin_var_call(mp_obj_t self_in, size_t n_args, size_t n_kw, const mp_obj_t *args) {
-    assert(MP_OBJ_IS_TYPE(self_in, &mp_type_fun_builtin_var));
+    assert(mp_obj_is_type(self_in, &mp_type_fun_builtin_var));
     mp_obj_fun_builtin_var_t *self = MP_OBJ_TO_PTR(self_in);
 
     // check number of arguments
@@ -373,7 +373,7 @@ mp_obj_t mp_obj_new_fun_bc(mp_obj_t def_args_in, mp_obj_t def_kw_args, const byt
     size_t n_extra_args = 0;
     mp_obj_tuple_t *def_args = MP_OBJ_TO_PTR(def_args_in);
     if (def_args_in != MP_OBJ_NULL) {
-        assert(MP_OBJ_IS_TYPE(def_args_in, &mp_type_tuple));
+        assert(mp_obj_is_type(def_args_in, &mp_type_tuple));
         n_def_args = def_args->len;
         n_extra_args = def_args->len;
     }
@@ -442,7 +442,7 @@ typedef mp_uint_t (*inline_asm_fun_4_t)(mp_uint_t, mp_uint_t, mp_uint_t, mp_uint
 // convert a MicroPython object to a sensible value for inline asm
 STATIC mp_uint_t convert_obj_for_inline_asm(mp_obj_t obj) {
     // TODO for byte_array, pass pointer to the array
-    if (MP_OBJ_IS_SMALL_INT(obj)) {
+    if (mp_obj_is_small_int(obj)) {
         return MP_OBJ_SMALL_INT_VALUE(obj);
     } else if (obj == mp_const_none) {
         return 0;
@@ -450,9 +450,9 @@ STATIC mp_uint_t convert_obj_for_inline_asm(mp_obj_t obj) {
         return 0;
     } else if (obj == mp_const_true) {
         return 1;
-    } else if (MP_OBJ_IS_TYPE(obj, &mp_type_int)) {
+    } else if (mp_obj_is_type(obj, &mp_type_int)) {
         return mp_obj_int_get_truncated(obj);
-    } else if (MP_OBJ_IS_STR(obj)) {
+    } else if (mp_obj_is_str(obj)) {
         // pointer to the string (it's probably constant though!)
         size_t l;
         return (mp_uint_t)mp_obj_str_get_data(obj, &l);

--- a/py/objgenerator.c
+++ b/py/objgenerator.c
@@ -131,7 +131,7 @@ STATIC void gen_instance_print(const mp_print_t *print, mp_obj_t self_in, mp_pri
 
 mp_vm_return_kind_t mp_obj_gen_resume(mp_obj_t self_in, mp_obj_t send_value, mp_obj_t throw_value, mp_obj_t *ret_val) {
     MP_STACK_CHECK();
-    mp_check_self(MP_OBJ_IS_TYPE(self_in, &mp_type_gen_instance));
+    mp_check_self(mp_obj_is_type(self_in, &mp_type_gen_instance));
     mp_obj_gen_instance_t *self = MP_OBJ_TO_PTR(self_in);
     if (self->code_state.ip == 0) {
         // Trying to resume already stopped generator

--- a/py/objint.c
+++ b/py/objint.c
@@ -49,10 +49,10 @@ STATIC mp_obj_t mp_obj_int_make_new(const mp_obj_type_t *type_in, size_t n_args,
             return MP_OBJ_NEW_SMALL_INT(0);
 
         case 1:
-            if (MP_OBJ_IS_INT(args[0])) {
+            if (mp_obj_is_int(args[0])) {
                 // already an int (small or long), just return it
                 return args[0];
-            } else if (MP_OBJ_IS_STR_OR_BYTES(args[0])) {
+            } else if (mp_obj_is_str_or_bytes(args[0])) {
                 // a string, parse it
                 size_t l;
                 const char *s = mp_obj_str_get_data(args[0], &l);
@@ -224,11 +224,11 @@ char *mp_obj_int_formatted(char **buf, size_t *buf_size, size_t *fmt_size, mp_co
     // Only have small ints; get the integer value to format.
     num = MP_OBJ_SMALL_INT_VALUE(self_in);
     #else
-    if (MP_OBJ_IS_SMALL_INT(self_in)) {
+    if (mp_obj_is_small_int(self_in)) {
         // A small int; get the integer value to format.
         num = MP_OBJ_SMALL_INT_VALUE(self_in);
     } else {
-        assert(MP_OBJ_IS_TYPE(self_in, &mp_type_int));
+        assert(mp_obj_is_type(self_in, &mp_type_int));
         // Not a small int.
         #if MICROPY_LONGINT_IMPL == MICROPY_LONGINT_IMPL_LONGLONG
         const mp_obj_int_t *self = self_in;
@@ -375,7 +375,7 @@ mp_obj_t mp_obj_int_binary_op_extra_cases(mp_binary_op_t op, mp_obj_t lhs_in, mp
         // true acts as 0
         return mp_binary_op(op, lhs_in, MP_OBJ_NEW_SMALL_INT(1));
     } else if (op == MP_BINARY_OP_MULTIPLY) {
-        if (MP_OBJ_IS_STR_OR_BYTES(rhs_in) || MP_OBJ_IS_TYPE(rhs_in, &mp_type_tuple) || MP_OBJ_IS_TYPE(rhs_in, &mp_type_list)) {
+        if (mp_obj_is_str_or_bytes(rhs_in) || mp_obj_is_type(rhs_in, &mp_type_tuple) || mp_obj_is_type(rhs_in, &mp_type_list)) {
             // multiply is commutative for these types, so delegate to them
             return mp_binary_op(op, rhs_in, lhs_in);
         }
@@ -432,7 +432,7 @@ STATIC mp_obj_t int_to_bytes(size_t n_args, const mp_obj_t *args) {
     memset(data, 0, len);
 
     #if MICROPY_LONGINT_IMPL != MICROPY_LONGINT_IMPL_NONE
-    if (!MP_OBJ_IS_SMALL_INT(args[0])) {
+    if (!mp_obj_is_small_int(args[0])) {
         mp_obj_int_to_bytes_impl(args[0], big_endian, len, data);
     } else
     #endif

--- a/py/objint_longlong.c
+++ b/py/objint_longlong.c
@@ -58,7 +58,7 @@ mp_obj_t mp_obj_int_from_bytes_impl(bool big_endian, size_t len, const byte *buf
 }
 
 void mp_obj_int_to_bytes_impl(mp_obj_t self_in, bool big_endian, size_t len, byte *buf) {
-    assert(MP_OBJ_IS_TYPE(self_in, &mp_type_int));
+    assert(mp_obj_is_type(self_in, &mp_type_int));
     mp_obj_int_t *self = self_in;
     long long val = self->val;
     if (big_endian) {
@@ -77,7 +77,7 @@ void mp_obj_int_to_bytes_impl(mp_obj_t self_in, bool big_endian, size_t len, byt
 
 int mp_obj_int_sign(mp_obj_t self_in) {
     mp_longint_impl_t val;
-    if (MP_OBJ_IS_SMALL_INT(self_in)) {
+    if (mp_obj_is_small_int(self_in)) {
         val = MP_OBJ_SMALL_INT_VALUE(self_in);
     } else {
         mp_obj_int_t *self = self_in;
@@ -122,16 +122,16 @@ mp_obj_t mp_obj_int_binary_op(mp_binary_op_t op, mp_obj_t lhs_in, mp_obj_t rhs_i
     long long lhs_val;
     long long rhs_val;
 
-    if (MP_OBJ_IS_SMALL_INT(lhs_in)) {
+    if (mp_obj_is_small_int(lhs_in)) {
         lhs_val = MP_OBJ_SMALL_INT_VALUE(lhs_in);
     } else {
-        assert(MP_OBJ_IS_TYPE(lhs_in, &mp_type_int));
+        assert(mp_obj_is_type(lhs_in, &mp_type_int));
         lhs_val = ((mp_obj_int_t*)lhs_in)->val;
     }
 
-    if (MP_OBJ_IS_SMALL_INT(rhs_in)) {
+    if (mp_obj_is_small_int(rhs_in)) {
         rhs_val = MP_OBJ_SMALL_INT_VALUE(rhs_in);
-    } else if (MP_OBJ_IS_TYPE(rhs_in, &mp_type_int)) {
+    } else if (mp_obj_is_type(rhs_in, &mp_type_int)) {
         rhs_val = ((mp_obj_int_t*)rhs_in)->val;
     } else {
         // delegate to generic function to check for extra cases
@@ -266,7 +266,7 @@ mp_obj_t mp_obj_new_int_from_str_len(const char **str, size_t len, bool neg, uns
 }
 
 mp_int_t mp_obj_int_get_truncated(mp_const_obj_t self_in) {
-    if (MP_OBJ_IS_SMALL_INT(self_in)) {
+    if (mp_obj_is_small_int(self_in)) {
         return MP_OBJ_SMALL_INT_VALUE(self_in);
     } else {
         const mp_obj_int_t *self = self_in;
@@ -281,7 +281,7 @@ mp_int_t mp_obj_int_get_checked(mp_const_obj_t self_in) {
 
 #if MICROPY_PY_BUILTINS_FLOAT
 mp_float_t mp_obj_int_as_float_impl(mp_obj_t self_in) {
-    assert(MP_OBJ_IS_TYPE(self_in, &mp_type_int));
+    assert(mp_obj_is_type(self_in, &mp_type_int));
     mp_obj_int_t *self = self_in;
     return self->val;
 }

--- a/py/objint_mpz.c
+++ b/py/objint_mpz.c
@@ -90,7 +90,7 @@ mp_obj_int_t *mp_obj_int_new_mpz(void) {
 // This particular routine should only be called for the mpz representation of the int.
 char *mp_obj_int_formatted_impl(char **buf, size_t *buf_size, size_t *fmt_size, mp_const_obj_t self_in,
                                 int base, const char *prefix, char base_char, char comma) {
-    assert(MP_OBJ_IS_TYPE(self_in, &mp_type_int));
+    assert(mp_obj_is_type(self_in, &mp_type_int));
     const mp_obj_int_t *self = MP_OBJ_TO_PTR(self_in);
 
     size_t needed_size = mp_int_format_size(mpz_max_num_bits(&self->mpz), base, prefix, comma);
@@ -112,14 +112,14 @@ mp_obj_t mp_obj_int_from_bytes_impl(bool big_endian, size_t len, const byte *buf
 }
 
 void mp_obj_int_to_bytes_impl(mp_obj_t self_in, bool big_endian, size_t len, byte *buf) {
-    assert(MP_OBJ_IS_TYPE(self_in, &mp_type_int));
+    assert(mp_obj_is_type(self_in, &mp_type_int));
     mp_obj_int_t *self = MP_OBJ_TO_PTR(self_in);
     memset(buf, 0, len);
     mpz_as_bytes(&self->mpz, big_endian, len, buf);
 }
 
 int mp_obj_int_sign(mp_obj_t self_in) {
-    if (MP_OBJ_IS_SMALL_INT(self_in)) {
+    if (mp_obj_is_small_int(self_in)) {
         mp_int_t val = MP_OBJ_SMALL_INT_VALUE(self_in);
         if (val < 0) {
             return -1;
@@ -167,25 +167,25 @@ mp_obj_t mp_obj_int_binary_op(mp_binary_op_t op, mp_obj_t lhs_in, mp_obj_t rhs_i
     mpz_dig_t z_int_dig[MPZ_NUM_DIG_FOR_INT];
 
     // lhs could be a small int (eg small-int + mpz)
-    if (MP_OBJ_IS_SMALL_INT(lhs_in)) {
+    if (mp_obj_is_small_int(lhs_in)) {
         mpz_init_fixed_from_int(&z_int, z_int_dig, MPZ_NUM_DIG_FOR_INT, MP_OBJ_SMALL_INT_VALUE(lhs_in));
         zlhs = &z_int;
     } else {
-        assert(MP_OBJ_IS_TYPE(lhs_in, &mp_type_int));
+        assert(mp_obj_is_type(lhs_in, &mp_type_int));
         zlhs = &((mp_obj_int_t*)MP_OBJ_TO_PTR(lhs_in))->mpz;
     }
 
     // if rhs is small int, then lhs was not (otherwise mp_binary_op handles it)
-    if (MP_OBJ_IS_SMALL_INT(rhs_in)) {
+    if (mp_obj_is_small_int(rhs_in)) {
         mpz_init_fixed_from_int(&z_int, z_int_dig, MPZ_NUM_DIG_FOR_INT, MP_OBJ_SMALL_INT_VALUE(rhs_in));
         zrhs = &z_int;
-    } else if (MP_OBJ_IS_TYPE(rhs_in, &mp_type_int)) {
+    } else if (mp_obj_is_type(rhs_in, &mp_type_int)) {
         zrhs = &((mp_obj_int_t*)MP_OBJ_TO_PTR(rhs_in))->mpz;
 #if MICROPY_PY_BUILTINS_FLOAT
     } else if (mp_obj_is_float(rhs_in)) {
         return mp_obj_float_binary_op(op, mpz_as_float(zlhs), rhs_in);
 #if MICROPY_PY_BUILTINS_COMPLEX
-    } else if (MP_OBJ_IS_TYPE(rhs_in, &mp_type_complex)) {
+    } else if (mp_obj_is_type(rhs_in, &mp_type_complex)) {
         return mp_obj_complex_binary_op(op, mpz_as_float(zlhs), 0, rhs_in);
 #endif
 #endif
@@ -320,7 +320,7 @@ mp_obj_t mp_obj_int_binary_op(mp_binary_op_t op, mp_obj_t lhs_in, mp_obj_t rhs_i
 
 #if MICROPY_PY_BUILTINS_POW3
 STATIC mpz_t *mp_mpz_for_int(mp_obj_t arg, mpz_t *temp) {
-    if (MP_OBJ_IS_SMALL_INT(arg)) {
+    if (mp_obj_is_small_int(arg)) {
         mpz_init_from_int(temp, MP_OBJ_SMALL_INT_VALUE(arg));
         return temp;
     } else {
@@ -330,7 +330,7 @@ STATIC mpz_t *mp_mpz_for_int(mp_obj_t arg, mpz_t *temp) {
 }
 
 mp_obj_t mp_obj_int_pow3(mp_obj_t base, mp_obj_t exponent,  mp_obj_t modulus) {
-    if (!MP_OBJ_IS_INT(base) || !MP_OBJ_IS_INT(exponent) || !MP_OBJ_IS_INT(modulus)) {
+    if (!mp_obj_is_int(base) || !mp_obj_is_int(exponent) || !mp_obj_is_int(modulus)) {
         mp_raise_TypeError("pow() with 3 arguments requires integers");
     } else {
         mp_obj_t result = mp_obj_new_int_from_ull(0); // Use the _from_ull version as this forces an mpz int
@@ -387,7 +387,7 @@ mp_obj_t mp_obj_new_int_from_str_len(const char **str, size_t len, bool neg, uns
 }
 
 mp_int_t mp_obj_int_get_truncated(mp_const_obj_t self_in) {
-    if (MP_OBJ_IS_SMALL_INT(self_in)) {
+    if (mp_obj_is_small_int(self_in)) {
         return MP_OBJ_SMALL_INT_VALUE(self_in);
     } else {
         const mp_obj_int_t *self = MP_OBJ_TO_PTR(self_in);
@@ -397,7 +397,7 @@ mp_int_t mp_obj_int_get_truncated(mp_const_obj_t self_in) {
 }
 
 mp_int_t mp_obj_int_get_checked(mp_const_obj_t self_in) {
-    if (MP_OBJ_IS_SMALL_INT(self_in)) {
+    if (mp_obj_is_small_int(self_in)) {
         return MP_OBJ_SMALL_INT_VALUE(self_in);
     } else {
         const mp_obj_int_t *self = MP_OBJ_TO_PTR(self_in);
@@ -413,7 +413,7 @@ mp_int_t mp_obj_int_get_checked(mp_const_obj_t self_in) {
 
 #if MICROPY_PY_BUILTINS_FLOAT
 mp_float_t mp_obj_int_as_float_impl(mp_obj_t self_in) {
-    assert(MP_OBJ_IS_TYPE(self_in, &mp_type_int));
+    assert(mp_obj_is_type(self_in, &mp_type_int));
     mp_obj_int_t *self = MP_OBJ_TO_PTR(self_in);
     return mpz_as_float(&self->mpz);
 }

--- a/py/objlist.c
+++ b/py/objlist.c
@@ -104,7 +104,7 @@ STATIC mp_obj_t list_binary_op(mp_binary_op_t op, mp_obj_t lhs, mp_obj_t rhs) {
     mp_obj_list_t *o = MP_OBJ_TO_PTR(lhs);
     switch (op) {
         case MP_BINARY_OP_ADD: {
-            if (!MP_OBJ_IS_TYPE(rhs, &mp_type_list)) {
+            if (!mp_obj_is_type(rhs, &mp_type_list)) {
                 return MP_OBJ_NULL; // op not supported
             }
             mp_obj_list_t *p = MP_OBJ_TO_PTR(rhs);
@@ -133,7 +133,7 @@ STATIC mp_obj_t list_binary_op(mp_binary_op_t op, mp_obj_t lhs, mp_obj_t rhs) {
         case MP_BINARY_OP_LESS_EQUAL:
         case MP_BINARY_OP_MORE:
         case MP_BINARY_OP_MORE_EQUAL: {
-            if (!MP_OBJ_IS_TYPE(rhs, &mp_type_list)) {
+            if (!mp_obj_is_type(rhs, &mp_type_list)) {
                 if (op == MP_BINARY_OP_EQUAL) {
                     return mp_const_false;
                 }
@@ -154,7 +154,7 @@ STATIC mp_obj_t list_subscr(mp_obj_t self_in, mp_obj_t index, mp_obj_t value) {
     if (value == MP_OBJ_NULL) {
         // delete
 #if MICROPY_PY_BUILTINS_SLICE
-        if (MP_OBJ_IS_TYPE(index, &mp_type_slice)) {
+        if (mp_obj_is_type(index, &mp_type_slice)) {
             mp_obj_list_t *self = MP_OBJ_TO_PTR(self_in);
             mp_bound_slice_t slice;
             if (!mp_seq_get_fast_slice_indexes(self->len, index, &slice)) {
@@ -178,7 +178,7 @@ STATIC mp_obj_t list_subscr(mp_obj_t self_in, mp_obj_t index, mp_obj_t value) {
         // load
         mp_obj_list_t *self = MP_OBJ_TO_PTR(self_in);
 #if MICROPY_PY_BUILTINS_SLICE
-        if (MP_OBJ_IS_TYPE(index, &mp_type_slice)) {
+        if (mp_obj_is_type(index, &mp_type_slice)) {
             mp_bound_slice_t slice;
             if (!mp_seq_get_fast_slice_indexes(self->len, index, &slice)) {
                 return mp_seq_extract_slice(self->len, self->items, &slice);
@@ -192,7 +192,7 @@ STATIC mp_obj_t list_subscr(mp_obj_t self_in, mp_obj_t index, mp_obj_t value) {
         return self->items[index_val];
     } else {
 #if MICROPY_PY_BUILTINS_SLICE
-        if (MP_OBJ_IS_TYPE(index, &mp_type_slice)) {
+        if (mp_obj_is_type(index, &mp_type_slice)) {
             mp_obj_list_t *self = MP_OBJ_TO_PTR(self_in);
             size_t value_len; mp_obj_t *value_items;
             mp_obj_get_array(value, &value_len, &value_items);
@@ -232,7 +232,7 @@ STATIC mp_obj_t list_getiter(mp_obj_t o_in, mp_obj_iter_buf_t *iter_buf) {
 }
 
 mp_obj_t mp_obj_list_append(mp_obj_t self_in, mp_obj_t arg) {
-    mp_check_self(MP_OBJ_IS_TYPE(self_in, &mp_type_list));
+    mp_check_self(mp_obj_is_type(self_in, &mp_type_list));
     mp_obj_list_t *self = MP_OBJ_TO_PTR(self_in);
     if (self->len >= self->alloc) {
         self->items = m_renew(mp_obj_t, self->items, self->alloc, self->alloc * 2);
@@ -244,8 +244,8 @@ mp_obj_t mp_obj_list_append(mp_obj_t self_in, mp_obj_t arg) {
 }
 
 STATIC mp_obj_t list_extend(mp_obj_t self_in, mp_obj_t arg_in) {
-    mp_check_self(MP_OBJ_IS_TYPE(self_in, &mp_type_list));
-    if (MP_OBJ_IS_TYPE(arg_in, &mp_type_list)) {
+    mp_check_self(mp_obj_is_type(self_in, &mp_type_list));
+    if (mp_obj_is_type(arg_in, &mp_type_list)) {
         mp_obj_list_t *self = MP_OBJ_TO_PTR(self_in);
         mp_obj_list_t *arg = MP_OBJ_TO_PTR(arg_in);
 
@@ -265,7 +265,7 @@ STATIC mp_obj_t list_extend(mp_obj_t self_in, mp_obj_t arg_in) {
 }
 
 STATIC mp_obj_t list_pop(size_t n_args, const mp_obj_t *args) {
-    mp_check_self(MP_OBJ_IS_TYPE(args[0], &mp_type_list));
+    mp_check_self(mp_obj_is_type(args[0], &mp_type_list));
     mp_obj_list_t *self = MP_OBJ_TO_PTR(args[0]);
     if (self->len == 0) {
         mp_raise_msg(&mp_type_IndexError, "pop from empty list");
@@ -325,7 +325,7 @@ mp_obj_t mp_obj_list_sort(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_
     mp_arg_parse_all(n_args - 1, pos_args + 1, kw_args,
         MP_ARRAY_SIZE(allowed_args), allowed_args, (mp_arg_val_t*)&args);
 
-    mp_check_self(MP_OBJ_IS_TYPE(pos_args[0], &mp_type_list));
+    mp_check_self(mp_obj_is_type(pos_args[0], &mp_type_list));
     mp_obj_list_t *self = MP_OBJ_TO_PTR(pos_args[0]);
 
     if (self->len > 1) {
@@ -338,7 +338,7 @@ mp_obj_t mp_obj_list_sort(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_
 }
 
 STATIC mp_obj_t list_clear(mp_obj_t self_in) {
-    mp_check_self(MP_OBJ_IS_TYPE(self_in, &mp_type_list));
+    mp_check_self(mp_obj_is_type(self_in, &mp_type_list));
     mp_obj_list_t *self = MP_OBJ_TO_PTR(self_in);
     self->len = 0;
     self->items = m_renew(mp_obj_t, self->items, self->alloc, LIST_MIN_ALLOC);
@@ -348,25 +348,25 @@ STATIC mp_obj_t list_clear(mp_obj_t self_in) {
 }
 
 STATIC mp_obj_t list_copy(mp_obj_t self_in) {
-    mp_check_self(MP_OBJ_IS_TYPE(self_in, &mp_type_list));
+    mp_check_self(mp_obj_is_type(self_in, &mp_type_list));
     mp_obj_list_t *self = MP_OBJ_TO_PTR(self_in);
     return mp_obj_new_list(self->len, self->items);
 }
 
 STATIC mp_obj_t list_count(mp_obj_t self_in, mp_obj_t value) {
-    mp_check_self(MP_OBJ_IS_TYPE(self_in, &mp_type_list));
+    mp_check_self(mp_obj_is_type(self_in, &mp_type_list));
     mp_obj_list_t *self = MP_OBJ_TO_PTR(self_in);
     return mp_seq_count_obj(self->items, self->len, value);
 }
 
 STATIC mp_obj_t list_index(size_t n_args, const mp_obj_t *args) {
-    mp_check_self(MP_OBJ_IS_TYPE(args[0], &mp_type_list));
+    mp_check_self(mp_obj_is_type(args[0], &mp_type_list));
     mp_obj_list_t *self = MP_OBJ_TO_PTR(args[0]);
     return mp_seq_index_obj(self->items, self->len, n_args, args);
 }
 
 STATIC mp_obj_t list_insert(mp_obj_t self_in, mp_obj_t idx, mp_obj_t obj) {
-    mp_check_self(MP_OBJ_IS_TYPE(self_in, &mp_type_list));
+    mp_check_self(mp_obj_is_type(self_in, &mp_type_list));
     mp_obj_list_t *self = MP_OBJ_TO_PTR(self_in);
     // insert has its own strange index logic
     mp_int_t index = MP_OBJ_SMALL_INT_VALUE(idx);
@@ -391,7 +391,7 @@ STATIC mp_obj_t list_insert(mp_obj_t self_in, mp_obj_t idx, mp_obj_t obj) {
 }
 
 mp_obj_t mp_obj_list_remove(mp_obj_t self_in, mp_obj_t value) {
-    mp_check_self(MP_OBJ_IS_TYPE(self_in, &mp_type_list));
+    mp_check_self(mp_obj_is_type(self_in, &mp_type_list));
     mp_obj_t args[] = {self_in, value};
     args[1] = list_index(2, args);
     list_pop(2, args);
@@ -400,7 +400,7 @@ mp_obj_t mp_obj_list_remove(mp_obj_t self_in, mp_obj_t value) {
 }
 
 STATIC mp_obj_t list_reverse(mp_obj_t self_in) {
-    mp_check_self(MP_OBJ_IS_TYPE(self_in, &mp_type_list));
+    mp_check_self(mp_obj_is_type(self_in, &mp_type_list));
     mp_obj_list_t *self = MP_OBJ_TO_PTR(self_in);
 
     mp_int_t len = self->len;

--- a/py/objmap.c
+++ b/py/objmap.c
@@ -49,7 +49,7 @@ STATIC mp_obj_t map_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_
 }
 
 STATIC mp_obj_t map_iternext(mp_obj_t self_in) {
-    mp_check_self(MP_OBJ_IS_TYPE(self_in, &mp_type_map));
+    mp_check_self(mp_obj_is_type(self_in, &mp_type_map));
     mp_obj_map_t *self = MP_OBJ_TO_PTR(self_in);
     mp_obj_t *nextses = m_new(mp_obj_t, self->n_iters);
 

--- a/py/objnamedtuple.c
+++ b/py/objnamedtuple.c
@@ -172,7 +172,7 @@ STATIC mp_obj_t new_namedtuple_type(mp_obj_t name_in, mp_obj_t fields_in) {
     size_t n_fields;
     mp_obj_t *fields;
     #if MICROPY_CPYTHON_COMPAT
-    if (MP_OBJ_IS_STR(fields_in)) {
+    if (mp_obj_is_str(fields_in)) {
         fields_in = mp_obj_str_split(1, &fields_in);
     }
     #endif

--- a/py/objobject.c
+++ b/py/objobject.c
@@ -49,7 +49,7 @@ STATIC mp_obj_t object___init__(mp_obj_t self) {
 STATIC MP_DEFINE_CONST_FUN_OBJ_1(object___init___obj, object___init__);
 
 STATIC mp_obj_t object___new__(mp_obj_t cls) {
-    if (!MP_OBJ_IS_TYPE(cls, &mp_type_type) || !mp_obj_is_instance_type((mp_obj_type_t*)MP_OBJ_TO_PTR(cls))) {
+    if (!mp_obj_is_type(cls, &mp_type_type) || !mp_obj_is_instance_type((mp_obj_type_t*)MP_OBJ_TO_PTR(cls))) {
         mp_raise_TypeError("__new__ arg must be a user-type");
     }
     // This executes only "__new__" part of instance creation.

--- a/py/objproperty.c
+++ b/py/objproperty.c
@@ -99,7 +99,7 @@ const mp_obj_type_t mp_type_property = {
 };
 
 const mp_obj_t *mp_obj_property_get(mp_obj_t self_in) {
-    mp_check_self(MP_OBJ_IS_TYPE(self_in, &mp_type_property));
+    mp_check_self(mp_obj_is_type(self_in, &mp_type_property));
     mp_obj_property_t *self = MP_OBJ_TO_PTR(self_in);
     return self->proxy;
 }

--- a/py/objrange.c
+++ b/py/objrange.c
@@ -140,7 +140,7 @@ STATIC mp_obj_t range_unary_op(mp_unary_op_t op, mp_obj_t self_in) {
 
 #if MICROPY_PY_BUILTINS_RANGE_BINOP
 STATIC mp_obj_t range_binary_op(mp_binary_op_t op, mp_obj_t lhs_in, mp_obj_t rhs_in) {
-    if (!MP_OBJ_IS_TYPE(rhs_in, &mp_type_range) || op != MP_BINARY_OP_EQUAL) {
+    if (!mp_obj_is_type(rhs_in, &mp_type_range) || op != MP_BINARY_OP_EQUAL) {
         return MP_OBJ_NULL; // op not supported
     }
     mp_obj_range_t *lhs = MP_OBJ_TO_PTR(lhs_in);
@@ -162,7 +162,7 @@ STATIC mp_obj_t range_subscr(mp_obj_t self_in, mp_obj_t index, mp_obj_t value) {
         mp_obj_range_t *self = MP_OBJ_TO_PTR(self_in);
         mp_int_t len = range_len(self);
 #if MICROPY_PY_BUILTINS_SLICE
-        if (MP_OBJ_IS_TYPE(index, &mp_type_slice)) {
+        if (mp_obj_is_type(index, &mp_type_slice)) {
             mp_bound_slice_t slice;
             mp_seq_get_fast_slice_indexes(len, index, &slice);
             mp_obj_range_t *o = m_new_obj(mp_obj_range_t);

--- a/py/objreversed.c
+++ b/py/objreversed.c
@@ -56,7 +56,7 @@ STATIC mp_obj_t reversed_make_new(const mp_obj_type_t *type, size_t n_args, size
 }
 
 STATIC mp_obj_t reversed_iternext(mp_obj_t self_in) {
-    mp_check_self(MP_OBJ_IS_TYPE(self_in, &mp_type_reversed));
+    mp_check_self(mp_obj_is_type(self_in, &mp_type_reversed));
     mp_obj_reversed_t *self = MP_OBJ_TO_PTR(self_in);
 
     // "raise" stop iteration if we are at the end (the start) of the sequence

--- a/py/objset.c
+++ b/py/objset.c
@@ -48,15 +48,15 @@ typedef struct _mp_obj_set_it_t {
 STATIC mp_obj_t set_it_iternext(mp_obj_t self_in);
 
 STATIC bool is_set_or_frozenset(mp_obj_t o) {
-    return MP_OBJ_IS_TYPE(o, &mp_type_set)
+    return mp_obj_is_type(o, &mp_type_set)
 #if MICROPY_PY_BUILTINS_FROZENSET
-        || MP_OBJ_IS_TYPE(o, &mp_type_frozenset)
+        || mp_obj_is_type(o, &mp_type_frozenset)
 #endif
     ;
 }
 
 // This macro is shorthand for mp_check_self to verify the argument is a set.
-#define check_set(o) mp_check_self(MP_OBJ_IS_TYPE(o, &mp_type_set))
+#define check_set(o) mp_check_self(mp_obj_is_type(o, &mp_type_set))
 
 // This macro is shorthand for mp_check_self to verify the argument is a
 // set or frozenset for methods that operate on both of these types.
@@ -66,7 +66,7 @@ STATIC void set_print(const mp_print_t *print, mp_obj_t self_in, mp_print_kind_t
     (void)kind;
     mp_obj_set_t *self = MP_OBJ_TO_PTR(self_in);
     #if MICROPY_PY_BUILTINS_FROZENSET
-    bool is_frozen = MP_OBJ_IS_TYPE(self_in, &mp_type_frozenset);
+    bool is_frozen = mp_obj_is_type(self_in, &mp_type_frozenset);
     #endif
     if (self->set.used == 0) {
         #if MICROPY_PY_BUILTINS_FROZENSET
@@ -434,7 +434,7 @@ STATIC mp_obj_t set_unary_op(mp_unary_op_t op, mp_obj_t self_in) {
         case MP_UNARY_OP_LEN: return MP_OBJ_NEW_SMALL_INT(self->set.used);
 #if MICROPY_PY_BUILTINS_FROZENSET
         case MP_UNARY_OP_HASH:
-            if (MP_OBJ_IS_TYPE(self_in, &mp_type_frozenset)) {
+            if (mp_obj_is_type(self_in, &mp_type_frozenset)) {
                 // start hash with unique value
                 mp_int_t hash = (mp_int_t)(uintptr_t)&mp_type_frozenset;
                 size_t max = self->set.alloc;
@@ -455,7 +455,7 @@ STATIC mp_obj_t set_unary_op(mp_unary_op_t op, mp_obj_t self_in) {
 STATIC mp_obj_t set_binary_op(mp_binary_op_t op, mp_obj_t lhs, mp_obj_t rhs) {
     mp_obj_t args[] = {lhs, rhs};
     #if MICROPY_PY_BUILTINS_FROZENSET
-    bool update = MP_OBJ_IS_TYPE(lhs, &mp_type_set);
+    bool update = mp_obj_is_type(lhs, &mp_type_set);
     #else
     bool update = true;
     #endif
@@ -590,7 +590,7 @@ mp_obj_t mp_obj_new_set(size_t n_args, mp_obj_t *items) {
 }
 
 void mp_obj_set_store(mp_obj_t self_in, mp_obj_t item) {
-    mp_check_self(MP_OBJ_IS_TYPE(self_in, &mp_type_set));
+    mp_check_self(mp_obj_is_type(self_in, &mp_type_set));
     mp_obj_set_t *self = MP_OBJ_TO_PTR(self_in);
     mp_set_lookup(&self->set, item, MP_MAP_LOOKUP_ADD_IF_NOT_FOUND);
 }

--- a/py/objset.c
+++ b/py/objset.c
@@ -85,7 +85,7 @@ STATIC void set_print(const mp_print_t *print, mp_obj_t self_in, mp_print_kind_t
     #endif
     mp_print_str(print, "{");
     for (size_t i = 0; i < self->set.alloc; i++) {
-        if (MP_SET_SLOT_IS_FILLED(&self->set, i)) {
+        if (mp_set_slot_is_filled(&self->set, i)) {
             if (!first) {
                 mp_print_str(print, ", ");
             }
@@ -135,7 +135,7 @@ STATIC mp_obj_t set_it_iternext(mp_obj_t self_in) {
     mp_set_t *set = &self->set->set;
 
     for (size_t i = self->cur; i < max; i++) {
-        if (MP_SET_SLOT_IS_FILLED(set, i)) {
+        if (mp_set_slot_is_filled(set, i)) {
             self->cur = i + 1;
             return set->table[i];
         }
@@ -441,7 +441,7 @@ STATIC mp_obj_t set_unary_op(mp_unary_op_t op, mp_obj_t self_in) {
                 mp_set_t *set = &self->set;
 
                 for (size_t i = 0; i < max; i++) {
-                    if (MP_SET_SLOT_IS_FILLED(set, i)) {
+                    if (mp_set_slot_is_filled(set, i)) {
                         hash += MP_OBJ_SMALL_INT_VALUE(mp_unary_op(MP_UNARY_OP_HASH, set->table[i]));
                     }
                 }

--- a/py/objslice.c
+++ b/py/objslice.c
@@ -89,7 +89,7 @@ mp_obj_t mp_obj_new_slice(mp_obj_t ostart, mp_obj_t ostop, mp_obj_t ostep) {
 }
 
 void mp_obj_slice_get(mp_obj_t self_in, mp_obj_t *start, mp_obj_t *stop, mp_obj_t *step) {
-    assert(MP_OBJ_IS_TYPE(self_in, &mp_type_slice));
+    assert(mp_obj_is_type(self_in, &mp_type_slice));
     mp_obj_slice_t *self = MP_OBJ_TO_PTR(self_in);
     *start = self->start;
     *stop = self->stop;

--- a/py/objstr.c
+++ b/py/objstr.c
@@ -118,7 +118,7 @@ STATIC void str_print(const mp_print_t *print, mp_obj_t self_in, mp_print_kind_t
     }
     #endif
     #if !MICROPY_PY_BUILTINS_STR_UNICODE
-    bool is_bytes = MP_OBJ_IS_TYPE(self_in, &mp_type_bytes);
+    bool is_bytes = mp_obj_is_type(self_in, &mp_type_bytes);
     #else
     bool is_bytes = true;
     #endif
@@ -155,7 +155,7 @@ mp_obj_t mp_obj_str_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_
 
         default: // 2 or 3 args
             // TODO: validate 2nd/3rd args
-            if (MP_OBJ_IS_TYPE(args[0], &mp_type_bytes)) {
+            if (mp_obj_is_type(args[0], &mp_type_bytes)) {
                 GET_STR_DATA_LEN(args[0], str_data, str_len);
                 GET_STR_HASH(args[0], str_hash);
                 if (str_hash == 0) {
@@ -205,7 +205,7 @@ STATIC mp_obj_t bytes_make_new(const mp_obj_type_t *type_in, size_t n_args, size
         return mp_const_empty_bytes;
     }
 
-    if (MP_OBJ_IS_STR(args[0])) {
+    if (mp_obj_is_str(args[0])) {
         if (n_args < 2 || n_args > 3) {
             goto wrong_args;
         }
@@ -224,7 +224,7 @@ STATIC mp_obj_t bytes_make_new(const mp_obj_type_t *type_in, size_t n_args, size
         goto wrong_args;
     }
 
-    if (MP_OBJ_IS_SMALL_INT(args[0])) {
+    if (mp_obj_is_small_int(args[0])) {
         mp_int_t len = MP_OBJ_SMALL_INT_VALUE(args[0]);
         if (len < 0) {
             mp_raise_ValueError(NULL);
@@ -299,7 +299,7 @@ const byte *find_subbytes(const byte *haystack, size_t hlen, const byte *needle,
 
 // Note: this function is used to check if an object is a str or bytes, which
 // works because both those types use it as their binary_op method.  Revisit
-// MP_OBJ_IS_STR_OR_BYTES if this fact changes.
+// mp_obj_is_str_or_bytes if this fact changes.
 mp_obj_t mp_obj_str_binary_op(mp_binary_op_t op, mp_obj_t lhs_in, mp_obj_t rhs_in) {
     // check for modulo
     if (op == MP_BINARY_OP_MODULO) {
@@ -307,10 +307,10 @@ mp_obj_t mp_obj_str_binary_op(mp_binary_op_t op, mp_obj_t lhs_in, mp_obj_t rhs_i
         mp_obj_t *args = &rhs_in;
         size_t n_args = 1;
         mp_obj_t dict = MP_OBJ_NULL;
-        if (MP_OBJ_IS_TYPE(rhs_in, &mp_type_tuple)) {
+        if (mp_obj_is_type(rhs_in, &mp_type_tuple)) {
             // TODO: Support tuple subclasses?
             mp_obj_tuple_get(rhs_in, &n_args, &args);
-        } else if (MP_OBJ_IS_TYPE(rhs_in, &mp_type_dict)) {
+        } else if (mp_obj_is_type(rhs_in, &mp_type_dict)) {
             dict = rhs_in;
         }
         return str_modulo_format(lhs_in, n_args, args, dict);
@@ -425,7 +425,7 @@ STATIC mp_obj_t bytes_subscr(mp_obj_t self_in, mp_obj_t index, mp_obj_t value) {
     if (value == MP_OBJ_SENTINEL) {
         // load
 #if MICROPY_PY_BUILTINS_SLICE
-        if (MP_OBJ_IS_TYPE(index, &mp_type_slice)) {
+        if (mp_obj_is_type(index, &mp_type_slice)) {
             mp_bound_slice_t slice;
             if (!mp_seq_get_fast_slice_indexes(self_len, index, &slice)) {
                 mp_raise_NotImplementedError("only slices with step=1 (aka None) are supported");
@@ -446,7 +446,7 @@ STATIC mp_obj_t bytes_subscr(mp_obj_t self_in, mp_obj_t index, mp_obj_t value) {
 }
 
 STATIC mp_obj_t str_join(mp_obj_t self_in, mp_obj_t arg) {
-    mp_check_self(MP_OBJ_IS_STR_OR_BYTES(self_in));
+    mp_check_self(mp_obj_is_str_or_bytes(self_in));
     const mp_obj_type_t *self_type = mp_obj_get_type(self_in);
 
     // get separation string
@@ -456,7 +456,7 @@ STATIC mp_obj_t str_join(mp_obj_t self_in, mp_obj_t arg) {
     size_t seq_len;
     mp_obj_t *seq_items;
 
-    if (!MP_OBJ_IS_TYPE(arg, &mp_type_list) && !MP_OBJ_IS_TYPE(arg, &mp_type_tuple)) {
+    if (!mp_obj_is_type(arg, &mp_type_list) && !mp_obj_is_type(arg, &mp_type_tuple)) {
         // arg is not a list nor a tuple, try to convert it to a list
         // TODO: Try to optimize?
         arg = mp_type_list.make_new(&mp_type_list, 1, 0, &arg);
@@ -686,7 +686,7 @@ MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(str_rsplit_obj, 1, 3, str_rsplit);
 
 STATIC mp_obj_t str_finder(size_t n_args, const mp_obj_t *args, int direction, bool is_index) {
     const mp_obj_type_t *self_type = mp_obj_get_type(args[0]);
-    mp_check_self(MP_OBJ_IS_STR_OR_BYTES(args[0]));
+    mp_check_self(mp_obj_is_str_or_bytes(args[0]));
 
     // check argument type
     if (mp_obj_get_type(args[1]) != self_type) {
@@ -784,7 +784,7 @@ MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(str_endswith_obj, 2, 3, str_endswith);
 enum { LSTRIP, RSTRIP, STRIP };
 
 STATIC mp_obj_t str_uni_strip(int type, size_t n_args, const mp_obj_t *args) {
-    mp_check_self(MP_OBJ_IS_STR_OR_BYTES(args[0]));
+    mp_check_self(mp_obj_is_str_or_bytes(args[0]));
     const mp_obj_type_t *self_type = mp_obj_get_type(args[0]);
 
     const byte *chars_to_del;
@@ -910,7 +910,7 @@ STATIC bool istype(char ch) {
 }
 
 STATIC bool arg_looks_integer(mp_obj_t arg) {
-    return MP_OBJ_IS_TYPE(arg, &mp_type_bool) || MP_OBJ_IS_INT(arg);
+    return mp_obj_is_type(arg, &mp_type_bool) || mp_obj_is_int(arg);
 }
 
 STATIC bool arg_looks_numeric(mp_obj_t arg) {
@@ -1382,7 +1382,7 @@ STATIC vstr_t mp_obj_str_format_helper(const char *str, const char *top, int *ar
 }
 
 mp_obj_t mp_obj_str_format(size_t n_args, const mp_obj_t *args, mp_map_t *kwargs) {
-    mp_check_self(MP_OBJ_IS_STR_OR_BYTES(args[0]));
+    mp_check_self(mp_obj_is_str_or_bytes(args[0]));
 
     GET_STR_DATA_LEN(args[0], str, len);
     int arg_i = 0;
@@ -1393,11 +1393,11 @@ MP_DEFINE_CONST_FUN_OBJ_KW(str_format_obj, 1, mp_obj_str_format);
 
 #if MICROPY_PY_BUILTINS_STR_OP_MODULO
 STATIC mp_obj_t str_modulo_format(mp_obj_t pattern, size_t n_args, const mp_obj_t *args, mp_obj_t dict) {
-    mp_check_self(MP_OBJ_IS_STR_OR_BYTES(pattern));
+    mp_check_self(mp_obj_is_str_or_bytes(pattern));
 
     GET_STR_DATA_LEN(pattern, str, len);
     const byte *start_str = str;
-    bool is_bytes = MP_OBJ_IS_TYPE(pattern, &mp_type_bytes);
+    bool is_bytes = mp_obj_is_type(pattern, &mp_type_bytes);
     size_t arg_i = 0;
     vstr_t vstr;
     mp_print_t print;
@@ -1501,7 +1501,7 @@ not_enough_args:
         }
         switch (*str) {
             case 'c':
-                if (MP_OBJ_IS_STR(arg)) {
+                if (mp_obj_is_str(arg)) {
                     size_t slen;
                     const char *s = mp_obj_str_get_data(arg, &slen);
                     if (slen != 1) {
@@ -1547,7 +1547,7 @@ not_enough_args:
                 mp_print_t arg_print;
                 vstr_init_print(&arg_vstr, 16, &arg_print);
                 mp_print_kind_t print_kind = (*str == 'r' ? PRINT_REPR : PRINT_STR);
-                if (print_kind == PRINT_STR && is_bytes && MP_OBJ_IS_TYPE(arg, &mp_type_bytes)) {
+                if (print_kind == PRINT_STR && is_bytes && mp_obj_is_type(arg, &mp_type_bytes)) {
                     // If we have something like b"%s" % b"1", bytes arg should be
                     // printed undecorated.
                     print_kind = PRINT_RAW;
@@ -1592,7 +1592,7 @@ not_enough_args:
 // The implementation is optimized, returning the original string if there's
 // nothing to replace.
 STATIC mp_obj_t str_replace(size_t n_args, const mp_obj_t *args) {
-    mp_check_self(MP_OBJ_IS_STR_OR_BYTES(args[0]));
+    mp_check_self(mp_obj_is_str_or_bytes(args[0]));
 
     mp_int_t max_rep = -1;
     if (n_args == 4) {
@@ -1700,7 +1700,7 @@ MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(str_replace_obj, 3, 4, str_replace);
 #if MICROPY_PY_BUILTINS_STR_COUNT
 STATIC mp_obj_t str_count(size_t n_args, const mp_obj_t *args) {
     const mp_obj_type_t *self_type = mp_obj_get_type(args[0]);
-    mp_check_self(MP_OBJ_IS_STR_OR_BYTES(args[0]));
+    mp_check_self(mp_obj_is_str_or_bytes(args[0]));
 
     // check argument type
     if (mp_obj_get_type(args[1]) != self_type) {
@@ -1742,7 +1742,7 @@ MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(str_count_obj, 2, 4, str_count);
 
 #if MICROPY_PY_BUILTINS_STR_PARTITION
 STATIC mp_obj_t str_partitioner(mp_obj_t self_in, mp_obj_t arg, int direction) {
-    mp_check_self(MP_OBJ_IS_STR_OR_BYTES(self_in));
+    mp_check_self(mp_obj_is_str_or_bytes(self_in));
     mp_obj_type_t *self_type = mp_obj_get_type(self_in);
     if (self_type != mp_obj_get_type(arg)) {
         bad_implicit_conversion(arg);
@@ -2092,7 +2092,7 @@ mp_obj_t mp_obj_new_bytes(const byte* data, size_t len) {
 }
 
 bool mp_obj_str_equal(mp_obj_t s1, mp_obj_t s2) {
-    if (MP_OBJ_IS_QSTR(s1) && MP_OBJ_IS_QSTR(s2)) {
+    if (mp_obj_is_qstr(s1) && mp_obj_is_qstr(s2)) {
         return s1 == s2;
     } else {
         GET_STR_HASH(s1, h1);
@@ -2124,9 +2124,9 @@ STATIC NORETURN void bad_implicit_conversion(mp_obj_t self_in) {
 // use this if you will anyway convert the string to a qstr
 // will be more efficient for the case where it's already a qstr
 qstr mp_obj_str_get_qstr(mp_obj_t self_in) {
-    if (MP_OBJ_IS_QSTR(self_in)) {
+    if (mp_obj_is_qstr(self_in)) {
         return MP_OBJ_QSTR_VALUE(self_in);
-    } else if (MP_OBJ_IS_TYPE(self_in, &mp_type_str)) {
+    } else if (mp_obj_is_type(self_in, &mp_type_str)) {
         mp_obj_str_t *self = MP_OBJ_TO_PTR(self_in);
         return qstr_from_strn((char*)self->data, self->len);
     } else {
@@ -2137,7 +2137,7 @@ qstr mp_obj_str_get_qstr(mp_obj_t self_in) {
 // only use this function if you need the str data to be zero terminated
 // at the moment all strings are zero terminated to help with C ASCIIZ compatibility
 const char *mp_obj_str_get_str(mp_obj_t self_in) {
-    if (MP_OBJ_IS_STR_OR_BYTES(self_in)) {
+    if (mp_obj_is_str_or_bytes(self_in)) {
         GET_STR_DATA_LEN(self_in, s, l);
         (void)l; // len unused
         return (const char*)s;
@@ -2147,7 +2147,7 @@ const char *mp_obj_str_get_str(mp_obj_t self_in) {
 }
 
 const char *mp_obj_str_get_data(mp_obj_t self_in, size_t *len) {
-    if (MP_OBJ_IS_STR_OR_BYTES(self_in)) {
+    if (mp_obj_is_str_or_bytes(self_in)) {
         GET_STR_DATA_LEN(self_in, s, l);
         *len = l;
         return (const char*)s;
@@ -2158,7 +2158,7 @@ const char *mp_obj_str_get_data(mp_obj_t self_in, size_t *len) {
 
 #if MICROPY_OBJ_REPR == MICROPY_OBJ_REPR_C
 const byte *mp_obj_str_get_data_no_check(mp_obj_t self_in, size_t *len) {
-    if (MP_OBJ_IS_QSTR(self_in)) {
+    if (mp_obj_is_qstr(self_in)) {
         return qstr_data(MP_OBJ_QSTR_VALUE(self_in), len);
     } else {
         *len = ((mp_obj_str_t*)self_in)->len;

--- a/py/objstr.h
+++ b/py/objstr.h
@@ -41,12 +41,12 @@ typedef struct _mp_obj_str_t {
 // use this macro to extract the string hash
 // warning: the hash can be 0, meaning invalid, and must then be explicitly computed from the data
 #define GET_STR_HASH(str_obj_in, str_hash) \
-    mp_uint_t str_hash; if (MP_OBJ_IS_QSTR(str_obj_in)) \
+    mp_uint_t str_hash; if (mp_obj_is_qstr(str_obj_in)) \
     { str_hash = qstr_hash(MP_OBJ_QSTR_VALUE(str_obj_in)); } else { str_hash = ((mp_obj_str_t*)MP_OBJ_TO_PTR(str_obj_in))->hash; }
 
 // use this macro to extract the string length
 #define GET_STR_LEN(str_obj_in, str_len) \
-    size_t str_len; if (MP_OBJ_IS_QSTR(str_obj_in)) \
+    size_t str_len; if (mp_obj_is_qstr(str_obj_in)) \
     { str_len = qstr_len(MP_OBJ_QSTR_VALUE(str_obj_in)); } else { str_len = ((mp_obj_str_t*)MP_OBJ_TO_PTR(str_obj_in))->len; }
 
 // use this macro to extract the string data and length
@@ -56,7 +56,7 @@ const byte *mp_obj_str_get_data_no_check(mp_obj_t self_in, size_t *len);
     size_t str_len; const byte *str_data = mp_obj_str_get_data_no_check(str_obj_in, &str_len);
 #else
 #define GET_STR_DATA_LEN(str_obj_in, str_data, str_len) \
-    const byte *str_data; size_t str_len; if (MP_OBJ_IS_QSTR(str_obj_in)) \
+    const byte *str_data; size_t str_len; if (mp_obj_is_qstr(str_obj_in)) \
     { str_data = qstr_data(MP_OBJ_QSTR_VALUE(str_obj_in), &str_len); } \
     else { str_len = ((mp_obj_str_t*)MP_OBJ_TO_PTR(str_obj_in))->len; str_data = ((mp_obj_str_t*)MP_OBJ_TO_PTR(str_obj_in))->data; }
 #endif

--- a/py/objstringio.c
+++ b/py/objstringio.c
@@ -194,12 +194,12 @@ STATIC mp_obj_t stringio_make_new(const mp_obj_type_t *type_in, size_t n_args, s
     mp_obj_stringio_t *o = stringio_new(type_in);
 
     if (n_args > 0) {
-        if (MP_OBJ_IS_INT(args[0])) {
+        if (mp_obj_is_int(args[0])) {
             sz = mp_obj_get_int(args[0]);
         } else {
             mp_get_buffer_raise(args[0], &bufinfo, MP_BUFFER_READ);
 
-            if (MP_OBJ_IS_STR_OR_BYTES(args[0])) {
+            if (mp_obj_is_str_or_bytes(args[0])) {
                 o->vstr = m_new_obj(vstr_t);
                 vstr_init_fixed_buf(o->vstr, bufinfo.len, bufinfo.buf);
                 o->vstr->len = bufinfo.len;

--- a/py/objstrunicode.c
+++ b/py/objstrunicode.c
@@ -126,7 +126,7 @@ const byte *str_index_to_ptr(const mp_obj_type_t *type, const byte *self_data, s
     // Copied from mp_get_index; I don't want bounds checking, just give me
     // the integer as-is. (I can't bounds-check without scanning the whole
     // string; an out-of-bounds index will be caught in the loops below.)
-    if (MP_OBJ_IS_SMALL_INT(index)) {
+    if (mp_obj_is_small_int(index)) {
         i = MP_OBJ_SMALL_INT_VALUE(index);
     } else if (!mp_obj_get_int_maybe(index, &i)) {
         nlr_raise(mp_obj_new_exception_msg_varg(&mp_type_TypeError, "string indices must be integers, not %s", mp_obj_get_type_str(index)));
@@ -182,7 +182,7 @@ STATIC mp_obj_t str_subscr(mp_obj_t self_in, mp_obj_t index, mp_obj_t value) {
     if (value == MP_OBJ_SENTINEL) {
         // load
 #if MICROPY_PY_BUILTINS_SLICE
-        if (MP_OBJ_IS_TYPE(index, &mp_type_slice)) {
+        if (mp_obj_is_type(index, &mp_type_slice)) {
             mp_obj_t ostart, ostop, ostep;
             mp_obj_slice_get(index, &ostart, &ostop, &ostep);
             if (ostep != mp_const_none && ostep != MP_OBJ_NEW_SMALL_INT(1)) {

--- a/py/objtuple.c
+++ b/py/objtuple.c
@@ -70,7 +70,7 @@ STATIC mp_obj_t mp_obj_tuple_make_new(const mp_obj_type_t *type_in, size_t n_arg
         case 1:
         default: {
             // 1 argument, an iterable from which we make a new tuple
-            if (MP_OBJ_IS_TYPE(args[0], &mp_type_tuple)) {
+            if (mp_obj_is_type(args[0], &mp_type_tuple)) {
                 return args[0];
             }
 
@@ -179,7 +179,7 @@ mp_obj_t mp_obj_tuple_subscr(mp_obj_t self_in, mp_obj_t index, mp_obj_t value) {
         // load
         mp_obj_tuple_t *self = MP_OBJ_TO_PTR(self_in);
 #if MICROPY_PY_BUILTINS_SLICE
-        if (MP_OBJ_IS_TYPE(index, &mp_type_slice)) {
+        if (mp_obj_is_type(index, &mp_type_slice)) {
             mp_bound_slice_t slice;
             if (!mp_seq_get_fast_slice_indexes(self->len, index, &slice)) {
                 mp_raise_NotImplementedError("only slices with step=1 (aka None) are supported");
@@ -197,14 +197,14 @@ mp_obj_t mp_obj_tuple_subscr(mp_obj_t self_in, mp_obj_t index, mp_obj_t value) {
 }
 
 STATIC mp_obj_t tuple_count(mp_obj_t self_in, mp_obj_t value) {
-    mp_check_self(MP_OBJ_IS_TYPE(self_in, &mp_type_tuple));
+    mp_check_self(mp_obj_is_type(self_in, &mp_type_tuple));
     mp_obj_tuple_t *self = MP_OBJ_TO_PTR(self_in);
     return mp_seq_count_obj(self->items, self->len, value);
 }
 STATIC MP_DEFINE_CONST_FUN_OBJ_2(tuple_count_obj, tuple_count);
 
 STATIC mp_obj_t tuple_index(size_t n_args, const mp_obj_t *args) {
-    mp_check_self(MP_OBJ_IS_TYPE(args[0], &mp_type_tuple));
+    mp_check_self(mp_obj_is_type(args[0], &mp_type_tuple));
     mp_obj_tuple_t *self = MP_OBJ_TO_PTR(args[0]);
     return mp_seq_index_obj(self->items, self->len, n_args, args);
 }
@@ -248,14 +248,14 @@ mp_obj_t mp_obj_new_tuple(size_t n, const mp_obj_t *items) {
 }
 
 void mp_obj_tuple_get(mp_obj_t self_in, size_t *len, mp_obj_t **items) {
-    assert(MP_OBJ_IS_TYPE(self_in, &mp_type_tuple));
+    assert(mp_obj_is_type(self_in, &mp_type_tuple));
     mp_obj_tuple_t *self = MP_OBJ_TO_PTR(self_in);
     *len = self->len;
     *items = &self->items[0];
 }
 
 void mp_obj_tuple_del(mp_obj_t self_in) {
-    assert(MP_OBJ_IS_TYPE(self_in, &mp_type_tuple));
+    assert(mp_obj_is_type(self_in, &mp_type_tuple));
     mp_obj_tuple_t *self = MP_OBJ_TO_PTR(self_in);
     m_del_var(mp_obj_tuple_t, mp_obj_t, self->len, self);
 }

--- a/py/objtype.c
+++ b/py/objtype.c
@@ -594,7 +594,7 @@ STATIC void mp_obj_instance_load_attr(mp_obj_t self_in, qstr attr, mp_obj_t *des
         mp_map_t *map = &self->members;
         mp_obj_t attr_dict = mp_obj_new_dict(map->used);
         for (size_t i = 0; i < map->alloc; ++i) {
-            if (MP_MAP_SLOT_IS_FILLED(map, i)) {
+            if (mp_map_slot_is_filled(map, i)) {
                 mp_obj_dict_store(attr_dict, map->table[i].key, map->table[i].value);
             }
         }
@@ -1146,7 +1146,7 @@ mp_obj_t mp_obj_new_type(qstr name, mp_obj_t bases_tuple, mp_obj_t locals_dict) 
     // Check if the class has any special accessor methods
     if (!(o->flags & TYPE_FLAG_HAS_SPECIAL_ACCESSORS)) {
         for (size_t i = 0; i < o->locals_dict->map.alloc; i++) {
-            if (MP_MAP_SLOT_IS_FILLED(&o->locals_dict->map, i)) {
+            if (mp_map_slot_is_filled(&o->locals_dict->map, i)) {
                 const mp_map_elem_t *elem = &o->locals_dict->map.table[i];
                 if (check_for_special_accessors(elem->key, elem->value)) {
                     o->flags |= TYPE_FLAG_HAS_SPECIAL_ACCESSORS;

--- a/py/objtype.c
+++ b/py/objtype.c
@@ -72,7 +72,7 @@ STATIC int instance_count_native_bases(const mp_obj_type_t *type, const mp_obj_t
             const mp_obj_t *item = parent_tuple->items;
             const mp_obj_t *top = item + parent_tuple->len;
             for (; item < top; ++item) {
-                assert(MP_OBJ_IS_TYPE(*item, &mp_type_type));
+                assert(mp_obj_is_type(*item, &mp_type_type));
                 const mp_obj_type_t *bt = (const mp_obj_type_t *)MP_OBJ_TO_PTR(*item);
                 count += instance_count_native_bases(bt, last_native_base);
             }
@@ -210,7 +210,7 @@ STATIC void mp_obj_class_lookup(struct class_lookup_data  *lookup, const mp_obj_
             const mp_obj_t *item = parent_tuple->items;
             const mp_obj_t *top = item + parent_tuple->len - 1;
             for (; item < top; ++item) {
-                assert(MP_OBJ_IS_TYPE(*item, &mp_type_type));
+                assert(mp_obj_is_type(*item, &mp_type_type));
                 mp_obj_type_t *bt = (mp_obj_type_t*)MP_OBJ_TO_PTR(*item);
                 if (bt == &mp_type_object) {
                     // Not a "real" type
@@ -223,7 +223,7 @@ STATIC void mp_obj_class_lookup(struct class_lookup_data  *lookup, const mp_obj_
             }
 
             // search last base (simple tail recursion elimination)
-            assert(MP_OBJ_IS_TYPE(*item, &mp_type_type));
+            assert(mp_obj_is_type(*item, &mp_type_type));
             type = (mp_obj_type_t*)MP_OBJ_TO_PTR(*item);
         #endif
         } else {
@@ -430,7 +430,7 @@ STATIC mp_obj_t instance_unary_op(mp_unary_op_t op, mp_obj_t self_in) {
                 break;
             case MP_UNARY_OP_INT:
                 // Must return int
-                if (!MP_OBJ_IS_INT(val)) {
+                if (!mp_obj_is_int(val)) {
                     mp_raise_TypeError(NULL);
                 }
                 break;
@@ -618,7 +618,7 @@ STATIC void mp_obj_instance_load_attr(mp_obj_t self_in, qstr attr, mp_obj_t *des
         }
 
         #if MICROPY_PY_BUILTINS_PROPERTY
-        if (MP_OBJ_IS_TYPE(member, &mp_type_property)) {
+        if (mp_obj_is_type(member, &mp_type_property)) {
             // object member is a property; delegate the load to the property
             // Note: This is an optimisation for code size and execution time.
             // The proper way to do it is have the functionality just below
@@ -698,7 +698,7 @@ STATIC bool mp_obj_instance_store_attr(mp_obj_t self_in, qstr attr, mp_obj_t val
 
     if (member[0] != MP_OBJ_NULL) {
         #if MICROPY_PY_BUILTINS_PROPERTY
-        if (MP_OBJ_IS_TYPE(member[0], &mp_type_property)) {
+        if (mp_obj_is_type(member[0], &mp_type_property)) {
             // attribute exists and is a property; delegate the store/delete
             // Note: This is an optimisation for code size and execution time.
             // The proper way to do it is have the functionality just below in
@@ -933,7 +933,7 @@ STATIC bool check_for_special_accessors(mp_obj_t key, mp_obj_t value) {
     }
     #endif
     #if MICROPY_PY_BUILTINS_PROPERTY
-    if (MP_OBJ_IS_TYPE(value, &mp_type_property)) {
+    if (mp_obj_is_type(value, &mp_type_property)) {
         return true;
     }
     #endif
@@ -1001,7 +1001,7 @@ STATIC mp_obj_t type_call(mp_obj_t self_in, size_t n_args, size_t n_kw, const mp
 }
 
 STATIC void type_attr(mp_obj_t self_in, qstr attr, mp_obj_t *dest) {
-    assert(MP_OBJ_IS_TYPE(self_in, &mp_type_type));
+    assert(mp_obj_is_type(self_in, &mp_type_type));
     mp_obj_type_t *self = MP_OBJ_TO_PTR(self_in);
 
     if (dest[0] == MP_OBJ_NULL) {
@@ -1071,10 +1071,10 @@ const mp_obj_type_t mp_type_type = {
 
 mp_obj_t mp_obj_new_type(qstr name, mp_obj_t bases_tuple, mp_obj_t locals_dict) {
     // Verify input objects have expected type
-    if (!MP_OBJ_IS_TYPE(bases_tuple, &mp_type_tuple)) {
+    if (!mp_obj_is_type(bases_tuple, &mp_type_tuple)) {
         mp_raise_TypeError(NULL);
     }
-    if (!MP_OBJ_IS_TYPE(locals_dict, &mp_type_dict)) {
+    if (!mp_obj_is_type(locals_dict, &mp_type_dict)) {
         mp_raise_TypeError(NULL);
     }
 
@@ -1086,7 +1086,7 @@ mp_obj_t mp_obj_new_type(qstr name, mp_obj_t bases_tuple, mp_obj_t locals_dict) 
     mp_obj_t *bases_items;
     mp_obj_tuple_get(bases_tuple, &bases_len, &bases_items);
     for (size_t i = 0; i < bases_len; i++) {
-        if (!MP_OBJ_IS_TYPE(bases_items[i], &mp_type_type)) {
+        if (!mp_obj_is_type(bases_items[i], &mp_type_type)) {
             mp_raise_TypeError(NULL);
         }
         mp_obj_type_t *t = MP_OBJ_TO_PTR(bases_items[i]);
@@ -1167,7 +1167,7 @@ mp_obj_t mp_obj_new_type(qstr name, mp_obj_t bases_tuple, mp_obj_t locals_dict) 
     mp_map_elem_t *elem = mp_map_lookup(locals_map, MP_OBJ_NEW_QSTR(MP_QSTR___new__), MP_MAP_LOOKUP);
     if (elem != NULL) {
         // __new__ slot exists; check if it is a function
-        if (MP_OBJ_IS_FUN(elem->value)) {
+        if (mp_obj_is_fun(elem->value)) {
             // __new__ is a function, wrap it in a staticmethod decorator
             elem->value = static_class_method_make_new(&mp_type_staticmethod, 1, 0, &elem->value);
         }
@@ -1200,7 +1200,7 @@ STATIC mp_obj_t super_make_new(const mp_obj_type_t *type_in, size_t n_args, size
     // 0 arguments are turned into 2 in the compiler
     // 1 argument is not yet implemented
     mp_arg_check_num(n_args, n_kw, 2, 2, false);
-    if (!MP_OBJ_IS_TYPE(args[0], &mp_type_type)) {
+    if (!mp_obj_is_type(args[0], &mp_type_type)) {
         mp_raise_TypeError(NULL);
     }
     mp_obj_super_t *o = m_new_obj(mp_obj_super_t);
@@ -1214,10 +1214,10 @@ STATIC void super_attr(mp_obj_t self_in, qstr attr, mp_obj_t *dest) {
         return;
     }
 
-    assert(MP_OBJ_IS_TYPE(self_in, &mp_type_super));
+    assert(mp_obj_is_type(self_in, &mp_type_super));
     mp_obj_super_t *self = MP_OBJ_TO_PTR(self_in);
 
-    assert(MP_OBJ_IS_TYPE(self->type, &mp_type_type));
+    assert(mp_obj_is_type(self->type, &mp_type_type));
 
     mp_obj_type_t *type = MP_OBJ_TO_PTR(self->type);
 
@@ -1242,7 +1242,7 @@ STATIC void super_attr(mp_obj_t self_in, qstr attr, mp_obj_t *dest) {
         size_t len = parent_tuple->len;
         const mp_obj_t *items = parent_tuple->items;
         for (size_t i = 0; i < len; i++) {
-            assert(MP_OBJ_IS_TYPE(items[i], &mp_type_type));
+            assert(mp_obj_is_type(items[i], &mp_type_type));
             if (MP_OBJ_TO_PTR(items[i]) == &mp_type_object) {
                 // The "object" type will be searched at the end of this function,
                 // and we don't want to lookup native methods in object.
@@ -1301,7 +1301,7 @@ bool mp_obj_is_subclass_fast(mp_const_obj_t object, mp_const_obj_t classinfo) {
         // not equivalent classes, keep searching base classes
 
         // object should always be a type object, but just return false if it's not
-        if (!MP_OBJ_IS_TYPE(object, &mp_type_type)) {
+        if (!mp_obj_is_type(object, &mp_type_type)) {
             return false;
         }
 
@@ -1337,10 +1337,10 @@ bool mp_obj_is_subclass_fast(mp_const_obj_t object, mp_const_obj_t classinfo) {
 STATIC mp_obj_t mp_obj_is_subclass(mp_obj_t object, mp_obj_t classinfo) {
     size_t len;
     mp_obj_t *items;
-    if (MP_OBJ_IS_TYPE(classinfo, &mp_type_type)) {
+    if (mp_obj_is_type(classinfo, &mp_type_type)) {
         len = 1;
         items = &classinfo;
-    } else if (MP_OBJ_IS_TYPE(classinfo, &mp_type_tuple)) {
+    } else if (mp_obj_is_type(classinfo, &mp_type_tuple)) {
         mp_obj_tuple_get(classinfo, &len, &items);
     } else {
         mp_raise_TypeError("issubclass() arg 2 must be a class or a tuple of classes");
@@ -1356,7 +1356,7 @@ STATIC mp_obj_t mp_obj_is_subclass(mp_obj_t object, mp_obj_t classinfo) {
 }
 
 STATIC mp_obj_t mp_builtin_issubclass(mp_obj_t object, mp_obj_t classinfo) {
-    if (!MP_OBJ_IS_TYPE(object, &mp_type_type)) {
+    if (!mp_obj_is_type(object, &mp_type_type)) {
         mp_raise_TypeError("issubclass() arg 1 must be a class");
     }
     return mp_obj_is_subclass(object, classinfo);

--- a/py/objzip.c
+++ b/py/objzip.c
@@ -49,7 +49,7 @@ STATIC mp_obj_t zip_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_
 }
 
 STATIC mp_obj_t zip_iternext(mp_obj_t self_in) {
-    mp_check_self(MP_OBJ_IS_TYPE(self_in, &mp_type_zip));
+    mp_check_self(mp_obj_is_type(self_in, &mp_type_zip));
     mp_obj_zip_t *self = MP_OBJ_TO_PTR(self_in);
     if (self->n_iters == 0) {
         return MP_OBJ_STOP_ITERATION;

--- a/py/parse.c
+++ b/py/parse.c
@@ -338,7 +338,7 @@ bool mp_parse_node_get_int_maybe(mp_parse_node_t pn, mp_obj_t *o) {
         #else
         *o = (mp_obj_t)pns->nodes[0];
         #endif
-        return MP_OBJ_IS_INT(*o);
+        return mp_obj_is_int(*o);
     } else {
         return false;
     }
@@ -477,7 +477,7 @@ STATIC void push_result_token(parser_t *parser, uint8_t rule_id) {
         mp_map_elem_t *elem;
         if (rule_id == RULE_atom
             && (elem = mp_map_lookup(&parser->consts, MP_OBJ_NEW_QSTR(id), MP_MAP_LOOKUP)) != NULL) {
-            if (MP_OBJ_IS_SMALL_INT(elem->value)) {
+            if (mp_obj_is_small_int(elem->value)) {
                 pn = mp_parse_node_new_small_int_checked(parser, elem->value);
             } else {
                 pn = make_node_const_object(parser, lex->tok_line, elem->value);
@@ -491,7 +491,7 @@ STATIC void push_result_token(parser_t *parser, uint8_t rule_id) {
         #endif
     } else if (lex->tok_kind == MP_TOKEN_INTEGER) {
         mp_obj_t o = mp_parse_num_integer(lex->vstr.buf, lex->vstr.len, 0, lex);
-        if (MP_OBJ_IS_SMALL_INT(o)) {
+        if (mp_obj_is_small_int(o)) {
             pn = mp_parse_node_new_small_int_checked(parser, o);
         } else {
             pn = make_node_const_object(parser, lex->tok_line, o);
@@ -768,7 +768,7 @@ STATIC bool fold_constants(parser_t *parser, uint8_t rule_id, size_t num_args) {
         }
         mp_obj_t dest[2];
         mp_load_method_maybe(elem->value, q_attr, dest);
-        if (!(dest[0] != MP_OBJ_NULL && MP_OBJ_IS_INT(dest[0]) && dest[1] == MP_OBJ_NULL)) {
+        if (!(dest[0] != MP_OBJ_NULL && mp_obj_is_int(dest[0]) && dest[1] == MP_OBJ_NULL)) {
             return false;
         }
         arg0 = dest[0];
@@ -783,7 +783,7 @@ STATIC bool fold_constants(parser_t *parser, uint8_t rule_id, size_t num_args) {
     for (size_t i = num_args; i > 0; i--) {
         pop_result(parser);
     }
-    if (MP_OBJ_IS_SMALL_INT(arg0)) {
+    if (mp_obj_is_small_int(arg0)) {
         push_result_node(parser, mp_parse_node_new_small_int_checked(parser, arg0));
     } else {
         // TODO reuse memory for parse node struct?

--- a/py/persistentcode.c
+++ b/py/persistentcode.c
@@ -272,9 +272,9 @@ STATIC void save_qstr(mp_print_t *print, qstr qst) {
 }
 
 STATIC void save_obj(mp_print_t *print, mp_obj_t o) {
-    if (MP_OBJ_IS_STR_OR_BYTES(o)) {
+    if (mp_obj_is_str_or_bytes(o)) {
         byte obj_type;
-        if (MP_OBJ_IS_STR(o)) {
+        if (mp_obj_is_str(o)) {
             obj_type = 's';
         } else {
             obj_type = 'b';
@@ -291,10 +291,10 @@ STATIC void save_obj(mp_print_t *print, mp_obj_t o) {
         // we save numbers using a simplistic text representation
         // TODO could be improved
         byte obj_type;
-        if (MP_OBJ_IS_TYPE(o, &mp_type_int)) {
+        if (mp_obj_is_type(o, &mp_type_int)) {
             obj_type = 'i';
         #if MICROPY_PY_BUILTINS_COMPLEX
-        } else if (MP_OBJ_IS_TYPE(o, &mp_type_complex)) {
+        } else if (mp_obj_is_type(o, &mp_type_complex)) {
             obj_type = 'c';
         #endif
         } else {

--- a/py/runtime.c
+++ b/py/runtime.c
@@ -760,7 +760,7 @@ void mp_call_prepare_args_n_kw_var(bool have_self, size_t n_args_n_kw, const mp_
         mp_map_t *map = mp_obj_dict_get_map(kw_dict);
         assert(args2_len + 2 * map->used <= args2_alloc); // should have enough, since kw_dict_len is in this case hinted correctly above
         for (size_t i = 0; i < map->alloc; i++) {
-            if (MP_MAP_SLOT_IS_FILLED(map, i)) {
+            if (mp_map_slot_is_filled(map, i)) {
                 // the key must be a qstr, so intern it if it's a string
                 mp_obj_t key = map->table[i].key;
                 if (!mp_obj_is_qstr(key)) {
@@ -1392,7 +1392,7 @@ void mp_import_all(mp_obj_t module) {
     // TODO: Support __all__
     mp_map_t *map = &mp_obj_module_get_globals(module)->map;
     for (size_t i = 0; i < map->alloc; i++) {
-        if (MP_MAP_SLOT_IS_FILLED(map, i)) {
+        if (mp_map_slot_is_filled(map, i)) {
             // Entry in module global scope may be generated programmatically
             // (and thus be not a qstr for longer names). Avoid turning it in
             // qstr if it has '_' and was used exactly to save memory.

--- a/py/runtime.c
+++ b/py/runtime.c
@@ -222,7 +222,7 @@ mp_obj_t mp_unary_op(mp_unary_op_t op, mp_obj_t arg) {
     if (op == MP_UNARY_OP_NOT) {
         // "not x" is the negative of whether "x" is true per Python semantics
         return mp_obj_new_bool(mp_obj_is_true(arg) == 0);
-    } else if (MP_OBJ_IS_SMALL_INT(arg)) {
+    } else if (mp_obj_is_small_int(arg)) {
         mp_int_t val = MP_OBJ_SMALL_INT_VALUE(arg);
         switch (op) {
             case MP_UNARY_OP_BOOL:
@@ -252,7 +252,7 @@ mp_obj_t mp_unary_op(mp_unary_op_t op, mp_obj_t arg) {
                 assert(op == MP_UNARY_OP_INVERT);
                 return MP_OBJ_NEW_SMALL_INT(~val);
         }
-    } else if (op == MP_UNARY_OP_HASH && MP_OBJ_IS_STR_OR_BYTES(arg)) {
+    } else if (op == MP_UNARY_OP_HASH && mp_obj_is_str_or_bytes(arg)) {
         // fast path for hashing str/bytes
         GET_STR_HASH(arg, h);
         if (h == 0) {
@@ -332,7 +332,7 @@ mp_obj_t mp_binary_op(mp_binary_op_t op, mp_obj_t lhs, mp_obj_t rhs) {
             } else {
                 return mp_const_false;
             }
-        } else if (MP_OBJ_IS_TYPE(rhs, &mp_type_tuple)) {
+        } else if (mp_obj_is_type(rhs, &mp_type_tuple)) {
             mp_obj_tuple_t *tuple = MP_OBJ_TO_PTR(rhs);
             for (size_t i = 0; i < tuple->len; i++) {
                 rhs = tuple->items[i];
@@ -348,9 +348,9 @@ mp_obj_t mp_binary_op(mp_binary_op_t op, mp_obj_t lhs, mp_obj_t rhs) {
         goto unsupported_op;
     }
 
-    if (MP_OBJ_IS_SMALL_INT(lhs)) {
+    if (mp_obj_is_small_int(lhs)) {
         mp_int_t lhs_val = MP_OBJ_SMALL_INT_VALUE(lhs);
-        if (MP_OBJ_IS_SMALL_INT(rhs)) {
+        if (mp_obj_is_small_int(rhs)) {
             mp_int_t rhs_val = MP_OBJ_SMALL_INT_VALUE(rhs);
             // This is a binary operation: lhs_val op rhs_val
             // We need to be careful to handle overflow; see CERT INT32-C
@@ -525,7 +525,7 @@ mp_obj_t mp_binary_op(mp_binary_op_t op, mp_obj_t lhs, mp_obj_t rhs) {
                 return res;
             }
 #if MICROPY_PY_BUILTINS_COMPLEX
-        } else if (MP_OBJ_IS_TYPE(rhs, &mp_type_complex)) {
+        } else if (mp_obj_is_type(rhs, &mp_type_complex)) {
             mp_obj_t res = mp_obj_complex_binary_op(op, lhs_val, 0, rhs);
             if (res == MP_OBJ_NULL) {
                 goto unsupported_op;
@@ -672,7 +672,7 @@ void mp_call_prepare_args_n_kw_var(bool have_self, size_t n_args_n_kw, const mp_
 
     // Try to get a hint for the size of the kw_dict
     uint kw_dict_len = 0;
-    if (kw_dict != MP_OBJ_NULL && MP_OBJ_IS_TYPE(kw_dict, &mp_type_dict)) {
+    if (kw_dict != MP_OBJ_NULL && mp_obj_is_type(kw_dict, &mp_type_dict)) {
         kw_dict_len = mp_obj_dict_len(kw_dict);
     }
 
@@ -694,7 +694,7 @@ void mp_call_prepare_args_n_kw_var(bool have_self, size_t n_args_n_kw, const mp_
         mp_seq_copy(args2 + args2_len, args, n_args, mp_obj_t);
         args2_len += n_args;
 
-    } else if (MP_OBJ_IS_TYPE(pos_seq, &mp_type_tuple) || MP_OBJ_IS_TYPE(pos_seq, &mp_type_list)) {
+    } else if (mp_obj_is_type(pos_seq, &mp_type_tuple) || mp_obj_is_type(pos_seq, &mp_type_list)) {
         // optimise the case of a tuple and list
 
         // get the items
@@ -755,7 +755,7 @@ void mp_call_prepare_args_n_kw_var(bool have_self, size_t n_args_n_kw, const mp_
     // Note that it can be arbitrary iterator.
     if (kw_dict == MP_OBJ_NULL) {
         // pass
-    } else if (MP_OBJ_IS_TYPE(kw_dict, &mp_type_dict)) {
+    } else if (mp_obj_is_type(kw_dict, &mp_type_dict)) {
         // dictionary
         mp_map_t *map = mp_obj_dict_get_map(kw_dict);
         assert(args2_len + 2 * map->used <= args2_alloc); // should have enough, since kw_dict_len is in this case hinted correctly above
@@ -763,7 +763,7 @@ void mp_call_prepare_args_n_kw_var(bool have_self, size_t n_args_n_kw, const mp_
             if (MP_MAP_SLOT_IS_FILLED(map, i)) {
                 // the key must be a qstr, so intern it if it's a string
                 mp_obj_t key = map->table[i].key;
-                if (!MP_OBJ_IS_QSTR(key)) {
+                if (!mp_obj_is_qstr(key)) {
                     key = mp_obj_str_intern_checked(key);
                 }
                 args2[args2_len++] = key;
@@ -793,7 +793,7 @@ void mp_call_prepare_args_n_kw_var(bool have_self, size_t n_args_n_kw, const mp_
             }
 
             // the key must be a qstr, so intern it if it's a string
-            if (!MP_OBJ_IS_QSTR(key)) {
+            if (!mp_obj_is_qstr(key)) {
                 key = mp_obj_str_intern_checked(key);
             }
 
@@ -828,7 +828,7 @@ mp_obj_t mp_call_method_n_kw_var(bool have_self, size_t n_args_n_kw, const mp_ob
 // unpacked items are stored in reverse order into the array pointed to by items
 void mp_unpack_sequence(mp_obj_t seq_in, size_t num, mp_obj_t *items) {
     size_t seq_len;
-    if (MP_OBJ_IS_TYPE(seq_in, &mp_type_tuple) || MP_OBJ_IS_TYPE(seq_in, &mp_type_list)) {
+    if (mp_obj_is_type(seq_in, &mp_type_tuple) || mp_obj_is_type(seq_in, &mp_type_list)) {
         mp_obj_t *seq_items;
         mp_obj_get_array(seq_in, &seq_len, &seq_items);
         if (seq_len < num) {
@@ -878,7 +878,7 @@ void mp_unpack_ex(mp_obj_t seq_in, size_t num_in, mp_obj_t *items) {
     size_t num_right = (num_in >> 8) & 0xff;
     DEBUG_OP_printf("unpack ex " UINT_FMT " " UINT_FMT "\n", num_left, num_right);
     size_t seq_len;
-    if (MP_OBJ_IS_TYPE(seq_in, &mp_type_tuple) || MP_OBJ_IS_TYPE(seq_in, &mp_type_list)) {
+    if (mp_obj_is_type(seq_in, &mp_type_tuple) || mp_obj_is_type(seq_in, &mp_type_list)) {
         mp_obj_t *seq_items;
         mp_obj_get_array(seq_in, &seq_len, &seq_items);
         if (seq_len < num_left + num_right) {
@@ -992,10 +992,10 @@ STATIC mp_obj_t mp_obj_new_checked_fun(const mp_obj_type_t *type, mp_obj_t fun) 
 // Conversion means dealing with static/class methods, callables, and values.
 // see http://docs.python.org/3/howto/descriptor.html
 void mp_convert_member_lookup(mp_obj_t self, const mp_obj_type_t *type, mp_obj_t member, mp_obj_t *dest) {
-    if (MP_OBJ_IS_TYPE(member, &mp_type_staticmethod)) {
+    if (mp_obj_is_type(member, &mp_type_staticmethod)) {
         // return just the function
         dest[0] = ((mp_obj_static_class_method_t*)MP_OBJ_TO_PTR(member))->fun;
-    } else if (MP_OBJ_IS_TYPE(member, &mp_type_classmethod)) {
+    } else if (mp_obj_is_type(member, &mp_type_classmethod)) {
         // return a bound method, with self being the type of this object
         // this type should be the type of the original instance, not the base
         // type (which is what is passed in the 'type' argument to this function)
@@ -1004,11 +1004,11 @@ void mp_convert_member_lookup(mp_obj_t self, const mp_obj_type_t *type, mp_obj_t
         }
         dest[0] = ((mp_obj_static_class_method_t*)MP_OBJ_TO_PTR(member))->fun;
         dest[1] = MP_OBJ_FROM_PTR(type);
-    } else if (MP_OBJ_IS_TYPE(member, &mp_type_type)) {
+    } else if (mp_obj_is_type(member, &mp_type_type)) {
         // Don't try to bind types (even though they're callable)
         dest[0] = member;
-    } else if (MP_OBJ_IS_FUN(member)
-        || (MP_OBJ_IS_OBJ(member)
+    } else if (mp_obj_is_fun(member)
+        || (mp_obj_is_obj(member)
             && (((mp_obj_base_t*)MP_OBJ_TO_PTR(member))->type->name == MP_QSTR_closure
                 || ((mp_obj_base_t*)MP_OBJ_TO_PTR(member))->type->name == MP_QSTR_generator))) {
         // only functions, closures and generators objects can be bound to self
@@ -1086,7 +1086,7 @@ void mp_load_method(mp_obj_t base, qstr attr, mp_obj_t *dest) {
             mp_raise_msg(&mp_type_AttributeError, "no such attribute");
         } else {
             // following CPython, we give a more detailed error message for type objects
-            if (MP_OBJ_IS_TYPE(base, &mp_type_type)) {
+            if (mp_obj_is_type(base, &mp_type_type)) {
                 nlr_raise(mp_obj_new_exception_msg_varg(&mp_type_AttributeError,
                     "type object '%q' has no attribute '%q'",
                     ((mp_obj_type_t*)MP_OBJ_TO_PTR(base))->name, attr));

--- a/py/vm.c
+++ b/py/vm.c
@@ -604,7 +604,7 @@ dispatch_loop:
                         sp -= 2;
                         mp_call_method_n_kw(3, 0, sp);
                         SET_TOP(mp_const_none);
-                    } else if (MP_OBJ_IS_SMALL_INT(TOP())) {
+                    } else if (mp_obj_is_small_int(TOP())) {
                         // Getting here there are two distinct cases:
                         //  - unwind return, stack: (..., __exit__, ctx_mgr, ret_val, SMALL_INT(-1))
                         //  - unwind jump, stack:   (..., __exit__, ctx_mgr, dest_ip, SMALL_INT(num_exc))
@@ -699,7 +699,7 @@ unwind_jump:;
                     // if TOS is an exception, reraises the exception
                     if (TOP() == mp_const_none) {
                         sp--;
-                    } else if (MP_OBJ_IS_SMALL_INT(TOP())) {
+                    } else if (mp_obj_is_small_int(TOP())) {
                         // We finished "finally" coroutine and now dispatch back
                         // to our caller, based on TOS value
                         mp_int_t cause = MP_OBJ_SMALL_INT_VALUE(POP());
@@ -1150,7 +1150,7 @@ yield:
 
                 ENTRY(MP_BC_YIELD_FROM): {
                     MARK_EXC_IP_SELECTIVE();
-//#define EXC_MATCH(exc, type) MP_OBJ_IS_TYPE(exc, type)
+//#define EXC_MATCH(exc, type) mp_obj_is_type(exc, type)
 #define EXC_MATCH(exc, type) mp_obj_exception_match(exc, type)
 #define GENERATOR_EXIT_IF_NEEDED(t) if (t != MP_OBJ_NULL && EXC_MATCH(t, MP_OBJ_FROM_PTR(&mp_type_GeneratorExit))) { mp_obj_t raise_t = mp_make_raise_obj(t); RAISE(raise_t); }
                     mp_vm_return_kind_t ret_kind;


### PR DESCRIPTION
This is an attempt to resolve #293 by downcasing most of the uppercase macros/functions, to clean up the C API.

These macros/inline-functions that have been downcased could in principle be (inline) functions so it makes sense to have them lower case, to match the other C API functions.

The remaining macros that are upper case are:
- MP_OBJ_TO_PTR, MP_OBJ_FROM_PTR
- MP_OBJ_NEW_SMALL_INT, MP_OBJ_SMALL_INT_VALUE
- MP_OBJ_NEW_QSTR, MP_OBJ_QSTR_VALUE
- MP_OBJ_FUN_MAKE_SIG
- MP_DECLARE_CONST_xxx
- MP_DEFINE_CONST_xxx

These must remain macros because they are used when defining const data (at least, MP_OBJ_NEW_SMALL_INT is so it makes sense to have MP_OBJ_SMALL_INT_VALUE also a macro).

For those macros that have been made lower case, compatibility macros are provided for the old names so that users do not need to change their code immediately.
