### PR TITLE
various: Fix gcc -fsanitize=undefined errors

### DIFF
--- a/extmod/crypto-algorithms/sha256.c
+++ b/extmod/crypto-algorithms/sha256.c
@@ -46,7 +46,7 @@ static void sha256_transform(CRYAL_SHA256_CTX *ctx, const BYTE data[])
 	WORD a, b, c, d, e, f, g, h, i, j, t1, t2, m[64];
 
 	for (i = 0, j = 0; i < 16; ++i, j += 4)
-		m[i] = (data[j] << 24) | (data[j + 1] << 16) | (data[j + 2] << 8) | (data[j + 3]);
+		m[i] = ((uint32_t)data[j] << 24) | (data[j + 1] << 16) | (data[j + 2] << 8) | (data[j + 3]);
 	for ( ; i < 64; ++i)
 		m[i] = SIG1(m[i - 2]) + m[i - 7] + SIG0(m[i - 15]) + m[i - 16];
 

--- a/extmod/moduasyncio.c
+++ b/extmod/moduasyncio.c
@@ -40,6 +40,8 @@ typedef struct _mp_obj_task_t {
     mp_obj_t ph_key;
 } mp_obj_task_t;
 
+#define PAIRHEAP(x) ((x) ? &x->pairheap : NULL)
+
 typedef struct _mp_obj_task_queue_t {
     mp_obj_base_t base;
     mp_obj_task_t *heap;
@@ -103,7 +105,7 @@ STATIC mp_obj_t task_queue_push_sorted(size_t n_args, const mp_obj_t *args) {
         assert(mp_obj_is_small_int(args[2]));
         task->ph_key = args[2];
     }
-    self->heap = (mp_obj_task_t *)mp_pairheap_push(task_lt, &self->heap->pairheap, &task->pairheap);
+    self->heap = (mp_obj_task_t *)mp_pairheap_push(task_lt, PAIRHEAP(self->heap), PAIRHEAP(task));
     return mp_const_none;
 }
 STATIC MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(task_queue_push_sorted_obj, 2, 3, task_queue_push_sorted);

--- a/ports/unix/variants/coverage/mpconfigvariant.h
+++ b/ports/unix/variants/coverage/mpconfigvariant.h
@@ -63,6 +63,7 @@
 #define MICROPY_PY_UCRYPTOLIB          (1)
 #define MICROPY_PY_UCRYPTOLIB_CTR      (1)
 #define MICROPY_PY_MICROPYTHON_HEAP_LOCKED (1)
+#define MICROPY_NONNULL_COMPLIANT (1)
 
 // use vfs's functions for import stat and builtin open
 #define mp_import_stat mp_vfs_import_stat

--- a/py/binary.c
+++ b/py/binary.c
@@ -202,7 +202,7 @@ long long mp_binary_get_int(size_t size, bool is_signed, bool big_endian, const 
         delta = 1;
     }
 
-    long long val = 0;
+    unsigned long long val = 0;
     if (is_signed && *src & 0x80) {
         val = -1;
     }

--- a/py/misc.h
+++ b/py/misc.h
@@ -319,4 +319,27 @@ typedef const char *mp_rom_error_text_t;
 // For now, forward directly to MP_COMPRESSED_ROM_TEXT.
 #define MP_ERROR_TEXT(x) (mp_rom_error_text_t)MP_COMPRESSED_ROM_TEXT(x)
 
+/** NULL-protected mem* wrappers ****/
+// In ISO C, memcpy(dest, NULL, 0) and similar are undefined (the source
+// and destination pointers are annotated as "non-null").
+// This doesn't matter much, as the implementation provided on embedded
+// platforms never dereferences the source or destintaion pointer if the
+// length is zero.  However, on Linux and particularly under undefined
+// behavior sanitizers, this is treated as an error.
+//
+// Use the "0" alternative where a NULL pointer and a zero length can
+// occur together, and on systems where compliance with ISO C is
+// important, ensure that MICROPY_NONNULL_COMPLIANT is defined to (1).
+#if MICROPY_NONNULL_COMPLIANT
+#define memcpy0(dest, src, n) ((n) != 0 ? memcpy((dest), (src), (n)) : (dest))
+#define memmove0(dest, src, n) ((n) != 0 ? memmove((dest), (src), (n)) : (dest))
+#define memset0(s, c, n) ((n) != 0 ? memset((s), (c), (n)) : (s))
+#define memcmp0(s1, s2, n) ((n) != 0 ? memcmp((s1), (s2), (n)) : (0))
+#else
+#define memcpy0(dest, src, n) memcpy((dest), (src), (n))
+#define memmove0(dest, src, n) memmove((dest), (src), (n))
+#define memset0(s, c, n) memset((s), (c), (n))
+#define memcmp0(s1, s2, n) memcmp((s1), (s2), (n))
+#endif
+
 #endif // MICROPY_INCLUDED_PY_MISC_H

