### PR TITLE
 ifdef zephyr i2c to reduce codesize

### DIFF
--- a/ports/zephyr/machine_i2c.c
+++ b/ports/zephyr/machine_i2c.c
@@ -39,6 +39,8 @@
 #include "extmod/machine_i2c.h"
 #include "modmachine.h"
 
+#if MICROPY_PY_MACHINE_I2C
+
 typedef struct _machine_hard_i2c_obj_t {
     mp_obj_base_t base;
     const struct device *dev;
@@ -136,3 +138,5 @@ const mp_obj_type_t machine_hard_i2c_type = {
     .protocol = &machine_hard_i2c_p,
     .locals_dict = (mp_obj_dict_t *)&mp_machine_soft_i2c_locals_dict,
 };
+
+#endif /* MICROPY_PY_MACHINE_I2C */

--- a/ports/zephyr/modmachine.c
+++ b/ports/zephyr/modmachine.c
@@ -60,7 +60,9 @@ STATIC const mp_rom_map_elem_t machine_module_globals_table[] = {
     #endif
     { MP_ROM_QSTR(MP_QSTR_reset_cause), MP_ROM_PTR(&machine_reset_cause_obj) },
 
+    #if MICROPY_PY_MACHINE_I2C
     { MP_ROM_QSTR(MP_QSTR_I2C), MP_ROM_PTR(&machine_hard_i2c_type) },
+    #endif /* MICROPY_PY_MACHINE_I2C */
     { MP_ROM_QSTR(MP_QSTR_Pin), MP_ROM_PTR(&machine_pin_type) },
     { MP_ROM_QSTR(MP_QSTR_Signal), MP_ROM_PTR(&machine_signal_type) },
 


### PR DESCRIPTION
wanted to reduce binary code size, while not using i2c.
setting MICROPY_PY_MACHINE_I2C to 0 still compiles the i2c related code

ifdef guarded the relevant places

Signed-off-by: Jonathan Bruchim <yonbruchim@gmail.com>