### PR TITLE
WIP: extmod/btstack: Add support for persistant bonding.

### DIFF
--- a/extmod/btstack/btstack.mk
+++ b/extmod/btstack/btstack.mk
@@ -8,11 +8,17 @@ MICROPY_BLUETOOTH_BTSTACK_ENABLE_CLASSIC ?= 0
 BTSTACK_EXTMOD_DIR = extmod/btstack
 
 EXTMOD_SRC_C += extmod/btstack/modbluetooth_btstack.c
-EXTMOD_SRC_C += extmod/btstack/le_device_db_fs.c
+EXTMOD_SRC_C += extmod/btstack/btstack_tlv_mpy.c
 
 INC += -I$(TOP)/$(BTSTACK_EXTMOD_DIR)
 
 CFLAGS_MOD += -DMICROPY_BLUETOOTH_BTSTACK=1
+ifneq ("$(MICROPY_PY_BLUETOOTH_DIAGNOSTIC_LOGGING)", "")
+CFLAGS_MOD += -DMICROPY_PY_BLUETOOTH_DIAGNOSTIC_LOGGING=$(MICROPY_PY_BLUETOOTH_DIAGNOSTIC_LOGGING)
+endif
+ifneq ("$(MICROPY_PY_BLUETOOTH_MAX_ATT_DB_SIZE)", "")
+CFLAGS_MOD += -DMAX_ATT_DB_SIZE=$(MICROPY_PY_BLUETOOTH_MAX_ATT_DB_SIZE)
+endif
 
 BTSTACK_DIR = $(TOP)/lib/btstack
 
@@ -33,7 +39,6 @@ SRC_BTSTACK = \
 	$(addprefix lib/btstack/src/, $(SRC_FILES)) \
 	$(addprefix lib/btstack/src/ble/, $(SRC_BLE_FILES)) \
 	lib/btstack/platform/embedded/btstack_run_loop_embedded.c \
-	lib/btstack/platform/posix/btstack_tlv_posix.c \
 	lib/btstack/3rd-party/rijndael/rijndael.c \
 	lib/btstack/3rd-party/micro-ecc/uECC.c
 

--- a/extmod/btstack/btstack.mk
+++ b/extmod/btstack/btstack.mk
@@ -9,6 +9,7 @@ BTSTACK_EXTMOD_DIR = extmod/btstack
 
 EXTMOD_SRC_C += extmod/btstack/modbluetooth_btstack.c
 EXTMOD_SRC_C += extmod/btstack/le_device_db_fs.c
+EXTMOD_SRC_C += extmod/mphciport.c
 
 INC += -I$(TOP)/$(BTSTACK_EXTMOD_DIR)
 

--- a/extmod/btstack/btstack.mk
+++ b/extmod/btstack/btstack.mk
@@ -8,7 +8,7 @@ MICROPY_BLUETOOTH_BTSTACK_ENABLE_CLASSIC ?= 0
 BTSTACK_EXTMOD_DIR = extmod/btstack
 
 EXTMOD_SRC_C += extmod/btstack/modbluetooth_btstack.c
-EXTMOD_SRC_C += extmod/btstack/btstack_tlv_mpy.c
+EXTMOD_SRC_C += extmod/btstack/le_device_db_fs.c
 
 INC += -I$(TOP)/$(BTSTACK_EXTMOD_DIR)
 
@@ -25,7 +25,6 @@ BTSTACK_DIR = $(TOP)/lib/btstack
 ifneq ($(wildcard $(BTSTACK_DIR)/src),)
 
 include $(BTSTACK_DIR)/src/Makefile.inc
-include $(BTSTACK_DIR)/src/ble/Makefile.inc
 
 INC += -I$(BTSTACK_DIR)/src
 INC += -I$(BTSTACK_DIR)/3rd-party/bluedroid/decoder/include
@@ -35,12 +34,22 @@ INC += -I$(BTSTACK_DIR)/3rd-party/micro-ecc
 INC += -I$(BTSTACK_DIR)/3rd-party/rijndael
 INC += -I$(BTSTACK_DIR)/3rd-party/yxml
 
+SRC_BLE_FILES = \
+    ancs_client.c \
+    att_db.c \
+    att_db_util.c \
+    att_dispatch.c \
+    att_server.c \
+    gatt_client.c \
+    sm.c
+
 SRC_BTSTACK = \
 	$(addprefix lib/btstack/src/, $(SRC_FILES)) \
 	$(addprefix lib/btstack/src/ble/, $(SRC_BLE_FILES)) \
 	lib/btstack/platform/embedded/btstack_run_loop_embedded.c \
 	lib/btstack/3rd-party/rijndael/rijndael.c \
 	lib/btstack/3rd-party/micro-ecc/uECC.c
+
 
 ifeq ($(MICROPY_BLUETOOTH_BTSTACK_USB),1)
 ifeq ($(MICROPY_BLUETOOTH_BTSTACK_H4),1)

--- a/extmod/btstack/btstack.mk
+++ b/extmod/btstack/btstack.mk
@@ -8,6 +8,7 @@ MICROPY_BLUETOOTH_BTSTACK_ENABLE_CLASSIC ?= 0
 BTSTACK_EXTMOD_DIR = extmod/btstack
 
 EXTMOD_SRC_C += extmod/btstack/modbluetooth_btstack.c
+EXTMOD_SRC_C += extmod/btstack/le_device_db_fs.c
 
 INC += -I$(TOP)/$(BTSTACK_EXTMOD_DIR)
 

--- a/extmod/btstack/btstack.mk
+++ b/extmod/btstack/btstack.mk
@@ -3,6 +3,7 @@
 ifeq ($(MICROPY_BLUETOOTH_BTSTACK),1)
 
 MICROPY_BLUETOOTH_BTSTACK_USB ?= 0
+MICROPY_BLUETOOTH_BTSTACK_ENABLE_CLASSIC ?= 0
 
 BTSTACK_EXTMOD_DIR = extmod/btstack
 
@@ -23,12 +24,17 @@ INC += -I$(BTSTACK_DIR)/src
 INC += -I$(BTSTACK_DIR)/3rd-party/bluedroid/decoder/include
 INC += -I$(BTSTACK_DIR)/3rd-party/bluedroid/encoder/include
 INC += -I$(BTSTACK_DIR)/3rd-party/md5
+INC += -I$(BTSTACK_DIR)/3rd-party/micro-ecc
+INC += -I$(BTSTACK_DIR)/3rd-party/rijndael
 INC += -I$(BTSTACK_DIR)/3rd-party/yxml
 
 SRC_BTSTACK = \
 	$(addprefix lib/btstack/src/, $(SRC_FILES)) \
-	$(addprefix lib/btstack/src/ble/, $(filter-out %_tlv.c, $(SRC_BLE_FILES))) \
-	lib/btstack/platform/embedded/btstack_run_loop_embedded.c
+	$(addprefix lib/btstack/src/ble/, $(SRC_BLE_FILES)) \
+	lib/btstack/platform/embedded/btstack_run_loop_embedded.c \
+	lib/btstack/platform/posix/btstack_tlv_posix.c \
+	lib/btstack/3rd-party/rijndael/rijndael.c \
+	lib/btstack/3rd-party/micro-ecc/uECC.c
 
 ifeq ($(MICROPY_BLUETOOTH_BTSTACK_USB),1)
 ifeq ($(MICROPY_BLUETOOTH_BTSTACK_H4),1)
@@ -66,7 +72,7 @@ endif
 LIB_SRC_C += $(SRC_BTSTACK)
 
 # Suppress some warnings.
-BTSTACK_WARNING_CFLAGS = -Wno-old-style-definition -Wno-unused-variable -Wno-unused-parameter
+BTSTACK_WARNING_CFLAGS = -Wno-old-style-definition -Wno-unused-variable -Wno-unused-parameter -Wno-double-promotion
 ifneq ($(CC),clang)
 BTSTACK_WARNING_CFLAGS += -Wno-format
 endif

