### PR TITLE
ports/rp2: Add JMP PIN support for PIO

### DIFF
--- a/examples/rp2/pio_uart_rx.py
+++ b/examples/rp2/pio_uart_rx.py
@@ -1,0 +1,97 @@
+# Example using PIO to create a UART RX interface
+
+import _thread
+from machine import Pin, UART
+from rp2 import PIO, StateMachine, asm_pio
+
+UART_BAUD = 9600
+
+# You'll need a wire from GPIO4 -> GPIO3
+HARD_UART_TX_PIN = Pin(4, Pin.OUT)
+PIO_RX_PIN = Pin(3, Pin.IN, Pin.PULL_UP)
+
+
+@asm_pio(
+    autopush=True,
+    push_thresh=8,
+    in_shiftdir=rp2.PIO.SHIFT_RIGHT,
+)
+def uart_rx_mini():
+    # fmt: off
+    # Wait for start bit
+    wait(0, pin, 0)
+    # Preload bit counter, delay until eye of first data bit
+    set(x, 7)                 [10]
+    # Loop 8 times
+    label("bitloop")
+    # Sample data
+    in_(pins, 1)
+    # Each iteration is 8 cycles
+    jmp(x_dec, "bitloop")     [6]
+    # fmt: on
+
+
+@asm_pio(
+    in_shiftdir=rp2.PIO.SHIFT_RIGHT,
+)
+def uart_rx():
+    # fmt: off
+    label("start")
+    # Stall until start bit is asserted
+    wait(0, pin, 0)
+    # Preload bit counter, then delay until halfway through
+    # the first data bit (12 cycles incl wait, set).
+    set(x, 7)                 [10]
+    label("bitloop")
+    # Shift data bit into ISR
+    in_(pins, 1)
+    # Loop 8 times, each loop iteration is 8 cycles
+    jmp(x_dec, "bitloop")     [6]
+    # Check stop bit (should be high)
+    jmp(pin, "good_stop")
+    # Either a framing error or a break. Set a sticky flag
+    # and wait for line to return to idle state.
+    irq(block, 4)
+    wait(1, pin, 0)
+    # Don't push data if we didn't see good framing.
+    jmp("start")
+    # No delay before returning to start; a little slack is
+    # important in case the TX clock is slightly too fast.
+    label("good_stop")
+    push(block)
+    # fmt: on
+
+
+baud = 9600
+
+# Set up the hard UART we're going to use to print characters
+uart = UART(1, UART_BAUD, tx=HARD_UART_TX_PIN)
+
+
+# Set up the state machine we're going to use to receive them.
+sm = StateMachine(
+    0,
+    uart_rx,
+    freq=8 * UART_BAUD,
+    in_base=PIO_RX_PIN,  # For WAIT, IN
+    jmp_pin=PIO_RX_PIN,  # For JMP
+)
+sm.active(1)
+
+
+def handler(sm):
+    print("break", time.ticks_ms(), end=" ")
+
+
+sm.irq(handler)
+
+# Tell core 1 to print some text to UART 1
+def core2_task():
+    uart.write("Hello, world from PIO!")
+
+
+_thread.start_new_thread(core2_task, ())
+
+# Echo characters received from PIO to the console
+while True:
+    print(chr(sm.get() >> 24), end="")

--- a/ports/rp2/rp2_pio.c
+++ b/ports/rp2/rp2_pio.c
@@ -422,13 +422,14 @@ STATIC void rp2_state_machine_print(const mp_print_t *print, mp_obj_t self_in, m
 }
 
 // StateMachine.init(prog, freq=-1, *,
