### PR TITLE
Introduce a mechanism for specifying a "manifest" for frozen files

### DIFF
--- a/ports/esp32/Makefile
+++ b/ports/esp32/Makefile
@@ -32,8 +32,7 @@ MICROPY_SSL_AXTLS = 0
 MICROPY_FATFS = 1
 MICROPY_PY_BTREE = 1
 
-#FROZEN_DIR = scripts
-FROZEN_MPY_DIR = modules
+FROZEN_MANIFEST ?= boards/manifest.py
 
 # include py core make definitions
 include $(TOP)/py/py.mk

--- a/ports/esp32/boards/manifest.py
+++ b/ports/esp32/boards/manifest.py
@@ -1,0 +1,6 @@
+freeze('modules')
+freeze('$(MPY)/tools', ('upip.py', 'upip_utarfile.py'))
+freeze('$(MPY)/ports/esp8266/modules', 'ntptime.py')
+freeze('$(MPY)/ports/esp8266/modules', ('webrepl.py', 'webrepl_setup.py', 'websocket_helper.py',))
+freeze('$(MPY)/drivers/dht', 'dht.py')
+freeze('$(MPY)/drivers/onewire')

--- a/ports/esp32/boards/manifest_release.py
+++ b/ports/esp32/boards/manifest_release.py
@@ -1,0 +1,8 @@
+include('boards/manifest.py')
+
+LIB = '../../../micropython-lib'
+
+freeze(LIB + '/upysh', 'upysh.py')
+freeze(LIB + '/urequests', 'urequests.py')
+freeze(LIB + '/umqtt.simple', 'umqtt/simple.py')
+freeze(LIB + '/umqtt.robust', 'umqtt/robust.py')

--- a/ports/esp32/modules/dht.py
+++ b/ports/esp32/modules/dht.py
@@ -1,1 +1,0 @@
-../../../drivers/dht/dht.py

--- a/ports/esp32/modules/ds18x20.py
+++ b/ports/esp32/modules/ds18x20.py
@@ -1,1 +1,0 @@
-../../esp8266/modules/ds18x20.py

--- a/ports/esp32/modules/ntptime.py
+++ b/ports/esp32/modules/ntptime.py
@@ -1,1 +1,0 @@
-../../esp8266/modules/ntptime.py

--- a/ports/esp32/modules/onewire.py
+++ b/ports/esp32/modules/onewire.py
@@ -1,1 +1,0 @@
-../../esp8266/modules/onewire.py

--- a/ports/esp32/modules/umqtt/robust.py
+++ b/ports/esp32/modules/umqtt/robust.py
@@ -1,1 +1,0 @@
-../../../../../micropython-lib/umqtt.robust/umqtt/robust.py

--- a/ports/esp32/modules/umqtt/simple.py
+++ b/ports/esp32/modules/umqtt/simple.py
@@ -1,1 +1,0 @@
-../../../../../micropython-lib/umqtt.simple/umqtt/simple.py

--- a/ports/esp32/modules/upip.py
+++ b/ports/esp32/modules/upip.py
@@ -1,1 +1,0 @@
-../../../tools/upip.py

--- a/ports/esp32/modules/upip_utarfile.py
+++ b/ports/esp32/modules/upip_utarfile.py
@@ -1,1 +1,0 @@
-../../../tools/upip_utarfile.py

--- a/ports/esp32/modules/upysh.py
+++ b/ports/esp32/modules/upysh.py
@@ -1,1 +1,0 @@
-../../../../micropython-lib/upysh/upysh.py

--- a/ports/esp32/modules/urequests.py
+++ b/ports/esp32/modules/urequests.py
@@ -1,1 +1,0 @@
-../../../../micropython-lib/urequests/urequests.py

--- a/ports/esp32/modules/webrepl.py
+++ b/ports/esp32/modules/webrepl.py
@@ -1,1 +1,0 @@
-../../esp8266/modules/webrepl.py

--- a/ports/esp32/modules/webrepl_setup.py
+++ b/ports/esp32/modules/webrepl_setup.py
@@ -1,1 +1,0 @@
-../../esp8266/modules/webrepl_setup.py

--- a/ports/esp32/modules/websocket_helper.py
+++ b/ports/esp32/modules/websocket_helper.py
@@ -1,1 +1,0 @@
-../../esp8266/modules/websocket_helper.py

