### PR TITLE
Add new make target "submodules" which inits required modules.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,8 +32,8 @@ jobs:
         - sudo apt-get install libnewlib-arm-none-eabi
         - arm-none-eabi-gcc --version
       script:
-        - git submodule update --init lib/lwip lib/mbedtls lib/stm32lib lib/mynewt-nimble
         - make ${MAKEOPTS} -C mpy-cross
+        - make ${MAKEOPTS} -C ports/stm32 submodules
         - make ${MAKEOPTS} -C ports/stm32 BOARD=NUCLEO_F091RC
         - make ${MAKEOPTS} -C ports/stm32 BOARD=PYBV11 MICROPY_PY_WIZNET5K=5200 MICROPY_PY_CC3K=1
         - make ${MAKEOPTS} -C ports/stm32 BOARD=PYBD_SF2
@@ -66,8 +66,8 @@ jobs:
         - gcc --version
         - python3 --version
       script:
-        - git submodule update --init lib/axtls lib/berkeley-db-1.xx lib/libffi
         - make ${MAKEOPTS} -C mpy-cross
+        - make ${MAKEOPTS} -C ports/unix submodules
         - make ${MAKEOPTS} -C ports/unix deplibs
         - make ${MAKEOPTS} -C ports/unix coverage
         # run the main test suite
@@ -87,8 +87,8 @@ jobs:
     - stage: test
       env: NAME="unix port build and tests"
       script:
-        - git submodule update --init lib/axtls lib/berkeley-db-1.xx lib/libffi
         - make ${MAKEOPTS} -C mpy-cross
+        - make ${MAKEOPTS} -C ports/unix submodules
         - make ${MAKEOPTS} -C ports/unix deplibs
         - make ${MAKEOPTS} -C ports/unix
         - make ${MAKEOPTS} -C ports/unix test
@@ -100,8 +100,8 @@ jobs:
       install:
         - sudo apt-get install gcc-multilib libffi-dev:i386
       script:
-        - git submodule update --init lib/axtls lib/berkeley-db-1.xx lib/libffi
         - make ${MAKEOPTS} -C mpy-cross PYTHON=python2
+        - make ${MAKEOPTS} -C ports/unix submodules
         - make ${MAKEOPTS} -C ports/unix PYTHON=python2 deplibs
         - make ${MAKEOPTS} -C ports/unix PYTHON=python2 nanbox
         - (cd tests && MICROPY_CPYTHON3=python3 MICROPY_MICROPYTHON=../ports/unix/micropython_nanbox ./run-tests)
@@ -112,8 +112,8 @@ jobs:
       install:
         - sudo apt-get install clang
       script:
-        - git submodule update --init lib/axtls lib/berkeley-db-1.xx lib/libffi
         - make ${MAKEOPTS} -C mpy-cross CC=clang
+        - make ${MAKEOPTS} -C ports/unix submodules
         - make ${MAKEOPTS} -C ports/unix CC=clang CFLAGS_EXTRA="-DMICROPY_STACKLESS=1 -DMICROPY_STACKLESS_STRICT=1"
         - make ${MAKEOPTS} -C ports/unix CC=clang test
 
@@ -149,11 +149,11 @@ jobs:
         - git clone https://github.com/espressif/esp-idf.git
         - export IDF_PATH=$(pwd)/esp-idf
       script:
-        - git submodule update --init lib/berkeley-db-1.xx
         - make ${MAKEOPTS} -C mpy-cross
         # IDF v3 build
         - git -C esp-idf checkout $(grep "ESPIDF_SUPHASH_V3 :=" ports/esp32/Makefile | cut -d " " -f 3)
         - git -C esp-idf submodule update --init components/json/cJSON components/esp32/lib components/esptool_py/esptool components/expat/expat components/lwip/lwip components/mbedtls/mbedtls components/micro-ecc/micro-ecc components/nghttp/nghttp2
+        - make ${MAKEOPTS} -C ports/esp32 submodules
         - make ${MAKEOPTS} -C ports/esp32
         # clean
         - git -C esp-idf clean -f -f -d components/json/cJSON components/esp32/lib components/expat/expat components/micro-ecc/micro-ecc components/nghttp/nghttp2
@@ -161,6 +161,7 @@ jobs:
         # IDF v4 build
         - git -C esp-idf checkout $(grep "ESPIDF_SUPHASH_V4 :=" ports/esp32/Makefile | cut -d " " -f 3)
         - git -C esp-idf submodule update --init components/bt/controller/lib components/bt/host/nimble/nimble components/esp_wifi/lib_esp32 components/esptool_py/esptool components/lwip/lwip components/mbedtls/mbedtls
