### PR TITLE
examples/bluetooth: Update to use positional-only args to irq().

### DIFF
--- a/examples/bluetooth/ble_simple_central.py
+++ b/examples/bluetooth/ble_simple_central.py
@@ -45,7 +45,7 @@ class BLESimpleCentral:
     def __init__(self, ble):
         self._ble = ble
         self._ble.active(True)
-        self._ble.irq(handler=self._irq)
+        self._ble.irq(self._irq)
 
         self._reset()
 

--- a/examples/bluetooth/ble_simple_peripheral.py
+++ b/examples/bluetooth/ble_simple_peripheral.py
@@ -31,7 +31,7 @@ class BLESimplePeripheral:
     def __init__(self, ble, name="mpy-uart"):
         self._ble = ble
         self._ble.active(True)
-        self._ble.irq(handler=self._irq)
+        self._ble.irq(self._irq)
         ((self._handle_tx, self._handle_rx),) = self._ble.gatts_register_services((_UART_SERVICE,))
         self._connections = set()
         self._write_callback = None

--- a/examples/bluetooth/ble_temperature.py
+++ b/examples/bluetooth/ble_temperature.py
@@ -35,7 +35,7 @@ class BLETemperature:
     def __init__(self, ble, name="mpy-temp"):
         self._ble = ble
         self._ble.active(True)
-        self._ble.irq(handler=self._irq)
+        self._ble.irq(self._irq)
         ((self._handle,),) = self._ble.gatts_register_services((_ENV_SENSE_SERVICE,))
         self._connections = set()
         self._payload = advertising_payload(

--- a/examples/bluetooth/ble_temperature_central.py
+++ b/examples/bluetooth/ble_temperature_central.py
@@ -56,7 +56,7 @@ class BLETemperatureCentral:
     def __init__(self, ble):
         self._ble = ble
         self._ble.active(True)
-        self._ble.irq(handler=self._irq)
+        self._ble.irq(self._irq)
 
         self._reset()
 

--- a/examples/bluetooth/ble_uart_peripheral.py
+++ b/examples/bluetooth/ble_uart_peripheral.py
@@ -31,7 +31,7 @@ class BLEUART:
     def __init__(self, ble, name="mpy-uart", rxbuf=100):
         self._ble = ble
         self._ble.active(True)
-        self._ble.irq(handler=self._irq)
+        self._ble.irq(self._irq)
         ((self._tx_handle, self._rx_handle),) = self._ble.gatts_register_services((_UART_SERVICE,))
         # Increase the size of the rx buffer and enable append mode.
         self._ble.gatts_set_buffer(self._rx_handle, rxbuf, True)


### PR DESCRIPTION
To match 6a6a5f9e151473bdcc1d14725d680691ff665a82. Docs were already updated.

Fixes #6489 - thanks @jp-96 sorry about the inconvenience!