### PR TITLE
[Fixed backport]: Add WPS and netstatus

### DIFF
--- a/docs/esp32/quickref.rst
+++ b/docs/esp32/quickref.rst
@@ -108,36 +108,36 @@ You can check the status of WPS connections, using :ref:`network.STA_WPS_PROBING
 
 Here is an example of WPS connection implementation using the button connected to one of the PINs::
 
-import machine
-import time
-import network
+    import machine
+    import time
+    import network
 
-button = machine.Pin(12, machine.Pin.IN, machine.Pin.PULL_UP)
-wlan = network.WLAN(network.STA_IF)
-wlan.active(True)
-while True:
-    if button.value() == 0:
-        wlan.start_wps()
-        print('start_wps')
-        while wlan.status() == network.STA_WPS_PROBING:
-            print("probing with WPS")
-            time.sleep(0.5)
+    button = machine.Pin(12, machine.Pin.IN, machine.Pin.PULL_UP)
+    wlan = network.WLAN(network.STA_IF)
+    wlan.active(True)
+    while True:
+        if button.value() == 0:
+            wlan.start_wps()
+            print('start_wps')
+            while wlan.status() == network.STA_WPS_PROBING:
+                print("probing with WPS")
+                time.sleep(0.5)
 
-        if wlan.status() == network.STA_WPS_SUCCESS:
-            print("WPS successful")
-            print("   ESSID:    ", wlan.config('essid'))
-            print("   Password: ", wlan.config('password'))
-            wlan.connect(wlan.config('essid'), wlan.config('password'))
-            print("Waiting for connection...")
-            while not wlan.isconnected():
-                machine.idle()
-            print("Connected.")
+            if wlan.status() == network.STA_WPS_SUCCESS:
+                print("WPS successful")
+                print("   ESSID:    ", wlan.config('essid'))
+                print("   Password: ", wlan.config('password'))
+                wlan.connect(wlan.config('essid'), wlan.config('password'))
+                print("Waiting for connection...")
+                while not wlan.isconnected():
+                    machine.idle()
+                print("Connected.")
 
-        elif wlan.status() == network.STA_WPS_FAILED:
-            print("WPS failed")
+            elif wlan.status() == network.STA_WPS_FAILED:
+                print("WPS failed")
 
-        elif wlan.status() == network.STA_WPS_TIMEOUT:
-            print("WPS timeout")
+            elif wlan.status() == network.STA_WPS_TIMEOUT:
+                print("WPS timeout")
 
 Delay and timing
 ----------------

--- a/docs/esp32/quickref.rst
+++ b/docs/esp32/quickref.rst
@@ -106,9 +106,8 @@ Method `start_wps` of the :ref:`network.WLAN <network.WLAN>` object turns on dis
 
 You can check the status of WPS connections, using :ref:`network.STA_WPS_PROBING <network.STA_WPS_PROBING>`, :ref:`network.STA_WPS_SUCCESS <network.STA_WPS_SUCCESS>`, :ref:`network.STA_WPS_FAILED <network.STA_WPS_FAILED>` and :ref:`network.STA_WPS_TIMEOUT <network.STA_WPS_TIMEOUT>` values of the `status` method of the `network.WLAN` object.
 
-Here is an example of WPS connection implementation using the button connected to one of the PINs.
+Here is an example of WPS connection implementation using the button connected to one of the PINs::
 
-```
 import machine
 import time
 import network
@@ -139,7 +138,6 @@ while True:
 
         elif wlan.status() == network.STA_WPS_TIMEOUT:
             print("WPS timeout")
-```
 
 Delay and timing
 ----------------

--- a/docs/esp32/quickref.rst
+++ b/docs/esp32/quickref.rst
@@ -101,6 +101,46 @@ Once the network is established the :mod:`socket <usocket>` module can be used
 to create and use TCP/UDP sockets as usual, and the ``urequests`` module for
 convenient HTTP requests.
 
+In the IoT solution `WPS Control <https://en.wikipedia.org/wiki/Wi-Fi_Protected_Setup>`_ is a common solution for connectivity problems.
+Method `start_wps` of the :ref:`network.WLAN <network.WLAN>` object turns on discovery mode and starts WPS probing on ESP32. Once an access point with WPS turned on would be found, connection would be established.
+
+You can check the status of WPS connections, using :ref:`network.STA_WPS_PROBING <network.STA_WPS_PROBING>`, :ref:`network.STA_WPS_SUCCESS <network.STA_WPS_SUCCESS>`, :ref:`network.STA_WPS_FAILED <network.STA_WPS_FAILED>` and :ref:`network.STA_WPS_TIMEOUT <network.STA_WPS_TIMEOUT>` values of the `status` method of the `network.WLAN` object.
+
+Here is an example of WPS connection implementation using the button connected to one of the PINs.
+
+```
+import machine
+import time
+import network
+
+button = machine.Pin(12, machine.Pin.IN, machine.Pin.PULL_UP)
+wlan = network.WLAN(network.STA_IF)
+wlan.active(True)
+while True:
+    if button.value() == 0:
+        wlan.start_wps()
+        print('start_wps')
+        while wlan.status() == network.STA_WPS_PROBING:
+            print("probing with WPS")
+            time.sleep(0.5)
+
+        if wlan.status() == network.STA_WPS_SUCCESS:
+            print("WPS successful")
+            print("   ESSID:    ", wlan.config('essid'))
+            print("   Password: ", wlan.config('password'))
+            wlan.connect(wlan.config('essid'), wlan.config('password'))
+            print("Waiting for connection...")
+            while not wlan.isconnected():
+                machine.idle()
+            print("Connected.")
+
+        elif wlan.status() == network.STA_WPS_FAILED:
+            print("WPS failed")
+
+        elif wlan.status() == network.STA_WPS_TIMEOUT:
+            print("WPS timeout")
+```
+
 Delay and timing
 ----------------
 

