### PR TITLE
[ESP8266] [Documentation] Add note that machine.RTC is not fully sup…

### DIFF
--- a/docs/esp8266/quickref.rst
+++ b/docs/esp8266/quickref.rst
@@ -235,7 +235,13 @@ and is accessed via the :ref:`machine.I2C <machine.I2C>` class::
 Real time clock (RTC)
 ---------------------
 
-See :ref:`machine.RTC <machine.RTC>` ::
+See :ref:`machine.RTC <machine.RTC>` 
+
+.. note:: Not all methods are implemented: `RTC.now()`, `RTC.irq(handler=*)` 
+          (using a custom handler), `RTC.init()` and `RTC.deinit()` are
+          currently not supported.
+
+::
 
     from machine import RTC
 

--- a/docs/esp8266/quickref.rst
+++ b/docs/esp8266/quickref.rst
@@ -235,13 +235,7 @@ and is accessed via the :ref:`machine.I2C <machine.I2C>` class::
 Real time clock (RTC)
 ---------------------
 
-See :ref:`machine.RTC <machine.RTC>` 
-
-.. note:: Not all methods are implemented: `RTC.now()`, `RTC.irq(handler=*)` 
-          (using a custom handler), `RTC.init()` and `RTC.deinit()` are
-          currently not supported.
-
-::
+See :ref:`machine.RTC <machine.RTC>` ::
 
     from machine import RTC
 
@@ -254,6 +248,10 @@ See :ref:`machine.RTC <machine.RTC>`
     import ntptime
     ntptime.settime() # set the rtc datetime from the remote server
     rtc.datetime()    # get the date and time in UTC
+
+.. note:: Not all methods are implemented: `RTC.now()`, `RTC.irq(handler=*)` 
+          (using a custom handler), `RTC.init()` and `RTC.deinit()` are
+          currently not supported.
 
 Deep-sleep mode
 ---------------


### PR DESCRIPTION
For the ESP8266 port, some methods of `machine.RTC` are not supported.

Add a note in the ESP8266 documentation, that `RTC.now()`, `RTC.init()`, `RTC.deinit()` and `RTC.irq()` with a `handler` keyword is currently not supported. 

Supported are only `RTC.ALARM0`, `RTC.alarm()`, `RTC.alarm_left()`, `RTC.datetime()`, `RTC.irq()` and `RTC.memory()`:
```python
>>> from machine import rtc
>>> rtc = RTC()
>>> dir(rtc)
['__class__', 'ALARM0', 'alarm', 'alarm_left', 'datetime', 'irq', 'memory']
```

This is mentioned in #3220, #3710 and in  #2701.