### PR TITLE
esp32/modmachine: fix reset_cause

### DIFF
--- a/ports/esp32/modmachine.c
+++ b/ports/esp32/modmachine.c
@@ -165,7 +165,7 @@ STATIC mp_obj_t machine_reset_cause(size_t n_args, const mp_obj_t *pos_args, mp_
             break;
 
         case ESP_RST_BROWNOUT:
-	case ESP_RST_EXT: // Comment in ESP-IDF: "For ESP32, ESP_RST_EXT is never returned"
+        case ESP_RST_EXT: // Comment in ESP-IDF: "For ESP32, ESP_RST_EXT is never returned"
             return MP_OBJ_NEW_SMALL_INT(MP_HARD_RESET);
             break;
 

--- a/ports/esp32/modmachine.c
+++ b/ports/esp32/modmachine.c
@@ -146,36 +146,31 @@ STATIC mp_obj_t machine_deepsleep(size_t n_args, const mp_obj_t *pos_args, mp_ma
 STATIC MP_DEFINE_CONST_FUN_OBJ_KW(machine_deepsleep_obj, 0,  machine_deepsleep);
 
 STATIC mp_obj_t machine_reset_cause(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
-    switch (rtc_get_reset_reason(0)) {
-        case POWERON_RESET:
+    switch (esp_reset_reason()) {
+        case ESP_RST_POWERON:
             return MP_OBJ_NEW_SMALL_INT(MP_PWRON_RESET);
             break;
-        case SW_RESET:
-        case SW_CPU_RESET:
+        case ESP_RST_SW:
+        case ESP_RST_PANIC:
             return MP_OBJ_NEW_SMALL_INT(MP_SOFT_RESET);
             break;
-        case OWDT_RESET:
-        case TG0WDT_SYS_RESET:
-        case TG1WDT_SYS_RESET:
-        case RTCWDT_SYS_RESET:
-        case RTCWDT_BROWN_OUT_RESET:
-        case RTCWDT_CPU_RESET:
-        case RTCWDT_RTC_RESET:
-        case TGWDT_CPU_RESET:
+        case ESP_RST_INT_WDT:
+        case ESP_RST_TASK_WDT:
+        case ESP_RST_WDT:
             return MP_OBJ_NEW_SMALL_INT(MP_WDT_RESET);
             break;
 
-        case DEEPSLEEP_RESET:
+        case ESP_RST_DEEPSLEEP:
             return MP_OBJ_NEW_SMALL_INT(MP_DEEPSLEEP_RESET);
             break;
 
-        case EXT_CPU_RESET:
+        case ESP_RST_BROWNOUT:
+        case ESP_RST_SDIO:
+        case ESP_RST_EXT:
             return MP_OBJ_NEW_SMALL_INT(MP_HARD_RESET);
             break;
 
-        case NO_MEAN:
-        case SDIO_RESET:
-        case INTRUSION_RESET:
+        case ESP_RST_UNKNOWN:
         default:
             return MP_OBJ_NEW_SMALL_INT(0);
             break;

--- a/ports/esp32/modmachine.c
+++ b/ports/esp32/modmachine.c
@@ -148,11 +148,8 @@ STATIC MP_DEFINE_CONST_FUN_OBJ_KW(machine_deepsleep_obj, 0,  machine_deepsleep);
 STATIC mp_obj_t machine_reset_cause(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
     switch (esp_reset_reason()) {
         case ESP_RST_POWERON:
+        case ESP_RST_BROWNOUT:
             return MP_OBJ_NEW_SMALL_INT(MP_PWRON_RESET);
-            break;
-        case ESP_RST_SW:
-        case ESP_RST_PANIC:
-            return MP_OBJ_NEW_SMALL_INT(MP_SOFT_RESET);
             break;
         case ESP_RST_INT_WDT:
         case ESP_RST_TASK_WDT:
@@ -164,7 +161,8 @@ STATIC mp_obj_t machine_reset_cause(size_t n_args, const mp_obj_t *pos_args, mp_
             return MP_OBJ_NEW_SMALL_INT(MP_DEEPSLEEP_RESET);
             break;
 
-        case ESP_RST_BROWNOUT:
+        case ESP_RST_SW:
+        case ESP_RST_PANIC:
         case ESP_RST_EXT: // Comment in ESP-IDF: "For ESP32, ESP_RST_EXT is never returned"
             return MP_OBJ_NEW_SMALL_INT(MP_HARD_RESET);
             break;

--- a/ports/esp32/modmachine.c
+++ b/ports/esp32/modmachine.c
@@ -165,11 +165,11 @@ STATIC mp_obj_t machine_reset_cause(size_t n_args, const mp_obj_t *pos_args, mp_
             break;
 
         case ESP_RST_BROWNOUT:
-        case ESP_RST_SDIO:
-        case ESP_RST_EXT:
+	case ESP_RST_EXT: // Comment in ESP-IDF: "For ESP32, ESP_RST_EXT is never returned"
             return MP_OBJ_NEW_SMALL_INT(MP_HARD_RESET);
             break;
 
+        case ESP_RST_SDIO:
         case ESP_RST_UNKNOWN:
         default:
             return MP_OBJ_NEW_SMALL_INT(0);


### PR DESCRIPTION
Fixes #5134
The code used to call `rtc_get_reset_reason` which is a "raw" reset cause. ESP-IDF massages that for the proper reset cause available from `esp_reset_cause`.
I would like to add a `machine.PANIC_RESET` to be able to distinguish a clean reset for seomthing like OTA update from an abort/assert type of reset, dunno whether that's acceptable.