### PR TITLE
Addition of a machine.Counter class (ESP32 only initially)

### DIFF
--- a/docs/library/machine.Counter.rst
+++ b/docs/library/machine.Counter.rst
@@ -55,6 +55,8 @@ Methods
    Initialise a counter by connecting it to an input pin. Optionally specify the
    counting direction and whether the rising or falling edge should be counted.
    Additional keyword parameters can customize the counter:
+     - ``pin``: the input pin, either a pin number (int), a pin name (str), or a Pin object
+       (note, however, that some ports may limit the choice, ESP32 in particular)
      - ``direction``: Counter.UP, Counter,DOWN
      - ``edge``: Counter.RISING, Counter.FALLING, Counter.BOTH
      - ``limit``: when counting up the register is reset to zero at the next edge after
@@ -65,6 +67,7 @@ Methods
        unchanged which can be useful to preserve counts when an application restarts.
 
    ESP32 notes:
+     - Only supports pin numbers for now.
      - Supports the following parameters: direction, edge, limit, and reset (**verify**).
      - The ESP32's counter units support additional features (e.g. a control
        pin and intermediate trigger values) but these are currently not supported.

--- a/docs/library/machine.Counter.rst
+++ b/docs/library/machine.Counter.rst
@@ -27,6 +27,11 @@ Example usage::
     sleep(10)
     print ctr.value
 
+Some use-cases for using a Counter are: counting motor shaft revolutions and deriving
+rotational velocity, measuring wind
+speed using an anemometer that produces N pulses per revolution, measuring rain using a
+tipping bucket.
+
 Availability of this class: esp32.
 
 Constructors
@@ -45,7 +50,7 @@ Constructors
 Methods
 -------
 
-.. method:: Counter.init(pin, direction=Counter.UP, edge=Counter.RISING, limit=None)
+.. method:: Counter.init(pin, direction=Counter.UP, edge=Counter.RISING, limit=None, reset=True)
 
    Initialise a counter by connecting it to an input pin. Optionally specify the
    counting direction and whether the rising or falling edge should be counted.
@@ -56,11 +61,14 @@ Methods
        it reaches the limit. This means that a limit of ``N`` produces the N+1 values 0..N.
        When counting down the register is set to the limit value at the next edge after it
        reaches zero.
+     - ``reset``: if True init resets the counter, else it leaves the current register value
+       unchanged which can be useful to preserve counts when an application restarts.
 
    ESP32 notes:
-     - the ESP32's counter units support additional features (e.g. a control
+     - Supports the following parameters: direction, edge, limit, and reset (**verify**).
+     - The ESP32's counter units support additional features (e.g. a control
        pin and intermediate trigger values) but these are currently not supported.
-     - when counting down the ESP32's hardware starts at zero, counts to a negative limit, then
+     - When counting down the ESP32's hardware starts at zero, counts to a negative limit, then
        resets back to zero. This class shifts the values such that the counter counts down 
        to zero from the limit, which is the more typical implementation on most microprocessors.
 
@@ -100,6 +108,8 @@ Methods
      than one power mode.
 
    ESP32 notes:
+   - The ESP32's 8 units with two channels each are exposed as 16 units such that ids
+     0 and 1 correspond to unit 0, ids 2 and 3 to unit 1, etc.
    - Supported triggers are ZERO and LIMIT.
    - The priority is ignored (**verify**).
    - For wake only machine.IDLE is supported.
@@ -110,20 +120,17 @@ Methods
 
    This method returns a callback object.
 
-Properties
-----------
+.. method:: Counter.value([x])
 
-.. property:: Counter.value
+   Reads or writes the current value of the counter.
 
-   The current value of the counter can be read and written using this property.
+.. method:: Counter.direction([x])
 
-.. property:: Counter.direction
+   Reads or changes the counting direction.
 
-   The counting direction can be changed using this property.
+.. method:: Counter.limit([x])
 
-.. property:: Counter.limit
-
-   The limit to which the counter counts up or from which it counts down.
+   Reads or changes the limit to which the counter counts up or from which it counts down.
 
 Constants
 ---------

--- a/docs/library/machine.Counter.rst
+++ b/docs/library/machine.Counter.rst
@@ -25,7 +25,7 @@ Example usage::
     from machine import Counter, Pin
     ctr = Counter(0, pin=4)
     sleep(10)
