### PR TITLE
extmod/modbluetooth.c: Clarify optional arguments.

### DIFF
--- a/docs/library/ubluetooth.rst
+++ b/docs/library/ubluetooth.rst
@@ -28,15 +28,15 @@ Constructor
 Configuration
 -------------
 
-.. method:: BLE.active([active])
+.. method:: BLE.active([active], /)
 
     Optionally changes the active state of the BLE radio, and returns the
     current state.
 
     The radio must be made active before using any other methods on this class.
 
-.. method:: BLE.config('param')
-            BLE.config(param=value, ...)
+.. method:: BLE.config('param', /)
+            BLE.config(*, param=value, ...)
 
     Get or set configuration values of the BLE interface.  To get a value the
     parameter name should be quoted as a string, and just one parameter is
@@ -76,7 +76,7 @@ Configuration
 Event Handling
 --------------
 
-.. method:: BLE.irq(handler)
+.. method:: BLE.irq(handler, /)
 
     Registers a callback for events from the BLE stack. The *handler* takes two
     arguments, ``event`` (which will be one of the codes below) and ``data``
@@ -195,7 +195,7 @@ program.
 Broadcaster Role (Advertiser)
 -----------------------------
 
-.. method:: BLE.gap_advertise(interval_us, adv_data=None, resp_data=None, connectable=True)
+.. method:: BLE.gap_advertise(interval_us, adv_data=None, *, resp_data=None, connectable=True)
 
     Starts advertising at the specified interval (in **micro**\ seconds). This
     interval will be rounded down to the nearest 625us. To stop advertising, set
@@ -214,7 +214,7 @@ Broadcaster Role (Advertiser)
 Observer Role (Scanner)
 -----------------------
 
-.. method:: BLE.gap_scan(duration_ms, [interval_us], [window_us], [active])
+.. method:: BLE.gap_scan(duration_ms, interval_us=1280000, window_us=11250, active=False, /)
 
     Run a scan operation lasting for the specified duration (in **milli**\ seconds).
 
@@ -244,7 +244,7 @@ Observer Role (Scanner)
         * 0x04 - SCAN_RSP - scan response
 
     ``active`` can be set ``True`` if you want to receive scan responses in the results.
-    
+
     When scanning is stopped (either due to the duration finishing or when
     explicitly stopped), the ``_IRQ_SCAN_DONE`` event will be raised.
 
@@ -268,7 +268,7 @@ writes from a central to a given characteristic, use
 :meth:`gatts_write<BLE.gatts_write>` after registration. e.g.
 ``gatts_write(char_handle, bytes(100))``.
 
-.. method:: BLE.gatts_register_services(services_definition)
+.. method:: BLE.gatts_register_services(services_definition, /)
 
     Configures the peripheral with the specified services, replacing any
     existing services.
@@ -308,26 +308,26 @@ writes from a central to a given characteristic, use
 
     **Note:** Advertising must be stopped before registering services.
 
-.. method:: BLE.gatts_read(value_handle)
+.. method:: BLE.gatts_read(value_handle, /)
 
     Reads the local value for this handle (which has either been written by
     :meth:`gatts_write <BLE.gatts_write>` or by a remote central).
 
-.. method:: BLE.gatts_write(value_handle, data)
+.. method:: BLE.gatts_write(value_handle, data, /)
 
     Writes the local value for this handle, which can be read by a central.
 
-.. method:: BLE.gatts_notify(conn_handle, value_handle, [data])
+.. method:: BLE.gatts_notify(conn_handle, value_handle, data=None, /)
 
     Sends a notification request to a connected central.
 
-    If *data* is specified, then that value is sent to the central as part of
+    If *data* is not ``None``, then that value is sent to the central as part of
     the notification. The local value will not be modified.
 
