### PR TITLE
extmod: implement basic "uevent" module (RFC, WIP)

### DIFF
--- a/docs/library/index.rst
+++ b/docs/library/index.rst
@@ -115,6 +115,7 @@ the following libraries.
    ubluetooth.rst
    ucryptolib.rst
    uctypes.rst
+   uevent.rst
 
 
 Port-specific libraries

--- a/docs/library/uevent.rst
+++ b/docs/library/uevent.rst
@@ -1,0 +1,35 @@
+:mod:`uevent` -- wait for events on a set of objects
+====================================================
+
+.. module:: uevent
+   :synopsis: wait for events on a set of objects
+
+This class is similar to the ``select`` and ``selectors`` modules but:
+- poll.register() will update flags, not overwrite
+- one-shot behaviour
+- poll_entry can have a user method set on it
+- everything can be O(1) in a native implementation
+- poll.notify() for async wake-up (TODO)
+- helps to minimise heap allocation, both in this module and for the user's use of it
+- unregister operates on the poll_entry (also on poll)
+
+Functions
+---------
+
+.. function:: poll()
+
+   Create an instance of the Poll class.
+
+.. _class: Poll
+
+class ``Poll``
+--------------
+
+Methods
+~~~~~~~
+
+.. method:: poll.register(obj[, eventmask])
+
+.. method:: poll.unregister(obj[, eventmask])
+
+.. method:: poll.poll_ms(timeout=-1, /)

