### PR TITLE
Apply yapf to format all Python code

### DIFF
--- a/drivers/dht/dht.py
+++ b/drivers/dht/dht.py
@@ -6,6 +6,7 @@ try:
 except:
     from pyb import dht_readinto
 
+
 class DHTBase:
     def __init__(self, pin):
         self.pin = pin
@@ -17,12 +18,14 @@ class DHTBase:
         if (buf[0] + buf[1] + buf[2] + buf[3]) & 0xff != buf[4]:
             raise Exception("checksum error")
 
+
 class DHT11(DHTBase):
     def humidity(self):
         return self.buf[0]
 
     def temperature(self):
         return self.buf[2]
+
 
 class DHT22(DHTBase):
     def humidity(self):

--- a/drivers/display/lcd160cr.py
+++ b/drivers/display/lcd160cr.py
@@ -29,6 +29,7 @@ _uart_baud_table = {
     460800: 8,
 }
 
+
 class LCD160CR:
     def __init__(self, connect=None, *, pwr=None, i2c=None, spi=None, i2c_addr=98):
         if connect in ('X', 'Y', 'XY', 'YX'):
@@ -292,7 +293,7 @@ class LCD160CR:
                 ix += len(line2) - 1
 
     def screen_load(self, buf):
-        l = self.w * self.h * 2+2
+        l = self.w * self.h * 2 + 2
         self._fcmd2b('<BBHBBB', 0x70, l, 16, self.w, self.h)
         n = 0
         ar = memoryview(buf)
@@ -315,7 +316,8 @@ class LCD160CR:
         self._fcmd2('<BBHH', 0x63, fg, bg)
 
     def set_font(self, font, scale=0, bold=0, trans=0, scroll=0):
-        self._fcmd2('<BBBB', 0x46, (scroll << 7) | (trans << 6) | ((font & 3) << 4) | (bold & 0xf), scale & 0xff)
+        self._fcmd2('<BBBB', 0x46, (scroll << 7) | (trans << 6) | ((font & 3) << 4) | (bold & 0xf),
+                    scale & 0xff)
 
     def write(self, s):
         # TODO: eventually check for room in LCD input queue
@@ -424,7 +426,8 @@ class LCD160CR:
     #### ADVANCED COMMANDS ####
 
     def set_spi_win(self, x, y, w, h):
-        pack_into('<BBBHHHHHHHH', self.buf19, 0, 2, 0x55, 10, x, y, x + w - 1, y + h - 1, 0, 0, 0, 0xffff)
+        pack_into('<BBBHHHHHHHH', self.buf19, 0, 2, 0x55, 10, x, y, x + w - 1, y + h - 1, 0, 0, 0,
+                  0xffff)
         self._send(self.buf19)
 
     def fast_spi(self, flush=True):

--- a/drivers/display/lcd160cr_test.py
+++ b/drivers/display/lcd160cr_test.py
@@ -3,10 +3,12 @@
 
 import time, math, framebuf, lcd160cr
 
+
 def get_lcd(lcd):
     if type(lcd) is str:
         lcd = lcd160cr.LCD160CR(lcd)
     return lcd
+
 
 def show_adc(lcd, adc):
     data = [adc.read_core_temp(), adc.read_core_vbat(), 3.3]
@@ -21,7 +23,7 @@ def show_adc(lcd, adc):
             lcd.set_pos(0, 100 + i * 16)
         else:
             lcd.set_font(2, trans=1)
-            lcd.set_pos(0, lcd.h-60 + i * 16)
+            lcd.set_pos(0, lcd.h - 60 + i * 16)
         lcd.write('%4s: ' % ('TEMP', 'VBAT', 'VREF')[i])
         if i > 0:
             s = '%6.3fV' % data[i]
@@ -31,8 +33,9 @@ def show_adc(lcd, adc):
             lcd.set_font(1, bold=0, scale=1)
         else:
             lcd.set_font(1, bold=0, scale=1, trans=1)
-            lcd.set_pos(45, lcd.h-60 + i * 16)
+            lcd.set_pos(45, lcd.h - 60 + i * 16)
         lcd.write(s)
+
 
 def test_features(lcd, orient=lcd160cr.PORTRAIT):
     # if we run on pyboard then use ADC and RTC features
@@ -80,15 +83,13 @@ def test_features(lcd, orient=lcd160cr.PORTRAIT):
             if tx2 >= 0 and ty2 >= 0 and tx2 < w and ty2 < h:
                 tx, ty = tx2, ty2
         else:
-             tx = (tx + 1) % w
-             ty = (ty + 1) % h
+            tx = (tx + 1) % w
+            ty = (ty + 1) % h
 
         # create and show the inline framebuf
         fbuf.fill(lcd.rgb(128 + int(64 * math.cos(0.1 * i)), 128, 192))
