### PR TITLE
sys.stdio: add support for ioctl and make sys.stdin.buffer.read non-blocking

### DIFF
--- a/extmod/misc.h
+++ b/extmod/misc.h
@@ -36,6 +36,7 @@ MP_DECLARE_CONST_FUN_OBJ_VAR_BETWEEN(mp_uos_dupterm_obj);
 
 #if MICROPY_PY_OS_DUPTERM
 bool mp_uos_dupterm_is_builtin_stream(mp_const_obj_t stream);
+uintptr_t mp_uos_dupterm_poll(uintptr_t poll_flags);
 int mp_uos_dupterm_rx_chr(void);
 void mp_uos_dupterm_tx_strn(const char *str, size_t len);
 void mp_uos_deactivate(size_t dupterm_idx, const char *msg, mp_obj_t exc);

--- a/extmod/uos_dupterm.c
+++ b/extmod/uos_dupterm.c
@@ -53,6 +53,45 @@ void mp_uos_deactivate(size_t dupterm_idx, const char *msg, mp_obj_t exc) {
     }
 }
 
+uintptr_t mp_uos_dupterm_poll(uintptr_t poll_flags) {
+    uintptr_t poll_flags_out = 0;
+
+    for (size_t idx = 0; idx < MICROPY_PY_OS_DUPTERM; ++idx) {
+        mp_obj_t s = MP_STATE_VM(dupterm_objs[idx]);
+        if (s == MP_OBJ_NULL) {
+            continue;
+        }
+
+        int errcode = 0;
+        mp_uint_t ret = 0;
+        const mp_stream_p_t *stream_p = mp_get_stream(s);
+        #if MICROPY_PY_UOS_DUPTERM_BUILTIN_STREAM
+        if (mp_uos_dupterm_is_builtin_stream(s)) {
+            ret = stream_p->ioctl(s, MP_STREAM_POLL, poll_flags, &errcode);
+        } else
+        #endif
+        {
+            nlr_buf_t nlr;
+            if (nlr_push(&nlr) == 0) {
+                ret = stream_p->ioctl(s, MP_STREAM_POLL, poll_flags, &errcode);
+                nlr_pop();
+            } else {
+                // Ignore error with ioctl
+            }
+        }
+
+        if (ret != MP_STREAM_ERROR) {
+            poll_flags_out |= ret;
+            if (poll_flags_out == poll_flags) {
+                // Finish early if all requested flags are set
+                break;
+            }
+        }
+    }
+
+    return poll_flags_out;
+}
+
 int mp_uos_dupterm_rx_chr(void) {
     for (size_t idx = 0; idx < MICROPY_PY_OS_DUPTERM; ++idx) {
         if (MP_STATE_VM(dupterm_objs[idx]) == MP_OBJ_NULL) {

--- a/lib/utils/sys_stdio_mphal.c
+++ b/lib/utils/sys_stdio_mphal.c
@@ -85,6 +85,16 @@ STATIC mp_uint_t stdio_write(mp_obj_t self_in, const void *buf, mp_uint_t size, 
     }
 }
 
+STATIC mp_uint_t stdio_ioctl(mp_obj_t self_in, mp_uint_t request, uintptr_t arg, int *errcode) {
+    (void)self_in;
+    if (request == MP_STREAM_POLL) {
+        return mp_hal_stdio_poll(arg);
+    } else {
+        *errcode = MP_EINVAL;
+        return MP_STREAM_ERROR;
+    }
+}
+
 STATIC mp_obj_t stdio_obj___exit__(size_t n_args, const mp_obj_t *args) {
     return mp_const_none;
 }
@@ -112,6 +122,7 @@ STATIC MP_DEFINE_CONST_DICT(stdio_locals_dict, stdio_locals_dict_table);
 STATIC const mp_stream_p_t stdio_obj_stream_p = {
     .read = stdio_read,
     .write = stdio_write,
+    .ioctl = stdio_ioctl,
     .is_text = true,
 };
 
@@ -146,6 +157,7 @@ STATIC mp_uint_t stdio_buffer_write(mp_obj_t self_in, const void *buf, mp_uint_t
 STATIC const mp_stream_p_t stdio_buffer_obj_stream_p = {
     .read = stdio_buffer_read,
     .write = stdio_buffer_write,
+    .ioctl = stdio_ioctl,
     .is_text = false,
 };
 

--- a/ports/cc3200/hal/cc3200_hal.h
+++ b/ports/cc3200/hal/cc3200_hal.h
@@ -64,5 +64,6 @@ extern void HAL_SystemDeInit (void);
 extern void HAL_IncrementTick(void);
 extern void mp_hal_set_interrupt_char (int c);
 
+#define mp_hal_stdio_poll(poll_flags) (0) // not implemented
 #define mp_hal_delay_us(usec) UtilsDelay(UTILS_DELAY_US_TO_COUNT(usec))
 #define mp_hal_ticks_cpu() (SysTickPeriodGet() - SysTickValueGet())

--- a/ports/esp32/mphalport.c
+++ b/ports/esp32/mphalport.c
@@ -34,6 +34,7 @@
 #include "rom/uart.h"
 
 #include "py/obj.h"
+#include "py/stream.h"
 #include "py/mpstate.h"
 #include "py/mphal.h"
 #include "extmod/misc.h"
@@ -44,6 +45,14 @@ TaskHandle_t mp_main_task_handle;
 
 STATIC uint8_t stdin_ringbuf_array[256];
 ringbuf_t stdin_ringbuf = {stdin_ringbuf_array, sizeof(stdin_ringbuf_array)};
+
+uintptr_t mp_hal_stdio_poll(uintptr_t poll_flags) {
+    uintptr_t ret = 0;
+    if ((poll_flags & MP_STREAM_POLL_RD) && stdin_ringbuf.iget != stdin_ringbuf.iput) {
+        ret |= MP_STREAM_POLL_RD;
+    }
+    return ret;
+}
 
 int mp_hal_stdin_rx_chr(void) {
     for (;;) {

--- a/ports/esp8266/esp_mphal.c
+++ b/ports/esp8266/esp_mphal.c
@@ -32,6 +32,7 @@
 #include "user_interface.h"
 #include "ets_alt_task.h"
 #include "py/runtime.h"
+#include "py/stream.h"
 #include "extmod/misc.h"
 #include "lib/utils/pyexec.h"
 
@@ -54,6 +55,14 @@ void mp_hal_delay_us(uint32_t us) {
     while (system_get_time() - start < us) {
         ets_event_poll();
     }
+}
+
+uintptr_t mp_hal_stdio_poll(uintptr_t poll_flags) {
+    uintptr_t ret = 0;
+    if ((poll_flags & MP_STREAM_POLL_RD) && stdin_ringbuf.iget != stdin_ringbuf.iput) {
+        ret |= MP_STREAM_POLL_RD;
+    }
+    return ret;
 }
 
 int mp_hal_stdin_rx_chr(void) {

--- a/ports/pic16bit/pic16bit_mphal.c
+++ b/ports/pic16bit/pic16bit_mphal.c
@@ -25,6 +25,7 @@
  */
 
 #include <string.h>
+#include "py/stream.h"
 #include "py/mphal.h"
 #include "board.h"
 
@@ -49,6 +50,14 @@ void mp_hal_delay_ms(mp_uint_t ms) {
 
 void mp_hal_set_interrupt_char(int c) {
     interrupt_char = c;
+}
+
+uintptr_t mp_hal_stdio_poll(uintptr_t poll_flags) {
+    uintptr_t ret = 0;
+    if ((poll_flags & MP_STREAM_POLL_RD) && uart_rx_any()) {
+        ret |= MP_STREAM_POLL_RD;
+    }
+    return ret;
 }
 
 int mp_hal_stdin_rx_chr(void) {

--- a/ports/stm32/mphalport.c
+++ b/ports/stm32/mphalport.c
@@ -1,6 +1,7 @@
 #include <string.h>
 
 #include "py/runtime.h"
+#include "py/stream.h"
 #include "py/mperrno.h"
 #include "py/mphal.h"
 #include "extmod/misc.h"
@@ -17,6 +18,16 @@ const byte mp_hal_status_to_errno_table[4] = {
 
 NORETURN void mp_hal_raise(HAL_StatusTypeDef status) {
     mp_raise_OSError(mp_hal_status_to_errno_table[status]);
+}
+
+MP_WEAK uintptr_t mp_hal_stdio_poll(uintptr_t poll_flags) {
+    uintptr_t ret = 0;
+    if (MP_STATE_PORT(pyb_stdio_uart) != NULL) {
+        int errcode;
+        const mp_stream_p_t *stream_p = mp_get_stream(MP_STATE_PORT(pyb_stdio_uart));
+        ret = stream_p->ioctl(MP_STATE_PORT(pyb_stdio_uart), MP_STREAM_POLL, poll_flags, &errcode);
+    }
+    return ret | mp_uos_dupterm_poll(poll_flags);
 }
 
 MP_WEAK int mp_hal_stdin_rx_chr(void) {

--- a/py/mphal.h
+++ b/py/mphal.h
@@ -34,6 +34,10 @@
 #include <mphalport.h>
 #endif
 
+#ifndef mp_hal_stdio_poll
+uintptr_t mp_hal_stdio_poll(uintptr_t poll_flags);
+#endif
+
 #ifndef mp_hal_stdin_rx_chr
 int mp_hal_stdin_rx_chr(void);
 #endif


### PR DESCRIPTION
This PR allows to poll sys.stdin for readability, and also makes sys.stdin.buffer.read non-blocking (but keeps sys.stdin.read blocking as it was before).  A port must provide `mp_hal_stdin_rx_avail()` for this to work (this function is only implemented on esp8266 for now).

Testing of polling can be done with:
```python
import sys, select
while True:
    res = select.select([sys.stdin.buffer], [], [])
    data = sys.stdin.buffer.read(1)
    print('got', data)
    if data == b'q':
        break
```

Testing of non-blocking read can be done with (enter chars while it's sleeping):
```python
import time, sys
time.sleep(3); print(sys.stdin.buffer.read(4)
```

See issue #4849 for background.