### PR TITLE
extmod/uasyncio: Truncate negative sleeps to 0.

### DIFF
--- a/extmod/uasyncio/core.py
+++ b/extmod/uasyncio/core.py
@@ -53,7 +53,7 @@ class SingletonGenerator:
 # Use a SingletonGenerator to do it without allocating on the heap
 def sleep_ms(t, sgen=SingletonGenerator()):
     assert sgen.state is None
-    sgen.state = ticks_add(ticks(), t)
+    sgen.state = ticks_add(ticks(), max(0, t))
     return sgen
 
 

--- a/tests/extmod/uasyncio_basic.py
+++ b/tests/extmod/uasyncio_basic.py
@@ -36,8 +36,16 @@ async def main():
     t1 = ticks()
     await delay_print(0.04, "long")
     t2 = ticks()
+    await delay_print(-1, "negative")
+    t3 = ticks()
 
-    print("took {} {}".format(round(ticks_diff(t1, t0), -1), round(ticks_diff(t2, t1), -1)))
+    print(
+        "took {} {} {}".format(
+            round(ticks_diff(t1, t0), -1),
+            round(ticks_diff(t2, t1), -1),
+            round(ticks_diff(t3, t2), -1),
+        )
+    )
 
 
 asyncio.run(main())

--- a/tests/extmod/uasyncio_basic.py.exp
+++ b/tests/extmod/uasyncio_basic.py.exp
@@ -2,4 +2,5 @@ start
 after sleep
 short
 long
-took 20 40
+negative
+took 20 40 0

--- a/tests/extmod/uasyncio_fair.py
+++ b/tests/extmod/uasyncio_fair.py
@@ -22,6 +22,7 @@ async def main():
     t1 = asyncio.create_task(task(1, -0.01))
     t2 = asyncio.create_task(task(2, 0.1))
     t3 = asyncio.create_task(task(3, 0.2))
+    t3 = asyncio.create_task(task(4, -100))
     await asyncio.sleep(0.5)
     t1.cancel()
     t2.cancel()

--- a/tests/extmod/uasyncio_fair.py.exp
+++ b/tests/extmod/uasyncio_fair.py.exp
@@ -3,6 +3,7 @@ task start 2
 task work 2
 task start 3
 task work 3
+task start 4
 task work 2
 task work 3
 task work 2


### PR DESCRIPTION
Otherwise a task that continuously awaits on a large negative sleep can monopolise the scheduler (because its wake time is always less than everything else in the pairing heap).
