### PR TITLE
all: Don't redefine MICROPY_GCREGS_SETJMP if it's already set elsewhere.

### DIFF
--- a/examples/embedding/mpconfigport_minimal.h
+++ b/examples/embedding/mpconfigport_minimal.h
@@ -97,7 +97,7 @@ extern const struct _mp_obj_module_t mp_module_os;
 // Do not change anything beyond this line
 //////////////////////////////////////////
 
-#if !defined(__x86_64__) || !defined(__i386__) || !defined(__thumb2__) || !defined(__thumb__) || !defined(__arm__)
+#if !(defined(MICROPY_GCREGS_SETJMP) || defined(__x86_64__) || defined(__i386__) || defined(__thumb2__) || defined(__thumb__) || defined(__arm__))
 // Fall back to setjmp() implementation for discovery of GC pointers in registers.
 #define MICROPY_GCREGS_SETJMP (1)
 #endif

--- a/mpy-cross/mpconfigport.h
+++ b/mpy-cross/mpconfigport.h
@@ -68,7 +68,7 @@
 
 #define MICROPY_PY_BUILTINS_STR_UNICODE (1)
 
-#if !defined(__x86_64__) || !defined(__i386__) || !defined(__thumb2__) || !defined(__thumb__) || !defined(__arm__)
+#if !(defined(MICROPY_GCREGS_SETJMP) || defined(__x86_64__) || defined(__i386__) || defined(__thumb2__) || defined(__thumb__) || defined(__arm__))
 // Fall back to setjmp() implementation for discovery of GC pointers in registers.
 #define MICROPY_GCREGS_SETJMP (1)
 #endif

--- a/ports/unix/mpconfigport.h
+++ b/ports/unix/mpconfigport.h
@@ -178,7 +178,7 @@
 
 extern const struct _mp_print_t mp_stderr_print;
 
-#if !defined(__x86_64__) || !defined(__i386__) || !defined(__thumb2__) || !defined(__thumb__) || !defined(__arm__)
+#if !(defined(MICROPY_GCREGS_SETJMP) || defined(__x86_64__) || defined(__i386__) || defined(__thumb2__) || defined(__thumb__) || defined(__arm__))
 // Fall back to setjmp() implementation for discovery of GC pointers in registers.
 #define MICROPY_GCREGS_SETJMP (1)
 #endif

--- a/ports/unix/variants/minimal/mpconfigvariant.h
+++ b/ports/unix/variants/minimal/mpconfigvariant.h
@@ -110,7 +110,7 @@ extern const struct _mp_obj_module_t mp_module_os;
 // Do not change anything beyond this line
 //////////////////////////////////////////
 
-#if !defined(__x86_64__) || !defined(__i386__) || !defined(__thumb2__) || !defined(__thumb__) || !defined(__arm__)
+#if !(defined(MICROPY_GCREGS_SETJMP) || defined(__x86_64__) || defined(__i386__) || defined(__thumb2__) || defined(__thumb__) || defined(__arm__))
 // Fall back to setjmp() implementation for discovery of GC pointers in registers.
 #define MICROPY_GCREGS_SETJMP (1)
 #endif


### PR DESCRIPTION
In particular Windows builds of mpy-cross set it externally.

Follow up to #5961