### PR TITLE
rp2: Allow boards to configure I2C/SPI pins using new macros.

### DIFF
--- a/ports/rp2/machine_i2c.c
+++ b/ports/rp2/machine_i2c.c
@@ -33,10 +33,16 @@
 #include "hardware/i2c.h"
 
 #define DEFAULT_I2C_FREQ (400000)
-#define DEFAULT_I2C0_SCL (9)
-#define DEFAULT_I2C0_SDA (8)
-#define DEFAULT_I2C1_SCL (7)
-#define DEFAULT_I2C1_SDA (6)
+
+#ifndef MICROPY_HW_I2C0_SCL
+#define MICROPY_HW_I2C0_SCL (9)
+#define MICROPY_HW_I2C0_SDA (8)
+#endif
+
+#ifndef MICROPY_HW_I2C1_SCL
+#define MICROPY_HW_I2C1_SCL (7)
+#define MICROPY_HW_I2C1_SDA (6)
+#endif
 
 // SDA/SCL on even/odd pins, I2C0/I2C1 on even/odd pairs of pins.
 #define IS_VALID_SCL(i2c, pin) (((pin) & 1) == 1 && (((pin) & 2) >> 1) == (i2c))
@@ -52,8 +58,8 @@ typedef struct _machine_i2c_obj_t {
 } machine_i2c_obj_t;
 
 STATIC machine_i2c_obj_t machine_i2c_obj[] = {
-    {{&machine_hw_i2c_type}, i2c0, 0, DEFAULT_I2C0_SCL, DEFAULT_I2C0_SDA, 0},
-    {{&machine_hw_i2c_type}, i2c1, 1, DEFAULT_I2C1_SCL, DEFAULT_I2C1_SDA, 0},
+    {{&machine_hw_i2c_type}, i2c0, 0, MICROPY_HW_I2C0_SCL, MICROPY_HW_I2C0_SDA, 0},
+    {{&machine_hw_i2c_type}, i2c1, 1, MICROPY_HW_I2C1_SCL, MICROPY_HW_I2C1_SDA, 0},
 };
 
 STATIC void machine_i2c_print(const mp_print_t *print, mp_obj_t self_in, mp_print_kind_t kind) {

--- a/ports/rp2/machine_spi.c
+++ b/ports/rp2/machine_spi.c
@@ -38,12 +38,18 @@
 #define DEFAULT_SPI_PHASE       (0)
 #define DEFAULT_SPI_BITS        (8)
 #define DEFAULT_SPI_FIRSTBIT    (SPI_MSB_FIRST)
-#define DEFAULT_SPI0_SCK        (6)
-#define DEFAULT_SPI0_MOSI       (7)
-#define DEFAULT_SPI0_MISO       (4)
-#define DEFAULT_SPI1_SCK        (10)
-#define DEFAULT_SPI1_MOSI       (11)
-#define DEFAULT_SPI1_MISO       (8)
+
+#ifndef MICROPY_HW_SPI0_SCK
+#define MICROPY_HW_SPI0_SCK     (6)
+#define MICROPY_HW_SPI0_MOSI    (7)
+#define MICROPY_HW_SPI0_MISO    (4)
+#endif
+
+#ifndef MICROPY_HW_SPI1_SCK
+#define MICROPY_HW_SPI1_SCK     (10)
+#define MICROPY_HW_SPI1_MOSI    (11)
+#define MICROPY_HW_SPI1_MISO    (8)
+#endif
 
 #define IS_VALID_PERIPH(spi, pin)   ((((pin) & 8) >> 3) == (spi))
 #define IS_VALID_SCK(spi, pin)      (((pin) & 3) == 2 && IS_VALID_PERIPH(spi, pin))
@@ -68,13 +74,13 @@ STATIC machine_spi_obj_t machine_spi_obj[] = {
     {
         {&machine_spi_type}, spi0, 0,
         DEFAULT_SPI_POLARITY, DEFAULT_SPI_PHASE, DEFAULT_SPI_BITS, DEFAULT_SPI_FIRSTBIT,
-        DEFAULT_SPI0_SCK, DEFAULT_SPI0_MOSI, DEFAULT_SPI0_MISO,
+        MICROPY_HW_SPI0_SCK, MICROPY_HW_SPI0_MOSI, MICROPY_HW_SPI0_MISO,
         0,
     },
     {
         {&machine_spi_type}, spi1, 1,
         DEFAULT_SPI_POLARITY, DEFAULT_SPI_PHASE, DEFAULT_SPI_BITS, DEFAULT_SPI_FIRSTBIT,
-        DEFAULT_SPI1_SCK, DEFAULT_SPI1_MOSI, DEFAULT_SPI1_MISO,
+        MICROPY_HW_SPI1_SCK, MICROPY_HW_SPI1_MOSI, MICROPY_HW_SPI1_MISO,
         0,
     },
 };


### PR DESCRIPTION
Next steps, update each `mpconfigboard.h` in `/ports/rp2/boards/*` with the board's preferred pins. eg.

```
#define MICROPY_HW_I2C0_SCL (5)
#define MICROPY_HW_I2C0_SDA (4)

#define MICROPY_HW_I2C1_SCL (7)
#define MICROPY_HW_I2C1_SDA (6)
```

```
#define MICROPY_HW_SPI0_SCK     (6)
#define MICROPY_HW_SPI0_MOSI    (7)
#define MICROPY_HW_SPI0_MISO    (4)

#define MICROPY_HW_SPI1_SCK     (10)
#define MICROPY_HW_SPI1_MOSI    (11)
#define MICROPY_HW_SPI1_MISO    (8)
```

As mentioned in https://github.com/micropython/micropython/issues/7476 `UART1` is currently defaulting to `4,5` which conflicts with the latest PICO pinout diagrams preferred pins.

Theres a PR which allows changing the default UART pins: https://github.com/micropython/micropython/pull/7503
Once that's merged, boards can put `UART1` on `8,9` and give `4,5` to `I2C0` and `19,16,18,17` to `SPI0`.

By having all UART, I2C and SPI default pins configurable, boards now have the freedom to pick and choose their favourites.

```
#define MICROPY_HW_UART0_TX  (0)
#define MICROPY_HW_UART0_RX  (1)
#define MICROPY_HW_UART0_CTS (2)
#define MICROPY_HW_UART0_RTS (3)

#define MICROPY_HW_UART0_TX  (8)
#define MICROPY_HW_UART0_RX  (9)
```