### PR TITLE
Esp32s2 changes

### DIFF
--- a/ports/esp32/boards/ESP32_S2_WROVER/mpconfigboard.h
+++ b/ports/esp32/boards/ESP32_S2_WROVER/mpconfigboard.h
@@ -6,10 +6,3 @@
 
 #define MICROPY_HW_I2C0_SCL                 (7)
 #define MICROPY_HW_I2C0_SDA                 (6)
-
-#define MICROPY_HW_SPI1_MOSI                (35)
-#define MICROPY_HW_SPI1_MISO                (37)
-#define MICROPY_HW_SPI1_SCK                 (36)
-#define MICROPY_HW_SPI2_MOSI                (11)
-#define MICROPY_HW_SPI2_MISO                (13)
-#define MICROPY_HW_SPI2_SCK                 (12)

--- a/ports/esp32/boards/GENERIC_S3/mpconfigboard.h
+++ b/ports/esp32/boards/GENERIC_S3/mpconfigboard.h
@@ -5,7 +5,3 @@
 
 #define MICROPY_HW_I2C0_SCL                 (9)
 #define MICROPY_HW_I2C0_SDA                 (8)
-
-#define MICROPY_HW_SPI1_MOSI                (35)
-#define MICROPY_HW_SPI1_MISO                (36)
-#define MICROPY_HW_SPI1_SCK                 (37)

--- a/ports/esp32/boards/GENERIC_S3_SPIRAM/mpconfigboard.h
+++ b/ports/esp32/boards/GENERIC_S3_SPIRAM/mpconfigboard.h
@@ -6,7 +6,3 @@
 
 #define MICROPY_HW_I2C0_SCL                 (9)
 #define MICROPY_HW_I2C0_SDA                 (8)
-
-#define MICROPY_HW_SPI1_MOSI                (35)
-#define MICROPY_HW_SPI1_MISO                (36)
-#define MICROPY_HW_SPI1_SCK                 (37)

--- a/ports/esp32/machine_hw_spi.c
+++ b/ports/esp32/machine_hw_spi.c
@@ -36,11 +36,31 @@
 
 #include "driver/spi_master.h"
 
-// Default pins for SPI(1), can be overridden by a board
+// SPI mappings by device, naming used by IDF old/new
+// upython   | ESP32     | ESP32S2   | ESP32S3 | ESP32C3
+// ----------+-----------+-----------+---------+---------
+// SPI(id=1) | HSPI/SPI2 | FSPI/SPI2 | SPI2    | SPI2
+// SPI(id=2) | VSPI/SPI3 | HSPI/SPI3 | SPI3    | err
+
+// Default pins for SPI(id=1) aka IDF SPI2, can be overridden by a board
 #ifndef MICROPY_HW_SPI1_SCK
-#define MICROPY_HW_SPI1_SCK (14)
-#define MICROPY_HW_SPI1_MOSI (13)
-#define MICROPY_HW_SPI1_MISO (12)
+#ifdef SPI2_IOMUX_PIN_NUM_CLK
+// Use IO_MUX pins by default.
+// If SPI lines are routed to other pins through GPIO matrix
+// routing adds some delay and lower limit applies to SPI clk freq
+#define MICROPY_HW_SPI1_SCK SPI2_IOMUX_PIN_NUM_CLK      // pin 14 on ESP32
+#define MICROPY_HW_SPI1_MOSI SPI2_IOMUX_PIN_NUM_MOSI    // pin 13 on ESP32
+#define MICROPY_HW_SPI1_MISO SPI2_IOMUX_PIN_NUM_MISO    // pin 12 on ESP32
+// Only for compatibility with IDF 4.2 and older
+#elif CONFIG_IDF_TARGET_ESP32S2
+#define MICROPY_HW_SPI1_SCK FSPI_IOMUX_PIN_NUM_CLK
+#define MICROPY_HW_SPI1_MOSI FSPI_IOMUX_PIN_NUM_MOSI
+#define MICROPY_HW_SPI1_MISO FSPI_IOMUX_PIN_NUM_MISO
+#else
+#define MICROPY_HW_SPI1_SCK HSPI_IOMUX_PIN_NUM_CLK
+#define MICROPY_HW_SPI1_MOSI HSPI_IOMUX_PIN_NUM_MOSI
+#define MICROPY_HW_SPI1_MISO HSPI_IOMUX_PIN_NUM_MISO
+#endif
 #endif
 
 // Default pins for SPI(2), can be overridden by a board

