### PR TITLE
py/builtinimport: Fix condition for including do_execute_raw_code().

### DIFF
--- a/py/builtinimport.c
+++ b/py/builtinimport.c
@@ -142,7 +142,7 @@ STATIC void do_load_from_lexer(mp_obj_t module_obj, mp_lexer_t *lex) {
 }
 #endif
 
-#if MICROPY_PERSISTENT_CODE_LOAD || MICROPY_MODULE_FROZEN_MPY
+#if (MICROPY_HAS_FILE_READER && MICROPY_PERSISTENT_CODE_LOAD) || MICROPY_MODULE_FROZEN_MPY
 STATIC void do_execute_raw_code(mp_obj_t module_obj, mp_raw_code_t *raw_code, const char *source_name) {
     (void)source_name;
 


### PR DESCRIPTION
Commit e33bc597 ("py: Remove calls to file reader functions when these are disabled.") changed the condition for one caller of
`do_execute_raw_code()` from

    #if MICROPY_PERSISTENT_CODE_LOAD

to

    #if MICROPY_HAS_FILE_READER && MICROPY_PERSISTENT_CODE_LOAD

The condition that enables compiling the function itself needs to be changed to match.
