### PR TITLE
Factor out efficient mp_hal_stdout_tx_strn_cooked from ports to lib/utils/stdout_helpers.c

### DIFF
--- a/lib/utils/stdout_helpers.c
+++ b/lib/utils/stdout_helpers.c
@@ -1,6 +1,30 @@
+/*
+ * This file is part of the MicroPython project, http://micropython.org/
+ *
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2021 Damien P. George
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
 #include <string.h>
-#include <unistd.h>
-#include "py/mpconfig.h"
 #include "py/mphal.h"
 
 /*
@@ -10,13 +34,25 @@
  */
 
 // Send "cooked" string of given length, where every occurrence of
-// LF character is replaced with CR LF.
+// LF character is replaced with CR LF ("\n" is converted to "\r\n").
+// This is an optimised version to reduce the number of calls made
+// to mp_hal_stdout_tx_strn.
 void mp_hal_stdout_tx_strn_cooked(const char *str, size_t len) {
+    const char *last = str;
     while (len--) {
         if (*str == '\n') {
-            mp_hal_stdout_tx_strn("\r", 1);
+            if (str > last) {
+                mp_hal_stdout_tx_strn(last, str - last);
+            }
+            mp_hal_stdout_tx_strn("\r\n", 2);
+            ++str;
+            last = str;
+        } else {
+            ++str;
         }
-        mp_hal_stdout_tx_strn(str++, 1);
+    }
+    if (str > last) {
+        mp_hal_stdout_tx_strn(last, str - last);
     }
 }
 

--- a/ports/cc3200/application.mk
+++ b/ports/cc3200/application.mk
@@ -147,6 +147,7 @@ APP_LIB_SRC_C = $(addprefix lib/,\
 	utils/gchelper_native.c \
 	utils/pyexec.c \
 	utils/interrupt_char.c \
+	utils/stdout_helpers.c \
 	utils/sys_stdio_mphal.c \
 	)
 

--- a/ports/cc3200/hal/cc3200_hal.c
+++ b/ports/cc3200/hal/cc3200_hal.c
@@ -141,10 +141,6 @@ void mp_hal_delay_ms(mp_uint_t delay) {
     }
 }
 
