### PR TITLE
stm32/mboot: Support mass erase dfu command

### DIFF
--- a/ports/stm32/flash.c
+++ b/ports/stm32/flash.c
@@ -151,7 +151,7 @@ bool flash_is_valid_addr(uint32_t addr) {
     return flash_layout[0].base_address <= addr && addr < end_of_flash;
 }
 
-uint32_t flash_get_sector_info(uint32_t addr, uint32_t *start_addr, uint32_t *size) {
+int32_t flash_get_sector_info(uint32_t addr, uint32_t *start_addr, uint32_t *size) {
     if (addr >= flash_layout[0].base_address) {
         uint32_t sector_index = 0;
         for (int i = 0; i < MP_ARRAY_SIZE(flash_layout); ++i) {
@@ -172,7 +172,7 @@ uint32_t flash_get_sector_info(uint32_t addr, uint32_t *start_addr, uint32_t *si
             }
         }
     }
-    return 0;
+    return -1;
 }
 
 int flash_erase(uint32_t flash_dest, uint32_t num_word32) {

--- a/ports/stm32/flash.h
+++ b/ports/stm32/flash.h
@@ -27,7 +27,7 @@
 #define MICROPY_INCLUDED_STM32_FLASH_H
 
 bool flash_is_valid_addr(uint32_t addr);
-uint32_t flash_get_sector_info(uint32_t addr, uint32_t *start_addr, uint32_t *size);
+int32_t flash_get_sector_info(uint32_t addr, uint32_t *start_addr, uint32_t *size);
 int flash_erase(uint32_t flash_dest, uint32_t num_word32);
 int flash_write(uint32_t flash_dest, const uint32_t *src, uint32_t num_word32);
 

--- a/ports/stm32/flashbdev.c
+++ b/ports/stm32/flashbdev.c
@@ -181,7 +181,7 @@ int32_t flash_bdev_ioctl(uint32_t op, uint32_t arg) {
 static uint8_t *flash_cache_get_addr_for_write(uint32_t flash_addr) {
     uint32_t flash_sector_start;
     uint32_t flash_sector_size;
-    uint32_t flash_sector_id = flash_get_sector_info(flash_addr, &flash_sector_start, &flash_sector_size);
+    int32_t flash_sector_id = flash_get_sector_info(flash_addr, &flash_sector_start, &flash_sector_size);
     if (flash_sector_size > FLASH_SECTOR_SIZE_MAX) {
         flash_sector_size = FLASH_SECTOR_SIZE_MAX;
     }
@@ -201,7 +201,7 @@ static uint8_t *flash_cache_get_addr_for_write(uint32_t flash_addr) {
 static uint8_t *flash_cache_get_addr_for_read(uint32_t flash_addr) {
     uint32_t flash_sector_start;
     uint32_t flash_sector_size;
-    uint32_t flash_sector_id = flash_get_sector_info(flash_addr, &flash_sector_start, &flash_sector_size);
+    int32_t flash_sector_id = flash_get_sector_info(flash_addr, &flash_sector_start, &flash_sector_size);
     if (flash_cache_sector_id == flash_sector_id) {
         // in cache, copy from there
         return (uint8_t *)CACHE_MEM_START_ADDR + flash_addr - flash_sector_start;

--- a/ports/stm32/mboot/dfu.h
+++ b/ports/stm32/mboot/dfu.h
@@ -67,6 +67,12 @@ typedef enum {
     DFU_CMD_DNLOAD = 8,
 } dfu_cmd_t;
 
+enum {
+    DFU_CMD_DNLOAD_SET_ADDRESS = 0x21,
+    DFU_CMD_DNLOAD_ERASE = 0x41,
+    DFU_CMD_DNLOAD_READ_UNPROTECT = 0x92,
+};
+
 // Error status flags
 typedef enum {
     DFU_STATUS_OK = 0x00,  // No error condition is present.

--- a/ports/stm32/mboot/main.c
+++ b/ports/stm32/mboot/main.c
@@ -440,6 +440,10 @@ static int usrbtn_state(void) {
 
 /******************************************************************************/
 // FLASH
+#if defined(STM32WB)
+#define FLASH_END FLASH_END_ADDR
+#endif
+#define APPLICATION_FLASH_LENGTH (FLASH_END + 1 - APPLICATION_ADDR)
 
 #ifndef MBOOT_SPIFLASH_LAYOUT
 #define MBOOT_SPIFLASH_LAYOUT ""
@@ -464,31 +468,33 @@ static int usrbtn_state(void) {
 #endif
 
 static int mboot_flash_mass_erase(void) {
-    // TODO
-    return -1;
+    // Erase all flash pages after mboot.
+    int ret = flash_erase(APPLICATION_ADDR, APPLICATION_FLASH_LENGTH / sizeof(uint32_t));
+    return ret;
 }
 
 static int mboot_flash_page_erase(uint32_t addr, uint32_t *next_addr) {
     uint32_t sector_size = 0;
-    uint32_t sector = flash_get_sector_info(addr, NULL, &sector_size);
-    if (sector == 0) {
-        // Don't allow to erase the sector with this bootloader in it
+    uint32_t sector_start = 0;
+    int32_t sector = flash_get_sector_info(addr, &sector_start, &sector_size);
+    if (sector <= 0) {
+        // Don't allow to erase the sector with this bootloader in it, or invalid sectors
         dfu_context.status = DFU_STATUS_ERROR_ADDRESS;
         dfu_context.error = MBOOT_ERROR_STR_OVERWRITE_BOOTLOADER_IDX;
         return -1;
     }
 
-    *next_addr = addr + sector_size;
+    *next_addr = sector_start + sector_size;
 
     // Erase the flash page.
-    int ret = flash_erase(addr, sector_size / sizeof(uint32_t));
+    int ret = flash_erase(sector_start, sector_size / sizeof(uint32_t));
     if (ret != 0) {
         return ret;
     }
 
     // Check the erase set bits to 1, at least for the first 256 bytes
     for (int i = 0; i < 64; ++i) {
-        if (((volatile uint32_t*)addr)[i] != 0xffffffff) {
+        if (((volatile uint32_t*)sector_start)[i] != 0xffffffff) {
             return -2;
         }
     }
@@ -523,7 +529,7 @@ static int mboot_flash_write(uint32_t addr, const uint8_t *src8, size_t len) {
 // Writable address space interface
 
 static int do_mass_erase(void) {
-    // TODO
+    // TODO spiflash erase ?
     return mboot_flash_mass_erase();
 }
 
@@ -791,20 +797,45 @@ static void dfu_init(void) {
     dfu_context.addr = 0x08000000;
 }
 
+// The DFU_GETSTATUS response before dfu_process_dnload is run should include the needed timeout adjustments
+static size_t get_timeout_ms() {
+    if (dfu_context.wBlockNum == 0) {
+        // download control commands
+        if (dfu_context.wLength >= 1 && dfu_context.buf[0] == DFU_CMD_DNLOAD_ERASE) {
+            if (dfu_context.wLength == 1) {
+                // mass erase command
+                // It takes 10-12 seconds to erase a 2MB stm part. Extrapolate a suitable timeout from this.
+                return APPLICATION_FLASH_LENGTH / 170;
+
+            } else if (dfu_context.wLength == 5) {
+                // erase page command
+                return 500;
+            }
+        }
+    } else if (dfu_context.wBlockNum > 1) {
+        // write data to memory command
+        return 500;
+    }
+    return 0;
+}
+
 static int dfu_process_dnload(void) {
     int ret = -1;
     if (dfu_context.wBlockNum == 0) {
         // download control commands
-        if (dfu_context.wLength >= 1 && dfu_context.buf[0] == 0x41) {
+        if (dfu_context.wLength >= 1 && dfu_context.buf[0] == DFU_CMD_DNLOAD_ERASE) {
             if (dfu_context.wLength == 1) {
                 // mass erase
                 ret = do_mass_erase();
+                if (ret != 0) {
+                    dfu_context.cmd = DFU_CMD_NONE;
+                }
             } else if (dfu_context.wLength == 5) {
                 // erase page
                 uint32_t next_addr;
                 ret = do_page_erase(get_le32(&dfu_context.buf[1]), &next_addr);
             }
-        } else if (dfu_context.wLength >= 1 && dfu_context.buf[0] == 0x21) {
+        } else if (dfu_context.wLength >= 1 && dfu_context.buf[0] == DFU_CMD_DNLOAD_SET_ADDRESS) {
             if (dfu_context.wLength == 5) {
                 // set address
                 dfu_context.addr = get_le32(&dfu_context.buf[1]);
@@ -888,12 +919,16 @@ static int dfu_handle_tx(int cmd, int arg, int len, uint8_t *buf, int max_len) {
             default:
                 dfu_context.state = DFU_STATE_BUSY;
         }
-        buf[0] = dfu_context.status; // bStatus
-        buf[1] = 0; // bwPollTimeout (ms)
-        buf[2] = 0; // bwPollTimeout (ms)
-        buf[3] = 0; // bwPollTimeout (ms)
-        buf[4] = dfu_context.state; // bState
-        buf[5] = dfu_context.error; // iString
+        size_t timeout_ms = get_timeout_ms();
+        buf[0] = dfu_context.status;          // bStatus
+        buf[1] = (timeout_ms >> 16) & 0xFF;   // bwPollTimeout (ms)
+        buf[2] = (timeout_ms >> 8) & 0xFF;    // bwPollTimeout (ms)
+        buf[3] = timeout_ms & 0xFF;           // bwPollTimeout (ms)
+        buf[4] = dfu_context.state;           // bState
+        buf[5] = dfu_context.error;           // iString
+        // Clear errors now they've been sent
+        dfu_context.status = DFU_STATUS_OK;
+        dfu_context.error = 0;
         return 6;
     }
     return -1;

--- a/ports/stm32/mboot/main.c
+++ b/ports/stm32/mboot/main.c
@@ -480,7 +480,8 @@ static int mboot_flash_page_erase(uint32_t addr, uint32_t *next_addr) {
     if (sector <= 0) {
         // Don't allow to erase the sector with this bootloader in it, or invalid sectors
         dfu_context.status = DFU_STATUS_ERROR_ADDRESS;
-        dfu_context.error = MBOOT_ERROR_STR_OVERWRITE_BOOTLOADER_IDX;
+        dfu_context.error = (sector == 0) ? MBOOT_ERROR_STR_OVERWRITE_BOOTLOADER_IDX
+                                          : MBOOT_ERROR_STR_INVALID_ADDRESS_IDX;
         return -1;
     }
 
@@ -503,11 +504,12 @@ static int mboot_flash_page_erase(uint32_t addr, uint32_t *next_addr) {
 }
 
 static int mboot_flash_write(uint32_t addr, const uint8_t *src8, size_t len) {
-    uint32_t sector = flash_get_sector_info(addr, NULL, NULL);
-    if (sector == 0) {
+    int32_t sector = flash_get_sector_info(addr, NULL, NULL);
+    if (sector <= 0) {
         // Don't allow to write the sector with this bootloader in it
         dfu_context.status = DFU_STATUS_ERROR_ADDRESS;
-        dfu_context.error = MBOOT_ERROR_STR_OVERWRITE_BOOTLOADER_IDX;
+        dfu_context.error = (sector == 0) ? MBOOT_ERROR_STR_OVERWRITE_BOOTLOADER_IDX
+                                          : MBOOT_ERROR_STR_INVALID_ADDRESS_IDX;
         return -1;
     }
 


### PR DESCRIPTION
The mass erase command is currently not implemented in mboot due to the desire to not wipe the bootloader itself.

This PR adds a 'fake' mass erase command which erased sector-by-sector everything except the first mboot sector.

This change was originally included as part of https://github.com/micropython/micropython/pull/5309 but I've split it out as it grew into a significantly larger change-set than originally anticipated.

The erase command can take some time, on my stm32f765 with 2MB of flash it takes 8 to 10 seconds. This is normally enough to make pydfu fail on a timeout.

The DFU standard includes a mechanism for the dfu device to request a longer timeout as part of the get-status response just before starting an operation. This timeout functionality has been implemented here.

This PR required / is sitting on top of https://github.com/micropython/micropython/pull/5724 and https://github.com/micropython/micropython/pull/5728 github doesn't have and PR stacking yet so  these PR's commits are at the bottom of this one. Only the last two commits are relevant directly to this.