### PR TITLE
drivers/display/ssd1306.py: Add rotate method.

### DIFF
--- a/drivers/display/ssd1306.py
+++ b/drivers/display/ssd1306.py
@@ -37,12 +37,12 @@ class SSD1306(framebuf.FrameBuffer):
 
     def init_display(self):
         for cmd in (
-            SET_DISP | 0x00,  # off
+            SET_DISP,  # display off
             # address setting
             SET_MEM_ADDR,
             0x00,  # horizontal
             # resolution and layout
-            SET_DISP_START_LINE | 0x00,
+            SET_DISP_START_LINE,  # start at line 0
             SET_SEG_REMAP | 0x01,  # column addr 127 mapped to SEG0
             SET_MUX_RATIO,
             self.height - 1,
@@ -66,14 +66,14 @@ class SSD1306(framebuf.FrameBuffer):
             # charge pump
             SET_CHARGE_PUMP,
             0x10 if self.external_vcc else 0x14,
-            SET_DISP | 0x01,
+            SET_DISP | 0x01,  # display on
         ):  # on
             self.write_cmd(cmd)
         self.fill(0)
         self.show()
 
     def poweroff(self):
-        self.write_cmd(SET_DISP | 0x00)
+        self.write_cmd(SET_DISP)
 
     def poweron(self):
         self.write_cmd(SET_DISP | 0x01)
@@ -84,6 +84,10 @@ class SSD1306(framebuf.FrameBuffer):
 
     def invert(self, invert):
         self.write_cmd(SET_NORM_INV | (invert & 1))
+
+    def rotate(self, rotate):
+        self.write_cmd(SET_COM_OUT_DIR | ((rotate & 1) << 3))
+        self.write_cmd(SET_SEG_REMAP | (rotate & 1))
 
     def show(self):
         x0 = 0


### PR DESCRIPTION
Adds `rotate(bool)` to official SSD1306 driver.

The existing `init_display()` method initialises the screen in the normal orientation.
This PR adds the ability to rotate the display 180 degrees, by remapping the segments and flipping the common output direction. Uses commands `SET_COM_OUT_DIR` and `SET_SEG_REMAP`.

Note: changing the common output direction updates the display immediately (mirrored vertically). After remapping the segments, you need to call `show()` again to repopulate the display memory with the pixel data in the reverse order (mirrored horizontally).

Testing on TinyPICO - ESP32
```
# MicroPython v1.14 on 2021-02-02; TinyPICO with ESP32-PICO-D4
from machine import Pin, I2C
import ssd1306
i2c = I2C(1, sda=Pin(21), scl=Pin(22))
display = ssd1306.SSD1306_I2C(128, 64, i2c)

# micropython logo
display.fill(0)
display.fill_rect(0, 0, 32, 32, 1)
display.fill_rect(2, 2, 28, 28, 0)
display.vline(9, 8, 22, 1)
display.vline(16, 2, 22, 1)
display.vline(23, 8, 22, 1)
display.fill_rect(26, 24, 2, 4, 1)

# some text
display.text('MicroPython', 40, 0, 1)
display.text('SSD1306', 40, 12, 1)
display.text('OLED 128x64', 40, 24, 1)
display.show()

# rotate 180 deg
display.rotate(True)
display.show()

# rotate 0 deg
display.rotate(False)
display.show()
```

![ssd1306-rotate](https://user-images.githubusercontent.com/1038959/115355583-246fbd80-a1fe-11eb-9a95-503e63fe42e6.jpg)
