### PR TITLE
fix: for implicit declaration of function 'rename'

### DIFF
--- a/extmod/vfs_posix.c
+++ b/extmod/vfs_posix.c
@@ -34,6 +34,7 @@
 #include <string.h>
 #include <sys/stat.h>
 #include <dirent.h>
+#include <stdio.h>
 
 typedef struct _mp_obj_vfs_posix_t {
     mp_obj_base_t base;


### PR DESCRIPTION
When compiling with MICROPY_VFS_POSIX enabled on macOS I got:
```
CC ../../extmod/vfs_posix.c
../../extmod/vfs_posix.c:264:15: error: implicit declaration of function 'rename' is invalid in C99
  [-Werror,-Wimplicit-function-declaration]
    int ret = rename(old_path, new_path);
              ^
1 error generated.
make: *** [build/extmod/vfs_posix.o] Error 1
```
Adding `#include <stdio.h>` fixes that error.