### PR TITLE
tests/basics: Split out literal tests that raise SyntaxWarning on CPy.

### DIFF
--- a/tests/basics/is_isnot.py
+++ b/tests/basics/is_isnot.py
@@ -1,14 +1,4 @@
-print(1 is 1)
-print(1 is 2)
-print(1 is not 1)
-print(1 is not 2)
-
-
 print([1, 2] is [1, 2])
 a = [1, 2]
 b = a
 print(b is a)
-
-# TODO: strings require special "is" handling, postponed
-# until qstr refactor.
-#print("a" is "a")

--- a/tests/basics/is_isnot_literal.py
+++ b/tests/basics/is_isnot_literal.py
@@ -1,0 +1,13 @@
+# test "is" and "is not" with literal arguments
+# these raise a SyntaxWarning in CPython because the results are
+# implementation dependent; see https://bugs.python.org/issue34850
+
+print(1 is 1)
+print(1 is 2)
+print(1 is not 1)
+print(1 is not 2)
+
+print("a" is "a")
+print("a" is "b")
+print("a" is not "a")
+print("a" is not "b")

--- a/tests/basics/is_isnot_literal.py.exp
+++ b/tests/basics/is_isnot_literal.py.exp
@@ -1,0 +1,8 @@
+True
+False
+False
+True
+True
+False
+False
+True

--- a/tests/basics/op_error.py
+++ b/tests/basics/op_error.py
@@ -30,15 +30,7 @@ except TypeError:
 
 # unsupported subscription
 try:
-    1[0]
-except TypeError:
-    print('TypeError')
-try:
     1[0] = 1
-except TypeError:
-    print('TypeError')
-try:
-    ''['']
 except TypeError:
     print('TypeError')
 try:
@@ -47,12 +39,6 @@ except TypeError:
     print('TypeError')
 try:
     del 1[0]
-except TypeError:
-    print('TypeError')
-
-# not callable
-try:
-    1()
 except TypeError:
     print('TypeError')
 

--- a/tests/basics/op_error_literal.py
+++ b/tests/basics/op_error_literal.py
@@ -1,0 +1,18 @@
+# test errors from bad operations with literals
+# these raise a SyntaxWarning in CPython; see https://bugs.python.org/issue15248
+
+# unsupported subscription
+try:
+    1[0]
+except TypeError:
+    print("TypeError")
+try:
+    ""[""]
+except TypeError:
+    print("TypeError")
+
+# not callable
+try:
+    1()
+except TypeError:
+    print("TypeError")

--- a/tests/basics/op_error_literal.py.exp
+++ b/tests/basics/op_error_literal.py.exp
@@ -1,0 +1,3 @@
+TypeError
+TypeError
+TypeError


### PR DESCRIPTION
Fixes issue #7330.