### PR TITLE
py/objexcept: Support errno attribute on OSError exceptions.

### DIFF
--- a/docs/library/builtins.rst
+++ b/docs/library/builtins.rst
@@ -176,10 +176,6 @@ Exceptions
 
 .. exception:: OSError
 
-    |see_cpython| `python:OSError`. MicroPython doesn't implement ``errno``
-    attribute, instead use the standard way to access exception arguments:
-    ``exc.args[0]``.
-
 .. exception:: RuntimeError
 
 .. exception:: StopIteration

--- a/docs/library/uerrno.rst
+++ b/docs/library/uerrno.rst
@@ -16,13 +16,13 @@ Constants
 
     Error codes, based on ANSI C/POSIX standard. All error codes start with
     "E". As mentioned above, inventory of the codes depends on
-    :term:`MicroPython port`. Errors are usually accessible as ``exc.args[0]``
+    :term:`MicroPython port`. Errors are usually accessible as ``exc.errno``
     where ``exc`` is an instance of `OSError`. Usage example::
 
         try:
             uos.mkdir("my_dir")
         except OSError as exc:
-            if exc.args[0] == uerrno.EEXIST:
+            if exc.errno == uerrno.EEXIST:
                 print("Directory already exists")
 
 .. data:: errorcode

--- a/extmod/uasyncio/stream.py
+++ b/extmod/uasyncio/stream.py
@@ -82,7 +82,7 @@ async def open_connection(host, port):
     try:
         s.connect(ai[-1])
     except OSError as er:
-        if er.args[0] != EINPROGRESS:
+        if er.errno != EINPROGRESS:
             raise er
     yield core._io_queue.queue_write(s)
     return ss, ss

--- a/py/objexcept.c
+++ b/py/objexcept.c
@@ -261,7 +261,9 @@ void mp_obj_exception_attr(mp_obj_t self_in, qstr attr, mp_obj_t *dest) {
     if (attr == MP_QSTR_args) {
         decompress_error_text_maybe(self);
         dest[0] = MP_OBJ_FROM_PTR(self->args);
-    } else if (self->base.type == &mp_type_StopIteration && attr == MP_QSTR_value) {
+    } else if (attr == MP_QSTR_value || attr == MP_QSTR_errno) {
+        // These are aliases for args[0]: .value for StopIteration and .errno for OSError.
+        // For efficiency let these attributes apply to all exception instances.
         dest[0] = mp_obj_exception_get_value(self_in);
     }
 }

--- a/tests/basics/exception1.py
+++ b/tests/basics/exception1.py
@@ -1,3 +1,5 @@
+# test basic properties of exceptions
+
 print(repr(IndexError()))
 print(str(IndexError()))
 
@@ -12,3 +14,6 @@ s = StopIteration()
 print(s.value)
 s = StopIteration(1, 2, 3)
 print(s.value)
+
+print(OSError().errno)
+print(OSError(1, "msg").errno)

--- a/tests/basics/subclass_native3.py
+++ b/tests/basics/subclass_native3.py
@@ -1,5 +1,9 @@
+# test subclassing a native exception
+
+
 class MyExc(Exception):
     pass
+
 
 e = MyExc(100, "Some error")
 print(e)
@@ -20,3 +24,19 @@ try:
     raise MyExc("Some error2")
 except:
     print("Caught user exception")
+
+
+class MyStopIteration(StopIteration):
+    pass
+
+
+print(MyStopIteration().value)
+print(MyStopIteration(1).value)
+
+
+class MyOSError(OSError):
+    pass
+
+
+print(MyOSError().errno)
+print(MyOSError(1, "msg").errno)

