### PR TITLE
added support for port number in upip.py

### DIFF
--- a/tools/upip.py
+++ b/tools/upip.py
@@ -129,7 +129,11 @@ def url_open(url):
 
     proto, _, host, urlpath = url.split("/", 3)
     try:
-        ai = usocket.getaddrinfo(host, 443, 0, usocket.SOCK_STREAM)
+        port = 443
+        if ":" in host:
+            host, port = host.split(":")
+            port = int(port)
+        ai = usocket.getaddrinfo(host, port, 0, usocket.SOCK_STREAM)
     except OSError as e:
         fatal("Unable to resolve %s (no Internet?)" % host, e)
     # print("Address infos:", ai)
@@ -147,7 +151,7 @@ def url_open(url):
                 warn_ussl = False
 
         # MicroPython rawsocket module supports file interface directly
-        s.write("GET /%s HTTP/1.0\r\nHost: %s\r\n\r\n" % (urlpath, host))
+        s.write("GET /%s HTTP/1.0\r\nHost: %s:%s\r\n\r\n" % (urlpath, host, port))
         l = s.readline()
         protover, status, msg = l.split(None, 2)
         if status != b"200":


### PR DESCRIPTION
adding a port number other then 443 to a pypi url maybe needed if a local server like devpi is used.

This issue came up when I was trying to locally deploy a micropython package using [devpi-server](https://devpi.net/docs/devpi/devpi/stable/%2Bd/index.html). 

After great support of Florian Schulze (devpi maintainer), devpi delivers  now exactly the JSON data and the files so that it can be used to install micropython packages with upip.py. I tested it with the ports of ESP8266 and UNIX.

See also my question on stackoverflow here: https://stackoverflow.com/questions/63711923/devpi-how-to-get-root-package-json-served?noredirect=1#comment113512857_63711923

It would be nice if this few code lines can make it to the master branch of micropython.
