### PR TITLE
Add sys.atexit.

### DIFF
--- a/ports/unix/main.c
+++ b/ports/unix/main.c
@@ -642,6 +642,12 @@ MP_NOINLINE int main_(int argc, char **argv) {
         }
     }
 
+    #if MICROPY_PY_SYS_ATEXIT
+    if (mp_obj_is_callable(MP_STATE_VM(exitfunc))) {
+        mp_call_function_0(MP_STATE_VM(exitfunc));
+    }
+    #endif
+
     #if MICROPY_PY_MICROPYTHON_MEM_INFO
     if (mp_verbose_flag) {
         mp_micropython_mem_info(0, NULL);

--- a/py/modsys.c
+++ b/py/modsys.c
@@ -146,6 +146,19 @@ STATIC mp_obj_t mp_sys_getsizeof(mp_obj_t obj) {
 STATIC MP_DEFINE_CONST_FUN_OBJ_1(mp_sys_getsizeof_obj, mp_sys_getsizeof);
 #endif
 
+#if MICROPY_PY_SYS_ATEXIT
+// atexit(callback): Callback is called when sys.exit is called.
+STATIC mp_obj_t mp_sys_atexit(mp_obj_t obj) {
+    if (mp_obj_is_callable(obj)) {
+        MP_STATE_VM(exitfunc) = obj;
+    } else {
+        MP_STATE_VM(exitfunc) = mp_const_none;
+    }
+    return mp_const_none;
+}
+MP_DEFINE_CONST_FUN_OBJ_1(mp_sys_atexit_obj, mp_sys_atexit);
+#endif
+
 STATIC const mp_rom_map_elem_t mp_module_sys_globals_table[] = {
     { MP_ROM_QSTR(MP_QSTR___name__), MP_ROM_QSTR(MP_QSTR_sys) },
 
@@ -178,6 +191,10 @@ STATIC const mp_rom_map_elem_t mp_module_sys_globals_table[] = {
 
     #if MICROPY_PY_SYS_EXIT
     { MP_ROM_QSTR(MP_QSTR_exit), MP_ROM_PTR(&mp_sys_exit_obj) },
+    #endif
+
+    #if MICROPY_PY_SYS_ATEXIT
+    { MP_ROM_QSTR(MP_QSTR_atexit), MP_ROM_PTR(&mp_sys_atexit_obj) },
     #endif
 
     #if MICROPY_PY_SYS_STDFILES

--- a/py/mpconfig.h
+++ b/py/mpconfig.h
@@ -1161,6 +1161,11 @@ typedef double mp_float_t;
 #define MICROPY_PY_SYS_EXIT (1)
 #endif
 
+// Whether to provide "sys.atexit" function
+#ifndef MICROPY_PY_SYS_ATEXIT
+#define MICROPY_PY_SYS_ATEXIT (0)
+#endif
+
 // Whether to provide "sys.getsizeof" function
 #ifndef MICROPY_PY_SYS_GETSIZEOF
 #define MICROPY_PY_SYS_GETSIZEOF (0)

--- a/py/mpstate.h
+++ b/py/mpstate.h
@@ -137,6 +137,11 @@ typedef struct _mp_state_vm_t {
     // dictionary with loaded modules (may be exposed as sys.modules)
     mp_obj_dict_t mp_loaded_modules_dict;
 
+    #if MICROPY_PY_SYS_ATEXIT
+    // exposed through sys.atexit function
+    mp_obj_t exitfunc;
+    #endif
+
     // pending exception object (MP_OBJ_NULL if not pending)
     volatile mp_obj_t mp_pending_exception;
 

--- a/py/runtime.c
+++ b/py/runtime.c
@@ -118,6 +118,10 @@ void mp_init(void) {
     MP_STATE_VM(vfs_mount_table) = NULL;
     #endif
 
+    #if MICROPY_PY_SYS_ATEXIT
+    MP_STATE_VM(exitfunc) = mp_const_none;
+    #endif
+
     #if MICROPY_PY_THREAD_GIL
     mp_thread_mutex_init(&MP_STATE_VM(gil_mutex));
     #endif

--- a/tests/misc/sys_atexit.py
+++ b/tests/misc/sys_atexit.py
@@ -1,0 +1,18 @@
+# test sys.atexit() function
+
+import sys
+try:
+    sys.atexit
+except AttributeError:
+    print('SKIP')
+    raise SystemExit
+
+some_var = None
+
+def do_at_exit():
+    print("done at exit:", some_var)
+
+sys.atexit(do_at_exit)
+
+some_var = "ok"
+print("done before exit")

--- a/tests/misc/sys_atexit.py.exp
+++ b/tests/misc/sys_atexit.py.exp
@@ -1,0 +1,2 @@
+done before exit
+done at exit: ok


### PR DESCRIPTION
PR implements `sys.atexit` that registers a function that is later triggered when the main script ends.

Enable via MICROPY_PY_SYS_ATEXIT.