### PR TITLE
esp8266: Provide custom machine_time_pulse_us that feeds soft WDT.

### DIFF
--- a/extmod/machine_pulse.c
+++ b/extmod/machine_pulse.c
@@ -30,7 +30,7 @@
 
 #if MICROPY_PY_MACHINE_PULSE
 
-mp_uint_t machine_time_pulse_us(mp_hal_pin_obj_t pin, int pulse_level, mp_uint_t timeout_us) {
+MP_WEAK mp_uint_t machine_time_pulse_us(mp_hal_pin_obj_t pin, int pulse_level, mp_uint_t timeout_us) {
     mp_uint_t start = mp_hal_ticks_us();
     while (mp_hal_pin_read(pin) != pulse_level) {
         if ((mp_uint_t)(mp_hal_ticks_us() - start) >= timeout_us) {

--- a/ports/windows/mpconfigport.h
+++ b/ports/windows/mpconfigport.h
@@ -214,6 +214,7 @@ extern const struct _mp_obj_module_t mp_module_time;
 // CL specific overrides from mpconfig
 
 #define NORETURN                    __declspec(noreturn)
+#define MP_WEAK
 #define MP_NOINLINE                 __declspec(noinline)
 #define MP_LIKELY(x)                (x)
 #define MP_UNLIKELY(x)              (x)


### PR DESCRIPTION
So that the timeout for machine.time_pulse_us() can be large.  The soft WDT is only feed every 65ms or so to try and keep the timing of the edges as accurate as possible.

Fixes issue #2775.