### PR TITLE
tools/pyboard.py: eval() of received data is dangerous. Remote code execution possible.

### DIFF
--- a/tools/pyboard.py
+++ b/tools/pyboard.py
@@ -70,6 +70,7 @@ Or:
 import sys
 import time
 import os
+import ast
 
 try:
     stdout = sys.stdout.buffer
@@ -426,7 +427,12 @@ class Pyboard:
                 data = bytearray()
                 self.exec_("print(r(%u))" % chunk_size, data_consumer=lambda d: data.extend(d))
                 assert data.endswith(b"\r\n\x04")
-                data = eval(str(data[:-3], "ascii"))
+                try:
+                    data = ast.literal_eval(str(data[:-3], "ascii"))
+                    if not isinstance(data, bytes):
+                        raise ValueError("Not bytes")
+                except (UnicodeError, ValueError) as e:
+                    raise PyboardError("fs_get: Could not interpret received data: %s" % str(e))
                 if not data:
                     break
                 f.write(data)


### PR DESCRIPTION
pyboard.py uses eval() to "parse" file data received from the board.
Using eval() on received data from the Micropython board is dangerous,
because a malicious board may inject arbitrary code execution on the PC
that is doing the operation.

Consider the following scenario:

Eve may write a malicious script to Bob's Micropython board in his
absence. On return Bob notices that something is wrong with the board,
because it doesn't work as expected anymore. He wants to read out
boot.py (or any other file) to see what is wrong. What he gets is a
remote code execution on his PC.

Proof of concept:

Eve:

```
  $ cat boot.py
  _print = print
  print = lambda *x, **y: _print("os.system('ls /; echo Pwned!')", end="\r\n\x04")
  $ ./pyboard.py -f cp boot.py :
  cp boot.py :boot.py
```

Bob:

```
  $ ./pyboard.py -f cp :boot.py /tmp/foo
  cp :boot.py /tmp/foo
  bin   chroot  dev  home        initrd.img.old  lib32  libx32      media  opt   root  sbin  sys  usr  vmlinuz
  boot  config  etc  initrd.img  lib             lib64  lost+found  mnt    proc  run   srv   tmp  var  vmlinuz.old
  Pwned!
```

Fix this by not using eval() to parse the received bytes.
Parse the bytes repr manually.

Parser test:
```
micropython/tools$ cat test.sh 
#!/bin/sh
set -e
./pyboard.py -d /dev/ttyUSB1 -f cp pyboard.py :pyboard.py
./pyboard.py -d /dev/ttyUSB1 -f cp :pyboard.py /tmp/pyboard2.py
cmp pyboard.py /tmp/pyboard2.py || exit 1
dd if=/dev/urandom of=/tmp/test.bin bs=1024 count=8
./pyboard.py -d /dev/ttyUSB1 -f cp /tmp/test.bin :test.bin
./pyboard.py -d /dev/ttyUSB1 -f cp :test.bin /tmp/test2.bin
cmp /tmp/test.bin /tmp/test2.bin || exit 1
echo "Ok!"

micropython/tools$ ./test.sh 
cp pyboard.py :pyboard.py
cp :pyboard.py /tmp/pyboard2.py
8+0 records in
8+0 records out
8192 bytes (8.2 kB, 8.0 KiB) copied, 0.000121316 s, 67.5 MB/s
cp /tmp/test.bin :test.bin
cp :test.bin /tmp/test2.bin
Ok!
```

This problem been reported and discussed in private in advance to this pull request. It has been agreed by all parties to create a pull request to fix the problem.
Thanks for the very quick and professional response!