### PR TITLE
py: handle builtins.__import__

### DIFF
--- a/py/modio.c
+++ b/py/modio.c
@@ -208,15 +208,7 @@ STATIC mp_obj_t resource_stream(mp_obj_t package_in, mp_obj_t path_in) {
     // package parameter being None, the path_in is interpreted as a
     // raw path.
     if (package_in != mp_const_none) {
-        mp_obj_t args[5];
-        args[0] = package_in;
-        args[1] = mp_const_none; // TODO should be globals
-        args[2] = mp_const_none; // TODO should be locals
-        args[3] = mp_const_true; // Pass sentinel "non empty" value to force returning of leaf module
-        args[4] = MP_OBJ_NEW_SMALL_INT(0);
-
-        // TODO lookup __import__ and call that instead of going straight to builtin implementation
-        mp_obj_t pkg = mp_builtin___import__(5, args);
+        mp_obj_t pkg = mp_import_name(mp_obj_str_get_qstr(package_in), mp_const_true, MP_OBJ_NEW_SMALL_INT(0));
 
         mp_obj_t dest[2];
         mp_load_method_maybe(pkg, MP_QSTR___path__, dest);

--- a/py/runtime.c
+++ b/py/runtime.c
@@ -1327,23 +1327,26 @@ mp_obj_t mp_make_raise_obj(mp_obj_t o) {
 mp_obj_t mp_import_name(qstr name, mp_obj_t fromlist, mp_obj_t level) {
     DEBUG_printf("import name '%s' level=%d\n", qstr_str(name), MP_OBJ_SMALL_INT_VALUE(level));
     // build args array
-    mp_obj_t argv[5];
-    argv[0] = MP_OBJ_NEW_QSTR(name);
-    argv[1] = mp_const_none; // TODO should be globals
-    argv[2] = mp_const_none; // TODO should be locals
-    argv[3] = fromlist;
-    argv[4] = level;
+    mp_obj_t args[5];
+    args[0] = MP_OBJ_NEW_QSTR(name);
+    args[1] = mp_const_none; // TODO should be globals
+    args[2] = mp_const_none; // TODO should be locals
+    args[3] = fromlist;
+    args[4] = level;
 #if MICROPY_CAN_OVERRIDE_BUILTINS
-    mp_obj_dict_t *bo_dict = MP_STATE_VM(mp_module_builtins_override_dict);
-    
-    // lookup __import__ and call that instead of going straight to builtin implementation
-    if (bo_dict != NULL) {        
-        mp_map_elem_t *cust_imp = mp_map_lookup(&bo_dict->map, MP_ROM_QSTR(MP_QSTR___import__), MP_MAP_LOOKUP);
-        if (cust_imp != NULL)
-            return mp_call_function_n_kw(cust_imp->value, 5, 0, argv);
+    {
+        mp_obj_dict_t *bo_dict = MP_STATE_VM(mp_module_builtins_override_dict);
+        
+        // lookup __import__ and call that instead of going straight to builtin implementation
+        if (bo_dict != NULL) {        
+            mp_map_elem_t *cust_imp = mp_map_lookup(&bo_dict->map, MP_ROM_QSTR(MP_QSTR___import__), MP_MAP_LOOKUP);
+            if (cust_imp != NULL) {
+                return mp_call_function_n_kw(cust_imp->value, 5, 0, args);
+            }
+        }
     }
 #endif    
-    return mp_builtin___import__(5, argv);
+    return mp_builtin___import__(5, args);
 }
 
 mp_obj_t mp_import_from(mp_obj_t module, qstr name) {

--- a/py/runtime.c
+++ b/py/runtime.c
@@ -1339,7 +1339,7 @@ mp_obj_t mp_import_name(qstr name, mp_obj_t fromlist, mp_obj_t level) {
         
         // lookup __import__ and call that instead of going straight to builtin implementation
         if (bo_dict != NULL) {        
-            mp_map_elem_t *cust_imp = mp_map_lookup(&bo_dict->map, MP_ROM_QSTR(MP_QSTR___import__), MP_MAP_LOOKUP);
+            mp_map_elem_t *cust_imp = mp_map_lookup(&bo_dict->map, MP_OBJ_NEW_QSTR(MP_QSTR___import__), MP_MAP_LOOKUP);
             if (cust_imp != NULL) {
                 return mp_call_function_n_kw(cust_imp->value, 5, 0, args);
             }

--- a/py/runtime.c
+++ b/py/runtime.c
@@ -1333,7 +1333,7 @@ mp_obj_t mp_import_name(qstr name, mp_obj_t fromlist, mp_obj_t level) {
     argv[2] = mp_const_none; // TODO should be locals
     argv[3] = fromlist;
     argv[4] = level;
-
+#if MICROPY_CAN_OVERRIDE_BUILTINS
     mp_obj_dict_t *bo_dict = MP_STATE_VM(mp_module_builtins_override_dict);
     
     // lookup __import__ and call that instead of going straight to builtin implementation
@@ -1342,6 +1342,7 @@ mp_obj_t mp_import_name(qstr name, mp_obj_t fromlist, mp_obj_t level) {
         if (cust_imp != NULL)
             return mp_call_function_n_kw(cust_imp->value, 5, 0, argv);
     }
+#endif    
     return mp_builtin___import__(5, argv);
 }
 


### PR DESCRIPTION
Fix compatibility regarding cpython behaviour.
Allows writing custom importers for any port.
Very usefull for javascript port since it would open ways to do imports and then asynchronous  toplevel (repl) imports later. note that asynchronous is also required for compiled wasm modules.

A simple filter test 
```
import builtins
old_imp = __import__
def __import__(name, *argv):
    global old_imp
    print("verbose import of '{0}' with {1} parameters".format(name,len(argv)) )
    return old_imp(name, *argv)

builtins.__import__ = __import__
import sys as verbose
```

Not sure for mp_obj_str_get_qstr(package_in) in modio, any testsuite that target those imports ?
