### PR TITLE
micropython/docs/library/: removed escape `\` 

### DIFF
--- a/docs/library/btree.rst
+++ b/docs/library/btree.rst
@@ -76,7 +76,7 @@ Example::
 Functions
 ---------
 
-.. function:: open(stream, \*, flags=0, pagesize=0, cachesize=0, minkeypage=0)
+.. function:: open(stream,*, flags=0, pagesize=0, cachesize=0, minkeypage=0)
 
    Open a database from a random-access `stream` (like an open file). All
    other parameters are optional and keyword-only, and allow to tweak advanced

--- a/docs/library/esp32.rst
+++ b/docs/library/esp32.rst
@@ -186,7 +186,7 @@ For more details see Espressif's `ESP-IDF RMT documentation.
    *beta feature* and the interface may change in the future.
 
 
-.. class:: RMT(channel, \*, pin=None, clock_div=8, carrier_freq=0, carrier_duty_percent=50)
+.. class:: RMT(channel, *, pin=None, clock_div=8, carrier_freq=0, carrier_duty_percent=50)
 
     This class provides access to one of the eight RMT channels. *channel* is
     required and identifies which RMT channel (0-7) will be configured. *pin*,

--- a/docs/library/lcd160cr.rst
+++ b/docs/library/lcd160cr.rst
@@ -37,7 +37,7 @@ For example::
 Constructors
 ------------
 
-.. class:: LCD160CR(connect=None, \*, pwr=None, i2c=None, spi=None, i2c_addr=98)
+.. class:: LCD160CR(connect=None, *, pwr=None, i2c=None, spi=None, i2c_addr=98)
 
     Construct an LCD160CR object.  The parameters are:
 

--- a/docs/library/lcd160cr.rst
+++ b/docs/library/lcd160cr.rst
@@ -37,7 +37,7 @@ For example::
 Constructors
 ------------
 
-.. class:: LCD160CR(connect=None, *, pwr=None, i2c=None, spi=None, i2c_addr=98)
+.. class:: LCD160CR(connect=None,*, pwr=None, i2c=None, spi=None, i2c_addr=98)
 
     Construct an LCD160CR object.  The parameters are:
 

--- a/docs/library/machine.ADCWiPy.rst
+++ b/docs/library/machine.ADCWiPy.rst
@@ -22,7 +22,7 @@ Usage::
 Constructors
 ------------
 
-.. class:: ADCWiPy(id=0, \*, bits=12)
+.. class:: ADCWiPy(id=0, *, bits=12)
 
    Create an ADC object associated with the given pin.
    This allows you to then read analog values on that pin.
@@ -39,7 +39,7 @@ Constructors
 Methods
 -------
 
-.. method:: ADCWiPy.channel(id, \*, pin)
+.. method:: ADCWiPy.channel(id, *, pin)
 
    Create an analog pin. If only channel ID is given, the correct pin will
    be selected. Alternatively, only the pin can be passed and the correct

--- a/docs/library/machine.I2C.rst
+++ b/docs/library/machine.I2C.rst
@@ -33,7 +33,7 @@ Example usage::
 Constructors
 ------------
 
-.. class:: I2C(id=-1, \*, scl, sda, freq=400000)
+.. class:: I2C(id=-1, *, scl, sda, freq=400000)
 
    Construct and return a new I2C object using the following parameters:
 
@@ -52,7 +52,7 @@ Constructors
 General Methods
 ---------------
 
-.. method:: I2C.init(scl, sda, \*, freq=400000)
+.. method:: I2C.init(scl, sda, *, freq=400000)
 
   Initialise the I2C bus with the given arguments:
 
@@ -153,14 +153,14 @@ from and written to.  In this case there are two addresses associated with an
 I2C transaction: the slave address and the memory address.  The following
 methods are convenience functions to communicate with such devices.
 
-.. method:: I2C.readfrom_mem(addr, memaddr, nbytes, \*, addrsize=8)
+.. method:: I2C.readfrom_mem(addr, memaddr, nbytes, *, addrsize=8)
 
    Read *nbytes* from the slave specified by *addr* starting from the memory
    address specified by *memaddr*.
    The argument *addrsize* specifies the address size in bits.
    Returns a `bytes` object with the data read.
 
