### PR TITLE
qemu-arm: add support and tests for Cortex-A9 with native emitter

### DIFF
--- a/ports/qemu-arm/Makefile
+++ b/ports/qemu-arm/Makefile
@@ -16,7 +16,8 @@ ifeq ($(BOARD),netduino2)
 CFLAGS += -mthumb -mcpu=cortex-m3 -mfloat-abi=soft
 CFLAGS += -DQEMU_SOC_STM32
 LDSCRIPT = stm32.ld
-SRC_BOARD_O = lib/utils/gchelper_m3.o
+SRC_BOARD_O = lib/utils/gchelper_native.o lib/utils/gchelper_m3.o
+MPY_CROSS_FLAGS += -march=armv7m
 endif
 
 ifeq ($(BOARD),microbit)
@@ -24,14 +25,26 @@ CFLAGS += -mthumb -mcpu=cortex-m0 -mfloat-abi=soft
 CFLAGS += -DQEMU_SOC_NRF51
 LDSCRIPT = nrf51.ld
 QEMU_EXTRA = -global nrf51-soc.flash-size=1048576 -global nrf51-soc.sram-size=262144
-SRC_BOARD_O = lib/utils/gchelper_m0.o
+SRC_BOARD_O = lib/utils/gchelper_native.o lib/utils/gchelper_m0.o
+MPY_CROSS_FLAGS += -march=armv7m
 endif
 
 ifeq ($(BOARD),mps2-an385)
 CFLAGS += -mthumb -mcpu=cortex-m3 -mfloat-abi=soft
 CFLAGS += -DQEMU_SOC_MPS2
 LDSCRIPT = mps2.ld
-SRC_BOARD_O = lib/utils/gchelper_m3.o
+SRC_BOARD_O = lib/utils/gchelper_native.o lib/utils/gchelper_m3.o
+MPY_CROSS_FLAGS += -march=armv7m
+endif
+
+ifeq ($(BOARD),sabrelite)
+CFLAGS += -mcpu=cortex-a9
+CFLAGS += -DQEMU_SOC_IMX6
+LDSCRIPT = imx6.ld
+QEMU_EXTRA = -m 128M
+SRC_BOARD_O = lib/utils/gchelper_generic.o
+# It's really armv7a but closest supported value is armv6.
+MPY_CROSS_FLAGS += -march=armv6
 endif
 
 CROSS_COMPILE ?= arm-none-eabi-
@@ -95,7 +108,6 @@ LIB_SRC_C += $(addprefix lib/,\
 	libm/atanf.c \
 	libm/atan2f.c \
 	libm/roundf.c \
-	utils/gchelper_native.c \
 	utils/sys_stdio_mphal.c \
 	)
 
@@ -125,7 +137,6 @@ ifneq ($(FROZEN_MANIFEST),)
 CFLAGS += -DMICROPY_MODULE_FROZEN_STR
 CFLAGS += -DMICROPY_MODULE_FROZEN_MPY
 CFLAGS += -DMICROPY_QSTR_EXTRA_POOL=mp_qstr_frozen_const_pool
-MPY_CROSS_FLAGS += -march=armv7m
 endif
 
 all: run

--- a/ports/qemu-arm/Makefile.test
+++ b/ports/qemu-arm/Makefile.test
@@ -4,6 +4,11 @@ FROZEN_MANIFEST ?= "freeze('test-frzmpy')"
 
 include Makefile
 
+ifeq ($(BOARD),sabrelite)
+# These don't work on Cortex-A9.
+TESTS_EXCLUDE = inlineasm/asmdiv.py inlineasm/asmspecialregs.py
+endif
+
 CFLAGS += -DTEST
 
 .PHONY: $(BUILD)/genhdr/tests.h
@@ -11,7 +16,7 @@ CFLAGS += -DTEST
 $(BUILD)/test_main.o: $(BUILD)/genhdr/tests.h
 $(BUILD)/genhdr/tests.h:
 	(cd $(TOP)/tests; ./run-tests.py --target=qemu-arm --write-exp)
-	$(Q)echo "Generating $@";(cd $(TOP)/tests; ../tools/tinytest-codegen.py) > $@
+	$(Q)echo "Generating $@";(cd $(TOP)/tests; ../tools/tinytest-codegen.py $(addprefix --exclude ,$(TESTS_EXCLUDE))) > $@
 
 $(BUILD)/lib/tinytest/tinytest.o: CFLAGS += -DNO_FORKING
 

