### PR TITLE
rp2: make GC lock work per CPU

### DIFF
--- a/lib/utils/pyexec.c
+++ b/lib/utils/pyexec.c
@@ -588,8 +588,8 @@ friendly_repl_reset:
 
         // If the GC is locked at this point there is no way out except a reset,
         // so force the GC to be unlocked to help the user debug what went wrong.
-        if (MP_STATE_MEM(gc_lock_depth) != 0) {
-            MP_STATE_MEM(gc_lock_depth) = 0;
+        if (MP_STATE_MEM(gc_lock_depth[MICROPY_EXECUTION_CORE_CUR]) != 0) {
+            MP_STATE_MEM(gc_lock_depth[MICROPY_EXECUTION_CORE_CUR]) = 0;
         }
 
         vstr_reset(&line);

--- a/ports/rp2/mpconfigport.h
+++ b/ports/rp2/mpconfigport.h
@@ -186,6 +186,11 @@ extern const struct _mp_obj_module_t mp_module_utime;
 #define MICROPY_BEGIN_ATOMIC_SECTION()     save_and_disable_interrupts()
 #define MICROPY_END_ATOMIC_SECTION(state)  restore_interrupts(state)
 
+#if MICROPY_PY_THREAD && !MICROPY_PY_THREAD_GIL
+#define MICROPY_EXECUTION_CORE_NUM (2)
+#define MICROPY_EXECUTION_CORE_CUR (get_core_num())
+#endif
+
 #if MICROPY_HW_ENABLE_USBDEV
 #define MICROPY_HW_USBDEV_TASK_HOOK extern void tud_task(void); tud_task();
 #define MICROPY_VM_HOOK_COUNT (10)

--- a/py/gc.c
+++ b/py/gc.c
@@ -150,7 +150,9 @@ void gc_init(void *start, void *end) {
     MP_STATE_MEM(gc_last_free_atb_index) = 0;
 
     // unlock the GC
-    MP_STATE_MEM(gc_lock_depth) = 0;
+    for (size_t i = 0; i < MICROPY_EXECUTION_CORE_NUM; ++i) {
+        MP_STATE_MEM(gc_lock_depth[i]) = 0;
+    }
 
     // allow auto collection
     MP_STATE_MEM(gc_auto_collect_enabled) = 1;
@@ -174,19 +176,19 @@ void gc_init(void *start, void *end) {
 }
 
 void gc_lock(void) {
-    GC_ENTER();
-    MP_STATE_MEM(gc_lock_depth)++;
-    GC_EXIT();
+    mp_uint_t atomic_state = MICROPY_BEGIN_ATOMIC_SECTION();
+    MP_STATE_MEM(gc_lock_depth[MICROPY_EXECUTION_CORE_CUR])++;
+    MICROPY_END_ATOMIC_SECTION(atomic_state);
 }
 
 void gc_unlock(void) {
-    GC_ENTER();
-    MP_STATE_MEM(gc_lock_depth)--;
-    GC_EXIT();
+    mp_uint_t atomic_state = MICROPY_BEGIN_ATOMIC_SECTION();
+    MP_STATE_MEM(gc_lock_depth[MICROPY_EXECUTION_CORE_CUR])--;
+    MICROPY_END_ATOMIC_SECTION(atomic_state);
 }
 
 bool gc_is_locked(void) {
-    return MP_STATE_MEM(gc_lock_depth) != 0;
+    return MP_STATE_MEM(gc_lock_depth[MICROPY_EXECUTION_CORE_CUR]) != 0;
 }
 
 // ptr should be of type void*
@@ -320,7 +322,6 @@ STATIC void gc_sweep(void) {
 
 void gc_collect_start(void) {
     GC_ENTER();
-    MP_STATE_MEM(gc_lock_depth)++;
     #if MICROPY_GC_ALLOC_THRESHOLD
     MP_STATE_MEM(gc_alloc_amount) = 0;
     #endif
@@ -360,13 +361,11 @@ void gc_collect_end(void) {
     gc_deal_with_stack_overflow();
     gc_sweep();
     MP_STATE_MEM(gc_last_free_atb_index) = 0;
-    MP_STATE_MEM(gc_lock_depth)--;
     GC_EXIT();
 }
 
 void gc_sweep_all(void) {
     GC_ENTER();
-    MP_STATE_MEM(gc_lock_depth)++;
     MP_STATE_MEM(gc_stack_overflow) = 0;
     gc_collect_end();
 }
@@ -445,13 +444,12 @@ void *gc_alloc(size_t n_bytes, unsigned int alloc_flags) {
         return NULL;
     }
 
-    GC_ENTER();
-
     // check if GC is locked
-    if (MP_STATE_MEM(gc_lock_depth) > 0) {
-        GC_EXIT();
+    if (MP_STATE_MEM(gc_lock_depth[MICROPY_EXECUTION_CORE_CUR]) > 0) {
         return NULL;
     }
+
+    GC_ENTER();
 
     size_t i;
     size_t end_block;
@@ -573,12 +571,12 @@ void *gc_alloc_with_finaliser(mp_uint_t n_bytes) {
 // force the freeing of a piece of memory
 // TODO: freeing here does not call finaliser
 void gc_free(void *ptr) {
-    GC_ENTER();
-    if (MP_STATE_MEM(gc_lock_depth) > 0) {
+    if (MP_STATE_MEM(gc_lock_depth[MICROPY_EXECUTION_CORE_CUR]) > 0) {
         // TODO how to deal with this error?
-        GC_EXIT();
         return;
     }
+
+    GC_ENTER();
 
     DEBUG_printf("gc_free(%p)\n", ptr);
 
@@ -674,14 +672,13 @@ void *gc_realloc(void *ptr_in, size_t n_bytes, bool allow_move) {
         return NULL;
     }
 
+    if (MP_STATE_MEM(gc_lock_depth[MICROPY_EXECUTION_CORE_CUR]) > 0) {
+        return NULL;
+    }
+
     void *ptr = ptr_in;
 
     GC_ENTER();
-
-    if (MP_STATE_MEM(gc_lock_depth) > 0) {
-        GC_EXIT();
-        return NULL;
-    }
 
     // get the GC block number corresponding to this pointer
     assert(VERIFY_PTR(ptr));

--- a/py/modmicropython.c
+++ b/py/modmicropython.c
@@ -130,13 +130,13 @@ STATIC MP_DEFINE_CONST_FUN_OBJ_0(mp_micropython_heap_lock_obj, mp_micropython_he
 
 STATIC mp_obj_t mp_micropython_heap_unlock(void) {
     gc_unlock();
-    return MP_OBJ_NEW_SMALL_INT(MP_STATE_MEM(gc_lock_depth));
+    return MP_OBJ_NEW_SMALL_INT(MP_STATE_MEM(gc_lock_depth[MICROPY_EXECUTION_CORE_CUR]));
 }
 STATIC MP_DEFINE_CONST_FUN_OBJ_0(mp_micropython_heap_unlock_obj, mp_micropython_heap_unlock);
 
 #if MICROPY_PY_MICROPYTHON_HEAP_LOCKED
 STATIC mp_obj_t mp_micropython_heap_locked(void) {
-    return MP_OBJ_NEW_SMALL_INT(MP_STATE_MEM(gc_lock_depth));
+    return MP_OBJ_NEW_SMALL_INT(MP_STATE_MEM(gc_lock_depth[MICROPY_EXECUTION_CORE_CUR]));
 }
 STATIC MP_DEFINE_CONST_FUN_OBJ_0(mp_micropython_heap_locked_obj, mp_micropython_heap_locked);
 #endif

--- a/py/mpconfig.h
+++ b/py/mpconfig.h
@@ -1541,6 +1541,13 @@ typedef double mp_float_t;
 #define MICROPY_END_ATOMIC_SECTION(state) (void)(state)
 #endif
 
+// The number (and current) independent execution cores/CPUs that the MicroPython
+// VM can run on.
+#ifndef MICROPY_EXECUTION_CORE_NUM
+#define MICROPY_EXECUTION_CORE_NUM (1)
+#define MICROPY_EXECUTION_CORE_CUR (0)
+#endif
+
 // Allow to override static modifier for global objects, e.g. to use with
 // object code analysis tools which don't support static symbols.
 #ifndef STATIC

--- a/py/mpstate.h
+++ b/py/mpstate.h
@@ -80,7 +80,7 @@ typedef struct _mp_state_mem_t {
 
     int gc_stack_overflow;
     MICROPY_GC_STACK_ENTRY_TYPE gc_stack[MICROPY_ALLOC_GC_STACK_SIZE];
-    uint16_t gc_lock_depth;
+    uint16_t gc_lock_depth[MICROPY_EXECUTION_CORE_NUM];
 
     // This variable controls auto garbage collection.  If set to 0 then the
     // GC won't automatically run when gc_alloc can't find enough blocks.  But


### PR DESCRIPTION
The rp2 port is the first port with multithreading without a GIL, and hard interrupts.  To make such IRQs work correctly some things need to be improved wrt locking the GC.

This PR takes a first step by making `gc_lock_depth` have one instance per CPU core.  That means that a given core can run a hard IRQ independently to the other, ie not lock the GC for the other CPU core while the hard IRQ is running.

It also puts more code in RAM for the rp2 port to make `Pin.irq()` have less jitter.

Should fix #6957.