### PR TITLE
The --help option throws error. Use -h option.

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ Use `CTRL-D` (i.e. EOF) to exit the shell.
 Learn about command-line options (in particular, how to increase heap size
 which may be needed for larger applications):
 
-    $ ./micropython --help
+    $ ./micropython -h
 
 Run complete testsuite:
 


### PR DESCRIPTION
The --help throws Invalid command line arguments message. Use -h option for help.

