### PR TITLE
extmod/modurandom: Add init method to seed the Yasmarang generator.

### DIFF
--- a/extmod/modurandom.c
+++ b/extmod/modurandom.c
@@ -94,7 +94,7 @@ STATIC MP_DEFINE_CONST_FUN_OBJ_1(mod_urandom_seed_obj, mod_urandom_seed);
 
 #ifdef MICROPY_PY_URANDOM_SEED_INIT_FUNC
 STATIC mp_obj_t mod_urandom___init__() {
-    mod_urandom_seed(mp_obj_new_int(MICROPY_PY_URANDOM_SEED_INIT_FUNC));
+    mod_urandom_seed(MP_OBJ_NEW_SMALL_INT(MICROPY_PY_URANDOM_SEED_INIT_FUNC));
     return mp_const_none;
 }
 STATIC MP_DEFINE_CONST_FUN_OBJ_0(mod_urandom___init___obj, mod_urandom___init__);

--- a/extmod/modurandom.c
+++ b/extmod/modurandom.c
@@ -92,6 +92,14 @@ STATIC mp_obj_t mod_urandom_seed(mp_obj_t seed_in) {
 }
 STATIC MP_DEFINE_CONST_FUN_OBJ_1(mod_urandom_seed_obj, mod_urandom_seed);
 
+#ifdef MICROPY_PY_URANDOM_SEED_INIT_FUNC
+STATIC mp_obj_t mod_urandom___init__() {
+    mod_urandom_seed(mp_obj_new_int(MICROPY_PY_URANDOM_SEED_INIT_FUNC));
+    return mp_const_none;
+}
+STATIC MP_DEFINE_CONST_FUN_OBJ_0(mod_urandom___init___obj, mod_urandom___init__);
+#endif
+
 #if MICROPY_PY_URANDOM_EXTRA_FUNCS
 
 STATIC mp_obj_t mod_urandom_randrange(size_t n_args, const mp_obj_t *args) {
@@ -202,6 +210,9 @@ STATIC MP_DEFINE_CONST_FUN_OBJ_2(mod_urandom_uniform_obj, mod_urandom_uniform);
 
 STATIC const mp_rom_map_elem_t mp_module_urandom_globals_table[] = {
     { MP_ROM_QSTR(MP_QSTR___name__), MP_ROM_QSTR(MP_QSTR_urandom) },
+    #ifdef MICROPY_PY_URANDOM_SEED_INIT_FUNC
+    { MP_ROM_QSTR(MP_QSTR___init__), MP_ROM_PTR(&mod_urandom___init___obj) },
+    #endif
     { MP_ROM_QSTR(MP_QSTR_getrandbits), MP_ROM_PTR(&mod_urandom_getrandbits_obj) },
     { MP_ROM_QSTR(MP_QSTR_seed), MP_ROM_PTR(&mod_urandom_seed_obj) },
     #if MICROPY_PY_URANDOM_EXTRA_FUNCS


### PR DESCRIPTION
mod_urandom___init__ seeds the yasmarang random number generator with a user-defined seeding function (MICROPY_PY_URANDOM_SEED_INIT_FUNC) that can be defined in the mpconfigport.h file.

The seeding function might for instance use a hardware randomness source.