### PR TITLE
py: Don't crash when calling enumerate()

### DIFF
--- a/py/objenumerate.c
+++ b/py/objenumerate.c
@@ -59,7 +59,7 @@ STATIC mp_obj_t enumerate_make_new(const mp_obj_type_t *type, size_t n_args, siz
     o->iter = mp_getiter(arg_vals.iterable.u_obj, NULL);
     o->cur = arg_vals.start.u_int;
 #else
-    (void)n_kw;
+    mp_arg_check_num(n_args, n_kw, 1, 2, false);
     mp_obj_enumerate_t *o = m_new_obj(mp_obj_enumerate_t);
     o->base.type = type;
     o->iter = mp_getiter(args[0], NULL);


### PR DESCRIPTION
..with no arguments and MICROPY_CPYTHON_COMPAT == 0.
This makes basics/fun_error2.py pass and not crash the
interpreter.

The test basics/builtin_enumerate.py will still fail when
MYCROPY_CPYTHON_COMPAT == 0 though.