### PR TITLE
stm32/qspi: Rework qspi configuration using stm32 hal interface.

### DIFF
--- a/ports/stm32/Makefile
+++ b/ports/stm32/Makefile
@@ -299,6 +299,7 @@ SRC_HAL = $(addprefix $(HAL_DIR)/Src/stm32$(MCU_SERIES)xx_,\
 	hal_flash_ex.c \
 	hal_gpio.c \
 	hal_i2c.c \
+	hal_qspi.c \
 	hal_pcd.c \
 	hal_pcd_ex.c \
 	hal_pwr.c \

--- a/ports/stm32/qspi.c
+++ b/ports/stm32/qspi.c
@@ -26,6 +26,7 @@
 
 #include <string.h>
 
+#include "py/obj.h"
 #include "py/mperrno.h"
 #include "py/mphal.h"
 #include "qspi.h"
@@ -33,7 +34,245 @@
 
 #if defined(MICROPY_HW_QSPIFLASH_SIZE_BITS_LOG2)
 
-void qspi_init(void) {
+QSPI_HandleTypeDef QSPIHandle;
+
+#define QSPI_OK             0
+#define QSPI_ERROR         -1
+#define QSPI_NOT_SUPPORTED -2
+
+/* Status Register */
+#define SR_WIP                      ((uint8_t)0x01)    /*!< Write in progress */
+#define SR_WREN                     ((uint8_t)0x02)    /*!< Write enable latch */
+#define SR_BLOCKPR                  ((uint8_t)0x5C)    /*!< Block protected against program and erase operations */
+#define SR_PRBOTTOM                 ((uint8_t)0x20)    /*!< Protected memory area defined by BLOCKPR starts from top or bottom */
+#define SR_SRWREN                   ((uint8_t)0x80)    /*!< Status register write enable/disable */
+
+#define DUMMY_CYCLES_READ_QUAD      10
+#define VCR_NB_DUMMY                ((uint8_t)0xF0)    /*!< Number of dummy clock cycles */
+
+/* Reset Operations */
+#define RESET_ENABLE_CMD                     0x66
+#define RESET_MEMORY_CMD                     0x99
+
+/* Identification Operations */
+#define READ_ID_CMD                          0x9E
+#define READ_ID_CMD2                         0x9F
+#define MULTIPLE_IO_READ_ID_CMD              0xAF
+#define READ_SERIAL_FLASH_DISCO_PARAM_CMD    0x5A
+
+/* Read Operations */
+#define READ_CMD                             0x03
+#define FAST_READ_CMD                        0x0B
+#define DUAL_OUT_FAST_READ_CMD               0x3B
+#define DUAL_INOUT_FAST_READ_CMD             0xBB
+#define QUAD_OUT_FAST_READ_CMD               0x6B
+#define QUAD_INOUT_FAST_READ_CMD             0xEB
+
+/* Write Operations */
+#define WRITE_ENABLE_CMD                     0x06
+#define WRITE_DISABLE_CMD                    0x04
+
+/* Register Operations */
+#define READ_STATUS_REG_CMD                  0x05
+#define WRITE_STATUS_REG_CMD                 0x01
+
+#define READ_LOCK_REG_CMD                    0xE8
+#define WRITE_LOCK_REG_CMD                   0xE5
+
+#define READ_FLAG_STATUS_REG_CMD             0x70
+#define CLEAR_FLAG_STATUS_REG_CMD            0x50
+
+#define READ_NONVOL_CFG_REG_CMD              0xB5
+#define WRITE_NONVOL_CFG_REG_CMD             0xB1
+
+#define READ_VOL_CFG_REG_CMD                 0x85
+#define WRITE_VOL_CFG_REG_CMD                0x81
+
+/**
+  * @brief  This function send a Write Enable and wait it is effective.
+  * @param  hqspi: QSPI handle
+  * @retval None
+  */
+static uint8_t QSPI_WriteEnable(QSPI_HandleTypeDef *hqspi)
+{
+    QSPI_CommandTypeDef     s_command;
+    QSPI_AutoPollingTypeDef s_config;
+
+    /* Enable write operations */
+    s_command.InstructionMode   = QSPI_INSTRUCTION_1_LINE;
+    s_command.Instruction       = WRITE_ENABLE_CMD;
+    s_command.AddressMode       = QSPI_ADDRESS_NONE;
+    s_command.AlternateByteMode = QSPI_ALTERNATE_BYTES_NONE;
+    s_command.DataMode          = QSPI_DATA_NONE;
+    s_command.DummyCycles       = 0;
+    s_command.DdrMode           = QSPI_DDR_MODE_DISABLE;
+    s_command.DdrHoldHalfCycle  = QSPI_DDR_HHC_ANALOG_DELAY;
+    s_command.SIOOMode          = QSPI_SIOO_INST_EVERY_CMD;
+
+    if (HAL_QSPI_Command(hqspi, &s_command, HAL_QPSI_TIMEOUT_DEFAULT_VALUE) != HAL_OK)
+    {
+        return QSPI_ERROR;
+    }
+    
+    /* Configure automatic polling mode to wait for write enabling */  
+    s_config.Match           = SR_WREN;
+    s_config.Mask            = SR_WREN;
+    s_config.MatchMode       = QSPI_MATCH_MODE_AND;
+    s_config.StatusBytesSize = 1;
+    s_config.Interval        = 0x10;
+    s_config.AutomaticStop   = QSPI_AUTOMATIC_STOP_ENABLE;
+
+    s_command.Instruction    = READ_STATUS_REG_CMD;
+    s_command.DataMode       = QSPI_DATA_1_LINE;
+
+    if (HAL_QSPI_AutoPolling(hqspi, &s_command, &s_config, HAL_QPSI_TIMEOUT_DEFAULT_VALUE) != HAL_OK)
+    {
+        return QSPI_ERROR;
+    }
+
+  return QSPI_OK;
+}
+
+
+/**
+  * @brief  This function read the SR of the memory and wait the EOP.
+  * @param  hqspi: QSPI handle
+  * @param  Timeout
+  * @retval None
+  */
+static uint8_t QSPI_AutoPollingMemReady(QSPI_HandleTypeDef *hqspi, uint32_t Timeout)
+{
+    QSPI_CommandTypeDef     s_command;
+    QSPI_AutoPollingTypeDef s_config;
+
+    /* Configure automatic polling mode to wait for memory ready */  
+    s_command.InstructionMode   = QSPI_INSTRUCTION_1_LINE;
+    s_command.Instruction       = READ_STATUS_REG_CMD;
+    s_command.AddressMode       = QSPI_ADDRESS_NONE;
+    s_command.AlternateByteMode = QSPI_ALTERNATE_BYTES_NONE;
+    s_command.DataMode          = QSPI_DATA_1_LINE;
+    s_command.DummyCycles       = 0;
+    s_command.DdrMode           = QSPI_DDR_MODE_DISABLE;
+    s_command.DdrHoldHalfCycle  = QSPI_DDR_HHC_ANALOG_DELAY;
+    s_command.SIOOMode          = QSPI_SIOO_INST_EVERY_CMD;
+
+    s_config.Match           = 0;
+    s_config.Mask            = SR_WIP;
+    s_config.MatchMode       = QSPI_MATCH_MODE_AND;
+    s_config.StatusBytesSize = 1;
+    s_config.Interval        = 0x10;
+    s_config.AutomaticStop   = QSPI_AUTOMATIC_STOP_ENABLE;
+
+    if (HAL_QSPI_AutoPolling(hqspi, &s_command, &s_config, Timeout) != HAL_OK)
+    {
+        return QSPI_ERROR;
+    }
+
+    return QSPI_OK;
+}
+
+/**
+  * @brief  This function reset the QSPI memory.
+  * @param  hqspi: QSPI handle
+  * @retval None
+  */
+static uint8_t QSPI_ResetMemory(QSPI_HandleTypeDef *hqspi)
+{
+    QSPI_CommandTypeDef s_command;
+
+    /* Initialize the reset enable command */
+    s_command.InstructionMode   = QSPI_INSTRUCTION_1_LINE;
+    s_command.Instruction       = RESET_ENABLE_CMD;
+    s_command.AddressMode       = QSPI_ADDRESS_NONE;
+    s_command.AlternateByteMode = QSPI_ALTERNATE_BYTES_NONE;
+    s_command.DataMode          = QSPI_DATA_NONE;
+    s_command.DummyCycles       = 0;
+    s_command.DdrMode           = QSPI_DDR_MODE_DISABLE;
+    s_command.DdrHoldHalfCycle  = QSPI_DDR_HHC_ANALOG_DELAY;
+    s_command.SIOOMode          = QSPI_SIOO_INST_EVERY_CMD;
+
+    /* Send the command */
+    if (HAL_QSPI_Command(hqspi, &s_command, HAL_QPSI_TIMEOUT_DEFAULT_VALUE) != HAL_OK)
+    {
+        return QSPI_ERROR;
+    }
+
+    /* Send the reset memory command */
+    s_command.Instruction = RESET_MEMORY_CMD;
+    if (HAL_QSPI_Command(hqspi, &s_command, HAL_QPSI_TIMEOUT_DEFAULT_VALUE) != HAL_OK)
+    {
+        return QSPI_ERROR;
+    }
+
+    /* Configure automatic polling mode to wait the memory is ready */  
+    if (QSPI_AutoPollingMemReady(hqspi, HAL_QPSI_TIMEOUT_DEFAULT_VALUE) != QSPI_OK)
+    {
+        return QSPI_ERROR;
+    }
+
+    return QSPI_OK;
+}
+
+/**
+  * @brief  This function configure the dummy cycles on memory side.
+  * @param  hqspi: QSPI handle
+  * @retval None
+  */
+static uint8_t QSPI_DummyCyclesCfg(QSPI_HandleTypeDef *hqspi)
+{
+    QSPI_CommandTypeDef s_command;
+    uint8_t reg;
+
+    /* Initialize the read volatile configuration register command */
+    s_command.InstructionMode   = QSPI_INSTRUCTION_1_LINE;
+    s_command.Instruction       = READ_VOL_CFG_REG_CMD;
+    s_command.AddressMode       = QSPI_ADDRESS_NONE;
+    s_command.AlternateByteMode = QSPI_ALTERNATE_BYTES_NONE;
+    s_command.DataMode          = QSPI_DATA_1_LINE;
+    s_command.DummyCycles       = 0;
+    s_command.NbData            = 1;
+    s_command.DdrMode           = QSPI_DDR_MODE_DISABLE;
+    s_command.DdrHoldHalfCycle  = QSPI_DDR_HHC_ANALOG_DELAY;
+    s_command.SIOOMode          = QSPI_SIOO_INST_EVERY_CMD;
+
+    /* Configure the command */
+    if (HAL_QSPI_Command(hqspi, &s_command, HAL_QPSI_TIMEOUT_DEFAULT_VALUE) != HAL_OK)
+    {
+        return QSPI_ERROR;
+    }
+
+    /* Reception of the data */
+    if (HAL_QSPI_Receive(hqspi, &reg, HAL_QPSI_TIMEOUT_DEFAULT_VALUE) != HAL_OK)
+    {
+        return QSPI_ERROR;
+    }
+
+    /* Enable write operations */
+    if (QSPI_WriteEnable(hqspi) != QSPI_OK)
+    {
+        return QSPI_ERROR;
+    }
+
+    /* Update volatile configuration register (with new dummy cycles) */  
+    s_command.Instruction = WRITE_VOL_CFG_REG_CMD;
+    MODIFY_REG(reg, VCR_NB_DUMMY, (DUMMY_CYCLES_READ_QUAD << POSITION_VAL(VCR_NB_DUMMY)));
+        
+    /* Configure the write volatile configuration register command */
+    if (HAL_QSPI_Command(hqspi, &s_command, HAL_QPSI_TIMEOUT_DEFAULT_VALUE) != HAL_OK)
+    {
+        return QSPI_ERROR;
+    }
+
+    /* Transmission of the data */
+    if (HAL_QSPI_Transmit(hqspi, &reg, HAL_QPSI_TIMEOUT_DEFAULT_VALUE) != HAL_OK)
+    {
+        return QSPI_ERROR;
+    }
+    
+    return QSPI_OK;
+}
+
+int qspi_init(void) {
     // Configure pins
     mp_hal_pin_config_alt_static(MICROPY_HW_QSPIFLASH_CS, MP_HAL_PIN_MODE_ALT, MP_HAL_PIN_PULL_NONE, STATIC_AF_QUADSPI_BK1_NCS);
     mp_hal_pin_config_alt_static(MICROPY_HW_QSPIFLASH_SCK, MP_HAL_PIN_MODE_ALT, MP_HAL_PIN_PULL_NONE, STATIC_AF_QUADSPI_CLK);
@@ -45,46 +284,115 @@ void qspi_init(void) {
     // Bring up the QSPI peripheral
 
     __HAL_RCC_QSPI_CLK_ENABLE();
+    __QSPI_FORCE_RESET();
+    __QSPI_RELEASE_RESET();
 
-    QUADSPI->CR =
-        2 << QUADSPI_CR_PRESCALER_Pos // F_CLK = F_AHB/3 (72MHz when CPU is 216MHz)
-        | 3 << QUADSPI_CR_FTHRES_Pos // 4 bytes must be available to read/write
-        #if defined(QUADSPI_CR_FSEL_Pos)
-        | 0 << QUADSPI_CR_FSEL_Pos // FLASH 1 selected
-        #endif
-        #if defined(QUADSPI_CR_DFM_Pos)
-        | 0 << QUADSPI_CR_DFM_Pos // dual-flash mode disabled
-        #endif
-        | 0 << QUADSPI_CR_SSHIFT_Pos // no sample shift
-        | 1 << QUADSPI_CR_TCEN_Pos // timeout counter enabled
-        | 1 << QUADSPI_CR_EN_Pos // enable the peripheral
-        ;
+      QSPIHandle.Instance = QUADSPI;
 
-    QUADSPI->DCR =
-        (MICROPY_HW_QSPIFLASH_SIZE_BITS_LOG2 - 3 - 1) << QUADSPI_DCR_FSIZE_Pos
-        | 1 << QUADSPI_DCR_CSHT_Pos // nCS stays high for 2 cycles
-        | 0 << QUADSPI_DCR_CKMODE_Pos // CLK idles at low state
-        ;
+    /* Call the DeInit function to reset the driver */
+    if (HAL_QSPI_DeInit(&QSPIHandle) != HAL_OK)
+    {
+        return QSPI_ERROR;
+    }
+
+    // QUADSPI->CR =
+    //     2 << QUADSPI_CR_PRESCALER_Pos // F_CLK = F_AHB/3 (72MHz when CPU is 216MHz)
+    //     | 3 << QUADSPI_CR_FTHRES_Pos // 4 bytes must be available to read/write
+    //     #if defined(QUADSPI_CR_FSEL_Pos)
+    //     | 0 << QUADSPI_CR_FSEL_Pos // FLASH 1 selected
+    //     #endif
+    //     #if defined(QUADSPI_CR_DFM_Pos)
+    //     | 0 << QUADSPI_CR_DFM_Pos // dual-flash mode disabled
+    //     #endif
+    //     | 0 << QUADSPI_CR_SSHIFT_Pos // no sample shift
+    //     | 1 << QUADSPI_CR_TCEN_Pos // timeout counter enabled
+    //     | 1 << QUADSPI_CR_EN_Pos // enable the peripheral
+    //     ;
+
+    // QUADSPI->DCR =
+    //     (MICROPY_HW_QSPIFLASH_SIZE_BITS_LOG2 - 3 - 1) << QUADSPI_DCR_FSIZE_Pos
+    //     | 1 << QUADSPI_DCR_CSHT_Pos // nCS stays high for 2 cycles
+    //     | 0 << QUADSPI_DCR_CKMODE_Pos // CLK idles at low state
+    //     ;
+
+    #define FLASH_SIZE                  0x2000000 /* 256 MBits => 32MBytes */
+    // #define SECTOR_SIZE                 0x10000   /* 256 sectors of 64KBytes */
+
+    /* QSPI initialization */
+    QSPIHandle.Init.ClockPrescaler     = 1; /* QSPI freq = 216 MHz/(1+1) = 108 Mhz */
+    QSPIHandle.Init.FifoThreshold      = 4;
+    QSPIHandle.Init.SampleShifting     = QSPI_SAMPLE_SHIFTING_HALFCYCLE;
+    QSPIHandle.Init.FlashSize          = POSITION_VAL(FLASH_SIZE) - 1;
+    QSPIHandle.Init.ChipSelectHighTime = QSPI_CS_HIGH_TIME_2_CYCLE;
+    QSPIHandle.Init.ClockMode          = QSPI_CLOCK_MODE_0;
+    QSPIHandle.Init.FlashID            = QSPI_FLASH_ID_1;
+    QSPIHandle.Init.DualFlash          = QSPI_DUALFLASH_DISABLE;
+
+    if (HAL_QSPI_Init(&QSPIHandle) != HAL_OK)
+    {
+        return QSPI_ERROR;
+    }
+
+    /* QSPI memory reset */
+    if (QSPI_ResetMemory(&QSPIHandle) != QSPI_OK)
+    {
+        return QSPI_NOT_SUPPORTED;
+    }
+    
+    /* Configuration of the dummy cycles on QSPI memory side */
+    if (QSPI_DummyCyclesCfg(&QSPIHandle) != QSPI_OK)
+    {
+        return QSPI_NOT_SUPPORTED;
+    }
+
+    return QSPI_OK;
 }
 
-void qspi_memory_map(void) {
+int qspi_memory_map(void) {
     // Enable memory-mapped mode
 
-    QUADSPI->ABR = 0; // disable continuous read mode
-    QUADSPI->LPTR = 100; // to tune
-    QUADSPI->CCR =
-        0 << QUADSPI_CCR_DDRM_Pos // DDR mode disabled
-        | 0 << QUADSPI_CCR_SIOO_Pos // send instruction every transaction
-        | 3 << QUADSPI_CCR_FMODE_Pos // memory-mapped mode
-        | 3 << QUADSPI_CCR_DMODE_Pos // data on 4 lines
-        | 4 << QUADSPI_CCR_DCYC_Pos // 4 dummy cycles
-        | 0 << QUADSPI_CCR_ABSIZE_Pos // 8-bit alternate byte
-        | 3 << QUADSPI_CCR_ABMODE_Pos // alternate byte on 4 lines
-        | 2 << QUADSPI_CCR_ADSIZE_Pos // 24-bit address size
-        | 3 << QUADSPI_CCR_ADMODE_Pos // address on 4 lines
-        | 1 << QUADSPI_CCR_IMODE_Pos // instruction on 1 line
-        | 0xeb << QUADSPI_CCR_INSTRUCTION_Pos // quad read opcode
-        ;
+    // QUADSPI->ABR = 0; // disable continuous read mode
+    // QUADSPI->LPTR = 100; // to tune
+    // QUADSPI->CCR =
+    //     0 << QUADSPI_CCR_DDRM_Pos // DDR mode disabled
+    //     | 0 << QUADSPI_CCR_SIOO_Pos // send instruction every transaction
+    //     | 3 << QUADSPI_CCR_FMODE_Pos // memory-mapped mode
+    //     | 3 << QUADSPI_CCR_DMODE_Pos // data on 4 lines
+    //     | 4 << QUADSPI_CCR_DCYC_Pos // 4 dummy cycles
+    //     | 0 << QUADSPI_CCR_ABSIZE_Pos // 8-bit alternate byte
+    //     | 3 << QUADSPI_CCR_ABMODE_Pos // alternate byte on 4 lines
+    //     | 2 << QUADSPI_CCR_ADSIZE_Pos // 24-bit address size
+    //     | 3 << QUADSPI_CCR_ADMODE_Pos // address on 4 lines
+    //     | 1 << QUADSPI_CCR_IMODE_Pos // instruction on 1 line
+    //     | 0xeb << QUADSPI_CCR_INSTRUCTION_Pos // quad read opcode
+    //     ;
+
+    QSPI_CommandTypeDef      s_command;
+    QSPI_MemoryMappedTypeDef s_mem_mapped_cfg;
+
+    /* Configure the command for the read instruction */
+    s_command.InstructionMode   = QSPI_INSTRUCTION_1_LINE;
+    s_command.Instruction       = QUAD_INOUT_FAST_READ_CMD;
+    s_command.AddressMode       = QSPI_ADDRESS_4_LINES;
+    s_command.AddressSize       = QSPI_ADDRESS_24_BITS;
+    s_command.AlternateByteMode = QSPI_ALTERNATE_BYTES_NONE;
+    s_command.DataMode          = QSPI_DATA_4_LINES;
+    s_command.DummyCycles       = DUMMY_CYCLES_READ_QUAD;
+    s_command.DdrMode           = QSPI_DDR_MODE_DISABLE;
+    s_command.DdrHoldHalfCycle  = QSPI_DDR_HHC_ANALOG_DELAY;
+    s_command.SIOOMode          = QSPI_SIOO_INST_EVERY_CMD;
+    
+    /* Configure the memory mapped mode */
+    s_mem_mapped_cfg.TimeOutActivation = QSPI_TIMEOUT_COUNTER_ENABLE;
+    s_mem_mapped_cfg.TimeOutPeriod     = 1;
+    
+    if (HAL_QSPI_MemoryMapped(&QSPIHandle, &s_command, &s_mem_mapped_cfg) != HAL_OK)
+    {
+        return QSPI_ERROR;
+    }
+
+    return QSPI_OK;
+
 }
 
 STATIC int qspi_ioctl(void *self_in, uint32_t cmd) {

--- a/ports/stm32/qspi.h
+++ b/ports/stm32/qspi.h
@@ -30,7 +30,7 @@
 
 extern const mp_qspi_proto_t qspi_proto;
 
-void qspi_init(void);
-void qspi_memory_map(void);
+int qspi_init(void);
+int qspi_memory_map(void);
 
 #endif // MICROPY_INCLUDED_STM32_QSPI_H


### PR DESCRIPTION
@dpgeorge In case you're interested in comparing for the memory map issue, here's the qspi hal function changes I had the other night.

Certainly not fit for merge, just put here for reference.

Is there a reason not to use the Hal functions for this? I would have though they'd give better compatibility across the chip part / ranges than the current direct to register approach, albeit at the cost of some extra code size I guess.

Largely originally from: https://github.com/littlevgl/stm32f746_disco_no_os_sw4stm32/blob/6859f11f6d39e1fa53283a9bdc864798d410a7c7/Utilities/STM32746G-Discovery/stm32746g_discovery_qspi.c