### PR TITLE
extmod/btstack: Schedule ops for background completion. 

### DIFF
--- a/docs/library/ubluetooth.rst
+++ b/docs/library/ubluetooth.rst
@@ -48,7 +48,8 @@ Configuration
     - ``'mac'``: Returns the device MAC address. If a device has a fixed address
       (e.g. PYBD) then it will be returned. Otherwise (e.g. ESP32) a random
       address will be generated when the BLE interface is made active.
-      Note: on some ports, accessing this value requires that the interface is
+
+      **Note:** on some ports, accessing this value requires that the interface is
       active (so that the MAC address can be queried from the controller).
 
     - ``'gap_name'``: Get/set the GAP device name used by service 0x1800,
@@ -71,12 +72,12 @@ Event Handling
     arguments, ``event`` (which will be one of the codes below) and ``data``
     (which is an event-specific tuple of values).
 
-    Note: the ``addr``, ``adv_data``, ``char_data``, ``notify_data``, and
-    ``uuid`` entries in the tuples are
-    references to data managed by the :mod:`ubluetooth` module (i.e. the same
-    instance will be re-used across multiple calls to the event handler). If
-    your program wants to use this data outside of the handler, then it must
-    copy them first, e.g. by using ``bytes(addr)`` or ``bluetooth.UUID(uuid)``.
+    **Note:** the ``addr``, ``adv_data``, ``char_data``, ``notify_data``, and
+    ``uuid`` entries in the tuples are references to data managed by the
+    :mod:`ubluetooth` module (i.e. the same instance will be re-used across
+    multiple calls to the event handler). If your program wants to use this
+    data outside of the handler, then it must copy them first, e.g. by using
+    ``bytes(addr)`` or ``bluetooth.UUID(uuid)``.
 
     An event handler showing all possible events::
 
@@ -189,7 +190,7 @@ Broadcaster Role (Advertiser)
     protocol (e.g. ``bytes``, ``bytearray``, ``str``). *adv_data* is included
     in all broadcasts, and *resp_data* is send in reply to an active scan.
 
-    Note: if *adv_data* (or *resp_data*) is ``None``, then the data passed
+    **Note:** if *adv_data* (or *resp_data*) is ``None``, then the data passed
     to the previous call to ``gap_advertise`` will be re-used. This allows a
     broadcaster to resume advertising with just ``gap_advertise(interval_us)``.
     To clear the advertising payload pass an empty ``bytes``, i.e. ``b''``.
@@ -280,8 +281,8 @@ writes from a central to a given characteristic, use
         ( (hr,), (tx, rx,), ) = bt.gatts_register_services(SERVICES)
 
     The three value handles (``hr``, ``tx``, ``rx``) can be used with
-    :meth:`gatts_read <BLE.gatts_read>`, :meth:`gatts_write <BLE.gatts_write>`,
-    and :meth:`gatts_notify <BLE.gatts_notify>`.
+    :meth:`gatts_read <BLE.gatts_read>`, :meth:`gatts_write <BLE.gatts_write>`, :meth:`gatts_notify <BLE.gatts_notify>`, and
+    :meth:`gatts_indicate <BLE.gatts_indicate>`.
 
     **Note:** Advertising must be stopped before registering services.
 
@@ -296,12 +297,24 @@ writes from a central to a given characteristic, use
 
 .. method:: BLE.gatts_notify(conn_handle, value_handle, [data])
 
-    Notifies a connected central that this value has changed and that it should
-    issue a read of the current value from this peripheral.
+    Sends a notification request to a connected central.
 
-    If *data* is specified, then the that value is sent to the central as part
-    of the notification, avoiding the need for a separate read request. Note
-    that this will not update the local value stored.
+    If *data* is specified, then that value is sent to the central as part of
+    the notification. The local value will not be modified.
+
+    Otherwise, if *data* is not specified, then the current local value (as
+    set with :meth:`gatts_write <BLE.gatts_write>`) will be sent.
+
+.. method:: BLE.gatts_indicate(conn_handle, value_handle)
+
+    Sends an indication request to a connected central.
+
+    **Note:** This does not currently support sending a custom value, it will
+    always send the current local value (as set with :meth:`gatts_write
+    <BLE.gatts_write>`).
+
+    **Note:** This does not currently support generating an event for sucessful
+    acknowledgment of the indication.
 
 .. method:: BLE.gatts_set_buffer(value_handle, len, append=False, /)
 

