### PR TITLE
py/mpprint: Fix length calculation for strings with precision-modifier (v2)

### DIFF
--- a/ports/unix/coverage.c
+++ b/ports/unix/coverage.c
@@ -186,7 +186,7 @@ STATIC mp_obj_t extra_coverage(void) {
         mp_printf(&mp_plat_print, "%ld\n", 123); // long
         mp_printf(&mp_plat_print, "%lx\n", 0x123); // long hex
         mp_printf(&mp_plat_print, "%X\n", 0x1abcdef); // capital hex
-        mp_printf(&mp_plat_print, "%.2s %.3s\n", "abc", "abc"); // fixed string precision
+        mp_printf(&mp_plat_print, "%.2s %.3s '%4.4s' '%5.5q' '%.3q'\n", "abc", "abc", "abc", MP_QSTR_True, MP_QSTR_True); // fixed string precision
         mp_printf(&mp_plat_print, "%.*s\n", -1, "abc"); // negative string precision
         mp_printf(&mp_plat_print, "%b %b\n", 0, 1); // bools
         #ifndef NDEBUG

--- a/py/mpprint.c
+++ b/py/mpprint.c
@@ -484,10 +484,10 @@ int mp_vprintf(const mp_print_t *print, const char *fmt, va_list args) {
                 qstr qst = va_arg(args, qstr);
                 size_t len;
                 const char *str = (const char *)qstr_data(qst, &len);
-                if (prec < 0) {
-                    prec = len;
+                if (prec >= 0 && (size_t)prec < len) {
+                    len = prec;
                 }
-                chrs += mp_print_strn(print, str, prec, flags, fill, width);
+                chrs += mp_print_strn(print, str, len, flags, fill, width);
                 break;
             }
             case 's': {
@@ -499,10 +499,11 @@ int mp_vprintf(const mp_print_t *print, const char *fmt, va_list args) {
                     break;
                 }
                 #endif
-                if (prec < 0) {
-                    prec = strlen(str);
+                size_t len = strlen(str);
+                if (prec >= 0 && (size_t)prec < len) {
+                    len = prec;
                 }
-                chrs += mp_print_strn(print, str, prec, flags, fill, width);
+                chrs += mp_print_strn(print, str, len, flags, fill, width);
                 break;
             }
             case 'd': {

--- a/py/objstr.c
+++ b/py/objstr.c
@@ -123,10 +123,10 @@ STATIC void str_print(const mp_print_t *print, mp_obj_t self_in, mp_print_kind_t
     bool is_bytes = true;
     #endif
     if (kind == PRINT_RAW || (!MICROPY_PY_BUILTINS_STR_UNICODE && kind == PRINT_STR && !is_bytes)) {
-        mp_printf(print, "%.*s", str_len, str_data);
+        print->print_strn(print->data, (const char *)str_data, str_len);
     } else {
         if (is_bytes) {
-            mp_print_str(print, "b");
+            print->print_strn(print->data, "b", 1);
         }
         mp_str_print_quoted(print, str_data, str_len, is_bytes);
     }

--- a/py/objstrunicode.c
+++ b/py/objstrunicode.c
@@ -92,7 +92,7 @@ STATIC void uni_print(const mp_print_t *print, mp_obj_t self_in, mp_print_kind_t
     }
     #endif
     if (kind == PRINT_STR) {
-        mp_printf(print, "%.*s", str_len, str_data);
+        print->print_strn(print->data, (const char *)str_data, str_len);
     } else {
         uni_print_quoted(print, str_data, str_len);
     }

--- a/tests/unix/extra_coverage.py.exp
+++ b/tests/unix/extra_coverage.py.exp
@@ -4,7 +4,7 @@
 123
 123
 1ABCDEF
-ab abc
+ab abc ' abc' ' True' 'Tru'
 
 false true
 (null)


### PR DESCRIPTION
This is #6563 rebased on latest master to test CI.