### PR TITLE
ports/stm32/boards/NUCLEO_L476RG/mpconfigboard: Added 5 reamining UARTs.

### DIFF
--- a/ports/stm32/boards/NUCLEO_L476RG/mpconfigboard.h
+++ b/ports/stm32/boards/NUCLEO_L476RG/mpconfigboard.h
@@ -9,45 +9,64 @@
 #define MICROPY_HW_ENABLE_DAC       (1)
 
 // MSI is used and is 4MHz
-#define MICROPY_HW_CLK_PLLM (1)
-#define MICROPY_HW_CLK_PLLN (40)
-#define MICROPY_HW_CLK_PLLP (RCC_PLLP_DIV7)
-#define MICROPY_HW_CLK_PLLQ (RCC_PLLQ_DIV2)
-#define MICROPY_HW_CLK_PLLR (RCC_PLLR_DIV2)
+#define MICROPY_HW_CLK_PLLM         (1)
+#define MICROPY_HW_CLK_PLLN         (40)
+#define MICROPY_HW_CLK_PLLP         (RCC_PLLP_DIV7)
+#define MICROPY_HW_CLK_PLLQ         (RCC_PLLQ_DIV2)
+#define MICROPY_HW_CLK_PLLR         (RCC_PLLR_DIV2)
+
+#define MICROPY_HW_FLASH_LATENCY    FLASH_LATENCY_4
 
 // The board has an external 32kHz crystal
 #define MICROPY_HW_RTC_USE_LSE      (1)
 
-// UART config
-#define MICROPY_HW_UART2_TX     (pin_A2)
-#define MICROPY_HW_UART2_RX     (pin_A3)
-
+// USART1 config
+#define MICROPY_HW_UART1_TX         (pin_A9)
+#define MICROPY_HW_UART1_RX         (pin_A10)
+// USART2 config. Connected to ST-Link
+#define MICROPY_HW_UART2_TX         (pin_A2)
+#define MICROPY_HW_UART2_RX         (pin_A3)
+#define MICROPY_HW_UART2_RTS        (pin_A1)
+#define MICROPY_HW_UART2_CTS        (pin_A0)
+// USART3 config 
+#define MICROPY_HW_UART3_TX         (pin_C4)
+#define MICROPY_HW_UART3_RX         (pin_C5)
+#define MICROPY_HW_UART3_RTS        (pin_B14)
+#define MICROPY_HW_UART3_CTS        (pin_B13)
+// UART4 config 
+#define MICROPY_HW_UART4_TX         (pin_A0)
+#define MICROPY_HW_UART4_RX         (pin_A1)
+// UART5 config 
+#define MICROPY_HW_UART5_TX         (pin_C12)
+#define MICROPY_HW_UART5_RX         (pin_D2)
+// LPUART config
+#define MICROPY_HW_LPUART1_TX       (pin_C1)
+#define MICROPY_HW_LPUART1_RX       (pin_C0)
+// USART2 is connected to the virtual com port on the ST-Link
 #define MICROPY_HW_UART_REPL        PYB_UART_2
 #define MICROPY_HW_UART_REPL_BAUD   115200
 
-#define MICROPY_HW_FLASH_LATENCY    FLASH_LATENCY_4
-
 // I2C busses
-#define MICROPY_HW_I2C1_SCL (pin_B8)
-#define MICROPY_HW_I2C1_SDA (pin_B9)
-#define MICROPY_HW_I2C2_SCL (pin_B10)
-#define MICROPY_HW_I2C2_SDA (pin_B11)
-#define MICROPY_HW_I2C3_SCL (pin_C0)
-#define MICROPY_HW_I2C3_SDA (pin_C1)
+#define MICROPY_HW_I2C1_SCL         (pin_B8)
+#define MICROPY_HW_I2C1_SDA         (pin_B9)
+#define MICROPY_HW_I2C2_SCL         (pin_B10)
+#define MICROPY_HW_I2C2_SDA         (pin_B11)
+#define MICROPY_HW_I2C3_SCL         (pin_C0)
+#define MICROPY_HW_I2C3_SDA         (pin_C1)
 
 // SPI busses
