### PR TITLE
esp32/partition improve OTA functionality

### DIFF
--- a/docs/library/esp32.rst
+++ b/docs/library/esp32.rst
@@ -105,14 +105,28 @@ methods to enable over-the-air (OTA) updates.
 
 .. classmethod:: Partition.mark_app_valid_cancel_rollback()
 
-    Signals that the current boot is considered successful.
-    Calling ``mark_app_valid_cancel_rollback`` is required on the first boot of a new
-    partition to avoid an automatic rollback at the next boot.
+    Signals that the current boot is considered successful by writing to the "otadata"
+    partition. Calling ``mark_app_valid_cancel_rollback`` is required on the first boot of a
+    new partition to avoid an automatic rollback at the next boot.
     This uses the ESP-IDF "app rollback" feature with "CONFIG_BOOTLOADER_APP_ROLLBACK_ENABLE"
     and  an ``OSError(-261)`` is raised if called on firmware that doesn't have the
     feature enabled.
     It is OK to call ``mark_app_valid_cancel_rollback`` on every boot and it is not
     necessary when booting firmare that was loaded using esptool.
+
+.. classmethod:: Partition.mark_app_invalid_rollback_and_reboot()
+
+    Mark the current app partition invalid, rollback to the previous workable partition that
+    was marked as valid with ``mark_app_valid_cancel_rollback()`` and then reboots.
+    If the rollback is sucessfull, the device will reset.  If the flash does not have 
+    at least one valid app (except the running app) then rollback is not possible.
+    If the "CONFIG_BOOTLOADER_APP_ROLLBACK_ENABLE" option is set, and a reset occurs without
+    calling either 
+    ``mark_app_valid_cancel_rollback()`` or ``mark_app_invalid_rollback_and_reboot()``
+    function then the application is rolled back.
+    This uses the ESP-IDF "app rollback" feature with "CONFIG_BOOTLOADER_APP_ROLLBACK_ENABLE"
+    and  an ``OSError(-261)`` is raised if called on firmware that doesn't have the
+    feature enabled.
 
 Constants
 ~~~~~~~~~

--- a/ports/esp32/esp32_partition.c
+++ b/ports/esp32/esp32_partition.c
@@ -218,6 +218,15 @@ STATIC MP_DEFINE_CONST_FUN_OBJ_1(esp32_partition_mark_app_valid_cancel_rollback_
 STATIC MP_DEFINE_CONST_CLASSMETHOD_OBJ(esp32_partition_mark_app_valid_cancel_rollback_obj,
     MP_ROM_PTR(&esp32_partition_mark_app_valid_cancel_rollback_fun_obj));
 
+STATIC mp_obj_t esp32_partition_mark_app_invalid_rollback_and_reboot(mp_obj_t cls_in) {
+    check_esp_err(esp_ota_mark_app_invalid_rollback_and_reboot());
+    return mp_const_none;
+}
+STATIC MP_DEFINE_CONST_FUN_OBJ_1(esp32_partition_mark_app_invalid_rollback_and_reboot_fun_obj,
+    esp32_partition_mark_app_invalid_rollback_and_reboot);
+STATIC MP_DEFINE_CONST_CLASSMETHOD_OBJ(esp32_mark_app_invalid_rollback_and_reboot_obj,
+    MP_ROM_PTR(&esp32_partition_mark_app_invalid_rollback_and_reboot_fun_obj));
+
 STATIC const mp_rom_map_elem_t esp32_partition_locals_dict_table[] = {
     { MP_ROM_QSTR(MP_QSTR_find), MP_ROM_PTR(&esp32_partition_find_obj) },
 
@@ -228,6 +237,7 @@ STATIC const mp_rom_map_elem_t esp32_partition_locals_dict_table[] = {
 
     { MP_ROM_QSTR(MP_QSTR_set_boot), MP_ROM_PTR(&esp32_partition_set_boot_obj) },
     { MP_ROM_QSTR(MP_QSTR_mark_app_valid_cancel_rollback), MP_ROM_PTR(&esp32_partition_mark_app_valid_cancel_rollback_obj) },
+    { MP_ROM_QSTR(MP_QSTR_mark_app_invalid_rollback_and_reboot), MP_ROM_PTR(&esp32_mark_app_invalid_rollback_and_reboot_obj) },
     { MP_ROM_QSTR(MP_QSTR_get_next_update), MP_ROM_PTR(&esp32_partition_get_next_update_obj) },
 
     { MP_ROM_QSTR(MP_QSTR_BOOT), MP_ROM_INT(ESP32_PARTITION_BOOT) },

--- a/tests/esp32/partition_ota.py
+++ b/tests/esp32/partition_ota.py
@@ -72,6 +72,13 @@ elif STEP == 3:
         f.write("STEP=4\\nEXPECT=\\"" + nxt.info()[4] + "\\"\\n")
     machine.reset()
 elif STEP == 4:
+    log("Mark app invalid and revert to the previous valid app!")
+    nxt = cur.get_next_update()
+    with open("step.py", "w") as f:
+        f.write("STEP=5\\nEXPECT=\\"" + nxt.info()[4] + "\\"\\n")
+    Partition.mark_app_invalid_rollback_and_reboot()
+    machine.reset()
+elif STEP == 5:
     log("Confirming boot ok and DONE!")
     Partition.mark_app_valid_cancel_rollback()
     import uos


### PR DESCRIPTION
* add class method  mark_app_invalid_rollback_and_reboot() in Partition class

The reciprocal method "mark_app_valid_cancel_rollback()" is already implemented.