### PR TITLE
lib/libc: Fix string0's implementation of strncpy.

### DIFF
--- a/lib/libc/string0.c
+++ b/lib/libc/string0.c
@@ -178,8 +178,10 @@ char *strncpy(char *s1, const char *s2, size_t n) {
      while (n > 0) {
          n--;
          if ((*dst++ = *src++) == '\0') {
-             /* If we get here, we found a null character at the end of s2 */
-             *dst = '\0';
+             /* If we get here, we found a null character at the end
+                of s2, so use memset to put null bytes at the end of
+                s1.  */
+             memset(dst, '\0', n);
              break;
          }
      }


### PR DESCRIPTION
Fixing 98e583430fb7b793119db27bad9f98119e81579f, the semantics of strncpy require that the remainder of dst be filled with null bytes.

Thanks to @robert-hh for picking this up.