### PR TITLE
py/objint: Add mp_obj_int_get_uint_checked() helper.

### DIFF
--- a/py/obj.h
+++ b/py/obj.h
@@ -748,6 +748,8 @@ void mp_obj_cell_set(mp_obj_t self_in, mp_obj_t obj);
 mp_int_t mp_obj_int_get_truncated(mp_const_obj_t self_in);
 // Will raise exception if value doesn't fit into mp_int_t
 mp_int_t mp_obj_int_get_checked(mp_const_obj_t self_in);
+// Will raise exception if value is negative or doesn't fit into mp_uint_t
+mp_uint_t mp_obj_int_get_uint_checked(mp_const_obj_t self_in);
 
 // exception
 #define mp_obj_is_native_exception_instance(o) (mp_obj_get_type(o)->make_new == mp_obj_exception_make_new)

--- a/py/objint_mpz.c
+++ b/py/objint_mpz.c
@@ -411,6 +411,22 @@ mp_int_t mp_obj_int_get_checked(mp_const_obj_t self_in) {
     }
 }
 
+mp_uint_t mp_obj_int_get_uint_checked(mp_const_obj_t self_in) {
+    if (mp_obj_is_small_int(self_in)) {
+        if (MP_OBJ_SMALL_INT_VALUE(self_in) >= 0) {
+            return MP_OBJ_SMALL_INT_VALUE(self_in);
+        }
+    } else {
+        const mp_obj_int_t *self = MP_OBJ_TO_PTR(self_in);
+        mp_uint_t value;
+        if (mpz_as_uint_checked(&self->mpz, &value)) {
+            return value;
+        }
+    }
+
+    mp_raise_msg(&mp_type_OverflowError, "overflow converting long int to machine word");
+}
+
 #if MICROPY_PY_BUILTINS_FLOAT
 mp_float_t mp_obj_int_as_float_impl(mp_obj_t self_in) {
     assert(mp_obj_is_type(self_in, &mp_type_int));


### PR DESCRIPTION
Can be used where mp_obj_int_get_checked() will overflow due
to the sign-bit solely.

Shouldn't affect code size, since it's unused at the moment.
Should any extmod/port use it, they'd "pay the price".

Addressed #2868, #2269 and possibly more.