### PR TITLE
ESP32 RMT Implementation

### DIFF
--- a/docs/esp32/general.rst
+++ b/docs/esp32/general.rst
@@ -52,6 +52,7 @@ For your convenience, some of technical specifications are provided below:
 * I2S: 2
 * ADC: 12-bit SAR ADC up to 18 channels
 * DAC: 2 8-bit DACs
+* RMT
 * Programming: using BootROM bootloader from UART - due to external FlashROM
   and always-available BootROM bootloader, the ESP32 is not brickable
 

--- a/docs/esp32/general.rst
+++ b/docs/esp32/general.rst
@@ -52,7 +52,7 @@ For your convenience, some of technical specifications are provided below:
 * I2S: 2
 * ADC: 12-bit SAR ADC up to 18 channels
 * DAC: 2 8-bit DACs
-* RMT
+* RMT: 8 channels allowing accurate pulse transmit/receive
 * Programming: using BootROM bootloader from UART - due to external FlashROM
   and always-available BootROM bootloader, the ESP32 is not brickable
 

--- a/docs/esp32/quickref.rst
+++ b/docs/esp32/quickref.rst
@@ -365,6 +365,22 @@ Notes:
     
     p1 = Pin(4, Pin.OUT, None)
 
+RMT
+---
+
+The RMT is a module, specific to the ESP32, that allows pulses of very accurate interval
+and duration to be sent and received::
+
+    rmt_channel = esp32.RMT(0, machine.Pin(18), 100)  # Channel 0, bound to Pin 18, clock divider of 100
+    rmt_channel.send_pulses((10, 1000, 10, 2000, 10, 3000))  # Send three long pulses with short delays between
+
+For more details see Espressif `ESP-IDF RMT documentation.
+<https://docs.espressif.com/projects/esp-idf/en/latest/api-reference/peripherals/rmt.html>`_.
+
+.. Warning::
+   The current MicroPython RMT implementation lacks some features, notably receiving pulses
+   and carrier transmit.
+
 OneWire driver
 --------------
 

--- a/docs/esp32/quickref.rst
+++ b/docs/esp32/quickref.rst
@@ -368,21 +368,35 @@ Notes:
 RMT
 ---
 
-The RMT (Remote Control) module, specific to the ESP32, was originally designed to send
-and receive infrared remote control signals. However, due to a flexible design and
-very accurate (12.5ns) pulse generation, it can also be used to transmit or receive
-many other types of digital signals::
+The RMT (Remote Control) module, specific to the ESP32, was originally designed
+to send and receive infrared remote control signals. However, due to a flexible
+design and very accurate (as low as 12.5ns) pulse generation, it can also be
+used to transmit or receive many other types of digital signals::
 
     r = esp32.RMT(0, Pin(18), 80)
     r  # RMT(channel=0, pin=18, clock_divider=80)
     r.resolution(), r.max_pulse_length()  # (1e-06, 0.032768)
-    r.send_pulses((100, 2000, 100, 4000), start_level=0)  # Send 0 for 100*1e-06s, 1 for 2000*1e-06s etc
+    r.send_pulses((100, 2000, 100, 4000), start=0)  # Send 0 for 100*1e-06s, 1 for 2000*1e-06s etc
 
-For more details see Espressif `ESP-IDF RMT documentation.
+The input to the RMT module is an 80MHz clock. ``clock_divider`` *divides* the
+clock input which determines the minimum *resolution* of a pulse. The numbers
+specificed in ``send_pulses`` are *multiplied* by the minimum resolution to
+define the pulses.
+
+``clock_divider`` is an 8-bit divider (0-255) and each pulse can be defined by
+multiplying the minimum resolution by a 15-bit (0-32,768) number. There are
+eight channels (0-7) and each can have a different clock divider.
+
+So, in the example above, the 80MHz clock is divided by 80. Thus the minimum
+resolution is (1/(80Mhz/80)) 1µs. Since the ``start`` level is 0 and toggles
+with each number, the bitstream is ``0101`` with durations of [100µs, 2ms,
+100µs, 4ms].
+
+For more details see Espressif's `ESP-IDF RMT documentation.
 <https://docs.espressif.com/projects/esp-idf/en/latest/api-reference/peripherals/rmt.html>`_.
 
 .. Warning::
-   The current MicroPython RMT implementation lacks some features, notably receiving pulses
+   The current MicroPython RMT implementation lacks some features, most notably receiving pulses
    and carrier transmit.
 
 OneWire driver

--- a/docs/esp32/quickref.rst
+++ b/docs/esp32/quickref.rst
@@ -373,31 +373,32 @@ to send and receive infrared remote control signals. However, due to a flexible
 design and very accurate (as low as 12.5ns) pulse generation, it can also be
 used to transmit or receive many other types of digital signals::
 
-    r = esp32.RMT(0, Pin(18), 80)
-    r  # RMT(channel=0, pin=18, clock_divider=80)
-    r.resolution(), r.max_pulse_length()  # (1e-06, 0.032768)
-    r.send_pulses((100, 2000, 100, 4000), start=0)  # Send 0 for 100*1e-06s, 1 for 2000*1e-06s etc
+    r = esp32.RMT(0, pin=Pin(18), clock_div=8)
+    r  # RMT(channel=0, pin=18, source_freq=80000000, clock_div=8)
+    # The *resolution* is 100ns (1/(source_freq/clock_div)).
+    r.send_pulses((1, 20, 2, 40), start=0)  # Send 0 for 100ns, 1 for 2000ns, 0 for 200ns, 1 for 4000ns
 
