### PR TITLE
rp2/mpthreadport: Add mp_thread_deinit to reset core1 on soft reset.

### DIFF
--- a/ports/rp2/main.c
+++ b/ports/rp2/main.c
@@ -138,6 +138,9 @@ int main(int argc, char **argv) {
         mp_printf(MP_PYTHON_PRINTER, "MPY: soft reboot\n");
         rp2_pio_deinit();
         machine_pin_deinit();
+        #if MICROPY_PY_THREAD
+        mp_thread_deinit();
+        #endif
         gc_sweep_all();
         mp_deinit();
     }

--- a/ports/rp2/mpthreadport.c
+++ b/ports/rp2/mpthreadport.c
@@ -46,6 +46,11 @@ void mp_thread_init(void) {
     core1_entry = NULL;
 }
 
+void mp_thread_deinit(void) {
+    multicore_reset_core1();
+    core1_entry = NULL;
+}
+
 void mp_thread_gc_others(void) {
     if (get_core_num() == 0) {
         // GC running on core0, trace core1's stack, if it's running.

--- a/ports/rp2/mpthreadport.h
+++ b/ports/rp2/mpthreadport.h
@@ -34,6 +34,7 @@ typedef struct mutex mp_thread_mutex_t;
 extern void *core_state[2];
 
 void mp_thread_init(void);
+void mp_thread_deinit(void);
 void mp_thread_gc_others(void);
 
 static inline void mp_thread_set_state(struct _mp_state_thread_t *state) {


### PR DESCRIPTION
Any code running on core1 should be stopped on soft-reset (the GC heap is reset so if code continues to run on core1 it will see corrupt memory).

