### PR TITLE
Bugfix AttributeError in ESP8266 _boot.py if flash not formatted

### DIFF
--- a/ports/esp8266/modules/_boot.py
+++ b/ports/esp8266/modules/_boot.py
@@ -3,11 +3,11 @@ gc.threshold((gc.mem_free() + gc.mem_alloc()) // 4)
 import uos
 from flashbdev import bdev
 
-try:
-    if bdev:
+if bdev:
+    try:
         uos.mount(bdev, '/')
-except OSError:
-    import inisetup
-    inisetup.setup()
+    except:
+        import inisetup
+        inisetup.setup()
 
 gc.collect()


### PR DESCRIPTION
The current _boot.py for ESP8266 does `except OSError` but if flash filesystem is not formatted, this Traceback will happen:

```
  File "_boot.py", line 8, in <module>
AttributeError: 'FlashBdev' object has no attribute 'mount'
```

Also it's not needed to try the mount if `flashbdev.bdev` is None, isn't it?