### PR TITLE
extmod/uasyncio: Add ThreadSafeEvent.

### DIFF
--- a/docs/library/uasyncio.rst
+++ b/docs/library/uasyncio.rst
@@ -125,6 +125,9 @@ class Event
 
     Set the event.  Any tasks waiting on the event will be scheduled to run.
 
+    Note: This must be called from within a task. It is not safe to call this
+    from an IRQ, scheduler callback, or other thread. See `ThreadSafeFlag`.
+
 .. method:: Event.clear()
 
     Clear the event.
@@ -133,6 +136,29 @@ class Event
 
     Wait for the event to be set.  If the event is already set then it returns
     immediately.
+
+    This is a coroutine.
+
+class ThreadSafeFlag
+--------------------
+
+.. class:: ThreadSafeFlag()
+
+    Create a new flag which can be used to synchronise a task with code running
+    outside the asyncio loop, such as other threads, IRQs, or scheduler
+    callbacks.  Flags start in the cleared state.
+
+.. method:: ThreadSafeFlag.set()
+
+    Set the flag.  If there is a task waiting on the event, it will be scheduled
+    to run.
+
+.. method:: ThreadSafeFlag.wait()
+
+    Wait for the flag to be set.  If the flag is already set then it returns
+    immediately.
+
+    A flag may only be waited on by a single task at a time.
 
     This is a coroutine.
 
@@ -188,7 +214,7 @@ TCP stream connections
     This is a coroutine.
 
 .. class:: Stream()
-    
+
     This represents a TCP stream connection.  To minimise code this class implements
     both a reader and a writer, and both ``StreamReader`` and ``StreamWriter`` alias to
     this class.

--- a/extmod/uasyncio/__init__.py
+++ b/extmod/uasyncio/__init__.py
@@ -10,6 +10,7 @@ _attrs = {
     "wait_for_ms": "funcs",
     "gather": "funcs",
     "Event": "event",
+    "ThreadSafeFlag": "event",
     "Lock": "lock",
     "open_connection": "stream",
     "start_server": "stream",

--- a/extmod/uasyncio/event.py
+++ b/extmod/uasyncio/event.py
@@ -14,6 +14,8 @@ class Event:
 
     def set(self):
         # Event becomes set, schedule any tasks waiting on it
+        # Note: This must not be called from anything except the thread running
+        # the asyncio loop (i.e. neither hard or soft IRQ, or a different thread).
         while self.waiting.peek():
             core._task_queue.push_head(self.waiting.pop_head())
         self.state = True
@@ -29,3 +31,32 @@ class Event:
             core.cur_task.data = self.waiting
             yield
         return True
+
+
+# MicroPython-extension: This can be set from outside the asyncio event loop,
+# such as other threads, IRQs or scheduler context. Implementation is a stream
+# that asyncio will poll until a flag is set.
+# Note: Unlike Event, this is self-clearing.
+try:
+    import uio
+
+    class ThreadSafeFlag(uio.IOBase):
+        def __init__(self):
+            self._flag = 0
+
+        def ioctl(self, req, flags):
+            if req == 3:  # MP_STREAM_POLL
+                return self._flag * flags
+            return None
+
+        def set(self):
+            self._flag = 1
+
+        async def wait(self):
+            if not self._flag:
+                yield core._io_queue.queue_read(self)
+            self._flag = 0
+
+
+except ImportError:
+    pass

--- a/tests/extmod/uasyncio_threadsafeflag.py
+++ b/tests/extmod/uasyncio_threadsafeflag.py
@@ -1,0 +1,79 @@
+# Test Event class
+
+try:
+    import uasyncio as asyncio
+except ImportError:
+    print("SKIP")
+    raise SystemExit
+
+
+import micropython
+
+try:
+    micropython.schedule
+except AttributeError:
+    print("SKIP")
+    raise SystemExit
+
+
+try:
+    # Unix port can't select/poll on user-defined types.
+    import uselect as select
+
+    poller = select.poll()
+    poller.register(asyncio.ThreadSafeFlag())
+except TypeError:
+    print("SKIP")
+    raise SystemExit
+
+
+async def task(id, flag):
+    print("task", id)
+    await flag.wait()
+    print("task", id, "done")
+
+
+def set_from_schedule(flag):
+    print("schedule")
+    flag.set()
+    print("schedule done")
+
+
+async def main():
+    flag = asyncio.ThreadSafeFlag()
+
+    # Set the flag from within the loop.
+    t = asyncio.create_task(task(1, flag))
+    print("yield")
+    await asyncio.sleep(0)
+    print("set event")
+    flag.set()
+    print("yield")
+    await asyncio.sleep(0)
+    print("wait task")
+    await t
+
+    # Set the flag from scheduler context.
+    print("----")
+    t = asyncio.create_task(task(2, flag))
+    print("yield")
+    await asyncio.sleep(0)
+    print("set event")
+    micropython.schedule(set_from_schedule, flag)
+    print("yield")
+    await asyncio.sleep(0)
+    print("wait task")
+    await t
+
+    # Flag already set.
+    print("----")
+    print("set event")
+    flag.set()
+    t = asyncio.create_task(task(3, flag))
+    print("yield")
+    await asyncio.sleep(0)
+    print("wait task")
+    await t
+
+
+asyncio.run(main())

--- a/tests/extmod/uasyncio_threadsafeflag.py.exp
+++ b/tests/extmod/uasyncio_threadsafeflag.py.exp
@@ -1,0 +1,21 @@
+yield
+task 1
+set event
+yield
+wait task
+task 1 done
+----
+yield
+task 2
+set event
+yield
+schedule
+schedule done
+wait task
+task 2 done
+----
+set event
+yield
+task 3
+task 3 done
+wait task


### PR DESCRIPTION
This is a MicroPython-extension that allows for events to be set from IRQ (hard or soft) or scheduler context.

Works on the bare-metal ports (which use extmod/uselect). To use this on Unix requires PR #6885