### PR TITLE
Add dht.start() and dht.receive() for use in event loops

### DIFF
--- a/docs/esp32/quickref.rst
+++ b/docs/esp32/quickref.rst
@@ -486,6 +486,33 @@ The DHT driver is implemented in software and works on all pins::
     d.temperature() # eg. 23.6 (°C)
     d.humidity()    # eg. 41.3 (% RH)
 
+Separate methods to send the start signal and receive the result
+exist to minimize blocking in event loops. This is a uasyncio
+based example printing the sensor data every 2 seconds::
+
+    import dht
+    import machine
+    import uasyncio as asyncio
+
+    async def report_dht_data(d):
+        while True:
+            await asyncio.sleep(2)
+            try:
+                wait_ms = d.start()
+                await asyncio.sleep_ms(wait_ms)
+                d.receive()
+            except Exception as ex:
+                print("error: {}".format(ex))
+                continue
+
+            print("temp: {}°C humi: {}%RH".format(d.temperature(),
+                                                  d.humidity()))
+
+    d = dht.DHT22(machine.Pin(4))
+    loop = asyncio.get_event_loop()
+    loop.create_task(report_dht_data(d))
+    loop.run_forever()
+
 WebREPL (web browser interactive prompt)
 ----------------------------------------
 

--- a/docs/esp8266/quickref.rst
+++ b/docs/esp8266/quickref.rst
@@ -362,6 +362,33 @@ The DHT driver is implemented in software and works on all pins::
     d.temperature() # eg. 23.6 (°C)
     d.humidity()    # eg. 41.3 (% RH)
 
+Separate methods to send the start signal and receive the result
+exist to minimize blocking in event loops. This is a uasyncio
+based example printing the sensor data every 2 seconds::
+
+    import dht
+    import machine
+    import uasyncio as asyncio
+
+    async def report_dht_data(d):
+        while True:
+            await asyncio.sleep(2)
+            try:
+                wait_ms = d.start()
+                await asyncio.sleep_ms(wait_ms)
+                d.receive()
+            except Exception as ex:
+                print("error: {}".format(ex))
+                continue
+
+            print("temp: {}°C humi: {}%RH".format(d.temperature(),
+                                                  d.humidity()))
+
+    d = dht.DHT22(machine.Pin(4))
+    loop = asyncio.get_event_loop()
+    loop.create_task(report_dht_data(d))
+    loop.run_forever()
+
 WebREPL (web browser interactive prompt)
 ----------------------------------------
 

--- a/drivers/dht/dht.py
+++ b/drivers/dht/dht.py
@@ -6,16 +6,35 @@ try:
 except:
     from pyb import dht_readinto
 
+from machine import Pin
+from utime import sleep_ms
+
 class DHTBase:
-    def __init__(self, pin):
+    def __init__(self, pin, delay_ms = 250, start_ms = 18):
         self.pin = pin
         self.buf = bytearray(5)
+        self.delay_ms = delay_ms
+        self.start_ms = start_ms
+        self.pin.init(mode=Pin.OPEN_DRAIN)
+        self.pin.on()
 
-    def measure(self):
+    def start(self):
+        self.pin.off()
+        return self.start_ms
+
+    def receive(self):
         buf = self.buf
         dht_readinto(self.pin, buf)
         if (buf[0] + buf[1] + buf[2] + buf[3]) & 0xff != buf[4]:
             raise Exception("checksum error")
+
+    def measure(self):
+        if self.delay_ms > 0:
+            self.pin.on()
+            sleep_ms(self.delay_ms)
+        self.start()
+        sleep_ms(self.start_ms)
+        self.receive()
 
 class DHT11(DHTBase):
     def humidity(self):

--- a/ports/esp8266/esp_mphal.h
+++ b/ports/esp8266/esp_mphal.h
@@ -91,11 +91,6 @@ void mp_hal_pin_open_drain(mp_hal_pin_obj_t pin);
         if ((p) == 16) { WRITE_PERI_REG(RTC_GPIO_ENABLE, (READ_PERI_REG(RTC_GPIO_ENABLE) & ~1)); } \
         else { gpio_output_set(0, 0, 0, 1 << (p)); /* set as input to avoid glitches */ } \
     } while (0)
-// The DHT driver requires using the open-drain feature of the GPIO to get it to work reliably
-#define mp_hal_pin_od_high_dht(p) do { \
-        if ((p) == 16) { WRITE_PERI_REG(RTC_GPIO_ENABLE, (READ_PERI_REG(RTC_GPIO_ENABLE) & ~1)); } \
-        else { gpio_output_set(1 << (p), 0, 1 << (p), 0); } \
-    } while (0)
 #define mp_hal_pin_read(p) pin_get(p)
 #define mp_hal_pin_write(p, v) pin_set((p), (v))
 


### PR DESCRIPTION
This moves all delays into the Python code of the driver
and adds separate methods to send the start pulse and
later receive the measurement with minimal blocking for
use in event loops like uasyncio.

Quickref changes for esp8266 and esp32 are included.