### PR TITLE
extmod/re1.5: Fix escaping in RE classes.

### DIFF
--- a/extmod/re1.5/compilecode.c
+++ b/extmod/re1.5/compilecode.c
@@ -53,6 +53,9 @@ static const char *_compilecode(const char *re, ByteProg *prog, int sizecode)
             PC++; // Skip # of pair byte
             prog->len++;
             for (cnt = 0; *re != ']'; re++, cnt++) {
+                if (*re == '\\') {
+                    ++re;
+                }
                 if (!*re) return NULL;
                 EMIT(PC++, *re);
                 if (re[1] == '-' && re[2] != ']') {

--- a/tests/extmod/ure1.py
+++ b/tests/extmod/ure1.py
@@ -88,3 +88,26 @@ except:
 
 # bytes objects
 m = re.match(rb'a+?', b'ab');  print(m.group(0))
+
+# escaping
+m = re.match(r'a\.c', 'a.c'); print(m.group(0) if m else '')
+m = re.match(r'a\.b', 'abc'); print(m is None)
+m = re.match(r'a\.b', 'a\\bc'); print(m is None)
+m = re.match(r'[a\-z]', 'abc'); print(m.group(0))
+m = re.match(r'[.\]]*', '.].]a'); print(m.group(0))
+m = re.match(r'[.\]+]*', '.]+.]a'); print(m.group(0))
+m = re.match(r'[a-f0-9x\-yz]*', 'abxcd1-23'); print(m.group(0))
+m = re.match(r'[a\\b]*', 'a\\aa\\bb\\bbab'); print(m.group(0))
+m = re.search(r'[a\-z]', '-'); print(m.group(0))
+m = re.search(r'[a\-z]', 'f'); print(m is None)
+m = re.search(r'[a\]z]', 'a'); print(m.group(0))
+print(re.compile(r'[-a]').split('foo-bar'))
+print(re.compile(r'[a-]').split('foo-bar'))
+print(re.compile(r'[ax\-]').split('foo-bar'))
+print(re.compile(r'[a\-x]').split('foo-bar'))
+print(re.compile(r'[\-ax]').split('foo-bar'))
+
+try:
+    re.compile(r'[a\]')
+except:
+    print("Caught invalid regex")


### PR DESCRIPTION
Fixes #3178 and #5220

Adds tests, including all the cases mentioned in both bugs.