### PR TITLE
tools/makemanifest: show directory name if there is a FreezeError

### DIFF
--- a/tools/makemanifest.py
+++ b/tools/makemanifest.py
@@ -199,7 +199,7 @@ def mkdir(filename):
 def freeze_internal(kind, path, script, opt):
     path = convert_path(path)
     if not os.path.isdir(path):
-        raise FreezeError("freeze path must be a directory")
+        raise FreezeError("freeze path must be a directory: %s" % path)
     if script is None and kind == KIND_AS_STR:
         if any(f[0] == KIND_AS_STR for f in manifest_list):
             raise FreezeError("can only freeze one str directory")

--- a/tools/makemanifest.py
+++ b/tools/makemanifest.py
@@ -199,7 +199,7 @@ def mkdir(filename):
 def freeze_internal(kind, path, script, opt):
     path = convert_path(path)
     if not os.path.isdir(path):
-        raise FreezeError("freeze path must be a directory: %s" % path)
+        raise FreezeError("freeze path must be a directory: {}".format(path))
     if script is None and kind == KIND_AS_STR:
         if any(f[0] == KIND_AS_STR for f in manifest_list):
             raise FreezeError("can only freeze one str directory")


### PR DESCRIPTION
If a freeze directory is not found, makemanifest raises an error;

`freeze error executing "/foo/my-manifest.py": freeze path must be a directory
`

To assist debugging, this PR adds the directory name to the error.

`freeze error executing "/foo/my-manifest.py": freeze path must be a directory: /bar/my-modules`