### PR TITLE
tests/micropython/heapalloc_fail_set: remove extra comma

### DIFF
--- a/tests/micropython/heapalloc_fail_set.py
+++ b/tests/micropython/heapalloc_fail_set.py
@@ -6,7 +6,7 @@ import micropython
 x = 1
 micropython.heap_lock()
 try:
-    {x,}
+    {x}
 except MemoryError:
     print('MemoryError: set create')
 micropython.heap_unlock()


### PR DESCRIPTION
Unlike tuples, sets to do need trailing comma when there is only one item.