### PR TITLE
py/runtime: move MICROPY_PORT_INIT_FUNC to end of mp_init()

### DIFF
--- a/py/runtime.c
+++ b/py/runtime.c
@@ -81,11 +81,6 @@ void mp_init(void) {
     MP_STATE_VM(mp_kbd_exception).args = (mp_obj_tuple_t*)&mp_const_empty_tuple_obj;
     #endif
 
-    // call port specific initialization if any
-#ifdef MICROPY_PORT_INIT_FUNC
-    MICROPY_PORT_INIT_FUNC;
-#endif
-
     #if MICROPY_ENABLE_COMPILER
     // optimization disabled by default
     MP_STATE_VM(mp_optimise_value) = 0;
@@ -140,19 +135,24 @@ void mp_init(void) {
     mp_thread_mutex_init(&MP_STATE_VM(gil_mutex));
     #endif
 
+    // call port specific initialization if any
+#ifdef MICROPY_PORT_INIT_FUNC
+    MICROPY_PORT_INIT_FUNC;
+#endif
+
     MP_THREAD_GIL_ENTER();
 }
 
 void mp_deinit(void) {
     MP_THREAD_GIL_EXIT();
 
-    //mp_obj_dict_free(&dict_main);
-    //mp_map_deinit(&MP_STATE_VM(mp_loaded_modules_map));
-
     // call port specific deinitialization if any
 #ifdef MICROPY_PORT_DEINIT_FUNC
     MICROPY_PORT_DEINIT_FUNC;
 #endif
+
+    //mp_obj_dict_free(&dict_main);
+    //mp_map_deinit(&MP_STATE_VM(mp_loaded_modules_map));
 }
 
 mp_obj_t mp_load_name(qstr qst) {


### PR DESCRIPTION
This moves the MICROPY_PORT_INIT_FUNC hook to the end of mp_init(), just before MP_THREAD_GIL_ENTER() so that everything is intialized before the hook is called.

The particular case this is trying to fix is for a MICROPY_PORT_INIT_FUNC that makes use of the GIL mutex in a background thread. The mutext must be intialized before MICROPY_PORT_INIT_FUNC is called, othwerwise we end up with a race condition where the background thread could potentially use it before it is intialized.