### PR TITLE
Uncrustify 0.71

### DIFF
--- a/py/objfun.c
+++ b/py/objfun.c
@@ -197,8 +197,8 @@ STATIC void dump_args(const mp_obj_t *a, size_t sz) {
         MP_BC_PRELUDE_SIG_DECODE_INTO(ip, n_state_out_var, n_exc_stack, scope_flags, n_pos_args, n_kwonly_args, n_def_args); \
                                     \
         /* state size in bytes */                                                 \
-        state_size_out_var = n_state_out_var *sizeof(mp_obj_t)                   \
-            + n_exc_stack *sizeof(mp_exc_stack_t);                \
+        state_size_out_var = n_state_out_var * sizeof(mp_obj_t)                   \
+            + n_exc_stack * sizeof(mp_exc_stack_t);                \
     }
 
 #define INIT_CODESTATE(code_state, _fun_bc, _n_state, n_args, n_kw, args) \

--- a/tools/codeformat.py
+++ b/tools/codeformat.py
@@ -76,9 +76,6 @@ C_EXTS = (
 PY_EXTS = (".py",)
 
 
-FIXUP_REPLACEMENTS = ((re.compile("sizeof\(([a-z_]+)\) \*\(([a-z_]+)\)"), r"sizeof(\1) * (\2)"),)
-
-
 def list_files(paths, exclusions=None, prefix=""):
     files = set()
     for pattern in paths:
@@ -123,10 +120,6 @@ def fixup_c(filename):
                         l = l[indent_diff:]
                     if directive == "endif":
                         dedent_stack.pop()
-
-            # Apply general regex-based fixups.
-            for regex, replacement in FIXUP_REPLACEMENTS:
-                l = regex.sub(replacement, l)
 
             # Write out line.
             f.write(l)

--- a/tools/uncrustify.cfg
+++ b/tools/uncrustify.cfg
@@ -1,4 +1,4 @@
-# Uncrustify-0.70.1
+# Uncrustify-0.71.0
 
 #
 # General options
@@ -668,12 +668,6 @@ sp_try_brace                    = ignore   # ignore/add/remove/force
 
 # Add or remove space between get/set and '{' if on the same line.
 sp_getset_brace                 = ignore   # ignore/add/remove/force
-
-# Add or remove space between a variable and '{' for C++ uniform
-# initialization.
-#
-# Default: add
-sp_word_brace                   = add      # ignore/add/remove/force
 
 # Add or remove space between a variable and '{' for a namespace.
 #


### PR DESCRIPTION
I updated the Pybricks PPA to uncrustify 0.71 that was released last month. It has a fix so that one less workaround is needed. Also an option was deprecated, so that is removed from our config file.