### PR TITLE
esp32/modnetwork: Added RSSI for WiFi STA

### DIFF
--- a/ports/esp32/modnetwork.c
+++ b/ports/esp32/modnetwork.c
@@ -46,7 +46,6 @@
 #include "esp_wifi_types.h"
 #include "esp_log.h"
 #include "esp_event_loop.h"
-#include "esp_log.h"
 #include "lwip/dns.h"
 #include "tcpip_adapter.h"
 

--- a/ports/esp32/modnetwork.c
+++ b/ports/esp32/modnetwork.c
@@ -398,7 +398,14 @@ STATIC mp_obj_t esp_status(size_t n_args, const mp_obj_t *args) {
             }
             return list;
         }
+        case (uintptr_t)MP_OBJ_NEW_QSTR(MP_QSTR_rssi): {
+            // return signal of AP, only in STA mode
+            require_if(args[0], WIFI_IF_STA);
 
+            wifi_ap_record_t info;
+            ESP_EXCEPTIONS(esp_wifi_sta_get_ap_info(&info));
+            return MP_OBJ_NEW_SMALL_INT(info.rssi);
+        }
         default:
             mp_raise_ValueError("unknown status param");
     }


### PR DESCRIPTION
Basically inspired from Arduino-C and STA code from uPy. Return RSSI value (int) when connected. Otherwise return None. For non-STA throw exception. (copied from other function actually, I supposed it's handy to keep it).