### PR TITLE
esp32/Makefile: Fix printing of supported git hash.

### DIFF
--- a/ports/esp32/Makefile
+++ b/ports/esp32/Makefile
@@ -65,8 +65,8 @@ ESPIDF = $(IDF_PATH)
 else
 $(info The ESPIDF variable has not been set, please set it to the root of the esp-idf repository.)
 $(info See README.md for installation instructions.)
+$(call print_supported_git_hash)
 $(error ESPIDF not set)
-print_supported_git_hash
 endif
 endif
 
@@ -97,7 +97,7 @@ $(info The git hash of ESP IDF does not match the supported version)
 $(info The build may complete and the firmware may work but it is not guaranteed)
 $(info ESP IDF path:       $(ESPIDF))
 $(info Current git hash:   $(ESPIDF_CURHASH))
-print_supported_git_hash
+$(call print_supported_git_hash)
 endif
 
 # pretty format of ESP IDF version, used internally by the IDF


### PR DESCRIPTION
Fixes comment by @andrewleech at https://github.com/micropython/micropython/pull/5107#discussion_r326441608 and a related issue raised by @nevercast 