### PR TITLE
modify deepsleep to allow wakeup on X1 or X18 on a STM32F7 (SF2/3/6W)

### DIFF
--- a/ports/stm32/modmachine.c
+++ b/ports/stm32/modmachine.c
@@ -92,12 +92,6 @@
 #if defined(STM32F7)
 #define PYB_RESET_DEEPSLEEP_X1 (5)
 #define PYB_RESET_DEEPSLEEP_X18 (6)
-#define PYB_PWR_WKUP_X1     (PWR_CSR2_EWUP1)
-#define PYB_PWR_WKUP_X1_FALLING     (PWR_CSR2_EWUP1)
-#define PYB_PWR_WKUP_X1_RISING     (0)
-#define PYB_PWR_WKUP_X18    (PWR_CSR2_EWUP4)
-#define PYB_PWR_WKUP_X18_FALLING     (PWR_CSR2_EWUP4)
-#define PYB_PWR_WKUP_X18_RISING     (0)
 #endif
 
 STATIC uint32_t reset_cause;
@@ -115,11 +109,11 @@ void machine_init(void) {
         reset_cause = PYB_RESET_DEEPSLEEP;
         PWR->CR1 |= PWR_CR1_CSBF;
 	if (PWR->CSR2 & PWR_CSR2_WUPF1) {
-	  reset_cause = PYB_RESET_DEEPSLEEP_X1;
-	  PWR->CR2 |= PWR_CR2_CWUPF1;
+	    reset_cause = PYB_RESET_DEEPSLEEP_X1;
+	    PWR->CR2 |= PWR_CR2_CWUPF1;
 	} else if (PWR->CSR2 & PWR_CSR2_WUPF4) {
-	  reset_cause = PYB_RESET_DEEPSLEEP_X18;
-	  PWR->CR2 |= PWR_CR2_CWUPF4;
+	    reset_cause = PYB_RESET_DEEPSLEEP_X18;
+	    PWR->CR2 |= PWR_CR2_CWUPF4;
 	}
 
     } else
