### PR TITLE
stm32/mboot: Error messages and invalid addresses

### DIFF
--- a/ports/stm32/mboot/dfu.h
+++ b/ports/stm32/mboot/dfu.h
@@ -1,0 +1,94 @@
+/*
+ * This file is part of the MicroPython project, http://micropython.org/
+ *
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2017-2019 Damien P. George
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#include <stdint.h>
+
+/******************************************************************************/
+// DFU
+// Spec: https://www.usb.org/sites/default/files/DFU_1.1.pdf
+
+#define DFU_XFER_SIZE (2048)
+
+//  DFU class requests
+enum {
+    DFU_DETACH = 0,
+    DFU_DNLOAD = 1,
+    DFU_UPLOAD = 2,
+    DFU_GETSTATUS = 3,
+    DFU_CLRSTATUS = 4,
+    DFU_GETSTATE = 5,
+    DFU_ABORT = 6,
+};
+
+// DFU States
+typedef enum {
+    DFU_STATE_IDLE = 2,
+    DFU_STATE_BUSY = 4,
+    DFU_STATE_DNLOAD_IDLE = 5,
+    DFU_STATE_MANIFEST = 7,
+    DFU_STATE_UPLOAD_IDLE = 9,
+    DFU_STATE_ERROR = 0xa,
+} dfu_states_t;
+
+typedef enum {
+    DFU_CMD_NONE = 0,
+    DFU_CMD_EXIT = 1,
+    DFU_CMD_UPLOAD = 7,
+    DFU_CMD_DNLOAD = 8,
+} dfu_cmd_t;
+
+// Error status flags
+typedef enum {
+    DFU_STATUS_OK = 0x00,  // No error condition is present.
+    DFU_STATUS_ERROR_TARGET = 0x01,  // File is not targeted for use by this device.
+    DFU_STATUS_ERROR_FILE = 0x02,  // File is for this device but fails some vendor-specific verification test.
+    DFU_STATUS_ERROR_WRITE = 0x03,  // Device is unable to write memory.
+    DFU_STATUS_ERROR_ERASE = 0x04,  // Memory erase function failed.
+    DFU_STATUS_ERROR_CHECK_ERASED = 0x05,  // Memory erase check failed.
+    DFU_STATUS_ERROR_PROG = 0x06,  // Program memory function failed.
+    DFU_STATUS_ERROR_VERIFY = 0x07,  // Programmed memory failed verification.
+    DFU_STATUS_ERROR_ADDRESS = 0x08,  // Cannot program memory due to received address that is out of range.
+    DFU_STATUS_ERROR_NOTDONE = 0x09,  // Received DFU_DNLOAD with wLength = 0, but device does not think it has all of the data yet.
+    DFU_STATUS_ERROR_FIRMWARE = 0x0A,  // Device's firmware is corrupt. It cannot return to run-time (non-DFU) operations.
+    DFU_STATUS_ERROR_VENDOR = 0x0B,  // iString indicates a vendor-specific error.
+    DFU_STATUS_ERROR_USBR = 0x0C,  // Device detected unexpected USB reset signaling.
+    DFU_STATUS_ERROR_POR = 0x0D,  // Device detected unexpected power on reset.
+    DFU_STATUS_ERROR_UNKNOWN = 0x0E,  // Something went wrong, but the device does not know what it was.
+    DFU_STATUS_ERROR_STALLEDPKT = 0x0F,  // Device stalled an unexpected request.
+} dfu_status_t;
+
+typedef struct _dfu_state_t {
+    dfu_states_t state;
+    dfu_cmd_t cmd;
+    dfu_status_t status;
+    uint8_t error;
+    uint16_t wBlockNum;
+    uint16_t wLength;
+    uint32_t addr;
+    uint8_t buf[DFU_XFER_SIZE] __attribute__((aligned(4)));
+} dfu_state_t;
+
+static dfu_state_t dfu_state SECTION_NOZERO_BSS;

--- a/ports/stm32/mboot/dfu.h
+++ b/ports/stm32/mboot/dfu.h
@@ -92,3 +92,10 @@ typedef struct _dfu_state_t {
 } dfu_state_t;
 
 static dfu_state_t dfu_state SECTION_NOZERO_BSS;
+
+// The DFU standard allows for error messages to be sent (via str index) in GETSTATUS responses
+#define MBOOT_ERROR_STR_OVERWRITE_BOOTLOADER_IDX 0x10
+#define MBOOT_ERROR_STR_OVERWRITE_BOOTLOADER "Can't overwrite mboot"
+
+#define MBOOT_ERROR_STR_INVALID_ADDRESS_IDX 0x11
+#define MBOOT_ERROR_STR_INVALID_ADDRESS "Address out of range"

