### PR TITLE
py/objarray: memoryview requires MP_TYPE_FLAG_EQ_CHECKS_OTHER_TYPE.

### DIFF
--- a/py/objarray.c
+++ b/py/objarray.c
@@ -574,6 +574,7 @@ const mp_obj_type_t mp_type_bytearray = {
 const mp_obj_type_t mp_type_memoryview = {
     { &mp_type_type },
     .name = MP_QSTR_memoryview,
+    .flags = MP_TYPE_FLAG_EQ_CHECKS_OTHER_TYPE,
     .make_new = memoryview_make_new,
     .getiter = array_iterator_new,
     .unary_op = array_unary_op,

--- a/tests/basics/array1.py
+++ b/tests/basics/array1.py
@@ -37,3 +37,23 @@ try:
     array.array('X')
 except ValueError:
     print("ValueError")
+
+# equality (CPython requires both sides are array)
+print(bytes(array.array('b', [0x61, 0x62, 0x63])) == b'abc')
+print(array.array('b', [0x61, 0x62, 0x63]) == b'abc')
+print(array.array('b', [0x61, 0x62, 0x63]) != b'abc')
+print(array.array('b', [0x61, 0x62, 0x63]) == b'xyz')
+print(array.array('b', [0x61, 0x62, 0x63]) != b'xyz')
+print(b'abc' == array.array('b', [0x61, 0x62, 0x63]))
+print(b'abc' != array.array('b', [0x61, 0x62, 0x63]))
+print(b'xyz' == array.array('b', [0x61, 0x62, 0x63]))
+print(b'xyz' != array.array('b', [0x61, 0x62, 0x63]))
+
+class X(array.array):
+    pass
+
+print(bytes(X('b', [0x61, 0x62, 0x63])) == b'abc')
+print(X('b', [0x61, 0x62, 0x63]) == b'abc')
+print(X('b', [0x61, 0x62, 0x63]) != b'abc')
+print(X('b', [0x61, 0x62, 0x63]) == array.array('b', [0x61, 0x62, 0x63]))
+print(X('b', [0x61, 0x62, 0x63]) != array.array('b', [0x61, 0x62, 0x63]))

--- a/tests/basics/memoryview1.py
+++ b/tests/basics/memoryview1.py
@@ -107,3 +107,21 @@ try:
     memoryview(b'a').noexist
 except AttributeError:
     print('AttributeError')
+
+# equality
+print(memoryview(b'abc') == b'abc')
+print(memoryview(b'abc') != b'abc')
+print(memoryview(b'abc') == b'xyz')
+print(memoryview(b'abc') != b'xyz')
+print(b'abc' == memoryview(b'abc'))
+print(b'abc' != memoryview(b'abc'))
+print(b'abc' == memoryview(b'xyz'))
+print(b'abc' != memoryview(b'xyz'))
+print(memoryview(b'abcdef')[2:4] == b'cd')
+print(memoryview(b'abcdef')[2:4] != b'cd')
+print(memoryview(b'abcdef')[2:4] == b'xy')
+print(memoryview(b'abcdef')[2:4] != b'xy')
+print(b'cd' == memoryview(b'abcdef')[2:4])
+print(b'cd' != memoryview(b'abcdef')[2:4])
+print(b'xy' == memoryview(b'abcdef')[2:4])
+print(b'xy' != memoryview(b'abcdef')[2:4])


### PR DESCRIPTION
Fixes #5674 (comparison of memoryview against bytes).