### PR TITLE
py/runtime: Fix crash when an exception class __new__ does not return an exception instance.

### DIFF
--- a/py/runtime.c
+++ b/py/runtime.c
@@ -1344,8 +1344,10 @@ mp_obj_t mp_make_raise_obj(mp_obj_t o) {
         // create and return a new exception instance by calling o
         // TODO could have an option to disable traceback, then builtin exceptions (eg TypeError)
         // could have const instances in ROM which we return here instead
-        return mp_call_function_n_kw(o, 0, 0, NULL);
-    } else if (mp_obj_is_exception_instance(o)) {
+        o = mp_call_function_n_kw(o, 0, 0, NULL);
+    }
+
+    if (mp_obj_is_exception_instance(o)) {
         // o is an instance of an exception, so use it as the exception
         return o;
     } else {

--- a/tests/basics/exception_derive.py
+++ b/tests/basics/exception_derive.py
@@ -1,0 +1,30 @@
+class Dummy(BaseException):
+    pass
+
+class GoodException(BaseException):
+    def __new__(cls, *args, **kwargs):
+        print("GoodException __new__")
+        return Dummy(*args, **kwargs)
+
+class BadException(BaseException):
+    def __new__(cls, *args, **kwargs):
+        print("BadException __new__")
+        return 1
+
+try:
+    raise GoodException("good message")
+except BaseException as good:
+    print(type(good), good.args[0])
+
+try:
+    raise BadException("bad message")
+except Exception as bad:
+    # Should be TypeError 'exceptions must derive from BaseException'
+    print(type(bad), bad.args[0])
+
+try:
+    def gen(): yield
+    gen().throw(BadException)
+except Exception as genbad:
+    # Should be TypeError 'exceptions must derive from BaseException'
+    print(type(genbad), genbad.args[0])

--- a/tests/basics/exception_derive.py.exp
+++ b/tests/basics/exception_derive.py.exp
@@ -1,0 +1,6 @@
+GoodException __new__
+<class 'Dummy'> good message
+BadException __new__
+<class 'TypeError'> exceptions must derive from BaseException
+BadException __new__
+<class 'TypeError'> exceptions must derive from BaseException


### PR DESCRIPTION
See CPython bug https://bugs.python.org/issue39091 for more details.

The simplest example of the crash comes when you define `__new__` to return an int. The `mp_obj_t` for an integer value will generally look like the given integer value, left-shifted by a few bits. The VM will then try to dereference that value here: https://github.com/micropython/micropython/blob/1c849d63a86782f006b73a9d570d542cfd18538e/py/vm.c#L1424

It might also be a good safe idea to change instances of `((mp_obj_base_t*)nlr.ret_val)->type` to `mp_obj_get_type(nlr.ret_val)`, but even in that case we'd still start doing weird things once we reach https://github.com/micropython/micropython/blob/1c849d63a86782f006b73a9d570d542cfd18538e/py/vm.c#L1481 since `nlr.ret_val` wouldn't be an exception instance.

**Edit:** Updated links to vm.c code to be permalinks.