### PR TITLE
drivers/dht: Make the pin float high again on esp8266 and add some options.

### DIFF
--- a/docs/esp32/quickref.rst
+++ b/docs/esp32/quickref.rst
@@ -462,15 +462,31 @@ The DHT driver is implemented in software and works on all pins::
     import dht
     import machine
 
-    d = dht.DHT11(machine.Pin(4))
+    d = dht.DHT11(machine.Pin(4), delay=250, flags=0)
     d.measure()
     d.temperature() # eg. 23 (°C)
     d.humidity()    # eg. 41 (% RH)
 
-    d = dht.DHT22(machine.Pin(4))
+    d = dht.DHT22(machine.Pin(4), delay=250, flags=0)
     d.measure()
     d.temperature() # eg. 23.6 (°C)
     d.humidity()    # eg. 41.3 (% RH)
+
+Use *delay* (optional) to specify how long in milliseconds the driver
+will wait before sending the start pulse to the sensor. Increase the
+value if you experience a high number of *ETIMEDOUT* errors when calling
+*measure()*. In applications using an event loop or uasyncio specify
+*delay=0* and handle the polling frequency in your framework, like using
+*await uasyncio.sleep(5)* in a coro dedicated to refresh the DHT data.
+
+*flags* (optional) is a or'ed combination of the following:
+
+* *dht.ENABLE_HIGH* - (ESP8266 only, ignored on ESP32) enable the output
+  as HIGH while reading data from the sensor. The open drain implementation
+  of the esp8266 port seems to require this for some sensors. Some details
+  are discussed in
+  `Issue #4233 <https://github.com/micropython/micropython/issues/4233>`_
+  .
 
 WebREPL (web browser interactive prompt)
 ----------------------------------------

--- a/docs/esp8266/quickref.rst
+++ b/docs/esp8266/quickref.rst
@@ -348,15 +348,31 @@ The DHT driver is implemented in software and works on all pins::
     import dht
     import machine
 
-    d = dht.DHT11(machine.Pin(4))
+    d = dht.DHT11(machine.Pin(4), delay=250, flags=0)
     d.measure()
     d.temperature() # eg. 23 (°C)
     d.humidity()    # eg. 41 (% RH)
 
-    d = dht.DHT22(machine.Pin(4))
+    d = dht.DHT22(machine.Pin(4), delay=250, flags=0)
     d.measure()
     d.temperature() # eg. 23.6 (°C)
     d.humidity()    # eg. 41.3 (% RH)
+
+Use *delay* (optional) to specify how long in milliseconds the driver
+will wait before sending the start pulse to the sensor. Increase the
+value if you experience a high number of *ETIMEDOUT* errors when calling
+*measure()*. In applications using an event loop or uasyncio specify
+*delay=0* and handle the polling frequency in your framework, like using
+*await uasyncio.sleep(5)* in a coro dedicated to refresh the DHT data.
+
+*flags* (optional) is a or'ed combination of the following:
+
+* *dht.ENABLE_HIGH* - (ESP8266 only, ignored on ESP32) enable the output
+  as HIGH while reading data from the sensor. The open drain implementation
+  of the esp8266 port seems to require this for some sensors. Some details
+  are discussed in
+  `Issue #4233 <https://github.com/micropython/micropython/issues/4233>`_
+  .
 
 WebREPL (web browser interactive prompt)
 ----------------------------------------

--- a/drivers/dht/dht.h
+++ b/drivers/dht/dht.h
@@ -3,6 +3,8 @@
 
 #include "py/obj.h"
 
-MP_DECLARE_CONST_FUN_OBJ_2(dht_readinto_obj);
+#define	DHT_FLAG_ENABLE_HIGH (0x01)
+
+MP_DECLARE_CONST_FUN_OBJ_3(dht_readinto_obj);
 
 #endif // MICROPY_INCLUDED_DRIVERS_DHT_DHT_H

--- a/drivers/dht/dht.py
+++ b/drivers/dht/dht.py
@@ -1,19 +1,31 @@
 # DHT11/DHT22 driver for MicroPython on ESP8266
 # MIT license; Copyright (c) 2016 Damien P. George
 
+ENABLE_HIGH = 1
+
 try:
     from esp import dht_readinto
 except:
     from pyb import dht_readinto
 
+from machine import Pin
+from utime import sleep_ms
+
 class DHTBase:
-    def __init__(self, pin):
+    def __init__(self, pin, delay=250, flags=0):
         self.pin = pin
         self.buf = bytearray(5)
+        self.delay = delay
+        self.flags = flags
+        pin.init(mode=Pin.OPEN_DRAIN, value=1)
+        if delay < 250:
+            sleep_ms(250 - delay)
 
     def measure(self):
         buf = self.buf
-        dht_readinto(self.pin, buf)
+        if self.delay > 0:
+            sleep_ms(self.delay)
+        dht_readinto(self.pin, self.flags, buf)
         if (buf[0] + buf[1] + buf[2] + buf[3]) & 0xff != buf[4]:
             raise Exception("checksum error")
 


### PR DESCRIPTION
Commit 033c32e first changed the usage of the pin during
open_drain operation to fix problems with i2c. Then commit
18d3a5d reverted that behavior for the dht driver on the
esp8266 only. This however does not work in all cases. This
commit makes the bahavior similar to an esp32 again and
offers the pre-033c32e mode as an option.

Adds kwarg "flags=0". Only possible option at this point
is dht.ENABLE_HIGH to drive the pin high like pre-033c32e.
More flag values may be added in the future.

Adds kwarg "delay=250" to control the initial delay before
the 18ms start pulse. Applications using uasyncio or an
event loop don't need any blocking delay. Busy loop apps
may need longer delays.