### PR TITLE
top: Add CODEOFCONDUCT.md document based on the PSF code of conduct.

### DIFF
--- a/CODEOFCONDUCT.md
+++ b/CODEOFCONDUCT.md
@@ -1,0 +1,53 @@
+MicroPython Code of Conduct
+===========================
+
+The MicroPython community is made up of members from around the globe with a
+diverse set of skills, personalities, and experiences.  It is through these
+differences that our community experiences great successes and continued growth.
+When you're working with members of the community, this Code of Conduct will
+help steer your interactions and keep MicroPython a positive, successful, and
+growing community.
+
+Members of the MicroPython community are open, considerate, and respectful.
+Behaviours that reinforce these values contribute to a positive environment, and
+include: acknowledging time and effort, being respectful of differing viewpoints
+and experiences, gracefully accepting constructive criticism, and using
+welcoming and inclusive language.
+
+Every member of our community has the right to have their identity respected.
+The MicroPython community is dedicated to providing a positive experience for
+everyone, regardless of age, gender identity and expression, sexual orientation,
+disability, physical appearance, body size, ethnicity, nationality, race, or
+religion (or lack thereof), education, or socio-economic status.
+
+Unacceptable behaviour includes: harassment, trolling, deliberate intimidation,
+violent threats or language directed against another person; insults, put downs,
+or jokes that are based upon stereotypes, that are exclusionary, or that hold
+others up for ridicule; unwelcome sexual attention or advances; sustained
+disruption of community discussions; publishing others' private information
+without explicit permission; and other conduct that is inappropriate for a
+professional audience including people of many different backgrounds.
+
+This code of conduct covers all online and offline presence related to the
+MicroPython project, including GitHub and the forum.  If a participant engages
+in behaviour that violates this code of conduct, the MicroPython team may take
+action as they deem appropriate, including warning the offender or expulsion
+from the community.  Community members asked to stop any inappropriate behaviour
+are expected to comply immediately.
+
+Thank you for helping make this a welcoming, friendly community for everyone.
+
+If you believe that someone is violating the code of conduct, or have any other
+concerns, please contact a member of the MicroPython team by emailing
+contact@micropython.org.
+
+License
+-------
+
+This Code of Conduct is licensed under the Creative Commons
+Attribution-ShareAlike 3.0 Unported License.
+
+Attributions
+------------
+
+Based on the Python code of conduct found at https://www.python.org/psf/conduct/


### PR DESCRIPTION
This is attempt number two adding a Code of Conduct document to the project.  See previous attempt at #4358 

The document here is based on the (new) PSF code of conduct, with significant simplifications to make it short and to the point.