### PR TITLE
rp2: Add timeout and invert to the machine.uart class

### DIFF
--- a/ports/rp2/machine_uart.c
+++ b/ports/rp2/machine_uart.c
@@ -69,15 +69,16 @@ STATIC machine_uart_obj_t machine_uart_obj[] = {
 };
 
 STATIC const char *_parity_name[] = {"None", "0", "1"};
+STATIC const char *_invert_name[] = {"None", "TX", "RX", "RX, TX"};
 
 /******************************************************************************/
 // MicroPython bindings for UART
 
 STATIC void machine_uart_print(const mp_print_t *print, mp_obj_t self_in, mp_print_kind_t kind) {
     machine_uart_obj_t *self = MP_OBJ_TO_PTR(self_in);
-    mp_printf(print, "UART(%u, baudrate=%u, bits=%u, parity=%s, stop=%u, tx=%d, rx=%d, timeout=%u, timeout_char=%u)",
+    mp_printf(print, "UART(%u, baudrate=%u, bits=%u, parity=%s, stop=%u, tx=%d, rx=%d, timeout=%u, timeout_char=%u, invert=%s)",
         self->uart_id, self->baudrate, self->bits, _parity_name[self->parity],
-        self->stop, self->tx, self->rx, self->timeout, self->timeout_char);
+        self->stop, self->tx, self->rx, self->timeout, self->timeout_char, _invert_name[self->invert]);
 }
 
 STATIC mp_obj_t machine_uart_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *all_args) {

--- a/ports/rp2/mpconfigport.h
+++ b/ports/rp2/mpconfigport.h
@@ -62,6 +62,7 @@
 #define MICROPY_LONGINT_IMPL                    (MICROPY_LONGINT_IMPL_MPZ)
 #define MICROPY_ENABLE_SOURCE_LINE              (1)
 #define MICROPY_FLOAT_IMPL                      (MICROPY_FLOAT_IMPL_FLOAT)
+#define MICROPY_STREAMS_NON_BLOCK               (1)
 #define MICROPY_MODULE_BUILTIN_INIT             (1)
 #define MICROPY_MODULE_WEAK_LINKS               (1)
 #define MICROPY_CAN_OVERRIDE_BUILTINS           (1)


### PR DESCRIPTION
This is a first attempt. It works, timeout and timeout_chars can be set and the object is properly printed, but there is an inherent problem in the way, machine_uart_read() and maybe machine_uart_write() is called. The problem is, when .e.g at uart.read() the numbers requested is larger than the ones in the FIFO. And that is different to e.g. the esp32 port.
```
Situation          ESP32    RP2
request == present  OK       OK
none requested      OK      Error
request > present   OK      Error
```
What happens is, that on the RP2, if machine_uart_read() returns less than the initially requested bytes, it will be called again with the remaining number, which will then run into a timeout. On ESP32, the caller is just happy with what it got and returns to the top level. When uart.read() is called without an argument, the size at the machine_uart_read() is 256.
So the stream algorithm behaves different. machine_uart_read() is called different in these two ports.

As a temporary fix, the function machine_uart_read() returns on timeout without an error and with the numbers of bytes read.