### PR TITLE
extmod/modussl_axtls: Reduce size of code that makes exception.

### DIFF
--- a/extmod/modussl_axtls.c
+++ b/extmod/modussl_axtls.c
@@ -55,53 +55,65 @@ struct ssl_args {
 
 STATIC const mp_obj_type_t ussl_socket_type;
 
-// Table of errors
-struct ssl_errs {
-    int16_t errnum;
-    const char *errstr;
+// Table of error strings corresponding to SSL_xxx error codes.
+STATIC const char *const ssl_error_tab1[] = {
+    "NOT_OK",
+    "DEAD",
+    "CLOSE_NOTIFY",
+    "EAGAIN",
 };
-STATIC const struct ssl_errs ssl_error_tab[] = {
-    { SSL_NOT_OK, "NOT_OK" },
-    { SSL_ERROR_DEAD, "DEAD" },
-    { SSL_CLOSE_NOTIFY, "CLOSE_NOTIFY" },
-    { SSL_EAGAIN, "EAGAIN" },
-    { SSL_ERROR_CONN_LOST, "CONN_LOST" },
-    { SSL_ERROR_RECORD_OVERFLOW, "RECORD_OVERFLOW" },
-    { SSL_ERROR_SOCK_SETUP_FAILURE, "SOCK_SETUP_FAILURE" },
-    { SSL_ERROR_INVALID_HANDSHAKE, "INVALID_HANDSHAKE" },
-    { SSL_ERROR_INVALID_PROT_MSG, "INVALID_PROT_MSG" },
-    { SSL_ERROR_INVALID_HMAC, "INVALID_HMAC" },
-    { SSL_ERROR_INVALID_VERSION, "INVALID_VERSION" },
-    { SSL_ERROR_UNSUPPORTED_EXTENSION, "UNSUPPORTED_EXTENSION" },
-    { SSL_ERROR_INVALID_SESSION, "INVALID_SESSION" },
-    { SSL_ERROR_NO_CIPHER, "NO_CIPHER" },
-    { SSL_ERROR_INVALID_CERT_HASH_ALG, "INVALID_CERT_HASH_ALG" },
-    { SSL_ERROR_BAD_CERTIFICATE, "BAD_CERTIFICATE" },
-    { SSL_ERROR_INVALID_KEY, "INVALID_KEY" },
-    { SSL_ERROR_FINISHED_INVALID, "FINISHED_INVALID" },
-    { SSL_ERROR_NO_CERT_DEFINED, "NO_CERT_DEFINED" },
-    { SSL_ERROR_NO_CLIENT_RENOG, "NO_CLIENT_RENOG" },
-    { SSL_ERROR_NOT_SUPPORTED, "NOT_SUPPORTED" },
+STATIC const char *const ssl_error_tab2[] = {
+    "CONN_LOST",
+    "RECORD_OVERFLOW",
+    "SOCK_SETUP_FAILURE",
+    NULL,
+    "INVALID_HANDSHAKE",
+    "INVALID_PROT_MSG",
+    "INVALID_HMAC",
+    "INVALID_VERSION",
+    "UNSUPPORTED_EXTENSION",
+    "INVALID_SESSION",
+    "NO_CIPHER",
+    "INVALID_CERT_HASH_ALG",
+    "BAD_CERTIFICATE",
+    "INVALID_KEY",
+    NULL,
+    "FINISHED_INVALID",
+    "NO_CERT_DEFINED",
+    "NO_CLIENT_RENOG",
+    "NOT_SUPPORTED",
 };
 
 STATIC NORETURN void ussl_raise_error(int err) {
-    for (size_t i = 0; i < MP_ARRAY_SIZE(ssl_error_tab); i++) {
-        if (ssl_error_tab[i].errnum == err) {
-            // construct string object
-            mp_obj_str_t *o_str = m_new_obj_maybe(mp_obj_str_t);
-            if (o_str == NULL) {
-                break;
-            }
-            o_str->base.type = &mp_type_str;
-            o_str->data = (const byte *)ssl_error_tab[i].errstr;
-            o_str->len = strlen((char *)o_str->data);
-            o_str->hash = qstr_compute_hash(o_str->data, o_str->len);
-            // raise
-            mp_obj_t args[2] = { MP_OBJ_NEW_SMALL_INT(err), MP_OBJ_FROM_PTR(o_str)};
-            nlr_raise(mp_obj_exception_make_new(&mp_type_OSError, 2, 0, args));
-        }
+    MP_STATIC_ASSERT(SSL_NOT_OK - 3 == SSL_EAGAIN);
+    MP_STATIC_ASSERT(SSL_ERROR_CONN_LOST - 18 == SSL_ERROR_NOT_SUPPORTED);
+
+    // Check if err corresponds to something in one of the error string tables.
+    const char *errstr = NULL;
+    if (SSL_NOT_OK >= err && err >= SSL_EAGAIN) {
+        errstr = ssl_error_tab1[SSL_NOT_OK - err];
+    } else if (SSL_ERROR_CONN_LOST >= err && err >= SSL_ERROR_NOT_SUPPORTED) {
+        errstr = ssl_error_tab2[SSL_ERROR_CONN_LOST - err];
     }
-    mp_raise_OSError(err);
+
+    // Unknown error, just raise the error code.
+    if (errstr == NULL) {
+        mp_raise_OSError(err);
+    }
+
+    // Construct string object.
+    mp_obj_str_t *o_str = m_new_obj_maybe(mp_obj_str_t);
+    if (o_str == NULL) {
+        mp_raise_OSError(err);
+    }
+    o_str->base.type = &mp_type_str;
+    o_str->data = (const byte *)errstr;
+    o_str->len = strlen((char *)o_str->data);
+    o_str->hash = qstr_compute_hash(o_str->data, o_str->len);
+
+    // Raise OSError(err, str).
+    mp_obj_t args[2] = { MP_OBJ_NEW_SMALL_INT(err), MP_OBJ_FROM_PTR(o_str)};
+    nlr_raise(mp_obj_exception_make_new(&mp_type_OSError, 2, 0, args));
 }
 
 


### PR DESCRIPTION
This replaces the for loop search with a simple index into the table based on the error code value.

Code size change for this patch is:
```
   bare-arm:    +0 +0.000% 
minimal x86:    +0 +0.000% 
   unix x64:  -152 -0.030% [incl -160(data)]
unix nanbox:  -112 -0.025% [incl -96(data)]
      stm32:    +0 +0.000% PYBV10
     cc3200:    +0 +0.000% 
    esp8266:   -64 -0.009% GENERIC
      esp32:    +0 +0.000% GENERIC
        nrf:    +0 +0.000% pca10040
       samd:    +0 +0.000% ADAFRUIT_ITSYBITSY_M4_EXPRESS
```

@tve FYI