### PR TITLE
Allow boards to define the SDMMC instance used for SD Card and for WiFi.

### DIFF
--- a/ports/stm32/boards/PYBD_SF2/mpconfigboard.h
+++ b/ports/stm32/boards/PYBD_SF2/mpconfigboard.h
@@ -165,6 +165,7 @@ extern struct _spi_bdev_t spi_bdev2;
 #define MICROPY_HW_LED_OFF(pin)     (mp_hal_pin_high(pin))
 
 // SD card
+#define MICROPY_HW_SDCARD_SDMMC             (2)
 #define MICROPY_HW_SDMMC2_CK                (pyb_pin_SD_CK)
 #define MICROPY_HW_SDMMC2_CMD               (pyb_pin_SD_CMD)
 #define MICROPY_HW_SDMMC2_D0                (pyb_pin_SD_D0)

--- a/ports/stm32/boards/STM32F769DISC/mpconfigboard.h
+++ b/ports/stm32/boards/STM32F769DISC/mpconfigboard.h
@@ -91,6 +91,7 @@ extern struct _spi_bdev_t spi_bdev;
 #define MICROPY_HW_LED_OFF(pin)     (mp_hal_pin_low(pin))
 
 // SD card detect switch
+#define MICROPY_HW_SDCARD_SDMMC             (2)
 #define MICROPY_HW_SDMMC2_CK                (pin_D6)
 #define MICROPY_HW_SDMMC2_CMD               (pin_D7)
 #define MICROPY_HW_SDMMC2_D0                (pin_G9)

--- a/ports/stm32/sdcard.c
+++ b/ports/stm32/sdcard.c
@@ -42,11 +42,10 @@
 
 #if defined(STM32F7) || defined(STM32H7) || defined(STM32L4)
 
-// The F7 has 2 SDMMC units but at the moment we only support using one of them in
-// a given build.  If a boards config file defines MICROPY_HW_SDMMC2_CK then SDMMC2
-// is used, otherwise SDMMC1 is used.
+// The H7/F7/L4 have 2 SDMMC peripherals, but at the moment this driver only supports using one of them at a time.
+// Use SDMMC2 only if the SD card SDMMC instance is defined explicitly as SDMMC2, otherwise SDMMC1 is used by default.
 
-#if defined(MICROPY_HW_SDMMC2_CK)
+#if (MICROPY_HW_SDCARD_SDMMC == 2)
 #define SDIO SDMMC2
 #define SDMMC_IRQHandler SDMMC2_IRQHandler
 #define SDMMC_CLK_ENABLE() __HAL_RCC_SDMMC2_CLK_ENABLE()
