### PR TITLE
py/compile: Fix handling of unwinding BaseException in async with.

### DIFF
--- a/py/compile.c
+++ b/py/compile.c
@@ -1830,7 +1830,7 @@ STATIC void compile_async_with_stmt_helper(compiler_t *comp, int n, mp_parse_nod
 
         // Detect if TOS an exception or not
         EMIT(dup_top);
-        EMIT_LOAD_GLOBAL(MP_QSTR_Exception);
+        EMIT_LOAD_GLOBAL(MP_QSTR_BaseException);
         EMIT_ARG(binary_op, MP_BINARY_OP_EXCEPTION_MATCH);
         EMIT_ARG(pop_jump_if, false, l_ret_unwind_jump); // if not an exception then we have case 3
 

--- a/tests/basics/async_with.py
+++ b/tests/basics/async_with.py
@@ -27,3 +27,13 @@ try:
     o.send(None)
 except ValueError:
     print('ValueError')
+
+# test raising BaseException to make sure it is handled by the async-with
+async def h():
+    async with AContext():
+        raise BaseException
+o = h()
+try:
+    o.send(None)
+except BaseException:
+    print('BaseException')

--- a/tests/basics/async_with.py.exp
+++ b/tests/basics/async_with.py.exp
@@ -6,3 +6,6 @@ enter
 1
 exit <class 'ValueError'> error
 ValueError
+enter
+exit <class 'BaseException'> 
+BaseException


### PR DESCRIPTION
Fixes #4552 