### PR TITLE
py/gc: Change include of stdint.h to stddef.h.

### DIFF
--- a/ports/esp8266/gccollect.h
+++ b/ports/esp8266/gccollect.h
@@ -26,6 +26,8 @@
 #ifndef MICROPY_INCLUDED_ESP8266_GCCOLLECT_H
 #define MICROPY_INCLUDED_ESP8266_GCCOLLECT_H
 
+#include <stdint.h>
+
 extern uint32_t _text_start;
 extern uint32_t _text_end;
 extern uint32_t _irom0_text_start;

--- a/py/gc.h
+++ b/py/gc.h
@@ -27,7 +27,7 @@
 #define MICROPY_INCLUDED_PY_GC_H
 
 #include <stdbool.h>
-#include <stdint.h>
+#include <stddef.h>
 
 void gc_init(void *start, void *end);
 


### PR DESCRIPTION
No std-int types are used in gc.h, but size_t is which needs stddef.h.

Follow up from #6763.