### PR TITLE
ntptime.py: added simple timezone support.

### DIFF
--- a/ports/esp8266/modules/ntptime.py
+++ b/ports/esp8266/modules/ntptime.py
@@ -9,6 +9,7 @@ except:
 
 # (date(2000, 1, 1) - date(1900, 1, 1)).days * 24*60*60
 NTP_DELTA = 3155673600
+_local_ntp_delta = 0
 
 # The NTP host can be configured at runtime by doing: ntptime.host = 'myhost.org'
 host = "pool.ntp.org"
@@ -26,14 +27,26 @@ def time():
     finally:
         s.close()
     val = struct.unpack("!I", msg[40:44])[0]
-    return val - NTP_DELTA
+    return val - NTP_DELTA + _local_ntp_delta
 
 
 # There's currently no timezone support in MicroPython, and the RTC is set in UTC time.
-def settime():
+def settime(tz=None):
+    if tz is not None:
+        timezone(tz)
+
     t = time()
     import machine
     import utime
 
     tm = utime.gmtime(t)
     machine.RTC().datetime((tm[0], tm[1], tm[2], tm[6] + 1, tm[3], tm[4], tm[5], 0))
+
+
+def timezone(offset=None):
+    global _local_ntp_delta
+
+    if offset is not None:
+        _local_ntp_delta = offset
+    else:
+        return _local_ntp_delta


### PR DESCRIPTION
This only adds the ability to have an offset from UTC
so that the RTC can give back localtime correctly.
daylight savings time must be handled by setting the
timezone 3600 second ahead or back.

Signed-off-by: mishafarms <github@mishafarms.us>