### PR TITLE
esp32/mpthreadport: Fix calculation of thread stack size.

### DIFF
--- a/ports/esp32/main.c
+++ b/ports/esp32/main.c
@@ -65,7 +65,6 @@
 // MicroPython runs as a task under FreeRTOS
 #define MP_TASK_PRIORITY        (ESP_TASK_PRIO_MIN + 1)
 #define MP_TASK_STACK_SIZE      (16 * 1024)
-#define MP_TASK_STACK_LEN       (MP_TASK_STACK_SIZE / sizeof(StackType_t))
 
 int vprintf_null(const char *format, va_list ap) {
     // do nothing: this is used as a log target during raw repl mode
@@ -75,7 +74,7 @@ int vprintf_null(const char *format, va_list ap) {
 void mp_task(void *pvParameter) {
     volatile uint32_t sp = (uint32_t)get_sp();
     #if MICROPY_PY_THREAD
-    mp_thread_init(pxTaskGetStackStart(NULL), MP_TASK_STACK_LEN);
+    mp_thread_init(pxTaskGetStackStart(NULL), MP_TASK_STACK_SIZE / sizeof(uintptr_t));
     #endif
     uart_init();
 
@@ -169,7 +168,7 @@ void app_main(void) {
         nvs_flash_erase();
         nvs_flash_init();
     }
-    xTaskCreatePinnedToCore(mp_task, "mp_task", MP_TASK_STACK_LEN, NULL, MP_TASK_PRIORITY, &mp_main_task_handle, MP_TASK_COREID);
+    xTaskCreatePinnedToCore(mp_task, "mp_task", MP_TASK_STACK_SIZE / sizeof(StackType_t), NULL, MP_TASK_PRIORITY, &mp_main_task_handle, MP_TASK_COREID);
 }
 
 void nlr_jump_fail(void *val) {

--- a/ports/esp32/mpthreadport.c
+++ b/ports/esp32/mpthreadport.c
@@ -83,7 +83,7 @@ void mp_thread_gc_others(void) {
         if (!th->ready) {
             continue;
         }
-        gc_collect_root(th->stack, th->stack_len); // probably not needed
+        gc_collect_root(th->stack, th->stack_len);
     }
     mp_thread_mutex_unlock(&thread_mutex);
 }
@@ -140,16 +140,16 @@ void mp_thread_create_ex(void *(*entry)(void *), void *arg, size_t *stack_size, 
         mp_raise_msg(&mp_type_OSError, MP_ERROR_TEXT("can't create thread"));
     }
 
-    // adjust the stack_size to provide room to recover from hitting the limit
-    *stack_size -= 1024;
-
     // add thread to linked list of all threads
     th->ready = 0;
     th->arg = arg;
     th->stack = pxTaskGetStackStart(th->id);
-    th->stack_len = *stack_size / sizeof(StackType_t);
+    th->stack_len = *stack_size / sizeof(uintptr_t);
     th->next = thread;
     thread = th;
+
+    // adjust the stack_size to provide room to recover from hitting the limit
+    *stack_size -= 1024;
 
     mp_thread_mutex_unlock(&thread_mutex);
 }


### PR DESCRIPTION
With this commit the code should work correctly regardless of the size of StackType_t (it's actually 1 byte in size for the esp32's custom FreeRTOS).

Fixes issue #6072.