### PR TITLE
RFC: C++ build support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -165,7 +165,7 @@ jobs:
     - stage: test
       name: "unix coverage 32-bit build and tests"
       install:
-        - sudo apt-get install gcc-multilib libffi-dev:i386
+        - sudo apt-get install gcc-multilib g++-multilib libffi-dev:i386
         - sudo apt-get install python3-pip
         - sudo pip3 install setuptools
         - sudo pip3 install pyelftools

--- a/docs/develop/cmodules.rst
+++ b/docs/develop/cmodules.rst
@@ -8,7 +8,8 @@ limitations with the Python environment, often due to an inability to access
 certain hardware resources or Python speed limitations.
 
 If your limitations can't be resolved with suggestions in :ref:`speed_python`,
-writing some or all of your module in C is a viable option.
+writing some or all of your module in C (and/or C++ if implemented for your port)
+is a viable option.
 
 If your module is designed to access or work with commonly available
 hardware or libraries please consider implementing it inside the MicroPython
@@ -29,7 +30,7 @@ Structure of an external C module
 
 A MicroPython user C module is a directory with the following files:
 
-* ``*.c`` and/or ``*.h`` source code files for your module.
+* ``*.c`` and/or ``*.cpp`` and/or ``*.h`` source code files for your module.
 
   These will typically include the low level functionality being implemented and
   the MicroPython binding functions to expose the functions and module(s).
@@ -44,12 +45,12 @@ A MicroPython user C module is a directory with the following files:
   in your ``micropython.mk`` to a local make variable,
   eg ``EXAMPLE_MOD_DIR := $(USERMOD_DIR)``
 
-  Your ``micropython.mk`` must add your modules C files relative to your
+  Your ``micropython.mk`` must add your module's source files relative to your
   expanded copy of ``$(USERMOD_DIR)`` to ``SRC_USERMOD``, eg
   ``SRC_USERMOD += $(EXAMPLE_MOD_DIR)/example.c``
 
   If you have custom ``CFLAGS`` settings or include folders to define, these
-  should be added to ``CFLAGS_USERMOD``.
+  should be added to ``CFLAGS_USERMOD``, or ``CXXFLAGS_USERMOD``.
 
   See below for full usage example.
 

--- a/docs/develop/cmodules.rst
+++ b/docs/develop/cmodules.rst
@@ -30,7 +30,7 @@ Structure of an external C module
 
 A MicroPython user C module is a directory with the following files:
 
-* ``*.c`` and/or ``*.cpp`` and/or ``*.h`` source code files for your module.
+* ``*.c`` / ``*.cpp`` / ``*.h`` source code files for your module.
 
   These will typically include the low level functionality being implemented and
   the MicroPython binding functions to expose the functions and module(s).
@@ -45,12 +45,13 @@ A MicroPython user C module is a directory with the following files:
   in your ``micropython.mk`` to a local make variable,
   eg ``EXAMPLE_MOD_DIR := $(USERMOD_DIR)``
 
-  Your ``micropython.mk`` must add your module's source files relative to your
+  Your ``micropython.mk`` must add your modules source files relative to your
   expanded copy of ``$(USERMOD_DIR)`` to ``SRC_USERMOD``, eg
   ``SRC_USERMOD += $(EXAMPLE_MOD_DIR)/example.c``
 
-  If you have custom ``CFLAGS`` settings or include folders to define, these
-  should be added to ``CFLAGS_USERMOD``, or ``CXXFLAGS_USERMOD``.
+  If you have custom compiler options (like ``-I`` to add directories to search
+  for header files), these should be added to ``CFLAGS_USERMOD`` for C code
+  and to ``CXXFLAGS_USERMOD`` for C++ code.
 
   See below for full usage example.
 
@@ -58,124 +59,113 @@ A MicroPython user C module is a directory with the following files:
 Basic example
 -------------
 
-This simple module named ``example`` provides a single function
-``example.add_ints(a, b)`` which adds the two integer args together and returns
-the result.
+This simple module named ``cexample`` provides a single function
+``cexample.add_ints(a, b)`` which adds the two integer args together and returns
+the result. It can be found in the MicroPython source tree and has
+a source file and a Makefile fragment with content as descibed above::
 
-Directory::
+    micropython/
+    └──examples/
+       └──usercmodule/
+          └──cexample/
+             ├── examplemodule.c
+             └── micropython.mk
 
