### PR TITLE
drivers/onewire/onewire.py: Fix undefined variable errors

### DIFF
--- a/drivers/onewire/onewire.py
+++ b/drivers/onewire/onewire.py
@@ -46,7 +46,7 @@ class OneWire:
 
     def select_rom(self, rom):
         self.reset()
-        self.writebyte(MATCH_ROM)
+        self.writebyte(self.MATCH_ROM)
         self.write(rom)
 
     def scan(self):
@@ -64,7 +64,7 @@ class OneWire:
     def _search_rom(self, l_rom, diff):
         if not self.reset():
             return None, 0
-        self.writebyte(SEARCH_ROM)
+        self.writebyte(self.SEARCH_ROM)
         if not l_rom:
             l_rom = bytearray(8)
         rom = bytearray(8)

--- a/drivers/onewire/onewire.py
+++ b/drivers/onewire/onewire.py
@@ -1,7 +1,6 @@
 # 1-Wire driver for MicroPython
 # MIT license; Copyright (c) 2016 Damien P. George
 
-from micropython import const
 import _onewire as _ow
 
 
@@ -10,9 +9,9 @@ class OneWireError(Exception):
 
 
 class OneWire:
-    SEARCH_ROM = const(0xF0)
-    MATCH_ROM = const(0x55)
-    SKIP_ROM = const(0xCC)
+    SEARCH_ROM = 0xF0
+    MATCH_ROM = 0x55
+    SKIP_ROM = 0xCC
 
     def __init__(self, pin):
         self.pin = pin


### PR DESCRIPTION
Dear Damien,

we are currently building a [test suite based on CPython/Pytest](https://github.com/hiveeyes/terkin-datalogger/tree/master/test) for invoking MicroPython programs. It works pretty good so far.

After spending some time adding tests for the telemetry domain, we would like to tackle the sensors domain. One thing we encountered there was that the file `drivers/onewire/onewire.py` actually raised `NameError: name 'SEARCH_ROM' is not defined` when being invoked on regular CPython3, see details below.

It looks like MicroPython is more forgiving here and while this looks like a cosmetic change / nit, we believe it is essentially about correctness and compatibility with CPython and should do no harm to MicroPython either.

So, we are humbly asking if you could consider merging this. This would enable us to continue our work while knowing that it might actually be also useful for others to be used with Genuine MicroPython.

With kind regards,
Andreas.

### Details
Invoking `pylint --errors-only` on this file yields:
```
E0602: Undefined variable 'MATCH_ROM' (undefined-variable)
E0602: Undefined variable 'SEARCH_ROM' (undefined-variable)
```

When invoking it on CPython, it croaks.
```
> self.writebyte(SEARCH_ROM)
E NameError: name 'SEARCH_ROM' is not defined
```

#### Editor highlighting
![image](https://user-images.githubusercontent.com/453543/77277679-c2245080-6cbd-11ea-9242-ef5919eaa807.png)

![image](https://user-images.githubusercontent.com/453543/77277689-c6e90480-6cbd-11ea-9814-7cdebef426ba.png)
