### PR TITLE
rp2: moduos.py: add uos.urandom().

### DIFF
--- a/ports/rp2/main.c
+++ b/ports/rp2/main.c
@@ -44,7 +44,7 @@
 #include "pico/binary_info.h"
 #include "hardware/rtc.h"
 #include "hardware/structs/rosc.h"
-#include "pico/time.h"
+#include "mphalport.h"
 
 extern uint8_t __StackTop, __StackBottom;
 static char gc_heap[192 * 1024];
@@ -171,11 +171,11 @@ void MP_WEAK __assert_func(const char *file, int line, const char *func, const c
 
 #define POLY (0xD5)
 
-uint8_t rosc_random_u8(void) {
+uint8_t rosc_random_u8(size_t cycles) {
     static uint8_t r;
-    for (size_t i = 0; i < 8; ++i) {
+    for (size_t i = 0; i < cycles; ++i) {
         r = ((r << 1) | rosc_hw->randombit) ^ (r & 0x80 ? POLY : 0);
-        busy_wait_us_32(1);
+        mp_hal_delay_us_fast(1);
     }
     return r;
 }
@@ -183,7 +183,7 @@ uint8_t rosc_random_u8(void) {
 uint32_t rosc_random_u32(void) {
     uint32_t value = 0;
     for (size_t i = 0; i < 4; ++i) {
-        value = value << 8 | rosc_random_u8();
+        value = value << 8 | rosc_random_u8(32);
     }
     return value;
 }

--- a/ports/rp2/main.c
+++ b/ports/rp2/main.c
@@ -173,7 +173,7 @@ void MP_WEAK __assert_func(const char *file, int line, const char *func, const c
 
 uint8_t rosc_random_u8(void) {
     static uint8_t r;
-    for (size_t i = 0; i < 32; ++i) {
+    for (size_t i = 0; i < 8; ++i) {
         r = ((r << 1) | rosc_hw->randombit) ^ (r & 0x80 ? POLY : 0);
         busy_wait_us_32(1);
     }

--- a/ports/rp2/moduos.c
+++ b/ports/rp2/moduos.c
@@ -57,7 +57,7 @@ STATIC mp_obj_t os_uname(void) {
 }
 STATIC MP_DEFINE_CONST_FUN_OBJ_0(os_uname_obj, os_uname);
 
-extern uint8_t rosc_random_u8(void);
+extern uint8_t rosc_random_u8(size_t cycles);
 
 STATIC mp_obj_t os_urandom(mp_obj_t num) {
     mp_int_t n = mp_obj_get_int(num);
@@ -65,7 +65,7 @@ STATIC mp_obj_t os_urandom(mp_obj_t num) {
     vstr_init_len(&vstr, n);
 
     for (int i = 0; i < n; i++) {
-        vstr.buf[i] = rosc_random_u8();
+        vstr.buf[i] = rosc_random_u8(8);
     }
     return mp_obj_new_str_from_vstr(&mp_type_bytes, &vstr);
 }

--- a/ports/rp2/moduos.c
+++ b/ports/rp2/moduos.c
@@ -57,10 +57,25 @@ STATIC mp_obj_t os_uname(void) {
 }
 STATIC MP_DEFINE_CONST_FUN_OBJ_0(os_uname_obj, os_uname);
 
+extern uint8_t rosc_random_u8(void);
+
+STATIC mp_obj_t os_urandom(mp_obj_t num) {
+    mp_int_t n = mp_obj_get_int(num);
+    vstr_t vstr;
+    vstr_init_len(&vstr, n);
+
+    for (int i = 0; i < n; i++) {
+        vstr.buf[i] = rosc_random_u8();
+    }
+    return mp_obj_new_str_from_vstr(&mp_type_bytes, &vstr);
+}
+STATIC MP_DEFINE_CONST_FUN_OBJ_1(os_urandom_obj, os_urandom);
+
 STATIC const mp_rom_map_elem_t os_module_globals_table[] = {
     { MP_ROM_QSTR(MP_QSTR___name__), MP_ROM_QSTR(MP_QSTR_uos) },
 
     { MP_ROM_QSTR(MP_QSTR_uname), MP_ROM_PTR(&os_uname_obj) },
+    { MP_ROM_QSTR(MP_QSTR_urandom), MP_ROM_PTR(&os_urandom_obj) },
 
     #if MICROPY_VFS
     { MP_ROM_QSTR(MP_QSTR_chdir), MP_ROM_PTR(&mp_vfs_chdir_obj) },


### PR DESCRIPTION
The implementation samples rosc.randombits at about 1Mhz, which is lower than the oscillator frequency. The gives better random values. For a 8 bit value 8 samples are taken and fed through
a 8 bit CRC, distributing the sampling over the byte following bytes. The resulting sampling rate is about 120k/sec.
    
The RNG does not include testing of error conditions, like the ROSC being in sync with the sampling or completely failing. Making the interim value static causes it to perform a little bit better in short sync or drop-out situations.
    
The output of uos.urandom() performs well with the NIST800-22 requirements. In my trial it passed all tests of the sts 2.1.2 test suite.

The changed algorithm is used for seeding the PRNG of the urandom module as well.

Edit: I ran a test of the random data with the Common Criteria test suite AIS 31, and it passed all tests too.
