### PR TITLE
added roundf.c to makefiles

### DIFF
--- a/ports/esp8266/Makefile
+++ b/ports/esp8266/Makefile
@@ -138,6 +138,7 @@ LIB_SRC_C = $(addprefix lib/,\
 	libm/asinfacosf.c \
 	libm/atanf.c \
 	libm/atan2f.c \
+	libm/roundf.c \
 	mp-readline/readline.c \
 	netutils/netutils.c \
 	timeutils/timeutils.c \

--- a/ports/nrf/Makefile
+++ b/ports/nrf/Makefile
@@ -151,6 +151,7 @@ SRC_LIB += $(addprefix lib/,\
         libm/asinfacosf.c \
         libm/atanf.c \
         libm/atan2f.c \
+        libm/roundf.c \
 	)
 
 endif

--- a/ports/qemu-arm/Makefile
+++ b/ports/qemu-arm/Makefile
@@ -90,6 +90,7 @@ LIB_SRC_C += $(addprefix lib/,\
 	libm/asinfacosf.c \
 	libm/atanf.c \
 	libm/atan2f.c \
+	libm/roundf.c \
 	utils/sys_stdio_mphal.c \
 	)
 

--- a/ports/stm32/Makefile
+++ b/ports/stm32/Makefile
@@ -214,6 +214,7 @@ SRC_LIBM = $(addprefix lib/libm/,\
 	kf_tan.c \
 	log1pf.c \
 	nearbyintf.c \
+	roundf.c \
 	sf_cos.c \
 	sf_erf.c \
 	sf_frexp.c \


### PR DESCRIPTION
As the title shows, this PR concerns only the makefiles on 4 ports, namely, adds `roundf.c` to the `LIB_SRC_C` makefile variable, so that user modules that rely on the floating point implementation of `round` can be compiled without having to modify anything in the `micropython` code base. 

The PR was suggested by @jimmo in the forum post https://forum.micropython.org/viewtopic.php?f=3&t=7987 . 