### PR TITLE
modbluetooth/hci: Create Uart object on heap to ensure gc tracks it correctly.

### DIFF
--- a/drivers/cyw43/cywbt.c
+++ b/drivers/cyw43/cywbt.c
@@ -53,12 +53,12 @@ STATIC void cywbt_wait_cts_low(void) {
 }
 
 STATIC int cywbt_hci_cmd_raw(size_t len, uint8_t *buf) {
-    uart_tx_strn(&mp_bluetooth_hci_uart_obj, (void*)buf, len);
+    uart_tx_strn(mp_bluetooth_hci_uart_obj, (void*)buf, len);
     for (int i = 0; i < 6; ++i) {
-        while (!uart_rx_any(&mp_bluetooth_hci_uart_obj)) {
+        while (!uart_rx_any(mp_bluetooth_hci_uart_obj)) {
             MICROPY_EVENT_POLL_HOOK
         }
-        buf[i] = uart_rx_char(&mp_bluetooth_hci_uart_obj);
+        buf[i] = uart_rx_char(mp_bluetooth_hci_uart_obj);
     }
 
     // expect a comand complete event (event 0x0e)
@@ -75,10 +75,10 @@ STATIC int cywbt_hci_cmd_raw(size_t len, uint8_t *buf) {
 
     int sz = buf[2] - 3;
     for (int i = 0; i < sz; ++i) {
-        while (!uart_rx_any(&mp_bluetooth_hci_uart_obj)) {
+        while (!uart_rx_any(mp_bluetooth_hci_uart_obj)) {
             MICROPY_EVENT_POLL_HOOK
         }
-        buf[i] = uart_rx_char(&mp_bluetooth_hci_uart_obj);
+        buf[i] = uart_rx_char(mp_bluetooth_hci_uart_obj);
     }
 
     return 0;

--- a/extmod/modbluetooth_hci.h
+++ b/extmod/modbluetooth_hci.h
@@ -45,7 +45,7 @@ int mp_bluetooth_hci_controller_wakeup(void);
 // These are used by the stack bindings (e.g. nimble/hal_uart.c)
 // as well as potentially the driver (e.g. cywbt.c).
 extern uint8_t mp_bluetooth_hci_cmd_buf[4 + 256];
-extern pyb_uart_obj_t mp_bluetooth_hci_uart_obj;
+extern pyb_uart_obj_t *mp_bluetooth_hci_uart_obj;
 
 int mp_bluetooth_hci_uart_init(uint32_t port);
 int mp_bluetooth_hci_uart_activate(void);


### PR DESCRIPTION
With the existing bluetooth / hci uart configuration where the uart is created in a static struct, the irq python function is left as a dangling object which the gc happily cleans up later. This means eventually further into the application, the uart.irq object is replaced with something quite different.