### PR TITLE
esp32/network_ppp: added ppp_set_usepeerdns(self->pcb, 1);

### DIFF
--- a/ports/esp32/network_ppp.c
+++ b/ports/esp32/network_ppp.c
@@ -130,6 +130,7 @@ STATIC mp_obj_t ppp_active(size_t n_args, const mp_obj_t *args) {
                 mp_raise_msg(&mp_type_RuntimeError, "init failed");
             }
             pppapi_set_default(self->pcb);
+	    ppp_set_usepeerdns(self->pcb, 1);
             pppapi_connect(self->pcb, 0);
 
             xTaskCreate(pppos_client_task, "ppp", 2048, self, 1, (TaskHandle_t*)&self->client_task_handle);


### PR DESCRIPTION
Without this, you often don't get any DNS server from your network provider. Additionally,
setting your own DNS _does not work_ without this option set; this is almost certainly
a bug in the PPP stack.