### PR TITLE
travis: Build unix nanbox with PYTHON=python2.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -94,16 +94,16 @@ jobs:
         - make ${MAKEOPTS} -C ports/unix test
         - (cd tests && MICROPY_CPYTHON3=python3 MICROPY_MICROPYTHON=../ports/unix/micropython ./run-perfbench.py 1000 1000)
 
-    # unix nanbox
+    # unix nanbox (and using Python 2 to check it can run the build scripts)
     - stage: test
       env: NAME="unix nanbox port build and tests"
       install:
         - sudo apt-get install gcc-multilib libffi-dev:i386
       script:
         - git submodule update --init lib/axtls lib/berkeley-db-1.xx lib/libffi
-        - make ${MAKEOPTS} -C mpy-cross
-        - make ${MAKEOPTS} -C ports/unix deplibs
-        - make ${MAKEOPTS} -C ports/unix nanbox
+        - make ${MAKEOPTS} -C mpy-cross PYTHON=python2
+        - make ${MAKEOPTS} -C ports/unix PYTHON=python2 deplibs
+        - make ${MAKEOPTS} -C ports/unix PYTHON=python2 nanbox
         - (cd tests && MICROPY_CPYTHON3=python3 MICROPY_MICROPYTHON=../ports/unix/micropython_nanbox ./run-tests)
 
     # unix stackless


### PR DESCRIPTION
To test build support with Python 2.7.