### PR TITLE
tools/mpy-tool.py: Fix offset of line number info.

### DIFF
--- a/tools/mpy-tool.py
+++ b/tools/mpy-tool.py
@@ -253,6 +253,7 @@ class RawCode(object):
             self.ip, self.ip2, self.prelude = extract_prelude(self.bytecode, self.prelude_offset)
             self.simple_name = self._unpack_qstr(self.ip2)
             self.source_file = self._unpack_qstr(self.ip2 + 2)
+            self.line_info_offset = self.ip2 + 4
 
     def _unpack_qstr(self, ip):
         qst = self.bytecode[ip] | self.bytecode[ip + 1] << 8
@@ -404,7 +405,10 @@ class RawCode(object):
             print("        .n_def_pos_args = %u," % self.prelude[5])
             print("        .qstr_block_name = %s," % self.simple_name.qstr_id)
             print("        .qstr_source_file = %s," % self.source_file.qstr_id)
-            print("        .line_info = fun_data_%s + %u," % (self.escaped_name, 0))  # TODO
+            print(
+                "        .line_info = fun_data_%s + %u,"
+                % (self.escaped_name, self.line_info_offset)
+            )
             print("        .opcodes = fun_data_%s + %u," % (self.escaped_name, self.ip))
             print("    },")
             print("    .line_of_definition = %u," % 0)  # TODO


### PR DESCRIPTION
When `mpy-tool.py` freezes functions it generates wrong pointer to the line number information. This manifests as garbage line numbers being reported in settrace hook (e.g. line 1000+ in 50-line file).