### PR TITLE
extmod/modonewire: Adjust timing within "onewire_bus_reset"

### DIFF
--- a/extmod/modonewire.c
+++ b/extmod/modonewire.c
@@ -45,13 +45,13 @@
 
 STATIC int onewire_bus_reset(mp_hal_pin_obj_t pin) {
     mp_hal_pin_write(pin, 0);
-    mp_hal_delay_us(TIMING_RESET1);
+    mp_hal_delay_us_fast(TIMING_RESET1);
     uint32_t i = mp_hal_quiet_timing_enter();
     mp_hal_pin_write(pin, 1);
     mp_hal_delay_us_fast(TIMING_RESET2);
     int status = !mp_hal_pin_read(pin);
     mp_hal_quiet_timing_exit(i);
-    mp_hal_delay_us(TIMING_RESET3);
+    mp_hal_delay_us_fast(TIMING_RESET3);
     return status;
 }
 


### PR DESCRIPTION
Dear George and the MicroPython community,

while working on [1,2], we just added #5289 and also stumbled on #4647. While we can't say for sure, we might have spotted a minor glitch which could possibly have negative impact on the correct timing of things.

So, maybe adjusting two function calls within `onewire_bus_reset` to `mp_hal_delay_us_fast()` instead of `mp_hal_delay_us()` could make things work for @kevinkk525 on the ESP32 platform.

Please correct me if I am wrong on that and feel free to close this PR right away if this is going into the wrong direction.

With kind regards,
Andreas.

[1] https://community.hiveeyes.org/t/untersuchung-und-verbesserung-des-timings-bei-der-ansteuerung-der-ds18b20-sensoren-unter-micropython/2309
[2] https://github.com/pycom/pycom-micropython-sigfox/pull/356
