### PR TITLE
nrf: Remove superfluous NULL in machine_hard_pwm_instances.

### DIFF
--- a/ports/nrf/modules/machine/pwm.c
+++ b/ports/nrf/modules/machine/pwm.c
@@ -70,8 +70,6 @@ STATIC const nrfx_pwm_t machine_hard_pwm_instances[] = {
 #if NRF52840
     NRFX_PWM_INSTANCE(3),
 #endif
-#else
-    NULL
 #endif
 };
 


### PR DESCRIPTION
Remove a unneeded NULL in machine_hard_pwm_instances[] when not building
for NRF52_SERIES.