### PR TITLE
extmod/nimble/nimble.mk: Add -Wno-old-style-declaration.

### DIFF
--- a/extmod/nimble/nimble.mk
+++ b/extmod/nimble/nimble.mk
@@ -101,7 +101,7 @@ INC += -I$(TOP)/$(NIMBLE_LIB_DIR)/nimble/include
 INC += -I$(TOP)/$(NIMBLE_LIB_DIR)/nimble/transport/uart/include
 INC += -I$(TOP)/$(NIMBLE_LIB_DIR)/porting/nimble/include
 
-$(BUILD)/$(NIMBLE_LIB_DIR)/%.o: CFLAGS += -Wno-maybe-uninitialized -Wno-pointer-arith -Wno-unused-but-set-variable -Wno-format -Wno-sign-compare
+$(BUILD)/$(NIMBLE_LIB_DIR)/%.o: CFLAGS += -Wno-maybe-uninitialized -Wno-pointer-arith -Wno-unused-but-set-variable -Wno-format -Wno-sign-compare -Wno-old-style-declaration
 
 endif
 


### PR DESCRIPTION
This is needed since -Wextra was added to the build in bef4127.

Signed-off-by: Jim Mussared <jim.mussared@gmail.com>