### PR TITLE
extmod: implement "uevent" module for event-based polling and use with uasyncio (RFC, WIP)

### DIFF
--- a/extmod/moduevent.c
+++ b/extmod/moduevent.c
@@ -1,0 +1,301 @@
+/*
+ * This file is part of the MicroPython project, http://micropython.org/
+ *
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2020 Damien P. George
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#include "py/runtime.h"
+#include "py/stream.h"
+#include "py/mphal.h"
+
+#if MICROPY_PY_UEVENT && !defined(__unix__)
+
+// This class is similar to selectors but:
+// - supports arbitrary event flags, determined by the underlying object
+// - poll.register() will update flags, not overwrite
+// - one-shot behaviour (hence the name "uevent")
+// - key=poll_entry can have a user method set on it
+// - everything is O(1) (would need a big hash table with selectors to get O(1))
+// - TODO: add poll.notify() for async wake-up
+
+typedef struct _mp_obj_poll_t {
+    mp_obj_base_t base;
+    void *entry_all;
+    volatile void *entry_ready;
+} mp_obj_poll_t;
+
+typedef struct _mp_obj_poll_entry_t {
+    mp_obj_base_t base;
+    mp_obj_t obj;
+    mp_uint_t (*ioctl)(mp_obj_t obj, mp_uint_t request, uintptr_t arg, int *errcode);
+    volatile uint16_t flags_waiting;
+    volatile uint16_t flags_ready;
+    uint16_t flags_user;
+    mp_obj_poll_t *poller;
+    void *next_all;
+    volatile void *next_ready;
+    // User stuff.
+    mp_obj_t user_data;
+    qstr user_method_name;
+    mp_obj_t user_method_obj;
+} mp_obj_poll_entry_t;
+
+STATIC void poll_entry_attr(mp_obj_t self_in, qstr attr, mp_obj_t *dest) {
+    mp_obj_poll_entry_t *self = MP_OBJ_TO_PTR(self_in);
+    if (dest[0] == MP_OBJ_NULL) {
+        // Load attribute.
+        if (attr == MP_QSTR_data) {
+            dest[0] = self->user_data;
+        } else if (attr == MP_QSTR_flags) {
+            dest[0] = MP_OBJ_NEW_SMALL_INT(self->flags_user);
+        } else if (attr == self->user_method_name) {
+            dest[0] = self->user_method_obj;
+            dest[1] = self;
+        }
+    } else if (dest[1] != MP_OBJ_NULL) {
+        // Store attribute.
+        if (attr == MP_QSTR_data) {
+            self->user_data = dest[1];
+            dest[0] = MP_OBJ_NULL; // success
+        } else if (attr != MP_QSTR_flags) {
+            self->user_method_name = attr;
+            self->user_method_obj = dest[1];
+            dest[0] = MP_OBJ_NULL; // success
+        }
+    }
+}
+
+STATIC const mp_obj_type_t mp_type_poll_entry = {
+    { &mp_type_type },
+    .name = MP_QSTR_poll_entry,
+    .attr = poll_entry_attr,
+};
+
+STATIC void poll_event_callback(void *arg_in, mp_uint_t flags) {
+    mp_obj_poll_entry_t *entry = arg_in;
+    if (!(entry->flags_waiting & flags)) {
+        //printf("CB0(%p %x %x %x)", arg_in, flags, entry->flags_waiting, entry->flags_ready);
+        return;
+    }
+    //printf("CB1(%p %x %x %x)", arg_in, flags, entry->flags_waiting, entry->flags_ready);
+    mp_uint_t atomic_state = MICROPY_BEGIN_ATOMIC_SECTION();
+    uint16_t old_flags_ready = entry->flags_ready;
+    entry->flags_ready |= entry->flags_waiting & flags;
+    entry->flags_waiting &= ~flags;
+    if (old_flags_ready == 0 && entry->flags_ready) {
+        entry->next_ready = entry->poller->entry_ready;
+        entry->poller->entry_ready = entry;
+    }
+    MICROPY_END_ATOMIC_SECTION(atomic_state);
+}
+
+STATIC mp_obj_poll_entry_t *poll_entry_new(void) {
+    mp_obj_poll_entry_t *self = m_new_obj(mp_obj_poll_entry_t);
+    self->base.type = &mp_type_poll_entry;
+    return self;
+}
+
+STATIC void poll_entry_init(mp_obj_poll_entry_t *self, mp_obj_t obj, mp_obj_poll_t *poller) {
+    self->obj = obj;
+    self->ioctl = mp_get_stream_raise(obj, MP_STREAM_OP_IOCTL)->ioctl;
+    self->flags_waiting = 0;
+    self->flags_ready = 0;
+    self->flags_user = 0;
+    self->poller = poller;
+    self->user_data = mp_const_none; // TODO consider not resetting this to reuse prev value
+    self->user_method_name = MP_QSTR_NULL;
+}
+
+STATIC void poll_print(const mp_print_t *print, mp_obj_t self_in, mp_print_kind_t kind) {
+    mp_obj_poll_t *self = MP_OBJ_TO_PTR(self_in);
+    size_t alloc = 0;
+    size_t waiting = 0;
+    size_t ready = 0;
+    for (mp_obj_poll_entry_t *entry = self->entry_all; entry != NULL; entry = entry->next_all) {
+        ++alloc;
+        if (entry->flags_waiting != 0) {
+            ++waiting;
+        }
+        if (entry->flags_ready != 0) {
+            ++ready;
+        }
+    }
+    mp_printf(print, "<poll alloc=%d waiting=%d ready=%d>", alloc, waiting, ready);
+}
+
+STATIC mp_obj_t poll_iternext(mp_obj_t self_in) {
+    mp_obj_poll_t *self = MP_OBJ_TO_PTR(self_in);
+
+    if (self->entry_ready != NULL) {
+        mp_uint_t atomic_state = MICROPY_BEGIN_ATOMIC_SECTION();
+        mp_obj_poll_entry_t *entry = (mp_obj_poll_entry_t *)self->entry_ready;
+        self->entry_ready = entry->next_ready;
+        entry->flags_user = entry->flags_ready;
+        entry->flags_ready = 0;
+        // if flags_waiting == 0 then put on entry_free list?
+        MICROPY_END_ATOMIC_SECTION(atomic_state);
+        return MP_OBJ_FROM_PTR(entry);
+    }
+
+    return MP_OBJ_STOP_ITERATION;
+}
+
+// register(obj[, eventmask])
+STATIC mp_obj_t poll_register(size_t n_args, const mp_obj_t *args) {
+    mp_obj_poll_t *self = MP_OBJ_TO_PTR(args[0]);
+    mp_uint_t flags;
+    if (n_args == 3) {
+        flags = mp_obj_get_int(args[2]);
+    } else {
+        flags = 0xff;
+    }
+    mp_obj_poll_entry_t *entry;
+    if (mp_obj_get_type(args[1]) == &mp_type_poll_entry) {
+        entry = MP_OBJ_TO_PTR(args[1]);
+    } else {
+        /*
+        mp_stream_event_t stream_event;
+        mp_int_t ret = entry->ioctl(entry->obj, MP_STREAM_GET_EVENT, (uintptr_t)&stream_event, &errcode);
+        if (ret == 0 && stream_event.callback == poll_event_callback) {
+            entry = stream_event.arg;
+            check entry.poller == self and entry.obj = args[1]
+        }
+        */
+
+        mp_obj_poll_entry_t *entry_free = NULL;
+        for (entry = self->entry_all; entry != NULL; entry = entry->next_all) {
+            if (entry->obj == args[1]) {
+                break;
+            }
+            if (entry->flags_waiting == 0 && entry->flags_ready == 0) {
+                // reuse memory
+                entry_free = entry;
+            }
+        }
+        if (entry == NULL) {
+            if (entry_free == NULL) {
+                entry = poll_entry_new();
+                entry->next_all = self->entry_all;
+                self->entry_all = entry;
+            }
+            poll_entry_init(entry, args[1], self);
+        }
+    }
+
+    mp_uint_t atomic_state = MICROPY_BEGIN_ATOMIC_SECTION();
+    entry->flags_waiting |= flags;
+    MICROPY_END_ATOMIC_SECTION(atomic_state);
+
+    int errcode;
+    mp_stream_event_t stream_event = { entry->flags_waiting == 0 ? NULL : poll_event_callback, entry };
+    mp_int_t ret = entry->ioctl(entry->obj, MP_STREAM_SET_EVENT, (uintptr_t)&stream_event, &errcode);
+    if (ret == MP_STREAM_ERROR) {
+        mp_raise_OSError(errcode);
+    }
+    if (entry->flags_waiting & ret) {
+        poll_event_callback(entry, ret);
+    }
+
+    return MP_OBJ_FROM_PTR(entry);
+}
+STATIC MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(poll_register_obj, 2, 3, poll_register);
+
+STATIC mp_obj_t poll_wait_ms(size_t n_args, const mp_obj_t *args) {
+    mp_obj_poll_t *self = MP_OBJ_TO_PTR(args[0]);
+
+    // work out timeout
+    mp_uint_t timeout_ms = -1;
+    if (n_args >= 2 && args[1] != mp_const_none) {
+        mp_int_t timeout_i = mp_obj_get_int(args[1]);
+        if (timeout_i >= 0) {
+            timeout_ms = timeout_i;
+        }
+    }
+
+    mp_uint_t start_tick = mp_hal_ticks_ms();
+    for (;;) {
+        if (self->entry_ready != NULL
+            || (timeout_ms != -1 && mp_hal_ticks_ms() - start_tick >= timeout_ms)) {
+            break;
+        }
+        MICROPY_EVENT_POLL_HOOK
+    }
+
+    return args[0];
+}
+STATIC MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(poll_wait_ms_obj, 1, 2, poll_wait_ms);
+
+STATIC mp_obj_t poll_dump(mp_obj_t self_in) {
+    mp_obj_poll_t *self = MP_OBJ_TO_PTR(self_in);
+    printf("all:");
+    for (mp_obj_poll_entry_t *entry = self->entry_all; entry != NULL; entry = entry->next_all) {
+        printf(" (%p %x:%x)", MP_OBJ_TO_PTR(entry->obj), entry->flags_waiting, entry->flags_ready);
+    }
+    printf("\nready:");
+    for (volatile mp_obj_poll_entry_t *entry = self->entry_ready; entry != NULL; entry = entry->next_ready) {
+        printf(" (%p %x:%x)", MP_OBJ_TO_PTR(entry->obj), entry->flags_waiting, entry->flags_ready);
+    }
+    printf("\n");
+    return mp_const_none;
+}
+STATIC MP_DEFINE_CONST_FUN_OBJ_1(poll_dump_obj, poll_dump);
+
+STATIC const mp_rom_map_elem_t poll_locals_dict_table[] = {
+    { MP_ROM_QSTR(MP_QSTR_register), MP_ROM_PTR(&poll_register_obj) },
+    { MP_ROM_QSTR(MP_QSTR_wait_ms), MP_ROM_PTR(&poll_wait_ms_obj) },
+    { MP_ROM_QSTR(MP_QSTR_dump), MP_ROM_PTR(&poll_dump_obj) },
+};
+STATIC MP_DEFINE_CONST_DICT(poll_locals_dict, poll_locals_dict_table);
+
+STATIC const mp_obj_type_t mp_type_poll = {
+    { &mp_type_type },
+    .name = MP_QSTR_poll,
+    .print = poll_print,
+    .getiter = mp_identity_getiter,
+    .iternext = poll_iternext,
+    .locals_dict = (mp_obj_dict_t *)&poll_locals_dict,
+};
+
+// poll()
+STATIC mp_obj_t mp_uevent_poll(void) {
+    mp_obj_poll_t *self = m_new_obj(mp_obj_poll_t);
+    self->base.type = &mp_type_poll;
+    self->entry_all = NULL;
+    self->entry_ready = NULL;
+    return MP_OBJ_FROM_PTR(self);
+}
+MP_DEFINE_CONST_FUN_OBJ_0(mp_uevent_poll_obj, mp_uevent_poll);
+
+STATIC const mp_rom_map_elem_t mp_module_uevent_globals_table[] = {
+    { MP_ROM_QSTR(MP_QSTR___name__), MP_ROM_QSTR(MP_QSTR_uevent) },
+    { MP_ROM_QSTR(MP_QSTR_poll), MP_ROM_PTR(&mp_uevent_poll_obj) },
+};
+
+STATIC MP_DEFINE_CONST_DICT(mp_module_uevent_globals, mp_module_uevent_globals_table);
+
+const mp_obj_module_t mp_module_uevent = {
+    .base = { &mp_type_module },
+    .globals = (mp_obj_dict_t *)&mp_module_uevent_globals,
+};
+
+#endif // MICROPY_PY_UEVENT

