### PR TITLE
tests/run-tests: Skip extmod/ticks_diff and extmod/time_ms_us automatically.

### DIFF
--- a/tests/extmod/ticks_diff.py
+++ b/tests/extmod/ticks_diff.py
@@ -1,4 +1,8 @@
-from utime import ticks_diff, ticks_add
+try:
+    from utime import ticks_diff, ticks_add
+except ImportError:
+    print("SKIP")
+    raise SystemExit
 
 MAX = ticks_add(0, -1)
 # Should be done like this to avoid small int overflow

--- a/tests/extmod/time_ms_us.py
+++ b/tests/extmod/time_ms_us.py
@@ -1,7 +1,7 @@
-import utime
 try:
-    utime.sleep_ms
-except AttributeError:
+    import utime
+    utime.sleep_ms, utime.sleep_us, utime.ticks_diff, utime.ticks_ms, utime.ticks_us, utime.ticks_cpu
+except (ImportError, AttributeError):
     print("SKIP")
     raise SystemExit
 

--- a/tests/run-tests
+++ b/tests/run-tests
@@ -384,8 +384,6 @@ def run_tests(pyb, tests, args, base_path="."):
             skip_tests.add('micropython/opt_level.py')      # don't assume line numbers are stored
         elif args.target == 'nrf':
             skip_tests.add('basics/memoryview1.py')         # no item assignment for memoryview
-            skip_tests.add('extmod/ticks_diff.py')          # unimplemented: utime.ticks_diff
-            skip_tests.add('extmod/time_ms_us.py')          # unimplemented: utime.ticks_ms
             skip_tests.add('extmod/urandom_basic.py')       # unimplemented: urandom.seed
             skip_tests.add('micropython/opt_level.py')      # no support for line numbers
             skip_tests.add('misc/non_compliant.py')         # no item assignment for bytearray


### PR DESCRIPTION
It's better decided this way, in runtime code, instead of hard-coding it in the tests execution framework.

It also means that if, at any point in the future, the missing functions will be implemented - the tests will "activate" automatically for the port.

Taken from https://github.com/micropython/micropython/pull/5482 (where I depend on this auto skipping).