### PR TITLE
zephyr: Include storage/flash_map.h unconditionally.

### DIFF
--- a/ports/zephyr/main.c
+++ b/ports/zephyr/main.c
@@ -38,9 +38,7 @@
 #include <usb/usb_device.h>
 #endif
 
-#ifdef CONFIG_FLASH_MAP
 #include <storage/flash_map.h>
-#endif
 
 #include "py/mperrno.h"
 #include "py/compile.h"


### PR DESCRIPTION
Include storage/flash_map.h unconditionally so we always have access to
the FLASH_AREA_LABEL_EXISTS macro, even if CONFIG_FLASH_MAP is not
defined.

This fixes a build error for the qemu_x86 board:

main.c:108:63: error: missing binary operator before token "("
  108 |     #elif defined(CONFIG_FLASH_MAP) && FLASH_AREA_LABEL_EXISTS(storage)
      |                                                               ^
../../py/mkrules.mk:88: recipe for target 'build/genhdr/qstr.i.last' failed

Signed-off-by: Maureen Helm <maureen.helm@nxp.com>

Fixes #6307