### PR TITLE
stm32/Makefile: Fix C++ linker flags when toolchain has spaces in path.

### DIFF
--- a/ports/stm32/Makefile
+++ b/ports/stm32/Makefile
@@ -145,7 +145,8 @@ endif
 CXXFLAGS += $(filter-out -Wmissing-prototypes -Wold-style-definition -std=gnu99,$(CFLAGS))
 CXXFLAGS += $(CXXFLAGS_MOD)
 ifneq ($(SRC_CXX)$(SRC_MOD_CXX),)
-LDFLAGS += -L$(dir $(shell $(CXX) $(CXXFLAGS) -print-file-name=libstdc++.a))
+LIBSTDCPP_FILE_NAME = "$(shell $(CXX) $(CXXFLAGS) -print-file-name=libstdc++.a)"
+LDFLAGS += -L"$(shell dirname $(LIBSTDCPP_FILE_NAME))"
 endif
 
 # Options for mpy-cross


### PR DESCRIPTION
The GNU Make dir command uses spaces as item separator so it does not
work for e.g building the STM32 port on Cygwin with a default Arm
installation in "c:/program files (x86)/GNU Arm Embedded Toolchain".
Fix by using POSIX dirname on a quoted path instead.

Fixes https://github.com/micropython/micropython/issues/6979