### PR TITLE
ports/stm32: Change default LSI_VALUE to 32000 for F4 MCUs.

### DIFF
--- a/ports/stm32/boards/stm32f4xx_hal_conf_base.h
+++ b/ports/stm32/boards/stm32f4xx_hal_conf_base.h
@@ -88,7 +88,7 @@
 
 // Oscillator values in Hz
 #define HSI_VALUE (16000000)
-#define LSI_VALUE (40000)
+#define LSI_VALUE (32000)
 
 // SysTick has the highest priority
 #define TICK_INT_PRIORITY (0x00)


### PR DESCRIPTION
In the STM32 HAL libraries, the default value for LSI_VALUE for F4 MCUs is 32 kHz.

I just noticed this when looking into watchdog timers since they use this clock. I haven't done an extensive review of STM32F4 datasheets to see if all match this value, but the ones I am using (STM32F413 and STM32F446) have a 32 kHz LSI clock.
