### PR TITLE
py/gc: Shouldn't include mpconfig.h and misc.h in gc.h

### DIFF
--- a/ports/esp8266/gccollect.c
+++ b/ports/esp8266/gccollect.c
@@ -26,6 +26,7 @@
 
 #include <stdio.h>
 
+#include "py/mpconfig.h"
 #include "py/gc.h"
 #include "gccollect.h"
 

--- a/py/gc.h
+++ b/py/gc.h
@@ -27,9 +27,7 @@
 #define MICROPY_INCLUDED_PY_GC_H
 
 #include <stdint.h>
-
-#include "py/mpconfig.h"
-#include "py/misc.h"
+#include <stdbool.h>
 
 void gc_init(void *start, void *end);
 


### PR DESCRIPTION
since gc.h don't reference any symbol from these header files
