### PR TITLE
py/dynruntime.h: Store module init to __init__ global so GC can find it.

### DIFF
--- a/py/dynruntime.h
+++ b/py/dynruntime.h
@@ -178,6 +178,7 @@ static inline mp_obj_t mp_obj_len_dyn(mp_obj_t o) {
 
 #define MP_DYNRUNTIME_INIT_ENTRY \
     mp_obj_t old_globals = mp_fun_table.swap_globals(self->globals); \
+    mp_fun_table.store_global(MP_QSTR___init__, MP_OBJ_FROM_PTR(self)); \
     mp_raw_code_t rc; \
     rc.kind = MP_CODE_NATIVE_VIPER; \
     rc.scope_flags = 0; \


### PR DESCRIPTION
This is a fix for #6045 where, on ARM-based ports, native code loaded from a .mpy file will be reclaimed by the GC because there's no reference to the very start of the native machine code block that is reachable from root pointers (only pointers to internal parts of the machine code block are reachable, but that doesn't help the GC find the memory).

The fix here works but is overkill because it's not needed on other archs (x86, xtensa) which already explicitly retain pointers to executable memory (in some port-specific way).  It adds a small amount of machine code to all .mpy files (in the module init function that's run on import).  It'd be possible to only include this additional code when compiling on ARM.

The fix works by storing the module's init function to the `__init__` entry of the modules dict, thereby retaining a GC-reachable pointer to the machine code data block.  The advantage of this approach is that the memory will be reclaimed if the module is deleted (from sys.modules).  The disadvantage is that if a user deletes/changes the `__init__` entry in the module then the data will be reclaimed even though it's still needed (but I'm not sure why one would delete/change that entry...).