### PR TITLE
lib/utils/mpirq: Add mp_irq_init func, and clean up unused init method.

### DIFF
--- a/lib/utils/mpirq.c
+++ b/lib/utils/mpirq.c
@@ -53,12 +53,16 @@ const mp_arg_t mp_irq_init_args[] = {
 
 mp_irq_obj_t *mp_irq_new(const mp_irq_methods_t *methods, mp_obj_t parent) {
     mp_irq_obj_t *self = m_new0(mp_irq_obj_t, 1);
+    mp_irq_init(self, methods, parent);
+    return self;
+}
+
+void mp_irq_init(mp_irq_obj_t *self, const mp_irq_methods_t *methods, mp_obj_t parent) {
     self->base.type = &mp_irq_type;
     self->methods = (mp_irq_methods_t *)methods;
     self->parent = parent;
     self->handler = mp_const_none;
     self->ishard = false;
-    return self;
 }
 
 void mp_irq_handler(mp_irq_obj_t *self) {

--- a/lib/utils/mpirq.h
+++ b/lib/utils/mpirq.h
@@ -26,6 +26,8 @@
 #ifndef MICROPY_INCLUDED_LIB_UTILS_MPIRQ_H
 #define MICROPY_INCLUDED_LIB_UTILS_MPIRQ_H
 
+#include "py/obj.h"
+
 /******************************************************************************
  DEFINE CONSTANTS
  ******************************************************************************/
@@ -41,20 +43,17 @@ enum {
  DEFINE TYPES
  ******************************************************************************/
 
-typedef mp_obj_t (*mp_irq_init_t)(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args);
-typedef mp_uint_t (*mp_irq_uint_method_one_uint_para_t)(mp_obj_t self, mp_uint_t trigger);
-typedef mp_uint_t (*mp_irq_int_method_one_para_t)(mp_obj_t self, mp_uint_t info_type);
+typedef mp_uint_t (*mp_irq_trigger_fun_t)(mp_obj_t self, mp_uint_t trigger);
+typedef mp_uint_t (*mp_irq_info_fun_t)(mp_obj_t self, mp_uint_t info_type);
 
 enum {
     MP_IRQ_INFO_FLAGS,
     MP_IRQ_INFO_TRIGGERS,
-    MP_IRQ_INFO_CNT
 };
 
 typedef struct _mp_irq_methods_t {
-    mp_irq_init_t init;
-    mp_irq_uint_method_one_uint_para_t trigger;
-    mp_irq_int_method_one_para_t info;
+    mp_irq_trigger_fun_t trigger;
+    mp_irq_info_fun_t info;
 } mp_irq_methods_t;
 
 typedef struct _mp_irq_obj_t {
@@ -77,6 +76,7 @@ extern const mp_obj_type_t mp_irq_type;
  ******************************************************************************/
 
 mp_irq_obj_t *mp_irq_new(const mp_irq_methods_t *methods, mp_obj_t parent);
+void mp_irq_init(mp_irq_obj_t *self, const mp_irq_methods_t *methods, mp_obj_t parent);
 void mp_irq_handler(mp_irq_obj_t *self);
 
 #endif // MICROPY_INCLUDED_LIB_UTILS_MPIRQ_H

--- a/ports/stm32/machine_uart.c
+++ b/ports/stm32/machine_uart.c
@@ -139,7 +139,6 @@ STATIC mp_uint_t pyb_uart_irq_info(mp_obj_t self_in, mp_uint_t info_type) {
 }
 
 STATIC const mp_irq_methods_t pyb_uart_irq_methods = {
-    .init = pyb_uart_irq,
     .trigger = pyb_uart_irq_trigger,
     .info = pyb_uart_irq_info,
 };

--- a/ports/zephyr/machine_pin.c
+++ b/ports/zephyr/machine_pin.c
@@ -213,11 +213,7 @@ STATIC mp_obj_t machine_pin_irq(size_t n_args, const mp_obj_t *pos_args, mp_map_
         }
         if (irq == NULL) {
             irq = m_new_obj(machine_pin_irq_obj_t);
-            irq->base.base.type = &mp_irq_type;
-            irq->base.methods = (mp_irq_methods_t *)&machine_pin_irq_methods;
-            irq->base.parent = MP_OBJ_FROM_PTR(self);
-            irq->base.handler = mp_const_none;
-            irq->base.ishard = false;
+            mp_irq_init(&irq->base, &machine_pin_irq_methods, MP_OBJ_FROM_PTR(self));
             irq->next = MP_STATE_PORT(machine_pin_irq_list);
             gpio_init_callback(&irq->callback, gpio_callback_handler, BIT(self->pin));
             int ret = gpio_add_callback(self->port, &irq->callback);
@@ -322,7 +318,6 @@ STATIC mp_uint_t machine_pin_irq_info(mp_obj_t self_in, mp_uint_t info_type) {
 }
 
 STATIC const mp_irq_methods_t machine_pin_irq_methods = {
-    .init = machine_pin_irq,
     .trigger = machine_pin_irq_trigger,
     .info = machine_pin_irq_info,
 };


### PR DESCRIPTION
`mp_irq_init()` is useful when the IRQ object is allocated by the caller.

The `mp_irq_methods_t.init` method is not used anywhere so has been removed (can easily be re-added if it's needed in the future).

Splits out work done in #6343 