### PR TITLE
py/modsys: Add sys.implementation.mpy to give supported .mpy version.

### DIFF
--- a/py/modsys.c
+++ b/py/modsys.c
@@ -34,6 +34,7 @@
 #include "py/stream.h"
 #include "py/smallint.h"
 #include "py/runtime.h"
+#include "py/persistentcode.h"
 
 #if MICROPY_PY_SYS_SETTRACE
 #include "py/objmodule.h"
@@ -66,22 +67,36 @@ STATIC const mp_obj_tuple_t mp_sys_implementation_version_info_obj = {
     3,
     { I(MICROPY_VERSION_MAJOR), I(MICROPY_VERSION_MINOR), I(MICROPY_VERSION_MICRO) }
 };
+#if MICROPY_PERSISTENT_CODE_LOAD
+#define SYS_IMPLEMENTATION_ELEMS \
+    MP_ROM_QSTR(MP_QSTR_micropython), \
+    MP_ROM_PTR(&mp_sys_implementation_version_info_obj), \
+    MP_ROM_INT(MPY_FILE_HEADER_INT)
+#else
+#define SYS_IMPLEMENTATION_ELEMS \
+    MP_ROM_QSTR(MP_QSTR_micropython), \
+    MP_ROM_PTR(&mp_sys_implementation_version_info_obj)
+#endif
 #if MICROPY_PY_ATTRTUPLE
-STATIC const qstr impl_fields[] = { MP_QSTR_name, MP_QSTR_version };
+STATIC const qstr impl_fields[] = {
+    MP_QSTR_name,
+    MP_QSTR_version,
+    #if MICROPY_PERSISTENT_CODE_LOAD
+    MP_QSTR_mpy,
+    #endif
+};
 STATIC MP_DEFINE_ATTRTUPLE(
     mp_sys_implementation_obj,
     impl_fields,
-    2,
-        MP_ROM_QSTR(MP_QSTR_micropython),
-        MP_ROM_PTR(&mp_sys_implementation_version_info_obj)
+    2 + MICROPY_PERSISTENT_CODE_LOAD,
+        SYS_IMPLEMENTATION_ELEMS
 );
 #else
 STATIC const mp_rom_obj_tuple_t mp_sys_implementation_obj = {
     {&mp_type_tuple},
-    2,
+    2 + MICROPY_PERSISTENT_CODE_LOAD,
     {
-        MP_ROM_QSTR(MP_QSTR_micropython),
-        MP_ROM_PTR(&mp_sys_implementation_version_info_obj),
+        SYS_IMPLEMENTATION_ELEMS
     }
 };
 #endif

--- a/py/persistentcode.c
+++ b/py/persistentcode.c
@@ -40,43 +40,6 @@
 
 #define QSTR_LAST_STATIC MP_QSTR_zip
 
-// Macros to encode/decode flags to/from the feature byte
-#define MPY_FEATURE_ENCODE_FLAGS(flags) (flags)
-#define MPY_FEATURE_DECODE_FLAGS(feat) ((feat) & 3)
-
-// Macros to encode/decode native architecture to/from the feature byte
-#define MPY_FEATURE_ENCODE_ARCH(arch) ((arch) << 2)
-#define MPY_FEATURE_DECODE_ARCH(feat) ((feat) >> 2)
-
-// The feature flag bits encode the compile-time config options that
-// affect the generate bytecode.
-#define MPY_FEATURE_FLAGS ( \
-    ((MICROPY_OPT_CACHE_MAP_LOOKUP_IN_BYTECODE) << 0) \
-    | ((MICROPY_PY_BUILTINS_STR_UNICODE) << 1) \
-    )
-// This is a version of the flags that can be configured at runtime.
-#define MPY_FEATURE_FLAGS_DYNAMIC ( \
-    ((MICROPY_OPT_CACHE_MAP_LOOKUP_IN_BYTECODE_DYNAMIC) << 0) \
-    | ((MICROPY_PY_BUILTINS_STR_UNICODE_DYNAMIC) << 1) \
-    )
-
-// Define the host architecture
-#if MICROPY_EMIT_X86
-#define MPY_FEATURE_ARCH (MP_NATIVE_ARCH_X86)
-#elif MICROPY_EMIT_X64
-#define MPY_FEATURE_ARCH (MP_NATIVE_ARCH_X64)
-#elif MICROPY_EMIT_THUMB
-#define MPY_FEATURE_ARCH (MP_NATIVE_ARCH_ARMV7M)
-#elif MICROPY_EMIT_ARM
-#define MPY_FEATURE_ARCH (MP_NATIVE_ARCH_ARMV6)
-#elif MICROPY_EMIT_XTENSA
-#define MPY_FEATURE_ARCH (MP_NATIVE_ARCH_XTENSA)
-#elif MICROPY_EMIT_XTENSAWIN
-#define MPY_FEATURE_ARCH (MP_NATIVE_ARCH_XTENSAWIN)
-#else
-#define MPY_FEATURE_ARCH (MP_NATIVE_ARCH_NONE)
-#endif
-
 #if MICROPY_DYNAMIC_COMPILER
 #define MPY_FEATURE_ARCH_DYNAMIC mp_dynamic_compiler.native_arch
 #else

