### PR TITLE
Javascript additional functionality

### DIFF
--- a/ports/javascript/Makefile
+++ b/ports/javascript/Makefile
@@ -36,6 +36,7 @@ SRC_C = \
 	main.c \
 	mphalport.c \
 	modutime.c \
+	js_module.c \
 
 SRC_QSTR += $(SRC_C)
 
@@ -59,5 +60,9 @@ min: $(BUILD)/micropython.js
 test: $(BUILD)/micropython.js $(TOP)/tests/run-tests
 	$(eval DIRNAME=ports/$(notdir $(CURDIR)))
 	cd $(TOP)/tests && MICROPY_MICROPYTHON=../ports/javascript/node_run.sh ./run-tests
+
+server: $(BUILD)/micropython.js
+	xdg-open http://localhost:8000/test.html
+	python3 -m http.server
 
 include $(TOP)/py/mkrules.mk

--- a/ports/javascript/README.md
+++ b/ports/javascript/README.md
@@ -7,16 +7,16 @@ Dependencies
 ------------
 
 Building micropython.js bears the same requirements as the standard MicroPython
-ports with the addition of Emscripten (and uglify-js for the minified file). 
+ports with the addition of Emscripten (and uglify-js for the minified file).
 
 A standard installation of Emscripten should provide functional code, however
 if memory errors are encountered it may be worthwhile to modify the tool.
-`emscripten-fastcomp/lib/Target/JSBackend.cpp` may require the minor fix 
+`emscripten-fastcomp/lib/Target/JSBackend.cpp` may require the minor fix
 found in JSBackend.patch. This patch attempts to address situations where
-C code running through Emscripten is denied access to Javascript variables 
-leading to false-positives in the MicroPython garbage collector as variables 
+C code running through Emscripten is denied access to Javascript variables
+leading to false-positives in the MicroPython garbage collector as variables
 with pointers exclusively in Javascript will be erased prematurely.
-Refer to Emscripten documentation for instructions on building Emscripten 
+Refer to Emscripten documentation for instructions on building Emscripten
 from source.
 
 Build instructions
@@ -29,6 +29,21 @@ In order to build micropython.js, run:
 To generate the minified file micropython.min.js, run:
 
     $ make min
+
+Running in the browser
+----------------------
+
+To run a small example in the browser, execute
+
+    $ make server
+
+This will spin up a simple Python http server. Then navigate to
+
+    http://localhost:8000/test.html
+
+to see the contents the test.html in this directory. Upon loading, the
+micropython (embedded in <script type="script/micropython"> tags) will be
+executed.
 
 Running with Node.js
 --------------------
@@ -47,7 +62,7 @@ MicroPython scripts may be executed using:
 
 	$ node build/micropython.js hello.py
 
-Alternatively micropython.js may by accessed by other javascript programs in node 
+Alternatively micropython.js may by accessed by other javascript programs in node
 using the require command and the general API outlined below. For example:
 
 ```javascript
@@ -72,21 +87,57 @@ demonstrates basic functionality:
   </head>
   <body>
     <div id='mp_js_stdout'></div>
-    <script>
-      mp_js_stdout.addEventListener('print', function(e) {
-        document.write(e.data);
-      }, false);
+    <script type="script/micropython">
+print("Hello World")
 
-      mp_js_init(64 * 1024);
-      mp_js_do_str('print(\'hello world\')');
+import js
+js.eval("console.log('Calling JS!')")
     </script>
   </body>
 </html>
 ```
 
 MicroPython code execution will suspend the browser so be sure to atomize usage
-within this environment. Unfortunately interrupts have not been implemented for the 
+within this environment. Unfortunately interrupts have not been implemented for the
 browser.
+
+The JavaScript to Python bridge
+-------------------------------
+
+A very basic JavaScript to Python bridge has been implemented. It is exposed to
+MicroPython through the ``js`` library.
+The js library so far has two functions:
+
+```
+js.eval(code)
+```
+
+Evaluates JavaScript code passed as string (calling eval(code) on the JS side).
+
+```
+ret_val = js.evali(code)
+```
+
+Also evaluates JS code using eval, but additionally returns an integer from JS
+to Python. This can be used to pass back data to the Python runtime.
+
+Usage example:
+
+```
+import js
+
+my_code = """
+function alert_from_py() {
+  alert("This is called from Python");
+}
+alert_from_py();
+"""
+
+js.eval(my_code)
+
+ret_val = js.evali("function x() { return 4; }; x();")
+# ret_val == 4
+```
 
 Testing
 -------
