### PR TITLE
py: don't add traceback info for finally or re-raised exceptions

### DIFF
--- a/py/vm.c
+++ b/py/vm.c
@@ -1361,7 +1361,9 @@ unwind_loop:
             // Set traceback info (file and line number) where the exception occurred, but not for:
             // - constant GeneratorExit object, because it's const
             // - exceptions re-raised by END_FINALLY
-            if (nlr.ret_val != &mp_const_GeneratorExit_obj && *code_state->ip != MP_BC_END_FINALLY) {
+            // - exceptions re-raised explicitly by "raise"
+            if (nlr.ret_val != &mp_const_GeneratorExit_obj && *code_state->ip != MP_BC_END_FINALLY
+                && !(*code_state->ip == MP_BC_RAISE_VARARGS && code_state->ip[1] == 0)) {
                 const byte *ip = code_state->fun_bc->bytecode;
                 ip = mp_decode_uint_skip(ip); // skip n_state
                 ip = mp_decode_uint_skip(ip); // skip n_exc_stack

--- a/py/vm.c
+++ b/py/vm.c
@@ -1358,10 +1358,10 @@ exception_handler:
 #if MICROPY_STACKLESS
 unwind_loop:
 #endif
-            // set file and line number that the exception occurred at
-            // TODO: don't set traceback for exceptions re-raised by END_FINALLY.
-            // But consider how to handle nested exceptions.
-            if (nlr.ret_val != &mp_const_GeneratorExit_obj) {
+            // Set traceback info (file and line number) where the exception occurred, but not for:
+            // - constant GeneratorExit object, because it's const
+            // - exceptions re-raised by END_FINALLY
+            if (nlr.ret_val != &mp_const_GeneratorExit_obj && *code_state->ip != MP_BC_END_FINALLY) {
                 const byte *ip = code_state->fun_bc->bytecode;
                 ip = mp_decode_uint_skip(ip); // skip n_state
                 ip = mp_decode_uint_skip(ip); // skip n_exc_stack

--- a/tests/misc/print_exception.py
+++ b/tests/misc/print_exception.py
@@ -47,6 +47,16 @@ except Exception as e:
     print('caught')
     print_exc(e)
 
+# Test that an exception propagated through a finally doesn't have a traceback added there
+try:
+    try:
+        f()
+    finally:
+        print('finally')
+except Exception as e:
+    print('caught')
+    print_exc(e)
+
 # Here we have a function with lots of bytecode generated for a single source-line, and
 # there is an error right at the end of the bytecode.  It should report the correct line.
 def f():

--- a/tests/misc/print_exception.py
+++ b/tests/misc/print_exception.py
@@ -57,6 +57,18 @@ except Exception as e:
     print('caught')
     print_exc(e)
 
+# Test that re-raising an exception doesn't add traceback info
+try:
+    try:
+        f()
+    except Exception as e:
+        print('reraise')
+        print_exc(e)
+        raise
+except Exception as e:
+    print('caught')
+    print_exc(e)
+
 # Here we have a function with lots of bytecode generated for a single source-line, and
 # there is an error right at the end of the bytecode.  It should report the correct line.
 def f():


### PR DESCRIPTION
This is a fix for #2928.  It makes sure that traceback info is not added to exceptions that 1) propagate through a finally block; 2) are re-raised with `raise` (no args).

Eg, before this patch (see #2928 for the test script):
```
Traceback (most recent call last):
  File "<stdin>", line 19, in <module> (finally)
  File "<stdin>", line 17, in <module> (re-raise)
  File "<stdin>", line 17, in <module> (re-raise)
  File "<stdin>", line 14, in <module>
  File "<stdin>", line 2, in some_fn
  File "<stdin>", line 5, in foo
  File "<stdin>", line 8, in bar
RuntimeError: something
```
and after this patch:
```
Traceback (most recent call last):
  File "<stdin>", line 14, in <module>
  File "<stdin>", line 2, in some_fn
  File "<stdin>", line 5, in foo
  File "<stdin>", line 8, in bar
RuntimeError: something
```
(which matches CPython output).

I think this is a good fix, it will improve error messages (not as confusing), and make finally's slightly more efficient (in time and RAM) by not bothering to add the traceback.

The downside is that it increases code size a bit:
```
   bare-arm:   +28 +0.042% 
minimal x86:   +16 +0.010% 
   unix x64:   +32 +0.006% 
unix nanbox:   +96 +0.022% 
      stm32:   +20 +0.005% PYBV10
     cc3200:   +32 +0.017% 
    esp8266:   +56 +0.009% 
      esp32:   +24 +0.002% GENERIC
        nrf:   +16 +0.011% pca10040
       samd:   +24 +0.024% ADAFRUIT_ITSYBITSY_M4_EXPRESS
```

Also, it may reduce VM performance (when raising exception) by a tiny amount due to the extra checks, but I didn't yet measure that.