### PR TITLE
ports/stm32: Fix EXTI to work with RTC Alarm

### DIFF
--- a/ports/stm32/extint.c
+++ b/ports/stm32/extint.c
@@ -93,18 +93,24 @@
 // The L4 MCU supports 40 Events/IRQs lines of the type configurable and direct.
 // Here we only support configurable line types.  Details, see page 330 of RM0351, Rev 1.
 // The USB_FS_WAKUP event is a direct type and there is no support for it.
-#define EXTI_Mode_Interrupt offsetof(EXTI_TypeDef, IMR1)
-#define EXTI_Mode_Event     offsetof(EXTI_TypeDef, EMR1)
+#define EXTI_Mode_Interrupt   offsetof(EXTI_TypeDef, IMR1)
+#define EXTI_Mode_Event       offsetof(EXTI_TypeDef, EMR1)
+#define EXTI_Trigger_Rising   offsetof(EXTI_TypeDef, RTSR1)
+#define EXTI_Trigger_Falling  offsetof(EXTI_TypeDef, FTSR1)
 #define EXTI_RTSR EXTI->RTSR1
 #define EXTI_FTSR EXTI->FTSR1
 #elif defined(STM32H7)
-#define EXTI_Mode_Interrupt offsetof(EXTI_Core_TypeDef, IMR1)
-#define EXTI_Mode_Event     offsetof(EXTI_Core_TypeDef, EMR1)
+#define EXTI_Mode_Interrupt   offsetof(EXTI_Core_TypeDef, IMR1)
+#define EXTI_Mode_Event       offsetof(EXTI_Core_TypeDef, EMR1)
+#define EXTI_Trigger_Rising   offsetof(EXTI_Core_TypeDef, RTSR1)
+#define EXTI_Trigger_Falling  offsetof(EXTI_Core_TypeDef, FTSR1)
 #define EXTI_RTSR EXTI->RTSR1
 #define EXTI_FTSR EXTI->FTSR1
 #else
-#define EXTI_Mode_Interrupt offsetof(EXTI_TypeDef, IMR)
-#define EXTI_Mode_Event     offsetof(EXTI_TypeDef, EMR)
+#define EXTI_Mode_Interrupt   offsetof(EXTI_TypeDef, IMR)
+#define EXTI_Mode_Event       offsetof(EXTI_TypeDef, EMR)
+#define EXTI_Trigger_Rising   offsetof(EXTI_TypeDef, RTSR)
+#define EXTI_Trigger_Falling  offsetof(EXTI_TypeDef, FTSR)
 #define EXTI_RTSR EXTI->RTSR
 #define EXTI_FTSR EXTI->FTSR
 #endif
