### PR TITLE
py/objgenerator: Add missing #if guard for PY_GENERATOR_PEND_THROW.

### DIFF
--- a/py/objgenerator.c
+++ b/py/objgenerator.c
@@ -297,6 +297,7 @@ STATIC mp_obj_t gen_instance_close(mp_obj_t self_in) {
 }
 STATIC MP_DEFINE_CONST_FUN_OBJ_1(gen_instance_close_obj, gen_instance_close);
 
+#if MICROPY_PY_GENERATOR_PEND_THROW
 STATIC mp_obj_t gen_instance_pend_throw(mp_obj_t self_in, mp_obj_t exc_in) {
     mp_obj_gen_instance_t *self = MP_OBJ_TO_PTR(self_in);
     if (self->code_state.sp == self->code_state.state - 1) {
@@ -307,6 +308,7 @@ STATIC mp_obj_t gen_instance_pend_throw(mp_obj_t self_in, mp_obj_t exc_in) {
     return prev;
 }
 STATIC MP_DEFINE_CONST_FUN_OBJ_2(gen_instance_pend_throw_obj, gen_instance_pend_throw);
+#endif
 
 STATIC const mp_rom_map_elem_t gen_instance_locals_dict_table[] = {
     { MP_ROM_QSTR(MP_QSTR_close), MP_ROM_PTR(&gen_instance_close_obj) },


### PR DESCRIPTION
Without it, gen_instance_pend_throw_obj is defined but not used
when MICROPY_PY_GENERATOR_PEND_THROW is set to 0.