### PR TITLE
rp2/machine_rtc: add initial support for RTC.

### DIFF
--- a/ports/rp2/CMakeLists.txt
+++ b/ports/rp2/CMakeLists.txt
@@ -86,6 +86,7 @@ set(MICROPY_SOURCE_PORT
     machine_i2c.c
     machine_pin.c
     machine_pwm.c
+    machine_rtc.c
     machine_spi.c
     machine_timer.c
     machine_uart.c
@@ -113,6 +114,7 @@ set(MICROPY_SOURCE_QSTR
     ${PROJECT_SOURCE_DIR}/machine_i2c.c
     ${PROJECT_SOURCE_DIR}/machine_pin.c
     ${PROJECT_SOURCE_DIR}/machine_pwm.c
+    ${PROJECT_SOURCE_DIR}/machine_rtc.c
     ${PROJECT_SOURCE_DIR}/machine_spi.c
     ${PROJECT_SOURCE_DIR}/machine_timer.c
     ${PROJECT_SOURCE_DIR}/machine_uart.c
@@ -155,6 +157,7 @@ set(PICO_SDK_COMPONENTS
     pico_time
     pico_unique_id
     tinyusb_common
+    pico_util
     tinyusb_device
 )
 

--- a/ports/rp2/machine_rtc.c
+++ b/ports/rp2/machine_rtc.c
@@ -1,0 +1,120 @@
+/*
+ * This file is part of the MicroPython project, http://micropython.org/
+ *
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2021 "Krzysztof Adamski" <k@japko.eu>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#include <stdio.h>
+#include <string.h>
+
+#include <time.h>
+#include <sys/time.h>
+
+#include "py/nlr.h"
+#include "py/obj.h"
+#include "py/runtime.h"
+#include "py/mphal.h"
+#include "py/mperrno.h"
+#include "lib/timeutils/timeutils.h"
+#include "hardware/rtc.h"
+#include "pico/util/datetime.h"
+#include "modmachine.h"
+
+typedef struct _machine_rtc_obj_t {
+    mp_obj_base_t base;
+} machine_rtc_obj_t;
+
+// singleton RTC object
+STATIC const machine_rtc_obj_t machine_rtc_obj = {{&machine_rtc_type}};
+
+STATIC mp_obj_t machine_rtc_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *args) {
+    // check arguments
+    mp_arg_check_num(n_args, n_kw, 0, 0, false);
+    bool r = rtc_running();
+
+    if (!r) {
+        // This shouldn't happen as rtc_init() is already called in main so
+        // it's here just in case
+        rtc_init();
+        datetime_t t = { .month = 1, .day = 1 };
+        rtc_set_datetime(&t);
+    }
+    // return constant object
+    return (mp_obj_t)&machine_rtc_obj;
+}
+
+STATIC mp_obj_t machine_rtc_datetime(mp_uint_t n_args, const mp_obj_t *args) {
+    if (n_args == 1) {
+        bool ret;
+        datetime_t t;
+
+        ret = rtc_get_datetime(&t);
+        if (!ret) {
+            mp_raise_OSError(MP_EIO);
+        }
+
+        mp_obj_t tuple[8] = {
+            mp_obj_new_int(t.year),
+            mp_obj_new_int(t.month),
+            mp_obj_new_int(t.day),
+            mp_obj_new_int(t.dotw),
+            mp_obj_new_int(t.hour),
+            mp_obj_new_int(t.min),
+            mp_obj_new_int(t.sec),
+            mp_obj_new_int(0)
+        };
+
+        return mp_obj_new_tuple(8, tuple);
+    } else {
+        mp_obj_t *items;
+
+        mp_obj_get_array_fixed_n(args[1], 8, &items);
+
+        datetime_t t = {
+            .year = mp_obj_get_int(items[0]),
+            .month = mp_obj_get_int(items[1]),
+            .day = mp_obj_get_int(items[2]),
+            .dotw = mp_obj_get_int(items[3]),
+            .hour = mp_obj_get_int(items[4]),
+            .min = mp_obj_get_int(items[5]),
+            .sec = mp_obj_get_int(items[6]),
+        };
+
+        rtc_set_datetime(&t);
+
+    }
+    return mp_const_none;
+}
+STATIC MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(machine_rtc_datetime_obj, 1, 2, machine_rtc_datetime);
+
+STATIC const mp_rom_map_elem_t machine_rtc_locals_dict_table[] = {
+    { MP_ROM_QSTR(MP_QSTR_datetime), MP_ROM_PTR(&machine_rtc_datetime_obj) },
+};
+STATIC MP_DEFINE_CONST_DICT(machine_rtc_locals_dict, machine_rtc_locals_dict_table);
+
+const mp_obj_type_t machine_rtc_type = {
+    { &mp_type_type },
+    .name = MP_QSTR_RTC,
+    .make_new = machine_rtc_make_new,
+    .locals_dict = (mp_obj_t)&machine_rtc_locals_dict,
+};

--- a/ports/rp2/modmachine.c
+++ b/ports/rp2/modmachine.c
@@ -164,6 +164,7 @@ STATIC const mp_rom_map_elem_t machine_module_globals_table[] = {
     { MP_ROM_QSTR(MP_QSTR_SoftI2C),             MP_ROM_PTR(&mp_machine_soft_i2c_type) },
     { MP_ROM_QSTR(MP_QSTR_Pin),                 MP_ROM_PTR(&machine_pin_type) },
     { MP_ROM_QSTR(MP_QSTR_PWM),                 MP_ROM_PTR(&machine_pwm_type) },
+    { MP_ROM_QSTR(MP_QSTR_RTC),                 MP_ROM_PTR(&machine_rtc_type) },
     { MP_ROM_QSTR(MP_QSTR_Signal),              MP_ROM_PTR(&machine_signal_type) },
     { MP_ROM_QSTR(MP_QSTR_SPI),                 MP_ROM_PTR(&machine_spi_type) },
     { MP_ROM_QSTR(MP_QSTR_SoftSPI),             MP_ROM_PTR(&mp_machine_soft_spi_type) },

--- a/ports/rp2/modmachine.h
+++ b/ports/rp2/modmachine.h
@@ -7,6 +7,7 @@ extern const mp_obj_type_t machine_adc_type;
 extern const mp_obj_type_t machine_hw_i2c_type;
 extern const mp_obj_type_t machine_pin_type;
 extern const mp_obj_type_t machine_pwm_type;
+extern const mp_obj_type_t machine_rtc_type;
 extern const mp_obj_type_t machine_spi_type;
 extern const mp_obj_type_t machine_timer_type;
 extern const mp_obj_type_t machine_uart_type;


### PR DESCRIPTION
Initial support for machine.RTC on rp2 port. It only supports datetime()
method and nothing else. The method gets/returns a tuple of 8 items,
just like esp32 port, for example, but the usec parameter is ignored as
the RP2 RTC only works up to seconds precision.

Signed-off-by: Krzysztof Adamski <k@japko.eu>