### PR TITLE
docs: utime: Mention that mktime() is not available on all ports.

### DIFF
--- a/docs/library/utime.rst
+++ b/docs/library/utime.rst
@@ -57,6 +57,8 @@ Functions
    which expresses a time as per localtime. It returns an integer which is
    the number of seconds since Jan 1, 2000.
 
+   Availability: Not every port implements this function.
+
 .. function:: sleep(seconds)
 
    Sleep for the given number of seconds. Some boards may accept *seconds* as a


### PR DESCRIPTION
The description of utime.mktime() is quite adhoc, not compatible with
CPython, hard to implement (or not much useful) in the case of lack
of always-powered RTC. That means that it doesn't make sense for all
ports, and various ports don't implement it, starting from the Unix
port.

Change-Id: I01855921dce038bf0df89f0bc916b564c3935a62