### PR TITLE
tools/mpy-tool.py: Fix merge of multiple mpy files to POP_TOP correctly.

### DIFF
--- a/tools/mpy-tool.py
+++ b/tools/mpy-tool.py
@@ -938,7 +938,7 @@ def merge_mpy(raw_codes, output_file):
         merged_mpy.extend(header)
 
         bytecode = bytearray()
-        bytecode_len = 6 + len(raw_codes) * 4 + 2
+        bytecode_len = 6 + len(raw_codes) * 5 + 2
         bytecode.append(bytecode_len << 2)  # kind and length
         bytecode.append(0b00000000)  # signature prelude
         bytecode.append(0b00001000)  # size prelude
@@ -947,7 +947,7 @@ def merge_mpy(raw_codes, output_file):
         for idx in range(len(raw_codes)):
             bytecode.append(0x32)  # MP_BC_MAKE_FUNCTION
             bytecode.append(idx)  # index raw code
-            bytecode.extend(b"\x34\x00")  # MP_BC_CALL_FUNCTION, 0 args
+            bytecode.extend(b"\x34\x00\x59")  # MP_BC_CALL_FUNCTION, 0 args, MP_BC_POP_TOP
         bytecode.extend(b"\x51\x63")  # MP_BC_LOAD_NONE, MP_BC_RETURN_VALUE
 
         bytecode.append(0)  # n_obj


### PR DESCRIPTION
MP_BC_CALL_FUNCTION will leave the result on the Python stack, so that result must be discarded by MP_BC_POP_TOP.
