### PR TITLE
inisetup.py: 'FAT' free warning

### DIFF
--- a/ports/esp32/modules/inisetup.py
+++ b/ports/esp32/modules/inisetup.py
@@ -21,7 +21,7 @@ def fs_corrupted():
     while 1:
         print(
             """\
-FAT filesystem appears to be corrupted. If you had important data there, you
+The filesystem appears to be corrupted. If you had important data there, you
 may want to make a flash snapshot to try to recover it. Otherwise, perform
 factory reprogramming of MicroPython firmware (completely erase flash, followed
 by firmware programming).

--- a/ports/esp8266/modules/inisetup.py
+++ b/ports/esp8266/modules/inisetup.py
@@ -30,7 +30,7 @@ def fs_corrupted():
     while 1:
         print(
             """\
-The FAT filesystem starting at sector %d with size %d sectors appears to
+The filesystem starting at sector %d with size %d sectors appears to
 be corrupted. If you had important data there, you may want to make a flash
 snapshot to try to recover it. Otherwise, perform factory reprogramming
 of MicroPython firmware (completely erase flash, followed by firmware


### PR DESCRIPTION
Just a tiny tiny change, since FAT is not any more the only Filesystem used.
Applies to the ESP32 and ESP8266 port.