### PR TITLE
py/objgenerator: Fix handling of None passed as 2nd arg to throw().

### DIFF
--- a/tests/basics/gen_yield_from_throw.py
+++ b/tests/basics/gen_yield_from_throw.py
@@ -1,8 +1,8 @@
 def gen():
     try:
         yield 1
-    except ValueError:
-        print("got ValueError from upstream!")
+    except ValueError as e:
+        print("got ValueError from upstream!", repr(e.args))
     yield "str1"
     raise TypeError
 
@@ -12,6 +12,24 @@ def gen2():
 g = gen2()
 print(next(g))
 print(g.throw(ValueError))
+try:
+    print(next(g))
+except TypeError:
+    print("got TypeError from downstream!")
+
+# passing None as second argument to throw
+g = gen2()
+print(next(g))
+print(g.throw(ValueError, None))
+try:
+    print(next(g))
+except TypeError:
+    print("got TypeError from downstream!")
+
+# passing an exception instance as second argument to throw
+g = gen2()
+print(next(g))
+print(g.throw(ValueError, ValueError(123)))
 try:
     print(next(g))
 except TypeError:

--- a/tests/basics/generator_throw.py
+++ b/tests/basics/generator_throw.py
@@ -28,8 +28,8 @@ except StopIteration:
 def gen():
     try:
         yield 123
-    except GeneratorExit:
-        print('GeneratorExit')
+    except GeneratorExit as e:
+        print('GeneratorExit', repr(e.args))
     yield 456
         
 # thrown a class
@@ -41,3 +41,13 @@ print(g.throw(GeneratorExit))
 g = gen()
 print(next(g))
 print(g.throw(GeneratorExit()))
+
+# thrown an instance with None as second arg
+g = gen()
+print(next(g))
+print(g.throw(GeneratorExit(), None))
+
+# thrown a class and instance
+g = gen()
+print(next(g))
+print(g.throw(GeneratorExit, GeneratorExit(123)))


### PR DESCRIPTION
Addresses issue #4527