### PR TITLE
ports/samd/boards/SAMD21_XPLAINED_PRO: Update configuration to use new Port features.

### DIFF
--- a/ports/samd/boards/SAMD21_XPLAINED_PRO/mpconfigboard.h
+++ b/ports/samd/boards/SAMD21_XPLAINED_PRO/mpconfigboard.h
@@ -14,14 +14,14 @@
 
 // Please consult the SAM_D21 Datasheet, I/O Multiplexing and Considerations.
 // USART pin assignments: (This board has 3 USARTS brought out to the pins. See https://docs.zephyrproject.org/1.14.1/boards/arm/atsamd21_xpro/doc/index.html#serial-port )
-// Tx==PA10=SERCOM0/PAD[2], Rx=PA11=SERCOM0/PAD[3]
+// Tx=PA10=SERCOM0/PAD[2], Rx=PA11=SERCOM0/PAD[3]
 #define CPU_FREQ (48000000) // For selecting Baud from clock.
 #define MP_PIN_GRP 1 // A=0, B=1
 #define MP_TX_PIN 10 //'n'
 #define MP_RX_PIN 11
 #define MP_PERIPHERAL_MUX 5 // 'n'th group of 2 pins
-#define USARTx SERCOM0 // SERCOM4:XIAO_M0 tx/rx
-#define MP_PORT_FUNC 0x22 // Sets PMUXE & PMUXO to the Alternative Function.A-H=0-7
+#define USARTx SERCOM0 // SERCOM0: tx/rx
+#define MP_PORT_FUNC 0x22 // Sets PMUXE & PMUXO to the Alternative Function.(A-H=0-7)
 #define MP_RXPO_PAD 3 // RXPO- Receive Data Pinout
 #define MP_TXPO_PAD 2 // TXPO- Tranmit Data Pinout
 #define MP_SERCOMx SERCOM0_ // APBCMASK

--- a/ports/samd/boards/SAMD21_XPLAINED_PRO/mpconfigboard.h
+++ b/ports/samd/boards/SAMD21_XPLAINED_PRO/mpconfigboard.h
@@ -1,2 +1,28 @@
 #define MICROPY_HW_BOARD_NAME "SAMD21-XPLAINED-PRO"
 #define MICROPY_HW_MCU_NAME   "SAMD21J18A"
+
+// MicroPython configs
+// samd_flash.c flash parameters
+// Build a 64k Flash storage at top. 256k-64k=196k
+// 256*1024=262144 minus 64*1024=65536 = 196608 = 0x30000
+#define MICROPY_HW_FLASH_STORAGE_BASE       (0x30000)
+#define MICROPY_HW_FLASH_STORAGE_BYTES      (0xFFFF) 
+#define VFS_BLOCK_SIZE_BYTES                (1536) // 24x 64B flash pages;
+
+// ASF4 MCU package specific Pin definitions
+#include "samd21j18a.h"
+
+// Please consult the SAM_D21 Datasheet, I/O Multiplexing and Considerations.
+// USART pin assignments: (This board has 3 USARTS brought out to the pins. See https://docs.zephyrproject.org/1.14.1/boards/arm/atsamd21_xpro/doc/index.html#serial-port )
+// Tx==PA10=SERCOM0/PAD[2], Rx=PA11=SERCOM0/PAD[3]
+#define CPU_FREQ (48000000) // For selecting Baud from clock.
+#define MP_PIN_GRP 1 // A=0, B=1
+#define MP_TX_PIN 10 //'n'
+#define MP_RX_PIN 11
+#define MP_PERIPHERAL_MUX 5 // 'n'th group of 2 pins
+#define USARTx SERCOM0 // SERCOM4:XIAO_M0 tx/rx
+#define MP_PORT_FUNC 0x22 // Sets PMUXE & PMUXO to the Alternative Function.A-H=0-7
+#define MP_RXPO_PAD 3 // RXPO- Receive Data Pinout
+#define MP_TXPO_PAD 2 // TXPO- Tranmit Data Pinout
+#define MP_SERCOMx SERCOM0_ // APBCMASK
+#define MP_SERCOM_GCLK_ID_x_CORE GCLK_CLKCTRL_ID_SERCOM0_CORE // Generic Clock Control

