### PR TITLE
stm32/boardctrl: Skip running main.py if boot.py had an error.

### DIFF
--- a/ports/stm32/boardctrl.c
+++ b/ports/stm32/boardctrl.c
@@ -155,6 +155,8 @@ int boardctrl_run_boot_py(boardctrl_state_t *state) {
             return BOARDCTRL_GOTO_SOFT_RESET_EXIT;
         }
         if (!ret) {
+            // There was an error, prevent main.py from running and flash LEDs.
+            state->reset_mode = BOARDCTRL_RESET_MODE_SAFE_MODE;
             flash_error(4);
         }
     }


### PR DESCRIPTION
Previous behaviour was, if `boot.py` had an exception then `main.py` would still run, which is probably unexpected.

This PR changes the behaviour so `main.py` is not run if `boot.py` has an error.