### PR TITLE
py/makeversionhdr: add --tags arg to git describe

### DIFF
--- a/py/makeversionhdr.py
+++ b/py/makeversionhdr.py
@@ -23,7 +23,7 @@ def get_version_info_from_git():
     # Note: git describe doesn't work if no tag is available
     try:
         git_tag = subprocess.check_output(
-            ["git", "describe", "--dirty", "--always", "--match", "v[1-9].*"],
+            ["git", "describe", "--tags", "--dirty", "--always", "--match", "v[1-9].*"],
             stderr=subprocess.STDOUT,
             universal_newlines=True,
         ).strip()


### PR DESCRIPTION
This adds the `--tags` argument to the `git describe` command that is used to define the `MICROPY_GIT_TAG` macro. This makes it match non-annotated tags. This is useful for MicroPython derivatives that don't use annotated tags.
