### PR TITLE
ports/samd/boards/WIO_TERMINAL_D51R: New board & configurations to use new Port features.

### DIFF
--- a/ports/samd/boards/WIO_TERMINAL_D51R/mpconfigboard.h
+++ b/ports/samd/boards/WIO_TERMINAL_D51R/mpconfigboard.h
@@ -1,0 +1,33 @@
+#define MICROPY_HW_BOARD_NAME "Wio Terminal D51R"
+#define MICROPY_HW_MCU_NAME   "SAMD51P19A"
+
+#define MICROPY_FLOAT_IMPL              (MICROPY_FLOAT_IMPL_FLOAT)
+#define MICROPY_PY_BUILTINS_COMPLEX     (0)
+#define MICROPY_PY_MATH                 (0)
+#define MICROPY_PY_CMATH                (0)
+
+// MicroPython configs
+// samd_flash.c flash parameters
+// Build a 128k Flash storage at top. 512k-128k=384k=0x60000
+// 512*1024= 0x80000 minus 128*1024= 0x20000 =  0x60000
+#define MICROPY_HW_FLASH_STORAGE_BASE       (0x60000)
+#define MICROPY_HW_FLASH_STORAGE_BYTES      (0x1FFFF)
+#define VFS_BLOCK_SIZE_BYTES                (1536) // 24x 64B flash pages;
+
+// ASF4 MCU package specific Pin definitions
+#include "samd51p19a.h"
+
+// Please consult the SAM_D51 Datasheet, I/O Multiplexing and Considerations.
+// WIO_Terminal USART pin assignments: Tx=BCM14=PB27=SERCOM2/PAD[0], Rx=BCM15=PB26=SERCOM2/PAD[1]
+#define CPU_FREQ (48000000) // For selecting Baud from clock.
+#define MP_PIN_GRP 1 // A-D=0-3
+#define MP_TX_PIN 27
+#define MP_RX_PIN 26 // 'n'
+#define MP_PERIPHERAL_MUX 13 // 'n'th group of 2 pins
+#define USARTx SERCOM2 // 
+#define MP_PORT_FUNC 0x22 // Sets PMUXE & PMUXO to the Alternative Function.A-N=0-13
+#define MP_RXPO_PAD 1 // RXPO- Receive Data Pinout
+#define MP_TXPO_PAD 0 // TXPO- Tranmit Data Pinout
+#define MP_SERCOMx SERCOM2_ // APBCMASK
+#define MP_SERCOM_GCLK_ID_x_CORE SERCOM2_GCLK_ID_CORE
+

--- a/ports/samd/boards/WIO_TERMINAL_D51R/mpconfigboard.mk
+++ b/ports/samd/boards/WIO_TERMINAL_D51R/mpconfigboard.mk
@@ -1,0 +1,8 @@
+MCU_SERIES = SAMD51
+CMSIS_MCU = SAMD51P19A
+LD_FILES = boards/samd51p19a.ld sections.ld
+TEXT0 = 0x4000
+
+# The ?='s allow overriding in mpconfigboard.mk.
+# MicroPython settings
+MICROPY_VFS_LFS1 ?= 1

--- a/ports/samd/boards/WIO_TERMINAL_D51R/pins.c
+++ b/ports/samd/boards/WIO_TERMINAL_D51R/pins.c
@@ -1,0 +1,61 @@
+/*
+ * This file is part of the MicroPython project, http://micropython.org/
+ *
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2021 Peter van der Burg
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * Used by machine_pin.c. Holds Board/MCU specific Pin allocations.
+ */
+
+#include "modmachine.h"
+#include "pins.h"
+
+// Ensure Declaration in "pins.h" reflects # of Pins defined here.
+const machine_pin_obj_t machine_pin_obj[] = {
+    {{&machine_pin_type}, PIN_PB08}, // A0/D0
+    {{&machine_pin_type}, PIN_PB09}, // A1/D1
+    {{&machine_pin_type}, PIN_PA07}, // A2/D2
+    {{&machine_pin_type}, PIN_PB04}, // A3/D3
+    {{&machine_pin_type}, PIN_PB05}, // A4/D4
+    {{&machine_pin_type}, PIN_PB06}, // A5/D5
+    {{&machine_pin_type}, PIN_PA04}, // A6/D6
+    {{&machine_pin_type}, PIN_PB07}, // A7/D7
+    {{&machine_pin_type}, PIN_PA06}, // A8/D8
+    {{&machine_pin_type}, PIN_PD08}, // SWITCH_X
+    {{&machine_pin_type}, PIN_PD09}, // SWITCH_Y
+    {{&machine_pin_type}, PIN_PD10}, // SWITCH_Z
+    {{&machine_pin_type}, PIN_PD12}, // SWITCH_B
+    {{&machine_pin_type}, PIN_PD20}, // SWITCH_U
+    {{&machine_pin_type}, PIN_PC26}, // BUTTON_1
+    {{&machine_pin_type}, PIN_PC27}, // BUTTON_2
+    {{&machine_pin_type}, PIN_PC28}, // BUTTON_3
+    {{&machine_pin_type}, PIN_PD11}, // BUZZER_CTR
+    {{&machine_pin_type}, PIN_PC14}, // 5V_OUTPUT_CTR- enable 5V on hdr
+    {{&machine_pin_type}, PIN_PC15}, // 3V3_OUTPUT_CTR- enable 3V3 on hdr
+};
+
+// Ensure Declaration in 'pins.h' reflects # of Pins defined here.
+const machine_led_obj_t machine_led_obj[] = {
+    {{&machine_led_type}, PIN_PA15}, // USER_LED (Blue)
+    {{&machine_led_type}, PIN_PC05}, // LCD_BACKLIGHT_CTR
+};
+

--- a/ports/samd/boards/WIO_TERMINAL_D51R/pins.h
+++ b/ports/samd/boards/WIO_TERMINAL_D51R/pins.h
@@ -1,0 +1,43 @@
+/*
+ * This file is part of the MicroPython project, http://micropython.org/
+ *
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2021 Peter van der Burg
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * Used by machine_pin.c & board specific pins.c. Holds Board/MCU specific Pin 
+ * allocations.
+ */
+
+typedef struct _machine_pin_obj_t {
+    mp_obj_base_t base;
+    uint32_t id;
+} machine_pin_obj_t;
+
+typedef struct _machine_led_obj_t {
+    mp_obj_base_t base;
+    uint32_t id;
+} machine_led_obj_t;
+
+// MUST explicitly hold array # of rows, else machine_pin.c wont compile.
+extern const machine_pin_obj_t machine_pin_obj[20];
+extern const machine_led_obj_t machine_led_obj[2];
+


### PR DESCRIPTION
This PR creates (new) board specific configuration files to utilise the new Port features. Each board defines its own block device size, Pin & Led layout and UART parameters.  (The Port's README is the user's reference). 

`mpconfigboard.h`: `Flash` size & define UART.
`mpconfigboard.mk`: `LFS1`
`pins.c`: Define `Pin` & `Led` arrays.
`pins.h`: Define Structs & Consts.