### PR TITLE
mpy-cross/Makefile: add OS detecting for building mpy-cross tool

### DIFF
--- a/mpy-cross/Makefile
+++ b/mpy-cross/Makefile
@@ -1,7 +1,12 @@
 include ../py/mkenv.mk
 
+ifeq ($(OS),Windows_NT)
+# define main target
+PROG = mpy-cross.exe
+else
 # define main target
 PROG = mpy-cross
+endif
 
 # qstr definitions (must come before including py.mk)
 QSTR_DEFS = qstrdefsport.h


### PR DESCRIPTION
add OS detecting for building mpy-cross tool itself too. test under github action runner here: [mpy-cross](https://github.com/ccccmagicboy/MicroPython_fw_action/actions/runs/49871075)