### PR TITLE
Add servo support to STM32L476DISC port

### DIFF
--- a/ports/stm32/boards/STM32L476DISC/mpconfigboard.h
+++ b/ports/stm32/boards/STM32L476DISC/mpconfigboard.h
@@ -9,6 +9,7 @@ void STM32L476DISC_board_early_init(void);
 #define MICROPY_HW_HAS_FLASH        (1)
 #define MICROPY_HW_ENABLE_RNG       (1)
 #define MICROPY_HW_ENABLE_RTC       (1)
+#define MICROPY_HW_ENABLE_SERVO     (1)
 #define MICROPY_HW_ENABLE_USB       (1)
 
 // use external SPI flash for storage


### PR DESCRIPTION
stm32l476 discovery port doesn't have enable servo option.