### PR TITLE
stm32: Enter bootloader via a system reset.

### DIFF
--- a/ports/stm32/Makefile
+++ b/ports/stm32/Makefile
@@ -92,6 +92,7 @@ CFLAGS += -fsingle-precision-constant -Wdouble-promotion
 endif
 
 LDFLAGS = -nostdlib -L $(LD_DIR) $(addprefix -T,$(LD_FILES)) -Map=$(@:.elf=.map) --cref
+LDFLAGS += --defsym=_estack_reserve=8
 LIBS = $(shell $(CC) $(CFLAGS) -print-libgcc-file-name)
 
 # Remove uncalled code from the final image.

--- a/ports/stm32/boards/PYBD_SF2/f722_qspi.ld
+++ b/ports/stm32/boards/PYBD_SF2/f722_qspi.ld
@@ -31,7 +31,7 @@ _minimum_heap_size = 16K;
 
 /* Define the stack.  The stack is full descending so begins just above last byte
    of RAM.  Note that EABI requires the stack to be 8-byte aligned for a call. */
-_estack = ORIGIN(RAM) + LENGTH(RAM);
+_estack = ORIGIN(RAM) + LENGTH(RAM) - _estack_reserve;
 _sstack = _estack - 16K;
 
 /* RAM extents for the garbage collector */

--- a/ports/stm32/boards/PYBD_SF6/f767.ld
+++ b/ports/stm32/boards/PYBD_SF6/f767.ld
@@ -30,7 +30,7 @@ _minimum_heap_size = 16K;
 
 /* Define the stack.  The stack is full descending so begins just above last byte
    of RAM.  Note that EABI requires the stack to be 8-byte aligned for a call. */
-_estack = ORIGIN(RAM) + LENGTH(RAM);
+_estack = ORIGIN(RAM) + LENGTH(RAM) - _estack_reserve;
 _sstack = _estack - 24K;
 
 /* RAM extents for the garbage collector */

--- a/ports/stm32/boards/STM32F769DISC/f769_qspi.ld
+++ b/ports/stm32/boards/STM32F769DISC/f769_qspi.ld
@@ -29,7 +29,7 @@ _minimum_heap_size = 16K;
 
 /* Define the stack.  The stack is full descending so begins just above last byte
    of RAM.  Note that EABI requires the stack to be 8-byte aligned for a call. */
-_estack = ORIGIN(RAM) + LENGTH(RAM);
+_estack = ORIGIN(RAM) + LENGTH(RAM) - _estack_reserve;
 _sstack = _estack - 32K; /* tunable */
 
 /* RAM extents for the garbage collector */

--- a/ports/stm32/boards/stm32f091xc.ld
+++ b/ports/stm32/boards/stm32f091xc.ld
@@ -16,7 +16,7 @@ _minimum_heap_size = 16K;
 
 /* Define the stack.  The stack is full descending so begins just above last byte above last byte
    of RAM.  Note that EABI requires the stack to be 8-byte aligned for a call. */
-_estack = ORIGIN(RAM) + LENGTH(RAM);
+_estack = ORIGIN(RAM) + LENGTH(RAM) - _estack_reserve;
 _sstack = _estack - 6K; /* tunable */
 
 /* RAM extents for the garbage collector */

--- a/ports/stm32/boards/stm32f401xd.ld
+++ b/ports/stm32/boards/stm32f401xd.ld
@@ -18,7 +18,7 @@ _minimum_heap_size = 16K; /* tunable */
 
 /* Define the stack.  The stack is full descending so begins just above last byte
    of RAM.  Note that EABI requires the stack to be 8-byte aligned for a call. */
-_estack = ORIGIN(RAM) + LENGTH(RAM);
+_estack = ORIGIN(RAM) + LENGTH(RAM) - _estack_reserve;
 _sstack = _estack - 16K;
 
 /* RAM extents for the garbage collector */

--- a/ports/stm32/boards/stm32f401xe.ld
+++ b/ports/stm32/boards/stm32f401xe.ld
@@ -18,7 +18,7 @@ _minimum_heap_size = 16K;
 
 /* Define the stack.  The stack is full descending so begins just above last byte
    of RAM.  Note that EABI requires the stack to be 8-byte aligned for a call. */
