### PR TITLE
tests: Make unix time test pass on more platforms.

### DIFF
--- a/tests/unix/time.py
+++ b/tests/unix/time.py
@@ -5,7 +5,7 @@ except ImportError:
 
 DAYS_PER_MONTH = [0, 31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31]
 
-tzseconds = -time.mktime((1970, 1, 1, 0, 0, 0, 0, 0, 0))
+tzseconds = -time.mktime((1970, 1, 1, 14, 0, 0, 0, 0, 0))
 
 def is_leap(year):
     return (year % 4) == 0
@@ -22,7 +22,7 @@ def test():
             else:
                 DAYS_PER_MONTH[2] = 28
             for day in range(1, DAYS_PER_MONTH[month] + 1):
-                secs = time.mktime((year, month, day, 0, 0, 0, 0, 0, 0)) + tzseconds
+                secs = time.mktime((year, month, day, 14, 0, 0, 0, 0, 0)) + tzseconds
                 if secs != seconds:
                     print("mktime failed for %d-%02d-%02d got %d expected %d" % (year, month, day, secs, seconds))
                     return


### PR DESCRIPTION
As the mktime documentation for CPython states: "The earliest
date for which it can generate a time is platform-dependent."
In particular on Windows this depends on the timezone so e.g.
for UTC+2 the earliest is 2 hours past midnight January 1970.
So change the reference to the earliest possible, for UTC+14.