### PR TITLE
py/objtype.c: Handle __dict__ attribute when type has no locals.

### DIFF
--- a/py/map.c
+++ b/py/map.c
@@ -40,17 +40,6 @@
 #define DEBUG_printf(...) (void)0
 #endif
 
-// Fixed empty map. Useful when need to call kw-receiving functions
-// without any keywords from C, etc.
-const mp_map_t mp_const_empty_map = {
-    .all_keys_are_qstrs = 0,
-    .is_fixed = 1,
-    .is_ordered = 1,
-    .used = 0,
-    .alloc = 0,
-    .table = NULL,
-};
-
 // This table of sizes is used to control the growth of hash tables.
 // The first set of sizes are chosen so the allocation fits exactly in a
 // 4-word GC block, and it's not so important for these small values to be

--- a/py/obj.h
+++ b/py/obj.h
@@ -422,8 +422,6 @@ typedef enum _mp_map_lookup_kind_t {
     MP_MAP_LOOKUP_ADD_IF_NOT_FOUND_OR_REMOVE_IF_FOUND = 3, // only valid for mp_set_lookup
 } mp_map_lookup_kind_t;
 
-extern const mp_map_t mp_const_empty_map;
-
 static inline bool mp_map_slot_is_filled(const mp_map_t *map, size_t pos) {
     assert(pos < map->alloc);
     return (map)->table[pos].key != MP_OBJ_NULL && (map)->table[pos].key != MP_OBJ_SENTINEL;
@@ -906,6 +904,12 @@ mp_obj_t mp_obj_dict_copy(mp_obj_t self_in);
 static inline mp_map_t *mp_obj_dict_get_map(mp_obj_t dict) {
     return &((mp_obj_dict_t *)MP_OBJ_TO_PTR(dict))->map;
 }
+
+extern const mp_obj_dict_t mp_const_empty_dict_obj;
+
+// Fixed empty map. Useful when need to call kw-receiving functions
+// without any keywords from C, etc.
+#define mp_const_empty_map (mp_const_empty_dict_obj.map)
 
 // set
 void mp_obj_set_store(mp_obj_t self_in, mp_obj_t item);

--- a/py/objdict.c
+++ b/py/objdict.c
@@ -33,6 +33,18 @@
 #include "py/objtype.h"
 #include "py/objstr.h"
 
+const mp_obj_dict_t mp_const_empty_dict_obj = {
+    .base = { .type = &mp_type_dict },
+    .map = {
+        .all_keys_are_qstrs = 0,
+        .is_fixed = 1,
+        .is_ordered = 1,
+        .used = 0,
+        .alloc = 0,
+        .table = NULL,
+    }
+};
+
 STATIC mp_obj_t dict_update(size_t n_args, const mp_obj_t *args, mp_map_t *kwargs);
 
 // This is a helper function to iterate through a dictionary.  The state of

--- a/py/objtype.c
+++ b/py/objtype.c
@@ -1014,13 +1014,16 @@ STATIC void type_attr(mp_obj_t self_in, qstr attr, mp_obj_t *dest) {
         if (attr == MP_QSTR___dict__) {
             // Returns a read-only dict of the class attributes.
             // If the internal locals is not fixed, a copy will be created.
-            mp_obj_dict_t *dict = self->locals_dict;
+            const mp_obj_dict_t *dict = self->locals_dict;
+            if (!dict) {
+                dict = &mp_const_empty_dict_obj;
+            }
             if (dict->map.is_fixed) {
                 dest[0] = MP_OBJ_FROM_PTR(dict);
             } else {
                 dest[0] = mp_obj_dict_copy(MP_OBJ_FROM_PTR(dict));
-                dict = MP_OBJ_TO_PTR(dest[0]);
-                dict->map.is_fixed = 1;
+                mp_obj_dict_t *dict_copy = MP_OBJ_TO_PTR(dest[0]);
+                dict_copy->map.is_fixed = 1;
             }
             return;
         }

--- a/tests/basics/class_dict.py
+++ b/tests/basics/class_dict.py
@@ -17,3 +17,8 @@ class Foo:
 
 d = Foo.__dict__
 print(d["a"], d["b"])
+
+
+# dict of a class that has no locals_dict (return empty dict).
+d = type(type('')).__dict__
+print(d is not None)


### PR DESCRIPTION
Reported by @pmp-p in IRC:

```
import sys
dir(type(sys))
```

dir() tries every single QSTR, and it trips on `__dict__` because `mp_type_module` (and others, e.g. `mp_type_type`) has no `locals_dict`.

Simple repro:

```
type(type('')).__dict__
```

Added a simple test based on that second repro... it's a bit simple but open to suggestions on how to compare to CPython (i.e. need to find a CPython type that has no locals). Could do a separate test with an .exp?