### PR TITLE
esp32/mpconfigport.h: Seed the urandom module on import

### DIFF
--- a/ports/esp32/mpconfigport.h
+++ b/ports/esp32/mpconfigport.h
@@ -6,6 +6,7 @@
 
 #include <stdint.h>
 #include <alloca.h>
+#include "esp_system.h"
 
 #if !MICROPY_ESP_IDF_4
 #include "rom/ets_sys.h"
@@ -140,6 +141,7 @@
 #define MICROPY_PY_UBINASCII_CRC32          (1)
 #define MICROPY_PY_URANDOM                  (1)
 #define MICROPY_PY_URANDOM_EXTRA_FUNCS      (1)
+#define MICROPY_PY_URANDOM_SEED_INIT_FUNC   (esp_random())
 #define MICROPY_PY_OS_DUPTERM               (1)
 #define MICROPY_PY_MACHINE                  (1)
 #define MICROPY_PY_MACHINE_PIN_MAKE_NEW     mp_pin_make_new

--- a/ports/esp8266/mpconfigport.h
+++ b/ports/esp8266/mpconfigport.h
@@ -31,6 +31,7 @@
 #define MICROPY_USE_INTERNAL_ERRNO  (1)
 #define MICROPY_ENABLE_SCHEDULER    (1)
 #define MICROPY_PY_DESCRIPTORS      (1)
+#define MICROPY_MODULE_BUILTIN_INIT (1)
 #define MICROPY_PY_BUILTINS_COMPLEX (0)
 #define MICROPY_PY_BUILTINS_STR_UNICODE (1)
 #define MICROPY_PY_BUILTINS_BYTEARRAY (1)
@@ -197,5 +198,8 @@ extern const struct _mp_obj_module_t mp_module_onewire;
 #define MP_FASTCODE(n) __attribute__((section(".iram0.text." #n))) n
 #define MICROPY_WRAP_MP_KEYBOARD_INTERRUPT(f) MP_FASTCODE(f)
 #define MICROPY_WRAP_MP_SCHED_SCHEDULE(f) MP_FASTCODE(f)
+
+#define WDEV_HWRNG ((volatile uint32_t *)0x3ff20e44)
+#define MICROPY_PY_URANDOM_SEED_INIT_FUNC   (*WDEV_HWRNG)
 
 #define _assert(expr) ((expr) ? (void)0 : __assert_func(__FILE__, __LINE__, __func__, #expr))

--- a/ports/stm32/mpconfigport.h
+++ b/ports/stm32/mpconfigport.h
@@ -81,6 +81,7 @@
 #define MICROPY_STREAMS_NON_BLOCK   (1)
 #define MICROPY_MODULE_WEAK_LINKS   (1)
 #define MICROPY_CAN_OVERRIDE_BUILTINS (1)
+#define MICROPY_MODULE_BUILTIN_INIT (1)
 #define MICROPY_USE_INTERNAL_ERRNO  (1)
 #define MICROPY_ENABLE_SCHEDULER    (1)
 #define MICROPY_SCHEDULER_DEPTH     (8)
@@ -361,6 +362,9 @@ typedef unsigned int mp_uint_t; // must be pointer size
 typedef long mp_off_t;
 
 #define MP_PLAT_PRINT_STRN(str, len) mp_hal_stdout_tx_strn_cooked(str, len)
+
+uint32_t rng_get(void);
+#define MICROPY_PY_URANDOM_SEED_INIT_FUNC   (rng_get())
 
 // We have inlined IRQ functions for efficiency (they are generally
 // 1 machine instruction).


### PR DESCRIPTION
For seeding the RNG function of the ESP-IDF is used, which is told
to be a true RNG, at least when WiFi or Bluetooth is enabled.
For a reproducible sequence of pseudo-random numbers, still seeding
with a known value is possible.