### PR TITLE
STM32H7 timer fixes.

### DIFF
--- a/ports/stm32/stm32_it.c
+++ b/ports/stm32/stm32_it.c
@@ -609,6 +609,14 @@ void TIM1_UP_TIM16_IRQHandler(void) {
 }
 #endif
 
+#if defined(STM32H7)
+void TIM1_UP_IRQHandler(void) {
+    IRQ_ENTER(TIM1_UP_IRQn);
+    timer_irq_handler(1);
+    IRQ_EXIT(TIM1_UP_IRQn);
+}
+#endif
+
 void TIM1_TRG_COM_TIM11_IRQHandler(void) {
     IRQ_ENTER(TIM1_TRG_COM_TIM11_IRQn);
     timer_irq_handler(11);
@@ -702,6 +710,26 @@ void TIM8_TRG_COM_TIM14_IRQHandler(void) {
     IRQ_ENTER(TIM8_TRG_COM_TIM14_IRQn);
     timer_irq_handler(14);
     IRQ_EXIT(TIM8_TRG_COM_TIM14_IRQn);
+}
+#endif
+
+#if defined(STM32H7)
+void TIM15_IRQHandler(void) {
+    IRQ_ENTER(TIM15_IRQn);
+    timer_irq_handler(15);
+    IRQ_EXIT(TIM15_IRQn);
+}
+
+void TIM16_IRQHandler(void) {
+    IRQ_ENTER(TIM16_IRQn);
+    timer_irq_handler(16);
+    IRQ_EXIT(TIM16_IRQn);
+}
+
+void TIM17_IRQHandler(void) {
+    IRQ_ENTER(TIM17_IRQn);
+    timer_irq_handler(17);
+    IRQ_EXIT(TIM17_IRQn);
 }
 #endif
 

--- a/ports/stm32/timer.c
+++ b/ports/stm32/timer.c
@@ -759,6 +759,8 @@ STATIC const uint32_t tim_instance_table[MICROPY_HW_MAX_TIMER] = {
     TIM_ENTRY(1, TIM1_BRK_UP_TRG_COM_IRQn),
     #elif defined(STM32F4) || defined(STM32F7)
     TIM_ENTRY(1, TIM1_UP_TIM10_IRQn),
+    #elif defined(STM32H7)
+    TIM_ENTRY(1, TIM1_UP_IRQn),
     #elif defined(STM32L4)
     TIM_ENTRY(1, TIM1_UP_TIM16_IRQn),
     #endif
@@ -780,7 +782,7 @@ STATIC const uint32_t tim_instance_table[MICROPY_HW_MAX_TIMER] = {
     TIM_ENTRY(7, TIM7_IRQn),
     #endif
     #if defined(TIM8)
-    #if defined(STM32F4) || defined(STM32F7)
+    #if defined(STM32F4) || defined(STM32F7) || defined(STM32H7)
     TIM_ENTRY(8, TIM8_UP_TIM13_IRQn),
     #elif defined(STM32L4)
     TIM_ENTRY(8, TIM8_UP_IRQn),


### PR DESCRIPTION
* Add missing TIM8/TIM8_UP_TIM13_IRQn entry for H7.
* Add missing TIM 1, 15, 16 and 17 IRQ handlers.
* Note: The F0 is also missing TIM 14, 15,16 and 17 IRQ handlers.