### PR TITLE
esp32/Makefile: Fix wrong target

### DIFF
--- a/ports/esp32/Makefile
+++ b/ports/esp32/Makefile
@@ -38,7 +38,7 @@ all:
     		$(BUILD)/micropython.bin \
     		$(BUILD)/firmware.bin
 
-$(BUILD)/bootloader/bootloader.bin $(BUILD)/partition_table/partition  -table.bin $(BUILD)/micropython.bin: FORCE
+$(BUILD)/bootloader/bootloader.bin $(BUILD)/partition_table/partition-table.bin $(BUILD)/micropython.bin: FORCE
 
 clean:
 	idf.py $(IDFPY_FLAGS) fullclean


### PR DESCRIPTION
   "$(BUILD)/partition_table/partition  -table.bin" is typing mistake.

Signed-off-by: leo chung <gewalalb@gmail.com>