### PR TITLE
STM32 Define start of stack separately from heap end.

### DIFF
--- a/ports/stm32/boards/STM32F769DISC/f769_qspi.ld
+++ b/ports/stm32/boards/STM32F769DISC/f769_qspi.ld
@@ -27,14 +27,16 @@ MEMORY
 _minimum_stack_size = 2K;
 _minimum_heap_size = 16K;
 
-/* Define tho top end of the stack */
+/* Define the stack.  The stack is full descending so begins just above last byte
+   of RAM.  Note that EABI requires the stack to be 8-byte aligned for a call. */
 _estack = ORIGIN(RAM) + LENGTH(RAM);
+_sstack = _estack - 32K; /* tunable */
 
 /* RAM extents for the garbage collector */
 _ram_start = ORIGIN(RAM);
 _ram_end = ORIGIN(RAM) + LENGTH(RAM);
 _heap_start = _ebss; /* heap starts just after statically allocated memory */
-_heap_end = 0x20078000; /* tunable */
+_heap_end = _sstack; /* bss + heap = 384K - 32K = 352K */
 
 ENTRY(Reset_Handler)
 

--- a/ports/stm32/boards/stm32f091xc.ld
+++ b/ports/stm32/boards/stm32f091xc.ld
@@ -14,13 +14,13 @@ MEMORY
 _minimum_stack_size = 2K;
 _minimum_heap_size = 16K;
 
-/* Define tho top end of the stack.  The stack is full descending so begins just
-   above last byte of RAM.  Note that EABI requires the stack to be 8-byte
-   aligned for a call. */
+/* Define the stack.  The stack is full descending so begins just above last byte above last byte
+   of RAM.  Note that EABI requires the stack to be 8-byte aligned for a call. */
 _estack = ORIGIN(RAM) + LENGTH(RAM);
+_sstack = _estack - 6K; /* tunable */
 
 /* RAM extents for the garbage collector */
 _ram_start = ORIGIN(RAM);
 _ram_end = ORIGIN(RAM) + LENGTH(RAM);
 _heap_start = _ebss; /* heap starts just after statically allocated memory */
-_heap_end = 0x20006800; /* room for a 6k stack */
+_heap_end = _sstack; /* bss + heap = 32K - 6K = 26K */

--- a/ports/stm32/boards/stm32f401xd.ld
+++ b/ports/stm32/boards/stm32f401xd.ld
@@ -14,15 +14,15 @@ MEMORY
 
 /* produce a link error if there is not this amount of RAM for these sections */
 _minimum_stack_size = 2K;
-_minimum_heap_size = 16K;
+_minimum_heap_size = 16K; /* tunable */
 
-/* Define tho top end of the stack.  The stack is full descending so begins just
-   above last byte of RAM.  Note that EABI requires the stack to be 8-byte
-   aligned for a call. */
+/* Define the stack.  The stack is full descending so begins just above last byte
+   of RAM.  Note that EABI requires the stack to be 8-byte aligned for a call. */
 _estack = ORIGIN(RAM) + LENGTH(RAM);
+_sstack = _estack - 16K;
 
 /* RAM extents for the garbage collector */
 _ram_start = ORIGIN(RAM);
 _ram_end = ORIGIN(RAM) + LENGTH(RAM);
 _heap_start = _ebss; /* heap starts just after statically allocated memory */
-_heap_end = 0x20014000; /* tunable */
+_heap_end = _sstack; /* bss + heap = 96K - 16K = 80K */

--- a/ports/stm32/boards/stm32f401xe.ld
+++ b/ports/stm32/boards/stm32f401xe.ld
@@ -16,13 +16,13 @@ MEMORY
 _minimum_stack_size = 2K;
 _minimum_heap_size = 16K;
 
-/* Define tho top end of the stack.  The stack is full descending so begins just
-   above last byte of RAM.  Note that EABI requires the stack to be 8-byte
-   aligned for a call. */
+/* Define the stack.  The stack is full descending so begins just above last byte
+   of RAM.  Note that EABI requires the stack to be 8-byte aligned for a call. */
 _estack = ORIGIN(RAM) + LENGTH(RAM);
