### PR TITLE
docs/library/framebuf.rst: Adjust dimensions in example

### DIFF
--- a/docs/library/framebuf.rst
+++ b/docs/library/framebuf.rst
@@ -19,11 +19,11 @@ For example::
     import framebuf
 
     # FrameBuffer needs 2 bytes for every RGB565 pixel
-    fbuf = framebuf.FrameBuffer(bytearray(10 * 100 * 2), 10, 100, framebuf.RGB565)
+    fbuf = framebuf.FrameBuffer(bytearray(100 * 10 * 2), 100, 10, framebuf.RGB565)
 
     fbuf.fill(0)
     fbuf.text('MicroPython!', 0, 0, 0xffff)
-    fbuf.hline(0, 10, 96, 0xffff)
+    fbuf.hline(0, 9, 96, 0xffff)
 
 Constructors
 ------------


### PR DESCRIPTION
This commit swaps the dimensions of the `framebuffer.FrameBuffer` in the
docs example from 10x100 to 100x10 pixels to avoid clipping.

This is done to better fit the subsequent example code, which writes
text of size 96x8 followed by a 96x1 horizontal line.

The y coordinate of the horizontal line is also adjusted such that it is
fully drawn inside of the new canvas bounds.