### PR TITLE
esp32: supply dns server in dhcp when run in ap mode

### DIFF
--- a/ports/esp32/modnetwork.c
+++ b/ports/esp32/modnetwork.c
@@ -535,7 +535,7 @@ STATIC mp_obj_t esp_ifconfig(size_t n_args, const mp_obj_t *args) {
                 ESP_EXCEPTIONS(tcpip_adapter_set_ip_info(WIFI_IF_AP, &info));
                 ESP_EXCEPTIONS(tcpip_adapter_set_dns_info(WIFI_IF_AP, TCPIP_ADAPTER_DNS_MAIN, &dns_info));
                 dhcps_offer_t opt_val = OFFER_DNS; // supply a dns server via dhcps
-    			ESP_EXCEPTIONS(tcpip_adapter_dhcps_option(TCPIP_ADAPTER_OP_SET, TCPIP_ADAPTER_DOMAIN_NAME_SERVER, &opt_val, 1));
+                ESP_EXCEPTIONS(tcpip_adapter_dhcps_option(TCPIP_ADAPTER_OP_SET, TCPIP_ADAPTER_DOMAIN_NAME_SERVER, &opt_val, 1));
                 ESP_EXCEPTIONS(tcpip_adapter_dhcps_start(WIFI_IF_AP));
             }
         } else {

--- a/ports/esp32/modnetwork.c
+++ b/ports/esp32/modnetwork.c
@@ -534,6 +534,8 @@ STATIC mp_obj_t esp_ifconfig(size_t n_args, const mp_obj_t *args) {
                 }
                 ESP_EXCEPTIONS(tcpip_adapter_set_ip_info(WIFI_IF_AP, &info));
                 ESP_EXCEPTIONS(tcpip_adapter_set_dns_info(WIFI_IF_AP, TCPIP_ADAPTER_DNS_MAIN, &dns_info));
+                dhcps_offer_t opt_val = OFFER_DNS; // supply a dns server via dhcps
+    			ESP_EXCEPTIONS(tcpip_adapter_dhcps_option(TCPIP_ADAPTER_OP_SET, TCPIP_ADAPTER_DOMAIN_NAME_SERVER, &opt_val, 1));
                 ESP_EXCEPTIONS(tcpip_adapter_dhcps_start(WIFI_IF_AP));
             }
         } else {


### PR DESCRIPTION
This is when running esp32 in ap mode.
Even you could set the dns server with `wlan.ifconfig` that value did not get sent in dhcp.
This pull request does fix this.