### PR TITLE
extmod/modbluetooth: Free temp arrays in gatts register services.

### DIFF
--- a/extmod/modbluetooth.c
+++ b/extmod/modbluetooth.c
@@ -619,6 +619,11 @@ STATIC mp_obj_t bluetooth_ble_gatts_register_services(mp_obj_t self_in, mp_obj_t
         }
         result->items[i] = MP_OBJ_FROM_PTR(service_handles);
     }
+
+    // Free temporary arrays.
+    m_del(uint16_t *, handles, len);
+    m_del(size_t, num_handles, len);
+
     return MP_OBJ_FROM_PTR(result);
 }
 STATIC MP_DEFINE_CONST_FUN_OBJ_2(bluetooth_ble_gatts_register_services_obj, bluetooth_ble_gatts_register_services);


### PR DESCRIPTION
This helps to reduce memory fragmentation, by freeing the heap data as soon
as it is not needed.  It also helps the compiler keeps a reference to the
beginning of both arrays, which need to be traceable by the GC (otherwise
some compilers may optimise this reference to something else).