### PR TITLE
ESP8266 made compatible with ulab module

### DIFF
--- a/ports/esp8266/Makefile
+++ b/ports/esp8266/Makefile
@@ -140,6 +140,14 @@ LIB_SRC_C = $(addprefix lib/,\
 	libm/atanf.c \
 	libm/atan2f.c \
 	libm/roundf.c \
+	libm/acoshf.c \
+	libm/asinhf.c \
+	libm/atanhf.c \
+	libm/log1pf.c \
+	libm/sf_erf.c \
+	libm/erf_lgamma.c \
+	libm/wf_lgamma.c \
+	libm/wf_tgamma.c \
 	mp-readline/readline.c \
 	netutils/netutils.c \
 	timeutils/timeutils.c \

--- a/ports/esp8266/boards/esp8266_common.ld
+++ b/ports/esp8266/boards/esp8266_common.ld
@@ -181,6 +181,8 @@ SECTIONS
         */frozen.o(.rodata.mp_frozen_sizes) /* frozen modules */
         */frozen.o(.rodata.mp_frozen_content) /* frozen modules */
 
+        *code/*.o*(.literal* .text*)   /* ulab module */
+        
         /* for -mforce-l32 */
         build-*/*.o(.rodata*)
 

--- a/ports/esp8266/boards/esp8266_common.ld
+++ b/ports/esp8266/boards/esp8266_common.ld
@@ -181,8 +181,6 @@ SECTIONS
         */frozen.o(.rodata.mp_frozen_sizes) /* frozen modules */
         */frozen.o(.rodata.mp_frozen_content) /* frozen modules */
 
-        *code/*.o*(.literal* .text*)   /* ulab module */
-        
         /* for -mforce-l32 */
         build-*/*.o(.rodata*)
 

--- a/ports/esp8266/mpconfigport.h
+++ b/ports/esp8266/mpconfigport.h
@@ -186,6 +186,9 @@ extern const struct _mp_obj_module_t mp_module_onewire;
     mp_obj_t pin_irq_handler[16]; \
     byte *uart0_rxbuf; \
 
+// We need an implementation of the log2 function which is not a macro
+#define MP_NEED_LOG2 (1)
+
 // We need to provide a declaration/definition of alloca()
 #include <alloca.h>
 


### PR DESCRIPTION
MicroPython for ESP8266 made compatible with [ulab user C module](https://github.com/v923z/micropython-ulab), by changing files :
-  "../ports/esp8266/boards/esp8266_common.ld" so ulab is moved from IRAM1 to IROM0, fixing the "`iram1_0_seg' overflowed" error;
-  '.../esp8266/Makefile' and '.../esp8266/mpconfigport.h' to define some math functions used by ulab, fixing the building/linking errors  "undefined reference to acoshf, asinhf, atanhf, erff, erfcf, tgammaf, lgammaf, log2f."

These file changes don't increase the firmware size when not including ulab module.

ulab compiles for MicroPython ESP8266 GENERIC (flash >= 2 MB) board, but overflow the IROM0 for GENERIC_1M and GENERIC_512k configurations.

See this [MicroPython Forum topic, "ulab for ESP8266"](https://forum.micropython.org/viewtopic.php?f=16&t=8767) for some discussions about ulab on ESP8266.
