### PR TITLE
Workaround pow implentation bugs when one of the arguments is NaN

### DIFF
--- a/ports/windows/mpconfigport.h
+++ b/ports/windows/mpconfigport.h
@@ -236,6 +236,8 @@ extern const struct _mp_obj_module_t mp_module_time;
 #define MICROPY_PY_MATH_FMOD_FIX_INFNAN (1)
 #ifdef _WIN64
 #define MICROPY_PY_MATH_MODF_FIX_NEGZERO (1)
+#else
+#define MICROPY_PY_MATH_POW_FIX_NAN (1)
 #endif
 #endif
 

--- a/py/modmath.c
+++ b/py/modmath.c
@@ -98,7 +98,19 @@ mp_float_t MICROPY_FLOAT_C_FUN(log2)(mp_float_t x) {
 // sqrt(x): returns the square root of x
 MATH_FUN_1(sqrt, sqrt)
 // pow(x, y): returns x to the power of y
+#if MICROPY_PY_MATH_POW_FIX_NAN
+mp_float_t pow_func(mp_float_t x, mp_float_t y) {
+    // pow(base, 0) returns 1 for any base, even when base is NaN
+    // pow(+1, exponent) returns 1 for any exponent, even when exponent is NaN
+    if (x == MICROPY_FLOAT_CONST(1.0) || y == MICROPY_FLOAT_CONST(0.0)) {
+        return MICROPY_FLOAT_CONST(1.0);
+    }
+    return MICROPY_FLOAT_C_FUN(pow)(x, y);
+}
+MATH_FUN_2(pow, pow_func)
+#else
 MATH_FUN_2(pow, pow)
+#endif
 // exp(x)
 MATH_FUN_1(exp, exp)
 #if MICROPY_PY_MATH_SPECIAL_FUNCTIONS

--- a/py/mpconfig.h
+++ b/py/mpconfig.h
@@ -1160,6 +1160,11 @@ typedef double mp_float_t;
 #define MICROPY_PY_MATH_MODF_FIX_NEGZERO (0)
 #endif
 
+// Whether to provide fix for pow(1, NaN) and pow(NaN, 0), which both should be 1 not NaN.
+#ifndef MICROPY_PY_MATH_POW_FIX_NAN
+#define MICROPY_PY_MATH_POW_FIX_NAN (0)
+#endif
+
 // Whether to provide "cmath" module
 #ifndef MICROPY_PY_CMATH
 #define MICROPY_PY_CMATH (0)

--- a/py/objfloat.c
+++ b/py/objfloat.c
@@ -293,7 +293,7 @@ mp_obj_t mp_obj_float_binary_op(mp_binary_op_t op, mp_float_t lhs_val, mp_obj_t 
             if (lhs_val == 0 && rhs_val < 0 && !isinf(rhs_val)) {
                 goto zero_division_error;
             }
-            if (lhs_val < 0 && rhs_val != MICROPY_FLOAT_C_FUN(floor)(rhs_val)) {
+            if (lhs_val < 0 && rhs_val != MICROPY_FLOAT_C_FUN(floor)(rhs_val) && !isnan(rhs_val)) {
                 #if MICROPY_PY_BUILTINS_COMPLEX
                 return mp_obj_complex_binary_op(MP_BINARY_OP_POWER, lhs_val, 0, rhs_in);
                 #else

--- a/py/objfloat.c
+++ b/py/objfloat.c
@@ -300,6 +300,12 @@ mp_obj_t mp_obj_float_binary_op(mp_binary_op_t op, mp_float_t lhs_val, mp_obj_t 
                 mp_raise_ValueError(MP_ERROR_TEXT("complex values not supported"));
                 #endif
             }
+            #if MICROPY_PY_MATH_POW_FIX_NAN // Also see modmath.c.
+            if (lhs_val == MICROPY_FLOAT_CONST(1.0) || rhs_val == MICROPY_FLOAT_CONST(0.0)) {
+                lhs_val = MICROPY_FLOAT_CONST(1.0);
+                break;
+            }
+            #endif
             lhs_val = MICROPY_FLOAT_C_FUN(pow)(lhs_val, rhs_val);
             break;
         case MP_BINARY_OP_DIVMOD: {

--- a/tests/float/inf_nan_arith.py
+++ b/tests/float/inf_nan_arith.py
@@ -1,0 +1,20 @@
+# Test behaviour of inf and nan in basic float operations
+
+inf = float("inf")
+nan = float("nan")
+
+values = (-2, -1, 0, 1, 2, inf, nan)
+
+for x in values:
+    for y in values:
+        print(x, y)
+        print("  + - *", x + y, x - y, x * y)
+        try:
+            print("  /", x / y)
+        except ZeroDivisionError:
+            print("  / ZeroDivisionError")
+        try:
+            print("  ** pow", x ** y, pow(x, y))
+        except ZeroDivisionError:
+            print("  ** pow ZeroDivisionError")
+        print("  == != < <= > >=", x == y, x != y, x < y, x <= y, x > y, x >= y)

--- a/tests/float/math_domain.py
+++ b/tests/float/math_domain.py
@@ -38,7 +38,7 @@ for name, f, args in (
 
 # double argument functions
 for name, f, args in (
-    ("pow", math.pow, ((0, 2), (-1, 2), (0, -1), (-1, 2.3))),
+    ("pow", math.pow, ((0, 2), (-1, 2), (0, -1), (-1, 2.3), (nan, 0), (1, nan))),
     ("fmod", math.fmod, ((1.2, inf), (1.2, -inf), (1.2, 0), (inf, 1.2))),
     ("atan2", math.atan2, ((0, 0), (-inf, inf), (-inf, -inf), (inf, -inf))),
     ("copysign", math.copysign, ()),


### PR DESCRIPTION
This PR is just to get the fix publicly visible, as far as I'm concerned the 2 commits can be merged.

Note: the code is written out in full in objfloat.c instead of reusing the line with `lhs_val = ...` because otherwise code formatting trips over it and messes up indentation of the closing brace.