### PR TITLE
WIP: py/objnone: Add mp_get_none() helper.

### DIFF
--- a/py/modbuiltins.c
+++ b/py/modbuiltins.c
@@ -575,7 +575,7 @@ MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(mp_builtin_getattr_obj, 2, 3, mp_builtin_get
 
 STATIC mp_obj_t mp_builtin_setattr(mp_obj_t base, mp_obj_t attr, mp_obj_t value) {
     mp_store_attr(base, mp_obj_str_get_qstr(attr), value);
-    return mp_const_none;
+    return mp_get_none();
 }
 MP_DEFINE_CONST_FUN_OBJ_3(mp_builtin_setattr_obj, mp_builtin_setattr);
 

--- a/py/obj.h
+++ b/py/obj.h
@@ -605,6 +605,7 @@ extern const mp_obj_type_t mp_type_ZeroDivisionError;
 // Constant objects, globally accessible
 // The macros are for convenience only
 #define mp_const_none (MP_OBJ_FROM_PTR(&mp_const_none_obj))
+mp_obj_t mp_get_none(void);
 #define mp_const_false (MP_OBJ_FROM_PTR(&mp_const_false_obj))
 #define mp_const_true (MP_OBJ_FROM_PTR(&mp_const_true_obj))
 #define mp_const_empty_bytes (MP_OBJ_FROM_PTR(&mp_const_empty_bytes_obj))

--- a/py/objnone.c
+++ b/py/objnone.c
@@ -49,3 +49,8 @@ const mp_obj_type_t mp_type_NoneType = {
 };
 
 const mp_obj_none_t mp_const_none_obj = {{&mp_type_NoneType}};
+
+mp_obj_t __attribute__((noinline)) mp_get_none(void)
+{
+    return mp_const_none;
+}


### PR DESCRIPTION
`mp_const_none` is widely used throughout the project, in many many different functions. Ideally, this constant should be loaded as easily as possible in different architectures (i.e, fit in different "load immediate" opcodes).
But that's not the case at the moment - `mp_const_none` is an object in the data section, and e.g in the case of ARM/Thumb, we get the `ldr r0, pc, ...; .word mp_const_none_obj` sequence. Sometimes the linker manages to merge multiple immediates as such, but not always.
In order to make the loading of it easier, we can either make the value a small immediate like `MP_OBJ_NULL` (and perhaps translate it back to the pointer in a common spot, `mp_call_function*`). Or we can add a helper that'll retrieve the value, and that's what I'm proposing here.

TL;DR by changing all `return mp_const_none;` in the project to `return mp_get_none();` I managed to get a 500~ bytes decrease in `nrf`, 200~ in `stm32` and `cc3200` and lower diffs in others.
Now, that's not optimized - not all accesses should be replaced with the helper call; In the case of ARM, only when it'll save the inclusion of the "load immediate" constant. I'm sure we can get better results if only selected call sites will be modified.
The cool thing with this is that it can be easily disabled based on a config - just `#define mp_get_none() mp_const_none` and it's done. So ports which are affected badly by this (e.g `esp32`) can opt-out.

What do you think?