### PR TITLE
nrf: readme: Add section about LTO.

### DIFF
--- a/ports/nrf/README.md
+++ b/ports/nrf/README.md
@@ -55,7 +55,21 @@ Alternatively the target board could be defined:
 
      make BOARD=pca10040
      make BOARD=pca10040 flash
-     
+
+## Compile without LTO enabled
+
+As a space optimization, LTO (Link Time Optimization) has been enabled on all
+targets in the nrf-port. The `-flto` linker flag can be toggled easily by using
+the argument LTO when building. The example below shows how to disable LTO for
+the compilation:
+
+    make BOARD=pca10040 LTO=0
+
+**Note**: There have been several issues with use of LTO in conjunction with
+GNU ARM Embedded Toolchain 7.2.1/4Q17. It's recommended to use a toolchain after
+this release, for example 7.3.1/2Q18 or 8.2.1/4Q18. The alternative would be to
+build the target using the LTO=0 as described above.
+ 
 ## Compile and Flash with Bluetooth Stack
 
 First prepare the bluetooth folder by downloading Bluetooth LE stacks and headers:


### PR DESCRIPTION
Adding section about on how to disable use of the linker flag
-flto, by setting the LTO=0 argument to Make. Also, added a
note on recommended toolchains to use that works well with
LTO enabled.