### PR TITLE
extmod/modurandom: Support an argument of bits=0 to getrandbits.

### DIFF
--- a/extmod/modurandom.c
+++ b/extmod/modurandom.c
@@ -87,8 +87,11 @@ STATIC uint32_t yasmarang_randbelow(uint32_t n) {
 
 STATIC mp_obj_t mod_urandom_getrandbits(mp_obj_t num_in) {
     int n = mp_obj_get_int(num_in);
-    if (n > 32 || n == 0) {
+    if (n > 32 || n < 0) {
         mp_raise_ValueError(MP_ERROR_TEXT("bits must be 32 or less"));
+    }
+    if (n == 0) {
+        return MP_OBJ_NEW_SMALL_INT(0);
     }
     uint32_t mask = ~0;
     // Beware of C undefined behavior when shifting by >= than bit size

--- a/tests/extmod/urandom_basic.py
+++ b/tests/extmod/urandom_basic.py
@@ -22,8 +22,11 @@ r = random.getrandbits(16)
 random.seed(1)
 print(random.getrandbits(16) == r)
 
-# check that it throws an error for zero bits
+# check that zero bits works
+print(random.getrandbits(0))
+
+# check that it throws an error for negative bits
 try:
-    random.getrandbits(0)
+    random.getrandbits(-1)
 except ValueError:
     print("ValueError")

--- a/tests/extmod/urandom_basic.py.exp
+++ b/tests/extmod/urandom_basic.py.exp
@@ -1,0 +1,4 @@
+True
+True
+0
+ValueError


### PR DESCRIPTION
The was changed in CPython 3.9, to allow 0.

See #6750 and #6922.