### PR TITLE
py/objstringio: Slightly optimize stringio_copy_on_write().

### DIFF
--- a/py/objstringio.c
+++ b/py/objstringio.c
@@ -70,9 +70,9 @@ STATIC mp_uint_t stringio_read(mp_obj_t o_in, void *buf, mp_uint_t size, int *er
 STATIC void stringio_copy_on_write(mp_obj_stringio_t *o) {
     const void *buf = o->vstr->buf;
     o->vstr->buf = m_new(char, o->vstr->len);
-    memcpy(o->vstr->buf, buf, o->vstr->len);
     o->vstr->fixed_buf = false;
     o->ref_obj = MP_OBJ_NULL;
+    memcpy(o->vstr->buf, buf, o->vstr->len);
 }
 
 STATIC mp_uint_t stringio_write(mp_obj_t o_in, const void *buf, mp_uint_t size, int *errcode) {


### PR DESCRIPTION
With the memcpy() call placed last, we avoid the effects of registers
clobbering.
It's definitely effective in non-inlined functions, but even here it
is still, apparently, making a small difference.

On stm32, this saves an extra `ldr` instruction to load `o->vstr` after
the memcpy() returns.

```
   bare-arm:    +0 +0.000% 
minimal x86:    +0 +0.000% 
   unix x64:    +0 +0.000% 
unix nanbox:    +0 +0.000% 
      stm32:    -4 -0.001% PYBV10
     cc3200:    +0 +0.000% 
      esp32:    -4 -0.000% GENERIC
        nrf:    +0 +0.000% pca10040
```