### PR TITLE
Fix javascript port build error

### DIFF
--- a/ports/javascript/Makefile
+++ b/ports/javascript/Makefile
@@ -51,7 +51,7 @@ OBJ = $(PY_O)
 OBJ += $(addprefix $(BUILD)/, $(SRC_LIB:.c=.o))
 OBJ += $(addprefix $(BUILD)/, $(SRC_C:.c=.o))
 
-JSFLAGS = -O0 -s EXPORTED_FUNCTIONS="['_mp_js_init', '_mp_js_init_repl', '_mp_js_do_str', '_mp_js_process_char', '_mp_hal_get_interrupt_char', '_mp_keyboard_interrupt']" -s EXTRA_EXPORTED_RUNTIME_METHODS="['ccall', 'cwrap']" -s "BINARYEN_TRAP_MODE='clamp'" --memory-init-file 0 --js-library library.js
+JSFLAGS = -O0 -s EXPORTED_FUNCTIONS="['_mp_js_init', '_mp_js_init_repl', '_mp_js_do_str', '_mp_js_process_char', '_mp_hal_get_interrupt_char', '_mp_keyboard_interrupt']" -s EXTRA_EXPORTED_RUNTIME_METHODS="['ccall', 'cwrap']" -s USE_SDL=2 --memory-init-file 0 --js-library library.js
 
 all: $(BUILD)/micropython.js
 

--- a/ports/nrf/drivers/bluetooth/ble_drv.c
+++ b/ports/nrf/drivers/bluetooth/ble_drv.c
@@ -116,7 +116,7 @@ static mp_obj_t mp_gattc_char_data_observer;
 static uint8_t m_adv_handle = BLE_GAP_ADV_SET_HANDLE_NOT_SET;
 static uint8_t m_scan_buffer[BLE_GAP_SCAN_BUFFER_MIN];
 
-nrf_nvic_state_t nrf_nvic_state = {0};
+nrf_nvic_state_t nrf_nvic_state = {{0},0};
 #endif
 
 #if (BLUETOOTH_SD == 110)


### PR DESCRIPTION
when I build javascript port under ubuntu 16.04, there is a error and can't get a successful build. So I change the makefile flag to  USE_SDL=2, and get a successful binary js file.