+        - make ${MAKEOPTS} -C ports/esp32 submodules
         - make ${MAKEOPTS} -C ports/esp32
 
     # esp8266 port
@@ -171,8 +172,8 @@ jobs:
         - zcat xtensa-lx106-elf-standalone.tar.gz | tar x
         - export PATH=$(pwd)/xtensa-lx106-elf/bin:$PATH
       script:
-        - git submodule update --init lib/axtls lib/berkeley-db-1.xx
         - make ${MAKEOPTS} -C mpy-cross
+        - make ${MAKEOPTS} -C ports/esp8266 submodules
         - make ${MAKEOPTS} -C ports/esp8266
         - make ${MAKEOPTS} -C ports/esp8266 BOARD=GENERIC_512K
 
@@ -184,7 +185,7 @@ jobs:
         - sudo apt-get install libnewlib-arm-none-eabi
         - arm-none-eabi-gcc --version
       script:
-        - git submodule update --init lib/nrfx
+        - make ${MAKEOPTS} -C ports/nrf submodules
         - make ${MAKEOPTS} -C ports/nrf
 
     # bare-arm and minimal ports
@@ -220,7 +221,7 @@ jobs:
         - sudo apt-get install gcc-arm-none-eabi
         - sudo apt-get install libnewlib-arm-none-eabi
       script:
-        - git submodule update --init lib/asf4 lib/tinyusb
+        - make ${MAKEOPTS} -C ports/samd submodules
         - make ${MAKEOPTS} -C ports/samd
 
     # teensy port

--- a/README.md
+++ b/README.md
@@ -86,8 +86,8 @@ Alternatively, fallback implementation based on setjmp/longjmp can be used.
 
 To build (see section below for required dependencies):
 
-    $ git submodule update --init
     $ cd ports/unix
+    $ make submodules
     $ make
 
 Then to give it a try:
@@ -127,13 +127,14 @@ Debian/Ubuntu/Mint derivative Linux distros, install `build-essential`
 Other dependencies can be built together with MicroPython. This may
 be required to enable extra features or capabilities, and in recent
 versions of MicroPython, these may be enabled by default. To build
-these additional dependencies, first fetch git submodules for them:
+these additional dependencies, in the port directory you're
+interested in (e.g. `ports/unix/`) first execute:
 
-    $ git submodule update --init
+    $ make submodules
 
-Use the same command to get the latest versions of dependencies, as
-they are updated from time to time. After that, in the port directory
-(e.g. `ports/unix/`), execute:
+This will fetch all the relevant git submodules (sub repositories) that
+the port needs.  Use the same command to get the latest versions of
+submodules as they are updated from time to time. After that execute:
 
     $ make deplibs
 
@@ -146,8 +147,8 @@ For example, to build SSL module (required for `upip` tool described above,
 and so enabled by dfeault), `MICROPY_PY_USSL` should be set to 1.
 
 For some ports, building required dependences is transparent, and happens
-automatically. They still need to be fetched with the git submodule command
-above.
+automatically.  But they still need to be fetched with the `make submodules`
+command.
 
 The STM32 version
 -----------------
@@ -159,8 +160,8 @@ https://launchpad.net/gcc-arm-embedded
 
 To build:
 
-    $ git submodule update --init
     $ cd ports/stm32
+    $ make submodules
     $ make
 
 You then need to get your board into DFU mode.  On the pyboard, connect the

--- a/ports/esp32/Makefile
+++ b/ports/esp32/Makefile
@@ -38,6 +38,8 @@ FROZEN_MPY_DIR = modules
 # include py core make definitions
 include $(TOP)/py/py.mk
 
+GIT_SUBMODULES = lib/berkeley-db-1.xx
+
 PORT ?= /dev/ttyUSB0
 BAUD ?= 460800
 FLASH_MODE ?= dio

--- a/ports/esp32/README.md
+++ b/ports/esp32/README.md
@@ -122,17 +122,10 @@ this repository):
 $ make -C mpy-cross
 ```
 
-The ESP32 port has a dependency on Berkeley DB, which is an external
-dependency (git submodule). You'll need to have git initialize that
-module using the commands:
-```bash
-$ git submodule init lib/berkeley-db-1.xx
-$ git submodule update
-```
-
 Then to build MicroPython for the ESP32 run:
 ```bash
 $ cd ports/esp32
