### PR TITLE
docs: Add note about multiple exception stack traces while heap is locked.

### DIFF
--- a/docs/reference/isr_rules.rst
+++ b/docs/reference/isr_rules.rst
@@ -42,6 +42,11 @@ for the purpose. Debugging is simplified if the following code is included in an
 
     import micropython
     micropython.alloc_emergency_exception_buf(100)
+    
+The emergency exception buffer can only hold one exception stack trace. This means that if a second exception is 
+thrown during the handling of an exception while the heap is locked, that the second exceptions stack trace will 
+replace the original one - even if the second exception is cleanly handled. This can lead to confusing exception
+messages if the buffer is later printed.
 
 Simplicity
 ~~~~~~~~~~


### PR DESCRIPTION
Suggesting some additional information in docs about multiple exceptions while heap locked, to assist in clarifying the behavior seen and explained in https://github.com/micropython/micropython/issues/6088