### PR TITLE
stm32/usbdev: Fix calculation of SCSI LUN size with multiple LUNs.

### DIFF
--- a/ports/stm32/usbd_msc_interface.h
+++ b/ports/stm32/usbd_msc_interface.h
@@ -26,8 +26,6 @@
 #ifndef MICROPY_INCLUDED_STM32_USBD_MSC_INTERFACE_H
 #define MICROPY_INCLUDED_STM32_USBD_MSC_INTERFACE_H
 
-#define USBD_MSC_MAX_LUN (2)
-
 extern const USBD_StorageTypeDef usbd_msc_fops;
 
 void usbd_msc_init_lu(size_t lu_n, const void *lu_data);

--- a/ports/stm32/usbdev/class/inc/usbd_cdc_msc_hid.h
+++ b/ports/stm32/usbdev/class/inc/usbd_cdc_msc_hid.h
@@ -34,6 +34,9 @@
 #define MSC_MEDIA_PACKET            (2048) // was 8192; how low can it go whilst still working?
 #define HID_DATA_FS_MAX_PACKET_SIZE (64) // endpoint IN & OUT packet size
 
+// Maximum number of LUN that can be exposed on the MSC interface
+#define USBD_MSC_MAX_LUN (2)
+
 // Need to define here for BOT and SCSI layers
 #define MSC_IN_EP     (0x81)
 #define MSC_OUT_EP    (0x01)
@@ -78,8 +81,8 @@ typedef struct {
   uint8_t                  scsi_sense_head;
   uint8_t                  scsi_sense_tail;
   
-  uint16_t                 scsi_blk_size;
-  uint32_t                 scsi_blk_nbr;
+  uint16_t                 scsi_blk_size[USBD_MSC_MAX_LUN];
+  uint32_t                 scsi_blk_nbr[USBD_MSC_MAX_LUN];
   
   uint32_t                 scsi_blk_addr_in_blks;
   uint32_t                 scsi_blk_len;


### PR DESCRIPTION
The SCSI driver calls GetCapacity to get the block size and number of blocks of the underlying block-device/LUN.  It caches these values and uses them later on to verify that reads/writes are within the bounds of the LUN.  But, prior to this commit, there was only one set of cached values for all LUNs, so the bounds checking for a LUN could use incorrect values, values from one of the other LUNs that most recently updated the cached values.  This would lead to failed SCSI requests.

This commit fixes this issue by having separate cached values for each LUN.