### PR TITLE
extmod/modbluetooth: Change scan result's "connectable" to "adv_type".

### DIFF
--- a/docs/library/ubluetooth.rst
+++ b/docs/library/ubluetooth.rst
@@ -93,7 +93,7 @@ Event Handling
                 conn_handle, attr_handle = data
             elif event == _IRQ_SCAN_RESULT:
                 # A single scan result.
-                addr_type, addr, connectable, rssi, adv_data = data
+                addr_type, addr, adv_type, rssi, adv_data = data
             elif event == _IRQ_SCAN_COMPLETE:
                 # Scan duration finished or manually stopped.
                 pass
@@ -185,7 +185,15 @@ Observer Role (Scanner)
     interval and window are 1.28 seconds and 11.25 milliseconds respectively
     (background scanning).
 
-    For each scan result, the ``_IRQ_SCAN_RESULT`` event will be raised.
+    For each scan result the ``_IRQ_SCAN_RESULT`` event will be raised, with event
+    data ``(addr_type, addr, adv_type, rssi, adv_data)``.  ``adv_type`` values correspond
+    to the Bluetooth Specification:
+
+        * 0x00 - ADV_IND - connectable and scannable undirected advertising
+        * 0x01 - ADV_DIRECT_IND - connectable directed advertising
+        * 0x02 - ADV_SCAN_IND - scannable undirected advertising
+        * 0x03 - ADV_NONCONN_IND - non-connectable undirected advertising
+        * 0x04 - SCAN_RSP - scan response
 
     When scanning is stopped (either due to the duration finishing or when
     explicitly stopped), the ``_IRQ_SCAN_COMPLETE`` event will be raised.

