### PR TITLE
py/ringbuf.h: Avoid wasted byte in ringbuf and don't inline get/put.

### DIFF
--- a/ports/esp32/mphalport.c
+++ b/ports/esp32/mphalport.c
@@ -48,7 +48,7 @@ ringbuf_t stdin_ringbuf = {stdin_ringbuf_array, sizeof(stdin_ringbuf_array)};
 
 uintptr_t mp_hal_stdio_poll(uintptr_t poll_flags) {
     uintptr_t ret = 0;
-    if ((poll_flags & MP_STREAM_POLL_RD) && stdin_ringbuf.iget != stdin_ringbuf.iput) {
+    if ((poll_flags & MP_STREAM_POLL_RD) && !ringbuf_is_empty(&stdin_ringbuf)) {
         ret |= MP_STREAM_POLL_RD;
     }
     return ret;

--- a/ports/esp8266/esp_mphal.c
+++ b/ports/esp8266/esp_mphal.c
@@ -59,7 +59,7 @@ void mp_hal_delay_us(uint32_t us) {
 
 uintptr_t mp_hal_stdio_poll(uintptr_t poll_flags) {
     uintptr_t ret = 0;
-    if ((poll_flags & MP_STREAM_POLL_RD) && stdin_ringbuf.iget != stdin_ringbuf.iput) {
+    if ((poll_flags & MP_STREAM_POLL_RD) && !ringbuf_is_empty(&stdin_ringbuf)) {
         ret |= MP_STREAM_POLL_RD;
     }
     return ret;

--- a/ports/esp8266/machine_uart.c
+++ b/ports/esp8266/machine_uart.c
@@ -31,6 +31,7 @@
 #include "ets_sys.h"
 #include "uart.h"
 
+#include "py/ringbuf.h"
 #include "py/runtime.h"
 #include "py/stream.h"
 #include "py/mperrno.h"
@@ -147,7 +148,7 @@ STATIC void pyb_uart_init_helper(pyb_uart_obj_t *self, size_t n_args, const mp_o
 
     // set rx ring buffer
     if (args[ARG_rxbuf].u_int > 0) {
-        uint16_t len = args[ARG_rxbuf].u_int + 1; // account for usable items in ringbuf
+        uint16_t len = ringbuf_fix_len(args[ARG_rxbuf].u_int);
         byte *buf;
         if (len <= UART0_STATIC_RXBUF_LEN) {
             buf = uart_ringbuf_array;

--- a/ports/esp8266/uart.c
+++ b/ports/esp8266/uart.c
@@ -203,7 +203,7 @@ static void uart0_rx_intr_handler(void *para) {
 bool uart_rx_wait(uint32_t timeout_us) {
     uint32_t start = system_get_time();
     for (;;) {
-        if (uart_ringbuf.iget != uart_ringbuf.iput) {
+        if (!ringbuf_is_empty(&uart_ringbuf)) {
             return true; // have at least 1 char ready for reading
         }
         if (system_get_time() - start >= timeout_us) {
@@ -214,7 +214,7 @@ bool uart_rx_wait(uint32_t timeout_us) {
 }
 
 int uart_rx_any(uint8 uart) {
-    if (uart_ringbuf.iget != uart_ringbuf.iput) {
+    if (!ringbuf_is_empty(&uart_ringbuf)) {
         return true; // have at least 1 char ready for reading
     }
     return false;

--- a/ports/nrf/modules/machine/uart.c
+++ b/ports/nrf/modules/machine/uart.c
@@ -52,7 +52,7 @@
 typedef struct _machine_hard_uart_buf_t {
     uint8_t tx_buf[1];
     uint8_t rx_buf[1];
-    uint8_t rx_ringbuf_array[64];
+    uint8_t rx_ringbuf_array[64]; // Must be divisible into 2^16, see py/ringbuf.h.
     volatile ringbuf_t rx_ringbuf;
 } machine_hard_uart_buf_t;
 
@@ -99,7 +99,7 @@ STATIC void uart_event_handler(nrfx_uart_event_t const *p_event, void *p_context
 }
 
 bool uart_rx_any(const machine_hard_uart_obj_t *self) {
-    return self->buf->rx_ringbuf.iput != self->buf->rx_ringbuf.iget;
+    return !ringbuf_is_empty((ringbuf_t*)&self->buf->rx_ringbuf);
 }
 
 int uart_rx_char(const machine_hard_uart_obj_t * self) {

--- a/py/py.mk
+++ b/py/py.mk
@@ -21,9 +21,9 @@ CSUPEROPT = -O3
 
 # External modules written in C.
 ifneq ($(USER_C_MODULES),)
-# pre-define USERMOD variables as expanded so that variables are immediate 
+# pre-define USERMOD variables as expanded so that variables are immediate
 # expanded as they're added to them
-SRC_USERMOD := 
+SRC_USERMOD :=
 CFLAGS_USERMOD :=
 LDFLAGS_USERMOD :=
 $(foreach module, $(wildcard $(USER_C_MODULES)/*/micropython.mk), \
@@ -86,6 +86,7 @@ PY_CORE_O_BASENAME = $(addprefix py/,\
 	stackctrl.o \
 	argcheck.o \
 	warning.o \
+	ringbuf.o \
 	map.o \
 	obj.o \
 	objarray.o \

--- a/py/ringbuf.c
+++ b/py/ringbuf.c
@@ -1,0 +1,56 @@
+/*
+ * This file is part of the MicroPython project, http://micropython.org/
+ *
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2016 Paul Sokolovsky
+ * Copyright (c) 2019 Jim Mussared
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+ #include "py/ringbuf.h"
+
+uint16_t ringbuf_fix_len(uint16_t len) {
+    if (len == 0) {
+        return 1;
+    }
+    len--;
+    len |= len >> 1;
+    len |= len >> 2;
+    len |= len >> 4;
+    len |= len >> 8;
+    len++;
+    return len ? len : 32768;
+}
+
+int ringbuf_get(ringbuf_t *r) {
+    if (ringbuf_is_empty(r)) {
+        return -1;
+    }
+    return r->buf[r->iget++ % r->size];
+}
+
+int ringbuf_put(ringbuf_t *r, uint8_t v) {
+    if (r->iput - r->iget == r->size) {
+        return -1;
+    }
+    r->buf[r->iput++ % r->size] = v;
+    return 0;
+}


### PR DESCRIPTION
For discussion... I'd like to consolidate `py/ringbuf.h` with the ringbuf implementation in modbluetooth.c in #4893 written by @aykevl, so this PR merges the two implementations into py/ringbuf.h.
The benefit of @aykevl's implementation is that when the size of the ringbuf is divisible into 2^16 (i.e. `2**16 % size == 0`), we can make the code smaller and avoid a wasted byte in the buffer.

I'm unsure whether the requirement that the buffer is divisible into 2^16 is a problem. It means that if the user sets the `rxbuf` kwarg on ESP8266, they may get a slightly larger buffer than expected (the code rounds up to the nearest power of two).

I've also changed ringbuf to no longer inline get/put -- this is only a saving if each of get/put are called once (on ESP8266/ESP32 this is not the case). On NRF, LTO does this for us anyway. (And NRF will benefit further when this gets used in modbluetooth).

This reduces code size on ESP8266 (-124) and NRF (-84) ports, and marginal increase on ESP32 (+24).
