### PR TITLE
esp32/machine_hw_spi:  fix exception msg when host is already in use

### DIFF
--- a/ports/esp32/machine_hw_spi.c
+++ b/ports/esp32/machine_hw_spi.c
@@ -205,7 +205,7 @@ STATIC void machine_hw_spi_init_internal(
             return;
 
         case ESP_ERR_INVALID_STATE:
-            mp_raise_msg(&mp_type_OSError, "SPI device already in use");
+            mp_raise_msg(&mp_type_OSError, "SPI host already in use");
             return;
     }
 


### PR DESCRIPTION
minor correction:  when a SPI bus is initialized with a SPI host that
is currently in use the exception msg incorrectly indicates "SPI device
already in use".  The mention of "device" in the exception msg is
confusing because the error is about trying to use a SPI host that
is already claimed.    Here is an example where this situtation happens:
HSPI host being used by a SDCard, and an attempt is made to create a new
SPI instance using spi = SPI(1, sck=Pin(18), mosi=Pin(23), miso=Pin(19))

A better exception msg is "SPI host already in use"