### PR TITLE
stm32/sdram: Fix compile issues from sdram startup test flag.

### DIFF
--- a/ports/stm32/main.c
+++ b/ports/stm32/main.c
@@ -501,6 +501,7 @@ void stm32_main(uint32_t reset_mode) {
     #if MICROPY_HW_SDRAM_SIZE
     sdram_init();
     bool sdram_valid = true;
+    UNUSED(sdram_valid);
     #if MICROPY_HW_SDRAM_STARTUP_TEST
     sdram_valid = sdram_test(true);
     #endif


### PR DESCRIPTION
The sdram test result that's now exposed in stm32 main throws a compile error for some boards, eg
```
main.c:503:10: error: variable 'sdram_valid' set but not used [-Werror=unused-but-set-variable]
```
This PR just flags the variable as unused to avoid the error.