### PR TITLE
esp32/machine_rtc: Add prefix to rtc user mem macro.

### DIFF
--- a/ports/esp32/machine_rtc.c
+++ b/ports/esp32/machine_rtc.c
@@ -64,7 +64,7 @@ typedef struct _machine_rtc_obj_t {
 #if MICROPY_HW_RTC_USER_MEM_MAX > 0
 #define MEM_MAGIC           0x75507921
 RTC_DATA_ATTR uint32_t rtc_user_mem_magic;
-RTC_DATA_ATTR uint32_t rtc_user_mem_len;
+RTC_DATA_ATTR uint16_t rtc_user_mem_len;
 RTC_DATA_ATTR uint8_t rtc_user_mem_data[MICROPY_HW_RTC_USER_MEM_MAX];
 #endif
 
@@ -146,10 +146,9 @@ STATIC MP_DEFINE_CONST_FUN_OBJ_2(machine_rtc_init_obj, machine_rtc_init);
 STATIC mp_obj_t machine_rtc_memory(mp_uint_t n_args, const mp_obj_t *args) {
     if (n_args == 1) {
         // read RTC memory
-        uint32_t len = rtc_user_mem_len;
         uint8_t rtcram[MICROPY_HW_RTC_USER_MEM_MAX];
-        memcpy( (char *) rtcram, (char *) rtc_user_mem_data, len);
-        return mp_obj_new_bytes(rtcram,  len);
+        memcpy( (char *) rtcram, (char *) rtc_user_mem_data, rtc_user_mem_len);
+        return mp_obj_new_bytes(rtcram,  rtc_user_mem_len);
     } else {
         // write RTC memory
         mp_buffer_info_t bufinfo;

--- a/ports/esp32/machine_rtc.c
+++ b/ports/esp32/machine_rtc.c
@@ -50,6 +50,9 @@ typedef struct _machine_rtc_obj_t {
         region `rtc_slow_seg' overflowed by N bytes
     The current system software allows almost 4096 to be used.
     To avoid running into issues if the system software uses more, 2048 was picked as a max length
+
+    You can also change this max length at compile time by defining MICROPY_HW_RTC_USER_MEM_MAX
+    either on your make line, or in your board config.
 */
 #ifndef MICROPY_HW_RTC_USER_MEM_MAX
 #define MICROPY_HW_RTC_USER_MEM_MAX     2048

--- a/ports/esp32/machine_rtc.c
+++ b/ports/esp32/machine_rtc.c
@@ -51,10 +51,12 @@ typedef struct _machine_rtc_obj_t {
     The current system software allows almost 4096 to be used.
     To avoid running into issues if the system software uses more, 2048 was picked as a max length
 */
-#define MEM_USER_MAXLEN     2048
+#ifndef MICROPY_HW_RTC_USER_MEM_MAX
+#define MICROPY_HW_RTC_USER_MEM_MAX     2048
+#endif
 RTC_DATA_ATTR uint32_t rtc_user_mem_magic;
 RTC_DATA_ATTR uint32_t rtc_user_mem_len;
-RTC_DATA_ATTR uint8_t rtc_user_mem_data[MEM_USER_MAXLEN];
+RTC_DATA_ATTR uint8_t rtc_user_mem_data[MICROPY_HW_RTC_USER_MEM_MAX];
 
 // singleton RTC object
 STATIC const machine_rtc_obj_t machine_rtc_obj = {{&machine_rtc_type}};
@@ -130,7 +132,7 @@ STATIC mp_obj_t machine_rtc_memory(mp_uint_t n_args, const mp_obj_t *args) {
     if (n_args == 1) {
         // read RTC memory
         uint32_t len = rtc_user_mem_len;
-        uint8_t rtcram[MEM_USER_MAXLEN];
+        uint8_t rtcram[MICROPY_HW_RTC_USER_MEM_MAX];
         memcpy( (char *) rtcram, (char *) rtc_user_mem_data, len);
         return mp_obj_new_bytes(rtcram,  len);
     } else {
@@ -138,7 +140,7 @@ STATIC mp_obj_t machine_rtc_memory(mp_uint_t n_args, const mp_obj_t *args) {
         mp_buffer_info_t bufinfo;
         mp_get_buffer_raise(args[1], &bufinfo, MP_BUFFER_READ);
 
-        if (bufinfo.len > MEM_USER_MAXLEN) {
+        if (bufinfo.len > MICROPY_HW_RTC_USER_MEM_MAX) {
             mp_raise_ValueError("buffer too long");
         }
         memcpy( (char *) rtc_user_mem_data, (char *) bufinfo.buf, bufinfo.len);


### PR DESCRIPTION
When working with ESP32 C modules, you may want to put symbols/data/code in to RTC memory so that you can write a deepsleep stub, or use the ULP on the ESP32. When doing so, the RTC memory region can sometimes overflow at linker time due to the allocations made within the ESP32 RTC module.

This fix allows modifying the size of that memory region in your board config to decrease the size, by adding `#define MICROPY_HW_RTC_USER_MEM_MAX 512` for example, the RTC module's user memory region would be decreased from 2K to 512 bytes, giving you space for other content outside of MicroPython.

This fix both renames the macro to something more suited for configuration use and allows it to be defined outside of the RTC module.