### PR TITLE
extmod/utime: Always invoke mp_hal_delay_ms when >= to 0ms

### DIFF
--- a/extmod/utime_mphal.c
+++ b/extmod/utime_mphal.c
@@ -48,7 +48,7 @@ MP_DEFINE_CONST_FUN_OBJ_1(mp_utime_sleep_obj, time_sleep);
 
 STATIC mp_obj_t time_sleep_ms(mp_obj_t arg) {
     mp_int_t ms = mp_obj_get_int(arg);
-    if (ms > 0) {
+    if (ms >= 0) {
         mp_hal_delay_ms(ms);
     }
     return mp_const_none;


### PR DESCRIPTION
Fixes https://github.com/micropython/micropython/issues/5345

Always call `mp_hal_delay_ms` with >= 0 ms argument. This makes `sleep_ms(0)` useful when combined with https://github.com/micropython/micropython/pull/5346 for ESP32 and https://github.com/micropython/micropython/pull/5347 for STM32 allowing yielding a thread by looping like such:

```
while not condition_met:
  sleep_ms(0)
```

This properly frees the GIL so that other threads, tasks or scheduled events can satisfy the `condition_met`