### PR TITLE
extmod/modujson: Support dump() of OrderedDict objects.

### DIFF
--- a/py/objdict.c
+++ b/py/objdict.c
@@ -60,7 +60,7 @@ STATIC void dict_print(const mp_print_t *print, mp_obj_t self_in, mp_print_kind_
     if (!(MICROPY_PY_UJSON && kind == PRINT_JSON)) {
         kind = PRINT_REPR;
     }
-    if (MICROPY_PY_COLLECTIONS_ORDEREDDICT && self->base.type != &mp_type_dict) {
+    if (MICROPY_PY_COLLECTIONS_ORDEREDDICT && self->base.type != &mp_type_dict && kind != PRINT_JSON) {
         mp_printf(print, "%q(", self->base.type->name);
     }
     mp_print_str(print, "{");
@@ -83,7 +83,7 @@ STATIC void dict_print(const mp_print_t *print, mp_obj_t self_in, mp_print_kind_
         mp_obj_print_helper(print, next->value, kind);
     }
     mp_print_str(print, "}");
-    if (MICROPY_PY_COLLECTIONS_ORDEREDDICT && self->base.type != &mp_type_dict) {
+    if (MICROPY_PY_COLLECTIONS_ORDEREDDICT && self->base.type != &mp_type_dict && kind != PRINT_JSON) {
         mp_print_str(print, ")");
     }
 }

--- a/tests/extmod/ujson_dumps_ordereddict.py
+++ b/tests/extmod/ujson_dumps_ordereddict.py
@@ -1,0 +1,12 @@
+try:
+    import ujson as json
+    from ucollections import OrderedDict
+except ImportError:
+    try:
+        import json
+        from collections import OrderedDict
+    except ImportError:
+        print("SKIP")
+        raise SystemExit
+
+print(json.dumps(OrderedDict(((1, 2), (3, 4)))))


### PR DESCRIPTION
Currently if `ujson.dump()` is used on an `OrderedDict` the repr class title is included in the json text, eg.
``` python
>>> print(json.dumps(OrderedDict(((1, 2), (3, 4)))))
OrderedDict({"1": 2, "3": 4})
```

This PR fixes the behavior to dump to json dict.
``` python
>>> print(json.dumps(OrderedDict(((1, 2), (3, 4)))))
{"1": 2, "3": 4}
```