### PR TITLE
all: Remove spaces between nested paren and inside function arg paren.

### DIFF
--- a/ports/cc3200/main.c
+++ b/ports/cc3200/main.c
@@ -100,9 +100,9 @@ int main (void) {
 }
 
 // We need this when configSUPPORT_STATIC_ALLOCATION is enabled
-void vApplicationGetIdleTaskMemory( StaticTask_t **ppxIdleTaskTCBBuffer,
+void vApplicationGetIdleTaskMemory(StaticTask_t **ppxIdleTaskTCBBuffer,
     StackType_t **ppxIdleTaskStackBuffer,
-    uint32_t *pulIdleTaskStackSize ) {
+    uint32_t *pulIdleTaskStackSize) {
     *ppxIdleTaskTCBBuffer = &xIdleTaskTCB;
     *ppxIdleTaskStackBuffer = uxIdleTaskStack;
     *pulIdleTaskStackSize = configMINIMAL_STACK_SIZE;

--- a/ports/esp32/machine_rtc.c
+++ b/ports/esp32/machine_rtc.c
@@ -156,7 +156,7 @@ STATIC mp_obj_t machine_rtc_memory(mp_uint_t n_args, const mp_obj_t *args) {
         if (bufinfo.len > MICROPY_HW_RTC_USER_MEM_MAX) {
             mp_raise_ValueError("buffer too long");
         }
-        memcpy( (char *) rtc_user_mem_data, (char *) bufinfo.buf, bufinfo.len);
+        memcpy((char *) rtc_user_mem_data, (char *) bufinfo.buf, bufinfo.len);
         rtc_user_mem_len = bufinfo.len;
         return mp_const_none;
     }

--- a/ports/esp32/machine_sdcard.c
+++ b/ports/esp32/machine_sdcard.c
@@ -309,7 +309,7 @@ STATIC mp_obj_t machine_sdcard_readblocks(mp_obj_t self_in, mp_obj_t block_num, 
     }
 
     mp_get_buffer_raise(buf, &bufinfo, MP_BUFFER_WRITE);
-    err = sdmmc_read_sectors(&(self->card), bufinfo.buf, mp_obj_get_int(block_num), bufinfo.len / _SECTOR_SIZE(self) );
+    err = sdmmc_read_sectors(&(self->card), bufinfo.buf, mp_obj_get_int(block_num), bufinfo.len / _SECTOR_SIZE(self));
 
     return mp_obj_new_bool(err == ESP_OK);
 }
@@ -326,7 +326,7 @@ STATIC mp_obj_t machine_sdcard_writeblocks(mp_obj_t self_in, mp_obj_t block_num,
     }
 
     mp_get_buffer_raise(buf, &bufinfo, MP_BUFFER_READ);
-    err = sdmmc_write_sectors(&(self->card), bufinfo.buf, mp_obj_get_int(block_num), bufinfo.len / _SECTOR_SIZE(self) );
+    err = sdmmc_write_sectors(&(self->card), bufinfo.buf, mp_obj_get_int(block_num), bufinfo.len / _SECTOR_SIZE(self));
 
     return mp_obj_new_bool(err == ESP_OK);
 }

--- a/ports/esp32/modnetwork.c
+++ b/ports/esp32/modnetwork.c
@@ -98,7 +98,7 @@ NORETURN void _esp_exceptions(esp_err_t e) {
         case ESP_ERR_TCPIP_ADAPTER_NO_MEM:
             mp_raise_OSError(MP_ENOMEM);
         default:
-            mp_raise_msg_varg( &mp_type_RuntimeError, "Wifi Unknown Error 0x%04x", e);
+            mp_raise_msg_varg(&mp_type_RuntimeError, "Wifi Unknown Error 0x%04x", e);
     }
 }
 
