### PR TITLE
docs: add info about .mpy files, and building native .mpy modules

### DIFF
--- a/docs/develop/cmodules.rst
+++ b/docs/develop/cmodules.rst
@@ -1,3 +1,5 @@
+.. _cmodules:
+
 MicroPython external C modules
 ==============================
 
@@ -16,6 +18,10 @@ more sense to keep this external to the main MicroPython repository.
 
 This chapter describes how to compile such external modules into the
 MicroPython executable or firmware image.
+
+An alternative approach is to use :ref:`natmod` which allows writing custom C
+code that is placed in a .mpy file, which can be imported dynamically in to
+a running MicroPython system without the need to recompile the main firmware.
 
 
 Structure of an external C module

--- a/docs/develop/index.rst
+++ b/docs/develop/index.rst
@@ -11,3 +11,4 @@ See the `getting started guide
 
    cmodules.rst
    qstr.rst
+   natmod.rst

--- a/docs/develop/natmod.rst
+++ b/docs/develop/natmod.rst
@@ -1,0 +1,202 @@
+.. _natmod:
+
+Native machine code in .mpy files
+=================================
+
+This section describes how to build and work with .mpy files that contain native
+machine code from a language other than Python.  This allows you to
+write code in a language like C, compile and link it into a .mpy file, and then
+import this file like a normal Python module.  This can be used for implementing
+functionality which is performance critical, or for including an existing
+library written in another language.
+
+One of the main advantages of using native .mpy files is that native machine code
+can be imported by a script dynamically, without the need to rebuild the main
+MicroPython firmware.  This is in contrast to :ref:`cmodules` which also allows
+defining custom modules in C but they must be compiled into the main firmware image.
+
+The focus here is on using C to build native modules, but in principle any
+language which can be compiled to stand-alone machine code can be put into a
+.mpy file.
+
+A native .mpy module is built using the ``mpy_ld.py`` tool, which is found in the
+``tools/`` directory of the project.  This tool takes a set of object files
+(.o files) and links them together to create a native .mpy files.
+
+Supported features and limitations
+----------------------------------
+
+A .mpy file can contain MicroPython bytecode and/or native machine code.  If it
+contains native machine code then the .mpy file has a specific architecture
+associated with it.  Current supported architectures are (these are the valid
+options for the ``ARCH`` variable, see below):
+
+* ``x86`` (32 bit)
+* ``x64`` (64 bit x86)
+* ``armv7m`` (ARM Thumb 2, eg Cortex-M3)
+* ``armv7emsp`` (ARM Thumb 2, single precision float, eg Cortex-M4F, Cortex-M7)
+* ``armv7emdp`` (ARM Thumb 2, double precision float, eg Cortex-M7)
+* ``xtensa`` (non-windowed, eg ESP8266)
+* ``xtensawin`` (windowed with window size 8, eg ESP32)
+
+When compiling and linking the native .mpy file the architecture must be chosen
+and the corresponding file can only be imported on that architecture.  For more
+details about .mpy files see :ref:`mpy_files`.
+
+Native code must be compiled as position independent code (PIC) and use a global
+offset table (GOT), although the details of this varies from architecture to
+architecture.  When importing .mpy files with native code the import machinery
+is able to do some basic relocation of the native code.  This includes
+relocating text, rodata and BSS sections.
+
+Supported features of the linker and dynamic loader are:
+
+* executable code (text)
+* read-only data (rodata), including strings and constant data (arrays, structs, etc)
+* zeroed data (BSS)
+* pointers in text to text, rodata and BSS
+* pointers in rodata to text, rodata and BSS
+
+The known limitations are:
+
+* data sections are not supported; workaround: use BSS data and initialise the
+  data values explicitly
+
+* static BSS variables are not supported; workaround: use global BSS variables
+
+So, if your C code has writable data, make sure the data is defined globally,
+without an initialiser, and only written to within functions.
+
+Defining a native module
+------------------------
+
+A native .mpy module is defined by a set of files that are used to build the .mpy.
+The filesystem layout consists of two main parts, the source files and the Makefile:
+
+* In the simplest case only a single C source file is required, which contains all
+  the code that will be compiled into the .mpy module.  This C source code must
+  include the ``py/dynruntime.h`` file to access the MicroPython dynamic API, and
+  must at least define a function called ``mpy_init``.  This function will be the
+  entry point of the module, called when the module is imported.
+
+  The module can be split into multiple C source files if desired.  Parts of the
+  module can also be implemented in Python.  All source files should be listed in
+  the Makefile, by adding them to the ``SRC`` variable (see below).  This includes
+  both C source files as well as any Python files which will be included in the
+  resulting .mpy file.
+
+* The ``Makefile`` contains the build configuration for the module and list the
+  source files used to build the .mpy module.  It should define ``MPY_DIR`` as the
+  location of the MicroPython repository (to find header files, the relevant Makefile
+  fragment, and the ``mpy_ld.py`` tool), ``MOD`` as the name of the module, ``SRC``
+  as the list of source files, optionally specify the machine architecture via ``ARCH``,
+  and then include ``py/dynruntime.mk``.
+
+Minimal example
+---------------
+
+This section provides a fully working example of a simple module named ``factorial``.
+This module provides a single function ``factorial.factorial(x)`` which computes the
+factorial of the input and returns the result.
+
+Directory layout::
+
+    factorial/
+    ├── factorial.c
+    └── Makefile
+
+The file ``factorial.c`` contains:
+
+.. code-block:: c
+
+    // Include the header file to get access to the MicroPython API
+    #include "py/dynruntime.h"
+
+    // Helper function to compute factorial
+    STATIC mp_int_t factorial_helper(mp_int_t x) {
+        if (x == 0) {
+            return 1;
+        }
+        return x * factorial_helper(x - 1);
+    }
+
+    // This is the function which will be called from Python, as factorial(x)
+    STATIC mp_obj_t factorial(mp_obj_t x_obj) {
+        // Extract the integer from the MicroPython input object
+        mp_int_t x = mp_obj_get_int(x_obj);
+        // Calculate the factorial
+        mp_int_t result = factorial_helper(x);
+        // Convert the result to a MicroPython integer object and return it
+        return mp_obj_new_int(result);
+    }
+    // Define a Python reference to the function above
+    STATIC MP_DEFINE_CONST_FUN_OBJ_1(factorial_obj, factorial);
+
+    // This is the entry point and is called when the module is imported
+    mp_obj_t mpy_init(mp_obj_fun_bc_t *self, size_t n_args, size_t n_kw, mp_obj_t *args) {
+        // This must be first, it sets up the globals dict and other things
+        MP_DYNRUNTIME_INIT_ENTRY
+
+        // Make the function available in the module's namespace
+        mp_store_global(MP_QSTR_factorial, MP_OBJ_FROM_PTR(&factorial_obj));
+
+        // This must be last, it restores the globals dict
+        MP_DYNRUNTIME_INIT_EXIT
+    }
+
+The file ``Makefile`` contains:
+
+.. code-block:: make
+
+    # Location of top-level MicroPython directory
+    MPY_DIR = ../../..
+
+    # Name of module
+    MOD = features0
+
+    # Source files (.c or .py)
+    SRC = features0.c
+
+    # Architecture to build for (x86, x64, armv7m, xtensa, xtensawin)
+    ARCH = x64
+
+    # Include to get the rules for compiling and linking the module
+    include $(MPY_DIR)/py/dynruntime.mk
+
+Compiling the module
+--------------------
+
+Be sure to select the correct ``ARCH`` for the target you are going to run on.
+Then build with::
+
+    $ make
+
+Without modifying the Makefile you can specify the target architecture via::
+
+    $ make ARCH=armv7m
+
+Module usage in MicroPython
+---------------------------
+
+Once the module is built there should be a file called ``factorial.mpy``.  Copy
+this so it is accessible on the filesystem of your MicroPython system and can be
+found in the import path.  The module con now be accessed in Python just like any
+other module, for example::
+
+    import factorial
+    print(factorial.factorial(10))
+    # should display 3628800
+
+Further examples
+----------------
+
+See ``examples/natmod/`` for further examples which show many of the available
+features of native .mpy modules.  Such features include:
+
+* using multiple C source files
+* including Python code alongside C code
+* rodata and BSS data
+* memory allocation
+* use of floating point
+* exception handling
+* including external C libraries

--- a/docs/reference/index.rst
+++ b/docs/reference/index.rst
@@ -21,6 +21,7 @@ implementation and the best practices to use them.
 
    glossary.rst
    repl.rst
+   mpyfiles.rst
    isr_rules.rst
    speed_python.rst
    constrained.rst

--- a/docs/reference/mpyfiles.rst
+++ b/docs/reference/mpyfiles.rst
@@ -1,0 +1,178 @@
+.. _mpy_files:
+
+MicroPython .mpy files
+======================
+
+MicroPython defines the concept of an .mpy file which is a binary container
+file format that holds precompiled code, and which can be imported like a
+normal .py module.  The file ``foo.mpy`` can be imported via ``import foo``,
+as long as ``foo.mpy`` can be found in the usual way by the import machinery.
+Usually, each directory listed in ``sys.path`` is searched in order.  When
+searching a particular directory ``foo.py`` is looked for first and if that
+is not found then ``foo.mpy`` is looked for, then the search continues in the
+next directory if neither is found.  As such, ``foo.py`` will take precedence
+over ``foo.mpy``.
+
+These .mpy files can contain bytecode which is usually generated from Python
+source files (.py files) via the ``mpy-cross`` program.  For some architectures
+an .mpy file can also contain native machine code, which can be generated in
+a variety of ways, most notably from C source code.
+
+Versioning and compatibility of .mpy files
+------------------------------------------
+
+A given .mpy file may or may not be compatible with a given MicroPython system.
+Compatibility is based on the following:
+
+* Version of the .mpy file: the version of the file must match the version
+  supported by the system loading it.
+
+* Bytecode features used in the .mpy file: there are two bytecode features
+  which must match between the file and the system: unicode support and
+  inline caching of map lookups in the bytecode.
+
+* Small integer bits: the .mpy file will require a minimum number of bits in
+  a small integer and the system loading it must support at least this many
+  bits.
+
+* Qstr compression window size: the .mpy file will require a minimum window
+  size for qstr decompression and the system loading it must have a window
+  greater or equal to this size.
+
+* Native architecture: if the .mpy file contains native machine code then
+  it will specify the architecture of that machine code and the system
+  loading it must support execution of that architecture's code.
+
+If a MicroPython system supports importing .mpy files then the
+``sys.implementation.mpy`` field will exist and return an integer which
+encodes the version (lower 8 bits), features and native architecture.
+
+Trying to import an .mpy file that fails one of the first four tests will
+raise ``ValueError('incompatible .mpy file')``.  Trying to import an .mpy
+file that fails the native architecture test (if it contains native machine
+code) will raise ``ValueError('incompatible .mpy arch')``.
+
+If importing an .mpy file fails then try the following:
+
+* Determine the .mpy version and flags supported by your MicroPython system
+  by executing::
+
+    import sys
+    sys_mpy = sys.implementation.mpy
+    arch = [None, 'x86', 'x64',
+        'armv6', 'armv6m', 'armv7m', 'armv7em', 'armv7emsp', 'armv7emdp',
+        'xtensa', 'xtensawin'][sys_mpy >> 10]
+    print('mpy version:', sys_mpy & 0xff)
+    print('mpy flags:', end='')
+    if arch:
+        print(' -march=' + arch, end='')
+    if sys_mpy & 0x100:
+        print(' -mcache-lookup-bc', end='')
+    if not sys_mpy & 0x200:
+        print(' -mno-unicode', end='')
+    print()
+
+* Check the validity of the .mpy file by inspecting the first two bytes of
+  the file.  The first byte should be an uppercase 'M' and the second byte
+  will be the version number, which should match the system version from above.
+  If it doesn't match then rebuild the .mpy file.
+
+* Check if the system .mpy version matches the version emitted by ``mpy-cross``
+  that was used to build the .mpy file, found by ``mpy-cross --version``.
+  If it doesn't match then recompile ``mpy-cross`` from the Git repository
+  checked out at the tag (or hash) reported by ``mpy-cross --version``.
+
+* Make sure you are using the correct ``mpy-cross`` flags, found by the code
+  above, or by inspecting the ``MPY_CROSS_FLAGS`` Makefile variable for the
+  port that you are using.
+
+The following table shows the correspondence between MicroPython release
+and .mpy version.
+
+=================== ============
+MicroPython release .mpy version
+=================== ============
+v1.12 and up        5
+v1.11               4
+v1.9.3 - v1.10      3
+v1.9 - v1.9.2       2
+v1.5.1 - v1.8.7     0
+=================== ============
+
+For completeness, the next table shows the Git commit of the main
+MicroPython repository at which the .mpy version was changed.
+
+=================== ========================================
+.mpy version change Git commit
+=================== ========================================
+4 to 5              5716c5cf65e9b2cb46c2906f40302401bdd27517
+3 to 4              9a5f92ea72754c01cc03e5efcdfe94021120531e
+2 to 3              ff93fd4f50321c6190e1659b19e64fef3045a484
+1 to 2              dd11af209d226b7d18d5148b239662e30ed60bad
+0 to 1              6a11048af1d01c78bdacddadd1b72dc7ba7c6478
+initial version 0   d8c834c95d506db979ec871417de90b7951edc30
+=================== ========================================
+
+Binary encoding of .mpy files
+-----------------------------
+
+MicroPython .mpy files are a binary container format with code objects
+stored internally in a nested hierarchy.  To keep files small while still
+providing a large range of possible values it uses the concept of a
+variably-encoded-unsigned-integer (vuint) in many places.  Similar to utf-8
+encoding, this encoding stores 7 bits per byte with the 8th bit (MSB) set
+if one or more bytes follow.  The bits of the unsigned integer are stored
+in the vuint in LSB form.
+
+The top-level of an .mpy file consists of two parts:
+
+* The header.
+
+* The raw-code for the outer scope of the module.
+  This outer scope is executed when the .mpy file is imported.
+
+The header
+~~~~~~~~~~
+
+The .mpy header is:
+
+======  ================================
+size    field
+======  ================================
+byte    value 0x4d (ASCII 'M')
+byte    .mpy version number
+byte    feature flags
+byte    number of bits in a small int
+vuint   size of qstr window
+======  ================================
+
+Raw code elements
+~~~~~~~~~~~~~~~~~
+
+A raw-code element contains code, either bytecode or native machine code.  Its
+contents are:
+
+======  ================================
+size    field
+======  ================================
+vuint   type and size
+...     code (bytecode or machine code)
+vuint   number of constant objects
+vuint   number of sub-raw-code elements
+...     constant objects
+...     sub-raw-code elements
+======  ================================
+
+The first vuint in a raw-code element encodes the type of code stored in this
+element (the two least-significant bits), and the decompressed length of the code
+(the amount of RAM to allocate for it).
+
+Following the vuint comes the code itself.  In the case of bytecode it also contains
+compressed qstr values.
+
+Following the code comes a vuint counting the number of constant objects, and
+another vuint counting the number of sub-raw-code elements.
+
+The constant objects are then stored next.
+
+Finally any sub-raw-code elements are stored, recursively.

--- a/examples/natmod/features0/Makefile
+++ b/examples/natmod/features0/Makefile
@@ -1,0 +1,14 @@
+# Location of top-level MicroPython directory
+MPY_DIR = ../../..
+
+# Name of module
+MOD = features0
+
+# Source files (.c or .py)
+SRC = features0.c
+
+# Architecture to build for (x86, x64, armv7m, xtensa, xtensawin)
+ARCH = x64
+
+# Include to get the rules for compiling and linking the module
+include $(MPY_DIR)/py/dynruntime.mk

--- a/examples/natmod/features0/features0.c
+++ b/examples/natmod/features0/features0.c
@@ -1,0 +1,40 @@
+/* This example demonstrates the following features in a native module:
+    - defining a simple function exposed to Python
+    - defining a local, helper C function
+    - getting and creating integer objects
+*/
+
+// Include the header file to get access to the MicroPython API
+#include "py/dynruntime.h"
+
+// Helper function to compute factorial
+STATIC mp_int_t factorial_helper(mp_int_t x) {
+    if (x == 0) {
+        return 1;
+    }
+    return x * factorial_helper(x - 1);
+}
+
+// This is the function which will be called from Python, as factorial(x)
+STATIC mp_obj_t factorial(mp_obj_t x_obj) {
+    // Extract the integer from the MicroPython input object
+    mp_int_t x = mp_obj_get_int(x_obj);
+    // Calculate the factorial
+    mp_int_t result = factorial_helper(x);
+    // Convert the result to a MicroPython integer object and return it
+    return mp_obj_new_int(result);
+}
+// Define a Python reference to the function above
+STATIC MP_DEFINE_CONST_FUN_OBJ_1(factorial_obj, factorial);
+
+// This is the entry point and is called when the module is imported
+mp_obj_t mpy_init(mp_obj_fun_bc_t *self, size_t n_args, size_t n_kw, mp_obj_t *args) {
+    // This must be first, it sets up the globals dict and other things
+    MP_DYNRUNTIME_INIT_ENTRY
+
+    // Make the function available in the module's namespace
+    mp_store_global(MP_QSTR_factorial, MP_OBJ_FROM_PTR(&factorial_obj));
+
+    // This must be last, it restores the globals dict
+    MP_DYNRUNTIME_INIT_EXIT
+}


### PR DESCRIPTION
This PR adds initial documentation which describes .mpy files and how to use them, and also information about writing and building native .mpy modules.