### PR TITLE
Fixed mpconfigboard for change to UM_TINYPICO naming.

### DIFF
--- a/ports/esp32/boards/UM_TINYPICO/mpconfigboard.cmake
+++ b/ports/esp32/boards/UM_TINYPICO/mpconfigboard.cmake
@@ -3,7 +3,7 @@ set(SDKCONFIG_DEFAULTS
     boards/sdkconfig.ble
     boards/sdkconfig.240mhz
     boards/sdkconfig.spiram
-    boards/TINYPICO/sdkconfig.board
+    boards/UM_TINYPICO/sdkconfig.board
 )
 
 if(NOT MICROPY_FROZEN_MANIFEST)


### PR DESCRIPTION
This change got lost in the process on my side, sorry.
I've confirmed building works with the fix.