### PR TITLE
Fixed bug in SPI card suport

### DIFF
--- a/docs/library/machine.SDCard.rst
+++ b/docs/library/machine.SDCard.rst
@@ -30,7 +30,7 @@ vary from platform to platform.
     The class implements the block protocol defined by :class:`uos.AbstractBlockDev`.
     This allows the mounting of an SD card to be as simple as::
 
-      uos.mount(storage.SDCard(), "/sd")
+      uos.mount(machine.SDCard(), "/sd")
 
     The constrcutor takes the following paramters:
 

--- a/ports/esp32/machine_sdcard.c
+++ b/ports/esp32/machine_sdcard.c
@@ -203,7 +203,6 @@ STATIC mp_obj_t machine_sdcard_make_new(const mp_obj_type_t *type, size_t n_args
 
     if (is_spi) {
         self->host.slot = slot_num ? HSPI_HOST : VSPI_HOST;
-        slot_num -= 2;
     }
 
     DEBUG_printf("  Calling host.init()");


### PR DESCRIPTION
Fixed a cut-and-paste error that had broken SPI interface support due to changes in the handling of slot numbers.

Also corrected typo in documentation resulting from the move of the `SDCard` class from the putative `storage` module to `machine`.
