### PR TITLE
py/objstringio.c: if/endif scope for MICROPY_PY_IO_BYTESIO

### DIFF
--- a/py/objstringio.c
+++ b/py/objstringio.c
@@ -244,12 +244,6 @@ STATIC const mp_stream_p_t stringio_stream_p = {
     .is_text = true,
 };
 
-STATIC const mp_stream_p_t bytesio_stream_p = {
-    .read = stringio_read,
-    .write = stringio_write,
-    .ioctl = stringio_ioctl,
-};
-
 const mp_obj_type_t mp_type_stringio = {
     { &mp_type_type },
     .name = MP_QSTR_StringIO,
@@ -262,6 +256,12 @@ const mp_obj_type_t mp_type_stringio = {
 };
 
 #if MICROPY_PY_IO_BYTESIO
+STATIC const mp_stream_p_t bytesio_stream_p = {
+    .read = stringio_read,
+    .write = stringio_write,
+    .ioctl = stringio_ioctl,
+};
+
 const mp_obj_type_t mp_type_bytesio = {
     { &mp_type_type },
     .name = MP_QSTR_BytesIO,


### PR DESCRIPTION
when MICROPY_PY_IO_BYTESIO (0) avoid :
```../../py/objstringio.c:247:28: error: unused variable 'bytesio_stream_p' [-Werror,-Wunused-const-variable]
STATIC const mp_stream_p_t bytesio_stream_p = {
                           ^
1 error generated.
shared:ERROR: compiler frontend failed to generate LLVM bitcode, halting
../../py/mkrules.mk:47: recipe for target 'build/py/objstringio.o' failed
make: *** [build/py/objstringio.o] Error 1
```