### PR TITLE
py/compile: Disallow 'import *' outside module level

### DIFF
--- a/py/compile.c
+++ b/py/compile.c
@@ -1196,10 +1196,12 @@ STATIC void compile_import_from(compiler_t *comp, mp_parse_node_struct_t *pns) {
     } while (0);
 
     if (MP_PARSE_NODE_IS_TOKEN_KIND(pns->nodes[1], MP_TOKEN_OP_STAR)) {
+#ifdef MICROPY_CPYTHON_COMPAT
         if (comp->scope_cur->kind != SCOPE_MODULE) {
-            compile_syntax_error(comp, (mp_parse_node_t)pns, "'import *' only allowed at module level");
+            compile_syntax_error(comp, (mp_parse_node_t)pns, "'import *' not at module level");
             return;
         }
+#endif
         EMIT_ARG(load_const_small_int, import_level);
 
         // build the "fromlist" tuple

--- a/py/compile.c
+++ b/py/compile.c
@@ -1196,6 +1196,10 @@ STATIC void compile_import_from(compiler_t *comp, mp_parse_node_struct_t *pns) {
     } while (0);
 
     if (MP_PARSE_NODE_IS_TOKEN_KIND(pns->nodes[1], MP_TOKEN_OP_STAR)) {
+        if (comp->scope_cur->kind != SCOPE_MODULE) {
+            compile_syntax_error(comp, (mp_parse_node_t)pns, "'import *' only allowed at module level");
+            return;
+        }
         EMIT_ARG(load_const_small_int, import_level);
 
         // build the "fromlist" tuple

--- a/tests/cmdline/cmd_showbc.py
+++ b/tests/cmdline/cmd_showbc.py
@@ -115,7 +115,7 @@ def f():
     # import
     import a
     from a import b
-    from a import *
+
 
     # raise
     raise
@@ -154,3 +154,6 @@ del Class
 # load super method
 def f(self):
     super().f()
+
+# import * (needs to be in module scope)
+from sys import *

--- a/tests/cmdline/cmd_showbc.py
+++ b/tests/cmdline/cmd_showbc.py
@@ -155,5 +155,5 @@ del Class
 def f(self):
     super().f()
 
-# import * (needs to be in module scope)
+# import * (with MICROPY_CPYTHON_COMPAT, needs to be in module scope)
 from sys import *

--- a/tests/cmdline/cmd_showbc.py.exp
+++ b/tests/cmdline/cmd_showbc.py.exp
@@ -7,7 +7,7 @@ arg names:
 (N_EXC_STACK 0)
   bc=-1 line=1
 ########
-  bc=\\d\+ line=155
+  bc=\\d\+ line=159
 00 MAKE_FUNCTION \.\+
 \\d\+ STORE_NAME f
 \\d\+ MAKE_FUNCTION \.\+
@@ -27,6 +27,11 @@ arg names:
 \\d\+ DELETE_NAME Class
 \\d\+ MAKE_FUNCTION \.\+
 \\d\+ STORE_NAME f
+\\d\+ LOAD_CONST_SMALL_INT 0
+\\d\+ LOAD_CONST_STRING '*'
+\\d\+ BUILD_TUPLE 1
+\\d\+ IMPORT_NAME 'sys'
+\\d\+ IMPORT_STAR
 \\d\+ LOAD_CONST_NONE
 \\d\+ RETURN_VALUE
 File cmdline/cmd_showbc.py, code block 'f' (descriptor: \.\+, bytecode @\.\+ bytes)
@@ -300,11 +305,6 @@ Raw bytecode (code_info_size=\\d\+, bytecode_size=\\d\+):
 \\d\+ IMPORT_FROM 'b'
 \\d\+ STORE_DEREF 14
 \\d\+ POP_TOP
-\\d\+ LOAD_CONST_SMALL_INT 0
-\\d\+ LOAD_CONST_STRING '*'
-\\d\+ BUILD_TUPLE 1
-\\d\+ IMPORT_NAME 'a'
-\\d\+ IMPORT_STAR
 \\d\+ RAISE_VARARGS 0
 \\d\+ LOAD_CONST_SMALL_INT 1
 \\d\+ RAISE_VARARGS 1

--- a/tests/import/import_star.py
+++ b/tests/import/import_star.py
@@ -1,0 +1,12 @@
+
+# 'import *' is not allowed in function scope
+try:
+    exec('def foo(): from x import *')
+except SyntaxError as er:
+    print('function', 'SyntaxError', er)
+
+# 'import *' is not allowed in class scope
+try:
+    exec('class C: from x import *')
+except SyntaxError as er:
+    print('class', 'SyntaxError', er)

--- a/tests/import/import_star.py
+++ b/tests/import/import_star.py
@@ -1,12 +1,19 @@
 
-# 'import *' is not allowed in function scope
 try:
-    exec('def foo(): from x import *')
+    exec('def foo(): from import1b import *')
 except SyntaxError as er:
-    print('function', 'SyntaxError', er)
+    # MICROPY_CPYTHON_COMPAT: 'import *' is not allowed in function scope
+    print(123)
+else:
+    # 'import *' always updates global scope
+    foo()
+    print(var)
 
-# 'import *' is not allowed in class scope
 try:
-    exec('class C: from x import *')
+    exec('class C: from import1b import *')
 except SyntaxError as er:
-    print('class', 'SyntaxError', er)
+    # MICROPY_CPYTHON_COMPAT: 'import *' is not allowed in class scope
+    print(123)
+else:
+    # 'import *' always updates global scope
+    print(var)

--- a/tests/import/import_star.py.exp
+++ b/tests/import/import_star.py.exp
@@ -1,2 +1,2 @@
-function SyntaxError 'import *' only allowed at module level
-class SyntaxError 'import *' only allowed at module level
+123
+123

--- a/tests/import/import_star.py.exp
+++ b/tests/import/import_star.py.exp
@@ -1,0 +1,2 @@
+function SyntaxError 'import *' only allowed at module level
+class SyntaxError 'import *' only allowed at module level

--- a/tests/run-tests
+++ b/tests/run-tests
@@ -204,6 +204,8 @@ def run_micropython(pyb, args, test_file, is_special=False):
                 break
         output_mupy = b''.join(lines_mupy)
 
+    with open('cmdline/cmd_showbc.py.exp.1', 'wb') as f:
+        f.write(output_mupy)
     return output_mupy
 
 


### PR DESCRIPTION
Fixes: https://github.com/micropython/micropython/issues/5121

I haven't found a good place in the codebase for a test. I'd appreciate a hint.
