### PR TITLE
stm32: Add support for a board to reserve certain peripherals.

### DIFF
--- a/ports/stm32/i2c.c
+++ b/ports/stm32/i2c.c
@@ -26,6 +26,7 @@
 
 #include "py/mperrno.h"
 #include "py/mphal.h"
+#include "py/runtime.h"
 #include "i2c.h"
 
 #if MICROPY_HW_ENABLE_HW_I2C
@@ -486,5 +487,54 @@ int i2c_writeto(i2c_t *i2c, uint16_t addr, const uint8_t *src, size_t len, bool 
 }
 
 #endif
+
+STATIC const uint8_t i2c_available =
+    0
+    #if defined(MICROPY_HW_I2C1_SCL)
+    | 1 << 1
+    #endif
+    #if defined(MICROPY_HW_I2C2_SCL)
+    | 1 << 2
+    #endif
+    #if defined(MICROPY_HW_I2C3_SCL)
+    | 1 << 3
+    #endif
+    #if defined(MICROPY_HW_I2C4_SCL)
+    | 1 << 4
+    #endif
+;
+
+int i2c_find_peripheral(mp_obj_t id) {
+    int i2c_id = 0;
+    if (mp_obj_is_str(id)) {
+        const char *port = mp_obj_str_get_str(id);
+        if (0) {
+        #ifdef MICROPY_HW_I2C1_NAME
+        } else if (strcmp(port, MICROPY_HW_I2C1_NAME) == 0) {
+            i2c_id = 1;
+        #endif
+        #ifdef MICROPY_HW_I2C2_NAME
+        } else if (strcmp(port, MICROPY_HW_I2C2_NAME) == 0) {
+            i2c_id = 2;
+        #endif
+        #ifdef MICROPY_HW_I2C3_NAME
+        } else if (strcmp(port, MICROPY_HW_I2C3_NAME) == 0) {
+            i2c_id = 3;
+        #endif
+        #ifdef MICROPY_HW_I2C4_NAME
+        } else if (strcmp(port, MICROPY_HW_I2C4_NAME) == 0) {
+            i2c_id = 4;
+        #endif
+        } else {
+            mp_raise_msg_varg(&mp_type_ValueError, MP_ERROR_TEXT("I2C(%s) doesn't exist"), port);
+        }
+    } else {
+        i2c_id = mp_obj_get_int(id);
+        if (i2c_id < 1 || i2c_id >= 8 * sizeof(i2c_available) || !(i2c_available & (1 << i2c_id))) {
+            mp_raise_msg_varg(&mp_type_ValueError, MP_ERROR_TEXT("I2C(%d) doesn't exist"), i2c_id);
+        }
+    }
+    return i2c_id;
+}
 
 #endif // MICROPY_HW_ENABLE_HW_I2C

--- a/ports/stm32/i2c.c
+++ b/ports/stm32/i2c.c
@@ -534,6 +534,12 @@ int i2c_find_peripheral(mp_obj_t id) {
             mp_raise_msg_varg(&mp_type_ValueError, MP_ERROR_TEXT("I2C(%d) doesn't exist"), i2c_id);
         }
     }
+
+    // check if the I2C is reserved for system use or not
+    if (MICROPY_HW_I2C_IS_RESERVED(i2c_id)) {
+        mp_raise_msg_varg(&mp_type_ValueError, MP_ERROR_TEXT("I2C(%d) is reserved"), i2c_id);
+    }
+
     return i2c_id;
 }
 

--- a/ports/stm32/i2c.h
+++ b/ports/stm32/i2c.h
@@ -62,4 +62,6 @@ int i2c_write(i2c_t *i2c, const uint8_t *src, size_t len, size_t next_len);
 int i2c_readfrom(i2c_t *i2c, uint16_t addr, uint8_t *dest, size_t len, bool stop);
 int i2c_writeto(i2c_t *i2c, uint16_t addr, const uint8_t *src, size_t len, bool stop);
 
+int i2c_find_peripheral(mp_obj_t id);
+
 #endif // MICROPY_INCLUDED_STM32_I2C_H

