### PR TITLE
stm32/boards/pllvalues.py: Support wider range of PLL values for F413.

### DIFF
--- a/ports/stm32/boards/pllvalues.py
+++ b/ports/stm32/boards/pllvalues.py
@@ -31,15 +31,26 @@ mcu_default = MCU(
     range_vco_out=range(192, 432 + 1),
 )
 
-mcu_h7 = MCU(
-    range_sysclk=range(2, 400 + 1, 2),  # above 400MHz currently unsupported
-    range_m=range(1, 63 + 1),
-    range_n=range(4, 512 + 1),
-    range_p=range(2, 128 + 1, 2),
-    range_q=range(1, 128 + 1),
-    range_vco_in=range(1, 16 + 1),
-    range_vco_out=range(150, 960 + 1),  # 150-420=medium, 192-960=wide
-)
+mcu_table = {
+    "stm32f413": MCU(
+        range_sysclk=range(2, 100 + 1, 2),
+        range_m=range(2, 63 + 1),
+        range_n=range(50, 432 + 1),
+        range_p=range(2, 8 + 1, 2),
+        range_q=range(2, 15 + 1),
+        range_vco_in=range(1, 2 + 1),
+        range_vco_out=range(100, 432 + 1),
+    ),
+    "stm32h7": MCU(
+        range_sysclk=range(2, 400 + 1, 2),  # above 400MHz currently unsupported
+        range_m=range(1, 63 + 1),
+        range_n=range(4, 512 + 1),
+        range_p=range(2, 128 + 1, 2),
+        range_q=range(1, 128 + 1),
+        range_vco_in=range(1, 16 + 1),
+        range_vco_out=range(150, 960 + 1),  # 150-420=medium, 192-960=wide
+    ),
+}
 
 
 def close_int(x):
@@ -271,10 +282,11 @@ def main():
         hse = int(argv[0])
 
     # Select MCU parameters
-    if mcu_series.startswith("stm32h7"):
-        mcu = mcu_h7
-    else:
-        mcu = mcu_default
+    mcu = mcu_default
+    for m in mcu_table:
+        if mcu_series.startswith(m):
+            mcu = mcu_table[m]
+            break
 
     # Relax constraint on PLLQ being 48MHz on MCUs which have separate PLLs for 48MHz
     relax_pll48 = mcu_series.startswith(("stm32f413", "stm32f7", "stm32h7"))


### PR DESCRIPTION
Also allows adding PLL ranges specific other MCUs in the future.