### PR TITLE
py/nlr: In MP_NLR_JUMP_HEAD make top and top_ptr volatile.

### DIFF
--- a/py/mpconfig.h
+++ b/py/mpconfig.h
@@ -1527,6 +1527,15 @@ typedef double mp_float_t;
 #define MP_UNLIKELY(x) __builtin_expect((x), 0)
 #endif
 
+// To annotate that code is unreachable
+#ifndef MP_UNREACHABLE
+#if defined(__GNUC__)
+#define MP_UNREACHABLE __builtin_unreachable();
+#else
+#define MP_UNREACHABLE for (;;);
+#endif
+#endif
+
 #ifndef MP_HTOBE16
 #if MP_ENDIANNESS_LITTLE
 # define MP_HTOBE16(x) ((uint16_t)( (((x) & 0xff) << 8) | (((x) >> 8) & 0xff) ))

--- a/py/nlrthumb.c
+++ b/py/nlrthumb.c
@@ -135,11 +135,7 @@ NORETURN void nlr_jump(void *val) {
     :                               // clobbered registers
     );
 
-    #if defined(__GNUC__)
-    __builtin_unreachable();
-    #else
-    for (;;); // needed to silence compiler warning
-    #endif
+    MP_UNREACHABLE
 }
 
 #endif // MICROPY_NLR_THUMB

--- a/py/nlrx64.c
+++ b/py/nlrx64.c
@@ -108,7 +108,7 @@ NORETURN void nlr_jump(void *val) {
     :                               // clobbered registers
     );
 
-    for (;;); // needed to silence compiler warning
+    MP_UNREACHABLE
 }
 
 #endif // MICROPY_NLR_X64

--- a/py/nlrx86.c
+++ b/py/nlrx86.c
@@ -100,7 +100,7 @@ NORETURN void nlr_jump(void *val) {
     :                               // clobbered registers
     );
 
-    for (;;); // needed to silence compiler warning
+    MP_UNREACHABLE
 }
 
 #endif // MICROPY_NLR_X86

--- a/py/nlrxtensa.c
+++ b/py/nlrxtensa.c
@@ -77,7 +77,7 @@ NORETURN void nlr_jump(void *val) {
     :                               // clobbered registers
     );
 
-    for (;;); // needed to silence compiler warning
+    MP_UNREACHABLE
 }
 
 #endif // MICROPY_NLR_XTENSA


### PR DESCRIPTION
The unix coverage port currently crashes with the toolchain and set up that I'm using (gcc 9.1.0 on Arch Linux x86-64).  This is due to gcc doing further optimisations which leads to the following code being omitted (ie no corresponding machine code generated) in `MP_NLR_JUMP_HEAD`:

    top->ret_val = val; \
    MP_NLR_RESTORE_PYSTACK(top); \
    *_top_ptr = top->prev; \

This is because the nlr_jump function is marked as no-return, so gcc deduces that the above code has no effect (rightfully so, I guess).

I'm not very happy with the solution presented here, rather it's more for discussion how to resolve the problem properly (and as an workaround if necessary).

There could be other variables that need to be declared volatile (eg to do with PYSTACK), and other platforms (non x86-64) may have different behaviour and require other fixes.

This really points to the importance of #4131, removal of NLR completely.