@@ -210,15 +216,21 @@ uint extint_register(mp_obj_t pin_obj, uint32_t mode, uint32_t pull, mp_obj_t ca
         pyb_extint_hard_irq[v_line] = true;
         pyb_extint_callback_arg[v_line] = MP_OBJ_NEW_SMALL_INT(v_line);
 
-        mp_hal_gpio_clock_enable(pin->gpio);
-        GPIO_InitTypeDef exti;
-        exti.Pin = pin->pin_mask;
-        exti.Mode = mode;
-        exti.Pull = pull;
-        exti.Speed = GPIO_SPEED_FREQ_HIGH;
-        HAL_GPIO_Init(pin->gpio, &exti);
+        if (pin == NULL) {
+            // pin will be NULL for non GPIO EXTI lines
+            extint_trigger_mode(v_line, mode);
+            extint_enable(v_line);
+        } else {
+            mp_hal_gpio_clock_enable(pin->gpio);
+            GPIO_InitTypeDef exti;
+            exti.Pin = pin->pin_mask;
+            exti.Mode = mode;
+            exti.Pull = pull;
+            exti.Speed = GPIO_SPEED_FREQ_HIGH;
+            HAL_GPIO_Init(pin->gpio, &exti);
 
-        // Calling HAL_GPIO_Init does an implicit extint_enable
+            // Calling HAL_GPIO_Init does an implicit extint_enable
+        }
 
         /* Enable and set NVIC Interrupt to the lowest priority */
         NVIC_SetPriority(IRQn_NONNEG(nvic_irq_channel[v_line]), IRQ_PRI_EXTINT);
@@ -262,19 +274,7 @@ void extint_register_pin(const pin_obj_t *pin, uint32_t mode, bool hard_irq, mp_
             (SYSCFG->EXTICR[line >> 2] & ~(0x0f << (4 * (line & 0x03))))
             | ((uint32_t)(GPIO_GET_INDEX(pin->gpio)) << (4 * (line & 0x03)));
 
-        // Enable or disable the rising detector
-        if ((mode & GPIO_MODE_IT_RISING) == GPIO_MODE_IT_RISING) {
-            EXTI_RTSR |= 1 << line;
-        } else {
-            EXTI_RTSR &= ~(1 << line);
-        }
-
-        // Enable or disable the falling detector
-        if ((mode & GPIO_MODE_IT_FALLING) == GPIO_MODE_IT_FALLING) {
-            EXTI_FTSR |= 1 << line;
-        } else {
-            EXTI_FTSR &= ~(1 << line);
-        }
+        extint_trigger_mode(line, mode);
 
         // Configure the NVIC
         NVIC_SetPriority(IRQn_NONNEG(nvic_irq_channel[line]), IRQ_PRI_EXTINT);
@@ -351,6 +351,35 @@ void extint_swint(uint line) {
     EXTI->SWIER &= ~(1 << line);
     EXTI->SWIER |= (1 << line);
 #endif
+}
+
+void extint_trigger_mode(uint line, uint32_t mode) {
+    if (line >= EXTI_NUM_VECTORS) {
+        return;
+    }
+    #if defined(STM32F0) || defined(STM32F7) || defined(STM32H7)
+    // The Cortex-M7 doesn't have bitband support.
+    mp_uint_t irq_state = disable_irq();
+    // Enable or disable the rising detector
+    if ((mode & GPIO_MODE_IT_RISING) == GPIO_MODE_IT_RISING) {
+        EXTI_RTSR |= (1 << line);
+    } else {
+        EXTI_RTSR &= ~(1 << line);
+    }
+    // Enable or disable the falling detector
+    if ((mode & GPIO_MODE_IT_FALLING) == GPIO_MODE_IT_FALLING) {
+        EXTI_FTSR |= 1 << line;
+    } else {
+        EXTI_FTSR &= ~(1 << line);
+    }
+    enable_irq(irq_state);
+    #else
+    // Since manipulating FTSR/RTSR is a read-modify-write, and we want this to
+    // be atomic, we use the bit-band area to just affect the bit we're
+    // interested in.
+    EXTI_MODE_BB(EXTI_Trigger_Rising, line) = (mode & GPIO_MODE_IT_RISING) == GPIO_MODE_IT_RISING;
+    EXTI_MODE_BB(EXTI_Trigger_Falling, line) = (mode & GPIO_MODE_IT_FALLING) == GPIO_MODE_IT_FALLING;
+    #endif
 }
 
 /// \method line()

--- a/ports/stm32/extint.c
+++ b/ports/stm32/extint.c
@@ -154,8 +154,13 @@ STATIC const uint8_t nvic_irq_channel[EXTI_NUM_VECTORS] = {
     #else
     PVD_IRQn,
     #endif
+    #if defined(STM32L4)
+    OTG_FS_WKUP_IRQn,
+    RTC_Alarm_IRQn,
+    #else
     RTC_Alarm_IRQn,
     OTG_FS_WKUP_IRQn,
+    #endif
     ETH_WKUP_IRQn,
     OTG_HS_WKUP_IRQn,
     TAMP_STAMP_IRQn,

--- a/ports/stm32/extint.c
+++ b/ports/stm32/extint.c
@@ -144,6 +144,13 @@ STATIC const uint8_t nvic_irq_channel[EXTI_NUM_VECTORS] = {
     EXTI4_15_IRQn, EXTI4_15_IRQn, EXTI4_15_IRQn, EXTI4_15_IRQn,
     EXTI4_15_IRQn, EXTI4_15_IRQn, EXTI4_15_IRQn, EXTI4_15_IRQn,
     EXTI4_15_IRQn, EXTI4_15_IRQn, EXTI4_15_IRQn, EXTI4_15_IRQn,
+    PVD_VDDIO2_IRQn,
+    RTC_IRQn,
+    0, // internal USB wakeup event
+    RTC_IRQn,
+    RTC_IRQn,
+    ADC1_COMP_IRQn,
+    ADC1_COMP_IRQn,
     #else
     EXTI0_IRQn,     EXTI1_IRQn,     EXTI2_IRQn,     EXTI3_IRQn,     EXTI4_IRQn,
     EXTI9_5_IRQn,   EXTI9_5_IRQn,   EXTI9_5_IRQn,   EXTI9_5_IRQn,   EXTI9_5_IRQn,

--- a/ports/stm32/extint.h
+++ b/ports/stm32/extint.h
@@ -59,13 +59,6 @@
 
 #define EXTI_NUM_VECTORS        (PYB_EXTI_NUM_VECTORS)
 
-#define EXTI_MODE_INTERRUPT     (offsetof(EXTI_TypeDef, IMR))
-#define EXTI_MODE_EVENT         (offsetof(EXTI_TypeDef, EMR))
-
-#define EXTI_TRIGGER_RISING         (offsetof(EXTI_TypeDef, RTSR))
-#define EXTI_TRIGGER_FALLING        (offsetof(EXTI_TypeDef, FTSR))
-#define EXTI_TRIGGER_RISING_FALLING (EXTI_TRIGGER_RISING + EXTI_TRIGGER_FALLING)  // just different from RISING or FALLING
-
 void extint_init0(void);
 
 uint extint_register(mp_obj_t pin_obj, uint32_t mode, uint32_t pull, mp_obj_t callback_obj, bool override_callback_obj);

--- a/ports/stm32/extint.h
+++ b/ports/stm32/extint.h
@@ -69,6 +69,7 @@ void extint_register_pin(const pin_obj_t *pin, uint32_t mode, bool hard_irq, mp_
 void extint_enable(uint line);
 void extint_disable(uint line);
 void extint_swint(uint line);
+void extint_trigger_mode(uint line, uint32_t mode);
 
 void Handle_EXTI_Irq(uint32_t line);
 

--- a/ports/stm32/extint.h
+++ b/ports/stm32/extint.h
@@ -34,8 +34,13 @@
 // Use the following constants for the internal sources:
 
 #define EXTI_PVD_OUTPUT         (16)
+#if defined(STM32L4)
+#define EXTI_RTC_ALARM          (18)
+#define EXTI_USB_OTG_FS_WAKEUP  (17)
+#else
 #define EXTI_RTC_ALARM          (17)
 #define EXTI_USB_OTG_FS_WAKEUP  (18)
+#endif
 #define EXTI_ETH_WAKEUP         (19)
 #define EXTI_USB_OTG_HS_WAKEUP  (20)
 #if defined(STM32F0) || defined(STM32L4)

--- a/ports/stm32/make-stmconst.py
+++ b/ports/stm32/make-stmconst.py
@@ -48,8 +48,8 @@ class Lexer:
         ('{', re.compile(r'{$')),
         ('}', re.compile(r'}$')),
         ('} TypeDef', re.compile(r'} *(?P<id>[A-Z][A-Za-z0-9_]+)_(?P<global>([A-Za-z0-9_]+)?)TypeDef;$')),
-        ('IO reg', re.compile(re_io_reg + r'; +/\*!< ' + re_comment + r', +' + re_addr_offset + r' *\*/')),
-        ('IO reg array', re.compile(re_io_reg + r'\[(?P<array>[2-8])\]; +/\*!< ' + re_comment + r', +' + re_addr_offset + r'-(0x[0-9A-Z]{2,3}) *\*/')),
+        ('IO reg', re.compile(re_io_reg + r'; */\*!< *' + re_comment + r', +' + re_addr_offset + r' *\*/')),
+        ('IO reg array', re.compile(re_io_reg + r'\[(?P<array>[2-8])\]; */\*!< *' + re_comment + r', +' + re_addr_offset + r'-(0x[0-9A-Z]{2,3}) *\*/')),
     )
 
     def __init__(self, filename):

--- a/ports/stm32/stm32_it.c
+++ b/ports/stm32/stm32_it.c
@@ -509,8 +509,18 @@ void RTC_WKUP_IRQHandler(void) {
 
 void RTC_IRQHandler(void) {
     IRQ_ENTER(RTC_IRQn);
-    RTC->ISR &= ~RTC_ISR_WUTF; // clear wakeup interrupt flag
-    Handle_EXTI_Irq(EXTI_RTC_WAKEUP); // clear EXTI flag and execute optional callback
+    if ((RTC->ISR & RTC_ISR_WUTF) != 0) {
+      RTC->ISR &= ~RTC_ISR_WUTF; // clear wakeup interrupt flag
+      Handle_EXTI_Irq(EXTI_RTC_WAKEUP); // clear EXTI flag and execute optional callback
+    }
+    if ((RTC->ISR & RTC_ISR_ALRAF) != 0) {
+      RTC->ISR &= ~RTC_ISR_ALRAF; // clear Alarm A flag
+      Handle_EXTI_Irq(EXTI_RTC_ALARM); // clear EXTI flag and execute optional callback
+    }
+    if ((RTC->ISR & RTC_ISR_TSF) != 0) {
+      RTC->ISR &= ~RTC_ISR_TSF; // clear timestamp flag
+      Handle_EXTI_Irq(EXTI_RTC_TIMESTAMP); // clear EXTI flag and execute optional callback
+    }
     IRQ_EXIT(RTC_IRQn);
 }
 


### PR DESCRIPTION
I tested the following script: 
https://github.com/dhylands/upy-examples/blob/c8f2ffe5a8ac0411340e61d344299bf1b335dc75/rtc_alarm.py
on the following boards:
PYBV11
NUCLEO_F091RC
NUCLEO_L476RG
NUCLEO_F746ZG

I don't have an H7 board to test with, so I couldn't test that variant, but I verified that the NUCLEO_H743ZI board built cleanly.

The pyboard image increased by 48 bytes due to some additional modstm constants which weren't being parsed before, and the ExtInt module contributed 36 bytes of code increase.