### PR TITLE
rp2: Move array import to toplevel.

### DIFF
--- a/ports/rp2/modules/rp2.py
+++ b/ports/rp2/modules/rp2.py
@@ -33,7 +33,9 @@ class PIOASMEmit:
         push_thresh=32,
         pull_thresh=32
     ):
-        from array import array
+        # uarray is a built-in module so importing it here won't require
+        # scanning the filesystem.
+        from uarray import array
 
         self.labels = {}
         execctrl = 0


### PR DESCRIPTION
Some forum users noticed that `sm.exec()` took longer the more was present on the flash filesystem connected to the RP2040. User [hippy](https://www.raspberrypi.org/forums/viewtopic.php?p=1845202#p1845202) traced this back to the `array` import inside `asm_pio()`, which is causing MicroPython to scan the filesystem. 

Moving this to the toplevel should mean it's only imported once, when MicroPython starts.

Unfortunately this exposes the `array` module as `rp2.array`. I can't see a way to avoid this; `__all__` doesn't appear to work here. I could rename it `_array` but it looks like we already export `const` as `rp2.const` so I chose not to.