### PR TITLE
accurate float int printing

### DIFF
--- a/py/formatfloat.c
+++ b/py/formatfloat.c
@@ -173,6 +173,7 @@ int mp_format_float(FPTYPE f, char *buf, size_t buf_size, char fmt, int prec, ch
     int num_digits = 0;
     const FPTYPE *pos_pow = g_pos_pow;
     const FPTYPE *neg_pow = g_neg_pow;
+    FPTYPE foriginal = f;
 
     if (fp_iszero(f)) {
         e = 0;
@@ -337,7 +338,24 @@ int mp_format_float(FPTYPE f, char *buf, size_t buf_size, char fmt, int prec, ch
     }
 
     // Print the digits of the mantissa
-    for (int i = 0; i < num_digits; ++i, --dec) {
+    int i = 0;
+    if ((fmt == 'f') && (dec >= 0)) { // handle with the integer part separately to avoid rounding errors
+        f = foriginal;
+        int32_t d = (int32_t)f;
+        f -= (FPTYPE)d;
+        f *= FPCONST(10.0);
+        s += dec;
+        while (i <= dec) {
+            *s-- = '0' + (d%10);
+            d /= 10;
+            i++;
+        }
+        s += i+1;
+        if (prec > 0)
+            *s++ = '.';
+        dec = -1;
+    }
+    for (; i < num_digits; ++i, --dec) {
         int32_t d = (int32_t)f;
         if (d < 0) {
             *s++ = '0';


### PR DESCRIPTION
This is to fix issue #4212 with the minimum change possible.

It has to store a copy of the input float value before it gets divided out by powers of 10, but it runs slightly faster with this benchmark:

```Python
t0 = time.ticks_us();  max(str(float(x))  for x in range(500000, 510000));  (time.ticks_us()-t0)*1e-6
```
* New 10.1633 seconds
* Original: 10.84897 seconds

This is because the implementation from @dhylands  [https://github.com/dhylands/format-float](format-float) does a floating point multiplication (by ten) for each digit, and my fix deals with the integer part of the number using only integer arithmetic.  


*I think there is scope for an overall faster implementation just using int32 arithmetic, but one would have to start by decoding the bit layout of the float into its mantissa and exponent, rather than interacting with value using normal arithmetic functions that do not depend on its encoding -- but since MicroPython is already bit packing and unpacking these values, this wouldn't make it any more dependent.*

*One advantage of any float32 format conversion is it's possible to exhaustively test every single combination of bits (there's only 4 billion of them) in just a few hours.*