### PR TITLE
Introduce non-blocking scan for access points for ESP32

### DIFF
--- a/docs/esp32/quickref.rst
+++ b/docs/esp32/quickref.rst
@@ -110,6 +110,14 @@ calling ``wlan.config(reconnects=n)``, where n are the number of desired reconne
 attempts (0 means it won't retry, -1 will restore the default behaviour of trying
 to reconnect forever).
 
+``wlan.scan()`` accepts a boolean argument which defaults to `True` to run a 
+scan for Access Points.  By default, the scan is blocking and returns the results 
+as a list.  ``wlan.scan(False)`` will run a non-blocking scan.  When the 
+non-blocking scan completes, the results are available by calling 
+``wlan.get_scan_results()``.  If a scan is in progress, any other commands 
+which change the state of the interface will cancel the scan.
+
+
 Delay and timing
 ----------------
 


### PR DESCRIPTION
Scan for APs in the background and retrieve ap records with a new function call.

`scan` run without any arguments, or as `scan(True)` is backwards compatible and returns a list of AP records.

`scan(False)` runs a non-blocking scan, taking advantage of the `blocking` argument to `esp_wifi_scan_start`.

When the scan is complete, the records are available by calling `wlan.get_scan_results()`.

When running a non-blocking scan, the results are stored in the wifi driver's dynamic memory.  A call to `esp_wifi_scan_get_ap_records` is requires to free that memory.

While testing, i noticed that other calls to the driver (e.g. connect, activate, etc). interrupt the scan and emit a SYSTEM_EVENT_SCAN_DONE event.  These appear to clear out the memory also, meaning no records are retrieved.  I didn't add any extra behavior to free the driver's memory as the IDF seems to handle it as long as the driver's state is changed.  e.g., the records don't hang around in memory if a connect is run after a scan, but before a call to `esp_wifi_scan_get_ap_records`.

`wlan.get_scan_results` has 2 behaviors:

- If no SCAN_DONE event is emitted, it returns None.  Either a scan is in progress or no scan was attempted.
- If a SCAN_DONE event occurred, it will return a (possibly empty) list of records once

I added a check against the record size as there are cases when a SCAN_DONE event is emitted but there are zero records returned, specifically when a scan was interrupted.

I didn't add anything to esp_state for scanning / scan_done since it wasn't strictly necessary, as the driver manages it's memory correctly imo.  If the user want's to check if there are scan results, just call wlan.get_scan_results().

to test:
```python
>>> import network
>>> wlan = network.WLAN(network.STA_IF)
>>> wlan.scan()
# list of APs as before
>>> wlan.scan(False)
>>> wlan.get_scan_results()
>>>
# scan finished
>>> wlan.get_scan_results()
# list of APs
```

To trigger edge cases:
```python
>>> wlan.scan(False)
>>> wlan.connect('ssid', 'pass')
>>> wlan.get_scan_results()
```