### PR TITLE
resolves #5125 and lets use `max_clients` kwarg when configuring AP

### DIFF
--- a/docs/esp32/quickref.rst
+++ b/docs/esp32/quickref.rst
@@ -82,6 +82,7 @@ The :mod:`network` module::
 
     ap = network.WLAN(network.AP_IF) # create access-point interface
     ap.config(essid='ESP-AP') # set the ESSID of the access point
+    ap.config(max_clients=10) # set how many clients can connect to the network
     ap.active(True)         # activate the interface
 
 A useful function for connecting to your local WiFi network is::

--- a/ports/esp32/modnetwork.c
+++ b/ports/esp32/modnetwork.c
@@ -619,7 +619,7 @@ STATIC mp_obj_t esp_config(size_t n_args, const mp_obj_t *args, mp_map_t *kwargs
                         ESP_EXCEPTIONS(tcpip_adapter_set_hostname(self->if_id, s));
                         break;
                     }
-                    case QS(MP_QSTR_max_connection): {
+                    case QS(MP_QSTR_max_clients): {
                         req_if = WIFI_IF_AP;
                         cfg.ap.max_connection = mp_obj_get_int(kwargs->table[i].value);
                         break;
@@ -696,6 +696,10 @@ STATIC mp_obj_t esp_config(size_t n_args, const mp_obj_t *args, mp_map_t *kwargs
             const char *s;
             ESP_EXCEPTIONS(tcpip_adapter_get_hostname(self->if_id, &s));
             val = mp_obj_new_str(s, strlen(s));
+            break;
+        }
+        case QS(MP_QSTR_max_clients): {
+            val = MP_OBJ_NEW_SMALL_INT(cfg.ap.max_connection);
             break;
         }
         default:

--- a/ports/esp32/modnetwork.c
+++ b/ports/esp32/modnetwork.c
@@ -619,6 +619,11 @@ STATIC mp_obj_t esp_config(size_t n_args, const mp_obj_t *args, mp_map_t *kwargs
                         ESP_EXCEPTIONS(tcpip_adapter_set_hostname(self->if_id, s));
                         break;
                     }
+                    case QS(MP_QSTR_max_connection): {
+                        req_if = WIFI_IF_AP;
+                        cfg.ap.max_connection = mp_obj_get_int(kwargs->table[i].value);
+                        break;
+                    }
                     default:
                         goto unknown;
                 }


### PR DESCRIPTION
As esp-idf provides `max_connection` field in the `wifi_ap_config_t`, I've added a case which lets use such an option when configuring AP on the ESP32.

Note that this is not dependent on `MAX_STA_COUNT` define in esp-idf's `components/wpa_supplicant/include/wpa/ap_config.h`. It is just a default value for the field and can be changed.

I have successfully tested it and managed to connect 10 clients. The 11th fails as expected. But it's still more than 4.