### PR TITLE
Add support clock mode for ESP32 ethernet module

### DIFF
--- a/ports/esp32/modnetwork.c
+++ b/ports/esp32/modnetwork.c
@@ -41,6 +41,7 @@
 #include "py/mphal.h"
 #include "py/mperrno.h"
 #include "netutils.h"
+#include "esp_eth.h"
 #include "esp_wifi.h"
 #include "esp_wifi_types.h"
 #include "esp_log.h"
@@ -696,6 +697,14 @@ STATIC const mp_rom_map_elem_t mp_module_network_globals_table[] = {
 
     { MP_ROM_QSTR(MP_QSTR_PHY_LAN8720), MP_ROM_INT(PHY_LAN8720) },
     { MP_ROM_QSTR(MP_QSTR_PHY_TLK110), MP_ROM_INT(PHY_TLK110) },
+
+    // ETH Clock modes from ESP-IDF
+    { MP_ROM_QSTR(MP_QSTR_ETH_CLOCK_GPIO0_IN), MP_ROM_INT(ETH_CLOCK_GPIO0_IN) },
+    // Disabled at Aug 22nd 2018, reenabled Jan 28th 2019 in ESP-IDF
+    // Because we use older SDK, it's currently disabled
+    //{ MP_ROM_QSTR(MP_QSTR_ETH_CLOCK_GPIO0_OUT), MP_ROM_INT(ETH_CLOCK_GPIO0_OUT) },
+    { MP_ROM_QSTR(MP_QSTR_ETH_CLOCK_GPIO16_OUT), MP_ROM_INT(ETH_CLOCK_GPIO16_OUT) },
+    { MP_ROM_QSTR(MP_QSTR_ETH_CLOCK_GPIO17_OUT), MP_ROM_INT(ETH_CLOCK_GPIO17_OUT) },
 
     { MP_ROM_QSTR(MP_QSTR_STAT_IDLE), MP_ROM_INT(STAT_IDLE)},
     { MP_ROM_QSTR(MP_QSTR_STAT_CONNECTING), MP_ROM_INT(STAT_CONNECTING)},

--- a/ports/esp32/modnetwork.c
+++ b/ports/esp32/modnetwork.c
@@ -190,6 +190,24 @@ static esp_err_t event_handler(void *ctx, system_event_t *event) {
         }
         break;
     }
+    case SYSTEM_EVENT_GOT_IP6:
+        ESP_LOGI("network", "Got IPv6 Yey!");
+        break;
+    case SYSTEM_EVENT_ETH_START:
+        ESP_LOGI("ethernet", "start");
+        break;
+    case SYSTEM_EVENT_ETH_STOP:
+        ESP_LOGI("ethernet", "stop");
+        break;
+    case SYSTEM_EVENT_ETH_CONNECTED:
+        ESP_LOGI("ethernet", "LAN cable connected");
+        break;
+    case SYSTEM_EVENT_ETH_DISCONNECTED:
+        ESP_LOGI("ethernet", "LAN cable disconnected");
+        break;
+    case SYSTEM_EVENT_ETH_GOT_IP:
+        ESP_LOGI("ethernet", "Got IP");
+        break;
     default:
         ESP_LOGI("network", "event %d", event->event_id);
         break;

--- a/ports/esp32/network_lan.c
+++ b/ports/esp32/network_lan.c
@@ -102,7 +102,7 @@ STATIC mp_obj_t get_lan(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_ar
         { MP_QSTR_power,        MP_ARG_KW_ONLY | MP_ARG_OBJ, {.u_obj = mp_const_none} },
         { MP_QSTR_phy_addr,     MP_ARG_KW_ONLY | MP_ARG_REQUIRED | MP_ARG_INT },
         { MP_QSTR_phy_type,     MP_ARG_KW_ONLY | MP_ARG_REQUIRED | MP_ARG_INT },
-        { MP_QSTR_clock_mode,   MP_ARG_KW_ONLY | MP_ARG_INT, {.u_int = ETH_CLOCK_GPIO0_IN} },
+        { MP_QSTR_clock_mode,   MP_ARG_KW_ONLY | MP_ARG_INT, {.u_int = -1} },
     };
 
     mp_arg_val_t args[MP_ARRAY_SIZE(allowed_args)];
@@ -126,7 +126,8 @@ STATIC mp_obj_t get_lan(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_ar
         mp_raise_ValueError("invalid phy type");
     }
 
