### PR TITLE
tools/makemanifest: Skip freezing unsupported files with warning.

### DIFF
--- a/tools/makemanifest.py
+++ b/tools/makemanifest.py
@@ -185,7 +185,8 @@ def freeze_internal(kind, path, script, opt):
                     kind = k
                     break
             else:
-                raise FreezeError('unsupported file type {}'.format(script))
+                print('warn: unsupported file type, skipped freeze: {}'.format(script))
+                return
         wanted_extension = extension_kind[kind]
         if not script.endswith(wanted_extension):
             raise FreezeError('expecting a {} file, got {}'.format(wanted_extension, script))


### PR DESCRIPTION
Simplest fix for #5255

@dpgeorge did you have a error case in mind this exception was catching? 
Perhaps there's a better way to handle it than this.