### PR TITLE
drivers/nrf24l01/nrf24l01test.py Add comment re Arduino compatibility

### DIFF
--- a/drivers/nrf24l01/nrf24l01test.py
+++ b/drivers/nrf24l01/nrf24l01test.py
@@ -23,6 +23,8 @@ elif sys.platform == 'esp32':  # Software SPI
 else:
     raise ValueError('Unsupported platform {}'.format(sys.platform))
 
+# For Arduino compatibility the byte order must be reversed
+# pipes = (b'\xe1\xf0\xf0\xf0\xf0', b'\xd2\xf0\xf0\xf0\xf0')
 pipes = (b'\xf0\xf0\xf0\xf0\xe1', b'\xf0\xf0\xf0\xf0\xd2')
 
 def master():

--- a/drivers/nrf24l01/nrf24l01test.py
+++ b/drivers/nrf24l01/nrf24l01test.py
@@ -23,9 +23,9 @@ elif sys.platform == 'esp32':  # Software SPI
 else:
     raise ValueError('Unsupported platform {}'.format(sys.platform))
 
-# For Arduino compatibility the byte order must be reversed
-# pipes = (b'\xe1\xf0\xf0\xf0\xf0', b'\xd2\xf0\xf0\xf0\xf0')
-pipes = (b'\xf0\xf0\xf0\xf0\xe1', b'\xf0\xf0\xf0\xf0\xd2')
+# Addresses are in little-endian format. They correspond to big-endian
+# 0xf0f0f0f0e1, 0xf0f0f0f0d2
+pipes = (b'\xe1\xf0\xf0\xf0\xf0', b'\xd2\xf0\xf0\xf0\xf0')
 
 def master():
     csn = Pin(cfg['csn'], mode=Pin.OUT, value=1)


### PR DESCRIPTION
Ref iss https://github.com/micropython/micropython/issues/5627.
I'm of two minds whether the code should be changed or this comment added. The choice of values for the pipes implies Arduino compatibility when, owing to byte order considerations, this does not actually exist.