### PR TITLE
esp32/Makefile: Include all driver/*.c in build. Fixes #4869

### DIFF
--- a/ports/esp32/Makefile
+++ b/ports/esp32/Makefile
@@ -256,21 +256,7 @@ $(HEADER_BUILD)/qstrdefs.generated.h: $(SDKCONFIG_H)
 ################################################################################
 # List of object files from the ESP32 IDF components
 
-ESPIDF_DRIVER_O = $(addprefix $(ESPCOMP)/driver/,\
-	uart.o \
-	periph_ctrl.o \
-	ledc.o \
-	gpio.o \
-	timer.o \
-	sdmmc_host.o \
-	sdmmc_transaction.o \
-	sdspi_crc.o \
-	sdspi_host.o \
-	sdspi_transaction.o \
-	spi_master.o \
-	spi_common.o \
-	rtc_module.o \
-	)
+ESPIDF_DRIVER_O = $(subst .c,.o,$(wildcard $(ESPCOMP)/driver/*.c))
 
 ESPIDF_EFUSE_O = $(addprefix $(ESPCOMP)/efuse/,\
 	esp32/esp_efuse_table.o \


### PR DESCRIPTION
Small change to import all drivers in the ESP32 port. This allows writing modules, internally or externally with the cmodules functionality that can use these ESP32 drivers.

For me personally, this allows me to write a cmodule that uses the I2S peripheral without modifying the Makefile.

A snippet of the `make` process showing the files included:
```
CC /builder/esp-idf/components/driver/spi_master.c
CC /builder/esp-idf/components/driver/sigmadelta.c
CC /builder/esp-idf/components/driver/uart.c
CC /builder/esp-idf/components/driver/sdspi_transaction.c
CC /builder/esp-idf/components/driver/sdio_slave.c
CC /builder/esp-idf/components/driver/i2c.c
CC /builder/esp-idf/components/driver/periph_ctrl.c
CC /builder/esp-idf/components/driver/ledc.c
CC /builder/esp-idf/components/driver/sdmmc_transaction.c
CC /builder/esp-idf/components/driver/sdspi_host.c
CC /builder/esp-idf/components/driver/pcnt.c
CC /builder/esp-idf/components/driver/sdspi_crc.c
CC /builder/esp-idf/components/driver/timer.c
CC /builder/esp-idf/components/driver/rmt.c
CC /builder/esp-idf/components/driver/mcpwm.c
CC /builder/esp-idf/components/driver/spi_common.c
CC /builder/esp-idf/components/driver/can.c
CC /builder/esp-idf/components/driver/spi_slave.c
CC /builder/esp-idf/components/driver/gpio.c
CC /builder/esp-idf/components/driver/sdmmc_host.c
CC /builder/esp-idf/components/driver/i2s.c
CC /builder/esp-idf/components/driver/rtc_module.c
AR build/esp-idf/driver/libdriver.a
```

Here is a screenshot of me initializing the I2S hardware via MicroPython, possible due to this change. (Python & CModule library not provided)
![Screenshot from 2019-06-25 13-37-25](https://user-images.githubusercontent.com/834342/60062768-a734a800-974e-11e9-959e-9c2a390ee045.png)

Discussion and issue initially raised here: https://github.com/micropython/micropython/issues/4869