### PR TITLE
rp2: Allow changing the clock frequency.

### DIFF
--- a/ports/rp2/modmachine.c
+++ b/ports/rp2/modmachine.c
@@ -37,6 +37,8 @@
 #include "hardware/watchdog.h"
 #include "pico/bootrom.h"
 #include "pico/unique_id.h"
+#include "pico/stdlib.h"
+
 
 #define RP2_RESET_PWRON (1)
 #define RP2_RESET_WDT (3)
@@ -80,10 +82,19 @@ STATIC mp_obj_t machine_bootloader(void) {
 }
 MP_DEFINE_CONST_FUN_OBJ_0(machine_bootloader_obj, machine_bootloader);
 
-STATIC mp_obj_t machine_freq(void) {
-    return MP_OBJ_NEW_SMALL_INT(clock_get_hz(clk_sys));
+STATIC mp_obj_t machine_freq(size_t n_args, const mp_obj_t *args) {
+    if (n_args == 0) {
+        return MP_OBJ_NEW_SMALL_INT(clock_get_hz(clk_sys));
+    } else {
+        mp_int_t freq = mp_obj_get_int(args[0]);
+        if (set_sys_clock_khz(freq / 1000, false)) {
+            return mp_const_none;
+        } else {
+            mp_raise_ValueError(MP_ERROR_TEXT("valid range 12-270MHz"));
+        }
+    }
 }
-MP_DEFINE_CONST_FUN_OBJ_0(machine_freq_obj, machine_freq);
+STATIC MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(machine_freq_obj, 0, 1, machine_freq);
 
 STATIC mp_obj_t machine_idle(void) {
     best_effort_wfe_or_timeout(make_timeout_time_ms(1));

--- a/ports/rp2/modmachine.c
+++ b/ports/rp2/modmachine.c
@@ -87,11 +87,10 @@ STATIC mp_obj_t machine_freq(size_t n_args, const mp_obj_t *args) {
         return MP_OBJ_NEW_SMALL_INT(clock_get_hz(clk_sys));
     } else {
         mp_int_t freq = mp_obj_get_int(args[0]);
-        if (set_sys_clock_khz(freq / 1000, false)) {
-            return mp_const_none;
-        } else {
-            mp_raise_ValueError(MP_ERROR_TEXT("valid range 12-270MHz"));
+        if (!set_sys_clock_khz(freq / 1000, false)) {
+            mp_raise_ValueError(MP_ERROR_TEXT("cannot change frequency"));
         }
+        return mp_const_none;
     }
 }
 STATIC MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(machine_freq_obj, 0, 1, machine_freq);

--- a/ports/rp2/modmachine.c
+++ b/ports/rp2/modmachine.c
@@ -38,6 +38,7 @@
 #include "pico/bootrom.h"
 #include "pico/unique_id.h"
 #include "pico/stdlib.h"
+#include "uart.h"
 
 
 #define RP2_RESET_PWRON (1)
@@ -90,6 +91,10 @@ STATIC mp_obj_t machine_freq(size_t n_args, const mp_obj_t *args) {
         if (!set_sys_clock_khz(freq / 1000, false)) {
             mp_raise_ValueError(MP_ERROR_TEXT("cannot change frequency"));
         }
+        #if MICROPY_HW_ENABLE_UART_REPL
+        setup_default_uart();
+        mp_uart_init();
+        #endif
         return mp_const_none;
     }
 }


### PR DESCRIPTION
Using machine.freq(). The safe ranges tested were 10 and 12-270MHz,
at which USB REPL still worked.
Requested settings can be checked with the script:
pico-sdk/src/rp2_common/hardware_clocks/scripts/vcocalc.py
At frequencies like 300MHz the script still signaled OK, but USB
did not work any more.