### PR TITLE
Add support for DS1822 sensor

### DIFF
--- a/drivers/onewire/ds18x20.py
+++ b/drivers/onewire/ds18x20.py
@@ -13,7 +13,7 @@ class DS18X20:
         self.buf = bytearray(9)
 
     def scan(self):
-        return [rom for rom in self.ow.scan() if rom[0] in (0x10, 0x28, 0x22]
+        return [rom for rom in self.ow.scan() if rom[0] in (0x10, 0x28, 0x22)]
 
     def convert_temp(self):
         self.ow.reset(True)

--- a/drivers/onewire/ds18x20.py
+++ b/drivers/onewire/ds18x20.py
@@ -13,7 +13,7 @@ class DS18X20:
         self.buf = bytearray(9)
 
     def scan(self):
-        return [rom for rom in self.ow.scan() if rom[0] == 0x10 or rom[0] == 0x28]
+        return [rom for rom in self.ow.scan() if rom[0] == 0x10 or rom[0] == 0x28 or rom[0] == 0x22]
 
     def convert_temp(self):
         self.ow.reset(True)

--- a/drivers/onewire/ds18x20.py
+++ b/drivers/onewire/ds18x20.py
@@ -13,7 +13,7 @@ class DS18X20:
         self.buf = bytearray(9)
 
     def scan(self):
-        return [rom for rom in self.ow.scan() if rom[0] == 0x10 or rom[0] == 0x28 or rom[0] == 0x22]
+        return [rom for rom in self.ow.scan() if rom[0] in (0x10, 0x28, 0x22]
 
     def convert_temp(self):
         self.ow.reset(True)


### PR DESCRIPTION
Adding rom[0] = 0x22 to recognize the DS1822 sensors. 

DS1822P sensor behaves just like the DS18B20 except for the following:
- it has a different family code: 0x22
- it has only the GND and DQ pins connected, it uses parasite power from the data line

Note for ESP8266 users (definitely true on Wemos D1 board): use 1kOhm pull-up resistor between the data line and the 3.3V