### PR TITLE
py/mperrno: Add MP_ECANCELED error code.

### DIFF
--- a/py/mperrno.h
+++ b/py/mperrno.h
@@ -81,6 +81,7 @@
 #define MP_EHOSTUNREACH     (113) // No route to host
 #define MP_EALREADY         (114) // Operation already in progress
 #define MP_EINPROGRESS      (115) // Operation now in progress
+#define MP_ECANCELED        (125) // Operation canceled
 
 #else
 
@@ -136,6 +137,7 @@
 #define MP_EHOSTUNREACH     EHOSTUNREACH
 #define MP_EALREADY         EALREADY
 #define MP_EINPROGRESS      EINPROGRESS
+#define MP_ECANCELED        ECANCELED
 
 #endif
 


### PR DESCRIPTION
This is useful when binding asynchronous functions in C.
