### PR TITLE
windows/make: Add usage of CFLAGS_EXTRA, LDFLAGS_EXTRA and SRC_MOD consistent with unix port

### DIFF
--- a/ports/windows/Makefile
+++ b/ports/windows/Makefile
@@ -15,8 +15,8 @@ INC += -I$(TOP)
 INC += -I$(BUILD)
 
 # compiler settings
-CFLAGS = $(INC) -Wall -Wpointer-arith -Werror -std=gnu99 -DUNIX -D__USE_MINGW_ANSI_STDIO=1 $(CFLAGS_MOD) $(COPT)
-LDFLAGS = $(LDFLAGS_MOD) -lm
+CFLAGS = $(INC) -Wall -Wpointer-arith -Werror -std=gnu99 -DUNIX -D__USE_MINGW_ANSI_STDIO=1 $(CFLAGS_MOD) $(COPT) $(CFLAGS_EXTRA)
+LDFLAGS = $(LDFLAGS_MOD) -lm $(LDFLAGS_EXTRA)
 
 # Debugging/Optimization
 ifdef DEBUG
@@ -40,6 +40,7 @@ SRC_C = \
 	realpath.c \
 	init.c \
 	sleep.c \
+	$(SRC_MOD)
 
 OBJ = $(PY_O) $(addprefix $(BUILD)/, $(SRC_C:.c=.o))
 


### PR DESCRIPTION
When trying to build an existing project using USER_C_MODULES on the windows port, I ran into this Makefile discrepancy with the unix port.

Hopefully this is a low risk addition to the windows port.