### PR TITLE
support various address families in uasyncio open_connection

### DIFF
--- a/extmod/uasyncio/stream.py
+++ b/extmod/uasyncio/stream.py
@@ -79,8 +79,8 @@ async def open_connection(host, port):
     from uerrno import EINPROGRESS
     import usocket as socket
 
-    ai = socket.getaddrinfo(host, port)[0]  # TODO this is blocking!
-    s = socket.socket()
+    ai = socket.getaddrinfo(host, port, 0, socket.SOCK_STREAM)[0]  # TODO this is blocking!
+    s = socket.socket(ai[0], ai[1], ai[2])
     s.setblocking(False)
     ss = Stream(s)
     try:


### PR DESCRIPTION
rudimentary support for various address families
only tested on esp32 and unix ports

encountered trouble using ```open_connection``` in my codebase when adding support for the unix port. after light investigation i found that the unix port was returning ipv6 addresses for ```socket.getaddrinfo()``` in some cases (notably **www.google.com**) which would cause ```open_connection``` to raise ```OSError 47``` (```MP_EAFNOSUPPORT```).

using the ```family``` tuple element returned by ```socket.getaddrinfo``` seems like it ought to be a portable way to adapt to the proper address family when creating a socket.

i've tried this out successfully on unix and esp32 ports, but clearly a more rigorous examination is needed. furthermore this is most likely just a fraction of the work needed to be done to claim that uasyncio truly supports ipv6

related issues:
#3683