### PR TITLE
stm32/mpconfigport.h: Use IRQ_PRI_PENDSV to protect bluetooth ringbuf.

### DIFF
--- a/extmod/modbluetooth.c
+++ b/extmod/modbluetooth.c
@@ -33,6 +33,7 @@
 #include "py/objarray.h"
 #include "py/qstr.h"
 #include "py/runtime.h"
+#include "py/mphal.h"
 #include "extmod/modbluetooth.h"
 #include <string.h>
 

--- a/ports/stm32/mpconfigport.h
+++ b/ports/stm32/mpconfigport.h
@@ -366,6 +366,10 @@ static inline mp_uint_t disable_irq(void) {
 #define MICROPY_PY_LWIP_REENTER irq_state = raise_irq_pri(IRQ_PRI_PENDSV);
 #define MICROPY_PY_LWIP_EXIT    restore_irq_pri(irq_state);
 
+// Bluetooth calls must run at a raised IRQ priority
+#define MICROPY_PY_BLUETOOTH_ENTER MICROPY_PY_LWIP_ENTER
+#define MICROPY_PY_BLUETOOTH_EXIT MICROPY_PY_LWIP_EXIT
+
 // We need an implementation of the log2 function which is not a macro
 #define MP_NEED_LOG2 (1)
 


### PR DESCRIPTION
The default protection for the BLE ringbuf is to use MICROPY_BEGIN_ATOMIC_SECTION, which disables all interrupts.  On stm32 it only needs to disable the lowest priority IRQ, pendsv, because that's the IRQ level at which the BLE stack is driven.