--- a/ports/samd/boards/SAMD21_XPLAINED_PRO/mpconfigboard.mk
+++ b/ports/samd/boards/SAMD21_XPLAINED_PRO/mpconfigboard.mk
@@ -2,3 +2,7 @@ MCU_SERIES = SAMD21
 CMSIS_MCU = SAMD21J18A
 LD_FILES = boards/samd21x18a.ld sections.ld
 TEXT0 = 0x2000
+
+# The ?='s allow overriding in mpconfigboard.mk.
+# MicroPython settings
+MICROPY_VFS_LFS1 ?= 1

--- a/ports/samd/boards/SAMD21_XPLAINED_PRO/pins.c
+++ b/ports/samd/boards/SAMD21_XPLAINED_PRO/pins.c
@@ -58,8 +58,8 @@ const machine_pin_obj_t machine_pin_obj[] = {
     {{&machine_pin_type}, PIN_PB13}, // PIN8_PWM(-)
     {{&machine_pin_type}, PIN_PB14}, // PIN9_IRQ/GPIO
     {{&machine_pin_type}, PIN_PB15}, // PIN10_SPI_SS_B/GPIO
-    //{{&machine_pin_type}, PIN_PA08}, // PIN11_TWI_SDA
-    //{{&machine_pin_type}, PIN_PA09}, // PIN12_TWI_SCL
+    {{NULL}, -1}, // PIN_PA08/ PIN11_TWI_SDA already defined
+    {{NULL}, -1}, // PIN_PA09/ PIN12_TWI_SCL already defined
     {{&machine_pin_type}, PIN_PB11}, // PIN13_UART_RX
     {{&machine_pin_type}, PIN_PB10}, // PIN14_UART_TX
     {{&machine_pin_type}, PIN_PA17}, // PIN15_SPI_SS_A
@@ -70,16 +70,16 @@ const machine_pin_obj_t machine_pin_obj[] = {
     // EXT3
     {{&machine_pin_type}, PIN_PA02}, // PIN3_ADC(+)
     {{&machine_pin_type}, PIN_PA03}, // PIN4_ADC(-)
-    //{{&machine_pin_type}, PIN_PB30}, // PIN5_GPIO
+    {{NULL}, -1}, // PIN_PB30/ PIN5_GPIO already defined
     {{&machine_pin_type}, PIN_PA15}, // PIN6_GPIO; USER_BUTTON
     {{&machine_pin_type}, PIN_PA12}, // PIN7_PWM(+)
     {{&machine_pin_type}, PIN_PA13}, // PIN8_PWM(-)
     {{&machine_pin_type}, PIN_PA28}, // PIN9_IRQ/GPIO
     {{&machine_pin_type}, PIN_PA27}, // PIN10_SPI_SS_B/GPIO
-    //{{&machine_pin_type}, PIN_PA08}, // PIN11_TWI_SDA
-    //{{&machine_pin_type}, PIN_PA09}, // PIN12_TWI_SCL
-    //{{&machine_pin_type}, PIN_PB11}, // PIN13_UART_RX
-    //{{&machine_pin_type}, PIN_PB10}, // PIN14_UART_TX
+    {{NULL}, -1}, // PIN_PA08/ PIN11_TWI_SDA already defined
+    {{NULL}, -1}, // PIN_PA09/ PIN12_TWI_SCL already defined
+    {{NULL}, -1}, // PIN_PB11/ PIN13_UART_RX already defined
+    {{NULL}, -1}, // PIN_PB10/ PIN14_UART_TX already defined
     {{&machine_pin_type}, PIN_PB17}, // PIN15_SPI_SS_A
     {{&machine_pin_type}, PIN_PB22}, // PIN16_SPI_MOSI
     {{&machine_pin_type}, PIN_PB16}, // PIN17_SPI_MISO

--- a/ports/samd/boards/SAMD21_XPLAINED_PRO/pins.c
+++ b/ports/samd/boards/SAMD21_XPLAINED_PRO/pins.c
@@ -50,9 +50,40 @@ const machine_pin_obj_t machine_pin_obj[] = {
     {{&machine_pin_type}, PIN_PA07}, // PIN18_SPI_SCK
 
     // EXT2
-    {{&machine_pin_type}, PIN_PA10}, // PIN3_ADC(+)    {{&machine_pin_type}, PIN_PA11}, // PIN4_ADC(-)    {{&machine_pin_type}, PIN_PA20}, // PIN5_GPIO    {{&machine_pin_type}, PIN_PA21}, // PIN6_GPIO    {{&machine_pin_type}, PIN_PB12}, // PIN7_PWM(+)    {{&machine_pin_type}, PIN_PB13}, // PIN8_PWM(-)    {{&machine_pin_type}, PIN_PB14}, // PIN9_IRQ/GPIO    {{&machine_pin_type}, PIN_PB15}, // PIN10_SPI_SS_B/GPIO    //{{&machine_pin_type}, PIN_PA08}, // PIN11_TWI_SDA    //{{&machine_pin_type}, PIN_PA09}, // PIN12_TWI_SCL    {{&machine_pin_type}, PIN_PB11}, // PIN13_UART_RX    {{&machine_pin_type}, PIN_PB10}, // PIN14_UART_TX    {{&machine_pin_type}, PIN_PA17}, // PIN15_SPI_SS_A    {{&machine_pin_type}, PIN_PA18}, // PIN16_SPI_MOSI    {{&machine_pin_type}, PIN_PA16}, // PIN17_SPI_MISO    {{&machine_pin_type}, PIN_PA19}, // PIN18_SPI_SCK
+    {{&machine_pin_type}, PIN_PA10}, // PIN3_ADC(+)
+    {{&machine_pin_type}, PIN_PA11}, // PIN4_ADC(-)
+    {{&machine_pin_type}, PIN_PA20}, // PIN5_GPIO
+    {{&machine_pin_type}, PIN_PA21}, // PIN6_GPIO
+    {{&machine_pin_type}, PIN_PB12}, // PIN7_PWM(+)
+    {{&machine_pin_type}, PIN_PB13}, // PIN8_PWM(-)
+    {{&machine_pin_type}, PIN_PB14}, // PIN9_IRQ/GPIO
+    {{&machine_pin_type}, PIN_PB15}, // PIN10_SPI_SS_B/GPIO
+    //{{&machine_pin_type}, PIN_PA08}, // PIN11_TWI_SDA
+    //{{&machine_pin_type}, PIN_PA09}, // PIN12_TWI_SCL
+    {{&machine_pin_type}, PIN_PB11}, // PIN13_UART_RX
+    {{&machine_pin_type}, PIN_PB10}, // PIN14_UART_TX
+    {{&machine_pin_type}, PIN_PA17}, // PIN15_SPI_SS_A
+    {{&machine_pin_type}, PIN_PA18}, // PIN16_SPI_MOSI
+    {{&machine_pin_type}, PIN_PA16}, // PIN17_SPI_MISO
+    {{&machine_pin_type}, PIN_PA19}, // PIN18_SPI_SCK
 
-    // EXT3    {{&machine_pin_type}, PIN_PA02}, // PIN3_ADC(+)    {{&machine_pin_type}, PIN_PA03}, // PIN4_ADC(-)    //{{&machine_pin_type}, PIN_PB30}, // PIN5_GPIO    {{&machine_pin_type}, PIN_PA15}, // PIN6_GPIO; USER_BUTTON    {{&machine_pin_type}, PIN_PA12}, // PIN7_PWM(+)    {{&machine_pin_type}, PIN_PA13}, // PIN8_PWM(-)    {{&machine_pin_type}, PIN_PA28}, // PIN9_IRQ/GPIO    {{&machine_pin_type}, PIN_PA27}, // PIN10_SPI_SS_B/GPIO    //{{&machine_pin_type}, PIN_PA08}, // PIN11_TWI_SDA    //{{&machine_pin_type}, PIN_PA09}, // PIN12_TWI_SCL    //{{&machine_pin_type}, PIN_PB11}, // PIN13_UART_RX    //{{&machine_pin_type}, PIN_PB10}, // PIN14_UART_TX    {{&machine_pin_type}, PIN_PB17}, // PIN15_SPI_SS_A    {{&machine_pin_type}, PIN_PB22}, // PIN16_SPI_MOSI    {{&machine_pin_type}, PIN_PB16}, // PIN17_SPI_MISO    {{&machine_pin_type}, PIN_PB23}, // PIN18_SPI_SCK
+    // EXT3
+    {{&machine_pin_type}, PIN_PA02}, // PIN3_ADC(+)
+    {{&machine_pin_type}, PIN_PA03}, // PIN4_ADC(-)
+    //{{&machine_pin_type}, PIN_PB30}, // PIN5_GPIO
+    {{&machine_pin_type}, PIN_PA15}, // PIN6_GPIO; USER_BUTTON
+    {{&machine_pin_type}, PIN_PA12}, // PIN7_PWM(+)
+    {{&machine_pin_type}, PIN_PA13}, // PIN8_PWM(-)
+    {{&machine_pin_type}, PIN_PA28}, // PIN9_IRQ/GPIO
+    {{&machine_pin_type}, PIN_PA27}, // PIN10_SPI_SS_B/GPIO
+    //{{&machine_pin_type}, PIN_PA08}, // PIN11_TWI_SDA
+    //{{&machine_pin_type}, PIN_PA09}, // PIN12_TWI_SCL
+    //{{&machine_pin_type}, PIN_PB11}, // PIN13_UART_RX
+    //{{&machine_pin_type}, PIN_PB10}, // PIN14_UART_TX
+    {{&machine_pin_type}, PIN_PB17}, // PIN15_SPI_SS_A
+    {{&machine_pin_type}, PIN_PB22}, // PIN16_SPI_MOSI
+    {{&machine_pin_type}, PIN_PB16}, // PIN17_SPI_MISO
+    {{&machine_pin_type}, PIN_PB23}, // PIN18_SPI_SCK
 };
 
 const machine_led_obj_t machine_led_obj[] = {

--- a/ports/samd/boards/SAMD21_XPLAINED_PRO/pins.c
+++ b/ports/samd/boards/SAMD21_XPLAINED_PRO/pins.c
@@ -1,0 +1,61 @@
+/*
+ * This file is part of the MicroPython project, http://micropython.org/
+ *
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2021 Peter van der Burg
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * Used by machine_pin.c. Holds Board/MCU specific Pin allocations.
+ */
+
+#include "modmachine.h"
+#include "pins.h"
+
+// Ensure Declaration in 'pins.h' reflects # of Pins defined here.
+const machine_pin_obj_t machine_pin_obj[] = {
+	// EXT1
+    {{&machine_pin_type}, PIN_PB00}, // PIN3_ADC(+)
+    {{&machine_pin_type}, PIN_PB01}, // PIN4_ADC(-)
+    {{&machine_pin_type}, PIN_PB06}, // PIN5_GPIO
+    {{&machine_pin_type}, PIN_PB07}, // PIN6_GPIO
+    {{&machine_pin_type}, PIN_PB02}, // PIN7_PWM(+)
+    {{&machine_pin_type}, PIN_PB03}, // PIN8_PWM(-)
+    {{&machine_pin_type}, PIN_PB04}, // PIN9_IRQ/GPIO
+    {{&machine_pin_type}, PIN_PB05}, // PIN10_SPI_SS_B/GPIO
+    {{&machine_pin_type}, PIN_PA08}, // PIN11_TWI_SDA
+    {{&machine_pin_type}, PIN_PA09}, // PIN12_TWI_SCL
+    {{&machine_pin_type}, PIN_PB09}, // PIN13_UART_RX
+    {{&machine_pin_type}, PIN_PB08}, // PIN14_UART_TX
+    {{&machine_pin_type}, PIN_PA05}, // PIN15_SPI_SS_A
+    {{&machine_pin_type}, PIN_PA06}, // PIN16_SPI_MOSI
+    {{&machine_pin_type}, PIN_PA04}, // PIN17_SPI_MISO
+    {{&machine_pin_type}, PIN_PA07}, // PIN18_SPI_SCK
+
+    // EXT2
+    {{&machine_pin_type}, PIN_PA10}, // PIN3_ADC(+)    {{&machine_pin_type}, PIN_PA11}, // PIN4_ADC(-)    {{&machine_pin_type}, PIN_PA20}, // PIN5_GPIO    {{&machine_pin_type}, PIN_PA21}, // PIN6_GPIO    {{&machine_pin_type}, PIN_PB12}, // PIN7_PWM(+)    {{&machine_pin_type}, PIN_PB13}, // PIN8_PWM(-)    {{&machine_pin_type}, PIN_PB14}, // PIN9_IRQ/GPIO    {{&machine_pin_type}, PIN_PB15}, // PIN10_SPI_SS_B/GPIO    //{{&machine_pin_type}, PIN_PA08}, // PIN11_TWI_SDA    //{{&machine_pin_type}, PIN_PA09}, // PIN12_TWI_SCL    {{&machine_pin_type}, PIN_PB11}, // PIN13_UART_RX    {{&machine_pin_type}, PIN_PB10}, // PIN14_UART_TX    {{&machine_pin_type}, PIN_PA17}, // PIN15_SPI_SS_A    {{&machine_pin_type}, PIN_PA18}, // PIN16_SPI_MOSI    {{&machine_pin_type}, PIN_PA16}, // PIN17_SPI_MISO    {{&machine_pin_type}, PIN_PA19}, // PIN18_SPI_SCK
+
+    // EXT3    {{&machine_pin_type}, PIN_PA02}, // PIN3_ADC(+)    {{&machine_pin_type}, PIN_PA03}, // PIN4_ADC(-)    //{{&machine_pin_type}, PIN_PB30}, // PIN5_GPIO    {{&machine_pin_type}, PIN_PA15}, // PIN6_GPIO; USER_BUTTON    {{&machine_pin_type}, PIN_PA12}, // PIN7_PWM(+)    {{&machine_pin_type}, PIN_PA13}, // PIN8_PWM(-)    {{&machine_pin_type}, PIN_PA28}, // PIN9_IRQ/GPIO    {{&machine_pin_type}, PIN_PA27}, // PIN10_SPI_SS_B/GPIO    //{{&machine_pin_type}, PIN_PA08}, // PIN11_TWI_SDA    //{{&machine_pin_type}, PIN_PA09}, // PIN12_TWI_SCL    //{{&machine_pin_type}, PIN_PB11}, // PIN13_UART_RX    //{{&machine_pin_type}, PIN_PB10}, // PIN14_UART_TX    {{&machine_pin_type}, PIN_PB17}, // PIN15_SPI_SS_A    {{&machine_pin_type}, PIN_PB22}, // PIN16_SPI_MOSI    {{&machine_pin_type}, PIN_PB16}, // PIN17_SPI_MISO    {{&machine_pin_type}, PIN_PB23}, // PIN18_SPI_SCK
+};
+
+const machine_led_obj_t machine_led_obj[] = {
+    {{&machine_led_type}, PIN_PB30}, // USER_LED
+};
+

--- a/ports/samd/boards/SAMD21_XPLAINED_PRO/pins.h
+++ b/ports/samd/boards/SAMD21_XPLAINED_PRO/pins.h
@@ -1,0 +1,43 @@
+/*
+ * This file is part of the MicroPython project, http://micropython.org/
+ *
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2021 Peter van der Burg
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * Used by machine_pin.c & board specific pins.c. Holds Board/MCU specific Pin 
+ * allocations.
+ */
+
+typedef struct _machine_pin_obj_t {
+    mp_obj_base_t base;
+    uint32_t id;
+} machine_pin_obj_t;
+
+typedef struct _machine_led_obj_t {
+    mp_obj_base_t base;
+    uint32_t id;
+} machine_led_obj_t;
+
+// MUST explicitly hold array # of rows, else machine_pin.c wont compile.
+extern const machine_pin_obj_t machine_pin_obj[41];
+extern const machine_led_obj_t machine_led_obj[1];
+

--- a/ports/samd/boards/SAMD21_XPLAINED_PRO/pins.h
+++ b/ports/samd/boards/SAMD21_XPLAINED_PRO/pins.h
@@ -38,6 +38,6 @@ typedef struct _machine_led_obj_t {
 } machine_led_obj_t;
 
 // MUST explicitly hold array # of rows, else machine_pin.c wont compile.
-extern const machine_pin_obj_t machine_pin_obj[41];
+extern const machine_pin_obj_t machine_pin_obj[48];
 extern const machine_led_obj_t machine_led_obj[1];
 


### PR DESCRIPTION
This PR updates board specific configuration files to utilise the new Port features. Each board defines its own block device size, Pin & Led layout and UART parameters.  (The Port's README is the user's reference). 

`mpconfigboard.h`: `Flash` size & define UART.
`mpconfigboard.mk`: `LFS1`
`pins.c`: Define `Pin` & `Led` arrays.
`pins.h`: Define Structs & Consts.