### PR TITLE
drivers: add general neopixel driver for all ports to use

### DIFF
--- a/drivers/neopixel/neopixel.c
+++ b/drivers/neopixel/neopixel.c
@@ -1,0 +1,81 @@
+/*
+ * This file is part of the MicroPython project, http://micropython.org/
+ *
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2019 Damien P. George
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#include "py/mphal.h"
+#include "drivers/neopixel/neopixel.h"
+
+#ifndef MP_FASTCODE
+#define MP_FASTCODE(f) f
+#endif
+
+STATIC void MP_FASTCODE(neopixel_write_bitbang)(mp_hal_pin_obj_t pin, const uint32_t *timing_ns,
+    size_t num_pixel, const uint8_t *pixel_buf) {
+    mp_uint_t atomic_state = MICROPY_BEGIN_ATOMIC_SECTION();
+
+    for (size_t i = 0; i < num_pixel; ++i) {
+        uint8_t pixel_data = pixel_buf[i];
+        for (size_t j = 0; j < 8; ++j) {
+            const uint32_t *timing_bit = &timing_ns[pixel_data >> 6 & 2];
+            mp_hal_pin_high(pin);
+            uint32_t delay = timing_bit[0];
+            while (--delay) {
+                __NOP();
+            }
+            mp_hal_pin_low(pin);
+            delay = timing_bit[1];
+            while (--delay) {
+                __NOP();
+            }
+            pixel_data <<= 1;
+        }
+    }
+
+    MICROPY_END_ATOMIC_SECTION(atomic_state);
+}
+
+STATIC mp_obj_t neopixel_write(mp_obj_t pin_in, mp_obj_t timing_in, mp_obj_t buf_in) {
+    // Get the pin to output to
+    mp_hal_pin_obj_t pin = mp_hal_get_pin_obj(pin_in);
+
+    // Get timing values (in ns) and convert to machine-dependent loop counters
+    uint32_t timing_ns[4];
+    mp_obj_t *timing;
+    mp_obj_get_array_fixed_n(timing_in, 4, &timing);
+    for (size_t i = 0; i < 4; ++i) {
+        uint32_t is_low_cycle = i & 1;
+        timing_ns[i] = mp_hal_delay_ns_calc_neopixel(mp_obj_get_int(timing[i]), is_low_cycle);
+    }
+
+    // Get buffer to write
+    mp_buffer_info_t bufinfo;
+    mp_get_buffer_raise(buf_in, &bufinfo, MP_BUFFER_READ);
+
+    // Output the bits on the pin
+    neopixel_write_bitbang(pin, timing_ns, bufinfo.len, bufinfo.buf);
+
+    return mp_const_none;
+}
+MP_DEFINE_CONST_FUN_OBJ_3(neopixel_write_obj, neopixel_write);

--- a/drivers/neopixel/neopixel.h
+++ b/drivers/neopixel/neopixel.h
@@ -1,0 +1,11 @@
+#ifndef MICROPY_INCLUDED_DRIVERS_NEOPIXEL_NEOPIXEL_H
+#define MICROPY_INCLUDED_DRIVERS_NEOPIXEL_NEOPIXEL_H
+
+#include "py/obj.h"
+
+// To be provided by the port
+uint32_t mp_hal_delay_ns_calc_neopixel(uint32_t ns, bool is_low_cycle);
+
+MP_DECLARE_CONST_FUN_OBJ_3(neopixel_write_obj);
+
+#endif // MICROPY_INCLUDED_DRIVERS_NEOPIXEL_NEOPIXEL_H

--- a/drivers/neopixel/neopixel.py
+++ b/drivers/neopixel/neopixel.py
@@ -1,0 +1,42 @@
+# NeoPixel driver for MicroPython on ESP32
+# MIT license; Copyright (c) 2016 Damien P. George
+
+try:
+    from esp import neopixel_write
+except:
+    from pyb import neopixel_write
+
+
+class NeoPixel:
+    ORDER = (1, 0, 2, 3)
+    WS400 = (500, 2000, 1200, 1300) # 400kHz, UNTESTED!
+    WS2812S = (350, 800, 700, 600)
+    
+    def __init__(self, pin, n, bpp=3, timing=1):
+        self.pin = pin
+        self.n = n
+        self.bpp = bpp
+        self.buf = bytearray(n * bpp)
+        self.pin.init(pin.OUT)
+        if timing == 0:
+            self.timing = self.WS400
+        elif timing == 1:
+            self.timing = self.WS2812S
+        else:
+            self.timing = timing # user supplied 4-tuple
+
+    def __setitem__(self, index, val):
+        offset = index * self.bpp
+        for i in range(self.bpp):
+            self.buf[offset + self.ORDER[i]] = val[i]
+
+    def __getitem__(self, index):
+        offset = index * self.bpp
+        return tuple(self.buf[offset + self.ORDER[i]] for i in range(self.bpp))
+
+    def fill(self, color):
+        for i in range(self.n):
+            self[i] = color
+
+    def write(self):
+        neopixel_write(self.pin, self.timing, self.buf)

--- a/ports/stm32/Makefile
+++ b/ports/stm32/Makefile
@@ -231,6 +231,7 @@ DRIVERS_SRC_C = $(addprefix drivers/,\
 	bus/softqspi.c \
 	memory/spiflash.c \
 	dht/dht.c \
+	neopixel/neopixel.c \
 	)
 
 SRC_C = \

--- a/ports/stm32/modpyb.c
+++ b/ports/stm32/modpyb.c
@@ -31,6 +31,7 @@
 #include "py/mphal.h"
 #include "lib/utils/pyexec.h"
 #include "drivers/dht/dht.h"
+#include "drivers/neopixel/neopixel.h"
 #include "stm32_it.h"
 #include "irq.h"
 #include "led.h"
@@ -187,8 +188,9 @@ STATIC const mp_rom_map_elem_t pyb_module_globals_table[] = {
     { MP_ROM_QSTR(MP_QSTR_mount), MP_ROM_PTR(&mp_vfs_mount_obj) },
     #endif
 
-    // This function is not intended to be public and may be moved elsewhere
+    // These functions are not intended to be public and may be moved elsewhere
     { MP_ROM_QSTR(MP_QSTR_dht_readinto), MP_ROM_PTR(&dht_readinto_obj) },
+    { MP_ROM_QSTR(MP_QSTR_neopixel_write), MP_ROM_PTR(&neopixel_write_obj) },
 
     { MP_ROM_QSTR(MP_QSTR_Timer), MP_ROM_PTR(&pyb_timer_type) },
 


### PR DESCRIPTION
Following on from #5294, this PR adds a general neopixel bit-bang driver.  A port needs to implement the `mp_hal_delay_ns_calc_neopixel(ns, is_low_cycle)` function to use this driver.

Also included is a high-level `neopixel.py` wrapper, which can replace the one currently in esp8266/esp32's modules directory.