### PR TITLE
Deal with C++ files in makeqstrdefs

### DIFF
--- a/py/makeqstrdefs.py
+++ b/py/makeqstrdefs.py
@@ -19,6 +19,9 @@ _MODE_QSTR = "qstr"
 # Extract MP_COMPRESSED_ROM_TEXT("") macros.  (Which come from MP_ERROR_TEXT)
 _MODE_COMPRESS = "compress"
 
+# File types which will be scanned.
+_FILE_TYPES = [".c", ".cc", ".cpp", ".cxx"]
+
 
 def write_out(fname, output):
     if output:
@@ -44,7 +47,7 @@ def process_file(f):
             m = re_line.match(line)
             assert m is not None
             fname = m.group(1)
-            if not fname.endswith(".c"):
+            if os.path.splitext(fname)[1].lower() not in _FILE_TYPES:
                 continue
             if fname != last_fname:
                 write_out(last_fname, output)

--- a/py/makeqstrdefs.py
+++ b/py/makeqstrdefs.py
@@ -58,7 +58,8 @@ def process_file(f):
             elif args.mode == _MODE_COMPRESS:
                 output.append(match)
 
-    write_out(last_fname, output)
+    if last_fname:
+        write_out(last_fname, output)
     return ""
 
 


### PR DESCRIPTION
This is one step in making the uPy core files compatible with C++; in practice it allows custom Makefiles which include the core Makefiles to add C++ source files to `SRC_QSTR` and have them processed just like C files.