### PR TITLE
Fixed DHT timing error, Issue #5848

### DIFF
--- a/drivers/dht/dht.h
+++ b/drivers/dht/dht.h
@@ -3,6 +3,6 @@
 
 #include "py/obj.h"
 
-MP_DECLARE_CONST_FUN_OBJ_2(dht_readinto_obj);
+MP_DECLARE_CONST_FUN_OBJ_3(dht_readinto_obj);
 
 #endif // MICROPY_INCLUDED_DRIVERS_DHT_DHT_H

--- a/drivers/dht/dht.py
+++ b/drivers/dht/dht.py
@@ -14,12 +14,16 @@ class DHTBase:
 
     def measure(self):
         buf = self.buf
-        dht_readinto(self.pin, buf)
+        dht_readinto(self.pin, buf, self.dht_version)
         if (buf[0] + buf[1] + buf[2] + buf[3]) & 0xFF != buf[4]:
             raise Exception("checksum error")
 
 
 class DHT11(DHTBase):
+    def __init__(self, pin):
+        DHTBase.__init__(self, pin)
+        self.dht_version = 11
+
     def humidity(self):
         return self.buf[0]
 
@@ -28,6 +32,10 @@ class DHT11(DHTBase):
 
 
 class DHT22(DHTBase):
+    def __init__(self, pin):
+        DHTBase.__init__(self, pin)
+        self.dht_version = 22
+
     def humidity(self):
         return (self.buf[0] << 8 | self.buf[1]) * 0.1
 


### PR DESCRIPTION
I fixed an error in the DHT driver which occurs if the system load is high: If there are many Python threads running, the DHT driver constantly reports a timeout error ETIMEDOUT. If the system load is low, there is no error.

The solution is to wait uninterruptable with **mp_hal_delay_us_fast** instead of interruptable with **mp_hal_delay_ms**.

As a further optimization if have added a parameter to the function **dht_readinto** to know if we have DHT11 or DHT22. The reason: DHT11 needs 18ms waiting after pulling the bus low, but DHT22 needs only 1-3ms waiting after pulling the bus low.

The python classes DHT11 and DHT22 have also been extended to store the DHT version in a member variable.

This solves the issue #5848 as was discussed with dpgeorge.

Stefan Hammes, Karlsruhe
