### PR TITLE
stm32/bluetooth: Allow using a generic uart hci radio.

### DIFF
--- a/ports/stm32/modbluetooth_hci.c
+++ b/ports/stm32/modbluetooth_hci.c
@@ -162,6 +162,30 @@ int mp_bluetooth_hci_uart_set_baudrate(uint32_t baudrate) {
     return 0;
 }
 
+MP_WEAK int mp_bluetooth_hci_controller_init(void) {
+    return 0;
+}
+
+MP_WEAK int mp_bluetooth_hci_controller_activate(void) {
+    return 0;
+}
+
+MP_WEAK int mp_bluetooth_hci_controller_deactivate(void) {
+    return 0;
+}
+
+MP_WEAK int mp_bluetooth_hci_controller_sleep_maybe(void) {
+    return 0;
+}
+
+MP_WEAK bool mp_bluetooth_hci_controller_woken(void) {
+    return true;
+}
+
+MP_WEAK int mp_bluetooth_hci_controller_wakeup(void) {
+    return 0;
+}
+
 int mp_bluetooth_hci_uart_activate(void) {
     // Interrupt on RX chunk received (idle)
     // Trigger stack poll when this happens


### PR DESCRIPTION
Provide stubs for when `MICROPY_PY_BLUETOOTH` is enabled without an explicitly supported radio like `MICROPY_PY_NETWORK_CYW43`

This allows use of an external UART HCI bluetooth controller, such as a nrf52 chip running:
* mynewt/nimble: https://mynewt.apache.org/latest/tutorials/ble/blehci_project.html
* zephyr: https://docs.zephyrproject.org/1.12.0/samples/bluetooth/hci_uart/README.html

This simply needs to be connected to a 4 wire uart on your stm and the appropriate defines set in board config:

`mpconfigboard.mk`
``` 
MICROPY_PY_BLUETOOTH = 1
MICROPY_BLUETOOTH_NIMBLE ?= 1
MICROPY_BLUETOOTH_BTSTACK ?= 0
```

`mpconfigboard.h`
```
#define MICROPY_PY_HCI_BT            (1)
#define MICROPY_HW_BLE_UART_ID       (PYB_UART_4)
#define MICROPY_HW_BLE_UART_BAUDRATE (1000000)

#define MICROPY_HW_UART4_TX          (pin_H13)
#define MICROPY_HW_UART4_RX          (pin_I9)
#define MICROPY_HW_UART4_RTS         (pin_B14)
#define MICROPY_HW_UART4_CTS         (pin_B0)
```
