### PR TITLE
RP2/machine_uart.c: Fix poll ioctl.

### DIFF
--- a/ports/rp2/machine_uart.c
+++ b/ports/rp2/machine_uart.c
@@ -477,7 +477,7 @@ STATIC mp_uint_t machine_uart_ioctl(mp_obj_t self_in, mp_uint_t request, mp_uint
     if (request == MP_STREAM_POLL) {
         uintptr_t flags = arg;
         ret = 0;
-        if ((flags & MP_STREAM_POLL_RD) && ringbuf_avail(&self->read_buffer) > 0) {
+        if ((flags & MP_STREAM_POLL_RD) && (uart_is_readable(self->uart) || ringbuf_avail(&self->read_buffer) > 0)) {
             ret |= MP_STREAM_POLL_RD;
         }
         if ((flags & MP_STREAM_POLL_WR) && ringbuf_free(&self->write_buffer) > 0) {


### PR DESCRIPTION
* The RX IRQ does not trigger if the FIFO is less than the trigger level.
* Use machine_uart_any to check for readability to drain the RX FIFO.