### PR TITLE
stm32/sdram: Expose the result of sdram startup test in stm32_main

### DIFF
--- a/ports/stm32/boards/STM32F429DISC/mpconfigboard.h
+++ b/ports/stm32/boards/STM32F429DISC/mpconfigboard.h
@@ -79,8 +79,8 @@
 // SDRAM
 #define MICROPY_HW_SDRAM_SIZE  (64 / 8 * 1024 * 1024)  // 64 Mbit
 #define MICROPY_HW_SDRAM_STARTUP_TEST             (1)
-#define MICROPY_HEAP_START              sdram_start()
-#define MICROPY_HEAP_END                sdram_end()
+#define MICROPY_HEAP_START ((sdram_valid)?sdram_start():&_heap_start)
+#define MICROPY_HEAP_END ((sdram_valid)?sdram_end():&_heap_end)
 
 // Timing configuration for 90 Mhz (11.90ns) of SD clock frequency (180Mhz/2)
 #define MICROPY_HW_SDRAM_TIMING_TMRD        (2)

--- a/ports/stm32/main.c
+++ b/ports/stm32/main.c
@@ -500,8 +500,9 @@ void stm32_main(uint32_t reset_mode) {
     #endif
     #if MICROPY_HW_SDRAM_SIZE
     sdram_init();
+    bool sdram_valid = true;
     #if MICROPY_HW_SDRAM_STARTUP_TEST
-    sdram_test(true);
+    sdram_valid = sdram_test(true);
     #endif
     #endif
     #if MICROPY_PY_THREAD

--- a/ports/stm32/sdram.c
+++ b/ports/stm32/sdram.c
@@ -255,7 +255,7 @@ static void sdram_init_seq(SDRAM_HandleTypeDef
     #endif
 }
 
-bool __attribute__((optimize("O0"))) sdram_test(bool fast) {
+bool sdram_test(bool fast) {
     uint8_t const pattern = 0xaa;
     uint8_t const antipattern = 0x55;
     uint8_t *const mem_base = (uint8_t*)sdram_start();
@@ -265,7 +265,7 @@ bool __attribute__((optimize("O0"))) sdram_test(bool fast) {
         *mem_base = i;
         if (*mem_base != i) {
             printf("data bus lines test failed! data (%d)\n", i);
-            __asm__ volatile ("BKPT");
+            return false;
         }
     }
 
@@ -275,7 +275,7 @@ bool __attribute__((optimize("O0"))) sdram_test(bool fast) {
         mem_base[i] = pattern;
         if (mem_base[i] != pattern) {
             printf("address bus lines test failed! address (%p)\n", &mem_base[i]);
-            __asm__ volatile ("BKPT");
+            return false;
         }
     }
 
@@ -284,7 +284,7 @@ bool __attribute__((optimize("O0"))) sdram_test(bool fast) {
     for (uint32_t i = 1; i < MICROPY_HW_SDRAM_SIZE; i <<= 1) {
         if (mem_base[i] != pattern) {
             printf("address bus overlap %p\n", &mem_base[i]);
-            __asm__ volatile ("BKPT");
+            return false;
         }
     }
 
@@ -294,7 +294,7 @@ bool __attribute__((optimize("O0"))) sdram_test(bool fast) {
             mem_base[i] = pattern;
             if (mem_base[i] != pattern) {
                 printf("address bus test failed! address (%p)\n", &mem_base[i]);
-                __asm__ volatile ("BKPT");
+                return false;
             }
         }
     } else {


### PR DESCRIPTION
This means boards can choose to only use it for gc heap if the test passes.