### PR TITLE
Use mp_stack API instead of local pointer for gc_collect and stack initialization

### DIFF
--- a/ports/zephyr/main.c
+++ b/ports/zephyr/main.c
@@ -48,7 +48,6 @@
 #include TEST
 #endif
 
-static char *stack_top;
 static char heap[MICROPY_HEAP_SIZE];
 
 void init_zephyr(void) {
@@ -79,9 +78,7 @@ void init_zephyr(void) {
 }
 
 int real_main(void) {
-    int stack_dummy;
-    stack_top = (char*)&stack_dummy;
-    mp_stack_set_top(stack_top);
+    mp_stack_ctrl_init();
     // Make MicroPython's stack limit somewhat smaller than full stack available
     mp_stack_set_limit(CONFIG_MAIN_STACK_SIZE - 512);
 
@@ -130,7 +127,7 @@ void gc_collect(void) {
     // pointers from CPU registers, and thus may function incorrectly.
     void *dummy;
     gc_collect_start();
-    gc_collect_root(&dummy, ((mp_uint_t)stack_top - (mp_uint_t)&dummy) / sizeof(mp_uint_t));
+    gc_collect_root(&dummy, ((mp_uint_t)MP_STATE_THREAD(stack_top) - (mp_uint_t)&dummy) / sizeof(mp_uint_t));
     gc_collect_end();
     //gc_dump_info();
 }


### PR DESCRIPTION
This change allows to embed micropython as library without REPL and use gc_collect