### PR TITLE
javascript: Add support for changed include path in emscripten 1.38.42

### DIFF
--- a/ports/javascript/Makefile
+++ b/ports/javascript/Makefile
@@ -16,7 +16,9 @@ INC += -I$(BUILD)
 CPP = clang -E
 
 ifdef EMSCRIPTEN
-    CPP += -isystem $(EMSCRIPTEN)/system/include/libc -cxx-isystem $(EMSCRIPTEN)/system/include/libcxx
+    CPP += -isystem $(EMSCRIPTEN)/system/include/libc 
+    CPP += -isystem $(EMSCRIPTEN)/system/lib/libc/musl/arch/emscripten 
+    CPP += -cxx-isystem $(EMSCRIPTEN)/system/include/libcxx
 endif
 
 CFLAGS = -m32 -Wall -Werror $(INC) -std=c99 $(COPT)


### PR DESCRIPTION
One of the system include paths in emscripten changed in 1.38.42 which breaks the clang precompiling stage of the javascript port make process.

This change simply adds the extra include path as needed, leaving the previous ones in place so as to not break build with existing installations.

For further discussion see https://github.com/trzecieu/emscripten-docker/issues/51