### PR TITLE
Allow building mpy-cross with msvc (2)

### DIFF
--- a/mpy-cross/mpconfigport.h
+++ b/mpy-cross/mpconfigport.h
@@ -96,6 +96,9 @@ typedef unsigned long mp_uint_t; // must be pointer size
 #include <stdint.h>
 typedef __int64 mp_int_t;
 typedef unsigned __int64 mp_uint_t;
+#elif defined ( _MSC_VER ) && defined( _WIN64 )
+typedef __int64 mp_int_t;
+typedef unsigned __int64 mp_uint_t;
 #else
 // These are definitions for machines where sizeof(int) == sizeof(void*),
 // regardless for actual size.
@@ -122,3 +125,37 @@ typedef long mp_off_t;
 #endif
 
 #include <stdint.h>
+
+// MSVC specifics - see windows/mpconfigport.h for explanation
+#ifdef _MSC_VER
+
+#define MP_ENDIANNESS_LITTLE        (1)
+#define NORETURN                    __declspec(noreturn)
+#define MP_NOINLINE                 __declspec(noinline)
+#define MP_LIKELY(x)                (x)
+#define MP_UNLIKELY(x)              (x)
+#define MICROPY_PORT_CONSTANTS      { "dummy", 0 }
+#ifdef _WIN64
+#define MP_SSIZE_MAX                _I64_MAX
+#else
+#define MP_SSIZE_MAX                _I32_MAX
+#endif
+#define MICROPY_MAKE_POINTER_CALLABLE(p) ((void*)(p)) //Avoid compiler warning about different const qualifiers
+#define restrict
+#define inline                      __inline
+#define alignof(t)                  __alignof(t)
+#undef MICROPY_ALLOC_PATH_MAX
+#define MICROPY_ALLOC_PATH_MAX      260
+#define PATH_MAX                    MICROPY_ALLOC_PATH_MAX
+#define S_ISREG(m)                  (((m) & S_IFMT) == S_IFREG)
+#define S_ISDIR(m)                  (((m) & S_IFMT) == S_IFDIR)
+#ifdef _WIN64
+#define SSIZE_MAX                   _I64_MAX
+typedef __int64                     ssize_t;
+#else
+#define SSIZE_MAX                   _I32_MAX
+typedef int                         ssize_t;
+#endif
+typedef mp_off_t                    off_t;
+
+#endif

--- a/mpy-cross/mpy-cross.vcxproj
+++ b/mpy-cross/mpy-cross.vcxproj
@@ -1,0 +1,103 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Debug|Win32">
+      <Configuration>Debug</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|Win32">
+      <Configuration>Release</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Debug|x64">
+      <Configuration>Debug</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|x64">
+      <Configuration>Release</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>{740F3A30-3B6C-4B59-9C50-AE4D5A4A9D12}</ProjectGuid>
+    <RootNamespace>mpy-cross</RootNamespace>
+    <PyBuildingMpyCross>True</PyBuildingMpyCross>
+    <PyBuildDir>$(MSBuildThisFileDirectory)build\</PyBuildDir>
+    <PyIncDirs>$(MSBuildThisFileDirectory)</PyIncDirs>
+    <PyTargetDir>$(MSBuildThisFileDirectory)</PyTargetDir>
+    <PyMsvcDir>$(MSBuildThisFileDirectory)..\ports\windows\msvc\</PyMsvcDir>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <PlatformToolset>$(DefaultPlatformToolset)</PlatformToolset>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <PlatformToolset>$(DefaultPlatformToolset)</PlatformToolset>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <PlatformToolset>$(DefaultPlatformToolset)</PlatformToolset>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <PlatformToolset>$(DefaultPlatformToolset)</PlatformToolset>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <ImportGroup Label="ExtensionSettings">
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+    <Import Project="$(PyMsvcDir)common.props" />
+    <Import Project="$(PyMsvcDir)debug.props" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+    <Import Project="$(PyMsvcDir)common.props" />
+    <Import Project="$(PyMsvcDir)release.props" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+    <Import Project="$(PyMsvcDir)common.props" />
+    <Import Project="$(PyMsvcDir)debug.props" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+    <Import Project="$(PyMsvcDir)common.props" />
+    <Import Project="$(PyMsvcDir)release.props" />
+  </ImportGroup>
+  <PropertyGroup Label="UserMacros">
+    <CustomPropsFile Condition="'$(CustomPropsFile)'==''">msvc/user.props</CustomPropsFile>
+  </PropertyGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <ClCompile />
+    <Link />
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <ClCompile />
+    <Link />
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <ClCompile />
+    <Link />
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <ClCompile />
+    <Link />
+  </ItemDefinitionGroup>
+  <Import Project="$(PyMsvcDir)sources.props" />
+  <ItemGroup>
+    <ClCompile Include="@(PyCoreSource)" />
+    <ClCompile Include="$(PyBaseDir)mpy-cross\gccollect.c"/>
+    <ClCompile Include="$(PyBaseDir)mpy-cross\main.c"/>
+    <ClCompile Include="$(PyBaseDir)ports\windows\fmode.c" />
+  </ItemGroup>
+  <Import Project="$(PyMsvcDir)genhdr.targets" />
+  <Import Project="$(CustomPropsFile)" Condition="exists('$(CustomPropsFile)')" />
+  <Target Name="GenHeaders" BeforeTargets="BuildGenerateSources" DependsOnTargets="GenerateHeaders">
+  </Target>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <ImportGroup Label="ExtensionTargets">
+  </ImportGroup>
+</Project>

