### PR TITLE
STM32L4 Optimise FLASH and RAM allocation.

### DIFF
--- a/ports/stm32/boards/B_L475E_IOT01A/mpconfigboard.mk
+++ b/ports/stm32/boards/B_L475E_IOT01A/mpconfigboard.mk
@@ -1,9 +1,7 @@
 MCU_SERIES = l4
 CMSIS_MCU = STM32L475xx
 # The stm32l475 does not have a LDC controller which is
-# the only diffrence to the stm32l476 - so reuse some files.
+# the only difference to the stm32l476 - so reuse some files.
 AF_FILE = boards/stm32l476_af.csv
-LD_FILES = boards/stm32l476xg.ld boards/common_ifs.ld
-TEXT0_ADDR = 0x08000000
-TEXT1_ADDR = 0x08004000
+LD_FILES = boards/stm32l476xg.ld boards/common_basic.ld
 OPENOCD_CONFIG = boards/openocd_stm32l4.cfg

--- a/ports/stm32/boards/LIMIFROG/mpconfigboard.mk
+++ b/ports/stm32/boards/LIMIFROG/mpconfigboard.mk
@@ -1,6 +1,4 @@
 MCU_SERIES = l4
 CMSIS_MCU = STM32L476xx
 AF_FILE = boards/stm32l476_af.csv
-LD_FILES = boards/stm32l476xe.ld boards/common_ifs.ld
-TEXT0_ADDR = 0x08000000
-TEXT1_ADDR = 0x08004000
+LD_FILES = boards/stm32l476xe.ld boards/common_basic.ld

--- a/ports/stm32/boards/NUCLEO_L476RG/mpconfigboard.mk
+++ b/ports/stm32/boards/NUCLEO_L476RG/mpconfigboard.mk
@@ -1,6 +1,5 @@
 MCU_SERIES = l4
 CMSIS_MCU = STM32L476xx
 AF_FILE = boards/stm32l476_af.csv
-LD_FILES = boards/stm32l476xg.ld boards/common_ifs.ld
-TEXT0_ADDR = 0x08000000
-TEXT1_ADDR = 0x08004000
+LD_FILES = boards/stm32l476xg.ld boards/common_basic.ld
+OPENOCD_CONFIG = boards/openocd_stm32l4.cfg

--- a/ports/stm32/boards/STM32L476DISC/mpconfigboard.mk
+++ b/ports/stm32/boards/STM32L476DISC/mpconfigboard.mk
@@ -1,7 +1,5 @@
 MCU_SERIES = l4
 CMSIS_MCU = STM32L476xx
 AF_FILE = boards/stm32l476_af.csv
-LD_FILES = boards/stm32l476xg.ld boards/common_ifs.ld
-TEXT0_ADDR = 0x08000000
-TEXT1_ADDR = 0x08004000
+LD_FILES = boards/stm32l476xg.ld boards/common_basic.ld
 OPENOCD_CONFIG = boards/openocd_stm32l4.cfg

--- a/ports/stm32/boards/STM32L496GDISC/mpconfigboard.mk
+++ b/ports/stm32/boards/STM32L496GDISC/mpconfigboard.mk
@@ -1,7 +1,5 @@
 MCU_SERIES = l4
 CMSIS_MCU = STM32L496xx
 AF_FILE = boards/stm32l496_af.csv
-LD_FILES = boards/stm32l496xg.ld boards/common_ifs.ld
-TEXT0_ADDR = 0x08000000
-TEXT1_ADDR = 0x08004000
+LD_FILES = boards/stm32l496xg.ld boards/common_basic.ld
 OPENOCD_CONFIG = boards/openocd_stm32l4.cfg

