### PR TITLE
esp32 RMT: Extend Micropython use of hardware carrier freq feature. 

### DIFF
--- a/docs/library/esp32.rst
+++ b/docs/library/esp32.rst
@@ -150,7 +150,12 @@ used to transmit or receive many other types of digital signals::
     from machine import Pin
 
     r = esp32.RMT(0, pin=Pin(18), clock_div=8)
-    r  # RMT(channel=0, pin=18, source_freq=80000000, clock_div=8)
+    r  # RMT(channel=0, pin=18, source_freq=80000000, clock_div=8, carrier_freq_hz=None, carrier_duty_percent=50)
+
+    # To use carrier frequency
+    r = esp32.RMT(0, pin=Pin(18), clock_div=8, carrier_freq_hz=38000)
+    r  # RMT(channel=0, pin=18, source_freq=80000000, clock_div=8, carrier_freq_hz=38000, carrier_duty_percent=50)
+
     # The channel resolution is 100ns (1/(source_freq/clock_div)).
     r.write_pulses((1, 20, 2, 40), start=0)  # Send 0 for 100ns, 1 for 2000ns, 0 for 200ns, 1 for 4000ns
 
@@ -164,27 +169,32 @@ define the pulses.
 multiplying the resolution by a 15-bit (0-32,768) number. There are eight
 channels (0-7) and each can have a different clock divider.
 
+To enable the carrier frequency feature of the esp32 hardware, specify the ``carrier_freq_hz`` to someting like 38000,
+a typical IR carrier frequency. (default value is ```None```)
+
 So, in the example above, the 80MHz clock is divided by 8. Thus the
 resolution is (1/(80Mhz/8)) 100ns. Since the ``start`` level is 0 and toggles
 with each number, the bitstream is ``0101`` with durations of [100ns, 2000ns,
 100ns, 4000ns].
 
+
 For more details see Espressif's `ESP-IDF RMT documentation.
 <https://docs.espressif.com/projects/esp-idf/en/latest/api-reference/peripherals/rmt.html>`_.
 
 .. Warning::
-   The current MicroPython RMT implementation lacks some features, most notably
-   receiving pulses and carrier transmit. RMT should be considered a
+   The current MicroPython RMT implementation lacks some features. Most noteably the recieve feature. RMT should be considered a
    *beta feature* and the interface may change in the future.
 
 
-.. class:: RMT(channel, \*, pin=None, clock_div=8)
+.. class:: RMT(channel, \*, pin=None, clock_div=8, carrier_freq_hz=None, carrier_duty_percent=50)
 
     This class provides access to one of the eight RMT channels. *channel* is
     required and identifies which RMT channel (0-7) will be configured. *pin*,
     also required, configures which Pin is bound to the RMT channel. *clock_div*
     is an 8-bit clock divider that divides the source clock (80MHz) to the RMT
-    channel allowing the resolution to be specified.
+    channel allowing the resolution to be specified. *carrier_freq_hz* is used to enable the carrier feature
+    and specify its frequency, default value is None (not enabled). To enable, specify a 32-bit interger.
+    *carrier_duty_percent* is default to 50. 
 
 .. method:: RMT.source_freq()
 

--- a/docs/library/esp32.rst
+++ b/docs/library/esp32.rst
@@ -186,7 +186,7 @@ For more details see Espressif's `ESP-IDF RMT documentation.
    *beta feature* and the interface may change in the future.
 
 
-.. class:: RMT(channel, \*, pin=None, clock_div=8, carrier_freq=None, carrier_duty_percent=50)
+.. class:: RMT(channel, \*, pin=None, clock_div=8, carrier_freq=0, carrier_duty_percent=50)
 
     This class provides access to one of the eight RMT channels. *channel* is
     required and identifies which RMT channel (0-7) will be configured. *pin*,

--- a/docs/library/esp32.rst
+++ b/docs/library/esp32.rst
@@ -153,8 +153,8 @@ used to transmit or receive many other types of digital signals::
     r  # RMT(channel=0, pin=18, source_freq=80000000, clock_div=8)
 
     # To use carrier frequency
