### PR TITLE
windows/msvc: Fix warnings regarding function declarations

### DIFF
--- a/ports/unix/modos.c
+++ b/ports/unix/modos.c
@@ -33,6 +33,9 @@
 #include <stdlib.h>
 #include <string.h>
 #include <dirent.h>
+#ifdef _MSC_VER
+#include <direct.h> // For mkdir
+#endif
 #include "py/mpconfig.h"
 
 #include "py/runtime.h"

--- a/ports/windows/msvc/common.props
+++ b/ports/windows/msvc/common.props
@@ -13,7 +13,7 @@
   <ItemDefinitionGroup>
     <ClCompile>
       <AdditionalIncludeDirectories>$(PyIncDirs);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-      <PreprocessorDefinitions>_USE_MATH_DEFINES;_CRT_SECURE_NO_WARNINGS;_MBCS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>_USE_MATH_DEFINES;_CRT_SECURE_NO_WARNINGS;_CRT_NONSTDC_NO_WARNINGS;_MBCS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <SDLCheck>false</SDLCheck>
       <WarningLevel>Level1</WarningLevel>
       <ExceptionHandling>false</ExceptionHandling>

--- a/ports/windows/msvc/sys/time.h
+++ b/ports/windows/msvc/sys/time.h
@@ -29,4 +29,6 @@
 // Get the definitions for timeval etc
 #include <Winsock2.h>
 
+int gettimeofday(struct timeval *tp, struct timezone *tz);
+
 #endif // MICROPY_INCLUDED_WINDOWS_MSVC_SYS_TIME_H


### PR DESCRIPTION
Fix missing mkdir and gettimeofday declarations, then silence
msvc-specific compiler warning C4996
'The POSIX name for this item is deprecated'.

This is working towards getting everything compiled with msvc at a higher warning level