### PR TITLE
 Typo @ UART7_IRQHandler or..

### DIFF
--- a/ports/stm32/stm32_it.c
+++ b/ports/stm32/stm32_it.c
@@ -735,7 +735,7 @@ void USART6_IRQHandler(void) {
     IRQ_EXIT(USART6_IRQn);
 }
 
-#if defined(UART8)
+#if defined(UART7)
 void UART7_IRQHandler(void) {
     IRQ_ENTER(UART7_IRQn);
     uart_irq_handler(7);


### PR DESCRIPTION
When assuming there is always an UART7 when there is an UART8 then this can be ignored :-)