--- a/ports/windows/.appveyor.yml
+++ b/ports/windows/.appveyor.yml
@@ -14,15 +14,27 @@ platform:
 - x86
 - x64
 
+before_build:
+- ps: |
+    @"
+    <?xml version="1.0" encoding="utf-8"?>
+    <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+      <Target Name="Build">
+        <MsBuild BuildInParallel="True" Projects="mpy-cross\mpy-cross.vcxproj;ports\windows\micropython.vcxproj"/>
+      </Target>
+    </Project>
+    "@ | Set-Content build.proj
+
 build:
-  project: ports/windows/micropython.vcxproj
+  project: build.proj
+  parallel: true
   verbosity: normal
 
 test_script:
-- cmd: >-
-    cd tests
-
-    %MICROPY_CPYTHON3% run-tests
+- ps: |
+    cd (Join-Path $env:APPVEYOR_BUILD_FOLDER 'tests')
+    & $env:MICROPY_CPYTHON3 run-tests
+    & $env:MICROPY_CPYTHON3 run-tests --via-mpy -d basics float micropython
 
 # After the build/test phase for the MSVC build completes,
 # build and test with mingw-w64, release versions only.
@@ -38,10 +50,26 @@ after_test:
     if ($LASTEXITCODE -ne 0) {
       throw "$env:MSYSTEM build exited with code $LASTEXITCODE"
     }
+    cd (Join-Path $env:APPVEYOR_BUILD_FOLDER 'mpy-cross')
+    # Building of mpy-cross hasn't been fixed across all possible windows/WSL/...
+    # variations and the STRIP step tries to strip mpy-cross whereas that should be
+    # mpy-cross.exe. Workaround for now by skipping actual strip and size commands.
+    C:\msys64\usr\bin\bash.exe -l -c "make -B -j4 V=1 STRIP=echo SIZE=echo"
+    if ($LASTEXITCODE -ne 0) {
+      throw "$env:MSYSTEM mpy_cross build exited with code $LASTEXITCODE"
+    }
     cd (Join-Path $env:APPVEYOR_BUILD_FOLDER 'tests')
-    & $env:MICROPY_CPYTHON3 run-tests -e math_fun -e float2int_double -e float_parse -e math_domain_special
+    $testArgs = @('run-tests')
+    foreach ($skipTest in @('math_fun', 'float2int_double', 'float_parse', 'math_domain_special')) {
+      $testArgs = $testArgs + '-e' + $skipTest
+    }
+    & $env:MICROPY_CPYTHON3 $testArgs
     if ($LASTEXITCODE -ne 0) {
       throw "$env:MSYSTEM tests exited with code $LASTEXITCODE"
+    }
+    & $env:MICROPY_CPYTHON3 ($testArgs + @('--via-mpy', '-d', 'basics', 'float', 'micropython'))
+    if ($LASTEXITCODE -ne 0) {
+      throw "$env:MSYSTEM mpy-cross tests exited with code $LASTEXITCODE"
     }
 
 skip_tags: true

--- a/ports/windows/Makefile
+++ b/ports/windows/Makefile
@@ -40,6 +40,7 @@ SRC_C = \
 	realpath.c \
 	init.c \
 	sleep.c \
+	fmode.c \
 
 OBJ = $(PY_O) $(addprefix $(BUILD)/, $(SRC_C:.c=.o))
 

