### PR TITLE
py/mkenv.mk: Change default PYTHON variable from "python" to "python3".

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,8 +60,9 @@ Additional components:
 The subdirectories above may include READMEs with additional info.
 
 "make" is used to build the components, or "gmake" on BSD-based systems.
-You will also need bash, gcc, and Python 3.3+ (if your system only has Python 2.7
-then invoke make with the additional option `PYTHON=python2`).
+You will also need bash, gcc, and Python 3.3+ available as the command `python3`
+(if your system only has Python 2.7 then invoke make with the additional option
+`PYTHON=python2`).
 
 The Unix version
 ----------------

--- a/README.md
+++ b/README.md
@@ -60,7 +60,8 @@ Additional components:
 The subdirectories above may include READMEs with additional info.
 
 "make" is used to build the components, or "gmake" on BSD-based systems.
-You will also need bash, gcc, and Python (at least 2.7 or 3.3).
+You will also need bash, gcc, and Python 3.3+ (if your system only has Python 2.7
+then invoke make with the additional option `PYTHON=python2`).
 
 The Unix version
 ----------------

--- a/py/mkenv.mk
+++ b/py/mkenv.mk
@@ -42,7 +42,7 @@ ECHO = @echo
 CP = cp
 MKDIR = mkdir
 SED = sed
-PYTHON = python
+PYTHON = python3
 
 AS = $(CROSS_COMPILE)as
 CC = $(CROSS_COMPILE)gcc


### PR DESCRIPTION
This change makes it so that `python3` is required by default to build MicroPython.  Python 2 can be used by specifying `make PYTHON=python2`.

This comes about due to a recent-ish change to PEP 394 that makes the `python` command more optional than before (even with Python 2 installed); see https://github.com/python/peps/commit/cd59ec03c8ff1e75089d5872520cd0706774b35b#diff-1d22f7bd72cbc900670f058b1107d426

Since the command `python` is no longer required to be provided by a distribution we need to use either `python2` or `python3` as commands.  And `python3` seems the obvious choice.

-----

An alternative to this PR is to auto-detect the executable: #1621.  But I'd rather the simpler approach here.

See also #1616.