--- a/ports/qemu-arm/imx6.ld
+++ b/ports/qemu-arm/imx6.ld
@@ -1,0 +1,47 @@
+/* Vector table is at 0x00000000, entry point is 0x10000000. */
+
+MEMORY
+{
+    ROM : ORIGIN = 0x00000000, LENGTH = 96K
+    RAM : ORIGIN = 0x10000000, LENGTH = 128M
+}
+
+_estack = ORIGIN(RAM) + LENGTH(RAM);
+
+SECTIONS
+{
+    .rom : {
+        . = ALIGN(4);
+        KEEP(*(.isr_vector))
+        . = ALIGN(4);
+    } > ROM
+
+    .text : {
+        . = ALIGN(4);
+        *(.text.Reset_Handler)
+        *(.text*)
+        *(.rodata*)
+        . = ALIGN(4);
+        _etext = .;
+        _sidata = _etext;
+    } > RAM
+
+    .data : AT ( _sidata )
+    {
+        . = ALIGN(4);
+        _sdata = .;
+        *(.data*)
+        . = ALIGN(4);
+        _edata = .;
+    } > RAM
+
+    .bss :
+    {
+        . = ALIGN(4);
+        _sbss = .;
+        *(.bss*)
+        *(COMMON)
+        . = ALIGN(4);
+        _ebss = .;
+    } > RAM
+}

--- a/ports/qemu-arm/mpconfigport.h
+++ b/ports/qemu-arm/mpconfigport.h
@@ -3,9 +3,16 @@
 // options to control how MicroPython is built
 
 #define MICROPY_ALLOC_PATH_MAX      (512)
-#define MICROPY_EMIT_X64            (0)
+
+#if defined(__ARM_ARCH_ISA_ARM)
+#define MICROPY_EMIT_ARM            (1)
+#define MICROPY_EMIT_INLINE_THUMB   (1)
+#elif defined(__ARM_ARCH_ISA_THUMB)
 #define MICROPY_EMIT_THUMB          (1)
 #define MICROPY_EMIT_INLINE_THUMB   (1)
+#define MICROPY_MAKE_POINTER_CALLABLE(p) ((void *)((mp_uint_t)(p) | 1))
+#endif
+
 #define MICROPY_MALLOC_USES_ALLOCATED_SIZE (1)
 #define MICROPY_MEM_STATS           (1)
 #define MICROPY_DEBUG_PRINTERS      (0)
@@ -42,8 +49,6 @@
 #define MICROPY_VFS                 (1)
 
 // type definitions for the specific machine
-
-#define MICROPY_MAKE_POINTER_CALLABLE(p) ((void *)((mp_uint_t)(p) | 1))
 
 #define MP_SSIZE_MAX (0x7fffffff)
 

--- a/ports/qemu-arm/startup.c
+++ b/ports/qemu-arm/startup.c
@@ -28,6 +28,27 @@ void Default_Handler(void) {
     }
 }
 
