### PR TITLE
unix: Always enter REPL when set -i flag.

### DIFF
--- a/ports/unix/main.c
+++ b/ports/unix/main.c
@@ -657,7 +657,7 @@ MP_NOINLINE int main_(int argc, char **argv) {
         inspect = true;
     }
     if (ret == NOTHING_EXECUTED || inspect) {
-        if (isatty(0)) {
+        if (isatty(0) || inspect) {
             prompt_read_history();
             ret = do_repl();
             prompt_write_history();


### PR DESCRIPTION
If you redirect stdin of Micropython, it will not enter REPL so you can't interact with it with another program or script. Always enter REPL when set -i flag can solve this issue.