### PR TITLE
Fix incorrect value of BR/EDR flag in bluetooth examples

### DIFF
--- a/examples/bluetooth/ble_advertising.py
+++ b/examples/bluetooth/ble_advertising.py
@@ -30,7 +30,7 @@ def advertising_payload(limited_disc=False, br_edr=False, name=None, services=No
 
     _append(
         _ADV_TYPE_FLAGS,
-        struct.pack("B", (0x01 if limited_disc else 0x02) + (0x00 if br_edr else 0x04)),
+        struct.pack("B", (0x01 if limited_disc else 0x02) + (0x18 if br_edr else 0x04)),
     )
 
     if name:


### PR DESCRIPTION
According to ```Supplement to the Bluetooth Core Specification v8 Part A 1.3.1```, to support BR/EDR, shouldn't we set the fifth bit (```Simultaneous LE and BR/EDR to Same
Device Capable (Controller)```) and fourth bit (```Simultaneous LE and BR/EDR to Same
Device Capable (Host)```) of the flag to ```1```? Currently these bits are set as ```0``` when ```br_edr``` is ```True```, this PR tried to fix this.