### PR TITLE
py/objsingleton: Use mp_generic_unary_op for singleton objects.

### DIFF
--- a/py/objsingleton.c
+++ b/py/objsingleton.c
@@ -47,6 +47,7 @@ const mp_obj_type_t mp_type_singleton = {
     { &mp_type_type },
     .name = MP_QSTR_,
     .print = singleton_print,
+    .unary_op = mp_generic_unary_op,
 };
 
 const mp_obj_singleton_t mp_const_ellipsis_obj = {{&mp_type_singleton}, MP_QSTR_Ellipsis};

--- a/tests/basics/builtin_ellipsis.py
+++ b/tests/basics/builtin_ellipsis.py
@@ -4,3 +4,6 @@ print(...)
 print(Ellipsis)
 
 print(... == Ellipsis)
+
+# Test that Ellipsis can be hashed
+print(type(hash(Ellipsis)))

--- a/tests/basics/class_notimpl.py
+++ b/tests/basics/class_notimpl.py
@@ -48,3 +48,6 @@ except TypeError:
 
 # NotImplemented isn't handled specially in unary methods
 print(-c)
+
+# Test that NotImplemented can be hashed
+print(type(hash(NotImplemented)))


### PR DESCRIPTION
So these types more closely match NoneType, eg they can be hashed, like in CPython.