### PR TITLE
stm32: add machine.Timer implemented as a 1ms resolution soft timer

### DIFF
--- a/ports/stm32/Makefile
+++ b/ports/stm32/Makefile
@@ -249,6 +249,7 @@ SRC_C = \
 	irq.c \
 	pendsv.c \
 	systick.c  \
+	softtimer.c  \
 	powerctrl.c \
 	powerctrlboot.c \
 	pybthread.c \

--- a/ports/stm32/Makefile
+++ b/ports/stm32/Makefile
@@ -278,6 +278,7 @@ SRC_C = \
 	machine_adc.c \
 	machine_i2c.c \
 	machine_spi.c \
+	machine_timer.c \
 	machine_uart.c \
 	modmachine.c \
 	modpyb.c \

--- a/ports/stm32/machine_timer.c
+++ b/ports/stm32/machine_timer.c
@@ -1,0 +1,132 @@
+/*
+ * This file is part of the MicroPython project, http://micropython.org/
+ *
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2019 Damien P. George
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#include "py/runtime.h"
+#include "py/mphal.h"
+#include "softtimer.h"
+
+typedef soft_timer_entry_t machine_timer_obj_t;
+
+const mp_obj_type_t machine_timer_type;
+
+STATIC void machine_timer_print(const mp_print_t *print, mp_obj_t self_in, mp_print_kind_t kind) {
+    machine_timer_obj_t *self = self_in;
+    qstr mode = self->mode == SOFT_TIMER_MODE_ONE_SHOT ? MP_QSTR_ONE_SHOT : MP_QSTR_PERIODIC;
+    mp_printf(print, "Timer(mode=%q, period=%u)", mode, self->delta_ms);
+}
+
+STATIC mp_obj_t machine_timer_init_helper(machine_timer_obj_t *self, size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
+    enum { ARG_mode, ARG_callback, ARG_period, ARG_tick_hz, ARG_freq, };
+    static const mp_arg_t allowed_args[] = {
+        { MP_QSTR_mode,         MP_ARG_KW_ONLY | MP_ARG_INT, {.u_int = SOFT_TIMER_MODE_PERIODIC} },
+        { MP_QSTR_callback,     MP_ARG_KW_ONLY | MP_ARG_OBJ, {.u_obj = mp_const_none} },
+        { MP_QSTR_period,       MP_ARG_KW_ONLY | MP_ARG_INT, {.u_int = 0xffffffff} },
+        { MP_QSTR_tick_hz,      MP_ARG_KW_ONLY | MP_ARG_INT, {.u_int = 1000} },
+        { MP_QSTR_freq,         MP_ARG_KW_ONLY | MP_ARG_OBJ, {.u_obj = mp_const_none} },
+    };
+
+    // Parse args
+    mp_arg_val_t args[MP_ARRAY_SIZE(allowed_args)];
+    mp_arg_parse_all(n_args, pos_args, kw_args, MP_ARRAY_SIZE(allowed_args), allowed_args, args);
+
+    self->mode = args[ARG_mode].u_int;
+    if (args[ARG_freq].u_obj != mp_const_none) {
+        // Frequency specified in Hz
+        #if MICROPY_PY_BUILTINS_FLOAT
+        self->delta_ms = 1000 / mp_obj_get_float(args[ARG_freq].u_obj);
+        #else
+        self->delta_ms = 1000 / mp_obj_get_int(args[ARG_freq].u_obj);
+        #endif
+    } else {
+        // Period specified
+        self->delta_ms = args[ARG_period].u_int * 1000 / args[ARG_tick_hz].u_int;
+    }
+    if (self->delta_ms < 1) {
+        self->delta_ms = 1;
+    }
+    self->expiry_ms = mp_hal_ticks_ms() + self->delta_ms;
+
+    self->callback = args[ARG_callback].u_obj;
+    soft_timer_insert(self);
+
+    return mp_const_none;
+}
+
+STATIC mp_obj_t machine_timer_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *args) {
+    machine_timer_obj_t *self = m_new_obj(machine_timer_obj_t);
+    self->base.type = &machine_timer_type;
+
+    // Get timer id (only soft timer (-1) supported at the moment)
+    mp_int_t id = -1;
+    if (n_args > 0) {
+        id = mp_obj_get_int(args[0]);
+        --n_args;
+        ++args;
+    }
+    if (id != -1) {
+        mp_raise_ValueError("Timer doesn't exist");
+    }
+
+    if (n_args > 0 || n_kw > 0) {
+        // Start the timer
+        mp_map_t kw_args;
+        mp_map_init_fixed_table(&kw_args, n_kw, args + n_args);
+        machine_timer_init_helper(self, n_args, args, &kw_args);
+    }
+
+    return MP_OBJ_FROM_PTR(self);
+}
+
+STATIC mp_obj_t machine_timer_init(size_t n_args, const mp_obj_t *args, mp_map_t *kw_args) {
+    machine_timer_obj_t *self = MP_OBJ_TO_PTR(args[0]);
+    soft_timer_remove(self);
+    return machine_timer_init_helper(self, n_args - 1, args + 1, kw_args);
+}
+STATIC MP_DEFINE_CONST_FUN_OBJ_KW(machine_timer_init_obj, 1, machine_timer_init);
+
+STATIC mp_obj_t machine_timer_deinit(mp_obj_t self_in) {
+    machine_timer_obj_t *self = MP_OBJ_TO_PTR(self_in);
+    soft_timer_remove(self);
+    return mp_const_none;
+}
+STATIC MP_DEFINE_CONST_FUN_OBJ_1(machine_timer_deinit_obj, machine_timer_deinit);
+
+STATIC const mp_rom_map_elem_t machine_timer_locals_dict_table[] = {
+    { MP_ROM_QSTR(MP_QSTR_init), MP_ROM_PTR(&machine_timer_init_obj) },
+    { MP_ROM_QSTR(MP_QSTR_deinit), MP_ROM_PTR(&machine_timer_deinit_obj) },
+
+    { MP_ROM_QSTR(MP_QSTR_ONE_SHOT), MP_ROM_INT(SOFT_TIMER_MODE_ONE_SHOT) },
+    { MP_ROM_QSTR(MP_QSTR_PERIODIC), MP_ROM_INT(SOFT_TIMER_MODE_PERIODIC) },
+};
+STATIC MP_DEFINE_CONST_DICT(machine_timer_locals_dict, machine_timer_locals_dict_table);
+
+const mp_obj_type_t machine_timer_type = {
+    { &mp_type_type },
+    .name = MP_QSTR_Timer,
+    .print = machine_timer_print,
+    .make_new = machine_timer_make_new,
+    .locals_dict = (mp_obj_dict_t*)&machine_timer_locals_dict,
+};

--- a/ports/stm32/main.c
+++ b/ports/stm32/main.c
@@ -55,6 +55,7 @@
 #include "gccollect.h"
 #include "factoryreset.h"
 #include "modmachine.h"
+#include "softtimer.h"
 #include "i2c.h"
 #include "spi.h"
 #include "uart.h"
@@ -743,6 +744,7 @@ soft_reset_exit:
     #if MICROPY_PY_NETWORK
     mod_network_deinit();
     #endif
+    soft_timer_deinit();
     timer_deinit();
     uart_deinit_all();
     #if MICROPY_HW_ENABLE_CAN

--- a/ports/stm32/modmachine.c
+++ b/ports/stm32/modmachine.c
@@ -399,8 +399,8 @@ STATIC const mp_rom_map_elem_t machine_module_globals_table[] = {
     { MP_ROM_QSTR(MP_QSTR_SPI),                 MP_ROM_PTR(&machine_hard_spi_type) },
     { MP_ROM_QSTR(MP_QSTR_UART),                MP_ROM_PTR(&pyb_uart_type) },
     { MP_ROM_QSTR(MP_QSTR_WDT),                 MP_ROM_PTR(&pyb_wdt_type) },
+    { MP_ROM_QSTR(MP_QSTR_Timer),               MP_ROM_PTR(&machine_timer_type) },
 #if 0
-    { MP_ROM_QSTR(MP_QSTR_Timer),               MP_ROM_PTR(&pyb_timer_type) },
     { MP_ROM_QSTR(MP_QSTR_HeartBeat),           MP_ROM_PTR(&pyb_heartbeat_type) },
     { MP_ROM_QSTR(MP_QSTR_SD),                  MP_ROM_PTR(&pyb_sd_type) },
 

--- a/ports/stm32/modmachine.h
+++ b/ports/stm32/modmachine.h
@@ -29,6 +29,7 @@
 #include "py/obj.h"
 
 extern const mp_obj_type_t machine_adc_type;
+extern const mp_obj_type_t machine_timer_type;
 
 void machine_init(void);
 void machine_deinit(void);

--- a/ports/stm32/mpconfigport.h
+++ b/ports/stm32/mpconfigport.h
@@ -282,6 +282,8 @@ struct _mp_bluetooth_nimble_root_pointers_t;
     \
     mp_obj_t pyb_extint_callback[PYB_EXTI_NUM_VECTORS]; \
     \
+    struct _soft_timer_entry_t *soft_timer_head; \
+    \
     /* pointers to all Timer objects (if they have been created) */ \
     struct _pyb_timer_obj_t *pyb_timer_obj_all[MICROPY_HW_MAX_TIMER]; \
     \

