### PR TITLE
esp32: Add support for hardware I2C.

### DIFF
--- a/docs/esp32/quickref.rst
+++ b/docs/esp32/quickref.rst
@@ -303,13 +303,21 @@ Hardware SPI has the same methods as Software SPI above::
 I2C bus
 -------
 
-The I2C driver is implemented in software and works on all pins,
-and is accessed via the :ref:`machine.I2C <machine.I2C>` class::
+The I2C driver has both software and hardware implementations, and the two
+hardware peripherals have identifiers 0 and 1.  Any available output-capable
+pins can be used for SCL and SDA.  The driver is accessed via the
+:ref:`machine.I2C <machine.I2C>` class::
 
     from machine import Pin, I2C
 
-    # construct an I2C bus
+    # construct a software I2C bus
     i2c = I2C(scl=Pin(5), sda=Pin(4), freq=100000)
+
+    # construct a hardware I2C bus
+    i2c = I2C(0)
+    i2c = I2C(1, scl=Pin(5), sda=Pin(4), freq=400000)
+
+    i2c.scan()              # scan for slave devices
 
     i2c.readfrom(0x3a, 4)   # read 4 bytes from slave device with address 0x3a
     i2c.writeto(0x3a, '12') # write '12' to slave device with address 0x3a

--- a/ports/esp32/Makefile
+++ b/ports/esp32/Makefile
@@ -181,6 +181,7 @@ SRC_C = \
 	machine_touchpad.c \
 	machine_adc.c \
 	machine_dac.c \
+	machine_i2c.c \
 	machine_pwm.c \
 	machine_uart.c \
 	modmachine.c \