--- a/py/mpconfig.h
+++ b/py/mpconfig.h
@@ -1718,4 +1718,8 @@ typedef double mp_float_t;
 #endif
 #endif
 
+#if !defined(MICROPY_NONNULL_COMPLIANT)
+#define MICROPY_NONNULL_COMPLIANT (0)
+#endif
+
 #endif // MICROPY_INCLUDED_PY_MPCONFIG_H

--- a/py/mpz.c
+++ b/py/mpz.c
@@ -697,7 +697,7 @@ STATIC mpz_t *mpz_clone(const mpz_t *src) {
     z->alloc = src->alloc;
     z->len = src->len;
     z->dig = m_new(mpz_dig_t, z->alloc);
-    memcpy(z->dig, src->dig, src->alloc * sizeof(mpz_dig_t));
+    memcpy0(z->dig, src->dig, src->alloc * sizeof(mpz_dig_t));
     return z;
 }
 
@@ -708,7 +708,7 @@ void mpz_set(mpz_t *dest, const mpz_t *src) {
     mpz_need_dig(dest, src->len);
     dest->neg = src->neg;
     dest->len = src->len;
-    memcpy(dest->dig, src->dig, src->len * sizeof(mpz_dig_t));
+    memcpy0(dest->dig, src->dig, src->len * sizeof(mpz_dig_t));
 }
 
 void mpz_set_from_int(mpz_t *z, mp_int_t val) {
@@ -741,7 +741,7 @@ void mpz_set_from_ll(mpz_t *z, long long val, bool is_signed) {
     unsigned long long uval;
     if (is_signed && val < 0) {
         z->neg = 1;
-        uval = -val;
+        uval = -(unsigned long long)val;
     } else {
         z->neg = 0;
         uval = val;

--- a/py/obj.h
+++ b/py/obj.h
@@ -993,8 +993,8 @@ void mp_seq_multiply(const void *items, size_t item_sz, size_t len, size_t times
 #if MICROPY_PY_BUILTINS_SLICE
 bool mp_seq_get_fast_slice_indexes(mp_uint_t len, mp_obj_t slice, mp_bound_slice_t *indexes);
 #endif
-#define mp_seq_copy(dest, src, len, item_t) memcpy(dest, src, len * sizeof(item_t))
-#define mp_seq_cat(dest, src1, len1, src2, len2, item_t) { memcpy(dest, src1, (len1) * sizeof(item_t)); memcpy(dest + (len1), src2, (len2) * sizeof(item_t)); }
+#define mp_seq_copy(dest, src, len, item_t) memcpy0(dest, src, len * sizeof(item_t))
+#define mp_seq_cat(dest, src1, len1, src2, len2, item_t) { memcpy0(dest, src1, (len1) * sizeof(item_t)); memcpy0(dest + (len1), src2, (len2) * sizeof(item_t)); }
 bool mp_seq_cmp_bytes(mp_uint_t op, const byte *data1, size_t len1, const byte *data2, size_t len2);
 bool mp_seq_cmp_objs(mp_uint_t op, const mp_obj_t *items1, size_t len1, const mp_obj_t *items2, size_t len2);
 mp_obj_t mp_seq_index_obj(const mp_obj_t *items, size_t len, size_t n_args, const mp_obj_t *args);
@@ -1002,17 +1002,17 @@ mp_obj_t mp_seq_count_obj(const mp_obj_t *items, size_t len, mp_obj_t value);
 mp_obj_t mp_seq_extract_slice(size_t len, const mp_obj_t *seq, mp_bound_slice_t *indexes);
 
 // Helper to clear stale pointers from allocated, but unused memory, to preclude GC problems
-#define mp_seq_clear(start, len, alloc_len, item_sz) memset((byte *)(start) + (len) * (item_sz), 0, ((alloc_len) - (len)) * (item_sz))
+#define mp_seq_clear(start, len, alloc_len, item_sz) memset0((byte *)(start) + (len) * (item_sz), 0, ((alloc_len) - (len)) * (item_sz))
 
 // Note: dest and slice regions may overlap
 #define mp_seq_replace_slice_no_grow(dest, dest_len, beg, end, slice, slice_len, item_sz) \
-    memmove(((char *)dest) + (beg) * (item_sz), slice, slice_len * (item_sz)); \
-    memmove(((char *)dest) + (beg + slice_len) * (item_sz), ((char *)dest) + (end) * (item_sz), (dest_len - end) * (item_sz));
+    (void)memmove0(((char *)dest) + (beg) * (item_sz), slice, slice_len * (item_sz)); \
+    (void)memmove0(((char *)dest) + (beg + slice_len) * (item_sz), ((char *)dest) + (end) * (item_sz), (dest_len - end) * (item_sz));
 
 // Note: dest and slice regions may overlap
 #define mp_seq_replace_slice_grow_inplace(dest, dest_len, beg, end, slice, slice_len, len_adj, item_sz) \
-    memmove(((char *)dest) + (beg + slice_len) * (item_sz), ((char *)dest) + (end) * (item_sz), ((dest_len) + (len_adj) - ((beg) + (slice_len))) * (item_sz)); \
-    memmove(((char *)dest) + (beg) * (item_sz), slice, slice_len * (item_sz));
+    (void)memmove0(((char *)dest) + (beg + slice_len) * (item_sz), ((char *)dest) + (end) * (item_sz), ((dest_len) + (len_adj) - ((beg) + (slice_len))) * (item_sz)); \
+    (void)memmove0(((char *)dest) + (beg) * (item_sz), slice, slice_len * (item_sz));
 
 // Provide translation for legacy API
 #define MP_OBJ_IS_SMALL_INT mp_obj_is_small_int

--- a/py/objarray.c
+++ b/py/objarray.c
@@ -127,7 +127,7 @@ STATIC mp_obj_t array_construct(char typecode, mp_obj_t initializer) {
         size_t sz = mp_binary_get_size('@', typecode, NULL);
         size_t len = bufinfo.len / sz;
         mp_obj_array_t *o = array_new(typecode, len);
-        memcpy(o->items, bufinfo.buf, len * sz);
+        memcpy0(o->items, bufinfo.buf, len * sz);
         return MP_OBJ_FROM_PTR(o);
     }
 
@@ -482,7 +482,7 @@ STATIC mp_obj_t array_subscr(mp_obj_t self_in, mp_obj_t index_in, mp_obj_t value
             #endif
             {
                 res = array_new(o->typecode, slice.stop - slice.start);
-                memcpy(res->items, (uint8_t *)o->items + slice.start * sz, (slice.stop - slice.start) * sz);
+                memcpy0(res->items, (uint8_t *)o->items + slice.start * sz, (slice.stop - slice.start) * sz);
             }
             return MP_OBJ_FROM_PTR(res);
         } else
@@ -599,7 +599,7 @@ size_t mp_obj_array_len(mp_obj_t self_in) {
 #if MICROPY_PY_BUILTINS_BYTEARRAY
 mp_obj_t mp_obj_new_bytearray(size_t n, void *items) {
     mp_obj_array_t *o = array_new(BYTEARRAY_TYPECODE, n);
-    memcpy(o->items, items, n);
+    memcpy0(o->items, items, n);
     return MP_OBJ_FROM_PTR(o);
 }
 

--- a/py/objdict.c
+++ b/py/objdict.c
@@ -247,7 +247,7 @@ mp_obj_t mp_obj_dict_copy(mp_obj_t self_in) {
     other->map.all_keys_are_qstrs = self->map.all_keys_are_qstrs;
     other->map.is_fixed = 0;
     other->map.is_ordered = self->map.is_ordered;
-    memcpy(other->map.table, self->map.table, self->map.alloc * sizeof(mp_map_elem_t));
+    memcpy0(other->map.table, self->map.table, self->map.alloc * sizeof(mp_map_elem_t));
     return other_out;
 }
 STATIC MP_DEFINE_CONST_FUN_OBJ_1(dict_copy_obj, mp_obj_dict_copy);

--- a/py/objint.c
+++ b/py/objint.c
@@ -106,14 +106,14 @@ STATIC mp_fp_as_int_class_t mp_classify_fp_as_int(mp_float_t val) {
         #if MICROPY_FLOAT_IMPL == MICROPY_FLOAT_IMPL_DOUBLE
         e |= u.i[MP_ENDIANNESS_BIG] != 0;
         #endif
-        if ((e & ~(1 << MP_FLOAT_SIGN_SHIFT_I32)) == 0) {
+        if ((e & ~(1U << MP_FLOAT_SIGN_SHIFT_I32)) == 0) {
             // handle case of -0 (when sign is set but rest of bits are zero)
             e = 0;
         } else {
-            e += ((1 << MP_FLOAT_EXP_BITS) - 1) << MP_FLOAT_EXP_SHIFT_I32;
+            e += ((1U << MP_FLOAT_EXP_BITS) - 1) << MP_FLOAT_EXP_SHIFT_I32;
         }
     } else {
-        e &= ~((1 << MP_FLOAT_EXP_SHIFT_I32) - 1);
+        e &= ~((1U << MP_FLOAT_EXP_SHIFT_I32) - 1);
     }
     // 8 * sizeof(uintptr_t) counts the number of bits for a small int
     // TODO provide a way to configure this properly

--- a/py/objset.c
+++ b/py/objset.c
@@ -178,7 +178,9 @@ STATIC mp_obj_t set_copy(mp_obj_t self_in) {
     other->base.type = self->base.type;
     mp_set_init(&other->set, self->set.alloc);
     other->set.used = self->set.used;
-    memcpy(other->set.table, self->set.table, self->set.alloc * sizeof(mp_obj_t));
+    if (self->set.alloc) {
+        memcpy(other->set.table, self->set.table, self->set.alloc * sizeof(mp_obj_t));
+    }
     return MP_OBJ_FROM_PTR(other);
 }
 STATIC MP_DEFINE_CONST_FUN_OBJ_1(set_copy_obj, set_copy);

--- a/py/qstr.c
+++ b/py/qstr.c
@@ -178,7 +178,7 @@ qstr qstr_find_strn(const char *str, size_t str_len) {
     // search pools for the data
     for (qstr_pool_t *pool = MP_STATE_VM(last_pool); pool != NULL; pool = pool->prev) {
         for (const byte **q = pool->qstrs, **q_top = pool->qstrs + pool->len; q < q_top; q++) {
-            if (Q_GET_HASH(*q) == str_hash && Q_GET_LENGTH(*q) == str_len && memcmp(Q_GET_DATA(*q), str, str_len) == 0) {
+            if (Q_GET_HASH(*q) == str_hash && Q_GET_LENGTH(*q) == str_len && memcmp0(Q_GET_DATA(*q), str, str_len) == 0) {
                 return pool->total_prev_len + (q - pool->qstrs);
             }
         }

--- a/py/runtime.c
+++ b/py/runtime.c
@@ -392,7 +392,7 @@ mp_obj_t mp_binary_op(mp_binary_op_t op, mp_obj_t lhs, mp_obj_t rhs) {
                         goto generic_binary_op;
                     } else {
                         // use standard precision
-                        lhs_val <<= rhs_val;
+                        lhs_val = (mp_uint_t)lhs_val << rhs_val;
                     }
                     break;
                 }

--- a/py/sequence.c
+++ b/py/sequence.c
@@ -105,7 +105,7 @@ bool mp_seq_cmp_bytes(mp_uint_t op, const byte *data1, size_t len1, const byte *
         }
     }
     size_t min_len = len1 < len2 ? len1 : len2;
-    int res = memcmp(data1, data2, min_len);
+    int res = memcmp0(data1, data2, min_len);
     if (op == MP_BINARY_OP_EQUAL) {
         // If we are checking for equality, here's the answer
         return res == 0;

--- a/py/showbc.c
+++ b/py/showbc.c
@@ -174,7 +174,7 @@ const byte *mp_bytecode_print_str(const mp_print_t *print, const byte *ip) {
                 num--;
             }
             do {
-                num = (num << 7) | (*ip & 0x7f);
+                num = ((mp_uint_t)num << 7) | (*ip & 0x7f);
             } while ((*ip++ & 0x80) != 0);
             mp_printf(print, "LOAD_CONST_SMALL_INT " INT_FMT, num);
             break;

--- a/py/smallint.h
+++ b/py/smallint.h
@@ -37,7 +37,7 @@
 #if MICROPY_OBJ_REPR == MICROPY_OBJ_REPR_A || MICROPY_OBJ_REPR == MICROPY_OBJ_REPR_C
 
 #define MP_SMALL_INT_MIN ((mp_int_t)(((mp_int_t)MP_OBJ_WORD_MSBIT_HIGH) >> 1))
-#define MP_SMALL_INT_FITS(n) ((((n) ^ ((n) << 1)) & MP_OBJ_WORD_MSBIT_HIGH) == 0)
+#define MP_SMALL_INT_FITS(n) ((((n) ^ ((mp_uint_t)(n) << 1)) & MP_OBJ_WORD_MSBIT_HIGH) == 0)
 // Mask to truncate mp_int_t to positive value
 #define MP_SMALL_INT_POSITIVE_MASK ~(MP_OBJ_WORD_MSBIT_HIGH | (MP_OBJ_WORD_MSBIT_HIGH >> 1))
 

--- a/py/vm.c
+++ b/py/vm.c
@@ -312,7 +312,7 @@ dispatch_loop:
                     DISPATCH();
 
                 ENTRY(MP_BC_LOAD_CONST_SMALL_INT): {
-                    mp_int_t num = 0;
+                    mp_uint_t num = 0;
                     if ((ip[0] & 0x40) != 0) {
                         // Number is negative
                         num--;


### PR DESCRIPTION
```
../../extmod/crypto-algorithms/sha256.c:49:19: runtime error: left shift of # by 24 places cannot be represented in type 'int'
../../extmod/moduasyncio.c:106:35: runtime error: member access within null pointer of type 'struct mp_obj_task_t'
../../py/binary.c:210:13: runtime error: left shift of negative value -1
../../py/mpz.c:711:5: runtime error: null pointer passed as argument 2, which is declared to never be null
../../py/mpz.c:744:16: runtime error: negation of -9223372036854775808 cannot be represented in type 'long long int'; cast to an unsigned type to negate this value to itself
../../py/objarray.c:130:9: runtime error: null pointer passed as argument 1, which is declared to never be null
../../py/objarray.c:377:5: runtime error: null pointer passed as argument 1, which is declared to never be null
../../py/objarray.c:457:21: runtime error: null pointer passed as argument 1, which is declared to never be null
../../py/objarray.c:457:21: runtime error: null pointer passed as argument 2, which is declared to never be null
../../py/objarray.c:461:21: runtime error: null pointer passed as argument 1, which is declared to never be null
../../py/objdict.c:250:5: runtime error: null pointer passed as argument 1, which is declared to never be null
../../py/objdict.c:250:5: runtime error: null pointer passed as argument 2, which is declared to never be null
../../py/objint.c:109:22: runtime error: left shift of 1 by 31 places cannot be represented in type 'int'
../../py/objint_mpz.c:374:9: runtime error: left shift of 4611686018427387904 by 1 places cannot be represented in type 'long int'
../../py/objint_mpz.c:374:9: runtime error: left shift of negative value -#
../../py/objset.c:181:5: runtime error: null pointer passed as argument 1, which is declared to never be null
../../py/objset.c:181:5: runtime error: null pointer passed as argument 2, which is declared to never be null
../../py/parsenum.c:106:14: runtime error: left shift of 4611686018427387904 by 1 places cannot be represented in type 'long int'
../../py/qstr.c:181:78: runtime error: null pointer passed as argument 2, which is declared to never be null
../../py/runtime.c:395:33: runtime error: left shift of negative value -#
../../py/sequence.c:108:15: runtime error: null pointer passed as argument 1, which is declared to never be null
../../py/sequence.c:108:15: runtime error: null pointer passed as argument 2, which is declared to never be null
../../py/showbc.c:177:28: runtime error: left shift of negative value -1
../../py/vm.c:321:36: runtime error: left shift of negative value -1
```

With these cumulative changes, `make VARIANT=coverage test_full` with -fsanitize=undefined passes, except for some problems in axtls.

My testing was done on an amd64 debian buster system using gcc-8.3 and these settings:
```
CFLAGS += -g3 -Og -fsanitize=undefined
LDFLAGS += -fsanitize=undefined
```

The changes are intended/expected to produce no runtime overhead, as the behavior of the mem* functions is only actually modified for the unix coverage run (MICROPY_NONNULL_COMPLIANT).

The introduced PAIRHEAP macro's conditional `(x ? &x->i : NULL)` assembles (under amd64 gcc 8.3 -Os) to the same as `&x->i`, since i is the initial field of the struct.  However, for the purposes of undefined behavior analysis the conditional is needed.

Signed-off-by: Jeff Epler <jepler@gmail.com>