### PR TITLE
esp32: Add initial support for ESP32C3 SoCs

### DIFF
--- a/ports/esp32/boards/GENERIC_C3/mpconfigboard.cmake
+++ b/ports/esp32/boards/GENERIC_C3/mpconfigboard.cmake
@@ -1,0 +1,10 @@
+set(IDF_TARGET esp32c3)
+
+set(SDKCONFIG_DEFAULTS
+    boards/sdkconfig.base
+    boards/sdkconfig.ble
+)
+
+if(NOT MICROPY_FROZEN_MANIFEST)
+    set(MICROPY_FROZEN_MANIFEST ${MICROPY_PORT_DIR}/boards/manifest.py)
+endif()

--- a/ports/esp32/boards/GENERIC_C3/mpconfigboard.h
+++ b/ports/esp32/boards/GENERIC_C3/mpconfigboard.h
@@ -1,0 +1,8 @@
+// This configuration is for a generic ESP32C3 board with 4MiB (or more) of flash.
+
+#define MICROPY_HW_BOARD_NAME               "ESP32C3 module"
+#define MICROPY_HW_MCU_NAME                 "ESP32C3"
+
+#define MICROPY_HW_ENABLE_SDCARD            (0)
+#define MICROPY_PY_MACHINE_DAC              (0)
+#define MICROPY_PY_MACHINE_I2S              (0)

