### PR TITLE
tests/run-tests: Use -BIS flags when running CPython.

### DIFF
--- a/tests/basics/containment.py
+++ b/tests/basics/containment.py
@@ -1,8 +1,8 @@
 # sets, see set_containment
 for i in 1, 2:
     for o in {1:2}, {1:2}.keys():
-        print("{} in {}: {}".format(i, o, i in o))
-        print("{} not in {}: {}".format(i, o, i not in o))
+        print("{} in {}: {}".format(i, str(o), i in o))
+        print("{} not in {}: {}".format(i, str(o), i not in o))
 
 haystack = "supercalifragilistc"
 for needle in [haystack[i:] for i in range(len(haystack))]:

--- a/tests/run-tests
+++ b/tests/run-tests
@@ -26,6 +26,10 @@ else:
     CPYTHON3 = os.getenv('MICROPY_CPYTHON3', 'python3')
     MICROPYTHON = os.getenv('MICROPY_MICROPYTHON', base_path('../ports/unix/micropython'))
 
+# Use CPython options to not save .pyc files, to only access the core standard library
+# (not site packages which may clash with u-module names), and improve start up time.
+CPYTHON3_CMD = [CPYTHON3, "-BS"]
+
 # mpy-cross is only needed if --via-mpy command-line arg is passed
 MPYCROSS = os.getenv('MICROPY_MPYCROSS', base_path('../mpy-cross/mpy-cross'))
 
@@ -319,7 +323,7 @@ def run_tests(pyb, tests, args, result_dir):
             upy_float_precision = int(upy_float_precision)
         has_complex = run_feature_check(pyb, args, base_path, 'complex.py') == b'complex\n'
         has_coverage = run_feature_check(pyb, args, base_path, 'coverage.py') == b'coverage\n'
-        cpy_byteorder = subprocess.check_output([CPYTHON3, base_path('feature_check/byteorder.py')])
+        cpy_byteorder = subprocess.check_output(CPYTHON3_CMD + [base_path('feature_check/byteorder.py')])
         skip_endian = (upy_byteorder != cpy_byteorder)
 
     # These tests don't test slice explicitly but rather use it to perform the test
@@ -498,7 +502,7 @@ def run_tests(pyb, tests, args, result_dir):
         else:
             # run CPython to work out expected output
             try:
-                output_expected = subprocess.check_output([CPYTHON3, '-B', test_file])
+                output_expected = subprocess.check_output(CPYTHON3_CMD + [test_file])
                 if args.write_exp:
                     with open(test_file_expected, 'wb') as f:
                         f.write(output_expected)


### PR DESCRIPTION
The use of -I and -S ensures that only the CPython standard library is accessible, which makes tests run the same regardless of any site-packages that are installed.  It also improves start-up time.

See issue #6474 