### PR TITLE
stm32/mphalport: fix ethernet for stm32f429

### DIFF
--- a/ports/stm32/mphalport.c
+++ b/ports/stm32/mphalport.c
@@ -176,6 +176,8 @@ typedef struct _pyb_otp_t {
 
 #if defined(STM32F722xx) || defined(STM32F723xx) || defined(STM32F732xx) || defined(STM32F733xx)
 #define OTP_ADDR (0x1ff079e0)
+#elif defined(STM32F429xx)
+#define OTP_ADDR (0x1fff79e0)
 #else
 #define OTP_ADDR (0x1ff0f3c0)
 #endif


### PR DESCRIPTION
Ethernet driver was failing to start because of incorrect OTP area address for the stm32f429 as the MAC address is stored in the OTP area.