### PR TITLE
extmod/btstack/btstack.mk: Add -Wimplicit-fallthrough=0.

### DIFF
--- a/extmod/btstack/btstack.mk
+++ b/extmod/btstack/btstack.mk
@@ -66,11 +66,12 @@ endif
 LIB_SRC_C += $(SRC_BTSTACK)
 
 # Suppress some warnings.
-BTSTACK_WARNING_CFLAGS = -Wno-old-style-definition -Wno-unused-variable -Wno-unused-parameter
+BTSTACK_WARNING_CFLAGS = -Wno-old-style-definition -Wno-unused-variable -Wno-unused-parameter -Wimplicit-fallthrough=0
 ifneq ($(CC),clang)
 BTSTACK_WARNING_CFLAGS += -Wno-format
 endif
 $(BUILD)/lib/btstack/src/%.o: CFLAGS += $(BTSTACK_WARNING_CFLAGS)
+$(BUILD)/lib/btstack/platform/%.o: CFLAGS += $(BTSTACK_WARNING_CFLAGS)
 
 endif
 endif


### PR DESCRIPTION
This is needed since -Wextra was added to the build in bef412789ea93c521bd9c2dddc22b9b3484da574.

I'm not sure why the CI didn't pick this up for #6510