+_sstack = _estack - 16K; /* tunable */
 
 /* RAM extents for the garbage collector */
 _ram_start = ORIGIN(RAM);
 _ram_end = ORIGIN(RAM) + LENGTH(RAM);
 _heap_start = _ebss; /* heap starts just after statically allocated memory */
-_heap_end = 0x20014000; /* tunable */
+_heap_end = _sstack; /* bss + heap = 96K - 16K = 80K. Note 16K used as FS cache */

--- a/ports/stm32/boards/stm32f405.ld
+++ b/ports/stm32/boards/stm32f405.ld
@@ -17,13 +17,13 @@ MEMORY
 _minimum_stack_size = 2K;
 _minimum_heap_size = 16K;
 
-/* Define tho top end of the stack.  The stack is full descending so begins just
-   above last byte of RAM.  Note that EABI requires the stack to be 8-byte
-   aligned for a call. */
+/* Define the stack.  The stack is full descending so begins just above last byte
+   of RAM.  Note that EABI requires the stack to be 8-byte aligned for a call. */
 _estack = ORIGIN(RAM) + LENGTH(RAM);
+_sstack = _estack - 16K; /* tunable */
 
 /* RAM extents for the garbage collector */
 _ram_start = ORIGIN(RAM);
 _ram_end = ORIGIN(RAM) + LENGTH(RAM);
 _heap_start = _ebss; /* heap starts just after statically allocated memory */
-_heap_end = 0x2001c000; /* tunable */
+_heap_end = _sstack; /* bss + heap = 128K - 16K = 112K */

--- a/ports/stm32/boards/stm32f411.ld
+++ b/ports/stm32/boards/stm32f411.ld
@@ -16,13 +16,13 @@ MEMORY
 _minimum_stack_size = 2K;
 _minimum_heap_size = 16K;
 
-/* Define tho top end of the stack.  The stack is full descending so begins just
-   above last byte of RAM.  Note that EABI requires the stack to be 8-byte
-   aligned for a call. */
+/* Define the stack.  The stack is full descending so begins just above last byte
+   of RAM.  Note that EABI requires the stack to be 8-byte aligned for a call. */
 _estack = ORIGIN(RAM) + LENGTH(RAM);
+_sstack = _estack - 16K; /* tunable */
 
 /* RAM extents for the garbage collector */
 _ram_start = ORIGIN(RAM);
 _ram_end = ORIGIN(RAM) + LENGTH(RAM);
 _heap_start = _ebss; /* heap starts just after statically allocated memory */
-_heap_end = 0x2001c000; /* tunable */
+_heap_end = _sstack; /* bss + heap = 128K - 16K = 112K */

--- a/ports/stm32/boards/stm32f413xg.ld
+++ b/ports/stm32/boards/stm32f413xg.ld
@@ -19,13 +19,13 @@ MEMORY
 _minimum_stack_size = 2K;
 _minimum_heap_size = 16K;
 
-/* Define tho top end of the stack.  The stack is full descending so begins just
-   above last byte of RAM.  Note that EABI requires the stack to be 8-byte
-   aligned for a call. */
+/* Define the stack.  The stack is full descending so begins just above last byte
+   of RAM.  Note that EABI requires the stack to be 8-byte aligned for a call. */
 _estack = ORIGIN(RAM) + LENGTH(RAM);
+_sstack = _estack - 16K; /* tunable */
 
 /* RAM extents for the garbage collector */
 _ram_start = ORIGIN(RAM);
 _ram_end = ORIGIN(RAM) + LENGTH(RAM);
 _heap_start = _ebss; /* heap starts just after statically allocated memory */
-_heap_end = _ram_end - 16K; /* 240K, tunable */
+_heap_end = _sstack; /* bss + heap = 256K - 16K = 240K */

--- a/ports/stm32/boards/stm32f413xh.ld
+++ b/ports/stm32/boards/stm32f413xh.ld
@@ -19,13 +19,13 @@ MEMORY
 _minimum_stack_size = 2K;
 _minimum_heap_size = 16K;
 
-/* Define tho top end of the stack.  The stack is full descending so begins just
-   above last byte of RAM.  Note that EABI requires the stack to be 8-byte
-   aligned for a call. */
+/* Define the stack.  The stack is full descending so begins just above last byte
+   of RAM.  Note that EABI requires the stack to be 8-byte aligned for a call. */
 _estack = ORIGIN(RAM) + LENGTH(RAM);
