### PR TITLE
esp32/modsocket: fix getaddrinfo to raise on error

### DIFF
--- a/ports/esp32/modsocket.c
+++ b/ports/esp32/modsocket.c
@@ -244,19 +244,24 @@ static int _socket_getaddrinfo2(const mp_obj_t host, const mp_obj_t portx, struc
     int res = _socket_getaddrinfo3(host_str, port_str, &hints, resp);
     MP_THREAD_GIL_ENTER();
 
+    // Per docs: instead of raising gaierror getaddrinfo raises negative error number
+    if (res != 0) {
+        mp_raise_OSError(res > 0 ? -res : res);
+    }
+    // Somehow LwIP returns a resolution of 0.0.0.0 for failed lookups, traced it as far back
+    // as netconn_gethostbyname_addrtype returning OK instead of error. Go figure...
+    if (*resp == NULL ||
+        (strcmp(resp[0]->ai_canonname, "0.0.0.0") == 0 && strcmp(host_str, "0.0.0.0") != 0)) {
+        mp_raise_OSError(-2); // name or service not known
+    }
+
     return res;
 }
 
 STATIC void _socket_getaddrinfo(const mp_obj_t addrtuple, struct addrinfo **resp) {
     mp_obj_t *elem;
     mp_obj_get_array_fixed_n(addrtuple, 2, &elem);
-    int res = _socket_getaddrinfo2(elem[0], elem[1], resp);
-    if (res != 0) {
-        mp_raise_OSError(res);
-    }
-    if (*resp == NULL) {
-        mp_raise_OSError(-2); // name or service not known
-    }
+    _socket_getaddrinfo2(elem[0], elem[1], resp);
 }
 
 STATIC mp_obj_t socket_make_new(const mp_obj_type_t *type_in, size_t n_args, size_t n_kw, const mp_obj_t *args) {

--- a/tests/esp32/resolve_on_connect.py
+++ b/tests/esp32/resolve_on_connect.py
@@ -1,5 +1,6 @@
 # Test that the esp32's socket module performs DNS resolutions on bind and connect
 import sys
+
 if sys.implementation.name == "micropython" and sys.platform != "esp32":
     print("SKIP")
     raise SystemExit

--- a/tests/esp32/resolve_on_connect.py
+++ b/tests/esp32/resolve_on_connect.py
@@ -1,0 +1,58 @@
+# Test that the esp32's socket module performs DNS resolutions on bind and connect
+import sys
+if sys.implementation.name == "micropython" and sys.platform != "esp32":
+    print("SKIP")
+    raise SystemExit
+
+try:
+    import usocket as socket, sys
+except:
+    import socket, sys
+
+
+def test_bind_resolves_0_0_0_0():
+    s = socket.socket()
+    try:
+        s.bind(("0.0.0.0", 31245))
+        print("bind actually bound")
+        s.close()
+    except Exception as e:
+        print("bind raised", e)
+
+
+def test_bind_resolves_localhost():
+    s = socket.socket()
+    try:
+        s.bind(("localhost", 31245))
+        print("bind actually bound")
+        s.close()
+    except Exception as e:
+        print("bind raised", e)
+
+
+def test_connect_resolves():
+    s = socket.socket()
+    try:
+        s.connect(("micropython.org", 80))
+        print("connect actually connected")
+        s.close()
+    except Exception as e:
+        print("connect raised", e)
+
+
+def test_connect_non_existant():
+    s = socket.socket()
+    try:
+        s.connect(("nonexistant.example.com", 80))
+        print("connect actually connected")
+        s.close()
+    except OSError as e:
+        print("connect raised OSError")
+    except Exception as e:
+        print("connect raised", e)
+
+
+test_funs = [n for n in dir() if n.startswith("test_")]
+for f in sorted(test_funs):
+    print("--", f, end=": ")
+    eval(f + "()")

--- a/tests/net_inet/getaddrinfo.py
+++ b/tests/net_inet/getaddrinfo.py
@@ -1,0 +1,96 @@
+try:
+    import usocket as socket, sys
+except:
+    import socket, sys
+
+
+def test_non_existant():
+    try:
+        res = socket.getaddrinfo("nonexistant.example.com", 80)
+        print("getaddrinfo returned", res)
+    except OSError as e:
+        # print(e)
+        print("getaddrinfo raised")
+
+
+def test_bogus():
+    try:
+        res = socket.getaddrinfo("..", 80)
+        print("getaddrinfo returned", res)
+    except OSError as e:
+        # print(e)
+        print("getaddrinfo raised")
+    except Exception as e:
+        print("getaddrinfo raised")  # CPython raises UnicodeError!?
+
+
+def test_ip_addr():
+    try:
+        res = socket.getaddrinfo("10.10.10.10", 80)
+        print("getaddrinfo returned resolutions")
+    except Exception as e:
+        print("getaddrinfo raised", e)
+
+
+def test_0_0_0_0():
+    try:
+        res = socket.getaddrinfo("0.0.0.0", 80)
+        print("getaddrinfo returned resolutions")
+    except Exception as e:
+        print("getaddrinfo raised", e)
+
+
+def test_valid():
+    try:
+        res = socket.getaddrinfo("micropython.org", 80)
+        print("getaddrinfo returned resolutions")
+    except Exception as e:
+        print("getaddrinfo raised", e)
+
+
+def test_bind_resolves_0_0_0_0():
+    s = socket.socket()
+    try:
+        s.bind(("0.0.0.0", 31245))
+        print("bind actually bound")
+        s.close()
+    except Exception as e:
+        print("bind raised", e)
+
+
+def test_bind_resolves_localhost():
+    s = socket.socket()
+    try:
+        s.bind(("localhost", 31245))
+        print("bind actually bound")
+        s.close()
+    except Exception as e:
+        print("bind raised", e)
+
+
+def test_connect_resolves():
+    s = socket.socket()
+    try:
+        s.connect(("micropython.org", 80))
+        print("connect actually connected")
+        s.close()
+    except Exception as e:
+        print("connect raised", e)
+
+
+def test_connect_non_existant():
+    s = socket.socket()
+    try:
+        s.connect(("nonexistant.example.com", 80))
+        print("connect actually connected")
+        s.close()
+    except OSError as e:
+        print("connect raised OSError")
+    except Exception as e:
+        print("connect raised", e)
+
+
+test_funs = [n for n in dir() if n.startswith("test_")]
+for f in sorted(test_funs):
+    print("--", f, end=": ")
+    eval(f + "()")

--- a/tests/net_inet/getaddrinfo.py
+++ b/tests/net_inet/getaddrinfo.py
@@ -15,10 +15,9 @@ def test_non_existant():
 
 def test_bogus():
     try:
-        res = socket.getaddrinfo("..", 80)
+        res = socket.getaddrinfo("hey.!!$$", 80)
         print("getaddrinfo returned", res)
     except OSError as e:
-        # print(e)
         print("getaddrinfo raised")
     except Exception as e:
         print("getaddrinfo raised")  # CPython raises UnicodeError!?

--- a/tests/net_inet/getaddrinfo.py
+++ b/tests/net_inet/getaddrinfo.py
@@ -48,48 +48,6 @@ def test_valid():
         print("getaddrinfo raised", e)
 
 
-def test_bind_resolves_0_0_0_0():
-    s = socket.socket()
-    try:
-        s.bind(("0.0.0.0", 31245))
-        print("bind actually bound")
-        s.close()
-    except Exception as e:
-        print("bind raised", e)
-
-
-def test_bind_resolves_localhost():
-    s = socket.socket()
-    try:
-        s.bind(("localhost", 31245))
-        print("bind actually bound")
-        s.close()
-    except Exception as e:
-        print("bind raised", e)
-
-
-def test_connect_resolves():
-    s = socket.socket()
-    try:
-        s.connect(("micropython.org", 80))
-        print("connect actually connected")
-        s.close()
-    except Exception as e:
-        print("connect raised", e)
-
-
-def test_connect_non_existant():
-    s = socket.socket()
-    try:
-        s.connect(("nonexistant.example.com", 80))
-        print("connect actually connected")
-        s.close()
-    except OSError as e:
-        print("connect raised OSError")
-    except Exception as e:
-        print("connect raised", e)
-
-
 test_funs = [n for n in dir() if n.startswith("test_")]
 for f in sorted(test_funs):
     print("--", f, end=": ")


### PR DESCRIPTION
This PR fixes the behavior of socket.getaddrinfo on the ESP32 so it raises an OSError when the name resolution fails instead of returning a `[]` or a resolution for `0.0.0.0`. A test is added to net_inet to verify behavior consistent with CPython (modulo the different types of exceptions per MP docs). Note that PYBD fails some tests, specifically, it does not resolve the `addr` argument to `connect` and `bind`.