--- a/extmod/moduevent_poll.c
+++ b/extmod/moduevent_poll.c
@@ -1,0 +1,262 @@
+/*
+ * This file is part of the MicroPython project, http://micropython.org/
+ *
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2020 Damien P. George
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#include "py/runtime.h"
+#include "py/stream.h"
+#include "py/mphal.h"
+
+#if MICROPY_PY_UEVENT && defined(__unix__)
+
+#include <poll.h>
+
+typedef struct _mp_obj_poll_t {
+    mp_obj_base_t base;
+    unsigned short alloc;
+    unsigned short len;
+    unsigned short iter_idx;
+    struct pollfd *entries;
+    struct _mp_obj_poll_entry_t *poll_entries;
+} mp_obj_poll_t;
+
+typedef struct _mp_obj_poll_entry_t {
+    mp_obj_base_t base;
+    mp_obj_t obj;
+    uint16_t flags;
+    // User stuff.
+    mp_obj_t user_data;
+    qstr user_method_name;
+    mp_obj_t user_method_obj;
+} mp_obj_poll_entry_t;
+
+STATIC void poll_entry_attr(mp_obj_t self_in, qstr attr, mp_obj_t *dest) {
+    mp_obj_poll_entry_t *self = MP_OBJ_TO_PTR(self_in);
+    if (dest[0] == MP_OBJ_NULL) {
+        // Load attribute.
+        if (attr == MP_QSTR_data) {
+            dest[0] = self->user_data;
+        } else if (attr == MP_QSTR_flags) {
+            dest[0] = MP_OBJ_NEW_SMALL_INT(self->flags);
+        } else if (attr == self->user_method_name) {
+            dest[0] = self->user_method_obj;
+            dest[1] = self;
+        }
+    } else if (dest[1] != MP_OBJ_NULL) {
+        // Store attribute.
+        if (attr == MP_QSTR_data) {
+            self->user_data = dest[1];
+            dest[0] = MP_OBJ_NULL; // success
+        } else if (attr != MP_QSTR_flags) {
+            self->user_method_name = attr;
+            self->user_method_obj = dest[1];
+            dest[0] = MP_OBJ_NULL; // success
+        }
+    }
+}
+
+STATIC const mp_obj_type_t mp_type_poll_entry = {
+    { &mp_type_type },
+    .name = MP_QSTR_poll_entry,
+    .attr = poll_entry_attr,
+};
+
+STATIC void poll_entry_init(mp_obj_poll_entry_t *self, mp_obj_t obj) {
+    self->base.type = &mp_type_poll_entry;
+    self->obj = obj;
+    self->flags = 0;
+    self->user_data = mp_const_none;
+    self->user_method_name = MP_QSTR_NULL;
+}
+
+STATIC mp_obj_t poll_iternext(mp_obj_t self_in) {
+    mp_obj_poll_t *self = MP_OBJ_TO_PTR(self_in);
+
+    struct pollfd *entries = self->entries + self->iter_idx;
+    for (int i = self->iter_idx; i < self->len; i++, entries++) {
+        self->iter_idx++;
+        if (entries->revents != 0) {
+            mp_obj_poll_entry_t *poll_entry = &self->poll_entries[i];
+            poll_entry->flags = 0;
+            if (entries->revents & POLLIN) {
+                poll_entry->flags |= 1;
+            }
+            if (entries->revents & POLLOUT) {
+                poll_entry->flags |= 2;
+            }
+            entries->events &= ~entries->revents;
+            entries->revents = 0;
+            return MP_OBJ_FROM_PTR(poll_entry);
+        }
+    }
+
+    return MP_OBJ_STOP_ITERATION;
+}
+
+// register(obj[, eventmask])
+STATIC mp_obj_t poll_register(size_t n_args, const mp_obj_t *args) {
+    mp_obj_poll_t *self = MP_OBJ_TO_PTR(args[0]);
+
+    const mp_stream_p_t *stream_p = mp_get_stream_raise(args[1], MP_STREAM_OP_IOCTL);
+    int err;
+    mp_uint_t res = stream_p->ioctl(args[1], MP_STREAM_GET_FILENO, 0, &err);
+    if (res == MP_STREAM_ERROR) {
+        mp_raise_OSError(err);
+    }
+    int fd = res;
+
+    mp_uint_t flags;
+    if (n_args == 3) {
+        flags = mp_obj_get_int(args[2]);
+    } else {
+        flags = 0xff;
+    }
+
+    struct pollfd *free_slot = NULL;
+
+    struct pollfd *entry = self->entries;
+    int idx = -1;
+    for (int i = 0; i < self->len; i++, entry++) {
+        int entry_fd = entry->fd;
+        if (entry_fd == fd) {
+            free_slot = entry;
+            idx = i;
+            break;
+        }
+        if (entry_fd == -1) {
+            free_slot = entry;
+        }
+    }
+
+    if (idx == -1) {
+        if (free_slot == NULL) {
+            if (self->len >= self->alloc) {
+                self->entries = m_renew(struct pollfd, self->entries, self->alloc, self->alloc + 4);
+                self->poll_entries = m_renew(mp_obj_poll_entry_t, self->poll_entries, self->alloc, self->alloc + 4);
+                self->alloc += 4;
+            }
+            free_slot = &self->entries[self->len++];
+        }
+
+        idx = free_slot - self->entries;
+        poll_entry_init(&self->poll_entries[idx], args[1]);
+        free_slot->fd = fd;
+    }
+
+    if (flags & 1) {
+        free_slot->events |= POLLIN;
+    }
+    if (flags & 2) {
+        free_slot->events |= POLLOUT;
+    }
+
+    return MP_OBJ_FROM_PTR(&self->poll_entries[idx]);
+}
+STATIC MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(poll_register_obj, 2, 3, poll_register);
+
+STATIC mp_obj_t poll_wait_ms(size_t n_args, const mp_obj_t *args) {
+    mp_obj_poll_t *self = MP_OBJ_TO_PTR(args[0]);
+
+    // work out timeout
+    mp_uint_t timeout_ms = -1;
+    if (n_args >= 2 && args[1] != mp_const_none) {
+        mp_int_t timeout_i = mp_obj_get_int(args[1]);
+        if (timeout_i >= 0) {
+            timeout_ms = timeout_i;
+        }
+    }
+
+    /*
+    printf("pollfd:");
+    struct pollfd *entry = self->entries;
+    for (int i = 0; i < self->len; i++, entry++) {
+        printf("(%d %d %d)", entry->fd, entry->events, entry->revents);
+    }
+    printf("\n");
+    */
+
+    for (;;) {
+        MP_THREAD_GIL_EXIT();
+        int n_ready = poll(self->entries, self->len, timeout_ms);
+        MP_THREAD_GIL_ENTER();
+        if (ret != -1) {
+            break;
+        }
+        if (errno == EINTR) {
+            mp_handle_pending(true);
+            /*
+            if (self->notify) {
+                break;
+            }
+            */
+        } else {
+            mp_raise_OSError(errno);
+        }
+    }
+
+    self->iter_idx = 0;
+
+    return args[0];
+}
+STATIC MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(poll_wait_ms_obj, 1, 2, poll_wait_ms);
+
+STATIC const mp_rom_map_elem_t poll_locals_dict_table[] = {
+    { MP_ROM_QSTR(MP_QSTR_register), MP_ROM_PTR(&poll_register_obj) },
+    { MP_ROM_QSTR(MP_QSTR_wait_ms), MP_ROM_PTR(&poll_wait_ms_obj) },
+};
+STATIC MP_DEFINE_CONST_DICT(poll_locals_dict, poll_locals_dict_table);
+
+STATIC const mp_obj_type_t mp_type_poll = {
+    { &mp_type_type },
+    .name = MP_QSTR_poll,
+    .getiter = mp_identity_getiter,
+    .iternext = poll_iternext,
+    .locals_dict = (mp_obj_dict_t *)&poll_locals_dict,
+};
+
+// poll()
+STATIC mp_obj_t mp_uevent_poll(void) {
+    mp_obj_poll_t *self = m_new_obj(mp_obj_poll_t);
+    self->base.type = &mp_type_poll;
+    self->alloc = 4;
+    self->len = 0;
+    self->entries = m_new(struct pollfd, self->alloc);
+    self->poll_entries = m_new(mp_obj_poll_entry_t, self->alloc);
+    return MP_OBJ_FROM_PTR(self);
+}
+MP_DEFINE_CONST_FUN_OBJ_0(mp_uevent_poll_obj, mp_uevent_poll);
+
+STATIC const mp_rom_map_elem_t mp_module_uevent_globals_table[] = {
+    { MP_ROM_QSTR(MP_QSTR___name__), MP_ROM_QSTR(MP_QSTR_uevent) },
+    { MP_ROM_QSTR(MP_QSTR_poll), MP_ROM_PTR(&mp_uevent_poll_obj) },
+};
+
+STATIC MP_DEFINE_CONST_DICT(mp_module_uevent_globals, mp_module_uevent_globals_table);
+
+const mp_obj_module_t mp_module_uevent = {
+    .base = { &mp_type_module },
+    .globals = (mp_obj_dict_t *)&mp_module_uevent_globals,
+};
+
+#endif // MICROPY_PY_UEVENT

