### PR TITLE
ports/unix/main: print errors and usage to stderr

### DIFF
--- a/ports/unix/main.c
+++ b/ports/unix/main.c
@@ -391,7 +391,7 @@ STATIC void pre_process_options(int argc, char **argv) {
 #endif
                 } else {
 invalid_arg:
-                    printf("Invalid option\n");
+                    fprintf(stderr, "Invalid option\n");
                     exit(usage(argv));
                 }
                 a++;
@@ -709,6 +709,6 @@ uint mp_import_stat(const char *path) {
 #endif
 
 void nlr_jump_fail(void *val) {
-    printf("FATAL: uncaught NLR %p\n", val);
+    fprintf(stderr, "FATAL: uncaught NLR %p\n", val);
     exit(1);
 }


### PR DESCRIPTION
When `stdout` is redirected, it is useful to have errors printed to `stderr` instead of being redirected. Usage only prints when bad arguments are given, so it is considered an error as well.