### PR TITLE
py/map.c: Clear value when re-using slot with ordered dictionaries

### DIFF
--- a/py/map.c
+++ b/py/map.c
@@ -221,6 +221,7 @@ mp_map_elem_t *MICROPY_WRAP_MP_MAP_LOOKUP(mp_map_lookup)(mp_map_t * map, mp_obj_
         }
         mp_map_elem_t *elem = map->table + map->used++;
         elem->key = index;
+        elem->value = MP_OBJ_NULL;
         if (!mp_obj_is_qstr(index)) {
             map->all_keys_are_qstrs = 0;
         }


### PR DESCRIPTION
Discovered this issue due to an intermittent crash when using `moduselect.c` with a series of serial ports that are continually connecting to send short bursts of data and then disconnecting.

This change brings the new ordered dictionary implementation in line with other places that re-use slots in maps or dictionaries, including:
* https://github.com/micropython/micropython/blob/51fd6c97773a7e0d76bb61e220b35b98f392e27e/py/map.c#L240-L241
* https://github.com/micropython/micropython/blob/51fd6c97773a7e0d76bb61e220b35b98f392e27e/py/objdict.c#L339-L340
* https://github.com/micropython/micropython/blob/51fd6c97773a7e0d76bb61e220b35b98f392e27e/py/map.c#L280-L281

The specific bug arises when a new item is added using `mp_map_lookup` that is able to occupy an available slot without causing the dictionary to re-allocate.

Roughly, the code that causes this issue could be like:
```
// Add a key that will cause an allocation
mp_map_elem_t *elem = mp_map_lookup(poll_map, mp_obj_id(obj_in), MP_MAP_LOOKUP_ADD_IF_NOT_FOUND);
elem->value = 100; // Set a value for us to discover later

// Now remove the new key
mp_map_lookup(&self->poll_map, mp_obj_id(obj_in), MP_MAP_LOOKUP_REMOVE_IF_FOUND);

// And add it back again
mp_map_elem_t *elem2 = mp_map_lookup(poll_map, mp_obj_id(obj_in), MP_MAP_LOOKUP_ADD_IF_NOT_FOUND);

// When the bug is present, the value returned will be identical, though it should be MP_OBJ_NULL)
assert(elem->value != elem2->value)
```
