### PR TITLE
Improved (in)equality testing with non-boolean results (v3)

### DIFF
--- a/py/obj.h
+++ b/py/obj.h
@@ -445,8 +445,14 @@ typedef mp_obj_t (*mp_fun_var_t)(size_t n, const mp_obj_t *);
 typedef mp_obj_t (*mp_fun_kw_t)(size_t n, const mp_obj_t *, mp_map_t *);
 
 // Flags for type behaviour (mp_obj_type_t.flags)
+// If MP_TYPE_FLAG_NEEDS_FULL_EQ_TEST is clear then all the following hold:
+//  (a) the type only implements the __eq__ operator and not the __ne__ operator;
+//  (b) __eq__ returns a boolean result (False or True);
+//  (c) __eq__ is reflexive (A==A is True);
+//  (d) the type can't be equal to an instance of any different class that also clears this flag.
 #define MP_TYPE_FLAG_IS_SUBCLASSED (0x0001)
 #define MP_TYPE_FLAG_HAS_SPECIAL_ACCESSORS (0x0002)
+#define MP_TYPE_FLAG_NEEDS_FULL_EQ_TEST (0x0004)
 
 typedef enum {
     PRINT_STR = 0,
@@ -729,6 +735,7 @@ void mp_obj_print_exception(const mp_print_t *print, mp_obj_t exc);
 
 bool mp_obj_is_true(mp_obj_t arg);
 bool mp_obj_is_callable(mp_obj_t o_in);
+mp_obj_t mp_obj_equal_not_equal(mp_binary_op_t op, mp_obj_t o1, mp_obj_t o2);
 bool mp_obj_equal(mp_obj_t o1, mp_obj_t o2);
 
 static inline bool mp_obj_is_integer(mp_const_obj_t o) { return mp_obj_is_int(o) || mp_obj_is_bool(o); } // returns true if o is bool, small int or long int

--- a/py/obj.h
+++ b/py/obj.h
@@ -444,6 +444,10 @@ typedef mp_obj_t (*mp_fun_var_t)(size_t n, const mp_obj_t *);
 // this arg to mp_map_lookup().
 typedef mp_obj_t (*mp_fun_kw_t)(size_t n, const mp_obj_t *, mp_map_t *);
 
+// Flags for type behaviour (mp_obj_type_t.flags)
+#define MP_TYPE_FLAG_IS_SUBCLASSED (0x0001)
+#define MP_TYPE_FLAG_HAS_SPECIAL_ACCESSORS (0x0002)
+
 typedef enum {
     PRINT_STR = 0,
     PRINT_REPR = 1,

--- a/py/objarray.c
+++ b/py/objarray.c
@@ -558,6 +558,7 @@ const mp_obj_type_t mp_type_array = {
 const mp_obj_type_t mp_type_bytearray = {
     { &mp_type_type },
     .name = MP_QSTR_bytearray,
+    .flags = MP_TYPE_FLAG_NEEDS_FULL_EQ_TEST,
     .print = array_print,
     .make_new = bytearray_make_new,
     .getiter = array_iterator_new,

--- a/py/objcomplex.c
+++ b/py/objcomplex.c
@@ -148,6 +148,7 @@ STATIC void complex_attr(mp_obj_t self_in, qstr attr, mp_obj_t *dest) {
 const mp_obj_type_t mp_type_complex = {
     { &mp_type_type },
     .name = MP_QSTR_complex,
+    .flags = MP_TYPE_FLAG_NEEDS_FULL_EQ_TEST,
     .print = complex_print,
     .make_new = complex_make_new,
     .unary_op = complex_unary_op,

--- a/py/objfloat.c
+++ b/py/objfloat.c
@@ -186,6 +186,7 @@ STATIC mp_obj_t float_binary_op(mp_binary_op_t op, mp_obj_t lhs_in, mp_obj_t rhs
 const mp_obj_type_t mp_type_float = {
     { &mp_type_type },
     .name = MP_QSTR_float,
+    .flags = MP_TYPE_FLAG_NEEDS_FULL_EQ_TEST,
     .print = float_print,
     .make_new = float_make_new,
     .unary_op = float_unary_op,

--- a/py/objset.c
+++ b/py/objset.c
@@ -564,6 +564,7 @@ STATIC MP_DEFINE_CONST_DICT(frozenset_locals_dict, frozenset_locals_dict_table);
 const mp_obj_type_t mp_type_frozenset = {
     { &mp_type_type },
     .name = MP_QSTR_frozenset,
+    .flags = MP_TYPE_FLAG_NEEDS_FULL_EQ_TEST,
     .print = set_print,
     .make_new = set_make_new,
     .unary_op = set_unary_op,

--- a/py/objtype.c
+++ b/py/objtype.c
@@ -467,7 +467,7 @@ const byte mp_binary_op_method_name[MP_BINARY_OP_NUM_RUNTIME] = {
     [MP_BINARY_OP_EQUAL] = MP_QSTR___eq__,
     [MP_BINARY_OP_LESS_EQUAL] = MP_QSTR___le__,
     [MP_BINARY_OP_MORE_EQUAL] = MP_QSTR___ge__,
-    // MP_BINARY_OP_NOT_EQUAL, // a != b calls a == b and inverts result
+    [MP_BINARY_OP_NOT_EQUAL] = MP_QSTR___ne__,
     [MP_BINARY_OP_CONTAINS] = MP_QSTR___contains__,
 
     // If an inplace method is not found a normal method will be used as a fallback
@@ -1100,7 +1100,7 @@ mp_obj_t mp_obj_new_type(qstr name, mp_obj_t bases_tuple, mp_obj_t locals_dict) 
     // TODO might need to make a copy of locals_dict; at least that's how CPython does it
 
     // Basic validation of base classes
-    uint16_t base_flags = 0;
+    uint16_t base_flags = MP_TYPE_FLAG_NEEDS_FULL_EQ_TEST;
     size_t bases_len;
     mp_obj_t *bases_items;
     mp_obj_tuple_get(bases_tuple, &bases_len, &bases_items);

--- a/py/objtype.c
+++ b/py/objtype.c
@@ -44,9 +44,6 @@
 #define ENABLE_SPECIAL_ACCESSORS \
     (MICROPY_PY_DESCRIPTORS  || MICROPY_PY_DELATTR_SETATTR || MICROPY_PY_BUILTINS_PROPERTY)
 
-#define TYPE_FLAG_IS_SUBCLASSED (0x0001)
-#define TYPE_FLAG_HAS_SPECIAL_ACCESSORS (0x0002)
-
 STATIC mp_obj_t static_class_method_make_new(const mp_obj_type_t *self_in, size_t n_args, size_t n_kw, const mp_obj_t *args);
 
 /******************************************************************************/
@@ -615,7 +612,7 @@ STATIC void mp_obj_instance_load_attr(mp_obj_t self_in, qstr attr, mp_obj_t *des
     mp_obj_class_lookup(&lookup, self->base.type);
     mp_obj_t member = dest[0];
     if (member != MP_OBJ_NULL) {
-        if (!(self->base.type->flags & TYPE_FLAG_HAS_SPECIAL_ACCESSORS)) {
+        if (!(self->base.type->flags & MP_TYPE_FLAG_HAS_SPECIAL_ACCESSORS)) {
             // Class doesn't have any special accessors to check so return straightaway
             return;
         }
@@ -680,7 +677,7 @@ STATIC void mp_obj_instance_load_attr(mp_obj_t self_in, qstr attr, mp_obj_t *des
 STATIC bool mp_obj_instance_store_attr(mp_obj_t self_in, qstr attr, mp_obj_t value) {
     mp_obj_instance_t *self = MP_OBJ_TO_PTR(self_in);
 
-    if (!(self->base.type->flags & TYPE_FLAG_HAS_SPECIAL_ACCESSORS)) {
+    if (!(self->base.type->flags & MP_TYPE_FLAG_HAS_SPECIAL_ACCESSORS)) {
         // Class doesn't have any special accessors so skip their checks
         goto skip_special_accessors;
     }
@@ -1061,13 +1058,13 @@ STATIC void type_attr(mp_obj_t self_in, qstr attr, mp_obj_t *dest) {
             } else {
                 #if ENABLE_SPECIAL_ACCESSORS
                 // Check if we add any special accessor methods with this store
-                if (!(self->flags & TYPE_FLAG_HAS_SPECIAL_ACCESSORS)) {
+                if (!(self->flags & MP_TYPE_FLAG_HAS_SPECIAL_ACCESSORS)) {
                     if (check_for_special_accessors(MP_OBJ_NEW_QSTR(attr), dest[1])) {
-                        if (self->flags & TYPE_FLAG_IS_SUBCLASSED) {
+                        if (self->flags & MP_TYPE_FLAG_IS_SUBCLASSED) {
                             // This class is already subclassed so can't have special accessors added
                             mp_raise_msg(&mp_type_AttributeError, "can't add special method to already-subclassed class");
                         }
-                        self->flags |= TYPE_FLAG_HAS_SPECIAL_ACCESSORS;
+                        self->flags |= MP_TYPE_FLAG_HAS_SPECIAL_ACCESSORS;
                     }
                 }
                 #endif
@@ -1123,8 +1120,8 @@ mp_obj_t mp_obj_new_type(qstr name, mp_obj_t bases_tuple, mp_obj_t locals_dict) 
         }
         #if ENABLE_SPECIAL_ACCESSORS
         if (mp_obj_is_instance_type(t)) {
-            t->flags |= TYPE_FLAG_IS_SUBCLASSED;
-            base_flags |= t->flags & TYPE_FLAG_HAS_SPECIAL_ACCESSORS;
+            t->flags |= MP_TYPE_FLAG_IS_SUBCLASSED;
+            base_flags |= t->flags & MP_TYPE_FLAG_HAS_SPECIAL_ACCESSORS;
         }
         #endif
     }
@@ -1166,12 +1163,12 @@ mp_obj_t mp_obj_new_type(qstr name, mp_obj_t bases_tuple, mp_obj_t locals_dict) 
 
     #if ENABLE_SPECIAL_ACCESSORS
     // Check if the class has any special accessor methods
-    if (!(o->flags & TYPE_FLAG_HAS_SPECIAL_ACCESSORS)) {
+    if (!(o->flags & MP_TYPE_FLAG_HAS_SPECIAL_ACCESSORS)) {
         for (size_t i = 0; i < o->locals_dict->map.alloc; i++) {
             if (mp_map_slot_is_filled(&o->locals_dict->map, i)) {
                 const mp_map_elem_t *elem = &o->locals_dict->map.table[i];
                 if (check_for_special_accessors(elem->key, elem->value)) {
-                    o->flags |= TYPE_FLAG_HAS_SPECIAL_ACCESSORS;
+                    o->flags |= MP_TYPE_FLAG_HAS_SPECIAL_ACCESSORS;
                     break;
                 }
             }

--- a/py/runtime.c
+++ b/py/runtime.c
@@ -323,19 +323,8 @@ mp_obj_t mp_binary_op(mp_binary_op_t op, mp_obj_t lhs, mp_obj_t rhs) {
 
     // deal with == and != for all types
     if (op == MP_BINARY_OP_EQUAL || op == MP_BINARY_OP_NOT_EQUAL) {
-        if (mp_obj_equal(lhs, rhs)) {
-            if (op == MP_BINARY_OP_EQUAL) {
-                return mp_const_true;
-            } else {
-                return mp_const_false;
-            }
-        } else {
-            if (op == MP_BINARY_OP_EQUAL) {
-                return mp_const_false;
-            } else {
-                return mp_const_true;
-            }
-        }
+        // mp_obj_equal_not_equal supports a bunch of shortcuts
+        return mp_obj_equal_not_equal(op, lhs, rhs);
     }
 
     // deal with exception_match for all types

--- a/tests/basics/special_comparisons.py
+++ b/tests/basics/special_comparisons.py
@@ -1,0 +1,33 @@
+class A:
+    def __eq__(self, other):
+        print("A __eq__ called")
+        return True
+
+class B:
+    def __ne__(self, other):
+        print("B __ne__ called")
+        return True
+
+class C:
+    def __eq__(self, other):
+        print("C __eq__ called")
+        return False
+
+class D:
+    def __ne__(self, other):
+        print("D __ne__ called")
+        return False
+
+a = A()
+b = B()
+c = C()
+d = D()
+
+def test(s):
+    print(s)
+    print(eval(s))
+
+for x in 'abcd':
+    for y in 'abcd':
+        test('{} == {}'.format(x,y))
+        test('{} != {}'.format(x,y))

--- a/tests/basics/special_comparisons2.py
+++ b/tests/basics/special_comparisons2.py
@@ -1,0 +1,31 @@
+class E:
+    def __repr__(self):
+        return "E"
+
+    def __eq__(self, other):
+        print('E eq', other)
+        return 123
+
+class F:
+    def __repr__(self):
+        return "F"
+
+    def __ne__(self, other):
+        print('F ne', other)
+        return -456
+
+print(E() != F())
+print(F() != E())
+
+tests = (None, 0, 1, 'a')
+
+for val in tests:
+    print('==== testing', val)
+    print(E() == val)
+    print(val == E())
+    print(E() != val)
+    print(val != E())
+    print(F() == val)
+    print(val == F())
+    print(F() != val)
+    print(val != F())

--- a/tests/basics/subclass_native2_tuple.py
+++ b/tests/basics/subclass_native2_tuple.py
@@ -19,3 +19,11 @@ a = Ctuple2()
 print(len(a))
 a = Ctuple2([1, 2, 3])
 print(len(a))
+
+a = tuple([1,2,3])
+b = Ctuple1([1,2,3])
+c = Ctuple2([1,2,3])
+
+print(a == b)
+print(b == c)
+print(c == a)


### PR DESCRIPTION
This is a (slightly) reworked version of #5533.  Changes made here compared to there:
- put moving/rename of `TYPE_FLAG_xxx` constants in a separate commit
- squashed other commits into 2 separate ones (main commit and addition of new test)
- renamed `mp_obj_equal_bop` to `mp_obj_equal_not_equal` to be more clear what it does (only eq and ne)
- renamed `MP_TYPE_FLAG_NO_EQUALITY_SHORTCUTS` to `MP_TYPE_FLAG_NEEDS_FULL_EQ_TEST` to phrase it in the positive rather than the negative (easier to understand code it's used in when using additional negatives in the logic)
- added back str-bytes comparison warning
