### PR TITLE
py/makecompresseddata.py: Don't prefix str with mark if not compressed.

### DIFF
--- a/py/makecompresseddata.py
+++ b/py/makecompresseddata.py
@@ -168,7 +168,11 @@ def main(collected_path, fn):
 
     # Print the replacements.
     for uncomp, comp in error_strings.items():
-        print('MP_MATCH_COMPRESSED("{}", "\\{:03o}{}")'.format(uncomp, _COMPRESSED_MARKER, comp))
+        if uncomp == comp:
+            prefix = ""
+        else:
+            prefix = "\\{:03o}".format(_COMPRESSED_MARKER)
+        print('MP_MATCH_COMPRESSED("{}", "{}{}")'.format(uncomp, prefix, comp))
 
     # Used to calculate the "true" length of the (escaped) compressed strings.
     def unescape(s):


### PR DESCRIPTION
If a string doesn't have any compressed parts then it doesn't need the compression sentinel byte at the start.

Change in code size for this PR:
```
   bare-arm:    +0 +0.000% 
minimal x86:    +0 +0.000% 
   unix x64:    +0 +0.000% 
unix nanbox:    +0 +0.000% 
      stm32:   -20 -0.005% PYBV10
     cc3200:    +0 +0.000% 
    esp8266:   -32 -0.005% GENERIC
      esp32:   -16 -0.001% GENERIC[incl -16(data)]
        nrf:    -4 -0.003% pca10040
       samd:    +0 +0.000% ADAFRUIT_ITSYBITSY_M4_EXPRESS
```

@jimmo does this look correct?