### PR TITLE
tools/pyboard: Split Ctrl-C into two separate steps with small delay

### DIFF
--- a/tools/pyboard.py
+++ b/tools/pyboard.py
@@ -287,7 +287,10 @@ class Pyboard:
         return data
 
     def enter_raw_repl(self):
-        self.serial.write(b'\r\x03\x03') # ctrl-C twice: interrupt any running program
+        # ctrl-C twice: interrupt any running program
+        self.serial.write(b'\r\x03')
+        time.sleep(0.01)
+        self.serial.write(b'\x03')
 
         # flush input (without relying on serial.flushInput())
         n = self.serial.inWaiting()


### PR DESCRIPTION
This makes pyboard.py successfully enter raw-repl on an ESP32 board.
Without the split the running program won't always successfully abort and thus entering raw-repl fails.

I'm not completely sure, if this also depends on the actual program that is running on the device and whether this also happens on a real pyboard.
So for reference, here's the program running on the device which triggers the behaviour for me:
```
from machine import Pin
from time import sleep
import micropython

p = Pin(0, Pin.OUT)

#@micropython.native
def func():
	for _ in range(1000):
		p.value(not p.value())
while 1:
	func()
```

This change has not been tested on an actual pyboard, because I don't have one.