### PR TITLE
extmod/uasyncio: fix wait_for cancellation

### DIFF
--- a/extmod/uasyncio/funcs.py
+++ b/extmod/uasyncio/funcs.py
@@ -10,7 +10,7 @@ async def wait_for(aw, timeout):
     if timeout is None:
         return await aw
 
-    def cancel(aw, timeout):
+    async def cancel(aw, timeout):
         await core.sleep(timeout)
         nonlocal can
         can=True

--- a/tests/extmod/uasyncio_wait_for.py
+++ b/tests/extmod/uasyncio_wait_for.py
@@ -31,6 +31,16 @@ async def task_raise():
     raise ValueError
 
 
+async def wait_for_cancel(id, t, t2):
+    print("wait_for_cancel start")
+    try:
+        await asyncio.wait_for(task(id, t), t2)
+    except asyncio.CancelledError:
+        print("wait_for_cancel cancelled")
+    except Exception as e:
+        print(e)
+
+
 async def main():
     # When task finished before the timeout
     print(await asyncio.wait_for(task(1, 0.01), 10))
@@ -55,6 +65,12 @@ async def main():
 
     # Timeout of None means wait forever
     print(await asyncio.wait_for(task(3, 0.1), None))
+
+    # When wait_for gets cancelled
+    t = asyncio.create_task(wait_for_cancel(4, 1, 2))
+    await asyncio.sleep(0.1)
+    t.cancel()
+    await asyncio.sleep(0.1)
 
     print("finish")
 

--- a/tests/extmod/uasyncio_wait_for.py.exp
+++ b/tests/extmod/uasyncio_wait_for.py.exp
@@ -12,4 +12,7 @@ ValueError
 task start 3
 task end 3
 6
+wait_for_cancel start
+task start 4
+wait_for_cancel cancelled
 finish


### PR DESCRIPTION
Fix errors when wait_for gets cancelled.

If wait_for() itself gets cancelled, wait_for currently doesn't know if itself got cancelled or if the killer task cancelled the awaited task aw. 
Fixes parts of #5797 