--- a/tests/cpydiff/types_exception_attrs.py
+++ b/tests/cpydiff/types_exception_attrs.py
@@ -1,0 +1,9 @@
+"""
+categories: Types,Exception
+description: All exceptions have readable ``value`` and ``errno`` attributes, not just ``StopIteration`` and ``OSError``.
+cause: MicroPython is optimised to reduce code size.
+workaround: Only use ``value`` on ``StopIteration`` exceptions, and ``errno`` on ``OSError`` exceptions.  Do not use or rely on these attributes on other exceptions.
+"""
+e = Exception(1)
+print(e.value)
+print(e.errno)

--- a/tests/extmod/btree1.py
+++ b/tests/extmod/btree1.py
@@ -65,7 +65,7 @@ print(db.seq(1, b"qux"))
 try:
     db.seq(b"foo1")
 except OSError as e:
-    print(e.args[0] == uerrno.EINVAL)
+    print(e.errno == uerrno.EINVAL)
 
 print(list(db.keys()))
 print(list(db.values()))

--- a/tests/extmod/btree_error.py
+++ b/tests/extmod/btree_error.py
@@ -27,7 +27,7 @@ class Device(uio.IOBase):
 try:
     db = btree.open(Device(), pagesize=511)
 except OSError as er:
-    print("OSError", er.args[0] == uerrno.EINVAL)
+    print("OSError", er.errno == uerrno.EINVAL)
 
 # Valid pagesize, device returns error on read; errno comes from Device.readinto
 try:

--- a/tests/extmod/uselect_poll_basic.py
+++ b/tests/extmod/uselect_poll_basic.py
@@ -33,7 +33,7 @@ poller.unregister(s)
 try:
     poller.modify(s, select.POLLIN)
 except OSError as e:
-    assert e.args[0] == errno.ENOENT
+    assert e.errno == errno.ENOENT
 
 # poll after closing the socket, should return POLLNVAL
 poller.register(s)

--- a/tests/extmod/usocket_tcp_basic.py
+++ b/tests/extmod/usocket_tcp_basic.py
@@ -14,4 +14,4 @@ s = socket.socket()
 try:
     s.recv(1)
 except OSError as er:
-    print("ENOTCONN:", er.args[0] == errno.ENOTCONN)
+    print("ENOTCONN:", er.errno == errno.ENOTCONN)

--- a/tests/extmod/usocket_udp_nonblock.py
+++ b/tests/extmod/usocket_udp_nonblock.py
@@ -17,4 +17,4 @@ s.settimeout(0)
 try:
     s.recv(1)
 except OSError as er:
-    print("EAGAIN:", er.args[0] == errno.EAGAIN)
+    print("EAGAIN:", er.errno == errno.EAGAIN)

--- a/tests/extmod/vfs_fat_fileio1.py
+++ b/tests/extmod/vfs_fat_fileio1.py
@@ -58,22 +58,22 @@ f.close()  # allowed
 try:
     f.write("world!")
 except OSError as e:
-    print(e.args[0] == uerrno.EINVAL)
+    print(e.errno == uerrno.EINVAL)
 
 try:
     f.read()
 except OSError as e:
-    print(e.args[0] == uerrno.EINVAL)
+    print(e.errno == uerrno.EINVAL)
 
 try:
     f.flush()
 except OSError as e:
-    print(e.args[0] == uerrno.EINVAL)
+    print(e.errno == uerrno.EINVAL)
 
 try:
     open("foo_file.txt", "x")
 except OSError as e:
-    print(e.args[0] == uerrno.EEXIST)
+    print(e.errno == uerrno.EEXIST)
 
 with open("foo_file.txt", "a") as f:
     f.write("world!")
@@ -105,7 +105,7 @@ vfs.mkdir("foo_dir")
 try:
     vfs.rmdir("foo_file.txt")
 except OSError as e:
-    print(e.args[0] == 20)  # uerrno.ENOTDIR
+    print(e.errno == 20)  # uerrno.ENOTDIR
 
 vfs.remove("foo_file.txt")
 print(list(vfs.ilistdir()))

--- a/tests/extmod/vfs_fat_fileio2.py
+++ b/tests/extmod/vfs_fat_fileio2.py
@@ -51,22 +51,22 @@ uos.chdir("/ramdisk")
 try:
     vfs.mkdir("foo_dir")
 except OSError as e:
