### PR TITLE
py: convert None/False/True to small immediate values

### DIFF
--- a/py/mpconfig.h
+++ b/py/mpconfig.h
@@ -70,25 +70,28 @@
 
 // A MicroPython object is a machine word having the following form:
 //  - xxxx...xxx1 : a small int, bits 1 and above are the value
-//  - xxxx...xx10 : a qstr, bits 2 and above are the value
+//  - xxxx...x010 : a qstr, bits 3 and above are the value
+//  - xxxx...x110 : an immediate object, bits 3 and above are the value
 //  - xxxx...xx00 : a pointer to an mp_obj_base_t (unless a fake object)
 #define MICROPY_OBJ_REPR_A (0)
 
 // A MicroPython object is a machine word having the following form:
 //  - xxxx...xx01 : a small int, bits 2 and above are the value
-//  - xxxx...xx11 : a qstr, bits 2 and above are the value
+//  - xxxx...x011 : a qstr, bits 3 and above are the value
+//  - xxxx...x111 : an immediate object, bits 3 and above are the value
 //  - xxxx...xxx0 : a pointer to an mp_obj_base_t (unless a fake object)
 #define MICROPY_OBJ_REPR_B (1)
 
 // A MicroPython object is a machine word having the following form (called R):
 //  - iiiiiiii iiiiiiii iiiiiiii iiiiiii1 small int with 31-bit signed value
-//  - 01111111 1qqqqqqq qqqqqqqq qqqqq110 str with 20-bit qstr value
+//  - 01111111 1qqqqqqq qqqqqqqq qqqq0110 str with 19-bit qstr value
+//  - 01111111 10000000 00000000 ssss1110 immediate object with 4-bit value
 //  - s1111111 10000000 00000000 00000010 +/- inf
 //  - s1111111 1xxxxxxx xxxxxxxx xxxxx010 nan, x != 0
 //  - seeeeeee efffffff ffffffff ffffff10 30-bit fp, e != 0xff
 //  - pppppppp pppppppp pppppppp pppppp00 ptr (4 byte alignment)
-// Str and float stored as O = R + 0x80800000, retrieved as R = O - 0x80800000.
-// This makes strs easier to encode/decode as they have zeros in the top 9 bits.
+// Str, immediate and float stored as O = R + 0x80800000, retrieved as R = O - 0x80800000.
+// This makes strs/immediates easier to encode/decode as they have zeros in the top 9 bits.
 // This scheme only works with 32-bit word size and float enabled.
 #define MICROPY_OBJ_REPR_C (2)
 
@@ -98,6 +101,7 @@
 //  - 01111111 11111000 00000000 00000000 00000000 00000000 00000000 00000000 normalised nan
 //  - 01111111 11111101 iiiiiiii iiiiiiii iiiiiiii iiiiiiii iiiiiiii iiiiiii1 small int
 //  - 01111111 11111110 00000000 00000000 qqqqqqqq qqqqqqqq qqqqqqqq qqqqqqq1 str
+//  - 01111111 11111111 ss000000 00000000 00000000 00000000 00000000 00000000 immediate object
 //  - 01111111 11111100 00000000 00000000 pppppppp pppppppp pppppppp pppppp00 ptr (4 byte alignment)
 // Stored as O = R + 0x8004000000000000, retrieved as R = O - 0x8004000000000000.
 // This makes pointers have all zeros in the top 32 bits.

--- a/py/mpconfig.h
+++ b/py/mpconfig.h
@@ -113,6 +113,13 @@
 #define MICROPY_OBJ_REPR (MICROPY_OBJ_REPR_A)
 #endif
 
+// Whether to encode None/False/True as immediate objects instead of pointers to
+// real objects.  Reduces code size by a decent amount without hurting
+// performance, for all representations except D on some architectures.
+#ifndef MICROPY_OBJ_IMMEDIATE_OBJS
+#define MICROPY_OBJ_IMMEDIATE_OBJS (MICROPY_OBJ_REPR != MICROPY_OBJ_REPR_D)
+#endif
+
 /*****************************************************************************/
 /* Memory allocation policy                                                  */
 

