### PR TITLE
py/modstruct: accept whitespace in ustruct format specifiers.

### DIFF
--- a/py/modstruct.c
+++ b/py/modstruct.c
@@ -26,6 +26,7 @@
  */
 
 #include <assert.h>
+#include <ctype.h>
 #include <string.h>
 
 #include "py/runtime.h"
@@ -88,6 +89,9 @@ STATIC size_t calc_size_items(const char *fmt, size_t *total_sz) {
     size_t size;
     for (size = 0; *fmt; fmt++) {
         mp_uint_t cnt = 1;
+        if (isspace(*fmt)) {
+            continue;
+        }
         if (unichar_isdigit(*fmt)) {
             cnt = get_fmt_num(&fmt);
         }
@@ -154,6 +158,9 @@ STATIC mp_obj_t struct_unpack_from(size_t n_args, const mp_obj_t *args) {
 
     for (size_t i = 0; i < num_items;) {
         mp_uint_t cnt = 1;
+        while(isspace(*fmt)) {
+            fmt++;
+        }
         if (unichar_isdigit(*fmt)) {
             cnt = get_fmt_num(&fmt);
         }
@@ -182,6 +189,10 @@ STATIC void struct_pack_into_internal(mp_obj_t fmt_in, byte *p, size_t n_args, c
     size_t i;
     for (i = 0; i < n_args;) {
         mp_uint_t cnt = 1;
+        while(isspace(*fmt)) {
+            fmt++;
+        }
+
         if (*fmt == '\0') {
             // more arguments given than used by format string; CPython raises struct.error here
             break;

--- a/tests/basics/struct1.py
+++ b/tests/basics/struct1.py
@@ -69,6 +69,16 @@ print(buf)
 struct.pack_into('<bbb', buf, -6, 0x44, 0x45, 0x46)
 print(buf)
 
+# whitespace ignored
+buf1 = bytearray(b'>>>123<<<')
+buf2 = bytearray(b'>>>123<<<')
+struct.pack_into('<bbb', buf1, 3, 0x41, 0x42, 0x43)
+struct.pack_into('< b\tb\n\t b', buf2, 3, 0x41, 0x42, 0x43)
+assert buf1 == buf2
+struct.pack_into('<bbb', buf1, -6, 0x44, 0x45, 0x46)
+struct.pack_into('<b \n b  b \t', buf2, -6, 0x44, 0x45, 0x46)
+assert buf1 == buf2
+
 # check that we get an error if the buffer is too small
 try:
     struct.pack_into('I', bytearray(1), 0, 0)

--- a/tests/basics/struct2.py
+++ b/tests/basics/struct2.py
@@ -25,6 +25,11 @@ print(struct.calcsize('0s1s0H2H'))
 print(struct.unpack('<0s1s0H2H', b'01234'))
 print(struct.pack('<0s1s0H2H', b'abc', b'abc', 258, 515))
 
+# whitespace in format strings
+assert struct.calcsize('0s1s0H2H') == struct.calcsize('0s 1s\t0H\n \t2H ')
+assert struct.unpack('<0s1s0H2H', b'01234') == struct.unpack('<  0s\n\t 1s0H 2H', b'01234')
+assert struct.pack('<0s1s0H2H', b'abc', b'abc', 258, 515) == struct.pack('<0s   1s\n0H2H\t', b'abc', b'abc', 258, 515)
+
 # check that we get an error if the buffer is too small
 try:
     struct.unpack('2H', b'\x00\x00')


### PR DESCRIPTION
An alternative to PR #4977 - just handle whitespace in the ustruct format specifiers.

My calculation is that this change grows the unix port by 124 bytes.