### PR TITLE
zephyr: Replace broken shell_net_iface() with more general shell_exec().

### DIFF
--- a/ports/zephyr/modzephyr.c
+++ b/ports/zephyr/modzephyr.c
@@ -31,6 +31,8 @@
 #include <stdio.h>
 #include <zephyr.h>
 #include <debug/thread_analyzer.h>
+#include <shell/shell.h>
+#include <shell/shell_uart.h>
 
 #include "modzephyr.h"
 #include "py/runtime.h"
@@ -53,17 +55,14 @@ STATIC mp_obj_t mod_thread_analyze(void) {
 STATIC MP_DEFINE_CONST_FUN_OBJ_0(mod_thread_analyze_obj, mod_thread_analyze);
 #endif
 
-#ifdef CONFIG_NET_SHELL
-
-// int net_shell_cmd_iface(int argc, char *argv[]);
-
-STATIC mp_obj_t mod_shell_net_iface(void) {
-    net_shell_cmd_iface(0, NULL);
+#ifdef CONFIG_SHELL_BACKEND_SERIAL
+STATIC mp_obj_t mod_shell_exec(mp_obj_t cmd_in) {
+    const char *cmd = mp_obj_str_get_str(cmd_in);
+    shell_execute_cmd(shell_backend_uart_get_ptr(), cmd);
     return mp_const_none;
 }
-STATIC MP_DEFINE_CONST_FUN_OBJ_0(mod_shell_net_iface_obj, mod_shell_net_iface);
-
-#endif // CONFIG_NET_SHELL
+STATIC MP_DEFINE_CONST_FUN_OBJ_1(mod_shell_exec_obj, mod_shell_exec);
+#endif // CONFIG_SHELL_BACKEND_SERIAL
 
 STATIC const mp_rom_map_elem_t mp_module_time_globals_table[] = {
     { MP_ROM_QSTR(MP_QSTR___name__), MP_ROM_QSTR(MP_QSTR_zephyr) },
@@ -72,9 +71,8 @@ STATIC const mp_rom_map_elem_t mp_module_time_globals_table[] = {
     #ifdef CONFIG_THREAD_ANALYZER
     { MP_ROM_QSTR(MP_QSTR_thread_analyze), MP_ROM_PTR(&mod_thread_analyze_obj) },
     #endif
-
-    #ifdef CONFIG_NET_SHELL
-    { MP_ROM_QSTR(MP_QSTR_shell_net_iface), MP_ROM_PTR(&mod_shell_net_iface_obj) },
+    #ifdef CONFIG_SHELL_BACKEND_SERIAL
+    { MP_ROM_QSTR(MP_QSTR_shell_exec), MP_ROM_PTR(&mod_shell_exec_obj) },
     #endif
     #ifdef CONFIG_DISK_ACCESS
     { MP_ROM_QSTR(MP_QSTR_DiskAccess), MP_ROM_PTR(&zephyr_disk_access_type) },

--- a/ports/zephyr/prj.conf
+++ b/ports/zephyr/prj.conf
@@ -57,7 +57,11 @@ CONFIG_THREAD_NAME=y
 # Required for usocket.pkt_get_info()
 CONFIG_NET_BUF_POOL_USAGE=y
 
-# Required for usocket.shell_*()
+# Required for zephyr.shell_exec()
+#CONFIG_SHELL=y
+#CONFIG_SHELL_BACKEND_SERIAL_INTERRUPT_DRIVEN=n
+
+# Required for zephyr.shell_exec("net iface")
 #CONFIG_NET_SHELL=y
 
 # Uncomment to enable "INFO" level net_buf logging


### PR DESCRIPTION
The zephyr function net_shell_cmd_iface() was removed in zephyr v1.14.0,
therefore the MicroPython zephyr port did not build with newer zephyr
versions when CONFIG_NET_SHELL=y. Replace with a more general
shell_exec() function that can execute any zephyr shell command. For
example:

```
>>> zephyr.shell_exec("net")

Subcommands:
  allocs     :Print network memory allocations.
  arp        :Print information about IPv4 ARP cache.
  conn       :Print information about network connections.
  dns        :Show how DNS is configured.
  events     :Monitor network management events.
  gptp       :Print information about gPTP support.
  iface      :Print information about network interfaces.
  ipv6       :Print information about IPv6 specific information and
              configuration.
  mem        :Print information about network memory usage.
  nbr        :Print neighbor information.
  ping       :Ping a network host.
  pkt        :net_pkt information.
  ppp        :PPP information.
  resume     :Resume a network interface
  route      :Show network route.
  stacks     :Show network stacks information.
  stats      :Show network statistics.
  suspend    :Suspend a network interface
  tcp        :Connect/send/close TCP connection.
  vlan       :Show VLAN information.
  websocket  :Print information about WebSocket connections.

>>> zephyr.shell_exec("kernel")

kernel - Kernel commands
Subcommands:
  cycles   :Kernel cycles.
  reboot   :Reboot.
  stacks   :List threads stack usage.
  threads  :List kernel threads.
  uptime   :Kernel uptime.
  version  :Kernel version.
```
Signed-off-by: Maureen Helm <maureen.helm@nxp.com>