### PR TITLE
stm32/mboot: Remove the use of timeout.

### DIFF
--- a/ports/stm32/mboot/main.c
+++ b/ports/stm32/mboot/main.c
@@ -800,28 +800,6 @@ static void dfu_init(void) {
     dfu_context.addr = 0x08000000;
 }
 
-// The DFU_GETSTATUS response before dfu_process_dnload is run should include the needed timeout adjustments
-static size_t get_timeout_ms(void) {
-    if (dfu_context.wBlockNum == 0) {
-        // download control commands
-        if (dfu_context.wLength >= 1 && dfu_context.buf[0] == DFU_CMD_DNLOAD_ERASE) {
-            if (dfu_context.wLength == 1) {
-                // mass erase command
-                // It takes 10-12 seconds to erase a 2MB stm part. Extrapolate a suitable timeout from this.
-                return APPLICATION_FLASH_LENGTH / 170;
-
-            } else if (dfu_context.wLength == 5) {
-                // erase page command
-                return 500;
-            }
-        }
-    } else if (dfu_context.wBlockNum > 1) {
-        // write data to memory command
-        return 500;
-    }
-    return 0;
-}
-
 static int dfu_process_dnload(void) {
     int ret = -1;
     if (dfu_context.wBlockNum == 0) {
@@ -922,11 +900,10 @@ static int dfu_handle_tx(int cmd, int arg, int len, uint8_t *buf, int max_len) {
             default:
                 dfu_context.state = DFU_STATE_BUSY;
         }
-        size_t timeout_ms = get_timeout_ms();
         buf[0] = dfu_context.status;          // bStatus
-        buf[1] = (timeout_ms >> 16) & 0xFF;   // bwPollTimeout (ms)
-        buf[2] = (timeout_ms >> 8) & 0xFF;    // bwPollTimeout (ms)
-        buf[3] = timeout_ms & 0xFF;           // bwPollTimeout (ms)
+        buf[1] = 0;                           // bwPollTimeout_lsb (ms)
+        buf[2] = 0;                           // bwPollTimeout     (ms)
+        buf[3] = 0;                           // bwPollTimeout_msb (ms)
         buf[4] = dfu_context.state;           // bState
         buf[5] = dfu_context.error;           // iString
         // Clear errors now they've been sent

--- a/ports/stm32/mboot/main.c
+++ b/ports/stm32/mboot/main.c
@@ -38,14 +38,11 @@
 #include "powerctrl.h"
 #include "dfu.h"
 
-// Using polling is about 10% faster than not using it (and using IRQ instead)
-// This DFU code with polling runs in about 70% of the time of the ST bootloader
-// With STM32WB MCUs only non-polling/IRQ mode is supported.
-#if defined(STM32WB)
+// In some test cases polling mode can run slightly faster, but also uses more power.
+// With STM32WB MCUs only non-polling/IRQ mode is supported. 
+// Polling mode will also cause failures with the mass-erase command on chips with larger 
+// flash sizes due to USB timeouts.
 #define USE_USB_POLLING (0)
-#else
-#define USE_USB_POLLING (1)
-#endif
 
 // Using cache probably won't make it faster because we run at a low frequency, and best
 // to keep the MCU config as minimal as possible.

--- a/tools/pydfu.py
+++ b/tools/pydfu.py
@@ -22,8 +22,6 @@ import sys
 import usb.core
 import usb.util
 import zlib
-import time
-import math
 
 # VID/PID
 __VID = 0x0483
@@ -31,8 +29,6 @@ __PID = 0xDF11
 
 # USB request __TIMEOUT
 __TIMEOUT = 4000
-__NEXT_TIMEOUT = 0
-__STATUS_TIMEOUT = 20000
 
 # DFU commands
 __DFU_DETACH = 0
@@ -99,13 +95,6 @@ else:
         return usb.util.get_string(dev, index)
 
 
-def timeout():
-    global __NEXT_TIMEOUT
-    t = max(__TIMEOUT, __NEXT_TIMEOUT)
-    __NEXT_TIMEOUT = 0
-    return int(math.ceil(t))
-
-
 def find_dfu_cfg_descr(descr):
     if len(descr) == 9 and descr[0] == 9 and descr[1] == _DFU_DESCRIPTOR_TYPE:
         nt = collections.namedtuple(
@@ -161,44 +150,23 @@ def init():
 
 def abort_request():
     """Sends an abort request."""
-    __dev.ctrl_transfer(0x21, __DFU_ABORT, 0, __DFU_INTERFACE, None, timeout())
+    __dev.ctrl_transfer(0x21, __DFU_ABORT, 0, __DFU_INTERFACE, None, __TIMEOUT)
 
 
 def clr_status():
     """Clears any error status (perhaps left over from a previous session)."""
-    __dev.ctrl_transfer(0x21, __DFU_CLRSTATUS, 0, __DFU_INTERFACE, None, timeout())
+    __dev.ctrl_transfer(0x21, __DFU_CLRSTATUS, 0, __DFU_INTERFACE, None, __TIMEOUT)
 
 
 def get_status():
     """Get the status of the last operation."""
-    _timeout = time.time() + max(__STATUS_TIMEOUT, timeout())
-    stat = None
-    while time.time() < _timeout:
-        try:
-            stat = __dev.ctrl_transfer(
-                0xA1, __DFU_GETSTATUS, 0, __DFU_INTERFACE, 6, int(_timeout - time.time())
-            )
-            break
-        except usb.core.USBError as ex:
-            # If the firmware is blocked the transfer can timeout much quicker than
-            # the supplied timeout. If so, retry until the overall timeout is used up.
-            if "Operation timed out" not in str(ex):
-                raise
-
-    if stat is None:
-        raise SystemExit("DFU: get_status timed out")
+    stat = __dev.ctrl_transfer(0xA1, __DFU_GETSTATUS, 0, __DFU_INTERFACE, 6, 20000)
 
     # firmware can provide an optional string for any error
     if stat[5]:
         message = get_string(__dev, stat[5])
         if message:
             print(message)
-
-    # firmware can send a longer timeout request while it's performing slow operation eg. erase
-    timeout_ms = stat[1] << 16 | stat[2] << 8 | stat[3]
-    if timeout_ms:
-        global __NEXT_TIMEOUT
-        __NEXT_TIMEOUT = __TIMEOUT + timeout_ms
 
     return stat[4]
 
@@ -212,9 +180,9 @@ def check_status(stage, expected):
 def mass_erase():
     """Performs a MASS erase (i.e. erases the entire device)."""
     # Send DNLOAD with first byte=0x41
-    __dev.ctrl_transfer(0x21, __DFU_DNLOAD, 0, __DFU_INTERFACE, "\x41", timeout())
+    __dev.ctrl_transfer(0x21, __DFU_DNLOAD, 0, __DFU_INTERFACE, "\x41", __TIMEOUT)
 
-    # Execute erase and wait until complete
+    # Execute last command
     check_status("erase", __DFU_STATE_DFU_DOWNLOAD_BUSY)
 
     # Check command state
@@ -228,7 +196,7 @@ def page_erase(addr):
 
     # Send DNLOAD with first byte=0x41 and page address
     buf = struct.pack("<BI", 0x41, addr)
-    __dev.ctrl_transfer(0x21, __DFU_DNLOAD, 0, __DFU_INTERFACE, buf, timeout())
+    __dev.ctrl_transfer(0x21, __DFU_DNLOAD, 0, __DFU_INTERFACE, buf, __TIMEOUT)
 
     # Execute last command
     check_status("erase", __DFU_STATE_DFU_DOWNLOAD_BUSY)
@@ -241,7 +209,7 @@ def set_address(addr):
     """Sets the address for the next operation."""
     # Send DNLOAD with first byte=0x21 and page address
     buf = struct.pack("<BI", 0x21, addr)
-    __dev.ctrl_transfer(0x21, __DFU_DNLOAD, 0, __DFU_INTERFACE, buf, timeout())
+    __dev.ctrl_transfer(0x21, __DFU_DNLOAD, 0, __DFU_INTERFACE, buf, __TIMEOUT)
 
     # Execute last command
     check_status("set address", __DFU_STATE_DFU_DOWNLOAD_BUSY)
@@ -275,7 +243,7 @@ def write_memory(addr, buf, progress=None, progress_addr=0, progress_size=0):
         # Send DNLOAD with fw data
         chunk = min(__cfg_descr.wTransferSize, xfer_total - xfer_bytes)
         __dev.ctrl_transfer(
-            0x21, __DFU_DNLOAD, 2, __DFU_INTERFACE, buf[xfer_bytes : xfer_bytes + chunk], timeout()
+            0x21, __DFU_DNLOAD, 2, __DFU_INTERFACE, buf[xfer_bytes : xfer_bytes + chunk], __TIMEOUT
         )
 
         # Execute last command
@@ -299,7 +267,7 @@ def write_page(buf, xfer_offset):
     set_address(xfer_base + xfer_offset)
 
     # Send DNLOAD with fw data
-    __dev.ctrl_transfer(0x21, __DFU_DNLOAD, 2, __DFU_INTERFACE, buf, timeout())
+    __dev.ctrl_transfer(0x21, __DFU_DNLOAD, 2, __DFU_INTERFACE, buf, __TIMEOUT)
 
     # Execute last command
     check_status("write memory", __DFU_STATE_DFU_DOWNLOAD_BUSY)
@@ -317,7 +285,7 @@ def exit_dfu():
     set_address(0x08000000)
 
     # Send DNLOAD with 0 length to exit DFU
-    __dev.ctrl_transfer(0x21, __DFU_DNLOAD, 0, __DFU_INTERFACE, None, timeout())
+    __dev.ctrl_transfer(0x21, __DFU_DNLOAD, 0, __DFU_INTERFACE, None, __TIMEOUT)
 
     try:
         # Execute last command


### PR DESCRIPTION
This is treated more like a "delay before continuing" in the spec / official tools and does not appear to be really needed.