### PR TITLE
esp32/esp32_rmt: Correct fix for looping

### DIFF
--- a/docs/library/esp32.rst
+++ b/docs/library/esp32.rst
@@ -209,19 +209,21 @@ For more details see Espressif's `ESP-IDF RMT documentation.
 
 .. method:: RMT.wait_done(timeout=0)
 
-    Returns True if `RMT.write_pulses` has completed.
+    Returns ``True`` if the channel is currently transmitting a stream of pulses
+    started with a call to `RMT.write_pulses`.
 
     If *timeout* (defined in ticks of ``source_freq / clock_div``) is specified
-    the method will wait for *timeout* or until `RMT.write_pulses` is complete,
-    returning ``False`` if the channel continues to transmit.
-
-.. Warning::
-    Avoid using ``wait_done()`` if looping is enabled.
+    the method will wait for *timeout* or until transmission is complete,
+    returning ``False`` if the channel continues to transmit. If looping is
+    enabled with `RMT.loop` and a stream has started, then this method will
+    always (wait and) return ``False``.
 
 .. method:: RMT.loop(enable_loop)
 
-    Configure looping on the channel, allowing a stream of pulses to be
-    indefinitely repeated. *enable_loop* is bool, set to True to enable looping.
+    Configure looping on the channel. *enable_loop* is bool, set to ``True`` to
+    enable looping on the *next* call to `RMT.write_pulses`. If called with
+    ``False`` while a looping stream is currently being transmitted then the
+    current set of pulses will be completed before transmission stops.
 
 .. method:: RMT.write_pulses(pulses, start)
 
@@ -229,6 +231,15 @@ For more details see Espressif's `ESP-IDF RMT documentation.
     length of each pulse is defined by a number to be multiplied by the channel
     resolution ``(1 / (source_freq / clock_div))``. *start* defines whether the
     stream starts at 0 or 1.
+
+    If transmission of a stream is currently in progress then this method will
+    block until transmission of that stream has ended before beginning sending
+    *pulses*.
+
+    If looping is enabled with `RMT.loop`, the stream of pulses will be repeated
+    indefinitely. Further calls to `RMT.write_pulses` will end the previous
+    stream - blocking until the last set of pulses has been transmitted -
+    before starting the next stream.
 
 
 Ultra-Low-Power co-processor

--- a/ports/esp32/esp32_rmt.c
+++ b/ports/esp32/esp32_rmt.c
@@ -110,8 +110,8 @@ STATIC mp_obj_t esp32_rmt_make_new(const mp_obj_type_t *type, size_t n_args, siz
 
     config.clk_div = self->clock_div;
 
-    check_esp_err(rmt_config(&config));
     check_esp_err(rmt_driver_install(config.channel, 0, 0));
+    check_esp_err(rmt_config(&config));
 
     return MP_OBJ_FROM_PTR(self);
 }

