### PR TITLE
rp2: Add support for USER_C_MODULES into the cmake build system

### DIFF
--- a/examples/usercmodule/cexample/micropython.cmake
+++ b/examples/usercmodule/cexample/micropython.cmake
@@ -1,0 +1,21 @@
+# Create an INTERFACE library for our C module.
+add_library(usermod_cexample INTERFACE)
+
+# Add our source files to the lib
+target_sources(usermod_cexample INTERFACE
+    ${CMAKE_CURRENT_LIST_DIR}/examplemodule.c
+)
+
+# Add the current directory as an include directory.
+target_include_directories(usermod_cexample INTERFACE
+    ${CMAKE_CURRENT_LIST_DIR}
+)
+
+# Enable the module automatically by adding the relevant compile definitions.
+target_compile_definitions(usermod_cexample INTERFACE
+    MODULE_CEXAMPLE_ENABLED=1
+)
+
+# Link our INTERFACE library to the usermod target.
+target_link_libraries(usermod INTERFACE usermod_cexample)
+

--- a/examples/usercmodule/cppexample/micropython.cmake
+++ b/examples/usercmodule/cppexample/micropython.cmake
@@ -1,0 +1,22 @@
+# Create an INTERFACE library for our CPP module.
+add_library(usermod_cppexample INTERFACE)
+
+# Add our source files to the library.
+target_sources(usermod_cppexample INTERFACE
+    ${CMAKE_CURRENT_LIST_DIR}/example.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/examplemodule.c
+)
+
+# Add the current directory as an include directory.
+target_include_directories(usermod_cppexample INTERFACE
+    ${CMAKE_CURRENT_LIST_DIR}
+)
+
+# Enable the module automatically by adding the relevant compile definitions.
+target_compile_definitions(usermod_cppexample INTERFACE
+    MODULE_CPPEXAMPLE_ENABLED=1
+)
+
+# Link our INTERFACE library to the usermod target.
+target_link_libraries(usermod INTERFACE usermod_cppexample)
+

--- a/examples/usercmodule/micropython.cmake
+++ b/examples/usercmodule/micropython.cmake
@@ -1,0 +1,11 @@
+# This top-level micropython.cmake is responsible for listing
+# the individual modules we want to include.
+# Paths are absolute, and ${CMAKE_CURRENT_LIST_DIR} can be
+# used to prefix subdirectories.
+
+# Add the C example.
+include(${CMAKE_CURRENT_LIST_DIR}/cexample/micropython.cmake)
+
+# Add the CPP example.
+include(${CMAKE_CURRENT_LIST_DIR}/cppexample/micropython.cmake)
+

--- a/ports/rp2/CMakeLists.txt
+++ b/ports/rp2/CMakeLists.txt
@@ -27,6 +27,8 @@ project(${MICROPY_TARGET})
 
 pico_sdk_init()
 
