### PR TITLE
extmod/modbluetooth: Expose read errors

### DIFF
--- a/docs/library/ubluetooth.rst
+++ b/docs/library/ubluetooth.rst
@@ -117,7 +117,7 @@ Event Handling
                 conn_handle, dsc_handle, uuid = data
             elif event == _IRQ_GATTC_READ_RESULT:
                 # A gattc_read() has completed.
-                conn_handle, value_handle, char_data = data
+                conn_handle, value_handle, status, char_data = data
             elif event == _IRQ_GATTC_WRITE_STATUS:
                 # A gattc_write() has completed.
                 conn_handle, value_handle, status = data

--- a/extmod/modbluetooth.h
+++ b/extmod/modbluetooth.h
@@ -260,6 +260,9 @@ void mp_bluetooth_gattc_on_characteristic_result(uint16_t conn_handle, uint16_t 
 // Notify modbluetooth that a descriptor was found.
 void mp_bluetooth_gattc_on_descriptor_result(uint16_t conn_handle, uint16_t handle, mp_obj_bluetooth_uuid_t *descriptor_uuid);
 
+// Notify modbluetooth that a gattc_read operation failed.
+void mp_bluetooth_gattc_read_error(uint16_t status, uint16_t conn_handle, uint16_t value_handle);
+
 // Notify modbluetooth that a read has completed with data (or notify/indicate data available, use `event` to disambiguate).
 // Note: these functions are to be called in a group protected by MICROPY_PY_BLUETOOTH_ENTER/EXIT.
 // _start returns the number of bytes to submit to the calls to _chunk, followed by a call to _end.

--- a/extmod/nimble/modbluetooth_nimble.c
+++ b/extmod/nimble/modbluetooth_nimble.c
@@ -820,9 +820,10 @@ STATIC int ble_gatt_attr_read_cb(uint16_t conn_handle, const struct ble_gatt_err
     if (!mp_bluetooth_is_active()) {
         return 0;
     }
-    // TODO: Maybe send NULL if error->status non-zero.
     if (error->status == 0) {
         gattc_on_data_available(MP_BLUETOOTH_IRQ_GATTC_READ_RESULT, conn_handle, attr->handle, attr->om);
+    } else {
+        mp_bluetooth_gattc_read_error(error->status, conn_handle, attr ? attr->handle : -1);
     }
     return 0;
 }


### PR DESCRIPTION
Reads can fail. Extend the `GATTC_READ_RESULT` IRQ by an `error` field. For
successful reads, communicate an `error` value of `0`. Upon failure, trigger
the event with the corresponding error code and empty response data.
