### PR TITLE
esp32/modsocket: Handle poll of a closed socket.

### DIFF
--- a/ports/esp32/modsocket.c
+++ b/ports/esp32/modsocket.c
@@ -676,6 +676,9 @@ STATIC mp_uint_t socket_stream_write(mp_obj_t self_in, const void *buf, mp_uint_
 STATIC mp_uint_t socket_stream_ioctl(mp_obj_t self_in, mp_uint_t request, uintptr_t arg, int *errcode) {
     socket_obj_t *socket = self_in;
     if (request == MP_STREAM_POLL) {
+        if (socket->fd == -1) {
+            return MP_STREAM_POLL_NVAL;
+        }
 
         fd_set rfds;
         FD_ZERO(&rfds);


### PR DESCRIPTION
This gets tests/extmod/uselect_poll_basic.py working on the esp32.

@tve FYI, this should fix the issue you found with `uasyncio` and write after closing the connection.