### PR TITLE
docs: Move ubluetooth under "MicroPython-specific libraries".

### DIFF
--- a/docs/library/index.rst
+++ b/docs/library/index.rst
@@ -80,7 +80,6 @@ it will fallback to loading the built-in ``ujson`` module.
    sys.rst
    uarray.rst
    ubinascii.rst
-   ubluetooth.rst
    ucollections.rst
    uerrno.rst
    uhashlib.rst
@@ -112,6 +111,7 @@ the following libraries.
    machine.rst
    micropython.rst
    network.rst
+   ubluetooth.rst
    ucryptolib.rst
    uctypes.rst
 


### PR DESCRIPTION
CPython does not have a `bluetooth` module, so it is not appropriate to call `ubluetooth` a Python standard library or micro-library.