-.. method:: I2C.readfrom_mem_into(addr, memaddr, buf, \*, addrsize=8)
+.. method:: I2C.readfrom_mem_into(addr, memaddr, buf, *, addrsize=8)
 
    Read into *buf* from the slave specified by *addr* starting from the
    memory address specified by *memaddr*.  The number of bytes read is the
@@ -170,7 +170,7 @@ methods are convenience functions to communicate with such devices.
 
    The method returns ``None``.
 
-.. method:: I2C.writeto_mem(addr, memaddr, buf, \*, addrsize=8)
+.. method:: I2C.writeto_mem(addr, memaddr, buf, *, addrsize=8)
 
    Write *buf* to the slave specified by *addr* starting from the
    memory address specified by *memaddr*.

--- a/docs/library/machine.Pin.rst
+++ b/docs/library/machine.Pin.rst
@@ -42,7 +42,7 @@ Usage Model::
 Constructors
 ------------
 
-.. class:: Pin(id, mode=-1, pull=-1, \*, value, drive, alt)
+.. class:: Pin(id, mode=-1, pull=-1,*, value, drive, alt)
 
    Access the pin peripheral (GPIO pin) associated with the given ``id``.  If
    additional arguments are given in the constructor then they are used to initialise
@@ -106,7 +106,7 @@ Constructors
 Methods
 -------
 
-.. method:: Pin.init(mode=-1, pull=-1, \*, value, drive, alt)
+.. method:: Pin.init(mode=-1, pull=-1,*, value, drive, alt)
 
    Re-initialise the pin using the given parameters.  Only those arguments that
    are specified will be set.  The rest of the pin peripheral state will remain
@@ -179,7 +179,7 @@ Methods
 
    Availability: WiPy.
 
-.. method:: Pin.irq(handler=None, trigger=(Pin.IRQ_FALLING | Pin.IRQ_RISING), \*, priority=1, wake=None, hard=False)
+.. method:: Pin.irq(handler=None, trigger=(Pin.IRQ_FALLING | Pin.IRQ_RISING),*, priority=1, wake=None, hard=False)
 
    Configure an interrupt handler to be called when the trigger source of the
    pin is active.  If the pin mode is ``Pin.IN`` then the trigger source is

--- a/docs/library/machine.RTC.rst
+++ b/docs/library/machine.RTC.rst
@@ -38,7 +38,7 @@ Methods
 
    Resets the RTC to the time of January 1, 2015 and starts running it again.
 
-.. method:: RTC.alarm(id, time, \*, repeat=False)
+.. method:: RTC.alarm(id, time, *, repeat=False)
 
    Set the RTC alarm. Time might be either a millisecond value to program the alarm to
    current time + time_in_ms in the future, or a datetimetuple. If the time passed is in
@@ -52,7 +52,7 @@ Methods
 
    Cancel a running alarm.
 
-.. method:: RTC.irq(\*, trigger, handler=None, wake=machine.IDLE)
+.. method:: RTC.irq(*, trigger, handler=None, wake=machine.IDLE)
 
    Create an irq object triggered by a real time clock alarm.
 

--- a/docs/library/machine.SPI.rst
+++ b/docs/library/machine.SPI.rst
@@ -29,7 +29,7 @@ Constructors
 Methods
 -------
 
-.. method:: SPI.init(baudrate=1000000, \*, polarity=0, phase=0, bits=8, firstbit=SPI.MSB, sck=None, mosi=None, miso=None, pins=(SCK, MOSI, MISO))
+.. method:: SPI.init(baudrate=1000000,*, polarity=0, phase=0, bits=8, firstbit=SPI.MSB, sck=None, mosi=None, miso=None, pins=(SCK, MOSI, MISO))
 
    Initialise the SPI bus with the given parameters:
 

--- a/docs/library/machine.Signal.rst
+++ b/docs/library/machine.Signal.rst
@@ -75,7 +75,7 @@ Constructors
 ------------
 
 .. class:: Signal(pin_obj, invert=False)
