### PR TITLE
esp32/uart: Add flow keyword argument to enable hardware flow control

### DIFF
--- a/ports/esp32/machine_uart.c
+++ b/ports/esp32/machine_uart.c
@@ -39,6 +39,7 @@
 typedef struct _machine_uart_obj_t {
     mp_obj_base_t base;
     uart_port_t uart_num;
+    uart_hw_flowcontrol_t flowcontrol;
     uint8_t bits;
     uint8_t parity;
     uint8_t stop;
@@ -93,11 +94,25 @@ STATIC void machine_uart_print(const mp_print_t *print, mp_obj_t self_in, mp_pri
             mp_printf(print, "INV_CTS");
         }
     }
+    if (self->flowcontrol) {
+        mp_printf(print, ", flow=");
+        uint32_t flow_mask = self->flowcontrol;
+        if (flow_mask & UART_HW_FLOWCTRL_RTS) {
+            mp_printf(print, "FLOW_RTS");
+            flow_mask &= ~UART_HW_FLOWCTRL_RTS;
+            if (flow_mask) {
+                mp_printf(print, "|");
+            }
+        }
+        if (flow_mask & UART_HW_FLOWCTRL_CTS) {
+            mp_printf(print, "FLOW_CTS");
+        }
+    }
     mp_printf(print, ")");
 }
 
 STATIC void machine_uart_init_helper(machine_uart_obj_t *self, size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
-    enum { ARG_baudrate, ARG_bits, ARG_parity, ARG_stop, ARG_tx, ARG_rx, ARG_rts, ARG_cts, ARG_txbuf, ARG_rxbuf, ARG_timeout, ARG_timeout_char, ARG_invert };
+    enum { ARG_baudrate, ARG_bits, ARG_parity, ARG_stop, ARG_tx, ARG_rx, ARG_rts, ARG_cts, ARG_txbuf, ARG_rxbuf, ARG_timeout, ARG_timeout_char, ARG_invert, ARG_flow };
     static const mp_arg_t allowed_args[] = {
         { MP_QSTR_baudrate, MP_ARG_INT, {.u_int = 0} },
         { MP_QSTR_bits, MP_ARG_INT, {.u_int = 0} },
@@ -112,6 +127,7 @@ STATIC void machine_uart_init_helper(machine_uart_obj_t *self, size_t n_args, co
         { MP_QSTR_timeout, MP_ARG_KW_ONLY | MP_ARG_INT, {.u_int = 0} },
         { MP_QSTR_timeout_char, MP_ARG_KW_ONLY | MP_ARG_INT, {.u_int = 0} },
         { MP_QSTR_invert, MP_ARG_KW_ONLY | MP_ARG_INT, {.u_int = 0} },
+        { MP_QSTR_flow, MP_ARG_KW_ONLY | MP_ARG_INT, {.u_int = 0} },
     };
     mp_arg_val_t args[MP_ARRAY_SIZE(allowed_args)];
     mp_arg_parse_all(n_args, pos_args, kw_args, MP_ARRAY_SIZE(allowed_args), allowed_args, args);
@@ -243,6 +259,13 @@ STATIC void machine_uart_init_helper(machine_uart_obj_t *self, size_t n_args, co
     }
     self->invert = args[ARG_invert].u_int;
     uart_set_line_inverse(self->uart_num, self->invert);
+
+    // set hardware flow control
+    if (args[ARG_flow].u_int & ~UART_HW_FLOWCTRL_CTS_RTS) {
+        mp_raise_ValueError(MP_ERROR_TEXT("invalid flow control mask"));
+    }
+    self->flowcontrol = args[ARG_flow].u_int;
+    uart_set_hw_flow_ctrl(self->uart_num, self->flowcontrol, UART_FIFO_LEN >> 1);
 }
 
 STATIC mp_obj_t machine_uart_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *args) {
@@ -384,6 +407,9 @@ STATIC const mp_rom_map_elem_t machine_uart_locals_dict_table[] = {
     { MP_ROM_QSTR(MP_QSTR_INV_RX), MP_ROM_INT(UART_INVERSE_RXD) },
     { MP_ROM_QSTR(MP_QSTR_INV_RTS), MP_ROM_INT(UART_INVERSE_RTS) },
     { MP_ROM_QSTR(MP_QSTR_INV_CTS), MP_ROM_INT(UART_INVERSE_CTS) },
+
+    { MP_ROM_QSTR(MP_QSTR_FLOW_RTS), MP_ROM_INT(UART_HW_FLOWCTRL_RTS) },
+    { MP_ROM_QSTR(MP_QSTR_FLOW_CTS), MP_ROM_INT(UART_HW_FLOWCTRL_CTS) },
 };
 
 STATIC MP_DEFINE_CONST_DICT(machine_uart_locals_dict, machine_uart_locals_dict_table);


### PR DESCRIPTION
This allows the hardware UART to (optionally) control the RTS and/or CTS pins.

The new "flow" keyword specifies a bitmask of FLOW_RTS, FLOW_CTS.

Without this patch, the UART driver for ESP32 ignores the RTS and CTS pins.