### PR TITLE
esp32: add I2C repeated start to read_mem() 

### DIFF
--- a/extmod/machine_i2c.c
+++ b/extmod/machine_i2c.c
@@ -508,13 +508,15 @@ STATIC int read_mem(mp_obj_t self_in, uint16_t addr, uint32_t memaddr, uint8_t a
     uint8_t memaddr_buf[4];
     size_t memaddr_len = fill_memaddr_buf(&memaddr_buf[0], memaddr, addrsize);
 
-    int ret = mp_machine_i2c_writeto(self, addr, memaddr_buf, memaddr_len, false);
-    if (ret != memaddr_len) {
-        // must generate STOP
-        mp_machine_i2c_writeto(self, addr, NULL, 0, true);
-        return ret;
-    }
-    return mp_machine_i2c_readfrom(self, addr, buf, len, true);
+    // Create partial write buffers
+    mp_machine_i2c_buf_t bufs[2] = {
+        {.len = memaddr_len, .buf = memaddr_buf},
+        {.len = len, .buf = (uint8_t *)buf},
+    };
+    // Do I2C transfer
+    mp_machine_i2c_p_t *i2c_p = (mp_machine_i2c_p_t *)self->type->protocol;
+    unsigned int flags = MP_MACHINE_I2C_FLAG_READ | MP_MACHINE_I2C_FLAG_STOP;
+    return i2c_p->transfer(self, addr, 2, bufs, flags);
 }
 
 STATIC int write_mem(mp_obj_t self_in, uint16_t addr, uint32_t memaddr, uint8_t addrsize, const uint8_t *buf, size_t len) {

--- a/ports/esp32/machine_i2c.c
+++ b/ports/esp32/machine_i2c.c
@@ -72,30 +72,30 @@ int machine_hw_i2c_transfer(mp_obj_base_t *self_in, uint16_t addr, size_t n, mp_
 
     int data_len = 0;
 
-    i2c_master_start(cmd); 
+    i2c_master_start(cmd);
 
-    // Following assumes function called with either 1 or 2 buffers 
-    if (n > 1) { 
+    // Following assumes function called with either 1 or 2 buffers
+    if (n > 1) {
         // if we were passed 2 buffers, 1st is memory/register, so Q slave addr (W)
-        i2c_master_write_byte(cmd, addr << 1 , true);    
-        // Q actual memory address from buffer   
-        i2c_master_write(cmd, bufs->buf, bufs->len, true);  
-        if (flags & MP_MACHINE_I2C_FLAG_READ) { 
+        i2c_master_write_byte(cmd, addr << 1 , true);
+        // Q actual memory address from buffer
+        i2c_master_write(cmd, bufs->buf, bufs->len, true);
+        if (flags & MP_MACHINE_I2C_FLAG_READ) {
             // Q repeated start to switch bus to read
-            i2c_master_start(cmd);  
+            i2c_master_start(cmd);
             // Q slave addr as (R)
-            i2c_master_write_byte(cmd, addr << 1 | MP_MACHINE_I2C_FLAG_READ, true);   
+            i2c_master_write_byte(cmd, addr << 1 | MP_MACHINE_I2C_FLAG_READ, true);
         }
         data_len += bufs->len;
-        //switch to data buffer 
-        ++bufs; 
-    } else { 
+        //switch to data buffer
+        ++bufs;
+    } else {
         // simple transaction, just Q slave address with (R/W)
         i2c_master_write_byte(cmd, addr << 1 | (flags & MP_MACHINE_I2C_FLAG_READ), true);
-    }   
+    }
 
-    if (flags & MP_MACHINE_I2C_FLAG_READ) { 
-        i2c_master_read(cmd, bufs->buf, bufs->len,I2C_MASTER_LAST_NACK); 
+    if (flags & MP_MACHINE_I2C_FLAG_READ) {
+        i2c_master_read(cmd, bufs->buf, bufs->len,I2C_MASTER_LAST_NACK);
     } else {
         if (bufs->len != 0) {
             i2c_master_write(cmd, bufs->buf, bufs->len, true);

--- a/ports/esp32/machine_i2c.c
+++ b/ports/esp32/machine_i2c.c
@@ -77,7 +77,7 @@ int machine_hw_i2c_transfer(mp_obj_base_t *self_in, uint16_t addr, size_t n, mp_
     // Following assumes function called with either 1 or 2 buffers
     if (n > 1) {
         // if we were passed 2 buffers, 1st is memory/register, so Q slave addr (W)
-        i2c_master_write_byte(cmd, addr << 1 , true);
+        i2c_master_write_byte(cmd, addr << 1, true);
         // Q actual memory address from buffer
         i2c_master_write(cmd, bufs->buf, bufs->len, true);
         if (flags & MP_MACHINE_I2C_FLAG_READ) {
@@ -87,7 +87,7 @@ int machine_hw_i2c_transfer(mp_obj_base_t *self_in, uint16_t addr, size_t n, mp_
             i2c_master_write_byte(cmd, addr << 1 | MP_MACHINE_I2C_FLAG_READ, true);
         }
         data_len += bufs->len;
-        //switch to data buffer
+        // switch to data buffer
         ++bufs;
     } else {
         // simple transaction, just Q slave address with (R/W)

--- a/ports/esp32/machine_i2c.c
+++ b/ports/esp32/machine_i2c.c
@@ -69,20 +69,40 @@ int machine_hw_i2c_transfer(mp_obj_base_t *self_in, uint16_t addr, size_t n, mp_
     machine_hw_i2c_obj_t *self = MP_OBJ_TO_PTR(self_in);
 
     i2c_cmd_handle_t cmd = i2c_cmd_link_create();
-    i2c_master_start(cmd);
-    i2c_master_write_byte(cmd, addr << 1 | (flags & MP_MACHINE_I2C_FLAG_READ), true);
 
     int data_len = 0;
-    for (; n--; ++bufs) {
-        if (flags & MP_MACHINE_I2C_FLAG_READ) {
-            i2c_master_read(cmd, bufs->buf, bufs->len, n == 0 ? I2C_MASTER_LAST_NACK : I2C_MASTER_ACK);
-        } else {
-            if (bufs->len != 0) {
-                i2c_master_write(cmd, bufs->buf, bufs->len, true);
-            }
+
+    i2c_master_start(cmd); 
+
+    // Following assumes function called with either 1 or 2 buffers 
+    if (n > 1) { 
+        // if we were passed 2 buffers, 1st is memory/register, so Q slave addr (W)
+        i2c_master_write_byte(cmd, addr << 1 , true);    
+        // Q actual memory address from buffer   
+        i2c_master_write(cmd, bufs->buf, bufs->len, true);  
+        if (flags & MP_MACHINE_I2C_FLAG_READ) { 
+            // Q repeated start to switch bus to read
+            i2c_master_start(cmd);  
+            // Q slave addr as (R)
+            i2c_master_write_byte(cmd, addr << 1 | MP_MACHINE_I2C_FLAG_READ, true);   
         }
         data_len += bufs->len;
+        //switch to data buffer 
+        ++bufs; 
+    } else { 
+        // simple transaction, just Q slave address with (R/W)
+        i2c_master_write_byte(cmd, addr << 1 | (flags & MP_MACHINE_I2C_FLAG_READ), true);
+    }   
+
+    if (flags & MP_MACHINE_I2C_FLAG_READ) { 
+        i2c_master_read(cmd, bufs->buf, bufs->len,I2C_MASTER_LAST_NACK); 
+    } else {
+        if (bufs->len != 0) {
+            i2c_master_write(cmd, bufs->buf, bufs->len, true);
+        }
     }
+
+    data_len += bufs->len;
 
     if (flags & MP_MACHINE_I2C_FLAG_STOP) {
         i2c_master_stop(cmd);


### PR DESCRIPTION
Existing esp32 I2C read_mem(), which uses separate write and read transfers to perform I2C register reads, is inefficient  as it does not use repeated start, and thus blocks longer than necessary on the ESP32 platform as it turns the bus around.  This wastes background processing time, e.g. when using asyncio.

This PR uses machine_hw_i2c_transfer() for read_mem(), which brings it in line with write_mem().

Existing machine_hw_i2c_transfer() although elegant, lacks the logic to do the bus turnaround for reads, so this has been modified to send a repeated start when performing a read operation.

This has been tested using high speed transfers up to 1Mbps with a variety of I2C devices, including single transaction  block transfers of >1500 bytes