### PR TITLE
all: Add mp_raise_msg_varg helper and use it where appropriate.

### DIFF
--- a/extmod/machine_mem.c
+++ b/extmod/machine_mem.c
@@ -42,7 +42,7 @@
 STATIC uintptr_t machine_mem_get_addr(mp_obj_t addr_o, uint align) {
     uintptr_t addr = mp_obj_int_get_truncated(addr_o);
     if ((addr & (align - 1)) != 0) {
-        nlr_raise(mp_obj_new_exception_msg_varg(&mp_type_ValueError, "address %08x is not aligned to %d bytes", addr, align));
+        mp_raise_msg_varg(&mp_type_ValueError, "address %08x is not aligned to %d bytes", addr, align);
     }
     return addr;
 }

--- a/ports/esp32/machine_i2c.c
+++ b/ports/esp32/machine_i2c.c
@@ -130,7 +130,7 @@ mp_obj_t machine_hw_i2c_make_new(const mp_obj_type_t *type, size_t n_args, size_
     // Get I2C bus
     mp_int_t i2c_id = mp_obj_get_int(args[ARG_id].u_obj);
     if (!(I2C_NUM_0 <= i2c_id && i2c_id < I2C_NUM_MAX)) {
-        nlr_raise(mp_obj_new_exception_msg_varg(&mp_type_ValueError, "I2C(%d) doesn't exist", i2c_id));
+        mp_raise_msg_varg(&mp_type_ValueError, "I2C(%d) doesn't exist", i2c_id);
     }
 
     // Get static peripheral object

--- a/ports/esp32/machine_pwm.c
+++ b/ports/esp32/machine_pwm.c
@@ -163,8 +163,7 @@ STATIC void esp32_pwm_init_helper(esp32_pwm_obj_t *self,
             .timer_sel = PWTIMER,
         };
         if (ledc_channel_config(&cfg) != ESP_OK) {
-            nlr_raise(mp_obj_new_exception_msg_varg(&mp_type_ValueError,
-                "PWM not supported on pin %d", self->pin));
+            mp_raise_msg_varg(&mp_type_ValueError, "PWM not supported on pin %d", self->pin);
         }
         chan_gpio[channel] = self->pin;
     }
