### PR TITLE
ports/pic16bit: offer passing the XC compiler version

### DIFF
--- a/ports/pic16bit/Makefile
+++ b/ports/pic16bit/Makefile
@@ -6,7 +6,8 @@ QSTR_DEFS = qstrdefsport.h
 # include py core make definitions
 include $(TOP)/py/py.mk
 
-XC16 = /opt/microchip/xc16/v1.35
+XCVERSION ?= 1.35
+XC16 ?= /opt/microchip/xc16/v$(XCVERSION)
 CROSS_COMPILE ?= $(XC16)/bin/xc16-
 
 PARTFAMILY = dsPIC33F


### PR DESCRIPTION
There are new releases of the toolchain available, so this offers just passing the version.

Update: it works fine with version 1.50 \o/ - so the default version could be raised to that; someone should probably verify that it not only builds, but also runs though. I'm trying to see if I can port to PIC24E, which we're using for the https://pslab.io board. :)

With 1.61, I can't build (yet) though:

```
ports/pic16bit $ make XCVERSION=1.61
Use make V=1 or set BUILD_VERBOSE in your environment to increase build verbosity.
GEN build/genhdr/qstr.i.last
GEN build/genhdr/qstr.split
GEN build/genhdr/qstrdefs.collected.h
QSTR updated
GEN build/genhdr/qstrdefs.generated.h
mkdir -p build/extmod/
mkdir -p build/lib/embed/
mkdir -p build/lib/mp-readline/
mkdir -p build/lib/utils/
mkdir -p build/py/
CC ../../py/mpstate.c
CC ../../py/nlr.c
...
CC ../../py/objstr.c
CC ../../py/objstrunicode.c
CC ../../py/objstringio.c
CC ../../py/objtuple.c
CC ../../py/objtype.c
../../py/objtype.c: In function 'mp_obj_class_lookup':
../../py/objtype.c:136:13: internal compiler error: Segmentation fault
Please submit a full bug report,
with preprocessed source if appropriate.
See <https://www.microchip.com/technical-support> for instructions.
make: *** [../../py/mkrules.mk:77: build/py/objtype.o] Error 255
```

I'll see if I can figure something out; probably will need to get back to Microchip since the compiler shouldn't segfault. :-)