### PR TITLE
schedule user callback when receving udp packet

### DIFF
--- a/extmod/modlwip.c
+++ b/extmod/modlwip.c
@@ -400,6 +400,8 @@ STATIC void _lwip_udp_incoming(void *arg, struct udp_pcb *upcb, struct pbuf *p, 
         socket->peer_port = (mp_uint_t)port;
         memcpy(&socket->peer, addr, sizeof(socket->peer));
     }
+    // call user callback when receving packet
+    exec_user_callback(socket);
 }
 
 // Callback for general tcp errors.

--- a/extmod/modlwip.c
+++ b/extmod/modlwip.c
@@ -400,7 +400,7 @@ STATIC void _lwip_udp_incoming(void *arg, struct udp_pcb *upcb, struct pbuf *p, 
         socket->peer_port = (mp_uint_t)port;
         memcpy(&socket->peer, addr, sizeof(socket->peer));
     }
-    // call user callback when receving packet
+    // schedule user callback when receving udp packet
     exec_user_callback(socket);
 }
 


### PR DESCRIPTION
Sample for testing

import socket, struct, time
soc = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
soc.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
soc.setblocking(False)

def my_cb(s):
  msg, adr = s.recvfrom(1024)
  print('cb recv from:',adr, 'len:', len(msg))
  s, = struct.unpack("!L",msg[40:44])
  t = time.localtime(s - 36524 * 86400)
  print(t)
  soc.setsockopt(socket.SOL_SOCKET, 20, my_cb)

aa = socket.getaddrinfo('fr.pool.ntp.org', 123, socket.AF_INET)[0][-1]
print(aa)

msg = bytearray(48)
msg[0] = 27
soc.sendto(msg, aa)