### PR TITLE
py/makedefs: Use io.open with utf-8 encoding when processing source.

### DIFF
--- a/py/makemoduledefs.py
+++ b/py/makemoduledefs.py
@@ -8,6 +8,7 @@
 from __future__ import print_function
 
 import re
+import io
 import os
 import argparse
 
@@ -49,7 +50,7 @@ def find_module_registrations(c_file):
         # No c file to match the object file, skip
         return set()
 
-    with open(c_file) as c_file_obj:
+    with io.open(c_file, encoding='utf-8') as c_file_obj:
         return set(re.findall(pattern, c_file_obj.read()))
 
 

--- a/py/makeqstrdefs.py
+++ b/py/makeqstrdefs.py
@@ -9,6 +9,7 @@ from __future__ import print_function
 
 import re
 import sys
+import io
 import os
 
 # Blacklist of qstrings that are specially handled in further
@@ -108,7 +109,7 @@ if __name__ == "__main__":
         pass
 
     if args.command == "split":
-        with open(args.input_filename) as infile:
+        with io.open(args.input_filename, encoding='utf-8') as infile:
             process_file(infile)
 
     if args.command == "cat":


### PR DESCRIPTION
In case (user) source code contains utf-8 encoded data and the default locale is not utf-8.

Improves upon #4592, and also fixes #4690