### PR TITLE
extmod/modbluetooth: Change module-owned bytes objects to memoryview.

### DIFF
--- a/docs/library/ubluetooth.rst
+++ b/docs/library/ubluetooth.rst
@@ -88,12 +88,22 @@ Event Handling
     arguments, ``event`` (which will be one of the codes below) and ``data``
     (which is an event-specific tuple of values).
 
-    **Note:** the ``addr``, ``adv_data``, ``char_data``, ``notify_data``, and
-    ``uuid`` entries in the tuples are references to data managed by the
-    :mod:`ubluetooth` module (i.e. the same instance will be re-used across
-    multiple calls to the event handler). If your program wants to use this
-    data outside of the handler, then it must copy them first, e.g. by using
-    ``bytes(addr)`` or ``bluetooth.UUID(uuid)``.
+    **Note:** As an optimisation to prevent unnecessary allocations, the ``addr``,
+    ``adv_data``, ``char_data``, ``notify_data``, and ``uuid`` entries in the
+    tuples are read-only memoryview instances pointing to ubluetooth's internal
+    ringbuffer, and are only valid during the invocation of the IRQ handler
+    function.  If your program needs to save one of these values to access after
+    the IRQ handler has returned (e.g. by saving it in a class instance or global
+    variable), then it needs to take a copy of the data, either by using ``bytes()``
+    or ``bluetooth.UUID()``, like this::
+
+        connected_addr = bytes(addr)  # equivalently: adv_data, char_data, or notify_data
+        matched_uuid = bluetooth.UUID(uuid)
+
+    For example, the IRQ handler for a scan result might inspect the ``adv_data``
+    to decide if it's the correct device, and only then copy the address data to be
+    used elsewhere in the program.  And to print data from within the IRQ handler,
+    ``print(bytes(addr))`` will be needed.
 
     An event handler showing all possible events::
 

--- a/py/objarray.h
+++ b/py/objarray.h
@@ -49,4 +49,14 @@ typedef struct _mp_obj_array_t {
     void *items;
 } mp_obj_array_t;
 
+#if MICROPY_PY_BUILTINS_MEMORYVIEW
+static inline void mp_obj_memoryview_init(mp_obj_array_t *self, size_t typecode, size_t offset, size_t len, void *items) {
+    self->base.type = &mp_type_memoryview;
+    self->typecode = typecode;
+    self->free = offset;
+    self->len = len;
+    self->items = items;
+}
+#endif
+
 #endif // MICROPY_INCLUDED_PY_OBJARRAY_H

--- a/tests/multi_bluetooth/ble_characteristic.py
+++ b/tests/multi_bluetooth/ble_characteristic.py
@@ -54,15 +54,15 @@ def irq(event, data):
             print("_IRQ_GATTC_CHARACTERISTIC_RESULT", data[-1])
             value_handle = data[2]
     elif event == _IRQ_GATTC_READ_RESULT:
-        print("_IRQ_GATTC_READ_RESULT", data[-1])
+        print("_IRQ_GATTC_READ_RESULT", bytes(data[-1]))
     elif event == _IRQ_GATTC_READ_DONE:
         print("_IRQ_GATTC_READ_DONE", data[-1])
     elif event == _IRQ_GATTC_WRITE_DONE:
         print("_IRQ_GATTC_WRITE_DONE", data[-1])
     elif event == _IRQ_GATTC_NOTIFY:
-        print("_IRQ_GATTC_NOTIFY", data[-1])
+        print("_IRQ_GATTC_NOTIFY", bytes(data[-1]))
     elif event == _IRQ_GATTC_INDICATE:
-        print("_IRQ_GATTC_INDICATE", data[-1])
+        print("_IRQ_GATTC_INDICATE", bytes(data[-1]))
     elif event == _IRQ_GATTS_INDICATE_DONE:
         print("_IRQ_GATTS_INDICATE_DONE", data[-1])
 

--- a/tests/multi_bluetooth/ble_gap_device_name.py
+++ b/tests/multi_bluetooth/ble_gap_device_name.py
@@ -36,7 +36,7 @@ def irq(event, data):
             print("_IRQ_GATTC_CHARACTERISTIC_RESULT", data[-1])
             value_handle = data[2]
     elif event == _IRQ_GATTC_READ_RESULT:
-        print("_IRQ_GATTC_READ_RESULT", data[-1])
+        print("_IRQ_GATTC_READ_RESULT", bytes(data[-1]))
 
     if waiting_event is not None:
         if isinstance(waiting_event, int) and event == waiting_event:

--- a/tests/multi_bluetooth/ble_gatt_data_transfer.py
+++ b/tests/multi_bluetooth/ble_gatt_data_transfer.py
@@ -67,7 +67,7 @@ def irq(event, data):
     elif event == _IRQ_GATTC_WRITE_DONE:
         print("_IRQ_GATTC_WRITE_DONE", data[-1])
     elif event == _IRQ_GATTC_NOTIFY:
-        print("_IRQ_GATTC_NOTIFY", data[-1])
+        print("_IRQ_GATTC_NOTIFY", bytes(data[-1]))
 
     if waiting_event is not None:
         if (isinstance(waiting_event, int) and event == waiting_event) or (


### PR DESCRIPTION
A read-only memoryview object is a better representation of the data, which is owned by the ubluetooth module and may change between calls to the user's irq callback function.

Note that some tests needed to be updated to work with this change, so it's a minor break of the public-facing API.  Eg a quick scan now looks like this:
```
>>> ble.irq(lambda *x:print(*x))
>>> ble.gap_scan(1000,100000,100000)
>>> 5 (1, <memoryview>, 0, -72, <memoryview>)
5 (1, <memoryview>, 0, -71, <memoryview>)
5 (1, <memoryview>, 0, -89, <memoryview>)
5 (1, <memoryview>, 0, -95, <memoryview>)
5 (0, <memoryview>, 3, -100, <memoryview>)
5 (1, <memoryview>, 0, -104, <memoryview>)
5 (1, <memoryview>, 0, -72, <memoryview>)
5 (1, <memoryview>, 0, -96, <memoryview>)
5 (1, <memoryview>, 0, -96, <memoryview>)
5 (0, <memoryview>, 0, -90, <memoryview>)
5 (1, <memoryview>, 0, -78, <memoryview>)
5 (1, <memoryview>, 0, -103, <memoryview>)
5 (1, <memoryview>, 0, -71, <memoryview>)
5 (1, <memoryview>, 3, -100, <memoryview>)
5 (0, <memoryview>, 3, -102, <memoryview>)
5 (1, <memoryview>, 0, -72, <memoryview>)
5 (1, <memoryview>, 3, -102, <memoryview>)
5 (1, <memoryview>, 3, -81, <memoryview>)
5 (0, <memoryview>, 3, -101, <memoryview>)
5 (1, <memoryview>, 3, -81, <memoryview>)
5 (1, <memoryview>, 0, -90, <memoryview>)
5 (1, <memoryview>, 3, -102, <memoryview>)
5 (1, <memoryview>, 0, -96, <memoryview>)
5 (1, <memoryview>, 0, -72, <memoryview>)
5 (1, <memoryview>, 3, -100, <memoryview>)
5 (1, <memoryview>, 0, -100, <memoryview>)
6 ()
```
@jimmo what do you think?