### PR TITLE
esp8266: add Pin.pin() method to return pin number

### DIFF
--- a/docs/esp8266/tutorial/pins.rst
+++ b/docs/esp8266/tutorial/pins.rst
@@ -19,6 +19,12 @@ it.  To make an input pin use::
 You can either use PULL_UP or None for the input pull-mode.  If it's
 not specified then it defaults to None, which is no pull resistor. GPIO16
 has no pull-up mode.
+
+You can query a ``Pin`` object for it's port number using::
+
+    >>> pin.pin()
+    0
+
 You can read the value on the pin using::
 
     >>> pin.value()

--- a/ports/esp8266/machine_pin.c
+++ b/ports/esp8266/machine_pin.c
@@ -354,6 +354,13 @@ STATIC mp_obj_t pyb_pin_value(size_t n_args, const mp_obj_t *args) {
 }
 STATIC MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(pyb_pin_value_obj, 1, 2, pyb_pin_value);
 
+// pin.pin()
+STATIC mp_obj_t pyb_pin_pin(mp_obj_t self_in) {
+    pyb_pin_obj_t *self = self_in;
+    return MP_OBJ_NEW_SMALL_INT(self->phys_port);
+}
+STATIC MP_DEFINE_CONST_FUN_OBJ_1(pyb_pin_pin_obj, pyb_pin_pin);
+
 STATIC mp_obj_t pyb_pin_off(mp_obj_t self_in) {
     pyb_pin_obj_t *self = self_in;
     pin_set(self->phys_port, 0);
@@ -428,6 +435,7 @@ STATIC const mp_rom_map_elem_t pyb_pin_locals_dict_table[] = {
     // instance methods
     { MP_ROM_QSTR(MP_QSTR_init),    MP_ROM_PTR(&pyb_pin_init_obj) },
     { MP_ROM_QSTR(MP_QSTR_value),   MP_ROM_PTR(&pyb_pin_value_obj) },
+    { MP_ROM_QSTR(MP_QSTR_pin),     MP_ROM_PTR(&pyb_pin_pin_obj) },
     { MP_ROM_QSTR(MP_QSTR_off),     MP_ROM_PTR(&pyb_pin_off_obj) },
     { MP_ROM_QSTR(MP_QSTR_on),      MP_ROM_PTR(&pyb_pin_on_obj) },
     { MP_ROM_QSTR(MP_QSTR_irq),     MP_ROM_PTR(&pyb_pin_irq_obj) },

--- a/ports/rp2/machine_pin.c
+++ b/ports/rp2/machine_pin.c
@@ -273,6 +273,13 @@ STATIC mp_obj_t machine_pin_value(size_t n_args, const mp_obj_t *args) {
 }
 STATIC MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(machine_pin_value_obj, 1, 2, machine_pin_value);
 
+// pin.pin()
+STATIC mp_obj_t machine_pin_pin(mp_obj_t self_in) {
+    machine_pin_obj_t *self = self_in;
+    return MP_OBJ_NEW_SMALL_INT(self->id);
+}
+STATIC MP_DEFINE_CONST_FUN_OBJ_1(machine_pin_pin_obj, machine_pin_pin);
+
 // pin.low()
 STATIC mp_obj_t machine_pin_low(mp_obj_t self_in) {
     machine_pin_obj_t *self = MP_OBJ_TO_PTR(self_in);
@@ -365,6 +372,7 @@ STATIC const mp_rom_map_elem_t machine_pin_locals_dict_table[] = {
     // instance methods
     { MP_ROM_QSTR(MP_QSTR_init), MP_ROM_PTR(&machine_pin_init_obj) },
     { MP_ROM_QSTR(MP_QSTR_value), MP_ROM_PTR(&machine_pin_value_obj) },
+    { MP_ROM_QSTR(MP_QSTR_pin), MP_ROM_PTR(&machine_pin_pin_obj) },
     { MP_ROM_QSTR(MP_QSTR_low), MP_ROM_PTR(&machine_pin_low_obj) },
     { MP_ROM_QSTR(MP_QSTR_high), MP_ROM_PTR(&machine_pin_high_obj) },
     { MP_ROM_QSTR(MP_QSTR_off), MP_ROM_PTR(&machine_pin_low_obj) },


### PR DESCRIPTION
Add a new Pin.pin() method to allow querying Pin objects for their
physical pin number.

---

This only applies to the esp8266 port, so I expect the enthusiasm for
this PR to be low. I wasn't sure if there was a sane way of
implementing something like this at a higher level, rather than
per-port, and I'm not equipped to test anything other than the esp8266
and esp32 ports.
