### PR TITLE
machine_adc.c: added raw_to_voltage(), use calibration

### DIFF
--- a/ports/esp32/main/CMakeLists.txt
+++ b/ports/esp32/main/CMakeLists.txt
@@ -81,6 +81,7 @@ set(IDF_COMPONENTS
     bt
     driver
     esp32
+    esp_adc_cal
     esp_common
     esp_eth
     esp_event


### PR DESCRIPTION
This change uses the ESP32 built-in calibration for the ADC.

Michael 