### PR TITLE
esp32: Add esp32.Partition class to interface to OTA functions.

### DIFF
--- a/ports/esp32/Makefile
+++ b/ports/esp32/Makefile
@@ -106,6 +106,7 @@ INC_ESPCOMP += -I$(ESPCOMP)/mbedtls/mbedtls/include
 INC_ESPCOMP += -I$(ESPCOMP)/mbedtls/port/include
 INC_ESPCOMP += -I$(ESPCOMP)/mdns/include
 INC_ESPCOMP += -I$(ESPCOMP)/mdns/private_include
+INC_ESPCOMP += -I$(ESPCOMP)/micro-ecc/micro-ecc
 INC_ESPCOMP += -I$(ESPCOMP)/spi_flash/include
 INC_ESPCOMP += -I$(ESPCOMP)/ulp/include
 INC_ESPCOMP += -I$(ESPCOMP)/vfs/include
@@ -193,6 +194,7 @@ SRC_C = \
 	network_ppp.c \
 	modsocket.c \
 	modesp.c \
+	esp32_partition.c \
 	esp32_ulp.c \
 	modesp32.c \
 	espneopixel.c \
@@ -259,6 +261,10 @@ $(HEADER_BUILD)/qstrdefs.generated.h: $(SDKCONFIG_H)
 
 ################################################################################
 # List of object files from the ESP32 IDF components
