### PR TITLE
bare-arm, minimal: Set CSUPEROPT=-Os to get minimal firmware size.

### DIFF
--- a/ports/bare-arm/Makefile
+++ b/ports/bare-arm/Makefile
@@ -14,6 +14,7 @@ INC += -I$(BUILD)
 
 CFLAGS_CORTEX_M4 = -mthumb -mtune=cortex-m4 -mabi=aapcs-linux -mcpu=cortex-m4 -mfpu=fpv4-sp-d16 -mfloat-abi=hard -fsingle-precision-constant -Wdouble-promotion
 CFLAGS = $(INC) -Wall -Werror -std=c99 -nostdlib $(CFLAGS_CORTEX_M4) $(COPT)
+CSUPEROPT = -Os # save some code space
 
 #Debugging/Optimization
 ifeq ($(DEBUG), 1)

--- a/ports/minimal/Makefile
+++ b/ports/minimal/Makefile
@@ -28,6 +28,8 @@ CFLAGS = -m32 $(INC) -Wall -Werror -std=c99 $(COPT)
 LDFLAGS = -m32 -Wl,-Map=$@.map,--cref -Wl,--gc-sections
 endif
 
+CSUPEROPT = -Os # save some code space
+
 # Tune for Debugging or Optimization
 ifeq ($(DEBUG), 1)
 CFLAGS += -O0 -ggdb


### PR DESCRIPTION
The Makefile option `CSUPEROPT` affects `py/vm.c` and `py/gc.c` and using -Os gets them compiling a bit smaller, and small firmware is the aim of these two ports.  Also, having these files compiled with -Os on these ports, and -O3 as the default on other ports, gives a better understanding of code-size changes when making changes to these files.