--- a/py/nativeglue.c
+++ b/py/nativeglue.c
@@ -255,9 +255,9 @@ STATIC double mp_obj_get_float_to_d(mp_obj_t o) {
 
 // these must correspond to the respective enum in runtime0.h
 const mp_fun_table_t mp_fun_table = {
-    &mp_const_none_obj,
-    &mp_const_false_obj,
-    &mp_const_true_obj,
+    mp_const_none,
+    mp_const_false,
+    mp_const_true,
     mp_native_from_obj,
     mp_native_to_obj,
     mp_native_swap_globals,

--- a/py/obj.c
+++ b/py/obj.c
@@ -46,6 +46,11 @@ const mp_obj_type_t *mp_obj_get_type(mp_const_obj_t o_in) {
     } else if (mp_obj_is_float(o_in)) {
         return &mp_type_float;
     #endif
+    #if MICROPY_OBJ_IMMEDIATE_OBJS
+    } else if (mp_obj_is_immediate_obj(o_in)) {
+        static const mp_obj_type_t *const types[2] = {&mp_type_NoneType, &mp_type_bool};
+        return types[MP_OBJ_IMMEDIATE_OBJ_VALUE(o_in) & 1];
+    #endif
     } else {
         const mp_obj_base_t *o = MP_OBJ_TO_PTR(o_in);
         return o->type;

--- a/py/obj.h
+++ b/py/obj.h
@@ -87,9 +87,14 @@ static inline bool mp_obj_is_small_int(mp_const_obj_t o)
 #define MP_OBJ_NEW_SMALL_INT(small_int) ((mp_obj_t)((((mp_uint_t)(small_int)) << 1) | 1))
 
 static inline bool mp_obj_is_qstr(mp_const_obj_t o)
-    { return ((((mp_int_t)(o)) & 3) == 2); }
-#define MP_OBJ_QSTR_VALUE(o) (((mp_uint_t)(o)) >> 2)
-#define MP_OBJ_NEW_QSTR(qst) ((mp_obj_t)((((mp_uint_t)(qst)) << 2) | 2))
+    { return ((((mp_int_t)(o)) & 7) == 2); }
+#define MP_OBJ_QSTR_VALUE(o) (((mp_uint_t)(o)) >> 3)
+#define MP_OBJ_NEW_QSTR(qst) ((mp_obj_t)((((mp_uint_t)(qst)) << 3) | 2))
+
+static inline bool mp_obj_is_immediate_obj(mp_const_obj_t o)
+    { return ((((mp_int_t)(o)) & 7) == 6); }
+#define MP_OBJ_IMMEDIATE_OBJ_VALUE(o) (((mp_uint_t)(o)) >> 3)
+#define MP_OBJ_NEW_IMMEDIATE_OBJ(val) ((mp_obj_t)(((val) << 3) | 6))
 
 #if MICROPY_PY_BUILTINS_FLOAT
 #define mp_const_float_e MP_ROM_PTR(&mp_const_float_e_obj)
@@ -113,9 +118,14 @@ static inline bool mp_obj_is_small_int(mp_const_obj_t o)
 #define MP_OBJ_NEW_SMALL_INT(small_int) ((mp_obj_t)((((mp_uint_t)(small_int)) << 2) | 1))
 
 static inline bool mp_obj_is_qstr(mp_const_obj_t o)
-    { return ((((mp_int_t)(o)) & 3) == 3); }
-#define MP_OBJ_QSTR_VALUE(o) (((mp_uint_t)(o)) >> 2)
-#define MP_OBJ_NEW_QSTR(qst) ((mp_obj_t)((((mp_uint_t)(qst)) << 2) | 3))
+    { return ((((mp_int_t)(o)) & 7) == 3); }
+#define MP_OBJ_QSTR_VALUE(o) (((mp_uint_t)(o)) >> 3)
+#define MP_OBJ_NEW_QSTR(qst) ((mp_obj_t)((((mp_uint_t)(qst)) << 3) | 3))
+
+static inline bool mp_obj_is_immediate_obj(mp_const_obj_t o)
+    { return ((((mp_int_t)(o)) & 7) == 7); }
+#define MP_OBJ_IMMEDIATE_OBJ_VALUE(o) (((mp_uint_t)(o)) >> 3)
+#define MP_OBJ_NEW_IMMEDIATE_OBJ(val) ((mp_obj_t)(((val) << 3) | 7))
 
 #if MICROPY_PY_BUILTINS_FLOAT
 #define mp_const_float_e MP_ROM_PTR(&mp_const_float_e_obj)
@@ -161,9 +171,14 @@ static inline mp_obj_t mp_obj_new_float(mp_float_t f) {
 #endif
 
 static inline bool mp_obj_is_qstr(mp_const_obj_t o)
-    { return (((mp_uint_t)(o)) & 0xff800007) == 0x00000006; }
-#define MP_OBJ_QSTR_VALUE(o) (((mp_uint_t)(o)) >> 3)
-#define MP_OBJ_NEW_QSTR(qst) ((mp_obj_t)((((mp_uint_t)(qst)) << 3) | 0x00000006))
+    { return (((mp_uint_t)(o)) & 0xff80000f) == 0x00000006; }
+#define MP_OBJ_QSTR_VALUE(o) (((mp_uint_t)(o)) >> 4)
+#define MP_OBJ_NEW_QSTR(qst) ((mp_obj_t)((((mp_uint_t)(qst)) << 4) | 0x00000006))
+
+static inline bool mp_obj_is_immediate_obj(mp_const_obj_t o)
+    { return (((mp_uint_t)(o)) & 0xff80000f) == 0x0000000e; }
+#define MP_OBJ_IMMEDIATE_OBJ_VALUE(o) (((mp_uint_t)(o)) >> 4)
+#define MP_OBJ_NEW_IMMEDIATE_OBJ(val) ((mp_obj_t)(((val) << 4) | 0xe))
 
 static inline bool mp_obj_is_obj(mp_const_obj_t o)
     { return ((((mp_int_t)(o)) & 3) == 0); }
@@ -179,6 +194,11 @@ static inline bool mp_obj_is_qstr(mp_const_obj_t o)
     { return ((((uint64_t)(o)) & 0xffff000000000000) == 0x0002000000000000); }
 #define MP_OBJ_QSTR_VALUE(o) ((((uint32_t)(o)) >> 1) & 0xffffffff)
 #define MP_OBJ_NEW_QSTR(qst) ((mp_obj_t)(((uint64_t)(((uint32_t)(qst)) << 1)) | 0x0002000000000001))
+
+static inline bool mp_obj_is_immediate_obj(mp_const_obj_t o)
+    { return ((((uint64_t)(o)) & 0xffff000000000000) == 0x0003000000000000); }
+#define MP_OBJ_IMMEDIATE_OBJ_VALUE(o) ((((uint32_t)(o)) >> 46) & 3)
+#define MP_OBJ_NEW_IMMEDIATE_OBJ(val) (((uint64_t)(val) << 46) | 0x0003000000000000)
 
 #if MICROPY_PY_BUILTINS_FLOAT
 

--- a/py/obj.h
+++ b/py/obj.h
@@ -263,12 +263,21 @@ typedef union _mp_rom_obj_t { uint64_t u64; struct { const void *lo, *hi; } u32;
 // Macros to create objects that are stored in ROM.
 
 #ifndef MP_ROM_NONE
+#if MICROPY_OBJ_IMMEDIATE_OBJS
+#define MP_ROM_NONE mp_const_none
+#else
 #define MP_ROM_NONE MP_ROM_PTR(&mp_const_none_obj)
+#endif
 #endif
 
 #ifndef MP_ROM_FALSE
+#if MICROPY_OBJ_IMMEDIATE_OBJS
+#define MP_ROM_FALSE mp_const_false
+#define MP_ROM_TRUE mp_const_true
+#else
 #define MP_ROM_FALSE MP_ROM_PTR(&mp_const_false_obj)
 #define MP_ROM_TRUE MP_ROM_PTR(&mp_const_true_obj)
+#endif
 #endif
 
 #ifndef MP_ROM_INT
@@ -622,17 +631,27 @@ extern const mp_obj_type_t mp_type_ValueError;
 extern const mp_obj_type_t mp_type_ViperTypeError;
 extern const mp_obj_type_t mp_type_ZeroDivisionError;
 
-// Constant objects, globally accessible
-// The macros are for convenience only
+// Constant objects, globally accessible: None, False, True
+// These should always be accessed via the below macros.
+#if MICROPY_OBJ_IMMEDIATE_OBJS
+// None is even while False/True are odd so their types can be distinguished with 1 bit.
+#define mp_const_none MP_OBJ_NEW_IMMEDIATE_OBJ(0)
+#define mp_const_false MP_OBJ_NEW_IMMEDIATE_OBJ(1)
+#define mp_const_true MP_OBJ_NEW_IMMEDIATE_OBJ(3)
+#else
 #define mp_const_none (MP_OBJ_FROM_PTR(&mp_const_none_obj))
 #define mp_const_false (MP_OBJ_FROM_PTR(&mp_const_false_obj))
 #define mp_const_true (MP_OBJ_FROM_PTR(&mp_const_true_obj))
-#define mp_const_empty_bytes (MP_OBJ_FROM_PTR(&mp_const_empty_bytes_obj))
-#define mp_const_empty_tuple (MP_OBJ_FROM_PTR(&mp_const_empty_tuple_obj))
-#define mp_const_notimplemented (MP_OBJ_FROM_PTR(&mp_const_notimplemented_obj))
 extern const struct _mp_obj_none_t mp_const_none_obj;
 extern const struct _mp_obj_bool_t mp_const_false_obj;
 extern const struct _mp_obj_bool_t mp_const_true_obj;
+#endif
+
+// Constant objects, globally accessible: b'', (), Ellipsis, NotImplemented, GeneratorExit()
+// The below macros are for convenience only.
+#define mp_const_empty_bytes (MP_OBJ_FROM_PTR(&mp_const_empty_bytes_obj))
+#define mp_const_empty_tuple (MP_OBJ_FROM_PTR(&mp_const_empty_tuple_obj))
+#define mp_const_notimplemented (MP_OBJ_FROM_PTR(&mp_const_notimplemented_obj))
 extern const struct _mp_obj_str_t mp_const_empty_bytes_obj;
 extern const struct _mp_obj_tuple_t mp_const_empty_tuple_obj;
 extern const struct _mp_obj_singleton_t mp_const_ellipsis_obj;

--- a/py/objbool.c
+++ b/py/objbool.c
@@ -28,21 +28,31 @@
 
 #include "py/runtime.h"
 
+#if MICROPY_OBJ_IMMEDIATE_OBJS
+
+#define BOOL_VALUE(o) ((o) == mp_const_false ? 0 : 1)
+
+#else
+
+#define BOOL_VALUE(o) (((mp_obj_bool_t*)MP_OBJ_TO_PTR(o))->value)
+
 typedef struct _mp_obj_bool_t {
     mp_obj_base_t base;
     bool value;
 } mp_obj_bool_t;
 
+#endif
+
 STATIC void bool_print(const mp_print_t *print, mp_obj_t self_in, mp_print_kind_t kind) {
-    mp_obj_bool_t *self = MP_OBJ_TO_PTR(self_in);
+    bool value = BOOL_VALUE(self_in);
     if (MICROPY_PY_UJSON && kind == PRINT_JSON) {
-        if (self->value) {
+        if (value) {
             mp_print_str(print, "true");
         } else {
             mp_print_str(print, "false");
         }
     } else {
-        if (self->value) {
+        if (value) {
             mp_print_str(print, "True");
         } else {
             mp_print_str(print, "False");
@@ -65,13 +75,13 @@ STATIC mp_obj_t bool_unary_op(mp_unary_op_t op, mp_obj_t o_in) {
     if (op == MP_UNARY_OP_LEN) {
         return MP_OBJ_NULL;
     }
-    mp_obj_bool_t *self = MP_OBJ_TO_PTR(o_in);
-    return mp_unary_op(op, MP_OBJ_NEW_SMALL_INT(self->value));
+    bool value = BOOL_VALUE(o_in);
+    return mp_unary_op(op, MP_OBJ_NEW_SMALL_INT(value));
 }
 
 STATIC mp_obj_t bool_binary_op(mp_binary_op_t op, mp_obj_t lhs_in, mp_obj_t rhs_in) {
-    mp_obj_bool_t *self = MP_OBJ_TO_PTR(lhs_in);
-    return mp_binary_op(op, MP_OBJ_NEW_SMALL_INT(self->value), rhs_in);
+    bool value = BOOL_VALUE(lhs_in);
+    return mp_binary_op(op, MP_OBJ_NEW_SMALL_INT(value), rhs_in);
 }
 
 const mp_obj_type_t mp_type_bool = {
@@ -83,5 +93,7 @@ const mp_obj_type_t mp_type_bool = {
     .binary_op = bool_binary_op,
 };
 
+#if !MICROPY_OBJ_IMMEDIATE_OBJS
 const mp_obj_bool_t mp_const_false_obj = {{&mp_type_bool}, false};
 const mp_obj_bool_t mp_const_true_obj = {{&mp_type_bool}, true};
+#endif

--- a/py/objnone.c
+++ b/py/objnone.c
@@ -28,9 +28,11 @@
 
 #include "py/obj.h"
 
+#if !MICROPY_OBJ_IMMEDIATE_OBJS
 typedef struct _mp_obj_none_t {
     mp_obj_base_t base;
 } mp_obj_none_t;
+#endif
 
 STATIC void none_print(const mp_print_t *print, mp_obj_t self_in, mp_print_kind_t kind) {
     (void)self_in;
@@ -48,4 +50,6 @@ const mp_obj_type_t mp_type_NoneType = {
     .unary_op = mp_generic_unary_op,
 };
 
+#if !MICROPY_OBJ_IMMEDIATE_OBJS
 const mp_obj_none_t mp_const_none_obj = {{&mp_type_NoneType}};
+#endif


### PR DESCRIPTION
Based on discussion in #5314, with full credit to @jongy for the idea:

> mp_const_none is widely used throughout the project 
> ...
> In order to make the loading of it easier, we can either make the value a small immediate like MP_OBJ_NULL

That's what's done in this PR, to make `None`, `False` and `True` small immediate values, namely `MP_OBJ_NONE`, `MP_OBJ_FALSE`, `MP_OBJ_TRUE`.

I had to steal some of the qstr encoding space in an object (see change to py/mpconfig.h) to encode these new values, so they were separate from true object pointers.  But it turned out pretty neat and straightforward to do it.  Hardly any places in the code assume anything about the None/False/True objects so they can easily become immediate values.

There are significant size reductions to ports:
```
   bare-arm:  -416 -0.628% 
minimal x86:  -308 -0.207% [incl -12(data)]
   unix x64:  -992 -0.199% [incl -256(data)]
      stm32: -1928 -0.507% PYBV10
     cc3200: -1240 -0.670% 
      esp32:  -528 -0.047% GENERIC[incl -32(data)]
        nrf:  -932 -0.638% pca10040
       samd:  -560 -0.549% ADAFRUIT_ITSYBITSY_M4_EXPRESS
```
Note that I only made it work for object representation A at this point.  Also, did not do any performance comparison tests with the changes.