### PR TITLE
Update mpconfigboard.h to enable DAC

### DIFF
--- a/ports/stm32/boards/NUCLEO_F446RE/mpconfigboard.h
+++ b/ports/stm32/boards/NUCLEO_F446RE/mpconfigboard.h
@@ -4,6 +4,7 @@
 #define MICROPY_HW_HAS_SWITCH       (1)
 #define MICROPY_HW_HAS_FLASH        (1)
 #define MICROPY_HW_ENABLE_RTC       (1)
+#define MICROPY_HW_ENABLE_DAC       (1)
 
 // HSE is 8MHz, CPU freq set to 168MHz. Using PLLQ for USB this gives a nice
 // 48 MHz clock for USB. To goto 180 MHz, I think that USB would need to be


### PR DESCRIPTION
The nucleo64 F446RE has two DACs, the first one (obtained with DAC(1)) on pin A2, the second (DAC(2)) on pin D13 that happens to be the pin the onboard LED is connected to. Enabling DAC seems to work fine with the examples on micropython documentation, although the triangle generator is closer to 8192 samples for one period than 2048.