### PR TITLE
py/asmarm: use __clear_cache on Linux/GCC

### DIFF
--- a/py/asmarm.c
+++ b/py/asmarm.c
@@ -40,7 +40,11 @@
 
 void asm_arm_end_pass(asm_arm_t *as) {
     if (as->base.pass == MP_ASM_PASS_EMIT) {
-#ifdef __arm__
+#if defined(__linux__) && defined(__GNUC__)
+	char *start = mp_asm_base_get_code(&as->base);
+	char *end = start + mp_asm_base_get_code_size(&as->base);
+	__clear_cache(start, end);
+#elif defined(__arm__)
         // flush I- and D-cache
         asm volatile(
                 "0:"


### PR DESCRIPTION
Comes from https://community.arm.com/developer/ip-products/processors/b/processors-ip-blog/posts/caches-and-self-modifying-code

This fixes a crash when running micropython using qemu-arm.