### PR TITLE
py: Expand type-equality flags to 3 separate ones to fix bool/namedtuple equality

### DIFF
--- a/py/obj.c
+++ b/py/obj.c
@@ -209,7 +209,7 @@ mp_obj_t mp_obj_equal_not_equal(mp_binary_op_t op, mp_obj_t o1, mp_obj_t o2) {
 
     // Shortcut for very common cases
     if (o1 == o2 &&
-        (mp_obj_is_small_int(o1) || !(mp_obj_get_type(o1)->flags & MP_TYPE_FLAG_NEEDS_FULL_EQ_TEST))) {
+        (mp_obj_is_small_int(o1) || !(mp_obj_get_type(o1)->flags & MP_TYPE_FLAG_EQ_NOT_REFLEXIVE))) {
         return local_true;
     }
 
@@ -250,10 +250,10 @@ mp_obj_t mp_obj_equal_not_equal(mp_binary_op_t op, mp_obj_t o1, mp_obj_t o2) {
         // If a full equality test is not needed and the other object is a different
         // type then we don't need to bother trying the comparison.
         if (type->binary_op != NULL &&
-            ((type->flags & MP_TYPE_FLAG_NEEDS_FULL_EQ_TEST) || mp_obj_get_type(o2) == type)) {
+            ((type->flags & MP_TYPE_FLAG_EQ_CHECKS_OTHER_TYPE) || mp_obj_get_type(o2) == type)) {
             // CPython is asymmetric: it will try __eq__ if there's no __ne__ but not the
             // other way around.  If the class doesn't need a full test we can skip __ne__.
-            if (op == MP_BINARY_OP_NOT_EQUAL && (type->flags & MP_TYPE_FLAG_NEEDS_FULL_EQ_TEST)) {
+            if (op == MP_BINARY_OP_NOT_EQUAL && (type->flags & MP_TYPE_FLAG_EQ_HAS_NEQ_TEST)) {
                 mp_obj_t r = type->binary_op(MP_BINARY_OP_NOT_EQUAL, o1, o2);
                 if (r != MP_OBJ_NULL) {
                     return r;

--- a/py/obj.h
+++ b/py/obj.h
@@ -445,14 +445,17 @@ typedef mp_obj_t (*mp_fun_var_t)(size_t n, const mp_obj_t *);
 typedef mp_obj_t (*mp_fun_kw_t)(size_t n, const mp_obj_t *, mp_map_t *);
 
 // Flags for type behaviour (mp_obj_type_t.flags)
-// If MP_TYPE_FLAG_NEEDS_FULL_EQ_TEST is clear then all the following hold:
-//  (a) the type only implements the __eq__ operator and not the __ne__ operator;
-//  (b) __eq__ returns a boolean result (False or True);
-//  (c) __eq__ is reflexive (A==A is True);
-//  (d) the type can't be equal to an instance of any different class that also clears this flag.
+// If MP_TYPE_FLAG_EQ_NOT_REFLEXIVE is clear then __eq__ is reflexive (A==A returns True).
+// If MP_TYPE_FLAG_EQ_CHECKS_OTHER_TYPE is clear then the type can't be equal to an
+// instance of any different class that also clears this flag.  If this flag is set
+// then the type may check for equality against a different type.
+// If MP_TYPE_FLAG_EQ_HAS_NEQ_TEST is clear then the type only implements the __eq__
+// operator and not the __ne__ operator.  If it's set then __ne__ may be implemented.
 #define MP_TYPE_FLAG_IS_SUBCLASSED (0x0001)
 #define MP_TYPE_FLAG_HAS_SPECIAL_ACCESSORS (0x0002)
-#define MP_TYPE_FLAG_NEEDS_FULL_EQ_TEST (0x0004)
+#define MP_TYPE_FLAG_EQ_NOT_REFLEXIVE (0x0040)
+#define MP_TYPE_FLAG_EQ_CHECKS_OTHER_TYPE (0x0080)
+#define MP_TYPE_FLAG_EQ_HAS_NEQ_TEST (0x0010)
 
 typedef enum {
     PRINT_STR = 0,

--- a/py/objarray.c
+++ b/py/objarray.c
@@ -557,8 +557,8 @@ const mp_obj_type_t mp_type_array = {
 #if MICROPY_PY_BUILTINS_BYTEARRAY
 const mp_obj_type_t mp_type_bytearray = {
     { &mp_type_type },
+    .flags = MP_TYPE_FLAG_EQ_CHECKS_OTHER_TYPE,
     .name = MP_QSTR_bytearray,
-    .flags = MP_TYPE_FLAG_NEEDS_FULL_EQ_TEST,
     .print = array_print,
     .make_new = bytearray_make_new,
     .getiter = array_iterator_new,

--- a/py/objbool.c
+++ b/py/objbool.c
@@ -86,6 +86,7 @@ STATIC mp_obj_t bool_binary_op(mp_binary_op_t op, mp_obj_t lhs_in, mp_obj_t rhs_
 
 const mp_obj_type_t mp_type_bool = {
     { &mp_type_type },
+    .flags = MP_TYPE_FLAG_EQ_CHECKS_OTHER_TYPE, // can match all numeric types
     .name = MP_QSTR_bool,
     .print = bool_print,
     .make_new = bool_make_new,

--- a/py/objcomplex.c
+++ b/py/objcomplex.c
@@ -147,8 +147,8 @@ STATIC void complex_attr(mp_obj_t self_in, qstr attr, mp_obj_t *dest) {
 
 const mp_obj_type_t mp_type_complex = {
     { &mp_type_type },
+    .flags = MP_TYPE_FLAG_EQ_NOT_REFLEXIVE | MP_TYPE_FLAG_EQ_CHECKS_OTHER_TYPE,
     .name = MP_QSTR_complex,
-    .flags = MP_TYPE_FLAG_NEEDS_FULL_EQ_TEST,
     .print = complex_print,
     .make_new = complex_make_new,
     .unary_op = complex_unary_op,

--- a/py/objfloat.c
+++ b/py/objfloat.c
@@ -185,8 +185,8 @@ STATIC mp_obj_t float_binary_op(mp_binary_op_t op, mp_obj_t lhs_in, mp_obj_t rhs
 
 const mp_obj_type_t mp_type_float = {
     { &mp_type_type },
+    .flags = MP_TYPE_FLAG_EQ_NOT_REFLEXIVE | MP_TYPE_FLAG_EQ_CHECKS_OTHER_TYPE,
     .name = MP_QSTR_float,
-    .flags = MP_TYPE_FLAG_NEEDS_FULL_EQ_TEST,
     .print = float_print,
     .make_new = float_make_new,
     .unary_op = float_unary_op,

--- a/py/objnamedtuple.c
+++ b/py/objnamedtuple.c
@@ -155,6 +155,7 @@ mp_obj_namedtuple_type_t *mp_obj_new_namedtuple_base(size_t n_fields, mp_obj_t *
 STATIC mp_obj_t mp_obj_new_namedtuple_type(qstr name, size_t n_fields, mp_obj_t *fields) {
     mp_obj_namedtuple_type_t *o = mp_obj_new_namedtuple_base(n_fields, fields);
     o->base.base.type = &mp_type_type;
+    o->base.flags = MP_TYPE_FLAG_EQ_CHECKS_OTHER_TYPE; // can match tuple
     o->base.name = name;
     o->base.print = namedtuple_print;
     o->base.make_new = namedtuple_make_new;

--- a/py/objset.c
+++ b/py/objset.c
@@ -563,8 +563,8 @@ STATIC MP_DEFINE_CONST_DICT(frozenset_locals_dict, frozenset_locals_dict_table);
 
 const mp_obj_type_t mp_type_frozenset = {
     { &mp_type_type },
+    .flags = MP_TYPE_FLAG_EQ_CHECKS_OTHER_TYPE,
     .name = MP_QSTR_frozenset,
-    .flags = MP_TYPE_FLAG_NEEDS_FULL_EQ_TEST,
     .print = set_print,
     .make_new = set_make_new,
     .unary_op = set_unary_op,

--- a/py/objtype.c
+++ b/py/objtype.c
@@ -1100,7 +1100,8 @@ mp_obj_t mp_obj_new_type(qstr name, mp_obj_t bases_tuple, mp_obj_t locals_dict) 
     // TODO might need to make a copy of locals_dict; at least that's how CPython does it
 
     // Basic validation of base classes
-    uint16_t base_flags = MP_TYPE_FLAG_NEEDS_FULL_EQ_TEST;
+    uint16_t base_flags = MP_TYPE_FLAG_EQ_NOT_REFLEXIVE
+        | MP_TYPE_FLAG_EQ_CHECKS_OTHER_TYPE | MP_TYPE_FLAG_EQ_HAS_NEQ_TEST;
     size_t bases_len;
     mp_obj_t *bases_items;
     mp_obj_tuple_get(bases_tuple, &bases_len, &bases_items);

--- a/tests/basics/bool1.py
+++ b/tests/basics/bool1.py
@@ -10,6 +10,30 @@ print(False or True)
 print(+True)
 print(-True)
 
+# comparison with itself
+print(False == False)
+print(False == True)
+print(True == False)
+print(True == True)
+print(False != False)
+print(False != True)
+print(True != False)
+print(True != True)
+
+# comparison with integers
+print(False == 0)
+print(0 == False)
+print(True == 1)
+print(1 == True)
+print(True == 2)
+print(2 == True)
+print(False != 0)
+print(0 != False)
+print(True != 1)
+print(1 != True)
+print(True != 2)
+print(2 != True)
+
 # unsupported unary op
 try:
     len(False)

--- a/tests/basics/dict1.py
+++ b/tests/basics/dict1.py
@@ -23,6 +23,34 @@ print({} == {1:1})
 # equality operator on dicts of same size but with different keys
 print({1:1} == {2:1})
 
+# 0 replacing False's item
+d = {}
+d[False] = 'false'
+d[0] = 'zero'
+print(d)
+
+# False replacing 0's item
+d = {}
+d[0] = 'zero'
+d[False] = 'false'
+print(d)
+
+# 1 replacing True's item
+d = {}
+d[True] = 'true'
+d[1] = 'one'
+print(d)
+
+# True replacing 1's item
+d = {}
+d[1] = 'one'
+d[True] = 'true'
+print(d)
+
+# mixed bools and integers
+d = {False:10, True:11, 2:12}
+print(d[0], d[1], d[2])
+
 # value not found
 try:
     {}[0]

--- a/tests/basics/namedtuple1.py
+++ b/tests/basics/namedtuple1.py
@@ -24,6 +24,9 @@ for t in T(1, 2), T(bar=1, foo=2):
 
     print(isinstance(t, tuple))
 
+    # Check tuple can compare equal to namedtuple with same elements
+    print(t == (t[0], t[1]), (t[0], t[1]) == t)
+
 # Create using positional and keyword args
 print(T(3, bar=4))
 

--- a/tests/basics/set_add.py
+++ b/tests/basics/set_add.py
@@ -1,3 +1,23 @@
 s = {1, 2, 3, 4}
 print(s.add(5))
 print(sorted(s))
+
+s = set()
+s.add(0)
+s.add(False)
+print(s)
+
+s = set()
+s.add(False)
+s.add(0)
+print(s)
+
+s = set()
+s.add(1)
+s.add(True)
+print(s)
+
+s = set()
+s.add(True)
+s.add(1)
+print(s)

--- a/tests/basics/set_basic.py
+++ b/tests/basics/set_basic.py
@@ -10,6 +10,10 @@ print(sorted(s))
 s = {1 + len(s)}
 print(s)
 
+# bools mixed with integers
+s = {False, True, 0, 1, 2}
+print(len(s))
+
 # Sets are not hashable
 try:
     {s: 1}

--- a/tests/float/complex1.py
+++ b/tests/float/complex1.py
@@ -36,6 +36,8 @@ ans = 1j ** 2.5j; print("%.5g %.5g" % (ans.real, ans.imag))
 # comparison
 print(1j == 1)
 print(1j == 1j)
+print(0 + 0j == False, 1 + 0j == True)
+print(False == 0 + 0j, True == 1 + 0j)
 
 # comparison of nan is special
 nan = float('nan') * 1j

--- a/tests/float/float1.py
+++ b/tests/float/float1.py
@@ -64,6 +64,8 @@ print(1.2 <= 3.4)
 print(1.2 <= -3.4)
 print(1.2 >= 3.4)
 print(1.2 >= -3.4)
+print(0.0 == False, 1.0 == True)
+print(False == 0.0, True == 1.0)
 
 # comparison of nan is special
 nan = float('nan')


### PR DESCRIPTION
Fixes #5615 and #5620, with tests for both.