### PR TITLE
extmod/moduhashlib: allow multiple calls to digest() method

### DIFF
--- a/extmod/moduhashlib.c
+++ b/extmod/moduhashlib.c
@@ -98,7 +98,8 @@ STATIC mp_obj_t uhashlib_sha256_digest(mp_obj_t self_in) {
     mp_obj_hash_t *self = MP_OBJ_TO_PTR(self_in);
     vstr_t vstr;
     vstr_init_len(&vstr, 32);
-    mbedtls_sha256_finish_ret((mbedtls_sha256_context *)&self->state, (unsigned char *)vstr.buf);
+    mbedtls_sha256_context tmp_ctx = *(mbedtls_sha256_context *)self->state;
+    mbedtls_sha256_finish_ret(&tmp_ctx, (unsigned char *)vstr.buf);
     return mp_obj_new_str_from_vstr(&mp_type_bytes, &vstr);
 }
 
@@ -129,7 +130,8 @@ STATIC mp_obj_t uhashlib_sha256_digest(mp_obj_t self_in) {
     mp_obj_hash_t *self = MP_OBJ_TO_PTR(self_in);
     vstr_t vstr;
     vstr_init_len(&vstr, SHA256_BLOCK_SIZE);
-    sha256_final((CRYAL_SHA256_CTX *)self->state, (byte *)vstr.buf);
+    CRYAL_SHA256_CTX tmp_ctx = *(CRYAL_SHA256_CTX *)self->state;
+    sha256_final(&tmp_ctx, (byte *)vstr.buf);
     return mp_obj_new_str_from_vstr(&mp_type_bytes, &vstr);
 }
 #endif

--- a/tests/extmod/uhashlib_sha256.py
+++ b/tests/extmod/uhashlib_sha256.py
@@ -26,13 +26,13 @@ print(hashlib.sha256(b"\xff" * 64).digest())
 # 56 bytes is a boundary case in the algorithm
 print(hashlib.sha256(b"\xff" * 56).digest())
 
-# TODO: running .digest() several times in row is not supported()
-# h = hashlib.sha256(b'123')
-# print(h.digest())
-# print(h.digest())
+# running .digest() several times in row is now supported
+h = hashlib.sha256(b'123')
+print(h.digest())
+print(h.digest())
 
-# TODO: partial digests are not supported
-# h = hashlib.sha256(b'123')
-# print(h.digest())
-# h.update(b'456')
-# print(h.digest())
+# partial digests are supported
+h = hashlib.sha256(b'123')
+print(h.digest())
+h.update(b'456')
+print(h.digest())


### PR DESCRIPTION
It's useful to be able to call `digest()` multiple times on a `sha256` object, and no way to code around the previous limitation of the `uhashlib` module which did not support that.

Fix is to copy the context and do the finalize operation on the copy. Cost is minimal (stack depth, one copy), and IMO, required by the API imposed by [PEP 452](https://www.python.org/dev/peps/pep-0452/). As it was, the sha256() object was left in an invalid state after first digest call and subsequent calls were returning garbage.

In my opinion, the right API for embedded systems, is to keep this fully-featured object-oriented API for complex cases, but also provide a single-shot function that doesn't keep state, and simply returns the binary digest of its only argument. A simple functional API like that can also accommodate hardware acceleration, which would be very difficult with the OO API.