--- a/extmod/btstack/btstack_config.h
+++ b/extmod/btstack/btstack_config.h
@@ -5,7 +5,7 @@
 #define ENABLE_BLE
 #define ENABLE_LE_PERIPHERAL
 #define ENABLE_LE_CENTRAL
-// #define ENABLE_CLASSIC
+#define ENABLE_CLASSIC
 #define ENABLE_LE_DATA_CHANNELS
 // #define ENABLE_LOG_INFO
 // #define ENABLE_LOG_DEBUG
@@ -30,11 +30,17 @@
 #define MAX_NR_AVDTP_STREAM_ENDPOINTS 1
 #define MAX_NR_AVDTP_CONNECTIONS 1
 #define MAX_NR_AVRCP_CONNECTIONS 1
+#define ENABLE_LE_SECURE_CONNECTIONS
+#define ENABLE_SOFTWARE_AES128
+#define ENABLE_MICRO_ECC_FOR_LE_SECURE_CONNECTIONS
+#define ENABLE_LE_DATA_LENGTH_EXTENSION
+#define ENABLE_ATT_DELAYED_RESPONSE
+#define ENABLE_L2CAP_ENHANCED_RETRANSMISSION_MODE
 
 #define MAX_NR_LE_DEVICE_DB_ENTRIES 4
 
-// Link Key DB and LE Device DB using TLV on top of Flash Sector interface
-// #define NVM_NUM_DEVICE_DB_ENTRIES 16
+// Link Key DB and LE Device DB on mpy filesystem
+#define NVM_NUM_DEVICE_DB_ENTRIES 16
 
 // We don't give btstack a malloc, so use a fixed-size ATT DB.
 #define MAX_ATT_DB_SIZE 512

--- a/extmod/btstack/btstack_tlv_mpy.c
+++ b/extmod/btstack/btstack_tlv_mpy.c
@@ -1,0 +1,311 @@
+/*
+ * Copyright (C) 2017 BlueKitchen GmbH
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of the copyright holders nor the names of
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY MATTHIAS RINGWALD AND CONTRIBUTORS
+ * ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL MATTHIAS
+ * RINGWALD OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
+ * THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ *
+ */
+
+#define BTSTACK_FILE__ "btstack_tlv_mpy.c"
+
+#include <stdio.h>
+#include <py/runtime.h>
+#include <py/builtin.h>
+#include <extmod/vfs.h>
+#include <py/stream.h>
+
+#include "btstack_tlv.h"
+#include "btstack_tlv_mpy.h"
+#include "btstack_debug.h"
+#include "btstack_util.h"
+#include "btstack_debug.h"
+#include "string.h"
+
+#include <stdlib.h>
+#include <string.h>
+
+static mp_obj_t _fopen(const char *path, const char *mode) {
+    mp_obj_t args[]  = {
+        mp_obj_new_str(path, strlen(path)),
+        mp_obj_new_str(mode, strlen(mode)),
+    };
+    return mp_builtin_open(2, args, (mp_map_t*)&mp_const_empty_map);
+}
+
+static size_t _fwrite(const void *buf, size_t len, mp_obj_t wFile) {
+    int errno;
+    const mp_stream_p_t *stream_p = mp_get_stream_raise(wFile, MP_STREAM_OP_WRITE);
+    mp_uint_t out_sz = stream_p->write(MP_OBJ_FROM_PTR(wFile), buf, len, &errno);
+    if (out_sz == MP_STREAM_ERROR) {
+        return -1;
+    } 
+    return out_sz;
+}
+
+static size_t _fread(void *buf, size_t len, mp_obj_t wFile)  {
+    int errno;
+    const mp_stream_p_t *stream_p = mp_get_stream_raise(wFile, MP_STREAM_OP_READ);
+    mp_uint_t out_sz = stream_p->read(MP_OBJ_FROM_PTR(wFile), buf, len, &errno);
+    if (out_sz == MP_STREAM_ERROR) {
+        return -1;
+    }
+    return out_sz;
+}
+
+void _fflush(mp_obj_t wFile) {
+    int errno;
+    const mp_stream_p_t *stream_p = mp_get_stream_raise(wFile, MP_STREAM_OP_WRITE);
+    stream_p->ioctl(MP_OBJ_FROM_PTR(wFile), MP_STREAM_FLUSH, 0, &errno);
+}
+
+static void inline _fclose(mp_obj_t wFile) {
+    mp_stream_close(wFile);
+}
+
+
+
+// Header:
+// - Magic: 'BTstack'
+// - Status:
+//   - bits 765432: reserved
+//	 - bits 10:     epoch
+
+// Entries
+// - Tag: 32 bit
+// - Len: 32 bit
+// - Value: Len in bytes
+
+#define BTSTACK_TLV_HEADER_LEN 8
+static const char * btstack_tlv_header_magic = "BTstack";
+
+#define DUMMY_SIZE 4
+typedef struct tlv_entry {
+	void   * next;
+	uint32_t tag;
+	uint32_t len;
+	uint8_t  value[DUMMY_SIZE];	// dummy size
+} tlv_entry_t;
+
+static int btstack_tlv_mpy_append_tag(btstack_tlv_mpy_t * self, uint32_t tag, const uint8_t * data, uint32_t data_size){
+
+	if (!self->file) return 1;
+
+	log_info("append tag %04x, len %u", tag, data_size);
+
+	uint8_t header[8];
+	big_endian_store_32(header, 0, tag);
+	big_endian_store_32(header, 4, data_size);
+	size_t written_header = _fwrite(header, sizeof(header), self->file);
+	if (written_header != sizeof(header)) return 1;
+	if (data_size > 0) {
+		size_t written_value = _fwrite(data, data_size, self->file);
+		if (written_value != data_size) return 1;
+	}
+	_fflush(self->file);
+	return 1;
+}
+
+static tlv_entry_t * btstack_tlv_mpy_find_entry(btstack_tlv_mpy_t * self, uint32_t tag){
+	btstack_linked_list_iterator_t it;
+	btstack_linked_list_iterator_init(&it, &self->entry_list);
+	while (btstack_linked_list_iterator_has_next(&it)){
+		tlv_entry_t * entry = (tlv_entry_t*) btstack_linked_list_iterator_next(&it);
+		if (entry->tag != tag) continue;
+		return entry;
+	}
+	return NULL;
+}
+
+/**
+ * Delete Tag
+ * @param tag
+ */
+static void btstack_tlv_mpy_delete_tag(void * context, uint32_t tag){
+	btstack_tlv_mpy_t * self = (btstack_tlv_mpy_t *) context;
+	btstack_linked_list_iterator_t it;
+	btstack_linked_list_iterator_init(&it, &self->entry_list);
+	while (btstack_linked_list_iterator_has_next(&it)){
+		tlv_entry_t * entry = (tlv_entry_t*) btstack_linked_list_iterator_next(&it);
+		if (entry->tag != tag) continue;
+		btstack_linked_list_iterator_remove(&it);
+		free(entry);
+		btstack_tlv_mpy_append_tag(self, tag, NULL, 0);
+		return;
+	}
+}
+
+/**
+ * Get Value for Tag
+ * @param tag
+ * @param buffer
+ * @param buffer_size
+ * @returns size of value
+ */
+static int btstack_tlv_mpy_get_tag(void * context, uint32_t tag, uint8_t * buffer, uint32_t buffer_size){
+	btstack_tlv_mpy_t * self = (btstack_tlv_mpy_t *) context;
+	tlv_entry_t * entry = btstack_tlv_mpy_find_entry(self, tag);
+	// not found
+	if (!entry) return 0;
+	// return len if buffer = NULL
+	if (!buffer) return entry->len;
+	// otherwise copy data into buffer
+	uint16_t bytes_to_copy = btstack_min(buffer_size, entry->len);
+	memcpy(buffer, &entry->value[0], bytes_to_copy);
+	return bytes_to_copy;
+}
+
+/**
+ * Store Tag 
+ * @param tag
+ * @param data
+ * @param data_size
+ */
+static int btstack_tlv_mpy_store_tag(void * context, uint32_t tag, const uint8_t * data, uint32_t data_size){
+	btstack_tlv_mpy_t * self = (btstack_tlv_mpy_t *) context;
+
+	// remove old entry
+	tlv_entry_t * old_entry = btstack_tlv_mpy_find_entry(self, tag);
+	if (old_entry){
+		btstack_linked_list_remove(&self->entry_list, (btstack_linked_item_t *) old_entry);
+		free(old_entry);
+	}
+
+	// create new entry
+	uint32_t entry_size = sizeof(tlv_entry_t) - DUMMY_SIZE + data_size;
+	tlv_entry_t * new_entry = (tlv_entry_t *) malloc(entry_size);
+	if (!new_entry) return 0;
+	memset(new_entry, 0, entry_size);
+	new_entry->tag = tag;
+	new_entry->len = data_size;
+	memcpy(&new_entry->value[0], data, data_size);
+
+	// append new entry
+	btstack_linked_list_add(&self->entry_list, (btstack_linked_item_t *) new_entry);
+
+	// write new tag
+	btstack_tlv_mpy_append_tag(self, tag, data, data_size);
+
+	return 0;
+}
+
+// returns 0 on success
+static int btstack_tlv_mpy_read_db(btstack_tlv_mpy_t * self){
+	// open file
+	log_info("open db %s", self->db_path);
+    self->file = _fopen(self->db_path,"r+");
+    uint8_t header[BTSTACK_TLV_HEADER_LEN];
+    if (self->file){
+    	// checker header
+	    size_t objects_read = _fread(header, BTSTACK_TLV_HEADER_LEN, self->file );
+	    int file_valid = 0;
+	    if (objects_read == BTSTACK_TLV_HEADER_LEN){
+	    	if (memcmp(header, btstack_tlv_header_magic, strlen(btstack_tlv_header_magic)) == 0){
+		    	log_info("BTstack Magic Header found");
+		    	// read entries
+		    	while (true){
+					uint8_t entry[8];
+					size_t 	entries_read = _fread(entry, sizeof(entry), self->file);
+					if (entries_read == 0){
+						// EOF, we're good
+						file_valid = 1;
+						break;
+					}
+					if (entries_read != sizeof(entry)) break;
+
+                    uint32_t tag = big_endian_read_32(entry, 0);
+                    uint32_t len = big_endian_read_32(entry, 4);
+
+                    // arbitrary safety check: values < 1000 bytes each
+                    if (len > 1000) break;
+
+                    // create new entry for regular tag
+                    tlv_entry_t * new_entry = NULL;
+                    if (len > 0) {
+                        new_entry = (tlv_entry_t *) malloc(sizeof(tlv_entry_t) - DUMMY_SIZE + len);
+                        if (!new_entry) return 0;
+                        new_entry->tag = tag;
+                        new_entry->len = len;
+
+                        // read
+                        size_t value_read = _fread(&new_entry->value[0], len, self->file);
+                        if (value_read != len) break;
+                    }
+
+                    // remove old entry
+                    tlv_entry_t * old_entry = btstack_tlv_mpy_find_entry(self, tag);
+                    if (old_entry){
+                        btstack_linked_list_remove(&self->entry_list, (btstack_linked_item_t *) old_entry);
+                        free(old_entry);
+                    }
+
+                    // append new entry
+                    if (new_entry){
+	                    btstack_linked_list_add(&self->entry_list, (btstack_linked_item_t *) new_entry);
+                    }
+		    	}
+	    	}
+	    }
+	    if (!file_valid) {
+	    	log_info("file invalid, re-create");
+    		_fclose(self->file);
+    		self->file = NULL;
+	    }
+    }
+    if (!self->file){
+    	// create truncate file
+	    self->file = _fopen(self->db_path,"w+");
+	    memset(header, 0, sizeof(header));
+	    strcpy((char *)header, btstack_tlv_header_magic);
+	    _fwrite(header, sizeof(header), self->file);
+	    // write out all valid entries (if any)
+		btstack_linked_list_iterator_t it;
+		btstack_linked_list_iterator_init(&it, &self->entry_list);
+		while (btstack_linked_list_iterator_has_next(&it)){
+			tlv_entry_t * entry = (tlv_entry_t*) btstack_linked_list_iterator_next(&it);
+			btstack_tlv_mpy_append_tag(self, entry->tag, &entry->value[0], entry->len);
+		}
+    }
+	return 0;
+}
+
+static const btstack_tlv_t btstack_tlv_mpy = {
+	/* int  (*get_tag)(..);     */ &btstack_tlv_mpy_get_tag,
+	/* int (*store_tag)(..);    */ &btstack_tlv_mpy_store_tag,
+	/* void (*delete_tag)(v..); */ &btstack_tlv_mpy_delete_tag,
+};
+
+/**
+ * Init Tag Length Value Store
+ */
+const btstack_tlv_t * btstack_tlv_mpy_init_instance(btstack_tlv_mpy_t * self, const char * db_path){
+	memset(self, 0, sizeof(btstack_tlv_mpy_t));
+	self->db_path = db_path;
+
+	// read DB
+	btstack_tlv_mpy_read_db(self);
+	return &btstack_tlv_mpy;
+}
+

