### PR TITLE
Custom float (and complex) casts

### DIFF
--- a/py/objcomplex.c
+++ b/py/objcomplex.c
@@ -94,7 +94,7 @@ STATIC mp_obj_t complex_make_new(const mp_obj_type_t *type_in, size_t n_args, si
                 if (dest[0] != MP_OBJ_NULL) {
                     mp_obj_t ret = mp_call_method_n_kw(0, 0, dest);
                     if (!mp_obj_is_type(ret, &mp_type_complex)) {
-		        mp_raise_TypeError(MP_ERROR_TEXT("__complex__ method returned non-complex"));
+                        mp_raise_TypeError(MP_ERROR_TEXT("__complex__ method returned non-complex"));
                     }
                     return ret;
                 }

--- a/py/objcomplex.c
+++ b/py/objcomplex.c
@@ -89,6 +89,15 @@ STATIC mp_obj_t complex_make_new(const mp_obj_type_t *type_in, size_t n_args, si
                 return args[0];
             } else {
                 // something else, try to cast it to a complex
+                mp_obj_t dest[2];
+                mp_load_method_maybe(args[0], MP_QSTR___complex__, dest);
+                if (dest[0] != MP_OBJ_NULL) {
+                    mp_obj_t ret = mp_call_method_n_kw(0, 0, dest);
+                    if (!mp_obj_is_type(ret, &mp_type_complex)) {
+                        mp_raise_TypeError("__complex__ method returned non-complex");
+                    }
+                    return ret;
+                }
                 return mp_obj_new_complex(mp_obj_get_float(args[0]), 0);
             }
 

--- a/py/objcomplex.c
+++ b/py/objcomplex.c
@@ -94,7 +94,7 @@ STATIC mp_obj_t complex_make_new(const mp_obj_type_t *type_in, size_t n_args, si
                 if (dest[0] != MP_OBJ_NULL) {
                     mp_obj_t ret = mp_call_method_n_kw(0, 0, dest);
                     if (!mp_obj_is_type(ret, &mp_type_complex)) {
-                        mp_raise_TypeError("__complex__ method returned non-complex");
+		        mp_raise_TypeError(MP_ERROR_TEXT("__complex__ method returned non-complex"));
                     }
                     return ret;
                 }

--- a/py/objfloat.c
+++ b/py/objfloat.c
@@ -140,7 +140,7 @@ STATIC mp_obj_t float_make_new(const mp_obj_type_t *type_in, size_t n_args, size
                 if (dest[0] != MP_OBJ_NULL) {
                     mp_obj_t ret = mp_call_method_n_kw(0, 0, dest);
                     if (!mp_obj_is_float(ret)) {
-                        mp_raise_TypeError("__float__ method returned non-float");
+		        mp_raise_TypeError(MP_ERROR_TEXT("__float__ method returned non-float"));
                     }
                     return ret;
                 }

--- a/py/objfloat.c
+++ b/py/objfloat.c
@@ -135,6 +135,15 @@ STATIC mp_obj_t float_make_new(const mp_obj_type_t *type_in, size_t n_args, size
                 return args[0];
             } else {
                 // something else, try to cast it to a float
+                mp_obj_t dest[2];
+                mp_load_method_maybe(args[0], MP_QSTR___float__, dest);
+                if (dest[0] != MP_OBJ_NULL) {
+                    mp_obj_t ret = mp_call_method_n_kw(0, 0, dest);
+                    if (!mp_obj_is_float(ret)) {
+                        mp_raise_TypeError("__float__ method returned non-float");
+                    }
+                    return ret;
+                }
                 return mp_obj_new_float(mp_obj_get_float(args[0]));
             }
         }

--- a/py/objfloat.c
+++ b/py/objfloat.c
@@ -140,7 +140,7 @@ STATIC mp_obj_t float_make_new(const mp_obj_type_t *type_in, size_t n_args, size
                 if (dest[0] != MP_OBJ_NULL) {
                     mp_obj_t ret = mp_call_method_n_kw(0, 0, dest);
                     if (!mp_obj_is_float(ret)) {
-		        mp_raise_TypeError(MP_ERROR_TEXT("__float__ method returned non-float"));
+                        mp_raise_TypeError(MP_ERROR_TEXT("__float__ method returned non-float"));
                     }
                     return ret;
                 }

--- a/tests/float/custom_cast.py
+++ b/tests/float/custom_cast.py
@@ -1,17 +1,21 @@
+# Test a class that behaves correctly
+
 class Test1:
     def __float__(self):
         return 123.4
     def __complex__(self):
         return 123.4j
 
+print(float(Test1()))
+print(complex(Test1()))
+
+# Test a class that returns the wrong type
+
 class Test2:
     def _float__(self):
         return "Not a float"
     def __complex__(self):
         return "Not very complex"
-
-print(float(Test1()))
-print(complex(Test1()))
 
 try:
     print(float(Test2()))
@@ -23,3 +27,17 @@ try:
 except TypeError:
     print("TypeError")
 
+# Test a class that doesn't implement the conversion methods
+
+class Test3:
+    pass
+
+try:
+    print(float(Test3()))
+except TypeError:
+    print("TypeError")
+
+try:
+    print(complex(Test3()))
+except TypeError:
+    print("TypeError")

--- a/tests/float/custom_cast.py
+++ b/tests/float/custom_cast.py
@@ -1,21 +1,27 @@
 # Test a class that behaves correctly
 
+
 class Test1:
     def __float__(self):
         return 123.4
+
     def __complex__(self):
         return 123.4j
+
 
 print(float(Test1()))
 print(complex(Test1()))
 
 # Test a class that returns the wrong type
 
+
 class Test2:
     def __float__(self):
         return "Not a float"
+
     def __complex__(self):
         return "Not very complex"
+
 
 try:
     print(float(Test2()))
@@ -29,8 +35,10 @@ except TypeError:
 
 # Test a class that doesn't implement the conversion methods
 
+
 class Test3:
     pass
+
 
 try:
     print(float(Test3()))

--- a/tests/float/custom_cast.py
+++ b/tests/float/custom_cast.py
@@ -12,7 +12,7 @@ print(complex(Test1()))
 # Test a class that returns the wrong type
 
 class Test2:
-    def _float__(self):
+    def __float__(self):
         return "Not a float"
     def __complex__(self):
         return "Not very complex"

--- a/tests/float/custom_cast.py
+++ b/tests/float/custom_cast.py
@@ -1,0 +1,25 @@
+class Test1:
+    def __float__(self):
+        return 123.4
+    def __complex__(self):
+        return 123.4j
+
+class Test2:
+    def _float__(self):
+        return "Not a float"
+    def __complex__(self):
+        return "Not very complex"
+
+print(float(Test1()))
+print(complex(Test1()))
+
+try:
+    print(float(Test2()))
+except TypeError:
+    print("TypeError")
+
+try:
+    print(complex(Test2()))
+except TypeError:
+    print("TypeError")
+


### PR DESCRIPTION
This PR implements support for the `__float__` and `__complex__` special methods as described in the [Python data mode](https://docs.python.org/3.5/reference/datamodel.html#object.__complex__) for platforms that support the `float` and `complex` types. These methods allow custom classes to provide `float` or `complex` representations of themselves.

## Compatibility with C Python

The exceptions raised by this PR are the same types as those raised by C Python, but the messages are different (shorter, and constant). One minor difference in functionality is that this code raises a TypeError if the type of the results from these methods is not the desired `float` or `complex`, whereas C Python 3.6 and 3.7 allow subclasses of those types but issue a deprecation warning to indicate that the strict type will be required in the future.

## Is this addition necessary?

The main benefit of this addition is that it improves compatibility with C Python. The two use cases that motivated its creation were (a) custom classes representing sensors that have numeric, non-integer values and (b) allowing better compatibility for a micro-implementation of a subset of NumPy.

The additional code is very small (the static exception messages take up more space than the code on most CPU architectures, and could be made smaller if they were less informative). The code is only present on platforms that already carry the weight of the optional `float` and `complex` classes.

