### PR TITLE
github: Add FUNDING.yml file pointing to micropython GitHub sponsorship.

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,1 @@
+github: micropython


### PR DESCRIPTION
The MicroPython GitHub organisation now accepts sponsorship at https://github.com/sponsors/micropython (hooray!) and this PR should add a button on this repository linking to that page.