### PR TITLE
ports/unix: Add singlefp variant.

### DIFF
--- a/ports/unix/variants/singlefp/mpconfigvariant.h
+++ b/ports/unix/variants/singlefp/mpconfigvariant.h
@@ -1,0 +1,28 @@
+/*
+ * This file is part of the MicroPython project, http://micropython.org/
+ *
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2019 Damien P. George
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#define MICROPY_FLOAT_IMPL (MICROPY_FLOAT_IMPL_FLOAT)
+

--- a/ports/unix/variants/singlefp/mpconfigvariant.mk
+++ b/ports/unix/variants/singlefp/mpconfigvariant.mk
@@ -1,0 +1,3 @@
+# Single-precision floating point variant
+
+PROG ?= micropython-singlefp


### PR DESCRIPTION
Add a simple single-precision floating point UNIX variant to make it easy to do test builds against a single-precision platform.

This is useful for catching missing `MP_FLOAT_CONST()` macros in external modules without having to do a single-precision hardware build (like ESP32) with all of the toolchain that involves. Hoping to get this merged so that I can then create a workflow PR against [v923z/micropython-ulab](https://github.com/v923z/micropython-ulab
) to do a single-precision build and catch any such errors.