### PR TITLE
mpy-cross: Add --version command line option to print version info.

### DIFF
--- a/mpy-cross/main.c
+++ b/mpy-cross/main.c
@@ -34,6 +34,7 @@
 #include "py/runtime.h"
 #include "py/gc.h"
 #include "py/stackctrl.h"
+#include "genhdr/mpversion.h"
 #ifdef _WIN32
 #include "ports/windows/fmode.h"
 #endif
@@ -98,6 +99,7 @@ STATIC int usage(char **argv) {
     printf(
 "usage: %s [<opts>] [-X <implopt>] <input filename>\n"
 "Options:\n"
+"--version : show version information\n"
 "-o : output file for compiled bytecode (defaults to input with .mpy extension)\n"
 "-s : source filename to embed in the compiled bytecode (defaults to input file)\n"
 "-v : verbose (trace various operations); can be multiple\n"
@@ -209,6 +211,10 @@ MP_NOINLINE int main_(int argc, char **argv) {
         if (argv[a][0] == '-') {
             if (strcmp(argv[a], "-X") == 0) {
                 a += 1;
+            } else if (strcmp(argv[a], "--version") == 0) {
+                printf("MicroPython " MICROPY_GIT_TAG " on " MICROPY_BUILD_DATE
+                    "; mpy-cross emitting mpy v" MP_STRINGIFY(MPY_VERSION) "\n");
+                return 0;
             } else if (strcmp(argv[a], "-v") == 0) {
                 mp_verbose_flag++;
             } else if (strncmp(argv[a], "-O", 2) == 0) {

--- a/py/persistentcode.c
+++ b/py/persistentcode.c
@@ -40,9 +40,6 @@
 
 #define QSTR_LAST_STATIC MP_QSTR_zip
 
-// The current version of .mpy files
-#define MPY_VERSION (4)
-
 // Macros to encode/decode flags to/from the feature byte
 #define MPY_FEATURE_ENCODE_FLAGS(flags) (flags)
 #define MPY_FEATURE_DECODE_FLAGS(feat) ((feat) & 3)

--- a/py/persistentcode.h
+++ b/py/persistentcode.h
@@ -30,6 +30,9 @@
 #include "py/reader.h"
 #include "py/emitglue.h"
 
+// The current version of .mpy files
+#define MPY_VERSION 4
+
 enum {
     MP_NATIVE_ARCH_NONE = 0,
     MP_NATIVE_ARCH_X86,


### PR DESCRIPTION
Executing `mpy-cross --version` prints something like:
```
MicroPython v1.10-304-g8031b7a25 on 2019-05-02; mpy-cross emitting mpy v4
```
Addresses issue #3410