### PR TITLE
tools/codeformat: eliminate need for sizeof fixup

### DIFF
--- a/py/mpz.h
+++ b/py/mpz.h
@@ -93,7 +93,7 @@ typedef int8_t mpz_dbl_dig_signed_t;
 typedef struct _mpz_t {
     size_t neg : 1;
     size_t fixed_dig : 1;
-    size_t alloc : 8 * sizeof(size_t) - 2;
+    size_t alloc : (8 * sizeof(size_t) - 2);
     size_t len;
     mpz_dig_t *dig;
 } mpz_t;

--- a/py/objfun.c
+++ b/py/objfun.c
@@ -188,7 +188,7 @@ STATIC void dump_args(const mp_obj_t *a, size_t sz) {
 // With this macro you can tune the maximum number of function state bytes
 // that will be allocated on the stack.  Any function that needs more
 // than this will try to use the heap, with fallback to stack allocation.
-#define VM_MAX_STATE_ON_STACK (11 * sizeof(mp_uint_t))
+#define VM_MAX_STATE_ON_STACK (sizeof(mp_uint_t) * 11)
 
 #define DECODE_CODESTATE_SIZE(bytecode, n_state_out_var, state_size_out_var) \
     { \

--- a/tools/codeformat.py
+++ b/tools/codeformat.py
@@ -70,10 +70,7 @@ C_EXTS = (
 PY_EXTS = (".py",)
 
 
-FIXUP_REPLACEMENTS = (
-    (re.compile("sizeof\(([a-z_]+)\) \*\(([a-z_]+)\)"), r"sizeof(\1) * (\2)"),
-    (re.compile("([0-9]+) \*sizeof"), r"\1 * sizeof"),
-)
+FIXUP_REPLACEMENTS = ((re.compile("sizeof\(([a-z_]+)\) \*\(([a-z_]+)\)"), r"sizeof(\1) * (\2)"),)
 
 
 def list_files(paths, exclusions=None, prefix=""):


### PR DESCRIPTION
This eliminates the need for the `sizeof` regex fixup by rearranging things a bit. All other bitfields already use the parentheses around expressions with `sizeof`, so one case is fixed by following this convention.

`VM_MAX_STATE_ON_STACK` is the only remaining problem and it can be worked around by changing the order of the operands.