### PR TITLE
extmod/vfs_lfsx: Fix import_stat so it takes into account current dir.

### DIFF
--- a/extmod/vfs_lfsx.c
+++ b/extmod/vfs_lfsx.c
@@ -31,6 +31,7 @@
 #include "py/stream.h"
 #include "py/binary.h"
 #include "py/objarray.h"
+#include "py/objstr.h"
 #include "py/mperrno.h"
 #include "extmod/vfs.h"
 
@@ -440,6 +441,8 @@ STATIC MP_DEFINE_CONST_DICT(MP_VFS_LFSx(locals_dict), MP_VFS_LFSx(locals_dict_ta
 STATIC mp_import_stat_t MP_VFS_LFSx(import_stat)(void *self_in, const char *path) {
     MP_OBJ_VFS_LFSx *self = self_in;
     struct LFSx_API (info) info;
+    mp_obj_str_t path_obj = { { &mp_type_str }, 0, 0, (const byte *)path };
+    path = MP_VFS_LFSx(make_path)(self, &path_obj);
     int ret = LFSx_API(stat)(&self->lfs, path, &info);
     if (ret == 0) {
         if (info.type == LFSx_MACRO(_TYPE_REG)) {

--- a/tests/extmod/vfs_lfs_mount.py
+++ b/tests/extmod/vfs_lfs_mount.py
@@ -58,6 +58,12 @@ def test(bdev, vfs_class):
         f.write('print("package")\n')
     import lfspkg
 
+    # chdir and import module from current directory (needs "" in sys.path)
+    uos.mkdir("/lfs/subdir")
+    uos.chdir("/lfs/subdir")
+    uos.rename("/lfs/lfsmod.py", "/lfs/subdir/lfsmod2.py")
+    import lfsmod2
+
     # umount
     uos.umount("/lfs")
 
@@ -72,6 +78,7 @@ import sys
 
 sys.path.clear()
 sys.path.append("/lfs")
+sys.path.append("")
 
 # run tests
 test(bdev, uos.VfsLfs1)

--- a/tests/extmod/vfs_lfs_mount.py.exp
+++ b/tests/extmod/vfs_lfs_mount.py.exp
@@ -1,6 +1,8 @@
 test <class 'VfsLfs1'>
 hello from lfs
 package
+hello from lfs
 test <class 'VfsLfs2'>
 hello from lfs
 package
+hello from lfs


### PR DESCRIPTION
CPython semantics require searching the current directory if the import is not absolute (when "" is in sys.path).

Fixes issue #6037.