### PR TITLE
stm32/mboot: Change debug compiler optimisation to -Og

### DIFF
--- a/ports/stm32/mboot/Makefile
+++ b/ports/stm32/mboot/Makefile
@@ -92,7 +92,7 @@ LDFLAGS += --gc-sections
 # Debugging/Optimization
 ifeq ($(DEBUG), 1)
 CFLAGS += -g -DPENDSV_DEBUG
-COPT = -O0
+COPT = -Og
 else
 COPT += -Os -DNDEBUG
 endif


### PR DESCRIPTION
With mboot encrpytion and fsload enabled, the DEBUG build `-O0` compiler settings result in mboot no longer fitting in the sector.
This PR changes this to `-Og` which also brings it into line with the regular stm32 build.