### PR TITLE
unix/Makefile: Remove old variant targets that are no longer needed.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -113,7 +113,7 @@ jobs:
         - make ${MAKEOPTS} -C mpy-cross
         - make ${MAKEOPTS} -C ports/unix MICROPY_FORCE_32BIT=1 submodules
         - make ${MAKEOPTS} -C ports/unix MICROPY_FORCE_32BIT=1 deplibs
-        - make ${MAKEOPTS} -C ports/unix MICROPY_FORCE_32BIT=1 coverage
+        - make ${MAKEOPTS} -C ports/unix MICROPY_FORCE_32BIT=1 VARIANT=coverage
         # run the main test suite
         - (cd tests && MICROPY_CPYTHON3=python3 MICROPY_MICROPYTHON=../ports/unix/micropython-coverage ./run-tests)
         - (cd tests && MICROPY_CPYTHON3=python3 MICROPY_MICROPYTHON=../ports/unix/micropython-coverage ./run-tests -d thread)
@@ -186,7 +186,7 @@ jobs:
     - stage: test
       env: NAME="minimal unix port build and tests"
       script:
-        - make ${MAKEOPTS} -C ports/unix minimal
+        - make ${MAKEOPTS} -C ports/unix VARIANT=minimal
         - (cd tests && MICROPY_CPYTHON3=python3 MICROPY_MICROPYTHON=../ports/unix/micropython-minimal ./run-tests -e exception_chain -e self_type_check -e subclass_native_init -d basics)
 
     # windows port via mingw

--- a/ports/unix/Makefile
+++ b/ports/unix/Makefile
@@ -221,24 +221,6 @@ test_gcov: test_full
 	gcov -o $(BUILD)/py $(TOP)/py/*.c
 	gcov -o $(BUILD)/extmod $(TOP)/extmod/*.c
 
-# Maintain historical targets from pre-variant configurations.
-fast:
-	$(MAKE) VARIANT=fast
-
-minimal:
-	$(MAKE) VARIANT=minimal
-
-nanbox:
-	$(MAKE) VARIANT=nanbox
-
-freedos:
-	$(MAKE) VARIANT=freedos
-
-coverage:
-	$(MAKE) VARIANT=coverage
-coverage_test:
-	$(MAKE) VARIANT=coverage test_gcov
-
 # Value of configure's --host= option (required for cross-compilation).
 # Deduce it from CROSS_COMPILE by default, but can be overridden.
 ifneq ($(CROSS_COMPILE),)


### PR DESCRIPTION
To eliminate confusion about what targets to use when building.