### PR TITLE
tools/verifygitlog.py: Fix error message for commit subject line.

### DIFF
--- a/tools/verifygitlog.py
+++ b/tools/verifygitlog.py
@@ -57,8 +57,9 @@ def verify(sha):
     # Subject line.
     subject_line = raw_body[0]
     very_verbose("subject_line", subject_line)
-    if not re.match(r"^[^!]+: [A-Z]+.+ .+\.$", subject_line):
-        error("Subject line should contain ': ' and end in '.': " + subject_line)
+    subject_line_format = r"^[^!]+: [A-Z]+.+ .+\.$"
+    if not re.match(subject_line_format, subject_line):
+        error("Subject line should match " + repr(subject_line_format) + ": " + subject_line)
     if len(subject_line) >= 73:
         error("Subject line should be 72 or less characters: " + subject_line)
 


### PR DESCRIPTION
Fix https://github.com/micropython/micropython/runs/1801587962?check_suite_focus=true.

In this run, we see:

```
 error: commit a1a7285: Subject line should contain ': ' and end in '.': py/makeversionhdr: honor SOURCE_DATE_EPOCH if present.
```

However, the subject line "py/makeversionhdr: honor SOURCE_DATE_EPOCH if present." actually contains a ': ' and ends with a '.', which could be confusing.

Expand the error message to also mention that the subject should be a capitalized sentence.
