### PR TITLE
mimxrt: Add and change build scripts for nightly builds.

### DIFF
--- a/ports/mimxrt/Makefile
+++ b/ports/mimxrt/Makefile
@@ -289,7 +289,7 @@ OBJ += $(BUILD)/pins_gen.o
 # Workaround for bug in older gcc, warning on "static usbd_device_t _usbd_dev = { 0 };"
 $(BUILD)/lib/tinyusb/src/device/usbd.o: CFLAGS += -Wno-missing-braces
 
-all: $(BUILD)/firmware.hex
+all: $(BUILD)/firmware.hex $(BUILD)/firmware.bin
 
 $(BUILD)/firmware.elf: $(OBJ)
 	$(ECHO) "LINK $@"

--- a/tools/autobuild/autobuild.sh
+++ b/tools/autobuild/autobuild.sh
@@ -66,6 +66,8 @@ cd ../esp32
 ${AUTODIR}/build-esp32-latest.sh ${IDF_PATH_V4} ${FW_TAG} ${LOCAL_FIRMWARE}
 cd ../rp2
 ${AUTODIR}/build-rp2-latest.sh ${FW_TAG} ${LOCAL_FIRMWARE}
+cd ../mimxrt
+${AUTODIR}/build-mimxrt-latest.sh ${FW_TAG} ${LOCAL_FIRMWARE}
 
 popd
 

--- a/tools/autobuild/build-mimxrt-latest.sh
+++ b/tools/autobuild/build-mimxrt-latest.sh
@@ -31,6 +31,6 @@ if [ ! -r modmimxrt.c ]; then
 fi
 
 # build the boards
-do_build Teensy_4.0 TEENSY40 hex
-do_build Teensy_4.1 TEENSY41 hex
+do_build TEENSY40 TEENSY40 hex
+do_build TEENSY41 TEENSY41 hex
 do_build MIMXRT1020_EVK MIMXRT1020_EVK bin

--- a/tools/autobuild/build-mimxrt-latest.sh
+++ b/tools/autobuild/build-mimxrt-latest.sh
@@ -4,12 +4,14 @@
 function do_build() {
     descr=$1
     board=$2
+    ext=$3
+    shift
     shift
     shift
     echo "building $descr $board"
-    build_dir=/tmp/rp2-build-$board
+    build_dir=/tmp/mimxrt-build-$board
     $MICROPY_AUTOBUILD_MAKE $@ BOARD=$board BUILD=$build_dir || exit 1
-    mv $build_dir/firmware.hex $dest_dir/$descr$fw_tag.hex
+    mv $build_dir/firmware.$ext $dest_dir/$descr$fw_tag.$ext
     rm -rf $build_dir
 }
 
@@ -24,10 +26,11 @@ dest_dir=$2
 
 # check we are in the correct directory
 if [ ! -r modmimxrt.c ]; then
-    echo "must be in rp2 directory"
+    echo "must be in mimxrt directory"
     exit 1
 fi
 
 # build the boards
-do_build Teensy_4.0 TEENSY40
-do_build Teensy_4.1 TEENSY41
+do_build Teensy_4.0 TEENSY40 hex
+do_build Teensy_4.1 TEENSY41 hex
+do_build MIMXRT1020_EVK MIMXRT1020_EVK bin

--- a/tools/autobuild/build-mimxrt-latest.sh
+++ b/tools/autobuild/build-mimxrt-latest.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+
+# function for building firmware
+function do_build() {
+    descr=$1
+    board=$2
+    shift
+    shift
+    echo "building $descr $board"
+    build_dir=/tmp/rp2-build-$board
+    $MICROPY_AUTOBUILD_MAKE $@ BOARD=$board BUILD=$build_dir || exit 1
+    mv $build_dir/firmware.hex $dest_dir/$descr$fw_tag.hex
+    rm -rf $build_dir
+}
+
+# check/get parameters
+if [ $# != 2 ]; then
+    echo "usage: $0 <fw-tag> <dest-dir>"
+    exit 1
+fi
+
+fw_tag=$1
+dest_dir=$2
+
+# check we are in the correct directory
+if [ ! -r modmimxrt.c ]; then
+    echo "must be in rp2 directory"
+    exit 1
+fi
+
+# build the boards
+do_build Teensy_4.0 TEENSY40
+do_build Teensy_4.1 TEENSY41


### PR DESCRIPTION
This scripts create the  files for Teensy 4.0 and Teensy 4.1. 
User of MIMXRT10xx_EVK board should be able do build the firmware
themselves. They might need specific DEBUG settings.