### PR TITLE
stm32/i2c: Use timeout passed through from machine.I2C() if set, else existing default of 50ms.

### DIFF
--- a/ports/stm32/i2c.h
+++ b/ports/stm32/i2c.h
@@ -56,10 +56,10 @@ void i2c_er_irq_handler(mp_uint_t i2c_id);
 typedef I2C_TypeDef i2c_t;
 
 int i2c_init(i2c_t *i2c, mp_hal_pin_obj_t scl, mp_hal_pin_obj_t sda, uint32_t freq);
-int i2c_start_addr(i2c_t *i2c, int rd_wrn, uint16_t addr, size_t len, bool stop);
-int i2c_read(i2c_t *i2c, uint8_t *dest, size_t len, size_t next_len);
-int i2c_write(i2c_t *i2c, const uint8_t *src, size_t len, size_t next_len);
-int i2c_readfrom(i2c_t *i2c, uint16_t addr, uint8_t *dest, size_t len, bool stop);
-int i2c_writeto(i2c_t *i2c, uint16_t addr, const uint8_t *src, size_t len, bool stop);
+int i2c_start_addr(i2c_t *i2c, int rd_wrn, uint16_t addr, size_t len, bool stop, uint32_t timeout);
+int i2c_read(i2c_t *i2c, uint8_t *dest, size_t len, size_t next_len, uint32_t timeout);
+int i2c_write(i2c_t *i2c, const uint8_t *src, size_t len, size_t next_len, uint32_t timeout);
+int i2c_readfrom(i2c_t *i2c, uint16_t addr, uint8_t *dest, size_t len, bool stop, uint32_t timeout);
+int i2c_writeto(i2c_t *i2c, uint16_t addr, const uint8_t *src, size_t len, bool stop, uint32_t timeout);
 
 #endif // MICROPY_INCLUDED_STM32_I2C_H


### PR DESCRIPTION
This PR ensure stm32 hardware i2c implementation honors the existing `timeout` argument on `machine.I2C` init commands.

Previously the stm32 i2c timeout is hard coded to 50ms which isn't guaranteed to be enough depending on the clock stretching specs of the I2C device(s) in use.

Ah, I now see timeout is an undocumented arg, not described on: https://docs.micropython.org/en/latest/library/machine.I2C.html
I'm not sure if it's implemented for any other ports at this stage.
