### PR TITLE
STM32WB: lib stm fix

### DIFF
--- a/ports/stm32/make-stmconst.py
+++ b/ports/stm32/make-stmconst.py
@@ -46,7 +46,7 @@ class LexerError(Exception):
 
 class Lexer:
     re_io_reg = r"__IO uint(?P<bits>8|16|32)_t +(?P<reg>[A-Z0-9]+)"
-    re_comment = r"(?P<comment>[A-Za-z0-9 \-/_()&:]+)"
+    re_comment = r"(?P<comment>[A-Za-z0-9 \-/_()&:\[\]]+)"
     re_addr_offset = r"Address offset: (?P<offset>0x[0-9A-Z]{2,3})"
     regexs = (
         (


### PR DESCRIPTION
When importing the stm lib on a WB series processor, no EXTI offset addresses are shown.
In the device h file, there are square brackets in the comment section, so adding them to the regex fixes it.