### PR TITLE
esp32: Specify port and baud on erase_flash

### DIFF
--- a/ports/esp32/Makefile
+++ b/ports/esp32/Makefile
@@ -37,7 +37,7 @@ deploy:
 	idf.py $(IDFPY_FLAGS) -p $(PORT) -b $(BAUD) flash
 
 erase:
-	idf.py $(IDFPY_FLAGS) erase_flash
+	idf.py $(IDFPY_FLAGS) -p $(PORT) -b $(BAUD) erase_flash
 
 submodules:
 	git submodule update --init $(addprefix ../../,$(GIT_SUBMODULES))


### PR DESCRIPTION
_Makes_ `make erase` behave like `make deploy`, allowing `PORT` and `BAUD` the be provided.

eg. I have 2x TinyPICOs plugged in.
1st one: /dev/tty.SLAB_USBtoUART
2nd one: /dev/tty.SLAB_USBtoUART54

Attempting to erase flash on the 2nd one.
No PORT passed to idf.py
Defaults to the 1st TP.

```
Mikes-MacBook-Pro:esp32 mike$ make BOARD=TINYPICO PORT=/dev/tty.SLAB_USBtoUART54 erase
idf.py -D MICROPY_BOARD=TINYPICO -B build-TINYPICO erase_flash
Executing action: erase_flash
Choosing default port b'/dev/cu.SLAB_USBtoUART' (use '-p PORT' option to set a specific serial port)
Running esptool.py in directory /Users/mike/Development/MicroPython/micropython/ports/esp32/build-TINYPICO
Executing "/Users/mike/.espressif/python_env/idf4.2_py3.9_env/bin/python /Users/mike/Development/MicroPython/esp/esp-idf/components/esptool_py/esptool/esptool.py -p /dev/cu.SLAB_USBtoUART -b 460800 --before default_reset --after hard_reset --chip esp32 erase_flash"...
esptool.py v3.0
Serial port /dev/cu.SLAB_USBtoUART
Connecting....
```