-The input to the RMT module is an 80MHz clock. ``clock_divider`` *divides* the
-clock input which determines the minimum *resolution* of a pulse. The numbers
-specificed in ``send_pulses`` are *multiplied* by the minimum resolution to
+The input to the RMT module is an 80MHz clock (in the future it may be able to
+configure the input clock but, for now, it's fixed). ``clock_div`` *divides*
+the clock input which determines the *resolution* of the RMT channel. The
+numbers specificed in ``send_pulses`` are *multiplied* by the resolution to
 define the pulses.
 
-``clock_divider`` is an 8-bit divider (0-255) and each pulse can be defined by
-multiplying the minimum resolution by a 15-bit (0-32,768) number. There are
-eight channels (0-7) and each can have a different clock divider.
+``clock_div`` is an 8-bit divider (0-255) and each pulse can be defined by
+multiplying the resolution by a 15-bit (0-32,768) number. There are eight
+channels (0-7) and each can have a different clock divider.
 
-So, in the example above, the 80MHz clock is divided by 80. Thus the minimum
-resolution is (1/(80Mhz/80)) 1µs. Since the ``start`` level is 0 and toggles
-with each number, the bitstream is ``0101`` with durations of [100µs, 2ms,
-100µs, 4ms].
+So, in the example above, the 80MHz clock is divided by 8. Thus the
+resolution is (1/(80Mhz/8)) 100ns. Since the ``start`` level is 0 and toggles
+with each number, the bitstream is ``0101`` with durations of [100ns, 2000ns,
+100ns, 4000ns].
 
 For more details see Espressif's `ESP-IDF RMT documentation.
 <https://docs.espressif.com/projects/esp-idf/en/latest/api-reference/peripherals/rmt.html>`_.
 
 .. Warning::
    The current MicroPython RMT implementation lacks some features, most notably receiving pulses
-   and carrier transmit.
+   and carrier transmit. It's also a *beta feature* and the interface may change in the future.
 
 OneWire driver
 --------------

--- a/docs/esp32/quickref.rst
+++ b/docs/esp32/quickref.rst
@@ -368,11 +368,15 @@ Notes:
 RMT
 ---
 
-The RMT is a module, specific to the ESP32, that allows pulses of very accurate interval
-and duration to be sent and received::
+The RMT (Remote Control) module, specific to the ESP32, was originally designed to send
+and receive infrared remote control signals. However, due to a flexible design and
+very accurate (12.5ns) pulse generation, it can also be used to transmit or receive
+many other types of digital signals::
 
-    rmt_channel = esp32.RMT(0, machine.Pin(18), 100)  # Channel 0, bound to Pin 18, clock divider of 100
-    rmt_channel.send_pulses((10, 1000, 10, 2000, 10, 3000))  # Send three long pulses with short delays between
+    r = esp32.RMT(0, Pin(18), 80)
+    r  # RMT(channel=0, pin=18, clock_divider=80)
+    r.resolution(), r.max_pulse_length()  # (1e-06, 0.032768)
+    r.send_pulses((100, 2000, 100, 4000), start_level=0)  # Send 0 for 100*1e-06s, 1 for 2000*1e-06s etc
 
 For more details see Espressif `ESP-IDF RMT documentation.
 <https://docs.espressif.com/projects/esp-idf/en/latest/api-reference/peripherals/rmt.html>`_.

--- a/docs/esp32/quickref.rst
+++ b/docs/esp32/quickref.rst
@@ -368,37 +368,19 @@ Notes:
 RMT
 ---
 
-The RMT (Remote Control) module, specific to the ESP32, was originally designed
-to send and receive infrared remote control signals. However, due to a flexible
-design and very accurate (as low as 12.5ns) pulse generation, it can also be
-used to transmit or receive many other types of digital signals::
+See :ref:`esp32.RMT <esp32.RMT>`
+
+The RMT is ESP32-specific and allows generation of accurate digital pulses with
+12.5ns resolution. Usage is::
+
+    import esp32
+    from machine import Pin
 
     r = esp32.RMT(0, pin=Pin(18), clock_div=8)
-    r  # RMT(channel=0, pin=18, source_freq=80000000, clock_div=8)
-    # The *resolution* is 100ns (1/(source_freq/clock_div)).
+    r   # RMT(channel=0, pin=18, source_freq=80000000, clock_div=8)
+    # The channel resolution is 100ns (1/(source_freq/clock_div)).
     r.send_pulses((1, 20, 2, 40), start=0)  # Send 0 for 100ns, 1 for 2000ns, 0 for 200ns, 1 for 4000ns
 
-The input to the RMT module is an 80MHz clock (in the future it may be able to
-configure the input clock but, for now, it's fixed). ``clock_div`` *divides*
-the clock input which determines the *resolution* of the RMT channel. The
-numbers specificed in ``send_pulses`` are *multiplied* by the resolution to
-define the pulses.
-
-``clock_div`` is an 8-bit divider (0-255) and each pulse can be defined by
-multiplying the resolution by a 15-bit (0-32,768) number. There are eight
-channels (0-7) and each can have a different clock divider.
-
-So, in the example above, the 80MHz clock is divided by 8. Thus the
-resolution is (1/(80Mhz/8)) 100ns. Since the ``start`` level is 0 and toggles
-with each number, the bitstream is ``0101`` with durations of [100ns, 2000ns,
-100ns, 4000ns].
-
-For more details see Espressif's `ESP-IDF RMT documentation.
-<https://docs.espressif.com/projects/esp-idf/en/latest/api-reference/peripherals/rmt.html>`_.
-
-.. Warning::
-   The current MicroPython RMT implementation lacks some features, most notably receiving pulses
-   and carrier transmit. It's also a *beta feature* and the interface may change in the future.
 
 OneWire driver
 --------------

--- a/docs/library/esp32.rst
+++ b/docs/library/esp32.rst
@@ -101,6 +101,50 @@ The Ultra-Low-Power co-processor
 
     Start the ULP running at the given *entry_point*.
 
+RMT
+---
+
+.. class:: RMT(channel, pin, clock_div)
+
+    This class provides access to one of the eight RMT channels. *channel* is
+    required and identifies which RMT channel (0-7) will be configured. *pin*,
+    also required, configures which Pin is bound to the RMT channel. *clock_div*
+    is an 8-bit clock divider that divides the source clock (80MHz) to the RMT
+    channel allowing the *resolution* to be specified.
+
+.. method:: RMT.source_freq()
+
+    Returns the source clock frequency. Currently the source clock is not
+    configurable so this will always return 80MHz.
+
+.. method:: RMT.clock_div()
+
+    Return the clock divider. Note that *resolution* is
+    ``1/(source_freq/clock_div)``.
+
+.. method:: RMT.wait_done(timeout=0)
+
+    Returns True if ``send_pulses`` has completed.
+
+    If *timeout* (defined in ticks of ``source_freq/clock_div``) is specified
+    the method will wait for *timeout* or until ``send_pulses`` is complete,
+    returning False if the channel continues to transmit.
+
+.. Warning::
+    Avoid using ``wait_done()`` if looping is enabled.
+
+.. method:: RMT.loop(enable_loop)
+
+    Configure looping on the channel, allowing a stream of pulses to be
+    indefinitely repeated. *enable_loop* is bool, set to True to enable looping.
+
+.. method:: RMT.send_pulses(pulses, start)
+
+    Begin sending *pulses*, a list or tuple defining the stream of pulses. The
+    length of each pulse is defined by a number to be multiplied by the channel
+    resolution (1/(source_freq/clock_div)). *start* defines whether the stream
+    starts at 0 or 1.
+
 
 Constants
 ---------

--- a/ports/esp32/Makefile
+++ b/ports/esp32/Makefile
@@ -324,6 +324,7 @@ SRC_C = \
 	modesp.c \
 	esp32_partition.c \
 	esp32_ulp.c \
+	esp32_rmt.c \
 	modesp32.c \
 	espneopixel.c \
 	machine_hw_spi.c \

--- a/ports/esp32/esp32_rmt.c
+++ b/ports/esp32/esp32_rmt.c
@@ -95,7 +95,7 @@ STATIC mp_obj_t esp32_rmt_make_new(const mp_obj_type_t *type, size_t n_args, siz
     config.tx_config.loop_en = 0;
 
     config.tx_config.carrier_en = 0;
-    config.tx_config.idle_output_en = 0;
+    config.tx_config.idle_output_en = 1;
     config.tx_config.idle_level = 0;
     config.tx_config.carrier_duty_percent = 0;
     config.tx_config.carrier_freq_hz = 0;

--- a/ports/esp32/esp32_rmt.c
+++ b/ports/esp32/esp32_rmt.c
@@ -173,10 +173,10 @@ STATIC mp_obj_t esp32_rmt_send_pulses(size_t n_args, const mp_obj_t *pos_args, m
 
     esp32_rmt_obj_t *self = MP_OBJ_TO_PTR(args[0].u_obj);
     mp_obj_t pulses = args[1].u_obj;
-    mp_uint_t start_level = args[2].u_int;
+    mp_uint_t start = args[2].u_int;
 
-    if (start_level < 0 || start_level > 1) {
-        mp_raise_ValueError("start_level can only be 0 or 1");
+    if (start < 0 || start > 1) {
+        mp_raise_ValueError("start can only be 0 or 1");
     }
 
     mp_uint_t pulses_length = 0;
@@ -203,13 +203,13 @@ STATIC mp_obj_t esp32_rmt_send_pulses(size_t n_args, const mp_obj_t *pos_args, m
     {
         mp_uint_t pulse_index = item_index * 2;
         self->items[item_index].duration0 = mp_obj_get_int(pulses_ptr[pulse_index++]);
-        self->items[item_index].level0 = start_level++; // Note that start_level _could_ wrap.
-        //printf("duration=%d start_level=%d\n", items[item_index].duration0, items[item_index].level0);
+        self->items[item_index].level0 = start++; // Note that start _could_ wrap.
+        //printf("duration=%d start=%d\n", items[item_index].duration0, items[item_index].level0);
         if (pulse_index < pulses_length)
         {
             self->items[item_index].duration1 = mp_obj_get_int(pulses_ptr[pulse_index]);
-            self->items[item_index].level1 = start_level++;
-            //printf("duration=%d start_level=%d\n", items[item_index].duration1, items[item_index].level1);
+            self->items[item_index].level1 = start++;
+            //printf("duration=%d start=%d\n", items[item_index].duration1, items[item_index].level1);
         }
     }
     check_esp_err(rmt_write_items(self->channel_id, self->items, num_items, false /* non-blocking */));

--- a/ports/esp32/esp32_rmt.c
+++ b/ports/esp32/esp32_rmt.c
@@ -45,11 +45,14 @@ typedef struct _esp32_rmt_obj_t {
 
 // TODO
 //
+//   o Write up documentation
 //   o Check all the input parameters
 //   o Return exceptions when errors occur
 //   o Manage an array of channels (so user can't create the same one repeatedly)
 //     - Check if channel is initialised (in particular: after deinit)
 //   o Investigate: Send without blocking? (Need an 'is_sending' method)
+//     - Memory management becomes significantly more complex. Need to ensure memory is not freed before it's used.
+//     - Also need to take care that memory is not freed by the MicroPython GC.
 //   o Add debug option? Emit printf debug messages?
 //     - Idea: Generate timing diagram (maybe with https://wavedrom.com/ ?) Extension.
 //   o Consider: Auto-manage RMT channels? Currently user chooses a channel
@@ -65,6 +68,8 @@ typedef struct _esp32_rmt_obj_t {
 //   o Add carrier modulation methods
 //   o Add rx support
 
+// ESP-IDF RMT:
+// Espressif examples: https://github.com/espressif/arduino-esp32/tree/master/libraries/ESP32/examples/RMT
 
 STATIC mp_obj_t esp32_rmt_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *args) {
     // fixme: check arguments
@@ -154,6 +159,10 @@ STATIC mp_obj_t esp32_rmt_send_pulses(mp_obj_t self_in, mp_obj_t pulses, mp_obj_
     // fixme: Handle if not a tuple
     if(MP_OBJ_IS_TYPE(pulses, &mp_type_tuple) == true) {
         mp_obj_tuple_get(pulses, &pulses_length, &pulses_ptr);
+    } else if(MP_OBJ_IS_TYPE(pulses, &mp_type_list) == true) {
+        mp_obj_list_get(pulses, &pulses_length, &pulses_ptr);
+    } else {
+        mp_raise_TypeError("Pulses must be defined as a tuple or list");
     }
 
     mp_uint_t num_items = (pulses_length / 2) + (pulses_length % 2);

--- a/ports/esp32/esp32_rmt.c
+++ b/ports/esp32/esp32_rmt.c
@@ -3,7 +3,7 @@
  *
  * The MIT License (MIT)
  *
- * Copyright (c) 2018 "Matt Trentini" <matt.trentini@gmail.com>
+ * Copyright (c) 2019 "Matt Trentini" <matt.trentini@gmail.com>
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -42,6 +42,30 @@ typedef struct _esp32_rmt_obj_t {
     uint8_t clock_divider;
 } esp32_rmt_obj_t;
 
+
+// TODO
+//
+//   o Check all the input parameters
+//   o Return exceptions when errors occur
+//   o Manage an array of channels (so user can't create the same one repeatedly)
+//     - Check if channel is initialised (in particular: after deinit)
+//   o Investigate: Send without blocking? (Need an 'is_sending' method)
+//   o Add debug option? Emit printf debug messages?
+//     - Idea: Generate timing diagram (maybe with https://wavedrom.com/ ?) Extension.
+//   o Consider: Auto-manage RMT channels? Currently user chooses a channel
+//     - Alternative: Give the user the next available channel
+//   o Raise exception if pulses is not a tuple
+//     - Consider: Using iterables. Will make memory management much trickier though
+//     - Consider: Allowing lists as well as tuples
+//   o Do we need to allow the option to use multiple memory blocks?
+//   o Consider supporting other ways to specify pulses:
+//     - Fixed interval (specify pattern of 1's/0's)
+//     - Specify both value and ticks
+//     - See PyCom RMT docs
+//   o Add carrier modulation methods
+//   o Add rx support
+
+
 STATIC mp_obj_t esp32_rmt_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *args) {
     // fixme: check arguments
     // 1 <= channel_id <= 8
@@ -60,18 +84,17 @@ STATIC mp_obj_t esp32_rmt_make_new(const mp_obj_type_t *type, size_t n_args, siz
 
     rmt_config_t config;
     config.rmt_mode = RMT_MODE_TX;
-    config.channel = self->channel_id; // Technically should use enum eg RMT_CHANNEL_0
+    config.channel = (rmt_channel_t) self->channel_id;
     config.gpio_num = self->pin;
     config.mem_block_num = 1;
     config.tx_config.loop_en = 0;
 
-    // Shouldn't be necessary to set these (until we use them...)
-    // config.tx_config.carrier_en = 0;
-    // config.tx_config.idle_output_en = 0;
-    // config.tx_config.idle_level = 0;
-    // config.tx_config.carrier_duty_percent = 0;
-    // config.tx_config.carrier_freq_hz = 0;
-    // config.tx_config.carrier_level = 1;
+    config.tx_config.carrier_en = 0;
+    config.tx_config.idle_output_en = 0;
+    config.tx_config.idle_level = 0;
+    config.tx_config.carrier_duty_percent = 0;
+    config.tx_config.carrier_freq_hz = 0;
+    config.tx_config.carrier_level = 1;
 
     config.clk_div = self->clock_divider;
 
@@ -89,10 +112,24 @@ STATIC void esp32_rmt_print(const mp_print_t *print, mp_obj_t self_in, mp_print_
 }
 
 
+STATIC mp_obj_t esp32_rmt_deinit(mp_obj_t self_in) {
+    // fixme: check for valid channel. Return exception if error occurs.
+    esp32_rmt_obj_t *self = MP_OBJ_TO_PTR(self_in);
+    rmt_driver_uninstall(self->channel_id);
+
+    return mp_const_none;
+}
+STATIC MP_DEFINE_CONST_FUN_OBJ_1(esp32_rmt_deinit_obj, esp32_rmt_deinit);
+
+static float resolution_for_divider(uint8_t clock_divider)
+{
+    return 1.0 / (APB_CLK_FREQ / clock_divider);
+}
+
 // Return the resolution (shortest possible pulse), in seconds
 STATIC mp_obj_t esp32_rmt_resolution(mp_obj_t self_in) {
     esp32_rmt_obj_t *self = MP_OBJ_TO_PTR(self_in);
-    return mp_obj_new_float(1.0/(APB_CLK_FREQ / self->clock_divider));
+    return mp_obj_new_float(resolution_for_divider(self->clock_divider));
 }
 STATIC MP_DEFINE_CONST_FUN_OBJ_1(esp32_rmt_resolution_obj, esp32_rmt_resolution);
 
@@ -100,7 +137,7 @@ STATIC MP_DEFINE_CONST_FUN_OBJ_1(esp32_rmt_resolution_obj, esp32_rmt_resolution)
 // Return the longest pulse duration
 STATIC mp_obj_t esp32_rmt_max_duration(mp_obj_t self_in) {
     esp32_rmt_obj_t *self = MP_OBJ_TO_PTR(self_in);
-    return mp_obj_new_float((1.0/(APB_CLK_FREQ / self->clock_divider)) * 32768);
+    return mp_obj_new_float(resolution_for_divider(self->clock_divider) * 32768); // 2^15 is the maximum number of bits for ticks
 }
 STATIC MP_DEFINE_CONST_FUN_OBJ_1(esp32_rmt_max_duration_obj, esp32_rmt_max_duration);
 
@@ -122,19 +159,19 @@ STATIC mp_obj_t esp32_rmt_send_pulses(mp_obj_t self_in, mp_obj_t pulses, mp_obj_
     mp_uint_t num_items = (pulses_length / 2) + (pulses_length % 2);
     rmt_item32_t* items = (rmt_item32_t*)m_malloc(num_items * sizeof(rmt_item32_t));
 
-    printf("num_items=%d pulses_length=%d\n\n", num_items, pulses_length);
+    //printf("num_items=%d pulses_length=%d\n\n", num_items, pulses_length);
 
     for (mp_uint_t item_index = 0; item_index < num_items; item_index++)
     {
         mp_uint_t pulse_index = item_index * 2;
         items[item_index].duration0 = mp_obj_get_int(pulses_ptr[pulse_index++]);
         items[item_index].level0 = level++; // Note that level _could_ wrap.
-        printf("duration=%d level=%d\n", items[item_index].duration0, items[item_index].level0);
+        //printf("duration=%d level=%d\n", items[item_index].duration0, items[item_index].level0);
         if (pulse_index < pulses_length)
         {
             items[item_index].duration1 = mp_obj_get_int(pulses_ptr[pulse_index]);
             items[item_index].level1 = level++;
-            printf("duration=%d level=%d\n", items[item_index].duration1, items[item_index].level1);
+            //printf("duration=%d level=%d\n", items[item_index].duration1, items[item_index].level1);
         }
     }
     ESP_ERROR_CHECK(rmt_write_items(self->channel_id, items, num_items, true));
@@ -152,6 +189,7 @@ STATIC MP_DEFINE_CONST_FUN_OBJ_3(esp32_rmt_send_pulses_obj, esp32_rmt_send_pulse
 
 STATIC const mp_rom_map_elem_t esp32_rmt_locals_dict_table[] = {
     { MP_ROM_QSTR(MP_QSTR_send_pulses), MP_ROM_PTR(&esp32_rmt_send_pulses_obj) },
+    { MP_ROM_QSTR(MP_QSTR_deinit), MP_ROM_PTR(&esp32_rmt_deinit_obj) },
     { MP_ROM_QSTR(MP_QSTR_resolution), MP_ROM_PTR(&esp32_rmt_resolution_obj) },
     { MP_ROM_QSTR(MP_QSTR_max_duration), MP_ROM_PTR(&esp32_rmt_max_duration_obj) },
 };
@@ -164,6 +202,3 @@ const mp_obj_type_t esp32_rmt_type = {
     .make_new = esp32_rmt_make_new,
     .locals_dict = (mp_obj_dict_t *)&esp32_rmt_locals_dict,
 };
-
-// ch1 = RMT(1, Pin(18), 80, 0) # channel, pin, clock_divider, idle_level
-// ch1.send_items((1000, 500, 1000), start=0)

--- a/ports/esp32/esp32_rmt.c
+++ b/ports/esp32/esp32_rmt.c
@@ -226,23 +226,19 @@ STATIC mp_obj_t esp32_rmt_send_pulses(size_t n_args, const mp_obj_t *pos_args, m
     mp_uint_t num_items = (pulses_length / 2) + (pulses_length % 2);
     if (num_items > self->num_items)
     {
-        //printf("realloc required, old=%u, new=%u\n", self->num_items, num_items);
         self->items = (rmt_item32_t*)m_realloc(self->items, num_items * sizeof(rmt_item32_t *));
         self->num_items = num_items;
     }
-    //printf("num_items=%d pulses_length=%d\n\n", num_items, pulses_length);
 
     for (mp_uint_t item_index = 0; item_index < num_items; item_index++)
     {
         mp_uint_t pulse_index = item_index * 2;
         self->items[item_index].duration0 = mp_obj_get_int(pulses_ptr[pulse_index++]);
         self->items[item_index].level0 = start++; // Note that start _could_ wrap.
-        //printf("duration=%d start=%d\n", items[item_index].duration0, items[item_index].level0);
         if (pulse_index < pulses_length)
         {
             self->items[item_index].duration1 = mp_obj_get_int(pulses_ptr[pulse_index]);
             self->items[item_index].level1 = start++;
-            //printf("duration=%d start=%d\n", items[item_index].duration1, items[item_index].level1);
         }
     }
     check_esp_err(rmt_write_items(self->channel_id, self->items, num_items, false /* non-blocking */));

--- a/ports/esp32/esp32_rmt.c
+++ b/ports/esp32/esp32_rmt.c
@@ -1,0 +1,169 @@
+/*
+ * This file is part of the MicroPython project, http://micropython.org/
+ *
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2018 "Matt Trentini" <matt.trentini@gmail.com>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#include "py/runtime.h"
+
+#include "driver/rmt.h"
+
+#include "py/runtime.h"
+#include "modmachine.h"
+#include "mphalport.h"
+
+// Forward declaration
+extern const mp_obj_type_t esp32_rmt_type;
+
+typedef struct _esp32_rmt_obj_t {
+    mp_obj_base_t base;
+    uint8_t channel_id;
+    gpio_num_t pin;
+    uint8_t clock_divider;
+} esp32_rmt_obj_t;
+
+STATIC mp_obj_t esp32_rmt_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *args) {
+    // fixme: check arguments
+    // 1 <= channel_id <= 8
+    // 1 <= clock_divider <= 255
+    mp_arg_check_num(n_args, n_kw, 3, MP_OBJ_FUN_ARGS_MAX, true);
+    mp_uint_t channel_id = mp_obj_get_int(args[0]);
+    gpio_num_t pin_id = machine_pin_get_id(args[1]);
+    mp_uint_t clock_divider = mp_obj_get_int(args[2]);
+    // fixme: should have an idle_level...
+
+    esp32_rmt_obj_t *self = m_new_obj(esp32_rmt_obj_t);
+    self->base.type = &esp32_rmt_type;
+    self->channel_id = channel_id;
+    self->pin = pin_id;
+    self->clock_divider = clock_divider;
+
+    rmt_config_t config;
+    config.rmt_mode = RMT_MODE_TX;
+    config.channel = self->channel_id; // Technically should use enum eg RMT_CHANNEL_0
+    config.gpio_num = self->pin;
+    config.mem_block_num = 1;
+    config.tx_config.loop_en = 0;
+
+    // Shouldn't be necessary to set these (until we use them...)
+    // config.tx_config.carrier_en = 0;
+    // config.tx_config.idle_output_en = 0;
+    // config.tx_config.idle_level = 0;
+    // config.tx_config.carrier_duty_percent = 0;
+    // config.tx_config.carrier_freq_hz = 0;
+    // config.tx_config.carrier_level = 1;
+
+    config.clk_div = self->clock_divider;
+
+    // fixme: Error handling should be nicer; raise an exception
+    ESP_ERROR_CHECK(rmt_config(&config));
+    ESP_ERROR_CHECK(rmt_driver_install(config.channel, 0, 0));
+
+    return MP_OBJ_FROM_PTR(self);
+}
+
+
+STATIC void esp32_rmt_print(const mp_print_t *print, mp_obj_t self_in, mp_print_kind_t kind) {
+    esp32_rmt_obj_t *self = MP_OBJ_TO_PTR(self_in);
+    mp_printf(print, "RMT(channel=%u, pin=%u, clock_divider=%u)", self->channel_id, self->pin, self->clock_divider);
+}
+
+
+// Return the resolution (shortest possible pulse), in seconds
+STATIC mp_obj_t esp32_rmt_resolution(mp_obj_t self_in) {
+    esp32_rmt_obj_t *self = MP_OBJ_TO_PTR(self_in);
+    return mp_obj_new_float(1.0/(APB_CLK_FREQ / self->clock_divider));
+}
+STATIC MP_DEFINE_CONST_FUN_OBJ_1(esp32_rmt_resolution_obj, esp32_rmt_resolution);
+
+
+// Return the longest pulse duration
+STATIC mp_obj_t esp32_rmt_max_duration(mp_obj_t self_in) {
+    esp32_rmt_obj_t *self = MP_OBJ_TO_PTR(self_in);
+    return mp_obj_new_float((1.0/(APB_CLK_FREQ / self->clock_divider)) * 32768);
+}
+STATIC MP_DEFINE_CONST_FUN_OBJ_1(esp32_rmt_max_duration_obj, esp32_rmt_max_duration);
+
+
+STATIC mp_obj_t esp32_rmt_send_pulses(mp_obj_t self_in, mp_obj_t pulses, mp_obj_t start_level) {
+    esp32_rmt_obj_t *self = MP_OBJ_TO_PTR(self_in);
+    mp_uint_t level = mp_obj_get_int(start_level);
+    // fixme: Check inputs
+    // start_level => [0,1]
+
+    mp_uint_t pulses_length = 0;
+    mp_obj_t* pulses_ptr = NULL;
+
+    // fixme: Handle if not a tuple
+    if(MP_OBJ_IS_TYPE(pulses, &mp_type_tuple) == true) {
+        mp_obj_tuple_get(pulses, &pulses_length, &pulses_ptr);
+    }
+
+    mp_uint_t num_items = (pulses_length / 2) + (pulses_length % 2);
+    rmt_item32_t* items = (rmt_item32_t*)m_malloc(num_items * sizeof(rmt_item32_t));
+
+    printf("num_items=%d pulses_length=%d\n\n", num_items, pulses_length);
+
+    for (mp_uint_t item_index = 0; item_index < num_items; item_index++)
+    {
+        mp_uint_t pulse_index = item_index * 2;
+        items[item_index].duration0 = mp_obj_get_int(pulses_ptr[pulse_index++]);
+        items[item_index].level0 = level++; // Note that level _could_ wrap.
+        printf("duration=%d level=%d\n", items[item_index].duration0, items[item_index].level0);
+        if (pulse_index < pulses_length)
+        {
+            items[item_index].duration1 = mp_obj_get_int(pulses_ptr[pulse_index]);
+            items[item_index].level1 = level++;
+            printf("duration=%d level=%d\n", items[item_index].duration1, items[item_index].level1);
+        }
+    }
+    ESP_ERROR_CHECK(rmt_write_items(self->channel_id, items, num_items, true));
+
+    m_free(items);
+
+    // if (result != ESP_OK) {
+    //     nlr_raise(mp_obj_new_exception_msg(&mp_type_OSError, "rmt_write_items failed!"));
+    // }
+
+    return MP_OBJ_NEW_SMALL_INT(num_items);
+}
+STATIC MP_DEFINE_CONST_FUN_OBJ_3(esp32_rmt_send_pulses_obj, esp32_rmt_send_pulses);
+
+
+STATIC const mp_rom_map_elem_t esp32_rmt_locals_dict_table[] = {
+    { MP_ROM_QSTR(MP_QSTR_send_pulses), MP_ROM_PTR(&esp32_rmt_send_pulses_obj) },
+    { MP_ROM_QSTR(MP_QSTR_resolution), MP_ROM_PTR(&esp32_rmt_resolution_obj) },
+    { MP_ROM_QSTR(MP_QSTR_max_duration), MP_ROM_PTR(&esp32_rmt_max_duration_obj) },
+};
+STATIC MP_DEFINE_CONST_DICT(esp32_rmt_locals_dict, esp32_rmt_locals_dict_table);
+
+const mp_obj_type_t esp32_rmt_type = {
+    { &mp_type_type },
+    .name = MP_QSTR_RMT,
+    .print = esp32_rmt_print,
+    .make_new = esp32_rmt_make_new,
+    .locals_dict = (mp_obj_dict_t *)&esp32_rmt_locals_dict,
+};
+
+// ch1 = RMT(1, Pin(18), 80, 0) # channel, pin, clock_divider, idle_level
+// ch1.send_items((1000, 500, 1000), start=0)

--- a/ports/esp32/esp32_rmt.c
+++ b/ports/esp32/esp32_rmt.c
@@ -215,9 +215,9 @@ STATIC mp_obj_t esp32_rmt_send_pulses(size_t n_args, const mp_obj_t *pos_args, m
     mp_uint_t pulses_length = 0;
     mp_obj_t* pulses_ptr = NULL;
 
-    if(MP_OBJ_IS_TYPE(pulses, &mp_type_tuple) == true) {
+    if(mp_obj_is_type(pulses, &mp_type_tuple) == true) {
         mp_obj_tuple_get(pulses, &pulses_length, &pulses_ptr);
-    } else if(MP_OBJ_IS_TYPE(pulses, &mp_type_list) == true) {
+    } else if(mp_obj_is_type(pulses, &mp_type_list) == true) {
         mp_obj_list_get(pulses, &pulses_length, &pulses_ptr);
     } else {
         mp_raise_TypeError("Pulses must be specified with a tuple or list");

--- a/ports/esp32/main.c
+++ b/ports/esp32/main.c
@@ -68,9 +68,6 @@ int vprintf_null(const char *format, va_list ap) {
     return 0;
 }
 
-// Forward-declare RMT deinit function (could be defined in a header).
-void esp32_rmt_deinit_all(void);
-
 void mp_task(void *pvParameter) {
     volatile uint32_t sp = (uint32_t)get_sp();
     #if MICROPY_PY_THREAD
@@ -150,7 +147,6 @@ soft_reset:
     mp_hal_stdout_tx_str("MPY: soft reboot\r\n");
 
     // deinitialise peripherals
-    esp32_rmt_deinit_all();
     machine_pins_deinit();
     usocket_events_deinit();
 

--- a/ports/esp32/main.c
+++ b/ports/esp32/main.c
@@ -57,6 +57,7 @@
 #include "modnetwork.h"
 #include "mpthreadport.h"
 
+
 // MicroPython runs as a task under FreeRTOS
 #define MP_TASK_PRIORITY        (ESP_TASK_PRIO_MIN + 1)
 #define MP_TASK_STACK_SIZE      (16 * 1024)
@@ -66,6 +67,9 @@ int vprintf_null(const char *format, va_list ap) {
     // do nothing: this is used as a log target during raw repl mode
     return 0;
 }
+
+// Forward-declare RMT deinit function (could be defined in a header).
+void esp32_rmt_deinit_all(void);
 
 void mp_task(void *pvParameter) {
     volatile uint32_t sp = (uint32_t)get_sp();
@@ -146,6 +150,7 @@ soft_reset:
     mp_hal_stdout_tx_str("MPY: soft reboot\r\n");
 
     // deinitialise peripherals
+    esp32_rmt_deinit_all();
     machine_pins_deinit();
     usocket_events_deinit();
 

--- a/ports/esp32/modesp32.c
+++ b/ports/esp32/modesp32.c
@@ -157,6 +157,8 @@ STATIC const mp_rom_map_elem_t esp32_module_globals_table[] = {
     { MP_ROM_QSTR(MP_QSTR_Partition), MP_ROM_PTR(&esp32_partition_type) },
     { MP_ROM_QSTR(MP_QSTR_ULP), MP_ROM_PTR(&esp32_ulp_type) },
 
+    { MP_ROM_QSTR(MP_QSTR_RMT), MP_ROM_PTR(&esp32_rmt_type) },
+
     { MP_ROM_QSTR(MP_QSTR_WAKEUP_ALL_LOW), MP_ROM_PTR(&mp_const_false_obj) },
     { MP_ROM_QSTR(MP_QSTR_WAKEUP_ANY_HIGH), MP_ROM_PTR(&mp_const_true_obj) },
 };

--- a/ports/esp32/modesp32.h
+++ b/ports/esp32/modesp32.h
@@ -28,5 +28,5 @@
 
 extern const mp_obj_type_t esp32_partition_type;
 extern const mp_obj_type_t esp32_ulp_type;
-
+extern const mp_obj_type_t esp32_rmt_type;
 #endif // MICROPY_INCLUDED_ESP32_MODESP32_H


### PR DESCRIPTION
This is the start of a MicroPython implementation for [RMT](https://docs.espressif.com/projects/esp-idf/en/latest/api-reference/peripherals/rmt.html) on the ESP32. 

RMT allows accurate (down to 12.5ns) sending and receiving of pulses. This implementation currently only provides transmit features and there are some limitations:

- ~~Blocking only~~ (`send_pulses` is now non-blocking)
  - ~~Non-blocking is _possible_ but increases complexity~~
  - ~~May need some help looking at how to implement the ISR and pass that back as an optional callback...~~
- ~~Looping is not exposed (it's possible to loop a pattern indefinitely)~~
  -~~_Requires_ non-blocking~~
- Carrier features - selecting a base frequency that can be modulated - is not yet provided
- Idle level is not configurable
- Only one memory block per channel

(Update: non-blocking and looping have been implemented)

I'd be curious which of these features is _most_ important to people.

The short-term intent is to allow this to be used to provide a solid NeoPixel implementation. On the ESP32 it's difficult to make toggle pins accurately enough since the operating system periodically interrupts. The RMT provides accurate timing independent of the OS. 

Note that [FastLED](https://github.com/FastLED/FastLED), a popular C library for controlling Neopixels, [successfully uses RMT](https://github.com/FastLED/FastLED) for the ESP32 implementation.

Basic usage:

```python
>>> import esp32
>>> from machine import Pin
>>> r = esp32.RMT(1, pin=Pin(18), clock_div=80)
>>> r
RMT(channel=1, pin=18, clock_div=80)
>>> r.send_pulses((100, 2000, 100, 4000), start=0)  # Send 0 for 100*1e-06s, 1 for 2000*1e-06s etc
```
The length of the buffer is restricted only by available memory.

Managing resources is not-quite-right yet (once an RMT channel has been allocated it isn't deintialised on soft boot) but I expect to address that soon.  

From [PyCom's RMT documentation](https://docs.pycom.io/tutorials/all/rmt/) (take care not to inspect their implementation since it's an incompatible license) they appear to offer _three_ different ways to configure a tx buffer. The second model is similar to the one implemented here. Which, if any, of the others would be of most use?

For reference there are a few related issues:
#5117 
#5157 
#3453

Although this RMT implementation  isn't complete yet I think it is in a _useful_ state and I thought it worthwhile to submit and gather feedback for the future direction.