### PR TITLE
extmod/uasyncio: Allow catching exceptions in start_server.

### DIFF
--- a/extmod/uasyncio/stream.py
+++ b/extmod/uasyncio/stream.py
@@ -116,6 +116,9 @@ class Server:
         s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
         s.bind(ai[-1])
         s.listen(backlog)
+        self.task = core.create_task(self._listen(cb, s))
+
+    async def _listen(self, cb, s):
         # Accept incoming connections
         while True:
             try:
@@ -138,7 +141,7 @@ class Server:
 # TODO could use an accept-callback on socket read activity instead of creating a task
 async def start_server(cb, host, port, backlog=5):
     s = Server()
-    s.task = core.create_task(s._serve(cb, host, port, backlog))
+    await s._serve(cb, host, port, backlog)
     return s
 
 


### PR DESCRIPTION
Currently when using `uasyncio.start_server()` the socket configuration is done inside a `uasyncio.create_task()` background function.

If the address:port is already in use however this throws a:
```
Traceback (most recent call last):
  File "uasyncio/stream.py", line 1, in start_server
  File "uasyncio/stream.py", line 1, in _serve
OSError: [Errno 98] EADDRINUSE
```
which cannot be cleanly caught behind the `create_task()`.

This PR splits up the server port init so that the initial socket configuration is in a normal `await`ed function, before deferring the listen while loop to the background `uasyncio.create_task()` function. This means that any OSError from the initial socket configuration is propagated directly up the call stack.
