### PR TITLE
stm32/powerctrlboot.c: Updatde clock and PLL selection.

### DIFF
--- a/ports/stm32/boards/NUCLEO_F091RC/mpconfigboard.h
+++ b/ports/stm32/boards/NUCLEO_F091RC/mpconfigboard.h
@@ -16,8 +16,14 @@
 #define MICROPY_HW_ENABLE_TIMER     (1)
 #define MICROPY_HW_HAS_SWITCH       (1)
 
-// For system clock, board uses internal 48MHz, HSI48
-#define MICROPY_HW_CLK_USE_HSI48    (1)
+// For system clock, enable one source:
+//#define MICROPY_HW_CLK_USE_HSI      (1) // internal 8MHz -> PLL = 48MHz.
+#define MICROPY_HW_CLK_USE_HSI48    (1) // internal 48MHz.
+//#define MICROPY_HW_CLK_USE_HSE      (1) // external crystal -> PLL = 48MHz.
+// For HSE set the crystal / clock input frequency HSE_VALUE in stm32f0xx_hal_conf.h
+#if MICROPY_HW_CLK_USE_HSE
+#define MICROPY_HW_CLK_USE_BYPASS   (1) // HSE comes from STLINK 8MHz, not crystal.
+#endif
 
 // The board has an external 32kHz crystal
 #define MICROPY_HW_RTC_USE_LSE      (1)

--- a/ports/stm32/powerctrlboot.c
+++ b/ports/stm32/powerctrlboot.c
@@ -38,11 +38,15 @@ void SystemClock_Config(void) {
 
     #if MICROPY_HW_CLK_USE_HSI48
     // Use the 48MHz internal oscillator
+    // HAL does not support RCC CFGR SW=3 (HSI48 direct to SYSCLK)
+    // so use HSI48 -> PREDIV(divide by 2) -> PLL (mult by 2) -> SYSCLK.
 
     RCC->CR2 |= RCC_CR2_HSI48ON;
     while ((RCC->CR2 & RCC_CR2_HSI48RDY) == 0) {
+        // Wait for HSI48 to be ready
     }
-    const uint32_t sysclk_src = 3;
+    RCC->CFGR = 0 << RCC_CFGR_PLLMUL_Pos | 3 << RCC_CFGR_PLLSRC_Pos; // PLL mult by 2, src = HSI48/PREDIV
+    RCC->CFGR2 = 1; // Input clock divided by 2
 
     #else
     // Use HSE and the PLL to get a 48MHz SYSCLK
@@ -56,13 +60,14 @@ void SystemClock_Config(void) {
     }
     RCC->CFGR = ((48000000 / HSE_VALUE) - 2) << RCC_CFGR_PLLMUL_Pos | 2 << RCC_CFGR_PLLSRC_Pos;
     RCC->CFGR2 = 0; // Input clock not divided
+    
+    #endif
+    
     RCC->CR |= RCC_CR_PLLON; // Turn PLL on
     while ((RCC->CR & RCC_CR_PLLRDY) == 0) {
         // Wait for PLL to lock
     }
     const uint32_t sysclk_src = 2;
-
-    #endif
 
     // Select SYSCLK source
     RCC->CFGR |= sysclk_src << RCC_CFGR_SW_Pos;

--- a/ports/stm32/powerctrlboot.c
+++ b/ports/stm32/powerctrlboot.c
@@ -48,7 +48,7 @@ void SystemClock_Config(void) {
     RCC->CFGR = 0 << RCC_CFGR_PLLMUL_Pos | 3 << RCC_CFGR_PLLSRC_Pos; // PLL mult by 2, src = HSI48/PREDIV
     RCC->CFGR2 = 1; // Input clock divided by 2
 
-    #else
+    #elif MICROPY_HW_CLK_USE_HSE
     // Use HSE and the PLL to get a 48MHz SYSCLK
 
     #if MICROPY_HW_CLK_USE_BYPASS
@@ -61,6 +61,18 @@ void SystemClock_Config(void) {
     RCC->CFGR = ((48000000 / HSE_VALUE) - 2) << RCC_CFGR_PLLMUL_Pos | 2 << RCC_CFGR_PLLSRC_Pos;
     RCC->CFGR2 = 0; // Input clock not divided
     
+    #elif MICROPY_HW_CLK_USE_HSI
+    // Use the 8MHz internal oscillator and the PLL to get a 48MHz SYSCLK
+
+    RCC->CR |= RCC_CR_HSION;
+    while ((RCC->CR & RCC_CR_HSIRDY) == 0) {
+        // Wait for HSI to be ready
+    }
+    RCC->CFGR = 4 << RCC_CFGR_PLLMUL_Pos | 1 << RCC_CFGR_PLLSRC_Pos; // PLL mult by 6, src = HSI
+    RCC->CFGR2 = 0; // Input clock not divided
+
+    #else
+    #error System clock not specified
     #endif
     
     RCC->CR |= RCC_CR_PLLON; // Turn PLL on


### PR DESCRIPTION
This addresses https://github.com/micropython/micropython/issues/5049
The baud rate was wrong because stm32lib SystemCoreClockUpdate sets
SystemCoreClock to 8MHz instead of 48MHz if HSI48 is routed directly to SYSCLK.
Work around is to use HSI48 -> PREDIV (/2) -> PLL (*2) -> SYSCLK.