-    if (args[ARG_clock_mode].u_int != ETH_CLOCK_GPIO0_IN &&
+    if (args[ARG_clock_mode].u_int != -1 &&
+        args[ARG_clock_mode].u_int != ETH_CLOCK_GPIO0_IN &&
         // Disabled due ESP-IDF (see modnetwork.c note)
         //args[ARG_clock_mode].u_int != ETH_CLOCK_GPIO0_OUT &&
         args[ARG_clock_mode].u_int != ETH_CLOCK_GPIO16_OUT &&
@@ -154,7 +155,10 @@ STATIC mp_obj_t get_lan(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_ar
     config.phy_addr = args[ARG_phy_addr].u_int;
     config.gpio_config = init_lan_rmii;
     config.tcpip_input = tcpip_adapter_eth_input;
-    config.clock_mode = args[ARG_clock_mode].u_int;
+
+    if (args[ARG_clock_mode].u_int != -1) {
+        config.clock_mode = args[ARG_clock_mode].u_int;
+    }
 
     if (esp_eth_init(&config) == ESP_OK) {
         self->active = false;

--- a/ports/esp32/network_lan.c
+++ b/ports/esp32/network_lan.c
@@ -99,7 +99,7 @@ STATIC mp_obj_t get_lan(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_ar
         { MP_QSTR_id,           MP_ARG_OBJ, {.u_obj = mp_const_none} },
         { MP_QSTR_mdc,          MP_ARG_KW_ONLY | MP_ARG_REQUIRED | MP_ARG_OBJ },
         { MP_QSTR_mdio,         MP_ARG_KW_ONLY | MP_ARG_REQUIRED | MP_ARG_OBJ },
-        { MP_QSTR_power,        MP_ARG_KW_ONLY | MP_ARG_REQUIRED | MP_ARG_OBJ },
+        { MP_QSTR_power,        MP_ARG_KW_ONLY | MP_ARG_OBJ, {.u_obj = mp_const_none} },
         { MP_QSTR_phy_addr,     MP_ARG_KW_ONLY | MP_ARG_REQUIRED | MP_ARG_INT },
         { MP_QSTR_phy_type,     MP_ARG_KW_ONLY | MP_ARG_REQUIRED | MP_ARG_INT },
         { MP_QSTR_clock_mode,   MP_ARG_KW_ONLY | MP_ARG_INT, {.u_int = ETH_CLOCK_GPIO0_IN} },

--- a/ports/esp32/network_lan.c
+++ b/ports/esp32/network_lan.c
@@ -94,7 +94,7 @@ STATIC mp_obj_t get_lan(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_ar
         return MP_OBJ_FROM_PTR(&lan_obj);
     }
 
-    enum { ARG_id, ARG_mdc, ARG_mdio, ARG_power, ARG_phy_addr, ARG_phy_type };
+    enum { ARG_id, ARG_mdc, ARG_mdio, ARG_power, ARG_phy_addr, ARG_phy_type, ARG_clock_mode };
     static const mp_arg_t allowed_args[] = {
         { MP_QSTR_id,           MP_ARG_OBJ, {.u_obj = mp_const_none} },
         { MP_QSTR_mdc,          MP_ARG_KW_ONLY | MP_ARG_REQUIRED | MP_ARG_OBJ },
@@ -102,6 +102,7 @@ STATIC mp_obj_t get_lan(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_ar
         { MP_QSTR_power,        MP_ARG_KW_ONLY | MP_ARG_REQUIRED | MP_ARG_OBJ },
         { MP_QSTR_phy_addr,     MP_ARG_KW_ONLY | MP_ARG_REQUIRED | MP_ARG_INT },
         { MP_QSTR_phy_type,     MP_ARG_KW_ONLY | MP_ARG_REQUIRED | MP_ARG_INT },
+        { MP_QSTR_clock_mode,   MP_ARG_KW_ONLY | MP_ARG_INT },
     };
 
     mp_arg_val_t args[MP_ARRAY_SIZE(allowed_args)];
@@ -125,6 +126,16 @@ STATIC mp_obj_t get_lan(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_ar
         mp_raise_ValueError("invalid phy type");
     }
 
+    // Optional parametr, can be None or enum
+    if (args[ARG_clock_mode].u_obj != mp_const_none &&
+        args[ARG_clock_mode].u_int != ETH_CLOCK_GPIO0_IN &&
+        // Disabled due ESP-IDF (see modnetwork.c note)
+        //args[ARG_clock_mode].u_int != ETH_CLOCK_GPIO0_OUT &&
+        args[ARG_clock_mode].u_int != ETH_CLOCK_GPIO16_OUT &&
+        args[ARG_clock_mode].u_int != ETH_CLOCK_GPIO17_OUT) {
+        mp_raise_ValueError("invalid clock mode");
+    }
+
     eth_config_t config;
 
     switch (args[ARG_phy_type].u_int) {
@@ -145,6 +156,9 @@ STATIC mp_obj_t get_lan(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_ar
     config.phy_addr = args[ARG_phy_addr].u_int;
     config.gpio_config = init_lan_rmii;
     config.tcpip_input = tcpip_adapter_eth_input;
+
+    // Clock mode, if not specified, fallback to default GPIO0 IN mode
+    config.clock_mode = args[ARG_clock_mode].u_obj == mp_const_none ? ETH_CLOCK_GPIO0_IN : args[ARG_clock_mode].u_int;
 
     if (esp_eth_init(&config) == ESP_OK) {
         self->active = false;

--- a/ports/esp32/network_lan.c
+++ b/ports/esp32/network_lan.c
@@ -102,7 +102,7 @@ STATIC mp_obj_t get_lan(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_ar
         { MP_QSTR_power,        MP_ARG_KW_ONLY | MP_ARG_REQUIRED | MP_ARG_OBJ },
         { MP_QSTR_phy_addr,     MP_ARG_KW_ONLY | MP_ARG_REQUIRED | MP_ARG_INT },
         { MP_QSTR_phy_type,     MP_ARG_KW_ONLY | MP_ARG_REQUIRED | MP_ARG_INT },
-        { MP_QSTR_clock_mode,   MP_ARG_KW_ONLY | MP_ARG_INT },
+        { MP_QSTR_clock_mode,   MP_ARG_KW_ONLY | MP_ARG_INT, {.u_int = ETH_CLOCK_GPIO0_IN} },
     };
 
     mp_arg_val_t args[MP_ARRAY_SIZE(allowed_args)];
@@ -126,9 +126,7 @@ STATIC mp_obj_t get_lan(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_ar
         mp_raise_ValueError("invalid phy type");
     }
 
-    // Optional parametr, can be None or enum
-    if (args[ARG_clock_mode].u_obj != mp_const_none &&
-        args[ARG_clock_mode].u_int != ETH_CLOCK_GPIO0_IN &&
+    if (args[ARG_clock_mode].u_int != ETH_CLOCK_GPIO0_IN &&
         // Disabled due ESP-IDF (see modnetwork.c note)
         //args[ARG_clock_mode].u_int != ETH_CLOCK_GPIO0_OUT &&
         args[ARG_clock_mode].u_int != ETH_CLOCK_GPIO16_OUT &&
@@ -156,9 +154,7 @@ STATIC mp_obj_t get_lan(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_ar
     config.phy_addr = args[ARG_phy_addr].u_int;
     config.gpio_config = init_lan_rmii;
     config.tcpip_input = tcpip_adapter_eth_input;
-
-    // Clock mode, if not specified, fallback to default GPIO0 IN mode
-    config.clock_mode = args[ARG_clock_mode].u_obj == mp_const_none ? ETH_CLOCK_GPIO0_IN : args[ARG_clock_mode].u_int;
+    config.clock_mode = args[ARG_clock_mode].u_int;
 
     if (esp_eth_init(&config) == ESP_OK) {
         self->active = false;


### PR DESCRIPTION
I've added optional parameter support for network.LAN `clock_mode` and implemented new enum string for `network` module class to support Clock mode for ESP32.

Can be used for some cases when especially LAN8720 modules uses clock source from ESP's pin GPIO17.

usage:
```
import machine
import network

lan = network.LAN(mdc = machine.Pin(23), mdio = machine.Pin(18), power=None, phy_type = network.PHY_LAN8720, phy_addr=1, clock_mode=network.ETH_CLOCK_GPIO17_OUT)
lan.active(1)
```


new enum at network module:
```
>>> for i in dir(network): print(i)
... 
ETH_CLOCK_GPIO0_IN
ETH_CLOCK_GPIO16_OUT
ETH_CLOCK_GPIO17_OUT
...
```

Also added catch events for ethernet module:

```
I (44868) ethernet: start
True
>>> I (48868) ethernet: LAN cable connected
I (49798) event: eth ip: 10.0.0.137, mask: 255.255.255.0, gw: 10.0.0.1
I (49798) ethernet: Got IP
I (64868) ethernet: LAN cable disconnected
I (72868) ethernet: LAN cable connected
I (73798) event: eth ip: 10.0.0.137, mask: 255.255.255.0, gw: 10.0.0.1
I (73798) ethernet: Got IP
```

should fix #4502

Later I think about do some events like wifi has. But for fix work with different clock modes should be this enough.