### PR TITLE
esp32/mphalport: Fix mp_hal_time_ns offset.

### DIFF
--- a/ports/esp32/mphalport.c
+++ b/ports/esp32/mphalport.c
@@ -45,6 +45,7 @@
 #include "py/mpstate.h"
 #include "py/mphal.h"
 #include "extmod/misc.h"
+#include "lib/timeutils/timeutils.h"
 #include "lib/utils/pyexec.h"
 #include "mphalport.h"
 
@@ -199,7 +200,10 @@ void mp_hal_delay_us(uint32_t us) {
 uint64_t mp_hal_time_ns(void) {
     struct timeval tv;
     gettimeofday(&tv, NULL);
-    return (uint64_t)tv.tv_sec * 1000000000ULL + (uint64_t)tv.tv_usec * 1000ULL;
+    // gettimeofday returns seconds since 2000/1/1
+    uint64_t ns = timeutils_seconds_since_2000_to_nanoseconds_since_1970(tv.tv_sec);
+    ns += (uint64_t)tv.tv_usec * 1000ULL;
+    return ns;
 }
 
 // Wake up the main task if it is sleeping


### PR DESCRIPTION
gettimeofday returns seconds since 2000/1/1 so needs to be adjusted to seconds since 1970/1/1 to give the correct return value of mp_hal_time_ns.

