### PR TITLE
stm32/sdio.c: Add functions to disable/enable SDIOITIE and reenable SDIO.

### DIFF
--- a/drivers/cyw43/cyw43_ctrl.c
+++ b/drivers/cyw43/cyw43_ctrl.c
@@ -112,7 +112,7 @@ void cyw43_deinit(cyw43_t *self) {
     self->itf_state = 0;
 
     // Disable async polling
-    SDMMC1->MASK &= ~SDMMC_MASK_SDIOITIE;
+    sdio_enable_irq(false);
     cyw43_poll = NULL;
 
     #ifdef pyb_pin_WL_RFSW_VDD
@@ -164,7 +164,7 @@ STATIC int cyw43_ensure_up(cyw43_t *self) {
     cyw43_sleep = CYW43_SLEEP_MAX;
     cyw43_poll = cyw43_poll_func;
     #if USE_SDIOIT
-    SDMMC1->MASK |= SDMMC_MASK_SDIOITIE;
+    sdio_enable_irq(true);
     #else
     extern void extint_set(const pin_obj_t *pin, uint32_t mode);
     extint_set(pyb_pin_WL_HOST_WAKE, GPIO_MODE_IT_FALLING);
@@ -209,7 +209,7 @@ STATIC void cyw43_poll_func(void) {
     }
 
     #if USE_SDIOIT
-    SDMMC1->MASK |= SDMMC_MASK_SDIOITIE;
+    sdio_enable_irq(true);
     #endif
 }
 
@@ -227,10 +227,7 @@ int cyw43_cb_read_host_interrupt_pin(void *cb_data) {
 void cyw43_cb_ensure_awake(void *cb_data) {
     cyw43_sleep = CYW43_SLEEP_MAX;
     #if !USE_SDIOIT
-    if (__HAL_RCC_SDMMC1_IS_CLK_DISABLED()) {
-        __HAL_RCC_SDMMC1_CLK_ENABLE(); // enable SDIO peripheral
-        sdio_enable_high_speed_4bit();
-    }
+    sdio_reenable();
     #endif
 }
 

--- a/ports/stm32/sdio.c
+++ b/ports/stm32/sdio.c
@@ -93,6 +93,21 @@ void sdio_deinit(void) {
     #endif
 }
 
+void sdio_reenable(void) {
+    if (__HAL_RCC_SDMMC1_IS_CLK_DISABLED()) {
+        __HAL_RCC_SDMMC1_CLK_ENABLE(); // enable SDIO peripheral
+        sdio_enable_high_speed_4bit();
+    }
+}
+
+void sdio_enable_irq(bool enable) {
+    if (enable) {
+        SDMMC1->MASK |= SDMMC_MASK_SDIOITIE;
+    } else {
+        SDMMC1->MASK &= ~SDMMC_MASK_SDIOITIE;
+    }
+}
+
 void sdio_enable_high_speed_4bit(void) {
     SDMMC_TypeDef *SDIO = SDMMC1;
     SDIO->POWER = 0; // power off

--- a/ports/stm32/sdio.h
+++ b/ports/stm32/sdio.h
@@ -31,6 +31,8 @@
 
 void sdio_init(uint32_t irq_pri);
 void sdio_deinit(void);
+void sdio_reenable(void);
+void sdio_enable_irq(bool enable);
 void sdio_enable_high_speed_4bit(void);
 int sdio_transfer(uint32_t cmd, uint32_t arg, uint32_t *resp);
 int sdio_transfer_cmd53(bool write, uint32_t block_size, uint32_t arg, size_t len, uint8_t *buf);


### PR DESCRIPTION
* As per discussion in #6986.
* Tested on PYBD_SF2
* Note had to fix cyw43_ctrl.c formatting.