### PR TITLE
rp2_pio.c: Fix sm.get(buf) size expectation.

### DIFF
--- a/ports/rp2/rp2_pio.c
+++ b/ports/rp2/rp2_pio.c
@@ -608,6 +608,9 @@ STATIC mp_obj_t rp2_state_machine_get(size_t n_args, const mp_obj_t *args) {
             } else {
                 bufinfo.typecode |= 0x20; // make lowercase to support upper and lower
             }
+            if (bufinfo.len <= 0) {  // edge case: buffer of zero length supplied
+                return args[1];
+            }
         }
         if (n_args > 2) {
             shift = mp_obj_get_int(args[2]);
@@ -625,9 +628,6 @@ STATIC mp_obj_t rp2_state_machine_get(size_t n_args, const mp_obj_t *args) {
         if (dest == NULL) {
             return mp_obj_new_int_from_uint(value);
         }
-        if (dest >= dest_top) {
-            return args[1];
-        }
         if (bufinfo.typecode == 'b') {
             *(uint8_t *)dest = value;
             dest += sizeof(uint8_t);
@@ -639,6 +639,9 @@ STATIC mp_obj_t rp2_state_machine_get(size_t n_args, const mp_obj_t *args) {
             dest += sizeof(uint32_t);
         } else {
             mp_raise_ValueError("unsupported buffer type");
+        }
+        if (dest >= dest_top) {
+            return args[1];
         }
     }
 }


### PR DESCRIPTION
sm.get(buf) was waiting for one item more than the length of
the supplied buffer. Even if this item was not stored, sm.get() waited
to get that item from the RX fifo. If the state machine did not
supply it, sm.get() stalled. So the check was moved to the end
of the capture loop. Moving it to the start was not possible due
to the code for the non-buffer variant of sm.get().
As part of that, the edge case for a zero length buffer was moved up
to the section, where the function arguments are handled. In case
of a zero length buffer, sm.get() now returns immediately that buffer.
It could as well return None, but for return type consistency, returning
the buffer seems better.