-    print ctr.value
+    print ctr.value()
 
 Some use-cases for using a Counter are: counting motor shaft revolutions and deriving
 rotational velocity, measuring wind
@@ -70,6 +70,8 @@ Methods
    ESP32 notes:
      - Only supports pin numbers for now.
      - Supports the following parameters: direction, edge, limit, and reset (**verify**).
+     - The ESP32's counter units support two channels, which really means two pin pairs, so one pin
+       could cause an increment and the other a decrement. Only one channel is currently suported.
      - The ESP32's counter units support additional features (e.g. a control
        pin and intermediate trigger values) but these are currently not supported.
      - When counting down the ESP32's hardware starts at zero, counts to a negative limit, then
@@ -127,14 +129,6 @@ Methods
 .. method:: Counter.value([x])
 
    Reads or writes the current value of the counter.
-
-.. method:: Counter.direction([x])
-
-   Reads or changes the counting direction.
-
-.. method:: Counter.limit([x])
-
-   Reads or changes the limit to which the counter counts up or from which it counts down.
 
 Constants
 ---------

--- a/docs/library/machine.Counter.rst
+++ b/docs/library/machine.Counter.rst
@@ -52,11 +52,12 @@ Methods
 
 .. method:: Counter.init(pin, direction=Counter.UP, edge=Counter.RISING, limit=None, reset=True)
 
-   Initialise a counter by connecting it to an input pin. Optionally specify the
+   Initialise a counter by connecting it to an input pin.
+   The input pin can be specified as a pin number (int), a pin name (str), or a Pin object
+   (however, some ports may limit the choice, the ESP32 in particular).
+   Optionally specify the
    counting direction and whether the rising or falling edge should be counted.
    Additional keyword parameters can customize the counter:
-     - ``pin``: the input pin, either a pin number (int), a pin name (str), or a Pin object
-       (note, however, that some ports may limit the choice, ESP32 in particular)
      - ``direction``: Counter.UP, Counter,DOWN
      - ``edge``: Counter.RISING, Counter.FALLING, Counter.BOTH
      - ``limit``: when counting up the register is reset to zero at the next edge after

