### PR TITLE
stm32/mboot: Add support for signed and encrypted DFU files.

### DIFF
--- a/lib/libhydrogen/LICENSE
+++ b/lib/libhydrogen/LICENSE
@@ -1,0 +1,18 @@
+/*
+ * ISC License
+ *
+ * Copyright (c) 2017-2019
+ * Frank Denis <j at pureftpd dot org>
+ *
+ * Permission to use, copy, modify, and/or distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ */

--- a/lib/libhydrogen/README.md
+++ b/lib/libhydrogen/README.md
@@ -1,0 +1,36 @@
+[![Build Status](https://travis-ci.org/jedisct1/libhydrogen.svg?branch=master)](https://travis-ci.org/jedisct1/libhydrogen?branch=master)
+[![Financial Contributors on Open Collective](https://opencollective.com/libhydrogen/all/badge.svg?label=financial+contributors)](https://opencollective.com/libhydrogen) [![Coverity Scan Build Status](https://scan.coverity.com/projects/13315/badge.svg)](https://scan.coverity.com/projects/13315)
+
+![libhydrogen](https://raw.github.com/jedisct1/libhydrogen/master/logo.png)
+==============
+
+The Hydrogen library is a small, easy-to-use, hard-to-misuse cryptographic library.
+
+Features:
+- Consistent high-level API, inspired by libsodium. Instead of low-level primitives, it exposes simple functions to solve common problems that cryptography can solve.
+- 100% built using just two cryptographic building blocks: the [Curve25519](https://cr.yp.to/ecdh.html) elliptic curve, and the [Gimli](https://csrc.nist.gov/CSRC/media/Projects/Lightweight-Cryptography/documents/round-1/spec-doc/gimli-spec.pdf) permutation.
+- Small and easy to audit. Implemented as one tiny file for every set of operation, and adding a single `.c` file to your project is all it takes to use libhydrogen in your project.
+- The whole code is released under a single, very liberal license (ISC).
+- Zero dynamic memory allocations and low stack requirements (median: 32 bytes, max: 128 bytes). This makes it usable in constrained environments such as microcontrollers.
+- Portable: written in standard C99. Supports Linux, *BSD, MacOS, Windows, and the Arduino IDE out of the box.
+- Can generate cryptographically-secure random numbers, even on Arduino boards.
+- Attempts to mitigate the implications of accidental misuse, even on systems with an unreliable PRG and/or no clock.
+
+Non-goals:
+- Having multiple primitives serving the same purpose, even to provide compatibility with other libraries.
+- Networking -- but a simple key exchange API based on the Noise protocol is available, and a STROBE-based transport API will be implemented.
+- Interoperability with other libraries.
+- Replacing libsodium. Libhydrogen tries to keep the number of APIs and the code size down to a minimum.
+
+# [Libhydrogen documentation](https://github.com/jedisct1/libhydrogen/wiki)
+
+The documentation is maintained in the [libhydrogen wiki](https://github.com/jedisct1/libhydrogen/wiki).
+
+The legacy libhydrogen code (leveraging XChaCha20, SipHashX, BLAKE2SX, Curve25519) remains available in the [v0 branch](https://github.com/jedisct1/libhydrogen/tree/v0).
+
+## Contributors
+
+### Code Contributors
+
+This project exists thanks to all the people who contribute. [[Contribute](CONTRIBUTING.md)].
+<a href="https://github.com/jedisct1/libhydrogen/graphs/contributors"><img src="https://opencollective.com/libhydrogen/contributors.svg?width=890&button=false" /></a>

--- a/lib/libhydrogen/hydrogen.c
+++ b/lib/libhydrogen/hydrogen.c
@@ -1,0 +1,18 @@
+#include "hydrogen.h"
+
+#include "impl/common.h"
+#include "impl/hydrogen_p.h"
+
+#include "impl/core.h"
+#include "impl/gimli-core.h"
+#include "impl/random.h"
+
+#include "impl/hash.h"
+#include "impl/kdf.h"
+#include "impl/secretbox.h"
+
+#include "impl/x25519.h"
+
+#include "impl/kx.h"
+#include "impl/pwhash.h"
+#include "impl/sign.h"

--- a/lib/libhydrogen/hydrogen.h
+++ b/lib/libhydrogen/hydrogen.h
@@ -1,0 +1,315 @@
+#ifndef hydrogen_H
+#define hydrogen_H
+
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+#ifdef __cplusplus
+#ifdef __GNUC__
+#pragma GCC diagnostic ignored "-Wlong-long"
+#endif
+extern "C" {
+#endif
+
+#if defined(__clang__) || defined(__GNUC__)
+#define _hydro_attr_(X) __attribute__(X)
+#else
+#define _hydro_attr_(X)
+#endif
+#define _hydro_attr_deprecated_ _hydro_attr_((deprecated))
+#define _hydro_attr_malloc_ _hydro_attr_((malloc))
+#define _hydro_attr_noinline_ _hydro_attr_((noinline))
+#define _hydro_attr_noreturn_ _hydro_attr_((noreturn))
+#define _hydro_attr_warn_unused_result_ _hydro_attr_((warn_unused_result))
+#define _hydro_attr_weak_ _hydro_attr_((weak))
+
+#if defined(__INTEL_COMPILER) || defined(_MSC_VER)
+#define _hydro_attr_aligned_(X) __declspec(align(X))
+#elif defined(__clang__) || defined(__GNUC__)
+#define _hydro_attr_aligned_(X) _hydro_attr_((aligned(X)))
+#else
+#define _hydro_attr_aligned_(X)
+#endif
+
+#define HYDRO_VERSION_MAJOR 1
+#define HYDRO_VERSION_MINOR 0
+
+int hydro_init(void);
+
+/* ---------------- */
+
+#define hydro_random_SEEDBYTES 32
+
+uint32_t hydro_random_u32(void);
+
+uint32_t hydro_random_uniform(const uint32_t upper_bound);
+
+void hydro_random_buf(void *out, size_t out_len);
+
+void hydro_random_buf_deterministic(void *out, size_t out_len,
+                                    const uint8_t seed[hydro_random_SEEDBYTES]);
+
+void hydro_random_ratchet(void);
+
+void hydro_random_reseed(void);
+
+/* ---------------- */
+
+#define hydro_hash_BYTES 32
+#define hydro_hash_BYTES_MAX 65535
+#define hydro_hash_BYTES_MIN 16
+#define hydro_hash_CONTEXTBYTES 8
+#define hydro_hash_KEYBYTES 32
+
+typedef struct hydro_hash_state {
+    uint32_t state[12];
+    uint8_t  buf_off;
+    uint8_t  align[3];
+} hydro_hash_state;
+
+void hydro_hash_keygen(uint8_t key[hydro_hash_KEYBYTES]);
+
+int hydro_hash_init(hydro_hash_state *state, const char ctx[hydro_hash_CONTEXTBYTES],
+                    const uint8_t key[hydro_hash_KEYBYTES]);
+
+int hydro_hash_update(hydro_hash_state *state, const void *in_, size_t in_len);
+
+int hydro_hash_final(hydro_hash_state *state, uint8_t *out, size_t out_len);
+
+int hydro_hash_hash(uint8_t *out, size_t out_len, const void *in_, size_t in_len,
+                    const char    ctx[hydro_hash_CONTEXTBYTES],
+                    const uint8_t key[hydro_hash_KEYBYTES]);
+
+/* ---------------- */
+
+#define hydro_secretbox_CONTEXTBYTES 8
+#define hydro_secretbox_HEADERBYTES (20 + 16)
+#define hydro_secretbox_KEYBYTES 32
+#define hydro_secretbox_PROBEBYTES 16
+
+void hydro_secretbox_keygen(uint8_t key[hydro_secretbox_KEYBYTES]);
+
+int hydro_secretbox_encrypt(uint8_t *c, const void *m_, size_t mlen, uint64_t msg_id,
+                            const char    ctx[hydro_secretbox_CONTEXTBYTES],
+                            const uint8_t key[hydro_secretbox_KEYBYTES]);
+
+int hydro_secretbox_decrypt(void *m_, const uint8_t *c, size_t clen, uint64_t msg_id,
+                            const char    ctx[hydro_secretbox_CONTEXTBYTES],
+                            const uint8_t key[hydro_secretbox_KEYBYTES])
+    _hydro_attr_warn_unused_result_;
+
+void hydro_secretbox_probe_create(uint8_t probe[hydro_secretbox_PROBEBYTES], const uint8_t *c,
+                                  size_t c_len, const char ctx[hydro_secretbox_CONTEXTBYTES],
+                                  const uint8_t key[hydro_secretbox_KEYBYTES]);
+
+int hydro_secretbox_probe_verify(const uint8_t probe[hydro_secretbox_PROBEBYTES], const uint8_t *c,
+                                 size_t c_len, const char ctx[hydro_secretbox_CONTEXTBYTES],
+                                 const uint8_t key[hydro_secretbox_KEYBYTES])
+    _hydro_attr_warn_unused_result_;
+
+/* ---------------- */
+
+#define hydro_kdf_CONTEXTBYTES 8
+#define hydro_kdf_KEYBYTES 32
+#define hydro_kdf_BYTES_MAX 65535
+#define hydro_kdf_BYTES_MIN 16
+
+void hydro_kdf_keygen(uint8_t key[hydro_kdf_KEYBYTES]);
+
+int hydro_kdf_derive_from_key(uint8_t *subkey, size_t subkey_len, uint64_t subkey_id,
+                              const char    ctx[hydro_kdf_CONTEXTBYTES],
+                              const uint8_t key[hydro_kdf_KEYBYTES]);
+
+/* ---------------- */
+
+#define hydro_sign_BYTES 64
+#define hydro_sign_CONTEXTBYTES 8
+#define hydro_sign_PUBLICKEYBYTES 32
+#define hydro_sign_SECRETKEYBYTES 64
+#define hydro_sign_SEEDBYTES 32
+
+typedef struct hydro_sign_state {
+    hydro_hash_state hash_st;
+} hydro_sign_state;
+
+typedef struct hydro_sign_keypair {
+    uint8_t pk[hydro_sign_PUBLICKEYBYTES];
+    uint8_t sk[hydro_sign_SECRETKEYBYTES];
+} hydro_sign_keypair;
+
+void hydro_sign_keygen(hydro_sign_keypair *kp);
+
+void hydro_sign_keygen_deterministic(hydro_sign_keypair *kp,
+                                     const uint8_t       seed[hydro_sign_SEEDBYTES]);
+
+int hydro_sign_init(hydro_sign_state *state, const char ctx[hydro_sign_CONTEXTBYTES]);
+
+int hydro_sign_update(hydro_sign_state *state, const void *m_, size_t mlen);
+
+int hydro_sign_final_create(hydro_sign_state *state, uint8_t csig[hydro_sign_BYTES],
+                            const uint8_t sk[hydro_sign_SECRETKEYBYTES]);
+
+int hydro_sign_final_verify(hydro_sign_state *state, const uint8_t csig[hydro_sign_BYTES],
+                            const uint8_t pk[hydro_sign_PUBLICKEYBYTES])
+    _hydro_attr_warn_unused_result_;
+
+int hydro_sign_create(uint8_t csig[hydro_sign_BYTES], const void *m_, size_t mlen,
+                      const char    ctx[hydro_sign_CONTEXTBYTES],
+                      const uint8_t sk[hydro_sign_SECRETKEYBYTES]);
+
+int hydro_sign_verify(const uint8_t csig[hydro_sign_BYTES], const void *m_, size_t mlen,
+                      const char    ctx[hydro_sign_CONTEXTBYTES],
+                      const uint8_t pk[hydro_sign_PUBLICKEYBYTES]) _hydro_attr_warn_unused_result_;
+
+/* ---------------- */
+
+#define hydro_kx_SESSIONKEYBYTES 32
+#define hydro_kx_PUBLICKEYBYTES 32
+#define hydro_kx_SECRETKEYBYTES 32
+#define hydro_kx_PSKBYTES 32
+#define hydro_kx_SEEDBYTES 32
+
+typedef struct hydro_kx_keypair {
+    uint8_t pk[hydro_kx_PUBLICKEYBYTES];
+    uint8_t sk[hydro_kx_SECRETKEYBYTES];
+} hydro_kx_keypair;
+
+typedef struct hydro_kx_session_keypair {
+    uint8_t rx[hydro_kx_SESSIONKEYBYTES];
+    uint8_t tx[hydro_kx_SESSIONKEYBYTES];
+} hydro_kx_session_keypair;
+
+typedef struct hydro_kx_state {
+    hydro_kx_keypair eph_kp;
+    hydro_hash_state h_st;
+} hydro_kx_state;
+
+void hydro_kx_keygen(hydro_kx_keypair *static_kp);
+
+void hydro_kx_keygen_deterministic(hydro_kx_keypair *static_kp,
+                                   const uint8_t     seed[hydro_kx_SEEDBYTES]);
+
+/* NOISE_N */
+
+#define hydro_kx_N_PACKET1BYTES (32 + 16)
+
+int hydro_kx_n_1(hydro_kx_session_keypair *kp, uint8_t packet1[hydro_kx_N_PACKET1BYTES],
+                 const uint8_t psk[hydro_kx_PSKBYTES],
+                 const uint8_t peer_static_pk[hydro_kx_PUBLICKEYBYTES]);
+
+int hydro_kx_n_2(hydro_kx_session_keypair *kp, const uint8_t packet1[hydro_kx_N_PACKET1BYTES],
+                 const uint8_t psk[hydro_kx_PSKBYTES], const hydro_kx_keypair *static_kp);
+
+/* NOISE_KK */
+
+#define hydro_kx_KK_PACKET1BYTES (32 + 16)
+#define hydro_kx_KK_PACKET2BYTES (32 + 16)
+
+int hydro_kx_kk_1(hydro_kx_state *state, uint8_t packet1[hydro_kx_KK_PACKET1BYTES],
+                  const uint8_t           peer_static_pk[hydro_kx_PUBLICKEYBYTES],
+                  const hydro_kx_keypair *static_kp);
+
+int hydro_kx_kk_2(hydro_kx_session_keypair *kp, uint8_t packet2[hydro_kx_KK_PACKET2BYTES],
+                  const uint8_t           packet1[hydro_kx_KK_PACKET1BYTES],
+                  const uint8_t           peer_static_pk[hydro_kx_PUBLICKEYBYTES],
+                  const hydro_kx_keypair *static_kp);
+
+int hydro_kx_kk_3(hydro_kx_state *state, hydro_kx_session_keypair *kp,
+                  const uint8_t           packet2[hydro_kx_KK_PACKET2BYTES],
+                  const hydro_kx_keypair *static_kp);
+
+/* NOISE_XX */
+
+#define hydro_kx_XX_PACKET1BYTES (32 + 16)
+#define hydro_kx_XX_PACKET2BYTES (32 + 32 + 16 + 16)
+#define hydro_kx_XX_PACKET3BYTES (32 + 16 + 16)
+
+int hydro_kx_xx_1(hydro_kx_state *state, uint8_t packet1[hydro_kx_XX_PACKET1BYTES],
+                  const uint8_t psk[hydro_kx_PSKBYTES]);
+
+int hydro_kx_xx_2(hydro_kx_state *state, uint8_t packet2[hydro_kx_XX_PACKET2BYTES],
+                  const uint8_t packet1[hydro_kx_XX_PACKET1BYTES],
+                  const uint8_t psk[hydro_kx_PSKBYTES], const hydro_kx_keypair *static_kp);
+
+int hydro_kx_xx_3(hydro_kx_state *state, hydro_kx_session_keypair *kp,
+                  uint8_t       packet3[hydro_kx_XX_PACKET3BYTES],
+                  uint8_t       peer_static_pk[hydro_kx_PUBLICKEYBYTES],
+                  const uint8_t packet2[hydro_kx_XX_PACKET2BYTES],
+                  const uint8_t psk[hydro_kx_PSKBYTES], const hydro_kx_keypair *static_kp);
+
+int hydro_kx_xx_4(hydro_kx_state *state, hydro_kx_session_keypair *kp,
+                  uint8_t       peer_static_pk[hydro_kx_PUBLICKEYBYTES],
+                  const uint8_t packet3[hydro_kx_XX_PACKET3BYTES],
+                  const uint8_t psk[hydro_kx_PSKBYTES]);
+
+/* ---------------- */
+
+#define hydro_pwhash_CONTEXTBYTES 8
+#define hydro_pwhash_MASTERKEYBYTES 32
+#define hydro_pwhash_STOREDBYTES 128
+
+void hydro_pwhash_keygen(uint8_t master_key[hydro_pwhash_MASTERKEYBYTES]);
+
+int hydro_pwhash_deterministic(uint8_t *h, size_t h_len, const char *passwd, size_t passwd_len,
+                               const char    ctx[hydro_pwhash_CONTEXTBYTES],
+                               const uint8_t master_key[hydro_pwhash_MASTERKEYBYTES],
+                               uint64_t opslimit, size_t memlimit, uint8_t threads);
+
+int hydro_pwhash_create(uint8_t stored[hydro_pwhash_STOREDBYTES], const char *passwd,
+                        size_t passwd_len, const uint8_t master_key[hydro_pwhash_MASTERKEYBYTES],
+                        uint64_t opslimit, size_t memlimit, uint8_t threads);
+
+int hydro_pwhash_verify(const uint8_t stored[hydro_pwhash_STOREDBYTES], const char *passwd,
+                        size_t passwd_len, const uint8_t master_key[hydro_pwhash_MASTERKEYBYTES],
+                        uint64_t opslimit_max, size_t memlimit_max, uint8_t threads_max);
+
+int hydro_pwhash_derive_static_key(uint8_t *static_key, size_t static_key_len,
+                                   const uint8_t stored[hydro_pwhash_STOREDBYTES],
+                                   const char *passwd, size_t passwd_len,
+                                   const char    ctx[hydro_pwhash_CONTEXTBYTES],
+                                   const uint8_t master_key[hydro_pwhash_MASTERKEYBYTES],
+                                   uint64_t opslimit_max, size_t memlimit_max, uint8_t threads_max);
+
+int hydro_pwhash_reencrypt(uint8_t       stored[hydro_pwhash_STOREDBYTES],
+                           const uint8_t master_key[hydro_pwhash_MASTERKEYBYTES],
+                           const uint8_t new_master_key[hydro_pwhash_MASTERKEYBYTES]);
+
+int hydro_pwhash_upgrade(uint8_t       stored[hydro_pwhash_STOREDBYTES],
+                         const uint8_t master_key[hydro_pwhash_MASTERKEYBYTES], uint64_t opslimit,
+                         size_t memlimit, uint8_t threads);
+
+/* ---------------- */
+
+void hydro_memzero(void *pnt, size_t len);
+
+void hydro_increment(uint8_t *n, size_t len);
+
+bool hydro_equal(const void *b1_, const void *b2_, size_t len);
+
+int hydro_compare(const uint8_t *b1_, const uint8_t *b2_, size_t len);
+
+char *hydro_bin2hex(char *hex, size_t hex_maxlen, const uint8_t *bin, size_t bin_len);
+
+int hydro_hex2bin(uint8_t *bin, size_t bin_maxlen, const char *hex, size_t hex_len,
+                  const char *ignore, const char **hex_end_p);
+
+int hydro_pad(unsigned char *buf, size_t unpadded_buflen, size_t blocksize, size_t max_buflen);
+
+int hydro_unpad(const unsigned char *buf, size_t padded_buflen, size_t blocksize);
+
+/* ---------------- */
+
+#define HYDRO_HWTYPE_ATMEGA328 1
+
+#ifndef HYDRO_HWTYPE
+#ifdef __AVR__
+#define HYDRO_HWTYPE HYDRO_HWTYPE_ATMEGA328
+#endif
+#endif
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/lib/libhydrogen/impl/common.h
+++ b/lib/libhydrogen/impl/common.h
@@ -1,0 +1,321 @@
+#include <errno.h>
+#include <limits.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
+
+#if !defined(__unix__) && (defined(__APPLE__) || defined(__linux__))
+#define __unix__ 1
+#endif
+#ifndef __GNUC__
+#define __restrict__
+#endif
+
+#if defined(__BYTE_ORDER__) && defined(__ORDER_BIG_ENDIAN__) && \
+    __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
+#define NATIVE_BIG_ENDIAN
+#endif
+#ifndef NATIVE_BIG_ENDIAN
+#ifndef NATIVE_LITTLE_ENDIAN
+#define NATIVE_LITTLE_ENDIAN
+#endif
+#endif
+
+#ifndef TLS
+#if defined(_WIN32) && !defined(__GNUC__)
+#define TLS __declspec(thread)
+#elif (defined(__clang__) || defined(__GNUC__)) && defined(__unix__)
+#define TLS __thread
+#else
+#define TLS
+#endif
+#endif
+
+#ifndef SIZE_MAX
+#define SIZE_MAX ((size_t) -1)
+#endif
+
+#ifdef __OpenBSD__
+#define HAVE_EXPLICIT_BZERO 1
+#elif defined(__GLIBC__) && defined(__GLIBC_PREREQ) && defined(_GNU_SOURCE)
+#if __GLIBC_PREREQ(2, 25)
+#define HAVE_EXPLICIT_BZERO 1
+#endif
+#endif
+
+#define COMPILER_ASSERT(X) (void) sizeof(char[(X) ? 1 : -1])
+
+#define ROTL32(x, b) (uint32_t)(((x) << (b)) | ((x) >> (32 - (b))))
+#define ROTL64(x, b) (uint64_t)(((x) << (b)) | ((x) >> (64 - (b))))
+#define ROTR32(x, b) (uint32_t)(((x) >> (b)) | ((x) << (32 - (b))))
+#define ROTR64(x, b) (uint64_t)(((x) >> (b)) | ((x) << (64 - (b))))
+
+#define LOAD64_LE(SRC) load64_le(SRC)
+static inline uint64_t
+load64_le(const uint8_t src[8])
+{
+#ifdef NATIVE_LITTLE_ENDIAN
+    uint64_t w;
+    memcpy(&w, src, sizeof w);
+    return w;
+#else
+    uint64_t w = (uint64_t) src[0];
+    w |= (uint64_t) src[1] << 8;
+    w |= (uint64_t) src[2] << 16;
+    w |= (uint64_t) src[3] << 24;
+    w |= (uint64_t) src[4] << 32;
+    w |= (uint64_t) src[5] << 40;
+    w |= (uint64_t) src[6] << 48;
+    w |= (uint64_t) src[7] << 56;
+    return w;
+#endif
+}
+
+#define STORE64_LE(DST, W) store64_le((DST), (W))
+static inline void
+store64_le(uint8_t dst[8], uint64_t w)
+{
+#ifdef NATIVE_LITTLE_ENDIAN
+    memcpy(dst, &w, sizeof w);
+#else
+    dst[0] = (uint8_t) w;
+    w >>= 8;
+    dst[1] = (uint8_t) w;
+    w >>= 8;
+    dst[2] = (uint8_t) w;
+    w >>= 8;
+    dst[3] = (uint8_t) w;
+    w >>= 8;
+    dst[4] = (uint8_t) w;
+    w >>= 8;
+    dst[5] = (uint8_t) w;
+    w >>= 8;
+    dst[6] = (uint8_t) w;
+    w >>= 8;
+    dst[7]     = (uint8_t) w;
+#endif
+}
+
+#define LOAD32_LE(SRC) load32_le(SRC)
+static inline uint32_t
+load32_le(const uint8_t src[4])
+{
+#ifdef NATIVE_LITTLE_ENDIAN
+    uint32_t w;
+    memcpy(&w, src, sizeof w);
+    return w;
+#else
+    uint32_t w = (uint32_t) src[0];
+    w |= (uint32_t) src[1] << 8;
+    w |= (uint32_t) src[2] << 16;
+    w |= (uint32_t) src[3] << 24;
+    return w;
+#endif
+}
+
+#define STORE32_LE(DST, W) store32_le((DST), (W))
+static inline void
+store32_le(uint8_t dst[4], uint32_t w)
+{
+#ifdef NATIVE_LITTLE_ENDIAN
+    memcpy(dst, &w, sizeof w);
+#else
+    dst[0] = (uint8_t) w;
+    w >>= 8;
+    dst[1] = (uint8_t) w;
+    w >>= 8;
+    dst[2] = (uint8_t) w;
+    w >>= 8;
+    dst[3]     = (uint8_t) w;
+#endif
+}
+
+#define LOAD16_LE(SRC) load16_le(SRC)
+static inline uint16_t
+load16_le(const uint8_t src[2])
+{
+#ifdef NATIVE_LITTLE_ENDIAN
+    uint16_t w;
+    memcpy(&w, src, sizeof w);
+    return w;
+#else
+    uint16_t w = (uint16_t) src[0];
+    w |= (uint16_t) src[1] << 8;
+    return w;
+#endif
+}
+
+#define STORE16_LE(DST, W) store16_le((DST), (W))
+static inline void
+store16_le(uint8_t dst[2], uint16_t w)
+{
+#ifdef NATIVE_LITTLE_ENDIAN
+    memcpy(dst, &w, sizeof w);
+#else
+    dst[0] = (uint8_t) w;
+    w >>= 8;
+    dst[1]     = (uint8_t) w;
+#endif
+}
+
+/* ----- */
+
+#define LOAD64_BE(SRC) load64_be(SRC)
+static inline uint64_t
+load64_be(const uint8_t src[8])
+{
+#ifdef NATIVE_BIG_ENDIAN
+    uint64_t w;
+    memcpy(&w, src, sizeof w);
+    return w;
+#else
+    uint64_t w = (uint64_t) src[7];
+    w |= (uint64_t) src[6] << 8;
+    w |= (uint64_t) src[5] << 16;
+    w |= (uint64_t) src[4] << 24;
+    w |= (uint64_t) src[3] << 32;
+    w |= (uint64_t) src[2] << 40;
+    w |= (uint64_t) src[1] << 48;
+    w |= (uint64_t) src[0] << 56;
+    return w;
+#endif
+}
+
+#define STORE64_BE(DST, W) store64_be((DST), (W))
+static inline void
+store64_be(uint8_t dst[8], uint64_t w)
+{
+#ifdef NATIVE_BIG_ENDIAN
+    memcpy(dst, &w, sizeof w);
+#else
+    dst[7] = (uint8_t) w;
+    w >>= 8;
+    dst[6] = (uint8_t) w;
+    w >>= 8;
+    dst[5] = (uint8_t) w;
+    w >>= 8;
+    dst[4] = (uint8_t) w;
+    w >>= 8;
+    dst[3] = (uint8_t) w;
+    w >>= 8;
+    dst[2] = (uint8_t) w;
+    w >>= 8;
+    dst[1] = (uint8_t) w;
+    w >>= 8;
+    dst[0]     = (uint8_t) w;
+#endif
+}
+
+#define LOAD32_BE(SRC) load32_be(SRC)
+static inline uint32_t
+load32_be(const uint8_t src[4])
+{
+#ifdef NATIVE_BIG_ENDIAN
+    uint32_t w;
+    memcpy(&w, src, sizeof w);
+    return w;
+#else
+    uint32_t w = (uint32_t) src[3];
+    w |= (uint32_t) src[2] << 8;
+    w |= (uint32_t) src[1] << 16;
+    w |= (uint32_t) src[0] << 24;
+    return w;
+#endif
+}
+
+#define STORE32_BE(DST, W) store32_be((DST), (W))
+static inline void
+store32_be(uint8_t dst[4], uint32_t w)
+{
+#ifdef NATIVE_BIG_ENDIAN
+    memcpy(dst, &w, sizeof w);
+#else
+    dst[3] = (uint8_t) w;
+    w >>= 8;
+    dst[2] = (uint8_t) w;
+    w >>= 8;
+    dst[1] = (uint8_t) w;
+    w >>= 8;
+    dst[0]     = (uint8_t) w;
+#endif
+}
+
+#define LOAD16_BE(SRC) load16_be(SRC)
+static inline uint16_t
+load16_be(const uint8_t src[2])
+{
+#ifdef NATIVE_BIG_ENDIAN
+    uint16_t w;
+    memcpy(&w, src, sizeof w);
+    return w;
+#else
+    uint16_t w = (uint16_t) src[1];
+    w |= (uint16_t) src[0] << 8;
+    return w;
+#endif
+}
+
+#define STORE16_BE(DST, W) store16_be((DST), (W))
+static inline void
+store16_be(uint8_t dst[2], uint16_t w)
+{
+#ifdef NATIVE_BIG_ENDIAN
+    memcpy(dst, &w, sizeof w);
+#else
+    dst[1] = (uint8_t) w;
+    w >>= 8;
+    dst[0] = (uint8_t) w;
+#endif
+}
+
+static inline void
+mem_cpy(void *__restrict__ dst_, const void *__restrict__ src_, size_t n)
+{
+    unsigned char *      dst = (unsigned char *) dst_;
+    const unsigned char *src = (const unsigned char *) src_;
+    size_t               i;
+
+    for (i = 0; i < n; i++) {
+        dst[i] = src[i];
+    }
+}
+
+static inline void
+mem_zero(void *dst_, size_t n)
+{
+    unsigned char *dst = (unsigned char *) dst_;
+    size_t         i;
+
+    for (i = 0; i < n; i++) {
+        dst[i] = 0;
+    }
+}
+
+static inline void
+mem_xor(void *__restrict__ dst_, const void *__restrict__ src_, size_t n)
+{
+    unsigned char *      dst = (unsigned char *) dst_;
+    const unsigned char *src = (const unsigned char *) src_;
+    size_t               i;
+
+    for (i = 0; i < n; i++) {
+        dst[i] ^= src[i];
+    }
+}
+
+static inline void
+mem_xor2(void *__restrict__ dst_, const void *__restrict__ src1_, const void *__restrict__ src2_,
+         size_t n)
+{
+    unsigned char *      dst  = (unsigned char *) dst_;
+    const unsigned char *src1 = (const unsigned char *) src1_;
+    const unsigned char *src2 = (const unsigned char *) src2_;
+    size_t               i;
+
+    for (i = 0; i < n; i++) {
+        dst[i] = src1[i] ^ src2[i];
+    }
+}
+
+static const uint8_t zero[64] = { 0 };

--- a/lib/libhydrogen/impl/core.h
+++ b/lib/libhydrogen/impl/core.h
@@ -1,0 +1,223 @@
+int
+hydro_init(void)
+{
+    if (hydro_random_init() != 0) {
+        abort();
+    }
+    return 0;
+}
+
+void
+hydro_memzero(void *pnt, size_t len)
+{
+#ifdef HAVE_EXPLICIT_BZERO
+    explicit_bzero(pnt, len);
+#else
+    volatile unsigned char *volatile pnt_ = (volatile unsigned char *volatile) pnt;
+    size_t i                              = (size_t) 0U;
+
+    while (i < len) {
+        pnt_[i++] = 0U;
+    }
+#endif
+}
+
+void
+hydro_increment(uint8_t *n, size_t len)
+{
+    size_t        i;
+    uint_fast16_t c = 1U;
+
+    for (i = 0; i < len; i++) {
+        c += (uint_fast16_t) n[i];
+        n[i] = (uint8_t) c;
+        c >>= 8;
+    }
+}
+
+char *
+hydro_bin2hex(char *hex, size_t hex_maxlen, const uint8_t *bin, size_t bin_len)
+{
+    size_t       i = (size_t) 0U;
+    unsigned int x;
+    int          b;
+    int          c;
+
+    if (bin_len >= SIZE_MAX / 2 || hex_maxlen <= bin_len * 2U) {
+        abort();
+    }
+    while (i < bin_len) {
+        c = bin[i] & 0xf;
+        b = bin[i] >> 4;
+        x = (unsigned char) (87U + c + (((c - 10U) >> 8) & ~38U)) << 8 |
+            (unsigned char) (87U + b + (((b - 10U) >> 8) & ~38U));
+        hex[i * 2U] = (char) x;
+        x >>= 8;
+        hex[i * 2U + 1U] = (char) x;
+        i++;
+    }
+    hex[i * 2U] = 0U;
+
+    return hex;
+}
+
+int
+hydro_hex2bin(uint8_t *bin, size_t bin_maxlen, const char *hex, size_t hex_len, const char *ignore,
+              const char **hex_end_p)
+{
+    size_t        bin_pos = (size_t) 0U;
+    size_t        hex_pos = (size_t) 0U;
+    int           ret     = 0;
+    unsigned char c;
+    unsigned char c_alpha0, c_alpha;
+    unsigned char c_num0, c_num;
+    uint8_t       c_acc = 0U;
+    uint8_t       c_val;
+    unsigned char state = 0U;
+
+    while (hex_pos < hex_len) {
+        c        = (unsigned char) hex[hex_pos];
+        c_num    = c ^ 48U;
+        c_num0   = (c_num - 10U) >> 8;
+        c_alpha  = (c & ~32U) - 55U;
+        c_alpha0 = ((c_alpha - 10U) ^ (c_alpha - 16U)) >> 8;
+        if ((c_num0 | c_alpha0) == 0U) {
+            if (ignore != NULL && state == 0U && strchr(ignore, c) != NULL) {
+                hex_pos++;
+                continue;
+            }
+            break;
+        }
+        c_val = (uint8_t)((c_num0 & c_num) | (c_alpha0 & c_alpha));
+        if (bin_pos >= bin_maxlen) {
+            ret   = -1;
+            errno = ERANGE;
+            break;
+        }
+        if (state == 0U) {
+            c_acc = c_val * 16U;
+        } else {
+            bin[bin_pos++] = c_acc | c_val;
+        }
+        state = ~state;
+        hex_pos++;
+    }
+    if (state != 0U) {
+        hex_pos--;
+        errno = EINVAL;
+        ret   = -1;
+    }
+    if (ret != 0) {
+        bin_pos = (size_t) 0U;
+    }
+    if (hex_end_p != NULL) {
+        *hex_end_p = &hex[hex_pos];
+    } else if (hex_pos != hex_len) {
+        errno = EINVAL;
+        ret   = -1;
+    }
+    if (ret != 0) {
+        return ret;
+    }
+    return (int) bin_pos;
+}
+
+bool
+hydro_equal(const void *b1_, const void *b2_, size_t len)
+{
+    const volatile uint8_t *volatile b1 = (const volatile uint8_t *volatile) b1_;
+    const uint8_t *b2                   = (const uint8_t *) b2_;
+    size_t         i;
+    uint8_t        d = (uint8_t) 0U;
+
+    if (b1 == b2) {
+        d = ~d;
+    }
+    for (i = 0U; i < len; i++) {
+        d |= b1[i] ^ b2[i];
+    }
+    return (bool) (1 & ((d - 1) >> 8));
+}
+
+int
+hydro_compare(const uint8_t *b1_, const uint8_t *b2_, size_t len)
+{
+    const volatile uint8_t *volatile b1 = (const volatile uint8_t *volatile) b1_;
+    const uint8_t *b2                   = (const uint8_t *) b2_;
+    uint8_t        gt                   = 0U;
+    uint8_t        eq                   = 1U;
+    size_t         i;
+
+    i = len;
+    while (i != 0U) {
+        i--;
+        gt |= ((b2[i] - b1[i]) >> 8) & eq;
+        eq &= ((b2[i] ^ b1[i]) - 1) >> 8;
+    }
+    return (int) (gt + gt + eq) - 1;
+}
+
+int
+hydro_pad(unsigned char *buf, size_t unpadded_buflen, size_t blocksize, size_t max_buflen)
+{
+    unsigned char *        tail;
+    size_t                 i;
+    size_t                 xpadlen;
+    size_t                 xpadded_len;
+    volatile unsigned char mask;
+    unsigned char          barrier_mask;
+
+    if (blocksize <= 0U || max_buflen > INT_MAX) {
+        return -1;
+    }
+    xpadlen = blocksize - 1U;
+    if ((blocksize & (blocksize - 1U)) == 0U) {
+        xpadlen -= unpadded_buflen & (blocksize - 1U);
+    } else {
+        xpadlen -= unpadded_buflen % blocksize;
+    }
+    if (SIZE_MAX - unpadded_buflen <= xpadlen) {
+        return -1;
+    }
+    xpadded_len = unpadded_buflen + xpadlen;
+    if (xpadded_len >= max_buflen) {
+        return -1;
+    }
+    tail = &buf[xpadded_len];
+    mask = 0U;
+    for (i = 0; i < blocksize; i++) {
+        barrier_mask = (unsigned char) (((i ^ xpadlen) - 1U) >> ((sizeof(size_t) - 1U) * CHAR_BIT));
+        tail[-i]     = (tail[-i] & mask) | (0x80 & barrier_mask);
+        mask |= barrier_mask;
+    }
+    return (int) (xpadded_len + 1);
+}
+
+int
+hydro_unpad(const unsigned char *buf, size_t padded_buflen, size_t blocksize)
+{
+    const unsigned char *tail;
+    unsigned char        acc = 0U;
+    unsigned char        c;
+    unsigned char        valid   = 0U;
+    volatile size_t      pad_len = 0U;
+    size_t               i;
+    size_t               is_barrier;
+
+    if (padded_buflen < blocksize || blocksize <= 0U) {
+        return -1;
+    }
+    tail = &buf[padded_buflen - 1U];
+
+    for (i = 0U; i < blocksize; i++) {
+        c          = tail[-i];
+        is_barrier = (((acc - 1U) & (pad_len - 1U) & ((c ^ 0x80) - 1U)) >> 8) & 1U;
+        acc |= c;
+        pad_len |= (i & -is_barrier);
+        valid |= (unsigned char) is_barrier;
+    }
+    if (valid == 0) {
+        return -1;
+    }
+    return (int) (padded_buflen - 1 - pad_len);
+}

--- a/lib/libhydrogen/impl/gimli-core.h
+++ b/lib/libhydrogen/impl/gimli-core.h
@@ -1,0 +1,25 @@
+#ifdef __SSE2__
+#include "gimli-core/sse2.h"
+#else
+#include "gimli-core/portable.h"
+#endif
+
+static void
+gimli_core_u8(uint8_t state_u8[gimli_BLOCKBYTES], uint8_t tag)
+{
+    state_u8[gimli_BLOCKBYTES - 1] ^= tag;
+#ifndef NATIVE_LITTLE_ENDIAN
+    uint32_t state_u32[12];
+    int      i;
+
+    for (i = 0; i < 12; i++) {
+        state_u32[i] = LOAD32_LE(&state_u8[i * 4]);
+    }
+    gimli_core(state_u32);
+    for (i = 0; i < 12; i++) {
+        STORE32_LE(&state_u8[i * 4], state_u32[i]);
+    }
+#else
+    gimli_core((uint32_t *) (void *) state_u8); /* state_u8 must be properly aligned */
+#endif
+}

--- a/lib/libhydrogen/impl/gimli-core/portable.h
+++ b/lib/libhydrogen/impl/gimli-core/portable.h
@@ -1,0 +1,39 @@
+static void
+gimli_core(uint32_t state[gimli_BLOCKBYTES / 4])
+{
+    unsigned int round;
+    unsigned int column;
+    uint32_t     x;
+    uint32_t     y;
+    uint32_t     z;
+
+    for (round = 24; round > 0; round--) {
+        for (column = 0; column < 4; column++) {
+            x = ROTL32(state[column], 24);
+            y = ROTL32(state[4 + column], 9);
+            z = state[8 + column];
+
+            state[8 + column] = x ^ (z << 1) ^ ((y & z) << 2);
+            state[4 + column] = y ^ x ^ ((x | z) << 1);
+            state[column]     = z ^ y ^ ((x & y) << 3);
+        }
+        switch (round & 3) {
+        case 0:
+            x        = state[0];
+            state[0] = state[1];
+            state[1] = x;
+            x        = state[2];
+            state[2] = state[3];
+            state[3] = x;
+            state[0] ^= ((uint32_t) 0x9e377900 | round);
+            break;
+        case 2:
+            x        = state[0];
+            state[0] = state[2];
+            state[2] = x;
+            x        = state[1];
+            state[1] = state[3];
+            state[3] = x;
+        }
+    }
+}

--- a/lib/libhydrogen/impl/gimli-core/sse2.h
+++ b/lib/libhydrogen/impl/gimli-core/sse2.h
@@ -1,0 +1,97 @@
+#include <tmmintrin.h>
+
+#define S 9
+
+static inline __m128i
+shift(__m128i x, int bits)
+{
+    return _mm_slli_epi32(x, bits);
+}
+
+static inline __m128i
+rotate(__m128i x, int bits)
+{
+    return _mm_slli_epi32(x, bits) | _mm_srli_epi32(x, 32 - bits);
+}
+
+#ifdef __SSSE3__
+static inline __m128i
+rotate24(__m128i x)
+{
+    return _mm_shuffle_epi8(x, _mm_set_epi8(12, 15, 14, 13, 8, 11, 10, 9, 4, 7, 6, 5, 0, 3, 2, 1));
+}
+#else
+static inline __m128i
+rotate24(__m128i x)
+{
+    uint8_t _hydro_attr_aligned_(16) x8[16], y8[16];
+
+    _mm_storeu_si128((__m128i *) (void *) x8, x);
+
+    y8[ 0] = x8[ 1]; y8[ 1] = x8[ 2]; y8[ 2] = x8[ 3]; y8[ 3] = x8[ 0];
+    y8[ 4] = x8[ 5]; y8[ 5] = x8[ 6]; y8[ 6] = x8[ 7]; y8[ 7] = x8[ 4];
+    y8[ 8] = x8[ 9]; y8[ 9] = x8[10]; y8[10] = x8[11]; y8[11] = x8[ 8];
+    y8[12] = x8[13]; y8[13] = x8[14]; y8[14] = x8[15]; y8[15] = x8[12];
+
+    return _mm_loadu_si128((const __m128i *) (const void *) y8);
+}
+#endif
+
+static const uint32_t coeffs[24] _hydro_attr_aligned_(16) = {
+    0x9e377904, 0, 0, 0, 0x9e377908, 0, 0, 0, 0x9e37790c, 0, 0, 0,
+    0x9e377910, 0, 0, 0, 0x9e377914, 0, 0, 0, 0x9e377918, 0, 0, 0,
+};
+
+static void
+gimli_core(uint32_t state[gimli_BLOCKBYTES / 4])
+{
+    __m128i x = _mm_loadu_si128((const __m128i *) (const void *) &state[0]);
+    __m128i y = _mm_loadu_si128((const __m128i *) (const void *) &state[4]);
+    __m128i z = _mm_loadu_si128((const __m128i *) (const void *) &state[8]);
+    __m128i newy;
+    __m128i newz;
+    int     round;
+
+    for (round = 5; round >= 0; round--) {
+        x    = rotate24(x);
+        y    = rotate(y, S);
+        newz = x ^ shift(z, 1) ^ shift(y & z, 2);
+        newy = y ^ x ^ shift(x | z, 1);
+        x    = z ^ y ^ shift(x & y, 3);
+        y    = newy;
+        z    = newz;
+
+        x = _mm_shuffle_epi32(x, _MM_SHUFFLE(2, 3, 0, 1));
+        x ^= ((const __m128i *) (const void *) coeffs)[round];
+
+        x    = rotate24(x);
+        y    = rotate(y, S);
+        newz = x ^ shift(z, 1) ^ shift(y & z, 2);
+        newy = y ^ x ^ shift(x | z, 1);
+        x    = z ^ y ^ shift(x & y, 3);
+        y    = newy;
+        z    = newz;
+
+        x    = rotate24(x);
+        y    = rotate(y, S);
+        newz = x ^ shift(z, 1) ^ shift(y & z, 2);
+        newy = y ^ x ^ shift(x | z, 1);
+        x    = z ^ y ^ shift(x & y, 3);
+        y    = newy;
+        z    = newz;
+
+        x = _mm_shuffle_epi32(x, _MM_SHUFFLE(1, 0, 3, 2));
+
+        x    = rotate24(x);
+        y    = rotate(y, S);
+        newz = x ^ shift(z, 1) ^ shift(y & z, 2);
+        newy = y ^ x ^ shift(x | z, 1);
+        x    = z ^ y ^ shift(x & y, 3);
+        y    = newy;
+        z    = newz;
+    }
+
+    _mm_storeu_si128((__m128i *) (void *) &state[0], x);
+    _mm_storeu_si128((__m128i *) (void *) &state[4], y);
+    _mm_storeu_si128((__m128i *) (void *) &state[8], z);
+}

--- a/lib/libhydrogen/impl/hash.h
+++ b/lib/libhydrogen/impl/hash.h
@@ -1,0 +1,140 @@
+int
+hydro_hash_update(hydro_hash_state *state, const void *in_, size_t in_len)
+{
+    const uint8_t *in  = (const uint8_t *) in_;
+    uint8_t *      buf = (uint8_t *) (void *) state->state;
+    size_t         left;
+    size_t         ps;
+    size_t         i;
+
+    while (in_len > 0) {
+        left = gimli_RATE - state->buf_off;
+        if ((ps = in_len) > left) {
+            ps = left;
+        }
+        for (i = 0; i < ps; i++) {
+            buf[state->buf_off + i] ^= in[i];
+        }
+        in += ps;
+        in_len -= ps;
+        state->buf_off += (uint8_t) ps;
+        if (state->buf_off == gimli_RATE) {
+            gimli_core_u8(buf, 0);
+            state->buf_off = 0;
+        }
+    }
+    return 0;
+}
+
+/* pad(str_enc("kmac") || str_enc(context)) || pad(str_enc(k)) ||
+   msg || right_enc(msg_len) || 0x00 */
+
+int
+hydro_hash_init(hydro_hash_state *state, const char ctx[hydro_hash_CONTEXTBYTES],
+                const uint8_t key[hydro_hash_KEYBYTES])
+{
+    uint8_t block[64] = { 4, 'k', 'm', 'a', 'c', 8 };
+    size_t  p;
+
+    COMPILER_ASSERT(hydro_hash_KEYBYTES <= sizeof block - gimli_RATE - 1);
+    COMPILER_ASSERT(hydro_hash_CONTEXTBYTES == 8);
+    mem_zero(block + 14, sizeof block - 14);
+    memcpy(block + 6, ctx, 8);
+    if (key != NULL) {
+        block[gimli_RATE] = (uint8_t) hydro_hash_KEYBYTES;
+        memcpy(block + gimli_RATE + 1, key, hydro_hash_KEYBYTES);
+        p = (gimli_RATE + 1 + hydro_hash_KEYBYTES + (gimli_RATE - 1)) & ~(size_t)(gimli_RATE - 1);
+    } else {
+        block[gimli_RATE] = (uint8_t) 0;
+        p                 = (gimli_RATE + 1 + 0 + (gimli_RATE - 1)) & ~(size_t)(gimli_RATE - 1);
+    }
+    mem_zero(state, sizeof *state);
+    hydro_hash_update(state, block, p);
+
+    return 0;
+}
+
+/* pad(str_enc("tmac") || str_enc(context)) || pad(str_enc(k)) ||
+   pad(right_enc(tweak)) || msg || right_enc(msg_len) || 0x00 */
+
+static int
+hydro_hash_init_with_tweak(hydro_hash_state *state, const char ctx[hydro_hash_CONTEXTBYTES],
+                           uint64_t tweak, const uint8_t key[hydro_hash_KEYBYTES])
+{
+    uint8_t block[80] = { 4, 't', 'm', 'a', 'c', 8 };
+    size_t  p;
+
+    COMPILER_ASSERT(hydro_hash_KEYBYTES <= sizeof block - 2 * gimli_RATE - 1);
+    COMPILER_ASSERT(hydro_hash_CONTEXTBYTES == 8);
+    mem_zero(block + 14, sizeof block - 14);
+    memcpy(block + 6, ctx, 8);
+    if (key != NULL) {
+        block[gimli_RATE] = (uint8_t) hydro_hash_KEYBYTES;
+        memcpy(block + gimli_RATE + 1, key, hydro_hash_KEYBYTES);
+        p = (gimli_RATE + 1 + hydro_hash_KEYBYTES + (gimli_RATE - 1)) & ~(size_t)(gimli_RATE - 1);
+    } else {
+        block[gimli_RATE] = (uint8_t) 0;
+        p                 = (gimli_RATE + 1 + 0 + (gimli_RATE - 1)) & ~(size_t)(gimli_RATE - 1);
+    }
+    block[p] = (uint8_t) sizeof tweak;
+    STORE64_LE(&block[p + 1], tweak);
+    p += gimli_RATE;
+    mem_zero(state, sizeof *state);
+    hydro_hash_update(state, block, p);
+
+    return 0;
+}
+
+int
+hydro_hash_final(hydro_hash_state *state, uint8_t *out, size_t out_len)
+{
+    uint8_t  lc[4];
+    uint8_t *buf = (uint8_t *) (void *) state->state;
+    size_t   i;
+    size_t   lc_len;
+    size_t   leftover;
+
+    if (out_len < hydro_hash_BYTES_MIN || out_len > hydro_hash_BYTES_MAX) {
+        return -1;
+    }
+    COMPILER_ASSERT(hydro_hash_BYTES_MAX <= 0xffff);
+    lc[1]  = (uint8_t) out_len;
+    lc[2]  = (uint8_t)(out_len >> 8);
+    lc[3]  = 0;
+    lc_len = (size_t)(1 + (lc[2] != 0));
+    lc[0]  = (uint8_t) lc_len;
+    hydro_hash_update(state, lc, 1 + lc_len + 1);
+    gimli_pad_u8(buf, state->buf_off, gimli_DOMAIN_XOF);
+    for (i = 0; i < out_len / gimli_RATE; i++) {
+        gimli_core_u8(buf, 0);
+        memcpy(out + i * gimli_RATE, buf, gimli_RATE);
+    }
+    leftover = out_len % gimli_RATE;
+    if (leftover != 0) {
+        gimli_core_u8(buf, 0);
+        mem_cpy(out + i * gimli_RATE, buf, leftover);
+    }
+    state->buf_off = gimli_RATE;
+
+    return 0;
+}
+
+int
+hydro_hash_hash(uint8_t *out, size_t out_len, const void *in_, size_t in_len,
+                const char ctx[hydro_hash_CONTEXTBYTES], const uint8_t key[hydro_hash_KEYBYTES])
+{
+    hydro_hash_state st;
+    const uint8_t *  in = (const uint8_t *) in_;
+
+    if (hydro_hash_init(&st, ctx, key) != 0 || hydro_hash_update(&st, in, in_len) != 0 ||
+        hydro_hash_final(&st, out, out_len) != 0) {
+        return -1;
+    }
+    return 0;
+}
+
+void
+hydro_hash_keygen(uint8_t key[hydro_hash_KEYBYTES])
+{
+    hydro_random_buf(key, hydro_hash_KEYBYTES);
+}

--- a/lib/libhydrogen/impl/hydrogen_p.h
+++ b/lib/libhydrogen/impl/hydrogen_p.h
@@ -1,0 +1,83 @@
+static int hydro_random_init(void);
+
+/* ---------------- */
+
+#define gimli_BLOCKBYTES 48
+#define gimli_CAPACITY 32
+#define gimli_RATE 16
+
+#define gimli_TAG_HEADER 0x01
+#define gimli_TAG_PAYLOAD 0x02
+#define gimli_TAG_FINAL 0x08
+#define gimli_TAG_FINAL0 0xf8
+#define gimli_TAG_KEY0 0xfe
+#define gimli_TAG_KEY 0xff
+
+#define gimli_DOMAIN_AEAD 0x0
+#define gimli_DOMAIN_XOF 0xf
+
+static void gimli_core_u8(uint8_t state_u8[gimli_BLOCKBYTES], uint8_t tag);
+
+static inline void
+gimli_pad_u8(uint8_t buf[gimli_BLOCKBYTES], size_t pos, uint8_t domain)
+{
+    buf[pos] ^= (domain << 1) | 1;
+    buf[gimli_RATE - 1] ^= 0x80;
+}
+
+static inline void
+hydro_mem_ct_zero_u32(uint32_t *dst_, size_t n)
+{
+    volatile uint32_t *volatile dst = (volatile uint32_t * volatile)(void *) dst_;
+    size_t i;
+
+    for (i = 0; i < n; i++) {
+        dst[i] = 0;
+    }
+}
+
+static inline uint32_t hydro_mem_ct_cmp_u32(const uint32_t *b1_, const uint32_t *b2,
+                                            size_t n) _hydro_attr_warn_unused_result_;
+
+static inline uint32_t
+hydro_mem_ct_cmp_u32(const uint32_t *b1_, const uint32_t *b2, size_t n)
+{
+    const volatile uint32_t *volatile b1 = (const volatile uint32_t *volatile)(const void *) b1_;
+    size_t   i;
+    uint32_t cv = 0;
+
+    for (i = 0; i < n; i++) {
+        cv |= b1[i] ^ b2[i];
+    }
+    return cv;
+}
+
+/* ---------------- */
+
+static int hydro_hash_init_with_tweak(hydro_hash_state *state,
+                                      const char ctx[hydro_hash_CONTEXTBYTES], uint64_t tweak,
+                                      const uint8_t key[hydro_hash_KEYBYTES]);
+
+/* ---------------- */
+
+#define hydro_secretbox_NONCEBYTES 20
+#define hydro_secretbox_MACBYTES 16
+
+/* ---------------- */
+
+#define hydro_x25519_BYTES 32
+#define hydro_x25519_PUBLICKEYBYTES 32
+#define hydro_x25519_SECRETKEYBYTES 32
+
+static int hydro_x25519_scalarmult(uint8_t       out[hydro_x25519_BYTES],
+                                   const uint8_t scalar[hydro_x25519_SECRETKEYBYTES],
+                                   const uint8_t x1[hydro_x25519_PUBLICKEYBYTES],
+                                   bool          clamp) _hydro_attr_warn_unused_result_;
+
+static inline int hydro_x25519_scalarmult_base(uint8_t       pk[hydro_x25519_PUBLICKEYBYTES],
+                                               const uint8_t sk[hydro_x25519_SECRETKEYBYTES])
+    _hydro_attr_warn_unused_result_;
+
+static inline void
+hydro_x25519_scalarmult_base_uniform(uint8_t       pk[hydro_x25519_PUBLICKEYBYTES],
+                                     const uint8_t sk[hydro_x25519_SECRETKEYBYTES]);

--- a/lib/libhydrogen/impl/kdf.h
+++ b/lib/libhydrogen/impl/kdf.h
@@ -1,0 +1,20 @@
+int
+hydro_kdf_derive_from_key(uint8_t *subkey, size_t subkey_len, uint64_t subkey_id,
+                          const char    ctx[hydro_kdf_CONTEXTBYTES],
+                          const uint8_t key[hydro_kdf_KEYBYTES])
+{
+    hydro_hash_state st;
+
+    COMPILER_ASSERT(hydro_kdf_CONTEXTBYTES >= hydro_hash_CONTEXTBYTES);
+    COMPILER_ASSERT(hydro_kdf_KEYBYTES >= hydro_hash_KEYBYTES);
+    if (hydro_hash_init_with_tweak(&st, ctx, subkey_id, key) != 0) {
+        return -1;
+    }
+    return hydro_hash_final(&st, subkey, subkey_len);
+}
+
+void
+hydro_kdf_keygen(uint8_t key[hydro_kdf_KEYBYTES])
+{
+    hydro_random_buf(key, hydro_kdf_KEYBYTES);
+}

--- a/lib/libhydrogen/impl/kx.h
+++ b/lib/libhydrogen/impl/kx.h
@@ -1,0 +1,456 @@
+#define hydro_kx_AEAD_KEYBYTES hydro_hash_KEYBYTES
+#define hydro_kx_AEAD_MACBYTES 16
+
+#define hydro_kx_CONTEXT "hydro_kx"
+
+static void
+hydro_kx_aead_init(uint8_t aead_state[gimli_BLOCKBYTES], uint8_t k[hydro_kx_AEAD_KEYBYTES],
+                   hydro_kx_state *state)
+{
+    static const uint8_t prefix[] = { 6, 'k', 'x', 'x', '2', '5', '6', 0 };
+
+    hydro_hash_final(&state->h_st, k, hydro_kx_AEAD_KEYBYTES);
+
+    mem_zero(aead_state + sizeof prefix, gimli_BLOCKBYTES - sizeof prefix);
+    memcpy(aead_state, prefix, sizeof prefix);
+    gimli_core_u8(aead_state, gimli_TAG_HEADER);
+
+    COMPILER_ASSERT(hydro_kx_AEAD_KEYBYTES == 2 * gimli_RATE);
+    mem_xor(aead_state, k, gimli_RATE);
+    gimli_core_u8(aead_state, gimli_TAG_KEY);
+    mem_xor(aead_state, k + gimli_RATE, gimli_RATE);
+    gimli_core_u8(aead_state, gimli_TAG_KEY);
+}
+
+static void
+hydro_kx_aead_final(uint8_t *aead_state, const uint8_t key[hydro_kx_AEAD_KEYBYTES])
+{
+    COMPILER_ASSERT(hydro_kx_AEAD_KEYBYTES == gimli_CAPACITY);
+    mem_xor(aead_state + gimli_RATE, key, hydro_kx_AEAD_KEYBYTES);
+    gimli_core_u8(aead_state, gimli_TAG_FINAL);
+    mem_xor(aead_state + gimli_RATE, key, hydro_kx_AEAD_KEYBYTES);
+    gimli_core_u8(aead_state, gimli_TAG_FINAL);
+}
+
+static void
+hydro_kx_aead_xor_enc(uint8_t aead_state[gimli_BLOCKBYTES], uint8_t *out, const uint8_t *in,
+                      size_t inlen)
+{
+    size_t i;
+    size_t leftover;
+
+    for (i = 0; i < inlen / gimli_RATE; i++) {
+        mem_xor2(&out[i * gimli_RATE], &in[i * gimli_RATE], aead_state, gimli_RATE);
+        memcpy(aead_state, &out[i * gimli_RATE], gimli_RATE);
+        gimli_core_u8(aead_state, gimli_TAG_PAYLOAD);
+    }
+    leftover = inlen % gimli_RATE;
+    if (leftover != 0) {
+        mem_xor2(&out[i * gimli_RATE], &in[i * gimli_RATE], aead_state, leftover);
+        mem_cpy(aead_state, &out[i * gimli_RATE], leftover);
+    }
+    gimli_pad_u8(aead_state, leftover, gimli_DOMAIN_AEAD);
+    gimli_core_u8(aead_state, gimli_TAG_PAYLOAD);
+}
+
+static void
+hydro_kx_aead_xor_dec(uint8_t aead_state[gimli_BLOCKBYTES], uint8_t *out, const uint8_t *in,
+                      size_t inlen)
+{
+    size_t i;
+    size_t leftover;
+
+    for (i = 0; i < inlen / gimli_RATE; i++) {
+        mem_xor2(&out[i * gimli_RATE], &in[i * gimli_RATE], aead_state, gimli_RATE);
+        memcpy(aead_state, &in[i * gimli_RATE], gimli_RATE);
+        gimli_core_u8(aead_state, gimli_TAG_PAYLOAD);
+    }
+    leftover = inlen % gimli_RATE;
+    if (leftover != 0) {
+        mem_xor2(&out[i * gimli_RATE], &in[i * gimli_RATE], aead_state, leftover);
+        mem_cpy(aead_state, &in[i * gimli_RATE], leftover);
+    }
+    gimli_pad_u8(aead_state, leftover, gimli_DOMAIN_AEAD);
+    gimli_core_u8(aead_state, gimli_TAG_PAYLOAD);
+}
+
+static void
+hydro_kx_aead_encrypt(hydro_kx_state *state, uint8_t *c, const uint8_t *m, size_t mlen)
+{
+    _hydro_attr_aligned_(16) uint8_t aead_state[gimli_BLOCKBYTES];
+    uint8_t                          k[hydro_kx_AEAD_KEYBYTES];
+    uint8_t *                        mac = &c[0];
+    uint8_t *                        ct  = &c[hydro_kx_AEAD_MACBYTES];
+
+    hydro_kx_aead_init(aead_state, k, state);
+    hydro_kx_aead_xor_enc(aead_state, ct, m, mlen);
+    hydro_kx_aead_final(aead_state, k);
+    COMPILER_ASSERT(hydro_kx_AEAD_MACBYTES <= gimli_CAPACITY);
+    memcpy(mac, aead_state + gimli_RATE, hydro_kx_AEAD_MACBYTES);
+    hydro_hash_update(&state->h_st, c, mlen + hydro_kx_AEAD_MACBYTES);
+}
+
+static int hydro_kx_aead_decrypt(hydro_kx_state *state, uint8_t *m, const uint8_t *c,
+                                 size_t clen) _hydro_attr_warn_unused_result_;
+
+static int
+hydro_kx_aead_decrypt(hydro_kx_state *state, uint8_t *m, const uint8_t *c, size_t clen)
+{
+    _hydro_attr_aligned_(16) uint32_t int_state[gimli_BLOCKBYTES / 4];
+    uint32_t                          pub_mac[hydro_kx_AEAD_MACBYTES / 4];
+    uint8_t                           k[hydro_kx_AEAD_KEYBYTES];
+    uint8_t *                         aead_state = (uint8_t *) (void *) int_state;
+    const uint8_t *                   mac;
+    const uint8_t *                   ct;
+    size_t                            mlen;
+    uint32_t                          cv;
+
+    if (clen < hydro_kx_AEAD_MACBYTES) {
+        return -1;
+    }
+    mac  = &c[0];
+    ct   = &c[hydro_kx_AEAD_MACBYTES];
+    mlen = clen - hydro_kx_AEAD_MACBYTES;
+    memcpy(pub_mac, mac, sizeof pub_mac);
+    hydro_kx_aead_init(aead_state, k, state);
+    hydro_hash_update(&state->h_st, c, clen);
+    hydro_kx_aead_xor_dec(aead_state, m, ct, mlen);
+    hydro_kx_aead_final(aead_state, k);
+    COMPILER_ASSERT(hydro_kx_AEAD_MACBYTES <= gimli_CAPACITY);
+    COMPILER_ASSERT(gimli_RATE % 4 == 0);
+    cv = hydro_mem_ct_cmp_u32(int_state + gimli_RATE / 4, pub_mac, hydro_kx_AEAD_MACBYTES / 4);
+    hydro_mem_ct_zero_u32(int_state, gimli_BLOCKBYTES / 4);
+    if (cv != 0) {
+        mem_zero(m, mlen);
+        return -1;
+    }
+    return 0;
+}
+
+/* -- */
+
+void
+hydro_kx_keygen(hydro_kx_keypair *static_kp)
+{
+    hydro_random_buf(static_kp->sk, hydro_kx_SECRETKEYBYTES);
+    if (hydro_x25519_scalarmult_base(static_kp->pk, static_kp->sk) != 0) {
+        abort();
+    }
+}
+
+void
+hydro_kx_keygen_deterministic(hydro_kx_keypair *static_kp, const uint8_t seed[hydro_kx_SEEDBYTES])
+{
+    COMPILER_ASSERT(hydro_kx_SEEDBYTES >= hydro_random_SEEDBYTES);
+    hydro_random_buf_deterministic(static_kp->sk, hydro_kx_SECRETKEYBYTES, seed);
+    if (hydro_x25519_scalarmult_base(static_kp->pk, static_kp->sk) != 0) {
+        abort();
+    }
+}
+
+static void
+hydro_kx_init_state(hydro_kx_state *state, const char *name)
+{
+    mem_zero(state, sizeof *state);
+    hydro_hash_init(&state->h_st, hydro_kx_CONTEXT, NULL);
+    hydro_hash_update(&state->h_st, name, strlen(name));
+    hydro_hash_final(&state->h_st, NULL, 0);
+}
+
+static void
+hydro_kx_final(hydro_kx_state *state, uint8_t session_k1[hydro_kx_SESSIONKEYBYTES],
+               uint8_t session_k2[hydro_kx_SESSIONKEYBYTES])
+{
+    uint8_t kdf_key[hydro_kdf_KEYBYTES];
+
+    hydro_hash_final(&state->h_st, kdf_key, sizeof kdf_key);
+    hydro_kdf_derive_from_key(session_k1, hydro_kx_SESSIONKEYBYTES, 0, hydro_kx_CONTEXT, kdf_key);
+    hydro_kdf_derive_from_key(session_k2, hydro_kx_SESSIONKEYBYTES, 1, hydro_kx_CONTEXT, kdf_key);
+}
+
+static int
+hydro_kx_dh(hydro_kx_state *state, const uint8_t sk[hydro_x25519_SECRETKEYBYTES],
+            const uint8_t pk[hydro_x25519_PUBLICKEYBYTES])
+{
+    uint8_t dh_result[hydro_x25519_BYTES];
+
+    if (hydro_x25519_scalarmult(dh_result, sk, pk, 1) != 0) {
+        return -1;
+    }
+    hydro_hash_update(&state->h_st, dh_result, hydro_x25519_BYTES);
+
+    return 0;
+}
+
+static void
+hydro_kx_eph_keygen(hydro_kx_state *state, hydro_kx_keypair *kp)
+{
+    hydro_kx_keygen(kp);
+    hydro_hash_update(&state->h_st, kp->pk, sizeof kp->pk);
+}
+
+/* NOISE_N */
+
+int
+hydro_kx_n_1(hydro_kx_session_keypair *kp, uint8_t packet1[hydro_kx_N_PACKET1BYTES],
+             const uint8_t psk[hydro_kx_PSKBYTES],
+             const uint8_t peer_static_pk[hydro_kx_PUBLICKEYBYTES])
+{
+    hydro_kx_state state;
+    uint8_t *      packet1_eph_pk = &packet1[0];
+    uint8_t *      packet1_mac    = &packet1[hydro_kx_PUBLICKEYBYTES];
+
+    if (psk == NULL) {
+        psk = zero;
+    }
+    hydro_kx_init_state(&state, "Noise_Npsk0_hydro1");
+    hydro_hash_update(&state.h_st, peer_static_pk, hydro_x25519_PUBLICKEYBYTES);
+
+    hydro_hash_update(&state.h_st, psk, hydro_kx_PSKBYTES);
+    hydro_kx_eph_keygen(&state, &state.eph_kp);
+    if (hydro_kx_dh(&state, state.eph_kp.sk, peer_static_pk) != 0) {
+        return -1;
+    }
+    hydro_kx_aead_encrypt(&state, packet1_mac, NULL, 0);
+    memcpy(packet1_eph_pk, state.eph_kp.pk, sizeof state.eph_kp.pk);
+
+    hydro_kx_final(&state, kp->rx, kp->tx);
+
+    return 0;
+}
+
+int
+hydro_kx_n_2(hydro_kx_session_keypair *kp, const uint8_t packet1[hydro_kx_N_PACKET1BYTES],
+             const uint8_t psk[hydro_kx_PSKBYTES], const hydro_kx_keypair *static_kp)
+{
+    hydro_kx_state state;
+    const uint8_t *peer_eph_pk = &packet1[0];
+    const uint8_t *packet1_mac = &packet1[hydro_kx_PUBLICKEYBYTES];
+
+    if (psk == NULL) {
+        psk = zero;
+    }
+    hydro_kx_init_state(&state, "Noise_Npsk0_hydro1");
+    hydro_hash_update(&state.h_st, static_kp->pk, hydro_kx_PUBLICKEYBYTES);
+
+    hydro_hash_update(&state.h_st, psk, hydro_kx_PSKBYTES);
+    hydro_hash_update(&state.h_st, peer_eph_pk, hydro_x25519_PUBLICKEYBYTES);
+    if (hydro_kx_dh(&state, static_kp->sk, peer_eph_pk) != 0 ||
+        hydro_kx_aead_decrypt(&state, NULL, packet1_mac, hydro_kx_AEAD_MACBYTES) != 0) {
+        return -1;
+    }
+    hydro_kx_final(&state, kp->tx, kp->rx);
+
+    return 0;
+}
+
+/* NOISE_KK */
+
+int
+hydro_kx_kk_1(hydro_kx_state *state, uint8_t packet1[hydro_kx_KK_PACKET1BYTES],
+              const uint8_t           peer_static_pk[hydro_kx_PUBLICKEYBYTES],
+              const hydro_kx_keypair *static_kp)
+{
+    uint8_t *packet1_eph_pk = &packet1[0];
+    uint8_t *packet1_mac    = &packet1[hydro_kx_PUBLICKEYBYTES];
+
+    hydro_kx_init_state(state, "Noise_KK_hydro1");
+    hydro_hash_update(&state->h_st, static_kp->pk, hydro_kx_PUBLICKEYBYTES);
+    hydro_hash_update(&state->h_st, peer_static_pk, hydro_kx_PUBLICKEYBYTES);
+
+    hydro_kx_eph_keygen(state, &state->eph_kp);
+    if (hydro_kx_dh(state, state->eph_kp.sk, peer_static_pk) != 0 ||
+        hydro_kx_dh(state, static_kp->sk, peer_static_pk) != 0) {
+        return -1;
+    }
+    hydro_kx_aead_encrypt(state, packet1_mac, NULL, 0);
+    memcpy(packet1_eph_pk, state->eph_kp.pk, sizeof state->eph_kp.pk);
+
+    return 0;
+}
+
+int
+hydro_kx_kk_2(hydro_kx_session_keypair *kp, uint8_t packet2[hydro_kx_KK_PACKET2BYTES],
+              const uint8_t           packet1[hydro_kx_KK_PACKET1BYTES],
+              const uint8_t           peer_static_pk[hydro_kx_PUBLICKEYBYTES],
+              const hydro_kx_keypair *static_kp)
+{
+    hydro_kx_state state;
+    const uint8_t *peer_eph_pk    = &packet1[0];
+    const uint8_t *packet1_mac    = &packet1[hydro_kx_PUBLICKEYBYTES];
+    uint8_t *      packet2_eph_pk = &packet2[0];
+    uint8_t *      packet2_mac    = &packet2[hydro_kx_PUBLICKEYBYTES];
+
+    hydro_kx_init_state(&state, "Noise_KK_hydro1");
+    hydro_hash_update(&state.h_st, peer_static_pk, hydro_kx_PUBLICKEYBYTES);
+    hydro_hash_update(&state.h_st, static_kp->pk, hydro_kx_PUBLICKEYBYTES);
+
+    hydro_hash_update(&state.h_st, peer_eph_pk, hydro_kx_PUBLICKEYBYTES);
+    if (hydro_kx_dh(&state, static_kp->sk, peer_eph_pk) != 0 ||
+        hydro_kx_dh(&state, static_kp->sk, peer_static_pk) != 0 ||
+        hydro_kx_aead_decrypt(&state, NULL, packet1_mac, hydro_kx_AEAD_MACBYTES) != 0) {
+        return -1;
+    }
+
+    hydro_kx_eph_keygen(&state, &state.eph_kp);
+    if (hydro_kx_dh(&state, state.eph_kp.sk, peer_eph_pk) != 0 ||
+        hydro_kx_dh(&state, state.eph_kp.sk, peer_static_pk) != 0) {
+        return -1;
+    }
+    hydro_kx_aead_encrypt(&state, packet2_mac, NULL, 0);
+    hydro_kx_final(&state, kp->tx, kp->rx);
+    memcpy(packet2_eph_pk, state.eph_kp.pk, sizeof state.eph_kp.pk);
+
+    return 0;
+}
+
+int
+hydro_kx_kk_3(hydro_kx_state *state, hydro_kx_session_keypair *kp,
+              const uint8_t packet2[hydro_kx_KK_PACKET2BYTES], const hydro_kx_keypair *static_kp)
+{
+    const uint8_t *peer_eph_pk = packet2;
+    const uint8_t *packet2_mac = &packet2[hydro_kx_PUBLICKEYBYTES];
+
+    hydro_hash_update(&state->h_st, peer_eph_pk, hydro_kx_PUBLICKEYBYTES);
+    if (hydro_kx_dh(state, state->eph_kp.sk, peer_eph_pk) != 0 ||
+        hydro_kx_dh(state, static_kp->sk, peer_eph_pk) != 0) {
+        return -1;
+    }
+
+    if (hydro_kx_aead_decrypt(state, NULL, packet2_mac, hydro_kx_AEAD_MACBYTES) != 0) {
+        return -1;
+    }
+    hydro_kx_final(state, kp->rx, kp->tx);
+
+    return 0;
+}
+
+/* NOISE_XX */
+
+int
+hydro_kx_xx_1(hydro_kx_state *state, uint8_t packet1[hydro_kx_XX_PACKET1BYTES],
+              const uint8_t psk[hydro_kx_PSKBYTES])
+{
+    uint8_t *packet1_eph_pk = &packet1[0];
+    uint8_t *packet1_mac    = &packet1[hydro_kx_PUBLICKEYBYTES];
+
+    if (psk == NULL) {
+        psk = zero;
+    }
+    hydro_kx_init_state(state, "Noise_XXpsk0+psk3_hydro1");
+
+    hydro_kx_eph_keygen(state, &state->eph_kp);
+    hydro_hash_update(&state->h_st, psk, hydro_kx_PSKBYTES);
+    memcpy(packet1_eph_pk, state->eph_kp.pk, sizeof state->eph_kp.pk);
+    hydro_kx_aead_encrypt(state, packet1_mac, NULL, 0);
+
+    return 0;
+}
+
+int
+hydro_kx_xx_2(hydro_kx_state *state, uint8_t packet2[hydro_kx_XX_PACKET2BYTES],
+              const uint8_t packet1[hydro_kx_XX_PACKET1BYTES], const uint8_t psk[hydro_kx_PSKBYTES],
+              const hydro_kx_keypair *static_kp)
+{
+    const uint8_t *peer_eph_pk           = &packet1[0];
+    const uint8_t *packet1_mac           = &packet1[hydro_kx_PUBLICKEYBYTES];
+    uint8_t *      packet2_eph_pk        = &packet2[0];
+    uint8_t *      packet2_enc_static_pk = &packet2[hydro_kx_PUBLICKEYBYTES];
+    uint8_t *      packet2_mac =
+        &packet2[hydro_kx_PUBLICKEYBYTES + hydro_kx_PUBLICKEYBYTES + hydro_kx_AEAD_MACBYTES];
+
+    if (psk == NULL) {
+        psk = zero;
+    }
+    hydro_kx_init_state(state, "Noise_XXpsk0+psk3_hydro1");
+
+    hydro_hash_update(&state->h_st, peer_eph_pk, hydro_kx_PUBLICKEYBYTES);
+    hydro_hash_update(&state->h_st, psk, hydro_kx_PSKBYTES);
+    if (hydro_kx_aead_decrypt(state, NULL, packet1_mac, hydro_kx_AEAD_MACBYTES) != 0) {
+        return -1;
+    }
+
+    hydro_kx_eph_keygen(state, &state->eph_kp);
+    if (hydro_kx_dh(state, state->eph_kp.sk, peer_eph_pk) != 0) {
+        return -1;
+    }
+    hydro_kx_aead_encrypt(state, packet2_enc_static_pk, static_kp->pk, sizeof static_kp->pk);
+    if (hydro_kx_dh(state, static_kp->sk, peer_eph_pk) != 0) {
+        return -1;
+    }
+    hydro_kx_aead_encrypt(state, packet2_mac, NULL, 0);
+
+    memcpy(packet2_eph_pk, state->eph_kp.pk, sizeof state->eph_kp.pk);
+
+    return 0;
+}
+
+int
+hydro_kx_xx_3(hydro_kx_state *state, hydro_kx_session_keypair *kp,
+              uint8_t       packet3[hydro_kx_XX_PACKET3BYTES],
+              uint8_t       peer_static_pk[hydro_kx_PUBLICKEYBYTES],
+              const uint8_t packet2[hydro_kx_XX_PACKET2BYTES], const uint8_t psk[hydro_kx_PSKBYTES],
+              const hydro_kx_keypair *static_kp)
+{
+    uint8_t        peer_static_pk_[hydro_kx_PUBLICKEYBYTES];
+    const uint8_t *peer_eph_pk        = &packet2[0];
+    const uint8_t *peer_enc_static_pk = &packet2[hydro_kx_PUBLICKEYBYTES];
+    const uint8_t *packet2_mac =
+        &packet2[hydro_kx_PUBLICKEYBYTES + hydro_kx_PUBLICKEYBYTES + hydro_kx_AEAD_MACBYTES];
+    uint8_t *packet3_enc_static_pk = &packet3[0];
+    uint8_t *packet3_mac           = &packet3[hydro_kx_PUBLICKEYBYTES + hydro_kx_AEAD_MACBYTES];
+
+    if (psk == NULL) {
+        psk = zero;
+    }
+    if (peer_static_pk == NULL) {
+        peer_static_pk = peer_static_pk_;
+    }
+    hydro_hash_update(&state->h_st, peer_eph_pk, hydro_kx_PUBLICKEYBYTES);
+    if (hydro_kx_dh(state, state->eph_kp.sk, peer_eph_pk) != 0 ||
+        hydro_kx_aead_decrypt(state, peer_static_pk, peer_enc_static_pk,
+                              hydro_kx_PUBLICKEYBYTES + hydro_kx_AEAD_MACBYTES) != 0 ||
+        hydro_kx_dh(state, state->eph_kp.sk, peer_static_pk) != 0 ||
+        hydro_kx_aead_decrypt(state, NULL, packet2_mac, hydro_kx_AEAD_MACBYTES) != 0) {
+        return -1;
+    }
+
+    hydro_kx_aead_encrypt(state, packet3_enc_static_pk, static_kp->pk, sizeof static_kp->pk);
+    if (hydro_kx_dh(state, static_kp->sk, peer_eph_pk) != 0) {
+        return -1;
+    }
+    hydro_hash_update(&state->h_st, psk, hydro_kx_PSKBYTES);
+    hydro_kx_aead_encrypt(state, packet3_mac, NULL, 0);
+    hydro_kx_final(state, kp->rx, kp->tx);
+
+    return 0;
+}
+
+int
+hydro_kx_xx_4(hydro_kx_state *state, hydro_kx_session_keypair *kp,
+              uint8_t       peer_static_pk[hydro_kx_PUBLICKEYBYTES],
+              const uint8_t packet3[hydro_kx_XX_PACKET3BYTES], const uint8_t psk[hydro_kx_PSKBYTES])
+{
+    uint8_t        peer_static_pk_[hydro_kx_PUBLICKEYBYTES];
+    const uint8_t *peer_enc_static_pk = &packet3[0];
+    const uint8_t *packet3_mac        = &packet3[hydro_kx_PUBLICKEYBYTES + hydro_kx_AEAD_MACBYTES];
+
+    if (psk == NULL) {
+        psk = zero;
+    }
+    if (peer_static_pk == NULL) {
+        peer_static_pk = peer_static_pk_;
+    }
+    if (hydro_kx_aead_decrypt(state, peer_static_pk, peer_enc_static_pk,
+                              hydro_kx_PUBLICKEYBYTES + hydro_kx_AEAD_MACBYTES) != 0 ||
+        hydro_kx_dh(state, state->eph_kp.sk, peer_static_pk) != 0) {
+        return -1;
+    }
+    hydro_hash_update(&state->h_st, psk, hydro_kx_PSKBYTES);
+    if (hydro_kx_aead_decrypt(state, NULL, packet3_mac, hydro_kx_AEAD_MACBYTES) != 0) {
+        return -1;
+    }
+    hydro_kx_final(state, kp->tx, kp->rx);
+
+    return 0;
+}

--- a/lib/libhydrogen/impl/pwhash.h
+++ b/lib/libhydrogen/impl/pwhash.h
@@ -1,0 +1,281 @@
+#define hydro_pwhash_ENC_ALGBYTES 1
+#define hydro_pwhash_HASH_ALGBYTES 1
+#define hydro_pwhash_THREADSBYTES 1
+#define hydro_pwhash_OPSLIMITBYTES 8
+#define hydro_pwhash_MEMLIMITBYTES 8
+#define hydro_pwhash_HASHBYTES 32
+#define hydro_pwhash_SALTBYTES 16
+#define hydro_pwhash_PARAMSBYTES                                                           \
+    (hydro_pwhash_HASH_ALGBYTES + hydro_pwhash_THREADSBYTES + hydro_pwhash_OPSLIMITBYTES + \
+     hydro_pwhash_MEMLIMITBYTES + hydro_pwhash_SALTBYTES + hydro_pwhash_HASHBYTES)
+#define hydro_pwhash_ENC_ALG 0x01
+#define hydro_pwhash_HASH_ALG 0x01
+#define hydro_pwhash_CONTEXT "hydro_pw"
+
+static int
+_hydro_pwhash_hash(uint8_t out[hydro_random_SEEDBYTES], size_t h_len,
+                   const uint8_t salt[hydro_pwhash_SALTBYTES], const char *passwd,
+                   size_t passwd_len, const char ctx[hydro_pwhash_CONTEXTBYTES],
+                   const uint8_t master_key[hydro_pwhash_MASTERKEYBYTES], uint64_t opslimit,
+                   size_t memlimit, uint8_t threads)
+{
+    _hydro_attr_aligned_(16) uint8_t state[gimli_BLOCKBYTES];
+    hydro_hash_state                 h_st;
+    uint8_t                          tmp64_u8[8];
+    uint64_t                         i;
+    uint8_t                          tmp8;
+
+    COMPILER_ASSERT(hydro_pwhash_MASTERKEYBYTES >= hydro_hash_KEYBYTES);
+    hydro_hash_init(&h_st, ctx, master_key);
+
+    STORE64_LE(tmp64_u8, (uint64_t) passwd_len);
+    hydro_hash_update(&h_st, tmp64_u8, sizeof tmp64_u8);
+    hydro_hash_update(&h_st, passwd, passwd_len);
+
+    hydro_hash_update(&h_st, salt, hydro_pwhash_SALTBYTES);
+
+    tmp8 = hydro_pwhash_HASH_ALG;
+    hydro_hash_update(&h_st, &tmp8, 1);
+
+    hydro_hash_update(&h_st, &threads, 1);
+
+    STORE64_LE(tmp64_u8, (uint64_t) memlimit);
+    hydro_hash_update(&h_st, tmp64_u8, sizeof tmp64_u8);
+
+    STORE64_LE(tmp64_u8, (uint64_t) h_len);
+    hydro_hash_update(&h_st, tmp64_u8, sizeof tmp64_u8);
+
+    hydro_hash_final(&h_st, (uint8_t *) (void *) &state, sizeof state);
+
+    gimli_core_u8(state, 1);
+    COMPILER_ASSERT(gimli_RATE >= 8);
+    for (i = 0; i < opslimit; i++) {
+        mem_zero(state, gimli_RATE);
+        STORE64_LE(state, i);
+        gimli_core_u8(state, 0);
+    }
+    mem_zero(state, gimli_RATE);
+
+    COMPILER_ASSERT(hydro_random_SEEDBYTES == gimli_CAPACITY);
+    memcpy(out, state + gimli_RATE, hydro_random_SEEDBYTES);
+    hydro_memzero(state, sizeof state);
+
+    return 0;
+}
+
+void
+hydro_pwhash_keygen(uint8_t master_key[hydro_pwhash_MASTERKEYBYTES])
+{
+    hydro_random_buf(master_key, hydro_pwhash_MASTERKEYBYTES);
+}
+
+int
+hydro_pwhash_deterministic(uint8_t *h, size_t h_len, const char *passwd, size_t passwd_len,
+                           const char    ctx[hydro_pwhash_CONTEXTBYTES],
+                           const uint8_t master_key[hydro_pwhash_MASTERKEYBYTES], uint64_t opslimit,
+                           size_t memlimit, uint8_t threads)
+{
+    uint8_t seed[hydro_random_SEEDBYTES];
+
+    COMPILER_ASSERT(sizeof zero >= hydro_pwhash_SALTBYTES);
+    COMPILER_ASSERT(sizeof zero >= hydro_pwhash_MASTERKEYBYTES);
+
+    (void) memlimit;
+    if (_hydro_pwhash_hash(seed, h_len, zero, passwd, passwd_len, ctx, master_key, opslimit,
+                           memlimit, threads) != 0) {
+        return -1;
+    }
+    hydro_random_buf_deterministic(h, h_len, seed);
+    hydro_memzero(seed, sizeof seed);
+
+    return 0;
+}
+
+int
+hydro_pwhash_create(uint8_t stored[hydro_pwhash_STOREDBYTES], const char *passwd, size_t passwd_len,
+                    const uint8_t master_key[hydro_pwhash_MASTERKEYBYTES], uint64_t opslimit,
+                    size_t memlimit, uint8_t threads)
+{
+    uint8_t *const enc_alg     = &stored[0];
+    uint8_t *const secretbox   = &enc_alg[hydro_pwhash_ENC_ALGBYTES];
+    uint8_t *const hash_alg    = &secretbox[hydro_secretbox_HEADERBYTES];
+    uint8_t *const threads_u8  = &hash_alg[hydro_pwhash_HASH_ALGBYTES];
+    uint8_t *const opslimit_u8 = &threads_u8[hydro_pwhash_THREADSBYTES];
+    uint8_t *const memlimit_u8 = &opslimit_u8[hydro_pwhash_OPSLIMITBYTES];
+    uint8_t *const salt        = &memlimit_u8[hydro_pwhash_MEMLIMITBYTES];
+    uint8_t *const h           = &salt[hydro_pwhash_SALTBYTES];
+
+    COMPILER_ASSERT(hydro_pwhash_STOREDBYTES >= hydro_pwhash_ENC_ALGBYTES +
+                                                    hydro_secretbox_HEADERBYTES +
+                                                    hydro_pwhash_PARAMSBYTES);
+    (void) memlimit;
+    mem_zero(stored, hydro_pwhash_STOREDBYTES);
+    *enc_alg    = hydro_pwhash_ENC_ALG;
+    *hash_alg   = hydro_pwhash_HASH_ALG;
+    *threads_u8 = threads;
+    STORE64_LE(opslimit_u8, opslimit);
+    STORE64_LE(memlimit_u8, (uint64_t) memlimit);
+    hydro_random_buf(salt, hydro_pwhash_SALTBYTES);
+
+    COMPILER_ASSERT(sizeof zero >= hydro_pwhash_MASTERKEYBYTES);
+    if (_hydro_pwhash_hash(h, hydro_pwhash_HASHBYTES, salt, passwd, passwd_len,
+                           hydro_pwhash_CONTEXT, zero, opslimit, memlimit, threads) != 0) {
+        return -1;
+    }
+    COMPILER_ASSERT(hydro_pwhash_MASTERKEYBYTES == hydro_secretbox_KEYBYTES);
+
+    return hydro_secretbox_encrypt(secretbox, hash_alg, hydro_pwhash_PARAMSBYTES,
+                                   (uint64_t) *enc_alg, hydro_pwhash_CONTEXT, master_key);
+}
+
+static int
+_hydro_pwhash_verify(uint8_t       computed_h[hydro_pwhash_HASHBYTES],
+                     const uint8_t stored[hydro_pwhash_STOREDBYTES], const char *passwd,
+                     size_t passwd_len, const uint8_t master_key[hydro_pwhash_MASTERKEYBYTES],
+                     uint64_t opslimit_max, size_t memlimit_max, uint8_t threads_max)
+{
+    const uint8_t *const enc_alg   = &stored[0];
+    const uint8_t *const secretbox = &enc_alg[hydro_pwhash_ENC_ALGBYTES];
+
+    uint8_t        params[hydro_pwhash_PARAMSBYTES];
+    uint8_t *const hash_alg    = &params[0];
+    uint8_t *const threads_u8  = &hash_alg[hydro_pwhash_HASH_ALGBYTES];
+    uint8_t *const opslimit_u8 = &threads_u8[hydro_pwhash_THREADSBYTES];
+    uint8_t *const memlimit_u8 = &opslimit_u8[hydro_pwhash_OPSLIMITBYTES];
+    uint8_t *const salt        = &memlimit_u8[hydro_pwhash_MEMLIMITBYTES];
+    uint8_t *const h           = &salt[hydro_pwhash_SALTBYTES];
+
+    uint64_t opslimit;
+    size_t   memlimit;
+    uint8_t  threads;
+
+    (void) memlimit;
+    if (*enc_alg != hydro_pwhash_ENC_ALG) {
+        return -1;
+    }
+    if (hydro_secretbox_decrypt(params, secretbox,
+                                hydro_secretbox_HEADERBYTES + hydro_pwhash_PARAMSBYTES,
+                                (uint64_t) *enc_alg, hydro_pwhash_CONTEXT, master_key) != 0) {
+        return -1;
+    }
+    if (*hash_alg != hydro_pwhash_HASH_ALG || (opslimit = LOAD64_LE(opslimit_u8)) > opslimit_max ||
+        (memlimit = (size_t) LOAD64_LE(memlimit_u8)) > memlimit_max ||
+        (threads = *threads_u8) > threads_max) {
+        return -1;
+    }
+    if (_hydro_pwhash_hash(computed_h, hydro_pwhash_HASHBYTES, salt, passwd, passwd_len,
+                           hydro_pwhash_CONTEXT, zero, opslimit, memlimit, threads) == 0 &&
+        hydro_equal(computed_h, h, hydro_pwhash_HASHBYTES) == 1) {
+        return 0;
+    }
+    return -1;
+}
+
+int
+hydro_pwhash_verify(const uint8_t stored[hydro_pwhash_STOREDBYTES], const char *passwd,
+                    size_t passwd_len, const uint8_t master_key[hydro_pwhash_MASTERKEYBYTES],
+                    uint64_t opslimit_max, size_t memlimit_max, uint8_t threads_max)
+{
+    uint8_t computed_h[hydro_pwhash_HASHBYTES];
+    int     ret;
+
+    ret = _hydro_pwhash_verify(computed_h, stored, passwd, passwd_len, master_key, opslimit_max,
+                               memlimit_max, threads_max);
+    hydro_memzero(computed_h, sizeof computed_h);
+
+    return ret;
+}
+
+int
+hydro_pwhash_derive_static_key(uint8_t *static_key, size_t static_key_len,
+                               const uint8_t stored[hydro_pwhash_STOREDBYTES], const char *passwd,
+                               size_t passwd_len, const char ctx[hydro_pwhash_CONTEXTBYTES],
+                               const uint8_t master_key[hydro_pwhash_MASTERKEYBYTES],
+                               uint64_t opslimit_max, size_t memlimit_max, uint8_t threads_max)
+{
+    uint8_t computed_h[hydro_pwhash_HASHBYTES];
+
+    if (_hydro_pwhash_verify(computed_h, stored, passwd, passwd_len, master_key, opslimit_max,
+                             memlimit_max, threads_max) != 0) {
+        hydro_memzero(computed_h, sizeof computed_h);
+        return -1;
+    }
+    COMPILER_ASSERT(hydro_kdf_CONTEXTBYTES <= hydro_pwhash_CONTEXTBYTES);
+    COMPILER_ASSERT(hydro_kdf_KEYBYTES <= hydro_pwhash_HASHBYTES);
+    hydro_kdf_derive_from_key(static_key, static_key_len, 0, ctx, computed_h);
+    hydro_memzero(computed_h, sizeof computed_h);
+
+    return 0;
+}
+
+int
+hydro_pwhash_reencrypt(uint8_t       stored[hydro_pwhash_STOREDBYTES],
+                       const uint8_t master_key[hydro_pwhash_MASTERKEYBYTES],
+                       const uint8_t new_master_key[hydro_pwhash_MASTERKEYBYTES])
+{
+    uint8_t *const enc_alg   = &stored[0];
+    uint8_t *const secretbox = &enc_alg[hydro_pwhash_ENC_ALGBYTES];
+    uint8_t *const params    = &secretbox[hydro_secretbox_HEADERBYTES];
+
+    if (*enc_alg != hydro_pwhash_ENC_ALG) {
+        return -1;
+    }
+    if (hydro_secretbox_decrypt(secretbox, secretbox,
+                                hydro_secretbox_HEADERBYTES + hydro_pwhash_PARAMSBYTES,
+                                (uint64_t) *enc_alg, hydro_pwhash_CONTEXT, master_key) != 0) {
+        return -1;
+    }
+    memmove(params, secretbox, hydro_pwhash_PARAMSBYTES);
+    return hydro_secretbox_encrypt(secretbox, params, hydro_pwhash_PARAMSBYTES, (uint64_t) *enc_alg,
+                                   hydro_pwhash_CONTEXT, new_master_key);
+}
+
+int
+hydro_pwhash_upgrade(uint8_t       stored[hydro_pwhash_STOREDBYTES],
+                     const uint8_t master_key[hydro_pwhash_MASTERKEYBYTES], uint64_t opslimit,
+                     size_t memlimit, uint8_t threads)
+{
+    uint8_t *const enc_alg     = &stored[0];
+    uint8_t *const secretbox   = &enc_alg[hydro_pwhash_ENC_ALGBYTES];
+    uint8_t *const params      = &secretbox[hydro_secretbox_HEADERBYTES];
+    uint8_t *const hash_alg    = &params[0];
+    uint8_t *const threads_u8  = &hash_alg[hydro_pwhash_HASH_ALGBYTES];
+    uint8_t *const opslimit_u8 = &threads_u8[hydro_pwhash_THREADSBYTES];
+    uint8_t *const memlimit_u8 = &opslimit_u8[hydro_pwhash_OPSLIMITBYTES];
+    uint8_t *const salt        = &memlimit_u8[hydro_pwhash_MEMLIMITBYTES];
+    uint8_t *const h           = &salt[hydro_pwhash_SALTBYTES];
+
+    _hydro_attr_aligned_(16) uint8_t state[gimli_BLOCKBYTES];
+    uint64_t                         i;
+    uint64_t                         opslimit_prev;
+
+    if (*enc_alg != hydro_pwhash_ENC_ALG) {
+        return -1;
+    }
+    if (hydro_secretbox_decrypt(secretbox, secretbox,
+                                hydro_secretbox_HEADERBYTES + hydro_pwhash_PARAMSBYTES,
+                                (uint64_t) *enc_alg, hydro_pwhash_CONTEXT, master_key) != 0) {
+        return -1;
+    }
+    memmove(params, secretbox, hydro_pwhash_PARAMSBYTES);
+    opslimit_prev = LOAD64_LE(opslimit_u8);
+    if (*hash_alg != hydro_pwhash_HASH_ALG) {
+        mem_zero(stored, hydro_pwhash_STOREDBYTES);
+        return -1;
+    }
+    COMPILER_ASSERT(hydro_random_SEEDBYTES == gimli_CAPACITY);
+    memcpy(state + gimli_RATE, h, hydro_random_SEEDBYTES);
+    for (i = opslimit_prev; i < opslimit; i++) {
+        mem_zero(state, gimli_RATE);
+        STORE64_LE(state, i);
+        gimli_core_u8(state, 0);
+    }
+    mem_zero(state, gimli_RATE);
+    memcpy(h, state + gimli_RATE, hydro_random_SEEDBYTES);
+    *threads_u8 = threads;
+    STORE64_LE(opslimit_u8, opslimit);
+    STORE64_LE(memlimit_u8, (uint64_t) memlimit);
+
+    return hydro_secretbox_encrypt(secretbox, params, hydro_pwhash_PARAMSBYTES, (uint64_t) *enc_alg,
+                                   hydro_pwhash_CONTEXT, master_key);
+}

--- a/lib/libhydrogen/impl/random.h
+++ b/lib/libhydrogen/impl/random.h
@@ -1,0 +1,466 @@
+static TLS struct {
+    _hydro_attr_aligned_(16) uint8_t state[gimli_BLOCKBYTES];
+    uint64_t counter;
+    uint8_t  initialized;
+    uint8_t  available;
+} hydro_random_context;
+
+#if defined(AVR) && !defined(__unix__)
+#include <Arduino.h>
+
+static bool
+hydro_random_rbit(uint16_t x)
+{
+    uint8_t x8;
+
+    x8 = ((uint8_t)(x >> 8)) ^ (uint8_t) x;
+    x8 = (x8 >> 4) ^ (x8 & 0xf);
+    x8 = (x8 >> 2) ^ (x8 & 0x3);
+    x8 = (x8 >> 1) ^ x8;
+
+    return (bool) (x8 & 1);
+}
+
+static int
+hydro_random_init(void)
+{
+    const char       ctx[hydro_hash_CONTEXTBYTES] = { 'h', 'y', 'd', 'r', 'o', 'P', 'R', 'G' };
+    hydro_hash_state st;
+    uint16_t         ebits = 0;
+    uint16_t         tc;
+    bool             a, b;
+
+    cli();
+    MCUSR = 0;
+    WDTCSR |= _BV(WDCE) | _BV(WDE);
+    WDTCSR = _BV(WDIE);
+    sei();
+
+    hydro_hash_init(&st, ctx, NULL);
+
+    while (ebits < 256) {
+        delay(1);
+        tc = TCNT1;
+        hydro_hash_update(&st, (const uint8_t *) &tc, sizeof tc);
+        a = hydro_random_rbit(tc);
+        delay(1);
+        tc = TCNT1;
+        b  = hydro_random_rbit(tc);
+        hydro_hash_update(&st, (const uint8_t *) &tc, sizeof tc);
+        if (a == b) {
+            continue;
+        }
+        hydro_hash_update(&st, (const uint8_t *) &b, sizeof b);
+        ebits++;
+    }
+
+    cli();
+    MCUSR = 0;
+    WDTCSR |= _BV(WDCE) | _BV(WDE);
+    WDTCSR = 0;
+    sei();
+
+    hydro_hash_final(&st, hydro_random_context.state, sizeof hydro_random_context.state);
+    hydro_random_context.counter = ~LOAD64_LE(hydro_random_context.state);
+
+    return 0;
+}
+
+ISR(WDT_vect) {}
+
+#elif (defined(ESP32) || defined(ESP8266)) && !defined(__unix__)
+
+// Important: RF *must* be activated on ESP board
+// https://techtutorialsx.com/2017/12/22/esp32-arduino-random-number-generation/
+
+#include <esp_system.h>
+
+static int
+hydro_random_init(void)
+{
+    const char       ctx[hydro_hash_CONTEXTBYTES] = { 'h', 'y', 'd', 'r', 'o', 'P', 'R', 'G' };
+    hydro_hash_state st;
+    uint16_t         ebits = 0;
+
+    hydro_hash_init(&st, ctx, NULL);
+
+    while (ebits < 256) {
+        uint32_t r = esp_random();
+
+        delay(10);
+        hydro_hash_update(&st, (const uint32_t *) &r, sizeof r);
+        ebits += 32;
+    }
+
+    hydro_hash_final(&st, hydro_random_context.state, sizeof hydro_random_context.state);
+    hydro_random_context.counter = ~LOAD64_LE(hydro_random_context.state);
+
+    return 0;
+}
+
+#elif defined(PARTICLE) && defined(PLATFORM_ID) && PLATFORM_ID > 2 && !defined(__unix__)
+
+// Note: All particle platforms except for the Spark Core have a HW RNG.  Only allow building on
+// supported platforms for now. PLATFORM_ID definitions:
+// https://github.com/particle-iot/device-os/blob/mesh-develop/hal/shared/platforms.h
+
+#include "Particle.h"
+
+static int
+hydro_random_init(void)
+{
+    const char       ctx[hydro_hash_CONTEXTBYTES] = { 'h', 'y', 'd', 'r', 'o', 'P', 'R', 'G' };
+    hydro_hash_state st;
+    uint16_t         ebits = 0;
+
+    hydro_hash_init(&st, ctx, NULL);
+
+    while (ebits < 256) {
+        uint32_t r = HAL_RNG_GetRandomNumber();
+        hydro_hash_update(&st, (const uint32_t *) &r, sizeof r);
+        ebits += 32;
+    }
+
+    hydro_hash_final(&st, hydro_random_context.state, sizeof hydro_random_context.state);
+    hydro_random_context.counter = ~LOAD64_LE(hydro_random_context.state);
+
+    return 0;
+}
+
+#elif (defined(NRF52832_XXAA) || defined(NRF52832_XXAB)) && !defined(__unix__)
+
+// Important: The SoftDevice *must* be activated to enable reading from the RNG
+// http://infocenter.nordicsemi.com/index.jsp?topic=%2Fcom.nordic.infocenter.nrf52832.ps.v1.1%2Frng.html
+
+#include <nrf_soc.h>
+
+static int
+hydro_random_init(void)
+{
+    const char       ctx[hydro_hash_CONTEXTBYTES] = { 'h', 'y', 'd', 'r', 'o', 'P', 'R', 'G' };
+    hydro_hash_state st;
+    const uint8_t    total_bytes     = 32;
+    uint8_t          remaining_bytes = total_bytes;
+    uint8_t          available_bytes;
+    uint8_t          rand_buffer[32];
+
+    hydro_hash_init(&st, ctx, NULL);
+
+    for (;;) {
+        if (sd_rand_application_bytes_available_get(&available_bytes) != NRF_SUCCESS) {
+            return -1;
+        }
+        if (available_bytes > 0) {
+            if (available_bytes > remaining_bytes) {
+                available_bytes = remaining_bytes;
+            }
+            if (sd_rand_application_vector_get(rand_buffer, available_bytes) != NRF_SUCCESS) {
+                return -1;
+            }
+            hydro_hash_update(&st, rand_buffer, total_bytes);
+            remaining_bytes -= available_bytes;
+        }
+        if (remaining_bytes <= 0) {
+            break;
+        }
+        delay(10);
+    }
+    hydro_hash_final(&st, hydro_random_context.state, sizeof hydro_random_context.state);
+    hydro_random_context.counter = ~LOAD64_LE(hydro_random_context.state);
+
+    return 0;
+}
+
+#elif defined(_WIN32)
+
+#include <windows.h>
+#define RtlGenRandom SystemFunction036
+#if defined(__cplusplus)
+extern "C"
+#endif
+    BOOLEAN NTAPI
+    RtlGenRandom(PVOID RandomBuffer, ULONG RandomBufferLength);
+#pragma comment(lib, "advapi32.lib")
+
+static int
+hydro_random_init(void)
+{
+    if (!RtlGenRandom((PVOID) hydro_random_context.state,
+                      (ULONG) sizeof hydro_random_context.state)) {
+        return -1;
+    }
+    hydro_random_context.counter = ~LOAD64_LE(hydro_random_context.state);
+
+    return 0;
+}
+
+#elif defined(__wasi__)
+
+#include <unistd.h>
+
+static int
+hydro_random_init(void)
+{
+    if (getentropy(hydro_random_context.state, sizeof hydro_random_context.state) != 0) {
+        return -1;
+    }
+    hydro_random_context.counter = ~LOAD64_LE(hydro_random_context.state);
+
+    return 0;
+}
+
+#elif defined(__unix__)
+
+#include <errno.h>
+#include <fcntl.h>
+#ifdef __linux__
+#include <poll.h>
+#endif
+#include <sys/types.h>
+#include <unistd.h>
+
+#ifdef __linux__
+static int
+hydro_random_block_on_dev_random(void)
+{
+    struct pollfd pfd;
+    int           fd;
+    int           pret;
+
+    fd = open("/dev/random", O_RDONLY);
+    if (fd == -1) {
+        return 0;
+    }
+    pfd.fd      = fd;
+    pfd.events  = POLLIN;
+    pfd.revents = 0;
+    do {
+        pret = poll(&pfd, 1, -1);
+    } while (pret < 0 && (errno == EINTR || errno == EAGAIN));
+    if (pret != 1) {
+        (void) close(fd);
+        errno = EIO;
+        return -1;
+    }
+    return close(fd);
+}
+#endif
+
+static ssize_t
+hydro_random_safe_read(const int fd, void *const buf_, size_t len)
+{
+    unsigned char *buf = (unsigned char *) buf_;
+    ssize_t        readnb;
+
+    do {
+        while ((readnb = read(fd, buf, len)) < (ssize_t) 0 && (errno == EINTR || errno == EAGAIN)) {
+        }
+        if (readnb < (ssize_t) 0) {
+            return readnb;
+        }
+        if (readnb == (ssize_t) 0) {
+            break;
+        }
+        len -= (size_t) readnb;
+        buf += readnb;
+    } while (len > (ssize_t) 0);
+
+    return (ssize_t)(buf - (unsigned char *) buf_);
+}
+
+static int
+hydro_random_init(void)
+{
+    uint8_t tmp[gimli_BLOCKBYTES + 8];
+    int     fd;
+    int     ret = -1;
+
+#ifdef __linux__
+    if (hydro_random_block_on_dev_random() != 0) {
+        return -1;
+    }
+#endif
+    do {
+        fd = open("/dev/urandom", O_RDONLY);
+        if (fd == -1 && errno != EINTR) {
+            return -1;
+        }
+    } while (fd == -1);
+    if (hydro_random_safe_read(fd, tmp, sizeof tmp) == (ssize_t) sizeof tmp) {
+        memcpy(hydro_random_context.state, tmp, gimli_BLOCKBYTES);
+        memcpy(&hydro_random_context.counter, tmp + gimli_BLOCKBYTES, 8);
+        hydro_memzero(tmp, sizeof tmp);
+        ret = 0;
+    }
+    ret |= close(fd);
+
+    return ret;
+}
+
+#elif defined(TARGET_LIKE_MBED)
+
+#include <mbedtls/ctr_drbg.h>
+#include <mbedtls/entropy.h>
+
+#if defined(MBEDTLS_ENTROPY_C)
+
+static int
+hydro_random_init(void)
+{
+    mbedtls_entropy_context entropy;
+    uint16_t                pos = 0;
+
+    mbedtls_entropy_init(&entropy);
+
+    // Pull data directly out of the entropy pool for the state, as it's small enough.
+    if (mbedtls_entropy_func(&entropy, (uint8_t *) &hydro_random_context.counter,
+                             sizeof hydro_random_context.counter) != 0) {
+        return -1;
+    }
+    // mbedtls_entropy_func can't provide more than MBEDTLS_ENTROPY_BLOCK_SIZE in one go.
+    // This constant depends of mbedTLS configuration (whether the PRNG is backed by SHA256/SHA512
+    // at this time) Therefore, if necessary, we get entropy multiple times.
+
+    do {
+        const uint8_t dataLeftToConsume = gimli_BLOCKBYTES - pos;
+        const uint8_t currentChunkSize  = (dataLeftToConsume > MBEDTLS_ENTROPY_BLOCK_SIZE)
+                                             ? MBEDTLS_ENTROPY_BLOCK_SIZE
+                                             : dataLeftToConsume;
+
+        // Forces mbedTLS to fetch fresh entropy, then get some to feed libhydrogen.
+        if (mbedtls_entropy_gather(&entropy) != 0 ||
+            mbedtls_entropy_func(&entropy, &hydro_random_context.state[pos], currentChunkSize) !=
+                0) {
+            return -1;
+        }
+        pos += MBEDTLS_ENTROPY_BLOCK_SIZE;
+    } while (pos < gimli_BLOCKBYTES);
+
+    mbedtls_entropy_free(&entropy);
+
+    return 0;
+}
+
+#else
+#error Need an entropy source
+#endif
+
+#else
+#error Unsupported platform
+#endif
+
+static void
+hydro_random_check_initialized(void)
+{
+    if (hydro_random_context.initialized == 0) {
+        if (hydro_random_init() != 0) {
+            abort();
+        }
+        gimli_core_u8(hydro_random_context.state, 0);
+        hydro_random_ratchet();
+        hydro_random_context.initialized = 1;
+    }
+}
+
+void
+hydro_random_ratchet(void)
+{
+    mem_zero(hydro_random_context.state, gimli_RATE);
+    STORE64_LE(hydro_random_context.state, hydro_random_context.counter);
+    hydro_random_context.counter++;
+    gimli_core_u8(hydro_random_context.state, 0);
+    hydro_random_context.available = gimli_RATE;
+}
+
+uint32_t
+hydro_random_u32(void)
+{
+    uint32_t v;
+
+    hydro_random_check_initialized();
+    if (hydro_random_context.available < 4) {
+        hydro_random_ratchet();
+    }
+    memcpy(&v, &hydro_random_context.state[gimli_RATE - hydro_random_context.available], 4);
+    hydro_random_context.available -= 4;
+
+    return v;
+}
+
+uint32_t
+hydro_random_uniform(const uint32_t upper_bound)
+{
+    uint32_t min;
+    uint32_t r;
+
+    if (upper_bound < 2U) {
+        return 0;
+    }
+    min = (1U + ~upper_bound) % upper_bound; /* = 2**32 mod upper_bound */
+    do {
+        r = hydro_random_u32();
+    } while (r < min);
+    /* r is now clamped to a set whose size mod upper_bound == 0
+     * the worst case (2**31+1) requires 2 attempts on average */
+
+    return r % upper_bound;
+}
+
+void
+hydro_random_buf(void *out, size_t out_len)
+{
+    uint8_t *p = (uint8_t *) out;
+    size_t   i;
+    size_t   leftover;
+
+    hydro_random_check_initialized();
+    for (i = 0; i < out_len / gimli_RATE; i++) {
+        gimli_core_u8(hydro_random_context.state, 0);
+        memcpy(p + i * gimli_RATE, hydro_random_context.state, gimli_RATE);
+    }
+    leftover = out_len % gimli_RATE;
+    if (leftover != 0) {
+        gimli_core_u8(hydro_random_context.state, 0);
+        mem_cpy(p + i * gimli_RATE, hydro_random_context.state, leftover);
+    }
+    hydro_random_ratchet();
+}
+
+void
+hydro_random_buf_deterministic(void *out, size_t out_len,
+                               const uint8_t seed[hydro_random_SEEDBYTES])
+{
+    static const uint8_t             prefix[] = { 7, 'd', 'r', 'b', 'g', '2', '5', '6' };
+    _hydro_attr_aligned_(16) uint8_t state[gimli_BLOCKBYTES];
+    uint8_t *                        p = (uint8_t *) out;
+    size_t                           i;
+    size_t                           leftover;
+
+    mem_zero(state, gimli_BLOCKBYTES);
+    COMPILER_ASSERT(sizeof prefix + 8 <= gimli_RATE);
+    memcpy(state, prefix, sizeof prefix);
+    STORE64_LE(state + sizeof prefix, (uint64_t) out_len);
+    gimli_core_u8(state, 1);
+    COMPILER_ASSERT(hydro_random_SEEDBYTES == gimli_RATE * 2);
+    mem_xor(state, seed, gimli_RATE);
+    gimli_core_u8(state, 2);
+    mem_xor(state, seed + gimli_RATE, gimli_RATE);
+    gimli_core_u8(state, 2);
+    for (i = 0; i < out_len / gimli_RATE; i++) {
+        gimli_core_u8(state, 0);
+        memcpy(p + i * gimli_RATE, state, gimli_RATE);
+    }
+    leftover = out_len % gimli_RATE;
+    if (leftover != 0) {
+        gimli_core_u8(state, 0);
+        mem_cpy(p + i * gimli_RATE, state, leftover);
+    }
+    hydro_random_ratchet();
+}
+
+void
+hydro_random_reseed(void)
+{
+    hydro_random_context.initialized = 0;
+    hydro_random_check_initialized();
+}

--- a/lib/libhydrogen/impl/secretbox.h
+++ b/lib/libhydrogen/impl/secretbox.h
@@ -1,0 +1,236 @@
+#define hydro_secretbox_IVBYTES 20
+#define hydro_secretbox_SIVBYTES 20
+#define hydro_secretbox_MACBYTES 16
+
+void
+hydro_secretbox_keygen(uint8_t key[hydro_secretbox_KEYBYTES])
+{
+    hydro_random_buf(key, hydro_secretbox_KEYBYTES);
+}
+
+static void
+hydro_secretbox_xor_enc(uint8_t buf[gimli_BLOCKBYTES], uint8_t *out, const uint8_t *in,
+                        size_t inlen)
+{
+    size_t i;
+    size_t leftover;
+
+    for (i = 0; i < inlen / gimli_RATE; i++) {
+        mem_xor2(&out[i * gimli_RATE], &in[i * gimli_RATE], buf, gimli_RATE);
+        memcpy(buf, &out[i * gimli_RATE], gimli_RATE);
+        gimli_core_u8(buf, gimli_TAG_PAYLOAD);
+    }
+    leftover = inlen % gimli_RATE;
+    if (leftover != 0) {
+        mem_xor2(&out[i * gimli_RATE], &in[i * gimli_RATE], buf, leftover);
+        mem_cpy(buf, &out[i * gimli_RATE], leftover);
+    }
+    gimli_pad_u8(buf, leftover, gimli_DOMAIN_AEAD);
+    gimli_core_u8(buf, gimli_TAG_PAYLOAD);
+}
+
+static void
+hydro_secretbox_xor_dec(uint8_t buf[gimli_BLOCKBYTES], uint8_t *out, const uint8_t *in,
+                        size_t inlen)
+{
+    size_t i;
+    size_t leftover;
+
+    for (i = 0; i < inlen / gimli_RATE; i++) {
+        mem_xor2(&out[i * gimli_RATE], &in[i * gimli_RATE], buf, gimli_RATE);
+        memcpy(buf, &in[i * gimli_RATE], gimli_RATE);
+        gimli_core_u8(buf, gimli_TAG_PAYLOAD);
+    }
+    leftover = inlen % gimli_RATE;
+    if (leftover != 0) {
+        mem_xor2(&out[i * gimli_RATE], &in[i * gimli_RATE], buf, leftover);
+        mem_cpy(buf, &in[i * gimli_RATE], leftover);
+    }
+    gimli_pad_u8(buf, leftover, gimli_DOMAIN_AEAD);
+    gimli_core_u8(buf, gimli_TAG_PAYLOAD);
+}
+
+static void
+hydro_secretbox_setup(uint8_t buf[gimli_BLOCKBYTES], uint64_t msg_id,
+                      const char    ctx[hydro_secretbox_CONTEXTBYTES],
+                      const uint8_t key[hydro_secretbox_KEYBYTES],
+                      const uint8_t iv[hydro_secretbox_IVBYTES], uint8_t key_tag)
+{
+    static const uint8_t prefix[] = { 6, 's', 'b', 'x', '2', '5', '6', 8 };
+    uint8_t              msg_id_le[8];
+
+    mem_zero(buf, gimli_BLOCKBYTES);
+    COMPILER_ASSERT(hydro_secretbox_CONTEXTBYTES == 8);
+    COMPILER_ASSERT(sizeof prefix + hydro_secretbox_CONTEXTBYTES <= gimli_RATE);
+    memcpy(buf, prefix, sizeof prefix);
+    memcpy(buf + sizeof prefix, ctx, hydro_secretbox_CONTEXTBYTES);
+    COMPILER_ASSERT(sizeof prefix + hydro_secretbox_CONTEXTBYTES == gimli_RATE);
+    gimli_core_u8(buf, gimli_TAG_HEADER);
+
+    COMPILER_ASSERT(hydro_secretbox_KEYBYTES == 2 * gimli_RATE);
+    mem_xor(buf, key, gimli_RATE);
+    gimli_core_u8(buf, key_tag);
+    mem_xor(buf, key + gimli_RATE, gimli_RATE);
+    gimli_core_u8(buf, key_tag);
+
+    COMPILER_ASSERT(hydro_secretbox_IVBYTES < gimli_RATE * 2);
+    buf[0] ^= hydro_secretbox_IVBYTES;
+    mem_xor(&buf[1], iv, gimli_RATE - 1);
+    gimli_core_u8(buf, gimli_TAG_HEADER);
+    mem_xor(buf, iv + gimli_RATE - 1, hydro_secretbox_IVBYTES - (gimli_RATE - 1));
+    STORE64_LE(msg_id_le, msg_id);
+    COMPILER_ASSERT(hydro_secretbox_IVBYTES - gimli_RATE + 8 <= gimli_RATE);
+    mem_xor(buf + hydro_secretbox_IVBYTES - gimli_RATE, msg_id_le, 8);
+    gimli_core_u8(buf, gimli_TAG_HEADER);
+}
+
+static void
+hydro_secretbox_final(uint8_t *buf, const uint8_t key[hydro_secretbox_KEYBYTES], uint8_t tag)
+{
+    COMPILER_ASSERT(hydro_secretbox_KEYBYTES == gimli_CAPACITY);
+    mem_xor(buf + gimli_RATE, key, hydro_secretbox_KEYBYTES);
+    gimli_core_u8(buf, tag);
+    mem_xor(buf + gimli_RATE, key, hydro_secretbox_KEYBYTES);
+    gimli_core_u8(buf, tag);
+}
+
+static int
+hydro_secretbox_encrypt_iv(uint8_t *c, const void *m_, size_t mlen, uint64_t msg_id,
+                           const char    ctx[hydro_secretbox_CONTEXTBYTES],
+                           const uint8_t key[hydro_secretbox_KEYBYTES],
+                           const uint8_t iv[hydro_secretbox_IVBYTES])
+{
+    _hydro_attr_aligned_(16) uint32_t state[gimli_BLOCKBYTES / 4];
+    uint8_t *                         buf = (uint8_t *) (void *) state;
+    const uint8_t *                   m   = (const uint8_t *) m_;
+    uint8_t *                         siv = &c[0];
+    uint8_t *                         mac = &c[hydro_secretbox_SIVBYTES];
+    uint8_t *                         ct  = &c[hydro_secretbox_SIVBYTES + hydro_secretbox_MACBYTES];
+    size_t                            i;
+    size_t                            leftover;
+
+    if (c == m) {
+        memmove(c + hydro_secretbox_HEADERBYTES, m, mlen);
+        m = c + hydro_secretbox_HEADERBYTES;
+    }
+
+    /* first pass: compute the SIV */
+
+    hydro_secretbox_setup(buf, msg_id, ctx, key, iv, gimli_TAG_KEY0);
+    for (i = 0; i < mlen / gimli_RATE; i++) {
+        mem_xor(buf, &m[i * gimli_RATE], gimli_RATE);
+        gimli_core_u8(buf, gimli_TAG_PAYLOAD);
+    }
+    leftover = mlen % gimli_RATE;
+    if (leftover != 0) {
+        mem_xor(buf, &m[i * gimli_RATE], leftover);
+    }
+    gimli_pad_u8(buf, leftover, gimli_DOMAIN_XOF);
+    gimli_core_u8(buf, gimli_TAG_PAYLOAD);
+
+    hydro_secretbox_final(buf, key, gimli_TAG_FINAL0);
+    COMPILER_ASSERT(hydro_secretbox_SIVBYTES <= gimli_CAPACITY);
+    memcpy(siv, buf + gimli_RATE, hydro_secretbox_SIVBYTES);
+
+    /* second pass: encrypt the message, mix the key, squeeze an extra block for
+     * the MAC */
+
+    COMPILER_ASSERT(hydro_secretbox_SIVBYTES == hydro_secretbox_IVBYTES);
+    hydro_secretbox_setup(buf, msg_id, ctx, key, siv, gimli_TAG_KEY);
+    hydro_secretbox_xor_enc(buf, ct, m, mlen);
+
+    hydro_secretbox_final(buf, key, gimli_TAG_FINAL);
+    COMPILER_ASSERT(hydro_secretbox_MACBYTES <= gimli_CAPACITY);
+    memcpy(mac, buf + gimli_RATE, hydro_secretbox_MACBYTES);
+
+    return 0;
+}
+
+void
+hydro_secretbox_probe_create(uint8_t probe[hydro_secretbox_PROBEBYTES], const uint8_t *c,
+                             size_t c_len, const char ctx[hydro_secretbox_CONTEXTBYTES],
+                             const uint8_t key[hydro_secretbox_KEYBYTES])
+{
+    const uint8_t *mac;
+
+    if (c_len < hydro_secretbox_HEADERBYTES) {
+        abort();
+    }
+    mac = &c[hydro_secretbox_SIVBYTES];
+    COMPILER_ASSERT(hydro_secretbox_CONTEXTBYTES >= hydro_hash_CONTEXTBYTES);
+    COMPILER_ASSERT(hydro_secretbox_KEYBYTES >= hydro_hash_KEYBYTES);
+    hydro_hash_hash(probe, hydro_secretbox_PROBEBYTES, mac, hydro_secretbox_MACBYTES, ctx, key);
+}
+
+int
+hydro_secretbox_probe_verify(const uint8_t probe[hydro_secretbox_PROBEBYTES], const uint8_t *c,
+                             size_t c_len, const char ctx[hydro_secretbox_CONTEXTBYTES],
+                             const uint8_t key[hydro_secretbox_KEYBYTES])
+{
+    uint8_t        computed_probe[hydro_secretbox_PROBEBYTES];
+    const uint8_t *mac;
+
+    if (c_len < hydro_secretbox_HEADERBYTES) {
+        return -1;
+    }
+    mac = &c[hydro_secretbox_SIVBYTES];
+    hydro_hash_hash(computed_probe, hydro_secretbox_PROBEBYTES, mac, hydro_secretbox_MACBYTES, ctx,
+                    key);
+    if (hydro_equal(computed_probe, probe, hydro_secretbox_PROBEBYTES) == 1) {
+        return 0;
+    }
+    hydro_memzero(computed_probe, hydro_secretbox_PROBEBYTES);
+    return -1;
+}
+
+int
+hydro_secretbox_encrypt(uint8_t *c, const void *m_, size_t mlen, uint64_t msg_id,
+                        const char    ctx[hydro_secretbox_CONTEXTBYTES],
+                        const uint8_t key[hydro_secretbox_KEYBYTES])
+{
+    uint8_t iv[hydro_secretbox_IVBYTES];
+
+    hydro_random_buf(iv, sizeof iv);
+
+    return hydro_secretbox_encrypt_iv(c, m_, mlen, msg_id, ctx, key, iv);
+}
+
+int
+hydro_secretbox_decrypt(void *m_, const uint8_t *c, size_t clen, uint64_t msg_id,
+                        const char    ctx[hydro_secretbox_CONTEXTBYTES],
+                        const uint8_t key[hydro_secretbox_KEYBYTES])
+{
+    _hydro_attr_aligned_(16) uint32_t state[gimli_BLOCKBYTES / 4];
+    uint32_t                          pub_mac[hydro_secretbox_MACBYTES / 4];
+    uint8_t *                         buf = (uint8_t *) (void *) state;
+    const uint8_t *                   siv;
+    const uint8_t *                   mac;
+    const uint8_t *                   ct;
+    uint8_t *                         m = (uint8_t *) m_;
+    size_t                            mlen;
+    uint32_t                          cv;
+
+    if (clen < hydro_secretbox_HEADERBYTES) {
+        return -1;
+    }
+    siv = &c[0];
+    mac = &c[hydro_secretbox_SIVBYTES];
+    ct  = &c[hydro_secretbox_SIVBYTES + hydro_secretbox_MACBYTES];
+
+    mlen = clen - hydro_secretbox_HEADERBYTES;
+    memcpy(pub_mac, mac, sizeof pub_mac);
+    COMPILER_ASSERT(hydro_secretbox_SIVBYTES == hydro_secretbox_IVBYTES);
+    hydro_secretbox_setup(buf, msg_id, ctx, key, siv, gimli_TAG_KEY);
+    hydro_secretbox_xor_dec(buf, m, ct, mlen);
+
+    hydro_secretbox_final(buf, key, gimli_TAG_FINAL);
+    COMPILER_ASSERT(hydro_secretbox_MACBYTES <= gimli_CAPACITY);
+    COMPILER_ASSERT(gimli_RATE % 4 == 0);
+    cv = hydro_mem_ct_cmp_u32(state + gimli_RATE / 4, pub_mac, hydro_secretbox_MACBYTES / 4);
+    hydro_mem_ct_zero_u32(state, gimli_BLOCKBYTES / 4);
+    if (cv != 0) {
+        mem_zero(m, mlen);
+        return -1;
+    }
+    return 0;
+}

--- a/lib/libhydrogen/impl/sign.h
+++ b/lib/libhydrogen/impl/sign.h
@@ -1,0 +1,207 @@
+#define hydro_sign_CHALLENGEBYTES 32
+#define hydro_sign_NONCEBYTES 32
+#define hydro_sign_PREHASHBYTES 64
+
+static void
+hydro_sign_p2(uint8_t sig[hydro_x25519_BYTES], const uint8_t challenge[hydro_sign_CHALLENGEBYTES],
+              const uint8_t eph_sk[hydro_x25519_BYTES], const uint8_t sk[hydro_x25519_BYTES])
+{
+    hydro_x25519_scalar_t scalar1, scalar2, scalar3;
+
+    COMPILER_ASSERT(hydro_sign_CHALLENGEBYTES == hydro_x25519_BYTES);
+    hydro_x25519_swapin(scalar1, eph_sk);
+    hydro_x25519_swapin(scalar2, sk);
+    hydro_x25519_swapin(scalar3, challenge);
+    hydro_x25519_sc_montmul(scalar1, scalar2, scalar3);
+    mem_zero(scalar2, sizeof scalar2);
+    hydro_x25519_sc_montmul(scalar2, scalar1, hydro_x25519_sc_r2);
+    hydro_x25519_swapout(sig, scalar2);
+}
+
+static void
+hydro_sign_challenge(uint8_t       challenge[hydro_sign_CHALLENGEBYTES],
+                     const uint8_t nonce[hydro_sign_NONCEBYTES],
+                     const uint8_t pk[hydro_sign_PUBLICKEYBYTES],
+                     const uint8_t prehash[hydro_sign_PREHASHBYTES])
+{
+    hydro_hash_state st;
+
+    hydro_hash_init(&st, (const char *) zero, NULL);
+    hydro_hash_update(&st, nonce, hydro_sign_NONCEBYTES);
+    hydro_hash_update(&st, pk, hydro_sign_PUBLICKEYBYTES);
+    hydro_hash_update(&st, prehash, hydro_sign_PREHASHBYTES);
+    hydro_hash_final(&st, challenge, hydro_sign_CHALLENGEBYTES);
+}
+
+static int
+hydro_sign_prehash(uint8_t csig[hydro_sign_BYTES], const uint8_t prehash[hydro_sign_PREHASHBYTES],
+                   const uint8_t sk[hydro_sign_SECRETKEYBYTES])
+{
+    hydro_hash_state st;
+    uint8_t          challenge[hydro_sign_CHALLENGEBYTES];
+    const uint8_t *  pk     = &sk[hydro_x25519_SECRETKEYBYTES];
+    uint8_t *        nonce  = &csig[0];
+    uint8_t *        sig    = &csig[hydro_sign_NONCEBYTES];
+    uint8_t *        eph_sk = sig;
+
+    hydro_random_buf(eph_sk, hydro_x25519_SECRETKEYBYTES);
+    COMPILER_ASSERT(hydro_x25519_SECRETKEYBYTES == hydro_hash_KEYBYTES);
+    hydro_hash_init(&st, (const char *) zero, sk);
+    hydro_hash_update(&st, eph_sk, hydro_x25519_SECRETKEYBYTES);
+    hydro_hash_update(&st, prehash, hydro_sign_PREHASHBYTES);
+    hydro_hash_final(&st, eph_sk, hydro_x25519_SECRETKEYBYTES);
+
+    hydro_x25519_scalarmult_base_uniform(nonce, eph_sk);
+    hydro_sign_challenge(challenge, nonce, pk, prehash);
+
+    COMPILER_ASSERT(hydro_sign_BYTES == hydro_sign_NONCEBYTES + hydro_x25519_SECRETKEYBYTES);
+    COMPILER_ASSERT(hydro_x25519_SECRETKEYBYTES <= hydro_sign_CHALLENGEBYTES);
+    hydro_sign_p2(sig, challenge, eph_sk, sk);
+
+    return 0;
+}
+
+static int
+hydro_sign_verify_core(hydro_x25519_fe xs[5], const hydro_x25519_limb_t *other1,
+                       const uint8_t other2[hydro_x25519_BYTES])
+{
+    hydro_x25519_limb_t *     z2 = xs[1], *x3 = xs[2], *z3 = xs[3];
+    hydro_x25519_fe           xo2;
+    const hydro_x25519_limb_t sixteen = 16;
+
+    hydro_x25519_swapin(xo2, other2);
+    memcpy(x3, other1, 2 * sizeof(hydro_x25519_fe));
+    hydro_x25519_ladder_part1(xs);
+
+    /* Here z2 = t2^2 */
+    hydro_x25519_mul1(z2, other1);
+    hydro_x25519_mul1(z2, other1 + hydro_x25519_NLIMBS);
+    hydro_x25519_mul1(z2, xo2);
+
+    hydro_x25519_mul(z2, z2, &sixteen, 1);
+
+    hydro_x25519_mul1(z3, xo2);
+    hydro_x25519_sub(z3, z3, x3);
+    hydro_x25519_sqr1(z3);
+
+    /* check equality */
+    hydro_x25519_sub(z3, z3, z2);
+
+    /* canon(z2): both sides are zero. canon(z3): the two sides are equal. */
+    /* Reject sigs where both sides are zero. */
+    return hydro_x25519_canon(z2) | ~hydro_x25519_canon(z3);
+}
+
+static int
+hydro_sign_verify_p2(const uint8_t sig[hydro_x25519_BYTES],
+                     const uint8_t challenge[hydro_sign_CHALLENGEBYTES],
+                     const uint8_t nonce[hydro_sign_NONCEBYTES],
+                     const uint8_t pk[hydro_x25519_BYTES])
+{
+    hydro_x25519_fe xs[7];
+
+    hydro_x25519_core(&xs[0], challenge, pk, 0);
+    hydro_x25519_core(&xs[2], sig, hydro_x25519_BASE_POINT, 0);
+
+    return hydro_sign_verify_core(&xs[2], xs[0], nonce);
+}
+
+static int
+hydro_sign_verify_challenge(const uint8_t csig[hydro_sign_BYTES],
+                            const uint8_t challenge[hydro_sign_CHALLENGEBYTES],
+                            const uint8_t pk[hydro_sign_PUBLICKEYBYTES])
+{
+    const uint8_t *nonce = &csig[0];
+    const uint8_t *sig   = &csig[hydro_sign_NONCEBYTES];
+
+    return hydro_sign_verify_p2(sig, challenge, nonce, pk);
+}
+
+void
+hydro_sign_keygen(hydro_sign_keypair *kp)
+{
+    uint8_t *pk_copy = &kp->sk[hydro_x25519_SECRETKEYBYTES];
+
+    COMPILER_ASSERT(hydro_sign_SECRETKEYBYTES ==
+                    hydro_x25519_SECRETKEYBYTES + hydro_x25519_PUBLICKEYBYTES);
+    COMPILER_ASSERT(hydro_sign_PUBLICKEYBYTES == hydro_x25519_PUBLICKEYBYTES);
+    hydro_random_buf(kp->sk, hydro_x25519_SECRETKEYBYTES);
+    hydro_x25519_scalarmult_base_uniform(kp->pk, kp->sk);
+    memcpy(pk_copy, kp->pk, hydro_x25519_PUBLICKEYBYTES);
+}
+
+void
+hydro_sign_keygen_deterministic(hydro_sign_keypair *kp, const uint8_t seed[hydro_sign_SEEDBYTES])
+{
+    uint8_t *pk_copy = &kp->sk[hydro_x25519_SECRETKEYBYTES];
+
+    COMPILER_ASSERT(hydro_sign_SEEDBYTES >= hydro_random_SEEDBYTES);
+    hydro_random_buf_deterministic(kp->sk, hydro_x25519_SECRETKEYBYTES, seed);
+    hydro_x25519_scalarmult_base_uniform(kp->pk, kp->sk);
+    memcpy(pk_copy, kp->pk, hydro_x25519_PUBLICKEYBYTES);
+}
+
+int
+hydro_sign_init(hydro_sign_state *state, const char ctx[hydro_sign_CONTEXTBYTES])
+{
+    return hydro_hash_init(&state->hash_st, ctx, NULL);
+}
+
+int
+hydro_sign_update(hydro_sign_state *state, const void *m_, size_t mlen)
+{
+    return hydro_hash_update(&state->hash_st, m_, mlen);
+}
+
+int
+hydro_sign_final_create(hydro_sign_state *state, uint8_t csig[hydro_sign_BYTES],
+                        const uint8_t sk[hydro_sign_SECRETKEYBYTES])
+{
+    uint8_t prehash[hydro_sign_PREHASHBYTES];
+
+    hydro_hash_final(&state->hash_st, prehash, sizeof prehash);
+
+    return hydro_sign_prehash(csig, prehash, sk);
+}
+
+int
+hydro_sign_final_verify(hydro_sign_state *state, const uint8_t csig[hydro_sign_BYTES],
+                        const uint8_t pk[hydro_sign_PUBLICKEYBYTES])
+{
+    uint8_t        challenge[hydro_sign_CHALLENGEBYTES];
+    uint8_t        prehash[hydro_sign_PREHASHBYTES];
+    const uint8_t *nonce = &csig[0];
+
+    hydro_hash_final(&state->hash_st, prehash, sizeof prehash);
+    hydro_sign_challenge(challenge, nonce, pk, prehash);
+
+    return hydro_sign_verify_challenge(csig, challenge, pk);
+}
+
+int
+hydro_sign_create(uint8_t csig[hydro_sign_BYTES], const void *m_, size_t mlen,
+                  const char    ctx[hydro_sign_CONTEXTBYTES],
+                  const uint8_t sk[hydro_sign_SECRETKEYBYTES])
+{
+    hydro_sign_state st;
+
+    if (hydro_sign_init(&st, ctx) != 0 || hydro_sign_update(&st, m_, mlen) != 0 ||
+        hydro_sign_final_create(&st, csig, sk) != 0) {
+        return -1;
+    }
+    return 0;
+}
+
+int
+hydro_sign_verify(const uint8_t csig[hydro_sign_BYTES], const void *m_, size_t mlen,
+                  const char    ctx[hydro_sign_CONTEXTBYTES],
+                  const uint8_t pk[hydro_sign_PUBLICKEYBYTES])
+{
+    hydro_sign_state st;
+
+    if (hydro_sign_init(&st, ctx) != 0 || hydro_sign_update(&st, m_, mlen) != 0 ||
+        hydro_sign_final_verify(&st, csig, pk) != 0) {
+        return -1;
+    }
+    return 0;
+}

--- a/lib/libhydrogen/impl/x25519.h
+++ b/lib/libhydrogen/impl/x25519.h
@@ -1,0 +1,384 @@
+/*
+ * Based on Michael Hamburg's STROBE reference implementation.
+ * Copyright (c) 2015-2016 Cryptography Research, Inc.
+ * MIT License (MIT)
+ */
+
+#if defined(__GNUC__) && defined(__SIZEOF_INT128__)
+#define hydro_x25519_WBITS 64
+#else
+#define hydro_x25519_WBITS 32
+#endif
+
+#if hydro_x25519_WBITS == 64
+typedef uint64_t    hydro_x25519_limb_t;
+typedef __uint128_t hydro_x25519_dlimb_t;
+typedef __int128_t  hydro_x25519_sdlimb_t;
+#define hydro_x25519_eswap_limb(X) LOAD64_LE((const uint8_t *) &(X))
+#define hydro_x25519_LIMB(x) x##ull
+#elif hydro_x25519_WBITS == 32
+typedef uint32_t hydro_x25519_limb_t;
+typedef uint64_t hydro_x25519_dlimb_t;
+typedef int64_t  hydro_x25519_sdlimb_t;
+#define hydro_x25519_eswap_limb(X) LOAD32_LE((const uint8_t *) &(X))
+#define hydro_x25519_LIMB(x) (uint32_t)(x##ull), (uint32_t)((x##ull) >> 32)
+#else
+#error "Need to know hydro_x25519_WBITS"
+#endif
+
+#define hydro_x25519_NLIMBS (256 / hydro_x25519_WBITS)
+typedef hydro_x25519_limb_t hydro_x25519_fe[hydro_x25519_NLIMBS];
+
+typedef hydro_x25519_limb_t hydro_x25519_scalar_t[hydro_x25519_NLIMBS];
+
+static const hydro_x25519_limb_t hydro_x25519_MONTGOMERY_FACTOR =
+    (hydro_x25519_limb_t) 0xd2b51da312547e1bull;
+
+static const hydro_x25519_scalar_t hydro_x25519_sc_p = { hydro_x25519_LIMB(0x5812631a5cf5d3ed),
+                                                         hydro_x25519_LIMB(0x14def9dea2f79cd6),
+                                                         hydro_x25519_LIMB(0x0000000000000000),
+                                                         hydro_x25519_LIMB(0x1000000000000000) };
+
+static const hydro_x25519_scalar_t hydro_x25519_sc_r2 = { hydro_x25519_LIMB(0xa40611e3449c0f01),
+                                                          hydro_x25519_LIMB(0xd00e1ba768859347),
+                                                          hydro_x25519_LIMB(0xceec73d217f5be65),
+                                                          hydro_x25519_LIMB(0x0399411b7c309a3d) };
+
+static const uint8_t hydro_x25519_BASE_POINT[hydro_x25519_BYTES] = { 9 };
+
+static const hydro_x25519_limb_t hydro_x25519_a24[1] = { 121665 };
+
+static inline hydro_x25519_limb_t
+hydro_x25519_umaal(hydro_x25519_limb_t *carry, hydro_x25519_limb_t acc, hydro_x25519_limb_t mand,
+                   hydro_x25519_limb_t mier)
+{
+    hydro_x25519_dlimb_t tmp = (hydro_x25519_dlimb_t) mand * mier + acc + *carry;
+
+    *carry = tmp >> hydro_x25519_WBITS;
+    return (hydro_x25519_limb_t) tmp;
+}
+
+static inline hydro_x25519_limb_t
+hydro_x25519_adc(hydro_x25519_limb_t *carry, hydro_x25519_limb_t acc, hydro_x25519_limb_t mand)
+{
+    hydro_x25519_dlimb_t total = (hydro_x25519_dlimb_t) *carry + acc + mand;
+
+    *carry = total >> hydro_x25519_WBITS;
+    return (hydro_x25519_limb_t) total;
+}
+
+static inline hydro_x25519_limb_t
+hydro_x25519_adc0(hydro_x25519_limb_t *carry, hydro_x25519_limb_t acc)
+{
+    hydro_x25519_dlimb_t total = (hydro_x25519_dlimb_t) *carry + acc;
+
+    *carry = total >> hydro_x25519_WBITS;
+    return (hydro_x25519_limb_t) total;
+}
+
+static void
+hydro_x25519_propagate(hydro_x25519_fe x, hydro_x25519_limb_t over)
+{
+    hydro_x25519_limb_t carry;
+    int                 i;
+
+    over = x[hydro_x25519_NLIMBS - 1] >> (hydro_x25519_WBITS - 1) | over << 1;
+    x[hydro_x25519_NLIMBS - 1] &= ~((hydro_x25519_limb_t) 1 << (hydro_x25519_WBITS - 1));
+    carry = over * 19;
+    for (i = 0; i < hydro_x25519_NLIMBS; i++) {
+        x[i] = hydro_x25519_adc0(&carry, x[i]);
+    }
+}
+
+static void
+hydro_x25519_add(hydro_x25519_fe out, const hydro_x25519_fe a, const hydro_x25519_fe b)
+{
+    hydro_x25519_limb_t carry = 0;
+    int                 i;
+
+    for (i = 0; i < hydro_x25519_NLIMBS; i++) {
+        out[i] = hydro_x25519_adc(&carry, a[i], b[i]);
+    }
+    hydro_x25519_propagate(out, carry);
+}
+
+static void
+hydro_x25519_sub(hydro_x25519_fe out, const hydro_x25519_fe a, const hydro_x25519_fe b)
+{
+    hydro_x25519_sdlimb_t carry = -38;
+    int                   i;
+
+    for (i = 0; i < hydro_x25519_NLIMBS; i++) {
+        out[i] = (hydro_x25519_limb_t)(carry = carry + a[i] - b[i]);
+        carry >>= hydro_x25519_WBITS;
+    }
+    hydro_x25519_propagate(out, (hydro_x25519_limb_t)(1 + carry));
+}
+
+static void
+hydro_x25519_swapin(hydro_x25519_limb_t *x, const uint8_t *in)
+{
+    int i;
+
+    memcpy(x, in, sizeof(hydro_x25519_fe));
+    for (i = 0; i < hydro_x25519_NLIMBS; i++) {
+        x[i] = hydro_x25519_eswap_limb(x[i]);
+    }
+}
+
+static void
+hydro_x25519_swapout(uint8_t *out, hydro_x25519_limb_t *x)
+{
+    int i;
+
+    for (i = 0; i < hydro_x25519_NLIMBS; i++) {
+        x[i] = hydro_x25519_eswap_limb(x[i]);
+    }
+    memcpy(out, x, sizeof(hydro_x25519_fe));
+}
+
+static void
+hydro_x25519_mul(hydro_x25519_fe out, const hydro_x25519_fe a, const hydro_x25519_fe b, int nb)
+{
+    hydro_x25519_limb_t accum[2 * hydro_x25519_NLIMBS] = { 0 };
+    hydro_x25519_limb_t carry2;
+    int                 i, j;
+
+    for (i = 0; i < nb; i++) {
+        carry2                   = 0;
+        hydro_x25519_limb_t mand = b[i];
+        for (j = 0; j < hydro_x25519_NLIMBS; j++) {
+            accum[i + j] = hydro_x25519_umaal(&carry2, accum[i + j], mand, a[j]);
+        }
+        accum[i + j] = carry2;
+    }
+    carry2 = 0;
+    for (j = 0; j < hydro_x25519_NLIMBS; j++) {
+        const hydro_x25519_limb_t mand = 38;
+
+        out[j] = hydro_x25519_umaal(&carry2, accum[j], mand, accum[j + hydro_x25519_NLIMBS]);
+    }
+    hydro_x25519_propagate(out, carry2);
+}
+
+static void
+hydro_x25519_sqr(hydro_x25519_fe out, const hydro_x25519_fe a)
+{
+    hydro_x25519_mul(out, a, a, hydro_x25519_NLIMBS);
+}
+
+static void
+hydro_x25519_mul1(hydro_x25519_fe out, const hydro_x25519_fe a)
+{
+    hydro_x25519_mul(out, a, out, hydro_x25519_NLIMBS);
+}
+
+static void
+hydro_x25519_sqr1(hydro_x25519_fe a)
+{
+    hydro_x25519_mul1(a, a);
+}
+
+static void
+hydro_x25519_condswap(hydro_x25519_limb_t a[2 * hydro_x25519_NLIMBS],
+                      hydro_x25519_limb_t b[2 * hydro_x25519_NLIMBS], hydro_x25519_limb_t doswap)
+{
+    int i;
+
+    for (i = 0; i < 2 * hydro_x25519_NLIMBS; i++) {
+        hydro_x25519_limb_t xorv = (a[i] ^ b[i]) & doswap;
+        a[i] ^= xorv;
+        b[i] ^= xorv;
+    }
+}
+
+static int
+hydro_x25519_canon(hydro_x25519_fe x)
+{
+    hydro_x25519_sdlimb_t carry;
+    hydro_x25519_limb_t   carry0 = 19;
+    hydro_x25519_limb_t   res;
+    int                   i;
+
+    for (i = 0; i < hydro_x25519_NLIMBS; i++) {
+        x[i] = hydro_x25519_adc0(&carry0, x[i]);
+    }
+    hydro_x25519_propagate(x, carry0);
+    carry = -19;
+    res   = 0;
+    for (i = 0; i < hydro_x25519_NLIMBS; i++) {
+        res |= x[i] = (hydro_x25519_limb_t)(carry += x[i]);
+        carry >>= hydro_x25519_WBITS;
+    }
+    return ((hydro_x25519_dlimb_t) res - 1) >> hydro_x25519_WBITS;
+}
+
+static void
+hydro_x25519_ladder_part1(hydro_x25519_fe xs[5])
+{
+    hydro_x25519_limb_t *x2 = xs[0], *z2 = xs[1], *x3 = xs[2], *z3 = xs[3], *t1 = xs[4];
+
+    hydro_x25519_add(t1, x2, z2);              // t1 = A
+    hydro_x25519_sub(z2, x2, z2);              // z2 = B
+    hydro_x25519_add(x2, x3, z3);              // x2 = C
+    hydro_x25519_sub(z3, x3, z3);              // z3 = D
+    hydro_x25519_mul1(z3, t1);                 // z3 = DA
+    hydro_x25519_mul1(x2, z2);                 // x3 = BC
+    hydro_x25519_add(x3, z3, x2);              // x3 = DA+CB
+    hydro_x25519_sub(z3, z3, x2);              // z3 = DA-CB
+    hydro_x25519_sqr1(t1);                     // t1 = AA
+    hydro_x25519_sqr1(z2);                     // z2 = BB
+    hydro_x25519_sub(x2, t1, z2);              // x2 = E = AA-BB
+    hydro_x25519_mul(z2, x2, hydro_x25519_a24, // z2 = E*a24
+                     sizeof(hydro_x25519_a24) / sizeof(hydro_x25519_a24[0]));
+    hydro_x25519_add(z2, z2, t1); // z2 = E*a24 + AA
+}
+
+static void
+hydro_x25519_ladder_part2(hydro_x25519_fe xs[5], const hydro_x25519_fe x1)
+{
+    hydro_x25519_limb_t *x2 = xs[0], *z2 = xs[1], *x3 = xs[2], *z3 = xs[3], *t1 = xs[4];
+
+    hydro_x25519_sqr1(z3);        // z3 = (DA-CB)^2
+    hydro_x25519_mul1(z3, x1);    // z3 = x1 * (DA-CB)^2
+    hydro_x25519_sqr1(x3);        // x3 = (DA+CB)^2
+    hydro_x25519_mul1(z2, x2);    // z2 = AA*(E*a24+AA)
+    hydro_x25519_sub(x2, t1, x2); // x2 = BB again
+    hydro_x25519_mul1(x2, t1);    // x2 = AA*BB
+}
+
+static void
+hydro_x25519_core(hydro_x25519_fe xs[5], const uint8_t scalar[hydro_x25519_BYTES],
+                  const uint8_t *x1, bool clamp)
+{
+    hydro_x25519_limb_t  swap;
+    hydro_x25519_limb_t *x2 = xs[0], *x3 = xs[2], *z3 = xs[3];
+    hydro_x25519_fe      x1i;
+    int                  i;
+
+    hydro_x25519_swapin(x1i, x1);
+    x1   = (const uint8_t *) x1i;
+    swap = 0;
+    mem_zero(xs, 4 * sizeof(hydro_x25519_fe));
+    x2[0] = z3[0] = 1;
+    memcpy(x3, x1, sizeof(hydro_x25519_fe));
+    for (i = 255; i >= 0; i--) {
+        uint8_t             bytei = scalar[i / 8];
+        hydro_x25519_limb_t doswap;
+        hydro_x25519_fe     x1_dup;
+
+        if (clamp) {
+            if (i / 8 == 0) {
+                bytei &= ~7;
+            } else if (i / 8 == hydro_x25519_BYTES - 1) {
+                bytei &= 0x7F;
+                bytei |= 0x40;
+            }
+        }
+        doswap = 1U + ~(hydro_x25519_limb_t)((bytei >> (i % 8)) & 1);
+        hydro_x25519_condswap(x2, x3, swap ^ doswap);
+        swap = doswap;
+        hydro_x25519_ladder_part1(xs);
+        memcpy(x1_dup, x1, sizeof x1_dup);
+        hydro_x25519_ladder_part2(xs, x1_dup);
+    }
+    hydro_x25519_condswap(x2, x3, swap);
+}
+
+static int
+hydro_x25519_scalarmult(uint8_t       out[hydro_x25519_BYTES],
+                        const uint8_t scalar[hydro_x25519_SECRETKEYBYTES],
+                        const uint8_t x1[hydro_x25519_PUBLICKEYBYTES], bool clamp)
+{
+    hydro_x25519_fe      xs[5];
+    hydro_x25519_limb_t *x2, *z2, *z3;
+    hydro_x25519_limb_t *prev;
+    int                  i;
+    int                  ret;
+
+    hydro_x25519_core(xs, scalar, x1, clamp);
+
+    /* Precomputed inversion chain */
+    x2   = xs[0];
+    z2   = xs[1];
+    z3   = xs[3];
+    prev = z2;
+
+    /* Raise to the p-2 = 0x7f..ffeb */
+    for (i = 253; i >= 0; i--) {
+        hydro_x25519_sqr(z3, prev);
+        prev = z3;
+        if (i >= 8 || (0xeb >> i & 1)) {
+            hydro_x25519_mul1(z3, z2);
+        }
+    }
+
+    /* Here prev = z3 */
+    /* x2 /= z2 */
+    hydro_x25519_mul1(x2, z3);
+    ret = hydro_x25519_canon(x2);
+    hydro_x25519_swapout(out, x2);
+
+    if (clamp == 0) {
+        return 0;
+    }
+    return ret;
+}
+
+static inline int
+hydro_x25519_scalarmult_base(uint8_t       pk[hydro_x25519_PUBLICKEYBYTES],
+                             const uint8_t sk[hydro_x25519_SECRETKEYBYTES])
+{
+    return hydro_x25519_scalarmult(pk, sk, hydro_x25519_BASE_POINT, 1);
+}
+
+static inline void
+hydro_x25519_scalarmult_base_uniform(uint8_t       pk[hydro_x25519_PUBLICKEYBYTES],
+                                     const uint8_t sk[hydro_x25519_SECRETKEYBYTES])
+{
+    if (hydro_x25519_scalarmult(pk, sk, hydro_x25519_BASE_POINT, 0) != 0) {
+        abort();
+    }
+}
+
+static void
+hydro_x25519_sc_montmul(hydro_x25519_scalar_t out, const hydro_x25519_scalar_t a,
+                        const hydro_x25519_scalar_t b)
+{
+    hydro_x25519_limb_t hic = 0;
+    int                 i, j;
+
+    for (i = 0; i < hydro_x25519_NLIMBS; i++) {
+        hydro_x25519_limb_t carry = 0, carry2 = 0, mand = a[i],
+                            mand2 = hydro_x25519_MONTGOMERY_FACTOR;
+
+        for (j = 0; j < hydro_x25519_NLIMBS; j++) {
+            hydro_x25519_limb_t acc = out[j];
+
+            acc = hydro_x25519_umaal(&carry, acc, mand, b[j]);
+            if (j == 0) {
+                mand2 *= acc;
+            }
+            acc = hydro_x25519_umaal(&carry2, acc, mand2, hydro_x25519_sc_p[j]);
+            if (j > 0) {
+                out[j - 1] = acc;
+            }
+        }
+
+        /* Add two carry registers and high carry */
+        out[hydro_x25519_NLIMBS - 1] = hydro_x25519_adc(&hic, carry, carry2);
+    }
+
+    /* Reduce */
+    hydro_x25519_sdlimb_t scarry = 0;
+    for (i = 0; i < hydro_x25519_NLIMBS; i++) {
+        out[i] = (hydro_x25519_limb_t)(scarry = scarry + out[i] - hydro_x25519_sc_p[i]);
+        scarry >>= hydro_x25519_WBITS;
+    }
+    hydro_x25519_limb_t need_add = (hydro_x25519_limb_t) - (scarry + hic);
+
+    hydro_x25519_limb_t carry = 0;
+    for (i = 0; i < hydro_x25519_NLIMBS; i++) {
+        out[i] = hydro_x25519_umaal(&carry, out[i], need_add, hydro_x25519_sc_p[i]);
+    }
+}

--- a/ports/stm32/Makefile
+++ b/ports/stm32/Makefile
@@ -41,6 +41,7 @@ HAL_DIR=lib/stm32lib/STM32$(MCU_SERIES_UPPER)xx_HAL_Driver
 USBDEV_DIR=usbdev
 #USBHOST_DIR=usbhost
 DFU=$(TOP)/tools/dfu.py
+ENCRYPT_BIN=$(TOP)/tools/mboot_signed_dfu.py
 # may need to prefix dfu-util with sudo
 USE_PYDFU ?= 1
 PYDFU ?= $(TOP)/tools/pydfu.py
@@ -143,6 +144,16 @@ CXXFLAGS += $(filter-out -Wmissing-prototypes -Wold-style-definition -std=gnu99,
 CXXFLAGS += $(CXXFLAGS_MOD)
 ifneq ($(SRC_CXX)$(SRC_MOD_CXX),)
 LDFLAGS += -L$(dir $(shell $(CXX) $(CXXFLAGS) -print-file-name=libstdc++.a))
+endif
+
+# encrypted bootloader support
+MBOOT_ENCRYPTED ?= 0
+
+ifeq ($(MBOOT_ENCRYPTED), 1)
+# Ensure this matches mboot Makefile
+MBOOT_ENC_CHUNKSIZE ?= $$(( 24 * 1024 ))
+ENCRYPT_SECRET_KEY ?= $(BOARD_DIR)/key
+ENCRYPT_PUBLIC_KEY ?= $(BOARD_DIR)/key.pub
 endif
 
 # Options for mpy-cross
@@ -516,6 +527,11 @@ endif
 
 endif
 
+ifeq ($(MBOOT_ENCRYPTED), 1)
+CFLAGS += -DMBOOT_ENCRYPTED=1 -DAPPLICATION_ADDR=$(TEXT0_ADDR)
+SRC_C += footer.c
+endif
+
 OBJ += $(PY_O)
 OBJ += $(addprefix $(BUILD)/, $(LIB_SRC_C:.c=.o))
 OBJ += $(LIBM_O)
@@ -596,6 +612,18 @@ define GENERATE_BIN
 	$(Q)$(OBJCOPY) -O binary $(addprefix -j ,$(3)) $(2) $(1)
 endef
 
+ifeq ($(MBOOT_ENCRYPTED),1)
+define GENERATE_DFU
+	$(ECHO) "GEN ENC $(1)"
+	$(Q)$(PYTHON) $(ENCRYPT_BIN) \
+	-v $(BUILD)/genhdr/mpversion.h \
+	-D $(BOOTLOADER_DFU_USB_VID):$(BOOTLOADER_DFU_USB_PID) \
+	-s $(ENCRYPT_SECRET_KEY) -p $(ENCRYPT_PUBLIC_KEY) \
+	$(if $(2),$(addprefix -b ,$(3):$(2))) \
+	$(if $(4),$(addprefix -b ,$(5):$(4))) \
+	$(1)
+endef
+else
 define GENERATE_DFU
 	$(ECHO) "GEN $(1)"
 	$(Q)$(PYTHON) $(DFU) \
@@ -604,6 +632,7 @@ define GENERATE_DFU
 	$(if $(4),$(addprefix -b ,$(5):$(4))) \
 	$(1)
 endef
+endif
 
 define GENERATE_HEX
 	$(ECHO) "GEN $(1)"
@@ -623,7 +652,7 @@ TEXT0_ADDR ?= 0x08000000
 ifeq ($(TEXT1_ADDR),)
 # No TEXT1_ADDR given so put all firmware at TEXT0_ADDR location
 
-TEXT0_SECTIONS ?= .isr_vector .text .data
+TEXT0_SECTIONS ?= .isr_vector .text .data .footer
 
 deploy-stlink: $(BUILD)/firmware.bin
 	$(call RUN_STLINK,$^,$(TEXT0_ADDR))
@@ -641,7 +670,7 @@ else
 # TEXT0_ADDR and TEXT1_ADDR are specified so split firmware between these locations
 
 TEXT0_SECTIONS ?= .isr_vector
-TEXT1_SECTIONS ?= .text .data
+TEXT1_SECTIONS ?= .text .data .footer
 
 deploy-stlink: $(BUILD)/firmware0.bin $(BUILD)/firmware1.bin
 	$(call RUN_STLINK,$(word 1,$^),$(TEXT0_ADDR))

--- a/ports/stm32/boards/common_extratext_data_in_flash_app.ld
+++ b/ports/stm32/boards/common_extratext_data_in_flash_app.ld
@@ -1,5 +1,11 @@
 /* This linker script fragment is intended to be included in SECTIONS. */
 
+.ARM.exidx : {
+    __exidx_start = .;
+    *(.ARM.exidx* .gnu.linkonce.armexidx.*)
+    __exidx_end = .;
+} >FLASH_APP
+
 /* For C++ exception handling */
 .ARM :
 {
@@ -20,3 +26,8 @@ _sidata = LOADADDR(.data);
     . = ALIGN(4);
     _edata = .;
 } >RAM AT> FLASH_APP
+    
+.footer (ORIGIN(FLASH) + LENGTH(FLASH) - 0xD0 /* FW_FOOTER_LENGTH */ ) : 
+{
+    KEEP(*(.footer*)) /* put footer at end of flash space if defined in build */
+} >FLASH

--- a/ports/stm32/boards/common_extratext_data_in_flash_text.ld
+++ b/ports/stm32/boards/common_extratext_data_in_flash_text.ld
@@ -20,3 +20,8 @@ _sidata = LOADADDR(.data);
     . = ALIGN(4);
     _edata = .;
 } >RAM AT> FLASH_TEXT
+
+.footer (ORIGIN(FLASH) + LENGTH(FLASH) - 0xD0 /* FW_FOOTER_LENGTH */ ) : 
+{
+    KEEP(*(.footer*)) /* put footer at end of flash space */
+} >FLASH

--- a/ports/stm32/footer.c
+++ b/ports/stm32/footer.c
@@ -3,7 +3,7 @@
  *
  * The MIT License (MIT)
  *
- * Copyright (c) 2013, 2014 Damien P. George
+ * Copyright (c) 2013-2018 Damien P. George
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -23,16 +23,14 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-#ifndef MICROPY_INCLUDED_STM32_RNG_H
-#define MICROPY_INCLUDED_STM32_RNG_H
 
-#include "py/mpconfig.h"
+#if MBOOT_ENCRYPTED
+#include <mboot/encryption.h>
 
-uint32_t rng_get(void);
+// Instantiate firmware footer at end of cpu flash
+__attribute__((section(".footer"), used))
+const fw_footer_v1_t fw_footer = {
+    FOOTER_VERSION
+};
 
-#if !MBOOT
-#include "py/obj.h"
-MP_DECLARE_CONST_FUN_OBJ_0(pyb_rng_get_obj);
 #endif
-
-#endif // MICROPY_INCLUDED_STM32_RNG_H

--- a/ports/stm32/mboot/Makefile
+++ b/ports/stm32/mboot/Makefile
@@ -28,6 +28,7 @@ HAL_DIR=lib/stm32lib/STM32$(MCU_SERIES_UPPER)xx_HAL_Driver
 USBDEV_DIR=usbdev
 DFU=$(TOP)/tools/dfu.py
 PYDFU ?= $(TOP)/tools/pydfu.py
+MBOOT_SET_KEYS ?= $(TOP)/tools/mboot_set_key.py
 BOOTLOADER_DFU_USB_VID ?= 0x0483
 BOOTLOADER_DFU_USB_PID ?= 0xDF11
 STFLASH ?= st-flash
@@ -86,7 +87,7 @@ LDFLAGS += --gc-sections
 # Debugging/Optimization
 ifeq ($(DEBUG), 1)
 CFLAGS += -g -DPENDSV_DEBUG
-COPT = -O0
+COPT = -Og
 else
 COPT += -Os -DNDEBUG
 endif
@@ -128,6 +129,23 @@ SRC_O = \
 	$(STARTUP_FILE) \
 	$(SYSTEM_FILE) \
 	ports/stm32/resethandler.o \
+
+MBOOT_ENCRYPTED ?= 0
+ifeq ($(MBOOT_ENCRYPTED), 1)
+
+# Ensure this matches stm32 Makefile
+MBOOT_ENC_CHUNKSIZE ?= $$(( 24 * 1024 ))
+ENCRYPT_PUBLIC_KEY ?= $(BOARD_DIR)/key.pub
+
+SRC_C += \
+	lib/libhydrogen/hydrogen.c \
+    ports/stm32/rng.c
+
+CFLAGS += -DMBOOT_ENCRYPTED=1 -DPARTICLE -DPLATFORM_ID=3
+CFLAGS += -DMBOOT_ENC_CHUNKSIZE=$(MBOOT_ENC_CHUNKSIZE)
+
+$(BUILD)/lib/libhydrogen/hydrogen.o: COPT = -Os -DNDEBUG
+endif
 
 $(BUILD)/$(HAL_DIR)/Src/stm32$(MCU_SERIES)xx_ll_usb.o: CFLAGS += -Wno-attributes
 SRC_HAL = $(addprefix $(HAL_DIR)/Src/stm32$(MCU_SERIES)xx_,\
@@ -171,14 +189,21 @@ deploy-stlink: $(BUILD)/firmware.dfu
 	$(ECHO) "Writing $< to the board via ST-LINK"
 	$(Q)$(STFLASH) write $(BUILD)/firmware.bin $(FLASH_ADDR)
 
-$(BUILD)/firmware.dfu: $(BUILD)/firmware.elf
-	$(ECHO) "Create $@"
-	$(Q)$(OBJCOPY) -O binary -j .isr_vector -j .text -j .data $^ $(BUILD)/firmware.bin
-	$(Q)$(PYTHON) $(DFU) -b $(FLASH_ADDR):$(BUILD)/firmware.bin $@
+$(BUILD)/firmware.bin: $(BUILD)/firmware.elf
+	$(Q)$(OBJCOPY) -O binary --gap-fill 0xFF -j .isr_vector -j .text -j .data -j .footer $^ $@
+ifeq ($(MBOOT_ENCRYPTED), 1)
+ifneq ("$(wildcard $(ENCRYPT_PUBLIC_KEY))","")
+	$(Q)$(PYTHON) $(MBOOT_SET_KEYS) -p $(ENCRYPT_PUBLIC_KEY) -b $@
+endif
+endif
 
-$(BUILD)/firmware.hex: $(BUILD)/firmware.elf
+$(BUILD)/firmware.dfu: $(BUILD)/firmware.bin
 	$(ECHO) "Create $@"
-	$(Q)$(OBJCOPY) -O ihex $< $@
+	$(Q)$(PYTHON) $(DFU) -b $(FLASH_ADDR):$^ $@
+
+$(BUILD)/firmware.hex: $(BUILD)/firmware.bin
+	$(ECHO) "Create $@"
+	$(Q)$(OBJCOPY) -I binary --change-addresses $(FLASH_ADDR) -O ihex $^ $@
 
 $(BUILD)/firmware.elf: $(OBJ)
 	$(ECHO) "LINK $@"

--- a/ports/stm32/mboot/Particle.h
+++ b/ports/stm32/mboot/Particle.h
@@ -1,0 +1,9 @@
+// Stub header for libhydrogen use
+#include "py/mphal.h"
+
+
+#include "rng.h"
+
+static inline uint32_t HAL_RNG_GetRandomNumber() {
+    return rng_get();
+}

--- a/ports/stm32/mboot/dfu.h
+++ b/ports/stm32/mboot/dfu.h
@@ -104,6 +104,4 @@ typedef struct _dfu_state_t {
     uint8_t buf[DFU_XFER_SIZE] __attribute__((aligned(4)));
 } dfu_context_t;
 
-static dfu_context_t dfu_context SECTION_NOZERO_BSS;
-
 #endif // MICROPY_INCLUDED_STM32_MBOOT_DFU_H

--- a/ports/stm32/mboot/encryption.h
+++ b/ports/stm32/mboot/encryption.h
@@ -1,0 +1,89 @@
+/*
+ * This file is part of the MicroPython project, http://micropython.org/
+ *
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2017-2019 Damien P. George
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+#ifndef MICROPY_INCLUDED_STM32_MBOOT_ENCRYPTION_H
+#define MICROPY_INCLUDED_STM32_MBOOT_ENCRYPTION_H
+
+#if MBOOT_ENCRYPTED
+
+#include <stdint.h>
+#include "py/mphal.h"
+#include "dfu.h"
+#include "extmod/uzlib/uzlib.h"
+#include "lib/libhydrogen/hydrogen.h"
+
+// Encrypted & signed bootloader support
+
+#define MBOOT_FW_SECTIONS 4
+#define FOOTER_VERSION 1
+
+// Footer stored at the end of flash; 208 bytes long
+typedef struct __attribute__ ((__packed__)) {
+    uint32_t address;
+    uint32_t length;
+    uint8_t sha256[32];
+} fw_footer_section_v1_t;
+
+typedef uint8_t public_key_t[hydro_sign_PUBLICKEYBYTES];
+
+typedef struct __attribute__ ((__packed__)) _fw_footer_v1 {
+    uint8_t footer_vers;
+    char version[15];
+    public_key_t public_key;
+    fw_footer_section_v1_t sections[MBOOT_FW_SECTIONS];
+} fw_footer_v1_t;
+
+enum chunk_format {
+    RAW=0,
+    GZIP=1
+};
+
+// Each DFU chunk transfered has this header to validate it.
+typedef struct __attribute__ ((__packed__)) _chunk_header_v1 {
+    uint8_t header_vers;
+    uint8_t format;  // chunk_format
+    uint32_t address;
+    uint32_t length;
+    uint8_t signature[64];  // hydro_sign_BYTES
+} chunk_header_v1_t;
+
+#define MBOOT_PUBLIC_KEY_LOCATION (APPLICATION_ADDR - sizeof(public_key_t))
+#define FW_FOOTER_LOCATION (FLASH_END + 1 - sizeof(fw_footer_v1_t))
+
+// Used by liibhydrogen
+#define ENC_CONTEXT "mbootenc"
+
+// pyb_usbdd_StrDescriptor
+#define  MBOOT_ERROR_STR_UNENCRYPTED_IDX 0x12
+#define  MBOOT_ERROR_STR_UNENCRYPTED "Encryption key not yet flashed"
+
+#define  MBOOT_ERROR_STR_INVALID_SIG_IDX 0x13
+#define  MBOOT_ERROR_STR_INVALID_SIG "Invalid signature in file"
+
+#define  MBOOT_ERROR_STR_INVALID_READ_IDX 0x14
+#define  MBOOT_ERROR_STR_INVALID_READ "Read support disabled on encrypted bootloader"
+
+#endif // MBOOT_ENCRYPTED
+#endif // MICROPY_INCLUDED_STM32_MBOOT_ENCRYPTION_H

--- a/ports/stm32/mboot/mboot.h
+++ b/ports/stm32/mboot/mboot.h
@@ -55,7 +55,7 @@ void led_state_all(unsigned int mask);
 
 int do_page_erase(uint32_t addr, uint32_t *next_addr);
 void do_read(uint32_t addr, int len, uint8_t *buf);
-int do_write(uint32_t addr, const uint8_t *src8, size_t len);
+int do_write(uint32_t addr, uint8_t *src8, size_t len);
 
 const uint8_t *elem_search(const uint8_t *elem, uint8_t elem_id);
 int fsload_process(void);

--- a/ports/stm32/mboot/stm32_generic.ld
+++ b/ports/stm32/mboot/stm32_generic.ld
@@ -52,6 +52,11 @@ SECTIONS
         . = ALIGN(4);
         _edata = .;
     } >RAM AT> FLASH_BL
+    
+    .footer (ORIGIN(FLASH_BL) + LENGTH(FLASH_BL) - 32 /* ENC_KEY_LENGTH */ ) : 
+    {
+        KEEP(*(.footer*)) /* put key at end of bootloader sector if defined in build */
+    } >FLASH_BL
 
     /* Zeroed-out data section */
     .bss :

--- a/ports/stm32/rng.c
+++ b/ports/stm32/rng.c
@@ -55,11 +55,13 @@ uint32_t rng_get(void) {
     return RNG->DR;
 }
 
+#if !MBOOT
 // Return a 30-bit hardware generated random number.
 STATIC mp_obj_t pyb_rng_get(void) {
     return mp_obj_new_int(rng_get() >> 2);
 }
 MP_DEFINE_CONST_FUN_OBJ_0(pyb_rng_get_obj, pyb_rng_get);
+#endif
 
 #else // MICROPY_HW_ENABLE_RNG
 

--- a/tools/dfu.py
+++ b/tools/dfu.py
@@ -72,15 +72,15 @@ def parse(file, dump_images=False):
         print("PARSE ERROR")
 
 
-def build(file, targets, device=DEFAULT_DEVICE):
+def build(file, targets, device=DEFAULT_DEVICE, pad=True):
     data = b""
     for t, target in enumerate(targets):
         tdata = b""
         for image in target:
-            # pad image to 8 bytes (needed at least for L476)
-            pad = (8 - len(image["data"]) % 8) % 8
-            image["data"] = image["data"] + bytes(bytearray(8)[0:pad])
-            #
+            if pad:
+                # pad image to 8 bytes (needed at least for L476)
+                pad = (8 - len(image["data"]) % 8) % 8
+                image["data"] = image["data"] + bytes(bytearray(8)[0:pad])
             tdata += struct.pack("<2I", image["address"], len(image["data"])) + image["data"]
         tdata = (
             struct.pack("<6sBI255s2I", b"Target", 0, 1, b"ST...", len(tdata), len(target)) + tdata

--- a/tools/intelhex.py
+++ b/tools/intelhex.py
@@ -1,0 +1,1595 @@
+# Copyright (c) 2005-2018, Alexander Belchenko
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms,
+# with or without modification, are permitted provided
+# that the following conditions are met:
+#
+# * Redistributions of source code must retain
+#   the above copyright notice, this list of conditions
+#   and the following disclaimer.
+# * Redistributions in binary form must reproduce
+#   the above copyright notice, this list of conditions
+#   and the following disclaimer in the documentation
+#   and/or other materials provided with the distribution.
+# * Neither the name of the author nor the names
+#   of its contributors may be used to endorse
+#   or promote products derived from this software
+#   without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING,
+# BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+# AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+# IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE
+# FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+# OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+# PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,
+# OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+# AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+# STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+# EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+"""Intel HEX format manipulation library."""
+
+__docformat__ = "javadoc"
+
+from array import array
+from binascii import hexlify, unhexlify
+from bisect import bisect_right
+import os
+import sys
+
+# from intelhex.compat import (
+#     IntTypes,
+#     StrType,
+#     StringIO,
+#     array_tobytes,
+#     asbytes,
+#     asstr,
+#     dict_items_g,
+#     dict_keys,
+#     dict_keys_g,
+#     range_g,
+#     range_l,
+#     )
+
+# from intelhex.getsizeof import total_size
+
+
+class _DeprecatedParam(object):
+    pass
+
+
+_DEPRECATED = _DeprecatedParam()
+
+
+class IntelHex(object):
+    """ Intel HEX file reader. """
+
+    def __init__(self, source=None):
+        """ Constructor. If source specified, object will be initialized
+        with the contents of source. Otherwise the object will be empty.
+
+        @param  source      source for initialization
+                            (file name of HEX file, file object, addr dict or
+                             other IntelHex object)
+        """
+        # public members
+        self.padding = 0x0FF
+        # Start Address
+        self.start_addr = None
+
+        # private members
+        self._buf = {}
+        self._offset = 0
+
+        if source is not None:
+            if isinstance(source, StrType) or getattr(source, "read", None):
+                # load hex file
+                self.loadhex(source)
+            elif isinstance(source, dict):
+                self.fromdict(source)
+            elif isinstance(source, IntelHex):
+                self.padding = source.padding
+                if source.start_addr:
+                    self.start_addr = source.start_addr.copy()
+                self._buf = source._buf.copy()
+            else:
+                raise ValueError("source: bad initializer type")
+
+    def _decode_record(self, s, line=0):
+        """Decode one record of HEX file.
+
+        @param  s       line with HEX record.
+        @param  line    line number (for error messages).
+
+        @raise  EndOfFile   if EOF record encountered.
+        """
+        s = s.rstrip("\r\n")
+        if not s:
+            return  # empty line
+
+        if s[0] == ":":
+            try:
+                bin = array("B", unhexlify(asbytes(s[1:])))
+            except (TypeError, ValueError):
+                # this might be raised by unhexlify when odd hexascii digits
+                raise HexRecordError(line=line)
+            length = len(bin)
+            if length < 5:
+                raise HexRecordError(line=line)
+        else:
+            raise HexRecordError(line=line)
+
+        record_length = bin[0]
+        if length != (5 + record_length):
+            raise RecordLengthError(line=line)
+
+        addr = bin[1] * 256 + bin[2]
+
+        record_type = bin[3]
+        if not (0 <= record_type <= 5):
+            raise RecordTypeError(line=line)
+
+        crc = sum(bin)
+        crc &= 0x0FF
+        if crc != 0:
+            raise RecordChecksumError(line=line)
+
+        if record_type == 0:
+            # data record
+            addr += self._offset
+            for i in range_g(4, 4 + record_length):
+                if not self._buf.get(addr, None) is None:
+                    raise AddressOverlapError(address=addr, line=line)
+                self._buf[addr] = bin[i]
+                addr += 1  # FIXME: addr should be wrapped
+                # BUT after 02 record (at 64K boundary)
+                # and after 04 record (at 4G boundary)
+
+        elif record_type == 1:
+            # end of file record
+            if record_length != 0:
+                raise EOFRecordError(line=line)
+            raise _EndOfFile
+
+        elif record_type == 2:
+            # Extended 8086 Segment Record
+            if record_length != 2 or addr != 0:
+                raise ExtendedSegmentAddressRecordError(line=line)
+            self._offset = (bin[4] * 256 + bin[5]) * 16
+
+        elif record_type == 4:
+            # Extended Linear Address Record
+            if record_length != 2 or addr != 0:
+                raise ExtendedLinearAddressRecordError(line=line)
+            self._offset = (bin[4] * 256 + bin[5]) * 65536
+
+        elif record_type == 3:
+            # Start Segment Address Record
+            if record_length != 4 or addr != 0:
+                raise StartSegmentAddressRecordError(line=line)
+            if self.start_addr:
+                raise DuplicateStartAddressRecordError(line=line)
+            self.start_addr = {
+                "CS": bin[4] * 256 + bin[5],
+                "IP": bin[6] * 256 + bin[7],
+            }
+
+        elif record_type == 5:
+            # Start Linear Address Record
+            if record_length != 4 or addr != 0:
+                raise StartLinearAddressRecordError(line=line)
+            if self.start_addr:
+                raise DuplicateStartAddressRecordError(line=line)
+            self.start_addr = {
+                "EIP": (bin[4] * 16777216 + bin[5] * 65536 + bin[6] * 256 + bin[7]),
+            }
+
+    def loadhex(self, fobj):
+        """Load hex file into internal buffer. This is not necessary
+        if object was initialized with source set. This will overwrite
+        addresses if object was already initialized.
+
+        @param  fobj        file name or file-like object
+        """
+        if getattr(fobj, "read", None) is None:
+            fobj = open(fobj, "r")
+            fclose = fobj.close
+        else:
+            fclose = None
+
+        self._offset = 0
+        line = 0
+
+        try:
+            decode = self._decode_record
+            try:
+                for s in fobj:
+                    line += 1
+                    decode(s, line)
+            except _EndOfFile:
+                pass
+        finally:
+            if fclose:
+                fclose()
+
+    def loadbin(self, fobj, offset=0):
+        """Load bin file into internal buffer. Not needed if source set in
+        constructor. This will overwrite addresses without warning
+        if object was already initialized.
+
+        @param  fobj        file name or file-like object
+        @param  offset      starting address offset
+        """
+        fread = getattr(fobj, "read", None)
+        if fread is None:
+            f = open(fobj, "rb")
+            fread = f.read
+            fclose = f.close
+        else:
+            fclose = None
+
+        try:
+            self.frombytes(array("B", asbytes(fread())), offset=offset)
+        finally:
+            if fclose:
+                fclose()
+
+    def loadfile(self, fobj, format):
+        """Load data file into internal buffer. Preferred wrapper over
+        loadbin or loadhex.
+
+        @param  fobj        file name or file-like object
+        @param  format      file format ("hex" or "bin")
+        """
+        if format == "hex":
+            self.loadhex(fobj)
+        elif format == "bin":
+            self.loadbin(fobj)
+        else:
+            raise ValueError('format should be either "hex" or "bin";' " got %r instead" % format)
+
+    # alias (to be consistent with method tofile)
+    fromfile = loadfile
+
+    def fromdict(self, dikt):
+        """Load data from dictionary. Dictionary should contain int keys
+        representing addresses. Values should be the data to be stored in
+        those addresses in unsigned char form (i.e. not strings).
+        The dictionary may contain the key, ``start_addr``
+        to indicate the starting address of the data as described in README.
+
+        The contents of the dict will be merged with this object and will
+        overwrite any conflicts. This function is not necessary if the
+        object was initialized with source specified.
+        """
+        s = dikt.copy()
+        start_addr = s.get("start_addr")
+        if start_addr is not None:
+            del s["start_addr"]
+        for k in dict_keys_g(s):
+            if type(k) not in IntTypes or k < 0:
+                raise ValueError("Source dictionary should have only int keys")
+        self._buf.update(s)
+        if start_addr is not None:
+            self.start_addr = start_addr
+
+    def frombytes(self, bytes, offset=0):
+        """Load data from array or list of bytes.
+        Similar to loadbin() method but works directly with iterable bytes.
+        """
+        for b in bytes:
+            self._buf[offset] = b
+            offset += 1
+
+    def _get_start_end(self, start=None, end=None, size=None):
+        """Return default values for start and end if they are None.
+        If this IntelHex object is empty then it's error to
+        invoke this method with both start and end as None. 
+        """
+        if (start, end) == (None, None) and self._buf == {}:
+            raise EmptyIntelHexError
+        if size is not None:
+            if None not in (start, end):
+                raise ValueError(
+                    "tobinarray: you can't use start,end and size" " arguments in the same time"
+                )
+            if (start, end) == (None, None):
+                start = self.minaddr()
+            if start is not None:
+                end = start + size - 1
+            else:
+                start = end - size + 1
+                if start < 0:
+                    raise ValueError(
+                        "tobinarray: invalid size (%d) " "for given end address (%d)" % (size, end)
+                    )
+        else:
+            if start is None:
+                start = self.minaddr()
+            if end is None:
+                end = self.maxaddr()
+            if start > end:
+                start, end = end, start
+        return start, end
+
+    def tobinarray(self, start=None, end=None, pad=_DEPRECATED, size=None):
+        """ Convert this object to binary form as array. If start and end 
+        unspecified, they will be inferred from the data.
+        @param  start   start address of output bytes.
+        @param  end     end address of output bytes (inclusive).
+        @param  pad     [DEPRECATED PARAMETER, please use self.padding instead]
+                        fill empty spaces with this value
+                        (if pad is None then this method uses self.padding).
+        @param  size    size of the block, used with start or end parameter.
+        @return         array of unsigned char data.
+        """
+        if not isinstance(pad, _DeprecatedParam):
+            print("IntelHex.tobinarray: 'pad' parameter is deprecated.")
+            if pad is not None:
+                print("Please, use IntelHex.padding attribute instead.")
+            else:
+                print("Please, don't pass it explicitly.")
+                print("Use syntax like this: ih.tobinarray(start=xxx, end=yyy, size=zzz)")
+        else:
+            pad = None
+        return self._tobinarray_really(start, end, pad, size)
+
+    def _tobinarray_really(self, start, end, pad, size):
+        """Return binary array."""
+        if pad is None:
+            pad = self.padding
+        bin = array("B")
+        if self._buf == {} and None in (start, end):
+            return bin
+        if size is not None and size <= 0:
+            raise ValueError("tobinarray: wrong value for size")
+        start, end = self._get_start_end(start, end, size)
+        for i in range_g(start, end + 1):
+            bin.append(self._buf.get(i, pad))
+        return bin
+
+    def tobinstr(self, start=None, end=None, pad=_DEPRECATED, size=None):
+        """ Convert to binary form and return as binary string.
+        @param  start   start address of output bytes.
+        @param  end     end address of output bytes (inclusive).
+        @param  pad     [DEPRECATED PARAMETER, please use self.padding instead]
+                        fill empty spaces with this value
+                        (if pad is None then this method uses self.padding).
+        @param  size    size of the block, used with start or end parameter.
+        @return         bytes string of binary data.
+        """
+        if not isinstance(pad, _DeprecatedParam):
+            print("IntelHex.tobinstr: 'pad' parameter is deprecated.")
+            if pad is not None:
+                print("Please, use IntelHex.padding attribute instead.")
+            else:
+                print("Please, don't pass it explicitly.")
+                print("Use syntax like this: ih.tobinstr(start=xxx, end=yyy, size=zzz)")
+        else:
+            pad = None
+        return self._tobinstr_really(start, end, pad, size)
+
+    def _tobinstr_really(self, start, end, pad, size):
+        return array_tobytes(self._tobinarray_really(start, end, pad, size))
+
+    def tobinfile(self, fobj, start=None, end=None, pad=_DEPRECATED, size=None):
+        """Convert to binary and write to file.
+
+        @param  fobj    file name or file object for writing output bytes.
+        @param  start   start address of output bytes.
+        @param  end     end address of output bytes (inclusive).
+        @param  pad     [DEPRECATED PARAMETER, please use self.padding instead]
+                        fill empty spaces with this value
+                        (if pad is None then this method uses self.padding).
+        @param  size    size of the block, used with start or end parameter.
+        """
+        if not isinstance(pad, _DeprecatedParam):
+            print("IntelHex.tobinfile: 'pad' parameter is deprecated.")
+            if pad is not None:
+                print("Please, use IntelHex.padding attribute instead.")
+            else:
+                print("Please, don't pass it explicitly.")
+                print("Use syntax like this: ih.tobinfile(start=xxx, end=yyy, size=zzz)")
+        else:
+            pad = None
+        if getattr(fobj, "write", None) is None:
+            fobj = open(fobj, "wb")
+            close_fd = True
+        else:
+            close_fd = False
+
+        fobj.write(self._tobinstr_really(start, end, pad, size))
+
+        if close_fd:
+            fobj.close()
+
+    def todict(self):
+        """Convert to python dictionary.
+
+        @return         dict suitable for initializing another IntelHex object.
+        """
+        r = {}
+        r.update(self._buf)
+        if self.start_addr:
+            r["start_addr"] = self.start_addr
+        return r
+
+    def addresses(self):
+        """Returns all used addresses in sorted order.
+        @return         list of occupied data addresses in sorted order. 
+        """
+        aa = dict_keys(self._buf)
+        aa.sort()
+        return aa
+
+    def minaddr(self):
+        """Get minimal address of HEX content.
+        @return         minimal address or None if no data
+        """
+        aa = dict_keys(self._buf)
+        if aa == []:
+            return None
+        else:
+            return min(aa)
+
+    def maxaddr(self):
+        """Get maximal address of HEX content.
+        @return         maximal address or None if no data
+        """
+        aa = dict_keys(self._buf)
+        if aa == []:
+            return None
+        else:
+            return max(aa)
+
+    def __getitem__(self, addr):
+        """ Get requested byte from address.
+        @param  addr    address of byte.
+        @return         byte if address exists in HEX file, or self.padding
+                        if no data found.
+        """
+        t = type(addr)
+        if t in IntTypes:
+            if addr < 0:
+                raise TypeError("Address should be >= 0.")
+            return self._buf.get(addr, self.padding)
+        elif t == slice:
+            addresses = dict_keys(self._buf)
+            ih = IntelHex()
+            if addresses:
+                addresses.sort()
+                start = addr.start or addresses[0]
+                stop = addr.stop or (addresses[-1] + 1)
+                step = addr.step or 1
+                for i in range_g(start, stop, step):
+                    x = self._buf.get(i)
+                    if x is not None:
+                        ih[i] = x
+            return ih
+        else:
+            raise TypeError("Address has unsupported type: %s" % t)
+
+    def __setitem__(self, addr, byte):
+        """Set byte at address."""
+        t = type(addr)
+        if t in IntTypes:
+            if addr < 0:
+                raise TypeError("Address should be >= 0.")
+            self._buf[addr] = byte
+        elif t == slice:
+            if not isinstance(byte, (list, tuple)):
+                raise ValueError("Slice operation expects sequence of bytes")
+            start = addr.start
+            stop = addr.stop
+            step = addr.step or 1
+            if None not in (start, stop):
+                ra = range_l(start, stop, step)
+                if len(ra) != len(byte):
+                    raise ValueError("Length of bytes sequence does not match " "address range")
+            elif (start, stop) == (None, None):
+                raise TypeError("Unsupported address range")
+            elif start is None:
+                start = stop - len(byte)
+            elif stop is None:
+                stop = start + len(byte)
+            if start < 0:
+                raise TypeError("start address cannot be negative")
+            if stop < 0:
+                raise TypeError("stop address cannot be negative")
+            j = 0
+            for i in range_g(start, stop, step):
+                self._buf[i] = byte[j]
+                j += 1
+        else:
+            raise TypeError("Address has unsupported type: %s" % t)
+
+    def __delitem__(self, addr):
+        """Delete byte at address."""
+        t = type(addr)
+        if t in IntTypes:
+            if addr < 0:
+                raise TypeError("Address should be >= 0.")
+            del self._buf[addr]
+        elif t == slice:
+            addresses = dict_keys(self._buf)
+            if addresses:
+                addresses.sort()
+                start = addr.start or addresses[0]
+                stop = addr.stop or (addresses[-1] + 1)
+                step = addr.step or 1
+                for i in range_g(start, stop, step):
+                    x = self._buf.get(i)
+                    if x is not None:
+                        del self._buf[i]
+        else:
+            raise TypeError("Address has unsupported type: %s" % t)
+
+    def __len__(self):
+        """Return count of bytes with real values."""
+        return len(dict_keys(self._buf))
+
+    def _get_eol_textfile(eolstyle, platform):
+        if eolstyle == "native":
+            return "\n"
+        elif eolstyle == "CRLF":
+            if platform != "win32":
+                return "\r\n"
+            else:
+                return "\n"
+        else:
+            raise ValueError("wrong eolstyle %s" % repr(eolstyle))
+
+    _get_eol_textfile = staticmethod(_get_eol_textfile)
+
+    def write_hex_file(self, f, write_start_addr=True, eolstyle="native", byte_count=16):
+        """Write data to file f in HEX format.
+
+        @param  f                   filename or file-like object for writing
+        @param  write_start_addr    enable or disable writing start address
+                                    record to file (enabled by default).
+                                    If there is no start address in obj, nothing
+                                    will be written regardless of this setting.
+        @param  eolstyle            can be used to force CRLF line-endings
+                                    for output file on different platforms.
+                                    Supported eol styles: 'native', 'CRLF'.
+        @param byte_count           number of bytes in the data field
+        """
+        if byte_count > 255 or byte_count < 1:
+            raise ValueError("wrong byte_count value: %s" % byte_count)
+        fwrite = getattr(f, "write", None)
+        if fwrite:
+            fobj = f
+            fclose = None
+        else:
+            fobj = open(f, "w")
+            fwrite = fobj.write
+            fclose = fobj.close
+
+        eol = IntelHex._get_eol_textfile(eolstyle, sys.platform)
+
+        # Translation table for uppercasing hex ascii string.
+        # timeit shows that using hexstr.translate(table)
+        # is faster than hexstr.upper():
+        # 0.452ms vs. 0.652ms (translate vs. upper)
+        if sys.version_info[0] >= 3:
+            # Python 3
+            table = bytes(range_l(256)).upper()
+        else:
+            # Python 2
+            table = "".join(chr(i).upper() for i in range_g(256))
+
+        # start address record if any
+        if self.start_addr and write_start_addr:
+            keys = dict_keys(self.start_addr)
+            keys.sort()
+            bin = array("B", asbytes("\0" * 9))
+            if keys == ["CS", "IP"]:
+                # Start Segment Address Record
+                bin[0] = 4  # reclen
+                bin[1] = 0  # offset msb
+                bin[2] = 0  # offset lsb
+                bin[3] = 3  # rectyp
+                cs = self.start_addr["CS"]
+                bin[4] = (cs >> 8) & 0x0FF
+                bin[5] = cs & 0x0FF
+                ip = self.start_addr["IP"]
+                bin[6] = (ip >> 8) & 0x0FF
+                bin[7] = ip & 0x0FF
+                bin[8] = (-sum(bin)) & 0x0FF  # chksum
+                fwrite(":" + asstr(hexlify(array_tobytes(bin)).translate(table)) + eol)
+            elif keys == ["EIP"]:
+                # Start Linear Address Record
+                bin[0] = 4  # reclen
+                bin[1] = 0  # offset msb
+                bin[2] = 0  # offset lsb
+                bin[3] = 5  # rectyp
+                eip = self.start_addr["EIP"]
+                bin[4] = (eip >> 24) & 0x0FF
+                bin[5] = (eip >> 16) & 0x0FF
+                bin[6] = (eip >> 8) & 0x0FF
+                bin[7] = eip & 0x0FF
+                bin[8] = (-sum(bin)) & 0x0FF  # chksum
+                fwrite(":" + asstr(hexlify(array_tobytes(bin)).translate(table)) + eol)
+            else:
+                if fclose:
+                    fclose()
+                raise InvalidStartAddressValueError(start_addr=self.start_addr)
+
+        # data
+        addresses = dict_keys(self._buf)
+        addresses.sort()
+        addr_len = len(addresses)
+        if addr_len:
+            minaddr = addresses[0]
+            maxaddr = addresses[-1]
+
+            if maxaddr > 65535:
+                need_offset_record = True
+            else:
+                need_offset_record = False
+            high_ofs = 0
+
+            cur_addr = minaddr
+            cur_ix = 0
+
+            while cur_addr <= maxaddr:
+                if need_offset_record:
+                    bin = array("B", asbytes("\0" * 7))
+                    bin[0] = 2  # reclen
+                    bin[1] = 0  # offset msb
+                    bin[2] = 0  # offset lsb
+                    bin[3] = 4  # rectyp
+                    high_ofs = int(cur_addr >> 16)
+                    b = divmod(high_ofs, 256)
+                    bin[4] = b[0]  # msb of high_ofs
+                    bin[5] = b[1]  # lsb of high_ofs
+                    bin[6] = (-sum(bin)) & 0x0FF  # chksum
+                    fwrite(":" + asstr(hexlify(array_tobytes(bin)).translate(table)) + eol)
+
+                while True:
+                    # produce one record
+                    low_addr = cur_addr & 0x0FFFF
+                    # chain_len off by 1
+                    chain_len = min(byte_count - 1, 65535 - low_addr, maxaddr - cur_addr)
+
+                    # search continuous chain
+                    stop_addr = cur_addr + chain_len
+                    if chain_len:
+                        ix = bisect_right(
+                            addresses, stop_addr, cur_ix, min(cur_ix + chain_len + 1, addr_len)
+                        )
+                        chain_len = ix - cur_ix  # real chain_len
+                        # there could be small holes in the chain
+                        # but we will catch them by try-except later
+                        # so for big continuous files we will work
+                        # at maximum possible speed
+                    else:
+                        chain_len = 1  # real chain_len
+
+                    bin = array("B", asbytes("\0" * (5 + chain_len)))
+                    b = divmod(low_addr, 256)
+                    bin[1] = b[0]  # msb of low_addr
+                    bin[2] = b[1]  # lsb of low_addr
+                    bin[3] = 0  # rectype
+                    try:  # if there is small holes we'll catch them
+                        for i in range_g(chain_len):
+                            bin[4 + i] = self._buf[cur_addr + i]
+                    except KeyError:
+                        # we catch a hole so we should shrink the chain
+                        chain_len = i
+                        bin = bin[: 5 + i]
+                    bin[0] = chain_len
+                    bin[4 + chain_len] = (-sum(bin)) & 0x0FF  # chksum
+                    fwrite(":" + asstr(hexlify(array_tobytes(bin)).translate(table)) + eol)
+
+                    # adjust cur_addr/cur_ix
+                    cur_ix += chain_len
+                    if cur_ix < addr_len:
+                        cur_addr = addresses[cur_ix]
+                    else:
+                        cur_addr = maxaddr + 1
+                        break
+                    high_addr = int(cur_addr >> 16)
+                    if high_addr > high_ofs:
+                        break
+
+        # end-of-file record
+        fwrite(":00000001FF" + eol)
+        if fclose:
+            fclose()
+
+    def tofile(self, fobj, format):
+        """Write data to hex or bin file. Preferred method over tobin or tohex.
+
+        @param  fobj        file name or file-like object
+        @param  format      file format ("hex" or "bin")
+        """
+        if format == "hex":
+            self.write_hex_file(fobj)
+        elif format == "bin":
+            self.tobinfile(fobj)
+        else:
+            raise ValueError('format should be either "hex" or "bin";' " got %r instead" % format)
+
+    def gets(self, addr, length):
+        """Get string of bytes from given address. If any entries are blank
+        from addr through addr+length, a NotEnoughDataError exception will
+        be raised. Padding is not used.
+        """
+        a = array("B", asbytes("\0" * length))
+        try:
+            for i in range_g(length):
+                a[i] = self._buf[addr + i]
+        except KeyError:
+            raise NotEnoughDataError(address=addr, length=length)
+        return array_tobytes(a)
+
+    def puts(self, addr, s):
+        """Put string of bytes at given address. Will overwrite any previous
+        entries.
+        """
+        a = array("B", asbytes(s))
+        for i in range_g(len(a)):
+            self._buf[addr + i] = a[i]
+
+    def getsz(self, addr):
+        """Get zero-terminated bytes string from given address. Will raise 
+        NotEnoughDataError exception if a hole is encountered before a 0.
+        """
+        i = 0
+        try:
+            while True:
+                if self._buf[addr + i] == 0:
+                    break
+                i += 1
+        except KeyError:
+            raise NotEnoughDataError(
+                msg=("Bad access at 0x%X: " "not enough data to read zero-terminated string")
+                % addr
+            )
+        return self.gets(addr, i)
+
+    def putsz(self, addr, s):
+        """Put bytes string in object at addr and append terminating zero at end."""
+        self.puts(addr, s)
+        self._buf[addr + len(s)] = 0
+
+    def find(self, sub, start=None, end=None):
+        """Return the lowest index in self[start:end] where subsection sub is found.
+        Optional arguments start and end are interpreted as in slice notation.
+        
+        @param  sub     bytes-like subsection to find
+        @param  start   start of section to search within (optional)
+        @param  end     end of section to search within (optional)
+        """
+        sub = bytes(sub)
+        for start, end in self[slice(start, end)].segments():
+            b = self.gets(start, end - start)
+            i = b.find(sub)
+            if i != -1:
+                return start + i
+        return -1
+
+    def dump(self, tofile=None, width=16, withpadding=False):
+        """Dump object content to specified file object or to stdout if None.
+        Format is a hexdump with some header information at the beginning,
+        addresses on the left, and data on right.
+
+        @param  tofile          file-like object to dump to
+        @param  width           number of bytes per line (i.e. columns)
+        @param  withpadding     print padding character instead of '--'
+        @raise  ValueError      if width is not a positive integer
+        """
+
+        if not isinstance(width, int) or width < 1:
+            raise ValueError("width must be a positive integer.")
+        # The integer can be of float type - does not work with bit operations
+        width = int(width)
+        if tofile is None:
+            tofile = sys.stdout
+
+        # start addr possibly
+        if self.start_addr is not None:
+            cs = self.start_addr.get("CS")
+            ip = self.start_addr.get("IP")
+            eip = self.start_addr.get("EIP")
+            if eip is not None and cs is None and ip is None:
+                tofile.write("EIP = 0x%08X\n" % eip)
+            elif eip is None and cs is not None and ip is not None:
+                tofile.write("CS = 0x%04X, IP = 0x%04X\n" % (cs, ip))
+            else:
+                tofile.write("start_addr = %r\n" % start_addr)
+        # actual data
+        addresses = dict_keys(self._buf)
+        if addresses:
+            addresses.sort()
+            minaddr = addresses[0]
+            maxaddr = addresses[-1]
+            startaddr = (minaddr // width) * width
+            endaddr = ((maxaddr // width) + 1) * width
+            maxdigits = max(len(hex(endaddr)) - 2, 4)  # Less 2 to exclude '0x'
+            templa = "%%0%dX" % maxdigits
+            rangewidth = range_l(width)
+            if withpadding:
+                pad = self.padding
+            else:
+                pad = None
+            for i in range_g(startaddr, endaddr, width):
+                tofile.write(templa % i)
+                tofile.write(" ")
+                s = []
+                for j in rangewidth:
+                    x = self._buf.get(i + j, pad)
+                    if x is not None:
+                        tofile.write(" %02X" % x)
+                        if (
+                            32 <= x < 127
+                        ):  # GNU less does not like 0x7F (128 decimal) so we'd better show it as dot
+                            s.append(chr(x))
+                        else:
+                            s.append(".")
+                    else:
+                        tofile.write(" --")
+                        s.append(" ")
+                tofile.write("  |" + "".join(s) + "|\n")
+
+    def merge(self, other, overlap="error"):
+        """Merge content of other IntelHex object into current object (self).
+        @param  other   other IntelHex object.
+        @param  overlap action on overlap of data or starting addr:
+                        - error: raising OverlapError;
+                        - ignore: ignore other data and keep current data
+                                  in overlapping region;
+                        - replace: replace data with other data
+                                  in overlapping region.
+
+        @raise  TypeError       if other is not instance of IntelHex
+        @raise  ValueError      if other is the same object as self 
+                                (it can't merge itself)
+        @raise  ValueError      if overlap argument has incorrect value
+        @raise  AddressOverlapError    on overlapped data
+        """
+        # check args
+        if not isinstance(other, IntelHex):
+            raise TypeError("other should be IntelHex object")
+        if other is self:
+            raise ValueError("Can't merge itself")
+        if overlap not in ("error", "ignore", "replace"):
+            raise ValueError("overlap argument should be either " "'error', 'ignore' or 'replace'")
+        # merge data
+        this_buf = self._buf
+        other_buf = other._buf
+        for i in other_buf:
+            if i in this_buf:
+                if overlap == "error":
+                    raise AddressOverlapError("Data overlapped at address 0x%X" % i)
+                elif overlap == "ignore":
+                    continue
+            this_buf[i] = other_buf[i]
+        # merge start_addr
+        if self.start_addr != other.start_addr:
+            if self.start_addr is None:  # set start addr from other
+                self.start_addr = other.start_addr
+            elif other.start_addr is None:  # keep existing start addr
+                pass
+            else:  # conflict
+                if overlap == "error":
+                    raise AddressOverlapError("Starting addresses are different")
+                elif overlap == "replace":
+                    self.start_addr = other.start_addr
+
+    def segments(self):
+        """Return a list of ordered tuple objects, representing contiguous occupied data addresses.
+        Each tuple has a length of two and follows the semantics of the range and xrange objects.
+        The second entry of the tuple is always an integer greater than the first entry.
+        """
+        addresses = self.addresses()
+        if not addresses:
+            return []
+        elif len(addresses) == 1:
+            return [(addresses[0], addresses[0] + 1)]
+        adjacent_differences = [(b - a) for (a, b) in zip(addresses[:-1], addresses[1:])]
+        breaks = [i for (i, x) in enumerate(adjacent_differences) if x > 1]
+        endings = [addresses[b] for b in breaks]
+        endings.append(addresses[-1])
+        beginings = [addresses[b + 1] for b in breaks]
+        beginings.insert(0, addresses[0])
+        return [(a, b + 1) for (a, b) in zip(beginings, endings)]
+
+    def get_memory_size(self):
+        """Returns the approximate memory footprint for data."""
+        n = sys.getsizeof(self)
+        n += sys.getsizeof(self.padding)
+        n += total_size(self.start_addr)
+        n += total_size(self._buf)
+        n += sys.getsizeof(self._offset)
+        return n
+
+
+# /IntelHex
+
+
+class IntelHex16bit(IntelHex):
+    """Access to data as 16-bit words. Intended to use with Microchip HEX files."""
+
+    def __init__(self, source=None):
+        """Construct class from HEX file
+        or from instance of ordinary IntelHex class. If IntelHex object
+        is passed as source, the original IntelHex object should not be used
+        again because this class will alter it. This class leaves padding
+        alone unless it was precisely 0xFF. In that instance it is sign
+        extended to 0xFFFF.
+
+        @param  source  file name of HEX file or file object
+                        or instance of ordinary IntelHex class.
+                        Will also accept dictionary from todict method.
+        """
+        if isinstance(source, IntelHex):
+            # from ihex8
+            self.padding = source.padding
+            self.start_addr = source.start_addr
+            # private members
+            self._buf = source._buf
+            self._offset = source._offset
+        elif isinstance(source, dict):
+            raise IntelHexError(
+                "IntelHex16bit does not support initialization from dictionary yet.\n"
+                "Patches are welcome."
+            )
+        else:
+            IntelHex.__init__(self, source)
+
+        if self.padding == 0x0FF:
+            self.padding = 0x0FFFF
+
+    def __getitem__(self, addr16):
+        """Get 16-bit word from address.
+        Raise error if only one byte from the pair is set.
+        We assume a Little Endian interpretation of the hex file.
+
+        @param  addr16  address of word (addr8 = 2 * addr16).
+        @return         word if bytes exists in HEX file, or self.padding
+                        if no data found.
+        """
+        addr1 = addr16 * 2
+        addr2 = addr1 + 1
+        byte1 = self._buf.get(addr1, None)
+        byte2 = self._buf.get(addr2, None)
+
+        if byte1 != None and byte2 != None:
+            return byte1 | (byte2 << 8)  # low endian
+
+        if byte1 == None and byte2 == None:
+            return self.padding
+
+        raise BadAccess16bit(address=addr16)
+
+    def __setitem__(self, addr16, word):
+        """Sets the address at addr16 to word assuming Little Endian mode.
+        """
+        addr_byte = addr16 * 2
+        b = divmod(word, 256)
+        self._buf[addr_byte] = b[1]
+        self._buf[addr_byte + 1] = b[0]
+
+    def minaddr(self):
+        """Get minimal address of HEX content in 16-bit mode.
+
+        @return         minimal address used in this object
+        """
+        aa = dict_keys(self._buf)
+        if aa == []:
+            return 0
+        else:
+            return min(aa) >> 1
+
+    def maxaddr(self):
+        """Get maximal address of HEX content in 16-bit mode.
+
+        @return         maximal address used in this object 
+        """
+        aa = dict_keys(self._buf)
+        if aa == []:
+            return 0
+        else:
+            return max(aa) >> 1
+
+    def tobinarray(self, start=None, end=None, size=None):
+        """Convert this object to binary form as array (of 2-bytes word data).
+        If start and end unspecified, they will be inferred from the data.
+        @param  start   start address of output data.
+        @param  end     end address of output data (inclusive).
+        @param  size    size of the block (number of words),
+                        used with start or end parameter.
+        @return         array of unsigned short (uint16_t) data.
+        """
+        bin = array("H")
+
+        if self._buf == {} and None in (start, end):
+            return bin
+
+        if size is not None and size <= 0:
+            raise ValueError("tobinarray: wrong value for size")
+
+        start, end = self._get_start_end(start, end, size)
+
+        for addr in range_g(start, end + 1):
+            bin.append(self[addr])
+
+        return bin
+
+
+# /class IntelHex16bit
+
+
+def hex2bin(fin, fout, start=None, end=None, size=None, pad=None):
+    """Hex-to-Bin convertor engine.
+    @return     0   if all OK
+
+    @param  fin     input hex file (filename or file-like object)
+    @param  fout    output bin file (filename or file-like object)
+    @param  start   start of address range (optional)
+    @param  end     end of address range (inclusive; optional)
+    @param  size    size of resulting file (in bytes) (optional)
+    @param  pad     padding byte (optional)
+    """
+    try:
+        h = IntelHex(fin)
+    except HexReaderError:
+        e = sys.exc_info()[1]  # current exception
+        txt = "ERROR: bad HEX file: %s" % str(e)
+        print(txt)
+        return 1
+
+    # start, end, size
+    if size != None and size != 0:
+        if end == None:
+            if start == None:
+                start = h.minaddr()
+            end = start + size - 1
+        else:
+            if (end + 1) >= size:
+                start = end + 1 - size
+            else:
+                start = 0
+
+    try:
+        if pad is not None:
+            # using .padding attribute rather than pad argument to function call
+            h.padding = pad
+        h.tobinfile(fout, start, end)
+    except IOError:
+        e = sys.exc_info()[1]  # current exception
+        txt = "ERROR: Could not write to file: %s: %s" % (fout, str(e))
+        print(txt)
+        return 1
+
+    return 0
+
+
+# /def hex2bin
+
+
+def bin2hex(fin, fout, offset=0):
+    """Simple bin-to-hex convertor.
+    @return     0   if all OK
+
+    @param  fin     input bin file (filename or file-like object)
+    @param  fout    output hex file (filename or file-like object)
+    @param  offset  starting address offset for loading bin
+    """
+    h = IntelHex()
+    try:
+        h.loadbin(fin, offset)
+    except IOError:
+        e = sys.exc_info()[1]  # current exception
+        txt = "ERROR: unable to load bin file:", str(e)
+        print(txt)
+        return 1
+
+    try:
+        h.tofile(fout, format="hex")
+    except IOError:
+        e = sys.exc_info()[1]  # current exception
+        txt = "ERROR: Could not write to file: %s: %s" % (fout, str(e))
+        print(txt)
+        return 1
+
+    return 0
+
+
+# /def bin2hex
+
+
+def diff_dumps(ih1, ih2, tofile=None, name1="a", name2="b", n_context=3):
+    """Diff 2 IntelHex objects and produce unified diff output for their
+    hex dumps.
+
+    @param ih1        first IntelHex object to compare
+    @param ih2        second IntelHex object to compare
+    @param tofile     file-like object to write output
+    @param name1      name of the first hex file to show in the diff header
+    @param name2      name of the first hex file to show in the diff header
+    @param n_context  number of context lines in the unidiff output
+    """
+
+    def prepare_lines(ih):
+        sio = StringIO()
+        ih.dump(sio)
+        dump = sio.getvalue()
+        lines = dump.splitlines()
+        return lines
+
+    a = prepare_lines(ih1)
+    b = prepare_lines(ih2)
+    import difflib
+
+    result = list(
+        difflib.unified_diff(a, b, fromfile=name1, tofile=name2, n=n_context, lineterm="")
+    )
+    if tofile is None:
+        tofile = sys.stdout
+    output = "\n".join(result) + "\n"
+    tofile.write(output)
+
+
+class Record(object):
+    """Helper methods to build valid ihex records."""
+
+    def _from_bytes(bytes):
+        """Takes a list of bytes, computes the checksum, and outputs the entire
+        record as a string. bytes should be the hex record without the colon
+        or final checksum.
+
+        @param  bytes   list of byte values so far to pack into record.
+        @return         String representation of one HEX record
+        """
+        assert len(bytes) >= 4
+        # calculate checksum
+        s = (-sum(bytes)) & 0x0FF
+        bin = array("B", bytes + [s])
+        return ":" + asstr(hexlify(array_tobytes(bin))).upper()
+
+    _from_bytes = staticmethod(_from_bytes)
+
+    def data(offset, bytes):
+        """Return Data record. This constructs the full record, including
+        the length information, the record type (0x00), the
+        checksum, and the offset.
+
+        @param  offset  load offset of first byte.
+        @param  bytes   list of byte values to pack into record.
+
+        @return         String representation of one HEX record
+        """
+        assert 0 <= offset < 65536
+        assert 0 < len(bytes) < 256
+        b = [len(bytes), (offset >> 8) & 0x0FF, offset & 0x0FF, 0x00] + bytes
+        return Record._from_bytes(b)
+
+    data = staticmethod(data)
+
+    def eof():
+        """Return End of File record as a string.
+        @return         String representation of Intel Hex EOF record 
+        """
+        return ":00000001FF"
+
+    eof = staticmethod(eof)
+
+    def extended_segment_address(usba):
+        """Return Extended Segment Address Record.
+        @param  usba     Upper Segment Base Address.
+
+        @return         String representation of Intel Hex USBA record.
+        """
+        b = [2, 0, 0, 0x02, (usba >> 8) & 0x0FF, usba & 0x0FF]
+        return Record._from_bytes(b)
+
+    extended_segment_address = staticmethod(extended_segment_address)
+
+    def start_segment_address(cs, ip):
+        """Return Start Segment Address Record.
+        @param  cs      16-bit value for CS register.
+        @param  ip      16-bit value for IP register.
+
+        @return         String representation of Intel Hex SSA record.
+        """
+        b = [4, 0, 0, 0x03, (cs >> 8) & 0x0FF, cs & 0x0FF, (ip >> 8) & 0x0FF, ip & 0x0FF]
+        return Record._from_bytes(b)
+
+    start_segment_address = staticmethod(start_segment_address)
+
+    def extended_linear_address(ulba):
+        """Return Extended Linear Address Record.
+        @param  ulba    Upper Linear Base Address.
+
+        @return         String representation of Intel Hex ELA record.
+        """
+        b = [2, 0, 0, 0x04, (ulba >> 8) & 0x0FF, ulba & 0x0FF]
+        return Record._from_bytes(b)
+
+    extended_linear_address = staticmethod(extended_linear_address)
+
+    def start_linear_address(eip):
+        """Return Start Linear Address Record.
+        @param  eip     32-bit linear address for the EIP register.
+
+        @return         String representation of Intel Hex SLA record.
+        """
+        b = [
+            4,
+            0,
+            0,
+            0x05,
+            (eip >> 24) & 0x0FF,
+            (eip >> 16) & 0x0FF,
+            (eip >> 8) & 0x0FF,
+            eip & 0x0FF,
+        ]
+        return Record._from_bytes(b)
+
+    start_linear_address = staticmethod(start_linear_address)
+
+
+class _BadFileNotation(Exception):
+    """Special error class to use with _get_file_and_addr_range."""
+
+    pass
+
+
+def _get_file_and_addr_range(s, _support_drive_letter=None):
+    """Special method for hexmerge.py script to split file notation
+    into 3 parts: (filename, start, end)
+
+    @raise _BadFileNotation  when string cannot be safely split.
+    """
+    if _support_drive_letter is None:
+        _support_drive_letter = os.name == "nt"
+    drive = ""
+    if _support_drive_letter:
+        if s[1:2] == ":" and s[0].upper() in "".join(
+            [chr(i) for i in range_g(ord("A"), ord("Z") + 1)]
+        ):
+            drive = s[:2]
+            s = s[2:]
+    parts = s.split(":")
+    n = len(parts)
+    if n == 1:
+        fname = parts[0]
+        fstart = None
+        fend = None
+    elif n != 3:
+        raise _BadFileNotation
+    else:
+        fname = parts[0]
+
+        def ascii_hex_to_int(ascii):
+            if ascii is not None:
+                try:
+                    return int(ascii, 16)
+                except ValueError:
+                    raise _BadFileNotation
+            return ascii
+
+        fstart = ascii_hex_to_int(parts[1] or None)
+        fend = ascii_hex_to_int(parts[2] or None)
+    return drive + fname, fstart, fend
+
+
+##
+# IntelHex Errors Hierarchy:
+#
+#  IntelHexError    - basic error
+#       HexReaderError  - general hex reader error
+#           AddressOverlapError - data for the same address overlap
+#           HexRecordError      - hex record decoder base error
+#               RecordLengthError    - record has invalid length
+#               RecordTypeError      - record has invalid type (RECTYP)
+#               RecordChecksumError  - record checksum mismatch
+#               EOFRecordError              - invalid EOF record (type 01)
+#               ExtendedAddressRecordError  - extended address record base error
+#                   ExtendedSegmentAddressRecordError   - invalid extended segment address record (type 02)
+#                   ExtendedLinearAddressRecordError    - invalid extended linear address record (type 04)
+#               StartAddressRecordError     - start address record base error
+#                   StartSegmentAddressRecordError      - invalid start segment address record (type 03)
+#                   StartLinearAddressRecordError       - invalid start linear address record (type 05)
+#                   DuplicateStartAddressRecordError    - start address record appears twice
+#                   InvalidStartAddressValueError       - invalid value of start addr record
+#       _EndOfFile  - it's not real error, used internally by hex reader as signal that EOF record found
+#       BadAccess16bit - not enough data to read 16 bit value (deprecated, see NotEnoughDataError)
+#       NotEnoughDataError - not enough data to read N contiguous bytes
+#       EmptyIntelHexError - requested operation cannot be performed with empty object
+
+
+class IntelHexError(Exception):
+    """Base Exception class for IntelHex module"""
+
+    _fmt = "IntelHex base error"  #: format string
+
+    def __init__(self, msg=None, **kw):
+        """Initialize the Exception with the given message.
+        """
+        self.msg = msg
+        for key, value in dict_items_g(kw):
+            setattr(self, key, value)
+
+    def __str__(self):
+        """Return the message in this Exception."""
+        if self.msg:
+            return self.msg
+        try:
+            return self._fmt % self.__dict__
+        except (NameError, ValueError, KeyError):
+            e = sys.exc_info()[1]  # current exception
+            return "Unprintable exception %s: %s" % (repr(e), str(e))
+
+
+class _EndOfFile(IntelHexError):
+    """Used for internal needs only."""
+
+    _fmt = "EOF record reached -- signal to stop read file"
+
+
+class HexReaderError(IntelHexError):
+    _fmt = "Hex reader base error"
+
+
+class AddressOverlapError(HexReaderError):
+    _fmt = "Hex file has data overlap at address 0x%(address)X on line %(line)d"
+
+
+# class NotAHexFileError was removed in trunk.revno.54 because it's not used
+
+
+class HexRecordError(HexReaderError):
+    _fmt = "Hex file contains invalid record at line %(line)d"
+
+
+class RecordLengthError(HexRecordError):
+    _fmt = "Record at line %(line)d has invalid length"
+
+
+class RecordTypeError(HexRecordError):
+    _fmt = "Record at line %(line)d has invalid record type"
+
+
+class RecordChecksumError(HexRecordError):
+    _fmt = "Record at line %(line)d has invalid checksum"
+
+
+class EOFRecordError(HexRecordError):
+    _fmt = "File has invalid End-of-File record"
+
+
+class ExtendedAddressRecordError(HexRecordError):
+    _fmt = "Base class for extended address exceptions"
+
+
+class ExtendedSegmentAddressRecordError(ExtendedAddressRecordError):
+    _fmt = "Invalid Extended Segment Address Record at line %(line)d"
+
+
+class ExtendedLinearAddressRecordError(ExtendedAddressRecordError):
+    _fmt = "Invalid Extended Linear Address Record at line %(line)d"
+
+
+class StartAddressRecordError(HexRecordError):
+    _fmt = "Base class for start address exceptions"
+
+
+class StartSegmentAddressRecordError(StartAddressRecordError):
+    _fmt = "Invalid Start Segment Address Record at line %(line)d"
+
+
+class StartLinearAddressRecordError(StartAddressRecordError):
+    _fmt = "Invalid Start Linear Address Record at line %(line)d"
+
+
+class DuplicateStartAddressRecordError(StartAddressRecordError):
+    _fmt = "Start Address Record appears twice at line %(line)d"
+
+
+class InvalidStartAddressValueError(StartAddressRecordError):
+    _fmt = "Invalid start address value: %(start_addr)s"
+
+
+class NotEnoughDataError(IntelHexError):
+    _fmt = "Bad access at 0x%(address)X: " "not enough data to read %(length)d contiguous bytes"
+
+
+class BadAccess16bit(NotEnoughDataError):
+    _fmt = "Bad access at 0x%(address)X: not enough data to read 16 bit value"
+
+
+class EmptyIntelHexError(IntelHexError):
+    _fmt = "Requested operation cannot be executed with empty object"
+
+
+# intelhex.compat
+
+if sys.version_info[0] >= 3:
+    # Python 3
+    Python = 3
+
+    def asbytes(s):
+        if isinstance(s, bytes):
+            return s
+        return s.encode("latin1")
+
+    def asstr(s):
+        if isinstance(s, str):
+            return s
+        return s.decode("latin1")
+
+    array_tobytes = getattr(array, "tobytes", array.tostring)
+
+    IntTypes = (int,)
+    StrType = str
+    UnicodeType = str
+
+    range_g = range  # range generator
+
+    def range_l(*args):  # range list
+        return list(range(*args))
+
+    def dict_keys(dikt):  # dict keys list
+        return list(dikt.keys())
+
+    def dict_keys_g(dikt):  # dict keys generator
+        return dikt.keys()
+
+    def dict_items_g(dikt):  # dict items generator
+        return dikt.items()
+
+    from io import StringIO, BytesIO
+
+    def get_binary_stdout():
+        return sys.stdout.buffer
+
+    def get_binary_stdin():
+        return sys.stdin.buffer
+
+
+else:
+    # Python 2
+    Python = 2
+
+    asbytes = str
+    asstr = str
+
+    array_tobytes = array.tostring
+
+    IntTypes = (int, long)
+    StrType = basestring
+    UnicodeType = unicode
+
+    # range_g = xrange    # range generator
+    def range_g(*args):
+        # we want to use xrange here but on python 2 it does not work with long ints
+        try:
+            return xrange(*args)
+        except OverflowError:
+            start = 0
+            stop = 0
+            step = 1
+            n = len(args)
+            if n == 1:
+                stop = args[0]
+            elif n == 2:
+                start, stop = args
+            elif n == 3:
+                start, stop, step = args
+            else:
+                raise TypeError("wrong number of arguments in range_g call!")
+            if step == 0:
+                raise ValueError("step cannot be zero")
+            if step > 0:
+
+                def up(start, stop, step):
+                    while start < stop:
+                        yield start
+                        start += step
+
+                return up(start, stop, step)
+            else:
+
+                def down(start, stop, step):
+                    while start > stop:
+                        yield start
+                        start += step
+
+                return down(start, stop, step)
+
+    range_l = range  # range list
+
+    def dict_keys(dikt):  # dict keys list
+        return dikt.keys()
+
+    def dict_keys_g(dikt):  # dict keys generator
+        return dikt.keys()
+
+    def dict_items_g(dikt):  # dict items generator
+        return dikt.items()
+
+    from cStringIO import StringIO
+
+    BytesIO = StringIO
+
+    import os
+
+    def _force_stream_binary(stream):
+        """Force binary mode for stream on Windows."""
+        if os.name == "nt":
+            f_fileno = getattr(stream, "fileno", None)
+            if f_fileno:
+                fileno = f_fileno()
+                if fileno >= 0:
+                    import msvcrt
+
+                    msvcrt.setmode(fileno, os.O_BINARY)
+        return stream
+
+    def get_binary_stdout():
+        return _force_stream_binary(sys.stdout)
+
+    def get_binary_stdin():
+        return _force_stream_binary(sys.stdin)
+
+
+# intelhex.getsizeof
+
+import sys
+from itertools import chain
+from collections import deque
+
+try:
+    from reprlib import repr
+except ImportError:
+    pass
+
+
+def total_size(o, handlers={}, verbose=False):
+    """ Returns the approximate memory footprint an object and all of its contents.
+
+    Automatically finds the contents of the following builtin containers and
+    their subclasses:  tuple, list, deque, dict, set and frozenset.
+    To search other containers, add handlers to iterate over their contents:
+
+        handlers = {SomeContainerClass: iter,
+                    OtherContainerClass: OtherContainerClass.get_elements}
+
+    """
+    dict_handler = lambda d: chain.from_iterable(d.items())
+    all_handlers = {
+        tuple: iter,
+        list: iter,
+        deque: iter,
+        dict: dict_handler,
+        set: iter,
+        frozenset: iter,
+    }
+    all_handlers.update(handlers)  # user handlers take precedence
+    seen = set()  # track which object id's have already been seen
+    default_size = sys.getsizeof(0)  # estimate sizeof object without __sizeof__
+
+    def sizeof(o):
+        if id(o) in seen:  # do not double count the same object
+            return 0
+        seen.add(id(o))
+        s = sys.getsizeof(o, default_size)
+
+        if verbose:
+            print(s, type(o), repr(o))  # , file=stderr)
+
+        for typ, handler in all_handlers.items():
+            if isinstance(o, typ):
+                s += sum(map(sizeof, handler(o)))
+                break
+        return s
+
+    return sizeof(o)

--- a/tools/mboot_generate_keys.py
+++ b/tools/mboot_generate_keys.py
@@ -1,0 +1,21 @@
+import os
+import sys
+import pyhy
+
+kp = pyhy.hydro_sign_keygen()
+
+if len(sys.argv) > 1:
+    path = sys.argv[1]
+else:
+    path = "."
+
+secret_key = os.path.join(path, "key")
+public_key = os.path.join(path, "key.pub")
+
+print("Writing secret key to", secret_key)
+with open(secret_key, "wb") as keyfile:
+    keyfile.write(bytearray(kp.sk))
+
+print("Writing public key to", public_key)
+with open(public_key, "wb") as keyfile:
+    keyfile.write(bytearray(kp.pk))

--- a/tools/mboot_set_key.py
+++ b/tools/mboot_set_key.py
@@ -1,0 +1,47 @@
+# Used to set the encrypted mboot security key in the last 32 bytes of the mboot binary
+import os
+from optparse import OptionParser
+
+if __name__ == "__main__":
+
+    usage = """
+    %prog [{-p|--public} key.pub {-b|--binary} file.bin"""
+    parser = OptionParser(usage=usage)
+    parser.add_option(
+        "-p", "--public", dest="public_key", help="public key file", metavar="PUBLIC"
+    )
+    parser.add_option(
+        "-b",
+        "--binary",
+        dest="binfile",
+        help="set encryption key at end of binary",
+        metavar="BINFILE",
+    )
+    parser.add_option(
+        "-l",
+        "--location",
+        dest="location",
+        default=32736,
+        help="set encryption key at end of binary",
+        metavar="BINFILE",
+    )
+
+    (options, args) = parser.parse_args()
+
+    with open(options.public_key, "rb") as keyfile:
+        key_public = keyfile.read()
+
+    with open(options.binfile, "rb") as binfile:
+        binary = binfile.read()
+
+    location = int(options.location)
+
+    pad = location - len(binary)
+    if pad > 0:
+        binary += b"\xFF" * pad
+
+    with open(options.binfile, "wb") as binfile:
+        binfile.write(binary[0:location])
+        binfile.write(key_public)
+
+    print("Set encryption key in", options.binfile)

--- a/tools/mboot_signed_dfu.py
+++ b/tools/mboot_signed_dfu.py
@@ -1,0 +1,268 @@
+import os
+import re
+import sys
+import zlib
+import struct
+import hashlib
+import intelhex
+from optparse import OptionParser
+
+import dfu
+
+try:
+    import pyhy
+except ImportError:
+    raise SystemExit(
+        "ERROR: pyhy not found. Please install python pyhy for encrypted mboot support\n> pip3 install pyhy"
+    )
+
+DEFAULT_CHUNKSIZE = 24 * 1024
+DEFAULT_DEVICE = "0x0483:0xdf11"
+FOOTER_LENGTH = 0xD0
+FOOTER_VERSION = 1
+
+ENABLE_ZIP = True
+
+# Must match ENC_CONTEXT in mboot.c
+HYDROGEN_CONTEXT = "mbootenc"
+
+
+def generate_fw_footer(version, section_info, public_key):
+    """
+    From mboot.c: 
+    typedef struct __attribute__ ((__packed__)) _fw_header_v1 {
+        uint8_t footer_vers;
+        char version[15];
+        uint8_t public_key[32];  // hydro_sign_PUBLICKEYBYTES
+        struct {
+            uint32_t address;
+            uint32_t length;
+            uint8_t  sha256[32];
+        } sections[4];
+    } fw_footer_v1_t;
+    """
+    header_v1_fmt = "<B 15s 32s"  # II32s II32s II32s II32s"
+    vers = version[0:15].encode("utf8")
+
+    section_length = 40
+
+    if len(section_info) > 4:
+        raise SystemExit("More than 4 firmware sections is not supported")
+
+    section_header = b""
+    for s in section_info:
+        section_header += struct.pack("<II", s[0], s[1]) + s[2]
+
+    for _ in range(4 - (len(section_info))):
+        section_header += b"\xFF" * 40
+
+    header = struct.pack(
+        header_v1_fmt, FOOTER_VERSION, vers, public_key,  # footer version  # fw semantic version
+    )
+    return header + section_header
+
+
+def encrypt(data):
+    """ We use the public key as the symmetric key for encryption as the device has it stored already """
+    return pyhy.hydro_secretbox_encrypt(data, 0, HYDROGEN_CONTEXT, key_public)
+
+
+def sign(data):
+    sig = pyhy.hydro_sign_create(data, HYDROGEN_CONTEXT, key_private)
+    return sig
+
+
+def chunk_header(address, data, is_zipped=False):
+    """
+    typedef struct __attribute__ ((__packed__)) _chunk_header_v1 {
+        uint8_t header_vers;
+        uint8_t format;
+        uint32_t address;
+        uint32_t length;
+        uint8_t signature[64];  // hydro_sign_BYTES
+    } chunk_header_v1_t;
+
+    enum chunk_format {
+        RAW=0,
+        GZIP=1
+    };
+    """
+    chunk_header_v1_fmt = "<B B I I 64s"
+    sig = sign(data)
+    header = struct.pack(
+        chunk_header_v1_fmt, 1, 1 if is_zipped else 0, address, len(data), sig,  # header version
+    )
+    return header
+
+
+def data_chunks(data, n):
+    for i in range(0, len(data), n):
+        yield data[i : i + n]
+
+
+if __name__ == "__main__":
+
+    usage = """
+    %prog [{-c|--chunksize} chunksize] {-s|--secret} key {-p|--public} key.pub  {-b|--build} address:file.bin [-b address:file.bin ...] [{-D|--device}=vendor:device] outfile.dfu"""
+    parser = OptionParser(usage=usage)
+    parser.add_option(
+        "-v",
+        "--version",
+        dest="version",
+        help="sematic version, up to 15 characters, or mpversion.h",
+        metavar="VERSION",
+    )
+    parser.add_option(
+        "-s", "--secret", dest="secret_key", help="private key file", metavar="PRIVATE"
+    )
+    parser.add_option(
+        "-p", "--public", dest="public_key", help="public key file", metavar="PUBLIC"
+    )
+    parser.add_option(
+        "-b",
+        "--build",
+        action="append",
+        dest="binfiles",
+        help="build a DFU file from given BINFILES",
+        metavar="BINFILES",
+    )
+    parser.add_option(
+        "-D",
+        "--device",
+        action="store",
+        dest="device",
+        help="build for DEVICE, defaults to %s" % DEFAULT_DEVICE,
+        metavar="DEVICE",
+    )
+    parser.add_option(
+        "-c",
+        "--chunksize",
+        dest="chunksize",
+        help="chunks must fit in ram while mboot verifies and decrypts, defaults to %s"
+        % DEFAULT_CHUNKSIZE,
+        metavar="CHUNKSIZE",
+    )
+    (options, args) = parser.parse_args()
+
+    device = DEFAULT_DEVICE
+    if options.device:
+        device = options.device
+    try:
+        v, d = map(lambda x: int(x, 0) & 0xFFFF, device.split(":", 1))
+    except:
+        raise SystemExit("Invalid device '%s'." % device)
+
+    chunk_size = DEFAULT_CHUNKSIZE
+    if options.chunksize:
+        chunk_size = options.chunksize
+
+    if not os.path.exists(options.secret_key):
+        raise SystemExit("Please create signing/encryption key in %s" % options.secret_key)
+    with open(options.secret_key, "rb") as keyfile:
+        key_private = keyfile.read()
+
+    with open(options.public_key, "rb") as keyfile:
+        key_public = keyfile.read()
+
+    if os.path.exists(options.version):
+        with open(options.version, "r") as mpversion_h:
+            mpversion = mpversion_h.read()
+        vers_match = re.search(r'MICROPY_GIT_TAG "(.*)"', mpversion)
+        version = vers_match.group(1) if vers_match else ""
+    else:
+        version = options.version
+
+    if options.binfiles and len(args) >= 1:
+        outfile = args[0]
+        target = []
+        section_info = []
+        footer = None
+
+        binfiles = []
+        for arg in options.binfiles:
+            try:
+                address, binfile = arg.split(":", 1)
+            except ValueError:
+                raise SystemExit("Address:file couple '%s' invalid." % arg)
+            try:
+                address = int(address, 0) & 0xFFFFFFFF
+            except ValueError:
+                raise SystemExit("Address %s invalid." % address)
+            if not os.path.isfile(binfile):
+                raise SystemExit("Unreadable file '%s'." % binfile)
+
+            binfiles.append((address, binfile))
+
+        # Ensure firmware sections are processed in order
+        for section, b in enumerate(sorted(binfiles, key=lambda b: b[0])):
+            address, binfile = b
+            with open(binfile, "rb") as fwfile:
+                fw = fwfile.read()
+            length = len(fw)
+
+            last_section = section == len(binfiles) - 1
+
+            if last_section:
+                footer_addr = address + length - FOOTER_LENGTH
+                print("Footer address: 0x%08x" % footer_addr)
+                # Check firmware then truncate section before footer
+                assert (
+                    fw[-FOOTER_LENGTH] == FOOTER_VERSION
+                ), "Firmware has incorrect FOOTER_VERSION: %s" % list(fw[-FOOTER_LENGTH:])
+                fw = fw[0:-FOOTER_LENGTH]
+
+            # first byte is skipped for hash as it contains the APP_VALIDITY_BITS
+            # which will be changed in firmware once hash is successfully verified.
+            start = 1 if section == 0 else 0
+            sha256 = hashlib.sha256(fw[start:]).digest()
+            section_info.append([address, len(fw), sha256])
+
+            if last_section:
+                # Last section, generate footer, append back to firmware
+                footer = generate_fw_footer(version, section_info, key_public)
+                assert FOOTER_LENGTH == len(footer), "Footer incorrect length, check version"
+                fw += footer
+
+            # Split the firmware into chunks, encrypt and sign the chunks
+            # then register them as individual dfu targets
+            for i, chunk in enumerate(data_chunks(fw, chunk_size)):
+                chunk_addr = address + i * chunk_size
+                if ENABLE_ZIP:
+                    c = zlib.compressobj(level=9, memLevel=9, wbits=-15)  # wsize=15, no header
+                    chunk = c.compress(chunk) + c.flush()
+                encrypted = encrypt(chunk)
+                c_header = chunk_header(chunk_addr, encrypted, is_zipped=ENABLE_ZIP)
+                chunk = c_header + encrypted
+
+                target.append({"address": chunk_addr, "data": chunk})
+
+        # Save un-encrypted bin, hex and dfu file of just the footer. This can be written
+        # to new device to store the key and enable encryption support
+        with open(binfile[:-4] + ".ftr" + binfile[-4:], "wb") as hdrfile:
+            hdrfile.write(footer)
+        ih = intelhex.IntelHex()
+        ih.frombytes(bytearray(footer), offset=footer_addr)
+        with open(binfile[:-4] + ".ftr.hex", "w") as hdrfile:
+            ih.tofile(hdrfile, format="hex")
+
+        footer_target = [{"address": footer_addr, "data": footer}]
+        dfu.build(binfile[:-4] + ".ftr.dfu", [footer_target], device)
+
+        # if ENABLE_ZIP:
+        #     c = zlib.compressobj(level=9, memLevel=9, wbits=-15) # wsize=15, no header
+        #     footer = c.compress(footer) + c.flush()
+
+        # Create encrypted copy of footer for inclusion in main dfu file
+        # encrypted = encrypt(footer)
+        # c_footer = chunk_header(footer_addr, encrypted, is_zipped=ENABLE_ZIP)
+        # fw_footer_chunk = c_footer + encrypted
+
+        # target.append({ 'address': footer_addr, 'data': fw_footer_chunk })
+
+        # Build dfu file of all the encrypted & signed chunks with footer
+        dfu.build(outfile, [target], device, pad=not ENABLE_ZIP)
+        print("Written", outfile)
+
+    else:
+        parser.print_help()
+        sys.exit(1)


### PR DESCRIPTION
This PR adds optional support for signed and encrypted dfu images in stm32 mboot.

This requires additional settings in the board config and requires `pyhy` python module to be installed into `python3` used when building mboot, eg:
```
    pip3 install pyhy
```
In addition to the standard changes made to mpconfigboard.mk to enable mboot, for encrypted support you also need to add:
```
    MBOOT_ENCRYPTED = 1
```
Also, alongside the existing `TEXT0_ADDR` setting the length of application 
flash space is needed, so for an F767 with 2MB of flash where the application 
starts after the 32K of mboot space, it will equal `2048K - 32K == 0x1F8000`:
```
    TEXT0_ADDR = 0x08008000
    TEXT0_LENGTH = 0x1F8000
```
You will also need to generate a compatible pair of public and private key files, which should be stored in the board definition folder (next to mpconfigboard.mk):
```
    python3 micropython/tools/mboot_generate_keys.py micropython/ports/stm32/boards/PYBD_SF6
    cd micropython/ports/stm32
    make BOARD=PYBD_SF6
```
Once you build the firmware, the `firmware.dfu` file will contain the encrypted and signed binaries.

There will also be an extra `firmware.ftr.bin` and `firmware.ftr.dfu` pair of files which contain an
un-encrypted copy of the footer with the encryption key, either of which can be flashed along with mboot to a fresh device to prepare it for decrypting the full `firmware.dfu`.

---

### Implementation details

The PR utilisies the encryption library [libhydrogen](https://github.com/jedisct1/libhydrogen) which provides both the asymetric signing and symetric encryption used in this PR in a high level fashion suitable for non-cryptography specialists to use safely. It's small enough to fit in the existing mboot flash space and uses modern secure ciphers.

This system works without needing any support from the application and without flash space for a second copy of the firmware. 

The encryption script included (`tools/mboot_signed_dfu.py`) breaks the firmware into chunks (16K by default) each of which is individually zipped, signed and encrypted. 
Each chunk is included in the dfu fiile and sent to the device using standard dfu tools, where it's first stored in ram, before its signature is checked for validation.
If that passes, the chunk is then decrypted. The decryption also included a hash behind the scenes to ensure it's valid.
If that passes, the chunk is un-zipped.
If that passes, the sector of flash is erased (if it hasn't already been erased by a prior chunk), then the chunk is written to flash.

Once all firmware chunks are transmitted a hash check is triggered. This confirms the sha256 of the entire firmware image as stored in flash. If that passes the validity bits at the start of the application flash are set. These are read my mboot at startup before jumping to the application.

When encryption is enabled, read support is disabled in mboot. 
The erase command in dfu is also ignored as the flash sectors are tracked and erased as needed only after a transmitted chunk has been validated. This does mean that chunks need to be sent in order, however standard dfu tools all seem to do this by default.

As mentioned in the previous section, there is also a footer included with the firmware. 
This footer contains the asymmetric public key, used to validate the signature and also used as the symmetric key for decryption.
The footer also contains a version number string (not explicitly used currently) and details about each fw image included (normally two sections for builds with internal flash storage, one otherwise) including its address, length and sha256 hash. 

Another potential future extension is to use the version number in the footer to prevent downgrades if desitred. This feature has been been investigated yet however.

---

### firmware footer location

It's currently stored in the final 96 bytes (0x60 hex) of flash on the chip. 
I initially planned to store it either in the final space of the mboot sector, or the start of the application flash space, but have ended up with this implementation. This is very much open to discussion however.

Storing it in mboot space meant it could not be updated with the application, thereby invalidating any of the other details such as version/length/crc etc. It would only be of use for the encrpytion key, but again, make that difficult to update in future if needed.

Storing the details at the start of application space required moving the start of the application forward by 512 bytes (0x200) as this appears to be a requirement for the interrupt ventor table system in the stm range, it needs to be aligned to blocks of this size in most if not all chips. This means you lose 416 bytes of flash, not insignificant on some parts.

I have also thought about storing these details inside the application space, just after the interrupt vector. This would mean I'd need to consider the vector table as one separate section of firmware, then slice in the header/footer data, then continue with the rest of the firmware. This may well be the best option and I'm still considering implementing it, but wanted to get the current working code up for review/discussion first.

---

Based on discussions in https://github.com/micropython/micropython/issues/5267