### PR TITLE
py/builtinimport.c: Allow built-in modules to be packages.

### DIFF
--- a/py/mpconfig.h
+++ b/py/mpconfig.h
@@ -684,6 +684,12 @@ typedef double mp_float_t;
 #define MICROPY_MODULE_BUILTIN_INIT (0)
 #endif
 
+// Whether to support built-in packages (e.g. foo.bar)
+// (by default all built-ins must be top-level modules only)
+#ifndef MICROPY_MODULE_BUILTIN_PACKAGES
+#define MICROPY_MODULE_BUILTIN_PACKAGES (0)
+#endif
+
 // Whether to support module-level __getattr__ (see PEP 562)
 #ifndef MICROPY_MODULE_GETATTR
 #define MICROPY_MODULE_GETATTR (0)

--- a/py/objmodule.h
+++ b/py/objmodule.h
@@ -31,16 +31,4 @@
 extern const mp_map_t mp_builtin_module_map;
 extern const mp_map_t mp_builtin_module_weak_links_map;
 
-mp_obj_t mp_module_get(qstr module_name);
-void mp_module_register(qstr qstr, mp_obj_t module);
-
-#if MICROPY_MODULE_BUILTIN_INIT
-void mp_module_call_init(qstr module_name, mp_obj_t module_obj);
-#else
-static inline void mp_module_call_init(qstr module_name, mp_obj_t module_obj) {
-    (void)module_name;
-    (void)module_obj;
-}
-#endif
-
 #endif // MICROPY_INCLUDED_PY_OBJMODULE_H

--- a/py/runtime.c
+++ b/py/runtime.c
@@ -1340,6 +1340,12 @@ mp_obj_t mp_import_name(qstr name, mp_obj_t fromlist, mp_obj_t level) {
     return mp_builtin___import__(5, args);
 }
 
+bool mp_obj_is_package(mp_obj_t module) {
+    mp_obj_t dest[2];
+    mp_load_method_maybe(module, MP_QSTR___path__, dest);
+    return dest[0] != MP_OBJ_NULL;
+}
+
 mp_obj_t mp_import_from(mp_obj_t module, qstr name) {
     DEBUG_printf("import from %p %s\n", module, qstr_str(name));
 


### PR DESCRIPTION
The goal here is to make a built-in `unumpy`, and along with it `unumpy.fft` and `unumpy.linalg`.

Two main changes:
 - Make built-in module importing happen as part of the dotted path walking as for regular modules.
 - Rather than making the submodule an attribute on the package (which can't be done on a built-in module), find them in `mp_loaded_modules_dict`.

 Note: to make this work, the built-in submodule sets its `__name__` to (e.g.) `QSTR_unumpy_dot_fft`, with corresponding `Q(unumpy.fft)` in qstrdefs.