### PR TITLE
docs: Improve esp32 and esp8266 do_reconnect examples

### DIFF
--- a/docs/esp32/quickref.rst
+++ b/docs/esp32/quickref.rst
@@ -87,6 +87,7 @@ The :mod:`network` module::
 A useful function for connecting to your local WiFi network is::
 
     def do_connect():
+        from time import sleep
         import network
         wlan = network.WLAN(network.STA_IF)
         while not wlan.isconnected():
@@ -94,7 +95,7 @@ A useful function for connecting to your local WiFi network is::
             wlan.active(True)
             wlan.connect('<essid>', '<password>')
             while wlan.status() == network.STAT_CONNECTING:
-                pass
+                sleep(.1)
         print('network config:', wlan.ifconfig())
 
 Once the network is established the :mod:`socket <usocket>` module can be used

--- a/docs/esp32/quickref.rst
+++ b/docs/esp32/quickref.rst
@@ -89,11 +89,11 @@ A useful function for connecting to your local WiFi network is::
     def do_connect():
         import network
         wlan = network.WLAN(network.STA_IF)
-        wlan.active(True)
-        if not wlan.isconnected():
-            print('connecting to network...')
-            wlan.connect('essid', 'password')
-            while not wlan.isconnected():
+        while not wlan.isconnected():
+            print('attempting connection...')
+            wlan.active(True)
+            wlan.connect('<essid>', '<password>')
+            while wlan.status() == network.STAT_CONNECTING:
                 pass
         print('network config:', wlan.ifconfig())
 

--- a/docs/esp8266/quickref.rst
+++ b/docs/esp8266/quickref.rst
@@ -70,11 +70,11 @@ A useful function for connecting to your local WiFi network is::
     def do_connect():
         import network
         wlan = network.WLAN(network.STA_IF)
-        wlan.active(True)
-        if not wlan.isconnected():
-            print('connecting to network...')
-            wlan.connect('essid', 'password')
-            while not wlan.isconnected():
+        while not wlan.isconnected():
+            print('attempting connection...')
+            wlan.active(True)
+            wlan.connect('<essid>', '<password>')
+            while wlan.status() == network.STAT_CONNECTING:
                 pass
         print('network config:', wlan.ifconfig())
 

--- a/docs/esp8266/quickref.rst
+++ b/docs/esp8266/quickref.rst
@@ -68,6 +68,7 @@ The :mod:`network` module::
 A useful function for connecting to your local WiFi network is::
 
     def do_connect():
+        from time import sleep
         import network
         wlan = network.WLAN(network.STA_IF)
         while not wlan.isconnected():
@@ -75,7 +76,7 @@ A useful function for connecting to your local WiFi network is::
             wlan.active(True)
             wlan.connect('<essid>', '<password>')
             while wlan.status() == network.STAT_CONNECTING:
-                pass
+                sleep(.1)
         print('network config:', wlan.ifconfig())
 
 Once the network is established the :mod:`socket <usocket>` module can be used

--- a/docs/esp8266/tutorial/network_basics.rst
+++ b/docs/esp8266/tutorial/network_basics.rst
@@ -56,6 +56,7 @@ Here is a function you can run (or put in your boot.py file) to automatically
 connect to your WiFi network::
 
     def do_connect():
+        from time import sleep
         import network
         sta_if = network.WLAN(network.STA_IF)
         while not sta_if.isconnected():
@@ -63,7 +64,7 @@ connect to your WiFi network::
             sta_if.active(True)
             sta_if.connect('<essid>', '<password>')
             while sta_if.status() == network.STAT_CONNECTING:
-                pass
+                sleep(.1)
         print('network config:', sta_if.ifconfig())
 
 Sockets

--- a/docs/esp8266/tutorial/network_basics.rst
+++ b/docs/esp8266/tutorial/network_basics.rst
@@ -58,11 +58,11 @@ connect to your WiFi network::
     def do_connect():
         import network
         sta_if = network.WLAN(network.STA_IF)
-        if not sta_if.isconnected():
-            print('connecting to network...')
+        while not sta_if.isconnected():
+            print('attempting connection...')
             sta_if.active(True)
             sta_if.connect('<essid>', '<password>')
-            while not sta_if.isconnected():
+            while sta_if.status() == network.STAT_CONNECTING:
                 pass
         print('network config:', sta_if.ifconfig())
 


### PR DESCRIPTION
This unifies the do_connect examples and improves their logic by not
giving up after a single failed connection attempt.  They now retry
indefinitely until the connection could be established.  This change
was recommended by dpgeorge in micropython/micropython#3537

Tested on an esp32.