### PR TITLE
extmod/modbluetooth: Rename to "ubluetooth"

### DIFF
--- a/docs/library/index.rst
+++ b/docs/library/index.rst
@@ -74,13 +74,13 @@ it will fallback to loading the built-in ``ujson`` module.
    :maxdepth: 1
 
    builtins.rst
-   bluetooth.rst
    cmath.rst
    gc.rst
    math.rst
    sys.rst
    uarray.rst
    ubinascii.rst
+   ubluetooth.rst
    ucollections.rst
    uerrno.rst
    uhashlib.rst

--- a/docs/library/ubluetooth.rst
+++ b/docs/library/ubluetooth.rst
@@ -1,7 +1,7 @@
-:mod:`bluetooth` --- low-level Bluetooth
+:mod:`ubluetooth` --- low-level Bluetooth
 ========================================
 
-.. module:: bluetooth
+.. module:: ubluetooth
    :synopsis: Low-level Bluetooth radio functionality
 
 This module provides an interface to a Bluetooth controller on a board.
@@ -123,7 +123,7 @@ The event codes are::
     _IRQ_GATTC_INDICATE                  = const(1 << 14)
 
 In order to save space in the firmware, these constants are not included on the
-:mod:`bluetooth` module. Add the ones that you need from the list above to your
+:mod:`ubluetooth` module. Add the ones that you need from the list above to your
 program.
 
 
@@ -203,8 +203,8 @@ writes from a central to a given characteristic, use
     value.
 
     The **flags** are a bitwise-OR combination of the
-    :data:`bluetooth.FLAGS_READ`, :data:`bluetooth.FLAGS_WRITE` and
-    :data:`bluetooth.FLAGS_NOTIFY` values defined below.
+    :data:`ubluetooth.FLAGS_READ`, :data:`bluetooth.FLAGS_WRITE` and
+    :data:`ubluetooth.FLAGS_NOTIFY` values defined below.
 
     The return value is a list (one element per service) of tuples (each element
     is a value handle). Characteristics and descriptor handles are flattened
@@ -321,6 +321,6 @@ Constructor
 Constants
 ---------
 
-.. data:: bluetooth.FLAG_READ
-          bluetooth.FLAG_WRITE
-          bluetooth.FLAG_NOTIFY
+.. data:: ubluetooth.FLAG_READ
+          ubluetooth.FLAG_WRITE
+          ubluetooth.FLAG_NOTIFY

