### PR TITLE
esp32/machine_pin: Use rtc_gpio_deinit instead of gpio_reset_pin.

### DIFF
--- a/ports/esp32/machine_pin.c
+++ b/ports/esp32/machine_pin.c
@@ -30,6 +30,7 @@
 #include <string.h>
 
 #include "driver/gpio.h"
+#include "driver/rtc_io.h"
 
 #include "py/runtime.h"
 #include "py/mphal.h"
@@ -157,9 +158,11 @@ STATIC mp_obj_t machine_pin_obj_init_helper(const machine_pin_obj_t *self, size_
     mp_arg_val_t args[MP_ARRAY_SIZE(allowed_args)];
     mp_arg_parse_all(n_args, pos_args, kw_args, MP_ARRAY_SIZE(allowed_args), allowed_args, args);
 
-    // reset the pin first if this is a mode-setting init (grab it back from ADC)
+    // reset the pin to digital if this is a mode-setting init (grab it back from ADC)
     if (args[ARG_mode].u_obj != mp_const_none) {
-        gpio_reset_pin(self->id);
+        if (rtc_gpio_is_valid_gpio(self->id)) {
+            rtc_gpio_deinit(self->id);
+        }
     }
 
     // configure the pin for gpio


### PR DESCRIPTION
Commit 8a917ad2529ea3df5f47e2be5b4edf362d2d03f6 added the gpio_reset_pin()
call to make sure that pins that were used as ADC inputs could subsequently
be used as digital IO.  But calling gpio_reset_pin() will enable the
pull-up on the pin and so pull it high for a brief period.  Instead use
rtc_gpio_deinit() which will just reconfigure the pin as a digital IO and
do nothing else.

Fixes issue #7079 (see also #5771).
