### PR TITLE
Split ESP32 ESP-IDF v3 and v4 travis builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -238,8 +238,6 @@ jobs:
     - stage: test
       env: NAME="esp32 ESP-IDFv3 port build"
       install:
-        - sudo apt-get install python3-pip
-        - sudo pip3 install 'pyparsing<2.4'
         - curl -L https://dl.espressif.com/dl/xtensa-esp32-elf-linux64-1.22.0-80-g6c4433a-5.2.0.tar.gz | tar zxf -
         - export PATH=$(pwd)/xtensa-esp32-elf/bin:$PATH
         - git clone https://github.com/espressif/esp-idf.git

--- a/.travis.yml
+++ b/.travis.yml
@@ -234,28 +234,35 @@ jobs:
         - make ${MAKEOPTS} -C mpy-cross
         - make ${MAKEOPTS} -C ports/windows CROSS_COMPILE=i686-w64-mingw32-
 
-    # esp32 port
+    # esp32 w/ESP-IDFv3 port
     - stage: test
-      env: NAME="esp32 port build"
+      env: NAME="esp32 ESP-IDFv3 port build"
       install:
         - sudo apt-get install python3-pip
         - sudo pip3 install 'pyparsing<2.4'
-        - wget https://dl.espressif.com/dl/xtensa-esp32-elf-linux64-1.22.0-80-g6c4433a-5.2.0.tar.gz
-        - zcat xtensa-esp32-elf-linux64-1.22.0-80-g6c4433a-5.2.0.tar.gz | tar x
+        - curl -L https://dl.espressif.com/dl/xtensa-esp32-elf-linux64-1.22.0-80-g6c4433a-5.2.0.tar.gz | tar zxf -
         - export PATH=$(pwd)/xtensa-esp32-elf/bin:$PATH
         - git clone https://github.com/espressif/esp-idf.git
         - export IDF_PATH=$(pwd)/esp-idf
       script:
         - make ${MAKEOPTS} -C mpy-cross
-        # IDF v3 build
         - git -C esp-idf checkout $(grep "ESPIDF_SUPHASH_V3 :=" ports/esp32/Makefile | cut -d " " -f 3)
         - git -C esp-idf submodule update --init components/json/cJSON components/esp32/lib components/esptool_py/esptool components/expat/expat components/lwip/lwip components/mbedtls/mbedtls components/micro-ecc/micro-ecc components/nghttp/nghttp2 components/nimble components/bt
         - make ${MAKEOPTS} -C ports/esp32 submodules
         - make ${MAKEOPTS} -C ports/esp32
-        # clean
-        - git -C esp-idf clean -f -f -d components/json/cJSON components/esp32/lib components/expat/expat components/micro-ecc/micro-ecc components/nghttp/nghttp2
-        - make ${MAKEOPTS} -C ports/esp32 clean
-        # IDF v4 build
+
+    # esp32 w/ESP-IDFv4 port
+    - stage: test
+      env: NAME="esp32 ESP-IDFv4 port build"
+      install:
+        - sudo apt-get install python3-pip
+        - sudo pip3 install 'pyparsing<2.4'
+        - curl -L https://dl.espressif.com/dl/xtensa-esp32-elf-gcc8_2_0-esp-2019r2-linux-amd64.tar.gz | tar zxf -
+        - export PATH=$(pwd)/xtensa-esp32-elf/bin:$PATH
+        - git clone https://github.com/espressif/esp-idf.git
+        - export IDF_PATH=$(pwd)/esp-idf
+      script:        # IDF v4 build
+        - make ${MAKEOPTS} -C mpy-cross
         - git -C esp-idf checkout $(grep "ESPIDF_SUPHASH_V4 :=" ports/esp32/Makefile | cut -d " " -f 3)
         - git -C esp-idf submodule update --init components/bt/controller/lib components/bt/host/nimble/nimble components/esp_wifi/lib_esp32 components/esptool_py/esptool components/lwip/lwip components/mbedtls/mbedtls
         - make ${MAKEOPTS} -C ports/esp32 submodules


### PR DESCRIPTION
I'm trying to split the esp-idf v3 and v4 travis jobs to make it easier to see what is happening when there is a failure. The majority of the time is taken by the actual make process so the extra overhead of the double download seems minimal (and it's at travis' expense anyway).