### PR TITLE
ports/samd/boards/ADAFRUIT_FEATHER_M0_EXPRESS: Update configuration to use new Port features.

### DIFF
--- a/ports/samd/boards/ADAFRUIT_FEATHER_M0_EXPRESS/mpconfigboard.h
+++ b/ports/samd/boards/ADAFRUIT_FEATHER_M0_EXPRESS/mpconfigboard.h
@@ -19,8 +19,8 @@
 #define MP_TX_PIN 22 //'n'
 #define MP_RX_PIN 23
 #define MP_PERIPHERAL_MUX 11 // 'n'th group of 2 pins
-#define USARTx SERCOM5 // SERCOM4:XIAO_M0 tx/rx
-#define MP_PORT_FUNC 0x33 // Sets PMUXE & PMUXO to the Alternative Function.A-H=0-7
+#define USARTx SERCOM5 // SERCOM5: tx/rx
+#define MP_PORT_FUNC 0x33 // Sets PMUXE & PMUXO to the Alternative Function.(A-H=0-7)
 #define MP_RXPO_PAD 3 // RXPO- Receive Data Pinout
 #define MP_TXPO_PAD 2 // TXPO- Tranmit Data Pinout
 #define MP_SERCOMx SERCOM5_ // APBCMASK

--- a/ports/samd/boards/ADAFRUIT_FEATHER_M0_EXPRESS/mpconfigboard.h
+++ b/ports/samd/boards/ADAFRUIT_FEATHER_M0_EXPRESS/mpconfigboard.h
@@ -1,2 +1,27 @@
 #define MICROPY_HW_BOARD_NAME "Feather M0 Express"
 #define MICROPY_HW_MCU_NAME   "SAMD21G18A"
+
+// MicroPython configs
+// samd_flash.c flash parameters
+// Build a 64k Flash storage at top. 256k-64k=196k
+// 256*1024=262144 minus 64*1024=65536 = 196608 = 0x30000
+#define MICROPY_HW_FLASH_STORAGE_BASE       (0x30000)
+#define MICROPY_HW_FLASH_STORAGE_BYTES      (0xFFFF) 
+#define VFS_BLOCK_SIZE_BYTES                (1536) // 24x 64B flash pages;
+
+// ASF4 MCU package specific Pin definitions
+#include "samd21g18a.h"
+
+// Please consult the SAM_D21 Datasheet, I/O Multiplexing and Considerations.
+// USART pin assignments: Tx=PB22=SERCOM5/PAD[2], Rx=PB23==SERCOM5/PAD[3]
+#define CPU_FREQ (48000000) // For selecting Baud from clock.
+#define MP_PIN_GRP 1 // A=0, B=1
+#define MP_TX_PIN 22 //'n'
+#define MP_RX_PIN 23
+#define MP_PERIPHERAL_MUX 11 // 'n'th group of 2 pins
+#define USARTx SERCOM5 // SERCOM4:XIAO_M0 tx/rx
+#define MP_PORT_FUNC 0x33 // Sets PMUXE & PMUXO to the Alternative Function.A-H=0-7
+#define MP_RXPO_PAD 3 // RXPO- Receive Data Pinout
+#define MP_TXPO_PAD 2 // TXPO- Tranmit Data Pinout
+#define MP_SERCOMx SERCOM5_ // APBCMASK
+#define MP_SERCOM_GCLK_ID_x_CORE GCLK_CLKCTRL_ID_SERCOM5_CORE // Generic Clock Control

--- a/ports/samd/boards/ADAFRUIT_FEATHER_M0_EXPRESS/mpconfigboard.mk
+++ b/ports/samd/boards/ADAFRUIT_FEATHER_M0_EXPRESS/mpconfigboard.mk
@@ -2,3 +2,7 @@ MCU_SERIES = SAMD21
 CMSIS_MCU = SAMD21G18A
 LD_FILES = boards/samd21x18a.ld sections.ld
 TEXT0 = 0x2000
