### PR TITLE
fix for "wrong number of arguments"

### DIFF
--- a/examples/bluetooth/ble_advertising.py
+++ b/examples/bluetooth/ble_advertising.py
@@ -38,7 +38,7 @@ def advertising_payload(limited_disc=False, br_edr=False, name=None, services=No
 
     if services:
         for uuid in services:
-            b = bytes(uuid)
+            b = bytes(uuid, 'utf-8')
             if len(b) == 2:
                 _append(_ADV_TYPE_UUID16_COMPLETE, b)
             elif len(b) == 4:


### PR DESCRIPTION
esp32-idf3-20200422-v1.12-388-g388d419ba.bin

Traceback (most recent call last):
  File "main.py", line 87, in <module>
  File "main.py", line 72, in demo
  File "main.py", line 42, in __init__
  File "ble_advertising.py", line 41, in advertising_payload
TypeError: wrong number of arguments