@@ -250,8 +250,8 @@ STATIC mp_obj_t get_wlan(size_t n_args, const mp_obj_t *args) {
     if (!initialized) {
         wifi_init_config_t cfg = WIFI_INIT_CONFIG_DEFAULT();
         ESP_LOGD("modnetwork", "Initializing WiFi");
-        ESP_EXCEPTIONS( esp_wifi_init(&cfg) );
-        ESP_EXCEPTIONS( esp_wifi_set_storage(WIFI_STORAGE_RAM) );
+        ESP_EXCEPTIONS(esp_wifi_init(&cfg));
+        ESP_EXCEPTIONS(esp_wifi_set_storage(WIFI_STORAGE_RAM));
         ESP_LOGD("modnetwork", "Initialized");
         initialized = 1;
     }
@@ -273,7 +273,7 @@ STATIC mp_obj_t esp_initialize() {
         ESP_LOGD("modnetwork", "Initializing TCP/IP");
         tcpip_adapter_init();
         ESP_LOGD("modnetwork", "Initializing Event Loop");
-        ESP_EXCEPTIONS( esp_event_loop_init(event_handler, NULL) );
+        ESP_EXCEPTIONS(esp_event_loop_init(event_handler, NULL));
         ESP_LOGD("modnetwork", "esp_event_loop_init done");
         initialized = 1;
     }
@@ -353,12 +353,12 @@ STATIC mp_obj_t esp_connect(size_t n_args, const mp_obj_t *pos_args, mp_map_t *k
             wifi_sta_config.sta.bssid_set = 1;
             memcpy(wifi_sta_config.sta.bssid, p, sizeof(wifi_sta_config.sta.bssid));
         }
-        ESP_EXCEPTIONS( esp_wifi_set_config(ESP_IF_WIFI_STA, &wifi_sta_config) );
+        ESP_EXCEPTIONS(esp_wifi_set_config(ESP_IF_WIFI_STA, &wifi_sta_config));
     }
 
     // connect to the WiFi AP
     MP_THREAD_GIL_EXIT();
-    ESP_EXCEPTIONS( esp_wifi_connect() );
+    ESP_EXCEPTIONS(esp_wifi_connect());
     MP_THREAD_GIL_ENTER();
     wifi_sta_connect_requested = true;
 
@@ -368,7 +368,7 @@ STATIC MP_DEFINE_CONST_FUN_OBJ_KW(esp_connect_obj, 1, esp_connect);
 
 STATIC mp_obj_t esp_disconnect(mp_obj_t self_in) {
     wifi_sta_connect_requested = false;
-    ESP_EXCEPTIONS( esp_wifi_disconnect() );
+    ESP_EXCEPTIONS(esp_wifi_disconnect());
     return mp_const_none;
 }
 
