### PR TITLE
tests/run-tests: handle 'CRASH' return by float.py

### DIFF
--- a/tests/run-tests
+++ b/tests/run-tests
@@ -288,7 +288,11 @@ def run_tests(pyb, tests, args, base_path="."):
             skip_tests.add('cmdline/repl_emacs_keys.py')
 
         upy_byteorder = run_feature_check(pyb, args, base_path, 'byteorder.py')
-        upy_float_precision = int(run_feature_check(pyb, args, base_path, 'float.py'))
+        upy_float_precision = run_feature_check(pyb, args, base_path, 'float.py')
+        if upy_float_precision == b'CRASH':
+            upy_float_precision = 0
+        else:
+            upy_float_precision = int(upy_float_precision)
         has_complex = run_feature_check(pyb, args, base_path, 'complex.py') == b'complex\n'
         has_coverage = run_feature_check(pyb, args, base_path, 'coverage.py') == b'coverage\n'
         cpy_byteorder = subprocess.check_output([CPYTHON3, base_path + '/feature_check/byteorder.py'])


### PR DESCRIPTION
It is possile for `run_feature_check(pyb, args, base_path, 'float.py')` to
return `b'CRASH'`. This causes an unhandled exception in `int()`.

This fixes the problem by first testing for `b'CRASH'` before trying
to convert the return value to an integer.