### PR TITLE
nRF : user C modules compatible, enable in Makefile

### DIFF
--- a/ports/nrf/Makefile
+++ b/ports/nrf/Makefile
@@ -113,7 +113,7 @@ endif
 
 
 CFLAGS += $(CFLAGS_MCU_$(MCU_SERIES))
-CFLAGS += $(INC) -Wall -Werror -g -ansi -std=c11 -nostdlib $(COPT) $(NRF_DEFINES) $(CFLAGS_MOD)
+CFLAGS += $(INC) -Wall -Werror -g -ansi -std=c11 -nostdlib $(COPT) $(NRF_DEFINES) $(CFLAGS_MOD) $(CFLAGS_EXTRA)
 CFLAGS += -fno-strict-aliasing
 CFLAGS += -Iboards/$(BOARD)
 CFLAGS += -DNRF5_HAL_H='<$(MCU_VARIANT)_hal.h>'
@@ -445,11 +445,11 @@ flash: deploy
 
 $(BUILD)/$(OUTPUT_FILENAME).elf: $(OBJ)
 	$(ECHO) "LINK $@"
-	$(Q)$(CC) $(LDFLAGS) -o $@ $(OBJ) $(LIBS)
+	$(Q)$(CC) $(LDFLAGS) -o $@ $(OBJ) $(LDFLAGS_MOD) $(LIBS)
 	$(Q)$(SIZE) $@
 
 # List of sources for qstr extraction
-SRC_QSTR += $(SRC_C) $(SRC_LIB) $(DRIVERS_SRC_C) $(SRC_BOARD_MODULES)
+SRC_QSTR += $(SRC_C) $(SRC_LIB) $(DRIVERS_SRC_C) $(SRC_BOARD_MODULES) $(SRC_MOD) 
 
 # Append any auto-generated sources that are needed by sources listed in
 # SRC_QSTR


### PR DESCRIPTION
User (External) C modules are not currently enabled in MicroPython ports/nrf because 'micropython/ports/nrf/Makefile' don't use all of these keywords, 'SRC_MOD', 'CFLAGS_MOD', 'LDFLAGS_MOD' and 'CFLAGS_EXTRA', in the right place.

This PR fix this issue, inserting 'SRC_MOD', 'CFLAGS_MOD', 'LDFLAGS_MOD' and 'CFLAGS_EXTRA' in correct places of 'micropython/ports/nrf/Makefile' so that user (external) C modules can be built when compiling nRF firmware.