### PR TITLE
Nrf9160 socket support

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -36,3 +36,6 @@
 [submodule "lib/nxp_driver"]
 	path = lib/nxp_driver
 	url = https://github.com/hathach/nxp_driver.git
+[submodule "lib/nrfxlib"]
+	path = lib/nrfxlib
+	url = https://github.com/nrfconnect/sdk-nrfxlib.git

--- a/ports/nrf/Makefile
+++ b/ports/nrf/Makefile
@@ -46,7 +46,7 @@ endif
 # include py core make definitions
 include ../../py/py.mk
 
-GIT_SUBMODULES = lib/nrfx lib/tinyusb
+GIT_SUBMODULES = lib/nrfx lib/tinyusb lib/nrfxlib
 
 MICROPY_VFS_FAT ?= 0
 MPY_CROSS = ../../mpy-cross/mpy-cross

--- a/ports/nrf/Makefile
+++ b/ports/nrf/Makefile
@@ -162,6 +162,13 @@ endif
 
 ifeq ($(MCU_VARIANT), nrf91)
 
+LIBBSD_FILE_NAME = $(TOP)/lib/nrfxlib/bsdlib/lib/cortex-m33/hard-float/libbsd_nrf9160_xxaa.a
+
+LIBS += -L $(dir $(LIBGCC_FILE_NAME)) -lc
+LIBS += -L $(dir $(LIBBSD_FILE_NAME)) -lbsd_nrf9160_xxaa
+
+INC += -I$(TOP)/lib/nrfxlib/bsdlib/include
+
 SRC_LIB += $(addprefix lib/,\
         libm/math.c \
         libm/fmodf.c \
@@ -182,6 +189,17 @@ SRC_LIB += $(addprefix lib/,\
         libm/atanf.c \
         libm/atan2f.c \
         )
+
+SRC_C += \
+        drivers/lte/bsd_os.c
+
+DRIVERS_SRC_C += $(addprefix modules/,\
+        socket/modnetwork.c \
+        socket/modusocket.c \
+        socket/modnwlte.c \
+        )
+
+INC += -I./modules/socket
 
 SRC_NRFX += $(addprefix lib/nrfx/drivers/src/,\
         nrfx_uarte.c \

--- a/ports/nrf/boards/actinius_icarus/mpconfigboard.h
+++ b/ports/nrf/boards/actinius_icarus/mpconfigboard.h
@@ -57,6 +57,10 @@
 #define MICROPY_HW_ENABLE_DAC       (0)
 #define MICROPY_HW_ENABLE_CAN       (0)
 
+#define MICROPY_PY_USOCKET          (1)
+#define MICROPY_PY_NETWORK          (1)
+#define MICROPY_PY_LTE_SOCKET       (1)
+
 #define MICROPY_HW_LED_TRICOLOR     (1)
 #define MICROPY_HW_LED_PULLUP       (1)
 

--- a/ports/nrf/boards/pca10090/mpconfigboard.h
+++ b/ports/nrf/boards/pca10090/mpconfigboard.h
@@ -55,6 +55,10 @@
 #define MICROPY_HW_ENABLE_DAC       (0)
 #define MICROPY_HW_ENABLE_CAN       (0)
 
+#define MICROPY_PY_USOCKET          (1)
+#define MICROPY_PY_NETWORK          (1)
+#define MICROPY_PY_LTE_SOCKET       (1)
+
 #define MICROPY_HW_LED_COUNT        (4)
 #define MICROPY_HW_LED_PULLUP       (0)
 

--- a/ports/nrf/drivers/lte/bsd_os.c
+++ b/ports/nrf/drivers/lte/bsd_os.c
@@ -1,0 +1,187 @@
+#include <bsd_os.h>
+#include <nrf_errno.h>
+#include <bsd_platform.h>
+#include <bsd_limits.h>
+
+#include <nrf.h>
+#include "nrf_gpio.h"
+#include "errno.h"
+#include "py/mphal.h"
+
+#define BSD_OS_TRACE_ENABLED 0
+
+#if BSD_OS_TRACE_ENABLED
+
+#include <nrfx_uarte.h>
+
+#define BSD_OS_TRACE_IRQ          EGU2_IRQn
+#define BSD_OS_TRACE_IRQ_PRIORITY 6
+#define BSD_OS_TRACE_IRQ_HANDLER  EGU2_IRQHandler
+
+#define BSD_OS_TRACE_UART_IRQ_PRIORITY 3
+#define BSD_OS_TRACE_UART_FLOW_CONTROL 0
+#define BSD_OS_TRACE_UART_INSTANCE     3
+#define BSD_OS_TRACE_UART_IRQ_PRIORITY 3
+
+#define BSD_OS_TRACE_PIN_RX  0
+#define BSD_OS_TRACE_PIN_TX  1
+#define BSD_OS_TRACE_PIN_RTS 14
+#define BSD_OS_TRACE_PIN_CTS 15
+
+static nrfx_uarte_t m_uarte_instance = NRFX_UARTE_INSTANCE(BSD_OS_TRACE_UART_INSTANCE);
+
+#endif // BSD_OS_TRACE_ENABLED
+
+typedef struct {
+    uint32_t context;
+    mp_uint_t prev_time;
+} bsd_os_timer_t;
+
+static bsd_os_timer_t timers[8];
+
+void read_task_create(void) {
+    // The read task is achieved using SW interrupt.
+    NVIC_SetPriority(BSD_APPLICATION_IRQ, BSD_APPLICATION_IRQ_PRIORITY);
+    NVIC_ClearPendingIRQ(BSD_APPLICATION_IRQ);
+    NVIC_EnableIRQ(BSD_APPLICATION_IRQ);
+}
+
+#if BSD_OS_TRACE_ENABLED
+void trace_uart_init(void) {
+    const nrfx_uarte_config_t config = {
+        .pseltxd = BSD_OS_TRACE_PIN_TX,
+        .pselrxd = BSD_OS_TRACE_PIN_RX,
+        .pselcts = BSD_OS_TRACE_PIN_CTS,
+        .pselrts = BSD_OS_TRACE_PIN_RTS,
+        .hwfc = BSD_OS_TRACE_UART_FLOW_CONTROL,
+        .parity = NRF_UARTE_PARITY_EXCLUDED,
+        .baudrate = NRF_UARTE_BAUDRATE_1000000,
+        .interrupt_priority = BSD_OS_TRACE_UART_IRQ_PRIORITY,
+        .p_context = NULL,
+    };
+
+    nrfx_uarte_init(&m_uarte_instance, &config, NULL);
+}
+
+void trace_task_create(void) {
+    NVIC_SetPriority(BSD_OS_TRACE_IRQ, BSD_OS_TRACE_IRQ_PRIORITY);
+    NVIC_ClearPendingIRQ(BSD_OS_TRACE_IRQ);
+    NVIC_EnableIRQ(BSD_OS_TRACE_IRQ);
+}
+#endif
+void bsd_os_init(void) {
+    read_task_create();
+    #if BSD_OS_TRACE_ENABLED
+    trace_uart_init();
+    trace_task_create();
+    #endif
+}
+
+int32_t locate_timer(uint32_t context) {
+    for (int i = 0; i < 8; i++)
+    {
+        if (timers[i].context == context) {
+            return i;
+        }
+    }
+    return -1;
+}
+
+int32_t locate_free(void) {
+    for (int i = 0; i < 8; i++)
+    {
+        if (timers[i].context == 0) {
+            return i;
+        }
+    }
+    return -1;
+}
+
+int32_t bsd_os_timedwait(uint32_t context, int32_t *timeout) {
+    if (*timeout == BSD_OS_FOREVER) {
+        return 0;
+    }
+
+    if (*timeout == 0) {
+        return NRF_ETIMEDOUT;
+    }
+
+    mp_uint_t tick = mp_hal_ticks_ms();
+    // Locate timer or free spot.
+    int32_t timer = locate_timer(context);
+    if (timer == -1) {
+        timer = locate_free();
+
+        if (timer == -1) {
+            return NRF_ENOMEM;
+        }
+
+        timers[timer].context = context;
+        timers[timer].prev_time = tick;
+        // First time, only allocate.
+        return 0;
+    }
+    mp_uint_t diff = tick - timers[timer].prev_time;
+
+    if (diff > *timeout) {
+
+        timers[timer].context = 0;
+        timers[timer].prev_time = 0;
+        return NRF_ETIMEDOUT;
+    }
+    return 0;
+}
+
+int nrf_errno;
+
+void bsd_os_errno_set(int errno_val) {
+    nrf_errno = errno_val;
+}
+
+void bsd_os_application_irq_set(void) {
+    NVIC_SetPendingIRQ(BSD_APPLICATION_IRQ);
+}
+
+
+void bsd_os_application_irq_clear(void) {
+    NVIC_ClearPendingIRQ(BSD_APPLICATION_IRQ);
+}
+
+void BSD_APPLICATION_IRQ_HANDLER(void) {
+    bsd_os_application_irq_handler();
+}
+
+void bsd_os_trace_irq_set(void) {
+    #if BSD_OS_TRACE_ENABLED
+    NVIC_SetPendingIRQ(BSD_OS_TRACE_IRQ);
+    #else
+    bsd_os_trace_irq_handler();
+    #endif
+}
+
+void bsd_os_trace_irq_clear(void) {
+    #if BSD_OS_TRACE_ENABLED
+    NVIC_ClearPendingIRQ(BSD_OS_TRACE_IRQ);
+    #endif
+}
+
+#if BSD_OS_TRACE_ENABLED
+void BSD_OS_TRACE_IRQ_HANDLER(void) {
+    bsd_os_trace_irq_handler();
+}
+#endif
+
+int32_t bsd_os_trace_put(const uint8_t *const p_buffer, uint32_t buf_len) {
+    #if BSD_OS_TRACE_ENABLED
+    uint32_t remaining_bytes = buf_len;
+
+    while (remaining_bytes) {
+        uint8_t transfered_len = MIN(remaining_bytes, UINT8_MAX);
+        uint32_t index = buf_len - remaining_bytes;
+
+        nrfx_uarte_tx(&m_uarte_instance, &p_buffer[index], transfered_len);
+        remaining_bytes -= transfered_len;
+    }
+    #endif
+    return 0;
+}

--- a/ports/nrf/examples/nrf9160_gps.py
+++ b/ports/nrf/examples/nrf9160_gps.py
@@ -1,0 +1,46 @@
+# GNSS sample for pca10090
+
+import network
+import socket
+
+n = network.NRF91()
+
+at = socket.socket(socket.AF_LTE, socket.SOCK_DGRAM, socket.PROTO_AT)
+at.send("AT+CFUN=4")  # Flight mode.
+at.recv(20)
+
+# Enable LTE + GNSS, persistently stored.
+# Mask of "0, 0, 1, 0" also possible if
+# only GNSS is of interest.
+at.send("AT%XSYSTEMMODE=1,0,1,0")
+at.recv(20)
+
+# Antenna tuning for pca10090 GNSS.
+at.send("AT%XMAGPIO=1,0,0,1,1,1574,1577")
+at.recv(20)
+
+# Implicit CFUN=1. GNSS sockets can respond, and LTE starts to connect.
+# Returns when LTE link has been established. Alternativly, set a timeout
+# on connect; n.connect(seconds).
+n.connect()
+
+gps = socket.socket(socket.AF_LOCAL, socket.SOCK_DGRAM, socket.PROTO_GNSS)
+gps.setsockopt(socket.SOL_GNSS, socket.SO_GNSS_FIX_RETRY, bytearray([0, 0]))
+gps.setsockopt(socket.SOL_GNSS, socket.SO_GNSS_FIX_INTERVAL, bytearray([1, 0]))
+
+nmea_mask = (
+    socket.GNSS_NMEA_CONFIG_GGA_FLAG
+    | socket.GNSS_NMEA_CONFIG_GLL_FLAG
+    | socket.GNSS_NMEA_CONFIG_GSA_FLAG
+    | socket.GNSS_NMEA_CONFIG_GSV_FLAG
+    | socket.GNSS_NMEA_CONFIG_RMC_FLAG
+)
+
+gps.setsockopt(socket.SOL_GNSS, socket.SO_GNSS_NMEA_MASK, bytearray([nmea_mask, 0]))
+gps.setsockopt(socket.SOL_GNSS, socket.SO_GNSS_START, bytearray([0, 0, 0, 0]))
+count = 0
+while 1:
+    count += 1
+    bytes = gps.recv(580)
+    if bytes[0] == 2:
+        print("NMEA:%s" % str(bytes[8:], "utf-8"))

--- a/ports/nrf/examples/nrf9160_http.py
+++ b/ports/nrf/examples/nrf9160_http.py
@@ -1,0 +1,13 @@
+# HTTP GET sample.
+
+import network, socket
+
+n = network.NRF91()
+n.connect()
+
+addr = socket.getaddrinfo("micropython.org", 80)
+s = socket.socket(socket.AF_INET, socket.SOCK_STREAM, socket.IPPROTO_TCP)
+s.connect(addr[0][-1])
+s.send("GET / HTTP/1.1\r\nHost: micropython.org\r\n\r\n")
+res = s.recv(1000)
+print(res)

--- a/ports/nrf/main.c
+++ b/ports/nrf/main.c
@@ -76,6 +76,10 @@
 #include "usb_cdc.h"
 #endif
 
+#if MICROPY_PY_NETWORK
+#include "modnetwork.h"
+#endif
+
 void do_str(const char *src, mp_parse_input_kind_t input_kind) {
     mp_lexer_t *lex = mp_lexer_new_from_str_len(MP_QSTR__lt_stdin_gt_, src, strlen(src), 0);
     if (lex == NULL) {
@@ -232,6 +236,10 @@ soft_reset:
     #endif
 
     led_state(1, 0);
+
+    #if MICROPY_PY_NETWORK
+    mod_network_init();
+    #endif
 
     #if MICROPY_VFS || MICROPY_MBFS || MICROPY_MODULE_FROZEN
     // run boot.py and main.py if they exist.

--- a/ports/nrf/modules/socket/modnetwork.c
+++ b/ports/nrf/modules/socket/modnetwork.c
@@ -1,0 +1,90 @@
+/*
+ * This file is part of the Micro Python project, http://micropython.org/
+ *
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2014 Damien P. George
+ * Copyright (c) 2019 Glenn Ruben Bakke
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#include <stdio.h>
+#include <stdint.h>
+#include <string.h>
+
+#include "py/nlr.h"
+#include "py/objlist.h"
+#include "py/runtime.h"
+#include "modnetwork.h"
+
+#if MICROPY_PY_NETWORK
+
+/// \module network - network configuration
+///
+/// This module provides network drivers and routing configuration.
+
+void mod_network_init(void) {
+    mp_obj_list_init(&MP_STATE_PORT(mod_network_nic_list), 0);
+}
+
+void mod_network_register_nic(mp_obj_t nic) {
+    for (mp_uint_t i = 0; i < MP_STATE_PORT(mod_network_nic_list).len; i++) {
+        if (MP_STATE_PORT(mod_network_nic_list).items[i] == nic) {
+            // nic already registered
+            return;
+        }
+    }
+    // nic not registered so add to list
+    mp_obj_list_append(&MP_STATE_PORT(mod_network_nic_list), nic);
+}
+
+mp_obj_t mod_network_find_nic(const uint8_t *ip) {
+    // find a NIC that is suited to given IP address
+    for (mp_uint_t i = 0; i < MP_STATE_PORT(mod_network_nic_list).len; i++) {
+        mp_obj_t nic = MP_STATE_PORT(mod_network_nic_list).items[i];
+        return nic;
+    }
+
+    mp_raise_msg(&mp_type_OSError, MP_ERROR_TEXT("no available NIC"));
+}
+
+STATIC mp_obj_t network_route(void) {
+    return &MP_STATE_PORT(mod_network_nic_list);
+}
+STATIC MP_DEFINE_CONST_FUN_OBJ_0(network_route_obj, network_route);
+
+STATIC const mp_map_elem_t mp_module_network_globals_table[] = {
+    { MP_OBJ_NEW_QSTR(MP_QSTR___name__), MP_OBJ_NEW_QSTR(MP_QSTR_network) },
+
+    #if MICROPY_PY_LTE_SOCKET
+    { MP_OBJ_NEW_QSTR(MP_QSTR_NRF91), (mp_obj_t)&mod_network_nic_type_nrf91 },
+    #endif
+
+    { MP_OBJ_NEW_QSTR(MP_QSTR_route), (mp_obj_t)&network_route_obj },
+};
+
+STATIC MP_DEFINE_CONST_DICT(mp_module_network_globals, mp_module_network_globals_table);
+
+const mp_obj_module_t mp_module_network = {
+    .base = { &mp_type_module },
+    .globals = (mp_obj_dict_t *)&mp_module_network_globals,
+};
+
+#endif  // MICROPY_PY_NETWORK

--- a/ports/nrf/modules/socket/modnetwork.h
+++ b/ports/nrf/modules/socket/modnetwork.h
@@ -1,0 +1,82 @@
+/*
+ * This file is part of the Micro Python project, http://micropython.org/
+ *
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2013, 2014 Damien P. George
+ * Copyright (c) 2019 Glenn Ruben Bakke
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#define MOD_NETWORK_IPADDR_BUF_SIZE (sizeof(nrf_in6_addr))
+
+#define MOD_NETWORK_AF_INET (2)
+#define MOD_NETWORK_AF_INET6 (10)
+
+#define MOD_NETWORK_SOCK_STREAM (1)
+#define MOD_NETWORK_SOCK_DGRAM (2)
+#define MOD_NETWORK_SOCK_RAW (3)
+
+struct _mod_network_socket_obj_t;
+
+typedef struct _mod_network_nic_type_t {
+    mp_obj_type_t base;
+
+    // API for non-socket operations
+    int (*gethostbyname)(mp_obj_t nic, const char *name, mp_uint_t len, const char *interface, mp_uint_t interface_len, uint8_t *ip_out, uint8_t *out_family, uint8_t *out_proto);
+
+    // API for socket operations; return -1 on error
+    int (*socket)(struct _mod_network_socket_obj_t *socket, int *_errno);
+    void (*close)(struct _mod_network_socket_obj_t *socket);
+    int (*bind)(struct _mod_network_socket_obj_t *socket, byte *ip, mp_uint_t port, int *_errno);
+    int (*listen)(struct _mod_network_socket_obj_t *socket, mp_int_t backlog, int *_errno);
+    int (*accept)(struct _mod_network_socket_obj_t *socket, struct _mod_network_socket_obj_t *socket2, byte *ip, mp_uint_t *port, int *_errno);
+    int (*connect)(struct _mod_network_socket_obj_t *socket, byte *ip, mp_uint_t port, int *_errno);
+    mp_uint_t (*send)(struct _mod_network_socket_obj_t *socket, const byte *buf, mp_uint_t len, int *_errno);
+    mp_uint_t (*recv)(struct _mod_network_socket_obj_t *socket, byte *buf, mp_uint_t len, int *_errno);
+    mp_uint_t (*sendto)(struct _mod_network_socket_obj_t *socket, const byte *buf, mp_uint_t len, byte *ip, mp_uint_t port, int *_errno);
+    mp_uint_t (*recvfrom)(struct _mod_network_socket_obj_t *socket, byte *buf, mp_uint_t len, byte *ip, mp_uint_t *port, int *_errno);
+    int (*getsockopt)(struct _mod_network_socket_obj_t *socket, mp_uint_t level, mp_uint_t opt, void *optval, mp_uint_t *optlen, int *_errno);
+    int (*setsockopt)(struct _mod_network_socket_obj_t *socket, mp_uint_t level, mp_uint_t opt, const void *optval, mp_uint_t optlen, int *_errno);
+    int (*settimeout)(struct _mod_network_socket_obj_t *socket, mp_uint_t timeout_ms, int *_errno);
+    int (*ioctl)(struct _mod_network_socket_obj_t *socket, mp_uint_t request, mp_uint_t arg, int *_errno);
+} mod_network_nic_type_t;
+
+typedef struct _mod_network_socket_obj_t {
+    mp_obj_base_t base;
+    mp_obj_t nic;
+    mod_network_nic_type_t *nic_type;
+    union {
+        struct {
+            uint16_t domain;
+            uint16_t type;
+            uint16_t proto;
+            int fileno;
+        } u_param;
+        mp_uint_t u_state;
+    };
+    struct udp_pcb *p_socket;
+} mod_network_socket_obj_t;
+
+extern const mod_network_nic_type_t mod_network_nic_type_nrf91;
+
+void mod_network_init(void);
+void mod_network_register_nic(mp_obj_t nic);
+mp_obj_t mod_network_find_nic(const uint8_t *ip);

--- a/ports/nrf/modules/socket/modnwlte.c
+++ b/ports/nrf/modules/socket/modnwlte.c
@@ -1,0 +1,888 @@
+/*
+ * This file is part of the Micro Python project, http://micropython.org/
+ *
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2019 Glenn Ruben Bakke
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <stdint.h>
+#include <string.h>
+#include "py/mphal.h"
+
+#if MICROPY_PY_NETWORK && MICROPY_PY_LTE_SOCKET
+
+#include "py/nlr.h"
+#include "py/objlist.h"
+#include "py/runtime.h"
+#include "py/mperrno.h"
+#include "py/stream.h"
+
+#include "nrf_socket.h"
+#include "nrf_errno.h"
+#include "bsd_platform.h"
+
+#include "modnetwork.h"
+#include "pin.h"
+#include "genhdr/pins.h"
+#include "bsd.h"
+#include "bsd_os.h"
+
+extern int nrf_errno;
+
+void bsd_recoverable_error_handler(uint32_t error) {
+    // printf("bsd_recoverable_error_handler: %lu\n", error);
+}
+
+uint32_t inet_addr(uint8_t a, uint8_t b, uint8_t c, uint8_t d) {
+    uint32_t value = 0;
+    value |= (uint32_t)((((uint8_t)(d)) << 24) & 0xFF000000);
+    value |= (uint32_t)((((uint8_t)(c)) << 16) & 0x00FF0000);
+    value |= (uint32_t)((((uint8_t)(b)) << 8) & 0x0000FF00);
+    value |= (uint32_t)((((uint8_t)(a)) << 0) & 0x000000FF);
+
+    return value;
+}
+
+/// \moduleref network
+
+typedef struct _lte_nrf91_obj_t {
+    mp_obj_base_t base;
+} lte_nrf91_obj_t;
+
+STATIC lte_nrf91_obj_t lte_nrf91_obj;
+
+STATIC int lte_nrf91_gethostbyname(mp_obj_t nic, const char *name, mp_uint_t len, const char *interface, mp_uint_t interface_len, uint8_t *out_ip, uint8_t *out_family, uint8_t *out_proto) {
+    struct nrf_addrinfo *p_info;
+    struct nrf_addrinfo hints;
+    struct nrf_addrinfo apn_hints;
+
+    memset(&hints, 0, sizeof(struct nrf_addrinfo));
+    hints.ai_flags = 0;
+    hints.ai_family = NRF_AF_INET;
+
+    if (out_family != NULL) {
+        if (*out_family == MOD_NETWORK_AF_INET) {
+            hints.ai_family = NRF_AF_INET;
+        } else if (*out_family == MOD_NETWORK_AF_INET6) {
+            hints.ai_family = NRF_AF_INET6;
+        }
+    }
+
+    hints.ai_socktype = NRF_SOCK_STREAM;
+    hints.ai_protocol = 0;
+
+    if ((interface != NULL) && (interface_len > 0)) {
+        apn_hints.ai_family = NRF_AF_LTE;
+        apn_hints.ai_socktype = NRF_SOCK_MGMT;
+        apn_hints.ai_protocol = NRF_PROTO_PDN;
+        apn_hints.ai_canonname = (char *)interface;
+        hints.ai_next = &apn_hints;
+    }
+
+    int32_t retval = nrf_getaddrinfo(name, NULL, &hints, &p_info);
+
+    if (retval == 0) {
+        if (p_info->ai_addr->sa_family == NRF_AF_INET) {
+            *out_family = MOD_NETWORK_AF_INET;
+            struct nrf_sockaddr_in *p_addr = (struct nrf_sockaddr_in *)p_info->ai_addr;
+            memcpy(out_ip, &p_addr->sin_addr.s_addr, sizeof(struct nrf_in_addr));
+        } else if (p_info->ai_addr->sa_family == NRF_AF_INET6) {
+            *out_family = MOD_NETWORK_AF_INET6;
+            struct nrf_sockaddr_in6 *p_addr = (struct nrf_sockaddr_in6 *)p_info->ai_addr;
+            memcpy(out_ip, p_addr->sin6_addr.s6_addr, sizeof(struct nrf_in6_addr));
+        }
+
+        nrf_freeaddrinfo(p_info);
+        return 0;
+    }
+
+    return -1;
+}
+
+STATIC int lte_nrf91_socket_socket(mod_network_socket_obj_t *socket, int *_errno) {
+    socket->u_param.fileno = nrf_socket(socket->u_param.domain, socket->u_param.type, socket->u_param.proto);
+
+    if (socket->u_param.fileno < 0) {
+        *_errno = MP_EINVAL;
+        return -1;
+    }
+
+    return 0;
+}
+
+STATIC void lte_nrf91_socket_close(mod_network_socket_obj_t *socket) {
+    (void)nrf_close(socket->u_param.fileno);
+
+    // Clear it anyway.
+    socket->u_param.fileno = -1;
+}
+
+STATIC int lte_nrf91_socket_bind(mod_network_socket_obj_t *socket, byte *ip, mp_uint_t port, int *_errno) {
+    int res = -1;
+    if (socket->u_param.domain == MOD_NETWORK_AF_INET) {
+        struct nrf_sockaddr_in addr4;
+        addr4.sin_len = sizeof(struct nrf_sockaddr_in);
+        addr4.sin_family = NRF_AF_INET;
+        addr4.sin_port = NRF_HTONS(port);
+        addr4.sin_addr.s_addr = (uint32_t)inet_addr(ip[0], ip[1], ip[2], ip[3]);
+        res = nrf_bind(socket->u_param.fileno, (struct nrf_sockaddr *)&addr4, sizeof(struct nrf_sockaddr_in));
+    } else if (socket->u_param.domain == MOD_NETWORK_AF_INET6) {
+        struct nrf_sockaddr_in6 addr6;
+        addr6.sin6_len = sizeof(struct nrf_sockaddr_in6);
+        addr6.sin6_family = NRF_AF_INET6;
+        addr6.sin6_port = NRF_HTONS(port);
+        memcpy((void *)addr6.sin6_addr.s6_addr, ip, sizeof(struct nrf_in6_addr));
+        res = nrf_bind(socket->u_param.fileno, (struct nrf_sockaddr *)&addr6, sizeof(struct nrf_sockaddr_in6));
+    }
+
+    if (res != 0) {
+        *_errno = nrf_errno;
+        return -1;
+    }
+
+    return res;
+}
+
+STATIC int lte_nrf91_socket_listen(mod_network_socket_obj_t *socket, mp_int_t backlog, int *_errno) {
+    int res = -1;
+    res = nrf_listen(socket->u_param.fileno, backlog);
+    if (res != 0) {
+        *_errno = nrf_errno;
+        return -1;
+    }
+
+    return res;
+}
+
+STATIC int lte_nrf91_socket_accept(mod_network_socket_obj_t *socket, mod_network_socket_obj_t *socket2, byte *ip, mp_uint_t *port, int *_errno) {
+    int res = -1;
+    struct nrf_sockaddr_in addr4;
+    struct nrf_sockaddr_in6 addr6;
+    if (socket->u_param.domain == MOD_NETWORK_AF_INET) {
+        nrf_socklen_t addr_len = sizeof(struct nrf_sockaddr_in);
+        res = nrf_accept(socket->u_param.fileno, (struct nrf_sockaddr *)&addr4, &addr_len);
+        if (res < 0) {
+            *_errno = nrf_errno;
+            return -1;
+        }
+    } else if (socket->u_param.domain == MOD_NETWORK_AF_INET6) {
+        nrf_socklen_t addr_len = sizeof(struct nrf_sockaddr_in6);
+        res = nrf_accept(socket->u_param.fileno, (struct nrf_sockaddr *)&addr6, &addr_len);
+
+        if (res < 0) {
+            *_errno = nrf_errno;
+            return -1;
+        }
+    }
+
+    socket2->u_param.fileno = res;
+
+    if (socket->u_param.domain == MOD_NETWORK_AF_INET) {
+        *port = NRF_NTOHS(addr4.sin_port);
+        memcpy(ip, &addr4.sin_addr.s_addr, sizeof(struct nrf_in_addr));
+    } else if (socket->u_param.domain == MOD_NETWORK_AF_INET6) {
+        *port = NRF_NTOHS(addr6.sin6_port);
+        memcpy(ip, (void *)addr6.sin6_addr.s6_addr, sizeof(struct nrf_in6_addr));
+    }
+
+    return res;
+}
+
+STATIC int lte_nrf91_socket_connect(mod_network_socket_obj_t *socket, byte *ip, mp_uint_t port, int *_errno) {
+    int res = -1;
+    if (socket->u_param.domain == MOD_NETWORK_AF_INET) {
+        struct nrf_sockaddr_in addr4;
+        addr4.sin_len = sizeof(struct nrf_sockaddr_in);
+        addr4.sin_family = NRF_AF_INET;
+        addr4.sin_port = NRF_HTONS(port);
+        addr4.sin_addr.s_addr = (uint32_t)inet_addr(ip[0], ip[1], ip[2], ip[3]);
+        res = nrf_connect(socket->u_param.fileno, (struct nrf_sockaddr *)&addr4, sizeof(struct nrf_sockaddr_in));
+    } else if (socket->u_param.domain == MOD_NETWORK_AF_INET6) {
+        struct nrf_sockaddr_in6 addr6;
+        addr6.sin6_len = sizeof(struct nrf_sockaddr_in6);
+        addr6.sin6_family = NRF_AF_INET6;
+        addr6.sin6_port = NRF_HTONS(port);
+        memcpy((void *)addr6.sin6_addr.s6_addr, ip, sizeof(struct nrf_in6_addr));
+        res = nrf_connect(socket->u_param.fileno, (struct nrf_sockaddr *)&addr6, sizeof(struct nrf_sockaddr_in6));
+    } else {
+        // If AF_LTE, SOCK_MGMT, PROTO_PDN. Or, similar, pass it raw.
+        res = nrf_connect(socket->u_param.fileno, ip, port);
+    }
+
+    if (res == -1) {
+        *_errno = nrf_errno;
+        return -1;
+    }
+
+    return res;
+}
+
+STATIC mp_uint_t lte_nrf91_socket_send(mod_network_socket_obj_t *socket, const byte *buf, mp_uint_t len, int *_errno) {
+    mp_int_t res = nrf_send(socket->u_param.fileno, buf, len, 0);
+
+    if (res < 0) {
+        *_errno = nrf_errno;
+        return -1;
+    }
+
+    return res;
+}
+
+STATIC mp_uint_t lte_nrf91_socket_recv(mod_network_socket_obj_t *socket, byte *buf, mp_uint_t len, int *_errno) {
+    mp_int_t res = nrf_recv(socket->u_param.fileno, buf, len, 0);
+
+    if (res < 0) {
+        *_errno = nrf_errno;
+        return -1;
+    }
+
+    return res;
+}
+
+STATIC mp_uint_t lte_nrf91_socket_sendto(mod_network_socket_obj_t *socket, const byte *buf, mp_uint_t len, byte *ip, mp_uint_t port, int *_errno) {
+    struct nrf_sockaddr *p_servaddr;
+    nrf_socklen_t addrlen;
+    struct nrf_sockaddr_in addr4;
+    struct nrf_sockaddr_in6 addr6;
+
+    // Make sure something is assigned.
+    p_servaddr = (struct nrf_sockaddr *)&addr4;
+    addrlen = sizeof(struct nrf_sockaddr_in);
+
+    if (socket->u_param.domain == MOD_NETWORK_AF_INET) {
+        addr4.sin_len = sizeof(struct nrf_sockaddr_in);
+        addr4.sin_family = NRF_AF_INET;
+        addr4.sin_port = NRF_HTONS(port);
+        addr4.sin_addr.s_addr = (uint32_t)inet_addr(ip[0], ip[1], ip[2], ip[3]);
+        p_servaddr = (struct nrf_sockaddr *)&addr4;
+        addrlen = sizeof(struct nrf_sockaddr_in);
+    } else if (socket->u_param.domain == MOD_NETWORK_AF_INET6) {
+        addr6.sin6_len = sizeof(struct nrf_sockaddr_in6);
+        addr6.sin6_family = NRF_AF_INET6;
+        addr6.sin6_port = NRF_HTONS(port);
+        memcpy((void *)addr6.sin6_addr.s6_addr, ip, sizeof(struct nrf_in6_addr));
+        p_servaddr = (struct nrf_sockaddr *)&addr6;
+        addrlen = sizeof(struct nrf_sockaddr_in6);
+    }
+
+    mp_int_t res = nrf_sendto(socket->u_param.fileno,
+        buf,
+        len,
+        0,
+        p_servaddr,
+        addrlen);
+
+    if (res < 0) {
+        *_errno = nrf_errno;
+        return -1;
+    }
+
+    return res;
+}
+
+STATIC mp_uint_t lte_nrf91_socket_recvfrom(mod_network_socket_obj_t *socket, byte *buf, mp_uint_t len, byte *ip, mp_uint_t *port, int *_errno) {
+    struct nrf_sockaddr *p_servaddr;
+    nrf_socklen_t addrlen;
+    struct nrf_sockaddr_in addr4;
+    struct nrf_sockaddr_in6 addr6;
+
+    // Make sure something is assigned.
+    p_servaddr = (struct nrf_sockaddr *)&addr4;
+
+    if (socket->u_param.domain == MOD_NETWORK_AF_INET) {
+        p_servaddr = (struct nrf_sockaddr *)&addr4;
+        addrlen = sizeof(struct nrf_sockaddr_in);
+    } else if (socket->u_param.domain == MOD_NETWORK_AF_INET6) {
+        p_servaddr = (struct nrf_sockaddr *)&addr6;
+        addrlen = sizeof(struct nrf_sockaddr_in6);
+    }
+
+    mp_int_t res = nrf_recvfrom(socket->u_param.fileno,
+        buf,
+        len,
+        NRF_MSG_WAITALL,
+        p_servaddr,
+        &addrlen);
+    if (res < 0) {
+        *_errno = nrf_errno;
+        return -1;
+    }
+
+    if (socket->u_param.domain == MOD_NETWORK_AF_INET) {
+        *port = NRF_NTOHS(addr4.sin_port);
+        memcpy(ip, &addr4.sin_addr.s_addr, sizeof(struct nrf_in_addr));
+    } else if (socket->u_param.domain == MOD_NETWORK_AF_INET6) {
+        *port = NRF_NTOHS(addr6.sin6_port);
+        memcpy(ip, (void *)addr6.sin6_addr.s6_addr, sizeof(struct nrf_in6_addr));
+    }
+
+    return res;
+}
+
+STATIC int lte_nrf91_socket_getsockopt(mod_network_socket_obj_t *socket, mp_uint_t level, mp_uint_t opt, void *optval, mp_uint_t *optlen, int *_errno) {
+    nrf_socklen_t length = *optlen;
+    mp_int_t res = nrf_getsockopt(socket->u_param.fileno, level, opt, optval, &length);
+    *optlen = length;
+
+    if (res < 0) {
+        *_errno = nrf_errno;
+        return -1;
+    }
+
+    return res;
+}
+
+STATIC int lte_nrf91_socket_setsockopt(mod_network_socket_obj_t *socket, mp_uint_t level, mp_uint_t opt, const void *optval, mp_uint_t optlen, int *_errno) {
+    mp_int_t res = nrf_setsockopt(socket->u_param.fileno, level, opt, optval, optlen);
+    if (res < 0) {
+        *_errno = nrf_errno;
+        return -1;
+    }
+
+    return res;
+}
+
+STATIC int lte_nrf91_socket_settimeout(mod_network_socket_obj_t *socket, mp_uint_t timeout_ms, int *_errno) {
+    struct nrf_timeval timeout = {
+        .tv_sec = timeout_ms / 1000,
+        .tv_usec = (timeout_ms % 1000) * 1000
+    };
+    mp_int_t res = nrf_setsockopt(socket->u_param.fileno, NRF_SOL_SOCKET, NRF_SO_RCVTIMEO, &timeout, sizeof(struct nrf_timeval));
+    if (res < 0) {
+        *_errno = nrf_errno;
+        return -1;
+    }
+
+    mp_int_t flags = nrf_fcntl(socket->u_param.fileno, NRF_F_GETFL, 0);
+    if (timeout_ms > 0) {
+        flags &= ~NRF_O_NONBLOCK;
+    } else {
+        flags |= NRF_O_NONBLOCK;
+    }
+
+    nrf_fcntl(socket->u_param.fileno, NRF_F_SETFL, flags);
+
+    return res;
+}
+
+STATIC int lte_nrf91_socket_ioctl(mod_network_socket_obj_t *socket, mp_uint_t request, mp_uint_t arg, int *_errno) {
+    switch (request) {
+        case MP_STREAM_GET_FILENO:
+            return socket->u_param.fileno;
+        default:
+            *_errno = MP_EINVAL;
+            return -1;
+    }
+}
+
+char *at_ltrim(char *str, char delimiter) {
+    char *result = str;
+    result = strchr(result, delimiter);
+    if (result != NULL) {
+        return ++result;
+    }
+    return str;
+}
+
+uint8_t at_param_count_get(char *original_str) {
+    char *result = original_str;
+    char target = ',';
+    uint8_t count = 0;
+    result = strchr(result, target);
+    while (result != NULL) {
+        count++;
+        result = strchr(result + 1, target);
+    }
+
+    if (count > 0) {
+        count += 1; // include last param after last comma.
+    }
+
+    return count;
+}
+
+char *at_strtok(char *str, uint16_t *len, char delimiter) {
+    char *result = str;
+    result = strchr(result, delimiter);
+    if (result != NULL) {
+        *len = (uint32_t)result - (uint32_t)str;
+        return str;
+    }
+    return NULL;
+}
+
+char *at_token_get(uint8_t index, char *str, uint16_t *len) {
+    uint8_t count = at_param_count_get(str);
+
+    if (count < 1) {
+        return NULL;
+    }
+
+    uint8_t max_index = count - 1;
+
+    uint16_t length = 0;
+    char *token = str;
+    for (uint8_t i = 0; i <= max_index; i++) {
+        if ((i == 0) && (i == max_index)) {
+            // First token and last.
+            token = at_ltrim(token, ':');
+            token = at_ltrim(token, ' ');
+            token = at_strtok(token, &length, '\r');
+        } else if (i == 0) {
+            // First token.
+            token = at_ltrim(token, ':');
+            token = at_ltrim(token, ' ');
+            token = at_strtok(token, &length, ',');
+        } else if (i == max_index) {
+            // Last token.
+            token = at_ltrim(token + length, ',');
+            token = at_strtok(token, &length, '\r');
+        } else {
+            token = at_ltrim(token + length, ',');
+            token = at_strtok(token, &length, ',');
+        }
+
+        if (i == index) {
+            *len = length;
+            return token;
+        }
+    }
+
+    return NULL;
+}
+
+/******************************************************************************/
+// Micro Python bindings
+
+/// \classmethod \constructor
+/// Create and return a nrf91 LTE object.
+STATIC mp_obj_t lte_nrf91_make_new(const mp_obj_type_t *type, mp_uint_t n_args, mp_uint_t n_kw, const mp_obj_t *args) {
+    // check arguments
+    // mp_arg_check_num(n_args, n_kw, 0, 0, false);
+
+    // init the nrf91 LTE object
+    lte_nrf91_obj.base.type = (mp_obj_type_t *)&mod_network_nic_type_nrf91;
+
+    // blocking call to turn on LTE modem.
+    bsd_init_params_t init_params = {
+        .trace_on = true,
+        .bsd_memory_address = BSD_RESERVED_MEMORY_ADDRESS,
+        .bsd_memory_size = BSD_RESERVED_MEMORY_SIZE
+    };
+
+    static bool initialized = false;
+    if (!initialized) {
+        bsd_init(&init_params);
+    } else {
+        bsd_shutdown();
+        bsd_init(&init_params);
+    }
+    // regiser NIC with network module
+    mod_network_register_nic(&lte_nrf91_obj);
+
+    // return nrf91 LTE object
+    return &lte_nrf91_obj;
+}
+
+STATIC mp_obj_t lte_nrf91_mode(size_t n_args, const mp_obj_t *args) {
+    mod_network_nic_type_t *self = args[0];
+    (void)self;
+    if (n_args == 1) {
+        // return active mode.
+    } else {
+        // set requested mode.
+    }
+
+    return mp_const_none;
+}
+STATIC MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(lte_nrf91_mode_obj, 1, 2, lte_nrf91_mode);
+
+static char m_result_buffer[512];
+
+STATIC bool send_at_command(int handle, uint8_t *cmd, uint16_t cmd_len) {
+    memset(m_result_buffer, 0, MP_ARRAY_SIZE(m_result_buffer));
+    int written = 0;
+    written = nrf_send(handle, cmd, cmd_len, 0);
+    if (written != cmd_len) {
+        return false;
+    }
+
+    int read = 0;
+    while (true) {
+        read = nrf_recv(handle, m_result_buffer, MP_ARRAY_SIZE(m_result_buffer), 0);
+        if (read >= 2) {
+            if (strstr(m_result_buffer, "OK\r\n\0") != NULL) {
+                break;
+            }
+        }
+    }
+    return true;
+}
+
+int send_at_command_with_result(int handle, uint8_t *cmd, uint16_t cmd_len, char *res_buffer, uint16_t res_buffer_len) {
+    int written = 0;
+    written = nrf_send(handle, cmd, cmd_len, 0);
+    if (written != cmd_len) {
+        return false;
+    }
+
+    int read = 0;
+    while (true) {
+        read = nrf_recv(handle, res_buffer, res_buffer_len, 0);
+        if (read >= 2) {
+            if (strstr((char *)res_buffer, "OK\r\n\0") != NULL) {
+                break;
+            }
+            return -1;
+        }
+    }
+    return read;
+}
+
+STATIC mp_obj_t lte_nrf91_connect(size_t n_args, const mp_obj_t *args) {
+    bool use_timeout = false;
+    mp_int_t timeout = -1;
+    mp_uint_t tick = 0;
+
+    if (n_args == 2) {
+        #if MICROPY_PY_BUILTINS_FLOAT
+        timeout = 1000 * mp_obj_get_float(args[1]);
+        #else
+        timeout = 1000 * mp_obj_get_int(args[1]);
+        #endif
+
+        if (timeout >= 0) {
+            use_timeout = true;
+            tick = mp_hal_ticks_ms();
+        }
+    }
+
+    int handle = nrf_socket(NRF_AF_LTE, NRF_SOCK_DGRAM, NRF_PROTO_AT);
+    if (handle < 0) {
+        return mp_const_false;
+    }
+
+    bool success;
+
+    struct nrf_timeval sock_timeout = {
+        .tv_sec = (timeout) / 1000,
+        .tv_usec = (timeout * 1000) % 1000000
+    };
+
+    int sock_opt_result = nrf_setsockopt(handle, NRF_SOL_SOCKET, NRF_SO_RCVTIMEO, &sock_timeout, sizeof(struct nrf_timeval));
+    if (sock_opt_result < 0) {
+        goto cleanup;
+    }
+
+    static const char at_cfun4[] = "AT+CFUN=4";
+    success = send_at_command(handle, (uint8_t *)at_cfun4, MP_ARRAY_SIZE(at_cfun4));
+    if (!success) {
+        goto cleanup;
+    }
+
+    static const char at_cereg[] = "AT+CEREG=2";
+    success = send_at_command(handle, (uint8_t *)at_cereg, MP_ARRAY_SIZE(at_cereg));
+    if (!success) {
+        goto cleanup;
+    }
+
+    static const char at_cfun1[] = "AT+CFUN=1";
+    success = send_at_command(handle, (uint8_t *)at_cfun1, MP_ARRAY_SIZE(at_cfun1));
+    if (!success) {
+        goto cleanup;
+    }
+
+    memset(m_result_buffer, 0, MP_ARRAY_SIZE(m_result_buffer));
+
+    bool link_established = false;
+
+    while ((!link_established) && ((!use_timeout) || (timeout > 0))) {
+        if (use_timeout) {
+            mp_uint_t new_tick = mp_hal_ticks_ms();
+            mp_uint_t diff_tick = new_tick - tick;
+            tick = new_tick;
+            timeout -= diff_tick;
+        }
+
+        if (use_timeout && (timeout <= 0)) {
+            // In case of timeout, exit before entering timed receive with the same timeout.
+            break;
+        }
+        int read = nrf_recv(handle, m_result_buffer, MP_ARRAY_SIZE(m_result_buffer), NRF_MSG_DONTWAIT);
+
+        // Only continue looping if it is not a serious error.
+        if ((read < 0) && (nrf_errno != NRF_EAGAIN)) {
+            goto cleanup;
+        }
+
+        if (read >= 9) {
+            if ((strncmp(m_result_buffer, "+CEREG: 1", 9) == 0) || /* Registered, home network. */
+                (strncmp(m_result_buffer, "+CEREG: 5", 9) == 0)) { /* Registered, roaming. */
+
+                link_established = true;
+                break;
+            }
+        }
+    }
+
+cleanup:
+
+    (void)nrf_close(handle);
+
+    if ((use_timeout && timeout <= 0) && (!link_established)) {
+        mp_raise_OSError(MP_ETIMEDOUT);
+    } else if (!success) {
+        return mp_const_false;
+    } else {
+        return mp_const_true;
+    }
+}
+STATIC MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(lte_nrf91_connect_obj, 1, 2, lte_nrf91_connect);
+
+STATIC mp_obj_t lte_nrf91_disconnect(mp_obj_t self_in) {
+    int handle = nrf_socket(NRF_AF_LTE, NRF_SOCK_DGRAM, NRF_PROTO_AT);
+    if (handle < 0) {
+        return mp_const_false;
+    }
+
+    bool success;
+
+    static const char at_cfun4[] = "AT+CFUN=4";
+    success = send_at_command(handle, (uint8_t *)at_cfun4, MP_ARRAY_SIZE(at_cfun4));
+    if (!success) {
+        (void)nrf_close(handle);
+        return mp_const_false;
+    }
+
+    static const char at_cfun1[] = "AT+CFUN=0";
+    success = send_at_command(handle, (uint8_t *)at_cfun1, MP_ARRAY_SIZE(at_cfun1));
+    if (!success) {
+        (void)nrf_close(handle);
+        return mp_const_false;
+    }
+
+    (void)nrf_close(handle);
+
+    return mp_const_true;
+}
+STATIC MP_DEFINE_CONST_FUN_OBJ_1(lte_nrf91_disconnect_obj, lte_nrf91_disconnect);
+
+STATIC mp_obj_t lte_nrf91_ifconfig(mp_uint_t n_args, const mp_obj_t *args) {
+    int handle = nrf_socket(NRF_AF_LTE, NRF_SOCK_DGRAM, NRF_PROTO_AT);
+    if (handle < 0) {
+        return mp_const_false;
+    }
+
+    mp_obj_t ret_list = mp_obj_new_list(0, NULL);
+
+    if ((n_args == 2) && mp_obj_is_int(args[1]) && mp_obj_get_int(args[1]) == 1) {
+        static const char at_cgcontrdp[] = "AT+CGCONTRDP";
+        static char at_cgcontrdp_numbered[MP_ARRAY_SIZE(at_cgcontrdp) + 3];
+
+        for (uint8_t cid = 0; cid < 12; cid++)
+        {
+            memset(m_result_buffer, 0, MP_ARRAY_SIZE(m_result_buffer));
+            snprintf(at_cgcontrdp_numbered,
+                MP_ARRAY_SIZE(at_cgcontrdp_numbered),
+                "%s=%u",
+                at_cgcontrdp, cid);
+            int len = send_at_command_with_result(handle, (uint8_t *)at_cgcontrdp_numbered, MP_ARRAY_SIZE(at_cgcontrdp_numbered), m_result_buffer, MP_ARRAY_SIZE(m_result_buffer));
+
+            char *buffer = m_result_buffer;
+            int remaining_len = len;
+
+            while ((remaining_len > 10) && (buffer != NULL)) {
+                uint16_t cid_length = 0;
+                uint16_t apn_length = 0;
+                uint16_t dns_prim_addr_length = 0;
+                uint16_t dns_sec_addr_length = 0;
+                uint16_t ipv4_mtu_size_length = 0;
+
+                char *p_cid = at_token_get(0, buffer, &cid_length);
+                char *p_apn = at_token_get(2, buffer, &apn_length);
+                char *p_dns_prim_addr = at_token_get(5, buffer, &dns_prim_addr_length);
+                char *p_dns_sec_addr = at_token_get(6, buffer, &dns_sec_addr_length);
+                char *p_ipv4_mtu_size = at_token_get(11, buffer, &ipv4_mtu_size_length);
+
+                mp_obj_tuple_t *tuple = mp_obj_new_tuple(5, NULL);
+                if ((p_cid != NULL) && (cid_length > 0)) {
+                    tuple->items[0] = mp_obj_new_str(p_cid, cid_length);
+                }
+                if ((p_apn != NULL) && (apn_length > 1)) {
+                    tuple->items[1] = mp_obj_new_str(p_apn + 1, apn_length - 2); // Hack to get rid of quotes
+                } else {
+                    tuple->items[1] = mp_const_none;
+                }
+                if ((p_dns_prim_addr != NULL) && (dns_prim_addr_length > 7)) {
+                    tuple->items[2] = mp_obj_new_str(p_dns_prim_addr + 1, dns_prim_addr_length - 2); // Hack to get rid of quotes
+                } else {
+                    tuple->items[2] = mp_const_none;
+                }
+                if ((p_dns_sec_addr != NULL) && (dns_sec_addr_length > 7)) {
+                    tuple->items[3] = mp_obj_new_str(p_dns_sec_addr + 1, dns_sec_addr_length - 2); // Hack to get rid of quotes
+                } else {
+                    tuple->items[3] = mp_const_none;
+                }
+                if ((p_ipv4_mtu_size != NULL) && (ipv4_mtu_size_length > 0)) {
+                    tuple->items[4] = mp_obj_new_int(atoi(p_ipv4_mtu_size));
+                } else {
+                    tuple->items[4] = mp_const_none;
+                }
+                mp_obj_list_append(ret_list, tuple);
+
+                buffer = strstr(buffer, "\r\n");
+                if (buffer != NULL) {
+                    buffer += 2; // Increment \r\n.
+                    uint32_t offset = ((uint32_t)buffer - (uint32_t)&m_result_buffer[0]);
+                    remaining_len = len - offset;
+                }
+            }
+        }
+    } else {
+        static const char at_cgpaddr[] = "AT+CGPADDR";
+        static char at_cgpaddr_numbered[MP_ARRAY_SIZE(at_cgpaddr) + 3];
+
+        for (uint8_t cid = 0; cid < 12; cid++)
+        {
+            memset(m_result_buffer, 0, MP_ARRAY_SIZE(m_result_buffer));
+            snprintf(at_cgpaddr_numbered,
+                MP_ARRAY_SIZE(at_cgpaddr_numbered),
+                "%s=%u",
+                at_cgpaddr, cid);
+
+            int len = send_at_command_with_result(handle, (uint8_t *)at_cgpaddr_numbered, MP_ARRAY_SIZE(at_cgpaddr_numbered), m_result_buffer, MP_ARRAY_SIZE(m_result_buffer));
+            if (len > 6) {
+                uint16_t cid_length = 0;
+                uint16_t ipv4_length = 0;
+                uint16_t ipv6_length = 0;
+
+                char *p_cid = at_token_get(0, m_result_buffer, &cid_length);
+                char *p_ipv4 = at_token_get(1, m_result_buffer, &ipv4_length);
+                char *p_ipv6 = at_token_get(2, m_result_buffer, &ipv6_length);
+
+                mp_obj_tuple_t *tuple = mp_obj_new_tuple(3, NULL);
+                if ((p_cid != NULL) && (cid_length > 0)) {
+                    tuple->items[0] = mp_obj_new_str(p_cid, cid_length);
+                }
+                if ((p_ipv4 != NULL) && (ipv4_length > 7)) {
+                    tuple->items[1] = mp_obj_new_str(p_ipv4 + 1, ipv4_length - 2); // Hack to get rid of quotes
+                } else {
+                    tuple->items[1] = mp_const_none;
+                }
+                if ((p_ipv6 != NULL) && (ipv6_length > 4)) {
+                    tuple->items[2] = mp_obj_new_str(p_ipv6 + 1, ipv6_length - 2); // Hack to get rid of quotes
+                } else {
+                    tuple->items[2] = mp_const_none;
+                }
+
+                mp_obj_list_append(ret_list, tuple);
+            }
+        }
+    }
+    (void)nrf_close(handle);
+
+    return ret_list;
+}
+STATIC MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(lte_nrf91_ifconfig_obj, 1, 2, lte_nrf91_ifconfig);
+
+STATIC mp_obj_t lte_nrf91_version(mp_obj_t self_in) {
+    int handle = nrf_socket(NRF_AF_LTE, NRF_SOCK_DGRAM, NRF_PROTO_AT);
+    if (handle < 0) {
+        return mp_const_false;
+    }
+
+    static const char at_cgmr[] = "AT+CGMR";
+    int len = send_at_command_with_result(handle, (uint8_t *)at_cgmr, MP_ARRAY_SIZE(at_cgmr), m_result_buffer, MP_ARRAY_SIZE(m_result_buffer));
+
+    (void)nrf_close(handle);
+
+    if (len == -1) {
+        return mp_const_false;
+    }
+
+    return mp_obj_new_str(m_result_buffer, len - 7);
+}
+STATIC MP_DEFINE_CONST_FUN_OBJ_1(lte_nrf91_version_obj, lte_nrf91_version);
+
+STATIC mp_obj_t lte_nrf91_at(mp_obj_t self_in, mp_obj_t query) {
+    int handle = nrf_socket(NRF_AF_LTE, NRF_SOCK_DGRAM, NRF_PROTO_AT);
+    if (handle < 0) {
+        return mp_const_false;
+    }
+
+    mp_uint_t query_len = 0;
+    const char *query_str = NULL;
+    if (mp_obj_is_str(query)) {
+        query_str = mp_obj_str_get_data(query, &query_len);
+    }
+
+    int len = send_at_command_with_result(handle, (uint8_t *)query_str, query_len, m_result_buffer, MP_ARRAY_SIZE(m_result_buffer));
+
+    (void)nrf_close(handle);
+
+    if (len == -1) {
+        return mp_const_false;
+    }
+
+    return mp_obj_new_str(m_result_buffer, len);
+}
+STATIC MP_DEFINE_CONST_FUN_OBJ_2(lte_nrf91_at_obj, lte_nrf91_at);
+
+STATIC const mp_rom_map_elem_t lte_nrf91_locals_dict_table[] = {
+    { MP_ROM_QSTR(MP_QSTR_mode),                MP_ROM_PTR(&lte_nrf91_mode_obj) },
+    { MP_ROM_QSTR(MP_QSTR_connect),             MP_ROM_PTR(&lte_nrf91_connect_obj) },
+    { MP_ROM_QSTR(MP_QSTR_disconnect),          MP_ROM_PTR(&lte_nrf91_disconnect_obj) },
+    { MP_ROM_QSTR(MP_QSTR_ifconfig),            MP_ROM_PTR(&lte_nrf91_ifconfig_obj) },
+    { MP_ROM_QSTR(MP_QSTR_version),             MP_ROM_PTR(&lte_nrf91_version_obj) },
+    { MP_ROM_QSTR(MP_QSTR_at),           MP_ROM_PTR(&lte_nrf91_at_obj) },
+
+};
+STATIC MP_DEFINE_CONST_DICT(lte_nrf91_locals_dict, lte_nrf91_locals_dict_table);
+
+
+const mod_network_nic_type_t mod_network_nic_type_nrf91 = {
+    .base = {
+        { &mp_type_type },
+        .name = MP_QSTR_LTE,
+        .make_new = lte_nrf91_make_new,
+        .locals_dict = (mp_obj_t)&lte_nrf91_locals_dict,
+    },
+    .gethostbyname = lte_nrf91_gethostbyname,
+    .socket = lte_nrf91_socket_socket,
+    .close = lte_nrf91_socket_close,
+    .bind = lte_nrf91_socket_bind,
+    .listen = lte_nrf91_socket_listen,
+    .accept = lte_nrf91_socket_accept,
+    .connect = lte_nrf91_socket_connect,
+    .send = lte_nrf91_socket_send,
+    .recv = lte_nrf91_socket_recv,
+    .sendto = lte_nrf91_socket_sendto,
+    .recvfrom = lte_nrf91_socket_recvfrom,
+    .getsockopt = lte_nrf91_socket_getsockopt,
+    .setsockopt = lte_nrf91_socket_setsockopt,
+    .settimeout = lte_nrf91_socket_settimeout,
+    .ioctl = lte_nrf91_socket_ioctl,
+};
+
+#endif

--- a/ports/nrf/modules/socket/modusocket.c
+++ b/ports/nrf/modules/socket/modusocket.c
@@ -1,0 +1,757 @@
+/*
+ * This file is part of the Micro Python project, http://micropython.org/
+ *
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2014 Damien P. George
+ * Copyright (c) 2019 Glenn Ruben Bakke
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#include <stdio.h>
+#include <string.h>
+
+#include "py/nlr.h"
+#include "py/objtuple.h"
+#include "py/objlist.h"
+#include "py/objstr.h"
+#include "py/runtime.h"
+#include "py/mperrno.h"
+#include "py/stream.h"
+
+#if MICROPY_PY_USOCKET
+
+#include "modnetwork.h"
+#include "nrf_socket.h"
+#include "nrf_errno.h"
+
+/******************************************************************************/
+// socket class
+
+STATIC const mp_obj_type_t socket_type;
+
+static void raise_os_errno(int errno_val) {
+    switch (errno_val) {
+        case NRF_EPERM:
+            mp_raise_msg(&mp_type_OSError, MP_ERROR_TEXT("NRF_EPERM: 1"));
+            break;
+        case NRF_ENOENT:
+            mp_raise_msg(&mp_type_OSError, MP_ERROR_TEXT("NRF_ENOENT: 2"));
+            break;
+        case NRF_EIO:
+            mp_raise_msg(&mp_type_OSError, MP_ERROR_TEXT("NRF_EIO: 5"));
+            break;
+        case NRF_ENOEXEC:
+            mp_raise_msg(&mp_type_OSError, MP_ERROR_TEXT("NRF_ENOEXEC: 8"));
+            break;
+        case NRF_EBADF:
+            mp_raise_msg(&mp_type_OSError, MP_ERROR_TEXT("NRF_EBADF: 9"));
+            break;
+        case NRF_ENOMEM:
+            mp_raise_msg(&mp_type_OSError, MP_ERROR_TEXT("NRF_ENOMEM: 12"));
+            break;
+        case NRF_EACCES:
+            mp_raise_msg(&mp_type_OSError, MP_ERROR_TEXT("NRF_EACCES: 13"));
+            break;
+        case NRF_EFAULT:
+            mp_raise_msg(&mp_type_OSError, MP_ERROR_TEXT("NRF_EFAULT: 14"));
+            break;
+        case NRF_EINVAL:
+            mp_raise_msg(&mp_type_OSError, MP_ERROR_TEXT("NRF_EINVAL: 22"));
+            break;
+        case NRF_EMFILE:
+            mp_raise_msg(&mp_type_OSError, MP_ERROR_TEXT("NRF_EMFILE: 24"));
+            break;
+        case NRF_ENOSPC:
+            mp_raise_msg(&mp_type_OSError, MP_ERROR_TEXT("NRF_ENOSPC: 28"));
+            break;
+        case NRF_EAGAIN:
+            mp_raise_msg(&mp_type_OSError, MP_ERROR_TEXT("NRF_EAGAIN: 35"));
+            break;
+        case NRF_EMSGSIZE:
+            mp_raise_msg(&mp_type_OSError, MP_ERROR_TEXT("NRF_EBADF: 40"));
+            break;
+        case NRF_EPROTOTYPE:
+            mp_raise_msg(&mp_type_OSError, MP_ERROR_TEXT("NRF_EPROTOTYPE: 41"));
+            break;
+        case NRF_ENOPROTOOPT:
+            mp_raise_msg(&mp_type_OSError, MP_ERROR_TEXT("NRF_ENOPROTOOPT: 42"));
+            break;
+        case NRF_EPROTONOSUPPORT:
+            mp_raise_msg(&mp_type_OSError, MP_ERROR_TEXT("NRF_EPROTONOSUPPORT: 43"));
+            break;
+        case NRF_ESOCKTNOSUPPORT:
+            mp_raise_msg(&mp_type_OSError, MP_ERROR_TEXT("NRF_EBADF: 44"));
+            break;
+        case NRF_EOPNOTSUPP:
+            mp_raise_msg(&mp_type_OSError, MP_ERROR_TEXT("NRF_EOPNOTSUPP: 45"));
+            break;
+        case NRF_EAFNOSUPPORT:
+            mp_raise_msg(&mp_type_OSError, MP_ERROR_TEXT("NRF_EAFNOSUPPORT: 47"));
+            break;
+        case NRF_EADDRINUSE:
+            mp_raise_msg(&mp_type_OSError, MP_ERROR_TEXT("NRF_EADDRINUSE: 48"));
+            break;
+        case NRF_ENETDOWN:
+            mp_raise_msg(&mp_type_OSError, MP_ERROR_TEXT("NRF_ENETDOWN: 50"));
+            break;
+        case NRF_ENETUNREACH:
+            mp_raise_msg(&mp_type_OSError, MP_ERROR_TEXT("NRF_ENETUNREACH: 51"));
+            break;
+        case NRF_ENETRESET:
+            mp_raise_msg(&mp_type_OSError, MP_ERROR_TEXT("NRF_ENETRESET: 52"));
+            break;
+        case NRF_ECONNRESET:
+            mp_raise_msg(&mp_type_OSError, MP_ERROR_TEXT("NRF_ECONNRESET: 54"));
+            break;
+        case NRF_EISCONN:
+            mp_raise_msg(&mp_type_OSError, MP_ERROR_TEXT("NRF_EISCONN: 56"));
+            break;
+        case NRF_ENOTCONN:
+            mp_raise_msg(&mp_type_OSError, MP_ERROR_TEXT("NRF_ENOTCONN: 57"));
+            break;
+        case NRF_ETIMEDOUT:
+            mp_raise_msg(&mp_type_OSError, MP_ERROR_TEXT("NRF_ETIMEDOUT: 60"));
+            break;
+        case NRF_ENOBUFS:
+            mp_raise_msg(&mp_type_OSError, MP_ERROR_TEXT("NRF_ENOBUFS: 105"));
+            break;
+        case NRF_EHOSTDOWN:
+            mp_raise_msg(&mp_type_OSError, MP_ERROR_TEXT("NRF_EHOSTDOWN: 112"));
+            break;
+        case NRF_EALREADY:
+            mp_raise_msg(&mp_type_OSError, MP_ERROR_TEXT("NRF_EALREADY: 114"));
+            break;
+        case NRF_EINPROGRESS:
+            mp_raise_msg(&mp_type_OSError, MP_ERROR_TEXT("NRF_EINPROGRESS: 115"));
+            break;
+        case NRF_ECANCELED:
+            mp_raise_msg(&mp_type_OSError, MP_ERROR_TEXT("NRF_ECANCELED: 125"));
+            break;
+        case NRF_ENOKEY:
+            mp_raise_msg(&mp_type_OSError, MP_ERROR_TEXT("NRF_ENOKEY: 126"));
+            break;
+        case NRF_EKEYEXPIRED:
+            mp_raise_msg(&mp_type_OSError, MP_ERROR_TEXT("NRF_EKEYEXPIRED: 127"));
+            break;
+        case NRF_EKEYREVOKED:
+            mp_raise_msg(&mp_type_OSError, MP_ERROR_TEXT("NRF_EKEYREVOKED: 128"));
+            break;
+        case NRF_EKEYREJECTED:
+            mp_raise_msg(&mp_type_OSError, MP_ERROR_TEXT("NRF_EKEYREJECTED: 129"));
+            break;
+        default:
+            mp_raise_msg_varg(&mp_type_ValueError, MP_ERROR_TEXT("NRF_ERROR UNKNOWN (%d)"), errno_val);
+            break;
+    }
+}
+
+STATIC void socket_select_nic(mod_network_socket_obj_t *self, const byte *ip) {
+    if (self->nic == MP_OBJ_NULL) {
+        // select NIC based on IP
+        self->nic = mod_network_find_nic(ip);
+        self->nic_type = (mod_network_nic_type_t *)mp_obj_get_type(self->nic);
+
+        // call the NIC to open the socket
+        int _errno;
+        if (self->nic_type->socket(self, &_errno) != 0) {
+            mp_raise_OSError(_errno);
+        }
+    }
+}
+
+// constructor socket(family=AF_INET, type=SOCK_STREAM, proto=0, fileno=None)
+STATIC mp_obj_t socket_make_new(const mp_obj_type_t *type, mp_uint_t n_args, mp_uint_t n_kw, const mp_obj_t *args) {
+    mp_arg_check_num(n_args, n_kw, 0, 4, false);
+
+    // create socket object (not bound to any NIC yet)
+    mod_network_socket_obj_t *s = m_new_obj_with_finaliser(mod_network_socket_obj_t);
+    s->base.type = (mp_obj_t)&socket_type;
+    s->nic = MP_OBJ_NULL;
+    s->nic_type = NULL;
+    s->u_param.domain = MOD_NETWORK_AF_INET;
+    s->u_param.type = MOD_NETWORK_SOCK_STREAM;
+    s->u_param.fileno = -1;
+    if (n_args >= 1) {
+        s->u_param.domain = mp_obj_get_int(args[0]);
+        if (n_args >= 2) {
+            s->u_param.type = mp_obj_get_int(args[1]);
+            if (n_args >= 3) {
+                s->u_param.proto = mp_obj_get_int(args[2]);
+                if (n_args >= 4) {
+                    s->u_param.fileno = mp_obj_get_int(args[3]);
+                }
+            }
+        }
+    }
+
+    if (s->u_param.fileno == -1) {
+        // check if we need to select a NIC
+        socket_select_nic(s, NULL);
+    }
+
+    return s;
+}
+
+// method socket.close()
+STATIC mp_obj_t socket_close(mp_obj_t self_in) {
+    mod_network_socket_obj_t *self = self_in;
+    if (self->nic != MP_OBJ_NULL) {
+        self->nic_type->close(self);
+        self->nic = MP_OBJ_NULL;
+    }
+    return mp_const_none;
+}
+STATIC MP_DEFINE_CONST_FUN_OBJ_1(socket_close_obj, socket_close);
+
+static mp_uint_t parse_ip_addr(mp_uint_t family_in, mp_obj_t addr_in, void *addr_out) {
+
+    mp_obj_t *items;
+    mp_obj_get_array_fixed_n(addr_in, 2, &items);
+
+    mp_uint_t addr_len;
+    const char *addr_str = mp_obj_str_get_data(items[0], &addr_len);
+
+    nrf_inet_pton(family_in, addr_str, addr_out);
+
+    return mp_obj_get_int(items[1]);
+}
+
+static mp_obj_t format_ip_addr(mp_uint_t family_in, void *addr_in, mp_uint_t port_in) {
+    char addr_str[NRF_INET6_ADDRSTRLEN];
+    const char *result = nrf_inet_ntop(family_in, addr_in, addr_str, sizeof(addr_str));
+
+    mp_obj_t tuple[2] = {
+        tuple[0] = mp_obj_new_str(result, strlen(result)),
+        tuple[1] = mp_obj_new_int(port_in),
+    };
+
+    return mp_obj_new_tuple(2, tuple);
+}
+
+// method socket.bind(address)
+STATIC mp_obj_t socket_bind(mp_obj_t self_in, mp_obj_t addr_in) {
+    mod_network_socket_obj_t *self = self_in;
+
+    byte addr[NRF_INET6_ADDRSTRLEN];
+    mp_uint_t port = parse_ip_addr(self->u_param.domain, addr_in, addr);
+
+    // call the NIC to bind the socket
+    int _errno;
+    if (self->nic_type->bind(self, (uint8_t *)&addr, port, &_errno) != 0) {
+        raise_os_errno(_errno);
+    }
+
+    return mp_const_none;
+}
+STATIC MP_DEFINE_CONST_FUN_OBJ_2(socket_bind_obj, socket_bind);
+
+// method socket.listen(backlog)
+STATIC mp_obj_t socket_listen(mp_obj_t self_in, mp_obj_t backlog) {
+    mod_network_socket_obj_t *self = self_in;
+
+    if (self->nic == MP_OBJ_NULL) {
+        // not connected
+        // TODO Coult we listen even if not bound...
+        // mp_raise_OSError(MP_ENOTCONN);
+    }
+
+    int _errno;
+    if (self->nic_type->listen(self, mp_obj_get_int(backlog), &_errno) != 0) {
+        raise_os_errno(_errno);
+    }
+
+    return mp_const_none;
+}
+STATIC MP_DEFINE_CONST_FUN_OBJ_2(socket_listen_obj, socket_listen);
+
+// method socket.accept()
+STATIC mp_obj_t socket_accept(mp_obj_t self_in) {
+    mod_network_socket_obj_t *self = self_in;
+
+    // create new socket object
+    // starts with empty NIC so that finaliser doesn't run close() method if accept() fails
+    mod_network_socket_obj_t *socket2 = m_new_obj_with_finaliser(mod_network_socket_obj_t);
+    socket2->base.type = (mp_obj_t)&socket_type;
+    socket2->nic = MP_OBJ_NULL;
+    socket2->nic_type = NULL;
+
+    // accept incoming connection
+    uint8_t ip[MOD_NETWORK_IPADDR_BUF_SIZE];
+    mp_uint_t port;
+
+    int _errno = 0;
+    if (self->nic_type->accept(self, socket2, ip, &port, &_errno) < 0) {
+        raise_os_errno(_errno);
+    }
+
+    // new socket has valid state, so set the NIC to the same as parent
+    socket2->nic = self->nic;
+    socket2->nic_type = self->nic_type;
+
+    // make the return value
+    mp_obj_tuple_t *client = mp_obj_new_tuple(2, NULL);
+    client->items[0] = socket2;
+    client->items[1] = format_ip_addr(self->u_param.domain, ip, port);
+
+    return client;
+}
+STATIC MP_DEFINE_CONST_FUN_OBJ_1(socket_accept_obj, socket_accept);
+
+// method socket.connect(address)
+STATIC mp_obj_t socket_connect(mp_obj_t self_in, mp_obj_t addr_in) {
+    mod_network_socket_obj_t *self = self_in;
+    byte *p_address = NULL;
+    byte addr[MOD_NETWORK_IPADDR_BUF_SIZE];
+
+    mp_uint_t port_or_len = 0;
+    // if string, its a character array.
+    if (mp_obj_is_str(addr_in)) {
+        GET_STR_DATA_LEN(addr_in, str_data, str_len);
+
+        p_address = (byte *)str_data;
+        port_or_len = str_len;
+    } else {
+        // else if tupple, its an address.
+
+        // get address
+        port_or_len = parse_ip_addr(self->u_param.domain, addr_in, addr);
+        p_address = addr;
+    }
+
+    // call the NIC to connect the socket
+    int _errno;
+    if (self->nic_type->connect(self, p_address, port_or_len, &_errno) != 0) {
+        raise_os_errno(_errno);
+    }
+
+    return mp_const_none;
+}
+STATIC MP_DEFINE_CONST_FUN_OBJ_2(socket_connect_obj, socket_connect);
+
+// method socket.send(bytes)
+STATIC mp_obj_t socket_send(mp_obj_t self_in, mp_obj_t buf_in) {
+    mod_network_socket_obj_t *self = self_in;
+    if (self->nic == MP_OBJ_NULL) {
+        // not connected
+        mp_raise_OSError(MP_EPIPE);
+    }
+    mp_buffer_info_t bufinfo;
+    mp_get_buffer_raise(buf_in, &bufinfo, MP_BUFFER_READ);
+    int _errno;
+    mp_uint_t ret = self->nic_type->send(self, bufinfo.buf, bufinfo.len, &_errno);
+    if (ret == -1) {
+        raise_os_errno(_errno);
+    }
+    return mp_obj_new_int_from_uint(ret);
+}
+STATIC MP_DEFINE_CONST_FUN_OBJ_2(socket_send_obj, socket_send);
+
+// method socket.recv(bufsize)
+STATIC mp_obj_t socket_recv(mp_obj_t self_in, mp_obj_t len_in) {
+    mod_network_socket_obj_t *self = self_in;
+    if (self->nic == MP_OBJ_NULL) {
+        // not connected
+        mp_raise_OSError(MP_ENOTCONN);
+    }
+    mp_int_t len = mp_obj_get_int(len_in);
+    vstr_t vstr;
+    vstr_init_len(&vstr, len);
+    int _errno;
+    mp_uint_t ret = self->nic_type->recv(self, (byte *)vstr.buf, len, &_errno);
+    if (ret == -1) {
+        raise_os_errno(_errno);
+    }
+    if (ret == 0) {
+        return mp_const_empty_bytes;
+    }
+    vstr.len = ret;
+    return mp_obj_new_str_from_vstr(&mp_type_bytes, &vstr);
+}
+STATIC MP_DEFINE_CONST_FUN_OBJ_2(socket_recv_obj, socket_recv);
+
+// method socket.sendto(bytes, address)
+STATIC mp_obj_t socket_sendto(mp_obj_t self_in, mp_obj_t data_in, mp_obj_t addr_in) {
+    mod_network_socket_obj_t *self = self_in;
+
+    // get the data
+    mp_buffer_info_t bufinfo;
+    mp_get_buffer_raise(data_in, &bufinfo, MP_BUFFER_READ);
+
+    // get address
+    byte addr[MOD_NETWORK_IPADDR_BUF_SIZE];
+    mp_uint_t port = parse_ip_addr(self->u_param.domain, addr_in, addr);
+
+    // check if we need to select a NIC
+    socket_select_nic(self, addr);
+
+    // call the NIC to sendto
+    int _errno;
+    mp_int_t ret = self->nic_type->sendto(self, bufinfo.buf, bufinfo.len, addr, port, &_errno);
+    if (ret == -1) {
+        mp_raise_OSError(_errno);
+    }
+
+    return mp_obj_new_int(ret);
+}
+STATIC MP_DEFINE_CONST_FUN_OBJ_3(socket_sendto_obj, socket_sendto);
+
+// method socket.recvfrom(bufsize)
+STATIC mp_obj_t socket_recvfrom(mp_obj_t self_in, mp_obj_t len_in) {
+    mod_network_socket_obj_t *self = self_in;
+    if (self->nic == MP_OBJ_NULL) {
+        // not connected
+        mp_raise_OSError(MP_ENOTCONN);
+    }
+    vstr_t vstr;
+    vstr_init_len(&vstr, mp_obj_get_int(len_in));
+    byte addr[MOD_NETWORK_IPADDR_BUF_SIZE];
+    mp_uint_t port;
+    int _errno;
+    mp_int_t ret = self->nic_type->recvfrom(self, (byte *)vstr.buf, vstr.len, addr, &port, &_errno);
+    if (ret == -1) {
+        mp_raise_OSError(_errno);
+    }
+    mp_obj_t tuple[2];
+    if (ret == 0) {
+        tuple[0] = mp_const_empty_bytes;
+    } else {
+        vstr.len = ret;
+        tuple[0] = mp_obj_new_str_from_vstr(&mp_type_bytes, &vstr);
+    }
+
+    tuple[1] = format_ip_addr(self->u_param.domain, addr, port);
+
+    return mp_obj_new_tuple(2, tuple);
+}
+STATIC MP_DEFINE_CONST_FUN_OBJ_2(socket_recvfrom_obj, socket_recvfrom);
+
+// method socket.getsockopt(level, optname, value)
+STATIC mp_obj_t socket_getsockopt(mp_uint_t n_args, const mp_obj_t *args) {
+    mod_network_socket_obj_t *self = args[0];
+    if (self->nic == MP_OBJ_NULL) {
+        // not connected
+        mp_raise_OSError(MP_ENOTCONN);
+    }
+
+    mp_int_t level = mp_obj_get_int(args[1]);
+    mp_int_t opt = mp_obj_get_int(args[2]);
+    vstr_t vstr;
+    vstr_init_len(&vstr, mp_obj_get_int(args[3]));
+
+    int _errno;
+    // TODO: figure out if &vstr.len can be passed like this ...
+    if (self->nic_type->getsockopt(self, level, opt, vstr.buf, &vstr.len, &_errno) != 0) {
+        mp_raise_OSError(_errno);
+    }
+
+    if (vstr.len == 0) {
+        return mp_const_none;
+    }
+
+    return mp_obj_new_str_from_vstr(&mp_type_bytes, &vstr);
+}
+STATIC MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(socket_getsockopt_obj, 4, 4, socket_getsockopt);
+
+// method socket.setsockopt(level, optname, value)
+STATIC mp_obj_t socket_setsockopt(mp_uint_t n_args, const mp_obj_t *args) {
+    mod_network_socket_obj_t *self = args[0];
+    if (self->nic == MP_OBJ_NULL) {
+        // not connected
+        mp_raise_OSError(MP_ENOTCONN);
+    }
+
+    mp_int_t level = mp_obj_get_int(args[1]);
+    mp_int_t opt = mp_obj_get_int(args[2]);
+
+    const void *optval;
+    mp_uint_t optlen;
+    mp_int_t val;
+    if (mp_obj_is_integer(args[3])) {
+        val = mp_obj_get_int_truncated(args[3]);
+        optval = &val;
+        optlen = sizeof(val);
+    } else if (args[3] == mp_const_none) {
+        optval = NULL;
+        optlen = 0;
+    } else {
+        mp_buffer_info_t bufinfo;
+        mp_get_buffer_raise(args[3], &bufinfo, MP_BUFFER_READ);
+        optval = bufinfo.buf;
+        optlen = bufinfo.len;
+    }
+
+    int _errno;
+    if (self->nic_type->setsockopt(self, level, opt, optval, optlen, &_errno) != 0) {
+        mp_raise_OSError(_errno);
+    }
+
+    return mp_const_none;
+}
+STATIC MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(socket_setsockopt_obj, 4, 4, socket_setsockopt);
+
+// method socket.settimeout(value)
+// timeout=0 means non-blocking
+// timeout=None means blocking
+// otherwise, timeout is in seconds
+STATIC mp_obj_t socket_settimeout(mp_obj_t self_in, mp_obj_t timeout_in) {
+    mod_network_socket_obj_t *self = self_in;
+    if (self->nic == MP_OBJ_NULL) {
+        // not connected
+        mp_raise_OSError(MP_ENOTCONN);
+    }
+    mp_uint_t timeout;
+    if (timeout_in == mp_const_none) {
+        timeout = -1;
+    } else {
+        #if MICROPY_PY_BUILTINS_FLOAT
+        timeout = 1000 * mp_obj_get_float(timeout_in);
+        #else
+        timeout = 1000 * mp_obj_get_int(timeout_in);
+        #endif
+    }
+    int _errno;
+    if (self->nic_type->settimeout(self, timeout, &_errno) != 0) {
+        mp_raise_OSError(_errno);
+    }
+    return mp_const_none;
+}
+STATIC MP_DEFINE_CONST_FUN_OBJ_2(socket_settimeout_obj, socket_settimeout);
+
+// method socket.setblocking(flag)
+STATIC mp_obj_t socket_setblocking(mp_obj_t self_in, mp_obj_t blocking) {
+    if (mp_obj_is_true(blocking)) {
+        return socket_settimeout(self_in, mp_const_none);
+    } else {
+        return socket_settimeout(self_in, MP_OBJ_NEW_SMALL_INT(0));
+    }
+}
+STATIC MP_DEFINE_CONST_FUN_OBJ_2(socket_setblocking_obj, socket_setblocking);
+
+STATIC const mp_map_elem_t socket_locals_dict_table[] = {
+    { MP_OBJ_NEW_QSTR(MP_QSTR___del__), (mp_obj_t)&socket_close_obj },
+    { MP_OBJ_NEW_QSTR(MP_QSTR_close), (mp_obj_t)&socket_close_obj },
+    { MP_OBJ_NEW_QSTR(MP_QSTR_bind), (mp_obj_t)&socket_bind_obj },
+    { MP_OBJ_NEW_QSTR(MP_QSTR_listen), (mp_obj_t)&socket_listen_obj },
+    { MP_OBJ_NEW_QSTR(MP_QSTR_accept), (mp_obj_t)&socket_accept_obj },
+    { MP_OBJ_NEW_QSTR(MP_QSTR_connect), (mp_obj_t)&socket_connect_obj },
+    { MP_OBJ_NEW_QSTR(MP_QSTR_send), (mp_obj_t)&socket_send_obj },
+    { MP_OBJ_NEW_QSTR(MP_QSTR_recv), (mp_obj_t)&socket_recv_obj },
+    { MP_OBJ_NEW_QSTR(MP_QSTR_write), (mp_obj_t)&socket_send_obj },
+    { MP_OBJ_NEW_QSTR(MP_QSTR_read), (mp_obj_t)&socket_recv_obj },
+    { MP_OBJ_NEW_QSTR(MP_QSTR_sendto), (mp_obj_t)&socket_sendto_obj },
+    { MP_OBJ_NEW_QSTR(MP_QSTR_recvfrom), (mp_obj_t)&socket_recvfrom_obj },
+    { MP_OBJ_NEW_QSTR(MP_QSTR_getsockopt), (mp_obj_t)&socket_getsockopt_obj },
+    { MP_OBJ_NEW_QSTR(MP_QSTR_setsockopt), (mp_obj_t)&socket_setsockopt_obj },
+    { MP_OBJ_NEW_QSTR(MP_QSTR_settimeout), (mp_obj_t)&socket_settimeout_obj },
+    { MP_OBJ_NEW_QSTR(MP_QSTR_setblocking), (mp_obj_t)&socket_setblocking_obj },
+};
+
+STATIC MP_DEFINE_CONST_DICT(socket_locals_dict, socket_locals_dict_table);
+
+mp_uint_t socket_ioctl(mp_obj_t self_in, mp_uint_t request, mp_uint_t arg, int *errcode) {
+    mod_network_socket_obj_t *self = self_in;
+    return self->nic_type->ioctl(self, request, arg, errcode);
+}
+
+STATIC const mp_stream_p_t socket_stream_p = {
+    .ioctl = socket_ioctl,
+    .is_text = false,
+};
+
+STATIC const mp_obj_type_t socket_type = {
+    { &mp_type_type },
+    .name = MP_QSTR_socket,
+    .make_new = socket_make_new,
+    .protocol = &socket_stream_p,
+    .locals_dict = (mp_obj_t)&socket_locals_dict,
+};
+
+/******************************************************************************/
+// usocket module
+
+// function usocket.getaddrinfo(host, port, [interface_name])
+STATIC mp_obj_t mod_usocket_getaddrinfo(mp_uint_t n_args, const mp_obj_t *args) {
+    mp_uint_t hlen;
+    const char *host = mp_obj_str_get_data(args[0], &hlen);
+    mp_int_t port = mp_obj_get_int(args[1]);
+
+    mp_uint_t interface_len = 0;
+    const char *interface = NULL;
+    if ((n_args == 3) && mp_obj_is_str(args[2])) {
+        interface = mp_obj_str_get_data(args[2], &interface_len);
+    }
+    // find a NIC that can do a name lookup
+    for (mp_uint_t i = 0; i < MP_STATE_PORT(mod_network_nic_list).len; i++) {
+        mp_obj_t nic = MP_STATE_PORT(mod_network_nic_list).items[i];
+        mod_network_nic_type_t *nic_type = (mod_network_nic_type_t *)mp_obj_get_type(nic);
+        if (nic_type->gethostbyname != NULL) {
+            byte ipv4_out_ip[MOD_NETWORK_IPADDR_BUF_SIZE];
+            uint8_t ipv4_out_family = MOD_NETWORK_AF_INET;
+            uint8_t ipv4_out_proto = 0;
+            int result_ipv4 = -1;
+
+            mp_obj_t ret_list = mp_obj_new_list(0, NULL);
+
+            if ((result_ipv4 = nic_type->gethostbyname(nic, host, hlen, interface, interface_len, ipv4_out_ip, &ipv4_out_family, &ipv4_out_proto)) == 0) {
+                mp_obj_tuple_t *tuple = mp_obj_new_tuple(5, NULL);
+                tuple->items[0] = MP_OBJ_NEW_SMALL_INT(MOD_NETWORK_AF_INET);
+                tuple->items[1] = MP_OBJ_NEW_SMALL_INT(MOD_NETWORK_SOCK_STREAM);
+                tuple->items[2] = MP_OBJ_NEW_SMALL_INT(0);
+                tuple->items[3] = MP_OBJ_NEW_QSTR(MP_QSTR_);
+                tuple->items[4] = format_ip_addr(ipv4_out_family, ipv4_out_ip, port);
+                mp_obj_list_append(ret_list, tuple);
+            }
+
+            byte ipv6_out_ip[MOD_NETWORK_IPADDR_BUF_SIZE];
+            uint8_t ipv6_out_family = MOD_NETWORK_AF_INET6;
+            uint8_t ipv6_out_proto = 0;
+            int result_ipv6 = -1;
+            if ((result_ipv6 = nic_type->gethostbyname(nic, host, hlen, interface, interface_len, ipv6_out_ip, &ipv6_out_family, &ipv6_out_proto)) == 0) {
+                mp_obj_tuple_t *tuple = mp_obj_new_tuple(5, NULL);
+                tuple->items[0] = MP_OBJ_NEW_SMALL_INT(MOD_NETWORK_AF_INET6);
+                tuple->items[1] = MP_OBJ_NEW_SMALL_INT(MOD_NETWORK_SOCK_STREAM);
+                tuple->items[2] = MP_OBJ_NEW_SMALL_INT(0);
+                tuple->items[3] = MP_OBJ_NEW_QSTR(MP_QSTR_);
+                tuple->items[4] = format_ip_addr(ipv6_out_family, ipv6_out_ip, port);
+                mp_obj_list_append(ret_list, tuple);
+            }
+
+            if ((result_ipv4 != 0) && (result_ipv6 != 0)) {
+                // TODO CPython raises: socket.gaierror: [Errno -2] Name or service not known
+                mp_raise_OSError(98); // EADDRNOTAVAIL
+            }
+
+            return ret_list;
+        }
+    }
+
+    mp_raise_msg(&mp_type_OSError, MP_ERROR_TEXT("no available NIC"));
+}
+STATIC MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(mod_usocket_getaddrinfo_obj, 2, 3, mod_usocket_getaddrinfo);
+
+STATIC const mp_map_elem_t mp_module_usocket_globals_table[] = {
+    { MP_OBJ_NEW_QSTR(MP_QSTR___name__), MP_OBJ_NEW_QSTR(MP_QSTR_usocket) },
+
+    { MP_OBJ_NEW_QSTR(MP_QSTR_socket), (mp_obj_t)&socket_type },
+    { MP_OBJ_NEW_QSTR(MP_QSTR_getaddrinfo), (mp_obj_t)&mod_usocket_getaddrinfo_obj },
+
+    // class constants
+
+    // Socket levels.
+    { MP_OBJ_NEW_QSTR(MP_QSTR_AF_LOCAL), MP_OBJ_NEW_SMALL_INT(NRF_AF_LOCAL) },
+    { MP_OBJ_NEW_QSTR(MP_QSTR_AF_PACKET), MP_OBJ_NEW_SMALL_INT(NRF_AF_PACKET) },
+    { MP_OBJ_NEW_QSTR(MP_QSTR_AF_INET), MP_OBJ_NEW_SMALL_INT(MOD_NETWORK_AF_INET) },
+    { MP_OBJ_NEW_QSTR(MP_QSTR_AF_INET6), MP_OBJ_NEW_SMALL_INT(MOD_NETWORK_AF_INET6) },
+    { MP_OBJ_NEW_QSTR(MP_QSTR_AF_LTE), MP_OBJ_NEW_SMALL_INT(NRF_AF_LTE) },
+
+    // Socket types.
+    { MP_OBJ_NEW_QSTR(MP_QSTR_SOCK_STREAM), MP_OBJ_NEW_SMALL_INT(MOD_NETWORK_SOCK_STREAM) },
+    { MP_OBJ_NEW_QSTR(MP_QSTR_SOCK_DGRAM), MP_OBJ_NEW_SMALL_INT(MOD_NETWORK_SOCK_DGRAM) },
+    { MP_OBJ_NEW_QSTR(MP_QSTR_SOCK_RAW), MP_OBJ_NEW_SMALL_INT(NRF_SOCK_RAW) },
+    { MP_OBJ_NEW_QSTR(MP_QSTR_SOCK_MGMT), MP_OBJ_NEW_SMALL_INT(NRF_SOCK_MGMT) },
+
+    // Socket protocols.
+    { MP_OBJ_NEW_QSTR(MP_QSTR_IPPROTO_TCP), MP_OBJ_NEW_SMALL_INT(NRF_IPPROTO_TCP) },
+    { MP_OBJ_NEW_QSTR(MP_QSTR_IPPROTO_UDP), MP_OBJ_NEW_SMALL_INT(NRF_IPPROTO_UDP) },
+    { MP_OBJ_NEW_QSTR(MP_QSTR_PROTO_AT), MP_OBJ_NEW_SMALL_INT(NRF_PROTO_AT) },
+    { MP_OBJ_NEW_QSTR(MP_QSTR_PROTO_PDN), MP_OBJ_NEW_SMALL_INT(NRF_PROTO_PDN) },
+    { MP_OBJ_NEW_QSTR(MP_QSTR_PROTO_DFU), MP_OBJ_NEW_SMALL_INT(NRF_PROTO_DFU) },
+    { MP_OBJ_NEW_QSTR(MP_QSTR_PROTO_GNSS), MP_OBJ_NEW_SMALL_INT(NRF_PROTO_GNSS) },
+    { MP_OBJ_NEW_QSTR(MP_QSTR_SPROTO_TLS1v2), MP_OBJ_NEW_SMALL_INT(NRF_SPROTO_TLS1v2) },
+    { MP_OBJ_NEW_QSTR(MP_QSTR_SPROTO_TLS1v3), MP_OBJ_NEW_SMALL_INT(NRF_SPROTO_TLS1v3) },
+    { MP_OBJ_NEW_QSTR(MP_QSTR_SPROTO_DTLS1v2), MP_OBJ_NEW_SMALL_INT(NRF_SPROTO_DTLS1v2) },
+
+    // Socket options levels.
+    { MP_OBJ_NEW_QSTR(MP_QSTR_SOL_SOCKET), MP_OBJ_NEW_SMALL_INT(NRF_SOL_SOCKET) },
+    { MP_OBJ_NEW_QSTR(MP_QSTR_SOL_SECURE), MP_OBJ_NEW_SMALL_INT(NRF_SOL_SECURE) },
+    { MP_OBJ_NEW_QSTR(MP_QSTR_SOL_PDN), MP_OBJ_NEW_SMALL_INT(NRF_SOL_PDN) },
+    { MP_OBJ_NEW_QSTR(MP_QSTR_SOL_DFU), MP_OBJ_NEW_SMALL_INT(NRF_SOL_DFU) },
+    { MP_OBJ_NEW_QSTR(MP_QSTR_SOL_GNSS), MP_OBJ_NEW_SMALL_INT(NRF_SOL_GNSS) },
+
+    // Socket options.
+
+    // SOL_SOCKET.
+    { MP_OBJ_NEW_QSTR(MP_QSTR_SO_ERROR), MP_OBJ_NEW_SMALL_INT(NRF_SO_ERROR) },
+    { MP_OBJ_NEW_QSTR(MP_QSTR_SO_RCVTIMEO), MP_OBJ_NEW_SMALL_INT(NRF_SO_RCVTIMEO) },
+    { MP_OBJ_NEW_QSTR(MP_QSTR_SO_SNDTIMEO), MP_OBJ_NEW_SMALL_INT(NRF_SO_SNDTIMEO) },
+    { MP_OBJ_NEW_QSTR(MP_QSTR_SO_BINDTODEVICE), MP_OBJ_NEW_SMALL_INT(NRF_SO_BINDTODEVICE) },
+    { MP_OBJ_NEW_QSTR(MP_QSTR_SO_SILENCE_ALL), MP_OBJ_NEW_SMALL_INT(NRF_SO_SILENCE_ALL) },
+    { MP_OBJ_NEW_QSTR(MP_QSTR_SO_SILENCE_IP_ECHO_REPLY), MP_OBJ_NEW_SMALL_INT(NRF_SO_SILENCE_IP_ECHO_REPLY) },
+    { MP_OBJ_NEW_QSTR(MP_QSTR_SO_SILENCE_IPV6_ECHO_REPLY), MP_OBJ_NEW_SMALL_INT(NRF_SO_SILENCE_IPV6_ECHO_REPLY) },
+    { MP_OBJ_NEW_QSTR(MP_QSTR_SO_REUSEADDR), MP_OBJ_NEW_SMALL_INT(NRF_SO_REUSEADDR) },
+
+    // SOL_SECURE.
+    { MP_OBJ_NEW_QSTR(MP_QSTR_SO_SEC_ROLE), MP_OBJ_NEW_SMALL_INT(NRF_SO_SEC_ROLE) },
+    { MP_OBJ_NEW_QSTR(MP_QSTR_SO_SEC_TAG_LIST), MP_OBJ_NEW_SMALL_INT(NRF_SO_SEC_TAG_LIST) },
+    { MP_OBJ_NEW_QSTR(MP_QSTR_SO_SEC_SESSION_CACHE), MP_OBJ_NEW_SMALL_INT(NRF_SO_SEC_SESSION_CACHE) },
+    { MP_OBJ_NEW_QSTR(MP_QSTR_SO_SEC_PEER_VERIFY), MP_OBJ_NEW_SMALL_INT(NRF_SO_SEC_PEER_VERIFY) },
+    { MP_OBJ_NEW_QSTR(MP_QSTR_SO_SEC_HOSTNAME), MP_OBJ_NEW_SMALL_INT(NRF_SO_HOSTNAME) },
+    { MP_OBJ_NEW_QSTR(MP_QSTR_SO_SEC_CIPHERSUITE_LIST), MP_OBJ_NEW_SMALL_INT(NRF_SO_CIPHERSUITE_LIST) },
+    { MP_OBJ_NEW_QSTR(MP_QSTR_SO_SEC_CIPHER_IN_USE), MP_OBJ_NEW_SMALL_INT(NRF_SO_CIPHER_IN_USE) },
+
+    // SOL_PDN
+    { MP_OBJ_NEW_QSTR(MP_QSTR_SO_PDN_AF), MP_OBJ_NEW_SMALL_INT(NRF_SO_PDN_AF) },
+    { MP_OBJ_NEW_QSTR(MP_QSTR_SO_PDN_CONTEXT_ID), MP_OBJ_NEW_SMALL_INT(NRF_SO_PDN_CONTEXT_ID) },
+    { MP_OBJ_NEW_QSTR(MP_QSTR_SO_PDN_STATE), MP_OBJ_NEW_SMALL_INT(NRF_SO_PDN_STATE) },
+
+    // SOL_DFU
+    { MP_OBJ_NEW_QSTR(MP_QSTR_SO_DFU_FW_VERSION), MP_OBJ_NEW_SMALL_INT(NRF_SO_DFU_FW_VERSION) },
+    { MP_OBJ_NEW_QSTR(MP_QSTR_SO_DFU_RESOURCES), MP_OBJ_NEW_SMALL_INT(NRF_SO_DFU_RESOURCES) },
+    { MP_OBJ_NEW_QSTR(MP_QSTR_SO_DFU_TIMEO), MP_OBJ_NEW_SMALL_INT(NRF_SO_DFU_TIMEO) },
+    { MP_OBJ_NEW_QSTR(MP_QSTR_SO_DFU_APPLY), MP_OBJ_NEW_SMALL_INT(NRF_SO_DFU_APPLY) },
+    { MP_OBJ_NEW_QSTR(MP_QSTR_SO_DFU_REVERT), MP_OBJ_NEW_SMALL_INT(NRF_SO_DFU_REVERT) },
+    { MP_OBJ_NEW_QSTR(MP_QSTR_SO_DFU_BACKUP_DELETE), MP_OBJ_NEW_SMALL_INT(NRF_SO_DFU_BACKUP_DELETE) },
+    { MP_OBJ_NEW_QSTR(MP_QSTR_SO_DFU_OFFSET), MP_OBJ_NEW_SMALL_INT(NRF_SO_DFU_OFFSET) },
+    { MP_OBJ_NEW_QSTR(MP_QSTR_SO_DFU_ERROR), MP_OBJ_NEW_SMALL_INT(NRF_SO_DFU_ERROR) },
+
+    // SOL_GNSS
+    { MP_OBJ_NEW_QSTR(MP_QSTR_SO_GNSS_FIX_INTERVAL), MP_OBJ_NEW_SMALL_INT(NRF_SO_GNSS_FIX_INTERVAL) },
+    { MP_OBJ_NEW_QSTR(MP_QSTR_SO_GNSS_FIX_RETRY), MP_OBJ_NEW_SMALL_INT(NRF_SO_GNSS_FIX_RETRY) },
+    { MP_OBJ_NEW_QSTR(MP_QSTR_SO_GNSS_SYSTEM), MP_OBJ_NEW_SMALL_INT(NRF_SO_GNSS_SYSTEM) },
+    { MP_OBJ_NEW_QSTR(MP_QSTR_SO_GNSS_NMEA_MASK), MP_OBJ_NEW_SMALL_INT(NRF_SO_GNSS_NMEA_MASK) },
+    { MP_OBJ_NEW_QSTR(MP_QSTR_SO_GNSS_ELEVATION_MASK), MP_OBJ_NEW_SMALL_INT(NRF_SO_GNSS_ELEVATION_MASK) },
+    { MP_OBJ_NEW_QSTR(MP_QSTR_SO_GNSS_USE_CASE), MP_OBJ_NEW_SMALL_INT(NRF_SO_GNSS_USE_CASE) },
+    { MP_OBJ_NEW_QSTR(MP_QSTR_SO_GNSS_START), MP_OBJ_NEW_SMALL_INT(NRF_SO_GNSS_START) },
+    { MP_OBJ_NEW_QSTR(MP_QSTR_SO_GNSS_STOP), MP_OBJ_NEW_SMALL_INT(NRF_SO_GNSS_STOP) },
+    { MP_OBJ_NEW_QSTR(MP_QSTR_SO_GNSS_PSM), MP_OBJ_NEW_SMALL_INT(NRF_SO_GNSS_POWER_SAVE_MODE) },
+    { MP_OBJ_NEW_QSTR(MP_QSTR_SO_GNSS_ENABLE_PRIORITY), MP_OBJ_NEW_SMALL_INT(NRF_SO_GNSS_ENABLE_PRIORITY) },
+    { MP_OBJ_NEW_QSTR(MP_QSTR_SO_GNSS_DISABLE_PRIORITY), MP_OBJ_NEW_SMALL_INT(NRF_SO_GNSS_DISABLE_PRIORITY) },
+
+    // GNSS option value flags.
+    { MP_OBJ_NEW_QSTR(MP_QSTR_GNSS_NMEA_CONFIG_GGA_FLAG), MP_OBJ_NEW_SMALL_INT(NRF_GNSS_NMEA_GGA_MASK) },
+    { MP_OBJ_NEW_QSTR(MP_QSTR_GNSS_NMEA_CONFIG_GLL_FLAG), MP_OBJ_NEW_SMALL_INT(NRF_GNSS_NMEA_GLL_MASK) },
+    { MP_OBJ_NEW_QSTR(MP_QSTR_GNSS_NMEA_CONFIG_GSA_FLAG), MP_OBJ_NEW_SMALL_INT(NRF_GNSS_NMEA_GSA_MASK) },
+    { MP_OBJ_NEW_QSTR(MP_QSTR_GNSS_NMEA_CONFIG_GSV_FLAG), MP_OBJ_NEW_SMALL_INT(NRF_GNSS_NMEA_GSV_MASK) },
+    { MP_OBJ_NEW_QSTR(MP_QSTR_GNSS_NMEA_CONFIG_RMC_FLAG), MP_OBJ_NEW_SMALL_INT(NRF_GNSS_NMEA_RMC_MASK) },
+
+    // GNSS Power Saving Mode (PSM).
+    { MP_OBJ_NEW_QSTR(MP_QSTR_GNSS_PSM_DISABLED), MP_OBJ_NEW_SMALL_INT(NRF_GNSS_PSM_DISABLED) },
+    { MP_OBJ_NEW_QSTR(MP_QSTR_GNSS_PSM_DUTY_CYCLE_PERF), MP_OBJ_NEW_SMALL_INT(NRF_GNSS_PSM_DUTY_CYCLING_PERFORMANCE) },
+    { MP_OBJ_NEW_QSTR(MP_QSTR_GNSS_PSM_DUTY_CYCLE_POWER), MP_OBJ_NEW_SMALL_INT(NRF_GNSS_PSM_DUTY_CYCLING_POWER) },
+};
+STATIC MP_DEFINE_CONST_DICT(mp_module_usocket_globals, mp_module_usocket_globals_table);
+
+const mp_obj_module_t mp_module_usocket = {
+    .base = { &mp_type_module },
+    .globals = (mp_obj_dict_t *)&mp_module_usocket_globals,
+};
+
+#endif  // MICROPY_PY_USOCKET

--- a/ports/nrf/mpconfigport.h
+++ b/ports/nrf/mpconfigport.h
@@ -178,6 +178,14 @@
 #define MICROPY_PY_TIME_TICKS       (1)
 #endif
 
+#ifndef MICROPY_PY_LTE_SOCKET
+#define MICROPY_PY_LTE_SOCKET       (0)
+#endif
+
+#ifndef MICROPY_PY_NETWORK
+#define MICROPY_PY_NETWORK          (0)
+#endif
+
 #define MICROPY_ENABLE_EMERGENCY_EXCEPTION_BUF   (1)
 #define MICROPY_EMERGENCY_EXCEPTION_BUF_SIZE  (0)
 
@@ -217,6 +225,22 @@ extern const struct _mp_obj_module_t mp_module_utime;
 extern const struct _mp_obj_module_t mp_module_uos;
 extern const struct _mp_obj_module_t mp_module_ubluepy;
 extern const struct _mp_obj_module_t music_module;
+
+#if MICROPY_PY_USOCKET
+extern const struct _mp_obj_module_t mp_module_usocket;
+#define SOCKET_BUILTIN_MODULE               { MP_OBJ_NEW_QSTR(MP_QSTR_usocket), (mp_obj_t)&mp_module_usocket },
+#define SOCKET_BUILTIN_MODULE_WEAK_LINKS    { MP_OBJ_NEW_QSTR(MP_QSTR_socket), (mp_obj_t)&mp_module_usocket },
+#else
+#define SOCKET_BUILTIN_MODULE
+#define SOCKET_BUILTIN_MODULE_WEAK_LINKS
+#endif
+
+#if MICROPY_PY_NETWORK
+extern const struct _mp_obj_module_t mp_module_network;
+#define NETWORK_BUILTIN_MODULE              { MP_OBJ_NEW_QSTR(MP_QSTR_network), (mp_obj_t)&mp_module_network },
+#else
+#define NETWORK_BUILTIN_MODULE
+#endif
 
 #if MICROPY_PY_UBLUEPY
 #define UBLUEPY_MODULE                      { MP_ROM_QSTR(MP_QSTR_ubluepy), MP_ROM_PTR(&mp_module_ubluepy) },
@@ -267,7 +291,8 @@ extern const struct _mp_obj_module_t ble_module;
     { MP_ROM_QSTR(MP_QSTR_uos), MP_ROM_PTR(&mp_module_uos) }, \
     MUSIC_MODULE \
     MICROPY_BOARD_BUILTINS \
-
+    SOCKET_BUILTIN_MODULE \
+    NETWORK_BUILTIN_MODULE \
 
 #endif // BLUETOOTH_SD
 
@@ -299,6 +324,13 @@ extern const struct _mp_obj_module_t ble_module;
 #define ROOT_POINTERS_SOFTPWM
 #endif
 
+#if MICROPY_PY_NETWORK && MICROPY_PY_LTE_SOCKET
+#define ROOT_POINTERS_NIC_LIST \
+    mp_obj_list_t mod_network_nic_list;
+#else
+#define ROOT_POINTERS_NIC_LIST
+#endif
+
 #if defined(NRF52840_XXAA)
 #define NUM_OF_PINS 48
 #else
@@ -319,6 +351,8 @@ extern const struct _mp_obj_module_t ble_module;
     \
     /* micro:bit root pointers */ \
     void *async_data[2]; \
+    \
+    ROOT_POINTERS_NIC_LIST \
 
 #define MICROPY_EVENT_POLL_HOOK \
     do { \


### PR DESCRIPTION
Adding nrf9160 sockets support by using the `bsdlib` provided by Nordic Semiconductor. This enables micropython nrf9160 port with GNSS, AT-commands, IPv4, IPv6,  UDP, TCP, DTLS1v2, TLS1v2, RAW socket (AF_PACKET), PDN/APN, getaddrinfo() and getaddrinfo() on specified PDN/APN, on-chip Modem DFU.

Samples provided for HTTP and GNSS.

Known limitations which should be handled later:
* Secure credentials interface in order to establish TLS/DTLS connections. Can be performed manually through AT (AT%CMNG) commands at the moment.
* AGPS.
* Poll. Want to see if extmod/moduselect can be used. I have a version of moduselect.c that works, but it is pretty much 99% duplicate code of other moduselect's. Setting sockets in non-block mode is still possible.
* Network mode() switch interface to select LTE, NB-IOT, GPS and combo of these.
* Network init() and unit() methods. To toggle the library on and off in case of sleep or during on-chip modem DFU upgrade.
