### PR TITLE
esp32: Change from FAT to littlefs v2 as default filesystem.

### DIFF
--- a/ports/esp32/modules/inisetup.py
+++ b/ports/esp32/modules/inisetup.py
@@ -33,8 +33,8 @@ by firmware programming).
 def setup():
     check_bootsec()
     print("Performing initial setup")
-    uos.VfsFat.mkfs(bdev)
-    vfs = uos.VfsFat(bdev)
+    uos.VfsLfs2.mkfs(bdev)
+    vfs = uos.VfsLfs2(bdev)
     uos.mount(vfs, "/")
     with open("boot.py", "w") as f:
         f.write(


### PR DESCRIPTION
This commit changes the default filesystem type for esp32 to littlefs v2.  This port already enables both VfsFat and VfsLfs2, so either can be used for the filesystem, and existing systems that use FAT will still work.