### PR TITLE
unix/btstack_usb.c: Allow choosing adaptor via env var.

### DIFF
--- a/examples/bluetooth/ble_temperature_central.py
+++ b/examples/bluetooth/ble_temperature_central.py
@@ -128,7 +128,7 @@ class BLETemperatureCentral:
             if conn_handle == self._conn_handle and uuid == _ENV_SENSE_UUID:
                 self._start_handle, self._end_handle = start_handle, end_handle
 
-        elif event == _IRQ_GATTC_SERVICES_DONE:
+        elif event == _IRQ_GATTC_SERVICE_DONE:
             # Service query complete.
             if self._start_handle and self._end_handle:
                 self._ble.gattc_discover_characteristics(
@@ -143,7 +143,7 @@ class BLETemperatureCentral:
             if conn_handle == self._conn_handle and uuid == _TEMP_UUID:
                 self._value_handle = value_handle
 
-        elif event == _IRQ_GATTC_CHARACTERISTICS_DONE:
+        elif event == _IRQ_GATTC_CHARACTERISTIC_DONE:
             # Characteristic query complete.
             if self._value_handle:
                 # We've finished connecting and discovering device, fire the connect callback.

--- a/ports/unix/btstack_usb.c
+++ b/ports/unix/btstack_usb.c
@@ -110,7 +110,23 @@ void mp_bluetooth_btstack_port_init(void) {
         btstack_run_loop_embedded_get_instance()->init();
     }
 
-    // TODO: allow setting USB device path via cmdline/env var.
+    // MICROPYBTUSB can be a ':'' or '-' separated port list.
+    char *path = getenv("MICROPYBTUSB");
+    if (path != NULL) {
+        uint8_t usb_path[7] = {0};
+        size_t usb_path_len = 0;
+
+        while (usb_path_len < MP_ARRAY_SIZE(usb_path)) {
+            char *delimiter;
+            usb_path[usb_path_len++] = strtol(path, &delimiter, 16);
+            if (!delimiter || (*delimiter != ':' && *delimiter != '-')) {
+                break;
+            }
+            path = delimiter + 1;
+        }
+
+        hci_transport_usb_set_path(usb_path_len, usb_path);
+    }
 
     // hci_dump_open(NULL, HCI_DUMP_STDOUT);
     hci_init(hci_transport_usb_instance(), NULL);


### PR DESCRIPTION
This allows you to run (for example):

```
env MICROPYBTUSB=2-2 ./micropython-dev ../../examples/bluetooth/ble_temperature_central.py
```

to choose a specific USB path.

Additionally, this PR enables the BLE multitests to run entirely with the unix port, e.g.

```
env MICROPY_MICROPYTHON=../ports/unix/micropython-dev ./run-multitests.py -i micropython,MICROPYBTUSB=01 -i micropython,MICROPYBTUSB=02:02 multi_bluetooth/ble_*.py
```

That's using two different adaptors, a BCM20702A and a CSR8510 (as suggested by @mringwal, thanks!), which both seem to work well.

Questions:
 - We seem to have two conventions for env vars. e.g. `MICROPY_MICROPYTHON` for run-multitests.py, but generally the unix port uses `MICROPYPATH` or `MICROPYINSPECT`?
 - Is this a reasonable (ab)use of the `-i` flag to run-multitest.py?