### PR TITLE
neopixel.py: Added __len__ to support iterating

### DIFF
--- a/ports/esp32/modules/neopixel.py
+++ b/ports/esp32/modules/neopixel.py
@@ -15,6 +15,9 @@ class NeoPixel:
         self.pin.init(pin.OUT)
         self.timing = timing
 
+    def __len__(self):
+        return self.n
+
     def __setitem__(self, index, val):
         offset = index * self.bpp
         for i in range(self.bpp):

--- a/ports/esp8266/modules/neopixel.py
+++ b/ports/esp8266/modules/neopixel.py
@@ -15,6 +15,9 @@ class NeoPixel:
         self.pin.init(pin.OUT)
         self.timing = timing
 
+    def __len__(self):
+        return self.n
+
     def __setitem__(self, index, val):
         offset = index * self.bpp
         for i in range(self.bpp):


### PR DESCRIPTION
Allow neopixels to be used in iterators.

an example:

import neopixel

np = neopixel.NeoPixel(machine.Pin(21), 8)
np[4] = (40, 20, 0)

for led in np:
    print(led)

gives the following output
(0, 0, 0)
(0, 0, 0)
(0, 0, 0)
(0, 0, 0)
(40, 20, 0)
(0, 0, 0)
(0, 0, 0)
(0, 0, 0)

Michael 