### PR TITLE
py/objboundmeth: Implement equality comparisons

### DIFF
--- a/tests/basics/boundmeth1.py
+++ b/tests/basics/boundmeth1.py
@@ -28,3 +28,11 @@ try:
     A().f.x = 1
 except AttributeError:
     print('AttributeError')
+
+# equality tests
+i = A()         # need methods to be bound from the same instance
+m = i.f
+print(m == i.f)
+print(m != i.f)
+print(m == i.g)
+print(m != i.g)


### PR DESCRIPTION
Currently different bound method instances will compare as unequal even
when both instances bind the same method and object. This is different
to the CPython implementation and, for example, will cause problems
when working with lists that contain callbacks since things like
list.remove() will not work correctly.

Fix this the obvious way by introducing a binary op and implementing
MP_BINARY_OP_EQUAL. A simple test case is provided.

Currently this is unconditionally compiled and on a Thumb2 system
(ports/nrf) it resulted in a 68 byte increase in code size.

Signed-off-by: Daniel Thompson <daniel@redfelineninja.org.uk>