### PR TITLE
esp32: make machine.soft_reset() work in main.py

### DIFF
--- a/ports/esp32/main.c
+++ b/ports/esp32/main.c
@@ -77,6 +77,7 @@ void mp_task(void *pvParameter) {
     mp_thread_init(pxTaskGetStackStart(NULL), MP_TASK_STACK_SIZE / sizeof(uintptr_t));
     #endif
     uart_init();
+    machine_init();
 
     // TODO: CONFIG_SPIRAM_SUPPORT is for 3.3 compatibility, remove after move to 4.0.
     #if CONFIG_ESP32_SPIRAM_SUPPORT || CONFIG_SPIRAM_SUPPORT
@@ -122,7 +123,10 @@ soft_reset:
     pyexec_frozen_module("_boot.py");
     pyexec_file_if_exists("boot.py");
     if (pyexec_mode_kind == PYEXEC_MODE_FRIENDLY_REPL) {
-        pyexec_file_if_exists("main.py");
+        int ret = pyexec_file_if_exists("main.py");
+        if (ret & PYEXEC_FORCED_EXIT) {
+            goto soft_reset_exit;
+        }
     }
 
     for (;;) {
@@ -138,6 +142,8 @@ soft_reset:
             }
         }
     }
+
+soft_reset_exit:
 
     #if MICROPY_BLUETOOTH_NIMBLE
     mp_bluetooth_deinit();
@@ -155,6 +161,7 @@ soft_reset:
 
     // deinitialise peripherals
     machine_pins_deinit();
+    machine_deinit();
     usocket_events_deinit();
 
     mp_deinit();

--- a/ports/esp32/modmachine.c
+++ b/ports/esp32/modmachine.c
@@ -65,6 +65,8 @@ typedef enum {
     MP_SOFT_RESET
 } reset_reason_t;
 
+STATIC bool is_soft_reset = 0;
+
 STATIC mp_obj_t machine_freq(size_t n_args, const mp_obj_t *args) {
     if (n_args == 0) {
         // get
@@ -146,6 +148,9 @@ STATIC mp_obj_t machine_deepsleep(size_t n_args, const mp_obj_t *pos_args, mp_ma
 STATIC MP_DEFINE_CONST_FUN_OBJ_KW(machine_deepsleep_obj, 0,  machine_deepsleep);
 
 STATIC mp_obj_t machine_reset_cause(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
+    if (is_soft_reset) {
+        return MP_OBJ_NEW_SMALL_INT(MP_SOFT_RESET);
+    }
     switch (esp_reset_reason()) {
         case ESP_RST_POWERON:
         case ESP_RST_BROWNOUT:
@@ -176,6 +181,15 @@ STATIC mp_obj_t machine_reset_cause(size_t n_args, const mp_obj_t *pos_args, mp_
     }
 }
 STATIC MP_DEFINE_CONST_FUN_OBJ_KW(machine_reset_cause_obj, 0,  machine_reset_cause);
+
+void machine_init(void) {
+    is_soft_reset = 0;
+}
+
+void machine_deinit(void) {
+    // we are doing a soft-reset so change the reset_cause
+    is_soft_reset = 1;
+}
 
 STATIC mp_obj_t machine_wake_reason(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
     return MP_OBJ_NEW_SMALL_INT(esp_sleep_get_wakeup_cause());

--- a/ports/esp32/modmachine.h
+++ b/ports/esp32/modmachine.h
@@ -22,6 +22,8 @@ extern const mp_obj_type_t machine_uart_type;
 extern const mp_obj_type_t machine_rtc_type;
 extern const mp_obj_type_t machine_sdcard_type;
 
+void machine_init(void);
+void machine_deinit(void);
 void machine_pins_init(void);
 void machine_pins_deinit(void);
 void machine_timer_deinit_all(void);


### PR DESCRIPTION
This patch fixes two issues on the esp32: it enables `machine.soft_reset()` to be called in `main.py` and it enables `machine.reset_cause()` to correctly identify a soft reset. The former is useful in that it enables soft resets in applications that are started at boot time.
The support is patterned after the stm32 port.
No docs changes 'cause this makes things works as documented.
No unit test, I can create one but due to the reset it ends up being pretty messy.