### PR TITLE
tests/cpydiff/modules_struct_whitespace_in_format: Run black.

### DIFF
--- a/tests/cpydiff/modules_struct_whitespace_in_format.py
+++ b/tests/cpydiff/modules_struct_whitespace_in_format.py
@@ -7,7 +7,7 @@ workaround: Don't use spaces in format strings.
 import struct
 
 try:
-    print(struct.pack('b b', 1, 2))
-    print('Should have worked')
+    print(struct.pack("b b", 1, 2))
+    print("Should have worked")
 except:
-    print('struct.error')
+    print("struct.error")


### PR DESCRIPTION
This test sneaked through without proper formatting and is causing CI for other unrelated changes to fail.