-           Signal(pin_arguments..., \*, invert=False)
+           Signal(pin_arguments...,*, invert=False)
 
    Create a Signal object. There're two ways to create it:
 

--- a/docs/library/machine.Timer.rst
+++ b/docs/library/machine.Timer.rst
@@ -35,7 +35,7 @@ Constructors
 Methods
 -------
 
-.. method:: Timer.init(\*, mode=Timer.PERIODIC, period=-1, callback=None)
+.. method:: Timer.init(*, mode=Timer.PERIODIC, period=-1, callback=None)
 
    Initialise the timer. Example::
 

--- a/docs/library/machine.TimerWiPy.rst
+++ b/docs/library/machine.TimerWiPy.rst
@@ -39,7 +39,7 @@ Constructors
 Methods
 -------
 
-.. method:: TimerWiPy.init(mode, \*, width=16)
+.. method:: TimerWiPy.init(mode, *, width=16)
 
    Initialise the timer. Example::
 
@@ -64,7 +64,7 @@ Methods
 
    Deinitialises the timer. Stops the timer, and disables the timer peripheral.
 
-.. method:: TimerWiPy.channel(channel, \**, freq, period, polarity=TimerWiPy.POSITIVE, duty_cycle=0)
+.. method:: TimerWiPy.channel(channel, **, freq, period, polarity=TimerWiPy.POSITIVE, duty_cycle=0)
 
    If only a channel identifier passed, then a previously initialized channel
    object is returned (or ``None`` if there is no previous channel).
@@ -113,7 +113,7 @@ TimerChannel objects are created using the Timer.channel() method.
 Methods
 -------
 
-.. method:: timerchannel.irq(\*, trigger, priority=1, handler=None)
+.. method:: timerchannel.irq(*, trigger, priority=1, handler=None)
 
     The behavior of this callback is heavily dependent on the operating
     mode of the timer channel:

--- a/docs/library/machine.UART.rst
+++ b/docs/library/machine.UART.rst
@@ -43,7 +43,7 @@ Constructors
 Methods
 -------
 
-.. method:: UART.init(baudrate=9600, bits=8, parity=None, stop=1, \*, ...)
+.. method:: UART.init(baudrate=9600, bits=8, parity=None, stop=1,*, ...)
 
    Initialise the UART bus with the given parameters:
 

--- a/docs/library/network.CC3K.rst
+++ b/docs/library/network.CC3K.rst
@@ -51,7 +51,7 @@ Constructors
 Methods
 -------
 
-.. method:: CC3K.connect(ssid, key=None, \*, security=WPA2, bssid=None)
+.. method:: CC3K.connect(ssid, key=None, *, security=WPA2, bssid=None)
 
    Connect to a WiFi access point using the given SSID, and other security
    parameters.

--- a/docs/library/network.WLAN.rst
+++ b/docs/library/network.WLAN.rst
@@ -32,7 +32,7 @@ Methods
     argument is passed. Otherwise, query current state if no argument is
     provided. Most other methods require active interface.
 
-.. method:: WLAN.connect(ssid=None, password=None, \*, bssid=None)
+.. method:: WLAN.connect(ssid=None, password=None, *, bssid=None)
 
     Connect to the specified wireless network, using the specified password.
     If *bssid* is given then the connection will be restricted to the

--- a/docs/library/network.WLANWiPy.rst
+++ b/docs/library/network.WLANWiPy.rst
@@ -43,7 +43,7 @@ Constructors
 Methods
 -------
 
-.. method:: WLANWiPy.init(mode, \*, ssid, auth, channel, antenna)
+.. method:: WLANWiPy.init(mode, *, ssid, auth, channel, antenna)
 
    Set or get the WiFi network processor configuration.
 
@@ -69,7 +69,7 @@ Methods
       # configure as an station
       wlan.init(mode=WLAN.STA)
 
-.. method:: WLANWiPy.connect(ssid, \*, auth=None, bssid=None, timeout=None)
+.. method:: WLANWiPy.connect(ssid, *, auth=None, bssid=None, timeout=None)
 
    Connect to a WiFi access point using the given SSID, and other security
    parameters.
