### PR TITLE
extmod: Seed random module on import (v2)

### DIFF
--- a/extmod/modurandom.c
+++ b/extmod/modurandom.c
@@ -31,14 +31,28 @@
 
 #if MICROPY_PY_URANDOM
 
+// Work out if the seed will be set on import or not.
+#if MICROPY_MODULE_BUILTIN_INIT && defined(MICROPY_PY_URANDOM_SEED_INIT_FUNC)
+#define SEED_ON_IMPORT (1)
+#else
+#define SEED_ON_IMPORT (0)
+#endif
+
 // Yasmarang random number generator
 // by Ilya Levin
 // http://www.literatecode.com/yasmarang
 // Public Domain
 
 #if !MICROPY_ENABLE_DYNRUNTIME
+#if SEED_ON_IMPORT
+// If the state is seeded on import then keep these variables in the BSS.
+STATIC uint32_t yasmarang_pad, yasmarang_n, yasmarang_d;
+STATIC uint8_t yasmarang_dat;
+#else
+// Without seed-on-import these variables must be initialised via the data section.
 STATIC uint32_t yasmarang_pad = 0xeda4baba, yasmarang_n = 69, yasmarang_d = 233;
 STATIC uint8_t yasmarang_dat = 0;
+#endif
 #endif
 
 STATIC uint32_t yasmarang(void) {
@@ -83,15 +97,24 @@ STATIC mp_obj_t mod_urandom_getrandbits(mp_obj_t num_in) {
 }
 STATIC MP_DEFINE_CONST_FUN_OBJ_1(mod_urandom_getrandbits_obj, mod_urandom_getrandbits);
 
-STATIC mp_obj_t mod_urandom_seed(mp_obj_t seed_in) {
-    mp_uint_t seed = mp_obj_get_int_truncated(seed_in);
+STATIC mp_obj_t mod_urandom_seed(size_t n_args, const mp_obj_t *args) {
+    mp_uint_t seed;
+    if (n_args == 0 || args[0] == mp_const_none) {
+        #ifdef MICROPY_PY_URANDOM_SEED_INIT_FUNC
+        seed = MICROPY_PY_URANDOM_SEED_INIT_FUNC;
+        #else
+        mp_raise_ValueError(MP_ERROR_TEXT("no default seed"));
+        #endif
+    } else {
+        seed = mp_obj_get_int_truncated(args[0]);
+    }
     yasmarang_pad = seed;
     yasmarang_n = 69;
     yasmarang_d = 233;
     yasmarang_dat = 0;
     return mp_const_none;
 }
-STATIC MP_DEFINE_CONST_FUN_OBJ_1(mod_urandom_seed_obj, mod_urandom_seed);
+STATIC MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(mod_urandom_seed_obj, 0, 1, mod_urandom_seed);
 
 #if MICROPY_PY_URANDOM_EXTRA_FUNCS
 
@@ -189,9 +212,15 @@ STATIC MP_DEFINE_CONST_FUN_OBJ_2(mod_urandom_uniform_obj, mod_urandom_uniform);
 
 #endif // MICROPY_PY_URANDOM_EXTRA_FUNCS
 
-#ifdef MICROPY_PY_URANDOM_SEED_INIT_FUNC
+#if SEED_ON_IMPORT
 STATIC mp_obj_t mod_urandom___init__() {
-    mod_urandom_seed(MP_OBJ_NEW_SMALL_INT(MICROPY_PY_URANDOM_SEED_INIT_FUNC));
+    // This module may be imported by more than one name so need to ensure
+    // that it's only ever seeded once.
+    static bool seeded = false;
+    if (!seeded) {
+        seeded = true;
+        mod_urandom_seed(0, NULL);
+    }
     return mp_const_none;
 }
 STATIC MP_DEFINE_CONST_FUN_OBJ_0(mod_urandom___init___obj, mod_urandom___init__);
@@ -200,7 +229,7 @@ STATIC MP_DEFINE_CONST_FUN_OBJ_0(mod_urandom___init___obj, mod_urandom___init__)
 #if !MICROPY_ENABLE_DYNRUNTIME
 STATIC const mp_rom_map_elem_t mp_module_urandom_globals_table[] = {
     { MP_ROM_QSTR(MP_QSTR___name__), MP_ROM_QSTR(MP_QSTR_urandom) },
-    #ifdef MICROPY_PY_URANDOM_SEED_INIT_FUNC
+    #if SEED_ON_IMPORT
     { MP_ROM_QSTR(MP_QSTR___init__), MP_ROM_PTR(&mod_urandom___init___obj) },
     #endif
     { MP_ROM_QSTR(MP_QSTR_getrandbits), MP_ROM_PTR(&mod_urandom_getrandbits_obj) },

--- a/ports/esp32/mpconfigport.h
+++ b/ports/esp32/mpconfigport.h
@@ -6,6 +6,7 @@
 
 #include <stdint.h>
 #include <alloca.h>
+#include "esp_system.h"
 
 #if !MICROPY_ESP_IDF_4
 #include "rom/ets_sys.h"
@@ -141,6 +142,7 @@
 #define MICROPY_PY_UBINASCII_CRC32          (1)
 #define MICROPY_PY_URANDOM                  (1)
 #define MICROPY_PY_URANDOM_EXTRA_FUNCS      (1)
+#define MICROPY_PY_URANDOM_SEED_INIT_FUNC   (esp_random())
 #define MICROPY_PY_OS_DUPTERM               (1)
 #define MICROPY_PY_MACHINE                  (1)
 #define MICROPY_PY_MACHINE_PIN_MAKE_NEW     mp_pin_make_new

--- a/ports/esp8266/mpconfigport.h
+++ b/ports/esp8266/mpconfigport.h
@@ -26,6 +26,7 @@
 #define MICROPY_HELPER_REPL         (1)
 #define MICROPY_HELPER_LEXER_UNIX   (0)
 #define MICROPY_ENABLE_SOURCE_LINE  (1)
+#define MICROPY_MODULE_BUILTIN_INIT (1)
 #define MICROPY_MODULE_WEAK_LINKS   (1)
 #define MICROPY_CAN_OVERRIDE_BUILTINS (1)
 #define MICROPY_USE_INTERNAL_ERRNO  (1)
@@ -69,6 +70,7 @@
 #define MICROPY_PY_UTIMEQ           (1)
 #define MICROPY_PY_UJSON            (1)
 #define MICROPY_PY_URANDOM          (1)
+#define MICROPY_PY_URANDOM_SEED_INIT_FUNC (*WDEV_HWRNG)
 #define MICROPY_PY_URE              (1)
 #define MICROPY_PY_USELECT          (1)
 #define MICROPY_PY_UTIME_MP_HAL     (1)
@@ -196,5 +198,7 @@ extern const struct _mp_obj_module_t mp_module_onewire;
 #define MP_FASTCODE(n) __attribute__((section(".iram0.text." #n))) n
 #define MICROPY_WRAP_MP_KEYBOARD_INTERRUPT(f) MP_FASTCODE(f)
 #define MICROPY_WRAP_MP_SCHED_SCHEDULE(f) MP_FASTCODE(f)
+
+#define WDEV_HWRNG ((volatile uint32_t *)0x3ff20e44)
 
 #define _assert(expr) ((expr) ? (void)0 : __assert_func(__FILE__, __LINE__, __func__, #expr))

--- a/ports/stm32/mpconfigport.h
+++ b/ports/stm32/mpconfigport.h
@@ -79,6 +79,7 @@
 #define MICROPY_FLOAT_IMPL          (MICROPY_FLOAT_IMPL_FLOAT)
 #endif
 #define MICROPY_STREAMS_NON_BLOCK   (1)
+#define MICROPY_MODULE_BUILTIN_INIT (1)
 #define MICROPY_MODULE_WEAK_LINKS   (1)
 #define MICROPY_CAN_OVERRIDE_BUILTINS (1)
 #define MICROPY_USE_INTERNAL_ERRNO  (1)
@@ -167,6 +168,7 @@
 #endif
 #ifndef MICROPY_PY_URANDOM
 #define MICROPY_PY_URANDOM          (1)
+#define MICROPY_PY_URANDOM_SEED_INIT_FUNC (rng_get())
 #endif
 #ifndef MICROPY_PY_URANDOM_EXTRA_FUNCS
 #define MICROPY_PY_URANDOM_EXTRA_FUNCS (1)
@@ -427,3 +429,6 @@ static inline mp_uint_t disable_irq(void) {
 
 // We need to provide a declaration/definition of alloca()
 #include <alloca.h>
+
+// Needed for MICROPY_PY_URANDOM_SEED_INIT_FUNC.
+uint32_t rng_get(void);

--- a/tests/extmod/urandom_seed_default.py
+++ b/tests/extmod/urandom_seed_default.py
@@ -1,0 +1,30 @@
+# test urandom.seed() without any arguments
+
+try:
+    import urandom as random
+except ImportError:
+    try:
+        import random
+    except ImportError:
+        print("SKIP")
+        raise SystemExit
+
+try:
+    random.seed()
+except ValueError:
+    # no default seed on this platform
+    print("SKIP")
+    raise SystemExit
+
+
+def rng_seq():
+    return [random.getrandbits(16) for _ in range(10)]
+
+
+# seed with default and check that doesn't produce the same RNG sequence
+random.seed()
+seq = rng_seq()
+random.seed()
+print(seq == rng_seq())
+random.seed(None)
+print(seq == rng_seq())


### PR DESCRIPTION
This PR builds on #6362.  It contains:
- random module is seeded with hardware RNG on stm32, esp8266, esp32
- for sm32 MCUs without hardware RNG, the seeding of the pRNG is improved, uses systick+rtc+unique-id
- adds support for `random.seed()` and `random.seed(None)`, which re-seeds the module with a hardware RNG
- `import random` calls `random.seed()` (instead of passing in the HW RNG to `seed(...)`)
- fixes a bug where the seed is initialised twice if the module is imported by different names, eg `random` and `urandom`

Fixes #6347. 