### PR TITLE
py/gc.c: Allow "permanent" allocs, and use this for NimBLE.

### DIFF
--- a/extmod/nimble/modbluetooth_nimble.c
+++ b/extmod/nimble/modbluetooth_nimble.c
@@ -373,11 +373,6 @@ int mp_bluetooth_init(void) {
     MP_STATE_PORT(bluetooth_nimble_root_pointers) = m_new0(mp_bluetooth_nimble_root_pointers_t, 1);
     mp_bluetooth_gatts_db_create(&MP_STATE_PORT(bluetooth_nimble_root_pointers)->gatts_db);
 
-    #if !MICROPY_BLUETOOTH_NIMBLE_BINDINGS_ONLY
-    // Dereference any previous NimBLE mallocs.
-    MP_STATE_PORT(bluetooth_nimble_memory) = NULL;
-    #endif
-
     // Allow port (ESP32) to override NimBLE's HCI init.
     // Otherwise default implementation above calls ble_hci_uart_init().
     mp_bluetooth_nimble_port_hci_init();
@@ -438,11 +433,6 @@ void mp_bluetooth_deinit(void) {
     mp_bluetooth_nimble_port_hci_deinit();
 
     MP_STATE_PORT(bluetooth_nimble_root_pointers) = NULL;
-
-    #if !MICROPY_BLUETOOTH_NIMBLE_BINDINGS_ONLY
-    // Dereference any previous NimBLE mallocs.
-    MP_STATE_PORT(bluetooth_nimble_memory) = NULL;
-    #endif
 
     DEBUG_printf("mp_bluetooth_deinit: shut down\n");
 }

--- a/ports/stm32/main.c
+++ b/ports/stm32/main.c
@@ -548,6 +548,9 @@ void stm32_main(uint32_t reset_mode) {
     MP_STATE_PORT(pyb_uart_obj_all)[MICROPY_HW_UART_REPL - 1] = &pyb_uart_repl_obj;
     #endif
 
+    // GC init
+    gc_init(MICROPY_HEAP_START, MICROPY_HEAP_END);
+
 soft_reset:
 
     #if defined(MICROPY_HW_LED2)
@@ -575,9 +578,6 @@ soft_reset:
     // Note: stack control relies on main thread being initialised above
     mp_stack_set_top(&_estack);
     mp_stack_set_limit((char *)&_estack - (char *)&_sstack - 1024);
-
-    // GC init
-    gc_init(MICROPY_HEAP_START, MICROPY_HEAP_END);
 
     #if MICROPY_ENABLE_PYSTACK
     static mp_obj_t pystack[384];
@@ -770,6 +770,7 @@ soft_reset_exit:
     pyb_thread_deinit();
     #endif
 
+    // Frees all non-permanent allocations.
     gc_sweep_all();
 
     goto soft_reset;

--- a/ports/stm32/mpconfigport.h
+++ b/ports/stm32/mpconfigport.h
@@ -297,9 +297,9 @@ extern const struct _mp_obj_module_t mp_module_onewire;
 #endif
 
 #if MICROPY_BLUETOOTH_NIMBLE
+#define MICROPY_GC_PERMANENT_ALLOCS (1)
 struct _mp_bluetooth_nimble_root_pointers_t;
-struct _mp_bluetooth_nimble_malloc_t;
-#define MICROPY_PORT_ROOT_POINTER_BLUETOOTH_NIMBLE struct _mp_bluetooth_nimble_malloc_t *bluetooth_nimble_memory; struct _mp_bluetooth_nimble_root_pointers_t *bluetooth_nimble_root_pointers;
+#define MICROPY_PORT_ROOT_POINTER_BLUETOOTH_NIMBLE struct _mp_bluetooth_nimble_root_pointers_t *bluetooth_nimble_root_pointers;
 #else
 #define MICROPY_PORT_ROOT_POINTER_BLUETOOTH_NIMBLE
 #endif

--- a/ports/unix/mpconfigport.h
+++ b/ports/unix/mpconfigport.h
@@ -315,9 +315,9 @@ struct _mp_bluetooth_btstack_root_pointers_t;
 #define MICROPY_BLUETOOTH_ROOT_POINTERS struct _mp_bluetooth_btstack_root_pointers_t *bluetooth_btstack_root_pointers;
 #endif
 #if MICROPY_BLUETOOTH_NIMBLE
+#define MICROPY_GC_PERMANENT_ALLOCS (1)
 struct _mp_bluetooth_nimble_root_pointers_t;
-struct _mp_bluetooth_nimble_malloc_t;
-#define MICROPY_BLUETOOTH_ROOT_POINTERS struct _mp_bluetooth_nimble_malloc_t *bluetooth_nimble_memory; struct _mp_bluetooth_nimble_root_pointers_t *bluetooth_nimble_root_pointers;
+#define MICROPY_BLUETOOTH_ROOT_POINTERS struct _mp_bluetooth_nimble_root_pointers_t *bluetooth_nimble_root_pointers;
 #endif
 #else
 #define MICROPY_BLUETOOTH_ROOT_POINTERS

--- a/ports/unix/variants/coverage/mpconfigvariant.h
+++ b/ports/unix/variants/coverage/mpconfigvariant.h
@@ -30,6 +30,7 @@
 #define MICROPY_VFS                    (1)
 #define MICROPY_PY_UOS_VFS             (1)
 
+#define MICROPY_GC_PERMANENT_ALLOCS    (1)
 #define MICROPY_OPT_MATH_FACTORIAL     (1)
 #define MICROPY_FLOAT_HIGH_QUALITY_HASH (1)
 #define MICROPY_ENABLE_SCHEDULER       (1)

--- a/py/gc.h
+++ b/py/gc.h
@@ -48,6 +48,14 @@ void gc_collect_end(void);
 // Use this function to sweep the whole heap and run all finalisers
 void gc_sweep_all(void);
 
+#if MICROPY_GC_PERMANENT_ALLOCS
+// Mark an allocation as "permanent", which means that it will be treated
+// as marked even if not discoverable by the root pointer tree walk, including
+// from gc_sweep_all. For example, this allows it to survive a soft reset.
+// Note that these allocations are not recursively scanned for GC heap pointers.
+void gc_set_permanent(void *ptr, bool permanent);
+#endif
+
 enum {
     GC_ALLOC_FLAG_HAS_FINALISER = 1,
 };

--- a/py/mpconfig.h
+++ b/py/mpconfig.h
@@ -159,6 +159,14 @@
 #define MICROPY_GC_ALLOC_THRESHOLD (1)
 #endif
 
+// Allow GC heap allocations to be set as "always marked" using
+// gc_set_permanent, regardless of whether they can be found during the main
+// root pointer tree walk. Note that these allocations are not recursively
+// scanned for GC heap pointers.
+#ifndef MICROPY_GC_PERMANENT_ALLOCS
+#define MICROPY_GC_PERMANENT_ALLOCS (0)
+#endif
+
 // Number of bytes to allocate initially when creating new chunks to store
 // interned string data.  Smaller numbers lead to more chunks being needed
 // and more wastage at the end of the chunk.  Larger numbers lead to wasted

--- a/py/mpstate.h
+++ b/py/mpstate.h
@@ -102,6 +102,15 @@ typedef struct _mp_state_mem_t {
     // This is a global mutex used to make the GC thread-safe.
     mp_thread_mutex_t gc_mutex;
     #endif
+
+    #if MICROPY_GC_PERMANENT_ALLOCS
+    // List of block numbers that are "always marked" allocs.
+    MICROPY_GC_STACK_ENTRY_TYPE *gc_permanent;
+    // Current number of used entries in gc_permanent.
+    uint16_t gc_permanent_used;
+    // Current allocation size (in entries) of gc_permanent.
+    uint16_t gc_permanent_alloc;
+    #endif
 } mp_state_mem_t;
 
 // This structure hold runtime and VM information.  It includes a section

--- a/tests/unix/extra_coverage.py.exp
+++ b/tests/unix/extra_coverage.py.exp
@@ -17,6 +17,7 @@ abc
 # GC
 0
 0
+0 1 1 1
 # vstr
 tests
 sts


### PR DESCRIPTION
The intent is to allow for NimBLE (which must use malloc) to make heap allocations that survive across soft reset. This is a requirement because both stacks (especially btstack) expect to be only initialised once (they have global state in .bss that it doesn't clear on shutdown -- https://github.com/bluekitchen/btstack/issues/312), so the plan is to change the behaviour of `ble.active()` to startup the stack on first init, but then subsquently just move it in and out of low-power mode. Additionally, btstack currently uses static (.bss) but the intent is that this will allow us to make btstack use malloc also (which leaves more RAM free for heap if BLE is unused).

An alternative that was considered was to create a dedicated "non-GC" heap for things like NimBLE to use. Reserving a region would be both wasteful and limited, but any more sophisticated scheme that allows for "stealing" regions from the GC heap would get complicated.

This will also (I hope, with some ubluetooth API additions) make it possible to make "background" BLE services in Python (i.e. a BLE UART REPL that survive a soft reset).

The "permanent" allocations are deliberately not the same as root pointers -- i.e. they're not recursively searched. This feature is not meant to replace the current root pointer management (i.e. MICROPY_PORT_ROOT_POINTERS).