### PR TITLE
py/objfloat: Fix handling of negative float to power of nan.

### DIFF
--- a/py/objfloat.c
+++ b/py/objfloat.c
@@ -293,7 +293,7 @@ mp_obj_t mp_obj_float_binary_op(mp_binary_op_t op, mp_float_t lhs_val, mp_obj_t 
             if (lhs_val == 0 && rhs_val < 0 && !isinf(rhs_val)) {
                 goto zero_division_error;
             }
-            if (lhs_val < 0 && rhs_val != MICROPY_FLOAT_C_FUN(floor)(rhs_val)) {
+            if (lhs_val < 0 && rhs_val != MICROPY_FLOAT_C_FUN(floor)(rhs_val) && !isnan(rhs_val)) {
                 #if MICROPY_PY_BUILTINS_COMPLEX
                 return mp_obj_complex_binary_op(MP_BINARY_OP_POWER, lhs_val, 0, rhs_in);
                 #else

--- a/tests/float/inf_nan_arith.py
+++ b/tests/float/inf_nan_arith.py
@@ -1,0 +1,20 @@
+# Test behaviour of inf and nan in basic float operations
+
+inf = float("inf")
+nan = float("nan")
+
+values = (-2, -1, 0, 1, 2, inf, nan)
+
+for x in values:
+    for y in values:
+        print(x, y)
+        print("  + - *", x + y, x - y, x * y)
+        try:
+            print("  /", x / y)
+        except ZeroDivisionError:
+            print("  / ZeroDivisionError")
+        try:
+            print("  ** pow", x ** y, pow(x, y))
+        except ZeroDivisionError:
+            print("  ** pow ZeroDivisionError")
+        print("  == != < <= > >=", x == y, x != y, x < y, x <= y, x > y, x >= y)


### PR DESCRIPTION
Prior to this commit, pow(-2, float('nan')) would return (nan+nanj), or raise an exception on targets that don't support complex numbers.  This is fixed to return simply nan, as CPython does.
