### PR TITLE
Add Pin.pin() to ESP32 port to address #6538

### DIFF
--- a/ports/esp32/machine_pin.c
+++ b/ports/esp32/machine_pin.c
@@ -260,6 +260,13 @@ STATIC mp_obj_t machine_pin_on(mp_obj_t self_in) {
 }
 STATIC MP_DEFINE_CONST_FUN_OBJ_1(machine_pin_on_obj, machine_pin_on);
 
+// pin.pin()
+STATIC mp_obj_t machine_pin_pin(mp_obj_t self_in) {
+    machine_pin_obj_t *self = MP_OBJ_TO_PTR(self_in);
+    return MP_OBJ_NEW_SMALL_INT(self->id);
+}
+STATIC MP_DEFINE_CONST_FUN_OBJ_1(machine_pin_pin_obj, machine_pin_pin);
+
 // pin.irq(handler=None, trigger=IRQ_FALLING|IRQ_RISING)
 STATIC mp_obj_t machine_pin_irq(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
     enum { ARG_handler, ARG_trigger, ARG_wake };
@@ -332,6 +339,8 @@ STATIC const mp_rom_map_elem_t machine_pin_locals_dict_table[] = {
     { MP_ROM_QSTR(MP_QSTR_off), MP_ROM_PTR(&machine_pin_off_obj) },
     { MP_ROM_QSTR(MP_QSTR_on), MP_ROM_PTR(&machine_pin_on_obj) },
     { MP_ROM_QSTR(MP_QSTR_irq), MP_ROM_PTR(&machine_pin_irq_obj) },
+    { MP_ROM_QSTR(MP_QSTR_pin), MP_ROM_PTR(&machine_pin_pin_obj) },
+
 
     // class constants
     { MP_ROM_QSTR(MP_QSTR_IN), MP_ROM_INT(GPIO_MODE_INPUT) },


### PR DESCRIPTION
See #6538. Tested on TinyPICO:

```
MicroPython v1.13-103-gb137d064e-dirty on 2020-10-11; TinyPICO with ESP32-PICO-D4
Type "help()" for more information.
>>> from machine import Pin
>>> p = Pin(4)
>>> p
Pin(4)
>>> p.pin()
4
```
