### PR TITLE
unix/Makefile: Reserve CFLAGS_EXTRA/LDFLAGS_EXTRA for external use.

### DIFF
--- a/ports/unix/Makefile
+++ b/ports/unix/Makefile
@@ -40,7 +40,7 @@ INC += -I$(BUILD)
 # compiler settings
 CWARN = -Wall -Werror
 CWARN += -Wpointer-arith -Wuninitialized
-CFLAGS = $(INC) $(CWARN) -std=gnu99 -DUNIX $(CFLAGS_MOD) $(COPT) -I$(VARIANT_DIR) $(CFLAGS_EXTRA)
+CFLAGS += $(INC) $(CWARN) -std=gnu99 -DUNIX $(CFLAGS_MOD) $(COPT) -I$(VARIANT_DIR) $(CFLAGS_EXTRA)
 
 # Debugging/Optimization
 ifdef DEBUG
@@ -91,7 +91,7 @@ else
 # Use gcc syntax for map file
 LDFLAGS_ARCH = -Wl,-Map=$@.map,--cref -Wl,--gc-sections
 endif
-LDFLAGS = $(LDFLAGS_MOD) $(LDFLAGS_ARCH) -lm $(LDFLAGS_EXTRA)
+LDFLAGS += $(LDFLAGS_MOD) $(LDFLAGS_ARCH) -lm $(LDFLAGS_EXTRA)
 
 # Flags to link with pthread library
 LIBPTHREAD = -lpthread

--- a/ports/unix/variants/coverage/mpconfigvariant.mk
+++ b/ports/unix/variants/coverage/mpconfigvariant.mk
@@ -2,13 +2,13 @@ PROG ?= micropython-coverage
 
 COPT = -O0
 
-CFLAGS_EXTRA += \
+CFLAGS += \
 	-fprofile-arcs -ftest-coverage \
 	-Wdouble-promotion -Wformat -Wmissing-declarations -Wmissing-prototypes -Wsign-compare \
 	-Wold-style-definition -Wpointer-arith -Wshadow -Wuninitialized -Wunused-parameter \
 	-DMICROPY_UNIX_COVERAGE
 
-LDFLAGS_EXTRA += -fprofile-arcs -ftest-coverage
+LDFLAGS += -fprofile-arcs -ftest-coverage
 
 FROZEN_MANIFEST = manifest_coverage.py
 

--- a/ports/unix/variants/freedos/mpconfigvariant.mk
+++ b/ports/unix/variants/freedos/mpconfigvariant.mk
@@ -4,7 +4,7 @@ STRIP = i586-pc-msdosdjgpp-strip
 
 SIZE = i586-pc-msdosdjgpp-size
 
-CFLAGS_EXTRA = \
+CFLAGS += \
 	-DMICROPY_NLR_SETJMP \
 	-Dtgamma=gamma \
 	-DMICROPY_EMIT_X86=0 \


### PR DESCRIPTION
When CFLAGS_EXTRA/LDFLAGS_EXTRA (or anything) is set on the command line of a make invocation then it will completely override any setting or appending of these variables in the makefile(s).  This means builds like the coverage variant will have their mpconfigvariant.mk settings overridden.  Fix this by using CFLAGS/LDFLAGS exclusively in the makefile(s), reserving the CFLAGS_EXTRA/LDFLAGS_EXTRA variables for external command-line use only.