### PR TITLE
add test for array constructor

### DIFF
--- a/tests/cpydiff/module_array_constructor.py
+++ b/tests/cpydiff/module_array_constructor.py
@@ -1,0 +1,11 @@
+"""
+categories: Modules,array
+description: overflow checking is not implemented
+cause: micropython implements implicit truncation in order to reduce code size and execution time
+workaround: mask value
+"""
+import array
+
+value = 257
+a = array.array("b", [value & 0xff])
+print(a)

--- a/tests/cpydiff/module_array_constructor.py
+++ b/tests/cpydiff/module_array_constructor.py
@@ -2,10 +2,9 @@
 categories: Modules,array
 description: overflow checking is not implemented
 cause: micropython implements implicit truncation in order to reduce code size and execution time
-workaround: mask value
+workaround: if CPython compatibility is needed then mask the value explicitly
 """
 import array
 
-value = 257
-a = array.array("b", [value & 0xff])
+a = array.array("b", [257])
 print(a)


### PR DESCRIPTION
This PR adds a simple test to demonstrate the difference between `CPython` and `micropython` for the case, when an array is constructed with values that do not fit the container. 

The corresponding issue can be found under https://github.com/micropython/micropython/issues/7377