### PR TITLE
ports/esp32/mpconfigport.h: Remove duplicate uhashlib registration.

### DIFF
--- a/ports/esp32/mpconfigport.h
+++ b/ports/esp32/mpconfigport.h
@@ -200,7 +200,6 @@ extern const struct _mp_obj_module_t mp_module_onewire;
     { MP_OBJ_NEW_QSTR(MP_QSTR_machine), (mp_obj_t)&mp_module_machine }, \
     { MP_OBJ_NEW_QSTR(MP_QSTR_network), (mp_obj_t)&mp_module_network }, \
     { MP_OBJ_NEW_QSTR(MP_QSTR__onewire), (mp_obj_t)&mp_module_onewire }, \
-    { MP_OBJ_NEW_QSTR(MP_QSTR_uhashlib), (mp_obj_t)&mp_module_uhashlib }, \
 
 #define MP_STATE_PORT MP_STATE_VM
 


### PR DESCRIPTION
Raised in the forum here: https://forum.micropython.org/viewtopic.php?f=3&t=8988&p=50679

uhashlib is currently registered by both objmodule.c and esp32/mpconfigport.h. I don't think this has any ill effect other than using slightly more ROM and being visible in `help('modules')` twice, but easy fix.