### PR TITLE
esp8266/modules/ntptime.py: Add param for NTP host

### DIFF
--- a/ports/esp8266/modules/ntptime.py
+++ b/ports/esp8266/modules/ntptime.py
@@ -10,9 +10,11 @@ except:
 # (date(2000, 1, 1) - date(1900, 1, 1)).days * 24*60*60
 NTP_DELTA = 3155673600
 
-host = "pool.ntp.org"
+DEFAULT_HOST = "pool.ntp.org"
 
-def time():
+def time(host=None):
+    if host==None:
+        host = DEFAULT_HOST
     NTP_QUERY = bytearray(48)
     NTP_QUERY[0] = 0x1b
     addr = socket.getaddrinfo(host, 123)[0][-1]


### PR DESCRIPTION
The current ntplib.py has its timeserver hardcoded as `pool.ntp.org`. This patch adds a `host` parameter so users can supply an alternative.

In our case, we wanted to use our university's timeserver since it's close, and we wanted to refer to it by IP address to avoid an extra round-trip for the DNS lookup.

You can also explicitly pass `None` to use the default, in case you're passing in another variable.

```python
# Example usage
ntptime.time()    # default, pool.ntp.org
ntptime.time(host="ntp.uit.no")    # UiT timeserver
ntptime.time(host=None)    # default, pool.ntp.org
```

Hope you find it useful.

Cheers!