### PR TITLE
py/objstr: bytes(bytes_obj) is bytes_obj

### DIFF
--- a/py/objstr.c
+++ b/py/objstr.c
@@ -205,6 +205,10 @@ STATIC mp_obj_t bytes_make_new(const mp_obj_type_t *type_in, size_t n_args, size
         return mp_const_empty_bytes;
     }
 
+    if (mp_obj_is_type(args[0], &mp_type_bytes)) {
+        return args[0];
+    }
+
     if (mp_obj_is_str(args[0])) {
         if (n_args < 2 || n_args > 3) {
             goto wrong_args;


### PR DESCRIPTION
Calling the `bytes` constructor on a `bytes` object returns the original `bytes` object. This addresses #6320 and has been tested on an ESP32, and everything seems to be working fine:

```python
MicroPython v1.13-dirty on 2020-09-18; ESP32 module with ESP32
Type "help()" for more information.
>>> a = b"Original"
>>> b = a
>>> c = bytes(a)
>>> type(a)
<class 'bytes'>
>>> a is b
True
>>> a is c
True
>>> id(a)
1073642736
>>> id(b)
1073642736
>>> id(c)
1073642736
```