### PR TITLE
extmod/modbluetooth: Allow setting ringbuf size via BLE.config(ringbuf).

### DIFF
--- a/docs/library/ubluetooth.rst
+++ b/docs/library/ubluetooth.rst
@@ -32,13 +32,26 @@ Configuration
 
     The radio must be made active before using any other methods on this class.
 
-.. method:: BLE.config(name)
+.. method:: BLE.config('param')
+            BLE.config(param=value, ...)
 
-    Queries a configuration value by *name*. Currently supported values are:
+    Get or set configuration values of the BLE interface.  To get a value the
+    parameter name should be quoted as a string, and just one parameter is
+    queried at a time.  To set values use the keyword syntax, and one ore more
+    parameter can be set at a time.
+
+    Currently supported values are:
 
     - ``'mac'``: Returns the device MAC address. If a device has a fixed address
       (e.g. PYBD) then it will be returned. Otherwise (e.g. ESP32) a random
       address will be generated when the BLE interface is made active.
+
+    - ``'rxbuf'``: Set the size in bytes of the internal buffer used to store
+      incoming events.  This buffer is global to the entire BLE driver and so
+      handles incoming data for all events, including all characteristics.
+      Increasing this allows better handling of bursty incoming data (for
+      example scan results) and the ability for a central role to receive
+      larger characteristic values.
 
 Event Handling
 --------------


### PR DESCRIPTION
The size of the event ringbuf was previously fixed to compile-time config value, but it's necessary to sometimes increase this for applications that have large characteristic buffers to read, or many events at once.

With this PR the size can be set via `BLE.config(ringbuf=512)`, for example.

TODO: perhaps rename the `ringbuf` parameter to something else like `event_buf` or `evbuf` because the fact it uses a ring-buffer is just an implementation detail (eg for UART the ringbuf is called `rxbuf`).