--- a/ports/stm32/machine_i2c.c
+++ b/ports/stm32/machine_i2c.c
@@ -210,39 +210,8 @@ mp_obj_t machine_hard_i2c_make_new(const mp_obj_type_t *type, size_t n_args, siz
     mp_arg_val_t args[MP_ARRAY_SIZE(allowed_args)];
     mp_arg_parse_all_kw_array(n_args, n_kw, all_args, MP_ARRAY_SIZE(allowed_args), allowed_args, args);
 
-    // work out i2c bus
-    int i2c_id = 0;
-    if (mp_obj_is_str(args[ARG_id].u_obj)) {
-        const char *port = mp_obj_str_get_str(args[ARG_id].u_obj);
-        if (0) {
-        #ifdef MICROPY_HW_I2C1_NAME
-        } else if (strcmp(port, MICROPY_HW_I2C1_NAME) == 0) {
-            i2c_id = 1;
-        #endif
-        #ifdef MICROPY_HW_I2C2_NAME
-        } else if (strcmp(port, MICROPY_HW_I2C2_NAME) == 0) {
-            i2c_id = 2;
-        #endif
-        #ifdef MICROPY_HW_I2C3_NAME
-        } else if (strcmp(port, MICROPY_HW_I2C3_NAME) == 0) {
-            i2c_id = 3;
-        #endif
-        #ifdef MICROPY_HW_I2C4_NAME
-        } else if (strcmp(port, MICROPY_HW_I2C4_NAME) == 0) {
-            i2c_id = 4;
-        #endif
-        } else {
-            mp_raise_msg_varg(&mp_type_ValueError, MP_ERROR_TEXT("I2C(%s) doesn't exist"), port);
-        }
-    } else {
-        i2c_id = mp_obj_get_int(args[ARG_id].u_obj);
-        if (i2c_id < 1 || i2c_id > MP_ARRAY_SIZE(machine_hard_i2c_obj)
-            || machine_hard_i2c_obj[i2c_id - 1].base.type == NULL) {
-            mp_raise_msg_varg(&mp_type_ValueError, MP_ERROR_TEXT("I2C(%d) doesn't exist"), i2c_id);
-        }
-    }
-
     // get static peripheral object
+    int i2c_id = i2c_find_peripheral(args[ARG_id].u_obj);
     machine_hard_i2c_obj_t *self = (machine_hard_i2c_obj_t *)&machine_hard_i2c_obj[i2c_id - 1];
 
     // here we would check the scl/sda pins and configure them, but it's not implemented

--- a/ports/stm32/machine_uart.c
+++ b/ports/stm32/machine_uart.c
@@ -345,6 +345,11 @@ STATIC mp_obj_t pyb_uart_make_new(const mp_obj_type_t *type, size_t n_args, size
         }
     }
 
