### PR TITLE
rp2: Added SD card + FAT support.

### DIFF
--- a/ports/rp2/manifest.py
+++ b/ports/rp2/manifest.py
@@ -1,3 +1,4 @@
 freeze("modules")
 freeze("$(MPY_DIR)/drivers/onewire")
 include("$(MPY_DIR)/extmod/uasyncio/manifest.py")
+freeze("$(MPY_DIR)/drivers/sdcard")

--- a/ports/rp2/manifest.py
+++ b/ports/rp2/manifest.py
@@ -2,3 +2,4 @@ freeze("modules")
 freeze("$(MPY_DIR)/drivers/onewire")
 include("$(MPY_DIR)/extmod/uasyncio/manifest.py")
 freeze("$(MPY_DIR)/drivers/sdcard")
+

--- a/ports/rp2/mpconfigport.h
+++ b/ports/rp2/mpconfigport.h
@@ -117,6 +117,13 @@
 #define MICROPY_PY_FRAMEBUF                     (1)
 #define MICROPY_VFS                             (1)
 #define MICROPY_VFS_LFS2                        (1)
+#define MICROPY_VFS_FAT                         (1)
+
+// fatfs configuration
+#define MICROPY_FATFS_ENABLE_LFN                (1)
+#define MICROPY_FATFS_LFN_CODE_PAGE             437 /* 1=SFN/ANSI 437=LFN/U.S.(OEM) */
+#define MICROPY_FATFS_RPATH                     (2)
+#define MICROPY_FATFS_NORTC                     (1)
 
 // Use VfsLfs2's types for fileio/textio
 #define mp_type_fileio mp_type_vfs_lfs2_fileio


### PR DESCRIPTION
I've added the sdcard module to manifest.py, and included the FAT driver. I think these are worthwhile including in the RP2040 port, given the prevalence of SD card breakout modules, and several other boards/hats including MicroSD card slots.