### PR TITLE
stm32: Use hardware sqrt F7/H7.

### DIFF
--- a/lib/libm_dbl/thumb_vfp_sqrt.c
+++ b/lib/libm_dbl/thumb_vfp_sqrt.c
@@ -1,0 +1,10 @@
+// an implementation of sqrt for Thumb using hardware double-precision VFP instructions
+
+double sqrt(double x) {
+    double ret;
+    asm volatile (
+            "vsqrt.f64  %P0, %P1\n"
+            : "=w" (ret)
+            : "w"  (x));
+    return ret;
+}

--- a/ports/stm32/Makefile
+++ b/ports/stm32/Makefile
@@ -173,12 +173,16 @@ SRC_LIBM = $(addprefix lib/libm_dbl/,\
 	scalbn.c \
 	sin.c \
 	sinh.c \
-	sqrt.c \
 	tan.c \
 	tanh.c \
 	tgamma.c \
 	trunc.c \
 	)
+ifeq ($(MCU_SERIES),$(filter $(MCU_SERIES),f7 h7))
+SRC_LIBM += lib/libm_dbl/thumb_vfp_sqrt.c
+else
+SRC_LIBM += lib/libm_dbl/sqrt.c
+endif
 else
 SRC_LIBM = $(addprefix lib/libm/,\
 	math.c \


### PR DESCRIPTION
Identical to cd527bb324ade952d11a134859d38bf5272c165e but for double.
This gives a -2.754% improvement on bm_float.py.
-35% improvement on calling sqrt in a loop.