-#define MICROPY_HW_SPI1_NSS     (pin_A4)
-#define MICROPY_HW_SPI1_SCK     (pin_B3)
-#define MICROPY_HW_SPI1_MISO    (pin_B4)
-#define MICROPY_HW_SPI1_MOSI    (pin_B5)
-#define MICROPY_HW_SPI2_NSS     (pin_B12)
-#define MICROPY_HW_SPI2_SCK     (pin_B13)
-#define MICROPY_HW_SPI2_MISO    (pin_B14)
-#define MICROPY_HW_SPI2_MOSI    (pin_B15)
+#define MICROPY_HW_SPI1_NSS         (pin_A4)
+#define MICROPY_HW_SPI1_SCK         (pin_B3)
+#define MICROPY_HW_SPI1_MISO        (pin_B4)
+#define MICROPY_HW_SPI1_MOSI        (pin_B5)
+#define MICROPY_HW_SPI2_NSS         (pin_B12)
+#define MICROPY_HW_SPI2_SCK         (pin_B13)
+#define MICROPY_HW_SPI2_MISO        (pin_B14)
+#define MICROPY_HW_SPI2_MOSI        (pin_B15)
 
 // CAN bus
-#define MICROPY_HW_CAN1_TX (pin_A12)
-#define MICROPY_HW_CAN1_RX (pin_A11)
+#define MICROPY_HW_CAN1_TX          (pin_A12)
+#define MICROPY_HW_CAN1_RX          (pin_A11)
 
 // USRSW is pulled low. Pressing the button makes the input go high.
 #define MICROPY_HW_USRSW_PIN        (pin_C13)
@@ -61,4 +80,4 @@
 #define MICROPY_HW_LED_OFF(pin)     (mp_hal_pin_low(pin))
 
 // USB config
-#define MICROPY_HW_USB_FS (1)
+#define MICROPY_HW_USB_FS           (1)


### PR DESCRIPTION
**STM32L476RG** mcu of **NUCLEO_L476RG** board has 6 UART/USART units in total (USART1, USART2, USART3, UART4, UART5 and LPUART1), but only UART2, which is connected to REPL, is defined and available for Python code. As a result there is currently no possibility to use serial communication with external devices (like MH-Z19 sensor) together with REPL.

This pull request resolves this issue with missing UART units in [NUCLEO_L476RG board official MicroPython firmware](https://micropython.org/resources/firmware/NUCLEO_L476RG-20210202-v1.14.dfu), which also affected others multiple times, for example:
- [Can not initialize STM32L476 UART](https://forum.micropython.org/viewtopic.php?f=12&t=7235)
- [UART(4) doesnВґt exist (STM32L476 Nucleo) ](https://forum.micropython.org/viewtopic.php?t=6484)
- [NUCLEO-L476RG firmware has only UART2 defined](https://forum.micropython.org/viewtopic.php?t=9919)

Tested on real NUCLEO_L476RG board:

```
MicroPython v1.14-120-g42cf77f48-dirty on 2021-03-20; NUCLEO-L476RG with STM32L476RG
Type "help()" for more information.
>>> print(pyb.UART(3, 9600).write(b'\xff\x01\x86\x00\x00\x00\x00\x00\x79'))
9
>>> print(pyb.UART(1, 9600).write(b'\xff\x01\x86\x00\x00\x00\x00\x00\x79'))
9
>>> print(pyb.UART(4, 9600).write(b'\xff\x01\x86\x00\x00\x00\x00\x00\x79'))
9
>>> print(pyb.UART(5, 9600).write(b'\xff\x01\x86\x00\x00\x00\x00\x00\x79'))
9
>>> print(pyb.UART('LP1',0).write(b'\xff\x01\x86\x00\x00\x00\x00\x00\x79'))
9
>>> print(pyb.UART(6, 0).write(b'\xff\x01\x86\x00\x00\x00\x00\x00\x79'))
9
>>> 
```
Tested in real scenario using [MH-Z19C](https://www.winsen-sensor.com/sensors/co2-sensor/mh-z19c.html) CO2 sensor with UART interface:
```
MPY: sync filesystems
MPY: soft reboot
78.723  co2         = 500.00
79.735  co2         = 500.00
80.747  co2         = 500.00
81.759  co2         = 500.00
82.77101  co2         = 500.00
83.784  co2         = 500.00
84.796  co2         = 500.00
85.808  co2         = 500.00
86.82  co2         = 500.00
87.832  co2         = 500.00
88.844  co2         = 500.00
```
References:
- [STM32L476xx Datasheet](https://www.st.com/resource/en/datasheet/stm32l476rg.pdf)
- [UM1724 STM32 Nucleo-64 boards (MB1136) User manual](https://www.google.com/url?sa=t&rct=j&q=&esrc=s&source=web&cd=&cad=rja&uact=8&ved=2ahUKEwjt79u2nL_vAhWdDWMBHboRCdoQFjAAegQIAxAD&url=https%3A%2F%2Fwww.st.com%2Fresource%2Fen%2Fuser_manual%2Fdm00105823-stm32-nucleo-64-boards-mb1136-stmicroelectronics.pdf&usg=AOvVaw1tpwdEvyHAdV47LlhTlao1)

Signed-off-by: Alexander Ziubin <aziubin@googlemail.com>
