### PR TITLE
Various travis improvements

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -121,6 +121,18 @@ jobs:
         - make ${MAKEOPTS} -C mpy-cross
         - make ${MAKEOPTS} -C ports/windows CROSS_COMPILE=i686-w64-mingw32-
 
+    # esp8266 port
+    - stage: test
+      env: NAME="esp8266 port build"
+      install:
+        - wget https://github.com/jepler/esp-open-sdk/releases/download/2018-06-10/xtensa-lx106-elf-standalone.tar.gz
+        - zcat xtensa-lx106-elf-standalone.tar.gz | tar x
+        - export PATH=$(pwd)/xtensa-lx106-elf/bin:$PATH
+      script:
+        - git submodule update --init lib/axtls lib/berkeley-db-1.xx
+        - make ${MAKEOPTS} -C mpy-cross
+        - make ${MAKEOPTS} -C ports/esp8266
+
     # nrf port
     - stage: test
       env: NAME="nrf port build"

--- a/.travis.yml
+++ b/.travis.yml
@@ -121,6 +121,23 @@ jobs:
         - make ${MAKEOPTS} -C mpy-cross
         - make ${MAKEOPTS} -C ports/windows CROSS_COMPILE=i686-w64-mingw32-
 
+    # esp32 port
+    - stage: test
+      env: NAME="esp32 port build"
+      install:
+        - sudo apt-get install python3-pip
+        - sudo pip3 install pyparsing
+        - wget https://dl.espressif.com/dl/xtensa-esp32-elf-linux64-1.22.0-80-g6c4433a-5.2.0.tar.gz
+        - zcat xtensa-esp32-elf-linux64-1.22.0-80-g6c4433a-5.2.0.tar.gz | tar x
+        - export PATH=$(pwd)/xtensa-esp32-elf/bin:$PATH
+        - git clone https://github.com/espressif/esp-idf.git
+        - git -C esp-idf checkout $(grep "ESPIDF_SUPHASH :=" ports/esp32/Makefile | cut -d " " -f 3)
+        - git -C esp-idf submodule update --init components/json/cJSON components/esp32/lib components/esptool_py/esptool components/expat/expat components/lwip/lwip components/mbedtls/mbedtls components/micro-ecc/micro-ecc components/nghttp/nghttp2
+      script:
+        - git submodule update --init lib/berkeley-db-1.xx
+        - make ${MAKEOPTS} -C mpy-cross
+        - make ${MAKEOPTS} -C ports/esp32 ESPIDF=$(pwd)/esp-idf
+
     # esp8266 port
     - stage: test
       env: NAME="esp8266 port build"

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,8 @@ cache:
 env:
   global:
     - MAKEOPTS="-j4"
+git:
+  submodules: false
 
 # define the successive stages
 stages:
@@ -30,6 +32,7 @@ jobs:
         - sudo apt-get install libnewlib-arm-none-eabi
         - arm-none-eabi-gcc --version
       script:
+        - git submodule update --init lib/lwip lib/mbedtls lib/stm32lib
         - make ${MAKEOPTS} -C mpy-cross
         - make ${MAKEOPTS} -C ports/stm32
         - make ${MAKEOPTS} -C ports/stm32 BOARD=PYBV11 MICROPY_PY_WIZNET5K=5200 MICROPY_PY_CC3K=1
@@ -60,6 +63,7 @@ jobs:
         - gcc --version
         - python3 --version
       script:
+        - git submodule update --init lib/axtls lib/berkeley-db-1.xx lib/libffi
         - make ${MAKEOPTS} -C mpy-cross
         - make ${MAKEOPTS} -C ports/unix deplibs
         - make ${MAKEOPTS} -C ports/unix coverage
@@ -80,6 +84,7 @@ jobs:
     - stage: test
       env: NAME="unix port build and tests"
       script:
+        - git submodule update --init lib/axtls lib/berkeley-db-1.xx lib/libffi
         - make ${MAKEOPTS} -C mpy-cross
         - make ${MAKEOPTS} -C ports/unix deplibs
         - make ${MAKEOPTS} -C ports/unix
@@ -91,6 +96,7 @@ jobs:
       install:
         - sudo apt-get install gcc-multilib libffi-dev:i386
       script:
+        - git submodule update --init lib/axtls lib/berkeley-db-1.xx lib/libffi
         - make ${MAKEOPTS} -C mpy-cross
         - make ${MAKEOPTS} -C ports/unix deplibs
         - make ${MAKEOPTS} -C ports/unix nanbox
@@ -100,6 +106,7 @@ jobs:
     - stage: test
       env: NAME="unix stackless port build and tests"
       script:
+        - git submodule update --init lib/axtls lib/berkeley-db-1.xx lib/libffi
         - make ${MAKEOPTS} -C mpy-cross
         - make ${MAKEOPTS} -C ports/unix deplibs
         - make ${MAKEOPTS} -C ports/unix CFLAGS_EXTRA="-DMICROPY_STACKLESS=1 -DMICROPY_STACKLESS_STRICT=1"
@@ -122,6 +129,7 @@ jobs:
         - sudo apt-get install libnewlib-arm-none-eabi
         - arm-none-eabi-gcc --version
       script:
+        - git submodule update --init lib/nrfx
         - make ${MAKEOPTS} -C ports/nrf
 
     # bare-arm and minimal ports


### PR DESCRIPTION
- only fetch submodules when needed for any given build (saves time, bandwidth)
- build esp8266 as part of Travis CI, takes about 1 minute in total
- build esp32, takes about 3 minutes