-//     in_base=None, out_base=None, set_base=None, sideset_base=None,
-//     in_shiftdir=None, out_shiftdir=None, push_thresh=None, pull_thresh=None,
+//     in_base=None, out_base=None, set_base=None, jmp_pin=None,
+//     sideset_base=None, in_shiftdir=None, out_shiftdir=None,
+//     push_thresh=None, pull_thresh=None,
 // )
 STATIC mp_obj_t rp2_state_machine_init_helper(const rp2_state_machine_obj_t *self, size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
     enum {
         ARG_prog, ARG_freq,
-        ARG_in_base, ARG_out_base, ARG_set_base, ARG_sideset_base,
+        ARG_in_base, ARG_out_base, ARG_set_base, ARG_jmp_pin, ARG_sideset_base,
         ARG_in_shiftdir, ARG_out_shiftdir, ARG_push_thresh, ARG_pull_thresh
     };
     static const mp_arg_t allowed_args[] = {
@@ -437,6 +438,7 @@ STATIC mp_obj_t rp2_state_machine_init_helper(const rp2_state_machine_obj_t *sel
         { MP_QSTR_in_base, MP_ARG_KW_ONLY | MP_ARG_OBJ, {.u_rom_obj = MP_ROM_NONE} },
         { MP_QSTR_out_base, MP_ARG_KW_ONLY | MP_ARG_OBJ, {.u_rom_obj = MP_ROM_NONE} },
         { MP_QSTR_set_base, MP_ARG_KW_ONLY | MP_ARG_OBJ, {.u_rom_obj = MP_ROM_NONE} },
+        { MP_QSTR_jmp_pin, MP_ARG_KW_ONLY | MP_ARG_OBJ, {.u_rom_obj = MP_ROM_NONE} },
         { MP_QSTR_sideset_base, MP_ARG_KW_ONLY | MP_ARG_OBJ, {.u_rom_obj = MP_ROM_NONE} },
         { MP_QSTR_in_shiftdir, MP_ARG_KW_ONLY | MP_ARG_OBJ, {.u_rom_obj = MP_ROM_NONE} },
         { MP_QSTR_out_shiftdir, MP_ARG_KW_ONLY | MP_ARG_OBJ, {.u_rom_obj = MP_ROM_NONE} },
@@ -485,6 +487,11 @@ STATIC mp_obj_t rp2_state_machine_init_helper(const rp2_state_machine_obj_t *sel
     // Configure in pin base, if needed.
     if (args[ARG_in_base].u_obj != mp_const_none) {
         sm_config_set_in_pins(&config, mp_hal_get_pin_obj(args[ARG_in_base].u_obj));
+    }
+
+    // Configure jmp pin, if needed.
+    if (args[ARG_jmp_pin].u_obj != mp_const_none) {
+        sm_config_set_jmp_pin(&config, mp_hal_get_pin_obj(args[ARG_jmp_pin].u_obj));
     }
 
     // Configure out pins, if needed.

--- a/ports/rp2/rp2_pio.c
+++ b/ports/rp2/rp2_pio.c
@@ -489,11 +489,6 @@ STATIC mp_obj_t rp2_state_machine_init_helper(const rp2_state_machine_obj_t *sel
         sm_config_set_in_pins(&config, mp_hal_get_pin_obj(args[ARG_in_base].u_obj));
     }
 
-    // Configure jmp pin, if needed.
-    if (args[ARG_jmp_pin].u_obj != mp_const_none) {
-        sm_config_set_jmp_pin(&config, mp_hal_get_pin_obj(args[ARG_jmp_pin].u_obj));
-    }
-
     // Configure out pins, if needed.
     asm_pio_config_t out_config = ASM_PIO_CONFIG_DEFAULT;
     asm_pio_get_pins("out", prog[PROG_OUT_PINS], args[ARG_out_base].u_obj, &out_config);
@@ -506,6 +501,11 @@ STATIC mp_obj_t rp2_state_machine_init_helper(const rp2_state_machine_obj_t *sel
     asm_pio_get_pins("set", prog[PROG_SET_PINS], args[ARG_set_base].u_obj, &set_config);
     if (set_config.base >= 0) {
         sm_config_set_set_pins(&config, set_config.base, set_config.count);
+    }
+
+    // Configure jmp pin, if needed.
+    if (args[ARG_jmp_pin].u_obj != mp_const_none) {
+        sm_config_set_jmp_pin(&config, mp_hal_get_pin_obj(args[ARG_jmp_pin].u_obj));
     }
 
     // Configure sideset pin, if needed.


### PR DESCRIPTION
PIO state machines can make a conditional jump on the state of a pin: the `JMP PIN` command.
This requires the pin to be configured with `sm_config_set_jmp_pin`, but until now we didn't have a way of doing that in MicroPython.

This patch adds a new `jmp_pin=None` argument to `StateMachine`.
If it is not `None` then we try to interpret it as a Pin, and pass its value to `sm_config_set_jmp_pin`.

This change allows for porting the `uart_rx` example to MicroPython, shown below.
The example uses `jmp(pin)`, so without the `jmp_pin` argument it doesn't work: the branch to `good_stop` is never taken, so nothing is pushed into the FIFO.

```py
from machine import Pin, UART

rx = Pin(5, Pin.IN, Pin.PULL_UP)

@rp2.asm_pio(
    in_shiftdir=rp2.PIO.SHIFT_RIGHT,
)
def uart_rx():
    wrap_target()
    label("start")
    wait(0, pin, 0)
    set(x, 7)                        [10]
    label("bitloop")
    in_(pins, 1)
    jmp(x_dec, "bitloop")                  [6]
    jmp(pin, "good_stop")
    irq(block, 4)
    wait(1, pin, 0)
    jmp("start")
    label("good_stop")
    push(block)
    wrap()

baud = 9600

sm = rp2.StateMachine(0, uart_rx, freq=baud*8, in_base=rx, jmp_pin=rx)
sm.active(1)

while True:
    # Print hex bytes to the console.
    b = sm.get() >> 24
    print("{:02x}".format(b), end=" ")
```

I am new to this codebase, so please review with care 😅