### PR TITLE
extmod/bluetooth: Add BLE().gap_pair(conn_handle, bond, mitm, lesc) function

### DIFF
--- a/extmod/btstack/modbluetooth_btstack.c
+++ b/extmod/btstack/modbluetooth_btstack.c
@@ -1057,6 +1057,17 @@ int mp_bluetooth_set_preferred_mtu(uint16_t mtu) {
     }
     return 0;
 }
+    
+int mp_bluetooth_gap_pair(int conn_handle, bool bond, bool mitm, bool lesc) {
+    sm_set_authentication_requirements(
+        (bond? SM_AUTHREQ_BONDING: 0) |
+        (mitm ? SM_AUTHREQ_MITM_PROTECTION : 0 ) |
+        (lesc ? SM_AUTHREQ_SECURE_CONNECTION : 0 )
+    );
+    // start pairing
+    sm_request_pairing(conn_handle);
+    return 0;
+}
 
 int mp_bluetooth_gap_disconnect(uint16_t conn_handle) {
     DEBUG_printf("mp_bluetooth_gap_disconnect\n");

--- a/extmod/modbluetooth.c
+++ b/extmod/modbluetooth.c
@@ -638,6 +638,33 @@ STATIC mp_obj_t bluetooth_ble_gap_scan(size_t n_args, const mp_obj_t *args) {
 STATIC MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(bluetooth_ble_gap_scan_obj, 1, 5, bluetooth_ble_gap_scan);
 #endif // MICROPY_PY_BLUETOOTH_ENABLE_CENTRAL_MODE
 
+STATIC mp_obj_t bluetooth_ble_gap_pair(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
+    #ifdef MICROPY_PY_BLUETOOTH_BOND_FILE
+    #define BOND_DEFAULT 1
+    #else
+    #define BOND_DEFAULT 0
+    #endif
+    enum { ARG_conn_handle, ARG_bond, ARG_mitm, ARG_lesc, /*ARG_pin*/ };
+    static const mp_arg_t allowed_args[] = {
+        { MP_QSTR_conn_handle, MP_ARG_REQUIRED | MP_ARG_INT, {.u_int = 0} },
+        { MP_QSTR_bond,  MP_ARG_BOOL, {.u_bool = BOND_DEFAULT} },
+        { MP_QSTR_mitm,  MP_ARG_BOOL, {.u_bool = false} },
+        { MP_QSTR_lesc,  MP_ARG_BOOL, {.u_bool = true} },
+        // { MP_QSTR_pin, MP_ARG_INT, {.u_int = -1} },
+    };
+    mp_arg_val_t args[MP_ARRAY_SIZE(allowed_args)];
+    mp_arg_parse_all(n_args - 1, pos_args + 1, kw_args, MP_ARRAY_SIZE(allowed_args), allowed_args, args);
+
+    mp_int_t conn_handle = args[ARG_conn_handle].u_int;
+    bool bond = args[ARG_bond].u_bool;
+    bool mitm = args[ARG_mitm].u_bool;
+    bool lesc = args[ARG_lesc].u_bool;
+    // mp_int_t pin = args[ARG_pin].u_int;
+
+    return bluetooth_handle_errno(mp_bluetooth_gap_pair(conn_handle, bond, mitm, lesc));
+}
+STATIC MP_DEFINE_CONST_FUN_OBJ_KW(bluetooth_ble_gap_pair_obj, 1, bluetooth_ble_gap_pair);
+
 STATIC mp_obj_t bluetooth_ble_gap_disconnect(mp_obj_t self_in, mp_obj_t conn_handle_in) {
     (void)self_in;
     uint16_t conn_handle = mp_obj_get_int(conn_handle_in);
@@ -799,6 +826,7 @@ STATIC const mp_rom_map_elem_t bluetooth_ble_locals_dict_table[] = {
     #if MICROPY_PY_BLUETOOTH_ENABLE_CENTRAL_MODE
     { MP_ROM_QSTR(MP_QSTR_gap_connect), MP_ROM_PTR(&bluetooth_ble_gap_connect_obj) },
     { MP_ROM_QSTR(MP_QSTR_gap_scan), MP_ROM_PTR(&bluetooth_ble_gap_scan_obj) },
+    { MP_ROM_QSTR(MP_QSTR_gap_pair), MP_ROM_PTR(&bluetooth_ble_gap_pair_obj) },
     #endif
     { MP_ROM_QSTR(MP_QSTR_gap_disconnect), MP_ROM_PTR(&bluetooth_ble_gap_disconnect_obj) },
     // GATT Server (i.e. peripheral/advertiser role)

--- a/extmod/modbluetooth.h
+++ b/extmod/modbluetooth.h
@@ -216,6 +216,9 @@ int mp_bluetooth_gatts_indicate(uint16_t conn_handle, uint16_t value_handle);
 // Append-mode means that remote writes will append and local reads will clear after reading.
 int mp_bluetooth_gatts_set_buffer(uint16_t value_handle, size_t len, bool append);
 
+// Initial pairing/bonding
+int mp_bluetooth_gap_pair(int conn_handle, bool bond, bool mitm, bool lesc);
+
 // Disconnect from a central or peripheral.
 int mp_bluetooth_gap_disconnect(uint16_t conn_handle);
 

--- a/extmod/nimble/modbluetooth_nimble.c
+++ b/extmod/nimble/modbluetooth_nimble.c
@@ -724,6 +724,13 @@ int mp_bluetooth_gatts_register_service(mp_obj_bluetooth_uuid_t *service_uuid, m
     return 0;
 }
 
+int mp_bluetooth_gap_pair(int conn_handle, bool bond, bool mitm, bool lesc) {
+    ble_hs_cfg.sm_bonding = bond;
+    ble_hs_cfg.sm_mitm = mitm;
+    ble_hs_cfg.sm_sc = lesc;
+    return ble_gap_security_initiate(conn_handle);
+}
+
 int mp_bluetooth_gap_disconnect(uint16_t conn_handle) {
     if (!mp_bluetooth_is_active()) {
         return ERRNO_BLUETOOTH_NOT_ACTIVE;


### PR DESCRIPTION
Adds python function to trigger a pairing/bonding operation with the current peer.
For use with:
* extmod/nimble: Add support for persistant bonding: https://github.com/micropython/micropython/pull/6289
* WIP: extmod/btstack: Add support for persistant bonding: https://github.com/micropython/micropython/pull/6312

TODO: docs