### PR TITLE
docs/reference and docs/unix - Help People upip

### DIFF
--- a/docs/reference/packages.rst
+++ b/docs/reference/packages.rst
@@ -14,12 +14,12 @@ packages:
 
 1. Python modules and packages are turned into distribution package
    archives, and published at the Python Package Index (PyPI).
-2. `upip` package manager can be used to install a distribution package
-   on a `MicroPython port` with networking capabilities (for example,
-   on the Unix port).
+2. `upip` package manager is used to install a distribution package
+   on a `MicroPython port` with networking capabilities. You can run upip
+   on your microcontroller or your Unix port.
 3. For ports without networking capabilities, an "installation image"
-   can be prepared on the Unix port, and transferred to a device by
-   suitable means.
+   can be prepared on the Unix port. You can :ref:`cross install <cross-installing>`
+   to your development environment then transfer the code to your device. 
 4. For low-memory ports, the installation image can be frozen as the
    bytecode into MicroPython executable, thus minimizing the memory
    storage overheads.
@@ -119,6 +119,7 @@ commands which corresponds to the example above are::
 
 [TODO: Describe installation path.]
 
+.. _cross_installing:
 
 Cross-installing packages
 -------------------------
@@ -138,6 +139,8 @@ would need to transfer contents of this directory (without the
 ``install_dir/`` prefix) to the device, at the suitable location, where
 it can be found by the Python ``import`` statement (see discussion of
 the `upip` installation path above).
+
+See Also: :ref:`How to install the `MicroPython Unix port` <unix_quickref>`
 
 
 Cross-installing packages with freezing

--- a/docs/reference/packages.rst
+++ b/docs/reference/packages.rst
@@ -18,8 +18,8 @@ packages:
    on a `MicroPython port` with networking capabilities. You can run upip
    on your microcontroller or your Unix port.
 3. For ports without networking capabilities, an "installation image"
-   can be prepared on the Unix port. You can :ref:`cross install <cross-installing>`
-   to your development environment then transfer the code to your device. 
+   can be prepared on the Unix port. You can also install packages to your development
+   environment (a Unic\MacOs\Winows Port) then transfer the code to your device. see: `Cross-installing packages`_
 4. For low-memory ports, the installation image can be frozen as the
    bytecode into MicroPython executable, thus minimizing the memory
    storage overheads.
@@ -118,8 +118,6 @@ commands which corresponds to the example above are::
     micropython -m upip install micropython-pystone_lowmem
 
 [TODO: Describe installation path.]
-
-.. _cross_installing:
 
 Cross-installing packages
 -------------------------

--- a/docs/reference/packages.rst
+++ b/docs/reference/packages.rst
@@ -15,11 +15,10 @@ packages:
 1. Python modules and packages are turned into distribution package
    archives, and published at the Python Package Index (PyPI).
 2. `upip` package manager is used to install a distribution package
-   on a `MicroPython port` with networking capabilities. You can run upip
-   on your microcontroller or your Unix port.
+   on a `MicroPython port` with networking capabilities.
 3. For ports without networking capabilities, an "installation image"
-   can be prepared on the Unix port. You can also install packages to your development
-   environment (a Unic\MacOs\Winows Port) then transfer the code to your device. see: `Cross-installing packages`_
+   is prepared on the Unix\Mac\Windows Port (the dev environment) then copied
+   to your device. see: `Cross-installing packages`_
 4. For low-memory ports, the installation image can be frozen as the
    bytecode into MicroPython executable, thus minimizing the memory
    storage overheads.
@@ -118,6 +117,7 @@ commands which corresponds to the example above are::
     micropython -m upip install micropython-pystone_lowmem
 
 [TODO: Describe installation path.]
+
 
 Cross-installing packages
 -------------------------

--- a/docs/unix/quickref.rst
+++ b/docs/unix/quickref.rst
@@ -13,7 +13,7 @@ latest versions, you should build from source as outlined in the wiki page:
 Here some common ways to install unofficial builds:
 
 * MacOs: ``brew install micropython`` from https://formulae.brew.sh/formula/micropython
-* Unix: ``apt get micropython`` (or your favorite variant of apt, apt-get). MicroPython may already be in your distrbution.
+* Unix: ``apt get micropython``
 * Windows: Unknown at this time.
 
 

--- a/docs/unix/quickref.rst
+++ b/docs/unix/quickref.rst
@@ -3,6 +3,20 @@
 Quick reference for the UNIX and Windows ports
 ==============================================
 
+
+Installation
+------------
+
+MicroPython does not publish builds for MacOs, Unix, and Windows. If you need
+latest versions, you should build from source as outlined in the wiki page: 
+`Getting Started <https://github.com/micropython/micropython/wiki/Getting-Started>`_.
+Here some common ways to install unofficial builds:
+
+* MacOs: ``brew install micropython`` from https://formulae.brew.sh/formula/micropython
+* Unix: ``apt get micropython`` (or your favorite variant of apt, apt-get). MicroPython may already be in your distrbution.
+* Windows: Unknown at this time.
+
+
 Command line options
 --------------------
 


### PR DESCRIPTION
These changes are intended to help people successfully find there way to successfully upip installing packages.

* Added how to install section to Unix Quickref, which refers people to hot do a build and how to install on Unix and MacOS.
* Modified the Packages page to make it clearer you should use a cross install if you can't use upip on your device and linked the cross install to the how to install so you can find your way successfully.

This might take another change... I probably screwed up the RST. I don't use it ever so I had to look up a bunch of things.