### PR TITLE
Add MCO output

### DIFF
--- a/ports/stm32/boards/NUCLEO_F091RC/board_init.c
+++ b/ports/stm32/boards/NUCLEO_F091RC/board_init.c
@@ -1,0 +1,21 @@
+#include STM32_HAL_H
+#include "mpconfigboard.h"
+
+void STM32F091RC_board_early_init(void) {
+#if defined(MICROPY_HW_MCO)
+/* redirect to:       source RCC_MCOSource:       prescaler RCC_MCODiv:
+ * RCC_MCO1: PA8      RCC_MCO1SOURCE_HSI          RCC_MCODIV_1
+ * RCC_MCO2: PC9      RCC_MCO1SOURCE_LSE          RCC_MCODIV_2
+ *                    RCC_MCO1SOURCE_HSE          RCC_MCODIV_3
+ *                    RCC_MCO1SOURCE_PLLCLK       RCC_MCODIV_4
+ *                    RCC_MCO2SOURCE_SYSCLK       RCC_MCODIV_5
+ *                    RCC_MCO2SOURCE_PLLI2SCLK
+ *                    RCC_MCO2SOURCE_I2SCLK
+ *                    RCC_MCO2SOURCE_HSE
+ *                    RCC_MCO2SOURCE_PLLCLK
+**/
+
+    // output 8MHz to the PA8 output
+    HAL_RCC_MCOConfig(RCC_MCO1, RCC_MCO1SOURCE_HSI, RCC_MCODIV_1);
+#endif
+}

--- a/ports/stm32/boards/NUCLEO_F091RC/mpconfigboard.h
+++ b/ports/stm32/boards/NUCLEO_F091RC/mpconfigboard.h
@@ -1,6 +1,11 @@
 #define MICROPY_HW_BOARD_NAME       "NUCLEO-F091RC"
 #define MICROPY_HW_MCU_NAME         "STM32F091RCT6"
 
+#define MICROPY_BOARD_EARLY_INIT    STM32F091RC_board_early_init
+void STM32F091RC_board_early_init(void);
+
+#define MICROPY_HW_MCO              (1)
+
 #define MICROPY_EMIT_THUMB          (0)
 #define MICROPY_EMIT_INLINE_THUMB   (0)
 #define MICROPY_PY_USOCKET          (0)


### PR DESCRIPTION
Added MCO output function. It can be used to generate a signal that is derived from the clocking system. The MCO is not always needed. However it can be added through the `MICROPY_BOARD_EARLY_INIT` provision which seems to be a good place to put it.
The MCO output is available on all the STM32 derivates.
