### PR TITLE
esp32/machine_sdcard: Use deinit_p to deinit SD bus in SPI mode.

### DIFF
--- a/ports/esp32/machine_sdcard.c
+++ b/ports/esp32/machine_sdcard.c
@@ -256,7 +256,14 @@ STATIC mp_obj_t sd_deinit(mp_obj_t self_in) {
     DEBUG_printf("De-init host\n");
 
     if (self->flags & SDCARD_CARD_FLAGS_HOST_INIT_DONE) {
-        self->host.deinit();
+        #if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(4, 2, 0)
+        if (self->host.flags & SDMMC_HOST_FLAG_DEINIT_ARG) {
+            self->host.deinit_p(self->host.slot);
+        } else
+        #endif
+        {
+            self->host.deinit();
+        }
         self->flags &= ~SDCARD_CARD_FLAGS_HOST_INIT_DONE;
     }
 


### PR DESCRIPTION
Fixes issue #7352.
