### PR TITLE
py/objstr: remove duplicate % in error string

### DIFF
--- a/py/objstr.c
+++ b/py/objstr.c
@@ -1523,7 +1523,7 @@ STATIC mp_obj_t str_modulo_format(mp_obj_t pattern, size_t n_args, const mp_obj_
                     size_t slen;
                     const char *s = mp_obj_str_get_data(arg, &slen);
                     if (slen != 1) {
-                        mp_raise_TypeError("%%c needs int or char");
+                        mp_raise_TypeError("%c needs int or char");
                     }
                     mp_print_strn(&print, s, 1, flags, ' ', width);
                 } else if (arg_looks_integer(arg)) {


### PR DESCRIPTION
Fixes this output:

```
MicroPython v1.12-213-g8db5d2d1f-dirty on 2020-03-04; darwin version
Use Ctrl-D to exit, Ctrl-E for paste mode
>>> print('%c' % 'foo')
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
TypeError: %%c needs int or char
```
Expected:
```
Python 3.7.6 (default, Dec 30 2019, 19:38:28) 
[Clang 11.0.0 (clang-1100.0.33.16)] on darwin
Type "help", "copyright", "credits" or "license" for more information.
>>> print('%c' % 'foo')
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
TypeError: %c requires int or char
```
