### PR TITLE
esp32: Restore FROZEN_MANIFEST support with new CMake build system.

### DIFF
--- a/ports/esp32/Makefile
+++ b/ports/esp32/Makefile
@@ -26,6 +26,10 @@ endif
 
 IDFPY_FLAGS += -D MICROPY_BOARD=$(BOARD) -B $(BUILD) $(CMAKE_ARGS)
 
+ifdef FROZEN_MANIFEST
+       IDFPY_FLAGS += -D MICROPY_FROZEN_MANIFEST=$(FROZEN_MANIFEST)
+endif
+
 all:
 	idf.py $(IDFPY_FLAGS) build
 	@$(PYTHON) makeimg.py \

--- a/ports/esp32/boards/GENERIC/mpconfigboard.cmake
+++ b/ports/esp32/boards/GENERIC/mpconfigboard.cmake
@@ -2,5 +2,6 @@ set(SDKCONFIG_DEFAULTS
     boards/sdkconfig.base
     boards/sdkconfig.ble
 )
-
-set(MICROPY_FROZEN_MANIFEST ${MICROPY_PORT_DIR}/boards/manifest.py)
+if(NOT MICROPY_FROZEN_MANIFEST)
+    set(MICROPY_FROZEN_MANIFEST ${MICROPY_PORT_DIR}/boards/manifest.py)
+endif()

--- a/ports/esp32/boards/GENERIC_D2WD/mpconfigboard.cmake
+++ b/ports/esp32/boards/GENERIC_D2WD/mpconfigboard.cmake
@@ -4,4 +4,6 @@ set(SDKCONFIG_DEFAULTS
     boards/GENERIC_D2WD/sdkconfig.board
 )
 
-set(MICROPY_FROZEN_MANIFEST ${MICROPY_PORT_DIR}/boards/manifest.py)
+if(NOT MICROPY_FROZEN_MANIFEST)
+    set(MICROPY_FROZEN_MANIFEST ${MICROPY_PORT_DIR}/boards/manifest.py)
+endif()

--- a/ports/esp32/boards/GENERIC_OTA/mpconfigboard.cmake
+++ b/ports/esp32/boards/GENERIC_OTA/mpconfigboard.cmake
@@ -4,4 +4,6 @@ set(SDKCONFIG_DEFAULTS
     boards/GENERIC_OTA/sdkconfig.board
 )
 
-set(MICROPY_FROZEN_MANIFEST ${MICROPY_PORT_DIR}/boards/manifest.py)
+if(NOT MICROPY_FROZEN_MANIFEST)
+    set(MICROPY_FROZEN_MANIFEST ${MICROPY_PORT_DIR}/boards/manifest.py)
+endif()

--- a/ports/esp32/boards/GENERIC_S2/mpconfigboard.cmake
+++ b/ports/esp32/boards/GENERIC_S2/mpconfigboard.cmake
@@ -5,4 +5,6 @@ set(SDKCONFIG_DEFAULTS
     boards/sdkconfig.usb
 )
 
-set(MICROPY_FROZEN_MANIFEST ${MICROPY_PORT_DIR}/boards/manifest.py)
+if(NOT MICROPY_FROZEN_MANIFEST)
+    set(MICROPY_FROZEN_MANIFEST ${MICROPY_PORT_DIR}/boards/manifest.py)
+endif()

--- a/ports/esp32/boards/GENERIC_SPIRAM/mpconfigboard.cmake
+++ b/ports/esp32/boards/GENERIC_SPIRAM/mpconfigboard.cmake
@@ -4,4 +4,6 @@ set(SDKCONFIG_DEFAULTS
     boards/sdkconfig.spiram
 )
 
-set(MICROPY_FROZEN_MANIFEST ${MICROPY_PORT_DIR}/boards/manifest.py)
+if(NOT MICROPY_FROZEN_MANIFEST)
+    set(MICROPY_FROZEN_MANIFEST ${MICROPY_PORT_DIR}/boards/manifest.py)
+endif()

--- a/ports/esp32/boards/TINYPICO/mpconfigboard.cmake
+++ b/ports/esp32/boards/TINYPICO/mpconfigboard.cmake
@@ -6,4 +6,6 @@ set(SDKCONFIG_DEFAULTS
     boards/TINYPICO/sdkconfig.board
 )
 
-set(MICROPY_FROZEN_MANIFEST ${MICROPY_BOARD_DIR}/manifest.py)
+if(NOT MICROPY_FROZEN_MANIFEST)
+    set(MICROPY_FROZEN_MANIFEST ${MICROPY_BOARD_DIR}/manifest.py)
+endif()


### PR DESCRIPTION
FROZEN_MANIFEST is set in the ../boards/*/mpconfigboard.cmake files.

This PR re-enables the command-line make option "FROZEN_MANIFEST".

The ../boards/*/mpconfigboard.cmake will now use the command-line FROZEN_MANIFEST if supplied.

`Usage: make FROZEN_MANIFEST=~/foo/my-manifest.py`

