### PR TITLE
docs/library/machine.I2C.rst: Use positional-only arguments syntax.

### DIFF
--- a/docs/library/machine.I2C.rst
+++ b/docs/library/machine.I2C.rst
@@ -89,7 +89,7 @@ These methods are available on software I2C only.
 
    Generate a STOP condition on the bus (SDA transitions to high while SCL is high).
 
-.. method:: I2C.readinto(buf, nack=True)
+.. method:: I2C.readinto(buf, nack=True, /)
 
    Reads bytes from the bus and stores them into *buf*.  The number of bytes
    read is the length of *buf*.  An ACK will be sent on the bus after
@@ -109,13 +109,13 @@ Standard bus operations
 The following methods implement the standard I2C master read and write
 operations that target a given slave device.
 
-.. method:: I2C.readfrom(addr, nbytes, stop=True)
+.. method:: I2C.readfrom(addr, nbytes, stop=True, /)
 
    Read *nbytes* from the slave specified by *addr*.
    If *stop* is true then a STOP condition is generated at the end of the transfer.
    Returns a `bytes` object with the data read.
 
-.. method:: I2C.readfrom_into(addr, buf, stop=True)
+.. method:: I2C.readfrom_into(addr, buf, stop=True, /)
 
    Read into *buf* from the slave specified by *addr*.
    The number of bytes read will be the length of *buf*.
@@ -123,7 +123,7 @@ operations that target a given slave device.
 
    The method returns ``None``.
 
-.. method:: I2C.writeto(addr, buf, stop=True)
+.. method:: I2C.writeto(addr, buf, stop=True, /)
 
    Write the bytes from *buf* to the slave specified by *addr*.  If a
    NACK is received following the write of a byte from *buf* then the
@@ -131,7 +131,7 @@ operations that target a given slave device.
    generated at the end of the transfer, even if a NACK is received.
    The function returns the number of ACKs that were received.
 
-.. method:: I2C.writevto(addr, vector, stop=True)
+.. method:: I2C.writevto(addr, vector, stop=True, /)
 
    Write the bytes contained in *vector* to the slave specified by *addr*.
    *vector* should be a tuple or list of objects with the buffer protocol.


### PR DESCRIPTION
I've added positional-only args syntax to the methods of the I2C class.

@dpgeorge in your proposal in #5196 were you proposing just for I2C or to add this everywhere?

Closes #5196.