--- a/ports/esp8266/Makefile
+++ b/ports/esp8266/Makefile
@@ -26,8 +26,9 @@ MICROPY_FATFS ?= 1
 MICROPY_PY_BTREE ?= 1
 BTREE_DEFS_EXTRA = -DDEFPSIZE=1024 -DMINCACHE=3
 
-FROZEN_DIR ?= scripts
-FROZEN_MPY_DIR ?= modules
+FROZEN_MANIFEST ?= boards/manifest.py
+FROZEN_DIR ?=
+FROZEN_MPY_DIR ?=
 
 # include py core make definitions
 include $(TOP)/py/py.mk
@@ -179,9 +180,9 @@ CONFVARS_FILE = $(BUILD)/confvars
 
 ifeq ($(wildcard $(CONFVARS_FILE)),)
 $(shell $(MKDIR) -p $(BUILD))
-$(shell echo $(FROZEN_DIR) $(UART_OS) > $(CONFVARS_FILE))
-else ifneq ($(shell cat $(CONFVARS_FILE)), $(FROZEN_DIR) $(UART_OS))
-$(shell echo $(FROZEN_DIR) $(UART_OS) > $(CONFVARS_FILE))
+$(shell echo $(FROZEN_MANIFEST) $(UART_OS) > $(CONFVARS_FILE))
+else ifneq ($(shell cat $(CONFVARS_FILE)), $(FROZEN_MANIFEST) $(UART_OS))
+$(shell echo $(FROZEN_MANIFEST) $(UART_OS) > $(CONFVARS_FILE))
 endif
 
 $(BUILD)/uart.o: $(CONFVARS_FILE)

--- a/ports/esp8266/boards/manifest.py
+++ b/ports/esp8266/boards/manifest.py
@@ -1,0 +1,4 @@
+freeze('modules')
+freeze('$(MPY)/tools', ('upip.py', 'upip_utarfile.py'))
+freeze('$(MPY)/drivers/dht', 'dht.py')
+freeze('$(MPY)/drivers/onewire')

--- a/ports/esp8266/modules/dht.py
+++ b/ports/esp8266/modules/dht.py
@@ -1,1 +1,0 @@
-../../../drivers/dht/dht.py

--- a/ports/esp8266/modules/ds18x20.py
+++ b/ports/esp8266/modules/ds18x20.py
@@ -1,1 +1,0 @@
-../../../drivers/onewire/ds18x20.py

--- a/ports/esp8266/modules/onewire.py
+++ b/ports/esp8266/modules/onewire.py
@@ -1,1 +1,0 @@
-../../../drivers/onewire/onewire.py

--- a/ports/esp8266/modules/upip.py
+++ b/ports/esp8266/modules/upip.py
@@ -1,1 +1,0 @@
-../../../tools/upip.py

--- a/ports/esp8266/modules/upip_utarfile.py
+++ b/ports/esp8266/modules/upip_utarfile.py
@@ -1,1 +1,0 @@
-../../../tools/upip_utarfile.py

--- a/ports/qemu-arm/Makefile
+++ b/ports/qemu-arm/Makefile
@@ -114,11 +114,10 @@ OBJ = $(OBJ_COMMON) $(OBJ_RUN) $(OBJ_TEST)
 # List of sources for qstr extraction
 SRC_QSTR += $(SRC_COMMON_C) $(SRC_RUN_C) $(LIB_SRC_C)
 
-ifneq ($(FROZEN_MPY_DIR),)
-# To use frozen bytecode, put your .py files in a subdirectory (eg frozen/) and
-# then invoke make with FROZEN_MPY_DIR=frozen (be sure to build from scratch).
-CFLAGS += -DMICROPY_QSTR_EXTRA_POOL=mp_qstr_frozen_const_pool
+ifneq ($(FROZEN_MANIFEST),)
+CFLAGS += -DMICROPY_MODULE_FROZEN_STR
 CFLAGS += -DMICROPY_MODULE_FROZEN_MPY
+CFLAGS += -DMICROPY_QSTR_EXTRA_POOL=mp_qstr_frozen_const_pool
 MPY_CROSS_FLAGS += -march=armv7m
 endif
 

--- a/ports/qemu-arm/Makefile.test
+++ b/ports/qemu-arm/Makefile.test
@@ -1,6 +1,6 @@
 LIB_SRC_C = lib/upytesthelper/upytesthelper.c
 
