### PR TITLE
extmod/modurandom.c: getrandombits() method has proper error message.

### DIFF
--- a/examples/getmorebits.py
+++ b/examples/getmorebits.py
@@ -1,0 +1,13 @@
+import random
+
+
+def getmorebits(bits: int) -> int:
+    n = bits // 32
+    k = 0
+    d = 0
+    while k < n:
+        d |= random.getrandbits(32) << (k * 32)
+        k += 1
+    d |= random.getrandbits(bits % 32) << (k * 32)
+
+    return d

--- a/examples/getmorebits.py
+++ b/examples/getmorebits.py
@@ -2,12 +2,18 @@ import random
 
 
 def getmorebits(bits: int) -> int:
+    """
+    :param bits: The number of bits to generate.
+    :return: The resulting integer.
+    """
+
     n = bits // 32
-    k = 0
     d = 0
-    while k < n:
-        d |= random.getrandbits(32) << (k * 32)
-        k += 1
-    d |= random.getrandbits(bits % 32) << (k * 32)
+    for i in range(n):
+        d |= getrandbits(32) << (i * 32)
+
+    r = bits % 32
+    if bits >= 1:
+        d |= getrandbits(bits % 32) << (n * 32)
 
     return d

--- a/extmod/modurandom.c
+++ b/extmod/modurandom.c
@@ -88,7 +88,7 @@ STATIC uint32_t yasmarang_randbelow(uint32_t n) {
 STATIC mp_obj_t mod_urandom_getrandbits(mp_obj_t num_in) {
     int n = mp_obj_get_int(num_in);
     if (n > 32 || n == 0) {
-        mp_raise_ValueError(NULL);
+        mp_raise_ValueError(MP_ERROR_TEXT("The number of bits must be between 1 and 32."));
     }
     uint32_t mask = ~0;
     // Beware of C undefined behavior when shifting by >= than bit size

--- a/tests/cpydiff/modules_random_getrandbits.py
+++ b/tests/cpydiff/modules_random_getrandbits.py
@@ -1,0 +1,12 @@
+"""
+categories: Modules,random
+description: ``getrandbits`` method can only return a maximum of 32 bits at a time.
+cause: unknown
+workaround: If you need a number that's larger than 32bits and want to use getrandbits use the code below.
+"""
+
+import random
+
+
+x = random.getrandbits(64)
+print("{} is {} bits".format(x))

--- a/tests/cpydiff/modules_random_randint.py
+++ b/tests/cpydiff/modules_random_randint.py
@@ -1,0 +1,12 @@
+"""
+categories: Modules,random
+description: ``randint`` method can only return an integer that is at most the native word size.
+cause: Uknown
+workaround: If you need integers larger than native wordsize call randint multiple times and shift result.
+"""
+
+import random
+
+
+x = random.randint(2 ** 128 - 1, 2 ** 128)
+print("x={}".format(x))

--- a/tests/cpydiff/types_int_bit_length.py
+++ b/tests/cpydiff/types_int_bit_length.py
@@ -6,4 +6,4 @@ workaround: Avoid using this method on micropython.
 """
 
 x = 255
-print("{} is {} bits long.".format(x,x.bit_length())
+print("{} is {} bits long.".format(x,x.bit_length()))

--- a/tests/cpydiff/types_int_bit_length.py
+++ b/tests/cpydiff/types_int_bit_length.py
@@ -1,0 +1,9 @@
+"""
+categories: Types,int
+description: ``bit_length`` method doesn't exist.
+cause: bit_length method is not implemented.
+workaround: Avoid using this method on micropython.
+"""
+
+x = 255
+print("{} is {} bits long.".format(x,x.bit_length())


### PR DESCRIPTION
tests/cpydiff: Random module differences for getrandbits and randint.
tests/cpydiff: Int type describes lack of bit length.
examples/getmorebits.py: Example function to get arbritrary number of bits.

extmod/modurandom.c
The random module's getrandbits() method didn't give a proper error
message when calling it with a value that was outside of the range
of 1-32. Now instead of simply giving a ValueError it gives an error
message that states that the number of bits must be between 1 and 32.

tests/cpydiff:modules_random_getrandbits.py;modules_random_randint.py
Since the random module's methods getrandbits() and randint() differe
from the CPython random module's version of the methods tests have been
added. For getrandbits the relevant documentation is shown and added to
the docs. The same is given for randint method so that the information
is more easily found.

examples/getmorebits.py
This function is the example function referenced in the
modules_random_getrandbits.py workaround. It allows getting an arbitrary
number of random bits.

tests/cpydiff/types_int_bit_length.py
Finally since the Int object lacks the bit_length() method ther is a test
for that method also to include within the docs. It now shows the person
what they can see on micropython compared to CPython.


This commit also fixes some of the gripes I had talked about in #6712 by making it so that getrandbits() actually returns an error messsage instead of NULL. Further the CPython differences are now also listed that I had talked about wishing to have been done.