### PR TITLE
esp32/Makefile: Fix subst->patsubst

### DIFF
--- a/ports/esp32/Makefile
+++ b/ports/esp32/Makefile
@@ -290,7 +290,7 @@ $(HEADER_BUILD)/qstrdefs.generated.h: $(SDKCONFIG_H) $(BOARD_DIR)/mpconfigboard.
 ################################################################################
 # List of object files from the ESP32 IDF components
 
-ESPIDF_BOOTLOADER_SUPPORT_O = $(subst .c,.o,\
+ESPIDF_BOOTLOADER_SUPPORT_O = $(patsubst %.c,%.o,\
 	$(filter-out $(ESPCOMP)/bootloader_support/src/bootloader_init.c,\
 		$(wildcard $(ESPCOMP)/bootloader_support/src/*.c)))
 


### PR DESCRIPTION
Follow-up to #4919 -- Looks like this line was added later from an older branch.