### PR TITLE
docs/pyboard: Clarify files on pyboard

### DIFF
--- a/docs/pyboard/tutorial/script.rst
+++ b/docs/pyboard/tutorial/script.rst
@@ -46,17 +46,17 @@ a window (or command line) should be showing the files on the pyboard drive.
 The drive you are looking at is known as ``/flash`` by the pyboard, and should contain
 the following 4 files:
 
-* `boot.py <http://micropython.org/resources/fresh-pyboard/boot.py>`_ -- this script is executed when the pyboard boots up.  It sets
-    up various configuration options for the pyboard.
+* `boot.py <http://micropython.org/resources/fresh-pyboard/boot.py>`_ -- the various configuration options for the pyboard.
+    It is executed when the pyboard boots up.
 
-* `main.py <http://micropython.org/resources/fresh-pyboard/main.py>`_ -- this is the main script that will contain your Python program.
+* `main.py <http://micropython.org/resources/fresh-pyboard/main.py>`_ -- the Python program to be run.
     It is executed after ``boot.py``.
 
-* `README.txt <http://micropython.org/resources/fresh-pyboard/README.txt>`_ -- this contains some very basic information about getting
-    started with the pyboard.
+* `README.txt <http://micropython.org/resources/fresh-pyboard/README.txt>`_ -- basic information about getting started with the pyboard.
+    There is more information
 
-* `pybcdc.inf <http://micropython.org/resources/fresh-pyboard/pybcdc.inf>`_ -- this is a Windows driver file to configure the serial USB
-    device.  More about this in the next tutorial.
+* `pybcdc.inf <http://micropython.org/resources/fresh-pyboard/pybcdc.inf>`_ -- the Windows driver file to configure the serial USB device.
+    More about this in the next tutorial.
 
 Editing ``main.py``
 -------------------


### PR DESCRIPTION
Text and formats have been simplified.

Note: formatting for me and @jimmo appear different to the website version as shown in the screenshots below.

**When compiled on my laptop:**
<img width="634" alt="local" src="https://user-images.githubusercontent.com/4584200/62514893-f7317f00-b863-11e9-92c3-820da703fe1a.png">

**Website**:
![image](https://user-images.githubusercontent.com/4584200/62514880-e4b74580-b863-11e9-9cd9-27eb33a565c5.png)