--- a/extmod/virtpin.h
+++ b/extmod/virtpin.h
@@ -28,12 +28,13 @@
 
 #include "py/obj.h"
 
-#define MP_PIN_READ   (1)
-#define MP_PIN_WRITE  (2)
-#define MP_PIN_INPUT  (3)
-#define MP_PIN_OUTPUT (4)
+// These need to be distinct from any MP_STREAM_xxx ioctl request codes.
+#define MP_PIN_READ   (101)
+#define MP_PIN_WRITE  (102)
+#define MP_PIN_INPUT  (103)
+#define MP_PIN_OUTPUT (104)
 
-// Pin protocol
+// Pin protocol, a subset of the stream protocol.
 typedef struct _mp_pin_p_t {
     mp_uint_t (*ioctl)(mp_obj_t obj, mp_uint_t request, uintptr_t arg, int *errcode);
 } mp_pin_p_t;

--- a/ports/stm32/extint.h
+++ b/ports/stm32/extint.h
@@ -61,6 +61,10 @@
 
 void extint_init0(void);
 
+void extint_register_event(const pin_obj_t *pin, uint32_t mode);
+struct _mp_stream_event_t *extint_get_stream_event(const pin_obj_t *pin);
+uint32_t extint_get_event_count(const pin_obj_t *pin, uint32_t *timestamp_us, bool clear);
+
 uint extint_register(mp_obj_t pin_obj, uint32_t mode, uint32_t pull, mp_obj_t callback_obj, bool override_callback_obj);
 void extint_register_pin(const pin_obj_t *pin, uint32_t mode, bool hard_irq, mp_obj_t callback_obj);
 