--- a/extmod/modbluetooth.c
+++ b/extmod/modbluetooth.c
@@ -645,7 +645,7 @@ STATIC const mp_obj_type_t bluetooth_ble_type = {
 };
 
 STATIC const mp_rom_map_elem_t mp_module_bluetooth_globals_table[] = {
-    { MP_ROM_QSTR(MP_QSTR___name__), MP_ROM_QSTR(MP_QSTR_bluetooth) },
+    { MP_ROM_QSTR(MP_QSTR___name__), MP_ROM_QSTR(MP_QSTR_ubluetooth) },
     { MP_ROM_QSTR(MP_QSTR_BLE), MP_ROM_PTR(&bluetooth_ble_type) },
     { MP_ROM_QSTR(MP_QSTR_UUID), MP_ROM_PTR(&bluetooth_uuid_type) },
     { MP_ROM_QSTR(MP_QSTR_FLAG_READ), MP_ROM_INT(MP_BLUETOOTH_CHARACTERISTIC_FLAG_READ) },
@@ -655,7 +655,7 @@ STATIC const mp_rom_map_elem_t mp_module_bluetooth_globals_table[] = {
 
 STATIC MP_DEFINE_CONST_DICT(mp_module_bluetooth_globals, mp_module_bluetooth_globals_table);
 
-const mp_obj_module_t mp_module_bluetooth = {
+const mp_obj_module_t mp_module_ubluetooth = {
     .base = { &mp_type_module },
     .globals = (mp_obj_dict_t*)&mp_module_bluetooth_globals,
 };

--- a/ports/esp32/mpconfigport.h
+++ b/ports/esp32/mpconfigport.h
@@ -191,14 +191,7 @@ extern const struct _mp_obj_module_t uos_module;
 extern const struct _mp_obj_module_t mp_module_usocket;
 extern const struct _mp_obj_module_t mp_module_machine;
 extern const struct _mp_obj_module_t mp_module_network;
-extern const struct _mp_obj_module_t mp_module_bluetooth;
 extern const struct _mp_obj_module_t mp_module_onewire;
-
-#if MICROPY_PY_BLUETOOTH
-#define BLUETOOTH_BUILTIN_MODULE              { MP_ROM_QSTR(MP_QSTR_bluetooth), MP_ROM_PTR(&mp_module_bluetooth) },
-#else
-#define BLUETOOTH_BUILTIN_MODULE
-#endif
 
 #define MICROPY_PORT_BUILTIN_MODULES \
     { MP_OBJ_NEW_QSTR(MP_QSTR_esp), (mp_obj_t)&esp_module }, \
@@ -208,7 +201,6 @@ extern const struct _mp_obj_module_t mp_module_onewire;
     { MP_OBJ_NEW_QSTR(MP_QSTR_usocket), (mp_obj_t)&mp_module_usocket }, \
     { MP_OBJ_NEW_QSTR(MP_QSTR_machine), (mp_obj_t)&mp_module_machine }, \
     { MP_OBJ_NEW_QSTR(MP_QSTR_network), (mp_obj_t)&mp_module_network }, \
-    BLUETOOTH_BUILTIN_MODULE \
     { MP_OBJ_NEW_QSTR(MP_QSTR__onewire), (mp_obj_t)&mp_module_onewire }, \
     { MP_OBJ_NEW_QSTR(MP_QSTR_uhashlib), (mp_obj_t)&mp_module_uhashlib }, \
 

--- a/ports/stm32/mpconfigport.h
+++ b/ports/stm32/mpconfigport.h
@@ -211,7 +211,6 @@ extern const struct _mp_obj_module_t mp_module_uos;
 extern const struct _mp_obj_module_t mp_module_utime;
 extern const struct _mp_obj_module_t mp_module_usocket;
 extern const struct _mp_obj_module_t mp_module_network;
-extern const struct _mp_obj_module_t mp_module_bluetooth;
 extern const struct _mp_obj_module_t mp_module_onewire;
 
 #if MICROPY_PY_STM
@@ -237,12 +236,6 @@ extern const struct _mp_obj_module_t mp_module_onewire;
 #define NETWORK_BUILTIN_MODULE
 #endif
 
-#if MICROPY_PY_BLUETOOTH
-#define BLUETOOTH_BUILTIN_MODULE              { MP_ROM_QSTR(MP_QSTR_bluetooth), MP_ROM_PTR(&mp_module_bluetooth) },
-#else
-#define BLUETOOTH_BUILTIN_MODULE
-#endif
-
 #define MICROPY_PORT_BUILTIN_MODULES \
     { MP_ROM_QSTR(MP_QSTR_umachine), MP_ROM_PTR(&machine_module) }, \
     { MP_ROM_QSTR(MP_QSTR_pyb), MP_ROM_PTR(&pyb_module) }, \
@@ -251,7 +244,6 @@ extern const struct _mp_obj_module_t mp_module_onewire;
     { MP_ROM_QSTR(MP_QSTR_utime), MP_ROM_PTR(&mp_module_utime) }, \
     SOCKET_BUILTIN_MODULE \
     NETWORK_BUILTIN_MODULE \
-    BLUETOOTH_BUILTIN_MODULE \
     { MP_ROM_QSTR(MP_QSTR__onewire), MP_ROM_PTR(&mp_module_onewire) }, \
 
 // extra constants

--- a/py/builtin.h
+++ b/py/builtin.h
@@ -122,6 +122,7 @@ extern const mp_obj_module_t mp_module_uwebsocket;
 extern const mp_obj_module_t mp_module_webrepl;
 extern const mp_obj_module_t mp_module_framebuf;
 extern const mp_obj_module_t mp_module_btree;
+extern const mp_obj_module_t mp_module_ubluetooth;
 
 extern const char MICROPY_PY_BUILTINS_HELP_TEXT[];
 

--- a/py/objmodule.c
+++ b/py/objmodule.c
@@ -224,6 +224,9 @@ STATIC const mp_rom_map_elem_t mp_builtin_module_table[] = {
 #if MICROPY_PY_BTREE
     { MP_ROM_QSTR(MP_QSTR_btree), MP_ROM_PTR(&mp_module_btree) },
 #endif
+#if MICROPY_PY_BLUETOOTH
+    { MP_ROM_QSTR(MP_QSTR_ubluetooth), MP_ROM_PTR(&mp_module_ubluetooth) },
+#endif
 
     // extra builtin modules as defined by a port
     MICROPY_PORT_BUILTIN_MODULES


### PR DESCRIPTION
Related to #4370 (equivalent change for array->uarray), and #5241 (weak links by default).

This should be a no-op for most users, but allows customisation.