### PR TITLE
stm32/mboot & pydfu USB vid and pid

### DIFF
--- a/ports/stm32/Makefile
+++ b/ports/stm32/Makefile
@@ -45,7 +45,8 @@ DFU=$(TOP)/tools/dfu.py
 USE_PYDFU ?= 1
 PYDFU ?= $(TOP)/tools/pydfu.py
 DFU_UTIL ?= dfu-util
-DEVICE=0483:df11
+BOOTLOADER_DFU_USB_VID ?= 0x0483
+BOOTLOADER_DFU_USB_PID ?= 0xDF11
 STFLASH ?= st-flash
 OPENOCD ?= openocd
 OPENOCD_CONFIG ?= boards/openocd_stm32f4.cfg
@@ -544,9 +545,9 @@ endif
 deploy: $(BUILD)/firmware.dfu
 	$(ECHO) "Writing $< to the board"
 ifeq ($(USE_PYDFU),1)
-	$(Q)$(PYTHON) $(PYDFU) -u $<
+	$(Q)$(PYTHON) $(PYDFU) --vid $(BOOTLOADER_DFU_USB_VID) --pid $(BOOTLOADER_DFU_USB_PID) -u $<
 else
-	$(Q)$(DFU_UTIL) -a 0 -d $(DEVICE) -D $<
+	$(Q)$(DFU_UTIL) -a 0 -d $(BOOTLOADER_DFU_USB_VID):$(BOOTLOADER_DFU_USB_PID) -D $<
 endif
 
 # A board should specify TEXT0_ADDR if to use a different location than the
@@ -570,7 +571,7 @@ deploy-openocd: $(BUILD)/firmware.dfu
 $(BUILD)/firmware.dfu: $(BUILD)/firmware.elf
 	$(ECHO) "Create $@"
 	$(Q)$(OBJCOPY) -O binary $(addprefix -j ,$(TEXT0_SECTIONS)) $^ $(BUILD)/firmware.bin
-	$(Q)$(PYTHON) $(DFU) -b $(TEXT0_ADDR):$(BUILD)/firmware.bin $@
+	$(Q)$(PYTHON) $(DFU) -D $(BOOTLOADER_DFU_USB_VID):$(BOOTLOADER_DFU_USB_PID) -b $(TEXT0_ADDR):$(BUILD)/firmware.bin $@
 
 else
 # TEXT0_ADDR and TEXT1_ADDR are specified so split firmware between these locations
@@ -592,7 +593,7 @@ $(BUILD)/firmware.dfu: $(BUILD)/firmware.elf
 	$(ECHO) "GEN $@"
 	$(Q)$(OBJCOPY) -O binary $(addprefix -j ,$(TEXT0_SECTIONS)) $^ $(BUILD)/firmware0.bin
 	$(Q)$(OBJCOPY) -O binary $(addprefix -j ,$(TEXT1_SECTIONS)) $^ $(BUILD)/firmware1.bin
-	$(Q)$(PYTHON) $(DFU) -b $(TEXT0_ADDR):$(BUILD)/firmware0.bin -b $(TEXT1_ADDR):$(BUILD)/firmware1.bin $@
+	$(Q)$(PYTHON) $(DFU) -D $(BOOTLOADER_DFU_USB_VID):$(BOOTLOADER_DFU_USB_PID) -b $(TEXT0_ADDR):$(BUILD)/firmware0.bin -b $(TEXT1_ADDR):$(BUILD)/firmware1.bin $@
 
 endif
 

--- a/ports/stm32/mboot/Makefile
+++ b/ports/stm32/mboot/Makefile
@@ -28,7 +28,6 @@ HAL_DIR=lib/stm32lib/STM32$(MCU_SERIES_UPPER)xx_HAL_Driver
 USBDEV_DIR=usbdev
 DFU=$(TOP)/tools/dfu.py
 PYDFU ?= $(TOP)/tools/pydfu.py
-DEVICE=0483:df11
 STFLASH ?= st-flash
 OPENOCD ?= openocd
 OPENOCD_CONFIG ?= boards/openocd_stm32f4.cfg
@@ -71,6 +70,10 @@ LIBS = $(shell $(CC) $(CFLAGS) -print-libgcc-file-name)
 # Remove uncalled code from the final image.
 CFLAGS += -fdata-sections -ffunction-sections
 LDFLAGS += --gc-sections
+
+BOOTLOADER_DFU_USB_VID ?= 0x0483
+BOOTLOADER_DFU_USB_PID ?= 0xDF11
+CFLAGS += -DBOOTLOADER_DFU_USB_VID=$(BOOTLOADER_DFU_USB_VID) -DBOOTLOADER_DFU_USB_PID=$(BOOTLOADER_DFU_USB_PID)
 
 # Debugging/Optimization
 ifeq ($(DEBUG), 1)

--- a/ports/stm32/mboot/main.c
+++ b/ports/stm32/mboot/main.c
@@ -1109,10 +1109,16 @@ typedef struct _pyb_usbdd_obj_t {
 #endif
 
 #ifndef MBOOT_USB_VID
+#ifdef BOOTLOADER_DFU_USB_VID
+#define MBOOT_USB_VID BOOTLOADER_DFU_USB_VID
+#else
 #define MBOOT_USB_VID 0x0483
 #endif
 
 #ifndef MBOOT_USB_PID
+#ifdef BOOTLOADER_DFU_USB_PID
+#define MBOOT_USB_PID BOOTLOADER_DFU_USB_PID
+#else
 #define MBOOT_USB_PID 0xDF11
 #endif
 


### PR DESCRIPTION
In mboot, the ability to override the usb vendor/product id's was added back in https://github.com/micropython/micropython/pull/4584

However, when the main firmware is turned into a dfu file the default vid/pid are used there. `pydfu` doesn't care about this but `dfu-util` does and prevents its use.

This PR exposes `MBOOT_USB_VID` and `MBOOT_USB_PID` as make variables, for use on either command line or `mpconfigboard.mk`, to set vid/pid in both mboot and dfu files