### PR TITLE
ports/unix/main: add support for MICROPYINSPECT environment variable

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -12,3 +12,4 @@ MicroPython documentation and references
     esp8266/quickref.rst
     esp32/quickref.rst
     wipy/quickref.rst
+    unix/quickref.rst

--- a/docs/unix/quickref.rst
+++ b/docs/unix/quickref.rst
@@ -1,0 +1,89 @@
+.. _unix_quickref:
+
+Quick reference for the UNIX and Windows ports
+==============================================
+
+Command line options
+--------------------
+
+Usage::
+
+    micropython [ -i ] [ -O<level> ] [ -v ] [ -X <option> ] [ -c <command> | -m <module> | <script> ] [ <args> ]
+
+
+Invocation options:
+
+.. option:: -c <command>
+
+   Runs the code in ``<command>``. The code can be one or more Python statements.
+
+.. option:: -m <module>
+
+   Runs the module ``<module>``. The module must be in ``sys.path``.
+
+.. option:: <script>
+
+   Runs the file ``<script>``. The script must be a valid MicroPython source
+   code file.
+
+If none of the 3 options above are given, then MicroPython is run in an
+interactive REPL mode.
+
+
+.. option:: <args>
+
+    Any additional arguments after the module or script will be passed to
+    ``sys.argv`` (not supported with the :option:`-c` option).
+
+
+General options:
+
+.. option:: -i
+
+    Enables inspection. When this flag is set, MicroPython will enter the
+    interactive REPL mode after the command, module or script has finished.
+    This can be useful for debugging the state after an unhandled exception.
+    Also see the :envvar:`MICROPYINSPECT` environment variable.
+
+.. option:: -O | -O<level> | -OO...
+
+    Sets the optimization level. The ``O`` can be followed by a number or can
+    be repeated multiple times to indicate the level. E.g. ``-O3`` is the same
+    as ``-OOO``.
+
+.. option:: -v
+
+    Increases the verbosity level. This option can be given multiple times.
+    This option only has an effect if ``MICROPY_DEBUG_PRINTERS`` was enabled
+    when MicroPython itself was compiled.
+
+.. option:: -X <option>
+
+    Specifies additional implementation-specific options. Possible options are:
+
+    - ``-X compile-only`` compiles the command, module or script but does not
+      run it.
+    - ``-X emit={bytecode,native,viper}`` sets the default code emitter. Native
+      emitters may not be available depending on the settings when MicroPython
+      itself was compiled.
+    - ``-X heapsize=<n>[w][K|M]`` sets the heap size for the garbage collector.
+      The suffix ``w`` means words instead of bytes. ``K`` means x1024 and ``M``
+      means x1024x1024.
+
+
+
+Environment variables
+---------------------
+
+.. envvar:: MICROPYPATH
+
+    Overrides the default search path for MicroPython libraries. ``MICROPYPATH``
+    should be set to a colon separated list of directories. If ``MICROPYPATH`` is
+    not defined, the search path will be ``~/.micropython/lib:/usr/lib/micropython``
+    or the value of the ``MICROPY_PY_SYS_PATH_DEFAULT`` option if it was set
+    when MicroPython itself was compiled.
+
+.. envvar:: MICROPYINSPECT
+
+    Enables inspection. If ``MICROPYINSPECT`` is set to a non-empty string, it
+    has the same effect as setting the :option:`-i` command line option.

--- a/docs/unix/quickref.rst
+++ b/docs/unix/quickref.rst
@@ -8,7 +8,7 @@ Command line options
 
 Usage::
 
-    micropython [ -i ] [ -O<level> ] [ -v ] [ -X <option> ] [ -c <command> | -m <module> | <script> ] [ <args> ]
+    micropython [ -h ] [ -i ] [ -O<level> ] [ -v ] [ -X <option> ] [ -c <command> | -m <module> | <script> ] [ <args> ]
 
 
 Invocation options:
@@ -37,6 +37,10 @@ interactive REPL mode.
 
 
 General options:
+
+.. option:: -h
+
+    Prints a help message containing the command line usage and exits.
 
 .. option:: -i
 

--- a/ports/unix/main.c
+++ b/ports/unix/main.c
@@ -647,6 +647,10 @@ MP_NOINLINE int main_(int argc, char **argv) {
         }
     }
 
