### PR TITLE
all: Clean up error strings to use lowercase and change cannot to can't.

### DIFF
--- a/extmod/moduasyncio.c
+++ b/extmod/moduasyncio.c
@@ -173,7 +173,7 @@ STATIC mp_obj_t task_cancel(mp_obj_t self_in) {
     // Can't cancel self (not supported yet).
     mp_obj_t cur_task = mp_obj_dict_get(uasyncio_context, MP_OBJ_NEW_QSTR(MP_QSTR_cur_task));
     if (self_in == cur_task) {
-        mp_raise_msg(&mp_type_RuntimeError, MP_ERROR_TEXT("cannot cancel self"));
+        mp_raise_msg(&mp_type_RuntimeError, MP_ERROR_TEXT("can't cancel self"));
     }
     // If Task waits on another task then forward the cancel to the one it's waiting on.
     while (mp_obj_is_subclass_fast(MP_OBJ_FROM_PTR(mp_obj_get_type(self->data)), MP_OBJ_FROM_PTR(&task_type))) {

--- a/extmod/moductypes.c
+++ b/extmod/moductypes.c
@@ -226,7 +226,7 @@ STATIC mp_uint_t uctypes_struct_size(mp_obj_t desc_in, int layout_type, mp_uint_
             // but scalar structure field is lowered into native Python int, so all
             // type info is lost. So, we cannot say if it's scalar type description,
             // or such lowered scalar.
-            mp_raise_TypeError(MP_ERROR_TEXT("Cannot unambiguously get sizeof scalar"));
+            mp_raise_TypeError(MP_ERROR_TEXT("can't unambiguously get sizeof scalar"));
         }
         syntax_error();
     }
@@ -557,7 +557,7 @@ STATIC mp_obj_t uctypes_struct_subscr(mp_obj_t self_in, mp_obj_t index_in, mp_ob
     } else {
         // load / store
         if (!mp_obj_is_type(self->desc, &mp_type_tuple)) {
-            mp_raise_TypeError(MP_ERROR_TEXT("struct: cannot index"));
+            mp_raise_TypeError(MP_ERROR_TEXT("struct: can't index"));
         }
 
         mp_obj_tuple_t *t = MP_OBJ_TO_PTR(self->desc);

--- a/extmod/modure.c
+++ b/extmod/modure.c
@@ -235,7 +235,7 @@ STATIC mp_obj_t re_split(size_t n_args, const mp_obj_t *args) {
         mp_obj_t s = mp_obj_new_str_of_type(str_type, (const byte *)subj.begin, caps[0] - subj.begin);
         mp_obj_list_append(retval, s);
         if (self->re.sub > 0) {
-            mp_raise_NotImplementedError(MP_ERROR_TEXT("Splitting with sub-captures"));
+            mp_raise_NotImplementedError(MP_ERROR_TEXT("splitting with sub-captures"));
         }
         subj.begin = caps[1];
         if (maxsplit > 0 && --maxsplit == 0) {
@@ -403,7 +403,7 @@ STATIC mp_obj_t mod_re_compile(size_t n_args, const mp_obj_t *args) {
     int error = re1_5_compilecode(&o->re, re_str);
     if (error != 0) {
     error:
-        mp_raise_ValueError(MP_ERROR_TEXT("Error in regex"));
+        mp_raise_ValueError(MP_ERROR_TEXT("error in regex"));
     }
     #if MICROPY_PY_URE_DEBUG
     if (flags & FLAG_DEBUG) {

--- a/ports/esp32/machine_adc.c
+++ b/ports/esp32/machine_adc.c
@@ -81,7 +81,7 @@ STATIC mp_obj_t madc_make_new(const mp_obj_type_t *type, size_t n_args, size_t n
     if (err == ESP_OK) {
         return MP_OBJ_FROM_PTR(self);
     }
-    mp_raise_ValueError(MP_ERROR_TEXT("Parameter Error"));
+    mp_raise_ValueError(MP_ERROR_TEXT("parameter error"));
 }
 
 STATIC void madc_print(const mp_print_t *print, mp_obj_t self_in, mp_print_kind_t kind) {
@@ -104,7 +104,7 @@ STATIC mp_obj_t madc_read(mp_obj_t self_in) {
     madc_obj_t *self = self_in;
     int val = adc1_get_raw(self->adc1_id);
     if (val == -1) {
-        mp_raise_ValueError(MP_ERROR_TEXT("Parameter Error"));
+        mp_raise_ValueError(MP_ERROR_TEXT("parameter error"));
     }
     return MP_OBJ_NEW_SMALL_INT(val);
 }
@@ -117,7 +117,7 @@ STATIC mp_obj_t madc_atten(mp_obj_t self_in, mp_obj_t atten_in) {
     if (err == ESP_OK) {
         return mp_const_none;
     }
-    mp_raise_ValueError(MP_ERROR_TEXT("Parameter Error"));
+    mp_raise_ValueError(MP_ERROR_TEXT("parameter error"));
 }
 MP_DEFINE_CONST_FUN_OBJ_2(madc_atten_obj, madc_atten);
 
@@ -125,7 +125,7 @@ STATIC mp_obj_t madc_width(mp_obj_t cls_in, mp_obj_t width_in) {
     adc_bits_width_t width = mp_obj_get_int(width_in);
     esp_err_t err = adc1_config_width(width);
     if (err != ESP_OK) {
-        mp_raise_ValueError(MP_ERROR_TEXT("Parameter Error"));
+        mp_raise_ValueError(MP_ERROR_TEXT("parameter error"));
     }
     switch (width) {
         case ADC_WIDTH_9Bit:

--- a/ports/esp32/machine_dac.c
+++ b/ports/esp32/machine_dac.c
@@ -70,7 +70,7 @@ STATIC mp_obj_t mdac_make_new(const mp_obj_type_t *type, size_t n_args, size_t n
     if (err == ESP_OK) {
         return MP_OBJ_FROM_PTR(self);
     }
-    mp_raise_ValueError(MP_ERROR_TEXT("Parameter Error"));
+    mp_raise_ValueError(MP_ERROR_TEXT("parameter error"));
 }
 
 STATIC void mdac_print(const mp_print_t *print, mp_obj_t self_in, mp_print_kind_t kind) {
@@ -82,14 +82,14 @@ STATIC mp_obj_t mdac_write(mp_obj_t self_in, mp_obj_t value_in) {
     mdac_obj_t *self = self_in;
     int value = mp_obj_get_int(value_in);
     if (value < 0 || value > 255) {
-        mp_raise_ValueError(MP_ERROR_TEXT("Value out of range"));
+        mp_raise_ValueError(MP_ERROR_TEXT("value out of range"));
     }
 
     esp_err_t err = dac_output_voltage(self->dac_id, value);
     if (err == ESP_OK) {
         return mp_const_none;
     }
-    mp_raise_ValueError(MP_ERROR_TEXT("Parameter Error"));
+    mp_raise_ValueError(MP_ERROR_TEXT("parameter error"));
 }
 MP_DEFINE_CONST_FUN_OBJ_2(mdac_write_obj, mdac_write);
 

--- a/ports/esp32/machine_pwm.c
+++ b/ports/esp32/machine_pwm.c
@@ -173,7 +173,7 @@ STATIC void esp32_pwm_init_helper(esp32_pwm_obj_t *self,
     if (tval != -1) {
         if (tval != timer_cfg.freq_hz) {
             if (!set_freq(tval)) {
-                mp_raise_msg_varg(&mp_type_ValueError, MP_ERROR_TEXT("Bad frequency %d"), tval);
+                mp_raise_msg_varg(&mp_type_ValueError, MP_ERROR_TEXT("bad frequency %d"), tval);
             }
         }
     }
@@ -247,7 +247,7 @@ STATIC mp_obj_t esp32_pwm_freq(size_t n_args, const mp_obj_t *args) {
     // set
     int tval = mp_obj_get_int(args[1]);
     if (!set_freq(tval)) {
-        mp_raise_msg_varg(&mp_type_ValueError, MP_ERROR_TEXT("Bad frequency %d"), tval);
+        mp_raise_msg_varg(&mp_type_ValueError, MP_ERROR_TEXT("bad frequency %d"), tval);
     }
     return mp_const_none;
 }

--- a/ports/esp32/machine_sdcard.c
+++ b/ports/esp32/machine_sdcard.c
@@ -177,7 +177,7 @@ STATIC mp_obj_t machine_sdcard_make_new(const mp_obj_type_t *type, size_t n_args
 
     int slot_num = arg_vals[ARG_slot].u_int;
     if (slot_num < 0 || slot_num > 3) {
-        mp_raise_ValueError(MP_ERROR_TEXT("Slot number must be between 0 and 3 inclusive"));
+        mp_raise_ValueError(MP_ERROR_TEXT("slot number must be between 0 and 3 inclusive"));
     }
 
     // Slots 0 and 1 are native SD/MMC, slots 2 and 3 are SPI
@@ -253,7 +253,7 @@ STATIC mp_obj_t machine_sdcard_make_new(const mp_obj_type_t *type, size_t n_args
         if (width == 1 || width == 4 || (width == 8 && slot_num == 0)) {
             slot_config.width = width;
         } else {
-            mp_raise_ValueError(MP_ERROR_TEXT("Width must be 1 or 4 (or 8 on slot 0)"));
+            mp_raise_ValueError(MP_ERROR_TEXT("width must be 1 or 4 (or 8 on slot 0)"));
         }
 
         DEBUG_printf("  Calling init_slot()");

--- a/ports/nrf/boards/microbit/modules/microbitimage.c
+++ b/ports/nrf/boards/microbit/modules/microbitimage.c
@@ -351,7 +351,7 @@ mp_obj_t microbit_image_get_pixel(mp_obj_t self_in, mp_obj_t x_in, mp_obj_t y_in
     mp_int_t x = mp_obj_get_int(x_in);
     mp_int_t y = mp_obj_get_int(y_in);
     if (x < 0 || y < 0) {
-        mp_raise_ValueError(MP_ERROR_TEXT("index cannot be negative"));
+        mp_raise_ValueError(MP_ERROR_TEXT("index can't be negative"));
     }
     if (x < imageWidth(self) && y < imageHeight(self)) {
         return MP_OBJ_NEW_SMALL_INT(imageGetPixelValue(self, x, y));
@@ -363,7 +363,7 @@ MP_DEFINE_CONST_FUN_OBJ_3(microbit_image_get_pixel_obj, microbit_image_get_pixel
 /* Raise an exception if not mutable */
 static void check_mutability(microbit_image_obj_t *self) {
     if (self->base.five) {
-        mp_raise_TypeError(MP_ERROR_TEXT("image cannot be modified (try copying first)"));
+        mp_raise_TypeError(MP_ERROR_TEXT("image can't be modified (try copying first)"));
     }
 }
 
@@ -375,7 +375,7 @@ mp_obj_t microbit_image_set_pixel(mp_uint_t n_args, const mp_obj_t *args) {
     mp_int_t x = mp_obj_get_int(args[1]);
     mp_int_t y = mp_obj_get_int(args[2]);
     if (x < 0 || y < 0) {
-        mp_raise_ValueError(MP_ERROR_TEXT("index cannot be negative"));
+        mp_raise_ValueError(MP_ERROR_TEXT("index can't be negative"));
     }
     mp_int_t bright = mp_obj_get_int(args[3]);
     if (bright < 0 || bright > MAX_BRIGHTNESS)
@@ -416,7 +416,7 @@ mp_obj_t microbit_image_blit(mp_uint_t n_args, const mp_obj_t *args) {
     mp_int_t w = mp_obj_get_int(args[4]);
     mp_int_t h = mp_obj_get_int(args[5]);
     if (w < 0 || h < 0) {
-        mp_raise_ValueError(MP_ERROR_TEXT("size cannot be negative"));
+        mp_raise_ValueError(MP_ERROR_TEXT("size can't be negative"));
     }
     mp_int_t xdest;
     mp_int_t ydest;

--- a/ports/stm32/pyb_i2c.c
+++ b/ports/stm32/pyb_i2c.c
@@ -200,7 +200,7 @@ STATIC void i2c_set_baudrate(I2C_InitTypeDef *init, uint32_t baudrate) {
             return;
         }
     }
-    mp_raise_msg_varg(&mp_type_ValueError, MP_ERROR_TEXT("Unsupported I2C baudrate: %u"), baudrate);
+    mp_raise_msg_varg(&mp_type_ValueError, MP_ERROR_TEXT("unsupported I2C baudrate: %u"), baudrate);
 }
 
 uint32_t pyb_i2c_get_baudrate(I2C_HandleTypeDef *i2c) {

--- a/ports/unix/modffi.c
+++ b/ports/unix/modffi.c
@@ -148,7 +148,7 @@ STATIC ffi_type *get_ffi_type(mp_obj_t o_in) {
     }
     // TODO: Support actual libffi type objects
 
-    mp_raise_TypeError(MP_ERROR_TEXT("Unknown type"));
+    mp_raise_TypeError(MP_ERROR_TEXT("unknown type"));
 }
 
 STATIC mp_obj_t return_ffi_value(ffi_arg val, char type) {
@@ -218,7 +218,7 @@ STATIC mp_obj_t make_func(mp_obj_t rettype_in, void *func, mp_obj_t argtypes_in)
 
     int res = ffi_prep_cif(&o->cif, FFI_DEFAULT_ABI, nparams, char2ffi_type(*rettype), o->params);
     if (res != FFI_OK) {
-        mp_raise_ValueError(MP_ERROR_TEXT("Error in ffi_prep_cif"));
+        mp_raise_ValueError(MP_ERROR_TEXT("error in ffi_prep_cif"));
     }
 
     return MP_OBJ_FROM_PTR(o);
@@ -276,7 +276,7 @@ STATIC mp_obj_t mod_ffi_callback(mp_obj_t rettype_in, mp_obj_t func_in, mp_obj_t
 
     int res = ffi_prep_cif(&o->cif, FFI_DEFAULT_ABI, nparams, char2ffi_type(*rettype), o->params);
     if (res != FFI_OK) {
-        mp_raise_ValueError(MP_ERROR_TEXT("Error in ffi_prep_cif"));
+        mp_raise_ValueError(MP_ERROR_TEXT("error in ffi_prep_cif"));
     }
 
     res = ffi_prep_closure_loc(o->clo, &o->cif, call_py_func, MP_OBJ_TO_PTR(func_in), o->func);
@@ -425,7 +425,7 @@ STATIC mp_obj_t ffifunc_call(mp_obj_t self_in, size_t n_args, size_t n_kw, const
     }
 
 error:
-    mp_raise_TypeError(MP_ERROR_TEXT("Don't know how to pass object to native function"));
+    mp_raise_TypeError(MP_ERROR_TEXT("don't know how to pass object to native function"));
 }
 
 STATIC const mp_obj_type_t ffifunc_type = {

--- a/ports/unix/modjni.c
+++ b/ports/unix/modjni.c
@@ -531,7 +531,7 @@ STATIC mp_obj_t call_method(jobject obj, const char *name, jarray methods, bool 
                     ret = new_jobject(res);
                 } else {
                     JJ(ReleaseStringUTFChars, name_o, decl);
-                    mp_raise_TypeError(MP_ERROR_TEXT("cannot handle return type"));
+                    mp_raise_TypeError(MP_ERROR_TEXT("can't handle return type"));
                 }
 
                 JJ(ReleaseStringUTFChars, name_o, decl);

--- a/py/builtinimport.c
+++ b/py/builtinimport.c
@@ -313,7 +313,7 @@ mp_obj_t mp_builtin___import__(size_t n_args, const mp_obj_t *args) {
 
         // We must have some component left over to import from
         if (p == this_name) {
-            mp_raise_ValueError(MP_ERROR_TEXT("cannot perform relative import"));
+            mp_raise_ValueError(MP_ERROR_TEXT("can't perform relative import"));
         }
 
         uint new_mod_l = (mod_len == 0 ? (size_t)(p - this_name) : (size_t)(p - this_name) + 1 + mod_len);

--- a/py/objslice.c
+++ b/py/objslice.c
@@ -124,7 +124,7 @@ void mp_obj_slice_indices(mp_obj_t self_in, mp_int_t length, mp_bound_slice_t *r
     } else {
         step = mp_obj_get_int(self->step);
         if (step == 0) {
-            mp_raise_ValueError(MP_ERROR_TEXT("slice step cannot be zero"));
+            mp_raise_ValueError(MP_ERROR_TEXT("slice step can't be zero"));
         }
     }
 

--- a/py/objtype.c
+++ b/py/objtype.c
@@ -989,9 +989,9 @@ STATIC mp_obj_t type_call(mp_obj_t self_in, size_t n_args, size_t n_kw, const mp
 
     if (self->make_new == NULL) {
         #if MICROPY_ERROR_REPORTING == MICROPY_ERROR_REPORTING_TERSE
-        mp_raise_TypeError(MP_ERROR_TEXT("cannot create instance"));
+        mp_raise_TypeError(MP_ERROR_TEXT("can't create instance"));
         #else
-        mp_raise_msg_varg(&mp_type_TypeError, MP_ERROR_TEXT("cannot create '%q' instances"), self->name);
+        mp_raise_msg_varg(&mp_type_TypeError, MP_ERROR_TEXT("can't create '%q' instances"), self->name);
         #endif
     }
 

--- a/py/runtime.c
+++ b/py/runtime.c
@@ -1392,7 +1392,7 @@ mp_obj_t mp_import_from(mp_obj_t module, qstr name) {
     if (dest[1] != MP_OBJ_NULL) {
         // Hopefully we can't import bound method from an object
     import_error:
-        mp_raise_msg_varg(&mp_type_ImportError, MP_ERROR_TEXT("cannot import name %q"), name);
+        mp_raise_msg_varg(&mp_type_ImportError, MP_ERROR_TEXT("can't import name %q"), name);
     }
 
     if (dest[0] != MP_OBJ_NULL) {


### PR DESCRIPTION
Now that error string compression is there it's more important to have consistent error string formatting (eg all lowercase English words, consistent contractions).  This PR cleans up some of the strings to make them more consistent.  Change in code size is:
```
   bare-arm:    -4 -0.006% 
minimal x86:    +0 +0.000% 
   unix x64:    +0 +0.000% 
unix nanbox:   -32 -0.007% 
      stm32:   -24 -0.006% PYBV10
     cc3200:    +0 +0.000% 
    esp8266:   -24 -0.004% GENERIC
      esp32:   -32 -0.002% GENERIC[incl -32(data)]
        nrf:    -4 -0.003% pca10040
       samd:   -12 -0.012% ADAFRUIT_ITSYBITSY_M4_EXPRESS
```
(It's also now much easier to find all error strings by grep'ing for `MP_ERROR_TEXT`.)