### PR TITLE
stm32/mboot: Automatically reboot when USB is disconnected.

### DIFF
--- a/ports/stm32/mboot/main.c
+++ b/ports/stm32/mboot/main.c
@@ -1526,6 +1526,9 @@ enter_bootloader:
     uint32_t ss = systick_ms;
     int ss2 = -1;
     #endif
+    #if MBOOT_REBOOT_ON_DISCONNECT
+    bool has_connected = false;
+    #endif
     for (;;) {
         #if USE_USB_POLLING
         #if MBOOT_USB_AUTODETECT_PORT || MICROPY_HW_USB_MAIN_DEV == USB_PHY_FS_ID
@@ -1558,6 +1561,15 @@ enter_bootloader:
         mp_hal_delay_ms(50);
         led_state(LED0, 0);
         mp_hal_delay_ms(950);
+        #endif
+
+        #if MBOOT_REBOOT_ON_DISCONNECT
+        if (pyb_usbdd.hUSBDDevice.dev_state == USBD_STATE_CONFIGURED) {
+            has_connected = true;
+        }
+        if (has_connected && pyb_usbdd.hUSBDDevice.dev_state == USBD_STATE_SUSPENDED) {
+            do_reset();
+        }
         #endif
     }
 }


### PR DESCRIPTION
This mboot PR detects when USB is disconnected (after being connected) and automatically resets back out of mboot mode.

I'm not confident my method is the cleanest, though from a search online of stm hal related posts I couldn't see a particularly official way of detecting disconnects.

In our (battery powered) application, it's not always obvious when the unit is in mboot mode (our user leds are via i2c driver so not as easily used in mboot). As such we can have a user thinking the unit is powered down, but the unit doesn't respond as expected due to it actually still running mboot. 

When the unit automatically resets itself after being unplugged from USB these concerns disappear.

