### PR TITLE
py/showbc: Pass in an mp_print_t struct to all bytecode-print functions.

### DIFF
--- a/py/bc.h
+++ b/py/bc.h
@@ -226,10 +226,10 @@ const byte *mp_decode_uint_skip(const byte *ptr);
 mp_vm_return_kind_t mp_execute_bytecode(mp_code_state_t *code_state, volatile mp_obj_t inject_exc);
 mp_code_state_t *mp_obj_fun_bc_prepare_codestate(mp_obj_t func, size_t n_args, size_t n_kw, const mp_obj_t *args);
 void mp_setup_code_state(mp_code_state_t *code_state, size_t n_args, size_t n_kw, const mp_obj_t *args);
-void mp_bytecode_print(const void *descr, const byte *code, mp_uint_t len, const mp_uint_t *const_table);
-void mp_bytecode_print2(const byte *code, size_t len, const mp_uint_t *const_table);
-const byte *mp_bytecode_print_str(const byte *ip);
-#define mp_bytecode_print_inst(code, const_table) mp_bytecode_print2(code, 1, const_table)
+void mp_bytecode_print(const mp_print_t *print, const void *descr, const byte *code, mp_uint_t len, const mp_uint_t *const_table);
+void mp_bytecode_print2(const mp_print_t *print, const byte *code, size_t len, const mp_uint_t *const_table);
+const byte *mp_bytecode_print_str(const mp_print_t *print, const byte *ip);
+#define mp_bytecode_print_inst(print, code, const_table) mp_bytecode_print2(print, code, 1, const_table)
 
 // Helper macros to access pointer with least significant bits holding flags
 #define MP_TAGPTR_PTR(x) ((void *)((uintptr_t)(x) & ~((uintptr_t)3)))

--- a/py/emitglue.c
+++ b/py/emitglue.c
@@ -92,7 +92,7 @@ void mp_emit_glue_assign_bytecode(mp_raw_code_t *rc, const byte *code,
     #endif
     #if MICROPY_DEBUG_PRINTERS
     if (mp_verbose_flag >= 2) {
-        mp_bytecode_print(rc, code, len, const_table);
+        mp_bytecode_print(&mp_plat_print, rc, code, len, const_table);
     }
     #endif
 }

--- a/py/vm.c
+++ b/py/vm.c
@@ -39,7 +39,7 @@
 // *FORMAT-OFF*
 
 #if 0
-#define TRACE(ip) printf("sp=%d ", (int)(sp - &code_state->state[0] + 1)); mp_bytecode_print2(ip, 1, code_state->fun_bc->const_table);
+#define TRACE(ip) printf("sp=%d ", (int)(sp - &code_state->state[0] + 1)); mp_bytecode_print2(&mp_plat_print, ip, 1, code_state->fun_bc->const_table);
 #else
 #define TRACE(ip)
 #endif


### PR DESCRIPTION
So the output can be redirected if needed.

No change to existing functionality.