### PR TITLE
lib/utils/pyexec: improve pyexec so it can be used by unix (WIP)

### DIFF
--- a/lib/utils/pyexec.c
+++ b/lib/utils/pyexec.c
@@ -63,7 +63,10 @@ int pyexec_exec_src(const void *source, mp_parse_input_kind_t input_kind, int ex
     #endif
 
     // By default a SystemExit exception returns a value based on its argument.
-    pyexec_system_exit = 0;
+    #ifndef MICROPY_PYEXEC_SYSTEM_EXIT_DEFAULT
+    #define MICROPY_PYEXEC_SYSTEM_EXIT_DEFAULT (0)
+    #endif
+    pyexec_system_exit = MICROPY_PYEXEC_SYSTEM_EXIT_DEFAULT;
 
     nlr_buf_t nlr;
     if (nlr_push(&nlr) == 0) {

--- a/lib/utils/pyexec.c
+++ b/lib/utils/pyexec.c
@@ -458,7 +458,12 @@ int pyexec_friendly_repl(void) {
     #endif
 
 friendly_repl_reset:
+    #ifdef MICROPY_HW_BOARD_NAME
     mp_hal_stdout_tx_str("MicroPython " MICROPY_GIT_TAG " on " MICROPY_BUILD_DATE "; " MICROPY_HW_BOARD_NAME " with " MICROPY_HW_MCU_NAME "\r\n");
+    #else
+    mp_hal_stdout_tx_str("MicroPython " MICROPY_GIT_TAG " on " MICROPY_BUILD_DATE "; " MICROPY_PY_SYS_PLATFORM " version\r\nUse Ctrl-D to exit, Ctrl-E for paste mode\n");
+    #endif
+
     #if MICROPY_PY_BUILTINS_HELP
     mp_hal_stdout_tx_str("Type \"help()\" for more information.\r\n");
     #endif

--- a/lib/utils/pyexec.h
+++ b/lib/utils/pyexec.h
@@ -52,6 +52,7 @@ extern int pyexec_system_exit;
 #define PYEXEC_SWITCH_MODE (0x200)
 
 int pyexec_exec_src(const void *source, mp_parse_input_kind_t input_kind, int exec_flags);
+int pyexec_handle_uncaught_exception(mp_obj_base_t *exc);
 int pyexec_raw_repl(void);
 int pyexec_friendly_repl(void);
 int pyexec_file(const char *filename);

--- a/lib/utils/pyexec.h
+++ b/lib/utils/pyexec.h
@@ -44,9 +44,13 @@ extern int pyexec_system_exit;
 #define PYEXEC_FLAG_PRINT_EOF               (0x0001)
 #define PYEXEC_FLAG_ALLOW_DEBUGGING         (0x0002)
 #define PYEXEC_FLAG_IS_REPL                 (0x0004)
-#define PYEXEC_FLAG_SOURCE_IS_RAW_CODE      (0x0008)
-#define PYEXEC_FLAG_SOURCE_IS_VSTR          (0x0010)
-#define PYEXEC_FLAG_SOURCE_IS_FILENAME      (0x0020)
+#define PYEXEC_FLAG_COMPILE_ONLY            (0x0008)
+#define PYEXEC_FLAG_SOURCE_IS_RAW_CODE      (0x0010)
+#define PYEXEC_FLAG_SOURCE_IS_VSTR          (0x0020)
+#define PYEXEC_FLAG_SOURCE_IS_FILENAME      (0x0040)
+#if MICROPY_HELPER_LEXER_UNIX
+#define PYEXEC_FLAG_SOURCE_IS_FD            (0x0080)
+#endif
 
 #define PYEXEC_FORCED_EXIT (0x100)
 #define PYEXEC_SWITCH_MODE (0x200)

--- a/lib/utils/pyexec.h
+++ b/lib/utils/pyexec.h
@@ -27,6 +27,7 @@
 #define MICROPY_INCLUDED_LIB_UTILS_PYEXEC_H
 
 #include "py/obj.h"
+#include "py/parse.h"
 
 typedef enum {
     PYEXEC_MODE_FRIENDLY_REPL,
@@ -40,9 +41,17 @@ extern pyexec_mode_kind_t pyexec_mode_kind;
 // It will reset to 0 at the start of each execution (eg each REPL entry).
 extern int pyexec_system_exit;
 
+#define PYEXEC_FLAG_PRINT_EOF               (0x0001)
+#define PYEXEC_FLAG_ALLOW_DEBUGGING         (0x0002)
+#define PYEXEC_FLAG_IS_REPL                 (0x0004)
+#define PYEXEC_FLAG_SOURCE_IS_RAW_CODE      (0x0008)
+#define PYEXEC_FLAG_SOURCE_IS_VSTR          (0x0010)
+#define PYEXEC_FLAG_SOURCE_IS_FILENAME      (0x0020)
+
 #define PYEXEC_FORCED_EXIT (0x100)
 #define PYEXEC_SWITCH_MODE (0x200)
 
+int pyexec_exec_src(const void *source, mp_parse_input_kind_t input_kind, int exec_flags);
 int pyexec_raw_repl(void);
 int pyexec_friendly_repl(void);
 int pyexec_file(const char *filename);

--- a/ports/cc3200/mptask.c
+++ b/ports/cc3200/mptask.c
@@ -185,7 +185,7 @@ soft_reset:
         if (ret & PYEXEC_FORCED_EXIT) {
             goto soft_reset_exit;
         }
-        if (!ret) {
+        if (ret) {
             // flash the system led
             mperror_signal_error();
         }
@@ -210,7 +210,7 @@ soft_reset:
             if (ret & PYEXEC_FORCED_EXIT) {
                 goto soft_reset_exit;
             }
-            if (!ret) {
+            if (ret) {
                 // flash the system led
                 mperror_signal_error();
             }

--- a/ports/stm32/main.c
+++ b/ports/stm32/main.c
@@ -660,7 +660,7 @@ soft_reset:
         if (ret & PYEXEC_FORCED_EXIT) {
             goto soft_reset_exit;
         }
-        if (!ret) {
+        if (ret) {
             flash_error(4);
         }
     }
@@ -721,7 +721,7 @@ soft_reset:
         if (ret & PYEXEC_FORCED_EXIT) {
             goto soft_reset_exit;
         }
-        if (!ret) {
+        if (ret) {
             flash_error(3);
         }
     }

--- a/ports/teensy/main.c
+++ b/ports/teensy/main.c
@@ -302,7 +302,7 @@ soft_reset:
     #if MICROPY_MODULE_FROZEN
     pyexec_frozen_module("boot.py");
     #else
-    if (!pyexec_file_if_exists("/boot.py")) {
+    if (pyexec_file_if_exists("/boot.py")) {
         flash_error(4);
     }
     #endif
@@ -322,7 +322,7 @@ soft_reset:
         } else {
             vstr_add_str(vstr, mp_obj_str_get_str(pyb_config_main));
         }
-        if (!pyexec_file_if_exists(vstr_null_terminated_str(vstr))) {
+        if (pyexec_file_if_exists(vstr_null_terminated_str(vstr))) {
             flash_error(3);
         }
         vstr_free(vstr);

--- a/ports/unix/Makefile
+++ b/ports/unix/Makefile
@@ -206,6 +206,7 @@ LIB_SRC_C += $(addprefix lib/,\
 	$(LIB_SRC_C_EXTRA) \
 	timeutils/timeutils.c \
 	utils/gchelper_generic.c \
+	utils/pyexec.c \
 	)
 
 OBJ = $(PY_O)

--- a/ports/unix/mpconfigport.h
+++ b/ports/unix/mpconfigport.h
@@ -357,4 +357,6 @@ struct _mp_bluetooth_btstack_root_pointers_t;
 #include <sched.h>
 #define MICROPY_UNIX_MACHINE_IDLE sched_yield();
 
+#define MICROPY_PYEXEC_SYSTEM_EXIT_DEFAULT (PYEXEC_FORCED_EXIT)
+
 #endif // MICROPY_UNIX_MINIMAL

--- a/ports/unix/mphalport.h
+++ b/ports/unix/mphalport.h
@@ -32,9 +32,12 @@
 
 void mp_hal_set_interrupt_char(char c);
 
-#define mp_hal_stdio_poll unused // this is not implemented, nor needed
+#define mp_hal_stdio_mode_raw mp_hal_stdio_mode_raw
+#define mp_hal_stdio_mode_orig mp_hal_stdio_mode_orig
 void mp_hal_stdio_mode_raw(void);
 void mp_hal_stdio_mode_orig(void);
+
+#define mp_hal_stdio_poll unused // this is not implemented, nor needed
 
 #if MICROPY_PY_BUILTINS_INPUT && MICROPY_USE_READLINE == 0
 

--- a/py/mphal.h
+++ b/py/mphal.h
@@ -34,6 +34,14 @@
 #include <mphalport.h>
 #endif
 
+#ifndef mp_hal_stdio_mode_raw
+#define mp_hal_stdio_mode_raw()
+#endif
+
+#ifndef mp_hal_stdio_mode_orig
+#define mp_hal_stdio_mode_orig()
+#endif
+
 #ifndef mp_hal_stdio_poll
 uintptr_t mp_hal_stdio_poll(uintptr_t poll_flags);
 #endif


### PR DESCRIPTION
Background: unix has its own custom REPL loop and parse-compile-execute function, while bare-metal ports all use the one provided by `lib/utils/pyexec.c`.

This set of commits aims to improve and factor the existing code in `lib/utils/pyexec.c` so that it can be used by the unix port.  It adds a few optional features to `pyexec.c` and makes some functions there public, including some flags.

The final commit here then updates the unix port to use the new `pyexec.c` code, which is mostly just deleting things from unix's `main.c`.

This is still a WIP because it's not fully tested and there are some subtle changes, including to the behaviour of `SystemExit` to try and make the code usable by unix and bare-metal (eg on bare-metal the argument of `SystemExit` exceptions is now interpreted and used as the return value of the `pyexec.c` functions).