### PR TITLE
nrf/boards/led: Refactor code.

### DIFF
--- a/ports/nrf/boards/blueio_tag_evim/mpconfigboard.h
+++ b/ports/nrf/boards/blueio_tag_evim/mpconfigboard.h
@@ -46,13 +46,10 @@
 #define MICROPY_HW_LED_PULLUP       (1)
 
 #define MICROPY_HW_LED1             (30) // LED1
-#define MICROPY_HW_LED1_LEVEL		(0)
+#define MICROPY_HW_LED1_PULLUP      (0)
 #define MICROPY_HW_LED2             (20) // LED2
-#define MICROPY_HW_LED2_LEVEL		(1)
 #define MICROPY_HW_LED3             (19) // LED3
-#define MICROPY_HW_LED3_LEVEL		(1)
 #define MICROPY_HW_LED4             (18) // LED4
-#define MICROPY_HW_LED4_LEVEL		(1)
 
 // UART config
 #define MICROPY_HW_UART1_RX         (8)

--- a/ports/nrf/modules/board/led.c
+++ b/ports/nrf/modules/board/led.c
@@ -38,24 +38,24 @@ typedef struct _board_led_obj_t {
     mp_uint_t led_id;
     mp_uint_t hw_pin;
     uint8_t hw_pin_port;
-    bool act_level;
+    bool pullup;
 } board_led_obj_t;
 
