### PR TITLE
drivers/display/ssd1306.py /ssd1306: convert umlauts

### DIFF
--- a/drivers/display/ssd1306.py
+++ b/drivers/display/ssd1306.py
@@ -100,6 +100,9 @@ class SSD1306(framebuf.FrameBuffer):
         self.write_cmd(self.pages - 1)
         self.write_data(self.buffer)
 
+    def text(self, _text, _x, _y, _color=1):
+        _text = str(_text).replace('ä', 'ae').replace('ö', 'oe').replace('ü', 'ue').replace('Ä', 'Ae').replace('Ö', 'Oe').replace('Ü', 'Ue').replace('ß', 'ss')
+        super().text(_text, _x, _y, _color)
 
 class SSD1306_I2C(SSD1306):
     def __init__(self, width, height, i2c, addr=0x3C, external_vcc=False):


### PR DESCRIPTION
umlauts (ä, ü, ö, Ä, Ü, Ö) and ß are not supportet and not correct displayed
This change transformes these characters to ae, ue, ..., ss
tested on ESP32, feel free to integrate