### PR TITLE
Fix potential null-dereferencing pointers

### DIFF
--- a/py/objdict.c
+++ b/py/objdict.c
@@ -291,6 +291,7 @@ STATIC mp_obj_t dict_get_helper(size_t n_args, const mp_obj_t *args, mp_map_look
             value = args[2];
         }
         if (lookup_kind == MP_MAP_LOOKUP_ADD_IF_NOT_FOUND) {
+            assert(elem);
             elem->value = value;
         }
     } else {

--- a/py/objtype.c
+++ b/py/objtype.c
@@ -88,6 +88,7 @@ STATIC mp_obj_t native_base_init_wrapper(size_t n_args, const mp_obj_t *args) {
     mp_obj_instance_t *self = MP_OBJ_TO_PTR(args[0]);
     const mp_obj_type_t *native_base = NULL;
     instance_count_native_bases(self->base.type, &native_base);
+    assert(native_base);
     self->subobj[0] = native_base->make_new(native_base, n_args - 1, 0, args + 1);
     return mp_const_none;
 }

--- a/py/vm.c
+++ b/py/vm.c
@@ -1462,6 +1462,7 @@ unwind_loop:
             // - constant GeneratorExit object, because it's const
             // - exceptions re-raised by END_FINALLY
             // - exceptions re-raised explicitly by "raise"
+            assert(nlr.ret_val == &mp_const_GeneratorExit_obj || code_state->ip);
             if (nlr.ret_val != &mp_const_GeneratorExit_obj
                 && *code_state->ip != MP_BC_END_FINALLY
                 && *code_state->ip != MP_BC_RAISE_LAST) {


### PR DESCRIPTION
I ran [Clang Static Analyzer](https://clang-analyzer.llvm.org) and detected some potential null-deferencing pointers and a dangling reference.
I am not sure that I chose the right way to fix them (for instance, for the null-dereference, whether to add an assert or an if condition) but at least the PR highlights the vulnerable lines.