### PR TITLE
Add pyboard v1.1 schematic link

### DIFF
--- a/docs/pyboard/hardware/index.rst
+++ b/docs/pyboard/hardware/index.rst
@@ -4,7 +4,7 @@ The pyboard hardware
 For the pyboard:
 
 * v1.1
-    * `PYBv1.1 schematics <https://micropython.org/resources/PYBv11-schematics.pdf>`_ (261KiB PDF)
+    * `PYBv1.1 schematics and layout <https://micropython.org/resources/PYBv11.pdf>`_ (261KiB PDF)
 * v1.0
     * `PYBv1.0 schematics and layout <http://micropython.org/resources/PYBv10b.pdf>`_ (2.4MiB PDF)
     * `PYBv1.0 metric dimensions <http://micropython.org/resources/PYBv10b-metric-dimensions.pdf>`_ (360KiB PDF)

--- a/docs/pyboard/hardware/index.rst
+++ b/docs/pyboard/hardware/index.rst
@@ -3,9 +3,12 @@ The pyboard hardware
 
 For the pyboard:
 
-* `PYBv1.0 schematics and layout <http://micropython.org/resources/PYBv10b.pdf>`_ (2.4MiB PDF)
-* `PYBv1.0 metric dimensions <http://micropython.org/resources/PYBv10b-metric-dimensions.pdf>`_ (360KiB PDF)
-* `PYBv1.0 imperial dimensions <http://micropython.org/resources/PYBv10b-imperial-dimensions.pdf>`_ (360KiB PDF)
+* v1.1
+    * `PYBv1.1 schematics <https://micropython.org/resources/PYBv11-schematics.pdf>`_ (261KiB PDF)
+* v1.0
+    * `PYBv1.0 schematics and layout <http://micropython.org/resources/PYBv10b.pdf>`_ (2.4MiB PDF)
+    * `PYBv1.0 metric dimensions <http://micropython.org/resources/PYBv10b-metric-dimensions.pdf>`_ (360KiB PDF)
+    * `PYBv1.0 imperial dimensions <http://micropython.org/resources/PYBv10b-imperial-dimensions.pdf>`_ (360KiB PDF)
 
 For the official skin modules:
 


### PR DESCRIPTION
Fixes #4558.

Is there a single PDF that also has the v1.1 layouts?