### PR TITLE
extmod/modujson: Support specifying separators in dump()/dumps() (v2)

### DIFF
--- a/docs/library/ujson.rst
+++ b/docs/library/ujson.rst
@@ -12,13 +12,19 @@ data format.
 Functions
 ---------
 
-.. function:: dump(obj, stream)
+.. function:: dump(obj, stream, separators=None)
 
    Serialise *obj* to a JSON string, writing it to the given *stream*.
 
-.. function:: dumps(obj)
+   If specified, separators should be an ``(item_separator, key_separator)``
+   tuple. The default is ``(', ', ': ')``. To get the most compact JSON
+   representation, you should specify ``(',', ':')`` to eliminate whitespace.
+
+.. function:: dumps(obj, separators=None)
 
    Return *obj* represented as a JSON string.
+
+   The arguments have the same meaning as in `dump`.
 
 .. function:: load(stream)
 

--- a/py/mpconfig.h
+++ b/py/mpconfig.h
@@ -1380,6 +1380,11 @@ typedef double mp_float_t;
 #define MICROPY_PY_UJSON (0)
 #endif
 
+// Whether to support the "separators" argument to dump, dumps
+#ifndef MICROPY_PY_UJSON_SEPARATORS
+#define MICROPY_PY_UJSON_SEPARATORS (1)
+#endif
+
 #ifndef MICROPY_PY_URE
 #define MICROPY_PY_URE (0)
 #endif

--- a/py/mpprint.h
+++ b/py/mpprint.h
@@ -52,6 +52,14 @@ typedef struct _mp_print_t {
     mp_print_strn_t print_strn;
 } mp_print_t;
 
+typedef struct _mp_print_ext_t {
+    mp_print_t base;
+    const char *item_separator;
+    const char *key_separator;
+}mp_print_ext_t;
+
+#define MP_PRINT_GET_EXT(print) ((mp_print_ext_t *)print)
+
 // All (non-debug) prints go through one of the two interfaces below.
 // 1) Wrapper for platform print function, which wraps MP_PLAT_PRINT_STRN.
 extern const mp_print_t mp_plat_print;

