### PR TITLE
tests/cpydiff: Add test and workaround for function.__module__ attr.

### DIFF
--- a/tests/cpydiff/core_function_moduleattr.py
+++ b/tests/cpydiff/core_function_moduleattr.py
@@ -1,0 +1,13 @@
+"""
+categories: Core,Functions
+description: Function objects do not have the ``__module__`` attribute
+cause: MicroPython is optimized for reduced code size and RAM usage.
+workaround: Use ``sys.modules[function.__globals__['__name__']]`` for non-builtin modules.
+"""
+
+
+def f():
+    pass
+
+
+print(f.__module__)


### PR DESCRIPTION
MicroPython does not store any reference from a function object to the module it was defined in, but there is a way to use function.__globals__ to indirectly get the module.

See issue #7259.