--- a/ports/esp32/espneopixel.c
+++ b/ports/esp32/espneopixel.c
@@ -13,14 +13,17 @@ void IRAM_ATTR esp_neopixel_write(uint8_t pin, uint8_t *pixels, uint32_t numByte
     uint8_t *p, *end, pix, mask;
     uint32_t t, time0, time1, period, c, startTime, pinMask, gpio_reg_set, gpio_reg_clear;
 
-    if (pin < 32) {
-        pinMask = 1 << pin;
-        gpio_reg_set = GPIO_OUT_W1TS_REG;
-        gpio_reg_clear = GPIO_OUT_W1TC_REG;
-    } else {
+    #if !CONFIG_IDF_TARGET_ESP32C3
+    if (pin >= 32) {
         pinMask = 1 << (pin - 32);
         gpio_reg_set = GPIO_OUT1_W1TS_REG;
         gpio_reg_clear = GPIO_OUT1_W1TC_REG;
+    } else
+    #endif
+    {
+        pinMask = 1 << pin;
+        gpio_reg_set = GPIO_OUT_W1TS_REG;
+        gpio_reg_clear = GPIO_OUT_W1TC_REG;
     }
     p = pixels;
     end = p + numBytes;

--- a/ports/esp32/gccollect.c
+++ b/ports/esp32/gccollect.c
@@ -35,8 +35,10 @@
 #include "py/mpthread.h"
 #include "gccollect.h"
 #include "soc/cpu.h"
-#include "xtensa/hal.h"
 
+#if CONFIG_IDF_TARGET_ESP32 || CONFIG_IDF_TARGET_ESP32S2 || CONFIG_IDF_TARGET_ESP32S3
+
+#include "xtensa/hal.h"
 
 static void gc_collect_inner(int level) {
     if (level < XCHAL_NUM_AREGS / 8) {
@@ -64,3 +66,18 @@ void gc_collect(void) {
     gc_collect_inner(0);
     gc_collect_end();
 }
+
+#elif CONFIG_IDF_TARGET_ESP32C3
+
+#include "shared/runtime/gchelper.h"
+
+void gc_collect(void) {
+    gc_collect_start();
+    gc_helper_collect_regs_and_stack();
+    #if MICROPY_PY_THREAD
+    mp_thread_gc_others();
+    #endif
+    gc_collect_end();
+}
+
+#endif

--- a/ports/esp32/machine_adc.c
+++ b/ports/esp32/machine_adc.c
@@ -52,6 +52,12 @@ STATIC const madc_obj_t madc_obj[] = {
     {{&machine_adc_type}, GPIO_NUM_33, ADC1_CHANNEL_5},
     {{&machine_adc_type}, GPIO_NUM_34, ADC1_CHANNEL_6},
     {{&machine_adc_type}, GPIO_NUM_35, ADC1_CHANNEL_7},
+    #elif CONFIG_IDF_TARGET_ESP32C3
+    {{&machine_adc_type}, GPIO_NUM_0, ADC1_CHANNEL_0},
+    {{&machine_adc_type}, GPIO_NUM_1, ADC1_CHANNEL_1},
+    {{&machine_adc_type}, GPIO_NUM_2, ADC1_CHANNEL_2},
+    {{&machine_adc_type}, GPIO_NUM_3, ADC1_CHANNEL_3},
+    {{&machine_adc_type}, GPIO_NUM_4, ADC1_CHANNEL_4},
     #elif CONFIG_IDF_TARGET_ESP32S2 || CONFIG_IDF_TARGET_ESP32S3
     {{&machine_adc_type}, GPIO_NUM_1, ADC1_CHANNEL_0},
     {{&machine_adc_type}, GPIO_NUM_2, ADC1_CHANNEL_1},

--- a/ports/esp32/machine_dac.c
+++ b/ports/esp32/machine_dac.c
@@ -27,14 +27,14 @@
 
 #include <stdio.h>
 
-#include "esp_log.h"
-
-#include "driver/gpio.h"
-#include "driver/dac.h"
-
 #include "py/runtime.h"
 #include "py/mphal.h"
 #include "modmachine.h"
+
+#if MICROPY_PY_MACHINE_DAC
+
+#include "driver/gpio.h"
+#include "driver/dac.h"
 
 typedef struct _mdac_obj_t {
     mp_obj_base_t base;
@@ -111,3 +111,5 @@ const mp_obj_type_t machine_dac_type = {
     .make_new = mdac_make_new,
     .locals_dict = (mp_obj_t)&mdac_locals_dict,
 };
+
+#endif // MICROPY_PY_MACHINE_DAC

--- a/ports/esp32/machine_hw_spi.c
+++ b/ports/esp32/machine_hw_spi.c
@@ -53,6 +53,10 @@
 #define MP_HW_SPI_MAX_XFER_BYTES (4092)
 #define MP_HW_SPI_MAX_XFER_BITS (MP_HW_SPI_MAX_XFER_BYTES * 8) // Has to be an even multiple of 8
 
+#if CONFIG_IDF_TARGET_ESP32C3
+#define HSPI_HOST SPI2_HOST
+#endif
+
 typedef struct _machine_hw_spi_default_pins_t {
     int8_t sck;
     int8_t mosi;

--- a/ports/esp32/machine_i2s.c
+++ b/ports/esp32/machine_i2s.c
@@ -38,6 +38,8 @@
 #include "modmachine.h"
 #include "mphalport.h"
 
+#if MICROPY_PY_MACHINE_I2S
+
 #include "driver/i2s.h"
 #include "soc/i2s_reg.h"
 #include "freertos/FreeRTOS.h"
@@ -807,3 +809,5 @@ const mp_obj_type_t machine_i2s_type = {
     .make_new = machine_i2s_make_new,
     .locals_dict = (mp_obj_dict_t *)&machine_i2s_locals_dict,
 };
+
+#endif // MICROPY_PY_MACHINE_I2S

--- a/ports/esp32/machine_i2s.c
+++ b/ports/esp32/machine_i2s.c
@@ -255,8 +255,8 @@ STATIC uint32_t fill_appbuf_from_dma(machine_i2s_obj_t *self, mp_buffer_info_t *
     uint8_t appbuf_sample_size_in_bytes = (self->bits / 8) * (self->format == STEREO ? 2: 1);
     uint32_t num_bytes_needed_from_dma = appbuf->len * (I2S_RX_FRAME_SIZE_IN_BYTES / appbuf_sample_size_in_bytes);
     while (num_bytes_needed_from_dma) {
-        uint32_t num_bytes_requested_from_dma = MIN(sizeof(self->transform_buffer), num_bytes_needed_from_dma);
-        uint32_t num_bytes_received_from_dma = 0;
+        size_t num_bytes_requested_from_dma = MIN(sizeof(self->transform_buffer), num_bytes_needed_from_dma);
+        size_t num_bytes_received_from_dma = 0;
 
         TickType_t delay;
         if (self->io_mode == UASYNCIO) {
@@ -312,12 +312,12 @@ STATIC uint32_t fill_appbuf_from_dma(machine_i2s_obj_t *self, mp_buffer_info_t *
     return a_index;
 }
 
-STATIC uint32_t copy_appbuf_to_dma(machine_i2s_obj_t *self, mp_buffer_info_t *appbuf) {
+STATIC size_t copy_appbuf_to_dma(machine_i2s_obj_t *self, mp_buffer_info_t *appbuf) {
     if ((self->bits == I2S_BITS_PER_SAMPLE_32BIT) && (self->format == STEREO)) {
         swap_32_bit_stereo_channels(appbuf);
     }
 
-    uint32_t num_bytes_written = 0;
+    size_t num_bytes_written = 0;
 
     TickType_t delay;
     if (self->io_mode == UASYNCIO) {
@@ -518,7 +518,7 @@ STATIC mp_obj_t machine_i2s_make_new(const mp_obj_type_t *type, size_t n_pos_arg
     return MP_OBJ_FROM_PTR(self);
 }
 
-STATIC mp_obj_t machine_i2s_obj_init(mp_uint_t n_pos_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
+STATIC mp_obj_t machine_i2s_obj_init(size_t n_pos_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
     machine_i2s_obj_t *self = pos_args[0];
     machine_i2s_deinit(self);
     machine_i2s_init_helper(self, n_pos_args - 1, pos_args + 1, kw_args);
@@ -731,12 +731,12 @@ STATIC mp_uint_t machine_i2s_stream_write(mp_obj_t self_in, const void *buf_in, 
         mp_buffer_info_t appbuf;
         appbuf.buf = (void *)buf_in;
         appbuf.len = size;
-        uint32_t num_bytes_written = copy_appbuf_to_dma(self, &appbuf);
+        size_t num_bytes_written = copy_appbuf_to_dma(self, &appbuf);
         return num_bytes_written;
     }
 }
 
-STATIC mp_uint_t machine_i2s_ioctl(mp_obj_t self_in, mp_uint_t request, mp_uint_t arg, int *errcode) {
+STATIC mp_uint_t machine_i2s_ioctl(mp_obj_t self_in, mp_uint_t request, uintptr_t arg, int *errcode) {
     machine_i2s_obj_t *self = MP_OBJ_TO_PTR(self_in);
     mp_uint_t ret;
     mp_uint_t flags = arg;

--- a/ports/esp32/machine_pin.c
+++ b/ports/esp32/machine_pin.c
@@ -40,6 +40,10 @@
 #include "machine_rtc.h"
 #include "modesp32.h"
 
+#if CONFIG_IDF_TARGET_ESP32C3
+#include "hal/gpio_ll.h"
+#endif
+
 // Used to implement a range of pull capabilities
 #define GPIO_PULL_DOWN (1)
 #define GPIO_PULL_UP   (2)
@@ -98,6 +102,31 @@ STATIC const machine_pin_obj_t machine_pin_obj[] = {
     {{&machine_pin_type}, GPIO_NUM_37},
     {{&machine_pin_type}, GPIO_NUM_38},
     {{&machine_pin_type}, GPIO_NUM_39},
+
+    #elif CONFIG_IDF_TARGET_ESP32C3
+
+    {{&machine_pin_type}, GPIO_NUM_0},
+    {{&machine_pin_type}, GPIO_NUM_1},
+    {{&machine_pin_type}, GPIO_NUM_2},
+    {{&machine_pin_type}, GPIO_NUM_3},
+    {{&machine_pin_type}, GPIO_NUM_4},
+    {{&machine_pin_type}, GPIO_NUM_5},
+    {{&machine_pin_type}, GPIO_NUM_6},
+    {{&machine_pin_type}, GPIO_NUM_7},
+    {{&machine_pin_type}, GPIO_NUM_8},
+    {{&machine_pin_type}, GPIO_NUM_9},
+    {{&machine_pin_type}, GPIO_NUM_10},
+    {{&machine_pin_type}, GPIO_NUM_11},
+    {{&machine_pin_type}, GPIO_NUM_12},
+    {{&machine_pin_type}, GPIO_NUM_13},
+    {{&machine_pin_type}, GPIO_NUM_14},
+    {{&machine_pin_type}, GPIO_NUM_15},
+    {{&machine_pin_type}, GPIO_NUM_16},
+    {{&machine_pin_type}, GPIO_NUM_17},
+    {{&machine_pin_type}, GPIO_NUM_18},
+    {{&machine_pin_type}, GPIO_NUM_19},
+    {{&machine_pin_type}, GPIO_NUM_20},
+    {{&machine_pin_type}, GPIO_NUM_21},
 
     #elif CONFIG_IDF_TARGET_ESP32S2 || CONFIG_IDF_TARGET_ESP32S3
 
@@ -213,9 +242,17 @@ STATIC mp_obj_t machine_pin_obj_init_helper(const machine_pin_obj_t *self, size_
     // reset the pin to digital if this is a mode-setting init (grab it back from ADC)
     if (args[ARG_mode].u_obj != mp_const_none) {
         if (rtc_gpio_is_valid_gpio(self->id)) {
+            #if !CONFIG_IDF_TARGET_ESP32C3
             rtc_gpio_deinit(self->id);
+            #endif
         }
     }
+
+    #if CONFIG_IDF_TARGET_ESP32C3
+    if (self->id == 18 || self->id == 19) {
+        CLEAR_PERI_REG_MASK(USB_DEVICE_CONF0_REG, USB_DEVICE_USB_PAD_ENABLE);
+    }
+    #endif
 
     // configure the pin for gpio
     gpio_pad_select_gpio(self->id);
@@ -493,6 +530,31 @@ STATIC const machine_pin_irq_obj_t machine_pin_irq_object[] = {
     {{&machine_pin_irq_type}, GPIO_NUM_37},
     {{&machine_pin_irq_type}, GPIO_NUM_38},
     {{&machine_pin_irq_type}, GPIO_NUM_39},
+
+    #elif CONFIG_IDF_TARGET_ESP32C3
+
+    {{&machine_pin_irq_type}, GPIO_NUM_0},
+    {{&machine_pin_irq_type}, GPIO_NUM_1},
+    {{&machine_pin_irq_type}, GPIO_NUM_2},
+    {{&machine_pin_irq_type}, GPIO_NUM_3},
+    {{&machine_pin_irq_type}, GPIO_NUM_4},
+    {{&machine_pin_irq_type}, GPIO_NUM_5},
+    {{&machine_pin_irq_type}, GPIO_NUM_6},
+    {{&machine_pin_irq_type}, GPIO_NUM_7},
+    {{&machine_pin_irq_type}, GPIO_NUM_8},
+    {{&machine_pin_irq_type}, GPIO_NUM_9},
+    {{&machine_pin_irq_type}, GPIO_NUM_10},
+    {{&machine_pin_irq_type}, GPIO_NUM_11},
+    {{&machine_pin_irq_type}, GPIO_NUM_12},
+    {{&machine_pin_irq_type}, GPIO_NUM_13},
+    {{&machine_pin_irq_type}, GPIO_NUM_14},
+    {{&machine_pin_irq_type}, GPIO_NUM_15},
+    {{&machine_pin_irq_type}, GPIO_NUM_16},
+    {{&machine_pin_irq_type}, GPIO_NUM_17},
+    {{&machine_pin_irq_type}, GPIO_NUM_18},
+    {{&machine_pin_irq_type}, GPIO_NUM_19},
+    {{&machine_pin_irq_type}, GPIO_NUM_20},
+    {{&machine_pin_irq_type}, GPIO_NUM_21},
 
     #elif CONFIG_IDF_TARGET_ESP32S2 || CONFIG_IDF_TARGET_ESP32S3
 

--- a/ports/esp32/machine_rtc.c
+++ b/ports/esp32/machine_rtc.c
@@ -121,7 +121,7 @@ STATIC mp_obj_t machine_rtc_datetime_helper(mp_uint_t n_args, const mp_obj_t *ar
         return mp_const_none;
     }
 }
-STATIC mp_obj_t machine_rtc_datetime(mp_uint_t n_args, const mp_obj_t *args) {
+STATIC mp_obj_t machine_rtc_datetime(size_t n_args, const mp_obj_t *args) {
     return machine_rtc_datetime_helper(n_args, args);
 }
 STATIC MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(machine_rtc_datetime_obj, 1, 2, machine_rtc_datetime);
@@ -142,7 +142,7 @@ STATIC mp_obj_t machine_rtc_init(mp_obj_t self_in, mp_obj_t date) {
 STATIC MP_DEFINE_CONST_FUN_OBJ_2(machine_rtc_init_obj, machine_rtc_init);
 
 #if MICROPY_HW_RTC_USER_MEM_MAX > 0
-STATIC mp_obj_t machine_rtc_memory(mp_uint_t n_args, const mp_obj_t *args) {
+STATIC mp_obj_t machine_rtc_memory(size_t n_args, const mp_obj_t *args) {
     if (n_args == 1) {
         // read RTC memory
         uint8_t rtcram[MICROPY_HW_RTC_USER_MEM_MAX];

--- a/ports/esp32/machine_timer.c
+++ b/ports/esp32/machine_timer.c
@@ -229,7 +229,7 @@ STATIC mp_obj_t machine_timer_deinit(mp_obj_t self_in) {
 }
 STATIC MP_DEFINE_CONST_FUN_OBJ_1(machine_timer_deinit_obj, machine_timer_deinit);
 
-STATIC mp_obj_t machine_timer_init(mp_uint_t n_args, const mp_obj_t *args, mp_map_t *kw_args) {
+STATIC mp_obj_t machine_timer_init(size_t n_args, const mp_obj_t *args, mp_map_t *kw_args) {
     return machine_timer_init_helper(args[0], n_args - 1, args + 1, kw_args);
 }
 STATIC MP_DEFINE_CONST_FUN_OBJ_KW(machine_timer_init_obj, 1, machine_timer_init);

--- a/ports/esp32/machine_uart.c
+++ b/ports/esp32/machine_uart.c
@@ -443,7 +443,7 @@ STATIC mp_uint_t machine_uart_write(mp_obj_t self_in, const void *buf_in, mp_uin
     return bytes_written;
 }
 
-STATIC mp_uint_t machine_uart_ioctl(mp_obj_t self_in, mp_uint_t request, mp_uint_t arg, int *errcode) {
+STATIC mp_uint_t machine_uart_ioctl(mp_obj_t self_in, mp_uint_t request, uintptr_t arg, int *errcode) {
     machine_uart_obj_t *self = self_in;
     mp_uint_t ret;
     if (request == MP_STREAM_POLL) {

--- a/ports/esp32/main.c
+++ b/ports/esp32/main.c
@@ -70,6 +70,13 @@
 #define MP_TASK_PRIORITY        (ESP_TASK_PRIO_MIN + 1)
 #define MP_TASK_STACK_SIZE      (16 * 1024)
 
+// Set the margin for detecting stack overflow, depending on the CPU architecture.
+#if CONFIG_IDF_TARGET_ESP32C3
+#define MP_TASK_STACK_LIMIT_MARGIN (2048)
+#else
+#define MP_TASK_STACK_LIMIT_MARGIN (1024)
+#endif
+
 int vprintf_null(const char *format, va_list ap) {
     // do nothing: this is used as a log target during raw repl mode
     return 0;
@@ -127,7 +134,7 @@ void mp_task(void *pvParameter) {
 soft_reset:
     // initialise the stack pointer for the main thread
     mp_stack_set_top((void *)sp);
-    mp_stack_set_limit(MP_TASK_STACK_SIZE - 1024);
+    mp_stack_set_limit(MP_TASK_STACK_SIZE - MP_TASK_STACK_LIMIT_MARGIN);
     gc_init(mp_task_heap, mp_task_heap + mp_task_heap_size);
     mp_init();
     mp_obj_list_init(mp_sys_path, 0);

--- a/ports/esp32/main.c
+++ b/ports/esp32/main.c
@@ -138,7 +138,9 @@ soft_reset:
 
     // initialise peripherals
     machine_pins_init();
+    #if MICROPY_PY_MACHINE_I2S
     machine_i2s_init0();
+    #endif
 
     // run boot-up scripts
     pyexec_frozen_module("_boot.py");

--- a/ports/esp32/main/CMakeLists.txt
+++ b/ports/esp32/main/CMakeLists.txt
@@ -34,6 +34,9 @@ set(MICROPY_SOURCE_LIB
     ${MICROPY_DIR}/lib/oofatfs/ff.c
     ${MICROPY_DIR}/lib/oofatfs/ffunicode.c
 )
+if(IDF_TARGET STREQUAL "esp32c3")
+    list(APPEND MICROPY_SOURCE_LIB ${MICROPY_DIR}/shared/runtime/gchelper_generic.c)
+endif()
 
 set(MICROPY_SOURCE_DRIVERS
     ${MICROPY_DIR}/drivers/bus/softspi.c
@@ -133,6 +136,9 @@ endif()
 
 if(IDF_TARGET STREQUAL "esp32")
     list(APPEND IDF_COMPONENTS esp32)
+elseif(IDF_TARGET STREQUAL "esp32c3")
+    list(APPEND IDF_COMPONENTS esp32c3)
+    list(APPEND IDF_COMPONENTS riscv)
 elseif(IDF_TARGET STREQUAL "esp32s2")
     list(APPEND IDF_COMPONENTS esp32s2)
     list(APPEND IDF_COMPONENTS tinyusb)

--- a/ports/esp32/modesp32.c
+++ b/ports/esp32/modesp32.c
@@ -109,7 +109,7 @@ STATIC mp_obj_t esp32_wake_on_ext1(size_t n_args, const mp_obj_t *pos_args, mp_m
 
     // Check that all pins are allowed
     if (args[ARG_pins].u_obj != mp_const_none) {
-        mp_uint_t len = 0;
+        size_t len = 0;
         mp_obj_t *elem;
         mp_obj_get_array(args[ARG_pins].u_obj, &len, &elem);
         ext1_pins = 0;

--- a/ports/esp32/modesp32.c
+++ b/ports/esp32/modesp32.c
@@ -30,7 +30,6 @@
 #include <time.h>
 #include <sys/time.h>
 #include "soc/rtc_cntl_reg.h"
-#include "soc/sens_reg.h"
 #include "driver/gpio.h"
 #include "driver/adc.h"
 #include "esp_heap_caps.h"
@@ -133,6 +132,8 @@ STATIC mp_obj_t esp32_wake_on_ext1(size_t n_args, const mp_obj_t *pos_args, mp_m
 STATIC MP_DEFINE_CONST_FUN_OBJ_KW(esp32_wake_on_ext1_obj, 0, esp32_wake_on_ext1);
 
 #if CONFIG_IDF_TARGET_ESP32
+
+#include "soc/sens_reg.h"
 
 STATIC mp_obj_t esp32_raw_temperature(void) {
     SET_PERI_REG_BITS(SENS_SAR_MEAS_WAIT2_REG, SENS_FORCE_XPD_SAR, 3, SENS_FORCE_XPD_SAR_S);

--- a/ports/esp32/modmachine.c
+++ b/ports/esp32/modmachine.c
@@ -277,7 +277,9 @@ STATIC const mp_rom_map_elem_t machine_module_globals_table[] = {
     { MP_ROM_QSTR(MP_QSTR_TouchPad), MP_ROM_PTR(&machine_touchpad_type) },
     #endif
     { MP_ROM_QSTR(MP_QSTR_ADC), MP_ROM_PTR(&machine_adc_type) },
+    #if MICROPY_PY_MACHINE_DAC
     { MP_ROM_QSTR(MP_QSTR_DAC), MP_ROM_PTR(&machine_dac_type) },
+    #endif
     { MP_ROM_QSTR(MP_QSTR_I2C), MP_ROM_PTR(&machine_hw_i2c_type) },
     { MP_ROM_QSTR(MP_QSTR_SoftI2C), MP_ROM_PTR(&mp_machine_soft_i2c_type) },
     { MP_ROM_QSTR(MP_QSTR_I2S), MP_ROM_PTR(&machine_i2s_type) },

--- a/ports/esp32/modmachine.c
+++ b/ports/esp32/modmachine.c
@@ -282,7 +282,9 @@ STATIC const mp_rom_map_elem_t machine_module_globals_table[] = {
     #endif
     { MP_ROM_QSTR(MP_QSTR_I2C), MP_ROM_PTR(&machine_hw_i2c_type) },
     { MP_ROM_QSTR(MP_QSTR_SoftI2C), MP_ROM_PTR(&mp_machine_soft_i2c_type) },
+    #if MICROPY_PY_MACHINE_I2S
     { MP_ROM_QSTR(MP_QSTR_I2S), MP_ROM_PTR(&machine_i2s_type) },
+    #endif
     { MP_ROM_QSTR(MP_QSTR_PWM), MP_ROM_PTR(&machine_pwm_type) },
     { MP_ROM_QSTR(MP_QSTR_RTC), MP_ROM_PTR(&machine_rtc_type) },
     { MP_ROM_QSTR(MP_QSTR_SPI), MP_ROM_PTR(&machine_hw_spi_type) },

--- a/ports/esp32/mpconfigport.h
+++ b/ports/esp32/mpconfigport.h
@@ -11,13 +11,18 @@
 // object representation and NLR handling
 #define MICROPY_OBJ_REPR                    (MICROPY_OBJ_REPR_A)
 #define MICROPY_NLR_SETJMP                  (1)
+#if CONFIG_IDF_TARGET_ESP32C3
+#define MICROPY_GCREGS_SETJMP               (1)
+#endif
 
 // memory allocation policies
 #define MICROPY_ALLOC_PATH_MAX              (128)
 
 // emitters
 #define MICROPY_PERSISTENT_CODE_LOAD        (1)
+#if !CONFIG_IDF_TARGET_ESP32C3
 #define MICROPY_EMIT_XTENSAWIN              (1)
+#endif
 
 // compiler configuration
 #define MICROPY_COMP_MODULE_CONST           (1)

--- a/ports/esp32/mpconfigport.h
+++ b/ports/esp32/mpconfigport.h
@@ -153,6 +153,9 @@
 #define MICROPY_PY_MACHINE_SPI              (1)
 #define MICROPY_PY_MACHINE_SPI_MSB          (0)
 #define MICROPY_PY_MACHINE_SPI_LSB          (1)
+#ifndef MICROPY_PY_MACHINE_DAC
+#define MICROPY_PY_MACHINE_DAC              (1)
+#endif
 #ifndef MICROPY_HW_ENABLE_SDCARD
 #define MICROPY_HW_ENABLE_SDCARD            (1)
 #endif

--- a/ports/esp32/mpconfigport.h
+++ b/ports/esp32/mpconfigport.h
@@ -156,6 +156,9 @@
 #ifndef MICROPY_PY_MACHINE_DAC
 #define MICROPY_PY_MACHINE_DAC              (1)
 #endif
+#ifndef MICROPY_PY_MACHINE_I2S
+#define MICROPY_PY_MACHINE_I2S              (1)
+#endif
 #ifndef MICROPY_HW_ENABLE_SDCARD
 #define MICROPY_HW_ENABLE_SDCARD            (1)
 #endif

--- a/ports/esp32/mphalport.c
+++ b/ports/esp32/mphalport.c
@@ -108,7 +108,7 @@ int mp_hal_stdin_rx_chr(void) {
     }
 }
 
-void mp_hal_stdout_tx_strn(const char *str, uint32_t len) {
+void mp_hal_stdout_tx_strn(const char *str, size_t len) {
     // Only release the GIL if many characters are being sent
     bool release_gil = len > 20;
     if (release_gil) {

--- a/ports/esp32/mphalport.c
+++ b/ports/esp32/mphalport.c
@@ -35,6 +35,8 @@
 
 #if CONFIG_IDF_TARGET_ESP32
 #include "esp32/rom/uart.h"
+#elif CONFIG_IDF_TARGET_ESP32C3
+#include "esp32c3/rom/uart.h"
 #elif CONFIG_IDF_TARGET_ESP32S2
 #include "esp32s2/rom/uart.h"
 #elif CONFIG_IDF_TARGET_ESP32S3

--- a/ports/esp32/mphalport.h
+++ b/ports/esp32/mphalport.h
@@ -51,7 +51,11 @@ void check_esp_err(esp_err_t code);
 uint32_t mp_hal_ticks_us(void);
 __attribute__((always_inline)) static inline uint32_t mp_hal_ticks_cpu(void) {
     uint32_t ccount;
+    #if CONFIG_IDF_TARGET_ESP32C3
+    __asm__ __volatile__ ("csrr %0, 0x7E2" : "=r" (ccount)); // Machine Performance Counter Value
+    #else
     __asm__ __volatile__ ("rsr %0,ccount" : "=a" (ccount));
+    #endif
     return ccount;
 }
 

--- a/ports/esp32/uart.c
+++ b/ports/esp32/uart.c
@@ -51,7 +51,7 @@ STATIC void IRAM_ATTR uart_irq_handler(void *arg) {
     while (uart->status.rxfifo_cnt) {
         #if CONFIG_IDF_TARGET_ESP32
         uint8_t c = uart->fifo.rw_byte;
-        #elif CONFIG_IDF_TARGET_ESP32S2
+        #elif CONFIG_IDF_TARGET_ESP32C3 || CONFIG_IDF_TARGET_ESP32S2
         uint8_t c = READ_PERI_REG(UART_FIFO_AHB_REG(0)); // UART0
         #endif
         if (c == mp_interrupt_char) {

--- a/tools/ci.sh
+++ b/tools/ci.sh
@@ -86,12 +86,19 @@ function ci_esp32_setup_helper {
     git clone https://github.com/espressif/esp-idf.git
     git -C esp-idf checkout $1
     git -C esp-idf submodule update --init \
-        components/bt/controller/lib \
         components/bt/host/nimble/nimble \
         components/esp_wifi \
         components/esptool_py/esptool \
         components/lwip/lwip \
         components/mbedtls/mbedtls
+    if [ -d esp-idf/components/bt/controller/esp32 ]; then
+        git -C esp-idf submodule update --init \
+            components/bt/controller/lib_esp32 \
+            components/bt/controller/lib_esp32c3_family
+    else
+        git -C esp-idf submodule update --init \
+            components/bt/controller/lib
+    fi
     ./esp-idf/install.sh
 }
 
@@ -100,7 +107,7 @@ function ci_esp32_idf402_setup {
 }
 
 function ci_esp32_idf43_setup {
-    ci_esp32_setup_helper v4.3-beta2
+    ci_esp32_setup_helper v4.3
 }
 
 function ci_esp32_build {
@@ -110,6 +117,9 @@ function ci_esp32_build {
     make ${MAKEOPTS} -C ports/esp32
     make ${MAKEOPTS} -C ports/esp32 clean
     make ${MAKEOPTS} -C ports/esp32 USER_C_MODULES=../../../examples/usercmodule/micropython.cmake FROZEN_MANIFEST=$(pwd)/ports/esp32/boards/manifest.py
+    if [ -d $IDF_PATH/components/esp32c3 ]; then
+        make ${MAKEOPTS} -C ports/esp32 BOARD=GENERIC_C3
+    fi
     if [ -d $IDF_PATH/components/esp32s2 ]; then
         make ${MAKEOPTS} -C ports/esp32 BOARD=GENERIC_S2
     fi


### PR DESCRIPTION
This adds a GENERIC_C3 board which compiles against the latest IDF v4.4.  It is untested.