--- a/examples/bluetooth/ble_advertising.py
+++ b/examples/bluetooth/ble_advertising.py
@@ -47,7 +47,8 @@ def advertising_payload(limited_disc=False, br_edr=False, name=None, services=No
                 _append(_ADV_TYPE_UUID128_COMPLETE, b)
 
     # See org.bluetooth.characteristic.gap.appearance.xml
-    _append(_ADV_TYPE_APPEARANCE, struct.pack("<h", appearance))
+    if appearance:
+        _append(_ADV_TYPE_APPEARANCE, struct.pack("<h", appearance))
 
     return payload
 

--- a/examples/bluetooth/ble_simple_central.py
+++ b/examples/bluetooth/ble_simple_central.py
@@ -1,0 +1,245 @@
+# This example finds and connects to a peripheral running the
+# UART service (e.g. ble_simple_peripheral.py).
+
+import bluetooth
+import random
+import struct
+import time
+import micropython
+
+from ble_advertising import decode_services, decode_name
+
+from micropython import const
+
+_IRQ_CENTRAL_CONNECT = const(1)
+_IRQ_CENTRAL_DISCONNECT = const(2)
+_IRQ_GATTS_WRITE = const(3)
+_IRQ_GATTS_READ_REQUEST = const(4)
+_IRQ_SCAN_RESULT = const(5)
+_IRQ_SCAN_DONE = const(6)
+_IRQ_PERIPHERAL_CONNECT = const(7)
+_IRQ_PERIPHERAL_DISCONNECT = const(8)
+_IRQ_GATTC_SERVICE_RESULT = const(9)
+_IRQ_GATTC_SERVICE_DONE = const(10)
+_IRQ_GATTC_CHARACTERISTIC_RESULT = const(11)
+_IRQ_GATTC_CHARACTERISTIC_DONE = const(12)
+_IRQ_GATTC_DESCRIPTOR_RESULT = const(13)
+_IRQ_GATTC_DESCRIPTOR_DONE = const(14)
+_IRQ_GATTC_READ_RESULT = const(15)
+_IRQ_GATTC_READ_DONE = const(16)
+_IRQ_GATTC_WRITE_DONE = const(17)
+_IRQ_GATTC_NOTIFY = const(18)
+_IRQ_GATTC_INDICATE = const(19)
+
+_ADV_IND = const(0x00)
+_ADV_DIRECT_IND = const(0x01)
+_ADV_SCAN_IND = const(0x02)
+_ADV_NONCONN_IND = const(0x03)
+
+_UART_SERVICE_UUID = bluetooth.UUID("6E400001-B5A3-F393-E0A9-E50E24DCCA9E")
+_UART_RX_CHAR_UUID = bluetooth.UUID("6E400002-B5A3-F393-E0A9-E50E24DCCA9E")
+_UART_TX_CHAR_UUID = bluetooth.UUID("6E400003-B5A3-F393-E0A9-E50E24DCCA9E")
+
+
+class BLESimpleCentral:
+    def __init__(self, ble):
+        self._ble = ble
+        self._ble.active(True)
+        self._ble.irq(handler=self._irq)
+
+        self._reset()
+
+    def _reset(self):
+        # Cached name and address from a successful scan.
+        self._name = None
+        self._addr_type = None
+        self._addr = None
+
+        # Callbacks for completion of various operations.
+        # These reset back to None after being invoked.
+        self._scan_callback = None
+        self._conn_callback = None
+        self._read_callback = None
+
+        # Persistent callback for when new data is notified from the device.
+        self._notify_callback = None
+
+        # Connected device.
+        self._conn_handle = None
+        self._start_handle = None
+        self._end_handle = None
+        self._tx_handle = None
+        self._rx_handle = None
+
+    def _irq(self, event, data):
+        if event == _IRQ_SCAN_RESULT:
+            addr_type, addr, adv_type, rssi, adv_data = data
+            if adv_type in (_ADV_IND, _ADV_DIRECT_IND,) and _UART_SERVICE_UUID in decode_services(
+                adv_data
+            ):
+                # Found a potential device, remember it and stop scanning.
+                self._addr_type = addr_type
+                self._addr = bytes(
+                    addr
+                )  # Note: addr buffer is owned by caller so need to copy it.
+                self._name = decode_name(adv_data) or "?"
+                self._ble.gap_scan(None)
+
+        elif event == _IRQ_SCAN_DONE:
+            if self._scan_callback:
+                if self._addr:
+                    # Found a device during the scan (and the scan was explicitly stopped).
+                    self._scan_callback(self._addr_type, self._addr, self._name)
+                    self._scan_callback = None
+                else:
+                    # Scan timed out.
+                    self._scan_callback(None, None, None)
+
+        elif event == _IRQ_PERIPHERAL_CONNECT:
+            # Connect successful.
+            conn_handle, addr_type, addr, = data
+            if addr_type == self._addr_type and addr == self._addr:
+                self._conn_handle = conn_handle
+                self._ble.gattc_discover_services(self._conn_handle)
+
+        elif event == _IRQ_PERIPHERAL_DISCONNECT:
+            # Disconnect (either initiated by us or the remote end).
+            conn_handle, _, _, = data
+            if conn_handle == self._conn_handle:
+                # If it was initiated by us, it'll already be reset.
+                self._reset()
+
+        elif event == _IRQ_GATTC_SERVICE_RESULT:
+            # Connected device returned a service.
+            conn_handle, start_handle, end_handle, uuid = data
+            print("service", data)
+            if conn_handle == self._conn_handle and uuid == _UART_SERVICE_UUID:
+                self._start_handle, self._end_handle = start_handle, end_handle
+
+        elif event == _IRQ_GATTC_SERVICE_DONE:
+            # Service query complete.
+            if self._start_handle and self._end_handle:
+                self._ble.gattc_discover_characteristics(
+                    self._conn_handle, self._start_handle, self._end_handle
+                )
+            else:
+                print("Failed to find uart service.")
+
+        elif event == _IRQ_GATTC_CHARACTERISTIC_RESULT:
+            # Connected device returned a characteristic.
+            conn_handle, def_handle, value_handle, properties, uuid = data
+            if conn_handle == self._conn_handle and uuid == _UART_RX_CHAR_UUID:
+                self._rx_handle = value_handle
+            if conn_handle == self._conn_handle and uuid == _UART_TX_CHAR_UUID:
+                self._tx_handle = value_handle
+
+        elif event == _IRQ_GATTC_CHARACTERISTIC_DONE:
+            # Characteristic query complete.
+            if self._tx_handle is not None and self._rx_handle is not None:
+                # We've finished connecting and discovering device, fire the connect callback.
+                if self._conn_callback:
+                    self._conn_callback()
+            else:
+                print("Failed to find uart rx characteristic.")
+
+        elif event == _IRQ_GATTC_WRITE_DONE:
+            conn_handle, value_handle, status = data
+            print("TX complete")
+
+        elif event == _IRQ_GATTC_NOTIFY:
+            conn_handle, value_handle, notify_data = data
+            if conn_handle == self._conn_handle and value_handle == self._tx_handle:
+                if self._notify_callback:
+                    self._notify_callback(notify_data)
+
+    # Returns true if we've successfully connected and discovered characteristics.
+    def is_connected(self):
+        return (
+            self._conn_handle is not None
+            and self._tx_handle is not None
+            and self._rx_handle is not None
+        )
+
+    # Find a device advertising the environmental sensor service.
+    def scan(self, callback=None):
+        self._addr_type = None
+        self._addr = None
+        self._scan_callback = callback
+        self._ble.gap_scan(2000, 30000, 30000)
+
+    # Connect to the specified device (otherwise use cached address from a scan).
+    def connect(self, addr_type=None, addr=None, callback=None):
+        self._addr_type = addr_type or self._addr_type
+        self._addr = addr or self._addr
+        self._conn_callback = callback
+        if self._addr_type is None or self._addr is None:
+            return False
+        self._ble.gap_connect(self._addr_type, self._addr)
+        return True
+
+    # Disconnect from current device.
+    def disconnect(self):
+        if not self._conn_handle:
+            return
+        self._ble.gap_disconnect(self._conn_handle)
+        self._reset()
+
+    # Send data over the UART
+    def write(self, v, response=False):
+        if not self.is_connected():
+            return
+        self._ble.gattc_write(self._conn_handle, self._rx_handle, v, 1 if response else 0)
+
+    # Set handler for when data is received over the UART.
+    def on_notify(self, callback):
+        self._notify_callback = callback
+
+
+def demo():
+    ble = bluetooth.BLE()
+    central = BLESimpleCentral(ble)
+
+    not_found = False
+
+    def on_scan(addr_type, addr, name):
+        if addr_type is not None:
+            print("Found peripheral:", addr_type, addr, name)
+            central.connect()
+        else:
+            nonlocal not_found
+            not_found = True
+            print("No peripheral found.")
+
+    central.scan(callback=on_scan)
+
+    # Wait for connection...
+    while not central.is_connected():
+        time.sleep_ms(100)
+        if not_found:
+            return
+
+    print("Connected")
+
+    def on_rx(v):
+        print("RX", v)
+
+    central.on_notify(on_rx)
+
+    with_response = False
+
+    i = 0
+    while central.is_connected():
+        try:
+            v = str(i) + "_"
+            print("TX", v)
+            central.write(v, with_response)
+        except:
+            print("TX failed")
+        i += 1
+        time.sleep_ms(400 if with_response else 30)
+
+    print("Disconnected")
+
+
+if __name__ == "__main__":
+    demo()

--- a/examples/bluetooth/ble_simple_peripheral.py
+++ b/examples/bluetooth/ble_simple_peripheral.py
@@ -1,0 +1,98 @@
+# This example demonstrates a UART periperhal.
+
+import bluetooth
+import random
+import struct
+import time
+from ble_advertising import advertising_payload
+
+from micropython import const
+
+_IRQ_CENTRAL_CONNECT = const(1)
+_IRQ_CENTRAL_DISCONNECT = const(2)
+_IRQ_GATTS_WRITE = const(3)
+
+_UART_UUID = bluetooth.UUID("6E400001-B5A3-F393-E0A9-E50E24DCCA9E")
+_UART_TX = (
+    bluetooth.UUID("6E400003-B5A3-F393-E0A9-E50E24DCCA9E"),
+    bluetooth.FLAG_READ | bluetooth.FLAG_NOTIFY,
+)
+_UART_RX = (
+    bluetooth.UUID("6E400002-B5A3-F393-E0A9-E50E24DCCA9E"),
+    bluetooth.FLAG_WRITE | bluetooth.FLAG_WRITE_NO_RESPONSE,
+)
+_UART_SERVICE = (
+    _UART_UUID,
+    (_UART_TX, _UART_RX,),
+)
+
+
+class BLESimplePeripheral:
+    def __init__(self, ble, name="mpy-uart"):
+        self._ble = ble
+        self._ble.active(True)
+        self._ble.irq(handler=self._irq)
+        ((self._handle_tx, self._handle_rx,),) = self._ble.gatts_register_services(
+            (_UART_SERVICE,)
+        )
+        self._connections = set()
+        self._write_callback = None
+        self._payload = advertising_payload(name=name, services=[_UART_UUID],)
+        self._advertise()
+
+    def _irq(self, event, data):
+        # Track connections so we can send notifications.
+        if event == _IRQ_CENTRAL_CONNECT:
+            conn_handle, _, _, = data
+            print("New connection", conn_handle)
+            self._connections.add(conn_handle)
+        elif event == _IRQ_CENTRAL_DISCONNECT:
+            conn_handle, _, _, = data
+            print("Disconnected", conn_handle)
+            self._connections.remove(conn_handle)
+            # Start advertising again to allow a new connection.
+            self._advertise()
+        elif event == _IRQ_GATTS_WRITE:
+            conn_handle, value_handle = data
+            value = self._ble.gatts_read(value_handle)
+            if value_handle == self._handle_rx and self._write_callback:
+                self._write_callback(value)
+
+    def send(self, data):
+        for conn_handle in self._connections:
+            self._ble.gatts_notify(conn_handle, self._handle_tx, data)
+
+    def is_connected(self):
+        return len(self._connections) > 0
+
+    def _advertise(self, interval_us=500000):
+        print("Starting advertising")
+        self._ble.gap_advertise(interval_us, adv_data=self._payload)
+
+    def on_write(self, callback):
+        self._write_callback = callback
+
+
+def demo():
+    ble = bluetooth.BLE()
+    p = BLESimplePeripheral(ble)
+
+    def on_rx(v):
+        print("RX", v)
+
+    p.on_write(on_rx)
+
+    i = 0
+    while True:
+        if p.is_connected():
+            # Short burst of queued notifications.
+            for _ in range(3):
+                data = str(i) + "_"
+                print("TX", data)
+                p.send(data)
+                i += 1
+        time.sleep_ms(100)
+
+
+if __name__ == "__main__":
+    demo()

--- a/extmod/btstack/modbluetooth_btstack.c
+++ b/extmod/btstack/modbluetooth_btstack.c
@@ -814,6 +814,8 @@ int mp_bluetooth_gatts_indicate(uint16_t conn_handle, uint16_t value_handle) {
     size_t len = 0;
     mp_bluetooth_gatts_db_read(MP_STATE_PORT(bluetooth_btstack_root_pointers)->gatts_db, value_handle, &data, &len);
 
+    // TODO: Handle ATT_EVENT_HANDLE_VALUE_INDICATION_COMPLETE to generate acknowledgment event.
+
     // Attempt to send immediately, will copy buffer.
     MICROPY_PY_BLUETOOTH_ENTER
     int err = att_server_indicate(conn_handle, value_handle, data, len);

--- a/extmod/btstack/modbluetooth_btstack.c
+++ b/extmod/btstack/modbluetooth_btstack.c
@@ -53,8 +53,6 @@ STATIC const uint16_t BTSTACK_GAP_DEVICE_NAME_HANDLE = 3;
 
 volatile int mp_bluetooth_btstack_state = MP_BLUETOOTH_BTSTACK_STATE_OFF;
 
-STATIC btstack_packet_callback_registration_t hci_event_callback_registration;
-
 STATIC int btstack_error_to_errno(int err) {
     DEBUG_EVENT_printf("  --> btstack error: %d\n", err);
     if (err == ERROR_CODE_SUCCESS) {
@@ -84,6 +82,148 @@ STATIC mp_obj_bluetooth_uuid_t create_mp_uuid(uint16_t uuid16, const uint8_t *uu
     }
     return result;
 }
+
+// Notes on supporting background ops (i.e. an attempt to gatts_notify while and existing
+// notification is in progress):
+
+// GATTS Notify/Indicate (att_server_notify/indicate)
+// * When available, copies buffer immediately.
+// * Otherwise fails with BTSTACK_ACL_BUFFERS_FULL
+// * Use att_server_request_to_send_notification/indication to get callback
+//   * Takes btstack_context_callback_registration_t (and takes ownership) and conn_handle.
+//   * Callback is invoked with just the context member of the btstack_context_callback_registration_t
+
+// GATTC Write without response (gatt_client_write_value_of_characteristic_without_response)
+// * When available, copies buffer immediately.
+// * Otherwise, fails with GATT_CLIENT_BUSY.
+// * Use gatt_client_request_can_write_without_response_event to get callback
+//   * Takes btstack_packet_handler_t (function pointer) and conn_handle
+//   * Callback is involved, use gatt_event_can_write_without_response_get_handle to get the conn_handle (no other context)
+//   * There can only be one pending gatt_client_request_can_write_without_response_event (otherwise we fail with EALREADY).
+
+// GATTC Write with response (gatt_client_write_value_of_characteristic)
+// * When peripheral is available, takes ownership of buffer.
+// * Otherwise, fails with GATT_CLIENT_IN_WRONG_STATE (we fail the operation).
+// * Raises GATT_EVENT_QUERY_COMPLETE to the supplied packet handler.
+
+// For notify/indicate/write-without-response that proceed immediately, nothing extra required.
+// For all other cases, buffer needs to be copied and protected from GC.
+// For notify/indicate:
+//  * btstack_context_callback_registration_t:
+//     * needs to be malloc'ed
+//     * needs to be protected from GC
+//     * context arg needs to point back to the callback registration so it can be freed and un-protected
+// For write-without-response
+//  * only the conn_handle is available in the callback
+//  * so we need a queue of conn_handle->(value_handle, copied buffer)
+
+// Pending operation types.
+enum {
+    // Queued for sending when possible.
+    MP_BLUETOOTH_BTSTACK_PENDING_NOTIFY, // Waiting for context callback
+    MP_BLUETOOTH_BTSTACK_PENDING_INDICATE, // Waiting for context callback
+    MP_BLUETOOTH_BTSTACK_PENDING_WRITE_NO_RESPONSE, // Waiting for conn handle
+    // Hold buffer pointer until complete.
+    MP_BLUETOOTH_BTSTACK_PENDING_WRITE, // Waiting for write done event
+};
+
+// Pending operation:
+//  - Holds a GC reference to the copied outgoing buffer.
+//  - Provides enough information for the callback handler to execute the desired operation.
+struct _mp_btstack_pending_op_t {
+    mp_btstack_pending_op_t *next; // Must be first field to match btstack_linked_item.
+
+    // See enum above.
+    uint16_t op_type;
+
+    // For all op types.
+    uint16_t conn_handle;
+
+    // For notify/indicate only.
+    // context_registration.context will point back to this struct.
+    btstack_context_callback_registration_t context_registration;
+
+    uint16_t value_handle;
+
+    // For notify/indicate/write-without-response, this is the actual buffer to send.
+    // For write-with-response, just holding onto the buffer for GC ref.
+    size_t len;
+    uint8_t buf[];
+};
+
+// Called in response to a gatts_notify/indicate being unable to complete, which then calls
+// att_server_request_to_send_notification.
+// We now have an opportunity to re-try the operation with an empty ACL buffer.
+STATIC void btstack_notify_indicate_ready_handler(void * context) {
+    MICROPY_PY_BLUETOOTH_ENTER
+    mp_btstack_pending_op_t *pending_op = (mp_btstack_pending_op_t*)context;
+    DEBUG_EVENT_printf("btstack_notify_indicate_ready_handler op_type=%d conn_handle=%d value_handle=%d len=%lu\n", pending_op->op_type, pending_op->conn_handle, pending_op->value_handle, pending_op->len);
+    if (pending_op->op_type == MP_BLUETOOTH_BTSTACK_PENDING_NOTIFY) {
+        int err = att_server_notify(pending_op->conn_handle, pending_op->value_handle, pending_op->buf, pending_op->len);
+        DEBUG_EVENT_printf("btstack_notify_indicate_ready_handler: sending notification err=%d\n", err);
+        assert(err == ERROR_CODE_SUCCESS);
+        (void)err;
+    } else if (pending_op->op_type == MP_BLUETOOTH_BTSTACK_PENDING_INDICATE) {
+        int err = att_server_indicate(pending_op->conn_handle, pending_op->value_handle, NULL, 0);
+        DEBUG_EVENT_printf("btstack_notify_indicate_ready_handler: sending indication err=%d\n", err);
+        assert(err == ERROR_CODE_SUCCESS);
+        (void)err;
+    } else {
+        DEBUG_EVENT_printf("btstack_notify_indicate_ready_handler: wrong type of op\n");
+        assert(0);
+    }
+    assert(btstack_linked_list_remove(&MP_STATE_PORT(bluetooth_btstack_root_pointers)->pending_ops, (btstack_linked_item_t*)pending_op));
+    MICROPY_PY_BLUETOOTH_EXIT
+}
+
+// Register a pending background operation -- copies the buffer, and makes it known to the GC.
+STATIC mp_btstack_pending_op_t* btstack_enqueue_pending_operation(uint16_t op_type, uint16_t conn_handle, uint16_t value_handle, const uint8_t *buf, size_t len) {
+    DEBUG_EVENT_printf("btstack_enqueue_pending_operation op_type=%d conn_handle=%d value_handle=%d len=%lu\n", op_type, conn_handle, value_handle, len);
+    mp_btstack_pending_op_t *pending_op = m_malloc(sizeof(mp_btstack_pending_op_t) + len);
+    pending_op->op_type = op_type;
+    pending_op->conn_handle = conn_handle;
+    pending_op->value_handle = value_handle;
+    pending_op->len = len;
+    memcpy(pending_op->buf, buf, len);
+
+    if (op_type == MP_BLUETOOTH_BTSTACK_PENDING_NOTIFY || op_type == MP_BLUETOOTH_BTSTACK_PENDING_INDICATE) {
+        pending_op->context_registration.callback = &btstack_notify_indicate_ready_handler;
+        pending_op->context_registration.context = pending_op;
+    }
+
+    MICROPY_PY_BLUETOOTH_ENTER
+    assert(btstack_linked_list_add(&MP_STATE_PORT(bluetooth_btstack_root_pointers)->pending_ops, (btstack_linked_item_t*)pending_op));
+    MICROPY_PY_BLUETOOTH_EXIT
+
+    return pending_op;
+}
+
+#if MICROPY_PY_BLUETOOTH_ENABLE_CENTRAL_MODE
+// Cleans up a pending op of the specified type for this conn_handle (and if specified, value_handle).
+// Used by MP_BLUETOOTH_BTSTACK_PENDING_WRITE and MP_BLUETOOTH_BTSTACK_PENDING_WRITE_NO_RESPONSE.
+// At the moment, both will set value_handle=0xffff as the events do not know their value_handle.
+// TODO: Can we make btstack give us the value_handle for regular write (with response) so that we
+// know for sure that we're using the correct entry.
+STATIC mp_btstack_pending_op_t* btstack_finish_pending_operation(uint16_t op_type, uint16_t conn_handle, uint16_t value_handle) {
+    MICROPY_PY_BLUETOOTH_ENTER
+    DEBUG_EVENT_printf("btstack_finish_pending_operation op_type=%d conn_handle=%d value_handle=%d\n", op_type, conn_handle, value_handle);
+    btstack_linked_list_iterator_t it;
+    btstack_linked_list_iterator_init(&it, &MP_STATE_PORT(bluetooth_btstack_root_pointers)->pending_ops);
+    while (btstack_linked_list_iterator_has_next(&it)){
+        mp_btstack_pending_op_t *pending_op = (mp_btstack_pending_op_t*)btstack_linked_list_iterator_next(&it);
+
+        if (pending_op->op_type == op_type && pending_op->conn_handle == conn_handle && (value_handle == 0xffff || pending_op->value_handle == value_handle)) {
+            DEBUG_EVENT_printf("btstack_finish_pending_operation: found value_handle=%d len=%lu\n", pending_op->value_handle, pending_op->len);
+            assert(btstack_linked_list_remove(&MP_STATE_PORT(bluetooth_btstack_root_pointers)->pending_ops, (btstack_linked_item_t*)pending_op));
+            MICROPY_PY_BLUETOOTH_EXIT
+            return pending_op;
+        }
+    }
+    DEBUG_EVENT_printf("btstack_finish_pending_operation: not found\n");
+    MICROPY_PY_BLUETOOTH_EXIT
+    return NULL;
+}
+#endif
 
 STATIC void btstack_packet_handler(uint8_t packet_type, uint8_t *packet, uint8_t irq) {
     DEBUG_EVENT_printf("btstack_packet_handler(packet_type=%u, packet=%p)\n", packet_type, packet);
@@ -161,12 +301,17 @@ STATIC void btstack_packet_handler(uint8_t packet_type, uint8_t *packet, uint8_t
         mp_bluetooth_gap_on_connected_disconnected(irq_event, conn_handle, 0xff, addr);
     #if MICROPY_PY_BLUETOOTH_ENABLE_CENTRAL_MODE
     } else if (event_type == GATT_EVENT_QUERY_COMPLETE) {
-        DEBUG_EVENT_printf("  --> gatt query complete\n");
         uint16_t conn_handle = gatt_event_query_complete_get_handle(packet);
         uint16_t status = gatt_event_query_complete_get_att_status(packet);
+        DEBUG_EVENT_printf("  --> gatt query complete irq=%d conn_handle=%d status=%d\n", irq, conn_handle, status);
         if (irq == MP_BLUETOOTH_IRQ_GATTC_READ_DONE || irq == MP_BLUETOOTH_IRQ_GATTC_WRITE_DONE) {
-            // TODO there is no value_handle available to pass here
-            mp_bluetooth_gattc_on_read_write_status(irq, conn_handle, 0, status);
+            // TODO there is no value_handle available to pass here.
+            // TODO try and get this implemented in btstack.
+            mp_bluetooth_gattc_on_read_write_status(irq, conn_handle, 0xffff, status);
+            // Unref the saved buffer for the write operation on this conn_handle.
+            if (irq == MP_BLUETOOTH_IRQ_GATTC_WRITE_DONE) {
+                assert(btstack_finish_pending_operation(MP_BLUETOOTH_BTSTACK_PENDING_WRITE, conn_handle, 0xffff));
+            }
         } else if (irq == MP_BLUETOOTH_IRQ_GATTC_SERVICE_DONE ||
                    irq == MP_BLUETOOTH_IRQ_GATTC_CHARACTERISTIC_DONE ||
                    irq == MP_BLUETOOTH_IRQ_GATTC_DESCRIPTOR_DONE) {
@@ -223,6 +368,15 @@ STATIC void btstack_packet_handler(uint8_t packet_type, uint8_t *packet, uint8_t
         len = mp_bluetooth_gattc_on_data_available_start(MP_BLUETOOTH_IRQ_GATTC_INDICATE, conn_handle, value_handle, len, &atomic_state);
         mp_bluetooth_gattc_on_data_available_chunk(data, len);
         mp_bluetooth_gattc_on_data_available_end(atomic_state);
+    } else if (event_type == GATT_EVENT_CAN_WRITE_WITHOUT_RESPONSE) {
+        uint16_t conn_handle = gatt_event_can_write_without_response_get_handle(packet);
+        DEBUG_EVENT_printf("  --> gatt can write without response %d\n", conn_handle);
+        mp_btstack_pending_op_t *pending_op = btstack_finish_pending_operation(MP_BLUETOOTH_BTSTACK_PENDING_WRITE_NO_RESPONSE, conn_handle, 0xffff);
+        if (pending_op) {
+            DEBUG_EVENT_printf("  --> ready for value_handle=%d len=%lu\n", pending_op->value_handle, pending_op->len);
+            gatt_client_write_value_of_characteristic_without_response(pending_op->conn_handle, pending_op->value_handle, pending_op->len, (uint8_t *)pending_op->buf);
+        }
+
     #endif // MICROPY_PY_BLUETOOTH_ENABLE_CENTRAL_MODE
     } else {
         DEBUG_EVENT_printf("  --> hci event type: unknown (0x%02x)\n", event_type);
@@ -237,6 +391,10 @@ STATIC void btstack_packet_handler_generic(uint8_t packet_type, uint16_t channel
     (void)size;
     btstack_packet_handler(packet_type, packet, 0);
 }
+
+STATIC btstack_packet_callback_registration_t hci_event_callback_registration = {
+    .callback = &btstack_packet_handler_generic
+};
 
 #if MICROPY_PY_BLUETOOTH_ENABLE_CENTRAL_MODE
 // For when the handler is being used for service discovery.
@@ -326,7 +484,6 @@ int mp_bluetooth_init(void) {
     #endif
 
     // Register for HCI events.
-    hci_event_callback_registration.callback = &btstack_packet_handler_generic;
     hci_add_event_handler(&hci_event_callback_registration);
 
     // Set a timeout for HCI initialisation.
@@ -612,14 +769,44 @@ int mp_bluetooth_gatts_notify(uint16_t conn_handle, uint16_t value_handle) {
 
 int mp_bluetooth_gatts_notify_send(uint16_t conn_handle, uint16_t value_handle, const uint8_t *value, size_t *value_len) {
     DEBUG_EVENT_printf("mp_bluetooth_gatts_notify_send\n");
-    // TODO: We need to use att_server_request_to_send_notification here as the stack may not be ready to send a notification.
+
+    // Attempt to send immediately, will copy buffer.
+    MICROPY_PY_BLUETOOTH_ENTER
     int err = att_server_notify(conn_handle, value_handle, value, *value_len);
-    return btstack_error_to_errno(err);
+    MICROPY_PY_BLUETOOTH_EXIT
+
+    if (err == BTSTACK_ACL_BUFFERS_FULL) {
+        DEBUG_EVENT_printf("mp_bluetooth_gatts_notify_send: ACL buffer full, scheduling callback\n");
+        // Schedule callback, making a copy of the buffer.
+        mp_btstack_pending_op_t *pending_op = btstack_enqueue_pending_operation(MP_BLUETOOTH_BTSTACK_PENDING_NOTIFY, conn_handle, value_handle, value, *value_len);
+
+        att_server_request_to_send_notification(&pending_op->context_registration, conn_handle);
+        // We don't know how many bytes will be sent.
+        *value_len = 0;
+
+        return 0;
+    } else {
+        return btstack_error_to_errno(err);
+    }
 }
 
 int mp_bluetooth_gatts_indicate(uint16_t conn_handle, uint16_t value_handle) {
     DEBUG_EVENT_printf("mp_bluetooth_gatts_indicate\n");
-    return btstack_error_to_errno(att_server_indicate(conn_handle, value_handle, NULL, 0));
+
+    // Attempt to send immediately, will copy buffer.
+    MICROPY_PY_BLUETOOTH_ENTER
+    int err = att_server_indicate(conn_handle, value_handle, NULL, 0);
+    MICROPY_PY_BLUETOOTH_EXIT
+
+    if (err == BTSTACK_ACL_BUFFERS_FULL) {
+        DEBUG_EVENT_printf("mp_bluetooth_gatts_indicate: ACL buffer full, scheduling callback\n");
+        // Schedule callback, making a copy of the buffer.
+        mp_btstack_pending_op_t *pending_op = btstack_enqueue_pending_operation(MP_BLUETOOTH_BTSTACK_PENDING_INDICATE, conn_handle, value_handle, NULL, 0);
+        att_server_request_to_send_indication(&pending_op->context_registration, conn_handle);
+        return 0;
+    } else {
+        return btstack_error_to_errno(err);
+    }
 }
 
 int mp_bluetooth_gatts_set_buffer(uint16_t value_handle, size_t len, bool append) {
@@ -751,19 +938,40 @@ int mp_bluetooth_gattc_read(uint16_t conn_handle, uint16_t value_handle) {
 int mp_bluetooth_gattc_write(uint16_t conn_handle, uint16_t value_handle, const uint8_t *value, size_t *value_len, unsigned int mode) {
     DEBUG_EVENT_printf("mp_bluetooth_gattc_write\n");
 
-    // TODO the below gatt_client functions do not copy the data and require it to be valid
-    // until the write is done, so there should be some kind of buffering done here.
+    // We should be distinguishing between gatt_client_write_value_of_characteristic vs
+    // gatt_client_write_characteristic_descriptor_using_descriptor_handle.
+    // However both are implemented using send_gatt_write_attribute_value_request under the hood,
+    // and we get the exact same event to the packet handler.
+    // Same story for the "without response" version.
+
+    int err;
 
     if (mode == MP_BLUETOOTH_WRITE_MODE_NO_RESPONSE) {
-        // TODO need to call gatt_client_request_can_write_without_response_event then do
-        // the actual write on the callback from that.
-        return btstack_error_to_errno(gatt_client_write_value_of_characteristic_without_response(conn_handle, value_handle, *value_len, (uint8_t *)value));
-    }
-    if (mode == MP_BLUETOOTH_WRITE_MODE_WITH_RESPONSE) {
-        return btstack_error_to_errno(gatt_client_write_value_of_characteristic(&btstack_packet_handler_write_with_response, conn_handle, value_handle, *value_len, (uint8_t *)value));
+        // If possible, this will send immediately, copying the buffer directly to the ACL buffer.
+        err = gatt_client_write_value_of_characteristic_without_response(conn_handle, value_handle, *value_len, (uint8_t *)value);
+        if (err == GATT_CLIENT_BUSY) {
+            DEBUG_EVENT_printf("mp_bluetooth_gattc_write: client busy\n");
+            // Can't send right now, need to take a copy of the buffer and add it to the queue.
+            btstack_enqueue_pending_operation(MP_BLUETOOTH_BTSTACK_PENDING_WRITE_NO_RESPONSE, conn_handle, value_handle, value, *value_len);
+            // Notify when this conn_handle can write.
+            err = gatt_client_request_can_write_without_response_event(&btstack_packet_handler_generic, conn_handle);
+        } else {
+            DEBUG_EVENT_printf("mp_bluetooth_gattc_write: other failure: %d\n", err);
+        }
+    } else if (mode == MP_BLUETOOTH_WRITE_MODE_WITH_RESPONSE) {
+        // Pending operation copies the value buffer and keeps a GC reference until the response comes back.
+        // TODO: Is there always a response?
+        mp_btstack_pending_op_t *pending_op = btstack_enqueue_pending_operation(MP_BLUETOOTH_BTSTACK_PENDING_WRITE, conn_handle, value_handle, value, *value_len);
+        err = gatt_client_write_value_of_characteristic(&btstack_packet_handler_write_with_response, conn_handle, value_handle, pending_op->len, pending_op->buf);
+        if (err != ERROR_CODE_SUCCESS) {
+            // Failure. Unref the pending operation.
+            btstack_finish_pending_operation(MP_BLUETOOTH_BTSTACK_PENDING_WRITE, conn_handle, value_handle);
+        }
+    } else {
+        return MP_EINVAL;
     }
 
-    return MP_EINVAL;
+    return btstack_error_to_errno(err);
 }
 #endif // MICROPY_PY_BLUETOOTH_ENABLE_CENTRAL_MODE
 

--- a/extmod/btstack/modbluetooth_btstack.h
+++ b/extmod/btstack/modbluetooth_btstack.h
@@ -35,9 +35,6 @@
 
 typedef struct _mp_btstack_pending_op_t mp_btstack_pending_op_t;
 
-//typedef struct btstack_linked_item btstack_linked_item_t;
-//typedef btstack_linked_item_t * btstack_linked_list_t;
-
 typedef struct _mp_bluetooth_btstack_root_pointers_t {
     // This stores both the advertising data and the scan response data, concatenated together.
     uint8_t *adv_data;

--- a/extmod/btstack/modbluetooth_btstack.h
+++ b/extmod/btstack/modbluetooth_btstack.h
@@ -33,6 +33,11 @@
 
 #include "lib/btstack/src/btstack.h"
 
+typedef struct _mp_btstack_pending_op_t mp_btstack_pending_op_t;
+
+//typedef struct btstack_linked_item btstack_linked_item_t;
+//typedef btstack_linked_item_t * btstack_linked_list_t;
+
 typedef struct _mp_bluetooth_btstack_root_pointers_t {
     // This stores both the advertising data and the scan response data, concatenated together.
     uint8_t *adv_data;
@@ -45,6 +50,7 @@ typedef struct _mp_bluetooth_btstack_root_pointers_t {
     #if MICROPY_PY_BLUETOOTH_ENABLE_CENTRAL_MODE
     // Registration for notify/indicate events.
     gatt_client_notification_t notification;
+    btstack_linked_list_t pending_ops;
     #endif
 } mp_bluetooth_btstack_root_pointers_t;
 

--- a/extmod/modbluetooth.c
+++ b/extmod/modbluetooth.c
@@ -321,8 +321,7 @@ STATIC mp_obj_t bluetooth_ble_config(size_t n_args, const mp_obj_t *args, mp_map
                     case MP_QSTR_gap_name: {
                         mp_buffer_info_t bufinfo;
                         mp_get_buffer_raise(e->value, &bufinfo, MP_BUFFER_READ);
-                        int ret = mp_bluetooth_gap_set_device_name(bufinfo.buf, bufinfo.len);
-                        bluetooth_handle_errno(ret);
+                        bluetooth_handle_errno(mp_bluetooth_gap_set_device_name(bufinfo.buf, bufinfo.len));
                         break;
                     }
                     case MP_QSTR_rxbuf: {
@@ -663,16 +662,24 @@ STATIC mp_obj_t bluetooth_ble_gatts_notify(size_t n_args, const mp_obj_t *args) 
     if (n_args == 4) {
         mp_buffer_info_t bufinfo = {0};
         mp_get_buffer_raise(args[3], &bufinfo, MP_BUFFER_READ);
-        size_t len = bufinfo.len;
-        int err = mp_bluetooth_gatts_notify_send(conn_handle, value_handle, bufinfo.buf, &len);
+        int err = mp_bluetooth_gatts_notify_send(conn_handle, value_handle, bufinfo.buf, bufinfo.len);
         bluetooth_handle_errno(err);
-        return MP_OBJ_NEW_SMALL_INT(len);
+        return mp_const_none;
     } else {
         int err = mp_bluetooth_gatts_notify(conn_handle, value_handle);
         return bluetooth_handle_errno(err);
     }
 }
 STATIC MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(bluetooth_ble_gatts_notify_obj, 3, 4, bluetooth_ble_gatts_notify);
+
+STATIC mp_obj_t bluetooth_ble_gatts_indicate(mp_obj_t self_in, mp_obj_t conn_handle_in, mp_obj_t value_handle_in) {
+    mp_int_t conn_handle = mp_obj_get_int(conn_handle_in);
+    mp_int_t value_handle = mp_obj_get_int(value_handle_in);
+
+    int err = mp_bluetooth_gatts_indicate(conn_handle, value_handle);
+    return bluetooth_handle_errno(err);
+}
+STATIC MP_DEFINE_CONST_FUN_OBJ_3(bluetooth_ble_gatts_indicate_obj, bluetooth_ble_gatts_indicate);
 
 STATIC mp_obj_t bluetooth_ble_gatts_set_buffer(size_t n_args, const mp_obj_t *args) {
     mp_int_t value_handle = mp_obj_get_int(args[1]);
@@ -765,6 +772,7 @@ STATIC const mp_rom_map_elem_t bluetooth_ble_locals_dict_table[] = {
     { MP_ROM_QSTR(MP_QSTR_gatts_read), MP_ROM_PTR(&bluetooth_ble_gatts_read_obj) },
     { MP_ROM_QSTR(MP_QSTR_gatts_write), MP_ROM_PTR(&bluetooth_ble_gatts_write_obj) },
     { MP_ROM_QSTR(MP_QSTR_gatts_notify), MP_ROM_PTR(&bluetooth_ble_gatts_notify_obj) },
+    { MP_ROM_QSTR(MP_QSTR_gatts_indicate), MP_ROM_PTR(&bluetooth_ble_gatts_indicate_obj) },
     { MP_ROM_QSTR(MP_QSTR_gatts_set_buffer), MP_ROM_PTR(&bluetooth_ble_gatts_set_buffer_obj) },
     #if MICROPY_PY_BLUETOOTH_ENABLE_CENTRAL_MODE
     // GATT Client (i.e. central/scanner role)
@@ -1165,8 +1173,14 @@ int mp_bluetooth_gatts_db_write(mp_gatts_db_t db, uint16_t handle, const uint8_t
     mp_bluetooth_gatts_db_entry_t *entry = mp_bluetooth_gatts_db_lookup(db, handle);
     if (entry) {
         if (value_len > entry->data_alloc) {
-            entry->data = m_new(uint8_t, value_len);
-            entry->data_alloc = value_len;
+            uint8_t *data = m_new_maybe(uint8_t, value_len);
+            if (data) {
+                entry->data = data;
+                entry->data_alloc = value_len;
+            } else {
+                MICROPY_PY_BLUETOOTH_EXIT
+                return MP_ENOMEM;
+            }
         }
 
         memcpy(entry->data, value, value_len);
@@ -1180,10 +1194,16 @@ int mp_bluetooth_gatts_db_resize(mp_gatts_db_t db, uint16_t handle, size_t len, 
     MICROPY_PY_BLUETOOTH_ENTER
     mp_bluetooth_gatts_db_entry_t *entry = mp_bluetooth_gatts_db_lookup(db, handle);
     if (entry) {
-        entry->data = m_renew(uint8_t, entry->data, entry->data_alloc, len);
-        entry->data_alloc = len;
-        entry->data_len = 0;
-        entry->append = append;
+        uint8_t *data = m_renew_maybe(uint8_t, entry->data, entry->data_alloc, len, true);
+        if (data) {
+            entry->data = data;
+            entry->data_alloc = len;
+            entry->data_len = 0;
+            entry->append = append;
+        } else {
+            MICROPY_PY_BLUETOOTH_EXIT
+            return MP_ENOMEM;
+        }
     }
     MICROPY_PY_BLUETOOTH_EXIT
     return entry ? 0 : MP_EINVAL;

--- a/extmod/modbluetooth.h
+++ b/extmod/modbluetooth.h
@@ -199,7 +199,7 @@ int mp_bluetooth_gatts_write(uint16_t value_handle, const uint8_t *value, size_t
 // Notify the central that it should do a read.
 int mp_bluetooth_gatts_notify(uint16_t conn_handle, uint16_t value_handle);
 // Notify the central, including a data payload. (Note: does not set the gatts db value).
-int mp_bluetooth_gatts_notify_send(uint16_t conn_handle, uint16_t value_handle, const uint8_t *value, size_t *value_len);
+int mp_bluetooth_gatts_notify_send(uint16_t conn_handle, uint16_t value_handle, const uint8_t *value, size_t value_len);
 // Indicate the central.
 int mp_bluetooth_gatts_indicate(uint16_t conn_handle, uint16_t value_handle);
 

--- a/extmod/nimble/modbluetooth_nimble.c
+++ b/extmod/nimble/modbluetooth_nimble.c
@@ -587,13 +587,13 @@ int mp_bluetooth_gatts_notify(uint16_t conn_handle, uint16_t value_handle) {
     return ble_hs_err_to_errno(ble_gattc_notify(conn_handle, value_handle));
 }
 
-int mp_bluetooth_gatts_notify_send(uint16_t conn_handle, uint16_t value_handle, const uint8_t *value, size_t *value_len) {
+int mp_bluetooth_gatts_notify_send(uint16_t conn_handle, uint16_t value_handle, const uint8_t *value, size_t value_len) {
     if (!mp_bluetooth_is_active()) {
         return ERRNO_BLUETOOTH_NOT_ACTIVE;
     }
-    struct os_mbuf *om = ble_hs_mbuf_from_flat(value, *value_len);
+    struct os_mbuf *om = ble_hs_mbuf_from_flat(value, value_len);
     if (om == NULL) {
-        return -1;
+        return MP_ENOMEM;
     }
     // TODO: check that notify_custom takes ownership of om, if not os_mbuf_free_chain(om).
     return ble_hs_err_to_errno(ble_gattc_notify_custom(conn_handle, value_handle, om));

--- a/extmod/nimble/modbluetooth_nimble.c
+++ b/extmod/nimble/modbluetooth_nimble.c
@@ -603,6 +603,8 @@ int mp_bluetooth_gatts_indicate(uint16_t conn_handle, uint16_t value_handle) {
     if (!mp_bluetooth_is_active()) {
         return ERRNO_BLUETOOTH_NOT_ACTIVE;
     }
+    // TODO: catch BLE_GAP_EVENT_NOTIFY_TX to raise an event for completed
+    // indication transaction.
     return ble_hs_err_to_errno(ble_gattc_indicate(conn_handle, value_handle));
 }
 

--- a/ports/unix/btstack_usb.c
+++ b/ports/unix/btstack_usb.c
@@ -156,7 +156,10 @@ STATIC void *btstack_thread(void *arg) {
     // Or, if a timeout results in it being set to TIMEOUT.
 
     while (mp_bluetooth_btstack_state == MP_BLUETOOTH_BTSTACK_STATE_STARTING || mp_bluetooth_btstack_state == MP_BLUETOOTH_BTSTACK_STATE_ACTIVE) {
+        // Pretend like we're running in IRQ context (i.e. other things can't be running at the same time).
+        mp_uint_t atomic_state = MICROPY_BEGIN_ATOMIC_SECTION();
         btstack_run_loop_embedded_execute_once();
+        MICROPY_END_ATOMIC_SECTION(atomic_state);
 
         // The USB transport schedules events to the run loop at 1ms intervals,
         // and the implementation currently polls rather than selects.

--- a/ports/unix/mpthreadport.c
+++ b/ports/unix/mpthreadport.c
@@ -65,7 +65,8 @@ STATIC pthread_key_t tls_key;
 // The mutex is used for any code in this port that needs to be thread safe.
 // Specifically for thread management, access to the linked list is one example.
 // But also, e.g. scheduler state.
-STATIC pthread_mutex_t thread_mutex = PTHREAD_MUTEX_INITIALIZER;
+STATIC pthread_mutex_t thread_mutex;
+STATIC pthread_mutexattr_t thread_mutex_attr;
 STATIC thread_t *thread;
 
 // this is used to synchronise the signal handler of the thread
@@ -110,6 +111,12 @@ STATIC void mp_thread_gc(int signo, siginfo_t *info, void *context) {
 void mp_thread_init(void) {
     pthread_key_create(&tls_key, NULL);
     pthread_setspecific(tls_key, &mp_state_ctx.thread);
+
+    // Needs to be a recursive mutex to emulate the behavior of
+    // BEGIN_ATOMIC_SECTION on bare metal.
+    pthread_mutexattr_init(&thread_mutex_attr);
+    pthread_mutexattr_settype(&thread_mutex_attr, PTHREAD_MUTEX_RECURSIVE);
+    pthread_mutex_init(&thread_mutex, &thread_mutex_attr);
 
     // create first entry in linked list of all threads
     thread = malloc(sizeof(thread_t));

--- a/ports/unix/mpthreadport.c
+++ b/ports/unix/mpthreadport.c
@@ -66,7 +66,6 @@ STATIC pthread_key_t tls_key;
 // Specifically for thread management, access to the linked list is one example.
 // But also, e.g. scheduler state.
 STATIC pthread_mutex_t thread_mutex;
-STATIC pthread_mutexattr_t thread_mutex_attr;
 STATIC thread_t *thread;
 
 // this is used to synchronise the signal handler of the thread
@@ -114,6 +113,7 @@ void mp_thread_init(void) {
 
     // Needs to be a recursive mutex to emulate the behavior of
     // BEGIN_ATOMIC_SECTION on bare metal.
+    pthread_mutexattr_t thread_mutex_attr;
     pthread_mutexattr_init(&thread_mutex_attr);
     pthread_mutexattr_settype(&thread_mutex_attr, PTHREAD_MUTEX_RECURSIVE);
     pthread_mutex_init(&thread_mutex, &thread_mutex_attr);

--- a/tests/multi_bluetooth/ble_characteristic.py
+++ b/tests/multi_bluetooth/ble_characteristic.py
@@ -16,6 +16,7 @@ _IRQ_GATTC_READ_RESULT = const(15)
 _IRQ_GATTC_READ_DONE = const(16)
 _IRQ_GATTC_WRITE_DONE = const(17)
 _IRQ_GATTC_NOTIFY = const(18)
+_IRQ_GATTC_INDICATE = const(19)
 
 SERVICE_UUID = bluetooth.UUID("A5A5A5A5-FFFF-9999-1111-5A5A5A5A5A5A")
 CHAR_UUID = bluetooth.UUID("00000000-1111-2222-3333-444444444444")
@@ -59,6 +60,8 @@ def irq(event, data):
         print("_IRQ_GATTC_WRITE_DONE", data[-1])
     elif event == _IRQ_GATTC_NOTIFY:
         print("_IRQ_GATTC_NOTIFY", data[-1])
+    elif event == _IRQ_GATTC_INDICATE:
+        print("_IRQ_GATTC_INDICATE", data[-1])
 
     if waiting_event is not None:
         if (isinstance(waiting_event, int) and event == waiting_event) or (
@@ -115,6 +118,16 @@ def instance0():
         print("gatts_notify")
         ble.gatts_notify(conn_handle, char_handle, "periph2")
 
+        # Wait for a write to the characteristic from the central.
+        wait_for_event(_IRQ_GATTS_WRITE, TIMEOUT_MS)
+
+        # Wait a bit, then notify a new value on the characteristic.
+        time.sleep_ms(1000)
+        print("gatts_write")
+        ble.gatts_write(char_handle, "periph3")
+        print("gatts_indicate")
+        ble.gatts_indicate(conn_handle, char_handle)
+
         # Wait for the central to disconnect.
         wait_for_event(_IRQ_CENTRAL_DISCONNECT, TIMEOUT_MS)
     finally:
@@ -159,6 +172,17 @@ def instance1():
 
         # Wait for a notify (should have new data), then read old value (should be unchanged).
         wait_for_event(_IRQ_GATTC_NOTIFY, TIMEOUT_MS)
+        print("gattc_read")
+        ble.gattc_read(conn_handle, value_handle)
+        wait_for_event(_IRQ_GATTC_READ_RESULT, TIMEOUT_MS)
+
+        # Write to the characteristic, and ask for a response.
+        print("gattc_write")
+        ble.gattc_write(conn_handle, value_handle, "central2", 1)
+        wait_for_event(_IRQ_GATTC_WRITE_DONE, TIMEOUT_MS)
+
+        # Wait for a indicate (should have new data), then read new value.
+        wait_for_event(_IRQ_GATTC_INDICATE, TIMEOUT_MS)
         print("gattc_read")
         ble.gattc_read(conn_handle, value_handle)
         wait_for_event(_IRQ_GATTC_READ_RESULT, TIMEOUT_MS)

--- a/tests/multi_bluetooth/ble_characteristic.py.exp
+++ b/tests/multi_bluetooth/ble_characteristic.py.exp
@@ -6,6 +6,9 @@ gatts_write
 gatts_notify
 _IRQ_GATTS_WRITE b'central1'
 gatts_notify
+_IRQ_GATTS_WRITE b'central2'
+gatts_write
+gatts_indicate
 _IRQ_CENTRAL_DISCONNECT
 --- instance1 ---
 gap_connect
@@ -25,6 +28,12 @@ _IRQ_GATTC_WRITE_DONE 0
 _IRQ_GATTC_NOTIFY b'periph2'
 gattc_read
 _IRQ_GATTC_READ_RESULT b'central1'
+_IRQ_GATTC_READ_DONE 0
+gattc_write
+_IRQ_GATTC_WRITE_DONE 0
+_IRQ_GATTC_INDICATE b'periph3'
+gattc_read
+_IRQ_GATTC_READ_RESULT b'periph3'
 _IRQ_GATTC_READ_DONE 0
 gap_disconnect: True
 _IRQ_PERIPHERAL_DISCONNECT


### PR DESCRIPTION
The goal of this PR is to allow using `ble.gatts_notify()` at any time, even if the stack is not ready to send the notification right now.

This also addresses the same issue for `ble.gatts_indicate` and `ble.gattc_write` (without response). The result is that you can now:
 - Call notify/indicate at any time.
 - Call write-without-response while another one is in progress. (But no additional ones can queue, and will fail with EALREADY)

Unfortunately the three cases notify/indicate, write-with-response and write-without-response all require slightly different implementations.

This PR also addresses two other issues:
 - The buffer passed to write-with-response wasn't copied, meaning it could be modified by the caller, affecting the in-progress write.
 - The buffer wasn't tracked to prevent the GC free'ing it.