### PR TITLE
ports/esp32/main.c: Use both 3.3 and 4.0 config vars to enable spiram

### DIFF
--- a/ports/esp32/main.c
+++ b/ports/esp32/main.c
@@ -74,7 +74,8 @@ void mp_task(void *pvParameter) {
     #endif
     uart_init();
 
-    #if CONFIG_ESP32_SPIRAM_SUPPORT
+    // TODO: CONFIG_SPIRAM_SUPPORT is for 3.3 compatibility, remove after move to 4.0.
+    #if CONFIG_ESP32_SPIRAM_SUPPORT || CONFIG_SPIRAM_SUPPORT
     // Try to use the entire external SPIRAM directly for the heap
     size_t mp_task_heap_size;
     void *mp_task_heap = (void*)0x3f800000;


### PR DESCRIPTION
Fixes #5114