### PR TITLE
Patch framebuf MONO_VMSB fotmat

### DIFF
--- a/docs/library/framebuf.rst
+++ b/docs/library/framebuf.rst
@@ -126,6 +126,15 @@ Constants
     locations until the rightmost edge is reached. Further bytes are rendered
     at locations starting at the leftmost edge, 8 pixels lower.
 
+.. data:: framebuf.MONO_VMSB
+
+    Monochrome (1-bit) color format
+    This defines a mapping where the bits in a byte are vertically mapped with
+    bit 7 being nearest the top of the screen. Consequently each byte occupies
+    8 vertical pixels. Subsequent bytes appear at successive horizontal
+    locations until the rightmost edge is reached. Further bytes are rendered
+    at locations starting at the leftmost edge, 8 pixels lower.
+
 .. data:: framebuf.MONO_HLSB
 
     Monochrome (1-bit) color format


### PR DESCRIPTION
#6303 
I have tested with ssd1306.py driver(modified MONO_VLSB to MONO_VMSB), and as expect, the text is upside down.
![1599311303152](https://user-images.githubusercontent.com/16630430/92305750-a804d300-efbc-11ea-8844-f45e7ce61c6c.jpg)
