### PR TITLE
nrf: Start fixing nrf52840 to build with latest tinyusb.

### DIFF
--- a/ports/nrf/Makefile
+++ b/ports/nrf/Makefile
@@ -260,7 +260,6 @@ SRC_C += $(addprefix lib/tinyusb/src/,\
 	class/cdc/cdc_device.c \
 	tusb.c \
 	portable/nordic/nrf5x/dcd_nrf5x.c \
-	portable/nordic/nrf5x/hal_nrf5x.c \
 	)
 endif
 

--- a/ports/nrf/drivers/usb/usb_descriptors.c
+++ b/ports/nrf/drivers/usb/usb_descriptors.c
@@ -107,8 +107,8 @@ const uint16_t *tud_descriptor_string_cb(uint8_t index) {
         }
     }
 
-    // first byte is len, second byte is string type
-    desc_str[0] = TUD_DESC_STR_HEADER(len);
+    // first byte is length (including header), second byte is string type                                                                                                                                                                                      
+    desc_str[0] = (TUSB_DESC_STRING << 8 ) | (2*len + 2)
 
     return desc_str;
 }


### PR DESCRIPTION
All nrf52840 based board configs have been broken since: https://github.com/micropython/micropython/commit/6cea369b89b2223cf07ff8768e50dc39bbb770fe

as shown in:
https://gitlab.com/alelec/micropython_ci/-/jobs/467045194

This PR starts to fix this by:
* removing the Makefile reference to now-obsolete file, see:
https://github.com/hathach/tinyusb/commit/d211035a0a50cd5ac5ee17ea1194bf92b4b6bd2a
* Update `drivers/usb/usb_descriptors.c` as per https://github.com/hathach/tinyusb/commit/30de17a83029abeee44cbfd7aa5a3ac63d0ce65d

But then that gets to a much longer list of compile errors that I suspect are from an nrfx library incompatiblity?
```
In file included from ../../lib/nrfx/mdk/nrf.h:93,                                                                                                                                                                                                              
                 from ../../lib/tinyusb/src/portable/nordic/nrf5x/dcd_nrf5x.c:31:                                                                                                                                                                               
../../lib/tinyusb/src/portable/nordic/nrf5x/dcd_nrf5x.c: In function 'hfclk_running':                                                                                                                                                                           
../../lib/nrfx/mdk/nrf52840.h:2824:37: error: incompatible type for argument 1 of 'nrf_clock_hf_is_running'                                                                                                                                                     
 #define NRF_CLOCK                   ((NRF_CLOCK_Type*)         NRF_CLOCK_BASE)                                                                                                                                                                                 
                                     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~                                                                                                                                                                                 
../../lib/tinyusb/src/portable/nordic/nrf5x/dcd_nrf5x.c:575:34: note: in expansion of macro 'NRF_CLOCK'                                                                                                                                                         
   return nrf_clock_hf_is_running(NRF_CLOCK, NRF_CLOCK_HFCLK_HIGH_ACCURACY);                                                                                                                                                                                    
                                  ^~~~~~~~~                                                                                                                                                                                                                     
In file included from ../../lib/tinyusb/src/portable/nordic/nrf5x/dcd_nrf5x.c:32:                                                                                                                                                                               
../../lib/nrfx/hal/nrf_clock.h:462:64: note: expected 'nrf_clock_hfclk_t' {aka 'enum <anonymous>'} but argument is of type 'NRF_CLOCK_Type *' {aka 'struct <anonymous> *'}                                                                                      
 __STATIC_INLINE bool nrf_clock_hf_is_running(nrf_clock_hfclk_t clk_src)                                                                                                                                                                                        
                                              ~~~~~~~~~~~~~~~~~~^~~~~~~                                                                                                                                                                                         
../../lib/tinyusb/src/portable/nordic/nrf5x/dcd_nrf5x.c:575:10: error: too many arguments to function 'nrf_clock_hf_is_running'                                                                                                                                 
   return nrf_clock_hf_is_running(NRF_CLOCK, NRF_CLOCK_HFCLK_HIGH_ACCURACY);
```