### PR TITLE
Add sys.excepthook CPython alternative sys.setexcepthook to MicroPython.

### DIFF
--- a/py/mpconfig.h
+++ b/py/mpconfig.h
@@ -1171,6 +1171,11 @@ typedef double mp_float_t;
 #define MICROPY_PY_SYS_ATEXIT (0)
 #endif
 
+// Whether to provide "sys.setexcepthook" function
+#ifndef MICROPY_PY_SYS_EXCEPTHOOK
+#define MICROPY_PY_SYS_EXCEPTHOOK (0)
+#endif
+
 // Whether to provide "sys.settrace" function
 #ifndef MICROPY_PY_SYS_SETTRACE
 #define MICROPY_PY_SYS_SETTRACE (0)

--- a/py/mpstate.h
+++ b/py/mpstate.h
@@ -154,6 +154,10 @@ typedef struct _mp_state_vm_t {
     mp_obj_t sys_exitfunc;
     #endif
 
+    #if MICROPY_PY_SYS_EXCEPTHOOK
+    mp_obj_t sys_excepthook;
+    #endif
+
     // dictionary for the __main__ module
     mp_obj_dict_t dict_main;
 

--- a/py/runtime.c
+++ b/py/runtime.c
@@ -125,6 +125,10 @@ void mp_init(void) {
     MP_STATE_VM(sys_exitfunc) = mp_const_none;
     #endif
 
+    #if MICROPY_PY_SYS_EXCEPTHOOK
+    MP_STATE_VM(sys_excepthook) = mp_const_none;
+    #endif
+
     #if MICROPY_PY_SYS_SETTRACE
     MP_STATE_THREAD(prof_trace_callback) = MP_OBJ_NULL;
     MP_STATE_THREAD(prof_callback_is_executing) = false;

--- a/tests/misc/sys_setexcepthook.py
+++ b/tests/misc/sys_setexcepthook.py
@@ -1,0 +1,19 @@
+import sys
+try:
+    sys.setexcepthook
+except:
+    print("SKIP")
+    raise SystemExit
+
+def handler(t, v, bt):
+    print("type:", str(t))
+    print("value:", str(v))
+
+sys.setexcepthook(handler)
+
+try:
+    raise Exception("inside except block")
+except Exception:
+    pass
+
+raise Exception("outside except block")

--- a/tests/misc/sys_setexcepthook.py.exp
+++ b/tests/misc/sys_setexcepthook.py.exp
@@ -1,0 +1,3 @@
+type: <class 'Exception'>
+value: outside except block
+CRASH


### PR DESCRIPTION
Hi,

I wanted to implement fully CPython compatible `sys.excepthook` but what I ended up with is this redux.

Differences:
* In MicroPython it's not possible to create selectively assignable module attributes. Or I didn't figure-out how to do it. Meaning:
```Python
# in CPython you do this
sys.excepthook = handler

# in uPy you have to do this
sys.setexcepthook(handler)
```

* The handler is expecting 3 arguments (type, value, traceback). But for simplicity the _traceback_ is __None__ for now. Traceback argument is also omitted in already implemented `sys.exc_info` so I guess it's OK.

* For simplicity the error messages for assigning the incompatible handler object are simplified compared to CPython.

Also I can't decide on proper naming (again). The feature is wrapped in `MICROPY_PY_SYS_EXCEPTHOOK` ifdef but the API is `sys.setexcepthook`. So, let me know what do you prefer to make as less confusion as possible.

If somebody knows how to make ONLY `sys.excepthook` assignable in uPy sys module that would be the best.

Cheers!