### PR TITLE
esp32/esp32_rmt: New RMT capabilities.

### DIFF
--- a/docs/library/esp32.rst
+++ b/docs/library/esp32.rst
@@ -150,14 +150,13 @@ used to transmit or receive many other types of digital signals::
     from machine import Pin
 
     r = esp32.RMT(0, pin=Pin(18), clock_div=8)
-    r  # RMT(channel=0, pin=18, source_freq=80000000, clock_div=8)
+    r  # RMT(channel=0, pin=18, source_freq=80000000, clock_div=8, idle_level=0)
 
-    # To use carrier frequency
-    r = esp32.RMT(0, pin=Pin(18), clock_div=8, carrier_freq=38000)
-    r  # RMT(channel=0, pin=18, source_freq=80000000, clock_div=8, carrier_freq=38000, carrier_duty_percent=50)
+    # To apply a carrier frequency to the high output
+    r = esp32.RMT(0, pin=Pin(18), clock_div=8, tx_carrier=(38000, 50, 1))
 
     # The channel resolution is 100ns (1/(source_freq/clock_div)).
-    r.write_pulses((1, 20, 2, 40), start=0)  # Send 0 for 100ns, 1 for 2000ns, 0 for 200ns, 1 for 4000ns
+    r.write_pulses((1, 20, 2, 40), 0)  # Send 0 for 100ns, 1 for 2000ns, 0 for 200ns, 1 for 4000ns
 
 The input to the RMT module is an 80MHz clock (in the future it may be able to
 configure the input clock but, for now, it's fixed). ``clock_div`` *divides*
@@ -168,9 +167,6 @@ define the pulses.
 ``clock_div`` is an 8-bit divider (0-255) and each pulse can be defined by
 multiplying the resolution by a 15-bit (0-32,768) number. There are eight
 channels (0-7) and each can have a different clock divider.
-
-To enable the carrier frequency feature of the esp32 hardware, specify the
-``carrier_freq`` as something like 38000, a typical IR carrier frequency.
 
 So, in the example above, the 80MHz clock is divided by 8. Thus the
 resolution is (1/(80Mhz/8)) 100ns. Since the ``start`` level is 0 and toggles
@@ -186,16 +182,22 @@ For more details see Espressif's `ESP-IDF RMT documentation.
    *beta feature* and the interface may change in the future.
 
 
-.. class:: RMT(channel, *, pin=None, clock_div=8, carrier_freq=0, carrier_duty_percent=50)
+.. class:: RMT(channel, *, pin=None, clock_div=8, idle_level=False,
+               tx_carrier=None)
 
     This class provides access to one of the eight RMT channels. *channel* is
     required and identifies which RMT channel (0-7) will be configured. *pin*,
     also required, configures which Pin is bound to the RMT channel. *clock_div*
     is an 8-bit clock divider that divides the source clock (80MHz) to the RMT
-    channel allowing the resolution to be specified. *carrier_freq* is used to
-    enable the carrier feature and specify its frequency, default value is ``0``
-    (not enabled).  To enable, specify a positive integer.  *carrier_duty_percent*
-    defaults to 50.
+    channel allowing the resolution to be specified. *idle_level* specifies
+    what level the output will be when no transmission is in progress and can
+    be any value that converts to a boolean, with ``True`` representing high
+    voltage and ``False`` representing low.
+
+    To enable the transmission carrier feature, *tx_carrier* should be a tuple
+    of three positive integers: carrier frequency, duty percent (``0`` to
+    ``100``) and the output level to apply the carrier to (a boolean as per
+    *idle_level*).
 
 .. method:: RMT.source_freq()
 
@@ -207,39 +209,47 @@ For more details see Espressif's `ESP-IDF RMT documentation.
     Return the clock divider. Note that the channel resolution is
     ``1 / (source_freq / clock_div)``.
 
-.. method:: RMT.wait_done(timeout=0)
+.. method:: RMT.wait_done(*, timeout=0)
 
-    Returns ``True`` if the channel is currently transmitting a stream of pulses
-    started with a call to `RMT.write_pulses`.
-
-    If *timeout* (defined in ticks of ``source_freq / clock_div``) is specified
-    the method will wait for *timeout* or until transmission is complete,
-    returning ``False`` if the channel continues to transmit. If looping is
-    enabled with `RMT.loop` and a stream has started, then this method will
-    always (wait and) return ``False``.
+    Returns ``True`` if the channel is idle or ``False`` if a sequence of
+    pulses started with `RMT.write_pulses` is being transmitted. If the
+    *timeout* keyword argument is given then block for up to this many
+    milliseconds for transmission to complete.
 
 .. method:: RMT.loop(enable_loop)
 
     Configure looping on the channel. *enable_loop* is bool, set to ``True`` to
     enable looping on the *next* call to `RMT.write_pulses`. If called with
-    ``False`` while a looping stream is currently being transmitted then the
-    current set of pulses will be completed before transmission stops.
+    ``False`` while a looping sequence is currently being transmitted then the
+    current loop iteration will be completed and then transmission will stop.
 
-.. method:: RMT.write_pulses(pulses, start)
+.. method:: RMT.write_pulses(duration, data=True)
 
-    Begin sending *pulses*, a list or tuple defining the stream of pulses. The
-    length of each pulse is defined by a number to be multiplied by the channel
-    resolution ``(1 / (source_freq / clock_div))``. *start* defines whether the
-    stream starts at 0 or 1.
+    Begin transmitting a sequence. There are three ways to specify this:
 
-    If transmission of a stream is currently in progress then this method will
-    block until transmission of that stream has ended before beginning sending
-    *pulses*.
+    **Mode 1:** *duration* is a list or tuple of durations. The optional *data*
+    argument specifies the initial output level. The output level will toggle
+    after each duration.
 
-    If looping is enabled with `RMT.loop`, the stream of pulses will be repeated
-    indefinitely. Further calls to `RMT.write_pulses` will end the previous
-    stream - blocking until the last set of pulses has been transmitted -
-    before starting the next stream.
+    **Mode 2:** *duration* is a positive integer and *data* is a list or tuple
+    of output levels. *duration* specifies a fixed duration for each.
+
+    **Mode 3:** *duration* and *data* are lists or tuples of equal length,
+    specifying individual durations and the output level for each.
+
+    Durations are in integer units of the channel resolution (as described
+    above), between 1 and 32767 units. Output levels are any value that can
+    be converted to a boolean, with ``True`` representing high voltage and
+    ``False`` representing low.
+
+    If transmission of an earlier sequence is in progress then this method will
+    block until that transmission is complete before beginning the new sequence.
+
+    If looping has been enabled with `RMT.loop`, the sequence will be
+    repeated indefinitely. Further calls to this method will block until the
+    end of the current loop iteration before immediately beginning to loop the
+    new sequence of pulses. Looping sequences longer than 126 pulses is not
+    supported by the hardware.
 
 
 Ultra-Low-Power co-processor

--- a/ports/esp32/esp32_rmt.c
+++ b/ports/esp32/esp32_rmt.c
@@ -52,8 +52,6 @@ typedef struct _esp32_rmt_obj_t {
     uint8_t channel_id;
     gpio_num_t pin;
     uint8_t clock_div;
-    uint16_t carrier_duty_percent;
-    uint32_t carrier_freq;
     mp_uint_t num_items;
     rmt_item32_t *items;
     bool loop_en;
@@ -64,24 +62,16 @@ STATIC mp_obj_t esp32_rmt_make_new(const mp_obj_type_t *type, size_t n_args, siz
         { MP_QSTR_id,        MP_ARG_REQUIRED | MP_ARG_INT, {.u_int = -1} },
         { MP_QSTR_pin,       MP_ARG_REQUIRED | MP_ARG_KW_ONLY | MP_ARG_OBJ, {.u_obj = mp_const_none} },
         { MP_QSTR_clock_div,                   MP_ARG_KW_ONLY | MP_ARG_INT, {.u_int = 8} }, // 100ns resolution
-        { MP_QSTR_carrier_duty_percent,        MP_ARG_KW_ONLY | MP_ARG_INT, {.u_int = 50} },
-        { MP_QSTR_carrier_freq,                MP_ARG_KW_ONLY | MP_ARG_INT, {.u_int = 0} },
+        { MP_QSTR_idle_level,                  MP_ARG_KW_ONLY | MP_ARG_BOOL, {.u_bool = false} }, // low voltage
+        { MP_QSTR_tx_carrier,                  MP_ARG_KW_ONLY | MP_ARG_OBJ, {.u_obj = mp_const_none} }, // no carrier
     };
     mp_arg_val_t args[MP_ARRAY_SIZE(allowed_args)];
     mp_arg_parse_all_kw_array(n_args, n_kw, all_args, MP_ARRAY_SIZE(allowed_args), allowed_args, args);
     mp_uint_t channel_id = args[0].u_int;
     gpio_num_t pin_id = machine_pin_get_id(args[1].u_obj);
     mp_uint_t clock_div = args[2].u_int;
-
-    bool carrier_en = false;
-    mp_uint_t carrier_duty_percent = 0;
-    mp_uint_t carrier_freq = 0;
-
-    if (args[4].u_int > 0) {
-        carrier_en = true;
-        carrier_duty_percent = args[3].u_int;
-        carrier_freq = args[4].u_int;
-    }
+    mp_uint_t idle_level = args[3].u_bool;
+    mp_obj_t tx_carrier_obj = args[4].u_obj;
 
     if (clock_div < 1 || clock_div > 255) {
         mp_raise_ValueError(MP_ERROR_TEXT("clock_div must be between 1 and 255"));
@@ -92,8 +82,6 @@ STATIC mp_obj_t esp32_rmt_make_new(const mp_obj_type_t *type, size_t n_args, siz
     self->channel_id = channel_id;
     self->pin = pin_id;
     self->clock_div = clock_div;
-    self->carrier_duty_percent = carrier_duty_percent;
-    self->carrier_freq = carrier_freq;
     self->loop_en = false;
 
     rmt_config_t config = {0};
@@ -103,12 +91,30 @@ STATIC mp_obj_t esp32_rmt_make_new(const mp_obj_type_t *type, size_t n_args, siz
     config.mem_block_num = 1;
     config.tx_config.loop_en = 0;
 
-    config.tx_config.carrier_en = carrier_en;
+    if (tx_carrier_obj != mp_const_none) {
+        mp_obj_t *tx_carrier_details = NULL;
+        mp_obj_get_array_fixed_n(tx_carrier_obj, 3, &tx_carrier_details);
+        mp_uint_t frequency = mp_obj_get_int(tx_carrier_details[0]);
+        mp_uint_t duty = mp_obj_get_int(tx_carrier_details[1]);
+        mp_uint_t level = mp_obj_is_true(tx_carrier_details[2]);
+
+        if (frequency == 0) {
+            mp_raise_ValueError(MP_ERROR_TEXT("tx_carrier frequency must be >0"));
+        }
+        if (duty > 100) {
+            mp_raise_ValueError(MP_ERROR_TEXT("tx_carrier duty must be 0..100"));
+        }
+
+        config.tx_config.carrier_en = 1;
+        config.tx_config.carrier_freq_hz = frequency;
+        config.tx_config.carrier_duty_percent = duty;
+        config.tx_config.carrier_level = level;
+    } else {
+        config.tx_config.carrier_en = 0;
+    }
+
     config.tx_config.idle_output_en = 1;
-    config.tx_config.idle_level = 0;
-    config.tx_config.carrier_duty_percent = self->carrier_duty_percent;
-    config.tx_config.carrier_freq_hz = self->carrier_freq;
-    config.tx_config.carrier_level = 1;
+    config.tx_config.idle_level = idle_level;
 
     config.clk_div = self->clock_div;
 
@@ -121,14 +127,11 @@ STATIC mp_obj_t esp32_rmt_make_new(const mp_obj_type_t *type, size_t n_args, siz
 STATIC void esp32_rmt_print(const mp_print_t *print, mp_obj_t self_in, mp_print_kind_t kind) {
     esp32_rmt_obj_t *self = MP_OBJ_TO_PTR(self_in);
     if (self->pin != -1) {
-        mp_printf(print, "RMT(channel=%u, pin=%u, source_freq=%u, clock_div=%u",
-            self->channel_id, self->pin, APB_CLK_FREQ, self->clock_div);
-        if (self->carrier_freq > 0) {
-            mp_printf(print, ", carrier_freq=%u, carrier_duty_percent=%u)",
-                self->carrier_freq, self->carrier_duty_percent);
-        } else {
-            mp_printf(print, ")");
-        }
+        bool idle_output_en;
+        rmt_idle_level_t idle_level;
+        check_esp_err(rmt_get_idle_level(self->channel_id, &idle_output_en, &idle_level));
+        mp_printf(print, "RMT(channel=%u, pin=%u, source_freq=%u, clock_div=%u, idle_level=%u)",
+            self->channel_id, self->pin, APB_CLK_FREQ, self->clock_div, idle_level);
     } else {
         mp_printf(print, "RMT()");
     }
@@ -162,7 +165,7 @@ STATIC mp_obj_t esp32_rmt_clock_div(mp_obj_t self_in) {
 STATIC MP_DEFINE_CONST_FUN_OBJ_1(esp32_rmt_clock_div_obj, esp32_rmt_clock_div);
 
 // Query whether the channel has finished sending pulses. Takes an optional
-// timeout (in ticks of the 80MHz clock), returning true if the pulse stream has
+// timeout (in milliseconds), returning true if the pulse stream has
 // completed or false if they are still transmitting (or timeout is reached).
 STATIC mp_obj_t esp32_rmt_wait_done(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
     static const mp_arg_t allowed_args[] = {
@@ -175,7 +178,7 @@ STATIC mp_obj_t esp32_rmt_wait_done(size_t n_args, const mp_obj_t *pos_args, mp_
 
     esp32_rmt_obj_t *self = MP_OBJ_TO_PTR(args[0].u_obj);
 
-    esp_err_t err = rmt_wait_tx_done(self->channel_id, args[1].u_int);
+    esp_err_t err = rmt_wait_tx_done(self->channel_id, args[1].u_int / portTICK_PERIOD_MS);
     return err == ESP_OK ? mp_const_true : mp_const_false;
 }
 STATIC MP_DEFINE_CONST_FUN_OBJ_KW(esp32_rmt_wait_done_obj, 1, esp32_rmt_wait_done);
@@ -195,45 +198,63 @@ STATIC mp_obj_t esp32_rmt_loop(mp_obj_t self_in, mp_obj_t loop) {
 }
 STATIC MP_DEFINE_CONST_FUN_OBJ_2(esp32_rmt_loop_obj, esp32_rmt_loop);
 
-STATIC mp_obj_t esp32_rmt_write_pulses(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
-    static const mp_arg_t allowed_args[] = {
-        { MP_QSTR_self,   MP_ARG_REQUIRED | MP_ARG_OBJ, {.u_obj = mp_const_none} },
-        { MP_QSTR_pulses, MP_ARG_REQUIRED | MP_ARG_OBJ, {.u_obj = mp_const_none} },
-        { MP_QSTR_start,  MP_ARG_KW_ONLY | MP_ARG_INT, {.u_int = 1} },
-    };
+STATIC mp_obj_t esp32_rmt_write_pulses(size_t n_args, const mp_obj_t *args) {
+    esp32_rmt_obj_t *self = MP_OBJ_TO_PTR(args[0]);
+    mp_obj_t duration_obj = args[1];
+    mp_obj_t data_obj = n_args > 2 ? args[2] : mp_const_true;
 
-    mp_arg_val_t args[MP_ARRAY_SIZE(allowed_args)];
-    mp_arg_parse_all(n_args, pos_args, kw_args, MP_ARRAY_SIZE(allowed_args), allowed_args, args);
+    mp_uint_t duration = 0;
+    size_t duration_length = 0;
+    mp_obj_t *duration_ptr = NULL;
+    mp_uint_t data = 0;
+    size_t data_length = 0;
+    mp_obj_t *data_ptr = NULL;
+    mp_uint_t num_pulses = 0;
 
-    esp32_rmt_obj_t *self = MP_OBJ_TO_PTR(args[0].u_obj);
-    mp_obj_t pulses = args[1].u_obj;
-    mp_uint_t start = args[2].u_int;
-
-    if (start > 1) {
-        mp_raise_ValueError(MP_ERROR_TEXT("start must be 0 or 1"));
+    if (!(mp_obj_is_type(data_obj, &mp_type_tuple) || mp_obj_is_type(data_obj, &mp_type_list))) {
+        // Mode 1: array of durations, toggle initial data value
+        mp_obj_get_array(duration_obj, &duration_length, &duration_ptr);
+        data = mp_obj_is_true(data_obj);
+        num_pulses = duration_length;
+    } else if (mp_obj_is_int(duration_obj)) {
+        // Mode 2: constant duration, array of data values
+        duration = mp_obj_get_int(duration_obj);
+        mp_obj_get_array(data_obj, &data_length, &data_ptr);
+        num_pulses = data_length;
+    } else {
+        // Mode 3: arrays of durations and data values
+        mp_obj_get_array(duration_obj, &duration_length, &duration_ptr);
+        mp_obj_get_array(data_obj, &data_length, &data_ptr);
+        if (duration_length != data_length) {
+            mp_raise_ValueError(MP_ERROR_TEXT("duration and data must have same length"));
+        }
+        num_pulses = duration_length;
     }
 
-    size_t pulses_length = 0;
-    mp_obj_t *pulses_ptr = NULL;
-    mp_obj_get_array(pulses, &pulses_length, &pulses_ptr);
-
-    mp_uint_t num_items = (pulses_length / 2) + (pulses_length % 2);
-    if (self->loop_en && num_items > 63) {
-        mp_raise_ValueError(MP_ERROR_TEXT("too many pulses for loop"));
+    if (num_pulses == 0) {
+        mp_raise_ValueError(MP_ERROR_TEXT("No pulses"));
+    }
+    if (self->loop_en && num_pulses > 126) {
+        mp_raise_ValueError(MP_ERROR_TEXT("Too many pulses for loop"));
     }
 
+    mp_uint_t num_items = (num_pulses / 2) + (num_pulses % 2);
     if (num_items > self->num_items) {
         self->items = (rmt_item32_t *)m_realloc(self->items, num_items * sizeof(rmt_item32_t *));
         self->num_items = num_items;
     }
 
-    for (mp_uint_t item_index = 0; item_index < num_items; item_index++) {
-        mp_uint_t pulse_index = item_index * 2;
-        self->items[item_index].duration0 = mp_obj_get_int(pulses_ptr[pulse_index++]);
-        self->items[item_index].level0 = start++; // Note that start _could_ wrap.
-        if (pulse_index < pulses_length) {
-            self->items[item_index].duration1 = mp_obj_get_int(pulses_ptr[pulse_index]);
-            self->items[item_index].level1 = start++;
+    for (mp_uint_t item_index = 0, pulse_index = 0; item_index < num_items; item_index++) {
+        self->items[item_index].duration0 = duration_length ? mp_obj_get_int(duration_ptr[pulse_index]) : duration;
+        self->items[item_index].level0 = data_length ? mp_obj_is_true(data_ptr[pulse_index]) : data++;
+        pulse_index++;
+        if (pulse_index < num_pulses) {
+            self->items[item_index].duration1 = duration_length ? mp_obj_get_int(duration_ptr[pulse_index]) : duration;
+            self->items[item_index].level1 = data_length ? mp_obj_is_true(data_ptr[pulse_index]) : data++;
+            pulse_index++;
+        } else {
+            self->items[item_index].duration1 = 0;
+            self->items[item_index].level1 = 0;
         }
     }
 
@@ -247,7 +268,7 @@ STATIC mp_obj_t esp32_rmt_write_pulses(size_t n_args, const mp_obj_t *pos_args, 
         check_esp_err(rmt_wait_tx_done(self->channel_id, portMAX_DELAY));
     }
 
-    check_esp_err(rmt_write_items(self->channel_id, self->items, num_items, false /* non-blocking */));
+    check_esp_err(rmt_write_items(self->channel_id, self->items, num_items, false));
 
     if (self->loop_en) {
         check_esp_err(rmt_set_tx_intr_en(self->channel_id, false));
@@ -256,7 +277,7 @@ STATIC mp_obj_t esp32_rmt_write_pulses(size_t n_args, const mp_obj_t *pos_args, 
 
     return mp_const_none;
 }
-STATIC MP_DEFINE_CONST_FUN_OBJ_KW(esp32_rmt_write_pulses_obj, 2, esp32_rmt_write_pulses);
+STATIC MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(esp32_rmt_write_pulses_obj, 2, 3, esp32_rmt_write_pulses);
 
 STATIC const mp_rom_map_elem_t esp32_rmt_locals_dict_table[] = {
     { MP_ROM_QSTR(MP_QSTR___del__), MP_ROM_PTR(&esp32_rmt_deinit_obj) },


### PR DESCRIPTION
Following on from discussion in mattytrentini#11, I've picked up @mattytrentini's new RMT capabilities: new, better `tx_carrier` specification; `idle_level` setting; and more flexible ways of specifying pulses in `write_pulses()`.

Following on a "fixme" question in the working code, I implemented the ability to disable idle output (`config.tx_config.idle_output_en = 0`) by supplying `idle_level=None` when constructing the `RMT` object. However, I am unable to actually see this do anything useful when testing on real hardware with an oscilloscope.

I had naively assumed that it would leave the output high impedance when not transmitting, but as far as I can see the output still sits at 0V when idle. Trying with a TX carrier enabled also shows that the carrier continues to be generated when idle as well, so it doesn't control that. What is this setting actually for? The ESP-IDF documentation says nothing on the matter other than `idle_output_en` "[enables] the RMT output if idle". You got any experience of this @mattytrentini? If nobody knows what it's meant to do, I may take this logic back out again.

I have run a load of tests on an ESP32 board and everything else here seems to work as I would expect. Documentation has been updated to match the new logic.

Also, I have a question for @dpgeorge on error checking: following @mattytrentini's lead, I've put in fairly extensive parameter checking with useful error messages. However, is it preferable to be a bit simpler and more terse in order to keep the binary size down? I've seen other files where all the errors are just something like "parameter error".