### PR TITLE
esp32/modnetwork: Still try to reconnect to WLAN even with AUTH_FAIL.

### DIFF
--- a/ports/esp32/modnetwork.c
+++ b/ports/esp32/modnetwork.c
@@ -159,8 +159,8 @@ static esp_err_t event_handler(void *ctx, system_event_t *event) {
                 message = "\nno AP found";
                 break;
             case WIFI_REASON_AUTH_FAIL:
+                // Password may be wrong, or it just failed to connect; try to reconnect.
                 message = "\nauthentication failed";
-                wifi_sta_connect_requested = false;
                 break;
             default:
                 // Let other errors through and try to reconnect.


### PR DESCRIPTION
WIFI_REASON_AUTH_FAIL does not necessarily mean the password is wrong, and a wrong password may not lead to a WIFI_REASON_AUTH_FAIL error code.  So to improve reliability connecting to a WLAN always reconnect regardless of the error.

See issue #3537 and #4838 