### PR TITLE
mimxrt: Preliminary fix for tinyusb endpoint issues

### DIFF
--- a/ports/mimxrt/tusb_config.h
+++ b/ports/mimxrt/tusb_config.h
@@ -30,7 +30,8 @@
 #define CFG_TUSB_OS             (OPT_OS_NONE)
 
 #define CFG_TUD_CDC             (1)
-#define CFG_TUD_CDC_RX_BUFSIZE  (256)
-#define CFG_TUD_CDC_TX_BUFSIZE  (256)
+#define CFG_TUD_CDC_RX_BUFSIZE  (512)
+#define CFG_TUD_CDC_TX_BUFSIZE  (512)
+#define CFG_TUD_CDC_EPSIZE      (512)
 
 #endif // MICROPY_INCLUDED_MIMXRT_TUSB_CONFIG_H


### PR DESCRIPTION
Preliminary fix for incorrect endpoint buffer size for high-speed device in tinyusb.
Should allow to run scripts via pyboard.py.
#6034 