+
+ESPIDF_BOOTLOADER_SUPPORT_O = $(subst .c,.o,\
+	$(filter-out $(ESPCOMP)/bootloader_support/src/bootloader_init.c,\
+		$(wildcard $(ESPCOMP)/bootloader_support/src/*.c)))
 
 ESPIDF_DRIVER_O = $(patsubst %.c,%.o,$(wildcard $(ESPCOMP)/driver/*.c))
 
@@ -371,6 +377,7 @@ $(BUILD_ESPIDF_LIB)/$(1)/lib$(1).a: $(addprefix $$(BUILD)/,$(2))
 	$(Q)$(AR) cru $$@ $$^
 endef
 
+$(eval $(call gen_espidf_lib_rule,bootloader_support,$(ESPIDF_BOOTLOADER_SUPPORT_O)))
 $(eval $(call gen_espidf_lib_rule,driver,$(ESPIDF_DRIVER_O)))
 $(eval $(call gen_espidf_lib_rule,efuse,$(ESPIDF_EFUSE_O)))
 $(eval $(call gen_espidf_lib_rule,esp32,$(ESPIDF_ESP32_O)))

--- a/ports/esp32/esp32_partition.c
+++ b/ports/esp32/esp32_partition.c
@@ -168,7 +168,6 @@ STATIC mp_obj_t esp32_partition_writeblocks(mp_obj_t self_in, mp_obj_t block_num
 }
 STATIC MP_DEFINE_CONST_FUN_OBJ_3(esp32_partition_writeblocks_obj, esp32_partition_writeblocks);
 
-// TODO could be an ioctl?
 STATIC mp_obj_t esp32_partition_eraseblocks(mp_obj_t self_in, mp_obj_t block_num, mp_obj_t size_in) {
     esp32_partition_obj_t *self = MP_OBJ_TO_PTR(self_in);
     uint32_t start_addr = mp_obj_get_int_truncated(block_num) * BLOCK_SIZE_BYTES;
@@ -195,7 +194,6 @@ STATIC const mp_rom_map_elem_t esp32_partition_locals_dict_table[] = {
     { MP_ROM_QSTR(MP_QSTR_find), MP_ROM_PTR(&esp32_partition_find_obj) },
 
     { MP_ROM_QSTR(MP_QSTR_info), MP_ROM_PTR(&esp32_partition_info_obj) },
-
     { MP_ROM_QSTR(MP_QSTR_readblocks), MP_ROM_PTR(&esp32_partition_readblocks_obj) },
     { MP_ROM_QSTR(MP_QSTR_writeblocks), MP_ROM_PTR(&esp32_partition_writeblocks_obj) },
     { MP_ROM_QSTR(MP_QSTR_eraseblocks), MP_ROM_PTR(&esp32_partition_eraseblocks_obj) },
@@ -203,10 +201,8 @@ STATIC const mp_rom_map_elem_t esp32_partition_locals_dict_table[] = {
     { MP_ROM_QSTR(MP_QSTR_set_boot), MP_ROM_PTR(&esp32_partition_set_boot_obj) },
     { MP_ROM_QSTR(MP_QSTR_get_next_update), MP_ROM_PTR(&esp32_partition_get_next_update_obj) },
 
-    { MP_ROM_QSTR(MP_QSTR_FIRST), MP_ROM_INT(ESP32_PARTITION_FIRST) },
     { MP_ROM_QSTR(MP_QSTR_BOOT), MP_ROM_INT(ESP32_PARTITION_BOOT) },
     { MP_ROM_QSTR(MP_QSTR_RUNNING), MP_ROM_INT(ESP32_PARTITION_RUNNING) },
-
     { MP_ROM_QSTR(MP_QSTR_TYPE_APP), MP_ROM_INT(ESP_PARTITION_TYPE_APP) },
     { MP_ROM_QSTR(MP_QSTR_TYPE_DATA), MP_ROM_INT(ESP_PARTITION_TYPE_DATA) },
 };

--- a/ports/esp32/esp32_partition.c
+++ b/ports/esp32/esp32_partition.c
@@ -1,0 +1,190 @@
+/*
+ * This file is part of the MicroPython project, http://micropython.org/
+ *
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2019 Damien P. George
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#include <string.h>
+
+#include "py/runtime.h"
+#include "py/mperrno.h"
+#include "modesp32.h"
+#include "esp_ota_ops.h"
+
+enum {
+    ESP32_PARTITION_FIRST,
+    ESP32_PARTITION_BOOT,
+    ESP32_PARTITION_RUNNING,
+};
+
+typedef struct _esp32_partition_obj_t {
+    mp_obj_base_t base;
+    const esp_partition_t *part;
+} esp32_partition_obj_t;
+
+static inline void check_esp_err(esp_err_t e) {
+    if (e != ESP_OK) {
+        mp_raise_OSError(-e);
+    }
+}
+
+STATIC esp32_partition_obj_t *esp32_partition_new(const esp_partition_t *part) {
+    if (part == NULL) {
+        mp_raise_OSError(MP_ENOENT);
+    }
+    esp32_partition_obj_t *self = m_new_obj(esp32_partition_obj_t);
+    self->base.type = &esp32_partition_type;
+    self->part = part;
+    return self;
+}
+
+STATIC void esp32_partition_print(const mp_print_t *print, mp_obj_t self_in, mp_print_kind_t kind) {
+    esp32_partition_obj_t *self = MP_OBJ_TO_PTR(self_in);
+    mp_printf(print, "<Partition type=%u, subtype=%u, address=%u, size=%u, label=%s, encrypted=%u>",
+        self->part->type, self->part->subtype,
+        self->part->address, self->part->size,
+        &self->part->label[0], self->part->encrypted
+    );
+}
+
+STATIC mp_obj_t esp32_partition_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *all_args) {
+    // Parse args
+    enum { ARG_id, ARG_type, ARG_subtype, ARG_label };
+    static const mp_arg_t allowed_args[] = {
+        { MP_QSTR_id, MP_ARG_REQUIRED | MP_ARG_INT },
+        { MP_QSTR_type, MP_ARG_KW_ONLY | MP_ARG_INT, {.u_int = ESP_PARTITION_TYPE_APP} },
+        { MP_QSTR_subtype, MP_ARG_KW_ONLY | MP_ARG_INT, {.u_int = ESP_PARTITION_SUBTYPE_ANY} },
+        { MP_QSTR_label, MP_ARG_KW_ONLY | MP_ARG_OBJ, {.u_rom_obj = MP_ROM_PTR(&mp_const_none_obj)} },
+    };
+    mp_arg_val_t args[MP_ARRAY_SIZE(allowed_args)];
+    mp_arg_parse_all_kw_array(n_args, n_kw, all_args, MP_ARRAY_SIZE(allowed_args), allowed_args, args);
+
+    // Get requested partition
+    const esp_partition_t *part;
+    switch (args[ARG_id].u_int) {
+        case ESP32_PARTITION_FIRST: {
+            const char *label = NULL;
+            if (args[ARG_label].u_obj != mp_const_none) {
+                label = mp_obj_str_get_str(args[ARG_label].u_obj);
+            }
+            part = esp_partition_find_first(args[ARG_type].u_int, args[ARG_subtype].u_int, label);
+            break;
+        }
+        case ESP32_PARTITION_BOOT:
+            part = esp_ota_get_boot_partition();
+            break;
+        case ESP32_PARTITION_RUNNING:
+            part = esp_ota_get_running_partition();
+            break;
+        default:
+            mp_raise_ValueError(NULL);
+    }
+
+    // Return new object
+    return MP_OBJ_FROM_PTR(esp32_partition_new(part));
+}
+
+STATIC mp_obj_t esp32_partition_metadata(mp_obj_t self_in) {
+    esp32_partition_obj_t *self = MP_OBJ_TO_PTR(self_in);
+    mp_obj_t tuple[] = {
+        MP_OBJ_NEW_SMALL_INT(self->part->type),
+        MP_OBJ_NEW_SMALL_INT(self->part->subtype),
+        mp_obj_new_int_from_uint(self->part->address),
+        mp_obj_new_int_from_uint(self->part->size),
+        mp_obj_new_str(&self->part->label[0], strlen(&self->part->label[0])),
+        mp_obj_new_bool(self->part->encrypted),
+    };
+    return mp_obj_new_tuple(6, tuple);
+}
+STATIC MP_DEFINE_CONST_FUN_OBJ_1(esp32_partition_metadata_obj, esp32_partition_metadata);
+
+// TODO different signature to readinto(buf[, maxlen])
+STATIC mp_obj_t esp32_partition_readinto(mp_obj_t self_in, mp_obj_t offset_in, mp_obj_t buf_in) {
+    esp32_partition_obj_t *self = MP_OBJ_TO_PTR(self_in);
+    uint32_t offset = mp_obj_get_int_truncated(offset_in);
+    mp_buffer_info_t bufinfo;
+    mp_get_buffer_raise(buf_in, &bufinfo, MP_BUFFER_WRITE);
+    check_esp_err(esp_partition_read(self->part, offset, bufinfo.buf, bufinfo.len));
+    return mp_const_none;
+}
+STATIC MP_DEFINE_CONST_FUN_OBJ_3(esp32_partition_readinto_obj, esp32_partition_readinto);
+
+// TODO different signature to write(buf[, maxlen]) / write(buf[, offset, maxlen])
+STATIC mp_obj_t esp32_partition_write(mp_obj_t self_in, mp_obj_t offset_in, mp_obj_t buf_in) {
+    esp32_partition_obj_t *self = MP_OBJ_TO_PTR(self_in);
+    uint32_t offset = mp_obj_get_int_truncated(offset_in);
+    mp_buffer_info_t bufinfo;
+    mp_get_buffer_raise(buf_in, &bufinfo, MP_BUFFER_READ);
+    check_esp_err(esp_partition_read(self->part, offset, bufinfo.buf, bufinfo.len));
+    return mp_const_none;
+}
+STATIC MP_DEFINE_CONST_FUN_OBJ_3(esp32_partition_write_obj, esp32_partition_write);
+
+STATIC mp_obj_t esp32_partition_erase(mp_obj_t self_in, mp_obj_t start_addr_in, mp_obj_t size_in) {
+    esp32_partition_obj_t *self = MP_OBJ_TO_PTR(self_in);
+    uint32_t start_addr = mp_obj_get_int_truncated(start_addr_in);
+    uint32_t size = mp_obj_get_int_truncated(size_in);
+    check_esp_err(esp_partition_erase_range(self->part, start_addr, size));
+    return mp_const_none;
+}
+STATIC MP_DEFINE_CONST_FUN_OBJ_3(esp32_partition_erase_obj, esp32_partition_erase);
+
+STATIC mp_obj_t esp32_partition_set_boot(mp_obj_t self_in) {
+    esp32_partition_obj_t *self = MP_OBJ_TO_PTR(self_in);
+    esp_ota_set_boot_partition(self->part);
+    return mp_const_none;
+}
+STATIC MP_DEFINE_CONST_FUN_OBJ_1(esp32_partition_set_boot_obj, esp32_partition_set_boot);
+
+STATIC mp_obj_t esp32_partition_get_next_update(mp_obj_t self_in) {
+    esp32_partition_obj_t *self = MP_OBJ_TO_PTR(self_in);
+    return MP_OBJ_FROM_PTR(esp32_partition_new(esp_ota_get_next_update_partition(self->part)));
+}
+STATIC MP_DEFINE_CONST_FUN_OBJ_1(esp32_partition_get_next_update_obj, esp32_partition_get_next_update);
+
+STATIC const mp_rom_map_elem_t esp32_partition_locals_dict_table[] = {
+    { MP_ROM_QSTR(MP_QSTR_metadata), MP_ROM_PTR(&esp32_partition_metadata_obj) },
+
+    { MP_ROM_QSTR(MP_QSTR_readinto), MP_ROM_PTR(&esp32_partition_readinto_obj) },
+    { MP_ROM_QSTR(MP_QSTR_write), MP_ROM_PTR(&esp32_partition_write_obj) },
+    { MP_ROM_QSTR(MP_QSTR_erase), MP_ROM_PTR(&esp32_partition_erase_obj) },
+
+    { MP_ROM_QSTR(MP_QSTR_set_boot), MP_ROM_PTR(&esp32_partition_set_boot_obj) },
+    { MP_ROM_QSTR(MP_QSTR_get_next_update), MP_ROM_PTR(&esp32_partition_get_next_update_obj) },
+
+    { MP_ROM_QSTR(MP_QSTR_FIRST), MP_ROM_INT(ESP32_PARTITION_FIRST) },
+    { MP_ROM_QSTR(MP_QSTR_BOOT), MP_ROM_INT(ESP32_PARTITION_BOOT) },
+    { MP_ROM_QSTR(MP_QSTR_RUNNING), MP_ROM_INT(ESP32_PARTITION_RUNNING) },
+
+    { MP_ROM_QSTR(MP_QSTR_TYPE_APP), MP_ROM_INT(ESP_PARTITION_TYPE_APP) },
+    { MP_ROM_QSTR(MP_QSTR_TYPE_DATA), MP_ROM_INT(ESP_PARTITION_TYPE_DATA) },
+};
+STATIC MP_DEFINE_CONST_DICT(esp32_partition_locals_dict, esp32_partition_locals_dict_table);
+
+const mp_obj_type_t esp32_partition_type = {
+    { &mp_type_type },
+    .name = MP_QSTR_Partition,
+    .print = esp32_partition_print,
+    .make_new = esp32_partition_make_new,
+    .locals_dict = (mp_obj_dict_t*)&esp32_partition_locals_dict,
+};

--- a/ports/esp32/esp32_partition.c
+++ b/ports/esp32/esp32_partition.c
@@ -109,7 +109,7 @@ STATIC mp_obj_t esp32_partition_make_new(const mp_obj_type_t *type, size_t n_arg
     return MP_OBJ_FROM_PTR(esp32_partition_new(part));
 }
 
-STATIC mp_obj_t esp32_partition_metadata(mp_obj_t self_in) {
+STATIC mp_obj_t esp32_partition_info(mp_obj_t self_in) {
     esp32_partition_obj_t *self = MP_OBJ_TO_PTR(self_in);
     mp_obj_t tuple[] = {
         MP_OBJ_NEW_SMALL_INT(self->part->type),
@@ -121,7 +121,7 @@ STATIC mp_obj_t esp32_partition_metadata(mp_obj_t self_in) {
     };
     return mp_obj_new_tuple(6, tuple);
 }
-STATIC MP_DEFINE_CONST_FUN_OBJ_1(esp32_partition_metadata_obj, esp32_partition_metadata);
+STATIC MP_DEFINE_CONST_FUN_OBJ_1(esp32_partition_info_obj, esp32_partition_info);
 
 STATIC mp_obj_t esp32_partition_readblocks(mp_obj_t self_in, mp_obj_t block_num, mp_obj_t buf_in) {
     esp32_partition_obj_t *self = MP_OBJ_TO_PTR(self_in);
@@ -167,7 +167,7 @@ STATIC mp_obj_t esp32_partition_get_next_update(mp_obj_t self_in) {
 STATIC MP_DEFINE_CONST_FUN_OBJ_1(esp32_partition_get_next_update_obj, esp32_partition_get_next_update);
 
 STATIC const mp_rom_map_elem_t esp32_partition_locals_dict_table[] = {
-    { MP_ROM_QSTR(MP_QSTR_metadata), MP_ROM_PTR(&esp32_partition_metadata_obj) },
+    { MP_ROM_QSTR(MP_QSTR_info), MP_ROM_PTR(&esp32_partition_info_obj) },
 
     { MP_ROM_QSTR(MP_QSTR_readblocks), MP_ROM_PTR(&esp32_partition_readblocks_obj) },
     { MP_ROM_QSTR(MP_QSTR_writeblocks), MP_ROM_PTR(&esp32_partition_writeblocks_obj) },

--- a/ports/esp32/modesp32.c
+++ b/ports/esp32/modesp32.c
@@ -154,6 +154,7 @@ STATIC const mp_rom_map_elem_t esp32_module_globals_table[] = {
     { MP_ROM_QSTR(MP_QSTR_raw_temperature), MP_ROM_PTR(&esp32_raw_temperature_obj) },
     { MP_ROM_QSTR(MP_QSTR_hall_sensor), MP_ROM_PTR(&esp32_hall_sensor_obj) },
 
+    { MP_ROM_QSTR(MP_QSTR_Partition), MP_ROM_PTR(&esp32_partition_type) },
     { MP_ROM_QSTR(MP_QSTR_ULP), MP_ROM_PTR(&esp32_ulp_type) },
 
     { MP_ROM_QSTR(MP_QSTR_WAKEUP_ALL_LOW), MP_ROM_PTR(&mp_const_false_obj) },

--- a/ports/esp32/modesp32.h
+++ b/ports/esp32/modesp32.h
@@ -26,6 +26,7 @@
 #define RTC_LAST_EXT_PIN 39
 #define RTC_IS_VALID_EXT_PIN(pin_id) ((1ll << (pin_id)) & RTC_VALID_EXT_PINS)
 
+extern const mp_obj_type_t esp32_partition_type;
 extern const mp_obj_type_t esp32_ulp_type;
 
 #endif // MICROPY_INCLUDED_ESP32_MODESP32_H


### PR DESCRIPTION
Following on from the comment https://github.com/micropython/micropython/pull/3576#issuecomment-486954865 here is a proposal for a wrapper class for the ESP32 OTA/partition functions.

The API is based around a single Partition class.  The constructor is used to create new Partition objects, and methods manipulate such objects.

```python
from esp32 import Partition

# Constructors
Partition(Partition.FIRST, type=Partition.TYPE_APP)
Partition(Partition.FIRST, type=Partition.TYPE_DATA)
Partition(Partition.FIRST, type=Partition.TYPE_DATA, subtype=2, label='nvs')
Partition(Partition.BOOT) # get boot partition
Partition(Partition.RUNNING) # get currently running partition

# Methods
part.info() # returns a 6-tuple of (type, subtype, addr, size, label, encr)
part.readblocks(block_num, buf)
part.writeblocks(block_num, buf)
part.eraseblocks(block_num, size)
part.set_boot() # sets current as bootable, for next reset
part.get_next_update() # returns new Partition
```
I didn't yet test the OTA functionality

Edit: updated signatures for partition methods.