### PR TITLE
all: Use compile-time qstr when possible.

### DIFF
--- a/lib/utils/pyexec.c
+++ b/lib/utils/pyexec.c
@@ -546,12 +546,6 @@ int pyexec_friendly_repl(void) {
     vstr_t line;
     vstr_init(&line, 32);
 
-    #if defined(USE_HOST_MODE) && MICROPY_HW_HAS_LCD
-    // in host mode, we enable the LCD for the repl
-    mp_obj_t lcd_o = mp_call_function_0(mp_load_name(qstr_from_str("LCD")));
-    mp_call_function_1(mp_load_attr(lcd_o, qstr_from_str("light")), mp_const_true);
-    #endif
-
 friendly_repl_reset:
     mp_hal_stdout_tx_str("MicroPython " MICROPY_GIT_TAG " on " MICROPY_BUILD_DATE "; " MICROPY_HW_BOARD_NAME " with " MICROPY_HW_MCU_NAME "\r\n");
     #if MICROPY_PY_BUILTINS_HELP

--- a/ports/unix/main.c
+++ b/ports/unix/main.c
@@ -532,8 +532,8 @@ MP_NOINLINE int main_(int argc, char **argv) {
     {
         MP_DECLARE_CONST_FUN_OBJ_0(extra_coverage_obj);
         MP_DECLARE_CONST_FUN_OBJ_0(extra_cpp_coverage_obj);
-        mp_store_global(QSTR_FROM_STR_STATIC("extra_coverage"), MP_OBJ_FROM_PTR(&extra_coverage_obj));
-        mp_store_global(QSTR_FROM_STR_STATIC("extra_cpp_coverage"), MP_OBJ_FROM_PTR(&extra_cpp_coverage_obj));
+        mp_store_global(MP_QSTR_extra_coverage, MP_OBJ_FROM_PTR(&extra_coverage_obj));
+        mp_store_global(MP_QSTR_extra_cpp_coverage, MP_OBJ_FROM_PTR(&extra_cpp_coverage_obj));
     }
     #endif
 
@@ -546,9 +546,9 @@ MP_NOINLINE int main_(int argc, char **argv) {
     // test_obj.attr = 42
     //
     // mp_obj_t test_class_type, test_class_instance;
-    // test_class_type = mp_obj_new_type(QSTR_FROM_STR_STATIC("TestClass"), mp_const_empty_tuple, mp_obj_new_dict(0));
-    // mp_store_name(QSTR_FROM_STR_STATIC("test_obj"), test_class_instance = mp_call_function_0(test_class_type));
-    // mp_store_attr(test_class_instance, QSTR_FROM_STR_STATIC("attr"), mp_obj_new_int(42));
+    // test_class_type = mp_obj_new_type(qstr_from_str("TestClass"), mp_const_empty_tuple, mp_obj_new_dict(0));
+    // mp_store_name(qstr_from_str("test_obj"), test_class_instance = mp_call_function_0(test_class_type));
+    // mp_store_attr(test_class_instance, qstr_from_str("attr"), mp_obj_new_int(42));
 
     /*
     printf("bytes:\n");

--- a/py/qstr.h
+++ b/py/qstr.h
@@ -32,7 +32,7 @@
 // See qstrdefs.h for a list of qstr's that are available as constants.
 // Reference them as MP_QSTR_xxxx.
 //
-// Note: it would be possible to define MP_QSTR_xxx as qstr_from_str_static("xxx")
+// Note: it would be possible to define MP_QSTR_xxx as qstr_from_str("xxx")
 // for qstrs that are referenced this way, but you don't want to have them in ROM.
 
 // first entry in enum will be MP_QSTRnull=0, which indicates invalid/no qstr
@@ -55,7 +55,6 @@ typedef struct _qstr_pool_t {
     const byte *qstrs[];
 } qstr_pool_t;
 
-#define QSTR_FROM_STR_STATIC(s) (qstr_from_strn((s), strlen(s)))
 #define QSTR_TOTAL() (MP_STATE_VM(last_pool)->total_prev_len + MP_STATE_VM(last_pool)->len)
 
 void qstr_init(void);


### PR DESCRIPTION
For consistency qstr_from_str should be used for strings
known at runtime only.