### PR TITLE
Added support for __float__ and __complex__ methods (version 2)

### DIFF
--- a/py/obj.c
+++ b/py/obj.c
@@ -359,6 +359,10 @@ mp_float_t mp_obj_get_float(mp_obj_t arg) {
     mp_float_t val;
 
     if (!mp_obj_get_float_maybe(arg, &val)) {
+        arg = mp_unary_op(MP_UNARY_OP_FLOAT, arg);
+        if (mp_obj_get_float_maybe(arg, &val)) {
+            return val;
+        }
         #if MICROPY_ERROR_REPORTING == MICROPY_ERROR_REPORTING_TERSE
         mp_raise_TypeError(MP_ERROR_TEXT("can't convert to float"));
         #else
@@ -399,6 +403,10 @@ bool mp_obj_get_complex_maybe(mp_obj_t arg, mp_float_t *real, mp_float_t *imag) 
 
 void mp_obj_get_complex(mp_obj_t arg, mp_float_t *real, mp_float_t *imag) {
     if (!mp_obj_get_complex_maybe(arg, real, imag)) {
+        arg = mp_unary_op(MP_UNARY_OP_COMPLEX, arg);
+        if (mp_obj_get_complex_maybe(arg, real, imag)) {
+            return;
+        }
         #if MICROPY_ERROR_REPORTING == MICROPY_ERROR_REPORTING_TERSE
         mp_raise_TypeError(MP_ERROR_TEXT("can't convert to complex"));
         #else

--- a/py/obj.c
+++ b/py/obj.c
@@ -396,9 +396,21 @@ bool mp_obj_get_complex_maybe(mp_obj_t arg, mp_float_t *real, mp_float_t *imag) 
 
 void mp_obj_get_complex(mp_obj_t arg, mp_float_t *real, mp_float_t *imag) {
     if (!mp_obj_get_complex_maybe(arg, real, imag)) {
-        arg = mp_unary_op(MP_UNARY_OP_COMPLEX, arg);
-        // This can go unchecked because mp_unary_op() would have raised a TypeError already
-        mp_obj_get_complex_maybe(arg, real, imag);
+        nlr_buf_t nlr;
+        if (nlr_push(&nlr) == 0) {
+            // This can go unchecked because mp_unary_op() would have raised a TypeError already
+            mp_obj_get_complex_maybe(mp_unary_op(MP_UNARY_OP_COMPLEX, arg), real, imag);
+            nlr_pop();
+            return;
+        } else {
+            // If the cast raised anything othher than a TypeError, re-raise it.
+            if (!mp_obj_is_subclass_fast(MP_OBJ_FROM_PTR(((mp_obj_base_t *)nlr.ret_val)->type), MP_OBJ_FROM_PTR(&mp_type_TypeError))) {
+                nlr_jump(nlr.ret_val);
+            }
+        }
+        // Still failed; try to turn it into a float
+        *imag = 0.0;
+        *real = mp_obj_get_float(arg);
     }
 }
 #endif

--- a/py/obj.c
+++ b/py/obj.c
@@ -404,15 +404,16 @@ bool mp_obj_get_complex_maybe(mp_obj_t arg, mp_float_t *real, mp_float_t *imag) 
 void mp_obj_get_complex(mp_obj_t arg, mp_float_t *real, mp_float_t *imag) {
     if (!mp_obj_get_complex_maybe(arg, real, imag)) {
         arg = mp_unary_op(MP_UNARY_OP_COMPLEX, arg);
-        if (mp_obj_get_complex_maybe(arg, real, imag)) {
-            return;
+        if (arg != MP_OBJ_NULL && mp_obj_is_type(arg, &mp_type_complex)) {
+	    mp_obj_get_complex_maybe(arg, real, imag);
+        } else {
+            #if MICROPY_ERROR_REPORTING == MICROPY_ERROR_REPORTING_TERSE
+            mp_raise_TypeError(MP_ERROR_TEXT("can't convert to complex"));
+            #else
+            mp_raise_msg_varg(&mp_type_TypeError,
+                MP_ERROR_TEXT("can't convert %s to complex"), mp_obj_get_type_str(arg));
+            #endif
         }
-        #if MICROPY_ERROR_REPORTING == MICROPY_ERROR_REPORTING_TERSE
-        mp_raise_TypeError(MP_ERROR_TEXT("can't convert to complex"));
-        #else
-        mp_raise_msg_varg(&mp_type_TypeError,
-            MP_ERROR_TEXT("can't convert %s to complex"), mp_obj_get_type_str(arg));
-        #endif
     }
 }
 #endif

--- a/py/obj.c
+++ b/py/obj.c
@@ -360,15 +360,8 @@ mp_float_t mp_obj_get_float(mp_obj_t arg) {
 
     if (!mp_obj_get_float_maybe(arg, &val)) {
         arg = mp_unary_op(MP_UNARY_OP_FLOAT, arg);
-        if (mp_obj_get_float_maybe(arg, &val)) {
-            return val;
-        }
-        #if MICROPY_ERROR_REPORTING == MICROPY_ERROR_REPORTING_TERSE
-        mp_raise_TypeError(MP_ERROR_TEXT("can't convert to float"));
-        #else
-        mp_raise_msg_varg(&mp_type_TypeError,
-            MP_ERROR_TEXT("can't convert %s to float"), mp_obj_get_type_str(arg));
-        #endif
+        // This can be unchecked because mp_unary_op() requires the return of a float
+         mp_obj_get_float_maybe(arg, &val);
     }
 
     return val;
@@ -404,16 +397,8 @@ bool mp_obj_get_complex_maybe(mp_obj_t arg, mp_float_t *real, mp_float_t *imag) 
 void mp_obj_get_complex(mp_obj_t arg, mp_float_t *real, mp_float_t *imag) {
     if (!mp_obj_get_complex_maybe(arg, real, imag)) {
         arg = mp_unary_op(MP_UNARY_OP_COMPLEX, arg);
-        if (arg != MP_OBJ_NULL && mp_obj_is_type(arg, &mp_type_complex)) {
-	    mp_obj_get_complex_maybe(arg, real, imag);
-        } else {
-            #if MICROPY_ERROR_REPORTING == MICROPY_ERROR_REPORTING_TERSE
-            mp_raise_TypeError(MP_ERROR_TEXT("can't convert to complex"));
-            #else
-            mp_raise_msg_varg(&mp_type_TypeError,
-                MP_ERROR_TEXT("can't convert %s to complex"), mp_obj_get_type_str(arg));
-            #endif
-        }
+        // This can go unchecked because mp_unary_op() would have raised a TypeError already
+        mp_obj_get_complex_maybe(arg, real, imag);
     }
 }
 #endif

--- a/py/objcomplex.c
+++ b/py/objcomplex.c
@@ -91,7 +91,7 @@ STATIC mp_obj_t complex_make_new(const mp_obj_type_t *type_in, size_t n_args, si
                 // something else, try to cast it to a complex
                 mp_obj_t cast_obj = mp_unary_op_maybe(MP_UNARY_OP_COMPLEX, args[0]);
                 if (cast_obj != MP_OBJ_NULL) {
-		    return cast_obj;
+                    return cast_obj;
                 }
 
                 return mp_obj_new_complex(mp_obj_get_float(args[0]), 0);

--- a/py/objcomplex.c
+++ b/py/objcomplex.c
@@ -89,11 +89,9 @@ STATIC mp_obj_t complex_make_new(const mp_obj_type_t *type_in, size_t n_args, si
                 return args[0];
             } else {
                 // something else, try to cast it to a complex
-                mp_float_t real, imag;
                 mp_obj_t cast_obj = mp_unary_op_maybe(MP_UNARY_OP_COMPLEX, args[0]);
-                if (cast_obj != MP_OBJ_NULL && mp_obj_is_type(cast_obj, &mp_type_complex)) {
-                    mp_obj_get_complex(cast_obj, &real, &imag);
-                    return mp_obj_new_complex(real, imag);
+                if (cast_obj != MP_OBJ_NULL) {
+		    return cast_obj;
                 }
 
                 return mp_obj_new_complex(mp_obj_get_float(args[0]), 0);

--- a/py/objcomplex.c
+++ b/py/objcomplex.c
@@ -89,6 +89,13 @@ STATIC mp_obj_t complex_make_new(const mp_obj_type_t *type_in, size_t n_args, si
                 return args[0];
             } else {
                 // something else, try to cast it to a complex
+                mp_float_t real, imag;
+                mp_obj_t cast_obj = mp_unary_op_maybe(MP_UNARY_OP_COMPLEX, args[0]);
+                if (cast_obj != MP_OBJ_NULL && mp_obj_is_type(cast_obj, &mp_type_complex)) {
+                    mp_obj_get_complex(cast_obj, &real, &imag);
+                    return mp_obj_new_complex(real, imag);
+                }
+
                 return mp_obj_new_complex(mp_obj_get_float(args[0]), 0);
             }
 

--- a/py/objcomplex.c
+++ b/py/objcomplex.c
@@ -89,12 +89,9 @@ STATIC mp_obj_t complex_make_new(const mp_obj_type_t *type_in, size_t n_args, si
                 return args[0];
             } else {
                 // something else, try to cast it to a complex
-                mp_obj_t cast_obj = mp_unary_op_maybe(MP_UNARY_OP_COMPLEX, args[0]);
-                if (cast_obj != MP_OBJ_NULL) {
-                    return cast_obj;
-                }
-
-                return mp_obj_new_complex(mp_obj_get_float(args[0]), 0);
+                mp_float_t real, imag;
+                mp_obj_get_complex(args[0], &real, &imag);
+                return mp_obj_new_complex(real, imag);
             }
 
         case 2:

--- a/py/objtype.c
+++ b/py/objtype.c
@@ -443,7 +443,7 @@ STATIC mp_obj_t instance_unary_op(mp_unary_op_t op, mp_obj_t self_in) {
                     mp_raise_TypeError(NULL);
                 }
                 break;
-	    #endif
+            #endif
             #if MICROPY_PY_BUILTINS_COMPLEX
             case MP_UNARY_OP_COMPLEX:
                 // Must return complex
@@ -451,8 +451,8 @@ STATIC mp_obj_t instance_unary_op(mp_unary_op_t op, mp_obj_t self_in) {
                     mp_raise_TypeError(NULL);
                 }
                 break;
-	    #endif
-	    default:
+            #endif
+            default:
                 // No need to do anything
                 ;
         }

--- a/py/objtype.c
+++ b/py/objtype.c
@@ -379,6 +379,12 @@ const byte mp_unary_op_method_name[MP_UNARY_OP_NUM_RUNTIME] = {
     [MP_UNARY_OP_INVERT] = MP_QSTR___invert__,
     [MP_UNARY_OP_ABS] = MP_QSTR___abs__,
     #endif
+    #if MICROPY_PY_BUILTINS_FLOAT
+    [MP_UNARY_OP_FLOAT] = MP_QSTR___float__,
+    #endif
+    #if MICROPY_PY_BUILTINS_COMPLEX
+    [MP_UNARY_OP_COMPLEX] = MP_QSTR___complex__,
+    #endif
     #if MICROPY_PY_SYS_GETSIZEOF
     [MP_UNARY_OP_SIZEOF] = MP_QSTR___sizeof__,
     #endif

--- a/py/objtype.c
+++ b/py/objtype.c
@@ -436,7 +436,23 @@ STATIC mp_obj_t instance_unary_op(mp_unary_op_t op, mp_obj_t self_in) {
                     mp_raise_TypeError(NULL);
                 }
                 break;
-            default:
+            #if MICROPY_PY_BUILTINS_FLOAT
+            case MP_UNARY_OP_FLOAT:
+                // Must return float
+                if (!mp_obj_is_type(val, &mp_type_float)) {
+                    mp_raise_TypeError(NULL);
+                }
+                break;
+	    #endif
+            #if MICROPY_PY_BUILTINS_COMPLEX
+            case MP_UNARY_OP_COMPLEX:
+                // Must return complex
+                if (!mp_obj_is_type(val, &mp_type_complex)) {
+                    mp_raise_TypeError(NULL);
+                }
+                break;
+	    #endif
+	    default:
                 // No need to do anything
                 ;
         }

--- a/py/runtime.c
+++ b/py/runtime.c
@@ -263,10 +263,14 @@ mp_obj_t mp_unary_op_maybe(mp_unary_op_t op, mp_obj_t arg) {
                 } else {
                     return MP_OBJ_NEW_SMALL_INT(-val);
                 }
+            #if MICROPY_PY_BUILTINS_FLOAT
             case MP_UNARY_OP_FLOAT:
+            #if MICROPY_PY_BUILTINS_COMPLEX
             case MP_UNARY_OP_COMPLEX:
+            #endif
                 // These are handled in obj.c
                 return MP_OBJ_NULL;
+            #endif
             default:
                 assert(op == MP_UNARY_OP_INVERT);
                 return MP_OBJ_NEW_SMALL_INT(~val);

--- a/py/runtime.c
+++ b/py/runtime.c
@@ -231,7 +231,7 @@ void mp_delete_global(qstr qst) {
     mp_obj_dict_delete(MP_OBJ_FROM_PTR(mp_globals_get()), MP_OBJ_NEW_QSTR(qst));
 }
 
-mp_obj_t mp_unary_op(mp_unary_op_t op, mp_obj_t arg) {
+mp_obj_t mp_unary_op_maybe(mp_unary_op_t op, mp_obj_t arg) {
     DEBUG_OP_printf("unary " UINT_FMT " %q %p\n", op, mp_unary_op_method_name[op], arg);
 
     if (op == MP_UNARY_OP_NOT) {
@@ -277,31 +277,38 @@ mp_obj_t mp_unary_op(mp_unary_op_t op, mp_obj_t arg) {
         return MP_OBJ_NEW_SMALL_INT(h);
     } else {
         const mp_obj_type_t *type = mp_obj_get_type(arg);
+        mp_obj_t result = MP_OBJ_NULL;
         if (type->unary_op != NULL) {
-            mp_obj_t result = type->unary_op(op, arg);
-            if (result != MP_OBJ_NULL) {
-                return result;
-            }
+            result = type->unary_op(op, arg);
         }
-        // With MP_UNARY_OP_INT, mp_unary_op() becomes a fallback for mp_obj_get_int().
-        // In this case provide a more focused error message to not confuse, e.g. chr(1.0)
-        #if MICROPY_ERROR_REPORTING == MICROPY_ERROR_REPORTING_TERSE
-        if (op == MP_UNARY_OP_INT) {
-            mp_raise_TypeError(MP_ERROR_TEXT("can't convert to int"));
-        } else {
-            mp_raise_TypeError(MP_ERROR_TEXT("unsupported type for operator"));
-        }
-        #else
-        if (op == MP_UNARY_OP_INT) {
-            mp_raise_msg_varg(&mp_type_TypeError,
-                MP_ERROR_TEXT("can't convert %s to int"), mp_obj_get_type_str(arg));
-        } else {
-            mp_raise_msg_varg(&mp_type_TypeError,
-                MP_ERROR_TEXT("unsupported type for %q: '%s'"),
-                mp_unary_op_method_name[op], mp_obj_get_type_str(arg));
-        }
-        #endif
+        return result;
     }
+}
+
+mp_obj_t mp_unary_op(mp_unary_op_t op, mp_obj_t arg) {
+    mp_obj_t result = mp_unary_op_maybe(op, arg);
+    if (result != MP_OBJ_NULL) {
+        return result;
+    }
+
+    // With MP_UNARY_OP_INT, mp_unary_op() becomes a fallback for mp_obj_get_int().
+    // In this case provide a more focused error message to not confuse, e.g. chr(1.0)
+    #if MICROPY_ERROR_REPORTING == MICROPY_ERROR_REPORTING_TERSE
+    if (op == MP_UNARY_OP_INT) {
+        mp_raise_TypeError(MP_ERROR_TEXT("can't convert to int"));
+    } else {
+        mp_raise_TypeError(MP_ERROR_TEXT("unsupported type for operator"));
+    }
+    #else
+    if (op == MP_UNARY_OP_INT) {
+        mp_raise_msg_varg(&mp_type_TypeError,
+             MP_ERROR_TEXT("can't convert %s to int"), mp_obj_get_type_str(arg));
+    } else {
+        mp_raise_msg_varg(&mp_type_TypeError,
+             MP_ERROR_TEXT("unsupported type for %q: '%s'"),
+             mp_unary_op_method_name[op], mp_obj_get_type_str(arg));
+    }
+    #endif
 }
 
 mp_obj_t mp_binary_op(mp_binary_op_t op, mp_obj_t lhs, mp_obj_t rhs) {

--- a/py/runtime.c
+++ b/py/runtime.c
@@ -231,7 +231,7 @@ void mp_delete_global(qstr qst) {
     mp_obj_dict_delete(MP_OBJ_FROM_PTR(mp_globals_get()), MP_OBJ_NEW_QSTR(qst));
 }
 
-mp_obj_t mp_unary_op_maybe(mp_unary_op_t op, mp_obj_t arg) {
+mp_obj_t mp_unary_op(mp_unary_op_t op, mp_obj_t arg) {
     DEBUG_OP_printf("unary " UINT_FMT " %q %p\n", op, mp_unary_op_method_name[op], arg);
 
     if (op == MP_UNARY_OP_NOT) {
@@ -285,38 +285,31 @@ mp_obj_t mp_unary_op_maybe(mp_unary_op_t op, mp_obj_t arg) {
         return MP_OBJ_NEW_SMALL_INT(h);
     } else {
         const mp_obj_type_t *type = mp_obj_get_type(arg);
-        mp_obj_t result = MP_OBJ_NULL;
         if (type->unary_op != NULL) {
-            result = type->unary_op(op, arg);
+            mp_obj_t result = type->unary_op(op, arg);
+            if (result != MP_OBJ_NULL) {
+                return result;
+            }
         }
-        return result;
+        // With MP_UNARY_OP_INT, mp_unary_op() becomes a fallback for mp_obj_get_int().
+        // In this case provide a more focused error message to not confuse, e.g. chr(1.0)
+        #if MICROPY_ERROR_REPORTING == MICROPY_ERROR_REPORTING_TERSE
+        if (op == MP_UNARY_OP_INT) {
+            mp_raise_TypeError(MP_ERROR_TEXT("can't convert to int"));
+        } else {
+            mp_raise_TypeError(MP_ERROR_TEXT("unsupported type for operator"));
+        }
+        #else
+        if (op == MP_UNARY_OP_INT) {
+            mp_raise_msg_varg(&mp_type_TypeError,
+                MP_ERROR_TEXT("can't convert %s to int"), mp_obj_get_type_str(arg));
+        } else {
+            mp_raise_msg_varg(&mp_type_TypeError,
+                MP_ERROR_TEXT("unsupported type for %q: '%s'"),
+                mp_unary_op_method_name[op], mp_obj_get_type_str(arg));
+        }
+        #endif
     }
-}
-
-mp_obj_t mp_unary_op(mp_unary_op_t op, mp_obj_t arg) {
-    mp_obj_t result = mp_unary_op_maybe(op, arg);
-    if (result != MP_OBJ_NULL) {
-        return result;
-    }
-
-    // With MP_UNARY_OP_INT, mp_unary_op() becomes a fallback for mp_obj_get_int().
-    // In this case provide a more focused error message to not confuse, e.g. chr(1.0)
-    #if MICROPY_ERROR_REPORTING == MICROPY_ERROR_REPORTING_TERSE
-    if (op == MP_UNARY_OP_INT) {
-        mp_raise_TypeError(MP_ERROR_TEXT("can't convert to int"));
-    } else {
-        mp_raise_TypeError(MP_ERROR_TEXT("unsupported type for operator"));
-    }
-    #else
-    if (op == MP_UNARY_OP_INT) {
-        mp_raise_msg_varg(&mp_type_TypeError,
-            MP_ERROR_TEXT("can't convert %s to int"), mp_obj_get_type_str(arg));
-    } else {
-        mp_raise_msg_varg(&mp_type_TypeError,
-            MP_ERROR_TEXT("unsupported type for %q: '%s'"),
-            mp_unary_op_method_name[op], mp_obj_get_type_str(arg));
-    }
-    #endif
 }
 
 mp_obj_t mp_binary_op(mp_binary_op_t op, mp_obj_t lhs, mp_obj_t rhs) {

--- a/py/runtime.c
+++ b/py/runtime.c
@@ -263,6 +263,10 @@ mp_obj_t mp_unary_op_maybe(mp_unary_op_t op, mp_obj_t arg) {
                 } else {
                     return MP_OBJ_NEW_SMALL_INT(-val);
                 }
+            case MP_UNARY_OP_FLOAT:
+            case MP_UNARY_OP_COMPLEX:
+                // These are handled in obj.c
+                return MP_OBJ_NULL;
             default:
                 assert(op == MP_UNARY_OP_INVERT);
                 return MP_OBJ_NEW_SMALL_INT(~val);
@@ -302,7 +306,7 @@ mp_obj_t mp_unary_op(mp_unary_op_t op, mp_obj_t arg) {
     #else
     if (op == MP_UNARY_OP_INT) {
         mp_raise_msg_varg(&mp_type_TypeError,
-	    MP_ERROR_TEXT("can't convert %s to int"), mp_obj_get_type_str(arg));
+            MP_ERROR_TEXT("can't convert %s to int"), mp_obj_get_type_str(arg));
     } else {
         mp_raise_msg_varg(&mp_type_TypeError,
             MP_ERROR_TEXT("unsupported type for %q: '%s'"),

--- a/py/runtime.h
+++ b/py/runtime.h
@@ -109,7 +109,6 @@ void mp_delete_name(qstr qst);
 void mp_delete_global(qstr qst);
 
 mp_obj_t mp_unary_op(mp_unary_op_t op, mp_obj_t arg);
-mp_obj_t mp_unary_op_maybe(mp_unary_op_t op, mp_obj_t arg);
 mp_obj_t mp_binary_op(mp_binary_op_t op, mp_obj_t lhs, mp_obj_t rhs);
 
 mp_obj_t mp_call_function_0(mp_obj_t fun);

--- a/py/runtime.h
+++ b/py/runtime.h
@@ -109,6 +109,7 @@ void mp_delete_name(qstr qst);
 void mp_delete_global(qstr qst);
 
 mp_obj_t mp_unary_op(mp_unary_op_t op, mp_obj_t arg);
+mp_obj_t mp_unary_op_maybe(mp_unary_op_t op, mp_obj_t arg);
 mp_obj_t mp_binary_op(mp_binary_op_t op, mp_obj_t lhs, mp_obj_t rhs);
 
 mp_obj_t mp_call_function_0(mp_obj_t fun);

--- a/py/runtime0.h
+++ b/py/runtime0.h
@@ -76,12 +76,8 @@ typedef enum {
     MP_UNARY_OP_HASH, // __hash__; must return a small int
     MP_UNARY_OP_ABS, // __abs__
     MP_UNARY_OP_INT, // __int__
-    #if MICROPY_PY_BUILTINS_FLOAT
     MP_UNARY_OP_FLOAT, // __float__
-    #endif
-    #if MICROPY_PY_BUILTINS_COMPLEX
     MP_UNARY_OP_COMPLEX, // __complex__
-    #endif
     MP_UNARY_OP_SIZEOF, // for sys.getsizeof()
 } mp_unary_op_t;
 

--- a/py/runtime0.h
+++ b/py/runtime0.h
@@ -76,6 +76,12 @@ typedef enum {
     MP_UNARY_OP_HASH, // __hash__; must return a small int
     MP_UNARY_OP_ABS, // __abs__
     MP_UNARY_OP_INT, // __int__
+    #if MICROPY_PY_BUILTINS_FLOAT
+    MP_UNARY_OP_FLOAT, // __float__
+    #endif
+    #if MICROPY_PY_BUILTINS_COMPLEX
+    MP_UNARY_OP_COMPLEX, // __complex__
+    #endif
     MP_UNARY_OP_SIZEOF, // for sys.getsizeof()
 } mp_unary_op_t;
 

--- a/tests/float/custom_cast.py
+++ b/tests/float/custom_cast.py
@@ -49,3 +49,27 @@ try:
     print(complex(Test3()))
 except TypeError:
     print("TypeError")
+
+
+# Test a class that raises non-TypeError exception in conversions
+# Also checks that the error in __complex__ does not cause a fallback
+# to using __float__
+
+
+class Test4:
+    def __float__(self):
+        return [1, 2, 3][4]
+
+    def __complex__(self):
+        return 1.0 / 0.0
+
+
+try:
+    print(float(Test4()))
+except IndexError:
+    print("IndexError")
+
+try:
+    print(complex(Test4()))
+except ZeroDivisionError:
+    print("ZeroDivisionError")

--- a/tests/float/custom_cast.py
+++ b/tests/float/custom_cast.py
@@ -1,0 +1,51 @@
+# Test a class that behaves correctly
+
+
+class Test1:
+    def __float__(self):
+        return 123.4
+
+    def __complex__(self):
+        return 123.4j
+
+
+print(float(Test1()))
+print(complex(Test1()))
+
+# Test a class that returns the wrong type
+
+
+class Test2:
+    def __float__(self):
+        return "Not a float"
+
+    def __complex__(self):
+        return "Not very complex"
+
+
+try:
+    print(float(Test2()))
+except TypeError:
+    print("TypeError")
+
+try:
+    print(complex(Test2()))
+except TypeError:
+    print("TypeError")
+
+# Test a class that doesn't implement the conversion methods
+
+
+class Test3:
+    pass
+
+
+try:
+    print(float(Test3()))
+except TypeError:
+    print("TypeError")
+
+try:
+    print(complex(Test3()))
+except TypeError:
+    print("TypeError")

--- a/tests/float/custom_cast_differences.py
+++ b/tests/float/custom_cast_differences.py
@@ -1,0 +1,19 @@
+# In general inheriting from native types is a bit broken on MicroPython.
+# As a result, classes that decend from native types do NOT inherit their
+# implicit casting to float or complex and have to do it for themselves.
+
+
+class T1(int):
+    pass
+
+
+class T2(int):
+    def __float__(self):
+        return float(int(self))
+
+
+for test in [T1("123"), T2("123")]:
+    try:
+        print(float(test))
+    except TypeError:
+        print("TypeError")

--- a/tests/float/custom_cast_differences.py.exp
+++ b/tests/float/custom_cast_differences.py.exp
@@ -1,0 +1,2 @@
+TypeError
+123.0

--- a/tests/float/custom_cast_implicit.py
+++ b/tests/float/custom_cast_implicit.py
@@ -1,5 +1,6 @@
 try:
     from math import *
+    from cmath import polar
 except ImportError:
     print("SKIP")
     raise SystemExit
@@ -70,5 +71,11 @@ for i in instances:
 
     try:
         print(1.0j + complex(i))
+    except TypeError:
+        print("Type Error")
+
+    try:
+        r, theta = polar(i)
+        print("{:.5g}, {:.5g}".format(r, theta))
     except TypeError:
         print("Type Error")

--- a/tests/float/custom_cast_implicit.py
+++ b/tests/float/custom_cast_implicit.py
@@ -1,0 +1,58 @@
+try:
+    from math import *
+except ImportError:
+    print("SKIP")
+    raise SystemExit
+
+
+class T1:
+    pass
+
+
+class T2:
+    def __float__(self):
+        return 1.23
+
+
+class T3:
+    def __float__(self):
+        return 1.23
+
+    def __complex__(self):
+        return 1.23j
+
+
+instances = [T1(), T2(), T3()]
+
+for i in instances:
+    print(i.__class__.__name__)
+
+    try:
+        print("{:.5g}".format(sin(i)))
+    except TypeError:
+        print("Type Error")
+
+    try:
+        print(1.0 + i)
+    except TypeError:
+        print("Type Error")
+
+    try:
+        print(1.0 + float(i))
+    except TypeError:
+        print("Type Error")
+
+    try:
+        print(1.0j + i)
+    except TypeError:
+        print("Type Error")
+
+    try:
+        print(1.0j + float(i))
+    except TypeError:
+        print("Type Error")
+
+    try:
+        print(1.0j + complex(i))
+    except TypeError:
+        print("Type Error")

--- a/tests/float/custom_cast_implicit.py
+++ b/tests/float/custom_cast_implicit.py
@@ -22,7 +22,23 @@ class T3:
         return 1.23j
 
 
-instances = [T1(), T2(), T3()]
+class T4:
+    def __float__(self):
+        return 1
+
+    def __complex__(self):
+        return 1
+
+
+class T5:
+    def __float__(self):
+        return []
+
+    def __complex__(self):
+        return []
+
+
+instances = [T1(), T2(), T3(), T4(), T5()]
 
 for i in instances:
     print(i.__class__.__name__)


### PR DESCRIPTION
This is a replacement to #6148, making use of the recently added `mp_obj_get_complex_maybe()` and with extra test cases for some scenarios that failed previously.

Note that this also adds a new `mp_unary_op_maybe()` function that can return `MP_OBJ_NULL` when the operation is not implemented, as opposed to raising an exception (it simply splits the old `mp_unary_op()` into two parts). This function is used in this PR but might be useful for simplifying code elsewhere too, including a fix for #6175 if desired.
