### PR TITLE
port-javascript: handle FROZEN_MPY_DIR 

### DIFF
--- a/ports/javascript/Makefile
+++ b/ports/javascript/Makefile
@@ -25,14 +25,17 @@ LDFLAGS = -m32 -Wl,-Map=$@.map,--cref -Wl,--gc-sections
 CFLAGS += -O0 -DNDEBUG
 CFLAGS += -fdata-sections -ffunction-sections
 
-ifdef FROZEN_MPY_DIR
-	CFLAGS += -DFROZEN_MPY_DIR=$(FROZEN_MPY_DIR)
-	CFLAGS += -DMICROPY_MODULE_FROZEN=1
-	CFLAGS += -DMICROPY_MODULE_FROZEN_MPY=1
-# //for qstr.c
-	CFLAGS +=-DMICROPY_QSTR_EXTRA_POOL=mp_qstr_frozen_const_pool
-# //for build/genhdr/qstr.i.last
-	QSTR_GEN_EXTRA_CFLAGS=-DMICROPY_QSTR_EXTRA_POOL=mp_qstr_frozen_const_pool
+ifneq ($(FROZEN_DIR),)
+# To use frozen source modules, put your .py files in a subdirectory (eg scripts/)
+# and then invoke make with FROZEN_DIR=scripts (be sure to build from scratch).
+CFLAGS += -DMICROPY_MODULE_FROZEN_STR
+endif
+
+ifneq ($(FROZEN_MPY_DIR),)
+# To use frozen bytecode, put your .py files in a subdirectory (eg frozen/) and
+# then invoke make with FROZEN_MPY_DIR=frozen (be sure to build from scratch).
+CFLAGS += -DMICROPY_QSTR_EXTRA_POOL=mp_qstr_frozen_const_pool
+CFLAGS += -DMICROPY_MODULE_FROZEN_MPY
 endif
 
 SRC_LIB = $(addprefix lib/,\

--- a/ports/javascript/Makefile
+++ b/ports/javascript/Makefile
@@ -25,6 +25,10 @@ LDFLAGS = -m32 -Wl,-Map=$@.map,--cref -Wl,--gc-sections
 CFLAGS += -O0 -DNDEBUG
 CFLAGS += -fdata-sections -ffunction-sections
 
+ifdef FROZEN_MPY_DIR
+	CFLAGS += -DFROZEN_MPY_DIR=$(FROZEN_MPY_DIR)
+endif
+
 SRC_LIB = $(addprefix lib/,\
 	utils/interrupt_char.c \
 	utils/stdout_helpers.c \

--- a/ports/javascript/Makefile
+++ b/ports/javascript/Makefile
@@ -27,6 +27,8 @@ CFLAGS += -fdata-sections -ffunction-sections
 
 ifdef FROZEN_MPY_DIR
 	CFLAGS += -DFROZEN_MPY_DIR=$(FROZEN_MPY_DIR)
+	CFLAGS += -DMICROPY_MODULE_FROZEN=1
+	CFLAGS += -DMICROPY_MODULE_FROZEN_MPY=1
 # //for qstr.c
 	CFLAGS +=-DMICROPY_QSTR_EXTRA_POOL=mp_qstr_frozen_const_pool
 # //for build/genhdr/qstr.i.last

--- a/ports/javascript/Makefile
+++ b/ports/javascript/Makefile
@@ -27,6 +27,10 @@ CFLAGS += -fdata-sections -ffunction-sections
 
 ifdef FROZEN_MPY_DIR
 	CFLAGS += -DFROZEN_MPY_DIR=$(FROZEN_MPY_DIR)
+# //for qstr.c
+	CFLAGS +=-DMICROPY_QSTR_EXTRA_POOL=mp_qstr_frozen_const_pool
+# //for build/genhdr/qstr.i.last
+	QSTR_GEN_EXTRA_CFLAGS=-DMICROPY_QSTR_EXTRA_POOL=mp_qstr_frozen_const_pool
 endif
 
 SRC_LIB = $(addprefix lib/,\

--- a/ports/javascript/mpconfigport.h
+++ b/ports/javascript/mpconfigport.h
@@ -210,9 +210,3 @@ typedef long mp_off_t;
 
 #define MICROPY_PORT_ROOT_POINTERS \
     const char *readline_hist[8];
-
-#ifdef FROZEN_MPY_DIR
-#define MICROPY_MODULE_FROZEN       (1)
-#define MICROPY_MODULE_FROZEN_MPY   (1)
-#endif
-#define MICROPY_MODULE_FROZEN_STR   (0)

--- a/ports/javascript/mpconfigport.h
+++ b/ports/javascript/mpconfigport.h
@@ -210,3 +210,8 @@ typedef long mp_off_t;
 
 #define MICROPY_PORT_ROOT_POINTERS \
     const char *readline_hist[8];
+
+#ifdef FROZEN_MPY_DIR
+#define MICROPY_MODULE_FROZEN       (1)
+#define MICROPY_MODULE_FROZEN_MPY   (1)
+#endif

--- a/ports/javascript/mpconfigport.h
+++ b/ports/javascript/mpconfigport.h
@@ -214,5 +214,5 @@ typedef long mp_off_t;
 #ifdef FROZEN_MPY_DIR
 #define MICROPY_MODULE_FROZEN       (1)
 #define MICROPY_MODULE_FROZEN_MPY   (1)
-#define MICROPY_MODULE_FROZEN_STR   (1)
 #endif
+#define MICROPY_MODULE_FROZEN_STR   (0)

--- a/ports/javascript/mpconfigport.h
+++ b/ports/javascript/mpconfigport.h
@@ -214,4 +214,5 @@ typedef long mp_off_t;
 #ifdef FROZEN_MPY_DIR
 #define MICROPY_MODULE_FROZEN       (1)
 #define MICROPY_MODULE_FROZEN_MPY   (1)
+#define MICROPY_MODULE_FROZEN_STR   (1)
 #endif


### PR DESCRIPTION
tested on 1.9.3 with 2 .py in a folder called modules: one imp.py and an empty module
built with
```emmake make FROZEN_MPY_DIR=modules```