### PR TITLE
docs/library/machine.Timer.rst: Add documentation for constructor arguments.

### DIFF
--- a/docs/library/machine.Timer.rst
+++ b/docs/library/machine.Timer.rst
@@ -31,6 +31,8 @@ Constructors
 
    Construct a new timer object of the given id. Id of -1 constructs a
    virtual timer (if supported by a board).
+   
+   See ``init`` for parameters of initialisation.
 
 Methods
 -------


### PR DESCRIPTION
Followed convention in other classes that have an `init` method and referenced `init` from constructor.