### PR TITLE
py: Rename sys module to usys.

### DIFF
--- a/docs/library/index.rst
+++ b/docs/library/index.rst
@@ -77,7 +77,6 @@ it will fallback to loading the built-in ``ujson`` module.
    cmath.rst
    gc.rst
    math.rst
-   sys.rst
    uarray.rst
    uasyncio.rst
    ubinascii.rst
@@ -93,6 +92,7 @@ it will fallback to loading the built-in ``ujson`` module.
    usocket.rst
    ussl.rst
    ustruct.rst
+   usys.rst
    utime.rst
    uzlib.rst
    _thread.rst

--- a/docs/library/usys.rst
+++ b/docs/library/usys.rst
@@ -1,7 +1,7 @@
-:mod:`sys` -- system specific functions
-=======================================
+:mod:`usys` -- system specific functions
+=======================================+
 
-.. module:: sys
+.. module:: usys
    :synopsis: system specific functions
 
 |see_cpython_module| :mod:`python:sys`.
@@ -28,10 +28,10 @@ Functions
       This function is a MicroPython extension intended to provide similar
       functionality to the :mod:`atexit` module in CPython.
 
-.. function:: print_exception(exc, file=sys.stdout, /)
+.. function:: print_exception(exc, file=usys.stdout, /)
 
    Print exception with a traceback to a file-like object *file* (or
-   `sys.stdout` by default).
+   `usys.stdout` by default).
 
    .. admonition:: Difference to CPython
       :class: attention
@@ -84,7 +84,7 @@ Constants
    value directly, but instead count number of bits in it::
 
     bits = 0
-    v = sys.maxsize
+    v = usys.maxsize
     while v:
         bits += 1
         v >>= 1
@@ -113,7 +113,7 @@ Constants
    is an identifier of a board, e.g. ``"pyboard"`` for the original MicroPython
    reference board. It thus can be used to distinguish one board from another.
    If you need to check whether your program runs on MicroPython (vs other
-   Python implementation), use `sys.implementation` instead.
+   Python implementation), use `usys.implementation` instead.
 
 .. data:: stderr
 

--- a/drivers/nrf24l01/nrf24l01test.py
+++ b/drivers/nrf24l01/nrf24l01test.py
@@ -1,6 +1,6 @@
 """Test for nrf24l01 module.  Portable between MicroPython targets."""
 
-import sys
+import usys
 import ustruct as struct
 import utime
 from machine import Pin, SPI
@@ -14,14 +14,14 @@ _RX_POLL_DELAY = const(15)
 # master may be a slow device. Value tested with Pyboard, ESP32 and ESP8266.
 _SLAVE_SEND_DELAY = const(10)
 
-if sys.platform == "pyboard":
+if usys.platform == "pyboard":
     cfg = {"spi": 2, "miso": "Y7", "mosi": "Y8", "sck": "Y6", "csn": "Y5", "ce": "Y4"}
-elif sys.platform == "esp8266":  # Hardware SPI
+elif usys.platform == "esp8266":  # Hardware SPI
     cfg = {"spi": 1, "miso": 12, "mosi": 13, "sck": 14, "csn": 4, "ce": 5}
-elif sys.platform == "esp32":  # Software SPI
+elif usys.platform == "esp32":  # Software SPI
     cfg = {"spi": -1, "miso": 32, "mosi": 33, "sck": 25, "csn": 26, "ce": 27}
 else:
-    raise ValueError("Unsupported platform {}".format(sys.platform))
+    raise ValueError("Unsupported platform {}".format(usys.platform))
 
 # Addresses are in little-endian format. They correspond to big-endian
 # 0xf0f0f0f0e1, 0xf0f0f0f0d2

--- a/extmod/webrepl/websocket_helper.py
+++ b/extmod/webrepl/websocket_helper.py
@@ -1,4 +1,7 @@
-import sys
+try:
+    import usys as sys
+except ImportError:
+    import sys
 
 try:
     import ubinascii as binascii

