### PR TITLE
esp32: Add support for building with IDF v4.1.1 and v4.2

### DIFF
--- a/ports/esp32/README.md
+++ b/ports/esp32/README.md
@@ -28,7 +28,7 @@ manage the ESP32 microcontroller, as well as a way to manage the required
 build environment and toolchains needed to build the firmware.
 
 The ESP-IDF changes quickly and MicroPython only supports certain versions.
-Currently MicroPython supports v4.0.2 and v4.1.1,
+Currently MicroPython supports v4.0.2, v4.1.1 and v4.2,
 although other IDF v4 versions may also work.
 
 To install the ESP-IDF the full instructions can be found at the

--- a/ports/esp32/README.md
+++ b/ports/esp32/README.md
@@ -28,8 +28,8 @@ manage the ESP32 microcontroller, as well as a way to manage the required
 build environment and toolchains needed to build the firmware.
 
 The ESP-IDF changes quickly and MicroPython only supports certain versions.
-Currently MicroPython supports v4.0.2, although other IDF v4 versions may also
-work.
+Currently MicroPython supports v4.0.2 and v4.1.1,
+although other IDF v4 versions may also work.
 
 To install the ESP-IDF the full instructions can be found at the
 [Espressif Getting Started guide](https://docs.espressif.com/projects/esp-idf/en/v4.0.2/get-started/index.html#installation-step-by-step).
@@ -50,6 +50,7 @@ To check out a copy of the IDF use git clone:
 $ git clone -b v4.0.2 --recursive https://github.com/espressif/esp-idf.git
 ```
 
+You can replace `v4.0.2` with `v4.1.1` or any other supported version.
 (You don't need a full recursive clone; see the `ci_esp32_setup` function in
 `tools/ci.sh` in this repository for more detailed set-up commands.)
 

--- a/ports/esp32/esp32_ulp.c
+++ b/ports/esp32/esp32_ulp.c
@@ -85,11 +85,7 @@ STATIC const mp_rom_map_elem_t esp32_ulp_locals_dict_table[] = {
     { MP_ROM_QSTR(MP_QSTR_set_wakeup_period), MP_ROM_PTR(&esp32_ulp_set_wakeup_period_obj) },
     { MP_ROM_QSTR(MP_QSTR_load_binary), MP_ROM_PTR(&esp32_ulp_load_binary_obj) },
     { MP_ROM_QSTR(MP_QSTR_run), MP_ROM_PTR(&esp32_ulp_run_obj) },
-    #if !MICROPY_ESP_IDF_4
-    { MP_ROM_QSTR(MP_QSTR_RESERVE_MEM), MP_ROM_INT(CONFIG_ULP_COPROC_RESERVE_MEM) },
-    #else
     { MP_ROM_QSTR(MP_QSTR_RESERVE_MEM), MP_ROM_INT(CONFIG_ESP32_ULP_COPROC_RESERVE_MEM) },
-    #endif
 };
 STATIC MP_DEFINE_CONST_DICT(esp32_ulp_locals_dict, esp32_ulp_locals_dict_table);
 

--- a/ports/esp32/machine_uart.c
+++ b/ports/esp32/machine_uart.c
@@ -36,6 +36,20 @@
 #include "py/mperrno.h"
 #include "modmachine.h"
 
+#if ESP_IDF_VERSION < ESP_IDF_VERSION_VAL(4, 1, 0)
+#define UART_INV_TX UART_INVERSE_TXD
+#define UART_INV_RX UART_INVERSE_RXD
+#define UART_INV_RTS UART_INVERSE_RTS
+#define UART_INV_CTS UART_INVERSE_CTS
+#else
+#define UART_INV_TX UART_SIGNAL_TXD_INV
+#define UART_INV_RX UART_SIGNAL_RXD_INV
+#define UART_INV_RTS UART_SIGNAL_RTS_INV
+#define UART_INV_CTS UART_SIGNAL_CTS_INV
+#endif
+
+#define UART_INV_MASK (UART_INV_TX | UART_INV_RX | UART_INV_RTS | UART_INV_CTS)
+
 typedef struct _machine_uart_obj_t {
     mp_obj_base_t base;
     uart_port_t uart_num;
@@ -68,28 +82,28 @@ STATIC void machine_uart_print(const mp_print_t *print, mp_obj_t self_in, mp_pri
     if (self->invert) {
         mp_printf(print, ", invert=");
         uint32_t invert_mask = self->invert;
-        if (invert_mask & UART_INVERSE_TXD) {
+        if (invert_mask & UART_INV_TX) {
             mp_printf(print, "INV_TX");
-            invert_mask &= ~UART_INVERSE_TXD;
+            invert_mask &= ~UART_INV_TX;
             if (invert_mask) {
                 mp_printf(print, "|");
             }
         }
-        if (invert_mask & UART_INVERSE_RXD) {
+        if (invert_mask & UART_INV_RX) {
             mp_printf(print, "INV_RX");
-            invert_mask &= ~UART_INVERSE_RXD;
+            invert_mask &= ~UART_INV_RX;
             if (invert_mask) {
                 mp_printf(print, "|");
             }
         }
-        if (invert_mask & UART_INVERSE_RTS) {
+        if (invert_mask & UART_INV_RTS) {
             mp_printf(print, "INV_RTS");
-            invert_mask &= ~UART_INVERSE_RTS;
+            invert_mask &= ~UART_INV_RTS;
             if (invert_mask) {
                 mp_printf(print, "|");
             }
         }
-        if (invert_mask & UART_INVERSE_CTS) {
+        if (invert_mask & UART_INV_CTS) {
             mp_printf(print, "INV_CTS");
         }
     }
@@ -238,7 +252,7 @@ STATIC void machine_uart_init_helper(machine_uart_obj_t *self, size_t n_args, co
     }
 
     // set line inversion
-    if (args[ARG_invert].u_int & ~UART_LINE_INV_MASK) {
+    if (args[ARG_invert].u_int & ~UART_INV_MASK) {
         mp_raise_ValueError(MP_ERROR_TEXT("invalid inversion mask"));
     }
     self->invert = args[ARG_invert].u_int;
@@ -380,10 +394,10 @@ STATIC const mp_rom_map_elem_t machine_uart_locals_dict_table[] = {
     { MP_ROM_QSTR(MP_QSTR_write), MP_ROM_PTR(&mp_stream_write_obj) },
     { MP_ROM_QSTR(MP_QSTR_sendbreak), MP_ROM_PTR(&machine_uart_sendbreak_obj) },
 
-    { MP_ROM_QSTR(MP_QSTR_INV_TX), MP_ROM_INT(UART_INVERSE_TXD) },
-    { MP_ROM_QSTR(MP_QSTR_INV_RX), MP_ROM_INT(UART_INVERSE_RXD) },
-    { MP_ROM_QSTR(MP_QSTR_INV_RTS), MP_ROM_INT(UART_INVERSE_RTS) },
-    { MP_ROM_QSTR(MP_QSTR_INV_CTS), MP_ROM_INT(UART_INVERSE_CTS) },
+    { MP_ROM_QSTR(MP_QSTR_INV_TX), MP_ROM_INT(UART_INV_TX) },
+    { MP_ROM_QSTR(MP_QSTR_INV_RX), MP_ROM_INT(UART_INV_RX) },
+    { MP_ROM_QSTR(MP_QSTR_INV_RTS), MP_ROM_INT(UART_INV_RTS) },
+    { MP_ROM_QSTR(MP_QSTR_INV_CTS), MP_ROM_INT(UART_INV_CTS) },
 };
 
 STATIC MP_DEFINE_CONST_DICT(machine_uart_locals_dict, machine_uart_locals_dict_table);

--- a/ports/esp32/main.c
+++ b/ports/esp32/main.c
@@ -37,11 +37,7 @@
 #include "esp_task.h"
 #include "soc/cpu.h"
 #include "esp_log.h"
-#if MICROPY_ESP_IDF_4
 #include "esp32/spiram.h"
-#else
-#include "esp_spiram.h"
-#endif
 
 #include "py/stackctrl.h"
 #include "py/nlr.h"

--- a/ports/esp32/main/CMakeLists.txt
+++ b/ports/esp32/main/CMakeLists.txt
@@ -108,6 +108,11 @@ if(IDF_VERSION_MINOR GREATER_EQUAL 1)
     list(APPEND IDF_COMPONENTS esp_netif)
 endif()
 
+if(IDF_VERSION_MINOR GREATER_EQUAL 2)
+    list(APPEND IDF_COMPONENTS esp_system)
+    list(APPEND IDF_COMPONENTS esp_timer)
+endif()
+
 # Register the main IDF component.
 idf_component_register(
     SRCS
@@ -168,6 +173,13 @@ foreach(comp ${IDF_COMPONENTS})
         list(APPEND MICROPY_CPP_DEF_EXTRA ${_def})
     endif()
 endforeach()
+
+if(IDF_VERSION_MINOR GREATER_EQUAL 2)
+    # These paths cannot currently be found by the IDF_COMPONENTS search loop above,
+    # so add them explicitly.
+    list(APPEND MICROPY_CPP_INC_EXTRA ${IDF_PATH}/components/soc/soc/${IDF_TARGET}/include)
+    list(APPEND MICROPY_CPP_INC_EXTRA ${IDF_PATH}/components/soc/soc/include)
+endif()
 
 # Include the main MicroPython cmake rules.
 include(${MICROPY_DIR}/py/mkrules.cmake)

--- a/ports/esp32/main/CMakeLists.txt
+++ b/ports/esp32/main/CMakeLists.txt
@@ -104,6 +104,10 @@ set(IDF_COMPONENTS
     xtensa
 )
 
+if(IDF_VERSION_MINOR GREATER_EQUAL 1)
+    list(APPEND IDF_COMPONENTS esp_netif)
+endif()
+
 # Register the main IDF component.
 idf_component_register(
     SRCS

--- a/ports/esp32/modesp.c
+++ b/ports/esp32/modesp.c
@@ -29,9 +29,6 @@
 
 #include <stdio.h>
 
-#if !MICROPY_ESP_IDF_4
-#include "rom/gpio.h"
-#endif
 #include "esp_log.h"
 #include "esp_spi_flash.h"
 

--- a/ports/esp32/modmachine.c
+++ b/ports/esp32/modmachine.c
@@ -32,15 +32,9 @@
 
 #include "freertos/FreeRTOS.h"
 #include "freertos/task.h"
-#if MICROPY_ESP_IDF_4
 #include "esp32/rom/rtc.h"
 #include "esp32/clk.h"
 #include "esp_sleep.h"
-#else
-#include "rom/ets_sys.h"
-#include "rom/rtc.h"
-#include "esp_clk.h"
-#endif
 #include "esp_pm.h"
 #include "driver/touch_pad.h"
 

--- a/ports/esp32/modnetwork.c
+++ b/ports/esp32/modnetwork.c
@@ -45,7 +45,6 @@
 #include "esp_wifi.h"
 #include "esp_log.h"
 #include "lwip/dns.h"
-#include "tcpip_adapter.h"
 #include "mdns.h"
 
 #if !MICROPY_ESP_IDF_4
@@ -54,6 +53,12 @@
 #endif
 
 #include "modnetwork.h"
+
+#if ESP_IDF_VERSION < ESP_IDF_VERSION_VAL(4, 1, 0)
+#define DNS_MAIN TCPIP_ADAPTER_DNS_MAIN
+#else
+#define DNS_MAIN ESP_NETIF_DNS_MAIN
+#endif
 
 #define MODNETWORK_INCLUDE_CONSTANTS (1)
 
@@ -491,7 +496,7 @@ STATIC mp_obj_t esp_ifconfig(size_t n_args, const mp_obj_t *args) {
     tcpip_adapter_ip_info_t info;
     tcpip_adapter_dns_info_t dns_info;
     tcpip_adapter_get_ip_info(self->if_id, &info);
-    tcpip_adapter_get_dns_info(self->if_id, TCPIP_ADAPTER_DNS_MAIN, &dns_info);
+    tcpip_adapter_get_dns_info(self->if_id, DNS_MAIN, &dns_info);
     if (n_args == 1) {
         // get
         mp_obj_t tuple[4] = {
@@ -526,14 +531,14 @@ STATIC mp_obj_t esp_ifconfig(size_t n_args, const mp_obj_t *args) {
                     _esp_exceptions(e);
                 }
                 ESP_EXCEPTIONS(tcpip_adapter_set_ip_info(self->if_id, &info));
-                ESP_EXCEPTIONS(tcpip_adapter_set_dns_info(self->if_id, TCPIP_ADAPTER_DNS_MAIN, &dns_info));
+                ESP_EXCEPTIONS(tcpip_adapter_set_dns_info(self->if_id, DNS_MAIN, &dns_info));
             } else if (self->if_id == WIFI_IF_AP) {
                 esp_err_t e = tcpip_adapter_dhcps_stop(WIFI_IF_AP);
                 if (e != ESP_OK && e != ESP_ERR_TCPIP_ADAPTER_DHCP_ALREADY_STOPPED) {
                     _esp_exceptions(e);
                 }
                 ESP_EXCEPTIONS(tcpip_adapter_set_ip_info(WIFI_IF_AP, &info));
-                ESP_EXCEPTIONS(tcpip_adapter_set_dns_info(WIFI_IF_AP, TCPIP_ADAPTER_DNS_MAIN, &dns_info));
+                ESP_EXCEPTIONS(tcpip_adapter_set_dns_info(WIFI_IF_AP, DNS_MAIN, &dns_info));
                 ESP_EXCEPTIONS(tcpip_adapter_dhcps_start(WIFI_IF_AP));
             }
         } else {

--- a/ports/esp32/modsocket.c
+++ b/ports/esp32/modsocket.c
@@ -46,7 +46,6 @@
 #include "py/stream.h"
 #include "py/mperrno.h"
 #include "lib/netutils/netutils.h"
-#include "tcpip_adapter.h"
 #include "mdns.h"
 #include "modnetwork.h"
 
@@ -181,7 +180,12 @@ static int _socket_getaddrinfo3(const char *nodename, const char *servname,
         memcpy(nodename_no_local, nodename, nodename_len - local_len);
         nodename_no_local[nodename_len - local_len] = '\0';
 
+        #if ESP_IDF_VERSION < ESP_IDF_VERSION_VAL(4, 1, 0)
         struct ip4_addr addr = {0};
+        #else
+        esp_ip4_addr_t addr = {0};
+        #endif
+
         esp_err_t err = mdns_query_a(nodename_no_local, MDNS_QUERY_TIMEOUT_MS, &addr);
         if (err != ESP_OK) {
             if (err == ESP_ERR_NOT_FOUND) {

--- a/ports/esp32/modsocket.c
+++ b/ports/esp32/modsocket.c
@@ -55,18 +55,6 @@
 #include "lwip/igmp.h"
 #include "esp_log.h"
 
-#if !MICROPY_ESP_IDF_4
-#define lwip_bind lwip_bind_r
-#define lwip_listen lwip_listen_r
-#define lwip_accept lwip_accept_r
-#define lwip_setsockopt lwip_setsockopt_r
-#define lwip_fnctl lwip_fnctl_r
-#define lwip_recvfrom lwip_recvfrom_r
-#define lwip_write lwip_write_r
-#define lwip_sendto lwip_sendto_r
-#define lwip_close lwip_close_r
-#endif
-
 #define SOCKET_POLL_US (100000)
 #define MDNS_QUERY_TIMEOUT_MS (5000)
 #define MDNS_LOCAL_SUFFIX ".local"

--- a/ports/esp32/mpconfigport.h
+++ b/ports/esp32/mpconfigport.h
@@ -8,10 +8,6 @@
 #include <alloca.h>
 #include "esp_system.h"
 
-#if !MICROPY_ESP_IDF_4
-#include "rom/ets_sys.h"
-#endif
-
 // object representation and NLR handling
 #define MICROPY_OBJ_REPR                    (MICROPY_OBJ_REPR_A)
 #define MICROPY_NLR_SETJMP                  (1)

--- a/ports/esp32/mphalport.c
+++ b/ports/esp32/mphalport.c
@@ -32,12 +32,7 @@
 
 #include "freertos/FreeRTOS.h"
 #include "freertos/task.h"
-
-#if MICROPY_ESP_IDF_4
 #include "esp32/rom/uart.h"
-#else
-#include "rom/uart.h"
-#endif
 
 #include "py/obj.h"
 #include "py/objstr.h"

--- a/ports/esp32/mpthreadport.c
+++ b/ports/esp32/mpthreadport.c
@@ -34,9 +34,6 @@
 #include "mpthreadport.h"
 
 #include "esp_task.h"
-#if !MICROPY_ESP_IDF_4
-#include "freertos/semphr.h"
-#endif
 
 #if MICROPY_PY_THREAD
 

--- a/ports/esp32/uart.c
+++ b/ports/esp32/uart.c
@@ -29,6 +29,7 @@
 #include <stdio.h>
 
 #include "driver/uart.h"
+#include "soc/uart_periph.h"
 
 #include "py/runtime.h"
 #include "py/mphal.h"


### PR DESCRIPTION
This PR adds support for building the esp32 port (using cmake, idf.py) with IDF v4.1.1 and v4.2.  It also still supports IDF v4.0.2.

It's nice that this is simple now!