### PR TITLE
extmod uasyncio: Lock RuntimeError CPython compatibility

### DIFF
--- a/extmod/uasyncio/lock.py
+++ b/extmod/uasyncio/lock.py
@@ -19,7 +19,7 @@ class Lock:
 
     def release(self):
         if self.state != 1:
-            raise RuntimeError
+            raise RuntimeError("Lock is not acquired.")
         if self.waiting.peek():
             # Task(s) waiting on lock, schedule next Task
             self.state = self.waiting.pop_head()

--- a/extmod/uasyncio/lock.py
+++ b/extmod/uasyncio/lock.py
@@ -19,7 +19,7 @@ class Lock:
 
     def release(self):
         if self.state != 1:
-            raise RuntimeError("Lock is not acquired.")
+            raise RuntimeError("Lock not acquired")
         if self.waiting.peek():
             # Task(s) waiting on lock, schedule next Task
             self.state = self.waiting.pop_head()


### PR DESCRIPTION
Lock should raise a RuntimeError with an error message like CPython does.