### PR TITLE
extmod/nimble: Automatically notify subscribed connections on gatts_write().

### DIFF
--- a/extmod/nimble/modbluetooth_nimble.c
+++ b/extmod/nimble/modbluetooth_nimble.c
@@ -582,10 +582,10 @@ int mp_bluetooth_gatts_write(uint16_t value_handle, const uint8_t *value, size_t
     if (!mp_bluetooth_is_active()) {
         return ERRNO_BLUETOOTH_NOT_ACTIVE;
     }
-    return mp_bluetooth_gatts_db_write(MP_STATE_PORT(bluetooth_nimble_root_pointers)->gatts_db, value_handle, value, value_len);
+    int ret = mp_bluetooth_gatts_db_write(MP_STATE_PORT(bluetooth_nimble_root_pointers)->gatts_db, value_handle, value, value_len);
+    ble_gatts_chr_updated(value_handle);
+    return ret;
 }
-
-// TODO: Could use ble_gatts_chr_updated to send to all subscribed centrals.
 
 int mp_bluetooth_gatts_notify(uint16_t conn_handle, uint16_t value_handle) {
     if (!mp_bluetooth_is_active()) {


### PR DESCRIPTION
This change means that when a central has subscribed to notifications on a characteristic on the peripheral running micropython, any writes to that characteristic are automatically notified to the connected central. 

This is the default behavior on any other BLE stack I've worked with in the past.