### PR TITLE
ports/stm32/mboot - Set USE_MBOOT=1 by default

### DIFF
--- a/ports/stm32/mboot/Makefile
+++ b/ports/stm32/mboot/Makefile
@@ -8,6 +8,10 @@ BUILD ?= build-$(BOARD)
 # Allow the directory containing the board configuration to be specified
 BOARD_DIR ?= $(abspath ../boards/$(BOARD))
 
+# Set USE_MBOOT to 1 so that TEXT0_ADDR gets set properly for those boards
+# that can be built with or without mboot.
+USE_MBOOT ?= 1
+
 # Sanity check that the board configuration directory exists
 ifeq ($(wildcard $(BOARD_DIR)/.),)
 $(error Invalid BOARD specified: $(BOARD_DIR))


### PR DESCRIPTION
This allows boards that need USE_MBOOT to be built
properly whether USE_MBOOT=1 is specified when building mboot.