### PR TITLE
ports/samd: Add Flash() module and Class to utilise INTERNAL Flash.

### DIFF
--- a/ports/samd/modsamd.c
+++ b/ports/samd/modsamd.c
@@ -1,0 +1,44 @@
+/*
+ * This file is part of the MicroPython project, http://micropython.org/
+ *
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2019 Damien P. George
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+#include <stdio.h>
+
+#include "py/runtime.h"
+#include "samd_soc.h"
+#include "py/obj.h"
+
+extern const mp_obj_type_t samd_flash_type;
+
+
+STATIC const mp_rom_map_elem_t samd_module_globals_table[] = {
+    { MP_ROM_QSTR(MP_QSTR___name__), MP_ROM_QSTR(MP_QSTR_samd) },
+    { MP_ROM_QSTR(MP_QSTR_Flash), MP_ROM_PTR(&samd_flash_type) },
+};
+STATIC MP_DEFINE_CONST_DICT(samd_module_globals, samd_module_globals_table);
+
+const mp_obj_module_t mp_module_samd = {
+    .base = { &mp_type_module },
+    .globals = (mp_obj_dict_t *)&samd_module_globals,
+};

--- a/ports/samd/moduos.c
+++ b/ports/samd/moduos.c
@@ -1,0 +1,75 @@
+/*
+ * This file is part of the MicroPython project, http://micropython.org/
+ *
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2016 Damien P. George
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#include "py/runtime.h"
+#include "extmod/vfs.h"
+#include "extmod/vfs_fat.h"
+#include "extmod/vfs_lfs.h"
+
+STATIC const mp_rom_map_elem_t os_module_globals_table[] = {
+    { MP_ROM_QSTR(MP_QSTR___name__), MP_ROM_QSTR(MP_QSTR_uos) },
+
+    #if MICROPY_VFS
+    { MP_ROM_QSTR(MP_QSTR_chdir), MP_ROM_PTR(&mp_vfs_chdir_obj) },
+    { MP_ROM_QSTR(MP_QSTR_getcwd), MP_ROM_PTR(&mp_vfs_getcwd_obj) },
+    { MP_ROM_QSTR(MP_QSTR_listdir), MP_ROM_PTR(&mp_vfs_listdir_obj) },
+    { MP_ROM_QSTR(MP_QSTR_mkdir), MP_ROM_PTR(&mp_vfs_mkdir_obj) },
+    { MP_ROM_QSTR(MP_QSTR_remove), MP_ROM_PTR(&mp_vfs_remove_obj) },
+    { MP_ROM_QSTR(MP_QSTR_rename), MP_ROM_PTR(&mp_vfs_rename_obj) },
+    { MP_ROM_QSTR(MP_QSTR_rmdir), MP_ROM_PTR(&mp_vfs_rmdir_obj) },
+    { MP_ROM_QSTR(MP_QSTR_stat), MP_ROM_PTR(&mp_vfs_stat_obj) },
+    { MP_ROM_QSTR(MP_QSTR_statvfs), MP_ROM_PTR(&mp_vfs_statvfs_obj) },
+    #endif
+
+    // The following are MicroPython extensions.
+
+    #if MICROPY_PY_OS_DUPTERM
+    { MP_ROM_QSTR(MP_QSTR_dupterm), MP_ROM_PTR(&mp_uos_dupterm_obj) },
+    #endif
+
+    #if MICROPY_VFS
+    { MP_ROM_QSTR(MP_QSTR_ilistdir), MP_ROM_PTR(&mp_vfs_ilistdir_obj) },
+    { MP_ROM_QSTR(MP_QSTR_mount), MP_ROM_PTR(&mp_vfs_mount_obj) },
+    { MP_ROM_QSTR(MP_QSTR_umount), MP_ROM_PTR(&mp_vfs_umount_obj) },
+    #if MICROPY_VFS_FAT
+    { MP_ROM_QSTR(MP_QSTR_VfsFat), MP_ROM_PTR(&mp_fat_vfs_type) },
+    #endif
+    #if MICROPY_VFS_LFS1
+    { MP_ROM_QSTR(MP_QSTR_VfsLfs1), MP_ROM_PTR(&mp_type_vfs_lfs1) },
+    #endif
+    #if MICROPY_VFS_LFS2
+    { MP_ROM_QSTR(MP_QSTR_VfsLfs2), MP_ROM_PTR(&mp_type_vfs_lfs2) },
+    #endif
+    #endif
+};
+STATIC MP_DEFINE_CONST_DICT(os_module_globals, os_module_globals_table);
+
+const mp_obj_module_t mp_module_uos = {
+    .base = { &mp_type_module },
+    .globals = (mp_obj_dict_t *)&os_module_globals,
+};
+
+MP_REGISTER_MODULE(MP_QSTR_uos, mp_module_uos, MICROPY_PY_UOS);

--- a/ports/samd/samd_flash.c
+++ b/ports/samd/samd_flash.c
@@ -1,0 +1,196 @@
+/*
+ * This file is part of the MicroPython project, http://micropython.org/
+ *
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2019 Damien P. George
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+#include <stdio.h>
+
+#include "py/runtime.h"
+#include "extmod/vfs.h"
+#include "samd_soc.h"
+#include "hal_flash.h"
+
+// ASF 4
+#include "hal_flash.h"
+#include "hal_init.h"
+#include "hpl_gclk_base.h"
+
+#if defined(MCU_SAMD21)
+#include "lib/asf4/samd21/hpl/pm/hpl_pm_base.h"
+#elif defined(MCU_SAMD51)
+#include "lib/asf4/samd51/hpl/pm/hpl_pm_base.h"
+#include "lib/asf4/samd51/hri/hri_mclk_d51.h"
+#endif
+
+
+static struct flash_descriptor flash_desc;
+//STATIC mp_int_t BLOCK_SIZE = 1536; //24x 64B flash pages;
+STATIC mp_int_t BLOCK_SIZE = VFS_BLOCK_SIZE_BYTES; // Board specific: mpconfigboard.h
+extern const mp_obj_type_t samd_flash_type;
+
+typedef struct _samd_flash_obj_t {
+    mp_obj_base_t base;
+    uint32_t flash_base;
+    uint32_t flash_size;
+} samd_flash_obj_t;
+
+// Build a Flash storage at top. 
+STATIC samd_flash_obj_t samd_flash_obj = {
+    .base = { &samd_flash_type },
+    .flash_base = MICROPY_HW_FLASH_STORAGE_BASE, // Board specific: mpconfigboard.h
+    .flash_size = MICROPY_HW_FLASH_STORAGE_BYTES, // Board specific: mpconfigboard.h
+};
+
+// FLASH stuff
+STATIC mp_obj_t samd_flash_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *all_args) {
+    // No args required. bdev=Flash(). Start Addr & Size defined in samd_flash_obj.
+    mp_arg_check_num(n_args, n_kw, 0,0, false);
+
+    // Return singleton object.
+    return MP_OBJ_FROM_PTR(&samd_flash_obj);
+}
+
+// Flash init (from cctpy)
+// Method is needed for when MP starts up in _boot.py
+STATIC mp_obj_t samd_flash_init(void) {
+    #ifdef SAMD51
+    hri_mclk_set_AHBMASK_NVMCTRL_bit(MCLK);
+    #endif
+    #ifdef SAMD21
+    _pm_enable_bus_clock(PM_BUS_APBB, NVMCTRL);
+    #endif
+
+    flash_init(&flash_desc, NVMCTRL);
+    return mp_const_none;
+}
+STATIC MP_DEFINE_CONST_FUN_OBJ_0(samd_flash_init_obj, samd_flash_init);
+
+// Function for ioctl.
+STATIC mp_obj_t eraseblock(uint32_t sector_in) {
+    // Destination address aligned with page start to be erased.
+    uint32_t DEST_ADDR = sector_in; // Number of pages to be erased.
+    mp_int_t PAGE_SIZE = flash_get_page_size(&flash_desc); // adf4 API call
+
+    flash_erase(&flash_desc,DEST_ADDR,(BLOCK_SIZE / PAGE_SIZE));
+
+    return mp_const_none;
+}
+
+STATIC mp_obj_t samd_flash_version(void) {
+    printf("Flash Driver Version: %lu\n", flash_get_version());
+    return mp_const_none;
+}
+MP_DEFINE_CONST_FUN_OBJ_0(samd_flash_version_obj, samd_flash_version);
+
+
+STATIC mp_obj_t samd_flash_size(void) {
+    // adf4 API calls
+    mp_int_t PAGES = flash_get_total_pages(&flash_desc);
+    mp_int_t PAGE_SIZE = flash_get_page_size(&flash_desc);
+    printf("Flash Size: %u Bytes\n",  PAGES*PAGE_SIZE);
+    return mp_const_none;
+}
+MP_DEFINE_CONST_FUN_OBJ_0(samd_flash_size_obj, samd_flash_size);
+
+
+STATIC mp_obj_t samd_flash_readblocks(size_t n_args, const mp_obj_t *args) {
+    uint32_t offset = (mp_obj_get_int(args[1]) * BLOCK_SIZE) + samd_flash_obj.flash_base;
+    mp_buffer_info_t bufinfo;
+    mp_get_buffer_raise(args[2], &bufinfo, MP_BUFFER_WRITE);
+    if (n_args == 4) {
+        offset += mp_obj_get_int(args[3]);
+    }
+
+    // Read data to flash (adf4 API)
+    flash_read(&flash_desc,offset,bufinfo.buf,bufinfo.len);
+
+    return mp_const_none;
+}
+
+STATIC MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(samd_flash_readblocks_obj, 3, 4, samd_flash_readblocks);
+
+
+STATIC mp_obj_t samd_flash_writeblocks(size_t n_args, const mp_obj_t *args) {
+    uint32_t offset = (mp_obj_get_int(args[1]) * BLOCK_SIZE) + samd_flash_obj.flash_base;
+    mp_buffer_info_t bufinfo;
+    mp_get_buffer_raise(args[2], &bufinfo, MP_BUFFER_READ);
+    if (n_args == 3) {
+        eraseblock(offset);
+        // TODO check return value
+    } else {
+        offset += mp_obj_get_int(args[3]);
+    }
+    // Write data to flash (adf4 API)
+    flash_write(&flash_desc,offset, bufinfo.buf, bufinfo.len);
+    // TODO check return value
+    return mp_const_none;
+}
+
+STATIC MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(samd_flash_writeblocks_obj, 3, 4, samd_flash_writeblocks);
+
+
+STATIC mp_obj_t samd_flash_ioctl(mp_obj_t self_in, mp_obj_t cmd_in, mp_obj_t arg_in) {
+    samd_flash_obj_t *self = MP_OBJ_TO_PTR(self_in);
+    mp_int_t cmd = mp_obj_get_int(cmd_in);
+
+    switch (cmd) {
+        case MP_BLOCKDEV_IOCTL_INIT:
+            samd_flash_init();
+            return MP_OBJ_NEW_SMALL_INT(0);
+        case MP_BLOCKDEV_IOCTL_DEINIT:
+            return MP_OBJ_NEW_SMALL_INT(0);
+        case MP_BLOCKDEV_IOCTL_SYNC:
+            return MP_OBJ_NEW_SMALL_INT(0);
+        case MP_BLOCKDEV_IOCTL_BLOCK_COUNT:
+            return MP_OBJ_NEW_SMALL_INT(self->flash_size / BLOCK_SIZE);
+        case MP_BLOCKDEV_IOCTL_BLOCK_SIZE:
+            return MP_OBJ_NEW_SMALL_INT(BLOCK_SIZE);
+        case MP_BLOCKDEV_IOCTL_BLOCK_ERASE: {
+            eraseblock(mp_obj_get_int(arg_in) * BLOCK_SIZE + samd_flash_obj.flash_base);
+            // TODO check return value
+            return MP_OBJ_NEW_SMALL_INT(0);
+        }
+        default:
+            return mp_const_none;
+    }
+}
+
+STATIC MP_DEFINE_CONST_FUN_OBJ_3(samd_flash_ioctl_obj, samd_flash_ioctl);
+
+
+STATIC const mp_rom_map_elem_t samd_flash_locals_dict_table[] = {
+    { MP_ROM_QSTR(MP_QSTR_flash_version), MP_ROM_PTR(&samd_flash_version_obj) },
+    { MP_ROM_QSTR(MP_QSTR_flash_size), MP_ROM_PTR(&samd_flash_size_obj) },
+    { MP_ROM_QSTR(MP_QSTR_flash_init), MP_ROM_PTR(&samd_flash_init_obj) },
+    { MP_ROM_QSTR(MP_QSTR_readblocks), MP_ROM_PTR(&samd_flash_readblocks_obj) },
+    { MP_ROM_QSTR(MP_QSTR_writeblocks), MP_ROM_PTR(&samd_flash_writeblocks_obj) },
+    { MP_ROM_QSTR(MP_QSTR_ioctl), MP_ROM_PTR(&samd_flash_ioctl_obj) },
+};
+STATIC MP_DEFINE_CONST_DICT(samd_flash_locals_dict, samd_flash_locals_dict_table);
+
+const mp_obj_type_t samd_flash_type = {
+    { &mp_type_type },
+    .name = MP_QSTR_Flash,
+    .make_new = samd_flash_make_new,
+    .locals_dict = (mp_obj_dict_t *)&samd_flash_locals_dict,
+};


### PR DESCRIPTION
This PR adds a 'samd' module that includes a Flash() class that **only** accesses the **internal** Flash. The internal flash is shared with non volatile program space used by the bootloader and the MicroPython code. Depending on the SAMD chip, a LSF1 block device is created at the top of Flash of either 64kB (SAMD21) or 128kB (SAMD51) set in the board's `mpconfigboard.h`.

- `ports/samd/modsamd.c`: Add the 'samd' module to MicroPython.
- `ports/samd/moduos.c`: Adds UOS functions to the Port.
- `ports/samd/samd_flash.c`: Adds internal flash block device and necessary block device functions.