### PR TITLE
fix manifest build error on Windows OS

### DIFF
--- a/tools/makemanifest.py
+++ b/tools/makemanifest.py
@@ -235,6 +235,9 @@ def main():
     # Get paths to tools
     MAKE_FROZEN = VARS["MPY_DIR"] + "/tools/make-frozen.py"
     MPY_CROSS = VARS["MPY_DIR"] + "/mpy-cross/mpy-cross"
+    if sys.platform == "win32":
+        MPY_CROSS += ".exe"
+    MPY_CROSS = os.getenv("MICROPY_MPYCROSS", MPY_CROSS)
     MPY_TOOL = VARS["MPY_DIR"] + "/tools/mpy-tool.py"
 
     # Ensure mpy-cross is built


### PR DESCRIPTION
cause of build error:  reference to MPY cross compiler is missing EXE file extension.  This causes a Windows build to break when the manifest feature is used.  Here is the build error:

mpy-cross not found at C:\Users\miket\Documents\micropython_projects\build-esp32/mpy-cross/mpy-cross, please build it first
make: *** [../../py/mkrules.mk:103: build-GENERIC/frozen_content.c] Error 1

the build runs cleanly when the EXE file extension is added to the mpy-cross reference

note:  Linux builds are unaffected because they do not rely on file extensions