--- a/ports/stm32/mboot/main.c
+++ b/ports/stm32/mboot/main.c
@@ -78,7 +78,6 @@
 #endif
 #endif
 
-
 // These bits are used to detect valid application firmware at APPLICATION_ADDR
 #define APP_VALIDITY_BITS (0x00000003)
 
@@ -527,6 +526,13 @@ static const flash_layout_t flash_layout[] = {
 
 #endif
 
+static inline bool addr_in_flash(uint32_t addr) {
+    uint8_t last = MP_ARRAY_SIZE(flash_layout)-1;
+    uint32_t end_of_flash = flash_layout[last].base_address + 
+            flash_layout[last].sector_count * flash_layout[last].sector_size;
+    return addr >= flash_layout[0].base_address && addr < end_of_flash;
+}
+
 static uint32_t flash_get_sector_index(uint32_t addr, uint32_t *sector_size) {
     if (addr >= flash_layout[0].base_address) {
         uint32_t sector_index = 0;
@@ -620,6 +626,8 @@ static int flash_page_erase(uint32_t addr, uint32_t *next_addr) {
 static int flash_write(uint32_t addr, const uint8_t *src8, size_t len) {
     if (addr >= flash_layout[0].base_address && addr < flash_layout[0].base_address + flash_layout[0].sector_size) {
         // Don't allow to write the sector with this bootloader in it
+        dfu_state.status = DFU_STATUS_ERROR_ADDRESS;
+        dfu_state.error = MBOOT_ERROR_STR_OVERWRITE_BOOTLOADER_IDX;
         return -1;
     }
 
@@ -733,7 +741,13 @@ int do_write(uint32_t addr, const uint8_t *src8, size_t len) {
     }
     #endif
 
-    return flash_write(addr, src8, len);
+    if (addr_in_flash(addr)) {
+        return flash_write(addr, src8, len);
+    }
+
+    dfu_state.status = DFU_STATUS_ERROR_ADDRESS;
+    dfu_state.error = MBOOT_ERROR_STR_INVALID_ADDRESS_IDX;
+    return -1;
 }
 
 /******************************************************************************/
@@ -910,6 +924,8 @@ uint8_t i2c_slave_process_tx_byte(void) {
 static void dfu_init(void) {
     dfu_state.state = DFU_STATE_IDLE;
     dfu_state.cmd = DFU_CMD_NONE;
+    dfu_state.status = DFU_STATUS_OK;
+    dfu_state.error = 0;
     dfu_state.addr = 0x08000000;
 }
 
@@ -1157,6 +1173,14 @@ static uint8_t *pyb_usbdd_StrDescriptor(USBD_HandleTypeDef *pdev, uint8_t idx, u
 
         case USBD_IDX_CONFIG_STR:
             USBD_GetString((uint8_t*)FLASH_LAYOUT_STR, str_desc, length);
+            return str_desc;
+
+        case MBOOT_ERROR_STR_OVERWRITE_BOOTLOADER_IDX:
+            USBD_GetString((uint8_t*)MBOOT_ERROR_STR_OVERWRITE_BOOTLOADER, str_desc, length);
+            return str_desc;
+
+        case MBOOT_ERROR_STR_INVALID_ADDRESS_IDX:
+            USBD_GetString((uint8_t*)MBOOT_ERROR_STR_INVALID_ADDRESS, str_desc, length);
             return str_desc;
 
         default:

--- a/tools/pydfu.py
+++ b/tools/pydfu.py
@@ -148,6 +148,13 @@ def clr_status():
 def get_status():
     """Get the status of the last operation."""
     stat = __dev.ctrl_transfer(0xA1, __DFU_GETSTATUS, 0, __DFU_INTERFACE, 6, 20000)
+
+    # firmware can provide an optional string for any error
+    if stat[5]:
+        message = get_string(__dev, stat[5])
+        if message:
+            print(message)
+
     return stat[4]
 
 


### PR DESCRIPTION
The DFU standard (https://www.usb.org/sites/default/files/DFU_1.1.pdf) allows for custom error messages to be sent back to the computer to better describe problems.

This PR adds further protection against writing to out-of-bounds areas from improper or unmatched dfu files as well as cleaning up some of the internal naming of dfu state/status flags.

I found that if mboot tried to flash a chunk of data to a a flash address just above the valid range the chip would hang forever. This is protected against in this change.

The error string handling is used to alert the user if an an out-of-range address is hit or if overwriting the first sector (mboot) is attempted.