### PR TITLE
stm32/machine_uart: Change default UART timeout to 0, for non blocking.

### DIFF
--- a/docs/library/pyb.UART.rst
+++ b/docs/library/pyb.UART.rst
@@ -69,7 +69,7 @@ Constructors
 Methods
 -------
 
-.. method:: UART.init(baudrate, bits=8, parity=None, stop=1, \*, timeout=1000, flow=0, timeout_char=0, read_buf_len=64)
+.. method:: UART.init(baudrate, bits=8, parity=None, stop=1, \*, timeout=0, flow=0, timeout_char=0, read_buf_len=64)
 
    Initialise the UART bus with the given parameters:
 

--- a/ports/stm32/machine_uart.c
+++ b/ports/stm32/machine_uart.c
@@ -224,7 +224,7 @@ STATIC mp_obj_t pyb_uart_init_helper(pyb_uart_obj_t *self, size_t n_args, const 
         { MP_QSTR_parity, MP_ARG_OBJ, {.u_rom_obj = MP_ROM_PTR(&mp_const_none_obj)} },
         { MP_QSTR_stop, MP_ARG_INT, {.u_int = 1} },
         { MP_QSTR_flow, MP_ARG_KW_ONLY | MP_ARG_INT, {.u_int = UART_HWCONTROL_NONE} },
-        { MP_QSTR_timeout, MP_ARG_KW_ONLY | MP_ARG_INT, {.u_int = 1000} },
+        { MP_QSTR_timeout, MP_ARG_KW_ONLY | MP_ARG_INT, {.u_int = 0} },
         { MP_QSTR_timeout_char, MP_ARG_KW_ONLY | MP_ARG_INT, {.u_int = 0} },
         { MP_QSTR_rxbuf, MP_ARG_KW_ONLY | MP_ARG_INT, {.u_int = -1} },
         { MP_QSTR_read_buf_len, MP_ARG_KW_ONLY | MP_ARG_INT, {.u_int = 64} }, // legacy


### PR DESCRIPTION
It's more common to need non-blocking behaviour when reading from a UART, rather than having a large timeout like 1000ms (the original behaviour).  With a large timeout it's 1) likely that the function will read forever if characters keep trickling it; or 2) the function will unnecessarily wait when characters come sporadically, eg at a REPL prompt.

Resolves issue #4683