### PR TITLE
fix: It crashes if enable MICROPY_DEBUG_VERBOSE

### DIFF
--- a/py/gc.c
+++ b/py/gc.c
@@ -109,6 +109,12 @@
 void gc_init(void *start, void *end) {
     // align end pointer on block boundary
     end = (void*)((uintptr_t)end & (~(BYTES_PER_BLOCK - 1)));
+
+#if MICROPY_PY_THREAD_GIL
+    mp_thread_mutex_init(&MP_STATE_VM(gil_mutex));
+#endif
+    MP_THREAD_GIL_ENTER();
+
     DEBUG_printf("Initializing GC heap: %p..%p = " UINT_FMT " bytes\n", start, end, (byte*)end - (byte*)start);
 
     // calculate parameters for GC (T=total, A=alloc table, F=finaliser table, P=pool; all in bytes):

--- a/py/runtime.c
+++ b/py/runtime.c
@@ -134,12 +134,6 @@ void mp_init(void) {
     #if MICROPY_PY_BLUETOOTH
     MP_STATE_VM(bluetooth) = MP_OBJ_NULL;
     #endif
-
-    #if MICROPY_PY_THREAD_GIL
-    mp_thread_mutex_init(&MP_STATE_VM(gil_mutex));
-    #endif
-
-    MP_THREAD_GIL_ENTER();
 }
 
 void mp_deinit(void) {


### PR DESCRIPTION
- If enable `MICROPY_DEBUG_VERBOSE`, `mp_thread_mutex_lock(&MP_STATE_VM(gil_mutex), 1)` and `mp_thread_mutex_unlock(&MP_STATE_VM(gil_mutex))` were called before `mp_thread_mutex_init(&MP_STATE_VM(gil_mutex))`.