### PR TITLE
ports/samd: Updates the 'machine' module adding Pin(), Led(), uart() & unique_id()

### DIFF
--- a/ports/samd/machine_led.c
+++ b/ports/samd/machine_led.c
@@ -1,0 +1,193 @@
+/*
+ * This is part of the MicroPython project, http://micropython.org/
+ *
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2016-2021 Damien P. George
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * Uses pins.h & pins.c to create board (MCU package) specific 'machine_led_obj' array.
+ */
+
+#include <stdio.h>
+#include <string.h>
+
+#include "py/runtime.h"
+#include "py/mphal.h"
+#include "lib/utils/mpirq.h"
+#include "modmachine.h"
+#include "extmod/virtpin.h"
+
+#include "pins.h" // boards/<BOARD>/
+
+// ASF4 (MCU package specific pin defs in 'boards')
+#include "hal_gpio.h"
+#include "hpl_gpio.h"
+#include "hal_atomic.h"
+
+
+#define GPIO_MODE_OUT (1)
+
+
+// Macros to access the state of the hardware.
+
+STATIC void machine_led_print(const mp_print_t *print, mp_obj_t self_in, mp_print_kind_t kind)
+{
+    machine_led_obj_t *self = self_in;
+    mp_printf(print, "Pin(%u)", self->id);
+}
+
+// pin.init(mode, pull=None, *, value=None, alt=FUNC_SIO)
+STATIC mp_obj_t machine_led_obj_init_helper(const machine_led_obj_t *self, size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
+    enum { ARG_mode, ARG_value};
+    static const mp_arg_t allowed_args[] = {
+        { MP_QSTR_mode, MP_ARG_OBJ, {.u_rom_obj = MP_ROM_NONE}},
+        { MP_QSTR_value, MP_ARG_KW_ONLY | MP_ARG_OBJ, {.u_rom_obj = MP_ROM_NONE}},
+    };
+
+    // parse args
+    mp_arg_val_t args[MP_ARRAY_SIZE(allowed_args)];
+    mp_arg_parse_all(n_args, pos_args, kw_args, MP_ARRAY_SIZE(allowed_args), allowed_args, args);
+
+    // set initial value (do this before configuring mode/pull)
+    if (args[ARG_value].u_obj != mp_const_none) {
+        gpio_set_pin_level(self->id, mp_obj_is_true(args[ARG_value].u_obj));
+    }
+
+    // configure mode
+    gpio_set_pin_direction(self->id, GPIO_DIRECTION_OUT);
+
+    return mp_const_none;
+}
+
+// constructor(id, ...)
+mp_obj_t mp_led_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *args) {
+    mp_arg_check_num(n_args, n_kw, 1, MP_OBJ_FUN_ARGS_MAX, true);
+
+    // get the wanted pin object
+    int wanted_pin = mp_obj_get_int(args[0]);
+    const machine_led_obj_t *self = NULL;
+    if (0 <= wanted_pin && wanted_pin < MP_ARRAY_SIZE(machine_led_obj)) {
+        self = (machine_led_obj_t *)&machine_led_obj[wanted_pin];
+    }
+
+    // the array could be padded with 'nulls' (see other Ports).
+    // Will also error if the asked for pin (index) is greater than the array row size.
+    if (self == NULL || self->base.type == NULL) {
+        mp_raise_ValueError(MP_ERROR_TEXT("invalid pin"));
+    }
+
+    // If the previous test is true, we dont get this far...
+
+    if (n_args > 1 || n_kw > 0) {
+        // pin mode given, so configure this GPIO
+        mp_map_t kw_args;
+        mp_map_init_fixed_table(&kw_args, n_kw, args + n_args);
+        machine_led_obj_init_helper(self, n_args - 1, args + 1, &kw_args);
+    }
+
+    return MP_OBJ_FROM_PTR(self);
+}
+
+
+// fast method for getting/setting pin value
+STATIC mp_obj_t machine_led_call(mp_obj_t self_in, size_t n_args, size_t n_kw, const mp_obj_t *args) {
+    mp_arg_check_num(n_args, n_kw, 0, 1, false);
+    machine_led_obj_t *self = self_in;
+    if (n_args == 0) {
+        // get pin
+        return MP_OBJ_NEW_SMALL_INT(gpio_get_pin_level(self->id));
+    } else {
+        // set pin
+        bool value = mp_obj_is_true(args[0]);
+        gpio_set_pin_level(self->id, value);
+        
+        return mp_const_none;
+    }
+}
+
+// pin.init(mode)
+STATIC mp_obj_t machine_led_obj_init(size_t n_args, const mp_obj_t *args, mp_map_t *kw_args) {
+    return machine_led_obj_init_helper(args[0], n_args - 1, args + 1, kw_args);
+}
+MP_DEFINE_CONST_FUN_OBJ_KW(machine_led_init_obj, 1, machine_led_obj_init);
+
+// pin.value([value])
+STATIC mp_obj_t machine_led_value(size_t n_args, const mp_obj_t *args) {
+    return machine_led_call(args[0], n_args - 1, 0, args + 1);
+}
+STATIC MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(machine_led_value_obj, 1, 2, machine_led_value);
+
+// pin.low()
+STATIC mp_obj_t machine_led_low(mp_obj_t self_in) {
+    machine_led_obj_t *self = MP_OBJ_TO_PTR(self_in);
+    gpio_set_pin_direction(self->id, GPIO_DIRECTION_OUT);
+    gpio_set_pin_level(self->id, false);
+
+    return mp_const_none;
+}
+STATIC MP_DEFINE_CONST_FUN_OBJ_1(machine_led_low_obj, machine_led_low);
+
+// pin.high()
+STATIC mp_obj_t machine_led_high(mp_obj_t self_in) {
+    machine_led_obj_t *self = MP_OBJ_TO_PTR(self_in);
+    gpio_set_pin_direction(self->id, GPIO_DIRECTION_OUT);
+    gpio_set_pin_level(self->id, true);
+
+    return mp_const_none;
+}
+STATIC MP_DEFINE_CONST_FUN_OBJ_1(machine_led_high_obj, machine_led_high);
+
+// pin.toggle()
+STATIC mp_obj_t machine_led_toggle(mp_obj_t self_in) {
+    machine_led_obj_t *self = MP_OBJ_TO_PTR(self_in);
+    gpio_set_pin_direction(self->id, GPIO_DIRECTION_OUT);
+    gpio_toggle_pin_level(self->id);
+
+    return mp_const_none;
+}
+STATIC MP_DEFINE_CONST_FUN_OBJ_1(machine_led_toggle_obj, machine_led_toggle);
+
+
+STATIC const mp_rom_map_elem_t machine_led_locals_dict_table[] = {
+    // instance methods
+    { MP_ROM_QSTR(MP_QSTR_init), MP_ROM_PTR(&machine_led_init_obj) },
+    { MP_ROM_QSTR(MP_QSTR_value), MP_ROM_PTR(&machine_led_value_obj) },
+    { MP_ROM_QSTR(MP_QSTR_low), MP_ROM_PTR(&machine_led_low_obj) },
+    { MP_ROM_QSTR(MP_QSTR_high), MP_ROM_PTR(&machine_led_high_obj) },
+    { MP_ROM_QSTR(MP_QSTR_off), MP_ROM_PTR(&machine_led_low_obj) },
+    { MP_ROM_QSTR(MP_QSTR_on), MP_ROM_PTR(&machine_led_high_obj) },
+    { MP_ROM_QSTR(MP_QSTR_toggle), MP_ROM_PTR(&machine_led_toggle_obj) },
+
+    // class constants
+    { MP_ROM_QSTR(MP_QSTR_OUT), MP_ROM_INT(GPIO_MODE_OUT) },
+};
+STATIC MP_DEFINE_CONST_DICT(machine_led_locals_dict, machine_led_locals_dict_table);
+
+const mp_obj_type_t machine_led_type = {
+    { &mp_type_type },
+    .name = MP_QSTR_Led,
+    .print = machine_led_print,
+    .make_new = mp_led_make_new,
+    .call = machine_led_call,
+    //.protocol = &pin_pin_p,
+    .locals_dict = (mp_obj_t)&machine_led_locals_dict,
+};
+

