### PR TITLE
mpy-cross: Do not automatically build mpy-cross, rather do it manually.

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,17 @@ You will also need bash, gcc, and Python 3.3+ available as the command `python3`
 (if your system only has Python 2.7 then invoke make with the additional option
 `PYTHON=python2`).
 
+The MicroPython cross-compiler, mpy-cross
+-----------------------------------------
+
+Most ports require the MicroPython cross-compiler to be built first.  This
+program, called mpy-cross, is used to pre-compile Python scripts to .mpy
+files which can then be included (frozen) into the firmware/executable for
+a port.  To build mpy-cross use:
+
+    $ cd mpy-cross
+    $ make
+
 The Unix version
 ----------------
 

--- a/mpy-cross/Makefile
+++ b/mpy-cross/Makefile
@@ -1,20 +1,3 @@
-# The following is a temporary hack to forefully undefine vars that might have
-# be defined by a calling Makefile (from recursive make).
-# TODO: Find a better way to be able to call this Makefile recursively.
-ifneq ($(findstring undefine,$(.FEATURES)),)
-override undefine COPT
-override undefine CFLAGS_EXTRA
-override undefine LDFLAGS_EXTRA
-override undefine MICROPY_FORCE_32BIT
-override undefine CROSS_COMPILE
-override undefine FROZEN_DIR
-override undefine FROZEN_MPY_DIR
-override undefine USER_C_MODULES
-override undefine SRC_MOD
-override undefine BUILD
-override undefine PROG
-endif
-
 include ../py/mkenv.mk
 
 # define main target

--- a/py/mkrules.mk
+++ b/py/mkrules.mk
@@ -103,16 +103,12 @@ $(BUILD)/frozen.c: $(wildcard $(FROZEN_DIR)/*) $(HEADER_BUILD) $(FROZEN_EXTRA_DE
 endif
 
 ifneq ($(FROZEN_MPY_DIR),)
-# to build the MicroPython cross compiler
-$(TOP)/mpy-cross/mpy-cross: $(TOP)/py/*.[ch] $(TOP)/mpy-cross/*.[ch] $(TOP)/ports/windows/fmode.c
-	$(Q)$(MAKE) -C $(TOP)/mpy-cross
-
 # make a list of all the .py files that need compiling and freezing
 FROZEN_MPY_PY_FILES := $(shell find -L $(FROZEN_MPY_DIR) -type f -name '*.py' | $(SED) -e 's=^$(FROZEN_MPY_DIR)/==')
 FROZEN_MPY_MPY_FILES := $(addprefix $(BUILD)/frozen_mpy/,$(FROZEN_MPY_PY_FILES:.py=.mpy))
 
 # to build .mpy files from .py files
-$(BUILD)/frozen_mpy/%.mpy: $(FROZEN_MPY_DIR)/%.py $(TOP)/mpy-cross/mpy-cross
+$(BUILD)/frozen_mpy/%.mpy: $(FROZEN_MPY_DIR)/%.py
 	@$(ECHO) "MPY $<"
 	$(Q)$(MKDIR) -p $(dir $@)
 	$(Q)$(MPY_CROSS) -o $@ -s $(<:$(FROZEN_MPY_DIR)/%=%) $(MPY_CROSS_FLAGS) $<


### PR DESCRIPTION
Building mpy-cross automatically leads to some issues with the build process and slows it down (see eg #3255, #3987, #4733).  Instead, require it to be built manually.

mpy-cross is pretty stable now, and well known by users, so I think it's only a minor inconvenience to require it to be built manually (roughly once each release), and this is a simple way to fix a lot of problems with having it auto-built.