### PR TITLE
tests/thread/thread_stacksize1.py: increase stack size for cpython

### DIFF
--- a/tests/thread/thread_stacksize1.py
+++ b/tests/thread/thread_stacksize1.py
@@ -9,7 +9,7 @@ import _thread
 if sys.implementation.name == "micropython":
     sz = 2 * 1024
 else:
-    sz = 32 * 1024
+    sz = 512 * 1024
 
 
 def foo():


### PR DESCRIPTION
On arm64

  >>> _thread.stack_size(32*1024)
  Traceback (most recent call last):
    File "<stdin>", line 1, in <module>
  ValueError: size not valid: 32768 bytes

Increase to 512k since on modern Linux, the default stack size is usually 8MB.