### PR TITLE
Some minor usability enhancements for pyboard.py

### DIFF
--- a/docs/reference/pyboard.py.rst
+++ b/docs/reference/pyboard.py.rst
@@ -24,8 +24,8 @@ Running ``pyboard.py --help`` gives the following output:
 
 .. code-block:: text
 
-    usage: pyboard [-h] [--device DEVICE] [-b BAUDRATE] [-u USER]
-                   [-p PASSWORD] [-c COMMAND] [-w WAIT] [--follow] [-f]
+    usage: pyboard [-h] [-d DEVICE] [-b BAUDRATE] [-u USER] [-p PASSWORD]
+                   [-c COMMAND] [-w WAIT] [--follow | --no-follow] [-f]
                    [files [files ...]]
 
     Run scripts on the pyboard.
@@ -35,8 +35,8 @@ Running ``pyboard.py --help`` gives the following output:
 
     optional arguments:
       -h, --help            show this help message and exit
-      --device DEVICE       the serial device or the IP address of the
-                            pyboard
+      -d DEVICE, --device DEVICE
+                            the serial device or the IP address of the pyboard
       -b BAUDRATE, --baudrate BAUDRATE
                             the baud rate of the serial device
       -u USER, --user USER  the telnet login username

--- a/docs/reference/pyboard.py.rst
+++ b/docs/reference/pyboard.py.rst
@@ -59,6 +59,17 @@ with the device.::
     $ pyboard.py --device /dev/ttyACM0 -c 'print(1+1)'
     2
 
+If you are often interacting with the same device, you can set the environment
+variable ``PYBOARD_DEVICE`` as an alternative to using the ``--device``
+command line option.  For example, the following is equivalent to the previous
+example::
+
+    $ export PYBOARD_DEVICE=/dev/ttyACM0
+    $ pyboard.py -c 'print(1+1)'
+
+Similarly, the ``PYBOARD_BAUDRATE`` environment variable can be used
+to set the default for the `--baudrate` option.
+
 Running a script on the device
 ------------------------------
 

--- a/tools/pyboard.py
+++ b/tools/pyboard.py
@@ -558,11 +558,13 @@ def main():
     cmd_parser = argparse.ArgumentParser(description="Run scripts on the pyboard.")
     cmd_parser.add_argument(
         "--device",
-        default="/dev/ttyACM0",
+        default=os.environ.get("PYBOARD_DEVICE", "/dev/ttyACM0"),
         help="the serial device or the IP address of the pyboard",
     )
     cmd_parser.add_argument(
-        "-b", "--baudrate", default=115200, help="the baud rate of the serial device"
+        "-b", "--baudrate",
+        default=os.environ.get("PYBOARD_BAUDRATE", "115200"),
+        help="the baud rate of the serial device"
     )
     cmd_parser.add_argument("-u", "--user", default="micro", help="the telnet login username")
     cmd_parser.add_argument("-p", "--password", default="python", help="the telnet login password")

--- a/tools/pyboard.py
+++ b/tools/pyboard.py
@@ -557,7 +557,7 @@ def main():
 
     cmd_parser = argparse.ArgumentParser(description="Run scripts on the pyboard.")
     cmd_parser.add_argument(
-        "--device",
+        "-d", "--device",
         default=os.environ.get("PYBOARD_DEVICE", "/dev/ttyACM0"),
         help="the serial device or the IP address of the pyboard",
     )


### PR DESCRIPTION
- Allow `-d` as an alias for `--device`
- Allow defaults for `--device` and `--baud` to be set via
  `PYBOARD_DEVICE` and `PYBOARD_BAUD` environment variables.