### PR TITLE
rp2/machine_rtc: Check return value from rtc_set_alarm.

### DIFF
--- a/ports/rp2/machine_rtc.c
+++ b/ports/rp2/machine_rtc.c
@@ -100,7 +100,9 @@ STATIC mp_obj_t machine_rtc_datetime(mp_uint_t n_args, const mp_obj_t *args) {
             .sec = mp_obj_get_int(items[6]),
         };
 
-        rtc_set_datetime(&t);
+        if (!rtc_set_datetime(&t)) {
+            mp_raise_OSError(MP_EINVAL);
+        }
 
     }
     return mp_const_none;


### PR DESCRIPTION
The rtc_set_datetime() from pico-sdk will validate the values in the
datetime_t structure and refuse to set the time if they aren't valid. It
makes sense to raise an exception if this happens instead of failing
silently which might be confusing (as an example, see:
https://github.com/micropython/micropython/pull/6928#issuecomment-860166044
).