### PR TITLE
zephyr: Update to zephyr v2.4.0.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -54,7 +54,7 @@ jobs:
           zephyrprojectrtos/ci:v0.11.8
         - docker ps -a
       install:
-        - docker exec zephyr-ci west init --mr v2.3.0 /zephyrproject
+        - docker exec zephyr-ci west init --mr v2.4.0 /zephyrproject
         - docker exec -w /zephyrproject zephyr-ci west update
         - docker exec -w /zephyrproject zephyr-ci west zephyr-export
       script:

--- a/ports/zephyr/README.md
+++ b/ports/zephyr/README.md
@@ -4,7 +4,7 @@ MicroPython port to Zephyr RTOS
 This is a work-in-progress port of MicroPython to Zephyr RTOS
 (http://zephyrproject.org).
 
-This port requires Zephyr version 2.3.0, and may also work on higher
+This port requires Zephyr version 2.4.0, and may also work on higher
 versions.  All boards supported
 by Zephyr (with standard level of features support, like UART console)
 should work with MicroPython (but not all were tested).
@@ -38,13 +38,13 @@ setup is correct.
 If you already have Zephyr installed but are having issues building the
 MicroPython port then try installing the correct version of Zephyr via:
 
-    $ west init zephyrproject -m https://github.com/zephyrproject-rtos/zephyr --mr v2.3.0
+    $ west init zephyrproject -m https://github.com/zephyrproject-rtos/zephyr --mr v2.4.0
 
 Alternatively, you don't have to redo the Zephyr installation to just
 switch from master to a tagged release, you can instead do:
 
     $ cd zephyrproject/zephyr
-    $ git checkout v2.3.0
+    $ git checkout v2.4.0
     $ west update
 
 With Zephyr installed you may then need to configure your environment,

--- a/ports/zephyr/machine_i2c.c
+++ b/ports/zephyr/machine_i2c.c
@@ -97,7 +97,7 @@ STATIC int machine_hard_i2c_transfer_single(mp_obj_base_t *self_in, uint16_t add
     struct i2c_msg msg;
     int ret;
 
-    msg.buf = (u8_t *)buf;
+    msg.buf = (uint8_t *)buf;
     msg.len = len;
     msg.flags = 0;
 

--- a/ports/zephyr/machine_i2c.c
+++ b/ports/zephyr/machine_i2c.c
@@ -42,7 +42,7 @@ STATIC const mp_obj_type_t machine_hard_i2c_type;
 
 typedef struct _machine_hard_i2c_obj_t {
     mp_obj_base_t base;
-    struct device *dev;
+    const struct device *dev;
     bool restart;
 } machine_hard_i2c_obj_t;
 
@@ -65,7 +65,7 @@ mp_obj_t machine_hard_i2c_make_new(const mp_obj_type_t *type, size_t n_args, siz
     mp_arg_parse_all_kw_array(n_args, n_kw, all_args, MP_ARRAY_SIZE(allowed_args), allowed_args, args);
 
     const char *dev_name = mp_obj_str_get_str(args[ARG_id].u_obj);
-    struct device *dev = device_get_binding(dev_name);
+    const struct device *dev = device_get_binding(dev_name);
 
     if (dev == NULL) {
         mp_raise_ValueError(MP_ERROR_TEXT("device not found"));

--- a/ports/zephyr/machine_pin.c
+++ b/ports/zephyr/machine_pin.c
@@ -58,7 +58,7 @@ void machine_pin_deinit(void) {
     MP_STATE_PORT(machine_pin_irq_list) = NULL;
 }
 
-STATIC void gpio_callback_handler(struct device *port, struct gpio_callback *cb, gpio_port_pins_t pins) {
+STATIC void gpio_callback_handler(const struct device *port, struct gpio_callback *cb, gpio_port_pins_t pins) {
     machine_pin_irq_obj_t *irq = CONTAINER_OF(cb, machine_pin_irq_obj_t, callback);
 
     #if MICROPY_STACK_CHECK
@@ -132,7 +132,7 @@ mp_obj_t mp_pin_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, 
     mp_obj_get_array_fixed_n(args[0], 2, &items);
     const char *drv_name = mp_obj_str_get_str(items[0]);
     int wanted_pin = mp_obj_get_int(items[1]);
-    struct device *wanted_port = device_get_binding(drv_name);
+    const struct device *wanted_port = device_get_binding(drv_name);
     if (!wanted_port) {
         mp_raise_ValueError(MP_ERROR_TEXT("invalid port"));
     }

--- a/ports/zephyr/modmachine.h
+++ b/ports/zephyr/modmachine.h
@@ -9,7 +9,7 @@ MP_DECLARE_CONST_FUN_OBJ_0(machine_info_obj);
 
 typedef struct _machine_pin_obj_t {
     mp_obj_base_t base;
-    struct device *port;
+    const struct device *port;
     uint32_t pin;
     struct _machine_pin_irq_obj_t *irq;
 } machine_pin_obj_t;

--- a/ports/zephyr/modzsensor.c
+++ b/ports/zephyr/modzsensor.c
@@ -35,7 +35,7 @@
 
 typedef struct _mp_obj_sensor_t {
     mp_obj_base_t base;
-    struct device *dev;
+    const struct device *dev;
 } mp_obj_sensor_t;
 
 STATIC mp_obj_t sensor_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *args) {

--- a/ports/zephyr/uart_core.c
+++ b/ports/zephyr/uart_core.c
@@ -53,7 +53,7 @@ void mp_hal_stdout_tx_strn(const char *str, mp_uint_t len) {
         }
     }
     #else
-    static struct device *uart_console_dev;
+    static const struct device *uart_console_dev;
     if (uart_console_dev == NULL) {
         uart_console_dev = device_get_binding(CONFIG_UART_CONSOLE_ON_DEV_NAME);
     }

--- a/ports/zephyr/zephyr_storage.c
+++ b/ports/zephyr/zephyr_storage.c
@@ -146,7 +146,7 @@ typedef struct _zephyr_flash_area_obj_t {
     const struct flash_area *area;
     int block_size;
     int block_count;
-    u8_t id;
+    uint8_t id;
 } zephyr_flash_area_obj_t;
 
 STATIC void zephyr_flash_area_print(const mp_print_t *print, mp_obj_t self_in, mp_print_kind_t kind) {


### PR DESCRIPTION
Minor changes to the zephyr port to update to zephyr v2.4.0. 

~~This PR is in draft status until the zephyr release is finalized.~~
The PR is now ready to go.

~~@tejlmand will you please have a look at the commit `zephyr: Move system includes to the end of Z_CFLAGS.`~~
A minor zephyr build system bug was fixed and this workaround commit was removed.