### PR TITLE
usb interface descriptors

### DIFF
--- a/ports/stm32/usbd_desc.c
+++ b/ports/stm32/usbd_desc.c
@@ -188,6 +188,24 @@ STATIC uint8_t *USBD_StrDescriptor(USBD_HandleTypeDef *pdev, uint8_t idx, uint16
             }
             break;
 
+        #ifdef USBD_INTERFACE_CDC0_STRING
+        case USBD_IDX_INTERFACE_CDC0_STR:
+            str = USBD_INTERFACE_CDC0_STRING;
+            break;
+        #endif
+
+        #ifdef USBD_INTERFACE_CDC1_STRING
+        case USBD_IDX_INTERFACE_CDC1_STR:
+            str = USBD_INTERFACE_CDC1_STRING;
+            break;
+        #endif
+
+        #ifdef USBD_INTERFACE_CDC2_STRING
+        case USBD_IDX_INTERFACE_CDC2_STR:
+            str = USBD_INTERFACE_CDC2_STRING;
+            break;
+        #endif
+
         default:
             // invalid string index
             return NULL;

--- a/ports/stm32/usbdev/class/src/usbd_cdc_msc_hid.c
+++ b/ports/stm32/usbdev/class/src/usbd_cdc_msc_hid.c
@@ -438,6 +438,20 @@ static size_t make_cdc_desc(uint8_t *dest, int need_iad, uint8_t iface_num) {
         memcpy(dest, cdc_class_desc_data + 8, sizeof(cdc_class_desc_data) - 8);
     }
     dest[2] = iface_num;        // bInterfaceNumber, main class
+
+#ifdef USBD_INTERFACE_CDC0_STRING
+    if (iface_num == 0)
+        dest[8] = USBD_IDX_INTERFACE_CDC0_STR;   // iInterface:
+#endif
+#ifdef USBD_INTERFACE_CDC1_STRING
+    if (iface_num == 2)
+        dest[8] = USBD_IDX_INTERFACE_CDC1_STR;   // iInterface:
+#endif
+#ifdef USBD_INTERFACE_CDC2_STRING
+    if (iface_num == 4)
+        dest[8] = USBD_IDX_INTERFACE_CDC2_STR;   // iInterface:
+#endif
+
     dest[18] = iface_num + 1;   // bDataInterface
     dest[26] = iface_num + 0;   // bMasterInterface
     dest[27] = iface_num + 1;   // bSlaveInterface

--- a/ports/stm32/usbdev/core/inc/usbd_def.h
+++ b/ports/stm32/usbdev/core/inc/usbd_def.h
@@ -66,6 +66,9 @@
 #define  USBD_IDX_SERIAL_STR                            0x03
 #define  USBD_IDX_CONFIG_STR                            0x04
 #define  USBD_IDX_INTERFACE_STR                         0x05
+#define  USBD_IDX_INTERFACE_CDC0_STR                    0x06
+#define  USBD_IDX_INTERFACE_CDC1_STR                    0x07
+#define  USBD_IDX_INTERFACE_CDC2_STR                    0x08
 
 #define  USB_REQ_TYPE_STANDARD                          0x00
 #define  USB_REQ_TYPE_CLASS                             0x20


### PR DESCRIPTION
A patch for the stm32 port: add usb interface descriptors to CDC virtual comm ports.

After applying this patch you can assign usb interface descriptors to virtual comm ports in mpconfigboard.h:
```
#define MICROPY_HW_USB_CDC_NUM      (3)
#define USBD_INTERFACE_CDC0_STRING    "Micropython"
#define USBD_INTERFACE_CDC1_STRING    "GDB Server"
#define USBD_INTERFACE_CDC2_STRING    "UART Port"
```

I use this to have the os take different actions for different serial ports. e.g. on linux, in /etc/udev/rules, add a rule:
```
SUBSYSTEM=="tty", ACTION=="add", ATTRS{interface}=="Micropython", SYMLINK+="ttyPy"
```
to always call the micropython serial port /dev/ttyPy