### PR TITLE
esp32/modmachine: add soft_reset function to esp32 and to docs

### DIFF
--- a/docs/library/machine.rst
+++ b/docs/library/machine.rst
@@ -27,6 +27,11 @@ Reset related functions
    Resets the device in a manner similar to pushing the external RESET
    button.
 
+.. function:: soft_reset()
+
+   Performs a soft reset of the interpreter trying not to reset the method by which the user is
+   connected to the MicroPython board (USB-serial, or Wifi).
+   
 .. function:: reset_cause()
 
    Get the reset cause. See :ref:`constants <machine_constants>` for the possible return values.

--- a/ports/esp32/modmachine.c
+++ b/ports/esp32/modmachine.c
@@ -46,6 +46,7 @@
 
 #include "py/obj.h"
 #include "py/runtime.h"
+#include "lib/utils/pyexec.h"
 #include "extmod/machine_mem.h"
 #include "extmod/machine_signal.h"
 #include "extmod/machine_pulse.h"
@@ -193,6 +194,12 @@ STATIC mp_obj_t machine_reset(void) {
 }
 STATIC MP_DEFINE_CONST_FUN_OBJ_0(machine_reset_obj, machine_reset);
 
+STATIC mp_obj_t machine_soft_reset(void) {
+    pyexec_system_exit = PYEXEC_FORCED_EXIT;
+    nlr_raise(mp_obj_new_exception(&mp_type_SystemExit));
+}
+STATIC MP_DEFINE_CONST_FUN_OBJ_0(machine_soft_reset_obj, machine_soft_reset);
+
 STATIC mp_obj_t machine_unique_id(void) {
     uint8_t chipid[6];
     esp_efuse_mac_get_default(chipid);
@@ -228,6 +235,7 @@ STATIC const mp_rom_map_elem_t machine_module_globals_table[] = {
 
     { MP_ROM_QSTR(MP_QSTR_freq), MP_ROM_PTR(&machine_freq_obj) },
     { MP_ROM_QSTR(MP_QSTR_reset), MP_ROM_PTR(&machine_reset_obj) },
+    { MP_ROM_QSTR(MP_QSTR_soft_reset), MP_ROM_PTR(&machine_soft_reset_obj) },
     { MP_ROM_QSTR(MP_QSTR_unique_id), MP_ROM_PTR(&machine_unique_id_obj) },
     { MP_ROM_QSTR(MP_QSTR_sleep), MP_ROM_PTR(&machine_lightsleep_obj) },
     { MP_ROM_QSTR(MP_QSTR_lightsleep), MP_ROM_PTR(&machine_lightsleep_obj) },


### PR DESCRIPTION
Adds simple mention of soft_reset to docs.
Implements soft_reset for esp32.