-    print(e.args[0] == uerrno.EEXIST)
+    print(e.errno == uerrno.EEXIST)
 
 try:
     vfs.remove("foo_dir")
 except OSError as e:
-    print(e.args[0] == uerrno.EISDIR)
+    print(e.errno == uerrno.EISDIR)
 
 try:
     vfs.remove("no_file.txt")
 except OSError as e:
-    print(e.args[0] == uerrno.ENOENT)
+    print(e.errno == uerrno.ENOENT)
 
 try:
     vfs.rename("foo_dir", "/null/file")
 except OSError as e:
-    print(e.args[0] == uerrno.ENOENT)
+    print(e.errno == uerrno.ENOENT)
 
 # file in dir
 with open("foo_dir/file-in-dir.txt", "w+t") as f:
@@ -82,7 +82,7 @@ with open("foo_dir/sub_file.txt", "w") as f:
 try:
     vfs.rmdir("foo_dir")
 except OSError as e:
-    print(e.args[0] == uerrno.EACCES)
+    print(e.errno == uerrno.EACCES)
 
 # trim full path
 vfs.rename("foo_dir/file-in-dir.txt", "foo_dir/file.txt")
@@ -111,5 +111,5 @@ try:
     f = open("large_file.txt", "wb")
     f.write(bytearray(bsize * free))
 except OSError as e:
-    print("ENOSPC:", e.args[0] == 28)  # uerrno.ENOSPC
+    print("ENOSPC:", e.errno == 28)  # uerrno.ENOSPC
 f.close()

--- a/tests/extmod/vfs_fat_more.py
+++ b/tests/extmod/vfs_fat_more.py
@@ -90,7 +90,7 @@ for exist in ("", "/", "dir", "/dir", "dir/subdir"):
     try:
         uos.mkdir(exist)
     except OSError as er:
-        print("mkdir OSError", er.args[0] == 17)  # EEXIST
+        print("mkdir OSError", er.errno == 17)  # EEXIST
 
 uos.chdir("/")
 print(uos.stat("test5.txt")[:-3])

--- a/tests/extmod/vfs_fat_ramdisk.py
+++ b/tests/extmod/vfs_fat_ramdisk.py
@@ -57,7 +57,7 @@ print("getcwd:", vfs.getcwd())
 try:
     vfs.stat("no_file.txt")
 except OSError as e:
-    print(e.args[0] == uerrno.ENOENT)
+    print(e.errno == uerrno.ENOENT)
 
 with vfs.open("foo_file.txt", "w") as f:
     f.write("hello!")
@@ -80,7 +80,7 @@ with vfs.open("sub_file.txt", "w") as f:
 try:
     vfs.chdir("sub_file.txt")
 except OSError as e:
-    print(e.args[0] == uerrno.ENOENT)
+    print(e.errno == uerrno.ENOENT)
 
 vfs.chdir("..")
 print("getcwd:", vfs.getcwd())
@@ -94,4 +94,4 @@ print(list(vfs.ilistdir(b"")))
 try:
     vfs.ilistdir(b"no_exist")
 except OSError as e:
-    print("ENOENT:", e.args[0] == uerrno.ENOENT)
+    print("ENOENT:", e.errno == uerrno.ENOENT)

--- a/tests/extmod/websocket_basic.py
+++ b/tests/extmod/websocket_basic.py
@@ -59,4 +59,4 @@ print(ws.ioctl(9))
 try:
     ws.ioctl(-1)
 except OSError as e:
-    print("ioctl: EINVAL:", e.args[0] == uerrno.EINVAL)
+    print("ioctl: EINVAL:", e.errno == uerrno.EINVAL)

