### PR TITLE
stm32: allow COPT to be passed in make command to override default gcc optimisation level

### DIFF
--- a/drivers/memory/spiflash.c
+++ b/drivers/memory/spiflash.c
@@ -127,7 +127,7 @@ STATIC void mp_spiflash_write_cmd_addr(mp_spiflash_t *self, uint8_t cmd, uint32_
 }
 
 STATIC int mp_spiflash_wait_sr(mp_spiflash_t *self, uint8_t mask, uint8_t val, uint32_t timeout) {
-    uint8_t sr;
+    uint8_t sr = 0;
     for (; timeout; --timeout) {
         sr = mp_spiflash_read_cmd(self, CMD_RDSR, 1);
         if ((sr & mask) == val) {

--- a/ports/stm32/Makefile
+++ b/ports/stm32/Makefile
@@ -99,9 +99,10 @@ LDFLAGS += --gc-sections
 # Debugging/Optimization
 ifeq ($(DEBUG), 1)
 CFLAGS += -g -DPENDSV_DEBUG
-COPT = -O0
+COPT ?= -O0
 else
-COPT += -Os -DNDEBUG
+COPT ?= -Os
+COPT += -DNDEBUG
 endif
 
 SRC_LIB = $(addprefix lib/,\


### PR DESCRIPTION
The stm32 gcc optimisation level is currently hardcoded in the makefile. 

In debug mode, this is `-O0` which can easily overflow on smaller device or bigger code builds (eg with frozen code).

It's useful to be able to change this to `-Og` for instance if needed for an individual project.

Eg. `make DEBUG=1 V=1 COPT="-Og"`

While doing this locally, I found a trivial uninitialised variable warning that strangely isn't detected in `-O0` or `-Os` used currently; `sr` is used uninitialised if `timeout==0`. 
I hope you don't mind me tacking it onto this same PR.