--- a/ports/esp32/machine_i2c.c
+++ b/ports/esp32/machine_i2c.c
@@ -1,0 +1,179 @@
+/*
+ * This file is part of the MicroPython project, http://micropython.org/
+ *
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2019 Damien P. George
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#include "py/runtime.h"
+#include "py/mphal.h"
+#include "py/mperrno.h"
+#include "extmod/machine_i2c.h"
+
+#include "driver/i2c.h"
+
+#define I2C_0_DEFAULT_SCL (GPIO_NUM_18)
+#define I2C_0_DEFAULT_SDA (GPIO_NUM_19)
+#define I2C_1_DEFAULT_SCL (GPIO_NUM_25)
+#define I2C_1_DEFAULT_SDA (GPIO_NUM_26)
+
+#define I2C_DEFAULT_TIMEOUT_US (10000) // 10ms
+
+typedef struct _machine_hw_i2c_obj_t {
+    mp_obj_base_t base;
+    i2c_port_t port : 8;
+    gpio_num_t scl : 8;
+    gpio_num_t sda : 8;
+} machine_hw_i2c_obj_t;
+
+STATIC const mp_obj_type_t machine_hw_i2c_type;
+STATIC machine_hw_i2c_obj_t machine_hw_i2c_obj[I2C_NUM_MAX];
+
+STATIC void machine_hw_i2c_init(machine_hw_i2c_obj_t *self, uint32_t freq, uint32_t timeout_us, bool first_init) {
+    if (!first_init) {
+        i2c_driver_delete(self->port);
+    }
+    i2c_config_t conf = {
+        .mode = I2C_MODE_MASTER,
+        .sda_io_num = self->sda,
+        .sda_pullup_en = GPIO_PULLUP_ENABLE,
+        .scl_io_num = self->scl,
+        .scl_pullup_en = GPIO_PULLUP_ENABLE,
+        .master.clk_speed = freq,
+    };
+    i2c_param_config(self->port, &conf);
+    i2c_set_timeout(self->port, I2C_APB_CLK_FREQ / 1000000 * timeout_us);
+    i2c_driver_install(self->port, I2C_MODE_MASTER, 0, 0, 0);
+}
+
+int machine_hw_i2c_transfer(mp_obj_base_t *self_in, uint16_t addr, size_t n, mp_machine_i2c_buf_t *bufs, unsigned int flags) {
+    machine_hw_i2c_obj_t *self = MP_OBJ_TO_PTR(self_in);
+
+    i2c_cmd_handle_t cmd = i2c_cmd_link_create();
+    i2c_master_start(cmd);
+    i2c_master_write_byte(cmd, addr << 1 | (flags & MP_MACHINE_I2C_FLAG_READ), true);
+
+    int data_len = 0;
+    for (; n--; ++bufs) {
+        if (flags & MP_MACHINE_I2C_FLAG_READ) {
+            i2c_master_read(cmd, bufs->buf, bufs->len, n == 0 ? I2C_MASTER_LAST_NACK : I2C_MASTER_ACK);
+        } else {
+            if (bufs->len != 0) {
+                i2c_master_write(cmd, bufs->buf, bufs->len, true);
+            }
+        }
+        data_len += bufs->len;
+    }
+
+    if (flags & MP_MACHINE_I2C_FLAG_STOP) {
+        i2c_master_stop(cmd);
+    }
+
+    // TODO proper timeout
+    esp_err_t err = i2c_master_cmd_begin(self->port, cmd, 100 * (1 + data_len) / portTICK_RATE_MS);
+    i2c_cmd_link_delete(cmd);
+
+    if (err == ESP_FAIL) {
+        return -MP_ENODEV;
+    } else if (err == ESP_ERR_TIMEOUT) {
+        return -MP_ETIMEDOUT;
+    } else if (err != ESP_OK) {
+        return -abs(err);
+    }
+
+    return data_len;
+}
+
+/******************************************************************************/
+// MicroPython bindings for machine API
+
+STATIC void machine_hw_i2c_print(const mp_print_t *print, mp_obj_t self_in, mp_print_kind_t kind) {
+    machine_hw_i2c_obj_t *self = MP_OBJ_TO_PTR(self_in);
+    int h, l;
+    i2c_get_period(self->port, &h, &l);
+    mp_printf(print, "I2C(%u, scl=%u, sda=%u, freq=%u)",
+        self->port, self->scl, self->sda, I2C_APB_CLK_FREQ / (h + l));
+}
+
+mp_obj_t machine_hw_i2c_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *all_args) {
+    // Parse args
+    enum { ARG_id, ARG_scl, ARG_sda, ARG_freq, ARG_timeout };
+    static const mp_arg_t allowed_args[] = {
+        { MP_QSTR_id, MP_ARG_REQUIRED | MP_ARG_OBJ },
+        { MP_QSTR_scl, MP_ARG_KW_ONLY | MP_ARG_OBJ, {.u_obj = MP_OBJ_NULL} },
+        { MP_QSTR_sda, MP_ARG_KW_ONLY | MP_ARG_OBJ, {.u_obj = MP_OBJ_NULL} },
+        { MP_QSTR_freq, MP_ARG_KW_ONLY | MP_ARG_INT, {.u_int = 400000} },
+        { MP_QSTR_timeout, MP_ARG_KW_ONLY | MP_ARG_INT, {.u_int = I2C_DEFAULT_TIMEOUT_US} },
+    };
+    mp_arg_val_t args[MP_ARRAY_SIZE(allowed_args)];
+    mp_arg_parse_all_kw_array(n_args, n_kw, all_args, MP_ARRAY_SIZE(allowed_args), allowed_args, args);
+
+    // Get I2C bus
+    mp_int_t i2c_id = mp_obj_get_int(args[ARG_id].u_obj);
+    if (!(I2C_NUM_0 <= i2c_id && i2c_id < I2C_NUM_MAX)) {
+        nlr_raise(mp_obj_new_exception_msg_varg(&mp_type_ValueError, "I2C(%d) doesn't exist", i2c_id));
+    }
+
+    // Get static peripheral object
+    machine_hw_i2c_obj_t *self = (machine_hw_i2c_obj_t*)&machine_hw_i2c_obj[i2c_id];
+
+    bool first_init = false;
+    if (self->base.type == NULL) {
+        // Created for the first time, set default pins
+        self->base.type = &machine_hw_i2c_type;
+        self->port = i2c_id;
+        if (self->port == I2C_NUM_0) {
+            self->scl = I2C_0_DEFAULT_SCL;
+            self->sda = I2C_0_DEFAULT_SDA;
+        } else {
+            self->scl = I2C_1_DEFAULT_SCL;
+            self->sda = I2C_1_DEFAULT_SDA;
+        }
+        first_init = true;
+    }
+
+    // Set SCL/SDA pins if given
+    if (args[ARG_scl].u_obj != MP_OBJ_NULL) {
+        self->scl = mp_hal_get_pin_obj(args[ARG_scl].u_obj);
+    }
+    if (args[ARG_sda].u_obj != MP_OBJ_NULL) {
+        self->sda = mp_hal_get_pin_obj(args[ARG_sda].u_obj);
+    }
+
+    // Initialise the I2C peripheral
+    machine_hw_i2c_init(self, args[ARG_freq].u_int, args[ARG_timeout].u_int, first_init);
+
+    return MP_OBJ_FROM_PTR(self);
+}
+
+STATIC const mp_machine_i2c_p_t machine_hw_i2c_p = {
+    .transfer = machine_hw_i2c_transfer,
+};
+
+STATIC const mp_obj_type_t machine_hw_i2c_type = {
+    { &mp_type_type },
+    .name = MP_QSTR_I2C,
+    .print = machine_hw_i2c_print,
+    .make_new = machine_hw_i2c_make_new,
+    .protocol = &machine_hw_i2c_p,
+    .locals_dict = (mp_obj_dict_t*)&mp_machine_soft_i2c_locals_dict,
+};

--- a/ports/esp32/mpconfigport.h
+++ b/ports/esp32/mpconfigport.h
@@ -137,6 +137,7 @@
 #define MICROPY_PY_MACHINE_PIN_MAKE_NEW     mp_pin_make_new
 #define MICROPY_PY_MACHINE_PULSE            (1)
 #define MICROPY_PY_MACHINE_I2C              (1)
+#define MICROPY_PY_MACHINE_I2C_MAKE_NEW     machine_hw_i2c_make_new
 #define MICROPY_PY_MACHINE_SPI              (1)
 #define MICROPY_PY_MACHINE_SPI_MSB          (0)
 #define MICROPY_PY_MACHINE_SPI_LSB          (1)


### PR DESCRIPTION
This PR adds support for hardware I2C on the esp32.  Sample usage:
```python
i2c = machine.I2C(0, freq=1000000) # uses default pins
i2c_1 = machine.I2C(1, scl=machine.Pin(4), sda=machine.Pin(5))
i2c.scan()
```
Only basic testing of this code has been done so far, but it seems to work.