### PR TITLE
esp32: add GPIO hold capability

### DIFF
--- a/docs/library/esp32.rst
+++ b/docs/library/esp32.rst
@@ -11,6 +11,11 @@ controlling ESP32 modules.
 Functions
 ---------
 
+.. function:: gpio_hold(pin, hold)
+
+    Configure IO hold functionality on the given *pin*.
+    *hold* should be a boolean value: true to enable and false to disable the hold.
+
 .. function:: wake_on_touch(wake)
 
     Configure whether or not a touch will wake the device from sleep.

--- a/docs/library/machine.Pin.rst
+++ b/docs/library/machine.Pin.rst
@@ -235,6 +235,7 @@ not all constants are available on all ports.
 
 .. data:: Pin.PULL_UP
           Pin.PULL_DOWN
+          Pin.PULL_HOLD
 
    Selects whether there is a pull up/down resistor.  Use the value
    ``None`` for no pull.

--- a/ports/esp32/machine_pin.c
+++ b/ports/esp32/machine_pin.c
@@ -137,7 +137,7 @@ STATIC mp_obj_t machine_pin_obj_init_helper(const machine_pin_obj_t *self, size_
     enum { ARG_mode, ARG_pull, ARG_value };
     static const mp_arg_t allowed_args[] = {
         { MP_QSTR_mode, MP_ARG_OBJ, {.u_obj = mp_const_none}},
-        { MP_QSTR_pull, MP_ARG_OBJ, {.u_obj = mp_const_none}},
+        { MP_QSTR_pull, MP_ARG_OBJ, {.u_obj = MP_OBJ_NEW_SMALL_INT(-1)}},
         { MP_QSTR_value, MP_ARG_KW_ONLY | MP_ARG_OBJ, {.u_obj = MP_OBJ_NULL}},
     };
 
@@ -164,8 +164,12 @@ STATIC mp_obj_t machine_pin_obj_init_helper(const machine_pin_obj_t *self, size_
     }
 
     // configure pull
-    if (args[ARG_pull].u_obj != mp_const_none) {
-        gpio_set_pull_mode(self->id, mp_obj_get_int(args[ARG_pull].u_obj));
+    if (args[ARG_pull].u_obj != MP_OBJ_NEW_SMALL_INT(-1)) {
+        if (args[ARG_pull].u_obj == mp_const_none) {
+            gpio_set_pull_mode(self->id, GPIO_FLOATING);
+        } else {
+            gpio_set_pull_mode(self->id, mp_obj_get_int(args[ARG_pull].u_obj));
+        }
     }
 
     return mp_const_none;

--- a/ports/esp32/modesp32.c
+++ b/ports/esp32/modesp32.c
@@ -43,6 +43,17 @@
 #include "machine_rtc.h"
 #include "modesp32.h"
 
+STATIC mp_obj_t esp32_gpio_hold(mp_obj_t pin_obj, mp_obj_t hold) {
+    gpio_num_t pin = machine_pin_get_id(pin_obj);
+    if (mp_obj_is_true(hold)) {
+        gpio_hold_en(pin);
+    } else {
+        gpio_hold_dis(pin);
+    }
+    return mp_const_none;
+}
+STATIC MP_DEFINE_CONST_FUN_OBJ_2(esp32_gpio_hold_obj, esp32_gpio_hold);
+
 STATIC mp_obj_t esp32_wake_on_touch(const mp_obj_t wake) {
 
     if (machine_rtc_config.ext0_pin != -1) {
@@ -148,6 +159,7 @@ STATIC MP_DEFINE_CONST_FUN_OBJ_0(esp32_hall_sensor_obj, esp32_hall_sensor);
 STATIC const mp_rom_map_elem_t esp32_module_globals_table[] = {
     { MP_ROM_QSTR(MP_QSTR___name__), MP_ROM_QSTR(MP_QSTR_esp32) },
 
+    { MP_ROM_QSTR(MP_QSTR_gpio_hold), MP_ROM_PTR(&esp32_gpio_hold_obj) },
     { MP_ROM_QSTR(MP_QSTR_wake_on_touch), MP_ROM_PTR(&esp32_wake_on_touch_obj) },
     { MP_ROM_QSTR(MP_QSTR_wake_on_ext0), MP_ROM_PTR(&esp32_wake_on_ext0_obj) },
     { MP_ROM_QSTR(MP_QSTR_wake_on_ext1), MP_ROM_PTR(&esp32_wake_on_ext1_obj) },


### PR DESCRIPTION
This can be used to lower power consumption during deepsleep.

Eg:
```python
rtc_pin.init(rtc_pin.IN, None)
esp32.gpio_hold(rtc_pin)
machine.deepsleep()
```