-_estack = ORIGIN(RAM) + LENGTH(RAM);
+_estack = ORIGIN(RAM) + LENGTH(RAM) - _estack_reserve;
 _sstack = _estack - 16K; /* tunable */
 
 /* RAM extents for the garbage collector */

--- a/ports/stm32/boards/stm32f405.ld
+++ b/ports/stm32/boards/stm32f405.ld
@@ -19,7 +19,7 @@ _minimum_heap_size = 16K;
 
 /* Define the stack.  The stack is full descending so begins just above last byte
    of RAM.  Note that EABI requires the stack to be 8-byte aligned for a call. */
-_estack = ORIGIN(RAM) + LENGTH(RAM);
+_estack = ORIGIN(RAM) + LENGTH(RAM) - _estack_reserve;
 _sstack = _estack - 16K; /* tunable */
 
 /* RAM extents for the garbage collector */

--- a/ports/stm32/boards/stm32f411.ld
+++ b/ports/stm32/boards/stm32f411.ld
@@ -18,7 +18,7 @@ _minimum_heap_size = 16K;
 
 /* Define the stack.  The stack is full descending so begins just above last byte
    of RAM.  Note that EABI requires the stack to be 8-byte aligned for a call. */
-_estack = ORIGIN(RAM) + LENGTH(RAM);
+_estack = ORIGIN(RAM) + LENGTH(RAM) - _estack_reserve;
 _sstack = _estack - 16K; /* tunable */
 
 /* RAM extents for the garbage collector */

--- a/ports/stm32/boards/stm32f413xg.ld
+++ b/ports/stm32/boards/stm32f413xg.ld
@@ -21,7 +21,7 @@ _minimum_heap_size = 16K;
 
 /* Define the stack.  The stack is full descending so begins just above last byte
    of RAM.  Note that EABI requires the stack to be 8-byte aligned for a call. */
-_estack = ORIGIN(RAM) + LENGTH(RAM);
+_estack = ORIGIN(RAM) + LENGTH(RAM) - _estack_reserve;
 _sstack = _estack - 16K; /* tunable */
 
 /* RAM extents for the garbage collector */

--- a/ports/stm32/boards/stm32f413xh.ld
+++ b/ports/stm32/boards/stm32f413xh.ld
@@ -21,7 +21,7 @@ _minimum_heap_size = 16K;
 
 /* Define the stack.  The stack is full descending so begins just above last byte
    of RAM.  Note that EABI requires the stack to be 8-byte aligned for a call. */
-_estack = ORIGIN(RAM) + LENGTH(RAM);
+_estack = ORIGIN(RAM) + LENGTH(RAM) - _estack_reserve;
 _sstack = _estack - 16K; /* tunable */
 
 /* RAM extents for the garbage collector */

--- a/ports/stm32/boards/stm32f429.ld
+++ b/ports/stm32/boards/stm32f429.ld
@@ -19,7 +19,7 @@ _minimum_heap_size = 16K;
 
 /* Define the stack.  The stack is full descending so begins just above last byte
    of RAM.  Note that EABI requires the stack to be 8-byte aligned for a call. */
-_estack = ORIGIN(RAM) + LENGTH(RAM);
+_estack = ORIGIN(RAM) + LENGTH(RAM) - _estack_reserve;
 _sstack = _estack - 16K; /* tunable */
 
 /* RAM extents for the garbage collector */

--- a/ports/stm32/boards/stm32f439.ld
+++ b/ports/stm32/boards/stm32f439.ld
@@ -20,7 +20,7 @@ _minimum_heap_size = 16K;
 
 /* Define the stack.  The stack is full descending so begins just above last byte
    of RAM.  Note that EABI requires the stack to be 8-byte aligned for a call. */
-_estack = ORIGIN(RAM) + LENGTH(RAM);
+_estack = ORIGIN(RAM) + LENGTH(RAM) - _estack_reserve;
 _sstack = _estack - 16K; /* tunable */
 
 /* RAM extents for the garbage collector */