+include(${MICROPY_DIR}/py/usermod.cmake)
+
 add_executable(${MICROPY_TARGET})
 
 set(MICROPY_QSTRDEFS_PORT
@@ -80,6 +82,7 @@ set(MICROPY_SOURCE_PORT
 set(MICROPY_SOURCE_QSTR
     ${MICROPY_SOURCE_PY}
     ${MICROPY_SOURCE_EXTMOD}
+    ${MICROPY_SOURCE_USERMOD}
     ${MICROPY_DIR}/lib/utils/mpirq.c
     ${MICROPY_DIR}/lib/utils/sys_stdio_mphal.c
     ${PROJECT_SOURCE_DIR}/machine_adc.c
@@ -142,7 +145,10 @@ target_sources(${MICROPY_TARGET} PRIVATE
     ${MICROPY_SOURCE_PORT}
 )
 
+target_link_libraries(${MICROPY_TARGET} usermod)
+
 target_include_directories(${MICROPY_TARGET} PRIVATE
+    ${MICROPY_INC_USERMOD}
     "${PROJECT_SOURCE_DIR}"
     "${MICROPY_DIR}"
     "${CMAKE_BINARY_DIR}"

--- a/ports/rp2/Makefile
+++ b/ports/rp2/Makefile
@@ -6,8 +6,14 @@ BUILD = build
 
 $(VERBOSE)MAKESILENT = -s
 
+CMAKE_ARGS =
+
+ifdef USER_C_MODULES
+CMAKE_ARGS += -DUSER_C_MODULES=${USER_C_MODULES}
+endif
+
 all:
-	[ -d $(BUILD) ] || cmake -S . -B $(BUILD) -DPICO_BUILD_DOCS=0
+	[ -d $(BUILD) ] || cmake -S . -B $(BUILD) -DPICO_BUILD_DOCS=0 ${CMAKE_ARGS}
 	$(MAKE) $(MAKESILENT) -C $(BUILD)
 
 clean:

--- a/ports/rp2/mpthreadport.h
+++ b/ports/rp2/mpthreadport.h
@@ -41,7 +41,7 @@ static inline void mp_thread_set_state(struct _mp_state_thread_t *state) {
 }
 
 static inline struct _mp_state_thread_t *mp_thread_get_state(void) {
-    return core_state[get_core_num()];
+    return (struct _mp_state_thread_t *)core_state[get_core_num()];
 }
 
 static inline void mp_thread_mutex_init(mp_thread_mutex_t *m) {

--- a/py/mkrules.cmake
+++ b/py/mkrules.cmake
@@ -69,7 +69,7 @@ add_custom_command(
 # it was last run, but it looks like it's not possible to specify that with cmake.
 add_custom_command(
     OUTPUT ${MICROPY_QSTRDEFS_LAST}
-    COMMAND ${Python3_EXECUTABLE} ${MICROPY_PY_DIR}/makeqstrdefs.py pp ${CMAKE_C_COMPILER} -E output ${MICROPY_GENHDR_DIR}/qstr.i.last cflags ${MICROPY_CPP_FLAGS} -DNO_QSTR sources ${MICROPY_SOURCE_QSTR}
+    COMMAND ${Python3_EXECUTABLE} ${MICROPY_PY_DIR}/makeqstrdefs.py pp ${CMAKE_C_COMPILER} -E output ${MICROPY_GENHDR_DIR}/qstr.i.last cflags ${MICROPY_CPP_FLAGS} -DNO_QSTR cxxflags ${MICROPY_CPP_FLAGS} -DNO_QSTR sources ${MICROPY_SOURCE_QSTR}
     DEPENDS ${MICROPY_MODULEDEFS}
         ${MICROPY_SOURCE_QSTR}
     VERBATIM

--- a/py/usermod.cmake
+++ b/py/usermod.cmake
@@ -1,0 +1,52 @@
+# Create a target for all user modules to link against.
+add_library(usermod INTERFACE)
+
+function(usermod_gather_sources SOURCES_VARNAME INCLUDE_DIRECTORIES_VARNAME INCLUDED_VARNAME LIB)
+    if (NOT ${LIB} IN_LIST ${INCLUDED_VARNAME})
+        list(APPEND ${INCLUDED_VARNAME} ${LIB})
+
+        # Gather library sources
+        get_target_property(lib_sources ${LIB} INTERFACE_SOURCES)
+        if (lib_sources)
+            list(APPEND ${SOURCES_VARNAME} ${lib_sources})
+        endif()
+
+        # Gather library includes
+        get_target_property(lib_include_directories ${LIB} INTERFACE_INCLUDE_DIRECTORIES)
+        if (lib_include_directories)
+            list(APPEND ${INCLUDE_DIRECTORIES_VARNAME} ${lib_include_directories})
+        endif()
+
+        # Recurse linked libraries
+        get_target_property(trans_depend ${LIB} INTERFACE_LINK_LIBRARIES)
+        if (trans_depend)
+            foreach(SUB_LIB ${trans_depend})
+                usermod_gather_sources(
+                    ${SOURCES_VARNAME}
+                    ${INCLUDE_DIRECTORIES_VARNAME}
+                    ${INCLUDED_VARNAME}
+                    ${SUB_LIB})
+            endforeach()
+        endif()
+
+        set(${SOURCES_VARNAME} ${${SOURCES_VARNAME}} PARENT_SCOPE)
+        set(${INCLUDE_DIRECTORIES_VARNAME} ${${INCLUDE_DIRECTORIES_VARNAME}} PARENT_SCOPE)
+        set(${INCLUDED_VARNAME} ${${INCLUDED_VARNAME}} PARENT_SCOPE)
+    endif()
+endfunction()
+
+# Include CMake files for user modules.
+if (USER_C_MODULES)
+    foreach(USER_C_MODULE_PATH ${USER_C_MODULES})
+        message("Including User C Module(s) from ${USER_C_MODULE_PATH}")
+        include(${USER_C_MODULE_PATH})
+    endforeach()
+endif()
+
+# Recursively gather sources for QSTR scanning - doesn't support generator expressions.
+usermod_gather_sources(MICROPY_SOURCE_USERMOD MICROPY_INC_USERMOD found_modules usermod)
+
+# Report found modules.
+list(REMOVE_ITEM found_modules "usermod")
+list(JOIN found_modules ", " found_modules)
+message("Found User C Module(s): ${found_modules}")

--- a/tools/ci.sh
+++ b/tools/ci.sh
@@ -181,6 +181,8 @@ function ci_rp2_build {
     make ${MAKEOPTS} -C mpy-cross
     git submodule update --init lib/pico-sdk lib/tinyusb
     make ${MAKEOPTS} -C ports/rp2
+    make ${MAKEOPTS} -C ports/rp2 clean
+    make ${MAKEOPTS} -C ports/rp2 USER_C_MODULES=../../examples/usercmodule/micropython.cmake
 }
 
 ########################################################################################


### PR DESCRIPTION
I've been preserving these files in our own fork of MicroPython since Graham wrote them, source - https://github.com/raspberrypi/micropython/commit/a8b3c0c26699562ffbe1f901c8e5abed0a95a258

This is the USER_C_MODULES support that our continuous-integration and deployment relies upon to bake our libraries (https://github.com/pimoroni/pimoroni-pico/tree/main/micropython/modules) into MicroPython for our own .uf2 release. It's been pretty robust up to this point, and I'd love to get it merged so I can target upstream MicroPython for releases rather than maintaining our own CI fork.