### PR TITLE
py/parse: Remove unnecessary check in const folding for ** operator.

### DIFF
--- a/py/parse.c
+++ b/py/parse.c
@@ -655,8 +655,8 @@ STATIC bool fold_constants(parser_t *parser, uint8_t rule_id, size_t num_args) {
                 return false;
             }
             mp_token_kind_t tok = MP_PARSE_NODE_LEAF_ARG(peek_result(parser, i));
-            if (tok == MP_TOKEN_OP_AT || tok == MP_TOKEN_OP_SLASH || tok == MP_TOKEN_OP_DBL_STAR) {
-                // Can't fold @ or / or **
+            if (tok == MP_TOKEN_OP_AT || tok == MP_TOKEN_OP_SLASH) {
+                // Can't fold @ or /
                 return false;
             }
             mp_binary_op_t op = MP_BINARY_OP_LSHIFT + (tok - MP_TOKEN_OP_DBL_LESS);

--- a/tests/micropython/const_error.py
+++ b/tests/micropython/const_error.py
@@ -15,3 +15,12 @@ test_syntax("a = const(x)")
 
 # redefined constant
 test_syntax("A = const(1); A = const(2)")
+
+# these operations are not supported within const
+test_syntax("A = const(1 @ 2)")
+test_syntax("A = const(1 / 2)")
+test_syntax("A = const(1 ** 2)")
+test_syntax("A = const(1 << -2)")
+test_syntax("A = const(1 >> -2)")
+test_syntax("A = const(1 % 0)")
+test_syntax("A = const(1 // 0)")

--- a/tests/micropython/const_error.py.exp
+++ b/tests/micropython/const_error.py.exp
@@ -1,2 +1,9 @@
 SyntaxError
 SyntaxError
+SyntaxError
+SyntaxError
+SyntaxError
+SyntaxError
+SyntaxError
+SyntaxError
+SyntaxError


### PR DESCRIPTION
In this part of the code there is no way to get the ** operator, so no need to check for it.

This commit also adds tests for this, and other related, invalid const operations.

Related to #5865 