### PR TITLE
ports/esp32/Makefile: Fix path expansion for ESPIDF_DRIVER_O

### DIFF
--- a/ports/esp32/Makefile
+++ b/ports/esp32/Makefile
@@ -256,7 +256,7 @@ $(HEADER_BUILD)/qstrdefs.generated.h: $(SDKCONFIG_H)
 ################################################################################
 # List of object files from the ESP32 IDF components
 
-ESPIDF_DRIVER_O = $(subst .c,.o,$(wildcard $(ESPCOMP)/driver/*.c))
+ESPIDF_DRIVER_O = $(patsubst %.c,%.o,$(wildcard $(ESPCOMP)/driver/*.c))
 
 ESPIDF_EFUSE_O = $(addprefix $(ESPCOMP)/efuse/,\
 	esp32/esp_efuse_table.o \


### PR DESCRIPTION
It was using subst to s/.c/.o/ which changed .c anywhere in the path. (I have ESPIDF set to `/home/jimmo/src/github.com/espressif/esp-idf`, resulting in github.oom)