### PR TITLE
stm32: support USB device on STM32L432

### DIFF
--- a/ports/stm32/boards/NUCLEO_L432KC/mpconfigboard.h
+++ b/ports/stm32/boards/NUCLEO_L432KC/mpconfigboard.h
@@ -14,6 +14,7 @@
 #define MICROPY_HW_ENABLE_RTC       (1)
 #define MICROPY_HW_ENABLE_ADC       (1)
 #define MICROPY_HW_ENABLE_DAC       (1)
+#define MICROPY_HW_ENABLE_USB       (1)
 #define MICROPY_HW_ENABLE_TIMER     (1)
 #define MICROPY_HW_HAS_SWITCH       (0)
 
@@ -57,4 +58,8 @@
 #define MICROPY_HW_LED_OFF(pin)     (mp_hal_pin_low(pin))
 
 // USB config
-#define MICROPY_HW_USB_FS (0)
+#define MICROPY_HW_USB_FS           (1)
+#define MICROPY_HW_USB_MSC          (0)
+#define MICROPY_HW_USB_HID          (0)
+#define USBD_CDC_RX_DATA_SIZE       (256)
+#define USBD_CDC_TX_DATA_SIZE       (256)

--- a/ports/stm32/stm32_it.c
+++ b/ports/stm32/stm32_it.c
@@ -298,7 +298,7 @@ void DebugMon_Handler(void) {
 /*  file (startup_stm32f4xx.s).                                               */
 /******************************************************************************/
 
-#if defined(STM32L0)
+#if defined(STM32L0) || defined(STM32L432xx)
 
 #if MICROPY_HW_USB_FS
 void USB_IRQHandler(void) {

--- a/ports/stm32/usbd_cdc_interface.c
+++ b/ports/stm32/usbd_cdc_interface.c
@@ -142,7 +142,7 @@ int8_t usbd_cdc_control(usbd_cdc_state_t *cdc_in, uint8_t cmd, uint8_t* pbuf, ui
                 // configure its serial port (in most cases to disable local echo)
                 cdc->connect_state = USBD_CDC_CONNECT_STATE_CONNECTING;
                 usbd_cdc_connect_tx_timer = 8; // wait for 8 SOF IRQs
-                #if defined(STM32L0) || defined(STM32WB)
+                #if defined(STM32L0) || defined(STM32L432xx) || defined(STM32WB)
                 USB->CNTR |= USB_CNTR_SOFM;
                 #else
                 PCD_HandleTypeDef *hpcd = cdc->base.usbd->pdev->pData;
@@ -219,7 +219,7 @@ void HAL_PCD_SOFCallback(PCD_HandleTypeDef *hpcd) {
         --usbd_cdc_connect_tx_timer;
     } else {
         usbd_cdc_msc_hid_state_t *usbd = ((USBD_HandleTypeDef*)hpcd->pData)->pClassData;
-        #if defined(STM32L0) || defined(STM32WB)
+        #if defined(STM32L0) || defined(STM32L432xx) || defined(STM32WB)
         USB->CNTR &= ~USB_CNTR_SOFM;
         #else
         hpcd->Instance->GINTMSK &= ~USB_OTG_GINTMSK_SOFM;

--- a/ports/stm32/usbd_conf.c
+++ b/ports/stm32/usbd_conf.c
@@ -44,7 +44,7 @@ PCD_HandleTypeDef pcd_fs_handle;
 PCD_HandleTypeDef pcd_hs_handle;
 #endif
 
-#if defined(STM32L0) || defined(STM32WB)
+#if defined(STM32L0) || defined(STM32L432xx) || defined(STM32WB)
 // The STM32L0xx has a single USB device-only instance
 #define USB_OTG_FS USB
 #endif
@@ -64,6 +64,8 @@ void HAL_PCD_MspInit(PCD_HandleTypeDef *hpcd) {
         const uint32_t otg_alt = GPIO_AF10_OTG1_FS;
         #elif defined(STM32L0)
         const uint32_t otg_alt = GPIO_AF0_USB;
+        #elif defined(STM32L432xx)
+        const uint32_t otg_alt = GPIO_AF10_USB_FS;
         #elif defined(STM32WB)
         const uint32_t otg_alt = GPIO_AF10_USB;
         #else
@@ -92,7 +94,7 @@ void HAL_PCD_MspInit(PCD_HandleTypeDef *hpcd) {
         #endif
 
         // Enable USB FS Clocks
-        #if defined(STM32L0) || defined(STM32WB)
+        #if defined(STM32L0) || defined(STM32L432xx) || defined(STM32WB)
         __HAL_RCC_USB_CLK_ENABLE();
         #else
         __USB_OTG_FS_CLK_ENABLE();
@@ -113,6 +115,9 @@ void HAL_PCD_MspInit(PCD_HandleTypeDef *hpcd) {
         #if defined(STM32L0)
         NVIC_SetPriority(USB_IRQn, IRQ_PRI_OTG_FS);
         HAL_NVIC_EnableIRQ(USB_IRQn);
+        #elif defined(STM32L432xx)
+        NVIC_SetPriority(USB_FS_IRQn, IRQ_PRI_OTG_FS);
+        HAL_NVIC_EnableIRQ(USB_FS_IRQn);
         #elif defined(STM32WB)
         NVIC_SetPriority(USB_LP_IRQn, IRQ_PRI_OTG_FS);
         HAL_NVIC_EnableIRQ(USB_LP_IRQn);
@@ -195,7 +200,7 @@ void HAL_PCD_MspInit(PCD_HandleTypeDef *hpcd) {
   * @retval None
   */
 void HAL_PCD_MspDeInit(PCD_HandleTypeDef *hpcd) {
-    #if defined(STM32L0) || defined(STM32WB)
+    #if defined(STM32L0) || defined(STM32L432xx) || defined(STM32WB)
     __HAL_RCC_USB_CLK_DISABLE();
     #else
 
@@ -379,7 +384,7 @@ USBD_StatusTypeDef USBD_LL_Init(USBD_HandleTypeDef *pdev, int high_speed) {
         pcd_fs_handle.Init.lpm_enable = DISABLE;
         pcd_fs_handle.Init.battery_charging_enable = DISABLE;
         #endif
-        #if !defined(STM32L0) && !defined(STM32WB)
+        #if !defined(STM32L0) && !defined(STM32L432xx) && !defined(STM32WB)
         pcd_fs_handle.Init.use_dedicated_ep1 = 0;
         pcd_fs_handle.Init.dma_enable = 0;
         #if !defined(MICROPY_HW_USB_VBUS_DETECT_PIN)
@@ -396,7 +401,7 @@ USBD_StatusTypeDef USBD_LL_Init(USBD_HandleTypeDef *pdev, int high_speed) {
         // Initialize LL Driver
         HAL_PCD_Init(&pcd_fs_handle);
 
-        #if defined(STM32L0) || defined(STM32WB)
+        #if defined(STM32L0) || defined(STM32L432xx) || defined(STM32WB)
         // We have 512 16-bit words it total to use here (when using PCD_SNG_BUF)
         HAL_PCDEx_PMAConfig(&pcd_fs_handle, 0x00, PCD_SNG_BUF, 64); // EP0
         HAL_PCDEx_PMAConfig(&pcd_fs_handle, 0x80, PCD_SNG_BUF, 128); // EP0


### PR DESCRIPTION
This PR adds support for USB device-only mode on STM32L432 MCUs.  It compiles but it's untested.