### PR TITLE
extmod/vfs: Fix lookup of entry in root dir so it fails correctly.

### DIFF
--- a/extmod/vfs.c
+++ b/extmod/vfs.c
@@ -83,12 +83,8 @@ mp_vfs_mount_t *mp_vfs_lookup_path(const char *path, const char **path_out) {
             }
         }
 
-        // if we get here then there's nothing mounted on /
-
-        if (is_abs) {
-            // path began with / and was not found
-            return MP_VFS_NONE;
-        }
+        // if we get here then there's nothing mounted on /, so the path doesn't exist
+        return MP_VFS_NONE;
     }
 
     // a relative path within a mounted device

--- a/tests/extmod/vfs_basic.py
+++ b/tests/extmod/vfs_basic.py
@@ -74,6 +74,14 @@ print(uos.statvfs("/")[9] >= 32)
 # getcwd when in root dir
 print(uos.getcwd())
 
+# test operations on the root directory with nothing mounted, they should all fail
+for func in ("chdir", "listdir", "mkdir", "remove", "rmdir", "stat"):
+    for arg in ("x", "/x"):
+        try:
+            getattr(uos, func)(arg)
+        except OSError:
+            print(func, arg, "OSError")
+
 # basic mounting and listdir
 uos.mount(Filesystem(1), "/test_mnt")
 print(uos.listdir())

--- a/tests/extmod/vfs_basic.py.exp
+++ b/tests/extmod/vfs_basic.py.exp
@@ -1,6 +1,18 @@
 (16384, 0, 0, 0, 0, 0, 0, 0, 0, 0)
 True
 /
+chdir x OSError
+chdir /x OSError
+listdir x OSError
+listdir /x OSError
+mkdir x OSError
+mkdir /x OSError
+remove x OSError
+remove /x OSError
+rmdir x OSError
+rmdir /x OSError
+stat x OSError
+stat /x OSError
 1 mount False False
 ['test_mnt']
 ('test_mnt', 16384, 0)


### PR DESCRIPTION
Prior to this commit, uos.chdir('/') followed by uos.stat('noexist') would succeed that stat even though the entry did not exist (some other functions like listdir would have similar issues).  This is because, if the current directory was the root and the path was relative, mp_vfs_lookup_path would return success for bad paths.