### PR TITLE
stm32/sdmmc: Ensure only the correct SD or MMC interrupt handler is run.

### DIFF
--- a/ports/stm32/sdcard.c
+++ b/ports/stm32/sdcard.c
@@ -370,6 +370,7 @@ STATIC void sdmmc_irq_handler(void) {
         #if MICROPY_HW_ENABLE_SDCARD
         case PYB_SDMMC_FLAG_ACTIVE | PYB_SDMMC_FLAG_SD:
             HAL_SD_IRQHandler(&sdmmc_handle.sd);
+            break;
         #endif
         #if MICROPY_HW_ENABLE_MMCARD
         case PYB_SDMMC_FLAG_ACTIVE | PYB_SDMMC_FLAG_MMC:


### PR DESCRIPTION
Should resolve https://github.com/micropython/micropython/issues/4741