### PR TITLE
unix: Handle pending events/scheduler in MICROPY_EVENT_POLL_HOOK.

### DIFF
--- a/ports/unix/mpconfigport.h
+++ b/ports/unix/mpconfigport.h
@@ -362,7 +362,12 @@ struct _mp_bluetooth_nimble_malloc_t;
 #define MICROPY_END_ATOMIC_SECTION(x) (void)x; mp_thread_unix_end_atomic_section()
 #endif
 
-#define MICROPY_EVENT_POLL_HOOK mp_hal_delay_us(500);
+#define MICROPY_EVENT_POLL_HOOK \
+    do { \
+        extern void mp_handle_pending(bool); \
+        mp_handle_pending(true); \
+        mp_hal_delay_us(500); \
+    } while (0);
 
 #include <sched.h>
 #define MICROPY_UNIX_MACHINE_IDLE sched_yield();


### PR DESCRIPTION
This makes the unix port handling of `micropython.schedule()` more closely match other ports, ensuring they're run in the background regularly.

This is also required for unix support of https://github.com/micropython/micropython/pull/6438