### PR TITLE
add ENTRY(Reset_Handler) in common.ld, so we can debug nrf chips step…

### DIFF
--- a/ports/nrf/boards/common.ld
+++ b/ports/nrf/boards/common.ld
@@ -1,3 +1,4 @@
+ENTRY(Reset_Handler)
 /* define output sections */
 SECTIONS
 {


### PR DESCRIPTION
add ENTRY(Reset_Handler) in common.ld, so we can debug nrf chips step by step with Ozone tool. 
( Ozone is SEGGER’s user-friendly and high-performance debugger for Arm and RISC-V Microcontroller programs.) 