--- a/ports/stm32/boards/stm32l432.ld
+++ b/ports/stm32/boards/stm32l432.ld
@@ -5,23 +5,30 @@
 /* Specify the memory areas */
 MEMORY
 {
-    FLASH (rx)      : ORIGIN = 0x08000000, LENGTH = 256K
-    FLASH_TEXT (rx) : ORIGIN = 0x08000000, LENGTH = 256K
-    RAM (xrw)       : ORIGIN = 0x20000000, LENGTH = 48K
-    SRAM2 (xrw)     : ORIGIN = 0x10000000, LENGTH = 16K
+    FLASH (rx)      : ORIGIN = 0x08000000, LENGTH = 230K /* sectors 0-114 */
+    FLASH_FS (r)    : ORIGIN = 0x08060000, LENGTH = 26K /* sectors 115-127 */
+    RAM (xrw)       : ORIGIN = 0x20000000, LENGTH = 64K /* SRAM1, 48K + SRAM2, 16K */
 }
 
 /* produce a link error if there is not this amount of RAM for these sections */
 _minimum_stack_size = 2K;
 _minimum_heap_size = 16K;
 
-/* Define the stack.  The stack is full descending so begins just above last byte
-   of RAM.  Note that EABI requires the stack to be 8-byte aligned for a call. */
-_estack = ORIGIN(RAM) + LENGTH(RAM) - _estack_reserve;
-_sstack = _estack - 6K; /* tunable */
+/* Define the stack.  The stack is full descending so begins just above last byte of RAM,
+   or bottom of FS cache..  Note that EABI requires the stack to be 8-byte aligned for a call. */
 
 /* RAM extents for the garbage collector */
-_ram_start = ORIGIN(RAM);
 _ram_end = ORIGIN(RAM) + LENGTH(RAM);
+_ram_start = ORIGIN(RAM);
+
+_ram_fs_cache_end = _ram_end;
+_ram_fs_cache_start = _ram_fs_cache_end - 2K; /* fs cache = 2K */
+
+_estack = _ram_fs_cache_start - _estack_reserve;
+_sstack = _estack - 10K; /* stack = 10K */
+
+_heap_end = _sstack; /* bss + heap = 52K, tunable by adjusting stack size */
 _heap_start = _ebss; /* heap starts just after statically allocated memory */
-_heap_end = _sstack;
+
+_flash_fs_start = ORIGIN(FLASH_FS);
+_flash_fs_end   = ORIGIN(FLASH_FS) + LENGTH(FLASH_FS);

--- a/ports/stm32/boards/stm32l476xe.ld
+++ b/ports/stm32/boards/stm32l476xe.ld
@@ -5,31 +5,31 @@
 /* Specify the memory areas */
 MEMORY
 {
-    FLASH (rx)      : ORIGIN = 0x08000000, LENGTH = 512K
-    FLASH_ISR (rx)  : ORIGIN = 0x08000000, LENGTH = 16K /* sectors 0-7 */
-    FLASH_TEXT (rx) : ORIGIN = 0x08004000, LENGTH = 368K /* sectors 8-191 */
+    FLASH (rx)      : ORIGIN = 0x08000000, LENGTH = 384K /* sectors 0-191 */
     FLASH_FS (r)    : ORIGIN = 0x08060000, LENGTH = 128K /* sectors 192-255 */
     RAM (xrw)       : ORIGIN = 0x20000000, LENGTH = 96K
-    SRAM2 (xrw)     : ORIGIN = 0x10000000, LENGTH = 32K
-    FS_CACHE(xrw)   : ORIGIN = 0x10007800, LENGTH = 2K
+    SRAM2 (xrw)     : ORIGIN = 0x10000000, LENGTH = 32K /* not contiguous with RAM */
 }
 
 /* produce a link error if there is not this amount of RAM for these sections */
 _minimum_stack_size = 2K;
 _minimum_heap_size = 16K;
 
-/* Define the stack.  The stack is full descending so begins just above last byte
-   of RAM.  Note that EABI requires the stack to be 8-byte aligned for a call. */
-_estack = ORIGIN(RAM) + LENGTH(RAM) - _estack_reserve;
-_sstack = _estack - 16K; /* tunable */
+/* Define the stack.  The stack is full descending so begins just above last byte of RAM,
+   or bottom of FS cache..  Note that EABI requires the stack to be 8-byte aligned for a call. */
 
 /* RAM extents for the garbage collector */
-_ram_fs_cache_start = ORIGIN(FS_CACHE);
-_ram_fs_cache_end = ORIGIN(FS_CACHE) + LENGTH(FS_CACHE);
-_ram_start = ORIGIN(RAM);
 _ram_end = ORIGIN(RAM) + LENGTH(RAM);
