### PR TITLE
lib/tinytest: fix result not printed on newline

### DIFF
--- a/lib/tinytest/tinytest.c
+++ b/lib/tinytest/tinytest.c
@@ -234,9 +234,8 @@ testcase_run_one(const struct testgroup_t *group,
 		return SKIP;
 	}
 
-	printf("# starting %s%s\n", group->prefix, testcase->name);
 	if (opt_verbosity>0 && !opt_forked) {
-		//printf("%s%s: ", group->prefix, testcase->name);
+		printf("%s%s: ", group->prefix, testcase->name);
 	} else {
 		if (opt_verbosity==0) printf(".");
 		cur_test_prefix = group->prefix;
@@ -253,7 +252,6 @@ testcase_run_one(const struct testgroup_t *group,
 		outcome = testcase_run_bare_(testcase);
 	}
 
-	printf("%s%s: ", group->prefix, testcase->name);
 	if (outcome == OK) {
 		++n_ok;
 		if (opt_verbosity>0 && !opt_forked)
@@ -265,8 +263,7 @@ testcase_run_one(const struct testgroup_t *group,
 	} else {
 		++n_bad;
 		if (!opt_forked)
-			//printf("\n  [%s FAILED]\n", testcase->name);
-			puts("FAILED");
+			printf("\n  [%s FAILED]\n", testcase->name);
 	}
 
 	if (opt_forked) {

--- a/tools/tinytest-codegen.py
+++ b/tools/tinytest-codegen.py
@@ -33,8 +33,10 @@ test_function = (
     "void {name}(void* data) {{\n"
     "  static const char pystr[] = {script};\n"
     "  static const char exp[] = {output};\n"
+    '  printf("\\n");\n'
     "  upytest_set_expected_output(exp, sizeof(exp) - 1);\n"
     "  upytest_execute_test(pystr);\n"
+    '  printf("result: ");\n'
     "}}"
 )
 


### PR DESCRIPTION
When a test prints output during a test, it does so by adding a newline to the beginning of the line, rather than the end. So we need to do the same when printing the final result of the test, otherwise it ends up being appended to the end of the last message, which makes it hard to read.

Fixes: f4ed2dfa942339dc1f174e8a83ff0d41073f1972