### PR TITLE
py/builtinimport: Change relative import's ValueError to ImportError.

### DIFF
--- a/py/builtinimport.c
+++ b/py/builtinimport.c
@@ -313,7 +313,7 @@ mp_obj_t mp_builtin___import__(size_t n_args, const mp_obj_t *args) {
 
         // We must have some component left over to import from
         if (p == this_name) {
-            mp_raise_ValueError(MP_ERROR_TEXT("can't perform relative import"));
+            mp_raise_msg(&mp_type_ImportError, MP_ERROR_TEXT("can't perform relative import"));
         }
 
         uint new_mod_l = (mod_len == 0 ? (size_t)(p - this_name) : (size_t)(p - this_name) + 1 + mod_len);

--- a/tests/import/import_pkg7.py.exp
+++ b/tests/import/import_pkg7.py.exp
@@ -1,0 +1,8 @@
+pkg __name__: pkg7
+pkg __name__: pkg7.subpkg1
+pkg __name__: pkg7.subpkg1.subpkg2
+mod1
+mod2
+mod1.foo
+mod2.bar
+ImportError

--- a/tests/import/pkg7/subpkg1/subpkg2/mod3.py
+++ b/tests/import/pkg7/subpkg1/subpkg2/mod3.py
@@ -7,5 +7,5 @@ print(bar)
 # attempted relative import beyond top-level package
 try:
     from .... import mod1
-except ValueError:
-    print("ValueError")
+except ImportError:
+    print("ImportError")


### PR DESCRIPTION
Following CPython change, see https://bugs.python.org/issue37444.

Fixes #6750.