### PR TITLE
ports/stm32/main: Add mp_deinit() in main.

### DIFF
--- a/ports/stm32/main.c
+++ b/ports/stm32/main.c
@@ -662,6 +662,7 @@ soft_reset_exit:
     MICROPY_BOARD_END_SOFT_RESET(&state);
 
     gc_sweep_all();
+    mp_deinit();
 
     goto soft_reset;
 }


### PR DESCRIPTION
This adds a call to `mp_deinit()` in the main function of the STM32 port. This enables the use of the `MICROPY_PORT_DEINIT_FUNC` hook on that port.

This is just something I noticed while looking at the code. I don't have an actual use case at this time, so happy to hold off on this until someone actually needs it.