### PR TITLE
all: Organize compiler warning flags in makefiles

### DIFF
--- a/ports/bare-arm/Makefile
+++ b/ports/bare-arm/Makefile
@@ -15,8 +15,9 @@ INC += -I.
 INC += -I$(TOP)
 INC += -I$(BUILD)
 
-CFLAGS_CORTEX_M4 = -mthumb -mtune=cortex-m4 -mabi=aapcs-linux -mcpu=cortex-m4 -mfpu=fpv4-sp-d16 -mfloat-abi=hard -fsingle-precision-constant -Wdouble-promotion
-CFLAGS = $(INC) -Wall -Werror -std=c99 -nostdlib $(CFLAGS_CORTEX_M4) $(COPT)
+CFLAGS_CORTEX_M4 = -mthumb -mtune=cortex-m4 -mabi=aapcs-linux -mcpu=cortex-m4 -mfpu=fpv4-sp-d16 -mfloat-abi=hard -fsingle-precision-constant
+CWARN = -Wall -Werror -Wdouble-promotion
+CFLAGS = $(INC) $(CWARN) -std=c99 -nostdlib $(CFLAGS_CORTEX_M4) $(COPT)
 CSUPEROPT = -Os # save some code space
 
 #Debugging/Optimization

--- a/ports/cc3200/Makefile
+++ b/ports/cc3200/Makefile
@@ -19,8 +19,9 @@ include ../../py/mkenv.mk
 
 CROSS_COMPILE ?= arm-none-eabi-
 
-CFLAGS_CORTEX_M4 = -mthumb -mtune=cortex-m4 -march=armv7e-m -mabi=aapcs -mcpu=cortex-m4 -msoft-float -mfloat-abi=soft -fsingle-precision-constant -Wdouble-promotion
-CFLAGS = -Wall -Wpointer-arith -Werror -std=gnu99 -nostdlib $(CFLAGS_CORTEX_M4) -Os
+CFLAGS_CORTEX_M4 = -mthumb -mtune=cortex-m4 -march=armv7e-m -mabi=aapcs -mcpu=cortex-m4 -msoft-float -mfloat-abi=soft -fsingle-precision-constant
+CWARN = -Wall -Werror -Wpointer-arith -Wdouble-promotion
+CFLAGS = $(CWARN) -std=gnu99 -nostdlib $(CFLAGS_CORTEX_M4) -Os
 CFLAGS += -g -ffunction-sections -fdata-sections -fno-common -fsigned-char -mno-unaligned-access
 CFLAGS += -Iboards/$(BOARD)
 CFLAGS += $(CFLAGS_MOD)

--- a/ports/esp32/Makefile
+++ b/ports/esp32/Makefile
@@ -256,11 +256,12 @@ endif
 # these flags are common to C and C++ compilation
 CFLAGS_COMMON = -Os -ffunction-sections -fdata-sections -fstrict-volatile-bitfields \
 	-mlongcalls -nostdlib \
-	-Wall -Werror -Wno-error=unused-function -Wno-error=unused-but-set-variable \
-	-Wno-error=unused-variable -Wno-error=deprecated-declarations \
 	-DESP_PLATFORM
 
-CFLAGS_BASE = -std=gnu99 $(CFLAGS_COMMON) -DMBEDTLS_CONFIG_FILE='"mbedtls/esp_config.h"' -DHAVE_CONFIG_H
+CWARN = -Wall -Werror -Wno-error=unused-function -Wno-error=unused-but-set-variable \
+				-Wno-error=unused-variable -Wno-error=deprecated-declarations
+
+CFLAGS_BASE = -std=gnu99 $(CFLAGS_COMMON) $(CWARN) -DMBEDTLS_CONFIG_FILE='"mbedtls/esp_config.h"' -DHAVE_CONFIG_H
 CFLAGS = $(CFLAGS_BASE) $(INC) $(INC_ESPCOMP) $(INC_NEWLIB)
 CFLAGS += -DIDF_VER=\"$(IDF_VER)\"
 CFLAGS += $(CFLAGS_MOD) $(CFLAGS_EXTRA)
