### PR TITLE
docs/library/machine.RTC.rst Fix example code, document datetime method.

### DIFF
--- a/docs/library/machine.RTC.rst
+++ b/docs/library/machine.RTC.rst
@@ -4,14 +4,14 @@
 class RTC -- real time clock
 ============================
 
-The RTC is and independent clock that keeps track of the date
+The RTC is an independent clock that keeps track of the date
 and time.
 
 Example usage::
 
     rtc = machine.RTC()
-    rtc.init((2014, 5, 1, 4, 13, 0, 0, 0))
-    print(rtc.now())
+    rtc.datetime((2020, 1, 21, 2, 10, 32, 36, 0))
+    print(rtc.datetime())
 
 
 Constructors
@@ -23,6 +23,20 @@ Constructors
 
 Methods
 -------
+
+.. method:: RTC.datetime([datetimetuple])
+
+   Get or set the date and time of the RTC.
+
+   With no arguments, this method returns an 8-tuple with the current
+   date and time.  With 1 argument (being an 8-tuple) it sets the date
+   and time.
+
+   The 8-tuple has the following format:
+
+       (year, month, day, weekday, hours, minutes, seconds, subseconds)
+
+   The meaning of the ``subseconds`` field is hardware dependent.
 
 .. method:: RTC.init(datetime)
 


### PR DESCRIPTION
This is the minimum change to fix the example code so it actually runs.

Unfortunately documenting the RTC class is difficult because it has been implemented differently for each platform. I checked STM, ESP8266 and ESP32. All implement `datetime`. Implementation of `init` is platform dependent: STM accepts no args. ESP8266 does not implement it while ESP32 requires a datetime tuple. Further, each platform implements a different set of methods and some documented methods are not implemented on any of these platforms: for example the `now` method.

Methods such as `calibrate` are inherently hardware dependent but where a method is implemented across platforms its calling signature should (in my view) be consistent.

There are other platforms where I don't own hardware so can't test. I'm stumped as to how properly to document this class.