### PR TITLE
py/objint: Allow int constructor to accept any obj with buffer protocol.

### DIFF
--- a/py/objint.c
+++ b/py/objint.c
@@ -48,15 +48,14 @@ STATIC mp_obj_t mp_obj_int_make_new(const mp_obj_type_t *type_in, size_t n_args,
         case 0:
             return MP_OBJ_NEW_SMALL_INT(0);
 
-        case 1:
+        case 1: {
+            mp_buffer_info_t bufinfo;
             if (mp_obj_is_int(args[0])) {
                 // already an int (small or long), just return it
                 return args[0];
-            } else if (mp_obj_is_str_or_bytes(args[0])) {
+            } else if (mp_get_buffer(args[0], &bufinfo, MP_BUFFER_READ)) {
                 // a string, parse it
-                size_t l;
-                const char *s = mp_obj_str_get_data(args[0], &l);
-                return mp_parse_num_integer(s, l, 0, NULL);
+                return mp_parse_num_integer(bufinfo.buf, bufinfo.len, 0, NULL);
             #if MICROPY_PY_BUILTINS_FLOAT
             } else if (mp_obj_is_float(args[0])) {
                 return mp_obj_new_int_from_float(mp_obj_float_get(args[0]));
@@ -64,6 +63,7 @@ STATIC mp_obj_t mp_obj_int_make_new(const mp_obj_type_t *type_in, size_t n_args,
             } else {
                 return mp_unary_op(MP_UNARY_OP_INT, args[0]);
             }
+        }
 
         case 2:
         default: {

--- a/tests/basics/int_bytearray.py
+++ b/tests/basics/int_bytearray.py
@@ -1,0 +1,5 @@
+# test int interacting with bytearray
+
+# should accept bytearray as an argument
+print(int(bytearray(b"123")))
+print(int.from_bytes(bytearray(b"\x00\x01"), "little"))


### PR DESCRIPTION
This makes it compatible with CPython, consistent with float's constructor, and reduces code size.

Code size change:
```
   bare-arm:   -28 -0.043% 
minimal x86:   -16 -0.011% 
   unix x64:   -88 -0.017% 
unix nanbox:   -28 -0.006% 
      stm32:   -20 -0.005% PYBV10
     cc3200:   -32 -0.017% 
    esp8266:   -16 -0.002% GENERIC
      esp32:    -8 -0.001% GENERIC
        nrf:   -24 -0.017% pca10040
       samd:   -20 -0.020% ADAFRUIT_ITSYBITSY_M4_EXPRESS
```