### PR TITLE
usb stream

### DIFF
--- a/ports/stm32/usbd_hid_interface.h
+++ b/ports/stm32/usbd_hid_interface.h
@@ -22,4 +22,6 @@ static inline int usbd_hid_rx_num(usbd_hid_itf_t *hid) {
 
 int usbd_hid_rx(usbd_hid_itf_t *hid, size_t len, uint8_t *buf, uint32_t timeout_ms);
 
+usbd_hid_itf_t *usbd_hid_get();
+
 #endif // MICROPY_INCLUDED_STM32_USBD_HID_INTERFACE_H


### PR DESCRIPTION
Two patches: one to usb stream object, one to usb hid.

- add "flush" to a usb stream object
else on full-speed usb a 64-byte packet might stay in the buffers forever.

- expose usb hid device to user c modules
allows a user c module to implement a usb hid device. Does not cost flash memory if not used by a module.
Code sample: implement a [cmsis-dap probe](https://github.com/koendv/free-dap/blob/devel/platform/stm32/freedap.c)  in micropython.
