### PR TITLE
py/map: Convert map implementation to preserve insertion order (WIP, RFC)

### DIFF
--- a/py/obj.h
+++ b/py/obj.h
@@ -431,9 +431,11 @@ static inline bool mp_map_slot_is_filled(const mp_map_t *map, size_t pos) {
 
 void mp_map_init(mp_map_t *map, size_t n);
 void mp_map_init_fixed_table(mp_map_t *map, size_t n, const mp_obj_t *table);
+void mp_map_init_copy(mp_map_t *map, const mp_map_t *src);
 mp_map_t *mp_map_new(size_t n);
 void mp_map_deinit(mp_map_t *map);
 void mp_map_free(mp_map_t *map);
+size_t mp_map_num_filled_slots(mp_map_t *map);
 mp_map_elem_t *mp_map_lookup(mp_map_t *map, mp_obj_t index, mp_map_lookup_kind_t lookup_kind);
 void mp_map_clear(mp_map_t *map);
 void mp_map_dump(mp_map_t *map);

--- a/py/objdict.c
+++ b/py/objdict.c
@@ -112,9 +112,9 @@ STATIC mp_obj_t dict_unary_op(mp_unary_op_t op, mp_obj_t self_in) {
     mp_obj_dict_t *self = MP_OBJ_TO_PTR(self_in);
     switch (op) {
         case MP_UNARY_OP_BOOL:
-            return mp_obj_new_bool(self->map.used != 0);
+            return mp_obj_new_bool(mp_map_num_filled_slots(&self->map) != 0);
         case MP_UNARY_OP_LEN:
-            return MP_OBJ_NEW_SMALL_INT(self->map.used);
+            return MP_OBJ_NEW_SMALL_INT(mp_map_num_filled_slots(&self->map));
         #if MICROPY_PY_SYS_GETSIZEOF
         case MP_UNARY_OP_SIZEOF: {
             size_t sz = sizeof(*self) + sizeof(*self->map.table) * self->map.alloc;
@@ -230,15 +230,10 @@ STATIC MP_DEFINE_CONST_FUN_OBJ_1(dict_clear_obj, dict_clear);
 mp_obj_t mp_obj_dict_copy(mp_obj_t self_in) {
     mp_check_self(mp_obj_is_dict_type(self_in));
     mp_obj_dict_t *self = MP_OBJ_TO_PTR(self_in);
-    mp_obj_t other_out = mp_obj_new_dict(self->map.alloc);
-    mp_obj_dict_t *other = MP_OBJ_TO_PTR(other_out);
+    mp_obj_dict_t *other = m_new_obj(mp_obj_dict_t);
     other->base.type = self->base.type;
-    other->map.used = self->map.used;
-    other->map.all_keys_are_qstrs = self->map.all_keys_are_qstrs;
-    other->map.is_fixed = 0;
-    other->map.is_ordered = self->map.is_ordered;
-    memcpy(other->map.table, self->map.table, self->map.alloc * sizeof(mp_map_elem_t));
-    return other_out;
+    mp_map_init_copy(&other->map, &self->map);
+    return MP_OBJ_FROM_PTR(other);
 }
 STATIC MP_DEFINE_CONST_FUN_OBJ_1(dict_copy_obj, mp_obj_dict_copy);
 


### PR DESCRIPTION
This PR changes the map implementation to make maps preserve insertion order, ie dicts are ordered by default.  At this stage it's just for discussion, *there's not (yet) any intention of merging it*.  See #6170 for additional discussion on this topic.

It uses a similar algorithm to PyPy/CPython.  RAM overhead compared to the existing (non-order preserving) implementation is +12.5% for dicts with <255 elements, and +25% for dicts with <65535 elements.  The code change is surprisingly simple.

TODO:
- support dicts >65535 elements
- make it optional at compile-time
- make OrderedDict use this new implementation
- implement more efficient deletion (currently there are pathological cases where the dict will grow forever if elements are continuously deleted and inserted)
- profile performance and memory use
