### PR TITLE
mimxrt/machine_rtc: Change format of RTC.datetime to match other ports.

### DIFF
--- a/ports/mimxrt/machine_rtc.c
+++ b/ports/mimxrt/machine_rtc.c
@@ -61,16 +61,17 @@ STATIC mp_obj_t machine_rtc_datetime_helper(size_t n_args, const mp_obj_t *args)
         // Get date and time.
         snvs_lp_srtc_datetime_t srtc_date;
         SNVS_LP_SRTC_GetDatetime(SNVS, &srtc_date);
+        int weekday = calc_weekday(srtc_date.year, srtc_date.month, srtc_date.day);
 
         mp_obj_t tuple[8] = {
             mp_obj_new_int(srtc_date.year),
             mp_obj_new_int(srtc_date.month),
             mp_obj_new_int(srtc_date.day),
+            mp_obj_new_int((weekday + 6) % 7),
             mp_obj_new_int(srtc_date.hour),
             mp_obj_new_int(srtc_date.minute),
             mp_obj_new_int(srtc_date.second),
             mp_obj_new_int(ticks_us64() % 1000000),
-            mp_const_none,
         };
         return mp_obj_new_tuple(8, tuple);
     } else {
@@ -84,9 +85,9 @@ STATIC mp_obj_t machine_rtc_datetime_helper(size_t n_args, const mp_obj_t *args)
         srtc_date.year = year >= 100 ? year : year + 2000; // allow 21 for 2021
         srtc_date.month = mp_obj_get_int(items[1]);
         srtc_date.day = mp_obj_get_int(items[2]);
-        srtc_date.hour = mp_obj_get_int(items[3]);
-        srtc_date.minute = mp_obj_get_int(items[4]);
-        srtc_date.second = mp_obj_get_int(items[5]);
+        srtc_date.hour = mp_obj_get_int(items[4]);
+        srtc_date.minute = mp_obj_get_int(items[5]);
+        srtc_date.second = mp_obj_get_int(items[6]);
         if (SNVS_LP_SRTC_SetDatetime(SNVS, &srtc_date) != kStatus_Success) {
             mp_raise_ValueError(NULL);
         }
@@ -101,7 +102,20 @@ STATIC mp_obj_t machine_rtc_datetime(mp_uint_t n_args, const mp_obj_t *args) {
 STATIC MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(machine_rtc_datetime_obj, 1, 2, machine_rtc_datetime);
 
 STATIC mp_obj_t machine_rtc_now(mp_obj_t self_in) {
-    return machine_rtc_datetime_helper(1, &self_in);
+    // Get date and time.
+    snvs_lp_srtc_datetime_t srtc_date;
+    SNVS_LP_SRTC_GetDatetime(SNVS, &srtc_date);
+    mp_obj_t tuple[8] = {
+        mp_obj_new_int(srtc_date.year),
+        mp_obj_new_int(srtc_date.month),
+        mp_obj_new_int(srtc_date.day),
+        mp_obj_new_int(srtc_date.hour),
+        mp_obj_new_int(srtc_date.minute),
+        mp_obj_new_int(srtc_date.second),
+        mp_obj_new_int(ticks_us64() % 1000000),
+        mp_const_none,
+    };
+    return mp_obj_new_tuple(8, tuple);
 }
 STATIC MP_DEFINE_CONST_FUN_OBJ_1(machine_rtc_now_obj, machine_rtc_now);
 
@@ -111,16 +125,6 @@ STATIC mp_obj_t machine_rtc_init(mp_obj_t self_in, mp_obj_t date) {
     return mp_const_none;
 }
 STATIC MP_DEFINE_CONST_FUN_OBJ_2(machine_rtc_init_obj, machine_rtc_init);
-
-STATIC mp_obj_t machine_rtc_weekday(mp_obj_t self_in) {
-    (void)self_in; // unused
-    int day;
-    snvs_lp_srtc_datetime_t srtc_date;
-    SNVS_LP_SRTC_GetDatetime(SNVS, &srtc_date);
-    day = calc_weekday(srtc_date.year, srtc_date.month, srtc_date.day);
-    return MP_OBJ_NEW_SMALL_INT((day + 6) % 7);
-}
-STATIC MP_DEFINE_CONST_FUN_OBJ_1(machine_rtc_weekday_obj, machine_rtc_weekday);
 
 // calibration(cal)
 // When the argument is a number in the range [-16 to 15], set the calibration value.
@@ -143,7 +147,6 @@ STATIC const mp_rom_map_elem_t machine_rtc_locals_dict_table[] = {
     { MP_ROM_QSTR(MP_QSTR_init), MP_ROM_PTR(&machine_rtc_init_obj) },
     { MP_ROM_QSTR(MP_QSTR_datetime), MP_ROM_PTR(&machine_rtc_datetime_obj) },
     { MP_ROM_QSTR(MP_QSTR_now), MP_ROM_PTR(&machine_rtc_now_obj) },
-    { MP_ROM_QSTR(MP_QSTR_weekday), MP_ROM_PTR(&machine_rtc_weekday_obj) },
     { MP_ROM_QSTR(MP_QSTR_calibration), MP_ROM_PTR(&machine_rtc_calibration_obj) },
 };
 STATIC MP_DEFINE_CONST_DICT(machine_rtc_locals_dict, machine_rtc_locals_dict_table);


### PR DESCRIPTION
Following on from #7318, and after discussion https://github.com/micropython/micropython/pull/6928#issuecomment-859513267 and also #5553.

The point of this PR is to change `RTC.datetime()` on the mimxrt port to take/return an 8-tuple in the same format as most of the existing ports (stm32, esp8266, esp32).  In the first version of #7318 @robert-hh did already have it this way but I suggested to change it to match CPython's datetime format (see https://github.com/micropython/micropython/pull/7318#issuecomment-848497591).  That suggestion was a bit eager because it just introduces too much incompatibility, see https://github.com/micropython/micropython/pull/6928#issuecomment-859480494 .

Changes in this PR:
- change `RTC.datetime()` to take/return an 8-tuple with format `(year, month, day, weekday, hour, minute, second, microsecond)`
- remove unnecessary `RTC.weekday()`
- keep behaviour of `RTC.now()` so it returns `(year, month, day, hour, minute, second, microsecond, tzinfo)`.  This matches the docs and the cc3200 port (and no other port has this `now()` method).