+_ram_start = ORIGIN(RAM);
+
+_ram_fs_cache_end = ORIGIN(SRAM2) + LENGTH(SRAM2); /* fs_cache in SRAM2 */
+_ram_fs_cache_start = _ram_fs_cache_end - 2K; /* fs cache = 2K */
+
+_estack = _ram_fs_cache_start - _estack_reserve; /* stack in SRAM2 */
+_sstack = ORIGIN(SRAM2); /* stack = 30K */
+
+_heap_end = _ram_end; /* bss + heap = 96K, tunable by adjusting stack size */
 _heap_start = _ebss; /* heap starts just after statically allocated memory */
-_heap_end = _sstack;
 
 _flash_fs_start = ORIGIN(FLASH_FS);
 _flash_fs_end   = ORIGIN(FLASH_FS) + LENGTH(FLASH_FS);

--- a/ports/stm32/boards/stm32l476xg.ld
+++ b/ports/stm32/boards/stm32l476xg.ld
@@ -5,31 +5,31 @@
 /* Specify the memory areas */
 MEMORY
 {
-    FLASH (rx)      : ORIGIN = 0x08000000, LENGTH = 1024K
-    FLASH_ISR (rx)  : ORIGIN = 0x08000000, LENGTH = 16K /* sectors 0-7 */
-    FLASH_TEXT (rx) : ORIGIN = 0x08004000, LENGTH = 496K /* sectors 8-255 */
+    FLASH (rx)      : ORIGIN = 0x08000000, LENGTH = 512K /* sectors 0-255 */
     FLASH_FS (r)    : ORIGIN = 0x08080000, LENGTH = 512K /* sectors 256-511 */
     RAM (xrw)       : ORIGIN = 0x20000000, LENGTH = 96K
-    SRAM2 (xrw)     : ORIGIN = 0x10000000, LENGTH = 32K
-    FS_CACHE(xrw)   : ORIGIN = 0x10007800, LENGTH = 2K
+    SRAM2 (xrw)     : ORIGIN = 0x10000000, LENGTH = 32K /* not contiguous with RAM */
 }
 
 /* produce a link error if there is not this amount of RAM for these sections */
 _minimum_stack_size = 2K;
 _minimum_heap_size = 16K;
 
-/* Define the stack.  The stack is full descending so begins just above last byte
-   of RAM.  Note that EABI requires the stack to be 8-byte aligned for a call. */
-_estack = ORIGIN(RAM) + LENGTH(RAM) - _estack_reserve;
-_sstack = _estack - 16K; /* tunable */
+/* Define the stack.  The stack is full descending so begins just above last byte of RAM,
+   or bottom of FS cache..  Note that EABI requires the stack to be 8-byte aligned for a call. */
 
 /* RAM extents for the garbage collector */
-_ram_fs_cache_start = ORIGIN(FS_CACHE);
-_ram_fs_cache_end = ORIGIN(FS_CACHE) + LENGTH(FS_CACHE);
-_ram_start = ORIGIN(RAM);
 _ram_end = ORIGIN(RAM) + LENGTH(RAM);
+_ram_start = ORIGIN(RAM);
+
+_ram_fs_cache_end = ORIGIN(SRAM2) + LENGTH(SRAM2); /* fs_cache in SRAM2 */
+_ram_fs_cache_start = _ram_fs_cache_end - 2K; /* fs cache = 2K */
+
+_estack = _ram_fs_cache_start - _estack_reserve; /* stack in SRAM2 */
+_sstack = ORIGIN(SRAM2); /* stack = 30K */
+
+_heap_end = _ram_end; /* bss + heap = 96K, tunable by adjusting stack size */
 _heap_start = _ebss; /* heap starts just after statically allocated memory */
-_heap_end = _sstack;
 
 _flash_fs_start = ORIGIN(FLASH_FS);
 _flash_fs_end   = ORIGIN(FLASH_FS) + LENGTH(FLASH_FS);

