### PR TITLE
stm32: Add uart_set_baudrate() function and use it in set up of BLE HCI

### DIFF
--- a/ports/stm32/boards/stm32f0xx_hal_conf_base.h
+++ b/ports/stm32/boards/stm32f0xx_hal_conf_base.h
@@ -49,6 +49,7 @@
 #include "stm32f0xx_hal_wwdg.h"
 #include "stm32f0xx_ll_adc.h"
 #include "stm32f0xx_ll_rtc.h"
+#include "stm32f0xx_ll_usart.h"
 
 // Enable various HAL modules
 #define HAL_MODULE_ENABLED

--- a/ports/stm32/boards/stm32f4xx_hal_conf_base.h
+++ b/ports/stm32/boards/stm32f4xx_hal_conf_base.h
@@ -56,6 +56,7 @@
 #include "stm32f4xx_ll_adc.h"
 #include "stm32f4xx_ll_pwr.h"
 #include "stm32f4xx_ll_rtc.h"
+#include "stm32f4xx_ll_usart.h"
 
 // Enable various HAL modules
 #define HAL_ADC_MODULE_ENABLED

--- a/ports/stm32/boards/stm32f7xx_hal_conf_base.h
+++ b/ports/stm32/boards/stm32f7xx_hal_conf_base.h
@@ -56,6 +56,7 @@
 #include "stm32f7xx_ll_adc.h"
 #include "stm32f7xx_ll_pwr.h"
 #include "stm32f7xx_ll_rtc.h"
+#include "stm32f7xx_ll_usart.h"
 
 // Enable various HAL modules
 #define HAL_ADC_MODULE_ENABLED

--- a/ports/stm32/boards/stm32h7xx_hal_conf_base.h
+++ b/ports/stm32/boards/stm32h7xx_hal_conf_base.h
@@ -56,6 +56,7 @@
 #include "stm32h7xx_ll_adc.h"
 #include "stm32h7xx_ll_pwr.h"
 #include "stm32h7xx_ll_rtc.h"
+#include "stm32h7xx_ll_usart.h"
 
 // Enable various HAL modules
 #define HAL_ADC_MODULE_ENABLED

--- a/ports/stm32/boards/stm32l0xx_hal_conf_base.h
+++ b/ports/stm32/boards/stm32l0xx_hal_conf_base.h
@@ -48,6 +48,7 @@
 #include "stm32l0xx_hal_wwdg.h"
 #include "stm32l0xx_ll_adc.h"
 #include "stm32l0xx_ll_rtc.h"
+#include "stm32l0xx_ll_usart.h"
 
 // Enable various HAL modules
 #define HAL_MODULE_ENABLED

--- a/ports/stm32/boards/stm32l4xx_hal_conf_base.h
+++ b/ports/stm32/boards/stm32l4xx_hal_conf_base.h
@@ -52,6 +52,7 @@
 #include "stm32l4xx_hal_wwdg.h"
 #include "stm32l4xx_ll_adc.h"
 #include "stm32l4xx_ll_rtc.h"
+#include "stm32l4xx_ll_usart.h"
 
 // Enable various HAL modules
 #define HAL_MODULE_ENABLED

--- a/ports/stm32/boards/stm32wbxx_hal_conf_base.h
+++ b/ports/stm32/boards/stm32wbxx_hal_conf_base.h
@@ -43,6 +43,7 @@
 #include "stm32wbxx_hal_usart.h"
 #include "stm32wbxx_ll_adc.h"
 #include "stm32wbxx_ll_rtc.h"
+#include "stm32wbxx_ll_usart.h"
 
 // Enable various HAL modules
 #define HAL_MODULE_ENABLED

--- a/ports/stm32/uart.h
+++ b/ports/stm32/uart.h
@@ -86,6 +86,8 @@ void uart_irq_handler(mp_uint_t uart_id);
 
 void uart_attach_to_repl(pyb_uart_obj_t *self, bool attached);
 uint32_t uart_get_baudrate(pyb_uart_obj_t *self);
+void uart_set_baudrate(pyb_uart_obj_t *self, uint32_t baudrate);
+
 mp_uint_t uart_rx_any(pyb_uart_obj_t *uart_obj);
 bool uart_rx_wait(pyb_uart_obj_t *self, uint32_t timeout);
 int uart_rx_char(pyb_uart_obj_t *uart_obj);


### PR DESCRIPTION
Can improve start up of some BT HCI controllers by not sending spurious characters on the UART TX when changing baudrate.