### PR TITLE
esp32: minor threading improvements

### DIFF
--- a/ports/esp32/mpthreadport.c
+++ b/ports/esp32/mpthreadport.c
@@ -192,7 +192,10 @@ void vPortCleanUpTCB(void *tcb) {
 }
 
 void mp_thread_mutex_init(mp_thread_mutex_t *mutex) {
-    mutex->handle = xSemaphoreCreateMutexStatic(&mutex->buffer);
+    // Need a binary semaphore so a lock can be acquired on one Python thread
+    // and then released on another.
+    mutex->handle = xSemaphoreCreateBinaryStatic(&mutex->buffer);
+    xSemaphoreGive(mutex->handle);
 }
 
 int mp_thread_mutex_lock(mp_thread_mutex_t *mutex, int wait) {

--- a/ports/esp32/mpthreadport.c
+++ b/ports/esp32/mpthreadport.c
@@ -166,6 +166,8 @@ void mp_thread_finish(void) {
     mp_thread_mutex_unlock(&thread_mutex);
 }
 
+// This is called from the FreeRTOS idle task and is not within Python context,
+// so MP_STATE_THREAD is not valid and it does not have the GIL.
 void vPortCleanUpTCB(void *tcb) {
     if (thread == NULL) {
         // threading not yet initialised
@@ -182,8 +184,7 @@ void vPortCleanUpTCB(void *tcb) {
                 // move the start pointer
                 thread = th->next;
             }
-            // explicitly release all its memory
-            m_del(thread_t, th, 1);
+            // The "th" memory will eventually be reclaimed by the GC.
             break;
         }
     }

--- a/tests/thread/stress_aes.py
+++ b/tests/thread/stress_aes.py
@@ -235,7 +235,7 @@ class LockedCounter:
 count = LockedCounter()
 
 
-def thread_entry():
+def thread_entry(n_loop):
     global count
 
     aes = AES(256)
@@ -244,7 +244,7 @@ def thread_entry():
     data = bytearray(128)
     # from now on we don't use the heap
 
-    for loop in range(5):
+    for loop in range(n_loop):
         # encrypt
         aes.set_key(key)
         aes.set_iv(iv)
@@ -265,8 +265,20 @@ def thread_entry():
 
 
 if __name__ == "__main__":
-    n_thread = 20
+    import sys
+
+    if sys.platform == "rp2":
+        n_thread = 1
+        n_loop = 2
+    elif sys.platform in ("esp32", "pyboard"):
+        n_thread = 2
+        n_loop = 2
+    else:
+        n_thread = 20
+        n_loop = 5
     for i in range(n_thread):
-        _thread.start_new_thread(thread_entry, ())
+        _thread.start_new_thread(thread_entry, (n_loop,))
+    thread_entry(n_loop)
     while count.value < n_thread:
         time.sleep(1)
+    print("done")

--- a/tests/thread/stress_create.py
+++ b/tests/thread/stress_create.py
@@ -1,9 +1,13 @@
 # stress test for creating many threads
 
 try:
-    import utime as time
+    import utime
+
+    sleep_ms = utime.sleep_ms
 except ImportError:
     import time
+
+    sleep_ms = lambda t: time.sleep(t / 1000)
 import _thread
 
 
@@ -16,9 +20,11 @@ while thread_num < 500:
     try:
         _thread.start_new_thread(thread_entry, (thread_num,))
         thread_num += 1
-    except MemoryError:
-        pass
+    except (MemoryError, OSError) as er:
+        # Cannot create a new thead at this stage, yield for a bit to
+        # let existing threads run to completion and free up resources.
+        sleep_ms(50)
 
 # wait for the last threads to terminate
-time.sleep(1)
+sleep_ms(500)
 print("done")

--- a/tests/thread/thread_lock5.py
+++ b/tests/thread/thread_lock5.py
@@ -1,0 +1,16 @@
+# test _thread lock objects where a lock is acquired/released by a different thread
+
+import _thread
+
+
+def thread_entry():
+    print("thread about to release lock")
+    lock.release()
+
+
+lock = _thread.allocate_lock()
+lock.acquire()
+_thread.start_new_thread(thread_entry, ())
+lock.acquire()
+print("main has lock")
+lock.release()


### PR DESCRIPTION
- don't free thread struct memory in `vPortCleanUpTCB()` because it's not legal
- use a binary semaphore for thread mutex implementation
- add a new thread test
- get existing threat tests running on esp32 (those that didn't)