### PR TITLE
stm32/uart: Fix LPUART1 to set/get baudrate correctly, and allow lower baudrates

### DIFF
--- a/ports/stm32/boards/stm32h7xx_hal_conf_base.h
+++ b/ports/stm32/boards/stm32h7xx_hal_conf_base.h
@@ -54,6 +54,7 @@
 #include "stm32h7xx_hal_usart.h"
 #include "stm32h7xx_hal_wwdg.h"
 #include "stm32h7xx_ll_adc.h"
+#include "stm32h7xx_ll_lpuart.h"
 #include "stm32h7xx_ll_pwr.h"
 #include "stm32h7xx_ll_rtc.h"
 #include "stm32h7xx_ll_usart.h"

--- a/ports/stm32/boards/stm32l0xx_hal_conf_base.h
+++ b/ports/stm32/boards/stm32l0xx_hal_conf_base.h
@@ -47,6 +47,7 @@
 #include "stm32l0xx_hal_usart.h"
 #include "stm32l0xx_hal_wwdg.h"
 #include "stm32l0xx_ll_adc.h"
+#include "stm32l0xx_ll_lpuart.h"
 #include "stm32l0xx_ll_rtc.h"
 #include "stm32l0xx_ll_usart.h"
 

--- a/ports/stm32/boards/stm32l4xx_hal_conf_base.h
+++ b/ports/stm32/boards/stm32l4xx_hal_conf_base.h
@@ -51,6 +51,7 @@
 #include "stm32l4xx_hal_usart.h"
 #include "stm32l4xx_hal_wwdg.h"
 #include "stm32l4xx_ll_adc.h"
+#include "stm32l4xx_ll_lpuart.h"
 #include "stm32l4xx_ll_rtc.h"
 #include "stm32l4xx_ll_usart.h"
 

--- a/ports/stm32/boards/stm32wbxx_hal_conf_base.h
+++ b/ports/stm32/boards/stm32wbxx_hal_conf_base.h
@@ -42,6 +42,7 @@
 #include "stm32wbxx_hal_uart.h"
 #include "stm32wbxx_hal_usart.h"
 #include "stm32wbxx_ll_adc.h"
+#include "stm32wbxx_ll_lpuart.h"
 #include "stm32wbxx_ll_rtc.h"
 #include "stm32wbxx_ll_usart.h"
 

--- a/ports/stm32/uart.c
+++ b/ports/stm32/uart.c
@@ -746,6 +746,15 @@ uint32_t uart_get_source_freq(pyb_uart_obj_t *self) {
 }
 
 uint32_t uart_get_baudrate(pyb_uart_obj_t *self) {
+    #if defined(LPUART1)
+    if (self->uart_id == PYB_LPUART_1) {
+        return LL_LPUART_GetBaudRate(self->uartx, uart_get_source_freq(self)
+            #if defined(STM32H7) || defined(STM32WB)
+            , self->uartx->PRESC
+            #endif
+            );
+    }
+    #endif
     return LL_USART_GetBaudRate(self->uartx, uart_get_source_freq(self),
         #if defined(STM32H7) || defined(STM32WB)
         self->uartx->PRESC,
@@ -754,6 +763,16 @@ uint32_t uart_get_baudrate(pyb_uart_obj_t *self) {
 }
 
 void uart_set_baudrate(pyb_uart_obj_t *self, uint32_t baudrate) {
+    #if defined(LPUART1)
+    if (self->uart_id == PYB_LPUART_1) {
+        LL_LPUART_SetBaudRate(self->uartx, uart_get_source_freq(self),
+            #if defined(STM32H7) || defined(STM32WB)
+            LL_LPUART_PRESCALER_DIV1,
+            #endif
+            baudrate);
+        return;
+    }
+    #endif
     LL_USART_SetBaudRate(self->uartx, uart_get_source_freq(self),
         #if defined(STM32H7) || defined(STM32WB)
         LL_USART_PRESCALER_DIV1,

--- a/ports/stm32/uart.h
+++ b/ports/stm32/uart.h
@@ -88,6 +88,7 @@ void uart_deinit(pyb_uart_obj_t *uart_obj);
 void uart_irq_handler(mp_uint_t uart_id);
 
 void uart_attach_to_repl(pyb_uart_obj_t *self, bool attached);
+uint32_t uart_get_source_freq(pyb_uart_obj_t *self);
 uint32_t uart_get_baudrate(pyb_uart_obj_t *self);
 void uart_set_baudrate(pyb_uart_obj_t *self, uint32_t baudrate);
 


### PR DESCRIPTION
Fixes issue #7466.