### PR TITLE
travis: Change nrf pca10056 board to build with soft-device enabled.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -292,10 +292,11 @@ jobs:
         - sudo apt-get install libnewlib-arm-none-eabi
         - arm-none-eabi-gcc --version
       script:
+        - ports/nrf/drivers/bluetooth/download_ble_stack.sh s132_nrf52_6_1_1
         - make ${MAKEOPTS} -C ports/nrf submodules
         - make ${MAKEOPTS} -C ports/nrf BOARD=pca10040
         - make ${MAKEOPTS} -C ports/nrf BOARD=microbit
-        - make ${MAKEOPTS} -C ports/nrf BOARD=pca10056
+        - make ${MAKEOPTS} -C ports/nrf BOARD=pca10056 SD=s132
 
     # bare-arm and minimal ports, with size-diff check
     - stage: test


### PR DESCRIPTION
To test building with SD which enables a lot of additional code.

See issue #6152