-    example/
-    ├── example.c
-    └── micropython.mk
-
-
-``example.c``
-
-.. code-block:: c
-
-    // Include required definitions first.
-    #include "py/obj.h"
-    #include "py/runtime.h"
-    #include "py/builtin.h"
-
-    // This is the function which will be called from Python as example.add_ints(a, b).
-    STATIC mp_obj_t example_add_ints(mp_obj_t a_obj, mp_obj_t b_obj) {
-        // Extract the ints from the micropython input objects
-        int a = mp_obj_get_int(a_obj);
-        int b = mp_obj_get_int(b_obj);
-
-        // Calculate the addition and convert to MicroPython object.
-        return mp_obj_new_int(a + b);
-    }
-    // Define a Python reference to the function above
-    STATIC MP_DEFINE_CONST_FUN_OBJ_2(example_add_ints_obj, example_add_ints);
-
-    // Define all properties of the example module.
-    // Table entries are key/value pairs of the attribute name (a string)
-    // and the MicroPython object reference.
-    // All identifiers and strings are written as MP_QSTR_xxx and will be
-    // optimized to word-sized integers by the build system (interned strings).
-    STATIC const mp_rom_map_elem_t example_module_globals_table[] = {
-        { MP_ROM_QSTR(MP_QSTR___name__), MP_ROM_QSTR(MP_QSTR_example) },
-        { MP_ROM_QSTR(MP_QSTR_add_ints), MP_ROM_PTR(&example_add_ints_obj) },
-    };
-    STATIC MP_DEFINE_CONST_DICT(example_module_globals, example_module_globals_table);
-
-    // Define module object.
-    const mp_obj_module_t example_user_cmodule = {
-        .base = { &mp_type_module },
-        .globals = (mp_obj_dict_t*)&example_module_globals,
-    };
-
-    // Register the module to make it available in Python
-    MP_REGISTER_MODULE(MP_QSTR_example, example_user_cmodule, MODULE_EXAMPLE_ENABLED);
-
-
-``micropython.mk``
-
-.. code-block:: make
-
-    EXAMPLE_MOD_DIR := $(USERMOD_DIR)
-
-    # Add all C files to SRC_USERMOD.
-    SRC_USERMOD += $(EXAMPLE_MOD_DIR)/example.c
-
-    # We can add our module folder to include paths if needed
-    # This is not actually needed in this example.
-    CFLAGS_USERMOD += -I$(EXAMPLE_MOD_DIR)
-
-Finally you will need to define ``MODULE_EXAMPLE_ENABLED`` to 1. This
-can be done by adding ``CFLAGS_EXTRA=-DMODULE_EXAMPLE_ENABLED=1`` to
-the ``make`` command, or editing ``mpconfigport.h`` or
-``mpconfigboard.h`` to add
-
-.. code-block:: c
-
-    #define MODULE_EXAMPLE_ENABLED (1)
-
-Note that the exact method depends on the port as they have different
-structures. If not done correctly it will compile but importing will
-fail to find the module.
+Refer to the comments in these 2 files for additional explanation.
+Next to the ``cexample`` module there's also ``cppexample`` which
+works in the same way but shows one way of mixing C and C++ code
+in MicroPython.
 
 
 Compiling the cmodule into MicroPython
 --------------------------------------
 
 To build such a module, compile MicroPython (see `getting started
-<https://github.com/micropython/micropython/wiki/Getting-Started>`_) with an
-extra ``make`` flag named ``USER_C_MODULES`` set to the directory containing
-all modules you want included (not to the module itself). For example:
+<https://github.com/micropython/micropython/wiki/Getting-Started>`_),
+applying 2 modifications:
+
+- an extra ``make`` flag named ``USER_C_MODULES`` set to the directory
+  containing all modules you want included (not to the module itself).
+  For building the example modules which come with MicroPython,
+  set ``USER_C_MODULES`` to the ``examples/usercmodule`` directory.
+  For your own projects it's more convenient to keep custom code out of
+  the main source tree so a typical project directory structure will look
+  like this::
+
+      my_project/
+      ├── modules/
+      │   └──example1/
+      │       ├──example1.c
+      │       └──micropython.mk
+      │   └──example2/
+      │       ├──example2.c
+      │       └──micropython.mk
+      └── micropython/
+          ├──ports/
+         ... ├──stm32/
+            ...
 
 
-Directory::
+  with ``USER_C_MODULES`` set to the ``my_project/modules`` directory.
 
-    my_project/
-    ├── modules/
-    │   └──example/
-    │       ├──example.c
-    │       └──micropython.mk
-    └── micropython/
-        ├──ports/
-       ... ├──stm32/
-          ...
+- all modules found in this directory will be compiled, but only those
+  which are explicitly enabled will be availabe for importing. Enabling a
+  module is done by setting the preprocessor define from its module
+  registration to 1. For example if the source code defines the module with
 
