### PR TITLE
modules/inisetup.py: Create main.py as well

### DIFF
--- a/ports/esp8266/modules/inisetup.py
+++ b/ports/esp8266/modules/inisetup.py
@@ -62,4 +62,6 @@ import gc
 gc.collect()
 """
         )
+    with open("main.py", "w") as f:
+        f.write("# main.py -- put your code here!\r\n")
     return vfs


### PR DESCRIPTION
That very simple PR prevents a common irritation of people dealing with MicroPython
on ESP8266 for the first time.