### PR TITLE
Add a rotate180 method to the SSD1306 display driver

### DIFF
--- a/drivers/display/ssd1306.py
+++ b/drivers/display/ssd1306.py
@@ -85,6 +85,10 @@ class SSD1306(framebuf.FrameBuffer):
     def invert(self, invert):
         self.write_cmd(SET_NORM_INV | (invert & 1))
 
+    def rotate180(self, rotate):
+        self.write_cmd(SET_COM_OUT_DIR | ((rotate & 1) << 3))
+        self.write_cmd(SET_SEG_REMAP | ((rotate & 1) << 0))
+
     def show(self):
         x0 = 0
         x1 = self.width - 1


### PR DESCRIPTION
This simply sets a bit in the REG_REMAP and COM_OUT_DIR registers to change the scan directions. By flipping vertically and horizonally, the effect is the same as a 180 degree rotation.  Handy, in case your display is upside-down for whatever reason.

Signed-off-by: Chris Kuethe <chris.kuethe@gmail.com>