### PR TITLE
py/mkrules.mk: workaround fused multiply-add inaccuracy

### DIFF
--- a/py/mkrules.mk
+++ b/py/mkrules.mk
@@ -14,6 +14,9 @@ OBJ_EXTRA_ORDER_DEPS += $(HEADER_BUILD)/compressed.data.h
 CFLAGS += -DMICROPY_ROM_TEXT_COMPRESSION=1
 endif
 
+# see 'fused multiply-add' problem
+CFLAGS += -ffp-contract=off
+
 # QSTR generation uses the same CFLAGS, with these modifications.
 # Note: := to force evalulation immediately.
 QSTR_GEN_CFLAGS := $(CFLAGS)


### PR DESCRIPTION
On arm64, `print(float('.' + '9' * 70))` resulted in `1.000000000000001` rather that `1.0`.

This is because

  dec_val = 10 * dec_val + dig;

was converted into a single fused multiply-add instruction (fmadd) rather than two (mulsd and addsd on x86), thus caused a slightly different rounding loss when `dec_val` is about to overflow.

The parsing process of `'.' + '9' * 70` would look like this on x86

  10000000000000003053453312.000000 45208b2a2c280292 -25
  100000000000000021944598528.000000 4554adf4b7320336 -26
  1000000000000000288165462016.000000 4589d971e4fe8404 -27

and on arm64

  10000000000000003053453312.000000 45208b2a2c280292 -25
  100000000000000039124467712.000000 4554adf4b7320337 -26
  1000000000000000425604415488.000000 4589d971e4fe8405 -27

Detect the overflow earily to avoid the rounding loss.