### PR TITLE
mimxrt: Stop a previous timer on channel reuse.

### DIFF
--- a/ports/mimxrt/machine_timer.c
+++ b/ports/mimxrt/machine_timer.c
@@ -148,6 +148,12 @@ STATIC mp_obj_t machine_timer_make_new(const mp_obj_type_t *type, size_t n_args,
         mp_raise_ValueError(MP_ERROR_TEXT("Timer does not exist"));
     }
 
+    // check, if a timer exists at that channel and stop it first
+    if (MP_STATE_PORT(timer_table)[id] != NULL) {
+        PIT_StopTimer(PIT, channel_no[id]);
+        MP_STATE_PORT(timer_table)[id] = NULL;
+    }
+
     // Set initial values
     self->id = id;
     self->channel = channel_no[id];

--- a/ports/mimxrt/machine_timer.c
+++ b/ports/mimxrt/machine_timer.c
@@ -37,7 +37,7 @@
 #define TIMER_MIN_PERIOD 1
 
 #define alarm_callback PIT_IRQHandler
-#define PIT_SOURCE_CLOCK CLOCK_GetFreq(kCLOCK_OscClk)
+#define PIT_SOURCE_CLOCK CLOCK_GetIpgFreq()
 #define PIT_IRQ_ID PIT_IRQn
 
 typedef struct _machine_timer_obj_t {
@@ -188,8 +188,6 @@ void machine_timer_init_PIT(void) {
     // PIT timer
     // Enable clock gate for GPIO1
     CLOCK_EnableClock(kCLOCK_Gpio1); // ?
-    // Set PERCLK_CLK source to OSC_CLK
-    CLOCK_SetMux(kCLOCK_PerclkMux, 1U);
     // Set PERCLK_CLK divider to 1
     CLOCK_SetDiv(kCLOCK_PerclkDiv, 0U);
 

--- a/ports/mimxrt/mpconfigport.h
+++ b/ports/mimxrt/mpconfigport.h
@@ -125,7 +125,6 @@ extern const struct _mp_obj_module_t mp_module_utime;
     do { \
         extern void mp_handle_pending(bool); \
         mp_handle_pending(true); \
-        __WFE(); \
     } while (0);
 
 #define MICROPY_MAKE_POINTER_CALLABLE(p) ((void *)((mp_uint_t)(p) | 1))


### PR DESCRIPTION
As suggested by Damien. Doing it now, before it fades away in the past.