--- a/ports/stm32/softtimer.c
+++ b/ports/stm32/softtimer.c
@@ -1,0 +1,112 @@
+/*
+ * This file is part of the MicroPython project, http://micropython.org/
+ *
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2019 Damien P. George
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#include <stdint.h>
+#include "py/runtime.h"
+#include "irq.h"
+#include "softtimer.h"
+
+#define TICKS_PERIOD 0x80000000
+#define TICKS_DIFF(t1, t0) ((int32_t)(((t1 - t0 + TICKS_PERIOD / 2) & (TICKS_PERIOD - 1)) - TICKS_PERIOD / 2))
+
+extern __IO uint32_t uwTick;
+
+volatile uint32_t soft_timer_next;
+
+void soft_timer_deinit(void) {
+    MP_STATE_PORT(soft_timer_head) = NULL;
+}
+
+STATIC void soft_timer_schedule_systick(uint32_t ticks_ms) {
+    uint32_t irq_state = disable_irq();
+    uint32_t uw_tick = uwTick;
+    if (TICKS_DIFF(ticks_ms, uw_tick) <= 0) {
+        soft_timer_next = uw_tick + 1;
+    } else {
+        soft_timer_next = ticks_ms;
+    }
+    enable_irq(irq_state);
+}
+
+// Must be executed at IRQ_PRI_PENDSV
+void soft_timer_handler(void) {
+    uint32_t ticks_ms = uwTick;
+    soft_timer_entry_t *head = MP_STATE_PORT(soft_timer_head);
+    while (head != NULL && TICKS_DIFF(head->expiry_ms, ticks_ms) <= 0) {
+        mp_sched_schedule(head->callback, MP_OBJ_FROM_PTR(head));
+        if (head->mode == SOFT_TIMER_MODE_PERIODIC) {
+            head->expiry_ms += head->delta_ms;
+            // Shift this node along to its new position
+            soft_timer_entry_t *cur = head;
+            while (cur->next != NULL && TICKS_DIFF(head->expiry_ms, cur->next->expiry_ms) >= 0) {
+                cur = cur->next;
+            }
+            if (cur != head) {
+                soft_timer_entry_t *next = head->next;
+                head->next = cur->next;
+                cur->next = head;
+                head = next;
+            }
+        } else {
+            head = head->next;
+        }
+    }
+    MP_STATE_PORT(soft_timer_head) = head;
+    if (head == NULL) {
+        // No more timers left, set largest delay possible
+        soft_timer_next = uwTick;
+    } else {
+        // Set soft_timer_next so SysTick calls us back at the correct time
+        soft_timer_schedule_systick(head->expiry_ms);
+    }
+}
+
+void soft_timer_insert(soft_timer_entry_t *entry) {
+    uint32_t irq_state = raise_irq_pri(IRQ_PRI_PENDSV);
+    soft_timer_entry_t **head_ptr = &MP_STATE_PORT(soft_timer_head);
+    while (*head_ptr != NULL && TICKS_DIFF(entry->expiry_ms, (*head_ptr)->expiry_ms) >= 0) {
+        head_ptr = &(*head_ptr)->next;
+    }
+    entry->next = *head_ptr;
+    *head_ptr = entry;
+    if (head_ptr == &MP_STATE_PORT(soft_timer_head)) {
+        // This new timer became the earliest one so set soft_timer_next
+        soft_timer_schedule_systick((*head_ptr)->expiry_ms);
+    }
+    restore_irq_pri(irq_state);
+}
+
+void soft_timer_remove(soft_timer_entry_t *entry) {
+    uint32_t irq_state = raise_irq_pri(IRQ_PRI_PENDSV);
+    soft_timer_entry_t **cur = &MP_STATE_PORT(soft_timer_head);
+    while (*cur != NULL) {
+        if (*cur == entry) {
+            *cur = entry->next;
+            break;
+        }
+    }
+    restore_irq_pri(irq_state);
+}

--- a/ports/stm32/systick.c
+++ b/ports/stm32/systick.c
@@ -27,7 +27,9 @@
 #include "py/runtime.h"
 #include "py/mphal.h"
 #include "irq.h"
+#include "pendsv.h"
 #include "systick.h"
+#include "softtimer.h"
 #include "pybthread.h"
 
 extern __IO uint32_t uwTick;
@@ -50,6 +52,10 @@ void SysTick_Handler(void) {
     systick_dispatch_t f = systick_dispatch_table[uw_tick & (SYSTICK_DISPATCH_NUM_SLOTS - 1)];
     if (f != NULL) {
         f(uw_tick);
+    }
+
+    if (soft_timer_next == uw_tick) {
+        pendsv_schedule_dispatch(PENDSV_DISPATCH_SOFT_TIMER, soft_timer_handler);
     }
 
     #if MICROPY_PY_THREAD


### PR DESCRIPTION
This PR adds a very simple but useful implementation of `machine.Timer` to the stm32 port, providing a "software timer" with a 1ms resolution, allowing unlimited number of concurrent timers.  They can be one-shot or periodic, have a Python callback, and can be cancelled.

It uses SysTick to implement the soft timer, so doesn't impact an existing hardware timer.  There is a very small overhead added to the SysTick IRQ, which could be further optimised (eg by patching systick_irq code dynamically).

The Python-level API is intended to match esp8266 and esp32, like this:
```python
from machine import Timer
t = Timer(-1, mode=Timer.PERIODIC, callback=lambda t:print(t), period=2000)
<wait a bit>
t.deinit()
```

Ultimately the Timer API will be refined further, see discussion at #2971, but for now this at least provides a starting point and something useful and portable.