### PR TITLE
windows: Publish executables from Appveyor builds available (v2)

### DIFF
--- a/mpy-cross/Makefile
+++ b/mpy-cross/Makefile
@@ -60,3 +60,12 @@ OBJ = $(PY_CORE_O)
 OBJ += $(addprefix $(BUILD)/, $(SRC_C:.c=.o))
 
 include $(TOP)/py/mkrules.mk
+
+PREFIX = /usr/local
+BINDIR = $(DESTDIR)$(PREFIX)/bin
+
+install: $(PROG)
+	install -D $(PROG) $(BINDIR)/$(PROG)
+
+uninstall:
+	-rm $(BINDIR)/$(PROG)

--- a/ports/windows/.appveyor.yml
+++ b/ports/windows/.appveyor.yml
@@ -5,81 +5,40 @@ skip_tags: true
 environment:
   # Python version used
   MICROPY_CPYTHON3: c:/python38/python.exe
-  # The variants.
-  matrix:
-    - PyVariant: dev
-    - PyVariant: standard
 
 init:
   # Set build version number to commit to be travis-like
 - ps: Update-AppveyorBuild -Version $env:appveyor_repo_commit.substring(0,8)
 
-configuration:
-- Debug
-- Release
-
-platform:
-- x86
-- x64
-
-matrix:
-  # One debug build is enough.
-  exclude:
-    - configuration: Debug
-      PyVariant: dev
-
-before_build:
+build_script:
 - ps: |
-    @"
-    <?xml version="1.0" encoding="utf-8"?>
-    <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-      <Target Name="Build">
-        <MsBuild BuildInParallel="True" Projects="mpy-cross\mpy-cross.vcxproj;ports\windows\micropython.vcxproj"/>
-      </Target>
-    </Project>
-    "@ | Set-Content build.proj
+    $upyDir = $env:APPVEYOR_BUILD_FOLDER
+    $msys2Bash = "C:/msys64/usr/bin/bash.exe"
+    $VerbosePreference = [Management.Automation.ActionPreference]::Continue
+    . "$upyDir/ports/windows/build.ps1"
 
-build:
-  project: build.proj
-  parallel: true
-  verbosity: normal
+    @(
+        @{platform = "Win32"; configuration = "Debug"; variant = "standard"},
+        @{platform = "Win32"; configuration = "Release"; variant = "standard"},
+        @{platform = "x64"; configuration = "Debug"; variant = "standard"},
+        @{platform = "x64"; configuration = "Release"; variant = "standard"},
+        @{platform = "x64"; configuration = "Release"; variant = "dev"}
+    ) |
+        ForEach-Object {
+            $buildOpts = "/p:Platform=$($_.platform);Configuration=$($_.configuration);PyVariant=$($_.variant)"
+            Invoke-MsvcBuild $uPydir $buildOpts 
+            Invoke-MsvcTests $uPydir $buildOpts
+        }
 
-test_script:
-- ps: |
-    $env:MICROPY_MICROPYTHON=(msbuild ports\windows\micropython.vcxproj /nologo /v:m /t:ShowTargetPath).Trim()
-    cd (Join-Path $env:APPVEYOR_BUILD_FOLDER 'tests')
-    & $env:MICROPY_CPYTHON3 run-tests.py
-    if ($LASTEXITCODE -ne 0) {
-      & $env:MICROPY_CPYTHON3 run-tests.py --print-failures
-      throw "Test failure"
-    }
-    & $env:MICROPY_CPYTHON3 run-tests.py --via-mpy -d basics float micropython
-    if ($LASTEXITCODE -ne 0) {
-      & $env:MICROPY_CPYTHON3 run-tests.py --print-failures
-      throw "Test failure"
-    }
-
-# After the build/test phase for the MSVC build completes,
-# build and test with mingw-w64, release versions only.
-after_test:
-- ps: |
-    if ($env:configuration -eq 'Debug') {
-      return
-    }
-    $env:MSYSTEM = if ($platform -eq 'x86') {'MINGW32'} else {'MINGW64'}
-    $env:CHERE_INVOKING = 'enabled_from_arguments'
-    cd (Join-Path $env:APPVEYOR_BUILD_FOLDER 'mpy-cross')
-    C:\msys64\usr\bin\bash.exe -l -c "make -B -j4 V=1"
-    if ($LASTEXITCODE -ne 0) {
-      throw "$env:MSYSTEM mpy_cross build exited with code $LASTEXITCODE"
-    }
-    cd (Join-Path $env:APPVEYOR_BUILD_FOLDER 'ports/windows')
-    C:\msys64\usr\bin\bash.exe -l -c "make -B -j4 V=1 MICROPY_MPYCROSS=../../mpy-cross/mpy-cross.exe VARIANT=$($env:PyVariant)"
-    if ($LASTEXITCODE -ne 0) {
-      throw "$env:MSYSTEM build exited with code $LASTEXITCODE"
-    }
-    C:\msys64\usr\bin\bash.exe -l -c "make V=1 test_full VARIANT=$($env:PyVariant)"
-    if ($LASTEXITCODE -ne 0) {
-      & $env:MICROPY_CPYTHON3 run-tests.py --print-failures
-      throw "Test failure"
-    }
+    @(
+        @{platform = "MINGW32"; variant = "standard"},
+        @{platform = "MINGW64"; variant = "standard"}
+        @{platform = "MINGW64"; variant = "dev"}
+    ) |
+        ForEach-Object {
+            $makeOpts = "-j4 V=1 PYTHON=$($env:MICROPY_CPYTHON3)"
+            $mpycrossMakeOpts = $makeOpts
+            $upyMakeOpts = "$makeOpts VARIANT=$($_.variant)"
+            Invoke-MingwBuild $uPydir $_.platform $msys2Bash $mpycrossMakeOpts $upyMakeOpts
+            Invoke-MingwTests $uPydir $_.platform $msys2Bash $upyMakeOpts
+        }

