### PR TITLE
extmod/modbluetooth: Enable configuration of rx buffer.

### DIFF
--- a/docs/library/ubluetooth.rst
+++ b/docs/library/ubluetooth.rst
@@ -246,6 +246,17 @@ writes from a central to a given characteristic, use
     of the notification, avoiding the need for a separate read request. Note
     that this will not update the local value stored.
 
+.. method:: BLE.gatts_set_buffer(value_handle, len, append=False)
+
+    Sets the internal buffer size for a value in bytes. This will limit the
+    largest possible write that can be received. The default is 20.
+
+    Setting *append* to ``True`` will make all remote writes append to, rather
+    than replace, the current value. At most **len** bytes can be buffered in
+    this way. When you use :meth:`gatts_read <BLE.gatts_read>`, the value will
+    be cleared after reading. This feature is useful when implementing something
+    like the Nordic UART Service.
+
 
 Central Role (GATT Client)
 --------------------------

--- a/examples/bluetooth/ble_uart_peripheral.py
+++ b/examples/bluetooth/ble_uart_peripheral.py
@@ -22,8 +22,8 @@ class BLEUART:
         self._ble.active(True)
         self._ble.irq(handler=self._irq)
         ((self._tx_handle, self._rx_handle,),) = self._ble.gatts_register_services((_UART_SERVICE,))
-        # Increase the size of the rx buffer.
-        self._ble.gatts_write(self._rx_handle, bytes(rxbuf))
+        # Increase the size of the rx buffer and enable append mode.
+        self._ble.gatts_set_buffer(self._rx_handle, rxbuf, True)
         self._connections = set()
         self._rx_buffer = bytearray()
         self._handler = None

--- a/extmod/modbluetooth.c
+++ b/extmod/modbluetooth.c
@@ -557,6 +557,14 @@ STATIC mp_obj_t bluetooth_ble_gatts_notify(size_t n_args, const mp_obj_t *args) 
 }
 STATIC MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(bluetooth_ble_gatts_notify_obj, 3, 4, bluetooth_ble_gatts_notify);
 
+STATIC mp_obj_t bluetooth_ble_gatts_set_buffer(size_t n_args, const mp_obj_t *args) {
+    mp_int_t value_handle = mp_obj_get_int(args[1]);
+    mp_int_t len = mp_obj_get_int(args[2]);
+    bool append = n_args >= 4 && mp_obj_is_true(args[3]);
+    return bluetooth_handle_errno(mp_bluetooth_gatts_set_buffer(value_handle, len, append));
+}
+STATIC MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(bluetooth_ble_gatts_set_buffer_obj, 3, 4, bluetooth_ble_gatts_set_buffer);
+
 // ----------------------------------------------------------------------------
 // Bluetooth object: GATTC (Central/Scanner role)
 // ----------------------------------------------------------------------------
@@ -626,6 +634,7 @@ STATIC const mp_rom_map_elem_t bluetooth_ble_locals_dict_table[] = {
     { MP_ROM_QSTR(MP_QSTR_gatts_read), MP_ROM_PTR(&bluetooth_ble_gatts_read_obj) },
     { MP_ROM_QSTR(MP_QSTR_gatts_write), MP_ROM_PTR(&bluetooth_ble_gatts_write_obj) },
     { MP_ROM_QSTR(MP_QSTR_gatts_notify), MP_ROM_PTR(&bluetooth_ble_gatts_notify_obj) },
+    { MP_ROM_QSTR(MP_QSTR_gatts_set_buffer), MP_ROM_PTR(&bluetooth_ble_gatts_set_buffer_obj) },
     #if MICROPY_PY_BLUETOOTH_ENABLE_CENTRAL_MODE
     // GATT Client (i.e. central/scanner role)
     { MP_ROM_QSTR(MP_QSTR_gattc_discover_services), MP_ROM_PTR(&bluetooth_ble_gattc_discover_services_obj) },

--- a/extmod/modbluetooth.h
+++ b/extmod/modbluetooth.h
@@ -183,6 +183,10 @@ int mp_bluetooth_gatts_notify_send(uint16_t conn_handle, uint16_t value_handle, 
 // Indicate the central.
 int mp_bluetooth_gatts_indicate(uint16_t conn_handle, uint16_t value_handle);
 
+// Resize and enable/disable append-mode on a value.
+// Append-mode means that remote writes will append and local reads will clear after reading.
+int mp_bluetooth_gatts_set_buffer(uint16_t value_handle, size_t len, bool append);
+
 // Disconnect from a central or peripheral.
 int mp_bluetooth_gap_disconnect(uint16_t conn_handle);
 


### PR DESCRIPTION
Enables a straightforward way to use the NUS without worrying about losing writes if there's a delay calling gatts_read before the next write appears.

Thanks to @mirko for the suggestion.