@@ -271,7 +272,7 @@ CFLAGS += -DMICROPY_ESP_IDF_4=1
 endif
 
 # this is what ESPIDF uses for c++ compilation
-CXXFLAGS = -std=gnu++11 $(CFLAGS_COMMON) $(INC) $(INC_ESPCOMP)
+CXXFLAGS = -std=gnu++11 $(CFLAGS_COMMON) $(CWARN) $(INC) $(INC_ESPCOMP)
 
 LDFLAGS = -nostdlib -Map=$(@:.elf=.map) --cref
 LDFLAGS += --gc-sections -static -EL
@@ -383,7 +384,7 @@ OBJ_MP += $(addprefix $(BUILD)/, $(LIB_SRC_C:.c=.o))
 OBJ_MP += $(addprefix $(BUILD)/, $(DRIVERS_SRC_C:.c=.o))
 
 # Only enable this for the MicroPython source: ignore warnings from esp-idf.
-$(OBJ_MP): CFLAGS += -Wdouble-promotion -Wfloat-conversion
+$(OBJ_MP): CWARN += -Wdouble-promotion -Wfloat-conversion
 
 # List of sources for qstr extraction
 SRC_QSTR += $(SRC_C) $(EXTMOD_SRC_C) $(LIB_SRC_C) $(DRIVERS_SRC_C)

--- a/ports/esp8266/Makefile
+++ b/ports/esp8266/Makefile
@@ -58,7 +58,8 @@ CFLAGS_XTENSA = -fsingle-precision-constant -Wdouble-promotion \
 	-Wl,-EL -mlongcalls -mtext-section-literals -mforce-l32 \
 	-DLWIP_OPEN_SRC
 
-CFLAGS = $(INC) -Wall -Wpointer-arith -Werror -std=gnu99 -nostdlib -DUART_OS=$(UART_OS) \
+CWARN = -Wall -Werror -Wpointer-arith
+CFLAGS = $(INC) $(CWARN) -std=gnu99 -nostdlib -DUART_OS=$(UART_OS) \
 	$(CFLAGS_XTENSA) $(CFLAGS_MOD) $(COPT) $(CFLAGS_EXTRA) -I$(BOARD_DIR)
 
 LD_FILES ?= boards/esp8266_2m.ld

--- a/ports/javascript/Makefile
+++ b/ports/javascript/Makefile
@@ -19,7 +19,8 @@ ifdef EMSCRIPTEN
     CPP += -isystem $(EMSCRIPTEN)/system/include/libc -cxx-isystem $(EMSCRIPTEN)/system/include/libcxx
 endif
 
-CFLAGS = -m32 -Wall -Werror -Wdouble-promotion -Wfloat-conversion $(INC) -std=c99 $(COPT)
+CWARN = -Wall -Werror -Wdouble-promotion -Wfloat-conversion
+CFLAGS = -m32 $(INC) $(CWARN) -std=c99 $(COPT)
 LDFLAGS = -m32 -Wl,-Map=$@.map,--cref -Wl,--gc-sections
 
 CFLAGS += -O0 -DNDEBUG

--- a/ports/mimxrt/Makefile
+++ b/ports/mimxrt/Makefile
@@ -40,7 +40,8 @@ INC += -I$(TOP)/lib/tinyusb/hw
 INC += -I$(TOP)/lib/tinyusb/hw/bsp/teensy_40
 
 CFLAGS_MCU = -mtune=cortex-m7 -mcpu=cortex-m7 -mfloat-abi=hard -mfpu=fpv5-d16
-CFLAGS = $(INC) -Wall -Werror -Wdouble-promotion -Wfloat-conversion -std=c99 -nostdlib -mthumb $(CFLAGS_MCU)
+CWARN = -Wall -Werror -Wdouble-promotion -Wfloat-conversion
+CFLAGS = $(INC) $(CWARN) -std=c99 -nostdlib -mthumb $(CFLAGS_MCU)
 CFLAGS += -DCPU_$(MCU_SERIES) -DCPU_$(MCU_VARIANT)
 CFLAGS += -DXIP_EXTERNAL_FLASH=1 \
 	-DXIP_BOOT_HEADER_ENABLE=1 \

