### PR TITLE
qemu-arm/README: Update link to toolchain

### DIFF
--- a/ports/qemu-arm/README.md
+++ b/ports/qemu-arm/README.md
@@ -15,8 +15,9 @@ The purposes of this port are to enable:
     - no need to use OpenOCD or anything else that might slow down the
       process in terms of plugging things together, pressing buttons, etc.
 
-This port will only work with with [GCC ARM Embedded](launchpad.net/gcc-arm-embedded)
-toolchain and not with CodeSourcery toolchain. You will need to modify
+This port will only work with the [GNU ARM Embedded Toolchain](
+https://developer.arm.com/tools-and-software/open-source-software/developer-tools/gnu-toolchain/gnu-rm)
+ and not with CodeSourcery toolchain. You will need to modify
 `LDFLAGS` if you want to use CodeSourcery's version of `arm-none-eabi`.
 The difference is that CodeSourcery needs `-T generic-m-hosted.ld` while
 ARM's version  requires `--specs=nano.specs --specs=rdimon.specs` to be


### PR DESCRIPTION
Without https:// it will assume it is a link
to a file in the current folder.