### PR TITLE
STM32: Factory Reset not Executed.

### DIFF
--- a/ports/stm32/main.c
+++ b/ports/stm32/main.c
@@ -531,7 +531,7 @@ soft_reset:
     // Create it if needed, mount in on /flash, and set it as current dir.
     bool mounted_flash = false;
     #if MICROPY_HW_FLASH_MOUNT_AT_BOOT
-    mounted_flash = init_flash_fs(reset_mode);
+    mounted_flash = init_flash_fs(state.reset_mode);
     #endif
 
     bool mounted_sdcard = false;


### PR DESCRIPTION
Fixes micropython/micropython#6903

state.reset_mode is updated by `MICROPY_BOARD_BEFORE_SOFT_RESET_LOOP`
but not passed to `init_flash_fs`.