### PR TITLE
stm32/mphalport: Put PYBD specific MAC code in board specific file.

### DIFF
--- a/ports/stm32/boards/PYBD_SF2/board_init.c
+++ b/ports/stm32/boards/PYBD_SF2/board_init.c
@@ -54,6 +54,8 @@ void board_early_init(void) {
     spi_bdev_ioctl(&spi_bdev2, BDEV_IOCTL_INIT, (uint32_t)&spiflash2_config);
 }
 
+#if !BUILDING_MBOOT
+
 void board_sleep(int value) {
     mp_spiflash_deepsleep(&spi_bdev.spiflash, value);
     mp_spiflash_deepsleep(&spi_bdev2.spiflash, value);
@@ -70,3 +72,5 @@ void mp_hal_get_mac(int idx, uint8_t buf[6]) {
     // Generate a random locally administered MAC address (LAA)
     mp_hal_generate_laa_mac(idx, buf);
 }
+
+#endif

--- a/ports/stm32/boards/PYBD_SF2/board_init.c
+++ b/ports/stm32/boards/PYBD_SF2/board_init.c
@@ -24,8 +24,22 @@
  * THE SOFTWARE.
  */
 
+#include <string.h>
 #include "py/mphal.h"
 #include "storage.h"
+
+#if defined(STM32F722xx) || defined(STM32F723xx) || defined(STM32F732xx) || defined(STM32F733xx)
+#define OTP_ADDR (0x1ff079e0)
+#else
+#define OTP_ADDR (0x1ff0f3c0)
+#endif
+#define OTP ((pyb_otp_t*)OTP_ADDR)
+
+typedef struct _pyb_otp_t {
+    uint16_t series;
+    uint16_t rev;
+    uint8_t mac[6];
+} pyb_otp_t;
 
 void mboot_board_early_init(void) {
     // Enable 500mA on WBUS-DIP28
@@ -43,4 +57,16 @@ void board_early_init(void) {
 void board_sleep(int value) {
     mp_spiflash_deepsleep(&spi_bdev.spiflash, value);
     mp_spiflash_deepsleep(&spi_bdev2.spiflash, value);
+}
+
+void mp_hal_get_mac(int idx, uint8_t buf[6]) {
+    // Check if OTP region has a valid MAC address, and use it if it does
+    if (OTP->series == 0x00d1 && OTP->mac[0] == 'H' && OTP->mac[1] == 'J' && OTP->mac[2] == '0') {
+        memcpy(buf, OTP->mac, 6);
+        buf[5] += idx;
+        return;
+    }
+
+    // Generate a random locally administered MAC address (LAA)
+    mp_hal_generate_laa_mac(idx, buf);
 }

--- a/ports/stm32/mboot/Makefile
+++ b/ports/stm32/mboot/Makefile
@@ -63,6 +63,7 @@ CFLAGS += -DSTM32_HAL_H='<stm32$(MCU_SERIES)xx_hal.h>'
 CFLAGS += -DBOARD_$(BOARD)
 CFLAGS += -DAPPLICATION_ADDR=$(TEXT0_ADDR)
 CFLAGS += -DFFCONF_H=\"ports/stm32/mboot/ffconf.h\"
+CFLAGS += -DBUILDING_MBOOT=1
 
 LDFLAGS = -nostdlib -L . -T stm32_generic.ld -Map=$(@:.elf=.map) --cref
 LIBS = $(shell $(CC) $(CFLAGS) -print-libgcc-file-name)

--- a/ports/stm32/mphalport.c
+++ b/ports/stm32/mphalport.c
@@ -168,28 +168,8 @@ void mp_hal_pin_config_speed(mp_hal_pin_obj_t pin_obj, uint32_t speed) {
 /*******************************************************************************/
 // MAC address
 
-typedef struct _pyb_otp_t {
-    uint16_t series;
-    uint16_t rev;
-    uint8_t mac[6];
-} pyb_otp_t;
-
-#if defined(STM32F722xx) || defined(STM32F723xx) || defined(STM32F732xx) || defined(STM32F733xx)
-#define OTP_ADDR (0x1ff079e0)
-#else
-#define OTP_ADDR (0x1ff0f3c0)
-#endif
-#define OTP ((pyb_otp_t*)OTP_ADDR)
-
-MP_WEAK void mp_hal_get_mac(int idx, uint8_t buf[6]) {
-    // Check if OTP region has a valid MAC address, and use it if it does
-    if (OTP->series == 0x00d1 && OTP->mac[0] == 'H' && OTP->mac[1] == 'J' && OTP->mac[2] == '0') {
-        memcpy(buf, OTP->mac, 6);
-        buf[5] += idx;
-        return;
-    }
-
-    // Generate a random locally administered MAC address (LAA)
+// Generate a random locally administered MAC address (LAA)
+void mp_hal_generate_laa_mac(int idx, uint8_t buf[6]) {
     uint8_t *id = (uint8_t *)MP_HAL_UNIQUE_ID_ADDRESS;
     buf[0] = 0x02; // LAA range
     buf[1] = (id[11] << 4) | (id[10] & 0xf);
@@ -197,6 +177,11 @@ MP_WEAK void mp_hal_get_mac(int idx, uint8_t buf[6]) {
     buf[3] = (id[7] << 4) | (id[6] & 0xf);
     buf[4] = id[2];
     buf[5] = (id[0] << 2) | idx;
+}
+
+// A board can override this if needed
+MP_WEAK void mp_hal_get_mac(int idx, uint8_t buf[6]) {
+    mp_hal_generate_laa_mac(idx, buf);
 }
 
 void mp_hal_get_mac_ascii(int idx, size_t chr_off, size_t chr_len, char *dest) {

--- a/ports/stm32/mphalport.h
+++ b/ports/stm32/mphalport.h
@@ -82,5 +82,6 @@ enum {
     MP_HAL_MAC_ETH0,
 };
 
+void mp_hal_generate_laa_mac(int idx, uint8_t buf[6]);
 void mp_hal_get_mac(int idx, uint8_t buf[6]);
 void mp_hal_get_mac_ascii(int idx, size_t chr_off, size_t chr_len, char *dest);


### PR DESCRIPTION
To resolve issue #5029.

Any board can override the `mp_hal_get_mac()` function to return a MAC address however it likes.  The default behaviour is to generate an LAA.