### PR TITLE
nrf/main: Execute boot.py and main.py frozen modules without file system

### DIFF
--- a/ports/nrf/main.c
+++ b/ports/nrf/main.c
@@ -230,7 +230,7 @@ pin_init0();
 
 led_state(1, 0);
 
-#if MICROPY_VFS || MICROPY_MBFS
+#if MICROPY_VFS || MICROPY_MBFS || MICROPY_MODULE_FROZEN
     // run boot.py and main.py if they exist.
     pyexec_file_if_exists("boot.py");
     pyexec_file_if_exists("main.py");


### PR DESCRIPTION
When the file system is not enabled, the boot.py and main.py modules will still be executed, if they are frozen.