### PR TITLE
nimble gatt init and ESP32 BLE init

### DIFF
--- a/extmod/nimble/modbluetooth_nimble.c
+++ b/extmod/nimble/modbluetooth_nimble.c
@@ -39,6 +39,7 @@
 #include "nimble/ble.h"
 #include "nimble/nimble_port.h"
 #include "services/gap/ble_svc_gap.h"
+#include "services/gatt/ble_svc_gatt.h"
 
 #ifndef MICROPY_PY_BLUETOOTH_DEFAULT_GAP_NAME
 #define MICROPY_PY_BLUETOOTH_DEFAULT_GAP_NAME "MPY NIMBLE"
@@ -271,8 +272,9 @@ int mp_bluetooth_init(void) {
     nimble_port_init();
     mp_bluetooth_nimble_port_postinit();
 
-    // By default, just register the default gap service.
+    // By default, just register the default gap/gatt service.
     ble_svc_gap_init();
+    ble_svc_gatt_init();
 
     mp_bluetooth_nimble_port_start();
 
@@ -466,8 +468,9 @@ int mp_bluetooth_gatts_register_service_begin(bool append) {
     // Reset the gatt characteristic value db.
     mp_bluetooth_gatts_db_reset(MP_STATE_PORT(bluetooth_nimble_root_pointers)->gatts_db);
 
-    // By default, just register the default gap service.
+    // By default, just register the default gap/gatt service.
     ble_svc_gap_init();
+    ble_svc_gatt_init();
 
     if (!append) {
         // Unref any previous service definitions.

--- a/ports/esp32/nimble.c
+++ b/ports/esp32/nimble.c
@@ -44,7 +44,6 @@ void mp_bluetooth_nimble_port_preinit(void) {
 }
 
 void mp_bluetooth_nimble_port_postinit(void) {
-    nimble_port_freertos_init(ble_host_task);
 }
 
 void mp_bluetooth_nimble_port_deinit(void) {
@@ -52,6 +51,7 @@ void mp_bluetooth_nimble_port_deinit(void) {
 }
 
 void mp_bluetooth_nimble_port_start(void) {
+    nimble_port_freertos_init(ble_host_task);
 }
 
 #endif


### PR DESCRIPTION
The gap service was appearing twice, so I added an initialization of the gatt service.

Also, on ESP32 devices, the nimble example shows that nimble_svc_gap_init() and bru_svc_gatt_init() are called, and then nimble_port_freertos_init(bru_host_task) is called.