### PR TITLE
extmod/modujson: Allow json.loads() to preserve dict order.

### DIFF
--- a/extmod/modjson.c
+++ b/extmod/modjson.c
@@ -283,6 +283,12 @@ static mp_obj_t mod_json_load(mp_obj_t stream_obj) {
                 break;
             case '{':
                 next = mp_obj_new_dict(0);
+                #if MICROPY_PY_JSON_ORDERED_DICT
+                // keep the locals ordered
+                mp_obj_dict_t *dict = MP_OBJ_TO_PTR(next);
+                dict->map.is_ordered = 1;
+                #endif
+
                 enter = true;
                 break;
             case '}':

--- a/ports/unix/variants/coverage/mpconfigvariant.h
+++ b/ports/unix/variants/coverage/mpconfigvariant.h
@@ -45,6 +45,7 @@
 #undef MICROPY_VFS_ROM_IOCTL
 #define MICROPY_VFS_ROM_IOCTL          (1)
 #define MICROPY_PY_CRYPTOLIB_CTR       (1)
+#define MICROPY_PY_JSON_ORDERED_DICT   (1)
 #define MICROPY_SCHEDULER_STATIC_NODES (1)
 
 // Enable os.uname for attrtuple coverage test

--- a/py/mpconfig.h
+++ b/py/mpconfig.h
@@ -1912,6 +1912,10 @@ typedef time_t mp_timestamp_t;
 #define MICROPY_PY_JSON (MICROPY_CONFIG_ROM_LEVEL_AT_LEAST_EXTRA_FEATURES)
 #endif
 
+#ifndef MICROPY_PY_JSON_ORDERED_DICT
+#define MICROPY_PY_JSON_ORDERED_DICT (0)
+#endif
+
 // Whether to support the "separators" argument to dump, dumps
 #ifndef MICROPY_PY_JSON_SEPARATORS
 #define MICROPY_PY_JSON_SEPARATORS (1)

--- a/tests/extmod/json_loads.py
+++ b/tests/extmod/json_loads.py
@@ -4,6 +4,12 @@ except ImportError:
     print("SKIP")
     raise SystemExit
 
+try:
+    extra_coverage
+    is_coverage = True
+except NameError:
+    is_coverage = False
+
 
 def my_print(o):
     if isinstance(o, dict):
@@ -32,6 +38,12 @@ my_print(json.loads('"abc\\ndef"'))
 my_print(json.loads('"abc\\rdef"'))
 my_print(json.loads('"abc\\tdef"'))
 my_print(json.loads('"abc\\uabcd"'))
+
+if is_coverage:  # Has ordered json loads enabled
+    o = json.loads('{"b":null, "c":false, "e":true}')
+    print(list(o.items()) == list(sorted(o.items())))
+else:
+    print(True)
 
 # whitespace handling
 my_print(json.loads('{\n\t"a":[]\r\n, "b":[1], "c":{"3":4}     \n\r\t\r\r\r\n}'))


### PR DESCRIPTION
When MICROPY_PY_UJSON_ORDERED_DICT is enabled.

Migrating away from using my previous https://github.com/micropython/micropython/pull/5323 PR to make all dict's ordered has unearthed a few other places we were relying on such functionality. 