### PR TITLE
py/gc.c: Simplify gc_alloc_table_byte_len calculation.

### DIFF
--- a/py/gc.c
+++ b/py/gc.c
@@ -118,9 +118,9 @@ void gc_init(void *start, void *end) {
     // => T = A * (1 + BLOCKS_PER_ATB / BLOCKS_PER_FTB + BLOCKS_PER_ATB * BYTES_PER_BLOCK)
     size_t total_byte_len = (byte*)end - (byte*)start;
 #if MICROPY_ENABLE_FINALISER
-    MP_STATE_MEM(gc_alloc_table_byte_len) = total_byte_len * BITS_PER_BYTE / (BITS_PER_BYTE + BITS_PER_BYTE * BLOCKS_PER_ATB / BLOCKS_PER_FTB + BITS_PER_BYTE * BLOCKS_PER_ATB * BYTES_PER_BLOCK);
+    MP_STATE_MEM(gc_alloc_table_byte_len) = total_byte_len / (1 + BLOCKS_PER_ATB / BLOCKS_PER_FTB + BLOCKS_PER_ATB * BYTES_PER_BLOCK);
 #else
-    MP_STATE_MEM(gc_alloc_table_byte_len) = total_byte_len / (1 + BITS_PER_BYTE / 2 * BYTES_PER_BLOCK);
+    MP_STATE_MEM(gc_alloc_table_byte_len) = total_byte_len / (1 + BLOCKS_PER_ATB * BYTES_PER_BLOCK);
 #endif
 
     MP_STATE_MEM(gc_alloc_table_start) = (byte*)start;


### PR DESCRIPTION
In the MICROPY_ENABLE_FINALISER case, BITS_PER_BYTE appeared in
the numerator and all terms of the denominator, meaning that it
can be simplified out entirely. This has the added benefit of
making the formula match the earlier comment.

In the other case, switch to using BLOCKS_PER_ATB instead of
BITS_PER_BYTE/2, for consistency with the FINALISER case.
(BITS_PER_BYTE is hardcoded to 8 in mpconfig.h.)