### PR TITLE
tree-wide: fix implicit casts

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -212,6 +212,8 @@ jobs:
         - make ${MAKEOPTS} -C ports/unix
         # OSX has poor time resolution and the following tests do not have the correct output
         - (cd tests && ./run-tests --exclude 'uasyncio_(basic|heaplock|lock|wait_task)')
+        # check for additional compiler errors/warnings
+        - make ${MAKEOPTS} -C ports/unix VARIANT=coverage
       after_failure:
         - (cd tests && for exp in *.exp; do testbase=$(basename $exp .exp); echo -e "\nFAILURE $testbase"; diff -u $testbase.exp $testbase.out; done)
 

--- a/extmod/moductypes.c
+++ b/extmod/moductypes.c
@@ -360,9 +360,9 @@ STATIC mp_obj_t get_aligned(uint val_type, void *p, mp_int_t index) {
             return mp_obj_new_int_from_ll(((int64_t *)p)[index]);
         #if MICROPY_PY_BUILTINS_FLOAT
         case FLOAT32:
-            return mp_obj_new_float(((float *)p)[index]);
+            return mp_obj_new_float((mp_float_t)((float *)p)[index]);
         case FLOAT64:
-            return mp_obj_new_float(((double *)p)[index]);
+            return mp_obj_new_float((mp_float_t)((double *)p)[index]);
         #endif
         default:
             assert(0);

--- a/ports/unix/modffi.c
+++ b/ports/unix/modffi.c
@@ -167,11 +167,11 @@ STATIC mp_obj_t return_ffi_value(ffi_arg val, char type) {
             union { ffi_arg ffi;
                     float flt;
             } val_union = { .ffi = val };
-            return mp_obj_new_float(val_union.flt);
+            return mp_obj_new_float((mp_float_t)val_union.flt);
         }
         case 'd': {
             double *p = (double *)&val;
-            return mp_obj_new_float(*p);
+            return mp_obj_new_float((mp_float_t)*p);
         }
         #endif
         case 'O':

--- a/ports/unix/modtime.c
+++ b/ports/unix/modtime.c
@@ -61,7 +61,7 @@ static inline int msec_sleep_tv(struct timeval *tv) {
 #endif
 
 #if defined(MP_CLOCKS_PER_SEC)
-#define CLOCK_DIV (MP_CLOCKS_PER_SEC / 1000.0F)
+#define CLOCK_DIV (MP_CLOCKS_PER_SEC / MICROPY_FLOAT_CONST(1000.0))
 #else
 #error Unsupported clock() implementation
 #endif
@@ -84,7 +84,7 @@ STATIC mp_obj_t mod_time_clock(void) {
     // float cannot represent full range of int32 precisely, so we pre-divide
     // int to reduce resolution, and then actually do float division hoping
     // to preserve integer part resolution.
-    return mp_obj_new_float((float)(clock() / 1000) / CLOCK_DIV);
+    return mp_obj_new_float((mp_float_t)(clock() / 1000) / CLOCK_DIV);
     #else
     return mp_obj_new_int((mp_int_t)clock());
     #endif

--- a/py/binary.c
+++ b/py/binary.c
@@ -176,9 +176,9 @@ mp_obj_t mp_binary_get_val_array(char typecode, void *p, size_t index) {
         #endif
         #if MICROPY_PY_BUILTINS_FLOAT
         case 'f':
-            return mp_obj_new_float(((float *)p)[index]);
+            return mp_obj_new_float((mp_float_t)((float *)p)[index]);
         case 'd':
-            return mp_obj_new_float(((double *)p)[index]);
+            return mp_obj_new_float((mp_float_t)((double *)p)[index]);
         #endif
         // Extension to CPython: array of objects
         case 'O':
@@ -244,12 +244,12 @@ mp_obj_t mp_binary_get_val(char struct_type, char val_type, byte *p_base, byte *
         union { uint32_t i;
                 float f;
         } fpu = {val};
-        return mp_obj_new_float(fpu.f);
+        return mp_obj_new_float((mp_float_t)fpu.f);
     } else if (val_type == 'd') {
         union { uint64_t i;
                 double f;
         } fpu = {val};
-        return mp_obj_new_float(fpu.f);
+        return mp_obj_new_float((mp_float_t)fpu.f);
     #endif
     } else if (is_signed(val_type)) {
         if ((long long)MP_SMALL_INT_MIN <= val && val <= (long long)MP_SMALL_INT_MAX) {

--- a/py/objarray.c
+++ b/py/objarray.c
@@ -445,7 +445,7 @@ STATIC mp_obj_t array_subscr(mp_obj_t self_in, mp_obj_t index_in, mp_obj_t value
                 }
                 #endif
                 if (len_adj > 0) {
-                    if (len_adj > o->free) {
+                    if ((size_t)len_adj > o->free) {
                         // TODO: alloc policy; at the moment we go conservative
                         o->items = m_renew(byte, o->items, (o->len + o->free) * item_sz, (o->len + len_adj) * item_sz);
                         o->free = len_adj;

--- a/py/parsenum.c
+++ b/py/parsenum.c
@@ -218,7 +218,7 @@ mp_obj_t mp_parse_num_decimal(const char *str, size_t len, bool allow_imag, bool
         if (str + 2 < top && (str[1] | 0x20) == 'n' && (str[2] | 0x20) == 'f') {
             // inf
             str += 3;
-            dec_val = INFINITY;
+            dec_val = (mp_float_t)INFINITY;
             if (str + 4 < top && (str[0] | 0x20) == 'i' && (str[1] | 0x20) == 'n' && (str[2] | 0x20) == 'i' && (str[3] | 0x20) == 't' && (str[4] | 0x20) == 'y') {
                 // infinity
                 str += 5;


### PR DESCRIPTION
These were found by building the unix coverage variant on macOS (so clang compiler). Mostly, these are fixing implicit cast of float/double to mp_float_t which is one of those two and one mp_int_t to size_t fix for good measure.