### PR TITLE
extmod/modbluetooth: Add support for active scanning.

### DIFF
--- a/docs/library/ubluetooth.rst
+++ b/docs/library/ubluetooth.rst
@@ -204,7 +204,7 @@ Broadcaster Role (Advertiser)
 Observer Role (Scanner)
 -----------------------
 
-.. method:: BLE.gap_scan(duration_ms, [interval_us], [window_us])
+.. method:: BLE.gap_scan(duration_ms, [interval_us, [window_us, [active]]])
 
     Run a scan operation lasting for the specified duration (in **milli**\ seconds).
 
@@ -218,6 +218,10 @@ Observer Role (Scanner)
     interval and window are 1.28 seconds and 11.25 milliseconds respectively
     (background scanning).
 
+    Use *active* set to ``True`` to initiate an active scan instead of a passive
+    one (the default). Each discovered device will be automatically scanned and any
+    active scan response will be raised as an event as below.
+
     For each scan result the ``_IRQ_SCAN_RESULT`` event will be raised, with event
     data ``(addr_type, addr, adv_type, rssi, adv_data)``.  ``adv_type`` values correspond
     to the Bluetooth Specification:
@@ -226,7 +230,7 @@ Observer Role (Scanner)
         * 0x01 - ADV_DIRECT_IND - connectable directed advertising
         * 0x02 - ADV_SCAN_IND - scannable undirected advertising
         * 0x03 - ADV_NONCONN_IND - non-connectable undirected advertising
-        * 0x04 - SCAN_RSP - scan response
+        * 0x04 - SCAN_RSP - active scan response
 
     When scanning is stopped (either due to the duration finishing or when
     explicitly stopped), the ``_IRQ_SCAN_DONE`` event will be raised.

--- a/extmod/btstack/modbluetooth_btstack.c
+++ b/extmod/btstack/modbluetooth_btstack.c
@@ -894,15 +894,14 @@ STATIC void hci_initialization_timeout_handler(btstack_timer_source_t *ds) {
     mp_bluetooth_gap_scan_stop();
 }
 