--- a/ports/esp32/Makefile
+++ b/ports/esp32/Makefile
@@ -651,8 +651,21 @@ ESPIDF_WPA_SUPPLICANT_O = $(addprefix $(ESPCOMP)/wpa_supplicant/,\
 	src/crypto/crypto_internal-cipher.o \
 	src/fast_crypto/fast_aes-unwrap.o \
 	src/fast_crypto/fast_aes-wrap.o \
+	src/fast_crypto/fast_aes-cbc.o \
 	src/fast_crypto/fast_sha256.o \
 	src/fast_crypto/fast_sha256-internal.o \
+	src/fast_crypto/fast_crypto_internal-modexp.o \
+	src/wps/wps.o \
+	src/wps/wps_validate.o \
+	src/wps/wps_registrar.o \
+	src/wps/wps_enrollee.o \
+	src/wps/wps_dev_attr.o \
+	src/wps/wps_common.o \
+	src/wps/wps_attr_process.o \
+	src/wps/wps_attr_parse.o \
+	src/wps/wps_attr_build.o \
+	src/wps/uuid.o \
+	src/wps/eap_common.o \
 	port/os_xtensa.o \
 	)
 

--- a/ports/esp32/modnetwork.c
+++ b/ports/esp32/modnetwork.c
@@ -169,11 +169,11 @@ static esp_err_t event_handler(void *ctx, system_event_t *event) {
         ESP_LOGI("wifi", "STA_START");
         break;
     case SYSTEM_EVENT_STA_GOT_IP:
-            wifi_sta_status = STATION_GOT_IP;
-            ESP_LOGI("network", "GOT_IP");
-            wifi_sta_connected = true;
-            wifi_sta_disconn_reason = 0; // Success so clear error. (in case of new error will be replaced anyway)
-            break;
+        wifi_sta_status = STATION_GOT_IP;
+        ESP_LOGI("network", "GOT_IP");
+        wifi_sta_connected = true;
+        wifi_sta_disconn_reason = 0; // Success so clear error. (in case of new error will be replaced anyway)
+        break;
     case SYSTEM_EVENT_STA_CONNECTED:
         ESP_LOGI("network", "CONNECTED");
         break;


### PR DESCRIPTION
This PR is basically a fixed version of @mactijn [port](https://github.com/micropython/micropython/pull/3530) of @jhgoebbert [PR#218](https://github.com/micropython/micropython-esp32/pull/218) which had conflicts with master and haven't passed the CI check.

We've fixed issues, merged code and tested functionality on our ESP-32 boards, but I would kindly ask maintainers to properly review the code.

It can be used as follows:

```
import machine
import time
import network

button = machine.Pin(12, machine.Pin.IN, machine.Pin.PULL_UP)
wlan = network.WLAN(network.STA_IF)
wlan.active(True)
while True:
    if button.value() == 0:
        wlan.start_wps()
        print('start_wps')
        while wlan.status() == network.STA_WPS_PROBING:
            print("probing with WPS")
            time.sleep(0.5)

        if wlan.status() == network.STA_WPS_SUCCESS:
            print("WPS successful")
            print("   ESSID:    ", wlan.config('essid'))
            print("   Password: ", wlan.config('password'))
            wlan.connect(wlan.config('essid'), wlan.config('password'))
            print("Waiting for connection...")
            while not wlan.isconnected():
                machine.idle()
            print("Connected.")

        elif wlan.status() == network.STA_WPS_FAILED:
            print("WPS failed")

        elif wlan.status() == network.STA_WPS_TIMEOUT:
            print("WPS timeout")