### PR TITLE
py/runtime.c: Fix op bool for subclasses of native types.

### DIFF
--- a/py/runtime.c
+++ b/py/runtime.c
@@ -284,6 +284,12 @@ mp_obj_t mp_unary_op(mp_unary_op_t op, mp_obj_t arg) {
                 return result;
             }
         }
+        if (op == MP_UNARY_OP_BOOL) {
+            // Type doesn't have unary_op (or didn't handle MP_UNARY_OP_BOOL),
+            // so is implicitly True as this code path is impossible to reach
+            // if arg==mp_const_none.
+            return mp_const_true;
+        }
         // With MP_UNARY_OP_INT, mp_unary_op() becomes a fallback for mp_obj_get_int().
         // In this case provide a more focused error message to not confuse, e.g. chr(1.0)
         #if MICROPY_ERROR_REPORTING <= MICROPY_ERROR_REPORTING_TERSE

--- a/tests/basics/unary_op.py
+++ b/tests/basics/unary_op.py
@@ -23,5 +23,12 @@ print(not A())
 # check user instances derived from builtins
 class B(int): pass
 print(not B())
+print(True if B() else False)
 class C(list): pass
 print(not C())
+print(True if C() else False)
+# type doesn't define unary_op
+class D(type): pass
+d = D("foo", (), {})
+print(not d)
+print(True if d else False)


### PR DESCRIPTION
Fixes #5677

This is +8 bytes on PYBV11.