### PR TITLE
stm32/mboot: Add support for littlefs in mboot

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -78,6 +78,7 @@ jobs:
         - make ${MAKEOPTS} -C ports/stm32 BOARD=NUCLEO_L073RZ
         - make ${MAKEOPTS} -C ports/stm32 BOARD=STM32L476DISC
         - make ${MAKEOPTS} -C ports/stm32 BOARD=NUCLEO_WB55
+        - make ${MAKEOPTS} -C ports/stm32/mboot BOARD=PYBV10 CFLAGS_EXTRA='-DMBOOT_FSLOAD=1 -DMBOOT_VFS_LFS2=1'
         - make ${MAKEOPTS} -C ports/stm32/mboot BOARD=PYBD_SF6
         - make ${MAKEOPTS} -C ports/stm32/mboot BOARD=NUCLEO_WB55
 

--- a/ports/stm32/boards/MIKROE_CLICKER2_STM32/mpconfigboard.h
+++ b/ports/stm32/boards/MIKROE_CLICKER2_STM32/mpconfigboard.h
@@ -83,3 +83,4 @@
 #define MBOOT_BOOTPIN_PULL          (MP_HAL_PIN_PULL_NONE)
 #define MBOOT_BOOTPIN_ACTIVE        (0)
 #define MBOOT_FSLOAD                (1)
+#define MBOOT_VFS_FAT               (1)

--- a/ports/stm32/boards/PYBD_SF2/mpconfigboard.h
+++ b/ports/stm32/boards/PYBD_SF2/mpconfigboard.h
@@ -188,6 +188,7 @@ extern struct _spi_bdev_t spi_bdev2;
 
 #define MBOOT_USB_AUTODETECT_PORT   (1)
 #define MBOOT_FSLOAD                (1)
+#define MBOOT_VFS_FAT               (1)
 
 #define MBOOT_I2C_PERIPH_ID         1
 #define MBOOT_I2C_SCL               (pin_B8)

--- a/ports/stm32/mboot/Makefile
+++ b/ports/stm32/mboot/Makefile
@@ -102,7 +102,8 @@ SRC_C = \
 	main.c \
 	elem.c \
 	fsload.c \
-	diskio.c \
+	gzstream.c \
+	vfs_fat.c \
 	drivers/bus/softspi.c \
 	drivers/bus/softqspi.c \
 	drivers/memory/spiflash.c \

--- a/ports/stm32/mboot/Makefile
+++ b/ports/stm32/mboot/Makefile
@@ -70,6 +70,8 @@ CFLAGS += -DSTM32_HAL_H='<stm32$(MCU_SERIES)xx_hal.h>'
 CFLAGS += -DBOARD_$(BOARD)
 CFLAGS += -DAPPLICATION_ADDR=$(TEXT0_ADDR)
 CFLAGS += -DFFCONF_H=\"ports/stm32/mboot/ffconf.h\"
+CFLAGS += -DLFS1_NO_MALLOC -DLFS1_NO_DEBUG -DLFS1_NO_WARN -DLFS1_NO_ERROR -DLFS1_NO_ASSERT
+CFLAGS += -DLFS2_NO_MALLOC -DLFS2_NO_DEBUG -DLFS2_NO_WARN -DLFS2_NO_ERROR -DLFS2_NO_ASSERT
 CFLAGS += -DBUILDING_MBOOT=1
 CFLAGS += -DBOOTLOADER_DFU_USB_VID=$(BOOTLOADER_DFU_USB_VID) -DBOOTLOADER_DFU_USB_PID=$(BOOTLOADER_DFU_USB_PID)
 
@@ -91,6 +93,10 @@ endif
 $(BUILD)/lib/libc/string0.o: CFLAGS += $(CFLAGS_BUILTIN)
 LIB_SRC_C = \
 	lib/libc/string0.c \
+	lib/littlefs/lfs1.c \
+	lib/littlefs/lfs1_util.c \
+	lib/littlefs/lfs2.c \
+	lib/littlefs/lfs2_util.c \
 	lib/oofatfs/ff.c \
 	lib/oofatfs/ffunicode.c \
 	extmod/uzlib/crc32.c \
