### PR TITLE
fix(docs): corrects typos in project README files

### DIFF
--- a/ports/stm32/mboot/README.md
+++ b/ports/stm32/mboot/README.md
@@ -159,7 +159,7 @@ Signed and encrypted DFU support
 --------------------------------
 
 Mboot optionally supports signing and encrypting the binary firmware in the DFU file.
-In general this is refered to as a packed DFU file.  This requires additional settings
+In general this is referred to as a packed DFU file.  This requires additional settings
 in the board config and requires the `pyhy` Python module to be installed for `python3`
 to be used when building packed firmware, eg:
 

--- a/ports/teensy/README.md
+++ b/ports/teensy/README.md
@@ -5,7 +5,7 @@ Currently the Teensy 3.1 port of MicroPython builds under Linux and not under Wi
 The tool chain required for the build can be found at <https://launchpad.net/gcc-arm-embedded>.
 
 Download the current Linux *.tar.bz2 file. Instructions regarding unpacking the file and moving it to the correct location
-as well as adding the extracted folders to the enviroment variable can be found at
+as well as adding the extracted folders to the environment variable can be found at
 <http://eliaselectronics.com/stm32f4-tutorials/setting-up-the-stm32f4-arm-development-toolchain/>
 
 In order to download the firmware image to the teensy, you'll need to use the


### PR DESCRIPTION
Scope of changes is restricted to docs only. Changes are in agreement with Standard American English. 