### PR TITLE
stm32/mboot: support boards with only two LEDs.

### DIFF
--- a/ports/stm32/mboot/main.c
+++ b/ports/stm32/mboot/main.c
@@ -408,7 +408,9 @@ void mp_hal_pin_config_speed(uint32_t port_pin, uint32_t speed) {
 
 #define LED0 MICROPY_HW_LED1
 #define LED1 MICROPY_HW_LED2
+#ifdef MICROPY_HW_LED3
 #define LED2 MICROPY_HW_LED3
+#endif
 #ifdef MICROPY_HW_LED4
 #define LED3 MICROPY_HW_LED4
 #endif
@@ -416,7 +418,9 @@ void mp_hal_pin_config_speed(uint32_t port_pin, uint32_t speed) {
 void led_init(void) {
     mp_hal_pin_output(LED0);
     mp_hal_pin_output(LED1);
+    #ifdef LED2
     mp_hal_pin_output(LED2);
+    #endif
     #ifdef LED3
     mp_hal_pin_output(LED3);
     #endif
@@ -436,7 +440,9 @@ void led_state(int led, int val) {
 void led_state_all(unsigned int mask) {
     led_state(LED0, mask & 1);
     led_state(LED1, mask & 2);
+    #ifdef LED2
     led_state(LED2, mask & 4);
+    #endif
     #ifdef LED3
     led_state(LED3, mask & 8);
     #endif
@@ -1345,10 +1351,14 @@ static int pyb_usbdd_shutdown(void) {
 
 #define RESET_MODE_NUM_STATES (4)
 #define RESET_MODE_TIMEOUT_CYCLES (8)
+#ifdef LED2
 #ifdef LED3
 #define RESET_MODE_LED_STATES 0x8421
 #else
 #define RESET_MODE_LED_STATES 0x7421
+#endif
+#else
+#define RESET_MODE_LED_STATES 0x3210
 #endif
 
 static int get_reset_mode(void) {


### PR DESCRIPTION
mboot currently requires at least three LEDs to display each of the four states.  However, since there are only four possible states, the states can be displayed using only two LEDs:

State 0: LED0 off, LED1 off
State 1: LED0 on, LED1 off
State 2: LED0 off, LED1 on
State 3: LED0 on, LED1 on