### PR TITLE
rp2_pio.c: Add three state machine helper functions.

### DIFF
--- a/ports/rp2/rp2_pio.c
+++ b/ports/rp2/rp2_pio.c
@@ -757,12 +757,18 @@ STATIC mp_obj_t rp2_state_machine_irq(size_t n_args, const mp_obj_t *pos_args, m
 STATIC MP_DEFINE_CONST_FUN_OBJ_KW(rp2_state_machine_irq_obj, 1, rp2_state_machine_irq);
 
 // StateMachine.restart()
-STATIC mp_obj_t rp2_state_machine_restart(mp_obj_t self_in) {
+STATIC mp_obj_t rp2_state_machine_restart(mp_obj_t self_in, mp_obj_t prog_in) {
     rp2_state_machine_obj_t *self = MP_OBJ_TO_PTR(self_in);
+    // Get the program data and extract the initial PC
+    mp_obj_t *prog;
+    mp_obj_get_array_fixed_n(prog_in, PROG_MAX_FIELDS, &prog);
+    mp_int_t initial_pc = mp_obj_get_int(prog[PROG_OFFSET_PIO0 + PIO_NUM(self->pio)]);
+
     pio_sm_restart(self->pio, self->sm);
+    pio_sm_exec(self->pio, self->sm, pio_encode_jmp(initial_pc));
     return mp_const_none;
 }
-STATIC MP_DEFINE_CONST_FUN_OBJ_1(rp2_state_machine_restart_obj, rp2_state_machine_restart);
+STATIC MP_DEFINE_CONST_FUN_OBJ_2(rp2_state_machine_restart_obj, rp2_state_machine_restart);
 
 // StateMachine.rx_fifo()
 STATIC mp_obj_t rp2_state_machine_rx_fifo(mp_obj_t self_in) {

--- a/ports/rp2/rp2_pio.c
+++ b/ports/rp2/rp2_pio.c
@@ -756,6 +756,28 @@ STATIC mp_obj_t rp2_state_machine_irq(size_t n_args, const mp_obj_t *pos_args, m
 }
 STATIC MP_DEFINE_CONST_FUN_OBJ_KW(rp2_state_machine_irq_obj, 1, rp2_state_machine_irq);
 
+// StateMachine.restart()
+STATIC mp_obj_t rp2_state_machine_restart(mp_obj_t self_in) {
+    rp2_state_machine_obj_t *self = MP_OBJ_TO_PTR(self_in);
+    pio_sm_restart(self->pio, self->sm);
+    return mp_const_none;
+}
+STATIC MP_DEFINE_CONST_FUN_OBJ_1(rp2_state_machine_restart_obj, rp2_state_machine_restart);
+
+// StateMachine.rx_fifo()
+STATIC mp_obj_t rp2_state_machine_rx_fifo(mp_obj_t self_in) {
+    rp2_state_machine_obj_t *self = MP_OBJ_TO_PTR(self_in);
+    return MP_OBJ_NEW_SMALL_INT(pio_sm_get_rx_fifo_level(self->pio, self->sm));
+}
+STATIC MP_DEFINE_CONST_FUN_OBJ_1(rp2_state_machine_rx_fifo_obj, rp2_state_machine_rx_fifo);
+
+// StateMachine.tx_fifo()
+STATIC mp_obj_t rp2_state_machine_tx_fifo(mp_obj_t self_in) {
+    rp2_state_machine_obj_t *self = MP_OBJ_TO_PTR(self_in);
+    return MP_OBJ_NEW_SMALL_INT(pio_sm_get_tx_fifo_level(self->pio, self->sm));
+}
+STATIC MP_DEFINE_CONST_FUN_OBJ_1(rp2_state_machine_tx_fifo_obj, rp2_state_machine_tx_fifo);
+
 STATIC const mp_rom_map_elem_t rp2_state_machine_locals_dict_table[] = {
     { MP_ROM_QSTR(MP_QSTR_init), MP_ROM_PTR(&rp2_state_machine_init_obj) },
     { MP_ROM_QSTR(MP_QSTR_active), MP_ROM_PTR(&rp2_state_machine_active_obj) },
@@ -763,6 +785,9 @@ STATIC const mp_rom_map_elem_t rp2_state_machine_locals_dict_table[] = {
     { MP_ROM_QSTR(MP_QSTR_get), MP_ROM_PTR(&rp2_state_machine_get_obj) },
     { MP_ROM_QSTR(MP_QSTR_put), MP_ROM_PTR(&rp2_state_machine_put_obj) },
     { MP_ROM_QSTR(MP_QSTR_irq), MP_ROM_PTR(&rp2_state_machine_irq_obj) },
+    { MP_ROM_QSTR(MP_QSTR_restart), MP_ROM_PTR(&rp2_state_machine_restart_obj) },
+    { MP_ROM_QSTR(MP_QSTR_rx_fifo), MP_ROM_PTR(&rp2_state_machine_rx_fifo_obj) },
+    { MP_ROM_QSTR(MP_QSTR_tx_fifo), MP_ROM_PTR(&rp2_state_machine_tx_fifo_obj) },
 };
 STATIC MP_DEFINE_CONST_DICT(rp2_state_machine_locals_dict, rp2_state_machine_locals_dict_table);
 

--- a/ports/stm32/boards/PYBD_SF2/mpconfigboard.h
+++ b/ports/stm32/boards/PYBD_SF2/mpconfigboard.h
@@ -89,6 +89,8 @@ extern struct _spi_bdev_t spi_bdev;
 #define MICROPY_HW_BDEV_WRITEBLOCKS(src, bl, n) spi_bdev_writeblocks(&spi_bdev, (src), (bl), (n))
 #define MICROPY_HW_BDEV_SPIFLASH_EXTENDED (&spi_bdev) // for extended block protocol
 
+#define MICROPY_HW_FLASH_MOUNT_AT_BOOT (0)
+
 // SPI flash #2, to be memory mapped
 #define MICROPY_HW_QSPIFLASH_SIZE_BITS_LOG2 (24)
 #define MICROPY_HW_QSPIFLASH_CS     (pyb_pin_QSPI2_CS)
@@ -174,7 +176,7 @@ extern struct _spi_bdev_t spi_bdev2;
 #define MICROPY_HW_SDCARD_DETECT_PIN        (pyb_pin_SD_SW)
 #define MICROPY_HW_SDCARD_DETECT_PULL       (GPIO_PULLUP)
 #define MICROPY_HW_SDCARD_DETECT_PRESENT    (GPIO_PIN_RESET)
-#define MICROPY_HW_SDCARD_MOUNT_AT_BOOT     (0)
+#define MICROPY_HW_SDCARD_MOUNT_AT_BOOT     (1)
 
 // USB config
 #define MICROPY_HW_USB_FS           (1)


### PR DESCRIPTION
statemachine.restart(): Restarts the state machine
statemachine.rx_fifo(): Return the number of RX FIFO items. 0 if empty
statemachine.tx_fifo(): Return the number of TX FIFO items. 0 if empty

restart() seems to be the most useful one, as it resets the state
machine to the initial state without the need to re-instantiation.
It also makes PIO code easier, because then stalling as error
state can be unlocked.

rx_fifo() is also useful, for MP code to check for data & timeout if
no data arrived. Complex logic is easier handled in Python code than
in PIO code.

tx_fifo() can be useful to check states where data is not
processed. And is mostly for symmetry.

These are tiny functions, with 2 or 3 active codelines only plus the
definition of their names.