### PR TITLE
rp2: Move manifest.py to boards directory.

### DIFF
--- a/ports/rp2/CMakeLists.txt
+++ b/ports/rp2/CMakeLists.txt
@@ -159,7 +159,7 @@ set(PICO_SDK_COMPONENTS
 
 # Define mpy-cross flags and frozen manifest
 set(MICROPY_CROSS_FLAGS -march=armv7m)
-set(MICROPY_FROZEN_MANIFEST ${PROJECT_SOURCE_DIR}/manifest.py)
+set(MICROPY_FROZEN_MANIFEST ${PROJECT_SOURCE_DIR}/boards/manifest.py)
 
 target_sources(${MICROPY_TARGET} PRIVATE
     ${MICROPY_SOURCE_PY}

--- a/ports/rp2/boards/manifest.py
+++ b/ports/rp2/boards/manifest.py
@@ -1,3 +1,3 @@
-freeze("modules")
+freeze("$(PORT_DIR)/modules")
 freeze("$(MPY_DIR)/drivers/onewire")
 include("$(MPY_DIR)/extmod/uasyncio/manifest.py")


### PR DESCRIPTION
To match other ports.
