### PR TITLE
qemu-arm: Let tinytest.o be built by standard build rules.

### DIFF
--- a/ports/qemu-arm/Makefile
+++ b/ports/qemu-arm/Makefile
@@ -33,12 +33,9 @@ endif
 
 CROSS_COMPILE = arm-none-eabi-
 
-TINYTEST = $(TOP)/lib/tinytest
-
 INC += -I.
 INC += -I$(TOP)
 INC += -I$(BUILD)
-INC += -I$(TINYTEST)
 
 CFLAGS += $(INC) -Wall -Wpointer-arith -Werror -std=gnu99 $(COPT) \
 	 -ffunction-sections -fdata-sections
@@ -71,6 +68,7 @@ SRC_RUN_C = \
 
 SRC_TEST_C = \
 	test_main.c \
+	lib/tinytest/tinytest.c \
 
 LIB_SRC_C += $(addprefix lib/,\
 	libc/string0.c \
@@ -108,7 +106,6 @@ ALL_OBJ_RUN = $(OBJ_COMMON) $(OBJ_RUN)
 
 OBJ_TEST =
 OBJ_TEST += $(addprefix $(BUILD)/, $(SRC_TEST_C:.c=.o))
-OBJ_TEST += $(BUILD)/tinytest.o
 
 ALL_OBJ_TEST = $(OBJ_COMMON) $(OBJ_TEST)
 

--- a/ports/qemu-arm/Makefile.test
+++ b/ports/qemu-arm/Makefile.test
@@ -13,8 +13,7 @@ $(BUILD)/genhdr/tests.h:
 	(cd $(TOP)/tests; ./run-tests --target=qemu-arm --write-exp)
 	$(Q)echo "Generating $@";(cd $(TOP)/tests; ../tools/tinytest-codegen.py) > $@
 
-$(BUILD)/tinytest.o:
-	$(Q)$(CC) $(CFLAGS) -DNO_FORKING -o $@ -c $(TINYTEST)/tinytest.c
+$(BUILD)/lib/tinytest/tinytest.o: CFLAGS += -DNO_FORKING
 
 $(BUILD)/firmware-test.elf: $(LDSCRIPT) $(ALL_OBJ_TEST)
 	$(Q)$(LD) $(LDFLAGS) -o $@ $(ALL_OBJ_TEST) $(LIBS)

--- a/ports/qemu-arm/test_main.c
+++ b/ports/qemu-arm/test_main.c
@@ -12,9 +12,8 @@
 #include "py/gc.h"
 #include "py/mperrno.h"
 #include "lib/utils/gchelper.h"
-
-#include "tinytest.h"
-#include "tinytest_macros.h"
+#include "lib/tinytest/tinytest.h"
+#include "lib/tinytest/tinytest_macros.h"
 
 #define HEAP_SIZE (100 * 1024)
 


### PR DESCRIPTION
This makes sure tinytest.o is rebuilt if any of its dependencies change.