### PR TITLE
ports/unix/main.c: fix var clobbered by longjmp

### DIFF
--- a/ports/unix/main.c
+++ b/ports/unix/main.c
@@ -592,7 +592,7 @@ MP_NOINLINE int main_(int argc, char **argv) {
 
                 mp_obj_t mod;
                 nlr_buf_t nlr;
-                // Allocating subpkg_tried on stack triggers the following error on ppc64le:
+                // Allocating subpkg_tried on stack triggers the following error on e.g. aarch64:
                 // error: variable 'subpkg_tried' might be clobbered by 'longjmp' or 'vfork' [-Werror=clobbered]
                 static bool subpkg_tried;
                 subpkg_tried = false;

--- a/ports/unix/main.c
+++ b/ports/unix/main.c
@@ -592,7 +592,7 @@ MP_NOINLINE int main_(int argc, char **argv) {
 
                 mp_obj_t mod;
                 nlr_buf_t nlr;
-                bool subpkg_tried = false;
+                static bool subpkg_tried = false;
 
             reimport:
                 if (nlr_push(&nlr) == 0) {

--- a/ports/unix/main.c
+++ b/ports/unix/main.c
@@ -592,7 +592,10 @@ MP_NOINLINE int main_(int argc, char **argv) {
 
                 mp_obj_t mod;
                 nlr_buf_t nlr;
-                static bool subpkg_tried = false;
+                // Allocating subpkg_tried on stack triggers the following error on ppc64le:
+                // error: variable 'subpkg_tried' might be clobbered by 'longjmp' or 'vfork' [-Werror=clobbered]
+                static bool subpkg_tried;
+                subpkg_tried = false;
 
             reimport:
                 if (nlr_push(&nlr) == 0) {


### PR DESCRIPTION
This fixes

```
main.c: In function 'main_':
main.c:595:22: error: variable 'subpkg_tried' might be clobbered by 'longjmp' or 'vfork' [-Werror=clobbered]
  595 |                 bool subpkg_tried = false;
      |                      ^~~~~~~~~~~~
```

when compiling on `ppc64le`.