### PR TITLE
py: Fixed case where shifting a memory view right corrupts the contents

### DIFF
--- a/py/obj.h
+++ b/py/obj.h
@@ -996,7 +996,7 @@ mp_obj_t mp_seq_extract_slice(size_t len, const mp_obj_t *seq, mp_bound_slice_t 
 #define mp_seq_clear(start, len, alloc_len, item_sz) memset((byte *)(start) + (len) * (item_sz), 0, ((alloc_len) - (len)) * (item_sz))
 #define mp_seq_replace_slice_no_grow(dest, dest_len, beg, end, slice, slice_len, item_sz) \
     /*printf("memcpy(%p, %p, %d)\n", dest + beg, slice, slice_len * (item_sz));*/ \
-    memcpy(((char *)dest) + (beg) * (item_sz), slice, slice_len * (item_sz)); \
+    memmove(((char *)dest) + (beg) * (item_sz), slice, slice_len * (item_sz)); \
     /*printf("memmove(%p, %p, %d)\n", dest + (beg + slice_len), dest + end, (dest_len - end) * (item_sz));*/ \
     memmove(((char *)dest) + (beg + slice_len) * (item_sz), ((char *)dest) + (end) * (item_sz), (dest_len - end) * (item_sz));
 

--- a/tests/basics/memoryview1.py
+++ b/tests/basics/memoryview1.py
@@ -125,3 +125,9 @@ print(b'cd' == memoryview(b'abcdef')[2:4])
 print(b'cd' != memoryview(b'abcdef')[2:4])
 print(b'xy' == memoryview(b'abcdef')[2:4])
 print(b'xy' != memoryview(b'abcdef')[2:4])
+
+# shift right
+b = bytearray(b'0123456789')
+m = memoryview(b)
+m[1:] = m[:-1]
+print(m == b'0012345678')


### PR DESCRIPTION
The following snippet (added to the tests) demonstrates the failure:

```python
b = bytearray(b'0123456789')
m = memoryview(b)
m[1:] = m[:-1]
print(m == b'0012345678')
```

The errant behaviour was observed on a PYBV11 but works fine on the
unix port.

Fixes #6244 