### PR TITLE
ESP32 : make option MICROPY_FLOAT_IMPL

### DIFF
--- a/ports/esp32/Makefile
+++ b/ports/esp32/Makefile
@@ -270,6 +270,17 @@ ifeq ($(ESPIDF_CURHASH),$(ESPIDF_SUPHASH_V4))
 CFLAGS += -DMICROPY_ESP_IDF_4=1
 endif
 
+# Configure floating point support
+ifeq ($(MICROPY_FLOAT_IMPL),double)
+CFLAGS += -DMICROPY_FLOAT_IMPL=MICROPY_FLOAT_IMPL_DOUBLE
+else
+ifeq ($(MICROPY_FLOAT_IMPL),none)
+CFLAGS += -DMICROPY_FLOAT_IMPL=MICROPY_FLOAT_IMPL_NONE
+else
+CFLAGS += -DMICROPY_FLOAT_IMPL=MICROPY_FLOAT_IMPL_FLOAT
+endif
+endif
+
 # this is what ESPIDF uses for c++ compilation
 CXXFLAGS = -std=gnu++11 $(CFLAGS_COMMON) $(INC) $(INC_ESPCOMP)
 

--- a/ports/esp32/mpconfigport.h
+++ b/ports/esp32/mpconfigport.h
@@ -44,7 +44,9 @@
 #define MICROPY_ENABLE_SOURCE_LINE          (1)
 #define MICROPY_ERROR_REPORTING             (MICROPY_ERROR_REPORTING_NORMAL)
 #define MICROPY_WARNINGS                    (1)
+#ifndef MICROPY_FLOAT_IMPL   // can be configured by each board via mpconfigboard.mk or by make option
 #define MICROPY_FLOAT_IMPL                  (MICROPY_FLOAT_IMPL_FLOAT)
+#endif
 #define MICROPY_CPYTHON_COMPAT              (1)
 #define MICROPY_STREAMS_NON_BLOCK           (1)
 #define MICROPY_STREAMS_POSIX_API           (1)


### PR DESCRIPTION
Implement make option MICROPY_FLOAT_IMPL on ESP32, so it is simpler to build ESP32 firmware with single or double precision float point numbers. For example :
```[esp32]$ make -j8 MICROPY_FLOAT_IMPL=double```
instead of changing the 'esp32/mpconfigport.h', line :
```#define MICROPY_FLOAT_IMPL                  (MICROPY_FLOAT_IMPL_FLOAT)```
to
```#define MICROPY_FLOAT_IMPL                  (MICROPY_FLOAT_IMPL_DOUBLE)```
Batch scripts to build many ESP32 firmware variants with combinations of boards (GENERIC, GENERIC_SPIRAM, etc), single/double precision, etc, become possible.

This option MICROPY_FLOAT_IMPL can also be configured by each board via $`BOARD/mpconfigboard.mk`.

In this way the ESP32 building workflow becomes more compatible with STM32 one.