### PR TITLE
esp32: Add support for mDNS queries and responder.

### DIFF
--- a/ports/esp32/Makefile
+++ b/ports/esp32/Makefile
@@ -74,6 +74,7 @@ INC += -I$(BUILD)
 
 INC_ESPCOMP += -I$(ESPCOMP)/bootloader_support/include
 INC_ESPCOMP += -I$(ESPCOMP)/bootloader_support/include_bootloader
+INC_ESPCOMP += -I$(ESPCOMP)/console
 INC_ESPCOMP += -I$(ESPCOMP)/driver/include
 INC_ESPCOMP += -I$(ESPCOMP)/driver/include/driver
 INC_ESPCOMP += -I$(ESPCOMP)/nghttp/port/include
@@ -103,6 +104,8 @@ INC_ESPCOMP += -I$(ESPCOMP)/lwip/port/esp32/include
 INC_ESPCOMP += -I$(ESPCOMP)/lwip/include/apps
 INC_ESPCOMP += -I$(ESPCOMP)/mbedtls/mbedtls/include
 INC_ESPCOMP += -I$(ESPCOMP)/mbedtls/port/include
+INC_ESPCOMP += -I$(ESPCOMP)/mdns/include
+INC_ESPCOMP += -I$(ESPCOMP)/mdns/private_include
 INC_ESPCOMP += -I$(ESPCOMP)/spi_flash/include
 INC_ESPCOMP += -I$(ESPCOMP)/ulp/include
 INC_ESPCOMP += -I$(ESPCOMP)/vfs/include
