### PR TITLE
ports/unix/mpthreadport: use SIGRTMIN + 5 for GC

### DIFF
--- a/ports/unix/mpthreadport.c
+++ b/ports/unix/mpthreadport.c
@@ -39,6 +39,8 @@
 #include <sched.h>
 #include <semaphore.h>
 
+#define MP_THREAD_GC_SIGNAL (SIGRTMIN + 5)
+
 // this structure forms a linked list, one node per active thread
 typedef struct _thread_t {
     pthread_t id;           // system id of thread
@@ -66,7 +68,7 @@ STATIC sem_t thread_signal_done;
 STATIC void mp_thread_gc(int signo, siginfo_t *info, void *context) {
     (void)info; // unused
     (void)context; // unused
-    if (signo == SIGUSR1) {
+    if (signo == MP_THREAD_GC_SIGNAL) {
         void gc_collect_regs_and_stack(void);
         gc_collect_regs_and_stack();
         // We have access to the context (regs, stack) of the thread but it seems
@@ -108,7 +110,7 @@ void mp_thread_init(void) {
     sa.sa_flags = SA_SIGINFO;
     sa.sa_sigaction = mp_thread_gc;
     sigemptyset(&sa.sa_mask);
-    sigaction(SIGUSR1, &sa, NULL);
+    sigaction(MP_THREAD_GC_SIGNAL, &sa, NULL);
 }
 
 void mp_thread_deinit(void) {
@@ -144,7 +146,7 @@ void mp_thread_gc_others(void) {
         if (!th->ready) {
             continue;
         }
-        pthread_kill(th->id, SIGUSR1);
+        pthread_kill(th->id, MP_THREAD_GC_SIGNAL);
         #if defined(__APPLE__)
         sem_wait(thread_signal_done_p);
         #else


### PR DESCRIPTION
This changes the signal used to trigger garbage collection from SIGUSR1 to SIGRTMIN + 5. SIGUSR1 is quite common compared to SIGRTMIN (measured by google search results) and is more likely to conflict with libraries that may use the same signal.

Posix specifies that there are at least 8 real-time signal so 5 was chosen as a "random" number to further avoid potential conflict with libraries that may use SIGRTMIN or SIGRTMAX.

Also, if we ever have a `usignal` module, it would be nice to leave SIGUSR1 and SIGUSR2 free for user programs.