### PR TITLE
tools/uncrustify: Enable more options to remove space between function name and '('.

### DIFF
--- a/extmod/vfs_fat_diskio.c
+++ b/extmod/vfs_fat_diskio.c
@@ -52,7 +52,7 @@ STATIC fs_user_mount_t *disk_get_device(void *bdev) {
 /* Read Sector(s)                                                        */
 /*-----------------------------------------------------------------------*/
 
-DRESULT disk_read (
+DRESULT disk_read(
     bdev_t pdrv,      /* Physical drive nmuber (0..) */
     BYTE *buff,        /* Data buffer to store read data */
     DWORD sector,    /* Sector address (LBA) */
@@ -72,7 +72,7 @@ DRESULT disk_read (
 /* Write Sector(s)                                                       */
 /*-----------------------------------------------------------------------*/
 
-DRESULT disk_write (
+DRESULT disk_write(
     bdev_t pdrv,          /* Physical drive nmuber (0..) */
     const BYTE *buff,    /* Data to be written */
     DWORD sector,        /* Sector address (LBA) */
@@ -98,7 +98,7 @@ DRESULT disk_write (
 /* Miscellaneous Functions                                               */
 /*-----------------------------------------------------------------------*/
 
-DRESULT disk_ioctl (
+DRESULT disk_ioctl(
     bdev_t pdrv,      /* Physical drive nmuber (0..) */
     BYTE cmd,        /* Control code */
     void *buff        /* Buffer to send/receive control data */

--- a/lib/utils/printf.c
+++ b/lib/utils/printf.c
@@ -104,7 +104,7 @@ STATIC void strn_print_strn(void *data, const char *str, size_t len) {
 // when linkings against it statically.
 // GCC 9 gives a warning about missing attributes so it's excluded until
 // uClibc+GCC9 support is needed.
-int __GI_vsnprintf(char *str, size_t size, const char *fmt, va_list ap) __attribute__((weak, alias ("vsnprintf")));
+int __GI_vsnprintf(char *str, size_t size, const char *fmt, va_list ap) __attribute__((weak, alias("vsnprintf")));
 #endif
 
 int vsnprintf(char *str, size_t size, const char *fmt, va_list ap) {

--- a/ports/cc3200/main.c
+++ b/ports/cc3200/main.c
@@ -51,8 +51,8 @@
  ******************************************************************************/
 
 // This is the static memory (TCB and stack) for the idle task
-static StaticTask_t xIdleTaskTCB __attribute__ ((section (".rtos_heap")));
-static StackType_t uxIdleTaskStack[configMINIMAL_STACK_SIZE] __attribute__ ((section (".rtos_heap"))) __attribute__((aligned (8)));
+static StaticTask_t xIdleTaskTCB __attribute__ ((section(".rtos_heap")));
+static StackType_t uxIdleTaskStack[configMINIMAL_STACK_SIZE] __attribute__ ((section(".rtos_heap"))) __attribute__((aligned(8)));
 
 /******************************************************************************
  DECLARE PUBLIC DATA
@@ -62,18 +62,18 @@ OsiTaskHandle mpTaskHandle;
 #endif
 
 // This is the FreeRTOS heap, defined here so we can put it in a special segment
-uint8_t ucHeap[ configTOTAL_HEAP_SIZE ] __attribute__ ((section (".rtos_heap"))) __attribute__((aligned (8)));
+uint8_t ucHeap[ configTOTAL_HEAP_SIZE ] __attribute__ ((section(".rtos_heap"))) __attribute__((aligned(8)));
 
 // This is the static memory (TCB and stack) for the main MicroPython task
-StaticTask_t mpTaskTCB __attribute__ ((section (".rtos_heap")));
-StackType_t mpTaskStack[MICROPY_TASK_STACK_LEN] __attribute__ ((section (".rtos_heap"))) __attribute__((aligned (8)));
+StaticTask_t mpTaskTCB __attribute__ ((section(".rtos_heap")));
+StackType_t mpTaskStack[MICROPY_TASK_STACK_LEN] __attribute__ ((section(".rtos_heap"))) __attribute__((aligned(8)));
 
 /******************************************************************************
  DEFINE PUBLIC FUNCTIONS
  ******************************************************************************/
 
-__attribute__ ((section (".boot")))
-int main (void) {
+__attribute__ ((section(".boot")))
+int main(void) {
 
     // Initialize the clocks and the interrupt system
     HAL_SystemInit();

--- a/ports/cc3200/mptask.c
+++ b/ports/cc3200/mptask.c
@@ -113,7 +113,7 @@ static const char fresh_boot_py[] = "# boot.py -- run on boot-up\r\n"
 
 uintptr_t cortex_m3_get_sp(void);
 
-void TASK_MicroPython (void *pvParameters) {
+void TASK_MicroPython(void *pvParameters) {
     // get the top of the stack to initialize the garbage collector
     uint32_t sp = cortex_m3_get_sp();
 
@@ -262,16 +262,16 @@ soft_reset_exit:
 /******************************************************************************
  DEFINE PRIVATE FUNCTIONS
  ******************************************************************************/
-__attribute__ ((section (".boot")))
-STATIC void mptask_pre_init (void) {
+__attribute__ ((section(".boot")))
+STATIC void mptask_pre_init(void) {
     // this one only makes sense after a poweron reset
     pyb_rtc_pre_init();
 
     // Create the simple link spawn task
-    ASSERT (OSI_OK == VStartSimpleLinkSpawnTask(SIMPLELINK_SPAWN_TASK_PRIORITY));
+    ASSERT(OSI_OK == VStartSimpleLinkSpawnTask(SIMPLELINK_SPAWN_TASK_PRIORITY));
 
     // Allocate memory for the flash file system
-    ASSERT ((sflash_vfs_fat = mem_Malloc(sizeof(*sflash_vfs_fat))) != NULL);
+    ASSERT((sflash_vfs_fat = mem_Malloc(sizeof(*sflash_vfs_fat))) != NULL);
 
     // this one allocates memory for the nvic vault
     pyb_sleep_pre_init();
@@ -295,7 +295,7 @@ STATIC void mptask_pre_init (void) {
     ASSERT(svTaskHandle != NULL);
 }
 
-STATIC void mptask_init_sflash_filesystem (void) {
+STATIC void mptask_init_sflash_filesystem(void) {
     FILINFO fno;
 
     // Initialise the local flash filesystem.
@@ -378,16 +378,16 @@ STATIC void mptask_init_sflash_filesystem (void) {
     }
 }
 
-STATIC void mptask_enter_ap_mode (void) {
+STATIC void mptask_enter_ap_mode(void) {
     // append the mac only if it's not the first boot
     bool add_mac = !PRCMGetSpecialBit(PRCM_FIRST_BOOT_BIT);
     // enable simplelink in ap mode (use the MAC address to make the ssid unique)
-    wlan_sl_init (ROLE_AP, MICROPY_PORT_WLAN_AP_SSID, strlen(MICROPY_PORT_WLAN_AP_SSID),
+    wlan_sl_init(ROLE_AP, MICROPY_PORT_WLAN_AP_SSID, strlen(MICROPY_PORT_WLAN_AP_SSID),
         MICROPY_PORT_WLAN_AP_SECURITY, MICROPY_PORT_WLAN_AP_KEY, strlen(MICROPY_PORT_WLAN_AP_KEY),
         MICROPY_PORT_WLAN_AP_CHANNEL, ANTENNA_TYPE_INTERNAL, add_mac);
 }
 
-STATIC void mptask_create_main_py (void) {
+STATIC void mptask_create_main_py(void) {
     // create empty main.py
     FIL fp;
     f_open(&sflash_vfs_fat->fatfs, &fp, "/main.py", FA_WRITE | FA_CREATE_ALWAYS);

--- a/ports/cc3200/serverstask.c
+++ b/ports/cc3200/serverstask.c
@@ -68,8 +68,8 @@ static volatile bool sleep_sockets = false;
  ******************************************************************************/
 
 // This is the static memory (TCB and stack) for the servers task
-StaticTask_t svTaskTCB __attribute__ ((section (".rtos_heap")));
-StackType_t svTaskStack[SERVERS_STACK_LEN] __attribute__ ((section (".rtos_heap"))) __attribute__((aligned (8)));
+StaticTask_t svTaskTCB __attribute__ ((section(".rtos_heap")));
+StackType_t svTaskStack[SERVERS_STACK_LEN] __attribute__ ((section(".rtos_heap"))) __attribute__((aligned(8)));
 
 char servers_user[SERVERS_USER_PASS_LEN_MAX + 1];
 char servers_pass[SERVERS_USER_PASS_LEN_MAX + 1];
@@ -77,12 +77,12 @@ char servers_pass[SERVERS_USER_PASS_LEN_MAX + 1];
 /******************************************************************************
  DECLARE PUBLIC FUNCTIONS
  ******************************************************************************/
-void TASK_Servers (void *pvParameters) {
+void TASK_Servers(void *pvParameters) {
 
     bool cycle = false;
 
-    strcpy (servers_user, SERVERS_DEF_USER);
-    strcpy (servers_pass, SERVERS_DEF_PASS);
+    strcpy(servers_user, SERVERS_DEF_USER);
+    strcpy(servers_pass, SERVERS_DEF_PASS);
 
     telnet_init();
     ftp_init();
@@ -143,12 +143,12 @@ void TASK_Servers (void *pvParameters) {
     }
 }
 
-void servers_start (void) {
+void servers_start(void) {
     servers_data.do_enable = true;
     mp_hal_delay_ms(SERVERS_CYCLE_TIME_MS * 3);
 }
 
-void servers_stop (void) {
+void servers_stop(void) {
     servers_data.do_disable = true;
     do {
         mp_hal_delay_ms(SERVERS_CYCLE_TIME_MS);
@@ -156,24 +156,24 @@ void servers_stop (void) {
     mp_hal_delay_ms(SERVERS_CYCLE_TIME_MS * 3);
 }
 
-void servers_reset (void) {
+void servers_reset(void) {
     servers_data.do_reset = true;
 }
 
-void servers_wlan_cycle_power (void) {
+void servers_wlan_cycle_power(void) {
     servers_data.do_wlan_cycle_power = true;
 }
 
-bool servers_are_enabled (void) {
+bool servers_are_enabled(void) {
     return servers_data.enabled;
 }
 
-void server_sleep_sockets (void) {
+void server_sleep_sockets(void) {
     sleep_sockets = true;
     mp_hal_delay_ms(SERVERS_CYCLE_TIME_MS + 1);
 }
 
-void servers_close_socket (int16_t *sd) {
+void servers_close_socket(int16_t *sd) {
     if (*sd > 0) {
         modusocket_socket_delete(*sd);
         sl_Close(*sd);
@@ -181,7 +181,7 @@ void servers_close_socket (int16_t *sd) {
     }
 }
 
-void servers_set_login (char *user, char *pass) {
+void servers_set_login(char *user, char *pass) {
     if (strlen(user) > SERVERS_USER_PASS_LEN_MAX || strlen(pass) > SERVERS_USER_PASS_LEN_MAX) {
         mp_raise_ValueError(MP_ERROR_TEXT("invalid argument(s) value"));
     }
@@ -189,7 +189,7 @@ void servers_set_login (char *user, char *pass) {
     memcpy(servers_pass, pass, SERVERS_USER_PASS_LEN_MAX);
 }
 
-void servers_set_timeout (uint32_t timeout) {
+void servers_set_timeout(uint32_t timeout) {
     if (timeout < SERVERS_MIN_TIMEOUT_MS) {
         // timeout is too low
         mp_raise_ValueError(MP_ERROR_TEXT("invalid argument(s) value"));
@@ -197,7 +197,7 @@ void servers_set_timeout (uint32_t timeout) {
     servers_data.timeout = timeout;
 }
 
-uint32_t servers_get_timeout (void) {
+uint32_t servers_get_timeout(void) {
     return servers_data.timeout;
 }
 

--- a/tools/uncrustify.cfg
+++ b/tools/uncrustify.cfg
@@ -512,35 +512,35 @@ sp_func_proto_paren             = remove   # ignore/add/remove/force
 
 # Add or remove space between function name and '()' on function declaration
 # without parameters.
-sp_func_proto_paren_empty       = ignore   # ignore/add/remove/force
+sp_func_proto_paren_empty       = remove   # ignore/add/remove/force
 
 # Add or remove space between function name and '(' with a typedef specifier.
-sp_func_type_paren              = ignore   # ignore/add/remove/force
+sp_func_type_paren              = remove   # ignore/add/remove/force
 
 # Add or remove space between alias name and '(' of a non-pointer function type typedef.
-sp_func_def_paren               = ignore   # ignore/add/remove/force
+sp_func_def_paren               = remove   # ignore/add/remove/force
 
 # Add or remove space between function name and '()' on function definition
 # without parameters.
-sp_func_def_paren_empty         = ignore   # ignore/add/remove/force
+sp_func_def_paren_empty         = remove   # ignore/add/remove/force
 
 # Add or remove space inside empty function '()'.
 # Overrides sp_after_angle unless use_sp_after_angle_always is set to true.
-sp_inside_fparens               = ignore   # ignore/add/remove/force
+sp_inside_fparens               = remove   # ignore/add/remove/force
 
 # Add or remove space inside function '(' and ')'.
 sp_inside_fparen                = remove   # ignore/add/remove/force
 
 # Add or remove space inside the first parentheses in a function type, as in
 # 'void (*x)(...)'.
-sp_inside_tparen                = ignore   # ignore/add/remove/force
+sp_inside_tparen                = remove   # ignore/add/remove/force
 
 # Add or remove space between the ')' and '(' in a function type, as in
 # 'void (*x)(...)'.
-sp_after_tparen_close           = ignore   # ignore/add/remove/force
+sp_after_tparen_close           = remove   # ignore/add/remove/force
 
 # Add or remove space between ']' and '(' when part of a function call.
-sp_square_fparen                = ignore   # ignore/add/remove/force
+sp_square_fparen                = remove   # ignore/add/remove/force
 
 # Add or remove space between ')' and '{' of function.
 sp_fparen_brace                 = force    # ignore/add/remove/force
@@ -555,11 +555,11 @@ sp_fparen_brace_initializer     = ignore   # ignore/add/remove/force
 sp_fparen_dbrace                = ignore   # ignore/add/remove/force
 
 # Add or remove space between function name and '(' on function calls.
-sp_func_call_paren              = ignore   # ignore/add/remove/force
+sp_func_call_paren              = remove   # ignore/add/remove/force
 
 # Add or remove space between function name and '()' on function calls without
 # parameters. If set to ignore (the default), sp_func_call_paren is used.
-sp_func_call_paren_empty        = ignore   # ignore/add/remove/force
+sp_func_call_paren_empty        = remove   # ignore/add/remove/force
 
 # Add or remove space between the user function name and '(' on function
 # calls. You need to set a keyword to be a user function in the config file,


### PR DESCRIPTION
With only `sp_func_proto_paren = remove` set, there are some cases where uncrustify misses removing a space between the function name and the opening `(`. This sets all of the related options to `force` as well.