### PR TITLE
rp2: mpconfigport.h: enable uerrno

### DIFF
--- a/ports/rp2/mpconfigport.h
+++ b/ports/rp2/mpconfigport.h
@@ -120,6 +120,7 @@
 #define MICROPY_VFS                             (1)
 #define MICROPY_VFS_LFS2                        (1)
 #define MICROPY_VFS_FAT                         (1)
+#define MICROPY_PY_UERRNO                       (1)
 
 // fatfs configuration
 #define MICROPY_FATFS_ENABLE_LFN                (1)


### PR DESCRIPTION
add uerrno to the raspberry pi pico port. fixes #6991

Not sure what else might be affected by this include, I don't know the source-code well enough to assess that but at least the errno module is available now.

(I'm a bit at a loss with that commit message formatting errors.. thought my title was fine and I definitely used a real email adress for my commit when I changed the file via the webui..)