### PR TITLE
ports/esp32/machine_sdcard.c: sdcard read/write speedup

### DIFF
--- a/docs/library/machine.SDCard.rst
+++ b/docs/library/machine.SDCard.rst
@@ -23,7 +23,7 @@ arguments that might need to be set in order to use either a non-standard slot
 or a non-standard pin assignment. The exact subset of arguments supported will
 vary from platform to platform.
 
-.. class:: SDCard(slot=1, width=1, cd=None, wp=None, sck=None, miso=None, mosi=None, cs=None)
+.. class:: SDCard(slot=1, width=1, cd=None, wp=None, sck=None, miso=None, mosi=None, cs=None, freq=20000000)
 
     This class provides access to SD or MMC storage cards using either
     a dedicated SD/MMC interface hardware or through an SPI channel.
@@ -50,6 +50,8 @@ vary from platform to platform.
      - *mosi* can be used to specify an SPI mosi pin.
 
      - *cs* can be used to specify an SPI chip select pin.
+     
+     - *freq* selects the SD/MMC interface frequency in Hz unit.(Note: only supported on the ESP32)
 
 Implementation-specific details
 -------------------------------

--- a/ports/esp32/machine_sdcard.c
+++ b/ports/esp32/machine_sdcard.c
@@ -126,6 +126,7 @@ STATIC mp_obj_t machine_sdcard_make_new(const mp_obj_type_t *type, size_t n_args
         ARG_mosi,
         ARG_sck,
         ARG_cs,
+        ARG_freq,
     };
     STATIC const mp_arg_t allowed_args[] = {
         { MP_QSTR_slot,     MP_ARG_KW_ONLY | MP_ARG_INT, {.u_int = 1} },
@@ -137,6 +138,8 @@ STATIC mp_obj_t machine_sdcard_make_new(const mp_obj_type_t *type, size_t n_args
         { MP_QSTR_mosi,     MP_ARG_KW_ONLY | MP_ARG_OBJ, {.u_obj = mp_const_none} },
         { MP_QSTR_sck,      MP_ARG_KW_ONLY | MP_ARG_OBJ, {.u_obj = mp_const_none} },
         { MP_QSTR_cs,       MP_ARG_KW_ONLY | MP_ARG_OBJ, {.u_obj = mp_const_none} },
+        // add freq key and default with 20,000,000(Hz)
+        { MP_QSTR_freq,  MP_ARG_KW_ONLY | MP_ARG_INT, {.u_int = 20000000} },
     };
     mp_arg_val_t arg_vals[MP_ARRAY_SIZE(allowed_args)];
     mp_map_t kw_args;
@@ -175,11 +178,16 @@ STATIC mp_obj_t machine_sdcard_make_new(const mp_obj_type_t *type, size_t n_args
     self->flags = 0;
     // Note that these defaults are macros that expand to structure
     // constants so we can't directly assign them to fields.
+
+    int freq = arg_vals[ARG_freq].u_int;
+
     if (is_spi) {
         sdmmc_host_t _temp_host = SDSPI_HOST_DEFAULT();
+        _temp_host.max_freq_khz = freq / 1000;
         self->host = _temp_host;
     } else {
         sdmmc_host_t _temp_host = SDMMC_HOST_DEFAULT();
+        _temp_host.max_freq_khz = freq / 1000;
         self->host = _temp_host;
     }
 


### PR DESCRIPTION
Use the 40MHz freq for SD card clk, tested on a esp32 module, and 30% read/write speed improve.