### PR TITLE
esp32: always release the GIL when doing delay_ms

### DIFF
--- a/ports/esp32/modmachine.c
+++ b/ports/esp32/modmachine.c
@@ -232,7 +232,9 @@ STATIC mp_obj_t machine_unique_id(void) {
 STATIC MP_DEFINE_CONST_FUN_OBJ_0(machine_unique_id_obj, machine_unique_id);
 
 STATIC mp_obj_t machine_idle(void) {
+    MP_THREAD_GIL_EXIT();
     taskYIELD();
+    MP_THREAD_GIL_ENTER();
     return mp_const_none;
 }
 STATIC MP_DEFINE_CONST_FUN_OBJ_0(machine_idle_obj, machine_idle);

--- a/ports/esp32/mphalport.c
+++ b/ports/esp32/mphalport.c
@@ -142,14 +142,22 @@ void mp_hal_delay_ms(uint32_t ms) {
     uint64_t dt;
     uint64_t t0 = esp_timer_get_time();
     for (;;) {
+        mp_handle_pending(true);
+        MICROPY_PY_USOCKET_EVENTS_HANDLER
+        MP_THREAD_GIL_EXIT();
         uint64_t t1 = esp_timer_get_time();
         dt = t1 - t0;
         if (dt + portTICK_PERIOD_MS * 1000 >= us) {
             // doing a vTaskDelay would take us beyond requested delay time
+            taskYIELD();
+            MP_THREAD_GIL_ENTER();
+            t1 = esp_timer_get_time();
+            dt = t1 - t0;
             break;
+        } else {
+            ulTaskNotifyTake(pdFALSE, 1);
+            MP_THREAD_GIL_ENTER();
         }
-        MICROPY_EVENT_POLL_HOOK
-        ulTaskNotifyTake(pdFALSE, 1);
     }
     if (dt < us) {
         // do the remaining delay accurately


### PR DESCRIPTION
This is an alternative to #5346 which takes into account the discussion in #5344.