### PR TITLE
py/makeqstrdefs.py: Remove unused blacklist.

### DIFF
--- a/py/makeqstrdefs.py
+++ b/py/makeqstrdefs.py
@@ -12,10 +12,6 @@ import sys
 import io
 import os
 
-# Blacklist of qstrings that are specially handled in further
-# processing and should be ignored
-QSTRING_BLACK_LIST = set(['NULL', 'number_of'])
-
 
 def write_out(fname, output):
     if output:
@@ -46,8 +42,7 @@ def process_file(f):
             continue
         for match in re_qstr.findall(line):
             name = match.replace('MP_QSTR_', '')
-            if name not in QSTRING_BLACK_LIST:
-                output.append('Q(' + name + ')')
+            output.append('Q(' + name + ')')
 
     write_out(last_fname, output)
     return ""


### PR DESCRIPTION
Fixes #5140

As of 7d58a19, `NULL` should no longer be here because it's allowed (MP_QSTRnull took its place). This entry was preventing the use of MP_QSTR_NULL to mean "NULL" (although this is not currently used). 7d58a19 was mostly about fixing "NULL" in frozen modules, and since frozen_mpy.c doesn't go through the main qstr pipeline, it didn't run into this.

I don't believe `number_of` is needed here either since 0a2e965, so this commit removes the blacklist altogether.