### PR TITLE
unix: Improve command line argument processing.

### DIFF
--- a/ports/unix/main.c
+++ b/ports/unix/main.c
@@ -341,6 +341,9 @@ STATIC int invalid_args(void) {
 STATIC void pre_process_options(int argc, char **argv) {
     for (int a = 1; a < argc; a++) {
         if (argv[a][0] == '-') {
+            if (strcmp(argv[a], "-c") == 0 || strcmp(argv[a], "-m") == 0) {
+                break;  // Everything after this is a command/module and arguments for it
+            }
             if (strcmp(argv[a], "-h") == 0) {
                 print_help(argv);
                 exit(0);
@@ -400,6 +403,8 @@ STATIC void pre_process_options(int argc, char **argv) {
                 }
                 a++;
             }
+        } else {
+            break;  // Not an option but a file
         }
     }
 }
@@ -568,11 +573,10 @@ MP_NOINLINE int main_(int argc, char **argv) {
                 if (a + 1 >= argc) {
                     return invalid_args();
                 }
+                set_sys_argv(argv, a + 1, a); // The -c becomes first item of sys.argv, as in CPython
+                set_sys_argv(argv, argc, a + 2); // Then what comes after the command
                 ret = do_str(argv[a + 1]);
-                if (ret & FORCED_EXIT) {
-                    break;
-                }
-                a += 1;
+                break;
             } else if (strcmp(argv[a], "-m") == 0) {
                 if (a + 1 >= argc) {
                     return invalid_args();

--- a/tests/cmdline/repl_inspect.py
+++ b/tests/cmdline/repl_inspect.py
@@ -1,2 +1,2 @@
-# cmdline: -c print("test") -i
+# cmdline: -i -c print("test")
 # -c option combined with -i option results in REPL

--- a/tests/cmdline/repl_inspect.py.exp
+++ b/tests/cmdline/repl_inspect.py.exp
@@ -1,6 +1,6 @@
 test
 MicroPython \.\+ version
 Use \.\+
->>> # cmdline: -c print("test") -i
+>>> # cmdline: -i -c print("test")
 >>> # -c option combined with -i option results in REPL
 >>> 


### PR DESCRIPTION
Per CPython everything which comes after the command, module or file
argument is not an option for the interpreter itself.  Hence the
processing of options should stop when encountering those, and the
remainder be passed as sys.argv.  Note he latter was already the
case for a module or file but not for a command.

This fixes issues like 'micropython myfile.py -h' showing the help
and exiting instead of passing '-h' as sys.argv[1], likewise for
'-X <something>' being treated as a special option no matter where it
occurs on the command line.