### PR TITLE
extmod/modujson: Support specifying separators in dump()

### DIFF
--- a/extmod/modujson.c
+++ b/extmod/modujson.c
@@ -50,8 +50,16 @@ STATIC mp_obj_t mod_ujson_dump(size_t n_args, const mp_obj_t *pos_args, mp_map_t
     }
 
     mp_get_stream_raise(pos_args[1], MP_STREAM_OP_WRITE);
-    mp_print_t print = {MP_OBJ_TO_PTR(pos_args[1]), mp_stream_write_adaptor};
-    mp_obj_print_helper(&print, pos_args[0], PRINT_JSON);
+
+    nlr_buf_t nlr;
+    if (nlr_push(&nlr) == 0) {
+        mp_print_t print = {MP_OBJ_TO_PTR(pos_args[1]), mp_stream_write_adaptor};
+        mp_obj_print_helper(&print, pos_args[0], PRINT_JSON);
+        nlr_pop();
+    } else {
+        // Re-raise the exception
+        nlr_raise(MP_OBJ_FROM_PTR(nlr.ret_val));
+    }
     return mp_const_none;
 }
 STATIC MP_DEFINE_CONST_FUN_OBJ_KW(mod_ujson_dump_obj, 2, mod_ujson_dump);
@@ -73,7 +81,15 @@ STATIC mp_obj_t mod_ujson_dumps(size_t n_args, const mp_obj_t *pos_args, mp_map_
     vstr_t vstr;
     mp_print_t print;
     vstr_init_print(&vstr, 8, &print);
-    mp_obj_print_helper(&print, pos_args[0], PRINT_JSON);
+
+    nlr_buf_t nlr;
+    if (nlr_push(&nlr) == 0) {
+        mp_obj_print_helper(&print, pos_args[0], PRINT_JSON);
+        nlr_pop();
+    } else {
+        // Re-raise the exception
+        nlr_raise(MP_OBJ_FROM_PTR(nlr.ret_val));
+    }
     return mp_obj_new_str_from_vstr(&mp_type_str, &vstr);
 }
 STATIC MP_DEFINE_CONST_FUN_OBJ_KW(mod_ujson_dumps_obj, 1, mod_ujson_dumps);

--- a/extmod/modujson.c
+++ b/extmod/modujson.c
@@ -31,25 +31,52 @@
 #include "py/parsenum.h"
 #include "py/runtime.h"
 #include "py/stream.h"
+#include "py/nlr.h"
 
 #if MICROPY_PY_UJSON
 
