### PR TITLE
esp32/time: make utime conform to CPython and add SNTP

### DIFF
--- a/docs/library/network.SNTP.rst
+++ b/docs/library/network.SNTP.rst
@@ -1,0 +1,50 @@
+.. currentmodule:: network
+.. _network.SNTP:
+
+class SNTP -- Simple Network Time Protocol
+==========================================
+
+This class provides an implementation of the standard SNTP protocol.
+
+    from network import SNTP
+    import time
+    # start SNTP to run in the background
+    sntp = SNTP()
+    sntp.start()
+    # check the status
+    while sntp.status != sntp.INSYNC:
+        time.sleep(1)
+    print("Time is synchronized()")
+
+Constructors
+------------
+.. class:: SNTP()
+
+Returns the SNTP singleton object.
+
+Methods
+-------
+
+.. method:: SNTP.start(servers=["pool.ntp.org"], poll=True, slew=True)
+
+    Starts the SNTP process to run in the background.
+    The keyword parameters are:
+    * servers: a list of NTP servers to query, the max number is implementation
+      dependent.
+    * poll: whether to explicitly poll NTP servers (True) or passively listen
+      for NTP broadcasts
+    * slew: whether to gradually adjust the time using adjtime (True) or
+      step the time (False). (If the time difference is large the system
+      time may be stepped even if slew==True.)
+
+.. method:: SNTP.stop()
+
+    Stops the SNTP process. The system clock continues to run but is no
+    longer synchronized.
+
+.. method:: SNTP.status()
+
+    Returns the current clock synchronization status: (semantics not yet clear)
+    * SNTP.STOPPED
+    * SNTP.INSYNC
+    * SNTP.ADJUSTING

--- a/ports/esp32/machine_rtc.c
+++ b/ports/esp32/machine_rtc.c
@@ -126,9 +126,10 @@ STATIC mp_obj_t machine_rtc_datetime(mp_uint_t n_args, const mp_obj_t *args) {
 }
 STATIC MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(machine_rtc_datetime_obj, 1, 2, machine_rtc_datetime);
 
