### PR TITLE
stm32: Change from systick to soft-timer for BT scheduling, and improve BTstack run loop

### DIFF
--- a/extmod/btstack/btstack.mk
+++ b/extmod/btstack/btstack.mk
@@ -30,7 +30,6 @@ INC += -I$(BTSTACK_DIR)/3rd-party/yxml
 SRC_BTSTACK = \
 	$(addprefix lib/btstack/src/, $(SRC_FILES)) \
 	$(addprefix lib/btstack/src/ble/, $(filter-out %_tlv.c, $(SRC_BLE_FILES))) \
-	lib/btstack/platform/embedded/btstack_run_loop_embedded.c
 
 ifeq ($(MICROPY_BLUETOOTH_BTSTACK_USB),1)
 ifeq ($(MICROPY_BLUETOOTH_BTSTACK_H4),1)

--- a/extmod/btstack/btstack_hci_uart.c
+++ b/extmod/btstack/btstack_hci_uart.c
@@ -86,6 +86,7 @@ STATIC int btstack_uart_open(void) {
 
 STATIC int btstack_uart_close(void) {
     mp_bluetooth_hci_controller_deinit();
+    mp_bluetooth_hci_uart_deinit();
     return 0;
 }
 

--- a/ports/stm32/main.c
+++ b/ports/stm32/main.c
@@ -54,6 +54,7 @@
 #endif
 
 #include "boardctrl.h"
+#include "mpbthciport.h"
 #include "mpu.h"
 #include "rfcore.h"
 #include "systick.h"
@@ -440,8 +441,7 @@ void stm32_main(uint32_t reset_mode) {
     systick_enable_dispatch(SYSTICK_DISPATCH_LWIP, mod_network_lwip_poll_wrapper);
     #endif
     #if MICROPY_PY_BLUETOOTH
-    extern void mp_bluetooth_hci_systick(uint32_t ticks_ms);
-    systick_enable_dispatch(SYSTICK_DISPATCH_BLUETOOTH_HCI, mp_bluetooth_hci_systick);
+    mp_bluetooth_hci_init();
     #endif
 
     #if MICROPY_PY_NETWORK_CYW43

--- a/ports/stm32/mpbthciport.c
+++ b/ports/stm32/mpbthciport.c
@@ -3,7 +3,7 @@
  *
  * The MIT License (MIT)
  *
- * Copyright (c) 2018-2020 Damien P. George
+ * Copyright (c) 2018-2021 Damien P. George
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -28,7 +28,8 @@
 #include "py/mphal.h"
 #include "extmod/mpbthci.h"
 #include "extmod/modbluetooth.h"
-#include "systick.h"
+#include "mpbthciport.h"
+#include "softtimer.h"
 #include "pendsv.h"
 #include "lib/utils/mpirq.h"
 
@@ -38,21 +39,47 @@
 
 uint8_t mp_bluetooth_hci_cmd_buf[4 + 256];
 
-// Must be provided by the stack bindings (e.g. mpnimbleport.c or mpbtstackport.c).
-// Request new data from the uart and pass to the stack, and run pending events/callouts.
-extern void mp_bluetooth_hci_poll(void);
+// Soft timer for scheduling a HCI poll.
+STATIC soft_timer_entry_t mp_bluetooth_hci_soft_timer;
 
-// Hook for pendsv poller to run this periodically every 128ms
-#define BLUETOOTH_HCI_TICK(tick) (((tick) & ~(SYSTICK_DISPATCH_NUM_SLOTS - 1) & 0x7f) == 0)
+#if MICROPY_PY_BLUETOOTH_USE_SYNC_EVENTS
+// Prevent double-enqueuing of the scheduled task.
+STATIC volatile bool events_task_is_scheduled;
+#endif
+
+// This is called by soft_timer and executes at IRQ_PRI_PENDSV.
+STATIC void mp_bluetooth_hci_soft_timer_callback(soft_timer_entry_t *self) {
+    mp_bluetooth_hci_poll_now();
+}
+
+void mp_bluetooth_hci_init(void) {
+    #if MICROPY_PY_BLUETOOTH_USE_SYNC_EVENTS
+    events_task_is_scheduled = false;
+    #endif
+    soft_timer_static_init(
+        &mp_bluetooth_hci_soft_timer,
+        SOFT_TIMER_MODE_ONE_SHOT,
+        0,
+        mp_bluetooth_hci_soft_timer_callback
+        );
+}
+
+STATIC void mp_bluetooth_hci_start_polling(void) {
+    #if MICROPY_PY_BLUETOOTH_USE_SYNC_EVENTS
+    events_task_is_scheduled = false;
+    #endif
+    mp_bluetooth_hci_poll_now();
+}
+
+void mp_bluetooth_hci_poll_in_ms(uint32_t ms) {
+    soft_timer_reinsert(&mp_bluetooth_hci_soft_timer, ms);
+}
 
 #if MICROPY_PY_BLUETOOTH_USE_SYNC_EVENTS
 
 // For synchronous mode, we run all BLE stack code inside a scheduled task.
-// This task is scheduled periodically (every 128ms) via SysTick, or
+// This task is scheduled periodically via a soft timer, or
 // immediately on HCI UART RXIDLE.
-
-// Prevent double-enqueuing of the scheduled task.
-STATIC volatile bool events_task_is_scheduled = false;
 
 STATIC mp_obj_t run_events_scheduled_task(mp_obj_t none_in) {
     (void)none_in;
@@ -65,23 +92,20 @@ STATIC MP_DEFINE_CONST_FUN_OBJ_1(run_events_scheduled_task_obj, run_events_sched
 
 // Called periodically (systick) or directly (e.g. UART RX IRQ) in order to
 // request that processing happens ASAP in the scheduler.
-void mp_bluetooth_hci_systick(uint32_t ticks_ms) {
-    if (events_task_is_scheduled) {
-        return;
-    }
-
-    if (ticks_ms == 0 || BLUETOOTH_HCI_TICK(ticks_ms)) {
+void mp_bluetooth_hci_poll_now(void) {
+    if (!events_task_is_scheduled) {
         events_task_is_scheduled = mp_sched_schedule(MP_OBJ_FROM_PTR(&run_events_scheduled_task_obj), mp_const_none);
+        if (!events_task_is_scheduled) {
+            // The schedule queue is full, set callback to try again soon.
+            mp_bluetooth_hci_poll_in_ms(5);
+        }
     }
 }
 
 #else // !MICROPY_PY_BLUETOOTH_USE_SYNC_EVENTS
 
-// Called periodically (systick) or directly (e.g. uart irq).
-void mp_bluetooth_hci_systick(uint32_t ticks_ms) {
-    if (ticks_ms == 0 || BLUETOOTH_HCI_TICK(ticks_ms)) {
-        pendsv_schedule_dispatch(PENDSV_DISPATCH_BLUETOOTH_HCI, mp_bluetooth_hci_poll);
-    }
+void mp_bluetooth_hci_poll_now(void) {
+    pendsv_schedule_dispatch(PENDSV_DISPATCH_BLUETOOTH_HCI, mp_bluetooth_hci_poll);
 }
 
 #endif
@@ -104,13 +128,12 @@ int mp_bluetooth_hci_uart_init(uint32_t port, uint32_t baudrate) {
 
     DEBUG_printf("mp_bluetooth_hci_uart_init (stm32 rfcore)\n");
 
-    #if MICROPY_PY_BLUETOOTH_USE_SYNC_EVENTS
-    events_task_is_scheduled = false;
-    #endif
-
     rfcore_ble_init();
     hci_uart_rx_buf_cur = 0;
     hci_uart_rx_buf_len = 0;
+
+    // Start the HCI polling to process any initial events/packets.
+    mp_bluetooth_hci_start_polling();
 
     return 0;
 }
@@ -163,7 +186,6 @@ int mp_bluetooth_hci_uart_readchar(void) {
 /******************************************************************************/
 // HCI over UART
 
-#include "pendsv.h"
 #include "uart.h"
 
 pyb_uart_obj_t mp_bluetooth_hci_uart_obj;
@@ -173,7 +195,7 @@ static uint8_t hci_uart_rxbuf[768];
 
 mp_obj_t mp_uart_interrupt(mp_obj_t self_in) {
     // Queue up the scheduler to run the HCI UART and event processing ASAP.
-    mp_bluetooth_hci_systick(0);
+    mp_bluetooth_hci_poll_now();
 
     return mp_const_none;
 }
@@ -181,10 +203,6 @@ MP_DEFINE_CONST_FUN_OBJ_1(mp_uart_interrupt_obj, mp_uart_interrupt);
 
 int mp_bluetooth_hci_uart_init(uint32_t port, uint32_t baudrate) {
     DEBUG_printf("mp_bluetooth_hci_uart_init (stm32)\n");
-
-    #if MICROPY_PY_BLUETOOTH_USE_SYNC_EVENTS
-    events_task_is_scheduled = false;
-    #endif
 
     // bits (8), stop (1), parity (none) and flow (rts/cts) are assumed to match MYNEWT_VAL_BLE_HCI_UART_ constants in syscfg.h.
     mp_bluetooth_hci_uart_obj.base.type = &pyb_uart_type;
@@ -207,6 +225,9 @@ int mp_bluetooth_hci_uart_init(uint32_t port, uint32_t baudrate) {
     mp_bluetooth_hci_uart_irq_obj.handler = MP_OBJ_FROM_PTR(&mp_uart_interrupt_obj);
     mp_bluetooth_hci_uart_irq_obj.ishard = true;
     uart_irq_config(&mp_bluetooth_hci_uart_obj, true);
+
+    // Start the HCI polling to process any initial events/packets.
+    mp_bluetooth_hci_start_polling();
 
     return 0;
 }

--- a/ports/stm32/mpbtstackport.c
+++ b/ports/stm32/mpbtstackport.c
@@ -3,7 +3,7 @@
  *
  * The MIT License (MIT)
  *
- * Copyright (c) 2020 Damien P. George
+ * Copyright (c) 2020-2021 Damien P. George
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -31,30 +31,78 @@
 #if MICROPY_PY_BLUETOOTH && MICROPY_BLUETOOTH_BTSTACK
 
 #include "lib/btstack/src/btstack.h"
-#include "lib/btstack/platform/embedded/btstack_run_loop_embedded.h"
-#include "lib/btstack/platform/embedded/hal_cpu.h"
-#include "lib/btstack/platform/embedded/hal_time_ms.h"
-
 #include "extmod/mpbthci.h"
 #include "extmod/btstack/btstack_hci_uart.h"
 #include "extmod/btstack/modbluetooth_btstack.h"
 #include "mpbthciport.h"
 
-// The IRQ functionality in btstack_run_loop_embedded.c is not used, so the
-// following three functions are empty.
+void mp_bluetooth_hci_poll_in_ms(uint32_t ms);
 
-void hal_cpu_disable_irqs(void) {
+static btstack_linked_list_t mp_btstack_runloop_timers;
+
+static void mp_btstack_runloop_init(void) {
+    mp_btstack_runloop_timers = NULL;
 }
 
-void hal_cpu_enable_irqs(void) {
+static void mp_btstack_runloop_set_timer(btstack_timer_source_t *tim, uint32_t timeout_ms) {
+    tim->timeout = mp_hal_ticks_ms() + timeout_ms + 1;
 }
 
-void hal_cpu_enable_irqs_and_sleep(void) {
+static void mp_btstack_runloop_add_timer(btstack_timer_source_t *tim) {
+    btstack_linked_item_t **node = &mp_btstack_runloop_timers;
+    for (; *node; node = &(*node)->next) {
+        btstack_timer_source_t *node_tim = (btstack_timer_source_t *)*node;
+        if (node_tim == tim) {
+            // Timer is already in the list, don't add it.
+            return;
+        }
+        int32_t delta = btstack_time_delta(tim->timeout, node_tim->timeout);
+        if (delta < 0) {
+            // Found sorted location in list.
+            break;
+        }
+    }
+
+    // Insert timer into list in sorted location.
+    tim->item.next = *node;
+    *node = &tim->item;
+
+    // Reschedule the HCI poll if this timer is at the head of the list.
+    if (mp_btstack_runloop_timers == &tim->item) {
+        int32_t delta_ms = btstack_time_delta(tim->timeout, mp_hal_ticks_ms());
+        mp_bluetooth_hci_poll_in_ms(delta_ms);
+    }
 }
 
-uint32_t hal_time_ms(void) {
+static bool mp_btstack_runloop_remove_timer(btstack_timer_source_t *tim) {
+    return btstack_linked_list_remove(&mp_btstack_runloop_timers, (btstack_linked_item_t *)tim);
+}
+
+static void mp_btstack_runloop_execute(void) {
+    // Should not be called.
+}
+
+static void mp_btstack_runloop_dump_timer(void) {
+    // Not implemented/needed.
+}
+
+static uint32_t mp_btstack_runloop_get_time_ms(void) {
     return mp_hal_ticks_ms();
 }
+
+static const btstack_run_loop_t mp_btstack_runloop_stm32 = {
+    &mp_btstack_runloop_init,
+    NULL, // add_data_source,
+    NULL, // remove_data_source,
+    NULL, // enable_data_source_callbacks,
+    NULL, // disable_data_source_callbacks,
+    &mp_btstack_runloop_set_timer,
+    &mp_btstack_runloop_add_timer,
+    &mp_btstack_runloop_remove_timer,
+    &mp_btstack_runloop_execute,
+    &mp_btstack_runloop_dump_timer,
+    &mp_btstack_runloop_get_time_ms,
+};
 
 STATIC const hci_transport_config_uart_t hci_transport_config_uart = {
     HCI_TRANSPORT_CONFIG_UART,
@@ -69,26 +117,32 @@ void mp_bluetooth_hci_poll(void) {
         return;
     }
 
-    // Process uart data.
+    // Process UART data.
     if (mp_bluetooth_btstack_state != MP_BLUETOOTH_BTSTACK_STATE_HALTING) {
         mp_bluetooth_btstack_hci_uart_process();
     }
 
-    // Call the BTstack run loop.
-    btstack_run_loop_embedded_execute_once();
-
-    // Call this function again in 128ms to check for new events.
-    // TODO: improve this by only calling back when needed.
-    mp_bluetooth_hci_poll_in_ms(128);
+    // Process any BTstack timers.
+    while (mp_btstack_runloop_timers != NULL) {
+        btstack_timer_source_t *tim = (btstack_timer_source_t *)mp_btstack_runloop_timers;
+        int32_t delta_ms = btstack_time_delta(tim->timeout, mp_hal_ticks_ms());
+        if (delta_ms > 0) {
+            // Timer has not expired yet, reschedule HCI poll for this timer.
+            mp_bluetooth_hci_poll_in_ms(delta_ms);
+            break;
+        }
+        btstack_linked_list_pop(&mp_btstack_runloop_timers);
+        tim->process(tim);
+    }
 }
 
 void mp_bluetooth_btstack_port_init(void) {
     static bool run_loop_init = false;
     if (!run_loop_init) {
         run_loop_init = true;
-        btstack_run_loop_init(btstack_run_loop_embedded_get_instance());
+        btstack_run_loop_init(&mp_btstack_runloop_stm32);
     } else {
-        btstack_run_loop_embedded_get_instance()->init();
+        mp_btstack_runloop_stm32.init();
     }
 
     // hci_dump_open(NULL, HCI_DUMP_STDOUT);

--- a/ports/stm32/mpbtstackport.c
+++ b/ports/stm32/mpbtstackport.c
@@ -38,6 +38,7 @@
 #include "extmod/mpbthci.h"
 #include "extmod/btstack/btstack_hci_uart.h"
 #include "extmod/btstack/modbluetooth_btstack.h"
+#include "mpbthciport.h"
 
 // The IRQ functionality in btstack_run_loop_embedded.c is not used, so the
 // following three functions are empty.
@@ -75,6 +76,10 @@ void mp_bluetooth_hci_poll(void) {
 
     // Call the BTstack run loop.
     btstack_run_loop_embedded_execute_once();
+
+    // Call this function again in 128ms to check for new events.
+    // TODO: improve this by only calling back when needed.
+    mp_bluetooth_hci_poll_in_ms(128);
 }
 
 void mp_bluetooth_btstack_port_init(void) {

--- a/ports/stm32/mpnimbleport.c
+++ b/ports/stm32/mpnimbleport.c
@@ -40,6 +40,7 @@
 #include "extmod/modbluetooth.h"
 #include "extmod/nimble/modbluetooth_nimble.h"
 #include "extmod/nimble/hal/hal_uart.h"
+#include "mpbthciport.h"
 
 // Get any pending data from the UART and send it to NimBLE's HCI buffers.
 // Any further processing by NimBLE will be run via its event queue.
@@ -55,6 +56,12 @@ void mp_bluetooth_hci_poll(void) {
 
         // Run any remaining events (e.g. if there was no UART data).
         mp_bluetooth_nimble_os_eventq_run_all();
+    }
+
+    if (mp_bluetooth_nimble_ble_state != MP_BLUETOOTH_NIMBLE_BLE_STATE_OFF) {
+        // Call this function again in 128ms to check for new events.
+        // TODO: improve this by only calling back when needed.
+        mp_bluetooth_hci_poll_in_ms(128);
     }
 }
 

--- a/ports/stm32/rfcore.c
+++ b/ports/stm32/rfcore.c
@@ -32,6 +32,7 @@
 #include "py/mphal.h"
 #include "py/runtime.h"
 #include "extmod/modbluetooth.h"
+#include "mpbthciport.h"
 #include "rtc.h"
 #include "rfcore.h"
 
@@ -714,8 +715,7 @@ void IPCC_C1_RX_IRQHandler(void) {
 
         #if MICROPY_PY_BLUETOOTH
         // Queue up the scheduler to process UART data and run events.
-        extern void mp_bluetooth_hci_systick(uint32_t ticks_ms);
-        mp_bluetooth_hci_systick(0);
+        mp_bluetooth_hci_poll_now();
         #endif
     }
 

--- a/ports/stm32/softtimer.c
+++ b/ports/stm32/softtimer.c
@@ -122,6 +122,7 @@ void soft_timer_gc_mark_all(void) {
 }
 
 void soft_timer_static_init(soft_timer_entry_t *entry, uint16_t mode, uint32_t delta_ms, void (*cb)(soft_timer_entry_t *)) {
+    mp_pairheap_init_node(soft_timer_lt, &entry->pairheap);
     entry->flags = 0;
     entry->mode = mode;
     entry->delta_ms = delta_ms;

--- a/ports/stm32/softtimer.h
+++ b/ports/stm32/softtimer.h
@@ -56,4 +56,11 @@ void soft_timer_static_init(soft_timer_entry_t *entry, uint16_t mode, uint32_t d
 void soft_timer_insert(soft_timer_entry_t *entry, uint32_t initial_delta_ms);
 void soft_timer_remove(soft_timer_entry_t *entry);
 
+// The timer will be reinserted into the heap so that it is called after initial_delta_ms milliseconds.
+// After that, if it's periodic, it will continue to be called every entry->delta_ms milliseconds.
+static inline void soft_timer_reinsert(soft_timer_entry_t *entry, uint32_t initial_delta_ms) {
+    soft_timer_remove(entry);
+    soft_timer_insert(entry, initial_delta_ms);
+}
+
 #endif // MICROPY_INCLUDED_STM32_SOFTTIMER_H

--- a/ports/unix/Makefile
+++ b/ports/unix/Makefile
@@ -177,6 +177,7 @@ endif
 # BTstack is enabled.
 GIT_SUBMODULES += lib/btstack
 include $(TOP)/extmod/btstack/btstack.mk
+SRC_BTSTACK += lib/btstack/platform/embedded/btstack_run_loop_embedded.c
 
 else
 


### PR DESCRIPTION
In this PR:
- Add soft_timer_reinsert() helper function.
- Change from systick to soft-timer for BT scheduling.  Instead of using systick the BT subsystem is now scheduled using a soft timer.  This means it is scheduled only when it is enabled.
- Provide an efficient, custom BTstack runloop.  It reschedules the BT HCI poll soft timer so that it is called exactly when the next timer expires.

TODO:
- [x] more testing with combinations of NimBLE, BTstack, sync/non-sync BLE events, and WB55 boards