### PR TITLE
uasyncio: make uasyncio.Event() safe to call from an interrupt v2 (RFC, WIP)

### DIFF
--- a/docs/library/micropython.rst
+++ b/docs/library/micropython.rst
@@ -113,6 +113,14 @@ Functions
    incoming stream of characters that is usually used for the REPL, in case
    that stream is used for other purposes.
 
+.. function:: scheduler_lock()
+
+   Lock the scheduler.  May be nested.
+
+.. function:: scheduler_unlock()
+
+   Unlock the scheduler.  May be nested.
+
 .. function:: schedule(func, arg)
 
    Schedule the function *func* to be executed "very soon".  The function

--- a/extmod/uasyncio/event.py
+++ b/extmod/uasyncio/event.py
@@ -1,9 +1,11 @@
 # MicroPython uasyncio module
 # MIT license; Copyright (c) 2019-2020 Damien P. George
 
+from micropython import scheduler_lock, scheduler_unlock
 from . import core
 
 # Event class for primitive events that can be waited on, set, and cleared
+# The following methods are safe to call from a scheduled callback: is_set, set, clear
 class Event:
     def __init__(self):
         self.state = False  # False=unset; True=set
@@ -13,19 +15,32 @@ class Event:
         return self.state
 
     def set(self):
+        if self.state:
+            return
         # Event becomes set, schedule any tasks waiting on it
+        scheduler_lock()
+        signal = False
         while self.waiting.peek():
             core._task_queue.push_head(self.waiting.pop_head())
+            signal = True
+        if signal:
+            # signal poll to finish
+            core._io_queue.notify.set()
         self.state = True
+        scheduler_unlock()
 
     def clear(self):
         self.state = False
 
     async def wait(self):
+        scheduler_lock()
         if not self.state:
             # Event not set, put the calling task on the event's waiting queue
             self.waiting.push_head(core.cur_task)
             # Set calling task's data to the event's queue so it can be removed if needed
             core.cur_task.data = self.waiting
+            scheduler_unlock()
             yield
+        else:
+            scheduler_unlock()
         return True

--- a/extmod/uasyncio/task.py
+++ b/extmod/uasyncio/task.py
@@ -4,6 +4,7 @@
 # This file contains the core TaskQueue based on a pairing heap, and the core Task class.
 # They can optionally be replaced by C implementations.
 
+import micropython
 from . import core
 
 
@@ -152,6 +153,7 @@ class Task:
         # Can't cancel self (not supported yet).
         if self is core.cur_task:
             raise RuntimeError("can't cancel self")
+        micropython.scheduler_lock()
         # If Task waits on another task then forward the cancel to the one it's waiting on.
         while isinstance(self.data, Task):
             self = self.data
@@ -165,4 +167,5 @@ class Task:
             core._task_queue.remove(self)
             core._task_queue.push_head(self)
         self.data = core.CancelledError
+        micropython.scheduler_unlock()
         return True

--- a/ports/stm32/mpconfigport.h
+++ b/ports/stm32/mpconfigport.h
@@ -376,30 +376,45 @@ static inline mp_uint_t disable_irq(void) {
 #define MICROPY_END_ATOMIC_SECTION(state)  enable_irq(state)
 
 #if MICROPY_PY_THREAD
-#define MICROPY_EVENT_POLL_HOOK \
+#define MICROPY_EVENT_WAIT_ATOMIC \
     do { \
-        extern void mp_handle_pending(bool); \
-        mp_handle_pending(true); \
-        if (pyb_thread_enabled) { \
-            MP_THREAD_GIL_EXIT(); \
-            pyb_thread_yield(); \
-            MP_THREAD_GIL_ENTER(); \
+        mp_uint_t atomic_state = MICROPY_BEGIN_ATOMIC_SECTION(); \
+        if (!mp_sched_any_pending()) { \
+            if (pyb_thread_enabled) { \
+                MICROPY_END_ATOMIC_SECTION(atomic_state); \
+                MP_THREAD_GIL_EXIT(); \
+                pyb_thread_yield(); \
+                MP_THREAD_GIL_ENTER(); \
+            } else { \
+                __WFI(); \
+                MICROPY_END_ATOMIC_SECTION(atomic_state); \
+            } \
         } else { \
-            __WFI(); \
+            MICROPY_END_ATOMIC_SECTION(atomic_state); \
         } \
-    } while (0);
+    } while (0)
 
 #define MICROPY_THREAD_YIELD() pyb_thread_yield()
 #else
-#define MICROPY_EVENT_POLL_HOOK \
+
+#define MICROPY_EVENT_WAIT_ATOMIC \
     do { \
-        extern void mp_handle_pending(bool); \
-        mp_handle_pending(true); \
-        __WFI(); \
-    } while (0);
+        mp_uint_t atomic_state = MICROPY_BEGIN_ATOMIC_SECTION(); \
+        if (!mp_sched_any_pending()) { \
+            __WFI(); \
+        } \
+        MICROPY_END_ATOMIC_SECTION(atomic_state); \
+    } while (0)
 
 #define MICROPY_THREAD_YIELD()
 #endif
