### PR TITLE
tests/extmod: Make uasyncio_fair test more reliable by adjusting sleeps.

### DIFF
--- a/tests/extmod/uasyncio_fair.py
+++ b/tests/extmod/uasyncio_fair.py
@@ -21,12 +21,13 @@ async def task(id, t):
 async def main():
     t1 = asyncio.create_task(task(1, -0.01))
     t2 = asyncio.create_task(task(2, 0.1))
-    t3 = asyncio.create_task(task(3, 0.2))
-    t3 = asyncio.create_task(task(4, -100))
+    t3 = asyncio.create_task(task(3, 0.18))
+    t4 = asyncio.create_task(task(4, -100))
     await asyncio.sleep(0.5)
     t1.cancel()
     t2.cancel()
     t3.cancel()
+    t4.cancel()
     print("finish")
 
 


### PR DESCRIPTION
With sleep(0.2) a multiple of sleep(0.1), the order of task 2 and 3 execution is not well defined, and depends on the precision of the system clock and how fast the rest of the code runs.  So change 0.2 to 0.18 to make the test more reliable.

Also fix a typo of t3/t4, and cancel t4 at the end.