### PR TITLE
unix: fix build on arm64-darwin

### DIFF
--- a/ports/unix/mpthreadport.c
+++ b/ports/unix/mpthreadport.c
@@ -126,7 +126,7 @@ void mp_thread_init(void) {
     thread->next = NULL;
 
     #if defined(__APPLE__)
-    snprintf(thread_signal_done_name, sizeof(thread_signal_done_name), "micropython_sem_%d", (int)thread->id);
+    snprintf(thread_signal_done_name, sizeof(thread_signal_done_name), "micropython_sem_%ld", (long)thread->id);
     thread_signal_done_p = sem_open(thread_signal_done_name, O_CREAT | O_EXCL, 0666, 0);
     #else
     sem_init(&thread_signal_done, 0, 0);


### PR DESCRIPTION
This fixes error: cast to smaller integer type 'int' from 'pthread_t'

pthread_t is defined as long, not as int