### PR TITLE
esp32: switch to esp-idf's errno.h to fix socket error codes

### DIFF
--- a/ports/esp32/modsocket.c
+++ b/ports/esp32/modsocket.c
@@ -153,6 +153,7 @@ void usocket_events_handler(void) {
 #endif // MICROPY_PY_USOCKET_EVENTS
 
 static inline void check_for_exceptions(void) {
+    // Give the scheduler a chance...
     mp_handle_pending(true);
 }
 

--- a/ports/esp32/mpconfigport.h
+++ b/ports/esp32/mpconfigport.h
@@ -55,7 +55,7 @@
 #define MICROPY_MODULE_FROZEN_MPY           (1)
 #define MICROPY_QSTR_EXTRA_POOL             mp_qstr_frozen_const_pool
 #define MICROPY_CAN_OVERRIDE_BUILTINS       (1)
-#define MICROPY_USE_INTERNAL_ERRNO          (1)
+#define MICROPY_USE_INTERNAL_ERRNO          (0) // errno.h from xtensa-esp32-elf/sys-include/sys
 #define MICROPY_USE_INTERNAL_PRINTF         (0) // ESP32 SDK requires its own printf
 #define MICROPY_ENABLE_SCHEDULER            (1)
 #define MICROPY_SCHEDULER_DEPTH             (8)

--- a/tests/net_hosted/connect_nonblock.py
+++ b/tests/net_hosted/connect_nonblock.py
@@ -2,8 +2,9 @@
 
 try:
     import usocket as socket
+    import uerrno as errno
 except:
-    import socket
+    import socket, errno
 
 
 def test(peer_addr):
@@ -12,7 +13,7 @@ def test(peer_addr):
     try:
         s.connect(peer_addr)
     except OSError as er:
-        print(er.args[0] == 115)  # 115 is EINPROGRESS
+        print(er.args[0] == errno.EINPROGRESS)
     s.close()
 
 


### PR DESCRIPTION
This PR replaces #5968 and #6569, which attempted to patch-up the error codes.
This PR is based on the esp32-idf41-cmake branch and thus uses the cmake build system.
The main change brought about by this PR is to set `MICROPY_USE_INTERNAL_ERRNO=0` to use the compiler's errno.h in `xtensa-esp32-elf/sys-include/sys` frmo the xtensa build tools.
It also removes the error code switcharoo in modsocket.c