-Building for stm32 port:
+  .. code-block:: c
+
+      MP_REGISTER_MODULE(MP_QSTR_cexample, example_user_cmodule, MODULE_CEXAMPLE_ENABLED);
+
+
+  then ``MODULE_CEXAMPLE_ENABLED`` has to be set to 1 to make the module available.
+  This can be done by adding ``CFLAGS_EXTRA=-DMODULE_CEXAMPLE_ENABLED=1`` to
+  the ``make`` command, or editing ``mpconfigport.h`` or ``mpconfigboard.h``
+  to add
+
+  .. code-block:: c
+
+      #define MODULE_CEXAMPLE_ENABLED (1)
+
+
+  Note that the exact method depends on the port as they have different
+  structures. If not done correctly it will compile but importing will
+  fail to find the module.
+
+To sum up, here's how the ``cexample`` module from the ``examples/usercmodule``
+directory can be built for the unix port:
+
+.. code-block:: bash
+
+    cd micropython/ports/unix
+    make USER_C_MODULES=../../examples/usercmodule CFLAGS_EXTRA=-DMODULE_CEXAMPLE_ENABLED=1 all
+
+The build output will show the modules found::
+
+    ...
+    Including User C Module from ../../examples/usercmodule/cexample
+    Including User C Module from ../../examples/usercmodule/cppexample
+    ...
+
+
+Or for your own project with a directory structure as shown above,
+including both modules and building the stm32 port for example:
 
 .. code-block:: bash
 
     cd my_project/micropython/ports/stm32
-    make USER_C_MODULES=../../../modules CFLAGS_EXTRA=-DMODULE_EXAMPLE_ENABLED=1 all
+    make USER_C_MODULES=../../../modules \
+      CFLAGS_EXTRA="-DMODULE_EXAMPLE1_ENABLED=1 -DMODULE_EXAMPLE2_ENABLED=1" all
 
 
 Module usage in MicroPython
 ---------------------------
 
-Once built into your copy of MicroPython, the module implemented
-in ``example.c`` above can now be accessed in Python just
-like any other builtin module, eg
+Once built into your copy of MicroPython, the module
+can now be accessed in Python just like any other builtin module, e.g.
 
 .. code-block:: python
 
-    import example
-    print(example.add_ints(1, 3))
+    import cexample
+    print(cexample.add_ints(1, 3))
     # should display 4

--- a/docs/develop/qstr.rst
+++ b/docs/develop/qstr.rst
@@ -51,7 +51,7 @@ Processing happens in the following stages:
    through the C pre-processor.  This means that any conditionally disabled code
    will be removed, and macros expanded.  This means we don't add strings to the
    pool that won't be used in the final firmware.  Because at this stage (thanks
-   to the ``NO_QSTR`` macro added by ``QSTR_GEN_EXTRA_CFLAGS``) there is no
+   to the ``NO_QSTR`` macro added by ``QSTR_GEN_CFLAGS``) there is no
    definition for ``MP_QSTR_Foo`` it passes through this stage unaffected.  This
    file also includes comments from the preprocessor that include line number
    information.  Note that this step only uses files that have changed, which

--- a/examples/usercmodule/cexample/examplemodule.c
+++ b/examples/usercmodule/cexample/examplemodule.c
@@ -1,0 +1,34 @@
+// Include MicroPython API.
+#include "py/runtime.h"
+
+// This is the function which will be called from Python as cexample.add_ints(a, b).
+STATIC mp_obj_t example_add_ints(mp_obj_t a_obj, mp_obj_t b_obj) {
+    // Extract the ints from the micropython input objects.
+    int a = mp_obj_get_int(a_obj);
+    int b = mp_obj_get_int(b_obj);
+
+    // Calculate the addition and convert to MicroPython object.
+    return mp_obj_new_int(a + b);
+}
+// Define a Python reference to the function above.
+STATIC MP_DEFINE_CONST_FUN_OBJ_2(example_add_ints_obj, example_add_ints);
+
+// Define all properties of the module.
+// Table entries are key/value pairs of the attribute name (a string)
+// and the MicroPython object reference.
+// All identifiers and strings are written as MP_QSTR_xxx and will be
+// optimized to word-sized integers by the build system (interned strings).
+STATIC const mp_rom_map_elem_t example_module_globals_table[] = {
+    { MP_ROM_QSTR(MP_QSTR___name__), MP_ROM_QSTR(MP_QSTR_cexample) },
+    { MP_ROM_QSTR(MP_QSTR_add_ints), MP_ROM_PTR(&example_add_ints_obj) },
+};
+STATIC MP_DEFINE_CONST_DICT(example_module_globals, example_module_globals_table);
+
+// Define module object.
+const mp_obj_module_t example_user_cmodule = {
+    .base = { &mp_type_module },
+    .globals = (mp_obj_dict_t *)&example_module_globals,
+};
+
+// Register the module to make it available in Python.
+MP_REGISTER_MODULE(MP_QSTR_cexample, example_user_cmodule, MODULE_CEXAMPLE_ENABLED);

--- a/examples/usercmodule/cexample/micropython.mk
+++ b/examples/usercmodule/cexample/micropython.mk
@@ -1,0 +1,9 @@
+EXAMPLE_MOD_DIR := $(USERMOD_DIR)
+
+# Add all C files to SRC_USERMOD.
+SRC_USERMOD += $(EXAMPLE_MOD_DIR)/examplemodule.c
+
+# We can add our module folder to include paths if needed
+# This is not actually needed in this example.
+CFLAGS_USERMOD += -I$(EXAMPLE_MOD_DIR)
+CEXAMPLE_MOD_DIR := $(USERMOD_DIR)