--- a/ports/windows/.appveyor.yml
+++ b/ports/windows/.appveyor.yml
@@ -37,8 +37,19 @@ build_script:
     ) |
         ForEach-Object {
             $makeOpts = "-j4 V=1 PYTHON=$($env:MICROPY_CPYTHON3)"
-            $mpycrossMakeOpts = $makeOpts
-            $upyMakeOpts = "$makeOpts VARIANT=$($_.variant)"
+            # Use distinct BINDIR so we can pick up artifacts without each build overwriting the output of the previous one.
+            $mpycrossMakeOpts = "$makeOpts BINDIR=build/$($_.platform)"
+            $upyMakeOpts = "$makeOpts VARIANT=$($_.variant) BINDIR=build-$($_.variant)/$($_.platform)"
             Invoke-MingwBuild $uPydir $_.platform $msys2Bash $mpycrossMakeOpts $upyMakeOpts
             Invoke-MingwTests $uPydir $_.platform $msys2Bash $upyMakeOpts
         }
+
+artifacts:
+  - path: mpy-cross/build/Releasex64/mpy-cross.exe
+    name: mpy-cross-msvc
+  - path: mpy-cross/build/MINGW64/mpy-cross.exe
+    name: mpy-cross-mingw
+  - path: ports/windows/build-standard/Releasex64/micropython.exe
+    name: micropython-msvc
+  - path: ports/windows/build-standard/MINGW64/micropython.exe
+    name: micropython-mingw

--- a/ports/windows/Build.ps1
+++ b/ports/windows/Build.ps1
@@ -1,0 +1,73 @@
+function Test-LastExitCode {
+    # Turn non-zero exitcode into a hard error.
+    if ($LASTEXITCODE -ne 0) {
+        throw "$Args exited with code $LASTEXITCODE"
+    }
+}
+
+function Watch-MicroPythonTestRun {
+    # Run tests, guarded by failure printing if needed.
+    $upyDir, $script = $Args
+    & $env:MICROPY_CPYTHON3 "$upyDir/tests/run-tests.py" --clean-failures
+    & $script
+    if ($LASTEXITCODE -ne 0) {
+        & $env:MICROPY_CPYTHON3 "$upyDir/tests/run-tests.py" --print-failures
+        throw "run-tests failed"
+    }
+}
+
+function Get-MsvcBuildOutput {
+    $projectFile, $buildOpts = $Args
+    (msbuild $projectFile /nologo /v:m /t:ShowTargetPath $buildOpts).Trim()
+    Test-LastExitCode "msbuild"
+}
+
+function Invoke-MsvcBuild {
+    $upyDir, $buildOpts = $Args
+    $projectFile = "$upyDir/build.proj"
+    Write-Verbose "Building for msvc: $projectFile with $buildOpts"
+
+    # Build multiple projects in parallel by using a separate project file as driver.
+    @"
+<Project>
+<Target Name="Build">
+  <MsBuild BuildInParallel="True" Projects="$upyDir/mpy-cross/mpy-cross.vcxproj;$upyDir/ports/windows/micropython.vcxproj"/>
+</Target>
+</Project>
+"@ | Set-Content $projectFile
+
+    msbuild /m $projectFile /t:Build $buildOpts
+    Test-LastExitCode "msbuild"
+}
+
+function Invoke-MsvcTests {
+    $upyDir, $buildOpts = $Args
+    $env:MICROPY_MICROPYTHON = Get-MsvcBuildOutput "$upyDir/ports/windows/micropython.vcxproj" $buildOpts
+    Write-Verbose "Testing with msvc: $env:MICROPY_MICROPYTHON"
+    Set-Location "$upyDir/tests"
+    Watch-MicroPythonTestRun $upyDir {& $env:MICROPY_CPYTHON3 run-tests.py}
+    Watch-MicroPythonTestRun $upyDir {& $env:MICROPY_CPYTHON3 run-tests.py --via-mpy -d basics float micropython}
+}
+
+function Invoke-MingwBuild {
+    $upyDir, $env:MSYSTEM, $bash, $crossMakeOpts, $upyMakeOpts = $Args
+    $env:CHERE_INVOKING = "enabled_from_arguments"
+    Write-Verbose "Building for $($env:MSYSTEM)"
+    Write-Verbose "mpy-cross: $crossMakeOpts"
+    Write-Verbose "micropython: $upyMakeOpts"
+    Set-Location "$upyDir"
+    # Clear LIB because when we get invoked from an environment which has it already, as is the case when
+    # the msvc build tools are configured, it might include bogus content like parentheses in paths.
+    & $bash -l -c "LIB='' make -B -C mpy-cross $crossMakeOpts"
+    Test-LastExitCode "make"
+    & $bash -l -c "LIB='' make -B -C ports/windows MICROPY_MPYCROSS=../../mpy-cross/mpy-cross.exe $upyMakeOpts"
+    Test-LastExitCode "make"
+}
+
+function Invoke-MingwTests {
+    $upyDir, $env:MSYSTEM, $bash, $makeOpts = $Args
+    $env:CHERE_INVOKING = "enabled_from_arguments"
+    Write-Verbose "Testing with $($env:MSYSTEM): $makeOpts"
+    Set-Location "$upyDir"
+    Watch-MicroPythonTestRun $upyDir {& $bash -l -c "make -C ports/windows test_full $makeOpts"}
+}

