### PR TITLE
py/runtime: Return obj->attr for obj.attr if attr has offset type.

### DIFF
--- a/py/mpconfig.h
+++ b/py/mpconfig.h
@@ -777,6 +777,11 @@ typedef double mp_float_t;
 #define MICROPY_PY_FUNCTION_ATTRS (0)
 #endif
 
+// Whether to enable getting attributes from class instance via C API.
+#ifndef MICROPY_PY_INSTANCE_ATTRS
+#define MICROPY_PY_INSTANCE_ATTRS (0)
+#endif
+
 // Whether to support the descriptors __get__, __set__, __delete__
 // This costs some code size and makes load/store/delete of instance
 // attributes slower for the classes that use this feature

--- a/py/obj.h
+++ b/py/obj.h
@@ -881,4 +881,23 @@ mp_obj_t mp_seq_extract_slice(size_t len, const mp_obj_t *seq, mp_bound_slice_t 
 #define MP_MAP_SLOT_IS_FILLED mp_map_slot_is_filled
 #define MP_SET_SLOT_IS_FILLED mp_set_slot_is_filled
 
+#if MICROPY_PY_INSTANCE_ATTRS
+extern const mp_obj_type_t mp_type_offset;
+
+typedef struct _offset_obj_t {
+    mp_obj_base_t base;
+    mp_int_t offset;
+} offset_obj_t;
+
+#define MP_ROM_ATTRIBUTE_OFFSET(obj_type, field_name) \
+    MP_ROM_PTR(( \
+        &(offset_obj_t) { \
+            .base = { \
+                .type = &mp_type_offset, \
+            }, \
+            .offset = offsetof(obj_type, field_name) \
+        }\
+    ))
+#endif // MICROPY_PY_INSTANCE_ATTRS
+
 #endif // MICROPY_INCLUDED_PY_OBJ_H

--- a/py/objtype.c
+++ b/py/objtype.c
@@ -1403,3 +1403,10 @@ const mp_obj_type_t mp_type_classmethod = {
     .name = MP_QSTR_classmethod,
     .make_new = static_class_method_make_new,
 };
+
+#if MICROPY_PY_INSTANCE_ATTRS
+const mp_obj_type_t mp_type_offset = {
+    { &mp_type_type },
+    .name = MP_QSTR_offset,
+};
+#endif // MICROPY_PY_INSTANCE_ATTRS

--- a/py/runtime.c
+++ b/py/runtime.c
@@ -1031,6 +1031,14 @@ void mp_convert_member_lookup(mp_obj_t self, const mp_obj_type_t *type, mp_obj_t
             dest[0] = member;
             dest[1] = self;
         }
+    #if MICROPY_PY_INSTANCE_ATTRS
+    } else if (MP_OBJ_IS_TYPE(member, &mp_type_offset)) {
+        // return the instance attribute self->member as self.member
+        if (self != MP_OBJ_NULL) {
+            size_t offset = ((offset_obj_t*)MP_OBJ_TO_PTR(member))->offset;
+            dest[0] = *(mp_obj_t*)((char*)MP_OBJ_TO_PTR(self) + offset);
+        }
+    #endif // MICROPY_PY_INSTANCE_ATTRS
     } else {
         // class member is a value, so just return that value
         dest[0] = member;


### PR DESCRIPTION
This provides a simple and lightweight mechanism for getting class instance attributes that are defined in C.

The idea is to simplify the process of making `self->something` a readable attribute. By adding it to the `locals_dict` instead of writing custom attribute handlers. 

Below is a minimal example C-defined class that uses this feature. Everything in the example is standard practice. The only new thing at this higher level is the `something` entry in the `locals_dict` table. 

This is a simplified example to illustrate how it works; the main practical use case arises when `mp_obj_t something` is an instance of another class that is also written in C.

```c

// modulename.ClassName object structure
typedef struct _modulename_ClassName_obj_t {
    mp_obj_base_t base;
    mp_obj_t something;
} modulename_ClassName_obj_t;

// modulename.ClassName.__init__
STATIC mp_obj_t modulename_ClassName_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *args ) {
    modulename_ClassName_obj_t *self = m_new_obj(modulename_ClassName_obj_t);
    self->base.type = (mp_obj_type_t*) type;

    // At this point, or in any other method, suppose that self->something
    // is initialized as an instance of a class that was written in c.
    // For the sake of this minimal example, we just make it an int.
    self->something = MP_OBJ_NEW_SMALL_INT(123);

    return MP_OBJ_FROM_PTR(self);
}

// modulename.ClassName.method
STATIC mp_obj_t modulename_ClassName_method(mp_obj_t self_in) {
    // This is just a method
    return mp_const_none;
}
STATIC MP_DEFINE_CONST_FUN_OBJ_1(modulename_ClassName_method_obj, modulename_ClassName_method);

// dir(modulename.ClassName)
STATIC const mp_rom_map_elem_t modulename_ClassName_locals_dict_table[] = {
    { MP_ROM_QSTR(MP_QSTR_method), MP_ROM_PTR(&modulename_ClassName_method_obj) },
    //
    // Everything in this example is standard. The following line is the only new thing.
    // It makes self->something accessible to the user using self.something
    //
    { MP_ROM_QSTR(MP_QSTR_something), MP_ROM_ATTRIBUTE_OFFSET(modulename_ClassName_obj_t, something) },
};
STATIC MP_DEFINE_CONST_DICT(modulename_ClassName_locals_dict, modulename_ClassName_locals_dict_table);

// type(modulename.ClassName)
STATIC const mp_obj_type_t modulename_ClassName_type = {
    { &mp_type_type },
    .name = MP_QSTR_ClassName,
    .make_new = modulename_ClassName_make_new,
    .locals_dict = (mp_obj_dict_t*)&modulename_ClassName_locals_dict,
};


```

The offset type in the `locals_dict` keeps the offset to the requested field that corresponds to that attribute. In turn, this is used by `mp_convert_member_lookup` to get the instance attribute as follows:

```c
    else if (MP_OBJ_IS_TYPE(member, &mp_type_offset)) {
        // return the instance attribute self->member as self.member
        if (self != MP_OBJ_NULL) {
            mp_int_t offset = ((offset_obj_t*)MP_OBJ_TO_PTR(member))->offset;
            dest[0] = *(mp_obj_t *) ((char *) self + offset);
        }
```

When called as a class attribute or when called if `self->something` is not (yet) defined, this returns that the attribute is not found, as expected.

It seems that `mp_obj_class_lookup` does something related, but I wasn't sure if that was suited for this problem. It is also entirely possible such a mechanism already exists and that I just failed to find it. In that case, please feel free to ignore this PR (although a hint to the right approach would be highly appreciated, thanks!)