@@ -452,9 +452,9 @@ STATIC mp_obj_t esp_scan(mp_obj_t self_in) {
     MP_THREAD_GIL_ENTER();
     if (status == 0) {
         uint16_t count = 0;
-        ESP_EXCEPTIONS( esp_wifi_scan_get_ap_num(&count) );
+        ESP_EXCEPTIONS(esp_wifi_scan_get_ap_num(&count));
         wifi_ap_record_t *wifi_ap_records = calloc(count, sizeof(wifi_ap_record_t));
-        ESP_EXCEPTIONS( esp_wifi_scan_get_ap_records(&count, wifi_ap_records) );
+        ESP_EXCEPTIONS(esp_wifi_scan_get_ap_records(&count, wifi_ap_records));
         for (uint16_t i = 0; i < count; i++) {
             mp_obj_tuple_t *t = mp_obj_new_tuple(6, NULL);
             uint8_t *x = memchr(wifi_ap_records[i].ssid, 0, sizeof(wifi_ap_records[i].ssid));

--- a/ports/esp8266/esppwm.c
+++ b/ports/esp8266/esppwm.c
@@ -108,7 +108,7 @@ pwm_insert_sort(struct pwm_single_param pwm[], uint8 n) {
 STATIC volatile uint8 critical = 0;
 
 #define LOCK_PWM(c)  do {                       \
-        while ( (c) == 1);                            \
+        while ((c) == 1);                            \
         (c) = 1;                                    \
 } while (0)
 

--- a/ports/esp8266/uart_register.h
+++ b/ports/esp8266/uart_register.h
@@ -6,14 +6,14 @@
 
 #ifndef UART_REGISTER_H_INCLUDED
 #define UART_REGISTER_H_INCLUDED
-#define REG_UART_BASE( i )  (0x60000000 + (i) * 0xf00)
+#define REG_UART_BASE(i)  (0x60000000 + (i) * 0xf00)
 //version value:32'h062000
 
-#define UART_FIFO( i )                          (REG_UART_BASE( i ) + 0x0)
+#define UART_FIFO(i)                          (REG_UART_BASE(i) + 0x0)
 #define UART_RXFIFO_RD_BYTE 0x000000FF
 #define UART_RXFIFO_RD_BYTE_S 0
 
-#define UART_INT_RAW( i )                       (REG_UART_BASE( i ) + 0x4)
+#define UART_INT_RAW(i)                       (REG_UART_BASE(i) + 0x4)
 #define UART_RXFIFO_TOUT_INT_RAW (BIT(8))
 #define UART_BRK_DET_INT_RAW (BIT(7))
 #define UART_CTS_CHG_INT_RAW (BIT(6))
@@ -24,7 +24,7 @@
 #define UART_TXFIFO_EMPTY_INT_RAW (BIT(1))
 #define UART_RXFIFO_FULL_INT_RAW (BIT(0))
 
-#define UART_INT_ST( i )                        (REG_UART_BASE( i ) + 0x8)
+#define UART_INT_ST(i)                        (REG_UART_BASE(i) + 0x8)
 #define UART_RXFIFO_TOUT_INT_ST (BIT(8))
 #define UART_BRK_DET_INT_ST (BIT(7))
 #define UART_CTS_CHG_INT_ST (BIT(6))
@@ -35,7 +35,7 @@
 #define UART_TXFIFO_EMPTY_INT_ST (BIT(1))
 #define UART_RXFIFO_FULL_INT_ST (BIT(0))
 
-#define UART_INT_ENA( i )                       (REG_UART_BASE( i ) + 0xC)
+#define UART_INT_ENA(i)                       (REG_UART_BASE(i) + 0xC)
 #define UART_RXFIFO_TOUT_INT_ENA (BIT(8))
 #define UART_BRK_DET_INT_ENA (BIT(7))
 #define UART_CTS_CHG_INT_ENA (BIT(6))
@@ -46,7 +46,7 @@
 #define UART_TXFIFO_EMPTY_INT_ENA (BIT(1))
 #define UART_RXFIFO_FULL_INT_ENA (BIT(0))
 
-#define UART_INT_CLR( i )                       (REG_UART_BASE( i ) + 0x10)
+#define UART_INT_CLR(i)                       (REG_UART_BASE(i) + 0x10)
 #define UART_RXFIFO_TOUT_INT_CLR (BIT(8))
 #define UART_BRK_DET_INT_CLR (BIT(7))
 #define UART_CTS_CHG_INT_CLR (BIT(6))
@@ -57,16 +57,16 @@
 #define UART_TXFIFO_EMPTY_INT_CLR (BIT(1))
 #define UART_RXFIFO_FULL_INT_CLR (BIT(0))
 
-#define UART_CLKDIV( i )                        (REG_UART_BASE( i ) + 0x14)
+#define UART_CLKDIV(i)                        (REG_UART_BASE(i) + 0x14)
 #define UART_CLKDIV_CNT 0x000FFFFF
 #define UART_CLKDIV_S 0
 
-#define UART_AUTOBAUD( i )                      (REG_UART_BASE( i ) + 0x18)
+#define UART_AUTOBAUD(i)                      (REG_UART_BASE(i) + 0x18)
 #define UART_GLITCH_FILT 0x000000FF
 #define UART_GLITCH_FILT_S 8
 #define UART_AUTOBAUD_EN (BIT(0))
 
-#define UART_STATUS( i )                        (REG_UART_BASE( i ) + 0x1C)
+#define UART_STATUS(i)                        (REG_UART_BASE(i) + 0x1C)
 #define UART_TXD (BIT(31))
 #define UART_RTSN (BIT(30))
 #define UART_DTRN (BIT(29))
@@ -78,7 +78,7 @@
 #define UART_RXFIFO_CNT 0x000000FF
 #define UART_RXFIFO_CNT_S 0
 
-#define UART_CONF0( i )                         (REG_UART_BASE( i ) + 0x20)
+#define UART_CONF0(i)                         (REG_UART_BASE(i) + 0x20)
 #define UART_TXFIFO_RST (BIT(18))
 #define UART_RXFIFO_RST (BIT(17))
 #define UART_IRDA_EN (BIT(16))
@@ -99,7 +99,7 @@
 #define UART_PARITY_EN (BIT(1))
 #define UART_PARITY (BIT(0))
 
-#define UART_CONF1( i )                         (REG_UART_BASE( i ) + 0x24)
+#define UART_CONF1(i)                         (REG_UART_BASE(i) + 0x24)
 #define UART_RX_TOUT_EN (BIT(31))
 #define UART_RX_TOUT_THRHD 0x0000007F
 #define UART_RX_TOUT_THRHD_S 24
@@ -111,18 +111,18 @@
 #define UART_RXFIFO_FULL_THRHD 0x0000007F
 #define UART_RXFIFO_FULL_THRHD_S 0
 
-#define UART_LOWPULSE( i )                      (REG_UART_BASE( i ) + 0x28)
+#define UART_LOWPULSE(i)                      (REG_UART_BASE(i) + 0x28)
 #define UART_LOWPULSE_MIN_CNT         0x000FFFFF
 #define UART_LOWPULSE_MIN_CNT_S     0
 
-#define UART_HIGHPULSE( i )                     (REG_UART_BASE( i ) + 0x2C)
+#define UART_HIGHPULSE(i)                     (REG_UART_BASE(i) + 0x2C)
 #define UART_HIGHPULSE_MIN_CNT         0x000FFFFF
 #define UART_HIGHPULSE_MIN_CNT_S     0
 
-#define UART_PULSE_NUM( i )                     (REG_UART_BASE( i ) + 0x30)
+#define UART_PULSE_NUM(i)                     (REG_UART_BASE(i) + 0x30)
 #define UART_PULSE_NUM_CNT                  0x0003FF
 #define UART_PULSE_NUM_CNT_S               0
 
-#define UART_DATE( i )                          (REG_UART_BASE( i ) + 0x78)
-#define UART_ID( i )                            (REG_UART_BASE( i ) + 0x7C)
+#define UART_DATE(i)                          (REG_UART_BASE(i) + 0x78)
+#define UART_ID(i)                            (REG_UART_BASE(i) + 0x7C)
 #endif // UART_REGISTER_H_INCLUDED

--- a/ports/nrf/gccollect.c
+++ b/ports/nrf/gccollect.c
@@ -33,7 +33,7 @@
 
 static inline uintptr_t get_sp(void) {
     uintptr_t result;
-    __asm__ ("mov %0, sp\n" : "=r" (result) );
+    __asm__ ("mov %0, sp\n" : "=r" (result));
     return result;
 }
 

--- a/ports/stm32/dma.c
+++ b/ports/stm32/dma.c
@@ -969,7 +969,7 @@ void dma_invalidate_channel(const dma_descr_t *dma_descr) {
     if (dma_descr != NULL) {
         dma_id_t dma_id = dma_descr->id;
         // Only compare the sub-instance, not the direction bit (MSB)
-        if ((dma_last_sub_instance[dma_id] & 0x7f) == DMA_SUB_INSTANCE_AS_UINT8(dma_descr->sub_instance) ) {
+        if ((dma_last_sub_instance[dma_id] & 0x7f) == DMA_SUB_INSTANCE_AS_UINT8(dma_descr->sub_instance)) {
             dma_last_sub_instance[dma_id] = DMA_INVALID_CHANNEL;
         }
     }

--- a/ports/teensy/modpyb.c
+++ b/ports/teensy/modpyb.c
@@ -247,7 +247,7 @@ STATIC MP_DEFINE_CONST_FUN_OBJ_0(pyb_standby_obj, pyb_standby);
 
 /// \function have_cdc()
 /// Return True if USB is connected as a serial device, False otherwise.
-STATIC mp_obj_t pyb_have_cdc(void ) {
+STATIC mp_obj_t pyb_have_cdc(void) {
     return mp_obj_new_bool(usb_vcp_is_connected());
 }
 STATIC MP_DEFINE_CONST_FUN_OBJ_0(pyb_have_cdc_obj, pyb_have_cdc);

--- a/py/mpconfig.h
+++ b/py/mpconfig.h
@@ -1600,7 +1600,7 @@ typedef double mp_float_t;
 
 #ifndef MP_HTOBE16
 #if MP_ENDIANNESS_LITTLE
-#define MP_HTOBE16(x) ((uint16_t)( (((x) & 0xff) << 8) | (((x) >> 8) & 0xff) ))
+#define MP_HTOBE16(x) ((uint16_t)((((x) & 0xff) << 8) | (((x) >> 8) & 0xff)))
 #define MP_BE16TOH(x) MP_HTOBE16(x)
 #else
 #define MP_HTOBE16(x) (x)
@@ -1610,7 +1610,7 @@ typedef double mp_float_t;
 
 #ifndef MP_HTOBE32
 #if MP_ENDIANNESS_LITTLE
-#define MP_HTOBE32(x) ((uint32_t)( (((x) & 0xff) << 24) | (((x) & 0xff00) << 8) | (((x) >> 8) & 0xff00) | (((x) >> 24) & 0xff) ))
+#define MP_HTOBE32(x) ((uint32_t)((((x) & 0xff) << 24) | (((x) & 0xff00) << 8) | (((x) >> 8) & 0xff00) | (((x) >> 24) & 0xff)))
 #define MP_BE32TOH(x) MP_HTOBE32(x)
 #else
 #define MP_HTOBE32(x) (x)

--- a/tools/uncrustify.cfg
+++ b/tools/uncrustify.cfg
@@ -164,7 +164,7 @@ sp_compare                      = force    # ignore/add/remove/force
 sp_inside_paren                 = ignore   # ignore/add/remove/force
 
 # Add or remove space between nested parentheses, i.e. '((' vs. ') )'.
-sp_paren_paren                  = ignore   # ignore/add/remove/force
+sp_paren_paren                  = remove   # ignore/add/remove/force
 
 # Add or remove space between back-to-back parentheses, i.e. ')(' vs. ') ('.
 sp_cparen_oparen                = ignore   # ignore/add/remove/force
@@ -524,7 +524,7 @@ sp_func_def_paren_empty         = ignore   # ignore/add/remove/force
 sp_inside_fparens               = ignore   # ignore/add/remove/force
 
 # Add or remove space inside function '(' and ')'.
-sp_inside_fparen                = ignore   # ignore/add/remove/force
+sp_inside_fparen                = remove   # ignore/add/remove/force
 
 # Add or remove space inside the first parentheses in a function type, as in
 # 'void (*x)(...)'.


### PR DESCRIPTION
Enables 2 more options in the uncrustify config to remove spaces inside parenthesis.