### PR TITLE
extmod/modbluetooth: Allow config of scan interval/window.

### DIFF
--- a/extmod/modbluetooth.c
+++ b/extmod/modbluetooth.c
@@ -501,23 +501,26 @@ STATIC mp_obj_t bluetooth_ble_gap_connect(size_t n_args, const mp_obj_t *args) {
 STATIC MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(bluetooth_ble_gap_connect_obj, 3, 4, bluetooth_ble_gap_connect);
 
 STATIC mp_obj_t bluetooth_ble_gap_scan(size_t n_args, const mp_obj_t *args) {
-    if (n_args == 2 && args[1] == mp_const_none) {
-        int err = mp_bluetooth_gap_scan_stop();
-        return bluetooth_handle_errno(err);
-    } else {
-        mp_int_t duration_ms = 0;
-        if (n_args == 2) {
-            if (!mp_obj_is_int(args[1])) {
-                mp_raise_ValueError("invalid duration");
-            }
-            duration_ms = mp_obj_get_int(args[1]);
+    // Default is indefinite scan, with the NimBLE "background scan" interval and window.
+    mp_int_t duration_ms = 0;
+    mp_int_t interval_us = 1280000;
+    mp_int_t window_us = 11250;
+    if (n_args > 1) {
+        if (args[1] == mp_const_none) {
+            // scan(None) --> stop scan.
+            return bluetooth_handle_errno(mp_bluetooth_gap_scan_stop());
         }
-
-        int err = mp_bluetooth_gap_scan_start(duration_ms);
-        return bluetooth_handle_errno(err);
+        duration_ms = mp_obj_get_int(args[1]);
+        if (n_args > 2) {
+            interval_us = mp_obj_get_int(args[2]);
+            if (n_args > 3) {
+                window_us = mp_obj_get_int(args[3]);
+            }
+        }
     }
+    return bluetooth_handle_errno(mp_bluetooth_gap_scan_start(duration_ms, interval_us, window_us));
 }
-STATIC MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(bluetooth_ble_gap_scan_obj, 1, 2, bluetooth_ble_gap_scan);
+STATIC MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(bluetooth_ble_gap_scan_obj, 1, 4, bluetooth_ble_gap_scan);
 #endif // MICROPY_PY_BLUETOOTH_ENABLE_CENTRAL_MODE
 
 STATIC mp_obj_t bluetooth_ble_gap_disconnect(mp_obj_t self_in, mp_obj_t conn_handle_in) {

--- a/extmod/modbluetooth.c
+++ b/extmod/modbluetooth.c
@@ -301,9 +301,9 @@ STATIC MP_DEFINE_CONST_FUN_OBJ_KW(bluetooth_ble_irq_obj, 1, bluetooth_ble_irq);
 // ----------------------------------------------------------------------------
 
 STATIC mp_obj_t bluetooth_ble_gap_advertise(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
-    enum { ARG_interval_ms, ARG_adv_data, ARG_resp_data, ARG_connectable };
+    enum { ARG_interval_us, ARG_adv_data, ARG_resp_data, ARG_connectable };
     static const mp_arg_t allowed_args[] = {
-        { MP_QSTR_interval_ms, MP_ARG_OBJ, {.u_obj = MP_OBJ_NEW_SMALL_INT(100)} },
+        { MP_QSTR_interval_us, MP_ARG_OBJ, {.u_obj = MP_OBJ_NEW_SMALL_INT(100)} },
         { MP_QSTR_adv_data, MP_ARG_OBJ, {.u_obj = mp_const_none } },
         { MP_QSTR_resp_data, MP_ARG_OBJ | MP_ARG_KW_ONLY, {.u_obj = mp_const_none } },
         { MP_QSTR_connectable, MP_ARG_OBJ | MP_ARG_KW_ONLY, {.u_obj = mp_const_true } },
@@ -311,8 +311,8 @@ STATIC mp_obj_t bluetooth_ble_gap_advertise(size_t n_args, const mp_obj_t *pos_a
     mp_arg_val_t args[MP_ARRAY_SIZE(allowed_args)];
     mp_arg_parse_all(n_args - 1, pos_args + 1, kw_args, MP_ARRAY_SIZE(allowed_args), allowed_args, args);
 
-    mp_int_t interval_ms;
-    if (args[ARG_interval_ms].u_obj == mp_const_none || (interval_ms = mp_obj_get_int(args[ARG_interval_ms].u_obj)) == 0) {
+    mp_int_t interval_us;
+    if (args[ARG_interval_us].u_obj == mp_const_none || (interval_us = mp_obj_get_int(args[ARG_interval_us].u_obj)) == 0) {
         mp_bluetooth_gap_advertise_stop();
         return mp_const_none;
     }
@@ -329,7 +329,7 @@ STATIC mp_obj_t bluetooth_ble_gap_advertise(size_t n_args, const mp_obj_t *pos_a
         mp_get_buffer_raise(args[ARG_resp_data].u_obj, &resp_bufinfo, MP_BUFFER_READ);
     }
 
-    return bluetooth_handle_errno(mp_bluetooth_gap_advertise_start(connectable, interval_ms, adv_bufinfo.buf, adv_bufinfo.len, resp_bufinfo.buf, resp_bufinfo.len));
+    return bluetooth_handle_errno(mp_bluetooth_gap_advertise_start(connectable, interval_us, adv_bufinfo.buf, adv_bufinfo.len, resp_bufinfo.buf, resp_bufinfo.len));
 }
 STATIC MP_DEFINE_CONST_FUN_OBJ_KW(bluetooth_ble_gap_advertise_obj, 1, bluetooth_ble_gap_advertise);
 

--- a/extmod/modbluetooth.h
+++ b/extmod/modbluetooth.h
@@ -157,7 +157,7 @@ void mp_bluetooth_get_device_addr(uint8_t *addr);
 
 // Start advertisement. Will re-start advertisement when already enabled.
 // Returns errno on failure.
-int mp_bluetooth_gap_advertise_start(bool connectable, uint16_t interval_ms, const uint8_t *adv_data, size_t adv_data_len, const uint8_t *sr_data, size_t sr_data_len);
+int mp_bluetooth_gap_advertise_start(bool connectable, int32_t interval_us, const uint8_t *adv_data, size_t adv_data_len, const uint8_t *sr_data, size_t sr_data_len);
 
 // Stop advertisement. No-op when already stopped.
 void mp_bluetooth_gap_advertise_stop(void);

--- a/extmod/modbluetooth.h
+++ b/extmod/modbluetooth.h
@@ -186,7 +186,7 @@ int mp_bluetooth_gap_disconnect(uint16_t conn_handle);
 
 #if MICROPY_PY_BLUETOOTH_ENABLE_CENTRAL_MODE
 // Start a discovery (scan). Set duration to zero to run continuously.
-int mp_bluetooth_gap_scan_start(int32_t duration_ms);
+int mp_bluetooth_gap_scan_start(int32_t duration_ms, int32_t interval_us, int32_t window_us);
 
 // Stop discovery (if currently active).
 int mp_bluetooth_gap_scan_stop(void);

--- a/extmod/modbluetooth_nimble.c
+++ b/extmod/modbluetooth_nimble.c
@@ -341,7 +341,7 @@ void mp_bluetooth_get_device_addr(uint8_t *addr) {
     #endif
 }
 
-int mp_bluetooth_gap_advertise_start(bool connectable, uint16_t interval_ms, const uint8_t *adv_data, size_t adv_data_len, const uint8_t *sr_data, size_t sr_data_len) {
+int mp_bluetooth_gap_advertise_start(bool connectable, int32_t interval_us, const uint8_t *adv_data, size_t adv_data_len, const uint8_t *sr_data, size_t sr_data_len) {
     int ret;
 
     mp_bluetooth_gap_advertise_stop();
@@ -360,18 +360,12 @@ int mp_bluetooth_gap_advertise_start(bool connectable, uint16_t interval_ms, con
         }
     }
 
-    // Convert from 1ms to 0.625ms units.
-    interval_ms = interval_ms * 8 / 5;
-    if (interval_ms < 0x20 || interval_ms > 0x4000) {
-        return MP_EINVAL;
-    }
-
     struct ble_gap_adv_params adv_params = {
         .conn_mode = connectable ? BLE_GAP_CONN_MODE_UND : BLE_GAP_CONN_MODE_NON,
         .disc_mode = BLE_GAP_DISC_MODE_GEN,
-        .itvl_min = interval_ms,
-        .itvl_max = interval_ms,
-        .channel_map = 7, // all 3 channels
+        .itvl_min = interval_us / BLE_HCI_ADV_ITVL, // convert to 625us units.
+        .itvl_max = interval_us / BLE_HCI_ADV_ITVL,
+        .channel_map = 7, // all 3 channels.
     };
 
     ret = ble_gap_adv_start(BLE_OWN_ADDR_PUBLIC, NULL, BLE_HS_FOREVER, &adv_params, gap_event_cb, NULL);

--- a/extmod/modbluetooth_nimble.c
+++ b/extmod/modbluetooth_nimble.c
@@ -614,16 +614,16 @@ STATIC int gap_scan_cb(struct ble_gap_event *event, void *arg) {
     return 0;
 }
 
-int mp_bluetooth_gap_scan_start(int32_t duration_ms) {
+int mp_bluetooth_gap_scan_start(int32_t duration_ms, int32_t interval_us, int32_t window_us) {
     if (duration_ms == 0) {
         duration_ms = BLE_HS_FOREVER;
     }
-    STATIC const struct ble_gap_disc_params discover_params = {
-        .itvl = BLE_GAP_SCAN_SLOW_INTERVAL1,
-        .window = BLE_GAP_SCAN_SLOW_WINDOW1,
+    struct ble_gap_disc_params discover_params = {
+        .itvl = MAX(BLE_HCI_SCAN_ITVL_MIN, MIN(BLE_HCI_SCAN_ITVL_MAX, interval_us / BLE_HCI_SCAN_ITVL)),
+        .window = MAX(BLE_HCI_SCAN_WINDOW_MIN, MIN(BLE_HCI_SCAN_WINDOW_MAX, window_us / BLE_HCI_SCAN_ITVL)),
         .filter_policy = BLE_HCI_CONN_FILT_NO_WL,
         .limited = 0,
-        .passive = 0,
+        .passive = 1,  // TODO: Handle BLE_HCI_ADV_RPT_EVTYPE_SCAN_RSP in gap_scan_cb above.
         .filter_duplicates = 0,
     };
     int err = ble_gap_disc(BLE_OWN_ADDR_PUBLIC, duration_ms, &discover_params, gap_scan_cb, NULL);


### PR DESCRIPTION
This adds two additional optional kwargs to `gap_scan()`:
  - `interval_ms`: How long between scans.
  - `window_ms`: How long to scan for during a scan.

The default with NimBLE is a 11.25ms window with a 1.28s interval.

Changing these parameters is important for detecting low-frequency
advertisements (e.g. beacons).