### PR TITLE
[STM32F446RE] NUCLEO board enable CAN bus support

### DIFF
--- a/ports/stm32/boards/NUCLEO_F446RE/mpconfigboard.h
+++ b/ports/stm32/boards/NUCLEO_F446RE/mpconfigboard.h
@@ -53,6 +53,12 @@
 #define MICROPY_HW_SPI4_MISO    (pin_A1)    //              pin 30 on CN7
 #define MICROPY_HW_SPI4_MOSI    (pin_A11)   //              pin 14 on CN10
 
+// CAN busses
+#define MICROPY_HW_CAN1_TX      (pin_B9)    //              pin 3 on CN10
+#define MICROPY_HW_CAN1_RX      (pin_B8)    //              pin 5 on CN10
+#define MICROPY_HW_CAN2_TX      (pin_B6)    //              pin 17 on CN10
+#define MICROPY_HW_CAN2_RX      (pin_B5)    //              pin 29 on CN10
+
 // USRSW is pulled low. Pressing the button makes the input go high.
 #define MICROPY_HW_USRSW_PIN        (pin_C13)
 #define MICROPY_HW_USRSW_PULL       (GPIO_NOPULL)


### PR DESCRIPTION
I have declared CAN1 and CAN2 pins in `mpconfigboard.h`. It has compiled well and without errors or warnings.
The only issue is that I can't bring it up. 
I have the Logic Analyser connected to CAN RX and CAN TX pins (also tried with TJA1050) which are PB8 and PB9. When running the code:
```py
from pyb import CAN
can = CAN(1, CAN.NORMAL)
# can = CAN(1, CAN.NORMAL, prescaler=2, sjw=1, bs1=14, bs2=6)
can.send('message!', 123)
```
I see no reaction.

I'm curious if I have missed something or It's not that easy to enable an extra interface.
PS. There was no Crystal soldered, later I have soldered one with 8MHz but nothing changed.