### PR TITLE
HTTP response code, content-type in server example

### DIFF
--- a/docs/esp8266/tutorial/network_tcp.rst
+++ b/docs/esp8266/tutorial/network_tcp.rst
@@ -118,5 +118,6 @@ that contains a table with the state of all the GPIO pins::
                 break
         rows = ['<tr><td>%s</td><td>%d</td></tr>' % (str(p), p.value()) for p in pins]
         response = html % '\n'.join(rows)
+        cl.send('HTTP/1.0 200 OK\r\nContent-type: text/html\r\n\r\n')
         cl.send(response)
         cl.close()


### PR DESCRIPTION
Safari/iOS web clients will fail if the the HTTP response code isn't sent

Safari shows an error:

> Safari Can't Open The Page
> Safari can't open the page "10.0.0.75" because the server unexpected dropped the
> connection.  This sometimes occurs when the server is busy. Wait for a few minutes,
> and then try again

By adding the http response code safari, chrome, firefox all will render the webpage

In addition this shows how to set content-type for a response.  Without content-type being set, popular command line browsers such as lynx/links will not render the html