### PR TITLE
py/objarray: Add memoryview.itemsize.

### DIFF
--- a/py/mpconfig.h
+++ b/py/mpconfig.h
@@ -856,6 +856,11 @@ typedef double mp_float_t;
 #define MICROPY_PY_BUILTINS_MEMORYVIEW (0)
 #endif
 
+// Whether to support memoryview.itemsize attribute
+#ifndef MICROPY_PY_BUILTINS_MEMORYVIEW_ITEMSIZE
+#define MICROPY_PY_BUILTINS_MEMORYVIEW_ITEMSIZE (0)
+#endif
+
 // Whether to support set object
 #ifndef MICROPY_PY_BUILTINS_SET
 #define MICROPY_PY_BUILTINS_SET (1)

--- a/py/objarray.c
+++ b/py/objarray.c
@@ -553,10 +553,25 @@ const mp_obj_type_t mp_type_bytearray = {
 #endif
 
 #if MICROPY_PY_BUILTINS_MEMORYVIEW
+#if MICROPY_PY_BUILTINS_MEMORYVIEW_ITEMSIZE
+STATIC void memoryview_attr(mp_obj_t self_in, qstr attr, mp_obj_t *dest) {
+    if (dest[0] != MP_OBJ_NULL) {
+        return;
+    }
+    if (attr == MP_QSTR_itemsize) {
+        mp_obj_array_t *self = MP_OBJ_TO_PTR(self_in);
+        dest[0] = MP_OBJ_NEW_SMALL_INT(mp_binary_get_size('@', self->typecode & TYPECODE_MASK, NULL));
+    }
+}
+#endif
+
 const mp_obj_type_t mp_type_memoryview = {
     { &mp_type_type },
     .name = MP_QSTR_memoryview,
     .make_new = memoryview_make_new,
+    #if MICROPY_PY_BUILTINS_MEMORYVIEW_ITEMSIZE
+    .attr = memoryview_attr,
+    #endif
     .getiter = array_iterator_new,
     .unary_op = array_unary_op,
     .binary_op = array_binary_op,

--- a/tests/basics/memoryview_itemsize.py
+++ b/tests/basics/memoryview_itemsize.py
@@ -1,0 +1,9 @@
+try:
+    memoryview(b'a').itemsize
+    from array import array
+except:
+    print("SKIP")
+    raise SystemExit
+
+for code in ['b', 'h', 'i', 'l', 'q', 'f', 'd']:
+    print(memoryview(array(code)).itemsize)


### PR DESCRIPTION
I'm trying to get msgpack running with MicroPython and for basic usage this is actually the only thing which is missing and cannot be solved by replacing `import xxx` with `import uxxx` etc.