### PR TITLE
py/parse: Expose rule-name printing as MICROPY_DEBUG_PARSE_RULE_NAME.

### DIFF
--- a/ports/unix/variants/coverage/mpconfigvariant.h
+++ b/ports/unix/variants/coverage/mpconfigvariant.h
@@ -30,6 +30,7 @@
 #define MICROPY_VFS                    (1)
 #define MICROPY_PY_UOS_VFS             (1)
 
+#define MICROPY_DEBUG_PARSE_RULE_NAME  (1)
 #define MICROPY_OPT_MATH_FACTORIAL     (1)
 #define MICROPY_FLOAT_HIGH_QUALITY_HASH (1)
 #define MICROPY_ENABLE_SCHEDULER       (1)

--- a/py/mpconfig.h
+++ b/py/mpconfig.h
@@ -454,6 +454,11 @@
 #define MICROPY_DEBUG_MP_OBJ_SENTINELS (0)
 #endif
 
+// Whether to print parse rule names (rather than integers) in mp_parse_node_print
+#ifndef MICROPY_DEBUG_PARSE_RULE_NAME
+#define MICROPY_DEBUG_PARSE_RULE_NAME (0)
+#endif
+
 // Whether to enable a simple VM stack overflow check
 #ifndef MICROPY_DEBUG_VM_STACK_OVERFLOW
 #define MICROPY_DEBUG_VM_STACK_OVERFLOW (0)

--- a/py/parse.c
+++ b/py/parse.c
@@ -55,9 +55,6 @@
 #define RULE_ARG_RULE           (0x2000)
 #define RULE_ARG_OPT_RULE       (0x3000)
 
-// (un)comment to use rule names; for debugging
-// #define USE_RULE_NAME (1)
-
 // *FORMAT-OFF*
 
 enum {
@@ -192,7 +189,7 @@ static const size_t FIRST_RULE_WITH_OFFSET_ABOVE_255 =
 #undef DEF_RULE_NC
 0;
 
-#if USE_RULE_NAME
+#if MICROPY_DEBUG_PARSE_RULE_NAME
 // Define an array of rule names corresponding to each rule
 STATIC const char *const rule_name_table[] = {
 #define DEF_RULE(rule, comp, kind, ...) #rule,
@@ -410,7 +407,7 @@ void mp_parse_node_print(const mp_print_t *print, mp_parse_node_t pn, size_t ind
             #endif
         } else {
             size_t n = MP_PARSE_NODE_STRUCT_NUM_NODES(pns);
-            #if USE_RULE_NAME
+            #if MICROPY_DEBUG_PARSE_RULE_NAME
             mp_printf(print, "%s(%u) (n=%u)\n", rule_name_table[MP_PARSE_NODE_STRUCT_KIND(pns)], (uint)MP_PARSE_NODE_STRUCT_KIND(pns), (uint)n);
             #else
             mp_printf(print, "rule(%u) (n=%u)\n", (uint)MP_PARSE_NODE_STRUCT_KIND(pns), (uint)n);

--- a/tests/cmdline/cmd_parsetree.py.exp
+++ b/tests/cmdline/cmd_parsetree.py.exp
@@ -1,31 +1,31 @@
 ----------------
-[   4] rule(1) (n=9)
+[   4] \(rule\|file_input_2\)(1) (n=9)
          tok(4)
-[   4]   rule(22) (n=4)
+[   4]   \(rule\|for_stmt\)(22) (n=4)
            id(i)
-[   4]     rule(45) (n=1)
+[   4]     \(rule\|atom_paren\)(45) (n=1)
              NULL
-[   5]     rule(8) (n=0)
+[   5]     \(rule\|pass_stmt\)(8) (n=0)
            NULL
-[   6]   rule(5) (n=2)
+[   6]   \(rule\|expr_stmt\)(5) (n=2)
            id(a)
            tok(14)
-[   7]   rule(5) (n=2)
+[   7]   \(rule\|expr_stmt\)(5) (n=2)
            id(b)
            str(str)
-[   8]   rule(5) (n=2)
+[   8]   \(rule\|expr_stmt\)(5) (n=2)
            id(c)
 [   8]     literal \.\+
-[   9]   rule(5) (n=2)
+[   9]   \(rule\|expr_stmt\)(5) (n=2)
            id(d)
            bytes(bytes)
-[  10]   rule(5) (n=2)
+[  10]   \(rule\|expr_stmt\)(5) (n=2)
            id(e)
 [  10]     literal \.\+
-[  11]   rule(5) (n=2)
+[  11]   \(rule\|expr_stmt\)(5) (n=2)
            id(f)
 [  11]     literal \.\+
-[  12]   rule(5) (n=2)
+[  12]   \(rule\|expr_stmt\)(5) (n=2)
            id(g)
            int(123)
 ----------------


### PR DESCRIPTION
So it can be configured by a port.  And enable it on unix coverage builds.