### PR TITLE
tools/codeformat: use -q option on uncrustify

### DIFF
--- a/tools/codeformat.py
+++ b/tools/codeformat.py
@@ -168,7 +168,7 @@ def main():
 
     # Format C files with uncrustify.
     if format_c:
-        batch(["uncrustify", "-c", UNCRUSTIFY_CFG, "-lC", "--no-backup"], lang_files(C_EXTS))
+        batch(["uncrustify", "-q", "-c", UNCRUSTIFY_CFG, "-lC", "--no-backup"], lang_files(C_EXTS))
         for file in lang_files(C_EXTS):
             fixup_c(file)
 


### PR DESCRIPTION
This suppresses the `Parsing: <file> as language C` lines when running `uncrustify`. This makes `codeformat.py` run a bit faster and on CI it makes for less scrolling through logs. (And `black` already uses the -q option too.)