--- a/examples/usercmodule/cppexample/example.cpp
+++ b/examples/usercmodule/cppexample/example.cpp
@@ -1,0 +1,17 @@
+extern "C" {
+#include <examplemodule.h>
+
+// Here we implement the function using C++ code, but since it's
+// declaration has to be compatible with C everything goes in extern "C" scope.
+mp_obj_t cppfunc(mp_obj_t a_obj, mp_obj_t b_obj) {
+    // Prove we have (at least) C++11 features.
+    const auto a = mp_obj_get_int(a_obj);
+    const auto b = mp_obj_get_int(b_obj);
+    const auto sum = [&]() {
+        return mp_obj_new_int(a + b);
+    } ();
+    // Prove we're being scanned for QSTRs.
+    mp_obj_t tup[] = {sum, MP_ROM_QSTR(MP_QSTR_hellocpp)};
+    return mp_obj_new_tuple(2, tup);
+}
+}

--- a/examples/usercmodule/cppexample/examplemodule.c
+++ b/examples/usercmodule/cppexample/examplemodule.c
@@ -1,0 +1,25 @@
+#include <examplemodule.h>
+
+// Define a Python reference to the function we'll make available.
+// See example.cpp for the definition.
+STATIC MP_DEFINE_CONST_FUN_OBJ_2(cppfunc_obj, cppfunc);
+
+// Define all properties of the module.
+// Table entries are key/value pairs of the attribute name (a string)
+// and the MicroPython object reference.
+// All identifiers and strings are written as MP_QSTR_xxx and will be
+// optimized to word-sized integers by the build system (interned strings).
+STATIC const mp_rom_map_elem_t cppexample_module_globals_table[] = {
+    { MP_ROM_QSTR(MP_QSTR___name__), MP_ROM_QSTR(MP_QSTR_cppexample) },
+    { MP_ROM_QSTR(MP_QSTR_cppfunc), MP_ROM_PTR(&cppfunc_obj) },
+};
+STATIC MP_DEFINE_CONST_DICT(cppexample_module_globals, cppexample_module_globals_table);
+
+// Define module object.
+const mp_obj_module_t cppexample_user_cmodule = {
+    .base = { &mp_type_module },
+    .globals = (mp_obj_dict_t *)&cppexample_module_globals,
+};
+
+// Register the module to make it available in Python.
+MP_REGISTER_MODULE(MP_QSTR_cppexample, cppexample_user_cmodule, MODULE_CPPEXAMPLE_ENABLED);

--- a/examples/usercmodule/cppexample/examplemodule.h
+++ b/examples/usercmodule/cppexample/examplemodule.h
@@ -1,0 +1,5 @@
+// Include MicroPython API.
+#include "py/runtime.h"
+
+// Declare the function we'll make available in Python as cppexample.cppfunc().
+extern mp_obj_t cppfunc(mp_obj_t a_obj, mp_obj_t b_obj);

--- a/examples/usercmodule/cppexample/micropython.mk
+++ b/examples/usercmodule/cppexample/micropython.mk
@@ -1,0 +1,12 @@
+CPPEXAMPLE_MOD_DIR := $(USERMOD_DIR)
+
+# Add our source files to the respective variables.
+SRC_USERMOD += $(CPPEXAMPLE_MOD_DIR)/examplemodule.c
+SRC_USERMOD_CXX += $(CPPEXAMPLE_MOD_DIR)/example.cpp
+
+# Add our module directory to the include path.
+CFLAGS_USERMOD += -I$(CPPEXAMPLE_MOD_DIR)
+CXXFLAGS_USERMOD += -I$(CPPEXAMPLE_MOD_DIR)
+
+# We use C++ features so have to link against the standard library.
+LDFLAGS_USERMOD += -lstdc++

--- a/ports/esp32/Makefile
+++ b/ports/esp32/Makefile
@@ -268,7 +268,7 @@ CFLAGS += -DMICROPY_ESP_IDF_4=1
 endif
 
 # this is what ESPIDF uses for c++ compilation
-CXXFLAGS = -std=gnu++11 $(CFLAGS_COMMON) $(INC) $(INC_ESPCOMP)
+CXXFLAGS = -std=gnu++11 $(CFLAGS_COMMON) $(INC) $(INC_ESPCOMP) $(CXXFLAGS_MOD)
 
 LDFLAGS = -nostdlib -Map=$(@:.elf=.map) --cref
 LDFLAGS += --gc-sections -static -EL
