### PR TITLE
Enable PDF doc generation

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -47,7 +47,7 @@ This can be achieved with:
 
     make latexpdf
 
-but require rather complete install of LaTeX with various extensions. On
-Debian/Ubuntu, try (500MB+ download):
+but requires a rather complete install of LaTeX with various extensions. On
+Debian/Ubuntu, try (1GB+ download):
 
-    apt-get install texlive-latex-recommended texlive-latex-extra
+    apt install texlive-latex-recommended texlive-latex-extra texlive-xetex texlive-fonts-extra cm-super xindy

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -259,6 +259,9 @@ latex_documents = [
 # If false, no module index is generated.
 #latex_domain_indices = True
 
+# Enable better Unicode support so that `make latexpdf` doesn't fail
+latex_engine = "xelatex"
+
 
 # -- Options for manual page output ---------------------------------------
 


### PR DESCRIPTION
`make latexpdf` failed because there were Unicode Greek characters in the documentation and the default processor (pdflatex) couldn't parse them. Changing the LaTeX engine to XeLaTeX fixes this, at the cost of an even larger TeX Live system download.

Updates one line in sphinx conf.py, and updated Debian packages are given in the README.