### PR TITLE
[WIP] nrf: Change Xenon board to use built-in bootloader.

### DIFF
--- a/ports/nrf/Makefile
+++ b/ports/nrf/Makefile
@@ -254,7 +254,7 @@ $(filter $(PY_BUILD)/../extmod/vfs_fat_%.o, $(PY_O)): COPT += -Os
 
 .PHONY: all flash deploy sd binary hex
 
-all: binary hex
+all: binary hex dfu
 
 OUTPUT_FILENAME = firmware
 
@@ -263,12 +263,19 @@ binary: $(BUILD)/$(OUTPUT_FILENAME).bin
 
 $(BUILD)/$(OUTPUT_FILENAME).bin: $(BUILD)/$(OUTPUT_FILENAME).elf
 	$(OBJCOPY) -O binary $< $@
+	$(Q)$(PYTHON) particle_fw.py $@
 
 ## Create binary .hex file from the .out file
 hex: $(BUILD)/$(OUTPUT_FILENAME).hex
 
 $(BUILD)/$(OUTPUT_FILENAME).hex: $(BUILD)/$(OUTPUT_FILENAME).elf
 	$(OBJCOPY) -O ihex $< $@
+
+dfu: $(BUILD)/$(OUTPUT_FILENAME).dfu
+
+$(BUILD)/$(OUTPUT_FILENAME).dfu: $(BUILD)/$(OUTPUT_FILENAME).bin
+	$(ECHO) "Create $@"
+	$(Q)$(PYTHON) $(TOP)/tools/dfu.py -b 0x00030000:$< $@
 
 FLASHER ?=
 

--- a/ports/nrf/boards/particle_xenon/board.ld
+++ b/ports/nrf/boards/particle_xenon/board.ld
@@ -1,0 +1,35 @@
+/*
+    GNU linker script for NRF52840, Particle bootloader layout
+*/
+
+_flash_size = 1M;
+_ram_size   = 252K;
+
+/* produce a link error if there is not this amount of RAM for these sections */
+_stack_size = 8K;
+_minimum_heap_size = 128K;
+
+
+/* Flash layout: bootloader | softdevice     | application     | filesystem */
+/* RAM layout:   softdevice RAM | application RAM */
+_sd_size       = DEFINED(_sd_size) ? _sd_size : 0;
+_sd_ram        = DEFINED(_sd_ram)  ? _sd_ram : 0;
+_fs_size       = DEFINED(_fs_size) ? _fs_size : 64K; /* TODO: set to 0 if not using the filesystem */
+_app_size      = 512K - _fs_size;
+_app_start     = 192K;
+_fs_start      = _sd_size + _app_size;
+_fs_end        = _fs_start + _fs_size;
+_app_ram_start = 0x20000000 + _sd_ram;
+_app_ram_size  = _ram_size - _sd_ram;
+_heap_start    = _ebss;
+_heap_end      = _ram_end - _stack_size;
+_heap_size     = _heap_end - _heap_start;
+
+ASSERT(_heap_size >= _minimum_heap_size, "not enough RAM left for heap")
+
+/* Specify the memory areas */
+MEMORY
+{
+    FLASH_TEXT (rx) : ORIGIN = _app_start,     LENGTH = _app_size     /* app */
+    RAM (xrw)       : ORIGIN = _app_ram_start, LENGTH = _app_ram_size
+}

--- a/ports/nrf/boards/particle_xenon/mpconfigboard.mk
+++ b/ports/nrf/boards/particle_xenon/mpconfigboard.mk
@@ -2,6 +2,6 @@ MCU_SERIES = m4
 MCU_VARIANT = nrf52
 MCU_SUB_VARIANT = nrf52840
 SOFTDEV_VERSION = 6.1.1
-LD_FILES += boards/nrf52840_1M_256k.ld
+LD_FILE = boards/particle_xenon/board.ld boards/common.ld
 
 NRF_DEFINES += -DNRF52840_XXAA

--- a/ports/nrf/device/startup_nrf52840.c
+++ b/ports/nrf/device/startup_nrf52840.c
@@ -43,6 +43,9 @@ void Default_Handler(void) {
 }
 
 void Reset_Handler(void) {
+    // VTOR
+    *((volatile uint32_t*)0xe000ed08) = 0x30000;
+
     uint32_t * p_src  = &_sidata;
     uint32_t * p_dest = &_sdata;
 
@@ -179,4 +182,13 @@ const func __Vectors[] __attribute__ ((section(".isr_vector"),used)) = {
     SPIM3_IRQHandler,
     0,
     PWM3_IRQHandler,
+
+    0, 0,
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+
+    // At 0x200: particle module_info_t
+    0, 0, 0, 0, 0, 0, 0, 0,
 };

--- a/ports/nrf/particle_fw.py
+++ b/ports/nrf/particle_fw.py
@@ -1,0 +1,12 @@
+import sys, struct, zlib
+
+BASE = 0x00030000
+
+with open(sys.argv[1], 'rb') as f:
+    data = bytearray(f.read())
+struct.pack_into('<IIBBHHBBII', data, 0x200, BASE, BASE + len(data), 0, 0, 0x138, 0x0e, 0x03, 0, 0, 0)
+crc = zlib.crc32(data)
+print('CRC: {:08x}'.format(crc))
+data += struct.pack('>I', crc)
+with open(sys.argv[1], 'wb') as f:
+    f.write(data)


### PR DESCRIPTION
This PR is a WIP to support the built-in bootloader on the nrf Xenon board (currently the entire flash is overwritten with MicroPython firmware using an external programmer; using this PR allows to use the built-in USB DFU to download firmware).