### PR TITLE
windows/Makefile: Add .exe extension to executables name.

### DIFF
--- a/ports/windows/.appveyor.yml
+++ b/ports/windows/.appveyor.yml
@@ -63,10 +63,7 @@ after_test:
       throw "$env:MSYSTEM build exited with code $LASTEXITCODE"
     }
     cd (Join-Path $env:APPVEYOR_BUILD_FOLDER 'mpy-cross')
-    # Building of mpy-cross hasn't been fixed across all possible windows/WSL/...
-    # variations and the STRIP step tries to strip mpy-cross whereas that should be
-    # mpy-cross.exe. Workaround for now by skipping actual strip and size commands.
-    C:\msys64\usr\bin\bash.exe -l -c "make -B -j4 V=1 STRIP=echo SIZE=echo"
+    C:\msys64\usr\bin\bash.exe -l -c "make -B -j4 V=1"
     if ($LASTEXITCODE -ne 0) {
       throw "$env:MSYSTEM mpy_cross build exited with code $LASTEXITCODE"
     }

--- a/ports/windows/Makefile
+++ b/ports/windows/Makefile
@@ -2,7 +2,7 @@ include ../../py/mkenv.mk
 -include mpconfigport.mk
 
 # define main target
-PROG = micropython.exe
+PROG = micropython
 
 # qstr definitions (must come before including py.mk)
 QSTR_DEFS = ../unix/qstrdefsport.h

--- a/py/mkrules.mk
+++ b/py/mkrules.mk
@@ -178,6 +178,13 @@ endif
 ifneq ($(PROG),)
 # Build a standalone executable (unix does this)
 
+# The executable should have an .exe extension for builds targetting 'pure'
+# Windows, i.e. msvc or mingw builds, but not when using msys or cygwin's gcc.
+COMPILER_TARGET := $(shell $(CC) -dumpmachine)
+ifneq (,$(findstring mingw,$(COMPILER_TARGET)))
+PROG := $(PROG).exe
+endif
+
 all: $(PROG)
 
 $(PROG): $(OBJ)
@@ -186,9 +193,9 @@ $(PROG): $(OBJ)
 # we may want to compile using Thumb, but link with non-Thumb libc.
 	$(Q)$(CC) -o $@ $^ $(LIB) $(LDFLAGS)
 ifndef DEBUG
-	$(Q)$(STRIP) $(STRIPFLAGS_EXTRA) $(PROG)
+	$(Q)$(STRIP) $(STRIPFLAGS_EXTRA) $@
 endif
-	$(Q)$(SIZE) $$(find $(BUILD) -path "$(BUILD)/build/frozen*.o") $(PROG)
+	$(Q)$(SIZE) $$(find $(BUILD) -path "$(BUILD)/build/frozen*.o") $@
 
 clean: clean-prog
 clean-prog:


### PR DESCRIPTION
This builds on #4996.

Uses the same logic applied in 5b57ae985ff7064dd7b09b0ce891697bfaa5dae2 to determine when to add .exe.

See related: #3310, #3361, #3370, #4143, #5727.