### PR TITLE
py/gc: Fix debug printing of pointer.

### DIFF
--- a/py/gc.c
+++ b/py/gc.c
@@ -294,7 +294,7 @@ STATIC void gc_sweep(void) {
                 }
                 #endif
                 free_tail = 1;
-                DEBUG_printf("gc_sweep(%p)\n", PTR_FROM_BLOCK(block));
+                DEBUG_printf("gc_sweep(%p)\n", (void *)PTR_FROM_BLOCK(block));
                 #if MICROPY_PY_GC_COLLECT_RETVAL
                 MP_STATE_MEM(gc_collected)++;
                 #endif


### PR DESCRIPTION
When DEBUG_printf is standard printf compilers require the value
for %p to be an actual pointer instead of an integer.