@@ -104,6 +110,7 @@ SRC_C = \
 	fsload.c \
 	gzstream.c \
 	vfs_fat.c \
+	vfs_lfs.c \
 	drivers/bus/softspi.c \
 	drivers/bus/softqspi.c \
 	drivers/memory/spiflash.c \

--- a/ports/stm32/mboot/README.md
+++ b/ports/stm32/mboot/README.md
@@ -2,11 +2,11 @@ Mboot - MicroPython boot loader
 ===============================
 
 Mboot is a custom bootloader for STM32 MCUs, and currently supports the
-STM32F4xx and STM32F7xx families.  It can provide a standard USB DFU interface
-on either the FS or HS peripherals, as well as a sophisticated, custom I2C
+STM32F4xx, STM32F7xx and STM32WBxx families.  It can provide a standard USB DFU
+interface on either the FS or HS peripherals, as well as a sophisticated, custom I2C
 interface.  It can also load and program firmware in .dfu.gz format from a
-filesystem.  It can fit in 16k of flash space, but all features enabled requires
-32k.
+filesystem, either FAT, littlefs 1 or littlfs 2.
+It can fit in 16k of flash space, but all features enabled requires 32k.
 
 How to use
 ----------
@@ -62,6 +62,15 @@ How to use
    To enable loading firmware from a filesystem use:
 
     #define MBOOT_FSLOAD (1)
+
+   and then enable one or more of the following depending on what filesystem
+   support is required in Mboot (note that the FAT driver is read-only and
+   quite compact, but littlefs supports both read and write so is rather
+   large):
+
+    #define MBOOT_VFS_FAT (1)
+    #define MBOOT_VFS_LFS1 (1)
+    #define MBOOT_VFS_LFS2 (1)
 
 2. Build the board's main application firmware as usual.
 
@@ -133,10 +142,18 @@ are located and what filename to program.  The elements to use are:
 `u32` means unsigned 32-bit little-endian integer.
 
 The firmware to load must be a gzip'd DfuSe file (.dfu.gz) and stored within a
-FAT formatted partition.
+FAT or littlefs formatted partition.
 
 The provided fwupdate.py script contains helper functions to call into Mboot
-with the correct data, and also to update Mboot itself.
+with the correct data, and also to update Mboot itself.  For example on PYBD
+the following will update the main MicroPython firmware from the file
+firmware.dfu.gz stored on the default FAT filesystem:
+
+    import fwupdate
+    fwupdate.update_mpy('firmware.dfu.gz', 0x80000000, 2 * 1024 * 1024)
+
+The 0x80000000 value is the address understood by Mboot as the location of
+the external SPI flash, configured via `MBOOT_SPIFLASH_ADDR`.
 
 Example: Mboot on PYBv1.x
 -------------------------

--- a/ports/stm32/mboot/fwupdate.py
+++ b/ports/stm32/mboot/fwupdate.py
@@ -1,9 +1,13 @@
 # Update Mboot or MicroPython from a .dfu.gz file on the board's filesystem
-# MIT license; Copyright (c) 2019 Damien P. George
+# MIT license; Copyright (c) 2019-2020 Damien P. George
 
 import struct, time
 import uzlib, machine, stm
 
+# Constants to be used with update_mpy
+VFS_FAT = 1
+VFS_LFS1 = 2
+VFS_LFS2 = 3
 
 FLASH_KEY1 = 0x45670123
 FLASH_KEY2 = 0xCDEF89AB
@@ -152,7 +156,7 @@ def update_mboot(filename):
     print("Programming finished, can now reset or turn off.")
 
 
-def update_mpy(filename, fs_base, fs_len):
+def update_mpy(filename, fs_base, fs_len, fs_type=VFS_FAT):
     # Check firmware is of .dfu.gz type
     try:
         with open(filename, "rb") as f:
@@ -166,11 +170,8 @@ def update_mpy(filename, fs_base, fs_len):
     ELEM_TYPE_END = 1
     ELEM_TYPE_MOUNT = 2
     ELEM_TYPE_FSLOAD = 3
