### PR TITLE
py: Rework mp_convert_member_lookup to properly handle built-ins.

### DIFF
--- a/py/obj.h
+++ b/py/obj.h
@@ -475,8 +475,8 @@ typedef mp_obj_t (*mp_fun_kw_t)(size_t n, const mp_obj_t *, mp_map_t *);
 // operator and not the __ne__ operator.  If it's set then __ne__ may be implemented.
 #define MP_TYPE_FLAG_IS_SUBCLASSED (0x0001)
 #define MP_TYPE_FLAG_HAS_SPECIAL_ACCESSORS (0x0002)
-#define MP_TYPE_FLAG_EQ_NOT_REFLEXIVE (0x0040)
-#define MP_TYPE_FLAG_EQ_CHECKS_OTHER_TYPE (0x0080)
+#define MP_TYPE_FLAG_EQ_NOT_REFLEXIVE (0x0004)
+#define MP_TYPE_FLAG_EQ_CHECKS_OTHER_TYPE (0x0008)
 #define MP_TYPE_FLAG_EQ_HAS_NEQ_TEST (0x0010)
 
 typedef enum {

--- a/py/obj.h
+++ b/py/obj.h
@@ -473,11 +473,15 @@ typedef mp_obj_t (*mp_fun_kw_t)(size_t n, const mp_obj_t *, mp_map_t *);
 // then the type may check for equality against a different type.
 // If MP_TYPE_FLAG_EQ_HAS_NEQ_TEST is clear then the type only implements the __eq__
 // operator and not the __ne__ operator.  If it's set then __ne__ may be implemented.
+// If MP_TYPE_FLAG_BINDS_SELF is set then the type as a method binds self as the first arg.
+// If MP_TYPE_FLAG_BUILTIN_FUN is set then the type is a built-in function type.
 #define MP_TYPE_FLAG_IS_SUBCLASSED (0x0001)
 #define MP_TYPE_FLAG_HAS_SPECIAL_ACCESSORS (0x0002)
 #define MP_TYPE_FLAG_EQ_NOT_REFLEXIVE (0x0004)
 #define MP_TYPE_FLAG_EQ_CHECKS_OTHER_TYPE (0x0008)
 #define MP_TYPE_FLAG_EQ_HAS_NEQ_TEST (0x0010)
+#define MP_TYPE_FLAG_BINDS_SELF (0x0020)
+#define MP_TYPE_FLAG_BUILTIN_FUN (0x0040)
 
 typedef enum {
     PRINT_STR = 0,

--- a/py/objclosure.c
+++ b/py/objclosure.c
@@ -80,6 +80,7 @@ STATIC void closure_print(const mp_print_t *print, mp_obj_t o_in, mp_print_kind_
 
 const mp_obj_type_t closure_type = {
     { &mp_type_type },
+    .flags = MP_TYPE_FLAG_BINDS_SELF,
     .name = MP_QSTR_closure,
     #if MICROPY_ERROR_REPORTING == MICROPY_ERROR_REPORTING_DETAILED
     .print = closure_print,

--- a/py/objfun.c
+++ b/py/objfun.c
@@ -58,6 +58,7 @@ STATIC mp_obj_t fun_builtin_0_call(mp_obj_t self_in, size_t n_args, size_t n_kw,
 
 const mp_obj_type_t mp_type_fun_builtin_0 = {
     { &mp_type_type },
+    .flags = MP_TYPE_FLAG_BINDS_SELF | MP_TYPE_FLAG_BUILTIN_FUN,
     .name = MP_QSTR_function,
     .call = fun_builtin_0_call,
     .unary_op = mp_generic_unary_op,
@@ -72,6 +73,7 @@ STATIC mp_obj_t fun_builtin_1_call(mp_obj_t self_in, size_t n_args, size_t n_kw,
 
 const mp_obj_type_t mp_type_fun_builtin_1 = {
     { &mp_type_type },
+    .flags = MP_TYPE_FLAG_BINDS_SELF | MP_TYPE_FLAG_BUILTIN_FUN,
     .name = MP_QSTR_function,
     .call = fun_builtin_1_call,
     .unary_op = mp_generic_unary_op,
@@ -86,6 +88,7 @@ STATIC mp_obj_t fun_builtin_2_call(mp_obj_t self_in, size_t n_args, size_t n_kw,
 
 const mp_obj_type_t mp_type_fun_builtin_2 = {
     { &mp_type_type },
+    .flags = MP_TYPE_FLAG_BINDS_SELF | MP_TYPE_FLAG_BUILTIN_FUN,
     .name = MP_QSTR_function,
     .call = fun_builtin_2_call,
     .unary_op = mp_generic_unary_op,
@@ -100,6 +103,7 @@ STATIC mp_obj_t fun_builtin_3_call(mp_obj_t self_in, size_t n_args, size_t n_kw,
 
 const mp_obj_type_t mp_type_fun_builtin_3 = {
     { &mp_type_type },
+    .flags = MP_TYPE_FLAG_BINDS_SELF | MP_TYPE_FLAG_BUILTIN_FUN,
     .name = MP_QSTR_function,
     .call = fun_builtin_3_call,
     .unary_op = mp_generic_unary_op,
@@ -130,6 +134,7 @@ STATIC mp_obj_t fun_builtin_var_call(mp_obj_t self_in, size_t n_args, size_t n_k
 
 const mp_obj_type_t mp_type_fun_builtin_var = {
     { &mp_type_type },
+    .flags = MP_TYPE_FLAG_BINDS_SELF | MP_TYPE_FLAG_BUILTIN_FUN,
     .name = MP_QSTR_function,
     .call = fun_builtin_var_call,
     .unary_op = mp_generic_unary_op,
@@ -355,6 +360,7 @@ void mp_obj_fun_bc_attr(mp_obj_t self_in, qstr attr, mp_obj_t *dest) {
 
 const mp_obj_type_t mp_type_fun_bc = {
     { &mp_type_type },
+    .flags = MP_TYPE_FLAG_BINDS_SELF,
     .name = MP_QSTR_function,
     #if MICROPY_CPYTHON_COMPAT
     .print = fun_bc_print,
@@ -406,6 +412,7 @@ STATIC mp_obj_t fun_native_call(mp_obj_t self_in, size_t n_args, size_t n_kw, co
 
 STATIC const mp_obj_type_t mp_type_fun_native = {
     { &mp_type_type },
+    .flags = MP_TYPE_FLAG_BINDS_SELF,
     .name = MP_QSTR_function,
     .call = fun_native_call,
     .unary_op = mp_generic_unary_op,
@@ -513,6 +520,7 @@ STATIC mp_obj_t fun_asm_call(mp_obj_t self_in, size_t n_args, size_t n_kw, const
 
 STATIC const mp_obj_type_t mp_type_fun_asm = {
     { &mp_type_type },
+    .flags = MP_TYPE_FLAG_BINDS_SELF,
     .name = MP_QSTR_function,
     .call = fun_asm_call,
     .unary_op = mp_generic_unary_op,

--- a/py/objgenerator.c
+++ b/py/objgenerator.c
@@ -73,6 +73,7 @@ STATIC mp_obj_t gen_wrap_call(mp_obj_t self_in, size_t n_args, size_t n_kw, cons
 
 const mp_obj_type_t mp_type_gen_wrap = {
     { &mp_type_type },
+    .flags = MP_TYPE_FLAG_BINDS_SELF,
     .name = MP_QSTR_generator,
     .call = gen_wrap_call,
     .unary_op = mp_generic_unary_op,
@@ -126,6 +127,7 @@ STATIC mp_obj_t native_gen_wrap_call(mp_obj_t self_in, size_t n_args, size_t n_k
 
 const mp_obj_type_t mp_type_native_gen_wrap = {
     { &mp_type_type },
+    .flags = MP_TYPE_FLAG_BINDS_SELF,
     .name = MP_QSTR_generator,
     .call = native_gen_wrap_call,
     .unary_op = mp_generic_unary_op,

--- a/tests/basics/class_bind_self.py
+++ b/tests/basics/class_bind_self.py
@@ -40,10 +40,17 @@ print(c.f2(2))
 print(c.f3())
 print(next(c.f4(4)))
 print(c.f5(5))
-#print(c.f6(-6)) not working in uPy
+print(c.f6(-6))
 print(c.f7(7))
 print(c.f8(8))
 print(c.f9(9))
+
+# test calling the functions accessed via the class itself
+print(C.f5(10))
+print(C.f6(-11))
+print(C.f7(12))
+print(C.f8(13))
+print(C.f9(14))
 
 # not working in uPy
 #class C(list):


### PR DESCRIPTION
This is a fix for #1326 and #6198, to make it so that built-in functions that are used as methods/functions of a class work correctly.

There `mp_convert_member_lookup()` function is pretty much completely changed, but actually for the most part it's just reorganised and the indenting changed.  The functional changes are:
- staticmethod and classmethod checks moved to later in the if-logic, because they are less common and so should be checked after the more common cases
- the explicit `mp_obj_is_type(member, &mp_type_type)` check is removed because it's now subsumed by other, more general tests in this function
- `MP_TYPE_FLAG_BINDS_SELF` and `MP_TYPE_FLAG_BUILTIN_FUN` type flags added to make the checks in this function much simpler (now they just test this bit in `type->flags`)
- an extra check is made for `mp_obj_is_instance_type(type)` to fix #1326 and #6198 

Code size change is:
```
   bare-arm:    +0 +0.000% 
minimal x86:   -12 -0.008% [incl -4(data)]
   unix x64:   -96 -0.019% 
unix nanbox:  -136 -0.030% [incl -24(data)]
      stm32:   -60 -0.016% PYBV10
     cc3200:   -48 -0.026% 
    esp8266:   -76 -0.011% GENERIC
      esp32:  -132 -0.010% GENERIC
        nrf:   -60 -0.042% pca10040
       samd:   -60 -0.059% ADAFRUIT_ITSYBITSY_M4_EXPRESS
```