### PR TITLE
lib/utils/gchelper_generic: Implement AArch64 support.

### DIFF
--- a/lib/utils/gchelper.h
+++ b/lib/utils/gchelper.h
@@ -39,6 +39,8 @@ typedef uintptr_t gc_helper_regs_t[6];
 typedef uintptr_t gc_helper_regs_t[4];
 #elif defined(__thumb2__) || defined(__thumb__) || defined(__arm__)
 typedef uintptr_t gc_helper_regs_t[10];
+#elif defined(__aarch64__)
+typedef uintptr_t gc_helper_regs_t[11]; // x19-x29
 #endif
 
 #endif

--- a/lib/utils/gchelper_generic.c
+++ b/lib/utils/gchelper_generic.c
@@ -123,6 +123,33 @@ STATIC void gc_helper_get_regs(gc_helper_regs_t arr) {
     arr[9] = r13;
 }
 
+#elif defined(__aarch64__)
+
+STATIC void gc_helper_get_regs(gc_helper_regs_t arr) {
+    const register long x19 asm ("x19");
+    const register long x20 asm ("x20");
+    const register long x21 asm ("x21");
+    const register long x22 asm ("x22");
+    const register long x23 asm ("x23");
+    const register long x24 asm ("x24");
+    const register long x25 asm ("x25");
+    const register long x26 asm ("x26");
+    const register long x27 asm ("x27");
+    const register long x28 asm ("x28");
+    const register long x29 asm ("x29");
+    arr[0] = x19;
+    arr[1] = x20;
+    arr[2] = x21;
+    arr[3] = x22;
+    arr[4] = x23;
+    arr[5] = x24;
+    arr[6] = x25;
+    arr[7] = x26;
+    arr[8] = x27;
+    arr[9] = x28;
+    arr[10] = x29;
+}
+
 #else
 
 #error "Architecture not supported for gc_helper_get_regs. Set MICROPY_GCREGS_SETJMP to use the fallback implementation."


### PR DESCRIPTION
Allows using `gc_helper_collect_regs_and_stack()` in AArch64 code with no `setjmp`.

Related: https://github.com/micropython/micropython/issues/4176, https://github.com/micropython/micropython/pull/6939

Tested on: https://github.com/micropython/micropython/pull/5482