-STATIC mp_obj_t machine_rtc_init(mp_obj_t self_in, mp_obj_t date) {
-    mp_obj_t args[2] = {self_in, date};
-    machine_rtc_datetime_helper(2, args);
+STATIC mp_obj_t machine_rtc_init(mp_uint_t n_args, const mp_obj_t *args) {
+    if (n_args == 2) {
+        machine_rtc_datetime_helper(n_args, args);
+    }
 
     #if MICROPY_HW_RTC_USER_MEM_MAX > 0
     if (rtc_user_mem_magic != MEM_MAGIC) {
@@ -139,7 +140,7 @@ STATIC mp_obj_t machine_rtc_init(mp_obj_t self_in, mp_obj_t date) {
 
     return mp_const_none;
 }
-STATIC MP_DEFINE_CONST_FUN_OBJ_2(machine_rtc_init_obj, machine_rtc_init);
+STATIC MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(machine_rtc_init_obj, 1, 2, machine_rtc_init);
 
 #if MICROPY_HW_RTC_USER_MEM_MAX > 0
 STATIC mp_obj_t machine_rtc_memory(mp_uint_t n_args, const mp_obj_t *args) {

--- a/ports/esp32/modsntp.c
+++ b/ports/esp32/modsntp.c
@@ -1,0 +1,74 @@
+/*
+ * This file is part of the MicroPython project, http://micropython.org/
+ *
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2020 by Thorsten von Eicken
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#include <time.h>
+#include <sys/time.h>
+#include <sntp.h>
+#include <lwip/apps/sntp.h>
+#include <esp_sntp.h>
+
+#include "py/obj.h"
+#include "py/runtime.h"
+
+STATIC mp_obj_t sntp_make_new(void) {
+}
+STATIC MP_DEFINE_CONST_FUN_OBJ_0(sntp_make_new_obj, sntp_make_new);
+
+STATIC mp_obj_t sntp_start(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
+    const mp_arg_t allowed_args[] = {
+        { MP_QSTR_poll,  MP_ARG_BOOL, {.u_bool = 1} },
+        { MP_QSTR_slew,  MP_ARG_BOOL, {.u_bool = 1} },
+        { MP_QSTR_servers,  MP_ARG_OBJ, {.u_obj = mp_obj_new_str()} },
+    };
+    mp_arg_val_t args[MP_ARRAY_SIZE(allowed_args)];
+    mp_arg_parse_all(n_args, pos_args, kw_args, MP_ARRAY_SIZE(allowed_args), allowed_args, args);
+}
+STATIC MP_DEFINE_CONST_FUN_OBJ_KW(sntp_start_obj, 0, sntp_start);
+
+STATIC mp_obj_t sntp_stop(void) {
+}
+STATIC MP_DEFINE_CONST_FUN_OBJ_0(sntp_stop_obj, sntp_stop);
+
+STATIC mp_obj_t sntp_status(void) {
+}
+STATIC MP_DEFINE_CONST_FUN_OBJ_0(sntp_status_obj, sntp_status);
+
+STATIC const mp_rom_map_elem_t sntp_locals_dict_table[] = {
+    { MP_ROM_QSTR(MP_QSTR_start), MP_ROM_PTR(&start_obj) },
+    { MP_ROM_QSTR(MP_QSTR_stop), MP_ROM_PTR(&stop_obj) },
+    { MP_ROM_QSTR(MP_QSTR_status), MP_ROM_PTR(&status_obj) },
+    { MP_ROM_QSTR(MP_QSTR_STOPPED), MP_ROM_INT(0) },
+    { MP_ROM_QSTR(MP_QSTR_INSYNC), MP_ROM_INT(1) },
+    { MP_ROM_QSTR(MP_QSTR_ADJUSTING), MP_ROM_INT(2) },
+};
+STATIC MP_DEFINE_CONST_DICT(sntp_locals_dict, sntp_locals_dict_table);
+
+const mp_obj_type_t network_sntp_type = {
+    { &mp_type_type },
+    .name = MP_QSTR_SNTP,
+    .make_new = sntp_make_new,
+    .locals_dict = (mp_obj_t)&sntp_locals_dict,
+};

--- a/ports/esp32/modutime.c
+++ b/ports/esp32/modutime.c
@@ -28,66 +28,167 @@
 
 #include <stdio.h>
 #include <string.h>
+#include <time.h>
 #include <sys/time.h>
+#include <errno.h>
 
 #include "py/runtime.h"
-#include "lib/timeutils/timeutils.h"
 #include "extmod/utime_mphal.h"
 
-STATIC mp_obj_t time_localtime(size_t n_args, const mp_obj_t *args) {
-    timeutils_struct_time_t tm;
-    mp_int_t seconds;
-    if (n_args == 0 || args[0] == mp_const_none) {
-        struct timeval tv;
-        gettimeofday(&tv, NULL);
-        seconds = tv.tv_sec;
-    } else {
-        seconds = mp_obj_get_int(args[0]);
-    }
-    timeutils_seconds_since_2000_to_struct_time(seconds, &tm);
-    mp_obj_t tuple[8] = {
-        tuple[0] = mp_obj_new_int(tm.tm_year),
-        tuple[1] = mp_obj_new_int(tm.tm_mon),
-        tuple[2] = mp_obj_new_int(tm.tm_mday),
-        tuple[3] = mp_obj_new_int(tm.tm_hour),
-        tuple[4] = mp_obj_new_int(tm.tm_min),
-        tuple[5] = mp_obj_new_int(tm.tm_sec),
-        tuple[6] = mp_obj_new_int(tm.tm_wday),
-        tuple[7] = mp_obj_new_int(tm.tm_yday),
-    };
-    return mp_obj_new_tuple(8, tuple);
-}
-STATIC MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(time_localtime_obj, 0, 1, time_localtime);
+// time module mostly compatible with CPython's time. For reference, this is the CPython
+// struct_time from https://docs.python.org/3/library/time.html#time.struct_time:
+// Index Attribute Values
+//   0   tm_year   (for example, 1993)
+//   1   tm_mon    range [1, 12]
+//   2   tm_mday   range [1, 31]
+//   3   tm_hour   range [0, 23]
+//   4   tm_min    range [0, 59]
+//   5   tm_sec    range [0, 61]; see (2) in strftime() description
+//   6   tm_wday   range [0, 6], Monday is 0
+//   7   tm_yday   range [1, 366]
+//   8   tm_isdst  0=no, 1=yes, -1=unknown
+// N/A   tm_zone   abbreviation of timezone name
+// N/A   tm_gmtoff offset east of UTC in seconds
+// This module supports the first 9 elements (i.e. a 9-tuple) without names.
 
-STATIC mp_obj_t time_mktime(mp_obj_t tuple) {
+// convert a python 9-tuple to a struct tm
+STATIC void time_tm_from_tuple(const mp_obj_t tuple, struct tm *tm) {
     size_t len;
     mp_obj_t *elem;
     mp_obj_get_array(tuple, &len, &elem);
 
-    // localtime generates a tuple of len 8. CPython uses 9, so we accept both.
-    if (len < 8 || len > 9) {
-        mp_raise_msg_varg(&mp_type_TypeError, MP_ERROR_TEXT("mktime needs a tuple of length 8 or 9 (%d given)"), len);
+    if (len != 9) {
+        mp_raise_msg_varg(&mp_type_TypeError, MP_ERROR_TEXT("9-tuple required (%d given)"), len);
     }
 
-    return mp_obj_new_int_from_uint(timeutils_mktime(mp_obj_get_int(elem[0]),
-        mp_obj_get_int(elem[1]), mp_obj_get_int(elem[2]), mp_obj_get_int(elem[3]),
-        mp_obj_get_int(elem[4]), mp_obj_get_int(elem[5])));
+    time_t wday = mp_obj_get_int(elem[6])+1;
+    if (wday > 7) wday = 0;
+    tm->tm_year = mp_obj_get_int(elem[0])-1900;
+    tm->tm_mon = mp_obj_get_int(elem[1])-1;
+    tm->tm_mday = mp_obj_get_int(elem[2]);
+    tm->tm_hour = mp_obj_get_int(elem[3]);
+    tm->tm_min = mp_obj_get_int(elem[4]);
+    tm->tm_sec = mp_obj_get_int(elem[5]);
+    tm->tm_wday = wday;
+    tm->tm_yday = mp_obj_get_int(elem[7])-1;
+    tm->tm_isdst = mp_obj_get_int(elem[8]);
+}
+
+// convert a struct tm to a python 9-tuple
+STATIC mp_obj_t *time_tm_to_tuple(const struct tm *tm) {
+    mp_obj_t tuple[9] = {
+        tuple[0] = mp_obj_new_int(1900+tm->tm_year),
+        tuple[1] = mp_obj_new_int(tm->tm_mon+1),
+        tuple[2] = mp_obj_new_int(tm->tm_mday),
+        tuple[3] = mp_obj_new_int(tm->tm_hour),
+        tuple[4] = mp_obj_new_int(tm->tm_min),
+        tuple[5] = mp_obj_new_int(tm->tm_sec),
+        tuple[6] = mp_obj_new_int(tm->tm_wday==0 ? 7 : tm->tm_wday-1),
+        tuple[7] = mp_obj_new_int(tm->tm_yday+1),
+        tuple[8] = mp_obj_new_int(tm->tm_isdst),
+    };
+    return mp_obj_new_tuple(8, tuple);
+}
+
+STATIC time_t time_get_seconds(size_t n_args, const mp_obj_t *args) {
+    if (n_args == 0 || args[0] == mp_const_none) {
+        struct timeval tv;
+        if (gettimeofday(&tv, NULL) != 0) {
+            mp_raise_OSError(errno);
+        }
+        return tv.tv_sec;
+    } else {
+        return mp_obj_get_int(args[0]);
+    }
+}
+
+STATIC mp_obj_t time_gmtime(size_t n_args, const mp_obj_t *args) {
+    time_t seconds = time_get_seconds(n_args, args);
+    struct tm tm;
+    gmtime_r(&seconds, &tm);
+    return time_tm_to_tuple(&tm);
+}
+STATIC MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(time_gmtime_obj, 0, 1, time_gmtime);
+
+STATIC mp_obj_t time_localtime(size_t n_args, const mp_obj_t *args) {
+    time_t seconds = time_get_seconds(n_args, args);
+    struct tm tm;
+    localtime_r(&seconds, &tm);
+    return time_tm_to_tuple(&tm);
+}
+STATIC MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(time_localtime_obj, 0, 1, time_localtime);
+
+STATIC mp_obj_t time_mktime(mp_obj_t tuple) {
+    struct tm tm;
+    time_tm_from_tuple(tuple, &tm);
+
+    time_t seconds = mktime(&tm);
+    if (seconds == -1) {
+        mp_raise_ValueError(MP_ERROR_TEXT("invalid input"));
+    }
+    return MP_OBJ_NEW_SMALL_INT(seconds);
 }
 STATIC MP_DEFINE_CONST_FUN_OBJ_1(time_mktime_obj, time_mktime);
 
 STATIC mp_obj_t time_time(void) {
     struct timeval tv;
-    gettimeofday(&tv, NULL);
+    if (gettimeofday(&tv, NULL) != 0) {
+        mp_raise_OSError(errno);
+    }
     return mp_obj_new_int(tv.tv_sec);
 }
 MP_DEFINE_CONST_FUN_OBJ_0(time_time_obj, time_time);
 
+STATIC mp_obj_t time_tzset(mp_obj_t tz) {
+    // tz is something like PST+8PDT,M3.2.0/2,M11.1.0/2
+    const char *zone = mp_obj_str_get_str(tz);
+    setenv("TZ", zone, 1);
+    tzset();
+    return mp_const_none;
+}
+MP_DEFINE_CONST_FUN_OBJ_1(time_tzset_obj, time_tzset);
+
+STATIC mp_obj_t time_set_time(const mp_obj_t seconds_in) {
+    struct timeval tv = { mp_obj_get_int(seconds_in), 0 };
+    if (settimeofday(&tv, NULL) != 0) {
+        mp_raise_OSError(errno);
+    }
+    return mp_const_none;
+}
+MP_DEFINE_CONST_FUN_OBJ_1(time_set_time_obj, time_set_time);
+
+STATIC mp_obj_t time_adjtime(const mp_obj_t microseconds_in) {
+    struct timeval tv = {
+        .tv_sec = 0,
+        .tv_usec = mp_obj_get_int(microseconds_in),
+    };
+    // turn microseconds into seconds+microseconds
+    if (tv.tv_usec >= 1000000) {
+        tv.tv_sec = tv.tv_usec / 1000000;
+        tv.tv_usec = tv.tv_usec - tv.tv_sec * 1000000;
+    } else if (tv.tv_usec <= -1000000) {
+        tv.tv_sec = -(-tv.tv_usec / 1000000); // round to zero
+        tv.tv_usec = tv.tv_usec - tv.tv_sec * 1000000; // negative remainder
+    }
+
+    struct timeval tv_old;
+    if (adjtime(&tv, &tv_old) != 0) {
+        mp_raise_OSError(errno);
+    }
+    return mp_obj_new_int(tv.tv_sec*1000000 + tv.tv_usec);
+}
+MP_DEFINE_CONST_FUN_OBJ_1(time_adjtime_obj, time_adjtime);
+
 STATIC const mp_rom_map_elem_t time_module_globals_table[] = {
     { MP_ROM_QSTR(MP_QSTR___name__), MP_ROM_QSTR(MP_QSTR_utime) },
 
+    { MP_ROM_QSTR(MP_QSTR_gmtime), MP_ROM_PTR(&time_gmtime_obj) },
     { MP_ROM_QSTR(MP_QSTR_localtime), MP_ROM_PTR(&time_localtime_obj) },
     { MP_ROM_QSTR(MP_QSTR_mktime), MP_ROM_PTR(&time_mktime_obj) },
+    { MP_ROM_QSTR(MP_QSTR_tzset), MP_ROM_PTR(&time_tzset_obj) },
     { MP_ROM_QSTR(MP_QSTR_time), MP_ROM_PTR(&time_time_obj) },
+    { MP_ROM_QSTR(MP_QSTR_set_time), MP_ROM_PTR(&time_set_time_obj) },
+    { MP_ROM_QSTR(MP_QSTR_adjtime), MP_ROM_PTR(&time_adjtime_obj) },
     { MP_ROM_QSTR(MP_QSTR_sleep), MP_ROM_PTR(&mp_utime_sleep_obj) },
     { MP_ROM_QSTR(MP_QSTR_sleep_ms), MP_ROM_PTR(&mp_utime_sleep_ms_obj) },
     { MP_ROM_QSTR(MP_QSTR_sleep_us), MP_ROM_PTR(&mp_utime_sleep_us_obj) },


### PR DESCRIPTION
This PR attempts to start fixing some of the issues with `utime` and `machine.RTC`, per #5969, #5553, #5733. The overall idea is to flesh out `utime` so it is (a) compatible with CPython and (b) fully-featured to manage the time and (internally) query/set the RTC. The `RTC.datetime` method would then be deprecated but left in-place for code compatibility and possibly for minimal ports that don't have `utime` (I have not looked at that aspect).

What this PR currently does is in the esp32 port:
- change `utime.localtime` and `utime.mktime` to conform to the CPython standard 9-tuple (well, actually to the 9 11-tuple elements that have numeric indexes).
- change the Epoch to be the POSIX 1970 Epoch.
- add `utime.gmtime` and `time.tzset` so one can set a time zone and query UTC as well as local time. The implementation of `tzset` does not conform to CPython in that it takes a zone specification whereas in CPython it takes no argument and the zone is set via the TZ environment variable.
- add `utime.set_time` and `utime.adjtime` as extensions WRT CPython so one can step the time or gradually adjust the time.
- add a `network.SNTP` class with methods to start SNTP, stop SNTP, and get the SNTP status (this is only partially implemented in this PR and is intended to leverage the LwIP SNTP implementation).

I believe that this ends up producing a clean interface to time that can be fully implemented on the bigger ports using newlib and LwIP, and that can be stripped down, e.g. without time-zone support, for smaller ports. It somewhat side-steps the incompatibilities between RTC implementations by leaving that class along for legacy use, as well as for minimal ports without `utime`.

I volunteer to port this PR to the unix and stm32 ports so these are in-sync.