+_sstack = _estack - 16K; /* tunable */
 
 /* RAM extents for the garbage collector */
 _ram_start = ORIGIN(RAM);
 _ram_end = ORIGIN(RAM) + LENGTH(RAM);
 _heap_start = _ebss; /* heap starts just after statically allocated memory */
-_heap_end = _ram_end - 16K; /* 240K, tunable */
+_heap_end = _sstack; /* bss + heap = 256K - 16K = 240K */

--- a/ports/stm32/boards/stm32f429.ld
+++ b/ports/stm32/boards/stm32f429.ld
@@ -17,13 +17,13 @@ MEMORY
 _minimum_stack_size = 2K;
 _minimum_heap_size = 16K;
 
-/* Define tho top end of the stack.  The stack is full descending so begins just
-   above last byte of RAM.  Note that EABI requires the stack to be 8-byte
-   aligned for a call. */
+/* Define the stack.  The stack is full descending so begins just above last byte
+   of RAM.  Note that EABI requires the stack to be 8-byte aligned for a call. */
 _estack = ORIGIN(RAM) + LENGTH(RAM);
+_sstack = _estack - 16K; /* tunable */
 
 /* RAM extents for the garbage collector */
 _ram_start = ORIGIN(RAM);
 _ram_end = ORIGIN(RAM) + LENGTH(RAM);
 _heap_start = _ebss; /* heap starts just after statically allocated memory */
-_heap_end = 0x2002c000; /* tunable */
+_heap_end = _sstack; /* bss + heap = 192K - 16K = 176K */

--- a/ports/stm32/boards/stm32f439.ld
+++ b/ports/stm32/boards/stm32f439.ld
@@ -18,11 +18,13 @@ MEMORY
 _minimum_stack_size = 2K;
 _minimum_heap_size = 16K;
 
-/* top end of the stack */
+/* Define the stack.  The stack is full descending so begins just above last byte
+   of RAM.  Note that EABI requires the stack to be 8-byte aligned for a call. */
 _estack = ORIGIN(RAM) + LENGTH(RAM);
+_sstack = _estack - 16K; /* tunable */
 
 /* RAM extents for the garbage collector */
 _ram_start = ORIGIN(RAM);
 _ram_end = ORIGIN(RAM) + LENGTH(RAM);
 _heap_start = _ebss; /* heap starts just after statically allocated memory */
-_heap_end = 0x2002c000; /* tunable */
+_heap_end = _sstack; /* bss + heap = 192K - 16K = 176K */

--- a/ports/stm32/boards/stm32f722.ld
+++ b/ports/stm32/boards/stm32f722.ld
@@ -15,13 +15,13 @@ MEMORY
 _minimum_stack_size = 2K;
 _minimum_heap_size = 16K;
 
-/* Define tho top end of the stack.  The stack is full descending so begins just
-   above last byte of RAM.  Note that EABI requires the stack to be 8-byte
-   aligned for a call. */
+/* Define the stack.  The stack is full descending so begins just above last byte
+   of RAM.  Note that EABI requires the stack to be 8-byte aligned for a call. */
 _estack = ORIGIN(RAM) + LENGTH(RAM);
+_sstack = _estack - 32K; /* tunable */
 
 /* RAM extents for the garbage collector */
 _ram_start = ORIGIN(RAM);
 _ram_end = ORIGIN(RAM) + LENGTH(RAM);
 _heap_start = _ebss; /* heap starts just after statically allocated memory */
-_heap_end = 0x20038000; /* tunable */
+_heap_end = _sstack; /* bss + heap = 256K - 32K = 224K */

--- a/ports/stm32/boards/stm32f746.ld
+++ b/ports/stm32/boards/stm32f746.ld
@@ -1,5 +1,5 @@
 /*
-    GNU linker script for STM32F405
+    GNU linker script for STM32F746
 */
 
 /* Specify the memory areas */
@@ -17,13 +17,13 @@ MEMORY
 _minimum_stack_size = 2K;
 _minimum_heap_size = 16K;
 
-/* Define tho top end of the stack.  The stack is full descending so begins just
-   above last byte of RAM.  Note that EABI requires the stack to be 8-byte
-   aligned for a call. */
+/* Define the stack.  The stack is full descending so begins just above last byte
+   of RAM.  Note that EABI requires the stack to be 8-byte aligned for a call. */
 _estack = ORIGIN(RAM) + LENGTH(RAM);
