### PR TITLE
py/runtime: Add MICROPY_LAZY_LOAD_GLOBAL.

### DIFF
--- a/py/mpconfig.h
+++ b/py/mpconfig.h
@@ -757,6 +757,14 @@ typedef double mp_float_t;
 #define MICROPY_CAN_OVERRIDE_BUILTINS (0)
 #endif
 
+// Allow ports to provide a lazy load function for undefined globals
+// By enabling this, MicroPython will call mp_lazy_load_global() whenever an undefined
+// global is accessed.  Ports can return a non-MP_OBJ_NULL value which will be returned instead
+// of raising NameError.  It is also cached for faster future access.
+#ifndef MICROPY_LAZY_LOAD_GLOBAL
+#define MICROPY_LAZY_LOAD_GLOBAL (0)
+#endif
+
 // Whether to check that the "self" argument of a builtin method has the
 // correct type.  Such an explicit check is only needed if a builtin
 // method escapes to Python land without a first argument, eg

--- a/py/runtime.c
+++ b/py/runtime.c
@@ -184,6 +184,14 @@ mp_obj_t mp_load_global(qstr qst) {
         #endif
         elem = mp_map_lookup((mp_map_t*)&mp_module_builtins_globals.map, MP_OBJ_NEW_QSTR(qst), MP_MAP_LOOKUP);
         if (elem == NULL) {
+            #if MICROPY_LAZY_LOAD_GLOBAL
+            mp_obj_t obj = mp_lazy_load_global(qst);
+            if (obj != MP_OBJ_NULL) {
+                // cache it for faster access next time
+                mp_store_global(qst, obj);
+                return obj;
+            }
+            #endif
             if (MICROPY_ERROR_REPORTING == MICROPY_ERROR_REPORTING_TERSE) {
                 mp_raise_msg(&mp_type_NameError, "name not defined");
             } else {

--- a/py/runtime.h
+++ b/py/runtime.h
@@ -93,6 +93,9 @@ static inline void mp_globals_set(mp_obj_dict_t *d) { MP_STATE_THREAD(dict_globa
 
 mp_obj_t mp_load_name(qstr qst);
 mp_obj_t mp_load_global(qstr qst);
+#ifdef MICROPY_LAZY_LOAD_GLOBAL
+mp_obj_t mp_lazy_load_global(qstr qst);
+#endif
 mp_obj_t mp_load_build_class(void);
 void mp_store_name(qstr qst, mp_obj_t obj);
 void mp_store_global(qstr qst, mp_obj_t obj);


### PR DESCRIPTION
Allow ports to provide a lazy load function for undefined globals.

Required for #5482 .

Continuing my explanation from the discussion in https://github.com/micropython/micropython/pull/5482#discussion_r363204762:

The rationale behind kernel symbols available as Python globals is to make kernel APIs calls as seamless as possible for the Python code.

Now, why do it lazily? I admit I didn't even try preloading them all, because I don't think it'll behave properly. First of all, since the number of symbols may be huge (e.g over 200k, depending on the kernel) it may slow down the initialization. More importantly, I assume it will induce a runtime performance hit - I don't believe MicroPython's dict lookup was ever meant to handle 200k dictionary entries. I also don't think we should fix it to handle such numbers. That's why doing it lazy makes sense - only those you need are actually loaded (and for simple scripts, you won't ever reach those huge numbers)

Also, not to mention that symbols can be added in runtime via modules, so preloading them once without any dynamic component is not an option).

Next, sliding to the discussion https://github.com/micropython/micropython/pull/5482#discussion_r363680363 about the global scope - as I said, I value typing speed and conciseness here, that's why symbols are available as mere globals.

In the kernel port I'll add a function `kernel_ffi.symbol(s: str) -> Symbol`. I'll also allow disabling the automatic global loads (as I explained here https://github.com/micropython/micropython/pull/5482#issuecomment-570621866). The `kernel_ffi.symbol` will be available in both cases. It'll also be used for symbols which are invalid Python identifiers and can't be loaded as globals either way (LTO symbols containing `.`'s, module symbols which are referenced with `modname:symname`, ...).

@stinos do you think this explanation (or part of it) fits anywhere in the code to justify this patch?