### PR TITLE
mimxrt: Extend the Pin module for SoftI2C, SoftSPI support.

### DIFF
--- a/ports/mimxrt/mphalport.h
+++ b/ports/mimxrt/mphalport.h
@@ -31,12 +31,22 @@
 #include "ticks.h"
 #include "pin.h"
 
+#define MP_HAL_PIN_FMT                  "%q"
+
 #define mp_hal_pin_obj_t const machine_pin_obj_t *
+#define mp_hal_get_pin_obj(o)   pin_find(o)
+#define mp_hal_pin_name(p)      ((p)->name)
+#define mp_hal_pin_input(p) machine_pin_set_mode(p, PIN_MODE_IN);
+#define mp_hal_pin_output(p) machine_pin_set_mode(p, PIN_MODE_OUT);
+#define mp_hal_pin_open_drain(p) machine_pin_set_mode(p, PIN_MODE_OPEN_DRAIN);
 #define mp_hal_pin_high(p) (GPIO_PinWrite(p->gpio, p->pin, 1U))
 #define mp_hal_pin_low(p) (GPIO_PinWrite(p->gpio, p->pin, 0U))
 #define mp_hal_pin_write(p, value) (GPIO_PinWrite(p->gpio, p->pin, value))
 #define mp_hal_pin_toggle(p) (GPIO_PortToggle(p->gpio, (1 << p->pin)))
-#define mp_hal_pin_read(p) (GPIO_PinRead(p->gpio, p->pin))
+#define mp_hal_pin_read(p) (GPIO_PinReadPadStatus(p->gpio, p->pin))
+
+#define mp_hal_pin_od_low(p)    mp_hal_pin_low(p)
+#define mp_hal_pin_od_high(p)   mp_hal_pin_high(p)
 
 void mp_hal_set_interrupt_char(int c);
 
@@ -56,6 +66,8 @@ static inline void mp_hal_delay_ms(mp_uint_t ms) {
 static inline void mp_hal_delay_us(mp_uint_t us) {
     ticks_delay_us64(us);
 }
+
+#define mp_hal_delay_us_fast(us) mp_hal_delay_us(us)
 
 static inline mp_uint_t mp_hal_ticks_cpu(void) {
     return 0;

--- a/ports/mimxrt/pin.h
+++ b/ports/mimxrt/pin.h
@@ -140,5 +140,6 @@ const machine_pin_obj_t *pin_find_named_pin(const mp_obj_dict_t *named_pins, mp_
 const machine_pin_af_obj_t *pin_find_af(const machine_pin_obj_t *pin, uint8_t fn);
 const machine_pin_af_obj_t *pin_find_af_by_index(const machine_pin_obj_t *pin, mp_uint_t af_idx);
 const machine_pin_af_obj_t *pin_find_af_by_name(const machine_pin_obj_t *pin, const char *name);
+void machine_pin_set_mode(const machine_pin_obj_t *pin, uint8_t mode);
 
 #endif // MICROPY_INCLUDED_MIMXRT_PIN_H


### PR DESCRIPTION
This change consists mostly of chaning and extending the required
definitions in mphalport.h.