### PR TITLE
stm32/boards/PYBD_SF2: Disable GCC 11 warnings for array bounds.

### DIFF
--- a/ports/stm32/boards/PYBD_SF2/board_init.c
+++ b/ports/stm32/boards/PYBD_SF2/board_init.c
@@ -64,7 +64,15 @@ void board_sleep(int value) {
 void mp_hal_get_mac(int idx, uint8_t buf[6]) {
     // Check if OTP region has a valid MAC address, and use it if it does
     if (OTP->series == 0x00d1 && OTP->mac[0] == 'H' && OTP->mac[1] == 'J' && OTP->mac[2] == '0') {
+        #if __GNUC__ >= 11
+        #pragma GCC diagnostic push
+        #pragma GCC diagnostic ignored "-Warray-bounds"
+        #pragma GCC diagnostic ignored "-Wstringop-overread"
+        #endif
         memcpy(buf, OTP->mac, 6);
+        #if __GNUC__ >= 11
+        #pragma GCC diagnostic pop
+        #endif
         buf[5] += idx;
         return;
     }


### PR DESCRIPTION
With GCC 11 there is now a warning about array bounds of OTP-mac, due to the OTP being a literal address.

This is a pretty ugly workaround for the warning, but I could not find anything better.