### PR TITLE
extmod/modbluetooth: Fix a -Wstrict-prototypes error.

### DIFF
--- a/extmod/modbluetooth.h
+++ b/extmod/modbluetooth.h
@@ -180,7 +180,7 @@ int mp_bluetooth_gatts_register_service_begin(bool append);
 // The value_handles won't be valid until after mp_bluetooth_register_service_end is called.
 int mp_bluetooth_gatts_register_service(mp_obj_bluetooth_uuid_t *service_uuid, mp_obj_bluetooth_uuid_t **characteristic_uuids, uint8_t *characteristic_flags, mp_obj_bluetooth_uuid_t **descriptor_uuids, uint8_t *descriptor_flags, uint8_t *num_descriptors, uint16_t *handles, size_t num_characteristics);
 // Register any queued services.
-int mp_bluetooth_gatts_register_service_end();
+int mp_bluetooth_gatts_register_service_end(void);
 
 // Read the value from the local gatts db (likely this has been written by a central).
 int mp_bluetooth_gatts_read(uint16_t value_handle, uint8_t **value, size_t *value_len);


### PR DESCRIPTION
Just a tiny change I've had from playing around with different compilation settings which included -Wstrict-prototypes. It really was the only error :)