-    r = esp32.RMT(0, pin=Pin(18), clock_div=8, carrier_freq_hz=38000)
-    r  # RMT(channel=0, pin=18, source_freq=80000000, clock_div=8, carrier_freq_hz=38000, carrier_duty_percent=50)
+    r = esp32.RMT(0, pin=Pin(18), clock_div=8, carrier_freq=38000)
+    r  # RMT(channel=0, pin=18, source_freq=80000000, clock_div=8, carrier_freq=38000, carrier_duty_percent=50)
 
     # The channel resolution is 100ns (1/(source_freq/clock_div)).
     r.write_pulses((1, 20, 2, 40), start=0)  # Send 0 for 100ns, 1 for 2000ns, 0 for 200ns, 1 for 4000ns
@@ -169,7 +169,7 @@ define the pulses.
 multiplying the resolution by a 15-bit (0-32,768) number. There are eight
 channels (0-7) and each can have a different clock divider.
 
-To enable the carrier frequency feature of the esp32 hardware, specify the ``carrier_freq_hz`` to someting like 38000,
+To enable the carrier frequency feature of the esp32 hardware, specify the ``carrier_freq`` to someting like 38000,
 a typical IR carrier frequency.
 
 So, in the example above, the 80MHz clock is divided by 8. Thus the
@@ -186,14 +186,14 @@ For more details see Espressif's `ESP-IDF RMT documentation.
    *beta feature* and the interface may change in the future.
 
 
-.. class:: RMT(channel, \*, pin=None, clock_div=8, carrier_freq_hz=None, carrier_duty_percent=50)
+.. class:: RMT(channel, \*, pin=None, clock_div=8, carrier_freq=None, carrier_duty_percent=50)
 
     This class provides access to one of the eight RMT channels. *channel* is
     required and identifies which RMT channel (0-7) will be configured. *pin*,
     also required, configures which Pin is bound to the RMT channel. *clock_div*
     is an 8-bit clock divider that divides the source clock (80MHz) to the RMT
-    channel allowing the resolution to be specified. *carrier_freq_hz* is used to enable the carrier feature
-    and specify its frequency, default value is ``None`` (not enabled). To enable, specify a 32-bit interger.
+    channel allowing the resolution to be specified. *carrier_freq* is used to enable the carrier feature
+    and specify its frequency, default value is ``0`` (not enabled). To enable, specify a 32-bit interger.
     *carrier_duty_percent* is default to 50.
 
 .. method:: RMT.source_freq()

--- a/docs/library/esp32.rst
+++ b/docs/library/esp32.rst
@@ -170,7 +170,7 @@ multiplying the resolution by a 15-bit (0-32,768) number. There are eight
 channels (0-7) and each can have a different clock divider.
 
 To enable the carrier frequency feature of the esp32 hardware, specify the ``carrier_freq_hz`` to someting like 38000,
-a typical IR carrier frequency. (default value is ```None```)
+a typical IR carrier frequency.
 
 So, in the example above, the 80MHz clock is divided by 8. Thus the
 resolution is (1/(80Mhz/8)) 100ns. Since the ``start`` level is 0 and toggles
@@ -193,7 +193,7 @@ For more details see Espressif's `ESP-IDF RMT documentation.
     also required, configures which Pin is bound to the RMT channel. *clock_div*
     is an 8-bit clock divider that divides the source clock (80MHz) to the RMT
     channel allowing the resolution to be specified. *carrier_freq_hz* is used to enable the carrier feature
-    and specify its frequency, default value is None (not enabled). To enable, specify a 32-bit interger.
+    and specify its frequency, default value is ``None`` (not enabled). To enable, specify a 32-bit interger.
     *carrier_duty_percent* is default to 50.
 
 .. method:: RMT.source_freq()

--- a/docs/library/esp32.rst
+++ b/docs/library/esp32.rst
@@ -150,7 +150,7 @@ used to transmit or receive many other types of digital signals::
     from machine import Pin
 
     r = esp32.RMT(0, pin=Pin(18), clock_div=8)
-    r  # RMT(channel=0, pin=18, source_freq=80000000, clock_div=8, carrier_freq_hz=None, carrier_duty_percent=50)
+    r  # RMT(channel=0, pin=18, source_freq=80000000, clock_div=8)
 
     # To use carrier frequency
     r = esp32.RMT(0, pin=Pin(18), clock_div=8, carrier_freq_hz=38000)
