### PR TITLE
travis: Make OSX build work again.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -211,8 +211,6 @@ jobs:
       env:
         - NAME="unix port build with clang on OSX"
         - PKG_CONFIG_PATH=/usr/local/opt/libffi/lib/pkgconfig
-      install:
-        - brew install pkgconfig
       script:
         - make ${MAKEOPTS} -C mpy-cross
         - make ${MAKEOPTS} -C ports/unix submodules


### PR DESCRIPTION
Recent builds are failing with the following error:

Error: pkg-config 0.29.2 is already installed

Assuming this will be the case form now on we don't have to
install it anymore.