### PR TITLE
Fix build with gcc9 and gcc10 based toolchains

### DIFF
--- a/lib/libc/string0.c
+++ b/lib/libc/string0.c
@@ -25,7 +25,7 @@
  */
 
 #include <stdint.h>
-#include <string.h>
+#include <stddef.h>
 
 #define likely(x) __builtin_expect((x), 1)
 
@@ -62,6 +62,12 @@ void *memcpy(void *dst, const void *src, size_t n) {
     }
 
     return dst;
+}
+
+void *__memcpy_chk(void *dest, const void *src, size_t len, size_t slen) {
+  if (len > slen)
+    return NULL;
+  return memcpy(dest, src, len);
 }
 
 void *memmove(void *dest, const void *src, size_t n) {


### PR DESCRIPTION
Possible fix that allow to build stm32 based targets with recent gcc (9 and 10)
Issue #6046
