### PR TITLE
extmod/moductypes: Use mp_obj_new_int_from_uint() when casting addresses.

### DIFF
--- a/extmod/moductypes.c
+++ b/extmod/moductypes.c
@@ -651,7 +651,7 @@ STATIC mp_int_t uctypes_get_buffer(mp_obj_t self_in, mp_buffer_info_t *bufinfo, 
 STATIC mp_obj_t uctypes_struct_addressof(mp_obj_t buf) {
     mp_buffer_info_t bufinfo;
     mp_get_buffer_raise(buf, &bufinfo, MP_BUFFER_READ);
-    return mp_obj_new_int((mp_int_t)(uintptr_t)bufinfo.buf);
+    return mp_obj_new_int_from_uint((mp_uint_t)(uintptr_t)bufinfo.buf);
 }
 MP_DEFINE_CONST_FUN_OBJ_1(uctypes_struct_addressof_obj, uctypes_struct_addressof);
 


### PR DESCRIPTION
Address ojbects are unsigned and thus should be instantiated with the uint variant.