### PR TITLE
rp2/tusb_config.h: Set CFG_TUD_CDC_EP_BUFSIZE to 256.

### DIFF
--- a/ports/rp2/tusb_config.h
+++ b/ports/rp2/tusb_config.h
@@ -28,6 +28,7 @@
 #define CFG_TUSB_RHPORT0_MODE   (OPT_MODE_DEVICE)
 
 #define CFG_TUD_CDC             (1)
+#define CFG_TUD_CDC_EP_BUFSIZE  (256)
 #define CFG_TUD_CDC_RX_BUFSIZE  (256)
 #define CFG_TUD_CDC_TX_BUFSIZE  (256)
 


### PR DESCRIPTION
This improves the speed of data going out of the MCU and in to the USB host.

See related #7479.