### PR TITLE
py: Add support for native C classes to call Python methods of child instance

### DIFF
--- a/examples/natmod/features3/Makefile
+++ b/examples/natmod/features3/Makefile
@@ -1,0 +1,14 @@
+# Location of top-level MicroPython directory
+MPY_DIR = ../../..
+
+# Name of module
+MOD = features3
+
+# Source files (.c or .py)
+SRC = main.c
+
+# Architecture to build for (x86, x64, armv7m, xtensa, xtensawin)
+ARCH = x64
+
+# Include to get the rules for compiling and linking the module
+include $(MPY_DIR)/py/dynruntime.mk

--- a/examples/natmod/features3/main.c
+++ b/examples/natmod/features3/main.c
@@ -1,0 +1,56 @@
+// Include the header file to get access to the MicroPython API
+#include "py/dynruntime.h"
+
+mp_obj_type_t native_type;
+
+typedef struct _mp_obj_native_t {
+    mp_obj_base_t base;
+    mp_int_t value;
+} mp_obj_native_t;
+
+mp_map_elem_t native_locals_dict_table[3];
+STATIC MP_DEFINE_CONST_DICT(native_locals_dict, native_locals_dict_table);
+
+STATIC mp_obj_t native_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *args) {
+    mp_obj_native_t *self = m_new_obj(mp_obj_native_t);
+    self->base.type = type;
+    self->value = 0;
+    return MP_OBJ_FROM_PTR(self);
+}
+
+STATIC mp_obj_t call_foo(mp_obj_t self_in) {
+    mp_obj_native_t *self = mp_obj_cast_to_native_base_unchecked(self_in);
+
+    // Call self.foo(value) which should go to the derived object
+    mp_obj_t dest[3];
+    mp_fun_table.load_method(self_in, MP_QSTR_foo, dest);
+    dest[2] = mp_obj_new_int(self->value);
+    mp_fun_table.call_method_n_kw(1, 0, dest);
+
+    return mp_const_none;
+}
+STATIC MP_DEFINE_CONST_FUN_OBJ_1(call_foo_obj, call_foo);
+
+STATIC mp_obj_t add(mp_obj_t self_in, mp_obj_t arg) {
+    mp_obj_native_t *self = mp_obj_cast_to_native_base_unchecked(self_in);
+    self->value += mp_obj_get_int(arg);
+    return mp_const_none;
+}
+STATIC MP_DEFINE_CONST_FUN_OBJ_2(add_obj, add);
+
+// This is the entry point and is called when the module is imported
+mp_obj_t mpy_init(mp_obj_fun_bc_t *self, size_t n_args, size_t n_kw, mp_obj_t *args) {
+    MP_DYNRUNTIME_INIT_ENTRY
+
+    native_type.base.type = &mp_type_type;
+    native_type.flags = MP_TYPE_FLAG_CAN_HANDLE_SUBCLASS;
+    native_type.name = MP_QSTR_Native;
+    native_type.make_new = native_make_new;
+    native_locals_dict_table[0] = (mp_map_elem_t){ MP_OBJ_NEW_QSTR(MP_QSTR_add), MP_OBJ_FROM_PTR(&add_obj) };
+    native_locals_dict_table[1] = (mp_map_elem_t){ MP_OBJ_NEW_QSTR(MP_QSTR_call_foo), MP_OBJ_FROM_PTR(&call_foo_obj) };
+    native_type.locals_dict = (void*)&native_locals_dict;
+
+    mp_store_global(MP_QSTR_Native, MP_OBJ_FROM_PTR(&native_type));
+
+    MP_DYNRUNTIME_INIT_EXIT
+}

--- a/examples/natmod/features3/test.py
+++ b/examples/natmod/features3/test.py
@@ -1,0 +1,32 @@
+from features3 import Native
+
+class Derived(Native):
+    def foo(self, val):
+        print('Derived.foo', val)
+
+class Derived2(Derived):
+    def foo(self, val):
+        print('Derived2.write', val)
+
+def test():
+    # Test single inheritance
+    f = Derived()
+    f.add(123)
+    f.call_foo()
+
+    # Call via bound method
+    f.add(456)
+    fun = f.call_foo
+    fun()
+
+    # Test double inheritance
+    f = Derived2()
+    f.add(123)
+    f.call_foo()
+
+    # Call via bound method
+    f.add(456)
+    fun = f.call_foo
+    fun()
+
+test()

