### PR TITLE
ports/samd/boards/MINISAM_M4: Update configuration to use new Port features.

### DIFF
--- a/ports/samd/boards/MINISAM_M4/mpconfigboard.h
+++ b/ports/samd/boards/MINISAM_M4/mpconfigboard.h
@@ -5,3 +5,28 @@
 #define MICROPY_PY_BUILTINS_COMPLEX     (0)
 #define MICROPY_PY_MATH                 (0)
 #define MICROPY_PY_CMATH                (0)
+
+// MicroPython configs
+// samd_flash.c flash parameters
+// Build a 128k Flash storage at top. 512k-128k=384k=0x60000
+// 512*1024= 0x80000 minus 128*1024= 0x20000 =  0x60000
+#define MICROPY_HW_FLASH_STORAGE_BASE       (0x60000)
+#define MICROPY_HW_FLASH_STORAGE_BYTES      (0x1FFFF)
+#define VFS_BLOCK_SIZE_BYTES                (1536) //
+
+// ASF4 MCU package specific Pin definitions
+#include "samd51g19a.h"
+
+// Please consult the SAM_D51 Datasheet, I/O Multiplexing and Considerations.
+// USART pin assignments: Tx=TX_D1=PA17=SERCOM3/PAD[0], Rx=RX_D0=PA16=SERCOM3/PAD[1]
+#define CPU_FREQ (48000000) // For selecting Baud from clock.
+#define MP_PIN_GRP 1 // A-D=0-3
+#define MP_TX_PIN 17
+#define MP_RX_PIN 16 // 'n'
+#define MP_PERIPHERAL_MUX 8 // 'n'th group of 2 pins
+#define USARTx SERCOM3 // 
+#define MP_PORT_FUNC 0x33 // Sets PMUXE & PMUXO to the Alternative Function.A-N=0-13
+#define MP_RXPO_PAD 1 // RXPO- Receive Data Pinout
+#define MP_TXPO_PAD 0 // TXPO- Tranmit Data Pinout
+#define MP_SERCOMx SERCOM3_ // APBCMASK
+#define MP_SERCOM_GCLK_ID_x_CORE SERCOM3_GCLK_ID_CORE

--- a/ports/samd/boards/MINISAM_M4/mpconfigboard.mk
+++ b/ports/samd/boards/MINISAM_M4/mpconfigboard.mk
@@ -3,3 +3,8 @@ MCU_SERIES = SAMD51
 CMSIS_MCU = SAMD51G19A
 LD_FILES = boards/samd51g19a.ld sections.ld
 TEXT0 = 0x4000
+
+# The ?='s allow overriding in mpconfigboard.mk.
+# MicroPython settings
+MICROPY_VFS_LFS1 ?= 1
+

--- a/ports/samd/boards/MINISAM_M4/pins.c
+++ b/ports/samd/boards/MINISAM_M4/pins.c
@@ -1,0 +1,52 @@
+/*
+ * This file is part of the MicroPython project, http://micropython.org/
+ *
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2021 Peter van der Burg
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * Used by machine_pin.c. Holds Board/MCU specific Pin allocations.
+ */
+
+#include "modmachine.h"
+#include "pins.h"
+
+// Ensure Declaration in 'pins.h' reflects # of Pins defined here.
+const machine_pin_obj_t machine_pin_obj[] = {
+    {{&machine_pin_type}, PIN_PA02}, // A0,D9
+    {{&machine_pin_type}, PIN_PB08}, // A1,D10
+    {{&machine_pin_type}, PIN_PB09}, // A2,D11
+    {{&machine_pin_type}, PIN_PA04}, // A3,D12
+    {{&machine_pin_type}, PIN_PA05}, // A4,D13
+    {{&machine_pin_type}, PIN_PA06}, // A5
+    {{&machine_pin_type}, PIN_PA16}, // RX_D0
+    {{&machine_pin_type}, PIN_PA17}, // TX_D1
+    {{&machine_pin_type}, PIN_PA07}, // D2,A6
+    {{&machine_pin_type}, PIN_PA19}, // D3
+    {{&machine_pin_type}, PIN_PA20}, // D4
+    {{&machine_pin_type}, PIN_PA21}, // D5
+    {{&machine_pin_type}, PIN_PA00}, // BUTTON
+};
+
+const machine_led_obj_t machine_led_obj[] = {
+    {{&machine_led_type}, PIN_PA15}, // LED
+};
+

--- a/ports/samd/boards/MINISAM_M4/pins.h
+++ b/ports/samd/boards/MINISAM_M4/pins.h
@@ -1,0 +1,43 @@
+/*
+ * This file is part of the MicroPython project, http://micropython.org/
+ *
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2021 Peter van der Burg
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * Used by machine_pin.c & board specific pins.c. Holds Board/MCU specific Pin 
+ * allocations.
+ */
+
+typedef struct _machine_pin_obj_t {
+    mp_obj_base_t base;
+    uint32_t id;
+} machine_pin_obj_t;
+
+typedef struct _machine_led_obj_t {
+    mp_obj_base_t base;
+    uint32_t id;
+} machine_led_obj_t;
+
+// MUST explicitly hold array # of rows, else machine_pin.c wont compile.
+extern const machine_pin_obj_t machine_pin_obj[13];
+extern const machine_led_obj_t machine_led_obj[1];
+


### PR DESCRIPTION
This PR updates board specific configuration files to utilise the new Port features. Each board defines its own block device size, Pin & Led layout and UART parameters.  (The Port's README is the user's reference). 

`mpconfigboard.h`: `Flash` size & define UART.
`mpconfigboard.mk`: `LFS1`
`pins.c`: Define `Pin` & `Led` arrays.
`pins.h`: Define Structs & Consts.