### PR TITLE
rp2: Force available data to the ring buffer on read.

### DIFF
--- a/ports/rp2/machine_uart.c
+++ b/ports/rp2/machine_uart.c
@@ -404,6 +404,13 @@ STATIC mp_uint_t machine_uart_read(mp_obj_t self_in, void *buf_in, mp_uint_t siz
     uint64_t timeout_char_us = (uint64_t)self->timeout_char * 1000;
     uint8_t *dest = buf_in;
 
+    // Try getting data to the ring buffer if it is empty.
+    if (ringbuf_avail(&self->read_buffer) == 0) {
+        self->read_lock = true;
+        uart_drain_rx_fifo(self);
+        self->read_lock = false;
+    }
+
     for (size_t i = 0; i < size; i++) {
         // Wait for the first/next character
         while (ringbuf_avail(&self->read_buffer) == 0) {

--- a/ports/rp2/machine_uart.c
+++ b/ports/rp2/machine_uart.c
@@ -404,16 +404,16 @@ STATIC mp_uint_t machine_uart_read(mp_obj_t self_in, void *buf_in, mp_uint_t siz
     uint64_t timeout_char_us = (uint64_t)self->timeout_char * 1000;
     uint8_t *dest = buf_in;
 
-    // Try getting data to the ring buffer if it is empty.
-    if (ringbuf_avail(&self->read_buffer) == 0) {
-        self->read_lock = true;
-        uart_drain_rx_fifo(self);
-        self->read_lock = false;
-    }
-
     for (size_t i = 0; i < size; i++) {
         // Wait for the first/next character
         while (ringbuf_avail(&self->read_buffer) == 0) {
+            if (uart_is_readable(self->uart)) {
+                // Force a few incoming bytes to the buffer
+                self->read_lock = true;
+                uart_drain_rx_fifo(self);
+                self->read_lock = false;
+                break;
+            }
             if (time_us_64() > t) {  // timed out
                 if (i <= 0) {
                     *errcode = MP_EAGAIN;
@@ -423,10 +423,6 @@ STATIC mp_uint_t machine_uart_read(mp_obj_t self_in, void *buf_in, mp_uint_t siz
                 }
             }
             MICROPY_EVENT_POLL_HOOK
-            // Force a few incoming bytes to the buffer
-            self->read_lock = true;
-            uart_drain_rx_fifo(self);
-            self->read_lock = false;
         }
         *dest++ = ringbuf_get(&(self->read_buffer));
         t = time_us_64() + timeout_char_us;


### PR DESCRIPTION
So uart.read() will return single characters even with a setting of timeout=0.