### PR TITLE
Add vt100 support to windows port.

### DIFF
--- a/ports/windows/windows_mphal.c
+++ b/ports/windows/windows_mphal.c
@@ -44,6 +44,7 @@ STATIC void assure_stdin_handle() {
     }
 }
 
+#if !MICROPY_HAL_HAS_VT100
 STATIC void assure_conout_handle() {
     if (!con_out) {
         con_out = CreateFile("CONOUT$", GENERIC_READ | GENERIC_WRITE,
@@ -52,6 +53,7 @@ STATIC void assure_conout_handle() {
         assert(con_out != INVALID_HANDLE_VALUE);
     }
 }
+#endif
 
 void mp_hal_stdio_mode_raw(void) {
     assure_stdin_handle();
@@ -60,6 +62,9 @@ void mp_hal_stdio_mode_raw(void) {
     mode &= ~ENABLE_ECHO_INPUT;
     mode &= ~ENABLE_LINE_INPUT;
     mode &= ~ENABLE_PROCESSED_INPUT;
+#if MICROPY_HAL_HAS_VT100
+    mode |= ENABLE_VIRTUAL_TERMINAL_INPUT;
+#endif
     SetConsoleMode(std_in, mode);
 }
 
@@ -105,6 +110,7 @@ void mp_hal_set_interrupt_char(char c) {
     }
 }
 
+#if !MICROPY_HAL_HAS_VT100
 void mp_hal_move_cursor_back(uint pos) {
     if (!pos) {
         return;
@@ -184,8 +190,25 @@ STATIC int esc_seq_chr() {
     }
     return 0;
 }
+#endif
 
 int mp_hal_stdin_rx_chr(void) {
+#if MICROPY_HAL_HAS_VT100
+    assure_stdin_handle();
+    DWORD num_read;
+    char inchar;
+    LPVOID buf = &inchar;
+    for (;;) {
+        BOOL read_ok;
+        read_ok = ReadFile(std_in, buf, 1, &num_read, NULL);
+        if (!read_ok || !num_read) {
+            continue;
+        }
+        else {
+            return inchar;
+        }
+    }
+#else
     // currently processing escape seq?
     const int ret = esc_seq_chr();
     if (ret) {
@@ -218,6 +241,7 @@ int mp_hal_stdin_rx_chr(void) {
             return c;
         }
     }
+#endif
 }
 
 void mp_hal_stdout_tx_strn(const char *str, size_t len) {

--- a/ports/windows/windows_mphal.c
+++ b/ports/windows/windows_mphal.c
@@ -203,8 +203,7 @@ int mp_hal_stdin_rx_chr(void) {
         read_ok = ReadFile(std_in, buf, 1, &num_read, NULL);
         if (!read_ok || !num_read) {
             continue;
-        }
-        else {
+        } else {
             return inchar;
         }
     }

--- a/ports/windows/windows_mphal.c
+++ b/ports/windows/windows_mphal.c
@@ -62,9 +62,9 @@ void mp_hal_stdio_mode_raw(void) {
     mode &= ~ENABLE_ECHO_INPUT;
     mode &= ~ENABLE_LINE_INPUT;
     mode &= ~ENABLE_PROCESSED_INPUT;
-#if MICROPY_HAL_HAS_VT100
+    #if MICROPY_HAL_HAS_VT100
     mode |= ENABLE_VIRTUAL_TERMINAL_INPUT;
-#endif
+    #endif
     SetConsoleMode(std_in, mode);
 }
 
@@ -193,13 +193,13 @@ STATIC int esc_seq_chr() {
 #endif
 
 int mp_hal_stdin_rx_chr(void) {
-#if MICROPY_HAL_HAS_VT100
+    #if MICROPY_HAL_HAS_VT100
     assure_stdin_handle();
+    BOOL read_ok;
     DWORD num_read;
     char inchar;
     LPVOID buf = &inchar;
     for (;;) {
-        BOOL read_ok;
         read_ok = ReadFile(std_in, buf, 1, &num_read, NULL);
         if (!read_ok || !num_read) {
             continue;
@@ -208,7 +208,7 @@ int mp_hal_stdin_rx_chr(void) {
             return inchar;
         }
     }
-#else
+    #else
     // currently processing escape seq?
     const int ret = esc_seq_chr();
     if (ret) {
@@ -241,7 +241,7 @@ int mp_hal_stdin_rx_chr(void) {
             return c;
         }
     }
-#endif
+    #endif
 }
 
 void mp_hal_stdout_tx_strn(const char *str, size_t len) {

--- a/ports/windows/windows_mphal.h
+++ b/ports/windows/windows_mphal.h
@@ -29,8 +29,10 @@
 
 #define MICROPY_HAL_HAS_VT100 (0)
 
+#if !MICROPY_HAL_HAS_VT100
 void mp_hal_move_cursor_back(unsigned int pos);
 void mp_hal_erase_line_from_cursor(unsigned int n_chars_to_erase);
+#endif
 
 #undef mp_hal_ticks_cpu
 mp_uint_t mp_hal_ticks_cpu(void);


### PR DESCRIPTION
This patch let terminal output of windows port can be the same as unix port, so we can use the same logic to interact with them, for example, embedded them in cross-platform gui.

Note that windows console doesn't support vt100 control sequence, normally you don't want to  enable vt100 support unless you redirect stdin/stdout to another program.