### PR TITLE
lib/mp-readline/readline.c: Added backward/forward/kill-word support.

### DIFF
--- a/lib/mp-readline/readline.c
+++ b/lib/mp-readline/readline.c
@@ -31,8 +31,11 @@
 #include "py/mpstate.h"
 #include "py/repl.h"
 #include "py/mphal.h"
-#include "py/unicode.h"
 #include "lib/mp-readline/readline.h"
+
+#if MICROPY_REPL_EMACS_KEYS
+#include "py/unicode.h"
+#endif
 
 #if 0 // print debugging info
 #define DEBUG_PRINT (1)
@@ -40,9 +43,6 @@
 #else // don't print debugging info
 #define DEBUG_printf(...) (void)0
 #endif
-
-#define FORWARD true
-#define BACKWARD false
 
 #define READLINE_HIST_SIZE (MP_ARRAY_SIZE(MP_STATE_PORT(readline_hist)))
 
@@ -102,6 +102,10 @@ typedef struct _readline_t {
 
 STATIC readline_t rl;
 
+#if MICROPY_REPL_EMACS_KEYS
+#define FORWARD true
+#define BACKWARD false
+
 size_t get_word_cursor_pos(bool direction) {
     char cursor_pos_step = direction == FORWARD ? 1 : -1;
     char buf_idx_offset = direction == FORWARD ? 0 : -1;
@@ -128,6 +132,7 @@ size_t get_word_cursor_pos(bool direction) {
     }
     return cursor_pos;
 }
+#endif
 
 int readline_process_char(int c) {
     size_t last_line_len = rl.line->len;
@@ -249,6 +254,7 @@ int readline_process_char(int c) {
             case '[':
                 rl.escape_seq = ESEQ_ESC_BRACKET;
                 break;
+            #if MICROPY_REPL_EMACS_KEYS
             case 'b':
                 // backword-word (Alt-b)
                 redraw_step_back = rl.cursor_pos - get_word_cursor_pos(BACKWARD);
@@ -282,6 +288,7 @@ int readline_process_char(int c) {
                 rl.escape_seq = ESEQ_NONE;
                 break;
             }
+            #endif
             case 'O':
                 rl.escape_seq = ESEQ_ESC_O;
                 break;

--- a/lib/mp-readline/readline.c
+++ b/lib/mp-readline/readline.c
@@ -27,11 +27,11 @@
 #include <stdio.h>
 #include <stdint.h>
 #include <string.h>
-#include <ctype.h>
 
 #include "py/mpstate.h"
 #include "py/repl.h"
 #include "py/mphal.h"
+#include "py/unicode.h"
 #include "lib/mp-readline/readline.h"
 
 #if 0 // print debugging info
@@ -40,6 +40,9 @@
 #else // don't print debugging info
 #define DEBUG_printf(...) (void)0
 #endif
+
+#define FORWARD true
+#define BACKWARD false
 
 #define READLINE_HIST_SIZE (MP_ARRAY_SIZE(MP_STATE_PORT(readline_hist)))
 
@@ -99,36 +102,31 @@ typedef struct _readline_t {
 
 STATIC readline_t rl;
 
-size_t get_previous_word_cursor_pos() {
-  size_t cursor_pos = rl.cursor_pos;
-  bool in_leading_nonalphanum = true;
-  while (cursor_pos > 0) {
-    if (!isalnum((unsigned char) rl.line->buf[cursor_pos - 1])) {
-      if (!in_leading_nonalphanum) {
-        break;
-      }
-    } else if (in_leading_nonalphanum) {
-      in_leading_nonalphanum = false;
+size_t get_word_cursor_pos(bool direction) {
+    char cursor_pos_step = direction == FORWARD ? 1 : -1;
+    char buf_idx_offset = direction == FORWARD ? 0 : -1;
+    size_t cursor_pos = rl.cursor_pos;
+    bool in_leading_nonalphanum = true;
+    char c;
+    while (1) {
+        c = rl.line->buf[cursor_pos + buf_idx_offset];
+        if (!(unichar_isalpha(c) || unichar_isdigit(c))) {
+            if (!in_leading_nonalphanum) {
+                break;
+            }
+        } else if (in_leading_nonalphanum) {
+            in_leading_nonalphanum = false;
+        }
+        if (direction == FORWARD) {
+            if (cursor_pos >= rl.line->len) {
+                break;
+            }
+        } else if (cursor_pos <= 0) {
+            break;
+        }
+        cursor_pos += cursor_pos_step;
     }
-    cursor_pos -= 1;
-  }
-  return cursor_pos;
-}
-
-size_t get_next_word_cursor_pos() {
-  size_t cursor_pos = rl.cursor_pos;
-  bool in_leading_nonalphanum = true;
-  while (cursor_pos < rl.line->len) {
-    if (!isalnum((unsigned char) rl.line->buf[cursor_pos])) {
-      if (!in_leading_nonalphanum) {
-        break;
-      }
-    } else if (in_leading_nonalphanum) {
-      in_leading_nonalphanum = false;
-    }
-    cursor_pos += 1;
-  }
-  return cursor_pos;
+    return cursor_pos;
 }
 
 int readline_process_char(int c) {
@@ -247,40 +245,43 @@ int readline_process_char(int c) {
             redraw_step_forward = 1;
         }
     } else if (rl.escape_seq == ESEQ_ESC) {
-        size_t num_chars;
         switch (c) {
             case '[':
                 rl.escape_seq = ESEQ_ESC_BRACKET;
                 break;
             case 'b':
-              // backword-word (Alt-b)
-              redraw_step_back = rl.cursor_pos - get_previous_word_cursor_pos();
-              rl.escape_seq = ESEQ_NONE;
-              break;
+                // backword-word (Alt-b)
+                redraw_step_back = rl.cursor_pos - get_word_cursor_pos(BACKWARD);
+                rl.escape_seq = ESEQ_NONE;
+                break;
             case 'f':
-              // forward-word (Alt-f)
-              redraw_step_forward = get_next_word_cursor_pos() - rl.cursor_pos;
-              rl.escape_seq = ESEQ_NONE;
-              break;
-            case 'd':
-              // kill-word (Alt-d)
-              num_chars = get_next_word_cursor_pos() - rl.cursor_pos;
-              if (num_chars) {
-                vstr_cut_out_bytes(rl.line, rl.cursor_pos, num_chars);
-                redraw_from_cursor = true;
-              }
-              rl.escape_seq = ESEQ_NONE;
-              break;
-            case 127:
-              // backward-kill-word (Alt-Backspace)
-              num_chars = rl.cursor_pos - get_previous_word_cursor_pos();
-              if (num_chars) {
-                vstr_cut_out_bytes(rl.line, rl.cursor_pos - num_chars, num_chars);
-                redraw_step_back = num_chars;
-                redraw_from_cursor = true;
-              }
-              rl.escape_seq = ESEQ_NONE;
-              break;
+                // forward-word (Alt-f)
+                redraw_step_forward = get_word_cursor_pos(FORWARD) - rl.cursor_pos;
+                rl.escape_seq = ESEQ_NONE;
+                break;
+            case 'd': {
+                // kill-word (Alt-d)
+                size_t num_chars;
+                num_chars = get_word_cursor_pos(FORWARD) - rl.cursor_pos;
+                if (num_chars) {
+                    vstr_cut_out_bytes(rl.line, rl.cursor_pos, num_chars);
+                    redraw_from_cursor = true;
+                }
+                rl.escape_seq = ESEQ_NONE;
+                break;
+            }
+            case 127: {
+                // backward-kill-word (Alt-Backspace)
+                size_t num_chars;
+                num_chars = rl.cursor_pos - get_word_cursor_pos(BACKWARD);
+                if (num_chars) {
+                    vstr_cut_out_bytes(rl.line, rl.cursor_pos - num_chars, num_chars);
+                    redraw_step_back = num_chars;
+                    redraw_from_cursor = true;
+                }
+                rl.escape_seq = ESEQ_NONE;
+                break;
+            }
             case 'O':
                 rl.escape_seq = ESEQ_ESC_O;
                 break;

--- a/lib/mp-readline/readline.h
+++ b/lib/mp-readline/readline.h
@@ -45,8 +45,4 @@ void readline_init(vstr_t *line, const char *prompt);
 void readline_note_newline(const char *prompt);
 int readline_process_char(int c);
 
-#if MICROPY_REPL_EMACS_KEYS
-size_t get_word_cursor_pos(bool direction);
-#endif
-
 #endif // MICROPY_INCLUDED_LIB_MP_READLINE_READLINE_H

--- a/lib/mp-readline/readline.h
+++ b/lib/mp-readline/readline.h
@@ -45,4 +45,8 @@ void readline_init(vstr_t *line, const char *prompt);
 void readline_note_newline(const char *prompt);
 int readline_process_char(int c);
 
+#if MICROPY_REPL_EMACS_KEYS
+size_t get_word_cursor_pos(bool direction);
+#endif
+
 #endif // MICROPY_INCLUDED_LIB_MP_READLINE_READLINE_H


### PR DESCRIPTION
This PR adds forward-word (Alt-f), backward-word (Alt-b), kill-word (Alt-d), and backward-kill-word (Alt-Backspace) support to readline.
