### PR TITLE
tests: Split out complex reverse-op tests to separate test file.

### DIFF
--- a/tests/float/complex_reverse_op.py
+++ b/tests/float/complex_reverse_op.py
@@ -1,0 +1,10 @@
+# test complex interacting with special reverse methods
+
+
+class A:
+    def __radd__(self, x):
+        print("__radd__")
+        return 2
+
+
+print(1j + A())

--- a/tests/float/complex_special_methods.py
+++ b/tests/float/complex_special_methods.py
@@ -6,10 +6,5 @@ class A:
         print("__add__")
         return 1
 
-    def __radd__(self, x):
-        print("__radd__")
-        return 2
-
 
 print(A() + 1j)
-print(1j + A())

--- a/tests/run-tests
+++ b/tests/run-tests
@@ -367,7 +367,7 @@ def run_tests(pyb, tests, args, result_dir):
     if not has_complex:
         skip_tests.add('float/complex1.py')
         skip_tests.add('float/complex1_intbig.py')
-        skip_tests.add('float/complex_special_mehods.py')
+        skip_tests.add('float/complex_special_methods.py')
         skip_tests.add('float/int_big_float.py')
         skip_tests.add('float/true_value.py')
         skip_tests.add('float/types.py')
@@ -476,7 +476,7 @@ def run_tests(pyb, tests, args, result_dir):
         skip_it |= skip_slice and is_slice
         skip_it |= skip_async and is_async
         skip_it |= skip_const and is_const
-        skip_it |= skip_revops and test_name.startswith("class_reverse_op")
+        skip_it |= skip_revops and "reverse_op" in test_name
         skip_it |= skip_io_module and is_io_module
 
         if args.list_tests:


### PR DESCRIPTION
So they can be skipped if __rOP__'s are not supported on the target.  Also fix the typo in the complex_special_methods.py filename.