--- a/ports/windows/init.c
+++ b/ports/windows/init.c
@@ -31,6 +31,7 @@
 #include <crtdbg.h>
 #endif
 #include "sleep.h"
+#include "fmode.h"
 
 extern BOOL WINAPI console_sighandler(DWORD evt);
 
@@ -61,6 +62,7 @@ void init() {
     // https://msdn.microsoft.com/en-us/library/bb531344(v=vs.140).aspx
     _set_output_format(_TWO_DIGIT_EXPONENT);
 #endif
+    set_fmode_binary();
 }
 
 void deinit() {

--- a/ports/windows/micropython.vcxproj
+++ b/ports/windows/micropython.vcxproj
@@ -25,29 +25,19 @@
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
-    <UseDebugLibraries>true</UseDebugLibraries>
     <PlatformToolset>$(DefaultPlatformToolset)</PlatformToolset>
-    <CharacterSet>MultiByte</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
-    <UseDebugLibraries>false</UseDebugLibraries>
     <PlatformToolset>$(DefaultPlatformToolset)</PlatformToolset>
-    <WholeProgramOptimization>true</WholeProgramOptimization>
-    <CharacterSet>MultiByte</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
-    <UseDebugLibraries>true</UseDebugLibraries>
     <PlatformToolset>$(DefaultPlatformToolset)</PlatformToolset>
-    <CharacterSet>MultiByte</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
-    <UseDebugLibraries>false</UseDebugLibraries>
     <PlatformToolset>$(DefaultPlatformToolset)</PlatformToolset>
-    <WholeProgramOptimization>true</WholeProgramOptimization>
-    <CharacterSet>MultiByte</CharacterSet>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <ImportGroup Label="ExtensionSettings">

--- a/ports/windows/micropython.vcxproj
+++ b/ports/windows/micropython.vcxproj
@@ -81,9 +81,27 @@
     <ClCompile />
     <Link />
   </ItemDefinitionGroup>
-  <ItemGroup>
-  </ItemGroup>
   <Import Project="msvc/sources.props" />
+  <ItemGroup>
+    <ClCompile Include="@(PyCoreSource)" />
+    <ClCompile Include="@(PyExtModSource)" />
+    <ClCompile Include="$(PyBaseDir)lib\mp-readline\*.c" />
+    <ClCompile Include="$(PyBaseDir)ports\windows\*.c" />
+    <ClCompile Include="$(PyBaseDir)ports\windows\msvc\*.c" />
+    <ClCompile Include="$(PyBaseDir)ports\unix\file.c"/>
+    <ClCompile Include="$(PyBaseDir)ports\unix\gccollect.c"/>
+    <ClCompile Include="$(PyBaseDir)ports\unix\input.c"/>
+    <ClCompile Include="$(PyBaseDir)ports\unix\main.c"/>
+    <ClCompile Include="$(PyBaseDir)ports\unix\modos.c"/>
+    <ClCompile Include="$(PyBaseDir)ports\unix\modtime.c"/>
+    <ClCompile Include="$(PyBaseDir)ports\unix\modmachine.c" />
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="@(PyCoreInclude)" />
+    <ClInclude Include="@(PyExtModInclude)" />
+    <ClInclude Include="$(PyBaseDir)ports\windows\*.h" />
+    <ClInclude Include="$(PyBaseDir)ports\windows\msvc\*.h" />
+  </ItemGroup>
   <Import Project="msvc/genhdr.targets" />
   <Import Project="$(CustomPropsFile)" Condition="exists('$(CustomPropsFile)')" />
   <Target Name="GenHeaders" BeforeTargets="BuildGenerateSources" DependsOnTargets="GenerateHeaders">

--- a/ports/windows/msvc/common.props
+++ b/ports/windows/msvc/common.props
@@ -8,6 +8,7 @@
     <OutDir>$(PyOutDir)</OutDir>
     <IntDir>$(PyIntDir)</IntDir>
     <PyFileCopyCookie>$(PyBuildDir)copycookie$(Configuration)$(Platform)</PyFileCopyCookie>
+    <CharacterSet>MultiByte</CharacterSet>
   </PropertyGroup>
   <ItemDefinitionGroup>
     <ClCompile>

--- a/ports/windows/msvc/common.props
+++ b/ports/windows/msvc/common.props
@@ -27,7 +27,7 @@
   </ItemDefinitionGroup>
   <ItemGroup>
     <PyOutputFiles Include="$(TargetPath)">
-      <Destination>$(PyWinDir)%(FileName)%(Extension)</Destination>
+      <Destination>$(PyTargetDir)%(FileName)%(Extension)</Destination>
     </PyOutputFiles>
     <PyCookieFiles Include="$(PyBuildDir)copycookie*" Exclude="$(PyFileCopyCookie)"/>
   </ItemGroup>

--- a/ports/windows/msvc/debug.props
+++ b/ports/windows/msvc/debug.props
@@ -3,6 +3,8 @@
   <ImportGroup Label="PropertySheets" />
   <PropertyGroup Label="UserMacros" />
   <PropertyGroup>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <WholeProgramOptimization>false</WholeProgramOptimization>
   </PropertyGroup>
   <ItemDefinitionGroup />
   <ItemGroup />

--- a/ports/windows/msvc/genhdr.targets
+++ b/ports/windows/msvc/genhdr.targets
@@ -54,7 +54,7 @@ using(var outFile = System.IO.File.CreateText(OutputFile)) {
   <Target Name="MakeQstrDefs" DependsOnTargets="MakeDestDir" Inputs="@(ClCompile);@(QstrDependencies)" Outputs="$(QstrDefsCollected)">
     <ItemGroup>
       <PyIncDirs Include="$(PyIncDirs)"/>
-      <PreProcDefs Include="%(ClCompile.PreProcessorDefinitions);NO_QSTR;N_X64;N_X86;N_THUMB;N_ARM"/>
+      <PreProcDefs Include="%(ClCompile.PreProcessorDefinitions);NO_QSTR"/>
       <PyQstrSourceFiles Include="@(ClCompile)">
         <OutFile>$([System.String]::new('%(FullPath)').Replace('$(PyBaseDir)', '$(DestDir)qstr\'))</OutFile>
       </PyQstrSourceFiles>

--- a/ports/windows/msvc/paths.props
+++ b/ports/windows/msvc/paths.props
@@ -26,9 +26,10 @@
     <PyBaseDir>$([System.IO.Path]::GetFullPath(`$(MSBuildThisFileDirectory)..\..\..`))\</PyBaseDir>
     <PyWinDir>$(PyBaseDir)ports\windows\</PyWinDir>
     <PyBuildDir Condition="'$(PyBuildDir)' == ''">$(PyWinDir)build\</PyBuildDir>
+    <PyTargetDir Condition="'$(PyTargetDir)' == ''">$(PyWinDir)</PyTargetDir>
 
     <!-- All include directories needed for uPy -->
-    <PyIncDirs>$(PyBaseDir);$(PyWinDir);$(PyBuildDir);$(PyWinDir)msvc</PyIncDirs>
+    <PyIncDirs>$(PyIncDirs);$(PyBaseDir);$(PyWinDir);$(PyBuildDir);$(PyWinDir)msvc</PyIncDirs>
 
     <!-- Within PyBuildDir different subdirectories are used based on configuration and platform.
          By default these are chosen based on the Configuration and Platform properties, but

--- a/ports/windows/msvc/release.props
+++ b/ports/windows/msvc/release.props
@@ -2,7 +2,10 @@
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ImportGroup Label="PropertySheets" />
   <PropertyGroup Label="UserMacros" />
-  <PropertyGroup />
+  <PropertyGroup>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+  </PropertyGroup>
   <ItemDefinitionGroup>
     <Link>
       <OptimizeReferences>true</OptimizeReferences>

--- a/ports/windows/msvc/sources.props
+++ b/ports/windows/msvc/sources.props
@@ -2,37 +2,25 @@
 <Project DefaultTargets="Build" ToolsVersion="12.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="paths.props" Condition="'$(PyPathsIncluded)' != 'True'"/>
   <ItemGroup>
-    <ClCompile Include="$(PyBaseDir)py\*.c" />
-    <ClCompile Include="$(PyBaseDir)ports\windows\*.c" />
-    <ClCompile Include="$(PyBaseDir)ports\windows\msvc\*.c" />
-    <ClCompile Include="$(PyBaseDir)lib\mp-readline\*.c" />
-    <ClCompile Include="$(PyBaseDir)lib\utils\printf.c" />
-    <ClCompile Include="$(PyBaseDir)ports\unix\file.c"/>
-    <ClCompile Include="$(PyBaseDir)ports\unix\gccollect.c"/>
-    <ClCompile Include="$(PyBaseDir)ports\unix\input.c"/>
-    <ClCompile Include="$(PyBaseDir)ports\unix\main.c"/>
-    <ClCompile Include="$(PyBaseDir)ports\unix\modos.c"/>
-    <ClCompile Include="$(PyBaseDir)ports\unix\modtime.c"/>
-    <ClCompile Include="$(PyBaseDir)ports\unix\modmachine.c" />
-    <ClCompile Include="$(PyBaseDir)extmod\machine_mem.c" />
-    <ClCompile Include="$(PyBaseDir)extmod\machine_pinbase.c" />
-    <ClCompile Include="$(PyBaseDir)extmod\machine_pulse.c" />
-    <ClCompile Include="$(PyBaseDir)extmod\machine_signal.c" />
-    <ClCompile Include="$(PyBaseDir)extmod\modubinascii.c" />
-    <ClCompile Include="$(PyBaseDir)extmod\moductypes.c" />
-    <ClCompile Include="$(PyBaseDir)extmod\moduhashlib.c" />
-    <ClCompile Include="$(PyBaseDir)extmod\moduheapq.c" />
-    <ClCompile Include="$(PyBaseDir)extmod\modujson.c" />
-    <ClCompile Include="$(PyBaseDir)extmod\modurandom.c" />
-    <ClCompile Include="$(PyBaseDir)extmod\modure.c" />
-    <ClCompile Include="$(PyBaseDir)extmod\modutimeq.c" />
-    <ClCompile Include="$(PyBaseDir)extmod\moduzlib.c" />
-    <ClCompile Include="$(PyBaseDir)extmod\utime_mphal.c" />
-    <ClCompile Include="$(PyBaseDir)extmod\virtpin.c" />
+    <PyCoreSource Include="$(PyBaseDir)py\*.c" />
+    <PyExtModSource Include="$(PyBaseDir)extmod\machine_mem.c" />
+    <PyExtModSource Include="$(PyBaseDir)extmod\machine_pinbase.c" />
+    <PyExtModSource Include="$(PyBaseDir)extmod\machine_pulse.c" />
+    <PyExtModSource Include="$(PyBaseDir)extmod\machine_signal.c" />
+    <PyExtModSource Include="$(PyBaseDir)extmod\modubinascii.c" />
+    <PyExtModSource Include="$(PyBaseDir)extmod\moductypes.c" />
+    <PyExtModSource Include="$(PyBaseDir)extmod\moduhashlib.c" />
+    <PyExtModSource Include="$(PyBaseDir)extmod\moduheapq.c" />
+    <PyExtModSource Include="$(PyBaseDir)extmod\modujson.c" />
+    <PyExtModSource Include="$(PyBaseDir)extmod\modurandom.c" />
+    <PyExtModSource Include="$(PyBaseDir)extmod\modure.c" />
+    <PyExtModSource Include="$(PyBaseDir)extmod\modutimeq.c" />
+    <PyExtModSource Include="$(PyBaseDir)extmod\moduzlib.c" />
+    <PyExtModSource Include="$(PyBaseDir)extmod\utime_mphal.c" />
+    <PyExtModSource Include="$(PyBaseDir)extmod\virtpin.c" />
   </ItemGroup>
   <ItemGroup>
-    <ClInclude Include="$(PyBaseDir)py\*.h" />
-    <ClInclude Include="$(PyBaseDir)ports\windows\*.h" />
-    <ClInclude Include="$(PyBaseDir)ports\windows\msvc\*.h" />
+    <PyCoreInclude Include="$(PyBaseDir)py\*.h" />
+    <PyExtModInclude Include="$(PyBaseDir)extmod\*.h" />
   </ItemGroup>
 </Project>

--- a/py/persistentcode.c
+++ b/py/persistentcode.c
@@ -748,7 +748,7 @@ void mp_raw_code_save(mp_raw_code_t *rc, mp_print_t *print) {
 // here we define mp_raw_code_save_file depending on the port
 // TODO abstract this away properly
 
-#if defined(__i386__) || defined(__x86_64__) || defined(__unix__)
+#if defined(__i386__) || defined(__x86_64__) || defined(_WIN32) || defined(__unix__)
 
 #include <unistd.h>
 #include <sys/stat.h>


### PR DESCRIPTION
This is a continuation of #2911 but with some changes to the latest version used there:
- mpy-cross project file in is mpy-cross directory, and mpy-cross.exe also ends up there, for consistency with the other ports; I didn't adjust the README though (assuming if you can build MicroPython you can build mpy-cross as well since the principle is easy and the same)
- extra commit to fix a warning
- remove unneeded `#undef``