### PR TITLE
Update ESP32 2MiB partition table

### DIFF
--- a/ports/esp32/partitions-2MiB.csv
+++ b/ports/esp32/partitions-2MiB.csv
@@ -4,5 +4,5 @@
 # Name,     Type, SubType, Offset,   Size, Flags
 nvs,        data, nvs,     0x9000,   0x6000,
 phy_init,   data, phy,     0xf000,   0x1000,
-factory,    app,  factory, 0x10000,  0x110000,
-vfs,        data, fat,     0x120000, 0xA0000,
+factory,    app,  factory, 0x10000,  0x160000,
+vfs,        data, fat,     0x170000, 0x50000,


### PR DESCRIPTION
The current micropython app size is larger than the size allocated in the partitions table.