### PR TITLE
py/compile: Allow 'return' outside function in minimal builds

### DIFF
--- a/py/compile.c
+++ b/py/compile.c
@@ -1041,10 +1041,12 @@ STATIC void compile_break_cont_stmt(compiler_t *comp, mp_parse_node_struct_t *pn
 }
 
 STATIC void compile_return_stmt(compiler_t *comp, mp_parse_node_struct_t *pns) {
+    #if MICROPY_CPYTHON_COMPAT
     if (comp->scope_cur->kind != SCOPE_FUNCTION) {
         compile_syntax_error(comp, (mp_parse_node_t)pns, "'return' outside function");
         return;
     }
+    #endif
     if (MP_PARSE_NODE_IS_NULL(pns->nodes[0])) {
         // no argument to 'return', so return None
         EMIT_ARG(load_const_tok, MP_TOKEN_KW_NONE);

--- a/tests/basics/syntaxerror.py
+++ b/tests/basics/syntaxerror.py
@@ -82,7 +82,6 @@ test_syntax("break")
 test_syntax("continue")
 
 # must be in a function
-test_syntax("return")
 test_syntax("yield")
 test_syntax("nonlocal a")
 test_syntax("await 1")

--- a/tests/basics/syntaxerror_return.py
+++ b/tests/basics/syntaxerror_return.py
@@ -1,0 +1,18 @@
+# With MICROPY_CPYTHON_COMPAT, the "return" statement can only appear in a
+# function.
+# Otherwise (in minimal builds), it ends execution of a module/class.
+
+try:
+    exec
+except NameError:
+    print("SKIP")
+    raise SystemExit
+
+try:
+    exec('return; print("this should not be executed.")')
+    # if we get here then MICROPY_CPYTHON_COMPAT is disabled and test
+    # should be skipped.
+    print("SKIP")
+    raise SystemExit
+except SyntaxError:
+    print('SyntaxError')


### PR DESCRIPTION
A `return` statement on module/class level is not correct Python, but nothing terribly bad happens when it's allowed.
Removing the check should shave a few bytes off the minimal build.

This is similar to MicroPython's treatment of `import *` in functions – see https://github.com/micropython/micropython/pull/5130