### PR TITLE
extend carrier frequency into RMT class

### DIFF
--- a/ports/esp32/esp32_rmt.c
+++ b/ports/esp32/esp32_rmt.c
@@ -52,7 +52,7 @@ typedef struct _esp32_rmt_obj_t {
     uint8_t channel_id;
     gpio_num_t pin;
     uint8_t clock_div;
-    uint8_t carrier_en;
+    bool carrier_en;
     uint8_t carrier_duty_percent;
     uint8_t carrier_freq_hz;
     mp_uint_t num_items;

--- a/ports/esp32/esp32_rmt.c
+++ b/ports/esp32/esp32_rmt.c
@@ -53,8 +53,8 @@ typedef struct _esp32_rmt_obj_t {
     gpio_num_t pin;
     uint8_t clock_div;
     bool carrier_en;
-    uint8_t carrier_duty_percent;
-    uint8_t carrier_freq_hz;
+    uint16_t carrier_duty_percent;
+    uint32_t carrier_freq_hz;
     mp_uint_t num_items;
     rmt_item32_t *items;
 } esp32_rmt_obj_t;

--- a/ports/esp32/esp32_rmt.c
+++ b/ports/esp32/esp32_rmt.c
@@ -73,7 +73,7 @@ STATIC mp_obj_t esp32_rmt_make_new(const mp_obj_type_t *type, size_t n_args, siz
     mp_uint_t channel_id = args[0].u_int;
     gpio_num_t pin_id = machine_pin_get_id(args[1].u_obj);
     mp_uint_t clock_div = args[2].u_int;
-    mp_uint_t carrier_en = args[3].u_bool;
+    bool carrier_en = args[3].u_bool;
     mp_uint_t carrier_duty_percent = args[4].u_int;
     mp_uint_t carrier_freq_hz = args[5].u_int;
 

--- a/ports/esp32/esp32_rmt.c
+++ b/ports/esp32/esp32_rmt.c
@@ -85,11 +85,11 @@ STATIC mp_obj_t esp32_rmt_make_new(const mp_obj_type_t *type, size_t n_args, siz
     config.mem_block_num = 1;
     config.tx_config.loop_en = 0;
 
-    config.tx_config.carrier_en = 0;
+    config.tx_config.carrier_en = true;
     config.tx_config.idle_output_en = 1;
     config.tx_config.idle_level = 0;
-    config.tx_config.carrier_duty_percent = 0;
-    config.tx_config.carrier_freq_hz = 0;
+    config.tx_config.carrier_duty_percent = 50;
+    config.tx_config.carrier_freq_hz = 38000;
     config.tx_config.carrier_level = 1;
 
     config.clk_div = self->clock_div;

--- a/ports/esp32/esp32_rmt.c
+++ b/ports/esp32/esp32_rmt.c
@@ -64,7 +64,7 @@ STATIC mp_obj_t esp32_rmt_make_new(const mp_obj_type_t *type, size_t n_args, siz
         { MP_QSTR_id,        MP_ARG_REQUIRED | MP_ARG_INT, {.u_int = -1} },
         { MP_QSTR_pin,       MP_ARG_REQUIRED | MP_ARG_KW_ONLY | MP_ARG_OBJ, {.u_obj = mp_const_none} },
         { MP_QSTR_clock_div,                   MP_ARG_KW_ONLY | MP_ARG_INT, {.u_int = 8} }, // 100ns resolution
-        { MP_QSTR_carrier_en,                  MP_ARG_KW_ONLY | MP_ARG_INT, {.u_int = 0} },
+        { MP_QSTR_carrier_en,                  MP_ARG_KW_ONLY | MP_ARG_BOOL, {.u_bool = false} },
         { MP_QSTR_carrier_duty_percent,        MP_ARG_KW_ONLY | MP_ARG_INT, {.u_int = 50} },
         { MP_QSTR_carrier_freq_hz,             MP_ARG_KW_ONLY | MP_ARG_INT, {.u_int = 38000} },
     };
@@ -73,9 +73,10 @@ STATIC mp_obj_t esp32_rmt_make_new(const mp_obj_type_t *type, size_t n_args, siz
     mp_uint_t channel_id = args[0].u_int;
     gpio_num_t pin_id = machine_pin_get_id(args[1].u_obj);
     mp_uint_t clock_div = args[2].u_int;
-    mp_uint_t carrier_en = args[3].u_int;
+    mp_uint_t carrier_en = args[3].u_bool;
     mp_uint_t carrier_duty_percent = args[4].u_int;
     mp_uint_t carrier_freq_hz = args[5].u_int;
+
 
     if (clock_div < 1 || clock_div > 255) {
         mp_raise_ValueError(MP_ERROR_TEXT("clock_div must be between 1 and 255"));
@@ -115,7 +116,7 @@ STATIC mp_obj_t esp32_rmt_make_new(const mp_obj_type_t *type, size_t n_args, siz
 STATIC void esp32_rmt_print(const mp_print_t *print, mp_obj_t self_in, mp_print_kind_t kind) {
     esp32_rmt_obj_t *self = MP_OBJ_TO_PTR(self_in);
     if (self->pin != -1) {
-        mp_printf(print, "RMT(channel=%u, pin=%u, source_freq=%u, clock_div=%u)",
+        mp_printf(print, "RMT(channel=%u, pin=%u, source_freq=%u, clock_div=%u, jonrob)",
             self->channel_id, self->pin, APB_CLK_FREQ, self->clock_div);
     } else {
         mp_printf(print, "RMT()");

--- a/ports/esp32/esp32_rmt.c
+++ b/ports/esp32/esp32_rmt.c
@@ -64,7 +64,7 @@ STATIC mp_obj_t esp32_rmt_make_new(const mp_obj_type_t *type, size_t n_args, siz
         { MP_QSTR_id,        MP_ARG_REQUIRED | MP_ARG_INT, {.u_int = -1} },
         { MP_QSTR_pin,       MP_ARG_REQUIRED | MP_ARG_KW_ONLY | MP_ARG_OBJ, {.u_obj = mp_const_none} },
         { MP_QSTR_clock_div,                   MP_ARG_KW_ONLY | MP_ARG_INT, {.u_int = 8} }, // 100ns resolution
-        { MP_QSTR_carrier_en,                  MP_ARG_KW_ONLY | MP_ARG_BOOL, {.u_bool = false} },
+        { MP_QSTR_carrier_en,                  MP_ARG_KW_ONLY | MP_ARG_OBJ, {.u_obj = mp_const_false} },
         { MP_QSTR_carrier_duty_percent,        MP_ARG_KW_ONLY | MP_ARG_INT, {.u_int = 50} },
         { MP_QSTR_carrier_freq_hz,             MP_ARG_KW_ONLY | MP_ARG_INT, {.u_int = 38000} },
     };
@@ -73,7 +73,7 @@ STATIC mp_obj_t esp32_rmt_make_new(const mp_obj_type_t *type, size_t n_args, siz
     mp_uint_t channel_id = args[0].u_int;
     gpio_num_t pin_id = machine_pin_get_id(args[1].u_obj);
     mp_uint_t clock_div = args[2].u_int;
-    bool carrier_en = args[3].u_bool;
+    mp_obj_t carrier_en = args[3].u_obj;
     mp_uint_t carrier_duty_percent = args[4].u_int;
     mp_uint_t carrier_freq_hz = args[5].u_int;
 
@@ -87,7 +87,7 @@ STATIC mp_obj_t esp32_rmt_make_new(const mp_obj_type_t *type, size_t n_args, siz
     self->channel_id = channel_id;
     self->pin = pin_id;
     self->clock_div = clock_div;
-    self->carrier_en = carrier_en;
+    self->carrier_en = mp_obj_is_true(carrier_en);
     self->carrier_duty_percent = carrier_duty_percent;
     self->carrier_freq_hz = carrier_freq_hz;
 

--- a/ports/esp32/makefile
+++ b/ports/esp32/makefile
@@ -1,0 +1,7 @@
+ESPIDF ?= $HOME/esp/xtensa-esp32-elf/bin
+BOARD ?= GENERIC
+PORT ?= /dev/ttyUSB0
+#FLASH_MODE ?= qio
+#FLASH_SIZE ?= 4MB
+#CROSS_COMPILE ?= xtensa-esp32-elf-
+include Makefile


### PR DESCRIPTION
The esp32 has hardware for the carrier freq. This allows micropython to use it! envoke with 
`r = esp32.RMT(0, pin=Pin(2), clock_div=80, carrier_en=True, carrier_duty_percent=50, carrier_freq_hz=38000)`

these three keyword args added `carrier_en=True, carrier_duty_percent=50, carrier_freq_hz=38000`