### PR TITLE
i2c: support writes with a list of buffers

### DIFF
--- a/extmod/machine_i2c.c
+++ b/extmod/machine_i2c.c
@@ -482,35 +482,26 @@ STATIC int read_mem(mp_obj_t self_in, uint16_t addr, uint32_t memaddr, uint8_t a
     return i2c_readfrom_helper(self, addr, buf, len, true);
 }
 
-#define MAX_MEMADDR_SIZE (4)
-#define BUF_STACK_SIZE (12)
-
 STATIC int write_mem(mp_obj_t self_in, uint16_t addr, uint32_t memaddr, uint8_t addrsize, const uint8_t *buf, size_t len) {
     mp_obj_base_t *self = (mp_obj_base_t*)MP_OBJ_TO_PTR(self_in);
-
-    // need some memory to create the buffer to send; try to use stack if possible
-    uint8_t buf2_stack[MAX_MEMADDR_SIZE + BUF_STACK_SIZE];
-    uint8_t *buf2;
-    size_t buf2_alloc = 0;
-    if (len <= BUF_STACK_SIZE) {
-        buf2 = buf2_stack;
-    } else {
-        buf2_alloc = MAX_MEMADDR_SIZE + len;
-        buf2 = m_new(uint8_t, buf2_alloc);
-    }
+    mp_machine_i2c_p_t *i2c_p = (mp_machine_i2c_p_t*)self->type->protocol;
 
     // create the buffer to send
     size_t memaddr_len = 0;
+    uint8_t memaddr_buf[4];
     for (int16_t i = addrsize - 8; i >= 0; i -= 8) {
-        buf2[memaddr_len++] = memaddr >> i;
+        memaddr_buf[memaddr_len++] = memaddr >> i;
     }
-    memcpy(buf2 + memaddr_len, buf, len);
 
-    int ret = i2c_writeto_helper(self, addr, buf2, memaddr_len + len, true);
-    if (buf2_alloc != 0) {
-        m_del(uint8_t, buf2, buf2_alloc);
+    int ret = i2c_p->start_addr(self, 0, addr, MP_I2C_CONT(memaddr_len + len, true));
+    if (ret < 0) {
+        return ret;
     }
-    return ret;
+    ret = i2c_p->write_part(self, memaddr_buf, memaddr_len, MP_I2C_CONT(len, true));
+    if (ret < 0) {
+        return ret;
+    }
+    return i2c_p->write_part(self, buf, len, MP_I2C_CONT(0, true));
 }
 
 STATIC const mp_arg_t machine_i2c_mem_allowed_args[] = {

--- a/extmod/machine_i2c.h
+++ b/extmod/machine_i2c.h
@@ -28,6 +28,10 @@
 
 #include "py/obj.h"
 
+#define MP_I2C_CONT_LEN_MASK (0x0f)
+#define MP_I2C_CONT_STOP (0x10)
+#define MP_I2C_CONT(next_len, stop) (((stop) ? MP_I2C_CONT_STOP : 0) | ((next_len) > MP_I2C_CONT_LEN_MASK ? MP_I2C_CONT_LEN_MASK : (next_len)))
+
 // I2C protocol
 // the first 4 methods can be NULL, meaning operation is not supported
 typedef struct _mp_machine_i2c_p_t {
@@ -35,8 +39,9 @@ typedef struct _mp_machine_i2c_p_t {
     int (*stop)(mp_obj_base_t *obj);
     int (*read)(mp_obj_base_t *obj, uint8_t *dest, size_t len, bool nack);
     int (*write)(mp_obj_base_t *obj, const uint8_t *src, size_t len);
-    int (*readfrom)(mp_obj_base_t *obj, uint16_t addr, uint8_t *dest, size_t len, bool stop);
-    int (*writeto)(mp_obj_base_t *obj, uint16_t addr, const uint8_t *src, size_t len, bool stop);
+    int (*start_addr)(mp_obj_base_t *obj, int rd_wrn, uint16_t addr, unsigned int cont);
+    int (*read_part)(mp_obj_base_t *obj, uint8_t *dest, size_t len, unsigned int cont);
+    int (*write_part)(mp_obj_base_t *obj, const uint8_t *src, size_t len, unsigned int cont);
 } mp_machine_i2c_p_t;
 
 typedef struct _mp_machine_soft_i2c_obj_t {

--- a/extmod/machine_i2c.h
+++ b/extmod/machine_i2c.h
@@ -55,7 +55,8 @@ typedef struct _mp_machine_soft_i2c_obj_t {
 extern const mp_obj_type_t machine_i2c_type;
 extern const mp_obj_dict_t mp_machine_soft_i2c_locals_dict;
 
-int mp_machine_soft_i2c_readfrom(mp_obj_base_t *self_in, uint16_t addr, uint8_t *dest, size_t len, bool stop);
-int mp_machine_soft_i2c_writeto(mp_obj_base_t *self_in, uint16_t addr, const uint8_t *src, size_t len, bool stop);
+int mp_machine_soft_i2c_start_addr(mp_obj_base_t *self_in, int rd_wrn, uint16_t addr, unsigned int cont);
+int mp_machine_soft_i2c_read_part(mp_obj_base_t *self_in, uint8_t *dest, size_t len, unsigned int cont);
+int mp_machine_soft_i2c_write_part(mp_obj_base_t *self_in, const uint8_t *src, size_t len, unsigned int cont);
 
 #endif // MICROPY_INCLUDED_EXTMOD_MACHINE_I2C_H

--- a/ports/stm32/machine_i2c.c
+++ b/ports/stm32/machine_i2c.c
@@ -179,8 +179,9 @@ STATIC void machine_hard_i2c_init(machine_hard_i2c_obj_t *self, uint32_t freq, u
     mp_hal_pin_open_drain(self->sda);
 }
 
-#define machine_hard_i2c_readfrom mp_machine_soft_i2c_readfrom
-#define machine_hard_i2c_writeto mp_machine_soft_i2c_writeto
+#define machine_hard_i2c_start_addr mp_machine_soft_i2c_start_addr
+#define machine_hard_i2c_read_part mp_machine_soft_i2c_read_part
+#define machine_hard_i2c_write_part mp_machine_soft_i2c_write_part
 
 #endif
 

--- a/ports/stm32/machine_i2c.c
+++ b/ports/stm32/machine_i2c.c
@@ -109,14 +109,19 @@ void machine_hard_i2c_init(machine_hard_i2c_obj_t *self, uint32_t freq, uint32_t
     i2c_init(self->i2c, self->scl, self->sda, freq);
 }
 
-int machine_hard_i2c_readfrom(mp_obj_base_t *self_in, uint16_t addr, uint8_t *dest, size_t len, bool stop) {
+int machine_hard_i2c_start_addr(mp_obj_base_t *self_in, int rd_wrn, uint16_t addr, unsigned int cont) {
     machine_hard_i2c_obj_t *self = MP_OBJ_TO_PTR(self_in);
-    return i2c_readfrom(self->i2c, addr, dest, len, stop);
+    return i2c_start_addr(self->i2c, rd_wrn, addr, cont & MP_I2C_CONT_LEN_MASK, (cont & MP_I2C_CONT_STOP) != 0);
 }
 
-int machine_hard_i2c_writeto(mp_obj_base_t *self_in, uint16_t addr, const uint8_t *src, size_t len, bool stop) {
+int machine_hard_i2c_read_part(mp_obj_base_t *self_in, uint8_t *dest, size_t len, unsigned int cont) {
     machine_hard_i2c_obj_t *self = MP_OBJ_TO_PTR(self_in);
-    return i2c_writeto(self->i2c, addr, src, len, stop);
+    return i2c_read(self->i2c, dest, len, cont & MP_I2C_CONT_LEN_MASK);
+}
+
+int machine_hard_i2c_write_part(mp_obj_base_t *self_in, const uint8_t *src, size_t len, unsigned int cont) {
+    machine_hard_i2c_obj_t *self = MP_OBJ_TO_PTR(self_in);
+    return i2c_write(self->i2c, src, len, cont & MP_I2C_CONT_LEN_MASK);
 }
 
 #else
@@ -240,8 +245,9 @@ mp_obj_t machine_hard_i2c_make_new(const mp_obj_type_t *type, size_t n_args, siz
 }
 
 STATIC const mp_machine_i2c_p_t machine_hard_i2c_p = {
-    .readfrom = machine_hard_i2c_readfrom,
-    .writeto = machine_hard_i2c_writeto,
+    .start_addr = machine_hard_i2c_start_addr,
+    .read_part = machine_hard_i2c_read_part,
+    .write_part = machine_hard_i2c_write_part,
 };
 
 STATIC const mp_obj_type_t machine_hard_i2c_type = {


### PR DESCRIPTION
This implements the ideas for extending `i2c.writeto()` as previously discussed in #4020 (which is still pending).  It allows to pass in a list of buffers to write all at once, eg:
```python
def write_data(i2c, data_buf):
    i2c.writeto(addr, (b'\x01', data_buf))
```

There are a few commits here:
- first is to change the C-level I2C API to support partial I2C transactions: sending a start+addr, then successions of buffers in separate C calls
- second to update stm32 to use this new C-API
- third to use this new C API to remove the need for temporary memory allocation in the existing `i2c.writeto_mem()`
- fourth is to extend `i2c.writeto()` to accept a tuple/list of buffers

It's not a trivial change.  Going down this route puts a burden on ports to implement the new I2C C-level API.  Some ports will have trouble doing this because the I2C abstraction they expose is not powerful enough to support such partial transactions, even though I2C as a bus is completely fine doing such things.

esp32 port will be ok, it provides a way to compose multiple writes.  nrf port won't be ok, it'll either not support this, need memory allocation to support it, or require low-level changes to its HAL (the hardware can support it, of course).  zephyr port will be ok because it provides composition (although will require a small buffer to be set aside for holding the messages).

----

The alternative is to not go down this path at all.  That would then put the burden on the user to find ways around the problem this is trying to solve, namely avoid dynamic memory allocation to combine buffers.  That filters all the way up to the top-level user API because they can no longer simply pass buffers down into I2C-based drivers containing data/payload, in case such buffers must be combined with addition data before being sent out (in a single I2C transaction).  Eg to send a string to a device might look to the user like `display.show('hello world')` but within the driver this string needs to be copied to a temporary buffer (of unknown initial size) and extra bytes added.

So the choice is to push complexity all the way down to the I2C peripheral driver, or all the way up to the end user.