@@ -354,6 +354,9 @@ SRC_C = \
 	$(wildcard $(BOARD_DIR)/*.c) \
 	$(SRC_MOD)
 
+SRC_CXX += \
+	$(SRC_MOD_CXX)
+
 EXTMOD_SRC_C += $(addprefix extmod/,\
 	modonewire.c \
 	)
@@ -376,6 +379,7 @@ DRIVERS_SRC_C = $(addprefix drivers/,\
 OBJ_MP =
 OBJ_MP += $(PY_O)
 OBJ_MP += $(addprefix $(BUILD)/, $(SRC_C:.c=.o))
+OBJ_MP += $(addprefix $(BUILD)/, $(SRC_CXX:.cpp=.o))
 OBJ_MP += $(addprefix $(BUILD)/, $(EXTMOD_SRC_C:.c=.o))
 OBJ_MP += $(addprefix $(BUILD)/, $(LIB_SRC_C:.c=.o))
 OBJ_MP += $(addprefix $(BUILD)/, $(DRIVERS_SRC_C:.c=.o))
@@ -384,7 +388,7 @@ OBJ_MP += $(addprefix $(BUILD)/, $(DRIVERS_SRC_C:.c=.o))
 $(OBJ_MP): CFLAGS += -Wdouble-promotion -Wfloat-conversion
 
 # List of sources for qstr extraction
-SRC_QSTR += $(SRC_C) $(EXTMOD_SRC_C) $(LIB_SRC_C) $(DRIVERS_SRC_C)
+SRC_QSTR += $(SRC_C) $(SRC_CXX) $(EXTMOD_SRC_C) $(LIB_SRC_C) $(DRIVERS_SRC_C)
 # Append any auto-generated sources that are needed by sources listed in SRC_QSTR
 SRC_QSTR_AUTO_DEPS +=
 

--- a/ports/esp32/Makefile
+++ b/ports/esp32/Makefile
@@ -781,22 +781,6 @@ $(BUILD)/application.elf: $(OBJ) $(LIB) $(BUILD)/esp32_out.ld $(BUILD)/esp32.pro
 	$(Q)$(LD) $(LDFLAGS) -o $@ $(APP_LD_ARGS)
 	$(Q)$(SIZE) $@
 
-define compile_cxx
-$(ECHO) "CXX $<"
-$(Q)$(CXX) $(CXXFLAGS) -c -MD -o $@ $<
-@# The following fixes the dependency file.
-@# See http://make.paulandlesley.org/autodep.html for details.
-@# Regex adjusted from the above to play better with Windows paths, etc.
-@$(CP) $(@:.o=.d) $(@:.o=.P); \
-  $(SED) -e 's/#.*//' -e 's/^.*:  *//' -e 's/ *\\$$//' \
-      -e '/^$$/ d' -e 's/$$/ :/' < $(@:.o=.d) >> $(@:.o=.P); \
-  $(RM) -f $(@:.o=.d)
-endef
-
-vpath %.cpp . $(TOP)
-$(BUILD)/%.o: %.cpp
-	$(call compile_cxx)
-
 ################################################################################
 # Declarations to build the bootloader
 

--- a/ports/unix/Makefile
+++ b/ports/unix/Makefile
@@ -248,13 +248,18 @@ LIB_SRC_C += $(addprefix lib/,\
 	utils/gchelper_generic.c \
 	)
 
+SRC_CXX += \
+	coveragecpp.cpp \
+	$(SRC_MOD_CXX)
+
 OBJ = $(PY_O)
 OBJ += $(addprefix $(BUILD)/, $(SRC_C:.c=.o))
+OBJ += $(addprefix $(BUILD)/, $(SRC_CXX:.cpp=.o))
 OBJ += $(addprefix $(BUILD)/, $(LIB_SRC_C:.c=.o))
 OBJ += $(addprefix $(BUILD)/, $(EXTMOD_SRC_C:.c=.o))
 
 # List of sources for qstr extraction
-SRC_QSTR += $(SRC_C) $(LIB_SRC_C) $(EXTMOD_SRC_C)
+SRC_QSTR += $(SRC_C) $(SRC_CXX) $(LIB_SRC_C) $(EXTMOD_SRC_C)
 # Append any auto-generated sources that are needed by sources listed in
 # SRC_QSTR
 SRC_QSTR_AUTO_DEPS +=
@@ -271,6 +276,14 @@ endif
 ifneq ($(FROZEN_MANIFEST)$(FROZEN_DIR),)
 CFLAGS += -DMICROPY_MODULE_FROZEN_STR
 endif
+
+HASCPP17 = $(shell expr `$(CC) -dumpversion | cut -f1 -d.` \>= 7)
+ifeq ($(HASCPP17), 1)
+	CXXFLAGS += -std=c++17
+else
+	CXXFLAGS += -std=c++11
+endif
+CXXFLAGS += $(filter-out -Wmissing-prototypes -Wold-style-definition -std=gnu99,$(CFLAGS) $(CXXFLAGS_MOD))
 
 ifeq ($(MICROPY_FORCE_32BIT),1)
 RUN_TESTS_MPY_CROSS_FLAGS = --mpy-cross-flags='-mcache-lookup-bc -march=x86'

--- a/ports/unix/coveragecpp.cpp
+++ b/ports/unix/coveragecpp.cpp
@@ -1,0 +1,23 @@
+extern "C" {
+#include "py/obj.h"
+}
+
+#if defined(MICROPY_UNIX_COVERAGE)
+
+// Just to test building of C++ code.
+STATIC mp_obj_t extra_cpp_coverage_impl() {
+    return mp_const_none;
+}
+
+extern "C" {
+mp_obj_t extra_cpp_coverage(void);
+mp_obj_t extra_cpp_coverage(void) {
+    return extra_cpp_coverage_impl();
+}
+
+// This is extern to avoid name mangling.
+extern const mp_obj_fun_builtin_fixed_t extra_cpp_coverage_obj = {{&mp_type_fun_builtin_0}, {extra_cpp_coverage}};
+
+}
+
+#endif

--- a/ports/unix/main.c
+++ b/ports/unix/main.c
@@ -531,7 +531,9 @@ MP_NOINLINE int main_(int argc, char **argv) {
     #if defined(MICROPY_UNIX_COVERAGE)
     {
         MP_DECLARE_CONST_FUN_OBJ_0(extra_coverage_obj);
+        MP_DECLARE_CONST_FUN_OBJ_0(extra_cpp_coverage_obj);
         mp_store_global(QSTR_FROM_STR_STATIC("extra_coverage"), MP_OBJ_FROM_PTR(&extra_coverage_obj));
+        mp_store_global(QSTR_FROM_STR_STATIC("extra_cpp_coverage"), MP_OBJ_FROM_PTR(&extra_cpp_coverage_obj));
     }
     #endif
 

--- a/ports/unix/variants/coverage/mpconfigvariant.mk
+++ b/ports/unix/variants/coverage/mpconfigvariant.mk
@@ -7,11 +7,13 @@ CFLAGS += \
 	-fprofile-arcs -ftest-coverage \
 	-Wformat -Wmissing-declarations -Wmissing-prototypes \
 	-Wold-style-definition -Wpointer-arith -Wshadow -Wuninitialized -Wunused-parameter \
-	-DMICROPY_UNIX_COVERAGE
+	-DMICROPY_UNIX_COVERAGE \
+	-DMODULE_CEXAMPLE_ENABLED=1 -DMODULE_CPPEXAMPLE_ENABLED=1
 
 LDFLAGS += -fprofile-arcs -ftest-coverage
 
 FROZEN_MANIFEST ?= $(VARIANT_DIR)/manifest.py
+USER_C_MODULES = $(TOP)/examples/usercmodule
 
 MICROPY_ROM_TEXT_COMPRESSION = 1
 MICROPY_VFS_FAT = 1

--- a/py/makeqstrdefs.py
+++ b/py/makeqstrdefs.py
@@ -44,7 +44,7 @@ def process_file(f):
             m = re_line.match(line)
             assert m is not None
             fname = m.group(1)
-            if not fname.endswith(".c"):
+            if os.path.splitext(fname)[1] not in [".c", ".cpp"]:
                 continue
             if fname != last_fname:
                 write_out(last_fname, output)

--- a/py/makeqstrdefs.py
+++ b/py/makeqstrdefs.py
@@ -58,7 +58,8 @@ def process_file(f):
             elif args.mode == _MODE_COMPRESS:
                 output.append(match)
 
-    write_out(last_fname, output)
+    if last_fname:
+        write_out(last_fname, output)
     return ""
 
 

--- a/py/makeqstrdefs.py
+++ b/py/makeqstrdefs.py
@@ -8,6 +8,7 @@ This script works with Python 2.6, 2.7, 3.3 and 3.4.
 from __future__ import print_function
 
 import re
+import subprocess
 import sys
 import io
 import os
@@ -18,6 +19,31 @@ _MODE_QSTR = "qstr"
 
 # Extract MP_COMPRESSED_ROM_TEXT("") macros.  (Which come from MP_ERROR_TEXT)
 _MODE_COMPRESS = "compress"
+
+
+def preprocess():
+    if any(src in args.dependencies for src in args.changed_sources):
+        sources = args.sources
+    elif any(args.changed_sources):
+        sources = args.changed_sources
+    else:
+        sources = args.sources
+    csources = []
+    cxxsources = []
+    for source in sources:
+        if source.endswith(".cpp"):
+            cxxsources.append(source)
+        else:
+            csources.append(source)
+    try:
+        os.makedirs(os.path.dirname(args.output[0]))
+    except OSError:
+        pass
+    with open(args.output[0], "w") as out_file:
+        if csources:
+            subprocess.check_call(args.pp + args.cflags + csources, stdout=out_file)
+        if cxxsources:
+            subprocess.check_call(args.pp + args.cxxflags + cxxsources, stdout=out_file)
 
 
 def write_out(fname, output):
@@ -105,7 +131,7 @@ def cat_together():
 
 
 if __name__ == "__main__":
-    if len(sys.argv) != 6:
+    if len(sys.argv) < 6:
         print("usage: %s command mode input_filename output_dir output_file" % sys.argv[0])
         sys.exit(2)
 
@@ -114,6 +140,37 @@ if __name__ == "__main__":
 
     args = Args()
     args.command = sys.argv[1]
+
+    if args.command == "pp":
+        named_args = {
+            s: []
+            for s in [
+                "pp",
+                "output",
+                "cflags",
+                "cxxflags",
+                "sources",
+                "changed_sources",
+                "dependencies",
+            ]
+        }
+
+        for arg in sys.argv[1:]:
+            if arg in named_args:
+                current_tok = arg
+            else:
+                named_args[current_tok].append(arg)
+
+        if not named_args["pp"] or len(named_args["output"]) != 1:
+            print("usage: %s %s ..." % (sys.argv[0], " ... ".join(named_args)))
+            sys.exit(2)
+
+        for k, v in named_args.items():
+            setattr(args, k, v)
+
+        preprocess()
+        sys.exit(0)
+
     args.mode = sys.argv[2]
     args.input_filename = sys.argv[3]  # Unused for command=cat
     args.output_dir = sys.argv[4]

--- a/py/misc.h
+++ b/py/misc.h
@@ -272,7 +272,12 @@ typedef union _mp_float_union_t {
 // Map MP_COMPRESSED_ROM_TEXT to the compressed strings.
 
 // Force usage of the MP_ERROR_TEXT macro by requiring an opaque type.
-typedef struct {} *mp_rom_error_text_t;
+typedef struct {
+    #ifdef __clang__
+    // Fix "error: empty struct has size 0 in C, size 1 in C++".
+    char dummy;
+    #endif
+} *mp_rom_error_text_t;
 
 #include <string.h>
 

--- a/py/mkrules.mk
+++ b/py/mkrules.mk
@@ -15,10 +15,12 @@ CFLAGS += -DMICROPY_ROM_TEXT_COMPRESSION=1
 endif
 
 # QSTR generation uses the same CFLAGS, with these modifications.
+QSTR_GEN_FLAGS = -DNO_QSTR -I$(BUILD)/tmp
 # Note: := to force evalulation immediately.
 QSTR_GEN_CFLAGS := $(CFLAGS)
-QSTR_GEN_CFLAGS += -DNO_QSTR
-QSTR_GEN_CFLAGS += -I$(BUILD)/tmp
+QSTR_GEN_CFLAGS += $(QSTR_GEN_FLAGS)
+QSTR_GEN_CXXFLAGS := $(CXXFLAGS)
+QSTR_GEN_CXXFLAGS += $(QSTR_GEN_FLAGS)
 
 # This file expects that OBJ contains a list of all of the object files.
 # The directory portion of each object file is used to locate the source
@@ -95,14 +97,14 @@ $(BUILD)/%.pp: %.c
 # to get built before we try to compile any of them.
 $(OBJ): | $(HEADER_BUILD)/qstrdefs.generated.h $(HEADER_BUILD)/mpversion.h $(OBJ_EXTRA_ORDER_DEPS)
 
-# The logic for qstr regeneration is:
+# The logic for qstr regeneration (applied by makeqstrdefs.py) is:
 # - if anything in QSTR_GLOBAL_DEPENDENCIES is newer, then process all source files ($^)
 # - else, if list of newer prerequisites ($?) is not empty, then process just these ($?)
 # - else, process all source files ($^) [this covers "make -B" which can set $? to empty]
 # See more information about this process in docs/develop/qstr.rst.
 $(HEADER_BUILD)/qstr.i.last: $(SRC_QSTR) $(QSTR_GLOBAL_DEPENDENCIES) | $(QSTR_GLOBAL_REQUIREMENTS)
 	$(ECHO) "GEN $@"
-	$(Q)$(CPP) $(QSTR_GEN_CFLAGS) $(if $(filter $?,$(QSTR_GLOBAL_DEPENDENCIES)),$^,$(if $?,$?,$^)) >$(HEADER_BUILD)/qstr.i.last
+	$(Q)$(PYTHON) $(PY_SRC)/makeqstrdefs.py pp $(CPP) output $(HEADER_BUILD)/qstr.i.last cflags $(QSTR_GEN_CFLAGS) cxxflags $(QSTR_GEN_CXXFLAGS) sources $^ dependencies $(QSTR_GLOBAL_DEPENDENCIES) changed_sources $?
 
 $(HEADER_BUILD)/qstr.split: $(HEADER_BUILD)/qstr.i.last
 	$(ECHO) "GEN $@"

--- a/py/mkrules.mk
+++ b/py/mkrules.mk
@@ -58,11 +58,27 @@ $(Q)$(CC) $(CFLAGS) -c -MD -o $@ $<
   $(RM) -f $(@:.o=.d)
 endef
 
+define compile_cxx
+$(ECHO) "CXX $<"
+$(Q)$(CXX) $(CXXFLAGS) -c -MD -o $@ $<
+@# The following fixes the dependency file.
+@# See http://make.paulandlesley.org/autodep.html for details.
+@# Regex adjusted from the above to play better with Windows paths, etc.
+@$(CP) $(@:.o=.d) $(@:.o=.P); \
+  $(SED) -e 's/#.*//' -e 's/^.*:  *//' -e 's/ *\\$$//' \
+      -e '/^$$/ d' -e 's/$$/ :/' < $(@:.o=.d) >> $(@:.o=.P); \
+  $(RM) -f $(@:.o=.d)
+endef
+
 vpath %.c . $(TOP) $(USER_C_MODULES)
 $(BUILD)/%.o: %.c
 	$(call compile_c)
 
 vpath %.c . $(TOP) $(USER_C_MODULES)
+
+vpath %.cpp . $(TOP) $(USER_C_MODULES)
+$(BUILD)/%.o: %.cpp
+	$(call compile_cxx)
 
 $(BUILD)/%.pp: %.c
 	$(ECHO) "PreProcess $<"

--- a/py/py.mk
+++ b/py/py.mk
@@ -33,7 +33,9 @@ ifneq ($(USER_C_MODULES),)
 # pre-define USERMOD variables as expanded so that variables are immediate
 # expanded as they're added to them
 SRC_USERMOD :=
+SRC_USERMOD_CXX :=
 CFLAGS_USERMOD :=
+CXXFLAGS_USERMOD :=
 LDFLAGS_USERMOD :=
 $(foreach module, $(wildcard $(USER_C_MODULES)/*/micropython.mk), \
     $(eval USERMOD_DIR = $(patsubst %/,%,$(dir $(module))))\
@@ -42,7 +44,9 @@ $(foreach module, $(wildcard $(USER_C_MODULES)/*/micropython.mk), \
 )
 
 SRC_MOD += $(patsubst $(USER_C_MODULES)/%.c,%.c,$(SRC_USERMOD))
+SRC_MOD_CXX += $(patsubst $(USER_C_MODULES)/%.cpp,%.cpp,$(SRC_USERMOD_CXX))
 CFLAGS_MOD += $(CFLAGS_USERMOD)
+CXXFLAGS_MOD += $(CXXFLAGS_USERMOD)
 LDFLAGS_MOD += $(LDFLAGS_USERMOD)
 endif
 

--- a/tests/unix/extra_coverage.py
+++ b/tests/unix/extra_coverage.py
@@ -46,6 +46,9 @@ stream.set_error(uerrno.EAGAIN)
 buf = uio.BufferedWriter(stream, 8)
 print(buf.write(bytearray(16)))
 
+# function defined in C++ code
+print("cpp", extra_cpp_coverage())
+
 # test basic import of frozen scripts
 import frzstr1
 

--- a/tests/unix/extra_coverage.py
+++ b/tests/unix/extra_coverage.py
@@ -49,6 +49,16 @@ print(buf.write(bytearray(16)))
 # function defined in C++ code
 print("cpp", extra_cpp_coverage())
 
+# test user C module
+import cexample
+
+print(cexample.add_ints(3, 2))
+
+# test user C module mixed with C++ code
+import cppexample
+
+print(cppexample.cppfunc(1, 2))
+
 # test basic import of frozen scripts
 import frzstr1
 

--- a/tests/unix/extra_coverage.py.exp
+++ b/tests/unix/extra_coverage.py.exp
@@ -144,6 +144,7 @@ OSError
 0
 None
 None
+cpp None
 frzstr1
 frzstr1.py
 frzmpy1

--- a/tests/unix/extra_coverage.py.exp
+++ b/tests/unix/extra_coverage.py.exp
@@ -145,6 +145,8 @@ OSError
 None
 None
 cpp None
+5
+(3, 'hellocpp')
 frzstr1
 frzstr1.py
 frzmpy1


### PR DESCRIPTION
These are a number of commits which gradually enable external makefiles (be it user C modules or something else) to have C++ code built into the output just like it's done for C code i.e. add files to SRC_QSTR/SRC_CPP/SRC_MOD_CPP/SRC_USERMOD_CPP which then gets scanned for QSTR and built with CXXFLAGS. Enabled (and tested) on unix and esp32 ports, the former so I can easily run tests, the latter in response to e.g. #6233.
I tried to keep changes minimal and in line with how things are done for the C code. Not too happy with how qstr.i.last is created but since my Makefile skills go no further then copy-paste/adjusting of fragments it's the best I could come up with which works in all cases I tried. Could be easier to e.g. modify makeqstrdefs so it can take multiple files so both PP steps can happen separately, not sure.
Even if not all of it is ok now, would be great to at least have some of the commits merged.