### PR TITLE
STM32 FDCAN: Enable interrupts from peripheral.

### DIFF
--- a/ports/stm32/fdcan.c
+++ b/ports/stm32/fdcan.c
@@ -158,10 +158,11 @@ bool can_init(pyb_can_obj_t *can_obj, uint32_t mode, uint32_t prescaler, uint32_
             return false;
     }
 
-    __HAL_FDCAN_ENABLE_IT(&can_obj->can, FDCAN_IT_BUS_OFF | FDCAN_IT_ERROR_WARNING | FDCAN_IT_ERROR_PASSIVE);
-    __HAL_FDCAN_ENABLE_IT(&can_obj->can, FDCAN_IT_RX_FIFO0_NEW_MESSAGE | FDCAN_IT_RX_FIFO1_NEW_MESSAGE);
-    __HAL_FDCAN_ENABLE_IT(&can_obj->can, FDCAN_IT_RX_FIFO0_MESSAGE_LOST | FDCAN_IT_RX_FIFO1_MESSAGE_LOST);
-    __HAL_FDCAN_ENABLE_IT(&can_obj->can, FDCAN_IT_RX_FIFO0_FULL | FDCAN_IT_RX_FIFO1_FULL);
+    uint32_t ActiveITs = FDCAN_IT_BUS_OFF | FDCAN_IT_ERROR_WARNING | FDCAN_IT_ERROR_PASSIVE;
+	ActiveITs |= FDCAN_IT_RX_FIFO0_NEW_MESSAGE | FDCAN_IT_RX_FIFO1_NEW_MESSAGE;
+	ActiveITs |= FDCAN_IT_RX_FIFO0_MESSAGE_LOST | FDCAN_IT_RX_FIFO1_MESSAGE_LOST;
+	ActiveITs |= FDCAN_IT_RX_FIFO0_FULL | FDCAN_IT_RX_FIFO1_FULL;
+	HAL_FDCAN_ActivateNotification(&can_obj->can, ActiveITs, 0);
 
     return true;
 }


### PR DESCRIPTION
Enable interrupts from peripheral (select one of 2 interrupt lines to NVIC) by using HAL function.

Callback does not get called when a message is received, unless the first bit of the FDCAN_ILE is set. 

FDCAN has 2 interrupt lines fro peripheral to NVIC, and different internal interrupts can be connected to one of the two lines to the NVIC controller. After selection, the 2 interrupt lines need to be enabled. This is handled by the HAL function.