### PR TITLE
add listdir to ports/unix/modos.c

### DIFF
--- a/ports/unix/modos.c
+++ b/ports/unix/modos.c
@@ -295,6 +295,17 @@ STATIC mp_obj_t mod_os_ilistdir(size_t n_args, const mp_obj_t *args) {
 }
 STATIC MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(mod_os_ilistdir_obj, 0, 1, mod_os_ilistdir);
 
+mp_obj_t mod_os_listdir(size_t n_args, const mp_obj_t *args) {
+    mp_obj_t iter = mod_os_ilistdir(n_args, args);
+    mp_obj_t dir_list = mp_obj_new_list(0, NULL);
+    mp_obj_t next;
+    while ((next = mp_iternext(iter)) != MP_OBJ_STOP_ITERATION) {
+        mp_obj_list_append(dir_list, mp_obj_subscr(next, MP_OBJ_NEW_SMALL_INT(0), MP_OBJ_SENTINEL));
+    }
+    return dir_list;
+}
+MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(mod_os_listdir_obj, 0, 1, mod_os_listdir);
+
 STATIC mp_obj_t mod_os_errno(size_t n_args, const mp_obj_t *args) {
     if (n_args == 0) {
         return MP_OBJ_NEW_SMALL_INT(errno);
@@ -321,6 +332,7 @@ STATIC const mp_rom_map_elem_t mp_module_os_globals_table[] = {
     { MP_ROM_QSTR(MP_QSTR_unsetenv), MP_ROM_PTR(&mod_os_unsetenv_obj) },
     { MP_ROM_QSTR(MP_QSTR_mkdir), MP_ROM_PTR(&mod_os_mkdir_obj) },
     { MP_ROM_QSTR(MP_QSTR_ilistdir), MP_ROM_PTR(&mod_os_ilistdir_obj) },
+    { MP_ROM_QSTR(MP_QSTR_listdir), MP_ROM_PTR(&mod_os_listdir_obj) },
     #if MICROPY_PY_OS_DUPTERM
     { MP_ROM_QSTR(MP_QSTR_dupterm), MP_ROM_PTR(&mp_uos_dupterm_obj) },
     #endif


### PR DESCRIPTION
There is no `listdir` in `modos.c`, so I mimicked https://github.com/micropython/micropython/blob/master/extmod/vfs.c to add `listdir`. The code works. 

However, current directory (`'.'`) and parent directory (`'..'`) are in the result. Is this the expected behaviour?
```
MicroPython cf6a015-dirty on 2021-02-19; win32 version
>>> import os
>>> os.listdir()
['.', '..', '.appveyor.yml', '.gitignore', 'build', 'fmode.c', 'fmode.h', 'init.c', 'init.h', 'Makefile', 'micropython.exe', 'micropython.vcxproj', 'mpconfigport.h', 'mpconfigport.mk', 'msvc', 'README.md', 'realpath.c', 'realpath.h', 'sleep.c', 'sleep.h', 'windows_mphal.c', 'windows_mphal.h']
```
but for CPython
```
Python 3.6.10 |Anaconda custom (64-bit)| (default, Jan  7 2020, 15:18:16) [MSC v.1916 64 bit (AMD64)] on win32

>>> import os
>>> os.listdir()
['.appveyor.yml', '.gitignore', 'build', 'fmode.c', 'fmode.h', 'init.c', 'init.h', 'Makefile', 'micropython.exe', 'micropython.vcxproj', 'mpconfigport.h', 'mpconfigport.mk', 'msvc', 'README.md', 'realpath.c', 'realpath.h', 'sleep.c', 'sleep.h', 'windows_mphal.c', 'windows_mphal.h']
```