### PR TITLE
extmod/nimble: Provide subscription information on subscribtion update.

### DIFF
--- a/extmod/modbluetooth.h
+++ b/extmod/modbluetooth.h
@@ -161,6 +161,7 @@
 #define MP_BLUETOOTH_IRQ_GET_SECRET                     (29)
 #define MP_BLUETOOTH_IRQ_SET_SECRET                     (30)
 #define MP_BLUETOOTH_IRQ_PASSKEY_ACTION                 (31)
+#define MP_BLUETOOTH_IRQ_SUBSCRIPTION_UPDATE            (32)
 
 #define MP_BLUETOOTH_ADDRESS_MODE_PUBLIC (0)
 #define MP_BLUETOOTH_ADDRESS_MODE_RANDOM (1)
@@ -413,6 +414,9 @@ void mp_bluetooth_gap_on_connected_disconnected(uint8_t event, uint16_t conn_han
 
 // Call this when any connection parameters have been changed.
 void mp_bluetooth_gap_on_connection_update(uint16_t conn_handle, uint16_t conn_interval, uint16_t conn_latency, uint16_t supervision_timeout, uint16_t status);
+
+// Call this when any connection subscribes or unsubscribes to a characteristic
+void mp_bluetooth_gatts_on_subscription_update(uint16_t conn_handle, uint16_t chr_value_handle, uint16_t cur_notify, uint16_t cur_indicate);
 
 #if MICROPY_PY_BLUETOOTH_ENABLE_PAIRING_BONDING
 // Call this when any connection encryption has been changed (e.g. during pairing).

--- a/extmod/nimble/modbluetooth_nimble.c
+++ b/extmod/nimble/modbluetooth_nimble.c
@@ -437,6 +437,12 @@ STATIC int commmon_gap_event_cb(struct ble_gap_event *event, void *arg) {
             return 0;
         }
 
+        case BLE_GAP_EVENT_SUBSCRIBE: {
+            DEBUG_printf("commmon_gap_event_cb: subscribe: characteristic handle=%d, reason=%d cur_notify=%d cur_indicate=%d \n", event->attr_handle, event->subscribe.reason, event->subscribe.cur_notify, event->subscribe.cur_indicate);
+            mp_bluetooth_gatts_on_subscription_update(event->subscribe.conn_handle, event->subscribe.attr_handle, event->subscribe.cur_notify, event->subscribe.cur_indicate);
+            return 0;
+        }
+
         default:
             DEBUG_printf("commmon_gap_event_cb: unknown type %d\n", event->type);
             return 0;


### PR DESCRIPTION
This change transmits subscription info when a subscribe event is fired.
This event initiates a new MP event and provides this information:

- Connection handle of the connection subscribing/unsubscribing
- Value handle of the characteristic being subscribed/unsubscribed to
- Current subscription status to notifications (binary format 0 or 1)
- Current subscription status to indications (binary format 0 or 1)

This implementation is inspired from another solution.
This solution uses such events to keep a list of subscribed connections.
See: https://github.com/h2zero/esp-nimble-cpp/search?q=setSubscribe