### PR TITLE
extmod/ure: Allow \\ in re.sub replacements.

### DIFF
--- a/extmod/modure.c
+++ b/extmod/modure.c
@@ -343,6 +343,9 @@ STATIC mp_obj_t re_sub_helper(size_t n_args, const mp_obj_t *args) {
                         const char *end_match = match->caps[match_no * 2 + 1];
                         vstr_add_strn(&vstr_return, start_match, end_match - start_match);
                     }
+                } else if (*repl == '\\') {
+                    // Add the \ character
+                    vstr_add_byte(&vstr_return, *repl++);
                 }
             } else {
                 // Just add the current byte from the replacement string

--- a/tests/extmod/ure_sub.py
+++ b/tests/extmod/ure_sub.py
@@ -69,3 +69,6 @@ try:
     re.sub(123, "a", "a")
 except TypeError:
     print("TypeError")
+
+# Include \ in the sub replacement
+print(re.sub("b", "\\\\b", "abc"))


### PR DESCRIPTION
I noticed this discrepancy with cpython when trying to port fnmatch to micropython; when using re.sub any `\\` in the replacements is completely ignored.

I was trying to make a replacement for re.escape which is not supported on micropython:
``` python
def re_escape(pattern):
return re.sub(r'([\^\$\.\|\?\*\+\(\)\[\\])', r'\\\1', pattern)
```
This should escape any regex special characters, however it currently acts as a no-op.

cpython:
```
>>> re.sub("b", "\\\\b", "abc")
'a\\bc'
```

micropython
```
>>> re.sub("b", "\\\\b", "abc")
'abc'
```

This PR adds handling for `\\` in re.sub including basic test case.