### PR TITLE
windows: Support EMIT_X64/X86 with msvc toolchain

### DIFF
--- a/ports/windows/alloc.c
+++ b/ports/windows/alloc.c
@@ -1,0 +1,101 @@
+/*
+ * This file is part of the MicroPython project, http://micropython.org/
+ *
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2014 Fabian Vogt
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#include <stdio.h>
+#include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include <windows.h>
+
+#include "py/mpstate.h"
+#include "py/gc.h"
+
+#if MICROPY_EMIT_NATIVE || (MICROPY_PY_FFI && MICROPY_FORCE_PLAT_ALLOC_EXEC)
+
+// The memory allocated here is not on the GC heap (and it may contain pointers
+// that need to be GC'd) so we must somehow trace this memory.  We do it by
+// keeping a linked list of all mmap'd regions, and tracing them explicitly.
+
+typedef struct _mmap_region_t {
+    void *ptr;
+    size_t len;
+    struct _mmap_region_t *next;
+} mmap_region_t;
+
+void mp_win_alloc_exec(size_t min_size, void **ptr, size_t *size) {
+    // size needs to be a multiple of the page size
+    *size = (min_size + 0xfff) & (~0xfff);
+    *ptr = VirtualAlloc(NULL, *size, MEM_RESERVE|MEM_COMMIT, PAGE_EXECUTE_READWRITE);
+
+    // add new link to the list of mmap'd regions
+    mmap_region_t *rg = m_new_obj(mmap_region_t);
+    rg->ptr = *ptr;
+    rg->len = min_size;
+    rg->next = MP_STATE_VM(mmap_region_head);
+    MP_STATE_VM(mmap_region_head) = rg;
+}
+
+void mp_win_free_exec(void *ptr, size_t size) {
+    VirtualFree(ptr, 0, MEM_RELEASE);
+
+    // unlink the mmap'd region from the list
+    for (mmap_region_t **rg = (mmap_region_t**)&MP_STATE_VM(mmap_region_head); *rg != NULL; *rg = (*rg)->next) {
+        if ((*rg)->ptr == ptr) {
+            mmap_region_t *next = (*rg)->next;
+            m_del_obj(mmap_region_t, *rg);
+            *rg = next;
+            return;
+        }
+    }
+}
+
+void mp_win_mark_exec(void) {
+    for (mmap_region_t *rg = MP_STATE_VM(mmap_region_head); rg != NULL; rg = rg->next) {
+        gc_collect_root(rg->ptr, rg->len / sizeof(mp_uint_t));
+    }
+}
+
+#if MICROPY_FORCE_PLAT_ALLOC_EXEC
+// Provide implementation of libffi ffi_closure_* functions in terms
+// of the functions above. On a normal Linux system, this save a lot
+// of code size.
+void *ffi_closure_alloc(size_t size, void **code);
+void ffi_closure_free(void *ptr);
+
+void *ffi_closure_alloc(size_t size, void **code) {
+    size_t dummy;
+    mp_win_alloc_exec(size, code, &dummy);
+    return *code;
+}
+
+void ffi_closure_free(void *ptr) {
+    (void)ptr;
+    // TODO
+}
+#endif
+
+#endif // MICROPY_EMIT_NATIVE || (MICROPY_PY_FFI && MICROPY_FORCE_PLAT_ALLOC_EXEC)

--- a/ports/windows/micropython.vcxproj
+++ b/ports/windows/micropython.vcxproj
@@ -51,6 +51,7 @@
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <ImportGroup Label="ExtensionSettings">
+    <Import Project="$(VCTargetsPath)\BuildCustomizations\masm.props" />
   </ImportGroup>
   <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
@@ -82,6 +83,9 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <ClCompile />
     <Link />
+    <Link>
+      <ImageHasSafeExceptionHandlers>false</ImageHasSafeExceptionHandlers>
+    </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <ClCompile />
@@ -100,5 +104,6 @@
   </Target>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">
+    <Import Project="$(VCTargetsPath)\BuildCustomizations\masm.targets" />
   </ImportGroup>
 </Project>

--- a/ports/windows/msvc/asmnlrx64.asm
+++ b/ports/windows/msvc/asmnlrx64.asm
@@ -1,0 +1,64 @@
+;
+; This file is part of the MicroPython project, http://micropython.org/
+;
+; The MIT License (MIT)
+;
+; Copyright (c) 2019 Jian Wang
+;
+; Permission is hereby granted, free of charge, to any person obtaining a copy
+; of this software and associated documentation files (the "Software"), to deal
+; in the Software without restriction, including without limitation the rights
+; to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+; copies of the Software, and to permit persons to whom the Software is
+; furnished to do so, subject to the following conditions:
+;
+; The above copyright notice and this permission notice shall be included in
+; all copies or substantial portions of the Software.
+;
+; THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+; IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+; FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+; AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+; LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+; OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+; THE SOFTWARE.
+;
+
+EXTERN      nlr_push_tail:PROC
+
+    .code
+
+nlr_push   PROC
+    pop     rdx                 ; load rip as well as fix rsp
+    mov     [rcx + 10h], rbx
+    mov     [rcx + 18h], rsp
+    mov     [rcx + 20h], rbp
+    mov     [rcx + 28h], rdi
+    mov     [rcx + 30h], rsi
+    mov     [rcx + 38h], r12
+    mov     [rcx + 40h], r13
+    mov     [rcx + 48h], r14
+    mov     [rcx + 50h], r15
+    mov     [rcx + 58h], rdx   ; rip
+
+    push   rdx                      ;nlr_push_tail needs the return address
+    jmp    nlr_push_tail   ;do the rest in C
+nlr_push   ENDP
+
+asm_nlr_jump PROC
+    mov     rbx, [rcx + 10h]
+    mov     rsp, [rcx + 18h]
+    mov     rbp, [rcx + 20h]
+    mov     rdi, [rcx + 28h]
+    mov     rsi, [rcx + 30h]
+    mov     r12, [rcx + 38h]
+    mov     r13, [rcx + 40h]
+    mov     r14, [rcx + 48h]
+    mov     r15, [rcx + 50h]
+
+    mov     rax, rdx               ; set return value
+    jmp     qword ptr [rcx + 58h]     ; rip
+asm_nlr_jump ENDP
+
+    END
+

--- a/ports/windows/msvc/asmnlrx86.asm
+++ b/ports/windows/msvc/asmnlrx86.asm
@@ -1,0 +1,58 @@
+;
+; This file is part of the MicroPython project, http://micropython.org/
+;
+; The MIT License (MIT)
+;
+; Copyright (c) 2019 Jian Wang
+;
+; Permission is hereby granted, free of charge, to any person obtaining a copy
+; of this software and associated documentation files (the "Software"), to deal
+; in the Software without restriction, including without limitation the rights
+; to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+; copies of the Software, and to permit persons to whom the Software is
+; furnished to do so, subject to the following conditions:
+;
+; The above copyright notice and this permission notice shall be included in
+; all copies or substantial portions of the Software.
+;
+; THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+; IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+; FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+; AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+; LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+; OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+; THE SOFTWARE.
+;
+
+    .model flat
+    .code
+
+EXTERN      _nlr_push_tail:PROC
+
+_nlr_push   PROC
+    pop     ecx                         ; ecx <- return address
+    mov     edx, [esp]                  ; edx <- nlr
+    mov     [edx + 08h], ecx            ; eip value to restore in nlr_jump
+    mov     [edx + 0Ch], ebp
+    mov     [edx + 10h], esp
+    mov     [edx + 14h], ebx
+    mov     [edx + 18h], edi
+    mov     [edx + 1Ch], esi
+
+    push    ecx                        ; make sure nlr_push_tail return back to nlr_push's caller()
+    jmp     _nlr_push_tail             ; do the rest in C
+_nlr_push   ENDP
+
+_asm_nlr_jump PROC
+    pop     eax                         ; skip return address
+    pop     edx                         ; edx <- nlr (top)
+    pop     eax                         ; eax <- val
+    mov     esi, [edx + 1Ch]
+    mov     edi, [edx + 18h]
+    mov     ebx, [edx + 14h]
+    mov     esp, [edx + 10h]
+    mov     ebp, [edx + 0Ch]
+    jmp     dword ptr [edx + 08h]       ; restore "eip"
+_asm_nlr_jump ENDP
+
+    END

--- a/ports/windows/msvc/sources.props
+++ b/ports/windows/msvc/sources.props
@@ -8,7 +8,6 @@
     <ClCompile Include="$(PyBaseDir)lib\mp-readline\*.c" />
     <ClCompile Include="$(PyBaseDir)lib\utils\printf.c" />
     <ClCompile Include="$(PyBaseDir)ports\unix\file.c"/>
-    <ClCompile Include="$(PyBaseDir)ports\unix\gccollect.c"/>
     <ClCompile Include="$(PyBaseDir)ports\unix\input.c"/>
     <ClCompile Include="$(PyBaseDir)ports\unix\main.c"/>
     <ClCompile Include="$(PyBaseDir)ports\unix\modos.c"/>
@@ -34,5 +33,17 @@
     <ClInclude Include="$(PyBaseDir)py\*.h" />
     <ClInclude Include="$(PyBaseDir)ports\windows\*.h" />
     <ClInclude Include="$(PyBaseDir)ports\windows\msvc\*.h" />
+  </ItemGroup>
+  <ItemGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <MASM Include="$(PyBaseDir)ports\windows\msvc\asmnlrx64.asm" />
+  </ItemGroup>
+  <ItemGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <MASM Include="$(PyBaseDir)ports\windows\msvc\asmnlrx64.asm" />
+  </ItemGroup>
+  <ItemGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <MASM Include="$(PyBaseDir)ports\windows\msvc\asmnlrx86.asm" />
+  </ItemGroup>
+  <ItemGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <MASM Include="$(PyBaseDir)ports\windows\msvc\asmnlrx86.asm" />
   </ItemGroup>
 </Project>

--- a/py/asmx64.h
+++ b/py/asmx64.h
@@ -127,23 +127,43 @@ void asm_x64_call_ind(asm_x64_t* as, size_t fun_id, int temp_r32);
 
 #define ASM_WORD_SIZE (8)
 
-#define REG_RET ASM_X64_REG_RAX
-#define REG_ARG_1 ASM_X64_REG_RDI
-#define REG_ARG_2 ASM_X64_REG_RSI
-#define REG_ARG_3 ASM_X64_REG_RDX
-#define REG_ARG_4 ASM_X64_REG_RCX
-#define REG_ARG_5 ASM_X64_REG_R08
+#ifdef _WIN64
+    #define REG_RET ASM_X64_REG_RAX
+    #define REG_ARG_1 ASM_X64_REG_RCX
+    #define REG_ARG_2 ASM_X64_REG_RDX
+    #define REG_ARG_3 ASM_X64_REG_R08
+    #define REG_ARG_4 ASM_X64_REG_R09
+    #define REG_ARG_5 ASM_X64_REG_R10
 
-// caller-save
-#define REG_TEMP0 ASM_X64_REG_RAX
-#define REG_TEMP1 ASM_X64_REG_RDI
-#define REG_TEMP2 ASM_X64_REG_RSI
+    // caller-save
+    #define REG_TEMP0 ASM_X64_REG_RAX
+    #define REG_TEMP1 ASM_X64_REG_RCX
+    #define REG_TEMP2 ASM_X64_REG_RDX
 
-// callee-save
-#define REG_LOCAL_1 ASM_X64_REG_RBX
-#define REG_LOCAL_2 ASM_X64_REG_R12
-#define REG_LOCAL_3 ASM_X64_REG_R13
-#define REG_LOCAL_NUM (3)
+    // callee-save
+    #define REG_LOCAL_1 ASM_X64_REG_RBX
+    #define REG_LOCAL_2 ASM_X64_REG_RSI
+    #define REG_LOCAL_3 ASM_X64_REG_RDI
+    #define REG_LOCAL_NUM (3)
+#else
+    #define REG_RET ASM_X64_REG_RAX
+    #define REG_ARG_1 ASM_X64_REG_RDI
+    #define REG_ARG_2 ASM_X64_REG_RSI
+    #define REG_ARG_3 ASM_X64_REG_RDX
+    #define REG_ARG_4 ASM_X64_REG_RCX
+    #define REG_ARG_5 ASM_X64_REG_R08
+
+    // caller-save
+    #define REG_TEMP0 ASM_X64_REG_RAX
+    #define REG_TEMP1 ASM_X64_REG_RDI
+    #define REG_TEMP2 ASM_X64_REG_RSI
+
+    // callee-save
+    #define REG_LOCAL_1 ASM_X64_REG_RBX
+    #define REG_LOCAL_2 ASM_X64_REG_R12
+    #define REG_LOCAL_3 ASM_X64_REG_R13
+    #define REG_LOCAL_NUM (3)
+#endif
 
 // Holds a pointer to mp_fun_table
 #define REG_FUN_TABLE ASM_X64_REG_FUN_TABLE

--- a/py/emitnx64.c
+++ b/py/emitnx64.c
@@ -9,9 +9,15 @@
 #include "py/asmx64.h"
 
 // Word indices of REG_LOCAL_x in nlr_buf_t
+#ifdef _WIN64
+#define NLR_BUF_IDX_LOCAL_1 (2) // rbx
+#define NLR_BUF_IDX_LOCAL_2 (6) // rsi
+#define NLR_BUF_IDX_LOCAL_3 (5) // rdi
+#else
 #define NLR_BUF_IDX_LOCAL_1 (5) // rbx
 #define NLR_BUF_IDX_LOCAL_2 (6) // r12
 #define NLR_BUF_IDX_LOCAL_3 (7) // r13
+#endif
 
 #define N_X64 (1)
 #define EXPORT_FUN(name) emit_native_x64_##name

--- a/py/nlr.h
+++ b/py/nlr.h
@@ -42,10 +42,10 @@
 #else
 #define MICROPY_NLR_OS_WINDOWS 0
 #endif
-#if defined(__i386__)
+#if defined(__i386__) || (defined(_WIN32) && !defined(_WIN64))
     #define MICROPY_NLR_X86 (1)
     #define MICROPY_NLR_NUM_REGS (6)
-#elif defined(__x86_64__)
+#elif defined(__x86_64__) || defined(_WIN64)
     #define MICROPY_NLR_X64 (1)
     #if MICROPY_NLR_OS_WINDOWS
         #define MICROPY_NLR_NUM_REGS (10)

--- a/py/nlrx64.c
+++ b/py/nlrx64.c
@@ -27,6 +27,7 @@
 #include "py/mpstate.h"
 
 #if MICROPY_NLR_X64
+#if !defined(_WIN32)
 
 #undef nlr_push
 
@@ -111,4 +112,5 @@ NORETURN void nlr_jump(void *val) {
     for (;;); // needed to silence compiler warning
 }
 
+#endif // !_WIN32
 #endif // MICROPY_NLR_X64

--- a/py/nlrx86.c
+++ b/py/nlrx86.c
@@ -27,6 +27,7 @@
 #include "py/mpstate.h"
 
 #if MICROPY_NLR_X86
+#if !defined(_WIN32)
 
 #undef nlr_push
 
@@ -103,4 +104,5 @@ NORETURN void nlr_jump(void *val) {
     for (;;); // needed to silence compiler warning
 }
 
+#endif // !_WIN32
 #endif // MICROPY_NLR_X86


### PR DESCRIPTION
The patches in this PR add support of MICROPY_EMIT_X64 and MICROPY_EMIT_X86 for msvc toolchain in ports/windows. They are enabled by default if building with msvc toolchain, but not with mingw and cygwin toolchain. It includes following changes:

- Add Windows X64 calling convention
- Add assembly code (masm) to support nlr_push and nlr_jump because msvc doesn't support inline assembly for X64 code
- Add alloc.c and gccollect.c (tweaked from unix/alloc.c and unix/gccollect.c) to use Windows memory management for gc

The patches pass all test cases of tests/micropython/native_*,viper_* on Windows.