### PR TITLE
tools/ci.sh: Update zephyr docker image to v0.11.13.

### DIFF
--- a/tools/ci.sh
+++ b/tools/ci.sh
@@ -455,14 +455,14 @@ function ci_windows_build {
 # ports/zephyr
 
 function ci_zephyr_setup {
-    docker pull zephyrprojectrtos/ci:v0.11.8
+    docker pull zephyrprojectrtos/ci:v0.11.13
     docker run --name zephyr-ci -d -it \
       -v "$(pwd)":/micropython \
-      -e ZEPHYR_SDK_INSTALL_DIR=/opt/sdk/zephyr-sdk-0.11.3 \
+      -e ZEPHYR_SDK_INSTALL_DIR=/opt/sdk/zephyr-sdk-0.12.2 \
       -e ZEPHYR_TOOLCHAIN_VARIANT=zephyr \
       -e ZEPHYR_BASE=/zephyrproject/zephyr \
       -w /micropython/ports/zephyr \
-      zephyrprojectrtos/ci:v0.11.8
+      zephyrprojectrtos/ci:v0.11.13
     docker ps -a
 }
 


### PR DESCRIPTION
Updates the zephyr docker image to the latest, v0.11.13. This updates CI
to use zephyr SDK v0.12.2 and GCC v10.2.0 for the zephyr port.

Signed-off-by: Maureen Helm <maureen.helm@nxp.com>