### PR TITLE
modbluetooth: Add event for "indicate acknowledgement".

### DIFF
--- a/docs/library/ubluetooth.rst
+++ b/docs/library/ubluetooth.rst
@@ -148,6 +148,10 @@ Event Handling
             elif event == _IRQ_GATTC_INDICATE:
                 # A peripheral has sent an indicate request.
                 conn_handle, value_handle, notify_data = data
+            elif event == _IRQ_GATTS_INDICATE_DONE:
+                # A central has acknowledged the indication.
+                # Note: Status will be zero on successful acknowledgment, implementation-specific value otherwise.
+                conn_handle, value_handle, status = data
 
 The event codes are::
 
@@ -171,6 +175,7 @@ The event codes are::
     _IRQ_GATTC_WRITE_DONE = const(17)
     _IRQ_GATTC_NOTIFY = const(18)
     _IRQ_GATTC_INDICATE = const(19)
+    _IRQ_GATTS_INDICATE_DONE = const(20)
 
 In order to save space in the firmware, these constants are not included on the
 :mod:`ubluetooth` module. Add the ones that you need from the list above to your
@@ -313,8 +318,8 @@ writes from a central to a given characteristic, use
     always send the current local value (as set with :meth:`gatts_write
     <BLE.gatts_write>`).
 
-    **Note:** This does not currently support generating an event for sucessful
-    acknowledgment of the indication.
+    On acknowledgment (or failure, e.g. timeout), the
+    ``_IRQ_GATTS_INDICATE_DONE`` event will be raised.
 
 .. method:: BLE.gatts_set_buffer(value_handle, len, append=False, /)
 

--- a/extmod/btstack/modbluetooth_btstack.c
+++ b/extmod/btstack/modbluetooth_btstack.c
@@ -238,6 +238,37 @@ STATIC mp_btstack_pending_op_t *btstack_finish_pending_operation(uint16_t op_typ
 }
 #endif
 
