### PR TITLE
ports: allow overriding CROSS_COMPILE

### DIFF
--- a/ports/bare-arm/Makefile
+++ b/ports/bare-arm/Makefile
@@ -6,7 +6,7 @@ QSTR_DEFS = qstrdefsport.h
 # include py core make definitions
 include $(TOP)/py/py.mk
 
-CROSS_COMPILE = arm-none-eabi-
+CROSS_COMPILE ?= arm-none-eabi-
 
 INC += -I.
 INC += -I$(TOP)

--- a/ports/esp32/README.md
+++ b/ports/esp32/README.md
@@ -85,7 +85,7 @@ BOARD = GENERIC
 #PORT = /dev/ttyUSB0
 #FLASH_MODE = qio
 #FLASH_SIZE = 4MB
-#CROSS_COMPILE = xtensa-esp32-elf-
+#CROSS_COMPILE ?= xtensa-esp32-elf-
 
 include Makefile
 ```

--- a/ports/esp8266/Makefile
+++ b/ports/esp8266/Makefile
@@ -39,7 +39,7 @@ PORT ?= /dev/ttyACM0
 BAUD ?= 115200
 FLASH_MODE ?= qio
 FLASH_SIZE ?= detect
-CROSS_COMPILE = xtensa-lx106-elf-
+CROSS_COMPILE ?= xtensa-lx106-elf-
 ESP_SDK = $(shell $(CC) -print-sysroot)/usr
 
 INC += -I.

--- a/ports/minimal/Makefile
+++ b/ports/minimal/Makefile
@@ -9,7 +9,7 @@ QSTR_DEFS = qstrdefsport.h
 include $(TOP)/py/py.mk
 
 ifeq ($(CROSS), 1)
-CROSS_COMPILE = arm-none-eabi-
+CROSS_COMPILE ?= arm-none-eabi-
 endif
 
 INC += -I.

--- a/ports/nrf/Makefile
+++ b/ports/nrf/Makefile
@@ -47,7 +47,7 @@ MICROPY_VFS_FAT ?= 0
 MPY_CROSS = ../../mpy-cross/mpy-cross
 MPY_TOOL = ../../tools/mpy-tool.py
 
-CROSS_COMPILE = arm-none-eabi-
+CROSS_COMPILE ?= arm-none-eabi-
 
 INC += -I.
 INC += -I../..

--- a/ports/pic16bit/Makefile
+++ b/ports/pic16bit/Makefile
@@ -7,7 +7,7 @@ QSTR_DEFS = qstrdefsport.h
 include $(TOP)/py/py.mk
 
 XC16 = /opt/microchip/xc16/v1.35
-CROSS_COMPILE = $(XC16)/bin/xc16-
+CROSS_COMPILE ?= $(XC16)/bin/xc16-
 
 PARTFAMILY = dsPIC33F
 PART = 33FJ256GP506

--- a/ports/powerpc/Makefile
+++ b/ports/powerpc/Makefile
@@ -9,7 +9,7 @@ include $(TOP)/py/py.mk
 ARCH = $(shell uname -m)
 ifneq ("$(ARCH)", "ppc64")
 ifneq ("$(ARCH)", "ppc64le")
-	CROSS_COMPILE = powerpc64le-linux-
+	CROSS_COMPILE ?= powerpc64le-linux-
 endif
 endif
 

--- a/ports/qemu-arm/Makefile
+++ b/ports/qemu-arm/Makefile
@@ -31,7 +31,7 @@ LDSCRIPT = mps2.ld
 SRC_BOARD_O = lib/utils/gchelper_m3.o
 endif
 
-CROSS_COMPILE = arm-none-eabi-
+CROSS_COMPILE ?= arm-none-eabi-
 
 INC += -I.
 INC += -I$(TOP)

--- a/ports/stm32/mboot/Makefile
+++ b/ports/stm32/mboot/Makefile
@@ -34,7 +34,7 @@ OPENOCD ?= openocd
 OPENOCD_CONFIG ?= boards/openocd_stm32f4.cfg
 STARTUP_FILE ?= lib/stm32lib/CMSIS/STM32$(MCU_SERIES_UPPER)xx/Source/Templates/gcc/startup_$(CMSIS_MCU_LOWER).o
 
-CROSS_COMPILE = arm-none-eabi-
+CROSS_COMPILE ?= arm-none-eabi-
 
 INC += -I.
 INC += -I..

--- a/ports/teensy/Makefile
+++ b/ports/teensy/Makefile
@@ -20,10 +20,10 @@ endif
 
 ifeq ($(USE_ARDUINO_TOOLCHAIN),1)
 $(info Using ARDUINO toolchain)
-CROSS_COMPILE = $(ARDUINO)/hardware/tools/arm-none-eabi/bin/arm-none-eabi-
+CROSS_COMPILE ?= $(ARDUINO)/hardware/tools/arm-none-eabi/bin/arm-none-eabi-
 else
 $(info Using toolchain from PATH)
-CROSS_COMPILE = arm-none-eabi-
+CROSS_COMPILE ?= arm-none-eabi-
 endif
 
 CFLAGS_TEENSY = -DF_CPU=96000000 -DUSB_SERIAL -D__MK20DX256__


### PR DESCRIPTION
Many ports already allow overriding CROSS_COMPILE. This modifies the
remaining ports to allow it as well.