### PR TITLE
rp2: machine_uart.c: Enable buffered transfer of data.

### DIFF
--- a/ports/rp2/machine_uart.c
+++ b/ports/rp2/machine_uart.c
@@ -67,11 +67,11 @@ typedef struct _machine_uart_obj_t {
     uint16_t timeout_char;  // timeout waiting between chars (in ms)
     uint8_t invert;
     ringbuf_t read_buffer;
-    bool read_lock; 
+    bool read_lock;
     ringbuf_t write_buffer;
     bool write_lock;
     uint8_t irq_nr;
-    void(* irq_handler)();
+    void (*irq_handler)();
 } machine_uart_obj_t;
 
 STATIC void uart0_irq_handler();
@@ -128,14 +128,14 @@ STATIC inline void uart_service_interrupt(machine_uart_obj_t *self) {
     if (uart_get_hw(self->uart)->mis & UART_UARTMIS_RXMIS_BITS) { // rx interrupt?
         // clear all interrupt bits but tx
         uart_get_hw(self->uart)->icr = UART_UARTICR_BITS & (~UART_UARTICR_TXIC_BITS);
-        if (! self->read_lock) {
+        if (!self->read_lock) {
             uart_drain_rx_fifo(self, false);
         }
     }
     if (uart_get_hw(self->uart)->mis & UART_UARTMIS_TXMIS_BITS) { // tx interrupt?
-         // clear all interrupt bits but rx
+        // clear all interrupt bits but rx
         uart_get_hw(self->uart)->icr = UART_UARTICR_BITS & (~UART_UARTICR_RXIC_BITS);
-        if (! self->write_lock) {
+        if (!self->write_lock) {
             uart_fill_tx_fifo(self, false);
         }
     }
@@ -155,11 +155,11 @@ STATIC void uart1_irq_handler() {
 STATIC void machine_uart_print(const mp_print_t *print, mp_obj_t self_in, mp_print_kind_t kind) {
     machine_uart_obj_t *self = MP_OBJ_TO_PTR(self_in);
     mp_printf(print, "UART(%u, baudrate=%u, bits=%u, parity=%s, stop=%u, tx=%d, rx=%d, "
-                     "txbuf=%d, rxbuf=%d, timeout=%u, timeout_char=%u, invert=%s)",
+        "txbuf=%d, rxbuf=%d, timeout=%u, timeout_char=%u, invert=%s)",
         self->uart_id, self->baudrate, self->bits, _parity_name[self->parity],
         self->stop, self->tx, self->rx, self->write_buffer.size - 1, self->read_buffer.size - 1,
         self->timeout, self->timeout_char, _invert_name[self->invert]);
-} 
+}
 
 STATIC mp_obj_t machine_uart_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *all_args) {
     enum { ARG_id, ARG_baudrate, ARG_bits, ARG_parity, ARG_stop, ARG_tx, ARG_rx,
@@ -323,7 +323,7 @@ STATIC mp_obj_t machine_uart_make_new(const mp_obj_type_t *type, size_t n_args, 
         MP_STATE_PORT(rp2_uart_tx_buffer[uart_id]) = self->write_buffer.buf;
 
         // set the irq handler
-        irq_set_exclusive_handler (self->irq_nr, self->irq_handler);
+        irq_set_exclusive_handler(self->irq_nr, self->irq_handler);
         irq_set_enabled(self->irq_nr, true);
         // enable the uart irq. this macro sets the rx irq level to 4
         uart_set_irq_enables(self->uart, true, true);

--- a/ports/rp2/machine_uart.c
+++ b/ports/rp2/machine_uart.c
@@ -423,10 +423,10 @@ STATIC mp_uint_t machine_uart_ioctl(mp_obj_t self_in, mp_uint_t request, mp_uint
     if (request == MP_STREAM_POLL) {
         uintptr_t flags = arg;
         ret = 0;
-        if ((flags & MP_STREAM_POLL_RD) && uart_is_readable(self->uart)) {
+        if ((flags & MP_STREAM_POLL_RD) && (ringbuf_avail(&self->read_buffer) > 0)) {
             ret |= MP_STREAM_POLL_RD;
         }
-        if ((flags & MP_STREAM_POLL_WR) && uart_is_writable(self->uart)) {
+        if ((flags & MP_STREAM_POLL_WR) && (ringbuf_free(&self->write_buffer) > 0)) {
             ret |= MP_STREAM_POLL_WR;
         }
     } else {

--- a/ports/rp2/machine_uart.c
+++ b/ports/rp2/machine_uart.c
@@ -405,11 +405,11 @@ STATIC mp_uint_t machine_uart_write(mp_obj_t self_in, const void *buf_in, mp_uin
         ringbuf_put(&(self->write_buffer), *src++);
         ++i;
         t = time_us_64() + timeout_char_us;
+        self->write_lock = true;
+        uart_fill_tx_fifo(self);
+        self->write_lock = false;
     }
     // just in case the fifo was drained during refill of the ringbuf
-    self->write_lock = true;
-    uart_fill_tx_fifo(self);
-    self->write_lock = false;
     return size;
 }
 

--- a/ports/rp2/machine_uart.c
+++ b/ports/rp2/machine_uart.c
@@ -43,6 +43,7 @@
 #define DEFAULT_UART1_TX (4)
 #define DEFAULT_UART1_RX (5)
 #define DEFAULT_BUFFER_SIZE (256)
+#define MIN_BUFFER_SIZE  (128)
 #define MAX_BUFFER_SIZE  (32766)
 
 #define IS_VALID_PERIPH(uart, pin)  (((((pin) + 4) & 8) >> 3) == (uart))
@@ -261,8 +262,8 @@ STATIC mp_obj_t machine_uart_make_new(const mp_obj_type_t *type, size_t n_args, 
         rxbuf_len = args[ARG_rxbuf].u_int;
         // minimal size is DEFAULT_BUFFER_SIZE
         // maximal size is MAX_BUFFER_SIZE
-        if (rxbuf_len < DEFAULT_BUFFER_SIZE) {
-            rxbuf_len = DEFAULT_BUFFER_SIZE;
+        if (rxbuf_len < MIN_BUFFER_SIZE) {
+            rxbuf_len = MIN_BUFFER_SIZE;
         } else if (rxbuf_len > MAX_BUFFER_SIZE) {
             mp_raise_ValueError(MP_ERROR_TEXT("rxbuf too large"));
         }
@@ -275,8 +276,8 @@ STATIC mp_obj_t machine_uart_make_new(const mp_obj_type_t *type, size_t n_args, 
         txbuf_len = args[ARG_txbuf].u_int;
         // minimal size is DEFAULT_BUFFER_SIZE
         // maximal size is MAX_BUFFER_SIZE
-        if (txbuf_len < DEFAULT_BUFFER_SIZE) {
-            txbuf_len = DEFAULT_BUFFER_SIZE;
+        if (txbuf_len < MIN_BUFFER_SIZE) {
+            txbuf_len = MIN_BUFFER_SIZE;
         } else if (txbuf_len > MAX_BUFFER_SIZE) {
             mp_raise_ValueError(MP_ERROR_TEXT("txbuf too large"));
         }

--- a/ports/rp2/machine_uart.c
+++ b/ports/rp2/machine_uart.c
@@ -71,7 +71,7 @@ typedef struct _machine_uart_obj_t {
     ringbuf_t write_buffer;
     bool write_lock;
     uint8_t irq_nr;
-    void (*irq_handler)();
+    irq_handler_t irq_handler;
 } machine_uart_obj_t;
 
 STATIC void uart0_irq_handler();
@@ -305,20 +305,10 @@ STATIC mp_obj_t machine_uart_make_new(const mp_obj_type_t *type, size_t n_args, 
         if (self->invert & UART_INVERT_TX) {
             gpio_set_outover(self->tx, GPIO_OVERRIDE_INVERT);
         }
-        // deallocate and allocate the buffers
-        // free a previous buffer if present
-        // this part is inconsistent in accessing the buffer structure itself.
-        if (self->read_buffer.buf != NULL) {
-            m_del(byte, self->read_buffer.buf, self->read_buffer.size);
-            MP_STATE_PORT(rp2_uart_rx_buffer[uart_id]) = NULL;
-        }
+        // allocate the buffers
         ringbuf_alloc(&(self->read_buffer), rxbuf_len + 1);
         MP_STATE_PORT(rp2_uart_rx_buffer[uart_id]) = self->read_buffer.buf;
 
-        if (self->write_buffer.buf != NULL) {
-            m_del(byte, self->write_buffer.buf, self->write_buffer.size);
-            MP_STATE_PORT(rp2_uart_tx_buffer[uart_id]) = NULL;
-        }
         ringbuf_alloc(&(self->write_buffer), txbuf_len + 1);
         MP_STATE_PORT(rp2_uart_tx_buffer[uart_id]) = self->write_buffer.buf;
 

--- a/ports/rp2/mpconfigport.h
+++ b/ports/rp2/mpconfigport.h
@@ -176,7 +176,7 @@ extern const struct _mp_obj_module_t mp_module_utime;
     void *rp2_state_machine_irq_obj[8]; \
     void *rp2_uart_rx_buffer[2]; \
     void *rp2_uart_tx_buffer[2]; \
-    
+
 #define MP_STATE_PORT MP_STATE_VM
 
 // Miscellaneous settings

--- a/ports/rp2/mpconfigport.h
+++ b/ports/rp2/mpconfigport.h
@@ -174,7 +174,9 @@ extern const struct _mp_obj_module_t mp_module_utime;
     void *machine_pin_irq_obj[30]; \
     void *rp2_pio_irq_obj[2]; \
     void *rp2_state_machine_irq_obj[8]; \
-
+    void *rp2_uart_rx_buffer[2]; \
+    void *rp2_uart_tx_buffer[2]; \
+    
 #define MP_STATE_PORT MP_STATE_VM
 
 // Miscellaneous settings


### PR DESCRIPTION
This PR adds support buffered transfer of data. The buffer size
is set using  rxbuf and txbuf keywords during instantiation
or init. The default and minimal size is 256. The maximal
size is 32766 (2**15 - 2).

uart.write() still includes checks for timeout, even if it is very
unlikely to happen due to a) lack of flow control support and
b) the minimal timeout values being longer than the time it needs
to send a byte .