### PR TITLE
esp32: Move to IDF 4.0 release version.

### DIFF
--- a/ports/esp32/Makefile
+++ b/ports/esp32/Makefile
@@ -52,13 +52,13 @@ SDKCONFIG_COMBINED = $(BUILD)/sdkconfig.combined
 SDKCONFIG_H = $(BUILD)/sdkconfig.h
 
 # The git hash of the currently supported ESP IDF version.
-# These correspond to v3.3.1 and v4.0-beta1.
+# These correspond to v3.3.1 and v4.0.
 ESPIDF_SUPHASH_V3 := 143d26aa49df524e10fb8e41a71d12e731b9b71d
-ESPIDF_SUPHASH_V4 := 310beae373446ceb9a4ad9b36b5428d7fdf2705f
+ESPIDF_SUPHASH_V4 := 463a9d8b7f9af8205222b80707f9bdbba7c530e1
 
 define print_supported_git_hash
 $(info Supported git hash (v3.3): $(ESPIDF_SUPHASH_V3))
-$(info Supported git hash (v4.0-beta1) (experimental): $(ESPIDF_SUPHASH_V4))
+$(info Supported git hash (v4.0) (experimental): $(ESPIDF_SUPHASH_V4))
 endef
 
 # paths to ESP IDF and its components


### PR DESCRIPTION
This was released recently. Confirmed that WiFi and BLE work. Would be good to investigate how it affects #5543

Importantly though, this fixes a fairly nasty WPA connection bug reported by SeonR (likely fixed by https://github.com/espressif/esp-idf/commit/e659f1b15a6d6e9fd521ea81379ae440a113d3c5).