### PR TITLE
unix/modtime: Fix time() precision on unix ports with non-double floats.

### DIFF
--- a/ports/unix/modtime.c
+++ b/ports/unix/modtime.c
@@ -67,7 +67,7 @@ static inline int msec_sleep_tv(struct timeval *tv) {
 #endif
 
 STATIC mp_obj_t mod_time_time(void) {
-    #if ((MICROPY_PY_BUILTINS_FLOAT) && (MICROPY_FLOAT_IMPL == MICROPY_FLOAT_IMPL_DOUBLE))
+    #if MICROPY_PY_BUILTINS_FLOAT && MICROPY_FLOAT_IMPL == MICROPY_FLOAT_IMPL_DOUBLE
     struct timeval tv;
     gettimeofday(&tv, NULL);
     mp_float_t val = tv.tv_sec + (mp_float_t)tv.tv_usec / 1000000;
@@ -137,7 +137,7 @@ STATIC mp_obj_t mod_time_gm_local_time(size_t n_args, const mp_obj_t *args, stru
     if (n_args == 0) {
         t = time(NULL);
     } else {
-        #if ((MICROPY_PY_BUILTINS_FLOAT) && (MICROPY_FLOAT_IMPL == MICROPY_FLOAT_IMPL_DOUBLE))
+        #if MICROPY_PY_BUILTINS_FLOAT && MICROPY_FLOAT_IMPL == MICROPY_FLOAT_IMPL_DOUBLE
         mp_float_t val = mp_obj_get_float(args[0]);
         t = (time_t)MICROPY_FLOAT_C_FUN(trunc)(val);
         #else

--- a/ports/unix/modtime.c
+++ b/ports/unix/modtime.c
@@ -67,7 +67,7 @@ static inline int msec_sleep_tv(struct timeval *tv) {
 #endif
 
 STATIC mp_obj_t mod_time_time(void) {
-    #if MICROPY_PY_BUILTINS_FLOAT
+    #if ((MICROPY_PY_BUILTINS_FLOAT) && (MICROPY_FLOAT_IMPL == MICROPY_FLOAT_IMPL_DOUBLE))
     struct timeval tv;
     gettimeofday(&tv, NULL);
     mp_float_t val = tv.tv_sec + (mp_float_t)tv.tv_usec / 1000000;
@@ -137,7 +137,7 @@ STATIC mp_obj_t mod_time_gm_local_time(size_t n_args, const mp_obj_t *args, stru
     if (n_args == 0) {
         t = time(NULL);
     } else {
-        #if MICROPY_PY_BUILTINS_FLOAT
+        #if ((MICROPY_PY_BUILTINS_FLOAT) && (MICROPY_FLOAT_IMPL == MICROPY_FLOAT_IMPL_DOUBLE))
         mp_float_t val = mp_obj_get_float(args[0]);
         t = (time_t)MICROPY_FLOAT_C_FUN(trunc)(val);
         #else

--- a/tests/extmod/utime_res.py
+++ b/tests/extmod/utime_res.py
@@ -1,0 +1,65 @@
+# test utime resolutions
+
+try:
+    import utime
+except ImportError:
+    print("SKIP")
+    raise SystemExit
+
+
+def gmtime_time():
+    return utime.gmtime(utime.time())
+
+
+def localtime_time():
+    return utime.localtime(utime.time())
+
+
+def test():
+    TEST_TIME = 2500
+    EXPECTED_MAP = (
+        # (function name, min. number of results in 2.5 sec)
+        ("time", 3),
+        ("gmtime", 3),
+        ("localtime", 3),
+        ("gmtime_time", 3),
+        ("localtime_time", 3),
+        ("ticks_ms", 15),
+        ("ticks_us", 15),
+        ("ticks_ns", 15),
+        ("ticks_cpu", 15),
+    )
+
+    # call time functions
+    results_map = {}
+    end_time = utime.ticks_ms() + TEST_TIME
+    while utime.ticks_diff(end_time, utime.ticks_ms()) > 0:
+        utime.sleep_ms(100)
+        for func_name, _ in EXPECTED_MAP:
+            try:
+                time_func = getattr(utime, func_name, None) or globals()[func_name]
+                now = time_func()  # may raise AttributeError
+            except (KeyError, AttributeError):
+                continue
+            try:
+                results_map[func_name].add(now)
+            except KeyError:
+                results_map[func_name] = {now}
+
+    # check results
+    for func_name, min_len in EXPECTED_MAP:
+        print("Testing %s" % func_name)
+        results = results_map.get(func_name)
+        if results is None:
+            pass
+        elif func_name == "ticks_cpu" and results == {0}:
+            # ticks_cpu() returns 0 on some ports (e.g. unix)
+            pass
+        elif len(results) < min_len:
+            print(
+                "%s() returns %s result%s in %s ms, expecting >= %s"
+                % (func_name, len(results), "s"[: len(results) != 1], TEST_TIME, min_len)
+            )
+
+
+test()

--- a/tests/extmod/utime_res.py.exp
+++ b/tests/extmod/utime_res.py.exp
@@ -1,0 +1,9 @@
+Testing time
+Testing gmtime
+Testing localtime
+Testing gmtime_time
+Testing localtime_time
+Testing ticks_ms
+Testing ticks_us
+Testing ticks_ns
+Testing ticks_cpu


### PR DESCRIPTION
With MICROPY_FLOAT_IMPL_FLOAT the results of utime.time(), gmtime() and localtime() change only every 129 seconds. As one consequence tests/extmod/vfs_lfs_mtime.py will fail on a unix port with LFS support.

With this patch these functions only return floats if MICROPY_FLOAT_IMPL_DOUBLE is used. Otherwise they return integers.

The new test detects the problem, and it also checks the precision of other utime functions. Please tell me if you'd prefer the latter to be removed. It is not mandatory for my fix.
