### PR TITLE
extmod/modubinascii: Update code, docs for hexlify now CPython has sep.

### DIFF
--- a/docs/library/ubinascii.rst
+++ b/docs/library/ubinascii.rst
@@ -14,13 +14,11 @@ Functions
 
 .. function:: hexlify(data, [sep])
 
-   Convert binary data to hexadecimal representation. Returns bytes string.
+   Convert the bytes in the *data* object to a hexadecimal representation.
+   Returns a bytes object.
 
-   .. admonition:: Difference to CPython
-      :class: attention
-
-      If additional argument, *sep* is supplied, it is used as a separator
-      between hexadecimal values.
+   If the additional argument *sep* is supplied it is used as a separator
+   between hexadecimal values.
 
 .. function:: unhexlify(data)
 

--- a/extmod/modubinascii.c
+++ b/extmod/modubinascii.c
@@ -34,8 +34,8 @@
 #if MICROPY_PY_UBINASCII
 
 STATIC mp_obj_t mod_binascii_hexlify(size_t n_args, const mp_obj_t *args) {
-    // Second argument is for an extension to allow a separator to be used
-    // between values.
+    // First argument is the data to convert.
+    // Second argument is an optional separator to be used between values.
     const char *sep = NULL;
     mp_buffer_info_t bufinfo;
     mp_get_buffer_raise(args[0], &bufinfo, MP_BUFFER_READ);


### PR DESCRIPTION
Since CPython 3.8 the optional "sep" argument to hexlify is officially supported, so update comments in the code and the docs to reflect this.
