### PR TITLE
ports/mimxrt/boards: Set __heap_size to 0 in MIMXRT1011.ld

### DIFF
--- a/ports/mimxrt/boards/MIMXRT1011.ld
+++ b/ports/mimxrt/boards/MIMXRT1011.ld
@@ -2,6 +2,7 @@
 __stack_size__ = 0x6000;
 _estack = __StackTop;
 _sstack = __StackLimit;
+__heap_size__ = 0;  /* Do not use the traditional C heap. */
 
 /* Use second OCRAM bank for GC heap. */
 _gc_heap_start = ORIGIN(m_data2);


### PR DESCRIPTION
- Set __heap_size as 0 to make MIMXRT1011 compile pass.