### PR TITLE
objtuple: Allow tuple-compatible classes like namedtuple to call mp_obj_tuple_get

### DIFF
--- a/py/objtuple.c
+++ b/py/objtuple.c
@@ -31,6 +31,9 @@
 #include "py/objtuple.h"
 #include "py/runtime.h"
 
+// type check is done on getiter method to allow tuple, namedtuple, attrtuple
+#define mp_obj_is_tuple_compatible(o) (mp_obj_is_obj(o) && ((mp_obj_base_t*)MP_OBJ_TO_PTR(o))->type->getiter == mp_obj_tuple_getiter)
+
 /******************************************************************************/
 /* tuple                                                                      */
 
@@ -102,7 +105,7 @@ STATIC mp_obj_t mp_obj_tuple_make_new(const mp_obj_type_t *type_in, size_t n_arg
 // Don't pass MP_BINARY_OP_NOT_EQUAL here
 STATIC mp_obj_t tuple_cmp_helper(mp_uint_t op, mp_obj_t self_in, mp_obj_t another_in) {
     // type check is done on getiter method to allow tuple, namedtuple, attrtuple
-    mp_check_self(mp_obj_get_type(self_in)->getiter == mp_obj_tuple_getiter);
+    mp_check_self(mp_obj_is_tuple_compatible(self_in));
     mp_obj_type_t *another_type = mp_obj_get_type(another_in);
     mp_obj_tuple_t *self = MP_OBJ_TO_PTR(self_in);
     if (another_type->getiter != mp_obj_tuple_getiter) {

--- a/py/objtuple.c
+++ b/py/objtuple.c
@@ -32,7 +32,8 @@
 #include "py/runtime.h"
 
 // type check is done on getiter method to allow tuple, namedtuple, attrtuple
-#define mp_obj_is_tuple_compatible(o) (mp_obj_is_obj(o) && ((mp_obj_base_t*)MP_OBJ_TO_PTR(o))->type->getiter == mp_obj_tuple_getiter)
+// Assumes mp_obj_is_obj has already been checked
+#define _mp_obj_is_tuple_compatible(o) ((mp_obj_base_t*)MP_OBJ_TO_PTR(o))->type->getiter == mp_obj_tuple_getiter
 
 /******************************************************************************/
 /* tuple                                                                      */
@@ -105,7 +106,7 @@ STATIC mp_obj_t mp_obj_tuple_make_new(const mp_obj_type_t *type_in, size_t n_arg
 // Don't pass MP_BINARY_OP_NOT_EQUAL here
 STATIC mp_obj_t tuple_cmp_helper(mp_uint_t op, mp_obj_t self_in, mp_obj_t another_in) {
     // type check is done on getiter method to allow tuple, namedtuple, attrtuple
-    mp_check_self(mp_obj_is_tuple_compatible(self_in));
+    assert(_mp_obj_is_tuple_compatible(self_in));
     mp_obj_type_t *another_type = mp_obj_get_type(another_in);
     mp_obj_tuple_t *self = MP_OBJ_TO_PTR(self_in);
     if (another_type->getiter != mp_obj_tuple_getiter) {
@@ -252,7 +253,7 @@ mp_obj_t mp_obj_new_tuple(size_t n, const mp_obj_t *items) {
 }
 
 void mp_obj_tuple_get(mp_obj_t self_in, size_t *len, mp_obj_t **items) {
-    mp_check_self(mp_obj_is_tuple_compatible(self_in));
+    assert(_mp_obj_is_tuple_compatible(self_in));
     mp_obj_tuple_t *self = MP_OBJ_TO_PTR(self_in);
     *len = self->len;
     *items = &self->items[0];

--- a/py/objtuple.c
+++ b/py/objtuple.c
@@ -104,7 +104,6 @@ STATIC mp_obj_t mp_obj_tuple_make_new(const mp_obj_type_t *type_in, size_t n_arg
 
 // Don't pass MP_BINARY_OP_NOT_EQUAL here
 STATIC mp_obj_t tuple_cmp_helper(mp_uint_t op, mp_obj_t self_in, mp_obj_t another_in) {
-    // type check is done on getiter method to allow tuple, namedtuple, attrtuple
     mp_check_self(mp_obj_is_tuple_compatible(self_in));
     mp_obj_type_t *another_type = mp_obj_get_type(another_in);
     mp_obj_tuple_t *self = MP_OBJ_TO_PTR(self_in);

--- a/py/objtuple.c
+++ b/py/objtuple.c
@@ -252,7 +252,7 @@ mp_obj_t mp_obj_new_tuple(size_t n, const mp_obj_t *items) {
 }
 
 void mp_obj_tuple_get(mp_obj_t self_in, size_t *len, mp_obj_t **items) {
-    assert(mp_obj_is_type(self_in, &mp_type_tuple));
+    mp_check_self(mp_obj_is_tuple_compatible(self_in));
     mp_obj_tuple_t *self = MP_OBJ_TO_PTR(self_in);
     *len = self->len;
     *items = &self->items[0];

--- a/py/objtuple.c
+++ b/py/objtuple.c
@@ -32,8 +32,7 @@
 #include "py/runtime.h"
 
 // type check is done on getiter method to allow tuple, namedtuple, attrtuple
-// Assumes mp_obj_is_obj has already been checked
-#define _mp_obj_is_tuple_compatible(o) ((mp_obj_base_t*)MP_OBJ_TO_PTR(o))->type->getiter == mp_obj_tuple_getiter
+#define mp_obj_is_tuple_compatible(o) (mp_obj_get_type(o)->getiter == mp_obj_tuple_getiter
 
 /******************************************************************************/
 /* tuple                                                                      */
@@ -106,7 +105,7 @@ STATIC mp_obj_t mp_obj_tuple_make_new(const mp_obj_type_t *type_in, size_t n_arg
 // Don't pass MP_BINARY_OP_NOT_EQUAL here
 STATIC mp_obj_t tuple_cmp_helper(mp_uint_t op, mp_obj_t self_in, mp_obj_t another_in) {
     // type check is done on getiter method to allow tuple, namedtuple, attrtuple
-    assert(_mp_obj_is_tuple_compatible(self_in));
+    mp_check_self(mp_obj_is_tuple_compatible(self_in));
     mp_obj_type_t *another_type = mp_obj_get_type(another_in);
     mp_obj_tuple_t *self = MP_OBJ_TO_PTR(self_in);
     if (another_type->getiter != mp_obj_tuple_getiter) {
@@ -253,7 +252,7 @@ mp_obj_t mp_obj_new_tuple(size_t n, const mp_obj_t *items) {
 }
 
 void mp_obj_tuple_get(mp_obj_t self_in, size_t *len, mp_obj_t **items) {
-    assert(_mp_obj_is_tuple_compatible(self_in));
+    assert(mp_obj_is_tuple_compatible(self_in));
     mp_obj_tuple_t *self = MP_OBJ_TO_PTR(self_in);
     *len = self->len;
     *items = &self->items[0];


### PR DESCRIPTION
.. adding a private macro mp_obj_is_tuple_compatible to encapsulate the check, which is used in two locations.

Closes: #5005 