### PR TITLE
py/objtype: Add type.__bases__ attribute.

### DIFF
--- a/py/objtype.c
+++ b/py/objtype.c
@@ -1014,6 +1014,21 @@ STATIC void type_attr(mp_obj_t self_in, qstr attr, mp_obj_t *dest) {
             dest[0] = MP_OBJ_NEW_QSTR(self->name);
             return;
         }
+        if (attr == MP_QSTR___bases__) {
+            if (self == &mp_type_object) {
+                dest[0] = mp_const_empty_tuple;
+                return;
+            }
+            mp_obj_t parent_obj = self->parent ? MP_OBJ_FROM_PTR(self->parent) : MP_OBJ_FROM_PTR(&mp_type_object);
+            #if MICROPY_MULTIPLE_INHERITANCE
+            if (mp_obj_is_type(parent_obj, &mp_type_tuple)) {
+                dest[0] = parent_obj;
+                return;
+            }
+            #endif
+            dest[0] = mp_obj_new_tuple(1, &parent_obj);
+            return;
+        }
         #endif
         struct class_lookup_data lookup = {
             .obj = (mp_obj_instance_t*)self,

--- a/tests/basics/class_bases.py
+++ b/tests/basics/class_bases.py
@@ -1,0 +1,41 @@
+# test for type.__bases__ implementation
+
+class A:
+    pass
+
+class B(object):
+    pass
+
+class C(B):
+    pass
+
+class D(C, A):
+    pass
+
+# Check the attribute exists
+print(hasattr(A, '__bases__'))
+print(hasattr(B, '__bases__'))
+print(hasattr(C, '__bases__'))
+print(hasattr(D, '__bases__'))
+
+# Check it is always a tuple
+print(type(A.__bases__) == tuple)
+print(type(B.__bases__) == tuple)
+print(type(C.__bases__) == tuple)
+print(type(D.__bases__) == tuple)
+
+# Check size
+print(len(A.__bases__) == 1)
+print(len(B.__bases__) == 1)
+print(len(C.__bases__) == 1)
+print(len(D.__bases__) == 2)
+
+# Check values
+print(A.__bases__[0] == object)
+print(B.__bases__[0] == object)
+print(C.__bases__[0] == B)
+print(D.__bases__[0] == C)
+print(D.__bases__[1] == A)
+
+# Object has an empty tuple
+print(object.__bases__ == tuple())


### PR DESCRIPTION
Proposal: Add `__bases__` attribute to types so that the inheritance heirachy can be inspected. Related to #5106 and #4368 

I have not implemented `.__base__` nor have I made any changes to anything `MRO` related. This is simply a read-only attribute that supports single and multiple inheritance. 

For me, the intent of this addition is so I can type check objects in my application to ensure they inherit from a common base class. 

It should be noted that I would like to add documentation and tests for this, once we finalize the draft. I'm not proposing we ignore housekeeping. 

Example:
```
>>> class A:
...     pass
>>> class B(object):
...     pass
>>> class C(B):
...     pass
>>> class D(C, A):
...     pass
>>> A.__bases__
(<class 'object'>,)
>>> B.__bases__
(<class 'object'>,)
>>> C.__bases__
(<class 'B'>,)
>>> D.__bases__
(<class 'C'>, <class 'A'>)
```