### PR TITLE
py/makeqstrdefs: Explicitly open file with utf-8 encoding.

### DIFF
--- a/py/makeqstrdefs.py
+++ b/py/makeqstrdefs.py
@@ -108,7 +108,7 @@ if __name__ == "__main__":
         pass
 
     if args.command == "split":
-        with open(args.input_filename) as infile:
+        with open(args.input_filename, encoding="utf-8") as infile:
             process_file(infile)
 
     if args.command == "cat":


### PR DESCRIPTION
Build process may run on systems with different default encoding (e.g. on
LOCALE=C, which is oftentimes the case for various containers/CI systems).
MicroPython source code is in UTF-8, and may actually contain such data
(if not the source itself, then tests for sure contain it, and they can be
embedded into an executable by converting them to C strings).

Change-Id: Ie1f2ce97e8b414a49745790dce1e108bb7cca7bf