+_sstack = _estack - 16K; /* tunable */
 
 /* RAM extents for the garbage collector */
 _ram_start = ORIGIN(RAM);
 _ram_end = ORIGIN(RAM) + LENGTH(RAM);
 _heap_start = _ebss; /* heap starts just after statically allocated memory */
-_heap_end = 0x2004c000; /* tunable */
+_heap_end = _sstack; /* bss + heap = 256K - 16K = 240K */

--- a/ports/stm32/boards/stm32f767.ld
+++ b/ports/stm32/boards/stm32f767.ld
@@ -18,13 +18,13 @@ MEMORY
 _minimum_stack_size = 2K;
 _minimum_heap_size = 16K;
 
-/* Define tho top end of the stack.  The stack is full descending so begins just
-   above last byte of RAM.  Note that EABI requires the stack to be 8-byte
-   aligned for a call. */
+/* Define the stack.  The stack is full descending so begins just above last byte
+   of RAM.  Note that EABI requires the stack to be 8-byte aligned for a call. */
 _estack = ORIGIN(RAM) + LENGTH(RAM);
+_sstack = _estack - 32K; /* tunable */
 
 /* RAM extents for the garbage collector */
 _ram_start = ORIGIN(RAM);
 _ram_end = ORIGIN(RAM) + LENGTH(RAM);
 _heap_start = _ebss; /* heap starts just after statically allocated memory */
-_heap_end = 0x20078000; /* tunable */
+_heap_end = _sstack; /* bss + heap = 384K - 32K = 352K */

--- a/ports/stm32/boards/stm32f769.ld
+++ b/ports/stm32/boards/stm32f769.ld
@@ -17,13 +17,13 @@ MEMORY
 _minimum_stack_size = 2K;
 _minimum_heap_size = 16K;
 
-/* Define tho top end of the stack.  The stack is full descending so begins just
-   above last byte of RAM.  Note that EABI requires the stack to be 8-byte
-   aligned for a call. */
+/* Define the stack.  The stack is full descending so begins just above last byte
+   of RAM.  Note that EABI requires the stack to be 8-byte aligned for a call. */
 _estack = ORIGIN(RAM) + LENGTH(RAM);
+_sstack = _estack - 32K; /* tunable */
 
 /* RAM extents for the garbage collector */
 _ram_start = ORIGIN(RAM);
 _ram_end = ORIGIN(RAM) + LENGTH(RAM);
 _heap_start = _ebss; /* heap starts just after statically allocated memory */
-_heap_end = 0x20078000; /* tunable */
+_heap_end = _sstack; /* bss + heap = 384K - 32K = 352K */

--- a/ports/stm32/boards/stm32h743.ld
+++ b/ports/stm32/boards/stm32h743.ld
@@ -17,13 +17,13 @@ MEMORY
 _minimum_stack_size = 2K;
 _minimum_heap_size = 16K;
 
-/* Define tho top end of the stack.  The stack is full descending so begins just
-   above last byte of RAM.  Note that EABI requires the stack to be 8-byte
-   aligned for a call. */
+/* Define the stack.  The stack is full descending so begins just above last byte
+   of RAM.  Note that EABI requires the stack to be 8-byte aligned for a call. */
 _estack = ORIGIN(RAM) + LENGTH(RAM);
+_sstack = _estack - 16K; /* tunable */
 
 /* RAM extents for the garbage collector */
 _ram_start = ORIGIN(RAM);
 _ram_end = ORIGIN(RAM) + LENGTH(RAM);
 _heap_start = _ebss; /* heap starts just after statically allocated memory */
-_heap_end = 0x2407C000; /* tunable */
+_heap_end = _sstack; /* bss + heap = 512K - 16K = 496K */

--- a/ports/stm32/boards/stm32l432.ld
+++ b/ports/stm32/boards/stm32l432.ld
@@ -15,13 +15,13 @@ MEMORY
 _minimum_stack_size = 2K;
 _minimum_heap_size = 16K;
 
