### PR TITLE
tests/run-tests: add MICROPY_EXEC_WRAPPER env var

### DIFF
--- a/tests/run-tests
+++ b/tests/run-tests
@@ -18,6 +18,10 @@ else:
     CPYTHON3 = os.getenv('MICROPY_CPYTHON3', 'python3')
     MICROPYTHON = os.getenv('MICROPY_MICROPYTHON', '../ports/unix/micropython')
 
+# MICROPY_WRAPPER can be used to wrap the micropython executable in another
+# executable, for example to set up a special environment
+WRAPPER = os.getenv('MICROPY_EXEC_WRAPPER', '').split()
+
 # mpy-cross is only needed if --via-mpy command-line arg is passed
 MPYCROSS = os.getenv('MICROPY_MPYCROSS', '../mpy-cross/mpy-cross')
 
@@ -64,6 +68,8 @@ def run_micropython(pyb, args, test_file, is_special=False):
         if is_special:
             # check for any cmdline options needed for this test
             args = [MICROPYTHON]
+            if WRAPPER:
+                args[:0] = WRAPPER
             with open(test_file, 'rb') as f:
                 line = f.readline()
                 if line.startswith(b'# cmdline:'):
@@ -125,6 +131,8 @@ def run_micropython(pyb, args, test_file, is_special=False):
 
             # create system command
             cmdlist = [MICROPYTHON, '-X', 'emit=' + args.emit]
+            if WRAPPER:
+                cmdlist[:0] = WRAPPER
             if args.heapsize is not None:
                 cmdlist.extend(['-X', 'heapsize=' + args.heapsize])
 


### PR DESCRIPTION
This adds an optional MICROPY_EXEC_WRAPPER environment variable
to the run-tests script. This allows wrapping the micropython executable
in another executable. This is useful for testing where a wrapper can be
used to create a special environment for running tests.

The name come from the exec-wrapper command in gdb which has a
similar purpose.