### PR TITLE
Pin ESP32 tasks to core

### DIFF
--- a/ports/esp32/main.c
+++ b/ports/esp32/main.c
@@ -151,7 +151,7 @@ soft_reset:
 
 void app_main(void) {
     nvs_flash_init();
-    xTaskCreate(mp_task, "mp_task", MP_TASK_STACK_LEN, NULL, MP_TASK_PRIORITY, &mp_main_task_handle);
+    xTaskCreatePinnedToCore(mp_task, "mp_task", MP_TASK_STACK_LEN, NULL, MP_TASK_PRIORITY, &mp_main_task_handle, ESP32_TASK_COREID);
 }
 
 void nlr_jump_fail(void *val) {

--- a/ports/esp32/modmachine.h
+++ b/ports/esp32/modmachine.h
@@ -3,6 +3,8 @@
 
 #include "py/obj.h"
 
+#define ESP32_TASK_COREID 1
+
 typedef enum {
     //MACHINE_WAKE_IDLE=0x01,
     MACHINE_WAKE_SLEEP=0x02,

--- a/ports/esp32/mpthreadport.c
+++ b/ports/esp32/mpthreadport.c
@@ -32,6 +32,7 @@
 #include "py/gc.h"
 #include "py/mpthread.h"
 #include "mpthreadport.h"
+#include "modmachine.h"
 
 #include "esp_task.h"
 
@@ -130,7 +131,7 @@ void mp_thread_create_ex(void *(*entry)(void*), void *arg, size_t *stack_size, i
     mp_thread_mutex_lock(&thread_mutex, 1);
 
     // create thread
-    BaseType_t result = xTaskCreate(freertos_entry, name, *stack_size / sizeof(StackType_t), arg, priority, &th->id);
+    BaseType_t result = xTaskCreatePinnedToCore(freertos_entry, name, *stack_size / sizeof(StackType_t), arg, priority, &th->id, ESP32_TASK_COREID);
     if (result != pdPASS) {
         mp_thread_mutex_unlock(&thread_mutex);
         nlr_raise(mp_obj_new_exception_msg(&mp_type_OSError, "can't create thread"));

--- a/ports/esp32/network_ppp.c
+++ b/ports/esp32/network_ppp.c
@@ -133,7 +133,7 @@ STATIC mp_obj_t ppp_active(size_t n_args, const mp_obj_t *args) {
             ppp_set_usepeerdns(self->pcb, 1);
             pppapi_connect(self->pcb, 0);
 
-            xTaskCreate(pppos_client_task, "ppp", 2048, self, 1, (TaskHandle_t*)&self->client_task_handle);
+            xTaskCreatePinnedToCore(pppos_client_task, "ppp", 2048, self, 1, (TaskHandle_t*)&self->client_task_handle, ESP32_TASK_COREID);
             self->active = true;
         } else {
             if (!self->active) {


### PR DESCRIPTION
This is required to ensure that ISR is always invoked on the same core as uPy.
see #4895