### PR TITLE
Fix typo in block device code example

### DIFF
--- a/docs/reference/filesystem.rst
+++ b/docs/reference/filesystem.rst
@@ -124,7 +124,7 @@ interface (i.e. both signatures and behaviours of the
             self.block_size = block_size
             self.data = bytearray(block_size * num_blocks)
 
-        def readblocks(self, block, buf, offset=0):
+        def readblocks(self, block_num, buf, offset=0):
             addr = block_num * self.block_size + offset
             for i in range(len(buf)):
                 buf[i] = self.data[addr + i]


### PR DESCRIPTION
After this PR, the following code in the [Custom block devices](https://github.com/micropython/micropython/blob/master/docs/reference/filesystem.rst#custom-block-devices) docs will print 'Hello world'.

BTW,  it might be a good idea to include the last 3 lines of my test there as a full example to reasure users on their understanding of the ram block device with extended interface


import os

bdev = RAMBlockDev(512, 50)
os.VfsLfs2.mkfs(bdev)
os.mount(bdev, '/ramdisk')

with open('/ramdisk/hello.txt', 'w') as f:
    f.write('Hello world')
print(open('/ramdisk/hello.txt').read())