### PR TITLE
Per-thread exceptions

### DIFF
--- a/ports/esp8266/modnetwork.c
+++ b/ports/esp8266/modnetwork.c
@@ -237,7 +237,7 @@ STATIC mp_obj_t esp_scan(mp_obj_t self_in) {
     while (esp_scan_list != NULL) {
         // our esp_scan_cb is called via ets_loop_iter so it's safe to set the
         // esp_scan_list variable to NULL without disabling interrupts
-        if (MP_STATE_VM(mp_pending_exception) != NULL) {
+        if (MP_STATE_THREAD(mp_pending_exception) != NULL) {
             esp_scan_list = NULL;
             mp_handle_pending(true);
         }

--- a/ports/nrf/boards/microbit/modules/microbitdisplay.c
+++ b/ports/nrf/boards/microbit/modules/microbitdisplay.c
@@ -149,7 +149,7 @@ STATIC void async_stop(void) {
 STATIC void wait_for_event(void) {
     while (!wakeup_event) {
         // allow CTRL-C to stop the animation
-        if (MP_STATE_VM(mp_pending_exception) != MP_OBJ_NULL) {
+        if (MP_STATE_THREAD(mp_pending_exception) != MP_OBJ_NULL) {
             async_stop();
             return;
         }

--- a/ports/nrf/modules/music/modmusic.c
+++ b/ports/nrf/modules/music/modmusic.c
@@ -140,7 +140,7 @@ STATIC void wait_async_music_idle(void) {
     // wait for the async music state to become idle
     while (music_data->async_state != ASYNC_MUSIC_STATE_IDLE) {
         // allow CTRL-C to stop the music
-        if (MP_STATE_VM(mp_pending_exception) != MP_OBJ_NULL) {
+        if (MP_STATE_THREAD(mp_pending_exception) != MP_OBJ_NULL) {
             music_data->async_state = ASYNC_MUSIC_STATE_IDLE;
             pwm_set_duty_cycle(music_data->async_pin->pin, 0); // TODO: remove pin setting.
             break;

--- a/ports/pic16bit/board.c
+++ b/ports/pic16bit/board.c
@@ -140,7 +140,7 @@ int switch_get(int sw) {
 // TODO need an irq
 void uart_rx_irq(void) {
     if (c == interrupt_char) {
-        MP_STATE_THREAD(mp_pending_exception) = MP_STATE_PORT(keyboard_interrupt_obj);
+        MP_STATE_MAIN_THREAD(mp_pending_exception) = MP_STATE_PORT(keyboard_interrupt_obj);
     }
 }
 */

--- a/ports/pic16bit/board.c
+++ b/ports/pic16bit/board.c
@@ -140,7 +140,7 @@ int switch_get(int sw) {
 // TODO need an irq
 void uart_rx_irq(void) {
     if (c == interrupt_char) {
-        MP_STATE_VM(mp_pending_exception) = MP_STATE_PORT(keyboard_interrupt_obj);
+        MP_STATE_THREAD(mp_pending_exception) = MP_STATE_PORT(keyboard_interrupt_obj);
     }
 }
 */

--- a/ports/stm32/pendsv.c
+++ b/ports/stm32/pendsv.c
@@ -60,10 +60,10 @@ void pendsv_init(void) {
 // the given exception object using nlr_jump in the context of the top-level
 // thread.
 void pendsv_kbd_intr(void) {
-    if (MP_STATE_VM(mp_pending_exception) == MP_OBJ_NULL) {
+    if (MP_STATE_THREAD(mp_pending_exception) == MP_OBJ_NULL) {
         mp_sched_keyboard_interrupt();
     } else {
-        MP_STATE_VM(mp_pending_exception) = MP_OBJ_NULL;
+        MP_STATE_THREAD(mp_pending_exception) = MP_OBJ_NULL;
         pendsv_object = &MP_STATE_VM(mp_kbd_exception);
         SCB->ICSR = SCB_ICSR_PENDSVSET_Msk;
     }

--- a/ports/stm32/pendsv.c
+++ b/ports/stm32/pendsv.c
@@ -60,10 +60,10 @@ void pendsv_init(void) {
 // the given exception object using nlr_jump in the context of the top-level
 // thread.
 void pendsv_kbd_intr(void) {
-    if (MP_STATE_THREAD(mp_pending_exception) == MP_OBJ_NULL) {
+    if (MP_STATE_MAIN_THREAD(mp_pending_exception) == MP_OBJ_NULL) {
         mp_sched_keyboard_interrupt();
     } else {
-        MP_STATE_THREAD(mp_pending_exception) = MP_OBJ_NULL;
+        MP_STATE_MAIN_THREAD(mp_pending_exception) = MP_OBJ_NULL;
         pendsv_object = &MP_STATE_VM(mp_kbd_exception);
         SCB->ICSR = SCB_ICSR_PENDSVSET_Msk;
     }

--- a/ports/unix/unix_mphal.c
+++ b/ports/unix/unix_mphal.c
@@ -54,7 +54,7 @@ STATIC void sighandler(int signum) {
         sigprocmask(SIG_SETMASK, &mask, NULL);
         nlr_raise(MP_OBJ_FROM_PTR(&MP_STATE_VM(mp_kbd_exception)));
         #else
-        if (MP_STATE_THREAD(mp_pending_exception) == MP_OBJ_FROM_PTR(&MP_STATE_VM(mp_kbd_exception))) {
+        if (MP_STATE_MAIN_THREAD(mp_pending_exception) == MP_OBJ_FROM_PTR(&MP_STATE_VM(mp_kbd_exception))) {
             // this is the second time we are called, so die straight away
             exit(1);
         }

--- a/ports/unix/unix_mphal.c
+++ b/ports/unix/unix_mphal.c
@@ -54,7 +54,7 @@ STATIC void sighandler(int signum) {
         sigprocmask(SIG_SETMASK, &mask, NULL);
         nlr_raise(MP_OBJ_FROM_PTR(&MP_STATE_VM(mp_kbd_exception)));
         #else
-        if (MP_STATE_VM(mp_pending_exception) == MP_OBJ_FROM_PTR(&MP_STATE_VM(mp_kbd_exception))) {
+        if (MP_STATE_THREAD(mp_pending_exception) == MP_OBJ_FROM_PTR(&MP_STATE_VM(mp_kbd_exception))) {
             // this is the second time we are called, so die straight away
             exit(1);
         }

--- a/ports/windows/windows_mphal.c
+++ b/ports/windows/windows_mphal.c
@@ -80,7 +80,7 @@ void mp_hal_stdio_mode_orig(void) {
 // the thread created for handling it might not be running yet so we'd miss the notification.
 BOOL WINAPI console_sighandler(DWORD evt) {
     if (evt == CTRL_C_EVENT) {
-        if (MP_STATE_VM(mp_pending_exception) == MP_OBJ_FROM_PTR(&MP_STATE_VM(mp_kbd_exception))) {
+        if (MP_STATE_THREAD(mp_pending_exception) == MP_OBJ_FROM_PTR(&MP_STATE_VM(mp_kbd_exception))) {
             // this is the second time we are called, so die straight away
             exit(1);
         }

--- a/ports/windows/windows_mphal.c
+++ b/ports/windows/windows_mphal.c
@@ -80,7 +80,7 @@ void mp_hal_stdio_mode_orig(void) {
 // the thread created for handling it might not be running yet so we'd miss the notification.
 BOOL WINAPI console_sighandler(DWORD evt) {
     if (evt == CTRL_C_EVENT) {
-        if (MP_STATE_THREAD(mp_pending_exception) == MP_OBJ_FROM_PTR(&MP_STATE_VM(mp_kbd_exception))) {
+        if (MP_STATE_MAIN_THREAD(mp_pending_exception) == MP_OBJ_FROM_PTR(&MP_STATE_VM(mp_kbd_exception))) {
             // this is the second time we are called, so die straight away
             exit(1);
         }

--- a/py/modthread.c
+++ b/py/modthread.c
@@ -174,6 +174,8 @@ STATIC void *thread_entry(void *args_in) {
     // The GC starts off unlocked on this thread.
     ts.gc_lock_depth = 0;
 
+    ts.mp_pending_exception = MP_OBJ_NULL;
+
     // set locals and globals from the calling context
     mp_locals_set(args->dict_locals);
     mp_globals_set(args->dict_globals);
@@ -184,7 +186,6 @@ STATIC void *thread_entry(void *args_in) {
     mp_thread_start();
 
     // TODO set more thread-specific state here:
-    //  mp_pending_exception? (root pointer)
     //  cur_exception (root pointer)
 
     DEBUG_printf("[thread] start ts=%p args=%p stack=%p\n", &ts, &args, MP_STATE_THREAD(stack_top));

--- a/py/mpstate.h
+++ b/py/mpstate.h
@@ -286,11 +286,13 @@ extern mp_state_ctx_t mp_state_ctx;
 #define MP_STATE_VM(x) (mp_state_ctx.vm.x)
 #define MP_STATE_MEM(x) (mp_state_ctx.mem.x)
 
+#define MP_STATE_MAIN_THREAD(x) (mp_state_ctx.thread.x)
+
 #if MICROPY_PY_THREAD
 extern mp_state_thread_t *mp_thread_get_state(void);
 #define MP_STATE_THREAD(x) (mp_thread_get_state()->x)
 #else
-#define MP_STATE_THREAD(x) (mp_state_ctx.thread.x)
+#define MP_STATE_THREAD(x)  MP_STATE_MAIN_THREAD(x)
 #endif
 
 #endif // MICROPY_INCLUDED_PY_MPSTATE_H

--- a/py/mpstate.h
+++ b/py/mpstate.h
@@ -137,9 +137,6 @@ typedef struct _mp_state_vm_t {
     // dictionary with loaded modules (may be exposed as sys.modules)
     mp_obj_dict_t mp_loaded_modules_dict;
 
-    // pending exception object (MP_OBJ_NULL if not pending)
-    volatile mp_obj_t mp_pending_exception;
-
     #if MICROPY_ENABLE_SCHEDULER
     mp_sched_item_t sched_queue[MICROPY_SCHEDULER_DEPTH];
     #endif
@@ -265,6 +262,9 @@ typedef struct _mp_state_thread_t {
     mp_obj_dict_t *dict_globals;
 
     nlr_buf_t *nlr_top;
+
+    // pending exception object (MP_OBJ_NULL if not pending)
+    volatile mp_obj_t mp_pending_exception;
 
     #if MICROPY_PY_SYS_SETTRACE
     mp_obj_t prof_trace_callback;

--- a/py/profile.c
+++ b/py/profile.c
@@ -297,7 +297,7 @@ STATIC mp_obj_t mp_prof_callback_invoke(mp_obj_t callback, prof_callback_args_t 
 
     mp_prof_is_executing = false;
 
-    if (MP_STATE_VM(mp_pending_exception) != MP_OBJ_NULL) {
+    if (MP_STATE_THREAD(mp_pending_exception) != MP_OBJ_NULL) {
         mp_handle_pending(true);
     }
     return top;

--- a/py/runtime.c
+++ b/py/runtime.c
@@ -62,7 +62,7 @@ void mp_init(void) {
     qstr_init();
 
     // no pending exceptions to start with
-    MP_STATE_VM(mp_pending_exception) = MP_OBJ_NULL;
+    MP_STATE_THREAD(mp_pending_exception) = MP_OBJ_NULL;
     #if MICROPY_ENABLE_SCHEDULER
     MP_STATE_VM(sched_state) = MP_SCHED_IDLE;
     MP_STATE_VM(sched_idx) = 0;

--- a/py/scheduler.c
+++ b/py/scheduler.c
@@ -29,7 +29,7 @@
 #include "py/runtime.h"
 
 void MICROPY_WRAP_MP_SCHED_EXCEPTION(mp_sched_exception)(mp_obj_t exc) {
-    MP_STATE_VM(mp_pending_exception) = exc;
+    MP_STATE_THREAD(mp_pending_exception) = exc;
     #if MICROPY_ENABLE_SCHEDULER
     if (MP_STATE_VM(sched_state) == MP_SCHED_IDLE) {
         MP_STATE_VM(sched_state) = MP_SCHED_PENDING;
@@ -66,9 +66,9 @@ void mp_handle_pending(bool raise_exc) {
         mp_uint_t atomic_state = MICROPY_BEGIN_ATOMIC_SECTION();
         // Re-check state is still pending now that we're in the atomic section.
         if (MP_STATE_VM(sched_state) == MP_SCHED_PENDING) {
-            mp_obj_t obj = MP_STATE_VM(mp_pending_exception);
+            mp_obj_t obj = MP_STATE_THREAD(mp_pending_exception);
             if (obj != MP_OBJ_NULL) {
-                MP_STATE_VM(mp_pending_exception) = MP_OBJ_NULL;
+                MP_STATE_THREAD(mp_pending_exception) = MP_OBJ_NULL;
                 if (!mp_sched_num_pending()) {
                     MP_STATE_VM(sched_state) = MP_SCHED_IDLE;
                 }
@@ -115,7 +115,7 @@ void mp_sched_unlock(void) {
     assert(MP_STATE_VM(sched_state) < 0);
     if (++MP_STATE_VM(sched_state) == 0) {
         // vm became unlocked
-        if (MP_STATE_VM(mp_pending_exception) != MP_OBJ_NULL || mp_sched_num_pending()) {
+        if (MP_STATE_THREAD(mp_pending_exception) != MP_OBJ_NULL || mp_sched_num_pending()) {
             MP_STATE_VM(sched_state) = MP_SCHED_PENDING;
         } else {
             MP_STATE_VM(sched_state) = MP_SCHED_IDLE;
@@ -148,9 +148,9 @@ bool MICROPY_WRAP_MP_SCHED_SCHEDULE(mp_sched_schedule)(mp_obj_t function, mp_obj
 
 // A variant of this is inlined in the VM at the pending exception check
 void mp_handle_pending(bool raise_exc) {
-    if (MP_STATE_VM(mp_pending_exception) != MP_OBJ_NULL) {
-        mp_obj_t obj = MP_STATE_VM(mp_pending_exception);
-        MP_STATE_VM(mp_pending_exception) = MP_OBJ_NULL;
+    if (MP_STATE_THREAD(mp_pending_exception) != MP_OBJ_NULL) {
+        mp_obj_t obj = MP_STATE_THREAD(mp_pending_exception);
+        MP_STATE_THREAD(mp_pending_exception) = MP_OBJ_NULL;
         if (raise_exc) {
             nlr_raise(obj);
         }

--- a/py/scheduler.c
+++ b/py/scheduler.c
@@ -28,8 +28,10 @@
 
 #include "py/runtime.h"
 
+// Schedules an exception on the main thread (for exceptions "thrown" by async
+// sources such as interrupts and UNIX signal handlers).
 void MICROPY_WRAP_MP_SCHED_EXCEPTION(mp_sched_exception)(mp_obj_t exc) {
-    MP_STATE_THREAD(mp_pending_exception) = exc;
+    MP_STATE_MAIN_THREAD(mp_pending_exception) = exc;
     #if MICROPY_ENABLE_SCHEDULER
     if (MP_STATE_VM(sched_state) == MP_SCHED_IDLE) {
         MP_STATE_VM(sched_state) = MP_SCHED_PENDING;

--- a/py/vm.c
+++ b/py/vm.c
@@ -1375,9 +1375,9 @@ pending_exception_check:
                     // Re-check state is still pending now that we're in the atomic section.
                     if (MP_STATE_VM(sched_state) == MP_SCHED_PENDING) {
                         MARK_EXC_IP_SELECTIVE();
-                        mp_obj_t obj = MP_STATE_VM(mp_pending_exception);
+                        mp_obj_t obj = MP_STATE_THREAD(mp_pending_exception);
                         if (obj != MP_OBJ_NULL) {
-                            MP_STATE_VM(mp_pending_exception) = MP_OBJ_NULL;
+                            MP_STATE_THREAD(mp_pending_exception) = MP_OBJ_NULL;
                             if (!mp_sched_num_pending()) {
                                 MP_STATE_VM(sched_state) = MP_SCHED_IDLE;
                             }
@@ -1391,10 +1391,10 @@ pending_exception_check:
                 }
                 #else
                 // This is an inlined variant of mp_handle_pending
-                if (MP_STATE_VM(mp_pending_exception) != MP_OBJ_NULL) {
+                if (MP_STATE_THREAD(mp_pending_exception) != MP_OBJ_NULL) {
                     MARK_EXC_IP_SELECTIVE();
-                    mp_obj_t obj = MP_STATE_VM(mp_pending_exception);
-                    MP_STATE_VM(mp_pending_exception) = MP_OBJ_NULL;
+                    mp_obj_t obj = MP_STATE_THREAD(mp_pending_exception);
+                    MP_STATE_THREAD(mp_pending_exception) = MP_OBJ_NULL;
                     RAISE(obj);
                 }
                 #endif


### PR DESCRIPTION
This is a fix for https://github.com/micropython/micropython/issues/7026.

I have updated some old patches to the current master branch. We've been using this on the UNIX port for a over a year now. One thing I'm not sure about is what happens when both threads and the scheduler are enabled. Would it be possible for the scheduler run on a different thread and delay the pending exception on the main thread?