--- a/ports/minimal/Makefile
+++ b/ports/minimal/Makefile
@@ -23,11 +23,13 @@ ifeq ($(CROSS), 1)
 DFU = $(TOP)/tools/dfu.py
 PYDFU = $(TOP)/tools/pydfu.py
 CFLAGS_CORTEX_M4 = -mthumb -mtune=cortex-m4 -mcpu=cortex-m4 -msoft-float -fsingle-precision-constant -Wdouble-promotion -Wfloat-conversion
-CFLAGS = $(INC) -Wall -Werror -std=c99 -nostdlib $(CFLAGS_CORTEX_M4) $(COPT)
+CWARN = -Wall -Werror
+CFLAGS = $(INC) $(CWARN) -std=c99 -nostdlib $(CFLAGS_CORTEX_M4) $(COPT)
 LDFLAGS = -nostdlib -T stm32f405.ld -Map=$@.map --cref --gc-sections
 else
 LD = gcc
-CFLAGS = -m32 $(INC) -Wall -Werror -Wdouble-promotion -Wfloat-conversion -std=c99 $(COPT)
+CWARN = -Wall -Werror -Wdouble-promotion -Wfloat-conversion
+CFLAGS = -m32 $(INC) $(CWARN) -std=c99 $(COPT)
 LDFLAGS = -m32 -Wl,-Map=$@.map,--cref -Wl,--gc-sections
 endif
 

--- a/ports/nrf/Makefile
+++ b/ports/nrf/Makefile
@@ -93,7 +93,7 @@ endif
 NRF_DEFINES += -D$(MCU_SUB_VARIANT_UPPER)
 NRF_DEFINES += -DCONFIG_GPIO_AS_PINRESET
 
-CFLAGS_CORTEX_M = -mthumb -mabi=aapcs -fsingle-precision-constant -Wdouble-promotion
+CFLAGS_CORTEX_M = -mthumb -mabi=aapcs -fsingle-precision-constant
 
 CFLAGS_MCU_m33 = $(CFLAGS_CORTEX_M) -mcpu=cortex-m33 -march=armv8-m.main+dsp -mcmse -mfpu=fpv5-sp-d16 -mfloat-abi=hard
 
@@ -111,7 +111,8 @@ endif
 
 
 CFLAGS += $(CFLAGS_MCU_$(MCU_SERIES))
-CFLAGS += $(INC) -Wall -Werror -g -ansi -std=c11 -nostdlib $(COPT) $(NRF_DEFINES) $(CFLAGS_MOD)
+CWARN = -Wall -Werror -Wdouble-promotion
+CFLAGS += $(INC) $(CWARN) -g -ansi -std=c11 -nostdlib $(COPT) $(NRF_DEFINES) $(CFLAGS_MOD)
 CFLAGS += -fno-strict-aliasing
 CFLAGS += -Iboards/$(BOARD)
 CFLAGS += -DNRF5_HAL_H='<$(MCU_VARIANT)_hal.h>'

--- a/ports/pic16bit/Makefile
+++ b/ports/pic16bit/Makefile
@@ -19,7 +19,8 @@ INC += -I$(XC16)/include
 INC += -I$(XC16)/support/$(PARTFAMILY)/h
 
 CFLAGS_PIC16BIT = -mcpu=$(PART) -mlarge-code
-CFLAGS = $(INC) -Wall -Werror -std=gnu99 -nostdlib $(CFLAGS_PIC16BIT) $(COPT)
+CWARN = -Wall -Werror
+CFLAGS = $(INC) $(CWARN) -std=gnu99 -nostdlib $(CFLAGS_PIC16BIT) $(COPT)
 
 #Debugging/Optimization
 ifeq ($(DEBUG), 1)

--- a/ports/powerpc/Makefile
+++ b/ports/powerpc/Makefile
@@ -16,8 +16,8 @@ endif
 INC += -I.
 INC += -I$(TOP)
 INC += -I$(BUILD)
