### PR TITLE
Fix irq stats.

### DIFF
--- a/ports/stm32/irq.c
+++ b/ports/stm32/irq.c
@@ -31,7 +31,7 @@
 /// \moduleref pyb
 
 #if IRQ_ENABLE_STATS
-uint32_t irq_stats[FPU_IRQn + 1] = {0};
+uint32_t irq_stats[IRQ_STATS_MAX] = {0};
 #endif
 
 /// \function wfi()

--- a/ports/stm32/irq.h
+++ b/ports/stm32/irq.h
@@ -39,7 +39,7 @@
 #define IRQ_ENABLE_STATS (0)
 
 #if IRQ_ENABLE_STATS
-extern uint32_t irq_stats[FPU_IRQn + 1];
+extern uint32_t irq_stats[256];
 #define IRQ_ENTER(irq) ++irq_stats[irq]
 #define IRQ_EXIT(irq)
 #else

--- a/ports/stm32/irq.h
+++ b/ports/stm32/irq.h
@@ -39,7 +39,12 @@
 #define IRQ_ENABLE_STATS (0)
 
 #if IRQ_ENABLE_STATS
-extern uint32_t irq_stats[256];
+#if defined(STM32H7)
+#define IRQ_STATS_MAX   (256)
+#else
+#define IRQ_STATS_MAX   (128)
+#endif
+extern uint32_t irq_stats[IRQ_STATS_MAX];
 #define IRQ_ENTER(irq) ++irq_stats[irq]
 #define IRQ_EXIT(irq)
 #else


### PR DESCRIPTION
* This may have been overlooked, but only the M4 and M7 MCUs have an FPU and FPU_IRQn. The build will fail for other MCUs like the F0.
* Additionally, FPU_IRQn is Not the last entry/IRQ number. For example see stm32f765xx.h IRQs numbers run up to 109.
* I think 256 should be enough for all the supported STMs, unless it's better to define it for each MCU.