### PR TITLE
esp8266/boards/GENERIC_512K: Add custom manifest without FS modules.

### DIFF
--- a/ports/esp8266/boards/GENERIC_512K/manifest.py
+++ b/ports/esp8266/boards/GENERIC_512K/manifest.py
@@ -1,0 +1,4 @@
+freeze("$(PORT_DIR)/modules", ("apa102.py", "neopixel.py", "ntptime.py", "port_diag.py"))
+freeze("$(MPY_DIR)/drivers/dht", "dht.py")
+freeze("$(MPY_DIR)/drivers/onewire")
+include("$(MPY_DIR)/extmod/webrepl/manifest.py")

--- a/ports/esp8266/boards/GENERIC_512K/mpconfigboard.mk
+++ b/ports/esp8266/boards/GENERIC_512K/mpconfigboard.mk
@@ -1,1 +1,3 @@
 LD_FILES = boards/esp8266_512k.ld
+
+FROZEN_MANIFEST ?= $(BOARD_DIR)/manifest.py


### PR DESCRIPTION
The 512k build does not have a filesystem so there is no reason to include
the filesystem-related modules.  This commit provides a custom manifest.py
for this board which no longer includes: _boot.py, flashbdev.py,
inisetup.py, upip.py, upip_utarfile.py.  This cuts the build down by about
9k of flash.