### PR TITLE
Update ports/nrf/README.md

### DIFF
--- a/ports/nrf/README.md
+++ b/ports/nrf/README.md
@@ -62,6 +62,7 @@ By default, the PCA10040 (nrf52832) is used as compile target. To build and flas
 
 Alternatively the target board could be defined:
 
+     make submodules
      make BOARD=pca10040
      make BOARD=pca10040 deploy
 


### PR DESCRIPTION
Add `make submodules` to commands when building for the first time.
Otherwise, on a first time build, the submodules have not been checked out and a lot of `fatal error: nrfx.h: No such file or directory` errors are generated.