### PR TITLE
py/builtinimport: Raise exception on empty name.

### DIFF
--- a/py/builtinimport.c
+++ b/py/builtinimport.c
@@ -334,6 +334,10 @@ mp_obj_t mp_builtin___import__(size_t n_args, const mp_obj_t *args) {
         mod_len = new_mod_l;
     }
 
+    if (mod_len == 0) {
+        mp_raise_ValueError(NULL);
+    }
+
     // check if module already exists
     qstr module_name_qstr = mp_obj_str_get_qstr(module_name);
     mp_obj_t module_obj = mp_module_get(module_name_qstr);

--- a/tests/import/builtin_import.py
+++ b/tests/import/builtin_import.py
@@ -9,6 +9,12 @@ try:
 except TypeError:
     print('TypeError')
 
+# module name should not be empty
+try:
+    __import__("")
+except ValueError:
+    print('ValueError')
+
 # level argument should be non-negative
 try:
     __import__('xyz', None, None, None, -1)


### PR DESCRIPTION
In Python3.7 (at least), __import__("") returns ValueError: Empty module name