### PR TITLE
stm32/usb_cdc: Add CTS flow control for usb cdc.

### DIFF
--- a/ports/stm32/usbd_cdc_interface.c
+++ b/ports/stm32/usbd_cdc_interface.c
@@ -74,6 +74,13 @@ uint8_t *usbd_cdc_init(usbd_cdc_state_t *cdc_in) {
     cdc->rx_buf_full = false;
     cdc->tx_need_empty_packet = 0;
     cdc->connect_state = USBD_CDC_CONNECT_STATE_DISCONNECTED;
+    if (cdc->attached_to_repl) {
+        // Default behavior is non-blocking when attached to repl
+        cdc->flow &= ~USBD_CDC_FLOWCONTROL_CTS;
+    } else {
+        cdc->flow |= USBD_CDC_FLOWCONTROL_CTS;
+    }
+
 
     // Return the buffer to place the first USB OUT packet
     return cdc->rx_packet_buf;
@@ -290,6 +297,19 @@ int usbd_cdc_tx_half_empty(usbd_cdc_itf_t *cdc) {
         tx_waiting += USBD_CDC_TX_DATA_SIZE;
     }
     return tx_waiting <= USBD_CDC_TX_DATA_SIZE / 2;
+}
+
+// Writes only fitting data if flow & CTS else writes all
+// Returns number of bytes actually written to the device.
+int usbd_cdc_tx_flow(usbd_cdc_itf_t *cdc, const uint8_t *buf, uint32_t len) {
+    if (cdc->flow & USBD_CDC_FLOWCONTROL_CTS) {
+        // Only write as much as can fit in tx buffer
+        return usbd_cdc_tx(cdc, buf, len, 0);
+    } else {
+        // Never block, keep most recent data in rolling buffer
+        usbd_cdc_tx_always(cdc, buf, len);
+        return len;
+    }
 }
 
 // timout in milliseconds.

--- a/ports/stm32/usbd_cdc_interface.h
+++ b/ports/stm32/usbd_cdc_interface.h
@@ -46,6 +46,7 @@
 // Flow control settings
 #define USBD_CDC_FLOWCONTROL_NONE (0)
 #define USBD_CDC_FLOWCONTROL_RTS (1)
+#define USBD_CDC_FLOWCONTROL_CTS (2)
 
 typedef struct _usbd_cdc_itf_t {
     usbd_cdc_state_t base; // state for the base CDC layer
@@ -75,6 +76,7 @@ static inline int usbd_cdc_is_connected(usbd_cdc_itf_t *cdc) {
 }
 
 int usbd_cdc_tx_half_empty(usbd_cdc_itf_t *cdc);
+int usbd_cdc_tx_flow(usbd_cdc_itf_t *cdc, const uint8_t *buf, uint32_t len);
 int usbd_cdc_tx(usbd_cdc_itf_t *cdc, const uint8_t *buf, uint32_t len, uint32_t timeout);
 void usbd_cdc_tx_always(usbd_cdc_itf_t *cdc, const uint8_t *buf, uint32_t len);
 


### PR DESCRIPTION
Off by default, can be enabled at run-time with:
eg. pyb.USB_VCP().init(flow=pyb.USB_VCP.RTS | pyb.USB_VCP.CTS)

This is a cleaner re-implementation of the CTS support I originally made for https://github.com/micropython/micropython/pull/4249 (which was simplified away during merge)