### PR TITLE
freezing/manifest: Ease the transition to manifests.

### DIFF
--- a/ports/esp8266/Makefile
+++ b/ports/esp8266/Makefile
@@ -189,6 +189,15 @@ $(BUILD)/uart.o: $(CONFVARS_FILE)
 
 FROZEN_EXTRA_DEPS = $(CONFVARS_FILE)
 
+ifneq ($(FROZEN_MANIFEST)$(FROZEN_MPY_DIR),)
+CFLAGS += -DMICROPY_MODULE_FROZEN_MPY
+CFLAGS += -DMICROPY_QSTR_EXTRA_POOL=mp_qstr_frozen_const_pool
+endif
+
+ifneq ($(FROZEN_MANIFEST)$(FROZEN_DIR),)
+CFLAGS += -DMICROPY_MODULE_FROZEN_STR
+endif
+
 .PHONY: deploy
 
 deploy: $(BUILD)/firmware-combined.bin

--- a/ports/esp8266/mpconfigport.h
+++ b/ports/esp8266/mpconfigport.h
@@ -94,10 +94,7 @@
 #define MICROPY_PY_STR_BYTES_CMP_WARN (1)
 #define MICROPY_STREAMS_NON_BLOCK   (1)
 #define MICROPY_STREAMS_POSIX_API   (1)
-#define MICROPY_MODULE_FROZEN_STR   (1)
-#define MICROPY_MODULE_FROZEN_MPY   (1)
 #define MICROPY_MODULE_FROZEN_LEXER mp_lexer_new_from_str32
-#define MICROPY_QSTR_EXTRA_POOL     mp_qstr_frozen_const_pool
 
 #define MICROPY_FATFS_ENABLE_LFN       (1)
 #define MICROPY_FATFS_RPATH            (2)

--- a/ports/unix/Makefile
+++ b/ports/unix/Makefile
@@ -188,6 +188,9 @@ CFLAGS += -DMPZ_DIG_SIZE=16 # force 16 bits to work on both 32 and 64 bit archs
 MPY_CROSS_FLAGS += -mcache-lookup-bc
 endif
 
+ifneq ($(FROZEN_MANIFEST)$(FROZEN_DIR),)
+CFLAGS += -DMICROPY_MODULE_FROZEN_STR
+endif
 
 include $(TOP)/py/mkrules.mk
 

--- a/ports/unix/mpconfigport.h
+++ b/ports/unix/mpconfigport.h
@@ -113,7 +113,6 @@
 #define MICROPY_PY_IO_IOBASE        (1)
 #define MICROPY_PY_IO_FILEIO        (1)
 #define MICROPY_PY_GC_COLLECT_RETVAL (1)
-#define MICROPY_MODULE_FROZEN_STR   (1)
 
 #ifndef MICROPY_STACKLESS
 #define MICROPY_STACKLESS           (0)

--- a/ports/unix/mpconfigport_fast.h
+++ b/ports/unix/mpconfigport_fast.h
@@ -33,8 +33,3 @@
 // 91 is a magic number proposed by @dpgeorge, which make pystone run ~ at tie
 // with CPython 3.4.
 #define MICROPY_MODULE_DICT_SIZE (91)
-
-// Don't include builtin upip, as this build is again intended just for
-// synthetic benchmarking
-#undef MICROPY_MODULE_FROZEN_STR
-#define MICROPY_MODULE_FROZEN_STR (0)

--- a/py/mkrules.mk
+++ b/py/mkrules.mk
@@ -101,15 +101,25 @@ ifneq ($(FROZEN_MANIFEST),)
 # to build frozen_content.c from a manifest
 $(BUILD)/frozen_content.c: FORCE $(BUILD)/genhdr/qstrdefs.generated.h
 	$(Q)$(MAKE_MANIFEST) -o $@ $(TOP) $(BUILD) "$(MPY_CROSS_FLAGS)" $(FROZEN_MANIFEST)
+
+ifneq ($(FROZEN_DIR),)
+$(error FROZEN_DIR cannot be used in conjunction with FROZEN_MANIFEST)
+endif
+
+ifneq ($(FROZEN_MPY_DIR),)
+$(error FROZEN_MPY_DIR cannot be used in conjunction with FROZEN_MANIFEST)
+endif
 endif
 
 ifneq ($(FROZEN_DIR),)
+$(info Warning: FROZEN_DIR is deprecated in favour of FROZEN_MANIFEST)
 $(BUILD)/frozen.c: $(wildcard $(FROZEN_DIR)/*) $(HEADER_BUILD) $(FROZEN_EXTRA_DEPS)
 	$(ECHO) "GEN $@"
 	$(Q)$(MAKE_FROZEN) $(FROZEN_DIR) > $@
 endif
 
 ifneq ($(FROZEN_MPY_DIR),)
+$(info Warning: FROZEN_MPY_DIR is deprecated in favour of FROZEN_MANIFEST)
 # make a list of all the .py files that need compiling and freezing
 FROZEN_MPY_PY_FILES := $(shell find -L $(FROZEN_MPY_DIR) -type f -name '*.py' | $(SED) -e 's=^$(FROZEN_MPY_DIR)/==')
 FROZEN_MPY_MPY_FILES := $(addprefix $(BUILD)/frozen_mpy/,$(FROZEN_MPY_PY_FILES:.py=.mpy))


### PR DESCRIPTION
- Adds error if the old way (FROZEN_MPY_DIR / FROZEN_DIR) is used at the same time as FROZEN_MANIFEST. (They are mutually exclusive).
- Adds warnings that the old way is deprecated.
- Allow building without manifests on unix and esp8266.