### PR TITLE
py/objgenerator: do not allow pend_throw to an unstarted generator.

### DIFF
--- a/tests/basics/generator_pend_throw.py
+++ b/tests/basics/generator_pend_throw.py
@@ -26,16 +26,6 @@ except Exception as e:
 
 print("ret was:", v)
 
-
-# Verify that pend_throw works on an unstarted coroutine.
-g = gen()
-g.pend_throw(OSError())
-try:
-    next(g)
-except Exception as e:
-    print("raised", repr(e))
-
-
 # Verify that you can't resume the coroutine from within the running coroutine.
 def gen_next():
     next(g)
@@ -77,14 +67,12 @@ g = gen_cancelled()
 print(next(g))
 g.pend_throw(CancelledError())
 print(next(g))
-# ...but not if the generator hasn't started.
+# pend_throw() is not allowed on generators that have not started yet
 g = gen_cancelled()
-g.pend_throw(CancelledError())
 try:
-    next(g)
-except Exception as e:
-    print("raised", repr(e))
-
+     g.pend_throw(CancelledError())
+except TypeError:
+     print("TypeError")
 
 # Verify that calling pend_throw returns the previous exception.
 g = gen()

--- a/tests/basics/generator_pend_throw.py.exp
+++ b/tests/basics/generator_pend_throw.py.exp
@@ -2,13 +2,12 @@
 1
 raised ValueError()
 ret was: None
-raised OSError()
 raised ValueError('generator already executing',)
-raised ValueError('generator already executing',)
+raised TypeError("can't pend throw to just-started generator",)
 0
 ignore CancelledError
 1
-raised CancelledError()
+TypeError
 None
 CancelledError()
 CancelledError()


### PR DESCRIPTION
pend_throw() to unstarted generators prevents catching the injected
exception by the generator's code breaking existing code that relies on
being able to catch all exceptions. See https://github.com/micropython/micropython/issues/5242#issuecomment-549485156