--- a/extmod/moduevent.c
+++ b/extmod/moduevent.c
@@ -1,0 +1,100 @@
+/*
+ * This file is part of the MicroPython project, http://micropython.org/
+ *
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2020 Damien P. George
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#include "py/runtime.h"
+#include "extmod/moduevent.h"
+
+#if MICROPY_PY_UEVENT != MICROPY_PY_UEVENT_IMPL_NONE
+
+STATIC const mp_obj_fun_builtin_var_t poll_unregister_obj;
+
+STATIC void mp_uevent_poll_entry_attr(mp_obj_t self_in, qstr attr, mp_obj_t *dest) {
+    mp_obj_poll_entry_base_t *self = MP_OBJ_TO_PTR(self_in);
+    if (dest[0] == MP_OBJ_NULL) {
+        // Load attribute.
+        if (attr == MP_QSTR_data) {
+            dest[0] = self->user_data;
+        } else if (attr == MP_QSTR_flags) {
+            dest[0] = MP_OBJ_NEW_SMALL_INT(self->user_flags);
+        } else if (attr == MP_QSTR_unregister) {
+            dest[0] = MP_OBJ_FROM_PTR(&poll_unregister_obj);
+            dest[1] = MP_OBJ_FROM_PTR(self);
+        } else if (attr == self->user_method_name) {
+            dest[0] = self->user_method_obj;
+            dest[1] = self_in;
+        }
+    } else if (dest[1] != MP_OBJ_NULL) {
+        // Store attribute.
+        if (attr == MP_QSTR_data) {
+            self->user_data = dest[1];
+            dest[0] = MP_OBJ_NULL; // success
+        } else if (attr != MP_QSTR_flags) {
+            self->user_method_name = attr;
+            self->user_method_obj = dest[1];
+            dest[0] = MP_OBJ_NULL; // success
+        }
+    }
+}
+
+const mp_obj_type_t mp_type_poll_entry = {
+    { &mp_type_type },
+    .name = MP_QSTR_poll_entry,
+    .attr = mp_uevent_poll_entry_attr,
+};
+
+STATIC MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(poll_register_obj, 2, 3, mp_uevent_poll_register);
+STATIC MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(poll_unregister_obj, 1, 2, mp_uevent_poll_unregister);
+STATIC MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(poll_poll_ms_obj, 1, 2, mp_uevent_poll_poll_ms);
+
+STATIC const mp_rom_map_elem_t poll_locals_dict_table[] = {
+    { MP_ROM_QSTR(MP_QSTR_register), MP_ROM_PTR(&poll_register_obj) },
+    { MP_ROM_QSTR(MP_QSTR_unregister), MP_ROM_PTR(&poll_unregister_obj) },
+    { MP_ROM_QSTR(MP_QSTR_poll_ms), MP_ROM_PTR(&poll_poll_ms_obj) },
+};
+STATIC MP_DEFINE_CONST_DICT(poll_locals_dict, poll_locals_dict_table);
+
+const mp_obj_type_t mp_type_poll = {
+    { &mp_type_type },
+    .name = MP_QSTR_poll,
+    .getiter = mp_identity_getiter,
+    .iternext = mp_uevent_poll_iternext,
+    .locals_dict = (mp_obj_dict_t *)&poll_locals_dict,
+};
+
+STATIC MP_DEFINE_CONST_FUN_OBJ_0(mp_uevent_poll_obj, mp_uevent_poll);
+
+STATIC const mp_rom_map_elem_t mp_module_uevent_globals_table[] = {
+    { MP_ROM_QSTR(MP_QSTR___name__), MP_ROM_QSTR(MP_QSTR_uevent) },
+    { MP_ROM_QSTR(MP_QSTR_poll), MP_ROM_PTR(&mp_uevent_poll_obj) },
+};
+STATIC MP_DEFINE_CONST_DICT(mp_module_uevent_globals, mp_module_uevent_globals_table);
+
+const mp_obj_module_t mp_module_uevent = {
+    .base = { &mp_type_module },
+    .globals = (mp_obj_dict_t *)&mp_module_uevent_globals,
+};
+
+#endif // MICROPY_PY_UEVENT != MICROPY_PY_UEVENT_IMPL_NONE

--- a/extmod/moduevent.h
+++ b/extmod/moduevent.h
@@ -1,0 +1,59 @@
+/*
+ * This file is part of the MicroPython project, http://micropython.org/
+ *
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2020 Damien P. George
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+#ifndef MICROPY_INCLUDED_EXTMOD_MODUEVENT_H
+#define MICROPY_INCLUDED_EXTMOD_MODUEVENT_H
+
+#include "py/obj.h"
+
+#define MICROPY_ALLOC_UEVENT_POLL_INIT (4)
+#define MICROPY_ALLOC_UEVENT_POLL_INC (4)
+
+#define UEVENT_READ (1)
+#define UEVENT_WRITE (2)
+
+typedef struct _mp_obj_poll_t mp_obj_poll_t;
+
+typedef struct _mp_obj_poll_entry_base_t {
+    mp_obj_base_t base;
+    mp_obj_poll_t *poller;
+    mp_obj_t obj;
+    uint16_t user_flags;
+    uint16_t user_method_name; // a qstr
+    mp_obj_t user_method_obj;
+    mp_obj_t user_data;
+} mp_obj_poll_entry_base_t;
+
+extern const mp_obj_type_t mp_type_poll;
+extern const mp_obj_type_t mp_type_poll_entry;
+
+// These should all be provided by a specific uevent implementation.
+mp_obj_t mp_uevent_poll_iternext(mp_obj_t self_in);
+mp_obj_t mp_uevent_poll_register(size_t n_args, const mp_obj_t *args);
+mp_obj_t mp_uevent_poll_unregister(size_t n_args, const mp_obj_t *args);
+mp_obj_t mp_uevent_poll_poll_ms(size_t n_args, const mp_obj_t *args);
+mp_obj_t mp_uevent_poll(void);
+
+#endif // MICROPY_INCLUDED_EXTMOD_MODUEVENT_H

--- a/extmod/moduevent_native.c
+++ b/extmod/moduevent_native.c
@@ -1,0 +1,244 @@
+/*
+ * This file is part of the MicroPython project, http://micropython.org/
+ *
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2020 Damien P. George
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#include "py/runtime.h"
+#include "py/stream.h"
+#include "py/mphal.h"
+#include "extmod/moduevent.h"
+
+#if MICROPY_PY_UEVENT == MICROPY_PY_UEVENT_IMPL_NATIVE
+
+struct _mp_obj_poll_t {
+    mp_obj_base_t base;
+    unsigned short alloc;
+    unsigned short len;
+    struct _mp_obj_poll_entry_t *entries;
+    struct _mp_obj_poll_entry_t *entry_ready;
+    struct _mp_obj_poll_entry_t *entry_free;
+};
+
+typedef struct _mp_obj_poll_entry_t {
+    mp_obj_poll_entry_base_t base;
+    struct _mp_obj_poll_entry_t *next;
+    mp_uint_t (*ioctl)(mp_obj_t obj, mp_uint_t request, uintptr_t arg, int *errcode);
+    uint16_t flags_waiting;
+    uint16_t flags_ready;
+} mp_obj_poll_entry_t;
+
+STATIC mp_obj_poll_entry_t *mp_uevent_poll_entry_new(mp_obj_poll_t *poller) {
+    if (poller->len >= poller->alloc) {
+        size_t new_alloc = poller->alloc + MICROPY_ALLOC_UEVENT_POLL_INC;
+        poller->entries = m_renew(mp_obj_poll_entry_t, poller->entries, poller->alloc, new_alloc);
+        poller->alloc = new_alloc;
+    }
+    mp_obj_poll_entry_t *self = &poller->entries[poller->len++];
+    self->base.base.type = &mp_type_poll_entry;
+    self->base.poller = poller;
+    self->base.user_method_name = MP_QSTR_NULL;
+    self->base.user_data = mp_const_none;
+    self->next = NULL;
+    return self;
+}
+
+STATIC void mp_uevent_poll_entry_init(mp_obj_poll_entry_t *self, mp_obj_t obj) {
+    self->base.obj = obj;
+    self->base.user_flags = 0;
+    self->ioctl = mp_get_stream_raise(obj, MP_STREAM_OP_IOCTL)->ioctl;
+    self->flags_waiting = 0;
+    self->flags_ready = 0;
+}
+
+STATIC void mp_uevent_poll_entry_process_event(mp_obj_poll_entry_t *entry, uint16_t flags) {
+    if (!(entry->flags_waiting & flags)) {
+        return;
+    }
+    uint16_t old_flags_ready = entry->flags_ready;
+    entry->flags_ready |= entry->flags_waiting & flags;
+    entry->flags_waiting &= ~flags;
+    if (old_flags_ready == 0 && entry->flags_ready) {
+        // Put entry on the ready linked list.
+        entry->next = entry->base.poller->entry_ready;
+        entry->base.poller->entry_ready = entry;
+    }
+}
+
+STATIC void mp_uevent_entry_clear_events(mp_obj_poll_t *self, mp_obj_poll_entry_t *entry, uint16_t flags) {
+    entry->flags_waiting &= ~flags;
+    if (entry->flags_waiting == 0) {
+        // Move entry to free list.
+        entry->base.obj = mp_const_none;
+        entry->next = self->entry_free;
+        self->entry_free = entry;
+    }
+}
+
+mp_obj_t mp_uevent_poll_iternext(mp_obj_t self_in) {
+    mp_obj_poll_t *self = MP_OBJ_TO_PTR(self_in);
+
+    if (self->entry_ready != NULL) {
+        mp_obj_poll_entry_t *entry = self->entry_ready;
+        self->entry_ready = entry->next;
+        entry->base.user_flags = entry->flags_ready;
+        entry->flags_ready = 0;
+        mp_uevent_entry_clear_events(self, entry, 0);
+        return MP_OBJ_FROM_PTR(entry);
+    }
+
+    return MP_OBJ_STOP_ITERATION;
+}
+
+mp_obj_t mp_uevent_poll_register(size_t n_args, const mp_obj_t *args) {
+    mp_obj_poll_t *self = MP_OBJ_TO_PTR(args[0]);
+    mp_uint_t flags;
+    if (n_args == 3) {
+        flags = mp_obj_get_int(args[2]);
+        // flags must be non-zero.
+    } else {
+        flags = 0xffff;
+    }
+    mp_obj_poll_entry_t *entry = NULL;
+    for (size_t i = 0; i < self->len; ++i) {
+        if (self->entries[i].base.obj == args[1]) {
+            entry = &self->entries[i];
+            break;
+        }
+    }
+    if (entry == NULL) {
+        if (self->entry_free != NULL) {
+            entry = self->entry_free;
+            self->entry_free = entry->next;
+        } else {
+            entry = mp_uevent_poll_entry_new(self);
+        }
+        mp_uevent_poll_entry_init(entry, args[1]);
+    }
+
+    entry->flags_waiting |= flags;
+
+    return MP_OBJ_FROM_PTR(entry);
+}
+
+mp_obj_t mp_uevent_poll_unregister(size_t n_args, const mp_obj_t *args) {
+    mp_obj_poll_entry_t *entry = MP_OBJ_TO_PTR(args[0]);
+    mp_uint_t flags = 0xffff;
+    if (n_args > 1) {
+        flags = mp_obj_get_int(args[1]);
+    }
+    mp_uevent_entry_clear_events(entry->base.poller, entry, flags);
+    return MP_OBJ_FROM_PTR(entry);
+}
+
+STATIC void mp_uevent_poll_check_waiting(mp_obj_poll_t *self) {
+    for (size_t i = 0; i < self->len; ++i) {
+        mp_obj_poll_entry_t *entry = &self->entries[i];
+        if (entry->flags_waiting == 0) {
+            continue;
+        }
+
+        uintptr_t poll_flags = 0;
+        if (entry->flags_waiting & UEVENT_READ) {
+            poll_flags |= MP_STREAM_POLL_RD;
+        }
+        if (entry->flags_waiting & UEVENT_WRITE) {
+            poll_flags |= MP_STREAM_POLL_WR;
+        }
+
+        int errcode;
+        mp_int_t ret = entry->ioctl(entry->base.obj, MP_STREAM_POLL, poll_flags, &errcode);
+
+        if (ret == -1) {
+            // error doing ioctl
+            mp_raise_OSError(errcode);
+        }
+
+        if (ret != 0) {
+            uint16_t flags_ready = 0;
+            if (ret & ~MP_STREAM_POLL_WR) {
+                flags_ready |= UEVENT_READ;
+            }
+            if (ret & ~MP_STREAM_POLL_RD) {
+                flags_ready |= UEVENT_WRITE;
+            }
+            mp_uevent_poll_entry_process_event(entry, flags_ready);
+        }
+    }
+}
+
+mp_obj_t mp_uevent_poll_poll_ms(size_t n_args, const mp_obj_t *args) {
+    mp_obj_poll_t *self = MP_OBJ_TO_PTR(args[0]);
+
+    // Determine timeout, in milliseconds.
+    mp_uint_t timeout_ms = -1;
+    if (n_args >= 2 && args[1] != mp_const_none) {
+        mp_int_t timeout_i = mp_obj_get_int(args[1]);
+        if (timeout_i >= 0) {
+            timeout_ms = timeout_i;
+        }
+    }
+
+    // Wait for event or timeout.
+    mp_uint_t start_tick = mp_hal_ticks_ms();
+    for (;;) {
+        mp_uevent_poll_check_waiting(self);
+        if (self->entry_ready != NULL
+            || (timeout_ms != -1 && mp_hal_ticks_ms() - start_tick >= timeout_ms)) {
+            break;
+        }
+        MICROPY_EVENT_POLL_HOOK
+    }
+
+    return args[0];
+}
+
+/*
+STATIC mp_obj_t poll_dump(mp_obj_t self_in) {
+    mp_obj_poll_t *self = MP_OBJ_TO_PTR(self_in);
+    printf("all:");
+    for (size_t i = 0; i < self->len; ++i) {
+        mp_obj_poll_entry_t *entry = &self->entries[i];
+        printf(" (%p %x:%x)", MP_OBJ_TO_PTR(entry->obj), entry->flags_waiting, entry->flags_ready);
+    }
+    printf("\nready:");
+    for (volatile mp_obj_poll_entry_t *entry = self->entry_ready; entry != NULL; entry = entry->next) {
+        printf(" (%p %x:%x)", MP_OBJ_TO_PTR(entry->obj), entry->flags_waiting, entry->flags_ready);
+    }
+    printf("\n");
+    return mp_const_none;
+}
+*/
+
+mp_obj_t mp_uevent_poll(void) {
+    mp_obj_poll_t *self = m_new_obj(mp_obj_poll_t);
+    self->base.type = &mp_type_poll;
+    self->alloc = MICROPY_ALLOC_UEVENT_POLL_INIT;
+    self->len = 0;
+    self->entries = m_new(mp_obj_poll_entry_t, self->alloc);
+    self->entry_ready = NULL;
+    self->entry_free = NULL;
+    return MP_OBJ_FROM_PTR(self);
+}
+
+#endif // MICROPY_PY_UEVENT == MICROPY_PY_UEVENT_IMPL_NATIVE