--- a/ports/esp32/esp32_rmt.c
+++ b/ports/esp32/esp32_rmt.c
@@ -56,6 +56,7 @@ typedef struct _esp32_rmt_obj_t {
     uint32_t carrier_freq;
     mp_uint_t num_items;
     rmt_item32_t *items;
+    bool loop_en;
 } esp32_rmt_obj_t;
 
 STATIC mp_obj_t esp32_rmt_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *all_args) {
@@ -93,6 +94,7 @@ STATIC mp_obj_t esp32_rmt_make_new(const mp_obj_type_t *type, size_t n_args, siz
     self->clock_div = clock_div;
     self->carrier_duty_percent = carrier_duty_percent;
     self->carrier_freq = carrier_freq;
+    self->loop_en = false;
 
     rmt_config_t config;
     config.rmt_mode = RMT_MODE_TX;
@@ -180,9 +182,14 @@ STATIC MP_DEFINE_CONST_FUN_OBJ_KW(esp32_rmt_wait_done_obj, 1, esp32_rmt_wait_don
 
 STATIC mp_obj_t esp32_rmt_loop(mp_obj_t self_in, mp_obj_t loop) {
     esp32_rmt_obj_t *self = MP_OBJ_TO_PTR(self_in);
-    int loop_en = mp_obj_get_int(loop);
-    check_esp_err(rmt_set_tx_intr_en(self->channel_id, !loop_en));
-    check_esp_err(rmt_set_tx_loop_mode(self->channel_id, loop_en));
+    bool loop_en = mp_obj_get_int(loop) ? true : false;
+    if (loop_en != self->loop_en) {
+        self->loop_en = loop_en;
+        if (!loop_en) {
+            check_esp_err(rmt_set_tx_loop_mode(self->channel_id, false));
+            check_esp_err(rmt_set_tx_intr_en(self->channel_id, true));
+        }
+    }
     return mp_const_none;
 }
 STATIC MP_DEFINE_CONST_FUN_OBJ_2(esp32_rmt_loop_obj, esp32_rmt_loop);
@@ -224,7 +231,22 @@ STATIC mp_obj_t esp32_rmt_write_pulses(size_t n_args, const mp_obj_t *pos_args, 
             self->items[item_index].level1 = start++;
         }
     }
+
+    if (self->loop_en) {
+        bool loop_en;
+        check_esp_err(rmt_get_tx_loop_mode(self->channel_id, &loop_en));
+        if (loop_en) {
+            check_esp_err(rmt_set_tx_loop_mode(self->channel_id, false));
+            check_esp_err(rmt_set_tx_intr_en(self->channel_id, true));
+        }
+    }
+
     check_esp_err(rmt_write_items(self->channel_id, self->items, num_items, false /* non-blocking */));
+
+    if (self->loop_en) {
+        check_esp_err(rmt_set_tx_intr_en(self->channel_id, false));
+        check_esp_err(rmt_set_tx_loop_mode(self->channel_id, true));
+    }
 
     return mp_const_none;
 }

--- a/ports/esp32/esp32_rmt.c
+++ b/ports/esp32/esp32_rmt.c
@@ -239,9 +239,9 @@ STATIC mp_obj_t esp32_rmt_write_pulses(size_t n_args, const mp_obj_t *pos_args, 
         if (loop_en) {
             check_esp_err(rmt_set_tx_intr_en(self->channel_id, true));
             check_esp_err(rmt_set_tx_loop_mode(self->channel_id, false));
-            check_esp_err(rmt_wait_tx_done(self->channel_id, portMAX_DELAY));
-            check_esp_err(rmt_set_tx_intr_en(self->channel_id, false));
         }
+        check_esp_err(rmt_wait_tx_done(self->channel_id, portMAX_DELAY));
+        check_esp_err(rmt_set_tx_intr_en(self->channel_id, false));
     }
 
     check_esp_err(rmt_write_items(self->channel_id, self->items, num_items, false /* non-blocking */));

--- a/ports/esp32/esp32_rmt.c
+++ b/ports/esp32/esp32_rmt.c
@@ -237,15 +237,16 @@ STATIC mp_obj_t esp32_rmt_write_pulses(size_t n_args, const mp_obj_t *pos_args, 
         bool loop_en;
         check_esp_err(rmt_get_tx_loop_mode(self->channel_id, &loop_en));
         if (loop_en) {
-            check_esp_err(rmt_set_tx_loop_mode(self->channel_id, false));
             check_esp_err(rmt_set_tx_intr_en(self->channel_id, true));
+            check_esp_err(rmt_set_tx_loop_mode(self->channel_id, false));
+            check_esp_err(rmt_wait_tx_done(self->channel_id, portMAX_DELAY));
+            check_esp_err(rmt_set_tx_intr_en(self->channel_id, false));
         }
     }
 
     check_esp_err(rmt_write_items(self->channel_id, self->items, num_items, false /* non-blocking */));
 
     if (self->loop_en) {
-        check_esp_err(rmt_set_tx_intr_en(self->channel_id, false));
         check_esp_err(rmt_set_tx_loop_mode(self->channel_id, true));
     }
 

--- a/ports/esp32/esp32_rmt.c
+++ b/ports/esp32/esp32_rmt.c
@@ -110,8 +110,8 @@ STATIC mp_obj_t esp32_rmt_make_new(const mp_obj_type_t *type, size_t n_args, siz
 
     config.clk_div = self->clock_div;
 
-    check_esp_err(rmt_driver_install(config.channel, 0, 0));
     check_esp_err(rmt_config(&config));
+    check_esp_err(rmt_driver_install(config.channel, 0, 0));
 
     return MP_OBJ_FROM_PTR(self);
 }

--- a/ports/esp32/esp32_rmt.c
+++ b/ports/esp32/esp32_rmt.c
@@ -182,10 +182,11 @@ STATIC MP_DEFINE_CONST_FUN_OBJ_KW(esp32_rmt_wait_done_obj, 1, esp32_rmt_wait_don
 
 STATIC mp_obj_t esp32_rmt_loop(mp_obj_t self_in, mp_obj_t loop) {
     esp32_rmt_obj_t *self = MP_OBJ_TO_PTR(self_in);
-    bool loop_en = mp_obj_get_int(loop) ? true : false;
-    if (loop_en != self->loop_en) {
-        self->loop_en = loop_en;
-        if (!loop_en) {
+    self->loop_en = mp_obj_get_int(loop);
+    if (!self->loop_en) {
+        bool loop_en;
+        check_esp_err(rmt_get_tx_loop_mode(self->channel_id, &loop_en));
+        if (loop_en) {
             check_esp_err(rmt_set_tx_loop_mode(self->channel_id, false));
             check_esp_err(rmt_set_tx_intr_en(self->channel_id, true));
         }

--- a/ports/esp32/esp32_rmt.c
+++ b/ports/esp32/esp32_rmt.c
@@ -110,8 +110,8 @@ STATIC mp_obj_t esp32_rmt_make_new(const mp_obj_type_t *type, size_t n_args, siz
 
     config.clk_div = self->clock_div;
 
-    check_esp_err(rmt_driver_install(config.channel, 0, 0));
     check_esp_err(rmt_config(&config));
+    check_esp_err(rmt_driver_install(config.channel, 0, 0));
 
     return MP_OBJ_FROM_PTR(self);
 }
@@ -180,7 +180,9 @@ STATIC MP_DEFINE_CONST_FUN_OBJ_KW(esp32_rmt_wait_done_obj, 1, esp32_rmt_wait_don
 
 STATIC mp_obj_t esp32_rmt_loop(mp_obj_t self_in, mp_obj_t loop) {
     esp32_rmt_obj_t *self = MP_OBJ_TO_PTR(self_in);
-    check_esp_err(rmt_set_tx_loop_mode(self->channel_id, mp_obj_get_int(loop)));
+    int loop_en = mp_obj_get_int(loop);
+    check_esp_err(rmt_set_tx_intr_en(self->channel_id, !loop_en));
+    check_esp_err(rmt_set_tx_loop_mode(self->channel_id, loop_en));
     return mp_const_none;
 }
 STATIC MP_DEFINE_CONST_FUN_OBJ_2(esp32_rmt_loop_obj, esp32_rmt_loop);


### PR DESCRIPTION
Return to calling `rmt_config()` before `rmt_driver_install()`; add `loop_en` object flag and explicitly control TX interrupt in `write_pulses()`. Provides correct looping, non-blocking writes and sensible behaviour for `wait_done()`. All as per notes in #6167.