### PR TITLE
Extend bluetooth API

### DIFF
--- a/extmod/modbluetooth.c
+++ b/extmod/modbluetooth.c
@@ -674,6 +674,16 @@ STATIC mp_obj_t bluetooth_ble_gattc_discover_services(mp_obj_t self_in, mp_obj_t
 }
 STATIC MP_DEFINE_CONST_FUN_OBJ_2(bluetooth_ble_gattc_discover_services_obj, bluetooth_ble_gattc_discover_services);
 
+STATIC mp_obj_t bluetooth_ble_gattc_discover_service_by_uuid(mp_obj_t self_in, mp_obj_t conn_handle_in, mp_obj_t uuid_in) {
+    mp_int_t conn_handle = mp_obj_get_int(conn_handle_in);
+    if (!mp_obj_is_type(uuid_in, &bluetooth_uuid_type)) {
+        mp_raise_ValueError(MP_ERROR_TEXT("invalid service UUID"));
+    }
+    mp_obj_bluetooth_uuid_t *service_uuid = MP_OBJ_TO_PTR(uuid_in);
+    return bluetooth_handle_errno(mp_bluetooth_gattc_discover_primary_service_by_uuid(conn_handle, service_uuid));
+}
+STATIC MP_DEFINE_CONST_FUN_OBJ_3(bluetooth_ble_gattc_discover_service_by_uuid_obj, bluetooth_ble_gattc_discover_service_by_uuid);
+
 STATIC mp_obj_t bluetooth_ble_gattc_discover_characteristics(size_t n_args, const mp_obj_t *args) {
     mp_int_t conn_handle = mp_obj_get_int(args[1]);
     mp_int_t start_handle = mp_obj_get_int(args[2]);
@@ -739,6 +749,7 @@ STATIC const mp_rom_map_elem_t bluetooth_ble_locals_dict_table[] = {
     #if MICROPY_PY_BLUETOOTH_ENABLE_CENTRAL_MODE
     // GATT Client (i.e. central/scanner role)
     { MP_ROM_QSTR(MP_QSTR_gattc_discover_services), MP_ROM_PTR(&bluetooth_ble_gattc_discover_services_obj) },
+    { MP_ROM_QSTR(MP_QSTR_gattc_discover_service_by_uuid), MP_ROM_PTR(&bluetooth_ble_gattc_discover_service_by_uuid_obj) },
     { MP_ROM_QSTR(MP_QSTR_gattc_discover_characteristics), MP_ROM_PTR(&bluetooth_ble_gattc_discover_characteristics_obj) },
     { MP_ROM_QSTR(MP_QSTR_gattc_discover_descriptors), MP_ROM_PTR(&bluetooth_ble_gattc_discover_descriptors_obj) },
     { MP_ROM_QSTR(MP_QSTR_gattc_read), MP_ROM_PTR(&bluetooth_ble_gattc_read_obj) },

--- a/extmod/modbluetooth.c
+++ b/extmod/modbluetooth.c
@@ -692,6 +692,18 @@ STATIC mp_obj_t bluetooth_ble_gattc_discover_characteristics(size_t n_args, cons
 }
 STATIC MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(bluetooth_ble_gattc_discover_characteristics_obj, 4, 4, bluetooth_ble_gattc_discover_characteristics);
 
+STATIC mp_obj_t bluetooth_ble_gattc_discover_characteristic_by_uuid(size_t n_args, const mp_obj_t *args) {
+    mp_int_t conn_handle = mp_obj_get_int(args[1]);
+    mp_int_t start_handle = mp_obj_get_int(args[2]);
+    mp_int_t end_handle = mp_obj_get_int(args[3]);
+    if (!mp_obj_is_type(args[4], &bluetooth_uuid_type)) {
+        mp_raise_ValueError(MP_ERROR_TEXT("invalid characteristic UUID"));
+    }
+    mp_obj_bluetooth_uuid_t *charactristic_uuid = MP_OBJ_TO_PTR(args[4]);
+    return bluetooth_handle_errno(mp_bluetooth_gattc_discover_characteristic_by_uuid(conn_handle, start_handle, end_handle, charactristic_uuid));
+}
+STATIC MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(bluetooth_ble_gattc_discover_characteristic_by_uuid_obj, 5, 5, bluetooth_ble_gattc_discover_characteristic_by_uuid);
+
 STATIC mp_obj_t bluetooth_ble_gattc_discover_descriptors(size_t n_args, const mp_obj_t *args) {
     mp_int_t conn_handle = mp_obj_get_int(args[1]);
     mp_int_t start_handle = mp_obj_get_int(args[2]);
@@ -751,6 +763,7 @@ STATIC const mp_rom_map_elem_t bluetooth_ble_locals_dict_table[] = {
     { MP_ROM_QSTR(MP_QSTR_gattc_discover_services), MP_ROM_PTR(&bluetooth_ble_gattc_discover_services_obj) },
     { MP_ROM_QSTR(MP_QSTR_gattc_discover_service_by_uuid), MP_ROM_PTR(&bluetooth_ble_gattc_discover_service_by_uuid_obj) },
     { MP_ROM_QSTR(MP_QSTR_gattc_discover_characteristics), MP_ROM_PTR(&bluetooth_ble_gattc_discover_characteristics_obj) },
+    { MP_ROM_QSTR(MP_QSTR_gattc_discover_characteristics), MP_ROM_PTR(&bluetooth_ble_gattc_discover_characteristic_by_uuid_obj) },
     { MP_ROM_QSTR(MP_QSTR_gattc_discover_descriptors), MP_ROM_PTR(&bluetooth_ble_gattc_discover_descriptors_obj) },
     { MP_ROM_QSTR(MP_QSTR_gattc_read), MP_ROM_PTR(&bluetooth_ble_gattc_read_obj) },
     { MP_ROM_QSTR(MP_QSTR_gattc_write), MP_ROM_PTR(&bluetooth_ble_gattc_write_obj) },

--- a/extmod/modbluetooth.h
+++ b/extmod/modbluetooth.h
@@ -217,6 +217,9 @@ int mp_bluetooth_gap_peripheral_connect(uint8_t addr_type, const uint8_t *addr, 
 // Find all primary services on the connected peripheral.
 int mp_bluetooth_gattc_discover_primary_services(uint16_t conn_handle);
 
+// Find primary service by UUID on the connected peripheral.
+int mp_bluetooth_gattc_discover_primary_service_by_uuid(uint16_t conn_handle, const mp_obj_bluetooth_uuid_t *service_uuid);
+
 // Find all characteristics on the specified service on a connected peripheral.
 int mp_bluetooth_gattc_discover_characteristics(uint16_t conn_handle, uint16_t start_handle, uint16_t end_handle);
 

--- a/extmod/modbluetooth.h
+++ b/extmod/modbluetooth.h
@@ -223,6 +223,9 @@ int mp_bluetooth_gattc_discover_primary_service_by_uuid(uint16_t conn_handle, co
 // Find all characteristics on the specified service on a connected peripheral.
 int mp_bluetooth_gattc_discover_characteristics(uint16_t conn_handle, uint16_t start_handle, uint16_t end_handle);
 
+// Find characteristic by UUID on the specified service on a connected peripheral.
+int mp_bluetooth_gattc_discover_characteristic_by_uuid(uint16_t conn_handle, uint16_t start_handle, uint16_t end_handle, const mp_obj_bluetooth_uuid_t *charactristic_uuid);
+
 // Find all descriptors on the specified characteristic on a connected peripheral.
 int mp_bluetooth_gattc_discover_descriptors(uint16_t conn_handle, uint16_t start_handle, uint16_t end_handle);
 

--- a/extmod/nimble/modbluetooth_nimble.c
+++ b/extmod/nimble/modbluetooth_nimble.c
@@ -805,6 +805,16 @@ int mp_bluetooth_gattc_discover_characteristics(uint16_t conn_handle, uint16_t s
     return ble_hs_err_to_errno(err);
 }
 
+int mp_bluetooth_gattc_discover_characteristic_by_uuid(uint16_t conn_handle, uint16_t start_handle, uint16_t end_handle, const mp_obj_bluetooth_uuid_t *charactristic_uuid)
+{
+    if (!mp_bluetooth_is_active()) {
+        return ERRNO_BLUETOOTH_NOT_ACTIVE;
+    }
+    ble_uuid_t *nimble_uuid = create_nimble_uuid(charactristic_uuid);
+    int err = ble_gattc_disc_chrs_by_uuid(conn_handle, start_handle, end_handle, nimble_uuid, &ble_gatt_characteristic_cb, NULL);
+    return ble_hs_err_to_errno(err);
+}
+
 STATIC int ble_gatt_descriptor_cb(uint16_t conn_handle, const struct ble_gatt_error *error, uint16_t characteristic_val_handle, const struct ble_gatt_dsc *descriptor, void *arg) {
     DEBUG_EVENT_printf("ble_gatt_descriptor_cb: conn_handle=%d status=%d chr_handle=%d dsc_handle=%d\n", conn_handle, error->status, characteristic_val_handle, descriptor ? descriptor->handle : -1);
     if (!mp_bluetooth_is_active()) {

--- a/extmod/nimble/modbluetooth_nimble.c
+++ b/extmod/nimble/modbluetooth_nimble.c
@@ -776,6 +776,15 @@ int mp_bluetooth_gattc_discover_primary_services(uint16_t conn_handle) {
     return ble_hs_err_to_errno(err);
 }
 
+int mp_bluetooth_gattc_discover_primary_service_by_uuid(uint16_t conn_handle, const mp_obj_bluetooth_uuid_t *uuid) {
+    if (!mp_bluetooth_is_active()) {
+        return ERRNO_BLUETOOTH_NOT_ACTIVE;
+    }
+    ble_uuid_t *nimble_uuid = create_nimble_uuid(uuid);
+    int err = ble_gattc_disc_svc_by_uuid(conn_handle, nimble_uuid, &peripheral_discover_service_cb, NULL);
+    return ble_hs_err_to_errno(err);
+}
+
 STATIC int ble_gatt_characteristic_cb(uint16_t conn_handle, const struct ble_gatt_error *error, const struct ble_gatt_chr *characteristic, void *arg) {
     DEBUG_EVENT_printf("ble_gatt_characteristic_cb: conn_handle=%d status=%d def_handle=%d val_handle=%d\n", conn_handle, error->status, characteristic ? characteristic->def_handle : -1, characteristic ? characteristic->val_handle : -1);
     if (!mp_bluetooth_is_active()) {


### PR DESCRIPTION
Add API to discover services/characteristics by UUID. This is useful if only a specific services/characteristics is required as it simplifies code in those cases. It also allows to sidestep a problem currently seen with ESP32 where scanning for characteristics while service scanning is still active leads to a crash (#5686). Unfortunately it is no possible to tell when scanning finished. Just scanning for a single UUID and scanning for a single characteristics allows to sidestep this problem easily.

Using the UUID specific API's has been suggested by ESP IDF developers: https://github.com/espressif/esp-idf/issues/4913#issuecomment-617755796