-STATIC mp_obj_t mod_ujson_dump(mp_obj_t obj, mp_obj_t stream) {
-    mp_get_stream_raise(stream, MP_STREAM_OP_WRITE);
-    mp_print_t print = {MP_OBJ_TO_PTR(stream), mp_stream_write_adaptor};
-    mp_obj_print_helper(&print, obj, PRINT_JSON);
+STATIC mp_obj_t mod_ujson_dump(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
+    enum {ARG_indent, ARG_separators};
+    const mp_arg_t allowed_args[] = {
+        { MP_QSTR_indent, MP_ARG_KW_ONLY | MP_ARG_OBJ, {.u_rom_obj = mp_const_none} },
+        { MP_QSTR_separators, MP_ARG_KW_ONLY | MP_ARG_OBJ, {.u_rom_obj = mp_const_none} },
+    };
+
+    mp_arg_val_t args[MP_ARRAY_SIZE(allowed_args)];
+    mp_arg_parse_all(n_args - 2, pos_args + 2, kw_args, MP_ARRAY_SIZE(allowed_args), allowed_args, args);
+
+    if (args[ARG_indent].u_obj != mp_const_none) {
+        mp_raise_NotImplementedError(MP_ERROR_TEXT("indent is not None"));
+    }
+
+    mp_get_stream_raise(pos_args[1], MP_STREAM_OP_WRITE);
+    mp_print_t print = {MP_OBJ_TO_PTR(pos_args[1]), mp_stream_write_adaptor};
+    mp_obj_print_helper(&print, pos_args[0], PRINT_JSON);
     return mp_const_none;
 }
-STATIC MP_DEFINE_CONST_FUN_OBJ_2(mod_ujson_dump_obj, mod_ujson_dump);
+STATIC MP_DEFINE_CONST_FUN_OBJ_KW(mod_ujson_dump_obj, 2, mod_ujson_dump);
 
-STATIC mp_obj_t mod_ujson_dumps(mp_obj_t obj) {
+STATIC mp_obj_t mod_ujson_dumps(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
+    enum {ARG_indent, ARG_separators};
+    const mp_arg_t allowed_args[] = {
+        { MP_QSTR_indent, MP_ARG_KW_ONLY | MP_ARG_OBJ, {.u_rom_obj = mp_const_none} },
+        { MP_QSTR_separators, MP_ARG_KW_ONLY | MP_ARG_OBJ, {.u_rom_obj = mp_const_none} },
+    };
+
+    mp_arg_val_t args[MP_ARRAY_SIZE(allowed_args)];
+    mp_arg_parse_all(n_args - 1, pos_args + 1, kw_args, MP_ARRAY_SIZE(allowed_args), allowed_args, args);
+
+    if (args[ARG_indent].u_obj != mp_const_none) {
+        mp_raise_NotImplementedError(MP_ERROR_TEXT("indent is not None"));
+    }
+
     vstr_t vstr;
     mp_print_t print;
     vstr_init_print(&vstr, 8, &print);
-    mp_obj_print_helper(&print, obj, PRINT_JSON);
+    mp_obj_print_helper(&print, pos_args[0], PRINT_JSON);
     return mp_obj_new_str_from_vstr(&mp_type_str, &vstr);
 }
-STATIC MP_DEFINE_CONST_FUN_OBJ_1(mod_ujson_dumps_obj, mod_ujson_dumps);
+STATIC MP_DEFINE_CONST_FUN_OBJ_KW(mod_ujson_dumps_obj, 1, mod_ujson_dumps);
 
 // The function below implements a simple non-recursive JSON parser.
 //

--- a/extmod/modujson.c
+++ b/extmod/modujson.c
@@ -35,6 +35,24 @@
 
 #if MICROPY_PY_UJSON
 
+static void mod_ujson_separators(mp_obj_t separators_in, const char **item_separator, const char **key_separator) {
+    if (separators_in == mp_const_none) {
+        *item_separator = ", ";
+        *key_separator = ": ";
+    } else {
+        mp_obj_t *items;
+        size_t len;
+        mp_obj_tuple_get(separators_in, &len, &items);
+
+        if (len != 2) {
+            mp_raise_ValueError(MP_ERROR_TEXT("too many values to unpack (expected 2)"));
+        }
+
+        *item_separator = mp_obj_str_get_str(items[0]);
+        *key_separator = mp_obj_str_get_str(items[1]);
+    }
+}
+
 const char *ujson_item_separator = ", ";
 const char *ujson_key_separator = ": ";
 
@@ -54,15 +72,29 @@ STATIC mp_obj_t mod_ujson_dump(size_t n_args, const mp_obj_t *pos_args, mp_map_t
 
     mp_get_stream_raise(pos_args[1], MP_STREAM_OP_WRITE);
 
+    const char *old_item_separator = ujson_item_separator;
+    const char *old_key_separator = ujson_key_separator;
+    bool raise = false;
+    mod_ujson_separators(args[ARG_separators].u_obj, &ujson_item_separator, &ujson_key_separator);
+
     nlr_buf_t nlr;
     if (nlr_push(&nlr) == 0) {
         mp_print_t print = {MP_OBJ_TO_PTR(pos_args[1]), mp_stream_write_adaptor};
         mp_obj_print_helper(&print, pos_args[0], PRINT_JSON);
         nlr_pop();
     } else {
-        // Re-raise the exception
+        raise = true;
+    }
+
+    // revert old values in case of nested dump
+    ujson_item_separator = old_item_separator;
+    ujson_key_separator = old_key_separator;
+
+    // Re-raise the exception
+    if (raise) {
         nlr_raise(MP_OBJ_FROM_PTR(nlr.ret_val));
     }
+
     return mp_const_none;
 }
 STATIC MP_DEFINE_CONST_FUN_OBJ_KW(mod_ujson_dump_obj, 2, mod_ujson_dump);
@@ -85,14 +117,28 @@ STATIC mp_obj_t mod_ujson_dumps(size_t n_args, const mp_obj_t *pos_args, mp_map_
     mp_print_t print;
     vstr_init_print(&vstr, 8, &print);
 
+    const char *old_item_separator = ujson_item_separator;
+    const char *old_key_separator = ujson_key_separator;
+    bool raise = false;
+    mod_ujson_separators(args[ARG_separators].u_obj, &ujson_item_separator, &ujson_key_separator);
+
     nlr_buf_t nlr;
     if (nlr_push(&nlr) == 0) {
         mp_obj_print_helper(&print, pos_args[0], PRINT_JSON);
         nlr_pop();
     } else {
-        // Re-raise the exception
+        raise = true;
+    }
+
+    // revert old values in case of nested dump
+    ujson_item_separator = old_item_separator;
+    ujson_key_separator = old_key_separator;
+
+    // Re-raise the exception
+    if (raise) {
         nlr_raise(MP_OBJ_FROM_PTR(nlr.ret_val));
     }
+
     return mp_obj_new_str_from_vstr(&mp_type_str, &vstr);
 }
 STATIC MP_DEFINE_CONST_FUN_OBJ_KW(mod_ujson_dumps_obj, 1, mod_ujson_dumps);

--- a/extmod/modujson.c
+++ b/extmod/modujson.c
@@ -35,6 +35,9 @@
 
 #if MICROPY_PY_UJSON
 
+const char *ujson_item_separator = ", ";
+const char *ujson_key_separator = ": ";
+
 STATIC mp_obj_t mod_ujson_dump(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
     enum {ARG_indent, ARG_separators};
     const mp_arg_t allowed_args[] = {

--- a/py/obj.h
+++ b/py/obj.h
@@ -490,6 +490,10 @@ typedef enum {
     PRINT_EXC_SUBCLASS = 0x80, // Internal flag for printing exception subclasses
 } mp_print_kind_t;
 
+// separators for ujson
+extern const char *ujson_item_separator;
+extern const char *ujson_key_separator;
+
 typedef struct _mp_obj_iter_buf_t {
     mp_obj_base_t base;
     mp_obj_t buf[3];

--- a/py/objdict.c
+++ b/py/objdict.c
@@ -72,6 +72,8 @@ STATIC void dict_print(const mp_print_t *print, mp_obj_t self_in, mp_print_kind_
     if (!(MICROPY_PY_UJSON && kind == PRINT_JSON)) {
         kind = PRINT_REPR;
     }
+    const char *item_separator = (kind == PRINT_JSON) ? ujson_item_separator : ", ";
+    const char *key_separator = (kind == PRINT_JSON) ? ujson_key_separator : ": ";
     if (MICROPY_PY_COLLECTIONS_ORDEREDDICT && self->base.type != &mp_type_dict && kind != PRINT_JSON) {
         mp_printf(print, "%q(", self->base.type->name);
     }
@@ -80,7 +82,7 @@ STATIC void dict_print(const mp_print_t *print, mp_obj_t self_in, mp_print_kind_
     mp_map_elem_t *next = NULL;
     while ((next = dict_iter_next(self, &cur)) != NULL) {
         if (!first) {
-            mp_print_str(print, ", ");
+            mp_print_str(print, item_separator);
         }
         first = false;
         bool add_quote = MICROPY_PY_UJSON && kind == PRINT_JSON && !mp_obj_is_str_or_bytes(next->key);
@@ -91,7 +93,7 @@ STATIC void dict_print(const mp_print_t *print, mp_obj_t self_in, mp_print_kind_
         if (add_quote) {
             mp_print_str(print, "\"");
         }
-        mp_print_str(print, ": ");
+        mp_print_str(print, key_separator);
         mp_obj_print_helper(print, next->value, kind);
     }
     mp_print_str(print, "}");

--- a/py/objlist.c
+++ b/py/objlist.c
@@ -47,10 +47,11 @@ STATIC void list_print(const mp_print_t *print, mp_obj_t o_in, mp_print_kind_t k
     if (!(MICROPY_PY_UJSON && kind == PRINT_JSON)) {
         kind = PRINT_REPR;
     }
+    const char *item_separator = (kind == PRINT_JSON) ? ujson_item_separator : ", ";
     mp_print_str(print, "[");
     for (size_t i = 0; i < o->len; i++) {
         if (i > 0) {
-            mp_print_str(print, ", ");
+            mp_print_str(print, item_separator);
         }
         mp_obj_print_helper(print, o->items[i], kind);
     }

--- a/py/objtuple.c
+++ b/py/objtuple.c
@@ -45,9 +45,10 @@ void mp_obj_tuple_print(const mp_print_t *print, mp_obj_t o_in, mp_print_kind_t 
         mp_print_str(print, "(");
         kind = PRINT_REPR;
     }
+    const char *item_separator = (kind == PRINT_JSON) ? ujson_item_separator : ", ";
     for (size_t i = 0; i < o->len; i++) {
         if (i > 0) {
-            mp_print_str(print, ", ");
+            mp_print_str(print, item_separator);
         }
         mp_obj_print_helper(print, o->items[i], kind);
     }


### PR DESCRIPTION
This PR adds support for the `separators` keyword argument in
ujson.dump() and ujson.dumps().

Additionally added the keyword argument `indent` which is only
allowed to be `None` and raises NotImplementedError
otherwise. This was added because the arguments is connected to
the `separators` argument.

This PR is currently implemented reentrant to support calling
json.dump/s in an interrupt. Since allocation (and in turn
json.dump/s) is not available in ISR's this could be removed to
simplify the implementation slightly.