+    // check if the UART is reserved for system use or not
+    if (MICROPY_HW_UART_IS_RESERVED(uart_id)) {
+        mp_raise_msg_varg(&mp_type_ValueError, MP_ERROR_TEXT("UART(%d) is reserved"), uart_id);
+    }
+
     pyb_uart_obj_t *self;
     if (MP_STATE_PORT(pyb_uart_obj_all)[uart_id - 1] == NULL) {
         // create new UART object

--- a/ports/stm32/mpconfigboard_common.h
+++ b/ports/stm32/mpconfigboard_common.h
@@ -127,6 +127,31 @@
 #define MICROPY_HW_FLASH_FS_LABEL "pybflash"
 #endif
 
+// Function to determine if the given can_id is reserved for system use or not.
+#ifndef MICROPY_HW_CAN_IS_RESERVED
+#define MICROPY_HW_CAN_IS_RESERVED(can_id) (false)
+#endif
+
+// Function to determine if the given i2c_id is reserved for system use or not.
+#ifndef MICROPY_HW_I2C_IS_RESERVED
+#define MICROPY_HW_I2C_IS_RESERVED(i2c_id) (false)
+#endif
+
+// Function to determine if the given spi_id is reserved for system use or not.
+#ifndef MICROPY_HW_SPI_IS_RESERVED
+#define MICROPY_HW_SPI_IS_RESERVED(spi_id) (false)
+#endif
+
+// Function to determine if the given tim_id is reserved for system use or not.
+#ifndef MICROPY_HW_TIM_IS_RESERVED
+#define MICROPY_HW_TIM_IS_RESERVED(tim_id) (false)
+#endif
+
+// Function to determine if the given uart_id is reserved for system use or not.
+#ifndef MICROPY_HW_UART_IS_RESERVED
+#define MICROPY_HW_UART_IS_RESERVED(uart_id) (false)
+#endif
+
 /*****************************************************************************/
 // General configuration
 

--- a/ports/stm32/pyb_can.c
+++ b/ports/stm32/pyb_can.c
@@ -203,6 +203,11 @@ STATIC mp_obj_t pyb_can_make_new(const mp_obj_type_t *type, size_t n_args, size_
         mp_raise_msg_varg(&mp_type_ValueError, MP_ERROR_TEXT("CAN(%d) doesn't exist"), can_idx);
     }
 
+    // check if the CAN is reserved for system use or not
+    if (MICROPY_HW_CAN_IS_RESERVED(can_idx)) {
+        mp_raise_msg_varg(&mp_type_ValueError, MP_ERROR_TEXT("CAN(%d) is reserved"), can_idx);
+    }
+
     pyb_can_obj_t *self;
     if (MP_STATE_PORT(pyb_can_obj_all)[can_idx - 1] == NULL) {
         self = m_new_obj(pyb_can_obj_t);

--- a/ports/stm32/pyb_i2c.c
+++ b/ports/stm32/pyb_i2c.c
@@ -668,39 +668,8 @@ STATIC mp_obj_t pyb_i2c_make_new(const mp_obj_type_t *type, size_t n_args, size_
     // check arguments
     mp_arg_check_num(n_args, n_kw, 1, MP_OBJ_FUN_ARGS_MAX, true);
 
-    // work out i2c bus
-    int i2c_id = 0;
-    if (mp_obj_is_str(args[0])) {
-        const char *port = mp_obj_str_get_str(args[0]);
-        if (0) {
-        #ifdef MICROPY_HW_I2C1_NAME
-        } else if (strcmp(port, MICROPY_HW_I2C1_NAME) == 0) {
-            i2c_id = 1;
-        #endif
-        #ifdef MICROPY_HW_I2C2_NAME
-        } else if (strcmp(port, MICROPY_HW_I2C2_NAME) == 0) {
-            i2c_id = 2;
-        #endif
-        #ifdef MICROPY_HW_I2C3_NAME
-        } else if (strcmp(port, MICROPY_HW_I2C3_NAME) == 0) {
-            i2c_id = 3;
-        #endif
-        #ifdef MICROPY_HW_I2C4_NAME
-        } else if (strcmp(port, MICROPY_HW_I2C4_NAME) == 0) {
-            i2c_id = 4;
-        #endif
-        } else {
-            mp_raise_msg_varg(&mp_type_ValueError, MP_ERROR_TEXT("I2C(%s) doesn't exist"), port);
-        }
-    } else {
-        i2c_id = mp_obj_get_int(args[0]);
-        if (i2c_id < 1 || i2c_id > MP_ARRAY_SIZE(pyb_i2c_obj)
-            || pyb_i2c_obj[i2c_id - 1].i2c == NULL) {
-            mp_raise_msg_varg(&mp_type_ValueError, MP_ERROR_TEXT("I2C(%d) doesn't exist"), i2c_id);
-        }
-    }
-
     // get I2C object
+    int i2c_id = i2c_find_peripheral(args[0]);
     const pyb_i2c_obj_t *i2c_obj = &pyb_i2c_obj[i2c_id - 1];
 
     if (n_args > 1 || n_kw > 0) {

--- a/ports/stm32/spi.c
+++ b/ports/stm32/spi.c
@@ -167,45 +167,52 @@ void spi_init0(void) {
 }
 
 int spi_find_index(mp_obj_t id) {
+    int spi_id;
     if (mp_obj_is_str(id)) {
         // given a string id
         const char *port = mp_obj_str_get_str(id);
         if (0) {
         #ifdef MICROPY_HW_SPI1_NAME
         } else if (strcmp(port, MICROPY_HW_SPI1_NAME) == 0) {
-            return 1;
+            spi_id = 1;
         #endif
         #ifdef MICROPY_HW_SPI2_NAME
         } else if (strcmp(port, MICROPY_HW_SPI2_NAME) == 0) {
-            return 2;
+            spi_id = 2;
         #endif
         #ifdef MICROPY_HW_SPI3_NAME
         } else if (strcmp(port, MICROPY_HW_SPI3_NAME) == 0) {
-            return 3;
+            spi_id = 3;
         #endif
         #ifdef MICROPY_HW_SPI4_NAME
         } else if (strcmp(port, MICROPY_HW_SPI4_NAME) == 0) {
-            return 4;
+            spi_id = 4;
         #endif
         #ifdef MICROPY_HW_SPI5_NAME
         } else if (strcmp(port, MICROPY_HW_SPI5_NAME) == 0) {
-            return 5;
+            spi_id = 5;
         #endif
         #ifdef MICROPY_HW_SPI6_NAME
         } else if (strcmp(port, MICROPY_HW_SPI6_NAME) == 0) {
-            return 6;
+            spi_id = 6;
         #endif
+        } else {
+            mp_raise_msg_varg(&mp_type_ValueError, MP_ERROR_TEXT("SPI(%s) doesn't exist"), port);
         }
-        mp_raise_msg_varg(&mp_type_ValueError, MP_ERROR_TEXT("SPI(%s) doesn't exist"), port);
     } else {
         // given an integer id
-        int spi_id = mp_obj_get_int(id);
-        if (spi_id >= 1 && spi_id <= MP_ARRAY_SIZE(spi_obj)
-            && spi_obj[spi_id - 1].spi != NULL) {
-            return spi_id;
+        spi_id = mp_obj_get_int(id);
+        if (spi_id < 1 || spi_id > MP_ARRAY_SIZE(spi_obj) || spi_obj[spi_id - 1].spi == NULL) {
+            mp_raise_msg_varg(&mp_type_ValueError, MP_ERROR_TEXT("SPI(%d) doesn't exist"), spi_id);
         }
-        mp_raise_msg_varg(&mp_type_ValueError, MP_ERROR_TEXT("SPI(%d) doesn't exist"), spi_id);
     }
+
+    // check if the SPI is reserved for system use or not
+    if (MICROPY_HW_SPI_IS_RESERVED(spi_id)) {
+        mp_raise_msg_varg(&mp_type_ValueError, MP_ERROR_TEXT("SPI(%d) is reserved"), spi_id);
+    }
+
+    return spi_id;
 }
 
 STATIC uint32_t spi_get_source_freq(SPI_HandleTypeDef *spi) {

--- a/ports/stm32/timer.c
+++ b/ports/stm32/timer.c
@@ -896,6 +896,11 @@ STATIC mp_obj_t pyb_timer_make_new(const mp_obj_type_t *type, size_t n_args, siz
         mp_raise_msg_varg(&mp_type_ValueError, MP_ERROR_TEXT("Timer(%d) doesn't exist"), tim_id);
     }
 
+    // check if the timer is reserved for system use or not
+    if (MICROPY_HW_TIM_IS_RESERVED(tim_id)) {
+        mp_raise_msg_varg(&mp_type_ValueError, MP_ERROR_TEXT("Timer(%d) is reserved"), tim_id);
+    }
+
     pyb_timer_obj_t *tim;
     if (MP_STATE_PORT(pyb_timer_obj_all)[tim_id - 1] == NULL) {
         // create new Timer object


### PR DESCRIPTION
If reserved, the peripheral cannot be accessed from Python.

TODO:
- support SPI
- support I2C
- support CAN