### PR TITLE
ESP32:machine_uart.c: Enable hardware flow control.

### DIFF
--- a/docs/library/machine.UART.rst
+++ b/docs/library/machine.UART.rst
@@ -24,6 +24,10 @@ are supported.
 
 WiPy/CC3200: Bits can be 5, 6, 7, 8. Stop can be 1 or 2.
 
+ESP32: Hardware flow control can be enabled by specifying pins for rts
+and cts. If the rts pin is specified, RTS flow control is enabled, if the
+cts pin is specified, CTS flow control is enabled. 
+
 A UART object acts like a `stream` object and reading and writing is done
 using the standard stream methods::
 
@@ -56,6 +60,8 @@ Methods
 
      - *tx* specifies the TX pin to use.
      - *rx* specifies the RX pin to use.
+     - *rts* specifies the RTS pin to use for RTS hardware flow control
+     - *cts* specifies the CTS pin to use for CTS hardware flow control
      - *txbuf* specifies the length in characters of the TX buffer.
      - *rxbuf* specifies the length in characters of the RX buffer.
      - *timeout* specifies the time to wait for the first character (in ms).

--- a/ports/esp32/machine_uart.c
+++ b/ports/esp32/machine_uart.c
@@ -149,6 +149,7 @@ STATIC void machine_uart_init_helper(machine_uart_obj_t *self, size_t n_args, co
         uart_get_baudrate(self->uart_num, &baudrate);
     }
 
+    uart_hw_flowcontrol_t flow_ctrl = UART_HW_FLOWCTRL_DISABLE;
     uart_set_pin(self->uart_num, args[ARG_tx].u_int, args[ARG_rx].u_int, args[ARG_rts].u_int, args[ARG_cts].u_int);
     if (args[ARG_tx].u_int != UART_PIN_NO_CHANGE) {
         self->tx = args[ARG_tx].u_int;
@@ -160,11 +161,14 @@ STATIC void machine_uart_init_helper(machine_uart_obj_t *self, size_t n_args, co
 
     if (args[ARG_rts].u_int != UART_PIN_NO_CHANGE) {
         self->rts = args[ARG_rts].u_int;
+        flow_ctrl |= UART_HW_FLOWCTRL_RTS;
     }
 
     if (args[ARG_cts].u_int != UART_PIN_NO_CHANGE) {
         self->cts = args[ARG_cts].u_int;
+        flow_ctrl |= UART_HW_FLOWCTRL_CTS;
     }
+    uart_set_hw_flow_ctrl(self->uart_num, flow_ctrl, 1); 
 
     // set data bits
     switch (args[ARG_bits].u_int) {

--- a/ports/esp32/machine_uart.c
+++ b/ports/esp32/machine_uart.c
@@ -168,7 +168,7 @@ STATIC void machine_uart_init_helper(machine_uart_obj_t *self, size_t n_args, co
         self->cts = args[ARG_cts].u_int;
         flow_ctrl |= UART_HW_FLOWCTRL_CTS;
     }
-    uart_set_hw_flow_ctrl(self->uart_num, flow_ctrl, 1); 
+    uart_set_hw_flow_ctrl(self->uart_num, flow_ctrl, UART_FIFO_LEN - 32); 
 
     // set data bits
     switch (args[ARG_bits].u_int) {


### PR DESCRIPTION
Hardware flow control will be enabled appropriately when rts or cts are defined. The rts-threshold is set 1, resulting in a rxbuf + 1, before rts is raised. Then still FIFO_size - 1 bytes can be received without data loss. The FIFO_size is 128.
Note: Setting rts_threshold to 0 has a strange side effect, that rts pulses with every received byte.