### PR TITLE
extmod/modbluetooth: Persist reference to NimBLE service instances.

### DIFF
--- a/examples/bluetooth/ble_uart_peripheral.py
+++ b/examples/bluetooth/ble_uart_peripheral.py
@@ -75,5 +75,29 @@ class BLEUART:
         self._ble.gap_advertise(interval_us, adv_data=self._payload)
 
 
-# ble = bluetooth.BLE()
-# uart = BLEUART(ble)
+def demo():
+    import time
+
+    ble = bluetooth.BLE()
+    uart = BLEUART(ble)
+
+    def on_rx():
+        print('rx: ', uart.read().decode().strip())
+
+    uart.irq(handler=on_rx)
+    nums = [4, 8, 15, 16, 23, 42]
+    i = 0
+
+    try:
+        while True:
+            uart.write(str(nums[i]) + '\n')
+            i = (i + 1) % len(nums)
+            time.sleep_ms(1000)
+    except KeyboardInterrupt:
+        pass
+
+    uart.close()
+
+
+if __name__ == '__main__':
+    demo()

--- a/extmod/modbluetooth.c
+++ b/extmod/modbluetooth.c
@@ -421,9 +421,9 @@ STATIC mp_obj_t bluetooth_ble_gatts_register_services(mp_obj_t self_in, mp_obj_t
     uint16_t **handles = m_new0(uint16_t*, len);
     size_t *num_handles = m_new0(size_t, len);
 
-    // We always reset the service list, as Nimble has no other option.
-    // TODO: Add a `reset` or `clear` kwarg (defaulting to True) to make this behavior optional.
-    int err = mp_bluetooth_gatts_register_service_begin(true);
+    // TODO: Add a `append` kwarg (defaulting to False) to make this behavior optional.
+    bool append = false;
+    int err = mp_bluetooth_gatts_register_service_begin(append);
     if (err != 0) {
         return bluetooth_handle_errno(err);
     }

--- a/extmod/modbluetooth.h
+++ b/extmod/modbluetooth.h
@@ -165,7 +165,7 @@ int mp_bluetooth_gap_advertise_start(bool connectable, int32_t interval_us, cons
 void mp_bluetooth_gap_advertise_stop(void);
 
 // Start adding services. Must be called before mp_bluetooth_register_service.
-int mp_bluetooth_gatts_register_service_begin(bool reset);
+int mp_bluetooth_gatts_register_service_begin(bool append);
 // // Add a service with the given list of characteristics to the queue to be registered.
 // The value_handles won't be valid until after mp_bluetooth_register_service_end is called.
 int mp_bluetooth_gatts_register_service(mp_obj_bluetooth_uuid_t *service_uuid, mp_obj_bluetooth_uuid_t **characteristic_uuids, uint8_t *characteristic_flags, mp_obj_bluetooth_uuid_t **descriptor_uuids, uint8_t *descriptor_flags, uint8_t *num_descriptors, uint16_t *handles, size_t num_characteristics);

--- a/extmod/modbluetooth_nimble.c
+++ b/extmod/modbluetooth_nimble.c
@@ -440,7 +440,7 @@ static int characteristic_access_cb(uint16_t conn_handle, uint16_t value_handle,
     return BLE_ATT_ERR_UNLIKELY;
 }
 
-int mp_bluetooth_gatts_register_service_begin(bool reset) {
+int mp_bluetooth_gatts_register_service_begin(bool append) {
     int ret = ble_gatts_reset();
     if (ret != 0) {
         return ble_hs_err_to_errno(ret);
@@ -452,7 +452,13 @@ int mp_bluetooth_gatts_register_service_begin(bool reset) {
     // By default, just register the default gap service.
     ble_svc_gap_init();
 
-    MP_STATE_PORT(bluetooth_nimble_root_pointers)->n_services = 0;
+    if (!append) {
+        // Unref any previous service definitions.
+        for (int i = 0; i < MP_STATE_PORT(bluetooth_nimble_root_pointers)->n_services; ++i) {
+            MP_STATE_PORT(bluetooth_nimble_root_pointers)->services[i] = NULL;
+        }
+        MP_STATE_PORT(bluetooth_nimble_root_pointers)->n_services = 0;
+    }
 
     return 0;
 }
@@ -462,11 +468,6 @@ int mp_bluetooth_gatts_register_service_end() {
     if (ret != 0) {
         return ble_hs_err_to_errno(ret);
     }
-
-    for (int i = 0; i < MP_STATE_PORT(bluetooth_nimble_root_pointers)->n_services; ++i) {
-        MP_STATE_PORT(bluetooth_nimble_root_pointers)->services[i] = NULL;
-    }
-    MP_STATE_PORT(bluetooth_nimble_root_pointers)->n_services = 0;
 
     return 0;
 }

--- a/extmod/modbluetooth_nimble.c
+++ b/extmod/modbluetooth_nimble.c
@@ -430,7 +430,7 @@ static int characteristic_access_cb(uint16_t conn_handle, uint16_t value_handle,
                 return BLE_ATT_ERR_ATTR_NOT_FOUND;
             }
             entry = MP_OBJ_TO_PTR(elem->value);
-            entry->data_len = MIN(MP_BLUETOOTH_MAX_ATTR_SIZE, OS_MBUF_PKTLEN(ctxt->om));
+            entry->data_len = MIN(entry->data_alloc, OS_MBUF_PKTLEN(ctxt->om));
             os_mbuf_copydata(ctxt->om, 0, entry->data_len, entry->data);
 
             mp_bluetooth_gatts_on_write(conn_handle, value_handle);


### PR DESCRIPTION
NimBLE doesn't actually copy this data, it requires it to stay live.
Only dereference when we register a new set of services.

Fixes #5226

This will allow incrementally adding services in the future, so
rename `reset` to `append` to make it clearer.

Also fix a truncation with chars/descs that have been increased
from the default size.