### PR TITLE
esp32/machine_rtc: Preserve RTC user memory over most reset causes.

### DIFF
--- a/ports/esp32/machine_rtc.c
+++ b/ports/esp32/machine_rtc.c
@@ -60,13 +60,23 @@ typedef struct _machine_rtc_obj_t {
 #define MICROPY_HW_RTC_USER_MEM_MAX     2048
 #endif
 
+// A board can enable MICROPY_HW_RTC_MEM_INIT_ALWAYS to always clear out RTC memory on boot.
+// Defaults to RTC_NOINIT_ATTR so the user memory survives WDT resets and the like.
+#if MICROPY_HW_RTC_MEM_INIT_ALWAYS
+#define _USER_MEM_ATTR RTC_DATA_ATTR
+#else
+#define _USER_MEM_ATTR RTC_NOINIT_ATTR
+#endif
+
 // Optionally compile user memory functionality if the size of memory is greater than 0
 #if MICROPY_HW_RTC_USER_MEM_MAX > 0
 #define MEM_MAGIC           0x75507921
-RTC_DATA_ATTR uint32_t rtc_user_mem_magic;
-RTC_DATA_ATTR uint16_t rtc_user_mem_len;
-RTC_DATA_ATTR uint8_t rtc_user_mem_data[MICROPY_HW_RTC_USER_MEM_MAX];
+_USER_MEM_ATTR uint32_t rtc_user_mem_magic;
+_USER_MEM_ATTR uint16_t rtc_user_mem_len;
+_USER_MEM_ATTR uint8_t rtc_user_mem_data[MICROPY_HW_RTC_USER_MEM_MAX];
 #endif
+
+#undef _USER_MEM_ATTR
 
 // singleton RTC object
 STATIC const machine_rtc_obj_t machine_rtc_obj = {{&machine_rtc_type}};
@@ -79,6 +89,13 @@ machine_rtc_config_t machine_rtc_config = {
 STATIC mp_obj_t machine_rtc_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *args) {
     // check arguments
     mp_arg_check_num(n_args, n_kw, 0, 0, false);
+
+    #if MICROPY_HW_RTC_USER_MEM_MAX > 0
+    if (rtc_user_mem_magic != MEM_MAGIC) {
+        rtc_user_mem_magic = MEM_MAGIC;
+        rtc_user_mem_len = 0;
+    }
+    #endif
 
     // return constant object
     return (mp_obj_t)&machine_rtc_obj;
@@ -129,13 +146,6 @@ STATIC MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(machine_rtc_datetime_obj, 1, 2, machi
 STATIC mp_obj_t machine_rtc_init(mp_obj_t self_in, mp_obj_t date) {
     mp_obj_t args[2] = {self_in, date};
     machine_rtc_datetime_helper(2, args);
-
-    #if MICROPY_HW_RTC_USER_MEM_MAX > 0
-    if (rtc_user_mem_magic != MEM_MAGIC) {
-        rtc_user_mem_magic = MEM_MAGIC;
-        rtc_user_mem_len = 0;
-    }
-    #endif
 
     return mp_const_none;
 }


### PR DESCRIPTION
ESP32: New compile-time #define allowing to preserve the RTC slow memory during most resets.

Usage:
```C
#define MICROPY_HW_RTC_USER_MEM_NOINIT
```
e.g. in port/esp32/board/XXX/mpconfigboard.h

When above is defined, the user memory area - accessible by `machine.RTC.memory()` will survive most reboot causes. A power-on reset (also caused by the EN pin on some boards) will clean the memory. When this happens, the magic number not found in the user memory will cause initialization.

After other resets (triggered by watchdogs, `machine.reset()`, ...), the user is responsible to check and validate the contents of the user area.