### PR TITLE
teensy: Fix build errors and warnings and enable -Werror.

### DIFF
--- a/ports/teensy/Makefile
+++ b/ports/teensy/Makefile
@@ -38,7 +38,7 @@ INC += -I$(TOP)/ports/stm32
 INC += -I$(BUILD)
 INC += -Icore
 
-CFLAGS = $(INC) -Wall -Wpointer-arith -std=gnu99 -nostdlib $(CFLAGS_CORTEX_M4)
+CFLAGS = $(INC) -Wall -Wpointer-arith -Werror -std=c99 -nostdlib $(CFLAGS_CORTEX_M4)
 LDFLAGS = -nostdlib -T mk20dx256.ld -msoft-float -mfloat-abi=soft
 
 ifeq ($(USE_ARDUINO_TOOLCHAIN),1)

--- a/ports/teensy/modpyb.c
+++ b/ports/teensy/modpyb.c
@@ -44,7 +44,6 @@
 #include "usrsw.h"
 #include "rng.h"
 #include "uart.h"
-#include "adc.h"
 #include "storage.h"
 #include "sdcard.h"
 #include "accel.h"

--- a/ports/teensy/mpconfigport.h
+++ b/ports/teensy/mpconfigport.h
@@ -72,10 +72,6 @@ typedef long mp_off_t;
 // value from disable_irq back to enable_irq.  If you really need
 // to know the machine-specific values, see irq.h.
 
-#ifndef __disable_irq
-#define __disable_irq() __asm__ volatile ("CPSID i");
-#endif
-
 __attribute__((always_inline)) static inline uint32_t __get_PRIMASK(void) {
     uint32_t result;
     __asm volatile ("MRS %0, primask" : "=r" (result));
@@ -92,7 +88,7 @@ __attribute__((always_inline)) static inline void enable_irq(mp_uint_t state) {
 
 __attribute__((always_inline)) static inline mp_uint_t disable_irq(void) {
     mp_uint_t state = __get_PRIMASK();
-    __disable_irq();
+    __asm__ volatile ("CPSID i");
     return state;
 }
 


### PR DESCRIPTION
Changes are:
- Remove include of stm32's adc.h because it was recently changed and is
  no longer compatible with teensy (and not used anyway).
- Remove define of __disable_irq in mpconfigport.h because it was clashing
  with an equivalent definition in core/mk20dx128.h.
- Add -Werror to CFLAGS, and change -std=gnu99 to -std=c99.