### PR TITLE
extmod/modlwip: Properly handle non-blocking and timeout on UDP recv.

### DIFF
--- a/tests/extmod/usocket_udp_nonblock.py
+++ b/tests/extmod/usocket_udp_nonblock.py
@@ -1,0 +1,20 @@
+# test non-blocking UDP sockets
+
+try:
+    import usocket as socket, uerrno as errno
+except ImportError:
+    try:
+        import socket, errno
+    except ImportError:
+        print("SKIP")
+        raise SystemExit
+
+
+s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+s.bind(socket.getaddrinfo('127.0.0.1', 8000)[0][-1])
+s.settimeout(0)
+
+try:
+    s.recv(1)
+except OSError as er:
+    print('EAGAIN:', er.args[0] == errno.EAGAIN)


### PR DESCRIPTION
Fixes UDP non-blocking recv so it returns EAGAIN instead of ETIMEDOUT.  Timeout waiting for incoming data is also improved by replacing 100ms delay with poll_sockets(), as is done in other parts of this module.

Fixes issue #5759.