### PR TITLE
stm32/nimble: Don't process background event queue until stack is active.

### DIFF
--- a/ports/stm32/nimble.c
+++ b/ports/stm32/nimble.c
@@ -47,8 +47,11 @@ void mp_bluetooth_hci_poll(void) {
     }
 
     mp_bluetooth_nimble_hci_uart_process();
+
     os_callout_process();
-    os_eventq_run_all();
+    if (mp_bluetooth_nimble_ble_state == MP_BLUETOOTH_NIMBLE_BLE_STATE_ACTIVE) {
+        os_eventq_run_all();
+    }
 }
 
 void mp_bluetooth_nimble_port_preinit(void) {


### PR DESCRIPTION
Resolves https://github.com/micropython/micropython/issues/6269

I still haven't confirmed whether this is a "correct" fix for the issue, however my mynewt/nimble based hci radio sometimes causes the assert in the linked issue without this change, but never throws the issue with it.
My pybd seems to work fine with the change too.
It does warrant some further investigation however.

To the best of my understanding, the assert is in a timer expired function. I think the timer is started near the top of the ble_hs_startup_go() function, but is serviced in the background event loop.

If that ble_hs_startup_go() function takes long enough the timer expires, the expiry callback is called in the background task.
That's not allowed to happen during BLE_HS_SYNC_STATE_BRINGUP though.

