### PR TITLE
py/scheduler: Add missing MICROPY_WRAP_MP_SCHED_EXCEPTION usage.

### DIFF
--- a/py/scheduler.c
+++ b/py/scheduler.c
@@ -28,7 +28,7 @@
 
 #include "py/runtime.h"
 
-void mp_sched_exception(mp_obj_t exc) {
+void MICROPY_WRAP_MP_SCHED_EXCEPTION(mp_sched_exception)(mp_obj_t exc) {
     MP_STATE_VM(mp_pending_exception) = exc;
     #if MICROPY_ENABLE_SCHEDULER
     if (MP_STATE_VM(sched_state) == MP_SCHED_IDLE) {


### PR DESCRIPTION
This was missed in commit 7cbf826a9575e18ce1b7fe11b0f0997509153260.