### PR TITLE
stm32: get small filesystem working on NUCLEO_L432KC

### DIFF
--- a/ports/stm32/boards/NUCLEO_L432KC/mpconfigboard.h
+++ b/ports/stm32/boards/NUCLEO_L432KC/mpconfigboard.h
@@ -13,13 +13,13 @@
 #define MICROPY_PY_UHEAPQ           (0)
 #define MICROPY_PY_UTIMEQ           (0)
 
-#define MICROPY_HW_ENABLE_INTERNAL_FLASH_STORAGE (0)
 #define MICROPY_HW_ENABLE_RTC       (1)
 #define MICROPY_HW_ENABLE_ADC       (1)
 #define MICROPY_HW_ENABLE_DAC       (1)
 #define MICROPY_HW_ENABLE_USB       (0) // requires a custom USB connector on PA11/PA12
 #define MICROPY_HW_ENABLE_TIMER     (1)
 #define MICROPY_HW_HAS_SWITCH       (0)
+#define MICROPY_HW_HAS_FLASH        (1)
 
 // MSI is used and is 4MHz
 #define MICROPY_HW_CLK_PLLM (1)

--- a/ports/stm32/boards/NUCLEO_L432KC/mpconfigboard.mk
+++ b/ports/stm32/boards/NUCLEO_L432KC/mpconfigboard.mk
@@ -6,6 +6,7 @@ OPENOCD_CONFIG = boards/openocd_stm32l4.cfg
 
 # MicroPython settings
 MICROPY_VFS_FAT = 0
+MICROPY_VFS_LFS1 ?= 1
 
 # Don't include default frozen modules because MCU is tight on flash space
 FROZEN_MANIFEST ?=

--- a/ports/stm32/boards/stm32l432.ld
+++ b/ports/stm32/boards/stm32l432.ld
@@ -6,7 +6,7 @@
 MEMORY
 {
     FLASH (rx)      : ORIGIN = 0x08000000, LENGTH = 230K /* sectors 0-114 */
-    FLASH_FS (r)    : ORIGIN = 0x08060000, LENGTH = 26K /* sectors 115-127 */
+    FLASH_FS (r)    : ORIGIN = 0x08039800, LENGTH = 26K /* sectors 115-127 */
     RAM (xrw)       : ORIGIN = 0x20000000, LENGTH = 64K /* SRAM1, 48K + SRAM2, 16K */
 }
 


### PR DESCRIPTION
The filesystem is 26k in size.