### PR TITLE
windows/msvc: Treat compiler warnings as errors.

### DIFF
--- a/ports/windows/msvc/common.props
+++ b/ports/windows/msvc/common.props
@@ -18,6 +18,7 @@
       <ExceptionHandling>false</ExceptionHandling>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
       <MinimalRebuild>false</MinimalRebuild>
+      <TreatWarningAsError>true</TreatWarningAsError>
     </ClCompile>
     <Link>
       <GenerateDebugInformation>true</GenerateDebugInformation>


### PR DESCRIPTION
This is consistent with the other ports and helps catching
problems early.