### PR TITLE
tools/pyboard: Fix exception: 'list' object has no attribute 'clear'

### DIFF
--- a/tools/pyboard.py
+++ b/tools/pyboard.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #
 # This file is part of the MicroPython project, http://micropython.org/
 #

--- a/tools/pyboard.py
+++ b/tools/pyboard.py
@@ -561,7 +561,7 @@ def main():
         # do filesystem commands, if given
         if args.filesystem:
             filesystem_command(pyb, args.files)
-            args.files.clear()
+            del args.files[:]
 
         # run the command, if given
         if args.command is not None:


### PR DESCRIPTION
This fixes:

```
$/micropython/tools$ ./pyboard.py --device /dev/ttyUSB0 --filesystem ls
ls :
         139 boot.py
         186 main.py
Traceback (most recent call last):
  File "./pyboard.py", line 608, in <module>
    main()
  File "./pyboard.py", line 572, in main
    args.files.clear()
AttributeError: 'list' object has no attribute 'clear'
```

I guess this probably is caused by argparse changing types between versions.
So don't rely on the type. Just re-assign the attribute.