### PR TITLE
ports/cc3200: Fix debug build

### DIFF
--- a/ports/cc3200/application.mk
+++ b/ports/cc3200/application.mk
@@ -182,7 +182,7 @@ ifeq ($(BTYPE), release)
 CFLAGS += -DNDEBUG
 else
 ifeq ($(BTYPE), debug)
-CFLAGS += -DNDEBUG
+CFLAGS += -DDEBUG
 else
 $(error Invalid BTYPE specified)
 endif

--- a/ports/cc3200/mods/modmachine.c
+++ b/ports/cc3200/mods/modmachine.c
@@ -26,6 +26,7 @@
  */
 
 #include <stdint.h>
+#include <stdio.h>
 
 #include "py/runtime.h"
 #include "py/mphal.h"


### PR DESCRIPTION
* Fix a typo in the Makefile that prevented the debug build to be actually
  enabled when BTYPE=debug is used.
* Add a missing header in modmachine.c that is used when a debug build is
  created.