### PR TITLE
esp8266: Fix ticks_ms to correctly handle wraparound of system counter.

### DIFF
--- a/ports/esp8266/esp_mphal.c
+++ b/ports/esp8266/esp_mphal.c
@@ -120,7 +120,9 @@ void mp_hal_debug_tx_strn_cooked(void *env, const char *str, uint32_t len) {
 }
 
 uint32_t mp_hal_ticks_ms(void) {
-    return ((uint64_t)system_time_high_word << 32 | (uint64_t)system_get_time()) / 1000;
+    // Compute milliseconds from 64-bit microsecond counter
+    system_time_update();
+    return ((uint64_t)system_time_high_word << 32 | (uint64_t)system_time_low_word) / 1000;
 }
 
 uint32_t mp_hal_ticks_us(void) {

--- a/ports/esp8266/ets_alt_task.h
+++ b/ports/esp8266/ets_alt_task.h
@@ -3,8 +3,10 @@
 
 extern int ets_loop_iter_disable;
 extern int ets_loop_dont_feed_sw_wdt;
+extern uint32_t system_time_low_word;
 extern uint32_t system_time_high_word;
 
+void system_time_update(void);
 bool ets_loop_iter(void);
 
 #endif // MICROPY_INCLUDED_ESP8266_ETS_ALT_TASK_H


### PR DESCRIPTION
To fix issue #4795 