### PR TITLE
py/emitnative: Fix x86-64 emitter to generate correct 8/16-bit stores.

### DIFF
--- a/py/asmx64.c
+++ b/py/asmx64.c
@@ -285,31 +285,28 @@ void asm_x64_mov_r64_to_mem64(asm_x64_t *as, int src_r64, int dest_r64, int dest
 }
 
 void asm_x64_mov_mem8_to_r64zx(asm_x64_t *as, int src_r64, int src_disp, int dest_r64) {
-    assert(src_r64 < 8);
-    if (dest_r64 < 8) {
+    if (src_r64 < 8 && dest_r64 < 8) {
         asm_x64_write_byte_2(as, 0x0f, OPCODE_MOVZX_RM8_TO_R64);
     } else {
-        asm_x64_write_byte_3(as, REX_PREFIX | REX_R, 0x0f, OPCODE_MOVZX_RM8_TO_R64);
+        asm_x64_write_byte_3(as, REX_PREFIX | REX_R_FROM_R64(dest_r64) | REX_B_FROM_R64(src_r64), 0x0f, OPCODE_MOVZX_RM8_TO_R64);
     }
     asm_x64_write_r64_disp(as, dest_r64, src_r64, src_disp);
 }
 
 void asm_x64_mov_mem16_to_r64zx(asm_x64_t *as, int src_r64, int src_disp, int dest_r64) {
-    assert(src_r64 < 8);
-    if (dest_r64 < 8) {
+    if (src_r64 < 8 && dest_r64 < 8) {
         asm_x64_write_byte_2(as, 0x0f, OPCODE_MOVZX_RM16_TO_R64);
     } else {
-        asm_x64_write_byte_3(as, REX_PREFIX | REX_R, 0x0f, OPCODE_MOVZX_RM16_TO_R64);
+        asm_x64_write_byte_3(as, REX_PREFIX | REX_R_FROM_R64(dest_r64) | REX_B_FROM_R64(src_r64), 0x0f, OPCODE_MOVZX_RM16_TO_R64);
     }
     asm_x64_write_r64_disp(as, dest_r64, src_r64, src_disp);
 }
 
 void asm_x64_mov_mem32_to_r64zx(asm_x64_t *as, int src_r64, int src_disp, int dest_r64) {
-    assert(src_r64 < 8);
-    if (dest_r64 < 8) {
+    if (src_r64 < 8 && dest_r64 < 8) {
         asm_x64_write_byte_1(as, OPCODE_MOV_RM64_TO_R64);
     } else {
-        asm_x64_write_byte_2(as, REX_PREFIX | REX_R, OPCODE_MOV_RM64_TO_R64);
+        asm_x64_write_byte_2(as, REX_PREFIX | REX_R_FROM_R64(dest_r64) | REX_B_FROM_R64(src_r64), OPCODE_MOV_RM64_TO_R64);
     }
     asm_x64_write_r64_disp(as, dest_r64, src_r64, src_disp);
 }

--- a/py/emitnative.c
+++ b/py/emitnative.c
@@ -1769,7 +1769,7 @@ STATIC void emit_native_store_subscr(emit_t *emit) {
             int reg_index = REG_ARG_2;
             int reg_value = REG_ARG_3;
             emit_pre_pop_reg_flexible(emit, &vtype_base, &reg_base, reg_index, reg_value);
-            #if N_X86
+            #if N_X64 || N_X86
             // special case: x86 needs byte stores to be from lower 4 regs (REG_ARG_3 is EDX)
             emit_pre_pop_reg(emit, &vtype_value, reg_value);
             #else
@@ -1856,7 +1856,7 @@ STATIC void emit_native_store_subscr(emit_t *emit) {
                 EMIT_NATIVE_VIPER_TYPE_ERROR(emit,
                     MP_ERROR_TEXT("can't store with '%q' index"), vtype_to_qstr(vtype_index));
             }
-            #if N_X86
+            #if N_X64 || N_X86
             // special case: x86 needs byte stores to be from lower 4 regs (REG_ARG_3 is EDX)
             emit_pre_pop_reg(emit, &vtype_value, reg_value);
             #else

--- a/tests/micropython/viper_misc2.py
+++ b/tests/micropython/viper_misc2.py
@@ -1,0 +1,21 @@
+# Miscellaneous viper tests
+
+# Test correct use of registers in load and store
+@micropython.viper
+def expand(dest: ptr8, source: ptr8, length: int):
+    n = 0
+    for x in range(0, length, 2):
+        c = source[x]
+        d = source[x + 1]
+        dest[n] = (c & 0xE0) | ((c & 0x1C) >> 1)
+        n += 1
+        dest[n] = ((c & 3) << 6) | ((d & 0xE0) >> 4)
+        n += 1
+        dest[n] = ((d & 0x1C) << 3) | ((d & 3) << 2)
+        n += 1
+
+
+source = b"\xaa\xaa\xff\xff"
+dest = bytearray(len(source) // 2 * 3)
+expand(dest, source, len(source))
+print(dest)

--- a/tests/micropython/viper_misc2.py.exp
+++ b/tests/micropython/viper_misc2.py.exp
@@ -1,0 +1,1 @@
+bytearray(b'\xa4\x8aH\xee\xce\xec')


### PR DESCRIPTION
Fixes issue #6643.