### PR TITLE
stm32/mboot: Leave bootloader from thread mode, not from IRQ.

### DIFF
--- a/ports/stm32/mboot/dfu.h
+++ b/ports/stm32/mboot/dfu.h
@@ -26,6 +26,7 @@
 #ifndef MICROPY_INCLUDED_STM32_MBOOT_DFU_H
 #define MICROPY_INCLUDED_STM32_MBOOT_DFU_H
 
+#include <stdbool.h>
 #include <stdint.h>
 
 // DFU spec: https://www.usb.org/sites/default/files/DFU_1.1.pdf
@@ -106,6 +107,7 @@ typedef struct _dfu_state_t {
     dfu_cmd_t cmd;
     dfu_status_t status;
     uint8_t error;
+    bool leave_dfu;
     uint16_t wBlockNum;
     uint16_t wLength;
     uint32_t addr;


### PR DESCRIPTION
Leaving the bootloader from an IRQ (eg USB or I2C IRQ) will not work if MBOOT_LEAVE_BOOTLOADER_VIA_RESET is disabled, ie if mboot jumps directly to the application.  This is because the CPU will still be in IRQ state when the application starts and IRQs of lower priority will be blocked.

Fix this by setting a flag when the bootloader should finish, and exit the bootloader always from the main (top level) thread.

This also improves the USB behaviour of mboot: it no longer abruptly disconnects when the manifest command is sent.