-
-CFLAGS = $(INC) -g -Wall -Wdouble-promotion -Wfloat-conversion -std=c99 $(COPT)
+CWARN = -Wall -Wdouble-promotion -Wfloat-conversion
+CFLAGS = $(INC) $(CWARN) -g -std=c99 $(COPT)
 CFLAGS += -mno-string -mno-multiple -mno-vsx -mno-altivec -nostdlib
 CFLAGS += -mlittle-endian -mstrict-align -msoft-float
 CFLAGS += -Os

--- a/ports/qemu-arm/Makefile
+++ b/ports/qemu-arm/Makefile
@@ -40,7 +40,8 @@ INC += -I.
 INC += -I$(TOP)
 INC += -I$(BUILD)
 
-CFLAGS += $(INC) -Wall -Wpointer-arith -Wdouble-promotion -Wfloat-conversion -Werror -std=gnu99 $(COPT) \
+CWARN = -Wall -Werror -Wpointer-arith -Wdouble-promotion -Wfloat-conversion
+CFLAGS += $(INC) $(CWARN) -std=gnu99 $(COPT) \
 	 -ffunction-sections -fdata-sections
 
 #Debugging/Optimization

--- a/ports/samd/Makefile
+++ b/ports/samd/Makefile
@@ -31,7 +31,8 @@ INC += -I$(TOP)/lib/tinyusb/src
 
 CFLAGS_MCU_SAMD21 = -mtune=cortex-m0plus -mcpu=cortex-m0plus -msoft-float
 CFLAGS_MCU_SAMD51 = -mtune=cortex-m4 -mcpu=cortex-m4 -mfpu=fpv4-sp-d16 -mfloat-abi=hard
-CFLAGS = $(INC) -Wall -Werror -std=c99 -nostdlib -mthumb $(CFLAGS_MCU_$(MCU_SERIES)) -fsingle-precision-constant -Wdouble-promotion
+CWARN = -Wall -Werror -Wdouble-promotion
+CFLAGS = $(INC) $(CWARN) -std=c99 -nostdlib -mthumb $(CFLAGS_MCU_$(MCU_SERIES)) -fsingle-precision-constant
 CFLAGS += -DMCU_$(MCU_SERIES) -D__$(CMSIS_MCU)__
 LDFLAGS = -nostdlib $(addprefix -T,$(LD_FILES)) -Map=$@.map --cref
 LIBS = $(shell $(CC) $(CFLAGS) -print-libgcc-file-name)

--- a/ports/stm32/Makefile
+++ b/ports/stm32/Makefile
@@ -94,7 +94,8 @@ CFLAGS_MCU_l4 = $(CFLAGS_CORTEX_M) -mtune=cortex-m4 -mcpu=cortex-m4
 CFLAGS_MCU_h7 = $(CFLAGS_CORTEX_M) -mtune=cortex-m7 -mcpu=cortex-m7
 CFLAGS_MCU_wb = $(CFLAGS_CORTEX_M) -mtune=cortex-m4 -mcpu=cortex-m4
 
-CFLAGS += $(INC) -Wall -Wpointer-arith -Werror -Wdouble-promotion -Wfloat-conversion -std=gnu99 -nostdlib $(CFLAGS_MOD) $(CFLAGS_EXTRA)
+CWARN = -Wall -Werror -Wpointer-arith -Wdouble-promotion -Wfloat-conversion 
+CFLAGS += $(INC) $(CWARN) -std=gnu99 -nostdlib $(CFLAGS_MOD) $(CFLAGS_EXTRA)
 CFLAGS += -D$(CMSIS_MCU)
 CFLAGS += $(CFLAGS_MCU_$(MCU_SERIES))
 CFLAGS += $(COPT)

--- a/ports/teensy/Makefile
+++ b/ports/teensy/Makefile
@@ -30,7 +30,7 @@ CROSS_COMPILE ?= arm-none-eabi-
 endif
 
 CFLAGS_TEENSY = -DF_CPU=96000000 -DUSB_SERIAL -D__MK20DX256__
