### PR TITLE
mimxrt: Return to the common rtc.datetime format.

### DIFF
--- a/ports/mimxrt/machine_rtc.c
+++ b/ports/mimxrt/machine_rtc.c
@@ -37,6 +37,7 @@ typedef struct _machine_rtc_obj_t {
 
 // Singleton RTC object.
 STATIC const machine_rtc_obj_t machine_rtc_obj = {{&machine_rtc_type}};
+uint32_t us_offset = 0;
 
 // Calculate the weekday from the date.
 // The result is zero based with 0 = Sunday.
@@ -70,7 +71,7 @@ STATIC mp_obj_t machine_rtc_datetime_helper(size_t n_args, const mp_obj_t *args)
             mp_obj_new_int(srtc_date.hour),
             mp_obj_new_int(srtc_date.minute),
             mp_obj_new_int(srtc_date.second),
-            mp_obj_new_int(ticks_us64() % 1000000),
+            mp_obj_new_int((ticks_us64() + us_offset) % 1000000),
         };
         return mp_obj_new_tuple(8, tuple);
     } else {
@@ -91,6 +92,7 @@ STATIC mp_obj_t machine_rtc_datetime_helper(size_t n_args, const mp_obj_t *args)
         if (SNVS_LP_SRTC_SetDatetime(SNVS, &srtc_date) != kStatus_Success) {
             mp_raise_ValueError(NULL);
         }
+        us_offset = (1000000 + mp_obj_get_int(items[7]) - ticks_us64() % 1000000) % 1000000;
 
         return mp_const_none;
     }


### PR DESCRIPTION
This change moves the datetime format back to the on used by all
other MP ports:
    
Year, Month, Day, Weekday, Hour, Minute, Second, Microsecond.
    
Weekday is a number between 0 and 6, with 0 assigned to Monday.
It has to be provided when setting the RTC with datetime(), but
will be ignored on entry and calculated when needed.
    
The weekday method was removed, since that is now again a part of the
datetime tuple.

The supplied value for microseconds in datetime() will be treated
as starting value for the reported microseconds. Due to internal
processing in setting the time, there is an offset about 1 ms.