@@ -131,7 +131,7 @@ Methods
 
    Get or set a 6-byte long bytes object with the MAC address.
 
-.. method:: WLANWiPy.irq(\*, handler, wake)
+.. method:: WLANWiPy.irq(*, handler, wake)
 
     Create a callback to be triggered when a WLAN event occurs during ``machine.SLEEP``
     mode. Events are triggered by socket activity or by WLAN connection/disconnection.

--- a/docs/library/network.rst
+++ b/docs/library/network.rst
@@ -58,7 +58,7 @@ parameter should be `id`.
         interface (behavior of calling them on inactive interface is
         undefined).
 
-.. method:: AbstractNIC.connect([service_id, key=None, \*, ...])
+.. method:: AbstractNIC.connect([service_id, key=None, *, ...])
 
        Connect the interface to a network. This method is optional, and
        available only for interfaces which are not "always connected".
@@ -82,7 +82,7 @@ parameter should be `id`.
 
        Returns ``True`` if connected to network, otherwise returns ``False``.
 
-.. method:: AbstractNIC.scan(\*, ...)
+.. method:: AbstractNIC.scan(*, ...)
 
        Scan for the available network services/connections. Returns a
        list of tuples with discovered service parameters. For various

--- a/docs/library/pyb.CAN.rst
+++ b/docs/library/pyb.CAN.rst
@@ -49,7 +49,7 @@ Class Methods
 Methods
 -------
 
-.. method:: CAN.init(mode, extframe=False, prescaler=100, \*, sjw=1, bs1=6, bs2=8, auto_restart=False)
+.. method:: CAN.init(mode, extframe=False, prescaler=100, *, sjw=1, bs1=6, bs2=8, auto_restart=False)
 
    Initialise the CAN bus with the given parameters:
 
@@ -135,7 +135,7 @@ Methods
    - number of pending RX messages on fifo 0
    - number of pending RX messages on fifo 1
 
-.. method:: CAN.setfilter(bank, mode, fifo, params, \*, rtr)
+.. method:: CAN.setfilter(bank, mode, fifo, params, *, rtr)
 
    Configure a filter bank:
 
@@ -187,7 +187,7 @@ Methods
 
    Return ``True`` if any message waiting on the FIFO, else ``False``.
 
-.. method:: CAN.recv(fifo, list=None, \*, timeout=5000)
+.. method:: CAN.recv(fifo, list=None, *, timeout=5000)
 
    Receive data on the bus:
 
@@ -220,7 +220,7 @@ Methods
         # No heap memory is allocated in the following call
         can.recv(0, lst)
 
-.. method:: CAN.send(data, id, \*, timeout=0, rtr=False)
+.. method:: CAN.send(data, id, *, timeout=0, rtr=False)
 
    Send a message on the bus:
 

--- a/docs/library/pyb.DAC.rst
+++ b/docs/library/pyb.DAC.rst
@@ -49,7 +49,7 @@ To output a continuous sine-wave at 12-bit resolution::
 Constructors
 ------------
 
-.. class:: pyb.DAC(port, bits=8, \*, buffering=None)
+.. class:: pyb.DAC(port, bits=8, *, buffering=None)
 
    Construct a new DAC object.
 
@@ -76,7 +76,7 @@ Constructors
 Methods
 -------
 
-.. method:: DAC.init(bits=8, \*, buffering=None)
+.. method:: DAC.init(bits=8, *, buffering=None)
 
    Reinitialise the DAC.  *bits* can be 8 or 12.  *buffering* can be
    ``None``, ``False`` or ``True``; see above constructor for the meaning
@@ -103,7 +103,7 @@ Methods
    value is 2\*\*``bits``-1, where ``bits`` is set when creating the DAC
    object or by using the ``init`` method.
 
-.. method:: DAC.write_timed(data, freq, \*, mode=DAC.NORMAL)
+.. method:: DAC.write_timed(data, freq, *, mode=DAC.NORMAL)
 
    Initiates a burst of RAM to DAC using a DMA transfer.
    The input data is treated as an array of bytes in 8-bit mode, and