--- a/ports/esp32/machine_hw_spi.c
+++ b/ports/esp32/machine_hw_spi.c
@@ -458,7 +458,7 @@ mp_obj_t machine_hw_spi_make_new(const mp_obj_type_t *type, size_t n_args, size_
 
     machine_hw_spi_obj_t *self;
     const machine_hw_spi_default_pins_t *default_pins;
-    if (args[ARG_id].u_int == HSPI_HOST) {
+    if (args[ARG_id].u_int == 1) { // SPI2_HOST which is FSPI_HOST on ESP32Sx, HSPI_HOST on others
         self = &machine_hw_spi_obj[0];
         default_pins = &machine_hw_spi_default_pins[0];
     } else {

--- a/ports/esp32/machine_hw_spi.c
+++ b/ports/esp32/machine_hw_spi.c
@@ -63,11 +63,20 @@
 #endif
 #endif
 
-// Default pins for SPI(2), can be overridden by a board
+// Default pins for SPI(id=2) aka IFD SPI3, can be overridden by a board
 #ifndef MICROPY_HW_SPI2_SCK
-#define MICROPY_HW_SPI2_SCK (18)
-#define MICROPY_HW_SPI2_MOSI (23)
-#define MICROPY_HW_SPI2_MISO (19)
+#if CONFIG_IDF_TARGET_ESP32
+// ESP32 has IO_MUX pins for VSPI/SPI3 lines, use them as defaults
+#define MICROPY_HW_SPI2_SCK VSPI_IOMUX_PIN_NUM_CLK      // pin 18
+#define MICROPY_HW_SPI2_MOSI VSPI_IOMUX_PIN_NUM_MOSI    // pin 23
+#define MICROPY_HW_SPI2_MISO VSPI_IOMUX_PIN_NUM_MISO    // pin 19
+#elif CONFIG_IDF_TARGET_ESP32S2 || CONFIG_IDF_TARGET_ESP32S3
+// ESP32S2 and S3 uses GPIO matrix for SPI3 pins, no IO_MUX possible
+// Set defaults to the pins used by SPI2 in Octal mode
+#define MICROPY_HW_SPI2_SCK (36)
+#define MICROPY_HW_SPI2_MOSI (35)
+#define MICROPY_HW_SPI2_MISO (37)
+#endif
 #endif
 
 #define MP_HW_SPI_MAX_XFER_BYTES (4092)
@@ -108,7 +117,9 @@ typedef struct _machine_hw_spi_obj_t {
 // Default pin mappings for the hardware SPI instances
 STATIC const machine_hw_spi_default_pins_t machine_hw_spi_default_pins[2] = {
     { .sck = MICROPY_HW_SPI1_SCK, .mosi = MICROPY_HW_SPI1_MOSI, .miso = MICROPY_HW_SPI1_MISO },
+    #ifdef MICROPY_HW_SPI2_SCK
     { .sck = MICROPY_HW_SPI2_SCK, .mosi = MICROPY_HW_SPI2_MOSI, .miso = MICROPY_HW_SPI2_MISO },
+    #endif
 };
 
 // Static objects mapping to HSPI and VSPI hardware peripherals

--- a/ports/esp32/machine_pin.c
+++ b/ports/esp32/machine_pin.c
@@ -177,7 +177,11 @@ STATIC const machine_pin_obj_t machine_pin_obj[] = {
     {{NULL}, -1}, // 23 not a pin
     {{NULL}, -1}, // 24 not a pin
     {{NULL}, -1}, // 25 not a pin
-    {{NULL}, -1}, // 26 FLASH/PSRAM
+    #if CONFIG_SPIRAM
+    {{NULL}, -1}, // 26 PSRAM
+    #else
+    {{&machine_pin_type}, GPIO_NUM_26},
+    #endif
     {{NULL}, -1}, // 27 FLASH/PSRAM
     {{NULL}, -1}, // 28 FLASH/PSRAM
     {{NULL}, -1}, // 29 FLASH/PSRAM
@@ -618,7 +622,11 @@ STATIC const machine_pin_irq_obj_t machine_pin_irq_object[] = {
     {{NULL}, -1}, // 23 not a pin
     {{NULL}, -1}, // 24 not a pin
     {{NULL}, -1}, // 25 not a pin
-    {{NULL}, -1}, // 26 FLASH/PSRAM
+    #if CONFIG_SPIRAM
+    {{NULL}, -1}, // 26 PSRAM
+    #else
+    {{&machine_pin_irq_type}, GPIO_NUM_26},
+    #endif
     {{NULL}, -1}, // 27 FLASH/PSRAM
     {{NULL}, -1}, // 28 FLASH/PSRAM
     {{NULL}, -1}, // 29 FLASH/PSRAM


### PR DESCRIPTION
HW SPI did not work on esp32-s2:
```
MicroPython v1.15-74-gfb631644e on 2021-05-04; ESP32S2 module with ESP32S2
Type "help()" for more information.
>>> esp.osdebug(0,esp.LOG_DEBUG)
>>> from machine import SPI
>>> spi1=SPI(1)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
ValueError: SPI(1) doesn't exist
>>> spi2=SPI(2)
E (128705) spi: spi_bus_initialize(632): invalid dma channel
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
OSError: invalid configuration
```
The problem is caused by different SPI_HOST aliases for CONFIG_IDF_TARGET_ESP32S2
in esp-idf/components/hal/include/hal/spi_types.h:
```
#define FSPI_HOST   SPI2_HOST
#define HSPI_HOST   SPI3_HOST
```
There is no VSPI_HOST so SPI(1) does not exist.
HSPI_HOST moved from SPI2 to SPI3. That's why SPI(2) tried wrong DMA channel.

MicroPython v1.15 is no longer compatible with IDF 3.x so we can avoid [HVF]SPI_HOST
aliases and use SPI[123]_HOST directly. Also from IDF 4.3 we can use SPI_DMA_CH_AUTO
instead of selecting proper channel number.

The commit "esp32-s2: set default SPI pins for GENERIC_S2 board" sets proper default pins
for SPI(1) and SPI(2). The question is if we should not change the default pin definitions
MICROPY_HW_SPI1_SCK... based on CONFIG_IDF_TARGET_ESP32S2

The last commit "esp32-s2: make GPIO 26 usable if SPIRAM is not configured"
is not related to SPI - just adds GPIO 26 if not used as SPIRAM CS