--- a/py/objmodule.c
+++ b/py/objmodule.c
@@ -159,7 +159,7 @@ STATIC const mp_rom_map_elem_t mp_builtin_module_table[] = {
     #endif
     #endif
     #if MICROPY_PY_SYS
-    { MP_ROM_QSTR(MP_QSTR_sys), MP_ROM_PTR(&mp_module_sys) },
+    { MP_ROM_QSTR(MP_QSTR_usys), MP_ROM_PTR(&mp_module_sys) },
     #endif
     #if MICROPY_PY_GC && MICROPY_ENABLE_GC
     { MP_ROM_QSTR(MP_QSTR_gc), MP_ROM_PTR(&mp_module_gc) },

--- a/tests/basics/async_await2.py
+++ b/tests/basics/async_await2.py
@@ -1,6 +1,9 @@
 # test await expression
 
-import sys
+try:
+    import usys as sys
+except ImportError:
+    import sys
 if sys.implementation.name == 'micropython':
     # uPy allows normal generators to be awaitables
     coroutine = lambda f: f

--- a/tests/basics/async_for2.py
+++ b/tests/basics/async_for2.py
@@ -1,6 +1,9 @@
 # test waiting within "async for" __anext__ function
 
-import sys
+try:
+    import usys as sys
+except ImportError:
+    import sys
 if sys.implementation.name == 'micropython':
     # uPy allows normal generators to be awaitables
     coroutine = lambda f: f

--- a/tests/basics/async_with2.py
+++ b/tests/basics/async_with2.py
@@ -1,6 +1,9 @@
 # test waiting within async with enter/exit functions
 
-import sys
+try:
+    import usys as sys
+except ImportError:
+    import sys
 if sys.implementation.name == 'micropython':
     # uPy allows normal generators to be awaitables
     coroutine = lambda f: f

--- a/tests/basics/attrtuple1.py
+++ b/tests/basics/attrtuple1.py
@@ -1,7 +1,10 @@
 # test attrtuple
 # we can't test this type directly so we use sys.implementation object
 
-import sys
+try:
+    import usys as sys
+except ImportError:
+    import sys
 t = sys.implementation
 
 # It can be just a normal tuple on small ports

--- a/tests/basics/builtin_callable.py
+++ b/tests/basics/builtin_callable.py
@@ -7,7 +7,10 @@ print(callable([]))
 print(callable("dfsd"))
 
 # modules should not be callabe
-import sys
+try:
+    import usys as sys
+except ImportError:
+    import sys
 print(callable(sys))
 
 # builtins should be callable

--- a/tests/basics/builtin_dir.py
+++ b/tests/basics/builtin_dir.py
@@ -4,7 +4,10 @@
 print('__name__' in dir())
 
 # dir of module
-import sys
+try:
+    import usys as sys
+except ImportError:
+    import sys
 print('version' in dir(sys))
 
 # dir of type

--- a/tests/basics/int_big1.py
+++ b/tests/basics/int_big1.py
@@ -102,7 +102,10 @@ x = 4611686018427387904 # big
 x = -4611686018427387904 # big
 
 # sys.maxsize is a constant mpz, so test it's compatible with dynamic ones
-import sys
+try:
+    import usys as sys
+except ImportError:
+    import sys
 print(sys.maxsize + 1 - 1 == sys.maxsize)
 
 # test extraction of big int value via mp_obj_get_int_maybe

--- a/tests/basics/module2.py
+++ b/tests/basics/module2.py
@@ -1,6 +1,6 @@
 # uPy behaviour only: builtin modules are read-only
-import sys
+import usys
 try:
-    sys.x = 1
+    usys.x = 1
 except AttributeError:
     print("AttributeError")

--- a/tests/basics/python34.py
+++ b/tests/basics/python34.py
@@ -33,9 +33,9 @@ test_syntax("del ()") # can't delete empty tuple (in 3.6 we can)
 
 # from basics/sys1.py
 # uPy prints version 3.4
-import sys
-print(sys.version[:3])
-print(sys.version_info[0], sys.version_info[1])
+import usys
+print(usys.version[:3])
+print(usys.version_info[0], usys.version_info[1])
 
 # from basics/exception1.py
 # in 3.7 no comma is printed if there is only 1 arg (in 3.4-3.6 one is printed)

--- a/tests/basics/string_compare.py
+++ b/tests/basics/string_compare.py
@@ -51,7 +51,10 @@ print("1/" <= "1")
 
 # this tests an internal string that doesn't have a hash with a string
 # that does have a hash, but the lengths of the two strings are different
-import sys
+try:
+    import usys as sys
+except ImportError:
+    import sys
 print(sys.version == 'a long string that has a hash')
 
 # this special string would have a hash of 0 but is incremented to 1

--- a/tests/basics/sys1.py
+++ b/tests/basics/sys1.py
@@ -1,6 +1,9 @@
 # test sys module
 
-import sys
+try:
+    import usys as sys
+except ImportError:
+    import sys
 
 print(sys.__name__)
 print(type(sys.path))

--- a/tests/basics/sys_exit.py
+++ b/tests/basics/sys_exit.py
@@ -1,6 +1,9 @@
 # test sys module's exit function
 
-import sys
+try:
+    import usys as sys
+except ImportError:
+    import sys
 
 try:
     sys.exit

--- a/tests/basics/sys_getsizeof.py
+++ b/tests/basics/sys_getsizeof.py
@@ -1,6 +1,9 @@
 # test sys.getsizeof() function
 
-import sys
+try:
+    import usys as sys
+except ImportError:
+    import sys
 try:
     sys.getsizeof
 except AttributeError:

--- a/tests/extmod/uctypes_array_assign_native_le.py
+++ b/tests/extmod/uctypes_array_assign_native_le.py
@@ -1,4 +1,4 @@
-import sys
+import usys
 
 try:
     import uctypes
@@ -6,7 +6,7 @@ except ImportError:
     print("SKIP")
     raise SystemExit
 
-if sys.byteorder != "little":
+if usys.byteorder != "little":
     print("SKIP")
     raise SystemExit
 

--- a/tests/extmod/uctypes_array_assign_native_le_intbig.py
+++ b/tests/extmod/uctypes_array_assign_native_le_intbig.py
@@ -1,4 +1,4 @@
-import sys
+import usys
 
 try:
     import uctypes
@@ -6,7 +6,7 @@ except ImportError:
     print("SKIP")
     raise SystemExit
 
-if sys.byteorder != "little":
+if usys.byteorder != "little":
     print("SKIP")
     raise SystemExit
 

--- a/tests/extmod/uctypes_native_le.py
+++ b/tests/extmod/uctypes_native_le.py
@@ -1,7 +1,7 @@
 # This test is exactly like uctypes_le.py, but uses native structure layout.
 # Codepaths for packed vs native structures are different. This test only works
 # on little-endian machine (no matter if 32 or 64 bit).
-import sys
+import usys
 
 try:
     import uctypes
@@ -9,7 +9,7 @@ except ImportError:
     print("SKIP")
     raise SystemExit
 
-if sys.byteorder != "little":
+if usys.byteorder != "little":
     print("SKIP")
     raise SystemExit
 

--- a/tests/extmod/uctypes_ptr_le.py
+++ b/tests/extmod/uctypes_ptr_le.py
@@ -1,4 +1,4 @@
-import sys
+import usys
 
 try:
     import uctypes
@@ -6,7 +6,7 @@ except ImportError:
     print("SKIP")
     raise SystemExit
 
-if sys.byteorder != "little":
+if usys.byteorder != "little":
     print("SKIP")
     raise SystemExit
 

--- a/tests/extmod/uctypes_ptr_native_le.py
+++ b/tests/extmod/uctypes_ptr_native_le.py
@@ -1,4 +1,4 @@
-import sys
+import usys
 
 try:
     import uctypes
@@ -6,7 +6,7 @@ except ImportError:
     print("SKIP")
     raise SystemExit
 
-if sys.byteorder != "little":
+if usys.byteorder != "little":
     print("SKIP")
     raise SystemExit
 

--- a/tests/extmod/vfs_fat_more.py
+++ b/tests/extmod/vfs_fat_more.py
@@ -111,10 +111,10 @@ print(uos.listdir())
 print(uos.listdir("sys"))
 
 # test importing a file from a mounted FS
-import sys
+import usys
 
-sys.path.clear()
-sys.path.append("/sys")
+usys.path.clear()
+usys.path.append("/sys")
 with open("sys/test_module.py", "w") as f:
     f.write('print("test_module!")')
 import test_module

--- a/tests/extmod/vfs_lfs_mount.py
+++ b/tests/extmod/vfs_lfs_mount.py
@@ -68,17 +68,17 @@ def test(bdev, vfs_class):
     uos.umount("/lfs")
 
     # clear imported modules
-    sys.modules.clear()
+    usys.modules.clear()
 
 
 bdev = RAMBlockDevice(30)
 
 # initialise path
-import sys
+import usys
 
-sys.path.clear()
-sys.path.append("/lfs")
-sys.path.append("")
+usys.path.clear()
+usys.path.append("/lfs")
+usys.path.append("")
 
 # run tests
 test(bdev, uos.VfsLfs1)

--- a/tests/extmod/vfs_userfs.py
+++ b/tests/extmod/vfs_userfs.py
@@ -1,7 +1,7 @@
 # test VFS functionality with a user-defined filesystem
 # also tests parts of uio.IOBase implementation
 
-import sys
+import usys
 
 try:
     import uio
@@ -76,9 +76,9 @@ f = open("/userfs/data.txt")
 print(f.read())
 
 # import files from the user filesystem
-sys.path.append("/userfs")
+usys.path.append("/userfs")
 import usermod1
 
 # unmount and undo path addition
 uos.umount("/userfs")
-sys.path.pop()
+usys.path.pop()

--- a/tests/feature_check/byteorder.py
+++ b/tests/feature_check/byteorder.py
@@ -1,3 +1,6 @@
-import sys
+try:
+    import usys as sys
+except ImportError:
+    import sys
 
 print(sys.byteorder)

--- a/tests/float/float2int_doubleprec_intbig.py
+++ b/tests/float/float2int_doubleprec_intbig.py
@@ -2,10 +2,10 @@
 
 try:
     import ustruct as struct
+    import usys as sys
 except:
     import struct
-
-import sys
+    import sys
 
 maxsize_bits = 0
 maxsize = sys.maxsize

--- a/tests/float/float2int_fp30_intbig.py
+++ b/tests/float/float2int_fp30_intbig.py
@@ -2,10 +2,10 @@
 
 try:
     import ustruct as struct
+    import usys as sys
 except:
     import struct
-
-import sys
+    import sys
 
 maxsize_bits = 0
 maxsize = sys.maxsize

--- a/tests/float/float2int_intbig.py
+++ b/tests/float/float2int_intbig.py
@@ -2,10 +2,10 @@
 
 try:
     import ustruct as struct
+    import usys as sys
 except:
     import struct
-
-import sys
+    import sys
 
 maxsize_bits = 0
 maxsize = sys.maxsize

--- a/tests/io/argv.py
+++ b/tests/io/argv.py
@@ -1,3 +1,6 @@
-import sys
+try:
+    import usys as sys
+except ImportError:
+    import sys
 
 print(sys.argv)

--- a/tests/io/builtin_print_file.py
+++ b/tests/io/builtin_print_file.py
@@ -1,6 +1,9 @@
 # test builtin print function, using file= argument
 
-import sys
+try:
+    import usys as sys
+except ImportError:
+    import sys
 
 try:
     sys.stdout

--- a/tests/io/file_stdio.py
+++ b/tests/io/file_stdio.py
@@ -1,4 +1,7 @@
-import sys
+try:
+    import usys as sys
+except ImportError:
+    import sys
 
 print(sys.stdin.fileno())
 print(sys.stdout.fileno())

--- a/tests/io/resource_stream.py
+++ b/tests/io/resource_stream.py
@@ -1,5 +1,5 @@
 import uio
-import sys
+import usys
 
 try:
     uio.resource_stream
@@ -11,5 +11,5 @@ buf = uio.resource_stream("data", "file2")
 print(buf.read())
 
 # resource_stream(None, ...) look ups from current dir, hence sys.path[0] hack
-buf = uio.resource_stream(None, sys.path[0] + "/data/file2")
+buf = uio.resource_stream(None, usys.path[0] + "/data/file2")
 print(buf.read())

--- a/tests/micropython/emg_exc.py
+++ b/tests/micropython/emg_exc.py
@@ -1,7 +1,7 @@
 # test that emergency exceptions work
 
 import micropython
-import sys
+import usys
 
 try:
     import uio
@@ -26,7 +26,7 @@ def f():
 
     # print the exception
     buf = uio.StringIO()
-    sys.print_exception(exc, buf)
+    usys.print_exception(exc, buf)
     for l in buf.getvalue().split("\n"):
         if l.startswith("  File "):
             print(l.split('"')[2])

--- a/tests/micropython/heapalloc_traceback.py
+++ b/tests/micropython/heapalloc_traceback.py
@@ -1,7 +1,7 @@
 # test that we can generate a traceback without allocating
 
 import micropython
-import sys
+import usys
 
 try:
     import uio
@@ -33,7 +33,7 @@ test()
 
 # print the exception that was raised
 buf = uio.StringIO()
-sys.print_exception(global_exc, buf)
+usys.print_exception(global_exc, buf)
 for l in buf.getvalue().split("\n"):
     # uPy on pyboard prints <stdin> as file, so remove filename.
     if l.startswith("  File "):

--- a/tests/micropython/import_mpy_invalid.py
+++ b/tests/micropython/import_mpy_invalid.py
@@ -1,7 +1,7 @@
 # test importing of invalid .mpy files
 
 try:
-    import sys, uio, uos
+    import usys, uio, uos
 
     uio.IOBase
     uos.mount
@@ -54,7 +54,7 @@ user_files = {
 
 # create and mount a user filesystem
 uos.mount(UserFS(user_files), "/userfs")
-sys.path.append("/userfs")
+usys.path.append("/userfs")
 
 # import .mpy files from the user filesystem
 for i in range(len(user_files)):
@@ -66,4 +66,4 @@ for i in range(len(user_files)):
 
 # unmount and undo path addition
 uos.umount("/userfs")
-sys.path.pop()
+usys.path.pop()

--- a/tests/micropython/import_mpy_native_x64.py
+++ b/tests/micropython/import_mpy_native_x64.py
@@ -1,7 +1,7 @@
 # test importing of .mpy files with native code (x64 only)
 
 try:
-    import sys, uio, uos
+    import usys, uio, uos
 
     uio.IOBase
     uos.mount
@@ -9,7 +9,7 @@ except (ImportError, AttributeError):
     print("SKIP")
     raise SystemExit
 
-if not (sys.platform == "linux" and sys.maxsize > 2 ** 32):
+if not (usys.platform == "linux" and usys.maxsize > 2 ** 32):
     print("SKIP")
     raise SystemExit
 
@@ -101,7 +101,7 @@ user_files = {
 
 # create and mount a user filesystem
 uos.mount(UserFS(user_files), "/userfs")
-sys.path.append("/userfs")
+usys.path.append("/userfs")
 
 # import .mpy files from the user filesystem
 for i in range(len(user_files)):
@@ -114,4 +114,4 @@ for i in range(len(user_files)):
 
 # unmount and undo path addition
 uos.umount("/userfs")
-sys.path.pop()
+usys.path.pop()

--- a/tests/micropython/opt_level_lineno.py
+++ b/tests/micropython/opt_level_lineno.py
@@ -3,4 +3,4 @@ import micropython as micropython
 # check that level 3 doesn't store line numbers
 # the expected output is that any line is printed as "line 1"
 micropython.opt_level(3)
-exec("try:\n xyz\nexcept NameError as er:\n import sys\n sys.print_exception(er)")
+exec("try:\n xyz\nexcept NameError as er:\n import usys\n usys.print_exception(er)")

--- a/tests/micropython/viper_misc_intbig.py
+++ b/tests/micropython/viper_misc_intbig.py
@@ -6,6 +6,6 @@ def viper_uint() -> uint:
     return uint(-1)
 
 
-import sys
+import usys
 
-print(viper_uint() == (sys.maxsize << 1 | 1))
+print(viper_uint() == (usys.maxsize << 1 | 1))

--- a/tests/misc/print_exception.py
+++ b/tests/misc/print_exception.py
@@ -1,10 +1,10 @@
-import sys
-
 try:
     try:
         import uio as io
+        import usys as sys
     except ImportError:
         import io
+        import sys
 except ImportError:
     print("SKIP")
     raise SystemExit

--- a/tests/misc/sys_atexit.py
+++ b/tests/misc/sys_atexit.py
@@ -1,9 +1,9 @@
 # test sys.atexit() function
 
-import sys
+import usys
 
 try:
-    sys.atexit
+    usys.atexit
 except AttributeError:
     print("SKIP")
     raise SystemExit
@@ -15,7 +15,7 @@ def do_at_exit():
     print("done at exit:", some_var)
 
 
-sys.atexit(do_at_exit)
+usys.atexit(do_at_exit)
 
 some_var = "ok"
 print("done before exit")

--- a/tests/misc/sys_exc_info.py
+++ b/tests/misc/sys_exc_info.py
@@ -1,4 +1,7 @@
-import sys
+try:
+    import usys as sys
+except ImportError:
+    import sys
 
 try:
     sys.exc_info

--- a/tests/run-natmodtests.py
+++ b/tests/run-natmodtests.py
@@ -30,7 +30,7 @@ TEST_MAPPINGS = {
 
 # Code to allow a target MicroPython to import an .mpy from RAM
 injected_import_hook_code = """\
-import sys, uos, uio
+import usys, uos, uio
 class __File(uio.IOBase):
   def __init__(self):
     self.off = 0
@@ -54,7 +54,7 @@ class __FS:
     return __File()
 uos.mount(__FS(), '/__remote')
 uos.chdir('/__remote')
-sys.modules['{}'] = __import__('__injected')
+usys.modules['{}'] = __import__('__injected')
 """
 
 

--- a/tests/run-tests-exp.py
+++ b/tests/run-tests-exp.py
@@ -5,7 +5,7 @@
 # This script is intended to be run by the same interpreter executable
 # which is to be tested, so should use minimal language functionality.
 #
-import sys
+import usys as sys
 import uos as os
 
 

--- a/tests/thread/thread_stacksize1.py
+++ b/tests/thread/thread_stacksize1.py
@@ -1,8 +1,10 @@
 # test setting the thread stack size
 #
 # MIT license; Copyright (c) 2016 Damien P. George on behalf of Pycom Ltd
-
-import sys
+try:
+    import usys as sys
+except ImportError:
+    import sys
 import _thread
 
 # different implementations have different minimum sizes


### PR DESCRIPTION
This is consistent with the other 'micro' modules and allows
implementing additional features via e.g. micropython-lib's sys.