### PR TITLE
ports/nrf/drivers/bluetooth/ble_drv.c line 119: Fix initialization error.

### DIFF
--- a/ports/nrf/drivers/bluetooth/ble_drv.c
+++ b/ports/nrf/drivers/bluetooth/ble_drv.c
@@ -116,7 +116,7 @@ static mp_obj_t mp_gattc_char_data_observer;
 static uint8_t m_adv_handle = BLE_GAP_ADV_SET_HANDLE_NOT_SET;
 static uint8_t m_scan_buffer[BLE_GAP_SCAN_BUFFER_MIN];
 
-nrf_nvic_state_t nrf_nvic_state = {0};
+nrf_nvic_state_t nrf_nvic_state = {{0},0};
 #endif
 
 #if (BLUETOOTH_SD == 110)


### PR DESCRIPTION
when I build nrf port under ubuntu 16.04, there is a error ----> error: missing braces around initializer [-Werror=missing-braces], so I fix it.