### PR TITLE
py/obj: Optimize comparison in `mp_obj_is_true`.

### DIFF
--- a/py/obj.c
+++ b/py/obj.c
@@ -113,7 +113,7 @@ bool mp_obj_is_true(mp_obj_t arg) {
     } else if (arg == mp_const_none) {
         return 0;
     } else if (mp_obj_is_small_int(arg)) {
-        if (MP_OBJ_SMALL_INT_VALUE(arg) == 0) {
+        if (arg == MP_OBJ_NEW_SMALL_INT(0)) {
             return 0;
         } else {
             return 1;


### PR DESCRIPTION
Instead of converting to a small int in runtime, this can be done in compile
time, then we only have only a simple comparison during runtime.
This reduces code size on some ports (e.g seen -4 on qemu-arm), in others
(e.g unix) it doesn't due to the way this function is compiled, structured and
optimized.

Might also have a slight impact on runtime performance.