--- a/ports/stm32/boards/stm32f722.ld
+++ b/ports/stm32/boards/stm32f722.ld
@@ -17,7 +17,7 @@ _minimum_heap_size = 16K;
 
 /* Define the stack.  The stack is full descending so begins just above last byte
    of RAM.  Note that EABI requires the stack to be 8-byte aligned for a call. */
-_estack = ORIGIN(RAM) + LENGTH(RAM);
+_estack = ORIGIN(RAM) + LENGTH(RAM) - _estack_reserve;
 _sstack = _estack - 32K; /* tunable */
 
 /* RAM extents for the garbage collector */

--- a/ports/stm32/boards/stm32f746.ld
+++ b/ports/stm32/boards/stm32f746.ld
@@ -19,7 +19,7 @@ _minimum_heap_size = 16K;
 
 /* Define the stack.  The stack is full descending so begins just above last byte
    of RAM.  Note that EABI requires the stack to be 8-byte aligned for a call. */
-_estack = ORIGIN(RAM) + LENGTH(RAM);
+_estack = ORIGIN(RAM) + LENGTH(RAM) - _estack_reserve;
 _sstack = _estack - 16K; /* tunable */
 
 /* RAM extents for the garbage collector */

--- a/ports/stm32/boards/stm32f767.ld
+++ b/ports/stm32/boards/stm32f767.ld
@@ -20,7 +20,7 @@ _minimum_heap_size = 16K;
 
 /* Define the stack.  The stack is full descending so begins just above last byte
    of RAM.  Note that EABI requires the stack to be 8-byte aligned for a call. */
-_estack = ORIGIN(RAM) + LENGTH(RAM);
+_estack = ORIGIN(RAM) + LENGTH(RAM) - _estack_reserve;
 _sstack = _estack - 32K; /* tunable */
 
 /* RAM extents for the garbage collector */

--- a/ports/stm32/boards/stm32f769.ld
+++ b/ports/stm32/boards/stm32f769.ld
@@ -19,7 +19,7 @@ _minimum_heap_size = 16K;
 
 /* Define the stack.  The stack is full descending so begins just above last byte
    of RAM.  Note that EABI requires the stack to be 8-byte aligned for a call. */
-_estack = ORIGIN(RAM) + LENGTH(RAM);
+_estack = ORIGIN(RAM) + LENGTH(RAM) - _estack_reserve;
 _sstack = _estack - 32K; /* tunable */
 
 /* RAM extents for the garbage collector */

--- a/ports/stm32/boards/stm32h743.ld
+++ b/ports/stm32/boards/stm32h743.ld
@@ -19,7 +19,7 @@ _minimum_heap_size = 16K;
 
 /* Define the stack.  The stack is full descending so begins just above last byte
    of RAM.  Note that EABI requires the stack to be 8-byte aligned for a call. */
-_estack = ORIGIN(RAM) + LENGTH(RAM);
+_estack = ORIGIN(RAM) + LENGTH(RAM) - _estack_reserve;
 _sstack = _estack - 16K; /* tunable */
 
 /* RAM extents for the garbage collector */

--- a/ports/stm32/boards/stm32l432.ld
+++ b/ports/stm32/boards/stm32l432.ld
@@ -17,7 +17,7 @@ _minimum_heap_size = 16K;
 
 /* Define the stack.  The stack is full descending so begins just above last byte
    of RAM.  Note that EABI requires the stack to be 8-byte aligned for a call. */
-_estack = ORIGIN(RAM) + LENGTH(RAM);
+_estack = ORIGIN(RAM) + LENGTH(RAM) - _estack_reserve;
 _sstack = _estack - 6K; /* tunable */
 
 /* RAM extents for the garbage collector */

--- a/ports/stm32/boards/stm32l476xe.ld
+++ b/ports/stm32/boards/stm32l476xe.ld
@@ -20,7 +20,7 @@ _minimum_heap_size = 16K;
 
 /* Define the stack.  The stack is full descending so begins just above last byte
    of RAM.  Note that EABI requires the stack to be 8-byte aligned for a call. */
-_estack = ORIGIN(RAM) + LENGTH(RAM);
+_estack = ORIGIN(RAM) + LENGTH(RAM) - _estack_reserve;
 _sstack = _estack - 16K; /* tunable */
 
 /* RAM extents for the garbage collector */

