### PR TITLE
py/scheduler: Make mp_sched_full a macro so it's always inlined.

### DIFF
--- a/py/runtime.h
+++ b/py/runtime.h
@@ -71,9 +71,7 @@ void mp_handle_pending_tail(mp_uint_t atomic_state);
 #if MICROPY_ENABLE_SCHEDULER
 void mp_sched_lock(void);
 void mp_sched_unlock(void);
-static inline unsigned int mp_sched_num_pending(void) {
-    return MP_STATE_VM(sched_len);
-}
+#define mp_sched_num_pending() (MP_STATE_VM(sched_len))
 bool mp_sched_schedule(mp_obj_t function, mp_obj_t arg);
 #endif
 

--- a/py/scheduler.c
+++ b/py/scheduler.c
@@ -45,14 +45,14 @@ void MICROPY_WRAP_MP_KEYBOARD_INTERRUPT(mp_keyboard_interrupt)(void) {
 
 #define IDX_MASK(i) ((i) & (MICROPY_SCHEDULER_DEPTH - 1))
 
-static inline bool mp_sched_full(void) {
+// This is a macro so it is guaranteed to be inlined in functions like
+// mp_sched_schedule that may be located in a special memory region.
+#define mp_sched_full() (mp_sched_num_pending() == MICROPY_SCHEDULER_DEPTH)
+
+static inline bool mp_sched_empty(void) {
     MP_STATIC_ASSERT(MICROPY_SCHEDULER_DEPTH <= 255); // MICROPY_SCHEDULER_DEPTH must fit in 8 bits
     MP_STATIC_ASSERT((IDX_MASK(MICROPY_SCHEDULER_DEPTH) == 0)); // MICROPY_SCHEDULER_DEPTH must be a power of 2
 
-    return mp_sched_num_pending() == MICROPY_SCHEDULER_DEPTH;
-}
-
-static inline bool mp_sched_empty(void) {
     return mp_sched_num_pending() == 0;
 }
 


### PR DESCRIPTION
Follow up to commit 544c308c18d134ade0ce23f39b73dc3f46074825 discussed in https://github.com/micropython/micropython/pull/5999#issuecomment-622751449