### PR TITLE
esp32/mpconfigport: Enable MICROPY_PY_DELATTR_SETATTR

### DIFF
--- a/ports/esp32/mpconfigport.h
+++ b/ports/esp32/mpconfigport.h
@@ -63,6 +63,7 @@
 // control over Python builtins
 #define MICROPY_PY_FUNCTION_ATTRS           (1)
 #define MICROPY_PY_DESCRIPTORS              (1)
+#define MICROPY_PY_DELATTR_SETATTR          (1)
 #define MICROPY_PY_STR_BYTES_CMP_WARN       (1)
 #define MICROPY_PY_BUILTINS_STR_UNICODE     (1)
 #define MICROPY_PY_BUILTINS_STR_CENTER      (1)


### PR DESCRIPTION
esp32 counterpart as discussed in #6427

I thought this is worth raising before it's completely forgotten