### PR TITLE
esp32/modnetwork: Fixed wifi.isconnected() is always true, even disconn

### DIFF
--- a/ports/esp32/modnetwork.c
+++ b/ports/esp32/modnetwork.c
@@ -169,7 +169,7 @@ static esp_err_t event_handler(void *ctx, system_event_t *event) {
         }
         ESP_LOGI("wifi", "STA_DISCONNECTED, reason:%d%s", disconn->reason, message);
 
-        bool reconnected = false;
+        wifi_sta_connected = false;
         if (wifi_sta_connect_requested) {
             wifi_mode_t mode;
             if (esp_wifi_get_mode(&mode) == ESP_OK) {
@@ -178,15 +178,9 @@ static esp_err_t event_handler(void *ctx, system_event_t *event) {
                     esp_err_t e = esp_wifi_connect();
                     if (e != ESP_OK) {
                         ESP_LOGI("wifi", "error attempting to reconnect: 0x%04x", e);
-                    } else {
-                        reconnected = true;
                     }
                 }
             }
-        }
-        if (wifi_sta_connected && !reconnected) {
-            // If already connected and we fail to reconnect
-            wifi_sta_connected = false;
         }
         break;
     }


### PR DESCRIPTION
I wonder why wlan.isconnected() always return "true" even when some AP gets reboot. And I found patch in commit 039f196c56b97d879b7ce731cd479395dd479c3d which redone logic "is connected" to support StaticIP. Unfortunately it break situation when you are successfully connected and later some AP lost.

This commit fix that, I tested it with static and with dynamic IP. Also in case new connect and also reconnect.

Explain why this idea does not work is: Code probably replied on situation when in `reconnect` part will `esp_wifi_connect` return something else than ESP_OK. But regarding to SDK documentation, ESP_OK is return whenever API success. Non OK will return just on some critical error (such out-of-mem...).
This way made code think every (even unsuccessful) attempt of reconnect considered was successful.

It's enough to have it like this, because after reconnect `GOT_IP` event is called and it will change `wifi_sta_connected` back to True