### PR TITLE
rp2/rp2_pio: Add fifo_join support for PIO.

### DIFF
--- a/examples/rp2/pio_uart_rx.py
+++ b/examples/rp2/pio_uart_rx.py
@@ -22,6 +22,7 @@ PIO_RX_PIN = Pin(3, Pin.IN, Pin.PULL_UP)
     autopush=True,
     push_thresh=8,
     in_shiftdir=rp2.PIO.SHIFT_RIGHT,
+    fifo_join=PIO.JOIN_RX,
 )
 def uart_rx_mini():
     # fmt: off

--- a/ports/rp2/modules/rp2.py
+++ b/ports/rp2/modules/rp2.py
@@ -31,14 +31,16 @@ class PIOASMEmit:
         autopush=False,
         autopull=False,
         push_thresh=32,
-        pull_thresh=32
+        pull_thresh=32,
+        fifo_join=0
     ):
         from array import array
 
         self.labels = {}
         execctrl = 0
         shiftctrl = (
-            (pull_thresh & 0x1F) << 25
+            fifo_join << 30
+            | (pull_thresh & 0x1F) << 25
             | (push_thresh & 0x1F) << 20
             | out_shiftdir << 19
             | in_shiftdir << 18

--- a/ports/rp2/rp2_pio.c
+++ b/ports/rp2/rp2_pio.c
@@ -363,6 +363,10 @@ STATIC const mp_rom_map_elem_t rp2_pio_locals_dict_table[] = {
     { MP_ROM_QSTR(MP_QSTR_IRQ_SM1), MP_ROM_INT(0x200) },
     { MP_ROM_QSTR(MP_QSTR_IRQ_SM2), MP_ROM_INT(0x400) },
     { MP_ROM_QSTR(MP_QSTR_IRQ_SM3), MP_ROM_INT(0x800) },
+
+    { MP_ROM_QSTR(MP_QSTR_JOIN_NONE), MP_ROM_INT(0) },
+    { MP_ROM_QSTR(MP_QSTR_JOIN_TX), MP_ROM_INT(1) },
+    { MP_ROM_QSTR(MP_QSTR_JOIN_RX), MP_ROM_INT(2) },
 };
 STATIC MP_DEFINE_CONST_DICT(rp2_pio_locals_dict, rp2_pio_locals_dict_table);
 


### PR DESCRIPTION
This PR adds support for joining the 4-word RX and TX FIFOs on the RP2040's PIOs into a single 8-word FIFO.

I've added `JOIN_{RX,TX,NONE}` constants to the PIO object, and set the appropriate bits in `shiftctrl`, as @dpgeorge suggested.

Resolves #6854.

---

I tested this with the following program:

```python
from machine import Pin
from rp2 import PIO, StateMachine, asm_pio

@asm_pio(
    fifo_join=PIO.JOIN_TX,
)
def prog():
    nop()

sm = StateMachine(0, prog)

for i in range(8):
    sm.put(i)
    print(i)
```
The program pushes words into an inactive StateMachine until it blocks because the machine's TX FIFO is full.

Without `fifo_join`, it prints 0-3 and then blocks. With `fifo_join`, it prints 0-7 and then exits.

With `fifo_join=PIO.JOIN_RX`, it blocks without printing anything, since the TX buffer has zero size and always reports being full.