### PR TITLE
extmod/vfs: Extended VFS protocol with path translation method.

### DIFF
--- a/extmod/vfs.h
+++ b/extmod/vfs.h
@@ -45,9 +45,15 @@
 #define BP_IOCTL_SEC_COUNT      (4)
 #define BP_IOCTL_SEC_SIZE       (5)
 
-// At the moment the VFS protocol just has import_stat, but could be extended to other methods
+// At the moment the VFS protocol just has following methods:
+// import_stat - returns paths entry type for an import method
+// vfs_path - if defined, this method is used to translate path that this
+// VFS expects
+// This protocol could be extended to other methods
+
 typedef struct _mp_vfs_proto_t {
     mp_import_stat_t (*import_stat)(void *self, const char *path);
+    void (*vfs_path)(void *self, const char *path, mp_obj_t *vfs_path);
 } mp_vfs_proto_t;
 
 typedef struct _mp_vfs_mount_t {


### PR DESCRIPTION
This patch extends mp_vfs_proto_t with method that may be used
for specifics VFS implementation path handling. One of possible
usage of this method may be to adapt OS filesystem paths to VFS
paths.

Signed-off-by: Pavel Kral <pavel.kral@omsquare.com>