### PR TITLE
py: Tidy up StopIteration handling, and support optimised StopIteration with an argument

### DIFF
--- a/extmod/modure.c
+++ b/extmod/modure.c
@@ -68,7 +68,7 @@ STATIC mp_obj_t match_group(mp_obj_t self_in, mp_obj_t no_in) {
     mp_obj_match_t *self = MP_OBJ_TO_PTR(self_in);
     mp_int_t no = mp_obj_get_int(no_in);
     if (no < 0 || no >= self->num_matches) {
-        nlr_raise(mp_obj_new_exception_arg1(&mp_type_IndexError, no_in));
+        mp_raise_type_arg(&mp_type_IndexError, no_in);
     }
 
     const char *start = self->caps[no * 2];
@@ -107,7 +107,7 @@ STATIC void match_span_helper(size_t n_args, const mp_obj_t *args, mp_obj_t span
     if (n_args == 2) {
         no = mp_obj_get_int(args[1]);
         if (no < 0 || no >= self->num_matches) {
-            nlr_raise(mp_obj_new_exception_arg1(&mp_type_IndexError, args[1]));
+            mp_raise_type_arg(&mp_type_IndexError, args[1]);
         }
     }
 
@@ -334,7 +334,7 @@ STATIC mp_obj_t re_sub_helper(size_t n_args, const mp_obj_t *args) {
                     }
 
                     if (match_no >= (unsigned int)match->num_matches) {
-                        nlr_raise(mp_obj_new_exception_arg1(&mp_type_IndexError, MP_OBJ_NEW_SMALL_INT(match_no)));
+                        mp_raise_type_arg(&mp_type_IndexError, MP_OBJ_NEW_SMALL_INT(match_no));
                     }
 
                     const char *start_match = match->caps[match_no * 2];

--- a/extmod/moduzlib.c
+++ b/extmod/moduzlib.c
@@ -201,7 +201,7 @@ STATIC mp_obj_t mod_uzlib_decompress(size_t n_args, const mp_obj_t *args) {
     return res;
 
 error:
-    nlr_raise(mp_obj_new_exception_arg1(&mp_type_ValueError, MP_OBJ_NEW_SMALL_INT(st)));
+    mp_raise_type_arg(&mp_type_ValueError, MP_OBJ_NEW_SMALL_INT(st));
 }
 STATIC MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(mod_uzlib_decompress_obj, 1, 3, mod_uzlib_decompress);
 

--- a/ports/mimxrt/machine_led.c
+++ b/ports/mimxrt/machine_led.c
@@ -44,7 +44,7 @@ STATIC mp_obj_t led_obj_make_new(const mp_obj_type_t *type, size_t n_args, size_
 
     // Check led id is in range
     if (!(1 <= led_id && led_id <= NUM_LEDS)) {
-        nlr_raise(mp_obj_new_exception_msg_varg(&mp_type_ValueError, "LED(%d) doesn't exist", led_id));
+        mp_raise_msg_varg(&mp_type_ValueError, "LED(%d) doesn't exist", led_id);
     }
 
     // Return reference to static object

--- a/ports/unix/modjni.c
+++ b/ports/unix/modjni.c
@@ -102,9 +102,9 @@ STATIC void check_exception(void) {
         mp_obj_t py_e = new_jobject(exc);
         JJ1(ExceptionClear);
         if (JJ(IsInstanceOf, exc, IndexException_class)) {
-            nlr_raise(mp_obj_new_exception_arg1(&mp_type_IndexError, py_e));
+            mp_raise_type_arg(&mp_type_IndexError, py_e);
         }
-        nlr_raise(mp_obj_new_exception_arg1(&mp_type_Exception, py_e));
+        mp_raise_type_arg(&mp_type_Exception, py_e);
     }
 }
 

--- a/ports/windows/.appveyor.yml
+++ b/ports/windows/.appveyor.yml
@@ -1,10 +1,10 @@
-image: Visual Studio 2013
+image: Visual Studio 2017
 clone_depth: 1
 skip_tags: true
 
 environment:
   # Python version used
-  MICROPY_CPYTHON3: c:/python34/python.exe
+  MICROPY_CPYTHON3: c:/python38/python.exe
 
 init:
   # Set build version number to commit to be travis-like

--- a/py/dynruntime.h
+++ b/py/dynruntime.h
@@ -215,6 +215,7 @@ static inline mp_obj_t mp_obj_len_dyn(mp_obj_t o) {
 #define mp_obj_new_exception_arg1(e_type, arg)  (mp_obj_new_exception_arg1_dyn((e_type), (arg)))
 
 #define nlr_raise(o)                            (mp_raise_dyn(o))
+#define mp_raise_type_arg(type, arg)            (mp_raise_dyn(mp_obj_new_exception_arg1_dyn((type), (arg))))
 #define mp_raise_msg(type, msg)                 (mp_fun_table.raise_msg((type), (msg)))
 #define mp_raise_OSError(er)                    (mp_raise_OSError_dyn(er))
 #define mp_raise_NotImplementedError(msg)       (mp_raise_msg(&mp_type_NotImplementedError, (msg)))

--- a/py/modbuiltins.c
+++ b/py/modbuiltins.c
@@ -322,7 +322,7 @@ STATIC mp_obj_t mp_builtin_next(size_t n_args, const mp_obj_t *args) {
     if (n_args == 1) {
         mp_obj_t ret = mp_iternext_allow_raise(args[0]);
         if (ret == MP_OBJ_STOP_ITERATION) {
-            mp_raise_type(&mp_type_StopIteration);
+            mp_raise_StopIteration(MP_STATE_THREAD(stop_iteration_arg));
         } else {
             return ret;
         }
@@ -336,7 +336,7 @@ MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(mp_builtin_next_obj, 1, 2, mp_builtin_next);
 STATIC mp_obj_t mp_builtin_next(mp_obj_t o) {
     mp_obj_t ret = mp_iternext_allow_raise(o);
     if (ret == MP_OBJ_STOP_ITERATION) {
-        mp_raise_type(&mp_type_StopIteration);
+        mp_raise_StopIteration(MP_STATE_THREAD(stop_iteration_arg));
     } else {
         return ret;
     }

--- a/py/modsys.c
+++ b/py/modsys.c
@@ -110,13 +110,11 @@ STATIC const MP_DEFINE_STR_OBJ(mp_sys_platform_obj, MICROPY_PY_SYS_PLATFORM);
 
 // exit([retval]): raise SystemExit, with optional argument given to the exception
 STATIC mp_obj_t mp_sys_exit(size_t n_args, const mp_obj_t *args) {
-    mp_obj_t exc;
     if (n_args == 0) {
-        exc = mp_obj_new_exception(&mp_type_SystemExit);
+        mp_raise_type(&mp_type_SystemExit);
     } else {
-        exc = mp_obj_new_exception_arg1(&mp_type_SystemExit, args[0]);
+        mp_raise_type_arg(&mp_type_SystemExit, args[0]);
     }
-    nlr_raise(exc);
 }
 MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(mp_sys_exit_obj, 0, 1, mp_sys_exit);
 

--- a/py/mpstate.h
+++ b/py/mpstate.h
@@ -266,6 +266,9 @@ typedef struct _mp_state_thread_t {
     // pending exception object (MP_OBJ_NULL if not pending)
     volatile mp_obj_t mp_pending_exception;
 
+    // If MP_OBJ_STOP_ITERATION is propagated then this holds its argument.
+    mp_obj_t stop_iteration_arg;
+
     #if MICROPY_PY_SYS_SETTRACE
     mp_obj_t prof_trace_callback;
     bool prof_callback_is_executing;

--- a/py/obj.h
+++ b/py/obj.h
@@ -739,7 +739,6 @@ mp_obj_t mp_obj_new_int_from_float(mp_float_t val);
 mp_obj_t mp_obj_new_complex(mp_float_t real, mp_float_t imag);
 #endif
 mp_obj_t mp_obj_new_exception(const mp_obj_type_t *exc_type);
-mp_obj_t mp_obj_new_exception_arg1(const mp_obj_type_t *exc_type, mp_obj_t arg);
 mp_obj_t mp_obj_new_exception_args(const mp_obj_type_t *exc_type, size_t n_args, const mp_obj_t *args);
 #if MICROPY_ERROR_REPORTING == MICROPY_ERROR_REPORTING_NONE
 #define mp_obj_new_exception_msg(exc_type, msg) mp_obj_new_exception(exc_type)
@@ -825,6 +824,10 @@ mp_obj_t mp_obj_exception_get_value(mp_obj_t self_in);
 mp_obj_t mp_obj_exception_make_new(const mp_obj_type_t *type_in, size_t n_args, size_t n_kw, const mp_obj_t *args);
 mp_obj_t mp_alloc_emergency_exception_buf(mp_obj_t size_in);
 void mp_init_emergency_exception_buf(void);
+static inline mp_obj_t mp_obj_new_exception_arg1(const mp_obj_type_t *exc_type, mp_obj_t arg) {
+    assert(exc_type->make_new == mp_obj_exception_make_new);
+    return mp_obj_exception_make_new(exc_type, 1, 0, &arg);
+}
 
 // str
 bool mp_obj_str_equal(mp_obj_t s1, mp_obj_t s2);

--- a/py/obj.h
+++ b/py/obj.h
@@ -779,9 +779,11 @@ bool mp_obj_is_callable(mp_obj_t o_in);
 mp_obj_t mp_obj_equal_not_equal(mp_binary_op_t op, mp_obj_t o1, mp_obj_t o2);
 bool mp_obj_equal(mp_obj_t o1, mp_obj_t o2);
 
+// returns true if o is bool, small int or long int
 static inline bool mp_obj_is_integer(mp_const_obj_t o) {
     return mp_obj_is_int(o) || mp_obj_is_bool(o);
-}                                                                                                        // returns true if o is bool, small int or long int
+}
+
 mp_int_t mp_obj_get_int(mp_const_obj_t arg);
 mp_int_t mp_obj_get_int_truncated(mp_const_obj_t arg);
 bool mp_obj_get_int_maybe(mp_const_obj_t arg, mp_int_t *value);

--- a/py/objdict.c
+++ b/py/objdict.c
@@ -190,7 +190,7 @@ mp_obj_t mp_obj_dict_get(mp_obj_t self_in, mp_obj_t index) {
     mp_obj_dict_t *self = MP_OBJ_TO_PTR(self_in);
     mp_map_elem_t *elem = mp_map_lookup(&self->map, index, MP_MAP_LOOKUP);
     if (elem == NULL) {
-        nlr_raise(mp_obj_new_exception_arg1(&mp_type_KeyError, index));
+        mp_raise_type_arg(&mp_type_KeyError, index);
     } else {
         return elem->value;
     }
@@ -206,7 +206,7 @@ STATIC mp_obj_t dict_subscr(mp_obj_t self_in, mp_obj_t index, mp_obj_t value) {
         mp_obj_dict_t *self = MP_OBJ_TO_PTR(self_in);
         mp_map_elem_t *elem = mp_map_lookup(&self->map, index, MP_MAP_LOOKUP);
         if (elem == NULL) {
-            nlr_raise(mp_obj_new_exception_arg1(&mp_type_KeyError, index));
+            mp_raise_type_arg(&mp_type_KeyError, index);
         } else {
             return elem->value;
         }
@@ -295,7 +295,7 @@ STATIC mp_obj_t dict_get_helper(size_t n_args, const mp_obj_t *args, mp_map_look
     if (elem == NULL || elem->value == MP_OBJ_NULL) {
         if (n_args == 2) {
             if (lookup_kind == MP_MAP_LOOKUP_REMOVE_IF_FOUND) {
-                nlr_raise(mp_obj_new_exception_arg1(&mp_type_KeyError, args[1]));
+                mp_raise_type_arg(&mp_type_KeyError, args[1]);
             } else {
                 value = mp_const_none;
             }

--- a/py/objexcept.c
+++ b/py/objexcept.c
@@ -111,6 +111,15 @@ mp_obj_t mp_alloc_emergency_exception_buf(mp_obj_t size_in) {
 #endif
 #endif  // MICROPY_ENABLE_EMERGENCY_EXCEPTION_BUF
 
+STATIC mp_obj_exception_t *get_native_exception(mp_obj_t self_in) {
+    assert(mp_obj_is_exception_instance(self_in));
+    if (mp_obj_is_native_exception_instance(self_in)) {
+        return MP_OBJ_TO_PTR(self_in);
+    } else {
+        return MP_OBJ_TO_PTR(((mp_obj_instance_t *)MP_OBJ_TO_PTR(self_in))->subobj[0]);
+    }
+}
+
 STATIC void decompress_error_text_maybe(mp_obj_exception_t *o) {
     #if MICROPY_ROM_TEXT_COMPRESSION
     if (o->args->len == 1 && mp_obj_is_type(o->args->items[0], &mp_type_str)) {
@@ -240,7 +249,7 @@ mp_obj_t mp_obj_exception_make_new(const mp_obj_type_t *type, size_t n_args, siz
 
 // Get exception "value" - that is, first argument, or None
 mp_obj_t mp_obj_exception_get_value(mp_obj_t self_in) {
-    mp_obj_exception_t *self = MP_OBJ_TO_PTR(self_in);
+    mp_obj_exception_t *self = get_native_exception(self_in);
     if (self->args->len == 0) {
         return mp_const_none;
     } else {
@@ -559,25 +568,15 @@ bool mp_obj_exception_match(mp_obj_t exc, mp_const_obj_t exc_type) {
 
 // traceback handling functions
 
-#define GET_NATIVE_EXCEPTION(self, self_in) \
-    /* make sure self_in is an exception instance */ \
-    assert(mp_obj_is_exception_instance(self_in)); \
-    mp_obj_exception_t *self; \
-    if (mp_obj_is_native_exception_instance(self_in)) { \
-        self = MP_OBJ_TO_PTR(self_in); \
-    } else { \
-        self = MP_OBJ_TO_PTR(((mp_obj_instance_t *)MP_OBJ_TO_PTR(self_in))->subobj[0]); \
-    }
-
 void mp_obj_exception_clear_traceback(mp_obj_t self_in) {
-    GET_NATIVE_EXCEPTION(self, self_in);
+    mp_obj_exception_t *self = get_native_exception(self_in);
     // just set the traceback to the null object
     // we don't want to call any memory management functions here
     self->traceback_data = NULL;
 }
 
 void mp_obj_exception_add_traceback(mp_obj_t self_in, qstr file, size_t line, qstr block) {
-    GET_NATIVE_EXCEPTION(self, self_in);
+    mp_obj_exception_t *self = get_native_exception(self_in);
 
     // append this traceback info to traceback data
     // if memory allocation fails (eg because gc is locked), just return
@@ -630,7 +629,7 @@ void mp_obj_exception_add_traceback(mp_obj_t self_in, qstr file, size_t line, qs
 }
 
 void mp_obj_exception_get_traceback(mp_obj_t self_in, size_t *n, size_t **values) {
-    GET_NATIVE_EXCEPTION(self, self_in);
+    mp_obj_exception_t *self = get_native_exception(self_in);
 
     if (self->traceback_data == NULL) {
         *n = 0;

--- a/py/objexcept.c
+++ b/py/objexcept.c
@@ -378,12 +378,6 @@ mp_obj_t mp_obj_new_exception(const mp_obj_type_t *exc_type) {
     return mp_obj_exception_make_new(exc_type, 0, 0, NULL);
 }
 
-// "Optimized" version for common(?) case of having 1 exception arg
-mp_obj_t mp_obj_new_exception_arg1(const mp_obj_type_t *exc_type, mp_obj_t arg) {
-    assert(exc_type->make_new == mp_obj_exception_make_new);
-    return mp_obj_exception_make_new(exc_type, 1, 0, &arg);
-}
-
 mp_obj_t mp_obj_new_exception_args(const mp_obj_type_t *exc_type, size_t n_args, const mp_obj_t *args) {
     assert(exc_type->make_new == mp_obj_exception_make_new);
     return mp_obj_exception_make_new(exc_type, n_args, 0, args);

--- a/py/objgenerator.c
+++ b/py/objgenerator.c
@@ -238,16 +238,20 @@ mp_vm_return_kind_t mp_obj_gen_resume(mp_obj_t self_in, mp_obj_t send_value, mp_
     return ret_kind;
 }
 
-STATIC mp_obj_t gen_resume_and_raise(mp_obj_t self_in, mp_obj_t send_value, mp_obj_t throw_value) {
+STATIC mp_obj_t gen_resume_and_raise(mp_obj_t self_in, mp_obj_t send_value, mp_obj_t throw_value, bool raise_stop_iteration) {
     mp_obj_t ret;
     switch (mp_obj_gen_resume(self_in, send_value, throw_value, &ret)) {
         case MP_VM_RETURN_NORMAL:
         default:
-            // Optimize return w/o value in case generator is used in for loop
-            if (ret == mp_const_none || ret == MP_OBJ_STOP_ITERATION) {
-                return MP_OBJ_STOP_ITERATION;
+            // A normal return is a StopIteration, either raise it or return
+            // MP_OBJ_STOP_ITERATION as an optimisation.
+            if (ret == mp_const_none) {
+                ret = MP_OBJ_NULL;
+            }
+            if (raise_stop_iteration) {
+                mp_raise_StopIteration(ret);
             } else {
-                nlr_raise(mp_obj_new_exception_arg1(&mp_type_StopIteration, ret));
+                return mp_make_stop_iteration(ret);
             }
 
         case MP_VM_RETURN_YIELD:
@@ -259,16 +263,11 @@ STATIC mp_obj_t gen_resume_and_raise(mp_obj_t self_in, mp_obj_t send_value, mp_o
 }
 
 STATIC mp_obj_t gen_instance_iternext(mp_obj_t self_in) {
-    return gen_resume_and_raise(self_in, mp_const_none, MP_OBJ_NULL);
+    return gen_resume_and_raise(self_in, mp_const_none, MP_OBJ_NULL, false);
 }
 
 STATIC mp_obj_t gen_instance_send(mp_obj_t self_in, mp_obj_t send_value) {
-    mp_obj_t ret = gen_resume_and_raise(self_in, send_value, MP_OBJ_NULL);
-    if (ret == MP_OBJ_STOP_ITERATION) {
-        mp_raise_type(&mp_type_StopIteration);
-    } else {
-        return ret;
-    }
+    return gen_resume_and_raise(self_in, send_value, MP_OBJ_NULL, true);
 }
 STATIC MP_DEFINE_CONST_FUN_OBJ_2(gen_instance_send_obj, gen_instance_send);
 
@@ -290,12 +289,7 @@ STATIC mp_obj_t gen_instance_throw(size_t n_args, const mp_obj_t *args) {
         exc = args[2];
     }
 
-    mp_obj_t ret = gen_resume_and_raise(args[0], mp_const_none, exc);
-    if (ret == MP_OBJ_STOP_ITERATION) {
-        mp_raise_type(&mp_type_StopIteration);
-    } else {
-        return ret;
-    }
+    return gen_resume_and_raise(args[0], mp_const_none, exc, true);
 }
 STATIC MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(gen_instance_throw_obj, 2, 4, gen_instance_throw);
 

--- a/py/objgenerator.c
+++ b/py/objgenerator.c
@@ -152,8 +152,9 @@ mp_vm_return_kind_t mp_obj_gen_resume(mp_obj_t self_in, mp_obj_t send_value, mp_
     mp_check_self(mp_obj_is_type(self_in, &mp_type_gen_instance));
     mp_obj_gen_instance_t *self = MP_OBJ_TO_PTR(self_in);
     if (self->code_state.ip == 0) {
-        // Trying to resume already stopped generator
-        *ret_val = MP_OBJ_STOP_ITERATION;
+        // Trying to resume an already stopped generator.
+        // This is an optimised "raise StopIteration(None)".
+        *ret_val = mp_const_none;
         return MP_VM_RETURN_NORMAL;
     }
 
@@ -212,6 +213,7 @@ mp_vm_return_kind_t mp_obj_gen_resume(mp_obj_t self_in, mp_obj_t send_value, mp_
             // subsequent next() may re-execute statements after last yield
             // again and again, leading to side effects.
             self->code_state.ip = 0;
+            // This is an optimised "raise StopIteration(*ret_val)".
             *ret_val = *self->code_state.sp;
             break;
 

--- a/py/objgetitemiter.c
+++ b/py/objgetitemiter.c
@@ -48,7 +48,6 @@ STATIC mp_obj_t it_iternext(mp_obj_t self_in) {
         // an exception was raised
         mp_obj_type_t *t = (mp_obj_type_t *)((mp_obj_base_t *)nlr.ret_val)->type;
         if (t == &mp_type_StopIteration || t == &mp_type_IndexError) {
-            // return MP_OBJ_STOP_ITERATION instead of raising
             return MP_OBJ_STOP_ITERATION;
         } else {
             // re-raise exception

--- a/py/objset.c
+++ b/py/objset.c
@@ -372,7 +372,7 @@ STATIC mp_obj_t set_remove(mp_obj_t self_in, mp_obj_t item) {
     check_set(self_in);
     mp_obj_set_t *self = MP_OBJ_TO_PTR(self_in);
     if (mp_set_lookup(&self->set, item, MP_MAP_LOOKUP_REMOVE_IF_FOUND) == MP_OBJ_NULL) {
-        nlr_raise(mp_obj_new_exception_arg1(&mp_type_KeyError, item));
+        mp_raise_type_arg(&mp_type_KeyError, item);
     }
     return mp_const_none;
 }

--- a/py/objstr.c
+++ b/py/objstr.c
@@ -1081,7 +1081,7 @@ STATIC vstr_t mp_obj_str_format_helper(const char *str, const char *top, int *ar
                 field_name = lookup;
                 mp_map_elem_t *key_elem = mp_map_lookup(kwargs, field_q, MP_MAP_LOOKUP);
                 if (key_elem == NULL) {
-                    nlr_raise(mp_obj_new_exception_arg1(&mp_type_KeyError, field_q));
+                    mp_raise_type_arg(&mp_type_KeyError, field_q);
                 }
                 arg = key_elem->value;
             }

--- a/py/pystack.c
+++ b/py/pystack.c
@@ -43,8 +43,7 @@ void *mp_pystack_alloc(size_t n_bytes) {
     #endif
     if (MP_STATE_THREAD(pystack_cur) + n_bytes > MP_STATE_THREAD(pystack_end)) {
         // out of memory in the pystack
-        nlr_raise(mp_obj_new_exception_arg1(&mp_type_RuntimeError,
-            MP_OBJ_NEW_QSTR(MP_QSTR_pystack_space_exhausted)));
+        mp_raise_type_arg(&mp_type_RuntimeError, MP_OBJ_NEW_QSTR(MP_QSTR_pystack_space_exhausted));
     }
     void *ptr = MP_STATE_THREAD(pystack_cur);
     MP_STATE_THREAD(pystack_cur) += n_bytes;

--- a/py/runtime.c
+++ b/py/runtime.c
@@ -1217,6 +1217,7 @@ mp_obj_t mp_getiter(mp_obj_t o_in, mp_obj_iter_buf_t *iter_buf) {
 mp_obj_t mp_iternext_allow_raise(mp_obj_t o_in) {
     const mp_obj_type_t *type = mp_obj_get_type(o_in);
     if (type->iternext != NULL) {
+        MP_STATE_THREAD(stop_iteration_arg) = MP_OBJ_NULL;
         return type->iternext(o_in);
     } else {
         // check for __next__ method
@@ -1242,6 +1243,7 @@ mp_obj_t mp_iternext(mp_obj_t o_in) {
     MP_STACK_CHECK(); // enumerate, filter, map and zip can recursively call mp_iternext
     const mp_obj_type_t *type = mp_obj_get_type(o_in);
     if (type->iternext != NULL) {
+        MP_STATE_THREAD(stop_iteration_arg) = MP_OBJ_NULL;
         return type->iternext(o_in);
     } else {
         // check for __next__ method
@@ -1256,7 +1258,7 @@ mp_obj_t mp_iternext(mp_obj_t o_in) {
                 return ret;
             } else {
                 if (mp_obj_is_subclass_fast(MP_OBJ_FROM_PTR(((mp_obj_base_t *)nlr.ret_val)->type), MP_OBJ_FROM_PTR(&mp_type_StopIteration))) {
-                    return MP_OBJ_STOP_ITERATION;
+                    return mp_make_stop_iteration(mp_obj_exception_get_value(MP_OBJ_FROM_PTR(nlr.ret_val)));
                 } else {
                     nlr_jump(nlr.ret_val);
                 }
@@ -1281,14 +1283,18 @@ mp_vm_return_kind_t mp_resume(mp_obj_t self_in, mp_obj_t send_value, mp_obj_t th
     }
 
     if (type->iternext != NULL && send_value == mp_const_none) {
+        MP_STATE_THREAD(stop_iteration_arg) = MP_OBJ_NULL;
         mp_obj_t ret = type->iternext(self_in);
         *ret_val = ret;
         if (ret != MP_OBJ_STOP_ITERATION) {
             return MP_VM_RETURN_YIELD;
         } else {
             // The generator is finished.
-            // This is an optimised "raise StopIteration(None)".
-            *ret_val = mp_const_none;
+            // This is an optimised "raise StopIteration(*ret_val)".
+            *ret_val = MP_STATE_THREAD(stop_iteration_arg);
+            if (*ret_val == MP_OBJ_NULL) {
+                *ret_val = mp_const_none;
+            }
             return MP_VM_RETURN_NORMAL;
         }
     }
@@ -1558,6 +1564,14 @@ NORETURN void mp_raise_NotImplementedError(mp_rom_error_text_t msg) {
 }
 
 #endif
+
+NORETURN void mp_raise_StopIteration(mp_obj_t arg) {
+    if (arg == MP_OBJ_NULL) {
+        mp_raise_type(&mp_type_StopIteration);
+    } else {
+        nlr_raise(mp_obj_new_exception_arg1(&mp_type_StopIteration, arg));
+    }
+}
 
 NORETURN void mp_raise_OSError(int errno_) {
     nlr_raise(mp_obj_new_exception_arg1(&mp_type_OSError, MP_OBJ_NEW_SMALL_INT(errno_)));

--- a/py/runtime.c
+++ b/py/runtime.c
@@ -1272,7 +1272,6 @@ mp_obj_t mp_iternext(mp_obj_t o_in) {
     }
 }
 
-// TODO: Unclear what to do with StopIterarion exception here.
 mp_vm_return_kind_t mp_resume(mp_obj_t self_in, mp_obj_t send_value, mp_obj_t throw_value, mp_obj_t *ret_val) {
     assert((send_value != MP_OBJ_NULL) ^ (throw_value != MP_OBJ_NULL));
     const mp_obj_type_t *type = mp_obj_get_type(self_in);
@@ -1287,8 +1286,9 @@ mp_vm_return_kind_t mp_resume(mp_obj_t self_in, mp_obj_t send_value, mp_obj_t th
         if (ret != MP_OBJ_STOP_ITERATION) {
             return MP_VM_RETURN_YIELD;
         } else {
-            // Emulate raise StopIteration()
-            // Special case, handled in vm.c
+            // The generator is finished.
+            // This is an optimised "raise StopIteration(None)".
+            *ret_val = mp_const_none;
             return MP_VM_RETURN_NORMAL;
         }
     }

--- a/py/runtime.c
+++ b/py/runtime.c
@@ -1565,21 +1565,24 @@ NORETURN void mp_raise_NotImplementedError(mp_rom_error_text_t msg) {
 
 #endif
 
+NORETURN void mp_raise_type_arg(const mp_obj_type_t *exc_type, mp_obj_t arg) {
+    nlr_raise(mp_obj_new_exception_arg1(exc_type, arg));
+}
+
 NORETURN void mp_raise_StopIteration(mp_obj_t arg) {
     if (arg == MP_OBJ_NULL) {
         mp_raise_type(&mp_type_StopIteration);
     } else {
-        nlr_raise(mp_obj_new_exception_arg1(&mp_type_StopIteration, arg));
+        mp_raise_type_arg(&mp_type_StopIteration, arg);
     }
 }
 
 NORETURN void mp_raise_OSError(int errno_) {
-    nlr_raise(mp_obj_new_exception_arg1(&mp_type_OSError, MP_OBJ_NEW_SMALL_INT(errno_)));
+    mp_raise_type_arg(&mp_type_OSError, MP_OBJ_NEW_SMALL_INT(errno_));
 }
 
 #if MICROPY_STACK_CHECK || MICROPY_ENABLE_PYSTACK
 NORETURN void mp_raise_recursion_depth(void) {
-    nlr_raise(mp_obj_new_exception_arg1(&mp_type_RuntimeError,
-        MP_OBJ_NEW_QSTR(MP_QSTR_maximum_space_recursion_space_depth_space_exceeded)));
+    mp_raise_type_arg(&mp_type_RuntimeError, MP_OBJ_NEW_QSTR(MP_QSTR_maximum_space_recursion_space_depth_space_exceeded));
 }
 #endif

--- a/py/runtime.h
+++ b/py/runtime.h
@@ -184,6 +184,7 @@ NORETURN void mp_raise_TypeError(mp_rom_error_text_t msg);
 NORETURN void mp_raise_NotImplementedError(mp_rom_error_text_t msg);
 #endif
 
+NORETURN void mp_raise_type_arg(const mp_obj_type_t *exc_type, mp_obj_t arg);
 NORETURN void mp_raise_StopIteration(mp_obj_t arg);
 NORETURN void mp_raise_OSError(int errno_);
 NORETURN void mp_raise_recursion_depth(void);

--- a/py/runtime.h
+++ b/py/runtime.h
@@ -154,6 +154,11 @@ mp_obj_t mp_iternext_allow_raise(mp_obj_t o); // may return MP_OBJ_STOP_ITERATIO
 mp_obj_t mp_iternext(mp_obj_t o); // will always return MP_OBJ_STOP_ITERATION instead of raising StopIteration(...)
 mp_vm_return_kind_t mp_resume(mp_obj_t self_in, mp_obj_t send_value, mp_obj_t throw_value, mp_obj_t *ret_val);
 
+static inline mp_obj_t mp_make_stop_iteration(mp_obj_t o) {
+    MP_STATE_THREAD(stop_iteration_arg) = o;
+    return MP_OBJ_STOP_ITERATION;
+}
+
 mp_obj_t mp_make_raise_obj(mp_obj_t o);
 
 mp_obj_t mp_import_name(qstr name, mp_obj_t fromlist, mp_obj_t level);
@@ -179,6 +184,7 @@ NORETURN void mp_raise_TypeError(mp_rom_error_text_t msg);
 NORETURN void mp_raise_NotImplementedError(mp_rom_error_text_t msg);
 #endif
 
+NORETURN void mp_raise_StopIteration(mp_obj_t arg);
 NORETURN void mp_raise_OSError(int errno_);
 NORETURN void mp_raise_recursion_depth(void);
 

--- a/py/vm.c
+++ b/py/vm.c
@@ -1257,16 +1257,9 @@ yield:
                         PUSH(ret_value);
                         goto yield;
                     } else if (ret_kind == MP_VM_RETURN_NORMAL) {
-                        // Pop exhausted gen
-                        sp--;
-                        if (ret_value == MP_OBJ_STOP_ITERATION) {
-                            // Optimize StopIteration
-                            // TODO: get StopIteration's value
-                            PUSH(mp_const_none);
-                        } else {
-                            PUSH(ret_value);
-                        }
-
+                        // The generator has finished, and returned a value via StopIteration
+                        // Replace exhausted generator with the returned value
+                        SET_TOP(ret_value);
                         // If we injected GeneratorExit downstream, then even
                         // if it was swallowed, we re-raise GeneratorExit
                         GENERATOR_EXIT_IF_NEEDED(t_exc);

--- a/tests/basics/gen_yield_from_stopped.py
+++ b/tests/basics/gen_yield_from_stopped.py
@@ -16,3 +16,15 @@ try:
     next(run())
 except StopIteration:
     print("StopIteration")
+
+
+# Where "f" is a native generator
+def run():
+    print((yield from f))
+
+
+f = zip()
+try:
+    next(run())
+except StopIteration:
+    print("StopIteration")

--- a/tests/basics/stopiteration.py
+++ b/tests/basics/stopiteration.py
@@ -1,0 +1,63 @@
+# test StopIteration interaction with generators
+
+try:
+    enumerate, exec
+except:
+    print("SKIP")
+    raise SystemExit
+
+
+def get_stop_iter_arg(msg, code):
+    try:
+        exec(code)
+        print("FAIL")
+    except StopIteration as er:
+        print(msg, er.args)
+
+
+class A:
+    def __iter__(self):
+        return self
+
+    def __next__(self):
+        raise StopIteration(42)
+
+
+class B:
+    def __getitem__(self, index):
+        # argument to StopIteration should get ignored
+        raise StopIteration(42)
+
+
+def gen(x):
+    return x
+    yield
+
+
+def gen2(x):
+    try:
+        yield
+    except ValueError:
+        pass
+    return x
+
+
+get_stop_iter_arg("next", "next(A())")
+get_stop_iter_arg("iter", "next(iter(B()))")
+get_stop_iter_arg("enumerate", "next(enumerate(A()))")
+get_stop_iter_arg("map", "next(map(lambda x:x, A()))")
+get_stop_iter_arg("zip", "next(zip(A()))")
+g = gen(None)
+get_stop_iter_arg("generator0", "next(g)")
+get_stop_iter_arg("generator1", "next(g)")
+g = gen(42)
+get_stop_iter_arg("generator0", "next(g)")
+get_stop_iter_arg("generator1", "next(g)")
+get_stop_iter_arg("send", "gen(None).send(None)")
+get_stop_iter_arg("send", "gen(42).send(None)")
+g = gen2(None)
+next(g)
+get_stop_iter_arg("throw", "g.throw(ValueError)")
+g = gen2(42)
+next(g)
+get_stop_iter_arg("throw", "g.throw(ValueError)")

--- a/tests/basics/subclass_native3.py
+++ b/tests/basics/subclass_native3.py
@@ -34,6 +34,26 @@ print(MyStopIteration().value)
 print(MyStopIteration(1).value)
 
 
+class Iter:
+    def __iter__(self):
+        return self
+
+    def __next__(self):
+        # This exception will stop the "yield from", with a value of 3
+        raise MyStopIteration(3)
+
+
+def gen():
+    print((yield from Iter()))
+    return 4
+
+
+try:
+    next(gen())
+except StopIteration as er:
+    print(er.args)
+
+
 class MyOSError(OSError):
     pass
 


### PR DESCRIPTION
This set of commits tidies up the handling of the `MP_OBJ_STOP_ITERATION` optimisation (which is a shortcut for actually creating a `StopIteration()` exception object), and allows it to take an optional argument, eg an optimisation of `StopIteration(arg)`.

It also adds some new tests to cover corner cases with `StopIteration` and generators that previously did not work.

I'm not sure all this is worth it though, because it adds code size without really adding much (useful) functionality.