### PR TITLE
stm32/usb: Add usb mode for VCP+VCP without MSC

### DIFF
--- a/ports/stm32/usb.c
+++ b/ports/stm32/usb.c
@@ -311,6 +311,11 @@ STATIC mp_obj_t pyb_usb_mode(size_t n_args, const mp_obj_t *pos_args, mp_map_t *
             pid = USBD_PID_CDC2_MSC;
         }
         mode = USBD_MODE_CDC2_MSC;
+    } else if (strcmp(mode_str, "CDC+CDC") == 0 || strcmp(mode_str, "VCP+VCP") == 0) {
+        if (args[2].u_int == -1) {
+            pid = USBD_PID_CDC2;
+        }
+        mode = USBD_MODE_CDC2;
     #endif
     } else if (strcmp(mode_str, "CDC+HID") == 0 || strcmp(mode_str, "VCP+HID") == 0) {
         if (args[2].u_int == -1) {

--- a/ports/stm32/usb.h
+++ b/ports/stm32/usb.h
@@ -37,6 +37,7 @@
 #define USBD_PID_CDC     (0x9802)
 #define USBD_PID_MSC     (0x9803)
 #define USBD_PID_CDC2_MSC (0x9804)
+#define USBD_PID_CDC2    (0x9805)
 
 typedef enum {
     PYB_USB_STORAGE_MEDIUM_NONE = 0,

--- a/ports/stm32/usbdev/class/src/usbd_cdc_msc_hid.c
+++ b/ports/stm32/usbdev/class/src/usbd_cdc_msc_hid.c
@@ -62,6 +62,7 @@
 
 #define CDC_IFACE_NUM_ALONE (0)
 #define CDC_IFACE_NUM_WITH_MSC (1)
+#define CDC2_IFACE_NUM_WITH_CDC (2)
 #define CDC2_IFACE_NUM_WITH_MSC (3)
 #define CDC_IFACE_NUM_WITH_HID (1)
 #define MSC_IFACE_NUM_WITH_CDC (0)
@@ -474,6 +475,18 @@ int USBD_SelectMode(usbd_cdc_msc_hid_state_t *usbd, uint32_t mode, USBD_HID_Mode
             break;
 
         #if MICROPY_HW_USB_ENABLE_CDC2
+        case USBD_MODE_CDC2: {
+            // Ensure the first interface is also enabled
+            usbd->usbd_mode |= USBD_MODE_CDC;
+
+            n += make_cdc_desc(d + n, 1, CDC_IFACE_NUM_ALONE);
+            n += make_cdc_desc_ep(d + n, 1, CDC2_IFACE_NUM_WITH_CDC, CDC2_CMD_EP, CDC2_OUT_EP, CDC2_IN_EP);
+            usbd->cdc->iface_num = CDC_IFACE_NUM_ALONE;
+            usbd->cdc2->iface_num = CDC2_IFACE_NUM_WITH_CDC;
+            num_itf = 4;
+            break;
+        }
+
         case USBD_MODE_CDC2_MSC: {
             n += make_msc_desc(d + n);
             n += make_cdc_desc(d + n, 1, CDC_IFACE_NUM_WITH_MSC);


### PR DESCRIPTION
When `MICROPY_HW_USB_ENABLE_CDC2` is enabled, this allows a usb mode of `VCP+VCP` rather than just the existing `VCP+VCP+MSC` for situation where two serial ports are desired, but mass storage is not.

I found it rather difficult to modify an existing configuration similar to the way the current CDC2 config was added onto VCP+MSC at runtime, so this includes a complete new template struct.

