### PR TITLE
all: Fix exception causes in 3 modules

### DIFF
--- a/drivers/display/lcd160cr.py
+++ b/drivers/display/lcd160cr.py
@@ -228,8 +228,8 @@ class LCD160CR:
     def set_uart_baudrate(self, baudrate):
         try:
             baudrate = _uart_baud_table[baudrate]
-        except KeyError:
-            raise ValueError("invalid baudrate")
+        except KeyError as e:
+            raise ValueError("invalid baudrate") from e
         self._fcmd2("<BBB", 0x18, baudrate)
 
     def set_startup_deco(self, value):

--- a/ports/stm32/mboot/mboot.py
+++ b/ports/stm32/mboot/mboot.py
@@ -28,8 +28,8 @@ class Bootloader:
         self.buf1 = bytearray(1)
         try:
             self.i2c.writeto(addr, b"")
-        except OSError:
-            raise Exception("no I2C mboot device found")
+        except OSError as e:
+            raise Exception("no I2C mboot device found") from e
 
     def wait_response(self):
         start = time.ticks_ms()

--- a/tools/makemanifest.py
+++ b/tools/makemanifest.py
@@ -149,9 +149,9 @@ def get_timestamp(path, default=None):
     try:
         stat = os.stat(path)
         return stat.st_mtime
-    except OSError:
+    except OSError as e:
         if default is None:
-            raise FreezeError("cannot stat {}".format(path))
+            raise FreezeError("cannot stat {}".format(path)) from e
         return default
 
 


### PR DESCRIPTION
The mistake is this: In some parts of the code, an exception is being caught and replaced with a more user-friendly error. In these cases the syntax `raise new_error from old_error` needs to be used.

Python 3's exception chaining means it shows not only the traceback of the current exception, but that of the original exception (and possibly more.) This is regardless of `raise from`. The usage of `raise from` tells Python to put a more accurate message between the tracebacks. Instead of this:

```
During handling of the above exception, another exception occurred:
```

You'll get this:

```
The above exception was the direct cause of the following exception:
```

The first is inaccurate, because it signifies a bug in the exception-handling code itself, which is a separate situation than wrapping an exception.

Let me know what you think!