### PR TITLE
travis: Change nrf pca10056 board to build with s140 SoftDevice.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -299,11 +299,11 @@ jobs:
         - sudo apt-get install libnewlib-arm-none-eabi
         - arm-none-eabi-gcc --version
       script:
-        - ports/nrf/drivers/bluetooth/download_ble_stack.sh s132_nrf52_6_1_1
+        - ports/nrf/drivers/bluetooth/download_ble_stack.sh s140_nrf52_6_1_1
         - make ${MAKEOPTS} -C ports/nrf submodules
         - make ${MAKEOPTS} -C ports/nrf BOARD=pca10040
         - make ${MAKEOPTS} -C ports/nrf BOARD=microbit
-        - make ${MAKEOPTS} -C ports/nrf BOARD=pca10056 SD=s132
+        - make ${MAKEOPTS} -C ports/nrf BOARD=pca10056 SD=s140
         - make ${MAKEOPTS} -C ports/nrf BOARD=pca10090
 
     # bare-arm and minimal ports, with size-diff check


### PR DESCRIPTION
It might compile fine with S132 as SoftDevice for nRF52840.
However, there might be different hardware on the SoC which in
turn could make it fail.

SoftDevice S140 is correct BLE stack for nRF52840 SoC and would
provide a more accurate test build.