### PR TITLE
py/struct: fix struct.unpack_from with nonzero offset.

### DIFF
--- a/extmod/moductypes.c
+++ b/extmod/moductypes.c
@@ -299,7 +299,7 @@ STATIC MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(uctypes_struct_sizeof_obj, 1, 2, ucty
 static inline mp_obj_t get_unaligned(uint val_type, byte *p, int big_endian) {
     char struct_type = big_endian ? '>' : '<';
     static const char type2char[16] = "BbHhIiQq------fd";
-    return mp_binary_get_val(struct_type, type2char[val_type], &p);
+    return mp_binary_get_val(struct_type, type2char[val_type], 0, &p);
 }
 
 static inline void set_unaligned(uint val_type, byte *p, int big_endian, mp_obj_t val) {

--- a/extmod/moductypes.c
+++ b/extmod/moductypes.c
@@ -299,7 +299,7 @@ STATIC MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(uctypes_struct_sizeof_obj, 1, 2, ucty
 static inline mp_obj_t get_unaligned(uint val_type, byte *p, int big_endian) {
     char struct_type = big_endian ? '>' : '<';
     static const char type2char[16] = "BbHhIiQq------fd";
-    return mp_binary_get_val(struct_type, type2char[val_type], 0, &p);
+    return mp_binary_get_val(struct_type, type2char[val_type], p, &p);
 }
 
 static inline void set_unaligned(uint val_type, byte *p, int big_endian, mp_obj_t val) {

--- a/py/binary.c
+++ b/py/binary.c
@@ -192,7 +192,7 @@ mp_obj_t mp_binary_get_val(char struct_type, char val_type, byte *p_base, byte *
     size_t size = mp_binary_get_size(struct_type, val_type, &align);
     if (struct_type == '@') {
         // align p relative to p_base
-        p += (uintptr_t)MP_ALIGN(p - p_base, (size_t)align)  - (p - p_base);
+        p = p_base + (uintptr_t)MP_ALIGN(p - p_base, (size_t)align);
         #if MP_ENDIANNESS_LITTLE
         struct_type = '<';
         #else

--- a/py/binary.c
+++ b/py/binary.c
@@ -185,14 +185,14 @@ long long mp_binary_get_int(mp_uint_t size, bool is_signed, bool big_endian, con
 }
 
 #define is_signed(typecode) (typecode > 'Z')
-mp_obj_t mp_binary_get_val(char struct_type, char val_type, mp_int_t offset, byte **ptr) {
+mp_obj_t mp_binary_get_val(char struct_type, char val_type, byte *p_base, byte **ptr) {
     byte *p = *ptr;
     mp_uint_t align;
 
     size_t size = mp_binary_get_size(struct_type, val_type, &align);
     if (struct_type == '@') {
-        // Make pointer aligned, taking the offset into account
-        p = (byte*)MP_ALIGN(p - offset, (size_t)align) + offset;
+        // align p relative to p_base
+        p += (uintptr_t)MP_ALIGN(p - p_base, (size_t)align)  - (p - p_base);
         #if MP_ENDIANNESS_LITTLE
         struct_type = '<';
         #else

--- a/py/binary.c
+++ b/py/binary.c
@@ -185,14 +185,14 @@ long long mp_binary_get_int(mp_uint_t size, bool is_signed, bool big_endian, con
 }
 
 #define is_signed(typecode) (typecode > 'Z')
-mp_obj_t mp_binary_get_val(char struct_type, char val_type, byte **ptr) {
+mp_obj_t mp_binary_get_val(char struct_type, char val_type, mp_int_t offset, byte **ptr) {
     byte *p = *ptr;
     mp_uint_t align;
 
     size_t size = mp_binary_get_size(struct_type, val_type, &align);
     if (struct_type == '@') {
-        // Make pointer aligned
-        p = (byte*)MP_ALIGN(p, (size_t)align);
+        // Make pointer aligned, taking the offset into account
+        p = (byte*)MP_ALIGN(p - offset, (size_t)align) + offset;
         #if MP_ENDIANNESS_LITTLE
         struct_type = '<';
         #else

--- a/py/binary.h
+++ b/py/binary.h
@@ -38,7 +38,7 @@ size_t mp_binary_get_size(char struct_type, char val_type, mp_uint_t *palign);
 mp_obj_t mp_binary_get_val_array(char typecode, void *p, mp_uint_t index);
 void mp_binary_set_val_array(char typecode, void *p, mp_uint_t index, mp_obj_t val_in);
 void mp_binary_set_val_array_from_int(char typecode, void *p, mp_uint_t index, mp_int_t val);
-mp_obj_t mp_binary_get_val(char struct_type, char val_type, byte **ptr);
+mp_obj_t mp_binary_get_val(char struct_type, char val_type, mp_int_t offset, byte **ptr);
 void mp_binary_set_val(char struct_type, char val_type, mp_obj_t val_in, byte **ptr);
 long long mp_binary_get_int(mp_uint_t size, bool is_signed, bool big_endian, const byte *src);
 void mp_binary_set_int(mp_uint_t val_sz, bool big_endian, byte *dest, mp_uint_t val);

--- a/py/binary.h
+++ b/py/binary.h
@@ -38,7 +38,7 @@ size_t mp_binary_get_size(char struct_type, char val_type, mp_uint_t *palign);
 mp_obj_t mp_binary_get_val_array(char typecode, void *p, mp_uint_t index);
 void mp_binary_set_val_array(char typecode, void *p, mp_uint_t index, mp_obj_t val_in);
 void mp_binary_set_val_array_from_int(char typecode, void *p, mp_uint_t index, mp_int_t val);
-mp_obj_t mp_binary_get_val(char struct_type, char val_type, mp_int_t offset, byte **ptr);
+mp_obj_t mp_binary_get_val(char struct_type, char val_type, byte *p_base, byte **ptr);
 void mp_binary_set_val(char struct_type, char val_type, mp_obj_t val_in, byte **ptr);
 long long mp_binary_get_int(mp_uint_t size, bool is_signed, bool big_endian, const byte *src);
 void mp_binary_set_int(mp_uint_t val_sz, bool big_endian, byte *dest, mp_uint_t val);

--- a/py/modstruct.c
+++ b/py/modstruct.c
@@ -164,7 +164,7 @@ STATIC mp_obj_t struct_unpack_from(size_t n_args, const mp_obj_t *args) {
             res->items[i++] = item;
         } else {
             while (cnt--) {
-                item = mp_binary_get_val(fmt_type, *fmt, &p);
+                item = mp_binary_get_val(fmt_type, *fmt, offset, &p);
                 res->items[i++] = item;
             }
         }

--- a/py/modstruct.c
+++ b/py/modstruct.c
@@ -146,6 +146,7 @@ STATIC mp_obj_t struct_unpack_from(size_t n_args, const mp_obj_t *args) {
         }
         p += offset;
     }
+    byte *p_base = p;
 
     // Check that the input buffer is big enough to unpack all the values
     if (p + total_sz > end_p) {
@@ -164,7 +165,7 @@ STATIC mp_obj_t struct_unpack_from(size_t n_args, const mp_obj_t *args) {
             res->items[i++] = item;
         } else {
             while (cnt--) {
-                item = mp_binary_get_val(fmt_type, *fmt, offset, &p);
+                item = mp_binary_get_val(fmt_type, *fmt, p_base, &p);
                 res->items[i++] = item;
             }
         }

--- a/tests/basics/struct2.py
+++ b/tests/basics/struct2.py
@@ -25,10 +25,19 @@ print(struct.calcsize('0s1s0H2H'))
 print(struct.unpack('<0s1s0H2H', b'01234'))
 print(struct.pack('<0s1s0H2H', b'abc', b'abc', 258, 515))
 
-b = bytearray(range(1, 10))
+b = bytearray(range(1, 13))
 
 assert struct.unpack_from('@i', b, 1) == struct.unpack_from('@i', b[1:], 0)
 assert struct.unpack_from('@ii', b, 1) == struct.unpack_from('@ii', b[1:], 0)
+
+assert struct.unpack('i', b[0:4]) == (0x4030201, )
+assert struct.unpack_from('i', b, 0) == (0x4030201, )
+
+assert struct.unpack('i', b[1:5]) == (0x5040302, )
+assert struct.unpack_from('i', b, 1) == (0x5040302, )
+
+assert struct.unpack('<bi', b[0:5]) == (0x1, 0x5040302)
+assert struct.unpack_from('<bi', b, 0) == (0x1, 0x5040302)
 
 # check that we get an error if the buffer is too small
 try:

--- a/tests/basics/struct2.py
+++ b/tests/basics/struct2.py
@@ -25,6 +25,11 @@ print(struct.calcsize('0s1s0H2H'))
 print(struct.unpack('<0s1s0H2H', b'01234'))
 print(struct.pack('<0s1s0H2H', b'abc', b'abc', 258, 515))
 
+b = bytearray(range(1, 10))
+
+assert struct.unpack_from('@i', b, 1) == struct.unpack_from('@i', b[1:], 0)
+assert struct.unpack_from('@ii', b, 1) == struct.unpack_from('@ii', b[1:], 0)
+
 # check that we get an error if the buffer is too small
 try:
     struct.unpack('2H', b'\x00\x00')

--- a/tests/basics/struct2.py
+++ b/tests/basics/struct2.py
@@ -39,6 +39,8 @@ assert struct.unpack_from('i', b, 1) == (0x5040302, )
 assert struct.unpack('<bi', b[0:5]) == (0x1, 0x5040302)
 assert struct.unpack_from('<bi', b, 0) == (0x1, 0x5040302)
 
+assert struct.unpack('h', memoryview(b'\x01\x02\x03')[1:]) == (0x302, )
+
 # check that we get an error if the buffer is too small
 try:
     struct.unpack('2H', b'\x00\x00')


### PR DESCRIPTION
In native mode, struct.unpack_from need to align to the format size,
but after taking the offset parameter to unpack_from

This is a fix for #3314 