### PR TITLE
py/objarray: Fix constructing a memoryview from a memoryview.

### DIFF
--- a/py/objarray.c
+++ b/py/objarray.c
@@ -220,6 +220,14 @@ STATIC mp_obj_t memoryview_make_new(const mp_obj_type_t *type_in, size_t n_args,
         bufinfo.len / mp_binary_get_size('@', bufinfo.typecode, NULL),
         bufinfo.buf));
 
+    // If the input object is a memoryview then need to point the items of the
+    // new memoryview to the start of the buffer so the GC can trace it.
+    if (mp_obj_get_type(args[0]) == &mp_type_memoryview) {
+        mp_obj_array_t *other = MP_OBJ_TO_PTR(args[0]);
+        self->memview_offset = other->memview_offset;
+        self->items = other->items;
+    }
+
     // test if the object can be written to
     if (mp_get_buffer(args[0], &bufinfo, MP_BUFFER_RW)) {
         self->typecode |= MP_OBJ_ARRAY_TYPECODE_FLAG_RW; // indicate writable buffer

--- a/py/objarray.c
+++ b/py/objarray.c
@@ -201,11 +201,7 @@ STATIC mp_obj_t bytearray_make_new(const mp_obj_type_t *type_in, size_t n_args, 
 
 mp_obj_t mp_obj_new_memoryview(byte typecode, size_t nitems, void *items) {
     mp_obj_array_t *self = m_new_obj(mp_obj_array_t);
-    self->base.type = &mp_type_memoryview;
-    self->typecode = typecode;
-    self->memview_offset = 0;
-    self->len = nitems;
-    self->items = items;
+    mp_obj_memoryview_init(self, typecode, 0, nitems, items);
     return MP_OBJ_FROM_PTR(self);
 }
 

--- a/tests/basics/memoryview_gc.py
+++ b/tests/basics/memoryview_gc.py
@@ -21,3 +21,13 @@ for i in range(100000):
 
 # check that the memoryview is still what we want
 print(list(m))
+
+# check that creating a memoryview of a memoryview retains the underlying data
+m = None
+gc.collect()  # cleanup from previous test
+m = memoryview(memoryview(bytearray(i for i in range(50)))[5:-5])
+print(sum(m), list(m[:10]))
+gc.collect()
+for i in range(10):
+    list(range(10))  # allocate memory to overwrite any reclaimed heap
+print(sum(m), list(m[:10]))


### PR DESCRIPTION
Fixes issue #7261.

TODO:
- [x] improve the test so it triggers the bug (prior to this fix) on bare metal boards