### PR TITLE
py/mpprint: Support printing %ld and %lu formats on 64-bit archs.

### DIFF
--- a/py/mpprint.c
+++ b/py/mpprint.c
@@ -503,22 +503,28 @@ int mp_vprintf(const mp_print_t *print, const char *fmt, va_list args) {
                 chrs += mp_print_strn(print, str, prec, flags, fill, width);
                 break;
             }
+            case 'd': {
+                mp_int_t val;
+                if (long_arg) {
+                    val = va_arg(args, long int);
+                } else {
+                    val = va_arg(args, int);
+                }
+                chrs += mp_print_int(print, val, 1, 10, 'a', flags, fill, width);
+                break;
+            }
             case 'u':
-                chrs += mp_print_int(print, va_arg(args, unsigned int), 0, 10, 'a', flags, fill, width);
-                break;
-            case 'd':
-                chrs += mp_print_int(print, va_arg(args, int), 1, 10, 'a', flags, fill, width);
-                break;
             case 'x':
             case 'X': {
-                char fmt_c = *fmt - 'X' + 'A';
+                int base = 16 - ((*fmt + 1) & 6);
+                char fmt_c = (*fmt & 0xf0) - 'P' + 'A';
                 mp_uint_t val;
                 if (long_arg) {
                     val = va_arg(args, unsigned long int);
                 } else {
                     val = va_arg(args, unsigned int);
                 }
-                chrs += mp_print_int(print, val, 0, 16, fmt_c, flags, fill, width);
+                chrs += mp_print_int(print, val, 0, base, fmt_c, flags, fill, width);
                 break;
             }
             case 'p':


### PR DESCRIPTION
Fixes issue #4702.