### PR TITLE
stm32/storage: Prevent attempts to read/write invalid block addresses.

### DIFF
--- a/ports/stm32/storage.c
+++ b/ports/stm32/storage.c
@@ -340,8 +340,12 @@ STATIC mp_obj_t pyb_flash_readblocks(size_t n_args, const mp_obj_t *args) {
     else if (self != &pyb_flash_obj) {
         // Extended block read on a sub-section of the flash storage
         uint32_t offset = mp_obj_get_int(args[3]);
-        block_num += self->start / PYB_FLASH_NATIVE_BLOCK_SIZE;
-        ret = MICROPY_HW_BDEV_READBLOCKS_EXT(bufinfo.buf, block_num, offset, bufinfo.len);
+        if ((block_num * PYB_FLASH_NATIVE_BLOCK_SIZE) >= self->len) {
+            ret = -MP_EFAULT; // Bad address
+        } else {
+            block_num += self->start / PYB_FLASH_NATIVE_BLOCK_SIZE;
+            ret = MICROPY_HW_BDEV_READBLOCKS_EXT(bufinfo.buf, block_num, offset, bufinfo.len);
+        }
     }
     #endif
     return MP_OBJ_NEW_SMALL_INT(ret);
@@ -363,8 +367,12 @@ STATIC mp_obj_t pyb_flash_writeblocks(size_t n_args, const mp_obj_t *args) {
     else if (self != &pyb_flash_obj) {
         // Extended block write on a sub-section of the flash storage
         uint32_t offset = mp_obj_get_int(args[3]);
-        block_num += self->start / PYB_FLASH_NATIVE_BLOCK_SIZE;
-        ret = MICROPY_HW_BDEV_WRITEBLOCKS_EXT(bufinfo.buf, block_num, offset, bufinfo.len);
+        if ((block_num * PYB_FLASH_NATIVE_BLOCK_SIZE) >= self->len) {
+            ret = -MP_EFAULT; // Bad address
+        } else {
+            block_num += self->start / PYB_FLASH_NATIVE_BLOCK_SIZE;
+            ret = MICROPY_HW_BDEV_WRITEBLOCKS_EXT(bufinfo.buf, block_num, offset, bufinfo.len);
+        }
     }
     #endif
     return MP_OBJ_NEW_SMALL_INT(ret);


### PR DESCRIPTION
This addresses the root cause of the QSPI deadlock issue seen in https://github.com/micropython/micropython/pull/6707

The problem there was a corrupted (?) LFS1 partition on the qspi flash is causing it to attempt to read an invalid address.

In this situation the QSPI driver does not have any checks for this and will get stuck waiting for data that never arrives.
Ideally all the spi/qspi functions would also be extended to check the transfer error flag and return an error if this happens.
An initial POC for this is available in https://github.com/micropython/micropython/pull/6992 but I expect a fair bit more work is needed here to make this suitable for inclusion.

This PR attempts to make sure these bad-address deadlock conditions get caught early and never make it to the qspi driver in the first place. As such it's a much smaller change that should be safe by itself, though I don't know if there are other conditions that might also cause uncaught qspi issues.