### PR TITLE
stm32: Disable pydfu.py by default on non-linux ports

### DIFF
--- a/ports/stm32/Makefile
+++ b/ports/stm32/Makefile
@@ -42,7 +42,9 @@ USBDEV_DIR=usbdev
 #USBHOST_DIR=usbhost
 DFU=$(TOP)/tools/dfu.py
 # may need to prefix dfu-util with sudo
+ifeq ($(shell uname -s),Linux)
 USE_PYDFU ?= 1
+endif
 PYDFU ?= $(TOP)/tools/pydfu.py
 DFU_UTIL ?= dfu-util
 BOOTLOADER_DFU_USB_VID ?= 0x0483


### PR DESCRIPTION
pydfu.py uses libusb, which only works under linux.

pydfu.py doesn't work on my Mac since libusb isn't supported there.