@@ -174,8 +173,7 @@ STATIC void esp32_pwm_init_helper(esp32_pwm_obj_t *self,
     if (tval != -1) {
         if (tval != timer_cfg.freq_hz) {
             if (!set_freq(tval)) {
-                nlr_raise(mp_obj_new_exception_msg_varg(&mp_type_ValueError,
-                    "Bad frequency %d", tval));
+                mp_raise_msg_varg(&mp_type_ValueError, "Bad frequency %d", tval);
             }
         }
     }
@@ -249,8 +247,7 @@ STATIC mp_obj_t esp32_pwm_freq(size_t n_args, const mp_obj_t *args) {
     // set
     int tval = mp_obj_get_int(args[1]);
     if (!set_freq(tval)) {
-        nlr_raise(mp_obj_new_exception_msg_varg(&mp_type_ValueError,
-            "Bad frequency %d", tval));
+        mp_raise_msg_varg(&mp_type_ValueError, "Bad frequency %d", tval);
     }
     return mp_const_none;
 }

--- a/ports/esp32/machine_uart.c
+++ b/ports/esp32/machine_uart.c
@@ -251,13 +251,13 @@ STATIC mp_obj_t machine_uart_make_new(const mp_obj_type_t *type, size_t n_args, 
     // get uart id
     mp_int_t uart_num = mp_obj_get_int(args[0]);
     if (uart_num < 0 || uart_num >= UART_NUM_MAX) {
-        nlr_raise(mp_obj_new_exception_msg_varg(&mp_type_ValueError, "UART(%d) does not exist", uart_num));
+        mp_raise_msg_varg(&mp_type_ValueError, "UART(%d) does not exist", uart_num);
     }
 
     // Attempts to use UART0 from Python has resulted in all sorts of fun errors.
     // FIXME: UART0 is disabled for now.
     if (uart_num == UART_NUM_0) {
-        nlr_raise(mp_obj_new_exception_msg_varg(&mp_type_ValueError, "UART(%d) is disabled (dedicated to REPL)", uart_num));
+        mp_raise_msg_varg(&mp_type_ValueError, "UART(%d) is disabled (dedicated to REPL)", uart_num);
     }
 
      // Defaults

--- a/ports/esp32/modnetwork.c
+++ b/ports/esp32/modnetwork.c
@@ -98,9 +98,7 @@ NORETURN void _esp_exceptions(esp_err_t e) {
       case ESP_ERR_TCPIP_ADAPTER_NO_MEM:
         mp_raise_OSError(MP_ENOMEM);
       default:
-        nlr_raise(mp_obj_new_exception_msg_varg(
-          &mp_type_RuntimeError, "Wifi Unknown Error 0x%04x", e
-        ));
+        mp_raise_msg_varg( &mp_type_RuntimeError, "Wifi Unknown Error 0x%04x", e);
    }
 }
 

--- a/ports/esp32/modutime.c
+++ b/ports/esp32/modutime.c
@@ -66,7 +66,7 @@ STATIC mp_obj_t time_mktime(mp_obj_t tuple) {
 
     // localtime generates a tuple of len 8. CPython uses 9, so we accept both.
     if (len < 8 || len > 9) {
-        nlr_raise(mp_obj_new_exception_msg_varg(&mp_type_TypeError, "mktime needs a tuple of length 8 or 9 (%d given)", len));
+        mp_raise_msg_varg(&mp_type_TypeError, "mktime needs a tuple of length 8 or 9 (%d given)", len);
     }
 
     return mp_obj_new_int_from_uint(timeutils_mktime(mp_obj_get_int(elem[0]),

--- a/ports/esp8266/machine_adc.c
+++ b/ports/esp8266/machine_adc.c
@@ -64,7 +64,7 @@ mp_obj_t machine_adc_make_new(const mp_obj_type_t *type_in, size_t n_args, size_
     case 1:
         return &machine_adc_vdd3;
     default:
-        nlr_raise(mp_obj_new_exception_msg_varg(&mp_type_ValueError, "ADC(%d) doesn't exist", chn));
+        mp_raise_msg_varg(&mp_type_ValueError, "ADC(%d) doesn't exist", chn);
     }
 }
 

--- a/ports/esp8266/machine_pwm.c
+++ b/ports/esp8266/machine_pwm.c
@@ -65,8 +65,7 @@ STATIC void pyb_pwm_init_helper(pyb_pwm_obj_t *self, size_t n_args, const mp_obj
 
     int channel = pwm_add(self->pin->phys_port, self->pin->periph, self->pin->func);
     if (channel == -1) {
-        nlr_raise(mp_obj_new_exception_msg_varg(&mp_type_ValueError,
-            "PWM not supported on pin %d", self->pin->phys_port));
+        mp_raise_msg_varg(&mp_type_ValueError, "PWM not supported on pin %d", self->pin->phys_port);
     }
 
     self->channel = channel;

--- a/ports/esp8266/machine_uart.c
+++ b/ports/esp8266/machine_uart.c
@@ -198,7 +198,7 @@ STATIC mp_obj_t pyb_uart_make_new(const mp_obj_type_t *type, size_t n_args, size
     // get uart id
     mp_int_t uart_id = mp_obj_get_int(args[0]);
     if (uart_id != 0 && uart_id != 1) {
-        nlr_raise(mp_obj_new_exception_msg_varg(&mp_type_ValueError, "UART(%d) does not exist", uart_id));
+        mp_raise_msg_varg(&mp_type_ValueError, "UART(%d) does not exist", uart_id);
     }
 
     // create instance

--- a/ports/esp8266/modesp.c
+++ b/ports/esp8266/modesp.c
@@ -288,8 +288,8 @@ void *esp_native_code_commit(void *buf, size_t len, void *reloc) {
 
     len = (len + 3) & ~3;
     if (esp_native_code_cur + len > esp_native_code_end) {
-        nlr_raise(mp_obj_new_exception_msg_varg(&mp_type_MemoryError,
-            "memory allocation failed, allocating %u bytes for native code", (uint)len));
+        mp_raise_msg_varg(&mp_type_MemoryError,
+            "memory allocation failed, allocating %u bytes for native code", (uint)len);
     }
 
     void *dest;

--- a/ports/esp8266/modutime.c
+++ b/ports/esp8266/modutime.c
@@ -88,7 +88,7 @@ STATIC mp_obj_t time_mktime(mp_obj_t tuple) {
 
     // localtime generates a tuple of len 8. CPython uses 9, so we accept both.
     if (len < 8 || len > 9) {
-        nlr_raise(mp_obj_new_exception_msg_varg(&mp_type_TypeError, "mktime needs a tuple of length 8 or 9 (%d given)", len));
+        mp_raise_msg_varg(&mp_type_TypeError, "mktime needs a tuple of length 8 or 9 (%d given)", len);
     }
 
     return mp_obj_new_int_from_uint(timeutils_mktime(mp_obj_get_int(elem[0]),

--- a/ports/nrf/drivers/bluetooth/ble_drv.c
+++ b/ports/nrf/drivers/bluetooth/ble_drv.c
@@ -606,13 +606,13 @@ bool ble_drv_advertise_data(ubluepy_advertise_data_t * p_adv_params) {
 
 #if (BLUETOOTH_SD == 110)
     if ((err_code = sd_ble_gap_adv_data_set(adv_data, byte_pos, NULL, 0)) != 0) {
-        nlr_raise(mp_obj_new_exception_msg_varg(&mp_type_OSError,
-                  "Can not apply advertisment data. status: 0x" HEX2_FMT, (uint16_t)err_code));
+        mp_raise_msg_varg(&mp_type_OSError,
+            "Can not apply advertisment data. status: 0x" HEX2_FMT, (uint16_t)err_code);
     }
 #else
     if ((err_code = sd_ble_gap_adv_set_configure(&m_adv_handle, &m_adv_data, &m_adv_params)) != 0) {
-        nlr_raise(mp_obj_new_exception_msg_varg(&mp_type_OSError,
-                  "Can not apply advertisment data. status: 0x" HEX2_FMT, (uint16_t)err_code));
+        mp_raise_msg_varg(&mp_type_OSError,
+            "Can not apply advertisment data. status: 0x" HEX2_FMT, (uint16_t)err_code);
     }
 #endif
     BLE_DRIVER_LOG("Set Adv data size: " UINT_FMT "\n", byte_pos);
@@ -626,8 +626,8 @@ bool ble_drv_advertise_data(ubluepy_advertise_data_t * p_adv_params) {
     err_code = sd_ble_gap_adv_start(m_adv_handle, conf_tag);
 #endif
     if (err_code != 0) {
-        nlr_raise(mp_obj_new_exception_msg_varg(&mp_type_OSError,
-                  "Can not start advertisment. status: 0x" HEX2_FMT, (uint16_t)err_code));
+        mp_raise_msg_varg(&mp_type_OSError,
+            "Can not start advertisment. status: 0x" HEX2_FMT, (uint16_t)err_code);
     }
 
     m_adv_in_progress = true;
@@ -641,13 +641,13 @@ void ble_drv_advertise_stop(void) {
 
 #if (BLUETOOTH_SD == 110)
         if ((err_code = sd_ble_gap_adv_stop()) != 0) {
-            nlr_raise(mp_obj_new_exception_msg_varg(&mp_type_OSError,
-                      "Can not stop advertisment. status: 0x" HEX2_FMT, (uint16_t)err_code));
+            mp_raise_msg_varg(&mp_type_OSError,
+                "Can not stop advertisment. status: 0x" HEX2_FMT, (uint16_t)err_code);
         }
 #else
         if ((err_code = sd_ble_gap_adv_stop(m_adv_handle)) != 0) {
-            nlr_raise(mp_obj_new_exception_msg_varg(&mp_type_OSError,
-                      "Can not stop advertisment. status: 0x" HEX2_FMT, (uint16_t)err_code));
+            mp_raise_msg_varg(&mp_type_OSError,
+                "Can not stop advertisment. status: 0x" HEX2_FMT, (uint16_t)err_code);
         }
 #endif
     }
@@ -666,8 +666,8 @@ void ble_drv_attr_s_read(uint16_t conn_handle, uint16_t handle, uint16_t len, ui
                                                handle,
                                                &gatts_value);
     if (err_code != 0) {
-        nlr_raise(mp_obj_new_exception_msg_varg(&mp_type_OSError,
-                  "Can not read attribute value. status: 0x" HEX2_FMT, (uint16_t)err_code));
+        mp_raise_msg_varg(&mp_type_OSError,
+            "Can not read attribute value. status: 0x" HEX2_FMT, (uint16_t)err_code);
     }
 
 }
@@ -683,8 +683,8 @@ void ble_drv_attr_s_write(uint16_t conn_handle, uint16_t handle, uint16_t len, u
     uint32_t err_code = sd_ble_gatts_value_set(conn_handle, handle, &gatts_value);
 
     if (err_code != 0) {
-        nlr_raise(mp_obj_new_exception_msg_varg(&mp_type_OSError,
-                  "Can not write attribute value. status: 0x" HEX2_FMT, (uint16_t)err_code));
+        mp_raise_msg_varg(&mp_type_OSError,
+            "Can not write attribute value. status: 0x" HEX2_FMT, (uint16_t)err_code);
     }
 }
 
@@ -707,8 +707,8 @@ void ble_drv_attr_s_notify(uint16_t conn_handle, uint16_t handle, uint16_t len, 
     BLE_DRIVER_LOG("Request TX, m_tx_in_progress: %u\n", m_tx_in_progress);
     uint32_t err_code;
     if ((err_code = sd_ble_gatts_hvx(conn_handle, &hvx_params)) != 0) {
-        nlr_raise(mp_obj_new_exception_msg_varg(&mp_type_OSError,
-                  "Can not notify attribute value. status: 0x" HEX2_FMT, (uint16_t)err_code));
+        mp_raise_msg_varg(&mp_type_OSError,
+            "Can not notify attribute value. status: 0x" HEX2_FMT, (uint16_t)err_code);
     }
     m_tx_in_progress++;
     BLE_DRIVER_LOG("Queued TX, m_tx_in_progress: %u\n", m_tx_in_progress);
@@ -746,8 +746,8 @@ void ble_drv_attr_c_read(uint16_t conn_handle, uint16_t handle, mp_obj_t obj, bl
                                           handle,
                                           0);
     if (err_code != 0) {
-        nlr_raise(mp_obj_new_exception_msg_varg(&mp_type_OSError,
-                  "Can not read attribute value. status: 0x" HEX2_FMT, (uint16_t)err_code));
+        mp_raise_msg_varg(&mp_type_OSError,
+            "Can not read attribute value. status: 0x" HEX2_FMT, (uint16_t)err_code);
     }
 
     while (gattc_char_data_handle != NULL) {
@@ -776,8 +776,8 @@ void ble_drv_attr_c_write(uint16_t conn_handle, uint16_t handle, uint16_t len, u
     uint32_t err_code = sd_ble_gattc_write(conn_handle, &write_params);
 
     if (err_code != 0) {
-        nlr_raise(mp_obj_new_exception_msg_varg(&mp_type_OSError,
-            "Can not write attribute value. status: 0x" HEX2_FMT, (uint16_t)err_code));
+        mp_raise_msg_varg(&mp_type_OSError,
+            "Can not write attribute value. status: 0x" HEX2_FMT, (uint16_t)err_code);
     }
 
     while (m_write_done != true) {
@@ -807,8 +807,8 @@ void ble_drv_scan_start(bool cont) {
         p_scan_params = NULL;
     }
     if ((err_code = sd_ble_gap_scan_start(p_scan_params, &scan_buffer)) != 0) {
-        nlr_raise(mp_obj_new_exception_msg_varg(&mp_type_OSError,
-                  "Can not start scanning. status: 0x" HEX2_FMT, (uint16_t)err_code));
+        mp_raise_msg_varg(&mp_type_OSError,
+            "Can not start scanning. status: 0x" HEX2_FMT, (uint16_t)err_code);
     }
 }
 
@@ -853,8 +853,8 @@ void ble_drv_connect(uint8_t * p_addr, uint8_t addr_type) {
                                        &scan_params,
                                        &conn_params,
                                        conn_tag)) != 0) {
-        nlr_raise(mp_obj_new_exception_msg_varg(&mp_type_OSError,
-                  "Can not connect. status: 0x" HEX2_FMT, (uint16_t)err_code));
+        mp_raise_msg_varg(&mp_type_OSError,
+            "Can not connect. status: 0x" HEX2_FMT, (uint16_t)err_code);
     }
 }
 

--- a/ports/nrf/modules/machine/pin.c
+++ b/ports/nrf/modules/machine/pin.c
@@ -375,7 +375,7 @@ STATIC mp_obj_t pin_obj_init_helper(const pin_obj_t *self, mp_uint_t n_args, con
                      NRF_GPIO_PIN_S0S1,
                      NRF_GPIO_PIN_NOSENSE);
     } else {
-        nlr_raise(mp_obj_new_exception_msg_varg(&mp_type_ValueError, "invalid pin mode: %d", mode));
+        mp_raise_msg_varg(&mp_type_ValueError, "invalid pin mode: %d", mode);
     }
 
     return mp_const_none;

--- a/ports/pic16bit/modpybled.c
+++ b/ports/pic16bit/modpybled.c
@@ -50,7 +50,7 @@ STATIC mp_obj_t pyb_led_make_new(const mp_obj_type_t *type, size_t n_args, size_
     mp_arg_check_num(n_args, n_kw, 1, 1, false);
     mp_int_t led_id = mp_obj_get_int(args[0]);
     if (!(1 <= led_id && led_id <= NUM_LED)) {
-        nlr_raise(mp_obj_new_exception_msg_varg(&mp_type_ValueError, "LED %d does not exist", led_id));
+        mp_raise_msg_varg(&mp_type_ValueError, "LED %d does not exist", led_id);
     }
     return (mp_obj_t)&pyb_led_obj[led_id - 1];
 }

--- a/ports/pic16bit/modpybswitch.c
+++ b/ports/pic16bit/modpybswitch.c
@@ -49,7 +49,7 @@ STATIC mp_obj_t pyb_switch_make_new(const mp_obj_type_t *type, size_t n_args, si
     mp_arg_check_num(n_args, n_kw, 1, 1, false);
     mp_int_t sw_id = mp_obj_get_int(args[0]);
     if (!(1 <= sw_id && sw_id <= NUM_SWITCH)) {
-        nlr_raise(mp_obj_new_exception_msg_varg(&mp_type_ValueError, "Switch %d does not exist", sw_id));
+        mp_raise_msg_varg(&mp_type_ValueError, "Switch %d does not exist", sw_id);
     }
     return (mp_obj_t)&pyb_switch_obj[sw_id - 1];
 }

--- a/ports/stm32/adc.c
+++ b/ports/stm32/adc.c
@@ -306,7 +306,7 @@ STATIC void adc_init_single(pyb_obj_adc_t *adc_obj) {
     multimode.Mode = ADC_MODE_INDEPENDENT;
     if (HAL_ADCEx_MultiModeConfigChannel(&adc_obj->handle, &multimode) != HAL_OK)
     {
-        nlr_raise(mp_obj_new_exception_msg_varg(&mp_type_ValueError, "Can not set multimode on ADC1 channel: %d", adc_obj->channel));
+        mp_raise_msg_varg(&mp_type_ValueError, "Can not set multimode on ADC1 channel: %d", adc_obj->channel);
     }
 #endif
 }
@@ -414,21 +414,20 @@ STATIC mp_obj_t adc_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_
         const pin_obj_t *pin = pin_find(pin_obj);
         if ((pin->adc_num & PIN_ADC_MASK) == 0) {
             // No ADC1 function on that pin
-            nlr_raise(mp_obj_new_exception_msg_varg(&mp_type_ValueError, "pin %q does not have ADC capabilities", pin->name));
+            mp_raise_msg_varg(&mp_type_ValueError, "pin %q does not have ADC capabilities", pin->name);
         }
         channel = pin->adc_channel;
     }
 
     if (!is_adcx_channel(channel)) {
-        nlr_raise(mp_obj_new_exception_msg_varg(&mp_type_ValueError, "not a valid ADC Channel: %d", channel));
+        mp_raise_msg_varg(&mp_type_ValueError, "not a valid ADC Channel: %d", channel);
     }
 
 
     if (ADC_FIRST_GPIO_CHANNEL <= channel && channel <= ADC_LAST_GPIO_CHANNEL) {
         // these channels correspond to physical GPIO ports so make sure they exist
         if (pin_adc_table[channel] == NULL) {
-            nlr_raise(mp_obj_new_exception_msg_varg(&mp_type_ValueError,
-                "channel %d not available on this board", channel));
+            mp_raise_msg_varg(&mp_type_ValueError, "channel %d not available on this board", channel);
         }
     }
 
@@ -700,8 +699,7 @@ void adc_init_all(pyb_adc_all_obj_t *adc_all, uint32_t resolution, uint32_t en_m
         case 16: resolution = ADC_RESOLUTION_16B; break;
         #endif
         default:
-            nlr_raise(mp_obj_new_exception_msg_varg(&mp_type_ValueError,
-                "resolution %d not supported", resolution));
+            mp_raise_msg_varg(&mp_type_ValueError, "resolution %d not supported", resolution);
     }
 
     for (uint32_t channel = ADC_FIRST_GPIO_CHANNEL; channel <= ADC_LAST_GPIO_CHANNEL; ++channel) {

--- a/ports/stm32/dac.c
+++ b/ports/stm32/dac.c
@@ -307,7 +307,7 @@ STATIC mp_obj_t pyb_dac_make_new(const mp_obj_type_t *type, size_t n_args, size_
         } else if (pin == pin_A5) {
             dac_id = 2;
         } else {
-            nlr_raise(mp_obj_new_exception_msg_varg(&mp_type_ValueError, "Pin(%q) doesn't have DAC capabilities", pin->name));
+            mp_raise_msg_varg(&mp_type_ValueError, "Pin(%q) doesn't have DAC capabilities", pin->name);
         }
     }
 
@@ -319,7 +319,7 @@ STATIC mp_obj_t pyb_dac_make_new(const mp_obj_type_t *type, size_t n_args, size_
         dac_channel = DAC_CHANNEL_2;
     #endif
     } else {
-        nlr_raise(mp_obj_new_exception_msg_varg(&mp_type_ValueError, "DAC(%d) doesn't exist", dac_id));
+        mp_raise_msg_varg(&mp_type_ValueError, "DAC(%d) doesn't exist", dac_id);
     }
 
     pyb_dac_obj_t *dac = &pyb_dac_obj[dac_id - 1];

--- a/ports/stm32/extint.c
+++ b/ports/stm32/extint.c
@@ -207,10 +207,10 @@ uint extint_register(mp_obj_t pin_obj, uint32_t mode, uint32_t pull, mp_obj_t ca
         // get both the port number and line number.
         v_line = mp_obj_get_int(pin_obj);
         if (v_line < 16) {
-            nlr_raise(mp_obj_new_exception_msg_varg(&mp_type_ValueError, "ExtInt vector %d < 16, use a Pin object", v_line));
+            mp_raise_msg_varg(&mp_type_ValueError, "ExtInt vector %d < 16, use a Pin object", v_line);
         }
         if (v_line >= EXTI_NUM_VECTORS) {
-            nlr_raise(mp_obj_new_exception_msg_varg(&mp_type_ValueError, "ExtInt vector %d >= max of %d", v_line, EXTI_NUM_VECTORS));
+            mp_raise_msg_varg(&mp_type_ValueError, "ExtInt vector %d >= max of %d", v_line, EXTI_NUM_VECTORS);
         }
     } else {
         pin = pin_find(pin_obj);
@@ -222,17 +222,17 @@ uint extint_register(mp_obj_t pin_obj, uint32_t mode, uint32_t pull, mp_obj_t ca
         mode != GPIO_MODE_EVT_RISING &&
         mode != GPIO_MODE_EVT_FALLING &&
         mode != GPIO_MODE_EVT_RISING_FALLING) {
-        nlr_raise(mp_obj_new_exception_msg_varg(&mp_type_ValueError, "invalid ExtInt Mode: %d", mode));
+        mp_raise_msg_varg(&mp_type_ValueError, "invalid ExtInt Mode: %d", mode);
     }
     if (pull != GPIO_NOPULL &&
         pull != GPIO_PULLUP &&
         pull != GPIO_PULLDOWN) {
-        nlr_raise(mp_obj_new_exception_msg_varg(&mp_type_ValueError, "invalid ExtInt Pull: %d", pull));
+        mp_raise_msg_varg(&mp_type_ValueError, "invalid ExtInt Pull: %d", pull);
     }
 
     mp_obj_t *cb = &MP_STATE_PORT(pyb_extint_callback)[v_line];
     if (!override_callback_obj && *cb != mp_const_none && callback_obj != mp_const_none) {
-        nlr_raise(mp_obj_new_exception_msg_varg(&mp_type_ValueError, "ExtInt vector %d is already in use", v_line));
+        mp_raise_msg_varg(&mp_type_ValueError, "ExtInt vector %d is already in use", v_line);
     }
 
     // We need to update callback atomically, so we disable the line
@@ -279,12 +279,11 @@ void extint_register_pin(const pin_obj_t *pin, uint32_t mode, bool hard_irq, mp_
     mp_obj_t *cb = &MP_STATE_PORT(pyb_extint_callback)[line];
     if (*cb != mp_const_none && MP_OBJ_FROM_PTR(pin) != pyb_extint_callback_arg[line]) {
         if (mp_obj_is_small_int(pyb_extint_callback_arg[line])) {
-            nlr_raise(mp_obj_new_exception_msg_varg(&mp_type_OSError,
-                "ExtInt vector %d is already in use", line));
+            mp_raise_msg_varg(&mp_type_OSError, "ExtInt vector %d is already in use", line);
         } else {
             const pin_obj_t *other_pin = MP_OBJ_TO_PTR(pyb_extint_callback_arg[line]);
-            nlr_raise(mp_obj_new_exception_msg_varg(&mp_type_OSError,
-                "IRQ resource already taken by Pin('%q')", other_pin->name));
+            mp_raise_msg_varg(&mp_type_OSError,
+                "IRQ resource already taken by Pin('%q')", other_pin->name);
         }
     }
 

--- a/ports/stm32/lcd.c
+++ b/ports/stm32/lcd.c
@@ -218,7 +218,7 @@ STATIC mp_obj_t pyb_lcd_make_new(const mp_obj_type_t *type, size_t n_args, size_
         lcd->pin_a0 = pyb_pin_Y5;
         lcd->pin_bl = pyb_pin_Y12;
     } else {
-        nlr_raise(mp_obj_new_exception_msg_varg(&mp_type_ValueError, "LCD(%s) doesn't exist", lcd_id));
+        mp_raise_msg_varg(&mp_type_ValueError, "LCD(%s) doesn't exist", lcd_id);
     }
 
     // init the SPI bus

--- a/ports/stm32/led.c
+++ b/ports/stm32/led.c
@@ -297,7 +297,7 @@ STATIC mp_obj_t led_obj_make_new(const mp_obj_type_t *type, size_t n_args, size_
 
     // check led number
     if (!(1 <= led_id && led_id <= NUM_LEDS)) {
-        nlr_raise(mp_obj_new_exception_msg_varg(&mp_type_ValueError, "LED(%d) doesn't exist", led_id));
+        mp_raise_msg_varg(&mp_type_ValueError, "LED(%d) doesn't exist", led_id);
     }
 
     // return static led object

--- a/ports/stm32/machine_adc.c
+++ b/ports/stm32/machine_adc.c
@@ -403,7 +403,7 @@ STATIC mp_obj_t machine_adc_make_new(const mp_obj_type_t *type, size_t n_args, s
         #endif
         } else {
             // No ADC function on given pin
-            nlr_raise(mp_obj_new_exception_msg_varg(&mp_type_ValueError, "Pin(%q) does not have ADC capabilities", pin->name));
+            mp_raise_msg_varg(&mp_type_ValueError, "Pin(%q) does not have ADC capabilities", pin->name);
         }
         channel = pin->adc_channel;
 

--- a/ports/stm32/machine_i2c.c
+++ b/ports/stm32/machine_i2c.c
@@ -231,15 +231,13 @@ mp_obj_t machine_hard_i2c_make_new(const mp_obj_type_t *type, size_t n_args, siz
             i2c_id = 4;
         #endif
         } else {
-            nlr_raise(mp_obj_new_exception_msg_varg(&mp_type_ValueError,
-                "I2C(%s) doesn't exist", port));
+            mp_raise_msg_varg(&mp_type_ValueError, "I2C(%s) doesn't exist", port);
         }
     } else {
         i2c_id = mp_obj_get_int(args[ARG_id].u_obj);
         if (i2c_id < 1 || i2c_id > MP_ARRAY_SIZE(machine_hard_i2c_obj)
             || machine_hard_i2c_obj[i2c_id - 1].base.type == NULL) {
-            nlr_raise(mp_obj_new_exception_msg_varg(&mp_type_ValueError,
-                "I2C(%d) doesn't exist", i2c_id));
+            mp_raise_msg_varg(&mp_type_ValueError, "I2C(%d) doesn't exist", i2c_id);
         }
     }
 

--- a/ports/stm32/machine_uart.c
+++ b/ports/stm32/machine_uart.c
@@ -281,7 +281,7 @@ STATIC mp_obj_t pyb_uart_init_helper(pyb_uart_obj_t *self, size_t n_args, const 
 
     // init UART (if it fails, it's because the port doesn't exist)
     if (!uart_init(self, baudrate, bits, parity, stop, flow)) {
-        nlr_raise(mp_obj_new_exception_msg_varg(&mp_type_ValueError, "UART(%d) doesn't exist", self->uart_id));
+        mp_raise_msg_varg(&mp_type_ValueError, "UART(%d) doesn't exist", self->uart_id);
     }
 
     // set timeout
@@ -323,7 +323,7 @@ STATIC mp_obj_t pyb_uart_init_helper(pyb_uart_obj_t *self, size_t n_args, const 
         baudrate_diff = baudrate - actual_baudrate;
     }
     if (20 * baudrate_diff > actual_baudrate) {
-        nlr_raise(mp_obj_new_exception_msg_varg(&mp_type_ValueError, "set baudrate %d is not within 5%% of desired value", actual_baudrate));
+        mp_raise_msg_varg(&mp_type_ValueError, "set baudrate %d is not within 5%% of desired value", actual_baudrate);
     }
 
     return mp_const_none;
@@ -394,12 +394,12 @@ STATIC mp_obj_t pyb_uart_make_new(const mp_obj_type_t *type, size_t n_args, size
             uart_id = PYB_UART_10;
         #endif
         } else {
-            nlr_raise(mp_obj_new_exception_msg_varg(&mp_type_ValueError, "UART(%s) doesn't exist", port));
+            mp_raise_msg_varg(&mp_type_ValueError, "UART(%s) doesn't exist", port);
         }
     } else {
         uart_id = mp_obj_get_int(args[0]);
         if (!uart_exists(uart_id)) {
-            nlr_raise(mp_obj_new_exception_msg_varg(&mp_type_ValueError, "UART(%d) doesn't exist", uart_id));
+            mp_raise_msg_varg(&mp_type_ValueError, "UART(%d) doesn't exist", uart_id);
         }
     }
 
@@ -520,7 +520,7 @@ STATIC mp_obj_t pyb_uart_irq(size_t n_args, const mp_obj_t *pos_args, mp_map_t *
         mp_uint_t trigger = args[MP_IRQ_ARG_INIT_trigger].u_int;
         mp_uint_t not_supported = trigger & ~mp_irq_allowed;
         if (trigger != 0 && not_supported) {
-            nlr_raise(mp_obj_new_exception_msg_varg(&mp_type_ValueError, "trigger 0x%08x unsupported", not_supported));
+            mp_raise_msg_varg(&mp_type_ValueError, "trigger 0x%08x unsupported", not_supported);
         }
 
         // Reconfigure user IRQs

--- a/ports/stm32/modnwcc3k.c
+++ b/ports/stm32/modnwcc3k.c
@@ -495,7 +495,7 @@ STATIC mp_obj_t cc3k_connect(size_t n_args, const mp_obj_t *pos_args, mp_map_t *
 
     // connect to AP
     if (wlan_connect(sec, (char*)ssid, ssid_len, (uint8_t*)bssid, (uint8_t*)key, key_len) != 0) {
-        nlr_raise(mp_obj_new_exception_msg_varg(&mp_type_OSError, "could not connect to ssid=%s, sec=%d, key=%s\n", ssid, sec, key));
+        mp_raise_msg_varg(&mp_type_OSError, "could not connect to ssid=%s, sec=%d, key=%s\n", ssid, sec, key);
     }
 
     return mp_const_none;

--- a/ports/stm32/modutime.c
+++ b/ports/stm32/modutime.c
@@ -106,7 +106,7 @@ STATIC mp_obj_t time_mktime(mp_obj_t tuple) {
 
     // localtime generates a tuple of len 8. CPython uses 9, so we accept both.
     if (len < 8 || len > 9) {
-        nlr_raise(mp_obj_new_exception_msg_varg(&mp_type_TypeError, "mktime needs a tuple of length 8 or 9 (%d given)", len));
+        mp_raise_msg_varg(&mp_type_TypeError, "mktime needs a tuple of length 8 or 9 (%d given)", len);
     }
 
     return mp_obj_new_int_from_uint(timeutils_mktime(mp_obj_get_int(elem[0]),

--- a/ports/stm32/pin.c
+++ b/ports/stm32/pin.c
@@ -176,7 +176,7 @@ const pin_obj_t *pin_find(mp_obj_t user_obj) {
         return pin_obj;
     }
 
-    nlr_raise(mp_obj_new_exception_msg_varg(&mp_type_ValueError, "Pin(%s) doesn't exist", mp_obj_str_get_str(user_obj)));
+    mp_raise_msg_varg(&mp_type_ValueError, "Pin(%s) doesn't exist", mp_obj_str_get_str(user_obj));
 }
 
 /// \method __str__()
@@ -342,7 +342,7 @@ STATIC mp_obj_t pin_obj_init_helper(const pin_obj_t *self, size_t n_args, const 
     // get io mode
     uint mode = args[0].u_int;
     if (!IS_GPIO_MODE(mode)) {
-        nlr_raise(mp_obj_new_exception_msg_varg(&mp_type_ValueError, "invalid pin mode: %d", mode));
+        mp_raise_msg_varg(&mp_type_ValueError, "invalid pin mode: %d", mode);
     }
 
     // get pull mode
@@ -351,7 +351,7 @@ STATIC mp_obj_t pin_obj_init_helper(const pin_obj_t *self, size_t n_args, const 
         pull = mp_obj_get_int(args[1].u_obj);
     }
     if (!IS_GPIO_PULL(pull)) {
-        nlr_raise(mp_obj_new_exception_msg_varg(&mp_type_ValueError, "invalid pin pull: %d", pull));
+        mp_raise_msg_varg(&mp_type_ValueError, "invalid pin pull: %d", pull);
     }
 
     // get af (alternate function); alt-arg overrides af-arg
@@ -360,7 +360,7 @@ STATIC mp_obj_t pin_obj_init_helper(const pin_obj_t *self, size_t n_args, const 
         af = args[2].u_int;
     }
     if ((mode == GPIO_MODE_AF_PP || mode == GPIO_MODE_AF_OD) && !IS_GPIO_AF(af)) {
-        nlr_raise(mp_obj_new_exception_msg_varg(&mp_type_ValueError, "invalid pin af: %d", af));
+        mp_raise_msg_varg(&mp_type_ValueError, "invalid pin af: %d", af);
     }
 
     // enable the peripheral clock for the port of this pin

--- a/ports/stm32/pyb_can.c
+++ b/ports/stm32/pyb_can.c
@@ -156,7 +156,7 @@ STATIC mp_obj_t pyb_can_init_helper(pyb_can_obj_t *self, size_t n_args, const mp
     // init CAN (if it fails, it's because the port doesn't exist)
     if (!can_init(self, args[ARG_mode].u_int, args[ARG_prescaler].u_int, args[ARG_sjw].u_int,
         args[ARG_bs1].u_int, args[ARG_bs2].u_int, args[ARG_auto_restart].u_bool)) {
-        nlr_raise(mp_obj_new_exception_msg_varg(&mp_type_ValueError, "CAN(%d) doesn't exist", self->can_id));
+        mp_raise_msg_varg(&mp_type_ValueError, "CAN(%d) doesn't exist", self->can_id);
     }
 
     return mp_const_none;
@@ -185,13 +185,13 @@ STATIC mp_obj_t pyb_can_make_new(const mp_obj_type_t *type, size_t n_args, size_
             can_idx = PYB_CAN_3;
         #endif
         } else {
-            nlr_raise(mp_obj_new_exception_msg_varg(&mp_type_ValueError, "CAN(%s) doesn't exist", port));
+            mp_raise_msg_varg(&mp_type_ValueError, "CAN(%s) doesn't exist", port);
         }
     } else {
         can_idx = mp_obj_get_int(args[0]);
     }
     if (can_idx < 1 || can_idx > MP_ARRAY_SIZE(MP_STATE_PORT(pyb_can_obj_all))) {
-        nlr_raise(mp_obj_new_exception_msg_varg(&mp_type_ValueError, "CAN(%d) doesn't exist", can_idx));
+        mp_raise_msg_varg(&mp_type_ValueError, "CAN(%d) doesn't exist", can_idx);
     }
 
     pyb_can_obj_t *self;

--- a/ports/stm32/pyb_i2c.c
+++ b/ports/stm32/pyb_i2c.c
@@ -200,8 +200,7 @@ STATIC void i2c_set_baudrate(I2C_InitTypeDef *init, uint32_t baudrate) {
             return;
         }
     }
-    nlr_raise(mp_obj_new_exception_msg_varg(&mp_type_ValueError,
-                                            "Unsupported I2C baudrate: %u", baudrate));
+    mp_raise_msg_varg(&mp_type_ValueError, "Unsupported I2C baudrate: %u", baudrate);
 }
 
 uint32_t pyb_i2c_get_baudrate(I2C_HandleTypeDef *i2c) {
@@ -680,15 +679,13 @@ STATIC mp_obj_t pyb_i2c_make_new(const mp_obj_type_t *type, size_t n_args, size_
             i2c_id = 4;
         #endif
         } else {
-            nlr_raise(mp_obj_new_exception_msg_varg(&mp_type_ValueError,
-                "I2C(%s) doesn't exist", port));
+            mp_raise_msg_varg(&mp_type_ValueError, "I2C(%s) doesn't exist", port);
         }
     } else {
         i2c_id = mp_obj_get_int(args[0]);
         if (i2c_id < 1 || i2c_id > MP_ARRAY_SIZE(pyb_i2c_obj)
             || pyb_i2c_obj[i2c_id - 1].i2c == NULL) {
-            nlr_raise(mp_obj_new_exception_msg_varg(&mp_type_ValueError,
-                "I2C(%d) doesn't exist", i2c_id));
+            mp_raise_msg_varg(&mp_type_ValueError, "I2C(%d) doesn't exist", i2c_id);
         }
     }
 

--- a/ports/stm32/sdcard.c
+++ b/ports/stm32/sdcard.c
@@ -768,7 +768,7 @@ STATIC mp_obj_t sd_read(mp_obj_t self, mp_obj_t block_num) {
 
     if (ret != 0) {
         m_del(uint8_t, dest, SDCARD_BLOCK_SIZE);
-        nlr_raise(mp_obj_new_exception_msg_varg(&mp_type_Exception, "sdcard_read_blocks failed [%u]", ret));
+        mp_raise_msg_varg(&mp_type_Exception, "sdcard_read_blocks failed [%u]", ret);
     }
 
     return mp_obj_new_bytearray_by_ref(SDCARD_BLOCK_SIZE, dest);
@@ -780,13 +780,13 @@ STATIC mp_obj_t sd_write(mp_obj_t self, mp_obj_t block_num, mp_obj_t data) {
     mp_buffer_info_t bufinfo;
     mp_get_buffer_raise(data, &bufinfo, MP_BUFFER_READ);
     if (bufinfo.len % SDCARD_BLOCK_SIZE != 0) {
-        nlr_raise(mp_obj_new_exception_msg_varg(&mp_type_ValueError, "writes must be a multiple of %d bytes", SDCARD_BLOCK_SIZE));
+        mp_raise_msg_varg(&mp_type_ValueError, "writes must be a multiple of %d bytes", SDCARD_BLOCK_SIZE);
     }
 
     mp_uint_t ret = sdcard_write_blocks(bufinfo.buf, mp_obj_get_int(block_num), bufinfo.len / SDCARD_BLOCK_SIZE);
 
     if (ret != 0) {
-        nlr_raise(mp_obj_new_exception_msg_varg(&mp_type_Exception, "sdcard_write_blocks failed [%u]", ret));
+        mp_raise_msg_varg(&mp_type_Exception, "sdcard_write_blocks failed [%u]", ret);
     }
 
     return mp_const_none;

--- a/ports/stm32/servo.c
+++ b/ports/stm32/servo.c
@@ -192,7 +192,7 @@ STATIC mp_obj_t pyb_servo_make_new(const mp_obj_type_t *type, size_t n_args, siz
 
     // check servo number
     if (!(0 <= servo_id && servo_id < PYB_SERVO_NUM)) {
-        nlr_raise(mp_obj_new_exception_msg_varg(&mp_type_ValueError, "Servo(%d) doesn't exist", servo_id + 1));
+        mp_raise_msg_varg(&mp_type_ValueError, "Servo(%d) doesn't exist", servo_id + 1);
     }
 
     // get and init servo object
@@ -250,7 +250,7 @@ STATIC mp_obj_t pyb_servo_calibration(size_t n_args, const mp_obj_t *args) {
     }
 
     // bad number of arguments
-    nlr_raise(mp_obj_new_exception_msg_varg(&mp_type_TypeError, "calibration expecting 1, 4 or 6 arguments, got %d", n_args));
+    mp_raise_msg_varg(&mp_type_TypeError, "calibration expecting 1, 4 or 6 arguments, got %d", n_args);
 }
 STATIC MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(pyb_servo_calibration_obj, 1, 6, pyb_servo_calibration);
 

--- a/ports/stm32/spi.c
+++ b/ports/stm32/spi.c
@@ -172,8 +172,7 @@ int spi_find_index(mp_obj_t id) {
             return 6;
         #endif
         }
-        nlr_raise(mp_obj_new_exception_msg_varg(&mp_type_ValueError,
-            "SPI(%s) doesn't exist", port));
+        mp_raise_msg_varg(&mp_type_ValueError, "SPI(%s) doesn't exist", port);
     } else {
         // given an integer id
         int spi_id = mp_obj_get_int(id);
@@ -181,8 +180,7 @@ int spi_find_index(mp_obj_t id) {
             && spi_obj[spi_id - 1].spi != NULL) {
             return spi_id;
         }
-        nlr_raise(mp_obj_new_exception_msg_varg(&mp_type_ValueError,
-            "SPI(%d) doesn't exist", spi_id));
+        mp_raise_msg_varg(&mp_type_ValueError, "SPI(%d) doesn't exist", spi_id);
     }
 }
 

--- a/ports/stm32/timer.c
+++ b/ports/stm32/timer.c
@@ -628,7 +628,7 @@ STATIC mp_obj_t pyb_timer_init_helper(pyb_timer_obj_t *self, size_t n_args, cons
 
     init->CounterMode = args[ARG_mode].u_int;
     if (!IS_TIM_COUNTER_MODE(init->CounterMode)) {
-        nlr_raise(mp_obj_new_exception_msg_varg(&mp_type_ValueError, "invalid mode (%d)", init->CounterMode));
+        mp_raise_msg_varg(&mp_type_ValueError, "invalid mode (%d)", init->CounterMode);
     }
 
     init->ClockDivision = args[ARG_div].u_int == 2 ? TIM_CLOCKDIVISION_DIV2 :
@@ -845,7 +845,7 @@ STATIC mp_obj_t pyb_timer_make_new(const mp_obj_type_t *type, size_t n_args, siz
 
     // check if the timer exists
     if (tim_id <= 0 || tim_id > MICROPY_HW_MAX_TIMER || tim_instance_table[tim_id - 1] == 0) {
-        nlr_raise(mp_obj_new_exception_msg_varg(&mp_type_ValueError, "Timer(%d) doesn't exist", tim_id));
+        mp_raise_msg_varg(&mp_type_ValueError, "Timer(%d) doesn't exist", tim_id);
     }
 
     pyb_timer_obj_t *tim;
@@ -994,7 +994,7 @@ STATIC mp_obj_t pyb_timer_channel(size_t n_args, const mp_obj_t *pos_args, mp_ma
     mp_int_t channel = mp_obj_get_int(pos_args[1]);
 
     if (channel < 1 || channel > 4) {
-        nlr_raise(mp_obj_new_exception_msg_varg(&mp_type_ValueError, "invalid channel (%d)", channel));
+        mp_raise_msg_varg(&mp_type_ValueError, "invalid channel (%d)", channel);
     }
 
     pyb_timer_channel_obj_t *chan = self->channel;
@@ -1052,7 +1052,7 @@ STATIC mp_obj_t pyb_timer_channel(size_t n_args, const mp_obj_t *pos_args, mp_ma
         const pin_obj_t *pin = MP_OBJ_TO_PTR(pin_obj);
         const pin_af_obj_t *af = pin_find_af(pin, AF_FN_TIM, self->tim_id);
         if (af == NULL) {
-            nlr_raise(mp_obj_new_exception_msg_varg(&mp_type_ValueError, "Pin(%q) doesn't have an af for Timer(%d)", pin->name, self->tim_id));
+            mp_raise_msg_varg(&mp_type_ValueError, "Pin(%q) doesn't have an af for Timer(%d)", pin->name, self->tim_id);
         }
         // pin.init(mode=AF_PP, af=idx)
         const mp_obj_t args2[6] = {
@@ -1133,7 +1133,7 @@ STATIC mp_obj_t pyb_timer_channel(size_t n_args, const mp_obj_t *pos_args, mp_ma
             #endif
 
             if (!IS_TIM_OC_POLARITY(oc_config.OCPolarity)) {
-                nlr_raise(mp_obj_new_exception_msg_varg(&mp_type_ValueError, "invalid polarity (%d)", oc_config.OCPolarity));
+                mp_raise_msg_varg(&mp_type_ValueError, "invalid polarity (%d)", oc_config.OCPolarity);
             }
             HAL_TIM_OC_ConfigChannel(&self->tim, &oc_config, TIMER_CHANNEL(chan));
             if (chan->callback == mp_const_none) {
@@ -1162,7 +1162,7 @@ STATIC mp_obj_t pyb_timer_channel(size_t n_args, const mp_obj_t *pos_args, mp_ma
             ic_config.ICFilter    = 0;
 
             if (!IS_TIM_IC_POLARITY(ic_config.ICPolarity)) {
-                nlr_raise(mp_obj_new_exception_msg_varg(&mp_type_ValueError, "invalid polarity (%d)", ic_config.ICPolarity));
+                mp_raise_msg_varg(&mp_type_ValueError, "invalid polarity (%d)", ic_config.ICPolarity);
             }
             HAL_TIM_IC_ConfigChannel(&self->tim, &ic_config, TIMER_CHANNEL(chan));
             if (chan->callback == mp_const_none) {
@@ -1192,7 +1192,7 @@ STATIC mp_obj_t pyb_timer_channel(size_t n_args, const mp_obj_t *pos_args, mp_ma
             enc_config.IC2Filter    = 0;
 
             if (!IS_TIM_IC_POLARITY(enc_config.IC1Polarity)) {
-                nlr_raise(mp_obj_new_exception_msg_varg(&mp_type_ValueError, "invalid polarity (%d)", enc_config.IC1Polarity));
+                mp_raise_msg_varg(&mp_type_ValueError, "invalid polarity (%d)", enc_config.IC1Polarity);
             }
             // Only Timers 1, 2, 3, 4, 5, and 8 support encoder mode
             if (
@@ -1214,7 +1214,7 @@ STATIC mp_obj_t pyb_timer_channel(size_t n_args, const mp_obj_t *pos_args, mp_ma
             &&  self->tim.Instance != TIM8
             #endif
             ) {
-                nlr_raise(mp_obj_new_exception_msg_varg(&mp_type_ValueError, "encoder not supported on timer %d", self->tim_id));
+                mp_raise_msg_varg(&mp_type_ValueError, "encoder not supported on timer %d", self->tim_id);
             }
 
             // Disable & clear the timer interrupt so that we don't trigger
@@ -1231,7 +1231,7 @@ STATIC mp_obj_t pyb_timer_channel(size_t n_args, const mp_obj_t *pos_args, mp_ma
         }
 
         default:
-            nlr_raise(mp_obj_new_exception_msg_varg(&mp_type_ValueError, "invalid mode (%d)", chan->mode));
+            mp_raise_msg_varg(&mp_type_ValueError, "invalid mode (%d)", chan->mode);
     }
 
     return MP_OBJ_FROM_PTR(chan);

--- a/ports/stm32/wdt.c
+++ b/ports/stm32/wdt.c
@@ -51,7 +51,7 @@ STATIC mp_obj_t pyb_wdt_make_new(const mp_obj_type_t *type, size_t n_args, size_
 
     mp_int_t id = args[ARG_id].u_int;
     if (id != 0) {
-        nlr_raise(mp_obj_new_exception_msg_varg(&mp_type_ValueError, "WDT(%d) doesn't exist", id));
+        mp_raise_msg_varg(&mp_type_ValueError, "WDT(%d) doesn't exist", id);
     }
 
     // timeout is in milliseconds

--- a/ports/teensy/led.c
+++ b/ports/teensy/led.c
@@ -97,7 +97,7 @@ STATIC mp_obj_t led_obj_make_new(const mp_obj_type_t *type, uint n_args, uint n_
 
     // check led number
     if (!(1 <= led_id && led_id <= NUM_LEDS)) {
-        nlr_raise(mp_obj_new_exception_msg_varg(&mp_type_ValueError, "LED %d does not exist", led_id));
+        mp_raise_msg_varg(&mp_type_ValueError, "LED %d does not exist", led_id);
     }
 
     // return static led object

--- a/ports/teensy/main.c
+++ b/ports/teensy/main.c
@@ -169,7 +169,7 @@ mp_obj_t pyb_gpio(int n_args, mp_obj_t *args) {
     return mp_const_none;
 
 pin_error:
-    nlr_raise(mp_obj_new_exception_msg_varg(&mp_type_ValueError, "pin %d does not exist", pin));
+    mp_raise_msg_varg(&mp_type_ValueError, "pin %d does not exist", pin);
 }
 
 MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(pyb_gpio_obj, 1, 2, pyb_gpio);

--- a/ports/teensy/servo.c
+++ b/ports/teensy/servo.c
@@ -70,7 +70,7 @@ static mp_obj_t servo_obj_attach(mp_obj_t self_in, mp_obj_t pin_obj) {
     return mp_const_none;
 
 pin_error:
-    nlr_raise(mp_obj_new_exception_msg_varg(MP_QSTR_ValueError, "pin %d does not exist", pin));
+    mp_raise_msg_varg(MP_QSTR_ValueError, "pin %d does not exist", pin);
 }
 
 static mp_obj_t servo_obj_detach(mp_obj_t self_in) {

--- a/ports/teensy/timer.c
+++ b/ports/teensy/timer.c
@@ -114,7 +114,7 @@ mp_uint_t get_prescaler_shift(mp_int_t prescaler) {
             return prescaler_shift;
         }
     }
-    nlr_raise(mp_obj_new_exception_msg_varg(&mp_type_TypeError, "prescaler must be a power of 2 between 1 and 128, not %d", prescaler));
+    mp_raise_msg_varg(&mp_type_TypeError, "prescaler must be a power of 2 between 1 and 128, not %d", prescaler);
 }
 
 /******************************************************************************/
@@ -273,7 +273,7 @@ STATIC mp_obj_t pyb_timer_init_helper(pyb_timer_obj_t *self, uint n_args, const 
         init->PrescalerShift = get_prescaler_shift(vals[1].u_int);
         init->Period = vals[2].u_int;
         if (!IS_FTM_PERIOD(init->Period)) {
-            nlr_raise(mp_obj_new_exception_msg_varg(&mp_type_TypeError, "period must be between 0 and 65535, not %d", init->Period));
+            mp_raise_msg_varg(&mp_type_TypeError, "period must be between 0 and 65535, not %d", init->Period);
         }
     } else {
         mp_raise_TypeError("must specify either freq, or prescaler and period");
@@ -281,7 +281,7 @@ STATIC mp_obj_t pyb_timer_init_helper(pyb_timer_obj_t *self, uint n_args, const 
 
     init->CounterMode = vals[3].u_int;
     if (!IS_FTM_COUNTERMODE(init->CounterMode)) {
-        nlr_raise(mp_obj_new_exception_msg_varg(&mp_type_TypeError, "invalid counter mode: %d", init->CounterMode));
+        mp_raise_msg_varg(&mp_type_TypeError, "invalid counter mode: %d", init->CounterMode);
     }
 
     // Currently core/mk20dx128.c sets SIM_SCGC6_FTM0, SIM_SCGC6_FTM1, SIM_SCGC3_FTM2
@@ -322,7 +322,7 @@ STATIC mp_obj_t pyb_timer_make_new(const mp_obj_type_t *type, size_t n_args, siz
         case 0: tim->ftm.Instance = FTM0; tim->irqn = IRQ_FTM0; break;
         case 1: tim->ftm.Instance = FTM1; tim->irqn = IRQ_FTM1; break;
         case 2: tim->ftm.Instance = FTM2; tim->irqn = IRQ_FTM2; break;
-        default: nlr_raise(mp_obj_new_exception_msg_varg(&mp_type_ValueError, "Timer %d does not exist", tim->tim_id));
+        default: mp_raise_msg_varg(&mp_type_ValueError, "Timer %d does not exist", tim->tim_id);
     }
 
     if (n_args > 1 || n_kw > 0) {
@@ -444,7 +444,7 @@ STATIC mp_obj_t pyb_timer_channel(size_t n_args, const mp_obj_t *args, mp_map_t 
     mp_int_t channel = mp_obj_get_int(args[1]);
 
     if (channel < 0 || channel > 7) {
-        nlr_raise(mp_obj_new_exception_msg_varg(&mp_type_ValueError, "Invalid channel (%d)", channel));
+        mp_raise_msg_varg(&mp_type_ValueError, "Invalid channel (%d)", channel);
     }
 
     pyb_timer_channel_obj_t *chan = self->channel;
@@ -502,7 +502,7 @@ STATIC mp_obj_t pyb_timer_channel(size_t n_args, const mp_obj_t *args, mp_map_t 
         const pin_obj_t *pin = pin_obj;
         const pin_af_obj_t *af = pin_find_af(pin, AF_FN_FTM, self->tim_id);
         if (af == NULL) {
-            nlr_raise(mp_obj_new_exception_msg_varg(&mp_type_ValueError, "pin %s doesn't have an af for TIM%d", qstr_str(pin->name), self->tim_id));
+            mp_raise_msg_varg(&mp_type_ValueError, "pin %s doesn't have an af for TIM%d", qstr_str(pin->name), self->tim_id);
         }
         // pin.init(mode=AF_PP, af=idx)
         const mp_obj_t args[6] = {
@@ -559,7 +559,7 @@ STATIC mp_obj_t pyb_timer_channel(size_t n_args, const mp_obj_t *args, mp_map_t 
             }
 
             if (!IS_FTM_OC_POLARITY(oc_config.OCPolarity)) {
-                nlr_raise(mp_obj_new_exception_msg_varg(&mp_type_ValueError, "Invalid polarity (%d)", oc_config.OCPolarity));
+                mp_raise_msg_varg(&mp_type_ValueError, "Invalid polarity (%d)", oc_config.OCPolarity);
             }
             HAL_FTM_OC_ConfigChannel(&self->ftm, &oc_config, channel);
             if (chan->callback == mp_const_none) {
@@ -579,7 +579,7 @@ STATIC mp_obj_t pyb_timer_channel(size_t n_args, const mp_obj_t *args, mp_map_t 
             }
 
             if (!IS_FTM_IC_POLARITY(ic_config.ICPolarity)) {
-                nlr_raise(mp_obj_new_exception_msg_varg(&mp_type_ValueError, "Invalid polarity (%d)", ic_config.ICPolarity));
+                mp_raise_msg_varg(&mp_type_ValueError, "Invalid polarity (%d)", ic_config.ICPolarity);
             }
             HAL_FTM_IC_ConfigChannel(&self->ftm, &ic_config, chan->channel);
             if (chan->callback == mp_const_none) {
@@ -591,7 +591,7 @@ STATIC mp_obj_t pyb_timer_channel(size_t n_args, const mp_obj_t *args, mp_map_t 
         }
 
         default:
-            nlr_raise(mp_obj_new_exception_msg_varg(&mp_type_ValueError, "Invalid mode (%d)", chan->mode));
+            mp_raise_msg_varg(&mp_type_ValueError, "Invalid mode (%d)", chan->mode);
     }
 
     return chan;

--- a/ports/teensy/uart.c
+++ b/ports/teensy/uart.c
@@ -283,7 +283,7 @@ STATIC mp_obj_t pyb_uart_init_helper(pyb_uart_obj_t *self, uint n_args, const mp
 
     // init UART (if it fails, it's because the port doesn't exist)
     if (!uart_init2(self)) {
-        nlr_raise(mp_obj_new_exception_msg_varg(&mp_type_ValueError, "UART port %d does not exist", self->uart_id));
+        mp_raise_msg_varg(&mp_type_ValueError, "UART port %d does not exist", self->uart_id);
     }
 #endif
 
@@ -330,7 +330,7 @@ STATIC mp_obj_t pyb_uart_make_new(const mp_obj_type_t *type, uint n_args, uint n
             o->uart_id = PYB_UART_YB;
 #endif
         } else {
-            nlr_raise(mp_obj_new_exception_msg_varg(&mp_type_ValueError, "UART port %s does not exist", port));
+            mp_raise_msg_varg(&mp_type_ValueError, "UART port %s does not exist", port);
         }
     } else {
         o->uart_id = mp_obj_get_int(args[0]);
@@ -406,7 +406,7 @@ STATIC mp_obj_t pyb_uart_send(uint n_args, const mp_obj_t *args, mp_map_t *kw_ar
 
     if (status != HAL_OK) {
         // TODO really need a HardwareError object, or something
-        nlr_raise(mp_obj_new_exception_msg_varg(&mp_type_Exception, "HAL_UART_Transmit failed with code %d", status));
+        mp_raise_msg_varg(&mp_type_Exception, "HAL_UART_Transmit failed with code %d", status);
     }
 #else
     (void)self;
@@ -453,7 +453,7 @@ STATIC mp_obj_t pyb_uart_recv(uint n_args, const mp_obj_t *args, mp_map_t *kw_ar
 
     if (status != HAL_OK) {
         // TODO really need a HardwareError object, or something
-        nlr_raise(mp_obj_new_exception_msg_varg(&mp_type_Exception, "HAL_UART_Receive failed with code %d", status));
+        mp_raise_msg_varg(&mp_type_Exception, "HAL_UART_Receive failed with code %d", status);
     }
 
     // return the received data

--- a/ports/unix/modmachine.c
+++ b/ports/unix/modmachine.c
@@ -49,7 +49,7 @@
 uintptr_t mod_machine_mem_get_addr(mp_obj_t addr_o, uint align) {
     uintptr_t addr = mp_obj_int_get_truncated(addr_o);
     if ((addr & (align - 1)) != 0) {
-        nlr_raise(mp_obj_new_exception_msg_varg(&mp_type_ValueError, "address %08x is not aligned to %d bytes", addr, align));
+        mp_raise_msg_varg(&mp_type_ValueError, "address %08x is not aligned to %d bytes", addr, align);
     }
     #if MICROPY_PLAT_DEV_MEM
     {

--- a/ports/unix/modusocket.c
+++ b/ports/unix/modusocket.c
@@ -580,7 +580,7 @@ STATIC mp_obj_t mod_socket_getaddrinfo(size_t n_args, const mp_obj_t *args) {
 
     if (res != 0) {
         // CPython: socket.gaierror
-        nlr_raise(mp_obj_new_exception_msg_varg(&mp_type_OSError, "[addrinfo error %d]", res));
+        mp_raise_msg_varg(&mp_type_OSError, "[addrinfo error %d]", res);
     }
     assert(addr_list);
 

--- a/py/argcheck.c
+++ b/py/argcheck.c
@@ -50,9 +50,9 @@ void mp_arg_check_num_sig(size_t n_args, size_t n_kw, uint32_t sig) {
             if (MICROPY_ERROR_REPORTING == MICROPY_ERROR_REPORTING_TERSE) {
                 mp_arg_error_terse_mismatch();
             } else {
-                nlr_raise(mp_obj_new_exception_msg_varg(&mp_type_TypeError,
+                mp_raise_msg_varg(&mp_type_TypeError,
                     "function takes %d positional arguments but %d were given",
-                    n_args_min, n_args));
+                    n_args_min, n_args);
             }
         }
     } else {
@@ -60,17 +60,17 @@ void mp_arg_check_num_sig(size_t n_args, size_t n_kw, uint32_t sig) {
             if (MICROPY_ERROR_REPORTING == MICROPY_ERROR_REPORTING_TERSE) {
                 mp_arg_error_terse_mismatch();
             } else {
-                nlr_raise(mp_obj_new_exception_msg_varg(&mp_type_TypeError,
+                mp_raise_msg_varg(&mp_type_TypeError,
                     "function missing %d required positional arguments",
-                    n_args_min - n_args));
+                    n_args_min - n_args);
             }
         } else if (n_args > n_args_max) {
             if (MICROPY_ERROR_REPORTING == MICROPY_ERROR_REPORTING_TERSE) {
                 mp_arg_error_terse_mismatch();
             } else {
-                nlr_raise(mp_obj_new_exception_msg_varg(&mp_type_TypeError,
+                mp_raise_msg_varg(&mp_type_TypeError,
                     "function expected at most %d arguments, got %d",
-                    n_args_max, n_args));
+                    n_args_max, n_args);
             }
         }
     }
@@ -93,8 +93,7 @@ void mp_arg_parse_all(size_t n_pos, const mp_obj_t *pos, mp_map_t *kws, size_t n
                     if (MICROPY_ERROR_REPORTING == MICROPY_ERROR_REPORTING_TERSE) {
                         mp_arg_error_terse_mismatch();
                     } else {
-                        nlr_raise(mp_obj_new_exception_msg_varg(&mp_type_TypeError,
-                            "'%q' argument required", allowed[i].qst));
+                        mp_raise_msg_varg(&mp_type_TypeError, "'%q' argument required", allowed[i].qst);
                     }
                 }
                 out_vals[i] = allowed[i].defval;

--- a/py/bc.c
+++ b/py/bc.c
@@ -83,12 +83,12 @@ STATIC NORETURN void fun_pos_args_mismatch(mp_obj_fun_bc_t *f, size_t expected, 
     mp_arg_error_terse_mismatch();
 #elif MICROPY_ERROR_REPORTING == MICROPY_ERROR_REPORTING_NORMAL
     (void)f;
-    nlr_raise(mp_obj_new_exception_msg_varg(&mp_type_TypeError,
-        "function takes %d positional arguments but %d were given", expected, given));
+    mp_raise_msg_varg(&mp_type_TypeError,
+        "function takes %d positional arguments but %d were given", expected, given);
 #elif MICROPY_ERROR_REPORTING == MICROPY_ERROR_REPORTING_DETAILED
-    nlr_raise(mp_obj_new_exception_msg_varg(&mp_type_TypeError,
+    mp_raise_msg_varg(&mp_type_TypeError,
         "%q() takes %d positional arguments but %d were given",
-        mp_obj_fun_get_name(MP_OBJ_FROM_PTR(f)), expected, given));
+        mp_obj_fun_get_name(MP_OBJ_FROM_PTR(f)), expected, given);
 #endif
 }
 
@@ -203,8 +203,8 @@ void mp_setup_code_state(mp_code_state_t *code_state, size_t n_args, size_t n_kw
             for (size_t j = 0; j < n_pos_args + n_kwonly_args; j++) {
                 if (wanted_arg_name == arg_names[j]) {
                     if (code_state->state[n_state - 1 - j] != MP_OBJ_NULL) {
-                        nlr_raise(mp_obj_new_exception_msg_varg(&mp_type_TypeError,
-                            "function got multiple values for argument '%q'", MP_OBJ_QSTR_VALUE(wanted_arg_name)));
+                        mp_raise_msg_varg(&mp_type_TypeError,
+                            "function got multiple values for argument '%q'", MP_OBJ_QSTR_VALUE(wanted_arg_name));
                     }
                     code_state->state[n_state - 1 - j] = kwargs[2 * i + 1];
                     goto continue2;
@@ -215,8 +215,8 @@ void mp_setup_code_state(mp_code_state_t *code_state, size_t n_args, size_t n_kw
                 if (MICROPY_ERROR_REPORTING == MICROPY_ERROR_REPORTING_TERSE) {
                     mp_raise_TypeError("unexpected keyword argument");
                 } else {
-                    nlr_raise(mp_obj_new_exception_msg_varg(&mp_type_TypeError,
-                        "unexpected keyword argument '%q'", MP_OBJ_QSTR_VALUE(wanted_arg_name)));
+                    mp_raise_msg_varg(&mp_type_TypeError,
+                        "unexpected keyword argument '%q'", MP_OBJ_QSTR_VALUE(wanted_arg_name));
                 }
             }
             mp_obj_dict_store(dict, kwargs[2 * i], kwargs[2 * i + 1]);
@@ -241,8 +241,8 @@ continue2:;
         // Check that all mandatory positional args are specified
         while (d < &code_state->state[n_state]) {
             if (*d++ == MP_OBJ_NULL) {
-                nlr_raise(mp_obj_new_exception_msg_varg(&mp_type_TypeError,
-                    "function missing required positional argument #%d", &code_state->state[n_state] - d));
+                mp_raise_msg_varg(&mp_type_TypeError,
+                    "function missing required positional argument #%d", &code_state->state[n_state] - d);
             }
         }
 
@@ -257,8 +257,8 @@ continue2:;
                 if (elem != NULL) {
                     code_state->state[n_state - 1 - n_pos_args - i] = elem->value;
                 } else {
-                    nlr_raise(mp_obj_new_exception_msg_varg(&mp_type_TypeError,
-                        "function missing required keyword argument '%q'", MP_OBJ_QSTR_VALUE(arg_names[n_pos_args + i])));
+                    mp_raise_msg_varg(&mp_type_TypeError,
+                        "function missing required keyword argument '%q'", MP_OBJ_QSTR_VALUE(arg_names[n_pos_args + i]));
                 }
             }
         }

--- a/py/builtinimport.c
+++ b/py/builtinimport.c
@@ -401,8 +401,7 @@ mp_obj_t mp_builtin___import__(size_t n_args, const mp_obj_t *args) {
                     if (MICROPY_ERROR_REPORTING == MICROPY_ERROR_REPORTING_TERSE) {
                         mp_raise_msg(&mp_type_ImportError, "module not found");
                     } else {
-                        nlr_raise(mp_obj_new_exception_msg_varg(&mp_type_ImportError,
-                            "no module named '%q'", mod_name));
+                        mp_raise_msg_varg(&mp_type_ImportError, "no module named '%q'", mod_name);
                     }
                 }
             } else {
@@ -505,8 +504,7 @@ mp_obj_t mp_builtin___import__(size_t n_args, const mp_obj_t *args) {
     if (MICROPY_ERROR_REPORTING == MICROPY_ERROR_REPORTING_TERSE) {
         mp_raise_msg(&mp_type_ImportError, "module not found");
     } else {
-        nlr_raise(mp_obj_new_exception_msg_varg(&mp_type_ImportError,
-            "no module named '%q'", module_name_qstr));
+        mp_raise_msg_varg(&mp_type_ImportError, "no module named '%q'", module_name_qstr);
     }
 }
 

--- a/py/modbuiltins.c
+++ b/py/modbuiltins.c
@@ -374,8 +374,8 @@ STATIC mp_obj_t mp_builtin_ord(mp_obj_t o_in) {
     if (MICROPY_ERROR_REPORTING == MICROPY_ERROR_REPORTING_TERSE) {
         mp_raise_TypeError("ord expects a character");
     } else {
-        nlr_raise(mp_obj_new_exception_msg_varg(&mp_type_TypeError,
-            "ord() expected a character, but string of length %d found", (int)len));
+        mp_raise_msg_varg(&mp_type_TypeError,
+            "ord() expected a character, but string of length %d found", (int)len);
     }
 }
 MP_DEFINE_CONST_FUN_OBJ_1(mp_builtin_ord_obj, mp_builtin_ord);

--- a/py/obj.c
+++ b/py/obj.c
@@ -362,8 +362,8 @@ mp_float_t mp_obj_get_float(mp_obj_t arg) {
         if (MICROPY_ERROR_REPORTING == MICROPY_ERROR_REPORTING_TERSE) {
             mp_raise_TypeError("can't convert to float");
         } else {
-            nlr_raise(mp_obj_new_exception_msg_varg(&mp_type_TypeError,
-                "can't convert %s to float", mp_obj_get_type_str(arg)));
+            mp_raise_msg_varg(&mp_type_TypeError,
+                "can't convert %s to float", mp_obj_get_type_str(arg));
         }
     }
 
@@ -395,8 +395,8 @@ void mp_obj_get_complex(mp_obj_t arg, mp_float_t *real, mp_float_t *imag) {
         if (MICROPY_ERROR_REPORTING == MICROPY_ERROR_REPORTING_TERSE) {
             mp_raise_TypeError("can't convert to complex");
         } else {
-            nlr_raise(mp_obj_new_exception_msg_varg(&mp_type_TypeError,
-                "can't convert %s to complex", mp_obj_get_type_str(arg)));
+            mp_raise_msg_varg(&mp_type_TypeError,
+                "can't convert %s to complex", mp_obj_get_type_str(arg));
         }
     }
 }
@@ -413,8 +413,8 @@ void mp_obj_get_array(mp_obj_t o, size_t *len, mp_obj_t **items) {
         if (MICROPY_ERROR_REPORTING == MICROPY_ERROR_REPORTING_TERSE) {
             mp_raise_TypeError("expected tuple/list");
         } else {
-            nlr_raise(mp_obj_new_exception_msg_varg(&mp_type_TypeError,
-                "object '%s' isn't a tuple or list", mp_obj_get_type_str(o)));
+            mp_raise_msg_varg(&mp_type_TypeError,
+                "object '%s' isn't a tuple or list", mp_obj_get_type_str(o));
         }
     }
 }
@@ -427,8 +427,8 @@ void mp_obj_get_array_fixed_n(mp_obj_t o, size_t len, mp_obj_t **items) {
         if (MICROPY_ERROR_REPORTING == MICROPY_ERROR_REPORTING_TERSE) {
             mp_raise_ValueError("tuple/list has wrong length");
         } else {
-            nlr_raise(mp_obj_new_exception_msg_varg(&mp_type_ValueError,
-                "requested length %d but object has length %d", (int)len, (int)seq_len));
+            mp_raise_msg_varg(&mp_type_ValueError,
+                "requested length %d but object has length %d", (int)len, (int)seq_len);
         }
     }
 }
@@ -442,9 +442,9 @@ size_t mp_get_index(const mp_obj_type_t *type, size_t len, mp_obj_t index, bool 
         if (MICROPY_ERROR_REPORTING == MICROPY_ERROR_REPORTING_TERSE) {
             mp_raise_TypeError("indices must be integers");
         } else {
-            nlr_raise(mp_obj_new_exception_msg_varg(&mp_type_TypeError,
+            mp_raise_msg_varg(&mp_type_TypeError,
                 "%q indices must be integers, not %s",
-                type->name, mp_obj_get_type_str(index)));
+                type->name, mp_obj_get_type_str(index));
         }
     }
 
@@ -462,8 +462,7 @@ size_t mp_get_index(const mp_obj_type_t *type, size_t len, mp_obj_t index, bool 
             if (MICROPY_ERROR_REPORTING == MICROPY_ERROR_REPORTING_TERSE) {
                 mp_raise_msg(&mp_type_IndexError, "index out of range");
             } else {
-                nlr_raise(mp_obj_new_exception_msg_varg(&mp_type_IndexError,
-                    "%q index out of range", type->name));
+                mp_raise_msg_varg(&mp_type_IndexError, "%q index out of range", type->name);
             }
         }
     }
@@ -497,8 +496,8 @@ mp_obj_t mp_obj_len(mp_obj_t o_in) {
         if (MICROPY_ERROR_REPORTING == MICROPY_ERROR_REPORTING_TERSE) {
             mp_raise_TypeError("object has no len");
         } else {
-            nlr_raise(mp_obj_new_exception_msg_varg(&mp_type_TypeError,
-                "object of type '%s' has no len()", mp_obj_get_type_str(o_in)));
+            mp_raise_msg_varg(&mp_type_TypeError,
+                "object of type '%s' has no len()", mp_obj_get_type_str(o_in));
         }
     } else {
         return len;
@@ -538,22 +537,22 @@ mp_obj_t mp_obj_subscr(mp_obj_t base, mp_obj_t index, mp_obj_t value) {
         if (MICROPY_ERROR_REPORTING == MICROPY_ERROR_REPORTING_TERSE) {
             mp_raise_TypeError("object doesn't support item deletion");
         } else {
-            nlr_raise(mp_obj_new_exception_msg_varg(&mp_type_TypeError,
-                "'%s' object doesn't support item deletion", mp_obj_get_type_str(base)));
+            mp_raise_msg_varg(&mp_type_TypeError,
+                "'%s' object doesn't support item deletion", mp_obj_get_type_str(base));
         }
     } else if (value == MP_OBJ_SENTINEL) {
         if (MICROPY_ERROR_REPORTING == MICROPY_ERROR_REPORTING_TERSE) {
             mp_raise_TypeError("object isn't subscriptable");
         } else {
-            nlr_raise(mp_obj_new_exception_msg_varg(&mp_type_TypeError,
-                "'%s' object isn't subscriptable", mp_obj_get_type_str(base)));
+            mp_raise_msg_varg(&mp_type_TypeError,
+                "'%s' object isn't subscriptable", mp_obj_get_type_str(base));
         }
     } else {
         if (MICROPY_ERROR_REPORTING == MICROPY_ERROR_REPORTING_TERSE) {
             mp_raise_TypeError("object doesn't support item assignment");
         } else {
-            nlr_raise(mp_obj_new_exception_msg_varg(&mp_type_TypeError,
-                "'%s' object doesn't support item assignment", mp_obj_get_type_str(base)));
+            mp_raise_msg_varg(&mp_type_TypeError,
+                "'%s' object doesn't support item assignment", mp_obj_get_type_str(base));
         }
     }
 }

--- a/py/obj.h
+++ b/py/obj.h
@@ -712,6 +712,9 @@ mp_obj_t mp_obj_new_exception_arg1(const mp_obj_type_t *exc_type, mp_obj_t arg);
 mp_obj_t mp_obj_new_exception_args(const mp_obj_type_t *exc_type, size_t n_args, const mp_obj_t *args);
 mp_obj_t mp_obj_new_exception_msg(const mp_obj_type_t *exc_type, const char *msg);
 mp_obj_t mp_obj_new_exception_msg_varg(const mp_obj_type_t *exc_type, const char *fmt, ...); // counts args by number of % symbols in fmt, excluding %%; can only handle void* sizes (ie no float/double!)
+#ifdef va_start
+mp_obj_t mp_obj_new_exception_msg_varg2(const mp_obj_type_t *exc_type, const char *fmt, va_list arg); // counts args by number of % symbols in fmt, excluding %%; can only handle void* sizes (ie no float/double!)
+#endif
 mp_obj_t mp_obj_new_fun_bc(mp_obj_t def_args, mp_obj_t def_kw_args, const byte *code, const mp_uint_t *const_table);
 mp_obj_t mp_obj_new_fun_native(mp_obj_t def_args_in, mp_obj_t def_kw_args, const void *fun_data, const mp_uint_t *const_table);
 mp_obj_t mp_obj_new_fun_asm(size_t n_args, const void *fun_data, mp_uint_t type_sig);

--- a/py/objexcept.c
+++ b/py/objexcept.c
@@ -385,6 +385,14 @@ STATIC void exc_add_strn(void *data, const char *str, size_t len) {
 }
 
 mp_obj_t mp_obj_new_exception_msg_varg(const mp_obj_type_t *exc_type, const char *fmt, ...) {
+    va_list args;
+    va_start(args, fmt);
+    mp_obj_t exc = mp_obj_new_exception_msg_varg2(exc_type, fmt, args);
+    va_end(args);
+    return exc;
+}
+
+mp_obj_t mp_obj_new_exception_msg_varg2(const mp_obj_type_t *exc_type, const char *fmt, va_list args) {
     assert(fmt != NULL);
 
     // Check that the given type is an exception type
@@ -425,10 +433,7 @@ mp_obj_t mp_obj_new_exception_msg_varg(const mp_obj_type_t *exc_type, const char
         // We have some memory to format the string
         struct _exc_printer_t exc_pr = {!used_emg_buf, o_str_alloc, 0, o_str_buf};
         mp_print_t print = {&exc_pr, exc_add_strn};
-        va_list ap;
-        va_start(ap, fmt);
-        mp_vprintf(&print, fmt, ap);
-        va_end(ap);
+        mp_vprintf(&print, fmt, args);
         exc_pr.buf[exc_pr.len] = '\0';
         o_str->len = exc_pr.len;
         o_str->data = exc_pr.buf;

--- a/py/objnamedtuple.c
+++ b/py/objnamedtuple.c
@@ -98,13 +98,13 @@ STATIC mp_obj_t namedtuple_make_new(const mp_obj_type_t *type_in, size_t n_args,
         if (MICROPY_ERROR_REPORTING == MICROPY_ERROR_REPORTING_TERSE) {
             mp_arg_error_terse_mismatch();
         } else if (MICROPY_ERROR_REPORTING == MICROPY_ERROR_REPORTING_NORMAL) {
-            nlr_raise(mp_obj_new_exception_msg_varg(&mp_type_TypeError,
+            mp_raise_msg_varg(&mp_type_TypeError,
                 "function takes %d positional arguments but %d were given",
-                num_fields, n_args + n_kw));
+                num_fields, n_args + n_kw);
         } else if (MICROPY_ERROR_REPORTING == MICROPY_ERROR_REPORTING_DETAILED) {
-            nlr_raise(mp_obj_new_exception_msg_varg(&mp_type_TypeError,
+            mp_raise_msg_varg(&mp_type_TypeError,
                 "%q() takes %d positional arguments but %d were given",
-                type->base.name, num_fields, n_args + n_kw));
+                type->base.name, num_fields, n_args + n_kw);
         }
     }
 
@@ -124,16 +124,15 @@ STATIC mp_obj_t namedtuple_make_new(const mp_obj_type_t *type_in, size_t n_args,
             if (MICROPY_ERROR_REPORTING == MICROPY_ERROR_REPORTING_TERSE) {
                 mp_arg_error_terse_mismatch();
             } else {
-                nlr_raise(mp_obj_new_exception_msg_varg(&mp_type_TypeError,
-                    "unexpected keyword argument '%q'", kw));
+                mp_raise_msg_varg(&mp_type_TypeError, "unexpected keyword argument '%q'", kw);
             }
         }
         if (tuple->items[id] != MP_OBJ_NULL) {
             if (MICROPY_ERROR_REPORTING == MICROPY_ERROR_REPORTING_TERSE) {
                 mp_arg_error_terse_mismatch();
             } else {
-                nlr_raise(mp_obj_new_exception_msg_varg(&mp_type_TypeError,
-                    "function got multiple values for argument '%q'", kw));
+                mp_raise_msg_varg(&mp_type_TypeError,
+                    "function got multiple values for argument '%q'", kw);
             }
         }
         tuple->items[id] = args[i + 1];

--- a/py/objstr.c
+++ b/py/objstr.c
@@ -1001,8 +1001,8 @@ STATIC vstr_t mp_obj_str_format_helper(const char *str, const char *top, int *ar
                         mp_raise_ValueError(
                             "end of format while looking for conversion specifier");
                     } else {
-                        nlr_raise(mp_obj_new_exception_msg_varg(&mp_type_ValueError,
-                            "unknown conversion specifier %c", *str));
+                        mp_raise_msg_varg(&mp_type_ValueError,
+                            "unknown conversion specifier %c", *str);
                     }
                 }
             }
@@ -1262,9 +1262,9 @@ STATIC vstr_t mp_obj_str_format_helper(const char *str, const char *top, int *ar
                     if (MICROPY_ERROR_REPORTING == MICROPY_ERROR_REPORTING_TERSE) {
                         terse_str_format_value_error();
                     } else {
-                        nlr_raise(mp_obj_new_exception_msg_varg(&mp_type_ValueError,
+                        mp_raise_msg_varg(&mp_type_ValueError,
                             "unknown format code '%c' for object of type '%s'",
-                            type, mp_obj_get_type_str(arg)));
+                            type, mp_obj_get_type_str(arg));
                     }
             }
         }
@@ -1334,9 +1334,9 @@ STATIC vstr_t mp_obj_str_format_helper(const char *str, const char *top, int *ar
                     if (MICROPY_ERROR_REPORTING == MICROPY_ERROR_REPORTING_TERSE) {
                         terse_str_format_value_error();
                     } else {
-                        nlr_raise(mp_obj_new_exception_msg_varg(&mp_type_ValueError,
+                        mp_raise_msg_varg(&mp_type_ValueError,
                             "unknown format code '%c' for object of type '%s'",
-                            type, mp_obj_get_type_str(arg)));
+                            type, mp_obj_get_type_str(arg));
                     }
             }
         } else {
@@ -1370,9 +1370,9 @@ STATIC vstr_t mp_obj_str_format_helper(const char *str, const char *top, int *ar
                     if (MICROPY_ERROR_REPORTING == MICROPY_ERROR_REPORTING_TERSE) {
                         terse_str_format_value_error();
                     } else {
-                        nlr_raise(mp_obj_new_exception_msg_varg(&mp_type_ValueError,
+                        mp_raise_msg_varg(&mp_type_ValueError,
                             "unknown format code '%c' for object of type '%s'",
-                            type, mp_obj_get_type_str(arg)));
+                            type, mp_obj_get_type_str(arg));
                     }
             }
         }
@@ -1574,9 +1574,9 @@ not_enough_args:
                 if (MICROPY_ERROR_REPORTING == MICROPY_ERROR_REPORTING_TERSE) {
                     terse_str_format_value_error();
                 } else {
-                    nlr_raise(mp_obj_new_exception_msg_varg(&mp_type_ValueError,
+                    mp_raise_msg_varg(&mp_type_ValueError,
                         "unsupported format character '%c' (0x%x) at index %d",
-                        *str, *str, str - start_str));
+                        *str, *str, str - start_str);
                 }
         }
     }
@@ -2112,9 +2112,9 @@ STATIC NORETURN void bad_implicit_conversion(mp_obj_t self_in) {
         mp_raise_TypeError("can't convert to str implicitly");
     } else {
         const qstr src_name = mp_obj_get_type(self_in)->name;
-        nlr_raise(mp_obj_new_exception_msg_varg(&mp_type_TypeError,
+        mp_raise_msg_varg(&mp_type_TypeError,
             "can't convert '%q' object to %q implicitly",
-            src_name, src_name == MP_QSTR_str ? MP_QSTR_bytes : MP_QSTR_str));
+            src_name, src_name == MP_QSTR_str ? MP_QSTR_bytes : MP_QSTR_str);
     }
 }
 

--- a/py/objstrunicode.c
+++ b/py/objstrunicode.c
@@ -129,7 +129,7 @@ const byte *str_index_to_ptr(const mp_obj_type_t *type, const byte *self_data, s
     if (mp_obj_is_small_int(index)) {
         i = MP_OBJ_SMALL_INT_VALUE(index);
     } else if (!mp_obj_get_int_maybe(index, &i)) {
-        nlr_raise(mp_obj_new_exception_msg_varg(&mp_type_TypeError, "string indices must be integers, not %s", mp_obj_get_type_str(index)));
+        mp_raise_msg_varg(&mp_type_TypeError, "string indices must be integers, not %s", mp_obj_get_type_str(index));
     }
     const byte *s, *top = self_data + self_len;
     if (i < 0)

--- a/py/objtype.c
+++ b/py/objtype.c
@@ -351,8 +351,8 @@ mp_obj_t mp_obj_instance_make_new(const mp_obj_type_t *self, size_t n_args, size
             if (MICROPY_ERROR_REPORTING == MICROPY_ERROR_REPORTING_TERSE) {
                 mp_raise_TypeError("__init__() should return None");
             } else {
-                nlr_raise(mp_obj_new_exception_msg_varg(&mp_type_TypeError,
-                    "__init__() should return None, not '%s'", mp_obj_get_type_str(init_ret)));
+                mp_raise_msg_varg(&mp_type_TypeError,
+                    "__init__() should return None, not '%s'", mp_obj_get_type_str(init_ret));
             }
         }
 
@@ -867,8 +867,8 @@ mp_obj_t mp_obj_instance_call(mp_obj_t self_in, size_t n_args, size_t n_kw, cons
         if (MICROPY_ERROR_REPORTING == MICROPY_ERROR_REPORTING_TERSE) {
             mp_raise_TypeError("object not callable");
         } else {
-            nlr_raise(mp_obj_new_exception_msg_varg(&mp_type_TypeError,
-                "'%s' object isn't callable", mp_obj_get_type_str(self_in)));
+            mp_raise_msg_varg(&mp_type_TypeError,
+                "'%s' object isn't callable", mp_obj_get_type_str(self_in));
         }
     }
     mp_obj_instance_t *self = MP_OBJ_TO_PTR(self_in);
@@ -992,8 +992,7 @@ STATIC mp_obj_t type_call(mp_obj_t self_in, size_t n_args, size_t n_kw, const mp
         if (MICROPY_ERROR_REPORTING == MICROPY_ERROR_REPORTING_TERSE) {
             mp_raise_TypeError("cannot create instance");
         } else {
-            nlr_raise(mp_obj_new_exception_msg_varg(&mp_type_TypeError,
-                "cannot create '%q' instances", self->name));
+            mp_raise_msg_varg(&mp_type_TypeError, "cannot create '%q' instances", self->name);
         }
     }
 
@@ -1115,8 +1114,8 @@ mp_obj_t mp_obj_new_type(qstr name, mp_obj_t bases_tuple, mp_obj_t locals_dict) 
             if (MICROPY_ERROR_REPORTING == MICROPY_ERROR_REPORTING_TERSE) {
                 mp_raise_TypeError("type isn't an acceptable base type");
             } else {
-                nlr_raise(mp_obj_new_exception_msg_varg(&mp_type_TypeError,
-                    "type '%q' isn't an acceptable base type", t->name));
+                mp_raise_msg_varg(&mp_type_TypeError,
+                    "type '%q' isn't an acceptable base type", t->name);
             }
         }
         #if ENABLE_SPECIAL_ACCESSORS

--- a/py/runtime.c
+++ b/py/runtime.c
@@ -25,6 +25,7 @@
  * THE SOFTWARE.
  */
 
+#include <stdarg.h>
 #include <stdio.h>
 #include <string.h>
 #include <assert.h>
@@ -187,8 +188,7 @@ mp_obj_t mp_load_global(qstr qst) {
             if (MICROPY_ERROR_REPORTING == MICROPY_ERROR_REPORTING_TERSE) {
                 mp_raise_msg(&mp_type_NameError, "name not defined");
             } else {
-                nlr_raise(mp_obj_new_exception_msg_varg(&mp_type_NameError,
-                    "name '%q' isn't defined", qst));
+                mp_raise_msg_varg(&mp_type_NameError, "name '%q' isn't defined", qst);
             }
         }
     }
@@ -293,12 +293,12 @@ mp_obj_t mp_unary_op(mp_unary_op_t op, mp_obj_t arg) {
             }
         } else {
             if (op == MP_UNARY_OP_INT) {
-                nlr_raise(mp_obj_new_exception_msg_varg(&mp_type_TypeError,
-                    "can't convert %s to int", mp_obj_get_type_str(arg)));
+                mp_raise_msg_varg(&mp_type_TypeError,
+                    "can't convert %s to int", mp_obj_get_type_str(arg));
             } else {
-                nlr_raise(mp_obj_new_exception_msg_varg(&mp_type_TypeError,
+                mp_raise_msg_varg(&mp_type_TypeError,
                     "unsupported type for %q: '%s'",
-                    mp_unary_op_method_name[op], mp_obj_get_type_str(arg)));
+                    mp_unary_op_method_name[op], mp_obj_get_type_str(arg));
             }
         }
     }
@@ -593,9 +593,9 @@ unsupported_op:
     if (MICROPY_ERROR_REPORTING == MICROPY_ERROR_REPORTING_TERSE) {
         mp_raise_TypeError("unsupported type for operator");
     } else {
-        nlr_raise(mp_obj_new_exception_msg_varg(&mp_type_TypeError,
+        mp_raise_msg_varg(&mp_type_TypeError,
             "unsupported types for %q: '%s', '%s'",
-            mp_binary_op_method_name[op], mp_obj_get_type_str(lhs), mp_obj_get_type_str(rhs)));
+            mp_binary_op_method_name[op], mp_obj_get_type_str(lhs), mp_obj_get_type_str(rhs));
     }
 
 zero_division:
@@ -635,8 +635,8 @@ mp_obj_t mp_call_function_n_kw(mp_obj_t fun_in, size_t n_args, size_t n_kw, cons
     if (MICROPY_ERROR_REPORTING == MICROPY_ERROR_REPORTING_TERSE) {
         mp_raise_TypeError("object not callable");
     } else {
-        nlr_raise(mp_obj_new_exception_msg_varg(&mp_type_TypeError,
-            "'%s' object isn't callable", mp_obj_get_type_str(fun_in)));
+        mp_raise_msg_varg(&mp_type_TypeError,
+            "'%s' object isn't callable", mp_obj_get_type_str(fun_in));
     }
 }
 
@@ -864,15 +864,13 @@ too_short:
     if (MICROPY_ERROR_REPORTING == MICROPY_ERROR_REPORTING_TERSE) {
         mp_raise_ValueError("wrong number of values to unpack");
     } else {
-        nlr_raise(mp_obj_new_exception_msg_varg(&mp_type_ValueError,
-            "need more than %d values to unpack", (int)seq_len));
+        mp_raise_msg_varg(&mp_type_ValueError, "need more than %d values to unpack", (int)seq_len);
     }
 too_long:
     if (MICROPY_ERROR_REPORTING == MICROPY_ERROR_REPORTING_TERSE) {
         mp_raise_ValueError("wrong number of values to unpack");
     } else {
-        nlr_raise(mp_obj_new_exception_msg_varg(&mp_type_ValueError,
-            "too many values to unpack (expected %d)", (int)num));
+        mp_raise_msg_varg(&mp_type_ValueError, "too many values to unpack (expected %d)", (int)num);
     }
 }
 
@@ -933,8 +931,7 @@ too_short:
     if (MICROPY_ERROR_REPORTING == MICROPY_ERROR_REPORTING_TERSE) {
         mp_raise_ValueError("wrong number of values to unpack");
     } else {
-        nlr_raise(mp_obj_new_exception_msg_varg(&mp_type_ValueError,
-            "need more than %d values to unpack", (int)seq_len));
+        mp_raise_msg_varg(&mp_type_ValueError, "need more than %d values to unpack", (int)seq_len);
     }
 }
 
@@ -972,8 +969,8 @@ STATIC mp_obj_t checked_fun_call(mp_obj_t self_in, size_t n_args, size_t n_kw, c
             if (MICROPY_ERROR_REPORTING != MICROPY_ERROR_REPORTING_DETAILED) {
                 mp_raise_TypeError("argument has wrong type");
             } else {
-                nlr_raise(mp_obj_new_exception_msg_varg(&mp_type_TypeError,
-                    "argument should be a '%q' not a '%q'", self->type->name, arg0_type->name));
+                mp_raise_msg_varg(&mp_type_TypeError,
+                    "argument should be a '%q' not a '%q'", self->type->name, arg0_type->name);
             }
         }
     }
@@ -1097,13 +1094,13 @@ void mp_load_method(mp_obj_t base, qstr attr, mp_obj_t *dest) {
         } else {
             // following CPython, we give a more detailed error message for type objects
             if (mp_obj_is_type(base, &mp_type_type)) {
-                nlr_raise(mp_obj_new_exception_msg_varg(&mp_type_AttributeError,
+                mp_raise_msg_varg(&mp_type_AttributeError,
                     "type object '%q' has no attribute '%q'",
-                    ((mp_obj_type_t*)MP_OBJ_TO_PTR(base))->name, attr));
+                    ((mp_obj_type_t*)MP_OBJ_TO_PTR(base))->name, attr);
             } else {
-                nlr_raise(mp_obj_new_exception_msg_varg(&mp_type_AttributeError,
+                mp_raise_msg_varg(&mp_type_AttributeError,
                     "'%s' object has no attribute '%q'",
-                    mp_obj_get_type_str(base), attr));
+                    mp_obj_get_type_str(base), attr);
             }
         }
     }
@@ -1139,9 +1136,9 @@ void mp_store_attr(mp_obj_t base, qstr attr, mp_obj_t value) {
     if (MICROPY_ERROR_REPORTING == MICROPY_ERROR_REPORTING_TERSE) {
         mp_raise_msg(&mp_type_AttributeError, "no such attribute");
     } else {
-        nlr_raise(mp_obj_new_exception_msg_varg(&mp_type_AttributeError,
+        mp_raise_msg_varg(&mp_type_AttributeError,
             "'%s' object has no attribute '%q'",
-            mp_obj_get_type_str(base), attr));
+            mp_obj_get_type_str(base), attr);
     }
 }
 
@@ -1184,8 +1181,8 @@ mp_obj_t mp_getiter(mp_obj_t o_in, mp_obj_iter_buf_t *iter_buf) {
     if (MICROPY_ERROR_REPORTING == MICROPY_ERROR_REPORTING_TERSE) {
         mp_raise_TypeError("object not iterable");
     } else {
-        nlr_raise(mp_obj_new_exception_msg_varg(&mp_type_TypeError,
-            "'%s' object isn't iterable", mp_obj_get_type_str(o_in)));
+        mp_raise_msg_varg(&mp_type_TypeError,
+            "'%s' object isn't iterable", mp_obj_get_type_str(o_in));
     }
 }
 
@@ -1206,8 +1203,8 @@ mp_obj_t mp_iternext_allow_raise(mp_obj_t o_in) {
             if (MICROPY_ERROR_REPORTING == MICROPY_ERROR_REPORTING_TERSE) {
                 mp_raise_TypeError("object not an iterator");
             } else {
-                nlr_raise(mp_obj_new_exception_msg_varg(&mp_type_TypeError,
-                    "'%s' object isn't an iterator", mp_obj_get_type_str(o_in)));
+                mp_raise_msg_varg(&mp_type_TypeError,
+                    "'%s' object isn't an iterator", mp_obj_get_type_str(o_in));
             }
         }
     }
@@ -1242,8 +1239,8 @@ mp_obj_t mp_iternext(mp_obj_t o_in) {
             if (MICROPY_ERROR_REPORTING == MICROPY_ERROR_REPORTING_TERSE) {
                 mp_raise_TypeError("object not an iterator");
             } else {
-                nlr_raise(mp_obj_new_exception_msg_varg(&mp_type_TypeError,
-                    "'%s' object isn't an iterator", mp_obj_get_type_str(o_in)));
+                mp_raise_msg_varg(&mp_type_TypeError,
+                    "'%s' object isn't an iterator", mp_obj_get_type_str(o_in));
             }
         }
     }
@@ -1378,7 +1375,7 @@ mp_obj_t mp_import_from(mp_obj_t module, qstr name) {
     if (dest[1] != MP_OBJ_NULL) {
         // Hopefully we can't import bound method from an object
 import_error:
-        nlr_raise(mp_obj_new_exception_msg_varg(&mp_type_ImportError, "cannot import name %q", name));
+        mp_raise_msg_varg(&mp_type_ImportError, "cannot import name %q", name);
     }
 
     if (dest[0] != MP_OBJ_NULL) {
@@ -1482,8 +1479,8 @@ NORETURN void m_malloc_fail(size_t num_bytes) {
         mp_raise_msg(&mp_type_MemoryError, "memory allocation failed, heap is locked");
     }
     #endif
-    nlr_raise(mp_obj_new_exception_msg_varg(&mp_type_MemoryError,
-        "memory allocation failed, allocating %u bytes", (uint)num_bytes));
+    mp_raise_msg_varg(&mp_type_MemoryError,
+        "memory allocation failed, allocating %u bytes", (uint)num_bytes);
 }
 
 NORETURN void mp_raise_msg(const mp_obj_type_t *exc_type, const char *msg) {
@@ -1492,6 +1489,14 @@ NORETURN void mp_raise_msg(const mp_obj_type_t *exc_type, const char *msg) {
     } else {
         nlr_raise(mp_obj_new_exception_msg(exc_type, msg));
     }
+}
+
+NORETURN void mp_raise_msg_varg(const mp_obj_type_t *exc_type, const char *fmt, ...) {
+    va_list args;
+    va_start(args, fmt);
+    mp_obj_t exc = mp_obj_new_exception_msg_varg2(exc_type, fmt, args);
+    va_end(args);
+    nlr_raise(exc);
 }
 
 NORETURN void mp_raise_ValueError(const char *msg) {

--- a/py/runtime.h
+++ b/py/runtime.h
@@ -153,6 +153,7 @@ void mp_import_all(mp_obj_t module);
 
 #define mp_raise_type(exc_type) mp_raise_msg(exc_type, NULL)
 NORETURN void mp_raise_msg(const mp_obj_type_t *exc_type, const char *msg);
+NORETURN void mp_raise_msg_varg(const mp_obj_type_t *exc_type, const char *fmt, ...);
 NORETURN void mp_raise_ValueError(const char *msg);
 NORETURN void mp_raise_TypeError(const char *msg);
 NORETURN void mp_raise_NotImplementedError(const char *msg);


### PR DESCRIPTION
Similar to the helpers `mp_raise_msg()`, `mp_raise_ValueError()` etc, this PR adds `mp_raise_msg_varg(type, fmt, ...)` as a helper for `nlr_raise(mp_obj_new_exception_msg_varg(type, fmt, ...))`.

It's a bit more involved because of the variadic arguments.  And probably won't work with some archs/compilers because there will be a `longjmp` over the `va_end()`, which is not technically allowed (may lead to memory leak).

The main motivation for this was to improve layout of the code for applying astyle, see https://github.com/micropython/micropython/issues/4223#issuecomment-582689891 .  With a single function `mp_raise_msg_varg()` instead of nested `nlr_raise` and `mp_obj_new_exception_msg_varg` there are less indentations to apply for the opening parenthesis when there are split lines.

So, even if the helper function cannot be used due to longjmp/va_end issues, I still think it'd be good to make this change and just have `mp_raise_msg_varg` a macro.  That way it could be made in to a proper function for ports that can do longjmp over va_end (most ports can do it).

Code size diff with this PR:
```
   bare-arm:   +28 +0.042% 
minimal x86:  +100 +0.067% 
   unix x64:   -56 -0.011% 
unix nanbox:  -284 -0.064% 
      stm32:  -204 -0.054% PYBV10
     cc3200:    +0 +0.000% 
    esp8266:   -68 -0.010% GENERIC
      esp32:   -92 -0.007% GENERIC
        nrf:  -136 -0.094% pca10040
       samd:    +0 +0.000% ADAFRUIT_ITSYBITSY_M4_EXPRESS
```