### PR TITLE
esp32/errno: fix lwip errno's for esp32

### DIFF
--- a/ports/esp32/Makefile
+++ b/ports/esp32/Makefile
@@ -354,6 +354,7 @@ SRC_C = \
 	mpthreadport.c \
 	machine_rtc.c \
 	machine_sdcard.c \
+	lwip_err.c \
 	$(wildcard $(BOARD_DIR)/*.c) \
 	$(SRC_MOD)
 
@@ -493,7 +494,7 @@ ESPIDF_SPI_FLASH_O = $(patsubst %.c,%.o,$(wildcard $(ESPCOMP)/spi_flash/*.c))
 ESPIDF_ULP_O = $(patsubst %.c,%.o,$(wildcard $(ESPCOMP)/ulp/*.c))
 
 $(BUILD)/$(ESPCOMP)/lwip/%.o: CFLAGS += -Wno-address -Wno-unused-variable -Wno-unused-but-set-variable
-ESPIDF_LWIP_O = $(patsubst %.c,%.o,\
+ESPIDF_LWIP_O = $(patsubst %.c,%.o, $(filter-out %lwip/src/api/err.c, \
 	$(wildcard $(ESPCOMP)/lwip/apps/dhcpserver/*.c) \
 	$(wildcard $(ESPCOMP)/lwip/lwip/src/api/*.c) \
 	$(wildcard $(ESPCOMP)/lwip/lwip/src/apps/sntp/*.c) \
@@ -504,7 +505,7 @@ ESPIDF_LWIP_O = $(patsubst %.c,%.o,\
 	$(wildcard $(ESPCOMP)/lwip/lwip/src/netif/*/*/*.c) \
 	$(wildcard $(ESPCOMP)/lwip/port/esp32/*.c) \
 	$(wildcard $(ESPCOMP)/lwip/port/esp32/*/*.c) \
-	)
+	))
 
 ESPIDF_MBEDTLS_O = $(patsubst %.c,%.o,\
 	$(wildcard $(ESPCOMP)/mbedtls/mbedtls/library/*.c) \

--- a/ports/esp32/lwip_err.c
+++ b/ports/esp32/lwip_err.c
@@ -1,0 +1,73 @@
+//
+// Micropython note: this is a copy of ESP-IDFv4.0's components/lwip/lwip/src/api/err.c with
+// the error EXXX constants replaced by MicroPython's to avoid getting the wrong values because
+// ESP-IDFv4.0 uses ones from newlib (in components/newlib) that have a bunch of different values.
+// It looks like ESP-IDFv4.1 fixes this discrepancy, at which point this file can be removed from
+// the esp32 port.
+
+/*
+ * Copyright (c) 2001-2004 Swedish Institute of Computer Science.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 3. The name of the author may not be used to endorse or promote products
+ *    derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR IMPLIED
+ * WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT
+ * SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+ * OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING
+ * IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY
+ * OF SUCH DAMAGE.
+ *
+ * This file is part of the lwIP TCP/IP stack.
+ *
+ * Author: Adam Dunkels <adam@sics.se>
+ *
+ */
+
+#include "lwip/def.h"
+#include "lwip/sys.h"
+#include "py/mperrno.h"
+
+/** Table to quickly map an lwIP error (err_t) to a socket error
+  * by using -err as an index */
+static const int err_to_errno_table[] = {
+    0,               /* ERR_OK          0      No error, everything OK. */
+    MP_ENOMEM,       /* ERR_MEM        -1      Out of memory error.     */
+    MP_ENOBUFS,      /* ERR_BUF        -2      Buffer error.            */
+    MP_EWOULDBLOCK,  /* ERR_TIMEOUT    -3      Timeout                  */
+    MP_EHOSTUNREACH, /* ERR_RTE        -4      Routing problem.         */
+    MP_EINPROGRESS,  /* ERR_INPROGRESS -5      Operation in progress    */
+    MP_EINVAL,       /* ERR_VAL        -6      Illegal value.           */
+    MP_EWOULDBLOCK,  /* ERR_WOULDBLOCK -7      Operation would block.   */
+    MP_EADDRINUSE,   /* ERR_USE        -8      Address in use.          */
+    MP_EALREADY,     /* ERR_ALREADY    -9      Already connecting.      */
+    MP_EISCONN,      /* ERR_ISCONN     -10     Conn already established.*/
+    MP_ENOTCONN,     /* ERR_CONN       -11     Not connected.           */
+    -1,              /* ERR_IF         -12     Low-level netif error    */
+    MP_ECONNABORTED, /* ERR_ABRT       -13     Connection aborted.      */
+    MP_ECONNRESET,   /* ERR_RST        -14     Connection reset.        */
+    MP_ENOTCONN,     /* ERR_CLSD       -15     Connection closed.       */
+    MP_EIO           /* ERR_ARG        -16     Illegal argument.        */
+};
+
+int
+err_to_errno(err_t err) {
+    if ((err > 0) || (-err >= (err_t)LWIP_ARRAYSIZE(err_to_errno_table))) {
+        return EIO;
+    }
+    // printf("lwip err_to_errno %d->%d\n", err, err_to_errno_table[-err]);
+    return err_to_errno_table[-err];
+}

--- a/ports/esp32/modsocket.c
+++ b/ports/esp32/modsocket.c
@@ -153,6 +153,13 @@ void usocket_events_handler(void) {
 
 #endif // MICROPY_PY_USOCKET_EVENTS
 
+// EXXX error constants in ESP-IDF v4.0 and prior come from a newlib errno.h which has some
+// non-posix values, i.e., different from mperrno.h. This used to get fixed incompletely in
+// exception_from_errno, but it turns out to be easier to fix in lwip's err.c which maps lwip's
+// netif error codes into EXXX. The old code is left in here until the whole problem really
+// goes away with ESP-IDF v4.1 (we hope).
+#define exception_from_errno(errno) mp_raise_OSError(errno)
+#if 0
 NORETURN static void exception_from_errno(int _errno) {
     // Here we need to convert from lwip errno values to MicroPython's standard ones
     if (_errno == EADDRINUSE) {
@@ -162,6 +169,7 @@ NORETURN static void exception_from_errno(int _errno) {
     }
     mp_raise_OSError(_errno);
 }
+#endif
 
 static inline void check_for_exceptions(void) {
     mp_handle_pending(true);


### PR DESCRIPTION
This commit addresses #5752 and fixes the issue cleanly in expectation of #5825 where it otherwise shows up through the mbedssl stack. I couldn't remember a case I could test at this stage, I'm not sure there is any because the errno's are currently fixed-up explicitly in `modsocket.c`. It's only with the fixes to mbedtls for non-blocking sockets that the errors are checked before that fix-up and then the mess surfaces.
(I've made the changes in this PR a while ago on my fork but had them as part of #5819 and pulled them out today to keep the individual PRs/commits cleanly focused.)