### PR TITLE
py/runtime: make sys.modules preallocate to a configurable size

### DIFF
--- a/py/mpconfig.h
+++ b/py/mpconfig.h
@@ -229,6 +229,11 @@
 #define MICROPY_MODULE_DICT_SIZE (1)
 #endif
 
+// Initial size of sys.modules dict
+#ifndef MICROPY_LOADED_MODULES_DICT_SIZE
+#define MICROPY_LOADED_MODULES_DICT_SIZE (3)
+#endif
+
 // Whether realloc/free should be passed allocated memory region size
 // You must enable this if MICROPY_MEM_STATS is enabled
 #ifndef MICROPY_MALLOC_USES_ALLOCATED_SIZE

--- a/py/runtime.c
+++ b/py/runtime.c
@@ -91,7 +91,7 @@ void mp_init(void) {
     #endif
 
     // init global module dict
-    mp_obj_dict_init(&MP_STATE_VM(mp_loaded_modules_dict), 3);
+    mp_obj_dict_init(&MP_STATE_VM(mp_loaded_modules_dict), MICROPY_LOADED_MODULES_DICT_SIZE);
 
     // initialise the __main__ module
     mp_obj_dict_init(&MP_STATE_VM(dict_main), 1);


### PR DESCRIPTION
This allows configuring the pre-allocated size of `sys.modules` dict, in order to prevent unwanted reallocations at run-time.

(3 sysmodules is really not quite enough for a larger project)