### PR TITLE
tools/codeformat: Add verbose option

### DIFF
--- a/tools/codeformat.py
+++ b/tools/codeformat.py
@@ -138,6 +138,7 @@ def main():
     cmd_parser = argparse.ArgumentParser(description="Auto-format C and Python files.")
     cmd_parser.add_argument("-c", action="store_true", help="Format C code only")
     cmd_parser.add_argument("-p", action="store_true", help="Format Python code only")
+    cmd_parser.add_argument("-v", action="store_true", help="Enable verbose output")
     cmd_parser.add_argument("files", nargs="*", help="Run on specific globs")
     args = cmd_parser.parse_args()
 
@@ -168,13 +169,21 @@ def main():
 
     # Format C files with uncrustify.
     if format_c:
-        batch(["uncrustify", "-q", "-c", UNCRUSTIFY_CFG, "-lC", "--no-backup"], lang_files(C_EXTS))
+        command = ["uncrustify", "-c", UNCRUSTIFY_CFG, "-lC", "--no-backup"]
+        if not args.v:
+            command.append("-q")
+        batch(command, lang_files(C_EXTS))
         for file in lang_files(C_EXTS):
             fixup_c(file)
 
     # Format Python files with black.
     if format_py:
-        batch(["black", "-q", "--fast", "--line-length=99"], lang_files(PY_EXTS))
+        command = ["black", "--fast", "--line-length=99"]
+        if args.v:
+            command.append("-v")
+        else:
+            command.append("-q")
+        batch(command, lang_files(PY_EXTS))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This adds a new command line option `-v` to `tools/codeformat.py` to enable verbose printing of all files that are scanned.

Normally `uncrustify` and `black` are called with the `-q` option so setting verbose suppresses the `-q` option and on `black` also enables the `-v` option which makes it print out all file names matching the filter similar to how `uncrustify` does by default.