### PR TITLE
rp2_pio.c: Allow more than 8 pins for PIO I/O.

### DIFF
--- a/ports/rp2/rp2_pio.c
+++ b/ports/rp2/rp2_pio.c
@@ -139,8 +139,8 @@ enum {
 typedef struct _asm_pio_config_t {
     int8_t base;
     uint8_t count;
-    uint8_t pindirs;
-    uint8_t pinvals;
+    uint32_t pindirs;
+    uint32_t pinvals;
 } asm_pio_config_t;
 
 STATIC void asm_pio_override_shiftctrl(mp_obj_t arg, uint32_t bits, uint32_t lsb, pio_sm_config *config) {


### PR DESCRIPTION
The bitmasks supplied for initialization were only 8 bit instead of 32. This PR solves issue https://github.com/micropython/micropython/issues/6933
