### PR TITLE
mpy-cross/main: Print uncaught nlr jump to stderr

### DIFF
--- a/mpy-cross/main.c
+++ b/mpy-cross/main.c
@@ -345,6 +345,6 @@ uint mp_import_stat(const char *path) {
 }
 
 void nlr_jump_fail(void *val) {
-    printf("FATAL: uncaught NLR %p\n", val);
+    fprintf(stderr, "FATAL: uncaught NLR %p\n", val);
     exit(1);
 }


### PR DESCRIPTION
This is to be consistent with the same change in the unix port (4ab8bee82f7d).