### PR TITLE
travis: Switch unix stackless build to use clang.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -106,13 +106,14 @@ jobs:
 
     # unix stackless
     - stage: test
-      env: NAME="unix stackless port build and tests"
+      env: NAME="unix stackless port build and tests with clang"
+      install:
+        - sudo apt-get install clang
       script:
         - git submodule update --init lib/axtls lib/berkeley-db-1.xx lib/libffi
-        - make ${MAKEOPTS} -C mpy-cross
-        - make ${MAKEOPTS} -C ports/unix deplibs
-        - make ${MAKEOPTS} -C ports/unix CFLAGS_EXTRA="-DMICROPY_STACKLESS=1 -DMICROPY_STACKLESS_STRICT=1"
-        - make ${MAKEOPTS} -C ports/unix test
+        - make ${MAKEOPTS} -C mpy-cross CC=clang
+        - make ${MAKEOPTS} -C ports/unix CC=clang CFLAGS_EXTRA="-DMICROPY_STACKLESS=1 -DMICROPY_STACKLESS_STRICT=1"
+        - make ${MAKEOPTS} -C ports/unix CC=clang test
 
     # windows port via mingw
     - stage: test

--- a/tests/stress/recursive_iternext.py
+++ b/tests/stress/recursive_iternext.py
@@ -14,7 +14,7 @@ except:
 try:
     # large stack/heap, eg unix
     [0] * 80000
-    N = 2400
+    N = 5000
 except:
     try:
         # medium, eg pyboard


### PR DESCRIPTION
To test a different compiler, other than gcc.

Also might be worth adding circleci as an additional CI to test Mac explicitly.