### PR TITLE
stm32/machine_adc: Fix ADC auto-calibration to run when ADC not enabled.

### DIFF
--- a/ports/stm32/boards/stm32f0xx_hal_conf_base.h
+++ b/ports/stm32/boards/stm32f0xx_hal_conf_base.h
@@ -47,6 +47,7 @@
 #include "stm32f0xx_hal_uart.h"
 #include "stm32f0xx_hal_usart.h"
 #include "stm32f0xx_hal_wwdg.h"
+#include "stm32f0xx_ll_adc.h"
 
 // Enable various HAL modules
 #define HAL_MODULE_ENABLED

--- a/ports/stm32/boards/stm32h7xx_hal_conf_base.h
+++ b/ports/stm32/boards/stm32h7xx_hal_conf_base.h
@@ -53,6 +53,7 @@
 #include "stm32h7xx_hal_uart.h"
 #include "stm32h7xx_hal_usart.h"
 #include "stm32h7xx_hal_wwdg.h"
+#include "stm32h7xx_ll_adc.h"
 
 // Enable various HAL modules
 #define HAL_ADC_MODULE_ENABLED

--- a/ports/stm32/boards/stm32l0xx_hal_conf_base.h
+++ b/ports/stm32/boards/stm32l0xx_hal_conf_base.h
@@ -46,6 +46,7 @@
 #include "stm32l0xx_hal_uart.h"
 #include "stm32l0xx_hal_usart.h"
 #include "stm32l0xx_hal_wwdg.h"
+#include "stm32l0xx_ll_adc.h"
 
 // Enable various HAL modules
 #define HAL_MODULE_ENABLED

--- a/ports/stm32/boards/stm32wbxx_hal_conf_base.h
+++ b/ports/stm32/boards/stm32wbxx_hal_conf_base.h
@@ -41,6 +41,7 @@
 #include "stm32wbxx_hal_tim.h"
 #include "stm32wbxx_hal_uart.h"
 #include "stm32wbxx_hal_usart.h"
+#include "stm32wbxx_ll_adc.h"
 
 // Enable various HAL modules
 #define HAL_MODULE_ENABLED

--- a/ports/stm32/machine_adc.c
+++ b/ports/stm32/machine_adc.c
@@ -156,10 +156,16 @@ STATIC void adc_config(ADC_TypeDef *adc, uint32_t bits) {
     #endif
 
     #if ADC_V2
-    if (adc->CR == 0) {
-        // ADC hasn't been enabled so calibrate it
-        adc->CR |= ADC_CR_ADCAL;
-        while (adc->CR & ADC_CR_ADCAL) {
+    if (!(adc->CR & ADC_CR_ADEN)) {
+        // ADC isn't enabled so calibrate it now
+        #if defined(STM32F0) || defined(STM32L0)
+        LL_ADC_StartCalibration(adc);
+        #elif defined(STM32L4) || defined(STM32WB)
+        LL_ADC_StartCalibration(adc, LL_ADC_SINGLE_ENDED);
+        #else
+        LL_ADC_StartCalibration(adc, LL_ADC_CALIB_OFFSET_LINEARITY, LL_ADC_SINGLE_ENDED);
+        #endif
+        while (LL_ADC_IsCalibrationOnGoing(adc)) {
         }
     }
 


### PR DESCRIPTION
Prior to this commit, the ADC calibration code was never executing because ADVREGEN bit was set making the CR register always non-zero.

This commit changes the logic so that ADC calibration is always run when the ADC is disabled and an ADC channel is initialised.
