### PR TITLE
specify NTP host to use in ntptime of ESP8266

### DIFF
--- a/ports/esp8266/modules/ntptime.py
+++ b/ports/esp8266/modules/ntptime.py
@@ -10,9 +10,7 @@ except:
 # (date(2000, 1, 1) - date(1900, 1, 1)).days * 24*60*60
 NTP_DELTA = 3155673600
 
-host = "pool.ntp.org"
-
-def time():
+def time(host="pool.ntp.org"):
     NTP_QUERY = bytearray(48)
     NTP_QUERY[0] = 0x1b
     addr = socket.getaddrinfo(host, 123)[0][-1]
@@ -28,8 +26,8 @@ def time():
 
 # There's currently no timezone support in MicroPython, so
 # utime.localtime() will return UTC time (as if it was .gmtime())
-def settime():
-    t = time()
+def settime(host="pool.ntp.org"):
+    t = time(host)
     import machine
     import utime
     tm = utime.localtime(t)


### PR DESCRIPTION
The NTP host for ntptime is hardcoded wich is really not helpfull especially because a lot of ESP might be behind firewalls in private networks.