### PR TITLE
tools/makemanifest.py: Support freezing a subdirectory recursively.

### DIFF
--- a/tools/makemanifest.py
+++ b/tools/makemanifest.py
@@ -76,9 +76,10 @@ def freeze(path, script=None, opt=0):
     If `script` is an iterable then freeze() is called on all items of the
     iterable (with the same `path` and `opt` passed through).
 
-    If `script` is a string then it specifies the filename to freeze, and
-    can include extra directories before the file.  The file will be
-    searched for in `path`.
+    If `script` is a string then it specifies the file or directory to
+    freeze, and can include extra directories before the file or last
+    directory.  The file or directory will be searched for in `path`.  If
+    `script` is a directory then all files in that directory will be frozen.
 
     `opt` is the optimisation level to pass to mpy-cross when compiling .py
     to .mpy.
@@ -182,14 +183,22 @@ def freeze_internal(kind, path, script, opt):
         if any(f[0] == KIND_AS_STR for f in manifest_list):
             raise FreezeError("can only freeze one str directory")
         manifest_list.append((KIND_AS_STR, path, script, opt))
-    elif script is None:
-        for dirpath, dirnames, filenames in os.walk(path, followlinks=True):
+    elif script is None or isinstance(script, str) and script.find(".") == -1:
+        # Recursively search `path` for files to freeze, optionally restricted
+        # to a subdirectory specified by `script`
+        if script is None:
+            subdir = ""
+        else:
+            subdir = "/" + script
+        for dirpath, dirnames, filenames in os.walk(path + subdir, followlinks=True):
             for f in filenames:
                 freeze_internal(kind, path, (dirpath + "/" + f)[len(path) + 1 :], opt)
     elif not isinstance(script, str):
+        # `script` is an iterable of items to freeze
         for s in script:
             freeze_internal(kind, path, s, opt)
     else:
+        # `script` should specify an individual file to be frozen
         extension_kind = {KIND_AS_MPY: ".py", KIND_MPY: ".mpy"}
         if kind == KIND_AUTO:
             for k, ext in extension_kind.items():


### PR DESCRIPTION
This adds support for freezing an entire directory while keeping the directory as part of the import path.  For example

    freeze("path/to/library", "module")

will recursively freeze all scripts in "path/to/library/module" and have them importable as "from module import ...".
