### PR TITLE
stm32/rfcore: Fix FUS layout and size of ipcc_device_info_table_t.

### DIFF
--- a/ports/stm32/boards/NUCLEO_WB55/rfcore.py
+++ b/ports/stm32/boards/NUCLEO_WB55/rfcore.py
@@ -34,8 +34,13 @@
 # to print out SRAM2A, register state and FUS/WS info.
 
 from machine import mem8, mem16, mem32
-import time, struct, uctypes
+import time, struct
 import stm
+
+
+def addressof(buf):
+    assert type(buf) is bytearray
+    return mem32[id(buf) + 12]
 
 
 class Flash:
@@ -68,7 +73,7 @@ class Flash:
         self.wait_not_busy()
         cr = 1 << 0  # PG
         mem32[stm.FLASH + stm.FLASH_CR] = cr
-        buf_addr = uctypes.addressof(buf)
+        buf_addr = addressof(buf)
         off = 0
         while off < len(buf):
             mem32[addr + off] = mem32[buf_addr + off]
@@ -110,13 +115,6 @@ OCF_FUS_FW_UPGRADE = const(0x54)
 OCF_FUS_FW_DELETE = const(0x55)
 OCF_FUS_START_WS = const(0x5A)
 OCF_BLE_INIT = const(0x66)
-
-
-@micropython.asm_thumb
-def asm_sev_wfe():
-    data(2, 0xBF40)  # sev
-    data(2, 0xBF20)  # wfe
-
 
 TABLE_DEVICE_INFO = const(0)
 TABLE_BLE = const(1)
@@ -198,6 +196,9 @@ def ipcc_init():
     BLE_CS_BUF = get_ipcc_table_word(TABLE_BLE, 1)
     BLE_EVT_QUEUE = get_ipcc_table_word(TABLE_BLE, 2)
     BLE_HCI_ACL_DATA_BUF = get_ipcc_table_word(TABLE_BLE, 3)
+
+    # Disable interrupts, the code here uses polling
+    mem32[stm.IPCC + stm.IPCC_C1CR] = 0
 
     print("IPCC initialised")
     print("SYS: 0x%08x 0x%08x" % (SYS_CMD_BUF, SYS_SYS_QUEUE))

--- a/ports/stm32/rfcore.c
+++ b/ports/stm32/rfcore.c
@@ -94,15 +94,35 @@ typedef struct _parse_hci_info_t {
 // [16:23] = SRAM2b (Number of 1k sectors)
 // [24:31] = SRAM2a (Number of 1k sectors)
 
-typedef struct __attribute__((packed)) _ipcc_device_info_table_t {
-    uint32_t safeboot_version;
-    uint32_t fus_version;
-    uint32_t fus_memorysize;
-    uint32_t fus_info;
-    uint32_t fw_version;
-    uint32_t fw_memorysize;
-    uint32_t fw_infostack;
-    uint32_t fw_reserved;
+typedef union __attribute__((packed)) _ipcc_device_info_table_t {
+    struct {
+        uint32_t table_state;
+        uint8_t reserved0;
+        uint8_t last_fus_state;
+        uint8_t last_ws_state;
+        uint8_t ws_type;
+        uint32_t safeboot_version;
+        uint32_t fus_version;
+        uint32_t fus_memorysize;
+        uint32_t ws_version;
+        uint32_t ws_memorysize;
+        uint32_t ws_ble_info;
+        uint32_t ws_thread_info;
+        uint32_t reserved1;
+        uint64_t uid64;
+        uint16_t device_id;
+        uint16_t pad;
+    } fus;
+    struct {
+        uint32_t safeboot_version;
+        uint32_t fus_version;
+        uint32_t fus_memorysize;
+        uint32_t fus_info;
+        uint32_t fw_version;
+        uint32_t fw_memorysize;
+        uint32_t fw_infostack;
+        uint32_t fw_reserved;
+    } ws;
 } ipcc_device_info_table_t;
 
 typedef struct __attribute__((packed)) _ipcc_ble_table_t {


### PR DESCRIPTION
The device info table has a different layout when core 2 is in FUS mode.  In particular it's larger than the 32 bytes used when in WS mode and if the correct amount of space is not allocated then the end of the table may be overwritten with other data (eg with FUS version 0.5.3).  So update the structure to fix this.

Also update rfcore.py to disable IRQs (which are enabled by rfcore.c), to not depend on uctypes, and to not require the asm_thumb emitter.