--- a/py/persistentcode.h
+++ b/py/persistentcode.h
@@ -33,6 +33,43 @@
 // The current version of .mpy files
 #define MPY_VERSION 5
 
+// Macros to encode/decode flags to/from the feature byte
+#define MPY_FEATURE_ENCODE_FLAGS(flags) (flags)
+#define MPY_FEATURE_DECODE_FLAGS(feat) ((feat) & 3)
+
+// Macros to encode/decode native architecture to/from the feature byte
+#define MPY_FEATURE_ENCODE_ARCH(arch) ((arch) << 2)
+#define MPY_FEATURE_DECODE_ARCH(feat) ((feat) >> 2)
+
+// The feature flag bits encode the compile-time config options that
+// affect the generate bytecode.
+#define MPY_FEATURE_FLAGS ( \
+    ((MICROPY_OPT_CACHE_MAP_LOOKUP_IN_BYTECODE) << 0) \
+    | ((MICROPY_PY_BUILTINS_STR_UNICODE) << 1) \
+    )
+// This is a version of the flags that can be configured at runtime.
+#define MPY_FEATURE_FLAGS_DYNAMIC ( \
+    ((MICROPY_OPT_CACHE_MAP_LOOKUP_IN_BYTECODE_DYNAMIC) << 0) \
+    | ((MICROPY_PY_BUILTINS_STR_UNICODE_DYNAMIC) << 1) \
+    )
+
+// Define the host architecture
+#if MICROPY_EMIT_X86
+#define MPY_FEATURE_ARCH (MP_NATIVE_ARCH_X86)
+#elif MICROPY_EMIT_X64
+#define MPY_FEATURE_ARCH (MP_NATIVE_ARCH_X64)
+#elif MICROPY_EMIT_THUMB
+#define MPY_FEATURE_ARCH (MP_NATIVE_ARCH_ARMV7M)
+#elif MICROPY_EMIT_ARM
+#define MPY_FEATURE_ARCH (MP_NATIVE_ARCH_ARMV6)
+#elif MICROPY_EMIT_XTENSA
+#define MPY_FEATURE_ARCH (MP_NATIVE_ARCH_XTENSA)
+#elif MICROPY_EMIT_XTENSAWIN
+#define MPY_FEATURE_ARCH (MP_NATIVE_ARCH_XTENSAWIN)
+#else
+#define MPY_FEATURE_ARCH (MP_NATIVE_ARCH_NONE)
+#endif
+
 enum {
     MP_NATIVE_ARCH_NONE = 0,
     MP_NATIVE_ARCH_X86,

--- a/py/persistentcode.h
+++ b/py/persistentcode.h
@@ -70,6 +70,10 @@
 #define MPY_FEATURE_ARCH (MP_NATIVE_ARCH_NONE)
 #endif
 
+// 16-bit little-endian integer with the second and third bytes of supported .mpy files
+#define MPY_FILE_HEADER_INT (MPY_VERSION \
+    | (MPY_FEATURE_ENCODE_FLAGS(MPY_FEATURE_FLAGS) | MPY_FEATURE_ENCODE_ARCH(MPY_FEATURE_ARCH)) << 8)
+
 enum {
     MP_NATIVE_ARCH_NONE = 0,
     MP_NATIVE_ARCH_X86,

--- a/tests/basics/sys1.py
+++ b/tests/basics/sys1.py
@@ -18,3 +18,9 @@ try:
 except AttributeError:
     # Effectively skip subtests
     print(True)
+
+if hasattr(sys.implementation, 'mpy'):
+    print(type(sys.implementation.mpy))
+else:
+    # Effectively skip subtests
+    print(int)


### PR DESCRIPTION
When importing a .mpy file it can fail if the version/flags/arch is not correct.  When you get such an error it's hard to tell exactly what went wrong and what .mpy version was expected.

One way to improve this is to give more detailed error messages, like "expecting version 5 but got version 4".  That would cost quite a bit in code size to make it useful enough.

The approach in this PR is different: to provide a `sys.implementation.mpy` entry which returns a bytes object that is the header of the .mpy file that is supported by the system being run.  This allows to programatically determine the supported .mpy file, and also for the user to find it out by inspecting this value.

Eg:
```python
MicroPython v1.11-525-g162016ad9-dirty on 2019-10-30; linux version
Use Ctrl-D to exit, Ctrl-E for paste mode
>>> import sys
>>> sys.implementation
(name='micropython', version=(1, 11, 0), mpy=b'M\x05\n\x00 ')
>>> sys.implementation.mpy
b'M\x05\n\x00 '
>>> sys.implementation.mpy[0] # initial 'M'
77
>>> sys.implementation.mpy[1] # version number
5
>>> sys.implementation.mpy[2] # flags
11
>>> bin(_)
'0b1011' # this is an x64 arch with cached-bc-lookup and unicode strings
```

Not sure if the 4th and 5th bytes are necessary (small int size, qstr window size respectively).

TODO: write test, work out code-size increase