### PR TITLE
Nrf ble adv fixes

### DIFF
--- a/ports/nrf/drivers/bluetooth/ble_drv.c
+++ b/ports/nrf/drivers/bluetooth/ble_drv.c
@@ -1088,7 +1088,7 @@ static void ble_evt_handler(ble_evt_t * p_ble_evt) {
                 char_data.decl_handle  = p_char->handle_decl;
                 char_data.value_handle = p_char->handle_value;
 
-                char_data.props |= (p_char->char_props.broadcast) ? UBLUEPY_PROP_BROADCAST : 0;
+                char_data.props  = (p_char->char_props.broadcast) ? UBLUEPY_PROP_BROADCAST : 0;
                 char_data.props |= (p_char->char_props.read) ? UBLUEPY_PROP_READ : 0;
                 char_data.props |= (p_char->char_props.write_wo_resp) ? UBLUEPY_PROP_WRITE_WO_RESP : 0;
                 char_data.props |= (p_char->char_props.write) ? UBLUEPY_PROP_WRITE : 0;

--- a/ports/nrf/drivers/bluetooth/ble_drv.c
+++ b/ports/nrf/drivers/bluetooth/ble_drv.c
@@ -109,7 +109,7 @@ static mp_obj_t mp_gattc_char_data_observer;
 #define BLE_GAP_ADV_MAX_SIZE 31
 #define BLE_DRV_CONN_CONFIG_TAG 1
 
-static uint8_t m_adv_handle;
+static uint8_t m_adv_handle = BLE_GAP_ADV_SET_HANDLE_NOT_SET;
 static uint8_t m_scan_buffer[BLE_GAP_SCAN_BUFFER_MIN];
 
 nrf_nvic_state_t nrf_nvic_state = {0};
@@ -407,7 +407,7 @@ bool ble_drv_advertise_data(ubluepy_advertise_data_t * p_adv_params) {
 
     uint8_t byte_pos = 0;
 
-    uint8_t adv_data[BLE_GAP_ADV_MAX_SIZE];
+    static uint8_t adv_data[BLE_GAP_ADV_MAX_SIZE];
 
     if (p_adv_params->device_name_len > 0) {
         ble_gap_conn_sec_mode_t sec_mode;


### PR DESCRIPTION
Issue found in testing of new s132/s140 v6.1.1 Bluetooth stack integration while verifying BLE REPL module. The advertisment data on-air was basically garbage which indicated something wrong with the advertisment data configuration. After some testing it turned out that ble_gap_adv_data_t->p_data is not copied by the stack, but rather has to be kept in persistent RAM even after sd_ble_gap_adv_set_configure() has been issued. Not able to reproduce the bug in current master, but the patch is backwards compatible and tested on top of current master (BLE REPL on microbit/nrf51822, pca10040/nrf52832 and, pca10056/nrf52840).