### PR TITLE
stm32/uart: Configure pull-up only on RX and CTS, not TX and RTS.

### DIFF
--- a/ports/stm32/uart.c
+++ b/ports/stm32/uart.c
@@ -474,10 +474,11 @@ bool uart_init(pyb_uart_obj_t *uart_obj,
     }
 
     uint32_t mode = MP_HAL_PIN_MODE_ALT;
-    uint32_t pull = MP_HAL_PIN_PULL_UP;
 
     for (uint i = 0; i < 4; i++) {
         if (pins[i] != NULL) {
+            // Configure pull-up on RX and CTS (the input pins).
+            uint32_t pull = (i & 1) ? MP_HAL_PIN_PULL_UP : MP_HAL_PIN_PULL_NONE;
             bool ret = mp_hal_pin_config_alt(pins[i], mode, pull, uart_fn, uart_unit);
             if (!ret) {
                 return false;


### PR DESCRIPTION
RX and CTS are the input pins and pull-ups are enabled so they don't cause a problem if left unconnected.

If needed, the pull-ups can be disabled in Python using machine.Pin after the UART is constructed.

See issue #4369.