-void mp_hal_stdout_tx_str(const char *str) {
-    mp_hal_stdout_tx_strn(str, strlen(str));
-}
-
 void mp_hal_stdout_tx_strn(const char *str, size_t len) {
     if (MP_STATE_PORT(os_term_dup_obj)) {
         if (mp_obj_is_type(MP_STATE_PORT(os_term_dup_obj)->stream_o, &pyb_uart_type)) {
@@ -156,25 +152,6 @@ void mp_hal_stdout_tx_strn(const char *str, size_t len) {
     }
     // and also to telnet
     telnet_tx_strn(str, len);
-}
-
-void mp_hal_stdout_tx_strn_cooked (const char *str, size_t len) {
-    int32_t nslen = 0;
-    const char *_str = str;
-
-    for (int i = 0; i < len; i++) {
-        if (str[i] == '\n') {
-            mp_hal_stdout_tx_strn(_str, nslen);
-            mp_hal_stdout_tx_strn("\r\n", 2);
-            _str += nslen + 1;
-            nslen = 0;
-        } else {
-            nslen++;
-        }
-    }
-    if (_str < str + len) {
-        mp_hal_stdout_tx_strn(_str, nslen);
-    }
 }
 
 int mp_hal_stdin_rx_chr(void) {

--- a/ports/esp32/main/CMakeLists.txt
+++ b/ports/esp32/main/CMakeLists.txt
@@ -27,6 +27,7 @@ set(MICROPY_SOURCE_LIB
     ${MICROPY_DIR}/lib/oofatfs/ffunicode.c
     ${MICROPY_DIR}/lib/timeutils/timeutils.c
     ${MICROPY_DIR}/lib/utils/interrupt_char.c
+    ${MICROPY_DIR}/lib/utils/stdout_helpers.c
     ${MICROPY_DIR}/lib/utils/sys_stdio_mphal.c
     ${MICROPY_DIR}/lib/utils/pyexec.c
 )

--- a/ports/esp32/mphalport.c
+++ b/ports/esp32/mphalport.c
@@ -108,10 +108,6 @@ int mp_hal_stdin_rx_chr(void) {
     }
 }
 
-void mp_hal_stdout_tx_str(const char *str) {
-    mp_hal_stdout_tx_strn(str, strlen(str));
-}
-
 void mp_hal_stdout_tx_strn(const char *str, uint32_t len) {
     // Only release the GIL if many characters are being sent
     bool release_gil = len > 20;
@@ -129,26 +125,6 @@ void mp_hal_stdout_tx_strn(const char *str, uint32_t len) {
         MP_THREAD_GIL_ENTER();
     }
     mp_uos_dupterm_tx_strn(str, len);
-}
-
-// Efficiently convert "\n" to "\r\n"
-void mp_hal_stdout_tx_strn_cooked(const char *str, size_t len) {
-    const char *last = str;
-    while (len--) {
-        if (*str == '\n') {
-            if (str > last) {
-                mp_hal_stdout_tx_strn(last, str - last);
-            }
-            mp_hal_stdout_tx_strn("\r\n", 2);
-            ++str;
-            last = str;
-        } else {
-            ++str;
-        }
-    }
-    if (str > last) {
-        mp_hal_stdout_tx_strn(last, str - last);
-    }
 }
 
 uint32_t mp_hal_ticks_ms(void) {

--- a/ports/esp8266/Makefile
+++ b/ports/esp8266/Makefile
@@ -145,6 +145,7 @@ LIB_SRC_C = $(addprefix lib/,\
 	timeutils/timeutils.c \
 	utils/pyexec.c \
 	utils/interrupt_char.c \
+	utils/stdout_helpers.c \
 	utils/sys_stdio_mphal.c \
 	)
 

--- a/ports/esp8266/esp_mphal.c
+++ b/ports/esp8266/esp_mphal.c
@@ -91,31 +91,8 @@ void mp_hal_debug_str(const char *str) {
 }
 #endif
 
-void mp_hal_stdout_tx_str(const char *str) {
-    mp_uos_dupterm_tx_strn(str, strlen(str));
-}
-
 void mp_hal_stdout_tx_strn(const char *str, uint32_t len) {
     mp_uos_dupterm_tx_strn(str, len);
-}
-
-void mp_hal_stdout_tx_strn_cooked(const char *str, uint32_t len) {
-    const char *last = str;
-    while (len--) {
-        if (*str == '\n') {
-            if (str > last) {
-                mp_uos_dupterm_tx_strn(last, str - last);
-            }
-            mp_uos_dupterm_tx_strn("\r\n", 2);
-            ++str;
-            last = str;
-        } else {
-            ++str;
-        }
-    }
-    if (str > last) {
-        mp_uos_dupterm_tx_strn(last, str - last);
-    }
 }
 
 void mp_hal_debug_tx_strn_cooked(void *env, const char *str, uint32_t len) {

--- a/ports/stm32/Makefile
+++ b/ports/stm32/Makefile
@@ -167,6 +167,7 @@ LIB_SRC_C += $(addprefix lib/,\
 	utils/gchelper_native.c \
 	utils/pyexec.c \
 	utils/interrupt_char.c \
+	utils/stdout_helpers.c \
 	utils/sys_stdio_mphal.c \
 	utils/mpirq.c \
 	)

--- a/ports/stm32/mphalport.c
+++ b/ports/stm32/mphalport.c
@@ -53,10 +53,6 @@ MP_WEAK int mp_hal_stdin_rx_chr(void) {
     }
 }
 
-void mp_hal_stdout_tx_str(const char *str) {
-    mp_hal_stdout_tx_strn(str, strlen(str));
-}
-
 MP_WEAK void mp_hal_stdout_tx_strn(const char *str, size_t len) {
     if (MP_STATE_PORT(pyb_stdio_uart) != NULL) {
         uart_tx_strn(MP_STATE_PORT(pyb_stdio_uart), str, len);
@@ -65,26 +61,6 @@ MP_WEAK void mp_hal_stdout_tx_strn(const char *str, size_t len) {
     lcd_print_strn(str, len);
     #endif
     mp_uos_dupterm_tx_strn(str, len);
-}
-
-// Efficiently convert "\n" to "\r\n"
-void mp_hal_stdout_tx_strn_cooked(const char *str, size_t len) {
-    const char *last = str;
-    while (len--) {
-        if (*str == '\n') {
-            if (str > last) {
-                mp_hal_stdout_tx_strn(last, str - last);
-            }
-            mp_hal_stdout_tx_strn("\r\n", 2);
-            ++str;
-            last = str;
-        } else {
-            ++str;
-        }
-    }
-    if (str > last) {
-        mp_hal_stdout_tx_strn(last, str - last);
-    }
 }
 
 #if __CORTEX_M >= 0x03


### PR DESCRIPTION
This efficient implementation of `mp_hal_stdout_tx_strn_cooked` is repeated by a few ports (esp32, esp8266, cc3200, stm32) and needed by others (eg rp2), so just make the common version in `lib/utils/stdout_helpers.c` this efficient one so all ports use the same one.

This helps with #7479, to make `print(data)` faster on rp2.