### PR TITLE
port-javascript: Makefile overhaul, sdk, and user mods 

### DIFF
--- a/ports/javascript/Makefile
+++ b/ports/javascript/Makefile
@@ -27,6 +27,9 @@ else
 CFLAGS += -Oz -g0 -DNDEBUG
 endif
 
+CFLAGS += -Wall -Werror $(INC) -std=c99 $(COPT)
+CFLAGS += -fdata-sections -ffunction-sections
+
 ifdef EMSCRIPTEN
 	# only for profiling, remove -s EMTERPRETIFY_ADVISE=1 when your EMTERPRETIFY_WHITELIST is ok
 	# not using an emterpreting list *is* bad and will lead to poor performance and huge binary.
@@ -56,10 +59,6 @@ else
 		CPP = gcc -E -D__CPP__
 	endif
 endif
-
-CFLAGS += -Wall -Werror $(INC) -std=c99 $(COPT)
-CFLAGS += -DNDEBUG
-CFLAGS += -fdata-sections -ffunction-sections
 
 SRC_LIB = $(addprefix lib/,\
 	utils/interrupt_char.c \

--- a/ports/javascript/Makefile
+++ b/ports/javascript/Makefile
@@ -16,7 +16,7 @@ INC += -I$(BUILD)
 CPP = clang -E
 
 ifdef EMSCRIPTEN
-    CPP += -isystem $(EMSCRIPTEN)/system/include/libc -cxx-isystem $(EMSCRIPTEN)/system/include/libcxx
+    CPP += --sysroot $(EMSCRIPTEN)/system -isystem $(EMSCRIPTEN)/system/include/libc -cxx-isystem $(EMSCRIPTEN)/system/include/libcxx
 endif
 
 CFLAGS = -m32 -Wall -Werror $(INC) -std=c99 $(COPT)

--- a/ports/javascript/Makefile
+++ b/ports/javascript/Makefile
@@ -16,7 +16,10 @@ INC += -I$(BUILD)
 CPP = clang -E
 
 ifdef EMSCRIPTEN
-    CPP += --sysroot $(EMSCRIPTEN)/system -isystem $(EMSCRIPTEN)/system/include/libc -cxx-isystem $(EMSCRIPTEN)/system/include/libcxx
+	CPP += -D__EMSCRIPTEN__
+	CPP += --sysroot $(EMSCRIPTEN)/system
+	CPP += -isystem $(EMSCRIPTEN)/system/include/libc
+	CPP += -cxx-isystem $(EMSCRIPTEN)/system/include/libcxx
 endif
 
 CFLAGS = -m32 -Wall -Werror $(INC) -std=c99 $(COPT)

--- a/ports/javascript/Makefile
+++ b/ports/javascript/Makefile
@@ -25,7 +25,7 @@ CFLAGS += -Oz -g0 -DNDEBUG
 endif
 
 CFLAGS += -Wall -Werror $(INC) -std=gnu11 $(COPT)
-CFLAGS += -fdata-sections -ffunction-sections -Wno-error=unused-function
+CFLAGS += -fdata-sections -ffunction-sections
 CFLAGS += $(CFLAGS_MOD)
 
 JSFLAGS += -s WASM=0

--- a/ports/javascript/Makefile
+++ b/ports/javascript/Makefile
@@ -13,15 +13,15 @@ CFLAGS += -Wall -Werror $(INC) -std=gnu11 $(COPT)
 CFLAGS += -fdata-sections -ffunction-sections
 CFLAGS += $(CFLAGS_MOD)
 
-JSFLAGS += -s WASM=0
-JSFLAGS += --memory-init-file 0 --js-library library.js
-JSFLAGS += -s EXTRA_EXPORTED_RUNTIME_METHODS="['ccall', 'cwrap']"
-JSFLAGS += -s EXPORTED_FUNCTIONS="['_mp_js_init', '_mp_js_init_repl',\
- '_mp_js_do_str', '_mp_js_process_char',\
- '_mp_hal_get_interrupt_char', '_mp_keyboard_interrupt' ]"
-
 
 ifdef EMSCRIPTEN
+
+	JSFLAGS += -s WASM=0
+	JSFLAGS += --memory-init-file 0 --js-library library.js
+	JSFLAGS += -s EXTRA_EXPORTED_RUNTIME_METHODS="['ccall', 'cwrap']"
+	JSFLAGS += -s EXPORTED_FUNCTIONS="['_mp_js_init', '_mp_js_init_repl',\
+ '_mp_js_do_str', '_mp_js_process_char',\
+ '_mp_hal_get_interrupt_char', '_mp_keyboard_interrupt' ]"
 
 	#Debugging/Optimization
 	ifeq ($(DEBUG), 1)
@@ -98,13 +98,6 @@ min: $(BUILD)/micropython.js
 
 test: $(BUILD)/micropython.js $(TOP)/tests/run-tests
 	$(eval DIRNAME=ports/$(notdir $(CURDIR)))
-
-# works with wasm + no nlr
-#	cd $(TOP)/tests &&\
- MICROPY_CPYTHON3=python3 MICROPY_MICROPYTHON=../$(DIRNAME)/node_run.sh PATH=../$(DIRNAME):${PATH}\
- ./run-tests-exp.sh
-
-# often broken !
 	cd $(TOP)/tests && MICROPY_CPYTHON3=python3 MICROPY_MICROPYTHON=../$(DIRNAME)/node_run.sh ./run-tests
 
 include $(TOP)/py/mkrules.mk

--- a/ports/javascript/Makefile
+++ b/ports/javascript/Makefile
@@ -78,6 +78,19 @@ OBJ = $(PY_O)
 OBJ += $(addprefix $(BUILD)/, $(SRC_LIB:.c=.o))
 OBJ += $(addprefix $(BUILD)/, $(SRC_C:.c=.o))
 
+ifneq ($(FROZEN_DIR),)
+# To use frozen source modules, put your .py files in a subdirectory (eg scripts/)
+# and then invoke make with FROZEN_DIR=scripts (be sure to build from scratch).
+CFLAGS += -DMICROPY_MODULE_FROZEN_STR
+endif
+
+ifneq ($(FROZEN_MPY_DIR),)
+# To use frozen bytecode, put your .py files in a subdirectory (eg frozen/) and
+# then invoke make with FROZEN_MPY_DIR=frozen (be sure to build from scratch).
+CFLAGS += -DMICROPY_QSTR_EXTRA_POOL=mp_qstr_frozen_const_pool
+CFLAGS += -DMICROPY_MODULE_FROZEN_MPY
+endif
+
 $(BUILD)/clang_predefs.h:
 	$(Q)mkdir -p $(dir $@)
 	$(Q)emcc $(CFLAGS) $(CFLAGS_EXTRA) $(JSFLAGS) -E -x c /dev/null -dM > $@

--- a/ports/javascript/Makefile
+++ b/ports/javascript/Makefile
@@ -23,11 +23,9 @@ ifdef EMSCRIPTEN
 	endif
 
 	CC = emcc
-	CPP = clang -E -D__CPP__ -D__EMSCRIPTEN__
+	CPP = clang -E -D__CPP__ -D__EMSCRIPTEN__ -Wno-macro-redefined
 	CPP += --sysroot $(EMSCRIPTEN)/system	
 	CPP += $(addprefix -isystem, $(shell env LC_ALL=C $(CC) $(CFLAGS_EXTRA) -E -x c++ /dev/null -v 2>&1 |sed -e '/^\#include <...>/,/^End of search/{ //!b };d'))
-	# Act like 'emcc'
-	CPP += -U__i386 -U__i386 -Ui386 -U__SSE -U__SSE_MATH -U__SSE2 -U__SSE2_MATH -U__MMX__ -U__SSE__ -U__SSE_MATH__ -U__SSE2__ -U__SSE2_MATH__
 else
 	ifdef CLANG
 		CC=clang
@@ -58,12 +56,20 @@ SRC_C = \
 
 SRC_QSTR += $(SRC_C)
 
+ifdef EMSCRIPTEN
+	SRC_QSTR += $(BUILD)/clang_predefs.h
+endif
+
+
 OBJ = 
 OBJ = $(PY_O) 
 OBJ += $(addprefix $(BUILD)/, $(SRC_LIB:.c=.o))
 OBJ += $(addprefix $(BUILD)/, $(SRC_C:.c=.o))
 
 JSFLAGS = -O0 -s EXPORTED_FUNCTIONS="['_mp_js_init', '_mp_js_init_repl', '_mp_js_do_str', '_mp_js_process_char', '_mp_hal_get_interrupt_char', '_mp_keyboard_interrupt']" -s EXTRA_EXPORTED_RUNTIME_METHODS="['ccall', 'cwrap']" -s "BINARYEN_TRAP_MODE='clamp'" --memory-init-file 0 --js-library library.js
+
+$(BUILD)/clang_predefs.h:
+	@emcc $(JSFLAGS) -E -x c /dev/null -dM > $@
 
 all: $(BUILD)/micropython.js
 

--- a/ports/javascript/Makefile
+++ b/ports/javascript/Makefile
@@ -23,8 +23,9 @@ ifdef EMSCRIPTEN
 	endif
 
 	CC = emcc
-	CPP = clang -E -D__CPP__ -D__EMSCRIPTEN__ -Wno-macro-redefined
-	CPP += --sysroot $(EMSCRIPTEN)/system	
+	CPP = clang -E -undef -D__CPP__ -D__EMSCRIPTEN__
+	CPP += --sysroot $(EMSCRIPTEN)/system
+	CPP += -include $(BUILD)/clang_predefs.h	
 	CPP += $(addprefix -isystem, $(shell env LC_ALL=C $(CC) $(CFLAGS_EXTRA) -E -x c++ /dev/null -v 2>&1 |sed -e '/^\#include <...>/,/^End of search/{ //!b };d'))
 else
 	ifdef CLANG
@@ -54,11 +55,14 @@ SRC_C = \
 	mphalport.c \
 	modutime.c \
 
-SRC_QSTR += $(SRC_C)
-
+#force preprocessor env to be created before qstr extraction
 ifdef EMSCRIPTEN
 	SRC_QSTR += $(BUILD)/clang_predefs.h
 endif
+
+SRC_QSTR += $(SRC_C)
+
+
 
 OBJ = 
 OBJ = $(PY_O) 
@@ -70,7 +74,7 @@ JSFLAGS += -s EXTRA_EXPORTED_RUNTIME_METHODS="['ccall', 'cwrap']"
 JSFLAGS += -s EXPORTED_FUNCTIONS="['_mp_js_init', '_mp_js_init_repl', '_mp_js_do_str', '_mp_js_process_char', '_mp_hal_get_interrupt_char', '_mp_keyboard_interrupt']" 
 
 $(BUILD)/clang_predefs.h:
-	@emcc $(JSFLAGS) -E -x c /dev/null -dM > $@
+	@emcc $(CFLAGS) $(CFLAGS_EXTRA) $(JSFLAGS) -E -x c /dev/null -dM > $@
 
 all: $(BUILD)/micropython.js
 

--- a/ports/javascript/Makefile
+++ b/ports/javascript/Makefile
@@ -74,7 +74,7 @@ JSFLAGS += -s EXTRA_EXPORTED_RUNTIME_METHODS="['ccall', 'cwrap']"
 JSFLAGS += -s EXPORTED_FUNCTIONS="['_mp_js_init', '_mp_js_init_repl', '_mp_js_do_str', '_mp_js_process_char', '_mp_hal_get_interrupt_char', '_mp_keyboard_interrupt']" 
 
 $(BUILD)/clang_predefs.h:
-        $(Q)mkdir -p $@
+        $(Q)mkdir -p $(dir $@)
 	$(Q)emcc $(CFLAGS) $(CFLAGS_EXTRA) $(JSFLAGS) -E -x c /dev/null -dM > $@
 
 # Create `clang_predefs.h` as soon as possible, using a Makefile trick

--- a/ports/javascript/Makefile
+++ b/ports/javascript/Makefile
@@ -15,7 +15,7 @@ INC += -I$(BUILD)
 
 #default debug options
 JSFLAGS ?= -O0 -g4 --source-map-base http://localhost:8000
-LDFLAGS ?= -m32
+LDFLAGS ?= -m32 -Wl,--gc-sections
 
 ifdef EMSCRIPTEN
 	# only for profiling, remove -s EMTERPRETIFY_ADVISE=1 when your EMTERPRETIFY_WHITELIST is ok
@@ -29,7 +29,7 @@ ifdef EMSCRIPTEN
 	#check if not using emscripten-upstream branch
 	ifeq (,$(findstring upstream/bin, $(EMMAKEN_COMPILER)))
 		JSFLAGS += -s "BINARYEN_TRAP_MODE='clamp'"
-		LDFLAGS += -Wl,-Map=$@.map,--cref -Wl,--gc-sections
+		LDFLAGS += -Wl,-Map=$@.map,--cref
 	endif  
 	
 	CC = emcc

--- a/ports/javascript/Makefile
+++ b/ports/javascript/Makefile
@@ -16,6 +16,7 @@ INC += -I$(BUILD)
 #default debug options
 JSFLAGS ?= -O0 -g4 --source-map-base http://localhost:8000
 LDFLAGS ?= -m32 -Wl,--gc-sections
+CFLAGS ?= -m32
 
 ifdef EMSCRIPTEN
 	# only for profiling, remove -s EMTERPRETIFY_ADVISE=1 when your EMTERPRETIFY_WHITELIST is ok
@@ -47,10 +48,8 @@ else
 	endif
 endif
 
-CFLAGS = -m32 -Wall -Werror $(INC) -std=c99 $(COPT)
-LDFLAGS = -m32 -Wl,-Map=$@.map,--cref -Wl,--gc-sections
-
-CFLAGS += -O0 -DNDEBUG
+CFLAGS += -Wall -Werror $(INC) -std=c99 $(COPT)
+CFLAGS += -DNDEBUG
 CFLAGS += -fdata-sections -ffunction-sections
 
 SRC_LIB = $(addprefix lib/,\
@@ -67,12 +66,11 @@ SRC_C = \
 
 SRC_QSTR += $(SRC_C)
 
-OBJ = 
 OBJ = $(PY_O) 
 OBJ += $(addprefix $(BUILD)/, $(SRC_LIB:.c=.o))
 OBJ += $(addprefix $(BUILD)/, $(SRC_C:.c=.o))
 
-JSFLAGS = -O0  -s "BINARYEN_TRAP_MODE='clamp'" --memory-init-file 0 --js-library library.js
+JSFLAGS += --memory-init-file 0 --js-library library.js
 JSFLAGS += -s EXTRA_EXPORTED_RUNTIME_METHODS="['ccall', 'cwrap']"
 JSFLAGS += -s EXPORTED_FUNCTIONS="['_mp_js_init', '_mp_js_init_repl', '_mp_js_do_str', '_mp_js_process_char', '_mp_hal_get_interrupt_char', '_mp_keyboard_interrupt']" 
 

--- a/ports/javascript/Makefile
+++ b/ports/javascript/Makefile
@@ -77,7 +77,7 @@ JSFLAGS += -s EXTRA_EXPORTED_RUNTIME_METHODS="['ccall', 'cwrap']"
 JSFLAGS += -s EXPORTED_FUNCTIONS="['_mp_js_init', '_mp_js_init_repl', '_mp_js_do_str', '_mp_js_process_char', '_mp_hal_get_interrupt_char', '_mp_keyboard_interrupt']" 
 
 $(BUILD)/clang_predefs.h:
-        $(Q)mkdir -p $(dir $@)
+	$(Q)mkdir -p $(dir $@)
 	$(Q)emcc $(CFLAGS) $(CFLAGS_EXTRA) $(JSFLAGS) -E -x c /dev/null -dM > $@
 
 # Create `clang_predefs.h` as soon as possible, using a Makefile trick

--- a/ports/javascript/Makefile
+++ b/ports/javascript/Makefile
@@ -6,12 +6,16 @@ QSTR_DEFS = qstrdefsport.h
 
 include $(TOP)/py/py.mk
 
-CC = emcc -g4
-LD = emcc -g4
+CC = emcc
+LD = emcc
 
 INC += -I.
 INC += -I$(TOP)
 INC += -I$(BUILD)
+
+#default debug options
+JSFLAGS ?= -O0 -g4 --source-map-base http://localhost:8000
+LDFLAGS ?= -m32
 
 ifdef EMSCRIPTEN
 	# only for profiling, remove -s EMTERPRETIFY_ADVISE=1 when your EMTERPRETIFY_WHITELIST is ok
@@ -22,6 +26,12 @@ ifdef EMSCRIPTEN
 		CFLAGS += -s EMTERPRETIFY_SYNCLIST='["_mp_execute_bytecode"]' -s EMTERPRETIFY_ADVISE=1
 	endif
 
+	#check if not using emscripten-upstream branch
+	ifeq (,$(findstring upstream/bin, $(EMMAKEN_COMPILER)))
+		JSFLAGS += -s "BINARYEN_TRAP_MODE='clamp'"
+		LDFLAGS = -m32 -Wl,-Map=$@.map,--cref -Wl,--gc-sections
+	endif  
+	
 	CC = emcc
 	CPP = clang -E -undef -D__CPP__ -D__EMSCRIPTEN__
 	CPP += --sysroot $(EMSCRIPTEN)/system

--- a/ports/javascript/Makefile
+++ b/ports/javascript/Makefile
@@ -29,7 +29,7 @@ ifdef EMSCRIPTEN
 	#check if not using emscripten-upstream branch
 	ifeq (,$(findstring upstream/bin, $(EMMAKEN_COMPILER)))
 		JSFLAGS += -s "BINARYEN_TRAP_MODE='clamp'"
-		LDFLAGS = -m32 -Wl,-Map=$@.map,--cref -Wl,--gc-sections
+		LDFLAGS += -Wl,-Map=$@.map,--cref -Wl,--gc-sections
 	endif  
 	
 	CC = emcc

--- a/ports/javascript/Makefile
+++ b/ports/javascript/Makefile
@@ -4,6 +4,7 @@ QSTR_DEFS = qstrdefsport.h
 
 include $(TOP)/py/py.mk
 
+
 INC += -I.
 INC += -I$(TOP)
 INC += -I$(BUILD)
@@ -13,48 +14,89 @@ CFLAGS += -Wall -Werror $(INC) -std=gnu11 $(COPT)
 CFLAGS += -fdata-sections -ffunction-sections
 CFLAGS += $(CFLAGS_MOD)
 
+CPPFLAGS +=  -D__CPP__
+
+ifdef __DEV__
+	CFLAGS += -D__DEV__=1
+	CPPFLAGS += -D__DEV__=1
+endif
 
 ifdef EMSCRIPTEN
-
-	JSFLAGS += -s WASM=0
-	JSFLAGS += --memory-init-file 0 --js-library library.js
-	JSFLAGS += -s EXTRA_EXPORTED_RUNTIME_METHODS="['ccall', 'cwrap']"
-	JSFLAGS += -s EXPORTED_FUNCTIONS="['_mp_js_init', '_mp_js_init_repl',\
- '_mp_js_do_str', '_mp_js_process_char',\
- '_mp_hal_get_interrupt_char', '_mp_keyboard_interrupt' ]"
+	#default debug options for browser debugger
+	JSFLAGS ?= --source-map-base http://localhost:8000
 
 	#Debugging/Optimization
 	ifeq ($(DEBUG), 1)
-	CFLAGS += -O0 -g4
+		CFLAGS += -O0 -g4 -fno-inline
 	else
-	CFLAGS += -Oz -g0 -DNDEBUG
+		CFLAGS += -O0 -g0 -DNDEBUG -fno-inline
 	endif
+	
+	JSFLAGS += -s WASM=1 -s TOTAL_MEMORY=512MB -s TOTAL_STACK=16777216
+	JSFLAGS += --memory-init-file 0 --js-library library.js
+	JSFLAGS += -s EXTRA_EXPORTED_RUNTIME_METHODS="['ccall', 'cwrap']"
+	JSFLAGS += -s EXPORTED_FUNCTIONS="[\
+ '_mp_js_init', '_mp_js_do_str', '_mp_js_process_char',\
+ '_mp_hal_get_interrupt_char', '_mp_keyboard_interrupt' ]"
+
+	CC = emcc $(JSFLAGS)
+	LD = emcc $(JSFLAGS)
+	CPP = clang -E -undef $(CPPFLAGS) -D__EMSCRIPTEN__ -U__STDC_VERSION__
+	CPP += --sysroot $(EMSCRIPTEN)/system
+	CPP += -include $(BUILD)/clang_predefs.h
+	CPP += $(addprefix -isystem, $(shell env LC_ALL=C $(CC) $(CFLAGS_EXTRA) -E -x c++ /dev/null -v 2>&1 |sed -e '/^\#include <...>/,/^End of search/{ //!b };d'))
 	
 	#check if not using emscripten-upstream branch
 	ifeq (,$(findstring upstream/bin, $(EMMAKEN_COMPILER)))
-		JSFLAGS += -s "BINARYEN_TRAP_MODE='clamp'"
+#use ASM.JS
+		JSFLAGS += -s WASM=0 -s "BINARYEN_TRAP_MODE='clamp'"
+	else 
+#wasm only !	
+#========================= PROBLEM HERE ==========================
+#wasm-ld: error: build/py/nlr.o: relocation R_WASM_MEMORY_ADDR_SLEB cannot be used against symbol mp_state_ctx; recompile with -fPIC
+# adding -fPIC will lose setjmp		
+		CFLAGS += -fPIC
+#=====================================================================
+		CFLAGS += -D__WASM__=1
+		CPP += -D__WASM__=1
+		#LDFLAGS += -Wl,--gc-sections
 	endif  
-
-	#default debug options for browser debugger
-	JSFLAGS ?= --source-map-base http://localhost:8000
 	
-	CC = emcc $(JSFLAGS)
-	LD = emcc $(JSFLAGS) $(LDFLAGS)
-	CPP = clang -E -undef -D__CPP__ -D__EMSCRIPTEN__ -U__STDC_VERSION__
-	CPP += --sysroot $(EMSCRIPTEN)/system
-	CPP += -include $(BUILD)/clang_predefs.h
-	CPP += $(addprefix -isystem, $(shell env LC_ALL=C $(CC) $(CFLAGS_EXTRA) -E -x c++ /dev/null -v 2>&1\
- |sed -e '/^\#include <...>/,/^End of search/{ //!b };d'))
- 
 
 else
-	ifdef CLANG
-		CC=clang
-		CPP=clang -E -D__CPP__
+	ifdef WASI
+		CC += -D__WASM__ -D__WASI__
+		CPP =$(CC) -D__CPP__ -E
 	else
-		CC = gcc
-		CPP = gcc -E -D__CPP__
+		ifdef CLANG
+			CC=clang
+			CPP=clang -D__CPP__ -E
+		else
+			CC = gcc
+			CPP = gcc -D__CPP__ -E
+		endif
 	endif
+
+	#Debugging/Optimization
+	ifeq ($(DEBUG), 1)
+		CFLAGS += -O0 -g3
+	else
+		CFLAGS += -O0 -g3 -DNDEBUG
+	endif		
+
+endif
+
+ifneq ($(FROZEN_DIR),)
+# To use frozen source modules, put your .py files in a subdirectory (eg scripts/)
+# and then invoke make with FROZEN_DIR=scripts (be sure to build from scratch).
+CFLAGS += -DMICROPY_MODULE_FROZEN_STR
+endif
+
+ifneq ($(FROZEN_MPY_DIR),)
+# To use frozen bytecode, put your .py files in a subdirectory (eg frozen/) and
+# then invoke make with FROZEN_MPY_DIR=frozen (be sure to build from scratch).
+CFLAGS += -DMICROPY_QSTR_EXTRA_POOL=mp_qstr_frozen_const_pool
+CFLAGS += -DMICROPY_MODULE_FROZEN_MPY
 endif
 
 SRC_LIB = $(addprefix lib/,\
@@ -70,40 +112,70 @@ SRC_C = \
 	modutime.c \
 
 
+
+
+
+
 SRC_C += $(SRC_MOD)
 
-SRC_QSTR += $(BUILD)/clang_predefs.h $(SRC_C) $(SRC_LIB)
+SRC_QSTR += $(SRC_C) $(SRC_LIB)
 
 OBJ = $(PY_O) 
 OBJ += $(addprefix $(BUILD)/, $(SRC_LIB:.c=.o))
 OBJ += $(addprefix $(BUILD)/, $(SRC_C:.c=.o))
 
-ifneq ($(FROZEN_DIR),)
-# To use frozen source modules, put your .py files in a subdirectory (eg scripts/)
-# and then invoke make with FROZEN_DIR=scripts (be sure to build from scratch).
-CFLAGS += -DMICROPY_MODULE_FROZEN_STR
-endif
 
-ifneq ($(FROZEN_MPY_DIR),)
-# To use frozen bytecode, put your .py files in a subdirectory (eg frozen/) and
-# then invoke make with FROZEN_MPY_DIR=frozen (be sure to build from scratch).
-CFLAGS += -DMICROPY_QSTR_EXTRA_POOL=mp_qstr_frozen_const_pool
-CFLAGS += -DMICROPY_MODULE_FROZEN_MPY
-endif
+#COPT += $(WASM_FLAGS) $(JSFLAGS)
 
 $(BUILD)/clang_predefs.h:
 	$(Q)mkdir -p $(dir $@)
-	$(Q)emcc $(CFLAGS) $(CFLAGS_EXTRA) $(JSFLAGS) -E -x c /dev/null -dM > $@
+	$(Q)emcc $(CFLAGS) $(CFLAGS_EXTRA) -E -x c /dev/null -dM > $@
 
 # Create `clang_predefs.h` as soon as possible, using a Makefile trick
 
 Makefile: $(BUILD)/clang_predefs.h
 
+CFLAGS += $(CFLAGS_EXTRA)
+
+
+ifdef SHARED
+BASENAME=micropython
+PROG=$(BASENAME).html
+LIBMICROPYTHON = lib$(BASENAME).a
+
+LD_PROG += -s MAIN_MODULE=1 -s EXPORT_ALL=1 
+LD_LIB = -s EXPORT_ALL=1 -s WASM=1 -s SIDE_MODULE=1 -s TOTAL_MEMORY=512MB
+
+all: $(PROG)
+
+libs: $(OBJ)
+	$(ECHO) "Linking static $(LIBMICROPYTHON)"
+	$(Q)$(AR) rcs $(LIBMICROPYTHON) $(OBJ)
+	$(ECHO) "Linking shared lib$(BASENAME)$(TARGET).wasm"
+	$(Q)$(LD) $(LD_SHARED) $(LD_LIB) -o lib$(BASENAME)$(TARGET).wasm $(OBJ) -ldl -lc
+
+	
+$(PROG): libs
+	$(ECHO) "Building executable $@"
+	$(Q)$(CC) $(CFLAGS) $(INC) $(COPT) $(WASM_FLAGS) $(LD_PROG) $(THR_FLAGS) \
+ -o $@ main.c -ldl -lm -lc -lmicropython -L. $(DLO) \
+ --preload-file assets@/assets \
+ --preload-file micropython/lib@/lib
+
+else
+
+ifdef WASI
+all: $(BUILD)/micropython.wasm
+
+$(BUILD)/micropython.wasm: $(OBJ)
+	$(CC) $(LDFLAGS) -o $@ $(OBJ)
+
+else
 all: $(BUILD)/micropython.js
 
 $(BUILD)/micropython.js: $(OBJ) library.js wrapper.js
 	$(ECHO) "LINK $(BUILD)/firmware.js"
-	$(Q)$(LD) -o $(BUILD)/firmware.js $(OBJ)
+	$(Q)$(LD) $(JSFLAGS) $(LDFLAGS) -o $(BUILD)/firmware.js $(OBJ)
 	cat wrapper.js $(BUILD)/firmware.js > $@
 
 min: $(BUILD)/micropython.js
@@ -112,5 +184,41 @@ min: $(BUILD)/micropython.js
 test: $(BUILD)/micropython.js $(TOP)/tests/run-tests
 	$(eval DIRNAME=ports/$(notdir $(CURDIR)))
 	cd $(TOP)/tests && MICROPY_CPYTHON3=python3 MICROPY_MICROPYTHON=../$(DIRNAME)/node_run.sh ./run-tests
+endif
+endif
+
 
 include $(TOP)/py/mkrules.mk
+
+
+check:
+	$(ECHO) "CC=[$(CC)]"	
+	$(ECHO) "CPP=[$(CPP)]"
+	$(ECHO) "COPT=[$(COPT)]"
+	$(ECHO) "CFLAGS=[$(CFLAGS)]"	
+	$(ECHO)	
+	$(ECHO) CXX=$(CXX)
+	$(ECHO) AS=$(AS)
+	$(ECHO) LD=$(LD)
+	$(ECHO) OBJCOPY=$(OBJCOPY)
+	$(ECHO) SIZE=$(SIZE)
+	$(ECHO) STRIP=$(STRIP)
+	$(ECHO) AR=$(AR)
+	$(ECHO)	
+#emscripten specifics
+	$(ECHO) EMSDK=$(EMSDK)
+	$(ECHO) UPSTREAM=$(UPSTREAM)	
+	$(ECHO) EMSCRIPTEN=$(EMSCRIPTEN)
+	$(ECHO) EMSDK_NODE=$(EMSDK_NODE)
+	$(ECHO) EMSCRIPTEN_TOOLS=$(EMSCRIPTEN_TOOLS)
+	$(ECHO) EM_CONFIG=$(EM_CONFIG)
+	$(ECHO) EMMAKEN_COMPILER=$(EMMAKEN_COMPILER)
+	$(ECHO) EMMAKEN_CFLAGS=$(EMMAKEN_CFLAGS)
+	$(ECHO) EMCC_FORCE_STDLIBS=$(EMCC_FORCE_STDLIBS)
+	$(ECHO) EM_CACHE=$(EM_CACHE)
+	$(ECHO) EM_CONFIG=$(EM_CONFIG)
+	$(ECHO) JSFLAGS=$(JSFLAGS)
+	$(shell env|grep ^EM)
+
+
+

--- a/ports/javascript/Makefile
+++ b/ports/javascript/Makefile
@@ -55,14 +55,7 @@ SRC_C = \
 	mphalport.c \
 	modutime.c \
 
-#force preprocessor env to be created before qstr extraction
-ifdef EMSCRIPTEN
-	SRC_QSTR += $(BUILD)/clang_predefs.h
-endif
-
 SRC_QSTR += $(SRC_C)
-
-
 
 OBJ = 
 OBJ = $(PY_O) 

--- a/ports/javascript/Makefile
+++ b/ports/javascript/Makefile
@@ -60,13 +60,14 @@ ifdef EMSCRIPTEN
 	SRC_QSTR += $(BUILD)/clang_predefs.h
 endif
 
-
 OBJ = 
 OBJ = $(PY_O) 
 OBJ += $(addprefix $(BUILD)/, $(SRC_LIB:.c=.o))
 OBJ += $(addprefix $(BUILD)/, $(SRC_C:.c=.o))
 
-JSFLAGS = -O0 -s EXPORTED_FUNCTIONS="['_mp_js_init', '_mp_js_init_repl', '_mp_js_do_str', '_mp_js_process_char', '_mp_hal_get_interrupt_char', '_mp_keyboard_interrupt']" -s EXTRA_EXPORTED_RUNTIME_METHODS="['ccall', 'cwrap']" -s "BINARYEN_TRAP_MODE='clamp'" --memory-init-file 0 --js-library library.js
+JSFLAGS = -O0  -s "BINARYEN_TRAP_MODE='clamp'" --memory-init-file 0 --js-library library.js
+JSFLAGS += -s EXTRA_EXPORTED_RUNTIME_METHODS="['ccall', 'cwrap']"
+JSFLAGS += -s EXPORTED_FUNCTIONS="['_mp_js_init', '_mp_js_init_repl', '_mp_js_do_str', '_mp_js_process_char', '_mp_hal_get_interrupt_char', '_mp_keyboard_interrupt']" 
 
 $(BUILD)/clang_predefs.h:
 	@emcc $(JSFLAGS) -E -x c /dev/null -dM > $@

--- a/ports/javascript/Makefile
+++ b/ports/javascript/Makefile
@@ -13,10 +13,19 @@ INC += -I.
 INC += -I$(TOP)
 INC += -I$(BUILD)
 
-#default debug options
-JSFLAGS ?= -O0 -g4 --source-map-base http://localhost:8000
+
 LDFLAGS ?= -m32 -Wl,--gc-sections
 CFLAGS ?= -m32
+
+#default debug options for browser debugger
+JSFLAGS ?= --source-map-base http://localhost:8000
+
+#Debugging/Optimization
+ifeq ($(DEBUG), 1)
+CFLAGS += -O0 -g4
+else
+CFLAGS += -Oz -g0 -DNDEBUG
+endif
 
 ifdef EMSCRIPTEN
 	# only for profiling, remove -s EMTERPRETIFY_ADVISE=1 when your EMTERPRETIFY_WHITELIST is ok

--- a/ports/javascript/Makefile
+++ b/ports/javascript/Makefile
@@ -13,13 +13,29 @@ INC += -I.
 INC += -I$(TOP)
 INC += -I$(BUILD)
 
-CPP = clang -E
-
 ifdef EMSCRIPTEN
-	CPP += -D__EMSCRIPTEN__
-	CPP += --sysroot $(EMSCRIPTEN)/system
-	CPP += -isystem $(EMSCRIPTEN)/system/include/libc
-	CPP += -cxx-isystem $(EMSCRIPTEN)/system/include/libcxx
+	# only for profiling, remove -s EMTERPRETIFY_ADVISE=1 when your EMTERPRETIFY_WHITELIST is ok
+	# not using an emterpreting list *is* bad and will lead to poor performance and huge binary.
+	ifdef ASYNC
+		CFLAGS += -D__EMTERPRETER__=1 
+		CFLAGS += -s EMTERPRETIFY=1 -s EMTERPRETIFY_ASYNC=1 -s 'EMTERPRETIFY_FILE="micropython.binary"'
+		CFLAGS += -s EMTERPRETIFY_SYNCLIST='["_mp_execute_bytecode"]' -s EMTERPRETIFY_ADVISE=1
+	endif
+
+	CC = emcc
+	CPP = clang -E -D__CPP__ -D__EMSCRIPTEN__
+	CPP += --sysroot $(EMSCRIPTEN)/system	
+	CPP += $(addprefix -isystem, $(shell env LC_ALL=C $(CC) $(CFLAGS_EXTRA) -E -x c++ /dev/null -v 2>&1 |sed -e '/^\#include <...>/,/^End of search/{ //!b };d'))
+	# Act like 'emcc'
+	CPP += -U__i386 -U__i386 -Ui386 -U__SSE -U__SSE_MATH -U__SSE2 -U__SSE2_MATH -U__MMX__ -U__SSE__ -U__SSE_MATH__ -U__SSE2__ -U__SSE2_MATH__
+else
+	ifdef CLANG
+		CC=clang
+		CPP=clang -E -D__CPP__
+	else
+		CC = gcc
+		CPP = gcc -E -D__CPP__
+	endif
 endif
 
 CFLAGS = -m32 -Wall -Werror $(INC) -std=c99 $(COPT)

--- a/ports/javascript/Makefile
+++ b/ports/javascript/Makefile
@@ -6,9 +6,6 @@ QSTR_DEFS = qstrdefsport.h
 
 include $(TOP)/py/py.mk
 
-CC = emcc
-LD = emcc
-
 INC += -I.
 INC += -I$(TOP)
 INC += -I$(BUILD)
@@ -27,8 +24,13 @@ else
 CFLAGS += -Oz -g0 -DNDEBUG
 endif
 
-CFLAGS += -Wall -Werror $(INC) -std=c99 $(COPT)
-CFLAGS += -fdata-sections -ffunction-sections
+CFLAGS += -Wall -Werror $(INC) -std=gnu11 $(COPT)
+CFLAGS += -fdata-sections -ffunction-sections -Wno-error=unused-function
+
+JSFLAGS += -s WASM=0
+JSFLAGS += --memory-init-file 0 --js-library library.js
+JSFLAGS += -s EXTRA_EXPORTED_RUNTIME_METHODS="['ccall', 'cwrap']"
+JSFLAGS += -s EXPORTED_FUNCTIONS="['_mp_js_init', '_mp_js_init_repl', '_mp_js_do_str', '_mp_js_process_char', '_mp_hal_get_interrupt_char', '_mp_keyboard_interrupt' ]" 
 
 ifdef EMSCRIPTEN
 	# only for profiling, remove -s EMTERPRETIFY_ADVISE=1 when your EMTERPRETIFY_WHITELIST is ok
@@ -45,10 +47,11 @@ ifdef EMSCRIPTEN
 		LDFLAGS += -Wl,-Map=$@.map,--cref
 	endif  
 	
-	CC = emcc
-	CPP = clang -E -undef -D__CPP__ -D__EMSCRIPTEN__
+	CC = emcc $(JSFLAGS)
+	LD = emcc $(JSFLAGS)
+	CPP = clang -E -undef -D__CPP__ -D__EMSCRIPTEN__ -U__STDC_VERSION__
 	CPP += --sysroot $(EMSCRIPTEN)/system
-	CPP += -include $(BUILD)/clang_predefs.h	
+	CPP += -include $(BUILD)/clang_predefs.h
 	CPP += $(addprefix -isystem, $(shell env LC_ALL=C $(CC) $(CFLAGS_EXTRA) -E -x c++ /dev/null -v 2>&1 |sed -e '/^\#include <...>/,/^End of search/{ //!b };d'))
 else
 	ifdef CLANG
@@ -72,15 +75,14 @@ SRC_C = \
 	mphalport.c \
 	modutime.c \
 
-SRC_QSTR += $(SRC_C)
+
+SRC_C += $(SRC_MOD)
+
+SRC_QSTR += $(BUILD)/clang_predefs.h $(SRC_C) $(SRC_LIB)
 
 OBJ = $(PY_O) 
 OBJ += $(addprefix $(BUILD)/, $(SRC_LIB:.c=.o))
 OBJ += $(addprefix $(BUILD)/, $(SRC_C:.c=.o))
-
-JSFLAGS += --memory-init-file 0 --js-library library.js
-JSFLAGS += -s EXTRA_EXPORTED_RUNTIME_METHODS="['ccall', 'cwrap']"
-JSFLAGS += -s EXPORTED_FUNCTIONS="['_mp_js_init', '_mp_js_init_repl', '_mp_js_do_str', '_mp_js_process_char', '_mp_hal_get_interrupt_char', '_mp_keyboard_interrupt']" 
 
 $(BUILD)/clang_predefs.h:
 	$(Q)mkdir -p $(dir $@)

--- a/ports/javascript/Makefile
+++ b/ports/javascript/Makefile
@@ -1,7 +1,5 @@
 include ../../py/mkenv.mk
 
-CROSS = 0
-
 QSTR_DEFS = qstrdefsport.h
 
 include $(TOP)/py/py.mk
@@ -11,19 +9,6 @@ INC += -I$(TOP)
 INC += -I$(BUILD)
 
 
-LDFLAGS ?= -m32 -Wl,--gc-sections
-CFLAGS ?= -m32
-
-#default debug options for browser debugger
-JSFLAGS ?= --source-map-base http://localhost:8000
-
-#Debugging/Optimization
-ifeq ($(DEBUG), 1)
-CFLAGS += -O0 -g4
-else
-CFLAGS += -Oz -g0 -DNDEBUG
-endif
-
 CFLAGS += -Wall -Werror $(INC) -std=gnu11 $(COPT)
 CFLAGS += -fdata-sections -ffunction-sections
 CFLAGS += $(CFLAGS_MOD)
@@ -31,29 +16,37 @@ CFLAGS += $(CFLAGS_MOD)
 JSFLAGS += -s WASM=0
 JSFLAGS += --memory-init-file 0 --js-library library.js
 JSFLAGS += -s EXTRA_EXPORTED_RUNTIME_METHODS="['ccall', 'cwrap']"
-JSFLAGS += -s EXPORTED_FUNCTIONS="['_mp_js_init', '_mp_js_init_repl', '_mp_js_do_str', '_mp_js_process_char', '_mp_hal_get_interrupt_char', '_mp_keyboard_interrupt' ]" 
+JSFLAGS += -s EXPORTED_FUNCTIONS="['_mp_js_init', '_mp_js_init_repl',\
+ '_mp_js_do_str', '_mp_js_process_char',\
+ '_mp_hal_get_interrupt_char', '_mp_keyboard_interrupt' ]"
+
 
 ifdef EMSCRIPTEN
-	# only for profiling, remove -s EMTERPRETIFY_ADVISE=1 when your EMTERPRETIFY_WHITELIST is ok
-	# not using an emterpreting list *is* bad and will lead to poor performance and huge binary.
-	ifdef ASYNC
-		CFLAGS += -D__EMTERPRETER__=1 
-		CFLAGS += -s EMTERPRETIFY=1 -s EMTERPRETIFY_ASYNC=1 -s 'EMTERPRETIFY_FILE="micropython.binary"'
-		CFLAGS += -s EMTERPRETIFY_SYNCLIST='["_mp_execute_bytecode"]' -s EMTERPRETIFY_ADVISE=1
-	endif
 
+	#Debugging/Optimization
+	ifeq ($(DEBUG), 1)
+	CFLAGS += -O0 -g4
+	else
+	CFLAGS += -Oz -g0 -DNDEBUG
+	endif
+	
 	#check if not using emscripten-upstream branch
 	ifeq (,$(findstring upstream/bin, $(EMMAKEN_COMPILER)))
 		JSFLAGS += -s "BINARYEN_TRAP_MODE='clamp'"
-		LDFLAGS += -Wl,-Map=$@.map,--cref
 	endif  
+
+	#default debug options for browser debugger
+	JSFLAGS ?= --source-map-base http://localhost:8000
 	
 	CC = emcc $(JSFLAGS)
-	LD = emcc $(JSFLAGS)
+	LD = emcc $(JSFLAGS) $(LDFLAGS)
 	CPP = clang -E -undef -D__CPP__ -D__EMSCRIPTEN__ -U__STDC_VERSION__
 	CPP += --sysroot $(EMSCRIPTEN)/system
 	CPP += -include $(BUILD)/clang_predefs.h
-	CPP += $(addprefix -isystem, $(shell env LC_ALL=C $(CC) $(CFLAGS_EXTRA) -E -x c++ /dev/null -v 2>&1 |sed -e '/^\#include <...>/,/^End of search/{ //!b };d'))
+	CPP += $(addprefix -isystem, $(shell env LC_ALL=C $(CC) $(CFLAGS_EXTRA) -E -x c++ /dev/null -v 2>&1\
+ |sed -e '/^\#include <...>/,/^End of search/{ //!b };d'))
+ 
+
 else
 	ifdef CLANG
 		CC=clang
@@ -97,7 +90,7 @@ all: $(BUILD)/micropython.js
 
 $(BUILD)/micropython.js: $(OBJ) library.js wrapper.js
 	$(ECHO) "LINK $(BUILD)/firmware.js"
-	$(Q)emcc $(LDFLAGS) -o $(BUILD)/firmware.js $(OBJ) $(JSFLAGS)
+	$(Q)$(LD) -o $(BUILD)/firmware.js $(OBJ)
 	cat wrapper.js $(BUILD)/firmware.js > $@
 
 min: $(BUILD)/micropython.js
@@ -105,6 +98,13 @@ min: $(BUILD)/micropython.js
 
 test: $(BUILD)/micropython.js $(TOP)/tests/run-tests
 	$(eval DIRNAME=ports/$(notdir $(CURDIR)))
-	cd $(TOP)/tests && MICROPY_MICROPYTHON=../ports/javascript/node_run.sh ./run-tests
+
+# works with wasm + no nlr
+#	cd $(TOP)/tests &&\
+ MICROPY_CPYTHON3=python3 MICROPY_MICROPYTHON=../$(DIRNAME)/node_run.sh PATH=../$(DIRNAME):${PATH}\
+ ./run-tests-exp.sh
+
+# often broken !
+	cd $(TOP)/tests && MICROPY_CPYTHON3=python3 MICROPY_MICROPYTHON=../$(DIRNAME)/node_run.sh ./run-tests
 
 include $(TOP)/py/mkrules.mk

--- a/ports/javascript/Makefile
+++ b/ports/javascript/Makefile
@@ -26,6 +26,7 @@ endif
 
 CFLAGS += -Wall -Werror $(INC) -std=gnu11 $(COPT)
 CFLAGS += -fdata-sections -ffunction-sections -Wno-error=unused-function
+CFLAGS += $(CFLAGS_MOD)
 
 JSFLAGS += -s WASM=0
 JSFLAGS += --memory-init-file 0 --js-library library.js

--- a/ports/javascript/Makefile
+++ b/ports/javascript/Makefile
@@ -74,7 +74,12 @@ JSFLAGS += -s EXTRA_EXPORTED_RUNTIME_METHODS="['ccall', 'cwrap']"
 JSFLAGS += -s EXPORTED_FUNCTIONS="['_mp_js_init', '_mp_js_init_repl', '_mp_js_do_str', '_mp_js_process_char', '_mp_hal_get_interrupt_char', '_mp_keyboard_interrupt']" 
 
 $(BUILD)/clang_predefs.h:
-	@emcc $(CFLAGS) $(CFLAGS_EXTRA) $(JSFLAGS) -E -x c /dev/null -dM > $@
+        $(Q)mkdir -p $@
+	$(Q)emcc $(CFLAGS) $(CFLAGS_EXTRA) $(JSFLAGS) -E -x c /dev/null -dM > $@
+
+# Create `clang_predefs.h` as soon as possible, using a Makefile trick
+
+Makefile: $(BUILD)/clang_predefs.h
 
 all: $(BUILD)/micropython.js
 

--- a/tests/run-tests-exp.sh
+++ b/tests/run-tests-exp.sh
@@ -6,7 +6,7 @@
 #
 
 RM="rm -f"
-MP_PY=micropython
+MP_PY=${MICROPY_MICROPYTHON:-micropython}
 
 numtests=0
 numtestcases=0


### PR DESCRIPTION
because emcc looks by itself into that ports folders cache but clang -E cannot.

This way if a header is missing clang used as preprocessor won't tap by default in /usr/include.

It will break build and will force user to explicitly add 
-I$(EM_CACHE)/asmjs/ports-builds/****somelib*****/include for his libs.