### PR TITLE
Add timing param to ESP8266 port of NeoPixel

### DIFF
--- a/docs/esp8266/quickref.rst
+++ b/docs/esp8266/quickref.rst
@@ -364,6 +364,13 @@ For low-level driving of a NeoPixel::
     import esp
     esp.neopixel_write(pin, grb_buf, is800khz)
 
+.. Warning::
+   By default ``NeoPixel`` is configured to control the more popular *800kHz*
+   units. It is possible to use alternative timing to control other (typically
+   400kHz) devices by passing ``timing=0`` when constructing the
+   ``NeoPixel`` object.
+
+
 APA102 driver
 -------------
 

--- a/ports/esp8266/modules/neopixel.py
+++ b/ports/esp8266/modules/neopixel.py
@@ -7,12 +7,13 @@ from esp import neopixel_write
 class NeoPixel:
     ORDER = (1, 0, 2, 3)
 
-    def __init__(self, pin, n, bpp=3):
+    def __init__(self, pin, n, bpp=3, timing=1):
         self.pin = pin
         self.n = n
         self.bpp = bpp
         self.buf = bytearray(n * bpp)
         self.pin.init(pin.OUT)
+        self.timing = timing
 
     def __setitem__(self, index, val):
         offset = index * self.bpp
@@ -28,4 +29,4 @@ class NeoPixel:
             self[i] = color
 
     def write(self):
-        neopixel_write(self.pin, self.buf, True)
+        neopixel_write(self.pin, self.buf, self.timing)


### PR DESCRIPTION
This timing parameter is present in the ESP32 port but missing in the ESP8266 port.
A similar parameter was added to the class constructor as seen in the ESP32 port.