### PR TITLE
travis: grep --text on qemu-arm output

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -75,7 +75,7 @@ jobs:
         - make ${MAKEOPTS} -C mpy-cross
         - make ${MAKEOPTS} -C ports/qemu-arm -f Makefile.test test
       after_failure:
-        - grep "FAIL" ports/qemu-arm/build/console.out
+        - grep --text "FAIL" ports/qemu-arm/build/console.out
 
     # unix coverage
     - stage: test


### PR DESCRIPTION
If the .out file contains non-text characters, grep won't show the output unless we ask nicely.

Fixes #5812

This patch can be seen working at https://travis-ci.org/github/micropython/micropython/jobs/667554548#L912-L915