### PR TITLE
Enable USB port on Particle Xenon board

### DIFF
--- a/ports/nrf/boards/particle_xenon/mpconfigboard.h
+++ b/ports/nrf/boards/particle_xenon/mpconfigboard.h
@@ -38,6 +38,8 @@
 #define MICROPY_PY_MACHINE_TEMP     (1)
 #define MICROPY_PY_RANDOM_HW_RNG    (1)
 
+#define MICROPY_HW_USB_CDC          (1)
+
 #define MICROPY_HW_HAS_LED          (1)
 #define MICROPY_HW_LED_TRICOLOR     (1)
 #define MICROPY_HW_LED_PULLUP       (1)


### PR DESCRIPTION
As mention in https://github.com/micropython/micropython/pull/5158#issuecomment-559931181, it will be great to run Micropython in Xenon boards. After applying the PR, the xenon board USB port becomes active and pyboard.py can be used.


Tests performed:

Test results are the exact same as with master pca10059::

(cd tests; ./run-tests --target nrf)

509 tests performed (14330 individual testcases)
506 tests passed
192 tests skipped: builtin_next_arg2 builtin_pow3 builtin_pow3_intbig builtin_range_binop builtin_round_int builtin_round_intbig bytearray_slice_assign bytes_partition class_delattr_setattr class_descriptor class_notimpl class_reverse_op deque1 deque2 dict_fixed errno1 exception_chain io_buffered_writer io_bytesio_cow io_bytesio_ext io_bytesio_ext2 io_iobase io_stringio1 io_stringio_with io_write_ext memoryview1 memoryview_itemsize namedtuple_asdict ordereddict1 ordereddict_eq slice_attrs special_methods2 string_center string_partition string_rpartition string_splitlines subclass_native_call sys_getsizeof btree1 framebuf1 framebuf16 framebuf2 framebuf4 framebuf8 framebuf_subclass machine1 machine_pinbase machine_pulse machine_signal ticks_diff time_ms_us ubinascii_a2b_base64 ubinascii_b2a_base64 ubinascii_crc32 ubinascii_hexlify ubinascii_micropython ubinascii_unhexlify ucryptolib_aes128_cbc ucryptolib_aes128_ctr ucryptolib_aes128_ecb ucryptolib_aes128_ecb_enc ucryptolib_aes128_ecb_inpl ucryptolib_aes128_ecb_into ucryptolib_aes256_cbc ucryptolib_aes256_ecb uctypes_32bit_intbig uctypes_array_assign_le uctypes_array_assign_native_le uctypes_array_assign_native_le_intbig uctypes_bytearray uctypes_byteat uctypes_error uctypes_le uctypes_le_float uctypes_native_float uctypes_native_le uctypes_print uctypes_ptr_le uctypes_ptr_native_le uctypes_sizeof uctypes_sizeof_float uctypes_sizeof_layout uctypes_sizeof_native uctypes_sizeof_od uhashlib_md5 uhashlib_sha1 uhashlib_sha256 uheapq1 ujson_dump ujson_dump_iobase ujson_dumps ujson_dumps_extra ujson_dumps_float ujson_dumps_ordereddict ujson_load ujson_loads ujson_loads_bytes ujson_loads_float urandom_basic ure1 ure_debug ure_error ure_group ure_groups ure_namedclass ure_span ure_split ure_split_empty ure_split_notimpl ure_stack_overflow ure_sub ure_sub_unmatched uselect_poll_basic ussl_basic ussl_keycert utimeq1 utimeq_stable uzlib_decompio uzlib_decompio_gz uzlib_decompress vfs_basic vfs_blockdev vfs_fat_fileio1 vfs_fat_fileio2 vfs_fat_more vfs_fat_oldproto vfs_fat_ramdisk vfs_fat_ramdisklarge vfs_lfs vfs_lfs_corrupt vfs_lfs_error vfs_lfs_file vfs_lfs_mount vfs_userfs websocket_basic cmath_fun cmath_fun_special float2int_doubleprec_intbig float_divmod float_parse_doubleprec math_domain_special math_factorial_intbig math_fun_special math_isclose emg_exc heapalloc_bytesio heapalloc_bytesio2 heapalloc_traceback meminfo memstats native_closure native_const native_const_intbig native_gen native_misc native_try native_try_deep native_with opt_level schedule viper_addr viper_args viper_binop_arith viper_binop_comp viper_binop_comp_imm viper_binop_divmod viper_binop_multi_comp viper_cond viper_const viper_const_intbig viper_error viper_globals viper_import viper_misc viper_misc_intbig viper_ptr16_load viper_ptr16_store viper_ptr32_load viper_ptr32_store viper_ptr8_load viper_ptr8_store viper_subscr viper_try viper_types viper_with non_compliant print_exception sys_atexit sys_exc_info sys_settrace_features sys_settrace_generator sys_settrace_loop
3 tests failed: parser heapalloc_fail_bytearray opt_level_lineno
