### PR TITLE
stm32/mboot: Allow unpacking dfu without secret key.

### DIFF
--- a/ports/stm32/mboot/mboot_pack_dfu.py
+++ b/ports/stm32/mboot/mboot_pack_dfu.py
@@ -86,9 +86,14 @@ class Keys:
 
     def load(self):
         with open(self.filename) as f:
-            self.sign_sk = self._load_data("mboot_pack_sign_secret_key", f.readline())
-            self.sign_pk = self._load_data("mboot_pack_sign_public_key", f.readline())
-            self.secretbox = self._load_data("mboot_pack_secretbox_key", f.readline())
+            for line in f:
+                for key, attr in (
+                    ("mboot_pack_sign_secret_key", "sign_sk"),
+                    ("mboot_pack_sign_public_key", "sign_pk"),
+                    ("mboot_pack_secretbox_key", "secretbox"),
+                ):
+                    if key in line:
+                        setattr(self, attr, self._load_data(key, line))
 
 
 def dfu_read(filename):
@@ -135,6 +140,8 @@ def encrypt(keys, data):
 
 
 def sign(keys, data):
+    if not hasattr(keys, "sign_sk"):
+        raise Exception("packing a dfu requires a secret key")
     return pyhy.hydro_sign_create(data, MBOOT_PACK_HYDRO_CONTEXT, keys.sign_sk)
 
 

--- a/tools/ci.sh
+++ b/tools/ci.sh
@@ -243,6 +243,10 @@ function ci_stm32_nucleo_build {
     BUILD_WB55=ports/stm32/build-NUCLEO_WB55
     python3 ports/stm32/mboot/mboot_pack_dfu.py -k $BOARD_WB55/mboot_keys.h unpack-dfu $BUILD_WB55/firmware.pack.dfu $BUILD_WB55/firmware.unpack.dfu
     diff $BUILD_WB55/firmware.unpack.dfu $BUILD_WB55/firmware.dfu
+    # Test unpack-dfu command works without a secret key
+    tail -n +2 $BOARD_WB55/mboot_keys.h > $BOARD_WB55/mboot_keys_no_sk.h
+    python3 ports/stm32/mboot/mboot_pack_dfu.py -k $BOARD_WB55/mboot_keys_no_sk.h unpack-dfu $BUILD_WB55/firmware.pack.dfu $BUILD_WB55/firmware.unpack_no_sk.dfu
+    diff $BUILD_WB55/firmware.unpack.dfu $BUILD_WB55/firmware.unpack_no_sk.dfu
 }
 
 ########################################################################################


### PR DESCRIPTION
- unpack-dfu command no longer requies a secret key to be present
- pack-dfu command raises a RuntimeError if no secret key is found