### PR TITLE
fix "TypeError: 'mode' argument required on spi.init()

### DIFF
--- a/drivers/display/ssd1306.py
+++ b/drivers/display/ssd1306.py
@@ -2,7 +2,7 @@
 
 from micropython import const
 import framebuf
-
+from pyb import SPI
 
 # register definitions
 SET_CONTRAST = const(0x81)
@@ -139,7 +139,7 @@ class SSD1306_SPI(SSD1306):
         super().__init__(width, height, external_vcc)
 
     def write_cmd(self, cmd):
-        self.spi.init(baudrate=self.rate, polarity=0, phase=0)
+        self.spi.init(SPI.MASTER, baudrate=self.rate, polarity=0, phase=0)
         self.cs(1)
         self.dc(0)
         self.cs(0)
@@ -147,7 +147,7 @@ class SSD1306_SPI(SSD1306):
         self.cs(1)
 
     def write_data(self, buf):
-        self.spi.init(baudrate=self.rate, polarity=0, phase=0)
+        self.spi.init(SPI.MASTER, baudrate=self.rate, polarity=0, phase=0)
         self.cs(1)
         self.dc(1)
         self.cs(0)


### PR DESCRIPTION
As of 1.12, it's apparently mandatory to specify SPI.MASTER.