### PR TITLE
esp8266: enable real open drain output on the pins

### DIFF
--- a/ports/esp8266/esppwm.c
+++ b/ports/esp8266/esppwm.c
@@ -384,7 +384,6 @@ pwm_add(uint8_t pin_id, uint32_t pin_mux, uint32_t pin_func){
             pwm.duty[i] = 0;
             pwm_gpio |= (1 << pin_num[channel]);
             PIN_FUNC_SELECT(pin_mux, pin_func);
-            GPIO_REG_WRITE(GPIO_PIN_ADDR(GPIO_ID_PIN(pin_num[channel])), GPIO_REG_READ(GPIO_PIN_ADDR(GPIO_ID_PIN(pin_num[channel]))) & (~ GPIO_PIN_PAD_DRIVER_SET(GPIO_PAD_DRIVER_ENABLE))); //disable open drain;
             pwm_channel_num++;
             UNLOCK_PWM(critical);   // leave critical
             return channel;

--- a/ports/esp8266/machine_pin.c
+++ b/ports/esp8266/machine_pin.c
@@ -203,26 +203,13 @@ void pin_set(uint pin, int value) {
 
     uint32_t enable = 0;
     uint32_t disable = 0;
-    switch (pin_mode[pin]) {
-        case GPIO_MODE_INPUT:
-            value = -1;
-            disable = 1;
-            break;
-
-        case GPIO_MODE_OUTPUT:
-            enable = 1;
-            break;
-
-        case GPIO_MODE_OPEN_DRAIN:
-            if (value == -1) {
-                return;
-            } else if (value == 0) {
-                enable = 1;
-            } else {
-                value = -1;
-                disable = 1;
-            }
-            break;
+    if (pin_mode[pin] == GPIO_MODE_INPUT)
+    {
+        value = -1;
+        disable = 1;
+    } else {
+        // GPIO_MODE_OUTPUT and GPIO_MODE_OPEN_DRAIN:
+        enable = 1;
     }
 
     enable <<= pin;
@@ -300,6 +287,10 @@ STATIC mp_obj_t pyb_pin_obj_init_helper(pyb_pin_obj_t *self, size_t n_args, cons
         if ((pull & GPIO_PULL_UP) != 0) {
             PIN_PULLUP_EN(self->periph);
         }
+    }
+
+    if (mode == GPIO_MODE_OPEN_DRAIN) {
+        mp_hal_pin_open_drain(self->phys_port);
     }
 
     pin_set(self->phys_port, value);

--- a/ports/esp8266/machine_pwm.c
+++ b/ports/esp8266/machine_pwm.c
@@ -28,6 +28,7 @@
 #include <stdint.h>
 
 #include "esppwm.h"
+#include "esp_mphal.h"
 
 #include "py/runtime.h"
 #include "modmachine.h"
@@ -75,6 +76,10 @@ STATIC void pyb_pwm_init_helper(pyb_pwm_obj_t *self, size_t n_args, const mp_obj
     }
     if (args[ARG_duty].u_int != -1) {
         pwm_set_duty(args[ARG_duty].u_int, self->channel);
+    }
+
+    if (pin_mode[self->pin->phys_port] == GPIO_MODE_OPEN_DRAIN) {
+        mp_hal_pin_open_drain(self->pin->phys_port);
     }
 
     pwm_start();
@@ -139,6 +144,10 @@ STATIC mp_obj_t pyb_pwm_duty(size_t n_args, const mp_obj_t *args) {
     if (!self->active) {
         pwm_add(self->pin->phys_port, self->pin->periph, self->pin->func);
         self->active = 1;
+
+        if (pin_mode[self->pin->phys_port] == GPIO_MODE_OPEN_DRAIN) {
+            mp_hal_pin_open_drain(self->pin->phys_port);
+        }
     }
     if (n_args == 1) {
         // get

--- a/ports/esp8266/modmachine.h
+++ b/ports/esp8266/modmachine.h
@@ -22,6 +22,17 @@ typedef struct _pyb_pin_obj_t {
 
 const pyb_pin_obj_t pyb_pin_obj[16 + 1];
 
+#define GPIO_MODE_INPUT (0)
+#define GPIO_MODE_OUTPUT (1)
+#define GPIO_MODE_OPEN_DRAIN (2) // synthesised
+#define GPIO_PULL_NONE (0)
+#define GPIO_PULL_UP (1)
+// Removed in SDK 1.1.0
+//#define GPIO_PULL_DOWN (2)
+
+extern uint8_t pin_mode[16+1];
+
+
 void pin_init0(void);
 void pin_intr_handler_iram(void *arg);
 void pin_intr_handler(uint32_t);


### PR DESCRIPTION
As noted in #5696, there were issues with PWM for `Pin.OPEN_DRAIN` gpio output mode. However, open drain was not being enabled, it was only emulated with the `Pin.value()` function.  This adds calls `mp_hal_pin_open_drain()` to put the pin into true open drain mode and removes the emulation code from `Pin.value()`.

It also removes the code that was explicitly turning off the open drain output during PWM. Together these changes allow driving external transistor high-current switches.