### PR TITLE
extmod/nimble: Fix attr NULL pointer resolution in ble_gatt_attr_read_cb

### DIFF
--- a/extmod/nimble/modbluetooth_nimble.c
+++ b/extmod/nimble/modbluetooth_nimble.c
@@ -846,7 +846,7 @@ STATIC int ble_gatt_attr_read_cb(uint16_t conn_handle, const struct ble_gatt_err
     if (error->status == 0) {
         gattc_on_data_available(MP_BLUETOOTH_IRQ_GATTC_READ_RESULT, conn_handle, attr->handle, attr->om);
     }
-    mp_bluetooth_gattc_on_read_write_status(MP_BLUETOOTH_IRQ_GATTC_READ_DONE, conn_handle, attr->handle, error->status);
+    mp_bluetooth_gattc_on_read_write_status(MP_BLUETOOTH_IRQ_GATTC_READ_DONE, conn_handle, attr ? attr->handle : -1, error->status);
     return 0;
 }
 


### PR DESCRIPTION
In case of error, NimBLE calls the read callback with attr = NULL.

See last arg of the error handler calls to `ble_gattc_read_cb` in NimBLE:
* [`ble_gattc_read_tmo`](https://github.com/apache/mynewt-nimble/blob/6e7c1d5d97ef02fda9919d4e83d407ac64cd26f9/nimble/host/src/ble_gattc.c#L2795):
```
static void
ble_gattc_read_tmo(struct ble_gattc_proc *proc)
{
    BLE_HS_DBG_ASSERT(!ble_hs_locked_by_cur_task());
    ble_gattc_dbg_assert_proc_not_inserted(proc);

    ble_gattc_read_cb(proc, BLE_HS_ETIMEOUT, 0, NULL);
}
```
* [`ble_gattc_read_err`](https://github.com/apache/mynewt-nimble/blob/6e7c1d5d97ef02fda9919d4e83d407ac64cd26f9/nimble/host/src/ble_gattc.c#L2808):
```
static void
ble_gattc_read_err(struct ble_gattc_proc *proc, int status,
                   uint16_t att_handle)
{
    ble_gattc_dbg_assert_proc_not_inserted(proc);
    ble_gattc_read_cb(proc, status, att_handle, NULL);
}
```

BLE read errors lead to crashes like this:
```
GATT procedure initiated: read; att_handle=59
ble_gatt_attr_read_cb: conn_handle=0 status=261 handle=-1
Guru Meditation Error: Core  1 panic'ed (LoadProhibited). Exception was unhandled.
```

Stacktrace:
```
0x401059c4: ble_gatt_attr_read_cb at modbluetooth_nimble.c:?
0x4015e80d: ble_gattc_read_cb at ble_gattc.c:?
0x4015e83b: ble_gattc_read_err at ble_gattc.c:?
0x4015fb4f: ble_gattc_rx_err at ??:?
0x40169ab9: ble_att_clt_rx_error at ??:?
0x4016998d: ble_att_rx at ble_att.c:?
0x40162995: ble_hs_hci_evt_acl_process at ??:?
0x40160f71: ble_hs_process_rx_data_queue at ??:?
0x40160f83: ble_hs_event_rx_data at ble_hs.c:?
0x40168306: nimble_port_run at ??:?
0x400f9b96: ble_host_task at nimble.c:?
0x400955f5: vPortTaskWrapper at port.c:?
```

Disassembled:
```
(gdb) disas 0x401059c4
Dump of assembler code for function ble_gatt_attr_read_cb:
   0x40105988 <+0>:	entry	a1, 32
   0x4010598b <+3>:	extui	a2, a2, 0, 16
   0x4010598e <+6>:	l16ui	a12, a3, 0
   0x40105991 <+9>:	movi.n	a13, -1
   0x40105993 <+11>:	beqz	a4, 0x40105999 <ble_gatt_attr_read_cb+17>
   0x40105996 <+14>:	l16ui	a13, a4, 0
   0x40105999 <+17>:	or	a11, a2, a2
   0x4010599c <+20>:	l32r	a10, 0x400d1f70 <_stext+8024>
   0x4010599f <+23>:	call8	0x401709f0 <printf>
   0x401059a2 <+26>:	l32r	a8, 0x400d1f4c <_stext+7988>
   0x401059a5 <+29>:	memw
   0x401059a8 <+32>:	l32i	a8, a8, 0
   0x401059ab <+35>:	bnei	a8, 2, 0x401059cd <ble_gatt_attr_read_cb+69>
   0x401059ae <+38>:	l16ui	a8, a3, 0
   0x401059b1 <+41>:	bnez.n	a8, 0x401059c0 <ble_gatt_attr_read_cb+56>
   0x401059b3 <+43>:	mov.n	a11, a2
   0x401059b5 <+45>:	movi.n	a10, 15
   0x401059b7 <+47>:	l32i	a13, a4, 4
   0x401059ba <+50>:	l16ui	a12, a4, 0
   0x401059bd <+53>:	call8	0x40105834 <gattc_on_data_available>
   0x401059c0 <+56>:	mov.n	a11, a2
   0x401059c2 <+58>:	movi.n	a10, 16
   0x401059c4 <+60>:	l16ui	a13, a3, 0
   0x401059c7 <+63>:	l16ui	a12, a4, 0
   0x401059ca <+66>:	call8	0x400f3df0 <mp_bluetooth_gattc_on_read_write_status>
   0x401059cd <+69>:	movi.n	a2, 0
   0x401059cf <+71>:	retw.n
```