### PR TITLE
Add in a esp_my9291_write() function

### DIFF
--- a/ports/esp8266/espneopixel.h
+++ b/ports/esp8266/espneopixel.h
@@ -2,5 +2,6 @@
 #define MICROPY_INCLUDED_ESP8266_ESPNEOPIXEL_H
 
 void esp_neopixel_write(uint8_t pin, uint8_t *pixels, uint32_t numBytes, bool is800KHz);
+void esp_my9291_write(uint8_t pinDI, uint8_t pinDCK, uint8_t *data, uint32_t numBytes);
 
 #endif // MICROPY_INCLUDED_ESP8266_ESPNEOPIXEL_H

--- a/ports/esp8266/modesp.c
+++ b/ports/esp8266/modesp.c
@@ -209,6 +209,15 @@ STATIC mp_obj_t esp_neopixel_write_(mp_obj_t pin, mp_obj_t buf, mp_obj_t is800k)
 }
 STATIC MP_DEFINE_CONST_FUN_OBJ_3(esp_neopixel_write_obj, esp_neopixel_write_);
 
+STATIC mp_obj_t esp_my9291_write_(mp_obj_t pinDI, mp_obj_t pinDCK, mp_obj_t buf) {
+    mp_buffer_info_t bufinfo;
+    mp_get_buffer_raise(buf, &bufinfo, MP_BUFFER_READ);
+    esp_my9291_write(mp_obj_get_pin_obj(pinDI)->phys_port, mp_obj_get_pin_obj(pinDCK)->phys_port, (uint8_t*)bufinfo.buf, bufinfo.len); 
+    return mp_const_none;
+}
+STATIC MP_DEFINE_CONST_FUN_OBJ_3(esp_my9291_write_obj, esp_my9291_write_);
+
+
 #if MICROPY_ESP8266_APA102
 STATIC mp_obj_t esp_apa102_write_(mp_obj_t clockPin, mp_obj_t dataPin, mp_obj_t buf) {
     mp_buffer_info_t bufinfo;
@@ -365,6 +374,7 @@ STATIC const mp_rom_map_elem_t esp_module_globals_table[] = {
     { MP_ROM_QSTR(MP_QSTR_flash_user_start), MP_ROM_PTR(&esp_flash_user_start_obj) },
     #if MICROPY_ESP8266_NEOPIXEL
     { MP_ROM_QSTR(MP_QSTR_neopixel_write), MP_ROM_PTR(&esp_neopixel_write_obj) },
+    { MP_ROM_QSTR(MP_QSTR_my9291_write), MP_ROM_PTR(&esp_my9291_write_obj) },
     #endif
     #if MICROPY_ESP8266_APA102
     { MP_ROM_QSTR(MP_QSTR_apa102_write), MP_ROM_PTR(&esp_apa102_write_obj) },

--- a/py/formatfloat.c
+++ b/py/formatfloat.c
@@ -164,6 +164,7 @@ int mp_format_float(FPTYPE f, char *buf, size_t buf_size, char fmt, int prec, ch
     int num_digits = 0;
     const FPTYPE *pos_pow = g_pos_pow;
     const FPTYPE *neg_pow = g_neg_pow;
+    FPTYPE foriginal = f;
 
     if (fp_iszero(f)) {
         e = 0;
@@ -328,7 +329,24 @@ int mp_format_float(FPTYPE f, char *buf, size_t buf_size, char fmt, int prec, ch
     }
 
     // Print the digits of the mantissa
-    for (int i = 0; i < num_digits; ++i, --dec) {
+    int i = 0;
+    if ((fmt == 'f') && (dec >= 0)) { // handle with the integer part separately to avoid rounding errors
+        f = foriginal;
+        int32_t d = (int32_t)f;
+        f -= (FPTYPE)d;
+        f *= FPCONST(10.0);
+        s += dec;
+        while (i <= dec) {
+            *s-- = '0' + (d%10);
+            d /= 10;
+            i++;
+        }
+        s += i+1;
+        if (prec > 0)
+            *s++ = '.';
+        dec = -1;
+    }
+    for (; i < num_digits; ++i, --dec) {
         int32_t d = (int32_t)f;
         if (d < 0) {
             *s++ = '0';


### PR DESCRIPTION
I've finally achieved my ambition [to put Micropython into a lightbulb](https://twitter.com/goatchurch/status/1232698764340727809)!

These  [AiLights](https://tinkerman.cat/post/ailight-hackable-rgbw-light-bulb) actually have a ESP8285, but the full Micropython with the mqtt-stack works fine.  The lighting controller is a my9291 chip with no documentation about its protocol, and the only implementation of it in Arduino-world [by bitbanging](https://github.com/xoseperez/my92xx).

I put the function into the same places as the `esp_neopixel_write()` function, which also is implemented by some some similar timed bitbanging.  I added some delays to keep the same time as the working arduino code.  Bitbanging directly from Micropython does not work: If the pulses are longer than 4microseconds the chip does not accept the signal.  

This is not the ideal function; it was originally meant to be 5 parameters, but the macro MP_DEFINE_CONST_FUN_OBJ_5 does not exist and it would have taken too many edits on the base code to put it in.  

So I'm putting this pull-request out here for comments about whether the function is adequate or in the right place, or whether a more general purpose function for bitbanging things like my9291 could be made (if there are any other chips like this).
