### PR TITLE
ports: Remove def of MP_PLAT_PRINT_STRN if it's the same as the default.

### DIFF
--- a/ports/cc3200/mpconfigport.h
+++ b/ports/cc3200/mpconfigport.h
@@ -197,8 +197,6 @@ typedef int32_t mp_int_t;                           // must be pointer size
 typedef unsigned int mp_uint_t;                     // must be pointer size
 typedef long mp_off_t;
 
-#define MP_PLAT_PRINT_STRN(str, len) mp_hal_stdout_tx_strn_cooked(str, len)
-
 #define MICROPY_BEGIN_ATOMIC_SECTION()              disable_irq()
 #define MICROPY_END_ATOMIC_SECTION(state)           enable_irq(state)
 #define MICROPY_EVENT_POLL_HOOK                     __WFI();

--- a/ports/esp32/mpconfigport.h
+++ b/ports/esp32/mpconfigport.h
@@ -223,7 +223,6 @@ struct mp_bluetooth_nimble_root_pointers_t;
 
 #define BYTES_PER_WORD (4)
 #define MICROPY_MAKE_POINTER_CALLABLE(p) ((void *)((mp_uint_t)(p)))
-#define MP_PLAT_PRINT_STRN(str, len) mp_hal_stdout_tx_strn_cooked(str, len)
 void *esp_native_code_commit(void *, size_t, void *);
 #define MP_PLAT_COMMIT_EXEC(buf, len, reloc) esp_native_code_commit(buf, len, reloc)
 #define MP_SSIZE_MAX (0x7fffffff)

--- a/ports/esp8266/mpconfigport.h
+++ b/ports/esp8266/mpconfigport.h
@@ -135,7 +135,6 @@ typedef uint32_t sys_prot_t; // for modlwip
 // ssize_t, off_t as required by POSIX-signatured functions in stream.h
 #include <sys/types.h>
 
-#define MP_PLAT_PRINT_STRN(str, len) mp_hal_stdout_tx_strn_cooked(str, len)
 void *esp_native_code_commit(void *, size_t, void *);
 #define MP_PLAT_COMMIT_EXEC(buf, len, reloc) esp_native_code_commit(buf, len, reloc)
 

--- a/ports/javascript/mpconfigport.h
+++ b/ports/javascript/mpconfigport.h
@@ -180,8 +180,6 @@ typedef int mp_int_t; // must be pointer size
 typedef unsigned mp_uint_t; // must be pointer size
 typedef long mp_off_t;
 
-#define MP_PLAT_PRINT_STRN(str, len) mp_hal_stdout_tx_strn_cooked(str, len)
-
 // extra built in names to add to the global namespace
 #define MICROPY_PORT_BUILTINS \
     { MP_ROM_QSTR(MP_QSTR_open), MP_ROM_PTR(&mp_builtin_open_obj) },

--- a/ports/mimxrt/mpconfigport.h
+++ b/ports/mimxrt/mpconfigport.h
@@ -98,7 +98,6 @@ extern const struct _mp_obj_module_t mp_module_utime;
     } while (0);
 
 #define MICROPY_MAKE_POINTER_CALLABLE(p) ((void *)((mp_uint_t)(p) | 1))
-#define MP_PLAT_PRINT_STRN(str, len) mp_hal_stdout_tx_strn_cooked(str, len)
 
 #define MP_SSIZE_MAX (0x7fffffff)
 typedef int mp_int_t; // must be pointer size

--- a/ports/nrf/mpconfigport.h
+++ b/ports/nrf/mpconfigport.h
@@ -332,8 +332,6 @@ extern const struct _mp_obj_module_t ble_module;
         __WFI(); \
     } while (0);
 
-#define MP_PLAT_PRINT_STRN(str, len) mp_hal_stdout_tx_strn_cooked(str, len)
-
 // We need to provide a declaration/definition of alloca()
 #include <alloca.h>
 

--- a/ports/pic16bit/mpconfigport.h
+++ b/ports/pic16bit/mpconfigport.h
@@ -84,8 +84,6 @@ typedef unsigned int mp_uint_t; // must be pointer size
 
 typedef int mp_off_t;
 
-#define MP_PLAT_PRINT_STRN(str, len) mp_hal_stdout_tx_strn_cooked(str, len)
-
 // extra builtin names to add to the global namespace
 #define MICROPY_PORT_BUILTINS \
     { MP_ROM_QSTR(MP_QSTR_open), MP_ROM_PTR(&mp_builtin_open_obj) },

--- a/ports/powerpc/mpconfigport.h
+++ b/ports/powerpc/mpconfigport.h
@@ -103,8 +103,6 @@ typedef unsigned long mp_uint_t; // must be pointer size
 
 typedef long mp_off_t;
 
-#define MP_PLAT_PRINT_STRN(str, len) mp_hal_stdout_tx_strn_cooked(str, len)
-
 // extra built in names to add to the global namespace
 #define MICROPY_PORT_BUILTINS \
     { MP_ROM_QSTR(MP_QSTR_open), MP_ROM_PTR(&mp_builtin_open_obj) },

--- a/ports/samd/mpconfigport.h
+++ b/ports/samd/mpconfigport.h
@@ -98,7 +98,6 @@ extern const struct _mp_obj_module_t mp_module_utime;
     } while (0);
 
 #define MICROPY_MAKE_POINTER_CALLABLE(p) ((void *)((mp_uint_t)(p) | 1))
-#define MP_PLAT_PRINT_STRN(str, len) mp_hal_stdout_tx_strn_cooked(str, len)
 
 #define MP_SSIZE_MAX (0x7fffffff)
 typedef int mp_int_t; // must be pointer size

--- a/ports/stm32/mpconfigport.h
+++ b/ports/stm32/mpconfigport.h
@@ -360,8 +360,6 @@ typedef unsigned int mp_uint_t; // must be pointer size
 
 typedef long mp_off_t;
 
-#define MP_PLAT_PRINT_STRN(str, len) mp_hal_stdout_tx_strn_cooked(str, len)
-
 // We have inlined IRQ functions for efficiency (they are generally
 // 1 machine instruction).
 //

--- a/ports/teensy/mpconfigport.h
+++ b/ports/teensy/mpconfigport.h
@@ -62,8 +62,6 @@ typedef int32_t mp_int_t; // must be pointer size
 typedef unsigned int mp_uint_t; // must be pointer size
 typedef long mp_off_t;
 
-#define MP_PLAT_PRINT_STRN(str, len) mp_hal_stdout_tx_strn_cooked(str, len)
-
 // We have inlined IRQ functions for efficiency (they are generally
 // 1 machine instruction).
 //


### PR DESCRIPTION
To simplify config, there's no need to specify MP_PLAT_PRINT_STRN if it's the same as the default definition in py/mpconfig.h.

