### PR TITLE
extmod/vfs_lfsx.c: reformat a path name into canonical form

### DIFF
--- a/extmod/vfs_lfs.c
+++ b/extmod/vfs_lfs.c
@@ -68,7 +68,7 @@ typedef struct _mp_obj_vfs_lfs1_file_t {
     uint8_t file_buffer[0];
 } mp_obj_vfs_lfs1_file_t;
 
-const char *mp_vfs_lfs1_make_path(mp_obj_vfs_lfs1_t *self, mp_obj_t path_in);
+char *mp_vfs_lfs1_make_path(mp_obj_vfs_lfs1_t *self, mp_obj_t path_in);
 mp_obj_t mp_vfs_lfs1_file_open(mp_obj_t self_in, mp_obj_t path_in, mp_obj_t mode_in);
 
 #include "extmod/vfs_lfsx.c"
@@ -114,7 +114,7 @@ typedef struct _mp_obj_vfs_lfs2_file_t {
     uint8_t file_buffer[0];
 } mp_obj_vfs_lfs2_file_t;
 
-const char *mp_vfs_lfs2_make_path(mp_obj_vfs_lfs2_t *self, mp_obj_t path_in);
+char *mp_vfs_lfs2_make_path(mp_obj_vfs_lfs2_t *self, mp_obj_t path_in);
 mp_obj_t mp_vfs_lfs2_file_open(mp_obj_t self_in, mp_obj_t path_in, mp_obj_t mode_in);
 
 #include "extmod/vfs_lfsx.c"

--- a/extmod/vfs_lfs.c
+++ b/extmod/vfs_lfs.c
@@ -68,6 +68,7 @@ typedef struct _mp_obj_vfs_lfs1_file_t {
     uint8_t file_buffer[0];
 } mp_obj_vfs_lfs1_file_t;
 
+char *mp_vfs_lfs1_get_token(const char *path, char sep, size_t *len);
 char *mp_vfs_lfs1_make_path(mp_obj_vfs_lfs1_t *self, mp_obj_t path_in);
 mp_obj_t mp_vfs_lfs1_file_open(mp_obj_t self_in, mp_obj_t path_in, mp_obj_t mode_in);
 
@@ -114,6 +115,7 @@ typedef struct _mp_obj_vfs_lfs2_file_t {
     uint8_t file_buffer[0];
 } mp_obj_vfs_lfs2_file_t;
 
+char *mp_vfs_lfs2_get_token(const char *path, char sep, size_t *len);
 char *mp_vfs_lfs2_make_path(mp_obj_vfs_lfs2_t *self, mp_obj_t path_in);
 mp_obj_t mp_vfs_lfs2_file_open(mp_obj_t self_in, mp_obj_t path_in, mp_obj_t mode_in);
 

--- a/extmod/vfs_lfsx.c
+++ b/extmod/vfs_lfsx.c
@@ -148,7 +148,11 @@ char *MP_VFS_LFSx(make_path)(MP_OBJ_VFS_LFSx * self, mp_obj_t path_in) {
             while (len_path > 0 && new_path[len_path] != '/') { // skip back w/o strrchr
                 len_path--;
             }
-            new_path[len_path == 0 ? 1 : len_path] = '\0';
+            if (len_path == 0) { // backed up to the tip
+                new_path[++len_path] = '\0';
+            } else {
+                new_path[len_path] = '\0';
+            }
         } else if (len_token != 1 || token[0] != '.') {
             if (len_path > 1) { // not at the start
                 new_path[len_path++] = '/';

--- a/extmod/vfs_lfsx.c
+++ b/extmod/vfs_lfsx.c
@@ -101,7 +101,7 @@ STATIC void MP_VFS_LFSx(init_config)(MP_OBJ_VFS_LFSx * self, mp_obj_t bdev, size
 
 // replacement for strtok, which does not modify the source string
 // but returns instead the length of the token
-static char *get_token(const char *path, char sep, size_t *len) {
+char *MP_VFS_LFSx(get_token)(const char *path, char sep, size_t *len) {
     static const char *ptr = ""; // safe initial state
     const char *start;
     if (path != NULL) {  // get initial start
@@ -143,7 +143,7 @@ char *MP_VFS_LFSx(make_path)(MP_OBJ_VFS_LFSx * self, mp_obj_t path_in) {
 
     size_t len_token;
     size_t len_path = strlen(new_path);
-    for (char *token = get_token(path, '/', &len_token); token != NULL;) {
+    for (char *token = MP_VFS_LFSx(get_token)(path, '/', &len_token); token != NULL;) {
         if (len_token == 2 && token[0] == '.' && token[1] == '.') { // double dot, skip back in new_path
             while (len_path > 0 && new_path[len_path] != '/') { // skip back w/o strrchr
                 len_path--;
@@ -162,7 +162,7 @@ char *MP_VFS_LFSx(make_path)(MP_OBJ_VFS_LFSx * self, mp_obj_t path_in) {
             }
             new_path[len_path] = '\0';
         }
-        token = get_token(NULL, '/', &len_token);
+        token = MP_VFS_LFSx(get_token)(NULL, '/', &len_token);
     }
     return new_path;
 }


### PR DESCRIPTION
It sorts out . and .. in the path name and removes multiple /'s
Question I have doubts about:
- It uses m_malloc() to allocate space for the new path name from
  the heap. How do I prevent gc_collect() from freeing it, before it
  is used. Not likely, but I did not follow all possible cases.
- I have a temporary buffer for pointers which I've set to 32 entries.
  This is smaller than the worst case. It there something like vstring
  for other data types? Obviously I could use m_malloc and gc_free, or
  malloc and free, since this data is only used within the function.