-int mp_bluetooth_gap_scan_start(int32_t duration_ms, int32_t interval_us, int32_t window_us) {
+int mp_bluetooth_gap_scan_start(int32_t duration_ms, int32_t interval_us, int32_t window_us, int32_t active) {
     DEBUG_EVENT_printf("mp_bluetooth_gap_scan_start\n");
 
     btstack_run_loop_set_timer(&scan_duration_timeout, duration_ms);
     btstack_run_loop_set_timer_handler(&scan_duration_timeout, hci_initialization_timeout_handler);
     btstack_run_loop_add_timer(&scan_duration_timeout);
 
-    // 0 = passive scan (we don't handle scan response).
-    gap_set_scan_parameters(0, interval_us / 625, window_us / 625);
+    gap_set_scan_parameters(active, interval_us / 625, window_us / 625);
     gap_start_scan();
 
     return 0;

--- a/extmod/modbluetooth.c
+++ b/extmod/modbluetooth.c
@@ -600,6 +600,7 @@ STATIC mp_obj_t bluetooth_ble_gap_scan(size_t n_args, const mp_obj_t *args) {
     mp_int_t duration_ms = 0;
     mp_int_t interval_us = 1280000;
     mp_int_t window_us = 11250;
+    mp_int_t active = 0;
     if (n_args > 1) {
         if (args[1] == mp_const_none) {
             // scan(None) --> stop scan.
@@ -610,12 +611,15 @@ STATIC mp_obj_t bluetooth_ble_gap_scan(size_t n_args, const mp_obj_t *args) {
             interval_us = mp_obj_get_int(args[2]);
             if (n_args > 3) {
                 window_us = mp_obj_get_int(args[3]);
+                if (n_args > 4) {
+                    active = mp_obj_get_int(args[4]);
+                }
             }
         }
     }
-    return bluetooth_handle_errno(mp_bluetooth_gap_scan_start(duration_ms, interval_us, window_us));
+    return bluetooth_handle_errno(mp_bluetooth_gap_scan_start(duration_ms, interval_us, window_us, active));
 }
-STATIC MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(bluetooth_ble_gap_scan_obj, 1, 4, bluetooth_ble_gap_scan);
+STATIC MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(bluetooth_ble_gap_scan_obj, 1, 5, bluetooth_ble_gap_scan);
 #endif // MICROPY_PY_BLUETOOTH_ENABLE_CENTRAL_MODE
 
 STATIC mp_obj_t bluetooth_ble_gap_disconnect(mp_obj_t self_in, mp_obj_t conn_handle_in) {

--- a/extmod/modbluetooth.h
+++ b/extmod/modbluetooth.h
@@ -215,7 +215,7 @@ int mp_bluetooth_gap_disconnect(uint16_t conn_handle);
 
 #if MICROPY_PY_BLUETOOTH_ENABLE_CENTRAL_MODE
 // Start a discovery (scan). Set duration to zero to run continuously.
-int mp_bluetooth_gap_scan_start(int32_t duration_ms, int32_t interval_us, int32_t window_us);
+int mp_bluetooth_gap_scan_start(int32_t duration_ms, int32_t interval_us, int32_t window_us, int32_t active);
 
 // Stop discovery (if currently active).
 int mp_bluetooth_gap_scan_stop(void);

--- a/extmod/nimble/modbluetooth_nimble.c
+++ b/extmod/nimble/modbluetooth_nimble.c
@@ -673,7 +673,7 @@ int mp_bluetooth_gap_scan_start(int32_t duration_ms, int32_t interval_us, int32_
         .window = MAX(BLE_HCI_SCAN_WINDOW_MIN, MIN(BLE_HCI_SCAN_WINDOW_MAX, window_us / BLE_HCI_SCAN_ITVL)),
         .filter_policy = BLE_HCI_CONN_FILT_NO_WL,
         .limited = 0,
-        .passive = active ? 0 : 1,
+        .passive = !active,
         .filter_duplicates = 0,
     };
     int err = ble_gap_disc(BLE_OWN_ADDR_PUBLIC, duration_ms, &discover_params, gap_scan_cb, NULL);

--- a/extmod/nimble/modbluetooth_nimble.c
+++ b/extmod/nimble/modbluetooth_nimble.c
@@ -661,7 +661,7 @@ STATIC int gap_scan_cb(struct ble_gap_event *event, void *arg) {
     return 0;
 }
 
-int mp_bluetooth_gap_scan_start(int32_t duration_ms, int32_t interval_us, int32_t window_us) {
+int mp_bluetooth_gap_scan_start(int32_t duration_ms, int32_t interval_us, int32_t window_us, int32_t active) {
     if (!mp_bluetooth_is_active()) {
         return ERRNO_BLUETOOTH_NOT_ACTIVE;
     }
@@ -673,7 +673,7 @@ int mp_bluetooth_gap_scan_start(int32_t duration_ms, int32_t interval_us, int32_
         .window = MAX(BLE_HCI_SCAN_WINDOW_MIN, MIN(BLE_HCI_SCAN_WINDOW_MAX, window_us / BLE_HCI_SCAN_ITVL)),
         .filter_policy = BLE_HCI_CONN_FILT_NO_WL,
         .limited = 0,
-        .passive = 1,  // TODO: Handle BLE_HCI_ADV_RPT_EVTYPE_SCAN_RSP in gap_scan_cb above.
+        .passive = active ? 0 : 1,
         .filter_duplicates = 0,
     };
     int err = ble_gap_disc(BLE_OWN_ADDR_PUBLIC, duration_ms, &discover_params, gap_scan_cb, NULL);


### PR DESCRIPTION
Add an additional argument to `ble_gap_scan()` to specify an active scan instead of a passive one, plus matching change to 
`modbluetooth_nimble.mp_bluetooth_gap_scan_start()`. The existing event mechanism seems to be sufficient to return scan responses, so no changes have been made to that.

Documentation updated to match and feature tested on an ESP32.

This is one of the #5186 additional features wish list. I'm not sure if @jimmo had additional plans for how this would work beyond the very simple implementation I've done here.