--- a/ports/zephyr/main.c
+++ b/ports/zephyr/main.c
@@ -51,6 +51,7 @@
 #include "extmod/vfs.h"
 #endif
 
+#include "modmachine.h"
 #include "modzephyr.h"
 
 #ifdef TEST
@@ -162,6 +163,9 @@ soft_reset:
     }
 
     printf("soft reboot\n");
+
+    machine_pin_deinit();
+
     goto soft_reset;
 
     return 0;

--- a/ports/zephyr/modmachine.h
+++ b/ports/zephyr/modmachine.h
@@ -11,6 +11,9 @@ typedef struct _machine_pin_obj_t {
     mp_obj_base_t base;
     struct device *port;
     uint32_t pin;
+    struct _machine_pin_irq_obj_t *irq;
 } machine_pin_obj_t;
+
+void machine_pin_deinit(void);
 
 #endif // MICROPY_INCLUDED_ZEPHYR_MODMACHINE_H

--- a/ports/zephyr/mpconfigport.h
+++ b/ports/zephyr/mpconfigport.h
@@ -119,7 +119,8 @@ typedef long mp_off_t;
 #define MP_STATE_PORT MP_STATE_VM
 
 #define MICROPY_PORT_ROOT_POINTERS \
-    const char *readline_hist[8];
+    const char *readline_hist[8]; \
+    void *machine_pin_irq_list; /* linked list of machine_pin_irq_obj_t */
 
 extern const struct _mp_obj_module_t mp_module_machine;
 extern const struct _mp_obj_module_t mp_module_time;