@@ -384,38 +378,15 @@ STATIC mp_obj_t machine_lightsleep(size_t n_args, const mp_obj_t *args) {
 MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(machine_lightsleep_obj, 0, 1, machine_lightsleep);
 
 STATIC mp_obj_t machine_deepsleep(size_t n_args, const mp_obj_t *args) {
-    // disable X1 and X18 flags
-#if defined(STM32F7)
-    PWR->CSR2 &= ~(PWR_CSR2_EWUP4 | PWR_CSR2_EWUP1);
-    PWR->CR2 &= ~(PWR_CR2_WUPP4 | PWR_CR2_WUPP1);
-#endif
     if (n_args != 0) {
-#if defined(STM32F7)
-      int ts_value = mp_obj_get_int(args[0]);
-      if (ts_value != 0) {
-#endif
         mp_obj_t args2[2] = {MP_OBJ_NULL, args[0]};
         pyb_rtc_wakeup(2, args2);
-#if defined(STM32F7)
-      }
-      if (n_args == 3) {
-	uint32_t pins = mp_obj_get_int(args[1]);
-	uint32_t falling = mp_obj_get_int(args[2]);
-	if ((pins | (PWR_CSR2_EWUP1 | PWR_CSR2_EWUP4)) != 0) {
-	  PWR->CSR2 |= pins;
-	  PWR->CR2 |= falling;
-	}
-      }
-#endif
     }
     powerctrl_enter_standby_mode();
     return mp_const_none;
 }
-#if defined(STM32F7)
-MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(machine_deepsleep_obj, 0, 3, machine_deepsleep);
-#else
+
 MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(machine_deepsleep_obj, 0, 1, machine_deepsleep);
-#endif
 
 STATIC mp_obj_t machine_reset_cause(void) {
     return MP_OBJ_NEW_SMALL_INT(reset_cause);
@@ -480,12 +451,6 @@ STATIC const mp_rom_map_elem_t machine_module_globals_table[] = {
     #if defined(STM32F7)
     { MP_ROM_QSTR(MP_QSTR_DEEPSLEEP_X1_RESET),     MP_ROM_INT(PYB_RESET_DEEPSLEEP_X1) },
     { MP_ROM_QSTR(MP_QSTR_DEEPSLEEP_X18_RESET),     MP_ROM_INT(PYB_RESET_DEEPSLEEP_X18) },
-    { MP_ROM_QSTR(MP_QSTR_WKUP_X1),          MP_ROM_INT(PYB_PWR_WKUP_X1) },
-    { MP_ROM_QSTR(MP_QSTR_WKUP_X1_FALLING),          MP_ROM_INT(PYB_PWR_WKUP_X1_FALLING) },
-    { MP_ROM_QSTR(MP_QSTR_WKUP_X1_RISING),          MP_ROM_INT(PYB_PWR_WKUP_X1_RISING) },
-    { MP_ROM_QSTR(MP_QSTR_WKUP_X18),          MP_ROM_INT(PYB_PWR_WKUP_X18) },
-    { MP_ROM_QSTR(MP_QSTR_WKUP_X18_FALLING),          MP_ROM_INT(PYB_PWR_WKUP_X18_FALLING) },
-    { MP_ROM_QSTR(MP_QSTR_WKUP_X18_RISING),          MP_ROM_INT(PYB_PWR_WKUP_X18_RISING) },
     #endif
     #if 0
     { MP_ROM_QSTR(MP_QSTR_WLAN_WAKE),           MP_ROM_INT(PYB_SLP_WAKED_BY_WLAN) },

--- a/ports/stm32/powerctrl.c
+++ b/ports/stm32/powerctrl.c
@@ -630,7 +630,7 @@ void powerctrl_enter_standby_mode(void) {
 
     #if defined(STM32F7)
     // disable wake-up flags
-    PWR->CSR2 &= ~(PWR_CSR2_EWUP6 | PWR_CSR2_EWUP5 | PWR_CSR2_EWUP4 | PWR_CSR2_EWUP3 | PWR_CSR2_EWUP2 | PWR_CSR2_EWUP1);
+    PWR->CSR2 &= ~(PWR_CSR2_EWUP6 | PWR_CSR2_EWUP5 | PWR_CSR2_EWUP3 | PWR_CSR2_EWUP2);
     // clear global wake-up flag
     PWR->CR2 |= PWR_CR2_CWUPF6 | PWR_CR2_CWUPF5 | PWR_CR2_CWUPF4 | PWR_CR2_CWUPF3 | PWR_CR2_CWUPF2 | PWR_CR2_CWUPF1;
     #elif defined(STM32H7)

--- a/ports/stm32/powerctrl.c
+++ b/ports/stm32/powerctrl.c
@@ -629,10 +629,14 @@ void powerctrl_enter_standby_mode(void) {
     RTC->ISR &= ~ISR_BITS;
 
     #if defined(STM32F7)
+        // Save user EWUP state
+    uint32_t csr2_ewup = PWR->CSR2 & (PWR_CSR2_EWUP6 | PWR_CSR2_EWUP5 | PWR_CSR2_EWUP4 | PWR_CSR2_EWUP3 | PWR_CSR2_EWUP2 | PWR_CSR2_EWUP1);
     // disable wake-up flags
-    PWR->CSR2 &= ~(PWR_CSR2_EWUP6 | PWR_CSR2_EWUP5 | PWR_CSR2_EWUP3 | PWR_CSR2_EWUP2);
+    PWR->CSR2 &= ~(PWR_CSR2_EWUP6 | PWR_CSR2_EWUP5 | PWR_CSR2_EWUP4 | PWR_CSR2_EWUP3 | PWR_CSR2_EWUP2 | PWR_CSR2_EWUP1);
     // clear global wake-up flag
     PWR->CR2 |= PWR_CR2_CWUPF6 | PWR_CR2_CWUPF5 | PWR_CR2_CWUPF4 | PWR_CR2_CWUPF3 | PWR_CR2_CWUPF2 | PWR_CR2_CWUPF1;
+    // Restore state
+    PWR->CSR2 |= csr2_ewup;
     #elif defined(STM32H7)
     // TODO
     #elif defined(STM32L4) || defined(STM32WB)


### PR DESCRIPTION
…F2/6W

example
machine.deepsleep([time_ms | 0 for infinity], [WKUP_PINS_X1/X18], [WKUP_PINS_X1/X18_RISING/FALLING])

machine.deepsleep()
machine.deepsleep(20000)
machine.deepsleep(10000, machine.WKUP_X1, machine.WKUP_X1_RISING)
machine.deepsleep(0, machine.WKUP_X1, machine.WKUP_X1_RISING)
machine.deepsleep(0, machine.WKUP_X1, machine.WKUP_X1_FALLING)

Prior to this commit only the timer wakeup would work for a deepsleep.
This was the case because for the STM32F7 all wakeup pins were cleared out before
entering in deepsleep

this commit is a work in progress for technical discussions.