### PR TITLE
docs: Fix minor grammer error in docs/reference/glossary.rst.

### DIFF
--- a/docs/reference/glossary.rst
+++ b/docs/reference/glossary.rst
@@ -177,7 +177,7 @@ Glossary
         typically accessible on a host PC via USB.
 
     stream
-        Also known as a "file-like object". An Python object which provides
+        Also known as a "file-like object". A Python object which provides
         sequential read-write access to the underlying data. A stream object
         implements a corresponding interface, which consists of methods like
         ``read()``, ``write()``, ``readinto()``, ``seek()``, ``flush()``,


### PR DESCRIPTION
This is a minor fix to the docs/reference/glossary.rst file.