+
+# The ?='s allow overriding in mpconfigboard.mk.
+# MicroPython settings
+MICROPY_VFS_LFS1 ?= 1

--- a/ports/samd/boards/ADAFRUIT_FEATHER_M0_EXPRESS/pins.c
+++ b/ports/samd/boards/ADAFRUIT_FEATHER_M0_EXPRESS/pins.c
@@ -1,0 +1,59 @@
+/*
+ * This file is part of the MicroPython project, http://micropython.org/
+ *
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2021 Peter van der Burg
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * Used by machine_pin.c. Holds Board/MCU specific Pin allocations.
+ */
+
+#include "modmachine.h"
+#include "pins.h"
+
+// Ensure Declaration in 'pins.h' reflects # of Pins defined here.
+const machine_pin_obj_t machine_pin_obj[] = {
+    {{&machine_pin_type}, PIN_PA11}, // D0
+    {{&machine_pin_type}, PIN_PA10}, // D1
+    {{&machine_pin_type}, PIN_PA14}, // D2
+    {{&machine_pin_type}, PIN_PA09}, // D3/ 
+    {{&machine_pin_type}, PIN_PA08}, // D4/ 
+    {{&machine_pin_type}, PIN_PA15}, // D5
+    {{&machine_pin_type}, PIN_PA20}, // D6
+    {{&machine_pin_type}, PIN_PA21}, // D7
+    {{&machine_pin_type}, PIN_PA06}, // D8/ 
+    {{&machine_pin_type}, PIN_PA07}, // D9/ 
+    {{&machine_pin_type}, PIN_PA18}, // D10
+    {{&machine_pin_type}, PIN_PA16}, // D11
+    {{&machine_pin_type}, PIN_PA19}, // D12
+    {{&machine_pin_type}, PIN_PA17}, // D13/ 
+	{{&machine_pin_type}, PIN_PA02}, // A0
+    {{&machine_pin_type}, PIN_PB08}, // A1
+    {{&machine_pin_type}, PIN_PB09}, // A2
+    {{&machine_pin_type}, PIN_PA04}, // A3/ 
+    {{&machine_pin_type}, PIN_PA05}, // A4/ 
+    {{&machine_pin_type}, PIN_PB02}, // A5
+};
+
+const machine_led_obj_t machine_led_obj[] = {
+    {{&machine_led_type}, PIN_PA17}, // D13/ user LED
+};
+

--- a/ports/samd/boards/ADAFRUIT_FEATHER_M0_EXPRESS/pins.h
+++ b/ports/samd/boards/ADAFRUIT_FEATHER_M0_EXPRESS/pins.h
@@ -1,0 +1,43 @@
+/*
+ * This file is part of the MicroPython project, http://micropython.org/
+ *
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2021 Peter van der Burg
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * Used by machine_pin.c & board specific pins.c. Holds Board/MCU specific Pin 
+ * allocations.
+ */
+
+typedef struct _machine_pin_obj_t {
+    mp_obj_base_t base;
+    uint32_t id;
+} machine_pin_obj_t;
+
+typedef struct _machine_led_obj_t {
+    mp_obj_base_t base;
+    uint32_t id;
+} machine_led_obj_t;
+
+// MUST explicitly hold array # of rows, else machine_pin.c wont compile.
+extern const machine_pin_obj_t machine_pin_obj[20];
+extern const machine_led_obj_t machine_led_obj[1];
+


### PR DESCRIPTION
This PR updates board specific configuration files to utilise the new Port features. Each board defines its own block device size, Pin & Led layout and UART parameters.  (The Port's README is the user's reference). 

`mpconfigboard.h`: `Flash` size & define UART.
`mpconfigboard.mk`: `LFS1`
`pins.c`: Define `Pin` & `Led` arrays.
`pins.h`: Define Structs & Consts.