### PR TITLE
stm32/usb: Make irq's default trigger enable all events.

### DIFF
--- a/docs/library/pyb.USB_VCP.rst
+++ b/docs/library/pyb.USB_VCP.rst
@@ -109,7 +109,7 @@ Methods
 
    Return value: number of bytes sent.
 
-.. method:: USB_VCP.irq(handler=None, trigger=0, hard=False)
+.. method:: USB_VCP.irq(handler=None, trigger=IRQ_RX, hard=False)
 
    Register *handler* to be called whenever an event specified by *trigger*
    occurs.  The *handler* function must take exactly one argument, which will

--- a/ports/stm32/usb.c
+++ b/ports/stm32/usb.c
@@ -829,11 +829,17 @@ STATIC mp_obj_t pyb_usb_vcp_recv(size_t n_args, const mp_obj_t *args, mp_map_t *
 }
 STATIC MP_DEFINE_CONST_FUN_OBJ_KW(pyb_usb_vcp_recv_obj, 1, pyb_usb_vcp_recv);
 
-// irq(handler=None, trigger=0, hard=False)
+// irq(handler=None, trigger=IRQ_RX, hard=False)
 STATIC mp_obj_t pyb_usb_vcp_irq(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
-    mp_arg_val_t args[MP_IRQ_ARG_INIT_NUM_ARGS];
-    mp_arg_parse_all(n_args - 1, pos_args + 1, kw_args, MP_IRQ_ARG_INIT_NUM_ARGS, mp_irq_init_args, args);
+    enum { ARG_handler, ARG_trigger, ARG_hard };
+    static const mp_arg_t allowed_args[] = {
+        { MP_QSTR_handler, MP_ARG_OBJ, {.u_rom_obj = MP_ROM_NONE} },
+        { MP_QSTR_trigger, MP_ARG_INT, {.u_int = USBD_CDC_IRQ_RX} },
+        { MP_QSTR_hard, MP_ARG_BOOL, {.u_bool = false} },
+    };
     pyb_usb_vcp_obj_t *self = MP_OBJ_TO_PTR(pos_args[0]);
+    mp_arg_val_t args[MP_ARRAY_SIZE(allowed_args)];
+    mp_arg_parse_all(n_args - 1, pos_args + 1, kw_args, MP_ARRAY_SIZE(allowed_args), allowed_args, args);
 
     if (n_args > 1 || kw_args->used != 0) {
         // Check the handler.


### PR DESCRIPTION
Following how other .irq() methods work on other objects.
