### PR TITLE
rp2: Use local tinyusb submodule rather than pico-sdk one

### DIFF
--- a/ports/mimxrt/board_init.c
+++ b/ports/mimxrt/board_init.c
@@ -90,11 +90,11 @@ void SysTick_Handler(void) {
 }
 
 void USB_OTG1_IRQHandler(void) {
-    tud_isr(0);
+    tud_int_handler(0);
     tud_task();
 }
 
 void USB_OTG2_IRQHandler(void) {
-    tud_isr(1);
+    tud_int_handler(1);
     tud_task();
 }

--- a/ports/mimxrt/tusb_config.h
+++ b/ports/mimxrt/tusb_config.h
@@ -32,6 +32,5 @@
 #define CFG_TUD_CDC             (1)
 #define CFG_TUD_CDC_RX_BUFSIZE  (512)
 #define CFG_TUD_CDC_TX_BUFSIZE  (512)
-#define CFG_TUD_CDC_EPSIZE      (512)
 
 #endif // MICROPY_INCLUDED_MIMXRT_TUSB_CONFIG_H

--- a/ports/mimxrt/tusb_port.c
+++ b/ports/mimxrt/tusb_port.c
@@ -67,7 +67,7 @@ static const tusb_desc_device_t usbd_desc_device = {
 };
 
 static const uint8_t usbd_desc_cfg[USBD_DESC_LEN] = {
-    TUD_CONFIG_DESCRIPTOR(USBD_ITF_MAX, USBD_STR_0, USBD_DESC_LEN,
+    TUD_CONFIG_DESCRIPTOR(1, USBD_ITF_MAX, USBD_STR_0, USBD_DESC_LEN,
         TUSB_DESC_CONFIG_ATT_REMOTE_WAKEUP, USBD_MAX_POWER_MA),
 
     TUD_CDC_DESCRIPTOR(USBD_ITF_CDC, USBD_STR_CDC, USBD_CDC_EP_CMD,
@@ -90,7 +90,7 @@ const uint8_t *tud_descriptor_configuration_cb(uint8_t index) {
     return usbd_desc_cfg;
 }
 
-const uint16_t *tud_descriptor_string_cb(uint8_t index) {
+const uint16_t *tud_descriptor_string_cb(uint8_t index, uint16_t langid) {
     #define DESC_STR_MAX (20)
     static uint16_t desc_str[DESC_STR_MAX];
 

--- a/ports/nrf/drivers/usb/usb_descriptors.c
+++ b/ports/nrf/drivers/usb/usb_descriptors.c
@@ -67,7 +67,7 @@ static const tusb_desc_device_t usbd_desc_device = {
 };
 
 static const uint8_t usbd_desc_cfg[USBD_DESC_LEN] = {
-    TUD_CONFIG_DESCRIPTOR(USBD_ITF_MAX, USBD_STR_0, USBD_DESC_LEN,
+    TUD_CONFIG_DESCRIPTOR(1, USBD_ITF_MAX, USBD_STR_0, USBD_DESC_LEN,
         TUSB_DESC_CONFIG_ATT_REMOTE_WAKEUP, USBD_MAX_POWER_MA),
 
     TUD_CDC_DESCRIPTOR(USBD_ITF_CDC, USBD_STR_CDC, USBD_CDC_EP_CMD,
@@ -90,7 +90,7 @@ const uint8_t *tud_descriptor_configuration_cb(uint8_t index) {
     return usbd_desc_cfg;
 }
 
-const uint16_t *tud_descriptor_string_cb(uint8_t index) {
+const uint16_t *tud_descriptor_string_cb(uint8_t index, uint16_t langid) {
     #define DESC_STR_MAX (20)
     static uint16_t desc_str[DESC_STR_MAX];
 

--- a/ports/rp2/CMakeLists.txt
+++ b/ports/rp2/CMakeLists.txt
@@ -14,6 +14,9 @@ else()
     set(PICO_SDK_PATH ../../lib/pico-sdk)
 endif()
 
+# Use the local tinyusb instead of the one in pico-sdk
+set(PICO_TINYUSB_PATH ${MPY_DIR}/lib/tinyusb)
+
 # Include component cmake fragments
 include(micropy_py.cmake)
 include(micropy_extmod.cmake)

--- a/ports/samd/tusb_port.c
+++ b/ports/samd/tusb_port.c
@@ -68,7 +68,7 @@ static const tusb_desc_device_t usbd_desc_device = {
 };
 
 static const uint8_t usbd_desc_cfg[USBD_DESC_LEN] = {
-    TUD_CONFIG_DESCRIPTOR(USBD_ITF_MAX, USBD_STR_0, USBD_DESC_LEN,
+    TUD_CONFIG_DESCRIPTOR(1, USBD_ITF_MAX, USBD_STR_0, USBD_DESC_LEN,
         TUSB_DESC_CONFIG_ATT_REMOTE_WAKEUP, USBD_MAX_POWER_MA),
 
     TUD_CDC_DESCRIPTOR(USBD_ITF_CDC, USBD_STR_CDC, USBD_CDC_EP_CMD,
@@ -91,7 +91,7 @@ const uint8_t *tud_descriptor_configuration_cb(uint8_t index) {
     return usbd_desc_cfg;
 }
 
-const uint16_t *tud_descriptor_string_cb(uint8_t index) {
+const uint16_t *tud_descriptor_string_cb(uint8_t index, uint16_t langid) {
     #define DESC_STR_MAX (20)
     static uint16_t desc_str[DESC_STR_MAX];
 
@@ -118,29 +118,29 @@ const uint16_t *tud_descriptor_string_cb(uint8_t index) {
 #if defined(MCU_SAMD21)
 
 void USB_Handler_wrapper(void) {
-    USB_Handler();
+    tud_int_handler(0);
     tud_task();
 }
 
 #elif defined(MCU_SAMD51)
 
 void USB_0_Handler_wrapper(void) {
-    USB_0_Handler();
+    tud_int_handler(0);
     tud_task();
 }
 
 void USB_1_Handler_wrapper(void) {
-    USB_1_Handler();
+    tud_int_handler(0);
     tud_task();
 }
 
 void USB_2_Handler_wrapper(void) {
-    USB_2_Handler();
+    tud_int_handler(0);
     tud_task();
 }
 
 void USB_3_Handler_wrapper(void) {
-    USB_3_Handler();
+    tud_int_handler(0);
     tud_task();
 }
 

--- a/tools/ci.sh
+++ b/tools/ci.sh
@@ -195,8 +195,7 @@ function ci_rp2_setup {
 
 function ci_rp2_build {
     make ${MAKEOPTS} -C mpy-cross
-    git submodule update --init lib/pico-sdk
-    git -C lib/pico-sdk submodule update --init lib/tinyusb
+    git submodule update --init lib/pico-sdk lib/tinyusb
     make ${MAKEOPTS} -C ports/rp2
 }
 


### PR DESCRIPTION
So that all MicroPython ports that use tinyusb use the same version.  Also requires fewer submodule checkouts when building rp2 along with other ports that use tinyusb.

TODO: check that other ports using tinyusb still work with this version.