--- a/extmod/btstack/btstack_tlv_mpy.h
+++ b/extmod/btstack/btstack_tlv_mpy.h
@@ -1,0 +1,68 @@
+/*
+ * Copyright (C) 2017 BlueKitchen GmbH
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of the copyright holders nor the names of
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY MATTHIAS RINGWALD AND CONTRIBUTORS
+ * ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL MATTHIAS
+ * RINGWALD OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
+ * THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ *
+ */
+
+/*
+ *  btstack_tlv_mpy.h
+ *
+ *  Implementation for BTstack's Tag Value Length Persistent Storage implementations
+ *  using in-memory storage (RAM & malloc) and append-only log files on disc
+ */
+
+#ifndef btstack_tlv_mpy_H
+#define btstack_tlv_mpy_H
+
+#include <stdint.h>
+#include <stdio.h>
+#include <extmod/vfs.h>
+#include "btstack_tlv.h"
+#include "btstack_linked_list.h"
+
+#if defined __cplusplus
+extern "C" {
+#endif
+
+typedef struct {
+	btstack_linked_list_t entry_list;
+	const char * db_path;
+	mp_obj_t file;
+} btstack_tlv_mpy_t;
+
+/**
+ * Init Tag Length Value Store
+ * @param context btstack_tlv_mpy_t 
+ * @param db_path on disc
+ */
+const btstack_tlv_t * btstack_tlv_mpy_init_instance(btstack_tlv_mpy_t * context, const char * db_path);
+
+#if defined __cplusplus
+}
+#endif
+#endif // btstack_tlv_mpy_H