+    const char *inspect_env = getenv("MICROPYINSPECT");
+    if (inspect_env && inspect_env[0] != '\0') {
+        inspect = true;
+    }
     if (ret == NOTHING_EXECUTED || inspect) {
         if (isatty(0)) {
             prompt_read_history();

--- a/ports/unix/main.c
+++ b/ports/unix/main.c
@@ -307,7 +307,9 @@ STATIC int usage(char **argv) {
     printf(
 "usage: %s [<opts>] [-X <implopt>] [-c <command>] [<filename>]\n"
 "Options:\n"
+#if MICROPY_DEBUG_PRINTERS
 "-v : verbose (trace various operations); can be multiple\n"
+#endif
 "-O[N] : apply bytecode optimizations of level N\n"
 "\n"
 "Implementation specific options (-X):\n", argv[0]

--- a/ports/unix/main.c
+++ b/ports/unix/main.c
@@ -305,7 +305,7 @@ STATIC int do_str(const char *str) {
 
 STATIC int usage(char **argv) {
     printf(
-"usage: %s [<opts>] [-X <implopt>] [-c <command>] [<filename>]\n"
+"usage: %s [<opts>] [-X <implopt>] [-c <command> | -m <module> | <filename>]\n"
 "Options:\n"
 "-i : enable inspection via REPL after running command/module/file\n"
 #if MICROPY_DEBUG_PRINTERS

--- a/ports/unix/main.c
+++ b/ports/unix/main.c
@@ -307,6 +307,7 @@ STATIC int usage(char **argv) {
     printf(
 "usage: %s [<opts>] [-X <implopt>] [-c <command>] [<filename>]\n"
 "Options:\n"
+"-i : enable inspection via REPL after running command/module/file\n"
 #if MICROPY_DEBUG_PRINTERS
 "-v : verbose (trace various operations); can be multiple\n"
 #endif

--- a/ports/unix/modos.c
+++ b/ports/unix/modos.c
@@ -180,6 +180,41 @@ STATIC mp_obj_t mod_os_getenv(mp_obj_t var_in) {
 }
 MP_DEFINE_CONST_FUN_OBJ_1(mod_os_getenv_obj, mod_os_getenv);
 
+STATIC mp_obj_t mod_os_putenv(mp_obj_t key_in, mp_obj_t value_in) {
+    const char *key = mp_obj_str_get_str(key_in);
+    const char *value = mp_obj_str_get_str(value_in);
+    int ret;
+
+    #if _WIN32
+    ret = _putenv_s(key, value);
+    #else
+    ret = setenv(key, value, 1);
+    #endif
+
+    if (ret == -1) {
+        mp_raise_OSError(errno);
+    }
+    return mp_const_none;
+}
+MP_DEFINE_CONST_FUN_OBJ_2(mod_os_putenv_obj, mod_os_putenv);
+
+STATIC mp_obj_t mod_os_unsetenv(mp_obj_t key_in) {
+    const char *key = mp_obj_str_get_str(key_in);
+    int ret;
+
+    #if _WIN32
+    ret = _putenv_s(key, "");
+    #else
+    ret = unsetenv(key);
+    #endif
+
+    if (ret == -1) {
+        mp_raise_OSError(errno);
+    }
+    return mp_const_none;
+}
+MP_DEFINE_CONST_FUN_OBJ_1(mod_os_unsetenv_obj, mod_os_unsetenv);
+
 STATIC mp_obj_t mod_os_mkdir(mp_obj_t path_in) {
     // TODO: Accept mode param
     const char *path = mp_obj_str_get_str(path_in);
@@ -283,6 +318,8 @@ STATIC const mp_rom_map_elem_t mp_module_os_globals_table[] = {
     { MP_ROM_QSTR(MP_QSTR_rename), MP_ROM_PTR(&mod_os_rename_obj) },
     { MP_ROM_QSTR(MP_QSTR_rmdir), MP_ROM_PTR(&mod_os_rmdir_obj) },
     { MP_ROM_QSTR(MP_QSTR_getenv), MP_ROM_PTR(&mod_os_getenv_obj) },
+    { MP_ROM_QSTR(MP_QSTR_putenv), MP_ROM_PTR(&mod_os_putenv_obj) },
+    { MP_ROM_QSTR(MP_QSTR_unsetenv), MP_ROM_PTR(&mod_os_unsetenv_obj) },
     { MP_ROM_QSTR(MP_QSTR_mkdir), MP_ROM_PTR(&mod_os_mkdir_obj) },
     { MP_ROM_QSTR(MP_QSTR_ilistdir), MP_ROM_PTR(&mod_os_ilistdir_obj) },
     #if MICROPY_PY_OS_DUPTERM

--- a/ports/unix/moduos_vfs.c
+++ b/ports/unix/moduos_vfs.c
@@ -37,6 +37,8 @@
 // These are defined in modos.c
 MP_DECLARE_CONST_FUN_OBJ_VAR_BETWEEN(mod_os_errno_obj);
 MP_DECLARE_CONST_FUN_OBJ_1(mod_os_getenv_obj);
+MP_DECLARE_CONST_FUN_OBJ_1(mod_os_putenv_obj);
+MP_DECLARE_CONST_FUN_OBJ_1(mod_os_unsetenv_obj);
 MP_DECLARE_CONST_FUN_OBJ_1(mod_os_system_obj);
 
 STATIC const mp_rom_map_elem_t uos_vfs_module_globals_table[] = {
@@ -45,6 +47,8 @@ STATIC const mp_rom_map_elem_t uos_vfs_module_globals_table[] = {
 
     { MP_ROM_QSTR(MP_QSTR_errno), MP_ROM_PTR(&mod_os_errno_obj) },
     { MP_ROM_QSTR(MP_QSTR_getenv), MP_ROM_PTR(&mod_os_getenv_obj) },
+    { MP_ROM_QSTR(MP_QSTR_putenv), MP_ROM_PTR(&mod_os_putenv_obj) },
+    { MP_ROM_QSTR(MP_QSTR_unsetenv), MP_ROM_PTR(&mod_os_unsetenv_obj) },
     { MP_ROM_QSTR(MP_QSTR_system), MP_ROM_PTR(&mod_os_system_obj) },
 
     { MP_ROM_QSTR(MP_QSTR_mount), MP_ROM_PTR(&mp_vfs_mount_obj) },

--- a/tests/cmdline/repl_inspect.py
+++ b/tests/cmdline/repl_inspect.py
@@ -1,0 +1,2 @@
+# cmdline: -c print("test") -i
+# -c option combined with -i option results in REPL

--- a/tests/cmdline/repl_inspect.py.exp
+++ b/tests/cmdline/repl_inspect.py.exp
@@ -1,0 +1,6 @@
+test
+MicroPython \.\+ version
+Use \.\+
+>>> # cmdline: -c print("test") -i
+>>> # -c option combined with -i option results in REPL
+>>> 

--- a/tests/cmdline/repl_micropyinspect
+++ b/tests/cmdline/repl_micropyinspect
@@ -1,0 +1,3 @@
+import uos
+
+uos.putenv('MICROPYINSPECT', '1')

--- a/tests/cmdline/repl_micropyinspect.py
+++ b/tests/cmdline/repl_micropyinspect.py
@@ -1,0 +1,2 @@
+# cmdline: cmdline/repl_micropyinspect
+# setting MICROPYINSPECT environment variable before program exit triggers REPL

--- a/tests/cmdline/repl_micropyinspect.py.exp
+++ b/tests/cmdline/repl_micropyinspect.py.exp
@@ -1,0 +1,5 @@
+MicroPython \.\+ version
+Use \.\+
+>>> # cmdline: cmdline/repl_micropyinspect
+>>> # setting MICROPYINSPECT environment variable before program exit triggers REPL
+>>> 

--- a/tests/cpydiff/modules_os_environ.py
+++ b/tests/cpydiff/modules_os_environ.py
@@ -1,0 +1,16 @@
+"""
+categories: Modules,os
+description: ``environ`` attribute is not implemented
+cause: Unknown
+workaround: Use ``getenv``, ``putenv`` and ``unsetenv``
+"""
+import os
+try:
+    print(os.environ.get('NEW_VARIABLE'))
+    os.environ['NEW_VARIABLE'] = 'VALUE'
+    print(os.environ['NEW_VARIABLE'])
+except AttributeError:
+    print('should not get here')
+    print(os.getenv('NEW_VARIABLE'))
+    os.putenv('NEW_VARIABLE', 'VALUE')
+    print(os.getenv('NEW_VARIABLE'))

--- a/tests/cpydiff/modules_os_getenv.py
+++ b/tests/cpydiff/modules_os_getenv.py
@@ -1,0 +1,10 @@
+"""
+categories: Modules,os
+description: ``getenv`` returns actual value instead of cached value
+cause: The ``environ`` attribute is not implemented
+workaround: Unknown
+"""
+import os
+print(os.getenv('NEW_VARIABLE'))
+os.putenv('NEW_VARIABLE', 'VALUE')
+print(os.getenv('NEW_VARIABLE'))

--- a/tests/cpydiff/modules_os_getenv_argcount.py
+++ b/tests/cpydiff/modules_os_getenv_argcount.py
@@ -1,0 +1,13 @@
+"""
+categories: Modules,os
+description: ``getenv`` only allows one argument
+cause: Unknown
+workaround: Test that the return value is ``None``
+"""
+import os
+try:
+    print(os.getenv('NEW_VARIABLE', 'DEFAULT'))
+except TypeError:
+    print('should not get here')
+    # this assumes NEW_VARIABLE is never an empty variable
+    print(os.getenv('NEW_VARIABLE') or 'DEFAULT')


### PR DESCRIPTION
This adds support for a MICROPYINSPECT environment variable that works
exactly like PYTHONINSPECT.

> If this is set to a non-empty string it is equivalent to specifying the -i option.
>
> This variable can also be modified by Python code using os.environ to force inspect mode on program termination.