### PR TITLE
py/scheduler.c: Rename sched_stack to sched_queue.

### DIFF
--- a/docs/library/micropython.rst
+++ b/docs/library/micropython.rst
@@ -136,5 +136,5 @@ Functions
    :ref:`reference documentation <isr_rules>` under "Creation of Python
    objects".
 
-   There is a finite stack to hold the scheduled functions and `schedule()`
-   will raise a `RuntimeError` if the stack is full.
+   There is a finite queue to hold the scheduled functions and `schedule()`
+   will raise a `RuntimeError` if the queue is full.

--- a/py/modmicropython.c
+++ b/py/modmicropython.c
@@ -150,7 +150,7 @@ STATIC MP_DEFINE_CONST_FUN_OBJ_1(mp_micropython_kbd_intr_obj, mp_micropython_kbd
 #if MICROPY_ENABLE_SCHEDULER
 STATIC mp_obj_t mp_micropython_schedule(mp_obj_t function, mp_obj_t arg) {
     if (!mp_sched_schedule(function, arg)) {
-        mp_raise_msg(&mp_type_RuntimeError, "schedule stack full");
+        mp_raise_msg(&mp_type_RuntimeError, "schedule queue full");
     }
     return mp_const_none;
 }

--- a/py/mpstate.h
+++ b/py/mpstate.h
@@ -141,7 +141,7 @@ typedef struct _mp_state_vm_t {
     volatile mp_obj_t mp_pending_exception;
 
     #if MICROPY_ENABLE_SCHEDULER
-    mp_sched_item_t sched_stack[MICROPY_SCHEDULER_DEPTH];
+    mp_sched_item_t sched_queue[MICROPY_SCHEDULER_DEPTH];
     #endif
 
     // current exception being handled, for sys.exc_info()

--- a/py/scheduler.c
+++ b/py/scheduler.c
@@ -65,7 +65,7 @@ void mp_handle_pending(void) {
 void mp_handle_pending_tail(mp_uint_t atomic_state) {
     MP_STATE_VM(sched_state) = MP_SCHED_LOCKED;
     if (!mp_sched_empty()) {
-        mp_sched_item_t item = MP_STATE_VM(sched_stack)[MP_STATE_VM(sched_idx)];
+        mp_sched_item_t item = MP_STATE_VM(sched_queue)[MP_STATE_VM(sched_idx)];
         MP_STATE_VM(sched_idx) = IDX_MASK(MP_STATE_VM(sched_idx) + 1);
         --MP_STATE_VM(sched_len);
         MICROPY_END_ATOMIC_SECTION(atomic_state);
@@ -107,11 +107,11 @@ bool mp_sched_schedule(mp_obj_t function, mp_obj_t arg) {
             MP_STATE_VM(sched_state) = MP_SCHED_PENDING;
         }
         uint8_t iput = IDX_MASK(MP_STATE_VM(sched_idx) + MP_STATE_VM(sched_len)++);
-        MP_STATE_VM(sched_stack)[iput].func = function;
-        MP_STATE_VM(sched_stack)[iput].arg = arg;
+        MP_STATE_VM(sched_queue)[iput].func = function;
+        MP_STATE_VM(sched_queue)[iput].arg = arg;
         ret = true;
     } else {
-        // schedule stack is full
+        // schedule queue is full
         ret = false;
     }
     MICROPY_END_ATOMIC_SECTION(atomic_state);


### PR DESCRIPTION
Behaviour was changed from stack to queue in 8977c7eb581f5d06500edb1ea29aea5cbda04f28, this updates variable names to match.
Also update other references (docs, error messages).

(Sorry about the trivial PR, but this caught me out when I was experimenting with something where the difference might matter, and had assumed the wrong thing based on the code).