### PR TITLE
Fix docs for machine.WDT

### DIFF
--- a/docs/library/machine.WDT.rst
+++ b/docs/library/machine.WDT.rst
@@ -22,7 +22,7 @@ Constructors
 
 .. class:: WDT(id=0, timeout=5000)
 
-   Create a WDT object and start it. The timeout must be given in seconds and
+   Create a WDT object and start it. The timeout must be given in milliseconds and
    the minimum value that is accepted is 1 second. Once it is running the timeout
    cannot be changed and the WDT cannot be stopped either.
 

--- a/docs/library/machine.WDT.rst
+++ b/docs/library/machine.WDT.rst
@@ -15,16 +15,18 @@ Example usage::
     wdt = WDT(timeout=2000)  # enable it with a timeout of 2s
     wdt.feed()
 
-Availability of this class: pyboard, WiPy.
+Availability of this class: pyboard, WiPy, esp8266, esp32.
 
 Constructors
 ------------
 
 .. class:: WDT(id=0, timeout=5000)
 
-   Create a WDT object and start it. The timeout must be given in milliseconds and
-   the minimum value that is accepted is 1 second. Once it is running the timeout
-   cannot be changed and the WDT cannot be stopped either.
+   Create a WDT object and start it. The timeout must be given in milliseconds.
+   Once it is running the timeout cannot be changed and the WDT cannot be stopped either.
+   
+   Notes: On the esp32 the minimum timeout is 1 second. On the esp8266 a timeout
+   cannot be specified, it is determined by the RTOS.
 
 Methods
 -------


### PR DESCRIPTION
Both the esp32 and stm32 have the timeout in milliseconds, as does the example at the top.