### PR TITLE
Simple fixes to enable embedding example to compile

### DIFF
--- a/examples/embedding/Makefile.upylib
+++ b/examples/embedding/Makefile.upylib
@@ -133,7 +133,6 @@ SRC_C = $(addprefix ports/unix/,\
 	gccollect.c \
 	unix_mphal.c \
 	input.c \
-	file.c \
 	modmachine.c \
 	modos.c \
 	moduselect.c \
@@ -146,6 +145,7 @@ SRC_C = $(addprefix ports/unix/,\
 LIB_SRC_C = $(addprefix lib/,\
 	$(LIB_SRC_C_EXTRA) \
 	utils/printf.c \
+	utils/gchelper_generic.c \
 	timeutils/timeutils.c \
 	)
 

--- a/examples/embedding/hello-embed.c
+++ b/examples/embedding/hello-embed.c
@@ -34,6 +34,7 @@
 #include "py/stackctrl.h"
 
 static char heap[16384];
+mp_state_ctx_t mp_state_ctx;
 
 mp_obj_t execute_from_str(const char *str) {
     nlr_buf_t nlr;


### PR DESCRIPTION
At least compiles now on MacOS. There were a few changes that had
broken this example, specifically 2cdf1d25f59409b6130c0e8b6cf50300aed2d7e6
removed file.c from ports/unix, and some other change in
mp handling created a need to explicitly specify mp_state_ctx
structure (I have no idea why definition in mpstate.c wasn't
visible to the linker, adding it to the hello-world.c fixed
the issue).