--- a/extmod/moduevent_poll.c
+++ b/extmod/moduevent_poll.c
@@ -1,0 +1,204 @@
+/*
+ * This file is part of the MicroPython project, http://micropython.org/
+ *
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2020 Damien P. George
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#include "py/runtime.h"
+#include "py/stream.h"
+#include "extmod/moduevent.h"
+
+#if MICROPY_PY_UEVENT == MICROPY_PY_UEVENT_IMPL_POLL
+
+#include <poll.h>
+
+typedef mp_obj_poll_entry_base_t mp_obj_poll_entry_t;
+
+struct _mp_obj_poll_t {
+    mp_obj_base_t base;
+    unsigned short alloc;
+    unsigned short len;
+    unsigned short iter_idx;
+    struct pollfd *pollfds;
+    mp_obj_poll_entry_t *entries;
+};
+
+STATIC void mp_uevent_poll_entry_init(mp_obj_poll_entry_t *self, mp_obj_poll_t *poller, mp_obj_t obj) {
+    self->base.type = &mp_type_poll_entry;
+    self->poller = poller;
+    self->obj = obj;
+    self->user_flags = 0;
+    self->user_method_name = MP_QSTR_NULL;
+    self->user_data = mp_const_none;
+}
+
+STATIC void mp_uevent_entry_clear_events(struct pollfd *pollfd, mp_obj_poll_entry_t *entry, size_t events) {
+    pollfd->events &= ~events;
+    if (pollfd->events == 0) {
+        // Free this pollfd/entry.
+        pollfd->fd = -1;
+        entry->obj = mp_const_none;
+    }
+}
+
+mp_obj_t mp_uevent_poll_iternext(mp_obj_t self_in) {
+    mp_obj_poll_t *self = MP_OBJ_TO_PTR(self_in);
+
+    for (; self->iter_idx < self->len; ++self->iter_idx) {
+        struct pollfd *pollfd = &self->pollfds[self->iter_idx];
+        mp_obj_poll_entry_t *entry = &self->entries[self->iter_idx];
+        if (pollfd->revents != 0) {
+            entry->user_flags = 0;
+            if (pollfd->revents & ~POLLOUT) {
+                entry->user_flags |= UEVENT_READ;
+            }
+            if (pollfd->revents & ~POLLIN) {
+                entry->user_flags |= UEVENT_WRITE;
+            }
+            mp_uevent_entry_clear_events(pollfd, entry, pollfd->revents);
+            pollfd->revents = 0;
+            return MP_OBJ_FROM_PTR(entry);
+        }
+    }
+
+    return MP_OBJ_STOP_ITERATION;
+}
+
+mp_obj_t mp_uevent_poll_register(size_t n_args, const mp_obj_t *args) {
+    mp_obj_poll_t *self = MP_OBJ_TO_PTR(args[0]);
+
+    const mp_stream_p_t *stream_p = mp_get_stream_raise(args[1], MP_STREAM_OP_IOCTL);
+    int err;
+    mp_uint_t res = stream_p->ioctl(args[1], MP_STREAM_GET_FILENO, 0, &err);
+    if (res == MP_STREAM_ERROR) {
+        mp_raise_OSError(err);
+    }
+    int fd = res;
+
+    mp_uint_t flags;
+    if (n_args == 3) {
+        flags = mp_obj_get_int(args[2]);
+    } else {
+        flags = 0xffff;
+    }
+
+    struct pollfd *pollfd = NULL;
+    struct pollfd *pollfd_unused = NULL;
+    for (size_t i = 0; i < self->len; ++i) {
+        if (self->entries[i].obj == args[1]) {
+            pollfd = &self->pollfds[i];
+            break;
+        }
+        if (self->entries[i].obj == mp_const_none) {
+            pollfd_unused = &self->pollfds[i];
+        }
+    }
+
+    if (pollfd == NULL) {
+        if (pollfd_unused == NULL) {
+            if (self->len >= self->alloc) {
+                size_t new_alloc = self->alloc + MICROPY_ALLOC_UEVENT_POLL_INC;
+                self->pollfds = m_renew(struct pollfd, self->pollfds, self->alloc, new_alloc);
+                self->entries = m_renew(mp_obj_poll_entry_t, self->entries, self->alloc, new_alloc);
+                self->alloc = new_alloc;
+            }
+            pollfd = &self->pollfds[self->len++];
+        } else {
+            pollfd = pollfd_unused;
+        }
+
+        pollfd->fd = fd;
+        mp_obj_poll_entry_t *entry = &self->entries[pollfd - &self->pollfds[0]];
+        mp_uevent_poll_entry_init(entry, self, args[1]);
+    }
+
+    if (flags & UEVENT_READ) {
+        pollfd->events |= POLLIN;
+    }
+    if (flags & UEVENT_WRITE) {
+        pollfd->events |= POLLOUT;
+    }
+
+    return MP_OBJ_FROM_PTR(&self->entries[pollfd - &self->pollfds[0]]);
+}
+
+mp_obj_t mp_uevent_poll_unregister(size_t n_args, const mp_obj_t *args) {
+    mp_obj_poll_entry_t *entry = MP_OBJ_TO_PTR(args[0]);
+    mp_uint_t flags = 0xffff;
+    if (n_args > 1) {
+        flags = mp_obj_get_int(args[1]);
+    }
+    size_t to_clear = 0;
+    if (flags & UEVENT_READ) {
+        to_clear |= POLLIN;
+    }
+    if (flags & UEVENT_WRITE) {
+        to_clear |= POLLOUT;
+    }
+    struct pollfd *pollfd = &entry->poller->pollfds[entry - &entry->poller->entries[0]];
+    mp_uevent_entry_clear_events(pollfd, entry, to_clear);
+    return MP_OBJ_FROM_PTR(entry);
+}
+
+mp_obj_t mp_uevent_poll_poll_ms(size_t n_args, const mp_obj_t *args) {
+    mp_obj_poll_t *self = MP_OBJ_TO_PTR(args[0]);
+
+    // work out timeout
+    mp_uint_t timeout_ms = -1;
+    if (n_args >= 2 && args[1] != mp_const_none) {
+        mp_int_t timeout_i = mp_obj_get_int(args[1]);
+        if (timeout_i >= 0) {
+            timeout_ms = timeout_i;
+        }
+    }
+
+    for (;;) {
+        MP_THREAD_GIL_EXIT();
+        int ret = poll(self->pollfds, self->len, timeout_ms);
+        MP_THREAD_GIL_ENTER();
+        if (ret != -1) {
+            break;
+        }
+        if (errno == EINTR) {
+            mp_handle_pending(true);
+        } else {
+            mp_raise_OSError(errno);
+        }
+    }
+
+    self->iter_idx = 0;
+
+    return args[0];
+}
+
+mp_obj_t mp_uevent_poll(void) {
+    mp_obj_poll_t *self = m_new_obj(mp_obj_poll_t);
+    self->base.type = &mp_type_poll;
+    self->alloc = MICROPY_ALLOC_UEVENT_POLL_INIT;
+    self->len = 0;
+    self->pollfds = m_new(struct pollfd, self->alloc);
+    self->entries = m_new(mp_obj_poll_entry_t, self->alloc);
+    return MP_OBJ_FROM_PTR(self);
+}
+
+#endif // MICROPY_PY_UEVENT == MICROPY_PY_UEVENT_IMPL_POLL

--- a/ports/esp32/mpconfigport.h
+++ b/ports/esp32/mpconfigport.h
@@ -126,6 +126,7 @@
 // extended modules
 #define MICROPY_PY_UASYNCIO                 (1)
 #define MICROPY_PY_UCTYPES                  (1)
+#define MICROPY_PY_UEVENT                   (MICROPY_PY_UEVENT_IMPL_NATIVE)
 #define MICROPY_PY_UZLIB                    (1)
 #define MICROPY_PY_UJSON                    (1)
 #define MICROPY_PY_URE                      (1)

--- a/ports/esp8266/mpconfigport.h
+++ b/ports/esp8266/mpconfigport.h
@@ -63,6 +63,7 @@
 #define MICROPY_PY_UERRNO           (1)
 #define MICROPY_PY_UBINASCII        (1)
 #define MICROPY_PY_UCTYPES          (1)
+#define MICROPY_PY_UEVENT           (MICROPY_PY_UEVENT_IMPL_NATIVE)
 #define MICROPY_PY_UHASHLIB         (1)
 #define MICROPY_PY_UHASHLIB_SHA1    (MICROPY_PY_USSL && MICROPY_SSL_AXTLS)
 #define MICROPY_PY_UHEAPQ           (1)

--- a/ports/stm32/mpconfigport.h
+++ b/ports/stm32/mpconfigport.h
@@ -140,6 +140,9 @@
 #ifndef MICROPY_PY_UCTYPES
 #define MICROPY_PY_UCTYPES          (1)
 #endif
+#ifndef MICROPY_PY_UEVENT
+#define MICROPY_PY_UEVENT           (MICROPY_PY_UEVENT_IMPL_NATIVE)
+#endif
 #ifndef MICROPY_PY_UZLIB
 #define MICROPY_PY_UZLIB            (1)
 #endif

--- a/ports/unix/mpconfigport.h
+++ b/ports/unix/mpconfigport.h
@@ -141,6 +141,7 @@
 #define MICROPY_PY_UTIME_MP_HAL     (1)
 #define MICROPY_PY_UERRNO           (1)
 #define MICROPY_PY_UCTYPES          (1)
+#define MICROPY_PY_UEVENT           (MICROPY_PY_UEVENT_IMPL_POLL)
 #define MICROPY_PY_UZLIB            (1)
 #define MICROPY_PY_UJSON            (1)
 #define MICROPY_PY_URE              (1)

--- a/py/builtin.h
+++ b/py/builtin.h
@@ -106,6 +106,7 @@ extern const mp_obj_dict_t mp_module_builtins_globals;
 extern const mp_obj_module_t mp_module_uasyncio;
 extern const mp_obj_module_t mp_module_uerrno;
 extern const mp_obj_module_t mp_module_uctypes;
+extern const mp_obj_module_t mp_module_uevent;
 extern const mp_obj_module_t mp_module_uzlib;
 extern const mp_obj_module_t mp_module_ujson;
 extern const mp_obj_module_t mp_module_ure;

--- a/py/mpconfig.h
+++ b/py/mpconfig.h
@@ -1315,6 +1315,14 @@ typedef double mp_float_t;
 #define MICROPY_PY_UCTYPES_NATIVE_C_TYPES (1)
 #endif
 
+// Whether to provide the "uevent" module, and which implementation to use
+#define MICROPY_PY_UEVENT_IMPL_NONE (0)
+#define MICROPY_PY_UEVENT_IMPL_NATIVE (1)
+#define MICROPY_PY_UEVENT_IMPL_POLL (2)
+#ifndef MICROPY_PY_UEVENT
+#define MICROPY_PY_UEVENT (MICROPY_PY_UEVENT_IMPL_NONE)
+#endif
+
 #ifndef MICROPY_PY_UZLIB
 #define MICROPY_PY_UZLIB (0)
 #endif

--- a/py/objmodule.c
+++ b/py/objmodule.c
@@ -179,6 +179,9 @@ STATIC const mp_rom_map_elem_t mp_builtin_module_table[] = {
     #if MICROPY_PY_UCTYPES
     { MP_ROM_QSTR(MP_QSTR_uctypes), MP_ROM_PTR(&mp_module_uctypes) },
     #endif
+    #if MICROPY_PY_UEVENT
+    { MP_ROM_QSTR(MP_QSTR_uevent), MP_ROM_PTR(&mp_module_uevent) },
+    #endif
     #if MICROPY_PY_UZLIB
     { MP_ROM_QSTR(MP_QSTR_uzlib), MP_ROM_PTR(&mp_module_uzlib) },
     #endif

--- a/py/py.mk
+++ b/py/py.mk
@@ -170,6 +170,9 @@ PY_CORE_O_BASENAME = $(addprefix py/,\
 PY_EXTMOD_O_BASENAME = \
 	extmod/moduasyncio.o \
 	extmod/moductypes.o \
+	extmod/moduevent.o \
+	extmod/moduevent_native.o \
+	extmod/moduevent_poll.o \
 	extmod/modujson.o \
 	extmod/modure.o \
 	extmod/moduzlib.o \

--- a/tests/extmod/uevent_basic.py
+++ b/tests/extmod/uevent_basic.py
@@ -1,0 +1,45 @@
+try:
+    import uio as io, usocket as socket, uevent
+except ImportError:
+    print("SKIP")
+    raise SystemExit
+
+
+poller = uevent.poll()
+
+# Simple poll with nothing registered.
+poller.poll_ms(1)
+print(list(poller))
+
+# Register a socket.
+s = socket.socket()
+entry = poller.register(s)
+
+# Registering the same stream again should retrieve the same entry.
+print(poller.register(s, 0) is entry)
+
+# Load/store attributes of the poll entry.
+entry.data = 123
+entry.custom_method = lambda self: ("custom_method", self.data)
+print(entry.flags, entry.custom_method())
+
+# Unregister socket via poll entry.
+entry.unregister()
+
+# Poll a closed socket, should be readable and writable.
+entry = poller.register(s, 3)
+s.close()
+poller.poll_ms(1)
+ready = list(poller)
+print(len(ready), ready[0].flags)
+
+# Register many sockets to test reallocation of internal array.
+poller.register(s)
+for _ in range(4):
+    poller.register(socket.socket())
+
+# Try registering an object that is not compatible.
+try:
+    poller.register(io.StringIO())
+except OSError:
+    print("OSError")

--- a/tests/extmod/uevent_basic.py.exp
+++ b/tests/extmod/uevent_basic.py.exp
@@ -1,0 +1,5 @@
+[]
+True
+0 ('custom_method', 123)
+1 3
+OSError


### PR DESCRIPTION
Background: the aim is to make events in MicroPython more generic and efficient, rather than having busy polling (based on POSIX poll) and being restricted to stream IO.  The main use is for the `uasyncio` module, eg so that external interrupts like pin edges can wake the asyncio scheduler, but the event sub-system should not be tied to uasyncio.

Already there is #6056, #6106 and #6110.  This PR takes the proof-of-concept PR #6110 and extracts out just the "uevent" module and implements it for the stm32 and unix ports, to start with.  At the moment this module is quite similar to the existing "uselect" module, at least on the surface.  But the idea is to make "uevent" as efficient as possible on bare-metal (ie O(1) for all operations) and support arbitrary events, and the existing "uselect" API is too restrictive to achieve this goal.

What's done in this PR:
- working implementation of uevent on stm32 and unix
- uasyncio changed to use uevent instead of uselect
- docs for uevent (still to be properly written)

There's no real functional change here, the aim is to switch to uevent in a seamless way and then gradually improve it.

For now the uevent module should be considered "private" because its interface may change.

Any ideas/comments on improvements or alternatives are welcome.