### PR TITLE
spiflash: Fix uninitialized variable 'sr'.

### DIFF
--- a/drivers/memory/spiflash.c
+++ b/drivers/memory/spiflash.c
@@ -128,15 +128,14 @@ STATIC void mp_spiflash_write_cmd_addr(mp_spiflash_t *self, uint8_t cmd, uint32_
 
 STATIC int mp_spiflash_wait_sr(mp_spiflash_t *self, uint8_t mask, uint8_t val, uint32_t timeout) {
     uint8_t sr;
-    for (; timeout; --timeout) {
+    do {
         sr = mp_spiflash_read_cmd(self, CMD_RDSR, 1);
         if ((sr & mask) == val) {
-            break;
+            return 0; // success
         }
-    }
-    if ((sr & mask) == val) {
-        return 0; // success
-    } else if (timeout == 0) {
+    } while (timeout--);
+
+    if (timeout == 0) {
         return -MP_ETIMEDOUT;
     } else {
         return -MP_EIO;


### PR DESCRIPTION
Fixes a trivial gcc uninitialised variable warning/error:
```
../../drivers/memory/spiflash.c: In function 'mp_spiflash_wait_sr':
../../drivers/memory/spiflash.c:137:21: error: 'sr' may be used uninitialized in this function [-Werror=maybe-uninitialized]
     if ((sr & mask) == val) {
```

 `sr` is used uninitialised if `timeout==0`.

Strangely this isn't detected in `-O0` or `-Os`, however under `-Og` it's a failing error.