### PR TITLE
unix/mphal: use CLOCK_MONOTONIC for ticks_ms/us

### DIFF
--- a/ports/unix/unix_mphal.c
+++ b/ports/unix/unix_mphal.c
@@ -187,13 +187,25 @@ void mp_hal_stdout_tx_str(const char *str) {
 }
 
 mp_uint_t mp_hal_ticks_ms(void) {
+#if (defined(_POSIX_TIMERS) && _POSIX_TIMERS > 0) && defined(_POSIX_MONOTONIC_CLOCK)
+    struct timespec tv;
+    clock_gettime(CLOCK_MONOTONIC, &tv);
+    return tv.tv_sec * 1000 + tv.tv_nsec / 1000000;
+#else
     struct timeval tv;
     gettimeofday(&tv, NULL);
     return tv.tv_sec * 1000 + tv.tv_usec / 1000;
+#endif
 }
 
 mp_uint_t mp_hal_ticks_us(void) {
+#if (defined(_POSIX_TIMERS) && _POSIX_TIMERS > 0) && defined(_POSIX_MONOTONIC_CLOCK)
+    struct timespec tv;
+    clock_gettime(CLOCK_MONOTONIC, &tv);
+    return tv.tv_sec * 1000000 + tv.tv_nsec / 1000;
+#else
     struct timeval tv;
     gettimeofday(&tv, NULL);
     return tv.tv_sec * 1000000 + tv.tv_usec;
+#endif
 }


### PR DESCRIPTION
Using gettimeofday  for ticks_ms/us is not guaranteed to be increasing, which is contrary to the [documentation](https://docs.micropython.org/en/latest/library/utime.html). Using CLOCK_MONOTONIC fixes this.