### PR TITLE
ports/unix: Add full uos.dupterm support.

### DIFF
--- a/extmod/os_dupterm.c
+++ b/extmod/os_dupterm.c
@@ -188,7 +188,7 @@ int mp_os_dupterm_tx_strn(const char *str, size_t len) {
             int errcode = 0;
             const mp_stream_p_t *stream_p = mp_get_stream(MP_STATE_VM(dupterm_objs[idx]));
             mp_uint_t written = stream_p->write(MP_STATE_VM(dupterm_objs[idx]), str, len, &errcode);
-            int write_res = MAX(0, written);
+            int write_res = (written == MP_STREAM_ERROR) ? 0 : (int)written;
             ret = MIN(write_res, ret);
             continue;
         }

--- a/extmod/vfs_posix_file.c
+++ b/extmod/vfs_posix_file.c
@@ -126,11 +126,27 @@ static mp_uint_t vfs_posix_file_read(mp_obj_t o_in, void *buf, mp_uint_t size, i
     return (mp_uint_t)r;
 }
 
+// Forward declarations needed for dupterm stdio redirect check below.
+extern mp_obj_vfs_posix_file_t mp_sys_stdout_obj;
+extern mp_obj_vfs_posix_file_t mp_sys_stderr_obj;
+#if MICROPY_PY_SYS_STDIO_BUFFER
+extern mp_obj_vfs_posix_file_t mp_sys_stdout_buffer_obj;
+extern mp_obj_vfs_posix_file_t mp_sys_stderr_buffer_obj;
+#endif
+
 static mp_uint_t vfs_posix_file_write(mp_obj_t o_in, const void *buf, mp_uint_t size, int *errcode) {
     mp_obj_vfs_posix_file_t *o = MP_OBJ_TO_PTR(o_in);
     check_fd_is_open(o);
     #if MICROPY_PY_OS_DUPTERM
-    if (o->fd <= STDERR_FILENO) {
+    // Redirect writes on the sys.stdout/stderr objects through dupterm so that
+    // user-registered dupterm streams also receive the output.  Use object
+    // identity rather than fd number to avoid false matches when a stdio fd
+    // has been closed (e.g. by GC finaliser) and the fd number reused.
+    if (o == &mp_sys_stdout_obj || o == &mp_sys_stderr_obj
+        #if MICROPY_PY_SYS_STDIO_BUFFER
+        || o == &mp_sys_stdout_buffer_obj || o == &mp_sys_stderr_buffer_obj
+        #endif
+        ) {
         mp_hal_stdout_tx_strn(buf, size);
         return size;
     }

--- a/ports/unix/main.c
+++ b/ports/unix/main.c
@@ -57,6 +57,10 @@
 #include "stack_size.h"
 #include "shared/runtime/pyexec.h"
 
+#if MICROPY_PY_OS_DUPTERM
+extern mp_obj_t mp_unix_stdio_obj;
+#endif
+
 // Command line options, with their defaults
 bool mp_compile_only = false;
 static uint emit_opt = MP_EMIT_OPT_NONE;
@@ -84,7 +88,6 @@ static void stderr_print_strn(void *env, const char *str, size_t len) {
     (void)env;
     ssize_t ret;
     MP_HAL_RETRY_SYSCALL(ret, write(STDERR_FILENO, str, len), {});
-    mp_os_dupterm_tx_strn(str, len);
 }
 
 const mp_print_t mp_stderr_print = {NULL, stderr_print_strn};
@@ -494,6 +497,11 @@ MP_NOINLINE int main_(int argc, char **argv) {
     #endif
 
     mp_init();
+
+    #if MICROPY_PY_OS_DUPTERM
+    // Register the builtin stdio stream as dupterm slot 0.
+    MP_STATE_VM(dupterm_objs[0]) = MP_OBJ_FROM_PTR(&mp_unix_stdio_obj);
+    #endif
 
     #if MICROPY_EMIT_NATIVE
     // Set default emitter options

--- a/ports/unix/mphalport.h
+++ b/ports/unix/mphalport.h
@@ -53,7 +53,9 @@
 
 void mp_hal_set_interrupt_char(char c);
 
-#define mp_hal_stdio_poll unused // this is not implemented, nor needed
+#if !MICROPY_PY_OS_DUPTERM
+#define mp_hal_stdio_poll unused // not implemented, nor needed without dupterm
+#endif
 void mp_hal_stdio_mode_raw(void);
 void mp_hal_stdio_mode_orig(void);
 

--- a/ports/unix/unix_mphal.c
+++ b/ports/unix/unix_mphal.c
@@ -30,10 +30,13 @@
 #include <time.h>
 #include <sys/time.h>
 #include <fcntl.h>
+#include <poll.h>
 
 #include "py/mphal.h"
 #include "py/mpthread.h"
 #include "py/runtime.h"
+#include "py/stream.h"
+#include "py/objtype.h"
 #include "extmod/misc.h"
 
 #if defined(__GLIBC__) && defined(__GLIBC_PREREQ)
@@ -72,7 +75,14 @@ static void sighandler(int signum) {
 }
 #endif
 
+#if MICROPY_KBD_EXCEPTION
+int mp_interrupt_char = -1;
+#endif
+
 void mp_hal_set_interrupt_char(char c) {
+    #if MICROPY_KBD_EXCEPTION
+    mp_interrupt_char = c;
+    #endif
     // configure terminal settings to (not) let ctrl-C through
     if (c == CHAR_CTRL_C) {
         #ifndef _WIN32
@@ -122,57 +132,102 @@ void mp_hal_stdio_mode_orig(void) {
 #endif
 
 #if MICROPY_PY_OS_DUPTERM
-static int call_dupterm_read(size_t idx) {
-    nlr_buf_t nlr;
-    if (nlr_push(&nlr) == 0) {
-        mp_obj_t read_m[3];
-        mp_load_method(MP_STATE_VM(dupterm_objs[idx]), MP_QSTR_read, read_m);
-        read_m[2] = MP_OBJ_NEW_SMALL_INT(1);
-        mp_obj_t res = mp_call_method_n_kw(1, 0, read_m);
-        if (res == mp_const_none) {
-            return -2;
-        }
-        mp_buffer_info_t bufinfo;
-        mp_get_buffer_raise(res, &bufinfo, MP_BUFFER_READ);
-        if (bufinfo.len == 0) {
-            mp_printf(&mp_plat_print, "dupterm: EOF received, deactivating\n");
-            MP_STATE_VM(dupterm_objs[idx]) = MP_OBJ_NULL;
-            return -1;
-        }
-        nlr_pop();
-        return *(byte *)bufinfo.buf;
-    } else {
-        // Temporarily disable dupterm to avoid infinite recursion
-        mp_obj_t save_term = MP_STATE_VM(dupterm_objs[idx]);
-        MP_STATE_VM(dupterm_objs[idx]) = NULL;
-        mp_printf(&mp_plat_print, "dupterm: ");
-        mp_obj_print_exception(&mp_plat_print, nlr.ret_val);
-        MP_STATE_VM(dupterm_objs[idx]) = save_term;
-    }
+// Builtin stream object that wraps STDIN/STDOUT file descriptors.
+// This is registered as dupterm slot 0 so that os.dupterm() can manage
+// the default console alongside user-provided streams.
 
-    return -1;
+typedef struct _mp_unix_stdio_obj_t {
+    mp_obj_base_t base;
+} mp_unix_stdio_obj_t;
+
+static mp_uint_t mp_unix_stdio_read(mp_obj_t self_in, void *buf, mp_uint_t size, int *errcode) {
+    (void)self_in;
+    // Use non-blocking read so dupterm can poll multiple slots.
+    struct pollfd pfd = { .fd = STDIN_FILENO, .events = POLLIN };
+    if (poll(&pfd, 1, 0) <= 0 || !(pfd.revents & POLLIN)) {
+        *errcode = MP_EAGAIN;
+        return MP_STREAM_ERROR;
+    }
+    ssize_t ret;
+    MP_HAL_RETRY_SYSCALL(ret, read(STDIN_FILENO, buf, size), {
+        *errcode = err;
+        return MP_STREAM_ERROR;
+    });
+    if (ret == 0) {
+        // EOF
+        *errcode = 0;
+        return 0;
+    }
+    return ret;
 }
-#endif
+
+static mp_uint_t mp_unix_stdio_write(mp_obj_t self_in, const void *buf, mp_uint_t size, int *errcode) {
+    (void)self_in;
+    ssize_t ret;
+    MP_HAL_RETRY_SYSCALL(ret, write(STDOUT_FILENO, buf, size), {
+        *errcode = err;
+        return MP_STREAM_ERROR;
+    });
+    return ret;
+}
+
+static mp_uint_t mp_unix_stdio_ioctl(mp_obj_t self_in, mp_uint_t request, uintptr_t arg, int *errcode) {
+    (void)self_in;
+    if (request == MP_STREAM_POLL) {
+        uintptr_t flags = arg;
+        uintptr_t ret = 0;
+        if (flags & MP_STREAM_POLL_RD) {
+            struct pollfd pfd = { .fd = STDIN_FILENO, .events = POLLIN };
+            if (poll(&pfd, 1, 0) > 0 && (pfd.revents & POLLIN)) {
+                ret |= MP_STREAM_POLL_RD;
+            }
+        }
+        if (flags & MP_STREAM_POLL_WR) {
+            ret |= MP_STREAM_POLL_WR;
+        }
+        return ret;
+    }
+    *errcode = MP_EINVAL;
+    return MP_STREAM_ERROR;
+}
+
+static const mp_stream_p_t mp_unix_stdio_stream_p = {
+    .read = mp_unix_stdio_read,
+    .write = mp_unix_stdio_write,
+    .ioctl = mp_unix_stdio_ioctl,
+};
+
+MP_DEFINE_CONST_OBJ_TYPE(
+    mp_unix_stdio_type,
+    MP_QSTR_stdio,
+    MP_TYPE_FLAG_NONE,
+    protocol, &mp_unix_stdio_stream_p
+    );
+
+mp_unix_stdio_obj_t mp_unix_stdio_obj = {{&mp_unix_stdio_type}};
+
+bool mp_os_dupterm_is_builtin_stream(mp_const_obj_t stream) {
+    return mp_obj_get_type(stream) == &mp_unix_stdio_type;
+}
+
+uintptr_t mp_hal_stdio_poll(uintptr_t poll_flags) {
+    return mp_os_dupterm_poll(poll_flags);
+}
+#endif // MICROPY_PY_OS_DUPTERM
 
 int mp_hal_stdin_rx_chr(void) {
     #if MICROPY_PY_OS_DUPTERM
-    // TODO only support dupterm one slot at the moment
-    if (MP_STATE_VM(dupterm_objs[0]) != MP_OBJ_NULL) {
-        int c;
-        do {
-            c = call_dupterm_read(0);
-        } while (c == -2);
-        if (c == -1) {
-            goto main_term;
+    for (;;) {
+        int c = mp_os_dupterm_rx_chr();
+        if (c >= 0) {
+            if (c == '\n') {
+                c = '\r';
+            }
+            return c;
         }
-        if (c == '\n') {
-            c = '\r';
-        }
-        return c;
+        mp_event_wait_indefinite();
     }
-main_term:;
-    #endif
-
+    #else
     unsigned char c;
     ssize_t ret;
     MP_HAL_RETRY_SYSCALL(ret, read(STDIN_FILENO, &c, 1), {});
@@ -182,17 +237,20 @@ main_term:;
         c = '\r';
     }
     return c;
+    #endif
 }
 
 mp_uint_t mp_hal_stdout_tx_strn(const char *str, size_t len) {
-    ssize_t ret;
-    MP_HAL_RETRY_SYSCALL(ret, write(STDOUT_FILENO, str, len), {});
-    mp_uint_t written = ret < 0 ? 0 : ret;
+    #if MICROPY_PY_OS_DUPTERM
     int dupterm_res = mp_os_dupterm_tx_strn(str, len);
     if (dupterm_res >= 0) {
-        written = MIN((mp_uint_t)dupterm_res, written);
+        return dupterm_res;
     }
-    return written;
+    // No dupterm streams active, write directly.
+    #endif
+    ssize_t ret;
+    MP_HAL_RETRY_SYSCALL(ret, write(STDOUT_FILENO, str, len), {});
+    return ret < 0 ? 0 : ret;
 }
 
 // cooked is same as uncooked because the terminal does some postprocessing

--- a/ports/unix/variants/mpconfigvariant_common.h
+++ b/ports/unix/variants/mpconfigvariant_common.h
@@ -93,6 +93,8 @@
 
 // Configure the "os" module with extra unix features.
 #define MICROPY_PY_OS_INCLUDEFILE      "ports/unix/modos.c"
+#define MICROPY_PY_OS_DUPTERM          (2)
+#define MICROPY_PY_OS_DUPTERM_BUILTIN_STREAM (1)
 #define MICROPY_PY_OS_ERRNO            (1)
 #define MICROPY_PY_OS_GETENV_PUTENV_UNSETENV (1)
 #define MICROPY_PY_OS_SYSTEM           (1)


### PR DESCRIPTION
The unix port currently supports a very limited uos.dupterm implementation. 
It can only replace stdin and/or duplicate stdout. 
When using uos.dupterm to replace slot 0 it does not return a handle to the existing (posix stdio) stream.

This PR resolves these issues, preferring to use dupterm for all stdio on unix when `MICROPY_PY_OS_DUPTERM=1` is configured in the build.

With this change simple modification of the output stream is possible, for example to format logging messaging with a basic timestamp
``` python
stdio = None

class logger:
    def write(self, buf):
        global stdio        
        stdio.write(str(utime.time()))
        stdio.write(" | ")
        stdio.write(buf)

stdio = uos.dupterm(logger(), 0)
```