--- a/ports/stm32/boards/stm32l496xg.ld
+++ b/ports/stm32/boards/stm32l496xg.ld
@@ -5,31 +5,30 @@
 /* Specify the memory areas */
 MEMORY
 {
-    FLASH (rx)      : ORIGIN = 0x08000000, LENGTH = 1024K
-    FLASH_ISR (rx)  : ORIGIN = 0x08000000, LENGTH = 16K       /* sectors 0-7 */
-    FLASH_TEXT (rx) : ORIGIN = 0x08004000, LENGTH = 596K      /* sectors 8-305 */
-    FLASH_FS (r)    : ORIGIN = 0x08099000, LENGTH = 412K      /* sectors 306-511 412 KiB */
-    RAM (xrw)       : ORIGIN = 0x20000000, LENGTH = 256K
-    SRAM2 (xrw)     : ORIGIN = 0x20040000, LENGTH = 62K       /* leave 2K for flash fs cache */
-    FS_CACHE(xrw)   : ORIGIN = 0x2004f800, LENGTH = 2K
+    FLASH (rx)      : ORIGIN = 0x08000000, LENGTH = 612K /* sectors 0-305 */
+    FLASH_FS (r)    : ORIGIN = 0x08099000, LENGTH = 412K /* sectors 306-511 412 KiB */
+    RAM (xrw)       : ORIGIN = 0x20000000, LENGTH = 320K /* SRAM1, 256K + SRAM2, 64K */
 }
 
 /* produce a link error if there is not this amount of RAM for these sections */
 _minimum_stack_size = 2K;
 _minimum_heap_size = 16K;
 
-/* Define the stack.  The stack is full descending so begins just above last byte
-   of RAM.  Note that EABI requires the stack to be 8-byte aligned for a call. */
-_estack = ORIGIN(RAM) + LENGTH(RAM) + LENGTH(SRAM2) - _estack_reserve;
-_sstack = _estack - 206K; /* tunable */
+/* Define the stack.  The stack is full descending so begins just above last byte of RAM,
+   or bottom of FS cache..  Note that EABI requires the stack to be 8-byte aligned for a call. */
 
 /* RAM extents for the garbage collector */
-_ram_fs_cache_start = ORIGIN(FS_CACHE);
-_ram_fs_cache_end = ORIGIN(FS_CACHE) + LENGTH(FS_CACHE);
+_ram_end = ORIGIN(RAM) + LENGTH(RAM);
 _ram_start = ORIGIN(RAM);
-_ram_end = ORIGIN(RAM) + LENGTH(RAM) + LENGTH(SRAM2);
+
+_ram_fs_cache_end = _ram_end;
+_ram_fs_cache_start = _ram_fs_cache_end - 2K; /* fs cache = 2K */
+
+_estack = _ram_fs_cache_start - _estack_reserve;
+_sstack = _estack - 16K; /* stack = 16K */
+
+_heap_end = _sstack; /* bss + heap = 302K, tunable by adjusting stack size */
 _heap_start = _ebss; /* heap starts just after statically allocated memory */
-_heap_end = _sstack;
 
 _flash_fs_start = ORIGIN(FLASH_FS);
 _flash_fs_end   = ORIGIN(FLASH_FS) + LENGTH(FLASH_FS);


### PR DESCRIPTION
boards/*/mpconfigboard.mk, boards/stm32l4*.ld  Remove FLASH_ISR.
    Small flash sector devices don't need FLASH_ISR. Reduces flash image by approx 1.5k.

boards/stm32l432.ld  Use SRAM2 to increase stack and heap size. SRAM2 contiguous with RAM.
boards/stm32l496xg.ld   Reduce stack and increase heap.

boards/stm32l476*.ld  Use SRAM2 for stack. SRAM2 is not mapped above RAM.
main.c, gccollect.h   Use _start_stack for L476 with relocated stack.
boards/ L475 & L476 /mpconfigboard.h enable stack relocation for L475, L476 ports.

RAM changes:
L432    stack   6k -> 10k   bss + heap   42k ->  52k
L476    stack  16k -> 30k   bss + heap   80k ->  96k
L496    stack 206k -> 62k   bss + heap  112k -> 256k