### PR TITLE
py: Factor out definition of mp_float_union_t to one location.

### DIFF
--- a/extmod/modurandom.c
+++ b/extmod/modurandom.c
@@ -163,19 +163,7 @@ STATIC MP_DEFINE_CONST_FUN_OBJ_1(mod_urandom_choice_obj, mod_urandom_choice);
 
 // returns a number in the range [0..1) using Yasmarang to fill in the fraction bits
 STATIC mp_float_t yasmarang_float(void) {
-    #if MICROPY_FLOAT_IMPL == MICROPY_FLOAT_IMPL_DOUBLE
-    typedef uint64_t mp_float_int_t;
-    #elif MICROPY_FLOAT_IMPL == MICROPY_FLOAT_IMPL_FLOAT
-    typedef uint32_t mp_float_int_t;
-    #endif
-    union {
-        mp_float_t f;
-        #if MP_ENDIANNESS_LITTLE
-        struct { mp_float_int_t frc:MP_FLOAT_FRAC_BITS, exp:MP_FLOAT_EXP_BITS, sgn:1; } p;
-        #else
-        struct { mp_float_int_t sgn:1, exp:MP_FLOAT_EXP_BITS, frc:MP_FLOAT_FRAC_BITS; } p;
-        #endif
-    } u;
+    mp_float_union_t u;
     u.p.sgn = 0;
     u.p.exp = (1 << (MP_FLOAT_EXP_BITS - 1)) - 1;
     if (MP_FLOAT_FRAC_BITS <= 32) {

--- a/py/misc.h
+++ b/py/misc.h
@@ -211,14 +211,37 @@ extern mp_uint_t mp_verbose_flag;
 /** float internals *************/
 
 #if MICROPY_PY_BUILTINS_FLOAT
+
 #if MICROPY_FLOAT_IMPL == MICROPY_FLOAT_IMPL_DOUBLE
 #define MP_FLOAT_EXP_BITS (11)
 #define MP_FLOAT_FRAC_BITS (52)
+typedef uint64_t mp_float_uint_t;
 #elif MICROPY_FLOAT_IMPL == MICROPY_FLOAT_IMPL_FLOAT
 #define MP_FLOAT_EXP_BITS (8)
 #define MP_FLOAT_FRAC_BITS (23)
+typedef uint32_t mp_float_uint_t;
 #endif
+
 #define MP_FLOAT_EXP_BIAS ((1 << (MP_FLOAT_EXP_BITS - 1)) - 1)
+
+typedef union _mp_float_union_t {
+    mp_float_t f;
+    #if MP_ENDIANNESS_LITTLE
+    struct {
+        mp_float_uint_t frc : MP_FLOAT_FRAC_BITS;
+        mp_float_uint_t exp : MP_FLOAT_EXP_BITS;
+        mp_float_uint_t sgn : 1;
+    } p;
+    #else
+    struct {
+        mp_float_uint_t sgn : 1
+        mp_float_uint_t exp : MP_FLOAT_EXP_BITS;
+        mp_float_uint_t frc : MP_FLOAT_FRAC_BITS;
+    } p;
+    #endif
+    mp_float_uint_t i;
+} mp_float_union_t;
+
 #endif // MICROPY_PY_BUILTINS_FLOAT
 
 #endif // MICROPY_INCLUDED_PY_MISC_H

--- a/py/mpz.c
+++ b/py/mpz.c
@@ -771,20 +771,7 @@ void mpz_set_from_ll(mpz_t *z, long long val, bool is_signed) {
 
 #if MICROPY_PY_BUILTINS_FLOAT
 void mpz_set_from_float(mpz_t *z, mp_float_t src) {
-#if MICROPY_FLOAT_IMPL == MICROPY_FLOAT_IMPL_DOUBLE
-typedef uint64_t mp_float_int_t;
-#elif MICROPY_FLOAT_IMPL == MICROPY_FLOAT_IMPL_FLOAT
-typedef uint32_t mp_float_int_t;
-#endif
-    union {
-        mp_float_t f;
-        #if MP_ENDIANNESS_LITTLE
-        struct { mp_float_int_t frc:MP_FLOAT_FRAC_BITS, exp:MP_FLOAT_EXP_BITS, sgn:1; } p;
-        #else
-        struct { mp_float_int_t sgn:1, exp:MP_FLOAT_EXP_BITS, frc:MP_FLOAT_FRAC_BITS; } p;
-        #endif
-    } u = {src};
-
+    mp_float_union_t u = {src};
     z->neg = u.p.sgn;
     if (u.p.exp == 0) {
         // value == 0 || value < 1
@@ -806,7 +793,7 @@ typedef uint32_t mp_float_int_t;
             const int dig_cnt = (adj_exp + 1 + (DIG_SIZE - 1)) / DIG_SIZE;
             const unsigned int rem = adj_exp % DIG_SIZE;
             int dig_ind, shft;
-            mp_float_int_t frc = u.p.frc | ((mp_float_int_t)1 << MP_FLOAT_FRAC_BITS);
+            mp_float_uint_t frc = u.p.frc | ((mp_float_uint_t)1 << MP_FLOAT_FRAC_BITS);
 
             if (adj_exp < MP_FLOAT_FRAC_BITS) {
                 shft = 0;

--- a/py/objfloat.c
+++ b/py/objfloat.c
@@ -60,21 +60,7 @@ const mp_obj_float_t mp_const_float_pi_obj = {{&mp_type_float}, M_PI};
 #if MICROPY_FLOAT_HIGH_QUALITY_HASH
 // must return actual integer value if it fits in mp_int_t
 mp_int_t mp_float_hash(mp_float_t src) {
-#if MICROPY_FLOAT_IMPL == MICROPY_FLOAT_IMPL_DOUBLE
-typedef uint64_t mp_float_uint_t;
-#elif MICROPY_FLOAT_IMPL == MICROPY_FLOAT_IMPL_FLOAT
-typedef uint32_t mp_float_uint_t;
-#endif
-    union {
-        mp_float_t f;
-        #if MP_ENDIANNESS_LITTLE
-        struct { mp_float_uint_t frc:MP_FLOAT_FRAC_BITS, exp:MP_FLOAT_EXP_BITS, sgn:1; } p;
-        #else
-        struct { mp_float_uint_t sgn:1, exp:MP_FLOAT_EXP_BITS, frc:MP_FLOAT_FRAC_BITS; } p;
-        #endif
-        mp_float_uint_t i;
-    } u = {.f = src};
-
+    mp_float_union_t u = {.f = src};
     mp_int_t val;
     const int adj_exp = (int)u.p.exp - MP_FLOAT_EXP_BIAS;
     if (adj_exp < 0) {


### PR DESCRIPTION
Having 3 separate definitions of the same thing doesn't make sense.