--- a/py/objdict.c
+++ b/py/objdict.c
@@ -69,8 +69,15 @@ STATIC mp_map_elem_t *dict_iter_next(mp_obj_dict_t *dict, size_t *cur) {
 STATIC void dict_print(const mp_print_t *print, mp_obj_t self_in, mp_print_kind_t kind) {
     mp_obj_dict_t *self = MP_OBJ_TO_PTR(self_in);
     bool first = true;
+    const char *item_separator = ", ";
+    const char *key_separator = ": ";
     if (!(MICROPY_PY_UJSON && kind == PRINT_JSON)) {
         kind = PRINT_REPR;
+    } else {
+        #if MICROPY_PY_UJSON_SEPARATORS
+        item_separator = MP_PRINT_GET_EXT(print)->item_separator;
+        key_separator = MP_PRINT_GET_EXT(print)->key_separator;
+        #endif
     }
     if (MICROPY_PY_COLLECTIONS_ORDEREDDICT && self->base.type != &mp_type_dict && kind != PRINT_JSON) {
         mp_printf(print, "%q(", self->base.type->name);
@@ -80,7 +87,7 @@ STATIC void dict_print(const mp_print_t *print, mp_obj_t self_in, mp_print_kind_
     mp_map_elem_t *next = NULL;
     while ((next = dict_iter_next(self, &cur)) != NULL) {
         if (!first) {
-            mp_print_str(print, ", ");
+            mp_print_str(print, item_separator);
         }
         first = false;
         bool add_quote = MICROPY_PY_UJSON && kind == PRINT_JSON && !mp_obj_is_str_or_bytes(next->key);
@@ -91,7 +98,7 @@ STATIC void dict_print(const mp_print_t *print, mp_obj_t self_in, mp_print_kind_
         if (add_quote) {
             mp_print_str(print, "\"");
         }
-        mp_print_str(print, ": ");
+        mp_print_str(print, key_separator);
         mp_obj_print_helper(print, next->value, kind);
     }
     mp_print_str(print, "}");

--- a/py/objlist.c
+++ b/py/objlist.c
@@ -44,13 +44,18 @@ STATIC mp_obj_t list_pop(size_t n_args, const mp_obj_t *args);
 
 STATIC void list_print(const mp_print_t *print, mp_obj_t o_in, mp_print_kind_t kind) {
     mp_obj_list_t *o = MP_OBJ_TO_PTR(o_in);
+    const char *item_separator = ", ";
     if (!(MICROPY_PY_UJSON && kind == PRINT_JSON)) {
         kind = PRINT_REPR;
+    } else {
+        #if MICROPY_PY_UJSON_SEPARATORS
+        item_separator = MP_PRINT_GET_EXT(print)->item_separator;
+        #endif
     }
     mp_print_str(print, "[");
     for (size_t i = 0; i < o->len; i++) {
         if (i > 0) {
-            mp_print_str(print, ", ");
+            mp_print_str(print, item_separator);
         }
         mp_obj_print_helper(print, o->items[i], kind);
     }

--- a/py/objtuple.c
+++ b/py/objtuple.c
@@ -39,15 +39,19 @@
 
 void mp_obj_tuple_print(const mp_print_t *print, mp_obj_t o_in, mp_print_kind_t kind) {
     mp_obj_tuple_t *o = MP_OBJ_TO_PTR(o_in);
+    const char *item_separator = ", ";
     if (MICROPY_PY_UJSON && kind == PRINT_JSON) {
         mp_print_str(print, "[");
+        #if MICROPY_PY_UJSON_SEPARATORS
+        item_separator = MP_PRINT_GET_EXT(print)->item_separator;
+        #endif
     } else {
         mp_print_str(print, "(");
         kind = PRINT_REPR;
     }
     for (size_t i = 0; i < o->len; i++) {
         if (i > 0) {
-            mp_print_str(print, ", ");
+            mp_print_str(print, item_separator);
         }
         mp_obj_print_helper(print, o->items[i], kind);
     }

--- a/tests/extmod/ujson_dump_separators.py
+++ b/tests/extmod/ujson_dump_separators.py
@@ -1,0 +1,62 @@
+try:
+    from uio import StringIO
+    import ujson as json
+except:
+    try:
+        from io import StringIO
+        import json
+    except ImportError:
+        print("SKIP")
+        raise SystemExit
+
+for sep in [
+    None,
+    (", ", ": "),
+    (",", ": "),
+    (",", ":"),
+    [", ", ": "],
+    [",", ": "],
+    [",", ":"],
+]:
+    s = StringIO()
+    json.dump(False, s, separators=sep)
+    print(s.getvalue())
+
+    s = StringIO()
+    json.dump({"a": (2, [3, None])}, s, separators=sep)
+    print(s.getvalue())
+
+    # dump to a small-int not allowed
+    try:
+        json.dump(123, 1, separators=sep)
+    except (AttributeError, OSError):  # CPython and uPy have different errors
+        print("Exception")
+
+    # dump to an object not allowed
+    try:
+        json.dump(123, {}, separators=sep)
+    except (AttributeError, OSError):  # CPython and uPy have different errors
+        print("Exception")
+
+
+try:
+    s = StringIO()
+    json.dump(False, s, separators={"a": 1})
+except (TypeError, ValueError):  # CPython and uPy have different errors
+    print("Exception")
+
+# invalid separator types
+for sep in [1, object()]:
+    try:
+        s = StringIO()
+        json.dump(False, s, separators=sep)
+    except TypeError:
+        print("Exception")
+
+# too many/ not enough separators
+for sep in [(), (",", ":", "?"), (",",), []]:
+    try:
+        s = StringIO()
+        json.dump(False, s, separators=sep)
+    except ValueError:
+        print("Exception")

--- a/tests/extmod/ujson_dumps_separators.py
+++ b/tests/extmod/ujson_dumps_separators.py
@@ -1,0 +1,60 @@
+try:
+    import ujson as json
+except ImportError:
+    try:
+        import json
+    except ImportError:
+        print("SKIP")
+        raise SystemExit
+
+for sep in [
+    None,
+    (", ", ": "),
+    (",", ": "),
+    (",", ":"),
+    [", ", ": "],
+    [",", ": "],
+    [",", ":"],
+]:
+    print(json.dumps(False, separators=sep))
+    print(json.dumps(True, separators=sep))
+    print(json.dumps(None, separators=sep))
+    print(json.dumps(1, separators=sep))
+    print(json.dumps("abc", separators=sep))
+    print(json.dumps("\x00\x01\x7e", separators=sep))
+    print(json.dumps([], separators=sep))
+    print(json.dumps([1], separators=sep))
+    print(json.dumps([1, 2], separators=sep))
+    print(json.dumps([1, True], separators=sep))
+    print(json.dumps((), separators=sep))
+    print(json.dumps((1,), separators=sep))
+    print(json.dumps((1, 2), separators=sep))
+    print(json.dumps((1, (2, 3)), separators=sep))
+    print(json.dumps({}, separators=sep))
+    print(json.dumps({"a": 1}, separators=sep))
+    print(json.dumps({"a": (2, [3, None])}, separators=sep))
+    print(json.dumps('"quoted"', separators=sep))
+    print(json.dumps("space\n\r\tspace", separators=sep))
+    print(json.dumps({None: -1}, separators=sep))
+    print(json.dumps({False: 0}, separators=sep))
+    print(json.dumps({True: 1}, separators=sep))
+    print(json.dumps({1: 2}, separators=sep))
+
+try:
+    json.dumps(False, separators={"a": 1})
+except (TypeError, ValueError):  # CPython and uPy have different errors
+    print("Exception")
+
+# invalid separator types
+for sep in [1, object()]:
+    try:
+        json.dumps(False, separators=sep)
+    except TypeError:
+        print("Exception")
+
+# too many/ not enough separators
+for sep in [(), (",", ":", "?"), (",",), []]:
+    try:
+        json.dumps(False, separators=sep)
+    except ValueError:
+        print("Exception")


### PR DESCRIPTION
This builds on #7337.  Changes here compared to that PR:
- makes this feature fully optional, controlled via `MICROPY_PY_UJSON_SEAPARATORS` (enabled by default)
- new code is fully optimised to reduce code size

When `MICROPY_PY_UJSON_SEAPARATORS` is disabled the size diff is 0.  When enabled, the diff is (for ports that enable ujson):
```
   unix x64:  +432 +0.080% [incl +32(data)]
unix nanbox:  +428 +0.095% 
      stm32:  +136 +0.035% PYBV10
     cc3200:  +144 +0.079% 
    esp8266:  +168 +0.024% GENERIC
      esp32:  +224 +0.015% GENERIC[incl +40(data)]
        rp2:  +160 +0.033% PICO
```