### PR TITLE
esp32: cmake user C module support

### DIFF
--- a/ports/esp32/Makefile
+++ b/ports/esp32/Makefile
@@ -18,7 +18,13 @@ GIT_SUBMODULES = lib/berkeley-db-1.xx
 
 .PHONY: all clean deploy erase submodules FORCE
 
-IDFPY_FLAGS += -D MICROPY_BOARD=$(BOARD) -B $(BUILD)
+CMAKE_ARGS =
+
+ifdef USER_C_MODULES
+	CMAKE_ARGS += -DUSER_C_MODULES=${USER_C_MODULES}
+endif
+
+IDFPY_FLAGS += -D MICROPY_BOARD=$(BOARD) -B $(BUILD) $(CMAKE_ARGS)
 
 all:
 	idf.py $(IDFPY_FLAGS) build

--- a/ports/esp32/main/CMakeLists.txt
+++ b/ports/esp32/main/CMakeLists.txt
@@ -25,7 +25,6 @@ set(MICROPY_SOURCE_LIB
     ${MICROPY_DIR}/lib/oofatfs/ffunicode.c
     ${MICROPY_DIR}/lib/timeutils/timeutils.c
     ${MICROPY_DIR}/lib/utils/interrupt_char.c
-    ${MICROPY_DIR}/lib/utils/stdout_helpers.c
     ${MICROPY_DIR}/lib/utils/sys_stdio_mphal.c
     ${MICROPY_DIR}/lib/utils/pyexec.c
 )

--- a/ports/esp32/main/CMakeLists.txt
+++ b/ports/esp32/main/CMakeLists.txt
@@ -5,6 +5,10 @@ get_filename_component(MICROPY_DIR ${PROJECT_DIR}/../.. ABSOLUTE)
 include(${MICROPY_DIR}/py/py.cmake)
 include(${MICROPY_DIR}/extmod/extmod.cmake)
 
+if(NOT CMAKE_BUILD_EARLY_EXPANSION)
+    include(${MICROPY_DIR}/py/usermod.cmake)
+endif()
+
 set(MICROPY_QSTRDEFS_PORT
     ${PROJECT_DIR}/qstrdefsport.h
 )
@@ -71,6 +75,7 @@ set(MICROPY_SOURCE_PORT
 set(MICROPY_SOURCE_QSTR
     ${MICROPY_SOURCE_PY}
     ${MICROPY_SOURCE_EXTMOD}
+    ${MICROPY_SOURCE_USERMOD}
     ${MICROPY_SOURCE_LIB}
     ${MICROPY_SOURCE_PORT}
 )
@@ -129,6 +134,7 @@ idf_component_register(
         ${MICROPY_SOURCE_PORT}
     INCLUDE_DIRS
         ${MICROPY_DIR}
+        ${MICROPY_INC_USERMOD}
         ${MICROPY_PORT_DIR}
         ${MICROPY_BOARD_DIR}
         ${CMAKE_BINARY_DIR}
@@ -158,6 +164,10 @@ target_compile_options(${MICROPY_TARGET} PUBLIC
     -Wno-deprecated-declarations
     -Wno-missing-field-initializers
 )
+
+# add usermod
+target_link_libraries(${MICROPY_TARGET} usermod)
+
 
 # Collect all of the include directories and compile definitions for the IDF components.
 foreach(comp ${IDF_COMPONENTS})

--- a/tools/ci.sh
+++ b/tools/ci.sh
@@ -100,6 +100,8 @@ function ci_esp32_build {
     make ${MAKEOPTS} -C mpy-cross
     make ${MAKEOPTS} -C ports/esp32 submodules
     make ${MAKEOPTS} -C ports/esp32
+    make ${MAKEOPTS} -C ports/esp32 clean
+    make ${MAKEOPTS} -C ports/esp32 USER_C_MODULES=../../../examples/usercmodule/micropython.cmake
 }
 
 ########################################################################################


### PR DESCRIPTION
This is #6956 with a minor change to the CI build to not use absolute paths.