### PR TITLE
H7 DMA Fixes

### DIFF
--- a/ports/stm32/dma.c
+++ b/ports/stm32/dma.c
@@ -626,8 +626,8 @@ void dma_init(DMA_HandleTypeDef *dma, const dma_descr_t *dma_descr, uint32_t dir
 
         dma_enable_clock(dma_id);
 
-        #if defined(STM32L4)
-        // Always reset and configure the L4 DMA peripheral
+        #if defined(STM32L4) || defined(STM32H7)
+        // Always reset and configure the H7 and L4 DMA peripheral
         // (dma->State is set to HAL_DMA_STATE_RESET by memset above)
         // TODO: understand how L4 DMA works so this is not needed
         HAL_DMA_DeInit(dma);

--- a/ports/stm32/irq.h
+++ b/ports/stm32/irq.h
@@ -143,6 +143,7 @@ MP_DECLARE_CONST_FUN_OBJ_0(pyb_irq_stats_obj);
 #define IRQ_PRI_TIM5            NVIC_EncodePriority(NVIC_PRIORITYGROUP_4, 6, 0)
 
 #define IRQ_PRI_CAN             NVIC_EncodePriority(NVIC_PRIORITYGROUP_4, 7, 0)
+#define IRQ_PRI_SPI             NVIC_EncodePriority(NVIC_PRIORITYGROUP_4, 8, 0)
 
 // Interrupt priority for non-special timers.
 #define IRQ_PRI_TIMX            NVIC_EncodePriority(NVIC_PRIORITYGROUP_4, 13, 0)

--- a/ports/stm32/spi.c
+++ b/ports/stm32/spi.c
@@ -97,6 +97,28 @@ const spi_t spi_obj[6] = {
     #endif
 };
 
+#if defined(STM32H7)
+// STM32H7 HAL requires SPI IRQs to be enabled and handled.
+#if defined(MICROPY_HW_SPI1_SCK)
+void SPI1_IRQHandler(void) { IRQ_ENTER(SPI1_IRQn); HAL_SPI_IRQHandler(&SPIHandle1); IRQ_EXIT(SPI1_IRQn); }
+#endif
+#if defined(MICROPY_HW_SPI2_SCK)
+void SPI2_IRQHandler(void) { IRQ_ENTER(SPI2_IRQn); HAL_SPI_IRQHandler(&SPIHandle2); IRQ_EXIT(SPI2_IRQn); }
+#endif
+#if defined(MICROPY_HW_SPI3_SCK)
+void SPI3_IRQHandler(void) { IRQ_ENTER(SPI3_IRQn); HAL_SPI_IRQHandler(&SPIHandle3); IRQ_EXIT(SPI3_IRQn); }
+#endif
+#if defined(MICROPY_HW_SPI4_SCK)
+void SPI4_IRQHandler(void) { IRQ_ENTER(SPI4_IRQn); HAL_SPI_IRQHandler(&SPIHandle4); IRQ_EXIT(SPI4_IRQn); }
+#endif
+#if defined(MICROPY_HW_SPI5_SCK)
+void SPI5_IRQHandler(void) { IRQ_ENTER(SPI5_IRQn); HAL_SPI_IRQHandler(&SPIHandle5); IRQ_EXIT(SPI5_IRQn); }
+#endif
+#if defined(MICROPY_HW_SPI6_SCK)
+void SPI6_IRQHandler(void) { IRQ_ENTER(SPI6_IRQn); HAL_SPI_IRQHandler(&SPIHandle6); IRQ_EXIT(SPI6_IRQn); }
+#endif
+#endif
+
 void spi_init0(void) {
     // Initialise the SPI handles.
     // The structs live on the BSS so all other fields will be zero after a reset.
@@ -341,6 +363,41 @@ void spi_init(const spi_t *self, bool enable_nss_pin) {
     // an initialisation the next time we use it.
     dma_invalidate_channel(self->tx_dma_descr);
     dma_invalidate_channel(self->rx_dma_descr);
+
+    #if defined(STM32H7)
+    if (0) {
+    #if defined(MICROPY_HW_SPI1_SCK)
+    } else if (spi->Instance == SPI1) {
+        NVIC_SetPriority(SPI1_IRQn, IRQ_PRI_SPI);
+        HAL_NVIC_EnableIRQ(SPI1_IRQn);
+    #endif
+    #if defined(MICROPY_HW_SPI2_SCK)
+    } else if (spi->Instance == SPI2) {
+        NVIC_SetPriority(SPI2_IRQn, IRQ_PRI_SPI);
+        HAL_NVIC_EnableIRQ(SPI2_IRQn);
+    #endif
+    #if defined(MICROPY_HW_SPI3_SCK)
+    } else if (spi->Instance == SPI3) {
+        NVIC_SetPriority(SPI3_IRQn, IRQ_PRI_SPI);
+        HAL_NVIC_EnableIRQ(SPI3_IRQn);
+    #endif
+    #if defined(MICROPY_HW_SPI4_SCK)
+    } else if (self->Instance == SPI4) {
+        NVIC_SetPriority(SPI4_IRQn, IRQ_PRI_SPI);
+        HAL_NVIC_EnableIRQ(SPI4_IRQn);
+    #endif
+    #if defined(MICROPY_HW_SPI5_SCK)
+    } else if (self->Instance == SPI5) {
+        NVIC_SetPriority(SPI5_IRQn, IRQ_PRI_SPI);
+        HAL_NVIC_EnableIRQ(SPI5_IRQn);
+    #endif
+    #if defined(MICROPY_HW_SPI6_SCK)
+    } else if (self->Instance == SPI6) {
+        NVIC_SetPriority(SPI6_IRQn, IRQ_PRI_SPI);
+        HAL_NVIC_EnableIRQ(SPI6_IRQn);
+    #endif
+    }
+    #endif
 }
 
 void spi_deinit(const spi_t *spi_obj) {
@@ -352,36 +409,42 @@ void spi_deinit(const spi_t *spi_obj) {
         __HAL_RCC_SPI1_FORCE_RESET();
         __HAL_RCC_SPI1_RELEASE_RESET();
         __HAL_RCC_SPI1_CLK_DISABLE();
+        HAL_NVIC_DisableIRQ(SPI1_IRQn);
     #endif
     #if defined(MICROPY_HW_SPI2_SCK)
     } else if (spi->Instance == SPI2) {
         __HAL_RCC_SPI2_FORCE_RESET();
         __HAL_RCC_SPI2_RELEASE_RESET();
         __HAL_RCC_SPI2_CLK_DISABLE();
+        HAL_NVIC_DisableIRQ(SPI2_IRQn);
     #endif
     #if defined(MICROPY_HW_SPI3_SCK)
     } else if (spi->Instance == SPI3) {
         __HAL_RCC_SPI3_FORCE_RESET();
         __HAL_RCC_SPI3_RELEASE_RESET();
         __HAL_RCC_SPI3_CLK_DISABLE();
+        HAL_NVIC_DisableIRQ(SPI3_IRQn);
     #endif
     #if defined(MICROPY_HW_SPI4_SCK)
     } else if (spi->Instance == SPI4) {
         __HAL_RCC_SPI4_FORCE_RESET();
         __HAL_RCC_SPI4_RELEASE_RESET();
         __HAL_RCC_SPI4_CLK_DISABLE();
+        HAL_NVIC_DisableIRQ(SPI4_IRQn);
     #endif
     #if defined(MICROPY_HW_SPI5_SCK)
     } else if (spi->Instance == SPI5) {
         __HAL_RCC_SPI5_FORCE_RESET();
         __HAL_RCC_SPI5_RELEASE_RESET();
         __HAL_RCC_SPI5_CLK_DISABLE();
+        HAL_NVIC_DisableIRQ(SPI5_IRQn);
     #endif
     #if defined(MICROPY_HW_SPI6_SCK)
     } else if (spi->Instance == SPI6) {
         __HAL_RCC_SPI6_FORCE_RESET();
         __HAL_RCC_SPI6_RELEASE_RESET();
         __HAL_RCC_SPI6_CLK_DISABLE();
+        HAL_NVIC_DisableIRQ(SPI6_IRQn);
     #endif
     }
 }

--- a/ports/stm32/spi.c
+++ b/ports/stm32/spi.c
@@ -252,12 +252,14 @@ void spi_set_params(const spi_t *spi_obj, uint32_t prescale, int32_t baudrate,
 
 // TODO allow to take a list of pins to use
 void spi_init(const spi_t *self, bool enable_nss_pin) {
+    uint32_t irqn = 0;
     SPI_HandleTypeDef *spi = self->spi;
     const pin_obj_t *pins[4] = { NULL, NULL, NULL, NULL };
 
     if (0) {
     #if defined(MICROPY_HW_SPI1_SCK)
     } else if (spi->Instance == SPI1) {
+        irqn = SPI1_IRQn;
         #if defined(MICROPY_HW_SPI1_NSS)
         pins[0] = MICROPY_HW_SPI1_NSS;
         #endif
@@ -271,6 +273,7 @@ void spi_init(const spi_t *self, bool enable_nss_pin) {
     #endif
     #if defined(MICROPY_HW_SPI2_SCK)
     } else if (spi->Instance == SPI2) {
+        irqn = SPI2_IRQn;
         #if defined(MICROPY_HW_SPI2_NSS)
         pins[0] = MICROPY_HW_SPI2_NSS;
         #endif
@@ -284,6 +287,7 @@ void spi_init(const spi_t *self, bool enable_nss_pin) {
     #endif
     #if defined(MICROPY_HW_SPI3_SCK)
     } else if (spi->Instance == SPI3) {
+        irqn = SPI3_IRQn;
         #if defined(MICROPY_HW_SPI3_NSS)
         pins[0] = MICROPY_HW_SPI3_NSS;
         #endif
@@ -297,6 +301,7 @@ void spi_init(const spi_t *self, bool enable_nss_pin) {
     #endif
     #if defined(MICROPY_HW_SPI4_SCK)
     } else if (spi->Instance == SPI4) {
+        irqn = SPI4_IRQn;
         #if defined(MICROPY_HW_SPI4_NSS)
         pins[0] = MICROPY_HW_SPI4_NSS;
         #endif
@@ -310,6 +315,7 @@ void spi_init(const spi_t *self, bool enable_nss_pin) {
     #endif
     #if defined(MICROPY_HW_SPI5_SCK)
     } else if (spi->Instance == SPI5) {
+        irqn = SPI5_IRQn;
         #if defined(MICROPY_HW_SPI5_NSS)
         pins[0] = MICROPY_HW_SPI5_NSS;
         #endif
@@ -323,6 +329,7 @@ void spi_init(const spi_t *self, bool enable_nss_pin) {
     #endif
     #if defined(MICROPY_HW_SPI6_SCK)
     } else if (spi->Instance == SPI6) {
+        irqn = SPI6_IRQn;
         #if defined(MICROPY_HW_SPI6_NSS)
         pins[0] = MICROPY_HW_SPI6_NSS;
         #endif
@@ -365,39 +372,11 @@ void spi_init(const spi_t *self, bool enable_nss_pin) {
     dma_invalidate_channel(self->rx_dma_descr);
 
     #if defined(STM32H7)
-    if (0) {
-    #if defined(MICROPY_HW_SPI1_SCK)
-    } else if (spi->Instance == SPI1) {
-        NVIC_SetPriority(SPI1_IRQn, IRQ_PRI_SPI);
-        HAL_NVIC_EnableIRQ(SPI1_IRQn);
-    #endif
-    #if defined(MICROPY_HW_SPI2_SCK)
-    } else if (spi->Instance == SPI2) {
-        NVIC_SetPriority(SPI2_IRQn, IRQ_PRI_SPI);
-        HAL_NVIC_EnableIRQ(SPI2_IRQn);
-    #endif
-    #if defined(MICROPY_HW_SPI3_SCK)
-    } else if (spi->Instance == SPI3) {
-        NVIC_SetPriority(SPI3_IRQn, IRQ_PRI_SPI);
-        HAL_NVIC_EnableIRQ(SPI3_IRQn);
-    #endif
-    #if defined(MICROPY_HW_SPI4_SCK)
-    } else if (self->Instance == SPI4) {
-        NVIC_SetPriority(SPI4_IRQn, IRQ_PRI_SPI);
-        HAL_NVIC_EnableIRQ(SPI4_IRQn);
-    #endif
-    #if defined(MICROPY_HW_SPI5_SCK)
-    } else if (self->Instance == SPI5) {
-        NVIC_SetPriority(SPI5_IRQn, IRQ_PRI_SPI);
-        HAL_NVIC_EnableIRQ(SPI5_IRQn);
-    #endif
-    #if defined(MICROPY_HW_SPI6_SCK)
-    } else if (self->Instance == SPI6) {
-        NVIC_SetPriority(SPI6_IRQn, IRQ_PRI_SPI);
-        HAL_NVIC_EnableIRQ(SPI6_IRQn);
-    #endif
-    }
-    #endif
+    NVIC_SetPriority(irqn, IRQ_PRI_SPI);
+    HAL_NVIC_EnableIRQ(irqn);
+    #else 
+    (void)irqn;
+    #endif 
 }
 
 void spi_deinit(const spi_t *spi_obj) {


### PR DESCRIPTION
Some DMA fixes for H7 as discussed in PR #4779
* Always reset and configure the DMA for H7 (doesn't work otherwise)
* Add SPI IRQn after CAN (could use same priority as CAN).
* Enable SPI IRQs and add SPI IRQHandlers to spi.c for the H7 (I assumed they're not needed for other MCUs).