### PR TITLE
extmod/modbluetooth: Prioritise non-scan-result events.

### DIFF
--- a/py/ringbuf.c
+++ b/py/ringbuf.c
@@ -26,6 +26,18 @@
 #include "ringbuf.h"
 
 int ringbuf_get16(ringbuf_t *r) {
+    int v = ringbuf_peek16(r);
+    if (v == -1) {
+        return v;
+    }
+    r->iget += 2;
+    if (r->iget >= r->size) {
+        r->iget -= r->size;
+    }
+    return v;
+}
+
+int ringbuf_peek16(ringbuf_t *r) {
     if (r->iget == r->iput) {
         return -1;
     }
@@ -36,12 +48,7 @@ int ringbuf_get16(ringbuf_t *r) {
     if (iget_a == r->iput) {
         return -1;
     }
-    uint16_t v = (r->buf[r->iget] << 8) | (r->buf[iget_a]);
-    r->iget = iget_a + 1;
-    if (r->iget == r->size) {
-        r->iget = 0;
-    }
-    return v;
+    return (r->buf[r->iget] << 8) | (r->buf[iget_a]);
 }
 
 int ringbuf_put16(ringbuf_t *r, uint16_t v) {

--- a/py/ringbuf.h
+++ b/py/ringbuf.h
@@ -82,6 +82,7 @@ static inline size_t ringbuf_avail(ringbuf_t *r) {
 
 // Note: big-endian. No-op if not enough room available for both bytes.
 int ringbuf_get16(ringbuf_t *r);
+int ringbuf_peek16(ringbuf_t *r);
 int ringbuf_put16(ringbuf_t *r, uint16_t v);
 
 #endif // MICROPY_INCLUDED_PY_RINGBUF_H


### PR DESCRIPTION
When a scan is in progress, the ring buffer can fill up and be saturated with scan result events. As intended, the extra events are dropped. But this isn't great for other events which ideally should take priority over the scan results.

This PR changes the enqueue behavior so that non-scan-result events can remove other scan-result events from the ringbuffer and take their place.