### PR TITLE
tests: Change default Python command used on Windows.

### DIFF
--- a/ports/windows/README.md
+++ b/ports/windows/README.md
@@ -90,6 +90,10 @@ Running the tests
 This is similar for all ports:
 
     cd ../../tests
+    python ./run-tests
+
+Though when running on Cygwin and using Cygwin's Python installation you'll need:
+
     python3 ./run-tests
 
 Depending on the combination of platform and Python version used it might be

--- a/ports/windows/msvc/genhdr.targets
+++ b/ports/windows/msvc/genhdr.targets
@@ -14,6 +14,7 @@
     <PyQstrDefs>$(PySrcDir)qstrdefs.h</PyQstrDefs>
     <QstrDefsCollected>$(DestDir)qstrdefscollected.h</QstrDefsCollected>
     <QstrGen>$(DestDir)qstrdefs.generated.h</QstrGen>
+    <PyPython Condition="'$(PyPython)' == ''">$(MICROPY_CPYTHON3)</PyPython>
     <PyPython Condition="'$(PyPython)' == ''">python</PyPython>
     <CLToolExe Condition="'$(CLToolExe)' == ''">cl.exe</CLToolExe>
     <PyClTool>$([System.IO.Path]::Combine(`$(CLToolPath)`, `$(CLToolExe)`))</PyClTool>

--- a/tests/run-tests
+++ b/tests/run-tests
@@ -20,7 +20,7 @@ def base_path(*p):
 # is of lower version, you can point MICROPY_CPYTHON3 environment var
 # to the correct executable.
 if os.name == 'nt':
-    CPYTHON3 = os.getenv('MICROPY_CPYTHON3', 'python3.exe')
+    CPYTHON3 = os.getenv('MICROPY_CPYTHON3', 'python')
     MICROPYTHON = os.getenv('MICROPY_MICROPYTHON', base_path('../ports/windows/micropython.exe'))
 else:
     CPYTHON3 = os.getenv('MICROPY_CPYTHON3', 'python3')


### PR DESCRIPTION
Default to just calling python since that is the most commonly
available: the official installer from python.org, anaconda,
msys2, chocolatey, ... all result in python being available
but not python3 (except for msys2).  On the other hand the only
system which does not have a python command by default seems to
be Cygwin, but we should not focus on what is likely the least
common usage scenario.