### PR TITLE
Docs: uasyncio.rst Detail exceptions in cancellation and timeouts

### DIFF
--- a/docs/library/uasyncio.rst
+++ b/docs/library/uasyncio.rst
@@ -64,13 +64,13 @@ Additional functions
 .. function:: wait_for(awaitable, timeout)
 
     Wait for the *awaitable* to complete, but cancel it if it takes longer
-    that *timeout* seconds.  If *awaitable* is not a task then a task will be
+    than *timeout* seconds.  If *awaitable* is not a task then a task will be
     created from it.
 
     If a timeout occurs, it cancels the task and raises ``asyncio.TimeoutError``:
     this should be trapped by the caller.  The task receives
-    ``asyncio.CancelledError`` which may be ignored.  Cleanup code may be run by
-    trapping the exception or via ``try ... finally``.
+    ``asyncio.CancelledError`` which may be ignored or trapped using ``try...except``
+    or ``try...finally`` to run cleanup code.
 
     Returns the return value of *awaitable*.
 

--- a/docs/library/uasyncio.rst
+++ b/docs/library/uasyncio.rst
@@ -68,7 +68,9 @@ Additional functions
     created from it.
 
     If a timeout occurs, it cancels the task and raises ``asyncio.TimeoutError``:
-    this should be trapped by the caller.
+    this should be trapped by the caller.  The task receives
+    ``asyncio.CancelledError`` which may be ignored.  Cleanup code may be run by
+    trapping the exception or via ``try ... finally``.
 
     Returns the return value of *awaitable*.
 
@@ -96,8 +98,9 @@ class Task
 
 .. method:: Task.cancel()
 
-    Cancel the task by injecting a ``CancelledError`` into it.  The task may
-    or may not ignore this exception.
+    Cancel the task by injecting ``asyncio.CancelledError`` into it.  The task may
+    ignore this exception.  Cleanup code may be run by trapping it, or via
+    ``try ... finally``.
 
 class Event
 -----------


### PR DESCRIPTION
Replaces https://github.com/micropython/micropython/pull/5883. Clarify the exceptions which are thrown in task cancellation and timeout.