+// This needs to be separate to btstack_packet_handler otherwise we get
+// dual-delivery of the HCI_EVENT_LE_META event.
+STATIC void btstack_packet_handler_att_server(uint8_t packet_type, uint16_t channel, uint8_t *packet, uint16_t size) {
+    (void)channel;
+    (void)size;
+    DEBUG_EVENT_printf("btstack_packet_handler_att_server(packet_type=%u, packet=%p)\n", packet_type, packet);
+    if (packet_type != HCI_EVENT_PACKET) {
+        return;
+    }
+
+    uint8_t event_type = hci_event_packet_get_type(packet);
+
+    if (event_type == ATT_EVENT_CONNECTED) {
+        DEBUG_EVENT_printf("  --> att connected\n");
+        // The ATT_EVENT_*CONNECTED events are fired for both peripheral and central role, with no way to tell which.
+        // So we use the HCI_EVENT_LE_META event directly in the main packet handler.
+    } else if (event_type == ATT_EVENT_DISCONNECTED) {
+        DEBUG_EVENT_printf("  --> att disconnected\n");
+    } else if (event_type == ATT_EVENT_HANDLE_VALUE_INDICATION_COMPLETE) {
+        DEBUG_EVENT_printf("  --> att indication complete\n");
+        uint16_t conn_handle = att_event_handle_value_indication_complete_get_conn_handle(packet);
+        uint16_t value_handle = att_event_handle_value_indication_complete_get_attribute_handle(packet);
+        uint8_t status = att_event_handle_value_indication_complete_get_status(packet);
+        mp_bluetooth_gatts_on_indicate_complete(conn_handle, value_handle, status);
+    } else if (event_type == HCI_EVENT_LE_META || event_type == HCI_EVENT_DISCONNECTION_COMPLETE) {
+        // Ignore, duplicated by att_server.c.
+    } else {
+        DEBUG_EVENT_printf("  --> hci att server event type: unknown (0x%02x)\n", event_type);
+    }
+}
+
 STATIC void btstack_packet_handler(uint8_t packet_type, uint8_t *packet, uint8_t irq) {
     DEBUG_EVENT_printf("btstack_packet_handler(packet_type=%u, packet=%p)\n", packet_type, packet);
     if (packet_type != HCI_EVENT_PACKET) {
@@ -245,11 +276,8 @@ STATIC void btstack_packet_handler(uint8_t packet_type, uint8_t *packet, uint8_t
     }
 
     uint8_t event_type = hci_event_packet_get_type(packet);
-    if (event_type == ATT_EVENT_CONNECTED) {
-        DEBUG_EVENT_printf("  --> att connected\n");
-    } else if (event_type == ATT_EVENT_DISCONNECTED) {
-        DEBUG_EVENT_printf("  --> att disconnected\n");
-    } else if (event_type == HCI_EVENT_LE_META) {
+
+    if (event_type == HCI_EVENT_LE_META) {
         DEBUG_EVENT_printf("  --> hci le meta\n");
         if (hci_event_le_meta_get_subevent_code(packet) == HCI_SUBEVENT_LE_CONNECTION_COMPLETE) {
             uint16_t conn_handle = hci_subevent_le_connection_complete_get_connection_handle(packet);
@@ -277,7 +305,7 @@ STATIC void btstack_packet_handler(uint8_t packet_type, uint8_t *packet, uint8_t
             mp_bluetooth_btstack_state = MP_BLUETOOTH_BTSTACK_STATE_OFF;
         }
     } else if (event_type == HCI_EVENT_TRANSPORT_PACKET_SENT) {
-        DEBUG_EVENT_printf("  --> hci transport packet set\n");
+        DEBUG_EVENT_printf("  --> hci transport packet sent\n");
     } else if (event_type == HCI_EVENT_COMMAND_COMPLETE) {
         DEBUG_EVENT_printf("  --> hci command complete\n");
     } else if (event_type == HCI_EVENT_COMMAND_STATUS) {
@@ -288,6 +316,8 @@ STATIC void btstack_packet_handler(uint8_t packet_type, uint8_t *packet, uint8_t
         DEBUG_EVENT_printf("  --> btstack # conns changed\n");
     } else if (event_type == HCI_EVENT_VENDOR_SPECIFIC) {
         DEBUG_EVENT_printf("  --> hci vendor specific\n");
+    } else if (event_type == GATT_EVENT_MTU) {
+        DEBUG_EVENT_printf("  --> hci MTU\n");
     } else if (event_type == HCI_EVENT_DISCONNECTION_COMPLETE) {
         DEBUG_EVENT_printf("  --> hci disconnect complete\n");
         uint16_t conn_handle = hci_event_disconnection_complete_get_connection_handle(packet);
@@ -499,6 +529,9 @@ int mp_bluetooth_init(void) {
 
     // Register for HCI events.
     hci_add_event_handler(&hci_event_callback_registration);
+
+    // Register for ATT server events.
+    att_server_register_packet_handler(&btstack_packet_handler_att_server);
 
     // Set a timeout for HCI initialisation.
     btstack_run_loop_set_timer(&btstack_init_deinit_timeout, BTSTACK_INIT_DEINIT_TIMEOUT_MS);
@@ -816,7 +849,8 @@ int mp_bluetooth_gatts_indicate(uint16_t conn_handle, uint16_t value_handle) {
     size_t len = 0;
     mp_bluetooth_gatts_db_read(MP_STATE_PORT(bluetooth_btstack_root_pointers)->gatts_db, value_handle, &data, &len);
 
-    // TODO: Handle ATT_EVENT_HANDLE_VALUE_INDICATION_COMPLETE to generate acknowledgment event.
+    // Indicate will raise ATT_EVENT_HANDLE_VALUE_INDICATION_COMPLETE when
+    // acknowledged (or timeout/error).
 
     // Attempt to send immediately, will copy buffer.
     MICROPY_PY_BLUETOOTH_ENTER

--- a/extmod/btstack/modbluetooth_btstack.h
+++ b/extmod/btstack/modbluetooth_btstack.h
@@ -44,10 +44,11 @@ typedef struct _mp_bluetooth_btstack_root_pointers_t {
     // Characteristic (and descriptor) value storage.
     mp_gatts_db_t gatts_db;
 
+    btstack_linked_list_t pending_ops;
+
     #if MICROPY_PY_BLUETOOTH_ENABLE_CENTRAL_MODE
     // Registration for notify/indicate events.
     gatt_client_notification_t notification;
-    btstack_linked_list_t pending_ops;
     #endif
 } mp_bluetooth_btstack_root_pointers_t;
 

--- a/extmod/modbluetooth.c
+++ b/extmod/modbluetooth.c
@@ -673,6 +673,7 @@ STATIC mp_obj_t bluetooth_ble_gatts_notify(size_t n_args, const mp_obj_t *args) 
 STATIC MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(bluetooth_ble_gatts_notify_obj, 3, 4, bluetooth_ble_gatts_notify);
 
 STATIC mp_obj_t bluetooth_ble_gatts_indicate(mp_obj_t self_in, mp_obj_t conn_handle_in, mp_obj_t value_handle_in) {
+    (void)self_in;
     mp_int_t conn_handle = mp_obj_get_int(conn_handle_in);
     mp_int_t value_handle = mp_obj_get_int(value_handle_in);
 

--- a/extmod/modbluetooth.c
+++ b/extmod/modbluetooth.c
@@ -836,10 +836,12 @@ STATIC void ringbuf_extract(ringbuf_t *ringbuf, mp_obj_tuple_t *data_tuple, size
         // Note the int8_t got packed into the ringbuf as a uint8_t.
         data_tuple->items[j++] = MP_OBJ_NEW_SMALL_INT((int8_t)ringbuf_get(ringbuf));
     }
+    #if MICROPY_PY_BLUETOOTH_ENABLE_CENTRAL_MODE
     if (uuid) {
         ringbuf_get_uuid(ringbuf, uuid);
         data_tuple->items[j++] = MP_OBJ_FROM_PTR(uuid);
     }
+    #endif
     // The code that enqueues into the ringbuf should ensure that it doesn't
     // put more than bt->irq_data_data_alloc bytes into the ringbuf, because
     // that's what's available here in bt->irq_data_bytes.

--- a/extmod/modbluetooth.h
+++ b/extmod/modbluetooth.h
@@ -68,6 +68,7 @@
 #define MP_BLUETOOTH_CHARACTERISTIC_FLAG_WRITE_NO_RESPONSE (1 << 2)
 #define MP_BLUETOOTH_CHARACTERISTIC_FLAG_WRITE    (1 << 3)
 #define MP_BLUETOOTH_CHARACTERISTIC_FLAG_NOTIFY   (1 << 4)
+#define MP_BLUETOOTH_CHARACTERISTIC_FLAG_INDICATE (1 << 5)
 
 // For mp_bluetooth_gattc_write, the mode parameter
 #define MP_BLUETOOTH_WRITE_MODE_NO_RESPONSE     (0)
@@ -107,6 +108,7 @@
 #define MP_BLUETOOTH_IRQ_GATTC_WRITE_DONE               (17)
 #define MP_BLUETOOTH_IRQ_GATTC_NOTIFY                   (18)
 #define MP_BLUETOOTH_IRQ_GATTC_INDICATE                 (19)
+#define MP_BLUETOOTH_IRQ_GATTS_INDICATE_DONE            (20)
 
 /*
 These aren't included in the module for space reasons, but can be used
@@ -132,6 +134,7 @@ _IRQ_GATTC_READ_DONE = const(16)
 _IRQ_GATTC_WRITE_DONE = const(17)
 _IRQ_GATTC_NOTIFY = const(18)
 _IRQ_GATTC_INDICATE = const(19)
+_IRQ_GATTS_INDICATE_DONE = const(20)
 */
 
 // Common UUID type.
@@ -244,6 +247,9 @@ void mp_bluetooth_gap_on_connected_disconnected(uint8_t event, uint16_t conn_han
 
 // Call this when a characteristic is written to.
 void mp_bluetooth_gatts_on_write(uint16_t conn_handle, uint16_t value_handle);
+
+// Call this when an acknowledgment is received for an indication.
+void mp_bluetooth_gatts_on_indicate_complete(uint16_t conn_handle, uint16_t value_handle, uint8_t status);
 
 #if MICROPY_PY_BLUETOOTH_GATTS_ON_READ_CALLBACK
 // Call this when a characteristic is read from. Return false to deny the read.

--- a/extmod/nimble/modbluetooth_nimble.c
+++ b/extmod/nimble/modbluetooth_nimble.c
@@ -96,6 +96,13 @@ STATIC ble_uuid_t *create_nimble_uuid(const mp_obj_bluetooth_uuid_t *uuid, ble_u
     }
 }
 
+// modbluetooth (and the layers above it) work in BE for addresses, Nimble works in LE.
+STATIC void reverse_addr_byte_order(uint8_t *addr_out, const uint8_t *addr_in) {
+    for (int i = 0; i < 6; ++i) {
+        addr_out[i] = addr_in[5 - i];
+    }
+}
+
 #if MICROPY_PY_BLUETOOTH_ENABLE_CENTRAL_MODE
 
 STATIC mp_obj_bluetooth_uuid_t create_mp_uuid(const ble_uuid_any_t *uuid) {
@@ -121,13 +128,6 @@ STATIC mp_obj_bluetooth_uuid_t create_mp_uuid(const ble_uuid_any_t *uuid) {
             assert(false);
     }
     return result;
-}
-
-// modbluetooth (and the layers above it) work in BE for addresses, Nimble works in LE.
-STATIC void reverse_addr_byte_order(uint8_t *addr_out, const uint8_t *addr_in) {
-    for (int i = 0; i < 6; ++i) {
-        addr_out[i] = addr_in[5 - i];
-    }
 }
 
 STATIC ble_addr_t create_nimble_addr(uint8_t addr_type, const uint8_t *addr) {

--- a/tests/multi_bluetooth/ble_characteristic.py
+++ b/tests/multi_bluetooth/ble_characteristic.py
@@ -17,12 +17,13 @@ _IRQ_GATTC_READ_DONE = const(16)
 _IRQ_GATTC_WRITE_DONE = const(17)
 _IRQ_GATTC_NOTIFY = const(18)
 _IRQ_GATTC_INDICATE = const(19)
+_IRQ_GATTS_INDICATE_DONE = const(20)
 
 SERVICE_UUID = bluetooth.UUID("A5A5A5A5-FFFF-9999-1111-5A5A5A5A5A5A")
 CHAR_UUID = bluetooth.UUID("00000000-1111-2222-3333-444444444444")
 CHAR = (
     CHAR_UUID,
-    bluetooth.FLAG_READ | bluetooth.FLAG_WRITE | bluetooth.FLAG_NOTIFY,
+    bluetooth.FLAG_READ | bluetooth.FLAG_WRITE | bluetooth.FLAG_NOTIFY | bluetooth.FLAG_INDICATE,
 )
 SERVICE = (
     SERVICE_UUID,
@@ -62,6 +63,8 @@ def irq(event, data):
         print("_IRQ_GATTC_NOTIFY", data[-1])
     elif event == _IRQ_GATTC_INDICATE:
         print("_IRQ_GATTC_INDICATE", data[-1])
+    elif event == _IRQ_GATTS_INDICATE_DONE:
+        print("_IRQ_GATTS_INDICATE_DONE", data[-1])
 
     if waiting_event is not None:
         if (isinstance(waiting_event, int) and event == waiting_event) or (
@@ -127,6 +130,9 @@ def instance0():
         ble.gatts_write(char_handle, "periph3")
         print("gatts_indicate")
         ble.gatts_indicate(conn_handle, char_handle)
+
+        # Wait for the indicate ack.
+        wait_for_event(_IRQ_GATTS_INDICATE_DONE, TIMEOUT_MS)
 
         # Wait for the central to disconnect.
         wait_for_event(_IRQ_CENTRAL_DISCONNECT, TIMEOUT_MS)

--- a/tests/multi_bluetooth/ble_characteristic.py.exp
+++ b/tests/multi_bluetooth/ble_characteristic.py.exp
@@ -9,6 +9,7 @@ gatts_notify
 _IRQ_GATTS_WRITE b'central2'
 gatts_write
 gatts_indicate
+_IRQ_GATTS_INDICATE_DONE 0
 _IRQ_CENTRAL_DISCONNECT
 --- instance1 ---
 gap_connect


### PR DESCRIPTION
Added `IRQ_GATTS_INDICATE_DONE` which will be raised with the status of an `gatts_indicate`. (Unlike notify, indications require acknowledgement).

Added example to ble_temperature.py and to the multitests in ble_characteristic.py.

Implemented for btstack and nimble, tested in both directions between unix/btstack and pybd/nimble.
