### PR TITLE
py/makeversionhdr.py: pass --git-dir ./.git

### DIFF
--- a/ports/windows/msvc/genhdr.targets
+++ b/ports/windows/msvc/genhdr.targets
@@ -10,6 +10,7 @@
   <PropertyGroup>
     <DestDir>$(PyBuildDir)genhdr\</DestDir>
     <PySrcDir>$(PyBaseDir)py\</PySrcDir>
+    <PyGitDir>$(PyBaseDir).git</PyGitDir>
     <QstrDefs>$(PyBaseDir)ports\unix\qstrdefsport.h</QstrDefs>
     <PyQstrDefs>$(PySrcDir)qstrdefs.h</PyQstrDefs>
     <QstrDefsCollected>$(DestDir)qstrdefscollected.h</QstrDefsCollected>
@@ -111,7 +112,7 @@ using(var outFile = System.IO.File.CreateText(OutputFile)) {
       <DestFile>$(DestDir)mpversion.h</DestFile>
       <TmpFile>$(DestFile).tmp</TmpFile>
     </PropertyGroup>
-    <Exec Command="$(PyPython) $(PySrcDir)makeversionhdr.py $(TmpFile)"/>
+    <Exec Command="$(PyPython) $(PySrcDir)makeversionhdr.py $(PyGitDir) $(TmpFile)"/>
     <MSBuild Projects="$(MSBuildThisFileFullPath)" Targets="CopyFileIfDifferent" Properties="SourceFile=$(TmpFile);DestFile=$(DestFile)"/>
   </Target>
 

--- a/py/makeversionhdr.py
+++ b/py/makeversionhdr.py
@@ -11,7 +11,7 @@ import os
 import datetime
 import subprocess
 
-def get_version_info_from_git():
+def get_version_info_from_git(git_dir):
     # Python 2.6 doesn't have check_output, so check for that
     try:
         subprocess.check_output
@@ -21,7 +21,7 @@ def get_version_info_from_git():
 
     # Note: git describe doesn't work if no tag is available
     try:
-        git_tag = subprocess.check_output(["git", "describe", "--dirty", "--always"], stderr=subprocess.STDOUT, universal_newlines=True).strip()
+        git_tag = subprocess.check_output(["git", "--git-dir", git_dir, "describe", "--dirty", "--always"], stderr=subprocess.STDOUT, universal_newlines=True).strip()
     except subprocess.CalledProcessError as er:
         if er.returncode == 128:
             # git exit code of 128 means no repository found
@@ -30,7 +30,7 @@ def get_version_info_from_git():
     except OSError:
         return None
     try:
-        git_hash = subprocess.check_output(["git", "rev-parse", "--short", "HEAD"], stderr=subprocess.STDOUT, universal_newlines=True).strip()
+        git_hash = subprocess.check_output(["git", "--git-dir", git_dir, "rev-parse", "--short", "HEAD"], stderr=subprocess.STDOUT, universal_newlines=True).strip()
     except subprocess.CalledProcessError:
         git_hash = "unknown"
     except OSError:
@@ -38,9 +38,9 @@ def get_version_info_from_git():
 
     try:
         # Check if there are any modified files.
-        subprocess.check_call(["git", "diff", "--no-ext-diff", "--quiet", "--exit-code"], stderr=subprocess.STDOUT)
+        subprocess.check_call(["git",  "--git-dir", git_dir, "diff", "--no-ext-diff", "--quiet", "--exit-code"], stderr=subprocess.STDOUT)
         # Check if there are any staged files.
-        subprocess.check_call(["git", "diff-index", "--cached", "--quiet", "HEAD", "--"], stderr=subprocess.STDOUT)
+        subprocess.check_call(["git",  "--git-dir", git_dir, "diff-index", "--cached", "--quiet", "HEAD", "--"], stderr=subprocess.STDOUT)
     except subprocess.CalledProcessError:
         git_hash += "-dirty"
     except OSError:
@@ -57,9 +57,9 @@ def get_version_info_from_docs_conf():
                 return git_tag, "<no hash>"
     return None
 
-def make_version_header(filename):
+def make_version_header(git_dir, filename):
     # Get version info using git, with fallback to docs/conf.py
-    info = get_version_info_from_git()
+    info = get_version_info_from_git(git_dir)
     if info is None:
         info = get_version_info_from_docs_conf()
 
@@ -88,4 +88,4 @@ def make_version_header(filename):
             f.write(file_data)
 
 if __name__ == "__main__":
-    make_version_header(sys.argv[1])
+    make_version_header(sys.argv[1], sys.argv[2])

--- a/py/py.mk
+++ b/py/py.mk
@@ -7,6 +7,9 @@ HEADER_BUILD = $(BUILD)/genhdr
 # file containing qstr defs for the core Python bit
 PY_QSTR_DEFS = $(PY_SRC)/qstrdefs.h
 
+# where git directory is located (to retrieve git version)
+PY_GIT_DIR = $(TOP)/.git
+
 # If qstr autogeneration is not disabled we specify the output header
 # for all collected qstrings.
 ifneq ($(QSTR_AUTOGEN_DISABLE),1)
@@ -215,7 +218,7 @@ FORCE:
 .PHONY: FORCE
 
 $(HEADER_BUILD)/mpversion.h: FORCE | $(HEADER_BUILD)
-	$(Q)$(PYTHON) $(PY_SRC)/makeversionhdr.py $@
+	$(Q)$(PYTHON) $(PY_SRC)/makeversionhdr.py $(PY_GIT_DIR) $@
 
 # mpconfigport.mk is optional, but changes to it may drastically change
 # overall config, so they need to be caught


### PR DESCRIPTION
micropython can be embedded in a more global git project such as
buildroot. In this case, micropython retrieves the version of this
global project. Fix this issue by passing --git-dir ./.git to ensure
that git commands take the current working directory as the git
directory

Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>