### PR TITLE
tools/upip: Skip empty entries when looking for install path.

### DIFF
--- a/tools/upip.py
+++ b/tools/upip.py
@@ -256,8 +256,12 @@ def install(to_install, install_path=None):
 def get_install_path():
     global install_path
     if install_path is None:
-        # sys.path[0] is current module's path
-        install_path = sys.path[1]
+        # sys.path[0] is current module's path, only use if no other suitable path exists
+        install_path = sys.path[0]
+        for path in sys.path[1:]:
+            if path:
+                install_path = path
+                break
     install_path = expandhome(install_path)
     return install_path
 


### PR DESCRIPTION
I'm not sure if I'm doing things backwards here, but I've got a local build of the unix port with the sys.path overridden to include relative project folders as such:
```
#define MICROPY_PY_SYS_PATH_DEFAULT ":./src:./src/lib:./src/lib/unix:~/.micropython/lib:/usr/lib/micropython"
```
Note the setting/string starts with an empty entry `:` 
I recently started building with a manifest to include frozen modules such as upip, uasyncio etc and found I needed the empty path at the start to ensure that the fronzen modules were used by default.

This empty path however broke upip as it uses the first path entry as the default install target. 
This PR addresses this by skipping any empty entries like this.