### PR TITLE
pyboard.py now exit's raw repl on pressing CTRL-C

### DIFF
--- a/tools/pyboard.py
+++ b/tools/pyboard.py
@@ -47,6 +47,7 @@ Or:
 Then:
 
     pyb.enter_raw_repl()
+    pyb.exec('import pyb')
     pyb.exec('pyb.LED(1).on()')
     pyb.exit_raw_repl()
 

--- a/tools/pyboard.py
+++ b/tools/pyboard.py
@@ -423,6 +423,7 @@ def main():
                 pyb.close()
                 sys.exit(1)
             except KeyboardInterrupt:
+                pyb.exit_raw_repl()
                 sys.exit(1)
             if ret_err:
                 pyb.exit_raw_repl()


### PR DESCRIPTION
When running a script from the command line `python pyboard.py my-script.py`
I press CTRL-C to get my command prompt back and enter REPL on the pyboard.
The pyboard is still in  raw REPL as outlined in issue <a href="https://github.com/micropython/micropython/issues/4626">#4626</a>
