### PR TITLE
extmod/modonewire.c: Fix onewire timing and logic.

### DIFF
--- a/extmod/modonewire.c
+++ b/extmod/modonewire.c
@@ -59,7 +59,7 @@ STATIC int onewire_bus_reset(mp_hal_pin_obj_t pin) {
 
 STATIC int onewire_bus_readbit(mp_hal_pin_obj_t pin) {
     mp_hal_pin_od_high(pin);
-    for (int tries=TIMING_LTRIES; tries && !mp_hal_pin_read(pin); tries--) {
+    for (int tries = TIMING_LTRIES; tries && !mp_hal_pin_read(pin); tries--) {
         mp_hal_delay_us(TIMING_LDELAY);
     }
     uint32_t i = mp_hal_quiet_timing_enter();
@@ -75,7 +75,7 @@ STATIC int onewire_bus_readbit(mp_hal_pin_obj_t pin) {
 
 STATIC void onewire_bus_writebit(mp_hal_pin_obj_t pin, int value) {
     mp_hal_pin_od_high(pin);
-    for (int tries=TIMING_LTRIES; tries && !mp_hal_pin_read(pin); tries--) {
+    for (int tries = TIMING_LTRIES; tries && !mp_hal_pin_read(pin); tries--) {
         mp_hal_delay_us(TIMING_LDELAY);
     }
     uint32_t i = mp_hal_quiet_timing_enter();

--- a/extmod/modonewire.c
+++ b/extmod/modonewire.c
@@ -33,12 +33,14 @@
 /******************************************************************************/
 // Low-level 1-Wire routines
 
+#define TIMING_LTRIES (10)
+#define TIMING_LDELAY (10)
 #define TIMING_RESET1 (480)
 #define TIMING_RESET2 (70)
 #define TIMING_RESET3 (410)
-#define TIMING_READ1 (5)
-#define TIMING_READ2 (5)
-#define TIMING_READ3 (40)
+#define TIMING_READ1  (10)
+#define TIMING_READ2  (20)
+#define TIMING_READ3  (30)
 #define TIMING_WRITE1 (10)
 #define TIMING_WRITE2 (50)
 #define TIMING_WRITE3 (10)
@@ -57,6 +59,8 @@ STATIC int onewire_bus_reset(mp_hal_pin_obj_t pin) {
 
 STATIC int onewire_bus_readbit(mp_hal_pin_obj_t pin) {
     mp_hal_pin_od_high(pin);
+    for (int tries=TIMING_LTRIES; tries && !mp_hal_pin_read(pin); tries--)
+        mp_hal_delay_us(TIMING_LDELAY);
     uint32_t i = mp_hal_quiet_timing_enter();
     mp_hal_pin_od_low(pin);
     mp_hal_delay_us_fast(TIMING_READ1);
@@ -69,6 +73,9 @@ STATIC int onewire_bus_readbit(mp_hal_pin_obj_t pin) {
 }
 
 STATIC void onewire_bus_writebit(mp_hal_pin_obj_t pin, int value) {
+    mp_hal_pin_od_high(pin);
+    for (int tries=TIMING_LTRIES; tries && !mp_hal_pin_read(pin); tries--)
+        mp_hal_delay_us(TIMING_LDELAY);
     uint32_t i = mp_hal_quiet_timing_enter();
     mp_hal_pin_od_low(pin);
     mp_hal_delay_us_fast(TIMING_WRITE1);

--- a/extmod/modonewire.c
+++ b/extmod/modonewire.c
@@ -59,8 +59,9 @@ STATIC int onewire_bus_reset(mp_hal_pin_obj_t pin) {
 
 STATIC int onewire_bus_readbit(mp_hal_pin_obj_t pin) {
     mp_hal_pin_od_high(pin);
-    for (int tries=TIMING_LTRIES; tries && !mp_hal_pin_read(pin); tries--)
+    for (int tries=TIMING_LTRIES; tries && !mp_hal_pin_read(pin); tries--) {
         mp_hal_delay_us(TIMING_LDELAY);
+    }
     uint32_t i = mp_hal_quiet_timing_enter();
     mp_hal_pin_od_low(pin);
     mp_hal_delay_us_fast(TIMING_READ1);
@@ -74,8 +75,9 @@ STATIC int onewire_bus_readbit(mp_hal_pin_obj_t pin) {
 
 STATIC void onewire_bus_writebit(mp_hal_pin_obj_t pin, int value) {
     mp_hal_pin_od_high(pin);
-    for (int tries=TIMING_LTRIES; tries && !mp_hal_pin_read(pin); tries--)
+    for (int tries=TIMING_LTRIES; tries && !mp_hal_pin_read(pin); tries--) {
         mp_hal_delay_us(TIMING_LDELAY);
+    }
     uint32_t i = mp_hal_quiet_timing_enter();
     mp_hal_pin_od_low(pin);
     mp_hal_delay_us_fast(TIMING_WRITE1);


### PR DESCRIPTION
The timing of the onewire module was way too fast when reading.
The write timing was correct, with a 10us low pulse for 1 and
60us for 0.  But read would pulse low for 5us and then sample
the wire after 10us.  This is way too fast since a 1 can be
a pulse of up to 15us and would be read as 0.  Plus the whole bit
time for read was only 50us, while a client may output a pulse
of up to 60us to indicate a 0.  Compounding the problem, the code
would not check if the bus was high before starting a bit pulse,
just blindly plowing through whatever the slave might have been
sending with the next bit before the slave was done.

This code now outputs a 10us pulse for read to be consistent with
the write, then samples the bus after 30us as is the case with
most implementations I found.  The total read bit time is 60us.
The code also first checks whether the bus is high before starting
a bit, and waits in 10us increments up to 100us before starting to
output a bit pulse.