### PR TITLE
add board-specific main script config option

### DIFF
--- a/ports/esp32/main.c
+++ b/ports/esp32/main.c
@@ -149,6 +149,10 @@ soft_reset:
         }
     }
 
+    #ifdef MICROPY_BOARD_MAIN
+    pyexec_frozen_module(MICROPY_BOARD_MAIN);
+    #endif
+
     for (;;) {
         if (pyexec_mode_kind == PYEXEC_MODE_RAW_REPL) {
             vprintf_like_t vprintf_log = esp_log_set_vprintf(vprintf_null);


### PR DESCRIPTION
Hi all!

First of all thank you for the continued work on the ESP32 port of micropython. I've been lurking for a couple years and the quality of work is exceptional. Here's a PR (for ESP32 port) demonstrating the kind of addition that would allow boards to optionally define their own frozen main script.

fixes https://github.com/micropython/micropython/issues/7440

