### PR TITLE
extmod/uasyncio: Add global exception handling

### DIFF
--- a/extmod/uasyncio/core.py
+++ b/extmod/uasyncio/core.py
@@ -249,7 +249,6 @@ class Loop:
     def default_exception_handler(self, context):
         print(context["message"])
         print("future:", context["future"], "coro=", context["future"].coro)
-        # missing traceback
         sys.print_exception(context["exception"])
 
     def call_exception_handler(self, context):

--- a/extmod/uasyncio/core.py
+++ b/extmod/uasyncio/core.py
@@ -262,7 +262,7 @@ class Loop:
 
     @classmethod
     def default_exception_handler(cls, context):
-        exc_handler(cls, context)
+        _exc_handler(cls, context)
 
     @classmethod
     def call_exception_handler(cls, context):

--- a/extmod/uasyncio/core.py
+++ b/extmod/uasyncio/core.py
@@ -30,7 +30,7 @@ _context = {"message":   _exc_message,
             "future":    None}
 
 
-def _exc_handler(loop, context):
+def _default_exc_handler(loop, context):
     print(context["message"])
     print("future:", context["future"], "coro=", context["future"].coro)
     # missing traceback
@@ -38,7 +38,7 @@ def _exc_handler(loop, context):
 
 
 # set default exception handler
-exc_handler = _exc_handler
+_exc_handler = _default_exc_handler
 
 
 ################################################################################
@@ -253,20 +253,20 @@ class Loop:
 
     @staticmethod
     def set_exception_handler(handler):
-        global exc_handler
-        exc_handler = handler
+        global _exc_handler
+        _exc_handler = handler
 
     @staticmethod
     def get_exception_handler():
-        return exc_handler
+        return _exc_handler
 
     @classmethod
     def default_exception_handler(cls, context):
-        _exc_handler(cls, context)
+        _default_exc_handler(cls, context)
 
     @classmethod
     def call_exception_handler(cls, context):
-        exc_handler(cls, context)
+        _exc_handler(cls, context)
 
 
 # The runq_len and waitq_len arguments are for legacy uasyncio compatibility

--- a/extmod/uasyncio/core.py
+++ b/extmod/uasyncio/core.py
@@ -29,9 +29,6 @@ _context = {"message":   _exc_message,
             "exception": None,
             "future":    None}
 
-# stores the user exception handler
-_exc_handler = None
-
 
 ################################################################################
 # Sleep functions
@@ -211,7 +208,7 @@ def run_until_complete(main_task=None):
             if not waiting and not isinstance(er, excs_stop):
                 _context["exception"] = er
                 _context["future"] = t
-                Loop().call_exception_handler(_context)
+                Loop.call_exception_handler(_context)
             # Indicate task is done
             t.coro = None
 
@@ -239,23 +236,21 @@ class Loop:
     def close(self):
         pass
 
-    def set_exception_handler(self, handler):
-        global _exc_handler
-        _exc_handler = handler
+    def set_exception_handler(handler):
+        Loop._exc_handler = handler
 
-    def get_exception_handler(self):
-        return _exc_handler if _exc_handler is not None else self.default_exception_handler
+    def get_exception_handler():
+        return Loop._exc_handler
 
-    def default_exception_handler(self, context):
+    def default_exception_handler(loop, context):
         print(context["message"])
         print("future:", context["future"], "coro=", context["future"].coro)
         sys.print_exception(context["exception"])
 
-    def call_exception_handler(self, context):
-        if _exc_handler is None:
-            self.default_exception_handler(context)
-        else:
-            _exc_handler(self, context)
+    def call_exception_handler(context):
+        Loop._exc_handler(Loop, context)
+
+    _exc_handler = default_exception_handler
 
 
 # The runq_len and waitq_len arguments are for legacy uasyncio compatibility


### PR DESCRIPTION
Support global exception handling to uasyncio according to CPython error handling: https://docs.python.org/3/library/asyncio-eventloop.html#error-handling-api

Adds the Loop methods (also changing all loop methods to be staticmethos or classmethods since there is only one loop) and a default exception handler. 

This is especially interesting since this new version of uasyncio doesn't throw exceptions to the caller of "loop.run_forever()" and therefore exceptions in other tasks are only printed to repl, where the user might never see it since the device will be deployed without logging the repl output. 
With a global exception handling a user can catch those exceptions and send them by mqtt or log them to a file on the device. 

The implementation preallocates a context dictionary so in case of an exception there shouldn't be any RAM allocations.

The used approach is compatible to CPython except for 2 problems:
1) There is no way to log the Exception traceback because "sys.print_exception" only prints the traceback to the repl. So there is no way to actually log the traceback, which would be very helpful. Hopefully this can be implemented. I understand that this might cause RAM allocation but a user might decide to use it anyway in a custom exception handler because it makes debugging a lot easier if you know in what file and line the error occured.
Edit: Apparently there is a way so that's fine.
2) In CPython the exception handler is called once the task is finished which created the task that threw an uncaught exception, whereas in UPy the exception handler is called immediately when the exception is thrown. This makes a difference in the following testcase but is generally just a minor difference that shouldn't cause any abnormal behaviour.

```
async def test_catch_uncaught_exception():
    # can't work with a local return value because the exception handler runs after
    # the current coroutine is finished in CPython. Works in UPy though.
    res = False

    async def fail():
        raise TypeError("uncaught exception")

    def handle_exception(loop, context):
        # context["message"] will always be there; but context["exception"] may not
        print(context)
        print(context["message"])
        print(context["exception"])
        msg = context.get("exception", context["message"])
        if mp:
            print("Caught: {}{}".format(type(context["exception"]), msg))
        else:
            print("Caught: {}".format({msg}))
        nonlocal res
        print("res is", res)
        res = True
        print("done")

    t = asyncio.create_task(fail())
    loop = asyncio.get_event_loop()
    loop.set_exception_handler(handle_exception)
    await asyncio.sleep(0.1)
    await asyncio.sleep(0.1)
    print("coro done")
    return res
```