-FROZEN_MPY_DIR ?= test-frzmpy
+FROZEN_MANIFEST ?= "freeze('test-frzmpy')"
 
 include Makefile
 

--- a/ports/stm32/Makefile
+++ b/ports/stm32/Makefile
@@ -18,8 +18,8 @@ include $(BOARD_DIR)/mpconfigboard.mk
 QSTR_DEFS = qstrdefsport.h $(BUILD)/pins_qstr.h $(BUILD)/modstm_qstr.h
 QSTR_GLOBAL_DEPENDENCIES = mpconfigboard_common.h $(BOARD_DIR)/mpconfigboard.h
 
-# directory containing scripts to be frozen as bytecode
-FROZEN_MPY_DIR ?= modules
+# File containing description of content to be frozen into firmware.
+FROZEN_MANIFEST ?= boards/manifest.py
 
 # include py core make definitions
 include $(TOP)/py/py.mk
@@ -485,13 +485,13 @@ $(TOP)/lib/stm32lib/README.md:
 	$(ECHO) "stm32lib submodule not found, fetching it now..."
 	(cd $(TOP) && git submodule update --init lib/stm32lib)
 
-ifneq ($(FROZEN_DIR),)
+ifneq ($(FROZEN_MANIFEST)$(FROZEN_DIR),)
 # To use frozen source modules, put your .py files in a subdirectory (eg scripts/)
 # and then invoke make with FROZEN_DIR=scripts (be sure to build from scratch).
 CFLAGS += -DMICROPY_MODULE_FROZEN_STR
 endif
 
-ifneq ($(FROZEN_MPY_DIR),)
+ifneq ($(FROZEN_MANIFEST)$(FROZEN_MPY_DIR),)
 # To use frozen bytecode, put your .py files in a subdirectory (eg frozen/) and
 # then invoke make with FROZEN_MPY_DIR=frozen (be sure to build from scratch).
 CFLAGS += -DMICROPY_QSTR_EXTRA_POOL=mp_qstr_frozen_const_pool

--- a/ports/stm32/boards/B_L072Z_LRWAN1/mpconfigboard.mk
+++ b/ports/stm32/boards/B_L072Z_LRWAN1/mpconfigboard.mk
@@ -5,4 +5,4 @@ AF_FILE = boards/stm32l072_af.csv
 LD_FILES = boards/stm32l072xz.ld boards/common_basic.ld
 
 # Don't include default frozen modules because MCU is tight on flash space
-FROZEN_MPY_DIR ?=
+FROZEN_MANIFEST ?=

--- a/ports/stm32/boards/ESPRUINO_PICO/mpconfigboard.mk
+++ b/ports/stm32/boards/ESPRUINO_PICO/mpconfigboard.mk
@@ -6,4 +6,4 @@ TEXT0_ADDR = 0x08000000
 TEXT1_ADDR = 0x08020000
 
 # Don't include default frozen modules because MCU is tight on flash space
-FROZEN_MPY_DIR ?=
+FROZEN_MANIFEST ?=

--- a/ports/stm32/boards/NUCLEO_F091RC/mpconfigboard.mk
+++ b/ports/stm32/boards/NUCLEO_F091RC/mpconfigboard.mk
@@ -4,4 +4,4 @@ AF_FILE = boards/stm32f091_af.csv
 LD_FILES = boards/stm32f091xc.ld boards/common_basic.ld
 
 # Don't include default frozen modules because MCU is tight on flash space
-FROZEN_MPY_DIR ?=
+FROZEN_MANIFEST ?=

--- a/ports/stm32/boards/NUCLEO_L073RZ/mpconfigboard.mk
+++ b/ports/stm32/boards/NUCLEO_L073RZ/mpconfigboard.mk
@@ -4,4 +4,4 @@ AF_FILE = boards/stm32l072_af.csv
 LD_FILES = boards/stm32l072xz.ld boards/common_basic.ld
 
 # Don't include default frozen modules because MCU is tight on flash space
-FROZEN_MPY_DIR ?=
+FROZEN_MANIFEST ?=

--- a/ports/stm32/boards/NUCLEO_L432KC/mpconfigboard.mk
+++ b/ports/stm32/boards/NUCLEO_L432KC/mpconfigboard.mk
@@ -5,4 +5,4 @@ LD_FILES = boards/stm32l432.ld boards/common_basic.ld
 OPENOCD_CONFIG = boards/openocd_stm32l4.cfg
 
 # Don't include default frozen modules because MCU is tight on flash space
