### PR TITLE
ESP32: don't throw exception in wifi.scan() if no Wifi in range

### DIFF
--- a/ports/esp32/modnetwork.c
+++ b/ports/esp32/modnetwork.c
@@ -453,6 +453,9 @@ STATIC mp_obj_t esp_scan(mp_obj_t self_in) {
     if (status == 0) {
         uint16_t count = 0;
         ESP_EXCEPTIONS(esp_wifi_scan_get_ap_num(&count));
+        if (count == 0) {
+            return list;
+        }
         wifi_ap_record_t *wifi_ap_records = calloc(count, sizeof(wifi_ap_record_t));
         ESP_EXCEPTIONS(esp_wifi_scan_get_ap_records(&count, wifi_ap_records));
         for (uint16_t i = 0; i < count; i++) {


### PR DESCRIPTION
If you use `wifi.scan()` and there are no wifis in range it will throw an exception that is totally unnecessary (and was not documented anywhere), correct way of handling "i don't see any wifi" is to return the empty list

This PR fixes that problem.