### PR TITLE
py/compile: Raise an error on async with/for outside an async function.

### DIFF
--- a/py/compile.c
+++ b/py/compile.c
@@ -1970,13 +1970,23 @@ STATIC void compile_async_stmt(compiler_t *comp, mp_parse_node_struct_t *pns) {
         compile_funcdef(comp, pns0);
         scope_t *fscope = (scope_t *)pns0->nodes[4];
         fscope->scope_flags |= MP_SCOPE_FLAG_GENERATOR;
-    } else if (MP_PARSE_NODE_STRUCT_KIND(pns0) == PN_for_stmt) {
-        // async for
-        compile_async_for_stmt(comp, pns0);
     } else {
-        // async with
-        assert(MP_PARSE_NODE_STRUCT_KIND(pns0) == PN_with_stmt);
-        compile_async_with_stmt(comp, pns0);
+        // async for/with; first verify the scope is a generator
+        int scope_flags = comp->scope_cur->scope_flags;
+        if (!(scope_flags & MP_SCOPE_FLAG_GENERATOR)) {
+            compile_syntax_error(comp, (mp_parse_node_t)pns0,
+                MP_ERROR_TEXT("async for/with outside async function"));
+            return;
+        }
+
+        if (MP_PARSE_NODE_STRUCT_KIND(pns0) == PN_for_stmt) {
+            // async for
+            compile_async_for_stmt(comp, pns0);
+        } else {
+            // async with
+            assert(MP_PARSE_NODE_STRUCT_KIND(pns0) == PN_with_stmt);
+            compile_async_with_stmt(comp, pns0);
+        }
     }
 }
 #endif

--- a/tests/basics/async_syntaxerror.py
+++ b/tests/basics/async_syntaxerror.py
@@ -1,0 +1,19 @@
+# test syntax errors using async
+
+try:
+    exec
+except NameError:
+    print("SKIP")
+    raise SystemExit
+
+
+def test_syntax(code):
+    try:
+        exec(code)
+        print("no SyntaxError")
+    except SyntaxError:
+        print("SyntaxError")
+
+
+test_syntax("async for x in (): x")
+test_syntax("async with x: x")

--- a/tests/basics/async_syntaxerror.py.exp
+++ b/tests/basics/async_syntaxerror.py.exp
@@ -1,0 +1,2 @@
+SyntaxError
+SyntaxError


### PR DESCRIPTION
Builds on #5731: reduces code size and adds a test.