### PR TITLE
py/asmarm: use __builtin___clear_cache instead of __clear_cache

### DIFF
--- a/py/asmarm.c
+++ b/py/asmarm.c
@@ -41,9 +41,9 @@
 void asm_arm_end_pass(asm_arm_t *as) {
     if (as->base.pass == MP_ASM_PASS_EMIT) {
 #if defined(__linux__) && defined(__GNUC__)
-	char *start = mp_asm_base_get_code(&as->base);
-	char *end = start + mp_asm_base_get_code_size(&as->base);
-	__clear_cache(start, end);
+        char *start = mp_asm_base_get_code(&as->base);
+        char *end = start + mp_asm_base_get_code_size(&as->base);
+        __builtin___clear_cache(start, end);
 #elif defined(__arm__)
         // flush I- and D-cache
         asm volatile(


### PR DESCRIPTION
`__clear_cache` causes compiler error when using clang.

    ../py/asmarm.c:46:2: error: implicit declaration of function '__clear_cache' is
          invalid in C99 [-Werror,-Wimplicit-function-declaration]
            __clear_cache(start, end);
            ^

Also replace tabs with spaces.