### PR TITLE
stm32: pin sometimes prints incorrectly

### DIFF
--- a/ports/stm32/pin_defs_stm32.c
+++ b/ports/stm32/pin_defs_stm32.c
@@ -8,9 +8,9 @@
 uint32_t pin_get_mode(const pin_obj_t *pin) {
     GPIO_TypeDef *gpio = pin->gpio;
     uint32_t mode = (gpio->MODER >> (pin->pin * 2)) & 3;
-    if (mode != GPIO_MODE_ANALOG) {
+    if (mode == GPIO_MODE_OUTPUT_PP || mode == GPIO_MODE_AF_PP) {
         if (gpio->OTYPER & pin->pin_mask) {
-            mode |= 1 << 4;
+            mode |= 1 << 4;     // Converts from xxx_PP to xxx_OD
         }
     }
     return mode;


### PR DESCRIPTION
If you configure a pin as an output type (I2C in this example)
and then later configure it back as an input, then it will
report the type incorrectly. Example:
```
>>> import machine
>>> b6 = machine.Pin('B6')
>>> b6
Pin(Pin.cpu.B6, mode=Pin.IN)
>>> machine.I2C(1)
I2C(1, scl=B6, sda=B7, freq=420000)
>>> b6
Pin(Pin.cpu.B6, mode=Pin.ALT_OPEN_DRAIN, pull=Pin.PULL_UP, af=Pin.AF4_I2C1)
>>> b6.init(machine.Pin.IN)
>>> b6
Pin(Pin.cpu.B6, mode=Pin.ALT_OPEN_DRAIN, af=Pin.AF4_I2C1)
>>>
```
with this fix, the last print now works properly:
```
>>> b6
Pin(Pin.cpu.B6, mode=Pin.IN)
>>>
```