### PR TITLE
py/py.mk: Use -fno-builtin and -ffreestanding to compile string0.c.

### DIFF
--- a/py/py.mk
+++ b/py/py.mk
@@ -266,6 +266,11 @@ $(HEADER_BUILD)/moduledefs.h: $(SRC_QSTR) $(QSTR_GLOBAL_DEPENDENCIES) | $(HEADER
 
 SRC_QSTR += $(HEADER_BUILD)/moduledefs.h
 
+# Standard C functions like memset need to be compiled with special flags so
+# the compiler does not optimise these functions in terms of themselves.
+CFLAGS_BUILTIN ?= -ffreestanding -fno-builtin -fno-lto
+$(BUILD)/lib/libc/string0.o: CFLAGS += $(CFLAGS_BUILTIN)
+
 # Force nlr code to always be compiled with space-saving optimisation so
 # that the function preludes are of a minimal and predictable form.
 $(PY_BUILD)/nlr%.o: CFLAGS += -Os


### PR DESCRIPTION
Otherwise functions like memset might get optimised to call themselves (eg with gcc 10).  And provide `CFLAGS_BUILTIN` so these options can be changed by a port if needed.

Fixes issue #6053.