### PR TITLE
tests/extmod/utime_time_ns.py: Relax bounds on time_ns measurement.

### DIFF
--- a/tests/extmod/utime_time_ns.py
+++ b/tests/extmod/utime_time_ns.py
@@ -11,14 +11,14 @@ except (ImportError, AttributeError):
 
 
 t0 = utime.time_ns()
-utime.sleep_us(1000)
+utime.sleep_us(5000)
 t1 = utime.time_ns()
 
 # Check that time_ns increases.
 print(t0 < t1)
 
-# Check that time_ns counts correctly, but be very lenient with the upper bound (50ms).
-if 950000 < t1 - t0 < 50000000:
+# Check that time_ns counts correctly, but be very lenient with the bounds (2ms to 50ms).
+if 2000000 < t1 - t0 < 50000000:
     print(True)
 else:
     print(t0, t1, t1 - t0)


### PR DESCRIPTION
Some devices have lower precision than 1ms for time_ns() (eg PYBv1.x has 3.9ms resolution of the RTC) so make the test more lenient for them.

