### PR TITLE
lib/libm: Reduce size of static two_over_pi array.

### DIFF
--- a/lib/libm/ef_rem_pio2.c
+++ b/lib/libm/ef_rem_pio2.c
@@ -35,9 +35,9 @@
  * Table of constants for 2/pi, 396 Hex digits (476 decimal) of 2/pi 
  */
 #ifdef __STDC__
-static const __int32_t two_over_pi[] = {
+static const __uint8_t two_over_pi[] = {
 #else
-static __int32_t two_over_pi[] = {
+static __uint8_t two_over_pi[] = {
 #endif
 0xA2, 0xF9, 0x83, 0x6E, 0x4E, 0x44, 0x15, 0x29, 0xFC,
 0x27, 0x57, 0xD1, 0xF5, 0x34, 0xDD, 0xC0, 0xDB, 0x62, 

--- a/lib/libm/fdlibm.h
+++ b/lib/libm/fdlibm.h
@@ -188,7 +188,7 @@ extern float __ieee754_scalbf __P((float,float));
 extern float __kernel_sinf __P((float,float,int));
 extern float __kernel_cosf __P((float,float));
 extern float __kernel_tanf __P((float,float,int));
-extern int   __kernel_rem_pio2f __P((float*,float*,int,int,int,const __int32_t*));
+extern int   __kernel_rem_pio2f __P((float*,float*,int,int,int,const __uint8_t*));
 
 /* A union which permits us to convert between a float and a 32 bit
    int.  */

--- a/lib/libm/kf_rem_pio2.c
+++ b/lib/libm/kf_rem_pio2.c
@@ -62,10 +62,10 @@ two8   =  2.5600000000e+02f, /* 0x43800000 */
 twon8  =  3.9062500000e-03f; /* 0x3b800000 */
 
 #ifdef __STDC__
-	int __kernel_rem_pio2f(float *x, float *y, int e0, int nx, int prec, const __int32_t *ipio2) 
+	int __kernel_rem_pio2f(float *x, float *y, int e0, int nx, int prec, const __uint8_t *ipio2) 
 #else
 	int __kernel_rem_pio2f(x,y,e0,nx,prec,ipio2) 	
-	float x[], y[]; int e0,nx,prec; __int32_t ipio2[];
+	float x[], y[]; int e0,nx,prec; __uint8_t ipio2[];
 #endif
 {
 	__int32_t jz,jx,jv,jp,jk,carry,n,iq[20],i,j,k,m,q0,ih;


### PR DESCRIPTION
Thanks to Jeff Epler for the idea.  See #6326 

Code size change for this patch is:
```
   bare-arm:    +0 +0.000% 
minimal x86:    +0 +0.000% 
   unix x64:    +0 +0.000% 
unix nanbox:    +0 +0.000% 
      stm32:  -568 -0.147% PYBV10
     cc3200:    +0 +0.000% 
    esp8266:  -576 -0.084% GENERIC
      esp32:    +0 +0.000% GENERIC
        nrf:  -596 -0.403% pca10040
       samd:    +0 +0.000% ADAFRUIT_ITSYBITSY_M4_EXPRESS
```