-        fbuf.line(w // 2, h // 2,
-            w // 2 + int(40 * math.cos(0.2 * i)),
-            h // 2 + int(40 * math.sin(0.2 * i)),
-            lcd.rgb(128, 255, 64))
+        fbuf.line(w // 2, h // 2, w // 2 + int(40 * math.cos(0.2 * i)),
+                  h // 2 + int(40 * math.sin(0.2 * i)), lcd.rgb(128, 255, 64))
         fbuf.hline(0, ty, w, lcd.rgb(64, 64, 64))
         fbuf.vline(tx, 0, h, lcd.rgb(64, 64, 64))
         fbuf.rect(tx - 3, ty - 3, 7, 7, lcd.rgb(64, 64, 64))
@@ -97,9 +98,8 @@ def test_features(lcd, orient=lcd160cr.PORTRAIT):
             y = h // 2 - 8 + int(32 * math.sin(0.05 * i + phase))
             fbuf.blit(mlogo, x, y)
         for j in range(-3, 3):
-            fbuf.text('MicroPython',
-                5, h // 2 + 9 * j + int(20 * math.sin(0.1 * (i + j))),
-                lcd.rgb(128 + 10 * j, 0, 128 - 10 * j))
+            fbuf.text('MicroPython', 5, h // 2 + 9 * j + int(20 * math.sin(0.1 * (i + j))),
+                      lcd.rgb(128 + 10 * j, 0, 128 - 10 * j))
         lcd.show_framebuf(fbuf)
 
         # show results from the ADC
@@ -111,7 +111,8 @@ def test_features(lcd, orient=lcd160cr.PORTRAIT):
             lcd.set_pos(2, 0)
             lcd.set_font(1)
             t = rtc.datetime()
-            lcd.write('%4d-%02d-%02d %2d:%02d:%02d.%01d' % (t[0], t[1], t[2], t[4], t[5], t[6], t[7] // 100000))
+            lcd.write('%4d-%02d-%02d %2d:%02d:%02d.%01d' %
+                      (t[0], t[1], t[2], t[4], t[5], t[6], t[7] // 100000))
 
         # compute the frame rate
         t1 = time.ticks_us()
@@ -121,6 +122,7 @@ def test_features(lcd, orient=lcd160cr.PORTRAIT):
         # show the frame rate
         lcd.set_pos(2, 9)
         lcd.write('%.2f fps' % (1000000 / dt))
+
 
 def test_mandel(lcd, orient=lcd160cr.PORTRAIT):
     # set orientation and clear screen
@@ -161,10 +163,12 @@ def test_mandel(lcd, orient=lcd160cr.PORTRAIT):
             line[2 * u + 1] = rgb >> 8
         spi.write(line)
 
+
 def test_all(lcd, orient=lcd160cr.PORTRAIT):
     lcd = get_lcd(lcd)
     test_features(lcd, orient)
     test_mandel(lcd, orient)
+
 
 print('To run all tests: test_all(<lcd>)')
 print('Individual tests are: test_features, test_mandel')

--- a/drivers/display/ssd1306.py
+++ b/drivers/display/ssd1306.py
@@ -3,25 +3,25 @@
 from micropython import const
 import framebuf
 
-
 # register definitions
-SET_CONTRAST        = const(0x81)
-SET_ENTIRE_ON       = const(0xa4)
-SET_NORM_INV        = const(0xa6)
-SET_DISP            = const(0xae)
-SET_MEM_ADDR        = const(0x20)
-SET_COL_ADDR        = const(0x21)
-SET_PAGE_ADDR       = const(0x22)
+SET_CONTRAST = const(0x81)
+SET_ENTIRE_ON = const(0xa4)
+SET_NORM_INV = const(0xa6)
+SET_DISP = const(0xae)
+SET_MEM_ADDR = const(0x20)
+SET_COL_ADDR = const(0x21)
+SET_PAGE_ADDR = const(0x22)
 SET_DISP_START_LINE = const(0x40)
-SET_SEG_REMAP       = const(0xa0)
-SET_MUX_RATIO       = const(0xa8)
-SET_COM_OUT_DIR     = const(0xc0)
-SET_DISP_OFFSET     = const(0xd3)
-SET_COM_PIN_CFG     = const(0xda)
-SET_DISP_CLK_DIV    = const(0xd5)
-SET_PRECHARGE       = const(0xd9)
-SET_VCOM_DESEL      = const(0xdb)
-SET_CHARGE_PUMP     = const(0x8d)
+SET_SEG_REMAP = const(0xa0)
+SET_MUX_RATIO = const(0xa8)
+SET_COM_OUT_DIR = const(0xc0)
+SET_DISP_OFFSET = const(0xd3)
+SET_COM_PIN_CFG = const(0xda)
+SET_DISP_CLK_DIV = const(0xd5)
+SET_PRECHARGE = const(0xd9)
+SET_VCOM_DESEL = const(0xdb)
+SET_CHARGE_PUMP = const(0x8d)
+
 
 # Subclassing FrameBuffer provides support for graphics primitives
 # http://docs.micropython.org/en/latest/pyboard/library/framebuf.html
@@ -37,27 +37,36 @@ class SSD1306(framebuf.FrameBuffer):
 
     def init_display(self):
         for cmd in (
-            SET_DISP | 0x00, # off
-            # address setting
-            SET_MEM_ADDR, 0x00, # horizontal
-            # resolution and layout
-            SET_DISP_START_LINE | 0x00,
-            SET_SEG_REMAP | 0x01, # column addr 127 mapped to SEG0
-            SET_MUX_RATIO, self.height - 1,
-            SET_COM_OUT_DIR | 0x08, # scan from COM[N] to COM0
-            SET_DISP_OFFSET, 0x00,
-            SET_COM_PIN_CFG, 0x02 if self.height == 32 else 0x12,
-            # timing and driving scheme
-            SET_DISP_CLK_DIV, 0x80,
-            SET_PRECHARGE, 0x22 if self.external_vcc else 0xf1,
-            SET_VCOM_DESEL, 0x30, # 0.83*Vcc
-            # display
-            SET_CONTRAST, 0xff, # maximum
-            SET_ENTIRE_ON, # output follows RAM contents
-            SET_NORM_INV, # not inverted
-            # charge pump
-            SET_CHARGE_PUMP, 0x10 if self.external_vcc else 0x14,
-            SET_DISP | 0x01): # on
+                SET_DISP | 0x00, # off
+                # address setting
+                SET_MEM_ADDR,
+                0x00, # horizontal
+                # resolution and layout
+                SET_DISP_START_LINE | 0x00,
+                SET_SEG_REMAP | 0x01, # column addr 127 mapped to SEG0
+                SET_MUX_RATIO,
+                self.height - 1,
+                SET_COM_OUT_DIR | 0x08, # scan from COM[N] to COM0
+                SET_DISP_OFFSET,
+                0x00,
+                SET_COM_PIN_CFG,
+                0x02 if self.height == 32 else 0x12,
+                # timing and driving scheme
+                SET_DISP_CLK_DIV,
+                0x80,
+                SET_PRECHARGE,
+                0x22 if self.external_vcc else 0xf1,
+                SET_VCOM_DESEL,
+                0x30, # 0.83*Vcc
+                # display
+                SET_CONTRAST,
+                0xff, # maximum
+                SET_ENTIRE_ON, # output follows RAM contents
+                SET_NORM_INV, # not inverted
+                # charge pump
+                SET_CHARGE_PUMP,
+                0x10 if self.external_vcc else 0x14,
+                SET_DISP | 0x01): # on
             self.write_cmd(cmd)
         self.fill(0)
         self.show()

--- a/drivers/nrf24l01/nrf24l01.py
+++ b/drivers/nrf24l01/nrf24l01.py
@@ -5,49 +5,50 @@ from micropython import const
 import utime
 
 # nRF24L01+ registers
-CONFIG      = const(0x00)
-EN_RXADDR   = const(0x02)
-SETUP_AW    = const(0x03)
-SETUP_RETR  = const(0x04)
-RF_CH       = const(0x05)
-RF_SETUP    = const(0x06)
-STATUS      = const(0x07)
-RX_ADDR_P0  = const(0x0a)
-TX_ADDR     = const(0x10)
-RX_PW_P0    = const(0x11)
+CONFIG = const(0x00)
+EN_RXADDR = const(0x02)
+SETUP_AW = const(0x03)
+SETUP_RETR = const(0x04)
+RF_CH = const(0x05)
+RF_SETUP = const(0x06)
+STATUS = const(0x07)
+RX_ADDR_P0 = const(0x0a)
+TX_ADDR = const(0x10)
+RX_PW_P0 = const(0x11)
 FIFO_STATUS = const(0x17)
-DYNPD	    = const(0x1c)
+DYNPD = const(0x1c)
 
 # CONFIG register
-EN_CRC      = const(0x08) # enable CRC
-CRCO        = const(0x04) # CRC encoding scheme; 0=1 byte, 1=2 bytes
-PWR_UP      = const(0x02) # 1=power up, 0=power down
-PRIM_RX     = const(0x01) # RX/TX control; 0=PTX, 1=PRX
+EN_CRC = const(0x08) # enable CRC
+CRCO = const(0x04) # CRC encoding scheme; 0=1 byte, 1=2 bytes
+PWR_UP = const(0x02) # 1=power up, 0=power down
+PRIM_RX = const(0x01) # RX/TX control; 0=PTX, 1=PRX
 
 # RF_SETUP register
-POWER_0     = const(0x00) # -18 dBm
-POWER_1     = const(0x02) # -12 dBm
-POWER_2     = const(0x04) # -6 dBm
-POWER_3     = const(0x06) # 0 dBm
-SPEED_1M    = const(0x00)
-SPEED_2M    = const(0x08)
-SPEED_250K  = const(0x20)
+POWER_0 = const(0x00) # -18 dBm
+POWER_1 = const(0x02) # -12 dBm
+POWER_2 = const(0x04) # -6 dBm
+POWER_3 = const(0x06) # 0 dBm
+SPEED_1M = const(0x00)
+SPEED_2M = const(0x08)
+SPEED_250K = const(0x20)
 
 # STATUS register
-RX_DR       = const(0x40) # RX data ready; write 1 to clear
-TX_DS       = const(0x20) # TX data sent; write 1 to clear
-MAX_RT      = const(0x10) # max retransmits reached; write 1 to clear
+RX_DR = const(0x40) # RX data ready; write 1 to clear
+TX_DS = const(0x20) # TX data sent; write 1 to clear
+MAX_RT = const(0x10) # max retransmits reached; write 1 to clear
 
 # FIFO_STATUS register
-RX_EMPTY    = const(0x01) # 1 if RX FIFO is empty
+RX_EMPTY = const(0x01) # 1 if RX FIFO is empty
 
 # constants for instructions
-R_RX_PL_WID  = const(0x60) # read RX payload width
+R_RX_PL_WID = const(0x60) # read RX payload width
 R_RX_PAYLOAD = const(0x61) # read RX payload
 W_TX_PAYLOAD = const(0xa0) # write TX payload
-FLUSH_TX     = const(0xe1) # flush TX FIFO
-FLUSH_RX     = const(0xe2) # flush RX FIFO
-NOP          = const(0xff) # use to read STATUS register
+FLUSH_TX = const(0xe1) # flush TX FIFO
+FLUSH_RX = const(0xe2) # flush RX FIFO
+NOP = const(0xff) # use to read STATUS register
+
 
 class NRF24L01:
     def __init__(self, spi, cs, ce, channel=46, payload_size=16):

--- a/drivers/nrf24l01/nrf24l01test.py
+++ b/drivers/nrf24l01/nrf24l01test.py
@@ -16,9 +16,9 @@ _SLAVE_SEND_DELAY = const(10)
 
 if sys.platform == 'pyboard':
     cfg = {'spi': 2, 'miso': 'Y7', 'mosi': 'Y8', 'sck': 'Y6', 'csn': 'Y5', 'ce': 'Y4'}
-elif sys.platform == 'esp8266':  # Hardware SPI
+elif sys.platform == 'esp8266': # Hardware SPI
     cfg = {'spi': 1, 'miso': 12, 'mosi': 13, 'sck': 14, 'csn': 4, 'ce': 5}
-elif sys.platform == 'esp32':  # Software SPI
+elif sys.platform == 'esp32': # Software SPI
     cfg = {'spi': -1, 'miso': 32, 'mosi': 33, 'sck': 25, 'csn': 26, 'ce': 27}
 else:
     raise ValueError('Unsupported platform {}'.format(sys.platform))
@@ -26,6 +26,7 @@ else:
 # Addresses are in little-endian format. They correspond to big-endian
 # 0xf0f0f0f0e1, 0xf0f0f0f0d2
 pipes = (b'\xe1\xf0\xf0\xf0\xf0', b'\xd2\xf0\xf0\xf0\xf0')
+
 
 def master():
     csn = Pin(cfg['csn'], mode=Pin.OUT, value=1)
@@ -77,13 +78,15 @@ def master():
             got_millis, = struct.unpack('i', nrf.recv())
 
             # print response and round-trip delay
-            print('got response:', got_millis, '(delay', utime.ticks_diff(utime.ticks_ms(), got_millis), 'ms)')
+            print('got response:', got_millis, '(delay',
+                  utime.ticks_diff(utime.ticks_ms(), got_millis), 'ms)')
             num_successes += 1
 
         # delay then loop
         utime.sleep_ms(250)
 
     print('master finished sending; successes=%d, failures=%d' % (num_successes, num_failures))
+
 
 def slave():
     csn = Pin(cfg['csn'], mode=Pin.OUT, value=1)
@@ -123,6 +126,7 @@ def slave():
                 pass
             print('sent response')
             nrf.start_listening()
+
 
 try:
     import pyb

--- a/drivers/onewire/ds18x20.py
+++ b/drivers/onewire/ds18x20.py
@@ -7,6 +7,7 @@ _CONVERT = const(0x44)
 _RD_SCRATCH = const(0xbe)
 _WR_SCRATCH = const(0x4e)
 
+
 class DS18X20:
     def __init__(self, onewire):
         self.ow = onewire

--- a/drivers/onewire/onewire.py
+++ b/drivers/onewire/onewire.py
@@ -4,8 +4,10 @@
 from micropython import const
 import _onewire as _ow
 
+
 class OneWireError(Exception):
     pass
+
 
 class OneWire:
     SEARCH_ROM = const(0xf0)

--- a/drivers/sdcard/sdcard.py
+++ b/drivers/sdcard/sdcard.py
@@ -23,7 +23,6 @@ Example usage on ESP8266:
 from micropython import const
 import time
 
-
 _CMD_TIMEOUT = const(100)
 
 _R1_IDLE_STATE = const(1 << 0)
@@ -101,7 +100,7 @@ class SDCard:
         elif csd[0] & 0xc0 == 0x00: # CSD version 1.0 (old, <=2GB)
             c_size = csd[6] & 0b11 | csd[7] << 2 | (csd[8] & 0b11000000) << 4
             c_size_mult = ((csd[9] & 0b11) << 1) | csd[10] >> 7
-            self.sectors = (c_size + 1) * (2 ** (c_size_mult + 2))
+            self.sectors = (c_size + 1) * (2**(c_size_mult + 2))
         else:
             raise OSError("SD card CSD format not supported")
         #print('sectors', self.sectors)
@@ -247,7 +246,7 @@ class SDCard:
             mv = memoryview(buf)
             while nblocks:
                 # receive the data and release card
-                self.readinto(mv[offset : offset + 512])
+                self.readinto(mv[offset:offset + 512])
                 offset += 512
                 nblocks -= 1
             if self.cmd(12, 0, 0xff, skip1=True):
@@ -271,7 +270,7 @@ class SDCard:
             offset = 0
             mv = memoryview(buf)
             while nblocks:
-                self.write(_TOKEN_CMD25, mv[offset : offset + 512])
+                self.write(_TOKEN_CMD25, mv[offset:offset + 512])
                 offset += 512
                 nblocks -= 1
             self.write_token(_TOKEN_STOP_TRAN)

--- a/drivers/sdcard/sdtest.py
+++ b/drivers/sdcard/sdtest.py
@@ -2,9 +2,10 @@
 # Peter hinch 30th Jan 2016
 import os, sdcard, machine
 
+
 def sdtest():
     spi = machine.SPI(1)
-    spi.init()  # Ensure right baudrate
+    spi.init() # Ensure right baudrate
     sd = sdcard.SDCard(spi, machine.Pin.board.X21) # Compatible with PCB
     vfs = os.VfsFat(sd)
     os.mount(vfs, '/fc')
@@ -18,7 +19,7 @@ def sdtest():
     fn = '/fc/rats.txt'
     print()
     print('Multiple block read/write')
-    with open(fn,'w') as f:
+    with open(fn, 'w') as f:
         n = f.write(lines)
         print(n, 'bytes written')
         n = f.write(short)
@@ -26,18 +27,18 @@ def sdtest():
         n = f.write(lines)
         print(n, 'bytes written')
 
-    with open(fn,'r') as f:
+    with open(fn, 'r') as f:
         result1 = f.read()
         print(len(result1), 'bytes read')
 
     fn = '/fc/rats1.txt'
     print()
     print('Single block read/write')
-    with open(fn,'w') as f:
+    with open(fn, 'w') as f:
         n = f.write(short) # one block
         print(n, 'bytes written')
 
-    with open(fn,'r') as f:
+    with open(fn, 'r') as f:
         result2 = f.read()
         print(len(result2), 'bytes read')
 

--- a/examples/SDdatalogger/boot.py
+++ b/examples/SDdatalogger/boot.py
@@ -8,18 +8,18 @@
 
 import pyb
 
-pyb.LED(3).on()                 # indicate we are waiting for switch press
-pyb.delay(2000)                 # wait for user to maybe press the switch
-switch_value = pyb.Switch()()   # sample the switch at end of delay
-pyb.LED(3).off()                # indicate that we finished waiting for the switch
+pyb.LED(3).on() # indicate we are waiting for switch press
+pyb.delay(2000) # wait for user to maybe press the switch
+switch_value = pyb.Switch()() # sample the switch at end of delay
+pyb.LED(3).off() # indicate that we finished waiting for the switch
 
-pyb.LED(4).on()                 # indicate that we are selecting the mode
+pyb.LED(4).on() # indicate that we are selecting the mode
 
 if switch_value:
     pyb.usb_mode('VCP+MSC')
-    pyb.main('cardreader.py')           # if switch was pressed, run this
+    pyb.main('cardreader.py') # if switch was pressed, run this
 else:
     pyb.usb_mode('VCP+HID')
-    pyb.main('datalogger.py')           # if switch wasn't pressed, run this
+    pyb.main('datalogger.py') # if switch wasn't pressed, run this
 
-pyb.LED(4).off()                # indicate that we finished selecting the mode
+pyb.LED(4).off() # indicate that we finished selecting the mode

--- a/examples/SDdatalogger/datalogger.py
+++ b/examples/SDdatalogger/datalogger.py
@@ -17,17 +17,17 @@ while True:
 
     # start if switch is pressed
     if switch():
-        pyb.delay(200)                      # delay avoids detection of multiple presses
-        blue.on()                           # blue LED indicates file open
-        log = open('/sd/log.csv', 'w')       # open file on SD (SD: '/sd/', flash: '/flash/)
+        pyb.delay(200) # delay avoids detection of multiple presses
+        blue.on() # blue LED indicates file open
+        log = open('/sd/log.csv', 'w') # open file on SD (SD: '/sd/', flash: '/flash/)
 
         # until switch is pressed again
         while not switch():
-            t = pyb.millis()                            # get time
-            x, y, z = accel.filtered_xyz()              # get acceleration data
-            log.write('{},{},{},{}\n'.format(t,x,y,z))  # write data to file
+            t = pyb.millis() # get time
+            x, y, z = accel.filtered_xyz() # get acceleration data
+            log.write('{},{},{},{}\n'.format(t, x, y, z)) # write data to file
 
         # end after switch is pressed again
-        log.close()                         # close file
-        blue.off()                          # blue LED indicates file closed
-        pyb.delay(200)                      # delay avoids detection of multiple presses
+        log.close() # close file
+        blue.off() # blue LED indicates file closed
+        pyb.delay(200) # delay avoids detection of multiple presses

--- a/examples/accellog.py
+++ b/examples/accellog.py
@@ -2,16 +2,19 @@
 
 import pyb
 
-accel = pyb.Accel()                                 # create object of accelerometer
-blue = pyb.LED(4)                                   # create object of blue LED
+accel = pyb.Accel() # create object of accelerometer
+blue = pyb.LED(4) # create object of blue LED
 
-log = open('/sd/log.csv', 'w')                      # open file to write data - /sd/ is the SD-card, /flash/ the internal memory
-blue.on()                                           # turn on blue LED
+log = open('/sd/log.csv',
+           'w') # open file to write data - /sd/ is the SD-card, /flash/ the internal memory
+blue.on() # turn on blue LED
 
-for i in range(100):                                # do 100 times (if the board is connected via USB, you can't write longer because the PC tries to open the filesystem which messes up your file.)
-        t = pyb.millis()                            # get time since reset
-        x, y, z = accel.filtered_xyz()              # get acceleration data
-        log.write('{},{},{},{}\n'.format(t,x,y,z))  # write data to file
+for i in range(
+        100
+): # do 100 times (if the board is connected via USB, you can't write longer because the PC tries to open the filesystem which messes up your file.)
+    t = pyb.millis() # get time since reset
+    x, y, z = accel.filtered_xyz() # get acceleration data
+    log.write('{},{},{},{}\n'.format(t, x, y, z)) # write data to file
 
-log.close()                                         # close file
-blue.off()                                          # turn off LED
+log.close() # close file
+blue.off() # turn off LED

--- a/examples/asmled.py
+++ b/examples/asmled.py
@@ -41,6 +41,7 @@ def flash_led(r0):
     cmp(r0, 0)
     bgt(loop1)
 
+
 # flash LED #2 using inline assembler
 # this version uses half-word sortes, and the convenience assembler operation 'movwt'
 @micropython.asm_thumb
@@ -80,6 +81,7 @@ def flash_led_v2(r0):
     label(loop_entry)
     cmp(r0, 0)
     bgt(loop1)
+
 
 flash_led(5)
 flash_led_v2(5)

--- a/examples/asmsum.py
+++ b/examples/asmsum.py
@@ -22,6 +22,7 @@ def asm_sum_words(r0, r1):
 
     mov(r0, r2)
 
+
 @micropython.asm_thumb
 def asm_sum_bytes(r0, r1):
 
@@ -45,6 +46,7 @@ def asm_sum_bytes(r0, r1):
     bgt(loop1)
 
     mov(r0, r2)
+
 
 import array
 

--- a/examples/bluetooth/ble_advertising.py
+++ b/examples/bluetooth/ble_advertising.py
@@ -28,7 +28,8 @@ def advertising_payload(limited_disc=False, br_edr=False, name=None, services=No
         nonlocal payload
         payload += struct.pack('BB', len(value) + 1, adv_type) + value
 
-    _append(_ADV_TYPE_FLAGS, struct.pack('B', (0x01 if limited_disc else 0x02) + (0x00 if br_edr else 0x04)))
+    _append(_ADV_TYPE_FLAGS,
+            struct.pack('B', (0x01 if limited_disc else 0x02) + (0x00 if br_edr else 0x04)))
 
     if name:
         _append(_ADV_TYPE_NAME, name)
@@ -76,10 +77,14 @@ def decode_services(payload):
 
 
 def demo():
-    payload = advertising_payload(name='micropython', services=[bluetooth.UUID(0x181A), bluetooth.UUID('6E400001-B5A3-F393-E0A9-E50E24DCCA9E')])
+    payload = advertising_payload(
+        name='micropython',
+        services=[bluetooth.UUID(0x181A),
+                  bluetooth.UUID('6E400001-B5A3-F393-E0A9-E50E24DCCA9E')])
     print(payload)
     print(decode_name(payload))
     print(decode_services(payload))
+
 
 if __name__ == '__main__':
     demo()

--- a/examples/bluetooth/ble_temperature.py
+++ b/examples/bluetooth/ble_temperature.py
@@ -10,26 +10,35 @@ import time
 from ble_advertising import advertising_payload
 
 from micropython import const
-_IRQ_CENTRAL_CONNECT                 = const(1 << 0)
-_IRQ_CENTRAL_DISCONNECT              = const(1 << 1)
+_IRQ_CENTRAL_CONNECT = const(1 << 0)
+_IRQ_CENTRAL_DISCONNECT = const(1 << 1)
 
 # org.bluetooth.service.environmental_sensing
 _ENV_SENSE_UUID = bluetooth.UUID(0x181A)
 # org.bluetooth.characteristic.temperature
-_TEMP_CHAR = (bluetooth.UUID(0x2A6E), bluetooth.FLAG_READ|bluetooth.FLAG_NOTIFY,)
-_ENV_SENSE_SERVICE = (_ENV_SENSE_UUID, (_TEMP_CHAR,),)
+_TEMP_CHAR = (
+    bluetooth.UUID(0x2A6E),
+    bluetooth.FLAG_READ | bluetooth.FLAG_NOTIFY,
+)
+_ENV_SENSE_SERVICE = (
+    _ENV_SENSE_UUID,
+    (_TEMP_CHAR, ),
+)
 
 # org.bluetooth.characteristic.gap.appearance.xml
 _ADV_APPEARANCE_GENERIC_THERMOMETER = const(768)
+
 
 class BLETemperature:
     def __init__(self, ble, name='mpy-temp'):
         self._ble = ble
         self._ble.active(True)
         self._ble.irq(handler=self._irq)
-        ((self._handle,),) = self._ble.gatts_register_services((_ENV_SENSE_SERVICE,))
+        ((self._handle, ), ) = self._ble.gatts_register_services((_ENV_SENSE_SERVICE, ))
         self._connections = set()
-        self._payload = advertising_payload(name=name, services=[_ENV_SENSE_UUID], appearance=_ADV_APPEARANCE_GENERIC_THERMOMETER)
+        self._payload = advertising_payload(name=name,
+                                            services=[_ENV_SENSE_UUID],
+                                            appearance=_ADV_APPEARANCE_GENERIC_THERMOMETER)
         self._advertise()
 
     def _irq(self, event, data):

--- a/examples/bluetooth/ble_temperature_central.py
+++ b/examples/bluetooth/ble_temperature_central.py
@@ -9,32 +9,39 @@ import micropython
 from ble_advertising import decode_services, decode_name
 
 from micropython import const
-_IRQ_CENTRAL_CONNECT                 = const(1 << 0)
-_IRQ_CENTRAL_DISCONNECT              = const(1 << 1)
-_IRQ_GATTS_WRITE                     = const(1 << 2)
-_IRQ_GATTS_READ_REQUEST              = const(1 << 3)
-_IRQ_SCAN_RESULT                     = const(1 << 4)
-_IRQ_SCAN_COMPLETE                   = const(1 << 5)
-_IRQ_PERIPHERAL_CONNECT              = const(1 << 6)
-_IRQ_PERIPHERAL_DISCONNECT           = const(1 << 7)
-_IRQ_GATTC_SERVICE_RESULT            = const(1 << 8)
-_IRQ_GATTC_CHARACTERISTIC_RESULT     = const(1 << 9)
-_IRQ_GATTC_DESCRIPTOR_RESULT         = const(1 << 10)
-_IRQ_GATTC_READ_RESULT               = const(1 << 11)
-_IRQ_GATTC_WRITE_STATUS              = const(1 << 12)
-_IRQ_GATTC_NOTIFY                    = const(1 << 13)
-_IRQ_GATTC_INDICATE                  = const(1 << 14)
-_IRQ_ALL                             = const(0xffff)
+_IRQ_CENTRAL_CONNECT = const(1 << 0)
+_IRQ_CENTRAL_DISCONNECT = const(1 << 1)
+_IRQ_GATTS_WRITE = const(1 << 2)
+_IRQ_GATTS_READ_REQUEST = const(1 << 3)
+_IRQ_SCAN_RESULT = const(1 << 4)
+_IRQ_SCAN_COMPLETE = const(1 << 5)
+_IRQ_PERIPHERAL_CONNECT = const(1 << 6)
+_IRQ_PERIPHERAL_DISCONNECT = const(1 << 7)
+_IRQ_GATTC_SERVICE_RESULT = const(1 << 8)
+_IRQ_GATTC_CHARACTERISTIC_RESULT = const(1 << 9)
+_IRQ_GATTC_DESCRIPTOR_RESULT = const(1 << 10)
+_IRQ_GATTC_READ_RESULT = const(1 << 11)
+_IRQ_GATTC_WRITE_STATUS = const(1 << 12)
+_IRQ_GATTC_NOTIFY = const(1 << 13)
+_IRQ_GATTC_INDICATE = const(1 << 14)
+_IRQ_ALL = const(0xffff)
 
 # org.bluetooth.service.environmental_sensing
 _ENV_SENSE_UUID = bluetooth.UUID(0x181A)
 # org.bluetooth.characteristic.temperature
 _TEMP_UUID = bluetooth.UUID(0x2A6E)
-_TEMP_CHAR = (_TEMP_UUID, bluetooth.FLAG_READ|bluetooth.FLAG_NOTIFY,)
-_ENV_SENSE_SERVICE = (_ENV_SENSE_UUID, (_TEMP_CHAR,),)
+_TEMP_CHAR = (
+    _TEMP_UUID,
+    bluetooth.FLAG_READ | bluetooth.FLAG_NOTIFY,
+)
+_ENV_SENSE_SERVICE = (
+    _ENV_SENSE_UUID,
+    (_TEMP_CHAR, ),
+)
 
 # org.bluetooth.characteristic.gap.appearance.xml
 _ADV_APPEARANCE_GENERIC_THERMOMETER = const(768)
+
 
 class BLETemperatureCentral:
     def __init__(self, ble):
@@ -72,7 +79,8 @@ class BLETemperatureCentral:
             if connectable and _ENV_SENSE_UUID in decode_services(adv_data):
                 # Found a potential device, remember it and stop scanning.
                 self._addr_type = addr_type
-                self._addr = bytes(addr) # Note: The addr buffer is owned by modbluetooth, need to copy it.
+                self._addr = bytes(
+                    addr) # Note: The addr buffer is owned by modbluetooth, need to copy it.
                 self._name = decode_name(adv_data) or '?'
                 self._ble.gap_scan(None)
 
@@ -104,7 +112,8 @@ class BLETemperatureCentral:
             # Connected device returned a service.
             conn_handle, start_handle, end_handle, uuid = data
             if conn_handle == self._conn_handle and uuid == _ENV_SENSE_UUID:
-                self._ble.gattc_discover_characteristics(self._conn_handle, start_handle, end_handle)
+                self._ble.gattc_discover_characteristics(self._conn_handle, start_handle,
+                                                         end_handle)
 
         elif event == _IRQ_GATTC_CHARACTERISTIC_RESULT:
             # Connected device returned a characteristic.
@@ -131,7 +140,6 @@ class BLETemperatureCentral:
                 self._update_value(notify_data)
                 if self._notify_callback:
                     self._notify_callback(self._value)
-
 
     # Returns true if we've successfully connected and discovered characteristics.
     def is_connected(self):
@@ -217,6 +225,7 @@ def demo():
     #     time.sleep_ms(2000)
 
     print('Disconnected')
+
 
 if __name__ == '__main__':
     demo()

--- a/examples/bluetooth/ble_uart_peripheral.py
+++ b/examples/bluetooth/ble_uart_peripheral.py
@@ -4,24 +4,40 @@ import bluetooth
 from ble_advertising import advertising_payload
 
 from micropython import const
-_IRQ_CENTRAL_CONNECT                 = const(1 << 0)
-_IRQ_CENTRAL_DISCONNECT              = const(1 << 1)
-_IRQ_GATTS_WRITE                     = const(1 << 2)
+_IRQ_CENTRAL_CONNECT = const(1 << 0)
+_IRQ_CENTRAL_DISCONNECT = const(1 << 1)
+_IRQ_GATTS_WRITE = const(1 << 2)
 
 _UART_UUID = bluetooth.UUID('6E400001-B5A3-F393-E0A9-E50E24DCCA9E')
-_UART_TX = (bluetooth.UUID('6E400003-B5A3-F393-E0A9-E50E24DCCA9E'), bluetooth.FLAG_NOTIFY,)
-_UART_RX = (bluetooth.UUID('6E400002-B5A3-F393-E0A9-E50E24DCCA9E'), bluetooth.FLAG_WRITE,)
-_UART_SERVICE = (_UART_UUID, (_UART_TX, _UART_RX,),)
+_UART_TX = (
+    bluetooth.UUID('6E400003-B5A3-F393-E0A9-E50E24DCCA9E'),
+    bluetooth.FLAG_NOTIFY,
+)
+_UART_RX = (
+    bluetooth.UUID('6E400002-B5A3-F393-E0A9-E50E24DCCA9E'),
+    bluetooth.FLAG_WRITE,
+)
+_UART_SERVICE = (
+    _UART_UUID,
+    (
+        _UART_TX,
+        _UART_RX,
+    ),
+)
 
 # org.bluetooth.characteristic.gap.appearance.xml
 _ADV_APPEARANCE_GENERIC_COMPUTER = const(128)
+
 
 class BLEUART:
     def __init__(self, ble, name='mpy-uart', rxbuf=100):
         self._ble = ble
         self._ble.active(True)
         self._ble.irq(handler=self._irq)
-        ((self._tx_handle, self._rx_handle,),) = self._ble.gatts_register_services((_UART_SERVICE,))
+        ((
+            self._tx_handle,
+            self._rx_handle,
+        ), ) = self._ble.gatts_register_services((_UART_SERVICE, ))
         # Increase the size of the rx buffer and enable append mode.
         self._ble.gatts_set_buffer(self._rx_handle, rxbuf, True)
         self._connections = set()

--- a/examples/bluetooth/ble_uart_repl.py
+++ b/examples/bluetooth/ble_uart_repl.py
@@ -20,14 +20,17 @@ if hasattr(machine, 'Timer'):
 else:
     _timer = None
 
+
 # Batch writes into 50ms intervals.
 def schedule_in(handler, delay_ms):
     def _wrap(_arg):
         handler()
+
     if _timer:
         _timer.init(mode=machine.Timer.ONE_SHOT, period=delay_ms, callback=_wrap)
     else:
         micropython.schedule(_wrap, None)
+
 
 # Simple buffering stream to support the dupterm requirements.
 class BLEUARTStream(io.IOBase):

--- a/examples/conwaylife.py
+++ b/examples/conwaylife.py
@@ -4,19 +4,15 @@ import pyb
 lcd = pyb.LCD('x')
 lcd.light(1)
 
+
 # do 1 iteration of Conway's Game of Life
 def conway_step():
-    for x in range(128):        # loop over x coordinates
-        for y in range(32):     # loop over y coordinates
+    for x in range(128): # loop over x coordinates
+        for y in range(32): # loop over y coordinates
             # count number of neighbours
-            num_neighbours = (lcd.get(x - 1, y - 1) +
-                lcd.get(x, y - 1) +
-                lcd.get(x + 1, y - 1) +
-                lcd.get(x - 1, y) +
-                lcd.get(x + 1, y) +
-                lcd.get(x + 1, y + 1) +
-                lcd.get(x, y + 1) +
-                lcd.get(x - 1, y + 1))
+            num_neighbours = (lcd.get(x - 1, y - 1) + lcd.get(x, y - 1) + lcd.get(x + 1, y - 1) +
+                              lcd.get(x - 1, y) + lcd.get(x + 1, y) + lcd.get(x + 1, y + 1) +
+                              lcd.get(x, y + 1) + lcd.get(x - 1, y + 1))
 
             # check if the centre cell is alive or not
             self = lcd.get(x, y)
@@ -25,21 +21,24 @@ def conway_step():
             if self and not (2 <= num_neighbours <= 3):
                 lcd.pixel(x, y, 0) # not enough, or too many neighbours: cell dies
             elif not self and num_neighbours == 3:
-                lcd.pixel(x, y, 1)   # exactly 3 neighbours around an empty cell: cell is born
+                lcd.pixel(x, y, 1) # exactly 3 neighbours around an empty cell: cell is born
+
 
 # randomise the start
 def conway_rand():
-    lcd.fill(0)                 # clear the LCD
-    for x in range(128):        # loop over x coordinates
-        for y in range(32):     # loop over y coordinates
-            lcd.pixel(x, y, pyb.rng() & 1)   # set the pixel randomly
+    lcd.fill(0) # clear the LCD
+    for x in range(128): # loop over x coordinates
+        for y in range(32): # loop over y coordinates
+            lcd.pixel(x, y, pyb.rng() & 1) # set the pixel randomly
+
 
 # loop for a certain number of frames, doing iterations of Conway's Game of Life
 def conway_go(num_frames):
     for i in range(num_frames):
-        conway_step()           # do 1 iteration
-        lcd.show()              # update the LCD
+        conway_step() # do 1 iteration
+        lcd.show() # update the LCD
         pyb.delay(50)
+
 
 # testing
 conway_rand()

--- a/examples/hwapi/button_reaction.py
+++ b/examples/hwapi/button_reaction.py
@@ -11,7 +11,7 @@ Ready? Cliiiiick!
 """)
 
 while 1:
-    delay = machine.time_pulse_us(BUTTON, 1, 10*1000*1000)
+    delay = machine.time_pulse_us(BUTTON, 1, 10 * 1000 * 1000)
     if delay < 0:
         print("Well, you're *really* slow")
     else:

--- a/examples/hwapi/hwconfig_console.py
+++ b/examples/hwapi/hwconfig_console.py
@@ -1,7 +1,6 @@
 # This is hwconfig for "emulation" for cases when there's no real hardware.
 # It just prints information to console.
 class LEDClass:
-
     def __init__(self, id):
         self.id = "LED(%d):" % id
 

--- a/examples/ledangle.py
+++ b/examples/ledangle.py
@@ -1,5 +1,6 @@
 import pyb
 
+
 def led_angle(seconds_to_run_for):
     # make LED objects
     l1 = pyb.LED(1)

--- a/examples/mandel.py
+++ b/examples/mandel.py
@@ -3,13 +3,14 @@ try:
 except:
     pass
 
+
 def mandelbrot():
     # returns True if c, complex, is in the Mandelbrot set
     #@micropython.native
     def in_set(c):
         z = 0
         for i in range(40):
-            z = z*z + c
+            z = z * z + c
             if abs(z) > 60:
                 return False
         return True
@@ -20,6 +21,7 @@ def mandelbrot():
             if in_set((u / 30 - 2) + (v / 15 - 1) * 1j):
                 lcd.set(u, v)
     lcd.show()
+
 
 # PC testing
 import lcd

--- a/examples/micropython.py
+++ b/examples/micropython.py
@@ -2,7 +2,9 @@
 
 # Dummy function decorators
 
+
 def nodecor(x):
     return x
+
 
 bytecode = native = viper = nodecor

--- a/examples/natmod/features2/test.py
+++ b/examples/natmod/features2/test.py
@@ -2,8 +2,10 @@
 
 import array
 
+
 def isclose(a, b):
     return abs(a - b) < 1e-3
+
 
 def test():
     tests = [
@@ -22,5 +24,6 @@ def test():
 
     if not all(tests):
         raise SystemExit(1)
+
 
 test()

--- a/examples/network/http_server.py
+++ b/examples/network/http_server.py
@@ -3,12 +3,12 @@ try:
 except:
     import socket
 
-
 CONTENT = b"""\
 HTTP/1.0 200 OK
 
 Hello #%d from MicroPython!
 """
+
 
 def main(micropython_optimize=False):
     s = socket.socket()

--- a/examples/network/http_server_simplistic.py
+++ b/examples/network/http_server_simplistic.py
@@ -5,12 +5,12 @@ try:
 except:
     import socket
 
-
 CONTENT = b"""\
 HTTP/1.0 200 OK
 
 Hello #%d from MicroPython!
 """
+
 
 def main():
     s = socket.socket()

--- a/examples/network/http_server_simplistic_commented.py
+++ b/examples/network/http_server_simplistic_commented.py
@@ -13,12 +13,12 @@ try:
 except:
     import socket
 
-
 CONTENT = b"""\
 HTTP/1.0 200 OK
 
 Hello #%d from MicroPython!
 """
+
 
 def main():
     s = socket.socket()

--- a/examples/network/http_server_ssl.py
+++ b/examples/network/http_server_ssl.py
@@ -5,19 +5,17 @@ except:
     import socket
 import ussl as ssl
 
-
 # This self-signed key/cert pair is randomly generated and to be used for
 # testing/demonstration only.  You should always generate your own key/cert.
-key = binascii.unhexlify(
-    b'3082013b020100024100cc20643fd3d9c21a0acba4f48f61aadd675f52175a9dcf07fbef'
-    b'610a6a6ba14abb891745cd18a1d4c056580d8ff1a639460f867013c8391cdc9f2e573b0f'
-    b'872d0203010001024100bb17a54aeb3dd7ae4edec05e775ca9632cf02d29c2a089b563b0'
-    b'd05cdf95aeca507de674553f28b4eadaca82d5549a86058f9996b07768686a5b02cb240d'
-    b'd9f1022100f4a63f5549e817547dca97b5c658038e8593cb78c5aba3c4642cc4cd031d86'
-    b'8f022100d598d870ffe4a34df8de57047a50b97b71f4d23e323f527837c9edae88c79483'
-    b'02210098560c89a70385c36eb07fd7083235c4c1184e525d838aedf7128958bedfdbb102'
-    b'2051c0dab7057a8176ca966f3feb81123d4974a733df0f958525f547dfd1c271f9022044'
-    b'6c2cafad455a671a8cf398e642e1be3b18a3d3aec2e67a9478f83c964c4f1f')
+key = binascii.unhexlify(b'3082013b020100024100cc20643fd3d9c21a0acba4f48f61aadd675f52175a9dcf07fbef'
+                         b'610a6a6ba14abb891745cd18a1d4c056580d8ff1a639460f867013c8391cdc9f2e573b0f'
+                         b'872d0203010001024100bb17a54aeb3dd7ae4edec05e775ca9632cf02d29c2a089b563b0'
+                         b'd05cdf95aeca507de674553f28b4eadaca82d5549a86058f9996b07768686a5b02cb240d'
+                         b'd9f1022100f4a63f5549e817547dca97b5c658038e8593cb78c5aba3c4642cc4cd031d86'
+                         b'8f022100d598d870ffe4a34df8de57047a50b97b71f4d23e323f527837c9edae88c79483'
+                         b'02210098560c89a70385c36eb07fd7083235c4c1184e525d838aedf7128958bedfdbb102'
+                         b'2051c0dab7057a8176ca966f3feb81123d4974a733df0f958525f547dfd1c271f9022044'
+                         b'6c2cafad455a671a8cf398e642e1be3b18a3d3aec2e67a9478f83c964c4f1f')
 cert = binascii.unhexlify(
     b'308201d53082017f020203e8300d06092a864886f70d01010505003075310b3009060355'
     b'0406130258583114301206035504080c0b54686550726f76696e63653110300e06035504'
@@ -34,12 +32,12 @@ cert = binascii.unhexlify(
     b'e960ae3ebc247371b525caeb41bbcf34686015a44c50d226e66aef0a97a63874ca5944ef'
     b'979b57f0b3')
 
-
 CONTENT = b"""\
 HTTP/1.0 200 OK
 
 Hello #%d from MicroPython!
 """
+
 
 def main(use_stream=True):
     s = socket.socket()

--- a/examples/pins.py
+++ b/examples/pins.py
@@ -4,6 +4,7 @@
 import pyb
 import pins_af
 
+
 def af():
     max_name_width = 0
     max_af_width = 0
@@ -13,21 +14,22 @@ def af():
             max_af_width = max(max_af_width, len(af_entry[1]))
     for pin_entry in pins_af.PINS_AF:
         pin_name = pin_entry[0]
-        print('%-*s ' % (max_name_width, pin_name),  end='')
+        print('%-*s ' % (max_name_width, pin_name), end='')
         for af_entry in pin_entry[1:]:
             print('%2d: %-*s ' % (af_entry[0], max_af_width, af_entry[1]), end='')
         print('')
 
+
 def pins():
-    mode_str = { pyb.Pin.IN     : 'IN',
-                 pyb.Pin.OUT_PP : 'OUT_PP',
-                 pyb.Pin.OUT_OD : 'OUT_OD',
-                 pyb.Pin.AF_PP  : 'AF_PP',
-                 pyb.Pin.AF_OD  : 'AF_OD',
-                 pyb.Pin.ANALOG : 'ANALOG' }
-    pull_str = { pyb.Pin.PULL_NONE : '',
-                 pyb.Pin.PULL_UP   : 'PULL_UP',
-                 pyb.Pin.PULL_DOWN : 'PULL_DOWN' }
+    mode_str = {
+        pyb.Pin.IN: 'IN',
+        pyb.Pin.OUT_PP: 'OUT_PP',
+        pyb.Pin.OUT_OD: 'OUT_OD',
+        pyb.Pin.AF_PP: 'AF_PP',
+        pyb.Pin.AF_OD: 'AF_OD',
+        pyb.Pin.ANALOG: 'ANALOG'
+    }
+    pull_str = {pyb.Pin.PULL_NONE: '', pyb.Pin.PULL_UP: 'PULL_UP', pyb.Pin.PULL_DOWN: 'PULL_DOWN'}
     width = [0, 0, 0, 0]
     rows = []
     for pin_entry in pins_af.PINS_AF:

--- a/examples/pyb.py
+++ b/examples/pyb.py
@@ -1,16 +1,21 @@
 # pyboard testing functions for CPython
 import time
 
+
 def delay(n):
     #time.sleep(float(n) / 1000)
     pass
 
+
 rand_seed = 1
+
+
 def rng():
     global rand_seed
     # for these choice of numbers, see P L'Ecuyer, "Tables of linear congruential generators of different sizes and good lattice structure"
     rand_seed = (rand_seed * 653276) % 8388593
     return rand_seed
+
 
 # LCD testing object for PC
 # uses double buffering

--- a/examples/switch.py
+++ b/examples/switch.py
@@ -24,6 +24,7 @@ orange_led = pyb.LED(3)
 blue_led = pyb.LED(4)
 all_leds = (red_led, green_led, orange_led, blue_led)
 
+
 def run_loop(leds=all_leds):
     """
     Start the loop.
@@ -40,6 +41,7 @@ def run_loop(leds=all_leds):
                 [led.off() for led in leds]
         except OSError: # VCPInterrupt # Ctrl+C in interpreter mode.
             break
+
 
 if __name__ == '__main__':
     run_loop()

--- a/examples/unix/ffi_example.py
+++ b/examples/unix/ffi_example.py
@@ -24,11 +24,13 @@ print("errno value:", errno.get())
 perror("perror after error")
 print()
 
+
 def cmp(pa, pb):
     a = uctypes.bytearray_at(pa, 1)
     b = uctypes.bytearray_at(pb, 1)
     print("cmp:", a, b)
     return a[0] - b[0]
+
 
 cmp_cb = ffi.callback("i", cmp, "PP")
 print("callback:", cmp_cb)

--- a/extmod/webrepl/manifest.py
+++ b/extmod/webrepl/manifest.py
@@ -1,1 +1,5 @@
-freeze('.', ('webrepl.py', 'webrepl_setup.py', 'websocket_helper.py',))
+freeze('.', (
+    'webrepl.py',
+    'webrepl_setup.py',
+    'websocket_helper.py',
+))

--- a/extmod/webrepl/webrepl.py
+++ b/extmod/webrepl/webrepl.py
@@ -9,6 +9,7 @@ import _webrepl
 listen_s = None
 client_s = None
 
+
 def setup_conn(port, accept_handler):
     global listen_s
     listen_s = socket.socket()

--- a/extmod/webrepl/webrepl_setup.py
+++ b/extmod/webrepl/webrepl_setup.py
@@ -6,14 +6,17 @@ import machine
 RC = "./boot.py"
 CONFIG = "./webrepl_cfg.py"
 
+
 def input_choice(prompt, choices):
     while 1:
         resp = input(prompt)
         if resp in choices:
             return resp
 
+
 def getpass(prompt):
     return input(prompt)
+
 
 def input_pass():
     while 1:
@@ -77,7 +80,8 @@ def main():
 
     if resp == "E":
         if exists(CONFIG):
-            resp2 = input_choice("Would you like to change WebREPL password? (y/n) ", ("y", "n", ""))
+            resp2 = input_choice("Would you like to change WebREPL password? (y/n) ",
+                                 ("y", "n", ""))
         else:
             print("To enable WebREPL, you must set password for it")
             resp2 = "y"
@@ -86,7 +90,6 @@ def main():
             passwd = input_pass()
             with open(CONFIG, "w") as f:
                 f.write("PASS = %r\n" % passwd)
-
 
     if resp not in ("D", "E") or (resp == "D" and not status) or (resp == "E" and status):
         print("No further action required")
@@ -98,5 +101,6 @@ def main():
     resp = input_choice("Would you like to reboot now? (y/n) ", ("y", "n", ""))
     if resp == "y":
         machine.reset()
+
 
 main()

--- a/extmod/webrepl/websocket_helper.py
+++ b/extmod/webrepl/websocket_helper.py
@@ -10,6 +10,7 @@ except:
 
 DEBUG = 0
 
+
 def server_handshake(sock):
     clr = sock.makefile("rwb", 0)
     l = clr.readline()
@@ -66,9 +67,11 @@ Sec-WebSocket-Key: foo\r
 \r
 """)
     l = cl.readline()
-#    print(l)
+    #    print(l)
     while 1:
         l = cl.readline()
         if l == b"\r\n":
             break
+
+
 #        sys.stdout.write(l)

--- a/lib/memzip/make-memzip.py
+++ b/lib/memzip/make-memzip.py
@@ -15,6 +15,7 @@ import subprocess
 import sys
 import types
 
+
 def create_zip(zip_filename, zip_dir):
     abs_zip_filename = os.path.abspath(zip_filename)
     save_cwd = os.getcwd()
@@ -23,6 +24,7 @@ def create_zip(zip_filename, zip_dir):
         os.remove(abs_zip_filename)
     subprocess.check_call(['zip', '-0', '-r', '-D', abs_zip_filename, '.'])
     os.chdir(save_cwd)
+
 
 def create_c_from_file(c_filename, zip_filename):
     with open(zip_filename, 'rb') as zip_file:
@@ -43,28 +45,22 @@ def create_c_from_file(c_filename, zip_filename):
                 print('', file=c_file)
             print('};', file=c_file)
 
+
 def main():
-    parser = argparse.ArgumentParser(
-        prog='make-memzip.py',
-        usage='%(prog)s [options] [command]',
-        description='Generates a C source memzip file.'
-    )
-    parser.add_argument(
-        '-z', '--zip-file',
-        dest='zip_filename',
-        help='Specifies the name of the created zip file.',
-        default='memzip_files.zip'
-    )
-    parser.add_argument(
-        '-c', '--c-file',
-        dest='c_filename',
-        help='Specifies the name of the created C source file.',
-        default='memzip_files.c'
-    )
-    parser.add_argument(
-        dest='source_dir',
-        default='memzip_files'
-    )
+    parser = argparse.ArgumentParser(prog='make-memzip.py',
+                                     usage='%(prog)s [options] [command]',
+                                     description='Generates a C source memzip file.')
+    parser.add_argument('-z',
+                        '--zip-file',
+                        dest='zip_filename',
+                        help='Specifies the name of the created zip file.',
+                        default='memzip_files.zip')
+    parser.add_argument('-c',
+                        '--c-file',
+                        dest='c_filename',
+                        help='Specifies the name of the created C source file.',
+                        default='memzip_files.c')
+    parser.add_argument(dest='source_dir', default='memzip_files')
     args = parser.parse_args(sys.argv[1:])
 
     print('args.zip_filename =', args.zip_filename)
@@ -74,6 +70,6 @@ def main():
     create_zip(args.zip_filename, args.source_dir)
     create_c_from_file(args.c_filename, args.zip_filename)
 
+
 if __name__ == "__main__":
     main()
-

--- a/ports/cc3200/boards/make-pins.py
+++ b/ports/cc3200/boards/make-pins.py
@@ -7,15 +7,16 @@ import argparse
 import sys
 import csv
 
+SUPPORTED_AFS = {
+    'UART': ('TX', 'RX', 'RTS', 'CTS'),
+    'SPI': ('CLK', 'MOSI', 'MISO', 'CS0'),
+    #'I2S': ('CLK', 'FS', 'DAT0', 'DAT1'),
+    'I2C': ('SDA', 'SCL'),
+    'TIM': ('PWM'),
+    'SD': ('CLK', 'CMD', 'DAT0'),
+    'ADC': ('CH0', 'CH1', 'CH2', 'CH3')
+}
 
-SUPPORTED_AFS = { 'UART': ('TX', 'RX', 'RTS', 'CTS'),
-                  'SPI': ('CLK', 'MOSI', 'MISO', 'CS0'),
-                  #'I2S': ('CLK', 'FS', 'DAT0', 'DAT1'),
-                  'I2C': ('SDA', 'SCL'),
-                  'TIM': ('PWM'),
-                  'SD': ('CLK', 'CMD', 'DAT0'),
-                  'ADC': ('CH0', 'CH1', 'CH2', 'CH3')
-                }
 
 def parse_port_pin(name_str):
     """Parses a string and returns a (port, gpio_bit) tuple."""
@@ -42,7 +43,8 @@ class AF:
         self.type = type
 
     def print(self):
-        print ('    AF({:16s}, {:4d}, {:8s}, {:4d}, {:8s}),    // {}'.format(self.name, self.idx, self.fn, self.unit, self.type, self.name))
+        print('    AF({:16s}, {:4d}, {:8s}, {:4d}, {:8s}),    // {}'.format(
+            self.name, self.idx, self.fn, self.unit, self.type, self.name))
 
 
 class Pin:
@@ -66,10 +68,11 @@ class Pin:
                 af.print()
             print('};')
             print('pin_obj_t pin_{:4s} = PIN({:6s}, {:1d}, {:3d}, {:2d}, pin_{}_af, {});\n'.format(
-                   self.name, self.name, self.port, self.gpio_bit, self.pin_num, self.name, len(self.afs)))
+                self.name, self.name, self.port, self.gpio_bit, self.pin_num, self.name,
+                len(self.afs)))
         else:
             print('pin_obj_t pin_{:4s} = PIN({:6s}, {:1d}, {:3d}, {:2d}, NULL, 0);\n'.format(
-                   self.name, self.name, self.port, self.gpio_bit, self.pin_num))
+                self.name, self.name, self.port, self.gpio_bit, self.pin_num))
 
     def print_header(self, hdr_file):
         hdr_file.write('extern pin_obj_t pin_{:s};\n'.format(self.name))
@@ -77,7 +80,7 @@ class Pin:
 
 class Pins:
     def __init__(self):
-        self.board_pins = []   # list of pin objects
+        self.board_pins = [] # list of pin objects
 
     def find_pin(self, port, gpio_bit):
         for pin in self.board_pins:
@@ -103,16 +106,17 @@ class Pins:
                 except:
                     continue
                 if not row[pin_col].isdigit():
-                    raise ValueError("Invalid pin number {:s} in row {:s}".format(row[pin_col]), row)
+                    raise ValueError("Invalid pin number {:s} in row {:s}".format(row[pin_col]),
+                                     row)
                 # Pin numbers must start from 0 when used with the TI API
-                pin_num = int(row[pin_col]) - 1;        
+                pin_num = int(row[pin_col]) - 1
                 pin = Pin(row[pinname_col], port_num, gpio_bit, pin_num)
                 self.board_pins.append(pin)
                 af_idx = 0
                 for af in row[af_start_col:]:
                     af_splitted = af.split('_')
                     fn_name = af_splitted[0].rstrip('0123456789')
-                    if  fn_name in SUPPORTED_AFS:
+                    if fn_name in SUPPORTED_AFS:
                         type_name = af_splitted[1]
                         if type_name in SUPPORTED_AFS[fn_name]:
                             unit_idx = af_splitted[0][-1]
@@ -136,9 +140,11 @@ class Pins:
         print('STATIC const mp_rom_map_elem_t pin_{:s}_pins_locals_dict_table[] = {{'.format(label))
         for pin in pins:
             if pin.board_pin:
-                print('    {{ MP_ROM_QSTR(MP_QSTR_{:6s}), MP_ROM_PTR(&pin_{:6s}) }},'.format(pin.name, pin.name))
+                print('    {{ MP_ROM_QSTR(MP_QSTR_{:6s}), MP_ROM_PTR(&pin_{:6s}) }},'.format(
+                    pin.name, pin.name))
         print('};')
-        print('MP_DEFINE_CONST_DICT(pin_{:s}_pins_locals_dict, pin_{:s}_pins_locals_dict_table);'.format(label, label));
+        print('MP_DEFINE_CONST_DICT(pin_{:s}_pins_locals_dict, pin_{:s}_pins_locals_dict_table);'.
+              format(label, label))
 
     def print(self):
         for pin in self.board_pins:
@@ -171,40 +177,35 @@ class Pins:
 
 
 def main():
-    parser = argparse.ArgumentParser(
-        prog="make-pins.py",
-        usage="%(prog)s [options] [command]",
-        description="Generate board specific pin file"
-    )
+    parser = argparse.ArgumentParser(prog="make-pins.py",
+                                     usage="%(prog)s [options] [command]",
+                                     description="Generate board specific pin file")
+    parser.add_argument("-a",
+                        "--af",
+                        dest="af_filename",
+                        help="Specifies the alternate function file for the chip",
+                        default="cc3200_af.csv")
     parser.add_argument(
-        "-a", "--af",
-        dest="af_filename",
-        help="Specifies the alternate function file for the chip",
-        default="cc3200_af.csv"
-    )
-    parser.add_argument(
-        "-b", "--board",
+        "-b",
+        "--board",
         dest="board_filename",
         help="Specifies the board file",
     )
-    parser.add_argument(
-        "-p", "--prefix",
-        dest="prefix_filename",
-        help="Specifies beginning portion of generated pins file",
-        default="cc3200_prefix.c"
-    )
-    parser.add_argument(
-        "-q", "--qstr",
-        dest="qstr_filename",
-        help="Specifies name of generated qstr header file",
-        default="build/pins_qstr.h"
-    )
-    parser.add_argument(
-        "-r", "--hdr",
-        dest="hdr_filename",
-        help="Specifies name of generated pin header file",
-        default="build/pins.h"
-    )
+    parser.add_argument("-p",
+                        "--prefix",
+                        dest="prefix_filename",
+                        help="Specifies beginning portion of generated pins file",
+                        default="cc3200_prefix.c")
+    parser.add_argument("-q",
+                        "--qstr",
+                        dest="qstr_filename",
+                        help="Specifies name of generated qstr header file",
+                        default="build/pins_qstr.h")
+    parser.add_argument("-r",
+                        "--hdr",
+                        dest="hdr_filename",
+                        help="Specifies name of generated pin header file",
+                        default="build/pins.h")
     args = parser.parse_args(sys.argv[1:])
 
     pins = Pins()

--- a/ports/cc3200/tools/smoke.py
+++ b/ports/cc3200/tools/smoke.py
@@ -2,7 +2,6 @@ from machine import Pin
 from machine import RTC
 import time
 import os
-
 """
 Execute it like this:
 
@@ -12,14 +11,16 @@ python3 run-tests --target wipy --device 192.168.1.1 ../cc3200/tools/smoke.py
 pin_map = [23, 24, 11, 12, 13, 14, 15, 16, 17, 22, 28, 10, 9, 8, 7, 6, 30, 31, 3, 0, 4, 5]
 test_bytes = os.urandom(1024)
 
-def test_pin_read (pull):
+
+def test_pin_read(pull):
     # enable the pull resistor on all pins, then read the value
     for p in pin_map:
         pin = Pin('GP' + str(p), mode=Pin.IN, pull=pull)
         # read the pin value
         print(pin())
 
-def test_pin_shorts (pull):
+
+def test_pin_shorts(pull):
     if pull == Pin.PULL_UP:
         pull_inverted = Pin.PULL_DOWN
     else:
@@ -35,6 +36,7 @@ def test_pin_shorts (pull):
         i += 1
         # read the pin value
         print(pin())
+
 
 test_pin_read(Pin.PULL_UP)
 test_pin_read(Pin.PULL_DOWN)
@@ -73,4 +75,3 @@ time.sleep_ms(1000)
 time2 = rtc.now()
 print(time2[5] - time1[5] == 1)
 print(time2[6] - time1[6] < 5000) # microseconds
-

--- a/ports/cc3200/tools/uniflash.py
+++ b/ports/cc3200/tools/uniflash.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-
 """
 Flash the WiPy (format, update service pack and program).
 
@@ -19,7 +18,7 @@ import subprocess
 
 
 def print_exception(e):
-    print ('Exception: {}, on line {}'.format(e, sys.exc_info()[-1].tb_lineno))
+    print('Exception: {}, on line {}'.format(e, sys.exc_info()[-1].tb_lineno))
 
 
 def execute(command):
@@ -43,12 +42,23 @@ def execute(command):
     else:
         raise ProcessException(command, exitCode, output)
 
+
 def main():
-    cmd_parser = argparse.ArgumentParser(description='Flash the WiPy and optionally run a small test on it.')
-    cmd_parser.add_argument('-u', '--uniflash', default=None, help='the path to the uniflash cli executable')
-    cmd_parser.add_argument('-c', '--config', default=None, help='the path to the uniflash config file')
+    cmd_parser = argparse.ArgumentParser(
+        description='Flash the WiPy and optionally run a small test on it.')
+    cmd_parser.add_argument('-u',
+                            '--uniflash',
+                            default=None,
+                            help='the path to the uniflash cli executable')
+    cmd_parser.add_argument('-c',
+                            '--config',
+                            default=None,
+                            help='the path to the uniflash config file')
     cmd_parser.add_argument('-p', '--port', default=8, help='the com serial port')
-    cmd_parser.add_argument('-s', '--servicepack', default=None, help='the path to the servicepack file')
+    cmd_parser.add_argument('-s',
+                            '--servicepack',
+                            default=None,
+                            help='the path to the servicepack file')
     args = cmd_parser.parse_args()
 
     output = ""
@@ -59,9 +69,15 @@ def main():
         if args.uniflash == None or args.config == None:
             raise ValueError('uniflash path and config path are mandatory')
         if args.servicepack == None:
-            output += execute([args.uniflash, '-config', args.config, '-setOptions', com_port, '-operations', 'format', 'program'])
+            output += execute([
+                args.uniflash, '-config', args.config, '-setOptions', com_port, '-operations',
+                'format', 'program'
+            ])
         else:
-            output += execute([args.uniflash, '-config', args.config, '-setOptions', com_port, servicepack_path, '-operations', 'format', 'servicePackUpdate', 'program'])
+            output += execute([
+                args.uniflash, '-config', args.config, '-setOptions', com_port, servicepack_path,
+                '-operations', 'format', 'servicePackUpdate', 'program'
+            ])
     except Exception as e:
         print_exception(e)
         output = ""
@@ -76,6 +92,7 @@ def main():
             print("ERROR: Programming failed!")
             print("======================================")
             sys.exit(1)
+
 
 if __name__ == "__main__":
     main()

--- a/ports/cc3200/tools/update-wipy.py
+++ b/ports/cc3200/tools/update-wipy.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-
 """
 The WiPy firmware update script. Transmits the specified firmware file
 over FTP, and then resets the WiPy and optionally verifies that software
@@ -23,12 +22,12 @@ from telnetlib import Telnet
 
 
 def print_exception(e):
-    print ('Exception: {}, on line {}'.format(e, sys.exc_info()[-1].tb_lineno))
+    print('Exception: {}, on line {}'.format(e, sys.exc_info()[-1].tb_lineno))
 
 
 def ftp_directory_exists(ftpobj, directory_name):
     filelist = []
-    ftpobj.retrlines('LIST',filelist.append)
+    ftpobj.retrlines('LIST', filelist.append)
     for f in filelist:
         if f.split()[-1] == directory_name:
             return True
@@ -37,34 +36,34 @@ def ftp_directory_exists(ftpobj, directory_name):
 
 def transfer_file(args):
     with FTP(args.ip, timeout=20) as ftp:
-        print ('FTP connection established')
+        print('FTP connection established')
 
         if '230' in ftp.login(args.user, args.password):
-            print ('Login successful')
+            print('Login successful')
 
             if '250' in ftp.cwd('/flash'):
                 if not ftp_directory_exists(ftp, 'sys'):
-                    print ('/flash/sys directory does not exist')
+                    print('/flash/sys directory does not exist')
                     if not '550' in ftp.mkd('sys'):
-                        print ('/flash/sys directory created')
+                        print('/flash/sys directory created')
                     else:
-                        print ('Error: cannot create /flash/sys directory')
+                        print('Error: cannot create /flash/sys directory')
                         return False
                 if '250' in ftp.cwd('sys'):
-                    print ("Entered '/flash/sys' directory")
+                    print("Entered '/flash/sys' directory")
                     with open(args.file, "rb") as fwfile:
-                        print ('Firmware image found, initiating transfer...')
+                        print('Firmware image found, initiating transfer...')
                         if '226' in ftp.storbinary("STOR " + 'mcuimg.bin', fwfile, 512):
-                            print ('File transfer complete')
+                            print('File transfer complete')
                             return True
                         else:
-                            print ('Error: file transfer failed')
+                            print('Error: file transfer failed')
                 else:
-                    print ('Error: cannot enter /flash/sys directory')
+                    print('Error: cannot enter /flash/sys directory')
             else:
-                print ('Error: cannot enter /flash directory')
+                print('Error: cannot enter /flash directory')
         else:
-            print ('Error: ftp login failed')
+            print('Error: ftp login failed')
 
     return False
 
@@ -84,12 +83,14 @@ def reset_board(args):
                 time.sleep(0.2)
                 tn.write(bytes(args.password, 'ascii') + b"\r\n")
 
-                if b'Type "help()" for more information.' in tn.read_until(b'Type "help()" for more information.', timeout=5):
+                if b'Type "help()" for more information.' in tn.read_until(
+                        b'Type "help()" for more information.', timeout=5):
                     print("Telnet login succeeded")
                     tn.write(b'\r\x03\x03') # ctrl-C twice: interrupt any running program
                     time.sleep(1)
                     tn.write(b'\r\x02') # ctrl-B: enter friendly REPL
-                    if b'Type "help()" for more information.' in tn.read_until(b'Type "help()" for more information.', timeout=5):
+                    if b'Type "help()" for more information.' in tn.read_until(
+                            b'Type "help()" for more information.', timeout=5):
                         tn.write(b"import machine\r\n")
                         tn.write(b"machine.reset()\r\n")
                         time.sleep(2)
@@ -114,7 +115,7 @@ def verify_update(args):
     success = False
     firmware_tag = ''
 
-    def find_tag (tag):
+    def find_tag(tag):
         if tag in firmware_tag:
             print("Verification passed")
             return True
@@ -139,9 +140,9 @@ def verify_update(args):
                 return False
 
     try:
-        firmware_tag = tn.read_until (b'with CC3200')
+        firmware_tag = tn.read_until(b'with CC3200')
         tag_file_path = args.file.rstrip('mcuimg.bin') + 'genhdr/mpversion.h'
-        
+
         if args.tag is not None:
             success = find_tag(bytes(args.tag, 'ascii'))
         else:
@@ -149,7 +150,8 @@ def verify_update(args):
                 for line in tag_file:
                     bline = bytes(line, 'ascii')
                     if b'MICROPY_GIT_HASH' in bline:
-                        bline = bline.lstrip(b'#define MICROPY_GIT_HASH ').replace(b'"', b'').replace(b'\r', b'').replace(b'\n', b'')
+                        bline = bline.lstrip(b'#define MICROPY_GIT_HASH ').replace(
+                            b'"', b'').replace(b'\r', b'').replace(b'\n', b'')
                         success = find_tag(bline)
                         break
 
@@ -164,12 +166,15 @@ def verify_update(args):
 
 
 def main():
-    cmd_parser = argparse.ArgumentParser(description='Update the WiPy firmware with the specified image file')
+    cmd_parser = argparse.ArgumentParser(
+        description='Update the WiPy firmware with the specified image file')
     cmd_parser.add_argument('-f', '--file', default=None, help='the path of the firmware file')
     cmd_parser.add_argument('-u', '--user', default='micro', help='the username')
     cmd_parser.add_argument('-p', '--password', default='python', help='the login password')
     cmd_parser.add_argument('--ip', default='192.168.1.1', help='the ip address of the WiPy')
-    cmd_parser.add_argument('--verify', action='store_true', help='verify that the update succeeded')
+    cmd_parser.add_argument('--verify',
+                            action='store_true',
+                            help='verify that the update succeeded')
     cmd_parser.add_argument('-t', '--tag', default=None, help='git tag of the firmware image')
     args = cmd_parser.parse_args()
 
@@ -181,7 +186,7 @@ def main():
         if transfer_file(args):
             if reset_board(args):
                 if args.verify:
-                    print ('Waiting for the WiFi connection to come up again...')
+                    print('Waiting for the WiFi connection to come up again...')
                     # this time is to allow the system's wireless network card to
                     # connect to the WiPy again.
                     time.sleep(5)

--- a/ports/esp32/boards/TINYPICO/modules/dotstar.py
+++ b/ports/esp32/boards/TINYPICO/modules/dotstar.py
@@ -26,7 +26,7 @@
 # THE SOFTWARE.
 
 START_HEADER_SIZE = 4
-LED_START = 0b11100000  # Three "1" bits, followed by 5 brightness bits
+LED_START = 0b11100000 # Three "1" bits, followed by 5 brightness bits
 
 # Pixel color order constants
 RGB = (0, 1, 2)
@@ -62,9 +62,7 @@ class DotStar:
         dotstar = DotStar(spi, 1)
         dotstar[0] = (128, 0, 0) # Red
     """
-
-    def __init__(self, spi, n, *, brightness=1.0, auto_write=True,
-                 pixel_order=BGR):
+    def __init__(self, spi, n, *, brightness=1.0, auto_write=True, pixel_order=BGR):
         self._spi = spi
         self._n = n
         # Supply one extra clock cycle for each two pixels in the strip.
@@ -178,8 +176,7 @@ class DotStar:
         if index >= self._n or index < 0:
             raise IndexError
         offset = index * 4
-        return tuple(self._buf[offset + (3 - i) + START_HEADER_SIZE]
-                     for i in range(3))
+        return tuple(self._buf[offset + (3 - i) + START_HEADER_SIZE] for i in range(3))
 
     def __len__(self):
         return self._n

--- a/ports/esp32/boards/TINYPICO/modules/tinypico.py
+++ b/ports/esp32/boards/TINYPICO/modules/tinypico.py
@@ -39,6 +39,7 @@ DAC2 = const(26)
 
 # Helper functions
 
+
 # Get a *rough* estimate of the current battery voltage
 # If the battery is not present, the charge IC will still report it's trying to charge at X voltage
 # so it will still show a voltage.
@@ -47,11 +48,12 @@ def get_battery_voltage():
     Returns the current battery voltage. If no battery is connected, returns 3.7V
     This is an approximation only, but useful to detect of the charge state of the battery is getting low.
     """
-    adc = ADC(Pin(BAT_VOLTAGE))             # Assign the ADC pin to read
-    measuredvbat = adc.read()               # Read the value
-    measuredvbat /= 4095                    # divide by 4095 as we are using the default ADC voltage range of 0-1V
-    measuredvbat *= 3.7                     # Multiply by 3.7V, our reference voltage
+    adc = ADC(Pin(BAT_VOLTAGE)) # Assign the ADC pin to read
+    measuredvbat = adc.read() # Read the value
+    measuredvbat /= 4095 # divide by 4095 as we are using the default ADC voltage range of 0-1V
+    measuredvbat *= 3.7 # Multiply by 3.7V, our reference voltage
     return measuredvbat
+
 
 # Return the current charge state of the battery - we need to read the value multiple times
 # to eliminate false negatives due to the charge IC not knowing the difference between no battery
@@ -61,13 +63,15 @@ def get_battery_charging():
     Returns the current battery charging state.
     This can trigger false positives as the charge IC can't tell the difference between a full battery or no battery connected.
     """
-    measuredVal = 0                         # start our reading at 0
-    io = Pin(BAT_CHARGE, Pin.IN)            # Assign the pin to read
+    measuredVal = 0 # start our reading at 0
+    io = Pin(BAT_CHARGE, Pin.IN) # Assign the pin to read
 
-    for y in range(0, 10):                  # loop through 10 times adding the read values together to ensure no false positives
+    for y in range(
+            0, 10
+    ): # loop through 10 times adding the read values together to ensure no false positives
         measuredVal += io.value()
 
-    return measuredVal == 0                 # return True if the value is 0
+    return measuredVal == 0 # return True if the value is 0
 
 
 # Power to the on-board Dotstar is controlled by a PNP transistor, so low is ON and high is OFF
@@ -80,16 +84,19 @@ def set_dotstar_power(state):
     """Set the power for the on-board Dostar to allow no current draw when not needed."""
     # Set the power pin to the inverse of state
     if state:
-        Pin(DOTSTAR_PWR, Pin.OUT, None)     # Break the PULL_HOLD on the pin
-        Pin(DOTSTAR_PWR).value(False)       # Set the pin to LOW to enable the Transistor
+        Pin(DOTSTAR_PWR, Pin.OUT, None) # Break the PULL_HOLD on the pin
+        Pin(DOTSTAR_PWR).value(False) # Set the pin to LOW to enable the Transistor
     else:
-        Pin(13, Pin.IN, Pin.PULL_HOLD)      # Set PULL_HOLD on the pin to allow the 3V3 pull-up to work
+        Pin(13, Pin.IN, Pin.PULL_HOLD) # Set PULL_HOLD on the pin to allow the 3V3 pull-up to work
 
-    Pin(DOTSTAR_CLK, Pin.OUT if state else Pin.IN)  # If power is on, set CLK to be output, otherwise input
-    Pin(DOTSTAR_DATA, Pin.OUT if state else Pin.IN) # If power is on, set DATA to be output, otherwise input
+    Pin(DOTSTAR_CLK,
+        Pin.OUT if state else Pin.IN) # If power is on, set CLK to be output, otherwise input
+    Pin(DOTSTAR_DATA,
+        Pin.OUT if state else Pin.IN) # If power is on, set DATA to be output, otherwise input
 
     # A small delay to let the IO change state
     time.sleep(.035)
+
 
 # Dotstar rainbow colour wheel
 def dotstar_color_wheel(wheel_pos):
@@ -104,6 +111,7 @@ def dotstar_color_wheel(wheel_pos):
     else:
         wheel_pos -= 170
         return wheel_pos * 3, 255 - wheel_pos * 3, 0
+
 
 # Go into deep sleep but shut down the APA first to save power
 # Use this if you want lowest deep  sleep current

--- a/ports/esp32/makeimg.py
+++ b/ports/esp32/makeimg.py
@@ -21,5 +21,5 @@ with open(file_out, 'wb') as fout:
             data = fin.read()
             fout.write(data)
             cur_offset += len(data)
-            print('%-12s% 8d' % (name, len(data))) 
+            print('%-12s% 8d' % (name, len(data)))
     print('%-12s% 8d' % ('total', cur_offset))

--- a/ports/esp32/modules/inisetup.py
+++ b/ports/esp32/modules/inisetup.py
@@ -1,6 +1,7 @@
 import uos
 from flashbdev import bdev
 
+
 def check_bootsec():
     buf = bytearray(bdev.ioctl(5, 0)) # 5 is SEC_SIZE
     bdev.readblocks(0, buf)
@@ -13,6 +14,7 @@ def check_bootsec():
         return True
     fs_corrupted()
 
+
 def fs_corrupted():
     import time
     while 1:
@@ -23,6 +25,7 @@ factory reprogramming of MicroPython firmware (completely erase flash, followed
 by firmware programming).
 """)
         time.sleep(3)
+
 
 def setup():
     check_bootsec()

--- a/ports/esp32/modules/neopixel.py
+++ b/ports/esp32/modules/neopixel.py
@@ -6,7 +6,7 @@ from esp import neopixel_write
 
 class NeoPixel:
     ORDER = (1, 0, 2, 3)
-    
+
     def __init__(self, pin, n, bpp=3, timing=1):
         self.pin = pin
         self.n = n
@@ -22,8 +22,7 @@ class NeoPixel:
 
     def __getitem__(self, index):
         offset = index * self.bpp
-        return tuple(self.buf[offset + self.ORDER[i]]
-                     for i in range(self.bpp))
+        return tuple(self.buf[offset + self.ORDER[i]] for i in range(self.bpp))
 
     def fill(self, color):
         for i in range(self.n):

--- a/ports/esp8266/modules/flashbdev.py
+++ b/ports/esp8266/modules/flashbdev.py
@@ -1,5 +1,6 @@
 import esp
 
+
 class FlashBdev:
 
     SEC_SIZE = 4096
@@ -24,16 +25,17 @@ class FlashBdev:
 
     def ioctl(self, op, arg):
         #print("ioctl(%d, %r)" % (op, arg))
-        if op == 4:  # MP_BLOCKDEV_IOCTL_BLOCK_COUNT
+        if op == 4: # MP_BLOCKDEV_IOCTL_BLOCK_COUNT
             return self.blocks
-        if op == 5:  # MP_BLOCKDEV_IOCTL_BLOCK_SIZE
+        if op == 5: # MP_BLOCKDEV_IOCTL_BLOCK_SIZE
             return self.SEC_SIZE
-        if op == 6:  # MP_BLOCKDEV_IOCTL_BLOCK_ERASE
+        if op == 6: # MP_BLOCKDEV_IOCTL_BLOCK_ERASE
             esp.flash_erase(arg + self.START_SEC)
             return 0
 
+
 size = esp.flash_size()
-if size < 1024*1024:
+if size < 1024 * 1024:
     bdev = None
 else:
     # 20K at the flash end is reserved for SDK params storage

--- a/ports/esp8266/modules/inisetup.py
+++ b/ports/esp8266/modules/inisetup.py
@@ -2,11 +2,13 @@ import uos
 import network
 from flashbdev import bdev
 
+
 def wifi():
     import ubinascii
     ap_if = network.WLAN(network.AP_IF)
     essid = b"MicroPython-%s" % ubinascii.hexlify(ap_if.config("mac")[-3:])
     ap_if.config(essid=essid, authmode=network.AUTH_WPA_WPA2_PSK, password=b"micropythoN")
+
 
 def check_bootsec():
     buf = bytearray(bdev.SEC_SIZE)
@@ -20,6 +22,7 @@ def check_bootsec():
         return True
     fs_corrupted()
 
+
 def fs_corrupted():
     import time
     while 1:
@@ -31,6 +34,7 @@ of MicroPython firmware (completely erase flash, followed by firmware
 programming).
 """ % (bdev.START_SEC, bdev.blocks))
         time.sleep(3)
+
 
 def setup():
     check_bootsec()

--- a/ports/esp8266/modules/neopixel.py
+++ b/ports/esp8266/modules/neopixel.py
@@ -21,8 +21,7 @@ class NeoPixel:
 
     def __getitem__(self, index):
         offset = index * self.bpp
-        return tuple(self.buf[offset + self.ORDER[i]]
-                     for i in range(self.bpp))
+        return tuple(self.buf[offset + self.ORDER[i]] for i in range(self.bpp))
 
     def fill(self, color):
         for i in range(self.n):

--- a/ports/esp8266/modules/ntptime.py
+++ b/ports/esp8266/modules/ntptime.py
@@ -13,6 +13,7 @@ NTP_DELTA = 3155673600
 # The NTP host can be configured at runtime by doing: ntptime.host = 'myhost.org'
 host = "pool.ntp.org"
 
+
 def time():
     NTP_QUERY = bytearray(48)
     NTP_QUERY[0] = 0x1b
@@ -26,6 +27,7 @@ def time():
         s.close()
     val = struct.unpack("!I", msg[40:44])[0]
     return val - NTP_DELTA
+
 
 # There's currently no timezone support in MicroPython, so
 # utime.localtime() will return UTC time (as if it was .gmtime())

--- a/ports/esp8266/modules/port_diag.py
+++ b/ports/esp8266/modules/port_diag.py
@@ -16,7 +16,8 @@ def main():
     SZ_MAP = {0: "512KB", 1: "256KB", 2: "1MB", 3: "2MB", 4: "4MB"}
     FREQ_MAP = {0: "40MHZ", 1: "26MHZ", 2: "20MHz", 0xf: "80MHz"}
     print("Byte @2: %02x" % ROM[2])
-    print("Byte @3: %02x (Flash size: %s Flash freq: %s)" % (ROM[3], SZ_MAP.get(ROM[3] >> 4, "?"), FREQ_MAP.get(ROM[3] & 0xf)))
+    print("Byte @3: %02x (Flash size: %s Flash freq: %s)" %
+          (ROM[3], SZ_MAP.get(ROM[3] >> 4, "?"), FREQ_MAP.get(ROM[3] & 0xf)))
     print("Firmware checksum:")
     print(esp.check_fw())
 
@@ -24,7 +25,8 @@ def main():
     print("STA ifconfig:", network.WLAN(network.STA_IF).ifconfig())
     print("AP ifconfig:", network.WLAN(network.AP_IF).ifconfig())
     print("Free WiFi driver buffers of type:")
-    for i, comm in enumerate(("1,2 TX", "4 Mngmt TX(len: 0x41-0x100)", "5 Mngmt TX (len: 0-0x40)", "7", "8 RX")):
+    for i, comm in enumerate(
+        ("1,2 TX", "4 Mngmt TX(len: 0x41-0x100)", "5 Mngmt TX (len: 0-0x40)", "7", "8 RX")):
         print("%d: %d (%s)" % (i, esp.esf_free_bufs(i), comm))
     print("lwIP PCBs:")
     lwip.print_pcbs()

--- a/ports/nrf/boards/make-pins.py
+++ b/ports/nrf/boards/make-pins.py
@@ -7,9 +7,8 @@ import argparse
 import sys
 import csv
 
-SUPPORTED_FN = {
-    'UART'  : ['RX', 'TX', 'CTS', 'RTS']
-}
+SUPPORTED_FN = {'UART': ['RX', 'TX', 'CTS', 'RTS']}
+
 
 def parse_pin(name_str):
     """Parses a string and returns a pin-num."""
@@ -21,6 +20,7 @@ def parse_pin(name_str):
     if not pin_str.isdigit():
         raise ValueError("Expecting numeric pin number.")
     return int(pin_str)
+
 
 def split_name_num(name_num):
     num = None
@@ -36,7 +36,6 @@ def split_name_num(name_num):
 
 class AlternateFunction(object):
     """Holds the information associated with a pins alternate function."""
-
     def __init__(self, idx, af_str):
         self.idx = idx
         self.af_str = af_str
@@ -70,14 +69,15 @@ class AlternateFunction(object):
     def print(self):
         """Prints the C representation of this AF."""
         if self.supported:
-            print('  AF',  end='')
+            print('  AF', end='')
         else:
             print('  //', end='')
         fn_num = self.fn_num
         if fn_num is None:
             fn_num = 0
-        print('({:2d}, {:8s}, {:2d}, {:10s}, {:8s}), // {:s}'.format(self.idx,
-              self.func, fn_num, self.pin_type, self.ptr(), self.af_str))
+        print('({:2d}, {:8s}, {:2d}, {:10s}, {:8s}), // {:s}'.format(self.idx, self.func,
+                                                                     fn_num, self.pin_type,
+                                                                     self.ptr(), self.af_str))
 
     def qstr_list(self):
         return [self.mux_name()]
@@ -85,7 +85,6 @@ class AlternateFunction(object):
 
 class Pin(object):
     """Holds the information associated with a pin."""
-
     def __init__(self, pin):
         self.pin = pin
         self.alt_fn = []
@@ -110,7 +109,7 @@ class Pin(object):
     def parse_adc(self, adc_str):
         if (adc_str[:3] != 'ADC'):
             return
-        (adc,channel) = adc_str.split('_')
+        (adc, channel) = adc_str.split('_')
         for idx in range(3, len(adc)):
             self.adc_num = int(adc[idx])
         self.adc_channel = int(channel[2:])
@@ -134,7 +133,7 @@ class Pin(object):
 
     def adc_num_str(self):
         str = ''
-        for adc_num in range(1,4):
+        for adc_num in range(1, 4):
             if self.adc_num & (1 << (adc_num - 1)):
                 if len(str) > 0:
                     str += ' | '
@@ -145,33 +144,28 @@ class Pin(object):
         return str
 
     def print_const_table_entry(self):
-        print('  PIN({:d}, {:s}, {:s}, {:d}),'.format(
-            self.pin,
-            self.alt_fn_name(null_if_0=True),
-            self.adc_num_str(), self.adc_channel))
+        print('  PIN({:d}, {:s}, {:s}, {:d}),'.format(self.pin, self.alt_fn_name(null_if_0=True),
+                                                      self.adc_num_str(), self.adc_channel))
 
     def print(self):
         if self.alt_fn_count == 0:
-            print("// ",  end='')
+            print("// ", end='')
         print('const pin_af_obj_t {:s}[] = {{'.format(self.alt_fn_name()))
         for alt_fn in self.alt_fn:
             alt_fn.print()
         if self.alt_fn_count == 0:
-            print("// ",  end='')
+            print("// ", end='')
         print('};')
         print('')
         print('const pin_obj_t pin_{:s} = PIN({:d}, {:s}, {:s}, {:d});'.format(
-            self.cpu_pin_name(), self.pin,
-            self.alt_fn_name(null_if_0=True),
-            self.adc_num_str(), self.adc_channel))
+            self.cpu_pin_name(), self.pin, self.alt_fn_name(null_if_0=True), self.adc_num_str(),
+            self.adc_channel))
         print('')
 
     def print_header(self, hdr_file):
-        hdr_file.write('extern const pin_obj_t pin_{:s};\n'.
-                       format(self.cpu_pin_name()))
+        hdr_file.write('extern const pin_obj_t pin_{:s};\n'.format(self.cpu_pin_name()))
         if self.alt_fn_count > 0:
-            hdr_file.write('extern const pin_af_obj_t pin_{:s}_af[];\n'.
-                           format(self.cpu_pin_name()))
+            hdr_file.write('extern const pin_af_obj_t pin_{:s}_af[];\n'.format(self.cpu_pin_name()))
 
     def qstr_list(self):
         result = []
@@ -182,7 +176,6 @@ class Pin(object):
 
 
 class NamedPin(object):
-
     def __init__(self, name, pin):
         self._name = name
         self._pin = pin
@@ -195,9 +188,8 @@ class NamedPin(object):
 
 
 class Pins(object):
-
     def __init__(self):
-        self.cpu_pins = []   # list of NamedPin objects
+        self.cpu_pins = [] # list of NamedPin objects
         self.board_pins = [] # list of NamedPin objects
 
     def find_pin(self, pin_num):
@@ -240,9 +232,12 @@ class Pins(object):
         for named_pin in named_pins:
             pin = named_pin.pin()
             if pin.is_board_pin():
-                print('  {{ MP_ROM_QSTR(MP_QSTR_{:s}), MP_ROM_PTR(&machine_board_pin_obj[{:d}]) }},'.format(named_pin.name(), pin.board_index))
+                print(
+                    '  {{ MP_ROM_QSTR(MP_QSTR_{:s}), MP_ROM_PTR(&machine_board_pin_obj[{:d}]) }},'.
+                    format(named_pin.name(), pin.board_index))
         print('};')
-        print('MP_DEFINE_CONST_DICT(pin_{:s}_pins_locals_dict, pin_{:s}_pins_locals_dict_table);'.format(label, label));
+        print('MP_DEFINE_CONST_DICT(pin_{:s}_pins_locals_dict, pin_{:s}_pins_locals_dict_table);'.
+              format(label, label))
 
     def print_const_table(self):
         num_board_pins = 0
@@ -259,7 +254,7 @@ class Pins(object):
             pin = named_pin.pin()
             if pin.is_board_pin():
                 pin.print_const_table_entry()
-        print('};');
+        print('};')
 
     def print(self):
         self.print_named('cpu', self.cpu_pins)
@@ -267,21 +262,20 @@ class Pins(object):
         self.print_named('board', self.board_pins)
 
     def print_adc(self, adc_num):
-        print('');
+        print('')
         print('const pin_obj_t * const pin_adc{:d}[] = {{'.format(adc_num))
         for channel in range(16):
             adc_found = False
             for named_pin in self.cpu_pins:
                 pin = named_pin.pin()
-                if (pin.is_board_pin() and
-                    (pin.adc_num & (1 << (adc_num - 1))) and (pin.adc_channel == channel)):
+                if (pin.is_board_pin() and (pin.adc_num & (1 << (adc_num - 1)))
+                        and (pin.adc_channel == channel)):
                     print('  &pin_{:s}, // {:d}'.format(pin.cpu_pin_name(), channel))
                     adc_found = True
                     break
             if not adc_found:
                 print('  NULL,    // {:d}'.format(channel))
         print('};')
-
 
     def print_header(self, hdr_filename):
         with open(hdr_filename, 'wt') as hdr_file:
@@ -306,9 +300,8 @@ class Pins(object):
             for qstr in sorted(qstr_set):
                 print('Q({})'.format(qstr), file=qstr_file)
 
-
     def print_af_hdr(self, af_const_filename):
-        with open(af_const_filename,  'wt') as af_const_file:
+        with open(af_const_filename, 'wt') as af_const_file:
             af_hdr_set = set([])
             mux_name_width = 0
             for named_pin in self.cpu_pins:
@@ -323,68 +316,58 @@ class Pins(object):
             for mux_name in sorted(af_hdr_set):
                 key = 'MP_ROM_QSTR(MP_QSTR_{}),'.format(mux_name)
                 val = 'MP_ROM_INT(GPIO_{})'.format(mux_name)
-                print('    { %-*s %s },' % (mux_name_width + 26, key, val),
-                      file=af_const_file)
+                print('    { %-*s %s },' % (mux_name_width + 26, key, val), file=af_const_file)
 
     def print_af_py(self, af_py_filename):
-        with open(af_py_filename,  'wt') as af_py_file:
-            print('PINS_AF = (', file=af_py_file);
+        with open(af_py_filename, 'wt') as af_py_file:
+            print('PINS_AF = (', file=af_py_file)
             for named_pin in self.board_pins:
                 print("  ('%s', " % named_pin.name(), end='', file=af_py_file)
                 for af in named_pin.pin().alt_fn:
                     if af.is_supported():
                         print("(%d, '%s'), " % (af.idx, af.af_str), end='', file=af_py_file)
                 print('),', file=af_py_file)
-            print(')',  file=af_py_file)
+            print(')', file=af_py_file)
 
 
 def main():
-    parser = argparse.ArgumentParser(
-        prog="make-pins.py",
-        usage="%(prog)s [options] [command]",
-        description="Generate board specific pin file"
-    )
+    parser = argparse.ArgumentParser(prog="make-pins.py",
+                                     usage="%(prog)s [options] [command]",
+                                     description="Generate board specific pin file")
+    parser.add_argument("-a",
+                        "--af",
+                        dest="af_filename",
+                        help="Specifies the alternate function file for the chip",
+                        default="nrf.csv")
+    parser.add_argument("--af-const",
+                        dest="af_const_filename",
+                        help="Specifies header file for alternate function constants.",
+                        default="build/pins_af_const.h")
+    parser.add_argument("--af-py",
+                        dest="af_py_filename",
+                        help="Specifies the filename for the python alternate function mappings.",
+                        default="build/pins_af.py")
     parser.add_argument(
-        "-a", "--af",
-        dest="af_filename",
-        help="Specifies the alternate function file for the chip",
-        default="nrf.csv"
-    )
-    parser.add_argument(
-        "--af-const",
-        dest="af_const_filename",
-        help="Specifies header file for alternate function constants.",
-        default="build/pins_af_const.h"
-    )
-    parser.add_argument(
-        "--af-py",
-        dest="af_py_filename",
-        help="Specifies the filename for the python alternate function mappings.",
-        default="build/pins_af.py"
-    )
-    parser.add_argument(
-        "-b", "--board",
+        "-b",
+        "--board",
         dest="board_filename",
         help="Specifies the board file",
     )
-    parser.add_argument(
-        "-p", "--prefix",
-        dest="prefix_filename",
-        help="Specifies beginning portion of generated pins file",
-        default="nrf52_prefix.c"
-    )
-    parser.add_argument(
-        "-q", "--qstr",
-        dest="qstr_filename",
-        help="Specifies name of generated qstr header file",
-        default="build/pins_qstr.h"
-    )
-    parser.add_argument(
-        "-r", "--hdr",
-        dest="hdr_filename",
-        help="Specifies name of generated pin header file",
-        default="build/pins.h"
-    )
+    parser.add_argument("-p",
+                        "--prefix",
+                        dest="prefix_filename",
+                        help="Specifies beginning portion of generated pins file",
+                        default="nrf52_prefix.c")
+    parser.add_argument("-q",
+                        "--qstr",
+                        dest="qstr_filename",
+                        help="Specifies name of generated qstr header file",
+                        default="build/pins_qstr.h")
+    parser.add_argument("-r",
+                        "--hdr",
+                        dest="hdr_filename",
+                        help="Specifies name of generated pin header file",
+                        default="build/pins.h")
     args = parser.parse_args(sys.argv[1:])
 
     pins = Pins()

--- a/ports/nrf/examples/mountsd.py
+++ b/ports/nrf/examples/mountsd.py
@@ -24,12 +24,13 @@ import os
 from machine import SPI, Pin
 from sdcard import SDCard
 
+
 def mnt():
     cs = Pin("P22", mode=Pin.OUT)
     sd = SDCard(SPI(0), cs)
     os.mount(sd, '/')
 
+
 def list():
     files = os.listdir()
     print(files)
-

--- a/ports/nrf/examples/musictest.py
+++ b/ports/nrf/examples/musictest.py
@@ -1,4 +1,4 @@
-# 
+#
 # Example usage where "P3" is the Buzzer pin.
 #
 #  from musictest import play
@@ -7,6 +7,7 @@
 
 from machine import Pin
 import music
+
 
 def play(pin_str):
     p = Pin(pin_str, mode=Pin.OUT)

--- a/ports/nrf/examples/nrf52_pwm.py
+++ b/ports/nrf/examples/nrf52_pwm.py
@@ -1,6 +1,7 @@
 import time
 from machine import PWM, Pin
 
+
 def pulse():
     for i in range(0, 101):
         p = PWM(0, Pin("P17", mode=Pin.OUT), freq=PWM.FREQ_16MHZ, duty=i, period=16000)
@@ -9,7 +10,7 @@ def pulse():
         p.deinit()
 
     for i in range(0, 101):
-        p = PWM(0, Pin("P17", mode=Pin.OUT), freq=PWM.FREQ_16MHZ, duty=100-i, period=16000)
+        p = PWM(0, Pin("P17", mode=Pin.OUT), freq=PWM.FREQ_16MHZ, duty=100 - i, period=16000)
         p.init()
         time.sleep_ms(10)
         p.deinit()

--- a/ports/nrf/examples/nrf52_servo.py
+++ b/ports/nrf/examples/nrf52_servo.py
@@ -25,26 +25,43 @@
 import time
 from machine import PWM, Pin
 
+
 class Servo():
     def __init__(self, pin_name=""):
         if pin_name:
             self.pin = Pin(pin_name, mode=Pin.OUT, pull=Pin.PULL_DOWN)
         else:
             self.pin = Pin("P22", mode=Pin.OUT, pull=Pin.PULL_DOWN)
+
     def left(self):
-        p = PWM(0, self.pin, freq=PWM.FREQ_125KHZ, pulse_width=105, period=2500, mode=PWM.MODE_HIGH_LOW)
+        p = PWM(0,
+                self.pin,
+                freq=PWM.FREQ_125KHZ,
+                pulse_width=105,
+                period=2500,
+                mode=PWM.MODE_HIGH_LOW)
         p.init()
         time.sleep_ms(200)
         p.deinit()
-        
+
     def center(self):
-        p = PWM(0, self.pin, freq=PWM.FREQ_125KHZ, pulse_width=188, period=2500, mode=PWM.MODE_HIGH_LOW)
+        p = PWM(0,
+                self.pin,
+                freq=PWM.FREQ_125KHZ,
+                pulse_width=188,
+                period=2500,
+                mode=PWM.MODE_HIGH_LOW)
         p.init()
         time.sleep_ms(200)
         p.deinit()
-        
+
     def right(self):
-        p = PWM(0, self.pin, freq=PWM.FREQ_125KHZ, pulse_width=275, period=2500, mode=PWM.MODE_HIGH_LOW)
+        p = PWM(0,
+                self.pin,
+                freq=PWM.FREQ_125KHZ,
+                pulse_width=275,
+                period=2500,
+                mode=PWM.MODE_HIGH_LOW)
         p.init()
         time.sleep_ms(200)
         p.deinit()

--- a/ports/nrf/examples/powerup.py
+++ b/ports/nrf/examples/powerup.py
@@ -41,11 +41,13 @@ from machine import ADC
 from machine import Pin
 from ubluepy import Peripheral, Scanner, constants
 
+
 def bytes_to_str(bytes):
     string = ""
     for b in bytes:
         string += chr(b)
     return string
+
 
 def get_device_names(scan_entries):
     dev_names = []
@@ -53,9 +55,10 @@ def get_device_names(scan_entries):
         scan = e.getScanData()
         if scan:
             for s in scan:
-               if s[0] == constants.ad_types.AD_TYPE_COMPLETE_LOCAL_NAME:
-                   dev_names.append((e, bytes_to_str(s[2])))
+                if s[0] == constants.ad_types.AD_TYPE_COMPLETE_LOCAL_NAME:
+                    dev_names.append((e, bytes_to_str(s[2])))
     return dev_names
+
 
 def find_device_by_name(name):
     s = Scanner()
@@ -65,6 +68,7 @@ def find_device_by_name(name):
     for dev in device_names:
         if name == dev[1]:
             return dev[0]
+
 
 class PowerUp3:
     def __init__(self):
@@ -76,14 +80,14 @@ class PowerUp3:
         self.btn_speed_off = Pin("P16", mode=Pin.IN, pull=Pin.PULL_UP)
 
         self.x_mid = 0
-        
+
         self.calibrate()
         self.connect()
         self.loop()
-        
+
     def read_stick_x(self):
         return self.x_adc.value()
-        
+
     def button_speed_up(self):
         return not bool(self.btn_speed_up.value())
 

--- a/ports/nrf/examples/seeed_tft.py
+++ b/ports/nrf/examples/seeed_tft.py
@@ -21,7 +21,6 @@
 # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
-
 """
 MicroPython Seeedstudio TFT Shield V2 driver, SPI interfaces, Analog GPIO
 Contains SD-card reader, LCD and Touch sensor
@@ -51,9 +50,11 @@ import framebuf
 from machine import SPI, Pin
 from sdcard import SDCard
 
+
 def mount_tf(self, mount_point="/"):
     sd = SDCard(SPI(0), Pin("P15", mode=Pin.OUT))
     os.mount(sd, mount_point)
+
 
 class ILI9341:
     def __init__(self, width, height):
@@ -61,14 +62,15 @@ class ILI9341:
         self.height = height
         self.pages = self.height // 8
         self.buffer = bytearray(self.pages * self.width)
-        self.framebuf = framebuf.FrameBuffer(self.buffer, self.width, self.height, framebuf.MONO_VLSB)
+        self.framebuf = framebuf.FrameBuffer(self.buffer, self.width, self.height,
+                                             framebuf.MONO_VLSB)
 
         self.spi = SPI(0)
         # chip select
         self.cs = Pin("P16", mode=Pin.OUT, pull=Pin.PULL_UP)
         # command
         self.dc = Pin("P17", mode=Pin.OUT, pull=Pin.PULL_UP)
-        
+
         # initialize all pins high
         self.cs.high()
         self.dc.high()
@@ -76,27 +78,26 @@ class ILI9341:
         self.spi.init(baudrate=8000000, phase=0, polarity=0)
 
         self.init_display()
-        
 
     def init_display(self):
         time.sleep_ms(500)
-        
+
         self.write_cmd(0x01)
-        
+
         time.sleep_ms(200)
-    
+
         self.write_cmd(0xCF)
         self.write_data(bytearray([0x00, 0x8B, 0x30]))
-    
+
         self.write_cmd(0xED)
         self.write_data(bytearray([0x67, 0x03, 0x12, 0x81]))
 
         self.write_cmd(0xE8)
         self.write_data(bytearray([0x85, 0x10, 0x7A]))
-    
+
         self.write_cmd(0xCB)
         self.write_data(bytearray([0x39, 0x2C, 0x00, 0x34, 0x02]))
-    
+
         self.write_cmd(0xF7)
         self.write_data(bytearray([0x20]))
 
@@ -107,54 +108,62 @@ class ILI9341:
         self.write_cmd(0xC0)
         # VRH[5:0]
         self.write_data(bytearray([0x1B]))
-        
+
         # Power control
         self.write_cmd(0xC1)
         # SAP[2:0];BT[3:0]
         self.write_data(bytearray([0x10]))
-        
+
         # VCM control
         self.write_cmd(0xC5)
         self.write_data(bytearray([0x3F, 0x3C]))
-    
+
         # VCM control2
         self.write_cmd(0xC7)
         self.write_data(bytearray([0xB7]))
-    
+
         # Memory Access Control
         self.write_cmd(0x36)
         self.write_data(bytearray([0x08]))
-    
+
         self.write_cmd(0x3A)
         self.write_data(bytearray([0x55]))
-    
+
         self.write_cmd(0xB1)
         self.write_data(bytearray([0x00, 0x1B]))
-        
+
         # Display Function Control
         self.write_cmd(0xB6)
         self.write_data(bytearray([0x0A, 0xA2]))
-    
+
         # 3Gamma Function Disable
         self.write_cmd(0xF2)
         self.write_data(bytearray([0x00]))
-        
+
         # Gamma curve selected
         self.write_cmd(0x26)
         self.write_data(bytearray([0x01]))
-    
+
         # Set Gamma
         self.write_cmd(0xE0)
-        self.write_data(bytearray([0x0F, 0x2A, 0x28, 0x08, 0x0E, 0x08, 0x54, 0XA9, 0x43, 0x0A, 0x0F, 0x00, 0x00, 0x00, 0x00]))
-    
+        self.write_data(
+            bytearray([
+                0x0F, 0x2A, 0x28, 0x08, 0x0E, 0x08, 0x54, 0XA9, 0x43, 0x0A, 0x0F, 0x00, 0x00, 0x00,
+                0x00
+            ]))
+
         # Set Gamma
         self.write_cmd(0XE1)
-        self.write_data(bytearray([0x00, 0x15, 0x17, 0x07, 0x11, 0x06, 0x2B, 0x56, 0x3C, 0x05, 0x10, 0x0F, 0x3F, 0x3F, 0x0F]))
-        
+        self.write_data(
+            bytearray([
+                0x00, 0x15, 0x17, 0x07, 0x11, 0x06, 0x2B, 0x56, 0x3C, 0x05, 0x10, 0x0F, 0x3F, 0x3F,
+                0x0F
+            ]))
+
         # Exit Sleep
         self.write_cmd(0x11)
         time.sleep_ms(120)
-        
+
         # Display on
         self.write_cmd(0x29)
         time.sleep_ms(500)
@@ -165,13 +174,13 @@ class ILI9341:
         self.write_cmd(0x2A)
         self.write_data(bytearray([0x00, 0x00]))
         self.write_data(bytearray([0x00, 0xef]))
-        
-        # set page 
+
+        # set page
         self.write_cmd(0x2B)
         self.write_data(bytearray([0x00, 0x00]))
         self.write_data(bytearray([0x01, 0x3f]))
 
-        self.write_cmd(0x2c);
+        self.write_cmd(0x2c)
 
         num_of_pixels = self.height * self.width
 
@@ -201,10 +210,9 @@ class ILI9341:
         self.cs.low()
         self.spi.write(bytearray([cmd]))
         self.cs.high()
-        
+
     def write_data(self, buf):
         self.dc.high()
         self.cs.low()
         self.spi.write(buf)
         self.cs.high()
-

--- a/ports/nrf/examples/ssd1306_mod.py
+++ b/ports/nrf/examples/ssd1306_mod.py
@@ -20,11 +20,11 @@
 
 from ssd1306 import SSD1306_I2C
 
-SET_COL_ADDR        = const(0x21)
-SET_PAGE_ADDR       = const(0x22)
+SET_COL_ADDR = const(0x21)
+SET_PAGE_ADDR = const(0x22)
+
 
 class SSD1306_I2C_Mod(SSD1306_I2C):
-
     def show(self):
         x0 = 0
         x1 = self.width - 1
@@ -44,10 +44,9 @@ class SSD1306_I2C_Mod(SSD1306_I2C):
         leftover = len(self.buffer) - (num_of_chunks * chunk_size)
 
         for i in range(0, num_of_chunks):
-            self.write_data(self.buffer[chunk_size*i:chunk_size*(i+1)])
+            self.write_data(self.buffer[chunk_size * i:chunk_size * (i + 1)])
         if (leftover > 0):
             self.write_data(self.buffer[chunk_size * num_of_chunks:])
-
 
     def write_data(self, buf):
         buffer = bytearray([0x40]) + buf # Co=0, D/C#=1

--- a/ports/nrf/examples/ubluepy_eddystone.py
+++ b/ports/nrf/examples/ubluepy_eddystone.py
@@ -1,19 +1,22 @@
 from ubluepy import Peripheral, constants
 
-BLE_GAP_ADV_FLAG_LE_GENERAL_DISC_MODE       = const(0x02)
-BLE_GAP_ADV_FLAG_BR_EDR_NOT_SUPPORTED       = const(0x04)
+BLE_GAP_ADV_FLAG_LE_GENERAL_DISC_MODE = const(0x02)
+BLE_GAP_ADV_FLAG_BR_EDR_NOT_SUPPORTED = const(0x04)
 
-BLE_GAP_ADV_FLAGS_LE_ONLY_GENERAL_DISC_MODE = const(BLE_GAP_ADV_FLAG_LE_GENERAL_DISC_MODE | BLE_GAP_ADV_FLAG_BR_EDR_NOT_SUPPORTED)
+BLE_GAP_ADV_FLAGS_LE_ONLY_GENERAL_DISC_MODE = const(BLE_GAP_ADV_FLAG_LE_GENERAL_DISC_MODE
+                                                    | BLE_GAP_ADV_FLAG_BR_EDR_NOT_SUPPORTED)
 
-EDDYSTONE_FRAME_TYPE_URL                    = const(0x10)
-EDDYSTONE_URL_PREFIX_HTTP_WWW               = const(0x00) # "http://www".
-EDDYSTONE_URL_SUFFIX_DOT_COM                = const(0x01) # ".com"
+EDDYSTONE_FRAME_TYPE_URL = const(0x10)
+EDDYSTONE_URL_PREFIX_HTTP_WWW = const(0x00) # "http://www".
+EDDYSTONE_URL_SUFFIX_DOT_COM = const(0x01) # ".com"
+
 
 def string_to_binarray(text):
     b = bytearray([])
     for c in text:
         b.append(ord(c))
     return b
+
 
 def gen_ad_type_content(ad_type, data):
     b = bytearray(1)
@@ -22,6 +25,7 @@ def gen_ad_type_content(ad_type, data):
     b[0] = len(b) - 1
     return b
 
+
 def generate_eddystone_adv_packet(url):
     # flags
     disc_mode = bytearray([BLE_GAP_ADV_FLAGS_LE_ONLY_GENERAL_DISC_MODE])
@@ -29,7 +33,8 @@ def generate_eddystone_adv_packet(url):
 
     # 16-bit uuid
     uuid = bytearray([0xAA, 0xFE])
-    packet_uuid16 = gen_ad_type_content(constants.ad_types.AD_TYPE_16BIT_SERVICE_UUID_COMPLETE, uuid)
+    packet_uuid16 = gen_ad_type_content(constants.ad_types.AD_TYPE_16BIT_SERVICE_UUID_COMPLETE,
+                                        uuid)
 
     # eddystone data
     rssi = 0xEE # -18 dB, approx signal strength at 0m.
@@ -52,7 +57,8 @@ def generate_eddystone_adv_packet(url):
 
     return packet
 
+
 def start():
-    adv_packet = generate_eddystone_adv_packet("micropython")  
+    adv_packet = generate_eddystone_adv_packet("micropython")
     p = Peripheral()
     p.advertise(data=adv_packet, connectable=False)

--- a/ports/nrf/examples/ubluepy_scan.py
+++ b/ports/nrf/examples/ubluepy_scan.py
@@ -1,10 +1,12 @@
 from ubluepy import Scanner, constants
 
+
 def bytes_to_str(bytes):
     string = ""
     for b in bytes:
         string += chr(b)
     return string
+
 
 def get_device_names(scan_entries):
     dev_names = []
@@ -12,27 +14,29 @@ def get_device_names(scan_entries):
         scan = e.getScanData()
         if scan:
             for s in scan:
-               if s[0] == constants.ad_types.AD_TYPE_COMPLETE_LOCAL_NAME:
-                   dev_names.append((e, bytes_to_str(s[2])))
+                if s[0] == constants.ad_types.AD_TYPE_COMPLETE_LOCAL_NAME:
+                    dev_names.append((e, bytes_to_str(s[2])))
     return dev_names
+
 
 def find_device_by_name(name):
     s = Scanner()
     scan_res = s.scan(100)
-    
+
     device_names = get_device_names(scan_res)
     for dev in device_names:
         if name == dev[1]:
             return dev[0]
+
 
 # >>> res = find_device_by_name("micr")
 # >>> if res:
 # ...     print("address:", res.addr())
 # ...     print("address type:", res.addr_type())
 # ...     print("rssi:", res.rssi())
-# ...     
-# ...     
-# ... 
+# ...
+# ...
+# ...
 # address: c2:73:61:89:24:45
 # address type: 1
 # rssi: -26

--- a/ports/nrf/examples/ubluepy_temp.py
+++ b/ports/nrf/examples/ubluepy_temp.py
@@ -26,12 +26,13 @@ from board import LED
 from machine import RTCounter, Temp
 from ubluepy import Service, Characteristic, UUID, Peripheral, constants
 
+
 def event_handler(id, handle, data):
     global rtc
     global periph
     global serv_env_sense
     global notif_enabled
- 
+
     if id == constants.EVT_GAP_CONNECTED:
         # indicated 'connected'
         LED(1).on()
@@ -50,10 +51,11 @@ def event_handler(id, handle, data):
             notif_enabled = True
             # start low power timer
             rtc.start()
-        else: 
+        else:
             notif_enabled = False
             # stop low power timer
             rtc.stop()
+
 
 def send_temp(timer_id):
     global notif_enabled
@@ -62,13 +64,14 @@ def send_temp(timer_id):
     if notif_enabled:
         # measure chip temperature
         temp = Temp.read()
-        temp =  temp * 100
+        temp = temp * 100
         char_temp.write(bytearray([temp & 0xFF, temp >> 8]))
+
 
 # start off with LED(1) off
 LED(1).off()
 
-# use RTC1 as RTC0 is used by bluetooth stack 
+# use RTC1 as RTC0 is used by bluetooth stack
 # set up RTC callback every 5 second
 rtc = RTCounter(1, period=50, mode=RTCounter.PERIODIC, callback=send_temp)
 
@@ -76,12 +79,12 @@ notif_enabled = False
 
 uuid_env_sense = UUID("0x181A") # Environmental Sensing service
 uuid_temp = UUID("0x2A6E") # Temperature characteristic
- 
+
 serv_env_sense = Service(uuid_env_sense)
 
 temp_props = Characteristic.PROP_NOTIFY | Characteristic.PROP_READ
 temp_attrs = Characteristic.ATTR_CCCD
-char_temp = Characteristic(uuid_temp, props = temp_props, attrs = temp_attrs)
+char_temp = Characteristic(uuid_temp, props=temp_props, attrs=temp_attrs)
 
 serv_env_sense.addCharacteristic(char_temp)
 
@@ -89,4 +92,3 @@ periph = Peripheral()
 periph.addService(serv_env_sense)
 periph.setConnectionHandler(event_handler)
 periph.advertise(device_name="micr_temp", services=[serv_env_sense])
-

--- a/ports/nrf/freeze/test.py
+++ b/ports/nrf/freeze/test.py
@@ -1,4 +1,5 @@
 import sys
 
+
 def hello():
     print("Hello %s!" % sys.platform)

--- a/ports/qemu-arm/test-frzmpy/native_frozen_align.py
+++ b/ports/qemu-arm/test-frzmpy/native_frozen_align.py
@@ -1,12 +1,15 @@
 import micropython
 
+
 @micropython.native
 def native_x(x):
     print(x + 1)
 
+
 @micropython.native
 def native_y(x):
     print(x + 1)
+
 
 @micropython.native
 def native_z(x):

--- a/ports/stm32/boards/STM32F4DISC/staccel.py
+++ b/ports/stm32/boards/STM32F4DISC/staccel.py
@@ -18,7 +18,7 @@ from micropython import const
 from pyb import Pin
 from pyb import SPI
 
-READWRITE_CMD = const(0x80) 
+READWRITE_CMD = const(0x80)
 MULTIPLEBYTE_CMD = const(0x40)
 WHO_AM_I_ADDR = const(0x0f)
 OUT_X_ADDR = const(0x29)
@@ -37,6 +37,7 @@ LIS3DSH_CTRL_REG5_ADDR = const(0x24)
 # Configuration for 100Hz sampling rate, +-2g range
 LIS3DSH_CTRL_REG4_CONF = const(0b01100111)
 LIS3DSH_CTRL_REG5_CONF = const(0b00000000)
+
 
 class STAccel:
     def __init__(self):

--- a/ports/stm32/boards/make-pins.py
+++ b/ports/stm32/boards/make-pins.py
@@ -9,26 +9,26 @@ import csv
 
 # Must have matching entries in AF_FN_* enum in ../pin_defs_stm32.h
 SUPPORTED_FN = {
-    'TIM'   : ['CH1',  'CH2',  'CH3',  'CH4',
-               'CH1N', 'CH2N', 'CH3N', 'CH1_ETR', 'ETR', 'BKIN'],
-    'I2C'   : ['SDA', 'SCL'],
-    'I2S'   : ['CK', 'MCK', 'SD', 'WS', 'EXTSD'],
-    'USART' : ['RX', 'TX', 'CTS', 'RTS', 'CK'],
-    'UART'  : ['RX', 'TX', 'CTS', 'RTS'],
-    'SPI'   : ['NSS', 'SCK', 'MISO', 'MOSI'],
-    'SDMMC' : ['CK', 'CMD', 'D0', 'D1', 'D2', 'D3'],
-    'CAN'   : ['TX', 'RX'],
+    'TIM': ['CH1', 'CH2', 'CH3', 'CH4', 'CH1N', 'CH2N', 'CH3N', 'CH1_ETR', 'ETR', 'BKIN'],
+    'I2C': ['SDA', 'SCL'],
+    'I2S': ['CK', 'MCK', 'SD', 'WS', 'EXTSD'],
+    'USART': ['RX', 'TX', 'CTS', 'RTS', 'CK'],
+    'UART': ['RX', 'TX', 'CTS', 'RTS'],
+    'SPI': ['NSS', 'SCK', 'MISO', 'MOSI'],
+    'SDMMC': ['CK', 'CMD', 'D0', 'D1', 'D2', 'D3'],
+    'CAN': ['TX', 'RX'],
 }
 
 CONDITIONAL_VAR = {
-    'I2C'   : 'MICROPY_HW_I2C{num}_SCL',
-    'I2S'   : 'MICROPY_HW_ENABLE_I2S{num}',
-    'SPI'   : 'MICROPY_HW_SPI{num}_SCK',
-    'UART'  : 'MICROPY_HW_UART{num}_TX',
-    'USART' : 'MICROPY_HW_UART{num}_TX',
-    'SDMMC' : 'MICROPY_HW_SDMMC{num}_CK',
-    'CAN'   : 'MICROPY_HW_CAN{num}_TX',
+    'I2C': 'MICROPY_HW_I2C{num}_SCL',
+    'I2S': 'MICROPY_HW_ENABLE_I2S{num}',
+    'SPI': 'MICROPY_HW_SPI{num}_SCK',
+    'UART': 'MICROPY_HW_UART{num}_TX',
+    'USART': 'MICROPY_HW_UART{num}_TX',
+    'SDMMC': 'MICROPY_HW_SDMMC{num}_CK',
+    'CAN': 'MICROPY_HW_CAN{num}_TX',
 }
+
 
 def parse_port_pin(name_str):
     """Parses a string and returns a (port-num, pin-num) tuple."""
@@ -44,6 +44,7 @@ def parse_port_pin(name_str):
         raise ValueError("Expecting numeric pin number.")
     return (port, int(pin_str))
 
+
 def split_name_num(name_num):
     num = None
     for num_idx in range(len(name_num) - 1, -1, -1):
@@ -54,6 +55,7 @@ def split_name_num(name_num):
                 num = int(num_str)
             break
     return name, num
+
 
 def conditional_var(name_num):
     # Try the specific instance first. For example, if name_num is UART4_RX
@@ -66,6 +68,7 @@ def conditional_var(name_num):
         var.append(CONDITIONAL_VAR[name_num])
     return var
 
+
 def print_conditional_if(cond_var, file=None):
     if cond_var:
         cond_str = []
@@ -76,6 +79,7 @@ def print_conditional_if(cond_var, file=None):
                 cond_str.append('defined({0})'.format(var))
         print('#if ' + ' || '.join(cond_str), file=file)
 
+
 def print_conditional_endif(cond_var, file=None):
     if cond_var:
         print('#endif', file=file)
@@ -83,7 +87,6 @@ def print_conditional_endif(cond_var, file=None):
 
 class AlternateFunction(object):
     """Holds the information associated with a pins alternate function."""
-
     def __init__(self, idx, af_str):
         self.idx = idx
         # Special case. We change I2S2ext_SD into I2S2_EXTSD so that it parses
@@ -124,14 +127,15 @@ class AlternateFunction(object):
         if self.supported:
             cond_var = conditional_var('{}{}'.format(self.func, self.fn_num))
             print_conditional_if(cond_var)
-            print('  AF',  end='')
+            print('  AF', end='')
         else:
             print('  //', end='')
         fn_num = self.fn_num
         if fn_num is None:
             fn_num = 0
-        print('({:2d}, {:8s}, {:2d}, {:10s}, {:8s}), // {:s}'.format(self.idx,
-              self.func, fn_num, self.pin_type, self.ptr(), self.af_str))
+        print('({:2d}, {:8s}, {:2d}, {:10s}, {:8s}), // {:s}'.format(self.idx, self.func,
+                                                                     fn_num, self.pin_type,
+                                                                     self.ptr(), self.af_str))
         print_conditional_endif(cond_var)
 
     def qstr_list(self):
@@ -140,7 +144,6 @@ class AlternateFunction(object):
 
 class Pin(object):
     """Holds the information associated with a pin."""
-
     def __init__(self, port, pin):
         self.port = port
         self.pin = pin
@@ -207,7 +210,7 @@ class Pin(object):
 
     def adc_num_str(self):
         str = ''
-        for adc_num in range(1,4):
+        for adc_num in range(1, 4):
             if self.adc_num & (1 << (adc_num - 1)):
                 if len(str) > 0:
                     str += ' | '
@@ -219,17 +222,16 @@ class Pin(object):
 
     def print(self):
         if self.alt_fn_count == 0:
-            print("// ",  end='')
+            print("// ", end='')
         print('const pin_af_obj_t {:s}[] = {{'.format(self.alt_fn_name()))
         for alt_fn in self.alt_fn:
             alt_fn.print()
         if self.alt_fn_count == 0:
-            print("// ",  end='')
+            print("// ", end='')
         print('};')
         print('')
         print('const pin_obj_t pin_{:s}_obj = PIN({:s}, {:d}, {:s}, {:s}, {:d});'.format(
-            self.cpu_pin_name(), self.port_letter(), self.pin,
-            self.alt_fn_name(null_if_0=True),
+            self.cpu_pin_name(), self.port_letter(), self.pin, self.alt_fn_name(null_if_0=True),
             self.adc_num_str(), self.adc_channel))
         print('')
 
@@ -249,7 +251,6 @@ class Pin(object):
 
 
 class NamedPin(object):
-
     def __init__(self, name, pin):
         if name.startswith('-'):
             self._is_hidden = True
@@ -270,9 +271,8 @@ class NamedPin(object):
 
 
 class Pins(object):
-
     def __init__(self):
-        self.cpu_pins = []   # list of NamedPin objects
+        self.cpu_pins = [] # list of NamedPin objects
         self.board_pins = [] # list of NamedPin objects
 
     def find_pin(self, port_num, pin_num):
@@ -316,9 +316,11 @@ class Pins(object):
         for named_pin in named_pins:
             pin = named_pin.pin()
             if pin.is_board_pin() and not named_pin.is_hidden():
-                print('  {{ MP_ROM_QSTR(MP_QSTR_{:s}), MP_ROM_PTR(&pin_{:s}_obj) }},'.format(named_pin.name(),  pin.cpu_pin_name()))
+                print('  {{ MP_ROM_QSTR(MP_QSTR_{:s}), MP_ROM_PTR(&pin_{:s}_obj) }},'.format(
+                    named_pin.name(), pin.cpu_pin_name()))
         print('};')
-        print('MP_DEFINE_CONST_DICT(pin_{:s}_pins_locals_dict, pin_{:s}_pins_locals_dict_table);'.format(label, label))
+        print('MP_DEFINE_CONST_DICT(pin_{:s}_pins_locals_dict, pin_{:s}_pins_locals_dict_table);'.
+              format(label, label))
 
     def print(self):
         for named_pin in self.cpu_pins:
@@ -338,8 +340,8 @@ class Pins(object):
             adc_found = False
             for named_pin in self.cpu_pins:
                 pin = named_pin.pin()
-                if (pin.is_board_pin() and
-                    (pin.adc_num & (1 << (adc_num - 1))) and (pin.adc_channel == channel)):
+                if (pin.is_board_pin() and (pin.adc_num & (1 << (adc_num - 1)))
+                        and (pin.adc_channel == channel)):
                     print('  &pin_{:s}_obj, // {:d}'.format(pin.cpu_pin_name(), channel))
                     adc_found = True
                     break
@@ -348,7 +350,6 @@ class Pins(object):
             if channel == 16:
                 print('#endif')
         print('};')
-
 
     def print_header(self, hdr_filename, obj_decls):
         with open(hdr_filename, 'wt') as hdr_file:
@@ -362,7 +363,9 @@ class Pins(object):
                 hdr_file.write('extern const pin_obj_t * const pin_adc3[];\n')
             # provide #define's mapping board to cpu name
             for named_pin in self.board_pins:
-                hdr_file.write("#define pyb_pin_{:s} pin_{:s}\n".format(named_pin.name(), named_pin.pin().cpu_pin_name()))
+                hdr_file.write("#define pyb_pin_{:s} pin_{:s}\n".format(
+                    named_pin.name(),
+                    named_pin.pin().cpu_pin_name()))
 
     def print_qstr(self, qstr_filename):
         with open(qstr_filename, 'wt') as qstr_file:
@@ -385,7 +388,7 @@ class Pins(object):
                 print_conditional_endif(cond_var, file=qstr_file)
 
     def print_af_hdr(self, af_const_filename):
-        with open(af_const_filename,  'wt') as af_const_file:
+        with open(af_const_filename, 'wt') as af_const_file:
             af_hdr_set = set([])
             mux_name_width = 0
             for named_pin in self.cpu_pins:
@@ -398,17 +401,16 @@ class Pins(object):
                             if len(mux_name) > mux_name_width:
                                 mux_name_width = len(mux_name)
             for mux_name in sorted(af_hdr_set):
-                af_words = mux_name.split('_')  # ex mux_name: AF9_I2C2
+                af_words = mux_name.split('_') # ex mux_name: AF9_I2C2
                 cond_var = conditional_var(af_words[1])
                 print_conditional_if(cond_var, file=af_const_file)
                 key = 'MP_ROM_QSTR(MP_QSTR_{}),'.format(mux_name)
                 val = 'MP_ROM_INT(GPIO_{})'.format(mux_name)
-                print('    { %-*s %s },' % (mux_name_width + 26, key, val),
-                      file=af_const_file)
+                print('    { %-*s %s },' % (mux_name_width + 26, key, val), file=af_const_file)
                 print_conditional_endif(cond_var, file=af_const_file)
 
     def print_af_defs(self, af_defs_filename, cmp_strings):
-        with open(af_defs_filename,  'wt') as af_defs_file:
+        with open(af_defs_filename, 'wt') as af_defs_file:
 
             STATIC_AF_TOKENS = {}
             for named_pin in self.board_pins:
@@ -426,8 +428,7 @@ class Pins(object):
                             )
                     else:
                         cmp_str = '    ((pin_obj) == (pin_%s)) ? (%d) : \\' % (
-                                named_pin.pin().cpu_pin_name(), af.idx
-                            )
+                            named_pin.pin().cpu_pin_name(), af.idx)
                     STATIC_AF_TOKENS[tok].append(cmp_str)
 
             for tok, pins in STATIC_AF_TOKENS.items():
@@ -436,7 +437,7 @@ class Pins(object):
                 print("    (0xffffffffffffffffULL))\n", file=af_defs_file)
 
     def print_af_py(self, af_py_filename):
-        with open(af_py_filename,  'wt') as af_py_file:
+        with open(af_py_filename, 'wt') as af_py_file:
             print('PINS_AF = (', file=af_py_file)
             for named_pin in self.board_pins:
                 if named_pin.is_hidden():
@@ -446,74 +447,62 @@ class Pins(object):
                     if af.is_supported():
                         print("(%d, '%s'), " % (af.idx, af.af_str), end='', file=af_py_file)
                 print('),', file=af_py_file)
-            print(')',  file=af_py_file)
+            print(')', file=af_py_file)
 
 
 def main():
-    parser = argparse.ArgumentParser(
-        prog="make-pins.py",
-        usage="%(prog)s [options] [command]",
-        description="Generate board specific pin file"
-    )
-    parser.add_argument(
-        "-a", "--af",
-        dest="af_filename",
-        help="Specifies the alternate function file for the chip",
-        default="stm32f4xx_af.csv"
-    )
-    parser.add_argument(
-        "--af-const",
-        dest="af_const_filename",
-        help="Specifies header file for alternate function constants.",
-        default="build/pins_af_const.h"
-    )
-    parser.add_argument(
-        "--af-py",
-        dest="af_py_filename",
-        help="Specifies the filename for the python alternate function mappings.",
-        default="build/pins_af.py"
-    )
-    parser.add_argument(
-        "--af-defs",
-        dest="af_defs_filename",
-        help="Specifies the filename for the alternate function defines.",
-        default="build/pins_af_defs.h"
-    )
+    parser = argparse.ArgumentParser(prog="make-pins.py",
+                                     usage="%(prog)s [options] [command]",
+                                     description="Generate board specific pin file")
+    parser.add_argument("-a",
+                        "--af",
+                        dest="af_filename",
+                        help="Specifies the alternate function file for the chip",
+                        default="stm32f4xx_af.csv")
+    parser.add_argument("--af-const",
+                        dest="af_const_filename",
+                        help="Specifies header file for alternate function constants.",
+                        default="build/pins_af_const.h")
+    parser.add_argument("--af-py",
+                        dest="af_py_filename",
+                        help="Specifies the filename for the python alternate function mappings.",
+                        default="build/pins_af.py")
+    parser.add_argument("--af-defs",
+                        dest="af_defs_filename",
+                        help="Specifies the filename for the alternate function defines.",
+                        default="build/pins_af_defs.h")
     parser.add_argument(
         "--af-defs-cmp-strings",
         dest="af_defs_cmp_strings",
-        help="Whether to compare pin name strings for the alternate function defines instead of object values",
+        help=
+        "Whether to compare pin name strings for the alternate function defines instead of object values",
         action="store_true",
     )
     parser.add_argument(
-        "-b", "--board",
+        "-b",
+        "--board",
         dest="board_filename",
         help="Specifies the board file",
     )
-    parser.add_argument(
-        "-p", "--prefix",
-        dest="prefix_filename",
-        help="Specifies beginning portion of generated pins file",
-        default="stm32f4xx_prefix.c"
-    )
-    parser.add_argument(
-        "-q", "--qstr",
-        dest="qstr_filename",
-        help="Specifies name of generated qstr header file",
-        default="build/pins_qstr.h"
-    )
-    parser.add_argument(
-        "-r", "--hdr",
-        dest="hdr_filename",
-        help="Specifies name of generated pin header file",
-        default="build/pins.h"
-    )
-    parser.add_argument(
-        "--hdr-obj-decls",
-        dest="hdr_obj_decls",
-        help="Whether to include declarations for pin objects in pin header file",
-        action="store_true"
-    )
+    parser.add_argument("-p",
+                        "--prefix",
+                        dest="prefix_filename",
+                        help="Specifies beginning portion of generated pins file",
+                        default="stm32f4xx_prefix.c")
+    parser.add_argument("-q",
+                        "--qstr",
+                        dest="qstr_filename",
+                        help="Specifies name of generated qstr header file",
+                        default="build/pins_qstr.h")
+    parser.add_argument("-r",
+                        "--hdr",
+                        dest="hdr_filename",
+                        help="Specifies name of generated pin header file",
+                        default="build/pins.h")
+    parser.add_argument("--hdr-obj-decls",
+                        dest="hdr_obj_decls",
+                        help="Whether to include declarations for pin objects in pin header file",
+                        action="store_true")
     args = parser.parse_args(sys.argv[1:])
 
     pins = Pins()

--- a/ports/stm32/make-stmconst.py
+++ b/ports/stm32/make-stmconst.py
@@ -12,16 +12,21 @@ import re
 # Python 2/3 compatibility
 import platform
 if platform.python_version_tuple()[0] == '2':
+
     def convert_bytes_to_str(b):
         return b
 elif platform.python_version_tuple()[0] == '3':
+
     def convert_bytes_to_str(b):
         try:
             return str(b, 'utf8')
         except ValueError:
             # some files have invalid utf8 bytes, so filter them out
             return ''.join(chr(l) for l in b if l <= 126)
+
+
 # end compatibility code
+
 
 # given a list of (name,regex) pairs, find the first one that matches the given line
 def re_match_first(regexs, line):
@@ -31,25 +36,40 @@ def re_match_first(regexs, line):
             return name, match
     return None, None
 
+
 class LexerError(Exception):
     def __init__(self, line):
         self.line = line
+
 
 class Lexer:
     re_io_reg = r'__IO uint(?P<bits>8|16|32)_t +(?P<reg>[A-Z0-9]+)'
     re_comment = r'(?P<comment>[A-Za-z0-9 \-/_()&]+)'
     re_addr_offset = r'Address offset: (?P<offset>0x[0-9A-Z]{2,3})'
     regexs = (
-        ('#define hex', re.compile(r'#define +(?P<id>[A-Z0-9_]+) +\(?(\(uint32_t\))?(?P<hex>0x[0-9A-F]+)U?L?\)?($| */\*)')),
+        ('#define hex',
+         re.compile(
+             r'#define +(?P<id>[A-Z0-9_]+) +\(?(\(uint32_t\))?(?P<hex>0x[0-9A-F]+)U?L?\)?($| */\*)')
+         ),
         ('#define X', re.compile(r'#define +(?P<id>[A-Z0-9_]+) +(?P<id2>[A-Z0-9_]+)($| +/\*)')),
-        ('#define X+hex', re.compile(r'#define +(?P<id>[A-Za-z0-9_]+) +\(?(?P<id2>[A-Z0-9_]+) \+ (?P<hex>0x[0-9A-F]+)U?L?\)?($| +/\*)')),
-        ('#define typedef', re.compile(r'#define +(?P<id>[A-Z0-9_]+(ext)?) +\(\([A-Za-z0-9_]+_TypeDef \*\) (?P<id2>[A-Za-z0-9_]+)\)($| +/\*)')),
+        ('#define X+hex',
+         re.compile(
+             r'#define +(?P<id>[A-Za-z0-9_]+) +\(?(?P<id2>[A-Z0-9_]+) \+ (?P<hex>0x[0-9A-F]+)U?L?\)?($| +/\*)'
+         )),
+        ('#define typedef',
+         re.compile(
+             r'#define +(?P<id>[A-Z0-9_]+(ext)?) +\(\([A-Za-z0-9_]+_TypeDef \*\) (?P<id2>[A-Za-z0-9_]+)\)($| +/\*)'
+         )),
         ('typedef struct', re.compile(r'typedef struct$')),
         ('{', re.compile(r'{$')),
         ('}', re.compile(r'}$')),
-        ('} TypeDef', re.compile(r'} *(?P<id>[A-Z][A-Za-z0-9_]+)_(?P<global>([A-Za-z0-9_]+)?)TypeDef;$')),
-        ('IO reg', re.compile(re_io_reg + r'; */\*!< *' + re_comment + r', +' + re_addr_offset + r' *\*/')),
-        ('IO reg array', re.compile(re_io_reg + r'\[(?P<array>[2-8])\]; */\*!< *' + re_comment + r', +' + re_addr_offset + r'-(0x[0-9A-Z]{2,3}) *\*/')),
+        ('} TypeDef',
+         re.compile(r'} *(?P<id>[A-Z][A-Za-z0-9_]+)_(?P<global>([A-Za-z0-9_]+)?)TypeDef;$')),
+        ('IO reg',
+         re.compile(re_io_reg + r'; */\*!< *' + re_comment + r', +' + re_addr_offset + r' *\*/')),
+        ('IO reg array',
+         re.compile(re_io_reg + r'\[(?P<array>[2-8])\]; */\*!< *' + re_comment + r', +' +
+                    re_addr_offset + r'-(0x[0-9A-Z]{2,3}) *\*/')),
     )
 
     def __init__(self, filename):
@@ -72,6 +92,7 @@ class Lexer:
         if match[0] != kind:
             raise LexerError(self.line_number)
         return match
+
 
 def parse_file(filename):
     lexer = Lexer(filename)
@@ -123,6 +144,7 @@ def parse_file(filename):
 
     return periphs, reg_defs
 
+
 def print_int_obj(val, needed_mpzs):
     if -0x40000000 <= val < 0x40000000:
         print('MP_ROM_INT(%#x)' % val, end='')
@@ -130,12 +152,14 @@ def print_int_obj(val, needed_mpzs):
         print('MP_ROM_PTR(&mpz_%08x)' % val, end='')
         needed_mpzs.add(val)
 
+
 def print_periph(periph_name, periph_val, needed_qstrs, needed_mpzs):
     qstr = periph_name.upper()
     print('{ MP_ROM_QSTR(MP_QSTR_%s), ' % qstr, end='')
     print_int_obj(periph_val, needed_mpzs)
     print(' },')
     needed_qstrs.add(qstr)
+
 
 def print_regs(reg_name, reg_defs, needed_qstrs, needed_mpzs):
     reg_name = reg_name.upper()
@@ -145,6 +169,7 @@ def print_regs(reg_name, reg_defs, needed_qstrs, needed_mpzs):
         print_int_obj(r[1], needed_mpzs)
         print(' }, // %s-bits, %s' % (r[2], r[3]))
         needed_qstrs.add(qstr)
+
 
 # This version of print regs groups registers together into submodules (eg GPIO submodule).
 # This makes the qstrs shorter, and makes the list of constants more manageable (since
@@ -165,7 +190,8 @@ STATIC const mp_rom_map_elem_t stm_%s_globals_table[] = {
     needed_qstrs.add(mod_name_upper)
 
     for r in reg_defs:
-        print('    { MP_ROM_QSTR(MP_QSTR_%s), MP_ROM_INT(%#x) }, // %s-bits, %s' % (r[0], r[1], r[2], r[3]))
+        print('    { MP_ROM_QSTR(MP_QSTR_%s), MP_ROM_INT(%#x) }, // %s-bits, %s' %
+              (r[0], r[1], r[2], r[3]))
         needed_qstrs.add(r[0])
 
     print("""};
@@ -179,12 +205,18 @@ const mp_obj_module_t stm_%s_obj = {
 };
 """ % (mod_name_lower, mod_name_lower, mod_name_lower, mod_name_upper, mod_name_lower))
 
+
 def main():
     cmd_parser = argparse.ArgumentParser(description='Extract ST constants from a C header file.')
     cmd_parser.add_argument('file', nargs=1, help='input file')
-    cmd_parser.add_argument('-q', '--qstr', dest='qstr_filename', default='build/stmconst_qstr.h',
+    cmd_parser.add_argument('-q',
+                            '--qstr',
+                            dest='qstr_filename',
+                            default='build/stmconst_qstr.h',
                             help='Specified the name of the generated qstr header file')
-    cmd_parser.add_argument('--mpz', dest='mpz_filename', default='build/stmconst_mpz.h',
+    cmd_parser.add_argument('--mpz',
+                            dest='mpz_filename',
+                            default='build/stmconst_mpz.h',
                             help='the destination file of the generated mpz header')
     args = cmd_parser.parse_args()
 
@@ -206,33 +238,33 @@ def main():
         print_periph(periph_name, periph_val, needed_qstrs, needed_mpzs)
 
     for reg in (
-        'ADC',
-        #'ADC_Common',
-        #'CAN_TxMailBox',
-        #'CAN_FIFOMailBox',
-        #'CAN_FilterRegister',
-        #'CAN',
-        'CRC',
-        'DAC',
-        'DBGMCU',
-        'DMA_Stream',
-        'DMA',
-        'EXTI',
-        'FLASH',
-        'GPIO',
-        'SYSCFG',
-        'I2C',
-        'IWDG',
-        'PWR',
-        'RCC',
-        'RTC',
-        #'SDIO',
-        'SPI',
-        'TIM',
-        'USART',
-        'WWDG',
-        'RNG',
-        ):
+            'ADC',
+            #'ADC_Common',
+            #'CAN_TxMailBox',
+            #'CAN_FIFOMailBox',
+            #'CAN_FilterRegister',
+            #'CAN',
+            'CRC',
+            'DAC',
+            'DBGMCU',
+            'DMA_Stream',
+            'DMA',
+            'EXTI',
+            'FLASH',
+            'GPIO',
+            'SYSCFG',
+            'I2C',
+            'IWDG',
+            'PWR',
+            'RCC',
+            'RTC',
+            #'SDIO',
+            'SPI',
+            'TIM',
+            'USART',
+            'WWDG',
+            'RNG',
+    ):
         if reg in reg_defs:
             print_regs(reg, reg_defs[reg], needed_qstrs, needed_mpzs)
         #print_regs_as_submodules(reg, reg_defs[reg], modules, needed_qstrs)
@@ -253,8 +285,11 @@ def main():
         for mpz in sorted(needed_mpzs):
             assert 0 <= mpz <= 0xffffffff
             print('STATIC const mp_obj_int_t mpz_%08x = {{&mp_type_int}, '
-                '{.neg=0, .fixed_dig=1, .alloc=2, .len=2, ' '.dig=(uint16_t*)(const uint16_t[]){%#x, %#x}}};'
-                % (mpz, mpz & 0xffff, (mpz >> 16) & 0xffff), file=mpz_file)
+                  '{.neg=0, .fixed_dig=1, .alloc=2, .len=2, '
+                  '.dig=(uint16_t*)(const uint16_t[]){%#x, %#x}}};' % (mpz, mpz & 0xffff,
+                                                                       (mpz >> 16) & 0xffff),
+                  file=mpz_file)
+
 
 if __name__ == "__main__":
     main()

--- a/ports/stm32/mboot/fwupdate.py
+++ b/ports/stm32/mboot/fwupdate.py
@@ -4,7 +4,6 @@
 import struct, time
 import uzlib, machine, stm
 
-
 FLASH_KEY1 = 0x45670123
 FLASH_KEY2 = 0xcdef89ab
 
@@ -17,6 +16,7 @@ def check_mem_contains(addr, buf):
             return False
     return True
 
+
 def check_mem_erased(addr, size):
     mem16 = stm.mem16
     r = range(0, size, 2)
@@ -24,6 +24,7 @@ def check_mem_erased(addr, size):
         if mem16[addr + off] != 0xffff:
             return False
     return True
+
 
 def dfu_read(filename):
     f = open(filename, 'rb')
@@ -71,16 +72,20 @@ def dfu_read(filename):
 
     return elems
 
+
 def flash_wait_not_busy():
     while stm.mem32[stm.FLASH + stm.FLASH_SR] & 1 << 16:
         machine.idle()
+
 
 def flash_unlock():
     stm.mem32[stm.FLASH + stm.FLASH_KEYR] = FLASH_KEY1
     stm.mem32[stm.FLASH + stm.FLASH_KEYR] = FLASH_KEY2
 
+
 def flash_lock():
     stm.mem32[stm.FLASH + stm.FLASH_CR] = 1 << 31 # LOCK
+
 
 def flash_erase_sector(sector):
     assert 0 <= sector <= 7 # for F722
@@ -95,6 +100,7 @@ def flash_erase_sector(sector):
     flash_wait_not_busy()
     stm.mem32[stm.FLASH + stm.FLASH_CR] = 0
 
+
 def flash_write(addr, buf):
     assert len(buf) % 4 == 0
     flash_wait_not_busy()
@@ -107,6 +113,7 @@ def flash_write(addr, buf):
         stm.mem32[addr + off] = struct.unpack_from('I', buf, off)[0]
         flash_wait_not_busy()
     stm.mem32[stm.FLASH + stm.FLASH_CR] = 0
+
 
 def update_mboot(filename):
     print('Loading file', filename)
@@ -150,6 +157,7 @@ def update_mboot(filename):
 
     print('Programming finished, can now reset or turn off.')
 
+
 def update_mpy(filename, fs_base, fs_len):
     # Check firmware is of .dfu.gz type
     try:
@@ -166,7 +174,9 @@ def update_mpy(filename, fs_base, fs_len):
     ELEM_TYPE_FSLOAD = 3
     ELEM_MOUNT_FAT = 1
     mount_point = 1
-    mount = struct.pack('<BBBBLL', ELEM_TYPE_MOUNT, 10, mount_point, ELEM_MOUNT_FAT, fs_base, fs_len)
-    fsup = struct.pack('<BBB', ELEM_TYPE_FSLOAD, 1 + len(filename), mount_point) + bytes(filename, 'ascii')
+    mount = struct.pack('<BBBBLL', ELEM_TYPE_MOUNT, 10, mount_point, ELEM_MOUNT_FAT, fs_base,
+                        fs_len)
+    fsup = struct.pack('<BBB', ELEM_TYPE_FSLOAD, 1 + len(filename), mount_point) + bytes(
+        filename, 'ascii')
     end = struct.pack('<BB', ELEM_TYPE_END, 0)
     machine.bootloader(mount + fsup + end)

--- a/ports/stm32/mboot/mboot.py
+++ b/ports/stm32/mboot/mboot.py
@@ -3,7 +3,6 @@
 
 import struct, time, os, hashlib
 
-
 I2C_CMD_ECHO = 1
 I2C_CMD_GETID = 2
 I2C_CMD_GETCAPS = 3
@@ -137,7 +136,9 @@ class Bootloader:
                     if p[0] <= addr < p[0] + p[1]:
                         # found page
                         if not page_erased[i]:
-                            print('\r% 3u%% erase 0x%08x' % (100 * (addr - start_addr) // fsize, addr), end='')
+                            print('\r% 3u%% erase 0x%08x' % (100 *
+                                                             (addr - start_addr) // fsize, addr),
+                                  end='')
                             self.pageerase(addr)
                             page_erased[i] = True
                         break

--- a/ports/teensy/memzip_files/boot.py
+++ b/ports/teensy/memzip_files/boot.py
@@ -1,10 +1,12 @@
 import pyb
 print("Executing boot.py")
 
+
 def pins():
     for pin_name in dir(pyb.Pin.board):
         pin = pyb.Pin(pin_name)
         print('{:10s} {:s}'.format(pin_name, str(pin)))
+
 
 def af():
     for pin_name in dir(pyb.Pin.board):

--- a/ports/teensy/memzip_files/main.py
+++ b/ports/teensy/memzip_files/main.py
@@ -11,5 +11,3 @@ pyb.delay(100)
 led.on()
 pyb.delay(100)
 led.off()
-
-

--- a/ports/unix/coverage-frzmpy/frzmpy_pkg2/mod.py
+++ b/ports/unix/coverage-frzmpy/frzmpy_pkg2/mod.py
@@ -1,4 +1,6 @@
 # test frozen package without __init__.py
 print('frzmpy_pkg2.mod')
+
+
 class Foo:
     x = 1

--- a/ports/unix/coverage-frzstr/frzstr_pkg2/mod.py
+++ b/ports/unix/coverage-frzstr/frzstr_pkg2/mod.py
@@ -1,4 +1,6 @@
 # test frozen package without __init__.py
 print('frzstr_pkg2.mod')
+
+
 class Foo:
     x = 1

--- a/py/makemoduledefs.py
+++ b/py/makemoduledefs.py
@@ -12,11 +12,7 @@ import io
 import os
 import argparse
 
-
-pattern = re.compile(
-    r"[\n;]\s*MP_REGISTER_MODULE\((.*?),\s*(.*?),\s*(.*?)\);",
-    flags=re.DOTALL
-)
+pattern = re.compile(r"[\n;]\s*MP_REGISTER_MODULE\((.*?),\s*(.*?),\s*(.*?)\);", flags=re.DOTALL)
 
 
 def find_c_file(obj_file, vpath):
@@ -67,16 +63,16 @@ def generate_module_table_header(modules):
     for module_name, obj_module, enabled_define in modules:
         mod_def = "MODULE_DEF_{}".format(module_name.upper())
         mod_defs.append(mod_def)
-        print((
-            "#if ({enabled_define})\n"
-            "    extern const struct _mp_obj_module_t {obj_module};\n"
-            "    #define {mod_def} {{ MP_ROM_QSTR({module_name}), MP_ROM_PTR(&{obj_module}) }},\n"
-            "#else\n"
-            "    #define {mod_def}\n"
-            "#endif\n"
-            ).format(module_name=module_name, obj_module=obj_module,
-                     enabled_define=enabled_define, mod_def=mod_def)
-        )
+        print(
+            ("#if ({enabled_define})\n"
+             "    extern const struct _mp_obj_module_t {obj_module};\n"
+             "    #define {mod_def} {{ MP_ROM_QSTR({module_name}), MP_ROM_PTR(&{obj_module}) }},\n"
+             "#else\n"
+             "    #define {mod_def}\n"
+             "#endif\n").format(module_name=module_name,
+                                obj_module=obj_module,
+                                enabled_define=enabled_define,
+                                mod_def=mod_def))
 
     print("\n#define MICROPY_REGISTERED_MODULES \\")
 
@@ -88,10 +84,10 @@ def generate_module_table_header(modules):
 
 def main():
     parser = argparse.ArgumentParser()
-    parser.add_argument("--vpath", default=".",
+    parser.add_argument("--vpath",
+                        default=".",
                         help="comma separated list of folders to search for c files in")
-    parser.add_argument("files", nargs="*",
-                        help="list of c files to search")
+    parser.add_argument("files", nargs="*", help="list of c files to search")
     args = parser.parse_args()
 
     vpath = [p.strip() for p in args.vpath.split(',')]

--- a/py/makeqstrdata.py
+++ b/py/makeqstrdata.py
@@ -21,7 +21,7 @@ elif platform.python_version_tuple()[0] == '3':
     from html.entities import codepoint2name
 # end compatibility code
 
-codepoint2name[ord('-')] = 'hyphen';
+codepoint2name[ord('-')] = 'hyphen'
 
 # add some custom names to map characters that aren't in HTML
 codepoint2name[ord(' ')] = 'space'
@@ -221,6 +221,7 @@ static_qstr_list = [
     "zip",
 ]
 
+
 # this must match the equivalent function in qstr.c
 def compute_hash(qstr, bytes_hash):
     hash = 5381
@@ -228,6 +229,7 @@ def compute_hash(qstr, bytes_hash):
         hash = (hash * 33) ^ b
     # Make sure that valid hash is never zero, zero means "hash not computed"
     return (hash & ((1 << (8 * bytes_hash)) - 1)) or 1
+
 
 def qstr_escape(qst):
     def esc_char(m):
@@ -237,7 +239,9 @@ def qstr_escape(qst):
         except KeyError:
             name = '0x%02x' % c
         return "_" + name + '_'
+
     return re.sub(r'[^A-Za-z0-9_]', esc_char, qst)
+
 
 def parse_input_headers(infiles):
     qcfgs = {}
@@ -312,6 +316,7 @@ def parse_input_headers(infiles):
 
     return qcfgs, qstrs
 
+
 def make_bytes(cfg_bytes_len, cfg_bytes_hash, qstr):
     qbytes = bytes_cons(qstr, 'utf8')
     qlen = len(qbytes)
@@ -325,9 +330,12 @@ def make_bytes(cfg_bytes_len, cfg_bytes_hash, qstr):
     if qlen >= (1 << (8 * cfg_bytes_len)):
         print('qstr is too long:', qstr)
         assert False
-    qlen_str = ('\\x%02x' * cfg_bytes_len) % tuple(((qlen >> (8 * i)) & 0xff) for i in range(cfg_bytes_len))
-    qhash_str = ('\\x%02x' * cfg_bytes_hash) % tuple(((qhash >> (8 * i)) & 0xff) for i in range(cfg_bytes_hash))
+    qlen_str = ('\\x%02x' * cfg_bytes_len) % tuple(
+        ((qlen >> (8 * i)) & 0xff) for i in range(cfg_bytes_len))
+    qhash_str = ('\\x%02x' * cfg_bytes_hash) % tuple(
+        ((qhash >> (8 * i)) & 0xff) for i in range(cfg_bytes_hash))
     return '(const byte*)"%s%s" "%s"' % (qhash_str, qlen_str, qdata)
+
 
 def print_qstr_data(qcfgs, qstrs):
     # get config variables
@@ -339,16 +347,19 @@ def print_qstr_data(qcfgs, qstrs):
     print('')
 
     # add NULL qstr with no hash or data
-    print('QDEF(MP_QSTRnull, (const byte*)"%s%s" "")' % ('\\x00' * cfg_bytes_hash, '\\x00' * cfg_bytes_len))
+    print('QDEF(MP_QSTRnull, (const byte*)"%s%s" "")' %
+          ('\\x00' * cfg_bytes_hash, '\\x00' * cfg_bytes_len))
 
     # go through each qstr and print it out
     for order, ident, qstr in sorted(qstrs.values(), key=lambda x: x[0]):
         qbytes = make_bytes(cfg_bytes_len, cfg_bytes_hash, qstr)
         print('QDEF(MP_QSTR_%s, %s)' % (ident, qbytes))
 
+
 def do_work(infiles):
     qcfgs, qstrs = parse_input_headers(infiles)
     print_qstr_data(qcfgs, qstrs)
+
 
 if __name__ == "__main__":
     do_work(sys.argv[1:])

--- a/py/makeqstrdefs.py
+++ b/py/makeqstrdefs.py
@@ -20,6 +20,7 @@ def write_out(fname, output):
         with open(args.output_dir + "/" + fname + ".qstr", "w") as f:
             f.write("\n".join(output) + "\n")
 
+
 def process_file(f):
     re_line = re.compile(r"#[line]*\s\d+\s\"([^\"]+)\"")
     re_qstr = re.compile(r'MP_QSTR_[_a-zA-Z0-9]+')
@@ -92,6 +93,7 @@ if __name__ == "__main__":
 
     class Args:
         pass
+
     args = Args()
     args.command = sys.argv[1]
     args.input_filename = sys.argv[2]

--- a/py/makeversionhdr.py
+++ b/py/makeversionhdr.py
@@ -11,6 +11,7 @@ import os
 import datetime
 import subprocess
 
+
 def get_version_info_from_git():
     # Python 2.6 doesn't have check_output, so check for that
     try:
@@ -21,7 +22,9 @@ def get_version_info_from_git():
 
     # Note: git describe doesn't work if no tag is available
     try:
-        git_tag = subprocess.check_output(["git", "describe", "--dirty", "--always"], stderr=subprocess.STDOUT, universal_newlines=True).strip()
+        git_tag = subprocess.check_output(["git", "describe", "--dirty", "--always"],
+                                          stderr=subprocess.STDOUT,
+                                          universal_newlines=True).strip()
     except subprocess.CalledProcessError as er:
         if er.returncode == 128:
             # git exit code of 128 means no repository found
@@ -30,7 +33,9 @@ def get_version_info_from_git():
     except OSError:
         return None
     try:
-        git_hash = subprocess.check_output(["git", "rev-parse", "--short", "HEAD"], stderr=subprocess.STDOUT, universal_newlines=True).strip()
+        git_hash = subprocess.check_output(["git", "rev-parse", "--short", "HEAD"],
+                                           stderr=subprocess.STDOUT,
+                                           universal_newlines=True).strip()
     except subprocess.CalledProcessError:
         git_hash = "unknown"
     except OSError:
@@ -38,15 +43,18 @@ def get_version_info_from_git():
 
     try:
         # Check if there are any modified files.
-        subprocess.check_call(["git", "diff", "--no-ext-diff", "--quiet", "--exit-code"], stderr=subprocess.STDOUT)
+        subprocess.check_call(["git", "diff", "--no-ext-diff", "--quiet", "--exit-code"],
+                              stderr=subprocess.STDOUT)
         # Check if there are any staged files.
-        subprocess.check_call(["git", "diff-index", "--cached", "--quiet", "HEAD", "--"], stderr=subprocess.STDOUT)
+        subprocess.check_call(["git", "diff-index", "--cached", "--quiet", "HEAD", "--"],
+                              stderr=subprocess.STDOUT)
     except subprocess.CalledProcessError:
         git_hash += "-dirty"
     except OSError:
         return None
 
     return git_tag, git_hash
+
 
 def get_version_info_from_docs_conf():
     with open(os.path.join(os.path.dirname(sys.argv[0]), "..", "docs", "conf.py")) as f:
@@ -56,6 +64,7 @@ def get_version_info_from_docs_conf():
                 git_tag = "v" + ver
                 return git_tag, "<no hash>"
     return None
+
 
 def make_version_header(filename):
     # Get version info using git, with fallback to docs/conf.py
@@ -86,6 +95,7 @@ def make_version_header(filename):
         print("GEN %s" % filename)
         with open(filename, 'w') as f:
             f.write(file_data)
+
 
 if __name__ == "__main__":
     make_version_header(sys.argv[1])

--- a/tools/codeformat.py
+++ b/tools/codeformat.py
@@ -1,0 +1,43 @@
+#!/usr/bin/env python3
+
+import sys, os, glob
+
+FILES = [
+    'drivers/**/*.py',
+    'examples/**/*.py',
+    'extmod/**/*.py',
+    'lib/**/*.py',
+    'ports/**/*.py',
+    'py/**/*.py',
+    'tools/**/*.py',
+]
+
+EXCLUSIONS = []
+
+
+def list_files():
+    files = set()
+    for pattern in FILES:
+        files.update(glob.glob(pattern, recursive=True))
+    for pattern in EXCLUSIONS:
+        files.difference_update(glob.fnmatch.filter(files, pattern))
+    return sorted(files)
+
+
+def main():
+    try:
+        os.stat('./tools/codeformat.py')
+    except OSError:
+        print('Run this from the top-level directory, e.g. ./tools/codeformat.py', file=sys.stderr)
+        sys.exit(1)
+
+    files = list_files()
+    for file in files:
+        print(file)
+        os.system(
+            "yapf --style '{based_on_style: pep8, column_limit: 100, spaces_before_comment=1}' -i "
+            + file)
+
+
+if __name__ == '__main__':
+    main()

--- a/tools/dfu.py
+++ b/tools/dfu.py
@@ -4,122 +4,150 @@
 # Distributed under Gnu LGPL 3.0
 # see http://www.gnu.org/licenses/lgpl-3.0.txt
 
-import sys,struct,zlib,os
+import sys, struct, zlib, os
 from optparse import OptionParser
 
-DEFAULT_DEVICE="0x0483:0xdf11"
+DEFAULT_DEVICE = "0x0483:0xdf11"
 
-def named(tuple,names):
-  return dict(zip(names.split(),tuple))
-def consume(fmt,data,names):
-  n = struct.calcsize(fmt)
-  return named(struct.unpack(fmt,data[:n]),names),data[n:]
+
+def named(tuple, names):
+    return dict(zip(names.split(), tuple))
+
+
+def consume(fmt, data, names):
+    n = struct.calcsize(fmt)
+    return named(struct.unpack(fmt, data[:n]), names), data[n:]
+
+
 def cstring(string):
-  return string.split('\0',1)[0]
+    return string.split('\0', 1)[0]
+
+
 def compute_crc(data):
-  return 0xFFFFFFFF & -zlib.crc32(data) -1
+    return 0xFFFFFFFF & -zlib.crc32(data) - 1
 
-def parse(file,dump_images=False):
-  print ('File: "%s"' % file)
-  data = open(file,'rb').read()
-  crc = compute_crc(data[:-4])
-  prefix, data = consume('<5sBIB',data,'signature version size targets')
-  print ('%(signature)s v%(version)d, image size: %(size)d, targets: %(targets)d' % prefix)
-  for t in range(prefix['targets']):
-    tprefix, data  = consume('<6sBI255s2I',data,'signature altsetting named name size elements')
-    tprefix['num'] = t
-    if tprefix['named']:
-      tprefix['name'] = cstring(tprefix['name'])
-    else:
-      tprefix['name'] = ''
-    print ('%(signature)s %(num)d, alt setting: %(altsetting)s, name: "%(name)s", size: %(size)d, elements: %(elements)d' % tprefix)
-    tsize = tprefix['size']
-    target, data = data[:tsize], data[tsize:]
-    for e in range(tprefix['elements']):
-      eprefix, target = consume('<2I',target,'address size')
-      eprefix['num'] = e
-      print ('  %(num)d, address: 0x%(address)08x, size: %(size)d' % eprefix)
-      esize = eprefix['size']
-      image, target = target[:esize], target[esize:]
-      if dump_images:
-        out = '%s.target%d.image%d.bin' % (file,t,e)
-        open(out,'wb').write(image)
-        print ('    DUMPED IMAGE TO "%s"' % out)
-    if len(target):
-      print ("target %d: PARSE ERROR" % t)
-  suffix = named(struct.unpack('<4H3sBI',data[:16]),'device product vendor dfu ufd len crc')
-  print ('usb: %(vendor)04x:%(product)04x, device: 0x%(device)04x, dfu: 0x%(dfu)04x, %(ufd)s, %(len)d, 0x%(crc)08x' % suffix)
-  if crc != suffix['crc']:
-    print ("CRC ERROR: computed crc32 is 0x%08x" % crc)
-  data = data[16:]
-  if data:
-    print ("PARSE ERROR")
 
-def build(file,targets,device=DEFAULT_DEVICE):
-  data = b''
-  for t,target in enumerate(targets):
-    tdata = b''
-    for image in target:
-      # pad image to 8 bytes (needed at least for L476)
-      pad = (8 - len(image['data']) % 8 ) % 8
-      image['data'] = image['data'] + bytes(bytearray(8)[0:pad])
-      #
-      tdata += struct.pack('<2I',image['address'],len(image['data']))+image['data']
-    tdata = struct.pack('<6sBI255s2I',b'Target',0,1, b'ST...',len(tdata),len(target)) + tdata
-    data += tdata
-  data  = struct.pack('<5sBIB',b'DfuSe',1,len(data)+11,len(targets)) + data
-  v,d=map(lambda x: int(x,0) & 0xFFFF, device.split(':',1))
-  data += struct.pack('<4H3sB',0,d,v,0x011a,b'UFD',16)
-  crc   = compute_crc(data)
-  data += struct.pack('<I',crc)
-  open(file,'wb').write(data)
+def parse(file, dump_images=False):
+    print('File: "%s"' % file)
+    data = open(file, 'rb').read()
+    crc = compute_crc(data[:-4])
+    prefix, data = consume('<5sBIB', data, 'signature version size targets')
+    print('%(signature)s v%(version)d, image size: %(size)d, targets: %(targets)d' % prefix)
+    for t in range(prefix['targets']):
+        tprefix, data = consume('<6sBI255s2I', data,
+                                'signature altsetting named name size elements')
+        tprefix['num'] = t
+        if tprefix['named']:
+            tprefix['name'] = cstring(tprefix['name'])
+        else:
+            tprefix['name'] = ''
+        print(
+            '%(signature)s %(num)d, alt setting: %(altsetting)s, name: "%(name)s", size: %(size)d, elements: %(elements)d'
+            % tprefix)
+        tsize = tprefix['size']
+        target, data = data[:tsize], data[tsize:]
+        for e in range(tprefix['elements']):
+            eprefix, target = consume('<2I', target, 'address size')
+            eprefix['num'] = e
+            print('  %(num)d, address: 0x%(address)08x, size: %(size)d' % eprefix)
+            esize = eprefix['size']
+            image, target = target[:esize], target[esize:]
+            if dump_images:
+                out = '%s.target%d.image%d.bin' % (file, t, e)
+                open(out, 'wb').write(image)
+                print('    DUMPED IMAGE TO "%s"' % out)
+        if len(target):
+            print("target %d: PARSE ERROR" % t)
+    suffix = named(struct.unpack('<4H3sBI', data[:16]), 'device product vendor dfu ufd len crc')
+    print(
+        'usb: %(vendor)04x:%(product)04x, device: 0x%(device)04x, dfu: 0x%(dfu)04x, %(ufd)s, %(len)d, 0x%(crc)08x'
+        % suffix)
+    if crc != suffix['crc']:
+        print("CRC ERROR: computed crc32 is 0x%08x" % crc)
+    data = data[16:]
+    if data:
+        print("PARSE ERROR")
 
-if __name__=="__main__":
-  usage = """
+
+def build(file, targets, device=DEFAULT_DEVICE):
+    data = b''
+    for t, target in enumerate(targets):
+        tdata = b''
+        for image in target:
+            # pad image to 8 bytes (needed at least for L476)
+            pad = (8 - len(image['data']) % 8) % 8
+            image['data'] = image['data'] + bytes(bytearray(8)[0:pad])
+            #
+            tdata += struct.pack('<2I', image['address'], len(image['data'])) + image['data']
+        tdata = struct.pack('<6sBI255s2I', b'Target', 0, 1, b'ST...', len(tdata),
+                            len(target)) + tdata
+        data += tdata
+    data = struct.pack('<5sBIB', b'DfuSe', 1, len(data) + 11, len(targets)) + data
+    v, d = map(lambda x: int(x, 0) & 0xFFFF, device.split(':', 1))
+    data += struct.pack('<4H3sB', 0, d, v, 0x011a, b'UFD', 16)
+    crc = compute_crc(data)
+    data += struct.pack('<I', crc)
+    open(file, 'wb').write(data)
+
+
+if __name__ == "__main__":
+    usage = """
 %prog [-d|--dump] infile.dfu
 %prog {-b|--build} address:file.bin [-b address:file.bin ...] [{-D|--device}=vendor:device] outfile.dfu"""
-  parser = OptionParser(usage=usage)
-  parser.add_option("-b", "--build", action="append", dest="binfiles",
-    help="build a DFU file from given BINFILES", metavar="BINFILES")
-  parser.add_option("-D", "--device", action="store", dest="device",
-    help="build for DEVICE, defaults to %s" % DEFAULT_DEVICE, metavar="DEVICE")
-  parser.add_option("-d", "--dump", action="store_true", dest="dump_images",
-    default=False, help="dump contained images to current directory")
-  (options, args) = parser.parse_args()
+    parser = OptionParser(usage=usage)
+    parser.add_option("-b",
+                      "--build",
+                      action="append",
+                      dest="binfiles",
+                      help="build a DFU file from given BINFILES",
+                      metavar="BINFILES")
+    parser.add_option("-D",
+                      "--device",
+                      action="store",
+                      dest="device",
+                      help="build for DEVICE, defaults to %s" % DEFAULT_DEVICE,
+                      metavar="DEVICE")
+    parser.add_option("-d",
+                      "--dump",
+                      action="store_true",
+                      dest="dump_images",
+                      default=False,
+                      help="dump contained images to current directory")
+    (options, args) = parser.parse_args()
 
-  if options.binfiles and len(args)==1:
-    target = []
-    for arg in options.binfiles:
-      try:
-        address,binfile = arg.split(':',1)
-      except ValueError:
-        print ("Address:file couple '%s' invalid." % arg)
+    if options.binfiles and len(args) == 1:
+        target = []
+        for arg in options.binfiles:
+            try:
+                address, binfile = arg.split(':', 1)
+            except ValueError:
+                print("Address:file couple '%s' invalid." % arg)
+                sys.exit(1)
+            try:
+                address = int(address, 0) & 0xFFFFFFFF
+            except ValueError:
+                print("Address %s invalid." % address)
+                sys.exit(1)
+            if not os.path.isfile(binfile):
+                print("Unreadable file '%s'." % binfile)
+                sys.exit(1)
+            target.append({'address': address, 'data': open(binfile, 'rb').read()})
+        outfile = args[0]
+        device = DEFAULT_DEVICE
+        if options.device:
+            device = options.device
+        try:
+            v, d = map(lambda x: int(x, 0) & 0xFFFF, device.split(':', 1))
+        except:
+            print("Invalid device '%s'." % device)
+            sys.exit(1)
+        build(outfile, [target], device)
+    elif len(args) == 1:
+        infile = args[0]
+        if not os.path.isfile(infile):
+            print("Unreadable file '%s'." % infile)
+            sys.exit(1)
+        parse(infile, dump_images=options.dump_images)
+    else:
+        parser.print_help()
         sys.exit(1)
-      try:
-        address = int(address,0) & 0xFFFFFFFF
-      except ValueError:
-        print ("Address %s invalid." % address)
-        sys.exit(1)
-      if not os.path.isfile(binfile):
-        print ("Unreadable file '%s'." % binfile)
-        sys.exit(1)
-      target.append({ 'address': address, 'data': open(binfile,'rb').read() })
-    outfile = args[0]
-    device = DEFAULT_DEVICE
-    if options.device:
-      device=options.device
-    try:
-      v,d=map(lambda x: int(x,0) & 0xFFFF, device.split(':',1))
-    except:
-      print ("Invalid device '%s'." % device)
-      sys.exit(1)
-    build(outfile,[target],device)
-  elif len(args)==1:
-    infile = args[0]
-    if not os.path.isfile(infile):
-      print ("Unreadable file '%s'." % infile)
-      sys.exit(1)
-    parse(infile, dump_images=options.dump_images)
-  else:
-    parser.print_help()
-    sys.exit(1)

--- a/tools/gen-cpydiff.py
+++ b/tools/gen-cpydiff.py
@@ -21,7 +21,6 @@
 # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
-
 """ gen-cpydiff generates documentation which outlines operations that differ between MicroPython
     and CPython. This script is called by the docs Makefile for html and Latex and may be run
     manually using the command make gen-cpydiff. """
@@ -57,8 +56,10 @@ RSTCHARS = ['=', '-', '~', '`', ':']
 SPLIT = '"""\n|categories: |description: |cause: |workaround: '
 TAB = '    '
 
-Output = namedtuple('output', ['name', 'class_', 'desc', 'cause', 'workaround', 'code',
-                               'output_cpy', 'output_upy', 'status'])
+Output = namedtuple(
+    'output',
+    ['name', 'class_', 'desc', 'cause', 'workaround', 'code', 'output_cpy', 'output_upy', 'status'])
+
 
 def readfiles():
     """ Reads test files """
@@ -79,12 +80,14 @@ def readfiles():
 
     return files
 
+
 def uimports(code):
     """ converts CPython module names into MicroPython equivalents """
     for uimport in UIMPORTLIST:
         uimport = bytes(uimport, 'utf8')
         code = code.replace(uimport, b'u' + uimport)
     return code
+
 
 def run_tests(tests):
     """ executes all tests """
@@ -94,10 +97,18 @@ def run_tests(tests):
             input_cpy = f.read()
         input_upy = uimports(input_cpy)
 
-        process = subprocess.Popen(CPYTHON3, shell=True, stdout=subprocess.PIPE, stdin=subprocess.PIPE, stderr=subprocess.PIPE)
+        process = subprocess.Popen(CPYTHON3,
+                                   shell=True,
+                                   stdout=subprocess.PIPE,
+                                   stdin=subprocess.PIPE,
+                                   stderr=subprocess.PIPE)
         output_cpy = [com.decode('utf8') for com in process.communicate(input_cpy)]
 
-        process = subprocess.Popen(MICROPYTHON, shell=True, stdout=subprocess.PIPE, stdin=subprocess.PIPE, stderr=subprocess.PIPE)
+        process = subprocess.Popen(MICROPYTHON,
+                                   shell=True,
+                                   stdout=subprocess.PIPE,
+                                   stdin=subprocess.PIPE,
+                                   stderr=subprocess.PIPE)
         output_upy = [com.decode('utf8') for com in process.communicate(input_upy)]
 
         if output_cpy[0] == output_upy[0] and output_cpy[1] == output_upy[1]:
@@ -106,12 +117,13 @@ def run_tests(tests):
         else:
             status = 'Unsupported'
 
-        output = Output(test.name, test.class_, test.desc, test.cause,
-                        test.workaround, test.code, output_cpy, output_upy, status)
+        output = Output(test.name, test.class_, test.desc, test.cause, test.workaround, test.code,
+                        output_cpy, output_upy, status)
         results.append(output)
 
     results.sort(key=lambda x: x.class_)
     return results
+
 
 def indent(block, spaces):
     """ indents paragraphs of text for rst formatting """
@@ -119,6 +131,7 @@ def indent(block, spaces):
     for line in block.split('\n'):
         new_block += spaces + line + '\n'
     return new_block
+
 
 def gen_table(contents):
     """ creates a table given any set of columns """
@@ -141,7 +154,7 @@ def gen_table(contents):
     table = table_divider
     for i in range(len(ylengths)):
         row = [column[i] for column in contents]
-        row = [entry + '\n' * (ylengths[i]-len(entry.split('\n'))) for entry in row]
+        row = [entry + '\n' * (ylengths[i] - len(entry.split('\n'))) for entry in row]
         row = [entry.split('\n') for entry in row]
         for j in range(ylengths[i]):
             k = 0
@@ -152,6 +165,7 @@ def gen_table(contents):
             table += '|\n'
         table += table_divider
     return table + '\n'
+
 
 def gen_rst(results):
     """ creates restructured text documents to display tests """
@@ -182,7 +196,7 @@ def gen_rst(results):
                     toctree.append(filename)
                 else:
                     rst.write(section[i] + '\n')
-                    rst.write(RSTCHARS[min(i, len(RSTCHARS)-1)] * len(section[i]))
+                    rst.write(RSTCHARS[min(i, len(RSTCHARS) - 1)] * len(section[i]))
                     rst.write('\n\n')
         class_ = section
         rst.write('.. _cpydiff_%s:\n\n' % output.name.rsplit('.', 1)[0])
@@ -212,6 +226,7 @@ def gen_rst(results):
     for section in toctree:
         index.write(indent(section + '.rst', TAB))
 
+
 def main():
     """ Main function """
 
@@ -222,5 +237,6 @@ def main():
     files = readfiles()
     results = run_tests(files)
     gen_rst(results)
+
 
 main()

--- a/tools/gendoc.py
+++ b/tools/gendoc.py
@@ -7,6 +7,7 @@ import argparse
 import re
 import markdown
 
+
 # given a list of (name,regex) pairs, find the first one that matches the given line
 def re_match_first(regexs, line):
     for name, regex in regexs:
@@ -15,9 +16,11 @@ def re_match_first(regexs, line):
             return name, match
     return None, None
 
+
 def makedirs(d):
     if not os.path.isdir(d):
         os.makedirs(d)
+
 
 class Lexer:
     class LexerError(Exception):
@@ -66,6 +69,7 @@ class Lexer:
     def error(self, msg):
         print('({}:{}) {}'.format(self.filename, self.cur_line, msg))
         raise Lexer.LexerError
+
 
 class MarkdownWriter:
     def __init__(self):
@@ -119,8 +123,9 @@ class MarkdownWriter:
     def constant(self, ctx, name, descr):
         self.single_line('`{}.{}` - {}'.format(ctx, name, descr))
 
+
 class ReStructuredTextWriter:
-    head_chars = {1:'=', 2:'-', 3:'.'}
+    head_chars = {1: '=', 2: '-', 3: '.'}
 
     def __init__(self):
         pass
@@ -183,8 +188,10 @@ class ReStructuredTextWriter:
         self.lines.append('.. data:: ' + name)
         self.para(descr, indent='   ')
 
+
 class DocValidateError(Exception):
     pass
+
 
 class DocItem:
     def __init__(self):
@@ -202,6 +209,7 @@ class DocItem:
     def dump(self, writer):
         writer.para(self.doc)
 
+
 class DocConstant(DocItem):
     def __init__(self, name, descr):
         super().__init__()
@@ -210,6 +218,7 @@ class DocConstant(DocItem):
 
     def dump(self, ctx, writer):
         writer.constant(ctx, self.name, self.descr)
+
 
 class DocFunction(DocItem):
     def __init__(self, name, args):
@@ -220,6 +229,7 @@ class DocFunction(DocItem):
     def dump(self, ctx, writer):
         writer.function(ctx, self.name, self.args, self.doc)
 
+
 class DocMethod(DocItem):
     def __init__(self, name, args):
         super().__init__()
@@ -228,6 +238,7 @@ class DocMethod(DocItem):
 
     def dump(self, ctx, writer):
         writer.method(ctx, self.name, self.args, self.doc)
+
 
 class DocClass(DocItem):
     def __init__(self, name, descr):
@@ -270,20 +281,21 @@ class DocClass(DocItem):
         super().dump(writer)
         if len(self.constructors) > 0:
             writer.heading(2, 'Constructors')
-            for f in sorted(self.constructors.values(), key=lambda x:x.name):
+            for f in sorted(self.constructors.values(), key=lambda x: x.name):
                 f.dump(self.name, writer)
         if len(self.classmethods) > 0:
             writer.heading(2, 'Class methods')
-            for f in sorted(self.classmethods.values(), key=lambda x:x.name):
+            for f in sorted(self.classmethods.values(), key=lambda x: x.name):
                 f.dump(self.name, writer)
         if len(self.methods) > 0:
             writer.heading(2, 'Methods')
-            for f in sorted(self.methods.values(), key=lambda x:x.name):
+            for f in sorted(self.methods.values(), key=lambda x: x.name):
                 f.dump(self.name.lower(), writer)
         if len(self.constants) > 0:
             writer.heading(2, 'Constants')
-            for c in sorted(self.constants.values(), key=lambda x:x.name):
+            for c in sorted(self.constants.values(), key=lambda x: x.name):
                 c.dump(self.name, writer)
+
 
 class DocModule(DocItem):
     def __init__(self, name, descr):
@@ -343,15 +355,15 @@ class DocModule(DocItem):
         writer.module(self.name, self.descr, self.doc)
         if self.functions:
             writer.heading(2, 'Functions')
-            for f in sorted(self.functions.values(), key=lambda x:x.name):
+            for f in sorted(self.functions.values(), key=lambda x: x.name):
                 f.dump(self.name, writer)
         if self.constants:
             writer.heading(2, 'Constants')
-            for c in sorted(self.constants.values(), key=lambda x:x.name):
+            for c in sorted(self.constants.values(), key=lambda x: x.name):
                 c.dump(self.name, writer)
         if self.classes:
             writer.heading(2, 'Classes')
-            for c in sorted(self.classes.values(), key=lambda x:x.name):
+            for c in sorted(self.classes.values(), key=lambda x: x.name):
                 writer.para('[`{}.{}`]({}) - {}'.format(self.name, c.name, c.name, c.descr))
 
     def write_html(self, dir):
@@ -380,6 +392,7 @@ class DocModule(DocItem):
             c.dump(rst_writer)
             with open(dir + '/' + self.name + '.' + c.name + '.rst', 'wt') as f:
                 f.write(rst_writer.end())
+
 
 class Doc:
     def __init__(self):
@@ -439,7 +452,7 @@ class Doc:
     def dump(self, writer):
         writer.heading(1, 'Modules')
         writer.para('These are the Python modules that are implemented.')
-        for m in sorted(self.modules.values(), key=lambda x:x.name):
+        for m in sorted(self.modules.values(), key=lambda x: x.name):
             writer.para('[`{}`]({}/) - {}'.format(m.name, m.name, m.descr))
 
     def write_html(self, dir):
@@ -459,6 +472,7 @@ class Doc:
         for m in self.modules.values():
             m.write_rst(dir)
 
+
 regex_descr = r'(?P<descr>.*)'
 
 doc_regexs = (
@@ -471,6 +485,7 @@ doc_regexs = (
     #(Doc.process_classref, re.compile(r'\\classref (?P<id>[A-Za-z0-9_]+)$')),
     (Doc.process_class, re.compile(r'\\class (?P<id>[A-Za-z0-9_]+) - ' + regex_descr + r'$')),
 )
+
 
 def process_file(file, doc):
     lex = Lexer(file)
@@ -495,9 +510,14 @@ def process_file(file, doc):
 
     return True
 
+
 def main():
-    cmd_parser = argparse.ArgumentParser(description='Generate documentation for pyboard API from C files.')
-    cmd_parser.add_argument('--outdir', metavar='<output dir>', default='gendoc-out', help='ouput directory')
+    cmd_parser = argparse.ArgumentParser(
+        description='Generate documentation for pyboard API from C files.')
+    cmd_parser.add_argument('--outdir',
+                            metavar='<output dir>',
+                            default='gendoc-out',
+                            help='ouput directory')
     cmd_parser.add_argument('--format', default='html', help='output format: html or rst')
     cmd_parser.add_argument('files', nargs='+', help='input files')
     args = cmd_parser.parse_args()
@@ -523,6 +543,7 @@ def main():
         return
 
     print('written to', args.outdir)
+
 
 if __name__ == "__main__":
     main()

--- a/tools/insert-usb-ids.py
+++ b/tools/insert-usb-ids.py
@@ -10,6 +10,7 @@ import string
 
 needed_keys = ('USB_PID_CDC_MSC', 'USB_PID_CDC_HID', 'USB_PID_CDC', 'USB_VID')
 
+
 def parse_usb_ids(filename):
     rv = dict()
     for line in open(filename).readlines():
@@ -25,6 +26,7 @@ def parse_usb_ids(filename):
         if k not in rv:
             raise Exception("Unable to parse %s from %s" % (k, filename))
     return rv
+
 
 if __name__ == "__main__":
     usb_ids_file = sys.argv[1]

--- a/tools/make-frozen.py
+++ b/tools/make-frozen.py
@@ -25,6 +25,7 @@ import os
 def module_name(f):
     return f
 
+
 modules = []
 
 if len(sys.argv) > 1:

--- a/tools/makemanifest.py
+++ b/tools/makemanifest.py
@@ -29,9 +29,9 @@ import sys
 import os
 import subprocess
 
-
 ###########################################################################
 # Public functions to be used in the manifest
+
 
 def include(manifest):
     """Include another manifest.
@@ -54,6 +54,7 @@ def include(manifest):
             os.chdir(os.path.dirname(manifest))
             exec(f.read())
             os.chdir(prev_cwd)
+
 
 def freeze(path, script=None, opt=0):
     """Freeze the input, automatically determining its type.  A .py script
@@ -84,6 +85,7 @@ def freeze(path, script=None, opt=0):
 
     freeze_internal(KIND_AUTO, path, script, opt)
 
+
 def freeze_as_str(path):
     """Freeze the given `path` and all .py scripts within it as a string,
     which will be compiled upon import.
@@ -91,12 +93,14 @@ def freeze_as_str(path):
 
     freeze_internal(KIND_AS_STR, path, None, 0)
 
+
 def freeze_as_mpy(path, script=None, opt=0):
     """Freeze the input (see above) by first compiling the .py scripts to
     .mpy files, then freezing the resulting .mpy files.
     """
 
     freeze_internal(KIND_AS_MPY, path, script, opt)
+
 
 def freeze_mpy(path, script=None, opt=0):
     """Freeze the input (see above), which must be .mpy files that are
@@ -118,8 +122,10 @@ VARS = {}
 
 manifest_list = []
 
+
 class FreezeError(Exception):
     pass
+
 
 def system(cmd):
     try:
@@ -128,6 +134,7 @@ def system(cmd):
     except subprocess.CalledProcessError as er:
         return -1, er.output
 
+
 def convert_path(path):
     # Perform variable substituion.
     for name, value in VARS.items():
@@ -135,6 +142,7 @@ def convert_path(path):
     # Convert to absolute path (so that future operations don't rely on
     # still being chdir'ed).
     return os.path.abspath(path)
+
 
 def get_timestamp(path, default=None):
     try:
@@ -145,12 +153,14 @@ def get_timestamp(path, default=None):
             raise FreezeError('cannot stat {}'.format(path))
         return default
 
+
 def get_timestamp_newest(path):
     ts_newest = 0
     for dirpath, dirnames, filenames in os.walk(path, followlinks=True):
         for f in filenames:
             ts_newest = max(ts_newest, get_timestamp(os.path.join(dirpath, f)))
     return ts_newest
+
 
 def mkdir(path):
     cur_path = ''
@@ -163,6 +173,7 @@ def mkdir(path):
                 pass
             else:
                 raise er
+
 
 def freeze_internal(kind, path, script, opt):
     path = convert_path(path)
@@ -192,13 +203,18 @@ def freeze_internal(kind, path, script, opt):
             raise FreezeError('expecting a {} file, got {}'.format(wanted_extension, script))
         manifest_list.append((kind, path, script, opt))
 
+
 def main():
     # Parse arguments
     import argparse
-    cmd_parser = argparse.ArgumentParser(description='A tool to generate frozen content in MicroPython firmware images.')
+    cmd_parser = argparse.ArgumentParser(
+        description='A tool to generate frozen content in MicroPython firmware images.')
     cmd_parser.add_argument('-o', '--output', help='output path')
     cmd_parser.add_argument('-b', '--build-dir', help='output path')
-    cmd_parser.add_argument('-f', '--mpy-cross-flags', default='', help='flags to pass to mpy-cross')
+    cmd_parser.add_argument('-f',
+                            '--mpy-cross-flags',
+                            default='',
+                            help='flags to pass to mpy-cross')
     cmd_parser.add_argument('-v', '--var', action='append', help='variables to substitute')
     cmd_parser.add_argument('files', nargs='+', help='input manifest list')
     args = cmd_parser.parse_args()
@@ -251,7 +267,8 @@ def main():
             if ts_infile >= ts_outfile:
                 print('MPY', script)
                 mkdir(outfile)
-                res, out = system([MPY_CROSS] + args.mpy_cross_flags.split() + ['-o', outfile, '-s', script, '-O{}'.format(opt), infile])
+                res, out = system([MPY_CROSS] + args.mpy_cross_flags.split() +
+                                  ['-o', outfile, '-s', script, '-O{}'.format(opt), infile])
                 if res != 0:
                     print('error compiling {}: {}'.format(infile, out))
                     raise SystemExit(1)
@@ -277,21 +294,21 @@ def main():
 
     # Freeze .mpy files
     if mpy_files:
-        res, output_mpy = system([sys.executable, MPY_TOOL, '-f', '-q', args.build_dir + '/genhdr/qstrdefs.preprocessed.h'] + mpy_files)
+        res, output_mpy = system([
+            sys.executable, MPY_TOOL, '-f', '-q', args.build_dir + '/genhdr/qstrdefs.preprocessed.h'
+        ] + mpy_files)
         if res != 0:
             print('error freezing mpy {}:'.format(mpy_files))
             print(str(output_mpy, 'utf8'))
             sys.exit(1)
     else:
-        output_mpy = (
-            b'#include "py/emitglue.h"\n'
-            b'extern const qstr_pool_t mp_qstr_const_pool;\n'
-            b'const qstr_pool_t mp_qstr_frozen_const_pool = {\n'
-            b'    (qstr_pool_t*)&mp_qstr_const_pool, MP_QSTRnumber_of, 0, 0\n'
-            b'};\n'
-            b'const char mp_frozen_mpy_names[1] = {"\\0"};\n'
-            b'const mp_raw_code_t *const mp_frozen_mpy_content[0] = {};\n'
-        )
+        output_mpy = (b'#include "py/emitglue.h"\n'
+                      b'extern const qstr_pool_t mp_qstr_const_pool;\n'
+                      b'const qstr_pool_t mp_qstr_frozen_const_pool = {\n'
+                      b'    (qstr_pool_t*)&mp_qstr_const_pool, MP_QSTRnumber_of, 0, 0\n'
+                      b'};\n'
+                      b'const char mp_frozen_mpy_names[1] = {"\\0"};\n'
+                      b'const mp_raw_code_t *const mp_frozen_mpy_content[0] = {};\n')
 
     # Generate output
     print('GEN', args.output)
@@ -301,6 +318,7 @@ def main():
         f.write(output_str)
         f.write(b'//\n// Content for MICROPY_MODULE_FROZEN_MPY\n//\n')
         f.write(output_mpy)
+
 
 if __name__ == '__main__':
     main()

--- a/tools/metrics.py
+++ b/tools/metrics.py
@@ -23,7 +23,6 @@
 # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
-
 """
 This script is used to compute metrics, like code size, of the various ports.
 
@@ -47,12 +46,14 @@ import sys, re, subprocess
 
 MAKE_FLAGS = ['-j3', 'CFLAGS_EXTRA=-DNDEBUG']
 
+
 class PortData:
     def __init__(self, name, dir, output, make_flags=None):
         self.name = name
         self.dir = dir
         self.output = output
         self.make_flags = make_flags
+
 
 port_data = {
     'b': PortData('bare-arm', 'bare-arm', 'build/firmware.elf'),
@@ -67,6 +68,7 @@ port_data = {
     'd': PortData('samd', 'samd', 'build-ADAFRUIT_ITSYBITSY_M4_EXPRESS/firmware.elf'),
 }
 
+
 def syscmd(*args):
     sys.stdout.flush()
     a2 = []
@@ -76,6 +78,7 @@ def syscmd(*args):
         elif a:
             a2.extend(a)
     subprocess.run(a2)
+
 
 def parse_port_list(args):
     if not args:
@@ -90,6 +93,7 @@ def parse_port_list(args):
                     print('unknown port:', port_char)
                     sys.exit(1)
         return ports
+
 
 def read_build_log(filename):
     data = dict()
@@ -111,6 +115,7 @@ def read_build_log(filename):
         else:
             is_size_line = line.startswith('text\t ')
     return data
+
 
 def do_diff(args):
     """Compute the difference between firmware sizes."""
@@ -151,6 +156,7 @@ def do_diff(args):
             warn = '[incl%s]' % warn
         print('%11s: %+5u %+.3f%% %s%s' % (name, delta, percent, board, warn))
 
+
 def do_clean(args):
     """Clean ports."""
 
@@ -159,6 +165,7 @@ def do_clean(args):
     print('CLEANING')
     for port in ports:
         syscmd('make', '-C', 'ports/{}'.format(port.dir), port.make_flags, 'clean')
+
 
 def do_build(args):
     """Build ports and print firmware sizes."""
@@ -174,6 +181,7 @@ def do_build(args):
 
     do_sizes(args)
 
+
 def do_sizes(args):
     """Compute and print sizes of firmware."""
 
@@ -182,6 +190,7 @@ def do_sizes(args):
     print('COMPUTING SIZES')
     for port in ports:
         syscmd('size', 'ports/{}/{}'.format(port.dir, port.output))
+
 
 def main():
     # Get command to execute
@@ -200,6 +209,7 @@ def main():
         print("{}: unknown command '{}'".format(sys.argv[0], cmd))
         sys.exit(1)
     cmd(sys.argv[1:])
+
 
 if __name__ == '__main__':
     main()

--- a/tools/mpy_cross_all.py
+++ b/tools/mpy_cross_all.py
@@ -6,7 +6,9 @@ import os.path
 argparser = argparse.ArgumentParser(description="Compile all .py files to .mpy recursively")
 argparser.add_argument("-o", "--out", help="output directory (default: input dir)")
 argparser.add_argument("--target", help="select MicroPython target config")
-argparser.add_argument("-mcache-lookup-bc", action="store_true", help="cache map lookups in the bytecode")
+argparser.add_argument("-mcache-lookup-bc",
+                       action="store_true",
+                       help="cache map lookups in the bytecode")
 argparser.add_argument("dir", help="input directory")
 args = argparser.parse_args()
 
@@ -31,8 +33,8 @@ for path, subdirs, files in os.walk(args.dir):
             out_dir = os.path.dirname(out_fpath)
             if not os.path.isdir(out_dir):
                 os.makedirs(out_dir)
-            cmd = "mpy-cross -v -v %s -s %s %s -o %s" % (TARGET_OPTS.get(args.target, ""),
-                fpath[path_prefix_len:], fpath, out_fpath)
+            cmd = "mpy-cross -v -v %s -s %s %s -o %s" % (TARGET_OPTS.get(
+                args.target, ""), fpath[path_prefix_len:], fpath, out_fpath)
             #print(cmd)
             res = os.system(cmd)
             assert res == 0

--- a/tools/mpy_ld.py
+++ b/tools/mpy_ld.py
@@ -23,7 +23,6 @@
 # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
-
 """
 Link .o files to .mpy
 """
@@ -79,8 +78,10 @@ R_386_GOT32X = 43
 ################################################################################
 # Architecture configuration
 
+
 def asm_jump_x86(entry):
     return struct.pack('<BI', 0xe9, entry - 5)
+
 
 def asm_jump_arm(entry):
     b_off = entry - 4
@@ -94,10 +95,12 @@ def asm_jump_arm(entry):
         b1 = 0xb800 | (b_off >> 1 & 0x7ff)
     return struct.pack('<HH', b0, b1)
 
+
 def asm_jump_xtensa(entry):
     jump_offset = entry - 4
     jump_op = jump_offset << 6 | 6
     return struct.pack('<BH', jump_op & 0xff, jump_op >> 8)
+
 
 class ArchData:
     def __init__(self, name, mpy_feature, qstr_entry_size, word_size, arch_got, asm_jump):
@@ -109,57 +112,92 @@ class ArchData:
         self.asm_jump = asm_jump
         self.separate_rodata = name == 'EM_XTENSA' and qstr_entry_size == 4
 
+
 ARCH_DATA = {
-    'x86': ArchData(
+    'x86':
+    ArchData(
         'EM_386',
-        MP_NATIVE_ARCH_X86 << 2 | MICROPY_PY_BUILTINS_STR_UNICODE | MICROPY_OPT_CACHE_MAP_LOOKUP_IN_BYTECODE,
-        2, 4, (R_386_PC32, R_386_GOT32, R_386_GOT32X), asm_jump_x86,
+        MP_NATIVE_ARCH_X86 << 2 | MICROPY_PY_BUILTINS_STR_UNICODE
+        | MICROPY_OPT_CACHE_MAP_LOOKUP_IN_BYTECODE,
+        2,
+        4,
+        (R_386_PC32, R_386_GOT32, R_386_GOT32X),
+        asm_jump_x86,
     ),
-    'x64': ArchData(
+    'x64':
+    ArchData(
         'EM_X86_64',
-        MP_NATIVE_ARCH_X64 << 2 | MICROPY_PY_BUILTINS_STR_UNICODE | MICROPY_OPT_CACHE_MAP_LOOKUP_IN_BYTECODE,
-        2, 8, (R_X86_64_REX_GOTPCRELX,), asm_jump_x86,
+        MP_NATIVE_ARCH_X64 << 2 | MICROPY_PY_BUILTINS_STR_UNICODE
+        | MICROPY_OPT_CACHE_MAP_LOOKUP_IN_BYTECODE,
+        2,
+        8,
+        (R_X86_64_REX_GOTPCRELX, ),
+        asm_jump_x86,
     ),
-    'armv7m': ArchData(
+    'armv7m':
+    ArchData(
         'EM_ARM',
         MP_NATIVE_ARCH_ARMV7M << 2 | MICROPY_PY_BUILTINS_STR_UNICODE,
-        2, 4, (R_ARM_GOT_BREL,), asm_jump_arm,
+        2,
+        4,
+        (R_ARM_GOT_BREL, ),
+        asm_jump_arm,
     ),
-    'armv7emsp': ArchData(
+    'armv7emsp':
+    ArchData(
         'EM_ARM',
         MP_NATIVE_ARCH_ARMV7EMSP << 2 | MICROPY_PY_BUILTINS_STR_UNICODE,
-        2, 4, (R_ARM_GOT_BREL,), asm_jump_arm,
+        2,
+        4,
+        (R_ARM_GOT_BREL, ),
+        asm_jump_arm,
     ),
-    'armv7emdp': ArchData(
+    'armv7emdp':
+    ArchData(
         'EM_ARM',
         MP_NATIVE_ARCH_ARMV7EMDP << 2 | MICROPY_PY_BUILTINS_STR_UNICODE,
-        2, 4, (R_ARM_GOT_BREL,), asm_jump_arm,
+        2,
+        4,
+        (R_ARM_GOT_BREL, ),
+        asm_jump_arm,
     ),
-    'xtensa': ArchData(
+    'xtensa':
+    ArchData(
         'EM_XTENSA',
         MP_NATIVE_ARCH_XTENSA << 2 | MICROPY_PY_BUILTINS_STR_UNICODE,
-        2, 4, (R_XTENSA_32, R_XTENSA_PLT), asm_jump_xtensa,
+        2,
+        4,
+        (R_XTENSA_32, R_XTENSA_PLT),
+        asm_jump_xtensa,
     ),
-    'xtensawin': ArchData(
+    'xtensawin':
+    ArchData(
         'EM_XTENSA',
         MP_NATIVE_ARCH_XTENSAWIN << 2 | MICROPY_PY_BUILTINS_STR_UNICODE,
-        4, 4, (R_XTENSA_32, R_XTENSA_PLT), asm_jump_xtensa,
+        4,
+        4,
+        (R_XTENSA_32, R_XTENSA_PLT),
+        asm_jump_xtensa,
     ),
 }
 
 ################################################################################
 # Helper functions
 
+
 def align_to(value, align):
     return (value + align - 1) & ~(align - 1)
 
+
 def unpack_u24le(data, offset):
     return data[offset] | data[offset + 1] << 8 | data[offset + 2] << 16
+
 
 def pack_u24le(data, offset, value):
     data[offset] = value & 0xff
     data[offset + 1] = value >> 8 & 0xff
     data[offset + 2] = value >> 16 & 0xff
+
 
 def xxd(text):
     for i in range(0, len(text), 16):
@@ -171,18 +209,22 @@ def xxd(text):
                 print(' {:08x}'.format(d), end='')
         print()
 
+
 # Smaller numbers are enabled first
 LOG_LEVEL_1 = 1
 LOG_LEVEL_2 = 2
 LOG_LEVEL_3 = 3
 log_level = LOG_LEVEL_1
 
+
 def log(level, msg):
     if level <= log_level:
         print(msg)
 
+
 ################################################################################
 # Qstr extraction
+
 
 def extract_qstrs(source_files):
     def read_qstrs(f):
@@ -217,11 +259,14 @@ def extract_qstrs(source_files):
 
     return static_qstrs, qstr_vals, qstr_objs
 
+
 ################################################################################
 # Linker
 
+
 class LinkError(Exception):
     pass
+
 
 class Section:
     def __init__(self, name, data, alignment, filename=None):
@@ -236,6 +281,7 @@ class Section:
     def from_elfsec(elfsec, filename):
         assert elfsec.header.sh_addr == 0
         return Section(elfsec.name, elfsec.data(), elfsec.data_alignment, filename)
+
 
 class GOTEntry:
     def __init__(self, name, sym, link_addr=0):
@@ -256,19 +302,21 @@ class GOTEntry:
     def isbss(self):
         return self.sec_name.startswith('.bss')
 
+
 class LiteralEntry:
     def __init__(self, value, offset):
         self.value = value
         self.offset = offset
 
+
 class LinkEnv:
     def __init__(self, arch):
         self.arch = ARCH_DATA[arch]
-        self.sections = []          # list of sections in order of output
-        self.literal_sections = []  # list of literal sections (xtensa only)
-        self.known_syms = {}        # dict of symbols that are defined
-        self.unresolved_syms = []   # list of unresolved symbols
-        self.mpy_relocs = []        # list of relocations needed in the output .mpy file
+        self.sections = [] # list of sections in order of output
+        self.literal_sections = [] # list of literal sections (xtensa only)
+        self.known_syms = {} # dict of symbols that are defined
+        self.unresolved_syms = [] # list of unresolved symbols
+        self.mpy_relocs = [] # list of relocations needed in the output .mpy file
 
     def check_arch(self, arch_name):
         if arch_name != self.arch.name:
@@ -285,12 +333,14 @@ class LinkEnv:
             return s.section.addr + s['st_value']
         raise LinkError('unknown symbol: {}'.format(name))
 
+
 def build_got_generic(env):
     env.got_entries = {}
     for sec in env.sections:
         for r in sec.reloc:
             s = r.sym
-            if not (s.entry['st_info']['bind'] == 'STB_GLOBAL' and r['r_info_type'] in env.arch.arch_got):
+            if not (s.entry['st_info']['bind'] == 'STB_GLOBAL'
+                    and r['r_info_type'] in env.arch.arch_got):
                 continue
             s_type = s.entry['st_info']['type']
             assert s_type in ('STT_NOTYPE', 'STT_FUNC', 'STT_OBJECT'), s_type
@@ -298,6 +348,7 @@ def build_got_generic(env):
             if s.name in env.got_entries:
                 continue
             env.got_entries[s.name] = GOTEntry(s.name, s)
+
 
 def build_got_xtensa(env):
     env.got_entries = {}
@@ -342,7 +393,9 @@ def build_got_xtensa(env):
                 if value in env.lit_entries:
                     # Deduplicate literals
                     continue
-                env.lit_entries[value] = LiteralEntry(value, len(env.lit_entries) * env.arch.word_size)
+                env.lit_entries[value] = LiteralEntry(value,
+                                                      len(env.lit_entries) * env.arch.word_size)
+
 
 def populate_got(env):
     # Compute GOT destination addresses
@@ -356,7 +409,8 @@ def populate_got(env):
         got_entry.link_addr += sec.addr + addr
 
     # Get sorted GOT, sorted by external, text, rodata, bss so relocations can be combined
-    got_list = sorted(env.got_entries.values(),
+    got_list = sorted(
+        env.got_entries.values(),
         key=lambda g: g.isexternal() + 2 * g.istext() + 3 * g.isrodata() + 4 * g.isbss())
 
     # Layout and populate the GOT
@@ -365,7 +419,8 @@ def populate_got(env):
         got_entry.offset = offset
         offset += env.arch.word_size
         o = env.got_section.addr + got_entry.offset
-        env.full_text[o:o + env.arch.word_size] = got_entry.link_addr.to_bytes(env.arch.word_size, 'little')
+        env.full_text[o:o + env.arch.word_size] = got_entry.link_addr.to_bytes(
+            env.arch.word_size, 'little')
 
     # Create a relocation for each GOT entry
     for got_entry in got_list:
@@ -388,7 +443,9 @@ def populate_got(env):
     # Print out the final GOT
     log(LOG_LEVEL_2, 'GOT: {:08x}'.format(env.got_section.addr))
     for g in got_list:
-        log(LOG_LEVEL_2, '  {:08x} {} -> {}+{:08x}'.format(g.offset, g.name, g.sec_name, g.link_addr))
+        log(LOG_LEVEL_2, '  {:08x} {} -> {}+{:08x}'.format(g.offset, g.name, g.sec_name,
+                                                           g.link_addr))
+
 
 def populate_lit(env):
     log(LOG_LEVEL_2, 'LIT: {:08x}'.format(env.lit_section.addr))
@@ -397,6 +454,7 @@ def populate_lit(env):
         log(LOG_LEVEL_2, '  {:08x} = {:08x}'.format(lit_entry.offset, value))
         o = env.lit_section.addr + lit_entry.offset
         env.full_text[o:o + env.arch.word_size] = value.to_bytes(env.arch.word_size, 'little')
+
 
 def do_relocation_text(env, text_addr, r):
     # Extract relevant info about symbol that's being relocated
@@ -417,9 +475,11 @@ def do_relocation_text(env, text_addr, r):
     log_name = None
 
     if (env.arch.name == 'EM_386' and r_info_type in (R_386_PC32, R_386_PLT32)
-        or env.arch.name == 'EM_X86_64' and r_info_type in (R_X86_64_PC32, R_X86_64_PLT32)
-        or env.arch.name == 'EM_ARM' and r_info_type in (R_ARM_REL32, R_ARM_THM_CALL, R_ARM_THM_JUMP24)
-        or s_bind == 'STB_LOCAL' and env.arch.name == 'EM_XTENSA' and r_info_type == R_XTENSA_32 # not GOT
+            or env.arch.name == 'EM_X86_64' and r_info_type in (R_X86_64_PC32, R_X86_64_PLT32)
+            or env.arch.name == 'EM_ARM'
+            and r_info_type in (R_ARM_REL32, R_ARM_THM_CALL, R_ARM_THM_JUMP24)
+            or s_bind == 'STB_LOCAL' and env.arch.name == 'EM_XTENSA'
+            and r_info_type == R_XTENSA_32 # not GOT
         ):
         # Standard relocation to fixed location within text/rodata
         if hasattr(s, 'resolved'):
@@ -431,10 +491,12 @@ def do_relocation_text(env, text_addr, r):
             raise LinkError('fixed relocation to rodata with rodata referenced via GOT')
 
         if sec.name.startswith('.bss'):
-            raise LinkError('{}: fixed relocation to bss (bss variables can\'t be static)'.format(s.filename))
+            raise LinkError('{}: fixed relocation to bss (bss variables can\'t be static)'.format(
+                s.filename))
 
         if sec.name.startswith('.external'):
-            raise LinkError('{}: fixed relocation to external symbol: {}'.format(s.filename, s.name))
+            raise LinkError('{}: fixed relocation to external symbol: {}'.format(
+                s.filename, s.name))
 
         addr = sec.addr + s['st_value']
         reloc = addr - r_offset + r_addend
@@ -446,16 +508,14 @@ def do_relocation_text(env, text_addr, r):
             reloc_type = 'thumb_b'
 
     elif (env.arch.name == 'EM_386' and r_info_type == R_386_GOTPC
-        or env.arch.name == 'EM_ARM' and r_info_type == R_ARM_BASE_PREL
-        ):
+          or env.arch.name == 'EM_ARM' and r_info_type == R_ARM_BASE_PREL):
         # Relocation to GOT address itself
         assert s.name == '_GLOBAL_OFFSET_TABLE_'
         addr = env.got_section.addr
         reloc = addr - r_offset + r_addend
 
     elif (env.arch.name == 'EM_386' and r_info_type in (R_386_GOT32, R_386_GOT32X)
-        or env.arch.name == 'EM_ARM' and r_info_type == R_ARM_GOT_BREL
-        ):
+          or env.arch.name == 'EM_ARM' and r_info_type == R_ARM_GOT_BREL):
         # Relcation pointing to GOT
         reloc = addr = env.got_entries[s.name].offset
 
@@ -529,6 +589,7 @@ def do_relocation_text(env, text_addr, r):
             log_name = s.name
     log(LOG_LEVEL_3, '  {:08x} {} -> {:08x}'.format(r_offset, log_name, addr))
 
+
 def do_relocation_data(env, text_addr, r):
     s = r.sym
     s_type = s.entry['st_info']['type']
@@ -541,9 +602,9 @@ def do_relocation_data(env, text_addr, r):
         r_addend = 0
 
     if (env.arch.name == 'EM_386' and r_info_type == R_386_32
-        or env.arch.name == 'EM_X86_64' and r_info_type == R_X86_64_64
-        or env.arch.name == 'EM_ARM' and r_info_type == R_ARM_ABS32
-        or env.arch.name == 'EM_XTENSA' and r_info_type == R_XTENSA_32):
+            or env.arch.name == 'EM_X86_64' and r_info_type == R_X86_64_64
+            or env.arch.name == 'EM_ARM' and r_info_type == R_ARM_ABS32
+            or env.arch.name == 'EM_XTENSA' and r_info_type == R_XTENSA_32):
         # Relocation in data.rel.ro to internal/external symbol
         if env.arch.word_size == 4:
             struct_type = '<I'
@@ -579,6 +640,7 @@ def do_relocation_data(env, text_addr, r):
     else:
         # Unknown/unsupported relocation
         assert 0, r_info_type
+
 
 def load_object_file(env, felf):
     with open(felf, 'rb') as f:
@@ -625,12 +687,14 @@ def load_object_file(env, felf):
                 sym.section = sections_shndx[shndx]
                 if sym['st_info']['bind'] == 'STB_GLOBAL':
                     # Defined global symbol
-                    if sym.name in env.known_syms and not sym.name.startswith('__x86.get_pc_thunk.'):
+                    if sym.name in env.known_syms and not sym.name.startswith(
+                            '__x86.get_pc_thunk.'):
                         raise LinkError('duplicate symbol: {}'.format(sym.name))
                     env.known_syms[sym.name] = sym
             elif sym.entry['st_shndx'] == 'SHN_UNDEF' and sym['st_info']['bind'] == 'STB_GLOBAL':
                 # Undefined global symbol, needs resolving
                 env.unresolved_syms.append(sym)
+
 
 def link_objects(env, native_qstr_vals_len, native_qstr_objs_len):
     # Build GOT information
@@ -654,16 +718,21 @@ def link_objects(env, native_qstr_vals_len, native_qstr_objs_len):
         env.sections.insert(1, env.lit_section)
 
     # Create section to contain mp_native_qstr_val_table
-    env.qstr_val_section = Section('.text.QSTR_VAL', bytearray(native_qstr_vals_len * env.arch.qstr_entry_size), env.arch.qstr_entry_size)
+    env.qstr_val_section = Section('.text.QSTR_VAL',
+                                   bytearray(native_qstr_vals_len * env.arch.qstr_entry_size),
+                                   env.arch.qstr_entry_size)
     env.sections.append(env.qstr_val_section)
 
     # Create section to contain mp_native_qstr_obj_table
-    env.qstr_obj_section = Section('.text.QSTR_OBJ', bytearray(native_qstr_objs_len * env.arch.word_size), env.arch.word_size)
+    env.qstr_obj_section = Section('.text.QSTR_OBJ',
+                                   bytearray(native_qstr_objs_len * env.arch.word_size),
+                                   env.arch.word_size)
     env.sections.append(env.qstr_obj_section)
 
     # Resolve unknown symbols
     mp_fun_table_sec = Section('.external.mp_fun_table', b'', 0)
-    fun_table = {key: 67 + idx
+    fun_table = {
+        key: 67 + idx
         for idx, key in enumerate([
             'mp_type_type',
             'mp_type_str',
@@ -724,7 +793,8 @@ def link_objects(env, native_qstr_vals_len, native_qstr_objs_len):
     for sec in env.sections:
         if not sec.reloc:
             continue
-        log(LOG_LEVEL_3, '{}: {} relocations via {}:'.format(sec.filename, sec.name, sec.reloc_name))
+        log(LOG_LEVEL_3, '{}: {} relocations via {}:'.format(sec.filename, sec.name,
+                                                             sec.reloc_name))
         for r in sec.reloc:
             if sec.name.startswith(('.text', '.rodata')):
                 do_relocation_text(env, sec.addr, r)
@@ -733,8 +803,10 @@ def link_objects(env, native_qstr_vals_len, native_qstr_objs_len):
             else:
                 assert 0, sec.name
 
+
 ################################################################################
 # .mpy output
+
 
 class MPYOutput:
     def open(self, fname):
@@ -785,6 +857,7 @@ class MPYOutput:
         if n > 1:
             self.write_uint(n)
 
+
 def build_mpy(env, entry_offset, fmpy, native_qstr_vals, native_qstr_objs):
     # Write jump instruction to start of text
     jump = env.arch.asm_jump(entry_offset)
@@ -803,13 +876,14 @@ def build_mpy(env, entry_offset, fmpy, native_qstr_vals, native_qstr_objs):
     out.open(fmpy)
 
     # MPY: header
-    out.write_bytes(bytearray([
-        ord('M'),
-        MPY_VERSION,
-        env.arch.mpy_feature,
-        MP_SMALL_INT_BITS,
-        QSTR_WINDOW_SIZE,
-    ]))
+    out.write_bytes(
+        bytearray([
+            ord('M'),
+            MPY_VERSION,
+            env.arch.mpy_feature,
+            MP_SMALL_INT_BITS,
+            QSTR_WINDOW_SIZE,
+        ]))
 
     # MPY: kind/len
     out.write_uint(len(env.full_text) << 2 | (MP_CODE_NATIVE_VIPER - MP_CODE_BYTECODE))
@@ -887,8 +961,10 @@ def build_mpy(env, entry_offset, fmpy, native_qstr_vals, native_qstr_objs):
 
     out.close()
 
+
 ################################################################################
 # main
+
 
 def do_preprocess(args):
     if args.output is None:
@@ -896,22 +972,26 @@ def do_preprocess(args):
         args.output = args.files[0][:-1] + 'config.h'
     static_qstrs, qstr_vals, qstr_objs = extract_qstrs(args.files)
     with open(args.output, 'w') as f:
-        print('#include <stdint.h>\n'
+        print(
+            '#include <stdint.h>\n'
             'typedef uintptr_t mp_uint_t;\n'
             'typedef intptr_t mp_int_t;\n'
-            'typedef uintptr_t mp_off_t;', file=f)
+            'typedef uintptr_t mp_off_t;',
+            file=f)
         for i, q in enumerate(static_qstrs):
             print('#define %s (%u)' % (q, i + 1), file=f)
         for i, q in enumerate(sorted(qstr_vals)):
             print('#define %s (mp_native_qstr_val_table[%d])' % (q, i), file=f)
         for i, q in enumerate(sorted(qstr_objs)):
-            print('#define MP_OBJ_NEW_QSTR_%s ((mp_obj_t)mp_native_qstr_obj_table[%d])' % (q, i), file=f)
+            print('#define MP_OBJ_NEW_QSTR_%s ((mp_obj_t)mp_native_qstr_obj_table[%d])' % (q, i),
+                  file=f)
         if args.arch == 'xtensawin':
             qstr_type = 'uint32_t' # esp32 can only read 32-bit values from IRAM
         else:
             qstr_type = 'uint16_t'
         print('extern const {} mp_native_qstr_val_table[];'.format(qstr_type), file=f)
         print('extern const mp_uint_t mp_native_qstr_obj_table[];', file=f)
+
 
 def do_link(args):
     if args.output is None:
@@ -941,6 +1021,7 @@ def do_link(args):
         print('LinkError:', er.args[0])
         sys.exit(1)
 
+
 def main():
     import argparse
     cmd_parser = argparse.ArgumentParser(description='Run scripts on the pyboard.')
@@ -948,7 +1029,10 @@ def main():
     cmd_parser.add_argument('--arch', default='x64', help='architecture')
     cmd_parser.add_argument('--preprocess', action='store_true', help='preprocess source files')
     cmd_parser.add_argument('--qstrs', default=None, help='file defining additional qstrs')
-    cmd_parser.add_argument('--output', '-o', default=None, help='output .mpy file (default to input with .o->.mpy)')
+    cmd_parser.add_argument('--output',
+                            '-o',
+                            default=None,
+                            help='output .mpy file (default to input with .o->.mpy)')
     cmd_parser.add_argument('files', nargs='+', help='input files')
     args = cmd_parser.parse_args()
 
@@ -959,6 +1043,7 @@ def main():
         do_preprocess(args)
     else:
         do_link(args)
+
 
 if __name__ == '__main__':
     main()

--- a/tools/pydfu.py
+++ b/tools/pydfu.py
@@ -3,7 +3,6 @@
 # Copyright (c) 2013/2014 Ibrahim Abdelkader <i.abdalkader@gmail.com>
 # This work is licensed under the MIT license, see the file LICENSE for
 # details.
-
 """This module implements enough functionality to program the STM32F4xx over
 DFU, without requiring dfu-util.
 
@@ -31,29 +30,28 @@ __PID = 0xdf11
 __TIMEOUT = 4000
 
 # DFU commands
-__DFU_DETACH    = 0
-__DFU_DNLOAD    = 1
-__DFU_UPLOAD    = 2
+__DFU_DETACH = 0
+__DFU_DNLOAD = 1
+__DFU_UPLOAD = 2
 __DFU_GETSTATUS = 3
 __DFU_CLRSTATUS = 4
-__DFU_GETSTATE  = 5
-__DFU_ABORT     = 6
+__DFU_GETSTATE = 5
+__DFU_ABORT = 6
 
 # DFU status
-__DFU_STATE_APP_IDLE                 = 0x00
-__DFU_STATE_APP_DETACH               = 0x01
-__DFU_STATE_DFU_IDLE                 = 0x02
-__DFU_STATE_DFU_DOWNLOAD_SYNC        = 0x03
-__DFU_STATE_DFU_DOWNLOAD_BUSY        = 0x04
-__DFU_STATE_DFU_DOWNLOAD_IDLE        = 0x05
-__DFU_STATE_DFU_MANIFEST_SYNC        = 0x06
-__DFU_STATE_DFU_MANIFEST             = 0x07
-__DFU_STATE_DFU_MANIFEST_WAIT_RESET  = 0x08
-__DFU_STATE_DFU_UPLOAD_IDLE          = 0x09
-__DFU_STATE_DFU_ERROR                = 0x0a
+__DFU_STATE_APP_IDLE = 0x00
+__DFU_STATE_APP_DETACH = 0x01
+__DFU_STATE_DFU_IDLE = 0x02
+__DFU_STATE_DFU_DOWNLOAD_SYNC = 0x03
+__DFU_STATE_DFU_DOWNLOAD_BUSY = 0x04
+__DFU_STATE_DFU_DOWNLOAD_IDLE = 0x05
+__DFU_STATE_DFU_MANIFEST_SYNC = 0x06
+__DFU_STATE_DFU_MANIFEST = 0x07
+__DFU_STATE_DFU_MANIFEST_WAIT_RESET = 0x08
+__DFU_STATE_DFU_UPLOAD_IDLE = 0x09
+__DFU_STATE_DFU_ERROR = 0x0a
 
-_DFU_DESCRIPTOR_TYPE                 = 0x21
-
+_DFU_DESCRIPTOR_TYPE = 0x21
 
 # USB device handle
 __dev = None
@@ -82,17 +80,10 @@ else:
 
 def find_dfu_cfg_descr(descr):
     if len(descr) == 9 and descr[0] == 9 and descr[1] == _DFU_DESCRIPTOR_TYPE:
-        nt = collections.namedtuple(
-            'CfgDescr',
-            [
-                'bLength',
-                'bDescriptorType',
-                'bmAttributes',
-                'wDetachTimeOut',
-                'wTransferSize',
-                'bcdDFUVersion'
-            ]
-        )
+        nt = collections.namedtuple('CfgDescr', [
+            'bLength', 'bDescriptorType', 'bmAttributes', 'wDetachTimeOut', 'wTransferSize',
+            'bcdDFUVersion'
+        ])
         return nt(*struct.unpack('<BBBHHH', bytearray(descr)))
     return None
 
@@ -127,8 +118,7 @@ def init():
         status = get_status()
         if status == __DFU_STATE_DFU_IDLE:
             break
-        elif (status == __DFU_STATE_DFU_DOWNLOAD_IDLE
-            or status == __DFU_STATE_DFU_UPLOAD_IDLE):
+        elif (status == __DFU_STATE_DFU_DOWNLOAD_IDLE or status == __DFU_STATE_DFU_UPLOAD_IDLE):
             abort_request()
         else:
             clr_status()
@@ -141,22 +131,19 @@ def abort_request():
 
 def clr_status():
     """Clears any error status (perhaps left over from a previous session)."""
-    __dev.ctrl_transfer(0x21, __DFU_CLRSTATUS, 0, __DFU_INTERFACE,
-                        None, __TIMEOUT)
+    __dev.ctrl_transfer(0x21, __DFU_CLRSTATUS, 0, __DFU_INTERFACE, None, __TIMEOUT)
 
 
 def get_status():
     """Get the status of the last operation."""
-    stat = __dev.ctrl_transfer(0xA1, __DFU_GETSTATUS, 0, __DFU_INTERFACE,
-                               6, 20000)
+    stat = __dev.ctrl_transfer(0xA1, __DFU_GETSTATUS, 0, __DFU_INTERFACE, 6, 20000)
     return stat[4]
 
 
 def mass_erase():
     """Performs a MASS erase (i.e. erases the entire device)."""
     # Send DNLOAD with first byte=0x41
-    __dev.ctrl_transfer(0x21, __DFU_DNLOAD, 0, __DFU_INTERFACE,
-                        '\x41', __TIMEOUT)
+    __dev.ctrl_transfer(0x21, __DFU_DNLOAD, 0, __DFU_INTERFACE, '\x41', __TIMEOUT)
 
     # Execute last command
     if get_status() != __DFU_STATE_DFU_DOWNLOAD_BUSY:
@@ -213,12 +200,10 @@ def write_memory(addr, buf, progress=None, progress_addr=0, progress_size=0):
 
     while xfer_bytes < xfer_total:
         if __verbose and xfer_count % 512 == 0:
-            print('Addr 0x%x %dKBs/%dKBs...' % (xfer_base + xfer_bytes,
-                                                xfer_bytes // 1024,
-                                                xfer_total // 1024))
+            print('Addr 0x%x %dKBs/%dKBs...' %
+                  (xfer_base + xfer_bytes, xfer_bytes // 1024, xfer_total // 1024))
         if progress and xfer_count % 2 == 0:
-            progress(progress_addr, xfer_base + xfer_bytes - progress_addr,
-                     progress_size)
+            progress(progress_addr, xfer_base + xfer_bytes - progress_addr, progress_size)
 
         # Set mem write address
         set_address(xfer_base + xfer_bytes)
@@ -271,8 +256,7 @@ def exit_dfu():
     set_address(0x08000000)
 
     # Send DNLOAD with 0 length to exit DFU
-    __dev.ctrl_transfer(0x21, __DFU_DNLOAD, 0, __DFU_INTERFACE,
-                        None, __TIMEOUT)
+    __dev.ctrl_transfer(0x21, __DFU_DNLOAD, 0, __DFU_INTERFACE, None, __TIMEOUT)
 
     try:
         # Execute last command
@@ -334,8 +318,7 @@ def read_dfu_file(filename):
     #   B   uint8_t     version     1
     #   I   uint32_t    size        Size of the DFU file (without suffix)
     #   B   uint8_t     targets     Number of targets
-    dfu_prefix, data = consume('<5sBIB', data,
-                               'signature version size targets')
+    dfu_prefix, data = consume('<5sBIB', data, 'signature version size targets')
     print('    %(signature)s v%(version)d, image size: %(size)d, '
           'targets: %(targets)d' % dfu_prefix)
     for target_idx in range(dfu_prefix['targets']):
@@ -349,8 +332,7 @@ def read_dfu_file(filename):
         #   255s    char[255]   name        Name of the target
         #   I       uint32_t    size        Size of image (without prefix)
         #   I       uint32_t    elements    Number of elements in the image
-        img_prefix, data = consume('<6sBI255s2I', data,
-                                   'signature altsetting named name '
+        img_prefix, data = consume('<6sBI255s2I', data, 'signature altsetting named name '
                                    'size elements')
         img_prefix['num'] = target_idx
         if img_prefix['named']:
@@ -358,8 +340,7 @@ def read_dfu_file(filename):
         else:
             img_prefix['name'] = ''
         print('    %(signature)s %(num)d, alt setting: %(altsetting)s, '
-              'name: "%(name)s", size: %(size)d, elements: %(elements)d'
-              % img_prefix)
+              'name: "%(name)s", size: %(size)d, elements: %(elements)d' % img_prefix)
 
         target_size = img_prefix['size']
         target_data = data[:target_size]
@@ -373,8 +354,7 @@ def read_dfu_file(filename):
             #   I   uint32_t    element     Size
             elem_prefix, target_data = consume('<2I', target_data, 'addr size')
             elem_prefix['num'] = elem_idx
-            print('      %(num)d, address: 0x%(addr)08x, size: %(size)d'
-                  % elem_prefix)
+            print('      %(num)d, address: 0x%(addr)08x, size: %(size)d' % elem_prefix)
             elem_size = elem_prefix['size']
             elem_data = target_data[:elem_size]
             target_data = target_data[elem_size:]
@@ -395,8 +375,7 @@ def read_dfu_file(filename):
     #   3s  char[3]     ufd         "UFD"
     #   B   uint8_t     len         16
     #   I   uint32_t    crc32       Checksum
-    dfu_suffix = named(struct.unpack('<4H3sBI', data[:16]),
-                       'device product vendor dfu ufd len crc')
+    dfu_suffix = named(struct.unpack('<4H3sBI', data[:16]), 'device product vendor dfu ufd len crc')
     print('    usb: %(vendor)04x:%(product)04x, device: 0x%(device)04x, '
           'dfu: 0x%(dfu)04x, %(ufd)s, %(len)d, 0x%(crc)08x' % dfu_suffix)
     if crc != dfu_suffix['crc']:
@@ -414,12 +393,10 @@ class FilterDFU(object):
     """Class for filtering USB devices to identify devices which are in DFU
     mode.
     """
-
     def __call__(self, device):
         for cfg in device:
             for intf in cfg:
-                return (intf.bInterfaceClass == 0xFE and
-                        intf.bInterfaceSubClass == 1)
+                return (intf.bInterfaceClass == 0xFE and intf.bInterfaceSubClass == 1)
 
 
 def get_dfu_devices(*args, **kwargs):
@@ -429,8 +406,7 @@ def get_dfu_devices(*args, **kwargs):
     """
 
     # Convert to list for compatibility with newer PyUSB
-    return list(usb.core.find(*args, find_all=True,
-                              custom_match=FilterDFU(), **kwargs))
+    return list(usb.core.find(*args, find_all=True, custom_match=FilterDFU(), **kwargs))
 
 
 def get_memory_layout(device):
@@ -463,8 +439,9 @@ def get_memory_layout(device):
                 page_size *= 1024 * 1024
             size = num_pages * page_size
             last_addr = addr + size - 1
-            result.append(named((addr, last_addr, size, num_pages, page_size),
-                          'addr last_addr size num_pages page_size'))
+            result.append(
+                named((addr, last_addr, size, num_pages, page_size),
+                      'addr last_addr size num_pages page_size'))
             addr += size
     return result
 
@@ -476,15 +453,13 @@ def list_dfu_devices(*args, **kwargs):
         print('No DFU capable devices found')
         return
     for device in devices:
-        print('Bus {} Device {:03d}: ID {:04x}:{:04x}'
-              .format(device.bus, device.address,
-                      device.idVendor, device.idProduct))
+        print('Bus {} Device {:03d}: ID {:04x}:{:04x}'.format(device.bus, device.address,
+                                                              device.idVendor, device.idProduct))
         layout = get_memory_layout(device)
         print('Memory Layout')
         for entry in layout:
-            print('    0x{:x} {:2d} pages of {:3d}K bytes'
-                  .format(entry['addr'], entry['num_pages'],
-                          entry['page_size'] // 1024))
+            print('    0x{:x} {:2d} pages of {:3d}K bytes'.format(entry['addr'], entry['num_pages'],
+                                                                  entry['page_size'] // 1024))
 
 
 def write_elements(elements, mass_erase_used, progress=None):
@@ -515,8 +490,7 @@ def write_elements(elements, mass_erase_used, progress=None):
                             write_size = page_addr + page_size - addr
                         page_erase(page_addr)
                         break
-            write_memory(addr, data[:write_size], progress,
-                         elem_addr, elem_size)
+            write_memory(addr, data[:write_size], progress, elem_addr, elem_size)
             data = data[write_size:]
             addr += write_size
             size -= write_size
@@ -528,13 +502,13 @@ def cli_progress(addr, offset, size):
     """Prints a progress report suitable for use on the command line."""
     width = 25
     done = offset * width // size
-    print('\r0x{:08x} {:7d} [{}{}] {:3d}% '
-          .format(addr, size, '=' * done, ' ' * (width - done),
-                  offset * 100 // size), end='')
+    print('\r0x{:08x} {:7d} [{}{}] {:3d}% '.format(addr, size, '=' * done, ' ' * (width - done),
+                                                   offset * 100 // size),
+          end='')
     try:
         sys.stdout.flush()
     except OSError:
-        pass    # Ignore Windows CLI "WinError 87" on Python 3.6
+        pass # Ignore Windows CLI "WinError 87" on Python 3.6
     if offset == size:
         print('')
 
@@ -544,30 +518,26 @@ def main():
     global __verbose
     # Parse CMD args
     parser = argparse.ArgumentParser(description='DFU Python Util')
-    parser.add_argument(
-        '-l', '--list',
-        help='list available DFU devices',
-        action='store_true',
-        default=False
-    )
-    parser.add_argument(
-        '-m', '--mass-erase',
-        help='mass erase device',
-        action='store_true',
-        default=False
-    )
-    parser.add_argument(
-        '-u', '--upload',
-        help='read file from DFU device',
-        dest='path',
-        default=False
-    )
-    parser.add_argument(
-        '-v', '--verbose',
-        help='increase output verbosity',
-        action='store_true',
-        default=False
-    )
+    parser.add_argument('-l',
+                        '--list',
+                        help='list available DFU devices',
+                        action='store_true',
+                        default=False)
+    parser.add_argument('-m',
+                        '--mass-erase',
+                        help='mass erase device',
+                        action='store_true',
+                        default=False)
+    parser.add_argument('-u',
+                        '--upload',
+                        help='read file from DFU device',
+                        dest='path',
+                        default=False)
+    parser.add_argument('-v',
+                        '--verbose',
+                        help='increase output verbosity',
+                        action='store_true',
+                        default=False)
     args = parser.parse_args()
 
     __verbose = args.verbose
@@ -594,6 +564,7 @@ def main():
         return
 
     print('No command specified')
+
 
 if __name__ == '__main__':
     main()

--- a/tools/tinytest-codegen.py
+++ b/tools/tinytest-codegen.py
@@ -18,8 +18,10 @@ def escape(s):
     }
     return "\"\"\n\"{}\"".format(''.join([lookup[x] if x in lookup else x for x in s]))
 
+
 def chew_filename(t):
-    return { 'func': "test_{}_fn".format(sub(r'/|\.|-', '_', t)), 'desc': t }
+    return {'func': "test_{}_fn".format(sub(r'/|\.|-', '_', t)), 'desc': t}
+
 
 def script_to_map(test_file):
     r = {"name": chew_filename(test_file)["func"]}
@@ -29,34 +31,33 @@ def script_to_map(test_file):
         r["output"] = escape(f.read())
     return r
 
-test_function = (
-    "void {name}(void* data) {{\n"
-    "  static const char pystr[] = {script};\n"
-    "  static const char exp[] = {output};\n"
-    '  printf("\\n");\n'
-    "  upytest_set_expected_output(exp, sizeof(exp) - 1);\n"
-    "  upytest_execute_test(pystr);\n"
-    '  printf("result: ");\n'
-    "}}"
-)
 
-testcase_struct = (
-    "struct testcase_t {name}_tests[] = {{\n{body}\n  END_OF_TESTCASES\n}};"
-)
-testcase_member = (
-    "  {{ \"{desc}\", {func}, TT_ENABLED_, 0, 0 }},"
-)
+test_function = ("void {name}(void* data) {{\n"
+                 "  static const char pystr[] = {script};\n"
+                 "  static const char exp[] = {output};\n"
+                 '  printf("\\n");\n'
+                 "  upytest_set_expected_output(exp, sizeof(exp) - 1);\n"
+                 "  upytest_execute_test(pystr);\n"
+                 '  printf("result: ");\n'
+                 "}}")
 
-testgroup_struct = (
-    "struct testgroup_t groups[] = {{\n{body}\n  END_OF_GROUPS\n}};"
-)
-testgroup_member = (
-    "  {{ \"{name}\", {name}_tests }},"
-)
+testcase_struct = ("struct testcase_t {name}_tests[] = {{\n{body}\n  END_OF_TESTCASES\n}};")
+testcase_member = ("  {{ \"{desc}\", {func}, TT_ENABLED_, 0, 0 }},")
+
+testgroup_struct = ("struct testgroup_t groups[] = {{\n{body}\n  END_OF_GROUPS\n}};")
+testgroup_member = ("  {{ \"{name}\", {name}_tests }},")
 
 ## XXX: may be we could have `--without <groups>` argument...
 # currently these tests are selected because they pass on qemu-arm
-test_dirs = ('basics', 'micropython', 'misc', 'extmod', 'float', 'inlineasm', 'qemu-arm',) # 'import', 'io',)
+test_dirs = (
+    'basics',
+    'micropython',
+    'misc',
+    'extmod',
+    'float',
+    'inlineasm',
+    'qemu-arm',
+) # 'import', 'io',)
 exclude_tests = (
     # pattern matching in .exp
     'basics/bytes_compare3.py',
@@ -68,16 +69,21 @@ exclude_tests = (
     # doesn't output to python stdout
     'extmod/ure_debug.py',
     'extmod/vfs_basic.py',
-    'extmod/vfs_fat_ramdisk.py', 'extmod/vfs_fat_fileio.py',
-    'extmod/vfs_fat_fsusermount.py', 'extmod/vfs_fat_oldproto.py',
+    'extmod/vfs_fat_ramdisk.py',
+    'extmod/vfs_fat_fileio.py',
+    'extmod/vfs_fat_fsusermount.py',
+    'extmod/vfs_fat_oldproto.py',
     # rounding issues
     'float/float_divmod.py',
     # requires double precision floating point to work
     'float/float2int_doubleprec_intbig.py',
     'float/float_parse_doubleprec.py',
     # inline asm FP tests (require Cortex-M4)
-    'inlineasm/asmfpaddsub.py', 'inlineasm/asmfpcmp.py', 'inlineasm/asmfpldrstr.py',
-    'inlineasm/asmfpmuldiv.py','inlineasm/asmfpsqrt.py',
+    'inlineasm/asmfpaddsub.py',
+    'inlineasm/asmfpcmp.py',
+    'inlineasm/asmfpldrstr.py',
+    'inlineasm/asmfpmuldiv.py',
+    'inlineasm/asmfpsqrt.py',
     # different filename in output
     'micropython/emg_exc.py',
     'micropython/heapalloc_traceback.py',
@@ -94,7 +100,8 @@ exclude_tests = (
 output = []
 tests = []
 
-argparser = argparse.ArgumentParser(description='Convert native MicroPython tests to tinytest/upytesthelper C code')
+argparser = argparse.ArgumentParser(
+    description='Convert native MicroPython tests to tinytest/upytesthelper C code')
 argparser.add_argument('--stdin', action="store_true", help='read list of tests from stdin')
 args = argparser.parse_args()
 

--- a/tools/upip.py
+++ b/tools/upip.py
@@ -14,7 +14,6 @@ import uzlib
 import upip_utarfile as tarfile
 gc.collect()
 
-
 debug = False
 index_urls = ["https://micropython.org/pi", "https://pypi.org/pypi"]
 install_path = None
@@ -23,8 +22,10 @@ gzdict_sz = 16 + 15
 
 file_buf = bytearray(512)
 
+
 class NotFoundError(Exception):
     pass
+
 
 def op_split(path):
     if path == "":
@@ -37,8 +38,10 @@ def op_split(path):
         head = "/"
     return (head, r[1])
 
+
 def op_basename(path):
     return op_split(path)[1]
+
 
 # Expects *file* name
 def _makedirs(name, mode=0o777):
@@ -70,6 +73,7 @@ def save_file(fname, subf):
                 break
             outf.write(file_buf, sz)
 
+
 def install_tar(f, prefix):
     meta = {}
     for info in f:
@@ -82,14 +86,14 @@ def install_tar(f, prefix):
 
         save = True
         for p in ("setup.", "PKG-INFO", "README"):
-                #print(fname, p)
-                if fname.startswith(p) or ".egg-info" in fname:
-                    if fname.endswith("/requires.txt"):
-                        meta["deps"] = f.extractfile(info).read()
-                    save = False
-                    if debug:
-                        print("Skipping", fname)
-                    break
+            #print(fname, p)
+            if fname.startswith(p) or ".egg-info" in fname:
+                if fname.endswith("/requires.txt"):
+                    meta["deps"] = f.extractfile(info).read()
+                save = False
+                if debug:
+                    print("Skipping", fname)
+                break
 
         if save:
             outfname = prefix + fname
@@ -101,15 +105,19 @@ def install_tar(f, prefix):
                 save_file(outfname, subf)
     return meta
 
+
 def expandhome(s):
     if "~/" in s:
         h = os.getenv("HOME")
         s = s.replace("~/", h + "/")
     return s
 
+
 import ussl
 import usocket
 warn_ussl = True
+
+
 def url_open(url):
     global warn_ussl
 
@@ -175,6 +183,7 @@ def fatal(msg, exc=None):
         raise exc
     sys.exit(1)
 
+
 def install_pkg(pkg_spec, install_path):
     data = get_pkg_metadata(pkg_spec)
 
@@ -197,6 +206,7 @@ def install_pkg(pkg_spec, install_path):
     del f2
     gc.collect()
     return meta
+
 
 def install(to_install, install_path=None):
     # Calculate gzip dictionary size to use
@@ -230,9 +240,9 @@ def install(to_install, install_path=None):
                 deps = deps.decode("utf-8").split("\n")
                 to_install.extend(deps)
     except Exception as e:
-        print("Error installing '{}': {}, packages may be partially installed".format(
-                pkg_spec, e),
-            file=sys.stderr)
+        print("Error installing '{}': {}, packages may be partially installed".format(pkg_spec, e),
+              file=sys.stderr)
+
 
 def get_install_path():
     global install_path
@@ -242,12 +252,14 @@ def get_install_path():
     install_path = expandhome(install_path)
     return install_path
 
+
 def cleanup():
     for fname in cleanup_files:
         try:
             os.unlink(fname)
         except OSError:
             print("Warning: Cannot delete " + fname)
+
 
 def help():
     print("""\
@@ -264,6 +276,7 @@ supports that).""")
 Note: only MicroPython packages (usually, named micropython-*) are supported
 for installation, upip does not support arbitrary code in setup.py.
 """)
+
 
 def main():
     global debug

--- a/tools/upip_utarfile.py
+++ b/tools/upip_utarfile.py
@@ -9,11 +9,12 @@ TAR_HEADER = {
 DIRTYPE = "dir"
 REGTYPE = "file"
 
+
 def roundup(val, align):
     return (val + align - 1) & ~(align - 1)
 
-class FileSection:
 
+class FileSection:
     def __init__(self, f, content_len, aligned_len):
         self.f = f
         self.content_len = content_len
@@ -47,13 +48,13 @@ class FileSection:
                 self.f.readinto(buf, s)
                 sz -= s
 
-class TarInfo:
 
+class TarInfo:
     def __str__(self):
         return "TarInfo(%r, %s, %d)" % (self.name, self.type, self.size)
 
-class TarFile:
 
+class TarFile:
     def __init__(self, name=None, fileobj=None):
         if fileobj:
             self.f = fileobj
@@ -62,24 +63,24 @@ class TarFile:
         self.subf = None
 
     def next(self):
-            if self.subf:
-                self.subf.skip()
-            buf = self.f.read(512)
-            if not buf:
-                return None
+        if self.subf:
+            self.subf.skip()
+        buf = self.f.read(512)
+        if not buf:
+            return None
 
-            h = uctypes.struct(uctypes.addressof(buf), TAR_HEADER, uctypes.LITTLE_ENDIAN)
+        h = uctypes.struct(uctypes.addressof(buf), TAR_HEADER, uctypes.LITTLE_ENDIAN)
 
-            # Empty block means end of archive
-            if h.name[0] == 0:
-                return None
+        # Empty block means end of archive
+        if h.name[0] == 0:
+            return None
 
-            d = TarInfo()
-            d.name = str(h.name, "utf-8").rstrip("\0")
-            d.size = int(bytes(h.size), 8)
-            d.type = [REGTYPE, DIRTYPE][d.name[-1] == "/"]
-            self.subf = d.subf = FileSection(self.f, d.size, roundup(d.size, 512))
-            return d
+        d = TarInfo()
+        d.name = str(h.name, "utf-8").rstrip("\0")
+        d.size = int(bytes(h.size), 8)
+        d.type = [REGTYPE, DIRTYPE][d.name[-1] == "/"]
+        self.subf = d.subf = FileSection(self.f, d.size, roundup(d.size, 512))
+        return d
 
     def __iter__(self):
         return self


### PR DESCRIPTION
Per discussion in #4223 here's an attempt to format the Python code (but not tests) using yapf.

Style is pep8 with a line length of 100.  But the line length could be decreased (eg to 88 to match black) without affecting much of the code.