### PR TITLE
tools/upip.py: avoid list out of range exception

### DIFF
--- a/tools/upip.py
+++ b/tools/upip.py
@@ -132,7 +132,11 @@ def url_open(url):
         ai = usocket.getaddrinfo(host, 443, 0, usocket.SOCK_STREAM)
     except OSError as e:
         fatal("Unable to resolve %s (no Internet?)" % host, e)
-    # print("Address infos:", ai)
+
+    if debug:
+        print("Address infos:", ai)
+    if len(ai) <= 0:
+        fatal("Unable to resolve %s (no Internet?)" % host)
     ai = ai[0]
 
     s = usocket.socket(ai[0], ai[1], ai[2])


### PR DESCRIPTION
On ESP32 devices, when the gateway or DNS serer is not a valid,
getaddrinfo returns an empty list. This leads to the rather unhelpful
error message when using upip.install(..):
  Error installing 'micropython-umqtt.simple': list index out of range,
  packages may be partially installed

Make sure a helpful error message is printed in this case.