@@ -124,5 +175,5 @@ the repl.
 mp_js_process_char(char)
 ```
 
-Input character into MicroPython repl. `char` must be of type `number`. This 
+Input character into MicroPython repl. `char` must be of type `number`. This
 will execute MicroPython code when necessary.

--- a/ports/javascript/hello.py
+++ b/ports/javascript/hello.py
@@ -1,0 +1,5 @@
+import js
+
+print("Hello Node!")
+
+js.eval("console.log('This is executed in JS');")

--- a/ports/javascript/js_module.c
+++ b/ports/javascript/js_module.c
@@ -1,0 +1,39 @@
+#include "py/nlr.h"
+#include "py/obj.h"
+#include "py/runtime.h"
+#include "py/binary.h"
+
+#include <stdio.h>
+
+// forward declare emscripten stuff
+void emscripten_run_script(const char *);
+int emscripten_run_script_int(const char *);
+
+STATIC mp_obj_t js_eval(mp_obj_t js_string) {
+    emscripten_run_script(mp_obj_str_get_str(js_string));
+    return mp_const_none;
+}
+
+STATIC mp_obj_t js_evali(mp_obj_t js_string) {
+    int res = emscripten_run_script_int(mp_obj_str_get_str(js_string));
+    return mp_obj_new_int(res);
+}
+
+STATIC MP_DEFINE_CONST_FUN_OBJ_1(js_eval_obj, js_eval);
+STATIC MP_DEFINE_CONST_FUN_OBJ_1(js_evali_obj, js_evali);
+
+STATIC const mp_map_elem_t js_globals_table[] = {
+    { MP_OBJ_NEW_QSTR(MP_QSTR___name__), MP_OBJ_NEW_QSTR(MP_QSTR_js) },
+    { MP_OBJ_NEW_QSTR(MP_QSTR_eval), (mp_obj_t)&js_eval_obj },
+    { MP_OBJ_NEW_QSTR(MP_QSTR_evali), (mp_obj_t)&js_evali_obj },
+};
+
+STATIC MP_DEFINE_CONST_DICT (
+    mp_module_js_globals,
+    js_globals_table
+);
+
+const mp_obj_module_t mp_module_js = {
+    .base = { &mp_type_module },
+    .globals = (mp_obj_dict_t*)&mp_module_js_globals,
+};

--- a/ports/javascript/mpconfigport.h
+++ b/ports/javascript/mpconfigport.h
@@ -126,9 +126,11 @@
 #define MP_SSIZE_MAX (0x7fffffff)
 
 extern const struct _mp_obj_module_t mp_module_utime;
+extern const struct _mp_obj_module_t mp_module_js;
 
 #define MICROPY_PORT_BUILTIN_MODULES \
     { MP_ROM_QSTR(MP_QSTR_utime), MP_ROM_PTR(&mp_module_utime) }, \
+    { MP_ROM_QSTR(MP_QSTR_js), MP_ROM_PTR(&mp_module_js) }, \
 
 #define MICROPY_PORT_BUILTIN_MODULE_WEAK_LINKS \
     { MP_ROM_QSTR(MP_QSTR_binascii), MP_ROM_PTR(&mp_module_ubinascii) }, \

--- a/ports/javascript/test.html
+++ b/ports/javascript/test.html
@@ -1,0 +1,46 @@
+<!doctype html>
+<html>
+  <head>
+    <script src="build/micropython.js"></script>
+    <script type="script/micropython">
+import js
+
+print("Hello World")
+
+# change this value for a different result
+nterms = 20
+
+# first two terms
+n1 = 0
+n2 = 1
+count = 0
+
+# evali returns an integer from JS
+# Can be used to implement a object registry etc.
+nterms = js.evali("(function() { return prompt('N iters of Fibonacci'); })();")
+
+# check if the number of terms is valid
+if nterms <= 0:
+   print("Please enter a positive integer")
+elif nterms == 1:
+   print("Fibonacci sequence upto", nterms, ":")
+   print(n1)
+elif nterms > 400:
+   print("This number is a little bit too high (> 400).")
+else:
+   print("Fibonacci sequence upto", nterms, ":")
+   while count < nterms:
+       print(n1, end=', ')
+       nth = n1 + n2
+       # update values
+       n1 = n2
+       n2 = nth
+       count += 1
+
+# js.eval("alert('hallo');")
+    </script>
+  </head>
+  <body>
+    <div id="mp_js_stdout"></div>
+  </body>
+</html>

--- a/ports/javascript/wrapper.js
+++ b/ports/javascript/wrapper.js
@@ -71,7 +71,42 @@ var mainProgram = function()
       } else {
           mp_js_do_str(contents);
       }
-  }
+   } else {
+     initBrowser();
+   }
 }
 
 Module["onRuntimeInitialized"] = mainProgram;
+
+var __initBrowserCount = 2;
+
+function initBrowser(e)
+{
+  __initBrowserCount--;
+  // window.onLoad and wasm have loaded...
+  if (__initBrowserCount == 0)
+  {
+    var mp_js_stdout = document.getElementById('mp_js_stdout');
+    mp_js_stdout.addEventListener('print', function(e) {
+      if (e.data == '\n') {
+        mp_js_stdout.innerHTML += "<br/>"
+      } else {
+        mp_js_stdout.innerHTML += e.data;
+      }
+    }, false);
+
+    mp_js_init(64 * 1024);
+    for (var i = 0; i < document.scripts.length; i++)
+    {
+      if (document.scripts[i].type == 'script/micropython')
+      {
+        mp_js_do_str(document.scripts[i].innerText);
+      }
+    }
+  }
+}
+
+if (typeof window !== 'undefined')
+{
+  window.onload = initBrowser;
+}


### PR DESCRIPTION
This adds some functionality to the Javascript port:

- two way JS <-> Python communication using a js module in Python and emscripten eval / evali functionality
- adds code to wrapper.js to initialize the browser correctly, and find all `<script type="script/micropython">` tags and executes them
- another make target `make server` which builds and shows the `test.html` webpage to see a small example of micropython functionality in the browser