### PR TITLE
py/misc.h: Always provide no-op defines without ROM_TEXT_COMPRESSION.

### DIFF
--- a/py/misc.h
+++ b/py/misc.h
@@ -259,25 +259,20 @@ typedef union _mp_float_union_t {
 
 /** ROM string compression *************/
 
+#if MICROPY_ROM_TEXT_COMPRESSION
+
 #ifdef NO_QSTR
 
-// QSTR extraction sets NO_QSTR.
+// Compression enabled but doing QSTR extraction.
 // So leave MP_COMPRESSED_ROM_TEXT in place for makeqstrdefs.py / makecompresseddata.py to find them.
-
-// However, dynamic native modules also set NO_QSTR, so provide a dummy implementation.
-#if MICROPY_ENABLE_DYNRUNTIME
-typedef const char *mp_rom_error_text_t;
-#define MP_COMPRESSED_ROM_TEXT(x) x
-#endif
 
 #else
 
-#if MICROPY_ROM_TEXT_COMPRESSION
+// Compression enabled and doing a regular build.
+// Map MP_COMPRESSED_ROM_TEXT to the compressed strings.
 
 // Force usage of the MP_ERROR_TEXT macro by requiring an opaque type.
 typedef struct {} *mp_rom_error_text_t;
-
-// Regular build -- map MP_COMPRESSED_ROM_TEXT to the compressed strings.
 
 #include <string.h>
 
@@ -297,15 +292,16 @@ inline __attribute__((always_inline)) const char *MP_COMPRESSED_ROM_TEXT(const c
     return msg;
 }
 
+#endif
+
 #else
 
 // Compression not enabled, just make it a no-op.
+
 typedef const char *mp_rom_error_text_t;
 #define MP_COMPRESSED_ROM_TEXT(x) x
 
 #endif // MICROPY_ROM_TEXT_COMPRESSION
-
-#endif // NO_QSTR
 
 // Might add more types of compressed text in the future.
 // For now, forward directly to MP_COMPRESSED_ROM_TEXT.

--- a/py/mkrules.mk
+++ b/py/mkrules.mk
@@ -7,19 +7,18 @@ endif
 # Extra deps that need to happen before object compilation.
 OBJ_EXTRA_ORDER_DEPS =
 
+ifeq ($(MICROPY_ROM_TEXT_COMPRESSION),1)
+# If compression is enabled, trigger the build of compressed.data.h...
+OBJ_EXTRA_ORDER_DEPS += $(HEADER_BUILD)/compressed.data.h
+# ...and enable the MP_COMPRESSED_ROM_TEXT macro (used by MP_ERROR_TEXT).
+CFLAGS += -DMICROPY_ROM_TEXT_COMPRESSION=1
+endif
+
 # QSTR generation uses the same CFLAGS, with these modifications.
 # Note: := to force evalulation immediately.
 QSTR_GEN_CFLAGS := $(CFLAGS)
 QSTR_GEN_CFLAGS += -DNO_QSTR
 QSTR_GEN_CFLAGS += -I$(BUILD)/tmp
-
-ifeq ($(MICROPY_ROM_TEXT_COMPRESSION),1)
-# If compression is enabled, trigger the build of compressed.data.h...
-OBJ_EXTRA_ORDER_DEPS += $(HEADER_BUILD)/compressed.data.h
-# ...and enable the MP_COMPRESSED_ROM_TEXT macro (used by MP_ERROR_TEXT).
-# Note, this doesn't get added to the QSTR_GEN_CFLAGS.
-CFLAGS += -DMICROPY_ROM_TEXT_COMPRESSION=1
-endif
 
 # This file expects that OBJ contains a list of all of the object files.
 # The directory portion of each object file is used to locate the source

--- a/py/objexcept.c
+++ b/py/objexcept.c
@@ -38,8 +38,9 @@
 #include "py/gc.h"
 #include "py/mperrno.h"
 
-// Extract the MP_MAX_UNCOMPRESSED_TEXT_LEN macro from "genhdr/compressed.data.h"
-#if MICROPY_ROM_TEXT_COMPRESSION
+#if MICROPY_ROM_TEXT_COMPRESSION && !defined(NO_QSTR)
+// Extract the MP_MAX_UNCOMPRESSED_TEXT_LEN macro from "genhdr/compressed.data.h".
+// Only need this if compression enabled and in a regular build (i.e. not during QSTR extraction).
 #define MP_MATCH_COMPRESSED(...) // Ignore
 #define MP_COMPRESSED_DATA(...) // Ignore
 #include "genhdr/compressed.data.h"


### PR DESCRIPTION
This provides a typedef for mp_rom_error_text_t, and a macro define for MP_COMPRESSED_ROM_TEXT, when MICROPY_ROM_TEXT_COMPRESSION is disabled.  This simplifies the configuration (it no longer has a special case for MICROPY_ENABLE_DYNRUNTIME) and makes it work for other cases that don't use compression (eg examples/embedding).

Related to #5909 