--- a/tests/multi_net/tcp_accept_recv.py
+++ b/tests/multi_net/tcp_accept_recv.py
@@ -17,7 +17,7 @@ def instance0():
     try:
         print("recv", s.recv(10))  # should raise Errno 107 ENOTCONN
     except OSError as er:
-        print(er.args[0])
+        print(er.errno)
     s.close()
 
 

--- a/tests/multi_net/tcp_client_rst.py
+++ b/tests/multi_net/tcp_client_rst.py
@@ -33,7 +33,7 @@ def instance0():
         print(s2.recv(10))
         print(convert_poll_list(poll.poll(1000)))
     except OSError as er:
-        print(er.args[0])
+        print(er.errno)
     print(convert_poll_list(poll.poll(1000)))
     # TODO lwip raises here but apparently it shouldn't
     print(s2.recv(10))

--- a/tests/multi_net/uasyncio_tcp_client_rst.py
+++ b/tests/multi_net/uasyncio_tcp_client_rst.py
@@ -24,7 +24,7 @@ async def handle_connection(reader, writer):
         writer.close()
         await writer.wait_closed()
     except OSError as er:
-        print("OSError", er.args[0])
+        print("OSError", er.errno)
     ev.set()
 
 

--- a/tests/net_hosted/accept_nonblock.py
+++ b/tests/net_hosted/accept_nonblock.py
@@ -12,5 +12,5 @@ s.listen(1)
 try:
     s.accept()
 except OSError as er:
-    print(er.args[0] == 11)  # 11 is EAGAIN
+    print(er.errno == 11)  # 11 is EAGAIN
 s.close()

--- a/tests/net_hosted/accept_timeout.py
+++ b/tests/net_hosted/accept_timeout.py
@@ -18,5 +18,5 @@ s.listen(1)
 try:
     s.accept()
 except OSError as er:
-    print(er.args[0] in (errno.ETIMEDOUT, "timed out"))  # CPython uses a string instead of errno
+    print(er.errno in (errno.ETIMEDOUT, "timed out"))  # CPython uses a string instead of errno
 s.close()

--- a/tests/net_hosted/connect_nonblock.py
+++ b/tests/net_hosted/connect_nonblock.py
@@ -13,7 +13,7 @@ def test(peer_addr):
     try:
         s.connect(peer_addr)
     except OSError as er:
-        print(er.args[0] == errno.EINPROGRESS)
+        print(er.errno == errno.EINPROGRESS)
     s.close()
 
 

--- a/tests/net_hosted/connect_nonblock_xfer.py
+++ b/tests/net_hosted/connect_nonblock_xfer.py
@@ -25,9 +25,9 @@ def do_connect(peer_addr, tls, handshake):
         # print("Connecting to", peer_addr)
         s.connect(peer_addr)
     except OSError as er:
-        print("connect:", er.args[0] == errno.EINPROGRESS)
-        if er.args[0] != errno.EINPROGRESS:
-            print("  got", er.args[0])
+        print("connect:", er.errno == errno.EINPROGRESS)
+        if er.errno != errno.EINPROGRESS:
+            print("  got", er.errno)
     # wrap with ssl/tls if desired
     if tls:
         try:
@@ -67,7 +67,7 @@ def test(peer_addr, tls=False, handshake=False):
         except OSError as er:
             #
             dp(er)
-            print("send:", er.args[0] in (errno.EAGAIN, errno.EINPROGRESS))
+            print("send:", er.errno in (errno.EAGAIN, errno.EINPROGRESS))
         s.close()
     else:  # fake it...
         print("connect:", True)
@@ -103,7 +103,7 @@ def test(peer_addr, tls=False, handshake=False):
             print("recv:", s.recv(10))
         except OSError as er:
             dp(er)
-            print("recv:", er.args[0] == errno.EAGAIN)
+            print("recv:", er.errno == errno.EAGAIN)
         s.close()
     else:  # fake it...
         print("connect:", True)

