### PR TITLE
stm32: Support static soft timer instances (v2)

### DIFF
--- a/ports/stm32/machine_timer.c
+++ b/ports/stm32/machine_timer.c
@@ -76,10 +76,10 @@ STATIC mp_obj_t machine_timer_init_helper(machine_timer_obj_t *self, size_t n_ar
     self->expiry_ms = mp_hal_ticks_ms() + self->delta_ms;
 
     if (args[ARG_callback].u_obj != MP_OBJ_NULL) {
-        self->callback = args[ARG_callback].u_obj;
+        self->py_callback = args[ARG_callback].u_obj;
     }
 
-    if (self->callback != mp_const_none) {
+    if (self->py_callback != mp_const_none) {
         soft_timer_insert(self);
     }
 
@@ -89,8 +89,9 @@ STATIC mp_obj_t machine_timer_init_helper(machine_timer_obj_t *self, size_t n_ar
 STATIC mp_obj_t machine_timer_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *args) {
     machine_timer_obj_t *self = m_new_obj(machine_timer_obj_t);
     self->pairheap.base.type = &machine_timer_type;
+    self->flags = SOFT_TIMER_FLAG_PY_CALLBACK;
     self->delta_ms = 1000;
-    self->callback = mp_const_none;
+    self->py_callback = mp_const_none;
 
     // Get timer id (only soft timer (-1) supported at the moment)
     mp_int_t id = -1;

--- a/ports/stm32/softtimer.h
+++ b/ports/stm32/softtimer.h
@@ -28,15 +28,21 @@
 
 #include "py/pairheap.h"
 
+#define SOFT_TIMER_FLAG_PY_CALLBACK (1)
+
 #define SOFT_TIMER_MODE_ONE_SHOT (1)
 #define SOFT_TIMER_MODE_PERIODIC (2)
 
 typedef struct _soft_timer_entry_t {
     mp_pairheap_t pairheap;
-    uint32_t mode;
+    uint16_t flags;
+    uint16_t mode;
     uint32_t expiry_ms;
     uint32_t delta_ms; // for periodic mode
-    mp_obj_t callback;
+    union {
+        void (*c_callback)(struct _soft_timer_entry_t *);
+        mp_obj_t py_callback;
+    };
 } soft_timer_entry_t;
 
 extern volatile uint32_t soft_timer_next;

--- a/ports/stm32/softtimer.h
+++ b/ports/stm32/softtimer.h
@@ -49,6 +49,8 @@ extern volatile uint32_t soft_timer_next;
 
 void soft_timer_deinit(void);
 void soft_timer_handler(void);
+
+void soft_timer_static_init(soft_timer_entry_t *entry, uint16_t mode, uint32_t delta_ms, void (*cb)(soft_timer_entry_t *));
 void soft_timer_insert(soft_timer_entry_t *entry);
 void soft_timer_remove(soft_timer_entry_t *entry);
 


### PR DESCRIPTION
This is an alternative to #7143.  The implementation here has two separate pairing heaps, one for static timers and one for GC allocated timers.  It is simpler.