### PR TITLE
esp32: Fail on unsupported IDF hash.

### DIFF
--- a/ports/esp32/Makefile
+++ b/ports/esp32/Makefile
@@ -53,8 +53,8 @@ SDKCONFIG_H = $(BUILD)/sdkconfig.h
 
 # The git hash of the currently supported ESP IDF version.
 # These correspond to v3.3.1 and v4.0.
-ESPIDF_SUPHASH_V3 := 143d26aa49df524e10fb8e41a71d12e731b9b71d
-ESPIDF_SUPHASH_V4 := a3f3c7bdc3e81d88eba076c31cd92bca9fadd02c
+ESPIDF_SUPHASH_V3 ?= 143d26aa49df524e10fb8e41a71d12e731b9b71d
+ESPIDF_SUPHASH_V4 ?= a3f3c7bdc3e81d88eba076c31cd92bca9fadd02c
 
 define print_supported_git_hash
 $(info Supported git hash (v3.3): $(ESPIDF_SUPHASH_V3))
@@ -95,12 +95,14 @@ $(info Please see README.md for more information)
 $(error Incorrect pyparsing version)
 endif
 else
-$(info ** WARNING **)
+$(info ** ERROR **)
 $(info The git hash of ESP IDF does not match the supported version)
 $(info The build may complete and the firmware may work but it is not guaranteed)
 $(info ESP IDF path:       $(ESPIDF))
 $(info Current git hash:   $(ESPIDF_CURHASH))
 dummy := $(call print_supported_git_hash)
+$(info To update the IDF version (or bypass this check), see ports/esp32/README.md)
+$(error Unsupported IDF version)
 endif
 
 # pretty format of ESP IDF version, used internally by the IDF

--- a/ports/esp32/Makefile
+++ b/ports/esp32/Makefile
@@ -54,7 +54,7 @@ SDKCONFIG_H = $(BUILD)/sdkconfig.h
 # The git hash of the currently supported ESP IDF version.
 # These correspond to v3.3.1 and v4.0.
 ESPIDF_SUPHASH_V3 := 143d26aa49df524e10fb8e41a71d12e731b9b71d
-ESPIDF_SUPHASH_V4 := 463a9d8b7f9af8205222b80707f9bdbba7c530e1
+ESPIDF_SUPHASH_V4 := a3f3c7bdc3e81d88eba076c31cd92bca9fadd02c
 
 define print_supported_git_hash
 $(info Supported git hash (v3.3): $(ESPIDF_SUPHASH_V3))

--- a/ports/esp32/README.md
+++ b/ports/esp32/README.md
@@ -48,6 +48,16 @@ $ git checkout <Current supported ESP-IDF commit hash>
 $ git submodule update --init --recursive
 ```
 
+If you need to update your IDF version (i.e. because the build is complaining):
+```bash
+$ cd $ESPIDF
+$ git fetch origin
+$ git checkout <Current supported ESP-IDF commit hash>
+$ git submodule update --init --recursive
+```
+
+Note: If you want to override the supported version, you can set `ESPIDF_SUPHASH_V4` (or `ESPIDF_SUPHASH_V3`) in your `makefile`/`GNUmakefile` (see below).
+
 Note: The ESP IDF v4.x support is currently experimental. It does not
 currently support PPP or wired Ethernet.
 


### PR DESCRIPTION
While I was doing #5851 it occurred to me that the current "unsupported hash" warning isn't very useful -- it flashes past way too quickly, and will be easily missed.

This PR makes it an error, and adds some more help to the README.

If someone really wants to override the hash, they can do so in `makefile`.