@@ -169,3 +170,6 @@ extern const struct _mp_obj_module_t mp_module_zsensor;
 // extra built in names to add to the global namespace
 #define MICROPY_PORT_BUILTINS \
     { MP_ROM_QSTR(MP_QSTR_open), MP_ROM_PTR(&mp_builtin_open_obj) },
+
+#define MICROPY_BEGIN_ATOMIC_SECTION irq_lock
+#define MICROPY_END_ATOMIC_SECTION irq_unlock

--- a/py/builtin.h
+++ b/py/builtin.h
@@ -105,6 +105,7 @@ extern const mp_obj_dict_t mp_module_builtins_globals;
 // extmod modules
 extern const mp_obj_module_t mp_module_uasyncio;
 extern const mp_obj_module_t mp_module_uerrno;
+extern const mp_obj_module_t mp_module_uevent;
 extern const mp_obj_module_t mp_module_uctypes;
 extern const mp_obj_module_t mp_module_uzlib;
 extern const mp_obj_module_t mp_module_ujson;

--- a/py/mpconfig.h
+++ b/py/mpconfig.h
@@ -1261,6 +1261,11 @@ typedef double mp_float_t;
 #define MICROPY_PY_UERRNO_ERRORCODE (1)
 #endif
 
+// Whether to provide the "uevent" module
+#ifndef MICROPY_PY_UEVENT
+#define MICROPY_PY_UEVENT (1)
+#endif
+
 // Whether to provide "uselect" module (baremetal implementation)
 #ifndef MICROPY_PY_USELECT
 #define MICROPY_PY_USELECT (0)

