### PR TITLE
esp32/CMakeLists.txt: Require CMake version 3.12.

### DIFF
--- a/ports/esp32/CMakeLists.txt
+++ b/ports/esp32/CMakeLists.txt
@@ -1,6 +1,6 @@
 # Top-level cmake file for building MicroPython on ESP32.
 
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.12)
 
 # Set the location of this port's directory.
 set(MICROPY_PORT_DIR ${CMAKE_SOURCE_DIR})


### PR DESCRIPTION
Because "find_package(Python3 ...)" requires at least this version of CMake.  And other features like GREATER_EQUAL and COMMAND_EXPAND_LISTS need at least CMake 3.7 and 3.8 respectively.

