### PR TITLE
Fix warnings from -Wfloat-conversion

### DIFF
--- a/extmod/moductypes.c
+++ b/extmod/moductypes.c
@@ -362,7 +362,7 @@ STATIC mp_obj_t get_aligned(uint val_type, void *p, mp_int_t index) {
         case FLOAT32:
             return mp_obj_new_float(((float *)p)[index]);
         case FLOAT64:
-            return mp_obj_new_float(((double *)p)[index]);
+            return mp_obj_new_float((mp_float_t) ((double *)p)[index]);
         #endif
         default:
             assert(0);
@@ -375,7 +375,7 @@ STATIC void set_aligned(uint val_type, void *p, mp_int_t index, mp_obj_t val) {
     if (val_type == FLOAT32 || val_type == FLOAT64) {
         mp_float_t v = mp_obj_get_float(val);
         if (val_type == FLOAT32) {
-            ((float *)p)[index] = v;
+            ((float *)p)[index] = (float) v;
         } else {
             ((double *)p)[index] = v;
         }

--- a/ports/bare-arm/Makefile
+++ b/ports/bare-arm/Makefile
@@ -13,7 +13,7 @@ INC += -I$(TOP)
 INC += -I$(BUILD)
 
 CFLAGS_CORTEX_M4 = -mthumb -mtune=cortex-m4 -mabi=aapcs-linux -mcpu=cortex-m4 -mfpu=fpv4-sp-d16 -mfloat-abi=hard -fsingle-precision-constant -Wdouble-promotion
-CFLAGS = $(INC) -Wall -Werror -std=c99 -nostdlib $(CFLAGS_CORTEX_M4) $(COPT)
+CFLAGS = $(INC) -Wall -Wfloat-conversion -Werror -std=c99 -nostdlib $(CFLAGS_CORTEX_M4) $(COPT)
 CSUPEROPT = -Os # save some code space
 
 #Debugging/Optimization

--- a/ports/cc3200/Makefile
+++ b/ports/cc3200/Makefile
@@ -20,7 +20,7 @@ include ../../py/mkenv.mk
 CROSS_COMPILE ?= arm-none-eabi-
 
 CFLAGS_CORTEX_M4 = -mthumb -mtune=cortex-m4 -march=armv7e-m -mabi=aapcs -mcpu=cortex-m4 -msoft-float -mfloat-abi=soft -fsingle-precision-constant -Wdouble-promotion
-CFLAGS = -Wall -Wpointer-arith -Werror -std=gnu99 -nostdlib $(CFLAGS_CORTEX_M4) -Os
+CFLAGS = -Wall -Wfloat-conversion -Wpointer-arith -Werror -std=gnu99 -nostdlib $(CFLAGS_CORTEX_M4) -Os
 CFLAGS += -g -ffunction-sections -fdata-sections -fno-common -fsigned-char -mno-unaligned-access
 CFLAGS += -Iboards/$(BOARD)
 CFLAGS += $(CFLAGS_MOD)

--- a/ports/javascript/Makefile
+++ b/ports/javascript/Makefile
@@ -19,7 +19,7 @@ ifdef EMSCRIPTEN
     CPP += -isystem $(EMSCRIPTEN)/system/include/libc -cxx-isystem $(EMSCRIPTEN)/system/include/libcxx
 endif
 
-CFLAGS = -m32 -Wall -Werror $(INC) -std=c99 $(COPT)
+CFLAGS = -m32 -Wall -Wfloat-conversion -Werror $(INC) -std=c99 $(COPT)
 LDFLAGS = -m32 -Wl,-Map=$@.map,--cref -Wl,--gc-sections
 
 CFLAGS += -O0 -DNDEBUG

--- a/ports/mimxrt/Makefile
+++ b/ports/mimxrt/Makefile
@@ -40,7 +40,7 @@ INC += -I$(TOP)/lib/tinyusb/hw
 INC += -I$(TOP)/lib/tinyusb/hw/bsp/teensy_40
 
 CFLAGS_MCU = -mtune=cortex-m7 -mcpu=cortex-m7 -mfloat-abi=hard -mfpu=fpv5-d16
-CFLAGS = $(INC) -Wall -Werror -std=c99 -nostdlib -mthumb $(CFLAGS_MCU)
+CFLAGS = $(INC) -Wall -Wfloat-conversion -Werror -std=c99 -nostdlib -mthumb $(CFLAGS_MCU)
 CFLAGS += -DCPU_$(MCU_SERIES) -DCPU_$(MCU_VARIANT)
 CFLAGS += -DXIP_EXTERNAL_FLASH=1 \
 	-DXIP_BOOT_HEADER_ENABLE=1 \

--- a/ports/minimal/Makefile
+++ b/ports/minimal/Makefile
@@ -20,7 +20,7 @@ ifeq ($(CROSS), 1)
 DFU = $(TOP)/tools/dfu.py
 PYDFU = $(TOP)/tools/pydfu.py
 CFLAGS_CORTEX_M4 = -mthumb -mtune=cortex-m4 -mcpu=cortex-m4 -msoft-float -fsingle-precision-constant -Wdouble-promotion
-CFLAGS = $(INC) -Wall -Werror -std=c99 -nostdlib $(CFLAGS_CORTEX_M4) $(COPT)
+CFLAGS = $(INC) -Wall -Wfloat-conversion -Werror -std=c99 -nostdlib $(CFLAGS_CORTEX_M4) $(COPT)
 LDFLAGS = -nostdlib -T stm32f405.ld -Map=$@.map --cref --gc-sections
 else
 LD = gcc

--- a/ports/pic16bit/Makefile
+++ b/ports/pic16bit/Makefile
@@ -19,7 +19,7 @@ INC += -I$(XC16)/include
 INC += -I$(XC16)/support/$(PARTFAMILY)/h
 
 CFLAGS_PIC16BIT = -mcpu=$(PART) -mlarge-code
-CFLAGS = $(INC) -Wall -Werror -std=gnu99 -nostdlib $(CFLAGS_PIC16BIT) $(COPT)
+CFLAGS = $(INC) -Wall -Wfloat-conversion -Werror -std=gnu99 -nostdlib $(CFLAGS_PIC16BIT) $(COPT)
 
 #Debugging/Optimization
 ifeq ($(DEBUG), 1)

--- a/ports/stm32/mboot/Makefile
+++ b/ports/stm32/mboot/Makefile
@@ -54,7 +54,7 @@ CFLAGS_MCU_f7 = $(CFLAGS_CORTEX_M) -mtune=cortex-m7 -mcpu=cortex-m7
 CFLAGS_MCU_h7 = $(CFLAGS_CORTEX_M) -mtune=cortex-m7 -mcpu=cortex-m7
 CFLAGS_MCU_l4 = $(CFLAGS_CORTEX_M) -mtune=cortex-m4 -mcpu=cortex-m4
 
-CFLAGS = $(INC) -Wall -Wpointer-arith -Werror -std=gnu99 -nostdlib $(CFLAGS_MOD) $(CFLAGS_EXTRA)
+CFLAGS = $(INC) -Wall -Wfloat-conversion -Wpointer-arith -Werror -std=gnu99 -nostdlib $(CFLAGS_MOD) $(CFLAGS_EXTRA)
 CFLAGS += -D$(CMSIS_MCU)
 CFLAGS += $(CFLAGS_MCU_$(MCU_SERIES))
 CFLAGS += $(COPT)

--- a/ports/teensy/Makefile
+++ b/ports/teensy/Makefile
@@ -35,7 +35,7 @@ INC += -I$(TOP)/ports/stm32
 INC += -I$(BUILD)
 INC += -Icore
 
-CFLAGS = $(INC) -Wall -Wpointer-arith -std=gnu99 -nostdlib $(CFLAGS_CORTEX_M4)
+CFLAGS = $(INC) -Wall -Wfloat-conversion -Wpointer-arith -std=gnu99 -nostdlib $(CFLAGS_CORTEX_M4)
 LDFLAGS = -nostdlib -T mk20dx256.ld -msoft-float -mfloat-abi=soft
 
 ifeq ($(USE_ARDUINO_TOOLCHAIN),1)

--- a/ports/unix/Makefile
+++ b/ports/unix/Makefile
@@ -39,7 +39,7 @@ INC += -I$(BUILD)
 
 # compiler settings
 CWARN = -Wall -Werror
-CWARN += -Wpointer-arith -Wuninitialized
+CWARN += -Wpointer-arith -Wuninitialized -Wfloat-conversion
 CFLAGS += $(INC) $(CWARN) -std=gnu99 -DUNIX $(CFLAGS_MOD) $(COPT) -I$(VARIANT_DIR) $(CFLAGS_EXTRA)
 
 # Debugging/Optimization

--- a/ports/unix/modffi.c
+++ b/ports/unix/modffi.c
@@ -378,7 +378,7 @@ STATIC mp_obj_t ffifunc_call(mp_obj_t self_in, size_t n_args, size_t n_kw, const
         #if MICROPY_PY_BUILTINS_FLOAT
         } else if (*argtype == 'f') {
             float *p = (float *)&values[i];
-            *p = mp_obj_get_float(a);
+            *p = (float) mp_obj_get_float(a);
         } else if (*argtype == 'd') {
             double *p = (double *)&values[i];
             *p = mp_obj_get_float(a);

--- a/ports/unix/modtime.c
+++ b/ports/unix/modtime.c
@@ -96,8 +96,8 @@ STATIC mp_obj_t mod_time_sleep(mp_obj_t arg) {
     struct timeval tv;
     mp_float_t val = mp_obj_get_float(arg);
     mp_float_t ipart;
-    tv.tv_usec = MICROPY_FLOAT_C_FUN(round)(MICROPY_FLOAT_C_FUN(modf)(val, &ipart) * MICROPY_FLOAT_CONST(1000000.));
-    tv.tv_sec = ipart;
+    tv.tv_usec = (time_t) MICROPY_FLOAT_C_FUN(round)(MICROPY_FLOAT_C_FUN(modf)(val, &ipart) * MICROPY_FLOAT_CONST(1000000.));
+    tv.tv_sec = (suseconds_t) ipart;
     int res;
     while (1) {
         MP_THREAD_GIL_EXIT();

--- a/ports/unix/modtime.c
+++ b/ports/unix/modtime.c
@@ -95,8 +95,8 @@ STATIC mp_obj_t mod_time_sleep(mp_obj_t arg) {
     #if MICROPY_PY_BUILTINS_FLOAT
     struct timeval tv;
     mp_float_t val = mp_obj_get_float(arg);
-    double ipart;
-    tv.tv_usec = round(modf(val, &ipart) * 1000000);
+    mp_float_t ipart;
+    tv.tv_usec = MICROPY_FLOAT_C_FUN(round)(MICROPY_FLOAT_C_FUN(modf)(val, &ipart) * MICROPY_FLOAT_CONST(1000000.));
     tv.tv_sec = ipart;
     int res;
     while (1) {

--- a/ports/unix/modusocket.c
+++ b/ports/unix/modusocket.c
@@ -383,8 +383,8 @@ STATIC mp_obj_t socket_settimeout(mp_obj_t self_in, mp_obj_t timeout_in) {
         #if MICROPY_PY_BUILTINS_FLOAT
         mp_float_t val = mp_obj_get_float(timeout_in);
         mp_float_t ipart;
-        tv.tv_usec = MICROPY_FLOAT_C_FUN(round)(MICROPY_FLOAT_C_FUN(modf)(val, &ipart) * 1000000);
-        tv.tv_sec = ipart;
+        tv.tv_usec = (time_t) MICROPY_FLOAT_C_FUN(round)(MICROPY_FLOAT_C_FUN(modf)(val, &ipart) * MICROPY_FLOAT_CONST(1000000.0));
+        tv.tv_sec = (suseconds_t) ipart;
         #else
         tv.tv_sec = mp_obj_get_int(timeout_in);
         #endif

--- a/ports/unix/modusocket.c
+++ b/ports/unix/modusocket.c
@@ -382,8 +382,8 @@ STATIC mp_obj_t socket_settimeout(mp_obj_t self_in, mp_obj_t timeout_in) {
     if (timeout_in != mp_const_none) {
         #if MICROPY_PY_BUILTINS_FLOAT
         mp_float_t val = mp_obj_get_float(timeout_in);
-        double ipart;
-        tv.tv_usec = round(modf(val, &ipart) * 1000000);
+        mp_float_t ipart;
+        tv.tv_usec = MICROPY_FLOAT_C_FUN(round)(MICROPY_FLOAT_C_FUN(modf)(val, &ipart) * 1000000);
         tv.tv_sec = ipart;
         #else
         tv.tv_sec = mp_obj_get_int(timeout_in);

--- a/ports/windows/Makefile
+++ b/ports/windows/Makefile
@@ -15,7 +15,7 @@ INC += -I$(TOP)
 INC += -I$(BUILD)
 
 # compiler settings
-CFLAGS = $(INC) -Wall -Wpointer-arith -Werror -std=gnu99 -DUNIX -D__USE_MINGW_ANSI_STDIO=1 $(CFLAGS_MOD) $(COPT) $(CFLAGS_EXTRA)
+CFLAGS = $(INC) -Wall -Wfloat-conversion -Wpointer-arith -Werror -std=gnu99 -DUNIX -D__USE_MINGW_ANSI_STDIO=1 $(CFLAGS_MOD) $(COPT) $(CFLAGS_EXTRA)
 LDFLAGS = $(LDFLAGS_MOD) -lm $(LDFLAGS_EXTRA)
 
 # Debugging/Optimization

--- a/ports/windows/mpconfigport.h
+++ b/ports/windows/mpconfigport.h
@@ -160,6 +160,8 @@ typedef int mp_int_t; // must be pointer size
 typedef unsigned int mp_uint_t; // must be pointer size
 #endif
 
+typedef long suseconds_t;
+
 // Just assume Windows is little-endian - mingw32 gcc doesn't
 // define standard endianness macros.
 #define MP_ENDIANNESS_LITTLE (1)

--- a/ports/windows/mpconfigport.h
+++ b/ports/windows/mpconfigport.h
@@ -162,6 +162,20 @@ typedef unsigned int mp_uint_t; // must be pointer size
 
 typedef long suseconds_t;
 
+// Something wrong in mingw's math.h leading to signbit et al. being defined
+// to versions taking float instead of double so fix this here.
+// Does mean this file must always come after #include <math.h>
+#if defined( __MINGW32__ ) && (MICROPY_FLOAT_IMPL == MICROPY_FLOAT_IMPL_DOUBLE)
+#undef signbit
+#undef isnan
+#undef isinf
+#undef fpclassify
+#define signbit __signbit
+#define isnan __isnan
+#define isinf(x) (__fpclassify(x) == FP_INFINITE)
+#define fpclassify __fpclassify
+#endif
+
 // Just assume Windows is little-endian - mingw32 gcc doesn't
 // define standard endianness macros.
 #define MP_ENDIANNESS_LITTLE (1)

--- a/py/binary.c
+++ b/py/binary.c
@@ -178,7 +178,7 @@ mp_obj_t mp_binary_get_val_array(char typecode, void *p, size_t index) {
         case 'f':
             return mp_obj_new_float(((float *)p)[index]);
         case 'd':
-            return mp_obj_new_float(((double *)p)[index]);
+            return mp_obj_new_float((mp_float_t) ((double *)p)[index]);
         #endif
         // Extension to CPython: array of objects
         case 'O':
@@ -249,7 +249,7 @@ mp_obj_t mp_binary_get_val(char struct_type, char val_type, byte *p_base, byte *
         union { uint64_t i;
                 double f;
         } fpu = {val};
-        return mp_obj_new_float(fpu.f);
+        return mp_obj_new_float((mp_float_t) fpu.f);
     #endif
     } else if (is_signed(val_type)) {
         if ((long long)MP_SMALL_INT_MIN <= val && val <= (long long)MP_SMALL_INT_MAX) {
@@ -311,7 +311,7 @@ void mp_binary_set_val(char struct_type, char val_type, mp_obj_t val_in, byte *p
             union { uint32_t i;
                     float f;
             } fp_sp;
-            fp_sp.f = mp_obj_get_float(val_in);
+            fp_sp.f = (float) mp_obj_get_float(val_in);
             val = fp_sp.i;
             break;
         }
@@ -359,7 +359,7 @@ void mp_binary_set_val_array(char typecode, void *p, size_t index, mp_obj_t val_
     switch (typecode) {
         #if MICROPY_PY_BUILTINS_FLOAT
         case 'f':
-            ((float *)p)[index] = mp_obj_get_float(val_in);
+            ((float *)p)[index] = (float) mp_obj_get_float(val_in);
             break;
         case 'd':
             ((double *)p)[index] = mp_obj_get_float(val_in);

--- a/py/formatfloat.c
+++ b/py/formatfloat.c
@@ -100,15 +100,15 @@ static inline int fp_isless1(float x) {
 
 static const FPTYPE g_pos_pow[] = {
     #if FPDECEXP > 32
-    1e256, 1e128, 1e64,
+    MICROPY_FLOAT_CONST(1e256), MICROPY_FLOAT_CONST(1e128), MICROPY_FLOAT_CONST(1e64),
     #endif
-    1e32, 1e16, 1e8, 1e4, 1e2, 1e1
+    MICROPY_FLOAT_CONST(1e32), MICROPY_FLOAT_CONST(1e16), MICROPY_FLOAT_CONST(1e8), MICROPY_FLOAT_CONST(1e4), MICROPY_FLOAT_CONST(1e2), MICROPY_FLOAT_CONST(1e1)
 };
 static const FPTYPE g_neg_pow[] = {
     #if FPDECEXP > 32
-    1e-256, 1e-128, 1e-64,
+    MICROPY_FLOAT_CONST(1e-256), MICROPY_FLOAT_CONST(1e-128), MICROPY_FLOAT_CONST(1e-64),
     #endif
-    1e-32, 1e-16, 1e-8, 1e-4, 1e-2, 1e-1
+    MICROPY_FLOAT_CONST(1e-32), MICROPY_FLOAT_CONST(1e-16), MICROPY_FLOAT_CONST(1e-8), MICROPY_FLOAT_CONST(1e-4), MICROPY_FLOAT_CONST(1e-2), MICROPY_FLOAT_CONST(1e-1)
 };
 
 int mp_format_float(FPTYPE f, char *buf, size_t buf_size, char fmt, int prec, char sign) {

--- a/py/formatfloat.c
+++ b/py/formatfloat.c
@@ -24,13 +24,15 @@
  * THE SOFTWARE.
  */
 
-#include "py/mpconfig.h"
-#if MICROPY_FLOAT_IMPL != MICROPY_FLOAT_IMPL_NONE
-
 #include <assert.h>
 #include <stdlib.h>
 #include <stdint.h>
 #include <math.h>
+
+#include "py/mpconfig.h"
+
+#if MICROPY_FLOAT_IMPL != MICROPY_FLOAT_IMPL_NONE
+
 #include "py/formatfloat.h"
 
 /***********************************************************************

--- a/py/modcmath.c
+++ b/py/modcmath.c
@@ -72,7 +72,7 @@ STATIC MP_DEFINE_CONST_FUN_OBJ_1(mp_cmath_exp_obj, mp_cmath_exp);
 STATIC mp_obj_t mp_cmath_log(mp_obj_t z_obj) {
     mp_float_t real, imag;
     mp_obj_get_complex(z_obj, &real, &imag);
-    return mp_obj_new_complex(0.5 * MICROPY_FLOAT_C_FUN(log)(real * real + imag * imag), MICROPY_FLOAT_C_FUN(atan2)(imag, real));
+    return mp_obj_new_complex(MICROPY_FLOAT_CONST(0.5) * MICROPY_FLOAT_C_FUN(log)(real * real + imag * imag), MICROPY_FLOAT_C_FUN(atan2)(imag, real));
 }
 STATIC MP_DEFINE_CONST_FUN_OBJ_1(mp_cmath_log_obj, mp_cmath_log);
 
@@ -81,7 +81,7 @@ STATIC MP_DEFINE_CONST_FUN_OBJ_1(mp_cmath_log_obj, mp_cmath_log);
 STATIC mp_obj_t mp_cmath_log10(mp_obj_t z_obj) {
     mp_float_t real, imag;
     mp_obj_get_complex(z_obj, &real, &imag);
-    return mp_obj_new_complex(0.5 * MICROPY_FLOAT_C_FUN(log10)(real * real + imag * imag), 0.4342944819032518 * MICROPY_FLOAT_C_FUN(atan2)(imag, real));
+    return mp_obj_new_complex(MICROPY_FLOAT_CONST(0.5) * MICROPY_FLOAT_C_FUN(log10)(real * real + imag * imag), MICROPY_FLOAT_CONST(0.4342944819032518) * MICROPY_FLOAT_C_FUN(atan2)(imag, real));
 }
 STATIC MP_DEFINE_CONST_FUN_OBJ_1(mp_cmath_log10_obj, mp_cmath_log10);
 #endif
@@ -91,7 +91,7 @@ STATIC mp_obj_t mp_cmath_sqrt(mp_obj_t z_obj) {
     mp_float_t real, imag;
     mp_obj_get_complex(z_obj, &real, &imag);
     mp_float_t sqrt_abs = MICROPY_FLOAT_C_FUN(pow)(real * real + imag * imag, 0.25);
-    mp_float_t theta = 0.5 * MICROPY_FLOAT_C_FUN(atan2)(imag, real);
+    mp_float_t theta = MICROPY_FLOAT_CONST(0.5) * MICROPY_FLOAT_C_FUN(atan2)(imag, real);
     return mp_obj_new_complex(sqrt_abs * MICROPY_FLOAT_C_FUN(cos)(theta), sqrt_abs * MICROPY_FLOAT_C_FUN(sin)(theta));
 }
 STATIC MP_DEFINE_CONST_FUN_OBJ_1(mp_cmath_sqrt_obj, mp_cmath_sqrt);

--- a/py/modmath.c
+++ b/py/modmath.c
@@ -24,12 +24,12 @@
  * THE SOFTWARE.
  */
 
+#include <math.h>
+
 #include "py/builtin.h"
 #include "py/runtime.h"
 
 #if MICROPY_PY_BUILTINS_FLOAT && MICROPY_PY_MATH
-
-#include <math.h>
 
 // M_PI is not part of the math.h standard and may not be defined
 // And by defining our own we can ensure it uses the correct const format.

--- a/py/mpprint.c
+++ b/py/mpprint.c
@@ -542,7 +542,7 @@ int mp_vprintf(const mp_print_t *print, const char *fmt, va_list args) {
             case 'g':
             case 'G': {
                 #if ((MICROPY_FLOAT_IMPL == MICROPY_FLOAT_IMPL_FLOAT) || (MICROPY_FLOAT_IMPL == MICROPY_FLOAT_IMPL_DOUBLE))
-                mp_float_t f = va_arg(args, double);
+                mp_float_t f = (mp_float_t) va_arg(args, double);
                 chrs += mp_print_float(print, f, *fmt, flags, fill, width, prec);
                 #else
                 #error Unknown MICROPY FLOAT IMPL

--- a/py/objcomplex.c
+++ b/py/objcomplex.c
@@ -27,13 +27,13 @@
 #include <stdlib.h>
 #include <stdio.h>
 #include <assert.h>
+#include <math.h>
 
 #include "py/parsenum.h"
 #include "py/runtime.h"
 
 #if MICROPY_PY_BUILTINS_COMPLEX
 
-#include <math.h>
 #include "py/formatfloat.h"
 
 typedef struct _mp_obj_complex_t {

--- a/py/objfloat.c
+++ b/py/objfloat.c
@@ -52,8 +52,8 @@ typedef struct _mp_obj_float_t {
     mp_float_t value;
 } mp_obj_float_t;
 
-const mp_obj_float_t mp_const_float_e_obj = {{&mp_type_float}, M_E};
-const mp_obj_float_t mp_const_float_pi_obj = {{&mp_type_float}, M_PI};
+const mp_obj_float_t mp_const_float_e_obj = {{&mp_type_float}, (mp_float_t) M_E};
+const mp_obj_float_t mp_const_float_pi_obj = {{&mp_type_float}, (mp_float_t) M_PI};
 
 #endif
 
@@ -208,24 +208,25 @@ STATIC void mp_obj_float_divmod(mp_float_t *x, mp_float_t *y) {
     mp_float_t div = (*x - mod) / *y;
 
     // Python specs require that mod has same sign as second operand
-    if (mod == 0.0) {
-        mod = MICROPY_FLOAT_C_FUN(copysign)(0.0, *y);
+    const mp_float_t zero = MICROPY_FLOAT_CONST(0.0);
+    if (mod == zero) {
+        mod = MICROPY_FLOAT_C_FUN(copysign)(zero, *y);
     } else {
-        if ((mod < 0.0) != (*y < 0.0)) {
+        if ((mod < zero) != (*y < zero)) {
             mod += *y;
-            div -= 1.0;
+            div -= MICROPY_FLOAT_CONST(1.0);
         }
     }
 
     mp_float_t floordiv;
-    if (div == 0.0) {
+    if (div == zero) {
         // if division is zero, take the correct sign of zero
-        floordiv = MICROPY_FLOAT_C_FUN(copysign)(0.0, *x / *y);
+        floordiv = MICROPY_FLOAT_C_FUN(copysign)(zero, *x / *y);
     } else {
         // Python specs require that x == (x//y)*y + (x%y)
         floordiv = MICROPY_FLOAT_C_FUN(floor)(div);
-        if (div - floordiv > 0.5) {
-            floordiv += 1.0;
+        if (div - floordiv > MICROPY_FLOAT_CONST(0.5)) {
+            floordiv += MICROPY_FLOAT_CONST(1.0);
         }
     }
 

--- a/py/objfloat.c
+++ b/py/objfloat.c
@@ -28,13 +28,13 @@
 #include <stdio.h>
 #include <string.h>
 #include <assert.h>
+#include <math.h>
 
 #include "py/parsenum.h"
 #include "py/runtime.h"
 
 #if MICROPY_PY_BUILTINS_FLOAT
 
-#include <math.h>
 #include "py/formatfloat.h"
 
 #if MICROPY_OBJ_REPR != MICROPY_OBJ_REPR_C && MICROPY_OBJ_REPR != MICROPY_OBJ_REPR_D

--- a/py/objint.c
+++ b/py/objint.c
@@ -27,6 +27,7 @@
 #include <stdlib.h>
 #include <assert.h>
 #include <string.h>
+#include <math.h>
 
 #include "py/parsenum.h"
 #include "py/smallint.h"
@@ -34,10 +35,6 @@
 #include "py/objstr.h"
 #include "py/runtime.h"
 #include "py/binary.h"
-
-#if MICROPY_PY_BUILTINS_FLOAT
-#include <math.h>
-#endif
 
 // This dispatcher function is expected to be independent of the implementation of long int
 STATIC mp_obj_t mp_obj_int_make_new(const mp_obj_type_t *type_in, size_t n_args, size_t n_kw, const mp_obj_t *args) {


### PR DESCRIPTION
Continuing #5773: enable that flag and fix the issues it shows. Last commit for mingw is a bit drastic so could be left out; because what it means is that before this change, things like isnan would forward to a function with signature isnan(float) even if the argument is a double. Seems very wrong, so maybe there's a better fix.