### PR TITLE
stm32: Support 2xVCP on WB55 MCUs, fix rfcore txpower init, allow building without FAT

### DIFF
--- a/ports/stm32/factoryreset.c
+++ b/ports/stm32/factoryreset.c
@@ -34,6 +34,8 @@
 
 #if MICROPY_HW_ENABLE_STORAGE
 
+#if MICROPY_VFS_FAT
+
 static const char fresh_boot_py[] =
     "# boot.py -- run on boot-up\r\n"
     "# can run arbitrary Python, but best to keep it minimal\r\n"
@@ -127,5 +129,14 @@ MP_WEAK int factory_reset_create_filesystem(void) {
 
     return 0; // success
 }
+
+#else
+
+// If FAT is not enabled then it's up to the board to create a fresh filesystem.
+MP_WEAK int factory_reset_create_filesystem(void) {
+    return 0; // success
+}
+
+#endif
 
 #endif // MICROPY_HW_ENABLE_STORAGE

--- a/ports/stm32/rfcore.c
+++ b/ports/stm32/rfcore.c
@@ -416,8 +416,13 @@ void rfcore_ble_check_msg(int (*cb)(void *, const uint8_t *, size_t), void *env)
         SWAP_UINT8(buf[3], buf[6]);
         SWAP_UINT8(buf[4], buf[5]);
         tl_ble_hci_cmd_resp(HCI_OPCODE(OGF_VENDOR, OCF_WRITE_CONFIG), 8, buf); // set BDADDR
-        tl_ble_hci_cmd_resp(HCI_OPCODE(OGF_VENDOR, OCF_SET_TX_POWER), 2, (const uint8_t *)"\x00\x06"); // 0 dBm
     }
+}
+
+// "level" is 0x00-0x1f, ranging from -40 dBm to +6 dBm (not linear).
+void rfcore_ble_set_txpower(uint8_t level) {
+    uint8_t buf[2] = { 0x00, level };
+    tl_ble_hci_cmd_resp(HCI_OPCODE(OGF_VENDOR, OCF_SET_TX_POWER), 2, buf);
 }
 
 #endif // defined(STM32WB)

--- a/ports/stm32/rfcore.h
+++ b/ports/stm32/rfcore.h
@@ -33,5 +33,6 @@ void rfcore_init(void);
 void rfcore_ble_init(void);
 void rfcore_ble_hci_cmd(size_t len, const uint8_t *src);
 void rfcore_ble_check_msg(int (*cb)(void *, const uint8_t *, size_t), void *env);
+void rfcore_ble_set_txpower(uint8_t level);
 
 #endif // MICROPY_INCLUDED_STM32_RFCORE_H

--- a/ports/stm32/usb.c
+++ b/ports/stm32/usb.c
@@ -93,8 +93,29 @@ pyb_usb_storage_medium_t pyb_usb_storage_medium = PYB_USB_STORAGE_MEDIUM_NONE;
 // Units of FIFO size arrays below are 4x 16-bit words = 8 bytes
 // There are 512x 16-bit words it total to use here (when using PCD_SNG_BUF)
 
-// EP0(out), EP0(in), MSC/HID(out), MSC/HID(in), unused, CDC_CMD(in), CDC_DATA(out), CDC_DATA(in)
-STATIC const uint8_t usbd_fifo_size_cdc1[] = {16, 16, 16, 16, 0, 16, 16, 16};
+STATIC const uint8_t usbd_fifo_size_cdc1[USBD_PMA_NUM_FIFO] = {
+    16, 16, 16, 16,         // EP0(out), EP0(in), MSC/HID(out), MSC/HID(in)
+    0, 16, 16, 16,          // unused, CDC_CMD(in), CDC_DATA(out), CDC_DATA(in)
+    0, 0, 0, 0, 0, 0, 0, 0, // 8x unused
+};
+
+#if MICROPY_HW_USB_CDC_NUM >= 2
+STATIC const uint8_t usbd_fifo_size_cdc2[USBD_PMA_NUM_FIFO] = {
+    8, 8, 16, 16,           // EP0(out), EP0(in), MSC/HID(out), MSC/HID(in)
+    0, 8, 12, 12,           // unused, CDC_CMD(in), CDC_DATA(out), CDC_DATA(in)
+    0, 8, 12, 12,           // unused, CDC2_CMD(in), CDC2_DATA(out), CDC2_DATA(in)
+    0, 0, 0, 0,             // 4x unused
+};
+
+// RX; EP0(in), MSC/HID, CDC_CMD, CDC_DATA, CDC2_CMD/HID, CDC2_DATA, HID
+STATIC const uint8_t usbd_fifo_size_cdc2_msc_hid[USBD_PMA_NUM_FIFO] = {
+    8, 8, 16, 16,           // EP0(out), EP0(in), MSC/HID(out), MSC/HID(in)
+    0, 8, 8, 8,             // unused, CDC_CMD(in), CDC_DATA(out), CDC_DATA(in)
+    0, 8, 8, 8,             // unused, CDC2_CMD(in), CDC2_DATA(out), CDC2_DATA(in)
+    8, 8,                   // HID(out), HID(in)
+    0, 0,                   // 2x unused
+};
+#endif
 
 #else
 

--- a/ports/stm32/usbd_conf.h
+++ b/ports/stm32/usbd_conf.h
@@ -51,7 +51,7 @@
 
 // For MCUs with a device-only USB peripheral
 #define USBD_PMA_RESERVE                      (64)
-#define USBD_PMA_NUM_FIFO                     (8)
+#define USBD_PMA_NUM_FIFO                     (16) // Maximum 8 endpoints, 2 FIFOs each
 
 // For MCUs with multiple OTG USB peripherals
 #define USBD_FS_NUM_TX_FIFO                   (6)


### PR DESCRIPTION
A set of minor improvements for stm32, mainly for WB55.