### PR TITLE
py/builtinevex: Support passing in a bytearray/buffer to eval/exec.

### DIFF
--- a/py/builtinevex.c
+++ b/py/builtinevex.c
@@ -136,17 +136,18 @@ STATIC mp_obj_t eval_exec_helper(size_t n_args, const mp_obj_t *args, mp_parse_i
     }
     #endif
 
-    size_t str_len;
-    const char *str = mp_obj_str_get_data(args[0], &str_len);
+    // Extract the source code.
+    mp_buffer_info_t bufinfo;
+    mp_get_buffer_raise(args[0], &bufinfo, MP_BUFFER_READ);
 
     // create the lexer
     // MP_PARSE_SINGLE_INPUT is used to indicate a file input
     mp_lexer_t *lex;
     if (MICROPY_PY_BUILTINS_EXECFILE && parse_input_kind == MP_PARSE_SINGLE_INPUT) {
-        lex = mp_lexer_new_from_file(str);
+        lex = mp_lexer_new_from_file(bufinfo.buf);
         parse_input_kind = MP_PARSE_FILE_INPUT;
     } else {
-        lex = mp_lexer_new_from_str_len(MP_QSTR__lt_string_gt_, str, str_len, 0);
+        lex = mp_lexer_new_from_str_len(MP_QSTR__lt_string_gt_, bufinfo.buf, bufinfo.len, 0);
     }
 
     return mp_parse_compile_execute(lex, parse_input_kind, globals, locals);

--- a/tests/basics/builtin_eval_buffer.py
+++ b/tests/basics/builtin_eval_buffer.py
@@ -1,0 +1,12 @@
+# test builtin eval with a buffer (bytearray/memoryview) input
+
+try:
+    eval
+    bytearray
+    memoryview
+except:
+    print("SKIP")
+    raise SystemExit
+
+print(eval(bytearray(b'1 + 1')))
+print(eval(memoryview(b'2 + 2')))

--- a/tests/basics/builtin_exec_buffer.py
+++ b/tests/basics/builtin_exec_buffer.py
@@ -1,0 +1,12 @@
+# test builtin exec with a buffer (bytearray/memoryview) input
+
+try:
+    exec
+    bytearray
+    memoryview
+except:
+    print("SKIP")
+    raise SystemExit
+
+exec(bytearray(b'print(1)'))
+exec(memoryview(b'print(2)'))


### PR DESCRIPTION
CPython allows this and it's a simple generalisation of the existing code which just supported str/bytes.

Fixes issue #5704.