### PR TITLE
Implement non-bool results from (in)equality tests

### DIFF
--- a/py/obj.h
+++ b/py/obj.h
@@ -681,6 +681,7 @@ void mp_obj_print_exception(const mp_print_t *print, mp_obj_t exc);
 bool mp_obj_is_true(mp_obj_t arg);
 bool mp_obj_is_callable(mp_obj_t o_in);
 bool mp_obj_equal(mp_obj_t o1, mp_obj_t o2);
+mp_obj_t mp_obj_equal_bop(mp_obj_t o1, mp_obj_t o2, bool not_equal);
 
 static inline bool mp_obj_is_integer(mp_const_obj_t o) { return mp_obj_is_int(o) || mp_obj_is_type(o, &mp_type_bool); } // returns true if o is bool, small int or long int
 mp_int_t mp_obj_get_int(mp_const_obj_t arg);

--- a/py/obj.h
+++ b/py/obj.h
@@ -681,7 +681,7 @@ void mp_obj_print_exception(const mp_print_t *print, mp_obj_t exc);
 bool mp_obj_is_true(mp_obj_t arg);
 bool mp_obj_is_callable(mp_obj_t o_in);
 bool mp_obj_equal(mp_obj_t o1, mp_obj_t o2);
-mp_obj_t mp_obj_equal_bop(mp_obj_t o1, mp_obj_t o2, bool not_equal);
+mp_obj_t mp_obj_equal_bop(mp_binary_op_t op, mp_obj_t o1, mp_obj_t o2);
 
 static inline bool mp_obj_is_integer(mp_const_obj_t o) { return mp_obj_is_int(o) || mp_obj_is_type(o, &mp_type_bool); } // returns true if o is bool, small int or long int
 mp_int_t mp_obj_get_int(mp_const_obj_t arg);

--- a/py/objtype.c
+++ b/py/objtype.c
@@ -470,7 +470,7 @@ const byte mp_binary_op_method_name[MP_BINARY_OP_NUM_RUNTIME] = {
     [MP_BINARY_OP_EQUAL] = MP_QSTR___eq__,
     [MP_BINARY_OP_LESS_EQUAL] = MP_QSTR___le__,
     [MP_BINARY_OP_MORE_EQUAL] = MP_QSTR___ge__,
-    // MP_BINARY_OP_NOT_EQUAL, // a != b calls a == b and inverts result
+    [MP_BINARY_OP_NOT_EQUAL] = MP_QSTR___ne__,
     [MP_BINARY_OP_CONTAINS] = MP_QSTR___contains__,
 
     // If an inplace method is not found a normal method will be used as a fallback

--- a/py/runtime.c
+++ b/py/runtime.c
@@ -323,19 +323,8 @@ mp_obj_t mp_binary_op(mp_binary_op_t op, mp_obj_t lhs, mp_obj_t rhs) {
 
     // deal with == and != for all types
     if (op == MP_BINARY_OP_EQUAL || op == MP_BINARY_OP_NOT_EQUAL) {
-        if (mp_obj_equal(lhs, rhs)) {
-            if (op == MP_BINARY_OP_EQUAL) {
-                return mp_const_true;
-            } else {
-                return mp_const_false;
-            }
-        } else {
-            if (op == MP_BINARY_OP_EQUAL) {
-                return mp_const_false;
-            } else {
-                return mp_const_true;
-            }
-        }
+        // mp_obj_equal_bop supports a bunch of shortcuts
+        return mp_obj_equal_bop(lhs, rhs, op == MP_BINARY_OP_NOT_EQUAL);
     }
 
     // deal with exception_match for all types

--- a/py/runtime.c
+++ b/py/runtime.c
@@ -324,7 +324,7 @@ mp_obj_t mp_binary_op(mp_binary_op_t op, mp_obj_t lhs, mp_obj_t rhs) {
     // deal with == and != for all types
     if (op == MP_BINARY_OP_EQUAL || op == MP_BINARY_OP_NOT_EQUAL) {
         // mp_obj_equal_bop supports a bunch of shortcuts
-        return mp_obj_equal_bop(lhs, rhs, op == MP_BINARY_OP_NOT_EQUAL);
+        return mp_obj_equal_bop(op, lhs, rhs);
     }
 
     // deal with exception_match for all types

--- a/tests/basics/special_comparisons.py
+++ b/tests/basics/special_comparisons.py
@@ -1,0 +1,33 @@
+class A:
+    def __eq__(self, other):
+        print("A __eq__ called")
+        return True
+
+class B:
+    def __ne__(self, other):
+        print("B __ne__ called")
+        return True
+
+class C:
+    def __eq__(self, other):
+        print("C __eq__ called")
+        return False
+
+class D:
+    def __ne__(self, other):
+        print("D __ne__ called")
+        return False
+
+a = A()
+b = B()
+c = C()
+d = D()
+
+def test(s):
+    print(s)
+    print(eval(s))
+
+for x in 'abcd':
+    for y in 'abcd':
+        test('{} == {}'.format(x,y))
+        test('{} != {}'.format(x,y))

--- a/tests/basics/special_comparisons2.py
+++ b/tests/basics/special_comparisons2.py
@@ -1,0 +1,33 @@
+class E:
+    def __repr__(self):
+        return "E"
+    
+    def __eq__(self, other):
+        print('E eq', other)
+        return 123
+
+class F:
+    def __repr__(self):
+        return "F"
+    
+    def __ne__(self, other):
+        print('F ne', other)
+        return -456
+
+print(E() != F())
+print(F() != E())
+
+# Disabling tests of strings pending update to string comparisons
+# tests = (None, 0, 1, 'a')
+tests = (None, 0, 1)
+
+for val in tests:
+    print('==== testing', val)
+    print(E() == val)
+    print(val == E())
+    print(E() != val)
+    print(val != E())
+    print(F() == val)
+    print(val == F())
+    print(F() != val)
+    print(val != F())


### PR DESCRIPTION
This PR implements a more complete replication of CPython's behaviour for equality and inequality testing. This addresses the issues discussed in #5382 and a few other warts. Improvements over the old code include:
 * Support for returning non-boolean results from comparisons (as used by `nunmpy` and others).
 * Support for non-reflexive equality tests.
 * Preferential use of `__ne__` methods and `MP_BINARY_OP_NOT_EQUAL` binary operators for inequality tests, when available.
 * Fallback to `op2 == op1` or `op2 != op1` when `op1` does not implement the (in)equality operators.

The PR also includes a more comprehensive set of tests for the behaviour of (in)equality operators implemented in special methods.
