### PR TITLE
prepro is $(CPP) not $(CC) -E

### DIFF
--- a/py/mkrules.mk
+++ b/py/mkrules.mk
@@ -53,7 +53,7 @@ vpath %.c . $(TOP) $(USER_C_MODULES)
 
 $(BUILD)/%.pp: %.c
 	$(ECHO) "PreProcess $<"
-	$(Q)$(CC) $(CFLAGS) -E -Wp,-C,-dD,-dI -o $@ $<
+	$(Q)$(CPP) $(CFLAGS) -Wp,-C,-dD,-dI -o $@ $<
 
 # The following rule uses | to create an order only prerequisite. Order only
 # prerequisites only get built if they don't exist. They don't cause timestamp


### PR DESCRIPTION
see Line 75 and most Makefile eg https://github.com/micropython/micropython/blob/5da60ff9cba990f239bdac2cd7ecdb2f84df4d63/ports/javascript/Makefile#L16