### PR TITLE
py: Simplify tuple subclass equality testing

### DIFF
--- a/py/objtuple.c
+++ b/py/objtuple.c
@@ -111,9 +111,6 @@ STATIC mp_obj_t tuple_cmp_helper(mp_uint_t op, mp_obj_t self_in, mp_obj_t anothe
         // Slow path for user subclasses
         another_in = mp_instance_cast_to_native_base(another_in, MP_OBJ_FROM_PTR(&mp_type_tuple));
         if (another_in == MP_OBJ_NULL) {
-            if (op == MP_BINARY_OP_EQUAL) {
-                return mp_const_false;
-            }
             return MP_OBJ_NULL;
         }
     }

--- a/tests/basics/subclass_native_cmp.py
+++ b/tests/basics/subclass_native_cmp.py
@@ -7,3 +7,6 @@ t = mytuple((1, 2, 3))
 print(t)
 print(t == (1, 2, 3))
 print((1, 2, 3) == t)
+
+print(t < (1, 2, 3), t < (1, 2, 4))
+print((1, 2, 3) <= t, (1, 2, 4) < t)


### PR DESCRIPTION
This removes code that handles tuple-subclass equality test.

Since commit 3aab54bf434e7f025a91ea05052f1bac439fad8c this piece of code is no longer needed because the top-level function mp_obj_equal_not_equal() now handles the case of user types, and will never call tuple's binary_op function with MP_BINARY_OP_EQUAL and a non-tuple on the RHS.

Tests are added for additional coverage of related parts of this function.

@nickovs FYI, looks to be another little win for the improved equality testing.