### PR TITLE
py/mpthread: use strong type in mp_thread_set_state()

### DIFF
--- a/ports/cc3200/mpthreadport.c
+++ b/ports/cc3200/mpthreadport.c
@@ -85,7 +85,7 @@ mp_state_thread_t *mp_thread_get_state(void) {
     return pvTaskGetThreadLocalStoragePointer(NULL, 0);
 }
 
-void mp_thread_set_state(void *state) {
+void mp_thread_set_state(mp_state_thread_t *state) {
     vTaskSetThreadLocalStoragePointer(NULL, 0, state);
 }
 

--- a/ports/esp32/mpthreadport.c
+++ b/ports/esp32/mpthreadport.c
@@ -92,7 +92,7 @@ mp_state_thread_t *mp_thread_get_state(void) {
     return pvTaskGetThreadLocalStoragePointer(NULL, 1);
 }
 
-void mp_thread_set_state(void *state) {
+void mp_thread_set_state(mp_state_thread_t *state) {
     vTaskSetThreadLocalStoragePointer(NULL, 1, state);
 }
 

--- a/ports/stm32/mpthreadport.h
+++ b/ports/stm32/mpthreadport.h
@@ -32,7 +32,7 @@ typedef pyb_mutex_t mp_thread_mutex_t;
 void mp_thread_init(void);
 void mp_thread_gc_others(void);
 
-static inline void mp_thread_set_state(void *state) {
+static inline void mp_thread_set_state(struct _mp_state_thread_t *state) {
     pyb_thread_set_local(state);
 }
 

--- a/ports/unix/mpthreadport.c
+++ b/ports/unix/mpthreadport.c
@@ -158,7 +158,7 @@ mp_state_thread_t *mp_thread_get_state(void) {
     return (mp_state_thread_t*)pthread_getspecific(tls_key);
 }
 
-void mp_thread_set_state(void *state) {
+void mp_thread_set_state(mp_state_thread_t *state) {
     pthread_setspecific(tls_key, state);
 }
 

--- a/py/mpthread.h
+++ b/py/mpthread.h
@@ -30,16 +30,16 @@
 
 #if MICROPY_PY_THREAD
 
+struct _mp_state_thread_t;
+
 #ifdef MICROPY_MPTHREADPORT_H
 #include MICROPY_MPTHREADPORT_H
 #else
 #include <mpthreadport.h>
 #endif
 
-struct _mp_state_thread_t;
-
 struct _mp_state_thread_t *mp_thread_get_state(void);
-void mp_thread_set_state(void *state);
+void mp_thread_set_state(struct _mp_state_thread_t *state);
 void mp_thread_create(void *(*entry)(void*), void *arg, size_t *stack_size);
 void mp_thread_start(void);
 void mp_thread_finish(void);


### PR DESCRIPTION
This modifies the signature of `mp_thread_set_state()` to use `mp_state_thread_t *` instead of `void *`. This matches the return type of `mp_thread_get_state()`, which returns the same value.