--- a/ports/stm32/boards/stm32l476xg.ld
+++ b/ports/stm32/boards/stm32l476xg.ld
@@ -20,7 +20,7 @@ _minimum_heap_size = 16K;
 
 /* Define the stack.  The stack is full descending so begins just above last byte
    of RAM.  Note that EABI requires the stack to be 8-byte aligned for a call. */
-_estack = ORIGIN(RAM) + LENGTH(RAM);
+_estack = ORIGIN(RAM) + LENGTH(RAM) - _estack_reserve;
 _sstack = _estack - 16K; /* tunable */
 
 /* RAM extents for the garbage collector */

--- a/ports/stm32/boards/stm32l496xg.ld
+++ b/ports/stm32/boards/stm32l496xg.ld
@@ -20,7 +20,7 @@ _minimum_heap_size = 16K;
 
 /* Define the stack.  The stack is full descending so begins just above last byte
    of RAM.  Note that EABI requires the stack to be 8-byte aligned for a call. */
-_estack = ORIGIN(RAM) + LENGTH(RAM) + LENGTH(SRAM2);
+_estack = ORIGIN(RAM) + LENGTH(RAM) + LENGTH(SRAM2) - _estack_reserve;
 _sstack = _estack - 206K; /* tunable */
 
 /* RAM extents for the garbage collector */

--- a/ports/stm32/main.c
+++ b/ports/stm32/main.c
@@ -45,6 +45,7 @@
 
 #include "systick.h"
 #include "pendsv.h"
+#include "powerctrl.h"
 #include "pybthread.h"
 #include "gccollect.h"
 #include "factoryreset.h"
@@ -368,6 +369,9 @@ STATIC uint update_reset_mode(uint reset_mode) {
 #endif
 
 void stm32_main(uint32_t reset_mode) {
+    // Check if bootloader should be entered instead of main application
+    powerctrl_check_enter_bootloader();
+
     // Enable caches and prefetch buffers
 
     #if defined(STM32F4)

--- a/ports/stm32/powerctrl.h
+++ b/ports/stm32/powerctrl.h
@@ -28,6 +28,10 @@
 
 #include <stdint.h>
 
+NORETURN void powerctrl_mcu_reset(void);
+NORETURN void powerctrl_enter_bootloader(uint32_t r0, uint32_t bl_addr);
+void powerctrl_check_enter_bootloader(void);
+
 int powerctrl_rcc_clock_config_pll(RCC_ClkInitTypeDef *rcc_init, uint32_t sysclk_mhz, bool need_pllsai);
 int powerctrl_set_sysclk(uint32_t sysclk, uint32_t ahb, uint32_t apb1, uint32_t apb2);
 void powerctrl_enter_stop_mode(void);

--- a/ports/stm32/stm32_it.c
+++ b/ports/stm32/stm32_it.c
@@ -72,6 +72,7 @@
 #include "stm32_it.h"
 #include "pendsv.h"
 #include "irq.h"
+#include "powerctrl.h"
 #include "pybthread.h"
 #include "gccollect.h"
 #include "extint.h"
@@ -144,7 +145,7 @@ int pyb_hard_fault_debug = 0;
 
 void HardFault_C_Handler(ExceptionRegisters_t *regs) {
     if (!pyb_hard_fault_debug) {
-        NVIC_SystemReset();
+        powerctrl_mcu_reset();
     }
 
     #if MICROPY_HW_ENABLE_USB


### PR DESCRIPTION
Entering a bootloader (ST system bootloader, or custom mboot) from software by directly branching to it is not reliable, and the reliability of it working can depend on the peripherals that were enabled by the application code.  It's also not possible to branch to a bootloader if the WDT is enabled (unless the bootloader has specific provisions to feed the WDT).

This patch changes the way a bootloader is entered from software by first doing a complete system reset, then branching to the desired bootloader early on in the start-up process.  The top two words of RAM (of the stack) are reserved to store flags indicating that the bootloader should be entered after a reset.

A benefit of going via system reset is that any WDT that is enabled will also be reset.

See #4413 for a previous attempt at this.