### PR TITLE
zephyr: fix build on macOS Mojave (10.14)

### DIFF
--- a/ports/zephyr/CMakeLists.txt
+++ b/ports/zephyr/CMakeLists.txt
@@ -17,6 +17,7 @@ zephyr_get_compile_options_for_lang_as_string(C options)
 add_custom_target(
   outputexports
   COMMAND echo CC="${CMAKE_C_COMPILER}"
+  COMMAND echo AR="${CMAKE_AR}"
   COMMAND echo Z_CFLAGS=${system_includes} ${includes} ${definitions} ${options}
   VERBATIM
   USES_TERMINAL


### PR DESCRIPTION
[#3685](https://github.com/micropython/micropython/issues/3685)

[ 96%] Linking C executable zephyr_prebuilt.elf
Memory region         Used Size  Region Size  %age Used
           FLASH:       32656 B      1020 KB      3.13%
            SRAM:       10876 B       256 KB      4.15%
        IDT_LIST:          88 B         2 KB      4.30%
/Users/damianomazzella/projects/gcc-arm-none-eabi-8-2018-q4-major/bin/../lib/gcc/arm-none-eabi/8.2.1/../../../../arm-none-eabi/bin/ld: ../app/libapp.a(zephyr_start.c.obj): in function `main':
/Users/damianomazzella/projects/micropython/ports/zephyr/src/zephyr_start.c:38: undefined reference to `real_main'
collect2: error: ld returned 1 exit status
make[3]: *** [zephyr/zephyr_prebuilt.elf] Error 1
make[2]: *** [zephyr/CMakeFiles/zephyr_prebuilt.dir/all] Error 2
make[1]: *** [all] Error 2
make: *** [all] Error 2
MBP-di-Damiano:~/projects/micropython/ports/zephyr$