--- a/extmod/btstack/le_device_db_fs.c
+++ b/extmod/btstack/le_device_db_fs.c
@@ -1,0 +1,515 @@
+/*
+ * Copyright (C) 2014 BlueKitchen GmbH
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of the copyright holders nor the names of
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ * 4. Any redistribution, use, or modification is done solely for
+ *    personal benefit and not for any commercial purpose or for
+ *    monetary gain.
+ *
+ * THIS SOFTWARE IS PROVIDED BY BLUEKITCHEN GMBH AND CONTRIBUTORS
+ * ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL MATTHIAS
+ * RINGWALD OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
+ * THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ *
+ * Please inquire about commercial licensing options at 
+ * contact@bluekitchen-gmbh.com
+ *
+ */
+
+#define BTSTACK_FILE__ "le_device_db_fs.c"
+ 
+#include <stdio.h>
+#include <string.h>
+
+#include <py/runtime.h>
+#include <py/builtin.h>
+#include <extmod/vfs.h>
+#include <py/stream.h>
+
+#include "btstack_config.h"
+#include "btstack_debug.h"
+#include "ble/le_device_db.h"
+#include "ble/core.h"
+
+#ifdef NVM_NUM_DEVICE_DB_ENTRIES
+
+// Central Device db implemenation using static memory
+typedef struct le_device_memory_db {
+
+    // Identification
+    int addr_type;
+    bd_addr_t addr;
+    sm_key_t irk;
+
+    // Stored pairing information allows to re-establish an enncrypted connection
+    // with a peripheral that doesn't have any persistent memory
+    sm_key_t ltk;
+    uint16_t ediv;
+    uint8_t  rand[8];
+    uint8_t  key_size;
+    uint8_t  authenticated;
+    uint8_t  authorized;
+    uint8_t  secure_connection;
+
+#ifdef ENABLE_LE_SIGNED_WRITE
+    // Signed Writes by remote
+    sm_key_t remote_csrk;
+    uint32_t remote_counter;
+
+    // Signed Writes by us
+    sm_key_t local_csrk;
+    uint32_t local_counter;
+#endif
+
+} le_device_memory_db_t;
+
+#define LE_DEVICE_MEMORY_SIZE 20
+
+#ifndef LE_DEVICE_DB_PATH
+#ifdef _WIN32
+#define LE_DEVICE_DB_PATH ""
+#else
+#define LE_DEVICE_DB_PATH "/flash/"
+#endif
+#endif
+
+#define DB_PATH_TEMPLATE (LE_DEVICE_DB_PATH "btstack_at_%s_le_device_db.txt")
+
+#ifdef ENABLE_LE_SIGNED_WRITE
+const  char * csv_header = "# addr_type, addr, irk, ltk, ediv, rand[8], key_size, authenticated, authorized, remote_csrk, remote_counter, local_csrk, local_counter, secure_connection";
+#else
+const  char * csv_header = "# addr_type, addr, irk, ltk, ediv, rand[8], key_size, authenticated, authorized, secure_connection";
+#endif
+
+static char db_path[sizeof(DB_PATH_TEMPLATE) - 2 + 17 + 1];
+
+static le_device_memory_db_t le_devices[LE_DEVICE_MEMORY_SIZE];
+
+static char bd_addr_to_dash_str_buffer[6*3];  // 12-45-78-01-34-67\0
+static char * bd_addr_to_dash_str(bd_addr_t addr){
+    char * p = bd_addr_to_dash_str_buffer;
+    int i;
+    for (i = 0; i < 6 ; i++) {
+        *p++ = char_for_nibble((addr[i] >> 4) & 0x0F);
+        *p++ = char_for_nibble((addr[i] >> 0) & 0x0F);
+        *p++ = '-';
+    }
+    *--p = 0;
+    return (char *) bd_addr_to_dash_str_buffer;
+}
+
+static mp_obj_t _fopen(const char *path, const char *mode)
+{
+    mp_obj_t args[]  = {
+        mp_obj_new_str(path, strlen(path)),
+        mp_obj_new_str(mode, strlen(mode)),
+    };
+    return mp_builtin_open(2, args, (mp_map_t*)&mp_const_empty_map);
+}
+
+static size_t _fwrite(const void *buf, size_t len, mp_obj_t wFile) 
+{
+    int errno;
+    const mp_stream_p_t *stream_p = mp_get_stream_raise(wFile, MP_STREAM_OP_WRITE);
+    mp_uint_t out_sz = stream_p->write(MP_OBJ_FROM_PTR(wFile), buf, len, &errno);
+    if (out_sz == MP_STREAM_ERROR) {
+        return -1;
+    } 
+    return out_sz;
+}
+
+static size_t _fread(void *buf, size_t len, mp_obj_t wFile) 
+{
+    int errno;
+    const mp_stream_p_t *stream_p = mp_get_stream_raise(wFile, MP_STREAM_OP_READ);
+    mp_uint_t out_sz = stream_p->read(MP_OBJ_FROM_PTR(wFile), buf, len, &errno);
+    if (out_sz == MP_STREAM_ERROR) {
+        return -1;
+    }
+    return out_sz;
+}
+
+static char _fgetc (mp_obj_t wFile) {
+    char c;
+    _fread(&c, 1, wFile);
+    return c;
+}
+
+static off_t  _flseek(mp_obj_t wFile, off_t offset, int whence)
+{
+    int errno;
+    const mp_stream_p_t *stream_p = mp_get_stream_raise(wFile, MP_STREAM_OP_IOCTL);
+    struct mp_stream_seek_t seek_s;
+    seek_s.offset = offset;
+    seek_s.whence = whence;
+    mp_uint_t res = stream_p->ioctl(MP_OBJ_FROM_PTR(wFile), MP_STREAM_SEEK, (mp_uint_t)(uintptr_t)&seek_s, &errno);
+    if (res == MP_STREAM_ERROR) {
+        return -1;
+    }
+    return seek_s.offset;
+}
+
+static bool _feof(mp_obj_t wFile)
+{
+    int current = _flseek(wFile, 0, SEEK_CUR);
+    int end = _flseek(wFile, 0, MP_SEEK_END);
+    if (current == end) {
+        return true;
+    }
+    _flseek(wFile, current, MP_SEEK_SET);
+    return false;
+}
+
+static void inline _fclose(mp_obj_t wFile)
+{
+    mp_stream_close(wFile);
+}
+
+
+static inline void write_delimiter(mp_obj_t wFile){
+    _fwrite(", ", 1, wFile);
+}
+static inline void write_hex_byte(mp_obj_t wFile, uint8_t value){
+    char buffer[2];
+    buffer[0] = char_for_nibble(value >>   4);
+    buffer[1] = char_for_nibble(value & 0x0f);
+    _fwrite(buffer, 2, wFile);
+}
+
+static inline void write_str(mp_obj_t wFile, const char * str){
+    _fwrite(str, strlen(str), wFile);
+    write_delimiter(wFile);
+}
+static void write_hex(mp_obj_t wFile, const uint8_t * value, int len){
+    int i;
+    for (i = 0; i < len; i++){
+        write_hex_byte(wFile, value[i]);
+    }
+    write_delimiter(wFile);
+}
+static void write_value(mp_obj_t wFile, uint32_t value, int len){
+    switch (len){
+        case 4:
+            write_hex_byte(wFile, value >> 24);
+        case 3:
+            write_hex_byte(wFile, value >> 16);
+        case 2:
+            write_hex_byte(wFile, value >> 8);
+        case 1:
+        default:
+            write_hex_byte(wFile, value);
+    }
+    write_delimiter(wFile);
+}
+
+static void le_device_db_store(void) {
+    int i;
+    // open file
+    mp_obj_t wFile = _fopen(db_path,"w+");
+    if (wFile == NULL) return;
+    _fwrite(csv_header, strlen(csv_header), wFile);
+    _fwrite("\n", 1, wFile);
+    for (i=0;i<LE_DEVICE_MEMORY_SIZE;i++){
+        if (le_devices[i].addr_type == BD_ADDR_TYPE_UNKNOWN) continue;
+        write_value(wFile, le_devices[i].addr_type, 1);
+        write_str(wFile,   bd_addr_to_str(le_devices[i].addr));
+        write_hex(wFile,   le_devices[i].irk, 16);
+        write_hex(wFile,   le_devices[i].ltk, 16);
+        write_value(wFile, le_devices[i].ediv, 2);
+        write_hex(wFile,   le_devices[i].rand, 8);
+        write_value(wFile, le_devices[i].key_size, 1);
+        write_value(wFile, le_devices[i].authenticated, 1);
+        write_value(wFile, le_devices[i].authorized, 1);
+#ifdef ENABLE_LE_SIGNED_WRITE
+        write_hex(wFile,   le_devices[i].remote_csrk, 16);
+        write_value(wFile, le_devices[i].remote_counter, 2);
+        write_hex(wFile,   le_devices[i].local_csrk, 16);
+        write_value(wFile, le_devices[i].local_counter, 2);
+#endif
+        write_value(wFile, le_devices[i].secure_connection, 1);
+        _fwrite("\n", 1, wFile);
+    }
+    _fclose(wFile);
+}
+static void read_delimiter(mp_obj_t wFile){
+    _fgetc(wFile);
+}
+
+static uint8_t read_hex_byte(mp_obj_t wFile){
+    int c = _fgetc(wFile);
+    if (c == ':') {
+        c = _fgetc(wFile);
+    }
+    int d = _fgetc(wFile);
+    return nibble_for_char(c) << 4 | nibble_for_char(d);
+}
+
+static void read_hex(mp_obj_t wFile, uint8_t * buffer, int len){
+    int i;
+    for (i=0;i<len;i++){
+        buffer[i] = read_hex_byte(wFile);
+    }
+    read_delimiter(wFile);
+}
+
+static uint32_t read_value(mp_obj_t wFile, int len){
+    uint32_t res = 0;
+    int i;
+    for (i=0;i<len;i++){
+        res = res << 8 | read_hex_byte(wFile);
+    }
+    read_delimiter(wFile);
+    return res;
+}
+
+static void le_device_db_read(void){
+    // open file
+    mp_obj_t wFile;
+    nlr_buf_t nlr;
+    if (nlr_push(&nlr) == 0) {
+        wFile = _fopen(db_path,"r");
+        nlr_pop();
+    } else {
+        return;
+    }
+
+    // skip header
+    while (true) {
+        int c = _fgetc(wFile);
+        if (_feof(wFile)) goto exit;
+        if (c == '\n') break;
+    }
+    // read entries
+    int i;
+    for (i=0 ; i<LE_DEVICE_MEMORY_SIZE ; i++){
+        memset(&le_devices[i], 0, sizeof(le_device_memory_db_t));
+        le_devices[i].addr_type = read_value(wFile, 1);
+        if (_feof(wFile)){
+            le_devices[i].addr_type = BD_ADDR_TYPE_UNKNOWN;
+            break;
+        }
+        read_hex(wFile,   le_devices[i].addr, 6);
+        read_hex(wFile,   le_devices[i].irk, 16);
+        read_hex(wFile,   le_devices[i].ltk, 16);
+        le_devices[i].ediv = read_value(wFile, 2);
+        read_hex(wFile,   le_devices[i].rand, 8);
+        le_devices[i].key_size      = read_value(wFile, 1);
+        le_devices[i].authenticated = read_value(wFile, 1);
+        le_devices[i].authorized    = read_value(wFile, 1);
+#ifdef ENABLE_LE_SIGNED_WRITE
+        read_hex(wFile,   le_devices[i].remote_csrk, 16);
+        le_devices[i].remote_counter = read_value(wFile, 2);
+        read_hex(wFile,   le_devices[i].local_csrk, 16);
+        le_devices[i].local_counter = read_value(wFile, 2);
+#endif
+        // read next character and secure connection field if hex nibble follows
+        int c = _fgetc(wFile);
+        if (nibble_for_char(c) >= 0){
+            int d = _fgetc(wFile);
+            le_devices[i].secure_connection = nibble_for_char(c) << 4 | nibble_for_char(d);
+            // read newline
+            _fgetc(wFile);
+        }
+    }
+exit:
+    _fclose(wFile);
+}
+
+void le_device_db_init(void){
+    int i;
+    for (i=0;i<LE_DEVICE_MEMORY_SIZE;i++){
+        le_devices[i].addr_type = BD_ADDR_TYPE_UNKNOWN;
+    }
+    snprintf(db_path, sizeof(db_path), DB_PATH_TEMPLATE, "00-00-00-00-00-00");
+}
+
+void le_device_db_set_local_bd_addr(bd_addr_t addr){
+    snprintf(db_path, sizeof(db_path), DB_PATH_TEMPLATE, bd_addr_to_dash_str(addr));
+    log_info("le_device_db_fs: path %s", db_path);
+    le_device_db_read();
+    le_device_db_dump();
+}
+
+// @returns number of device in db
+int le_device_db_count(void){
+    int i;
+    int counter = 0;
+    for (i=0;i<LE_DEVICE_MEMORY_SIZE;i++){
+        if (le_devices[i].addr_type != BD_ADDR_TYPE_UNKNOWN) counter++;
+    }
+    return counter;
+}
+
+int le_device_db_max_count(void){
+    return LE_DEVICE_MEMORY_SIZE;
+}
+
+// free device
+void le_device_db_remove(int index){
+    le_devices[index].addr_type = BD_ADDR_TYPE_UNKNOWN;
+    le_device_db_store();
+}
+
+int le_device_db_add(int addr_type, bd_addr_t addr, sm_key_t irk){
+    int i;
+    int index = -1;
+    for (i=0;i<LE_DEVICE_MEMORY_SIZE;i++){
+         if (le_devices[i].addr_type == BD_ADDR_TYPE_UNKNOWN){
+            index = i;
+            break;
+         }
+    }
+
+    if (index < 0) return -1;
+
+    log_info("Central Device DB adding type %u - %s", addr_type, bd_addr_to_str(addr));
+    log_info_key("irk", irk);
+
+    memset(&le_devices[index], 0, sizeof(le_device_memory_db_t));
+
+    le_devices[index].addr_type = addr_type;
+    memcpy(le_devices[index].addr, addr, 6);
+    memcpy(le_devices[index].irk, irk, 16);
+#ifdef ENABLE_LE_SIGNED_WRITE
+    le_devices[index].remote_counter = 0; 
+#endif
+    le_device_db_store();
+
+    return index;
+}
+
+
+// get device information: addr type and address
+void le_device_db_info(int index, int * addr_type, bd_addr_t addr, sm_key_t irk){
+    if (addr_type) *addr_type = le_devices[index].addr_type;
+    if (addr) memcpy(addr, le_devices[index].addr, 6);
+    if (irk) memcpy(irk, le_devices[index].irk, 16);
+}
+
+void le_device_db_encryption_set(int index, uint16_t ediv, uint8_t rand[8], sm_key_t ltk, int key_size, int authenticated, int authorized, int secure_connection){
+    log_info("LE Device DB set encryption for %u, ediv x%04x, key size %u, authenticated %u, authorized %u, secure connection %u",
+        index, ediv, key_size, authenticated, authorized, secure_connection);
+    le_device_memory_db_t * device = &le_devices[index];
+    device->ediv = ediv;
+    if (rand) memcpy(device->rand, rand, 8);
+    if (ltk) memcpy(device->ltk, ltk, 16);
+    device->key_size = key_size;
+    device->authenticated = authenticated;
+    device->authorized = authorized;
+    device->secure_connection = secure_connection;
+
+    le_device_db_store();
+}
+
+void le_device_db_encryption_get(int index, uint16_t * ediv, uint8_t rand[8], sm_key_t ltk, int * key_size, int * authenticated, int * authorized, int * secure_connection){
+    le_device_memory_db_t * device = &le_devices[index];
+    log_info("LE Device DB encryption for %u, ediv x%04x, keysize %u, authenticated %u, authorized %u, secure connection %u",
+        index, device->ediv, device->key_size, device->authenticated, device->authorized, device->secure_connection);
+    if (ediv) *ediv = device->ediv;
+    if (rand) memcpy(rand, device->rand, 8);
+    if (ltk)  memcpy(ltk, device->ltk, 16);    
+    if (key_size) *key_size = device->key_size;
+    if (authenticated) *authenticated = device->authenticated;
+    if (authorized) *authorized = device->authorized;
+    if (secure_connection) *secure_connection = device->secure_connection;
+}
+
+#ifdef ENABLE_LE_SIGNED_WRITE
+
+// get signature key
+void le_device_db_remote_csrk_get(int index, sm_key_t csrk){
+    if (index < 0 || index >= LE_DEVICE_MEMORY_SIZE){
+        log_error("le_device_db_remote_csrk_get called with invalid index %d", index);
+        return;
+    }
+    if (csrk) memcpy(csrk, le_devices[index].remote_csrk, 16);
+}
+
+void le_device_db_remote_csrk_set(int index, sm_key_t csrk){
+    if (index < 0 || index >= LE_DEVICE_MEMORY_SIZE){
+        log_error("le_device_db_remote_csrk_set called with invalid index %d", index);
+        return;
+    }
+    if (csrk) memcpy(le_devices[index].remote_csrk, csrk, 16);
+
+    le_device_db_store();
+}
+
+void le_device_db_local_csrk_get(int index, sm_key_t csrk){
+    if (index < 0 || index >= LE_DEVICE_MEMORY_SIZE){
+        log_error("le_device_db_local_csrk_get called with invalid index %d", index);
+        return;
+    }
+    if (csrk) memcpy(csrk, le_devices[index].local_csrk, 16);
+}
+
+void le_device_db_local_csrk_set(int index, sm_key_t csrk){
+    if (index < 0 || index >= LE_DEVICE_MEMORY_SIZE){
+        log_error("le_device_db_local_csrk_set called with invalid index %d", index);
+        return;
+    }
+    if (csrk) memcpy(le_devices[index].local_csrk, csrk, 16);
+
+    le_device_db_store();
+}
+
+// query last used/seen signing counter
+uint32_t le_device_db_remote_counter_get(int index){
+    return le_devices[index].remote_counter;
+}
+
+// update signing counter
+void le_device_db_remote_counter_set(int index, uint32_t counter){
+    le_devices[index].remote_counter = counter;
+
+    le_device_db_store();
+}
+
+// query last used/seen signing counter
+uint32_t le_device_db_local_counter_get(int index){
+    return le_devices[index].local_counter;
+}
+
+// update signing counter
+void le_device_db_local_counter_set(int index, uint32_t counter){
+    le_devices[index].local_counter = counter;
+
+    le_device_db_store();
+}
+#endif
+
+void le_device_db_dump(void){
+    log_info("Central Device DB dump, devices: %d", le_device_db_count());
+    int i;
+    for (i=0;i<LE_DEVICE_MEMORY_SIZE;i++){
+        if (le_devices[i].addr_type == BD_ADDR_TYPE_UNKNOWN) continue;
+        log_info("%u: %u %s", i, le_devices[i].addr_type, bd_addr_to_str(le_devices[i].addr));
+        log_info_key("ltk", le_devices[i].ltk);
+        log_info_key("irk", le_devices[i].irk);
+#ifdef ENABLE_LE_SIGNED_WRITE
+        log_info_key("local csrk", le_devices[i].local_csrk);
+        log_info_key("remote csrk", le_devices[i].remote_csrk);
+#endif
+    }
+}
+
+#endif // NVM_NUM_DEVICE_DB_ENTRIES

