### PR TITLE
set correct UART pins on STM32F429DISC

### DIFF
--- a/ports/stm32/boards/STM32F429DISC/mpconfigboard.h
+++ b/ports/stm32/boards/STM32F429DISC/mpconfigboard.h
@@ -19,8 +19,12 @@
 // UART config
 #define MICROPY_HW_UART1_TX     (pin_A9)
 #define MICROPY_HW_UART1_RX     (pin_A10)
-#define MICROPY_HW_UART2_TX     (pin_D8)
-#define MICROPY_HW_UART2_RX     (pin_D9)
+#define MICROPY_HW_UART2_TX     (pin_D5)
+#define MICROPY_HW_UART2_RX     (pin_D6)
+#define MICROPY_HW_UART3_TX     (pin_C10)
+#define MICROPY_HW_UART3_RX     (pin_C11)
+#define MICROPY_HW_UART6_TX     (pin_C6)
+#define MICROPY_HW_UART6_RX     (pin_C7)
 
 // I2C busses
 #define MICROPY_HW_I2C3_SCL (pin_A8)


### PR DESCRIPTION
I discovered bug, when I was trying to initialize UART(2) on board STM32F429DISC. It just displayed error message "ValueError: UART(2) doesn't exist", but that's not true at all. So I discovered, that in function `pin_find_af` in file `ports/stm32/pin_named_pins.c`, you are comparing `af->unit` with `unit`, and when not a single one equals you return NULL, and so it makes init fail. So I corrected UART pin definitions in `mpconfigboard.h` to make it equal with definitions in `stm32f429_af.csv`. And now it works not only UART(2), but also UART(3) and UART(6).