+
+#define MICROPY_EVENT_POLL_HOOK \
+    do { \
+        MICROPY_EVENT_WAIT_ATOMIC; \
+        extern void mp_handle_pending(bool); \
+        mp_handle_pending(true); \
+    } while (0);
 
 // The LwIP interface must run at a raised IRQ priority
 #define MICROPY_PY_LWIP_ENTER   uint32_t atomic_state = raise_irq_pri(IRQ_PRI_PENDSV);

--- a/ports/stm32/usbd_hid_interface.c
+++ b/ports/stm32/usbd_hid_interface.c
@@ -26,7 +26,7 @@
 
 #include "usbd_hid_interface.h"
 
-#include "py/mpstate.h"
+#include "py/runtime.h"
 #include "py/mperrno.h"
 #include "py/mphal.h"
 #include "usb.h"

--- a/py/modmicropython.c
+++ b/py/modmicropython.c
@@ -155,6 +155,18 @@ STATIC MP_DEFINE_CONST_FUN_OBJ_1(mp_micropython_kbd_intr_obj, mp_micropython_kbd
 #endif
 
 #if MICROPY_ENABLE_SCHEDULER
+STATIC mp_obj_t mp_micropython_scheduler_lock(void) {
+    mp_sched_lock();
+    return mp_const_none;
+}
+STATIC MP_DEFINE_CONST_FUN_OBJ_0(mp_micropython_scheduler_lock_obj, mp_micropython_scheduler_lock);
+
+STATIC mp_obj_t mp_micropython_scheduler_unlock(void) {
+    mp_sched_unlock();
+    return mp_const_none;
+}
+STATIC MP_DEFINE_CONST_FUN_OBJ_0(mp_micropython_scheduler_unlock_obj, mp_micropython_scheduler_unlock);
+
 STATIC mp_obj_t mp_micropython_schedule(mp_obj_t function, mp_obj_t arg) {
     if (!mp_sched_schedule(function, arg)) {
         mp_raise_msg(&mp_type_RuntimeError, MP_ERROR_TEXT("schedule queue full"));
@@ -199,6 +211,8 @@ STATIC const mp_rom_map_elem_t mp_module_micropython_globals_table[] = {
     { MP_ROM_QSTR(MP_QSTR_kbd_intr), MP_ROM_PTR(&mp_micropython_kbd_intr_obj) },
     #endif
     #if MICROPY_ENABLE_SCHEDULER
+    { MP_ROM_QSTR(MP_QSTR_scheduler_lock), MP_ROM_PTR(&mp_micropython_scheduler_lock_obj) },
+    { MP_ROM_QSTR(MP_QSTR_scheduler_unlock), MP_ROM_PTR(&mp_micropython_scheduler_unlock_obj) },
     { MP_ROM_QSTR(MP_QSTR_schedule), MP_ROM_PTR(&mp_micropython_schedule_obj) },
     #endif
 };

--- a/py/modmicropython.c
+++ b/py/modmicropython.c
@@ -154,19 +154,23 @@ STATIC mp_obj_t mp_micropython_kbd_intr(mp_obj_t int_chr_in) {
 STATIC MP_DEFINE_CONST_FUN_OBJ_1(mp_micropython_kbd_intr_obj, mp_micropython_kbd_intr);
 #endif
 
-#if MICROPY_ENABLE_SCHEDULER
 STATIC mp_obj_t mp_micropython_scheduler_lock(void) {
+    #if MICROPY_ENABLE_SCHEDULER
     mp_sched_lock();
+    #endif
     return mp_const_none;
 }
 STATIC MP_DEFINE_CONST_FUN_OBJ_0(mp_micropython_scheduler_lock_obj, mp_micropython_scheduler_lock);
 
 STATIC mp_obj_t mp_micropython_scheduler_unlock(void) {
+    #if MICROPY_ENABLE_SCHEDULER
     mp_sched_unlock();
+    #endif
     return mp_const_none;
 }
 STATIC MP_DEFINE_CONST_FUN_OBJ_0(mp_micropython_scheduler_unlock_obj, mp_micropython_scheduler_unlock);
 
+#if MICROPY_ENABLE_SCHEDULER
 STATIC mp_obj_t mp_micropython_schedule(mp_obj_t function, mp_obj_t arg) {
     if (!mp_sched_schedule(function, arg)) {
         mp_raise_msg(&mp_type_RuntimeError, MP_ERROR_TEXT("schedule queue full"));
@@ -210,9 +214,9 @@ STATIC const mp_rom_map_elem_t mp_module_micropython_globals_table[] = {
     #if MICROPY_KBD_EXCEPTION
     { MP_ROM_QSTR(MP_QSTR_kbd_intr), MP_ROM_PTR(&mp_micropython_kbd_intr_obj) },
     #endif
-    #if MICROPY_ENABLE_SCHEDULER
     { MP_ROM_QSTR(MP_QSTR_scheduler_lock), MP_ROM_PTR(&mp_micropython_scheduler_lock_obj) },
     { MP_ROM_QSTR(MP_QSTR_scheduler_unlock), MP_ROM_PTR(&mp_micropython_scheduler_unlock_obj) },
+    #if MICROPY_ENABLE_SCHEDULER
     { MP_ROM_QSTR(MP_QSTR_schedule), MP_ROM_PTR(&mp_micropython_schedule_obj) },
     #endif
 };

--- a/py/runtime.h
+++ b/py/runtime.h
@@ -71,8 +71,11 @@ void mp_handle_pending_tail(mp_uint_t atomic_state);
 #if MICROPY_ENABLE_SCHEDULER
 void mp_sched_lock(void);
 void mp_sched_unlock(void);
+#define mp_sched_any_pending() (MP_STATE_VM(sched_state) == MP_SCHED_PENDING)
 #define mp_sched_num_pending() (MP_STATE_VM(sched_len))
 bool mp_sched_schedule(mp_obj_t function, mp_obj_t arg);
+#else
+#define mp_sched_any_pending() (MP_STATE_VM(mp_pending_exception) != MP_OBJ_NULL)
 #endif
 
 // extra printing method specifically for mp_obj_t's which are integral type


### PR DESCRIPTION
This is a slight variation on #6056, making `uasyncio.Event().set()` safe to call from a soft-scheduled callback (with `micropython.schedule()`).

This version does not introduce `socket.socketpair()` for the signalling, but rather hides this in the poll object as a more general "notifier" object.  So you can now do this (independent to asyncio):
```python
import uselect
poll = uselect.poll()

# pass None to register a special notifier entity; returns the notifier
# on unix the notifier is a socketpair, but it could be anything on other ports
notifier = poll.register(None, uselect.POLLIN)

def callback():
    # set the notifier, will be irq/signal/thread safe
    # this will wake any poll.poll() sleeps
    notifier.set()

# sleep until an event
for ev, s in poll.poll():
    if s is notifier:
        # got woken by the notifier, clear it
        s.clear()
```

This abstracts out a lot of the detail of poll and wake-up behaviour and should allow a bare-metal port more flexibility in implementing the notifier (eg with a semaphore).

Apart from the addition of `micropython.scheduler_lock()`/`micropython.scheduler_unlock()`, the only public facing API behaviour that is added here is the ability to call `Event.set()` from a scheduled callback.  This would hopefully allow room for the underlying poll implementation to be completely changed (eg made more efficient) without the user noticing.