@@ -152,7 +151,7 @@ void sdcard_init(void) {
     // Note: the mp_hal_pin_config function will configure the GPIO in
     // fast mode which can do up to 50MHz.  This should be plenty for SDIO
     // which clocks up to 25MHz maximum.
-    #if defined(MICROPY_HW_SDMMC2_CK)
+    #if (MICROPY_HW_SDCARD_SDMMC == 2)
     // Use SDMMC2 peripheral with pins provided by the board's config
     mp_hal_pin_config_alt_static(MICROPY_HW_SDMMC2_CK, MP_HAL_PIN_MODE_ALT, MP_HAL_PIN_PULL_UP, STATIC_AF_SDMMC2_CK);
     mp_hal_pin_config_alt_static(MICROPY_HW_SDMMC2_CMD, MP_HAL_PIN_MODE_ALT, MP_HAL_PIN_PULL_UP, STATIC_AF_SDMMC2_CMD);
@@ -187,7 +186,7 @@ STATIC void sdmmc_msp_init(void) {
 
     #if defined(STM32H7)
     // Reset SDMMC
-    #if defined(MICROPY_HW_SDMMC2_CK)
+    #if (MICROPY_HW_SDCARD_SDMMC == 2)
     __HAL_RCC_SDMMC2_FORCE_RESET();
     __HAL_RCC_SDMMC2_RELEASE_RESET();
     #else

--- a/ports/stm32/sdio.c
+++ b/ports/stm32/sdio.c
@@ -28,7 +28,8 @@
 
 #include "py/mperrno.h"
 #include "py/mphal.h"
-#include "genhdr/pins.h"
+#include "pin.h"
+#include "pin_static_af.h"
 #include "pendsv.h"
 #include "sdio.h"
 
@@ -50,18 +51,56 @@ static volatile uint32_t sdmmc_error;
 static volatile uint8_t *sdmmc_buf_cur;
 static volatile uint8_t *sdmmc_buf_top;
 
+// The H7/F7/L4 have 2 SDMMC peripherals, but at the moment this driver only supports using one of them at a time.
+// Use SDMMC2 only if the WiFi SDMMC instance is defined explicitly as SDMMC2, otherwise SDMMC1 is used by default.
+
+#if (MICROPY_HW_WIFI_SDMMC == 2)
+#define SDMMC               (SDMMC2)
+#define SDMMC_IRQn          (SDMMC2_IRQn)
+#define SDMMC_IRQ_HANDLER   SDMMC2_IRQHandler
+#define SDMMC_CLK_ENABLE()  __HAL_RCC_SDMMC2_CLK_ENABLE()
+#define SDMMC_CLK_DISABLE() __HAL_RCC_SDMMC2_CLK_DISABLE()
+#else
+#define SDMMC               (SDMMC1)
+#define SDMMC_IRQn          (SDMMC1_IRQn)
+#define SDMMC_IRQ_HANDLER   SDMMC1_IRQHandler
+#define SDMMC_CLK_ENABLE()  __HAL_RCC_SDMMC1_CLK_ENABLE()
+#define SDMMC_CLK_DISABLE() __HAL_RCC_SDMMC1_CLK_DISABLE()
+#endif
+
+// If no custom SDIO pins defined, use the default ones
+#ifndef MICROPY_HW_SDMMC1_CK
+#define MICROPY_HW_SDMMC1_D0    (pin_C8)
+#define MICROPY_HW_SDMMC1_D1    (pin_C9)
+#define MICROPY_HW_SDMMC1_D2    (pin_C10)
+#define MICROPY_HW_SDMMC1_D3    (pin_C11)
+#define MICROPY_HW_SDMMC1_CK    (pin_C12)
+#define MICROPY_HW_SDMMC1_CMD   (pin_D2)
+#endif
+
 void sdio_init(uint32_t irq_pri) {
     // configure IO pins
-    mp_hal_pin_config(pin_C8, MP_HAL_PIN_MODE_ALT, MP_HAL_PIN_PULL_UP, 12);
-    mp_hal_pin_config(pin_C9, MP_HAL_PIN_MODE_ALT, MP_HAL_PIN_PULL_UP, 12);
-    mp_hal_pin_config(pin_C10, MP_HAL_PIN_MODE_ALT, MP_HAL_PIN_PULL_UP, 12);
-    mp_hal_pin_config(pin_C11, MP_HAL_PIN_MODE_ALT, MP_HAL_PIN_PULL_UP, 12);
-    mp_hal_pin_config(pin_C12, MP_HAL_PIN_MODE_ALT, MP_HAL_PIN_PULL_NONE, 12); // CLK doesn't need pull-up
-    mp_hal_pin_config(pin_D2, MP_HAL_PIN_MODE_ALT, MP_HAL_PIN_PULL_UP, 12);
+    #if (MICROPY_HW_WIFI_SDMMC == 2)
+    // Use SDMMC2 peripheral with pins provided by the board's config
+    mp_hal_pin_config_alt_static(MICROPY_HW_SDMMC2_CK, MP_HAL_PIN_MODE_ALT, MP_HAL_PIN_PULL_UP, STATIC_AF_SDMMC2_CK);
+    mp_hal_pin_config_alt_static(MICROPY_HW_SDMMC2_CMD, MP_HAL_PIN_MODE_ALT, MP_HAL_PIN_PULL_UP, STATIC_AF_SDMMC2_CMD);
+    mp_hal_pin_config_alt_static(MICROPY_HW_SDMMC2_D0, MP_HAL_PIN_MODE_ALT, MP_HAL_PIN_PULL_UP, STATIC_AF_SDMMC2_D0);
+    mp_hal_pin_config_alt_static(MICROPY_HW_SDMMC2_D1, MP_HAL_PIN_MODE_ALT, MP_HAL_PIN_PULL_UP, STATIC_AF_SDMMC2_D1);
+    mp_hal_pin_config_alt_static(MICROPY_HW_SDMMC2_D2, MP_HAL_PIN_MODE_ALT, MP_HAL_PIN_PULL_UP, STATIC_AF_SDMMC2_D2);
+    mp_hal_pin_config_alt_static(MICROPY_HW_SDMMC2_D3, MP_HAL_PIN_MODE_ALT, MP_HAL_PIN_PULL_UP, STATIC_AF_SDMMC2_D3);
+    #else
+    // Default SDIO/SDMMC config
+    mp_hal_pin_config_alt_static(MICROPY_HW_SDMMC1_CK, MP_HAL_PIN_MODE_ALT, MP_HAL_PIN_PULL_UP, STATIC_AF_SDMMC1_CK);
+    mp_hal_pin_config_alt_static(MICROPY_HW_SDMMC1_CMD, MP_HAL_PIN_MODE_ALT, MP_HAL_PIN_PULL_UP, STATIC_AF_SDMMC1_CMD);
+    mp_hal_pin_config_alt_static(MICROPY_HW_SDMMC1_D0, MP_HAL_PIN_MODE_ALT, MP_HAL_PIN_PULL_UP, STATIC_AF_SDMMC1_D0);
+    mp_hal_pin_config_alt_static(MICROPY_HW_SDMMC1_D1, MP_HAL_PIN_MODE_ALT, MP_HAL_PIN_PULL_UP, STATIC_AF_SDMMC1_D1);
+    mp_hal_pin_config_alt_static(MICROPY_HW_SDMMC1_D2, MP_HAL_PIN_MODE_ALT, MP_HAL_PIN_PULL_UP, STATIC_AF_SDMMC1_D2);
+    mp_hal_pin_config_alt_static(MICROPY_HW_SDMMC1_D3, MP_HAL_PIN_MODE_ALT, MP_HAL_PIN_PULL_UP, STATIC_AF_SDMMC1_D3);
+    #endif
 
-    __HAL_RCC_SDMMC1_CLK_ENABLE(); // enable SDIO peripheral
+    SDMMC_CLK_ENABLE(); // enable SDIO peripheral
 
-    SDMMC_TypeDef *SDIO = SDMMC1;
+    SDMMC_TypeDef *SDIO = SDMMC;
     #if defined(STM32F7)
     SDIO->CLKCR = SDMMC_CLKCR_HWFC_EN | SDMMC_CLKCR_PWRSAV | (120 - 2); // 1-bit, 400kHz
     #else
@@ -80,21 +119,21 @@ void sdio_init(uint32_t irq_pri) {
     __HAL_RCC_DMA2_CLK_ENABLE(); // enable DMA2 peripheral
     #endif
 
-    NVIC_SetPriority(SDMMC1_IRQn, irq_pri);
+    NVIC_SetPriority(SDMMC_IRQn, irq_pri);
 
     SDIO->MASK = 0;
-    HAL_NVIC_EnableIRQ(SDMMC1_IRQn);
+    HAL_NVIC_EnableIRQ(SDMMC_IRQn);
 }
 
 void sdio_deinit(void) {
-    __HAL_RCC_SDMMC1_CLK_DISABLE();
+    SDMMC_CLK_DISABLE();
     #if defined(STM32F7)
     __HAL_RCC_DMA2_CLK_DISABLE();
     #endif
 }
 
 void sdio_enable_high_speed_4bit(void) {
-    SDMMC_TypeDef *SDIO = SDMMC1;
+    SDMMC_TypeDef *SDIO = SDMMC;
     SDIO->POWER = 0; // power off
     mp_hal_delay_us(10);
     #if defined(STM32F7)
@@ -113,33 +152,33 @@ void sdio_enable_high_speed_4bit(void) {
     mp_hal_delay_us(10);
 }
 
-void SDMMC1_IRQHandler(void) {
-    if (SDMMC1->STA & SDMMC_STA_CMDREND) {
-        SDMMC1->ICR = SDMMC_ICR_CMDRENDC;
-        uint32_t r1 = SDMMC1->RESP1;
-        if (SDMMC1->RESPCMD == 53 && r1 & 0x800) {
-            printf("bad RESP1: %lu %lx\n", SDMMC1->RESPCMD, r1);
+void SDMMC_IRQ_HANDLER(void) {
+    if (SDMMC->STA & SDMMC_STA_CMDREND) {
+        SDMMC->ICR = SDMMC_ICR_CMDRENDC;
+        uint32_t r1 = SDMMC->RESP1;
+        if (SDMMC->RESPCMD == 53 && r1 & 0x800) {
+            printf("bad RESP1: %lu %lx\n", SDMMC->RESPCMD, r1);
             sdmmc_error = 0xffffffff;
-            SDMMC1->MASK &= SDMMC_MASK_SDIOITIE;
+            SDMMC->MASK &= SDMMC_MASK_SDIOITIE;
             sdmmc_irq_state = SDMMC_IRQ_STATE_DONE;
             return;
         }
         #if defined(STM32H7)
         if (!sdmmc_dma) {
-            while (sdmmc_buf_cur < sdmmc_buf_top && (SDMMC1->STA & SDMMC_STA_DPSMACT) && !(SDMMC1->STA & SDMMC_STA_RXFIFOE)) {
-                *(uint32_t *)sdmmc_buf_cur = SDMMC1->FIFO;
+            while (sdmmc_buf_cur < sdmmc_buf_top && (SDMMC->STA & SDMMC_STA_DPSMACT) && !(SDMMC->STA & SDMMC_STA_RXFIFOE)) {
+                *(uint32_t *)sdmmc_buf_cur = SDMMC->FIFO;
                 sdmmc_buf_cur += 4;
             }
         }
         #endif
         if (sdmmc_buf_cur >= sdmmc_buf_top) {
             // data transfer finished, so we are done
-            SDMMC1->MASK &= SDMMC_MASK_SDIOITIE;
+            SDMMC->MASK &= SDMMC_MASK_SDIOITIE;
             sdmmc_irq_state = SDMMC_IRQ_STATE_DONE;
             return;
         }
         if (sdmmc_write) {
-            SDMMC1->DCTRL =
+            SDMMC->DCTRL =
                 SDMMC_DCTRL_SDIOEN
                 | SDMMC_DCTRL_RWMOD
                 | sdmmc_block_size_log2 << SDMMC_DCTRL_DBLOCKSIZE_Pos
@@ -150,51 +189,51 @@ void SDMMC1_IRQHandler(void) {
                     | SDMMC_DCTRL_DTEN
             ;
             if (!sdmmc_dma) {
-                SDMMC1->MASK |= SDMMC_MASK_TXFIFOHEIE;
+                SDMMC->MASK |= SDMMC_MASK_TXFIFOHEIE;
             }
         }
         sdmmc_irq_state = SDMMC_IRQ_STATE_CMD_DONE;
-    } else if (SDMMC1->STA & SDMMC_STA_DATAEND) {
+    } else if (SDMMC->STA & SDMMC_STA_DATAEND) {
         // data transfer complete
         // note: it's possible to get DATAEND before CMDREND
-        SDMMC1->ICR = SDMMC_ICR_DATAENDC;
+        SDMMC->ICR = SDMMC_ICR_DATAENDC;
         #if defined(STM32F7)
         // check if there is some remaining data in RXFIFO
         if (!sdmmc_dma) {
-            while (SDMMC1->STA & SDMMC_STA_RXDAVL) {
-                *(uint32_t *)sdmmc_buf_cur = SDMMC1->FIFO;
+            while (SDMMC->STA & SDMMC_STA_RXDAVL) {
+                *(uint32_t *)sdmmc_buf_cur = SDMMC->FIFO;
                 sdmmc_buf_cur += 4;
             }
         }
         #endif
         if (sdmmc_irq_state == SDMMC_IRQ_STATE_CMD_DONE) {
             // command and data finished, so we are done
-            SDMMC1->MASK &= SDMMC_MASK_SDIOITIE;
+            SDMMC->MASK &= SDMMC_MASK_SDIOITIE;
             sdmmc_irq_state = SDMMC_IRQ_STATE_DONE;
         }
-    } else if (SDMMC1->STA & SDMMC_STA_TXFIFOHE) {
+    } else if (SDMMC->STA & SDMMC_STA_TXFIFOHE) {
         if (!sdmmc_dma && sdmmc_write) {
             // write up to 8 words to fifo
             for (size_t i = 8; i && sdmmc_buf_cur < sdmmc_buf_top; --i) {
-                SDMMC1->FIFO = *(uint32_t *)sdmmc_buf_cur;
+                SDMMC->FIFO = *(uint32_t *)sdmmc_buf_cur;
                 sdmmc_buf_cur += 4;
             }
             if (sdmmc_buf_cur >= sdmmc_buf_top) {
                 // finished, disable IRQ
-                SDMMC1->MASK &= ~SDMMC_MASK_TXFIFOHEIE;
+                SDMMC->MASK &= ~SDMMC_MASK_TXFIFOHEIE;
             }
         }
-    } else if (SDMMC1->STA & SDMMC_STA_RXFIFOHF) {
+    } else if (SDMMC->STA & SDMMC_STA_RXFIFOHF) {
         if (!sdmmc_dma && !sdmmc_write) {
             // read up to 8 words from fifo
             for (size_t i = 8; i && sdmmc_buf_cur < sdmmc_buf_top; --i) {
-                *(uint32_t *)sdmmc_buf_cur = SDMMC1->FIFO;
+                *(uint32_t *)sdmmc_buf_cur = SDMMC->FIFO;
                 sdmmc_buf_cur += 4;
             }
         }
-    } else if (SDMMC1->STA & SDMMC_STA_SDIOIT) {
-        SDMMC1->MASK &= ~SDMMC_MASK_SDIOITIE;
-        SDMMC1->ICR = SDMMC_ICR_SDIOITC;
+    } else if (SDMMC->STA & SDMMC_STA_SDIOIT) {
+        SDMMC->MASK &= ~SDMMC_MASK_SDIOITIE;
+        SDMMC->ICR = SDMMC_ICR_SDIOITC;
 
         #if MICROPY_PY_NETWORK_CYW43
         extern void (*cyw43_poll)(void);
@@ -202,11 +241,11 @@ void SDMMC1_IRQHandler(void) {
             pendsv_schedule_dispatch(PENDSV_DISPATCH_CYW43, cyw43_poll);
         }
         #endif
-    } else if (SDMMC1->STA & 0x3f) {
+    } else if (SDMMC->STA & 0x3f) {
         // an error
-        sdmmc_error = SDMMC1->STA;
-        SDMMC1->ICR = SDMMC_STATIC_FLAGS;
-        SDMMC1->MASK &= SDMMC_MASK_SDIOITIE;
+        sdmmc_error = SDMMC->STA;
+        SDMMC->ICR = SDMMC_STATIC_FLAGS;
+        SDMMC->MASK &= SDMMC_MASK_SDIOITIE;
         sdmmc_irq_state = SDMMC_IRQ_STATE_DONE;
     }
 }
@@ -214,22 +253,22 @@ void SDMMC1_IRQHandler(void) {
 int sdio_transfer(uint32_t cmd, uint32_t arg, uint32_t *resp) {
     #if defined(STM32F7)
     // Wait for any outstanding TX to complete
-    while (SDMMC1->STA & SDMMC_STA_TXACT) {
+    while (SDMMC->STA & SDMMC_STA_TXACT) {
     }
     #endif
 
     #if defined(STM32F7)
     DMA2_Stream3->CR = 0; // ensure DMA is reset
     #endif
-    SDMMC1->ICR = SDMMC_STATIC_FLAGS; // clear interrupts
-    SDMMC1->ARG = arg;
-    SDMMC1->CMD = cmd | SDMMC_CMD_WAITRESP_0 | SDMMC_CMD_CPSMEN;
+    SDMMC->ICR = SDMMC_STATIC_FLAGS; // clear interrupts
+    SDMMC->ARG = arg;
+    SDMMC->CMD = cmd | SDMMC_CMD_WAITRESP_0 | SDMMC_CMD_CPSMEN;
 
     sdmmc_irq_state = SDMMC_IRQ_STATE_CMD_DATA_PENDING;
     sdmmc_error = 0;
     sdmmc_buf_cur = NULL;
     sdmmc_buf_top = NULL;
-    SDMMC1->MASK = (SDMMC1->MASK & SDMMC_MASK_SDIOITIE) | SDMMC_MASK_CMDRENDIE | 0x3f;
+    SDMMC->MASK = (SDMMC->MASK & SDMMC_MASK_SDIOITIE) | SDMMC_MASK_CMDRENDIE | 0x3f;
 
     uint32_t start = mp_hal_ticks_ms();
     for (;;) {
@@ -238,13 +277,13 @@ int sdio_transfer(uint32_t cmd, uint32_t arg, uint32_t *resp) {
             break;
         }
         if (mp_hal_ticks_ms() - start > 1000) {
-            SDMMC1->MASK = DEFAULT_MASK;
-            printf("sdio_transfer timeout STA=0x%08x\n", (uint)SDMMC1->STA);
+            SDMMC->MASK = DEFAULT_MASK;
+            printf("sdio_transfer timeout STA=0x%08x\n", (uint)SDMMC->STA);
             return -MP_ETIMEDOUT;
         }
     }
 
-    SDMMC1->MASK &= SDMMC_MASK_SDIOITIE;
+    SDMMC->MASK &= SDMMC_MASK_SDIOITIE;
 
     if (sdmmc_error == SDMMC_STA_CCRCFAIL && cmd == 5) {
         // Errata: CMD CRC error is incorrectly generated for CMD 5
@@ -253,13 +292,13 @@ int sdio_transfer(uint32_t cmd, uint32_t arg, uint32_t *resp) {
         return -(0x1000000 | sdmmc_error);
     }
 
-    uint32_t rcmd = SDMMC1->RESPCMD;
+    uint32_t rcmd = SDMMC->RESPCMD;
     if (rcmd != cmd) {
         printf("sdio_transfer: cmd=%lu rcmd=%lu\n", cmd, rcmd);
         return -MP_EIO;
     }
     if (resp != NULL) {
-        *resp = SDMMC1->RESP1;
+        *resp = SDMMC->RESP1;
     }
     return 0;
 }
@@ -267,7 +306,7 @@ int sdio_transfer(uint32_t cmd, uint32_t arg, uint32_t *resp) {
 int sdio_transfer_cmd53(bool write, uint32_t block_size, uint32_t arg, size_t len, uint8_t *buf) {
     #if defined(STM32F7)
     // Wait for any outstanding TX to complete
-    while (SDMMC1->STA & SDMMC_STA_TXACT) {
+    while (SDMMC->STA & SDMMC_STA_TXACT) {
     }
     #endif
 
@@ -294,11 +333,11 @@ int sdio_transfer_cmd53(bool write, uint32_t block_size, uint32_t arg, size_t le
 
     bool dma = (len > 16);
 
-    SDMMC1->ICR = SDMMC_STATIC_FLAGS; // clear interrupts
-    SDMMC1->MASK &= SDMMC_MASK_SDIOITIE;
+    SDMMC->ICR = SDMMC_STATIC_FLAGS; // clear interrupts
+    SDMMC->MASK &= SDMMC_MASK_SDIOITIE;
 
-    SDMMC1->DTIMER = 0x2000000; // about 700ms running at 48MHz
-    SDMMC1->DLEN = (len + block_size - 1) & ~(block_size - 1);
+    SDMMC->DTIMER = 0x2000000; // about 700ms running at 48MHz
+    SDMMC->DLEN = (len + block_size - 1) & ~(block_size - 1);
 
     #if defined(STM32F7)
     DMA2_Stream3->CR = 0;
@@ -324,7 +363,7 @@ int sdio_transfer_cmd53(bool write, uint32_t block_size, uint32_t arg, size_t le
         #if defined(STM32F7)
         DMA2->LIFCR = 0x3f << 22;
         DMA2_Stream3->FCR = 0x07; // ?
-        DMA2_Stream3->PAR = (uint32_t)&SDMMC1->FIFO;
+        DMA2_Stream3->PAR = (uint32_t)&SDMMC->FIFO;
         if ((uint32_t)buf & 3) {
             printf("sdio_transfer_cmd53: buf=%p is not aligned for DMA\n", buf);
             return -MP_EINVAL;
@@ -344,12 +383,12 @@ int sdio_transfer_cmd53(bool write, uint32_t block_size, uint32_t arg, size_t le
             | 1 << 0 // EN
         ;
         #else
-        SDMMC1->IDMABASE0 = (uint32_t)buf;
-        SDMMC1->IDMACTRL = SDMMC_IDMA_IDMAEN;
+        SDMMC->IDMABASE0 = (uint32_t)buf;
+        SDMMC->IDMACTRL = SDMMC_IDMA_IDMAEN;
         #endif
     } else {
         #if defined(STM32H7)
-        SDMMC1->IDMACTRL = 0;
+        SDMMC->IDMACTRL = 0;
         #endif
     }
 
@@ -358,7 +397,7 @@ int sdio_transfer_cmd53(bool write, uint32_t block_size, uint32_t arg, size_t le
     // (and in case we get a long-running unrelated IRQ here on the host just
     // after writing to CMD to initiate the command)
     if (!write) {
-        SDMMC1->DCTRL =
+        SDMMC->DCTRL =
             SDMMC_DCTRL_SDIOEN
             | SDMMC_DCTRL_RWMOD
             | block_size_log2 << SDMMC_DCTRL_DBLOCKSIZE_Pos
@@ -370,8 +409,8 @@ int sdio_transfer_cmd53(bool write, uint32_t block_size, uint32_t arg, size_t le
         ;
     }
 
-    SDMMC1->ARG = arg;
-    SDMMC1->CMD = 53 | SDMMC_CMD_WAITRESP_0 | SDMMC_CMD_CPSMEN;
+    SDMMC->ARG = arg;
+    SDMMC->CMD = 53 | SDMMC_CMD_WAITRESP_0 | SDMMC_CMD_CPSMEN;
 
     sdmmc_irq_state = SDMMC_IRQ_STATE_CMD_DATA_PENDING;
     sdmmc_block_size_log2 = block_size_log2;
@@ -380,7 +419,7 @@ int sdio_transfer_cmd53(bool write, uint32_t block_size, uint32_t arg, size_t le
     sdmmc_error = 0;
     sdmmc_buf_cur = (uint8_t *)buf;
     sdmmc_buf_top = (uint8_t *)buf + len;
-    SDMMC1->MASK = (SDMMC1->MASK & SDMMC_MASK_SDIOITIE) | SDMMC_MASK_CMDRENDIE | SDMMC_MASK_DATAENDIE | SDMMC_MASK_RXFIFOHFIE | 0x3f;
+    SDMMC->MASK = (SDMMC->MASK & SDMMC_MASK_SDIOITIE) | SDMMC_MASK_CMDRENDIE | SDMMC_MASK_DATAENDIE | SDMMC_MASK_RXFIFOHFIE | 0x3f;
 
     // wait to complete transfer
     uint32_t start = mp_hal_ticks_ms();
@@ -390,23 +429,23 @@ int sdio_transfer_cmd53(bool write, uint32_t block_size, uint32_t arg, size_t le
             break;
         }
         if (mp_hal_ticks_ms() - start > 200) {
-            SDMMC1->MASK &= SDMMC_MASK_SDIOITIE;
+            SDMMC->MASK &= SDMMC_MASK_SDIOITIE;
             #if defined(STM32F7)
-            printf("sdio_transfer_cmd53: timeout wr=%d len=%u dma=%u buf_idx=%u STA=%08x SDMMC=%08x:%08x DMA=%08x:%08x:%08x RCC=%08x\n", write, (uint)len, (uint)dma, sdmmc_buf_cur - buf, (uint)SDMMC1->STA, (uint)SDMMC1->DCOUNT, (uint)SDMMC1->FIFOCNT, (uint)DMA2->LISR, (uint)DMA2->HISR, (uint)DMA2_Stream3->NDTR, (uint)RCC->AHB1ENR);
+            printf("sdio_transfer_cmd53: timeout wr=%d len=%u dma=%u buf_idx=%u STA=%08x SDMMC=%08x:%08x DMA=%08x:%08x:%08x RCC=%08x\n", write, (uint)len, (uint)dma, sdmmc_buf_cur - buf, (uint)SDMMC->STA, (uint)SDMMC->DCOUNT, (uint)SDMMC->FIFOCNT, (uint)DMA2->LISR, (uint)DMA2->HISR, (uint)DMA2_Stream3->NDTR, (uint)RCC->AHB1ENR);
             #else
-            printf("sdio_transfer_cmd53: timeout wr=%d len=%u dma=%u buf_idx=%u STA=%08x SDMMC=%08x:%08x IDMA=%08x\n", write, (uint)len, (uint)dma, sdmmc_buf_cur - buf, (uint)SDMMC1->STA, (uint)SDMMC1->DCOUNT, (uint)SDMMC1->DCTRL, (uint)SDMMC1->IDMACTRL);
+            printf("sdio_transfer_cmd53: timeout wr=%d len=%u dma=%u buf_idx=%u STA=%08x SDMMC=%08x:%08x IDMA=%08x\n", write, (uint)len, (uint)dma, sdmmc_buf_cur - buf, (uint)SDMMC->STA, (uint)SDMMC->DCOUNT, (uint)SDMMC->DCTRL, (uint)SDMMC->IDMACTRL);
             #endif
             return -MP_ETIMEDOUT;
         }
     }
 
-    SDMMC1->MASK &= SDMMC_MASK_SDIOITIE;
+    SDMMC->MASK &= SDMMC_MASK_SDIOITIE;
 
     if (sdmmc_error) {
         #if defined(STM32F7)
-        printf("sdio_transfer_cmd53: error=%08lx wr=%d len=%u dma=%u buf_idx=%u STA=%08x SDMMC=%08x:%08x DMA=%08x:%08x:%08x RCC=%08x\n", sdmmc_error, write, (uint)len, (uint)dma, sdmmc_buf_cur - buf, (uint)SDMMC1->STA, (uint)SDMMC1->DCOUNT, (uint)SDMMC1->FIFOCNT, (uint)DMA2->LISR, (uint)DMA2->HISR, (uint)DMA2_Stream3->NDTR, (uint)RCC->AHB1ENR);
+        printf("sdio_transfer_cmd53: error=%08lx wr=%d len=%u dma=%u buf_idx=%u STA=%08x SDMMC=%08x:%08x DMA=%08x:%08x:%08x RCC=%08x\n", sdmmc_error, write, (uint)len, (uint)dma, sdmmc_buf_cur - buf, (uint)SDMMC->STA, (uint)SDMMC->DCOUNT, (uint)SDMMC->FIFOCNT, (uint)DMA2->LISR, (uint)DMA2->HISR, (uint)DMA2_Stream3->NDTR, (uint)RCC->AHB1ENR);
         #else
-        printf("sdio_transfer_cmd53: error=%08lx wr=%d len=%u dma=%u buf_idx=%u STA=%08x SDMMC=%08x:%08x IDMA=%08x\n", sdmmc_error, write, (uint)len, (uint)dma, sdmmc_buf_cur - buf, (uint)SDMMC1->STA, (uint)SDMMC1->DCOUNT, (uint)SDMMC1->DCTRL, (uint)SDMMC1->IDMACTRL);
+        printf("sdio_transfer_cmd53: error=%08lx wr=%d len=%u dma=%u buf_idx=%u STA=%08x SDMMC=%08x:%08x IDMA=%08x\n", sdmmc_error, write, (uint)len, (uint)dma, sdmmc_buf_cur - buf, (uint)SDMMC->STA, (uint)SDMMC->DCOUNT, (uint)SDMMC->DCTRL, (uint)SDMMC->IDMACTRL);
         #endif
         return -(0x1000000 | sdmmc_error);
     }


### PR DESCRIPTION
* Currently sdcard.c uses SDMMC2 if MICROPY_HW_SDMMC2_CK is defined, which means that SDMMC2 can Not be used for WiFi/sdio.c, and WiFi/sdio.c SDMMC is hard-coded to SDMMC1 by default.
* This PR allows configuring the SDMMC instance used for sdcard.c and the one used for sdio.c explicitly in board config files.
* Boards can define the SDMMC used for SD card by defining : 
```
#define MICROPY_HW_SDCARD_SDMMC             (1 or 2)
```

* Boards can define the SDMMC used for WiFi by defining : 
```
#define MICROPY_HW_WIFI_SDMMC               (1 or 2)
```
* If a driver's SDMMC instance is Not defined, both sdcard.c and sdio.c use SDMMC1 by default. For example PYBD_SF2 now defines SDMMC2 for SD card, and nothing for WiFi, so sdio.c will fallback to the default SDMMC1.

* Note: Maybe the macros the abstract the SDMMC should be moved to a common place.