--- a/docs/library/machine.Counter.rst
+++ b/docs/library/machine.Counter.rst
@@ -1,0 +1,145 @@
+.. currentmodule:: machine
+.. _machine.Counter:
+
+class Counter -- hardware counter
+=================================
+
+A hardware counter counts the transitions or pulses on an input pin and accumulates the count into a
+hardware register. This register can be read, reset, and typically thresholds can be set to trigger
+interrupts when specific values are reached.
+
+Counters are related to timers and in some
+microprocessors use the same hardware. From a usage perspective, counters count
+edges (or pulses) that happen at arbitrary points in time and the resulting register
+values over time are expressed simply as counts whereas timers tend to count
+regular clock pulses and the resulting register values are expressed as units of time.
+
+Most hardware counter units can count up or down, can count on positive or negative
+incoming edges and can reset at/to some max value. On many microprocessors the input
+can be fed through a prescaler which divides the incoming pulses by a power of two.
+It is also common to find a filter which can cause short pulses due to glitches to be
+ignored.
+
+Example usage::
+
+    from machine import Counter, Pin
+    ctr = Counter(0, pin=4)
+    sleep(10)
+    print ctr.value
+
+Availability of this class: esp32.
+
+Constructors
+------------
+
+.. class:: Counter(id, ...)
+
+   Construct a Counter object for a specific hardware counter unit identified
+   by ``id``. Values 0, 1, etc. are commonly used.
+
+   With no additional parameters, the Counter object is created but the hardware is not
+   initialised (it has the settings from the last initialisation, if any).
+   If extra arguments are given, the hardware is initialised.
+   See ``init`` for parameters of initialisation.
+
+Methods
+-------
+
+.. method:: Counter.init(pin, direction=Counter.UP, edge=Counter.RISING, limit=None)
+
+   Initialise a counter by connecting it to an input pin. Optionally specify the
+   counting direction and whether the rising or falling edge should be counted.
+   Additional keyword parameters can customize the counter:
+     - ``direction``: Counter.UP, Counter,DOWN
+     - ``edge``: Counter.RISING, Counter.FALLING, Counter.BOTH
+     - ``limit``: when counting up the register is reset to zero at the next edge after
+       it reaches the limit. This means that a limit of ``N`` produces the N+1 values 0..N.
+       When counting down the register is set to the limit value at the next edge after it
+       reaches zero.
+
+   ESP32 notes:
+     - the ESP32's counter units support additional features (e.g. a control
+       pin and intermediate trigger values) but these are currently not supported.
+     - when counting down the ESP32's hardware starts at zero, counts to a negative limit, then
+       resets back to zero. This class shifts the values such that the counter counts down 
+       to zero from the limit, which is the more typical implementation on most microprocessors.
+
+.. method:: Counter.deinit()
+
+   Dissociates the counter unit from any Pin and disables any interrupt.
+
+.. method:: Counter.pause()
+
+   Disables the counter unit without changing its configuration or losing its value.
+   If the unit is already paused this is a no-op.
+
+.. method:: Counter.resume()
+
+   Resumes the counter unit after a pause.
+   If the unit is already running this is a no-op.
+
+.. method:: Counter.irq(trigger=Counter.ZERO, priority=1, handler=None, wake=machine.IDLE)
+
+   Configure an interrupt handler to be called when the trigger condition is met.
+   The interrupt handler is called from a hardware interrupt and may not allocate
+   memory; see :ref:`isr_rules`.
+
+   The arguments are:
+
+   - ``trigger``: the condition that triggers an interrupt.
+     ``Counter.ZERO``: when the counter reaches or is reset to zero.
+     ``Counter.LIMIT``: when the counter reaches or is reset to the limit value.
+     These values can be OR’ed together to trigger on multiple events.
+   - ``priority``: the priority level of the interrupt, the values are port-specific,
+     but higher values always represent higher priorities.
+   - ``handler``: the function to be called when the interrupt triggers. The handler
+     must take exactly one argument which is the Counter instance.
+   - ``wake``: selects the power mode in which this interrupt can wake up the system.
+     It can be machine.IDLE, machine.SLEEP or machine.DEEPSLEEP.
+     These values can also be OR’ed together to make a pin generate interrupts in more
+     than one power mode.
+
+   ESP32 notes:
+   - Supported triggers are ZERO and LIMIT.
+   - The priority is ignored (**verify**).
+   - For wake only machine.IDLE is supported.
+   - The counter unit samples the input at the APB clock frequency, which is 80Mhz or 12.5ns,
+     this places a lower bound on the width of pulses that can reliably be detected.
+     (If variable frequency is enabled for low power operation using machine.freq then
+     the APB clock may be as low as set with that method's min_freq parameter.)
+
+   This method returns a callback object.
+
+Properties
+----------
+
+.. property:: Counter.value
+
+   The current value of the counter can be read and written using this property.
+
+.. property:: Counter.direction
+
+   The counting direction can be changed using this property.
+
+.. property:: Counter.limit
+
+   The limit to which the counter counts up or from which it counts down.
+
+Constants
+---------
+
+.. data:: Counter.UP
+          Counter.DOWN
+
+   Selects the counting direction.
+
+.. data:: Counter.RISING
+          Counter.FALLING
+          Counter.BOTH
+
+   Selects the input pin transition/edge that is counted.
+
+.. data:: Counter.ZERO
+          Counter.LIMIT
+
+   Selects the state that causes an interrupt, see the description of the Counter.irq method.

--- a/ports/esp32/Makefile
+++ b/ports/esp32/Makefile
@@ -314,6 +314,7 @@ SRC_C = \
 	machine_dac.c \
 	machine_i2c.c \
 	machine_pwm.c \
+	machine_counter.c \
 	machine_uart.c \
 	modmachine.c \
 	modnetwork.c \

--- a/ports/esp32/machine_counter.c
+++ b/ports/esp32/machine_counter.c
@@ -1,0 +1,284 @@
+/*
+ * This file is part of the Micro Python project, http://micropython.org/
+ *
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2020 Thorsten von Eicken
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+#include <stdio.h>
+#include "driver/pcnt.h"
+#include "esp_err.h"
+
+#include "py/nlr.h"
+#include "py/runtime.h"
+#include "modmachine.h"
+#include "mphalport.h"
+
+// Forward dec'l
+extern const mp_obj_type_t machine_counter_type;
+
+typedef struct _esp32_counter_obj_t {
+    mp_obj_base_t base;
+    gpio_num_t pin;
+    uint8_t active;  // object refers to an init'ed and not deinit'ed counter
+    uint8_t running; // running = !paused
+    uint8_t unit;
+    uint8_t dir_up;  // true=up, false=down
+    uint8_t edges;   // 1=rising, 2=falling, 3=both
+    uint16_t limit;  // logical limit (negated for down-counting)
+} esp32_counter_obj_t;
+
+// Which unit/(channel) has which GPIO pin assigned?
+// (-1 if not assigned)
+STATIC gpio_num_t unit_gpio[PCNT_UNIT_MAX];
+
+#define DIR_UP       (PCNT_COUNT_INC)
+#define DIR_DOWN     (PCNT_COUNT_DEC)
+#define EDGE_RISING  (1)
+#define EDGE_FALLING (2)
+#define EDGE_BOTH    (3)
+#define TRIG_ZERO    (1)
+#define TRIG_LIMIT   (2)
+
+/******************************************************************************/
+
+// MicroPython bindings for COUNTER
+
+STATIC void esp32_counter_print(const mp_print_t *print, mp_obj_t self_in, mp_print_kind_t kind) {
+    esp32_counter_obj_t *self = MP_OBJ_TO_PTR(self_in);
+    mp_printf(print, "COUNTER(%u", self->pin);
+    if (self->active) {
+        int16_t v = 12345;
+        pcnt_get_counter_value(self->unit, &v);
+        if (!self->dir_up) v += self->limit; // adjust to limit..0 interval
+        mp_printf(print, ", %s, value=%u, limit=%u", self->running ? "running" : "paused",
+                (uint16_t)v, self->limit);
+        static char *(edges[]) = {"??", "rising", "falling", "both"};
+        mp_printf(print, ", dir=%s, edge=%s, unit=%d", self->dir_up ? "up":"down",
+                edges[self->edges], self->unit);
+
+    } else {
+        mp_printf(print, ", deinitialized");
+    }
+    mp_printf(print, ")");
+}
+
+STATIC void esp32_counter_init_helper(esp32_counter_obj_t *self,
+        size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
+    enum { ARG_direction, ARG_edge, ARG_limit, ARG_reset };
+    static const mp_arg_t allowed_args[] = {
+        { MP_QSTR_direction, MP_ARG_INT, {.u_int = DIR_UP} },
+        { MP_QSTR_edge, MP_ARG_INT, {.u_int = EDGE_RISING} },
+        { MP_QSTR_limit, MP_ARG_INT, {.u_int = 0} },
+        { MP_QSTR_reset, MP_ARG_BOOL, {.u_bool = 1} },
+    };
+    mp_arg_val_t args[MP_ARRAY_SIZE(allowed_args)];
+    mp_arg_parse_all(n_args, pos_args, kw_args,
+        MP_ARRAY_SIZE(allowed_args), allowed_args, args);
+
+    // Find a free COUNTER unit, also spot if our pin is already mentioned.
+    int unit = 0;
+    int avail = -1;
+    while (unit < PCNT_UNIT_MAX) {
+        if (unit_gpio[unit] == self->pin) { break; }
+        if ((avail == -1) && (unit_gpio[unit] == -1)) { avail = unit; }
+        unit++;
+    }
+    if (unit >= PCNT_UNIT_MAX) {
+        if (avail == -1) { mp_raise_ValueError("out of COUNTER units"); }
+        unit = avail;
+    }
+    self->unit = unit;
+
+    // config counter unit
+    self->active = 1;
+    self->running = 1;
+    pcnt_config_t cfg = {
+        .unit = unit,
+        .channel = 0,
+        .pulse_gpio_num = self->pin,
+        .ctrl_gpio_num = -1, // not yet supported
+        .counter_h_lim = 0,
+        .counter_l_lim = 0,
+        .pos_mode = PCNT_COUNT_DIS, // positive edge is no-op
+        .neg_mode = PCNT_COUNT_DIS, // negative edge is no-op
+        .lctrl_mode = PCNT_MODE_KEEP, // ctrl pin is no-op
+        .hctrl_mode = PCNT_MODE_KEEP, // ctrl pin is no-op
+    };
+    // figure direction and edges
+    self->dir_up = args[ARG_direction].u_int == PCNT_COUNT_INC;
+    self->edges = args[ARG_edge].u_int & EDGE_BOTH;
+    pcnt_count_mode_t mode = self->dir_up ? PCNT_COUNT_INC : PCNT_COUNT_DEC;
+    if (args[ARG_edge].u_int & EDGE_RISING) { cfg.pos_mode = mode; }
+    if (args[ARG_edge].u_int & EDGE_FALLING) { cfg.neg_mode = mode; }
+    // limit up or down
+    self->limit = args[ARG_limit].u_int;
+    if (self->limit == 0) self->limit = 0x7fff;
+    if (self->dir_up) { cfg.counter_h_lim = self->limit; }
+    else { cfg.counter_l_lim = -self->limit; }
+
+    //printf("Counter dir_up=%d edges=%d limit=%d\n", self->dir_up, self->edges, self->limit);
+    if (pcnt_unit_config(&cfg) != ESP_OK) {
+        nlr_raise(mp_obj_new_exception_msg_varg(&mp_type_ValueError,
+            "Counter not supported on pin %d", self->pin));
+    }
+    pcnt_counter_resume(unit); // apparently it starts paused...
+    unit_gpio[unit] = self->pin;
+
+    if (args[ARG_reset].u_bool) pcnt_counter_clear(self->unit);
+}
+
+STATIC bool counter_inited = false;
+
+STATIC mp_obj_t esp32_counter_make_new(const mp_obj_type_t *type,
+        size_t n_args, size_t n_kw, const mp_obj_t *args) {
+    mp_arg_check_num(n_args, n_kw, 1, MP_OBJ_FUN_ARGS_MAX, true);
+    gpio_num_t pin_id = machine_pin_get_id(args[0]);
+
+    // create counter object from the given pin
+    esp32_counter_obj_t *self = m_new_obj(esp32_counter_obj_t);
+    self->base.type = &machine_counter_type;
+    self->pin = pin_id;
+    self->active = 0;
+    self->unit = -1;
+
+    // start the counter subsystem if it's not already running
+    if (!counter_inited) {
+        // Initial condition: no units assigned
+        for (int x = 0; x < PCNT_UNIT_MAX; ++x) {
+            unit_gpio[x] = -1;
+        }
+        counter_inited = true;
+    }
+
+    // perform init with any keyword args
+    mp_map_t kw_args;
+    mp_map_init_fixed_table(&kw_args, n_kw, args + n_args);
+    esp32_counter_init_helper(self, n_args - 1, args + 1, &kw_args);
+
+    return MP_OBJ_FROM_PTR(self);
+}
+
+STATIC mp_obj_t esp32_counter_init(size_t n_args,
+        const mp_obj_t *args, mp_map_t *kw_args) {
+    esp32_counter_init_helper(args[0], n_args - 1, args + 1, kw_args);
+    return mp_const_none;
+}
+MP_DEFINE_CONST_FUN_OBJ_KW(esp32_counter_init_obj, 1, esp32_counter_init);
+
+STATIC mp_obj_t esp32_counter_deinit(mp_obj_t self_in) {
+    esp32_counter_obj_t *self = MP_OBJ_TO_PTR(self_in);
+    int unit = self->unit;
+
+    // Valid unit?
+    if ((unit >= 0) && (unit < PCNT_UNIT_MAX)) {
+        // Mark it unused, and tell the hardware to stop
+        unit_gpio[unit] = -1;
+        pcnt_counter_pause(self->unit);
+        pcnt_intr_disable(self->unit);
+        self->active = 0;
+        self->unit = -1;
+        //gpio_matrix_out(self->pin, SIG_GPIO_OUT_IDX, false, false); // is this needed???
+    }
+    return mp_const_none;
+}
+STATIC MP_DEFINE_CONST_FUN_OBJ_1(esp32_counter_deinit_obj, esp32_counter_deinit);
+
+STATIC mp_obj_t esp32_counter_pause(mp_obj_t arg0) {
+    esp32_counter_obj_t *self = MP_OBJ_TO_PTR(arg0);
+    if (self->active) {
+        pcnt_counter_pause(self->unit);
+    } else {
+        nlr_raise(mp_obj_new_exception_msg_varg(&mp_type_ValueError, "Unit inactive"));
+    }
+    return mp_const_none;
+}
+STATIC MP_DEFINE_CONST_FUN_OBJ_1(esp32_counter_pause_obj, esp32_counter_pause);
+
+STATIC mp_obj_t esp32_counter_resume(mp_obj_t arg0) {
+    esp32_counter_obj_t *self = MP_OBJ_TO_PTR(arg0);
+    if (self->active) {
+        pcnt_counter_resume(self->unit);
+    } else {
+        nlr_raise(mp_obj_new_exception_msg_varg(&mp_type_ValueError, "Unit inactive"));
+    }
+    return mp_const_none;
+}
+STATIC MP_DEFINE_CONST_FUN_OBJ_1(esp32_counter_resume_obj, esp32_counter_resume);
+
+STATIC mp_obj_t esp32_counter_value(size_t n_args, const mp_obj_t *args) {
+    esp32_counter_obj_t *self = MP_OBJ_TO_PTR(args[0]);
+    if (!self->active) {
+        nlr_raise(mp_obj_new_exception_msg_varg(&mp_type_ValueError, "Unit inactive"));
+        return mp_const_none;
+    }
+    if (n_args == 1) {
+        // get
+        int16_t v = 12345;
+        pcnt_get_counter_value(self->unit, &v);
+        if (!self->dir_up) v += self->limit; // adjust to limit..0 interval
+        return MP_OBJ_NEW_SMALL_INT((uint16_t)v);
+    }
+
+    // set
+    int tval = mp_obj_get_int(args[1]);
+    if (self->dir_up && tval != 0) {
+        nlr_raise(mp_obj_new_exception_msg_varg(&mp_type_ValueError,
+                    "Can only set value to zero"));
+    } else if (!self->dir_up && tval != self->limit) {
+        nlr_raise(mp_obj_new_exception_msg_varg(&mp_type_ValueError,
+                    "Can only set value to limit (%u)", self->limit));
+    } else {
+        pcnt_counter_clear(self->unit);
+    }
+    return mp_const_none;
+}
+STATIC MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(esp32_counter_value_obj, 1, 2, esp32_counter_value);
+
+STATIC const mp_rom_map_elem_t esp32_counter_locals_dict_table[] = {
+    { MP_ROM_QSTR(MP_QSTR_init), MP_ROM_PTR(&esp32_counter_init_obj) },
+    { MP_ROM_QSTR(MP_QSTR_deinit), MP_ROM_PTR(&esp32_counter_deinit_obj) },
+    { MP_ROM_QSTR(MP_QSTR_value), MP_ROM_PTR(&esp32_counter_value_obj) },
+    { MP_ROM_QSTR(MP_QSTR_pause), MP_ROM_PTR(&esp32_counter_pause_obj) },
+    { MP_ROM_QSTR(MP_QSTR_resume), MP_ROM_PTR(&esp32_counter_resume_obj) },
+#if 0
+    { MP_ROM_QSTR(MP_QSTR_irq), MP_ROM_PTR(&esp32_counter_irq_obj) },
+#endif
+    // class constants
+    { MP_ROM_QSTR(MP_QSTR_UP), MP_ROM_INT(PCNT_COUNT_INC) },
+    { MP_ROM_QSTR(MP_QSTR_DOWN), MP_ROM_INT(PCNT_COUNT_DEC) },
+    { MP_ROM_QSTR(MP_QSTR_RISING), MP_ROM_INT(EDGE_RISING) },
+    { MP_ROM_QSTR(MP_QSTR_FALLING), MP_ROM_INT(EDGE_FALLING) },
+    { MP_ROM_QSTR(MP_QSTR_BOTH), MP_ROM_INT(EDGE_BOTH) },
+    { MP_ROM_QSTR(MP_QSTR_ZERO), MP_ROM_INT(TRIG_ZERO) },
+    { MP_ROM_QSTR(MP_QSTR_LIMIT), MP_ROM_INT(TRIG_LIMIT) },
+};
+
+STATIC MP_DEFINE_CONST_DICT(esp32_counter_locals_dict,
+    esp32_counter_locals_dict_table);
+
+const mp_obj_type_t machine_counter_type = {
+    { &mp_type_type },
+    .name = MP_QSTR_COUNTER,
+    .print = esp32_counter_print,
+    .make_new = esp32_counter_make_new,
+    .locals_dict = (mp_obj_dict_t*)&esp32_counter_locals_dict,
+};

--- a/ports/esp32/machine_pin.c
+++ b/ports/esp32/machine_pin.c
@@ -124,12 +124,21 @@ STATIC void machine_pin_isr_handler(void *arg) {
     mp_hal_wake_main_task_from_isr();
 }
 
+// return the pin number given a pin number int, a string with the number, or
+// a Pin object
 gpio_num_t machine_pin_get_id(mp_obj_t pin_in) {
-    if (mp_obj_get_type(pin_in) != &machine_pin_type) {
-        mp_raise_ValueError("expecting a pin");
+    if (MP_OBJ_IS_SMALL_INT(pin_in)) {
+        return MP_OBJ_SMALL_INT_VALUE(pin_in);
+    } else if (MP_OBJ_IS_STR(pin_in)) {
+        mp_raise_ValueError("named pins not yet supported");
+        return -1;
+    } else if (mp_obj_get_type(pin_in) == &machine_pin_type) {
+        machine_pin_obj_t *pin_obj = pin_in;
+        return pin_obj->id;
+    } else {
+        mp_raise_ValueError("expecting a pin number, string, or object");
+        return -1;
     }
-    machine_pin_obj_t *self = pin_in;
-    return self->id;
 }
 
 STATIC void machine_pin_print(const mp_print_t *print, mp_obj_t self_in, mp_print_kind_t kind) {

--- a/ports/esp32/modmachine.c
+++ b/ports/esp32/modmachine.c
@@ -255,6 +255,7 @@ STATIC const mp_rom_map_elem_t machine_module_globals_table[] = {
     { MP_ROM_QSTR(MP_QSTR_DAC), MP_ROM_PTR(&machine_dac_type) },
     { MP_ROM_QSTR(MP_QSTR_I2C), MP_ROM_PTR(&machine_i2c_type) },
     { MP_ROM_QSTR(MP_QSTR_PWM), MP_ROM_PTR(&machine_pwm_type) },
+    { MP_ROM_QSTR(MP_QSTR_Counter), MP_ROM_PTR(&machine_counter_type) },
     { MP_ROM_QSTR(MP_QSTR_RTC), MP_ROM_PTR(&machine_rtc_type) },
     { MP_ROM_QSTR(MP_QSTR_SPI), MP_ROM_PTR(&mp_machine_soft_spi_type) },
     { MP_ROM_QSTR(MP_QSTR_UART), MP_ROM_PTR(&machine_uart_type) },

--- a/ports/esp32/modmachine.h
+++ b/ports/esp32/modmachine.h
@@ -16,6 +16,7 @@ extern const mp_obj_type_t machine_touchpad_type;
 extern const mp_obj_type_t machine_adc_type;
 extern const mp_obj_type_t machine_dac_type;
 extern const mp_obj_type_t machine_pwm_type;
+extern const mp_obj_type_t machine_counter_type;
 extern const mp_obj_type_t machine_hw_spi_type;
 extern const mp_obj_type_t machine_uart_type;
 extern const mp_obj_type_t machine_rtc_type;

--- a/tests/esp32/counter.py
+++ b/tests/esp32/counter.py
@@ -1,0 +1,118 @@
+'''
+machine.Counter tests.
+'''
+
+from machine import Counter, PWM, Pin
+from time import sleep_ms
+import os
+
+mch = os.uname().machine
+if 'ESP32' in mch:
+    ctr_pin = 21
+    ctr2_pin = 23
+    pwm_pin = 22
+else:
+    raise Exception('Board "' + mch + '" not supported!')
+
+ctr = Counter(ctr_pin)
+print(ctr)
+ctr.deinit()
+print(ctr)
+ctr.init()
+print(ctr)
+ctr.deinit()
+print(ctr)
+
+print("Test with String")
+try:
+    ctr = Counter(str(ctr_pin))
+except ValueError:
+    print("Exception")
+
+print("Test with Pin")
+ctr = Counter(Pin(ctr_pin), limit=100)
+print(ctr)
+
+pwm = PWM(pwm_pin, freq=100, duty=50)
+print(pwm)
+
+sleep_ms(150)
+print(ctr, ctr.value())
+sleep_ms(800)
+print(ctr, ctr.value())
+sleep_ms(100)
+print(ctr, ctr.value())
+ctr.value(0)
+print(ctr, ctr.value())
+sleep_ms(100)
+print(ctr, ctr.value())
+try:
+    ctr.value(100)
+except ValueError:
+    print("Exception")
+ctr.pause()
+print(ctr, ctr.value())
+sleep_ms(100)
+print(ctr, ctr.value())
+ctr.resume()
+sleep_ms(200)
+print(ctr, ctr.value())
+ctr.deinit()
+ctr = Counter(Pin(ctr_pin), limit=200, reset=False)
+print(ctr, ctr.value())
+sleep_ms(100)
+print(ctr, ctr.value())
+
+print("Test decr")
+ctr2 = Counter(ctr2_pin)
+print(ctr2, ctr2.value())
+sleep_ms(5)
+ctr = Counter(Pin(ctr_pin), limit=100, direction=Counter.DOWN, edge=Counter.BOTH)
+print(ctr, ctr.value())
+
+sleep_ms(150)
+print(ctr, ctr.value())
+sleep_ms(800)
+print(ctr, ctr.value())
+sleep_ms(100)
+print(ctr, ctr.value())
+ctr.value(100)
+print(ctr, ctr.value())
+sleep_ms(100)
+print(ctr, ctr.value())
+try:
+    ctr.value(0)
+except ValueError:
+    print("Exception")
+ctr.deinit()
+
+
+
+
+"""
+
+sd = SD(0, pins=sd_pins)
+sd = SD(id=0, pins=sd_pins)
+sd = SD(0, sd_pins)
+
+# check for memory leaks
+for i in range(0, 1000):
+    sd = sd = SD(0, pins=sd_pins)
+
+# next ones should raise
+try:
+    sd = SD(pins=())
+except Exception:
+    print("Exception")
+
+try:
+    sd = SD(pins=('GP10', 'GP11', 'GP8'))
+except Exception:
+    print("Exception")
+
+try:
+    sd = SD(pins=('GP10', 'GP11'))
+except Exception:
+    print("Exception")
+
+"""

--- a/tests/esp32/counter.py.exp
+++ b/tests/esp32/counter.py.exp
@@ -1,0 +1,29 @@
+COUNTER(21, running, value=0, limit=32767, dir=up, edge=rising, unit=0)
+COUNTER(21, deinitialized)
+COUNTER(21, running, value=0, limit=32767, dir=up, edge=rising, unit=0)
+COUNTER(21, deinitialized)
+Test with String
+Exception
+Test with Pin
+COUNTER(21, running, value=0, limit=100, dir=up, edge=rising, unit=0)
+PWM(22, freq=100, duty=50)
+COUNTER(21, running, value=16, limit=100, dir=up, edge=rising, unit=0) 16
+COUNTER(21, running, value=96, limit=100, dir=up, edge=rising, unit=0) 96
+COUNTER(21, running, value=6, limit=100, dir=up, edge=rising, unit=0) 6
+COUNTER(21, running, value=0, limit=100, dir=up, edge=rising, unit=0) 0
+COUNTER(21, running, value=10, limit=100, dir=up, edge=rising, unit=0) 10
+Exception
+COUNTER(21, running, value=10, limit=100, dir=up, edge=rising, unit=0) 10
+COUNTER(21, running, value=10, limit=100, dir=up, edge=rising, unit=0) 10
+COUNTER(21, running, value=30, limit=100, dir=up, edge=rising, unit=0) 30
+COUNTER(21, running, value=30, limit=200, dir=up, edge=rising, unit=0) 30
+COUNTER(21, running, value=40, limit=200, dir=up, edge=rising, unit=0) 40
+Test decr
+COUNTER(23, running, value=0, limit=32767, dir=up, edge=rising, unit=1) 0
+COUNTER(21, running, value=100, limit=100, dir=down, edge=both, unit=0) 100
+COUNTER(21, running, value=70, limit=100, dir=down, edge=both, unit=0) 70
+COUNTER(21, running, value=10, limit=100, dir=down, edge=both, unit=0) 10
+COUNTER(21, running, value=90, limit=100, dir=down, edge=both, unit=0) 90
+COUNTER(21, running, value=100, limit=100, dir=down, edge=both, unit=0) 100
+COUNTER(21, running, value=78, limit=100, dir=down, edge=both, unit=0) 78
+Exception


### PR DESCRIPTION
This PR proposes the addition of a machine.Counter class that uses a timer or counter register depending on the architecture to count transitions on an input pin and to optionally generate interrupts when the counter wraps around.

Right now this PR only consists of the documentation so the design can be debated before much code gets written. (The docs can be viewed in semi-formatted state by using the view file entry of the 3-dots menu at the right of the file's diff.)