### PR TITLE
windows/mpconfigport.h: Fix violation of C++ standard

### DIFF
--- a/ports/windows/mpconfigport.h
+++ b/ports/windows/mpconfigport.h
@@ -228,9 +228,11 @@ extern const struct _mp_obj_module_t mp_module_time;
 
 // CL specific definitions
 
+#ifndef __cplusplus
 #define restrict
 #define inline                      __inline
 #define alignof(t)                  __alignof(t)
+#endif
 #define PATH_MAX                    MICROPY_ALLOC_PATH_MAX
 #define S_ISREG(m)                  (((m) & S_IFMT) == S_IFREG)
 #define S_ISDIR(m)                  (((m) & S_IFMT) == S_IFDIR)


### PR DESCRIPTION
The C++ standard forbids redefining keywords, like inline and alignof,
so guard the definitions to avoid that, allowing to include the
micropython headers by C++ code.

This gets verified in msvc, not using the compiler but in code, so I only found this out recently after switching inlude file order..

