### PR TITLE
stm32/mboot: Allow overriding led_init and led_state in board folder.

### DIFF
--- a/ports/stm32/mboot/main.c
+++ b/ports/stm32/mboot/main.c
@@ -415,7 +415,7 @@ void mp_hal_pin_config_speed(uint32_t port_pin, uint32_t speed) {
 #define LED3 MICROPY_HW_LED4
 #endif
 
-void led_init(void) {
+MP_WEAK void led_init(void) {
     mp_hal_pin_output(LED0);
     mp_hal_pin_output(LED1);
     #ifdef LED2
@@ -426,7 +426,7 @@ void led_init(void) {
     #endif
 }
 
-void led_state(int led, int val) {
+MP_WEAK void led_state(int led, int val) {
     if (led == 1) {
         led = LED0;
     }


### PR DESCRIPTION
This PR simply adds the `__weak` decorator to `led_init()` and `led_state()` in mboot.
This allows for custom functions/logic to display mboot state on leds or other output devices.

On my custom hardware the user leds are on an expander chip, this change allows me to add a replacement of these two functions in a c file in the board folder to control the expander appropriately.