### PR TITLE
esp32/rtc: Update microseconds in RTC.datetime()

### DIFF
--- a/ports/esp32/machine_rtc.c
+++ b/ports/esp32/machine_rtc.c
@@ -103,6 +103,7 @@ STATIC mp_obj_t machine_rtc_datetime_helper(mp_uint_t n_args, const mp_obj_t *ar
 
         struct timeval tv = {0};
         tv.tv_sec = timeutils_seconds_since_2000(mp_obj_get_int(items[0]), mp_obj_get_int(items[1]), mp_obj_get_int(items[2]), mp_obj_get_int(items[4]), mp_obj_get_int(items[5]), mp_obj_get_int(items[6]));
+        tv.tv_usec = mp_obj_get_int(items[7]);
         settimeofday(&tv, NULL);
 
         return mp_const_none;


### PR DESCRIPTION
Fixes https://github.com/micropython/micropython/issues/5315

Set the microseconds component of the current system time when setting the RTC time with RTC.datetime().

Before this change: The RTC microseconds was reset to zero when updating the time.
After this change: The RTC microseconds are correctly set, allowing accurate time updates.