### PR TITLE
py/emitnative.c: Fix exception handling issues triggered by uasyncio.

### DIFF
--- a/py/emitnative.c
+++ b/py/emitnative.c
@@ -2058,7 +2058,7 @@ STATIC void emit_native_unwind_jump(emit_t *emit, mp_uint_t label, mp_uint_t exc
             ASM_MOV_REG_PCREL(emit->as, REG_RET, label & ~MP_EMIT_BREAK_FROM_FOR);
             ASM_MOV_LOCAL_REG(emit->as, LOCAL_IDX_EXC_HANDLER_UNWIND(emit), REG_RET);
             // Cancel any active exception (see also emit_native_pop_except_jump)
-            emit_native_mov_reg_const(emit, REG_RET, MP_F_CONST_NONE_OBJ);
+            ASM_MOV_REG_IMM(emit->as, REG_RET, (mp_uint_t)MP_OBJ_NULL);
             ASM_MOV_LOCAL_REG(emit->as, LOCAL_IDX_EXC_VAL(emit), REG_RET);
             // Jump to the innermost active finally
             label = first_finally->label;
@@ -2153,9 +2153,8 @@ STATIC void emit_native_with_cleanup(emit_t *emit, mp_uint_t label) {
 
     ASM_MOV_REG_LOCAL(emit->as, REG_ARG_1, LOCAL_IDX_EXC_VAL(emit)); // get exc
 
-    // Check if exc is None and jump to non-exc handler if it is
-    emit_native_mov_reg_const(emit, REG_ARG_2, MP_F_CONST_NONE_OBJ);
-    ASM_JUMP_IF_REG_EQ(emit->as, REG_ARG_1, REG_ARG_2, *emit->label_slot + 2);
+    // Check if exc is MP_OBJ_NULL (i.e. zero) and jump to non-exc handler if it is
+    ASM_JUMP_IF_REG_ZERO(emit->as, REG_ARG_1, *emit->label_slot + 2, false);
 
     ASM_LOAD_REG_REG_OFFSET(emit->as, REG_ARG_2, REG_ARG_1, 0); // get type(exc)
     emit_post_push_reg(emit, VTYPE_PYOBJ, REG_ARG_2); // push type(exc)
@@ -2175,9 +2174,9 @@ STATIC void emit_native_with_cleanup(emit_t *emit, mp_uint_t label) {
     emit_call(emit, MP_F_OBJ_IS_TRUE);
     ASM_JUMP_IF_REG_ZERO(emit->as, REG_RET, *emit->label_slot + 1, true);
 
-    // Replace exception with None
+    // Replace exception with MP_OBJ_NULL.
     emit_native_label_assign(emit, *emit->label_slot);
-    emit_native_mov_reg_const(emit, REG_TEMP0, MP_F_CONST_NONE_OBJ);
+    ASM_MOV_REG_IMM(emit->as, REG_TEMP0, (mp_uint_t)MP_OBJ_NULL);
     ASM_MOV_LOCAL_REG(emit->as, LOCAL_IDX_EXC_VAL(emit), REG_TEMP0);
 
     // end of with cleanup nlr_catch block
@@ -2255,7 +2254,7 @@ STATIC void emit_native_for_iter_end(emit_t *emit) {
 STATIC void emit_native_pop_except_jump(emit_t *emit, mp_uint_t label, bool within_exc_handler) {
     if (within_exc_handler) {
         // Cancel any active exception so subsequent handlers don't see it
-        emit_native_mov_reg_const(emit, REG_TEMP0, MP_F_CONST_NONE_OBJ);
+        ASM_MOV_REG_IMM(emit->as, REG_TEMP0, (mp_uint_t)MP_OBJ_NULL);
         ASM_MOV_LOCAL_REG(emit->as, LOCAL_IDX_EXC_VAL(emit), REG_TEMP0);
     } else {
         emit_native_leave_exc_stack(emit, false);

--- a/py/emitnative.c
+++ b/py/emitnative.c
@@ -2774,6 +2774,7 @@ STATIC void emit_native_yield(emit_t *emit, int kind) {
                 // Found active handler, get its PC
                 ASM_MOV_REG_PCREL(emit->as, REG_RET, e->label);
                 ASM_MOV_LOCAL_REG(emit->as, LOCAL_IDX_EXC_HANDLER_PC(emit), REG_RET);
+                break;
             }
         }
     }

--- a/py/nativeglue.c
+++ b/py/nativeglue.c
@@ -253,7 +253,7 @@ STATIC double mp_obj_get_float_to_d(mp_obj_t o) {
 
 #endif
 
-// these must correspond to the respective enum in runtime0.h
+// these must correspond to the respective enum in nativeglue.h
 const mp_fun_table_t mp_fun_table = {
     mp_const_none,
     mp_const_false,

--- a/tests/basics/gen_yield_from_pending.py
+++ b/tests/basics/gen_yield_from_pending.py
@@ -1,0 +1,24 @@
+# Tests that the pending exception state is managed correctly.
+# Reduced from tests/extmod/uasyncio_cancel_task.py which previously
+# failed on the native emitter.
+
+def noop_task():
+    print('noop task')
+    yield 1
+
+def raise_task():
+    print('raise task')
+    yield 2
+    print('raising')
+    raise Exception
+
+def main():
+    try:
+        yield from raise_task()
+    except:
+        print('main exception')
+
+    yield from noop_task()
+
+for z in main():
+    print('outer iter', z)

--- a/tests/basics/generator_throw_nested.py
+++ b/tests/basics/generator_throw_nested.py
@@ -1,0 +1,35 @@
+# Tests that the correct nested exception handler is used
+# when throwing into a generator.
+# Reduced from tests/extmod/uasyncio_wait_for.py which previously
+# failed on the native emitter.
+
+def gen():
+    try:
+        yield 1
+        try:
+            yield 2
+            try:
+                yield 3
+            except Exception:
+                yield 4
+                print(0)
+            yield 5
+        except Exception:
+            yield 6
+            print(1)
+        yield 7
+    except Exception:
+        yield 8
+        print(2)
+    yield 9
+
+for i in range(1, 10):
+    g = gen()
+    try:
+        for _ in range(i):
+            print(next(g))
+        print(g.throw(ValueError))
+    except ValueError:
+        print('ValueError')
+    except StopIteration:
+        print('StopIteration')


### PR DESCRIPTION
This fixes the issues that are currently causing the tests in #5332 to fail when run with the native emitter enabled.

Adds minimal tests to show the failures.