--- a/extmod/btstack/le_device_db_fs.h
+++ b/extmod/btstack/le_device_db_fs.h
@@ -1,0 +1,58 @@
+/*
+ * Copyright (C) 2016 BlueKitchen GmbH
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of the copyright holders nor the names of
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ * 4. Any redistribution, use, or modification is done solely for
+ *    personal benefit and not for any commercial purpose or for
+ *    monetary gain.
+ *
+ * THIS SOFTWARE IS PROVIDED BY BLUEKITCHEN GMBH AND CONTRIBUTORS
+ * ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL MATTHIAS
+ * RINGWALD OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
+ * THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ *
+ * Please inquire about commercial licensing options at 
+ * contact@bluekitchen-gmbh.com
+ *
+ */
+
+#ifndef LE_DEVICE_DB_FS_H
+#define LE_DEVICE_DB_FS_H
+
+#include "ble/le_device_db.h"
+
+#if defined __cplusplus
+extern "C" {
+#endif
+
+/*
+ * @brief Get le device db implementation that stores bonding information in /tmp
+ */
+const le_device_db_t * le_device_db_fs_instance(void);
+
+/* API_END */
+
+#if defined __cplusplus
+}
+#endif
+
+#endif // LE_DEVICE_DB_FS_H

--- a/extmod/btstack/modbluetooth_btstack.c
+++ b/extmod/btstack/modbluetooth_btstack.c
@@ -291,20 +291,34 @@ STATIC void btstack_packet_handler(uint8_t packet_type, uint8_t *packet, uint8_t
 
     if (event_type == HCI_EVENT_LE_META) {
         DEBUG_printf("  --> hci le meta\n");
-        if (hci_event_le_meta_get_subevent_code(packet) == HCI_SUBEVENT_LE_CONNECTION_COMPLETE) {
-            uint16_t conn_handle = hci_subevent_le_connection_complete_get_connection_handle(packet);
-            uint8_t addr_type = hci_subevent_le_connection_complete_get_peer_address_type(packet);
-            bd_addr_t addr;
-            hci_subevent_le_connection_complete_get_peer_address(packet, addr);
-            uint16_t irq_event;
-            if (hci_subevent_le_connection_complete_get_role(packet) == 0) {
-                // Master role.
-                irq_event = MP_BLUETOOTH_IRQ_PERIPHERAL_CONNECT;
-            } else {
-                // Slave role.
-                irq_event = MP_BLUETOOTH_IRQ_CENTRAL_CONNECT;
+        switch (hci_event_le_meta_get_subevent_code(packet)) {
+            case HCI_SUBEVENT_LE_CONNECTION_COMPLETE: {
+                uint16_t conn_handle = hci_subevent_le_connection_complete_get_connection_handle(packet);
+                uint8_t addr_type = hci_subevent_le_connection_complete_get_peer_address_type(packet);
+                bd_addr_t addr;
+                hci_subevent_le_connection_complete_get_peer_address(packet, addr);
+                uint16_t irq_event;
+                if (hci_subevent_le_connection_complete_get_role(packet) == 0) {
+                    // Master role.
+                    irq_event = MP_BLUETOOTH_IRQ_PERIPHERAL_CONNECT;
+                } else {
+                    // Slave role.
+                    irq_event = MP_BLUETOOTH_IRQ_CENTRAL_CONNECT;
+                }
+                mp_bluetooth_gap_on_connected_disconnected(irq_event, conn_handle, addr_type, addr);
+                break;
             }
-            mp_bluetooth_gap_on_connected_disconnected(irq_event, conn_handle, addr_type, addr);
+            case HCI_SUBEVENT_LE_CONNECTION_UPDATE_COMPLETE: {
+                // print connection parameters (without using float operations)
+                int con_handle = hci_subevent_le_connection_update_complete_get_connection_handle(packet);
+                int conn_interval = hci_subevent_le_connection_update_complete_get_conn_interval(packet);
+                int latency = hci_subevent_le_connection_update_complete_get_conn_latency(packet);
+                int timeout = hci_subevent_le_connection_update_complete_get_supervision_timeout(packet);
+                DEBUG_printf("- LE Connection %04x: connection update - connection interval %u.%02u ms, latency %u\n",
+                    con_handle, conn_interval * 125 / 100, 25 * (conn_interval & 3), latency);
+                mp_bluetooth_gatts_on_conn_update(con_handle, conn_interval, latency, timeout);
+                break;
+            }
         }
     } else if (event_type == BTSTACK_EVENT_STATE) {
         uint8_t state = btstack_event_state_get_state(packet);
@@ -1100,6 +1114,11 @@ int mp_bluetooth_gatts_indicate(uint16_t conn_handle, uint16_t value_handle) {
 int mp_bluetooth_gatts_set_buffer(uint16_t value_handle, size_t len, bool append) {
     DEBUG_printf("mp_bluetooth_gatts_set_buffer\n");
     return mp_bluetooth_gatts_db_resize(MP_STATE_PORT(bluetooth_btstack_root_pointers)->gatts_db, value_handle, len, append);
+}
+
+int mp_bluetooth_gap_pair(int conn_handle, bool bond, bool mitm, bool lesc) {
+    DEBUG_printf("TODO mp_bluetooth_gap_pair\n");
+    return 0;
 }
 
 int mp_bluetooth_gap_disconnect(uint16_t conn_handle) {

--- a/extmod/btstack/modbluetooth_btstack.c
+++ b/extmod/btstack/modbluetooth_btstack.c
@@ -31,12 +31,9 @@
 #if MICROPY_PY_BLUETOOTH && MICROPY_BLUETOOTH_BTSTACK
 
 #include "extmod/btstack/modbluetooth_btstack.h"
-#include "extmod/btstack/btstack_tlv_mpy.h"
 #include "extmod/modbluetooth.h"
 
 #include "lib/btstack/src/btstack.h"
-#include "lib/btstack/src/ble/le_device_db_tlv.h"
-#include "lib/btstack/src/classic/btstack_link_key_db_tlv.h"
 
 #define DEBUG_printf(...) // printf("btstack: " __VA_ARGS__)
 
@@ -55,9 +52,6 @@ STATIC const uint32_t BTSTACK_INIT_DEINIT_TIMEOUT_MS = 15000;
 STATIC const uint16_t BTSTACK_GAP_DEVICE_NAME_HANDLE = 3;
 
 volatile int mp_bluetooth_btstack_state = MP_BLUETOOTH_BTSTACK_STATE_OFF;
-
-static const btstack_tlv_t * tlv_impl;
-static btstack_tlv_mpy_t   tlv_context;
 
 #define ERRNO_BLUETOOTH_NOT_ACTIVE MP_ENODEV
 
@@ -137,6 +131,8 @@ enum {
     MP_BLUETOOTH_BTSTACK_PENDING_WRITE, // Waiting for write done event
 };
 
+static const btstack_tlv_t * tlv_impl;
+static btstack_tlv_mpy_t   tlv_context;
 // Pending operation:
 //  - Holds a GC reference to the copied outgoing buffer.
 //  - Provides enough information for the callback handler to execute the desired operation.
@@ -682,17 +678,6 @@ int mp_bluetooth_init(void) {
 
     #if MICROPY_PY_BLUETOOTH_ENABLE_CENTRAL_MODE
     gatt_client_init();
-    #endif
-
-    #ifdef MICROPY_PY_BLUETOOTH_BOND_FILE
-    tlv_impl = btstack_tlv_mpy_init_instance(&tlv_context, MICROPY_PY_BLUETOOTH_BOND_FILE);
-    btstack_tlv_set_instance(tlv_impl, &tlv_context);
-    #ifdef ENABLE_CLASSIC
-    hci_set_link_key_db(btstack_link_key_db_tlv_get_instance(tlv_impl, &tlv_context));
-    #endif
-    #ifdef ENABLE_BLE
-    le_device_db_tlv_configure(tlv_impl, &tlv_context);
-    #endif
     #endif
 
     // Register for HCI events.

--- a/extmod/btstack/modbluetooth_btstack.c
+++ b/extmod/btstack/modbluetooth_btstack.c
@@ -521,11 +521,11 @@ static void btstack_sm_packet_handler(uint8_t packet_type, uint16_t channel, uin
             sm_just_works_confirm(sm_event_just_works_request_get_handle(packet));
             break;
         case SM_EVENT_NUMERIC_COMPARISON_REQUEST:
-            printf("Confirming numeric comparison: %u\n", sm_event_numeric_comparison_request_get_passkey(packet));
+            printf("Confirming numeric comparison: %lu\n", sm_event_numeric_comparison_request_get_passkey(packet));
             sm_numeric_comparison_confirm(sm_event_passkey_display_number_get_handle(packet));
             break;
         case SM_EVENT_PASSKEY_DISPLAY_NUMBER:
-            printf("Display Passkey: %u\n", sm_event_passkey_display_number_get_passkey(packet));
+            printf("Display Passkey: %lu\n", sm_event_passkey_display_number_get_passkey(packet));
             break;
         case SM_EVENT_PASSKEY_INPUT_NUMBER:
             printf("Passkey Input requested\n");

--- a/extmod/modbluetooth.c
+++ b/extmod/modbluetooth.c
@@ -457,11 +457,11 @@ STATIC int bluetooth_gatts_register_service(mp_obj_t uuid_in, mp_obj_t character
 
     // Lists of characteristic uuids and flags.
     mp_obj_bluetooth_uuid_t **characteristic_uuids = m_new(mp_obj_bluetooth_uuid_t *, len);
-    uint8_t *characteristic_flags = m_new(uint8_t, len);
+    uint16_t *characteristic_flags = m_new(uint16_t, len);
 
     // Flattened list of descriptor uuids and flags. Grows (realloc) as more descriptors are encountered.
     mp_obj_bluetooth_uuid_t **descriptor_uuids = NULL;
-    uint8_t *descriptor_flags = NULL;
+    uint16_t *descriptor_flags = NULL;
     // How many descriptors in the flattened list per characteristic.
     uint8_t *num_descriptors = m_new(uint8_t, len);
 
@@ -502,7 +502,7 @@ STATIC int bluetooth_gatts_register_service(mp_obj_t uuid_in, mp_obj_t character
 
             // Grow the flattened uuids and flags arrays with this many more descriptors.
             descriptor_uuids = m_renew(mp_obj_bluetooth_uuid_t *, descriptor_uuids, descriptor_index, descriptor_index + num_descriptors[characteristic_index]);
-            descriptor_flags = m_renew(uint8_t, descriptor_flags, descriptor_index, descriptor_index + num_descriptors[characteristic_index]);
+            descriptor_flags = m_renew(uint16_t, descriptor_flags, descriptor_index, descriptor_index + num_descriptors[characteristic_index]);
 
             // Also grow the handles array.
             *handles = m_renew(uint16_t, *handles, *num_handles, *num_handles + num_descriptors[characteristic_index]);

--- a/extmod/modbluetooth.h
+++ b/extmod/modbluetooth.h
@@ -190,7 +190,7 @@ void mp_bluetooth_gap_advertise_stop(void);
 int mp_bluetooth_gatts_register_service_begin(bool append);
 // Add a service with the given list of characteristics to the queue to be registered.
 // The value_handles won't be valid until after mp_bluetooth_register_service_end is called.
-int mp_bluetooth_gatts_register_service(mp_obj_bluetooth_uuid_t *service_uuid, mp_obj_bluetooth_uuid_t **characteristic_uuids, uint8_t *characteristic_flags, mp_obj_bluetooth_uuid_t **descriptor_uuids, uint8_t *descriptor_flags, uint8_t *num_descriptors, uint16_t *handles, size_t num_characteristics);
+int mp_bluetooth_gatts_register_service(mp_obj_bluetooth_uuid_t *service_uuid, mp_obj_bluetooth_uuid_t **characteristic_uuids, uint16_t *characteristic_flags, mp_obj_bluetooth_uuid_t **descriptor_uuids, uint16_t *descriptor_flags, uint8_t *num_descriptors, uint16_t *handles, size_t num_characteristics);
 // Register any queued services.
 int mp_bluetooth_gatts_register_service_end(void);
 

--- a/extmod/nimble/modbluetooth_nimble.c
+++ b/extmod/nimble/modbluetooth_nimble.c
@@ -646,7 +646,7 @@ int mp_bluetooth_gatts_register_service_end() {
     return 0;
 }
 
-int mp_bluetooth_gatts_register_service(mp_obj_bluetooth_uuid_t *service_uuid, mp_obj_bluetooth_uuid_t **characteristic_uuids, uint8_t *characteristic_flags, mp_obj_bluetooth_uuid_t **descriptor_uuids, uint8_t *descriptor_flags, uint8_t *num_descriptors, uint16_t *handles, size_t num_characteristics) {
+int mp_bluetooth_gatts_register_service(mp_obj_bluetooth_uuid_t *service_uuid, mp_obj_bluetooth_uuid_t **characteristic_uuids, uint16_t *characteristic_flags, mp_obj_bluetooth_uuid_t **descriptor_uuids, uint16_t *descriptor_flags, uint8_t *num_descriptors, uint16_t *handles, size_t num_characteristics) {
     if (MP_STATE_PORT(bluetooth_nimble_root_pointers)->n_services == MP_BLUETOOTH_NIMBLE_MAX_SERVICES) {
         return MP_E2BIG;
     }

--- a/ports/unix/mpbtstackport_common.c
+++ b/ports/unix/mpbtstackport_common.c
@@ -36,9 +36,9 @@
 #include "lib/btstack/platform/embedded/btstack_run_loop_embedded.h"
 #include "lib/btstack/platform/embedded/hal_cpu.h"
 #include "lib/btstack/platform/embedded/hal_time_ms.h"
-#include "lib/btstack/platform/posix/btstack_tlv_posix.h"
 
 #include "extmod/btstack/modbluetooth_btstack.h"
+#include "extmod/btstack/btstack_tlv_mpy.h"
 
 #include "mpbtstackport.h"
 
@@ -51,7 +51,7 @@ STATIC bool using_static_address = false;
 #define TLV_DB_PATH_POSTFIX ".tlv"
 static char tlv_db_path[100];
 static const btstack_tlv_t * tlv_impl;
-static btstack_tlv_posix_t   tlv_context;
+static btstack_tlv_mpy_t   tlv_context;
 
 STATIC btstack_packet_callback_registration_t hci_event_callback_registration;
 
@@ -93,7 +93,7 @@ STATIC void packet_handler(uint8_t packet_type, uint16_t channel, uint8_t *packe
             strcpy(tlv_db_path, TLV_DB_PATH_PREFIX);
             strcat(tlv_db_path, bd_addr_to_str(local_addr));
             strcat(tlv_db_path, TLV_DB_PATH_POSTFIX);
-            tlv_impl = btstack_tlv_posix_init_instance(&tlv_context, tlv_db_path);
+            tlv_impl = btstack_tlv_mpy_init_instance(&tlv_context, tlv_db_path);
             btstack_tlv_set_instance(tlv_impl, &tlv_context);
 #ifdef ENABLE_CLASSIC
             hci_set_link_key_db(btstack_link_key_db_tlv_get_instance(tlv_impl, &tlv_context));

--- a/ports/unix/mpbtstackport_common.c
+++ b/ports/unix/mpbtstackport_common.c
@@ -31,16 +31,31 @@
 #if MICROPY_PY_BLUETOOTH && MICROPY_BLUETOOTH_BTSTACK
 
 #include "lib/btstack/src/btstack.h"
-
+#include "lib/btstack/src/ble/le_device_db_tlv.h"
+#include "lib/btstack/src/classic/btstack_link_key_db_tlv.h"
 #include "lib/btstack/platform/embedded/btstack_run_loop_embedded.h"
 #include "lib/btstack/platform/embedded/hal_cpu.h"
 #include "lib/btstack/platform/embedded/hal_time_ms.h"
+#include "lib/btstack/platform/posix/btstack_tlv_posix.h"
 
 #include "extmod/btstack/modbluetooth_btstack.h"
 
 #include "mpbtstackport.h"
 
-// Called by the UART polling thread in mpbthciport.c, or by the USB polling thread in mpbtstackport_usb.c.
+STATIC uint8_t local_addr[6] = {0};
+STATIC uint8_t static_address[6] = {0};
+STATIC volatile bool have_addr = false;
+STATIC bool using_static_address = false;
+
+#define TLV_DB_PATH_PREFIX "/tmp/btstack_"
+#define TLV_DB_PATH_POSTFIX ".tlv"
+static char tlv_db_path[100];
+static const btstack_tlv_t * tlv_impl;
+static btstack_tlv_posix_t   tlv_context;
+
+STATIC btstack_packet_callback_registration_t hci_event_callback_registration;
+
+// Called by the UART polling thread in mphciport.c, or by the USB polling thread in mpbtstackport_usb.c.
 bool mp_bluetooth_hci_poll(void) {
     if (mp_bluetooth_btstack_state == MP_BLUETOOTH_BTSTACK_STATE_STARTING || mp_bluetooth_btstack_state == MP_BLUETOOTH_BTSTACK_STATE_ACTIVE || mp_bluetooth_btstack_state == MP_BLUETOOTH_BTSTACK_STATE_HALTING) {
         // Pretend like we're running in IRQ context (i.e. other things can't be running at the same time).
@@ -55,6 +70,50 @@ bool mp_bluetooth_hci_poll(void) {
     }
 
     return false;
+}
+
+STATIC void packet_handler(uint8_t packet_type, uint16_t channel, uint8_t *packet, uint16_t size) {
+    (void)channel;
+    (void)size;
+    if (packet_type != HCI_EVENT_PACKET) {
+        return;
+    }
+    switch (hci_event_packet_get_type(packet)) {
+        case BTSTACK_EVENT_STATE:
+            if (btstack_event_state_get_state(packet) != HCI_STATE_WORKING) {
+                return;
+            }
+            gap_local_bd_addr(local_addr);
+            if (using_static_address) {
+                memcpy(local_addr, static_address, sizeof(local_addr));
+            }
+            have_addr = true;
+
+            printf("BTstack up and running on %s.\n", bd_addr_to_str(local_addr));
+            strcpy(tlv_db_path, TLV_DB_PATH_PREFIX);
+            strcat(tlv_db_path, bd_addr_to_str(local_addr));
+            strcat(tlv_db_path, TLV_DB_PATH_POSTFIX);
+            tlv_impl = btstack_tlv_posix_init_instance(&tlv_context, tlv_db_path);
+            btstack_tlv_set_instance(tlv_impl, &tlv_context);
+#ifdef ENABLE_CLASSIC
+            hci_set_link_key_db(btstack_link_key_db_tlv_get_instance(tlv_impl, &tlv_context));
+#endif
+#ifdef ENABLE_BLE
+            le_device_db_tlv_configure(tlv_impl, &tlv_context);
+#endif
+
+            break;
+        case HCI_EVENT_COMMAND_COMPLETE:
+            if (memcmp(packet, read_static_address_command_complete_prefix, sizeof(read_static_address_command_complete_prefix)) == 0) {
+                reverse_48(&packet[7], static_address);
+                gap_random_address_set(static_address);
+                using_static_address = true;
+                have_addr = true;
+            }
+            break;
+        default:
+            break;
+    }
 }
 
 // The IRQ functionality in btstack_run_loop_embedded.c is not used, so the


### PR DESCRIPTION
This is less finished than https://github.com/micropython/micropython/pull/6289 but does add basic support for persistent bonding.

It's based heavily on initial work by @jimmo to bring in most of the pairing infrastructure for btstack, with additional commits to add the filesystem interface for persistent bonding.

It does not use the same json backed file storage as my nimble PR above, opting at this stage to re-use btstack's own file format with updated bindings to the micropython file system.

Most btstack bonding ports use their "tlv" based storage system. A good portion of this relies on malloc/free however, for which there isn't currently an implementation set up for btstack. If btstack gets a similar dynamic memory allocator as nimble, this config system would likely be more reliable/performant based on my initial investigating - bindings to use tlv are included in this branch.

The currently enabled bindings however are based on a simpler single-file bonding interface picked from one of the posix ports: https://github.com/bluekitchen/btstack/blob/f07720a033c9fcfa856511634253b9889fa94cd8/platform/posix/le_device_db_fs.c