### PR TITLE
framebuf.rst Monochrome 1 bit modes are swapped

### DIFF
--- a/docs/library/framebuf.rst
+++ b/docs/library/framebuf.rst
@@ -130,7 +130,7 @@ Constants
 
     Monochrome (1-bit) color format
     This defines a mapping where the bits in a byte are horizontally mapped.
-    Each byte occupies 8 horizontal pixels with bit 0 being the leftmost.
+    Each byte occupies 8 horizontal pixels with bit 7 being the leftmost.
     Subsequent bytes appear at successive horizontal locations until the
     rightmost edge is reached. Further bytes are rendered on the next row, one
     pixel lower.
@@ -139,7 +139,7 @@ Constants
 
     Monochrome (1-bit) color format
     This defines a mapping where the bits in a byte are horizontally mapped.
-    Each byte occupies 8 horizontal pixels with bit 7 being the leftmost.
+    Each byte occupies 8 horizontal pixels with bit 0 being the leftmost.
     Subsequent bytes appear at successive horizontal locations until the
     rightmost edge is reached. Further bytes are rendered on the next row, one
     pixel lower.


### PR DESCRIPTION
This can be demonstrated by pasting the following on a Pyboard:
```
b = bytearray(32)
f = framebuf.FrameBuffer(b, 32, 8, framebuf.MONO_HLSB)
f.pixel(0, 0, 1)
print('MONO_HLSB', hex(b[0]))

b = bytearray(32)
f = framebuf.FrameBuffer(b, 32, 8, framebuf.MONO_HMSB)
f.pixel(0, 0, 1)
print('MONO_HMSB', hex(b[0]))
```
Outcome:
```
MONO_HLSB 0x80
MONO_HMSB 0x1
```
Reference [this forum thread](https://forum.micropython.org/viewtopic.php?f=15&t=7683)