### PR TITLE
stm32/nimble: Ensure bluetooth critical section allows uart interrupt.

### DIFF
--- a/extmod/nimble/nimble/npl_os.c
+++ b/extmod/nimble/nimble/npl_os.c
@@ -388,10 +388,11 @@ void ble_npl_time_delay(ble_npl_time_t ticks) {
 
 uint32_t ble_npl_hw_enter_critical(void) {
     DEBUG_CRIT_printf("ble_npl_hw_enter_critical()\n");
-    return raise_irq_pri(15);
+    MICROPY_PY_BLUETOOTH_ENTER;
+    return atomic_state;
 }
 
-void ble_npl_hw_exit_critical(uint32_t ctx) {
-    DEBUG_CRIT_printf("ble_npl_hw_exit_critical(%u)\n", (uint)ctx);
-    restore_irq_pri(ctx);
+void ble_npl_hw_exit_critical(uint32_t atomic_state) {
+    DEBUG_CRIT_printf("ble_npl_hw_exit_critical(%u)\n", (uint)atomic_state);
+    MICROPY_PY_BLUETOOTH_EXIT;
 }

--- a/ports/stm32/mpconfigport.h
+++ b/ports/stm32/mpconfigport.h
@@ -415,8 +415,13 @@ static inline mp_uint_t disable_irq(void) {
 #define MICROPY_PY_LWIP_EXIT    restore_irq_pri(atomic_state);
 
 // Bluetooth calls must run at a raised IRQ priority
-#define MICROPY_PY_BLUETOOTH_ENTER MICROPY_PY_LWIP_ENTER
-#define MICROPY_PY_BLUETOOTH_EXIT MICROPY_PY_LWIP_EXIT
+
+#if defined(STM32WB)
+#define MICROPY_PY_BLUETOOTH_ENTER uint32_t atomic_state = raise_irq_pri(IRQ_PRI_PENDSV);
+#else
+#define MICROPY_PY_BLUETOOTH_ENTER uint32_t atomic_state = raise_irq_pri(IRQ_PRI_UART);
+#endif
+#define MICROPY_PY_BLUETOOTH_EXIT  restore_irq_pri(atomic_state);
 
 // We need an implementation of the log2 function which is not a macro
 #define MP_NEED_LOG2 (1)


### PR DESCRIPTION
The `MICROPY_PY_BLUETOOTH_ENTER` / `MICROPY_PY_BLUETOOTH_EXIT` defines are used regularly to increase the priority of bluetooth processing.

On the stm32 port, this define is currently mapped to `MICROPY_PY_LWIP_ENTER/EXIT` which masks interrupts to `IRQ_PRI_PENDSV` as used to process background polling bluetooth functions.

This however masks out the uart which is used for uart hci bluetooth operations. This adds significant unreliability to the uart hci transport. 
For instance, if the wfi at https://github.com/micropython/micropython/blob/9883d8e818feba112935676eb5aa4ce211d7779c/extmod/nimble/nimble/npl_os.c#L252 is commented out, currently the uart transport if completely broken and fails at the first communication - the loop here times out without ever receiving /processing uart comms.

Actually, I guess this change should only be done if uart hci is enabled, it's not needed for esp / wb55 etc.