### PR TITLE
py/obj.h: Fix mp_seq_replace_slice_no_grow to use memmove not memcpy.

### DIFF
--- a/py/obj.h
+++ b/py/obj.h
@@ -992,17 +992,17 @@ bool mp_seq_cmp_objs(mp_uint_t op, const mp_obj_t *items1, size_t len1, const mp
 mp_obj_t mp_seq_index_obj(const mp_obj_t *items, size_t len, size_t n_args, const mp_obj_t *args);
 mp_obj_t mp_seq_count_obj(const mp_obj_t *items, size_t len, mp_obj_t value);
 mp_obj_t mp_seq_extract_slice(size_t len, const mp_obj_t *seq, mp_bound_slice_t *indexes);
+
 // Helper to clear stale pointers from allocated, but unused memory, to preclude GC problems
 #define mp_seq_clear(start, len, alloc_len, item_sz) memset((byte *)(start) + (len) * (item_sz), 0, ((alloc_len) - (len)) * (item_sz))
+
+// Note: dest and slice regions may overlap
 #define mp_seq_replace_slice_no_grow(dest, dest_len, beg, end, slice, slice_len, item_sz) \
-    /*printf("memcpy(%p, %p, %d)\n", dest + beg, slice, slice_len * (item_sz));*/ \
-    memcpy(((char *)dest) + (beg) * (item_sz), slice, slice_len * (item_sz)); \
-    /*printf("memmove(%p, %p, %d)\n", dest + (beg + slice_len), dest + end, (dest_len - end) * (item_sz));*/ \
+    memmove(((char *)dest) + (beg) * (item_sz), slice, slice_len * (item_sz)); \
     memmove(((char *)dest) + (beg + slice_len) * (item_sz), ((char *)dest) + (end) * (item_sz), (dest_len - end) * (item_sz));
 
 // Note: dest and slice regions may overlap
 #define mp_seq_replace_slice_grow_inplace(dest, dest_len, beg, end, slice, slice_len, len_adj, item_sz) \
-    /*printf("memmove(%p, %p, %d)\n", dest + beg + len_adj, dest + beg, (dest_len - beg) * (item_sz));*/ \
     memmove(((char *)dest) + (beg + slice_len) * (item_sz), ((char *)dest) + (end) * (item_sz), ((dest_len) + (len_adj) - ((beg) + (slice_len))) * (item_sz)); \
     memmove(((char *)dest) + (beg) * (item_sz), slice, slice_len * (item_sz));
 

--- a/tests/basics/memoryview1.py
+++ b/tests/basics/memoryview1.py
@@ -54,54 +54,6 @@ print(list(m[1:-1]))
 m[2] = 6
 print(a)
 
-# test slice assignment between memoryviews
-b1 = bytearray(b'1234')
-b2 = bytearray(b'5678')
-b3 = bytearray(b'5678')
-m1 = memoryview(b1)
-m2 = memoryview(b2)
-m3 = memoryview(b3)
-m2[1:3] = m1[0:2]
-print(b2)
-b3[1:3] = m1[0:2]
-print(b3)
-m1[2:4] = b3[1:3]
-print(b1)
-
-try:
-    m2[1:3] = b1[0:4]
-except ValueError:
-    print("ValueError")
-
-try:
-    m2[1:3] = m1[0:4]
-except ValueError:
-    print("ValueError")
-
-try:
-    m2[0:4] = m1[1:3]
-except ValueError:
-    print("ValueError")
-
-# test memoryview of arrays with items sized larger than 1
-a1 = array.array('i', [0]*5)
-m4 = memoryview(a1)
-a2 = array.array('i', [3]*5)
-m5 = memoryview(a2)
-m4[1:3] = m5[1:3]
-print(a1)
-
-try:
-    m4[1:3] = m2[1:3]
-except ValueError:
-    print("ValueError")
-
-# invalid assignment on RHS
-try:
-    memoryview(array.array('i'))[0:2] = b'1234'
-except ValueError:
-    print('ValueError')
-
 # invalid attribute
 try:
     memoryview(b'a').noexist

--- a/tests/basics/memoryview_slice_assign.py
+++ b/tests/basics/memoryview_slice_assign.py
@@ -61,3 +61,27 @@ try:
     memoryview(array.array('i'))[0:2] = b'1234'
 except ValueError:
     print('ValueError')
+
+# test shift left of bytearray
+b = bytearray(range(10))
+mv = memoryview(b)
+mv[1:] = mv[:-1]
+print(b)
+
+# test shift right of bytearray
+b = bytearray(range(10))
+mv = memoryview(b)
+mv[:-1] = mv[1:]
+print(b)
+
+# test shift left of array
+a = array.array('I', range(10))
+mv = memoryview(a)
+mv[1:] = mv[:-1]
+print(a)
+
+# test shift right of array
+a = array.array('I', range(10))
+mv = memoryview(a)
+mv[:-1] = mv[1:]
+print(a)

--- a/tests/basics/memoryview_slice_assign.py
+++ b/tests/basics/memoryview_slice_assign.py
@@ -1,0 +1,63 @@
+# test slice assignment to memoryview
+
+try:
+    memoryview(bytearray(1))[:] = memoryview(bytearray(1))
+except (NameError, TypeError):
+    print("SKIP")
+    raise SystemExit
+
+try:
+    import uarray as array
+except ImportError:
+    try:
+        import array
+    except ImportError:
+        print("SKIP")
+        raise SystemExit
+
+# test slice assignment between memoryviews
+b1 = bytearray(b'1234')
+b2 = bytearray(b'5678')
+b3 = bytearray(b'5678')
+m1 = memoryview(b1)
+m2 = memoryview(b2)
+m3 = memoryview(b3)
+m2[1:3] = m1[0:2]
+print(b2)
+b3[1:3] = m1[0:2]
+print(b3)
+m1[2:4] = b3[1:3]
+print(b1)
+
+# invalid slice assignments
+try:
+    m2[1:3] = b1[0:4]
+except ValueError:
+    print("ValueError")
+try:
+    m2[1:3] = m1[0:4]
+except ValueError:
+    print("ValueError")
+try:
+    m2[0:4] = m1[1:3]
+except ValueError:
+    print("ValueError")
+
+# test memoryview of arrays with items sized larger than 1
+a1 = array.array('i', [0]*5)
+m4 = memoryview(a1)
+a2 = array.array('i', [3]*5)
+m5 = memoryview(a2)
+m4[1:3] = m5[1:3]
+print(a1)
+
+try:
+    m4[1:3] = m2[1:3]
+except ValueError:
+    print("ValueError")
+
+# invalid assignment on RHS
+try:
+    memoryview(array.array('i'))[0:2] = b'1234'
+except ValueError:
+    print('ValueError')


### PR DESCRIPTION
Fixes #6244 