-FROZEN_MPY_DIR ?=
+FROZEN_MANIFEST ?=

--- a/ports/stm32/boards/manifest.py
+++ b/ports/stm32/boards/manifest.py
@@ -1,0 +1,3 @@
+freeze('$(MPY)/drivers/dht', 'dht.py')
+freeze('$(MPY)/drivers/display', ('lcd160cr.py', 'lcd160cr_test.py'))
+freeze('$(MPY)/drivers/onewire', 'onewire.py')

--- a/ports/stm32/modules/dht.py
+++ b/ports/stm32/modules/dht.py
@@ -1,1 +1,0 @@
-../../../drivers/dht/dht.py

--- a/ports/stm32/modules/lcd160cr.py
+++ b/ports/stm32/modules/lcd160cr.py
@@ -1,1 +1,0 @@
-../../../drivers/display/lcd160cr.py

--- a/ports/stm32/modules/lcd160cr_test.py
+++ b/ports/stm32/modules/lcd160cr_test.py
@@ -1,1 +1,0 @@
-../../../drivers/display/lcd160cr_test.py

--- a/ports/stm32/modules/onewire.py
+++ b/ports/stm32/modules/onewire.py
@@ -1,1 +1,0 @@
-../../../drivers/onewire/onewire.py

--- a/ports/unix/Makefile
+++ b/ports/unix/Makefile
@@ -1,8 +1,10 @@
 -include mpconfigport.mk
 include ../../py/mkenv.mk
 
-FROZEN_DIR = scripts
-FROZEN_MPY_DIR = modules
+# use FROZEN_MANIFEST for new projects, others are legacy
+FROZEN_MANIFEST ?= manifest.py
+FROZEN_DIR =
+FROZEN_MPY_DIR =
 
 # define main target
 PROG = micropython
@@ -177,9 +179,9 @@ SRC_QSTR += $(SRC_C) $(LIB_SRC_C)
 # SRC_QSTR
 SRC_QSTR_AUTO_DEPS +=
 
-ifneq ($(FROZEN_MPY_DIR),)
-# To use frozen bytecode, put your .py files in a subdirectory (eg frozen/) and
-# then invoke make with FROZEN_MPY_DIR=frozen (be sure to build from scratch).
+ifneq ($(FROZEN_MANIFEST)$(FROZEN_MPY_DIR),)
+# To use frozen code create a manifest.py file with a description of files to
+# freeze, then invoke make with FROZEN_MANIFEST=manifest.py (be sure to build from scratch).
 CFLAGS += -DMICROPY_QSTR_EXTRA_POOL=mp_qstr_frozen_const_pool
 CFLAGS += -DMICROPY_MODULE_FROZEN_MPY
 CFLAGS += -DMPZ_DIG_SIZE=16 # force 16 bits to work on both 32 and 64 bit archs
@@ -215,7 +217,7 @@ fast:
 # build a minimal interpreter
 minimal:
 	$(MAKE) COPT="-Os -DNDEBUG" CFLAGS_EXTRA='-DMP_CONFIGFILE="<mpconfigport_minimal.h>"' \
-	    BUILD=build-minimal PROG=micropython_minimal FROZEN_DIR= FROZEN_MPY_DIR= \
+	    BUILD=build-minimal PROG=micropython_minimal FROZEN_MANIFEST= \
 	    MICROPY_PY_BTREE=0 MICROPY_PY_FFI=0 MICROPY_PY_SOCKET=0 MICROPY_PY_THREAD=0 \
 	    MICROPY_PY_TERMIOS=0 MICROPY_PY_USSL=0 \
 	    MICROPY_USE_READLINE=0
@@ -252,7 +254,7 @@ coverage:
 	    -Wold-style-definition -Wpointer-arith -Wshadow -Wuninitialized -Wunused-parameter \
 	    -DMICROPY_UNIX_COVERAGE' \
 	    LDFLAGS_EXTRA='-fprofile-arcs -ftest-coverage' \
-	    FROZEN_DIR=coverage-frzstr FROZEN_MPY_DIR=coverage-frzmpy \
+	    FROZEN_MANIFEST=manifest_coverage.py \
 	    BUILD=build-coverage PROG=micropython_coverage
 
 coverage_test: coverage

