### PR TITLE
py/nlr: maybe restore warning via #pragma message

### DIFF
--- a/py/nlr.h
+++ b/py/nlr.h
@@ -67,7 +67,7 @@
     #define MICROPY_NLR_NUM_REGS (10)
 #else
     #define MICROPY_NLR_SETJMP (1)
-    //#warning "No native NLR support for this arch, using setjmp implementation"
+    #pragma message "No native NLR support for this arch, using setjmp implementation"
 #endif
 #endif
 

--- a/py/nlr.h
+++ b/py/nlr.h
@@ -67,7 +67,7 @@
     #define MICROPY_NLR_NUM_REGS (10)
 #else
     #define MICROPY_NLR_SETJMP (1)
-    #pragma message "No native NLR support for this arch, using setjmp implementation"
+    #pragma message ("No native NLR support for this arch, using setjmp implementation")
 #endif
 #endif
 

--- a/py/nlr.h
+++ b/py/nlr.h
@@ -67,7 +67,7 @@
     #define MICROPY_NLR_NUM_REGS (10)
 #else
     #define MICROPY_NLR_SETJMP (1)
-    #pragma message ("No native NLR support for this arch, using setjmp implementation")
+    #pragma message ("warning: No native NLR support for this arch, using setjmp implementation")
 #endif
 #endif
 


### PR DESCRIPTION
both gcc and clang accept that 
need testing of other compilers ?