### PR TITLE
py: Make mp_obj_get_type() return a const ptr to mp_obj_type_t.

### DIFF
--- a/extmod/modujson.c
+++ b/extmod/modujson.c
@@ -96,7 +96,7 @@ STATIC mp_obj_t mod_ujson_load(mp_obj_t stream_obj) {
     stack.len = 0;
     stack.items = NULL;
     mp_obj_t stack_top = MP_OBJ_NULL;
-    mp_obj_type_t *stack_top_type = NULL;
+    const mp_obj_type_t *stack_top_type = NULL;
     mp_obj_t stack_key = MP_OBJ_NULL;
     S_NEXT(s);
     for (;;) {

--- a/ports/stm32/moduos.c
+++ b/ports/stm32/moduos.c
@@ -111,7 +111,7 @@ STATIC MP_DEFINE_CONST_FUN_OBJ_1(os_urandom_obj, os_urandom);
 #endif
 
 bool mp_uos_dupterm_is_builtin_stream(mp_const_obj_t stream) {
-    mp_obj_type_t *type = mp_obj_get_type(stream);
+    const mp_obj_type_t *type = mp_obj_get_type(stream);
     return type == &pyb_uart_type
         #if MICROPY_HW_ENABLE_USB
         || type == &pyb_usb_vcp_type

--- a/ports/stm32/usb.c
+++ b/ports/stm32/usb.c
@@ -533,7 +533,7 @@ STATIC mp_obj_t pyb_usb_mode(size_t n_args, const mp_obj_t *pos_args, mp_map_t *
             mp_raise_ValueError("too many logical units");
         }
         for (size_t i = 0; i < msc_n; ++i) {
-            mp_obj_type_t *type = mp_obj_get_type(items[i]);
+            const mp_obj_type_t *type = mp_obj_get_type(items[i]);
             if (type == &pyb_flash_type
                 #if MICROPY_HW_ENABLE_SDCARD
                 || type == &pyb_sdcard_type

--- a/py/builtinhelp.c
+++ b/py/builtinhelp.c
@@ -134,7 +134,7 @@ STATIC void mp_help_print_obj(const mp_obj_t obj) {
     }
     #endif
 
-    mp_obj_type_t *type = mp_obj_get_type(obj);
+    const mp_obj_type_t *type = mp_obj_get_type(obj);
 
     // try to print something sensible about the given object
     mp_print_str(MP_PYTHON_PRINTER, "object ");

--- a/py/nativeglue.h
+++ b/py/nativeglue.h
@@ -146,7 +146,7 @@ typedef struct _mp_fun_table_t {
     NORETURN // Only certain compilers support no-return attributes in function pointer declarations
     #endif
     void (*raise_msg)(const mp_obj_type_t *exc_type, const char *msg);
-    mp_obj_type_t *(*obj_get_type)(mp_const_obj_t o_in);
+    const mp_obj_type_t *(*obj_get_type)(mp_const_obj_t o_in);
     mp_obj_t (*obj_new_str)(const char* data, size_t len);
     mp_obj_t (*obj_new_bytes)(const byte* data, size_t len);
     mp_obj_t (*obj_new_bytearray_by_ref)(size_t n, void *items);

--- a/py/obj.c
+++ b/py/obj.c
@@ -37,18 +37,18 @@
 #include "py/stackctrl.h"
 #include "py/stream.h" // for mp_obj_print
 
-mp_obj_type_t *mp_obj_get_type(mp_const_obj_t o_in) {
+const mp_obj_type_t *mp_obj_get_type(mp_const_obj_t o_in) {
     if (mp_obj_is_small_int(o_in)) {
-        return (mp_obj_type_t*)&mp_type_int;
+        return &mp_type_int;
     } else if (mp_obj_is_qstr(o_in)) {
-        return (mp_obj_type_t*)&mp_type_str;
+        return &mp_type_str;
     #if MICROPY_PY_BUILTINS_FLOAT
     } else if (mp_obj_is_float(o_in)) {
-        return (mp_obj_type_t*)&mp_type_float;
+        return &mp_type_float;
     #endif
     } else {
         const mp_obj_base_t *o = MP_OBJ_TO_PTR(o_in);
-        return (mp_obj_type_t*)o->type;
+        return o->type;
     }
 }
 
@@ -65,7 +65,7 @@ void mp_obj_print_helper(const mp_print_t *print, mp_obj_t o_in, mp_print_kind_t
         return;
     }
 #endif
-    mp_obj_type_t *type = mp_obj_get_type(o_in);
+    const mp_obj_type_t *type = mp_obj_get_type(o_in);
     if (type->print != NULL) {
         type->print((mp_print_t*)print, o_in, kind);
     } else {
@@ -119,7 +119,7 @@ bool mp_obj_is_true(mp_obj_t arg) {
             return 1;
         }
     } else {
-        mp_obj_type_t *type = mp_obj_get_type(arg);
+        const mp_obj_type_t *type = mp_obj_get_type(arg);
         if (type->unary_op != NULL) {
             mp_obj_t result = type->unary_op(MP_UNARY_OP_BOOL, arg);
             if (result != MP_OBJ_NULL) {
@@ -139,7 +139,7 @@ bool mp_obj_is_true(mp_obj_t arg) {
 }
 
 bool mp_obj_is_callable(mp_obj_t o_in) {
-    mp_call_fun_t call = mp_obj_get_type(o_in)->call;
+    const mp_call_fun_t call = mp_obj_get_type(o_in)->call;
     if (call != mp_obj_instance_call) {
         return call != NULL;
     }
@@ -209,7 +209,7 @@ bool mp_obj_equal(mp_obj_t o1, mp_obj_t o2) {
     }
 
     // generic type, call binary_op(MP_BINARY_OP_EQUAL)
-    mp_obj_type_t *type = mp_obj_get_type(o1);
+    const mp_obj_type_t *type = mp_obj_get_type(o1);
     if (type->binary_op != NULL) {
         mp_obj_t r = type->binary_op(MP_BINARY_OP_EQUAL, o1, o2);
         if (r != MP_OBJ_NULL) {
@@ -451,7 +451,7 @@ mp_obj_t mp_obj_len_maybe(mp_obj_t o_in) {
         GET_STR_LEN(o_in, l);
         return MP_OBJ_NEW_SMALL_INT(l);
     } else {
-        mp_obj_type_t *type = mp_obj_get_type(o_in);
+        const mp_obj_type_t *type = mp_obj_get_type(o_in);
         if (type->unary_op != NULL) {
             return type->unary_op(MP_UNARY_OP_LEN, o_in);
         } else {
@@ -461,7 +461,7 @@ mp_obj_t mp_obj_len_maybe(mp_obj_t o_in) {
 }
 
 mp_obj_t mp_obj_subscr(mp_obj_t base, mp_obj_t index, mp_obj_t value) {
-    mp_obj_type_t *type = mp_obj_get_type(base);
+    const mp_obj_type_t *type = mp_obj_get_type(base);
     if (type->subscr != NULL) {
         mp_obj_t ret = type->subscr(base, index, value);
         if (ret != MP_OBJ_NULL) {
@@ -506,7 +506,7 @@ mp_obj_t mp_identity_getiter(mp_obj_t self, mp_obj_iter_buf_t *iter_buf) {
 }
 
 bool mp_get_buffer(mp_obj_t obj, mp_buffer_info_t *bufinfo, mp_uint_t flags) {
-    mp_obj_type_t *type = mp_obj_get_type(obj);
+    const mp_obj_type_t *type = mp_obj_get_type(obj);
     if (type->buffer_p.get_buffer == NULL) {
         return false;
     }

--- a/py/obj.h
+++ b/py/obj.h
@@ -669,7 +669,7 @@ mp_obj_t mp_obj_new_getitem_iter(mp_obj_t *args, mp_obj_iter_buf_t *iter_buf);
 mp_obj_t mp_obj_new_module(qstr module_name);
 mp_obj_t mp_obj_new_memoryview(byte typecode, size_t nitems, void *items);
 
-mp_obj_type_t *mp_obj_get_type(mp_const_obj_t o_in);
+const mp_obj_type_t *mp_obj_get_type(mp_const_obj_t o_in);
 const char *mp_obj_get_type_str(mp_const_obj_t o_in);
 bool mp_obj_is_subclass_fast(mp_const_obj_t object, mp_const_obj_t classinfo); // arguments should be type objects
 mp_obj_t mp_instance_cast_to_native_base(mp_const_obj_t self_in, mp_const_obj_t native_type);

--- a/py/objfun.c
+++ b/py/objfun.c
@@ -455,7 +455,7 @@ STATIC mp_uint_t convert_obj_for_inline_asm(mp_obj_t obj) {
         size_t l;
         return (mp_uint_t)mp_obj_str_get_data(obj, &l);
     } else {
-        mp_obj_type_t *type = mp_obj_get_type(obj);
+        const mp_obj_type_t *type = mp_obj_get_type(obj);
 #if MICROPY_PY_BUILTINS_FLOAT
         if (type == &mp_type_float) {
             // convert float to int (could also pass in float registers)

--- a/py/objstr.c
+++ b/py/objstr.c
@@ -320,7 +320,7 @@ mp_obj_t mp_obj_str_binary_op(mp_binary_op_t op, mp_obj_t lhs_in, mp_obj_t rhs_i
     }
 
     // from now on we need lhs type and data, so extract them
-    mp_obj_type_t *lhs_type = mp_obj_get_type(lhs_in);
+    const mp_obj_type_t *lhs_type = mp_obj_get_type(lhs_in);
     GET_STR_DATA_LEN(lhs_in, lhs_data, lhs_len);
 
     // check for multiply
@@ -420,7 +420,7 @@ const byte *str_index_to_ptr(const mp_obj_type_t *type, const byte *self_data, s
 
 // This is used for both bytes and 8-bit strings. This is not used for unicode strings.
 STATIC mp_obj_t bytes_subscr(mp_obj_t self_in, mp_obj_t index, mp_obj_t value) {
-    mp_obj_type_t *type = mp_obj_get_type(self_in);
+    const mp_obj_type_t *type = mp_obj_get_type(self_in);
     GET_STR_DATA_LEN(self_in, self_data, self_len);
     if (value == MP_OBJ_SENTINEL) {
         // load
@@ -1743,7 +1743,7 @@ MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(str_count_obj, 2, 4, str_count);
 #if MICROPY_PY_BUILTINS_STR_PARTITION
 STATIC mp_obj_t str_partitioner(mp_obj_t self_in, mp_obj_t arg, int direction) {
     mp_check_self(mp_obj_is_str_or_bytes(self_in));
-    mp_obj_type_t *self_type = mp_obj_get_type(self_in);
+    const mp_obj_type_t *self_type = mp_obj_get_type(self_in);
     if (self_type != mp_obj_get_type(arg)) {
         bad_implicit_conversion(arg);
     }

--- a/py/objstrunicode.c
+++ b/py/objstrunicode.c
@@ -176,7 +176,7 @@ const byte *str_index_to_ptr(const mp_obj_type_t *type, const byte *self_data, s
 }
 
 STATIC mp_obj_t str_subscr(mp_obj_t self_in, mp_obj_t index, mp_obj_t value) {
-    mp_obj_type_t *type = mp_obj_get_type(self_in);
+    const mp_obj_type_t *type = mp_obj_get_type(self_in);
     assert(type == &mp_type_str);
     GET_STR_DATA_LEN(self_in, self_data, self_len);
     if (value == MP_OBJ_SENTINEL) {

--- a/py/objtuple.c
+++ b/py/objtuple.c
@@ -105,7 +105,7 @@ STATIC mp_obj_t mp_obj_tuple_make_new(const mp_obj_type_t *type_in, size_t n_arg
 // Don't pass MP_BINARY_OP_NOT_EQUAL here
 STATIC mp_obj_t tuple_cmp_helper(mp_uint_t op, mp_obj_t self_in, mp_obj_t another_in) {
     mp_check_self(mp_obj_is_tuple_compatible(self_in));
-    mp_obj_type_t *another_type = mp_obj_get_type(another_in);
+    const mp_obj_type_t *another_type = mp_obj_get_type(another_in);
     mp_obj_tuple_t *self = MP_OBJ_TO_PTR(self_in);
     if (another_type->getiter != mp_obj_tuple_getiter) {
         // Slow path for user subclasses

--- a/py/objtype.c
+++ b/py/objtype.c
@@ -897,7 +897,7 @@ mp_obj_t mp_obj_instance_getiter(mp_obj_t self_in, mp_obj_iter_buf_t *iter_buf) 
     if (member[0] == MP_OBJ_NULL) {
         return MP_OBJ_NULL;
     } else if (member[0] == MP_OBJ_SENTINEL) {
-        mp_obj_type_t *type = mp_obj_get_type(self->subobj[0]);
+        const mp_obj_type_t *type = mp_obj_get_type(self->subobj[0]);
         if (iter_buf == NULL) {
             iter_buf = m_new_obj(mp_obj_iter_buf_t);
         }
@@ -919,7 +919,7 @@ STATIC mp_int_t instance_get_buffer(mp_obj_t self_in, mp_buffer_info_t *bufinfo,
     };
     mp_obj_class_lookup(&lookup, self->base.type);
     if (member[0] == MP_OBJ_SENTINEL) {
-        mp_obj_type_t *type = mp_obj_get_type(self->subobj[0]);
+        const mp_obj_type_t *type = mp_obj_get_type(self->subobj[0]);
         return type->buffer_p.get_buffer(self->subobj[0], bufinfo, flags);
     } else {
         return 1; // object does not support buffer protocol
@@ -1393,7 +1393,7 @@ STATIC mp_obj_t mp_builtin_isinstance(mp_obj_t object, mp_obj_t classinfo) {
 MP_DEFINE_CONST_FUN_OBJ_2(mp_builtin_isinstance_obj, mp_builtin_isinstance);
 
 mp_obj_t mp_instance_cast_to_native_base(mp_const_obj_t self_in, mp_const_obj_t native_type) {
-    mp_obj_type_t *self_type = mp_obj_get_type(self_in);
+    const mp_obj_type_t *self_type = mp_obj_get_type(self_in);
     if (!mp_obj_is_subclass_fast(MP_OBJ_FROM_PTR(self_type), native_type)) {
         return MP_OBJ_NULL;
     }

--- a/py/opmethods.c
+++ b/py/opmethods.c
@@ -28,25 +28,25 @@
 #include "py/builtin.h"
 
 STATIC mp_obj_t op_getitem(mp_obj_t self_in, mp_obj_t key_in) {
-    mp_obj_type_t *type = mp_obj_get_type(self_in);
+    const mp_obj_type_t *type = mp_obj_get_type(self_in);
     return type->subscr(self_in, key_in, MP_OBJ_SENTINEL);
 }
 MP_DEFINE_CONST_FUN_OBJ_2(mp_op_getitem_obj, op_getitem);
 
 STATIC mp_obj_t op_setitem(mp_obj_t self_in, mp_obj_t key_in, mp_obj_t value_in) {
-    mp_obj_type_t *type = mp_obj_get_type(self_in);
+    const mp_obj_type_t *type = mp_obj_get_type(self_in);
     return type->subscr(self_in, key_in, value_in);
 }
 MP_DEFINE_CONST_FUN_OBJ_3(mp_op_setitem_obj, op_setitem);
 
 STATIC mp_obj_t op_delitem(mp_obj_t self_in, mp_obj_t key_in) {
-    mp_obj_type_t *type = mp_obj_get_type(self_in);
+    const mp_obj_type_t *type = mp_obj_get_type(self_in);
     return type->subscr(self_in, key_in, MP_OBJ_NULL);
 }
 MP_DEFINE_CONST_FUN_OBJ_2(mp_op_delitem_obj, op_delitem);
 
 STATIC mp_obj_t op_contains(mp_obj_t lhs_in, mp_obj_t rhs_in) {
-    mp_obj_type_t *type = mp_obj_get_type(lhs_in);
+    const mp_obj_type_t *type = mp_obj_get_type(lhs_in);
     return type->binary_op(MP_BINARY_OP_CONTAINS, lhs_in, rhs_in);
 }
 MP_DEFINE_CONST_FUN_OBJ_2(mp_op_contains_obj, op_contains);

--- a/py/runtime.c
+++ b/py/runtime.c
@@ -276,7 +276,7 @@ mp_obj_t mp_unary_op(mp_unary_op_t op, mp_obj_t arg) {
         }
         return MP_OBJ_NEW_SMALL_INT(h);
     } else {
-        mp_obj_type_t *type = mp_obj_get_type(arg);
+        const mp_obj_type_t *type = mp_obj_get_type(arg);
         if (type->unary_op != NULL) {
             mp_obj_t result = type->unary_op(op, arg);
             if (result != MP_OBJ_NULL) {
@@ -560,7 +560,7 @@ mp_obj_t mp_binary_op(mp_binary_op_t op, mp_obj_t lhs, mp_obj_t rhs) {
     }
 
     // generic binary_op supplied by type
-    mp_obj_type_t *type;
+    const mp_obj_type_t *type;
 generic_binary_op:
     type = mp_obj_get_type(lhs);
     if (type->binary_op != NULL) {
@@ -636,7 +636,7 @@ mp_obj_t mp_call_function_n_kw(mp_obj_t fun_in, size_t n_args, size_t n_kw, cons
     DEBUG_OP_printf("calling function %p(n_args=" UINT_FMT ", n_kw=" UINT_FMT ", args=%p)\n", fun_in, n_args, n_kw, args);
 
     // get the type
-    mp_obj_type_t *type = mp_obj_get_type(fun_in);
+    const mp_obj_type_t *type = mp_obj_get_type(fun_in);
 
     // do the call
     if (type->call != NULL) {
@@ -1067,7 +1067,7 @@ void mp_load_method_maybe(mp_obj_t obj, qstr attr, mp_obj_t *dest) {
     dest[1] = MP_OBJ_NULL;
 
     // get the type
-    mp_obj_type_t *type = mp_obj_get_type(obj);
+    const mp_obj_type_t *type = mp_obj_get_type(obj);
 
     // look for built-in names
 #if MICROPY_CPYTHON_COMPAT
@@ -1138,7 +1138,7 @@ void mp_load_method_protected(mp_obj_t obj, qstr attr, mp_obj_t *dest, bool catc
 
 void mp_store_attr(mp_obj_t base, qstr attr, mp_obj_t value) {
     DEBUG_OP_printf("store attr %p.%s <- %p\n", base, qstr_str(attr), value);
-    mp_obj_type_t *type = mp_obj_get_type(base);
+    const mp_obj_type_t *type = mp_obj_get_type(base);
     if (type->attr != NULL) {
         mp_obj_t dest[2] = {MP_OBJ_SENTINEL, value};
         type->attr(base, attr, dest);
@@ -1158,7 +1158,7 @@ void mp_store_attr(mp_obj_t base, qstr attr, mp_obj_t value) {
 
 mp_obj_t mp_getiter(mp_obj_t o_in, mp_obj_iter_buf_t *iter_buf) {
     assert(o_in);
-    mp_obj_type_t *type = mp_obj_get_type(o_in);
+    const mp_obj_type_t *type = mp_obj_get_type(o_in);
 
     // Check for native getiter which is the identity.  We handle this case explicitly
     // so we don't unnecessarily allocate any RAM for the iter_buf, which won't be used.
@@ -1203,7 +1203,7 @@ mp_obj_t mp_getiter(mp_obj_t o_in, mp_obj_iter_buf_t *iter_buf) {
 // may return MP_OBJ_STOP_ITERATION as an optimisation instead of raise StopIteration()
 // may also raise StopIteration()
 mp_obj_t mp_iternext_allow_raise(mp_obj_t o_in) {
-    mp_obj_type_t *type = mp_obj_get_type(o_in);
+    const mp_obj_type_t *type = mp_obj_get_type(o_in);
     if (type->iternext != NULL) {
         return type->iternext(o_in);
     } else {
@@ -1228,7 +1228,7 @@ mp_obj_t mp_iternext_allow_raise(mp_obj_t o_in) {
 // may raise other exceptions
 mp_obj_t mp_iternext(mp_obj_t o_in) {
     MP_STACK_CHECK(); // enumerate, filter, map and zip can recursively call mp_iternext
-    mp_obj_type_t *type = mp_obj_get_type(o_in);
+    const mp_obj_type_t *type = mp_obj_get_type(o_in);
     if (type->iternext != NULL) {
         return type->iternext(o_in);
     } else {
@@ -1263,7 +1263,7 @@ mp_obj_t mp_iternext(mp_obj_t o_in) {
 // TODO: Unclear what to do with StopIterarion exception here.
 mp_vm_return_kind_t mp_resume(mp_obj_t self_in, mp_obj_t send_value, mp_obj_t throw_value, mp_obj_t *ret_val) {
     assert((send_value != MP_OBJ_NULL) ^ (throw_value != MP_OBJ_NULL));
-    mp_obj_type_t *type = mp_obj_get_type(self_in);
+    const mp_obj_type_t *type = mp_obj_get_type(self_in);
 
     if (type == &mp_type_gen_instance) {
         return mp_obj_gen_resume(self_in, send_value, throw_value, ret_val);

--- a/py/sequence.c
+++ b/py/sequence.c
@@ -183,7 +183,7 @@ bool mp_seq_cmp_objs(mp_uint_t op, const mp_obj_t *items1, size_t len1, const mp
 
 // Special-case of index() which searches for mp_obj_t
 mp_obj_t mp_seq_index_obj(const mp_obj_t *items, size_t len, size_t n_args, const mp_obj_t *args) {
-    mp_obj_type_t *type = mp_obj_get_type(args[0]);
+    const mp_obj_type_t *type = mp_obj_get_type(args[0]);
     mp_obj_t value = args[1];
     size_t start = 0;
     size_t stop = len;

--- a/py/stream.c
+++ b/py/stream.c
@@ -85,7 +85,7 @@ mp_uint_t mp_stream_rw(mp_obj_t stream, void *buf_, mp_uint_t size, int *errcode
 }
 
 const mp_stream_p_t *mp_get_stream_raise(mp_obj_t self_in, int flags) {
-    mp_obj_type_t *type = mp_obj_get_type(self_in);
+    const mp_obj_type_t *type = mp_obj_get_type(self_in);
     const mp_stream_p_t *stream_p = type->protocol;
     if (stream_p == NULL
         || ((flags & MP_STREAM_OP_READ) && stream_p->read == NULL)


### PR DESCRIPTION
Most types are in rodata/ROM, and mp_obj_base_t.type is a constant pointer, so enforce this const-ness throughout the code base.  If a type ever needs to be modified (eg a user type) then a simple cast can be used.