### PR TITLE
moduasyncio: Add SSL support

### DIFF
--- a/docs/library/ussl.rst
+++ b/docs/library/ussl.rst
@@ -13,15 +13,24 @@ facilities for network sockets, both client-side and server-side.
 Functions
 ---------
 
-.. function:: ussl.wrap_socket(sock, server_side=False, keyfile=None, certfile=None, cert_reqs=CERT_NONE, ca_certs=None, do_handshake=True) 
+.. function:: ussl.wrap_socket(sock, server_side=False, keyfile=None, certfile=None, cert_reqs=CERT_NONE, ca_certs=None, server_hostname=None, do_handshake=True)
+
    Takes a `stream` *sock* (usually usocket.socket instance of ``SOCK_STREAM`` type),
    and returns an instance of ssl.SSLSocket, which wraps the underlying stream in
-   an SSL context. Returned object has the usual `stream` interface methods like
+   an SSL context. The returned object has the usual `stream` interface methods like
    ``read()``, ``write()``, etc.
    A server-side SSL socket should be created from a normal socket returned from
    :meth:`~usocket.socket.accept()` on a non-SSL listening server socket.
 
-   - *do_handshake* determines whether the handshake is done as part of the ``wrap_socket``
+   Parameters:
+
+   - ``server_side``: creates a server connection if True, else client connection. A
+     server connection requires a ``keyfile`` and a ``certfile``.
+   - ``cert_reqs``: specifies the level of certificate checking to be performed.
+   - ``ca_certs``: root certificates to use for certificate checking.
+   - ``server_hostname``: specifies the hostname of the server for verification purposes
+     as well for SNI (Server Name Identification).
+   - ``do_handshake``: determines whether the handshake is done as part of the ``wrap_socket``
      or whether it is deferred to be done as part of the initial reads or writes
      (there is no ``do_handshake`` method as in CPython).
      For blocking sockets doing the handshake immediately is standard. For non-blocking
@@ -58,3 +67,11 @@ Constants
           ussl.CERT_REQUIRED
 
     Supported values for *cert_reqs* parameter.
+
+    - CERT_NONE: in client mode accept just about any cert, in server mode do not
+      request a cert from the client.
+    - CERT_OPTIONAL: in client mode behaves the same as CERT_REQUIRED and in server
+      mode requests an optional cert from the client for authentication.
+    - CERT_REQUIRED: in client mode validates the server's cert and
+      in server mode requires the client to send a cert for authentication. Note that
+      ussl does not actually support client authentication.

--- a/extmod/modussl_mbedtls.c
+++ b/extmod/modussl_mbedtls.c
@@ -46,6 +46,15 @@
 #include "mbedtls/debug.h"
 #include "mbedtls/error.h"
 
