### PR TITLE
docs/library/btree.rst: Correct method name typo: `__detitem__` to `__delitem__`.

### DIFF
--- a/docs/library/btree.rst
+++ b/docs/library/btree.rst
@@ -118,7 +118,7 @@ Methods
 .. method:: btree.__getitem__(key)
             btree.get(key, default=None, /)
             btree.__setitem__(key, val)
-            btree.__detitem__(key)
+            btree.__delitem__(key)
             btree.__contains__(key)
 
    Standard dictionary methods.


### PR DESCRIPTION
Changed `__detitem__` (note extra 't', 'det' not 'del') to `__delitem__`.