### PR TITLE
drivers/sdcard.py Fix failure with shared SPI bus

### DIFF
--- a/drivers/sdcard/sdcard.py
+++ b/drivers/sdcard/sdcard.py
@@ -49,6 +49,7 @@ class SDCard:
         for i in range(512):
             self.dummybuf[i] = 0xFF
         self.dummybuf_memoryview = memoryview(self.dummybuf)
+        self.sdclear = b"\xff"*16
 
         # initialise the card
         self.init_card()
@@ -71,8 +72,7 @@ class SDCard:
         self.init_spi(100000)
 
         # clock card at least 100 cycles with cs high
-        for i in range(16):
-            self.spi.write(b"\xff")
+        self.spi.write(self.sdclear)
 
         # CMD0: init card; should return _R1_IDLE_STATE (allow 5 attempts)
         for _ in range(5):
@@ -227,6 +227,8 @@ class SDCard:
         self.spi.write(b"\xff")
 
     def readblocks(self, block_num, buf):
+        # clock card at least 100 cycles with cs high
+        self.spi.write(self.sdclear)
         nblocks = len(buf) // 512
         assert nblocks and not len(buf) % 512, "Buffer length is invalid"
         if nblocks == 1:
@@ -254,6 +256,8 @@ class SDCard:
                 raise OSError(5)  # EIO
 
     def writeblocks(self, block_num, buf):
+        # clock card at least 100 cycles with cs high
+        self.spi.write(self.sdclear)
         nblocks, err = divmod(len(buf), 512)
         assert nblocks and not err, "Buffer length is invalid"
         if nblocks == 1:

--- a/drivers/sdcard/sdcard.py
+++ b/drivers/sdcard/sdcard.py
@@ -49,7 +49,6 @@ class SDCard:
         for i in range(512):
             self.dummybuf[i] = 0xFF
         self.dummybuf_memoryview = memoryview(self.dummybuf)
-        self.sdclear = b"\xff"*16
 
         # initialise the card
         self.init_card()
@@ -72,7 +71,8 @@ class SDCard:
         self.init_spi(100000)
 
         # clock card at least 100 cycles with cs high
-        self.spi.write(self.sdclear)
+        for i in range(16):
+            self.spi.write(b"\xff")
 
         # CMD0: init card; should return _R1_IDLE_STATE (allow 5 attempts)
         for _ in range(5):
@@ -227,8 +227,8 @@ class SDCard:
         self.spi.write(b"\xff")
 
     def readblocks(self, block_num, buf):
-        # clock card at least 100 cycles with cs high
-        self.spi.write(self.sdclear)
+        # For shared bus operation
+        self.spi.write(b"\xff")
         nblocks = len(buf) // 512
         assert nblocks and not len(buf) % 512, "Buffer length is invalid"
         if nblocks == 1:
@@ -256,8 +256,8 @@ class SDCard:
                 raise OSError(5)  # EIO
 
     def writeblocks(self, block_num, buf):
-        # clock card at least 100 cycles with cs high
-        self.spi.write(self.sdclear)
+        # For shared bus operation
+        self.spi.write(b"\xff")
         nblocks, err = divmod(len(buf), 512)
         assert nblocks and not err, "Buffer length is invalid"
         if nblocks == 1:


### PR DESCRIPTION
If the SPI bus is shared with another device and that device is accessed concurrently with the SD card, the driver fails with `EIO` or timeouts. This patch writes >100 bus cycles with `MOSI` high prior to any access.

The fault may be demonstrated (with my SD card) with the following script:
```python
from machine import SPI, Pin
import sdcard
import os
spi = SPI(2)  # 2 MOSI Y8 MISO Y7 SCK Y6
sdcs = Pin('Y4', Pin.OUT, value=1)  # SD card CS
sd = sdcard.SDCard(spi, sdcs)
vfs = os.VfsFat(sd)
os.mount(vfs, '/fc')
os.listdir('/fc')
spi.write(b'\x00'*50)  # Write to notional device
with open('/fc/yellow.mp3', 'rb') as f:  # File must exist!
    f.read(20)
```
