### PR TITLE
tests/thread/thread_stacksize1: Fix crash on certain platforms

### DIFF
--- a/ports/unix/mpthreadport.c
+++ b/ports/unix/mpthreadport.c
@@ -221,7 +221,11 @@ void mp_thread_create(void *(*entry)(void *), void *arg, size_t *stack_size) {
 
     // adjust stack_size to provide room to recover from hitting the limit
     // this value seems to be about right for both 32-bit and 64-bit builds
-    *stack_size -= 8192;
+    if (*stack_size >= 2 * 8192) {
+        *stack_size -= 8192;
+    } else {
+        *stack_size /= 2;
+    }
 
     // add thread to linked list of all threads
     thread_t *th = malloc(sizeof(thread_t));


### PR DESCRIPTION
The test tests/thread/thread_stacksize1.py sometimes crashes with a segmentation fault because of an uncaught NLR jump.

    $ ./ports/unix/micropython-coverage tests/thread/thread_stacksize1.py
    0
    0
    True
    0
    Unhandled exception in thread started by FATAL: uncaught NLR 0x7fc316d06500

Using a debugger, this exception message was found to be:

    "maximum recursion depth exceeded"

To fix this, we add some additional checks in the test to give a bigger stack to "desktop" platforms that need it to avoid this crash.