### PR TITLE
Link Blynk examples to the official library

### DIFF
--- a/docs/wipy/tutorial/blynk.rst
+++ b/docs/wipy/tutorial/blynk.rst
@@ -1,19 +1,19 @@
 Getting started with Blynk and the WiPy
 ---------------------------------------
 
-Blynk is a platform with iOS and Android apps to control
-Arduino, Raspberry Pi and the likes over the Internet.
-You can easily build graphic interfaces for all your
-projects by simply dragging and dropping widgets.
+Blynk provides iOS and Android apps to control any hardware over the Internet
+or directly using Bluetooth. You can easily build graphic interfaces for all your projects
+by simply dragging and dropping widgets, right on your smartphone.
+Blynk is the most popular IoT platform used by design studios, makers, educators,
+and equipment vendors all over the world.
 
-There are several examples available that work out-of-the-box with
-the WiPy. Before anything else, make sure that your WiPy is running
+Before anything else, make sure that your WiPy is running
 the latest software, check :ref:`OTA How-To <wipy_firmware_upgrade>` for instructions.
 
-1. Get the `Blynk library <https://github.com/wipy/wipy/blob/master/lib/blynk/BlynkLib.py>`_ and put it in ``/flash/lib/`` via FTP.
-2. Get the `Blynk examples <https://github.com/wipy/wipy/tree/master/examples/blynk>`_, edit the network settings, and afterwards
-   upload them to ``/flash/lib/`` via FTP as well.
+1. Get the `Blynk library <https://github.com/vshymanskyy/blynk-library-python/blob/master/BlynkLib.py>`_ and put it in ``/flash/lib/`` via FTP.
+2. Get the `Blynk example for WiPy <https://github.com/vshymanskyy/blynk-library-python/blob/master/examples/hardware/PyCom_WiPy.py>`_, edit the network settings, and afterwards
+   upload it to ``/flash/`` via FTP as well.
 3. Follow the instructions on each example to setup the Blynk dashboard on your smartphone or tablet.
 4. Give it a try, for instance::
 
-   >>> execfile('01_simple.py')
+   >>> execfile('sync_virtual.py')


### PR DESCRIPTION
The WiPy docs link to an outdated (and no longer functional) version of Blynk library.
This links to the new Blynk Library 0.2.0, which supports all of the WiPy versions