### PR TITLE
zephyr: Fix build errors and warnings

### DIFF
--- a/ports/zephyr/Makefile
+++ b/ports/zephyr/Makefile
@@ -108,4 +108,4 @@ outdir/$(BOARD)/Makefile: $(CONF_FILE)
 
 $(Z_EXPORTS): outdir/$(BOARD)/Makefile
 	make --no-print-directory -C outdir/$(BOARD) outputexports CMAKE_COMMAND=: >$@
-	make -C outdir/$(BOARD) syscall_macros_h_target syscall_list_h_target kobj_types_h_target
+	make -C outdir/$(BOARD) syscall_list_h_target kobj_types_h_target

--- a/ports/zephyr/machine_i2c.c
+++ b/ports/zephyr/machine_i2c.c
@@ -30,7 +30,7 @@
 #include <string.h>
 
 #include <zephyr.h>
-#include <i2c.h>
+#include <drivers/i2c.h>
 
 #include "py/runtime.h"
 #include "py/gc.h"

--- a/ports/zephyr/machine_pin.c
+++ b/ports/zephyr/machine_pin.c
@@ -30,7 +30,7 @@
 #include <string.h>
 
 #include <zephyr.h>
-#include <gpio.h>
+#include <drivers/gpio.h>
 
 #include "py/runtime.h"
 #include "py/gc.h"

--- a/ports/zephyr/modmachine.c
+++ b/ports/zephyr/modmachine.c
@@ -28,7 +28,7 @@
 
 #include <stdint.h>
 #include <stdio.h>
-#include <misc/reboot.h>
+#include <power/reboot.h>
 
 #include "py/obj.h"
 #include "py/runtime.h"

--- a/ports/zephyr/modzephyr.c
+++ b/ports/zephyr/modzephyr.c
@@ -29,7 +29,7 @@
 
 #include <stdio.h>
 #include <zephyr.h>
-#include <misc/stack.h>
+#include <debug/stack.h>
 
 #include "py/runtime.h"
 

--- a/ports/zephyr/modzsensor.c
+++ b/ports/zephyr/modzsensor.c
@@ -29,7 +29,7 @@
 #include "py/runtime.h"
 
 #include <zephyr.h>
-#include <sensor.h>
+#include <drivers/sensor.h>
 
 #if MICROPY_PY_ZSENSOR
 

--- a/ports/zephyr/mphalport.h
+++ b/ports/zephyr/mphalport.h
@@ -2,7 +2,7 @@
 #include "lib/utils/interrupt_char.h"
 
 static inline mp_uint_t mp_hal_ticks_us(void) {
-    return SYS_CLOCK_HW_CYCLES_TO_NS(k_cycle_get_32()) / 1000;
+    return k_cyc_to_ns_floor64(k_cycle_get_32()) / 1000;
 }
 
 static inline mp_uint_t mp_hal_ticks_ms(void) {

--- a/ports/zephyr/src/zephyr_getchar.c
+++ b/ports/zephyr/src/zephyr_getchar.c
@@ -15,9 +15,9 @@
  */
 
 #include <zephyr.h>
-#include <uart.h>
+#include <drivers/uart.h>
 #include <drivers/console/uart_console.h>
-#include <misc/printk.h>
+#include <sys/printk.h>
 #include "zephyr_getchar.h"
 
 extern int mp_interrupt_char;

--- a/ports/zephyr/src/zephyr_start.c
+++ b/ports/zephyr/src/zephyr_start.c
@@ -24,7 +24,7 @@
  * THE SOFTWARE.
  */
 #include <zephyr.h>
-#include <console.h>
+#include <console/console.h>
 #include "zephyr_getchar.h"
 
 int real_main(void);

--- a/ports/zephyr/uart_core.c
+++ b/ports/zephyr/uart_core.c
@@ -27,8 +27,8 @@
 #include "py/mpconfig.h"
 #include "src/zephyr_getchar.h"
 // Zephyr headers
-#include <uart.h>
-#include <console.h>
+#include <drivers/uart.h>
+#include <console/console.h>
 
 /*
  * Core UART functions to implement for a port


### PR DESCRIPTION
Fixes several build errors and warnings in the zephyr port when building with recent versions of zephyr.