### PR TITLE
uasyncio/stream: write immediately

### DIFF
--- a/extmod/uasyncio/stream.py
+++ b/extmod/uasyncio/stream.py
@@ -40,7 +40,15 @@ class Stream:
                 return l
 
     def write(self, buf):
-        self.out_buf += buf
+        if self.out_buf == b'':
+            ret = self.s.write(buf)
+            if ret is None:
+                ret = 0
+            elif ret == len(buf):
+                return
+            self.out_buf = buf[ret:] # must make a copy
+        else:
+            self.out_buf += buf
 
     async def drain(self):
         mv = memoryview(self.out_buf)

--- a/extmod/uasyncio/stream.py
+++ b/extmod/uasyncio/stream.py
@@ -51,7 +51,8 @@ class Stream:
             self.out_buf += buf
 
     async def drain(self):
-        if self.out_buf == b"": return
+        if self.out_buf == b"":
+            return
         mv = memoryview(self.out_buf)
         off = 0
         while off < len(mv):

--- a/extmod/uasyncio/stream.py
+++ b/extmod/uasyncio/stream.py
@@ -40,17 +40,18 @@ class Stream:
                 return l
 
     def write(self, buf):
-        if self.out_buf == b'':
+        if self.out_buf == b"":
             ret = self.s.write(buf)
+            if ret == len(buf):
+                return
             if ret is None:
                 ret = 0
-            elif ret == len(buf):
-                return
-            self.out_buf = buf[ret:] # must make a copy
+            self.out_buf = buf[ret:]  # must make a copy
         else:
             self.out_buf += buf
 
     async def drain(self):
+        if self.out_buf == b"": return
         mv = memoryview(self.out_buf)
         off = 0
         while off < len(mv):


### PR DESCRIPTION
I'm trying to eliminate buffer copies when using asyncio. These are particularly painful WRT memory fragmentation when using 1400 byte buffers to nicely fill packets... One reallocation & copy site is the uasyncio write method and I'm trying to find some way to use it where I can eliminate that copy. This PR is the best I've come up so far that doesn't diverge from CPython. In fact, it more closely implements the CPython doc semantics: "The method attempts to write the data to the underlying socket immediately. If that fails, the data is queued in an internal write buffer until it can be sent."

If this enhancement is acceptable I'd create some unit tests. I'm happy to hear about alternatives.