### PR TITLE
RFC: Mechanism for allowing dynamic native modules to call port-specific functionality.

### DIFF
--- a/examples/natmod/features0/Makefile
+++ b/examples/natmod/features0/Makefile
@@ -8,7 +8,9 @@ MOD = features0
 SRC = features0.c
 
 # Architecture to build for (x86, x64, armv7m, xtensa, xtensawin)
-ARCH = x64
+ARCH = xtensawin
+
+PORT = esp32
 
 # Include to get the rules for compiling and linking the module
 include $(MPY_DIR)/py/dynruntime.mk

--- a/examples/natmod/features0/features0.c
+++ b/examples/natmod/features0/features0.c
@@ -7,22 +7,24 @@
 // Include the header file to get access to the MicroPython API
 #include "py/dynruntime.h"
 
-// Helper function to compute factorial
-STATIC mp_int_t factorial_helper(mp_int_t x) {
-    if (x == 0) {
-        return 1;
-    }
-    return x * factorial_helper(x - 1);
-}
+// // Helper function to compute factorial
+// STATIC mp_int_t factorial_helper(mp_int_t x) {
+//     if (x == 0) {
+//         return 1;
+//     }
+//     return x * factorial_helper(x - 1);
+// }
 
 // This is the function which will be called from Python, as factorial(x)
 STATIC mp_obj_t factorial(mp_obj_t x_obj) {
-    // Extract the integer from the MicroPython input object
-    mp_int_t x = mp_obj_get_int(x_obj);
-    // Calculate the factorial
-    mp_int_t result = factorial_helper(x);
-    // Convert the result to a MicroPython integer object and return it
-    return mp_obj_new_int(result);
+    // // Extract the integer from the MicroPython input object
+    // mp_int_t x = mp_obj_get_int(x_obj);
+    // // Calculate the factorial
+    // mp_int_t result = factorial_helper(x);
+    // // Convert the result to a MicroPython integer object and return it
+    // return mp_obj_new_int(result);
+
+    return mp_obj_new_int(mp_port_fun_table.esp_clk_cpu_freq());
 }
 // Define a Python reference to the function above
 STATIC MP_DEFINE_CONST_FUN_OBJ_1(factorial_obj, factorial);

--- a/ports/esp32/Makefile
+++ b/ports/esp32/Makefile
@@ -351,6 +351,7 @@ SRC_C = \
 	mpthreadport.c \
 	machine_rtc.c \
 	machine_sdcard.c \