-/* Define the top end of the stack.  The stack is full descending so begins just
-   above last byte of RAM.  Note that EABI requires the stack to be 8-byte
-   aligned for a call. */
+/* Define the stack.  The stack is full descending so begins just above last byte
+   of RAM.  Note that EABI requires the stack to be 8-byte aligned for a call. */
 _estack = ORIGIN(RAM) + LENGTH(RAM);
+_sstack = _estack - 6K; /* tunable */
 
 /* RAM extents for the garbage collector */
 _ram_start = ORIGIN(RAM);
 _ram_end = ORIGIN(RAM) + LENGTH(RAM);
 _heap_start = _ebss; /* heap starts just after statically allocated memory */
-_heap_end = 0x2000A800; /* room for a 6k stack */
+_heap_end = _sstack; /* bss + heap = 48K - 16K = 32K */

--- a/ports/stm32/boards/stm32l476xe.ld
+++ b/ports/stm32/boards/stm32l476xe.ld
@@ -18,10 +18,10 @@ MEMORY
 _minimum_stack_size = 2K;
 _minimum_heap_size = 16K;
 
-/* Define the top end of the stack.  The stack is full descending so begins just
-   above last byte of RAM.  Note that EABI requires the stack to be 8-byte
-   aligned for a call. */
+/* Define the stack.  The stack is full descending so begins just above last byte
+   of RAM.  Note that EABI requires the stack to be 8-byte aligned for a call. */
 _estack = ORIGIN(RAM) + LENGTH(RAM);
+_sstack = _estack - 16K; /* tunable */
 
 /* RAM extents for the garbage collector */
 _ram_fs_cache_start = ORIGIN(FS_CACHE);
@@ -29,7 +29,7 @@ _ram_fs_cache_end = ORIGIN(FS_CACHE) + LENGTH(FS_CACHE);
 _ram_start = ORIGIN(RAM);
 _ram_end = ORIGIN(RAM) + LENGTH(RAM);
 _heap_start = _ebss; /* heap starts just after statically allocated memory */
-_heap_end = 0x20014000; /* tunable */
+_heap_end = _sstack; /* bss + heap = 96K - 16K = 80K */
 
 _flash_fs_start = ORIGIN(FLASH_FS);
 _flash_fs_end   = ORIGIN(FLASH_FS) + LENGTH(FLASH_FS);

--- a/ports/stm32/boards/stm32l476xg.ld
+++ b/ports/stm32/boards/stm32l476xg.ld
@@ -18,10 +18,10 @@ MEMORY
 _minimum_stack_size = 2K;
 _minimum_heap_size = 16K;
 
-/* Define the top end of the stack.  The stack is full descending so begins just
-   above last byte of RAM.  Note that EABI requires the stack to be 8-byte
-   aligned for a call. */
+/* Define the stack.  The stack is full descending so begins just above last byte
+   of RAM.  Note that EABI requires the stack to be 8-byte aligned for a call. */
 _estack = ORIGIN(RAM) + LENGTH(RAM);
+_sstack = _estack - 16K; /* tunable */
 
 /* RAM extents for the garbage collector */
 _ram_fs_cache_start = ORIGIN(FS_CACHE);
@@ -29,7 +29,7 @@ _ram_fs_cache_end = ORIGIN(FS_CACHE) + LENGTH(FS_CACHE);
 _ram_start = ORIGIN(RAM);
 _ram_end = ORIGIN(RAM) + LENGTH(RAM);
 _heap_start = _ebss; /* heap starts just after statically allocated memory */
-_heap_end = 0x20014000; /* tunable */
+_heap_end = _sstack; /* bss + heap = 96K - 16K = 80K */
 
 _flash_fs_start = ORIGIN(FLASH_FS);
 _flash_fs_end   = ORIGIN(FLASH_FS) + LENGTH(FLASH_FS);

--- a/ports/stm32/boards/stm32l496xg.ld
+++ b/ports/stm32/boards/stm32l496xg.ld
@@ -18,10 +18,10 @@ MEMORY
 _minimum_stack_size = 2K;
 _minimum_heap_size = 16K;
 
-/* Define the top end of the stack.  The stack is full descending so begins just
-   above last byte of RAM.  Note that EABI requires the stack to be 8-byte
-   aligned for a call. */
+/* Define the stack.  The stack is full descending so begins just above last byte
+   of RAM.  Note that EABI requires the stack to be 8-byte aligned for a call. */
 _estack = ORIGIN(RAM) + LENGTH(RAM) + LENGTH(SRAM2);