+$ make submodules
 $ make
 ```
 This will produce binary firmware images in the `build/` subdirectory

--- a/ports/esp8266/Makefile
+++ b/ports/esp8266/Makefile
@@ -32,6 +32,8 @@ FROZEN_MPY_DIR ?= modules
 # include py core make definitions
 include $(TOP)/py/py.mk
 
+GIT_SUBMODULES = lib/axtls lib/berkeley-db-1.xx
+
 FWBIN = $(BUILD)/firmware-combined.bin
 PORT ?= /dev/ttyACM0
 BAUD ?= 115200

--- a/ports/nrf/Makefile
+++ b/ports/nrf/Makefile
@@ -41,6 +41,8 @@ QSTR_DEFS = qstrdefsport.h $(BUILD)/pins_qstr.h
 # include py core make definitions
 include ../../py/py.mk
 
+GIT_SUBMODULES = lib/nrfx lib/tinyusb
+
 MICROPY_FATFS ?= 0
 FATFS_DIR = lib/oofatfs
 MPY_CROSS = ../../mpy-cross/mpy-cross

--- a/ports/nrf/README.md
+++ b/ports/nrf/README.md
@@ -50,11 +50,11 @@ Prerequisite steps for building the nrf port:
 
     git clone <URL>.git micropython
     cd micropython
-    git submodule update --init
     make -C mpy-cross
 
 By default, the PCA10040 (nrf52832) is used as compile target. To build and flash issue the following command inside the ports/nrf/ folder:
 
+    make submodules
     make
     make flash
 

--- a/ports/samd/Makefile
+++ b/ports/samd/Makefile
@@ -19,6 +19,8 @@ QSTR_GLOBAL_DEPENDENCIES = $(BOARD_DIR)/mpconfigboard.h
 # Include py core make definitions
 include $(TOP)/py/py.mk
 
+GIT_SUBMODULES = lib/asf4 lib/tinyusb
+
 INC += -I.
 INC += -I$(TOP)
 INC += -I$(BUILD)

--- a/ports/stm32/Makefile
+++ b/ports/stm32/Makefile
@@ -24,6 +24,8 @@ FROZEN_MPY_DIR ?= modules
 # include py core make definitions
 include $(TOP)/py/py.mk
 
+GIT_SUBMODULES = lib/lwip lib/mbedtls lib/mynewt-nimble lib/stm32lib
+
 MCU_SERIES_UPPER = $(shell echo $(MCU_SERIES) | tr '[:lower:]' '[:upper:]')
 CMSIS_MCU_LOWER = $(shell echo $(CMSIS_MCU) | tr '[:upper:]' '[:lower:]')
 

--- a/ports/stm32/README.md
+++ b/ports/stm32/README.md
@@ -40,7 +40,11 @@ see [here](https://launchpad.net/gcc-arm-embedded) for the main GCC ARM
 Embedded page.  The compiler can be changed using the `CROSS_COMPILE` variable
 when invoking `make`.
 
-To build for a given board, run:
+First the submodules must be obtained using:
+
+    $ make submodules
+
+Then to build for a given board, run:
 
     $ make BOARD=PYBV11
 

--- a/ports/unix/Makefile
+++ b/ports/unix/Makefile
@@ -16,6 +16,8 @@ UNAME_S := $(shell uname -s)
 # include py core make definitions
 include $(TOP)/py/py.mk
 
+GIT_SUBMODULES = lib/axtls lib/berkeley-db-1.xx lib/libffi
+
 INC +=  -I.
 INC +=  -I$(TOP)
 INC += -I$(BUILD)

--- a/py/mkrules.mk
+++ b/py/mkrules.mk
@@ -143,6 +143,13 @@ clean-prog:
 .PHONY: clean-prog
 endif
 
+submodules:
+	$(ECHO) "Updating submodules: $(GIT_SUBMODULES)"
+ifneq ($(GIT_SUBMODULES),)
+	$(Q)git submodule update --init $(addprefix $(TOP)/,$(GIT_SUBMODULES))
+endif
+.PHONY: submodules
+
 LIBMICROPYTHON = libmicropython.a
 
 # We can execute extra commands after library creation using


### PR DESCRIPTION
Because there are now a lot of submodules in this project, and only a subset are needed for any given port, introduce a new make target called `submodules` which initialises only the required modules.