### PR TITLE
drivers/display/ssd1306.py: Add support for 72x40 displays.

### DIFF
--- a/drivers/display/ssd1306.py
+++ b/drivers/display/ssd1306.py
@@ -15,6 +15,7 @@ SET_PAGE_ADDR = const(0x22)
 SET_DISP_START_LINE = const(0x40)
 SET_SEG_REMAP = const(0xA0)
 SET_MUX_RATIO = const(0xA8)
+SET_IREF_SELECT = const(0xAD)
 SET_COM_OUT_DIR = const(0xC0)
 SET_DISP_OFFSET = const(0xD3)
 SET_COM_PIN_CFG = const(0xDA)
@@ -63,6 +64,8 @@ class SSD1306(framebuf.FrameBuffer):
             0xFF,  # maximum
             SET_ENTIRE_ON,  # output follows RAM contents
             SET_NORM_INV,  # not inverted
+            SET_IREF_SELECT,
+            0x30,  # enable internal IREF during display on
             # charge pump
             SET_CHARGE_PUMP,
             0x10 if self.external_vcc else 0x14,
@@ -92,10 +95,11 @@ class SSD1306(framebuf.FrameBuffer):
     def show(self):
         x0 = 0
         x1 = self.width - 1
-        if self.width == 64:
-            # displays with width of 64 pixels are shifted by 32
-            x0 += 32
-            x1 += 32
+        if self.width != 128:
+            # narrow displays use centred columns
+            col_offset = (128 - self.width) // 2
+            x0 += col_offset
+            x1 += col_offset
         self.write_cmd(SET_COL_ADDR)
         self.write_cmd(x0)
         self.write_cmd(x1)


### PR DESCRIPTION
Fix for https://github.com/micropython/micropython/issues/7281

The 72x40 OLED requires selecting the internal IREF, as opposed to the default external IREF. This is an undocumented feature in the SSD1306 datasheet, but is present in the SSD1315 datasheet. It's possible this 72x40 OLED is actually using the newer SSD1315 controller. Sending the IREF select command to SSD1306 displays has no effect on them, so I've just added it to the `init_display()` instead of wrapping in an `if width = 72`.

![it-works](https://user-images.githubusercontent.com/1038959/122328360-dd3e4880-cf72-11eb-8fab-98c91419ee0f.jpg)

I also have a 128x64 OLED using the SSD1315 controller (smaller ribbon cable) and the proposed change has no effect on the display, as the module comes with the correct current limiting resistor. You can use either internal or external IREF and it works the same.

After testing the various display sizes 128x64, 128x32, 72x40, 64x48, 64x32, I noticed all of the smaller displays use a column address offset which is exactly 1/2 of the remaining pixels. eg.
* on a 64px wide display, there's 32px offset each side (32+64+32=128)
* on a 72px wide display, there's 28px offset each side (28+72+28=128)

In `show()`, rather than hard coding to `32` when the width is `64`, I've made it calculate it based on the display width, which was tested on each of the above display dimensions.