--- a/ports/unix/manifest.py
+++ b/ports/unix/manifest.py
@@ -1,0 +1,2 @@
+freeze_as_mpy('$(MPY)/tools', 'upip.py')
+freeze_as_mpy('$(MPY)/tools', 'upip_utarfile.py', opt=3)

--- a/ports/unix/manifest_coverage.py
+++ b/ports/unix/manifest_coverage.py
@@ -1,0 +1,2 @@
+freeze_as_str('coverage-frzstr')
+freeze_as_mpy('coverage-frzmpy')

--- a/ports/unix/modules/upip.py
+++ b/ports/unix/modules/upip.py
@@ -1,1 +1,0 @@
-../../../tools/upip.py

--- a/ports/unix/modules/upip_utarfile.py
+++ b/ports/unix/modules/upip_utarfile.py
@@ -1,1 +1,0 @@
-../../../tools/upip_utarfile.py

--- a/py/mkenv.mk
+++ b/py/mkenv.mk
@@ -61,6 +61,7 @@ CXX += -m32
 LD += -m32
 endif
 
+MAKE_MANIFEST = $(PYTHON) $(TOP)/tools/makemanifest.py
 MAKE_FROZEN = $(PYTHON) $(TOP)/tools/make-frozen.py
 MPY_CROSS = $(TOP)/mpy-cross/mpy-cross
 MPY_TOOL = $(PYTHON) $(TOP)/tools/mpy-tool.py

--- a/py/mkrules.mk
+++ b/py/mkrules.mk
@@ -97,6 +97,12 @@ $(OBJ_DIRS):
 $(HEADER_BUILD):
 	$(MKDIR) -p $@
 
