### PR TITLE
tools/ci: Run apt-get update in ci_powerpc_setup.

### DIFF
--- a/tools/ci.sh
+++ b/tools/ci.sh
@@ -172,6 +172,7 @@ function ci_nrf_build {
 # ports/powerpc
 
 function ci_powerpc_setup {
+    sudo apt-get update
     sudo apt-get install gcc-powerpc64le-linux-gnu libc6-dev-ppc64el-cross
 }
 


### PR DESCRIPTION
This fixes failing builds when the GitHub CI image lags behind Ubuntu security updates.