### PR TITLE
docs/uos: Document extra requirements from stream objects passed to `dupterm`.

### DIFF
--- a/docs/library/uos.rst
+++ b/docs/library/uos.rst
@@ -115,7 +115,8 @@ Terminal redirection and duplication
 .. function:: dupterm(stream_object, index=0)
 
    Duplicate or switch the MicroPython terminal (the REPL) on the given `stream`-like
-   object. The *stream_object* argument must implement the ``readinto()`` and
+   object. The *stream_object* argument must be a native stream object, or derive
+   from ``uio.IOBase`` and implement the ``readinto()`` and
    ``write()`` methods.  The stream should be in non-blocking mode and
    ``readinto()`` should return ``None`` if there is no data available for reading.
 


### PR DESCRIPTION
As said here: https://forum.micropython.org/viewtopic.php?f=8&t=5868&p=33586

This is only correct for the `extmod/uos_dupterm.c` impl however, as e.g
`cc3200` impl does the `mp_load_method` itself, and anyway requires `read`
instead of `readinto`. Consolidation would do good.