### PR TITLE
py/objexcept: fix qstr hash for exception messages

### DIFF
--- a/py/objexcept.c
+++ b/py/objexcept.c
@@ -348,9 +348,9 @@ mp_obj_t mp_obj_new_exception_msg(const mp_obj_type_t *exc_type, const char *msg
 
     // Create the string object and call mp_obj_exception_make_new to create the exception
     o_str->base.type = &mp_type_str;
-    o_str->hash = qstr_compute_hash(o_str->data, o_str->len);
     o_str->len = strlen(msg);
     o_str->data = (const byte*)msg;
+    o_str->hash = qstr_compute_hash(o_str->data, o_str->len);
     mp_obj_t arg = MP_OBJ_FROM_PTR(o_str);
     return mp_obj_exception_make_new(exc_type, 1, 0, &arg);
 }


### PR DESCRIPTION
I was debugging one of our functional tests checking for a particular `ValueError()` string, and experienced odd behavior where string equality was failing.  After some digging, I found that `mp_obj_new_exception_msg()` was calculating the hash using uninitialized elements from the qstr struct.

Our failure was to create a 0-byte `.mpy` file in our file system, and try to import it.  Our test code expects a `ValueError` and checks that `assert e.args[0] == "incompatible .mpy file"`.