-static inline void LED_OFF(board_led_obj_t * const led_obj) {
-    if (led_obj->act_level) {
-        nrf_gpio_pin_clear(led_obj->hw_pin);
+static inline void led_off(board_led_obj_t * const led_obj) {
+    if (led_obj->pullup) {
+        nrf_gpio_pin_set(led_obj->hw_pin);
     }
     else {
-        nrf_gpio_pin_set(led_obj->hw_pin);
+        nrf_gpio_pin_clear(led_obj->hw_pin);
     }
 }
 
-static inline void LED_ON(board_led_obj_t * const led_obj) {
-    if (led_obj->act_level) {
-        nrf_gpio_pin_set(led_obj->hw_pin);
+static inline void led_on(board_led_obj_t * const led_obj) {
+    if (led_obj->pullup) {
+        nrf_gpio_pin_clear(led_obj->hw_pin);
     }
     else {
-        nrf_gpio_pin_clear(led_obj->hw_pin);
+        nrf_gpio_pin_set(led_obj->hw_pin);
     }
 }
 
@@ -64,89 +64,43 @@ static const board_led_obj_t board_led_obj[] = {
 
 #if MICROPY_HW_LED_TRICOLOR
 
-    {{&board_led_type}, BOARD_LED_RED, MICROPY_HW_LED_RED, 0, MICROPY_HW_LED_PULLUP != 0 ? 0 : 1},
-    {{&board_led_type}, BOARD_LED_GREEN, MICROPY_HW_LED_GREEN,0, MICROPY_HW_LED_PULLUP != 0 ? 0 : 1},
-    {{&board_led_type}, BOARD_LED_BLUE, MICROPY_HW_LED_BLUE,0, MICROPY_HW_LED_PULLUP != 0 ? 0 : 1},
-
-#elif (MICROPY_HW_LED_COUNT == 1)
-
+    {{&board_led_type}, BOARD_LED_RED, MICROPY_HW_LED_RED, 0, MICROPY_HW_LED_PULLUP},
+    {{&board_led_type}, BOARD_LED_GREEN, MICROPY_HW_LED_GREEN,0, MICROPY_HW_LED_PULLUP},
+    {{&board_led_type}, BOARD_LED_BLUE, MICROPY_HW_LED_BLUE,0, MICROPY_HW_LED_PULLUP},
+#endif
+#if (MICROPY_HW_LED_COUNT >= 1)
     {{&board_led_type}, BOARD_LED1, MICROPY_HW_LED1, 0,
-    #ifdef MICROPY_HW_LED1_LEVEL
-        MICROPY_HW_LED1_LEVEL,
+    #ifdef MICROPY_HW_LED1_PULLUP
+        MICROPY_HW_LED1_PULLUP
     #else
-        MICROPY_HW_LED_PULLUP != 0 ? 0 : 1
+        MICROPY_HW_LED_PULLUP
     #endif
     },
-
-#elif (MICROPY_HW_LED_COUNT == 2)
-
-    {{&board_led_type}, BOARD_LED1, MICROPY_HW_LED1, 0,
-    #ifdef MICROPY_HW_LED1_LEVEL
-        MICROPY_HW_LED1_LEVEL,
-    #else
-        MICROPY_HW_LED_PULLUP != 0 ? 0 : 1
-    #endif
-    },
+#endif
+#if (MICROPY_HW_LED_COUNT >= 2)
     {{&board_led_type}, BOARD_LED2, MICROPY_HW_LED2, 0,
-    #ifdef MICROPY_HW_LED2_LEVEL
-        MICROPY_HW_LED2_LEVEL,
+    #ifdef MICROPY_HW_LED2_PULLUP
+        MICROPY_HW_LED2_PULLUP
     #else
-        MICROPY_HW_LED_PULLUP != 0 ? 0 : 1
+        MICROPY_HW_LED_PULLUP
     #endif
     },
-
-#elif (MICROPY_HW_LED_COUNT == 3)
-
-    {{&board_led_type}, BOARD_LED1, MICROPY_HW_LED1, 0,
-    #ifdef MICROPY_HW_LED1_LEVEL
-        MICROPY_HW_LED1_LEVEL,
-    #else
-        MICROPY_HW_LED_PULLUP != 0 ? 0 : 1
-    #endif
-    },
-    {{&board_led_type}, BOARD_LED2, MICROPY_HW_LED2, 0,
-    #ifdef MICROPY_HW_LED2_LEVEL
-        MICROPY_HW_LED2_LEVEL,
-    #else
-        MICROPY_HW_LED_PULLUP != 0 ? 0 : 1
-    #endif
-    },
+#endif
+#if (MICROPY_HW_LED_COUNT >= 3)
     {{&board_led_type}, BOARD_LED3, MICROPY_HW_LED3, 0,
-    #ifdef MICROPY_HW_LED3_LEVEL
-        MICROPY_HW_LED3_LEVEL,
+    #ifdef MICROPY_HW_LED3_PULLUP
+        MICROPY_HW_LED3_PULLUP
     #else
-        MICROPY_HW_LED_PULLUP != 0 ? 0 : 1
+        MICROPY_HW_LED_PULLUP
     #endif
     },
-
-#else
-
-    {{&board_led_type}, BOARD_LED1, MICROPY_HW_LED1, 0,
-    #ifdef MICROPY_HW_LED1_LEVEL
-        MICROPY_HW_LED1_LEVEL,
-    #else
-        MICROPY_HW_LED_PULLUP != 0 ? 0 : 1
-    #endif
-    },
-    {{&board_led_type}, BOARD_LED2, MICROPY_HW_LED2, 0,
-    #ifdef MICROPY_HW_LED2_LEVEL
-        MICROPY_HW_LED2_LEVEL,
-    #else
-        MICROPY_HW_LED_PULLUP != 0 ? 0 : 1
-    #endif
-    },
-    {{&board_led_type}, BOARD_LED3, MICROPY_HW_LED3, 0,
-    #ifdef MICROPY_HW_LED3_LEVEL
-        MICROPY_HW_LED3_LEVEL,
-    #else
-        MICROPY_HW_LED_PULLUP != 0 ? 0 : 1
-    #endif
-    },
+#endif
+#if (MICROPY_HW_LED_COUNT == 4)
     {{&board_led_type}, BOARD_LED4, MICROPY_HW_LED4, 0,
-    #ifdef MICROPY_HW_LED4_LEVEL
-        MICROPY_HW_LED4_LEVEL,
+    #ifdef MICROPY_HW_LED4_PULLUP
+        MICROPY_HW_LED4_PULLUP
     #else
-        MICROPY_HW_LED_PULLUP != 0 ? 0 : 1
+        MICROPY_HW_LED_PULLUP
     #endif
     },
 #endif
@@ -156,17 +110,17 @@ static const board_led_obj_t board_led_obj[] = {
 
 void led_init(void) {
     for (uint8_t i = 0; i < NUM_LEDS; i++) {
-        LED_OFF((board_led_obj_t*)&board_led_obj[i]);
+        led_off((board_led_obj_t*)&board_led_obj[i]);
         nrf_gpio_cfg_output(board_led_obj[i].hw_pin);
     }
 }
 
 void led_state(board_led_obj_t * led_obj, int state) {
     if (state == 1) {
-        LED_ON(led_obj);
+        led_on(led_obj);
 
     } else {
-        LED_OFF(led_obj);
+        led_off(led_obj);
     }
 }
 


### PR DESCRIPTION
Align static functions to lowercase names.
Trim down source code lines for variants of MICROPY_HW_LED_COUNT.

Renamed configuration for MICROPY_HW_LEDx_LEVEL to MICROPY_HW_LEDx_PULLUP
to align with global PULLUP configuration.