### PR TITLE
stm32: add generic pairing heap implementation, and use it for the soft timer

### DIFF
--- a/ports/stm32/machine_timer.c
+++ b/ports/stm32/machine_timer.c
@@ -77,7 +77,7 @@ STATIC mp_obj_t machine_timer_init_helper(machine_timer_obj_t *self, size_t n_ar
 
 STATIC mp_obj_t machine_timer_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *args) {
     machine_timer_obj_t *self = m_new_obj(machine_timer_obj_t);
-    self->base.type = &machine_timer_type;
+    self->pairheap.base.type = &machine_timer_type;
 
     // Get timer id (only soft timer (-1) supported at the moment)
     mp_int_t id = -1;

--- a/ports/stm32/mpconfigport.h
+++ b/ports/stm32/mpconfigport.h
@@ -281,7 +281,7 @@ struct _mp_bluetooth_nimble_root_pointers_t;
     \
     mp_obj_t pyb_extint_callback[PYB_EXTI_NUM_VECTORS]; \
     \
-    struct _soft_timer_entry_t *soft_timer_head; \
+    struct _soft_timer_entry_t *soft_timer_heap; \
     \
     /* pointers to all Timer objects (if they have been created) */ \
     struct _pyb_timer_obj_t *pyb_timer_obj_all[MICROPY_HW_MAX_TIMER]; \

--- a/ports/stm32/softtimer.c
+++ b/ports/stm32/softtimer.c
@@ -37,7 +37,13 @@ extern __IO uint32_t uwTick;
 volatile uint32_t soft_timer_next;
 
 void soft_timer_deinit(void) {
-    MP_STATE_PORT(soft_timer_head) = NULL;
+    MP_STATE_PORT(soft_timer_heap) = NULL;
+}
+
+STATIC int soft_timer_lt(mp_pairheap_t *n1, mp_pairheap_t *n2) {
+    soft_timer_entry_t *e1 = (soft_timer_entry_t*)n1;
+    soft_timer_entry_t *e2 = (soft_timer_entry_t*)n2;
+    return TICKS_DIFF(e1->expiry_ms, e2->expiry_ms) < 0;
 }
 
 STATIC void soft_timer_schedule_systick(uint32_t ticks_ms) {
@@ -54,59 +60,38 @@ STATIC void soft_timer_schedule_systick(uint32_t ticks_ms) {
 // Must be executed at IRQ_PRI_PENDSV
 void soft_timer_handler(void) {
     uint32_t ticks_ms = uwTick;
-    soft_timer_entry_t *head = MP_STATE_PORT(soft_timer_head);
-    while (head != NULL && TICKS_DIFF(head->expiry_ms, ticks_ms) <= 0) {
-        mp_sched_schedule(head->callback, MP_OBJ_FROM_PTR(head));
-        if (head->mode == SOFT_TIMER_MODE_PERIODIC) {
-            head->expiry_ms += head->delta_ms;
-            // Shift this node along to its new position
-            soft_timer_entry_t *cur = head;
-            while (cur->next != NULL && TICKS_DIFF(head->expiry_ms, cur->next->expiry_ms) >= 0) {
-                cur = cur->next;
-            }
-            if (cur != head) {
-                soft_timer_entry_t *next = head->next;
-                head->next = cur->next;
-                cur->next = head;
-                head = next;
-            }
-        } else {
-            head = head->next;
+    soft_timer_entry_t *heap = MP_STATE_PORT(soft_timer_heap);
+    while (heap != NULL && TICKS_DIFF(heap->expiry_ms, ticks_ms) <= 0) {
+        soft_timer_entry_t *entry = heap;
+        heap = (soft_timer_entry_t*)mp_pairheap_pop(soft_timer_lt, &heap->pairheap);
+        mp_sched_schedule(entry->callback, MP_OBJ_FROM_PTR(entry));
+        if (entry->mode == SOFT_TIMER_MODE_PERIODIC) {
+            entry->expiry_ms += entry->delta_ms;
+            heap = (soft_timer_entry_t*)mp_pairheap_push(soft_timer_lt, &heap->pairheap, &entry->pairheap);
         }
     }
-    MP_STATE_PORT(soft_timer_head) = head;
-    if (head == NULL) {
+    MP_STATE_PORT(soft_timer_heap) = heap;
+    if (heap == NULL) {
         // No more timers left, set largest delay possible
         soft_timer_next = uwTick;
     } else {
         // Set soft_timer_next so SysTick calls us back at the correct time
-        soft_timer_schedule_systick(head->expiry_ms);
+        soft_timer_schedule_systick(heap->expiry_ms);
     }
 }
 
 void soft_timer_insert(soft_timer_entry_t *entry) {
     uint32_t irq_state = raise_irq_pri(IRQ_PRI_PENDSV);
-    soft_timer_entry_t **head_ptr = &MP_STATE_PORT(soft_timer_head);
-    while (*head_ptr != NULL && TICKS_DIFF(entry->expiry_ms, (*head_ptr)->expiry_ms) >= 0) {
-        head_ptr = &(*head_ptr)->next;
-    }
-    entry->next = *head_ptr;
-    *head_ptr = entry;
-    if (head_ptr == &MP_STATE_PORT(soft_timer_head)) {
+    MP_STATE_PORT(soft_timer_heap) = (soft_timer_entry_t*)mp_pairheap_push(soft_timer_lt, &MP_STATE_PORT(soft_timer_heap)->pairheap, &entry->pairheap);
+    if (entry == MP_STATE_PORT(soft_timer_heap)) {
         // This new timer became the earliest one so set soft_timer_next
-        soft_timer_schedule_systick((*head_ptr)->expiry_ms);
+        soft_timer_schedule_systick(entry->expiry_ms);
     }
     restore_irq_pri(irq_state);
 }
 
 void soft_timer_remove(soft_timer_entry_t *entry) {
     uint32_t irq_state = raise_irq_pri(IRQ_PRI_PENDSV);
-    soft_timer_entry_t **cur = &MP_STATE_PORT(soft_timer_head);
-    while (*cur != NULL) {
-        if (*cur == entry) {
-            *cur = entry->next;
-            break;
-        }
-    }
+    MP_STATE_PORT(soft_timer_heap) = (soft_timer_entry_t*)mp_pairheap_delete(soft_timer_lt, &MP_STATE_PORT(soft_timer_heap)->pairheap, &entry->pairheap);
     restore_irq_pri(irq_state);
 }

--- a/ports/stm32/softtimer.h
+++ b/ports/stm32/softtimer.h
@@ -26,14 +26,13 @@
 #ifndef MICROPY_INCLUDED_STM32_SOFTTIMER_H
 #define MICROPY_INCLUDED_STM32_SOFTTIMER_H
 
-#include "py/obj.h"
+#include "py/pairheap.h"
 
 #define SOFT_TIMER_MODE_ONE_SHOT (1)
 #define SOFT_TIMER_MODE_PERIODIC (2)
 
 typedef struct _soft_timer_entry_t {
-    mp_obj_base_t base; // so struct can be used as an object and still be traced by GC
-    struct _soft_timer_entry_t *next;
+    mp_pairheap_t pairheap;
     uint32_t mode;
     uint32_t expiry_ms;
     uint32_t delta_ms; // for periodic mode

--- a/py/pairheap.c
+++ b/py/pairheap.c
@@ -1,0 +1,139 @@
+/*
+ * This file is part of the MicroPython project, http://micropython.org/
+ *
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2020 Damien P. George
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#include "py/pairheap.h"
+
+// The mp_pairheap_t.next pointer can take one of the following values:
+//   - NULL: the node is the top of the heap
+//   - LSB set: the node is the last of the children and points to its parent node
+//   - other: the node is a child and not the last child
+// The macros below help manage this pointer.
+#define NEXT_MAKE_RIGHTMOST_PARENT(parent) ((void*)((uintptr_t)(parent) | 1))
+#define NEXT_IS_RIGHTMOST_PARENT(next) ((uintptr_t)(next) & 1)
+#define NEXT_GET_RIGHTMOST_PARENT(next) ((void*)((uintptr_t)(next) & ~1))
+
+// O(1), stable
+mp_pairheap_t *mp_pairheap_meld(mp_pairheap_lt_t lt, mp_pairheap_t *heap1, mp_pairheap_t *heap2) {
+    if (heap1 == NULL) {
+        return heap2;
+    }
+    if (heap2 == NULL) {
+        return heap1;
+    }
+    if (lt(heap1, heap2)) {
+        if (heap1->child == NULL) {
+            heap1->child = heap2;
+        } else {
+            heap1->child_last->next = heap2;
+        }
+        heap1->child_last = heap2;
+        heap2->next = NEXT_MAKE_RIGHTMOST_PARENT(heap1);
+        return heap1;
+    } else {
+        heap1->next = heap2->child;
+        heap2->child = heap1;
+        if (heap1->next == NULL) {
+            heap2->child_last = heap1;
+            heap1->next = NEXT_MAKE_RIGHTMOST_PARENT(heap2);
+        }
+        return heap2;
+    }
+}
+
+// amortised O(log N), stable
+mp_pairheap_t *mp_pairheap_pairing(mp_pairheap_lt_t lt, mp_pairheap_t *child) {
+    if (child == NULL) {
+        return NULL;
+    }
+    mp_pairheap_t *heap = NULL;
+    while (!NEXT_IS_RIGHTMOST_PARENT(child)) {
+        mp_pairheap_t *n1 = child;
+        child = child->next;
+        if (!NEXT_IS_RIGHTMOST_PARENT(child)) {
+            mp_pairheap_t *n2 = child;
+            child = child->next;
+            n1 = mp_pairheap_meld(lt, n1, n2);
+        }
+        heap = mp_pairheap_meld(lt, heap, n1);
+    }
+    heap->next = NULL;
+    return heap;
+}
+
+// amortised O(log N), stable
+mp_pairheap_t *mp_pairheap_delete(mp_pairheap_lt_t lt, mp_pairheap_t *heap, mp_pairheap_t *node) {
+    // Simple case of the top being the node to delete
+    if (node == heap) {
+        return mp_pairheap_pairing(lt, heap->child);
+    }
+
+    // Case where node is not in the heap
+    if (node->next == NULL) {
+        return heap;
+    }
+
+    // Find parent of node
+    mp_pairheap_t *parent = node;
+    while (!NEXT_IS_RIGHTMOST_PARENT(parent->next)) {
+        parent = parent->next;
+    }
+    parent = NEXT_GET_RIGHTMOST_PARENT(parent->next);
+
+    // Replace node with pairing of its children
+    mp_pairheap_t *next;
+    if (node == parent->child && node->child == NULL) {
+        if (NEXT_IS_RIGHTMOST_PARENT(node->next)) {
+            parent->child = NULL;
+        } else {
+            parent->child = node->next;
+        }
+        node->next = NULL;
+        return heap;
+    } else if (node == parent->child) {
+        next = node->next;
+        node->next = NULL;
+        node = mp_pairheap_pairing(lt, node->child);
+        parent->child = node;
+    } else {
+        mp_pairheap_t *n = parent->child;
+        while (node != n->next) {
+            n = n->next;
+        }
+        next = node->next;
+        node->next = NULL;
+        node = mp_pairheap_pairing(lt, node->child);
+        if (node == NULL) {
+            node = n;
+        } else {
+            n->next = node;
+        }
+    }
+    node->next = next;
+    if (NEXT_IS_RIGHTMOST_PARENT(next)) {
+        parent->child_last = node;
+    }
+    return heap;
+}

--- a/py/pairheap.h
+++ b/py/pairheap.h
@@ -1,0 +1,90 @@
+/*
+ * This file is part of the MicroPython project, http://micropython.org/
+ *
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2020 Damien P. George
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+#ifndef MICROPY_INCLUDED_PY_PAIRHEAP_H
+#define MICROPY_INCLUDED_PY_PAIRHEAP_H
+
+// This is an implementation of a pairing heap.  It is stable and has deletion
+// support.  Only the less-than operation needs to be defined on elements.
+//
+// See original paper for details:
+// Michael L. Fredman, Robert Sedjewick, Daniel D. Sleator, and Robert E. Tarjan.
+// The Pairing Heap: A New Form of Self-Adjusting Heap.
+// Algorithmica 1:111-129, 1986.
+// https://www.cs.cmu.edu/~sleator/papers/pairing-heaps.pdf
+
+#include "py/obj.h"
+
+// This struct forms the nodes of the heap and is intended to be extended, by
+// placing it first in another struct, to include additional information for the
+// element stored in the heap.  It includes "base" so it can be a MicroPython
+// object allocated on the heap and the GC can automatically trace all nodes by
+// following the tree structure.
+typedef struct _mp_pairheap_t {
+    mp_obj_base_t base;
+    struct _mp_pairheap_t *child;
+    struct _mp_pairheap_t *child_last;
+    struct _mp_pairheap_t *next;
+} mp_pairheap_t;
+
+// This is the function for the less-than operation on nodes/elements.
+typedef int (*mp_pairheap_lt_t)(mp_pairheap_t*, mp_pairheap_t*);
+
+// Core functions.
+mp_pairheap_t *mp_pairheap_meld(mp_pairheap_lt_t lt, mp_pairheap_t *heap1, mp_pairheap_t *heap2);
+mp_pairheap_t *mp_pairheap_pairing(mp_pairheap_lt_t lt, mp_pairheap_t *child);
+mp_pairheap_t *mp_pairheap_delete(mp_pairheap_lt_t lt, mp_pairheap_t *heap, mp_pairheap_t *node);
+
+// Create a new heap.
+static inline mp_pairheap_t *mp_pairheap_new(mp_pairheap_lt_t lt) {
+    (void)lt;
+    return NULL;
+}
+
+// Test if the heap is empty.
+static inline bool mp_pairheap_is_empty(mp_pairheap_lt_t lt, mp_pairheap_t *heap) {
+    (void)lt;
+    return heap == NULL;
+}
+
+// Peek at the top of the heap.  Will return NULL if empty.
+static inline mp_pairheap_t *mp_pairheap_peek(mp_pairheap_lt_t lt, mp_pairheap_t *heap) {
+    (void)lt;
+    return heap;
+}
+
+// Push new node onto existing heap.  Returns the new heap.
+static inline mp_pairheap_t *mp_pairheap_push(mp_pairheap_lt_t lt, mp_pairheap_t *heap, mp_pairheap_t *node) {
+    node->child = NULL;
+    node->next = NULL;
+    return mp_pairheap_meld(lt, node, heap); // node is first to be stable
+}
+
+// Pop the top off the heap, which must not be empty.  Returns the new heap.
+static inline mp_pairheap_t *mp_pairheap_pop(mp_pairheap_lt_t lt, mp_pairheap_t *heap) {
+    return mp_pairheap_pairing(lt, heap->child);
+}
+
+#endif // MICROPY_INCLUDED_PY_PAIRHEAP_H

--- a/py/py.mk
+++ b/py/py.mk
@@ -94,6 +94,7 @@ PY_CORE_O_BASENAME = $(addprefix py/,\
 	runtime_utils.o \
 	scheduler.o \
 	nativeglue.o \
+	pairheap.o \
 	ringbuf.o \
 	stackctrl.o \
 	argcheck.o \

--- a/tests/extmod/machine_timer.py
+++ b/tests/extmod/machine_timer.py
@@ -1,0 +1,37 @@
+# test machine.Timer
+
+try:
+    import utime, umachine as machine
+    machine.Timer
+except:
+    print("SKIP")
+    raise SystemExit
+
+# create and deinit
+t = machine.Timer(freq=1)
+t.deinit()
+
+# deinit again
+t.deinit()
+
+# create 2 and deinit
+t = machine.Timer(freq=1)
+t2 = machine.Timer(freq=1)
+t.deinit()
+t2.deinit()
+
+# create 2 and deinit in different order
+t = machine.Timer(freq=1)
+t2 = machine.Timer(freq=1)
+t2.deinit()
+t.deinit()
+
+# create one-shot timer with callback and wait for it to print (should be just once)
+t = machine.Timer(period=1, mode=machine.Timer.ONE_SHOT, callback=lambda t:print('one-shot'))
+utime.sleep_ms(5)
+t.deinit()
+
+# create periodic timer with callback and wait for it to print
+t = machine.Timer(period=4, mode=machine.Timer.PERIODIC, callback=lambda t:print('periodic'))
+utime.sleep_ms(14)
+t.deinit()

--- a/tests/extmod/machine_timer.py.exp
+++ b/tests/extmod/machine_timer.py.exp
@@ -1,0 +1,4 @@
+one-shot
+periodic
+periodic
+periodic

--- a/tests/unix/extra_coverage.py.exp
+++ b/tests/unix/extra_coverage.py.exp
@@ -101,6 +101,19 @@ cc99
 22ff
 -1
 -1
+# pairheap
+create: 0 0 0 0
+pop all: 0 1 2 3
+create: 7 6 5 4 3 2 1 0
+pop all: 0 1 2 3 4 5 6 7
+create: 1 - - 1 1 1 1 1 1
+pop all: 1 2
+create: 1 1 1 1 2 2
+pop all: 2 4
+create: 1 1 1 1 1
+pop all: 1 3 4
+create: 3 3 3 1 1 1
+pop all: 1 2 4 5
 0123456789 b'0123456789'
 7300
 7300


### PR DESCRIPTION
This improves the efficiency of stm32's machine.Timer (backed by a soft timer), going from an O(N) linked-list to a O(log N) pairing heap.  The pairing heap implementation is generic and can be used for other things, eg uasyncio's task queue.