### PR TITLE
zephyr: Update to zephyr v2.5.0.

### DIFF
--- a/ports/zephyr/README.md
+++ b/ports/zephyr/README.md
@@ -4,7 +4,7 @@ MicroPython port to Zephyr RTOS
 This is a work-in-progress port of MicroPython to Zephyr RTOS
 (http://zephyrproject.org).
 
-This port requires Zephyr version 2.4.0, and may also work on higher
+This port requires Zephyr version v2.5.0, and may also work on higher
 versions.  All boards supported
 by Zephyr (with standard level of features support, like UART console)
 should work with MicroPython (but not all were tested).
@@ -38,13 +38,13 @@ setup is correct.
 If you already have Zephyr installed but are having issues building the
 MicroPython port then try installing the correct version of Zephyr via:
 
-    $ west init zephyrproject -m https://github.com/zephyrproject-rtos/zephyr --mr v2.4.0
+    $ west init zephyrproject -m https://github.com/zephyrproject-rtos/zephyr --mr v2.5.0
 
 Alternatively, you don't have to redo the Zephyr installation to just
 switch from master to a tagged release, you can instead do:
 
     $ cd zephyrproject/zephyr
-    $ git checkout v2.4.0
+    $ git checkout v2.5.0
     $ west update
 
 With Zephyr installed you may then need to configure your environment,

--- a/tools/ci.sh
+++ b/tools/ci.sh
@@ -458,7 +458,7 @@ function ci_zephyr_setup {
 }
 
 function ci_zephyr_install {
-    docker exec zephyr-ci west init --mr v2.4.0 /zephyrproject
+    docker exec zephyr-ci west init --mr v2.5.0 /zephyrproject
     docker exec -w /zephyrproject zephyr-ci west update
     docker exec -w /zephyrproject zephyr-ci west zephyr-export
 }


### PR DESCRIPTION
Updates the zephyr port build instructions and CI to use the latest
zephyr release tag.

Signed-off-by: Maureen Helm <maureen.helm@nxp.com>

~~This PR is in draft status until the zephyr release is finalized.~~
The zephyr release has been finalized.