### PR TITLE
py/emitglue: Always flush caches when assigning native Thumb code.

### DIFF
--- a/.github/workflows/ports_unix.yml
+++ b/.github/workflows/ports_unix.yml
@@ -200,3 +200,17 @@ jobs:
     - name: Print failures
       if: failure()
       run: tests/run-tests.py --print-failures
+
+  qemu_arm:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Install packages
+      run: source tools/ci.sh && ci_unix_qemu_arm_setup
+    - name: Build
+      run: source tools/ci.sh && ci_unix_qemu_arm_build
+    - name: Run main test suite
+      run: source tools/ci.sh && ci_unix_qemu_arm_run_tests
+    - name: Print failures
+      if: failure()
+      run: tests/run-tests.py --print-failures

--- a/ports/unix/main.c
+++ b/ports/unix/main.c
@@ -451,7 +451,13 @@ MP_NOINLINE int main_(int argc, char **argv) {
     signal(SIGPIPE, SIG_IGN);
     #endif
 
-    mp_stack_set_limit(40000 * (sizeof(void *) / 4));
+    // Define a reasonable stack limit to detect stack overflow.
+    mp_uint_t stack_limit = 40000 * (sizeof(void *) / 4);
+    #if defined(__arm__) && !defined(__thumb2__)
+    // ARM (non-Thumb) architectures require more stack.
+    stack_limit *= 2;
+    #endif
+    mp_stack_set_limit(stack_limit);
 
     pre_process_options(argc, argv);
 

--- a/py/asmarm.c
+++ b/py/asmarm.c
@@ -38,25 +38,6 @@
 
 #define SIGNED_FIT24(x) (((x) & 0xff800000) == 0) || (((x) & 0xff000000) == 0xff000000)
 
-void asm_arm_end_pass(asm_arm_t *as) {
-    if (as->base.pass == MP_ASM_PASS_EMIT) {
-        #if (defined(__linux__) && defined(__GNUC__)) || __ARM_ARCH == 7
-        char *start = mp_asm_base_get_code(&as->base);
-        char *end = start + mp_asm_base_get_code_size(&as->base);
-        __builtin___clear_cache(start, end);
-        #elif defined(__arm__)
-        // flush I- and D-cache
-        asm volatile (
-            "0:"
-            "mrc p15, 0, r15, c7, c10, 3\n" // test and clean D-cache
-            "bne 0b\n"
-            "mov r0, #0\n"
-            "mcr p15, 0, r0, c7, c7, 0\n" // invalidate I-cache and D-cache
-            : : : "r0", "cc");
-        #endif
-    }
-}
-
 // Insert word into instruction flow
 STATIC void emit(asm_arm_t *as, uint op) {
     uint8_t *c = mp_asm_base_get_cur_to_write_bytes(&as->base, 4);

--- a/py/asmarm.h
+++ b/py/asmarm.h
@@ -72,7 +72,9 @@ typedef struct _asm_arm_t {
     uint stack_adjust;
 } asm_arm_t;
 
-void asm_arm_end_pass(asm_arm_t *as);
+static inline void asm_arm_end_pass(asm_arm_t *as) {
+    (void)as;
+}
 
 void asm_arm_entry(asm_arm_t *as, int num_locals);
 void asm_arm_exit(asm_arm_t *as);

--- a/py/asmthumb.c
+++ b/py/asmthumb.c
@@ -35,7 +35,6 @@
 
 #include "py/mpstate.h"
 #include "py/persistentcode.h"
-#include "py/mphal.h"
 #include "py/asmthumb.h"
 
 #define UNSIGNED_FIT5(x) ((uint32_t)(x) < 32)
@@ -60,20 +59,6 @@
 
 static inline byte *asm_thumb_get_cur_to_write_bytes(asm_thumb_t *as, int n) {
     return mp_asm_base_get_cur_to_write_bytes(&as->base, n);
-}
-
-void asm_thumb_end_pass(asm_thumb_t *as) {
-    (void)as;
-    // could check labels are resolved...
-
-    #if __ICACHE_PRESENT == 1
-    if (as->base.pass == MP_ASM_PASS_EMIT) {
-        // flush D-cache, so the code emitted is stored in memory
-        MP_HAL_CLEAN_DCACHE(as->base.code_base, as->base.code_size);
-        // invalidate I-cache
-        SCB_InvalidateICache();
-    }
-    #endif
 }
 
 /*

--- a/py/asmthumb.h
+++ b/py/asmthumb.h
@@ -70,7 +70,9 @@ typedef struct _asm_thumb_t {
     uint32_t stack_adjust;
 } asm_thumb_t;
 
-void asm_thumb_end_pass(asm_thumb_t *as);
+static inline void asm_thumb_end_pass(asm_thumb_t *as) {
+    (void)as;
+}
 
 void asm_thumb_entry(asm_thumb_t *as, int num_locals);
 void asm_thumb_exit(asm_thumb_t *as);

--- a/py/emitglue.c
+++ b/py/emitglue.c
@@ -108,6 +108,31 @@ void mp_emit_glue_assign_native(mp_raw_code_t *rc, mp_raw_code_kind_t kind, void
 
     assert(kind == MP_CODE_NATIVE_PY || kind == MP_CODE_NATIVE_VIPER || kind == MP_CODE_NATIVE_ASM);
 
+    // Some architectures require flushing/invalidation of the I/D caches,
+    // so that the generated native code which was created in data RAM will
+    // be available for execution from instruction RAM.
+    #if MICROPY_EMIT_THUMB || MICROPY_EMIT_INLINE_THUMB
+    #if __ICACHE_PRESENT == 1
+    // Flush D-cache, so the code emitted is stored in RAM.
+    MP_HAL_CLEAN_DCACHE(fun_data, fun_len);
+    // Invalidate I-cache, so the newly-created code is reloaded from RAM.
+    SCB_InvalidateICache();
+    #endif
+    #elif MICROPY_EMIT_ARM
+    #if (defined(__linux__) && defined(__GNUC__)) || __ARM_ARCH == 7
+    __builtin___clear_cache(fun_data, (uint8_t *)fun_data + fun_len);
+    #elif defined(__arm__)
+    // Flush I-cache and D-cache.
+    asm volatile (
+        "0:"
+        "mrc p15, 0, r15, c7, c10, 3\n" // test and clean D-cache
+        "bne 0b\n"
+        "mov r0, #0\n"
+        "mcr p15, 0, r0, c7, c7, 0\n" // invalidate I-cache and D-cache
+        : : : "r0", "cc");
+    #endif
+    #endif
+
     rc->kind = kind;
     rc->scope_flags = scope_flags;
     rc->n_pos_args = n_pos_args;

--- a/py/stackctrl.h
+++ b/py/stackctrl.h
@@ -40,7 +40,7 @@ void mp_stack_check(void);
 
 #else
 
-#define mp_stack_set_limit(limit)
+#define mp_stack_set_limit(limit) (void)(limit)
 #define MP_STACK_CHECK()
 
 #endif

--- a/tools/ci.sh
+++ b/tools/ci.sh
@@ -300,6 +300,12 @@ CI_UNIX_OPTS_QEMU_MIPS=(
     LDFLAGS_EXTRA="-static"
 )
 
+CI_UNIX_OPTS_QEMU_ARM=(
+    CROSS_COMPILE=arm-linux-gnueabi-
+    VARIANT=coverage
+    MICROPY_STANDALONE=1
+)
+
 function ci_unix_build_helper {
     make ${MAKEOPTS} -C mpy-cross
     make ${MAKEOPTS} -C ports/unix "$@" submodules
@@ -504,6 +510,25 @@ function ci_unix_qemu_mips_run_tests {
     # - ffi tests do not work
     file ./ports/unix/micropython-coverage
     (cd tests && MICROPY_MICROPYTHON=../ports/unix/micropython-coverage ./run-tests.py --exclude 'vfs_posix.py' --exclude 'ffi_(callback|float|float2).py')
+}
+
+function ci_unix_qemu_arm_setup {
+    sudo apt-get update
+    sudo apt-get install gcc-arm-linux-gnueabi g++-arm-linux-gnueabi
+    sudo apt-get install qemu-user
+    qemu-arm --version
+}
+
+function ci_unix_qemu_arm_build {
+    ci_unix_build_helper "${CI_UNIX_OPTS_QEMU_ARM[@]}"
+}
+
+function ci_unix_qemu_arm_run_tests {
+    # Issues with ARM tests:
+    # - (i)listdir does not work, it always returns the empty list (it's an issue with the underlying C call)
+    export QEMU_LD_PREFIX=/usr/arm-linux-gnueabi
+    file ./ports/unix/micropython-coverage
+    (cd tests && MICROPY_MICROPYTHON=../ports/unix/micropython-coverage ./run-tests.py --exclude 'vfs_posix.py')
 }
 
 ########################################################################################


### PR DESCRIPTION
Prior to this commit, cache flushing for Thumb native code was done only in the assembler code `asm_thumb_end_pass()` at the last pass of the assembler.  But this misses flushing the cache when loading native code from an .mpy file, ie in `persistentcode.c`.

The change here makes sure the cache is always flushed/cleaned/invalidated when assigning native code on Thumb archs.

This bug was found running `tests/micropython/import_mpy_native_gc.py` on the mimxrt port.

TODO: ~~needs more testing on different MCUs.~~