### PR TITLE
py/parse: Pass in an mp_print_t to mp_parse_node_print.

### DIFF
--- a/ports/unix/main.c
+++ b/ports/unix/main.c
@@ -133,7 +133,7 @@ STATIC int execute_from_lexer(int source_kind, const void *source, mp_parse_inpu
         // allow to print the parse tree in the coverage build
         if (mp_verbose_flag >= 3) {
             printf("----------------\n");
-            mp_parse_node_print(parse_tree.root, 0);
+            mp_parse_node_print(&mp_plat_print, parse_tree.root, 0);
             printf("----------------\n");
         }
         #endif

--- a/py/parse.c
+++ b/py/parse.c
@@ -368,35 +368,35 @@ size_t mp_parse_node_extract_list(mp_parse_node_t *pn, size_t pn_kind, mp_parse_
 }
 
 #if MICROPY_DEBUG_PRINTERS
-void mp_parse_node_print(mp_parse_node_t pn, size_t indent) {
+void mp_parse_node_print(const mp_print_t *print, mp_parse_node_t pn, size_t indent) {
     if (MP_PARSE_NODE_IS_STRUCT(pn)) {
-        printf("[% 4d] ", (int)((mp_parse_node_struct_t *)pn)->source_line);
+        mp_printf(print, "[% 4d] ", (int)((mp_parse_node_struct_t *)pn)->source_line);
     } else {
-        printf("       ");
+        mp_printf(print, "       ");
     }
     for (size_t i = 0; i < indent; i++) {
-        printf(" ");
+        mp_printf(print, " ");
     }
     if (MP_PARSE_NODE_IS_NULL(pn)) {
-        printf("NULL\n");
+        mp_printf(print, "NULL\n");
     } else if (MP_PARSE_NODE_IS_SMALL_INT(pn)) {
         mp_int_t arg = MP_PARSE_NODE_LEAF_SMALL_INT(pn);
-        printf("int(" INT_FMT ")\n", arg);
+        mp_printf(print, "int(" INT_FMT ")\n", arg);
     } else if (MP_PARSE_NODE_IS_LEAF(pn)) {
         uintptr_t arg = MP_PARSE_NODE_LEAF_ARG(pn);
         switch (MP_PARSE_NODE_LEAF_KIND(pn)) {
             case MP_PARSE_NODE_ID:
-                printf("id(%s)\n", qstr_str(arg));
+                mp_printf(print, "id(%s)\n", qstr_str(arg));
                 break;
             case MP_PARSE_NODE_STRING:
-                printf("str(%s)\n", qstr_str(arg));
+                mp_printf(print, "str(%s)\n", qstr_str(arg));
                 break;
             case MP_PARSE_NODE_BYTES:
-                printf("bytes(%s)\n", qstr_str(arg));
+                mp_printf(print, "bytes(%s)\n", qstr_str(arg));
                 break;
             default:
                 assert(MP_PARSE_NODE_LEAF_KIND(pn) == MP_PARSE_NODE_TOKEN);
-                printf("tok(%u)\n", (uint)arg);
+                mp_printf(print, "tok(%u)\n", (uint)arg);
                 break;
         }
     } else {
@@ -404,19 +404,19 @@ void mp_parse_node_print(mp_parse_node_t pn, size_t indent) {
         mp_parse_node_struct_t *pns = (mp_parse_node_struct_t *)pn;
         if (MP_PARSE_NODE_STRUCT_KIND(pns) == RULE_const_object) {
             #if MICROPY_OBJ_REPR == MICROPY_OBJ_REPR_D
-            printf("literal const(%016llx)\n", (uint64_t)pns->nodes[0] | ((uint64_t)pns->nodes[1] << 32));
+            mp_printf(print, "literal const(%016llx)\n", (uint64_t)pns->nodes[0] | ((uint64_t)pns->nodes[1] << 32));
             #else
-            printf("literal const(%p)\n", (mp_obj_t)pns->nodes[0]);
+            mp_printf(print, "literal const(%p)\n", (mp_obj_t)pns->nodes[0]);
             #endif
         } else {
             size_t n = MP_PARSE_NODE_STRUCT_NUM_NODES(pns);
             #if USE_RULE_NAME
-            printf("%s(%u) (n=%u)\n", rule_name_table[MP_PARSE_NODE_STRUCT_KIND(pns)], (uint)MP_PARSE_NODE_STRUCT_KIND(pns), (uint)n);
+            mp_printf(print, "%s(%u) (n=%u)\n", rule_name_table[MP_PARSE_NODE_STRUCT_KIND(pns)], (uint)MP_PARSE_NODE_STRUCT_KIND(pns), (uint)n);
             #else
-            printf("rule(%u) (n=%u)\n", (uint)MP_PARSE_NODE_STRUCT_KIND(pns), (uint)n);
+            mp_printf(print, "rule(%u) (n=%u)\n", (uint)MP_PARSE_NODE_STRUCT_KIND(pns), (uint)n);
             #endif
             for (size_t i = 0; i < n; i++) {
-                mp_parse_node_print(pns->nodes[i], indent + 2);
+                mp_parse_node_print(print, pns->nodes[i], indent + 2);
             }
         }
     }
@@ -424,10 +424,10 @@ void mp_parse_node_print(mp_parse_node_t pn, size_t indent) {
 #endif // MICROPY_DEBUG_PRINTERS
 
 /*
-STATIC void result_stack_show(parser_t *parser) {
-    printf("result stack, most recent first\n");
+STATIC void result_stack_show(const mp_print_t *print, parser_t *parser) {
+    mp_printf(print, "result stack, most recent first\n");
     for (ssize_t i = parser->result_stack_top - 1; i >= 0; i--) {
-        mp_parse_node_print(parser->result_stack[i], 0);
+        mp_parse_node_print(print, parser->result_stack[i], 0);
     }
 }
 */

--- a/py/parse.h
+++ b/py/parse.h
@@ -86,7 +86,7 @@ bool mp_parse_node_is_const_false(mp_parse_node_t pn);
 bool mp_parse_node_is_const_true(mp_parse_node_t pn);
 bool mp_parse_node_get_int_maybe(mp_parse_node_t pn, mp_obj_t *o);
 size_t mp_parse_node_extract_list(mp_parse_node_t *pn, size_t pn_kind, mp_parse_node_t **nodes);
-void mp_parse_node_print(mp_parse_node_t pn, size_t indent);
+void mp_parse_node_print(const mp_print_t *print, mp_parse_node_t pn, size_t indent);
 
 typedef enum {
     MP_PARSE_SINGLE_INPUT,


### PR DESCRIPTION
So the output can be redirected if needed.

Follow up to #6435 