### PR TITLE
esp32: Add support to build with ESP-IDF v4.3 pre-release.

### DIFF
--- a/ports/esp32/main/CMakeLists.txt
+++ b/ports/esp32/main/CMakeLists.txt
@@ -113,6 +113,12 @@ if(IDF_VERSION_MINOR GREATER_EQUAL 2)
     list(APPEND IDF_COMPONENTS esp_timer)
 endif()
 
+if(IDF_VERSION_MINOR GREATER_EQUAL 3)
+    list(APPEND IDF_COMPONENTS esp_hw_support)
+    list(APPEND IDF_COMPONENTS esp_pm)
+    list(APPEND IDF_COMPONENTS hal)
+endif()
+
 # Register the main IDF component.
 idf_component_register(
     SRCS

--- a/ports/esp32/modesp32.c
+++ b/ports/esp32/modesp32.c
@@ -35,7 +35,6 @@
 #include "driver/adc.h"
 #include "esp_heap_caps.h"
 #include "multi_heap.h"
-#include "../heap_private.h"
 
 #include "py/nlr.h"
 #include "py/obj.h"
@@ -45,6 +44,13 @@
 #include "modmachine.h"
 #include "machine_rtc.h"
 #include "modesp32.h"
+
+// These private includes are needed for idf_heap_info.
+#if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(4, 3, 0)
+#define MULTI_HEAP_FREERTOS
+#include "../multi_heap_platform.h"
+#endif
+#include "../heap_private.h"
 
 STATIC mp_obj_t esp32_wake_on_touch(const mp_obj_t wake) {
 


### PR DESCRIPTION
The esp32 port now builds against IDF v4.3-beta1, as well as v4.4-dev.