### PR TITLE
py: Rename remaining object types to be of the form mp_type_xxx.

### DIFF
--- a/py/modio.c
+++ b/py/modio.c
@@ -195,7 +195,7 @@ STATIC const mp_stream_p_t bufwriter_stream_p = {
     .write = bufwriter_write,
 };
 
-STATIC const mp_obj_type_t bufwriter_type = {
+STATIC const mp_obj_type_t mp_type_bufwriter = {
     { &mp_type_type },
     .name = MP_QSTR_BufferedWriter,
     .make_new = bufwriter_make_new,
@@ -270,7 +270,7 @@ STATIC const mp_rom_map_elem_t mp_module_io_globals_table[] = {
     { MP_ROM_QSTR(MP_QSTR_BytesIO), MP_ROM_PTR(&mp_type_bytesio) },
     #endif
     #if MICROPY_PY_IO_BUFFEREDWRITER
-    { MP_ROM_QSTR(MP_QSTR_BufferedWriter), MP_ROM_PTR(&bufwriter_type) },
+    { MP_ROM_QSTR(MP_QSTR_BufferedWriter), MP_ROM_PTR(&mp_type_bufwriter) },
     #endif
 };
 

--- a/py/objarray.c
+++ b/py/objarray.c
@@ -634,7 +634,7 @@ STATIC mp_obj_t array_it_iternext(mp_obj_t self_in) {
     }
 }
 
-STATIC const mp_obj_type_t array_it_type = {
+STATIC const mp_obj_type_t mp_type_array_it = {
     { &mp_type_type },
     .name = MP_QSTR_iterator,
     .getiter = mp_identity_getiter,
@@ -645,7 +645,7 @@ STATIC mp_obj_t array_iterator_new(mp_obj_t array_in, mp_obj_iter_buf_t *iter_bu
     assert(sizeof(mp_obj_array_t) <= sizeof(mp_obj_iter_buf_t));
     mp_obj_array_t *array = MP_OBJ_TO_PTR(array_in);
     mp_obj_array_it_t *o = (mp_obj_array_it_t *)iter_buf;
-    o->base.type = &array_it_type;
+    o->base.type = &mp_type_array_it;
     o->array = array;
     o->offset = 0;
     o->cur = 0;

--- a/py/objclosure.c
+++ b/py/objclosure.c
@@ -78,7 +78,7 @@ STATIC void closure_print(const mp_print_t *print, mp_obj_t o_in, mp_print_kind_
 }
 #endif
 
-const mp_obj_type_t closure_type = {
+const mp_obj_type_t mp_type_closure = {
     { &mp_type_type },
     .flags = MP_TYPE_FLAG_BINDS_SELF,
     .name = MP_QSTR_closure,
@@ -90,7 +90,7 @@ const mp_obj_type_t closure_type = {
 
 mp_obj_t mp_obj_new_closure(mp_obj_t fun, size_t n_closed_over, const mp_obj_t *closed) {
     mp_obj_closure_t *o = m_new_obj_var(mp_obj_closure_t, mp_obj_t, n_closed_over);
-    o->base.type = &closure_type;
+    o->base.type = &mp_type_closure;
     o->fun = fun;
     o->n_closed = n_closed_over;
     memcpy(o->closed, closed, n_closed_over * sizeof(mp_obj_t));

--- a/py/objdict.c
+++ b/py/objdict.c
@@ -408,8 +408,8 @@ STATIC MP_DEFINE_CONST_FUN_OBJ_KW(dict_update_obj, 1, dict_update);
 /******************************************************************************/
 /* dict views                                                                 */
 
-STATIC const mp_obj_type_t dict_view_type;
-STATIC const mp_obj_type_t dict_view_it_type;
+STATIC const mp_obj_type_t mp_type_dict_view;
+STATIC const mp_obj_type_t mp_type_dict_view_it;
 
 typedef enum _mp_dict_view_kind_t {
     MP_DICT_VIEW_ITEMS,
@@ -433,7 +433,7 @@ typedef struct _mp_obj_dict_view_t {
 } mp_obj_dict_view_t;
 
 STATIC mp_obj_t dict_view_it_iternext(mp_obj_t self_in) {
-    mp_check_self(mp_obj_is_type(self_in, &dict_view_it_type));
+    mp_check_self(mp_obj_is_type(self_in, &mp_type_dict_view_it));
     mp_obj_dict_view_it_t *self = MP_OBJ_TO_PTR(self_in);
     mp_map_elem_t *next = dict_iter_next(MP_OBJ_TO_PTR(self->dict), &self->cur);
 
@@ -454,7 +454,7 @@ STATIC mp_obj_t dict_view_it_iternext(mp_obj_t self_in) {
     }
 }
 
-STATIC const mp_obj_type_t dict_view_it_type = {
+STATIC const mp_obj_type_t mp_type_dict_view_it = {
     { &mp_type_type },
     .name = MP_QSTR_iterator,
     .getiter = mp_identity_getiter,
@@ -463,10 +463,10 @@ STATIC const mp_obj_type_t dict_view_it_type = {
 
 STATIC mp_obj_t dict_view_getiter(mp_obj_t view_in, mp_obj_iter_buf_t *iter_buf) {
     assert(sizeof(mp_obj_dict_view_it_t) <= sizeof(mp_obj_iter_buf_t));
-    mp_check_self(mp_obj_is_type(view_in, &dict_view_type));
+    mp_check_self(mp_obj_is_type(view_in, &mp_type_dict_view));
     mp_obj_dict_view_t *view = MP_OBJ_TO_PTR(view_in);
     mp_obj_dict_view_it_t *o = (mp_obj_dict_view_it_t *)iter_buf;
-    o->base.type = &dict_view_it_type;
+    o->base.type = &mp_type_dict_view_it;
     o->kind = view->kind;
     o->dict = view->dict;
     o->cur = 0;
@@ -475,7 +475,7 @@ STATIC mp_obj_t dict_view_getiter(mp_obj_t view_in, mp_obj_iter_buf_t *iter_buf)
 
 STATIC void dict_view_print(const mp_print_t *print, mp_obj_t self_in, mp_print_kind_t kind) {
     (void)kind;
-    mp_check_self(mp_obj_is_type(self_in, &dict_view_type));
+    mp_check_self(mp_obj_is_type(self_in, &mp_type_dict_view));
     mp_obj_dict_view_t *self = MP_OBJ_TO_PTR(self_in);
     bool first = true;
     mp_print_str(print, mp_dict_view_names[self->kind]);
@@ -505,7 +505,7 @@ STATIC mp_obj_t dict_view_binary_op(mp_binary_op_t op, mp_obj_t lhs_in, mp_obj_t
     return dict_binary_op(op, o->dict, rhs_in);
 }
 
-STATIC const mp_obj_type_t dict_view_type = {
+STATIC const mp_obj_type_t mp_type_dict_view = {
     { &mp_type_type },
     .name = MP_QSTR_dict_view,
     .print = dict_view_print,
@@ -515,7 +515,7 @@ STATIC const mp_obj_type_t dict_view_type = {
 
 STATIC mp_obj_t mp_obj_new_dict_view(mp_obj_t dict, mp_dict_view_kind_t kind) {
     mp_obj_dict_view_t *o = m_new_obj(mp_obj_dict_view_t);
-    o->base.type = &dict_view_type;
+    o->base.type = &mp_type_dict_view;
     o->dict = dict;
     o->kind = kind;
     return MP_OBJ_FROM_PTR(o);
@@ -548,7 +548,7 @@ STATIC mp_obj_t dict_getiter(mp_obj_t self_in, mp_obj_iter_buf_t *iter_buf) {
     assert(sizeof(mp_obj_dict_view_it_t) <= sizeof(mp_obj_iter_buf_t));
     mp_check_self(mp_obj_is_dict_or_ordereddict(self_in));
     mp_obj_dict_view_it_t *o = (mp_obj_dict_view_it_t *)iter_buf;
-    o->base.type = &dict_view_it_type;
+    o->base.type = &mp_type_dict_view_it;
     o->kind = MP_DICT_VIEW_KEYS;
     o->dict = self_in;
     o->cur = 0;

--- a/py/objgetitemiter.c
+++ b/py/objgetitemiter.c
@@ -57,7 +57,7 @@ STATIC mp_obj_t it_iternext(mp_obj_t self_in) {
     }
 }
 
-STATIC const mp_obj_type_t it_type = {
+STATIC const mp_obj_type_t mp_type_it = {
     { &mp_type_type },
     .name = MP_QSTR_iterator,
     .getiter = mp_identity_getiter,
@@ -68,7 +68,7 @@ STATIC const mp_obj_type_t it_type = {
 mp_obj_t mp_obj_new_getitem_iter(mp_obj_t *args, mp_obj_iter_buf_t *iter_buf) {
     assert(sizeof(mp_obj_getitem_iter_t) <= sizeof(mp_obj_iter_buf_t));
     mp_obj_getitem_iter_t *o = (mp_obj_getitem_iter_t *)iter_buf;
-    o->base.type = &it_type;
+    o->base.type = &mp_type_it;
     o->args[0] = args[0];
     o->args[1] = args[1];
     o->args[2] = MP_OBJ_NEW_SMALL_INT(0);

--- a/py/objrange.c
+++ b/py/objrange.c
@@ -50,7 +50,7 @@ STATIC mp_obj_t range_it_iternext(mp_obj_t o_in) {
     }
 }
 
-STATIC const mp_obj_type_t range_it_type = {
+STATIC const mp_obj_type_t mp_type_range_it = {
     { &mp_type_type },
     .name = MP_QSTR_iterator,
     .getiter = mp_identity_getiter,
@@ -60,7 +60,7 @@ STATIC const mp_obj_type_t range_it_type = {
 STATIC mp_obj_t mp_obj_new_range_iterator(mp_int_t cur, mp_int_t stop, mp_int_t step, mp_obj_iter_buf_t *iter_buf) {
     assert(sizeof(mp_obj_range_it_t) <= sizeof(mp_obj_iter_buf_t));
     mp_obj_range_it_t *o = (mp_obj_range_it_t *)iter_buf;
-    o->base.type = &range_it_type;
+    o->base.type = &mp_type_range_it;
     o->cur = cur;
     o->stop = stop;
     o->step = step;


### PR DESCRIPTION
For consistency with all other object types in the core.
