### PR TITLE
Apply black to format all Python code

### DIFF
--- a/drivers/dht/dht.py
+++ b/drivers/dht/dht.py
@@ -6,6 +6,7 @@ try:
 except:
     from pyb import dht_readinto
 
+
 class DHTBase:
     def __init__(self, pin):
         self.pin = pin
@@ -14,8 +15,9 @@ class DHTBase:
     def measure(self):
         buf = self.buf
         dht_readinto(self.pin, buf)
-        if (buf[0] + buf[1] + buf[2] + buf[3]) & 0xff != buf[4]:
+        if (buf[0] + buf[1] + buf[2] + buf[3]) & 0xFF != buf[4]:
             raise Exception("checksum error")
+
 
 class DHT11(DHTBase):
     def humidity(self):
@@ -24,12 +26,13 @@ class DHT11(DHTBase):
     def temperature(self):
         return self.buf[2]
 
+
 class DHT22(DHTBase):
     def humidity(self):
         return (self.buf[0] << 8 | self.buf[1]) * 0.1
 
     def temperature(self):
-        t = ((self.buf[2] & 0x7f) << 8 | self.buf[3]) * 0.1
+        t = ((self.buf[2] & 0x7F) << 8 | self.buf[3]) * 0.1
         if self.buf[2] & 0x80:
             t = -t
         return t

--- a/drivers/display/lcd160cr_test.py
+++ b/drivers/display/lcd160cr_test.py
@@ -3,10 +3,12 @@
 
 import time, math, framebuf, lcd160cr
 
+
 def get_lcd(lcd):
     if type(lcd) is str:
         lcd = lcd160cr.LCD160CR(lcd)
     return lcd
+
 
 def show_adc(lcd, adc):
     data = [adc.read_core_temp(), adc.read_core_vbat(), 3.3]
@@ -21,7 +23,7 @@ def show_adc(lcd, adc):
             lcd.set_pos(0, 100 + i * 16)
         else:
             lcd.set_font(2, trans=1)
-            lcd.set_pos(0, lcd.h-60 + i * 16)
+            lcd.set_pos(0, lcd.h - 60 + i * 16)
         lcd.write('%4s: ' % ('TEMP', 'VBAT', 'VREF')[i])
         if i > 0:
             s = '%6.3fV' % data[i]
@@ -31,14 +33,16 @@ def show_adc(lcd, adc):
             lcd.set_font(1, bold=0, scale=1)
         else:
             lcd.set_font(1, bold=0, scale=1, trans=1)
-            lcd.set_pos(45, lcd.h-60 + i * 16)
+            lcd.set_pos(45, lcd.h - 60 + i * 16)
         lcd.write(s)
+
 
 def test_features(lcd, orient=lcd160cr.PORTRAIT):
     # if we run on pyboard then use ADC and RTC features
     try:
         import pyb
-        adc = pyb.ADCAll(12, 0xf0000)
+
+        adc = pyb.ADCAll(12, 0xF0000)
         rtc = pyb.RTC()
     except:
         adc = None
@@ -53,7 +57,7 @@ def test_features(lcd, orient=lcd160cr.PORTRAIT):
     # create M-logo
     mlogo = framebuf.FrameBuffer(bytearray(17 * 17 * 2), 17, 17, framebuf.RGB565)
     mlogo.fill(0)
-    mlogo.fill_rect(1, 1, 15, 15, 0xffffff)
+    mlogo.fill_rect(1, 1, 15, 15, 0xFFFFFF)
     mlogo.vline(4, 4, 12, 0)
     mlogo.vline(8, 1, 12, 0)
     mlogo.vline(12, 4, 12, 0)
@@ -80,15 +84,18 @@ def test_features(lcd, orient=lcd160cr.PORTRAIT):
             if tx2 >= 0 and ty2 >= 0 and tx2 < w and ty2 < h:
                 tx, ty = tx2, ty2
         else:
-             tx = (tx + 1) % w
-             ty = (ty + 1) % h
+            tx = (tx + 1) % w
+            ty = (ty + 1) % h
 
         # create and show the inline framebuf
         fbuf.fill(lcd.rgb(128 + int(64 * math.cos(0.1 * i)), 128, 192))
-        fbuf.line(w // 2, h // 2,
+        fbuf.line(
+            w // 2,
+            h // 2,
             w // 2 + int(40 * math.cos(0.2 * i)),
             h // 2 + int(40 * math.sin(0.2 * i)),
-            lcd.rgb(128, 255, 64))
+            lcd.rgb(128, 255, 64),
+        )
         fbuf.hline(0, ty, w, lcd.rgb(64, 64, 64))
         fbuf.vline(tx, 0, h, lcd.rgb(64, 64, 64))
         fbuf.rect(tx - 3, ty - 3, 7, 7, lcd.rgb(64, 64, 64))
@@ -97,9 +104,12 @@ def test_features(lcd, orient=lcd160cr.PORTRAIT):
             y = h // 2 - 8 + int(32 * math.sin(0.05 * i + phase))
             fbuf.blit(mlogo, x, y)
         for j in range(-3, 3):
-            fbuf.text('MicroPython',
-                5, h // 2 + 9 * j + int(20 * math.sin(0.1 * (i + j))),
-                lcd.rgb(128 + 10 * j, 0, 128 - 10 * j))
+            fbuf.text(
+                'MicroPython',
+                5,
+                h // 2 + 9 * j + int(20 * math.sin(0.1 * (i + j))),
+                lcd.rgb(128 + 10 * j, 0, 128 - 10 * j),
+            )
         lcd.show_framebuf(fbuf)
 
         # show results from the ADC
@@ -111,7 +121,10 @@ def test_features(lcd, orient=lcd160cr.PORTRAIT):
             lcd.set_pos(2, 0)
             lcd.set_font(1)
             t = rtc.datetime()
-            lcd.write('%4d-%02d-%02d %2d:%02d:%02d.%01d' % (t[0], t[1], t[2], t[4], t[5], t[6], t[7] // 100000))
+            lcd.write(
+                '%4d-%02d-%02d %2d:%02d:%02d.%01d'
+                % (t[0], t[1], t[2], t[4], t[5], t[6], t[7] // 100000)
+            )
 
         # compute the frame rate
         t1 = time.ticks_us()
@@ -122,11 +135,12 @@ def test_features(lcd, orient=lcd160cr.PORTRAIT):
         lcd.set_pos(2, 9)
         lcd.write('%.2f fps' % (1000000 / dt))
 
+
 def test_mandel(lcd, orient=lcd160cr.PORTRAIT):
     # set orientation and clear screen
     lcd = get_lcd(lcd)
     lcd.set_orient(orient)
-    lcd.set_pen(0, 0xffff)
+    lcd.set_pen(0, 0xFFFF)
     lcd.erase()
 
     # function to compute Mandelbrot pixels
@@ -148,23 +162,25 @@ def test_mandel(lcd, orient=lcd160cr.PORTRAIT):
     spi = lcd.fast_spi()
 
     # draw the Mandelbrot set line-by-line
-    hh = ((h - 1) / 3.2)
-    ww = ((w - 1) / 2.4)
+    hh = (h - 1) / 3.2
+    ww = (w - 1) / 2.4
     for v in range(h):
         for u in range(w):
             c = in_set((v / hh - 2.3) + (u / ww - 1.2) * 1j)
             if c < 16:
                 rgb = c << 12 | c << 6
             else:
-                rgb = 0xf800 | c << 6
+                rgb = 0xF800 | c << 6
             line[2 * u] = rgb
             line[2 * u + 1] = rgb >> 8
         spi.write(line)
+
 
 def test_all(lcd, orient=lcd160cr.PORTRAIT):
     lcd = get_lcd(lcd)
     test_features(lcd, orient)
     test_mandel(lcd, orient)
+
 
 print('To run all tests: test_all(<lcd>)')
 print('Individual tests are: test_features, test_mandel')

--- a/drivers/display/ssd1306.py
+++ b/drivers/display/ssd1306.py
@@ -5,23 +5,23 @@ import framebuf
 
 
 # register definitions
-SET_CONTRAST        = const(0x81)
-SET_ENTIRE_ON       = const(0xa4)
-SET_NORM_INV        = const(0xa6)
-SET_DISP            = const(0xae)
-SET_MEM_ADDR        = const(0x20)
-SET_COL_ADDR        = const(0x21)
-SET_PAGE_ADDR       = const(0x22)
+SET_CONTRAST = const(0x81)
+SET_ENTIRE_ON = const(0xA4)
+SET_NORM_INV = const(0xA6)
+SET_DISP = const(0xAE)
+SET_MEM_ADDR = const(0x20)
+SET_COL_ADDR = const(0x21)
+SET_PAGE_ADDR = const(0x22)
 SET_DISP_START_LINE = const(0x40)
-SET_SEG_REMAP       = const(0xa0)
-SET_MUX_RATIO       = const(0xa8)
-SET_COM_OUT_DIR     = const(0xc0)
-SET_DISP_OFFSET     = const(0xd3)
-SET_COM_PIN_CFG     = const(0xda)
-SET_DISP_CLK_DIV    = const(0xd5)
-SET_PRECHARGE       = const(0xd9)
-SET_VCOM_DESEL      = const(0xdb)
-SET_CHARGE_PUMP     = const(0x8d)
+SET_SEG_REMAP = const(0xA0)
+SET_MUX_RATIO = const(0xA8)
+SET_COM_OUT_DIR = const(0xC0)
+SET_DISP_OFFSET = const(0xD3)
+SET_COM_PIN_CFG = const(0xDA)
+SET_DISP_CLK_DIV = const(0xD5)
+SET_PRECHARGE = const(0xD9)
+SET_VCOM_DESEL = const(0xDB)
+SET_CHARGE_PUMP = const(0x8D)
 
 # Subclassing FrameBuffer provides support for graphics primitives
 # http://docs.micropython.org/en/latest/pyboard/library/framebuf.html
@@ -37,27 +37,37 @@ class SSD1306(framebuf.FrameBuffer):
 
     def init_display(self):
         for cmd in (
-            SET_DISP | 0x00, # off
+            SET_DISP | 0x00,  # off
             # address setting
-            SET_MEM_ADDR, 0x00, # horizontal
+            SET_MEM_ADDR,
+            0x00,  # horizontal
             # resolution and layout
             SET_DISP_START_LINE | 0x00,
-            SET_SEG_REMAP | 0x01, # column addr 127 mapped to SEG0
-            SET_MUX_RATIO, self.height - 1,
-            SET_COM_OUT_DIR | 0x08, # scan from COM[N] to COM0
-            SET_DISP_OFFSET, 0x00,
-            SET_COM_PIN_CFG, 0x02 if self.height == 32 else 0x12,
+            SET_SEG_REMAP | 0x01,  # column addr 127 mapped to SEG0
+            SET_MUX_RATIO,
+            self.height - 1,
+            SET_COM_OUT_DIR | 0x08,  # scan from COM[N] to COM0
+            SET_DISP_OFFSET,
+            0x00,
+            SET_COM_PIN_CFG,
+            0x02 if self.height == 32 else 0x12,
             # timing and driving scheme
-            SET_DISP_CLK_DIV, 0x80,
-            SET_PRECHARGE, 0x22 if self.external_vcc else 0xf1,
-            SET_VCOM_DESEL, 0x30, # 0.83*Vcc
+            SET_DISP_CLK_DIV,
+            0x80,
+            SET_PRECHARGE,
+            0x22 if self.external_vcc else 0xF1,
+            SET_VCOM_DESEL,
+            0x30,  # 0.83*Vcc
             # display
-            SET_CONTRAST, 0xff, # maximum
-            SET_ENTIRE_ON, # output follows RAM contents
-            SET_NORM_INV, # not inverted
+            SET_CONTRAST,
+            0xFF,  # maximum
+            SET_ENTIRE_ON,  # output follows RAM contents
+            SET_NORM_INV,  # not inverted
             # charge pump
-            SET_CHARGE_PUMP, 0x10 if self.external_vcc else 0x14,
-            SET_DISP | 0x01): # on
+            SET_CHARGE_PUMP,
+            0x10 if self.external_vcc else 0x14,
+            SET_DISP | 0x01,
+        ):  # on
             self.write_cmd(cmd)
         self.fill(0)
         self.show()
@@ -92,15 +102,15 @@ class SSD1306(framebuf.FrameBuffer):
 
 
 class SSD1306_I2C(SSD1306):
-    def __init__(self, width, height, i2c, addr=0x3c, external_vcc=False):
+    def __init__(self, width, height, i2c, addr=0x3C, external_vcc=False):
         self.i2c = i2c
         self.addr = addr
         self.temp = bytearray(2)
-        self.write_list = [b'\x40', None] # Co=0, D/C#=1
+        self.write_list = [b'\x40', None]  # Co=0, D/C#=1
         super().__init__(width, height, external_vcc)
 
     def write_cmd(self, cmd):
-        self.temp[0] = 0x80 # Co=1, D/C#=0
+        self.temp[0] = 0x80  # Co=1, D/C#=0
         self.temp[1] = cmd
         self.i2c.writeto(self.addr, self.temp)
 
@@ -120,6 +130,7 @@ class SSD1306_SPI(SSD1306):
         self.res = res
         self.cs = cs
         import time
+
         self.res(1)
         time.sleep_ms(1)
         self.res(0)

--- a/drivers/nrf24l01/nrf24l01.py
+++ b/drivers/nrf24l01/nrf24l01.py
@@ -5,49 +5,50 @@ from micropython import const
 import utime
 
 # nRF24L01+ registers
-CONFIG      = const(0x00)
-EN_RXADDR   = const(0x02)
-SETUP_AW    = const(0x03)
-SETUP_RETR  = const(0x04)
-RF_CH       = const(0x05)
-RF_SETUP    = const(0x06)
-STATUS      = const(0x07)
-RX_ADDR_P0  = const(0x0a)
-TX_ADDR     = const(0x10)
-RX_PW_P0    = const(0x11)
+CONFIG = const(0x00)
+EN_RXADDR = const(0x02)
+SETUP_AW = const(0x03)
+SETUP_RETR = const(0x04)
+RF_CH = const(0x05)
+RF_SETUP = const(0x06)
+STATUS = const(0x07)
+RX_ADDR_P0 = const(0x0A)
+TX_ADDR = const(0x10)
+RX_PW_P0 = const(0x11)
 FIFO_STATUS = const(0x17)
-DYNPD	    = const(0x1c)
+DYNPD = const(0x1C)
 
 # CONFIG register
-EN_CRC      = const(0x08) # enable CRC
-CRCO        = const(0x04) # CRC encoding scheme; 0=1 byte, 1=2 bytes
-PWR_UP      = const(0x02) # 1=power up, 0=power down
-PRIM_RX     = const(0x01) # RX/TX control; 0=PTX, 1=PRX
+EN_CRC = const(0x08)  # enable CRC
+CRCO = const(0x04)  # CRC encoding scheme; 0=1 byte, 1=2 bytes
+PWR_UP = const(0x02)  # 1=power up, 0=power down
+PRIM_RX = const(0x01)  # RX/TX control; 0=PTX, 1=PRX
 
 # RF_SETUP register
-POWER_0     = const(0x00) # -18 dBm
-POWER_1     = const(0x02) # -12 dBm
-POWER_2     = const(0x04) # -6 dBm
-POWER_3     = const(0x06) # 0 dBm
-SPEED_1M    = const(0x00)
-SPEED_2M    = const(0x08)
-SPEED_250K  = const(0x20)
+POWER_0 = const(0x00)  # -18 dBm
+POWER_1 = const(0x02)  # -12 dBm
+POWER_2 = const(0x04)  # -6 dBm
+POWER_3 = const(0x06)  # 0 dBm
+SPEED_1M = const(0x00)
+SPEED_2M = const(0x08)
+SPEED_250K = const(0x20)
 
 # STATUS register
-RX_DR       = const(0x40) # RX data ready; write 1 to clear
-TX_DS       = const(0x20) # TX data sent; write 1 to clear
-MAX_RT      = const(0x10) # max retransmits reached; write 1 to clear
+RX_DR = const(0x40)  # RX data ready; write 1 to clear
+TX_DS = const(0x20)  # TX data sent; write 1 to clear
+MAX_RT = const(0x10)  # max retransmits reached; write 1 to clear
 
 # FIFO_STATUS register
-RX_EMPTY    = const(0x01) # 1 if RX FIFO is empty
+RX_EMPTY = const(0x01)  # 1 if RX FIFO is empty
 
 # constants for instructions
-R_RX_PL_WID  = const(0x60) # read RX payload width
-R_RX_PAYLOAD = const(0x61) # read RX payload
-W_TX_PAYLOAD = const(0xa0) # write TX payload
-FLUSH_TX     = const(0xe1) # flush TX FIFO
-FLUSH_RX     = const(0xe2) # flush RX FIFO
-NOP          = const(0xff) # use to read STATUS register
+R_RX_PL_WID = const(0x60)  # read RX payload width
+R_RX_PAYLOAD = const(0x61)  # read RX payload
+W_TX_PAYLOAD = const(0xA0)  # write TX payload
+FLUSH_TX = const(0xE1)  # flush TX FIFO
+FLUSH_RX = const(0xE2)  # flush RX FIFO
+NOP = const(0xFF)  # use to read STATUS register
+
 
 class NRF24L01:
     def __init__(self, spi, cs, ce, channel=46, payload_size=16):
@@ -84,7 +85,7 @@ class NRF24L01:
         self.reg_write(SETUP_RETR, (6 << 4) | 8)
 
         # set rf power and speed
-        self.set_power_speed(POWER_3, SPEED_250K) # Best for point to point links
+        self.set_power_speed(POWER_3, SPEED_250K)  # Best for point to point links
 
         # init CRC
         self.set_crc(2)
@@ -218,7 +219,7 @@ class NRF24L01:
         start = utime.ticks_ms()
         result = None
         while result is None and utime.ticks_diff(utime.ticks_ms(), start) < timeout:
-            result = self.send_done() # 1 == success, 2 == fail
+            result = self.send_done()  # 1 == success, 2 == fail
         if result == 2:
             raise OSError("send failed")
 
@@ -232,18 +233,18 @@ class NRF24L01:
         self.spi.readinto(self.buf, W_TX_PAYLOAD)
         self.spi.write(buf)
         if len(buf) < self.payload_size:
-            self.spi.write(b'\x00' * (self.payload_size - len(buf))) # pad out data
+            self.spi.write(b'\x00' * (self.payload_size - len(buf)))  # pad out data
         self.cs(1)
 
         # enable the chip so it can send the data
         self.ce(1)
-        utime.sleep_us(15) # needs to be >10us
+        utime.sleep_us(15)  # needs to be >10us
         self.ce(0)
 
     # returns None if send still in progress, 1 for success, 2 for fail
     def send_done(self):
         if not (self.reg_read(STATUS) & (TX_DS | MAX_RT)):
-            return None # tx not finished
+            return None  # tx not finished
 
         # either finished or failed: get and clear status flags, power down
         status = self.reg_write(STATUS, RX_DR | TX_DS | MAX_RT)

--- a/drivers/nrf24l01/nrf24l01test.py
+++ b/drivers/nrf24l01/nrf24l01test.py
@@ -27,6 +27,7 @@ else:
 # 0xf0f0f0f0e1, 0xf0f0f0f0d2
 pipes = (b'\xe1\xf0\xf0\xf0\xf0', b'\xd2\xf0\xf0\xf0\xf0')
 
+
 def master():
     csn = Pin(cfg['csn'], mode=Pin.OUT, value=1)
     ce = Pin(cfg['ce'], mode=Pin.OUT, value=0)
@@ -51,7 +52,7 @@ def master():
         # stop listening and send packet
         nrf.stop_listening()
         millis = utime.ticks_ms()
-        led_state = max(1, (led_state << 1) & 0x0f)
+        led_state = max(1, (led_state << 1) & 0x0F)
         print('sending:', millis, led_state)
         try:
             nrf.send(struct.pack('ii', millis, led_state))
@@ -74,16 +75,26 @@ def master():
 
         else:
             # recv packet
-            got_millis, = struct.unpack('i', nrf.recv())
+            (got_millis,) = struct.unpack('i', nrf.recv())
 
             # print response and round-trip delay
-            print('got response:', got_millis, '(delay', utime.ticks_diff(utime.ticks_ms(), got_millis), 'ms)')
+            print(
+                'got response:',
+                got_millis,
+                '(delay',
+                utime.ticks_diff(utime.ticks_ms(), got_millis),
+                'ms)',
+            )
             num_successes += 1
 
         # delay then loop
         utime.sleep_ms(250)
 
-    print('master finished sending; successes=%d, failures=%d' % (num_successes, num_failures))
+    print(
+        'master finished sending; successes=%d, failures=%d'
+        % (num_successes, num_failures)
+    )
+
 
 def slave():
     csn = Pin(cfg['csn'], mode=Pin.OUT, value=1)
@@ -124,8 +135,10 @@ def slave():
             print('sent response')
             nrf.start_listening()
 
+
 try:
     import pyb
+
     leds = [pyb.LED(i + 1) for i in range(4)]
 except:
     leds = []

--- a/drivers/onewire/ds18x20.py
+++ b/drivers/onewire/ds18x20.py
@@ -4,8 +4,9 @@
 from micropython import const
 
 _CONVERT = const(0x44)
-_RD_SCRATCH = const(0xbe)
-_WR_SCRATCH = const(0x4e)
+_RD_SCRATCH = const(0xBE)
+_WR_SCRATCH = const(0x4E)
+
 
 class DS18X20:
     def __init__(self, onewire):
@@ -40,12 +41,12 @@ class DS18X20:
         if rom[0] == 0x10:
             if buf[1]:
                 t = buf[0] >> 1 | 0x80
-                t = -((~t + 1) & 0xff)
+                t = -((~t + 1) & 0xFF)
             else:
                 t = buf[0] >> 1
             return t - 0.25 + (buf[7] - buf[6]) / buf[7]
         else:
             t = buf[1] << 8 | buf[0]
-            if t & 0x8000: # sign bit set
-                t = -((t ^ 0xffff) + 1)
+            if t & 0x8000:  # sign bit set
+                t = -((t ^ 0xFFFF) + 1)
             return t / 16

--- a/drivers/onewire/onewire.py
+++ b/drivers/onewire/onewire.py
@@ -4,13 +4,15 @@
 from micropython import const
 import _onewire as _ow
 
+
 class OneWireError(Exception):
     pass
 
+
 class OneWire:
-    SEARCH_ROM = const(0xf0)
+    SEARCH_ROM = const(0xF0)
     MATCH_ROM = const(0x55)
-    SKIP_ROM = const(0xcc)
+    SKIP_ROM = const(0xCC)
 
     def __init__(self, pin):
         self.pin = pin
@@ -51,7 +53,7 @@ class OneWire:
         devices = []
         diff = 65
         rom = False
-        for i in range(0xff):
+        for i in range(0xFF):
             rom, diff = self._search_rom(rom, diff)
             if rom:
                 devices += [rom]
@@ -73,10 +75,10 @@ class OneWire:
             for bit in range(8):
                 b = self.readbit()
                 if self.readbit():
-                    if b: # there are no devices or there is an error on the bus
+                    if b:  # there are no devices or there is an error on the bus
                         return None, 0
                 else:
-                    if not b: # collision, two devices with different bit meaning
+                    if not b:  # collision, two devices with different bit meaning
                         if diff > i or ((l_rom[byte] & (1 << bit)) and diff != i):
                             b = 1
                             next_diff = i

--- a/drivers/sdcard/sdcard.py
+++ b/drivers/sdcard/sdcard.py
@@ -27,15 +27,15 @@ import time
 _CMD_TIMEOUT = const(100)
 
 _R1_IDLE_STATE = const(1 << 0)
-#R1_ERASE_RESET = const(1 << 1)
+# R1_ERASE_RESET = const(1 << 1)
 _R1_ILLEGAL_COMMAND = const(1 << 2)
-#R1_COM_CRC_ERROR = const(1 << 3)
-#R1_ERASE_SEQUENCE_ERROR = const(1 << 4)
-#R1_ADDRESS_ERROR = const(1 << 5)
-#R1_PARAMETER_ERROR = const(1 << 6)
-_TOKEN_CMD25 = const(0xfc)
-_TOKEN_STOP_TRAN = const(0xfd)
-_TOKEN_DATA = const(0xfe)
+# R1_COM_CRC_ERROR = const(1 << 3)
+# R1_ERASE_SEQUENCE_ERROR = const(1 << 4)
+# R1_ADDRESS_ERROR = const(1 << 5)
+# R1_PARAMETER_ERROR = const(1 << 6)
+_TOKEN_CMD25 = const(0xFC)
+_TOKEN_STOP_TRAN = const(0xFD)
+_TOKEN_DATA = const(0xFE)
 
 
 class SDCard:
@@ -47,7 +47,7 @@ class SDCard:
         self.dummybuf = bytearray(512)
         self.tokenbuf = bytearray(1)
         for i in range(512):
-            self.dummybuf[i] = 0xff
+            self.dummybuf[i] = 0xFF
         self.dummybuf_memoryview = memoryview(self.dummybuf)
 
         # initialise the card
@@ -82,7 +82,7 @@ class SDCard:
             raise OSError("no SD card")
 
         # CMD8: determine card version
-        r = self.cmd(8, 0x01aa, 0x87, 4)
+        r = self.cmd(8, 0x01AA, 0x87, 4)
         if r == _R1_IDLE_STATE:
             self.init_card_v2()
         elif r == (_R1_IDLE_STATE | _R1_ILLEGAL_COMMAND):
@@ -96,15 +96,15 @@ class SDCard:
             raise OSError("no response from SD card")
         csd = bytearray(16)
         self.readinto(csd)
-        if csd[0] & 0xc0 == 0x40: # CSD version 2.0
+        if csd[0] & 0xC0 == 0x40:  # CSD version 2.0
             self.sectors = ((csd[8] << 8 | csd[9]) + 1) * 1024
-        elif csd[0] & 0xc0 == 0x00: # CSD version 1.0 (old, <=2GB)
+        elif csd[0] & 0xC0 == 0x00:  # CSD version 1.0 (old, <=2GB)
             c_size = csd[6] & 0b11 | csd[7] << 2 | (csd[8] & 0b11000000) << 4
             c_size_mult = ((csd[9] & 0b11) << 1) | csd[10] >> 7
             self.sectors = (c_size + 1) * (2 ** (c_size_mult + 2))
         else:
             raise OSError("SD card CSD format not supported")
-        #print('sectors', self.sectors)
+        # print('sectors', self.sectors)
 
         # CMD16: set block length to 512 bytes
         if self.cmd(16, 512, 0) != 0:
@@ -118,7 +118,7 @@ class SDCard:
             self.cmd(55, 0, 0)
             if self.cmd(41, 0, 0) == 0:
                 self.cdv = 512
-                #print("[SDCard] v1 card")
+                # print("[SDCard] v1 card")
                 return
         raise OSError("timeout waiting for v1 card")
 
@@ -130,7 +130,7 @@ class SDCard:
             if self.cmd(41, 0x40000000, 0) == 0:
                 self.cmd(58, 0, 0, 4)
                 self.cdv = 1
-                #print("[SDCard] v2 card")
+                # print("[SDCard] v2 card")
                 return
         raise OSError("timeout waiting for v2 card")
 
@@ -148,11 +148,11 @@ class SDCard:
         self.spi.write(buf)
 
         if skip1:
-            self.spi.readinto(self.tokenbuf, 0xff)
+            self.spi.readinto(self.tokenbuf, 0xFF)
 
         # wait for the response (response[7] == 0)
         for i in range(_CMD_TIMEOUT):
-            self.spi.readinto(self.tokenbuf, 0xff)
+            self.spi.readinto(self.tokenbuf, 0xFF)
             response = self.tokenbuf[0]
             if not (response & 0x80):
                 # this could be a big-endian integer that we are getting here
@@ -173,7 +173,7 @@ class SDCard:
 
         # read until start byte (0xff)
         for i in range(_CMD_TIMEOUT):
-            self.spi.readinto(self.tokenbuf, 0xff)
+            self.spi.readinto(self.tokenbuf, 0xFF)
             if self.tokenbuf[0] == _TOKEN_DATA:
                 break
         else:
@@ -183,7 +183,7 @@ class SDCard:
         # read data
         mv = self.dummybuf_memoryview
         if len(buf) != len(mv):
-            mv = mv[:len(buf)]
+            mv = mv[: len(buf)]
         self.spi.write_readinto(mv, buf)
 
         # read checksum
@@ -203,13 +203,13 @@ class SDCard:
         self.spi.write(b'\xff')
 
         # check the response
-        if (self.spi.read(1, 0xff)[0] & 0x1f) != 0x05:
+        if (self.spi.read(1, 0xFF)[0] & 0x1F) != 0x05:
             self.cs(1)
             self.spi.write(b'\xff')
             return
 
         # wait for write to finish
-        while self.spi.read(1, 0xff)[0] == 0:
+        while self.spi.read(1, 0xFF)[0] == 0:
             pass
 
         self.cs(1)
@@ -220,7 +220,7 @@ class SDCard:
         self.spi.read(1, token)
         self.spi.write(b'\xff')
         # wait for write to finish
-        while self.spi.read(1, 0xff)[0] == 0x00:
+        while self.spi.read(1, 0xFF)[0] == 0x00:
             pass
 
         self.cs(1)
@@ -234,7 +234,7 @@ class SDCard:
             if self.cmd(17, block_num * self.cdv, 0, release=False) != 0:
                 # release the card
                 self.cs(1)
-                raise OSError(5) # EIO
+                raise OSError(5)  # EIO
             # receive the data and release card
             self.readinto(buf)
         else:
@@ -242,7 +242,7 @@ class SDCard:
             if self.cmd(18, block_num * self.cdv, 0, release=False) != 0:
                 # release the card
                 self.cs(1)
-                raise OSError(5) # EIO
+                raise OSError(5)  # EIO
             offset = 0
             mv = memoryview(buf)
             while nblocks:
@@ -250,8 +250,8 @@ class SDCard:
                 self.readinto(mv[offset : offset + 512])
                 offset += 512
                 nblocks -= 1
-            if self.cmd(12, 0, 0xff, skip1=True):
-                raise OSError(5) # EIO
+            if self.cmd(12, 0, 0xFF, skip1=True):
+                raise OSError(5)  # EIO
 
     def writeblocks(self, block_num, buf):
         nblocks, err = divmod(len(buf), 512)
@@ -259,14 +259,14 @@ class SDCard:
         if nblocks == 1:
             # CMD24: set write address for single block
             if self.cmd(24, block_num * self.cdv, 0) != 0:
-                raise OSError(5) # EIO
+                raise OSError(5)  # EIO
 
             # send the data
             self.write(_TOKEN_DATA, buf)
         else:
             # CMD25: set write address for first block
             if self.cmd(25, block_num * self.cdv, 0) != 0:
-                raise OSError(5) # EIO
+                raise OSError(5)  # EIO
             # send the data
             offset = 0
             mv = memoryview(buf)
@@ -277,5 +277,5 @@ class SDCard:
             self.write_token(_TOKEN_STOP_TRAN)
 
     def ioctl(self, op, arg):
-        if op == 4: # get number of blocks
+        if op == 4:  # get number of blocks
             return self.sectors

--- a/drivers/sdcard/sdtest.py
+++ b/drivers/sdcard/sdtest.py
@@ -2,23 +2,24 @@
 # Peter hinch 30th Jan 2016
 import os, sdcard, machine
 
+
 def sdtest():
     spi = machine.SPI(1)
     spi.init()  # Ensure right baudrate
-    sd = sdcard.SDCard(spi, machine.Pin.board.X21) # Compatible with PCB
+    sd = sdcard.SDCard(spi, machine.Pin.board.X21)  # Compatible with PCB
     vfs = os.VfsFat(sd)
     os.mount(vfs, '/fc')
     print('Filesystem check')
     print(os.listdir('/fc'))
 
     line = 'abcdefghijklmnopqrstuvwxyz\n'
-    lines = line * 200 # 5400 chars
+    lines = line * 200  # 5400 chars
     short = '1234567890\n'
 
     fn = '/fc/rats.txt'
     print()
     print('Multiple block read/write')
-    with open(fn,'w') as f:
+    with open(fn, 'w') as f:
         n = f.write(lines)
         print(n, 'bytes written')
         n = f.write(short)
@@ -26,18 +27,18 @@ def sdtest():
         n = f.write(lines)
         print(n, 'bytes written')
 
-    with open(fn,'r') as f:
+    with open(fn, 'r') as f:
         result1 = f.read()
         print(len(result1), 'bytes read')
 
     fn = '/fc/rats1.txt'
     print()
     print('Single block read/write')
-    with open(fn,'w') as f:
-        n = f.write(short) # one block
+    with open(fn, 'w') as f:
+        n = f.write(short)  # one block
         print(n, 'bytes written')
 
-    with open(fn,'r') as f:
+    with open(fn, 'r') as f:
         result2 = f.read()
         print(len(result2), 'bytes read')
 

--- a/examples/SDdatalogger/boot.py
+++ b/examples/SDdatalogger/boot.py
@@ -8,18 +8,18 @@
 
 import pyb
 
-pyb.LED(3).on()                 # indicate we are waiting for switch press
-pyb.delay(2000)                 # wait for user to maybe press the switch
-switch_value = pyb.Switch()()   # sample the switch at end of delay
-pyb.LED(3).off()                # indicate that we finished waiting for the switch
+pyb.LED(3).on()  # indicate we are waiting for switch press
+pyb.delay(2000)  # wait for user to maybe press the switch
+switch_value = pyb.Switch()()  # sample the switch at end of delay
+pyb.LED(3).off()  # indicate that we finished waiting for the switch
 
-pyb.LED(4).on()                 # indicate that we are selecting the mode
+pyb.LED(4).on()  # indicate that we are selecting the mode
 
 if switch_value:
     pyb.usb_mode('VCP+MSC')
-    pyb.main('cardreader.py')           # if switch was pressed, run this
+    pyb.main('cardreader.py')  # if switch was pressed, run this
 else:
     pyb.usb_mode('VCP+HID')
-    pyb.main('datalogger.py')           # if switch wasn't pressed, run this
+    pyb.main('datalogger.py')  # if switch wasn't pressed, run this
 
-pyb.LED(4).off()                # indicate that we finished selecting the mode
+pyb.LED(4).off()  # indicate that we finished selecting the mode

--- a/examples/SDdatalogger/datalogger.py
+++ b/examples/SDdatalogger/datalogger.py
@@ -17,17 +17,17 @@ while True:
 
     # start if switch is pressed
     if switch():
-        pyb.delay(200)                      # delay avoids detection of multiple presses
-        blue.on()                           # blue LED indicates file open
-        log = open('/sd/log.csv', 'w')       # open file on SD (SD: '/sd/', flash: '/flash/)
+        pyb.delay(200)  # delay avoids detection of multiple presses
+        blue.on()  # blue LED indicates file open
+        log = open('/sd/log.csv', 'w')  # open file on SD (SD: '/sd/', flash: '/flash/)
 
         # until switch is pressed again
         while not switch():
-            t = pyb.millis()                            # get time
-            x, y, z = accel.filtered_xyz()              # get acceleration data
-            log.write('{},{},{},{}\n'.format(t,x,y,z))  # write data to file
+            t = pyb.millis()  # get time
+            x, y, z = accel.filtered_xyz()  # get acceleration data
+            log.write('{},{},{},{}\n'.format(t, x, y, z))  # write data to file
 
         # end after switch is pressed again
-        log.close()                         # close file
-        blue.off()                          # blue LED indicates file closed
-        pyb.delay(200)                      # delay avoids detection of multiple presses
+        log.close()  # close file
+        blue.off()  # blue LED indicates file closed
+        pyb.delay(200)  # delay avoids detection of multiple presses

--- a/examples/accel_i2c.py
+++ b/examples/accel_i2c.py
@@ -17,10 +17,10 @@ accel_pwr.value(1)
 i2c = I2C(1, baudrate=100000)
 addrs = i2c.scan()
 print("Scanning devices:", [hex(x) for x in addrs])
-if 0x4c not in addrs:
+if 0x4C not in addrs:
     print("Accelerometer is not detected")
 
-ACCEL_ADDR = 0x4c
+ACCEL_ADDR = 0x4C
 ACCEL_AXIS_X_REG = 0
 ACCEL_MODE_REG = 7
 

--- a/examples/accellog.py
+++ b/examples/accellog.py
@@ -2,16 +2,20 @@
 
 import pyb
 
-accel = pyb.Accel()                                 # create object of accelerometer
-blue = pyb.LED(4)                                   # create object of blue LED
+accel = pyb.Accel()  # create object of accelerometer
+blue = pyb.LED(4)  # create object of blue LED
 
-log = open('/sd/log.csv', 'w')                      # open file to write data - /sd/ is the SD-card, /flash/ the internal memory
-blue.on()                                           # turn on blue LED
+log = open(
+    '/sd/log.csv', 'w'
+)  # open file to write data - /sd/ is the SD-card, /flash/ the internal memory
+blue.on()  # turn on blue LED
 
-for i in range(100):                                # do 100 times (if the board is connected via USB, you can't write longer because the PC tries to open the filesystem which messes up your file.)
-        t = pyb.millis()                            # get time since reset
-        x, y, z = accel.filtered_xyz()              # get acceleration data
-        log.write('{},{},{},{}\n'.format(t,x,y,z))  # write data to file
+for i in range(
+    100
+):  # do 100 times (if the board is connected via USB, you can't write longer because the PC tries to open the filesystem which messes up your file.)
+    t = pyb.millis()  # get time since reset
+    x, y, z = accel.filtered_xyz()  # get acceleration data
+    log.write('{},{},{},{}\n'.format(t, x, y, z))  # write data to file
 
-log.close()                                         # close file
-blue.off()                                          # turn off LED
+log.close()  # close file
+blue.off()  # turn off LED

--- a/examples/asmled.py
+++ b/examples/asmled.py
@@ -2,8 +2,8 @@
 # this version is overly verbose and uses word stores
 @micropython.asm_thumb
 def flash_led(r0):
-    movw(r1, (stm.GPIOA + stm.GPIO_BSRRL) & 0xffff)
-    movt(r1, ((stm.GPIOA + stm.GPIO_BSRRL) >> 16) & 0x7fff)
+    movw(r1, (stm.GPIOA + stm.GPIO_BSRRL) & 0xFFFF)
+    movt(r1, ((stm.GPIOA + stm.GPIO_BSRRL) >> 16) & 0x7FFF)
     movw(r2, 1 << 13)
     movt(r2, 0)
     movw(r3, 0)
@@ -17,8 +17,8 @@ def flash_led(r0):
     str(r2, [r1, 0])
 
     # delay for a bit
-    movw(r4, 5599900 & 0xffff)
-    movt(r4, (5599900 >> 16) & 0xffff)
+    movw(r4, 5599900 & 0xFFFF)
+    movt(r4, (5599900 >> 16) & 0xFFFF)
     label(delay_on)
     sub(r4, r4, 1)
     cmp(r4, 0)
@@ -28,8 +28,8 @@ def flash_led(r0):
     str(r3, [r1, 0])
 
     # delay for a bit
-    movw(r4, 5599900 & 0xffff)
-    movt(r4, (5599900 >> 16) & 0xffff)
+    movw(r4, 5599900 & 0xFFFF)
+    movt(r4, (5599900 >> 16) & 0xFFFF)
     label(delay_off)
     sub(r4, r4, 1)
     cmp(r4, 0)
@@ -40,6 +40,7 @@ def flash_led(r0):
     label(loop_entry)
     cmp(r0, 0)
     bgt(loop1)
+
 
 # flash LED #2 using inline assembler
 # this version uses half-word sortes, and the convenience assembler operation 'movwt'
@@ -80,6 +81,7 @@ def flash_led_v2(r0):
     label(loop_entry)
     cmp(r0, 0)
     bgt(loop1)
+
 
 flash_led(5)
 flash_led_v2(5)

--- a/examples/asmsum.py
+++ b/examples/asmsum.py
@@ -22,6 +22,7 @@ def asm_sum_words(r0, r1):
 
     mov(r0, r2)
 
+
 @micropython.asm_thumb
 def asm_sum_bytes(r0, r1):
 
@@ -45,6 +46,7 @@ def asm_sum_bytes(r0, r1):
     bgt(loop1)
 
     mov(r0, r2)
+
 
 import array
 

--- a/examples/bluetooth/ble_advertising.py
+++ b/examples/bluetooth/ble_advertising.py
@@ -21,14 +21,19 @@ _ADV_TYPE_APPEARANCE = const(0x19)
 
 
 # Generate a payload to be passed to gap_advertise(adv_data=...).
-def advertising_payload(limited_disc=False, br_edr=False, name=None, services=None, appearance=0):
+def advertising_payload(
+    limited_disc=False, br_edr=False, name=None, services=None, appearance=0
+):
     payload = bytearray()
 
     def _append(adv_type, value):
         nonlocal payload
         payload += struct.pack('BB', len(value) + 1, adv_type) + value
 
-    _append(_ADV_TYPE_FLAGS, struct.pack('B', (0x01 if limited_disc else 0x02) + (0x00 if br_edr else 0x04)))
+    _append(
+        _ADV_TYPE_FLAGS,
+        struct.pack('B', (0x01 if limited_disc else 0x02) + (0x00 if br_edr else 0x04)),
+    )
 
     if name:
         _append(_ADV_TYPE_NAME, name)
@@ -54,7 +59,7 @@ def decode_field(payload, adv_type):
     result = []
     while i + 1 < len(payload):
         if payload[i + 1] == adv_type:
-            result.append(payload[i + 2:i + payload[i] + 1])
+            result.append(payload[i + 2 : i + payload[i] + 1])
         i += 1 + payload[i]
     return result
 
@@ -76,10 +81,17 @@ def decode_services(payload):
 
 
 def demo():
-    payload = advertising_payload(name='micropython', services=[bluetooth.UUID(0x181A), bluetooth.UUID('6E400001-B5A3-F393-E0A9-E50E24DCCA9E')])
+    payload = advertising_payload(
+        name='micropython',
+        services=[
+            bluetooth.UUID(0x181A),
+            bluetooth.UUID('6E400001-B5A3-F393-E0A9-E50E24DCCA9E'),
+        ],
+    )
     print(payload)
     print(decode_name(payload))
     print(decode_services(payload))
+
 
 if __name__ == '__main__':
     demo()

--- a/examples/bluetooth/ble_temperature.py
+++ b/examples/bluetooth/ble_temperature.py
@@ -10,17 +10,25 @@ import time
 from ble_advertising import advertising_payload
 
 from micropython import const
-_IRQ_CENTRAL_CONNECT                 = const(1 << 0)
-_IRQ_CENTRAL_DISCONNECT              = const(1 << 1)
+
+_IRQ_CENTRAL_CONNECT = const(1 << 0)
+_IRQ_CENTRAL_DISCONNECT = const(1 << 1)
 
 # org.bluetooth.service.environmental_sensing
 _ENV_SENSE_UUID = bluetooth.UUID(0x181A)
 # org.bluetooth.characteristic.temperature
-_TEMP_CHAR = (bluetooth.UUID(0x2A6E), bluetooth.FLAG_READ|bluetooth.FLAG_NOTIFY,)
-_ENV_SENSE_SERVICE = (_ENV_SENSE_UUID, (_TEMP_CHAR,),)
+_TEMP_CHAR = (
+    bluetooth.UUID(0x2A6E),
+    bluetooth.FLAG_READ | bluetooth.FLAG_NOTIFY,
+)
+_ENV_SENSE_SERVICE = (
+    _ENV_SENSE_UUID,
+    (_TEMP_CHAR,),
+)
 
 # org.bluetooth.characteristic.gap.appearance.xml
 _ADV_APPEARANCE_GENERIC_THERMOMETER = const(768)
+
 
 class BLETemperature:
     def __init__(self, ble, name='mpy-temp'):
@@ -29,7 +37,11 @@ class BLETemperature:
         self._ble.irq(handler=self._irq)
         ((self._handle,),) = self._ble.gatts_register_services((_ENV_SENSE_SERVICE,))
         self._connections = set()
-        self._payload = advertising_payload(name=name, services=[_ENV_SENSE_UUID], appearance=_ADV_APPEARANCE_GENERIC_THERMOMETER)
+        self._payload = advertising_payload(
+            name=name,
+            services=[_ENV_SENSE_UUID],
+            appearance=_ADV_APPEARANCE_GENERIC_THERMOMETER,
+        )
         self._advertise()
 
     def _irq(self, event, data):

--- a/examples/bluetooth/ble_temperature_central.py
+++ b/examples/bluetooth/ble_temperature_central.py
@@ -9,32 +9,40 @@ import micropython
 from ble_advertising import decode_services, decode_name
 
 from micropython import const
-_IRQ_CENTRAL_CONNECT                 = const(1 << 0)
-_IRQ_CENTRAL_DISCONNECT              = const(1 << 1)
-_IRQ_GATTS_WRITE                     = const(1 << 2)
-_IRQ_GATTS_READ_REQUEST              = const(1 << 3)
-_IRQ_SCAN_RESULT                     = const(1 << 4)
-_IRQ_SCAN_COMPLETE                   = const(1 << 5)
-_IRQ_PERIPHERAL_CONNECT              = const(1 << 6)
-_IRQ_PERIPHERAL_DISCONNECT           = const(1 << 7)
-_IRQ_GATTC_SERVICE_RESULT            = const(1 << 8)
-_IRQ_GATTC_CHARACTERISTIC_RESULT     = const(1 << 9)
-_IRQ_GATTC_DESCRIPTOR_RESULT         = const(1 << 10)
-_IRQ_GATTC_READ_RESULT               = const(1 << 11)
-_IRQ_GATTC_WRITE_STATUS              = const(1 << 12)
-_IRQ_GATTC_NOTIFY                    = const(1 << 13)
-_IRQ_GATTC_INDICATE                  = const(1 << 14)
-_IRQ_ALL                             = const(0xffff)
+
+_IRQ_CENTRAL_CONNECT = const(1 << 0)
+_IRQ_CENTRAL_DISCONNECT = const(1 << 1)
+_IRQ_GATTS_WRITE = const(1 << 2)
+_IRQ_GATTS_READ_REQUEST = const(1 << 3)
+_IRQ_SCAN_RESULT = const(1 << 4)
+_IRQ_SCAN_COMPLETE = const(1 << 5)
+_IRQ_PERIPHERAL_CONNECT = const(1 << 6)
+_IRQ_PERIPHERAL_DISCONNECT = const(1 << 7)
+_IRQ_GATTC_SERVICE_RESULT = const(1 << 8)
+_IRQ_GATTC_CHARACTERISTIC_RESULT = const(1 << 9)
+_IRQ_GATTC_DESCRIPTOR_RESULT = const(1 << 10)
+_IRQ_GATTC_READ_RESULT = const(1 << 11)
+_IRQ_GATTC_WRITE_STATUS = const(1 << 12)
+_IRQ_GATTC_NOTIFY = const(1 << 13)
+_IRQ_GATTC_INDICATE = const(1 << 14)
+_IRQ_ALL = const(0xFFFF)
 
 # org.bluetooth.service.environmental_sensing
 _ENV_SENSE_UUID = bluetooth.UUID(0x181A)
 # org.bluetooth.characteristic.temperature
 _TEMP_UUID = bluetooth.UUID(0x2A6E)
-_TEMP_CHAR = (_TEMP_UUID, bluetooth.FLAG_READ|bluetooth.FLAG_NOTIFY,)
-_ENV_SENSE_SERVICE = (_ENV_SENSE_UUID, (_TEMP_CHAR,),)
+_TEMP_CHAR = (
+    _TEMP_UUID,
+    bluetooth.FLAG_READ | bluetooth.FLAG_NOTIFY,
+)
+_ENV_SENSE_SERVICE = (
+    _ENV_SENSE_UUID,
+    (_TEMP_CHAR,),
+)
 
 # org.bluetooth.characteristic.gap.appearance.xml
 _ADV_APPEARANCE_GENERIC_THERMOMETER = const(768)
+
 
 class BLETemperatureCentral:
     def __init__(self, ble):
@@ -72,7 +80,9 @@ class BLETemperatureCentral:
             if connectable and _ENV_SENSE_UUID in decode_services(adv_data):
                 # Found a potential device, remember it and stop scanning.
                 self._addr_type = addr_type
-                self._addr = bytes(addr) # Note: The addr buffer is owned by modbluetooth, need to copy it.
+                self._addr = bytes(
+                    addr
+                )  # Note: The addr buffer is owned by modbluetooth, need to copy it.
                 self._name = decode_name(adv_data) or '?'
                 self._ble.gap_scan(None)
 
@@ -104,7 +114,9 @@ class BLETemperatureCentral:
             # Connected device returned a service.
             conn_handle, start_handle, end_handle, uuid = data
             if conn_handle == self._conn_handle and uuid == _ENV_SENSE_UUID:
-                self._ble.gattc_discover_characteristics(self._conn_handle, start_handle, end_handle)
+                self._ble.gattc_discover_characteristics(
+                    self._conn_handle, start_handle, end_handle
+                )
 
         elif event == _IRQ_GATTC_CHARACTERISTIC_RESULT:
             # Connected device returned a characteristic.
@@ -131,7 +143,6 @@ class BLETemperatureCentral:
                 self._update_value(notify_data)
                 if self._notify_callback:
                     self._notify_callback(self._value)
-
 
     # Returns true if we've successfully connected and discovered characteristics.
     def is_connected(self):
@@ -217,6 +228,7 @@ def demo():
     #     time.sleep_ms(2000)
 
     print('Disconnected')
+
 
 if __name__ == '__main__':
     demo()

--- a/examples/bluetooth/ble_uart_peripheral.py
+++ b/examples/bluetooth/ble_uart_peripheral.py
@@ -4,31 +4,46 @@ import bluetooth
 from ble_advertising import advertising_payload
 
 from micropython import const
-_IRQ_CENTRAL_CONNECT                 = const(1 << 0)
-_IRQ_CENTRAL_DISCONNECT              = const(1 << 1)
-_IRQ_GATTS_WRITE                     = const(1 << 2)
+
+_IRQ_CENTRAL_CONNECT = const(1 << 0)
+_IRQ_CENTRAL_DISCONNECT = const(1 << 1)
+_IRQ_GATTS_WRITE = const(1 << 2)
 
 _UART_UUID = bluetooth.UUID('6E400001-B5A3-F393-E0A9-E50E24DCCA9E')
-_UART_TX = (bluetooth.UUID('6E400003-B5A3-F393-E0A9-E50E24DCCA9E'), bluetooth.FLAG_NOTIFY,)
-_UART_RX = (bluetooth.UUID('6E400002-B5A3-F393-E0A9-E50E24DCCA9E'), bluetooth.FLAG_WRITE,)
-_UART_SERVICE = (_UART_UUID, (_UART_TX, _UART_RX,),)
+_UART_TX = (
+    bluetooth.UUID('6E400003-B5A3-F393-E0A9-E50E24DCCA9E'),
+    bluetooth.FLAG_NOTIFY,
+)
+_UART_RX = (
+    bluetooth.UUID('6E400002-B5A3-F393-E0A9-E50E24DCCA9E'),
+    bluetooth.FLAG_WRITE,
+)
+_UART_SERVICE = (
+    _UART_UUID,
+    (_UART_TX, _UART_RX,),
+)
 
 # org.bluetooth.characteristic.gap.appearance.xml
 _ADV_APPEARANCE_GENERIC_COMPUTER = const(128)
+
 
 class BLEUART:
     def __init__(self, ble, name='mpy-uart', rxbuf=100):
         self._ble = ble
         self._ble.active(True)
         self._ble.irq(handler=self._irq)
-        ((self._tx_handle, self._rx_handle,),) = self._ble.gatts_register_services((_UART_SERVICE,))
+        ((self._tx_handle, self._rx_handle,),) = self._ble.gatts_register_services(
+            (_UART_SERVICE,)
+        )
         # Increase the size of the rx buffer and enable append mode.
         self._ble.gatts_set_buffer(self._rx_handle, rxbuf, True)
         self._connections = set()
         self._rx_buffer = bytearray()
         self._handler = None
         # Optionally add services=[_UART_UUID], but this is likely to make the payload too large.
-        self._payload = advertising_payload(name=name, appearance=_ADV_APPEARANCE_GENERIC_COMPUTER)
+        self._payload = advertising_payload(
+            name=name, appearance=_ADV_APPEARANCE_GENERIC_COMPUTER
+        )
         self._advertise()
 
     def irq(self, handler):

--- a/examples/bluetooth/ble_uart_repl.py
+++ b/examples/bluetooth/ble_uart_repl.py
@@ -24,10 +24,12 @@ else:
 def schedule_in(handler, delay_ms):
     def _wrap(_arg):
         handler()
+
     if _timer:
         _timer.init(mode=machine.Timer.ONE_SHOT, period=delay_ms, callback=_wrap)
     else:
         micropython.schedule(_wrap, None)
+
 
 # Simple buffering stream to support the dupterm requirements.
 class BLEUARTStream(io.IOBase):

--- a/examples/conwaylife.py
+++ b/examples/conwaylife.py
@@ -1,4 +1,4 @@
-#import essential libraries
+# import essential libraries
 import pyb
 
 lcd = pyb.LCD('x')
@@ -6,40 +6,47 @@ lcd.light(1)
 
 # do 1 iteration of Conway's Game of Life
 def conway_step():
-    for x in range(128):        # loop over x coordinates
-        for y in range(32):     # loop over y coordinates
+    for x in range(128):  # loop over x coordinates
+        for y in range(32):  # loop over y coordinates
             # count number of neighbours
-            num_neighbours = (lcd.get(x - 1, y - 1) +
-                lcd.get(x, y - 1) +
-                lcd.get(x + 1, y - 1) +
-                lcd.get(x - 1, y) +
-                lcd.get(x + 1, y) +
-                lcd.get(x + 1, y + 1) +
-                lcd.get(x, y + 1) +
-                lcd.get(x - 1, y + 1))
+            num_neighbours = (
+                lcd.get(x - 1, y - 1)
+                + lcd.get(x, y - 1)
+                + lcd.get(x + 1, y - 1)
+                + lcd.get(x - 1, y)
+                + lcd.get(x + 1, y)
+                + lcd.get(x + 1, y + 1)
+                + lcd.get(x, y + 1)
+                + lcd.get(x - 1, y + 1)
+            )
 
             # check if the centre cell is alive or not
             self = lcd.get(x, y)
 
             # apply the rules of life
             if self and not (2 <= num_neighbours <= 3):
-                lcd.pixel(x, y, 0) # not enough, or too many neighbours: cell dies
+                lcd.pixel(x, y, 0)  # not enough, or too many neighbours: cell dies
             elif not self and num_neighbours == 3:
-                lcd.pixel(x, y, 1)   # exactly 3 neighbours around an empty cell: cell is born
+                lcd.pixel(
+                    x, y, 1
+                )  # exactly 3 neighbours around an empty cell: cell is born
+
 
 # randomise the start
 def conway_rand():
-    lcd.fill(0)                 # clear the LCD
-    for x in range(128):        # loop over x coordinates
-        for y in range(32):     # loop over y coordinates
-            lcd.pixel(x, y, pyb.rng() & 1)   # set the pixel randomly
+    lcd.fill(0)  # clear the LCD
+    for x in range(128):  # loop over x coordinates
+        for y in range(32):  # loop over y coordinates
+            lcd.pixel(x, y, pyb.rng() & 1)  # set the pixel randomly
+
 
 # loop for a certain number of frames, doing iterations of Conway's Game of Life
 def conway_go(num_frames):
     for i in range(num_frames):
-        conway_step()           # do 1 iteration
-        lcd.show()              # update the LCD
+        conway_step()  # do 1 iteration
+        lcd.show()  # update the LCD
         pyb.delay(50)
+
 
 # testing
 conway_rand()

--- a/examples/hwapi/button_reaction.py
+++ b/examples/hwapi/button_reaction.py
@@ -4,14 +4,16 @@ from hwconfig import LED, BUTTON
 
 # machine.time_pulse_us() function demo
 
-print("""\
+print(
+    """\
 Let's play an interesting game:
 You click button as fast as you can, and I tell you how slow you are.
 Ready? Cliiiiick!
-""")
+"""
+)
 
 while 1:
-    delay = machine.time_pulse_us(BUTTON, 1, 10*1000*1000)
+    delay = machine.time_pulse_us(BUTTON, 1, 10 * 1000 * 1000)
     if delay < 0:
         print("Well, you're *really* slow")
     else:

--- a/examples/hwapi/hwconfig_console.py
+++ b/examples/hwapi/hwconfig_console.py
@@ -1,7 +1,6 @@
 # This is hwconfig for "emulation" for cases when there's no real hardware.
 # It just prints information to console.
 class LEDClass:
-
     def __init__(self, id):
         self.id = "LED(%d):" % id
 

--- a/examples/ledangle.py
+++ b/examples/ledangle.py
@@ -1,5 +1,6 @@
 import pyb
 
+
 def led_angle(seconds_to_run_for):
     # make LED objects
     l1 = pyb.LED(1)

--- a/examples/mandel.py
+++ b/examples/mandel.py
@@ -3,13 +3,14 @@ try:
 except:
     pass
 
+
 def mandelbrot():
     # returns True if c, complex, is in the Mandelbrot set
-    #@micropython.native
+    # @micropython.native
     def in_set(c):
         z = 0
         for i in range(40):
-            z = z*z + c
+            z = z * z + c
             if abs(z) > 60:
                 return False
         return True
@@ -21,7 +22,9 @@ def mandelbrot():
                 lcd.set(u, v)
     lcd.show()
 
+
 # PC testing
 import lcd
+
 lcd = lcd.LCD(128, 32)
 mandelbrot()

--- a/examples/micropython.py
+++ b/examples/micropython.py
@@ -2,7 +2,9 @@
 
 # Dummy function decorators
 
+
 def nodecor(x):
     return x
+
 
 bytecode = native = viper = nodecor

--- a/examples/natmod/features2/test.py
+++ b/examples/natmod/features2/test.py
@@ -2,8 +2,10 @@
 
 import array
 
+
 def isclose(a, b):
     return abs(a - b) < 1e-3
+
 
 def test():
     tests = [
@@ -22,5 +24,6 @@ def test():
 
     if not all(tests):
         raise SystemExit(1)
+
 
 test()

--- a/examples/network/http_server.py
+++ b/examples/network/http_server.py
@@ -10,6 +10,7 @@ HTTP/1.0 200 OK
 Hello #%d from MicroPython!
 """
 
+
 def main(micropython_optimize=False):
     s = socket.socket()
 

--- a/examples/network/http_server_simplistic.py
+++ b/examples/network/http_server_simplistic.py
@@ -12,6 +12,7 @@ HTTP/1.0 200 OK
 Hello #%d from MicroPython!
 """
 
+
 def main():
     s = socket.socket()
     ai = socket.getaddrinfo("0.0.0.0", 8080)

--- a/examples/network/http_server_simplistic_commented.py
+++ b/examples/network/http_server_simplistic_commented.py
@@ -20,6 +20,7 @@ HTTP/1.0 200 OK
 Hello #%d from MicroPython!
 """
 
+
 def main():
     s = socket.socket()
 

--- a/examples/network/http_server_ssl.py
+++ b/examples/network/http_server_ssl.py
@@ -1,4 +1,5 @@
 import ubinascii as binascii
+
 try:
     import usocket as socket
 except:
@@ -17,7 +18,8 @@ key = binascii.unhexlify(
     b'8f022100d598d870ffe4a34df8de57047a50b97b71f4d23e323f527837c9edae88c79483'
     b'02210098560c89a70385c36eb07fd7083235c4c1184e525d838aedf7128958bedfdbb102'
     b'2051c0dab7057a8176ca966f3feb81123d4974a733df0f958525f547dfd1c271f9022044'
-    b'6c2cafad455a671a8cf398e642e1be3b18a3d3aec2e67a9478f83c964c4f1f')
+    b'6c2cafad455a671a8cf398e642e1be3b18a3d3aec2e67a9478f83c964c4f1f'
+)
 cert = binascii.unhexlify(
     b'308201d53082017f020203e8300d06092a864886f70d01010505003075310b3009060355'
     b'0406130258583114301206035504080c0b54686550726f76696e63653110300e06035504'
@@ -32,7 +34,8 @@ cert = binascii.unhexlify(
     b'a1d4c056580d8ff1a639460f867013c8391cdc9f2e573b0f872d0203010001300d06092a'
     b'864886f70d0101050500034100b0513fe2829e9ecbe55b6dd14c0ede7502bde5d46153c8'
     b'e960ae3ebc247371b525caeb41bbcf34686015a44c50d226e66aef0a97a63874ca5944ef'
-    b'979b57f0b3')
+    b'979b57f0b3'
+)
 
 
 CONTENT = b"""\
@@ -40,6 +43,7 @@ HTTP/1.0 200 OK
 
 Hello #%d from MicroPython!
 """
+
 
 def main(use_stream=True):
     s = socket.socket()

--- a/examples/pins.py
+++ b/examples/pins.py
@@ -4,6 +4,7 @@
 import pyb
 import pins_af
 
+
 def af():
     max_name_width = 0
     max_af_width = 0
@@ -13,21 +14,26 @@ def af():
             max_af_width = max(max_af_width, len(af_entry[1]))
     for pin_entry in pins_af.PINS_AF:
         pin_name = pin_entry[0]
-        print('%-*s ' % (max_name_width, pin_name),  end='')
+        print('%-*s ' % (max_name_width, pin_name), end='')
         for af_entry in pin_entry[1:]:
             print('%2d: %-*s ' % (af_entry[0], max_af_width, af_entry[1]), end='')
         print('')
 
+
 def pins():
-    mode_str = { pyb.Pin.IN     : 'IN',
-                 pyb.Pin.OUT_PP : 'OUT_PP',
-                 pyb.Pin.OUT_OD : 'OUT_OD',
-                 pyb.Pin.AF_PP  : 'AF_PP',
-                 pyb.Pin.AF_OD  : 'AF_OD',
-                 pyb.Pin.ANALOG : 'ANALOG' }
-    pull_str = { pyb.Pin.PULL_NONE : '',
-                 pyb.Pin.PULL_UP   : 'PULL_UP',
-                 pyb.Pin.PULL_DOWN : 'PULL_DOWN' }
+    mode_str = {
+        pyb.Pin.IN: 'IN',
+        pyb.Pin.OUT_PP: 'OUT_PP',
+        pyb.Pin.OUT_OD: 'OUT_OD',
+        pyb.Pin.AF_PP: 'AF_PP',
+        pyb.Pin.AF_OD: 'AF_OD',
+        pyb.Pin.ANALOG: 'ANALOG',
+    }
+    pull_str = {
+        pyb.Pin.PULL_NONE: '',
+        pyb.Pin.PULL_UP: 'PULL_UP',
+        pyb.Pin.PULL_DOWN: 'PULL_DOWN',
+    }
     width = [0, 0, 0, 0]
     rows = []
     for pin_entry in pins_af.PINS_AF:

--- a/examples/pyb.py
+++ b/examples/pyb.py
@@ -1,16 +1,21 @@
 # pyboard testing functions for CPython
 import time
 
+
 def delay(n):
-    #time.sleep(float(n) / 1000)
+    # time.sleep(float(n) / 1000)
     pass
 
+
 rand_seed = 1
+
+
 def rng():
     global rand_seed
     # for these choice of numbers, see P L'Ecuyer, "Tables of linear congruential generators of different sizes and good lattice structure"
     rand_seed = (rand_seed * 653276) % 8388593
     return rand_seed
+
 
 # LCD testing object for PC
 # uses double buffering
@@ -30,7 +35,7 @@ class LCD:
                 self.buf1[y][x] = self.buf2[y][x] = value
 
     def show(self):
-        print('') # blank line to separate frames
+        print('')  # blank line to separate frames
         for y in range(self.height):
             for x in range(self.width):
                 self.buf1[y][x] = self.buf2[y][x]

--- a/examples/switch.py
+++ b/examples/switch.py
@@ -24,6 +24,7 @@ orange_led = pyb.LED(3)
 blue_led = pyb.LED(4)
 all_leds = (red_led, green_led, orange_led, blue_led)
 
+
 def run_loop(leds=all_leds):
     """
     Start the loop.
@@ -38,8 +39,9 @@ def run_loop(leds=all_leds):
                 [led.on() for led in leds]
             else:
                 [led.off() for led in leds]
-        except OSError: # VCPInterrupt # Ctrl+C in interpreter mode.
+        except OSError:  # VCPInterrupt # Ctrl+C in interpreter mode.
             break
+
 
 if __name__ == '__main__':
     run_loop()

--- a/examples/unix/ffi_example.py
+++ b/examples/unix/ffi_example.py
@@ -24,11 +24,13 @@ print("errno value:", errno.get())
 perror("perror after error")
 print()
 
+
 def cmp(pa, pb):
     a = uctypes.bytearray_at(pa, 1)
     b = uctypes.bytearray_at(pb, 1)
     print("cmp:", a, b)
     return a[0] - b[0]
+
 
 cmp_cb = ffi.callback("i", cmp, "PP")
 print("callback:", cmp_cb)

--- a/examples/unix/machine_bios.py
+++ b/examples/unix/machine_bios.py
@@ -6,4 +6,4 @@
 
 import umachine as machine
 
-print(hex(machine.mem16[0xc0000]))
+print(hex(machine.mem16[0xC0000]))

--- a/extmod/webrepl/webrepl.py
+++ b/extmod/webrepl/webrepl.py
@@ -9,6 +9,7 @@ import _webrepl
 listen_s = None
 client_s = None
 
+
 def setup_conn(port, accept_handler):
     global listen_s
     listen_s = socket.socket()
@@ -63,6 +64,7 @@ def start(port=8266, password=None):
     if password is None:
         try:
             import webrepl_cfg
+
             _webrepl.password(webrepl_cfg.PASS)
             setup_conn(port, accept_conn)
             print("Started webrepl in normal mode")

--- a/extmod/webrepl/webrepl_setup.py
+++ b/extmod/webrepl/webrepl_setup.py
@@ -1,10 +1,12 @@
 import sys
-#import uos as os
+
+# import uos as os
 import os
 import machine
 
 RC = "./boot.py"
 CONFIG = "./webrepl_cfg.py"
+
 
 def input_choice(prompt, choices):
     while 1:
@@ -12,8 +14,10 @@ def input_choice(prompt, choices):
         if resp in choices:
             return resp
 
+
 def getpass(prompt):
     return input(prompt)
+
 
 def input_pass():
     while 1:
@@ -77,7 +81,9 @@ def main():
 
     if resp == "E":
         if exists(CONFIG):
-            resp2 = input_choice("Would you like to change WebREPL password? (y/n) ", ("y", "n", ""))
+            resp2 = input_choice(
+                "Would you like to change WebREPL password? (y/n) ", ("y", "n", "")
+            )
         else:
             print("To enable WebREPL, you must set password for it")
             resp2 = "y"
@@ -87,8 +93,11 @@ def main():
             with open(CONFIG, "w") as f:
                 f.write("PASS = %r\n" % passwd)
 
-
-    if resp not in ("D", "E") or (resp == "D" and not status) or (resp == "E" and status):
+    if (
+        resp not in ("D", "E")
+        or (resp == "D" and not status)
+        or (resp == "E" and status)
+    ):
         print("No further action required")
         sys.exit()
 
@@ -98,5 +107,6 @@ def main():
     resp = input_choice("Would you like to reboot now? (y/n) ", ("y", "n", ""))
     if resp == "y":
         machine.reset()
+
 
 main()

--- a/extmod/webrepl/websocket_helper.py
+++ b/extmod/webrepl/websocket_helper.py
@@ -1,4 +1,5 @@
 import sys
+
 try:
     import ubinascii as binascii
 except:
@@ -10,10 +11,11 @@ except:
 
 DEBUG = 0
 
+
 def server_handshake(sock):
     clr = sock.makefile("rwb", 0)
     l = clr.readline()
-    #sys.stdout.write(repr(l))
+    # sys.stdout.write(repr(l))
 
     webkey = None
 
@@ -23,7 +25,7 @@ def server_handshake(sock):
             raise OSError("EOF in headers")
         if l == b"\r\n":
             break
-    #    sys.stdout.write(l)
+        #    sys.stdout.write(l)
         h, v = [x.strip() for x in l.split(b":", 1)]
         if DEBUG:
             print((h, v))
@@ -43,11 +45,13 @@ def server_handshake(sock):
     if DEBUG:
         print("respkey:", respkey)
 
-    sock.send(b"""\
+    sock.send(
+        b"""\
 HTTP/1.1 101 Switching Protocols\r
 Upgrade: websocket\r
 Connection: Upgrade\r
-Sec-WebSocket-Accept: """)
+Sec-WebSocket-Accept: """
+    )
     sock.send(respkey)
     sock.send("\r\n\r\n")
 
@@ -57,18 +61,22 @@ Sec-WebSocket-Accept: """)
 # servers.
 def client_handshake(sock):
     cl = sock.makefile("rwb", 0)
-    cl.write(b"""\
+    cl.write(
+        b"""\
 GET / HTTP/1.1\r
 Host: echo.websocket.org\r
 Connection: Upgrade\r
 Upgrade: websocket\r
 Sec-WebSocket-Key: foo\r
 \r
-""")
+"""
+    )
     l = cl.readline()
-#    print(l)
+    #    print(l)
     while 1:
         l = cl.readline()
         if l == b"\r\n":
             break
+
+
 #        sys.stdout.write(l)

--- a/lib/memzip/make-memzip.py
+++ b/lib/memzip/make-memzip.py
@@ -15,6 +15,7 @@ import subprocess
 import sys
 import types
 
+
 def create_zip(zip_filename, zip_dir):
     abs_zip_filename = os.path.abspath(zip_filename)
     save_cwd = os.getcwd()
@@ -23,6 +24,7 @@ def create_zip(zip_filename, zip_dir):
         os.remove(abs_zip_filename)
     subprocess.check_call(['zip', '-0', '-r', '-D', abs_zip_filename, '.'])
     os.chdir(save_cwd)
+
 
 def create_c_from_file(c_filename, zip_filename):
     with open(zip_filename, 'rb') as zip_file:
@@ -43,28 +45,28 @@ def create_c_from_file(c_filename, zip_filename):
                 print('', file=c_file)
             print('};', file=c_file)
 
+
 def main():
     parser = argparse.ArgumentParser(
         prog='make-memzip.py',
         usage='%(prog)s [options] [command]',
-        description='Generates a C source memzip file.'
+        description='Generates a C source memzip file.',
     )
     parser.add_argument(
-        '-z', '--zip-file',
+        '-z',
+        '--zip-file',
         dest='zip_filename',
         help='Specifies the name of the created zip file.',
-        default='memzip_files.zip'
+        default='memzip_files.zip',
     )
     parser.add_argument(
-        '-c', '--c-file',
+        '-c',
+        '--c-file',
         dest='c_filename',
         help='Specifies the name of the created C source file.',
-        default='memzip_files.c'
+        default='memzip_files.c',
     )
-    parser.add_argument(
-        dest='source_dir',
-        default='memzip_files'
-    )
+    parser.add_argument(dest='source_dir', default='memzip_files')
     args = parser.parse_args(sys.argv[1:])
 
     print('args.zip_filename =', args.zip_filename)
@@ -74,6 +76,6 @@ def main():
     create_zip(args.zip_filename, args.source_dir)
     create_c_from_file(args.c_filename, args.zip_filename)
 
+
 if __name__ == "__main__":
     main()
-

--- a/ports/cc3200/boards/make-pins.py
+++ b/ports/cc3200/boards/make-pins.py
@@ -8,14 +8,16 @@ import sys
 import csv
 
 
-SUPPORTED_AFS = { 'UART': ('TX', 'RX', 'RTS', 'CTS'),
-                  'SPI': ('CLK', 'MOSI', 'MISO', 'CS0'),
-                  #'I2S': ('CLK', 'FS', 'DAT0', 'DAT1'),
-                  'I2C': ('SDA', 'SCL'),
-                  'TIM': ('PWM'),
-                  'SD': ('CLK', 'CMD', 'DAT0'),
-                  'ADC': ('CH0', 'CH1', 'CH2', 'CH3')
-                }
+SUPPORTED_AFS = {
+    'UART': ('TX', 'RX', 'RTS', 'CTS'),
+    'SPI': ('CLK', 'MOSI', 'MISO', 'CS0'),
+    #'I2S': ('CLK', 'FS', 'DAT0', 'DAT1'),
+    'I2C': ('SDA', 'SCL'),
+    'TIM': ('PWM'),
+    'SD': ('CLK', 'CMD', 'DAT0'),
+    'ADC': ('CH0', 'CH1', 'CH2', 'CH3'),
+}
+
 
 def parse_port_pin(name_str):
     """Parses a string and returns a (port, gpio_bit) tuple."""
@@ -32,6 +34,7 @@ def parse_port_pin(name_str):
 
 class AF:
     """Holds the description of an alternate function"""
+
     def __init__(self, name, idx, fn, unit, type):
         self.name = name
         self.idx = idx
@@ -42,11 +45,16 @@ class AF:
         self.type = type
 
     def print(self):
-        print ('    AF({:16s}, {:4d}, {:8s}, {:4d}, {:8s}),    // {}'.format(self.name, self.idx, self.fn, self.unit, self.type, self.name))
+        print(
+            '    AF({:16s}, {:4d}, {:8s}, {:4d}, {:8s}),    // {}'.format(
+                self.name, self.idx, self.fn, self.unit, self.type, self.name
+            )
+        )
 
 
 class Pin:
     """Holds the information associated with a pin."""
+
     def __init__(self, name, port, gpio_bit, pin_num):
         self.name = name
         self.port = port
@@ -65,11 +73,23 @@ class Pin:
             for af in self.afs:
                 af.print()
             print('};')
-            print('pin_obj_t pin_{:4s} = PIN({:6s}, {:1d}, {:3d}, {:2d}, pin_{}_af, {});\n'.format(
-                   self.name, self.name, self.port, self.gpio_bit, self.pin_num, self.name, len(self.afs)))
+            print(
+                'pin_obj_t pin_{:4s} = PIN({:6s}, {:1d}, {:3d}, {:2d}, pin_{}_af, {});\n'.format(
+                    self.name,
+                    self.name,
+                    self.port,
+                    self.gpio_bit,
+                    self.pin_num,
+                    self.name,
+                    len(self.afs),
+                )
+            )
         else:
-            print('pin_obj_t pin_{:4s} = PIN({:6s}, {:1d}, {:3d}, {:2d}, NULL, 0);\n'.format(
-                   self.name, self.name, self.port, self.gpio_bit, self.pin_num))
+            print(
+                'pin_obj_t pin_{:4s} = PIN({:6s}, {:1d}, {:3d}, {:2d}, NULL, 0);\n'.format(
+                    self.name, self.name, self.port, self.gpio_bit, self.pin_num
+                )
+            )
 
     def print_header(self, hdr_file):
         hdr_file.write('extern pin_obj_t pin_{:s};\n'.format(self.name))
@@ -77,7 +97,7 @@ class Pin:
 
 class Pins:
     def __init__(self):
-        self.board_pins = []   # list of pin objects
+        self.board_pins = []  # list of pin objects
 
     def find_pin(self, port, gpio_bit):
         for pin in self.board_pins:
@@ -103,20 +123,24 @@ class Pins:
                 except:
                     continue
                 if not row[pin_col].isdigit():
-                    raise ValueError("Invalid pin number {:s} in row {:s}".format(row[pin_col]), row)
+                    raise ValueError(
+                        "Invalid pin number {:s} in row {:s}".format(row[pin_col]), row
+                    )
                 # Pin numbers must start from 0 when used with the TI API
-                pin_num = int(row[pin_col]) - 1;        
+                pin_num = int(row[pin_col]) - 1
                 pin = Pin(row[pinname_col], port_num, gpio_bit, pin_num)
                 self.board_pins.append(pin)
                 af_idx = 0
                 for af in row[af_start_col:]:
                     af_splitted = af.split('_')
                     fn_name = af_splitted[0].rstrip('0123456789')
-                    if  fn_name in SUPPORTED_AFS:
+                    if fn_name in SUPPORTED_AFS:
                         type_name = af_splitted[1]
                         if type_name in SUPPORTED_AFS[fn_name]:
                             unit_idx = af_splitted[0][-1]
-                            pin.add_af(AF(af, af_idx, fn_name, int(unit_idx), type_name))
+                            pin.add_af(
+                                AF(af, af_idx, fn_name, int(unit_idx), type_name)
+                            )
                     af_idx += 1
 
     def parse_board_file(self, filename, cpu_pin_col):
@@ -133,12 +157,24 @@ class Pins:
 
     def print_named(self, label, pins):
         print('')
-        print('STATIC const mp_rom_map_elem_t pin_{:s}_pins_locals_dict_table[] = {{'.format(label))
+        print(
+            'STATIC const mp_rom_map_elem_t pin_{:s}_pins_locals_dict_table[] = {{'.format(
+                label
+            )
+        )
         for pin in pins:
             if pin.board_pin:
-                print('    {{ MP_ROM_QSTR(MP_QSTR_{:6s}), MP_ROM_PTR(&pin_{:6s}) }},'.format(pin.name, pin.name))
+                print(
+                    '    {{ MP_ROM_QSTR(MP_QSTR_{:6s}), MP_ROM_PTR(&pin_{:6s}) }},'.format(
+                        pin.name, pin.name
+                    )
+                )
         print('};')
-        print('MP_DEFINE_CONST_DICT(pin_{:s}_pins_locals_dict, pin_{:s}_pins_locals_dict_table);'.format(label, label));
+        print(
+            'MP_DEFINE_CONST_DICT(pin_{:s}_pins_locals_dict, pin_{:s}_pins_locals_dict_table);'.format(
+                label, label
+            )
+        )
 
     def print(self):
         for pin in self.board_pins:
@@ -174,36 +210,38 @@ def main():
     parser = argparse.ArgumentParser(
         prog="make-pins.py",
         usage="%(prog)s [options] [command]",
-        description="Generate board specific pin file"
+        description="Generate board specific pin file",
     )
     parser.add_argument(
-        "-a", "--af",
+        "-a",
+        "--af",
         dest="af_filename",
         help="Specifies the alternate function file for the chip",
-        default="cc3200_af.csv"
+        default="cc3200_af.csv",
     )
     parser.add_argument(
-        "-b", "--board",
-        dest="board_filename",
-        help="Specifies the board file",
+        "-b", "--board", dest="board_filename", help="Specifies the board file",
     )
     parser.add_argument(
-        "-p", "--prefix",
+        "-p",
+        "--prefix",
         dest="prefix_filename",
         help="Specifies beginning portion of generated pins file",
-        default="cc3200_prefix.c"
+        default="cc3200_prefix.c",
     )
     parser.add_argument(
-        "-q", "--qstr",
+        "-q",
+        "--qstr",
         dest="qstr_filename",
         help="Specifies name of generated qstr header file",
-        default="build/pins_qstr.h"
+        default="build/pins_qstr.h",
     )
     parser.add_argument(
-        "-r", "--hdr",
+        "-r",
+        "--hdr",
         dest="hdr_filename",
         help="Specifies name of generated pin header file",
-        default="build/pins.h"
+        default="build/pins.h",
     )
     args = parser.parse_args(sys.argv[1:])
 

--- a/ports/cc3200/tools/smoke.py
+++ b/ports/cc3200/tools/smoke.py
@@ -9,17 +9,42 @@ Execute it like this:
 python3 run-tests --target wipy --device 192.168.1.1 ../cc3200/tools/smoke.py
 """
 
-pin_map = [23, 24, 11, 12, 13, 14, 15, 16, 17, 22, 28, 10, 9, 8, 7, 6, 30, 31, 3, 0, 4, 5]
+pin_map = [
+    23,
+    24,
+    11,
+    12,
+    13,
+    14,
+    15,
+    16,
+    17,
+    22,
+    28,
+    10,
+    9,
+    8,
+    7,
+    6,
+    30,
+    31,
+    3,
+    0,
+    4,
+    5,
+]
 test_bytes = os.urandom(1024)
 
-def test_pin_read (pull):
+
+def test_pin_read(pull):
     # enable the pull resistor on all pins, then read the value
     for p in pin_map:
         pin = Pin('GP' + str(p), mode=Pin.IN, pull=pull)
         # read the pin value
         print(pin())
 
-def test_pin_shorts (pull):
+
+def test_pin_shorts(pull):
     if pull == Pin.PULL_UP:
         pull_inverted = Pin.PULL_DOWN
     else:
@@ -35,6 +60,7 @@ def test_pin_shorts (pull):
         i += 1
         # read the pin value
         print(pin())
+
 
 test_pin_read(Pin.PULL_UP)
 test_pin_read(Pin.PULL_DOWN)
@@ -72,5 +98,4 @@ time1 = rtc.now()
 time.sleep_ms(1000)
 time2 = rtc.now()
 print(time2[5] - time1[5] == 1)
-print(time2[6] - time1[6] < 5000) # microseconds
-
+print(time2[6] - time1[6] < 5000)  # microseconds

--- a/ports/cc3200/tools/uniflash.py
+++ b/ports/cc3200/tools/uniflash.py
@@ -19,11 +19,13 @@ import subprocess
 
 
 def print_exception(e):
-    print ('Exception: {}, on line {}'.format(e, sys.exc_info()[-1].tb_lineno))
+    print('Exception: {}, on line {}'.format(e, sys.exc_info()[-1].tb_lineno))
 
 
 def execute(command):
-    process = subprocess.Popen(command, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
+    process = subprocess.Popen(
+        command, stdout=subprocess.PIPE, stderr=subprocess.STDOUT
+    )
     cmd_log = ""
 
     # Poll process for new output until finished
@@ -43,12 +45,21 @@ def execute(command):
     else:
         raise ProcessException(command, exitCode, output)
 
+
 def main():
-    cmd_parser = argparse.ArgumentParser(description='Flash the WiPy and optionally run a small test on it.')
-    cmd_parser.add_argument('-u', '--uniflash', default=None, help='the path to the uniflash cli executable')
-    cmd_parser.add_argument('-c', '--config', default=None, help='the path to the uniflash config file')
+    cmd_parser = argparse.ArgumentParser(
+        description='Flash the WiPy and optionally run a small test on it.'
+    )
+    cmd_parser.add_argument(
+        '-u', '--uniflash', default=None, help='the path to the uniflash cli executable'
+    )
+    cmd_parser.add_argument(
+        '-c', '--config', default=None, help='the path to the uniflash config file'
+    )
     cmd_parser.add_argument('-p', '--port', default=8, help='the com serial port')
-    cmd_parser.add_argument('-s', '--servicepack', default=None, help='the path to the servicepack file')
+    cmd_parser.add_argument(
+        '-s', '--servicepack', default=None, help='the path to the servicepack file'
+    )
     args = cmd_parser.parse_args()
 
     output = ""
@@ -59,9 +70,33 @@ def main():
         if args.uniflash == None or args.config == None:
             raise ValueError('uniflash path and config path are mandatory')
         if args.servicepack == None:
-            output += execute([args.uniflash, '-config', args.config, '-setOptions', com_port, '-operations', 'format', 'program'])
+            output += execute(
+                [
+                    args.uniflash,
+                    '-config',
+                    args.config,
+                    '-setOptions',
+                    com_port,
+                    '-operations',
+                    'format',
+                    'program',
+                ]
+            )
         else:
-            output += execute([args.uniflash, '-config', args.config, '-setOptions', com_port, servicepack_path, '-operations', 'format', 'servicePackUpdate', 'program'])
+            output += execute(
+                [
+                    args.uniflash,
+                    '-config',
+                    args.config,
+                    '-setOptions',
+                    com_port,
+                    servicepack_path,
+                    '-operations',
+                    'format',
+                    'servicePackUpdate',
+                    'program',
+                ]
+            )
     except Exception as e:
         print_exception(e)
         output = ""
@@ -76,6 +111,7 @@ def main():
             print("ERROR: Programming failed!")
             print("======================================")
             sys.exit(1)
+
 
 if __name__ == "__main__":
     main()

--- a/ports/esp32/boards/TINYPICO/modules/dotstar.py
+++ b/ports/esp32/boards/TINYPICO/modules/dotstar.py
@@ -63,8 +63,7 @@ class DotStar:
         dotstar[0] = (128, 0, 0) # Red
     """
 
-    def __init__(self, spi, n, *, brightness=1.0, auto_write=True,
-                 pixel_order=BGR):
+    def __init__(self, spi, n, *, brightness=1.0, auto_write=True, pixel_order=BGR):
         self._spi = spi
         self._n = n
         # Supply one extra clock cycle for each two pixels in the strip.
@@ -79,10 +78,10 @@ class DotStar:
             self._buf[i] = 0x00
         # Mark the beginnings of each pixel.
         for i in range(START_HEADER_SIZE, self.end_header_index, 4):
-            self._buf[i] = 0xff
+            self._buf[i] = 0xFF
         # 0xff bytes at the end.
         for i in range(self.end_header_index, len(self._buf)):
-            self._buf[i] = 0xff
+            self._buf[i] = 0xFF
         self._brightness = 1.0
         # Set auto_write to False temporarily so brightness setter does _not_
         # call show() while in __init__.
@@ -129,7 +128,7 @@ class DotStar:
         offset = index * 4 + START_HEADER_SIZE
         rgb = value
         if isinstance(value, int):
-            rgb = (value >> 16, (value >> 8) & 0xff, value & 0xff)
+            rgb = (value >> 16, (value >> 8) & 0xFF, value & 0xFF)
 
         if len(rgb) == 4:
             brightness = value[3]
@@ -171,15 +170,18 @@ class DotStar:
             out = []
             for in_i in range(*index.indices(self._n)):
                 out.append(
-                    tuple(self._buf[in_i * 4 + (3 - i) + START_HEADER_SIZE] for i in range(3)))
+                    tuple(
+                        self._buf[in_i * 4 + (3 - i) + START_HEADER_SIZE]
+                        for i in range(3)
+                    )
+                )
             return out
         if index < 0:
             index += len(self)
         if index >= self._n or index < 0:
             raise IndexError
         offset = index * 4
-        return tuple(self._buf[offset + (3 - i) + START_HEADER_SIZE]
-                     for i in range(3))
+        return tuple(self._buf[offset + (3 - i) + START_HEADER_SIZE] for i in range(3))
 
     def __len__(self):
         return self._n
@@ -219,10 +221,12 @@ class DotStar:
             for i in range(START_HEADER_SIZE):
                 buf[i] = 0x00
             for i in range(START_HEADER_SIZE, self.end_header_index):
-                buf[i] = self._buf[i] if i % 4 == 0 else int(self._buf[i] * self._brightness)
+                buf[i] = (
+                    self._buf[i] if i % 4 == 0 else int(self._buf[i] * self._brightness)
+                )
             # Four 0xff bytes at the end.
             for i in range(self.end_header_index, len(buf)):
-                buf[i] = 0xff
+                buf[i] = 0xFF
 
         if self._spi:
             self._spi.write(buf)

--- a/ports/esp32/boards/TINYPICO/modules/tinypico.py
+++ b/ports/esp32/boards/TINYPICO/modules/tinypico.py
@@ -29,11 +29,11 @@ SPI_MOSI = const(23)
 SPI_CLK = const(18)
 SPI_MISO = const(19)
 
-#I2C
+# I2C
 I2C_SDA = const(21)
 I2C_SCL = const(22)
 
-#DAC
+# DAC
 DAC1 = const(25)
 DAC2 = const(26)
 
@@ -47,11 +47,14 @@ def get_battery_voltage():
     Returns the current battery voltage. If no battery is connected, returns 3.7V
     This is an approximation only, but useful to detect of the charge state of the battery is getting low.
     """
-    adc = ADC(Pin(BAT_VOLTAGE))             # Assign the ADC pin to read
-    measuredvbat = adc.read()               # Read the value
-    measuredvbat /= 4095                    # divide by 4095 as we are using the default ADC voltage range of 0-1V
-    measuredvbat *= 3.7                     # Multiply by 3.7V, our reference voltage
+    adc = ADC(Pin(BAT_VOLTAGE))  # Assign the ADC pin to read
+    measuredvbat = adc.read()  # Read the value
+    measuredvbat /= (
+        4095  # divide by 4095 as we are using the default ADC voltage range of 0-1V
+    )
+    measuredvbat *= 3.7  # Multiply by 3.7V, our reference voltage
     return measuredvbat
+
 
 # Return the current charge state of the battery - we need to read the value multiple times
 # to eliminate false negatives due to the charge IC not knowing the difference between no battery
@@ -61,13 +64,15 @@ def get_battery_charging():
     Returns the current battery charging state.
     This can trigger false positives as the charge IC can't tell the difference between a full battery or no battery connected.
     """
-    measuredVal = 0                         # start our reading at 0
-    io = Pin(BAT_CHARGE, Pin.IN)            # Assign the pin to read
+    measuredVal = 0  # start our reading at 0
+    io = Pin(BAT_CHARGE, Pin.IN)  # Assign the pin to read
 
-    for y in range(0, 10):                  # loop through 10 times adding the read values together to ensure no false positives
+    for y in range(
+        0, 10
+    ):  # loop through 10 times adding the read values together to ensure no false positives
         measuredVal += io.value()
 
-    return measuredVal == 0                 # return True if the value is 0
+    return measuredVal == 0  # return True if the value is 0
 
 
 # Power to the on-board Dotstar is controlled by a PNP transistor, so low is ON and high is OFF
@@ -80,16 +85,23 @@ def set_dotstar_power(state):
     """Set the power for the on-board Dostar to allow no current draw when not needed."""
     # Set the power pin to the inverse of state
     if state:
-        Pin(DOTSTAR_PWR, Pin.OUT, None)     # Break the PULL_HOLD on the pin
-        Pin(DOTSTAR_PWR).value(False)       # Set the pin to LOW to enable the Transistor
+        Pin(DOTSTAR_PWR, Pin.OUT, None)  # Break the PULL_HOLD on the pin
+        Pin(DOTSTAR_PWR).value(False)  # Set the pin to LOW to enable the Transistor
     else:
-        Pin(13, Pin.IN, Pin.PULL_HOLD)      # Set PULL_HOLD on the pin to allow the 3V3 pull-up to work
+        Pin(
+            13, Pin.IN, Pin.PULL_HOLD
+        )  # Set PULL_HOLD on the pin to allow the 3V3 pull-up to work
 
-    Pin(DOTSTAR_CLK, Pin.OUT if state else Pin.IN)  # If power is on, set CLK to be output, otherwise input
-    Pin(DOTSTAR_DATA, Pin.OUT if state else Pin.IN) # If power is on, set DATA to be output, otherwise input
+    Pin(
+        DOTSTAR_CLK, Pin.OUT if state else Pin.IN
+    )  # If power is on, set CLK to be output, otherwise input
+    Pin(
+        DOTSTAR_DATA, Pin.OUT if state else Pin.IN
+    )  # If power is on, set DATA to be output, otherwise input
 
     # A small delay to let the IO change state
-    time.sleep(.035)
+    time.sleep(0.035)
+
 
 # Dotstar rainbow colour wheel
 def dotstar_color_wheel(wheel_pos):
@@ -104,6 +116,7 @@ def dotstar_color_wheel(wheel_pos):
     else:
         wheel_pos -= 170
         return wheel_pos * 3, 255 - wheel_pos * 3, 0
+
 
 # Go into deep sleep but shut down the APA first to save power
 # Use this if you want lowest deep  sleep current

--- a/ports/esp32/makeimg.py
+++ b/ports/esp32/makeimg.py
@@ -21,5 +21,5 @@ with open(file_out, 'wb') as fout:
             data = fin.read()
             fout.write(data)
             cur_offset += len(data)
-            print('%-12s% 8d' % (name, len(data))) 
+            print('%-12s% 8d' % (name, len(data)))
     print('%-12s% 8d' % ('total', cur_offset))

--- a/ports/esp32/modules/_boot.py
+++ b/ports/esp32/modules/_boot.py
@@ -7,6 +7,7 @@ try:
         uos.mount(bdev, '/')
 except OSError:
     import inisetup
+
     vfs = inisetup.setup()
 
 gc.collect()

--- a/ports/esp32/modules/inisetup.py
+++ b/ports/esp32/modules/inisetup.py
@@ -1,28 +1,34 @@
 import uos
 from flashbdev import bdev
 
+
 def check_bootsec():
-    buf = bytearray(bdev.ioctl(5, 0)) # 5 is SEC_SIZE
+    buf = bytearray(bdev.ioctl(5, 0))  # 5 is SEC_SIZE
     bdev.readblocks(0, buf)
     empty = True
     for b in buf:
-        if b != 0xff:
+        if b != 0xFF:
             empty = False
             break
     if empty:
         return True
     fs_corrupted()
 
+
 def fs_corrupted():
     import time
+
     while 1:
-        print("""\
+        print(
+            """\
 FAT filesystem appears to be corrupted. If you had important data there, you
 may want to make a flash snapshot to try to recover it. Otherwise, perform
 factory reprogramming of MicroPython firmware (completely erase flash, followed
 by firmware programming).
-""")
+"""
+        )
         time.sleep(3)
+
 
 def setup():
     check_bootsec()
@@ -31,11 +37,13 @@ def setup():
     vfs = uos.VfsFat(bdev)
     uos.mount(vfs, '/')
     with open("boot.py", "w") as f:
-        f.write("""\
+        f.write(
+            """\
 # This file is executed on every boot (including wake-boot from deepsleep)
 #import esp
 #esp.osdebug(None)
 #import webrepl
 #webrepl.start()
-""")
+"""
+        )
     return vfs

--- a/ports/esp32/modules/neopixel.py
+++ b/ports/esp32/modules/neopixel.py
@@ -6,7 +6,7 @@ from esp import neopixel_write
 
 class NeoPixel:
     ORDER = (1, 0, 2, 3)
-    
+
     def __init__(self, pin, n, bpp=3, timing=1):
         self.pin = pin
         self.n = n
@@ -22,8 +22,7 @@ class NeoPixel:
 
     def __getitem__(self, index):
         offset = index * self.bpp
-        return tuple(self.buf[offset + self.ORDER[i]]
-                     for i in range(self.bpp))
+        return tuple(self.buf[offset + self.ORDER[i]] for i in range(self.bpp))
 
     def fill(self, color):
         for i in range(self.n):

--- a/ports/esp8266/modules/_boot.py
+++ b/ports/esp8266/modules/_boot.py
@@ -1,4 +1,5 @@
 import gc
+
 gc.threshold((gc.mem_free() + gc.mem_alloc()) // 4)
 import uos
 from flashbdev import bdev
@@ -8,6 +9,7 @@ if bdev:
         uos.mount(bdev, '/')
     except:
         import inisetup
+
         inisetup.setup()
 
 gc.collect()

--- a/ports/esp8266/modules/flashbdev.py
+++ b/ports/esp8266/modules/flashbdev.py
@@ -1,29 +1,30 @@
 import esp
 
+
 class FlashBdev:
 
     SEC_SIZE = 4096
     RESERVED_SECS = 1
     START_SEC = esp.flash_user_start() // SEC_SIZE + RESERVED_SECS
-    NUM_BLK = 0x6b - RESERVED_SECS
+    NUM_BLK = 0x6B - RESERVED_SECS
 
     def __init__(self, blocks=NUM_BLK):
         self.blocks = blocks
 
     def readblocks(self, n, buf, off=0):
-        #print("readblocks(%s, %x(%d), %d)" % (n, id(buf), len(buf), off))
+        # print("readblocks(%s, %x(%d), %d)" % (n, id(buf), len(buf), off))
         esp.flash_read((n + self.START_SEC) * self.SEC_SIZE + off, buf)
 
     def writeblocks(self, n, buf, off=None):
-        #print("writeblocks(%s, %x(%d), %d)" % (n, id(buf), len(buf), off))
-        #assert len(buf) <= self.SEC_SIZE, len(buf)
+        # print("writeblocks(%s, %x(%d), %d)" % (n, id(buf), len(buf), off))
+        # assert len(buf) <= self.SEC_SIZE, len(buf)
         if off is None:
             esp.flash_erase(n + self.START_SEC)
             off = 0
         esp.flash_write((n + self.START_SEC) * self.SEC_SIZE + off, buf)
 
     def ioctl(self, op, arg):
-        #print("ioctl(%d, %r)" % (op, arg))
+        # print("ioctl(%d, %r)" % (op, arg))
         if op == 4:  # MP_BLOCKDEV_IOCTL_BLOCK_COUNT
             return self.blocks
         if op == 5:  # MP_BLOCKDEV_IOCTL_BLOCK_SIZE
@@ -32,8 +33,9 @@ class FlashBdev:
             esp.flash_erase(arg + self.START_SEC)
             return 0
 
+
 size = esp.flash_size()
-if size < 1024*1024:
+if size < 1024 * 1024:
     bdev = None
 else:
     # 20K at the flash end is reserved for SDK params storage

--- a/ports/esp8266/modules/inisetup.py
+++ b/ports/esp8266/modules/inisetup.py
@@ -2,35 +2,46 @@ import uos
 import network
 from flashbdev import bdev
 
+
 def wifi():
     import ubinascii
+
     ap_if = network.WLAN(network.AP_IF)
     essid = b"MicroPython-%s" % ubinascii.hexlify(ap_if.config("mac")[-3:])
-    ap_if.config(essid=essid, authmode=network.AUTH_WPA_WPA2_PSK, password=b"micropythoN")
+    ap_if.config(
+        essid=essid, authmode=network.AUTH_WPA_WPA2_PSK, password=b"micropythoN"
+    )
+
 
 def check_bootsec():
     buf = bytearray(bdev.SEC_SIZE)
     bdev.readblocks(0, buf)
     empty = True
     for b in buf:
-        if b != 0xff:
+        if b != 0xFF:
             empty = False
             break
     if empty:
         return True
     fs_corrupted()
 
+
 def fs_corrupted():
     import time
+
     while 1:
-        print("""\
+        print(
+            """\
 The FAT filesystem starting at sector %d with size %d sectors appears to
 be corrupted. If you had important data there, you may want to make a flash
 snapshot to try to recover it. Otherwise, perform factory reprogramming
 of MicroPython firmware (completely erase flash, followed by firmware
 programming).
-""" % (bdev.START_SEC, bdev.blocks))
+"""
+            % (bdev.START_SEC, bdev.blocks)
+        )
         time.sleep(3)
+
 
 def setup():
     check_bootsec()
@@ -40,7 +51,8 @@ def setup():
     vfs = uos.VfsFat(bdev)
     uos.mount(vfs, '/')
     with open("boot.py", "w") as f:
-        f.write("""\
+        f.write(
+            """\
 # This file is executed on every boot (including wake-boot from deepsleep)
 #import esp
 #esp.osdebug(None)
@@ -50,5 +62,6 @@ import gc
 #import webrepl
 #webrepl.start()
 gc.collect()
-""")
+"""
+        )
     return vfs

--- a/ports/esp8266/modules/neopixel.py
+++ b/ports/esp8266/modules/neopixel.py
@@ -21,8 +21,7 @@ class NeoPixel:
 
     def __getitem__(self, index):
         offset = index * self.bpp
-        return tuple(self.buf[offset + self.ORDER[i]]
-                     for i in range(self.bpp))
+        return tuple(self.buf[offset + self.ORDER[i]] for i in range(self.bpp))
 
     def fill(self, color):
         for i in range(self.n):

--- a/ports/esp8266/modules/ntptime.py
+++ b/ports/esp8266/modules/ntptime.py
@@ -13,9 +13,10 @@ NTP_DELTA = 3155673600
 # The NTP host can be configured at runtime by doing: ntptime.host = 'myhost.org'
 host = "pool.ntp.org"
 
+
 def time():
     NTP_QUERY = bytearray(48)
-    NTP_QUERY[0] = 0x1b
+    NTP_QUERY[0] = 0x1B
     addr = socket.getaddrinfo(host, 123)[0][-1]
     s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
     try:
@@ -27,11 +28,13 @@ def time():
     val = struct.unpack("!I", msg[40:44])[0]
     return val - NTP_DELTA
 
+
 # There's currently no timezone support in MicroPython, so
 # utime.localtime() will return UTC time (as if it was .gmtime())
 def settime():
     t = time()
     import machine
     import utime
+
     tm = utime.localtime(t)
     machine.RTC().datetime((tm[0], tm[1], tm[2], tm[6] + 1, tm[3], tm[4], tm[5], 0))

--- a/ports/esp8266/modules/port_diag.py
+++ b/ports/esp8266/modules/port_diag.py
@@ -10,13 +10,19 @@ def main():
     fid = esp.flash_id()
 
     print("FlashROM:")
-    print("Flash ID: %x (Vendor: %x Device: %x)" % (fid, fid & 0xff, fid & 0xff00 | fid >> 16))
+    print(
+        "Flash ID: %x (Vendor: %x Device: %x)"
+        % (fid, fid & 0xFF, fid & 0xFF00 | fid >> 16)
+    )
 
     print("Flash bootloader data:")
     SZ_MAP = {0: "512KB", 1: "256KB", 2: "1MB", 3: "2MB", 4: "4MB"}
-    FREQ_MAP = {0: "40MHZ", 1: "26MHZ", 2: "20MHz", 0xf: "80MHz"}
+    FREQ_MAP = {0: "40MHZ", 1: "26MHZ", 2: "20MHz", 0xF: "80MHz"}
     print("Byte @2: %02x" % ROM[2])
-    print("Byte @3: %02x (Flash size: %s Flash freq: %s)" % (ROM[3], SZ_MAP.get(ROM[3] >> 4, "?"), FREQ_MAP.get(ROM[3] & 0xf)))
+    print(
+        "Byte @3: %02x (Flash size: %s Flash freq: %s)"
+        % (ROM[3], SZ_MAP.get(ROM[3] >> 4, "?"), FREQ_MAP.get(ROM[3] & 0xF))
+    )
     print("Firmware checksum:")
     print(esp.check_fw())
 
@@ -24,7 +30,15 @@ def main():
     print("STA ifconfig:", network.WLAN(network.STA_IF).ifconfig())
     print("AP ifconfig:", network.WLAN(network.AP_IF).ifconfig())
     print("Free WiFi driver buffers of type:")
-    for i, comm in enumerate(("1,2 TX", "4 Mngmt TX(len: 0x41-0x100)", "5 Mngmt TX (len: 0-0x40)", "7", "8 RX")):
+    for i, comm in enumerate(
+        (
+            "1,2 TX",
+            "4 Mngmt TX(len: 0x41-0x100)",
+            "5 Mngmt TX (len: 0-0x40)",
+            "7",
+            "8 RX",
+        )
+    ):
         print("%d: %d (%s)" % (i, esp.esf_free_bufs(i), comm))
     print("lwIP PCBs:")
     lwip.print_pcbs()

--- a/ports/nrf/boards/make-pins.py
+++ b/ports/nrf/boards/make-pins.py
@@ -7,9 +7,8 @@ import argparse
 import sys
 import csv
 
-SUPPORTED_FN = {
-    'UART'  : ['RX', 'TX', 'CTS', 'RTS']
-}
+SUPPORTED_FN = {'UART': ['RX', 'TX', 'CTS', 'RTS']}
+
 
 def parse_pin(name_str):
     """Parses a string and returns a pin-num."""
@@ -22,12 +21,13 @@ def parse_pin(name_str):
         raise ValueError("Expecting numeric pin number.")
     return int(pin_str)
 
+
 def split_name_num(name_num):
     num = None
     for num_idx in range(len(name_num) - 1, -1, -1):
         if not name_num[num_idx].isdigit():
-            name = name_num[0:num_idx + 1]
-            num_str = name_num[num_idx + 1:]
+            name = name_num[0 : num_idx + 1]
+            num_str = name_num[num_idx + 1 :]
             if len(num_str) > 0:
                 num = int(num_str)
             break
@@ -70,14 +70,17 @@ class AlternateFunction(object):
     def print(self):
         """Prints the C representation of this AF."""
         if self.supported:
-            print('  AF',  end='')
+            print('  AF', end='')
         else:
             print('  //', end='')
         fn_num = self.fn_num
         if fn_num is None:
             fn_num = 0
-        print('({:2d}, {:8s}, {:2d}, {:10s}, {:8s}), // {:s}'.format(self.idx,
-              self.func, fn_num, self.pin_type, self.ptr(), self.af_str))
+        print(
+            '({:2d}, {:8s}, {:2d}, {:10s}, {:8s}), // {:s}'.format(
+                self.idx, self.func, fn_num, self.pin_type, self.ptr(), self.af_str
+            )
+        )
 
     def qstr_list(self):
         return [self.mux_name()]
@@ -108,9 +111,9 @@ class Pin(object):
         self.board_index = index
 
     def parse_adc(self, adc_str):
-        if (adc_str[:3] != 'ADC'):
+        if adc_str[:3] != 'ADC':
             return
-        (adc,channel) = adc_str.split('_')
+        (adc, channel) = adc_str.split('_')
         for idx in range(3, len(adc)):
             self.adc_num = int(adc[idx])
         self.adc_channel = int(channel[2:])
@@ -134,7 +137,7 @@ class Pin(object):
 
     def adc_num_str(self):
         str = ''
-        for adc_num in range(1,4):
+        for adc_num in range(1, 4):
             if self.adc_num & (1 << (adc_num - 1)):
                 if len(str) > 0:
                     str += ' | '
@@ -145,33 +148,42 @@ class Pin(object):
         return str
 
     def print_const_table_entry(self):
-        print('  PIN({:d}, {:s}, {:s}, {:d}),'.format(
-            self.pin,
-            self.alt_fn_name(null_if_0=True),
-            self.adc_num_str(), self.adc_channel))
+        print(
+            '  PIN({:d}, {:s}, {:s}, {:d}),'.format(
+                self.pin,
+                self.alt_fn_name(null_if_0=True),
+                self.adc_num_str(),
+                self.adc_channel,
+            )
+        )
 
     def print(self):
         if self.alt_fn_count == 0:
-            print("// ",  end='')
+            print("// ", end='')
         print('const pin_af_obj_t {:s}[] = {{'.format(self.alt_fn_name()))
         for alt_fn in self.alt_fn:
             alt_fn.print()
         if self.alt_fn_count == 0:
-            print("// ",  end='')
+            print("// ", end='')
         print('};')
         print('')
-        print('const pin_obj_t pin_{:s} = PIN({:d}, {:s}, {:s}, {:d});'.format(
-            self.cpu_pin_name(), self.pin,
-            self.alt_fn_name(null_if_0=True),
-            self.adc_num_str(), self.adc_channel))
+        print(
+            'const pin_obj_t pin_{:s} = PIN({:d}, {:s}, {:s}, {:d});'.format(
+                self.cpu_pin_name(),
+                self.pin,
+                self.alt_fn_name(null_if_0=True),
+                self.adc_num_str(),
+                self.adc_channel,
+            )
+        )
         print('')
 
     def print_header(self, hdr_file):
-        hdr_file.write('extern const pin_obj_t pin_{:s};\n'.
-                       format(self.cpu_pin_name()))
+        hdr_file.write('extern const pin_obj_t pin_{:s};\n'.format(self.cpu_pin_name()))
         if self.alt_fn_count > 0:
-            hdr_file.write('extern const pin_af_obj_t pin_{:s}_af[];\n'.
-                           format(self.cpu_pin_name()))
+            hdr_file.write(
+                'extern const pin_af_obj_t pin_{:s}_af[];\n'.format(self.cpu_pin_name())
+            )
 
     def qstr_list(self):
         result = []
@@ -182,7 +194,6 @@ class Pin(object):
 
 
 class NamedPin(object):
-
     def __init__(self, name, pin):
         self._name = name
         self._pin = pin
@@ -195,10 +206,9 @@ class NamedPin(object):
 
 
 class Pins(object):
-
     def __init__(self):
-        self.cpu_pins = []   # list of NamedPin objects
-        self.board_pins = [] # list of NamedPin objects
+        self.cpu_pins = []  # list of NamedPin objects
+        self.board_pins = []  # list of NamedPin objects
 
     def find_pin(self, pin_num):
         for named_pin in self.cpu_pins:
@@ -236,13 +246,25 @@ class Pins(object):
                     self.board_pins.append(NamedPin(row[0], pin))
 
     def print_named(self, label, named_pins):
-        print('STATIC const mp_rom_map_elem_t pin_{:s}_pins_locals_dict_table[] = {{'.format(label))
+        print(
+            'STATIC const mp_rom_map_elem_t pin_{:s}_pins_locals_dict_table[] = {{'.format(
+                label
+            )
+        )
         for named_pin in named_pins:
             pin = named_pin.pin()
             if pin.is_board_pin():
-                print('  {{ MP_ROM_QSTR(MP_QSTR_{:s}), MP_ROM_PTR(&machine_board_pin_obj[{:d}]) }},'.format(named_pin.name(), pin.board_index))
+                print(
+                    '  {{ MP_ROM_QSTR(MP_QSTR_{:s}), MP_ROM_PTR(&machine_board_pin_obj[{:d}]) }},'.format(
+                        named_pin.name(), pin.board_index
+                    )
+                )
         print('};')
-        print('MP_DEFINE_CONST_DICT(pin_{:s}_pins_locals_dict, pin_{:s}_pins_locals_dict_table);'.format(label, label));
+        print(
+            'MP_DEFINE_CONST_DICT(pin_{:s}_pins_locals_dict, pin_{:s}_pins_locals_dict_table);'.format(
+                label, label
+            )
+        )
 
     def print_const_table(self):
         num_board_pins = 0
@@ -252,14 +274,16 @@ class Pins(object):
                 pin.set_board_index(num_board_pins)
                 num_board_pins += 1
         print('')
-        print('const uint8_t machine_pin_num_of_board_pins = {:d};'.format(num_board_pins))
+        print(
+            'const uint8_t machine_pin_num_of_board_pins = {:d};'.format(num_board_pins)
+        )
         print('')
         print('const pin_obj_t machine_board_pin_obj[{:d}] = {{'.format(num_board_pins))
         for named_pin in self.cpu_pins:
             pin = named_pin.pin()
             if pin.is_board_pin():
                 pin.print_const_table_entry()
-        print('};');
+        print('};')
 
     def print(self):
         self.print_named('cpu', self.cpu_pins)
@@ -267,21 +291,23 @@ class Pins(object):
         self.print_named('board', self.board_pins)
 
     def print_adc(self, adc_num):
-        print('');
+        print('')
         print('const pin_obj_t * const pin_adc{:d}[] = {{'.format(adc_num))
         for channel in range(16):
             adc_found = False
             for named_pin in self.cpu_pins:
                 pin = named_pin.pin()
-                if (pin.is_board_pin() and
-                    (pin.adc_num & (1 << (adc_num - 1))) and (pin.adc_channel == channel)):
+                if (
+                    pin.is_board_pin()
+                    and (pin.adc_num & (1 << (adc_num - 1)))
+                    and (pin.adc_channel == channel)
+                ):
                     print('  &pin_{:s}, // {:d}'.format(pin.cpu_pin_name(), channel))
                     adc_found = True
                     break
             if not adc_found:
                 print('  NULL,    // {:d}'.format(channel))
         print('};')
-
 
     def print_header(self, hdr_filename):
         with open(hdr_filename, 'wt') as hdr_file:
@@ -306,9 +332,8 @@ class Pins(object):
             for qstr in sorted(qstr_set):
                 print('Q({})'.format(qstr), file=qstr_file)
 
-
     def print_af_hdr(self, af_const_filename):
-        with open(af_const_filename,  'wt') as af_const_file:
+        with open(af_const_filename, 'wt') as af_const_file:
             af_hdr_set = set([])
             mux_name_width = 0
             for named_pin in self.cpu_pins:
@@ -323,67 +348,75 @@ class Pins(object):
             for mux_name in sorted(af_hdr_set):
                 key = 'MP_ROM_QSTR(MP_QSTR_{}),'.format(mux_name)
                 val = 'MP_ROM_INT(GPIO_{})'.format(mux_name)
-                print('    { %-*s %s },' % (mux_name_width + 26, key, val),
-                      file=af_const_file)
+                print(
+                    '    { %-*s %s },' % (mux_name_width + 26, key, val),
+                    file=af_const_file,
+                )
 
     def print_af_py(self, af_py_filename):
-        with open(af_py_filename,  'wt') as af_py_file:
-            print('PINS_AF = (', file=af_py_file);
+        with open(af_py_filename, 'wt') as af_py_file:
+            print('PINS_AF = (', file=af_py_file)
             for named_pin in self.board_pins:
                 print("  ('%s', " % named_pin.name(), end='', file=af_py_file)
                 for af in named_pin.pin().alt_fn:
                     if af.is_supported():
-                        print("(%d, '%s'), " % (af.idx, af.af_str), end='', file=af_py_file)
+                        print(
+                            "(%d, '%s'), " % (af.idx, af.af_str),
+                            end='',
+                            file=af_py_file,
+                        )
                 print('),', file=af_py_file)
-            print(')',  file=af_py_file)
+            print(')', file=af_py_file)
 
 
 def main():
     parser = argparse.ArgumentParser(
         prog="make-pins.py",
         usage="%(prog)s [options] [command]",
-        description="Generate board specific pin file"
+        description="Generate board specific pin file",
     )
     parser.add_argument(
-        "-a", "--af",
+        "-a",
+        "--af",
         dest="af_filename",
         help="Specifies the alternate function file for the chip",
-        default="nrf.csv"
+        default="nrf.csv",
     )
     parser.add_argument(
         "--af-const",
         dest="af_const_filename",
         help="Specifies header file for alternate function constants.",
-        default="build/pins_af_const.h"
+        default="build/pins_af_const.h",
     )
     parser.add_argument(
         "--af-py",
         dest="af_py_filename",
         help="Specifies the filename for the python alternate function mappings.",
-        default="build/pins_af.py"
+        default="build/pins_af.py",
     )
     parser.add_argument(
-        "-b", "--board",
-        dest="board_filename",
-        help="Specifies the board file",
+        "-b", "--board", dest="board_filename", help="Specifies the board file",
     )
     parser.add_argument(
-        "-p", "--prefix",
+        "-p",
+        "--prefix",
         dest="prefix_filename",
         help="Specifies beginning portion of generated pins file",
-        default="nrf52_prefix.c"
+        default="nrf52_prefix.c",
     )
     parser.add_argument(
-        "-q", "--qstr",
+        "-q",
+        "--qstr",
         dest="qstr_filename",
         help="Specifies name of generated qstr header file",
-        default="build/pins_qstr.h"
+        default="build/pins_qstr.h",
     )
     parser.add_argument(
-        "-r", "--hdr",
+        "-r",
+        "--hdr",
         dest="hdr_filename",
         help="Specifies name of generated pin header file",
-        default="build/pins.h"
+        default="build/pins.h",
     )
     args = parser.parse_args(sys.argv[1:])
 

--- a/ports/nrf/examples/mountsd.py
+++ b/ports/nrf/examples/mountsd.py
@@ -24,12 +24,13 @@ import os
 from machine import SPI, Pin
 from sdcard import SDCard
 
+
 def mnt():
     cs = Pin("P22", mode=Pin.OUT)
     sd = SDCard(SPI(0), cs)
     os.mount(sd, '/')
 
+
 def list():
     files = os.listdir()
     print(files)
-

--- a/ports/nrf/examples/musictest.py
+++ b/ports/nrf/examples/musictest.py
@@ -1,4 +1,4 @@
-# 
+#
 # Example usage where "P3" is the Buzzer pin.
 #
 #  from musictest import play
@@ -7,6 +7,7 @@
 
 from machine import Pin
 import music
+
 
 def play(pin_str):
     p = Pin(pin_str, mode=Pin.OUT)

--- a/ports/nrf/examples/nrf52_pwm.py
+++ b/ports/nrf/examples/nrf52_pwm.py
@@ -1,6 +1,7 @@
 import time
 from machine import PWM, Pin
 
+
 def pulse():
     for i in range(0, 101):
         p = PWM(0, Pin("P17", mode=Pin.OUT), freq=PWM.FREQ_16MHZ, duty=i, period=16000)
@@ -9,7 +10,9 @@ def pulse():
         p.deinit()
 
     for i in range(0, 101):
-        p = PWM(0, Pin("P17", mode=Pin.OUT), freq=PWM.FREQ_16MHZ, duty=100-i, period=16000)
+        p = PWM(
+            0, Pin("P17", mode=Pin.OUT), freq=PWM.FREQ_16MHZ, duty=100 - i, period=16000
+        )
         p.init()
         time.sleep_ms(10)
         p.deinit()

--- a/ports/nrf/examples/nrf52_servo.py
+++ b/ports/nrf/examples/nrf52_servo.py
@@ -25,26 +25,49 @@
 import time
 from machine import PWM, Pin
 
-class Servo():
+
+class Servo:
     def __init__(self, pin_name=""):
         if pin_name:
             self.pin = Pin(pin_name, mode=Pin.OUT, pull=Pin.PULL_DOWN)
         else:
             self.pin = Pin("P22", mode=Pin.OUT, pull=Pin.PULL_DOWN)
+
     def left(self):
-        p = PWM(0, self.pin, freq=PWM.FREQ_125KHZ, pulse_width=105, period=2500, mode=PWM.MODE_HIGH_LOW)
+        p = PWM(
+            0,
+            self.pin,
+            freq=PWM.FREQ_125KHZ,
+            pulse_width=105,
+            period=2500,
+            mode=PWM.MODE_HIGH_LOW,
+        )
         p.init()
         time.sleep_ms(200)
         p.deinit()
-        
+
     def center(self):
-        p = PWM(0, self.pin, freq=PWM.FREQ_125KHZ, pulse_width=188, period=2500, mode=PWM.MODE_HIGH_LOW)
+        p = PWM(
+            0,
+            self.pin,
+            freq=PWM.FREQ_125KHZ,
+            pulse_width=188,
+            period=2500,
+            mode=PWM.MODE_HIGH_LOW,
+        )
         p.init()
         time.sleep_ms(200)
         p.deinit()
-        
+
     def right(self):
-        p = PWM(0, self.pin, freq=PWM.FREQ_125KHZ, pulse_width=275, period=2500, mode=PWM.MODE_HIGH_LOW)
+        p = PWM(
+            0,
+            self.pin,
+            freq=PWM.FREQ_125KHZ,
+            pulse_width=275,
+            period=2500,
+            mode=PWM.MODE_HIGH_LOW,
+        )
         p.init()
         time.sleep_ms(200)
         p.deinit()

--- a/ports/nrf/examples/powerup.py
+++ b/ports/nrf/examples/powerup.py
@@ -41,11 +41,13 @@ from machine import ADC
 from machine import Pin
 from ubluepy import Peripheral, Scanner, constants
 
+
 def bytes_to_str(bytes):
     string = ""
     for b in bytes:
         string += chr(b)
     return string
+
 
 def get_device_names(scan_entries):
     dev_names = []
@@ -53,9 +55,10 @@ def get_device_names(scan_entries):
         scan = e.getScanData()
         if scan:
             for s in scan:
-               if s[0] == constants.ad_types.AD_TYPE_COMPLETE_LOCAL_NAME:
-                   dev_names.append((e, bytes_to_str(s[2])))
+                if s[0] == constants.ad_types.AD_TYPE_COMPLETE_LOCAL_NAME:
+                    dev_names.append((e, bytes_to_str(s[2])))
     return dev_names
+
 
 def find_device_by_name(name):
     s = Scanner()
@@ -65,6 +68,7 @@ def find_device_by_name(name):
     for dev in device_names:
         if name == dev[1]:
             return dev[0]
+
 
 class PowerUp3:
     def __init__(self):
@@ -76,14 +80,14 @@ class PowerUp3:
         self.btn_speed_off = Pin("P16", mode=Pin.IN, pull=Pin.PULL_UP)
 
         self.x_mid = 0
-        
+
         self.calibrate()
         self.connect()
         self.loop()
-        
+
     def read_stick_x(self):
         return self.x_adc.value()
-        
+
     def button_speed_up(self):
         return not bool(self.btn_speed_up.value())
 
@@ -146,7 +150,7 @@ class PowerUp3:
             self.angle(0)
 
     def rudder_left(self, angle):
-        steps = (angle // self.interval_size_left)
+        steps = angle // self.interval_size_left
         new_angle = 60 - steps
 
         if self.old_angle != new_angle:
@@ -154,7 +158,7 @@ class PowerUp3:
             self.old_angle = new_angle
 
     def rudder_right(self, angle):
-        steps = (angle // self.interval_size_right)
+        steps = angle // self.interval_size_right
         new_angle = -steps
 
         if self.old_angle != new_angle:
@@ -162,9 +166,9 @@ class PowerUp3:
             self.old_angle = new_angle
 
     def throttle(self, speed):
-        if (speed > 200):
+        if speed > 200:
             speed = 200
-        elif (speed < 0):
+        elif speed < 0:
             speed = 0
 
         if self.old_speed != speed:
@@ -188,10 +192,10 @@ class PowerUp3:
 
             # read out new angle
             new_angle = self.read_stick_x()
-            if (new_angle < 256):
-                if (new_angle > right_threshold):
+            if new_angle < 256:
+                if new_angle > right_threshold:
                     self.rudder_right(new_angle - self.x_mid)
-                elif (new_angle < left_threshold):
+                elif new_angle < left_threshold:
                     self.rudder_left(new_angle)
                 else:
                     self.rudder_center()

--- a/ports/nrf/examples/seeed_tft.py
+++ b/ports/nrf/examples/seeed_tft.py
@@ -51,9 +51,11 @@ import framebuf
 from machine import SPI, Pin
 from sdcard import SDCard
 
+
 def mount_tf(self, mount_point="/"):
     sd = SDCard(SPI(0), Pin("P15", mode=Pin.OUT))
     os.mount(sd, mount_point)
+
 
 class ILI9341:
     def __init__(self, width, height):
@@ -61,14 +63,16 @@ class ILI9341:
         self.height = height
         self.pages = self.height // 8
         self.buffer = bytearray(self.pages * self.width)
-        self.framebuf = framebuf.FrameBuffer(self.buffer, self.width, self.height, framebuf.MONO_VLSB)
+        self.framebuf = framebuf.FrameBuffer(
+            self.buffer, self.width, self.height, framebuf.MONO_VLSB
+        )
 
         self.spi = SPI(0)
         # chip select
         self.cs = Pin("P16", mode=Pin.OUT, pull=Pin.PULL_UP)
         # command
         self.dc = Pin("P17", mode=Pin.OUT, pull=Pin.PULL_UP)
-        
+
         # initialize all pins high
         self.cs.high()
         self.dc.high()
@@ -76,27 +80,26 @@ class ILI9341:
         self.spi.init(baudrate=8000000, phase=0, polarity=0)
 
         self.init_display()
-        
 
     def init_display(self):
         time.sleep_ms(500)
-        
+
         self.write_cmd(0x01)
-        
+
         time.sleep_ms(200)
-    
+
         self.write_cmd(0xCF)
         self.write_data(bytearray([0x00, 0x8B, 0x30]))
-    
+
         self.write_cmd(0xED)
         self.write_data(bytearray([0x67, 0x03, 0x12, 0x81]))
 
         self.write_cmd(0xE8)
         self.write_data(bytearray([0x85, 0x10, 0x7A]))
-    
+
         self.write_cmd(0xCB)
         self.write_data(bytearray([0x39, 0x2C, 0x00, 0x34, 0x02]))
-    
+
         self.write_cmd(0xF7)
         self.write_data(bytearray([0x20]))
 
@@ -107,54 +110,94 @@ class ILI9341:
         self.write_cmd(0xC0)
         # VRH[5:0]
         self.write_data(bytearray([0x1B]))
-        
+
         # Power control
         self.write_cmd(0xC1)
         # SAP[2:0];BT[3:0]
         self.write_data(bytearray([0x10]))
-        
+
         # VCM control
         self.write_cmd(0xC5)
         self.write_data(bytearray([0x3F, 0x3C]))
-    
+
         # VCM control2
         self.write_cmd(0xC7)
         self.write_data(bytearray([0xB7]))
-    
+
         # Memory Access Control
         self.write_cmd(0x36)
         self.write_data(bytearray([0x08]))
-    
+
         self.write_cmd(0x3A)
         self.write_data(bytearray([0x55]))
-    
+
         self.write_cmd(0xB1)
         self.write_data(bytearray([0x00, 0x1B]))
-        
+
         # Display Function Control
         self.write_cmd(0xB6)
         self.write_data(bytearray([0x0A, 0xA2]))
-    
+
         # 3Gamma Function Disable
         self.write_cmd(0xF2)
         self.write_data(bytearray([0x00]))
-        
+
         # Gamma curve selected
         self.write_cmd(0x26)
         self.write_data(bytearray([0x01]))
-    
+
         # Set Gamma
         self.write_cmd(0xE0)
-        self.write_data(bytearray([0x0F, 0x2A, 0x28, 0x08, 0x0E, 0x08, 0x54, 0XA9, 0x43, 0x0A, 0x0F, 0x00, 0x00, 0x00, 0x00]))
-    
+        self.write_data(
+            bytearray(
+                [
+                    0x0F,
+                    0x2A,
+                    0x28,
+                    0x08,
+                    0x0E,
+                    0x08,
+                    0x54,
+                    0xA9,
+                    0x43,
+                    0x0A,
+                    0x0F,
+                    0x00,
+                    0x00,
+                    0x00,
+                    0x00,
+                ]
+            )
+        )
+
         # Set Gamma
-        self.write_cmd(0XE1)
-        self.write_data(bytearray([0x00, 0x15, 0x17, 0x07, 0x11, 0x06, 0x2B, 0x56, 0x3C, 0x05, 0x10, 0x0F, 0x3F, 0x3F, 0x0F]))
-        
+        self.write_cmd(0xE1)
+        self.write_data(
+            bytearray(
+                [
+                    0x00,
+                    0x15,
+                    0x17,
+                    0x07,
+                    0x11,
+                    0x06,
+                    0x2B,
+                    0x56,
+                    0x3C,
+                    0x05,
+                    0x10,
+                    0x0F,
+                    0x3F,
+                    0x3F,
+                    0x0F,
+                ]
+            )
+        )
+
         # Exit Sleep
         self.write_cmd(0x11)
         time.sleep_ms(120)
-        
+
         # Display on
         self.write_cmd(0x29)
         time.sleep_ms(500)
@@ -164,14 +207,14 @@ class ILI9341:
         # set col
         self.write_cmd(0x2A)
         self.write_data(bytearray([0x00, 0x00]))
-        self.write_data(bytearray([0x00, 0xef]))
-        
-        # set page 
+        self.write_data(bytearray([0x00, 0xEF]))
+
+        # set page
         self.write_cmd(0x2B)
         self.write_data(bytearray([0x00, 0x00]))
-        self.write_data(bytearray([0x01, 0x3f]))
+        self.write_data(bytearray([0x01, 0x3F]))
 
-        self.write_cmd(0x2c);
+        self.write_cmd(0x2C)
 
         num_of_pixels = self.height * self.width
 
@@ -201,10 +244,9 @@ class ILI9341:
         self.cs.low()
         self.spi.write(bytearray([cmd]))
         self.cs.high()
-        
+
     def write_data(self, buf):
         self.dc.high()
         self.cs.low()
         self.spi.write(buf)
         self.cs.high()
-

--- a/ports/nrf/examples/ssd1306_mod.py
+++ b/ports/nrf/examples/ssd1306_mod.py
@@ -20,11 +20,11 @@
 
 from ssd1306 import SSD1306_I2C
 
-SET_COL_ADDR        = const(0x21)
-SET_PAGE_ADDR       = const(0x22)
+SET_COL_ADDR = const(0x21)
+SET_PAGE_ADDR = const(0x22)
+
 
 class SSD1306_I2C_Mod(SSD1306_I2C):
-
     def show(self):
         x0 = 0
         x1 = self.width - 1
@@ -39,16 +39,15 @@ class SSD1306_I2C_Mod(SSD1306_I2C):
         self.write_cmd(0)
         self.write_cmd(self.pages - 1)
 
-        chunk_size = 254 # 255, excluding opcode.
+        chunk_size = 254  # 255, excluding opcode.
         num_of_chunks = len(self.buffer) // chunk_size
         leftover = len(self.buffer) - (num_of_chunks * chunk_size)
 
         for i in range(0, num_of_chunks):
-            self.write_data(self.buffer[chunk_size*i:chunk_size*(i+1)])
-        if (leftover > 0):
-            self.write_data(self.buffer[chunk_size * num_of_chunks:])
-
+            self.write_data(self.buffer[chunk_size * i : chunk_size * (i + 1)])
+        if leftover > 0:
+            self.write_data(self.buffer[chunk_size * num_of_chunks :])
 
     def write_data(self, buf):
-        buffer = bytearray([0x40]) + buf # Co=0, D/C#=1
+        buffer = bytearray([0x40]) + buf  # Co=0, D/C#=1
         self.i2c.writeto(self.addr, buffer)

--- a/ports/nrf/examples/ubluepy_eddystone.py
+++ b/ports/nrf/examples/ubluepy_eddystone.py
@@ -1,19 +1,23 @@
 from ubluepy import Peripheral, constants
 
-BLE_GAP_ADV_FLAG_LE_GENERAL_DISC_MODE       = const(0x02)
-BLE_GAP_ADV_FLAG_BR_EDR_NOT_SUPPORTED       = const(0x04)
+BLE_GAP_ADV_FLAG_LE_GENERAL_DISC_MODE = const(0x02)
+BLE_GAP_ADV_FLAG_BR_EDR_NOT_SUPPORTED = const(0x04)
 
-BLE_GAP_ADV_FLAGS_LE_ONLY_GENERAL_DISC_MODE = const(BLE_GAP_ADV_FLAG_LE_GENERAL_DISC_MODE | BLE_GAP_ADV_FLAG_BR_EDR_NOT_SUPPORTED)
+BLE_GAP_ADV_FLAGS_LE_ONLY_GENERAL_DISC_MODE = const(
+    BLE_GAP_ADV_FLAG_LE_GENERAL_DISC_MODE | BLE_GAP_ADV_FLAG_BR_EDR_NOT_SUPPORTED
+)
 
-EDDYSTONE_FRAME_TYPE_URL                    = const(0x10)
-EDDYSTONE_URL_PREFIX_HTTP_WWW               = const(0x00) # "http://www".
-EDDYSTONE_URL_SUFFIX_DOT_COM                = const(0x01) # ".com"
+EDDYSTONE_FRAME_TYPE_URL = const(0x10)
+EDDYSTONE_URL_PREFIX_HTTP_WWW = const(0x00)  # "http://www".
+EDDYSTONE_URL_SUFFIX_DOT_COM = const(0x01)  # ".com"
+
 
 def string_to_binarray(text):
     b = bytearray([])
     for c in text:
         b.append(ord(c))
     return b
+
 
 def gen_ad_type_content(ad_type, data):
     b = bytearray(1)
@@ -22,6 +26,7 @@ def gen_ad_type_content(ad_type, data):
     b[0] = len(b) - 1
     return b
 
+
 def generate_eddystone_adv_packet(url):
     # flags
     disc_mode = bytearray([BLE_GAP_ADV_FLAGS_LE_ONLY_GENERAL_DISC_MODE])
@@ -29,10 +34,12 @@ def generate_eddystone_adv_packet(url):
 
     # 16-bit uuid
     uuid = bytearray([0xAA, 0xFE])
-    packet_uuid16 = gen_ad_type_content(constants.ad_types.AD_TYPE_16BIT_SERVICE_UUID_COMPLETE, uuid)
+    packet_uuid16 = gen_ad_type_content(
+        constants.ad_types.AD_TYPE_16BIT_SERVICE_UUID_COMPLETE, uuid
+    )
 
     # eddystone data
-    rssi = 0xEE # -18 dB, approx signal strength at 0m.
+    rssi = 0xEE  # -18 dB, approx signal strength at 0m.
     eddystone_data = bytearray([])
     eddystone_data.append(EDDYSTONE_FRAME_TYPE_URL)
     eddystone_data.append(rssi)
@@ -42,7 +49,9 @@ def generate_eddystone_adv_packet(url):
 
     # service data
     service_data = uuid + eddystone_data
-    packet_service_data = gen_ad_type_content(constants.ad_types.AD_TYPE_SERVICE_DATA, service_data)
+    packet_service_data = gen_ad_type_content(
+        constants.ad_types.AD_TYPE_SERVICE_DATA, service_data
+    )
 
     # generate advertisment packet
     packet = bytearray([])
@@ -52,7 +61,8 @@ def generate_eddystone_adv_packet(url):
 
     return packet
 
+
 def start():
-    adv_packet = generate_eddystone_adv_packet("micropython")  
+    adv_packet = generate_eddystone_adv_packet("micropython")
     p = Peripheral()
     p.advertise(data=adv_packet, connectable=False)

--- a/ports/nrf/examples/ubluepy_scan.py
+++ b/ports/nrf/examples/ubluepy_scan.py
@@ -1,10 +1,12 @@
 from ubluepy import Scanner, constants
 
+
 def bytes_to_str(bytes):
     string = ""
     for b in bytes:
         string += chr(b)
     return string
+
 
 def get_device_names(scan_entries):
     dev_names = []
@@ -12,27 +14,29 @@ def get_device_names(scan_entries):
         scan = e.getScanData()
         if scan:
             for s in scan:
-               if s[0] == constants.ad_types.AD_TYPE_COMPLETE_LOCAL_NAME:
-                   dev_names.append((e, bytes_to_str(s[2])))
+                if s[0] == constants.ad_types.AD_TYPE_COMPLETE_LOCAL_NAME:
+                    dev_names.append((e, bytes_to_str(s[2])))
     return dev_names
+
 
 def find_device_by_name(name):
     s = Scanner()
     scan_res = s.scan(100)
-    
+
     device_names = get_device_names(scan_res)
     for dev in device_names:
         if name == dev[1]:
             return dev[0]
+
 
 # >>> res = find_device_by_name("micr")
 # >>> if res:
 # ...     print("address:", res.addr())
 # ...     print("address type:", res.addr_type())
 # ...     print("rssi:", res.rssi())
-# ...     
-# ...     
-# ... 
+# ...
+# ...
+# ...
 # address: c2:73:61:89:24:45
 # address type: 1
 # rssi: -26

--- a/ports/nrf/examples/ubluepy_temp.py
+++ b/ports/nrf/examples/ubluepy_temp.py
@@ -26,12 +26,13 @@ from board import LED
 from machine import RTCounter, Temp
 from ubluepy import Service, Characteristic, UUID, Peripheral, constants
 
+
 def event_handler(id, handle, data):
     global rtc
     global periph
     global serv_env_sense
     global notif_enabled
- 
+
     if id == constants.EVT_GAP_CONNECTED:
         # indicated 'connected'
         LED(1).on()
@@ -50,10 +51,11 @@ def event_handler(id, handle, data):
             notif_enabled = True
             # start low power timer
             rtc.start()
-        else: 
+        else:
             notif_enabled = False
             # stop low power timer
             rtc.stop()
+
 
 def send_temp(timer_id):
     global notif_enabled
@@ -62,26 +64,27 @@ def send_temp(timer_id):
     if notif_enabled:
         # measure chip temperature
         temp = Temp.read()
-        temp =  temp * 100
+        temp = temp * 100
         char_temp.write(bytearray([temp & 0xFF, temp >> 8]))
+
 
 # start off with LED(1) off
 LED(1).off()
 
-# use RTC1 as RTC0 is used by bluetooth stack 
+# use RTC1 as RTC0 is used by bluetooth stack
 # set up RTC callback every 5 second
 rtc = RTCounter(1, period=50, mode=RTCounter.PERIODIC, callback=send_temp)
 
 notif_enabled = False
 
-uuid_env_sense = UUID("0x181A") # Environmental Sensing service
-uuid_temp = UUID("0x2A6E") # Temperature characteristic
- 
+uuid_env_sense = UUID("0x181A")  # Environmental Sensing service
+uuid_temp = UUID("0x2A6E")  # Temperature characteristic
+
 serv_env_sense = Service(uuid_env_sense)
 
 temp_props = Characteristic.PROP_NOTIFY | Characteristic.PROP_READ
 temp_attrs = Characteristic.ATTR_CCCD
-char_temp = Characteristic(uuid_temp, props = temp_props, attrs = temp_attrs)
+char_temp = Characteristic(uuid_temp, props=temp_props, attrs=temp_attrs)
 
 serv_env_sense.addCharacteristic(char_temp)
 
@@ -89,4 +92,3 @@ periph = Peripheral()
 periph.addService(serv_env_sense)
 periph.setConnectionHandler(event_handler)
 periph.advertise(device_name="micr_temp", services=[serv_env_sense])
-

--- a/ports/nrf/freeze/test.py
+++ b/ports/nrf/freeze/test.py
@@ -1,4 +1,5 @@
 import sys
 
+
 def hello():
     print("Hello %s!" % sys.platform)

--- a/ports/qemu-arm/test-frzmpy/native_frozen_align.py
+++ b/ports/qemu-arm/test-frzmpy/native_frozen_align.py
@@ -1,12 +1,15 @@
 import micropython
 
+
 @micropython.native
 def native_x(x):
     print(x + 1)
 
+
 @micropython.native
 def native_y(x):
     print(x + 1)
+
 
 @micropython.native
 def native_z(x):

--- a/ports/stm32/boards/STM32F4DISC/staccel.py
+++ b/ports/stm32/boards/STM32F4DISC/staccel.py
@@ -18,25 +18,26 @@ from micropython import const
 from pyb import Pin
 from pyb import SPI
 
-READWRITE_CMD = const(0x80) 
+READWRITE_CMD = const(0x80)
 MULTIPLEBYTE_CMD = const(0x40)
-WHO_AM_I_ADDR = const(0x0f)
+WHO_AM_I_ADDR = const(0x0F)
 OUT_X_ADDR = const(0x29)
-OUT_Y_ADDR = const(0x2b)
-OUT_Z_ADDR = const(0x2d)
-OUT_T_ADDR = const(0x0c)
+OUT_Y_ADDR = const(0x2B)
+OUT_Z_ADDR = const(0x2D)
+OUT_T_ADDR = const(0x0C)
 
-LIS302DL_WHO_AM_I_VAL = const(0x3b)
+LIS302DL_WHO_AM_I_VAL = const(0x3B)
 LIS302DL_CTRL_REG1_ADDR = const(0x20)
 # Configuration for 100Hz sampling rate, +-2g range
 LIS302DL_CONF = const(0b01000111)
 
-LIS3DSH_WHO_AM_I_VAL = const(0x3f)
+LIS3DSH_WHO_AM_I_VAL = const(0x3F)
 LIS3DSH_CTRL_REG4_ADDR = const(0x20)
 LIS3DSH_CTRL_REG5_ADDR = const(0x24)
 # Configuration for 100Hz sampling rate, +-2g range
 LIS3DSH_CTRL_REG4_CONF = const(0b01100111)
 LIS3DSH_CTRL_REG5_CONF = const(0b00000000)
+
 
 class STAccel:
     def __init__(self):
@@ -50,8 +51,12 @@ class STAccel:
             self.write_bytes(LIS302DL_CTRL_REG1_ADDR, bytearray([LIS302DL_CONF]))
             self.sensitivity = 18
         elif self.who_am_i == LIS3DSH_WHO_AM_I_VAL:
-            self.write_bytes(LIS3DSH_CTRL_REG4_ADDR, bytearray([LIS3DSH_CTRL_REG4_CONF]))
-            self.write_bytes(LIS3DSH_CTRL_REG5_ADDR, bytearray([LIS3DSH_CTRL_REG5_CONF]))
+            self.write_bytes(
+                LIS3DSH_CTRL_REG4_ADDR, bytearray([LIS3DSH_CTRL_REG4_CONF])
+            )
+            self.write_bytes(
+                LIS3DSH_CTRL_REG5_ADDR, bytearray([LIS3DSH_CTRL_REG5_CONF])
+            )
             self.sensitivity = 0.06 * 256
         else:
             raise Exception('LIS302DL or LIS3DSH accelerometer not present')
@@ -68,7 +73,7 @@ class STAccel:
             addr |= READWRITE_CMD
         self.cs_pin.low()
         self.spi.send(addr)
-        #buf = self.spi.send_recv(bytearray(nbytes * [0])) # read data, MSB first
+        # buf = self.spi.send_recv(bytearray(nbytes * [0])) # read data, MSB first
         buf = self.spi.recv(nbytes)
         self.cs_pin.high()
         return buf

--- a/ports/stm32/boards/make-pins.py
+++ b/ports/stm32/boards/make-pins.py
@@ -9,26 +9,37 @@ import csv
 
 # Must have matching entries in AF_FN_* enum in ../pin_defs_stm32.h
 SUPPORTED_FN = {
-    'TIM'   : ['CH1',  'CH2',  'CH3',  'CH4',
-               'CH1N', 'CH2N', 'CH3N', 'CH1_ETR', 'ETR', 'BKIN'],
-    'I2C'   : ['SDA', 'SCL'],
-    'I2S'   : ['CK', 'MCK', 'SD', 'WS', 'EXTSD'],
-    'USART' : ['RX', 'TX', 'CTS', 'RTS', 'CK'],
-    'UART'  : ['RX', 'TX', 'CTS', 'RTS'],
-    'SPI'   : ['NSS', 'SCK', 'MISO', 'MOSI'],
-    'SDMMC' : ['CK', 'CMD', 'D0', 'D1', 'D2', 'D3'],
-    'CAN'   : ['TX', 'RX'],
+    'TIM': [
+        'CH1',
+        'CH2',
+        'CH3',
+        'CH4',
+        'CH1N',
+        'CH2N',
+        'CH3N',
+        'CH1_ETR',
+        'ETR',
+        'BKIN',
+    ],
+    'I2C': ['SDA', 'SCL'],
+    'I2S': ['CK', 'MCK', 'SD', 'WS', 'EXTSD'],
+    'USART': ['RX', 'TX', 'CTS', 'RTS', 'CK'],
+    'UART': ['RX', 'TX', 'CTS', 'RTS'],
+    'SPI': ['NSS', 'SCK', 'MISO', 'MOSI'],
+    'SDMMC': ['CK', 'CMD', 'D0', 'D1', 'D2', 'D3'],
+    'CAN': ['TX', 'RX'],
 }
 
 CONDITIONAL_VAR = {
-    'I2C'   : 'MICROPY_HW_I2C{num}_SCL',
-    'I2S'   : 'MICROPY_HW_ENABLE_I2S{num}',
-    'SPI'   : 'MICROPY_HW_SPI{num}_SCK',
-    'UART'  : 'MICROPY_HW_UART{num}_TX',
-    'USART' : 'MICROPY_HW_UART{num}_TX',
-    'SDMMC' : 'MICROPY_HW_SDMMC{num}_CK',
-    'CAN'   : 'MICROPY_HW_CAN{num}_TX',
+    'I2C': 'MICROPY_HW_I2C{num}_SCL',
+    'I2S': 'MICROPY_HW_ENABLE_I2S{num}',
+    'SPI': 'MICROPY_HW_SPI{num}_SCK',
+    'UART': 'MICROPY_HW_UART{num}_TX',
+    'USART': 'MICROPY_HW_UART{num}_TX',
+    'SDMMC': 'MICROPY_HW_SDMMC{num}_CK',
+    'CAN': 'MICROPY_HW_CAN{num}_TX',
 }
+
 
 def parse_port_pin(name_str):
     """Parses a string and returns a (port-num, pin-num) tuple."""
@@ -44,16 +55,18 @@ def parse_port_pin(name_str):
         raise ValueError("Expecting numeric pin number.")
     return (port, int(pin_str))
 
+
 def split_name_num(name_num):
     num = None
     for num_idx in range(len(name_num) - 1, -1, -1):
         if not name_num[num_idx].isdigit():
-            name = name_num[0:num_idx + 1]
-            num_str = name_num[num_idx + 1:]
+            name = name_num[0 : num_idx + 1]
+            num_str = name_num[num_idx + 1 :]
             if len(num_str) > 0:
                 num = int(num_str)
             break
     return name, num
+
 
 def conditional_var(name_num):
     # Try the specific instance first. For example, if name_num is UART4_RX
@@ -66,6 +79,7 @@ def conditional_var(name_num):
         var.append(CONDITIONAL_VAR[name_num])
     return var
 
+
 def print_conditional_if(cond_var, file=None):
     if cond_var:
         cond_str = []
@@ -75,6 +89,7 @@ def print_conditional_if(cond_var, file=None):
             else:
                 cond_str.append('defined({0})'.format(var))
         print('#if ' + ' || '.join(cond_str), file=file)
+
 
 def print_conditional_endif(cond_var, file=None):
     if cond_var:
@@ -124,14 +139,17 @@ class AlternateFunction(object):
         if self.supported:
             cond_var = conditional_var('{}{}'.format(self.func, self.fn_num))
             print_conditional_if(cond_var)
-            print('  AF',  end='')
+            print('  AF', end='')
         else:
             print('  //', end='')
         fn_num = self.fn_num
         if fn_num is None:
             fn_num = 0
-        print('({:2d}, {:8s}, {:2d}, {:10s}, {:8s}), // {:s}'.format(self.idx,
-              self.func, fn_num, self.pin_type, self.ptr(), self.af_str))
+        print(
+            '({:2d}, {:8s}, {:2d}, {:10s}, {:8s}), // {:s}'.format(
+                self.idx, self.func, fn_num, self.pin_type, self.ptr(), self.af_str
+            )
+        )
         print_conditional_endif(cond_var)
 
     def qstr_list(self):
@@ -163,7 +181,7 @@ class Pin(object):
         self.board_pin = True
 
     def parse_adc(self, adc_str):
-        if (adc_str[:3] != 'ADC'):
+        if adc_str[:3] != 'ADC':
             return
 
         if adc_str.find('_INP') != -1:
@@ -184,8 +202,8 @@ class Pin(object):
             channel = channel[2:]
 
         for idx in range(3, len(adc)):
-            adc_num = int(adc[idx]) # 1, 2, or 3
-            self.adc_num |= (1 << (adc_num - 1))
+            adc_num = int(adc[idx])  # 1, 2, or 3
+            self.adc_num |= 1 << (adc_num - 1)
         self.adc_channel = int(channel)
 
     def parse_af(self, af_idx, af_strs_in):
@@ -207,7 +225,7 @@ class Pin(object):
 
     def adc_num_str(self):
         str = ''
-        for adc_num in range(1,4):
+        for adc_num in range(1, 4):
             if self.adc_num & (1 << (adc_num - 1)):
                 if len(str) > 0:
                     str += ' | '
@@ -219,18 +237,24 @@ class Pin(object):
 
     def print(self):
         if self.alt_fn_count == 0:
-            print("// ",  end='')
+            print("// ", end='')
         print('const pin_af_obj_t {:s}[] = {{'.format(self.alt_fn_name()))
         for alt_fn in self.alt_fn:
             alt_fn.print()
         if self.alt_fn_count == 0:
-            print("// ",  end='')
+            print("// ", end='')
         print('};')
         print('')
-        print('const pin_obj_t pin_{:s}_obj = PIN({:s}, {:d}, {:s}, {:s}, {:d});'.format(
-            self.cpu_pin_name(), self.port_letter(), self.pin,
-            self.alt_fn_name(null_if_0=True),
-            self.adc_num_str(), self.adc_channel))
+        print(
+            'const pin_obj_t pin_{:s}_obj = PIN({:s}, {:d}, {:s}, {:s}, {:d});'.format(
+                self.cpu_pin_name(),
+                self.port_letter(),
+                self.pin,
+                self.alt_fn_name(null_if_0=True),
+                self.adc_num_str(),
+                self.adc_channel,
+            )
+        )
         print('')
 
     def print_header(self, hdr_file):
@@ -249,7 +273,6 @@ class Pin(object):
 
 
 class NamedPin(object):
-
     def __init__(self, name, pin):
         if name.startswith('-'):
             self._is_hidden = True
@@ -270,10 +293,9 @@ class NamedPin(object):
 
 
 class Pins(object):
-
     def __init__(self):
-        self.cpu_pins = []   # list of NamedPin objects
-        self.board_pins = [] # list of NamedPin objects
+        self.cpu_pins = []  # list of NamedPin objects
+        self.board_pins = []  # list of NamedPin objects
 
     def find_pin(self, port_num, pin_num):
         for named_pin in self.cpu_pins:
@@ -308,17 +330,29 @@ class Pins(object):
                 pin = self.find_pin(port_num, pin_num)
                 if pin:
                     pin.set_is_board_pin()
-                    if row[0]: # Only add board pins that have a name
+                    if row[0]:  # Only add board pins that have a name
                         self.board_pins.append(NamedPin(row[0], pin))
 
     def print_named(self, label, named_pins):
-        print('STATIC const mp_rom_map_elem_t pin_{:s}_pins_locals_dict_table[] = {{'.format(label))
+        print(
+            'STATIC const mp_rom_map_elem_t pin_{:s}_pins_locals_dict_table[] = {{'.format(
+                label
+            )
+        )
         for named_pin in named_pins:
             pin = named_pin.pin()
             if pin.is_board_pin() and not named_pin.is_hidden():
-                print('  {{ MP_ROM_QSTR(MP_QSTR_{:s}), MP_ROM_PTR(&pin_{:s}_obj) }},'.format(named_pin.name(),  pin.cpu_pin_name()))
+                print(
+                    '  {{ MP_ROM_QSTR(MP_QSTR_{:s}), MP_ROM_PTR(&pin_{:s}_obj) }},'.format(
+                        named_pin.name(), pin.cpu_pin_name()
+                    )
+                )
         print('};')
-        print('MP_DEFINE_CONST_DICT(pin_{:s}_pins_locals_dict, pin_{:s}_pins_locals_dict_table);'.format(label, label))
+        print(
+            'MP_DEFINE_CONST_DICT(pin_{:s}_pins_locals_dict, pin_{:s}_pins_locals_dict_table);'.format(
+                label, label
+            )
+        )
 
     def print(self):
         for named_pin in self.cpu_pins:
@@ -338,9 +372,14 @@ class Pins(object):
             adc_found = False
             for named_pin in self.cpu_pins:
                 pin = named_pin.pin()
-                if (pin.is_board_pin() and
-                    (pin.adc_num & (1 << (adc_num - 1))) and (pin.adc_channel == channel)):
-                    print('  &pin_{:s}_obj, // {:d}'.format(pin.cpu_pin_name(), channel))
+                if (
+                    pin.is_board_pin()
+                    and (pin.adc_num & (1 << (adc_num - 1)))
+                    and (pin.adc_channel == channel)
+                ):
+                    print(
+                        '  &pin_{:s}_obj, // {:d}'.format(pin.cpu_pin_name(), channel)
+                    )
                     adc_found = True
                     break
             if not adc_found:
@@ -348,7 +387,6 @@ class Pins(object):
             if channel == 16:
                 print('#endif')
         print('};')
-
 
     def print_header(self, hdr_filename, obj_decls):
         with open(hdr_filename, 'wt') as hdr_file:
@@ -362,7 +400,11 @@ class Pins(object):
                 hdr_file.write('extern const pin_obj_t * const pin_adc3[];\n')
             # provide #define's mapping board to cpu name
             for named_pin in self.board_pins:
-                hdr_file.write("#define pyb_pin_{:s} pin_{:s}\n".format(named_pin.name(), named_pin.pin().cpu_pin_name()))
+                hdr_file.write(
+                    "#define pyb_pin_{:s} pin_{:s}\n".format(
+                        named_pin.name(), named_pin.pin().cpu_pin_name()
+                    )
+                )
 
     def print_qstr(self, qstr_filename):
         with open(qstr_filename, 'wt') as qstr_file:
@@ -385,7 +427,7 @@ class Pins(object):
                 print_conditional_endif(cond_var, file=qstr_file)
 
     def print_af_hdr(self, af_const_filename):
-        with open(af_const_filename,  'wt') as af_const_file:
+        with open(af_const_filename, 'wt') as af_const_file:
             af_hdr_set = set([])
             mux_name_width = 0
             for named_pin in self.cpu_pins:
@@ -403,12 +445,14 @@ class Pins(object):
                 print_conditional_if(cond_var, file=af_const_file)
                 key = 'MP_ROM_QSTR(MP_QSTR_{}),'.format(mux_name)
                 val = 'MP_ROM_INT(GPIO_{})'.format(mux_name)
-                print('    { %-*s %s },' % (mux_name_width + 26, key, val),
-                      file=af_const_file)
+                print(
+                    '    { %-*s %s },' % (mux_name_width + 26, key, val),
+                    file=af_const_file,
+                )
                 print_conditional_endif(cond_var, file=af_const_file)
 
     def print_af_defs(self, af_defs_filename, cmp_strings):
-        with open(af_defs_filename,  'wt') as af_defs_file:
+        with open(af_defs_filename, 'wt') as af_defs_file:
 
             STATIC_AF_TOKENS = {}
             for named_pin in self.board_pins:
@@ -420,14 +464,16 @@ class Pins(object):
                         STATIC_AF_TOKENS[tok] = []
                     if cmp_strings:
                         pin_name = named_pin.pin().cpu_pin_name()
-                        cmp_str = '    ((strcmp( #pin_obj , "(&pin_%s_obj)") ' \
-                            ' & strcmp( #pin_obj , "((&pin_%s_obj))")) == 0) ? (%d) : \\' % (
-                                pin_name, pin_name, af.idx
-                            )
+                        cmp_str = (
+                            '    ((strcmp( #pin_obj , "(&pin_%s_obj)") '
+                            ' & strcmp( #pin_obj , "((&pin_%s_obj))")) == 0) ? (%d) : \\'
+                            % (pin_name, pin_name, af.idx)
+                        )
                     else:
                         cmp_str = '    ((pin_obj) == (pin_%s)) ? (%d) : \\' % (
-                                named_pin.pin().cpu_pin_name(), af.idx
-                            )
+                            named_pin.pin().cpu_pin_name(),
+                            af.idx,
+                        )
                     STATIC_AF_TOKENS[tok].append(cmp_str)
 
             for tok, pins in STATIC_AF_TOKENS.items():
@@ -436,7 +482,7 @@ class Pins(object):
                 print("    (0xffffffffffffffffULL))\n", file=af_defs_file)
 
     def print_af_py(self, af_py_filename):
-        with open(af_py_filename,  'wt') as af_py_file:
+        with open(af_py_filename, 'wt') as af_py_file:
             print('PINS_AF = (', file=af_py_file)
             for named_pin in self.board_pins:
                 if named_pin.is_hidden():
@@ -444,40 +490,45 @@ class Pins(object):
                 print("  ('%s', " % named_pin.name(), end='', file=af_py_file)
                 for af in named_pin.pin().alt_fn:
                     if af.is_supported():
-                        print("(%d, '%s'), " % (af.idx, af.af_str), end='', file=af_py_file)
+                        print(
+                            "(%d, '%s'), " % (af.idx, af.af_str),
+                            end='',
+                            file=af_py_file,
+                        )
                 print('),', file=af_py_file)
-            print(')',  file=af_py_file)
+            print(')', file=af_py_file)
 
 
 def main():
     parser = argparse.ArgumentParser(
         prog="make-pins.py",
         usage="%(prog)s [options] [command]",
-        description="Generate board specific pin file"
+        description="Generate board specific pin file",
     )
     parser.add_argument(
-        "-a", "--af",
+        "-a",
+        "--af",
         dest="af_filename",
         help="Specifies the alternate function file for the chip",
-        default="stm32f4xx_af.csv"
+        default="stm32f4xx_af.csv",
     )
     parser.add_argument(
         "--af-const",
         dest="af_const_filename",
         help="Specifies header file for alternate function constants.",
-        default="build/pins_af_const.h"
+        default="build/pins_af_const.h",
     )
     parser.add_argument(
         "--af-py",
         dest="af_py_filename",
         help="Specifies the filename for the python alternate function mappings.",
-        default="build/pins_af.py"
+        default="build/pins_af.py",
     )
     parser.add_argument(
         "--af-defs",
         dest="af_defs_filename",
         help="Specifies the filename for the alternate function defines.",
-        default="build/pins_af_defs.h"
+        default="build/pins_af_defs.h",
     )
     parser.add_argument(
         "--af-defs-cmp-strings",
@@ -486,33 +537,34 @@ def main():
         action="store_true",
     )
     parser.add_argument(
-        "-b", "--board",
-        dest="board_filename",
-        help="Specifies the board file",
+        "-b", "--board", dest="board_filename", help="Specifies the board file",
     )
     parser.add_argument(
-        "-p", "--prefix",
+        "-p",
+        "--prefix",
         dest="prefix_filename",
         help="Specifies beginning portion of generated pins file",
-        default="stm32f4xx_prefix.c"
+        default="stm32f4xx_prefix.c",
     )
     parser.add_argument(
-        "-q", "--qstr",
+        "-q",
+        "--qstr",
         dest="qstr_filename",
         help="Specifies name of generated qstr header file",
-        default="build/pins_qstr.h"
+        default="build/pins_qstr.h",
     )
     parser.add_argument(
-        "-r", "--hdr",
+        "-r",
+        "--hdr",
         dest="hdr_filename",
         help="Specifies name of generated pin header file",
-        default="build/pins.h"
+        default="build/pins.h",
     )
     parser.add_argument(
         "--hdr-obj-decls",
         dest="hdr_obj_decls",
         help="Whether to include declarations for pin objects in pin header file",
-        action="store_true"
+        action="store_true",
     )
     args = parser.parse_args(sys.argv[1:])
 

--- a/ports/stm32/make-stmconst.py
+++ b/ports/stm32/make-stmconst.py
@@ -11,16 +11,23 @@ import re
 
 # Python 2/3 compatibility
 import platform
+
 if platform.python_version_tuple()[0] == '2':
+
     def convert_bytes_to_str(b):
         return b
+
+
 elif platform.python_version_tuple()[0] == '3':
+
     def convert_bytes_to_str(b):
         try:
             return str(b, 'utf8')
         except ValueError:
             # some files have invalid utf8 bytes, so filter them out
             return ''.join(chr(l) for l in b if l <= 126)
+
+
 # end compatibility code
 
 # given a list of (name,regex) pairs, find the first one that matches the given line
@@ -31,25 +38,70 @@ def re_match_first(regexs, line):
             return name, match
     return None, None
 
+
 class LexerError(Exception):
     def __init__(self, line):
         self.line = line
+
 
 class Lexer:
     re_io_reg = r'__IO uint(?P<bits>8|16|32)_t +(?P<reg>[A-Z0-9]+)'
     re_comment = r'(?P<comment>[A-Za-z0-9 \-/_()&]+)'
     re_addr_offset = r'Address offset: (?P<offset>0x[0-9A-Z]{2,3})'
     regexs = (
-        ('#define hex', re.compile(r'#define +(?P<id>[A-Z0-9_]+) +\(?(\(uint32_t\))?(?P<hex>0x[0-9A-F]+)U?L?\)?($| */\*)')),
-        ('#define X', re.compile(r'#define +(?P<id>[A-Z0-9_]+) +(?P<id2>[A-Z0-9_]+)($| +/\*)')),
-        ('#define X+hex', re.compile(r'#define +(?P<id>[A-Za-z0-9_]+) +\(?(?P<id2>[A-Z0-9_]+) \+ (?P<hex>0x[0-9A-F]+)U?L?\)?($| +/\*)')),
-        ('#define typedef', re.compile(r'#define +(?P<id>[A-Z0-9_]+(ext)?) +\(\([A-Za-z0-9_]+_TypeDef \*\) (?P<id2>[A-Za-z0-9_]+)\)($| +/\*)')),
+        (
+            '#define hex',
+            re.compile(
+                r'#define +(?P<id>[A-Z0-9_]+) +\(?(\(uint32_t\))?(?P<hex>0x[0-9A-F]+)U?L?\)?($| */\*)'
+            ),
+        ),
+        (
+            '#define X',
+            re.compile(r'#define +(?P<id>[A-Z0-9_]+) +(?P<id2>[A-Z0-9_]+)($| +/\*)'),
+        ),
+        (
+            '#define X+hex',
+            re.compile(
+                r'#define +(?P<id>[A-Za-z0-9_]+) +\(?(?P<id2>[A-Z0-9_]+) \+ (?P<hex>0x[0-9A-F]+)U?L?\)?($| +/\*)'
+            ),
+        ),
+        (
+            '#define typedef',
+            re.compile(
+                r'#define +(?P<id>[A-Z0-9_]+(ext)?) +\(\([A-Za-z0-9_]+_TypeDef \*\) (?P<id2>[A-Za-z0-9_]+)\)($| +/\*)'
+            ),
+        ),
         ('typedef struct', re.compile(r'typedef struct$')),
         ('{', re.compile(r'{$')),
         ('}', re.compile(r'}$')),
-        ('} TypeDef', re.compile(r'} *(?P<id>[A-Z][A-Za-z0-9_]+)_(?P<global>([A-Za-z0-9_]+)?)TypeDef;$')),
-        ('IO reg', re.compile(re_io_reg + r'; */\*!< *' + re_comment + r', +' + re_addr_offset + r' *\*/')),
-        ('IO reg array', re.compile(re_io_reg + r'\[(?P<array>[2-8])\]; */\*!< *' + re_comment + r', +' + re_addr_offset + r'-(0x[0-9A-Z]{2,3}) *\*/')),
+        (
+            '} TypeDef',
+            re.compile(
+                r'} *(?P<id>[A-Z][A-Za-z0-9_]+)_(?P<global>([A-Za-z0-9_]+)?)TypeDef;$'
+            ),
+        ),
+        (
+            'IO reg',
+            re.compile(
+                re_io_reg
+                + r'; */\*!< *'
+                + re_comment
+                + r', +'
+                + re_addr_offset
+                + r' *\*/'
+            ),
+        ),
+        (
+            'IO reg array',
+            re.compile(
+                re_io_reg
+                + r'\[(?P<array>[2-8])\]; */\*!< *'
+                + re_comment
+                + r', +'
+                + re_addr_offset
+                + r'-(0x[0-9A-Z]{2,3}) *\*/'
+            ),
+        ),
     )
 
     def __init__(self, filename):
@@ -72,6 +124,7 @@ class Lexer:
         if match[0] != kind:
             raise LexerError(self.line_number)
         return match
+
 
 def parse_file(filename):
     lexer = Lexer(filename)
@@ -112,7 +165,9 @@ def parse_file(filename):
                     regs.append((reg, offset, bits, comment))
                 else:
                     for i in range(int(d['array'])):
-                        regs.append((reg + str(i), offset + i * bits // 8, bits, comment))
+                        regs.append(
+                            (reg + str(i), offset + i * bits // 8, bits, comment)
+                        )
                 m = lexer.next_match()
             if m[0] == '}':
                 pass
@@ -123,6 +178,7 @@ def parse_file(filename):
 
     return periphs, reg_defs
 
+
 def print_int_obj(val, needed_mpzs):
     if -0x40000000 <= val < 0x40000000:
         print('MP_ROM_INT(%#x)' % val, end='')
@@ -130,12 +186,14 @@ def print_int_obj(val, needed_mpzs):
         print('MP_ROM_PTR(&mpz_%08x)' % val, end='')
         needed_mpzs.add(val)
 
+
 def print_periph(periph_name, periph_val, needed_qstrs, needed_mpzs):
     qstr = periph_name.upper()
     print('{ MP_ROM_QSTR(MP_QSTR_%s), ' % qstr, end='')
     print_int_obj(periph_val, needed_mpzs)
     print(' },')
     needed_qstrs.add(qstr)
+
 
 def print_regs(reg_name, reg_defs, needed_qstrs, needed_mpzs):
     reg_name = reg_name.upper()
@@ -145,6 +203,7 @@ def print_regs(reg_name, reg_defs, needed_qstrs, needed_mpzs):
         print_int_obj(r[1], needed_mpzs)
         print(' }, // %s-bits, %s' % (r[2], r[3]))
         needed_qstrs.add(qstr)
+
 
 # This version of print regs groups registers together into submodules (eg GPIO submodule).
 # This makes the qstrs shorter, and makes the list of constants more manageable (since
@@ -158,17 +217,24 @@ def print_regs_as_submodules(reg_name, reg_defs, modules, needed_qstrs):
     mod_name_upper = mod_name_lower.upper()
     modules.append((mod_name_lower, mod_name_upper))
 
-    print("""
+    print(
+        """
 STATIC const mp_rom_map_elem_t stm_%s_globals_table[] = {
     { MP_ROM_QSTR(MP_QSTR___name__), MP_ROM_QSTR(MP_QSTR_%s) },
-""" % (mod_name_lower, mod_name_upper))
+"""
+        % (mod_name_lower, mod_name_upper)
+    )
     needed_qstrs.add(mod_name_upper)
 
     for r in reg_defs:
-        print('    { MP_ROM_QSTR(MP_QSTR_%s), MP_ROM_INT(%#x) }, // %s-bits, %s' % (r[0], r[1], r[2], r[3]))
+        print(
+            '    { MP_ROM_QSTR(MP_QSTR_%s), MP_ROM_INT(%#x) }, // %s-bits, %s'
+            % (r[0], r[1], r[2], r[3])
+        )
         needed_qstrs.add(r[0])
 
-    print("""};
+    print(
+        """};
 
 STATIC MP_DEFINE_CONST_DICT(stm_%s_globals, stm_%s_globals_table);
 
@@ -177,15 +243,35 @@ const mp_obj_module_t stm_%s_obj = {
     .name = MP_QSTR_%s,
     .globals = (mp_obj_dict_t*)&stm_%s_globals,
 };
-""" % (mod_name_lower, mod_name_lower, mod_name_lower, mod_name_upper, mod_name_lower))
+"""
+        % (
+            mod_name_lower,
+            mod_name_lower,
+            mod_name_lower,
+            mod_name_upper,
+            mod_name_lower,
+        )
+    )
+
 
 def main():
-    cmd_parser = argparse.ArgumentParser(description='Extract ST constants from a C header file.')
+    cmd_parser = argparse.ArgumentParser(
+        description='Extract ST constants from a C header file.'
+    )
     cmd_parser.add_argument('file', nargs=1, help='input file')
-    cmd_parser.add_argument('-q', '--qstr', dest='qstr_filename', default='build/stmconst_qstr.h',
-                            help='Specified the name of the generated qstr header file')
-    cmd_parser.add_argument('--mpz', dest='mpz_filename', default='build/stmconst_mpz.h',
-                            help='the destination file of the generated mpz header')
+    cmd_parser.add_argument(
+        '-q',
+        '--qstr',
+        dest='qstr_filename',
+        default='build/stmconst_qstr.h',
+        help='Specified the name of the generated qstr header file',
+    )
+    cmd_parser.add_argument(
+        '--mpz',
+        dest='mpz_filename',
+        default='build/stmconst_mpz.h',
+        help='the destination file of the generated mpz header',
+    )
     args = cmd_parser.parse_args()
 
     periphs, reg_defs = parse_file(args.file[0])
@@ -193,7 +279,7 @@ def main():
     # add legacy GPIO constants that were removed when upgrading CMSIS
     if 'GPIO' in reg_defs and 'stm32f4' in args.file[0]:
         reg_defs['GPIO'].append(['BSRRL', 0x18, 16, 'legacy register'])
-        reg_defs['GPIO'].append(['BSRRH', 0x1a, 16, 'legacy register'])
+        reg_defs['GPIO'].append(['BSRRH', 0x1A, 16, 'legacy register'])
 
     modules = []
     needed_qstrs = set()
@@ -232,13 +318,13 @@ def main():
         'USART',
         'WWDG',
         'RNG',
-        ):
+    ):
         if reg in reg_defs:
             print_regs(reg, reg_defs[reg], needed_qstrs, needed_mpzs)
-        #print_regs_as_submodules(reg, reg_defs[reg], modules, needed_qstrs)
+        # print_regs_as_submodules(reg, reg_defs[reg], modules, needed_qstrs)
 
-    #print("#define MOD_STM_CONST_MODULES \\")
-    #for mod_lower, mod_upper in modules:
+    # print("#define MOD_STM_CONST_MODULES \\")
+    # for mod_lower, mod_upper in modules:
     #    print("    { MP_ROM_QSTR(MP_QSTR_%s), MP_ROM_PTR(&stm_%s_obj) }, \\" % (mod_upper, mod_lower))
 
     print("")
@@ -251,10 +337,15 @@ def main():
 
     with open(args.mpz_filename, 'wt') as mpz_file:
         for mpz in sorted(needed_mpzs):
-            assert 0 <= mpz <= 0xffffffff
-            print('STATIC const mp_obj_int_t mpz_%08x = {{&mp_type_int}, '
-                '{.neg=0, .fixed_dig=1, .alloc=2, .len=2, ' '.dig=(uint16_t*)(const uint16_t[]){%#x, %#x}}};'
-                % (mpz, mpz & 0xffff, (mpz >> 16) & 0xffff), file=mpz_file)
+            assert 0 <= mpz <= 0xFFFFFFFF
+            print(
+                'STATIC const mp_obj_int_t mpz_%08x = {{&mp_type_int}, '
+                '{.neg=0, .fixed_dig=1, .alloc=2, .len=2, '
+                '.dig=(uint16_t*)(const uint16_t[]){%#x, %#x}}};'
+                % (mpz, mpz & 0xFFFF, (mpz >> 16) & 0xFFFF),
+                file=mpz_file,
+            )
+
 
 if __name__ == "__main__":
     main()

--- a/ports/stm32/mboot/mboot.py
+++ b/ports/stm32/mboot/mboot.py
@@ -119,7 +119,7 @@ class Bootloader:
     def deployfile(self, filename, addr):
         pages = self.getlayout()
         page_erased = [False] * len(pages)
-        buf = bytearray(128) # maximum payload supported by I2C protocol
+        buf = bytearray(128)  # maximum payload supported by I2C protocol
         start_addr = addr
         self.setwraddr(addr)
         fsize = os.stat(filename)[6]
@@ -137,7 +137,11 @@ class Bootloader:
                     if p[0] <= addr < p[0] + p[1]:
                         # found page
                         if not page_erased[i]:
-                            print('\r% 3u%% erase 0x%08x' % (100 * (addr - start_addr) // fsize, addr), end='')
+                            print(
+                                '\r% 3u%% erase 0x%08x'
+                                % (100 * (addr - start_addr) // fsize, addr),
+                                end='',
+                            )
                             self.pageerase(addr)
                             page_erased[i] = True
                         break
@@ -158,7 +162,10 @@ class Bootloader:
                 addr += n
                 ntotal = addr - start_addr
                 if ntotal % 2048 == 0 or ntotal == fsize:
-                    print('\r% 3u%% % 7u bytes   ' % (100 * ntotal // fsize, ntotal), end='')
+                    print(
+                        '\r% 3u%% % 7u bytes   ' % (100 * ntotal // fsize, ntotal),
+                        end='',
+                    )
             t1 = time.ticks_ms()
         print()
         print('rate: %.2f KiB/sec' % (1024 * ntotal / (t1 - t0) / 1000))

--- a/ports/teensy/make-pins.py
+++ b/ports/teensy/make-pins.py
@@ -8,12 +8,12 @@ import sys
 import csv
 
 SUPPORTED_FN = {
-    'FTM'   : ['CH0',  'CH1',  'CH2',  'CH3', 'CH4', 'CH5', 'CH6', 'CH7',
-               'QD_PHA', 'QD_PHB'],
-    'I2C'   : ['SDA', 'SCL'],
-    'UART'  : ['RX', 'TX', 'CTS', 'RTS'],
-    'SPI'   : ['NSS', 'SCK', 'MISO', 'MOSI']
+    'FTM': ['CH0', 'CH1', 'CH2', 'CH3', 'CH4', 'CH5', 'CH6', 'CH7', 'QD_PHA', 'QD_PHB'],
+    'I2C': ['SDA', 'SCL'],
+    'UART': ['RX', 'TX', 'CTS', 'RTS'],
+    'SPI': ['NSS', 'SCK', 'MISO', 'MOSI'],
 }
+
 
 def parse_port_pin(name_str):
     """Parses a string and returns a (port-num, pin-num) tuple."""
@@ -29,12 +29,13 @@ def parse_port_pin(name_str):
         raise ValueError("Expecting numeric pin number.")
     return (port, int(pin_str))
 
+
 def split_name_num(name_num):
     num = None
     for num_idx in range(len(name_num) - 1, -1, -1):
         if not name_num[num_idx].isdigit():
-            name = name_num[0:num_idx + 1]
-            num_str = name_num[num_idx + 1:]
+            name = name_num[0 : num_idx + 1]
+            num_str = name_num[num_idx + 1 :]
             if len(num_str) > 0:
                 num = int(num_str)
             break
@@ -77,14 +78,17 @@ class AlternateFunction(object):
     def print(self):
         """Prints the C representation of this AF."""
         if self.supported:
-            print('  AF',  end='')
+            print('  AF', end='')
         else:
             print('  //', end='')
         fn_num = self.fn_num
         if fn_num is None:
             fn_num = 0
-        print('({:2d}, {:8s}, {:2d}, {:10s}, {:8s}), // {:s}'.format(self.idx,
-              self.func, fn_num, self.pin_type, self.ptr(), self.af_str))
+        print(
+            '({:2d}, {:8s}, {:2d}, {:10s}, {:8s}), // {:s}'.format(
+                self.idx, self.func, fn_num, self.pin_type, self.ptr(), self.af_str
+            )
+        )
 
     def qstr_list(self):
         return [self.mux_name()]
@@ -115,12 +119,12 @@ class Pin(object):
         self.board_pin = True
 
     def parse_adc(self, adc_str):
-        if (adc_str[:3] != 'ADC'):
+        if adc_str[:3] != 'ADC':
             return
-        (adc,channel) = adc_str.split('_')
+        (adc, channel) = adc_str.split('_')
         for idx in range(3, len(adc)):
-            adc_num = int(adc[idx]) # 1, 2, or 3
-            self.adc_num |= (1 << (adc_num - 1))
+            adc_num = int(adc[idx])  # 1, 2, or 3
+            self.adc_num |= 1 << (adc_num - 1)
         self.adc_channel = int(channel[2:])
 
     def parse_af(self, af_idx, af_strs_in):
@@ -142,7 +146,7 @@ class Pin(object):
 
     def adc_num_str(self):
         str = ''
-        for adc_num in range(1,4):
+        for adc_num in range(1, 4):
             if self.adc_num & (1 << (adc_num - 1)):
                 if len(str) > 0:
                     str += ' | '
@@ -154,26 +158,33 @@ class Pin(object):
 
     def print(self):
         if self.alt_fn_count == 0:
-            print("// ",  end='')
+            print("// ", end='')
         print('const pin_af_obj_t {:s}[] = {{'.format(self.alt_fn_name()))
         for alt_fn in self.alt_fn:
             alt_fn.print()
         if self.alt_fn_count == 0:
-            print("// ",  end='')
+            print("// ", end='')
         print('};')
         print('')
-        print('const pin_obj_t pin_{:s} = PIN({:s}, {:d}, {:d}, {:s}, {:s}, {:d});'.format(
-            self.cpu_pin_name(), self.port_letter(), self.pin,
-            self.alt_fn_count, self.alt_fn_name(null_if_0=True),
-            self.adc_num_str(), self.adc_channel))
+        print(
+            'const pin_obj_t pin_{:s} = PIN({:s}, {:d}, {:d}, {:s}, {:s}, {:d});'.format(
+                self.cpu_pin_name(),
+                self.port_letter(),
+                self.pin,
+                self.alt_fn_count,
+                self.alt_fn_name(null_if_0=True),
+                self.adc_num_str(),
+                self.adc_channel,
+            )
+        )
         print('')
 
     def print_header(self, hdr_file):
-        hdr_file.write('extern const pin_obj_t pin_{:s};\n'.
-                       format(self.cpu_pin_name()))
+        hdr_file.write('extern const pin_obj_t pin_{:s};\n'.format(self.cpu_pin_name()))
         if self.alt_fn_count > 0:
-            hdr_file.write('extern const pin_af_obj_t pin_{:s}_af[];\n'.
-                           format(self.cpu_pin_name()))
+            hdr_file.write(
+                'extern const pin_af_obj_t pin_{:s}_af[];\n'.format(self.cpu_pin_name())
+            )
 
     def qstr_list(self):
         result = []
@@ -184,7 +195,6 @@ class Pin(object):
 
 
 class NamedPin(object):
-
     def __init__(self, name, pin):
         self._name = name
         self._pin = pin
@@ -197,10 +207,9 @@ class NamedPin(object):
 
 
 class Pins(object):
-
     def __init__(self):
-        self.cpu_pins = []   # list of NamedPin objects
-        self.board_pins = [] # list of NamedPin objects
+        self.cpu_pins = []  # list of NamedPin objects
+        self.board_pins = []  # list of NamedPin objects
 
     def find_pin(self, port_num, pin_num):
         for named_pin in self.cpu_pins:
@@ -236,13 +245,25 @@ class Pins(object):
                     self.board_pins.append(NamedPin(row[0], pin))
 
     def print_named(self, label, named_pins):
-        print('STATIC const mp_rom_map_elem_t pin_{:s}_pins_locals_dict_table[] = {{'.format(label))
+        print(
+            'STATIC const mp_rom_map_elem_t pin_{:s}_pins_locals_dict_table[] = {{'.format(
+                label
+            )
+        )
         for named_pin in named_pins:
             pin = named_pin.pin()
             if pin.is_board_pin():
-                print('  {{ MP_ROM_QSTR(MP_QSTR_{:s}), MP_ROM_PTR(&pin_{:s}) }},'.format(named_pin.name(),  pin.cpu_pin_name()))
+                print(
+                    '  {{ MP_ROM_QSTR(MP_QSTR_{:s}), MP_ROM_PTR(&pin_{:s}) }},'.format(
+                        named_pin.name(), pin.cpu_pin_name()
+                    )
+                )
         print('};')
-        print('MP_DEFINE_CONST_DICT(pin_{:s}_pins_locals_dict, pin_{:s}_pins_locals_dict_table);'.format(label, label));
+        print(
+            'MP_DEFINE_CONST_DICT(pin_{:s}_pins_locals_dict, pin_{:s}_pins_locals_dict_table);'.format(
+                label, label
+            )
+        )
 
     def print(self):
         for named_pin in self.cpu_pins:
@@ -254,21 +275,23 @@ class Pins(object):
         self.print_named('board', self.board_pins)
 
     def print_adc(self, adc_num):
-        print('');
+        print('')
         print('const pin_obj_t * const pin_adc{:d}[] = {{'.format(adc_num))
         for channel in range(16):
             adc_found = False
             for named_pin in self.cpu_pins:
                 pin = named_pin.pin()
-                if (pin.is_board_pin() and
-                    (pin.adc_num & (1 << (adc_num - 1))) and (pin.adc_channel == channel)):
+                if (
+                    pin.is_board_pin()
+                    and (pin.adc_num & (1 << (adc_num - 1)))
+                    and (pin.adc_channel == channel)
+                ):
                     print('  &pin_{:s}, // {:d}'.format(pin.cpu_pin_name(), channel))
                     adc_found = True
                     break
             if not adc_found:
                 print('  NULL,    // {:d}'.format(channel))
         print('};')
-
 
     def print_header(self, hdr_filename):
         with open(hdr_filename, 'wt') as hdr_file:
@@ -293,9 +316,8 @@ class Pins(object):
             for qstr in sorted(qstr_set):
                 print('Q({})'.format(qstr), file=qstr_file)
 
-
     def print_af_hdr(self, af_const_filename):
-        with open(af_const_filename,  'wt') as af_const_file:
+        with open(af_const_filename, 'wt') as af_const_file:
             af_hdr_set = set([])
             mux_name_width = 0
             for named_pin in self.cpu_pins:
@@ -310,67 +332,75 @@ class Pins(object):
             for mux_name in sorted(af_hdr_set):
                 key = 'MP_OBJ_NEW_QSTR(MP_QSTR_{}),'.format(mux_name)
                 val = 'MP_OBJ_NEW_SMALL_INT(GPIO_{})'.format(mux_name)
-                print('    { %-*s %s },' % (mux_name_width + 26, key, val),
-                      file=af_const_file)
+                print(
+                    '    { %-*s %s },' % (mux_name_width + 26, key, val),
+                    file=af_const_file,
+                )
 
     def print_af_py(self, af_py_filename):
-        with open(af_py_filename,  'wt') as af_py_file:
-            print('PINS_AF = (', file=af_py_file);
+        with open(af_py_filename, 'wt') as af_py_file:
+            print('PINS_AF = (', file=af_py_file)
             for named_pin in self.board_pins:
                 print("  ('%s', " % named_pin.name(), end='', file=af_py_file)
                 for af in named_pin.pin().alt_fn:
                     if af.is_supported():
-                        print("(%d, '%s'), " % (af.idx, af.af_str), end='', file=af_py_file)
+                        print(
+                            "(%d, '%s'), " % (af.idx, af.af_str),
+                            end='',
+                            file=af_py_file,
+                        )
                 print('),', file=af_py_file)
-            print(')',  file=af_py_file)
+            print(')', file=af_py_file)
 
 
 def main():
     parser = argparse.ArgumentParser(
         prog="make-pins.py",
         usage="%(prog)s [options] [command]",
-        description="Generate board specific pin file"
+        description="Generate board specific pin file",
     )
     parser.add_argument(
-        "-a", "--af",
+        "-a",
+        "--af",
         dest="af_filename",
         help="Specifies the alternate function file for the chip",
-        default="mk20dx256_af.csv"
+        default="mk20dx256_af.csv",
     )
     parser.add_argument(
         "--af-const",
         dest="af_const_filename",
         help="Specifies header file for alternate function constants.",
-        default="build/pins_af_const.h"
+        default="build/pins_af_const.h",
     )
     parser.add_argument(
         "--af-py",
         dest="af_py_filename",
         help="Specifies the filename for the python alternate function mappings.",
-        default="build/pins_af.py"
+        default="build/pins_af.py",
     )
     parser.add_argument(
-        "-b", "--board",
-        dest="board_filename",
-        help="Specifies the board file",
+        "-b", "--board", dest="board_filename", help="Specifies the board file",
     )
     parser.add_argument(
-        "-p", "--prefix",
+        "-p",
+        "--prefix",
         dest="prefix_filename",
         help="Specifies beginning portion of generated pins file",
-        default="mk20dx256_prefix.c"
+        default="mk20dx256_prefix.c",
     )
     parser.add_argument(
-        "-q", "--qstr",
+        "-q",
+        "--qstr",
         dest="qstr_filename",
         help="Specifies name of generated qstr header file",
-        default="build/pins_qstr.h"
+        default="build/pins_qstr.h",
     )
     parser.add_argument(
-        "-r", "--hdr",
+        "-r",
+        "--hdr",
         dest="hdr_filename",
         help="Specifies name of generated pin header file",
-        default="build/pins.h"
+        default="build/pins.h",
     )
     args = parser.parse_args(sys.argv[1:])
 

--- a/ports/teensy/memzip_files/boot.py
+++ b/ports/teensy/memzip_files/boot.py
@@ -1,10 +1,13 @@
 import pyb
+
 print("Executing boot.py")
+
 
 def pins():
     for pin_name in dir(pyb.Pin.board):
         pin = pyb.Pin(pin_name)
         print('{:10s} {:s}'.format(pin_name, str(pin)))
+
 
 def af():
     for pin_name in dir(pyb.Pin.board):

--- a/ports/teensy/memzip_files/main.py
+++ b/ports/teensy/memzip_files/main.py
@@ -11,5 +11,3 @@ pyb.delay(100)
 led.on()
 pyb.delay(100)
 led.off()
-
-

--- a/ports/unix/coverage-frzmpy/frzmpy_pkg2/mod.py
+++ b/ports/unix/coverage-frzmpy/frzmpy_pkg2/mod.py
@@ -1,4 +1,6 @@
 # test frozen package without __init__.py
 print('frzmpy_pkg2.mod')
+
+
 class Foo:
     x = 1

--- a/ports/unix/coverage-frzstr/frzstr_pkg2/mod.py
+++ b/ports/unix/coverage-frzstr/frzstr_pkg2/mod.py
@@ -1,4 +1,6 @@
 # test frozen package without __init__.py
 print('frzstr_pkg2.mod')
+
+
 class Foo:
     x = 1

--- a/py/makemoduledefs.py
+++ b/py/makemoduledefs.py
@@ -14,8 +14,7 @@ import argparse
 
 
 pattern = re.compile(
-    r"[\n;]\s*MP_REGISTER_MODULE\((.*?),\s*(.*?),\s*(.*?)\);",
-    flags=re.DOTALL
+    r"[\n;]\s*MP_REGISTER_MODULE\((.*?),\s*(.*?),\s*(.*?)\);", flags=re.DOTALL
 )
 
 
@@ -67,15 +66,20 @@ def generate_module_table_header(modules):
     for module_name, obj_module, enabled_define in modules:
         mod_def = "MODULE_DEF_{}".format(module_name.upper())
         mod_defs.append(mod_def)
-        print((
-            "#if ({enabled_define})\n"
-            "    extern const struct _mp_obj_module_t {obj_module};\n"
-            "    #define {mod_def} {{ MP_ROM_QSTR({module_name}), MP_ROM_PTR(&{obj_module}) }},\n"
-            "#else\n"
-            "    #define {mod_def}\n"
-            "#endif\n"
-            ).format(module_name=module_name, obj_module=obj_module,
-                     enabled_define=enabled_define, mod_def=mod_def)
+        print(
+            (
+                "#if ({enabled_define})\n"
+                "    extern const struct _mp_obj_module_t {obj_module};\n"
+                "    #define {mod_def} {{ MP_ROM_QSTR({module_name}), MP_ROM_PTR(&{obj_module}) }},\n"
+                "#else\n"
+                "    #define {mod_def}\n"
+                "#endif\n"
+            ).format(
+                module_name=module_name,
+                obj_module=obj_module,
+                enabled_define=enabled_define,
+                mod_def=mod_def,
+            )
         )
 
     print("\n#define MICROPY_REGISTERED_MODULES \\")
@@ -88,10 +92,12 @@ def generate_module_table_header(modules):
 
 def main():
     parser = argparse.ArgumentParser()
-    parser.add_argument("--vpath", default=".",
-                        help="comma separated list of folders to search for c files in")
-    parser.add_argument("files", nargs="*",
-                        help="list of c files to search")
+    parser.add_argument(
+        "--vpath",
+        default=".",
+        help="comma separated list of folders to search for c files in",
+    )
+    parser.add_argument("files", nargs="*", help="list of c files to search")
     args = parser.parse_args()
 
     vpath = [p.strip() for p in args.vpath.split(',')]

--- a/py/makeqstrdefs.py
+++ b/py/makeqstrdefs.py
@@ -20,6 +20,7 @@ def write_out(fname, output):
         with open(args.output_dir + "/" + fname + ".qstr", "w") as f:
             f.write("\n".join(output) + "\n")
 
+
 def process_file(f):
     re_line = re.compile(r"#[line]*\s\d+\s\"([^\"]+)\"")
     re_qstr = re.compile(r'MP_QSTR_[_a-zA-Z0-9]+')
@@ -51,6 +52,7 @@ def process_file(f):
 def cat_together():
     import glob
     import hashlib
+
     hasher = hashlib.md5()
     all_lines = []
     outf = open(args.output_dir + "/out", "wb")
@@ -64,7 +66,7 @@ def cat_together():
     outf.close()
     hasher.update(all_lines)
     new_hash = hasher.hexdigest()
-    #print(new_hash)
+    # print(new_hash)
     old_hash = None
     try:
         with open(args.output_file + ".hash") as f:
@@ -92,6 +94,7 @@ if __name__ == "__main__":
 
     class Args:
         pass
+
     args = Args()
     args.command = sys.argv[1]
     args.input_filename = sys.argv[2]

--- a/py/makeversionhdr.py
+++ b/py/makeversionhdr.py
@@ -11,6 +11,7 @@ import os
 import datetime
 import subprocess
 
+
 def get_version_info_from_git():
     # Python 2.6 doesn't have check_output, so check for that
     try:
@@ -21,7 +22,11 @@ def get_version_info_from_git():
 
     # Note: git describe doesn't work if no tag is available
     try:
-        git_tag = subprocess.check_output(["git", "describe", "--dirty", "--always"], stderr=subprocess.STDOUT, universal_newlines=True).strip()
+        git_tag = subprocess.check_output(
+            ["git", "describe", "--dirty", "--always"],
+            stderr=subprocess.STDOUT,
+            universal_newlines=True,
+        ).strip()
     except subprocess.CalledProcessError as er:
         if er.returncode == 128:
             # git exit code of 128 means no repository found
@@ -30,7 +35,11 @@ def get_version_info_from_git():
     except OSError:
         return None
     try:
-        git_hash = subprocess.check_output(["git", "rev-parse", "--short", "HEAD"], stderr=subprocess.STDOUT, universal_newlines=True).strip()
+        git_hash = subprocess.check_output(
+            ["git", "rev-parse", "--short", "HEAD"],
+            stderr=subprocess.STDOUT,
+            universal_newlines=True,
+        ).strip()
     except subprocess.CalledProcessError:
         git_hash = "unknown"
     except OSError:
@@ -38,15 +47,22 @@ def get_version_info_from_git():
 
     try:
         # Check if there are any modified files.
-        subprocess.check_call(["git", "diff", "--no-ext-diff", "--quiet", "--exit-code"], stderr=subprocess.STDOUT)
+        subprocess.check_call(
+            ["git", "diff", "--no-ext-diff", "--quiet", "--exit-code"],
+            stderr=subprocess.STDOUT,
+        )
         # Check if there are any staged files.
-        subprocess.check_call(["git", "diff-index", "--cached", "--quiet", "HEAD", "--"], stderr=subprocess.STDOUT)
+        subprocess.check_call(
+            ["git", "diff-index", "--cached", "--quiet", "HEAD", "--"],
+            stderr=subprocess.STDOUT,
+        )
     except subprocess.CalledProcessError:
         git_hash += "-dirty"
     except OSError:
         return None
 
     return git_tag, git_hash
+
 
 def get_version_info_from_docs_conf():
     with open(os.path.join(os.path.dirname(sys.argv[0]), "..", "docs", "conf.py")) as f:
@@ -56,6 +72,7 @@ def get_version_info_from_docs_conf():
                 git_tag = "v" + ver
                 return git_tag, "<no hash>"
     return None
+
 
 def make_version_header(filename):
     # Get version info using git, with fallback to docs/conf.py
@@ -71,7 +88,11 @@ def make_version_header(filename):
 #define MICROPY_GIT_TAG "%s"
 #define MICROPY_GIT_HASH "%s"
 #define MICROPY_BUILD_DATE "%s"
-""" % (git_tag, git_hash, datetime.date.today().strftime("%Y-%m-%d"))
+""" % (
+        git_tag,
+        git_hash,
+        datetime.date.today().strftime("%Y-%m-%d"),
+    )
 
     # Check if the file contents changed from last time
     write_file = True
@@ -86,6 +107,7 @@ def make_version_header(filename):
         print("GEN %s" % filename)
         with open(filename, 'w') as f:
             f.write(file_data)
+
 
 if __name__ == "__main__":
     make_version_header(sys.argv[1])

--- a/tools/codeformat.py
+++ b/tools/codeformat.py
@@ -1,0 +1,44 @@
+#!/usr/bin/env python3
+
+import sys, os, glob
+
+FILES = [
+    "drivers/**/*.py",
+    "examples/**/*.py",
+    "extmod/**/*.py",
+    "lib/**/*.py",
+    "ports/**/*.py",
+    "py/**/*.py",
+    "tools/**/*.py",
+]
+
+EXCLUSIONS = []
+
+
+def list_files():
+    files = set()
+    for pattern in FILES:
+        files.update(glob.glob(pattern, recursive=True))
+    for pattern in EXCLUSIONS:
+        files.difference_update(glob.fnmatch.filter(files, pattern))
+    return sorted(files)
+
+
+def main():
+    try:
+        os.stat("./tools/codeformat.py")
+    except OSError:
+        print(
+            "Run this from the top-level directory, e.g. ./tools/codeformat.py",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    files = list_files()
+    for file in files:
+        print(file)
+        os.system("black -q --fast " + file)
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/dfu.py
+++ b/tools/dfu.py
@@ -4,122 +4,170 @@
 # Distributed under Gnu LGPL 3.0
 # see http://www.gnu.org/licenses/lgpl-3.0.txt
 
-import sys,struct,zlib,os
+import sys, struct, zlib, os
 from optparse import OptionParser
 
-DEFAULT_DEVICE="0x0483:0xdf11"
+DEFAULT_DEVICE = "0x0483:0xdf11"
 
-def named(tuple,names):
-  return dict(zip(names.split(),tuple))
-def consume(fmt,data,names):
-  n = struct.calcsize(fmt)
-  return named(struct.unpack(fmt,data[:n]),names),data[n:]
+
+def named(tuple, names):
+    return dict(zip(names.split(), tuple))
+
+
+def consume(fmt, data, names):
+    n = struct.calcsize(fmt)
+    return named(struct.unpack(fmt, data[:n]), names), data[n:]
+
+
 def cstring(string):
-  return string.split('\0',1)[0]
+    return string.split('\0', 1)[0]
+
+
 def compute_crc(data):
-  return 0xFFFFFFFF & -zlib.crc32(data) -1
+    return 0xFFFFFFFF & -zlib.crc32(data) - 1
 
-def parse(file,dump_images=False):
-  print ('File: "%s"' % file)
-  data = open(file,'rb').read()
-  crc = compute_crc(data[:-4])
-  prefix, data = consume('<5sBIB',data,'signature version size targets')
-  print ('%(signature)s v%(version)d, image size: %(size)d, targets: %(targets)d' % prefix)
-  for t in range(prefix['targets']):
-    tprefix, data  = consume('<6sBI255s2I',data,'signature altsetting named name size elements')
-    tprefix['num'] = t
-    if tprefix['named']:
-      tprefix['name'] = cstring(tprefix['name'])
-    else:
-      tprefix['name'] = ''
-    print ('%(signature)s %(num)d, alt setting: %(altsetting)s, name: "%(name)s", size: %(size)d, elements: %(elements)d' % tprefix)
-    tsize = tprefix['size']
-    target, data = data[:tsize], data[tsize:]
-    for e in range(tprefix['elements']):
-      eprefix, target = consume('<2I',target,'address size')
-      eprefix['num'] = e
-      print ('  %(num)d, address: 0x%(address)08x, size: %(size)d' % eprefix)
-      esize = eprefix['size']
-      image, target = target[:esize], target[esize:]
-      if dump_images:
-        out = '%s.target%d.image%d.bin' % (file,t,e)
-        open(out,'wb').write(image)
-        print ('    DUMPED IMAGE TO "%s"' % out)
-    if len(target):
-      print ("target %d: PARSE ERROR" % t)
-  suffix = named(struct.unpack('<4H3sBI',data[:16]),'device product vendor dfu ufd len crc')
-  print ('usb: %(vendor)04x:%(product)04x, device: 0x%(device)04x, dfu: 0x%(dfu)04x, %(ufd)s, %(len)d, 0x%(crc)08x' % suffix)
-  if crc != suffix['crc']:
-    print ("CRC ERROR: computed crc32 is 0x%08x" % crc)
-  data = data[16:]
-  if data:
-    print ("PARSE ERROR")
 
-def build(file,targets,device=DEFAULT_DEVICE):
-  data = b''
-  for t,target in enumerate(targets):
-    tdata = b''
-    for image in target:
-      # pad image to 8 bytes (needed at least for L476)
-      pad = (8 - len(image['data']) % 8 ) % 8
-      image['data'] = image['data'] + bytes(bytearray(8)[0:pad])
-      #
-      tdata += struct.pack('<2I',image['address'],len(image['data']))+image['data']
-    tdata = struct.pack('<6sBI255s2I',b'Target',0,1, b'ST...',len(tdata),len(target)) + tdata
-    data += tdata
-  data  = struct.pack('<5sBIB',b'DfuSe',1,len(data)+11,len(targets)) + data
-  v,d=map(lambda x: int(x,0) & 0xFFFF, device.split(':',1))
-  data += struct.pack('<4H3sB',0,d,v,0x011a,b'UFD',16)
-  crc   = compute_crc(data)
-  data += struct.pack('<I',crc)
-  open(file,'wb').write(data)
+def parse(file, dump_images=False):
+    print('File: "%s"' % file)
+    data = open(file, 'rb').read()
+    crc = compute_crc(data[:-4])
+    prefix, data = consume('<5sBIB', data, 'signature version size targets')
+    print(
+        '%(signature)s v%(version)d, image size: %(size)d, targets: %(targets)d'
+        % prefix
+    )
+    for t in range(prefix['targets']):
+        tprefix, data = consume(
+            '<6sBI255s2I', data, 'signature altsetting named name size elements'
+        )
+        tprefix['num'] = t
+        if tprefix['named']:
+            tprefix['name'] = cstring(tprefix['name'])
+        else:
+            tprefix['name'] = ''
+        print(
+            '%(signature)s %(num)d, alt setting: %(altsetting)s, name: "%(name)s", size: %(size)d, elements: %(elements)d'
+            % tprefix
+        )
+        tsize = tprefix['size']
+        target, data = data[:tsize], data[tsize:]
+        for e in range(tprefix['elements']):
+            eprefix, target = consume('<2I', target, 'address size')
+            eprefix['num'] = e
+            print('  %(num)d, address: 0x%(address)08x, size: %(size)d' % eprefix)
+            esize = eprefix['size']
+            image, target = target[:esize], target[esize:]
+            if dump_images:
+                out = '%s.target%d.image%d.bin' % (file, t, e)
+                open(out, 'wb').write(image)
+                print('    DUMPED IMAGE TO "%s"' % out)
+        if len(target):
+            print("target %d: PARSE ERROR" % t)
+    suffix = named(
+        struct.unpack('<4H3sBI', data[:16]), 'device product vendor dfu ufd len crc'
+    )
+    print(
+        'usb: %(vendor)04x:%(product)04x, device: 0x%(device)04x, dfu: 0x%(dfu)04x, %(ufd)s, %(len)d, 0x%(crc)08x'
+        % suffix
+    )
+    if crc != suffix['crc']:
+        print("CRC ERROR: computed crc32 is 0x%08x" % crc)
+    data = data[16:]
+    if data:
+        print("PARSE ERROR")
 
-if __name__=="__main__":
-  usage = """
+
+def build(file, targets, device=DEFAULT_DEVICE):
+    data = b''
+    for t, target in enumerate(targets):
+        tdata = b''
+        for image in target:
+            # pad image to 8 bytes (needed at least for L476)
+            pad = (8 - len(image['data']) % 8) % 8
+            image['data'] = image['data'] + bytes(bytearray(8)[0:pad])
+            #
+            tdata += (
+                struct.pack('<2I', image['address'], len(image['data'])) + image['data']
+            )
+        tdata = (
+            struct.pack(
+                '<6sBI255s2I', b'Target', 0, 1, b'ST...', len(tdata), len(target)
+            )
+            + tdata
+        )
+        data += tdata
+    data = struct.pack('<5sBIB', b'DfuSe', 1, len(data) + 11, len(targets)) + data
+    v, d = map(lambda x: int(x, 0) & 0xFFFF, device.split(':', 1))
+    data += struct.pack('<4H3sB', 0, d, v, 0x011A, b'UFD', 16)
+    crc = compute_crc(data)
+    data += struct.pack('<I', crc)
+    open(file, 'wb').write(data)
+
+
+if __name__ == "__main__":
+    usage = """
 %prog [-d|--dump] infile.dfu
 %prog {-b|--build} address:file.bin [-b address:file.bin ...] [{-D|--device}=vendor:device] outfile.dfu"""
-  parser = OptionParser(usage=usage)
-  parser.add_option("-b", "--build", action="append", dest="binfiles",
-    help="build a DFU file from given BINFILES", metavar="BINFILES")
-  parser.add_option("-D", "--device", action="store", dest="device",
-    help="build for DEVICE, defaults to %s" % DEFAULT_DEVICE, metavar="DEVICE")
-  parser.add_option("-d", "--dump", action="store_true", dest="dump_images",
-    default=False, help="dump contained images to current directory")
-  (options, args) = parser.parse_args()
+    parser = OptionParser(usage=usage)
+    parser.add_option(
+        "-b",
+        "--build",
+        action="append",
+        dest="binfiles",
+        help="build a DFU file from given BINFILES",
+        metavar="BINFILES",
+    )
+    parser.add_option(
+        "-D",
+        "--device",
+        action="store",
+        dest="device",
+        help="build for DEVICE, defaults to %s" % DEFAULT_DEVICE,
+        metavar="DEVICE",
+    )
+    parser.add_option(
+        "-d",
+        "--dump",
+        action="store_true",
+        dest="dump_images",
+        default=False,
+        help="dump contained images to current directory",
+    )
+    (options, args) = parser.parse_args()
 
-  if options.binfiles and len(args)==1:
-    target = []
-    for arg in options.binfiles:
-      try:
-        address,binfile = arg.split(':',1)
-      except ValueError:
-        print ("Address:file couple '%s' invalid." % arg)
+    if options.binfiles and len(args) == 1:
+        target = []
+        for arg in options.binfiles:
+            try:
+                address, binfile = arg.split(':', 1)
+            except ValueError:
+                print("Address:file couple '%s' invalid." % arg)
+                sys.exit(1)
+            try:
+                address = int(address, 0) & 0xFFFFFFFF
+            except ValueError:
+                print("Address %s invalid." % address)
+                sys.exit(1)
+            if not os.path.isfile(binfile):
+                print("Unreadable file '%s'." % binfile)
+                sys.exit(1)
+            target.append({'address': address, 'data': open(binfile, 'rb').read()})
+        outfile = args[0]
+        device = DEFAULT_DEVICE
+        if options.device:
+            device = options.device
+        try:
+            v, d = map(lambda x: int(x, 0) & 0xFFFF, device.split(':', 1))
+        except:
+            print("Invalid device '%s'." % device)
+            sys.exit(1)
+        build(outfile, [target], device)
+    elif len(args) == 1:
+        infile = args[0]
+        if not os.path.isfile(infile):
+            print("Unreadable file '%s'." % infile)
+            sys.exit(1)
+        parse(infile, dump_images=options.dump_images)
+    else:
+        parser.print_help()
         sys.exit(1)
-      try:
-        address = int(address,0) & 0xFFFFFFFF
-      except ValueError:
-        print ("Address %s invalid." % address)
-        sys.exit(1)
-      if not os.path.isfile(binfile):
-        print ("Unreadable file '%s'." % binfile)
-        sys.exit(1)
-      target.append({ 'address': address, 'data': open(binfile,'rb').read() })
-    outfile = args[0]
-    device = DEFAULT_DEVICE
-    if options.device:
-      device=options.device
-    try:
-      v,d=map(lambda x: int(x,0) & 0xFFFF, device.split(':',1))
-    except:
-      print ("Invalid device '%s'." % device)
-      sys.exit(1)
-    build(outfile,[target],device)
-  elif len(args)==1:
-    infile = args[0]
-    if not os.path.isfile(infile):
-      print ("Unreadable file '%s'." % infile)
-      sys.exit(1)
-    parse(infile, dump_images=options.dump_images)
-  else:
-    parser.print_help()
-    sys.exit(1)

--- a/tools/gen-cpydiff.py
+++ b/tools/gen-cpydiff.py
@@ -57,8 +57,21 @@ RSTCHARS = ['=', '-', '~', '`', ':']
 SPLIT = '"""\n|categories: |description: |cause: |workaround: '
 TAB = '    '
 
-Output = namedtuple('output', ['name', 'class_', 'desc', 'cause', 'workaround', 'code',
-                               'output_cpy', 'output_upy', 'status'])
+Output = namedtuple(
+    'output',
+    [
+        'name',
+        'class_',
+        'desc',
+        'cause',
+        'workaround',
+        'code',
+        'output_cpy',
+        'output_upy',
+        'status',
+    ],
+)
+
 
 def readfiles():
     """ Reads test files """
@@ -70,8 +83,9 @@ def readfiles():
         text = open(TESTPATH + test, 'r').read()
 
         try:
-            class_, desc, cause, workaround, code = [x.rstrip() for x in \
-                                                    list(filter(None, re.split(SPLIT, text)))]
+            class_, desc, cause, workaround, code = [
+                x.rstrip() for x in list(filter(None, re.split(SPLIT, text)))
+            ]
             output = Output(test, class_, desc, cause, workaround, code, '', '', '')
             files.append(output)
         except IndexError:
@@ -79,12 +93,14 @@ def readfiles():
 
     return files
 
+
 def uimports(code):
     """ converts CPython module names into MicroPython equivalents """
     for uimport in UIMPORTLIST:
         uimport = bytes(uimport, 'utf8')
         code = code.replace(uimport, b'u' + uimport)
     return code
+
 
 def run_tests(tests):
     """ executes all tests """
@@ -94,10 +110,22 @@ def run_tests(tests):
             input_cpy = f.read()
         input_upy = uimports(input_cpy)
 
-        process = subprocess.Popen(CPYTHON3, shell=True, stdout=subprocess.PIPE, stdin=subprocess.PIPE, stderr=subprocess.PIPE)
+        process = subprocess.Popen(
+            CPYTHON3,
+            shell=True,
+            stdout=subprocess.PIPE,
+            stdin=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+        )
         output_cpy = [com.decode('utf8') for com in process.communicate(input_cpy)]
 
-        process = subprocess.Popen(MICROPYTHON, shell=True, stdout=subprocess.PIPE, stdin=subprocess.PIPE, stderr=subprocess.PIPE)
+        process = subprocess.Popen(
+            MICROPYTHON,
+            shell=True,
+            stdout=subprocess.PIPE,
+            stdin=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+        )
         output_upy = [com.decode('utf8') for com in process.communicate(input_upy)]
 
         if output_cpy[0] == output_upy[0] and output_cpy[1] == output_upy[1]:
@@ -106,12 +134,22 @@ def run_tests(tests):
         else:
             status = 'Unsupported'
 
-        output = Output(test.name, test.class_, test.desc, test.cause,
-                        test.workaround, test.code, output_cpy, output_upy, status)
+        output = Output(
+            test.name,
+            test.class_,
+            test.desc,
+            test.cause,
+            test.workaround,
+            test.code,
+            output_cpy,
+            output_upy,
+            status,
+        )
         results.append(output)
 
     results.sort(key=lambda x: x.class_)
     return results
+
 
 def indent(block, spaces):
     """ indents paragraphs of text for rst formatting """
@@ -119,6 +157,7 @@ def indent(block, spaces):
     for line in block.split('\n'):
         new_block += spaces + line + '\n'
     return new_block
+
 
 def gen_table(contents):
     """ creates a table given any set of columns """
@@ -141,7 +180,7 @@ def gen_table(contents):
     table = table_divider
     for i in range(len(ylengths)):
         row = [column[i] for column in contents]
-        row = [entry + '\n' * (ylengths[i]-len(entry.split('\n'))) for entry in row]
+        row = [entry + '\n' * (ylengths[i] - len(entry.split('\n'))) for entry in row]
         row = [entry.split('\n') for entry in row]
         for j in range(ylengths[i]):
             k = 0
@@ -152,6 +191,7 @@ def gen_table(contents):
             table += '|\n'
         table += table_divider
     return table + '\n'
+
 
 def gen_rst(results):
     """ creates restructured text documents to display tests """
@@ -178,11 +218,15 @@ def gen_rst(results):
                     rst.write(HEADER)
                     rst.write(section[i] + '\n')
                     rst.write(RSTCHARS[0] * len(section[i]))
-                    rst.write(time.strftime("\nGenerated %a %d %b %Y %X UTC\n\n", time.gmtime()))
+                    rst.write(
+                        time.strftime(
+                            "\nGenerated %a %d %b %Y %X UTC\n\n", time.gmtime()
+                        )
+                    )
                     toctree.append(filename)
                 else:
                     rst.write(section[i] + '\n')
-                    rst.write(RSTCHARS[min(i, len(RSTCHARS)-1)] * len(section[i]))
+                    rst.write(RSTCHARS[min(i, len(RSTCHARS) - 1)] * len(section[i]))
                     rst.write('\n\n')
         class_ = section
         rst.write('.. _cpydiff_%s:\n\n' % output.name.rsplit('.', 1)[0])
@@ -212,6 +256,7 @@ def gen_rst(results):
     for section in toctree:
         index.write(indent(section + '.rst', TAB))
 
+
 def main():
     """ Main function """
 
@@ -222,5 +267,6 @@ def main():
     files = readfiles()
     results = run_tests(files)
     gen_rst(results)
+
 
 main()

--- a/tools/gendoc.py
+++ b/tools/gendoc.py
@@ -15,9 +15,11 @@ def re_match_first(regexs, line):
             return name, match
     return None, None
 
+
 def makedirs(d):
     if not os.path.isdir(d):
         os.makedirs(d)
+
 
 class Lexer:
     class LexerError(Exception):
@@ -66,6 +68,7 @@ class Lexer:
     def error(self, msg):
         print('({}:{}) {}'.format(self.filename, self.cur_line, msg))
         raise Lexer.LexerError
+
 
 class MarkdownWriter:
     def __init__(self):
@@ -119,8 +122,9 @@ class MarkdownWriter:
     def constant(self, ctx, name, descr):
         self.single_line('`{}.{}` - {}'.format(ctx, name, descr))
 
+
 class ReStructuredTextWriter:
-    head_chars = {1:'=', 2:'-', 3:'.'}
+    head_chars = {1: '=', 2: '-', 3: '.'}
 
     def __init__(self):
         pass
@@ -159,7 +163,11 @@ class ReStructuredTextWriter:
         self.lines.append(self._convert(text))
 
     def module(self, name, short_descr, descr):
-        self.heading(1, ':mod:`{}` --- {}'.format(name, self._convert(short_descr)), convert=False)
+        self.heading(
+            1,
+            ':mod:`{}` --- {}'.format(name, self._convert(short_descr)),
+            convert=False,
+        )
         self.lines.append('.. module:: {}'.format(name))
         self.lines.append('   :synopsis: {}'.format(short_descr))
         self.para(descr)
@@ -183,8 +191,10 @@ class ReStructuredTextWriter:
         self.lines.append('.. data:: ' + name)
         self.para(descr, indent='   ')
 
+
 class DocValidateError(Exception):
     pass
+
 
 class DocItem:
     def __init__(self):
@@ -202,6 +212,7 @@ class DocItem:
     def dump(self, writer):
         writer.para(self.doc)
 
+
 class DocConstant(DocItem):
     def __init__(self, name, descr):
         super().__init__()
@@ -210,6 +221,7 @@ class DocConstant(DocItem):
 
     def dump(self, ctx, writer):
         writer.constant(ctx, self.name, self.descr)
+
 
 class DocFunction(DocItem):
     def __init__(self, name, args):
@@ -220,6 +232,7 @@ class DocFunction(DocItem):
     def dump(self, ctx, writer):
         writer.function(ctx, self.name, self.args, self.doc)
 
+
 class DocMethod(DocItem):
     def __init__(self, name, args):
         super().__init__()
@@ -228,6 +241,7 @@ class DocMethod(DocItem):
 
     def dump(self, ctx, writer):
         writer.method(ctx, self.name, self.args, self.doc)
+
 
 class DocClass(DocItem):
     def __init__(self, name, descr):
@@ -270,20 +284,21 @@ class DocClass(DocItem):
         super().dump(writer)
         if len(self.constructors) > 0:
             writer.heading(2, 'Constructors')
-            for f in sorted(self.constructors.values(), key=lambda x:x.name):
+            for f in sorted(self.constructors.values(), key=lambda x: x.name):
                 f.dump(self.name, writer)
         if len(self.classmethods) > 0:
             writer.heading(2, 'Class methods')
-            for f in sorted(self.classmethods.values(), key=lambda x:x.name):
+            for f in sorted(self.classmethods.values(), key=lambda x: x.name):
                 f.dump(self.name, writer)
         if len(self.methods) > 0:
             writer.heading(2, 'Methods')
-            for f in sorted(self.methods.values(), key=lambda x:x.name):
+            for f in sorted(self.methods.values(), key=lambda x: x.name):
                 f.dump(self.name.lower(), writer)
         if len(self.constants) > 0:
             writer.heading(2, 'Constants')
-            for c in sorted(self.constants.values(), key=lambda x:x.name):
+            for c in sorted(self.constants.values(), key=lambda x: x.name):
                 c.dump(self.name, writer)
+
 
 class DocModule(DocItem):
     def __init__(self, name, descr):
@@ -305,7 +320,7 @@ class DocModule(DocItem):
         function = self.functions[name] = DocFunction(name, d['args'])
         function.add_doc(lex)
 
-    #def process_classref(self, lex, d):
+    # def process_classref(self, lex, d):
     #    name = d['id']
     #    self.classes[name] = name
     #    lex.opt_break()
@@ -337,22 +352,26 @@ class DocModule(DocItem):
 
     def validate(self):
         if self.descr is None:
-            raise DocValidateError('module {} referenced but never defined'.format(self.name))
+            raise DocValidateError(
+                'module {} referenced but never defined'.format(self.name)
+            )
 
     def dump(self, writer):
         writer.module(self.name, self.descr, self.doc)
         if self.functions:
             writer.heading(2, 'Functions')
-            for f in sorted(self.functions.values(), key=lambda x:x.name):
+            for f in sorted(self.functions.values(), key=lambda x: x.name):
                 f.dump(self.name, writer)
         if self.constants:
             writer.heading(2, 'Constants')
-            for c in sorted(self.constants.values(), key=lambda x:x.name):
+            for c in sorted(self.constants.values(), key=lambda x: x.name):
                 c.dump(self.name, writer)
         if self.classes:
             writer.heading(2, 'Classes')
-            for c in sorted(self.classes.values(), key=lambda x:x.name):
-                writer.para('[`{}.{}`]({}) - {}'.format(self.name, c.name, c.name, c.descr))
+            for c in sorted(self.classes.values(), key=lambda x: x.name):
+                writer.para(
+                    '[`{}.{}`]({}) - {}'.format(self.name, c.name, c.name, c.descr)
+                )
 
     def write_html(self, dir):
         md_writer = MarkdownWriter()
@@ -380,6 +399,7 @@ class DocModule(DocItem):
             c.dump(rst_writer)
             with open(dir + '/' + self.name + '.' + c.name + '.rst', 'wt') as f:
                 f.write(rst_writer.end())
+
 
 class Doc:
     def __init__(self):
@@ -439,7 +459,7 @@ class Doc:
     def dump(self, writer):
         writer.heading(1, 'Modules')
         writer.para('These are the Python modules that are implemented.')
-        for m in sorted(self.modules.values(), key=lambda x:x.name):
+        for m in sorted(self.modules.values(), key=lambda x: x.name):
             writer.para('[`{}`]({}/) - {}'.format(m.name, m.name, m.descr))
 
     def write_html(self, dir):
@@ -454,23 +474,43 @@ class Doc:
             m.write_html(mod_dir)
 
     def write_rst(self, dir):
-        #with open(os.path.join(dir, 'module', 'index.html'), 'wt') as f:
+        # with open(os.path.join(dir, 'module', 'index.html'), 'wt') as f:
         #    f.write(markdown.markdown(self.dump()))
         for m in self.modules.values():
             m.write_rst(dir)
 
+
 regex_descr = r'(?P<descr>.*)'
 
 doc_regexs = (
-    (Doc.process_module, re.compile(r'\\module (?P<id>[a-z][a-z0-9]*) - ' + regex_descr + r'$')),
+    (
+        Doc.process_module,
+        re.compile(r'\\module (?P<id>[a-z][a-z0-9]*) - ' + regex_descr + r'$'),
+    ),
     (Doc.process_moduleref, re.compile(r'\\moduleref (?P<id>[a-z]+)$')),
-    (Doc.process_function, re.compile(r'\\function (?P<id>[a-z0-9_]+)(?P<args>\(.*\))$')),
-    (Doc.process_classmethod, re.compile(r'\\classmethod (?P<id>\\?[a-z0-9_]+)(?P<args>\(.*\))$')),
-    (Doc.process_method, re.compile(r'\\method (?P<id>\\?[a-z0-9_]+)(?P<args>\(.*\))$')),
-    (Doc.process_constant, re.compile(r'\\constant (?P<id>[A-Za-z0-9_]+) - ' + regex_descr + r'$')),
-    #(Doc.process_classref, re.compile(r'\\classref (?P<id>[A-Za-z0-9_]+)$')),
-    (Doc.process_class, re.compile(r'\\class (?P<id>[A-Za-z0-9_]+) - ' + regex_descr + r'$')),
+    (
+        Doc.process_function,
+        re.compile(r'\\function (?P<id>[a-z0-9_]+)(?P<args>\(.*\))$'),
+    ),
+    (
+        Doc.process_classmethod,
+        re.compile(r'\\classmethod (?P<id>\\?[a-z0-9_]+)(?P<args>\(.*\))$'),
+    ),
+    (
+        Doc.process_method,
+        re.compile(r'\\method (?P<id>\\?[a-z0-9_]+)(?P<args>\(.*\))$'),
+    ),
+    (
+        Doc.process_constant,
+        re.compile(r'\\constant (?P<id>[A-Za-z0-9_]+) - ' + regex_descr + r'$'),
+    ),
+    # (Doc.process_classref, re.compile(r'\\classref (?P<id>[A-Za-z0-9_]+)$')),
+    (
+        Doc.process_class,
+        re.compile(r'\\class (?P<id>[A-Za-z0-9_]+) - ' + regex_descr + r'$'),
+    ),
 )
+
 
 def process_file(file, doc):
     lex = Lexer(file)
@@ -495,10 +535,17 @@ def process_file(file, doc):
 
     return True
 
+
 def main():
-    cmd_parser = argparse.ArgumentParser(description='Generate documentation for pyboard API from C files.')
-    cmd_parser.add_argument('--outdir', metavar='<output dir>', default='gendoc-out', help='ouput directory')
-    cmd_parser.add_argument('--format', default='html', help='output format: html or rst')
+    cmd_parser = argparse.ArgumentParser(
+        description='Generate documentation for pyboard API from C files.'
+    )
+    cmd_parser.add_argument(
+        '--outdir', metavar='<output dir>', default='gendoc-out', help='ouput directory'
+    )
+    cmd_parser.add_argument(
+        '--format', default='html', help='output format: html or rst'
+    )
     cmd_parser.add_argument('files', nargs='+', help='input files')
     args = cmd_parser.parse_args()
 
@@ -523,6 +570,7 @@ def main():
         return
 
     print('written to', args.outdir)
+
 
 if __name__ == "__main__":
     main()

--- a/tools/insert-usb-ids.py
+++ b/tools/insert-usb-ids.py
@@ -10,6 +10,7 @@ import string
 
 needed_keys = ('USB_PID_CDC_MSC', 'USB_PID_CDC_HID', 'USB_PID_CDC', 'USB_VID')
 
+
 def parse_usb_ids(filename):
     rv = dict()
     for line in open(filename).readlines():
@@ -25,6 +26,7 @@ def parse_usb_ids(filename):
         if k not in rv:
             raise Exception("Unable to parse %s from %s" % (k, filename))
     return rv
+
 
 if __name__ == "__main__":
     usb_ids_file = sys.argv[1]

--- a/tools/make-frozen.py
+++ b/tools/make-frozen.py
@@ -25,6 +25,7 @@ import os
 def module_name(f):
     return f
 
+
 modules = []
 
 if len(sys.argv) > 1:
@@ -35,7 +36,7 @@ if len(sys.argv) > 1:
         for f in filenames:
             fullpath = dirpath + "/" + f
             st = os.stat(fullpath)
-            modules.append((fullpath[root_len + 1:], st))
+            modules.append((fullpath[root_len + 1 :], st))
 
 print("#include <stdint.h>")
 print("const char mp_frozen_str_names[] = {")
@@ -62,7 +63,7 @@ for f, st in modules:
     # data.  We could just encode all characters as hex digits but it's nice
     # to be able to read the resulting C code as ASCII when possible.
 
-    data = bytearray(data) # so Python2 extracts each byte as an integer
+    data = bytearray(data)  # so Python2 extracts each byte as an integer
     esc_dict = {ord('\n'): '\\n', ord('\r'): '\\r', ord('"'): '\\"', ord('\\'): '\\\\'}
     chrs = ['"']
     break_str = False

--- a/tools/metrics.py
+++ b/tools/metrics.py
@@ -47,6 +47,7 @@ import sys, re, subprocess
 
 MAKE_FLAGS = ['-j3', 'CFLAGS_EXTRA=-DNDEBUG']
 
+
 class PortData:
     def __init__(self, name, dir, output, make_flags=None):
         self.name = name
@@ -54,18 +55,22 @@ class PortData:
         self.output = output
         self.make_flags = make_flags
 
+
 port_data = {
     'b': PortData('bare-arm', 'bare-arm', 'build/firmware.elf'),
     'm': PortData('minimal x86', 'minimal', 'build/firmware.elf'),
     'u': PortData('unix x64', 'unix', 'micropython'),
     'n': PortData('unix nanbox', 'unix', 'micropython-nanbox', 'VARIANT=nanbox'),
     's': PortData('stm32', 'stm32', 'build-PYBV10/firmware.elf', 'BOARD=PYBV10'),
-    'c': PortData('cc3200', 'cc3200', 'build/WIPY/release/application.axf', 'BTARGET=application'),
+    'c': PortData(
+        'cc3200', 'cc3200', 'build/WIPY/release/application.axf', 'BTARGET=application'
+    ),
     '8': PortData('esp8266', 'esp8266', 'build-GENERIC/firmware.elf'),
     '3': PortData('esp32', 'esp32', 'build-GENERIC/application.elf'),
     'r': PortData('nrf', 'nrf', 'build-pca10040/firmware.elf'),
     'd': PortData('samd', 'samd', 'build-ADAFRUIT_ITSYBITSY_M4_EXPRESS/firmware.elf'),
 }
+
 
 def syscmd(*args):
     sys.stdout.flush()
@@ -76,6 +81,7 @@ def syscmd(*args):
         elif a:
             a2.extend(a)
     subprocess.run(a2)
+
 
 def parse_port_list(args):
     if not args:
@@ -90,6 +96,7 @@ def parse_port_list(args):
                     print('unknown port:', port_char)
                     sys.exit(1)
         return ports
+
 
 def read_build_log(filename):
     data = dict()
@@ -111,6 +118,7 @@ def read_build_log(filename):
         else:
             is_size_line = line.startswith('text\t ')
     return data
+
 
 def do_diff(args):
     """Compute the difference between firmware sizes."""
@@ -151,6 +159,7 @@ def do_diff(args):
             warn = '[incl%s]' % warn
         print('%11s: %+5u %+.3f%% %s%s' % (name, delta, percent, board, warn))
 
+
 def do_clean(args):
     """Clean ports."""
 
@@ -159,6 +168,7 @@ def do_clean(args):
     print('CLEANING')
     for port in ports:
         syscmd('make', '-C', 'ports/{}'.format(port.dir), port.make_flags, 'clean')
+
 
 def do_build(args):
     """Build ports and print firmware sizes."""
@@ -174,6 +184,7 @@ def do_build(args):
 
     do_sizes(args)
 
+
 def do_sizes(args):
     """Compute and print sizes of firmware."""
 
@@ -182,6 +193,7 @@ def do_sizes(args):
     print('COMPUTING SIZES')
     for port in ports:
         syscmd('size', 'ports/{}/{}'.format(port.dir, port.output))
+
 
 def main():
     # Get command to execute
@@ -200,6 +212,7 @@ def main():
         print("{}: unknown command '{}'".format(sys.argv[0], cmd))
         sys.exit(1)
     cmd(sys.argv[1:])
+
 
 if __name__ == '__main__':
     main()

--- a/tools/mpy-tool.py
+++ b/tools/mpy-tool.py
@@ -27,6 +27,7 @@
 # Python 2/3 compatibility code
 from __future__ import print_function
 import platform
+
 if platform.python_version_tuple()[0] == '2':
     str_cons = lambda val, enc=None: val
     bytes_cons = lambda val, enc=None: bytearray(val)
@@ -48,6 +49,7 @@ from collections import namedtuple
 sys.path.append(sys.path[0] + '/../py')
 import makeqstrdata as qstrutil
 
+
 class FreezeError(Exception):
     def __init__(self, rawcode, msg):
         self.rawcode = rawcode
@@ -56,12 +58,16 @@ class FreezeError(Exception):
     def __str__(self):
         return 'error while freezing %s: %s' % (self.rawcode.source_file, self.msg)
 
+
 class Config:
     MPY_VERSION = 5
     MICROPY_LONGINT_IMPL_NONE = 0
     MICROPY_LONGINT_IMPL_LONGLONG = 1
     MICROPY_LONGINT_IMPL_MPZ = 2
+
+
 config = Config()
+
 
 class QStrType:
     def __init__(self, str):
@@ -69,10 +75,12 @@ class QStrType:
         self.qstr_esc = qstrutil.qstr_escape(self.str)
         self.qstr_id = 'MP_QSTR_' + self.qstr_esc
 
+
 # Initialise global list of qstrs with static qstrs
-global_qstrs = [None] # MP_QSTRnull should never be referenced
+global_qstrs = [None]  # MP_QSTRnull should never be referenced
 for n in qstrutil.static_qstr_list:
     global_qstrs.append(QStrType(n))
+
 
 class QStrWindow:
     def __init__(self, size):
@@ -80,12 +88,13 @@ class QStrWindow:
         self.size = size
 
     def push(self, val):
-        self.window = [val] + self.window[:self.size - 1]
+        self.window = [val] + self.window[: self.size - 1]
 
     def access(self, idx):
         val = self.window[idx]
-        self.window = [val] + self.window[:idx] + self.window[idx + 1:]
+        self.window = [val] + self.window[:idx] + self.window[idx + 1 :]
         return val
+
 
 MP_CODE_BYTECODE = 2
 MP_CODE_NATIVE_PY = 3
@@ -104,7 +113,7 @@ MP_NATIVE_ARCH_ARMV7EMDP = 8
 MP_NATIVE_ARCH_XTENSA = 9
 MP_NATIVE_ARCH_XTENSAWIN = 10
 
-MP_BC_MASK_EXTRA_BYTE = 0x9e
+MP_BC_MASK_EXTRA_BYTE = 0x9E
 
 MP_BC_FORMAT_BYTE = 0
 MP_BC_FORMAT_QSTR = 1
@@ -121,13 +130,15 @@ MP_BC_STORE_ATTR = 0x18
 def mp_opcode_format(bytecode, ip, count_var_uint):
     opcode = bytecode[ip]
     ip_start = ip
-    f = ((0x000003a4 >> (2 * ((opcode) >> 4))) & 3)
+    f = (0x000003A4 >> (2 * ((opcode) >> 4))) & 3
     if f == MP_BC_FORMAT_QSTR:
         if config.MICROPY_OPT_CACHE_MAP_LOOKUP_IN_BYTECODE:
-            if (opcode == MP_BC_LOAD_NAME
+            if (
+                opcode == MP_BC_LOAD_NAME
                 or opcode == MP_BC_LOAD_GLOBAL
                 or opcode == MP_BC_LOAD_ATTR
-                or opcode == MP_BC_STORE_ATTR):
+                or opcode == MP_BC_STORE_ATTR
+            ):
                 ip += 1
         ip += 3
     else:
@@ -143,10 +154,11 @@ def mp_opcode_format(bytecode, ip, count_var_uint):
         ip += extra_byte
     return f, ip - ip_start
 
+
 def read_prelude_sig(read_byte):
     z = read_byte()
     # xSSSSEAA
-    S = (z >> 3) & 0xf
+    S = (z >> 3) & 0xF
     E = (z >> 2) & 0x1
     F = 0
     A = z & 0x3
@@ -166,6 +178,7 @@ def read_prelude_sig(read_byte):
     S += 1
     return S, E, F, A, K, D
 
+
 def read_prelude_size(read_byte):
     I = 0
     C = 0
@@ -173,20 +186,29 @@ def read_prelude_size(read_byte):
     while True:
         z = read_byte()
         # xIIIIIIC
-        I |= ((z & 0x7e) >> 1) << (6 * n)
+        I |= ((z & 0x7E) >> 1) << (6 * n)
         C |= (z & 1) << n
         if not (z & 0x80):
             break
         n += 1
     return I, C
 
+
 def extract_prelude(bytecode, ip):
     def local_read_byte():
         b = bytecode[ip_ref[0]]
         ip_ref[0] += 1
         return b
-    ip_ref = [ip] # to close over ip in Python 2 and 3
-    n_state, n_exc_stack, scope_flags, n_pos_args, n_kwonly_args, n_def_pos_args = read_prelude_sig(local_read_byte)
+
+    ip_ref = [ip]  # to close over ip in Python 2 and 3
+    (
+        n_state,
+        n_exc_stack,
+        scope_flags,
+        n_pos_args,
+        n_kwonly_args,
+        n_def_pos_args,
+    ) = read_prelude_sig(local_read_byte)
     n_info, n_cell = read_prelude_size(local_read_byte)
     ip = ip_ref[0]
 
@@ -194,10 +216,16 @@ def extract_prelude(bytecode, ip):
     ip = ip2 + n_info + n_cell
     # ip now points to first opcode
     # ip2 points to simple_name qstr
-    return ip, ip2, (n_state, n_exc_stack, scope_flags, n_pos_args, n_kwonly_args, n_def_pos_args)
+    return (
+        ip,
+        ip2,
+        (n_state, n_exc_stack, scope_flags, n_pos_args, n_kwonly_args, n_def_pos_args),
+    )
+
 
 class MPFunTable:
     pass
+
 
 class RawCode(object):
     # a set of all escaped names, to make sure they are unique
@@ -205,10 +233,10 @@ class RawCode(object):
 
     # convert code kind number to string
     code_kind_str = {
-       MP_CODE_BYTECODE: 'MP_CODE_BYTECODE',
-       MP_CODE_NATIVE_PY: 'MP_CODE_NATIVE_PY',
-       MP_CODE_NATIVE_VIPER: 'MP_CODE_NATIVE_VIPER',
-       MP_CODE_NATIVE_ASM: 'MP_CODE_NATIVE_ASM',
+        MP_CODE_BYTECODE: 'MP_CODE_BYTECODE',
+        MP_CODE_NATIVE_PY: 'MP_CODE_NATIVE_PY',
+        MP_CODE_NATIVE_VIPER: 'MP_CODE_NATIVE_VIPER',
+        MP_CODE_NATIVE_ASM: 'MP_CODE_NATIVE_ASM',
     }
 
     def __init__(self, code_kind, bytecode, prelude_offset, qstrs, objs, raw_codes):
@@ -226,7 +254,9 @@ class RawCode(object):
             self.simple_name = global_qstrs[1]
         else:
             # extract prelude
-            self.ip, self.ip2, self.prelude = extract_prelude(self.bytecode, self.prelude_offset)
+            self.ip, self.ip2, self.prelude = extract_prelude(
+                self.bytecode, self.prelude_offset
+            )
             self.simple_name = self._unpack_qstr(self.ip2)
             self.source_file = self._unpack_qstr(self.ip2 + 2)
 
@@ -268,16 +298,27 @@ class RawCode(object):
                     obj_type = 'mp_type_str'
                 else:
                     obj_type = 'mp_type_bytes'
-                print('STATIC const mp_obj_str_t %s = {{&%s}, %u, %u, (const byte*)"%s"};'
-                    % (obj_name, obj_type, qstrutil.compute_hash(obj, config.MICROPY_QSTR_BYTES_IN_HASH),
-                        len(obj), ''.join(('\\x%02x' % b) for b in obj)))
+                print(
+                    'STATIC const mp_obj_str_t %s = {{&%s}, %u, %u, (const byte*)"%s"};'
+                    % (
+                        obj_name,
+                        obj_type,
+                        qstrutil.compute_hash(obj, config.MICROPY_QSTR_BYTES_IN_HASH),
+                        len(obj),
+                        ''.join(('\\x%02x' % b) for b in obj),
+                    )
+                )
             elif is_int_type(obj):
                 if config.MICROPY_LONGINT_IMPL == config.MICROPY_LONGINT_IMPL_NONE:
                     # TODO check if we can actually fit this long-int into a small-int
                     raise FreezeError(self, 'target does not support long int')
-                elif config.MICROPY_LONGINT_IMPL == config.MICROPY_LONGINT_IMPL_LONGLONG:
+                elif (
+                    config.MICROPY_LONGINT_IMPL == config.MICROPY_LONGINT_IMPL_LONGLONG
+                ):
                     # TODO
-                    raise FreezeError(self, 'freezing int to long-long is not implemented')
+                    raise FreezeError(
+                        self, 'freezing int to long-long is not implemented'
+                    )
                 elif config.MICROPY_LONGINT_IMPL == config.MICROPY_LONGINT_IMPL_MPZ:
                     neg = 0
                     if obj < 0:
@@ -291,32 +332,54 @@ class RawCode(object):
                         z >>= bits_per_dig
                     ndigs = len(digs)
                     digs = ','.join(('%#x' % d) for d in digs)
-                    print('STATIC const mp_obj_int_t %s = {{&mp_type_int}, '
+                    print(
+                        'STATIC const mp_obj_int_t %s = {{&mp_type_int}, '
                         '{.neg=%u, .fixed_dig=1, .alloc=%u, .len=%u, .dig=(uint%u_t*)(const uint%u_t[]){%s}}};'
-                        % (obj_name, neg, ndigs, ndigs, bits_per_dig, bits_per_dig, digs))
+                        % (
+                            obj_name,
+                            neg,
+                            ndigs,
+                            ndigs,
+                            bits_per_dig,
+                            bits_per_dig,
+                            digs,
+                        )
+                    )
             elif type(obj) is float:
-                print('#if MICROPY_OBJ_REPR == MICROPY_OBJ_REPR_A || MICROPY_OBJ_REPR == MICROPY_OBJ_REPR_B')
-                print('STATIC const mp_obj_float_t %s = {{&mp_type_float}, %.16g};'
-                    % (obj_name, obj))
+                print(
+                    '#if MICROPY_OBJ_REPR == MICROPY_OBJ_REPR_A || MICROPY_OBJ_REPR == MICROPY_OBJ_REPR_B'
+                )
+                print(
+                    'STATIC const mp_obj_float_t %s = {{&mp_type_float}, %.16g};'
+                    % (obj_name, obj)
+                )
                 print('#endif')
             elif type(obj) is complex:
-                print('STATIC const mp_obj_complex_t %s = {{&mp_type_complex}, %.16g, %.16g};'
-                    % (obj_name, obj.real, obj.imag))
+                print(
+                    'STATIC const mp_obj_complex_t %s = {{&mp_type_complex}, %.16g, %.16g};'
+                    % (obj_name, obj.real, obj.imag)
+                )
             else:
-                raise FreezeError(self, 'freezing of object %r is not implemented' % (obj,))
+                raise FreezeError(
+                    self, 'freezing of object %r is not implemented' % (obj,)
+                )
 
         # generate constant table, if it has any entries
         const_table_len = len(self.qstrs) + len(self.objs) + len(self.raw_codes)
         if const_table_len:
-            print('STATIC const mp_rom_obj_t const_table_data_%s[%u] = {'
-                % (self.escaped_name, const_table_len))
+            print(
+                'STATIC const mp_rom_obj_t const_table_data_%s[%u] = {'
+                % (self.escaped_name, const_table_len)
+            )
             for qst in self.qstrs:
                 print('    MP_ROM_QSTR(%s),' % global_qstrs[qst].qstr_id)
             for i in range(len(self.objs)):
                 if self.objs[i] is MPFunTable:
                     print('    &mp_fun_table,')
                 elif type(self.objs[i]) is float:
-                    print('#if MICROPY_OBJ_REPR == MICROPY_OBJ_REPR_A || MICROPY_OBJ_REPR == MICROPY_OBJ_REPR_B')
+                    print(
+                        '#if MICROPY_OBJ_REPR == MICROPY_OBJ_REPR_A || MICROPY_OBJ_REPR == MICROPY_OBJ_REPR_B'
+                    )
                     print('    MP_ROM_PTR(&const_obj_%s_%u),' % (self.escaped_name, i))
                     print('#elif MICROPY_OBJ_REPR == MICROPY_OBJ_REPR_C')
                     n = struct.unpack('<I', struct.pack('<f', self.objs[i]))[0]
@@ -343,7 +406,10 @@ class RawCode(object):
         print('    .n_pos_args = %u,' % self.prelude[3])
         print('    .fun_data = fun_data_%s,' % self.escaped_name)
         if len(self.qstrs) + len(self.objs) + len(self.raw_codes):
-            print('    .const_table = (mp_uint_t*)const_table_data_%s,' % self.escaped_name)
+            print(
+                '    .const_table = (mp_uint_t*)const_table_data_%s,'
+                % self.escaped_name
+            )
         else:
             print('    .const_table = NULL,')
         print('    #if MICROPY_PERSISTENT_CODE_SAVE')
@@ -361,15 +427,17 @@ class RawCode(object):
             print('        .n_def_pos_args = %u,' % self.prelude[5])
             print('        .qstr_block_name = %s,' % self.simple_name.qstr_id)
             print('        .qstr_source_file = %s,' % self.source_file.qstr_id)
-            print('        .line_info = fun_data_%s + %u,' % (self.escaped_name, 0)) # TODO
+            print(
+                '        .line_info = fun_data_%s + %u,' % (self.escaped_name, 0)
+            )  # TODO
             print('        .opcodes = fun_data_%s + %u,' % (self.escaped_name, self.ip))
             print('    },')
-            print('    .line_of_definition = %u,' % 0) # TODO
+            print('    .line_of_definition = %u,' % 0)  # TODO
             print('    #endif')
         print('    #if MICROPY_EMIT_MACHINE_CODE')
         print('    .prelude_offset = %u,' % self.prelude_offset)
         print('    .n_qstr = %u,' % len(qstr_links))
-        print('    .qstr_link = NULL,') # TODO
+        print('    .qstr_link = NULL,')  # TODO
         print('    #endif')
         print('    #endif')
         print('    #if MICROPY_EMIT_MACHINE_CODE')
@@ -377,16 +445,22 @@ class RawCode(object):
         print('    #endif')
         print('};')
 
+
 class RawCodeBytecode(RawCode):
     def __init__(self, bytecode, qstrs, objs, raw_codes):
-        super(RawCodeBytecode, self).__init__(MP_CODE_BYTECODE, bytecode, 0, qstrs, objs, raw_codes)
+        super(RawCodeBytecode, self).__init__(
+            MP_CODE_BYTECODE, bytecode, 0, qstrs, objs, raw_codes
+        )
 
     def freeze(self, parent_name):
         self.freeze_children(parent_name)
 
         # generate bytecode data
         print()
-        print('// frozen bytecode for file %s, scope %s%s' % (self.source_file.str, parent_name, self.simple_name.str))
+        print(
+            '// frozen bytecode for file %s, scope %s%s'
+            % (self.source_file.str, parent_name, self.simple_name.str)
+        )
         print('STATIC ', end='')
         if not config.MICROPY_OPT_CACHE_MAP_LOOKUP_IN_BYTECODE:
             print('const ', end='')
@@ -395,8 +469,20 @@ class RawCodeBytecode(RawCode):
         for i in range(self.ip2):
             print(' 0x%02x,' % self.bytecode[i], end='')
         print()
-        print('   ', self.simple_name.qstr_id, '& 0xff,', self.simple_name.qstr_id, '>> 8,')
-        print('   ', self.source_file.qstr_id, '& 0xff,', self.source_file.qstr_id, '>> 8,')
+        print(
+            '   ',
+            self.simple_name.qstr_id,
+            '& 0xff,',
+            self.simple_name.qstr_id,
+            '>> 8,',
+        )
+        print(
+            '   ',
+            self.source_file.qstr_id,
+            '& 0xff,',
+            self.source_file.qstr_id,
+            '>> 8,',
+        )
         print('   ', end='')
         for i in range(self.ip2 + 4, self.ip):
             print(' 0x%02x,' % self.bytecode[i], end='')
@@ -407,31 +493,68 @@ class RawCodeBytecode(RawCode):
             if f == 1:
                 qst = self._unpack_qstr(ip + 1).qstr_id
                 extra = '' if sz == 3 else ' 0x%02x,' % self.bytecode[ip + 3]
-                print('   ', '0x%02x,' % self.bytecode[ip], qst, '& 0xff,', qst, '>> 8,', extra)
+                print(
+                    '   ',
+                    '0x%02x,' % self.bytecode[ip],
+                    qst,
+                    '& 0xff,',
+                    qst,
+                    '>> 8,',
+                    extra,
+                )
             else:
-                print('   ', ''.join('0x%02x, ' % self.bytecode[ip + i] for i in range(sz)))
+                print(
+                    '   ',
+                    ''.join('0x%02x, ' % self.bytecode[ip + i] for i in range(sz)),
+                )
             ip += sz
         print('};')
 
         self.freeze_constants()
         self.freeze_module()
 
+
 class RawCodeNative(RawCode):
-    def __init__(self, code_kind, fun_data, prelude_offset, prelude, qstr_links, qstrs, objs, raw_codes, type_sig):
-        super(RawCodeNative, self).__init__(code_kind, fun_data, prelude_offset, qstrs, objs, raw_codes)
+    def __init__(
+        self,
+        code_kind,
+        fun_data,
+        prelude_offset,
+        prelude,
+        qstr_links,
+        qstrs,
+        objs,
+        raw_codes,
+        type_sig,
+    ):
+        super(RawCodeNative, self).__init__(
+            code_kind, fun_data, prelude_offset, qstrs, objs, raw_codes
+        )
         self.prelude = prelude
         self.qstr_links = qstr_links
         self.type_sig = type_sig
-        if config.native_arch in (MP_NATIVE_ARCH_X86, MP_NATIVE_ARCH_X64,
-            MP_NATIVE_ARCH_XTENSA, MP_NATIVE_ARCH_XTENSAWIN):
-            self.fun_data_attributes = '__attribute__((section(".text,\\"ax\\",@progbits # ")))'
+        if config.native_arch in (
+            MP_NATIVE_ARCH_X86,
+            MP_NATIVE_ARCH_X64,
+            MP_NATIVE_ARCH_XTENSA,
+            MP_NATIVE_ARCH_XTENSAWIN,
+        ):
+            self.fun_data_attributes = (
+                '__attribute__((section(".text,\\"ax\\",@progbits # ")))'
+            )
         else:
-            self.fun_data_attributes = '__attribute__((section(".text,\\"ax\\",%progbits @ ")))'
+            self.fun_data_attributes = (
+                '__attribute__((section(".text,\\"ax\\",%progbits @ ")))'
+            )
 
         # Allow single-byte alignment by default for x86/x64.
         # ARM needs word alignment, ARM Thumb needs halfword, due to instruction size.
         # Xtensa needs word alignment due to the 32-bit constant table embedded in the code.
-        if config.native_arch in (MP_NATIVE_ARCH_ARMV6, MP_NATIVE_ARCH_XTENSA, MP_NATIVE_ARCH_XTENSAWIN):
+        if config.native_arch in (
+            MP_NATIVE_ARCH_ARMV6,
+            MP_NATIVE_ARCH_XTENSA,
+            MP_NATIVE_ARCH_XTENSAWIN,
+        ):
             # ARMV6 or Xtensa -- four byte align.
             self.fun_data_attributes += ' __attribute__ ((aligned (4)))'
         elif MP_NATIVE_ARCH_ARMV6M <= config.native_arch <= MP_NATIVE_ARCH_ARMV7EMDP:
@@ -455,12 +578,19 @@ class RawCodeNative(RawCode):
             if is_obj:
                 qst = '((uintptr_t)MP_OBJ_NEW_QSTR(%s))' % qst
             if config.native_arch in (
-                MP_NATIVE_ARCH_X86, MP_NATIVE_ARCH_X64,
-                MP_NATIVE_ARCH_XTENSA, MP_NATIVE_ARCH_XTENSAWIN
-                ):
-                print('    %s & 0xff, (%s >> 8) & 0xff, (%s >> 16) & 0xff, %s >> 24,' % (qst, qst, qst, qst))
+                MP_NATIVE_ARCH_X86,
+                MP_NATIVE_ARCH_X64,
+                MP_NATIVE_ARCH_XTENSA,
+                MP_NATIVE_ARCH_XTENSAWIN,
+            ):
+                print(
+                    '    %s & 0xff, (%s >> 8) & 0xff, (%s >> 16) & 0xff, %s >> 24,'
+                    % (qst, qst, qst, qst)
+                )
                 return 4
-            elif MP_NATIVE_ARCH_ARMV6M <= config.native_arch <= MP_NATIVE_ARCH_ARMV7EMDP:
+            elif (
+                MP_NATIVE_ARCH_ARMV6M <= config.native_arch <= MP_NATIVE_ARCH_ARMV7EMDP
+            ):
                 if is_obj:
                     # qstr object, movw and movt
                     self._asm_thumb_rewrite_mov(pc, qst)
@@ -474,7 +604,7 @@ class RawCodeNative(RawCode):
                 assert 0
 
     def freeze(self, parent_name):
-        if self.prelude[2] & ~0x0f:
+        if self.prelude[2] & ~0x0F:
             raise FreezeError('unable to freeze code with relocations')
 
         self.freeze_children(parent_name)
@@ -482,12 +612,18 @@ class RawCodeNative(RawCode):
         # generate native code data
         print()
         if self.code_kind == MP_CODE_NATIVE_PY:
-            print('// frozen native code for file %s, scope %s%s' % (self.source_file.str, parent_name, self.simple_name.str))
+            print(
+                '// frozen native code for file %s, scope %s%s'
+                % (self.source_file.str, parent_name, self.simple_name.str)
+            )
         elif self.code_kind == MP_CODE_NATIVE_VIPER:
             print('// frozen viper code for scope %s' % (parent_name,))
         else:
             print('// frozen assembler code for scope %s' % (parent_name,))
-        print('STATIC const byte fun_data_%s[%u] %s = {' % (self.escaped_name, len(self.bytecode), self.fun_data_attributes))
+        print(
+            'STATIC const byte fun_data_%s[%u] %s = {'
+            % (self.escaped_name, len(self.bytecode), self.fun_data_attributes)
+        )
 
         if self.code_kind == MP_CODE_NATIVE_PY:
             i_top = self.prelude_offset
@@ -519,8 +655,20 @@ class RawCodeNative(RawCode):
                 print(' 0x%02x,' % self.bytecode[i], end='')
             print()
 
-            print('   ', self.simple_name.qstr_id, '& 0xff,', self.simple_name.qstr_id, '>> 8,')
-            print('   ', self.source_file.qstr_id, '& 0xff,', self.source_file.qstr_id, '>> 8,')
+            print(
+                '   ',
+                self.simple_name.qstr_id,
+                '& 0xff,',
+                self.simple_name.qstr_id,
+                '>> 8,',
+            )
+            print(
+                '   ',
+                self.source_file.qstr_id,
+                '& 0xff,',
+                self.source_file.qstr_id,
+                '>> 8,',
+            )
 
             print('   ', end='')
             for i in range(self.ip2 + 4, self.ip):
@@ -531,6 +679,7 @@ class RawCodeNative(RawCode):
 
         self.freeze_constants()
         self.freeze_module(self.qstr_links, self.type_sig)
+
 
 class BytecodeBuffer:
     def __init__(self, size):
@@ -544,20 +693,23 @@ class BytecodeBuffer:
         self.buf[self.idx] = b
         self.idx += 1
 
+
 def read_byte(f, out=None):
     b = bytes_cons(f.read(1))[0]
     if out is not None:
         out.append(b)
     return b
 
+
 def read_uint(f, out=None):
     i = 0
     while True:
         b = read_byte(f, out)
-        i = (i << 7) | (b & 0x7f)
+        i = (i << 7) | (b & 0x7F)
         if b & 0x80 == 0:
             break
     return i
+
 
 def read_qstr(f, qstr_win):
     ln = read_uint(f)
@@ -572,6 +724,7 @@ def read_qstr(f, qstr_win):
     global_qstrs.append(QStrType(data))
     qstr_win.push(len(global_qstrs) - 1)
     return len(global_qstrs) - 1
+
 
 def read_obj(f):
     obj_type = f.read(1)
@@ -592,19 +745,29 @@ def read_obj(f):
         else:
             assert 0
 
+
 def read_prelude(f, bytecode, qstr_win):
-    n_state, n_exc_stack, scope_flags, n_pos_args, n_kwonly_args, n_def_pos_args = read_prelude_sig(lambda: read_byte(f, bytecode))
+    (
+        n_state,
+        n_exc_stack,
+        scope_flags,
+        n_pos_args,
+        n_kwonly_args,
+        n_def_pos_args,
+    ) = read_prelude_sig(lambda: read_byte(f, bytecode))
     n_info, n_cell = read_prelude_size(lambda: read_byte(f, bytecode))
-    read_qstr_and_pack(f, bytecode, qstr_win) # simple_name
-    read_qstr_and_pack(f, bytecode, qstr_win) # source_file
+    read_qstr_and_pack(f, bytecode, qstr_win)  # simple_name
+    read_qstr_and_pack(f, bytecode, qstr_win)  # source_file
     for _ in range(n_info - 4 + n_cell):
         read_byte(f, bytecode)
     return n_state, n_exc_stack, scope_flags, n_pos_args, n_kwonly_args, n_def_pos_args
 
+
 def read_qstr_and_pack(f, bytecode, qstr_win):
     qst = read_qstr(f, qstr_win)
-    bytecode.append(qst & 0xff)
+    bytecode.append(qst & 0xFF)
     bytecode.append(qst >> 8)
+
 
 def read_bytecode(file, bytecode, qstr_win):
     while not bytecode.is_full():
@@ -619,6 +782,7 @@ def read_bytecode(file, bytecode, qstr_win):
                 pass
         for _ in range(sz):
             read_byte(file, bytecode)
+
 
 def read_raw_code(f, qstr_win):
     kind_len = read_uint(f)
@@ -645,9 +809,9 @@ def read_raw_code(f, qstr_win):
         if kind == MP_CODE_NATIVE_PY:
             prelude_offset = read_uint(f)
             _, name_idx, prelude = extract_prelude(fun_data.buf, prelude_offset)
-            fun_data.idx = name_idx # rewind to where qstrs are in prelude
-            read_qstr_and_pack(f, fun_data, qstr_win) # simple_name
-            read_qstr_and_pack(f, fun_data, qstr_win) # source_file
+            fun_data.idx = name_idx  # rewind to where qstrs are in prelude
+            read_qstr_and_pack(f, fun_data, qstr_win)  # simple_name
+            read_qstr_and_pack(f, fun_data, qstr_win)  # source_file
         else:
             prelude_offset = None
             scope_flags = read_uint(f)
@@ -673,7 +837,18 @@ def read_raw_code(f, qstr_win):
     if kind == MP_CODE_BYTECODE:
         return RawCodeBytecode(fun_data.buf, qstrs, objs, raw_codes)
     else:
-        return RawCodeNative(kind, fun_data.buf, prelude_offset, prelude, qstr_links, qstrs, objs, raw_codes, type_sig)
+        return RawCodeNative(
+            kind,
+            fun_data.buf,
+            prelude_offset,
+            prelude,
+            qstr_links,
+            qstrs,
+            objs,
+            raw_codes,
+            type_sig,
+        )
+
 
 def read_mpy(filename):
     with open(filename, 'rb') as f:
@@ -699,9 +874,11 @@ def read_mpy(filename):
         rc.qstr_win_size = qw_size
         return rc
 
+
 def dump_mpy(raw_codes):
     for rc in raw_codes:
         rc.dump()
+
 
 def freeze_mpy(base_qstrs, raw_codes):
     # add to qstrs
@@ -720,7 +897,10 @@ def freeze_mpy(base_qstrs, raw_codes):
     print('#include "py/nativeglue.h"')
     print()
 
-    print('#if MICROPY_OPT_CACHE_MAP_LOOKUP_IN_BYTECODE != %u' % config.MICROPY_OPT_CACHE_MAP_LOOKUP_IN_BYTECODE)
+    print(
+        '#if MICROPY_OPT_CACHE_MAP_LOOKUP_IN_BYTECODE != %u'
+        % config.MICROPY_OPT_CACHE_MAP_LOOKUP_IN_BYTECODE
+    )
     print('#error "incompatible MICROPY_OPT_CACHE_MAP_LOOKUP_IN_BYTECODE"')
     print('#endif')
     print()
@@ -735,7 +915,6 @@ def freeze_mpy(base_qstrs, raw_codes):
         print('#error "incompatible MPZ_DIG_SIZE"')
         print('#endif')
         print()
-
 
     print('#if MICROPY_PY_BUILTINS_FLOAT')
     print('typedef struct _mp_obj_float_t {')
@@ -767,7 +946,7 @@ def freeze_mpy(base_qstrs, raw_codes):
     qstr_pool_alloc = min(len(new), 10)
 
     print()
-    print('extern const qstr_pool_t mp_qstr_const_pool;');
+    print('extern const qstr_pool_t mp_qstr_const_pool;')
     print('const qstr_pool_t mp_qstr_frozen_const_pool = {')
     print('    (qstr_pool_t*)&mp_qstr_const_pool, // previous pool')
     print('    MP_QSTRnumber_of, // previous pool size')
@@ -775,8 +954,14 @@ def freeze_mpy(base_qstrs, raw_codes):
     print('    %u, // used entries' % len(new))
     print('    {')
     for _, _, qstr in new:
-        print('        %s,'
-            % qstrutil.make_bytes(config.MICROPY_QSTR_BYTES_IN_LEN, config.MICROPY_QSTR_BYTES_IN_HASH, qstr))
+        print(
+            '        %s,'
+            % qstrutil.make_bytes(
+                config.MICROPY_QSTR_BYTES_IN_LEN,
+                config.MICROPY_QSTR_BYTES_IN_HASH,
+                qstr,
+            )
+        )
     print('    },')
     print('};')
 
@@ -795,8 +980,9 @@ def freeze_mpy(base_qstrs, raw_codes):
         print('    &raw_code_%s,' % rc.escaped_name)
     print('};')
 
+
 def merge_mpy(raw_codes, output_file):
-    assert len(raw_codes) <= 31 # so var-uints all fit in 1 byte
+    assert len(raw_codes) <= 31  # so var-uints all fit in 1 byte
     merged_mpy = bytearray()
 
     if len(raw_codes) == 1:
@@ -806,36 +992,38 @@ def merge_mpy(raw_codes, output_file):
         header = bytearray(5)
         header[0] = ord('M')
         header[1] = config.MPY_VERSION
-        header[2] = (config.native_arch << 2
+        header[2] = (
+            config.native_arch << 2
             | config.MICROPY_PY_BUILTINS_STR_UNICODE << 1
-            | config.MICROPY_OPT_CACHE_MAP_LOOKUP_IN_BYTECODE)
+            | config.MICROPY_OPT_CACHE_MAP_LOOKUP_IN_BYTECODE
+        )
         header[3] = config.mp_small_int_bits
-        header[4] = 32 # qstr_win_size
+        header[4] = 32  # qstr_win_size
         merged_mpy.extend(header)
 
         bytecode = bytearray()
         bytecode_len = 6 + len(raw_codes) * 4 + 2
-        bytecode.append(bytecode_len << 2) # kind and length
-        bytecode.append(0b00000000) # signature prelude
-        bytecode.append(0b00001000) # size prelude
-        bytecode.extend(b'\x00\x01') # MP_QSTR_
-        bytecode.extend(b'\x00\x01') # MP_QSTR_
+        bytecode.append(bytecode_len << 2)  # kind and length
+        bytecode.append(0b00000000)  # signature prelude
+        bytecode.append(0b00001000)  # size prelude
+        bytecode.extend(b'\x00\x01')  # MP_QSTR_
+        bytecode.extend(b'\x00\x01')  # MP_QSTR_
         for idx in range(len(raw_codes)):
-            bytecode.append(0x32) # MP_BC_MAKE_FUNCTION
-            bytecode.append(idx) # index raw code
-            bytecode.extend(b'\x34\x00') # MP_BC_CALL_FUNCTION, 0 args
-        bytecode.extend(b'\x51\x63') # MP_BC_LOAD_NONE, MP_BC_RETURN_VALUE
+            bytecode.append(0x32)  # MP_BC_MAKE_FUNCTION
+            bytecode.append(idx)  # index raw code
+            bytecode.extend(b'\x34\x00')  # MP_BC_CALL_FUNCTION, 0 args
+        bytecode.extend(b'\x51\x63')  # MP_BC_LOAD_NONE, MP_BC_RETURN_VALUE
 
-        bytecode.append(0) # n_obj
-        bytecode.append(len(raw_codes)) # n_raw_code
+        bytecode.append(0)  # n_obj
+        bytecode.append(len(raw_codes))  # n_raw_code
 
         merged_mpy.extend(bytecode)
 
         for rc in raw_codes:
             with open(rc.mpy_source_file, 'rb') as f:
-                f.read(4) # skip header
-                read_uint(f) # skip qstr_win_size
-                data = f.read() # read rest of mpy file
+                f.read(4)  # skip header
+                read_uint(f)  # skip qstr_win_size
+                data = f.read()  # read rest of mpy file
                 merged_mpy.extend(data)
 
     if output_file is None:
@@ -844,32 +1032,45 @@ def merge_mpy(raw_codes, output_file):
         with open(output_file, 'wb') as f:
             f.write(merged_mpy)
 
+
 def main():
     import argparse
-    cmd_parser = argparse.ArgumentParser(description='A tool to work with MicroPython .mpy files.')
-    cmd_parser.add_argument('-d', '--dump', action='store_true',
-        help='dump contents of files')
-    cmd_parser.add_argument('-f', '--freeze', action='store_true',
-        help='freeze files')
-    cmd_parser.add_argument('--merge', action='store_true',
-        help='merge multiple .mpy files into one')
-    cmd_parser.add_argument('-q', '--qstr-header',
-        help='qstr header file to freeze against')
-    cmd_parser.add_argument('-mlongint-impl', choices=['none', 'longlong', 'mpz'], default='mpz',
-        help='long-int implementation used by target (default mpz)')
-    cmd_parser.add_argument('-mmpz-dig-size', metavar='N', type=int, default=16,
-        help='mpz digit size used by target (default 16)')
-    cmd_parser.add_argument('-o', '--output', default=None,
-        help='output file')
-    cmd_parser.add_argument('files', nargs='+',
-        help='input .mpy files')
+
+    cmd_parser = argparse.ArgumentParser(
+        description='A tool to work with MicroPython .mpy files.'
+    )
+    cmd_parser.add_argument(
+        '-d', '--dump', action='store_true', help='dump contents of files'
+    )
+    cmd_parser.add_argument('-f', '--freeze', action='store_true', help='freeze files')
+    cmd_parser.add_argument(
+        '--merge', action='store_true', help='merge multiple .mpy files into one'
+    )
+    cmd_parser.add_argument(
+        '-q', '--qstr-header', help='qstr header file to freeze against'
+    )
+    cmd_parser.add_argument(
+        '-mlongint-impl',
+        choices=['none', 'longlong', 'mpz'],
+        default='mpz',
+        help='long-int implementation used by target (default mpz)',
+    )
+    cmd_parser.add_argument(
+        '-mmpz-dig-size',
+        metavar='N',
+        type=int,
+        default=16,
+        help='mpz digit size used by target (default 16)',
+    )
+    cmd_parser.add_argument('-o', '--output', default=None, help='output file')
+    cmd_parser.add_argument('files', nargs='+', help='input .mpy files')
     args = cmd_parser.parse_args()
 
     # set config values relevant to target machine
     config.MICROPY_LONGINT_IMPL = {
-        'none':config.MICROPY_LONGINT_IMPL_NONE,
-        'longlong':config.MICROPY_LONGINT_IMPL_LONGLONG,
-        'mpz':config.MICROPY_LONGINT_IMPL_MPZ,
+        'none': config.MICROPY_LONGINT_IMPL_NONE,
+        'longlong': config.MICROPY_LONGINT_IMPL_LONGLONG,
+        'mpz': config.MICROPY_LONGINT_IMPL_MPZ,
     }[args.mlongint_impl]
     config.MPZ_DIG_SIZE = args.mmpz_dig_size
     config.native_arch = MP_NATIVE_ARCH_NONE
@@ -896,6 +1097,7 @@ def main():
             sys.exit(1)
     elif args.merge:
         merged_mpy = merge_mpy(raw_codes, args.output)
+
 
 if __name__ == '__main__':
     main()

--- a/tools/mpy_cross_all.py
+++ b/tools/mpy_cross_all.py
@@ -3,10 +3,14 @@ import argparse
 import os
 import os.path
 
-argparser = argparse.ArgumentParser(description="Compile all .py files to .mpy recursively")
+argparser = argparse.ArgumentParser(
+    description="Compile all .py files to .mpy recursively"
+)
 argparser.add_argument("-o", "--out", help="output directory (default: input dir)")
 argparser.add_argument("--target", help="select MicroPython target config")
-argparser.add_argument("-mcache-lookup-bc", action="store_true", help="cache map lookups in the bytecode")
+argparser.add_argument(
+    "-mcache-lookup-bc", action="store_true", help="cache map lookups in the bytecode"
+)
 argparser.add_argument("dir", help="input directory")
 args = argparser.parse_args()
 
@@ -26,13 +30,17 @@ for path, subdirs, files in os.walk(args.dir):
     for f in files:
         if f.endswith(".py"):
             fpath = path + "/" + f
-            #print(fpath)
+            # print(fpath)
             out_fpath = args.out + "/" + fpath[path_prefix_len:-3] + ".mpy"
             out_dir = os.path.dirname(out_fpath)
             if not os.path.isdir(out_dir):
                 os.makedirs(out_dir)
-            cmd = "mpy-cross -v -v %s -s %s %s -o %s" % (TARGET_OPTS.get(args.target, ""),
-                fpath[path_prefix_len:], fpath, out_fpath)
-            #print(cmd)
+            cmd = "mpy-cross -v -v %s -s %s %s -o %s" % (
+                TARGET_OPTS.get(args.target, ""),
+                fpath[path_prefix_len:],
+                fpath,
+                out_fpath,
+            )
+            # print(cmd)
             res = os.system(cmd)
             assert res == 0

--- a/tools/mpy_ld.py
+++ b/tools/mpy_ld.py
@@ -70,8 +70,8 @@ R_386_GOTPC = 10
 R_ARM_THM_CALL = 10
 R_XTENSA_DIFF32 = 19
 R_XTENSA_SLOT0_OP = 20
-R_ARM_BASE_PREL = 25 # aka R_ARM_GOTPC
-R_ARM_GOT_BREL = 26 # aka R_ARM_GOT32
+R_ARM_BASE_PREL = 25  # aka R_ARM_GOTPC
+R_ARM_GOT_BREL = 26  # aka R_ARM_GOT32
 R_ARM_THM_JUMP24 = 30
 R_X86_64_REX_GOTPCRELX = 42
 R_386_GOT32X = 43
@@ -79,28 +79,34 @@ R_386_GOT32X = 43
 ################################################################################
 # Architecture configuration
 
+
 def asm_jump_x86(entry):
-    return struct.pack('<BI', 0xe9, entry - 5)
+    return struct.pack('<BI', 0xE9, entry - 5)
+
 
 def asm_jump_arm(entry):
     b_off = entry - 4
     if b_off >> 11 == 0 or b_off >> 11 == -1:
         # Signed value fits in 12 bits
-        b0 = 0xe000 | (b_off >> 1 & 0x07ff)
+        b0 = 0xE000 | (b_off >> 1 & 0x07FF)
         b1 = 0
     else:
         # Use large jump
-        b0 = 0xf000 | (b_off >> 12 & 0x07ff)
-        b1 = 0xb800 | (b_off >> 1 & 0x7ff)
+        b0 = 0xF000 | (b_off >> 12 & 0x07FF)
+        b1 = 0xB800 | (b_off >> 1 & 0x7FF)
     return struct.pack('<HH', b0, b1)
+
 
 def asm_jump_xtensa(entry):
     jump_offset = entry - 4
     jump_op = jump_offset << 6 | 6
-    return struct.pack('<BH', jump_op & 0xff, jump_op >> 8)
+    return struct.pack('<BH', jump_op & 0xFF, jump_op >> 8)
+
 
 class ArchData:
-    def __init__(self, name, mpy_feature, qstr_entry_size, word_size, arch_got, asm_jump):
+    def __init__(
+        self, name, mpy_feature, qstr_entry_size, word_size, arch_got, asm_jump
+    ):
         self.name = name
         self.mpy_feature = mpy_feature
         self.qstr_entry_size = qstr_entry_size
@@ -109,57 +115,87 @@ class ArchData:
         self.asm_jump = asm_jump
         self.separate_rodata = name == 'EM_XTENSA' and qstr_entry_size == 4
 
+
 ARCH_DATA = {
     'x86': ArchData(
         'EM_386',
-        MP_NATIVE_ARCH_X86 << 2 | MICROPY_PY_BUILTINS_STR_UNICODE | MICROPY_OPT_CACHE_MAP_LOOKUP_IN_BYTECODE,
-        2, 4, (R_386_PC32, R_386_GOT32, R_386_GOT32X), asm_jump_x86,
+        MP_NATIVE_ARCH_X86 << 2
+        | MICROPY_PY_BUILTINS_STR_UNICODE
+        | MICROPY_OPT_CACHE_MAP_LOOKUP_IN_BYTECODE,
+        2,
+        4,
+        (R_386_PC32, R_386_GOT32, R_386_GOT32X),
+        asm_jump_x86,
     ),
     'x64': ArchData(
         'EM_X86_64',
-        MP_NATIVE_ARCH_X64 << 2 | MICROPY_PY_BUILTINS_STR_UNICODE | MICROPY_OPT_CACHE_MAP_LOOKUP_IN_BYTECODE,
-        2, 8, (R_X86_64_REX_GOTPCRELX,), asm_jump_x86,
+        MP_NATIVE_ARCH_X64 << 2
+        | MICROPY_PY_BUILTINS_STR_UNICODE
+        | MICROPY_OPT_CACHE_MAP_LOOKUP_IN_BYTECODE,
+        2,
+        8,
+        (R_X86_64_REX_GOTPCRELX,),
+        asm_jump_x86,
     ),
     'armv7m': ArchData(
         'EM_ARM',
         MP_NATIVE_ARCH_ARMV7M << 2 | MICROPY_PY_BUILTINS_STR_UNICODE,
-        2, 4, (R_ARM_GOT_BREL,), asm_jump_arm,
+        2,
+        4,
+        (R_ARM_GOT_BREL,),
+        asm_jump_arm,
     ),
     'armv7emsp': ArchData(
         'EM_ARM',
         MP_NATIVE_ARCH_ARMV7EMSP << 2 | MICROPY_PY_BUILTINS_STR_UNICODE,
-        2, 4, (R_ARM_GOT_BREL,), asm_jump_arm,
+        2,
+        4,
+        (R_ARM_GOT_BREL,),
+        asm_jump_arm,
     ),
     'armv7emdp': ArchData(
         'EM_ARM',
         MP_NATIVE_ARCH_ARMV7EMDP << 2 | MICROPY_PY_BUILTINS_STR_UNICODE,
-        2, 4, (R_ARM_GOT_BREL,), asm_jump_arm,
+        2,
+        4,
+        (R_ARM_GOT_BREL,),
+        asm_jump_arm,
     ),
     'xtensa': ArchData(
         'EM_XTENSA',
         MP_NATIVE_ARCH_XTENSA << 2 | MICROPY_PY_BUILTINS_STR_UNICODE,
-        2, 4, (R_XTENSA_32, R_XTENSA_PLT), asm_jump_xtensa,
+        2,
+        4,
+        (R_XTENSA_32, R_XTENSA_PLT),
+        asm_jump_xtensa,
     ),
     'xtensawin': ArchData(
         'EM_XTENSA',
         MP_NATIVE_ARCH_XTENSAWIN << 2 | MICROPY_PY_BUILTINS_STR_UNICODE,
-        4, 4, (R_XTENSA_32, R_XTENSA_PLT), asm_jump_xtensa,
+        4,
+        4,
+        (R_XTENSA_32, R_XTENSA_PLT),
+        asm_jump_xtensa,
     ),
 }
 
 ################################################################################
 # Helper functions
 
+
 def align_to(value, align):
     return (value + align - 1) & ~(align - 1)
+
 
 def unpack_u24le(data, offset):
     return data[offset] | data[offset + 1] << 8 | data[offset + 2] << 16
 
+
 def pack_u24le(data, offset, value):
-    data[offset] = value & 0xff
-    data[offset + 1] = value >> 8 & 0xff
-    data[offset + 2] = value >> 16 & 0xff
+    data[offset] = value & 0xFF
+    data[offset + 1] = value >> 8 & 0xFF
+    data[offset + 2] = value >> 16 & 0xFF
+
 
 def xxd(text):
     for i in range(0, len(text), 16):
@@ -167,9 +203,10 @@ def xxd(text):
         for j in range(4):
             off = i + j * 4
             if off < len(text):
-                d = int.from_bytes(text[off:off + 4], 'little')
+                d = int.from_bytes(text[off : off + 4], 'little')
                 print(' {:08x}'.format(d), end='')
         print()
+
 
 # Smaller numbers are enabled first
 LOG_LEVEL_1 = 1
@@ -177,12 +214,15 @@ LOG_LEVEL_2 = 2
 LOG_LEVEL_3 = 3
 log_level = LOG_LEVEL_1
 
+
 def log(level, msg):
     if level <= log_level:
         print(msg)
 
+
 ################################################################################
 # Qstr extraction
+
 
 def extract_qstrs(source_files):
     def read_qstrs(f):
@@ -200,12 +240,14 @@ def extract_qstrs(source_files):
                             vals.add(m.group())
                     if m:
                         s = m.span()
-                        line = line[:s[0]] + line[s[1]:]
+                        line = line[: s[0]] + line[s[1] :]
                     else:
                         line = ''
             return vals, objs
 
-    static_qstrs = ['MP_QSTR_' + qstrutil.qstr_escape(q) for q in qstrutil.static_qstr_list]
+    static_qstrs = [
+        'MP_QSTR_' + qstrutil.qstr_escape(q) for q in qstrutil.static_qstr_list
+    ]
 
     qstr_vals = set()
     qstr_objs = set()
@@ -217,11 +259,14 @@ def extract_qstrs(source_files):
 
     return static_qstrs, qstr_vals, qstr_objs
 
+
 ################################################################################
 # Linker
 
+
 class LinkError(Exception):
     pass
+
 
 class Section:
     def __init__(self, name, data, alignment, filename=None):
@@ -236,6 +281,7 @@ class Section:
     def from_elfsec(elfsec, filename):
         assert elfsec.header.sh_addr == 0
         return Section(elfsec.name, elfsec.data(), elfsec.data_alignment, filename)
+
 
 class GOTEntry:
     def __init__(self, name, sym, link_addr=0):
@@ -256,19 +302,21 @@ class GOTEntry:
     def isbss(self):
         return self.sec_name.startswith('.bss')
 
+
 class LiteralEntry:
     def __init__(self, value, offset):
         self.value = value
         self.offset = offset
 
+
 class LinkEnv:
     def __init__(self, arch):
         self.arch = ARCH_DATA[arch]
-        self.sections = []          # list of sections in order of output
+        self.sections = []  # list of sections in order of output
         self.literal_sections = []  # list of literal sections (xtensa only)
-        self.known_syms = {}        # dict of symbols that are defined
-        self.unresolved_syms = []   # list of unresolved symbols
-        self.mpy_relocs = []        # list of relocations needed in the output .mpy file
+        self.known_syms = {}  # dict of symbols that are defined
+        self.unresolved_syms = []  # list of unresolved symbols
+        self.mpy_relocs = []  # list of relocations needed in the output .mpy file
 
     def check_arch(self, arch_name):
         if arch_name != self.arch.name:
@@ -277,7 +325,10 @@ class LinkEnv:
     def print_sections(self):
         log(LOG_LEVEL_2, 'sections:')
         for sec in self.sections:
-            log(LOG_LEVEL_2, '  {:08x} {} size={}'.format(sec.addr, sec.name, len(sec.data)))
+            log(
+                LOG_LEVEL_2,
+                '  {:08x} {} size={}'.format(sec.addr, sec.name, len(sec.data)),
+            )
 
     def find_addr(self, name):
         if name in self.known_syms:
@@ -285,12 +336,16 @@ class LinkEnv:
             return s.section.addr + s['st_value']
         raise LinkError('unknown symbol: {}'.format(name))
 
+
 def build_got_generic(env):
     env.got_entries = {}
     for sec in env.sections:
         for r in sec.reloc:
             s = r.sym
-            if not (s.entry['st_info']['bind'] == 'STB_GLOBAL' and r['r_info_type'] in env.arch.arch_got):
+            if not (
+                s.entry['st_info']['bind'] == 'STB_GLOBAL'
+                and r['r_info_type'] in env.arch.arch_got
+            ):
                 continue
             s_type = s.entry['st_info']['type']
             assert s_type in ('STT_NOTYPE', 'STT_FUNC', 'STT_OBJECT'), s_type
@@ -298,6 +353,7 @@ def build_got_generic(env):
             if s.name in env.got_entries:
                 continue
             env.got_entries[s.name] = GOTEntry(s.name, s)
+
 
 def build_got_xtensa(env):
     env.got_entries = {}
@@ -312,7 +368,12 @@ def build_got_xtensa(env):
         for r in sec.reloc:
             s = r.sym
             s_type = s.entry['st_info']['type']
-            assert s_type in ('STT_NOTYPE', 'STT_FUNC', 'STT_OBJECT', 'STT_SECTION'), s_type
+            assert s_type in (
+                'STT_NOTYPE',
+                'STT_FUNC',
+                'STT_OBJECT',
+                'STT_SECTION',
+            ), s_type
             assert r['r_info_type'] in env.arch.arch_got
             assert r['r_offset'] % env.arch.word_size == 0
             # This entry is a global pointer
@@ -342,7 +403,10 @@ def build_got_xtensa(env):
                 if value in env.lit_entries:
                     # Deduplicate literals
                     continue
-                env.lit_entries[value] = LiteralEntry(value, len(env.lit_entries) * env.arch.word_size)
+                env.lit_entries[value] = LiteralEntry(
+                    value, len(env.lit_entries) * env.arch.word_size
+                )
+
 
 def populate_got(env):
     # Compute GOT destination addresses
@@ -356,8 +420,13 @@ def populate_got(env):
         got_entry.link_addr += sec.addr + addr
 
     # Get sorted GOT, sorted by external, text, rodata, bss so relocations can be combined
-    got_list = sorted(env.got_entries.values(),
-        key=lambda g: g.isexternal() + 2 * g.istext() + 3 * g.isrodata() + 4 * g.isbss())
+    got_list = sorted(
+        env.got_entries.values(),
+        key=lambda g: g.isexternal()
+        + 2 * g.istext()
+        + 3 * g.isrodata()
+        + 4 * g.isbss(),
+    )
 
     # Layout and populate the GOT
     offset = 0
@@ -365,7 +434,9 @@ def populate_got(env):
         got_entry.offset = offset
         offset += env.arch.word_size
         o = env.got_section.addr + got_entry.offset
-        env.full_text[o:o + env.arch.word_size] = got_entry.link_addr.to_bytes(env.arch.word_size, 'little')
+        env.full_text[o : o + env.arch.word_size] = got_entry.link_addr.to_bytes(
+            env.arch.word_size, 'little'
+        )
 
     # Create a relocation for each GOT entry
     for got_entry in got_list:
@@ -388,7 +459,13 @@ def populate_got(env):
     # Print out the final GOT
     log(LOG_LEVEL_2, 'GOT: {:08x}'.format(env.got_section.addr))
     for g in got_list:
-        log(LOG_LEVEL_2, '  {:08x} {} -> {}+{:08x}'.format(g.offset, g.name, g.sec_name, g.link_addr))
+        log(
+            LOG_LEVEL_2,
+            '  {:08x} {} -> {}+{:08x}'.format(
+                g.offset, g.name, g.sec_name, g.link_addr
+            ),
+        )
+
 
 def populate_lit(env):
     log(LOG_LEVEL_2, 'LIT: {:08x}'.format(env.lit_section.addr))
@@ -396,7 +473,10 @@ def populate_lit(env):
         value = lit_entry.value
         log(LOG_LEVEL_2, '  {:08x} = {:08x}'.format(lit_entry.offset, value))
         o = env.lit_section.addr + lit_entry.offset
-        env.full_text[o:o + env.arch.word_size] = value.to_bytes(env.arch.word_size, 'little')
+        env.full_text[o : o + env.arch.word_size] = value.to_bytes(
+            env.arch.word_size, 'little'
+        )
+
 
 def do_relocation_text(env, text_addr, r):
     # Extract relevant info about symbol that's being relocated
@@ -416,11 +496,17 @@ def do_relocation_text(env, text_addr, r):
     reloc_type = 'le32'
     log_name = None
 
-    if (env.arch.name == 'EM_386' and r_info_type in (R_386_PC32, R_386_PLT32)
-        or env.arch.name == 'EM_X86_64' and r_info_type in (R_X86_64_PC32, R_X86_64_PLT32)
-        or env.arch.name == 'EM_ARM' and r_info_type in (R_ARM_REL32, R_ARM_THM_CALL, R_ARM_THM_JUMP24)
-        or s_bind == 'STB_LOCAL' and env.arch.name == 'EM_XTENSA' and r_info_type == R_XTENSA_32 # not GOT
-        ):
+    if (
+        env.arch.name == 'EM_386'
+        and r_info_type in (R_386_PC32, R_386_PLT32)
+        or env.arch.name == 'EM_X86_64'
+        and r_info_type in (R_X86_64_PC32, R_X86_64_PLT32)
+        or env.arch.name == 'EM_ARM'
+        and r_info_type in (R_ARM_REL32, R_ARM_THM_CALL, R_ARM_THM_JUMP24)
+        or s_bind == 'STB_LOCAL'
+        and env.arch.name == 'EM_XTENSA'
+        and r_info_type == R_XTENSA_32  # not GOT
+    ):
         # Standard relocation to fixed location within text/rodata
         if hasattr(s, 'resolved'):
             s = s.resolved
@@ -431,10 +517,16 @@ def do_relocation_text(env, text_addr, r):
             raise LinkError('fixed relocation to rodata with rodata referenced via GOT')
 
         if sec.name.startswith('.bss'):
-            raise LinkError('{}: fixed relocation to bss (bss variables can\'t be static)'.format(s.filename))
+            raise LinkError(
+                '{}: fixed relocation to bss (bss variables can\'t be static)'.format(
+                    s.filename
+                )
+            )
 
         if sec.name.startswith('.external'):
-            raise LinkError('{}: fixed relocation to external symbol: {}'.format(s.filename, s.name))
+            raise LinkError(
+                '{}: fixed relocation to external symbol: {}'.format(s.filename, s.name)
+            )
 
         addr = sec.addr + s['st_value']
         reloc = addr - r_offset + r_addend
@@ -445,17 +537,23 @@ def do_relocation_text(env, text_addr, r):
             #   R_ARM_THM_JUMP24: b.w
             reloc_type = 'thumb_b'
 
-    elif (env.arch.name == 'EM_386' and r_info_type == R_386_GOTPC
-        or env.arch.name == 'EM_ARM' and r_info_type == R_ARM_BASE_PREL
-        ):
+    elif (
+        env.arch.name == 'EM_386'
+        and r_info_type == R_386_GOTPC
+        or env.arch.name == 'EM_ARM'
+        and r_info_type == R_ARM_BASE_PREL
+    ):
         # Relocation to GOT address itself
         assert s.name == '_GLOBAL_OFFSET_TABLE_'
         addr = env.got_section.addr
         reloc = addr - r_offset + r_addend
 
-    elif (env.arch.name == 'EM_386' and r_info_type in (R_386_GOT32, R_386_GOT32X)
-        or env.arch.name == 'EM_ARM' and r_info_type == R_ARM_GOT_BREL
-        ):
+    elif (
+        env.arch.name == 'EM_386'
+        and r_info_type in (R_386_GOT32, R_386_GOT32X)
+        or env.arch.name == 'EM_ARM'
+        and r_info_type == R_ARM_GOT_BREL
+    ):
         # Relcation pointing to GOT
         reloc = addr = env.got_entries[s.name].offset
 
@@ -500,23 +598,23 @@ def do_relocation_text(env, text_addr, r):
 
     # Write relocation
     if reloc_type == 'le32':
-        existing, = struct.unpack_from('<I', env.full_text, r_offset)
-        struct.pack_into('<I', env.full_text, r_offset, (existing + reloc) & 0xffffffff)
+        (existing,) = struct.unpack_from('<I', env.full_text, r_offset)
+        struct.pack_into('<I', env.full_text, r_offset, (existing + reloc) & 0xFFFFFFFF)
     elif reloc_type == 'thumb_b':
         b_h, b_l = struct.unpack_from('<HH', env.full_text, r_offset)
-        existing = (b_h & 0x7ff) << 12 | (b_l & 0x7ff) << 1
-        if existing >= 0x400000: # 2's complement
+        existing = (b_h & 0x7FF) << 12 | (b_l & 0x7FF) << 1
+        if existing >= 0x400000:  # 2's complement
             existing -= 0x800000
         new = existing + reloc
-        b_h = (b_h & 0xf800) | (new >> 12) & 0x7ff
-        b_l = (b_l & 0xf800) | (new >> 1) & 0x7ff
+        b_h = (b_h & 0xF800) | (new >> 12) & 0x7FF
+        b_l = (b_l & 0xF800) | (new >> 1) & 0x7FF
         struct.pack_into('<HH', env.full_text, r_offset, b_h, b_l)
     elif reloc_type == 'xtensa_l32r':
         l32r = unpack_u24le(env.full_text, r_offset)
-        assert l32r & 0xf == 1 # RI16 encoded l32r
+        assert l32r & 0xF == 1  # RI16 encoded l32r
         l32r_imm16 = l32r >> 8
-        l32r_imm16 = (l32r_imm16 + reloc >> 2) & 0xffff
-        l32r = l32r & 0xff | l32r_imm16 << 8
+        l32r_imm16 = (l32r_imm16 + reloc >> 2) & 0xFFFF
+        l32r = l32r & 0xFF | l32r_imm16 << 8
         pack_u24le(env.full_text, r_offset, l32r)
     else:
         assert 0, reloc_type
@@ -529,6 +627,7 @@ def do_relocation_text(env, text_addr, r):
             log_name = s.name
     log(LOG_LEVEL_3, '  {:08x} {} -> {:08x}'.format(r_offset, log_name, addr))
 
+
 def do_relocation_data(env, text_addr, r):
     s = r.sym
     s_type = s.entry['st_info']['type']
@@ -540,10 +639,16 @@ def do_relocation_data(env, text_addr, r):
     except KeyError:
         r_addend = 0
 
-    if (env.arch.name == 'EM_386' and r_info_type == R_386_32
-        or env.arch.name == 'EM_X86_64' and r_info_type == R_X86_64_64
-        or env.arch.name == 'EM_ARM' and r_info_type == R_ARM_ABS32
-        or env.arch.name == 'EM_XTENSA' and r_info_type == R_XTENSA_32):
+    if (
+        env.arch.name == 'EM_386'
+        and r_info_type == R_386_32
+        or env.arch.name == 'EM_X86_64'
+        and r_info_type == R_X86_64_64
+        or env.arch.name == 'EM_ARM'
+        and r_info_type == R_ARM_ABS32
+        or env.arch.name == 'EM_XTENSA'
+        and r_info_type == R_XTENSA_32
+    ):
         # Relocation in data.rel.ro to internal/external symbol
         if env.arch.word_size == 4:
             struct_type = '<I'
@@ -561,7 +666,7 @@ def do_relocation_data(env, text_addr, r):
             data = env.full_rodata
         else:
             data = env.full_text
-        existing, = struct.unpack_from(struct_type, data, r_offset)
+        (existing,) = struct.unpack_from(struct_type, data, r_offset)
         if sec.name.startswith(('.text', '.rodata', '.data.rel.ro', '.bss')):
             struct.pack_into(struct_type, data, r_offset, existing + addr)
             kind = sec.name
@@ -580,6 +685,7 @@ def do_relocation_data(env, text_addr, r):
         # Unknown/unsupported relocation
         assert 0, r_info_type
 
+
 def load_object_file(env, felf):
     with open(felf, 'rb') as f:
         elf = elffile.ELFFile(f)
@@ -589,13 +695,15 @@ def load_object_file(env, felf):
         symtab = list(elf.get_section_by_name('.symtab').iter_symbols())
 
         # Load needed sections from ELF file
-        sections_shndx = {} # maps elf shndx to Section object
+        sections_shndx = {}  # maps elf shndx to Section object
         for idx, s in enumerate(elf.iter_sections()):
             if s.header.sh_type in ('SHT_PROGBITS', 'SHT_NOBITS'):
                 if s.data_size == 0:
                     # Ignore empty sections
                     pass
-                elif s.name.startswith(('.literal', '.text', '.rodata', '.data.rel.ro', '.bss')):
+                elif s.name.startswith(
+                    ('.literal', '.text', '.rodata', '.data.rel.ro', '.bss')
+                ):
                     sec = Section.from_elfsec(s, felf)
                     sections_shndx[idx] = sec
                     if s.name.startswith('.literal'):
@@ -625,12 +733,18 @@ def load_object_file(env, felf):
                 sym.section = sections_shndx[shndx]
                 if sym['st_info']['bind'] == 'STB_GLOBAL':
                     # Defined global symbol
-                    if sym.name in env.known_syms and not sym.name.startswith('__x86.get_pc_thunk.'):
+                    if sym.name in env.known_syms and not sym.name.startswith(
+                        '__x86.get_pc_thunk.'
+                    ):
                         raise LinkError('duplicate symbol: {}'.format(sym.name))
                     env.known_syms[sym.name] = sym
-            elif sym.entry['st_shndx'] == 'SHN_UNDEF' and sym['st_info']['bind'] == 'STB_GLOBAL':
+            elif (
+                sym.entry['st_shndx'] == 'SHN_UNDEF'
+                and sym['st_info']['bind'] == 'STB_GLOBAL'
+            ):
                 # Undefined global symbol, needs resolving
                 env.unresolved_syms.append(sym)
+
 
 def link_objects(env, native_qstr_vals_len, native_qstr_objs_len):
     # Build GOT information
@@ -654,31 +768,42 @@ def link_objects(env, native_qstr_vals_len, native_qstr_objs_len):
         env.sections.insert(1, env.lit_section)
 
     # Create section to contain mp_native_qstr_val_table
-    env.qstr_val_section = Section('.text.QSTR_VAL', bytearray(native_qstr_vals_len * env.arch.qstr_entry_size), env.arch.qstr_entry_size)
+    env.qstr_val_section = Section(
+        '.text.QSTR_VAL',
+        bytearray(native_qstr_vals_len * env.arch.qstr_entry_size),
+        env.arch.qstr_entry_size,
+    )
     env.sections.append(env.qstr_val_section)
 
     # Create section to contain mp_native_qstr_obj_table
-    env.qstr_obj_section = Section('.text.QSTR_OBJ', bytearray(native_qstr_objs_len * env.arch.word_size), env.arch.word_size)
+    env.qstr_obj_section = Section(
+        '.text.QSTR_OBJ',
+        bytearray(native_qstr_objs_len * env.arch.word_size),
+        env.arch.word_size,
+    )
     env.sections.append(env.qstr_obj_section)
 
     # Resolve unknown symbols
     mp_fun_table_sec = Section('.external.mp_fun_table', b'', 0)
-    fun_table = {key: 67 + idx
-        for idx, key in enumerate([
-            'mp_type_type',
-            'mp_type_str',
-            'mp_type_list',
-            'mp_type_dict',
-            'mp_type_fun_builtin_0',
-            'mp_type_fun_builtin_1',
-            'mp_type_fun_builtin_2',
-            'mp_type_fun_builtin_3',
-            'mp_type_fun_builtin_var',
-            'mp_stream_read_obj',
-            'mp_stream_readinto_obj',
-            'mp_stream_unbuffered_readline_obj',
-            'mp_stream_write_obj',
-        ])
+    fun_table = {
+        key: 67 + idx
+        for idx, key in enumerate(
+            [
+                'mp_type_type',
+                'mp_type_str',
+                'mp_type_list',
+                'mp_type_dict',
+                'mp_type_fun_builtin_0',
+                'mp_type_fun_builtin_1',
+                'mp_type_fun_builtin_2',
+                'mp_type_fun_builtin_3',
+                'mp_type_fun_builtin_var',
+                'mp_stream_read_obj',
+                'mp_stream_readinto_obj',
+                'mp_stream_unbuffered_readline_obj',
+                'mp_stream_write_obj',
+            ]
+        )
     }
     for sym in env.unresolved_syms:
         assert sym['st_value'] == 0
@@ -697,14 +822,18 @@ def link_objects(env, native_qstr_vals_len, native_qstr_objs_len):
                 sym.section = mp_fun_table_sec
                 sym.mp_fun_table_offset = fun_table[sym.name]
             else:
-                raise LinkError('{}: undefined symbol: {}'.format(sym.filename, sym.name))
+                raise LinkError(
+                    '{}: undefined symbol: {}'.format(sym.filename, sym.name)
+                )
 
     # Align sections, assign their addresses, and create full_text
-    env.full_text = bytearray(env.arch.asm_jump(8)) # dummy, to be filled in later
+    env.full_text = bytearray(env.arch.asm_jump(8))  # dummy, to be filled in later
     env.full_rodata = bytearray(0)
     env.full_bss = bytearray(0)
     for sec in env.sections:
-        if env.arch.separate_rodata and sec.name.startswith(('.rodata', '.data.rel.ro')):
+        if env.arch.separate_rodata and sec.name.startswith(
+            ('.rodata', '.data.rel.ro')
+        ):
             data = env.full_rodata
         elif sec.name.startswith('.bss'):
             data = env.full_bss
@@ -724,7 +853,10 @@ def link_objects(env, native_qstr_vals_len, native_qstr_objs_len):
     for sec in env.sections:
         if not sec.reloc:
             continue
-        log(LOG_LEVEL_3, '{}: {} relocations via {}:'.format(sec.filename, sec.name, sec.reloc_name))
+        log(
+            LOG_LEVEL_3,
+            '{}: {} relocations via {}:'.format(sec.filename, sec.name, sec.reloc_name),
+        )
         for r in sec.reloc:
             if sec.name.startswith(('.text', '.rodata')):
                 do_relocation_text(env, sec.addr, r)
@@ -733,8 +865,10 @@ def link_objects(env, native_qstr_vals_len, native_qstr_objs_len):
             else:
                 assert 0, sec.name
 
+
 ################################################################################
 # .mpy output
+
 
 class MPYOutput:
     def open(self, fname):
@@ -750,10 +884,10 @@ class MPYOutput:
 
     def write_uint(self, val):
         b = bytearray()
-        b.insert(0, val & 0x7f)
+        b.insert(0, val & 0x7F)
         val >>= 7
         while val:
-            b.insert(0, 0x80 | (val & 0x7f))
+            b.insert(0, 0x80 | (val & 0x7F))
             val >>= 7
         self.write_bytes(b)
 
@@ -774,7 +908,7 @@ class MPYOutput:
             assert 6 <= dest <= 127
             assert n == 1
         dest = dest << 1 | need_offset
-        assert 0 <= dest <= 0xfe, dest
+        assert 0 <= dest <= 0xFE, dest
         self.write_bytes(bytes([dest]))
         if need_offset:
             if base == '.text':
@@ -785,10 +919,11 @@ class MPYOutput:
         if n > 1:
             self.write_uint(n)
 
+
 def build_mpy(env, entry_offset, fmpy, native_qstr_vals, native_qstr_objs):
     # Write jump instruction to start of text
     jump = env.arch.asm_jump(entry_offset)
-    env.full_text[:len(jump)] = jump
+    env.full_text[: len(jump)] = jump
 
     log(LOG_LEVEL_1, 'arch:         {}'.format(env.arch.name))
     log(LOG_LEVEL_1, 'text size:    {}'.format(len(env.full_text)))
@@ -797,19 +932,23 @@ def build_mpy(env, entry_offset, fmpy, native_qstr_vals, native_qstr_objs):
     log(LOG_LEVEL_1, 'bss size:     {}'.format(len(env.full_bss)))
     log(LOG_LEVEL_1, 'GOT entries:  {}'.format(len(env.got_entries)))
 
-    #xxd(env.full_text)
+    # xxd(env.full_text)
 
     out = MPYOutput()
     out.open(fmpy)
 
     # MPY: header
-    out.write_bytes(bytearray([
-        ord('M'),
-        MPY_VERSION,
-        env.arch.mpy_feature,
-        MP_SMALL_INT_BITS,
-        QSTR_WINDOW_SIZE,
-    ]))
+    out.write_bytes(
+        bytearray(
+            [
+                ord('M'),
+                MPY_VERSION,
+                env.arch.mpy_feature,
+                MP_SMALL_INT_BITS,
+                QSTR_WINDOW_SIZE,
+            ]
+        )
+    )
 
     # MPY: kind/len
     out.write_uint(len(env.full_text) << 2 | (MP_CODE_NATIVE_VIPER - MP_CODE_BYTECODE))
@@ -887,8 +1026,10 @@ def build_mpy(env, entry_offset, fmpy, native_qstr_vals, native_qstr_objs):
 
     out.close()
 
+
 ################################################################################
 # main
+
 
 def do_preprocess(args):
     if args.output is None:
@@ -896,22 +1037,30 @@ def do_preprocess(args):
         args.output = args.files[0][:-1] + 'config.h'
     static_qstrs, qstr_vals, qstr_objs = extract_qstrs(args.files)
     with open(args.output, 'w') as f:
-        print('#include <stdint.h>\n'
+        print(
+            '#include <stdint.h>\n'
             'typedef uintptr_t mp_uint_t;\n'
             'typedef intptr_t mp_int_t;\n'
-            'typedef uintptr_t mp_off_t;', file=f)
+            'typedef uintptr_t mp_off_t;',
+            file=f,
+        )
         for i, q in enumerate(static_qstrs):
             print('#define %s (%u)' % (q, i + 1), file=f)
         for i, q in enumerate(sorted(qstr_vals)):
             print('#define %s (mp_native_qstr_val_table[%d])' % (q, i), file=f)
         for i, q in enumerate(sorted(qstr_objs)):
-            print('#define MP_OBJ_NEW_QSTR_%s ((mp_obj_t)mp_native_qstr_obj_table[%d])' % (q, i), file=f)
+            print(
+                '#define MP_OBJ_NEW_QSTR_%s ((mp_obj_t)mp_native_qstr_obj_table[%d])'
+                % (q, i),
+                file=f,
+            )
         if args.arch == 'xtensawin':
-            qstr_type = 'uint32_t' # esp32 can only read 32-bit values from IRAM
+            qstr_type = 'uint32_t'  # esp32 can only read 32-bit values from IRAM
         else:
             qstr_type = 'uint16_t'
         print('extern const {} mp_native_qstr_val_table[];'.format(qstr_type), file=f)
         print('extern const mp_uint_t mp_native_qstr_obj_table[];', file=f)
+
 
 def do_link(args):
     if args.output is None:
@@ -936,19 +1085,38 @@ def do_link(args):
         for file in args.files:
             load_object_file(env, file)
         link_objects(env, len(native_qstr_vals), len(native_qstr_objs))
-        build_mpy(env, env.find_addr('mpy_init'), args.output, native_qstr_vals, native_qstr_objs)
+        build_mpy(
+            env,
+            env.find_addr('mpy_init'),
+            args.output,
+            native_qstr_vals,
+            native_qstr_objs,
+        )
     except LinkError as er:
         print('LinkError:', er.args[0])
         sys.exit(1)
 
+
 def main():
     import argparse
+
     cmd_parser = argparse.ArgumentParser(description='Run scripts on the pyboard.')
-    cmd_parser.add_argument('--verbose', '-v', action='count', default=1, help='increase verbosity')
+    cmd_parser.add_argument(
+        '--verbose', '-v', action='count', default=1, help='increase verbosity'
+    )
     cmd_parser.add_argument('--arch', default='x64', help='architecture')
-    cmd_parser.add_argument('--preprocess', action='store_true', help='preprocess source files')
-    cmd_parser.add_argument('--qstrs', default=None, help='file defining additional qstrs')
-    cmd_parser.add_argument('--output', '-o', default=None, help='output .mpy file (default to input with .o->.mpy)')
+    cmd_parser.add_argument(
+        '--preprocess', action='store_true', help='preprocess source files'
+    )
+    cmd_parser.add_argument(
+        '--qstrs', default=None, help='file defining additional qstrs'
+    )
+    cmd_parser.add_argument(
+        '--output',
+        '-o',
+        default=None,
+        help='output .mpy file (default to input with .o->.mpy)',
+    )
     cmd_parser.add_argument('files', nargs='+', help='input files')
     args = cmd_parser.parse_args()
 
@@ -959,6 +1127,7 @@ def main():
         do_preprocess(args)
     else:
         do_link(args)
+
 
 if __name__ == '__main__':
     main()

--- a/tools/pyboard.py
+++ b/tools/pyboard.py
@@ -77,18 +77,22 @@ except AttributeError:
     # Python2 doesn't have buffer attr
     stdout = sys.stdout
 
+
 def stdout_write_bytes(b):
     b = b.replace(b"\x04", b"")
     stdout.write(b)
     stdout.flush()
 
+
 class PyboardError(Exception):
     pass
+
 
 class TelnetToSerial:
     def __init__(self, ip, user, password, read_timeout=None):
         self.tn = None
         import telnetlib
+
         self.tn = telnetlib.Telnet(ip, timeout=15)
         self.read_timeout = read_timeout
         if b'Login as:' in self.tn.read_until(b'Login as:', timeout=read_timeout):
@@ -99,9 +103,12 @@ class TelnetToSerial:
                 time.sleep(0.2)
                 self.tn.write(bytes(password, 'ascii') + b"\r\n")
 
-                if b'for more information.' in self.tn.read_until(b'Type "help()" for more information.', timeout=read_timeout):
+                if b'for more information.' in self.tn.read_until(
+                    b'Type "help()" for more information.', timeout=read_timeout
+                ):
                     # login successful
                     from collections import deque
+
                     self.fifo = deque()
                     return
 
@@ -123,7 +130,10 @@ class TelnetToSerial:
                 timeout_count = 0
             else:
                 time.sleep(0.25)
-                if self.read_timeout is not None and timeout_count > 4 * self.read_timeout:
+                if (
+                    self.read_timeout is not None
+                    and timeout_count > 4 * self.read_timeout
+                ):
                     break
                 timeout_count += 1
 
@@ -151,24 +161,33 @@ class ProcessToSerial:
 
     def __init__(self, cmd):
         import subprocess
-        self.subp = subprocess.Popen(cmd, bufsize=0, shell=True, preexec_fn=os.setsid,
-            stdin=subprocess.PIPE, stdout=subprocess.PIPE)
+
+        self.subp = subprocess.Popen(
+            cmd,
+            bufsize=0,
+            shell=True,
+            preexec_fn=os.setsid,
+            stdin=subprocess.PIPE,
+            stdout=subprocess.PIPE,
+        )
 
         # Initially was implemented with selectors, but that adds Python3
         # dependency. However, there can be race conditions communicating
         # with a particular child process (like QEMU), and selectors may
         # still work better in that case, so left inplace for now.
         #
-        #import selectors
-        #self.sel = selectors.DefaultSelector()
-        #self.sel.register(self.subp.stdout, selectors.EVENT_READ)
+        # import selectors
+        # self.sel = selectors.DefaultSelector()
+        # self.sel.register(self.subp.stdout, selectors.EVENT_READ)
 
         import select
+
         self.poll = select.poll()
         self.poll.register(self.subp.stdout.fileno())
 
     def close(self):
         import signal
+
         os.killpg(os.getpgid(self.subp.pid), signal.SIGTERM)
 
     def read(self, size=1):
@@ -182,7 +201,7 @@ class ProcessToSerial:
         return len(data)
 
     def inWaiting(self):
-        #res = self.sel.select(0)
+        # res = self.sel.select(0)
         res = self.poll.poll(0)
         if res:
             return 1
@@ -198,8 +217,16 @@ class ProcessPtyToTerminal:
         import subprocess
         import re
         import serial
-        self.subp = subprocess.Popen(cmd.split(), bufsize=0, shell=False, preexec_fn=os.setsid,
-            stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+
+        self.subp = subprocess.Popen(
+            cmd.split(),
+            bufsize=0,
+            shell=False,
+            preexec_fn=os.setsid,
+            stdin=subprocess.PIPE,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+        )
         pty_line = self.subp.stderr.readline().decode("utf-8")
         m = re.search(r"/dev/pts/[0-9]+", pty_line)
         if not m:
@@ -213,6 +240,7 @@ class ProcessPtyToTerminal:
 
     def close(self):
         import signal
+
         os.killpg(os.getpgid(self.subp.pid), signal.SIGTERM)
 
     def read(self, size=1):
@@ -226,22 +254,32 @@ class ProcessPtyToTerminal:
 
 
 class Pyboard:
-    def __init__(self, device, baudrate=115200, user='micro', password='python', wait=0):
+    def __init__(
+        self, device, baudrate=115200, user='micro', password='python', wait=0
+    ):
         if device.startswith("exec:"):
-            self.serial = ProcessToSerial(device[len("exec:"):])
+            self.serial = ProcessToSerial(device[len("exec:") :])
         elif device.startswith("execpty:"):
-            self.serial = ProcessPtyToTerminal(device[len("qemupty:"):])
-        elif device and device[0].isdigit() and device[-1].isdigit() and device.count('.') == 3:
+            self.serial = ProcessPtyToTerminal(device[len("qemupty:") :])
+        elif (
+            device
+            and device[0].isdigit()
+            and device[-1].isdigit()
+            and device.count('.') == 3
+        ):
             # device looks like an IP address
             self.serial = TelnetToSerial(device, user, password, read_timeout=10)
         else:
             import serial
+
             delayed = False
             for attempt in range(wait + 1):
                 try:
-                    self.serial = serial.Serial(device, baudrate=baudrate, interCharTimeout=1)
+                    self.serial = serial.Serial(
+                        device, baudrate=baudrate, interCharTimeout=1
+                    )
                     break
-                except (OSError, IOError): # Py2 and Py3 have different errors
+                except (OSError, IOError):  # Py2 and Py3 have different errors
                     if wait == 0:
                         continue
                     if attempt == 0:
@@ -287,7 +325,7 @@ class Pyboard:
         return data
 
     def enter_raw_repl(self):
-        self.serial.write(b'\r\x03\x03') # ctrl-C twice: interrupt any running program
+        self.serial.write(b'\r\x03\x03')  # ctrl-C twice: interrupt any running program
 
         # flush input (without relying on serial.flushInput())
         n = self.serial.inWaiting()
@@ -295,13 +333,13 @@ class Pyboard:
             self.serial.read(n)
             n = self.serial.inWaiting()
 
-        self.serial.write(b'\r\x01') # ctrl-A: enter raw REPL
+        self.serial.write(b'\r\x01')  # ctrl-A: enter raw REPL
         data = self.read_until(1, b'raw REPL; CTRL-B to exit\r\n>')
         if not data.endswith(b'raw REPL; CTRL-B to exit\r\n>'):
             print(data)
             raise PyboardError('could not enter raw repl')
 
-        self.serial.write(b'\x04') # ctrl-D: soft reset
+        self.serial.write(b'\x04')  # ctrl-D: soft reset
         data = self.read_until(1, b'soft reboot\r\n')
         if not data.endswith(b'soft reboot\r\n'):
             print(data)
@@ -314,7 +352,7 @@ class Pyboard:
             raise PyboardError('could not enter raw repl')
 
     def exit_raw_repl(self):
-        self.serial.write(b'\r\x02') # ctrl-B: enter friendly REPL
+        self.serial.write(b'\r\x02')  # ctrl-B: enter friendly REPL
 
     def follow(self, timeout, data_consumer=None):
         # wait for normal output
@@ -345,7 +383,7 @@ class Pyboard:
 
         # write command
         for i in range(0, len(command_bytes), 256):
-            self.serial.write(command_bytes[i:min(i + 256, len(command_bytes))])
+            self.serial.write(command_bytes[i : min(i + 256, len(command_bytes))])
             time.sleep(0.01)
         self.serial.write(b'\x04')
 
@@ -355,7 +393,7 @@ class Pyboard:
             raise PyboardError('could not exec command (response: %r)' % data)
 
     def exec_raw(self, command, timeout=10, data_consumer=None):
-        self.exec_raw_no_follow(command);
+        self.exec_raw_no_follow(command)
         return self.follow(timeout, data_consumer)
 
     def eval(self, expression):
@@ -379,14 +417,18 @@ class Pyboard:
         return int(t[4]) * 3600 + int(t[5]) * 60 + int(t[6])
 
     def fs_ls(self, src):
-        cmd = "import uos\nfor f in uos.ilistdir(%s):\n" \
-            " print('{:12} {}{}'.format(f[3]if len(f)>3 else 0,f[0],'/'if f[1]&0x4000 else ''))" % \
-            (("'%s'" % src) if src else '')
+        cmd = (
+            "import uos\nfor f in uos.ilistdir(%s):\n"
+            " print('{:12} {}{}'.format(f[3]if len(f)>3 else 0,f[0],'/'if f[1]&0x4000 else ''))"
+            % (("'%s'" % src) if src else '')
+        )
         self.exec_(cmd, data_consumer=stdout_write_bytes)
 
     def fs_cat(self, src, chunk_size=256):
-        cmd = "with open('%s') as f:\n while 1:\n" \
+        cmd = (
+            "with open('%s') as f:\n while 1:\n"
             "  b=f.read(%u)\n  if not b:break\n  print(b,end='')" % (src, chunk_size)
+        )
         self.exec_(cmd, data_consumer=stdout_write_bytes)
 
     def fs_get(self, src, dest, chunk_size=256):
@@ -394,7 +436,9 @@ class Pyboard:
         with open(dest, 'wb') as f:
             while True:
                 data = bytearray()
-                self.exec_("print(r(%u))" % chunk_size, data_consumer=lambda d:data.extend(d))
+                self.exec_(
+                    "print(r(%u))" % chunk_size, data_consumer=lambda d: data.extend(d)
+                )
                 assert data.endswith(b'\r\n\x04')
                 data = eval(str(data[:-3], 'ascii'))
                 if not data:
@@ -424,11 +468,15 @@ class Pyboard:
     def fs_rm(self, src):
         self.exec_("import uos\nuos.remove('%s')" % src)
 
+
 # in Python2 exec is a keyword so one must use "exec_"
 # but for Python3 we want to provide the nicer version "exec"
 setattr(Pyboard, "exec", Pyboard.exec_)
 
-def execfile(filename, device='/dev/ttyACM0', baudrate=115200, user='micro', password='python'):
+
+def execfile(
+    filename, device='/dev/ttyACM0', baudrate=115200, user='micro', password='python'
+):
     pyb = Pyboard(device, baudrate, user, password)
     pyb.enter_raw_repl()
     output = pyb.execfile(filename)
@@ -436,11 +484,13 @@ def execfile(filename, device='/dev/ttyACM0', baudrate=115200, user='micro', pas
     pyb.exit_raw_repl()
     pyb.close()
 
+
 def filesystem_command(pyb, args):
     def fname_remote(src):
         if src.startswith(':'):
             src = src[1:]
         return src
+
     def fname_cp_dest(src, dest):
         src = src.rsplit('/', 1)[-1]
         if dest is None or dest == '':
@@ -470,8 +520,13 @@ def filesystem_command(pyb, args):
                 print(fmt % (src, dest2))
                 op(src, dest2)
         else:
-            op = {'ls': pyb.fs_ls, 'cat': pyb.fs_cat, 'mkdir': pyb.fs_mkdir,
-                'rmdir': pyb.fs_rmdir, 'rm': pyb.fs_rm}[cmd]
+            op = {
+                'ls': pyb.fs_ls,
+                'cat': pyb.fs_cat,
+                'mkdir': pyb.fs_mkdir,
+                'rmdir': pyb.fs_rmdir,
+                'rm': pyb.fs_rm,
+            }[cmd]
             if cmd == 'ls' and not args:
                 args = ['']
             for src in args:
@@ -483,6 +538,7 @@ def filesystem_command(pyb, args):
         pyb.exit_raw_repl()
         pyb.close()
         sys.exit(1)
+
 
 _injected_import_hook_code = """\
 import uos, uio
@@ -511,19 +567,47 @@ uos.umount('/_')
 del _injected_buf, _FS
 """
 
+
 def main():
     import argparse
+
     cmd_parser = argparse.ArgumentParser(description='Run scripts on the pyboard.')
-    cmd_parser.add_argument('--device', default='/dev/ttyACM0', help='the serial device or the IP address of the pyboard')
-    cmd_parser.add_argument('-b', '--baudrate', default=115200, help='the baud rate of the serial device')
-    cmd_parser.add_argument('-u', '--user', default='micro', help='the telnet login username')
-    cmd_parser.add_argument('-p', '--password', default='python', help='the telnet login password')
+    cmd_parser.add_argument(
+        '--device',
+        default='/dev/ttyACM0',
+        help='the serial device or the IP address of the pyboard',
+    )
+    cmd_parser.add_argument(
+        '-b', '--baudrate', default=115200, help='the baud rate of the serial device'
+    )
+    cmd_parser.add_argument(
+        '-u', '--user', default='micro', help='the telnet login username'
+    )
+    cmd_parser.add_argument(
+        '-p', '--password', default='python', help='the telnet login password'
+    )
     cmd_parser.add_argument('-c', '--command', help='program passed in as string')
-    cmd_parser.add_argument('-w', '--wait', default=0, type=int, help='seconds to wait for USB connected board to become available')
+    cmd_parser.add_argument(
+        '-w',
+        '--wait',
+        default=0,
+        type=int,
+        help='seconds to wait for USB connected board to become available',
+    )
     group = cmd_parser.add_mutually_exclusive_group()
-    group.add_argument('--follow', action='store_true', help='follow the output after running the scripts [default if no scripts given]')
-    group.add_argument('--no-follow', action='store_true', help='Do not follow the output after running the scripts.')
-    cmd_parser.add_argument('-f', '--filesystem', action='store_true', help='perform a filesystem action')
+    group.add_argument(
+        '--follow',
+        action='store_true',
+        help='follow the output after running the scripts [default if no scripts given]',
+    )
+    group.add_argument(
+        '--no-follow',
+        action='store_true',
+        help='Do not follow the output after running the scripts.',
+    )
+    cmd_parser.add_argument(
+        '-f', '--filesystem', action='store_true', help='perform a filesystem action'
+    )
     cmd_parser.add_argument('files', nargs='*', help='input files')
     args = cmd_parser.parse_args()
 
@@ -551,7 +635,9 @@ def main():
                     pyb.exec_raw_no_follow(buf)
                     ret_err = None
                 else:
-                    ret, ret_err = pyb.exec_raw(buf, timeout=None, data_consumer=stdout_write_bytes)
+                    ret, ret_err = pyb.exec_raw(
+                        buf, timeout=None, data_consumer=stdout_write_bytes
+                    )
             except PyboardError as er:
                 print(er)
                 pyb.close()
@@ -586,7 +672,9 @@ def main():
         pyb.exit_raw_repl()
 
     # if asked explicitly, or no files given, then follow the output
-    if args.follow or (args.command is None and not args.filesystem and len(args.files) == 0):
+    if args.follow or (
+        args.command is None and not args.filesystem and len(args.files) == 0
+    ):
         try:
             ret, ret_err = pyb.follow(timeout=None, data_consumer=stdout_write_bytes)
         except PyboardError as er:
@@ -601,6 +689,7 @@ def main():
 
     # close the connection to the pyboard
     pyb.close()
+
 
 if __name__ == "__main__":
     main()

--- a/tools/pydfu.py
+++ b/tools/pydfu.py
@@ -25,34 +25,34 @@ import zlib
 
 # VID/PID
 __VID = 0x0483
-__PID = 0xdf11
+__PID = 0xDF11
 
 # USB request __TIMEOUT
 __TIMEOUT = 4000
 
 # DFU commands
-__DFU_DETACH    = 0
-__DFU_DNLOAD    = 1
-__DFU_UPLOAD    = 2
+__DFU_DETACH = 0
+__DFU_DNLOAD = 1
+__DFU_UPLOAD = 2
 __DFU_GETSTATUS = 3
 __DFU_CLRSTATUS = 4
-__DFU_GETSTATE  = 5
-__DFU_ABORT     = 6
+__DFU_GETSTATE = 5
+__DFU_ABORT = 6
 
 # DFU status
-__DFU_STATE_APP_IDLE                 = 0x00
-__DFU_STATE_APP_DETACH               = 0x01
-__DFU_STATE_DFU_IDLE                 = 0x02
-__DFU_STATE_DFU_DOWNLOAD_SYNC        = 0x03
-__DFU_STATE_DFU_DOWNLOAD_BUSY        = 0x04
-__DFU_STATE_DFU_DOWNLOAD_IDLE        = 0x05
-__DFU_STATE_DFU_MANIFEST_SYNC        = 0x06
-__DFU_STATE_DFU_MANIFEST             = 0x07
-__DFU_STATE_DFU_MANIFEST_WAIT_RESET  = 0x08
-__DFU_STATE_DFU_UPLOAD_IDLE          = 0x09
-__DFU_STATE_DFU_ERROR                = 0x0a
+__DFU_STATE_APP_IDLE = 0x00
+__DFU_STATE_APP_DETACH = 0x01
+__DFU_STATE_DFU_IDLE = 0x02
+__DFU_STATE_DFU_DOWNLOAD_SYNC = 0x03
+__DFU_STATE_DFU_DOWNLOAD_BUSY = 0x04
+__DFU_STATE_DFU_DOWNLOAD_IDLE = 0x05
+__DFU_STATE_DFU_MANIFEST_SYNC = 0x06
+__DFU_STATE_DFU_MANIFEST = 0x07
+__DFU_STATE_DFU_MANIFEST_WAIT_RESET = 0x08
+__DFU_STATE_DFU_UPLOAD_IDLE = 0x09
+__DFU_STATE_DFU_ERROR = 0x0A
 
-_DFU_DESCRIPTOR_TYPE                 = 0x21
+_DFU_DESCRIPTOR_TYPE = 0x21
 
 
 # USB device handle
@@ -74,6 +74,8 @@ if 'length' in getargspec(usb.util.get_string).args:
     # PyUSB 1.0.0.b1 has the length argument
     def get_string(dev, index):
         return usb.util.get_string(dev, 255, index)
+
+
 else:
     # PyUSB 1.0.0.b2 dropped the length argument
     def get_string(dev, index):
@@ -90,8 +92,8 @@ def find_dfu_cfg_descr(descr):
                 'bmAttributes',
                 'wDetachTimeOut',
                 'wTransferSize',
-                'bcdDFUVersion'
-            ]
+                'bcdDFUVersion',
+            ],
         )
         return nt(*struct.unpack('<BBBHHH', bytearray(descr)))
     return None
@@ -127,8 +129,10 @@ def init():
         status = get_status()
         if status == __DFU_STATE_DFU_IDLE:
             break
-        elif (status == __DFU_STATE_DFU_DOWNLOAD_IDLE
-            or status == __DFU_STATE_DFU_UPLOAD_IDLE):
+        elif (
+            status == __DFU_STATE_DFU_DOWNLOAD_IDLE
+            or status == __DFU_STATE_DFU_UPLOAD_IDLE
+        ):
             abort_request()
         else:
             clr_status()
@@ -141,22 +145,19 @@ def abort_request():
 
 def clr_status():
     """Clears any error status (perhaps left over from a previous session)."""
-    __dev.ctrl_transfer(0x21, __DFU_CLRSTATUS, 0, __DFU_INTERFACE,
-                        None, __TIMEOUT)
+    __dev.ctrl_transfer(0x21, __DFU_CLRSTATUS, 0, __DFU_INTERFACE, None, __TIMEOUT)
 
 
 def get_status():
     """Get the status of the last operation."""
-    stat = __dev.ctrl_transfer(0xA1, __DFU_GETSTATUS, 0, __DFU_INTERFACE,
-                               6, 20000)
+    stat = __dev.ctrl_transfer(0xA1, __DFU_GETSTATUS, 0, __DFU_INTERFACE, 6, 20000)
     return stat[4]
 
 
 def mass_erase():
     """Performs a MASS erase (i.e. erases the entire device)."""
     # Send DNLOAD with first byte=0x41
-    __dev.ctrl_transfer(0x21, __DFU_DNLOAD, 0, __DFU_INTERFACE,
-                        '\x41', __TIMEOUT)
+    __dev.ctrl_transfer(0x21, __DFU_DNLOAD, 0, __DFU_INTERFACE, '\x41', __TIMEOUT)
 
     # Execute last command
     if get_status() != __DFU_STATE_DFU_DOWNLOAD_BUSY:
@@ -213,20 +214,28 @@ def write_memory(addr, buf, progress=None, progress_addr=0, progress_size=0):
 
     while xfer_bytes < xfer_total:
         if __verbose and xfer_count % 512 == 0:
-            print('Addr 0x%x %dKBs/%dKBs...' % (xfer_base + xfer_bytes,
-                                                xfer_bytes // 1024,
-                                                xfer_total // 1024))
+            print(
+                'Addr 0x%x %dKBs/%dKBs...'
+                % (xfer_base + xfer_bytes, xfer_bytes // 1024, xfer_total // 1024)
+            )
         if progress and xfer_count % 2 == 0:
-            progress(progress_addr, xfer_base + xfer_bytes - progress_addr,
-                     progress_size)
+            progress(
+                progress_addr, xfer_base + xfer_bytes - progress_addr, progress_size
+            )
 
         # Set mem write address
         set_address(xfer_base + xfer_bytes)
 
         # Send DNLOAD with fw data
         chunk = min(__cfg_descr.wTransferSize, xfer_total - xfer_bytes)
-        __dev.ctrl_transfer(0x21, __DFU_DNLOAD, 2, __DFU_INTERFACE,
-                            buf[xfer_bytes:xfer_bytes + chunk], __TIMEOUT)
+        __dev.ctrl_transfer(
+            0x21,
+            __DFU_DNLOAD,
+            2,
+            __DFU_INTERFACE,
+            buf[xfer_bytes : xfer_bytes + chunk],
+            __TIMEOUT,
+        )
 
         # Execute last command
         if get_status() != __DFU_STATE_DFU_DOWNLOAD_BUSY:
@@ -271,8 +280,7 @@ def exit_dfu():
     set_address(0x08000000)
 
     # Send DNLOAD with 0 length to exit DFU
-    __dev.ctrl_transfer(0x21, __DFU_DNLOAD, 0, __DFU_INTERFACE,
-                        None, __TIMEOUT)
+    __dev.ctrl_transfer(0x21, __DFU_DNLOAD, 0, __DFU_INTERFACE, None, __TIMEOUT)
 
     try:
         # Execute last command
@@ -334,10 +342,11 @@ def read_dfu_file(filename):
     #   B   uint8_t     version     1
     #   I   uint32_t    size        Size of the DFU file (without suffix)
     #   B   uint8_t     targets     Number of targets
-    dfu_prefix, data = consume('<5sBIB', data,
-                               'signature version size targets')
-    print('    %(signature)s v%(version)d, image size: %(size)d, '
-          'targets: %(targets)d' % dfu_prefix)
+    dfu_prefix, data = consume('<5sBIB', data, 'signature version size targets')
+    print(
+        '    %(signature)s v%(version)d, image size: %(size)d, '
+        'targets: %(targets)d' % dfu_prefix
+    )
     for target_idx in range(dfu_prefix['targets']):
         # Decode the Image Prefix
         #
@@ -349,17 +358,18 @@ def read_dfu_file(filename):
         #   255s    char[255]   name        Name of the target
         #   I       uint32_t    size        Size of image (without prefix)
         #   I       uint32_t    elements    Number of elements in the image
-        img_prefix, data = consume('<6sBI255s2I', data,
-                                   'signature altsetting named name '
-                                   'size elements')
+        img_prefix, data = consume(
+            '<6sBI255s2I', data, 'signature altsetting named name ' 'size elements'
+        )
         img_prefix['num'] = target_idx
         if img_prefix['named']:
             img_prefix['name'] = cstring(img_prefix['name'])
         else:
             img_prefix['name'] = ''
-        print('    %(signature)s %(num)d, alt setting: %(altsetting)s, '
-              'name: "%(name)s", size: %(size)d, elements: %(elements)d'
-              % img_prefix)
+        print(
+            '    %(signature)s %(num)d, alt setting: %(altsetting)s, '
+            'name: "%(name)s", size: %(size)d, elements: %(elements)d' % img_prefix
+        )
 
         target_size = img_prefix['size']
         target_data = data[:target_size]
@@ -373,8 +383,7 @@ def read_dfu_file(filename):
             #   I   uint32_t    element     Size
             elem_prefix, target_data = consume('<2I', target_data, 'addr size')
             elem_prefix['num'] = elem_idx
-            print('      %(num)d, address: 0x%(addr)08x, size: %(size)d'
-                  % elem_prefix)
+            print('      %(num)d, address: 0x%(addr)08x, size: %(size)d' % elem_prefix)
             elem_size = elem_prefix['size']
             elem_data = target_data[:elem_size]
             target_data = target_data[elem_size:]
@@ -395,10 +404,13 @@ def read_dfu_file(filename):
     #   3s  char[3]     ufd         "UFD"
     #   B   uint8_t     len         16
     #   I   uint32_t    crc32       Checksum
-    dfu_suffix = named(struct.unpack('<4H3sBI', data[:16]),
-                       'device product vendor dfu ufd len crc')
-    print('    usb: %(vendor)04x:%(product)04x, device: 0x%(device)04x, '
-          'dfu: 0x%(dfu)04x, %(ufd)s, %(len)d, 0x%(crc)08x' % dfu_suffix)
+    dfu_suffix = named(
+        struct.unpack('<4H3sBI', data[:16]), 'device product vendor dfu ufd len crc'
+    )
+    print(
+        '    usb: %(vendor)04x:%(product)04x, device: 0x%(device)04x, '
+        'dfu: 0x%(dfu)04x, %(ufd)s, %(len)d, 0x%(crc)08x' % dfu_suffix
+    )
     if crc != dfu_suffix['crc']:
         print('CRC ERROR: computed crc32 is 0x%08x' % crc)
         return
@@ -418,8 +430,7 @@ class FilterDFU(object):
     def __call__(self, device):
         for cfg in device:
             for intf in cfg:
-                return (intf.bInterfaceClass == 0xFE and
-                        intf.bInterfaceSubClass == 1)
+                return intf.bInterfaceClass == 0xFE and intf.bInterfaceSubClass == 1
 
 
 def get_dfu_devices(*args, **kwargs):
@@ -429,8 +440,7 @@ def get_dfu_devices(*args, **kwargs):
     """
 
     # Convert to list for compatibility with newer PyUSB
-    return list(usb.core.find(*args, find_all=True,
-                              custom_match=FilterDFU(), **kwargs))
+    return list(usb.core.find(*args, find_all=True, custom_match=FilterDFU(), **kwargs))
 
 
 def get_memory_layout(device):
@@ -463,8 +473,12 @@ def get_memory_layout(device):
                 page_size *= 1024 * 1024
             size = num_pages * page_size
             last_addr = addr + size - 1
-            result.append(named((addr, last_addr, size, num_pages, page_size),
-                          'addr last_addr size num_pages page_size'))
+            result.append(
+                named(
+                    (addr, last_addr, size, num_pages, page_size),
+                    'addr last_addr size num_pages page_size',
+                )
+            )
             addr += size
     return result
 
@@ -476,15 +490,19 @@ def list_dfu_devices(*args, **kwargs):
         print('No DFU capable devices found')
         return
     for device in devices:
-        print('Bus {} Device {:03d}: ID {:04x}:{:04x}'
-              .format(device.bus, device.address,
-                      device.idVendor, device.idProduct))
+        print(
+            'Bus {} Device {:03d}: ID {:04x}:{:04x}'.format(
+                device.bus, device.address, device.idVendor, device.idProduct
+            )
+        )
         layout = get_memory_layout(device)
         print('Memory Layout')
         for entry in layout:
-            print('    0x{:x} {:2d} pages of {:3d}K bytes'
-                  .format(entry['addr'], entry['num_pages'],
-                          entry['page_size'] // 1024))
+            print(
+                '    0x{:x} {:2d} pages of {:3d}K bytes'.format(
+                    entry['addr'], entry['num_pages'], entry['page_size'] // 1024
+                )
+            )
 
 
 def write_elements(elements, mass_erase_used, progress=None):
@@ -505,8 +523,7 @@ def write_elements(elements, mass_erase_used, progress=None):
             write_size = size
             if not mass_erase_used:
                 for segment in mem_layout:
-                    if addr >= segment['addr'] and \
-                       addr <= segment['last_addr']:
+                    if addr >= segment['addr'] and addr <= segment['last_addr']:
                         # We found the page containing the address we want to
                         # write, erase it
                         page_size = segment['page_size']
@@ -515,8 +532,7 @@ def write_elements(elements, mass_erase_used, progress=None):
                             write_size = page_addr + page_size - addr
                         page_erase(page_addr)
                         break
-            write_memory(addr, data[:write_size], progress,
-                         elem_addr, elem_size)
+            write_memory(addr, data[:write_size], progress, elem_addr, elem_size)
             data = data[write_size:]
             addr += write_size
             size -= write_size
@@ -528,13 +544,16 @@ def cli_progress(addr, offset, size):
     """Prints a progress report suitable for use on the command line."""
     width = 25
     done = offset * width // size
-    print('\r0x{:08x} {:7d} [{}{}] {:3d}% '
-          .format(addr, size, '=' * done, ' ' * (width - done),
-                  offset * 100 // size), end='')
+    print(
+        '\r0x{:08x} {:7d} [{}{}] {:3d}% '.format(
+            addr, size, '=' * done, ' ' * (width - done), offset * 100 // size
+        ),
+        end='',
+    )
     try:
         sys.stdout.flush()
     except OSError:
-        pass    # Ignore Windows CLI "WinError 87" on Python 3.6
+        pass  # Ignore Windows CLI "WinError 87" on Python 3.6
     if offset == size:
         print('')
 
@@ -545,28 +564,28 @@ def main():
     # Parse CMD args
     parser = argparse.ArgumentParser(description='DFU Python Util')
     parser.add_argument(
-        '-l', '--list',
+        '-l',
+        '--list',
         help='list available DFU devices',
         action='store_true',
-        default=False
+        default=False,
     )
     parser.add_argument(
-        '-m', '--mass-erase',
+        '-m',
+        '--mass-erase',
         help='mass erase device',
         action='store_true',
-        default=False
+        default=False,
     )
     parser.add_argument(
-        '-u', '--upload',
-        help='read file from DFU device',
-        dest='path',
-        default=False
+        '-u', '--upload', help='read file from DFU device', dest='path', default=False
     )
     parser.add_argument(
-        '-v', '--verbose',
+        '-v',
+        '--verbose',
         help='increase output verbosity',
         action='store_true',
-        default=False
+        default=False,
     )
     args = parser.parse_args()
 
@@ -594,6 +613,7 @@ def main():
         return
 
     print('No command specified')
+
 
 if __name__ == '__main__':
     main()

--- a/tools/tinytest-codegen.py
+++ b/tools/tinytest-codegen.py
@@ -18,8 +18,10 @@ def escape(s):
     }
     return "\"\"\n\"{}\"".format(''.join([lookup[x] if x in lookup else x for x in s]))
 
+
 def chew_filename(t):
-    return { 'func': "test_{}_fn".format(sub(r'/|\.|-', '_', t)), 'desc': t }
+    return {'func': "test_{}_fn".format(sub(r'/|\.|-', '_', t)), 'desc': t}
+
 
 def script_to_map(test_file):
     r = {"name": chew_filename(test_file)["func"]}
@@ -28,6 +30,7 @@ def script_to_map(test_file):
     with open(test_file + ".exp", "rb") as f:
         r["output"] = escape(f.read())
     return r
+
 
 test_function = (
     "void {name}(void* data) {{\n"
@@ -43,20 +46,22 @@ test_function = (
 testcase_struct = (
     "struct testcase_t {name}_tests[] = {{\n{body}\n  END_OF_TESTCASES\n}};"
 )
-testcase_member = (
-    "  {{ \"{desc}\", {func}, TT_ENABLED_, 0, 0 }},"
-)
+testcase_member = "  {{ \"{desc}\", {func}, TT_ENABLED_, 0, 0 }},"
 
-testgroup_struct = (
-    "struct testgroup_t groups[] = {{\n{body}\n  END_OF_GROUPS\n}};"
-)
-testgroup_member = (
-    "  {{ \"{name}\", {name}_tests }},"
-)
+testgroup_struct = "struct testgroup_t groups[] = {{\n{body}\n  END_OF_GROUPS\n}};"
+testgroup_member = "  {{ \"{name}\", {name}_tests }},"
 
 ## XXX: may be we could have `--without <groups>` argument...
 # currently these tests are selected because they pass on qemu-arm
-test_dirs = ('basics', 'micropython', 'misc', 'extmod', 'float', 'inlineasm', 'qemu-arm',) # 'import', 'io',)
+test_dirs = (
+    'basics',
+    'micropython',
+    'misc',
+    'extmod',
+    'float',
+    'inlineasm',
+    'qemu-arm',
+)  # 'import', 'io',)
 exclude_tests = (
     # pattern matching in .exp
     'basics/bytes_compare3.py',
@@ -68,16 +73,21 @@ exclude_tests = (
     # doesn't output to python stdout
     'extmod/ure_debug.py',
     'extmod/vfs_basic.py',
-    'extmod/vfs_fat_ramdisk.py', 'extmod/vfs_fat_fileio.py',
-    'extmod/vfs_fat_fsusermount.py', 'extmod/vfs_fat_oldproto.py',
+    'extmod/vfs_fat_ramdisk.py',
+    'extmod/vfs_fat_fileio.py',
+    'extmod/vfs_fat_fsusermount.py',
+    'extmod/vfs_fat_oldproto.py',
     # rounding issues
     'float/float_divmod.py',
     # requires double precision floating point to work
     'float/float2int_doubleprec_intbig.py',
     'float/float_parse_doubleprec.py',
     # inline asm FP tests (require Cortex-M4)
-    'inlineasm/asmfpaddsub.py', 'inlineasm/asmfpcmp.py', 'inlineasm/asmfpldrstr.py',
-    'inlineasm/asmfpmuldiv.py','inlineasm/asmfpsqrt.py',
+    'inlineasm/asmfpaddsub.py',
+    'inlineasm/asmfpcmp.py',
+    'inlineasm/asmfpldrstr.py',
+    'inlineasm/asmfpmuldiv.py',
+    'inlineasm/asmfpsqrt.py',
     # different filename in output
     'micropython/emg_exc.py',
     'micropython/heapalloc_traceback.py',
@@ -94,13 +104,19 @@ exclude_tests = (
 output = []
 tests = []
 
-argparser = argparse.ArgumentParser(description='Convert native MicroPython tests to tinytest/upytesthelper C code')
-argparser.add_argument('--stdin', action="store_true", help='read list of tests from stdin')
+argparser = argparse.ArgumentParser(
+    description='Convert native MicroPython tests to tinytest/upytesthelper C code'
+)
+argparser.add_argument(
+    '--stdin', action="store_true", help='read list of tests from stdin'
+)
 args = argparser.parse_args()
 
 if not args.stdin:
     for group in test_dirs:
-        tests += [test for test in glob('{}/*.py'.format(group)) if test not in exclude_tests]
+        tests += [
+            test for test in glob('{}/*.py'.format(group)) if test not in exclude_tests
+        ]
 else:
     for l in sys.stdin:
         tests.append(l.rstrip())

--- a/tools/uf2conv.py
+++ b/tools/uf2conv.py
@@ -1,23 +1,23 @@
 #!/usr/bin/env python3
 
 # Microsoft UF2
-# 
+#
 # The MIT License (MIT)
-# 
+#
 # Copyright (c) Microsoft Corporation
-# 
+#
 # All rights reserved.
-# 
+#
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
 # in the Software without restriction, including without limitation the rights
 # to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 # copies of the Software, and to permit persons to whom the Software is
 # furnished to do so, subject to the following conditions:
-# 
+#
 # The above copyright notice and this permission notice shall be included in all
 # copies or substantial portions of the Software.
-# 
+#
 # THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 # IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 # FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -35,16 +35,16 @@ import os.path
 import argparse
 
 
-UF2_MAGIC_START0 = 0x0A324655 # "UF2\n"
-UF2_MAGIC_START1 = 0x9E5D5157 # Randomly selected
-UF2_MAGIC_END    = 0x0AB16F30 # Ditto
+UF2_MAGIC_START0 = 0x0A324655  # "UF2\n"
+UF2_MAGIC_START1 = 0x9E5D5157  # Randomly selected
+UF2_MAGIC_END = 0x0AB16F30  # Ditto
 
 families = {
-    'SAMD21': 0x68ed2b88,
+    'SAMD21': 0x68ED2B88,
     'SAMD51': 0x55114460,
-    'NRF52': 0x1b57745f,
-    'STM32F1': 0x5ee21072,
-    'STM32F4': 0x57755a57,
+    'NRF52': 0x1B57745F,
+    'STM32F1': 0x5EE21072,
+    'STM32F4': 0x57755A57,
     'ATMEGA32': 0x16573617,
 }
 
@@ -58,6 +58,7 @@ def is_uf2(buf):
     w = struct.unpack("<II", buf[0:8])
     return w[0] == UF2_MAGIC_START0 and w[1] == UF2_MAGIC_START1
 
+
 def is_hex(buf):
     try:
         w = buf[0:30].decode("utf-8")
@@ -67,6 +68,7 @@ def is_hex(buf):
         return True
     return False
 
+
 def convert_from_uf2(buf):
     global appstartaddr
     numblocks = len(buf) // 512
@@ -74,7 +76,7 @@ def convert_from_uf2(buf):
     outp = b""
     for blockno in range(numblocks):
         ptr = blockno * 512
-        block = buf[ptr:ptr + 512]
+        block = buf[ptr : ptr + 512]
         hd = struct.unpack(b"<IIIIIIII", block[0:32])
         if hd[0] != UF2_MAGIC_START0 or hd[1] != UF2_MAGIC_START1:
             print("Skipping block at " + ptr + "; bad magic")
@@ -92,7 +94,7 @@ def convert_from_uf2(buf):
         padding = newaddr - curraddr
         if padding < 0:
             assert False, "Block out of order at " + ptr
-        if padding > 10*1024*1024:
+        if padding > 10 * 1024 * 1024:
             assert False, "More than 10M of padding needed at " + ptr
         if padding % 4 != 0:
             assert False, "Non-word padding size at " + ptr
@@ -103,6 +105,7 @@ def convert_from_uf2(buf):
         curraddr = newaddr + datalen
     return outp
 
+
 def convert_to_carray(file_content):
     outp = "const unsigned char bindata[] __attribute__((aligned(16))) = {"
     for i in range(len(file_content)):
@@ -111,6 +114,7 @@ def convert_to_carray(file_content):
         outp += "0x%02x, " % ord(file_content[i])
     outp += "\n};\n"
     return outp
+
 
 def convert_to_uf2(file_content):
     global familyid
@@ -121,19 +125,28 @@ def convert_to_uf2(file_content):
     outp = b""
     for blockno in range(numblocks):
         ptr = 256 * blockno
-        chunk = file_content[ptr:ptr + 256]
+        chunk = file_content[ptr : ptr + 256]
         flags = 0x0
         if familyid:
             flags |= 0x2000
-        hd = struct.pack(b"<IIIIIIII",
-            UF2_MAGIC_START0, UF2_MAGIC_START1,
-            flags, ptr + appstartaddr, 256, blockno, numblocks, familyid)
+        hd = struct.pack(
+            b"<IIIIIIII",
+            UF2_MAGIC_START0,
+            UF2_MAGIC_START1,
+            flags,
+            ptr + appstartaddr,
+            256,
+            blockno,
+            numblocks,
+            familyid,
+        )
         while len(chunk) < 256:
             chunk += b"\x00"
         block = hd + chunk + datapadding + struct.pack(b"<I", UF2_MAGIC_END)
         assert len(block) == 512
         outp += block
     return outp
+
 
 class Block:
     def __init__(self, addr):
@@ -145,14 +158,23 @@ class Block:
         flags = 0x0
         if familyid:
             flags |= 0x2000
-        hd = struct.pack("<IIIIIIII",
-            UF2_MAGIC_START0, UF2_MAGIC_START1,
-            flags, self.addr, 256, blockno, numblocks, familyid)
+        hd = struct.pack(
+            "<IIIIIIII",
+            UF2_MAGIC_START0,
+            UF2_MAGIC_START1,
+            flags,
+            self.addr,
+            256,
+            blockno,
+            numblocks,
+            familyid,
+        )
         hd += self.bytes[0:256]
         while len(hd) < 512 - 4:
             hd += b"\x00"
         hd += struct.pack("<I", UF2_MAGIC_END)
         return hd
+
 
 def convert_from_hex_to_uf2(buf):
     global appstartaddr
@@ -166,14 +188,14 @@ def convert_from_hex_to_uf2(buf):
         i = 1
         rec = []
         while i < len(line) - 1:
-            rec.append(int(line[i:i+2], 16))
+            rec.append(int(line[i : i + 2], 16))
             i += 2
         tp = rec[3]
         if tp == 4:
             upper = ((rec[4] << 8) | rec[5]) << 16
         elif tp == 2:
             upper = ((rec[4] << 8) | rec[5]) << 4
-            assert (upper & 0xffff) == 0
+            assert (upper & 0xFFFF) == 0
         elif tp == 1:
             break
         elif tp == 0:
@@ -182,10 +204,10 @@ def convert_from_hex_to_uf2(buf):
                 appstartaddr = addr
             i = 4
             while i < len(rec) - 1:
-                if not currblock or currblock.addr & ~0xff != addr & ~0xff:
-                    currblock = Block(addr & ~0xff)
+                if not currblock or currblock.addr & ~0xFF != addr & ~0xFF:
+                    currblock = Block(addr & ~0xFF)
                     blocks.append(currblock)
-                currblock.bytes[addr & 0xff] = rec[i]
+                currblock.bytes[addr & 0xFF] = rec[i]
                 addr += 1
                 i += 1
     numblocks = len(blocks)
@@ -194,12 +216,22 @@ def convert_from_hex_to_uf2(buf):
         resfile += blocks[i].encode(i, numblocks)
     return resfile
 
+
 def get_drives():
     drives = []
     if sys.platform == "win32":
-        r = subprocess.check_output(["wmic", "PATH", "Win32_LogicalDisk",
-                                     "get", "DeviceID,", "VolumeName,",
-                                     "FileSystem,", "DriveType"])
+        r = subprocess.check_output(
+            [
+                "wmic",
+                "PATH",
+                "Win32_LogicalDisk",
+                "get",
+                "DeviceID,",
+                "VolumeName,",
+                "FileSystem,",
+                "DriveType",
+            ]
+        )
         for line in r.split('\n'):
             words = re.split('\s+', line)
             if len(words) >= 3 and words[1] == "2" and words[2] == "FAT":
@@ -214,7 +246,6 @@ def get_drives():
                 rootpath = tmp
         for d in os.listdir(rootpath):
             drives.append(os.path.join(rootpath, d))
-
 
     def has_info(d):
         try:
@@ -244,28 +275,58 @@ def write_file(name, buf):
 
 def main():
     global appstartaddr, familyid
+
     def error(msg):
         print(msg)
         sys.exit(1)
+
     parser = argparse.ArgumentParser(description='Convert to UF2 or flash directly.')
-    parser.add_argument('input', metavar='INPUT', type=str, nargs='?',
-                        help='input file (HEX, BIN or UF2)')
-    parser.add_argument('-b' , '--base', dest='base', type=str,
-                        default="0x2000",
-                        help='set base address of application for BIN format (default: 0x2000)')
-    parser.add_argument('-o' , '--output', metavar="FILE", dest='output', type=str,
-                        help='write output to named file; defaults to "flash.uf2" or "flash.bin" where sensible')
-    parser.add_argument('-d' , '--device', dest="device_path",
-                        help='select a device path to flash')
-    parser.add_argument('-l' , '--list', action='store_true',
-                        help='list connected devices')
-    parser.add_argument('-c' , '--convert', action='store_true',
-                        help='do not flash, just convert')
-    parser.add_argument('-f' , '--family', dest='family', type=str,
-                        default="0x0",
-                        help='specify familyID - number or name (default: 0x0)')
-    parser.add_argument('-C' , '--carray', action='store_true',
-                        help='convert binary file to a C array, not UF2')
+    parser.add_argument(
+        'input',
+        metavar='INPUT',
+        type=str,
+        nargs='?',
+        help='input file (HEX, BIN or UF2)',
+    )
+    parser.add_argument(
+        '-b',
+        '--base',
+        dest='base',
+        type=str,
+        default="0x2000",
+        help='set base address of application for BIN format (default: 0x2000)',
+    )
+    parser.add_argument(
+        '-o',
+        '--output',
+        metavar="FILE",
+        dest='output',
+        type=str,
+        help='write output to named file; defaults to "flash.uf2" or "flash.bin" where sensible',
+    )
+    parser.add_argument(
+        '-d', '--device', dest="device_path", help='select a device path to flash'
+    )
+    parser.add_argument(
+        '-l', '--list', action='store_true', help='list connected devices'
+    )
+    parser.add_argument(
+        '-c', '--convert', action='store_true', help='do not flash, just convert'
+    )
+    parser.add_argument(
+        '-f',
+        '--family',
+        dest='family',
+        type=str,
+        default="0x0",
+        help='specify familyID - number or name (default: 0x0)',
+    )
+    parser.add_argument(
+        '-C',
+        '--carray',
+        action='store_true',
+        help='convert binary file to a C array, not UF2',
+    )
     args = parser.parse_args()
     appstartaddr = int(args.base, 0)
 
@@ -275,7 +336,10 @@ def main():
         try:
             familyid = int(args.family, 0)
         except ValueError:
-            error("Family ID needs to be a number or one of: " + ", ".join(families.keys()))
+            error(
+                "Family ID needs to be a number or one of: "
+                + ", ".join(families.keys())
+            )
 
     if args.list:
         list_drives()
@@ -296,8 +360,10 @@ def main():
             ext = "h"
         else:
             outbuf = convert_to_uf2(inpbuf)
-        print("Converting to %s, output size: %d, start address: 0x%x" %
-              (ext, len(outbuf), appstartaddr))
+        print(
+            "Converting to %s, output size: %d, start address: 0x%x"
+            % (ext, len(outbuf), appstartaddr)
+        )
         if args.convert:
             drives = []
             if args.output == None:

--- a/tools/upip.py
+++ b/tools/upip.py
@@ -12,6 +12,7 @@ import uerrno as errno
 import ujson as json
 import uzlib
 import upip_utarfile as tarfile
+
 gc.collect()
 
 
@@ -23,8 +24,10 @@ gzdict_sz = 16 + 15
 
 file_buf = bytearray(512)
 
+
 class NotFoundError(Exception):
     pass
+
 
 def op_split(path):
     if path == "":
@@ -37,8 +40,10 @@ def op_split(path):
         head = "/"
     return (head, r[1])
 
+
 def op_basename(path):
     return op_split(path)[1]
+
 
 # Expects *file* name
 def _makedirs(name, mode=0o777):
@@ -70,26 +75,27 @@ def save_file(fname, subf):
                 break
             outf.write(file_buf, sz)
 
+
 def install_tar(f, prefix):
     meta = {}
     for info in f:
-        #print(info)
+        # print(info)
         fname = info.name
         try:
-            fname = fname[fname.index("/") + 1:]
+            fname = fname[fname.index("/") + 1 :]
         except ValueError:
             fname = ""
 
         save = True
         for p in ("setup.", "PKG-INFO", "README"):
-                #print(fname, p)
-                if fname.startswith(p) or ".egg-info" in fname:
-                    if fname.endswith("/requires.txt"):
-                        meta["deps"] = f.extractfile(info).read()
-                    save = False
-                    if debug:
-                        print("Skipping", fname)
-                    break
+            # print(fname, p)
+            if fname.startswith(p) or ".egg-info" in fname:
+                if fname.endswith("/requires.txt"):
+                    meta["deps"] = f.extractfile(info).read()
+                save = False
+                if debug:
+                    print("Skipping", fname)
+                break
 
         if save:
             outfname = prefix + fname
@@ -101,15 +107,20 @@ def install_tar(f, prefix):
                 save_file(outfname, subf)
     return meta
 
+
 def expandhome(s):
     if "~/" in s:
         h = os.getenv("HOME")
         s = s.replace("~/", h + "/")
     return s
 
+
 import ussl
 import usocket
+
 warn_ussl = True
+
+
 def url_open(url):
     global warn_ussl
 
@@ -121,12 +132,12 @@ def url_open(url):
         ai = usocket.getaddrinfo(host, 443, 0, usocket.SOCK_STREAM)
     except OSError as e:
         fatal("Unable to resolve %s (no Internet?)" % host, e)
-    #print("Address infos:", ai)
+    # print("Address infos:", ai)
     ai = ai[0]
 
     s = usocket.socket(ai[0], ai[1], ai[2])
     try:
-        #print("Connect address:", addr)
+        # print("Connect address:", addr)
         s.connect(ai[-1])
 
         if proto == "https:":
@@ -175,6 +186,7 @@ def fatal(msg, exc=None):
         raise exc
     sys.exit(1)
 
+
 def install_pkg(pkg_spec, install_path):
     data = get_pkg_metadata(pkg_spec)
 
@@ -197,6 +209,7 @@ def install_pkg(pkg_spec, install_path):
     del f2
     gc.collect()
     return meta
+
 
 def install(to_install, install_path=None):
     # Calculate gzip dictionary size to use
@@ -230,9 +243,13 @@ def install(to_install, install_path=None):
                 deps = deps.decode("utf-8").split("\n")
                 to_install.extend(deps)
     except Exception as e:
-        print("Error installing '{}': {}, packages may be partially installed".format(
-                pkg_spec, e),
-            file=sys.stderr)
+        print(
+            "Error installing '{}': {}, packages may be partially installed".format(
+                pkg_spec, e
+            ),
+            file=sys.stderr,
+        )
+
 
 def get_install_path():
     global install_path
@@ -242,6 +259,7 @@ def get_install_path():
     install_path = expandhome(install_path)
     return install_path
 
+
 def cleanup():
     for fname in cleanup_files:
         try:
@@ -249,21 +267,27 @@ def cleanup():
         except OSError:
             print("Warning: Cannot delete " + fname)
 
+
 def help():
-    print("""\
+    print(
+        """\
 upip - Simple PyPI package manager for MicroPython
 Usage: micropython -m upip install [-p <path>] <package>... | -r <requirements.txt>
 import upip; upip.install(package_or_list, [<path>])
 
 If <path> is not given, packages will be installed into sys.path[1]
 (can be set from MICROPYPATH environment variable, if current system
-supports that).""")
+supports that)."""
+    )
     print("Current value of sys.path[1]:", sys.path[1])
-    print("""\
+    print(
+        """\
 
 Note: only MicroPython packages (usually, named micropython-*) are supported
 for installation, upip does not support arbitrary code in setup.py.
-""")
+"""
+    )
+
 
 def main():
     global debug

--- a/tools/upip_utarfile.py
+++ b/tools/upip_utarfile.py
@@ -9,11 +9,12 @@ TAR_HEADER = {
 DIRTYPE = "dir"
 REGTYPE = "file"
 
+
 def roundup(val, align):
     return (val + align - 1) & ~(align - 1)
 
-class FileSection:
 
+class FileSection:
     def __init__(self, f, content_len, aligned_len):
         self.f = f
         self.content_len = content_len
@@ -33,7 +34,7 @@ class FileSection:
         if self.content_len == 0:
             return 0
         if len(buf) > self.content_len:
-            buf = memoryview(buf)[:self.content_len]
+            buf = memoryview(buf)[: self.content_len]
         sz = self.f.readinto(buf)
         self.content_len -= sz
         return sz
@@ -47,13 +48,13 @@ class FileSection:
                 self.f.readinto(buf, s)
                 sz -= s
 
-class TarInfo:
 
+class TarInfo:
     def __str__(self):
         return "TarInfo(%r, %s, %d)" % (self.name, self.type, self.size)
 
-class TarFile:
 
+class TarFile:
     def __init__(self, name=None, fileobj=None):
         if fileobj:
             self.f = fileobj
@@ -62,24 +63,24 @@ class TarFile:
         self.subf = None
 
     def next(self):
-            if self.subf:
-                self.subf.skip()
-            buf = self.f.read(512)
-            if not buf:
-                return None
+        if self.subf:
+            self.subf.skip()
+        buf = self.f.read(512)
+        if not buf:
+            return None
 
-            h = uctypes.struct(uctypes.addressof(buf), TAR_HEADER, uctypes.LITTLE_ENDIAN)
+        h = uctypes.struct(uctypes.addressof(buf), TAR_HEADER, uctypes.LITTLE_ENDIAN)
 
-            # Empty block means end of archive
-            if h.name[0] == 0:
-                return None
+        # Empty block means end of archive
+        if h.name[0] == 0:
+            return None
 
-            d = TarInfo()
-            d.name = str(h.name, "utf-8").rstrip("\0")
-            d.size = int(bytes(h.size), 8)
-            d.type = [REGTYPE, DIRTYPE][d.name[-1] == "/"]
-            self.subf = d.subf = FileSection(self.f, d.size, roundup(d.size, 512))
-            return d
+        d = TarInfo()
+        d.name = str(h.name, "utf-8").rstrip("\0")
+        d.size = int(bytes(h.size), 8)
+        d.type = [REGTYPE, DIRTYPE][d.name[-1] == "/"]
+        self.subf = d.subf = FileSection(self.f, d.size, roundup(d.size, 512))
+        return d
 
     def __iter__(self):
         return self


### PR DESCRIPTION
Per discussion in #4223 here's an attempt to format the Python code (but not tests) using black.

In the spirit of black its defaults are used.

Main changes are:
- literal hex numbers use uppercase for the letters
- double quotes are preferred over single quotes
- previously aligned comments/assignments are no longer aligned