### PR TITLE
nrf: readme: Update link to nrfjprog download.

### DIFF
--- a/ports/nrf/README.md
+++ b/ports/nrf/README.md
@@ -114,13 +114,7 @@ Install the necessary tools to flash and debug using Segger:
 
 [JLink Download](https://www.segger.com/downloads/jlink#)
 
-[nrfjprog linux-32bit Download](https://www.nordicsemi.com/eng/nordic/Products/nRF52840/nRF5x-Command-Line-Tools-Linux32/58857)
-
-[nrfjprog linux-64bit Download](https://www.nordicsemi.com/eng/nordic/Products/nRF52840/nRF5x-Command-Line-Tools-Linux64/58852)
-
-[nrfjprog osx Download](https://www.nordicsemi.com/eng/nordic/Products/nRF52840/nRF5x-Command-Line-Tools-OSX/58855)
-
-[nrfjprog win32 Download](https://www.nordicsemi.com/eng/nordic/Products/nRF52840/nRF5x-Command-Line-Tools-Win32/58850)
+[nrfjprog Download](https://www.nordicsemi.com/Software-and-Tools/Development-Tools/nRF5-Command-Line-Tools/Download#infotabs)
 
 note: On Linux it might be required to link SEGGER's `libjlinkarm.so` inside nrfjprog's folder.
 


### PR DESCRIPTION
After new layout of nordicsemi.com the direct links to
command line tools (nrfjprog) has changed to become dynamic.
This patch removes the old direct links to each specific OS
variant and is replaced with one single link to the download
landing page instead.