--- a/tests/net_inet/ssl_errors.py
+++ b/tests/net_inet/ssl_errors.py
@@ -17,7 +17,7 @@ def test(addr, hostname, block=True):
         s.connect(addr)
         print("connected")
     except OSError as e:
-        if e.args[0] != errno.EINPROGRESS:
+        if e.errno != errno.EINPROGRESS:
             raise
         print("EINPROGRESS")
 

--- a/tests/net_inet/test_tls_nonblock.py
+++ b/tests/net_inet/test_tls_nonblock.py
@@ -16,7 +16,7 @@ def test_one(site, opts):
         s.connect(addr)
         raise OSError(-1, "connect blocks")
     except OSError as e:
-        if e.args[0] != errno.EINPROGRESS:
+        if e.errno != errno.EINPROGRESS:
             raise
 
     if sys.implementation.name != "micropython":
@@ -31,7 +31,7 @@ def test_one(site, opts):
             else:
                 s = ssl.wrap_socket(s, do_handshake_on_connect=False)
         except OSError as e:
-            if e.args[0] != errno.EINPROGRESS:
+            if e.errno != errno.EINPROGRESS:
                 raise
         print("wrapped")
 
@@ -69,7 +69,7 @@ def test_one(site, opts):
             try:
                 b = s.read(128)
             except OSError as err:
-                if err.args[0] == 2:  # 2=ssl.SSL_ERROR_WANT_READ:
+                if err.errno == 2:  # 2=ssl.SSL_ERROR_WANT_READ:
                     continue
                 raise
             if b is None:

--- a/tools/upip.py
+++ b/tools/upip.py
@@ -60,7 +60,7 @@ def _makedirs(name, mode=0o777):
             os.mkdir(s)
             ret = True
         except OSError as e:
-            if e.args[0] != errno.EEXIST and e.args[0] != errno.EISDIR:
+            if e.errno != errno.EEXIST and e.errno != errno.EISDIR:
                 raise e
             ret = False
     return ret


### PR DESCRIPTION
This PR adds the errno attribute to exceptions, so code can retrieve errno codes from an OSError using `exc.errno`.

This is an alternative implementation of #2407, which generated a lot of controversy at the time (4.5 years ago).

The reason to post this PR is to hopefully finish the discussion about adding/not adding this feature, and finally close #2407.

The implementation here is a simpler version of #2407 which simply lets `errno` (and the existing `value`) attributes to work on any exception instance (they both alias `args[0]`).  This is for efficiency and to keep code size down.  As I see it, the pros and cons of adding `errno` are:

Pros:
- more compatible with CPython, less difference to document and learn
- `OSError().errno` will correctly return `None`, whereas the current way of doing it via `OSError().args[0]` will raise an `IndexError`
- actually reduces code size on most bare-metal ports (because they already have the `errno` qstr)
- for Python code that uses `exc.errno` the generated bytecode is 2 bytes smaller and more efficient to execute (compared with `exc.args[0]`); so bytecode loaded to RAM saves 2 bytes RAM for each use of this attribute, and bytecode that is frozen saves 2 bytes flash/ROM for each use
- it's easier/shorter to type, and saves 2 bytes of space in .py files that use it (for each use)

Cons:
- increases code size by 4-8 bytes on minimal ports that don't enable the `uerrno` module (due to the additional qstr)
- all exceptions now have `.errno` and `.value` attributes (this is specific to the implementation here)

Feedback/comments welcome!

-----

Code size change of this PR:
```
   bare-arm:    +4 +0.006% 
minimal x86:    +8 +0.005% 
   unix x64:    +0 +0.000% 
unix nanbox:   +20 +0.004% 
      stm32:   -12 -0.003% PYBV10
     cc3200:   -16 -0.009% 
    esp8266:    -4 -0.001% GENERIC
      esp32:    -8 -0.001% GENERIC
        nrf:    +0 +0.000% pca10040
       samd:    +0 +0.000% ADAFRUIT_ITSYBITSY_M4_EXPRESS
        rp2:   -24 -0.005% PICO
```