### PR TITLE
esp32/hal: Always POLL_HOOK when delaying for milliseconds

### DIFF
--- a/ports/esp32/mphalport.c
+++ b/ports/esp32/mphalport.c
@@ -122,13 +122,13 @@ void mp_hal_delay_ms(uint32_t ms) {
     uint64_t dt;
     uint64_t t0 = esp_timer_get_time();
     for (;;) {
+        MICROPY_EVENT_POLL_HOOK
         uint64_t t1 = esp_timer_get_time();
         dt = t1 - t0;
         if (dt + portTICK_PERIOD_MS * 1000 >= us) {
             // doing a vTaskDelay would take us beyond requested delay time
             break;
         }
-        MICROPY_EVENT_POLL_HOOK
         ulTaskNotifyTake(pdFALSE, 1);
     }
     if (dt < us) {


### PR DESCRIPTION
Fixes https://github.com/micropython/micropython/issues/5344 

Ensure that `MICROPY_EVENT_POLL_HOOK` is always called when calling `utime.sleep_ms` so that scheduled events and thread switching occurs correctly.

`sleep_us` is not modified as it is expected to be fast and accurate.