@@ -194,7 +194,7 @@ For more details see Espressif's `ESP-IDF RMT documentation.
     is an 8-bit clock divider that divides the source clock (80MHz) to the RMT
     channel allowing the resolution to be specified. *carrier_freq_hz* is used to enable the carrier feature
     and specify its frequency, default value is None (not enabled). To enable, specify a 32-bit interger.
-    *carrier_duty_percent* is default to 50. 
+    *carrier_duty_percent* is default to 50.
 
 .. method:: RMT.source_freq()
 

--- a/ports/esp32/esp32_rmt.c
+++ b/ports/esp32/esp32_rmt.c
@@ -122,8 +122,13 @@ STATIC mp_obj_t esp32_rmt_make_new(const mp_obj_type_t *type, size_t n_args, siz
 STATIC void esp32_rmt_print(const mp_print_t *print, mp_obj_t self_in, mp_print_kind_t kind) {
     esp32_rmt_obj_t *self = MP_OBJ_TO_PTR(self_in);
     if (self->pin != -1) {
-        mp_printf(print, "RMT(channel=%u, pin=%u, source_freq=%u, clock_div=%u, carrier_freq_hz=%u, carrier_duty_percent=%u)",
-            self->channel_id, self->pin, APB_CLK_FREQ, self->clock_div, self->carrier_freq_hz, self->carrier_duty_percent);
+        if (self->carrier_en) {
+            mp_printf(print, "RMT(channel=%u, pin=%u, source_freq=%u, clock_div=%u, carrier_freq_hz=%u, carrier_duty_percent=%u)",
+                self->channel_id, self->pin, APB_CLK_FREQ, self->clock_div, self->carrier_freq_hz, self->carrier_duty_percent);
+        } else {
+            mp_printf(print, "RMT(channel=%u, pin=%u, source_freq=%u, clock_div=%u)",
+                self->channel_id, self->pin, APB_CLK_FREQ, self->clock_div);
+        }
     } else {
         mp_printf(print, "RMT()");
     }

--- a/ports/esp32/esp32_rmt.c
+++ b/ports/esp32/esp32_rmt.c
@@ -132,7 +132,7 @@ STATIC void esp32_rmt_print(const mp_print_t *print, mp_obj_t self_in, mp_print_
     } else {
         mp_printf(print, "RMT()");
     }
-}_
+}
 
 STATIC mp_obj_t esp32_rmt_deinit(mp_obj_t self_in) {
     // fixme: check for valid channel. Return exception if error occurs.

--- a/ports/esp32/esp32_rmt.c
+++ b/ports/esp32/esp32_rmt.c
@@ -65,7 +65,7 @@ STATIC mp_obj_t esp32_rmt_make_new(const mp_obj_type_t *type, size_t n_args, siz
         { MP_QSTR_pin,       MP_ARG_REQUIRED | MP_ARG_KW_ONLY | MP_ARG_OBJ, {.u_obj = mp_const_none} },
         { MP_QSTR_clock_div,                   MP_ARG_KW_ONLY | MP_ARG_INT, {.u_int = 8} }, // 100ns resolution
         { MP_QSTR_carrier_duty_percent,        MP_ARG_KW_ONLY | MP_ARG_INT, {.u_int = 50} },
-        { MP_QSTR_carrier_freq_hz,             MP_ARG_KW_ONLY | MP_ARG_OBJ, {.u_obj = mp_const_none} },
+        { MP_QSTR_carrier_freq_hz,             MP_ARG_KW_ONLY | MP_ARG_OBJ, {.u_obj = MP_OBJ_NULL} },
     };
     mp_arg_val_t args[MP_ARRAY_SIZE(allowed_args)];
     mp_arg_parse_all_kw_array(n_args, n_kw, all_args, MP_ARRAY_SIZE(allowed_args), allowed_args, args);
@@ -77,10 +77,11 @@ STATIC mp_obj_t esp32_rmt_make_new(const mp_obj_type_t *type, size_t n_args, siz
     mp_uint_t carrier_duty_percent = 0;
     mp_uint_t carrier_freq_hz = 0;
 
-    if (mp_obj_is_type(args[4], &mp_type_int)) {  // if a frequency is specified then assume carrier_en
+    if (args[4].u_obj != MP_OBJ_NULL) {
+	// if a frequency is specified then assume carrier_en
         carrier_en = mp_const_true;
         carrier_duty_percent = args[3].u_int;
-        carrier_freq_hz = mp_obj_get_int(args[4]);
+        carrier_freq_hz = mp_obj_get_int(args[4].u_obj);
     }
 
     if (clock_div < 1 || clock_div > 255) {

--- a/ports/esp32/esp32_rmt.c
+++ b/ports/esp32/esp32_rmt.c
@@ -77,10 +77,10 @@ STATIC mp_obj_t esp32_rmt_make_new(const mp_obj_type_t *type, size_t n_args, siz
     mp_uint_t carrier_duty_percent = 0;
     mp_uint_t carrier_freq = 0;
 
-    if (args[4].u_int != 0) {
+    if (args[4].u_int > 0) {
         carrier_en = true;
         carrier_duty_percent = args[3].u_int;
-        carrier_freq = mp_obj_get_int(args[4].u_obj);
+        carrier_freq = args[4].u_int;
     }
 
     if (clock_div < 1 || clock_div > 255) {
@@ -107,7 +107,7 @@ STATIC mp_obj_t esp32_rmt_make_new(const mp_obj_type_t *type, size_t n_args, siz
     config.tx_config.idle_output_en = 1;
     config.tx_config.idle_level = 0;
     config.tx_config.carrier_duty_percent = self->carrier_duty_percent;
-    config.tx_config.carrier_freq = self->carrier_freq;
+    config.tx_config.carrier_freq_hz = self->carrier_freq;
     config.tx_config.carrier_level = 1;
 
     config.clk_div = self->clock_div;

--- a/ports/esp32/esp32_rmt.c
+++ b/ports/esp32/esp32_rmt.c
@@ -52,7 +52,6 @@ typedef struct _esp32_rmt_obj_t {
     uint8_t channel_id;
     gpio_num_t pin;
     uint8_t clock_div;
-    bool carrier_en;
     uint16_t carrier_duty_percent;
     uint32_t carrier_freq;
     mp_uint_t num_items;
@@ -77,10 +76,10 @@ STATIC mp_obj_t esp32_rmt_make_new(const mp_obj_type_t *type, size_t n_args, siz
     mp_uint_t carrier_duty_percent = 0;
     mp_uint_t carrier_freq = 0;
 
-    if (args[4].u_int != 0) {
+    if (args[4].u_int > 0) {
         carrier_en = true;
         carrier_duty_percent = args[3].u_int;
-        carrier_freq = mp_obj_get_int(args[4].u_obj);
+        carrier_freq = args[4].u_int;
     }
 
     if (clock_div < 1 || clock_div > 255) {
@@ -92,7 +91,6 @@ STATIC mp_obj_t esp32_rmt_make_new(const mp_obj_type_t *type, size_t n_args, siz
     self->channel_id = channel_id;
     self->pin = pin_id;
     self->clock_div = clock_div;
-    self->carrier_en = carrier_en;
     self->carrier_duty_percent = carrier_duty_percent;
     self->carrier_freq = carrier_freq;
 
@@ -103,11 +101,11 @@ STATIC mp_obj_t esp32_rmt_make_new(const mp_obj_type_t *type, size_t n_args, siz
     config.mem_block_num = 1;
     config.tx_config.loop_en = 0;
 
-    config.tx_config.carrier_en = self->carrier_en;
+    config.tx_config.carrier_en = carrier_en;
     config.tx_config.idle_output_en = 1;
     config.tx_config.idle_level = 0;
     config.tx_config.carrier_duty_percent = self->carrier_duty_percent;
-    config.tx_config.carrier_freq = self->carrier_freq;
+    config.tx_config.carrier_freq_hz = self->carrier_freq;
     config.tx_config.carrier_level = 1;
 
     config.clk_div = self->clock_div;
@@ -123,7 +121,7 @@ STATIC void esp32_rmt_print(const mp_print_t *print, mp_obj_t self_in, mp_print_
     if (self->pin != -1) {
         mp_printf(print, "RMT(channel=%u, pin=%u, source_freq=%u, clock_div=%u",
             self->channel_id, self->pin, APB_CLK_FREQ, self->clock_div);
-        if (self->carrier_en) {
+        if (self->carrier_freq > 0) {
             mp_printf(print, ", carrier_freq=%u, carrier_duty_percent=%u)",
                 self->carrier_freq, self->carrier_duty_percent);
         } else {

--- a/ports/esp32/esp32_rmt.c
+++ b/ports/esp32/esp32_rmt.c
@@ -78,7 +78,6 @@ STATIC mp_obj_t esp32_rmt_make_new(const mp_obj_type_t *type, size_t n_args, siz
     mp_uint_t carrier_freq_hz = 0;
 
     if (args[4].u_obj != MP_OBJ_NULL) {
-	// if a frequency is specified then assume carrier_en
         carrier_en = mp_const_true;
         carrier_duty_percent = args[3].u_int;
         carrier_freq_hz = mp_obj_get_int(args[4].u_obj);
@@ -132,7 +131,7 @@ STATIC void esp32_rmt_print(const mp_print_t *print, mp_obj_t self_in, mp_print_
     } else {
         mp_printf(print, "RMT()");
     }
-}_
+}
 
 STATIC mp_obj_t esp32_rmt_deinit(mp_obj_t self_in) {
     // fixme: check for valid channel. Return exception if error occurs.

--- a/ports/esp32/esp32_rmt.c
+++ b/ports/esp32/esp32_rmt.c
@@ -132,7 +132,7 @@ STATIC void esp32_rmt_print(const mp_print_t *print, mp_obj_t self_in, mp_print_
     } else {
         mp_printf(print, "RMT()");
     }
-}
+}_
 
 STATIC mp_obj_t esp32_rmt_deinit(mp_obj_t self_in) {
     // fixme: check for valid channel. Return exception if error occurs.

--- a/ports/esp32/esp32_rmt.c
+++ b/ports/esp32/esp32_rmt.c
@@ -77,10 +77,10 @@ STATIC mp_obj_t esp32_rmt_make_new(const mp_obj_type_t *type, size_t n_args, siz
     mp_uint_t carrier_duty_percent = 0;
     mp_uint_t carrier_freq_hz = 0;
 
-    if (mp_obj_is_type(args[4].u_obj, &mp_type_int)) {  // if a frequency is specified then assume carrier_en
+    if (mp_obj_is_type(args[4], &mp_type_int)) {  // if a frequency is specified then assume carrier_en
         carrier_en = mp_const_true;
         carrier_duty_percent = args[3].u_int;
-        carrier_freq_hz = mp_obj_get_int(args[4].u_obj);
+        carrier_freq_hz = mp_obj_get_int(args[4]);
     }
 
     if (clock_div < 1 || clock_div > 255) {

--- a/ports/esp32/esp32_rmt.c
+++ b/ports/esp32/esp32_rmt.c
@@ -73,14 +73,14 @@ STATIC mp_obj_t esp32_rmt_make_new(const mp_obj_type_t *type, size_t n_args, siz
     gpio_num_t pin_id = machine_pin_get_id(args[1].u_obj);
     mp_uint_t clock_div = args[2].u_int;
 
+    mp_obj_t carrier_en = mp_const_false;
+    mp_uint_t carrier_duty_percent = 0;
+    mp_uint_t carrier_freq_hz = 0;
+
     if (mp_obj_is_type(args[4].u_obj, &mp_type_int)) {  // if a frequency is specified then assume carrier_en
-        mp_obj_t carrier_en = mp_const_true;
-        mp_uint_t carrier_duty_percent = args[3].u_int;
-        mp_uint_t carrier_freq_hz = mp_obj_get_int(args[4].u_obj);
-    } else {
-        mp_obj_t carrier_en = mp_const_false;
-        mp_uint_t carrier_duty_percent = 0;
-        mp_uint_t carrier_freq_hz = 0;
+        carrier_en = mp_const_true;
+        carrier_duty_percent = args[3].u_int;
+        carrier_freq_hz = mp_obj_get_int(args[4].u_obj);
     }
 
     if (clock_div < 1 || clock_div > 255) {


### PR DESCRIPTION
continuing from my premature pull request here: https://github.com/micropython/micropython/pull/6118