### PR TITLE
extmod/modlwip: Fix error return for TCP recv when not connected.

### DIFF
--- a/extmod/modlwip.c
+++ b/extmod/modlwip.c
@@ -757,8 +757,11 @@ STATIC mp_uint_t lwip_tcp_receive(lwip_socket_obj_t *socket, byte *buf, mp_uint_
                 return 0;
             }
         } else if (socket->state != STATE_CONNECTED) {
-            assert(socket->state < 0);
-            *_errno = error_lookup_table[-socket->state];
+            if (socket->state >= STATE_NEW) {
+                *_errno = MP_ENOTCONN;
+            } else {
+                *_errno = error_lookup_table[-socket->state];
+            }
             return -1;
         }
     }

--- a/tests/extmod/usocket_tcp_basic.py
+++ b/tests/extmod/usocket_tcp_basic.py
@@ -1,0 +1,17 @@
+# Test basic, stand-alone TCP socket functionality
+
+try:
+    import usocket as socket, uerrno as errno
+except ImportError:
+    try:
+        import socket, errno
+    except ImportError:
+        print("SKIP")
+        raise SystemExit
+
+# recv() on a fresh socket should raise ENOTCONN
+s = socket.socket()
+try:
+    s.recv(1)
+except OSError as er:
+    print("ENOTCONN:", er.args[0] == errno.ENOTCONN)


### PR DESCRIPTION
This commit fixes the cases when a TCP socket is in STATE_NEW, STATE_LISTENING or STATE_CONNECTING and recv() is called on it.  It now raises ENOTCONN instead of a random error code due to it previously indexing beyond the start of error_lookup_table[].