### PR TITLE
py/stream: Remove mp_stream_errno and use system errno instead.

### DIFF
--- a/extmod/extmod.mk
+++ b/extmod/extmod.mk
@@ -47,7 +47,7 @@ CFLAGS_MOD += -DMICROPY_PY_USSL=1
 ifeq ($(MICROPY_SSL_AXTLS),1)
 CFLAGS_MOD += -DMICROPY_SSL_AXTLS=1 -I$(TOP)/lib/axtls/ssl -I$(TOP)/lib/axtls/crypto -I$(TOP)/extmod/axtls-include
 AXTLS_DIR = lib/axtls
-$(BUILD)/$(AXTLS_DIR)/%.o: CFLAGS += -Wno-all -Wno-unused-parameter -Wno-uninitialized -Wno-sign-compare -Wno-old-style-definition $(AXTLS_DEFS_EXTRA)
+$(BUILD)/$(AXTLS_DIR)/%.o: CFLAGS += -Wno-all -Wno-unused-parameter -Wno-uninitialized -Wno-sign-compare -Wno-old-style-definition -Dmp_stream_errno=errno $(AXTLS_DEFS_EXTRA)
 SRC_MOD += $(addprefix $(AXTLS_DIR)/,\
 	ssl/asn1.c \
 	ssl/loader.c \

--- a/lib/embed/__errno.c
+++ b/lib/embed/__errno.c
@@ -1,0 +1,13 @@
+// This file provides a version of __errno() for embedded systems that do not have one.
+// This function is needed for expressions of the form: &errno
+
+static int embed_errno;
+
+#if defined(__linux__)
+int *__errno_location(void)
+#else
+int *__errno(void)
+#endif
+{
+    return &embed_errno;
+}

--- a/ports/esp32/mphalport.c
+++ b/ports/esp32/mphalport.c
@@ -195,13 +195,6 @@ void mp_hal_delay_us(uint32_t us) {
     }
 }
 
