### PR TITLE
stm32/sdram: Update MPU settings.

### DIFF
--- a/ports/stm32/sdram.c
+++ b/ports/stm32/sdram.c
@@ -39,6 +39,11 @@
 #define SDRAM_START_ADDRESS 0xD0000000
 #endif
 
+// Provides the MPU_REGION_SIZE_X value when passed the size of region in bytes
+#define MPU_REGION_SIZE(m) ((m-1)/((m-1)%255+1) / 255%255*8 + 7-86/((m-1)%255+12) - 1)
+
+#define SDRAM_MPU_REGION_SIZE (MPU_REGION_SIZE(MICROPY_HW_SDRAM_SIZE))
+
 #ifdef FMC_SDRAM_BANK
 
 static void sdram_init_seq(SDRAM_HandleTypeDef
@@ -244,16 +249,32 @@ static void sdram_init_seq(SDRAM_HandleTypeDef
     /* Disable the MPU */
     HAL_MPU_Disable();
 
-    /* Configure the MPU attributes as Write-Through for External SDRAM */
+    /* Configure the MPU attributes for External SDRAM 
+       Initially disable all access for the enture SDRAM memory space
+       Then Enable access/caching for the size used
+    */
     MPU_InitStruct.Enable = MPU_REGION_ENABLE;
+    MPU_InitStruct.Number = MPU_REGION_NUMBER4;
     MPU_InitStruct.BaseAddress = SDRAM_START_ADDRESS;
-    MPU_InitStruct.Size = MPU_REGION_SIZE_256MB;
-    MPU_InitStruct.AccessPermission = MPU_REGION_FULL_ACCESS;
+    MPU_InitStruct.Size = MPU_REGION_SIZE_512MB;
+    MPU_InitStruct.AccessPermission = MPU_REGION_NO_ACCESS;
     MPU_InitStruct.IsBufferable = MPU_ACCESS_NOT_BUFFERABLE;
+    MPU_InitStruct.IsCacheable = MPU_ACCESS_NOT_CACHEABLE;
+    MPU_InitStruct.IsShareable = MPU_ACCESS_NOT_SHAREABLE;
+    MPU_InitStruct.TypeExtField = MPU_TEX_LEVEL0;
+    MPU_InitStruct.SubRegionDisable = 0x00;
+    MPU_InitStruct.DisableExec = MPU_INSTRUCTION_ACCESS_DISABLE;
+    HAL_MPU_ConfigRegion(&MPU_InitStruct);
+
+    MPU_InitStruct.Enable = MPU_REGION_ENABLE;
+    MPU_InitStruct.Number = MPU_REGION_NUMBER5;
+    MPU_InitStruct.BaseAddress = SDRAM_START_ADDRESS;
+    MPU_InitStruct.Size = SDRAM_MPU_REGION_SIZE;
+    MPU_InitStruct.AccessPermission = MPU_REGION_FULL_ACCESS;
+    MPU_InitStruct.IsBufferable = MPU_ACCESS_BUFFERABLE;
     MPU_InitStruct.IsCacheable = MPU_ACCESS_CACHEABLE;
     MPU_InitStruct.IsShareable = MPU_ACCESS_NOT_SHAREABLE;
-    MPU_InitStruct.Number = MPU_REGION_NUMBER0;
-    MPU_InitStruct.TypeExtField = MPU_TEX_LEVEL0;
+    MPU_InitStruct.TypeExtField = MPU_TEX_LEVEL1;
     MPU_InitStruct.SubRegionDisable = 0x00;
     MPU_InitStruct.DisableExec = MPU_INSTRUCTION_ACCESS_ENABLE;
     HAL_MPU_ConfigRegion(&MPU_InitStruct);


### PR DESCRIPTION
Set active MPU region to size of sdram configured.
Update caching settings.
Change region numbers to avoid conflicts elsewhere in micropython codebase (eth).

The mpu region calculation macro was originally based on `IMAX_BITS` in the post by Hallvard B Furuset on http://computer-programming-forum.com/47-c-language/2e10680107131540.htm

It was updated to provide the correct value to replace the defines:
```
#define   MPU_REGION_SIZE_32B      ((uint8_t)0x04U)
#define   MPU_REGION_SIZE_64B      ((uint8_t)0x05U)
#define   MPU_REGION_SIZE_128B     ((uint8_t)0x06U)
```
based on size of region in bytes.

I confirmed its operation with
```
MP_STATIC_ASSERT(MPU_REGION_SIZE(32) == (MPU_REGION_SIZE_32B));
MP_STATIC_ASSERT(MPU_REGION_SIZE(256*1024) == (MPU_REGION_SIZE_256KB));
MP_STATIC_ASSERT(MPU_REGION_SIZE(512*1024*1024) == (MPU_REGION_SIZE_512MB));
```
But didn't think there was too much value leaving them in the code. Perhaps it would be better to consolidate all the MPU configuration code into a separate utility module and include this macro there with appropriate tests and guards.