--- a/docs/library/pyb.Flash.rst
+++ b/docs/library/pyb.Flash.rst
@@ -25,7 +25,7 @@ Constructors
 
    This constructor is deprecated and will be removed in a future version of MicroPython.
 
-.. class:: pyb.Flash(\*, start=-1, len=-1)
+.. class:: pyb.Flash(*, start=-1, len=-1)
    :noindex:
 
    Create and return a block device that accesses the flash at the specified offset. The length defaults to the remaining size of the device.

--- a/docs/library/pyb.I2C.rst
+++ b/docs/library/pyb.I2C.rst
@@ -84,7 +84,7 @@ Methods
 
    Turn off the I2C bus.
 
-.. method:: I2C.init(mode, \*, addr=0x12, baudrate=400000, gencall=False, dma=False)
+.. method:: I2C.init(mode, *, addr=0x12, baudrate=400000, gencall=False, dma=False)
 
   Initialise the I2C bus with the given parameters:
 
@@ -100,7 +100,7 @@ Methods
 
    Check if an I2C device responds to the given address.  Only valid when in master mode.
 
-.. method:: I2C.mem_read(data, addr, memaddr, \*, timeout=5000, addr_size=8)
+.. method:: I2C.mem_read(data, addr, memaddr, *, timeout=5000, addr_size=8)
 
    Read from the memory of an I2C device:
 
@@ -113,7 +113,7 @@ Methods
    Returns the read data.
    This is only valid in master mode.
 
-.. method:: I2C.mem_write(data, addr, memaddr, \*, timeout=5000, addr_size=8)
+.. method:: I2C.mem_write(data, addr, memaddr, *, timeout=5000, addr_size=8)
 
    Write to the memory of an I2C device:
 
@@ -126,7 +126,7 @@ Methods
    Returns ``None``.
    This is only valid in master mode.
 
-.. method:: I2C.recv(recv, addr=0x00, \*, timeout=5000)
+.. method:: I2C.recv(recv, addr=0x00, *, timeout=5000)
 
    Receive data on the bus:
 
@@ -138,7 +138,7 @@ Methods
    Return value: if ``recv`` is an integer then a new buffer of the bytes received,
    otherwise the same buffer that was passed in to ``recv``.
 
-.. method:: I2C.send(send, addr=0x00, \*, timeout=5000)
+.. method:: I2C.send(send, addr=0x00, *, timeout=5000)
 
    Send data on the bus:
 

--- a/docs/library/pyb.SPI.rst
+++ b/docs/library/pyb.SPI.rst
@@ -51,7 +51,7 @@ Methods
 
    Turn off the SPI bus.
 
-.. method:: SPI.init(mode, baudrate=328125, \*, prescaler, polarity=1, phase=0, bits=8, firstbit=SPI.MSB, ti=False, crc=None)
+.. method:: SPI.init(mode, baudrate=328125, *, prescaler, polarity=1, phase=0, bits=8, firstbit=SPI.MSB, ti=False, crc=None)
 
    Initialise the SPI bus with the given parameters:
 
@@ -76,7 +76,7 @@ Methods
    Printing the SPI object will show you the computed baudrate and the chosen
    prescaler.
 
-.. method:: SPI.recv(recv, \*, timeout=5000)
+.. method:: SPI.recv(recv, *, timeout=5000)
 
    Receive data on the bus:
 
@@ -87,7 +87,7 @@ Methods
    Return value: if ``recv`` is an integer then a new buffer of the bytes received,
    otherwise the same buffer that was passed in to ``recv``.
 
-.. method:: SPI.send(send, \*, timeout=5000)
+.. method:: SPI.send(send, *, timeout=5000)
 
    Send data on the bus:
 
@@ -96,7 +96,7 @@ Methods
 
    Return value: ``None``.
 
-.. method:: SPI.send_recv(send, recv=None, \*, timeout=5000)
+.. method:: SPI.send_recv(send, recv=None, *, timeout=5000)
 
    Send and receive data on the bus at the same time:
 

