### PR TITLE
nrf: Facilitate use of freeze manifest.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -296,6 +296,7 @@ jobs:
         - arm-none-eabi-gcc --version
       script:
         - ports/nrf/drivers/bluetooth/download_ble_stack.sh s132_nrf52_6_1_1
+        - make ${MAKEOPTS} -C mpy-cross
         - make ${MAKEOPTS} -C ports/nrf submodules
         - make ${MAKEOPTS} -C ports/nrf BOARD=pca10040
         - make ${MAKEOPTS} -C ports/nrf BOARD=microbit

--- a/ports/nrf/Makefile
+++ b/ports/nrf/Makefile
@@ -5,6 +5,8 @@ ifeq ($(wildcard boards/$(BOARD)/.),)
 $(error Invalid BOARD specified)
 endif
 
+BOARD_DIR ?= boards/$(BOARD)
+
 # If SoftDevice is selected, try to use that one.
 SD ?=
 SD_LOWER = $(shell echo $(SD) | tr '[:upper:]' '[:lower:]')
@@ -479,13 +481,13 @@ GEN_PINS_QSTR = $(BUILD)/pins_qstr.h
 GEN_PINS_AF_CONST = $(HEADER_BUILD)/pins_af_const.h
 GEN_PINS_AF_PY = $(BUILD)/pins_af.py
 
-ifneq ($(FROZEN_DIR),)
+ifneq ($(FROZEN_MANIFEST)$(FROZEN_DIR),)
 # To use frozen source modules, put your .py files in a subdirectory (eg scripts/)
 # and then invoke make with FROZEN_DIR=scripts (be sure to build from scratch).
 CFLAGS += -DMICROPY_MODULE_FROZEN_STR
 endif
 
-ifneq ($(FROZEN_MPY_DIR),)
+ifneq ($(FROZEN_MANIFEST)$(FROZEN_MPY_DIR),)
 # To use frozen bytecode, put your .py files in a subdirectory (eg frozen/) and
 # then invoke make with FROZEN_MPY_DIR=frozen (be sure to build from scratch).
 CFLAGS += -DMICROPY_QSTR_EXTRA_POOL=mp_qstr_frozen_const_pool

--- a/ports/nrf/README.md
+++ b/ports/nrf/README.md
@@ -107,6 +107,22 @@ To use frozen modules, put them in a directory (e.g. `freeze/`) and supply
 
      make BOARD=pca10040 FROZEN_MPY_DIR=freeze
 
+## Compile with freeze manifest
+
+Freeze manifests can be used by definining `FROZEN_MANIFEST` pointing to a
+`manifest.py`. This can either be done by a `make` invocation or by defining
+it in the specific target board's `mpconfigboard.mk`.
+
+For example:
+
+    make BOARD=pca10040 FROZEN_MANIFEST=path/to/manifest.py
+
+In case of using the target board's makefile, add a line similar to this:
+
+    FROZEN_MANIFEST ?= $(BOARD_DIR)/manifest.py
+
+In these two examples, the manual `make` invocation will have precedence.
+
 ## Enable MICROPY_VFS_FAT
 As the `oofatfs` module is not having header guards that can exclude the implementation compile time, this port provides a flag to enable it explicitly. The MICROPY_VFS_FAT is by default set to 0 and has to be set to 1 if `oofatfs` files should be compiled. This will be in addition of setting `MICROPY_VFS` in mpconfigport.h.
 


### PR DESCRIPTION
Adding FROZEN_MANIFEST to the Makefile which is set to
boards/manifest.py by default.

Adding the boards/manifest.py that will include the ports
'freeze' folder.

Adding BOARD_DIR to the Makefile which can be referenced in
boards/<board>/mpconfigboard.mk to include a board specific
manifest.