### PR TITLE
lib/lwip: Switch to use GitHub mirror repo.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -7,7 +7,7 @@
 	url = https://github.com/atgreen/libffi
 [submodule "lib/lwip"]
 	path = lib/lwip
-	url = https://git.savannah.gnu.org/r/lwip.git
+	url = https://github.com/lwip-tcpip/lwip.git
 [submodule "lib/berkeley-db-1.xx"]
 	path = lib/berkeley-db-1.xx
 	url = https://github.com/pfalcon/berkeley-db-1.xx


### PR DESCRIPTION
It is hopefully more reliable.

See #5356.