### PR TITLE
py/mkenv.mk: Don't emit info about BUILD_VERBOSE if it's set.

### DIFF
--- a/py/mkenv.mk
+++ b/py/mkenv.mk
@@ -20,16 +20,13 @@ ifeq ("$(origin V)", "command line")
 BUILD_VERBOSE=$(V)
 endif
 ifndef BUILD_VERBOSE
+$(info Use make V=1 or set BUILD_VERBOSE in your environment to increase build verbosity.)
 BUILD_VERBOSE = 0
 endif
 ifeq ($(BUILD_VERBOSE),0)
 Q = @
 else
 Q =
-endif
-# Since this is a new feature, advertise it
-ifeq ($(BUILD_VERBOSE),0)
-$(info Use make V=1 or set BUILD_VERBOSE in your environment to increase build verbosity.)
 endif
 
 # default settings; can be overridden in main Makefile


### PR DESCRIPTION
If the user sets V or BUILD_VERBOSE then they don't need to see this message.
