### PR TITLE
top: Update contribution and commit guide to include optional sign-off.

### DIFF
--- a/CODECONVENTIONS.md
+++ b/CODECONVENTIONS.md
@@ -27,9 +27,12 @@ change beyond 5 lines would likely require such detailed description.
 To get good practical examples of good commits and their messages, browse
 the `git log` of the project.
 
-MicroPython doesn't require explicit sign-off for patches ("Signed-off-by"
-lines and similar). Instead, the commit message, and your name and email
-address on it construes your sign-off of the following:
+When committing you are encouraged to sign-off your commit by adding
+"Signed-off-by" lines and similar, eg using "git commit -s".  If you don't
+explicitly sign-off in this way then the commit message, which includes your
+name and email address in the "Author" line, implies your sign-off.  In either
+case, of explicit or implicit sign-off, you are certifying and signing off
+against the following:
 
 * That you wrote the change yourself, or took it from a project with
   a compatible license (in the latter case the commit message, and possibly
@@ -43,8 +46,11 @@ address on it construes your sign-off of the following:
   copyright for your changes (for smaller changes, the commit message
   conveys your copyright; if you make significant changes to a particular
   source module, you're welcome to add your name to the file header).
-* Your signature for all of the above, which is the 'Author' line in
-  the commit message, and which should include your full real name and
+* Your contribution including commit message will be publicly and
+  indefinitely available for anyone to access, including redistribution
+  under the terms of the project's license.
+* Your signature for all of the above, which is the "Signed-off-by" line
+  or the "Author" line in the commit message, includes your full real name and
   a valid and active email address by which you can be contacted in the
   foreseeable future.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,6 +3,6 @@ make sure that you are acquainted with Contributor Guidelines:
 
 https://github.com/micropython/micropython/wiki/ContributorGuidelines
 
-and Code Conventions:
+as well as the Code Conventions, which includes details of how to commit:
 
 https://github.com/micropython/micropython/blob/master/CODECONVENTIONS.md


### PR DESCRIPTION
MicroPython already requires contributors to implicitly sign-off on a set of points, which are listed in CODECONVENTIONS.md (everyone who contributes should have read these at some point!).

This PR adjusts this wording to allow explicit sign-off using the git "Signed-off-by:" feature.  There is no reference to https://developercertificate.org/ because the project already has its own version of this.