### PR TITLE
nrf/Makefile: Improved Black Magic Probe commands.

### DIFF
--- a/ports/nrf/Makefile
+++ b/ports/nrf/Makefile
@@ -450,7 +450,7 @@ $(BUILD)/$(OUTPUT_FILENAME).elf: $(OBJ)
 	$(Q)$(SIZE) $@
 
 # List of sources for qstr extraction
-SRC_QSTR += $(SRC_C) $(SRC_LIB) $(DRIVERS_SRC_C) $(SRC_BOARD_MODULES) $(SRC_MOD) 
+SRC_QSTR += $(SRC_C) $(SRC_LIB) $(DRIVERS_SRC_C) $(SRC_BOARD_MODULES) $(SRC_MOD)
 
 # Append any auto-generated sources that are needed by sources listed in
 # SRC_QSTR

--- a/ports/nrf/Makefile
+++ b/ports/nrf/Makefile
@@ -395,19 +395,19 @@ else ifeq ($(FLASHER), bmp)
 BMP_PORT ?= /dev/ttyACM0
 
 deploy: $(BUILD)/$(OUTPUT_FILENAME).elf
-	$(Q)$(GDB) \
+	$(Q)$(GDB) -nx --batch \
 	    -ex 'target extended-remote $(BMP_PORT)' \
 	    -ex 'monitor tpwr enable' \
 	    -ex 'monitor swdp_scan' \
 	    -ex 'attach 1' \
 	    -ex 'set mem inaccessible-by-default off' \
 	    -ex 'load' \
+	    -ex 'compare-sections' \
 	    -ex 'kill' \
-	    -ex 'quit' \
 	    $<
 
 sd: $(BUILD)/$(OUTPUT_FILENAME).elf
-	$(Q)$(GDB) \
+	$(Q)$(GDB) -nx --batch \
 	    -ex 'target extended-remote $(BMP_PORT)' \
 	    -ex 'monitor tpwr enable' \
 	    -ex 'monitor swdp_scan' \
@@ -415,10 +415,11 @@ sd: $(BUILD)/$(OUTPUT_FILENAME).elf
 	    -ex 'set mem inaccessible-by-default off' \
 	    -ex 'monitor erase_mass' \
 	    -ex 'load' \
+	    -ex 'compare-sections' \
 	    -ex 'file $(SOFTDEV_HEX)' \
 	    -ex 'load' \
+	    -ex 'compare-sections' \
 	    -ex 'kill' \
-	    -ex 'quit' \
 	    $<
 
 else ifeq ($(FLASHER), openocd)


### PR DESCRIPTION
Used batch mode to get rid of the confirmation prompt on flashing.
Used 'compare-sections' to verify flash.
Removed the unnecessary `quit` at the end.