### PR TITLE
ports/qemu-arm/Makefile: allow overriding CROSS_COMPILE

### DIFF
--- a/ports/qemu-arm/Makefile
+++ b/ports/qemu-arm/Makefile
@@ -31,7 +31,7 @@ LDSCRIPT = mps2.ld
 SRC_BOARD_O = lib/utils/gchelper_m3.o
 endif
 
-CROSS_COMPILE = arm-none-eabi-
+CROSS_COMPILE ?= arm-none-eabi-
 
 INC += -I.
 INC += -I$(TOP)


### PR DESCRIPTION
This allows specifying a specific cross-compiler without having to
mess with the PATH environment variable. Most other MicroPython
ports already allow this.