+ifneq ($(FROZEN_MANIFEST),)
+# to build frozen_content.c from a manifest
+$(BUILD)/frozen_content.c: FORCE $(BUILD)/genhdr/qstrdefs.generated.h
+	$(Q)$(MAKE_MANIFEST) -o $@ $(TOP) $(BUILD) "$(MPY_CROSS_FLAGS)" $(FROZEN_MANIFEST)
+endif
+
 ifneq ($(FROZEN_DIR),)
 $(BUILD)/frozen.c: $(wildcard $(FROZEN_DIR)/*) $(HEADER_BUILD) $(FROZEN_EXTRA_DEPS)
 	$(ECHO) "GEN $@"

--- a/py/py.mk
+++ b/py/py.mk
@@ -202,6 +202,11 @@ PY_EXTMOD_O = $(addprefix $(BUILD)/, $(PY_EXTMOD_O_BASENAME))
 # this is a convenience variable for ports that want core, extmod and frozen code
 PY_O = $(PY_CORE_O) $(PY_EXTMOD_O)
 
+# object file for frozen code specified via a manifest
+ifneq ($(FROZEN_MANIFEST),)
+PY_O += $(BUILD)/$(BUILD)/frozen_content.o
+endif
+
 # object file for frozen files
 ifneq ($(FROZEN_DIR),)
 PY_O += $(BUILD)/$(BUILD)/frozen.o

--- a/tools/make-frozen.py
+++ b/tools/make-frozen.py
@@ -27,14 +27,15 @@ def module_name(f):
 
 modules = []
 
-root = sys.argv[1].rstrip("/")
-root_len = len(root)
+if len(sys.argv) > 1:
+    root = sys.argv[1].rstrip("/")
+    root_len = len(root)
 
-for dirpath, dirnames, filenames in os.walk(root):
-    for f in filenames:
-        fullpath = dirpath + "/" + f
-        st = os.stat(fullpath)
-        modules.append((fullpath[root_len + 1:], st))
+    for dirpath, dirnames, filenames in os.walk(root):
+        for f in filenames:
+            fullpath = dirpath + "/" + f
+            st = os.stat(fullpath)
+            modules.append((fullpath[root_len + 1:], st))
 
 print("#include <stdint.h>")
 print("const char mp_frozen_str_names[] = {")

--- a/tools/makemanifest.py
+++ b/tools/makemanifest.py
@@ -1,0 +1,252 @@
+#!/usr/bin/env python3
+#
+# This file is part of the MicroPython project, http://micropython.org/
+#
+# The MIT License (MIT)
+#
+# Copyright (c) 2019 Damien P. George
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+
+from __future__ import print_function
+import sys
+import os
+import subprocess
+
+
+###########################################################################
+# Public functions to be used in the manifest
+
+def include(manifest):
+    """Include another manifest.
+
+    The manifest argument can be a string (filename) or an iterable of
+    strings.
+    """
+
+    if not isinstance(manifest, str):
+        for m in manifest:
+            include(m)
+    else:
+        with open(manifest) as f:
+            exec(f.read())
+
+def freeze(path, script=None, opt=0):
+    """Freeze the input, automatically determining its type.  A .py script
+    will be compiled to a .mpy first then frozen, and a .mpy file will be
+    frozen directly.
+
+    `path` must be a directory, which is the base directory to search for
+    files from.  When importing the resulting frozen modules, the name of
+    the module will start after `path`, ie `path` is excluded from the
+    module name.
+
+    If `script` is None all files in `path` will be frozen.
+
+    If `script` is an iterable then freeze() is called on all items of the
+    iterable (with the same `path` and `opt` passed through).
+
+    If `script` is a string then it specifies the filename to freeze, and
+    can include extra directories before the file.  The file will be
+    searched for in `path`.
+
+    `opt` is the optimisation level to pass to mpy-cross when compiling .py
+    to .mpy.
+    """
+
+    freeze_internal(KIND_AUTO, path, script, opt)
+
+def freeze_as_str(path):
+    """Freeze the given `path` and all .py scripts within it as a string,
+    which will be compiled upon import.
+    """
+
+    freeze_internal(KIND_AS_STR, path, None, 0)
+
+def freeze_as_mpy(path, script=None, opt=0):
+    """Freeze the input (see above) by first compiling the .py scripts to
+    .mpy files, then freezing the resulting .mpy files.
+    """
+
+    freeze_internal(KIND_AS_MPY, path, script, opt)
+
+def freeze_mpy(path, script=None, opt=0):
+    """Freeze the input (see above), which must be .mpy files that are
+    frozen directly.
+    """
+
+    freeze_internal(KIND_MPY, path, script, opt)
+
+
+###########################################################################
+# Internal implementation
+
+KIND_AUTO = 0
+KIND_AS_STR = 1
+KIND_AS_MPY = 2
+KIND_MPY = 3
+
+manifest_list = []
+
+class FreezeError(Exception):
+    pass
+
+def system(cmd):
+    try:
+        output = subprocess.check_output(cmd, stderr=subprocess.STDOUT)
+        return 0, output
+    except subprocess.CalledProcessError as er:
+        return -1, er.output
+
+def convert_path(path):
+    return path.replace('$(MPY)', TOP)
+
+def get_timestamp(path, default=None):
+    try:
+        stat = os.stat(path)
+        return stat.st_mtime
+    except OSError:
+        if default is None:
+            raise FreezeError('cannot stat {}'.format(path))
+        return default
+
+def get_timestamp_newest(path):
+    ts_newest = 0
+    for dirpath, dirnames, filenames in os.walk(path):
+        for f in filenames:
+            ts_newest = max(ts_newest, get_timestamp(os.path.join(dirpath, f)))
+    return ts_newest
+
+def mkdir(path):
+    cur_path = ''
+    for p in path.split('/')[:-1]:
+        cur_path += p + '/'
+        try:
+            os.mkdir(cur_path)
+        except OSError as er:
+            if er.args[0] == 17: # file exists
+                pass
+            else:
+                raise er
+
+def freeze_internal(kind, path, script, opt):
+    path = convert_path(path)
+    if script is None and kind == KIND_AS_STR:
+        if any(f[0] == KIND_AS_STR for f in manifest_list):
+            raise FreezeError('can only freeze one str directory')
+        manifest_list.append((KIND_AS_STR, path, script, opt))
+    elif script is None:
+        for dirpath, dirnames, filenames in os.walk(path):
+            for f in filenames:
+                freeze_internal(kind, path, (dirpath + '/' + f)[len(path) + 1:], opt)
+    elif not isinstance(script, str):
+        for s in script:
+            freeze_internal(kind, path, s, opt)
+    else:
+        extension_kind = {KIND_AS_MPY: '.py', KIND_MPY: '.mpy'}
+        if kind == KIND_AUTO:
+            for k, ext in extension_kind.items():
+                if script.endswith(ext):
+                    kind = k
+                    break
+            else:
+                raise FreezeError('unsupported file type {}'.format(script))
+        wanted_extension = extension_kind[kind]
+        if not script.endswith(wanted_extension):
+            raise FreezeError('expecting a {} file, got {}'.format(wanted_extension, script))
+        manifest_list.append((kind, path, script, opt))
+
+def main():
+    global TOP
+
+    # Parse arguments
+    assert sys.argv[1] == '-o'
+    output_file = sys.argv[2]
+    TOP = sys.argv[3]
+    BUILD = sys.argv[4]
+    mpy_cross_flags = sys.argv[5]
+    input_manifest_list = sys.argv[6:]
+
+    # Get paths to tools
+    MAKE_FROZEN = TOP + '/tools/make-frozen.py'
+    MPY_CROSS = TOP + '/mpy-cross/mpy-cross'
+    MPY_TOOL = TOP + '/tools/mpy-tool.py'
+
+    # Include top-level inputs, to generate the manifest
+    for input_manifest in input_manifest_list:
+        try:
+            if input_manifest.endswith('.py'):
+                include(input_manifest)
+            else:
+                exec(input_manifest)
+        except FreezeError as er:
+            print('freeze error executing "{}": {}'.format(input_manifest, er.args[0]))
+            sys.exit(1)
+
+    # Process the manifest
+    str_paths = []
+    mpy_files = []
+    ts_newest = 0
+    for kind, path, script, opt in manifest_list:
+        if kind == KIND_AS_STR:
+            str_paths.append(path)
+            ts_outfile = get_timestamp_newest(path)
+        elif kind == KIND_AS_MPY:
+            infile = '{}/{}'.format(path, script)
+            outfile = '{}/frozen_mpy/{}.mpy'.format(BUILD, script[:-3])
+            ts_infile = get_timestamp(infile)
+            ts_outfile = get_timestamp(outfile, 0)
+            if ts_infile >= ts_outfile:
+                print('MPY', script)
+                mkdir(outfile)
+                res, out = system([MPY_CROSS] + mpy_cross_flags.split() + ['-o', outfile, '-s', script, '-O{}'.format(opt), infile])
+                if res != 0:
+                    print('error compiling {}: {}'.format(infile, out))
+                    raise SystemExit(1)
+                ts_outfile = get_timestamp(outfile)
+            mpy_files.append(outfile)
+        else:
+            assert kind == KIND_MPY
+            infile = '{}/{}'.format(path, script)
+            mpy_files.append(infile)
+            ts_outfile = get_timestamp(infile)
+        ts_newest = max(ts_newest, ts_outfile)
+
+    # Check if output file needs generating
+    if ts_newest < get_timestamp(output_file, 0):
+        # No files are newer than output file so it does not need updating
+        return
+
+    # Freeze paths as strings
+    _, output_str = system([MAKE_FROZEN] + str_paths)
+
+    # Freeze .mpy files
+    _, output_mpy = system([MPY_TOOL, '-f', '-q', BUILD + '/genhdr/qstrdefs.preprocessed.h'] + mpy_files)
+
+    # Generate output
+    print('GEN', output_file)
+    mkdir(output_file)
+    with open(output_file, 'wb') as f:
+        f.write(b'//\n// Content for MICROPY_MODULE_FROZEN_STR\n//\n')
+        f.write(output_str)
+        f.write(b'//\n// Content for MICROPY_MODULE_FROZEN_MPY\n//\n')
+        f.write(output_mpy)
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
This is an initial attempt to improve how frozen modules are specified.  Instead of using symlinks (which can be unreliable on Windows, and not that powerful) the approach presented here uses a manifest file (a Python script) to specify what scripts to freeze.  Some of the advantages of doing it this way are (not all are currently implemented):
- can specify arbitrary file locations for the scripts to be frozen
- can specify a different frozen name vs the actual file name
- can specify different mpy-cross options (eg optimisations) per file
- can specify to freeze via a string or compiled mpy file (currently `FROZEN_DIR` vs `FROZEN_MPY_DIR`)
- can eventually include resources/data in the manifest
- can eventually include read-only/memzip/initial filesystem in the manifest

Included in this PR is an example of how it would work for the unix port (freezing upip).

There could eventually be a hierarchy of manifests: one for the port, one for the particular board, and one for the user application (each could override the defaults if necessary).

The idea would be that this mechanism completely replaces the existing way to specify frozen files.

The implementation here is a bit rough (eg it unconditionally rebuilds each time), comments/discussion/etc are welcome.