### PR TITLE
tools/makemanifest.py: Allow passing flags to mpy-tool.py

### DIFF
--- a/py/mkrules.mk
+++ b/py/mkrules.mk
@@ -139,7 +139,7 @@ $(HEADER_BUILD):
 ifneq ($(FROZEN_MANIFEST),)
 # to build frozen_content.c from a manifest
 $(BUILD)/frozen_content.c: FORCE $(BUILD)/genhdr/qstrdefs.generated.h
-	$(Q)$(MAKE_MANIFEST) -o $@ -v "MPY_DIR=$(TOP)" -v "MPY_LIB_DIR=$(MPY_LIB_DIR)" -v "PORT_DIR=$(shell pwd)" -v "BOARD_DIR=$(BOARD_DIR)" -b "$(BUILD)" $(if $(MPY_CROSS_FLAGS),-f"$(MPY_CROSS_FLAGS)",) $(FROZEN_MANIFEST)
+	$(Q)$(MAKE_MANIFEST) -o $@ -v "MPY_DIR=$(TOP)" -v "MPY_LIB_DIR=$(MPY_LIB_DIR)" -v "PORT_DIR=$(shell pwd)" -v "BOARD_DIR=$(BOARD_DIR)" -b "$(BUILD)" $(if $(MPY_CROSS_FLAGS),-f"$(MPY_CROSS_FLAGS)",) --mpy-tool-flags="$(MPY_TOOL_FLAGS)" $(FROZEN_MANIFEST)
 
 ifneq ($(FROZEN_DIR),)
 $(error FROZEN_DIR cannot be used in conjunction with FROZEN_MANIFEST)

--- a/tools/makemanifest.py
+++ b/tools/makemanifest.py
@@ -248,6 +248,7 @@ def main():
         "-f", "--mpy-cross-flags", default="", help="flags to pass to mpy-cross"
     )
     cmd_parser.add_argument("-v", "--var", action="append", help="variables to substitute")
+    cmd_parser.add_argument("--mpy-tool-flags", default="", help="flags to pass to mpy-tool")
     cmd_parser.add_argument("files", nargs="+", help="input manifest list")
     args = cmd_parser.parse_args()
 
@@ -341,6 +342,7 @@ def main():
                 "-q",
                 args.build_dir + "/genhdr/qstrdefs.preprocessed.h",
             ]
+            + args.mpy_tool_flags.split()
             + mpy_files
         )
         if res != 0:


### PR DESCRIPTION
Use it to remain with the default MPZ_DIG_SIZE = 32 on 64-bit builds.