--- a/extmod/btstack/modbluetooth_btstack.c
+++ b/extmod/btstack/modbluetooth_btstack.c
@@ -115,11 +115,9 @@ STATIC void btstack_packet_handler(uint8_t packet_type, uint16_t channel, uint8_
         int8_t rssi = gap_event_advertising_report_get_rssi(packet);
         uint8_t length = gap_event_advertising_report_get_data_length(packet);
         const uint8_t *data = gap_event_advertising_report_get_data(packet);
-        bool connectable = adv_event_type == 0 || adv_event_type == 1;
-        if (adv_event_type <= 2) {
-            mp_bluetooth_gap_on_scan_result(address_type, address, connectable, rssi, data, length);
-        } else if (adv_event_type == 4) {
-            // TODO: Scan response.
+        // Emit an event for all advertising types except SCAN_RSP.
+        if (adv_event_type < 4) {
+            mp_bluetooth_gap_on_scan_result(address_type, address, adv_event_type, rssi, data, length);
         }
     } else if (event_type == HCI_EVENT_DISCONNECTION_COMPLETE) {
         DEBUG_EVENT_printf("  --> hci disconnect complete\n");

--- a/extmod/modbluetooth.h
+++ b/extmod/modbluetooth.h
@@ -248,7 +248,7 @@ bool mp_bluetooth_gatts_on_read_request(uint16_t conn_handle, uint16_t value_han
 void mp_bluetooth_gap_on_scan_complete(void);
 
 // Notify modbluetooth of a scan result.
-void mp_bluetooth_gap_on_scan_result(uint8_t addr_type, const uint8_t *addr, bool connectable, const int8_t rssi, const uint8_t *data, size_t data_len);
+void mp_bluetooth_gap_on_scan_result(uint8_t addr_type, const uint8_t *addr, uint8_t adv_type, const int8_t rssi, const uint8_t *data, size_t data_len);
 
 // Notify modbluetooth that a service was found (either by discover-all, or discover-by-uuid).
 void mp_bluetooth_gattc_on_primary_service_result(uint16_t conn_handle, uint16_t start_handle, uint16_t end_handle, mp_obj_bluetooth_uuid_t *service_uuid);

--- a/extmod/nimble/modbluetooth_nimble.c
+++ b/extmod/nimble/modbluetooth_nimble.c
@@ -339,7 +339,14 @@ bool mp_bluetooth_is_active(void) {
 
 void mp_bluetooth_get_device_addr(uint8_t *addr) {
     #if MICROPY_PY_BLUETOOTH_RANDOM_ADDR
-    ble_hs_id_copy_addr(BLE_ADDR_RANDOM, addr, NULL);
+    uint8_t addr_le[6];
+    int rc = ble_hs_id_copy_addr(BLE_ADDR_RANDOM, addr_le, NULL);
+    if (rc != 0) {
+        // Even with MICROPY_PY_BLUETOOTH_RANDOM_ADDR enabled the public address may
+        // be used instead, in which case there is no random address.
+        ble_hs_id_copy_addr(BLE_ADDR_PUBLIC, addr_le, NULL);
+    }
+    reverse_addr_byte_order(addr, addr_le);
     #else
     mp_hal_get_mac(MP_HAL_MAC_BDADDR, addr);
     #endif

--- a/extmod/nimble/modbluetooth_nimble.c
+++ b/extmod/nimble/modbluetooth_nimble.c
@@ -634,16 +634,9 @@ STATIC int gap_scan_cb(struct ble_gap_event *event, void *arg) {
         return 0;
     }
 
-    if (event->disc.event_type == BLE_HCI_ADV_RPT_EVTYPE_ADV_IND || event->disc.event_type == BLE_HCI_ADV_RPT_EVTYPE_NONCONN_IND) {
-        bool connectable = event->disc.event_type == BLE_HCI_ADV_RPT_EVTYPE_ADV_IND;
-        uint8_t addr[6];
-        reverse_addr_byte_order(addr, event->disc.addr.val);
-        mp_bluetooth_gap_on_scan_result(event->disc.addr.type, addr, connectable, event->disc.rssi, event->disc.data, event->disc.length_data);
-    } else if (event->disc.event_type == BLE_HCI_ADV_RPT_EVTYPE_SCAN_RSP) {
-        // TODO
-    } else if (event->disc.event_type == BLE_HCI_ADV_RPT_EVTYPE_SCAN_IND) {
-        // TODO
-    }
+    uint8_t addr[6];
+    reverse_addr_byte_order(addr, event->disc.addr.val);
+    mp_bluetooth_gap_on_scan_result(event->disc.addr.type, addr, event->disc.event_type, event->disc.rssi, event->disc.data, event->disc.length_data);
 
     return 0;
 }

--- a/tests/multi_bluetooth/ble_gap_advertise.py
+++ b/tests/multi_bluetooth/ble_gap_advertise.py
@@ -11,34 +11,48 @@ ADV_TIME_S = 3
 
 def instance0():
     multitest.globals(BDADDR=ble.config("mac"))
-    print("gap_advertise(20_000)")
-    ble.gap_advertise(20_000, b"\x02\x01\x06\x04\xffMPY")
     multitest.next()
+
+    print("gap_advertise(100_000, connectable=False)")
+    ble.gap_advertise(100_000, b"\x02\x01\x06\x04\xffMPY", connectable=False)
     time.sleep(ADV_TIME_S)
+
+    print("gap_advertise(20_000, connectable=True)")
+    ble.gap_advertise(20_000, b"\x02\x01\x06\x04\xffMPY", connectable=True)
+    time.sleep(ADV_TIME_S)
+
     print("gap_advertise(None)")
     ble.gap_advertise(None)
+
     ble.active(0)
 
 
 def instance1():
     multitest.next()
     finished = False
+    adv_types = set()
     adv_data = None
 
     def irq(ev, data):
-        nonlocal finished, adv_data
+        nonlocal finished, adv_types, adv_data
         if ev == _IRQ_SCAN_RESULT:
             if data[1] == BDADDR:
-                adv_data = bytes(data[4])
+                adv_types.add(data[2])
+                if adv_data is None:
+                    adv_data = bytes(data[4])
+                else:
+                    if adv_data != data[4]:
+                        adv_data = "MISMATCH"
         elif ev == _IRQ_SCAN_COMPLETE:
             finished = True
 
     ble.config(rxbuf=2000)
     ble.irq(irq)
-    ble.gap_scan(ADV_TIME_S * 1000, 10000, 10000)
+    ble.gap_scan(2 * ADV_TIME_S * 1000, 10000, 10000)
     while not finished:
         machine.idle()
     ble.active(0)
+    print("adv_types:", sorted(adv_types))
     print("adv_data:", adv_data)
 
 

--- a/tests/multi_bluetooth/ble_gap_advertise.py.exp
+++ b/tests/multi_bluetooth/ble_gap_advertise.py.exp
@@ -1,5 +1,7 @@
 --- instance0 ---
-gap_advertise(20_000)
+gap_advertise(100_000, connectable=False)
+gap_advertise(20_000, connectable=True)
 gap_advertise(None)
 --- instance1 ---
+adv_types: [0, 2]
 adv_data: b'\x02\x01\x06\x04\xffMPY'


### PR DESCRIPTION
This PR changes the BLE `_IRQ_SCAN_RESULT` data from:
```
addr_type, addr, connectable, rssi, adv_data
```
to:
```
addr_type, addr, adv_type, rssi, adv_data
```
This allows `_IRQ_SCAN_RESULT` to handle all scan result types (not just connectable and non-connectable passive scans), and to distinguish between them using `adv_type` which is an integer taking values 0x00-0x04 per the BT spec (see change to docs in this PR).

This is a breaking change to the API, albeit a very minor one: the existing `connectable` value was a boolean and `True` now becomes 0x00, `False` becomes 0x02.

Docs are updated and a test added.

Tested with 2x PYBD, with both NimBLE and BTstack stacks.

TODO: test on esp32.

Fixes #5738.