### PR TITLE
py/persistentcode.c: silence warning while adding code save for a port.

### DIFF
--- a/py/persistentcode.c
+++ b/py/persistentcode.c
@@ -337,7 +337,7 @@ STATIC mp_raw_code_t *load_raw_code(mp_reader_t *reader, qstr_window_t *qw) {
     byte *ip2;
     bytecode_prelude_t prelude = {0};
     #if MICROPY_EMIT_MACHINE_CODE
-    size_t prelude_offset;
+    size_t prelude_offset = 0;
     mp_uint_t type_sig = 0;
     size_t n_qstr_link = 0;
     #endif


### PR DESCRIPTION
```
../../py/persistentcode.c: In function 'load_raw_code':
../../py/persistentcode.c:340:12: error: 'prelude_offset' may be used uninitialized in this function [-Werror=maybe-uninitialized]
     size_t prelude_offset;
```