### PR TITLE
rp2/mphalport.c: Add dupterm TX support.

### DIFF
--- a/ports/rp2/moduos.c
+++ b/ports/rp2/moduos.c
@@ -26,6 +26,7 @@
 
 #include "py/objstr.h"
 #include "py/runtime.h"
+#include "extmod/misc.h"
 #include "extmod/vfs.h"
 #include "extmod/vfs_fat.h"
 #include "extmod/vfs_lfs.h"

--- a/ports/rp2/mphalport.c
+++ b/ports/rp2/mphalport.c
@@ -28,6 +28,7 @@
 #include "py/stream.h"
 #include "py/mphal.h"
 #include "lib/timeutils/timeutils.h"
+#include "extmod/misc.h"
 #include "tusb.h"
 #include "uart.h"
 #include "hardware/rtc.h"
@@ -122,6 +123,9 @@ void mp_hal_stdout_tx_strn(const char *str, mp_uint_t len) {
             i += n2;
         }
     }
+    #endif
+    #if MICROPY_PY_OS_DUPTERM
+    mp_uos_dupterm_tx_strn(str, len);
     #endif
 }
 


### PR DESCRIPTION
This PR adds `mp_uos_dupterm_tx_strn()` call into `mp_hal_stdout_tx_strn()` to make `uos.dupterm()` work.
Also I added `#include  "extmod/misc.h"` to `moduos.c` for the definition of `mp_uos_dupterm_obj`.