### PR TITLE
Fix mount raises AttributeError

### DIFF
--- a/extmod/vfs.c
+++ b/extmod/vfs.c
@@ -191,7 +191,8 @@ STATIC mp_obj_t mp_vfs_autodetect(mp_obj_t bdev_obj) {
     return mp_fat_vfs_type.make_new(&mp_fat_vfs_type, 1, 0, &bdev_obj);
     #endif
 
-    return bdev_obj;
+    // no filesystem found
+    mp_raise_OSError(MP_ENODEV);
 }
 
 mp_obj_t mp_vfs_mount(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {

--- a/tests/extmod/vfs_lfs_mount.py
+++ b/tests/extmod/vfs_lfs_mount.py
@@ -16,12 +16,12 @@ class RAMBlockDevice:
     def __init__(self, blocks):
         self.data = bytearray(blocks * self.ERASE_BLOCK_SIZE)
 
-    def readblocks(self, block, buf, off):
+    def readblocks(self, block, buf, off=0):
         addr = block * self.ERASE_BLOCK_SIZE + off
         for i in range(len(buf)):
             buf[i] = self.data[addr + i]
 
-    def writeblocks(self, block, buf, off):
+    def writeblocks(self, block, buf, off=0):
         addr = block * self.ERASE_BLOCK_SIZE + off
         for i in range(len(buf)):
             self.data[addr + i] = buf[i]
@@ -35,8 +35,16 @@ class RAMBlockDevice:
             return 0
 
 
-def test(bdev, vfs_class):
+def test(vfs_class):
     print("test", vfs_class)
+
+    bdev = RAMBlockDevice(30)
+
+    # mount bdev unformatted
+    try:
+        uos.mount(bdev, "/lfs")
+    except Exception as er:
+        print(repr(er))
 
     # mkfs
     vfs_class.mkfs(bdev)
@@ -84,11 +92,15 @@ def test(bdev, vfs_class):
     # umount
     uos.umount("/lfs")
 
+    # mount bdev again
+    uos.mount(bdev, "/lfs")
+
+    # umount
+    uos.umount("/lfs")
+
     # clear imported modules
     usys.modules.clear()
 
-
-bdev = RAMBlockDevice(30)
 
 # initialise path
 import usys
@@ -98,5 +110,5 @@ usys.path.append("/lfs")
 usys.path.append("")
 
 # run tests
-test(bdev, uos.VfsLfs1)
-test(bdev, uos.VfsLfs2)
+test(uos.VfsLfs1)
+test(uos.VfsLfs2)

--- a/tests/extmod/vfs_lfs_mount.py.exp
+++ b/tests/extmod/vfs_lfs_mount.py.exp
@@ -1,4 +1,5 @@
 test <class 'VfsLfs1'>
+OSError(19,)
 hello from lfs
 package
 hello from lfs
@@ -6,6 +7,7 @@ lfsmod2.py: print("hello from lfs")
 
 OSError(30,)
 test <class 'VfsLfs2'>
+OSError(19,)
 hello from lfs
 package
 hello from lfs


### PR DESCRIPTION
This PR fixes #6658: now uos.mount(bdev, ...) will always raise OSError(ENODEV,) if no filesystem is found on the block device "bdev".