--- a/py/dynruntime.h
+++ b/py/dynruntime.h
@@ -116,6 +116,7 @@ static inline void *m_realloc_dyn(void *ptr, size_t new_num_bytes) {
 #define mp_obj_len(o)                       (mp_obj_len_dyn(o))
 #define mp_obj_subscr(base, index, val)     (mp_fun_table.obj_subscr((base), (index), (val)))
 #define mp_obj_list_append(list, item)      (mp_fun_table.list_append((list), (item)))
+#define mp_obj_cast_to_native_base_unchecked(obj) (mp_fun_table.obj_cast_to_native_base_unchecked(obj))
 
 static inline mp_obj_t mp_obj_new_str_of_type_dyn(const mp_obj_type_t *type, const byte* data, size_t len) {
     if (type == &mp_type_str) {

--- a/py/nativeglue.c
+++ b/py/nativeglue.c
@@ -330,6 +330,7 @@ const mp_fun_table_t mp_fun_table = {
     mp_obj_get_float_to_d,
     mp_get_buffer_raise,
     mp_get_stream_raise,
+    mp_obj_cast_to_native_base_unchecked,
     &mp_plat_print,
     &mp_type_type,
     &mp_type_str,

--- a/py/nativeglue.h
+++ b/py/nativeglue.h
@@ -156,6 +156,7 @@ typedef struct _mp_fun_table_t {
     double (*obj_get_float_to_d)(mp_obj_t o);
     void (*get_buffer_raise)(mp_obj_t obj, mp_buffer_info_t *bufinfo, mp_uint_t flags);
     const mp_stream_p_t *(*get_stream_raise)(mp_obj_t self_in, int flags);
+    void *(*obj_cast_to_native_base_unchecked)(mp_const_obj_t self_in);
     const mp_print_t *plat_print;
     const mp_obj_type_t *type_type;
     const mp_obj_type_t *type_str;

--- a/py/obj.h
+++ b/py/obj.h
@@ -451,6 +451,7 @@ typedef mp_obj_t (*mp_fun_kw_t)(size_t n, const mp_obj_t *, mp_map_t *);
 #define MP_TYPE_FLAG_EQ_NOT_REFLEXIVE (0x0040)
 #define MP_TYPE_FLAG_EQ_CHECKS_OTHER_TYPE (0x0080)
 #define MP_TYPE_FLAG_EQ_HAS_NEQ_TEST (0x0010)
+#define MP_TYPE_FLAG_CAN_HANDLE_SUBCLASS (0x0020)
 
 typedef enum {
     PRINT_STR = 0,
@@ -728,6 +729,7 @@ mp_obj_t mp_obj_new_memoryview(byte typecode, size_t nitems, void *items);
 const mp_obj_type_t *mp_obj_get_type(mp_const_obj_t o_in);
 const char *mp_obj_get_type_str(mp_const_obj_t o_in);
 bool mp_obj_is_subclass_fast(mp_const_obj_t object, mp_const_obj_t classinfo); // arguments should be type objects
+void *mp_obj_cast_to_native_base_unchecked(mp_const_obj_t self_in);
 mp_obj_t mp_instance_cast_to_native_base(mp_const_obj_t self_in, mp_const_obj_t native_type);
 
 void mp_obj_print_helper(const mp_print_t *print, mp_obj_t o_in, mp_print_kind_t kind);

--- a/tools/mpy_ld.py
+++ b/tools/mpy_ld.py
@@ -663,7 +663,7 @@ def link_objects(env, native_qstr_vals_len, native_qstr_objs_len):
 
     # Resolve unknown symbols
     mp_fun_table_sec = Section('.external.mp_fun_table', b'', 0)
-    fun_table = {key: 67 + idx
+    fun_table = {key: 68 + idx
         for idx, key in enumerate([
             'mp_type_type',
             'mp_type_str',


### PR DESCRIPTION
This PR is inspired by https://forum.micropython.org/viewtopic.php?f=3&t=7662 and the native module example at https://github.com/jamesbowman/py-bteve/tree/2407c82f852937bdf430cb12469e2b59ab588b3e/mpy, and also CircuitPython's fix https://github.com/adafruit/circuitpython/pull/2550 (see https://github.com/adafruit/circuitpython/commit/81c3bc411fadd41890d4e432a204a12d0750955b and https://github.com/adafruit/circuitpython/commit/f6a635b102259c6bc7d0f163881eac5b5e50a117)

The aim is to allow Python classes to subclass native C classes (eg list) and for the C base class to then be able to call methods of the Python child instance.  Eg:
```python
class A:
    def foo(self):
        self.bar() # call inherited method
class B(A):
    def bar(self):
        print('B.bar')
b = B()
b.foo() # should eventually call b.bar()
```
except that we want to implement class `A` in native C code.

Currently this is not possible to do because native classes get passed their native instance, even if the top-level object is a derived user instance (eg as `b` is above).

One fix is to not extract out the native instance of derived user instances when invoking C methods, but instead pass the top-level instance to the C method.  The problem with this is that all C methods must now be aware that they could be passed a user instance and must handle it accordingly.

The PR here does it a different way, by adding a new type flag that is set only on C classes that can handle a user instance coming in as the "self" argument to their C method.  The advantage of this approach is that classes like tuple/list/dict that don't ever call methods of their inherited objects don't need to have this flag set and so don't need to change.  Only C classes that want to support this feature can enable the flag (there will be overhead in code size and execution time for the C methods to test and extract the native instance).

This PR also exposes the new API function to dynamic native modules, and provides a new example of a dynamic native module that uses this feature (see original forum post linked above).

@tannewt FYI