### PR TITLE
py/runtime: Do generic lookup if type->attr fails.

### DIFF
--- a/py/obj.h
+++ b/py/obj.h
@@ -553,6 +553,7 @@ struct _mp_obj_type_t {
     //
     // dest[0] = MP_OBJ_NULL means load
     //  return: for fail, do nothing
+    //          for fail but continue lookup in locals_dict, dest[1] = MP_OBJ_SENTINEL
     //          for attr, dest[0] = value
     //          for method, dest[0] = method, dest[1] = self
     //

--- a/py/runtime.c
+++ b/py/runtime.c
@@ -1014,6 +1014,8 @@ STATIC mp_obj_t mp_obj_new_checked_fun(const mp_obj_type_t *type, mp_obj_t fun) 
 // see http://docs.python.org/3/howto/descriptor.html
 // and also https://mail.python.org/pipermail/python-dev/2015-March/138950.html
 void mp_convert_member_lookup(mp_obj_t self, const mp_obj_type_t *type, mp_obj_t member, mp_obj_t *dest) {
+    // clear dest[1] to indicate no special attribute found yet
+    dest[1] = MP_OBJ_NULL;
     if (mp_obj_is_obj(member)) {
         const mp_obj_type_t *m_type = ((mp_obj_base_t *)MP_OBJ_TO_PTR(member))->type;
         if (m_type->flags & MP_TYPE_FLAG_BINDS_SELF) {


### PR DESCRIPTION
If the custom `type->attr` fails, don't give up just yet but look in the
`locals_dict`. This allows `type->attr` to extend rather than completely
replace the lookup.

This is useful for custom builtin classes that have mostly regular
methods but just a few special attributes/properties. This way,
`type->attr` needs to deal with the special cases only and the default
lookup will be used for generic methods.

This is an alternative to https://github.com/micropython/micropython/pull/4969.

The original was perhaps slightly more convenient since no custom
`attr` handler was required, but this is a much smaller change overall.
This new PR is also a bit more generic, as this makes it quite easy to add
properties that do a bit more than just returning an existing attribute.

EDIT: Rebased onto latest master.