+	portnativeglue.c \
 	$(wildcard $(BOARD_DIR)/*.c) \
 	$(SRC_MOD)
 

--- a/ports/esp32/mpconfigport.h
+++ b/ports/esp32/mpconfigport.h
@@ -59,6 +59,7 @@
 #define MICROPY_ENABLE_SCHEDULER            (1)
 #define MICROPY_SCHEDULER_DEPTH             (8)
 #define MICROPY_VFS                         (1)
+#define MICROPY_PORT_FUN_TABLE              (1)
 
 // control over Python builtins
 #define MICROPY_PY_FUNCTION_ATTRS           (1)

--- a/ports/esp32/portnativeglue.c
+++ b/ports/esp32/portnativeglue.c
@@ -1,0 +1,42 @@
+/*
+ * This file is part of the MicroPython project, http://micropython.org/
+ *
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2020 Jim Mussared
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#if MICROPY_ESP_IDF_4
+#include "esp32/clk.h"
+#else
+#include "esp_clk.h"
+#endif
+
+#include "py/runtime.h"
+#include "py/nativeglue.h"
+
+#if MICROPY_PORT_FUN_TABLE && MICROPY_EMIT_NATIVE
+
+const mp_port_fun_table_t mp_port_fun_table = {
+    esp_clk_cpu_freq,
+};
+
+#endif // MICROPY_PORT_FUN_TABLE && MICROPY_EMIT_NATIVE

--- a/ports/esp32/portnativeglue.h
+++ b/ports/esp32/portnativeglue.h
@@ -1,0 +1,36 @@
+/*
+ * This file is part of the MicroPython project, http://micropython.org/
+ *
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2020 Jim Mussared
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#ifndef MICROPY_INCLUDED_ESP32_PORTNATIVEGLUE_H
+#define MICROPY_INCLUDED_ESP32_PORTNATIVEGLUE_H
+
+typedef struct _mp_port_fun_table_t {
+    int (*esp_clk_cpu_freq)(void);
+} mp_port_fun_table_t;
+
+extern const mp_port_fun_table_t mp_port_fun_table;
+
+#endif // MICROPY_INCLUDED_ESP32_PORTNATIVEGLUE_H

--- a/py/dynruntime.h
+++ b/py/dynruntime.h
@@ -215,4 +215,13 @@ static inline void mp_raise_OSError_dyn(int er) {
 #define mp_obj_get_float(o)         (mp_obj_get_float_to_d((o)))
 #endif
 
+/******************************************************************************/
+// Port-specific functionality
+
+#if MICROPY_PORT_FUN_TABLE
+#define mp_port_fun_table           (*mp_fun_table.port_fun_table)
+#else
+#define mp_port_fun_table           ERROR_must_set_PORT_in_natmod_make
+#endif
+
 #endif // MICROPY_INCLUDED_PY_DYNRUNTIME_H

--- a/py/dynruntime.mk
+++ b/py/dynruntime.mk
@@ -32,6 +32,11 @@ CFLAGS += -fpic -fno-common
 CFLAGS += -U _FORTIFY_SOURCE # prevent use of __*_chk libc functions
 #CFLAGS += -fdata-sections -ffunction-sections
 
+ifneq ($(PORT),)
+CFLAGS += -I$(MPY_DIR)/ports/$(PORT)
+CFLAGS += -DMICROPY_PORT_FUN_TABLE
+endif
+
 MPY_CROSS_FLAGS += -march=$(ARCH)
 
 SRC_O += $(addprefix $(BUILD)/, $(patsubst %.c,%.o,$(filter %.c,$(SRC))))

--- a/py/nativeglue.c
+++ b/py/nativeglue.c
@@ -344,6 +344,11 @@ const mp_fun_table_t mp_fun_table = {
     &mp_stream_readinto_obj,
     &mp_stream_unbuffered_readline_obj,
     &mp_stream_write_obj,
+    #ifdef MICROPY_PORT_FUN_TABLE
+    &mp_port_fun_table,
+    #else
+    NULL,
+    #endif
 };
 
-#endif // MICROPY_EMIT_NATIVE
+#endif // MICROPY_EMIT_NATIVE && !MICROPY_DYNAMIC_COMPILER

--- a/py/nativeglue.h
+++ b/py/nativeglue.h
@@ -31,6 +31,12 @@
 #include "py/persistentcode.h"
 #include "py/stream.h"
 
+#if MICROPY_PORT_FUN_TABLE
+#include "portnativeglue.h"
+#else
+typedef void* mp_port_fun_table_t;
+#endif
+
 typedef enum {
     MP_F_CONST_NONE_OBJ = 0,
     MP_F_CONST_FALSE_OBJ,
@@ -170,6 +176,7 @@ typedef struct _mp_fun_table_t {
     const mp_obj_fun_builtin_var_t *stream_readinto_obj;
     const mp_obj_fun_builtin_var_t *stream_unbuffered_readline_obj;
     const mp_obj_fun_builtin_var_t *stream_write_obj;
+    const mp_port_fun_table_t *port_fun_table;
 } mp_fun_table_t;
 
 extern const mp_fun_table_t mp_fun_table;


### PR DESCRIPTION
This is an alternative to #5653 by @tve 

The main benefit of this approach is that it's extremely simple and requires no modifications to the linker/mpy machinery. Maintaining the table is obvious and straightforward and a logical extension of the existing mp_fun_table.

Main downside is that it calls to port-specific functions involve an indirection but I'm not sure this is too serious.

I'm not too fond of "portnativeglue.{c,h}" but mostly this is a PoC for discussion.

Includes a modification to natmod/features0 to demonstrate using it on ESP32.