--- a/ports/samd/machine_pin.c
+++ b/ports/samd/machine_pin.c
@@ -1,0 +1,349 @@
+/*
+ * This is part of the MicroPython project, http://micropython.org/
+ *
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2016-2021 Damien P. George
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * Uses pins.h & pins.c to create board (MCU package) specific 'machine_pin_obj' array.
+ */
+
+#include <stdio.h>
+#include <string.h>
+
+#include "py/runtime.h"
+#include "py/mphal.h"
+#include "lib/utils/mpirq.h"
+#include "modmachine.h"
+#include "extmod/virtpin.h"
+#include "samd_soc.h"
+
+#include "pins.h" // boards/<BOARD>/
+
+// ASF4 (MCU package specific pin defs in 'boards')
+#include "hal_gpio.h"
+#include "hpl_gpio.h"
+#include "hal_atomic.h"
+
+#define GPIO_MODE_IN (0)
+#define GPIO_MODE_OUT (1)
+//#define GPIO_MODE_ALT (3)
+
+#define GPIO_STRENGTH_2MA (0)
+#define GPIO_STRENGTH_8MA (1)
+
+// asf4 hpl_gpio.h gpio_pull_mode
+
+typedef struct _machine_pin_irq_obj_t {
+    mp_irq_obj_t base;
+    uint32_t flags;
+    uint32_t trigger;
+} machine_pin_irq_obj_t;
+
+STATIC const mp_irq_methods_t machine_pin_irq_methods;
+
+
+STATIC void machine_pin_print(const mp_print_t *print, mp_obj_t self_in, mp_print_kind_t kind)
+{
+    machine_pin_obj_t *self = self_in;
+    mp_printf(print, "Pin(%u)", self->id);
+}
+
+STATIC void pin_validate_drive(bool strength) {
+    if (strength != GPIO_STRENGTH_2MA && strength != GPIO_STRENGTH_8MA) {
+        mp_raise_ValueError(MP_ERROR_TEXT("invalid argument(s) value"));
+    }
+}
+
+
+// pin.init(mode, pull=None, *, value=None, drive=0). No 'alt' yet.
+STATIC mp_obj_t machine_pin_obj_init_helper(const machine_pin_obj_t *self, size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
+    enum { ARG_mode, ARG_pull, ARG_value, ARG_drive, ARG_alt };
+    static const mp_arg_t allowed_args[] = {
+        { MP_QSTR_mode, MP_ARG_OBJ, {.u_rom_obj = MP_ROM_NONE}},
+        { MP_QSTR_pull, MP_ARG_OBJ, {.u_rom_obj = MP_ROM_NONE}},
+        { MP_QSTR_value, MP_ARG_KW_ONLY | MP_ARG_OBJ, {.u_rom_obj = MP_ROM_NONE}},
+        { MP_QSTR_drive, MP_ARG_KW_ONLY | MP_ARG_INT, {.u_int = GPIO_STRENGTH_2MA} },
+    };
+
+    // parse args
+    mp_arg_val_t args[MP_ARRAY_SIZE(allowed_args)];
+    mp_arg_parse_all(n_args, pos_args, kw_args, MP_ARRAY_SIZE(allowed_args), allowed_args, args);
+
+    // set initial value (do this before configuring mode/pull)
+    if (args[ARG_value].u_obj != mp_const_none) {
+        gpio_set_pin_level(self->id, mp_obj_is_true(args[ARG_value].u_obj));
+    }
+
+    // configure mode
+    if (args[ARG_mode].u_obj != mp_const_none) {
+        mp_int_t mode = mp_obj_get_int(args[ARG_mode].u_obj);
+        if (mode == GPIO_MODE_IN) {
+            gpio_set_pin_direction(self->id, GPIO_DIRECTION_IN);
+        } else if (mode == GPIO_MODE_OUT) {
+            gpio_set_pin_direction(self->id, GPIO_DIRECTION_OUT);
+        } 
+    else {
+        gpio_set_pin_direction(self->id, GPIO_DIRECTION_IN); // If no args are given, the Pin is 'input'.
+        }
+    }
+    // configure pull. Only to be used with IN mode. The function sets the pin to INPUT.
+    uint32_t pull = 0;
+    mp_int_t mode = mp_obj_get_int(args[ARG_mode].u_obj);
+    if (mode == GPIO_MODE_OUT && args[ARG_pull].u_obj != mp_const_none) {
+        printf("PULL ignored. Only to be used with IN mode.\n");
+    } else if (args[ARG_pull].u_obj != mp_const_none) {
+        pull = mp_obj_get_int(args[ARG_pull].u_obj);
+        printf("Pull: (%lu)\n", pull);
+        gpio_set_pin_pull_mode(self->id, pull); // hal_gpio.h
+    }
+
+    // get the strength
+    bool strength = args[3].u_int;
+    pin_validate_drive(strength);
+
+    return mp_const_none;
+}
+
+// constructor(id, ...)
+mp_obj_t mp_pin_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *args) {
+    mp_arg_check_num(n_args, n_kw, 1, MP_OBJ_FUN_ARGS_MAX, true);
+
+    // get the wanted pin object
+    int wanted_pin = mp_obj_get_int(args[0]);
+
+    const machine_pin_obj_t *self = NULL;
+    if (0 <= wanted_pin && wanted_pin < MP_ARRAY_SIZE(machine_pin_obj)) {
+        self = (machine_pin_obj_t *)&machine_pin_obj[wanted_pin];
+    }
+
+    if (self == NULL || self->base.type == NULL) {
+        mp_raise_ValueError(MP_ERROR_TEXT("invalid pin"));
+    }
+        self = (machine_pin_obj_t *)&machine_pin_obj[wanted_pin];
+
+    if (n_args > 1 || n_kw > 0) {
+        // pin mode given, so configure this GPIO
+        mp_map_t kw_args;
+        mp_map_init_fixed_table(&kw_args, n_kw, args + n_args);
+        machine_pin_obj_init_helper(self, n_args - 1, args + 1, &kw_args);
+    }
+
+    return MP_OBJ_FROM_PTR(self);
+}
+
+
+// fast method for getting/setting pin value
+STATIC mp_obj_t machine_pin_call(mp_obj_t self_in, size_t n_args, size_t n_kw, const mp_obj_t *args) {
+    mp_arg_check_num(n_args, n_kw, 0, 1, false);
+    machine_pin_obj_t *self = self_in;
+    if (n_args == 0) {
+        // get pin
+        return MP_OBJ_NEW_SMALL_INT(gpio_get_pin_level(self->id));
+    } else {
+        // set pin
+        bool value = mp_obj_is_true(args[0]);
+        gpio_set_pin_level(self->id, value);
+
+        return mp_const_none;
+    }
+}
+
+// pin.init(mode, pull)
+STATIC mp_obj_t machine_pin_obj_init(size_t n_args, const mp_obj_t *args, mp_map_t *kw_args) {
+    return machine_pin_obj_init_helper(args[0], n_args - 1, args + 1, kw_args);
+}
+MP_DEFINE_CONST_FUN_OBJ_KW(machine_pin_init_obj, 1, machine_pin_obj_init);
+
+
+// pin.value([value])
+STATIC mp_obj_t machine_pin_value(size_t n_args, const mp_obj_t *args) {
+    return machine_pin_call(args[0], n_args - 1, 0, args + 1);
+}
+STATIC MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(machine_pin_value_obj, 1, 2, machine_pin_value);
+
+
+// pin.disable(pin)
+STATIC mp_obj_t machine_pin_disable(mp_obj_t self_in) {
+    machine_pin_obj_t *self = MP_OBJ_TO_PTR(self_in);
+    gpio_set_pin_direction(self->id, GPIO_DIRECTION_OFF); // Disables the pin (low power state)
+    return mp_const_none;
+}
+STATIC MP_DEFINE_CONST_FUN_OBJ_1(machine_pin_disable_obj, machine_pin_disable);
+
+
+// pin.low() Totem-pole (push-pull)
+STATIC mp_obj_t machine_pin_low(mp_obj_t self_in) {
+    machine_pin_obj_t *self = MP_OBJ_TO_PTR(self_in);
+    gpio_set_pin_direction(self->id, GPIO_DIRECTION_OUT);
+    gpio_set_pin_level(self->id, false);
+
+    return mp_const_none;
+}
+STATIC MP_DEFINE_CONST_FUN_OBJ_1(machine_pin_low_obj, machine_pin_low);
+
+// pin.high() Totem-pole (push-pull)
+STATIC mp_obj_t machine_pin_high(mp_obj_t self_in) {
+    machine_pin_obj_t *self = MP_OBJ_TO_PTR(self_in);
+    gpio_set_pin_direction(self->id, GPIO_DIRECTION_OUT);
+    gpio_set_pin_level(self->id, true);
+
+    return mp_const_none;
+}
+STATIC MP_DEFINE_CONST_FUN_OBJ_1(machine_pin_high_obj, machine_pin_high);
+
+// pin.toggle(). Only TOGGLE pins set as OUTPUT.
+STATIC mp_obj_t machine_pin_toggle(mp_obj_t self_in) {
+    machine_pin_obj_t *self = MP_OBJ_TO_PTR(self_in);
+
+    // Determine DIRECTION of PIN.
+    bool pin_dir;
+
+    pin_dir = (PORT->Group[(enum gpio_port)GPIO_PORT(self->id)].DIR.reg // Get PORT# 
+                   & (1 << GPIO_PIN(self->id))) // Isolate the Pin in question
+                   >> GPIO_PIN(self->id); // Shift to LSB for binary result.
+
+    if (pin_dir) {
+        // Pin is OUTPUT
+        gpio_set_pin_direction(self->id, GPIO_DIRECTION_OUT);
+        gpio_toggle_pin_level(self->id);
+    } else {
+        mp_raise_ValueError(MP_ERROR_TEXT("Cannot TOGGLE INPUT pin!\n"));
+        }
+    return mp_const_true;
+}
+STATIC MP_DEFINE_CONST_FUN_OBJ_1(machine_pin_toggle_obj, machine_pin_toggle);
+
+// Pin.drive(). Normal (0) is 2mA, High (1) allows 8mA.
+STATIC mp_obj_t machine_pin_drive(size_t n_args, const mp_obj_t *args) {
+    machine_pin_obj_t *self = args[0]; // Pin
+    if (n_args == 1) {
+        return mp_const_none;
+    } else {
+        bool strength = mp_obj_get_int(args[1]); // 0 or 1
+        pin_validate_drive(strength);
+        // Set the DRVSTR bit (ASF hri/hri_port_dxx.h
+        hri_port_write_PINCFG_DRVSTR_bit(PORT, 
+                                        (enum gpio_port)GPIO_PORT(self->id), 
+                                        GPIO_PIN(self->id),
+                                        strength);
+        return mp_const_none;
+    }
+}
+STATIC MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(machine_pin_drive_obj, 1, 2, machine_pin_drive);
+
+STATIC const mp_rom_map_elem_t machine_pin_locals_dict_table[] = {
+    // instance methods
+    { MP_ROM_QSTR(MP_QSTR_init), MP_ROM_PTR(&machine_pin_init_obj) },
+    { MP_ROM_QSTR(MP_QSTR_value), MP_ROM_PTR(&machine_pin_value_obj) },
+    { MP_ROM_QSTR(MP_QSTR_low), MP_ROM_PTR(&machine_pin_low_obj) },
+    { MP_ROM_QSTR(MP_QSTR_high), MP_ROM_PTR(&machine_pin_high_obj) },
+    { MP_ROM_QSTR(MP_QSTR_off), MP_ROM_PTR(&machine_pin_low_obj) },
+    { MP_ROM_QSTR(MP_QSTR_on), MP_ROM_PTR(&machine_pin_high_obj) },
+    { MP_ROM_QSTR(MP_QSTR_toggle), MP_ROM_PTR(&machine_pin_toggle_obj) },
+    { MP_ROM_QSTR(MP_QSTR_disable), MP_ROM_PTR(&machine_pin_disable_obj) },
+    { MP_ROM_QSTR(MP_QSTR_drive), MP_ROM_PTR(&machine_pin_drive_obj) },
+
+
+    //{ MP_ROM_QSTR(MP_QSTR_irq), MP_ROM_PTR(&machine_pin_irq_obj) },
+
+    // class constants
+    { MP_ROM_QSTR(MP_QSTR_IN), MP_ROM_INT(GPIO_MODE_IN) },
+    { MP_ROM_QSTR(MP_QSTR_OUT), MP_ROM_INT(GPIO_MODE_OUT) },
+    //{ MP_ROM_QSTR(MP_QSTR_ALT), MP_ROM_INT(GPIO_MODE_ALT) },
+    { MP_ROM_QSTR(MP_QSTR_PULL_OFF), MP_ROM_INT(GPIO_PULL_OFF) },
+    { MP_ROM_QSTR(MP_QSTR_PULL_UP), MP_ROM_INT(GPIO_PULL_UP) },
+    { MP_ROM_QSTR(MP_QSTR_PULL_DOWN), MP_ROM_INT(GPIO_PULL_DOWN) },
+    { MP_ROM_QSTR(MP_QSTR_LOW_POWER), MP_ROM_INT(GPIO_STRENGTH_2MA) },
+    { MP_ROM_QSTR(MP_QSTR_HIGH_POWER), MP_ROM_INT(GPIO_STRENGTH_8MA) },
+    //{ MP_ROM_QSTR(MP_QSTR_IRQ_RISING), MP_ROM_INT(GPIO_IRQ_EDGE_RISE) },
+    //{ MP_ROM_QSTR(MP_QSTR_IRQ_FALLING), MP_ROM_INT(GPIO_IRQ_EDGE_FALL) },
+};
+STATIC MP_DEFINE_CONST_DICT(machine_pin_locals_dict, machine_pin_locals_dict_table);
+
+
+STATIC mp_uint_t pin_ioctl(mp_obj_t self_in, mp_uint_t request, uintptr_t arg, int *errcode) {
+    (void)errcode;
+    machine_pin_obj_t *self = self_in;
+
+    switch (request) {
+        case MP_PIN_READ: {
+            return gpio_get_pin_level(self->id);
+        }
+        case MP_PIN_WRITE: {
+            gpio_set_pin_level(self->id, arg);
+            return 0;
+        }
+    }
+    return -1;
+}
+
+
+STATIC const mp_pin_p_t pin_pin_p = {
+    .ioctl = pin_ioctl,
+};
+
+const mp_obj_type_t machine_pin_type = {
+    { &mp_type_type },
+    .name = MP_QSTR_Pin,
+    .print = machine_pin_print,
+    .make_new = mp_pin_make_new,
+    .call = machine_pin_call,
+    //.protocol = &pin_pin_p,
+    .locals_dict = (mp_obj_t)&machine_pin_locals_dict,
+};
+
+/*
+STATIC mp_uint_t machine_pin_irq_trigger(mp_obj_t self_in, mp_uint_t new_trigger) {
+    machine_pin_obj_t *self = MP_OBJ_TO_PTR(self_in);
+    machine_pin_irq_obj_t *irq = MP_STATE_PORT(machine_pin_irq_obj[self->id]);
+    gpio_set_irq_enabled(self->id, GPIO_IRQ_ALL, false);
+    irq->flags = 0;
+    irq->trigger = new_trigger;
+    gpio_set_irq_enabled(self->id, new_trigger, true);
+    return 0;
+}
+
+STATIC mp_uint_t machine_pin_irq_info(mp_obj_t self_in, mp_uint_t info_type) {
+    machine_pin_obj_t *self = MP_OBJ_TO_PTR(self_in);
+    machine_pin_irq_obj_t *irq = MP_STATE_PORT(machine_pin_irq_obj[self->id]);
+    if (info_type == MP_IRQ_INFO_FLAGS) {
+        return irq->flags;
+    } else if (info_type == MP_IRQ_INFO_TRIGGERS) {
+        return irq->trigger;
+    }
+    return 0;
+}
+
+STATIC const mp_irq_methods_t machine_pin_irq_methods = {
+    .trigger = machine_pin_irq_trigger,
+    .info = machine_pin_irq_info,
+};
+*/
+
+mp_hal_pin_obj_t mp_hal_get_pin_obj(mp_obj_t obj) {
+    if (!mp_obj_is_type(obj, &machine_pin_type)) {
+        mp_raise_ValueError(MP_ERROR_TEXT("expecting a Pin"));
+    }
+    machine_pin_obj_t *pin = MP_OBJ_TO_PTR(obj);
+    return pin->id;
+}
+