-/*
-extern int mp_stream_errno;
-int *__errno() {
-    return &mp_stream_errno;
-}
-*/
-
 // Wake up the main task if it is sleeping
 void mp_hal_wake_main_task_from_isr(void) {
     BaseType_t xHigherPriorityTaskWoken = pdFALSE;

--- a/ports/esp8266/Makefile
+++ b/ports/esp8266/Makefile
@@ -120,6 +120,7 @@ EXTMOD_SRC_C = $(addprefix extmod/,\
         )
 
 LIB_SRC_C = $(addprefix lib/,\
+	embed/__errno.c \
 	libc/string0.c \
 	libm/math.c \
 	libm/fmodf.c \

--- a/ports/esp8266/esp_mphal.c
+++ b/ports/esp8266/esp_mphal.c
@@ -206,8 +206,3 @@ int ets_esf_free_bufs(int idx) {
     }
     return cnt;
 }
-
-extern int mp_stream_errno;
-int *__errno() {
-    return &mp_stream_errno;
-}

--- a/py/modio.c
+++ b/py/modio.c
@@ -59,12 +59,17 @@ STATIC mp_uint_t iobase_read_write(mp_obj_t obj, void *buf, mp_uint_t size, int 
     mp_load_method(obj, qst, dest);
     mp_obj_array_t ar = {{&mp_type_bytearray}, BYTEARRAY_TYPECODE, 0, size, buf};
     dest[2] = MP_OBJ_FROM_PTR(&ar);
-    mp_obj_t ret = mp_call_method_n_kw(1, 0, dest);
-    if (ret == mp_const_none) {
+    mp_obj_t ret_obj = mp_call_method_n_kw(1, 0, dest);
+    if (ret_obj == mp_const_none) {
         *errcode = MP_EAGAIN;
         return MP_STREAM_ERROR;
+    }
+    mp_int_t ret = mp_obj_get_int(ret_obj);
+    if (ret >= 0) {
+        return ret;
     } else {
-        return mp_obj_get_int(ret);
+        *errcode = -ret;
+        return MP_STREAM_ERROR;
     }
 }
 STATIC mp_uint_t iobase_read(mp_obj_t obj, void *buf, mp_uint_t size, int *errcode) {

--- a/py/stream.c
+++ b/py/stream.c
@@ -503,14 +503,12 @@ MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(mp_stream_ioctl_obj, 2, 3, stream_ioctl);
  * POSIX-compatible software to work with MicroPython streams.
  */
 
-// errno-like variable. If any of the functions below returned with error
-// status, this variable will contain error no.
-int mp_stream_errno;
+#include <errno.h>
 
 ssize_t mp_stream_posix_write(void *stream, const void *buf, size_t len) {
     mp_obj_base_t *o = stream;
     const mp_stream_p_t *stream_p = o->type->protocol;
-    mp_uint_t out_sz = stream_p->write(MP_OBJ_FROM_PTR(stream), buf, len, &mp_stream_errno);
+    mp_uint_t out_sz = stream_p->write(MP_OBJ_FROM_PTR(stream), buf, len, &errno);
     if (out_sz == MP_STREAM_ERROR) {
         return -1;
     } else {
@@ -521,7 +519,7 @@ ssize_t mp_stream_posix_write(void *stream, const void *buf, size_t len) {
 ssize_t mp_stream_posix_read(void *stream, void *buf, size_t len) {
     mp_obj_base_t *o = stream;
     const mp_stream_p_t *stream_p = o->type->protocol;
-    mp_uint_t out_sz = stream_p->read(MP_OBJ_FROM_PTR(stream), buf, len, &mp_stream_errno);
+    mp_uint_t out_sz = stream_p->read(MP_OBJ_FROM_PTR(stream), buf, len, &errno);
     if (out_sz == MP_STREAM_ERROR) {
         return -1;
     } else {
@@ -535,7 +533,7 @@ off_t mp_stream_posix_lseek(void *stream, off_t offset, int whence) {
     struct mp_stream_seek_t seek_s;
     seek_s.offset = offset;
     seek_s.whence = whence;
-    mp_uint_t res = stream_p->ioctl(MP_OBJ_FROM_PTR(stream), MP_STREAM_SEEK, (mp_uint_t)(uintptr_t)&seek_s, &mp_stream_errno);
+    mp_uint_t res = stream_p->ioctl(MP_OBJ_FROM_PTR(stream), MP_STREAM_SEEK, (mp_uint_t)(uintptr_t)&seek_s, &errno);
     if (res == MP_STREAM_ERROR) {
         return -1;
     }
@@ -545,7 +543,7 @@ off_t mp_stream_posix_lseek(void *stream, off_t offset, int whence) {
 int mp_stream_posix_fsync(void *stream) {
     mp_obj_base_t *o = stream;
     const mp_stream_p_t *stream_p = o->type->protocol;
-    mp_uint_t res = stream_p->ioctl(MP_OBJ_FROM_PTR(stream), MP_STREAM_FLUSH, 0, &mp_stream_errno);
+    mp_uint_t res = stream_p->ioctl(MP_OBJ_FROM_PTR(stream), MP_STREAM_FLUSH, 0, &errno);
     if (res == MP_STREAM_ERROR) {
         return -1;
     }

--- a/tests/extmod/btree_error.py
+++ b/tests/extmod/btree_error.py
@@ -1,0 +1,42 @@
+# Test that errno's propagate correctly through btree module.
+
+try:
+    import btree, uio, uerrno
+
+    uio.IOBase
+except (ImportError, AttributeError):
+    print("SKIP")
+    raise SystemExit
+
+
+class Device(uio.IOBase):
+    def __init__(self, read_ret=0, ioctl_ret=0):
+        self.read_ret = read_ret
+        self.ioctl_ret = ioctl_ret
+
+    def readinto(self, buf):
+        print("read", len(buf))
+        return self.read_ret
+
+    def ioctl(self, cmd, arg):
+        print("ioctl", cmd)
+        return self.ioctl_ret
+
+
+# Invalid pagesize; errno comes from btree library
+try:
+    db = btree.open(Device(), pagesize=511)
+except OSError as er:
+    print("OSError", er.args[0] == uerrno.EINVAL)
+
+# Valid pagesize, device returns error on read; errno comes from Device.readinto
+try:
+    db = btree.open(Device(-1000), pagesize=512)
+except OSError as er:
+    print(repr(er))
+
+# Valid pagesize, device returns error on seek; errno comes from Device.ioctl
+try:
+    db = btree.open(Device(0, -1001), pagesize=512)
+except OSError as er:
+    print(repr(er))

--- a/tests/extmod/btree_error.py.exp
+++ b/tests/extmod/btree_error.py.exp
@@ -1,0 +1,6 @@
+OSError True
+read 24
+OSError(1000,)
+read 24
+ioctl 2
+OSError(1001,)


### PR DESCRIPTION
This PR removes `mp_stream_errno` and uses the system-provided `errno` instead.

This change is made for two reasons:

1. A 3rd-party library (eg berkeley-db-1.xx, axtls) may use the system
       provided errno for certain errors, and yet MicroPython stream objects
       that it calls will be using the internal mp_stream_errno.  So if the
       library returns an error it is not known whether the corresponding errno
       code is stored in the system errno or mp_stream_errno.  Using the system
       errno in all cases (eg in the mp_stream_posix_XXX wrappers) fixes this
       ambiguity.

2. For systems that have threading the system-provided errno should always
       be used because the errno value is thread-local.

For systems that do not have an errno, the new lib/embed/__errno.c file is provided.

Also included in this PR is a new btree test which shows why such a change is needed (because without the fix the errno raised by the btree module is wrong).
