### PR TITLE
stm32f7/sdram: Use updated syntax for mpu_config_start/mpu_config_end.

### DIFF
--- a/ports/stm32/sdram.c
+++ b/ports/stm32/sdram.c
@@ -248,10 +248,10 @@ static void sdram_init_seq(SDRAM_HandleTypeDef
        Initially disable all access for the entire SDRAM memory space,
        then enable access/caching for the size used
     */
-    mpu_config_start();
+    uint32_t irq_state = mpu_config_start();
     mpu_config_region(MPU_REGION_SDRAM1, SDRAM_START_ADDRESS, MPU_CONFIG_DISABLE(0x00, MPU_REGION_SIZE_512MB));
     mpu_config_region(MPU_REGION_SDRAM2, SDRAM_START_ADDRESS, MPU_CONFIG_SDRAM(SDRAM_MPU_REGION_SIZE));
-    mpu_config_end();
+    mpu_config_end(irq_state);
     #endif
 }
 


### PR DESCRIPTION
Fixes a missed usage of https://github.com/micropython/micropython/commit/4f2c737b0c05cd138f15703d492ad64d39c3fcfd