### PR TITLE
Corrected documentation for the ESP32 hardware SPI support.

### DIFF
--- a/docs/esp32/quickref.rst
+++ b/docs/esp32/quickref.rst
@@ -128,6 +128,8 @@ with timer ID of -1::
 
 The period is in milliseconds.
 
+.. _Pins_and_GPIO:
+
 Pins and GPIO
 -------------
 
@@ -274,8 +276,14 @@ class::
 Hardware SPI bus
 ----------------
 
-There are two hardware SPI channels that allow faster (up to 80Mhz)
-transmission rates, but are only supported on a subset of pins.
+There are two hardware SPI channels that allow faster transmission
+rates (up to 80Mhz). These may be used on any IO pins that support the
+required direction and are otherwise unused (see :ref:`Pins_and_GPIO`)
+but if they are not configured to their default pins then they need to
+pass through an extra layer of GPIO multiplexing, which can impact
+their reliability at high speeds. Hardware SPI channels are limited
+to 40MHz when used on pins other than the default ones listed below.
+
 
 =====  ===========  ============
 \      HSPI (id=1)   VSPI (id=2)


### PR DESCRIPTION
The ESP32 hardware SPI code does support remapping of the `sck`, `miso` and `mosi` pins, although there are performance limitations due to the extra layer of GPIO multiplexing involved. See section 7 of the [ESP32 Technical Reference Manual](https://www.espressif.com/sites/default/files/documentation/esp32_technical_reference_manual_en.pdf) for details.