### PR TITLE
all: Consolidate BITS_PER_WORD, BITS_PER_BYTE, BYTES_PER_WORD macros

### DIFF
--- a/examples/embedding/hello-embed.c
+++ b/examples/embedding/hello-embed.c
@@ -53,7 +53,7 @@ mp_obj_t execute_from_str(const char *str) {
 
 int main() {
     // Initialized stack limit
-    mp_stack_set_limit(40000 * (BYTES_PER_WORD / 4));
+    mp_stack_set_limit(40000 * (sizeof(void *) / 4));
     // Initialize heap
     gc_init(heap, heap + sizeof(heap));
     // Initialize interpreter

--- a/mpy-cross/main.c
+++ b/mpy-cross/main.c
@@ -170,7 +170,7 @@ STATIC void pre_process_options(int argc, char **argv) {
                         heap_size *= 1024 * 1024;
                     }
                     if (word_adjust) {
-                        heap_size = heap_size * BYTES_PER_WORD / 4;
+                        heap_size = heap_size * MP_BYTES_PER_OBJ_WORD / 4;
                     }
                 } else {
                     exit(usage(argv));
@@ -182,7 +182,7 @@ STATIC void pre_process_options(int argc, char **argv) {
 }
 
 MP_NOINLINE int main_(int argc, char **argv) {
-    mp_stack_set_limit(40000 * (BYTES_PER_WORD / 4));
+    mp_stack_set_limit(40000 * (sizeof(void *) / 4));
 
     pre_process_options(argc, argv);
 

--- a/ports/esp32/mpconfigport.h
+++ b/ports/esp32/mpconfigport.h
@@ -221,7 +221,6 @@ struct mp_bluetooth_nimble_root_pointers_t;
 
 // type definitions for the specific machine
 
-#define BYTES_PER_WORD (4)
 #define MICROPY_MAKE_POINTER_CALLABLE(p) ((void *)((mp_uint_t)(p)))
 void *esp_native_code_commit(void *, size_t, void *);
 #define MP_PLAT_COMMIT_EXEC(buf, len, reloc) esp_native_code_commit(buf, len, reloc)

--- a/ports/nrf/mpconfigport.h
+++ b/ports/nrf/mpconfigport.h
@@ -201,8 +201,6 @@
 
 // type definitions for the specific machine
 
-#define BYTES_PER_WORD (4)
-
 #define MICROPY_MAKE_POINTER_CALLABLE(p) ((void *)((mp_uint_t)(p) | 1))
 
 #define MP_SSIZE_MAX (0x7fffffff)

--- a/ports/unix/main.c
+++ b/ports/unix/main.c
@@ -387,7 +387,7 @@ STATIC void pre_process_options(int argc, char **argv) {
                         goto invalid_arg;
                     }
                     if (word_adjust) {
-                        heap_size = heap_size * BYTES_PER_WORD / 4;
+                        heap_size = heap_size * MP_BYTES_PER_OBJ_WORD / 4;
                     }
                     // If requested size too small, we'll crash anyway
                     if (heap_size < 700) {
@@ -446,7 +446,7 @@ MP_NOINLINE int main_(int argc, char **argv) {
     signal(SIGPIPE, SIG_IGN);
     #endif
 
-    mp_stack_set_limit(40000 * (BYTES_PER_WORD / 4));
+    mp_stack_set_limit(40000 * (sizeof(void *) / 4));
 
     pre_process_options(argc, argv);
 

--- a/ports/unix/mpthreadport.c
+++ b/ports/unix/mpthreadport.c
@@ -206,7 +206,7 @@ void mp_thread_start(void) {
 void mp_thread_create(void *(*entry)(void *), void *arg, size_t *stack_size) {
     // default stack size is 8k machine-words
     if (*stack_size == 0) {
-        *stack_size = 8192 * BYTES_PER_WORD;
+        *stack_size = 8192 * sizeof(void *);
     }
 
     // minimum stack size is set by pthreads

--- a/py/binary.c
+++ b/py/binary.c
@@ -321,7 +321,7 @@ void mp_binary_set_val(char struct_type, char val_type, mp_obj_t val_in, byte *p
                     double f;
             } fp_dp;
             fp_dp.f = mp_obj_get_float_to_d(val_in);
-            if (BYTES_PER_WORD == 8) {
+            if (MP_BYTES_PER_OBJ_WORD == 8) {
                 val = fp_dp.i64;
             } else {
                 int be = struct_type == '>';
@@ -342,7 +342,7 @@ void mp_binary_set_val(char struct_type, char val_type, mp_obj_t val_in, byte *p
 
             val = mp_obj_get_int(val_in);
             // zero/sign extend if needed
-            if (BYTES_PER_WORD < 8 && size > sizeof(val)) {
+            if (MP_BYTES_PER_OBJ_WORD < 8 && size > sizeof(val)) {
                 int c = (mp_int_t)val < 0 ? 0xff : 0x00;
                 memset(p, c, size);
                 if (struct_type == '>') {

--- a/py/emitbc.c
+++ b/py/emitbc.c
@@ -36,7 +36,7 @@
 
 #if MICROPY_ENABLE_COMPILER
 
-#define BYTES_FOR_INT ((BYTES_PER_WORD * 8 + 6) / 7)
+#define BYTES_FOR_INT ((MP_BYTES_PER_OBJ_WORD * 8 + 6) / 7)
 #define DUMMY_DATA_SIZE (BYTES_FOR_INT)
 
 struct _emit_t {

--- a/py/gc.c
+++ b/py/gc.c
@@ -118,9 +118,9 @@ void gc_init(void *start, void *end) {
     // => T = A * (1 + BLOCKS_PER_ATB / BLOCKS_PER_FTB + BLOCKS_PER_ATB * BYTES_PER_BLOCK)
     size_t total_byte_len = (byte *)end - (byte *)start;
     #if MICROPY_ENABLE_FINALISER
-    MP_STATE_MEM(gc_alloc_table_byte_len) = total_byte_len * BITS_PER_BYTE / (BITS_PER_BYTE + BITS_PER_BYTE * BLOCKS_PER_ATB / BLOCKS_PER_FTB + BITS_PER_BYTE * BLOCKS_PER_ATB * BYTES_PER_BLOCK);
+    MP_STATE_MEM(gc_alloc_table_byte_len) = total_byte_len * MP_BITS_PER_BYTE / (MP_BITS_PER_BYTE + MP_BITS_PER_BYTE * BLOCKS_PER_ATB / BLOCKS_PER_FTB + MP_BITS_PER_BYTE * BLOCKS_PER_ATB * BYTES_PER_BLOCK);
     #else
-    MP_STATE_MEM(gc_alloc_table_byte_len) = total_byte_len / (1 + BITS_PER_BYTE / 2 * BYTES_PER_BLOCK);
+    MP_STATE_MEM(gc_alloc_table_byte_len) = total_byte_len / (1 + MP_BITS_PER_BYTE / 2 * BYTES_PER_BLOCK);
     #endif
 
     MP_STATE_MEM(gc_alloc_table_start) = (byte *)start;

--- a/py/gc.c
+++ b/py/gc.c
@@ -49,7 +49,7 @@
 // detect untraced object still in use
 #define CLEAR_ON_SWEEP (0)
 
-#define WORDS_PER_BLOCK ((MICROPY_BYTES_PER_GC_BLOCK) / BYTES_PER_WORD)
+#define WORDS_PER_BLOCK ((MICROPY_BYTES_PER_GC_BLOCK) / MP_BYTES_PER_OBJ_WORD)
 #define BYTES_PER_BLOCK (MICROPY_BYTES_PER_GC_BLOCK)
 
 // ATB = allocation table byte

--- a/py/mpconfig.h
+++ b/py/mpconfig.h
@@ -1535,8 +1535,9 @@ typedef double mp_float_t;
 #define BYTES_PER_WORD (sizeof(mp_uint_t))
 #endif
 
-#ifndef BITS_PER_BYTE
-#define BITS_PER_BYTE (8)
+// Number of bits in a byte
+#ifndef MP_BITS_PER_BYTE
+#define MP_BITS_PER_BYTE (8)
 #endif
 // mp_int_t value with most significant bit set
 #define WORD_MSBIT_HIGH (((mp_uint_t)1) << (BYTES_PER_WORD * 8 - 1))

--- a/py/mpconfig.h
+++ b/py/mpconfig.h
@@ -126,7 +126,7 @@
 // Number of bytes in memory allocation/GC block. Any size allocated will be
 // rounded up to be multiples of this.
 #ifndef MICROPY_BYTES_PER_GC_BLOCK
-#define MICROPY_BYTES_PER_GC_BLOCK (4 * BYTES_PER_WORD)
+#define MICROPY_BYTES_PER_GC_BLOCK (4 * MP_BYTES_PER_OBJ_WORD)
 #endif
 
 // Number of words allocated (in BSS) to the GC stack (minimum is 1)
@@ -1530,9 +1530,9 @@ typedef double mp_float_t;
 #define STATIC static
 #endif
 
-// Number of bytes in a word
-#ifndef BYTES_PER_WORD
-#define BYTES_PER_WORD (sizeof(mp_uint_t))
+// Number of bytes in an object word: mp_obj_t, mp_uint_t, mp_uint_t
+#ifndef MP_BYTES_PER_OBJ_WORD
+#define MP_BYTES_PER_OBJ_WORD (sizeof(mp_uint_t))
 #endif
 
 // Number of bits in a byte
@@ -1540,7 +1540,7 @@ typedef double mp_float_t;
 #define MP_BITS_PER_BYTE (8)
 #endif
 // mp_int_t value with most significant bit set
-#define WORD_MSBIT_HIGH (((mp_uint_t)1) << (BYTES_PER_WORD * 8 - 1))
+#define WORD_MSBIT_HIGH (((mp_uint_t)1) << (MP_BYTES_PER_OBJ_WORD * MP_BITS_PER_BYTE - 1))
 
 // Make sure both MP_ENDIANNESS_LITTLE and MP_ENDIANNESS_BIG are
 // defined and that they are the opposite of each other.

--- a/py/mpconfig.h
+++ b/py/mpconfig.h
@@ -1538,7 +1538,6 @@ typedef double mp_float_t;
 #ifndef BITS_PER_BYTE
 #define BITS_PER_BYTE (8)
 #endif
-#define BITS_PER_WORD (BITS_PER_BYTE * BYTES_PER_WORD)
 // mp_int_t value with most significant bit set
 #define WORD_MSBIT_HIGH (((mp_uint_t)1) << (BYTES_PER_WORD * 8 - 1))
 

--- a/py/mpconfig.h
+++ b/py/mpconfig.h
@@ -1540,7 +1540,7 @@ typedef double mp_float_t;
 #define MP_BITS_PER_BYTE (8)
 #endif
 // mp_int_t value with most significant bit set
-#define WORD_MSBIT_HIGH (((mp_uint_t)1) << (MP_BYTES_PER_OBJ_WORD * MP_BITS_PER_BYTE - 1))
+#define MP_OBJ_WORD_MSBIT_HIGH (((mp_uint_t)1) << (MP_BYTES_PER_OBJ_WORD * MP_BITS_PER_BYTE - 1))
 
 // Make sure both MP_ENDIANNESS_LITTLE and MP_ENDIANNESS_BIG are
 // defined and that they are the opposite of each other.

--- a/py/mpz.c
+++ b/py/mpz.c
@@ -1573,7 +1573,7 @@ bool mpz_as_int_checked(const mpz_t *i, mp_int_t *value) {
     mpz_dig_t *d = i->dig + i->len;
 
     while (d-- > i->dig) {
-        if (val > (~(WORD_MSBIT_HIGH) >> DIG_SIZE)) {
+        if (val > (~(MP_OBJ_WORD_MSBIT_HIGH) >> DIG_SIZE)) {
             // will overflow
             return false;
         }
@@ -1598,7 +1598,7 @@ bool mpz_as_uint_checked(const mpz_t *i, mp_uint_t *value) {
     mpz_dig_t *d = i->dig + i->len;
 
     while (d-- > i->dig) {
-        if (val > (~(WORD_MSBIT_HIGH) >> (DIG_SIZE - 1))) {
+        if (val > (~(MP_OBJ_WORD_MSBIT_HIGH) >> (DIG_SIZE - 1))) {
             // will overflow
             return false;
         }

--- a/py/objfloat.c
+++ b/py/objfloat.c
@@ -77,7 +77,7 @@ mp_int_t mp_float_hash(mp_float_t src) {
             // number may have a fraction; xor the integer part with the fractional part
             val = (frc >> (MP_FLOAT_FRAC_BITS - adj_exp))
                 ^ (frc & (((mp_float_uint_t)1 << (MP_FLOAT_FRAC_BITS - adj_exp)) - 1));
-        } else if ((unsigned int)adj_exp < BITS_PER_BYTE * sizeof(mp_int_t) - 1) {
+        } else if ((unsigned int)adj_exp < MP_BITS_PER_BYTE * sizeof(mp_int_t) - 1) {
             // the number is a (big) whole integer and will fit in val's signed-width
             val = (mp_int_t)frc << (adj_exp - MP_FLOAT_FRAC_BITS);
         } else {

--- a/py/objint.c
+++ b/py/objint.c
@@ -121,7 +121,7 @@ STATIC mp_fp_as_int_class_t mp_classify_fp_as_int(mp_float_t val) {
         return MP_FP_CLASS_FIT_SMALLINT;
     }
     #if MICROPY_LONGINT_IMPL == MICROPY_LONGINT_IMPL_LONGLONG
-    if (e <= (((sizeof(long long) * BITS_PER_BYTE) + MP_FLOAT_EXP_BIAS - 2) << MP_FLOAT_EXP_SHIFT_I32)) {
+    if (e <= (((sizeof(long long) * MP_BITS_PER_BYTE) + MP_FLOAT_EXP_BIAS - 2) << MP_FLOAT_EXP_SHIFT_I32)) {
         return MP_FP_CLASS_FIT_LONGINT;
     }
     #endif

--- a/py/persistentcode.c
+++ b/py/persistentcode.c
@@ -595,7 +595,7 @@ STATIC void mp_print_bytes(mp_print_t *print, const byte *data, size_t len) {
     print->print_strn(print->data, (const char *)data, len);
 }
 
-#define BYTES_FOR_INT ((BYTES_PER_WORD * 8 + 6) / 7)
+#define BYTES_FOR_INT ((MP_BYTES_PER_OBJ_WORD * 8 + 6) / 7)
 STATIC void mp_print_uint(mp_print_t *print, size_t n) {
     byte buf[BYTES_FOR_INT];
     byte *p = buf + sizeof(buf);

--- a/py/runtime.c
+++ b/py/runtime.c
@@ -387,7 +387,7 @@ mp_obj_t mp_binary_op(mp_binary_op_t op, mp_obj_t lhs, mp_obj_t rhs) {
                     if (rhs_val < 0) {
                         // negative shift not allowed
                         mp_raise_ValueError(MP_ERROR_TEXT("negative shift count"));
-                    } else if (rhs_val >= (mp_int_t)(sizeof(lhs_val) * BITS_PER_BYTE)
+                    } else if (rhs_val >= (mp_int_t)(sizeof(lhs_val) * MP_BITS_PER_BYTE)
                                || lhs_val > (MP_SMALL_INT_MAX >> rhs_val)
                                || lhs_val < (MP_SMALL_INT_MIN >> rhs_val)) {
                         // left-shift will overflow, so use higher precision integer
@@ -406,10 +406,10 @@ mp_obj_t mp_binary_op(mp_binary_op_t op, mp_obj_t lhs, mp_obj_t rhs) {
                         mp_raise_ValueError(MP_ERROR_TEXT("negative shift count"));
                     } else {
                         // standard precision is enough for right-shift
-                        if (rhs_val >= (mp_int_t)(sizeof(lhs_val) * BITS_PER_BYTE)) {
+                        if (rhs_val >= (mp_int_t)(sizeof(lhs_val) * MP_BITS_PER_BYTE)) {
                             // Shifting to big amounts is underfined behavior
                             // in C and is CPU-dependent; propagate sign bit.
-                            rhs_val = sizeof(lhs_val) * BITS_PER_BYTE - 1;
+                            rhs_val = sizeof(lhs_val) * MP_BITS_PER_BYTE - 1;
                         }
                         lhs_val >>= rhs_val;
                     }

--- a/py/runtime.c
+++ b/py/runtime.c
@@ -387,7 +387,9 @@ mp_obj_t mp_binary_op(mp_binary_op_t op, mp_obj_t lhs, mp_obj_t rhs) {
                     if (rhs_val < 0) {
                         // negative shift not allowed
                         mp_raise_ValueError(MP_ERROR_TEXT("negative shift count"));
-                    } else if (rhs_val >= (mp_int_t)BITS_PER_WORD || lhs_val > (MP_SMALL_INT_MAX >> rhs_val) || lhs_val < (MP_SMALL_INT_MIN >> rhs_val)) {
+                    } else if (rhs_val >= (mp_int_t)(sizeof(lhs_val) * BITS_PER_BYTE)
+                               || lhs_val > (MP_SMALL_INT_MAX >> rhs_val)
+                               || lhs_val < (MP_SMALL_INT_MIN >> rhs_val)) {
                         // left-shift will overflow, so use higher precision integer
                         lhs = mp_obj_new_int_from_ll(lhs_val);
                         goto generic_binary_op;
@@ -404,10 +406,10 @@ mp_obj_t mp_binary_op(mp_binary_op_t op, mp_obj_t lhs, mp_obj_t rhs) {
                         mp_raise_ValueError(MP_ERROR_TEXT("negative shift count"));
                     } else {
                         // standard precision is enough for right-shift
-                        if (rhs_val >= (mp_int_t)BITS_PER_WORD) {
+                        if (rhs_val >= (mp_int_t)(sizeof(lhs_val) * BITS_PER_BYTE)) {
                             // Shifting to big amounts is underfined behavior
                             // in C and is CPU-dependent; propagate sign bit.
-                            rhs_val = BITS_PER_WORD - 1;
+                            rhs_val = sizeof(lhs_val) * BITS_PER_BYTE - 1;
                         }
                         lhs_val >>= rhs_val;
                     }

--- a/py/smallint.h
+++ b/py/smallint.h
@@ -36,17 +36,17 @@
 // In SMALL_INT, next-to-highest bits is used as sign, so both must match for value in range
 #if MICROPY_OBJ_REPR == MICROPY_OBJ_REPR_A || MICROPY_OBJ_REPR == MICROPY_OBJ_REPR_C
 
-#define MP_SMALL_INT_MIN ((mp_int_t)(((mp_int_t)WORD_MSBIT_HIGH) >> 1))
-#define MP_SMALL_INT_FITS(n) ((((n) ^ ((n) << 1)) & WORD_MSBIT_HIGH) == 0)
+#define MP_SMALL_INT_MIN ((mp_int_t)(((mp_int_t)MP_OBJ_WORD_MSBIT_HIGH) >> 1))
+#define MP_SMALL_INT_FITS(n) ((((n) ^ ((n) << 1)) & MP_OBJ_WORD_MSBIT_HIGH) == 0)
 // Mask to truncate mp_int_t to positive value
-#define MP_SMALL_INT_POSITIVE_MASK ~(WORD_MSBIT_HIGH | (WORD_MSBIT_HIGH >> 1))
+#define MP_SMALL_INT_POSITIVE_MASK ~(MP_OBJ_WORD_MSBIT_HIGH | (MP_OBJ_WORD_MSBIT_HIGH >> 1))
 
 #elif MICROPY_OBJ_REPR == MICROPY_OBJ_REPR_B
 
-#define MP_SMALL_INT_MIN ((mp_int_t)(((mp_int_t)WORD_MSBIT_HIGH) >> 2))
+#define MP_SMALL_INT_MIN ((mp_int_t)(((mp_int_t)MP_OBJ_WORD_MSBIT_HIGH) >> 2))
 #define MP_SMALL_INT_FITS(n) ((((n) & MP_SMALL_INT_MIN) == 0) || (((n) & MP_SMALL_INT_MIN) == MP_SMALL_INT_MIN))
 // Mask to truncate mp_int_t to positive value
-#define MP_SMALL_INT_POSITIVE_MASK ~(WORD_MSBIT_HIGH | (WORD_MSBIT_HIGH >> 1) | (WORD_MSBIT_HIGH >> 2))
+#define MP_SMALL_INT_POSITIVE_MASK ~(MP_OBJ_WORD_MSBIT_HIGH | (MP_OBJ_WORD_MSBIT_HIGH >> 1) | (MP_OBJ_WORD_MSBIT_HIGH >> 2))
 
 #elif MICROPY_OBJ_REPR == MICROPY_OBJ_REPR_D
 


### PR DESCRIPTION
These are all renamed (or in the case of BITS_PER_WORD removed) to prefix with `MP_` and make it clearer what they measure (machine word vs object word, differs on nan-boxing builds).

See individual commits for more info.