### PR TITLE
rename platform_obj to mp_sys_platform_obj

### DIFF
--- a/py/modsys.c
+++ b/py/modsys.c
@@ -53,7 +53,7 @@ const mp_print_t mp_sys_stdout_print = {&mp_sys_stdout_obj, mp_stream_write_adap
 #endif
 
 // version - Python language version that this implementation conforms to, as a string
-STATIC const MP_DEFINE_STR_OBJ(version_obj, "3.4.0");
+STATIC const MP_DEFINE_STR_OBJ(mp_sys_version_obj, "3.4.0");
 
 // version_info - Python language version that this implementation conforms to, as a tuple of ints
 #define I(n) MP_OBJ_NEW_SMALL_INT(n)
@@ -105,7 +105,7 @@ STATIC const mp_rom_obj_tuple_t mp_sys_implementation_obj = {
 
 #ifdef MICROPY_PY_SYS_PLATFORM
 // platform - the platform that MicroPython is running on
-STATIC const MP_DEFINE_STR_OBJ(platform_obj, MICROPY_PY_SYS_PLATFORM);
+STATIC const MP_DEFINE_STR_OBJ(mp_sys_platform_obj, MICROPY_PY_SYS_PLATFORM);
 #endif
 
 // exit([retval]): raise SystemExit, with optional argument given to the exception
@@ -189,11 +189,11 @@ STATIC const mp_rom_map_elem_t mp_module_sys_globals_table[] = {
 
     { MP_ROM_QSTR(MP_QSTR_path), MP_ROM_PTR(&MP_STATE_VM(mp_sys_path_obj)) },
     { MP_ROM_QSTR(MP_QSTR_argv), MP_ROM_PTR(&MP_STATE_VM(mp_sys_argv_obj)) },
-    { MP_ROM_QSTR(MP_QSTR_version), MP_ROM_PTR(&version_obj) },
+    { MP_ROM_QSTR(MP_QSTR_version), MP_ROM_PTR(&mp_sys_version_obj) },
     { MP_ROM_QSTR(MP_QSTR_version_info), MP_ROM_PTR(&mp_sys_version_info_obj) },
     { MP_ROM_QSTR(MP_QSTR_implementation), MP_ROM_PTR(&mp_sys_implementation_obj) },
     #ifdef MICROPY_PY_SYS_PLATFORM
-    { MP_ROM_QSTR(MP_QSTR_platform), MP_ROM_PTR(&platform_obj) },
+    { MP_ROM_QSTR(MP_QSTR_platform), MP_ROM_PTR(&mp_sys_platform_obj) },
     #endif
     #if MP_ENDIANNESS_LITTLE
     { MP_ROM_QSTR(MP_QSTR_byteorder), MP_ROM_QSTR(MP_QSTR_little) },
@@ -210,7 +210,7 @@ STATIC const mp_rom_map_elem_t mp_module_sys_globals_table[] = {
     // of "one" bits in sys.maxsize.
     { MP_ROM_QSTR(MP_QSTR_maxsize), MP_ROM_INT(MP_SMALL_INT_MAX) },
     #else
-    { MP_ROM_QSTR(MP_QSTR_maxsize), MP_ROM_PTR(&mp_maxsize_obj) },
+    { MP_ROM_QSTR(MP_QSTR_maxsize), MP_ROM_PTR(&mp_sys_maxsize_obj) },
     #endif
     #endif
 

--- a/py/objint.h
+++ b/py/objint.h
@@ -38,7 +38,7 @@ typedef struct _mp_obj_int_t {
     #endif
 } mp_obj_int_t;
 
-extern const mp_obj_int_t mp_maxsize_obj;
+extern const mp_obj_int_t mp_sys_maxsize_obj;
 
 #if MICROPY_PY_BUILTINS_FLOAT
 mp_float_t mp_obj_int_as_float_impl(mp_obj_t self_in);

--- a/py/objint_longlong.c
+++ b/py/objint_longlong.c
@@ -40,7 +40,7 @@
 
 #if MICROPY_PY_SYS_MAXSIZE
 // Export value for sys.maxsize
-const mp_obj_int_t mp_maxsize_obj = {{&mp_type_int}, MP_SSIZE_MAX};
+const mp_obj_int_t mp_sys_maxsize_obj = {{&mp_type_int}, MP_SSIZE_MAX};
 #endif
 
 mp_obj_t mp_obj_int_from_bytes_impl(bool big_endian, size_t len, const byte *buf) {

--- a/py/objint_mpz.c
+++ b/py/objint_mpz.c
@@ -66,7 +66,7 @@ STATIC const mpz_dig_t maxsize_dig[] = {
     #endif
 };
 // *FORMAT-ON*
-const mp_obj_int_t mp_maxsize_obj = {
+const mp_obj_int_t mp_sys_maxsize_obj = {
     {&mp_type_int},
     {.fixed_dig = 1, .len = NUM_DIG, .alloc = NUM_DIG, .dig = (mpz_dig_t *)maxsize_dig}
 };


### PR DESCRIPTION
Although this is static, it is still nice to follow the usual naming convention of `mp_<module>_<name>` so that it is easy to find when grepping.