### PR TITLE
travis: Add OSX build.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -189,6 +189,22 @@ jobs:
         - make ${MAKEOPTS} -C ports/unix VARIANT=minimal
         - (cd tests && MICROPY_CPYTHON3=python3 MICROPY_MICROPYTHON=../ports/unix/micropython-minimal ./run-tests -e exception_chain -e self_type_check -e subclass_native_init -d basics)
 
+    # unix port on OSX
+    - stage: test
+      os: osx
+      osx_image: xcode11.3
+      env:
+        - NAME="unix port build with clang on OSX"
+        - PKG_CONFIG_PATH=/usr/local/opt/libffi/lib/pkgconfig
+      install:
+        - brew install pkgconfig
+      script:
+        - make ${MAKEOPTS} -C mpy-cross
+        - make ${MAKEOPTS} -C ports/unix submodules
+        - make ${MAKEOPTS} -C ports/unix deplibs
+        - make ${MAKEOPTS} -C ports/unix
+        - make ${MAKEOPTS} -C ports/unix test
+
     # windows port via mingw
     - stage: test
       env: NAME="windows port build via mingw"


### PR DESCRIPTION
Add a standard unix port build in an OSX environment using clang.
Should help in catching build failures due to
platform differences early on.