+_sstack = _estack - 206K; /* tunable */
 
 /* RAM extents for the garbage collector */
 _ram_fs_cache_start = ORIGIN(FS_CACHE);
@@ -29,7 +29,7 @@ _ram_fs_cache_end = ORIGIN(FS_CACHE) + LENGTH(FS_CACHE);
 _ram_start = ORIGIN(RAM);
 _ram_end = ORIGIN(RAM) + LENGTH(RAM) + LENGTH(SRAM2);
 _heap_start = _ebss; /* heap starts just after statically allocated memory */
-_heap_end = 0x2001C000; /* tunable */
+_heap_end = _sstack; /* bss + heap = 318K - 206K = 112K */
 
 _flash_fs_start = ORIGIN(FLASH_FS);
 _flash_fs_end   = ORIGIN(FLASH_FS) + LENGTH(FLASH_FS);

--- a/ports/stm32/gccollect.h
+++ b/ports/stm32/gccollect.h
@@ -37,6 +37,7 @@ extern uint32_t _sbss;
 extern uint32_t _ebss;
 extern uint32_t _heap_start;
 extern uint32_t _heap_end;
+extern uint32_t _sstack;
 extern uint32_t _estack;
 extern uint32_t _ram_end;
 

--- a/ports/stm32/main.c
+++ b/ports/stm32/main.c
@@ -520,7 +520,7 @@ soft_reset:
     // to recover from limit hit.  (Limit is measured in bytes.)
     // Note: stack control relies on main thread being initialised above
     mp_stack_set_top(&_estack);
-    mp_stack_set_limit((char*)&_estack - (char*)&_heap_end - 1024);
+    mp_stack_set_limit((char*)&_estack - (char*)&_sstack - 1024);
 
     // GC init
     gc_init(MICROPY_HEAP_START, MICROPY_HEAP_END);

--- a/ports/stm32/modmachine.c
+++ b/ports/stm32/modmachine.c
@@ -174,6 +174,7 @@ STATIC mp_obj_t machine_info(size_t n_args, const mp_obj_t *args) {
         printf("_edata=%p\n", &_edata);
         printf("_sbss=%p\n", &_sbss);
         printf("_ebss=%p\n", &_ebss);
+        printf("_sstack=%p\n", &_sstack);
         printf("_estack=%p\n", &_estack);
         printf("_ram_start=%p\n", &_ram_start);
         printf("_heap_start=%p\n", &_heap_start);

--- a/ports/stm32/pybthread.c
+++ b/ports/stm32/pybthread.c
@@ -70,8 +70,8 @@ void pyb_thread_init(pyb_thread_t *thread) {
     thread->sp = NULL; // will be set when this thread switches out
     thread->local_state = 0; // will be set by mp_thread_init
     thread->arg = NULL;
-    thread->stack = &_heap_end;
-    thread->stack_len = ((uint32_t)&_estack - (uint32_t)&_heap_end) / sizeof(uint32_t);
+    thread->stack = &_sstack;
+    thread->stack_len = ((uint32_t)&_estack - (uint32_t)&_sstack) / sizeof(uint32_t);
     thread->all_next = NULL;
     thread->run_prev = thread;
     thread->run_next = thread;

--- a/ports/stm32/stm32_it.c
+++ b/ports/stm32/stm32_it.c
@@ -181,7 +181,7 @@ void HardFault_C_Handler(ExceptionRegisters_t *regs) {
     if ((void*)&_ram_start <= (void*)regs && (void*)regs < (void*)&_ram_end) {
         mp_hal_stdout_tx_str("Stack:\r\n");
         uint32_t *stack_top = &_estack;
-        if ((void*)regs < (void*)&_heap_end) {
+        if ((void*)regs < (void*)&_sstack) {
             // stack not in static stack area so limit the amount we print
             stack_top = (uint32_t*)regs + 32;
         }


### PR DESCRIPTION
boards/*.ld  Add _sstack symbol. Define stack and heap in a clearer way.
gccollect.h, main.c, pybthread.c, stm32_it.c  Use _sstackk instead of _heap_end
modmachine.c machine.info()  print _sstack.