### PR TITLE
extmod/uasyncio: Fix start_server and wait_closed race condition

### DIFF
--- a/extmod/uasyncio/stream.py
+++ b/extmod/uasyncio/stream.py
@@ -112,7 +112,6 @@ class Server:
         s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
         s.bind(ai[-1])
         s.listen(backlog)
-        self.task = core.cur_task
         # Accept incoming connections
         while True:
             try:
@@ -135,7 +134,7 @@ class Server:
 # TODO could use an accept-callback on socket read activity instead of creating a task
 async def start_server(cb, host, port, backlog=5):
     s = Server()
-    core.create_task(s._serve(cb, host, port, backlog))
+    s.task = core.create_task(s._serve(cb, host, port, backlog))
     return s
 
 


### PR DESCRIPTION
This fix prevents server.wait_closed() from raising an AttributeError
when trying to access server.task. This can happen if it is called
immediately after start_server().