### PR TITLE
port-javascript: what ways about external imports

### DIFF
--- a/py/builtinimport.c
+++ b/py/builtinimport.c
@@ -45,6 +45,9 @@
 #endif
 
 #if MICROPY_ENABLE_EXTERNAL_IMPORT
+#if __EMSCRIPTEN__
+#include "stdlib.h"
+#endif
 
 #define PATH_SEP_CHAR '/'
 
@@ -145,11 +148,16 @@ STATIC void do_load_from_lexer(mp_obj_t module_obj, mp_lexer_t *lex) {
 #endif
 
 #if MICROPY_PERSISTENT_CODE_LOAD || MICROPY_MODULE_FROZEN_MPY
+#if MICROPY_PY___FILE__
+STATIC void do_execute_raw_code(mp_obj_t module_obj, mp_raw_code_t *raw_code, const char* source_name) {
+#else
 STATIC void do_execute_raw_code(mp_obj_t module_obj, mp_raw_code_t *raw_code) {
+#endif
     #if MICROPY_PY___FILE__
-    // TODO
-    //qstr source_name = lex->source_name;
-    //mp_store_attr(module_obj, MP_QSTR___file__, MP_OBJ_NEW_QSTR(source_name));
+    if (source_name!=NULL){
+        mp_store_attr(module_obj, MP_QSTR___file__, MP_OBJ_NEW_QSTR(qstr_from_str(source_name)));
+    } else
+        mp_store_attr(module_obj, MP_QSTR___file__, MP_OBJ_NEW_QSTR(qstr_from_str("<stdin>") ));
     #endif
 
     // execute the module in its context
@@ -206,7 +214,11 @@ STATIC void do_load(mp_obj_t module_obj, vstr_t *file) {
     // its data) in the list of frozen files, execute it.
     #if MICROPY_MODULE_FROZEN_MPY
     if (frozen_type == MP_FROZEN_MPY) {
+        #if MICROPY_PY___FILE__
+        do_execute_raw_code(module_obj, modref, file_str);
+        #else
         do_execute_raw_code(module_obj, modref);
+        #endif
         return;
     }
     #endif
@@ -216,7 +228,11 @@ STATIC void do_load(mp_obj_t module_obj, vstr_t *file) {
     #if MICROPY_HAS_FILE_READER && MICROPY_PERSISTENT_CODE_LOAD
     if (file_str[file->len - 3] == 'm') {
         mp_raw_code_t *raw_code = mp_raw_code_load_file(file_str);
+        #if MICROPY_PY___FILE__
+        do_execute_raw_code(module_obj, raw_code, file_str);
+        #else
         do_execute_raw_code(module_obj, raw_code);
+        #endif
         return;
     }
     #endif
@@ -224,8 +240,36 @@ STATIC void do_load(mp_obj_t module_obj, vstr_t *file) {
     // If we can compile scripts then load the file and compile and execute it.
     #if MICROPY_ENABLE_COMPILER
     {
+        #if __EMSCRIPTEN__
+        FILE *file = fopen(file_str,"r");
+        if (!file) {
+            fprintf(stderr, "do_load: fopen(%s) failed\n", file_str);
+            return;
+        }
+
+        fseeko(file, 0, SEEK_END);
+        off_t size_of_file = ftello(file);
+        fprintf(stderr, "mp_lexer_new_from_file(%s size=%lld)\n", file_str, (long long)size_of_file );
+        fseeko(file, 0, SEEK_SET);
+
+        char * cbuf = malloc(size_of_file+1);
+
+        if (cbuf == NULL) {
+            fprintf(stderr, "do_load:(%s size=%lld) malloc error\n", file_str, (long long)size_of_file );
+            return;
+        }
+
+        fread(cbuf, size_of_file, 1, file);
+        cbuf[size_of_file]=0;
+        fclose(file);
+
+        mp_lexer_t* lex = mp_lexer_new_from_str_len(qstr_from_str(file_str), cbuf, strlen(cbuf), 0);
+        do_load_from_lexer(module_obj, lex);
+        free(cbuf);
+        #else
         mp_lexer_t *lex = mp_lexer_new_from_file(file_str);
         do_load_from_lexer(module_obj, lex);
+        #endif
         return;
     }
     #else


### PR DESCRIPTION
- the ```.__file__``` support should be valid for all ports, it was a TODO

- this PR allow for use of MICROPY_ENABLE_EXTERNAL_IMPORT.

- it is probably not usefull to optimize file reading, since synchronous file reading shoud be avoided on javascript this is just for script compatibility with other ports.
    files are expected to be found whole in memfs, embed them via ```--preload-file``` or file packager.