-    ELEM_MOUNT_FAT = 1
     mount_point = 1
-    mount = struct.pack(
-        "<BBBBLL", ELEM_TYPE_MOUNT, 10, mount_point, ELEM_MOUNT_FAT, fs_base, fs_len
-    )
+    mount = struct.pack("<BBBBLL", ELEM_TYPE_MOUNT, 10, mount_point, fs_type, fs_base, fs_len)
     fsup = struct.pack("<BBB", ELEM_TYPE_FSLOAD, 1 + len(filename), mount_point) + bytes(
         filename, "ascii"
     )

--- a/ports/stm32/mboot/gzstream.c
+++ b/ports/stm32/mboot/gzstream.c
@@ -1,0 +1,94 @@
+/*
+ * This file is part of the MicroPython project, http://micropython.org/
+ *
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2019-2020 Damien P. George
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#include <string.h>
+
+#include "py/mphal.h"
+#include "extmod/uzlib/uzlib.h"
+#include "gzstream.h"
+#include "mboot.h"
+
+#if MBOOT_FSLOAD
+
+#define DICT_SIZE (1 << 15)
+
+typedef struct _gz_stream_t {
+    void *stream_data;
+    stream_read_t stream_read;
+    TINF_DATA tinf;
+    uint8_t buf[512];
+    uint8_t dict[DICT_SIZE];
+} gz_stream_t;
+
+static gz_stream_t gz_stream SECTION_NOZERO_BSS;
+
+static int gz_stream_read_src(TINF_DATA *tinf) {
+    int n = gz_stream.stream_read(gz_stream.stream_data, gz_stream.buf, sizeof(gz_stream.buf));
+    if (n < 0) {
+        // Stream error
+        return -1;
+    }
+    if (n == 0) {
+        // No data / EOF
+        return -1;
+    }
+
+    tinf->source = gz_stream.buf + 1;
+    tinf->source_limit = gz_stream.buf + n;
+    return gz_stream.buf[0];
+}
+
+int gz_stream_init(void *stream_data, stream_read_t stream_read) {
+    gz_stream.stream_data = stream_data;
+    gz_stream.stream_read = stream_read;
+
+    memset(&gz_stream.tinf, 0, sizeof(gz_stream.tinf));
+    gz_stream.tinf.readSource = gz_stream_read_src;
+
+    int st = uzlib_gzip_parse_header(&gz_stream.tinf);
+    if (st != TINF_OK) {
+        return -1;
+    }
+
+    uzlib_uncompress_init(&gz_stream.tinf, gz_stream.dict, DICT_SIZE);
+
+    return 0;
+}
+
+int gz_stream_read(size_t len, uint8_t *buf) {
+    gz_stream.tinf.dest = buf;
+    gz_stream.tinf.dest_limit = buf + len;
+    int st = uzlib_uncompress_chksum(&gz_stream.tinf);
+    if (st == TINF_DONE) {
+        return 0;
+    }
+    if (st < 0) {
+        return st;
+    }
+    return gz_stream.tinf.dest - buf;
+}
+
+#endif // MBOOT_FSLOAD

--- a/ports/stm32/mboot/gzstream.h
+++ b/ports/stm32/mboot/gzstream.h
@@ -3,7 +3,7 @@
  *
  * The MIT License (MIT)
  *
- * Copyright (c) 2019 Damien P. George
+ * Copyright (c) 2019-2020 Damien P. George
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -23,35 +23,23 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+#ifndef MICROPY_INCLUDED_STM32_MBOOT_GZSTREAM_H
+#define MICROPY_INCLUDED_STM32_MBOOT_GZSTREAM_H
 
-#include <stdint.h>
 #include <stddef.h>
+#include <stdint.h>
 
-// Use this to tag global static data in RAM that doesn't need to be zeroed on startup
-#define SECTION_NOZERO_BSS __attribute__((section(".nozero_bss")))
+typedef int (*stream_open_t)(void *stream, const char *fname);
+typedef void (*stream_close_t)(void *stream);
+typedef int (*stream_read_t)(void *stream, uint8_t *buf, size_t len);
 
-#define ELEM_DATA_SIZE (1024)
-#define ELEM_DATA_START (&_estack[0])
-#define ELEM_DATA_MAX (&_estack[ELEM_DATA_SIZE])
+typedef struct _stream_methods_t {
+    stream_open_t open;
+    stream_close_t close;
+    stream_read_t read;
+} stream_methods_t;
 
-enum {
-    ELEM_TYPE_END = 1,
-    ELEM_TYPE_MOUNT,
-    ELEM_TYPE_FSLOAD,
-};
+int gz_stream_init(void *stream_data, stream_read_t stream_read);
+int gz_stream_read(size_t len, uint8_t *buf);
 
-enum {
-    ELEM_MOUNT_FAT = 1,
-};
-
-extern uint8_t _estack[ELEM_DATA_SIZE];
-
-uint32_t get_le32(const uint8_t *b);
-void led_state_all(unsigned int mask);
-
-int do_page_erase(uint32_t addr, uint32_t *next_addr);
-void do_read(uint32_t addr, int len, uint8_t *buf);
-int do_write(uint32_t addr, const uint8_t *src8, size_t len);
-
-const uint8_t *elem_search(const uint8_t *elem, uint8_t elem_id);
-int fsload_process(void);
+#endif // MICROPY_INCLUDED_STM32_MBOOT_GZSTREAM_H

--- a/ports/stm32/mboot/mboot.h
+++ b/ports/stm32/mboot/mboot.h
@@ -3,7 +3,7 @@
  *
  * The MIT License (MIT)
  *
- * Copyright (c) 2019 Damien P. George
+ * Copyright (c) 2019-2020 Damien P. George
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -23,6 +23,8 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+#ifndef MICROPY_INCLUDED_STM32_MBOOT_MBOOT_H
+#define MICROPY_INCLUDED_STM32_MBOOT_MBOOT_H
 
 #include <stdint.h>
 #include <stddef.h>
@@ -42,6 +44,8 @@ enum {
 
 enum {
     ELEM_MOUNT_FAT = 1,
+    ELEM_MOUNT_LFS1,
+    ELEM_MOUNT_LFS2,
 };
 
 extern uint8_t _estack[ELEM_DATA_SIZE];
@@ -55,3 +59,5 @@ int do_write(uint32_t addr, const uint8_t *src8, size_t len);
 
 const uint8_t *elem_search(const uint8_t *elem, uint8_t elem_id);
 int fsload_process(void);
+
+#endif // MICROPY_INCLUDED_STM32_MBOOT_MBOOT_H

--- a/ports/stm32/mboot/vfs.h
+++ b/ports/stm32/mboot/vfs.h
@@ -3,7 +3,7 @@
  *
  * The MIT License (MIT)
  *
- * Copyright (c) 2019 Damien P. George
+ * Copyright (c) 2019-2020 Damien P. George
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -23,35 +23,21 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+#ifndef MICROPY_INCLUDED_STM32_MBOOT_VFS_H
+#define MICROPY_INCLUDED_STM32_MBOOT_VFS_H
 
-#include <stdint.h>
-#include <stddef.h>
+#include "lib/oofatfs/ff.h"
+#include "gzstream.h"
 
-// Use this to tag global static data in RAM that doesn't need to be zeroed on startup
-#define SECTION_NOZERO_BSS __attribute__((section(".nozero_bss")))
+typedef struct _vfs_fat_context_t {
+    uint32_t bdev_base_addr;
+    uint32_t bdev_byte_len;
+    FATFS fatfs;
+    FIL fp;
+} vfs_fat_context_t;
 
-#define ELEM_DATA_SIZE (1024)
-#define ELEM_DATA_START (&_estack[0])
-#define ELEM_DATA_MAX (&_estack[ELEM_DATA_SIZE])
+extern const stream_methods_t vfs_fat_stream_methods;
 
-enum {
-    ELEM_TYPE_END = 1,
-    ELEM_TYPE_MOUNT,
-    ELEM_TYPE_FSLOAD,
-};
+int vfs_fat_mount(vfs_fat_context_t *ctx, uint32_t base_addr, uint32_t byte_len);
 
-enum {
-    ELEM_MOUNT_FAT = 1,
-};
-
-extern uint8_t _estack[ELEM_DATA_SIZE];
-
-uint32_t get_le32(const uint8_t *b);
-void led_state_all(unsigned int mask);
-
-int do_page_erase(uint32_t addr, uint32_t *next_addr);
-void do_read(uint32_t addr, int len, uint8_t *buf);
-int do_write(uint32_t addr, const uint8_t *src8, size_t len);
-
-const uint8_t *elem_search(const uint8_t *elem, uint8_t elem_id);
-int fsload_process(void);
+#endif // MICROPY_INCLUDED_STM32_MBOOT_VFS_H

--- a/ports/stm32/mboot/vfs.h
+++ b/ports/stm32/mboot/vfs.h
@@ -26,8 +26,12 @@
 #ifndef MICROPY_INCLUDED_STM32_MBOOT_VFS_H
 #define MICROPY_INCLUDED_STM32_MBOOT_VFS_H
 
-#include "lib/oofatfs/ff.h"
 #include "gzstream.h"
+#include "mboot.h"
+
+#if MBOOT_VFS_FAT
+
+#include "lib/oofatfs/ff.h"
 
 typedef struct _vfs_fat_context_t {
     uint32_t bdev_base_addr;
@@ -39,5 +43,54 @@ typedef struct _vfs_fat_context_t {
 extern const stream_methods_t vfs_fat_stream_methods;
 
 int vfs_fat_mount(vfs_fat_context_t *ctx, uint32_t base_addr, uint32_t byte_len);
+
+#endif
+
+#if MBOOT_VFS_LFS1
+
+#include "lib/littlefs/lfs1.h"
+
+#define LFS_READ_SIZE (32)
+#define LFS_PROG_SIZE (32)
+#define LFS_LOOKAHEAD_SIZE (32)
+
+typedef struct _vfs_lfs1_context_t {
+    uint32_t bdev_base_addr;
+    struct lfs1_config config;
+    lfs1_t lfs;
+    struct lfs1_file_config filecfg;
+    uint8_t filebuf[LFS_PROG_SIZE];
+    lfs1_file_t file;
+} vfs_lfs1_context_t;
+
+extern const stream_methods_t vfs_lfs1_stream_methods;
+
+int vfs_lfs1_mount(vfs_lfs1_context_t *ctx, uint32_t base_addr, uint32_t byte_len);
+
+#endif
+
+#if MBOOT_VFS_LFS2
+
+#include "lib/littlefs/lfs2.h"
+
+#define LFS_READ_SIZE (32)
+#define LFS_PROG_SIZE (32)
+#define LFS_CACHE_SIZE (4 * LFS_READ_SIZE)
+#define LFS_LOOKAHEAD_SIZE (32)
+
+typedef struct _vfs_lfs2_context_t {
+    uint32_t bdev_base_addr;
+    struct lfs2_config config;
+    lfs2_t lfs;
+    struct lfs2_file_config filecfg;
+    uint8_t filebuf[LFS_CACHE_SIZE]; // lfs2 specific
+    lfs2_file_t file;
+} vfs_lfs2_context_t;
+
+extern const stream_methods_t vfs_lfs2_stream_methods;
+
+int vfs_lfs2_mount(vfs_lfs2_context_t *ctx, uint32_t base_addr, uint32_t byte_len);
+
+#endif
 
 #endif // MICROPY_INCLUDED_STM32_MBOOT_VFS_H

--- a/ports/stm32/mboot/vfs_fat.c
+++ b/ports/stm32/mboot/vfs_fat.c
@@ -30,7 +30,7 @@
 #include "mboot.h"
 #include "vfs.h"
 
-#if MBOOT_FSLOAD
+#if MBOOT_FSLOAD && MBOOT_VFS_FAT
 
 #if FF_MAX_SS == FF_MIN_SS
 #define SECSIZE (FF_MIN_SS)
@@ -119,4 +119,4 @@ const stream_methods_t vfs_fat_stream_methods = {
     vfs_fat_stream_read,
 };
 
-#endif // MBOOT_FSLOAD
+#endif // MBOOT_FSLOAD && MBOOT_VFS_FAT

--- a/ports/stm32/mboot/vfs_lfs.c
+++ b/ports/stm32/mboot/vfs_lfs.c
@@ -1,0 +1,177 @@
+/*
+ * This file is part of the MicroPython project, http://micropython.org/
+ *
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2020 Damien P. George
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#include <string.h>
+
+#include "py/mphal.h"
+#include "mboot.h"
+#include "vfs.h"
+
+#if MBOOT_FSLOAD && (MBOOT_VFS_LFS1 || MBOOT_VFS_LFS2)
+
+#if MBOOT_VFS_LFS1
+#if MBOOT_VFS_LFS2
+#error Unsupported
+#endif
+
+#define LFSx_MACRO(s) LFS1##s
+#define LFSx_API(x) lfs1_ ## x
+#define VFS_LFSx_CONTEXT_T vfs_lfs1_context_t
+#define VFS_LFSx_MOUNT vfs_lfs1_mount
+#define VFS_LFSx_STREAM_METHODS vfs_lfs1_stream_methods
+
+#define SUPERBLOCK_MAGIC_OFFSET (40)
+#define SUPERBLOCK_BLOCK_SIZE_OFFSET (28)
+#define SUPERBLOCK_BLOCK_COUNT_OFFSET (32)
+
+static uint8_t lfs_read_buffer[LFS_READ_SIZE];
+static uint8_t lfs_prog_buffer[LFS_PROG_SIZE];
+static uint8_t lfs_lookahead_buffer[LFS_LOOKAHEAD_SIZE / 8];
+
+#else
+
+#define LFSx_MACRO(s) LFS2##s
+#define LFSx_API(x) lfs2_ ## x
+#define VFS_LFSx_CONTEXT_T vfs_lfs2_context_t
+#define VFS_LFSx_MOUNT vfs_lfs2_mount
+#define VFS_LFSx_STREAM_METHODS vfs_lfs2_stream_methods
+
+#define SUPERBLOCK_MAGIC_OFFSET (8)
+#define SUPERBLOCK_BLOCK_SIZE_OFFSET (24)
+#define SUPERBLOCK_BLOCK_COUNT_OFFSET (28)
+
+static uint8_t lfs_read_buffer[LFS_CACHE_SIZE];
+static uint8_t lfs_prog_buffer[LFS_CACHE_SIZE];
+static uint8_t lfs_lookahead_buffer[LFS_LOOKAHEAD_SIZE];
+
+#endif
+
+static int dev_read(const struct LFSx_API (config) * c, LFSx_API(block_t) block, LFSx_API(off_t) off, void *buffer, LFSx_API(size_t) size) {
+    VFS_LFSx_CONTEXT_T *ctx = c->context;
+    if (0 <= block && block < ctx->config.block_count) {
+        do_read(ctx->bdev_base_addr + block * ctx->config.block_size + off, size, buffer);
+        return LFSx_MACRO(_ERR_OK);
+    }
+    return LFSx_MACRO(_ERR_IO);
+}
+
+static int dev_prog(const struct LFSx_API (config) * c, LFSx_API(block_t) block, LFSx_API(off_t) off, const void *buffer, LFSx_API(size_t) size) {
+    return LFSx_MACRO(_ERR_IO);
+}
+
+static int dev_erase(const struct LFSx_API (config) * c, LFSx_API(block_t) block) {
+    return LFSx_MACRO(_ERR_IO);
+}
+
+static int dev_sync(const struct LFSx_API (config) * c) {
+    return LFSx_MACRO(_ERR_OK);
+}
+
+int VFS_LFSx_MOUNT(VFS_LFSx_CONTEXT_T *ctx, uint32_t base_addr, uint32_t byte_len) {
+    // Read start of superblock.
+    uint8_t buf[48];
+    do_read(base_addr, sizeof(buf), buf);
+
+    // Verify littlefs and detect block size.
+    if (memcmp(&buf[SUPERBLOCK_MAGIC_OFFSET], "littlefs", 8) != 0) {
+        return -1;
+    }
+    uint32_t block_size = get_le32(&buf[SUPERBLOCK_BLOCK_SIZE_OFFSET]);
+    uint32_t block_count = get_le32(&buf[SUPERBLOCK_BLOCK_COUNT_OFFSET]);
+
+    // Verify size of volume.
+    if (block_size * block_count != byte_len) {
+        return -1;
+    }
+
+    ctx->bdev_base_addr = base_addr;
+
+    struct LFSx_API (config) *config = &ctx->config;
+    memset(config, 0, sizeof(*config));
+
+    config->context = ctx;
+
+    config->read = dev_read;
+    config->prog = dev_prog;
+    config->erase = dev_erase;
+    config->sync = dev_sync;
+
+    config->read_size = LFS_READ_SIZE;
+    config->prog_size = LFS_PROG_SIZE;
+    config->block_size = block_size;
+    config->block_count = byte_len / block_size;
+
+    #if MBOOT_VFS_LFS1
+    config->lookahead = LFS_LOOKAHEAD_SIZE;
+    config->read_buffer = lfs_read_buffer;
+    config->prog_buffer = lfs_prog_buffer;
+    config->lookahead_buffer = lfs_lookahead_buffer;
+    #else
+    config->block_cycles = 100;
+    config->cache_size = LFS_CACHE_SIZE;
+    config->lookahead_size = LFS_LOOKAHEAD_SIZE;
+    config->read_buffer = lfs_read_buffer;
+    config->prog_buffer = lfs_prog_buffer;
+    config->lookahead_buffer = lfs_lookahead_buffer;
+    #endif
+
+    int ret = LFSx_API(mount)(&ctx->lfs, &ctx->config);
+    if (ret < 0) {
+        return -1;
+    }
+    return 0;
+}
+
+static int vfs_lfs_stream_open(void *stream_in, const char *fname) {
+    VFS_LFSx_CONTEXT_T *ctx = stream_in;
+    memset(&ctx->file, 0, sizeof(ctx->file));
+    memset(&ctx->filecfg, 0, sizeof(ctx->filecfg));
+    ctx->filecfg.buffer = &ctx->filebuf[0];
+    LFSx_API(file_opencfg)(&ctx->lfs, &ctx->file, fname, LFSx_MACRO(_O_RDONLY), &ctx->filecfg);
+    return 0;
+}
+
+static void vfs_lfs_stream_close(void *stream_in) {
+    VFS_LFSx_CONTEXT_T *ctx = stream_in;
+    LFSx_API(file_close)(&ctx->lfs, &ctx->file);
+}
+
+static int vfs_lfs_stream_read(void *stream_in, uint8_t *buf, size_t len) {
+    VFS_LFSx_CONTEXT_T *ctx = stream_in;
+    LFSx_API(ssize_t) sz = LFSx_API(file_read)(&ctx->lfs, &ctx->file, buf, len);
+    if (sz < 0) {
+        return -1;
+    }
+    return sz;
+}
+
+const stream_methods_t VFS_LFSx_STREAM_METHODS = {
+    vfs_lfs_stream_open,
+    vfs_lfs_stream_close,
+    vfs_lfs_stream_read,
+};
+
+#endif // MBOOT_FSLOAD && (MBOOT_VFS_LFS1 || MBOOT_VFS_LFS2)


### PR DESCRIPTION
With this PR mboot now supports FAT, LFS1 and LFS2 filesystems, to load firmware from.  The filesystem needed by the board must be explicitly enabled by the configuration variables MBOOT_VFS_FAT, MBOOT_VFS_LFS1 and MBOOT_VFS_LFS2.  Boards that previously used FAT implicitly (with MBOOT_FSLOAD enabled) must now add the following config to mpconfigboard.h: `#define MBOOT_VFS_FAT (1)`