### PR TITLE
stm32/mpconfigport.h: Remove unused root pointer for BTstack bindings.

### DIFF
--- a/ports/stm32/mpconfigport.h
+++ b/ports/stm32/mpconfigport.h
@@ -272,7 +272,7 @@ struct _mp_bluetooth_nimble_root_pointers_t;
 
 #if MICROPY_BLUETOOTH_BTSTACK
 struct _mp_bluetooth_btstack_root_pointers_t;
-#define MICROPY_PORT_ROOT_POINTER_BLUETOOTH_BTSTACK void **bluetooth_nimble_memory; struct _mp_bluetooth_btstack_root_pointers_t *bluetooth_btstack_root_pointers;
+#define MICROPY_PORT_ROOT_POINTER_BLUETOOTH_BTSTACK struct _mp_bluetooth_btstack_root_pointers_t *bluetooth_btstack_root_pointers;
 #else
 #define MICROPY_PORT_ROOT_POINTER_BLUETOOTH_BTSTACK
 #endif


### PR DESCRIPTION
This was a cut-and-paste error from the NimBLE bindings.