### PR TITLE
docs/library/uos.rst Clarify AbstractBlockDev section

### DIFF
--- a/docs/library/uos.rst
+++ b/docs/library/uos.rst
@@ -218,11 +218,19 @@ represented by VFS classes.
 Block devices
 -------------
 
-A block device is an object which implements the block protocol, which is a set
-of methods described below by the :class:`AbstractBlockDev` class.  A concrete
-implementation of this class will usually allow access to the memory-like
-functionality a piece of hardware (like flash memory).  A block device can be
-used by a particular filesystem driver to store the data for its filesystem.
+A block device is an object which implements the block protocol. This enables a
+device to support MicroPython filesystems. The physical hardware is represented
+by a user defined class. The :class:`AbstractBlockDev` class is a template for
+the design of such a class: MicroPython does not actually provide that class,
+but an actual block device class must implement the methods described below.
+
+A concrete implementation of this class will usually allow access to the
+memory-like functionality a piece of hardware (like flash memory). A block
+device can be formatted to any supported filesystem and mounted using ``uos``
+methods.
+
+See :ref:`filesystem` for example implementations of block devices using the
+two variants of the block protocol described below.
 
 .. _block-device-interface:
 
@@ -294,5 +302,7 @@ that the block device supports the extended interface.
             (*arg* is unused)
           - 6 -- erase a block, *arg* is the block number to erase
 
-See :ref:`filesystem` for example implementations of block devices using both
-protocols.
+Unless otherwise stated ``ioctl(op, arg)`` can return None. Consequently an
+implementation can ignore unused values of ``op``. As a minimum value 4 must be
+intercepted; for littlefs 6 must be intercepted and return 0. The need for
+others is hardware dependent.

--- a/docs/library/uos.rst
+++ b/docs/library/uos.rst
@@ -225,7 +225,7 @@ the design of such a class: MicroPython does not actually provide that class,
 but an actual block device class must implement the methods described below.
 
 A concrete implementation of this class will usually allow access to the
-memory-like functionality a piece of hardware (like flash memory). A block
+memory-like functionality of a piece of hardware (like flash memory). A block
 device can be formatted to any supported filesystem and mounted using ``uos``
 methods.
 
@@ -303,6 +303,6 @@ that the block device supports the extended interface.
           - 6 -- erase a block, *arg* is the block number to erase
 
 Unless otherwise stated ``ioctl(op, arg)`` can return None. Consequently an
-implementation can ignore unused values of ``op``. As a minimum value 4 must be
-intercepted; for littlefs 6 must be intercepted and return 0. The need for
-others is hardware dependent.
+implementation can ignore unused values of ``op``. As a minimum
+``ioctl(4, ...)`` must be intercepted; for littlefs ``ioctl(6, ...)`` must be
+intercepted and return 0. The need for others is hardware dependent.

--- a/docs/library/uos.rst
+++ b/docs/library/uos.rst
@@ -302,7 +302,12 @@ that the block device supports the extended interface.
             (*arg* is unused)
           - 6 -- erase a block, *arg* is the block number to erase
 
-Unless otherwise stated ``ioctl(op, arg)`` can return None. Consequently an
-implementation can ignore unused values of ``op``. As a minimum
-``ioctl(4, ...)`` must be intercepted; for littlefs ``ioctl(6, ...)`` must be
-intercepted and return 0. The need for others is hardware dependent.
+       As a minimum ``ioctl(4, ...)`` must be intercepted; for littlefs
+       ``ioctl(6, ...)`` must also be intercepted. The need for others is
+       hardware dependent.
+
+       Unless otherwise stated ``ioctl(op, arg)`` can return ``None``.
+       Consequently an implementation can ignore unused values of ``op``. Where
+       ``op`` is intercepted, the return value for operations 4 and 5 are as
+       detailed above. Other operations should return 0 on success and non-zero
+       for failure, with the value returned being an ``OSError`` errno code.


### PR DESCRIPTION
Implements the change requested in #5478 

The statement in the last para on `ioctl` op 6 is based on experiment and existing code samples. I'd like to clarify the meaning of the return value if someone can provide guidance.