--- a/docs/library/pyb.Timer.rst
+++ b/docs/library/pyb.Timer.rst
@@ -62,7 +62,7 @@ Constructors
 Methods
 -------
 
-.. method:: Timer.init(\*, freq, prescaler, period)
+.. method:: Timer.init(*, freq, prescaler, period)
 
    Initialise the timer.  Initialisation must be either by frequency (in Hz)
    or by prescaler and period::

--- a/docs/library/pyb.UART.rst
+++ b/docs/library/pyb.UART.rst
@@ -69,7 +69,7 @@ Constructors
 Methods
 -------
 
-.. method:: UART.init(baudrate, bits=8, parity=None, stop=1, \*, timeout=0, flow=0, timeout_char=0, read_buf_len=64)
+.. method:: UART.init(baudrate, bits=8, parity=None, stop=1, *, timeout=0, flow=0, timeout_char=0, read_buf_len=64)
 
    Initialise the UART bus with the given parameters:
 

--- a/docs/library/pyb.USB_HID.rst
+++ b/docs/library/pyb.USB_HID.rst
@@ -21,7 +21,7 @@ Constructors
 Methods
 -------
 
-.. method:: USB_HID.recv(data, \*, timeout=5000)
+.. method:: USB_HID.recv(data, *, timeout=5000)
 
    Receive data on the bus:
 

--- a/docs/library/pyb.USB_VCP.rst
+++ b/docs/library/pyb.USB_VCP.rst
@@ -21,7 +21,7 @@ Constructors
 Methods
 -------
 
-.. method:: USB_VCP.init(\*, flow=-1)
+.. method:: USB_VCP.init(*, flow=-1)
 
    Configure the USB VCP port.  If the *flow* argument is not -1 then the value sets
    the flow control, which can be a bitwise-or of ``USB_VCP.RTS`` and ``USB_VCP.CTS``.
@@ -89,7 +89,7 @@ Methods
 
    Returns the number of bytes written.
 
-.. method:: USB_VCP.recv(data, \*, timeout=5000)
+.. method:: USB_VCP.recv(data, *, timeout=5000)
 
    Receive data on the bus:
 
@@ -100,7 +100,7 @@ Methods
    Return value: if ``data`` is an integer then a new buffer of the bytes received,
    otherwise the number of bytes read into ``data`` is returned.
 
-.. method:: USB_VCP.send(data, \*, timeout=5000)
+.. method:: USB_VCP.send(data, *, timeout=5000)
 
    Send data over the USB VCP:
 

--- a/docs/library/pyb.rst
+++ b/docs/library/pyb.rst
@@ -210,7 +210,7 @@ Miscellaneous functions
 
    It only makes sense to call this function from within boot.py.
 
-.. function:: mount(device, mountpoint, \*, readonly=False, mkfs=False)
+.. function:: mount(device, mountpoint, *, readonly=False, mkfs=False)
 
    .. note:: This function is deprecated. Mounting and unmounting devices should
       be performed by :meth:`uos.mount` and :meth:`uos.umount` instead.

--- a/docs/library/uasyncio.rst
+++ b/docs/library/uasyncio.rst
@@ -80,7 +80,7 @@ Additional functions
 
     This is a coroutine, and a MicroPython extension.
 
-.. function:: gather(\*awaitables, return_exceptions=False)
+.. function:: gather(*awaitables, return_exceptions=False)
 
     Run all *awaitables* concurrently.  Any *awaitables* that are not tasks are
     promoted to tasks.

--- a/docs/library/uos.rst
+++ b/docs/library/uos.rst
@@ -144,7 +144,7 @@ programs.  Ports that have this functionality provide the :func:`mount` and
 :func:`umount` functions, and possibly various filesystem implementations
 represented by VFS classes.
 
-.. function:: mount(fsobj, mount_point, \*, readonly)
+.. function:: mount(fsobj, mount_point,*, readonly)
 
     Mount the filesystem object *fsobj* at the location in the VFS given by the
     *mount_point* string.  *fsobj* can be a a VFS object that has a ``mount()``


### PR DESCRIPTION
closes #6209