@@ -346,6 +349,8 @@ ESPIDF_MBEDTLS_O = $(patsubst %.c,%.o,\
 	$(wildcard $(ESPCOMP)/mbedtls/port/*.c) \
 	)
 
+ESPIDF_MDNS_O = $(patsubst %.c,%.o,$(wildcard $(ESPCOMP)/mdns/*.c))
+
 $(BUILD)/$(ESPCOMP)/wpa_supplicant/%.o: CFLAGS += -DEMBEDDED_SUPP -DIEEE8021X_EAPOL -DEAP_PEER_METHOD -DEAP_MSCHAPv2 -DEAP_TTLS -DEAP_TLS -DEAP_PEAP -DUSE_WPA2_TASK -DCONFIG_WPS2 -DCONFIG_WPS_PIN -DUSE_WPS_TASK -DESPRESSIF_USE -DESP32_WORKAROUND -DALLOW_EVEN_MOD -D__ets__ -Wno-strict-aliasing
 ESPIDF_WPA_SUPPLICANT_O = $(patsubst %.c,%.o,\
 	$(wildcard $(ESPCOMP)/wpa_supplicant/port/*.c) \
@@ -390,6 +395,7 @@ $(eval $(call gen_espidf_lib_rule,spi_flash,$(ESPIDF_SPI_FLASH_O)))
 $(eval $(call gen_espidf_lib_rule,ulp,$(ESPIDF_ULP_O)))
 $(eval $(call gen_espidf_lib_rule,lwip,$(ESPIDF_LWIP_O)))
 $(eval $(call gen_espidf_lib_rule,mbedtls,$(ESPIDF_MBEDTLS_O)))
+$(eval $(call gen_espidf_lib_rule,mdns,$(ESPIDF_MDNS_O)))
 $(eval $(call gen_espidf_lib_rule,wpa_supplicant,$(ESPIDF_WPA_SUPPLICANT_O)))
 $(eval $(call gen_espidf_lib_rule,sdmmc,$(ESPIDF_SDMMC_O)))
 

--- a/ports/esp32/modnetwork.c
+++ b/ports/esp32/modnetwork.c
@@ -48,6 +48,7 @@
 #include "esp_event_loop.h"
 #include "lwip/dns.h"
 #include "tcpip_adapter.h"
+#include "mdns.h"
 
 #include "modnetwork.h"
 
@@ -128,6 +129,9 @@ static bool wifi_sta_connected = false;
 // Store the current status. 0 means None here, safe to do so as first enum value is WIFI_REASON_UNSPECIFIED=1.
 static uint8_t wifi_sta_disconn_reason = 0;
 
+// Whether mDNS has been initialised or not
+static bool mdns_initialised = false;
+
 // This function is called by the system-event task and so runs in a different
 // thread to the main MicroPython task.  It must not raise any Python exceptions.
 static esp_err_t event_handler(void *ctx, system_event_t *event) {
@@ -142,6 +146,12 @@ static esp_err_t event_handler(void *ctx, system_event_t *event) {
         ESP_LOGI("network", "GOT_IP");
         wifi_sta_connected = true;
         wifi_sta_disconn_reason = 0; // Success so clear error. (in case of new error will be replaced anyway)
+        if (!mdns_initialised) {
+            mdns_init();
+            mdns_hostname_set("esp32");
+            mdns_instance_name_set("esp32");
+            mdns_initialised = true;
+        }
         break;
     case SYSTEM_EVENT_STA_DISCONNECTED: {
         // This is a workaround as ESP32 WiFi libs don't currently

--- a/ports/esp32/modsocket.c
+++ b/ports/esp32/modsocket.c
@@ -47,6 +47,7 @@
 #include "py/mperrno.h"
 #include "lib/netutils/netutils.h"
 #include "tcpip_adapter.h"
+#include "mdns.h"
 #include "modnetwork.h"
 
 #include "lwip/sockets.h"
@@ -56,6 +57,8 @@
 #include "esp_log.h"
 
 #define SOCKET_POLL_US (100000)
+#define MDNS_QUERY_TIMEOUT_MS (5000)
+#define MDNS_LOCAL_SUFFIX ".local"
 
 typedef struct _socket_obj_t {
     mp_obj_base_t base;
@@ -150,6 +153,55 @@ static inline void check_for_exceptions(void) {
     mp_handle_pending();
 }
 
+// This function mimics lwip_getaddrinfo, with added support for mDNS queries
+static int _socket_getaddrinfo3(const char *nodename, const char *servname,
+    const struct addrinfo *hints, struct addrinfo **res) {
+    int nodename_len = strlen(nodename);
+    const int local_len = sizeof(MDNS_LOCAL_SUFFIX) - 1;
+    if (nodename_len > local_len
+        && strcasecmp(nodename + nodename_len - local_len, MDNS_LOCAL_SUFFIX) == 0) {
+        // mDNS query
+        char nodename_no_local[nodename_len - local_len + 1];
+        memcpy(nodename_no_local, nodename, nodename_len - local_len);
+        nodename_no_local[nodename_len - local_len] = '\0';
+
+        struct ip4_addr addr = {0};
+        esp_err_t err = mdns_query_a(nodename_no_local, MDNS_QUERY_TIMEOUT_MS, &addr);
+        if (err != ESP_OK) {
+            if (err == ESP_ERR_NOT_FOUND){
+                *res = NULL;
+                return 0;
+            }
+            *res = NULL;
+            return err;
+        }
+
+        struct addrinfo *ai = memp_malloc(MEMP_NETDB);
+        if (ai == NULL) {
+            *res = NULL;
+            return EAI_MEMORY;
+        }
+        memset(ai, 0, sizeof(struct addrinfo) + sizeof(struct sockaddr_storage));
+
+        struct sockaddr_in *sa = (struct sockaddr_in*)((uint8_t*)ai + sizeof(struct addrinfo));
+        inet_addr_from_ip4addr(&sa->sin_addr, &addr);
+        sa->sin_family = AF_INET;
+        sa->sin_len = sizeof(struct sockaddr_in);
+        sa->sin_port = lwip_htons((u16_t)atoi(servname));
+        ai->ai_family = AF_INET;
+        ai->ai_canonname = ((char*)sa + sizeof(struct sockaddr_storage));
+        memcpy(ai->ai_canonname, nodename, nodename_len + 1);
+        ai->ai_addrlen = sizeof(struct sockaddr_storage);
+        ai->ai_addr = (struct sockaddr*)sa;
+
+        *res = ai;
+        return 0;
+    } else {
+        // Normal query
+        return lwip_getaddrinfo(nodename, servname, hints, res);
+    }
+}
+
 static int _socket_getaddrinfo2(const mp_obj_t host, const mp_obj_t portx, struct addrinfo **resp) {
     const struct addrinfo hints = {
         .ai_family = AF_INET,
@@ -172,7 +224,7 @@ static int _socket_getaddrinfo2(const mp_obj_t host, const mp_obj_t portx, struc
     }
 
     MP_THREAD_GIL_EXIT();
-    int res = lwip_getaddrinfo(host_str, port_str, &hints, resp);
+    int res = _socket_getaddrinfo3(host_str, port_str, &hints, resp);
     MP_THREAD_GIL_ENTER();
 
     return res;


### PR DESCRIPTION
This adds support to the esp32 for mDNS queries and a responder.  See discussion in #4912.

For queries do: `socket.getaddrinfo('device.local', 123)`

The responder is automatically enabled, with default hostname "esp32.local".

TODO: work out a way to specify the hostname.  Probably need a new config option `wlan.config(mdns_hostname=...)`.  Or could reuse `wlan.config(dhcp_hostname=...)`.  Even though there are different concepts of hostnames it'd probably be a good idea to unify them into a single config, eg `wlan.config(hostname=...)`.