### PR TITLE
tools/makemanifest.py: Use sys.executable when invoking Python scripts.

### DIFF
--- a/tools/makemanifest.py
+++ b/tools/makemanifest.py
@@ -270,13 +270,13 @@ def main():
         return
 
     # Freeze paths as strings
-    res, output_str = system([MAKE_FROZEN] + str_paths)
+    res, output_str = system([sys.executable, MAKE_FROZEN] + str_paths)
     if res != 0:
         print('error freezing strings {}: {}'.format(str_paths, output_str))
         sys.exit(1)
 
     # Freeze .mpy files
-    res, output_mpy = system([MPY_TOOL, '-f', '-q', args.build_dir + '/genhdr/qstrdefs.preprocessed.h'] + mpy_files)
+    res, output_mpy = system([sys.executable, MPY_TOOL, '-f', '-q', args.build_dir + '/genhdr/qstrdefs.preprocessed.h'] + mpy_files)
     if res != 0:
         print('error freezing mpy {}: {}'.format(mpy_files, output_mpy))
         sys.exit(1)


### PR DESCRIPTION
Clean Ubuntu 18.04 doesn't even have a "python" program preinstalled, only "python3". So even if this script *is* py2 compatible, it won't run without additional installations.

Since everything in MicroPython is guaranteed to be py3 compatible, I think it's okay to explicitly state it whenever possible.