### PR TITLE
.gitignore: add `makefile` to ignore user makefile.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,6 +37,7 @@ __pycache__/
 # Customized Makefile/project overrides
 ######################
 GNUmakefile
+makefile
 user.props
 
 # Generated rst files


### PR DESCRIPTION
I realise that I could just use `GNUmakefile` for the same purpose, but I'm used to `makefile` (and I notice the ESP32 docs suggest to use `makefile`).