### PR TITLE
py/builtinhelp: Print help about external modules only if external imports are enabled

### DIFF
--- a/py/builtinhelp.c
+++ b/py/builtinhelp.c
@@ -123,8 +123,10 @@ STATIC void mp_help_print_modules(void) {
         mp_print_str(MP_PYTHON_PRINTER, "\n");
     }
 
+    #if MICROPY_ENABLE_EXTERNAL_IMPORT
     // let the user know there may be other modules available from the filesystem
     mp_print_str(MP_PYTHON_PRINTER, "Plus any modules on the filesystem\n");
+    #endif
 }
 #endif
 


### PR DESCRIPTION
This help message is irrelevant if the given MP build doesn't support external imports.