### PR TITLE
zephyr: Move Sensor class into zephyr module.

### DIFF
--- a/ports/zephyr/Makefile
+++ b/ports/zephyr/Makefile
@@ -46,11 +46,11 @@ SRC_C = main.c \
 	modusocket.c \
 	modutime.c \
 	modzephyr.c \
-	modzsensor.c \
 	modmachine.c \
 	machine_i2c.c \
 	machine_pin.c \
 	uart_core.c \
+	zephyr_sensor.c \
 	zephyr_storage.c \
 	lib/timeutils/timeutils.c \
 	lib/utils/stdout_helpers.c \

--- a/ports/zephyr/modzephyr.c
+++ b/ports/zephyr/modzephyr.c
@@ -97,6 +97,9 @@ STATIC const mp_rom_map_elem_t mp_module_time_globals_table[] = {
     #ifdef CONFIG_FLASH_MAP
     { MP_ROM_QSTR(MP_QSTR_FlashArea), MP_ROM_PTR(&zephyr_flash_area_type) },
     #endif
+    #ifdef CONFIG_SENSOR
+    { MP_ROM_QSTR(MP_QSTR_Sensor), MP_ROM_PTR(&zephyr_sensor_type) },
+    #endif
 };
 
 STATIC MP_DEFINE_CONST_DICT(mp_module_time_globals, mp_module_time_globals_table);

--- a/ports/zephyr/modzephyr.h
+++ b/ports/zephyr/modzephyr.h
@@ -37,4 +37,8 @@ extern const mp_obj_type_t zephyr_disk_access_type;
 extern const mp_obj_type_t zephyr_flash_area_type;
 #endif
 
+#ifdef CONFIG_SENSOR
+extern const mp_obj_type_t zephyr_sensor_type;
+#endif
+
 #endif // MICROPY_INCLUDED_ZEPHYR_MODZEPHYR_H

--- a/ports/zephyr/mpconfigport.h
+++ b/ports/zephyr/mpconfigport.h
@@ -76,7 +76,6 @@
 #define MICROPY_PY_UTIME            (1)
 #define MICROPY_PY_UTIME_MP_HAL     (1)
 #define MICROPY_PY_ZEPHYR           (1)
-#define MICROPY_PY_ZSENSOR          (1)
 #define MICROPY_PY_SYS_MODULES      (0)
 #define MICROPY_LONGINT_IMPL (MICROPY_LONGINT_IMPL_LONGLONG)
 #define MICROPY_FLOAT_IMPL (MICROPY_FLOAT_IMPL_FLOAT)
@@ -126,7 +125,6 @@ extern const struct _mp_obj_module_t mp_module_time;
 extern const struct _mp_obj_module_t mp_module_uos;
 extern const struct _mp_obj_module_t mp_module_usocket;
 extern const struct _mp_obj_module_t mp_module_zephyr;
-extern const struct _mp_obj_module_t mp_module_zsensor;
 
 #if MICROPY_PY_UOS
 #define MICROPY_PY_UOS_DEF { MP_ROM_QSTR(MP_QSTR_uos), MP_ROM_PTR(&mp_module_uos) },
@@ -152,19 +150,12 @@ extern const struct _mp_obj_module_t mp_module_zsensor;
 #define MICROPY_PY_ZEPHYR_DEF
 #endif
 
-#if MICROPY_PY_ZSENSOR
-#define MICROPY_PY_ZSENSOR_DEF { MP_ROM_QSTR(MP_QSTR_zsensor), MP_ROM_PTR(&mp_module_zsensor) },
-#else
-#define MICROPY_PY_ZSENSOR_DEF
-#endif
-
 #define MICROPY_PORT_BUILTIN_MODULES \
     { MP_ROM_QSTR(MP_QSTR_machine), MP_ROM_PTR(&mp_module_machine) }, \
     MICROPY_PY_UOS_DEF \
     MICROPY_PY_USOCKET_DEF \
     MICROPY_PY_UTIME_DEF \
     MICROPY_PY_ZEPHYR_DEF \
-    MICROPY_PY_ZSENSOR_DEF \
 
 // extra built in names to add to the global namespace
 #define MICROPY_PORT_BUILTINS \

--- a/ports/zephyr/zephyr_sensor.c
+++ b/ports/zephyr/zephyr_sensor.c
@@ -26,12 +26,13 @@
 
 #include <string.h>
 
+#include "modzephyr.h"
 #include "py/runtime.h"
 
 #include <zephyr.h>
 #include <drivers/sensor.h>
 
-#if MICROPY_PY_ZSENSOR
+#ifdef CONFIG_SENSOR
 
 typedef struct _mp_obj_sensor_t {
     mp_obj_base_t base;
@@ -102,20 +103,6 @@ STATIC const mp_rom_map_elem_t sensor_locals_dict_table[] = {
     { MP_ROM_QSTR(MP_QSTR_get_micros), MP_ROM_PTR(&sensor_get_micros_obj) },
     { MP_ROM_QSTR(MP_QSTR_get_millis), MP_ROM_PTR(&sensor_get_millis_obj) },
     { MP_ROM_QSTR(MP_QSTR_get_int), MP_ROM_PTR(&sensor_get_int_obj) },
-};
-
-STATIC MP_DEFINE_CONST_DICT(sensor_locals_dict, sensor_locals_dict_table);
-
-STATIC const mp_obj_type_t sensor_type = {
-    { &mp_type_type },
-    .name = MP_QSTR_Sensor,
-    .make_new = sensor_make_new,
-    .locals_dict = (void *)&sensor_locals_dict,
-};
-
-STATIC const mp_rom_map_elem_t mp_module_zsensor_globals_table[] = {
-    { MP_ROM_QSTR(MP_QSTR___name__), MP_ROM_QSTR(MP_QSTR_zsensor) },
-    { MP_ROM_QSTR(MP_QSTR_Sensor), MP_ROM_PTR(&sensor_type) },
 
 #define C(name) { MP_ROM_QSTR(MP_QSTR_##name), MP_ROM_INT(SENSOR_CHAN_##name) }
     C(ACCEL_X),
@@ -136,11 +123,13 @@ STATIC const mp_rom_map_elem_t mp_module_zsensor_globals_table[] = {
 #undef C
 };
 
-STATIC MP_DEFINE_CONST_DICT(mp_module_zsensor_globals, mp_module_zsensor_globals_table);
+STATIC MP_DEFINE_CONST_DICT(sensor_locals_dict, sensor_locals_dict_table);
 
-const mp_obj_module_t mp_module_zsensor = {
-    .base = { &mp_type_module },
-    .globals = (mp_obj_dict_t *)&mp_module_zsensor_globals,
+const mp_obj_type_t zephyr_sensor_type = {
+    { &mp_type_type },
+    .name = MP_QSTR_Sensor,
+    .make_new = sensor_make_new,
+    .locals_dict = (void *)&sensor_locals_dict,
 };
 
-#endif //MICROPY_PY_UHASHLIB
+#endif // CONFIG_SENSOR


### PR DESCRIPTION
Moves the Sensor class from the zsensor module to the zephyr module to
keep it together with other port-specific classes. This makes the zephyr
module more like the pyb module in other ports. Removes the now-empty
zsensor module.

Tested on the frdm_k64f board with the fxos8700
accelerometer/magnetometer sensor.