### PR TITLE
tools/autobuild: Use separate IDF version for newer esp32 boards

### DIFF
--- a/tools/autobuild/autobuild.sh
+++ b/tools/autobuild/autobuild.sh
@@ -4,7 +4,8 @@
 #
 # Requirements:
 # - All toolchains must be in path (arm-none-eabi-gcc, xtensa-lx106-elf)
-# - IDF_PATH_V4 must be set
+# - IDF_PATH_V42 must be set
+# - IDF_PATH_V43 must be set
 # - MICROPY_AUTOBUILD_MICROPYTHON_REPO must be set to location of micropython repository
 # - MICROPY_AUTOBUILD_MAKE must be set to the make command to use, eg "make -j2"
 #
@@ -12,8 +13,13 @@
 # - MICROPY_AUTOBUILD_REMOTE_MACHINE can be set to a remote ssh machine to copy files to
 # - MICROPY_AUTOBUILD_REMOTE_DIR can be set to destination directory on remote machine
 
-if [ ! -d "$IDF_PATH_V4" ]; then
-    echo "must set IDF_PATH_V4"
+if [ ! -d "$IDF_PATH_V42" ]; then
+    echo "must set IDF_PATH_V42"
+    exit 1
+fi
+
+if [ ! -d "$IDF_PATH_V43" ]; then
+    echo "must set IDF_PATH_V43"
     exit 1
 fi
 
@@ -63,7 +69,8 @@ ${AUTODIR}/build-cc3200-latest.sh ${FW_TAG} ${LOCAL_FIRMWARE}
 cd ../esp8266
 ${AUTODIR}/build-esp8266-latest.sh ${FW_TAG} ${LOCAL_FIRMWARE}
 cd ../esp32
-${AUTODIR}/build-esp32-latest.sh ${IDF_PATH_V4} ${FW_TAG} ${LOCAL_FIRMWARE}
+${AUTODIR}/build-esp32-latest.sh ${IDF_PATH_V42} ${FW_TAG} ${LOCAL_FIRMWARE}
+${AUTODIR}/build-esp32-latest.sh ${IDF_PATH_V43} ${FW_TAG} ${LOCAL_FIRMWARE}
 cd ../rp2
 ${AUTODIR}/build-rp2-latest.sh ${FW_TAG} ${LOCAL_FIRMWARE}
 cd ../mimxrt

--- a/tools/autobuild/build-esp32-latest.sh
+++ b/tools/autobuild/build-esp32-latest.sh
@@ -39,7 +39,11 @@ fi
 
 source $idf_path/export.sh
 
-# build the versions
-do_build esp32 GENERIC FROZEN_MANIFEST=$(pwd)/boards/manifest_release.py
-do_build esp32spiram GENERIC_SPIRAM FROZEN_MANIFEST=$(pwd)/boards/manifest_release.py
-do_build tinypico UM_TINYPICO
+# build the boards, based on the IDF version
+if idf.py --version | grep -q v4.2; then
+    do_build esp32 GENERIC FROZEN_MANIFEST=$(pwd)/boards/manifest_release.py
+    do_build esp32spiram GENERIC_SPIRAM FROZEN_MANIFEST=$(pwd)/boards/manifest_release.py
+    do_build tinypico UM_TINYPICO
+else
+    do_build esp32c3 GENERIC_C3
+fi

--- a/tools/autobuild/build-esp32-latest.sh
+++ b/tools/autobuild/build-esp32-latest.sh
@@ -46,4 +46,6 @@ if idf.py --version | grep -q v4.2; then
     do_build tinypico UM_TINYPICO
 else
     do_build esp32c3 GENERIC_C3
+    do_build tinys2 UM_TINYS2
+    do_build featherS2 UM_FEATHERS2
 fi


### PR DESCRIPTION
To fix #7544.  Also, can now build the `GENERIC_C3` board.