### PR TITLE
stm32/uart.c: Fix H7 UART Clock Source.

### DIFF
--- a/ports/stm32/uart.c
+++ b/ports/stm32/uart.c
@@ -118,16 +118,10 @@ STATIC const pyb_uart_irq_map_t mp_uart_irq_map[] = {
 void uart_init0(void) {
     #if defined(STM32H7)
     RCC_PeriphCLKInitTypeDef RCC_PeriphClkInit = {0};
-    // Configure USART1/6 clock source
-    RCC_PeriphClkInit.PeriphClockSelection = RCC_PERIPHCLK_USART16;
+    // Configure USART1/6 and USART2/3/4/5/7/8 clock sources
+    RCC_PeriphClkInit.PeriphClockSelection = RCC_PERIPHCLK_USART16 | RCC_PERIPHCLK_USART234578;
     RCC_PeriphClkInit.Usart16ClockSelection = RCC_USART16CLKSOURCE_D2PCLK2;
-    if (HAL_RCCEx_PeriphCLKConfig(&RCC_PeriphClkInit) != HAL_OK) {
-        __fatal_error("HAL_RCCEx_PeriphCLKConfig");
-    }
-
-    // Configure USART2/3/4/5/7/8 clock source
-    RCC_PeriphClkInit.PeriphClockSelection = RCC_PERIPHCLK_USART234578;
-    RCC_PeriphClkInit.Usart16ClockSelection = RCC_USART234578CLKSOURCE_D2PCLK1;
+    RCC_PeriphClkInit.Usart234578ClockSelection = RCC_USART234578CLKSOURCE_D2PCLK1;
     if (HAL_RCCEx_PeriphCLKConfig(&RCC_PeriphClkInit) != HAL_OK) {
         __fatal_error("HAL_RCCEx_PeriphCLKConfig");
     }


### PR DESCRIPTION
`Usart16ClockSelection` was overwritten and `Usart234578ClockSelection` was Not set.