### PR TITLE
nrf/Makefile: Disable ROM text compression when compiling for debug.

### DIFF
--- a/ports/nrf/Makefile
+++ b/ports/nrf/Makefile
@@ -38,8 +38,9 @@ endif
 # qstr definitions (must come before including py.mk)
 QSTR_DEFS = qstrdefsport.h $(BUILD)/pins_qstr.h
 
-# MicroPython feature configurations
+ifeq ($(DEBUG), 0)
 MICROPY_ROM_TEXT_COMPRESSION ?= 1
+endif
 
 # include py core make definitions
 include ../../py/py.mk


### PR DESCRIPTION
When compiling for debug (-O0) the .text segment cannot fit the
flash region when `MICROPY_ROM_TEXT_COMPRESSION=1`.

This patch enforce `MICROPY_ROM_TEXT_COMPRESSION=0` when compiling
for debug (`DEBUG=1`).

I have still not figured out which component that overflows. It seems to be related to `CFLAGS += -O0` only. However, it is quite easy to reproduce:
`make BOARD=pca10056 DEBUG=1`

The two different results;

Without patch:
```
LINK build-pca10056/firmware.elf
/opt/gcc-arm-none-eabi-8-2018-q4-major/bin/../lib/gcc/arm-none-eabi/8.2.1/../../../../arm-none-eabi/bin/ld: build-pca10056/firmware.elf section `.text' will not fit in region `FLASH_TEXT'
/opt/gcc-arm-none-eabi-8-2018-q4-major/bin/../lib/gcc/arm-none-eabi/8.2.1/../../../../arm-none-eabi/bin/ld: region `FLASH_TEXT' overflowed by 289836 bytes
collect2: error: ld returned 1 exit status
Makefile:450: recipe for target 'build-pca10056/
```

With patch:
```
LINK build-pca10056/firmware.elf
   text	   data	    bss	    dec	    hex	filename
 314036	     44	   2484	 316564	  4d494	build-pca10056/firmware.elf
arm-none-eabi-objcopy -O binary build-pca10056/firmware.elf build-pca10056/firmware.bin
arm-none-eabi-objcopy -O ihex build-pca10056/firmware.elf build-pca10056/firmware.hex
```