### PR TITLE
tools/makemanifest.py: Print nicely formatted errors from mpy-cross.

### DIFF
--- a/tools/makemanifest.py
+++ b/tools/makemanifest.py
@@ -288,7 +288,8 @@ def main():
                     + ["-o", outfile, "-s", script, "-O{}".format(opt), infile]
                 )
                 if res != 0:
-                    print("error compiling {}: {}".format(infile, out))
+                    print("error compiling {}:".format(infile))
+                    sys.stdout.buffer.write(out)
                     raise SystemExit(1)
                 ts_outfile = get_timestamp(outfile)
             mpy_files.append(outfile)


### PR DESCRIPTION
If mpy-cross exits with an error be sure to print that error in a way that is readable, instead of a long bytes object.