### PR TITLE
extmod/moduhashlib: Add members to `sha256` to make it usable by the `hmac` module.

### DIFF
--- a/docs/library/uhashlib.rst
+++ b/docs/library/uhashlib.rst
@@ -55,3 +55,8 @@ Methods
 
    This method is NOT implemented. Use ``ubinascii.hexlify(hash.digest())``
    to achieve a similar effect.
+
+.. method:: hash.copy()
+
+   Return a copy (“clone”) of the hash object. Availability depends on `MicroPython port`.
+

--- a/extmod/moduhashlib.c
+++ b/extmod/moduhashlib.c
@@ -74,9 +74,11 @@ STATIC mp_obj_t uhashlib_sha256_update(mp_obj_t self_in, mp_obj_t arg);
 #define mbedtls_sha256_finish_ret mbedtls_sha256_finish
 #endif
 
+#define SHA256_CONTEXT_SIZE sizeof(mbedtls_sha256_context)
+
 STATIC mp_obj_t uhashlib_sha256_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *args) {
     mp_arg_check_num(n_args, n_kw, 0, 1, false);
-    mp_obj_hash_t *o = m_new_obj_var(mp_obj_hash_t, char, sizeof(mbedtls_sha256_context));
+    mp_obj_hash_t *o = m_new_obj_var(mp_obj_hash_t, char, SHA256_CONTEXT_SIZE);
     o->base.type = type;
     mbedtls_sha256_init((mbedtls_sha256_context*)&o->state);
     mbedtls_sha256_starts_ret((mbedtls_sha256_context*)&o->state, 0);
@@ -106,9 +108,11 @@ STATIC mp_obj_t uhashlib_sha256_digest(mp_obj_t self_in) {
 
 #include "crypto-algorithms/sha256.c"
 
+#define SHA256_CONTEXT_SIZE sizeof(CRYAL_SHA256_CTX)
+
 STATIC mp_obj_t uhashlib_sha256_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *args) {
     mp_arg_check_num(n_args, n_kw, 0, 1, false);
-    mp_obj_hash_t *o = m_new_obj_var(mp_obj_hash_t, char, sizeof(CRYAL_SHA256_CTX));
+    mp_obj_hash_t *o = m_new_obj_var(mp_obj_hash_t, char, SHA256_CONTEXT_SIZE);
     o->base.type = type;
     sha256_init((CRYAL_SHA256_CTX*)o->state);
     if (n_args == 1) {
@@ -137,9 +141,23 @@ STATIC mp_obj_t uhashlib_sha256_digest(mp_obj_t self_in) {
 STATIC MP_DEFINE_CONST_FUN_OBJ_2(uhashlib_sha256_update_obj, uhashlib_sha256_update);
 STATIC MP_DEFINE_CONST_FUN_OBJ_1(uhashlib_sha256_digest_obj, uhashlib_sha256_digest);
 
+#if MICROPY_PY_UHASHLIB_SHA256_FOR_HMAC
+STATIC mp_obj_t uhashlib_sha256_copy(mp_obj_t self_in) {
+    mp_obj_hash_t *o = m_new_obj_var(mp_obj_hash_t, char, SHA256_CONTEXT_SIZE);
+    memcpy(o, self_in, sizeof(*o) + SHA256_CONTEXT_SIZE);
+    return MP_OBJ_FROM_PTR(o);
+}
+STATIC MP_DEFINE_CONST_FUN_OBJ_1(uhashlib_sha256_copy_obj, uhashlib_sha256_copy);
+#endif
+
 STATIC const mp_rom_map_elem_t uhashlib_sha256_locals_dict_table[] = {
     { MP_ROM_QSTR(MP_QSTR_update), MP_ROM_PTR(&uhashlib_sha256_update_obj) },
     { MP_ROM_QSTR(MP_QSTR_digest), MP_ROM_PTR(&uhashlib_sha256_digest_obj) },
+#if MICROPY_PY_UHASHLIB_SHA256_FOR_HMAC
+    { MP_ROM_QSTR(MP_QSTR_copy), MP_ROM_PTR(&uhashlib_sha256_copy_obj) },
+    { MP_ROM_QSTR(MP_QSTR_digest_size), MP_ROM_INT(32) },
+    { MP_ROM_QSTR(MP_QSTR_block_size), MP_ROM_INT(64) },
+#endif
 };
 
 STATIC MP_DEFINE_CONST_DICT(uhashlib_sha256_locals_dict, uhashlib_sha256_locals_dict_table);

--- a/ports/unix/mpconfigport_coverage.h
+++ b/ports/unix/mpconfigport_coverage.h
@@ -58,6 +58,7 @@
 #define MICROPY_PY_FRAMEBUF            (1)
 #define MICROPY_PY_COLLECTIONS_NAMEDTUPLE__ASDICT (1)
 #define MICROPY_PY_UCRYPTOLIB          (1)
+#define MICROPY_PY_UHASHLIB_SHA256_FOR_HMAC (1)
 
 // TODO these should be generic, not bound to fatfs
 #define mp_type_fileio mp_type_vfs_posix_fileio

--- a/py/mpconfig.h
+++ b/py/mpconfig.h
@@ -1267,6 +1267,11 @@ typedef double mp_float_t;
 #define MICROPY_PY_UHASHLIB_SHA256 (1)
 #endif
 
+// `hmac` module requires some attributes not always available from hash objects.
+#ifndef MICROPY_PY_UHASHLIB_SHA256_FOR_HMAC
+#define MICROPY_PY_UHASHLIB_SHA256_FOR_HMAC (0)
+#endif
+
 #ifndef MICROPY_PY_UCRYPTOLIB
 #define MICROPY_PY_UCRYPTOLIB (0)
 #endif

--- a/tests/extmod/uhashlib_sha256_hmac.py
+++ b/tests/extmod/uhashlib_sha256_hmac.py
@@ -1,0 +1,31 @@
+try:
+    import uhashlib as hashlib
+except ImportError:
+    try:
+        import hashlib
+    except ImportError:
+        # This is neither uPy, nor cPy, so must be uPy with
+        # uhashlib module disabled.
+        print("SKIP")
+        raise SystemExit
+
+try:
+    h = hashlib.sha256()
+    h.digest_size
+except AttributeError:
+    # SHA256/Extra attributes not enabled.
+    print("SKIP")
+    raise SystemExit
+
+
+print(h.block_size)
+print(h.digest_size)
+
+h.update(b"12343")
+h2 = h.copy()
+
+h.update(b"5")
+h2.update(b"6")
+
+print(h.digest())
+print(h2.digest())


### PR DESCRIPTION
`micropython-hmac` reuiqres extra attributes currently not implemented by `uhashlib`;
This patch enables them (and fixes #4500) if demanded (only for SHA256 though).