### PR TITLE
py/obj.h: Clarify comments about mp_map_t is_fixed and is_ordered.

### DIFF
--- a/py/obj.h
+++ b/py/obj.h
@@ -407,8 +407,8 @@ typedef struct _mp_rom_map_elem_t {
 
 typedef struct _mp_map_t {
     size_t all_keys_are_qstrs : 1;
-    size_t is_fixed : 1;    // a fixed array that can't be modified; must also be ordered
-    size_t is_ordered : 1;  // an ordered array
+    size_t is_fixed : 1;    // if set, table is fixed/read-only and can't be modified
+    size_t is_ordered : 1;  // if set, table is an ordered array, not a hash map
     size_t used : (8 * sizeof(size_t) - 3);
     size_t alloc;
     mp_map_elem_t *table;


### PR DESCRIPTION
Long ago, prior to 0ef01d0a75b8b2f48a72f0041e048a390b9e75b6, fixed and ordered maps were the same setting with the "table_is_fixed_array" member of mp_map_t.  But these settings are actually independent, and it is possible to have is_fixed=1, is_ordered=0 (although this can currently only be done by tools/cc1).  So update the comments to reflect this.