### PR TITLE
esp32/modnetwork: wlan.config(reconnects=N) may be used to disable automatic reconnects.

### DIFF
--- a/docs/esp32/quickref.rst
+++ b/docs/esp32/quickref.rst
@@ -102,6 +102,12 @@ Once the network is established the :mod:`socket <usocket>` module can be used
 to create and use TCP/UDP sockets as usual, and the ``urequests`` module for
 convenient HTTP requests.
 
+After a call to ``wlan.connect()``, micropython will by default retry to connect
+**forever**, even when the authentication failed or no AP is in range. ``wlan.status()`` will return ``network.STAT_CONNECTING`` in this state until a connection succeeds or the interface gets disabled (e.g. by ``wlan.active(False)``).
+
+This can be changed by calling ``wlan.config(reconnects=n)``, where n are the number of
+desired reconnects. A value of -1 will restore the default behavior (try to reconnect forever).
+
 Delay and timing
 ----------------
 

--- a/ports/esp32/modnetwork.c
+++ b/ports/esp32/modnetwork.c
@@ -142,12 +142,16 @@ static uint8_t wifi_sta_disconn_reason = 0;
 static bool mdns_initialised = false;
 #endif
 
+static uint8_t conf_wifi_sta_reconnects = 0;
+static uint8_t wifi_sta_reconnects;
+
 // This function is called by the system-event task and so runs in a different
 // thread to the main MicroPython task.  It must not raise any Python exceptions.
 static esp_err_t event_handler(void *ctx, system_event_t *event) {
     switch (event->event_id) {
         case SYSTEM_EVENT_STA_START:
             ESP_LOGI("wifi", "STA_START");
+            wifi_sta_reconnects = 0;
             break;
         case SYSTEM_EVENT_STA_CONNECTED:
             ESP_LOGI("network", "CONNECTED");
@@ -199,14 +203,22 @@ static esp_err_t event_handler(void *ctx, system_event_t *event) {
             wifi_sta_connected = false;
             if (wifi_sta_connect_requested) {
                 wifi_mode_t mode;
-                if (esp_wifi_get_mode(&mode) == ESP_OK) {
-                    if (mode & WIFI_MODE_STA) {
-                        // STA is active so attempt to reconnect.
-                        esp_err_t e = esp_wifi_connect();
-                        if (e != ESP_OK) {
-                            ESP_LOGI("wifi", "error attempting to reconnect: 0x%04x", e);
-                        }
+                if (esp_wifi_get_mode(&mode) != ESP_OK) {
+                    break;
+                }
+                if (!(mode & WIFI_MODE_STA)) {
+                    break;
+                }
+                if (conf_wifi_sta_reconnects) {
+                    ESP_LOGI("wifi", "reconnect counter=%d, max=%d",
+                        wifi_sta_reconnects, conf_wifi_sta_reconnects);
+                    if (++wifi_sta_reconnects >= conf_wifi_sta_reconnects) {
+                        break;
                     }
+                }
+                esp_err_t e = esp_wifi_connect();
+                if (e != ESP_OK) {
+                    ESP_LOGI("wifi", "error attempting to reconnect: 0x%04x", e);
                 }
             }
             break;
@@ -361,6 +373,7 @@ STATIC mp_obj_t esp_connect(size_t n_args, const mp_obj_t *pos_args, mp_map_t *k
         ESP_EXCEPTIONS(esp_wifi_set_config(ESP_IF_WIFI_STA, &wifi_sta_config));
     }
 
+    wifi_sta_reconnects = 0;
     // connect to the WiFi AP
     MP_THREAD_GIL_EXIT();
     ESP_EXCEPTIONS(esp_wifi_connect());
@@ -395,7 +408,9 @@ STATIC mp_obj_t esp_status(size_t n_args, const mp_obj_t *args) {
             if (wifi_sta_connected) {
                 // Happy path, connected with IP
                 return MP_OBJ_NEW_SMALL_INT(STAT_GOT_IP);
-            } else if (wifi_sta_connect_requested) {
+            } else if (wifi_sta_connect_requested
+                       && (conf_wifi_sta_reconnects == 0
+                           || wifi_sta_reconnects < conf_wifi_sta_reconnects)) {
                 // No connection or error, but is requested = Still connecting
                 return MP_OBJ_NEW_SMALL_INT(STAT_CONNECTING);
             } else if (wifi_sta_disconn_reason == 0) {
@@ -633,6 +648,14 @@ STATIC mp_obj_t esp_config(size_t n_args, const mp_obj_t *args, mp_map_t *kwargs
                         cfg.ap.max_connection = mp_obj_get_int(kwargs->table[i].value);
                         break;
                     }
+                    case QS(MP_QSTR_reconnects): {
+                        int reconnects = mp_obj_get_int(kwargs->table[i].value);
+                        req_if = WIFI_IF_STA;
+                        // parameter reconnects == -1 means to retry forever.
+                        // here means conf_wifi_sta_reconnects == 0 to retry forever.
+                        conf_wifi_sta_reconnects = (reconnects == -1) ? 0 : reconnects + 1;
+                        break;
+                    }
                     default:
                         goto unknown;
                 }
@@ -711,6 +734,11 @@ STATIC mp_obj_t esp_config(size_t n_args, const mp_obj_t *args, mp_map_t *kwargs
             val = MP_OBJ_NEW_SMALL_INT(cfg.ap.max_connection);
             break;
         }
+        case QS(MP_QSTR_reconnects):
+            req_if = WIFI_IF_STA;
+            int rec = conf_wifi_sta_reconnects - 1;
+            val = MP_OBJ_NEW_SMALL_INT(rec);
+            break;
         default:
             goto unknown;
     }


### PR DESCRIPTION
I consider the automatic reconnect mentioned in #5326 a **bug**, as 
- this doesn't seem the behavior of other ports
- it doesn't allow the developer/user to decide how to react to short/infinite wifi outages
- it doesn't allow to shutdown WIFI in the shortest possible time, given no AP can be reached.
- it's not documented anywhere (I added documentation in #7301)

This introduces a `#define MICROPY_WIFI_STA_CONNECT_TRIES` with the following values:
- 0 or undefined: current behavior (retry connect until wlan gets deactivated)
- 1: one connect try, no reconnect
- greater than zero: max. number of connection attempts.

Still testing this, as #4838 speaks of troubles regarding AUTH_FAILURE on first connect.

Maybe it might be better to define this at runtime, e.g. via `wlan.config()` ?