### PR TITLE
py/compile: Do not await __aiter__ special method return value.

### DIFF
--- a/py/compile.c
+++ b/py/compile.c
@@ -1798,7 +1798,8 @@ STATIC void compile_async_for_stmt(compiler_t *comp, mp_parse_node_struct_t *pns
     uint try_finally_label = comp_next_label(comp);
 
     compile_node(comp, pns->nodes[1]); // iterator
-    compile_await_object_method(comp, MP_QSTR___aiter__);
+    EMIT_ARG(load_method, MP_QSTR___aiter__, false);
+    EMIT_ARG(call_method, 0, 0, 0);
     compile_store_id(comp, context);
 
     START_BREAK_CONTINUE_BLOCK

--- a/tests/basics/async_for.py
+++ b/tests/basics/async_for.py
@@ -6,7 +6,7 @@ class AsyncIteratorWrapper:
         print('init')
         self._it = iter(obj)
 
-    async def __aiter__(self):
+    def __aiter__(self):
         print('aiter')
         return self
 

--- a/tests/basics/async_for2.py
+++ b/tests/basics/async_for2.py
@@ -21,9 +21,8 @@ class ARange:
         self.cur = 0
         self.high = high
 
-    async def __aiter__(self):
+    def __aiter__(self):
         print('aiter')
-        print('f returned:', await f(10))
         return self
 
     async def __anext__(self):

--- a/tests/basics/async_for2.py.exp
+++ b/tests/basics/async_for2.py.exp
@@ -1,9 +1,5 @@
 init
 aiter
-f start: 10
-coro yielded: 11
-coro yielded: 12
-f returned: 13
 anext
 f start: 20
 coro yielded: 21


### PR DESCRIPTION
As per discussion in #6267, the final PEP492 spec says that the `__aiter__()` method should not return an awaitable. This PR changes the compiler to not compile in an await and updates the async for tests to match.

Note that the test in `async_for2.py` has had to be more modified in behaviour as well as syntax as it can no longer yield in the `__aiter__()` method. I've just removed the call to `await f()` and the matching output completely.

Have run the UNIX port tests successfully on macOS and also tested with my own async iterable code on the ESP32 port.

**Note:** This will be a breaking change to any (not precompiled) code that currently defines `__aiter__` methods using `await`.