### PR TITLE
esp32/makeimg.py: Load sizes from partition table and verify data fits.

### DIFF
--- a/ports/esp32/makeimg.py
+++ b/ports/esp32/makeimg.py
@@ -1,19 +1,44 @@
-import sys
+# Combine bootloader, partition table and application into a final binary.
+
+import os, sys
+
+sys.path.append(os.getenv("IDF_PATH") + "/components/partition_table")
+
+import gen_esp32part
 
 OFFSET_BOOTLOADER = 0x1000
 OFFSET_PARTITIONS = 0x8000
-OFFSET_APPLICATION = 0x10000
+
+
+def load_partition_table(filename):
+    with open(filename, "rb") as f:
+        return gen_esp32part.PartitionTable.from_binary(f.read())
+
+
+partition_table = load_partition_table(sys.argv[2])
+
+max_size_bootloader = OFFSET_PARTITIONS - OFFSET_BOOTLOADER
+max_size_partitions = 0
+offset_application = 0
+max_size_application = 0
+
+for part in partition_table:
+    if part.name == "nvs":
+        max_size_partitions = part.offset - OFFSET_PARTITIONS
+    elif part.type == gen_esp32part.APP_TYPE and offset_application == 0:
+        offset_application = part.offset
+        max_size_application = part.size
 
 files_in = [
-    ("bootloader", OFFSET_BOOTLOADER, sys.argv[1]),
-    ("partitions", OFFSET_PARTITIONS, sys.argv[2]),
-    ("application", OFFSET_APPLICATION, sys.argv[3]),
+    ("bootloader", OFFSET_BOOTLOADER, max_size_bootloader, sys.argv[1]),
+    ("partitions", OFFSET_PARTITIONS, max_size_partitions, sys.argv[2]),
+    ("application", offset_application, max_size_application, sys.argv[3]),
 ]
 file_out = sys.argv[4]
 
 cur_offset = OFFSET_BOOTLOADER
 with open(file_out, "wb") as fout:
-    for name, offset, file_in in files_in:
+    for name, offset, max_size, file_in in files_in:
         assert offset >= cur_offset
         fout.write(b"\xff" * (offset - cur_offset))
         cur_offset = offset
@@ -21,5 +46,14 @@ with open(file_out, "wb") as fout:
             data = fin.read()
             fout.write(data)
             cur_offset += len(data)
-            print("%-12s% 8d" % (name, len(data)))
-    print("%-12s% 8d" % ("total", cur_offset))
+            print(
+                "%-12s@0x%06x % 8d  (% 8d remaining)"
+                % (name, offset, len(data), max_size - len(data))
+            )
+            if len(data) > max_size:
+                print(
+                    "ERROR: %s overflows allocated space of %d bytes by %d bytes"
+                    % (name, max_size, len(data) - max_size)
+                )
+                sys.exit(1)
+    print("%-22s% 8d" % ("total", cur_offset))

--- a/ports/esp32/partitions-16MiB.csv
+++ b/ports/esp32/partitions-16MiB.csv
@@ -1,6 +1,5 @@
 # Notes: the offset of the partition table itself is set in
-# $ESPIDF/components/partition_table/Kconfig.projbuild and the
-# offset of the factory/ota_0 partition is set in makeimg.py
+# $IDF_PATH/components/partition_table/Kconfig.projbuild.
 # Name,   Type, SubType, Offset,  Size, Flags
 nvs,      data, nvs,     0x9000,  0x6000,
 phy_init, data, phy,     0xf000,  0x1000,

--- a/ports/esp32/partitions-2MiB.csv
+++ b/ports/esp32/partitions-2MiB.csv
@@ -1,6 +1,5 @@
 # Notes: the offset of the partition table itself is set in
-# $ESPIDF/components/partition_table/Kconfig.projbuild and the
-# offset of the factory/ota_0 partition is set in makeimg.py
+# $IDF_PATH/components/partition_table/Kconfig.projbuild.
 # Name,     Type, SubType, Offset,   Size, Flags
 nvs,        data, nvs,     0x9000,   0x6000,
 phy_init,   data, phy,     0xf000,   0x1000,

--- a/ports/esp32/partitions-ota.csv
+++ b/ports/esp32/partitions-ota.csv
@@ -1,7 +1,6 @@
 # Partition table for MicroPython with OTA support using 4MB flash
 # Notes: the offset of the partition table itself is set in
-# $ESPIDF/components/partition_table/Kconfig.projbuild and the
-# offset of the factory/ota_0 partition is set in makeimg.py
+# $IDF_PATH/components/partition_table/Kconfig.projbuild.
 # Name,   Type, SubType, Offset,   Size,     Flags
 nvs,      data, nvs,     0x9000,   0x4000,
 otadata,  data, ota,     0xd000,   0x2000,

--- a/ports/esp32/partitions.csv
+++ b/ports/esp32/partitions.csv
@@ -1,6 +1,5 @@
 # Notes: the offset of the partition table itself is set in
-# $ESPIDF/components/partition_table/Kconfig.projbuild and the
-# offset of the factory/ota_0 partition is set in makeimg.py
+# $IDF_PATH/components/partition_table/Kconfig.projbuild.
 # Name,   Type, SubType, Offset,  Size, Flags
 nvs,      data, nvs,     0x9000,  0x6000,
 phy_init, data, phy,     0xf000,  0x1000,


### PR DESCRIPTION
Changes introduced are:
- the application offset is now loaded from the partition table instead of being hard-coded to 0x10000
- maximum size of all sections is computed using the partition table
- an error is generated if any section overflows its allocated space
- remaining bytes are printed for each section