### PR TITLE
py: make small optimisation to creation of exception objects

### DIFF
--- a/ports/unix/coverage.c
+++ b/ports/unix/coverage.c
@@ -387,6 +387,9 @@ STATIC mp_obj_t extra_coverage(void) {
         } else {
             mp_obj_print_exception(&mp_plat_print, MP_OBJ_FROM_PTR(nlr.ret_val));
         }
+
+        // call mp_obj_new_exception_args (it's a part of the public C API and not used in the core)
+        mp_obj_print_exception(&mp_plat_print, mp_obj_new_exception_args(&mp_type_ValueError, 0, NULL));
     }
 
     // warning

--- a/py/objexcept.c
+++ b/py/objexcept.c
@@ -304,17 +304,19 @@ MP_DEFINE_EXCEPTION(Exception, BaseException)
     */
 
 mp_obj_t mp_obj_new_exception(const mp_obj_type_t *exc_type) {
-    return mp_obj_new_exception_args(exc_type, 0, NULL);
+    assert(exc_type->make_new == mp_obj_exception_make_new);
+    return mp_obj_exception_make_new(exc_type, 0, 0, NULL);
 }
 
 // "Optimized" version for common(?) case of having 1 exception arg
 mp_obj_t mp_obj_new_exception_arg1(const mp_obj_type_t *exc_type, mp_obj_t arg) {
-    return mp_obj_new_exception_args(exc_type, 1, &arg);
+    assert(exc_type->make_new == mp_obj_exception_make_new);
+    return mp_obj_exception_make_new(exc_type, 1, 0, &arg);
 }
 
 mp_obj_t mp_obj_new_exception_args(const mp_obj_type_t *exc_type, size_t n_args, const mp_obj_t *args) {
     assert(exc_type->make_new == mp_obj_exception_make_new);
-    return exc_type->make_new(exc_type, n_args, 0, args);
+    return mp_obj_exception_make_new(exc_type, n_args, 0, args);
 }
 
 mp_obj_t mp_obj_new_exception_msg(const mp_obj_type_t *exc_type, const char *msg) {

--- a/py/objgenerator.c
+++ b/py/objgenerator.c
@@ -243,7 +243,7 @@ STATIC mp_obj_t gen_resume_and_raise(mp_obj_t self_in, mp_obj_t send_value, mp_o
             if (ret == mp_const_none || ret == MP_OBJ_STOP_ITERATION) {
                 return MP_OBJ_STOP_ITERATION;
             } else {
-                nlr_raise(mp_obj_new_exception_args(&mp_type_StopIteration, 1, &ret));
+                nlr_raise(mp_obj_new_exception_arg1(&mp_type_StopIteration, ret));
             }
 
         case MP_VM_RETURN_YIELD:

--- a/tests/unix/extra_coverage.py.exp
+++ b/tests/unix/extra_coverage.py.exp
@@ -58,6 +58,7 @@ TypeError: unsupported types for __divmod__: 'str', 'str'
 2
 OverflowError: overflow converting long int to machine word
 OverflowError: overflow converting long int to machine word
+ValueError: 
 Warning: test
 # format float
 ?


### PR DESCRIPTION
Saves about 10-70 bytes across all ports.