### PR TITLE
ports/stm32/rfcore.c: Fixes for WB55 firmware updating.

### DIFF
--- a/ports/stm32/rfcore.h
+++ b/ports/stm32/rfcore.h
@@ -37,6 +37,6 @@ void rfcore_ble_set_txpower(uint8_t level);
 
 MP_DECLARE_CONST_FUN_OBJ_0(rfcore_status_obj);
 MP_DECLARE_CONST_FUN_OBJ_1(rfcore_fw_version_obj);
-MP_DECLARE_CONST_FUN_OBJ_3(rfcore_sys_hci_obj);
+MP_DECLARE_CONST_FUN_OBJ_VAR_BETWEEN(rfcore_sys_hci_obj);
 
 #endif // MICROPY_INCLUDED_STM32_RFCORE_H


### PR DESCRIPTION
* Testing on more devices has revealed that the flash can be already unlocked on boot. I'm not entirely sure of the reason for this, but either way, if we attempt to unlock while unlocked, the chip resets. Detect the lock state and skip unlocking if necessary.
* Fix `_state_id` which was accidentally renamed to `_STATE_id` with a bad s/
* Make updating work with other firmware images (tested with ble_stack_full) which require a longer timeout for the first GET_STATE command.