+#if defined(__ARM_ARCH_ISA_ARM)
+
+// ARM architecture with standard ARM ISA.
+
+__attribute__((naked, section(".isr_vector"))) void isr_vector(void) {
+    __asm volatile (
+        "b Reset_Handler\n"
+        "b Default_Handler\n"
+        "b Default_Handler\n"
+        "b Default_Handler\n"
+        "b Default_Handler\n"
+        "nop\n"
+        "b Default_Handler\n"
+        "b Default_Handler\n"
+        );
+}
+
+#elif defined(__ARM_ARCH_ISA_THUMB)
+
+// ARM architecture with Thumb-only ISA.
+
 const uint32_t isr_vector[] __attribute__((section(".isr_vector"))) = {
     (uint32_t)&_estack,
     (uint32_t)&Reset_Handler,
@@ -46,6 +67,8 @@ const uint32_t isr_vector[] __attribute__((section(".isr_vector"))) = {
     (uint32_t)&Default_Handler, // PendSV_Handler
     (uint32_t)&Default_Handler, // SysTick_Handler
 };
+
+#endif
 
 void _start(void) {
     // Enable the UART
@@ -68,7 +91,11 @@ __attribute__((naked)) void exit(int status) {
         "ldr r1, =0x20026\n" // ADP_Stopped_ApplicationExit, a clean exit
         ".notclean:\n"
         "movs r0, #0x18\n" // SYS_EXIT
+        #if defined(__ARM_ARCH_ISA_ARM)
+        "svc 0x00123456\n"
+        #elif defined(__ARM_ARCH_ISA_THUMB)
         "bkpt 0xab\n"
+        #endif
         );
     for (;;) {
     }

--- a/ports/qemu-arm/uart.c
+++ b/ports/qemu-arm/uart.c
@@ -75,4 +75,31 @@ void uart_tx_strn(const char *buf, size_t len) {
     }
 }
 
+#elif defined(QEMU_SOC_IMX6)
+
+#define UART_UCR1_UARTEN (1 << 0)
+#define UART_UCR2_TXEN (1 << 2)
+
+typedef struct _UART_t {
+    volatile uint32_t URXD; // 0x00
+    volatile uint32_t r0[15];
+    volatile uint32_t UTXD; // 0x40
+    volatile uint32_t r1[15];
+    volatile uint32_t UCR1; // 0x80
+    volatile uint32_t UCR2; // 0x84
+} UART_t;
+
+#define UART1 ((UART_t *)(0x02020000))
+
+void uart_init(void) {
+    UART1->UCR1 = UART_UCR1_UARTEN;
+    UART1->UCR2 = UART_UCR2_TXEN;
+}
+
+void uart_tx_strn(const char *buf, size_t len) {
+    for (size_t i = 0; i < len; ++i) {
+        UART1->UTXD = buf[i];
+    }
+}
+
 #endif

--- a/py/asmarm.c
+++ b/py/asmarm.c
@@ -40,7 +40,7 @@
 
 void asm_arm_end_pass(asm_arm_t *as) {
     if (as->base.pass == MP_ASM_PASS_EMIT) {
-        #if defined(__linux__) && defined(__GNUC__)
+        #if (defined(__linux__) && defined(__GNUC__)) || __ARM_ARCH == 7
         char *start = mp_asm_base_get_code(&as->base);
         char *end = start + mp_asm_base_get_code_size(&as->base);
         __builtin___clear_cache(start, end);
@@ -48,10 +48,10 @@ void asm_arm_end_pass(asm_arm_t *as) {
         // flush I- and D-cache
         asm volatile (
             "0:"
-            "mrc p15, 0, r15, c7, c10, 3\n"
+            "mrc p15, 0, r15, c7, c10, 3\n" // test and clean D-cache
             "bne 0b\n"
             "mov r0, #0\n"
-            "mcr p15, 0, r0, c7, c7, 0\n"
+            "mcr p15, 0, r0, c7, c7, 0\n" // invalidate I-cache and D-cache
             : : : "r0", "cc");
         #endif
     }

--- a/tools/ci.sh
+++ b/tools/ci.sh
@@ -194,6 +194,8 @@ function ci_qemu_arm_build {
     make ${MAKEOPTS} -C ports/qemu-arm CFLAGS_EXTRA=-DMP_ENDIANNESS_BIG=1
     make ${MAKEOPTS} -C ports/qemu-arm clean
     make ${MAKEOPTS} -C ports/qemu-arm -f Makefile.test test
+    make ${MAKEOPTS} -C ports/qemu-arm -f Makefile.test clean
+    make ${MAKEOPTS} -C ports/qemu-arm -f Makefile.test BOARD=sabrelite test
 }
 
 ########################################################################################

--- a/tools/mpy-tool.py
+++ b/tools/mpy-tool.py
@@ -532,6 +532,7 @@ class RawCodeNative(RawCode):
             if config.native_arch in (
                 MP_NATIVE_ARCH_X86,
                 MP_NATIVE_ARCH_X64,
+                MP_NATIVE_ARCH_ARMV6,
                 MP_NATIVE_ARCH_XTENSA,
                 MP_NATIVE_ARCH_XTENSAWIN,
             ):

--- a/tools/tinytest-codegen.py
+++ b/tools/tinytest-codegen.py
@@ -108,9 +108,12 @@ argparser = argparse.ArgumentParser(
     description="Convert native MicroPython tests to tinytest/upytesthelper C code"
 )
 argparser.add_argument("--stdin", action="store_true", help="read list of tests from stdin")
+argparser.add_argument("--exclude", action="append", help="exclude test by name")
 args = argparser.parse_args()
 
 if not args.stdin:
+    if args.exclude:
+        exclude_tests += tuple(args.exclude)
     for group in test_dirs:
         tests += [test for test in glob("{}/*.py".format(group)) if test not in exclude_tests]
 else:


### PR DESCRIPTION
The main aim here is to have a way to test the ARM native emitter.  This is done by adding a new board to the `qemu-arm` port which has a Cortex-A9.

There are a few TODOs left here, but at least it shows how to get it working.