### PR TITLE
unix/modmachine: Handle repeated /dev/mem open errors.

### DIFF
--- a/ports/unix/modmachine.c
+++ b/ports/unix/modmachine.c
@@ -57,10 +57,11 @@ uintptr_t mod_machine_mem_get_addr(mp_obj_t addr_o, uint align) {
         static uintptr_t last_base = (uintptr_t)-1;
         static uintptr_t map_page;
         if (!fd) {
-            fd = open("/dev/mem", O_RDWR | O_SYNC);
-            if (fd == -1) {
+            int _fd = open("/dev/mem", O_RDWR | O_SYNC);
+            if (_fd == -1) {
                 mp_raise_OSError(errno);
             }
+            fd = _fd;
         }
 
         uintptr_t cur_base = addr & ~MICROPY_PAGE_MASK;


### PR DESCRIPTION
If opening of /dev/mem has failed, an `OSError` is appropriately raised, but
the next time `mem8/16/32` is accessed, the invalid file descriptor is
used and the MicroPython gets a SIGSEGV (Well, this happens because there's
no proper error handling in the `mmap` clause, but that's another problem).