### PR TITLE
stm32: Generalise flash mounting code so it supports arbitrary FS.

### DIFF
--- a/ports/stm32/factoryreset.h
+++ b/ports/stm32/factoryreset.h
@@ -29,5 +29,6 @@
 #include "lib/oofatfs/ff.h"
 
 void factory_reset_make_files(FATFS *fatfs);
+int factory_reset_create_filesystem(void);
 
 #endif // MICROPY_INCLUDED_STM32_FACTORYRESET_H

--- a/ports/stm32/storage.c
+++ b/ports/stm32/storage.c
@@ -234,7 +234,7 @@ mp_uint_t storage_write_blocks(const uint8_t *src, uint32_t block_num, uint32_t 
 // Expose the flash as an object with the block protocol.
 
 // there is a singleton Flash object
-STATIC const mp_obj_base_t pyb_flash_obj = {&pyb_flash_type};
+const mp_obj_base_t pyb_flash_obj = {&pyb_flash_type};
 
 STATIC mp_obj_t pyb_flash_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *args) {
     // check arguments

--- a/ports/stm32/storage.h
+++ b/ports/stm32/storage.h
@@ -63,6 +63,7 @@ int spi_bdev_readblocks(spi_bdev_t *bdev, uint8_t *dest, uint32_t block_num, uin
 int spi_bdev_writeblocks(spi_bdev_t *bdev, const uint8_t *src, uint32_t block_num, uint32_t num_blocks);
 
 extern const struct _mp_obj_type_t pyb_flash_type;
+extern const struct _mp_obj_base_t pyb_flash_obj;
 
 struct _fs_user_mount_t;
 void pyb_flash_init_vfs(struct _fs_user_mount_t *vfs);


### PR DESCRIPTION
This PR refactors and generalises the boot-mount routine on stm32 so that it can mount filesystems of arbitrary type.  Ie it no longer assumes that the filesystem is FAT.

It does this by using `mp_vfs_mount()` which does auto-detection of the filesystem type.

----------------

The idea with this is that the user could reformat the flash filesystem with littlefs (or other FS type) and then it would "just work".  So the could would support both FAT at littlefs, it just depends how the flash is formatted.

But there are two problems with getting this latter part working:
1. the existing flash block device has a partition table at the first block, and littlefs won't work with this
2. the existing flash block device has a block size of 512 bytes, not the native 4k (or otherwise) of external SPI flash, so littlefs must still go through the block device's cache

To fix (1) requires splitting out the partition table.  Since it's only really needed by the USB MSC, it's possible to split this partition stuff out from the storage driver (storage.c) and put it in the USB driver (usbd_msc_interface.c).  That would then free up storage.c to abstract just the blocks on the block device(s).

To fix (2) is difficult.  For the auto-mount code it would mean that the block size (and hence the block device) depends on the filesystem type (almost a chicken and egg problem).  A simple way forward would be to just use a 512 block size for littlefs, and make it go through the flash write cache (this should work ok).  Or switch to 4096 block size, but then FAT FS needs 4k blocks and is rather inefficient (although that's what esp8266 and esp32 do).

Things are simpler if there's no auto-detection.  Then the user would need to configure the filesystem type at compile time.  This PR would still be useful for that approach.