+// flags for _mp_obj_ssl_socket_t.poll_flag that control the poll ioctl
+// the issue is that when using ipoll we may be polling only for reading, and the socket may never
+// become readable because mbedtls needs to write soemthing (like a handshake or renegotiation) and
+// so poll never returns "it's readable" or "it's writable" and so nothing ever makes progress.
+// See also the commit message for
+// https://github.com/micropython/micropython/commit/9c7c082396f717a8a8eb845a0af407e78d38165f
+#define READ_NEEDS_WRITE 0x1 // mbedtls_ssl_read said "I need a write"
+#define WRITE_NEEDS_READ 0x2 // mbedtls_ssl_write said "I need a read"
+
 typedef struct _mp_obj_ssl_socket_t {
     mp_obj_base_t base;
     mp_obj_t sock;
@@ -56,6 +65,8 @@ typedef struct _mp_obj_ssl_socket_t {
     mbedtls_x509_crt cacert;
     mbedtls_x509_crt cert;
     mbedtls_pk_context pkey;
+    uint8_t poll_flag;
+    uint8_t poll_by_read; // true: at next poll try to read first
 } mp_obj_ssl_socket_t;
 
 struct ssl_args {
@@ -76,46 +87,29 @@ STATIC void mbedtls_debug(void *ctx, int level, const char *file, int line, cons
 }
 #endif
 
-STATIC NORETURN void mbedtls_raise_error(int err) {
-    // _mbedtls_ssl_send and _mbedtls_ssl_recv (below) turn positive error codes from the
-    // underlying socket into negative codes to pass them through mbedtls. Here we turn them
-    // positive again so they get interpreted as the OSError they really are. The
-    // cut-off of -256 is a bit hacky, sigh.
-    if (err < 0 && err > -256) {
-        mp_raise_OSError(-err);
+// mod_ssl_errstr returns the error string corresponding to the error code found in an OSError,
+// such as returned by read/write.
+STATIC mp_obj_t mod_ssl_errstr(mp_obj_t err_in) {
+    size_t err = mp_obj_get_int(err_in);
+    vstr_t vstr;
+    vstr_init_len(&vstr, 80);
+
+    // Including mbedtls_strerror takes about 16KB on the esp32 due to all the strings
+    #if 1
+    vstr.buf[0] = 0;
+    mbedtls_strerror(err, vstr.buf, vstr.alloc);
+    vstr.len = strlen(vstr.buf);
+    if (vstr.len == 0) {
+        return MP_OBJ_NULL;
     }
-
-    #if defined(MBEDTLS_ERROR_C)
-    // Including mbedtls_strerror takes about 1.5KB due to the error strings.
-    // MBEDTLS_ERROR_C is the define used by mbedtls to conditionally include mbedtls_strerror.
-    // It is set/unset in the MBEDTLS_CONFIG_FILE which is defined in the Makefile.
-
-    // Try to allocate memory for the message
-    #define ERR_STR_MAX 80  // mbedtls_strerror truncates if it doesn't fit
-    mp_obj_str_t *o_str = m_new_obj_maybe(mp_obj_str_t);
-    byte *o_str_buf = m_new_maybe(byte, ERR_STR_MAX);
-    if (o_str == NULL || o_str_buf == NULL) {
-        mp_raise_OSError(err);
-    }
-
-    // print the error message into the allocated buffer
-    mbedtls_strerror(err, (char *)o_str_buf, ERR_STR_MAX);
-    size_t len = strlen((char *)o_str_buf);
-
-    // Put the exception object together
-    o_str->base.type = &mp_type_str;
-    o_str->data = o_str_buf;
-    o_str->len = len;
-    o_str->hash = qstr_compute_hash(o_str->data, o_str->len);
-    // raise
-    mp_obj_t args[2] = { MP_OBJ_NEW_SMALL_INT(err), MP_OBJ_FROM_PTR(o_str)};
-    nlr_raise(mp_obj_exception_make_new(&mp_type_OSError, 2, 0, args));
     #else
-    // mbedtls is compiled without error strings so we simply return the err number
-    mp_raise_OSError(err); // err is typically a large negative number
+    vstr_printf(vstr, "mbedtls error -0x%x\n", -err);
     #endif
+    return mp_obj_new_str_from_vstr(&mp_type_bytes, &vstr);
 }
+STATIC MP_DEFINE_CONST_FUN_OBJ_1(mod_ssl_errstr_obj, mod_ssl_errstr);
 
+// _mbedtls_ssl_send is called by mbedtls to send bytes onto the underlying socket
 STATIC int _mbedtls_ssl_send(void *ctx, const byte *buf, size_t len) {
     mp_obj_t sock = *(mp_obj_t *)ctx;
 
@@ -237,6 +231,8 @@ STATIC mp_obj_ssl_socket_t *socket_new(mp_obj_t sock, struct ssl_args *args) {
         }
     }
 
+    o->poll_flag = 0;
+    o->poll_by_read = 0;
     if (args->do_handshake.u_bool) {
         while ((ret = mbedtls_ssl_handshake(&o->ssl)) != 0) {
             if (ret != MBEDTLS_ERR_SSL_WANT_READ && ret != MBEDTLS_ERR_SSL_WANT_WRITE) {
@@ -263,7 +259,7 @@ cleanup:
     } else if (ret == MBEDTLS_ERR_X509_BAD_INPUT_DATA) {
         mp_raise_ValueError(MP_ERROR_TEXT("invalid cert"));
     } else {
-        mbedtls_raise_error(ret);
+        mp_raise_OSError(-ret);
     }
 }
 
@@ -289,12 +285,16 @@ STATIC void socket_print(const mp_print_t *print, mp_obj_t self_in, mp_print_kin
 STATIC mp_uint_t socket_read(mp_obj_t o_in, void *buf, mp_uint_t size, int *errcode) {
     mp_obj_ssl_socket_t *o = MP_OBJ_TO_PTR(o_in);
 
+    o->poll_flag &= ~READ_NEEDS_WRITE; // clear flag
     int ret = mbedtls_ssl_read(&o->ssl, buf, size);
     if (ret == MBEDTLS_ERR_SSL_PEER_CLOSE_NOTIFY) {
         // end of stream
         return 0;
     }
     if (ret >= 0) {
+        // if we got all we wanted, for the next poll try a read first 'cause
+        // there may be data in the mbedtls record buffer
+        o->poll_by_read = ret == size;
         return ret;
     }
     if (ret == MBEDTLS_ERR_SSL_WANT_READ) {
@@ -303,6 +303,7 @@ STATIC mp_uint_t socket_read(mp_obj_t o_in, void *buf, mp_uint_t size, int *errc
         // If handshake is not finished, read attempt may end up in protocol
         // wanting to write next handshake message. The same may happen with
         // renegotation.
+        o->poll_flag |= READ_NEEDS_WRITE; // set flag
         ret = MP_EWOULDBLOCK;
     }
     *errcode = ret;
@@ -312,6 +313,7 @@ STATIC mp_uint_t socket_read(mp_obj_t o_in, void *buf, mp_uint_t size, int *errc
 STATIC mp_uint_t socket_write(mp_obj_t o_in, const void *buf, mp_uint_t size, int *errcode) {
     mp_obj_ssl_socket_t *o = MP_OBJ_TO_PTR(o_in);
 
+    o->poll_flag &= ~WRITE_NEEDS_READ; // clear flag
     int ret = mbedtls_ssl_write(&o->ssl, buf, size);
     if (ret >= 0) {
         return ret;
@@ -322,6 +324,7 @@ STATIC mp_uint_t socket_write(mp_obj_t o_in, const void *buf, mp_uint_t size, in
         // If handshake is not finished, write attempt may end up in protocol
         // wanting to read next handshake message. The same may happen with
         // renegotation.
+        o->poll_flag |= WRITE_NEEDS_READ; // set flag
         ret = MP_EWOULDBLOCK;
     }
     *errcode = ret;
@@ -348,6 +351,43 @@ STATIC mp_uint_t socket_ioctl(mp_obj_t o_in, mp_uint_t request, uintptr_t arg, i
         mbedtls_ssl_config_free(&self->conf);
         mbedtls_ctr_drbg_free(&self->ctr_drbg);
         mbedtls_entropy_free(&self->entropy);
+    } else if (request == MP_STREAM_POLL) {
+        mp_uint_t ret = 0;
+        // If the last read returned everything asked for there may be more in the mbedtls buffer,
+        // so find out. (There doesn't seem to be an equivalent issue with writes.)
+        if ((arg & MP_STREAM_POLL_RD) && self->poll_by_read) {
+            size_t avail = mbedtls_ssl_get_bytes_avail(&self->ssl);
+            if (avail > 0) {
+                ret = MP_STREAM_POLL_RD;
+            }
+        }
+        // If we're polling to read but not write but mbedtls previously said it needs to write in
+        // order to be able to read then poll for both and if either is available pretend the socket
+        // is readable. When the app then performs a read, mbedtls is happy to perform the writes as
+        // well. Essentially, what we're ensuring is that one of mbedtls' read/write functions is
+        // called as soon as the socket can do something.
+        if ((arg & MP_STREAM_POLL_RD) && !(arg & MP_STREAM_POLL_WR) &&
+            self->poll_flag & READ_NEEDS_WRITE) {
+            arg |= MP_STREAM_POLL_WR;
+            ret |= mp_get_stream(self->sock)->ioctl(self->sock, request, arg, errcode);
+            if (ret & MP_STREAM_POLL_WR) {
+                ret |= MP_STREAM_POLL_RD;
+                ret &= ~MP_STREAM_POLL_WR;
+            }
+            return ret;
+            // Now comes the same logic flipped around for write
+        } else if ((arg & MP_STREAM_POLL_WR) && !(arg & MP_STREAM_POLL_RD) &&
+                   self->poll_flag & WRITE_NEEDS_READ) {
+            arg |= MP_STREAM_POLL_RD;
+            ret |= mp_get_stream(self->sock)->ioctl(self->sock, request, arg, errcode);
+            if (ret & MP_STREAM_POLL_RD) {
+                ret |= MP_STREAM_POLL_WR;
+                ret &= ~MP_STREAM_POLL_RD;
+            }
+            return ret;
+        }
+        // Pass down to underlying socket
+        return ret | mp_get_stream(self->sock)->ioctl(self->sock, request, arg, errcode);
     }
     // Pass all requests down to the underlying socket
     return mp_get_stream(self->sock)->ioctl(self->sock, request, arg, errcode);
@@ -409,6 +449,7 @@ STATIC MP_DEFINE_CONST_FUN_OBJ_KW(mod_ssl_wrap_socket_obj, 1, mod_ssl_wrap_socke
 STATIC const mp_rom_map_elem_t mp_module_ssl_globals_table[] = {
     { MP_ROM_QSTR(MP_QSTR___name__), MP_ROM_QSTR(MP_QSTR_ussl) },
     { MP_ROM_QSTR(MP_QSTR_wrap_socket), MP_ROM_PTR(&mod_ssl_wrap_socket_obj) },
+    { MP_ROM_QSTR(MP_QSTR_errstr), MP_ROM_PTR(&mod_ssl_errstr_obj) },
 };
 
 STATIC MP_DEFINE_CONST_DICT(mp_module_ssl_globals, mp_module_ssl_globals_table);

--- a/ports/esp32/modsocket.c
+++ b/ports/esp32/modsocket.c
@@ -355,6 +355,9 @@ STATIC mp_obj_t socket_connect(const mp_obj_t arg0, const mp_obj_t arg1) {
     MP_THREAD_GIL_ENTER();
     lwip_freeaddrinfo(res);
     if (r != 0) {
+        // side-note: LwIP internally doesn't seem to have an error code for ECONNREFUSED and
+        // so refused connections show up as ECONNRESET. Could be band-aided for blocking connect,
+        // harder to do for nonblocking.
         mp_raise_OSError(errno);
     }
 

--- a/tests/multi_net/ssl_data.py.exp
+++ b/tests/multi_net/ssl_data.py.exp
@@ -1,4 +1,0 @@
---- instance0 ---
-b'client to server'
---- instance1 ---
-b'server to client'

--- a/tests/net_inet/uasyncio_ssl.py
+++ b/tests/net_inet/uasyncio_ssl.py
@@ -1,0 +1,47 @@
+# Attempt to test the funky poll patch in modussl_mbedtls, but sadly this works
+# without the patch...
+
+try:
+    import uasyncio as asyncio, ussl as ssl
+except ImportError:
+    try:
+        import asyncio, ssl
+    except ImportError:
+        print("SKIP")
+        raise SystemExit
+
+
+# open a connection and start by reading, not writing
+async def read_first(host, port):
+    reader, writer = await asyncio.open_connection(host, port, ssl=True)
+
+    print("read something")
+    inbuf = b""
+    while len(inbuf) < 20:
+        try:
+            b = await reader.read(100)
+        except OSError as e:
+            if e.args[0] < -120:
+                print("read SSL error -%x : %s" % (-e.args[0], ssl.errstr(e.args[0])))
+                raise OSError(e.args[0], bytes.decode(ssl.errstr(e.args[0])))
+            else:
+                print("read OSError: %d / -%x" % (e.args[0], -e.args[0]))
+                raise
+        print("read:", b)
+        if b is None:
+            continue
+        elif len(b) == 0:
+            print("EOF")
+            break
+        elif len(b) > 0:
+            inbuf += b
+        else:
+            raise ValueError("negative length returned by recv")
+
+    print("close")
+    writer.close()
+    await writer.wait_closed()
+    print("done")
+
+
+asyncio.run(read_first("aspmx.l.google.com", 25))


### PR DESCRIPTION
This PR sits on top of #5819 and ~#5825~#6615 and adds SSL support to uasyncio. Update: I backed out #5819 and ~#5825~#6615 to make the PR easier to review on github, obviously CI now fails. I'll do the proper rebase once the fate of these other PRs is determined.

Adding the wrap_socket to Stream.open_connection is relatively straight-forward. It's different from CPython (no SSLContext) but compatible. The trickier part is to deal with poll, see comments in modussl_mbedtls. I believe I came up with a clean solution but so far I have failed to produce a test case that generates the problem so I can have a fail-before/success-after confirmation that the solution actually works or actually is necessary. I need to think about a test case more but if anyone can construct one I'd love that too!

I added a errstr class function to ussl in order to convert an ssl error number to a string. This is needed when using uasyncio because it uses read/write which means ussl doesn't raise an OSError (which would have the error string) and when the app gets the OSError through the Stream stuff it is again unintelligible. Now at least one can write something like `if e.args[0] < -120: print(ssl.errstr(e.args[0]))`.

Open to-do items:
- figure out whether the poll patch is needed and works
- add strerr and poll patch to axtls
- make recv and send run their OSError raising through ussl_raise_error to get an error message in there
- add errstr to docs
- add wrap_socket to Server.serve
- test against esp32 espidf v3
- test on other platforms

I should say that the tests don't all pass. Specifically, net_inet/test_tls_sites fails on the esp32. I'm pretty sure the issue is an out-of-memory in esp-idf situation. It ends up dropping wifi. I believe if I fix #5835 there may be just enough memory again to sail through...

I'll proceed once I have feedback