### PR TITLE
tests/cpydiff: Random module differences for getrandbits and randint.

### DIFF
--- a/examples/getmorebits.py
+++ b/examples/getmorebits.py
@@ -1,0 +1,19 @@
+import random
+
+
+def getmorebits(bits: int) -> int:
+    """
+    :param bits: The number of bits to generate.
+    :return: The resulting integer.
+    """
+
+    n = bits // 32
+    d = 0
+    for i in range(n):
+        d |= getrandbits(32) << (i * 32)
+
+    r = bits % 32
+    if bits:
+        d |= getrandbits(bits % 32) << (n * 32)
+
+    return d

--- a/examples/getmorebits.py
+++ b/examples/getmorebits.py
@@ -1,4 +1,4 @@
-import random
+from random import getrandbits
 
 
 def getmorebits(bits: int) -> int:
@@ -13,7 +13,7 @@ def getmorebits(bits: int) -> int:
         d |= getrandbits(32) << (i * 32)
 
     r = bits % 32
-    if bits:
-        d |= getrandbits(bits % 32) << (n * 32)
+    if r >= 1:
+        d |= getrandbits(r) << (n * 32)
 
     return d

--- a/extmod/modurandom.c
+++ b/extmod/modurandom.c
@@ -88,7 +88,7 @@ STATIC uint32_t yasmarang_randbelow(uint32_t n) {
 STATIC mp_obj_t mod_urandom_getrandbits(mp_obj_t num_in) {
     int n = mp_obj_get_int(num_in);
     if (n > 32 || n == 0) {
-        mp_raise_ValueError(NULL);
+        mp_raise_ValueError(MP_ERROR_TEXT("The number of bits must be between 1 and 32."));
     }
     uint32_t mask = ~0;
     // Beware of C undefined behavior when shifting by >= than bit size

--- a/tests/cpydiff/modules_random_getrandbits.py
+++ b/tests/cpydiff/modules_random_getrandbits.py
@@ -1,0 +1,12 @@
+"""
+categories: Modules,random
+description: ``getrandbits`` method can only return a maximum of 32 bits at a time.
+cause: PRNG's internal state is only 32bits so it can only return a maximum of 32 bits of data at a time.
+workaround: If you need a number that has more than 32bits then utilize a function like getmorebits from the examples folder.
+"""
+
+import random
+
+
+x = random.getrandbits(64)
+print("{}".format(x))

--- a/tests/cpydiff/modules_random_randint.py
+++ b/tests/cpydiff/modules_random_randint.py
@@ -1,0 +1,12 @@
+"""
+categories: Modules,random
+description: ``randint`` method can only return an integer that is at most the native word size.
+cause: PRNG is only able to generate 32bits of state at a time. The result is then cast into a native sized int instead of a full int object.
+workaround: If you need integers larger than native wordsize use an approach like that seen in ```getmorebits.py``` from the examples folder.
+"""
+
+import random
+
+
+x = random.randint(2 ** 128 - 1, 2 ** 128)
+print("x={}".format(x))

--- a/tests/cpydiff/types_int_bit_length.py
+++ b/tests/cpydiff/types_int_bit_length.py
@@ -1,0 +1,9 @@
+"""
+categories: Types,int
+description: ``bit_length`` method doesn't exist.
+cause: bit_length method is not implemented.
+workaround: Avoid using this method on micropython.
+"""
+
+x = 255
+print("{} is {} bits long.".format(x, x.bit_length()))


### PR DESCRIPTION
tests/cpydiff: Random module differences for getrandbits and randint.
tests/cpydiff: Int type describes lack of bit length.
examples/getmorebits.py: Example function to get arbritrary number of bits.

extmod/modurandom.c
The random module's getrandbits() method didn't give a proper error
message when calling it with a value that was outside of the range
of 1-32. Now instead of simply giving a ValueError it gives an error
message that states that the number of bits must be between 1 and 32.

tests/cpydiff:modules_random_getrandbits.py;modules_random_randint.py
Since the random module's methods getrandbits() and randint() differe
from the CPython random module's version of the methods tests have been
added. For getrandbits the relevant documentation is shown and added to
the docs. The same is given for randint method so that the information
is more easily found.

examples/getmorebits.py
This function is the example function referenced in the
modules_random_getrandbits.py workaround. It allows getting an arbitrary
number of random bits.

tests/cpydiff/types_int_bit_length.py
Finally since the Int object lacks the bit_length() method ther is a test
for that method also to include within the docs. It now shows the person
what they can see on micropython compared to CPython.


This commit also fixes some of the gripes I had talked about in #6712 by making it so that getrandbits() actually returns an error messsage instead of NULL. Further the CPython differences are now also listed that I had talked about wishing to have been done.