--- a/ports/windows/Build.ps1
+++ b/ports/windows/Build.ps1
@@ -56,11 +56,20 @@ function Invoke-MingwBuild {
     Write-Verbose "mpy-cross: $crossMakeOpts"
     Write-Verbose "micropython: $upyMakeOpts"
     Set-Location "$upyDir"
+    # Treat passing BINDIR as trigger for the install target.
+    $crossTargets = "all"
+    if ($crossMakeOpts -match "BINDIR=") {
+        $crossTargets += " install"
+    }
+    $upyTargets = "all"
+    if ($upyMakeOpts -match "BINDIR=") {
+        $upyTargets += " install"
+    }
     # Clear LIB because when we get invoked from an environment which has it already, as is the case when
     # the msvc build tools are configured, it might include bogus content like parentheses in paths.
-    & $bash -l -c "LIB='' make -B -C mpy-cross $crossMakeOpts"
+    & $bash -l -c "LIB='' make -B -C mpy-cross $crossMakeOpts $crossTargets"
     Test-LastExitCode "make"
-    & $bash -l -c "LIB='' make -B -C ports/windows MICROPY_MPYCROSS=../../mpy-cross/mpy-cross.exe $upyMakeOpts"
+    & $bash -l -c "LIB='' make -B -C ports/windows MICROPY_MPYCROSS=../../mpy-cross/mpy-cross.exe $upyMakeOpts $upyTargets"
     Test-LastExitCode "make"
 }
 

--- a/ports/windows/Makefile
+++ b/ports/windows/Makefile
@@ -93,3 +93,12 @@ test: $(PROG) $(TOP)/tests/run-tests.py
 test_full: test
 	$(eval DIRNAME=ports/$(notdir $(CURDIR)))
 	cd $(TOP)/tests && MICROPY_MICROPYTHON=../$(DIRNAME)/$(PROG) $(PYTHON) ./run-tests.py --via-mpy $(RUN_TESTS_MPY_CROSS_FLAGS) $(RUN_TESTS_SKIP) -d basics float micropython
+
+PREFIX = /usr/local
+BINDIR = $(DESTDIR)$(PREFIX)/bin
+
+install: $(PROG)
+	install -D $(PROG) $(BINDIR)/$(PROG)
+
+uninstall:
+	-rm $(BINDIR)/$(PROG)


### PR DESCRIPTION
Alternative version for #6049.

This would make downloads of latest build available at `https://ci.appveyor.com/project/dpgeorge/micropython/build/artifacts` (see https://ci.appveyor.com/project/stinos/micropython/build/artifacts for example) or latest master at `https://ci.appveyor.com/project/dpgeorge/micropython/branch/master/artifacts` or for direct download (also curl) `https://ci.appveyor.com/api/projects/dpgeorge/micropython/artifacts/mpy-cross/mpy-cross.exe` etc.

I like this one better than #6049, not only because the downloads are now easily accessible but also because the complete CI build is one script which can be used locally.