### PR TITLE
Add macOS desktop metadata (.DS_Store) files to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,7 @@ user.props
 # Generated rst files
 ######################
 genrst/
+
+# MacOS desktop metadata files
+######################
+.DS_Store


### PR DESCRIPTION
When the source tree is browsed in a macOS machine the Finder leaves various metadata in files named `.DS_Store` in each directory. These should be ignored by `git`.