### PR TITLE
ports/unix/Makefile: Fix install target

### DIFF
--- a/ports/unix/Makefile
+++ b/ports/unix/Makefile
@@ -258,7 +258,8 @@ PREFIX = /usr/local
 BINDIR = $(DESTDIR)$(PREFIX)/bin
 
 install: $(PROG)
-	install -D $(PROG) $(BINDIR)/$(PROG)
+	install -d $(BINDIR)
+	install $(PROG) $(BINDIR)/$(PROG)
 
 uninstall:
 	-rm $(BINDIR)/$(PROG)


### PR DESCRIPTION
This fixes a regression due to the -D option of install not being universally available.

Fixes #5885