### PR TITLE
tools/mpremote: Fix os import error and ctrl-C handling on Windows

### DIFF
--- a/tools/mpremote/mpremote/main.py
+++ b/tools/mpremote/mpremote/main.py
@@ -25,21 +25,6 @@ from .console import Console, ConsolePosix
 
 _PROG = "mpremote"
 
-_AUTO_CONNECT_SEARCH_LIST = [
-    "/dev/ttyACM0",
-    "/dev/ttyACM1",
-    "/dev/ttyACM2",
-    "/dev/ttyACM3",
-    "/dev/ttyUSB0",
-    "/dev/ttyUSB1",
-    "/dev/ttyUSB2",
-    "/dev/ttyUSB3",
-    "COM0",
-    "COM1",
-    "COM2",
-    "COM3",
-]
-
 _BUILTIN_COMMAND_EXPANSIONS = {
     # Device connection shortcuts.
     "a0": "connect /dev/ttyACM0",
@@ -187,14 +172,12 @@ def do_connect(args):
             return None
         elif dev == "auto":
             # Auto-detect and auto-connect to the first available device.
-            ports = serial.tools.list_ports.comports()
-            for dev in _AUTO_CONNECT_SEARCH_LIST:
-                if any(p.device == dev for p in ports):
-                    try:
-                        return pyboard.PyboardExtended(dev, baudrate=115200)
-                    except pyboard.PyboardError as er:
-                        if not er.args[0].startswith("failed to access"):
-                            raise er
+            for p in sorted(serial.tools.list_ports.comports()):
+                try:
+                    return pyboard.PyboardExtended(p.device, baudrate=115200)
+                except pyboard.PyboardError as er:
+                    if not er.args[0].startswith("failed to access"):
+                        raise er
             raise pyboard.PyboardError("no device found")
         elif dev.startswith("id:"):
             # Search for a device with the given serial number.

--- a/tools/mpremote/mpremote/main.py
+++ b/tools/mpremote/mpremote/main.py
@@ -17,7 +17,7 @@ MicroPython device over a serial connection.  Commands supported are:
     mpremote repl                    -- enter REPL
 """
 
-import os, select, sys, time
+import os, sys
 import serial.tools.list_ports
 
 from . import pyboardextended as pyboard
@@ -249,12 +249,7 @@ def do_filesystem(pyb, args):
 
 def do_repl_main_loop(pyb, console_in, console_out_write, *, code_to_inject, file_to_inject):
     while True:
-        if isinstance(console_in, ConsolePosix):
-            # TODO pyb.serial might not have fd
-            select.select([console_in.infd, pyb.serial.fd], [], [])
-        else:
-            while not (console_in.inWaiting() or pyb.serial.inWaiting()):
-                time.sleep(0.01)
+        console_in.waitchar(pyb.serial)
         c = console_in.readchar()
         if c:
             if c == b"\x1d":  # ctrl-], quit

--- a/tools/mpremote/setup.cfg
+++ b/tools/mpremote/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = mpremote
-version = 0.0.4
+version = 0.0.5
 author = Damien George
 author_email = damien@micropython.org
 description = Tool for interacting remotely with MicroPython


### PR DESCRIPTION
This PR fixes and improves the following in `mpremote`:
- fixes os import error on Windows; issue #7390
- adds support for ctrl-C on Windows
- tries all available ports when doing auto-connect (so auto-connect should now work on Mac)
- bumps mpremote version to 0.0.5