--- a/py/objmodule.c
+++ b/py/objmodule.c
@@ -176,6 +176,9 @@ STATIC const mp_rom_map_elem_t mp_builtin_module_table[] = {
     #if MICROPY_PY_UERRNO
     { MP_ROM_QSTR(MP_QSTR_uerrno), MP_ROM_PTR(&mp_module_uerrno) },
     #endif
+    #if MICROPY_PY_UEVENT
+    { MP_ROM_QSTR(MP_QSTR_uevent), MP_ROM_PTR(&mp_module_uevent) },
+    #endif
     #if MICROPY_PY_UCTYPES
     { MP_ROM_QSTR(MP_QSTR_uctypes), MP_ROM_PTR(&mp_module_uctypes) },
     #endif

--- a/py/py.mk
+++ b/py/py.mk
@@ -170,6 +170,7 @@ PY_CORE_O_BASENAME = $(addprefix py/,\
 PY_EXTMOD_O_BASENAME = \
 	extmod/moduasyncio.o \
 	extmod/moductypes.o \
+	extmod/moduevent.o \
 	extmod/modujson.o \
 	extmod/modure.o \
 	extmod/moduzlib.o \

--- a/py/py.mk
+++ b/py/py.mk
@@ -171,6 +171,7 @@ PY_EXTMOD_O_BASENAME = \
 	extmod/moduasyncio.o \
 	extmod/moductypes.o \
 	extmod/moduevent.o \
+	extmod/moduevent_poll.o \
 	extmod/modujson.o \
 	extmod/modure.o \
 	extmod/moduzlib.o \

--- a/py/stream.h
+++ b/py/stream.h
@@ -69,9 +69,9 @@ struct mp_stream_seek_t {
 typedef struct _mp_stream_p_t {
     // On error, functions should return MP_STREAM_ERROR and fill in *errcode (values
     // are implementation-dependent, but will be exposed to user, e.g. via exception).
+    mp_uint_t (*ioctl)(mp_obj_t obj, mp_uint_t request, uintptr_t arg, int *errcode);
     mp_uint_t (*read)(mp_obj_t obj, void *buf, mp_uint_t size, int *errcode);
     mp_uint_t (*write)(mp_obj_t obj, const void *buf, mp_uint_t size, int *errcode);
-    mp_uint_t (*ioctl)(mp_obj_t obj, mp_uint_t request, uintptr_t arg, int *errcode);
     mp_uint_t is_text : 1; // default is bytes, set this for text stream
 } mp_stream_p_t;
 

--- a/py/stream.h
+++ b/py/stream.h
@@ -44,6 +44,15 @@
 #define MP_STREAM_SET_DATA_OPTS (9)  // Set data/message options
 #define MP_STREAM_GET_FILENO    (10) // Get fileno of underlying file
 
+// This is not really stream-based so should be elsewhere
+#define MP_STREAM_SET_EVENT     (11)
+#define MP_STREAM_EVENT_READ    (1)
+#define MP_STREAM_EVENT_WRITE   (2)
+typedef struct _mp_stream_event_t {
+    void (*callback)(void *arg, mp_uint_t flags);
+    void *arg;
+} mp_stream_event_t;
+
 // These poll ioctl values are compatible with Linux
 #define MP_STREAM_POLL_RD       (0x0001)
 #define MP_STREAM_POLL_WR       (0x0004)


### PR DESCRIPTION
This is an alternative to #6106 to allow arbitrary events to hook into uasyncio, not just streams that are readable/writable.

The idea here is to provide a new MicroPython-specific module called `uevent` which is similar in spirit to `select` and `selectors` but optimised for the needs of an async scheduler.  It's completely independent to `uasyncio` but used by it to wait for IO events.

The use of `uevent` goes like this:
```python
import uevent
poller = uevent.poll()
entry = poller.register(object, READ) # register object for READ events
poller.register(entry, WRITE) # also enable WRITE events on this object
entry.data = 'my data' # store arbitrary data into the entry

# wait for any events then iterate through the available ones
for entry in poller.wait_ms(timeout):
    print(entry.data)
```
It looks very similar to `select.poll` but has some important differences which make it better suited to handling events:
- registering an object updates (with logical or) the event flags if the object is already registered, it doesn't overwrite them
- once an event fires that event flag is cleared (but other event flags, if any, remain set for the next wait)
- each registered object is associated with additional user state for efficiency (to make things O(1))

The important thin with `uevent` is that on bare-metal it's implemented fully as O(1) for all operations (registering, modifying, waiting, getting next available event).  It does this by providing registered objects with a callback to call when they have an event of interest.

The PR here includes working code for stm32 (sockets and native pin events), unix (file descriptors only) and zephyr (native pin events).

The code is still very much WIP and proof-of-concept, but the highlights are:
- `extmod/modlwip.c` has very minimal changes to make it event driven, ie provide callbacks into uevent when sockets become readable/writable (so no more busy loop polling!)
- the code for zephyr to wait is literally just a `k_sem_take(&sem, timeout)`, with the semaphore set asynchronously by a pin interrupt
- the code for stm32 to wait is a "sleepy loop" which checks for any pending events (a simple check of the pointer of a linked list != NULL) or if the timeout has passed, and then does `MICROPY_EVENT_POLL_HOOK` (which could be just a WFI and it'd still work)
- on unix it still uses poll

The code to implement an async pin object with this PR is:
```python
class AsyncPin:
    def __init__(self, pin, trigger):
        self.pin = pin
        self.pin.set_event(trigger)

    async def wait_edge(self):
        yield asyncio.core._io_queue._enqueue(self.pin, 0)
        return self.pin.get_event()

async def main():
    usr = AsyncPin(Pin("USR"), Pin.IRQ_FALLING)
    await usr.wait_edge()

asyncio.run(main())
```
Note that one can't directly await on a raw `machine.Pin` object, instead such objects are registered with the poller and the poller wakes when the raw pin object has some kind of event.  It's then up to the `AsyncPin` wrapper to manage that event (in the case above it just retrieves it with `pin.get_event()` which returns the number of edges since the last call).

The code here doesn't yet implement a way to call `Event.set()` from a soft-scheduled callback, like #6106 does, but I still think that's a useful feature to have more control over waking asyncio from an IRQ.

In summary: the PR here reimplements the `select` module as `uevent` and makes it event/callback based (on bare-metal) rather than busy-loop polling.  And then builds on this to add events to `machine.Pin` objects so they can be registered with `uevent` and hence integrated with `uasyncio`.