### PR TITLE
STM32/softtimer 

### DIFF
--- a/ports/stm32/softtimer.c
+++ b/ports/stm32/softtimer.c
@@ -107,6 +107,7 @@ void soft_timer_remove(soft_timer_entry_t *entry) {
             *cur = entry->next;
             break;
         }
+        *cur = (*cur)->next;
     }
     restore_irq_pri(irq_state);
 }


### PR DESCRIPTION
soft_timer_remove: move to next node for traversal entry list.