### PR TITLE
RFC windows: Publish executables from Appveyor builds available

### DIFF
--- a/ports/windows/.appveyor.yml
+++ b/ports/windows/.appveyor.yml
@@ -78,3 +78,15 @@ deploy: off
 
 nuget:
   disable_publish_on_pr: true
+
+# Note this relies on after_test building the mingw version,
+# which will replace the .exe files built by msvc.
+artifacts:
+  - path: ports/windows/build/Release*/micropython.exe
+    name: micropython-msvc
+  - path: mpy-cross/build/Release*/mpy-cross.exe
+    name: mpy-cross-msvc
+  - path: ports/windows/micropython.exe
+    name: micropython-mingw
+  - path: mpy-cross/mpy-cross.exe
+    name: mpy-cross-mingw


### PR DESCRIPTION
This makes Appveyor store the micropython and mpy-cross executables (both msvc and mingw versions) so they become available for download. Unfortunately they are currently not available via a simple permalink (or I'm missing something) because the build is split in jobs and each job has it's own artifacts.

Suppose this gets merged as-is, then if you visit `https://ci.appveyor.com/project/dpgeorge/micropython/branch/master` you can click on one of the jobs there, then click 'Artifacts' and get a list of downloadable files. Alternatively a link like `https://ci.appveyor.com/api/projects/dpgeorge/micropython/artifacts/ports/windows/build/Releasex64/micropython.exe?branch=master&job=Configuration%3A%20Release%3B%20Platform%3A%20x64` does give direct access to a file so such links can be used in e.g. quickref.rst or the README. (Just to be clear: above links currently don't do anything, just an example of what they would be).

Alternatively I can change appveyor.yml to only have one job which builds all different versions. That's pretty easy and then a link like `https://ci.appveyor.com/project/dpgeorge/micropython/branch/master/artifacts` would directly show the artifacts and the direct links also become simpler.

Next step could be to publish these to Github itself. For instance to always provide the latest master build I think it's possible to make a release on github with a fixed name like `trunk`, and Appveyor can then automatically deploy the executables from the last build to that release. This would be neat because we can simply tell people to go to something like `https://github.com/micropython/micropython/releases/download/trunk/micropython-msvc.zip` to grab the latest build. But that only makes sense if we do the same for some of the Travis builds as well, e.g. also have Travis upload the latest unix executables to that release.