### PR TITLE
stm32/Makefile: Change -O0 to -Og for DEBUG=1 builds.

### DIFF
--- a/ports/stm32/Makefile
+++ b/ports/stm32/Makefile
@@ -133,7 +133,7 @@ LDFLAGS += --gc-sections
 # Debugging/Optimization
 ifeq ($(DEBUG), 1)
 CFLAGS += -g -DPENDSV_DEBUG
-COPT = -O0
+COPT = -Og
 # Disable text compression in debug builds
 MICROPY_ROM_TEXT_COMPRESSION = 0
 else

--- a/ports/stm32/can.c
+++ b/ports/stm32/can.c
@@ -226,8 +226,8 @@ int can_receive(CAN_HandleTypeDef *can, int fifo, CanRxMsgTypeDef *msg, uint8_t 
 HAL_StatusTypeDef CAN_Transmit(CAN_HandleTypeDef *hcan, uint32_t Timeout) {
     uint32_t transmitmailbox;
     uint32_t tickstart;
-    uint32_t rqcpflag;
-    uint32_t txokflag;
+    uint32_t rqcpflag = 0;
+    uint32_t txokflag = 0;
 
     // Check the parameters
     assert_param(IS_CAN_IDTYPE(hcan->pTxMsg->IDE));

--- a/tools/ci.sh
+++ b/tools/ci.sh
@@ -200,7 +200,7 @@ function ci_stm32_nucleo_build {
     make ${MAKEOPTS} -C ports/stm32 BOARD=NUCLEO_F091RC
     make ${MAKEOPTS} -C ports/stm32 BOARD=NUCLEO_H743ZI CFLAGS_EXTRA='-DMICROPY_PY_THREAD=1'
     make ${MAKEOPTS} -C ports/stm32 BOARD=NUCLEO_L073RZ
-    make ${MAKEOPTS} -C ports/stm32 BOARD=NUCLEO_L476RG
+    make ${MAKEOPTS} -C ports/stm32 BOARD=NUCLEO_L476RG DEBUG=1
     make ${MAKEOPTS} -C ports/stm32 BOARD=NUCLEO_WB55
     make ${MAKEOPTS} -C ports/stm32/mboot BOARD=NUCLEO_WB55
 }


### PR DESCRIPTION
And assign variables in can.c to prevent warnings with such a build.  And also build a board in CI with DEBUG=1 enabled, to test this.

See #6653 