### PR TITLE
added board definition for Sparkfun Thing Plus RP2040

### DIFF
--- a/ports/rp2/boards/SPARKFUN_PROMICRO/mpconfigboard.cmake
+++ b/ports/rp2/boards/SPARKFUN_PROMICRO/mpconfigboard.cmake
@@ -1,0 +1,1 @@
+# cmake file for Sparkfun Thing Plus RP2040 and Sparkfun Pro Micro RP2040

--- a/ports/rp2/boards/SPARKFUN_PROMICRO/mpconfigboard.h
+++ b/ports/rp2/boards/SPARKFUN_PROMICRO/mpconfigboard.h
@@ -1,0 +1,3 @@
+// Board and hardware specific configuration
+#define MICROPY_HW_BOARD_NAME                   "Sparkfun Pro Micro RP2040"
+#define MICROPY_HW_FLASH_STORAGE_BYTES          (15 * 1024 * 1024)

--- a/ports/rp2/boards/SPARKFUN_THINGPLUS/mpconfigboard.cmake
+++ b/ports/rp2/boards/SPARKFUN_THINGPLUS/mpconfigboard.cmake
@@ -1,0 +1,1 @@
+# cmake file for Sparkfun Thing Plus RP2040 and Sparkfun Pro Micro RP2040

--- a/ports/rp2/boards/SPARKFUN_THINGPLUS/mpconfigboard.h
+++ b/ports/rp2/boards/SPARKFUN_THINGPLUS/mpconfigboard.h
@@ -1,0 +1,3 @@
+// Board and hardware specific configuration
+#define MICROPY_HW_BOARD_NAME                   "Sparkfun Thing Plus RP2040"
+#define MICROPY_HW_FLASH_STORAGE_BYTES          (15 * 1024 * 1024)


### PR DESCRIPTION
Hi, 

with help of @robert-hh  (who created the actual files) I would like to get the board definitions for the Sparkfun Thing Plus RP2040 into micropython.
The build has been tested with the actual board and shows the expected 15MB of storage.