### PR TITLE
stm32/mpconfigport.h: Add support for a board to specify root pointers.

### DIFF
--- a/ports/stm32/mpconfigport.h
+++ b/ports/stm32/mpconfigport.h
@@ -353,6 +353,10 @@ struct _mp_bluetooth_btstack_root_pointers_t;
 #define MICROPY_PORT_ROOT_POINTER_BLUETOOTH_BTSTACK
 #endif
 
+#ifndef MICROPY_BOARD_ROOT_POINTERS
+#define MICROPY_BOARD_ROOT_POINTERS
+#endif
+
 #define MICROPY_PORT_ROOT_POINTERS \
     const char *readline_hist[8]; \
     \
@@ -384,9 +388,13 @@ struct _mp_bluetooth_btstack_root_pointers_t;
     /* list of registered NICs */ \
     mp_obj_list_t mod_network_nic_list; \
     \
+    /* root pointers for sub-systems */ \
     MICROPY_PORT_ROOT_POINTER_MBEDTLS \
     MICROPY_PORT_ROOT_POINTER_BLUETOOTH_NIMBLE \
-        MICROPY_PORT_ROOT_POINTER_BLUETOOTH_BTSTACK \
+    MICROPY_PORT_ROOT_POINTER_BLUETOOTH_BTSTACK \
+    \
+    /* root pointers defined by a board */ \
+        MICROPY_BOARD_ROOT_POINTERS \
 
 // type definitions for the specific machine
 


### PR DESCRIPTION
A board can now define MICROPY_BOARD_ROOT_POINTERS to specify any custom
root pointers.
