### PR TITLE
py/scope: Make sure low numbered qstrs fit in an uint8_t

### DIFF
--- a/py/scope.c
+++ b/py/scope.c
@@ -30,7 +30,7 @@
 
 #if MICROPY_ENABLE_COMPILER
 
-// these low numbered qstrs should fit in 8 bits
+// these low numbered qstrs should fit in 8 bits. See assertions below.
 STATIC const uint8_t scope_simple_name_table[] = {
     [SCOPE_MODULE] = MP_QSTR__lt_module_gt_,
     [SCOPE_LAMBDA] = MP_QSTR__lt_lambda_gt_,
@@ -41,6 +41,14 @@ STATIC const uint8_t scope_simple_name_table[] = {
 };
 
 scope_t *scope_new(scope_kind_t kind, mp_parse_node_t pn, qstr source_file, mp_uint_t emit_options) {
+    // Make sure those qstrs indeed fit in an uint8_t
+    MP_STATIC_ASSERT(MP_QSTR__lt_module_gt_ <= UINT8_MAX);
+    MP_STATIC_ASSERT(MP_QSTR__lt_lambda_gt_ <= UINT8_MAX);
+    MP_STATIC_ASSERT(MP_QSTR__lt_listcomp_gt_ <= UINT8_MAX);
+    MP_STATIC_ASSERT(MP_QSTR__lt_dictcomp_gt_ <= UINT8_MAX);
+    MP_STATIC_ASSERT(MP_QSTR__lt_setcomp_gt_ <= UINT8_MAX);
+    MP_STATIC_ASSERT(MP_QSTR__lt_genexpr_gt_ <= UINT8_MAX);
+
     scope_t *scope = m_new0(scope_t, 1);
     scope->kind = kind;
     scope->pn = pn;


### PR DESCRIPTION
The code of py/scope.c uses a few QSTRs it stores in an uint8_t array. Doing so, it assumes those QSTRs can indeed fit in an uint8_t.

This commit asserts this is true at compile time.

This is useful when MicroPython is integrated in another system where QSTRs are generated (just a bit) differently.