### PR TITLE
py/parse: Support constant folding of power operator for integers.

### DIFF
--- a/tests/basics/int_constfolding.py
+++ b/tests/basics/int_constfolding.py
@@ -30,6 +30,10 @@ print(-123 // 7, -123 % 7)
 print(123 // -7, 123 % -7)
 print(-123 // -7, -123 % -7)
 
+# power
+print(2 ** 3)
+print(3 ** 4)
+
 # won't fold so an exception can be raised at runtime
 try:
     1 << -1

--- a/tests/micropython/const_error.py
+++ b/tests/micropython/const_error.py
@@ -19,7 +19,7 @@ test_syntax("A = const(1); A = const(2)")
 # these operations are not supported within const
 test_syntax("A = const(1 @ 2)")
 test_syntax("A = const(1 / 2)")
-test_syntax("A = const(1 ** 2)")
+test_syntax("A = const(1 ** -2)")
 test_syntax("A = const(1 << -2)")
 test_syntax("A = const(1 >> -2)")
 test_syntax("A = const(1 % 0)")


### PR DESCRIPTION
As raised in #5865, constant folding in the parser does not support folding of the power `**` operator for integers.  It's actually quite easy to enable this, which is what is done in this PR.

Code size change for this is:
```
   bare-arm:   +36 +0.055% 
minimal x86:   +48 +0.032% 
   unix x64:   +48 +0.010% 
unix nanbox:   +64 +0.014% 
      stm32:   +52 +0.014% PYBV10
     cc3200:   +48 +0.026% 
    esp8266:   +40 +0.006% GENERIC
      esp32:   +36 +0.003% GENERIC
        nrf:   +40 +0.028% pca10040
       samd:   +36 +0.035% ADAFRUIT_ITSYBITSY_M4_EXPRESS
```

I'm not 100% sure the increase in code size is worth it... for powers of 2 one can use `1 << x`.  So what this enables here is folding of powers of integers other than 2.  Note that it enables it in general, eg in arbitrary code that has constant integer expressions like `foo(3 ** 2)`, as well as for the `const` feature, eg `X = const(3 ** 2)`.

An argument for merging this change is that really small builds won't include the compiler at all (and use `mpy-cross` offline) and so won't see an increase in code size.

If it's not included by default perhaps it could be included under a new conditional flag for compiler optimisations which is enabled for `mpy-cross` only.