### PR TITLE
py/runtime: Fix builtin compile() in "single" mode so it prints exprs.

### DIFF
--- a/py/runtime.c
+++ b/py/runtime.c
@@ -1473,7 +1473,7 @@ mp_obj_t mp_parse_compile_execute(mp_lexer_t *lex, mp_parse_input_kind_t parse_i
     if (nlr_push(&nlr) == 0) {
         qstr source_name = lex->source_name;
         mp_parse_tree_t parse_tree = mp_parse(lex, parse_input_kind);
-        mp_obj_t module_fun = mp_compile(&parse_tree, source_name, false);
+        mp_obj_t module_fun = mp_compile(&parse_tree, source_name, parse_input_kind == MP_PARSE_SINGLE_INPUT);
 
         mp_obj_t ret;
         if (MICROPY_PY_BUILTINS_COMPILE && globals == NULL) {

--- a/tests/basics/builtin_compile.py
+++ b/tests/basics/builtin_compile.py
@@ -1,11 +1,10 @@
 # test compile builtin
 
-def have_compile():
-    try:
-        compile
-        return True
-    except NameError:
-        return False
+try:
+    compile
+except NameError:
+    print("SKIP")
+    raise SystemExit
 
 def test():
     global x
@@ -26,8 +25,9 @@ def test():
     exec(c, {}, {"x":3})
 
     # single/eval mode
-    exec(compile('print(1 + 1)', 'file', 'single'))
-    print(eval(compile('1 + 1', 'file', 'eval')))
+    exec(compile("if 1: 10 + 1\n", "file", "single"))
+    exec(compile("print(10 + 2)", "file", "single"))
+    print(eval(compile("10 + 3", "file", "eval")))
 
     # bad mode
     try:
@@ -42,8 +42,4 @@ def test():
         print("NameError")
     print(x) # check 'x' still exists as a global
 
-if have_compile():
-    test()
-else:
-    print("SKIP")
-    raise SystemExit
+test()


### PR DESCRIPTION
As per CPython behaviour, compile(stmt, "file", "single") should create code which prints to stdout (via __repl_print__) the results of any expressions in stmt.