### PR TITLE
esp32: Add VFS FAT partition to partitions.csv and mount it as the FS.

### DIFF
--- a/ports/esp32/modules/flashbdev.py
+++ b/ports/esp32/modules/flashbdev.py
@@ -1,34 +1,4 @@
-import esp
+from esp32 import Partition
 
-class FlashBdev:
-
-    SEC_SIZE = 4096
-    START_SEC = esp.flash_user_start() // SEC_SIZE
-
-    def __init__(self, blocks):
-        self.blocks = blocks
-
-    def readblocks(self, n, buf):
-        #print("readblocks(%s, %x(%d))" % (n, id(buf), len(buf)))
-        esp.flash_read((n + self.START_SEC) * self.SEC_SIZE, buf)
-
-    def writeblocks(self, n, buf):
-        #print("writeblocks(%s, %x(%d))" % (n, id(buf), len(buf)))
-        #assert len(buf) <= self.SEC_SIZE, len(buf)
-        esp.flash_erase(n + self.START_SEC)
-        esp.flash_write((n + self.START_SEC) * self.SEC_SIZE, buf)
-
-    def ioctl(self, op, arg):
-        #print("ioctl(%d, %r)" % (op, arg))
-        if op == 4:  # BP_IOCTL_SEC_COUNT
-            return self.blocks
-        if op == 5:  # BP_IOCTL_SEC_SIZE
-            return self.SEC_SIZE
-
-size = esp.flash_size()
-if size < 1024*1024:
-    # flash too small for a filesystem
-    bdev = None
-else:
-    # for now we use a fixed size for the filesystem
-    bdev = FlashBdev(2048 * 1024 // FlashBdev.SEC_SIZE)
+bdev = Partition.find(Partition.TYPE_DATA, label='vfs')
+bdev = bdev[0] if bdev else None

--- a/ports/esp32/partitions.csv
+++ b/ports/esp32/partitions.csv
@@ -3,3 +3,4 @@
 nvs,      data, nvs,     0x9000,  0x6000,
 phy_init, data, phy,     0xf000,  0x1000,
 factory,  app,  factory, 0x10000, 0x180000,
+vfs,      data, fat,     0x200000, 0x200000,


### PR DESCRIPTION
This PR uses the newly-added `esp32.Partition` class to replace the existing `FlashBdev` class.  Partition objects implement the block protocol so can be directly mounted via `uos.mount()`.  This has the following benefits:
- allows the filesystem partition location and size to be specified in `partitions.csv`, and overridden by a particular board
- very easily allows to have multiple filesystems by simply adding extra entries to `partitions.csv`
- improves efficiency/speed of filesystem operations because the block device is implemented fully in C
- opens the possibility to have encrypted flash storage (since Partitions can be encrypted)

Note that this patch is fully backwards compatible: existing filesystems remain untouched and work with this new code.