### PR TITLE
STM32H7: FDCAN Fixes

### DIFF
--- a/ports/stm32/fdcan.c
+++ b/ports/stm32/fdcan.c
@@ -200,17 +200,21 @@ void can_clearfilter(pyb_can_obj_t *self, uint32_t f, uint8_t bank) {
 
 int can_receive(FDCAN_HandleTypeDef *can, int fifo, FDCAN_RxHeaderTypeDef *hdr, uint8_t *data, uint32_t timeout_ms) {
     volatile uint32_t *rxf, *rxa;
+    uint32_t fl;
+
     if (fifo == FDCAN_RX_FIFO0) {
         rxf = &can->Instance->RXF0S;
         rxa = &can->Instance->RXF0A;
+        fl = FDCAN_RXF0S_F0FL;
     } else {
         rxf = &can->Instance->RXF1S;
         rxa = &can->Instance->RXF1A;
+        fl = FDCAN_RXF1S_F1FL;
     }
 
     // Wait for a message to become available, with timeout
     uint32_t start = HAL_GetTick();
-    while ((*rxf & 7) == 0) {
+    while ((*rxf & fl) == 0) {
         MICROPY_EVENT_POLL_HOOK
         if (HAL_GetTick() - start >= timeout_ms) {
             return -MP_ETIMEDOUT;

--- a/ports/stm32/fdcan.c
+++ b/ports/stm32/fdcan.c
@@ -215,10 +215,12 @@ int can_receive(FDCAN_HandleTypeDef *can, int fifo, FDCAN_RxHeaderTypeDef *hdr, 
     // Wait for a message to become available, with timeout
     uint32_t start = HAL_GetTick();
     while ((*rxf & fl) == 0) {
-        MICROPY_EVENT_POLL_HOOK
-        if (HAL_GetTick() - start >= timeout_ms) {
-            return -MP_ETIMEDOUT;
+        if (timeout_ms != HAL_MAX_DELAY) {
+            if (HAL_GetTick() - start >= timeout_ms) {
+                return -MP_ETIMEDOUT;
+            }
         }
+        MICROPY_EVENT_POLL_HOOK
     }
 
     // Get pointer to incoming message

--- a/ports/stm32/fdcan.c
+++ b/ports/stm32/fdcan.c
@@ -218,8 +218,14 @@ int can_receive(FDCAN_HandleTypeDef *can, int fifo, FDCAN_RxHeaderTypeDef *hdr, 
     }
 
     // Get pointer to incoming message
-    uint32_t index = (can->Instance->RXF0S & FDCAN_RXF0S_F0GI) >> 8;
-    uint32_t *address = (uint32_t *)(can->msgRam.RxFIFO0SA + (index * can->Init.RxFifo0ElmtSize * 4));
+    uint32_t index, *address;
+    if (fifo == FDCAN_RX_FIFO0) {
+        index = (*rxf & FDCAN_RXF0S_F0GI) >> FDCAN_RXF0S_F0GI_Pos;
+        address = (uint32_t*)(can->msgRam.RxFIFO0SA + (index * can->Init.RxFifo0ElmtSize * 4));
+    } else {
+        index = (*rxf & FDCAN_RXF1S_F1GI) >> FDCAN_RXF1S_F1GI_Pos;
+        address = (uint32_t*)(can->msgRam.RxFIFO1SA + (index * can->Init.RxFifo1ElmtSize * 4));
+    }
 
     // Parse header of message
     hdr->IdType = *address & FDCAN_ELEMENT_MASK_XTD;

--- a/ports/stm32/fdcan.c
+++ b/ports/stm32/fdcan.c
@@ -227,10 +227,10 @@ int can_receive(FDCAN_HandleTypeDef *can, int fifo, FDCAN_RxHeaderTypeDef *hdr, 
     uint32_t index, *address;
     if (fifo == FDCAN_RX_FIFO0) {
         index = (*rxf & FDCAN_RXF0S_F0GI) >> FDCAN_RXF0S_F0GI_Pos;
-        address = (uint32_t*)(can->msgRam.RxFIFO0SA + (index * can->Init.RxFifo0ElmtSize * 4));
+        address = (uint32_t *)(can->msgRam.RxFIFO0SA + (index * can->Init.RxFifo0ElmtSize * 4));
     } else {
         index = (*rxf & FDCAN_RXF1S_F1GI) >> FDCAN_RXF1S_F1GI_Pos;
-        address = (uint32_t*)(can->msgRam.RxFIFO1SA + (index * can->Init.RxFifo1ElmtSize * 4));
+        address = (uint32_t *)(can->msgRam.RxFIFO1SA + (index * can->Init.RxFifo1ElmtSize * 4));
     }
 
     // Parse header of message

--- a/ports/stm32/pyb_can.c
+++ b/ports/stm32/pyb_can.c
@@ -432,6 +432,20 @@ STATIC mp_obj_t pyb_can_send(size_t n_args, const mp_obj_t *pos_args, mp_map_t *
 
     HAL_StatusTypeDef status;
     #if MICROPY_HW_ENABLE_FDCAN
+    uint32_t timeout_ms = args[ARG_timeout].u_int;
+    uint32_t start = HAL_GetTick();
+    while (HAL_FDCAN_GetTxFifoFreeLevel(&self->can) == 0) {
+        if (timeout_ms == 0) {
+            mp_hal_raise(HAL_TIMEOUT);
+        }
+        // Check for the Timeout
+        if (timeout_ms != HAL_MAX_DELAY) {
+            if (HAL_GetTick() - start >= timeout_ms) {
+                mp_hal_raise(HAL_TIMEOUT);
+            }
+        }
+        MICROPY_EVENT_POLL_HOOK
+    }
     status = HAL_FDCAN_AddMessageToTxFifoQ(&self->can, &tx_msg, tx_data);
     #else
     self->can.pTxMsg = &tx_msg;

--- a/ports/stm32/pyb_can.c
+++ b/ports/stm32/pyb_can.c
@@ -436,12 +436,12 @@ STATIC mp_obj_t pyb_can_send(size_t n_args, const mp_obj_t *pos_args, mp_map_t *
     uint32_t start = HAL_GetTick();
     while (HAL_FDCAN_GetTxFifoFreeLevel(&self->can) == 0) {
         if (timeout_ms == 0) {
-            mp_hal_raise(HAL_TIMEOUT);
+            mp_raise_OSError(MP_ETIMEDOUT);
         }
         // Check for the Timeout
         if (timeout_ms != HAL_MAX_DELAY) {
             if (HAL_GetTick() - start >= timeout_ms) {
-                mp_hal_raise(HAL_TIMEOUT);
+                mp_raise_OSError(MP_ETIMEDOUT);
             }
         }
         MICROPY_EVENT_POLL_HOOK


### PR DESCRIPTION
* Fix fdcan can_receive fifo0 was used for both fifo0 and fifo1.
* Check if timeout == HAL_MAX_DELAY in fdcan can_receive.
* Cleanup use FDCAN_RXFxS_FxFL instead of hard-coded value.
* Handle the timeout arg for FDCAN in pyb_can_send as specified in the [docs](http://docs.micropython.org/en/latest/library/pyb.CAN.html?highlight=can%20send#pyb.CAN.send).
