### PR TITLE
py/makeqstrdata: allow using \r\n as a QSTR if a port requires it

### DIFF
--- a/py/makeqstrdata.py
+++ b/py/makeqstrdata.py
@@ -282,6 +282,9 @@ def parse_input_headers(infiles):
                 # special case to specify control characters
                 if qstr == '\\n':
                     qstr = '\n'
+                    
+                if qstr == '\\r\\n':
+                    qstr = '\r\n'
 
                 # work out the corresponding qstr name
                 ident = qstr_escape(qstr)


### PR DESCRIPTION
MP_ROM_QSTR(MP_QSTR__0x0d__0x0a_) is usefull i you don't want to or can cook the terminal line because of a port specific stdio handling.
eg javascript port + xterm.js when  could benefit changing end="\n" to "\r\n" here https://github.com/micropython/micropython/blob/7c2e83324b1abfbec2bfaee2c60b50ceb3f9185a/py/modbuiltins.c#L402