-CFLAGS_CORTEX_M4 = -mthumb -mtune=cortex-m4 -mcpu=cortex-m4 -msoft-float -mfloat-abi=soft -fsingle-precision-constant -Wdouble-promotion $(CFLAGS_TEENSY)
+CFLAGS_CORTEX_M4 = -mthumb -mtune=cortex-m4 -mcpu=cortex-m4 -msoft-float -mfloat-abi=soft -fsingle-precision-constant $(CFLAGS_TEENSY)
 
 INC += -I.
 INC += -I$(TOP)
@@ -38,7 +38,8 @@ INC += -I$(TOP)/ports/stm32
 INC += -I$(BUILD)
 INC += -Icore
 
-CFLAGS = $(INC) -Wall -Wpointer-arith -std=gnu99 -nostdlib $(CFLAGS_CORTEX_M4)
+CWARN = -Wall -Wpointer-arith -Wdouble-promotion
+CFLAGS = $(INC) $(CWARN) -std=gnu99 -nostdlib $(CFLAGS_CORTEX_M4)
 LDFLAGS = -nostdlib -T mk20dx256.ld -msoft-float -mfloat-abi=soft
 
 ifeq ($(USE_ARDUINO_TOOLCHAIN),1)

--- a/ports/unix/Makefile
+++ b/ports/unix/Makefile
@@ -38,8 +38,7 @@ INC +=  -I$(TOP)
 INC += -I$(BUILD)
 
 # compiler settings
-CWARN = -Wall -Werror
-CWARN += -Wpointer-arith -Wuninitialized -Wdouble-promotion -Wsign-compare -Wfloat-conversion
+CWARN = -Wall -Werror -Wpointer-arith -Wuninitialized -Wdouble-promotion -Wsign-compare -Wfloat-conversion
 CFLAGS += $(INC) $(CWARN) -std=gnu99 -DUNIX $(CFLAGS_MOD) $(COPT) -I$(VARIANT_DIR) $(CFLAGS_EXTRA)
 
 # Debugging/Optimization

--- a/ports/windows/Makefile
+++ b/ports/windows/Makefile
@@ -15,7 +15,8 @@ INC += -I$(TOP)
 INC += -I$(BUILD)
 
 # compiler settings
-CFLAGS = $(INC) -Wall -Wpointer-arith -Wdouble-promotion -Werror -std=gnu99 -DUNIX -D__USE_MINGW_ANSI_STDIO=1 $(CFLAGS_MOD) $(COPT) $(CFLAGS_EXTRA)
+CWARN = -Wall -Werror -Wpointer-arith -Wdouble-promotion
+CFLAGS = $(INC) $(CWARN) -std=gnu99 -DUNIX -D__USE_MINGW_ANSI_STDIO=1 $(CFLAGS_MOD) $(COPT) $(CFLAGS_EXTRA)
 LDFLAGS = $(LDFLAGS_MOD) -lm $(LDFLAGS_EXTRA)
 
 # Debugging/Optimization


### PR DESCRIPTION
Move warning-related options into the CWARN variable for all ports.
This is more consistent and enables these flags to be easily
overridden from the command line.

It would be good to have this consistent across all ports, for example there just was a forum post where someone had trouble compiling ulab as C user module because of conversion warnings so with this change, instead of having to say 'modify makefile and remove ...' we can just say 'use CWARN=-Wall -Werror' for instance.

For most ports this is straightforward, but there are some exceptions which should be discussed:
- teensy/nrf have a separate CFLAGS_CORTEX_MX variable which just had `-Wdouble-promotion` so I moved that to CWARN. the end result is the same since CFLAGS_CORTEX_M4 is simply added to CFLAGS and not used elsewhere, but is there a reason why it's done like that and does it affect this change?
- esp32/mimxrt/samd add extra CFLAGS like `-Wno-missing-braces`, it could be argued these should also be added to CWARN instead for consistency? On they other hand they are sort of required to make comilation work so not sure what the nicest thing to do is.