### PR TITLE
all: Add mp_raise helper macro and use it where appropriate.

### DIFF
--- a/extmod/modbtree.c
+++ b/extmod/modbtree.c
@@ -256,7 +256,7 @@ STATIC mp_obj_t btree_subscr(mp_obj_t self_in, mp_obj_t index, mp_obj_t value) {
         key.data = (void*)mp_obj_str_get_data(index, &key.size);
         int res = __bt_delete(self->db, &key, 0);
         if (res == RET_SPECIAL) {
-            nlr_raise(mp_obj_new_exception(&mp_type_KeyError));
+            mp_raise_type(&mp_type_KeyError);
         }
         CHECK_ERROR(res);
         return mp_const_none;
@@ -266,7 +266,7 @@ STATIC mp_obj_t btree_subscr(mp_obj_t self_in, mp_obj_t index, mp_obj_t value) {
         key.data = (void*)mp_obj_str_get_data(index, &key.size);
         int res = __bt_get(self->db, &key, &val, 0);
         if (res == RET_SPECIAL) {
-            nlr_raise(mp_obj_new_exception(&mp_type_KeyError));
+            mp_raise_type(&mp_type_KeyError);
         }
         CHECK_ERROR(res);
         return mp_obj_new_bytes(val.data, val.size);

--- a/extmod/modurandom.c
+++ b/extmod/modurandom.c
@@ -154,7 +154,7 @@ STATIC mp_obj_t mod_urandom_choice(mp_obj_t seq) {
     if (len > 0) {
         return mp_obj_subscr(seq, mp_obj_new_int(yasmarang_randbelow(len)), MP_OBJ_SENTINEL);
     } else {
-        nlr_raise(mp_obj_new_exception(&mp_type_IndexError));
+        mp_raise_type(&mp_type_IndexError);
     }
 }
 STATIC MP_DEFINE_CONST_FUN_OBJ_1(mod_urandom_choice_obj, mod_urandom_choice);

--- a/extmod/moduzlib.c
+++ b/extmod/moduzlib.c
@@ -61,7 +61,7 @@ STATIC int read_src_stream(TINF_DATA *data) {
         mp_raise_OSError(err);
     }
     if (out_sz == 0) {
-        nlr_raise(mp_obj_new_exception(&mp_type_EOFError));
+        mp_raise_type(&mp_type_EOFError);
     }
     return c;
 }

--- a/ports/cc3200/mods/pybsleep.c
+++ b/ports/cc3200/mods/pybsleep.c
@@ -477,7 +477,7 @@ void pyb_sleep_suspend_exit (void) {
     MAP_IntPendSet(INT_PRCM);
 
     // force an exception to go back to the point where suspend mode was entered
-    nlr_raise(mp_obj_new_exception(&mp_type_SystemExit));
+    mp_raise_type(&mp_type_SystemExit);
 }
 
 STATIC void PRCMInterruptHandler (void) {

--- a/ports/esp32/modmachine.c
+++ b/ports/esp32/modmachine.c
@@ -196,7 +196,7 @@ STATIC MP_DEFINE_CONST_FUN_OBJ_0(machine_reset_obj, machine_reset);
 
 STATIC mp_obj_t machine_soft_reset(void) {
     pyexec_system_exit = PYEXEC_FORCED_EXIT;
-    nlr_raise(mp_obj_new_exception(&mp_type_SystemExit));
+    mp_raise_type(&mp_type_SystemExit);
 }
 STATIC MP_DEFINE_CONST_FUN_OBJ_0(machine_soft_reset_obj, machine_soft_reset);
 

--- a/ports/nrf/modules/machine/modmachine.c
+++ b/ports/nrf/modules/machine/modmachine.c
@@ -147,7 +147,7 @@ MP_DEFINE_CONST_FUN_OBJ_0(machine_reset_obj, machine_reset);
 
 STATIC mp_obj_t machine_soft_reset(void) {
     pyexec_system_exit = PYEXEC_FORCED_EXIT;
-    nlr_raise(mp_obj_new_exception(&mp_type_SystemExit));
+    mp_raise_type(&mp_type_SystemExit);
 }
 MP_DEFINE_CONST_FUN_OBJ_0(machine_soft_reset_obj, machine_soft_reset);
 

--- a/ports/nrf/modules/random/modrandom.c
+++ b/ports/nrf/modules/random/modrandom.c
@@ -155,7 +155,7 @@ STATIC mp_obj_t mod_random_choice(mp_obj_t seq) {
     if (len > 0) {
         return mp_obj_subscr(seq, mp_obj_new_int(randbelow(len)), MP_OBJ_SENTINEL);
     } else {
-        nlr_raise(mp_obj_new_exception(&mp_type_IndexError));
+        mp_raise_type(&mp_type_IndexError);
     }
 }
 STATIC MP_DEFINE_CONST_FUN_OBJ_1(mod_random_choice_obj, mod_random_choice);

--- a/ports/stm32/modmachine.c
+++ b/ports/stm32/modmachine.c
@@ -249,7 +249,7 @@ MP_DEFINE_CONST_FUN_OBJ_0(machine_reset_obj, machine_reset);
 
 STATIC mp_obj_t machine_soft_reset(void) {
     pyexec_system_exit = PYEXEC_FORCED_EXIT;
-    nlr_raise(mp_obj_new_exception(&mp_type_SystemExit));
+    mp_raise_type(&mp_type_SystemExit);
 }
 MP_DEFINE_CONST_FUN_OBJ_0(machine_soft_reset_obj, machine_soft_reset);
 

--- a/py/modbuiltins.c
+++ b/py/modbuiltins.c
@@ -244,10 +244,10 @@ STATIC mp_obj_t mp_builtin_input(size_t n_args, const mp_obj_t *args) {
     vstr_init(&line, 16);
     int ret = mp_hal_readline(&line, "");
     if (ret == CHAR_CTRL_C) {
-        nlr_raise(mp_obj_new_exception(&mp_type_KeyboardInterrupt));
+        mp_raise_type(&mp_type_KeyboardInterrupt);
     }
     if (line.len == 0 && ret == CHAR_CTRL_D) {
-        nlr_raise(mp_obj_new_exception(&mp_type_EOFError));
+        mp_raise_type(&mp_type_EOFError);
     }
     return mp_obj_new_str_from_vstr(&mp_type_str, &line);
 }
@@ -321,7 +321,7 @@ STATIC mp_obj_t mp_builtin_next(size_t n_args, const mp_obj_t *args) {
     if (n_args == 1) {
         mp_obj_t ret = mp_iternext_allow_raise(args[0]);
         if (ret == MP_OBJ_STOP_ITERATION) {
-            nlr_raise(mp_obj_new_exception(&mp_type_StopIteration));
+            mp_raise_type(&mp_type_StopIteration);
         } else {
             return ret;
         }
@@ -335,7 +335,7 @@ MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(mp_builtin_next_obj, 1, 2, mp_builtin_next);
 STATIC mp_obj_t mp_builtin_next(mp_obj_t o) {
     mp_obj_t ret = mp_iternext_allow_raise(o);
     if (ret == MP_OBJ_STOP_ITERATION) {
-        nlr_raise(mp_obj_new_exception(&mp_type_StopIteration));
+        mp_raise_type(&mp_type_StopIteration);
     } else {
         return ret;
     }

--- a/py/modthread.c
+++ b/py/modthread.c
@@ -271,7 +271,7 @@ STATIC mp_obj_t mod_thread_start_new_thread(size_t n_args, const mp_obj_t *args)
 STATIC MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(mod_thread_start_new_thread_obj, 2, 3, mod_thread_start_new_thread);
 
 STATIC mp_obj_t mod_thread_exit(void) {
-    nlr_raise(mp_obj_new_exception(&mp_type_SystemExit));
+    mp_raise_type(&mp_type_SystemExit);
 }
 STATIC MP_DEFINE_CONST_FUN_OBJ_0(mod_thread_exit_obj, mod_thread_exit);
 

--- a/py/objgenerator.c
+++ b/py/objgenerator.c
@@ -261,7 +261,7 @@ STATIC mp_obj_t gen_instance_iternext(mp_obj_t self_in) {
 STATIC mp_obj_t gen_instance_send(mp_obj_t self_in, mp_obj_t send_value) {
     mp_obj_t ret = gen_resume_and_raise(self_in, send_value, MP_OBJ_NULL);
     if (ret == MP_OBJ_STOP_ITERATION) {
-        nlr_raise(mp_obj_new_exception(&mp_type_StopIteration));
+        mp_raise_type(&mp_type_StopIteration);
     } else {
         return ret;
     }
@@ -288,7 +288,7 @@ STATIC mp_obj_t gen_instance_throw(size_t n_args, const mp_obj_t *args) {
 
     mp_obj_t ret = gen_resume_and_raise(args[0], mp_const_none, exc);
     if (ret == MP_OBJ_STOP_ITERATION) {
-        nlr_raise(mp_obj_new_exception(&mp_type_StopIteration));
+        mp_raise_type(&mp_type_StopIteration);
     } else {
         return ret;
     }

--- a/py/runtime.h
+++ b/py/runtime.h
@@ -151,6 +151,7 @@ mp_obj_t mp_import_name(qstr name, mp_obj_t fromlist, mp_obj_t level);
 mp_obj_t mp_import_from(mp_obj_t module, qstr name);
 void mp_import_all(mp_obj_t module);
 
+#define mp_raise_type(exc_type) mp_raise_msg(exc_type, NULL)
 NORETURN void mp_raise_msg(const mp_obj_type_t *exc_type, const char *msg);
 NORETURN void mp_raise_ValueError(const char *msg);
 NORETURN void mp_raise_TypeError(const char *msg);


### PR DESCRIPTION
This is a small change to:
1. reduce code size
2. provide a more consistent C-level API to raise exceptions, ie moving away from `nlr_raise` towards `mp_raise_XXX`; see also #5633 on this point

Code size change with this PR:
```
   bare-arm:    +0 +0.000% 
minimal x86:   -28 -0.019% 
   unix x64:   -64 -0.013% 
unix nanbox:   -64 -0.014% 
      stm32:    +0 +0.000% PYBV10
     cc3200:    +0 +0.000% 
    esp8266:   -12 -0.002% GENERIC
      esp32:    +8 +0.001% GENERIC
        nrf:    -8 -0.006% pca10040
       samd:    +0 +0.000% ADAFRUIT_ITSYBITSY_M4_EXPRESS
```