### PR TITLE
Make pyboard v1.1 pinout the default pinout shown

### DIFF
--- a/docs/pyboard/quickref.rst
+++ b/docs/pyboard/quickref.rst
@@ -3,16 +3,16 @@
 Quick reference for the pyboard
 ===============================
 
-The below pinout is for PYBv1.0.  You can also view pinouts for
+The below pinout is for PYBv1.1.  You can also view pinouts for
 other versions of the pyboard:
-`PYBv1.1 <http://micropython.org/resources/pybv11-pinout.jpg>`__
+`PYBv1.0 <http://micropython.org/resources/pybv10-pinout.jpg>`__
 or `PYBLITEv1.0-AC <http://micropython.org/resources/pyblitev10ac-pinout.jpg>`__
 or `PYBLITEv1.0 <http://micropython.org/resources/pyblitev10-pinout.jpg>`__.
 
 .. only:: not latex
 
-   .. image:: http://micropython.org/resources/pybv10-pinout.jpg
-      :alt: PYBv1.0 pinout
+   .. image:: http://micropython.org/resources/pybv11-pinout.jpg
+      :alt: PYBv1.1 pinout
       :width: 700px
 
 .. only:: latex

--- a/docs/pyboard/quickref.rst
+++ b/docs/pyboard/quickref.rst
@@ -17,8 +17,8 @@ or `PYBLITEv1.0 <http://micropython.org/resources/pyblitev10-pinout.jpg>`__.
 
 .. only:: latex
 
-   .. image:: http://micropython.org/resources/pybv10-pinout-800px.jpg
-      :alt: PYBv1.0 pinout
+   .. image:: http://micropython.org/resources/pybv11-pinout-800px.jpg
+      :alt: PYBv1.1 pinout
 
 Below is a quick reference for the pyboard.  If it is your first time working with
 this board please consider reading the following sections first:


### PR DESCRIPTION
**Edit**: Done.

~~Do not merge yet. The LaTex build requires a pre-scaled image, which it does not yet exist for the v1.1 board.~~

~~@dpgeorge Could you please create the following file: http://micropython.org/resources/pybv11-pinout-800px.jpg~~

This is needed to fix:

```rst
.. only:: latex

   .. image:: http://micropython.org/resources/pybv10-pinout-800px.jpg
      :alt: PYBv1.0 pinout
```

Then we can resolve this PR.

Resolves https://github.com/micropython/micropython/issues/4558#issuecomment-467841501

Approved in https://github.com/micropython/micropython/issues/4558#issuecomment-470921803