### PR TITLE
Adding support for ESP32-D2WD (2MiB) for issue #4986

### DIFF
--- a/ports/esp32/boards/GENERIC_D2WD/mpconfigboard.h
+++ b/ports/esp32/boards/GENERIC_D2WD/mpconfigboard.h
@@ -1,0 +1,2 @@
+#define MICROPY_HW_BOARD_NAME "Generic ESP32-D2WD module"
+#define MICROPY_HW_MCU_NAME "ESP32-D2WD"

--- a/ports/esp32/boards/GENERIC_D2WD/mpconfigboard.mk
+++ b/ports/esp32/boards/GENERIC_D2WD/mpconfigboard.mk
@@ -1,0 +1,7 @@
+SDKCONFIG += boards/sdkconfig.base
+PART_SRC = partitions-2MiB.csv
+FLASH_SIZE = 2MB
+FLASH_MODE = dio
+FLASH_FREQ = 40m
+
+$(info "Using $(PART_SRC)")

--- a/ports/esp32/modules/flashbdev.py
+++ b/ports/esp32/modules/flashbdev.py
@@ -1,34 +1,4 @@
-import esp
+from esp32 import Partition
 
-class FlashBdev:
-
-    SEC_SIZE = 4096
-    START_SEC = esp.flash_user_start() // SEC_SIZE
-
-    def __init__(self, blocks):
-        self.blocks = blocks
-
-    def readblocks(self, n, buf):
-        #print("readblocks(%s, %x(%d))" % (n, id(buf), len(buf)))
-        esp.flash_read((n + self.START_SEC) * self.SEC_SIZE, buf)
-
-    def writeblocks(self, n, buf):
-        #print("writeblocks(%s, %x(%d))" % (n, id(buf), len(buf)))
-        #assert len(buf) <= self.SEC_SIZE, len(buf)
-        esp.flash_erase(n + self.START_SEC)
-        esp.flash_write((n + self.START_SEC) * self.SEC_SIZE, buf)
-
-    def ioctl(self, op, arg):
-        #print("ioctl(%d, %r)" % (op, arg))
-        if op == 4:  # BP_IOCTL_SEC_COUNT
-            return self.blocks
-        if op == 5:  # BP_IOCTL_SEC_SIZE
-            return self.SEC_SIZE
-
-size = esp.flash_size()
-if size < 1024*1024:
-    # flash too small for a filesystem
-    bdev = None
-else:
-    # for now we use a fixed size for the filesystem
-    bdev = FlashBdev(2048 * 1024 // FlashBdev.SEC_SIZE)
+bdev = Partition.find(Partition.TYPE_DATA, label='vfs')
+bdev = bdev[0] if bdev else None

--- a/ports/esp32/partitions-2MiB.csv
+++ b/ports/esp32/partitions-2MiB.csv
@@ -1,0 +1,6 @@
+# Name,     Type, SubType, Offset,   Size, Flags
+# Note: if you change the phy_init or app partition offset, make sure to change the offset in Kconfig.projbuild
+nvs,        data, nvs,     0x9000,  0x6000,
+phy_init,   data, phy,     0xf000,  0x1000,
+factory,    app, factory,  0x10000, 0x110000,
+vfs,        data, fat,     0x120000, 0xA0000,

--- a/ports/esp32/partitions.csv
+++ b/ports/esp32/partitions.csv
@@ -3,3 +3,4 @@
 nvs,      data, nvs,     0x9000,  0x6000,
 phy_init, data, phy,     0xf000,  0x1000,
 factory,  app,  factory, 0x10000, 0x180000,
+vfs,      data, fat,     0x200000, 0x200000,


### PR DESCRIPTION
See Issue #4986 

This pull request attempts to support a custom flash user start address, custom flash storage partition size, and the ability to specify a partitions CSV file. By default, this setup still supports 4MiB as per usual, but if env variables are set, ESP32 chips with 2MiB built in are supported too.

Here are the custom values used to compile MicroPython for ESP32-D2WD with this code

```
# .envrc file

export ESPIDF="$HOME/esp-idf"
export FLASH_SIZE="2MB"
export FLASH_MODE="dio"
export FLASH_FREQ="40m"
export FLASH_USER_START=0x120000
export FLASH_STORAGE_PARTITION_SIZE=0xA0000
export PART_SRC="partitions-2MiB.csv"

```