### PR TITLE
ports/esp32: (Re)enable PPP support for ESP32 IDF-SDK version >=4

### DIFF
--- a/ports/esp32/modnetwork.c
+++ b/ports/esp32/modnetwork.c
@@ -755,8 +755,8 @@ STATIC const mp_rom_map_elem_t mp_module_network_globals_table[] = {
     { MP_ROM_QSTR(MP_QSTR_WLAN), MP_ROM_PTR(&get_wlan_obj) },
     #if !MICROPY_ESP_IDF_4
     { MP_ROM_QSTR(MP_QSTR_LAN), MP_ROM_PTR(&get_lan_obj) },
-    { MP_ROM_QSTR(MP_QSTR_PPP), MP_ROM_PTR(&ppp_make_new_obj) },
     #endif
+    { MP_ROM_QSTR(MP_QSTR_PPP), MP_ROM_PTR(&ppp_make_new_obj) },
     { MP_ROM_QSTR(MP_QSTR_phy_mode), MP_ROM_PTR(&esp_phy_mode_obj) },
 
     #if MODNETWORK_INCLUDE_CONSTANTS

--- a/ports/esp32/network_ppp.c
+++ b/ports/esp32/network_ppp.c
@@ -26,7 +26,6 @@
  * THE SOFTWARE.
  */
 
-#if !MICROPY_ESP_IDF_4
 #include "py/runtime.h"
 #include "py/mphal.h"
 #include "py/objtype.h"
@@ -284,5 +283,3 @@ const mp_obj_type_t ppp_if_type = {
     .name = MP_QSTR_PPP,
     .locals_dict = (mp_obj_dict_t *)&ppp_if_locals_dict,
 };
-
-#endif // !MICROPY_ESP_IDF_4


### PR DESCRIPTION
PPP support was disabled in 96008ff59a8af9883af17d01b951029d9d02eec9 -
marked as "unsupported".
With the currently supported v4.x version - 4c81978a - it appears to be
working just fine, though - hence, re-enabling.