-    Otherwise, if *data* is not specified, then the current local value (as
+    Otherwise, if *data* is ``None``, then the current local value (as
     set with :meth:`gatts_write <BLE.gatts_write>`) will be sent.
 
-.. method:: BLE.gatts_indicate(conn_handle, value_handle)
+.. method:: BLE.gatts_indicate(conn_handle, value_handle, /)
 
     Sends an indication request to a connected central.
 
@@ -361,7 +361,7 @@ Central Role (GATT Client)
 
     On success, the ``_IRQ_PERIPHERAL_CONNECT`` event will be raised.
 
-.. method:: BLE.gap_disconnect(conn_handle)
+.. method:: BLE.gap_disconnect(conn_handle, /)
 
     Disconnect the specified connection handle.
 
@@ -370,7 +370,7 @@ Central Role (GATT Client)
     Returns ``False`` if the connection handle wasn't connected, and ``True``
     otherwise.
 
-.. method:: BLE.gattc_discover_services(conn_handle, [uuid])
+.. method:: BLE.gattc_discover_services(conn_handle, uuid=None, /)
 
     Query a connected peripheral for its services.
 
@@ -379,7 +379,7 @@ Central Role (GATT Client)
     For each service discovered, the ``_IRQ_GATTC_SERVICE_RESULT`` event will
     be raised, followed by ``_IRQ_GATTC_SERVICE_DONE`` on completion.
 
-.. method:: BLE.gattc_discover_characteristics(conn_handle, start_handle, end_handle, [uuid])
+.. method:: BLE.gattc_discover_characteristics(conn_handle, start_handle, end_handle, uuid=None, /)
 
     Query a connected peripheral for characteristics in the specified range.
 
@@ -392,14 +392,14 @@ Central Role (GATT Client)
     For each characteristic discovered, the ``_IRQ_GATTC_CHARACTERISTIC_RESULT``
     event will be raised, followed by ``_IRQ_GATTC_CHARACTERISTIC_DONE`` on completion.
 
-.. method:: BLE.gattc_discover_descriptors(conn_handle, start_handle, end_handle)
+.. method:: BLE.gattc_discover_descriptors(conn_handle, start_handle, end_handle, /)
 
     Query a connected peripheral for descriptors in the specified range.
 
     For each descriptor discovered, the ``_IRQ_GATTC_DESCRIPTOR_RESULT`` event
     will be raised, followed by ``_IRQ_GATTC_DESCRIPTOR_DONE`` on completion.
 
-.. method:: BLE.gattc_read(conn_handle, value_handle)
+.. method:: BLE.gattc_read(conn_handle, value_handle, /)
 
     Issue a remote read to a connected peripheral for the specified
     characteristic or descriptor handle.
@@ -433,7 +433,7 @@ class UUID
 Constructor
 -----------
 
-.. class:: UUID(value)
+.. class:: UUID(value, /)
 
     Creates a UUID instance with the specified **value**.
 

--- a/extmod/modbluetooth.c
+++ b/extmod/modbluetooth.c
@@ -679,7 +679,7 @@ STATIC mp_obj_t bluetooth_ble_gatts_notify(size_t n_args, const mp_obj_t *args) 
     mp_int_t conn_handle = mp_obj_get_int(args[1]);
     mp_int_t value_handle = mp_obj_get_int(args[2]);
 
-    if (n_args == 4) {
+    if (n_args == 4 && args[3] != mp_const_none) {
         mp_buffer_info_t bufinfo = {0};
         mp_get_buffer_raise(args[3], &bufinfo, MP_BUFFER_READ);
         int err = mp_bluetooth_gatts_notify_send(conn_handle, value_handle, bufinfo.buf, bufinfo.len);
@@ -719,7 +719,10 @@ STATIC MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(bluetooth_ble_gatts_set_buffer_obj, 3
 STATIC mp_obj_t bluetooth_ble_gattc_discover_services(size_t n_args, const mp_obj_t *args) {
     mp_int_t conn_handle = mp_obj_get_int(args[1]);
     mp_obj_bluetooth_uuid_t *uuid = NULL;
-    if (n_args == 3) {
+    if (n_args == 3 && args[2] != mp_const_none) {
+        if (!mp_obj_is_type(args[2], &bluetooth_uuid_type)) {
+            mp_raise_TypeError(MP_ERROR_TEXT("UUID"));
+        }
         uuid = MP_OBJ_TO_PTR(args[2]);
     }
     return bluetooth_handle_errno(mp_bluetooth_gattc_discover_primary_services(conn_handle, uuid));
@@ -731,7 +734,10 @@ STATIC mp_obj_t bluetooth_ble_gattc_discover_characteristics(size_t n_args, cons
     mp_int_t start_handle = mp_obj_get_int(args[2]);
     mp_int_t end_handle = mp_obj_get_int(args[3]);
     mp_obj_bluetooth_uuid_t *uuid = NULL;
-    if (n_args == 3) {
+    if (n_args == 5 && args[4] != mp_const_none) {
+        if (!mp_obj_is_type(args[4], &bluetooth_uuid_type)) {
+            mp_raise_TypeError(MP_ERROR_TEXT("UUID"));
+        }
         uuid = MP_OBJ_TO_PTR(args[4]);
     }
     return bluetooth_handle_errno(mp_bluetooth_gattc_discover_characteristics(conn_handle, start_handle, end_handle, uuid));

--- a/extmod/modbluetooth.c
+++ b/extmod/modbluetooth.c
@@ -384,27 +384,21 @@ STATIC mp_obj_t bluetooth_ble_config(size_t n_args, const mp_obj_t *args, mp_map
 }
 STATIC MP_DEFINE_CONST_FUN_OBJ_KW(bluetooth_ble_config_obj, 1, bluetooth_ble_config);
 
-STATIC mp_obj_t bluetooth_ble_irq(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
-    enum { ARG_handler };
-    static const mp_arg_t allowed_args[] = {
-        { MP_QSTR_handler, MP_ARG_OBJ | MP_ARG_REQUIRED, {.u_rom_obj = MP_ROM_NONE} },
-    };
-    mp_arg_val_t args[MP_ARRAY_SIZE(allowed_args)];
-    mp_arg_parse_all(n_args - 1, pos_args + 1, kw_args, MP_ARRAY_SIZE(allowed_args), allowed_args, args);
-    mp_obj_t callback = args[ARG_handler].u_obj;
-    if (callback != mp_const_none && !mp_obj_is_callable(callback)) {
-        mp_raise_ValueError(MP_ERROR_TEXT("invalid callback"));
+STATIC mp_obj_t bluetooth_ble_irq(mp_obj_t self_in, mp_obj_t handler_in) {
+    (void)self_in;
+    if (handler_in != mp_const_none && !mp_obj_is_callable(handler_in)) {
+        mp_raise_ValueError(MP_ERROR_TEXT("invalid handler"));
     }
 
     // Update the callback.
     MICROPY_PY_BLUETOOTH_ENTER
     mp_obj_bluetooth_ble_t *o = MP_OBJ_TO_PTR(MP_STATE_VM(bluetooth));
-    o->irq_handler = callback;
+    o->irq_handler = handler_in;
     MICROPY_PY_BLUETOOTH_EXIT
 
     return mp_const_none;
 }
-STATIC MP_DEFINE_CONST_FUN_OBJ_KW(bluetooth_ble_irq_obj, 1, bluetooth_ble_irq);
+STATIC MP_DEFINE_CONST_FUN_OBJ_2(bluetooth_ble_irq_obj, bluetooth_ble_irq);
 
 // ----------------------------------------------------------------------------
 // Bluetooth object: GAP

--- a/extmod/modbluetooth.c
+++ b/extmod/modbluetooth.c
@@ -181,7 +181,7 @@ STATIC void bluetooth_uuid_print(const mp_print_t *print, mp_obj_t self_in, mp_p
     (void)kind;
 
     mp_obj_bluetooth_uuid_t *self = MP_OBJ_TO_PTR(self_in);
-    mp_printf(print, "UUID%u(%s", self->type * 8, self->type <= 4 ? "0x" : "'");
+    mp_printf(print, "UUID(%s", self->type <= 4 ? "0x" : "'");
     for (int i = 0; i < self->type; ++i) {
         if (i == 4 || i == 6 || i == 8 || i == 10) {
             mp_printf(print, "-");


### PR DESCRIPTION
* Fix handling of optional args in `BLE::gatts_notify`, `BLE::gattc_discover_services`, `BLE::gattc_discover_characteristics`
* Simplify `BLE::irq`'s `handler` arg.
* Update docs to use PEP570 syntax.