### PR TITLE
py/makeversionhdr.py: Match only git tags which look like versions.

### DIFF
--- a/py/makeversionhdr.py
+++ b/py/makeversionhdr.py
@@ -23,7 +23,7 @@ def get_version_info_from_git():
     # Note: git describe doesn't work if no tag is available
     try:
         git_tag = subprocess.check_output(
-            ["git", "describe", "--dirty", "--always"],
+            ["git", "describe", "--dirty", "--always", "--match", "v[1-9].*"],
             stderr=subprocess.STDOUT,
             universal_newlines=True,
         ).strip()


### PR DESCRIPTION
Some forks may use tags in their repositories for more than just
designating MicroPython releases. In those cases, the
makeversionhdr.py script would end up using a different tag than
intended. So, we tell `git describe` to only match tags that look like
a MicroPython version tag, such as `v1.12` or `v2.0`.

If there are any known forks which rely on _not_ filtering like this
(i.e. they _want_ other tags to be picked up),
then we can just keep this patch in our (internal) fork.