--- a/ports/samd/modmachine.c
+++ b/ports/samd/modmachine.c
@@ -23,10 +23,22 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+#include <stdio.h>
 
 #include "py/runtime.h"
 #include "extmod/machine_mem.h"
 #include "samd_soc.h"
+#include "modmachine.h"
+
+// ASF 4
+//#include "atmel_start_pins.h"
+//#include "peripheral_clk_config.h"
+//#include "hal/include/hal_delay.h"
+//#include "hal/include/hal_gpio.h"
+#include "hal_flash.h"
+#include "hal_init.h"
+#include "hpl_gclk_base.h"
+#include "hpl_pm_base.h"
 
 #if defined(MCU_SAMD21)
 #define DBL_TAP_ADDR ((volatile uint32_t *)(0x20000000 + 32 * 1024 - 4))
@@ -35,6 +47,10 @@
 #endif
 #define DBL_TAP_MAGIC_LOADER 0xf01669ef
 #define DBL_TAP_MAGIC_RESET 0xf02669ef
+
+//extern const mp_obj_type_t machine_uart_init_obj;
+MP_DEFINE_CONST_FUN_OBJ_0(machine_uart_init_obj, machine_uart_init);
+MP_DEFINE_CONST_FUN_OBJ_0(machine_uart_deinit_obj, machine_uart_deinit);
 
 STATIC mp_obj_t machine_reset(void) {
     *DBL_TAP_ADDR = DBL_TAP_MAGIC_RESET;
@@ -55,14 +71,67 @@ STATIC mp_obj_t machine_freq(void) {
 }
 MP_DEFINE_CONST_FUN_OBJ_0(machine_freq_obj, machine_freq);
 
+STATIC mp_obj_t machine_unique_id(void) {
+/*
+Each device has a unique 128-bit serial number which is a concatenation of four 32-bit
+words contained at the following addresses. The uniqueness of the serial number is
+guaranteed only when using all 128 bits.
+Atmel SAM D21E / SAM D21G / SAM D21J
+SMART ARM-Based Microcontroller
+DATASHEET
+9.6 (SAMD51) or 9.3.3 (or 10.3.3 depending on which manual)(SAMD21) Serial Number
+
+EXAMPLE (SAMD21)
+----------------
+OpenOCD:
+Word0:
+> at91samd21g18.cpu mdw 0x0080A00C 1
+0x0080a00c: 6e27f15f
+Words 1-3:
+> at91samd21g18.cpu mdw 0x0080A040 3
+0x0080a040: 50534b54 332e3120 ff091645
+
+MicroPython (this code and same order as shown in Arduino IDE)
+>>> ubinascii.hexlify(machine.unique_id())
+b'6e27f15f50534b54332e3120ff091645'
+
+*/
+
+    #if defined(MCU_SAMD21)
+    uint32_t* id_addresses[4] = {(uint32_t *) 0x0080A00C, (uint32_t *) 0x0080A040,
+                                 (uint32_t *) 0x0080A044, (uint32_t *) 0x0080A048};
+    #elif defined(MCU_SAMD51)
+    uint32_t* id_addresses[4] = {(uint32_t *) 0x008061FC, (uint32_t *) 0x00806010,
+                                 (uint32_t *) 0x00806014, (uint32_t *) 0x00806018};
+    #endif
+    uint8_t raw_id[16];
+
+    for (int i=0; i<4; i++) {
+        for (int k=0; k<4; k++) {
+            // 'Reverse' the read bytes into a 32 bit word (Consistent with Arduino)
+            raw_id[4 * i + k] = (*(id_addresses[i]) >> (24 - k * 8)) & 0xff;
+            // Original CircuitPython approach.
+            //raw_id[4 * i + k] = (*(id_addresses[i]) >> k * 8) & 0xff;
+        }
+    }
+
+    return mp_obj_new_bytes((byte *)&raw_id, sizeof(raw_id));
+}
+STATIC MP_DEFINE_CONST_FUN_OBJ_0(machine_unique_id_obj, machine_unique_id);
+
 STATIC const mp_rom_map_elem_t machine_module_globals_table[] = {
-    { MP_ROM_QSTR(MP_QSTR___name__),            MP_ROM_QSTR(MP_QSTR_umachine) },
-    { MP_ROM_QSTR(MP_QSTR_reset),               MP_ROM_PTR(&machine_reset_obj) },
-    { MP_ROM_QSTR(MP_QSTR_bootloader),          MP_ROM_PTR(&machine_bootloader_obj) },
-    { MP_ROM_QSTR(MP_QSTR_freq),                MP_ROM_PTR(&machine_freq_obj) },
-    { MP_ROM_QSTR(MP_QSTR_mem8),                MP_ROM_PTR(&machine_mem8_obj) },
-    { MP_ROM_QSTR(MP_QSTR_mem16),               MP_ROM_PTR(&machine_mem16_obj) },
-    { MP_ROM_QSTR(MP_QSTR_mem32),               MP_ROM_PTR(&machine_mem32_obj) },
+    { MP_ROM_QSTR(MP_QSTR___name__),          MP_ROM_QSTR(MP_QSTR_umachine) },
+    { MP_ROM_QSTR(MP_QSTR_reset),             MP_ROM_PTR(&machine_reset_obj) },
+    { MP_ROM_QSTR(MP_QSTR_bootloader),        MP_ROM_PTR(&machine_bootloader_obj) },
+    { MP_ROM_QSTR(MP_QSTR_freq),              MP_ROM_PTR(&machine_freq_obj) },
+    { MP_ROM_QSTR(MP_QSTR_mem8),              MP_ROM_PTR(&machine_mem8_obj) },
+    { MP_ROM_QSTR(MP_QSTR_mem16),             MP_ROM_PTR(&machine_mem16_obj) },
+    { MP_ROM_QSTR(MP_QSTR_mem32),             MP_ROM_PTR(&machine_mem32_obj) },
+    { MP_ROM_QSTR(MP_QSTR_unique_id),         MP_ROM_PTR(&machine_unique_id_obj) },
+    { MP_ROM_QSTR(MP_QSTR_uart_init),         MP_ROM_PTR(&machine_uart_init_obj) },
+    { MP_ROM_QSTR(MP_QSTR_uart_deinit),       MP_ROM_PTR(&machine_uart_deinit_obj) },
+    { MP_ROM_QSTR(MP_QSTR_Pin),               MP_ROM_PTR(&machine_pin_type) },
+    { MP_ROM_QSTR(MP_QSTR_Led),               MP_ROM_PTR(&machine_led_type) },
 };
 STATIC MP_DEFINE_CONST_DICT(machine_module_globals, machine_module_globals_table);
 

--- a/ports/samd/modmachine.h
+++ b/ports/samd/modmachine.h
@@ -1,0 +1,22 @@
+#ifndef MICROPY_INCLUDED_SAMD_MODMACHINE_H
+#define MICROPY_INCLUDED_SAMD_MODMACHINE_H
+
+#include "py/obj.h"
+
+extern const mp_obj_type_t machine_pin_type;
+extern const mp_obj_type_t machine_led_type;
+extern mp_obj_t machine_uart_init(void);
+extern mp_obj_t machine_uart_deinit(void);
+
+/*extern const mp_obj_type_t machine_adc_type;
+extern const mp_obj_type_t machine_hw_i2c_type;
+extern const mp_obj_type_t machine_pwm_type;
+extern const mp_obj_type_t machine_spi_type;
+extern const mp_obj_type_t machine_timer_type;
+extern const mp_obj_type_t machine_uart_type;
+extern const mp_obj_type_t machine_wdt_type;
+
+void machine_pin_init(void);
+void machine_pin_deinit(void);
+*/
+#endif // MICROPY_INCLUDED_SAMD_MODMACHINE_H


### PR DESCRIPTION
This PR updates the `machine` module that includes GPIO functions for `Pin` (input & output) & `Led` (output only), configures the USART to use board specific `uart` designations, and a function that pulls out the device's serial number (consistent with Arduino). 

Each board defines its own Pin & Led layout using an array. (The README illustrates this in a table). Other PRs update individual boards.

- `ports/samd/machine_pin.c`: `Pin` functions and constants. The pins are initialised as inputs.
- `ports/samd/machine_led.c`: `Led` functions and constants.
- `ports/samd/modmachine.c`: Updates the Module with `Pin`, `Led`, `unique_id`, `uart_init` & `uart_deinit`.
- `ports/samd/modmachine.h`: New file.