### PR TITLE
stm32/adc.c stm32/machine_adc.c: Change ADC clock and sampling time.

### DIFF
--- a/ports/stm32/adc.c
+++ b/ports/stm32/adc.c
@@ -241,7 +241,13 @@ STATIC void adcx_init_periph(ADC_HandleTypeDef *adch, uint32_t resolution) {
     adch->Init.EOCSelection          = ADC_EOC_SINGLE_CONV;
     adch->Init.ExternalTrigConv      = ADC_SOFTWARE_START;
     adch->Init.ExternalTrigConvEdge  = ADC_EXTERNALTRIGCONVEDGE_NONE;
-    #if defined(STM32F0) || defined(STM32F4) || defined(STM32F7)
+    #if defined(STM32F0)
+    adch->Init.ClockPrescaler        = ADC_CLOCK_SYNC_PCLK_DIV4; //12MHz.
+    adch->Init.ScanConvMode          = DISABLE;
+    adch->Init.DataAlign             = ADC_DATAALIGN_RIGHT;
+    adch->Init.DMAContinuousRequests = DISABLE;
+    adch->Init.SamplingTimeCommon    = ADC_SAMPLETIME_55CYCLES_5; // ~4uS
+    #elif defined(STM32F4) || defined(STM32F7)
     adch->Init.ClockPrescaler        = ADC_CLOCK_SYNC_PCLK_DIV2;
     adch->Init.ScanConvMode          = DISABLE;
     adch->Init.DataAlign             = ADC_DATAALIGN_RIGHT;
@@ -264,10 +270,6 @@ STATIC void adcx_init_periph(ADC_HandleTypeDef *adch, uint32_t resolution) {
     adch->Init.DMAContinuousRequests = DISABLE;
     #else
     #error Unsupported processor
-    #endif
-
-    #if defined(STM32F0)
-    adch->Init.SamplingTimeCommon = ADC_SAMPLETIME_71CYCLES_5;
     #endif
 
     HAL_ADC_Init(adch);
@@ -309,7 +311,7 @@ STATIC void adc_config_channel(ADC_HandleTypeDef *adc_handle, uint32_t channel) 
     sConfig.Channel = channel;
     sConfig.Rank = 1;
 #if defined(STM32F0)
-    sConfig.SamplingTime = ADC_SAMPLETIME_71CYCLES_5;
+    sConfig.SamplingTime = ADC_SAMPLETIME_55CYCLES_5;
 #elif defined(STM32F4) || defined(STM32F7)
     sConfig.SamplingTime = ADC_SAMPLETIME_15CYCLES;
 #elif defined(STM32H7)

--- a/ports/stm32/machine_adc.c
+++ b/ports/stm32/machine_adc.c
@@ -49,7 +49,7 @@
 #endif
 
 #if defined(STM32F0)
-#define ADC_SAMPLETIME_DEFAULT      ADC_SAMPLETIME_71CYCLES_5
+#define ADC_SAMPLETIME_DEFAULT      ADC_SAMPLETIME_13CYCLES_5
 #define ADC_SAMPLETIME_DEFAULT_INT  ADC_SAMPLETIME_239CYCLES_5
 #elif defined(STM32F4) || defined(STM32F7)
 #define ADC_SAMPLETIME_DEFAULT      ADC_SAMPLETIME_15CYCLES
@@ -126,7 +126,7 @@ STATIC void adc_config(ADC_TypeDef *adc, uint32_t bits) {
 
     // Configure clock mode
     #if defined(STM32F0)
-    adc->CFGR2 = 1 << ADC_CFGR2_CKMODE_Pos; // PCLK/2 (synchronous clock mode)
+    adc->CFGR2 = 2 << ADC_CFGR2_CKMODE_Pos; // PCLK/4 (synchronous clock mode)
     #elif defined(STM32F4) || defined(STM32F7) || defined(STM32L4)
     ADCx_COMMON->CCR = 0; // ADCPR=PCLK/2
     #elif defined(STM32H7)


### PR DESCRIPTION
STM32F0 has PLCK = 48MHz. Max ADC clock is 14MHz so use PCLK/4 = 12MHz.
In pyb.ADC set common sampling time to approx 4uS for internal and external sources.
In machine.ADC reduce sample time to approx 1uS for external source, leave int at max.