### PR TITLE
ports: Rename USBD_VID/PID config macros to MICROPY_HW_USB_VID/PID.

### DIFF
--- a/ports/mimxrt/tusb_port.c
+++ b/ports/mimxrt/tusb_port.c
@@ -26,8 +26,10 @@
 
 #include "tusb.h"
 
-#define USBD_VID (0xf055)
-#define USBD_PID (0x9802)
+#ifndef MICROPY_HW_USB_VID
+#define MICROPY_HW_USB_VID (0xf055)
+#define MICROPY_HW_USB_PID (0x9802)
+#endif
 
 #define USBD_DESC_LEN (TUD_CONFIG_DESC_LEN + TUD_CDC_DESC_LEN)
 #define USBD_MAX_POWER_MA (250)
@@ -57,8 +59,8 @@ static const tusb_desc_device_t usbd_desc_device = {
     .bDeviceSubClass = MISC_SUBCLASS_COMMON,
     .bDeviceProtocol = MISC_PROTOCOL_IAD,
     .bMaxPacketSize0 = CFG_TUD_ENDPOINT0_SIZE,
-    .idVendor = USBD_VID,
-    .idProduct = USBD_PID,
+    .idVendor = MICROPY_HW_USB_VID,
+    .idProduct = MICROPY_HW_USB_PID,
     .bcdDevice = 0x0100,
     .iManufacturer = USBD_STR_MANUF,
     .iProduct = USBD_STR_PRODUCT,

--- a/ports/nrf/drivers/usb/usb_descriptors.c
+++ b/ports/nrf/drivers/usb/usb_descriptors.c
@@ -26,8 +26,10 @@
 
 #include "tusb.h"
 
-#define USBD_VID (0xf055)
-#define USBD_PID (0x9802)
+#ifndef MICROPY_HW_USB_VID
+#define MICROPY_HW_USB_VID (0xf055)
+#define MICROPY_HW_USB_PID (0x9802)
+#endif
 
 #define USBD_DESC_LEN (TUD_CONFIG_DESC_LEN + TUD_CDC_DESC_LEN)
 #define USBD_MAX_POWER_MA (250)
@@ -57,8 +59,8 @@ static const tusb_desc_device_t usbd_desc_device = {
     .bDeviceSubClass    = MISC_SUBCLASS_COMMON,
     .bDeviceProtocol    = MISC_PROTOCOL_IAD,
     .bMaxPacketSize0    = CFG_TUD_ENDOINT0_SIZE,
-    .idVendor           = USBD_VID,
-    .idProduct          = USBD_PID,
+    .idVendor           = MICROPY_HW_USB_VID,
+    .idProduct          = MICROPY_HW_USB_PID,
     .bcdDevice          = 0x0100,
     .iManufacturer      = USBD_STR_MANUF,
     .iProduct           = USBD_STR_PRODUCT,

--- a/ports/samd/tusb_port.c
+++ b/ports/samd/tusb_port.c
@@ -27,8 +27,10 @@
 #include "samd_soc.h"
 #include "tusb.h"
 
-#define USBD_VID (0xf055)
-#define USBD_PID (0x9802)
+#ifndef MICROPY_HW_USB_VID
+#define MICROPY_HW_USB_VID (0xf055)
+#define MICROPY_HW_USB_PID (0x9802)
+#endif
 
 #define USBD_DESC_LEN (TUD_CONFIG_DESC_LEN + TUD_CDC_DESC_LEN)
 #define USBD_MAX_POWER_MA (250)
@@ -58,8 +60,8 @@ static const tusb_desc_device_t usbd_desc_device = {
     .bDeviceSubClass = MISC_SUBCLASS_COMMON,
     .bDeviceProtocol = MISC_PROTOCOL_IAD,
     .bMaxPacketSize0 = CFG_TUD_ENDOINT0_SIZE,
-    .idVendor = USBD_VID,
-    .idProduct = USBD_PID,
+    .idVendor = MICROPY_HW_USB_VID,
+    .idProduct = MICROPY_HW_USB_PID,
     .bcdDevice = 0x0100,
     .iManufacturer = USBD_STR_MANUF,
     .iProduct = USBD_STR_PRODUCT,

--- a/ports/stm32/Makefile
+++ b/ports/stm32/Makefile
@@ -725,7 +725,7 @@ GEN_PINS_AF_PY = $(BUILD)/pins_af.py
 INSERT_USB_IDS = $(TOP)/tools/insert-usb-ids.py
 FILE2H = $(TOP)/tools/file2h.py
 
-USB_IDS_FILE = usb.h
+USB_IDS_FILE = mpconfigboard_common.h
 CDCINF_TEMPLATE = pybcdc.inf_template
 GEN_CDCINF_FILE = $(HEADER_BUILD)/pybcdc.inf
 GEN_CDCINF_HEADER = $(HEADER_BUILD)/pybcdc_inf.h

--- a/ports/stm32/boards/B_L072Z_LRWAN1/mpconfigboard.h
+++ b/ports/stm32/boards/B_L072Z_LRWAN1/mpconfigboard.h
@@ -67,5 +67,5 @@
 #define MICROPY_HW_USB_FS           (1)
 #define MICROPY_HW_USB_MSC          (0)
 #define MICROPY_HW_USB_HID          (0)
-#define USBD_CDC_RX_DATA_SIZE       (256)
-#define USBD_CDC_TX_DATA_SIZE       (256)
+#define MICROPY_HW_USB_CDC_RX_DATA_SIZE (256)
+#define MICROPY_HW_USB_CDC_TX_DATA_SIZE (256)

--- a/ports/stm32/boards/NUCLEO_L432KC/mpconfigboard.h
+++ b/ports/stm32/boards/NUCLEO_L432KC/mpconfigboard.h
@@ -67,5 +67,5 @@
 #define MICROPY_HW_USB_FS           (MICROPY_HW_ENABLE_USB)
 #define MICROPY_HW_USB_MSC          (0)
 #define MICROPY_HW_USB_HID          (0)
-#define USBD_CDC_RX_DATA_SIZE       (256)
-#define USBD_CDC_TX_DATA_SIZE       (256)
+#define MICROPY_HW_USB_CDC_RX_DATA_SIZE (256)
+#define MICROPY_HW_USB_CDC_TX_DATA_SIZE (256)

--- a/ports/stm32/boards/NUCLEO_WB55/mpconfigboard.h
+++ b/ports/stm32/boards/NUCLEO_WB55/mpconfigboard.h
@@ -59,8 +59,8 @@
 
 // USB config
 #define MICROPY_HW_USB_FS           (1)
-#define USBD_CDC_RX_DATA_SIZE       (512)
-#define USBD_CDC_TX_DATA_SIZE       (512)
+#define MICROPY_HW_USB_CDC_RX_DATA_SIZE (512)
+#define MICROPY_HW_USB_CDC_TX_DATA_SIZE (512)
 
 // Bluetooth config
 #define MICROPY_HW_BLE_UART_ID       (0)

--- a/ports/stm32/boards/USBDONGLE_WB55/mpconfigboard.h
+++ b/ports/stm32/boards/USBDONGLE_WB55/mpconfigboard.h
@@ -43,8 +43,8 @@
 
 // USB config
 #define MICROPY_HW_USB_FS           (1)
-#define USBD_CDC_RX_DATA_SIZE       (512)
-#define USBD_CDC_TX_DATA_SIZE       (512)
+#define MICROPY_HW_USB_CDC_RX_DATA_SIZE (512)
+#define MICROPY_HW_USB_CDC_TX_DATA_SIZE (512)
 
 // Bluetooth config
 #define MICROPY_HW_BLE_UART_ID       (0)

--- a/ports/stm32/main.c
+++ b/ports/stm32/main.c
@@ -582,13 +582,13 @@ soft_reset:
     // init USB device to default setting if it was not already configured
     if (!(pyb_usb_flags & PYB_USB_FLAG_USB_MODE_CALLED)) {
         #if MICROPY_HW_USB_MSC
-        const uint16_t pid = USBD_PID_CDC_MSC;
+        const uint16_t pid = MICROPY_HW_USB_PID_CDC_MSC;
         const uint8_t mode = USBD_MODE_CDC_MSC;
         #else
-        const uint16_t pid = USBD_PID_CDC;
+        const uint16_t pid = MICROPY_HW_USB_PID_CDC;
         const uint8_t mode = USBD_MODE_CDC;
         #endif
-        pyb_usb_dev_init(pyb_usb_dev_detect(), USBD_VID, pid, mode, 0, NULL, NULL);
+        pyb_usb_dev_init(pyb_usb_dev_detect(), MICROPY_HW_USB_VID, pid, mode, 0, NULL, NULL);
     }
     #endif
 

--- a/ports/stm32/mpconfigboard_common.h
+++ b/ports/stm32/mpconfigboard_common.h
@@ -178,6 +178,33 @@
 #endif
 
 /*****************************************************************************/
+// USB configuration
+
+// The USBD_xxx VID/PID macros have been renamed to MICROPY_HW_USB_xxx.
+#ifdef USBD_VID
+#error "Old USBD_VID configuration option used"
+#endif
+
+// Default VID and PID values to use for the USB device.  If MICROPY_HW_USB_VID
+// is defined by a board then all needed PID options must also be defined.  The
+// VID and PID can also be set dynamically in pyb.usb_mode().
+// Windows needs a different PID to distinguish different device configurations.
+#ifndef MICROPY_HW_USB_VID
+#define MICROPY_HW_USB_VID              (0xf055)
+#define MICROPY_HW_USB_PID_CDC_MSC      (0x9800)
+#define MICROPY_HW_USB_PID_CDC_HID      (0x9801)
+#define MICROPY_HW_USB_PID_CDC          (0x9802)
+#define MICROPY_HW_USB_PID_MSC          (0x9803)
+#define MICROPY_HW_USB_PID_CDC2_MSC     (0x9804)
+#define MICROPY_HW_USB_PID_CDC2         (0x9805)
+#define MICROPY_HW_USB_PID_CDC3         (0x9806)
+#define MICROPY_HW_USB_PID_CDC3_MSC     (0x9807)
+#define MICROPY_HW_USB_PID_CDC_MSC_HID  (0x9808)
+#define MICROPY_HW_USB_PID_CDC2_MSC_HID (0x9809)
+#define MICROPY_HW_USB_PID_CDC3_MSC_HID (0x980a)
+#endif
+
+/*****************************************************************************/
 // General configuration
 
 // Heap start / end definitions

--- a/ports/stm32/mpconfigboard_common.h
+++ b/ports/stm32/mpconfigboard_common.h
@@ -189,7 +189,9 @@
     || defined(USBD_CONFIGURATION_HS_STRING) \
     || defined(USBD_INTERFACE_HS_STRING) \
     || defined(USBD_CONFIGURATION_FS_STRING) \
-    || defined(USBD_INTERFACE_FS_STRING)
+    || defined(USBD_INTERFACE_FS_STRING) \
+    || defined(USBD_CDC_RX_DATA_SIZE) \
+    || defined(USBD_CDC_TX_DATA_SIZE)
 #error "Old USBD_xxx configuration option used, renamed to MICROPY_HW_USB_xxx"
 #endif
 
@@ -242,6 +244,18 @@
 
 #ifndef MICROPY_HW_USB_INTERFACE_FS_STRING
 #define MICROPY_HW_USB_INTERFACE_FS_STRING      "Pyboard Interface"
+#endif
+
+// Amount of incoming buffer space for each CDC instance.
+// This must be 2 or greater, and a power of 2.
+#ifndef MICROPY_HW_USB_CDC_RX_DATA_SIZE
+#define MICROPY_HW_USB_CDC_RX_DATA_SIZE (1024)
+#endif
+
+// Amount of outgoing buffer space for each CDC instance.
+// This must be a power of 2 and no greater than 16384.
+#ifndef MICROPY_HW_USB_CDC_TX_DATA_SIZE
+#define MICROPY_HW_USB_CDC_TX_DATA_SIZE (1024)
 #endif
 
 /*****************************************************************************/

--- a/ports/stm32/mpconfigboard_common.h
+++ b/ports/stm32/mpconfigboard_common.h
@@ -180,9 +180,17 @@
 /*****************************************************************************/
 // USB configuration
 
-// The USBD_xxx VID/PID macros have been renamed to MICROPY_HW_USB_xxx.
-#ifdef USBD_VID
-#error "Old USBD_VID configuration option used"
+// The USBD_xxx macros have been renamed to MICROPY_HW_USB_xxx.
+#if defined(USBD_VID) \
+    || defined(USBD_LANGID_STRING) \
+    || defined(USBD_MANUFACTURER_STRING) \
+    || defined(USBD_PRODUCT_HS_STRING) \
+    || defined(USBD_PRODUCT_FS_STRING) \
+    || defined(USBD_CONFIGURATION_HS_STRING) \
+    || defined(USBD_INTERFACE_HS_STRING) \
+    || defined(USBD_CONFIGURATION_FS_STRING) \
+    || defined(USBD_INTERFACE_FS_STRING)
+#error "Old USBD_xxx configuration option used, renamed to MICROPY_HW_USB_xxx"
 #endif
 
 // Default VID and PID values to use for the USB device.  If MICROPY_HW_USB_VID
@@ -202,6 +210,38 @@
 #define MICROPY_HW_USB_PID_CDC_MSC_HID  (0x9808)
 #define MICROPY_HW_USB_PID_CDC2_MSC_HID (0x9809)
 #define MICROPY_HW_USB_PID_CDC3_MSC_HID (0x980a)
+#endif
+
+#ifndef MICROPY_HW_USB_LANGID_STRING
+#define MICROPY_HW_USB_LANGID_STRING            0x409
+#endif
+
+#ifndef MICROPY_HW_USB_MANUFACTURER_STRING
+#define MICROPY_HW_USB_MANUFACTURER_STRING      "MicroPython"
+#endif
+
+#ifndef MICROPY_HW_USB_PRODUCT_HS_STRING
+#define MICROPY_HW_USB_PRODUCT_HS_STRING        "Pyboard Virtual Comm Port in HS Mode"
+#endif
+
+#ifndef MICROPY_HW_USB_PRODUCT_FS_STRING
+#define MICROPY_HW_USB_PRODUCT_FS_STRING        "Pyboard Virtual Comm Port in FS Mode"
+#endif
+
+#ifndef MICROPY_HW_USB_CONFIGURATION_HS_STRING
+#define MICROPY_HW_USB_CONFIGURATION_HS_STRING  "Pyboard Config"
+#endif
+
+#ifndef MICROPY_HW_USB_INTERFACE_HS_STRING
+#define MICROPY_HW_USB_INTERFACE_HS_STRING      "Pyboard Interface"
+#endif
+
+#ifndef MICROPY_HW_USB_CONFIGURATION_FS_STRING
+#define MICROPY_HW_USB_CONFIGURATION_FS_STRING  "Pyboard Config"
+#endif
+
+#ifndef MICROPY_HW_USB_INTERFACE_FS_STRING
+#define MICROPY_HW_USB_INTERFACE_FS_STRING      "Pyboard Interface"
 #endif
 
 /*****************************************************************************/

--- a/ports/stm32/usb.c
+++ b/ports/stm32/usb.c
@@ -412,7 +412,7 @@ STATIC mp_obj_t pyb_usb_mode(size_t n_args, const mp_obj_t *pos_args, mp_map_t *
     static const mp_arg_t allowed_args[] = {
         { MP_QSTR_mode, MP_ARG_REQUIRED | MP_ARG_OBJ, {.u_rom_obj = MP_ROM_NONE} },
         { MP_QSTR_port, MP_ARG_KW_ONLY | MP_ARG_INT, {.u_int = -1} },
-        { MP_QSTR_vid, MP_ARG_KW_ONLY | MP_ARG_INT, {.u_int = USBD_VID} },
+        { MP_QSTR_vid, MP_ARG_KW_ONLY | MP_ARG_INT, {.u_int = MICROPY_HW_USB_VID} },
         { MP_QSTR_pid, MP_ARG_KW_ONLY | MP_ARG_INT, {.u_int = -1} },
         #if MICROPY_HW_USB_MSC
         { MP_QSTR_msc, MP_ARG_KW_ONLY | MP_ARG_OBJ, {.u_rom_obj = MP_ROM_PTR(&mp_const_empty_tuple_obj)} },
@@ -489,61 +489,61 @@ STATIC mp_obj_t pyb_usb_mode(size_t n_args, const mp_obj_t *pos_args, mp_map_t *
     uint8_t mode;
     if (strcmp(mode_str, "CDC+MSC") == 0 || strcmp(mode_str, "VCP+MSC") == 0) {
         if (pid == -1) {
-            pid = USBD_PID_CDC_MSC;
+            pid = MICROPY_HW_USB_PID_CDC_MSC;
         }
         mode = USBD_MODE_CDC_MSC;
     } else if (strcmp(mode_str, "VCP+MSC+HID") == 0) {
         if (pid == -1) {
-            pid = USBD_PID_CDC_MSC_HID;
+            pid = MICROPY_HW_USB_PID_CDC_MSC_HID;
         }
         mode = USBD_MODE_CDC_MSC_HID;
     #if MICROPY_HW_USB_CDC_NUM >= 2
     } else if (strcmp(mode_str, "VCP+VCP") == 0) {
         if (pid == -1) {
-            pid = USBD_PID_CDC2;
+            pid = MICROPY_HW_USB_PID_CDC2;
         }
         mode = USBD_MODE_CDC2;
     } else if (strcmp(mode_str, "VCP+VCP+MSC") == 0) {
         if (pid == -1) {
-            pid = USBD_PID_CDC2_MSC;
+            pid = MICROPY_HW_USB_PID_CDC2_MSC;
         }
         mode = USBD_MODE_CDC2_MSC;
     } else if (strcmp(mode_str, "2xVCP+MSC+HID") == 0) {
         if (pid == -1) {
-            pid = USBD_PID_CDC2_MSC_HID;
+            pid = MICROPY_HW_USB_PID_CDC2_MSC_HID;
         }
         mode = USBD_MODE_CDC2_MSC_HID;
     #endif
     #if MICROPY_HW_USB_CDC_NUM >= 3
     } else if (strcmp(mode_str, "3xVCP") == 0) {
         if (pid == -1) {
-            pid = USBD_PID_CDC3;
+            pid = MICROPY_HW_USB_PID_CDC3;
         }
         mode = USBD_MODE_CDC3;
     } else if (strcmp(mode_str, "3xVCP+MSC") == 0) {
         if (pid == -1) {
-            pid = USBD_PID_CDC3_MSC;
+            pid = MICROPY_HW_USB_PID_CDC3_MSC;
         }
         mode = USBD_MODE_CDC3_MSC;
     } else if (strcmp(mode_str, "3xVCP+MSC+HID") == 0) {
         if (pid == -1) {
-            pid = USBD_PID_CDC3_MSC_HID;
+            pid = MICROPY_HW_USB_PID_CDC3_MSC_HID;
         }
         mode = USBD_MODE_CDC3_MSC_HID;
     #endif
     } else if (strcmp(mode_str, "CDC+HID") == 0 || strcmp(mode_str, "VCP+HID") == 0) {
         if (pid == -1) {
-            pid = USBD_PID_CDC_HID;
+            pid = MICROPY_HW_USB_PID_CDC_HID;
         }
         mode = USBD_MODE_CDC_HID;
     } else if (strcmp(mode_str, "CDC") == 0 || strcmp(mode_str, "VCP") == 0) {
         if (pid == -1) {
-            pid = USBD_PID_CDC;
+            pid = MICROPY_HW_USB_PID_CDC;
         }
         mode = USBD_MODE_CDC;
     } else if (strcmp(mode_str, "MSC") == 0) {
         if (pid == -1) {
-            pid = USBD_PID_MSC;
+            pid = MICROPY_HW_USB_PID_MSC;
         }
         mode = USBD_MODE_MSC;
     } else {

--- a/ports/stm32/usb.h
+++ b/ports/stm32/usb.h
@@ -30,22 +30,6 @@
 
 #define PYB_USB_FLAG_USB_MODE_CALLED    (0x0002)
 
-#ifndef USBD_VID
-// Windows needs a different PID to distinguish different device configurations
-#define USBD_VID         (0xf055)
-#define USBD_PID_CDC_MSC (0x9800)
-#define USBD_PID_CDC_HID (0x9801)
-#define USBD_PID_CDC     (0x9802)
-#define USBD_PID_MSC     (0x9803)
-#define USBD_PID_CDC2_MSC (0x9804)
-#define USBD_PID_CDC2    (0x9805)
-#define USBD_PID_CDC3    (0x9806)
-#define USBD_PID_CDC3_MSC (0x9807)
-#define USBD_PID_CDC_MSC_HID (0x9808)
-#define USBD_PID_CDC2_MSC_HID (0x9809)
-#define USBD_PID_CDC3_MSC_HID (0x980a)
-#endif
-
 typedef enum {
     PYB_USB_STORAGE_MEDIUM_NONE = 0,
     PYB_USB_STORAGE_MEDIUM_FLASH,

--- a/ports/stm32/usbd_cdc_interface.c
+++ b/ports/stm32/usbd_cdc_interface.c
@@ -172,7 +172,7 @@ int8_t usbd_cdc_control(usbd_cdc_state_t *cdc_in, uint8_t cmd, uint8_t *pbuf, ui
 }
 
 static inline uint16_t usbd_cdc_tx_buffer_mask(uint16_t val) {
-    return val & (USBD_CDC_TX_DATA_SIZE - 1);
+    return val & (MICROPY_HW_USB_CDC_TX_DATA_SIZE - 1);
 }
 
 static inline uint16_t usbd_cdc_tx_buffer_size(usbd_cdc_itf_t *cdc) {
@@ -188,18 +188,18 @@ static inline bool usbd_cdc_tx_buffer_will_be_empty(usbd_cdc_itf_t *cdc) {
 }
 
 static inline bool usbd_cdc_tx_buffer_full(usbd_cdc_itf_t *cdc) {
-    return usbd_cdc_tx_buffer_size(cdc) == USBD_CDC_TX_DATA_SIZE;
+    return usbd_cdc_tx_buffer_size(cdc) == MICROPY_HW_USB_CDC_TX_DATA_SIZE;
 }
 
 static uint16_t usbd_cdc_tx_send_length(usbd_cdc_itf_t *cdc) {
-    uint16_t to_end = USBD_CDC_TX_DATA_SIZE - usbd_cdc_tx_buffer_mask(cdc->tx_buf_ptr_out);
+    uint16_t to_end = MICROPY_HW_USB_CDC_TX_DATA_SIZE - usbd_cdc_tx_buffer_mask(cdc->tx_buf_ptr_out);
     return MIN(usbd_cdc_tx_buffer_size(cdc), to_end);
 }
 
 static void usbd_cdc_tx_buffer_put(usbd_cdc_itf_t *cdc, uint8_t data, bool check_overflow) {
     cdc->tx_buf[usbd_cdc_tx_buffer_mask(cdc->tx_buf_ptr_in)] = data;
     cdc->tx_buf_ptr_in++;
-    if (check_overflow && usbd_cdc_tx_buffer_size(cdc) > USBD_CDC_TX_DATA_SIZE) {
+    if (check_overflow && usbd_cdc_tx_buffer_size(cdc) > MICROPY_HW_USB_CDC_TX_DATA_SIZE) {
         cdc->tx_buf_ptr_out++;
         cdc->tx_buf_ptr_out_next = cdc->tx_buf_ptr_out;
     }
@@ -270,7 +270,7 @@ void HAL_PCD_SOFCallback(PCD_HandleTypeDef *hpcd) {
 
 bool usbd_cdc_rx_buffer_full(usbd_cdc_itf_t *cdc) {
     int get = cdc->rx_buf_get, put = cdc->rx_buf_put;
-    int remaining = (get - put) + (-((int)(get <= put)) & USBD_CDC_RX_DATA_SIZE);
+    int remaining = (get - put) + (-((int)(get <= put)) & MICROPY_HW_USB_CDC_RX_DATA_SIZE);
     return remaining < CDC_DATA_MAX_PACKET_SIZE + 1;
 }
 
@@ -298,7 +298,7 @@ int8_t usbd_cdc_receive(usbd_cdc_state_t *cdc_in, size_t len) {
         if (cdc->attached_to_repl && *src == mp_interrupt_char) {
             pendsv_kbd_intr();
         } else {
-            uint16_t next_put = (cdc->rx_buf_put + 1) & (USBD_CDC_RX_DATA_SIZE - 1);
+            uint16_t next_put = (cdc->rx_buf_put + 1) & (MICROPY_HW_USB_CDC_RX_DATA_SIZE - 1);
             if (next_put == cdc->rx_buf_get) {
                 // overflow, we just discard the rest of the chars
                 break;
@@ -322,7 +322,7 @@ int8_t usbd_cdc_receive(usbd_cdc_state_t *cdc_in, size_t len) {
 
 int usbd_cdc_tx_half_empty(usbd_cdc_itf_t *cdc) {
     int32_t tx_waiting = usbd_cdc_tx_buffer_size(cdc);
-    return tx_waiting <= USBD_CDC_TX_DATA_SIZE / 2;
+    return tx_waiting <= MICROPY_HW_USB_CDC_TX_DATA_SIZE / 2;
 }
 
 // Writes only the data that fits if flow & CTS, else writes all data
@@ -405,7 +405,7 @@ void usbd_cdc_tx_always(usbd_cdc_itf_t *cdc, const uint8_t *buf, uint32_t len) {
 int usbd_cdc_rx_num(usbd_cdc_itf_t *cdc) {
     int32_t rx_waiting = (int32_t)cdc->rx_buf_put - (int32_t)cdc->rx_buf_get;
     if (rx_waiting < 0) {
-        rx_waiting += USBD_CDC_RX_DATA_SIZE;
+        rx_waiting += MICROPY_HW_USB_CDC_RX_DATA_SIZE;
     }
     usbd_cdc_rx_check_resume(cdc);
     return rx_waiting;
@@ -434,7 +434,7 @@ int usbd_cdc_rx(usbd_cdc_itf_t *cdc, uint8_t *buf, uint32_t len, uint32_t timeou
 
         // Copy byte from device to user buffer
         buf[i] = cdc->rx_user_buf[cdc->rx_buf_get];
-        cdc->rx_buf_get = (cdc->rx_buf_get + 1) & (USBD_CDC_RX_DATA_SIZE - 1);
+        cdc->rx_buf_get = (cdc->rx_buf_get + 1) & (MICROPY_HW_USB_CDC_RX_DATA_SIZE - 1);
     }
     usbd_cdc_rx_check_resume(cdc);
 

--- a/ports/stm32/usbd_cdc_interface.h
+++ b/ports/stm32/usbd_cdc_interface.h
@@ -31,12 +31,7 @@
   ******************************************************************************
   */
 
-#ifndef USBD_CDC_RX_DATA_SIZE
-#define USBD_CDC_RX_DATA_SIZE (1024) // this must be 2 or greater, and a power of 2
-#endif
-#ifndef USBD_CDC_TX_DATA_SIZE
-#define USBD_CDC_TX_DATA_SIZE (1024) // This must be a power of 2 and no greater than 16384
-#endif
+#include "py/mpconfig.h"
 
 // Values for connect_state
 #define USBD_CDC_CONNECT_STATE_DISCONNECTED (0)
@@ -52,14 +47,14 @@ typedef struct _usbd_cdc_itf_t {
     usbd_cdc_state_t base; // state for the base CDC layer
 
     uint8_t rx_packet_buf[CDC_DATA_MAX_PACKET_SIZE]; // received data from USB OUT endpoint is stored in this buffer
-    uint8_t rx_user_buf[USBD_CDC_RX_DATA_SIZE]; // received data is buffered here until the user reads it
+    uint8_t rx_user_buf[MICROPY_HW_USB_CDC_RX_DATA_SIZE]; // received data is buffered here until the user reads it
     volatile uint16_t rx_buf_put; // circular buffer index
     uint16_t rx_buf_get; // circular buffer index
     uint8_t rx_buf_full; // rx from host will be blocked while this is true
 
-    uint8_t tx_buf[USBD_CDC_TX_DATA_SIZE]; // data for USB IN endpoind is stored in this buffer
-    uint16_t tx_buf_ptr_in; // increment this pointer modulo USBD_CDC_TX_DATA_SIZE when new data is available
-    volatile uint16_t tx_buf_ptr_out; // increment this pointer modulo USBD_CDC_TX_DATA_SIZE when data is drained
+    uint8_t tx_buf[MICROPY_HW_USB_CDC_TX_DATA_SIZE]; // data for USB IN endpoind is stored in this buffer
+    uint16_t tx_buf_ptr_in; // increment this pointer modulo MICROPY_HW_USB_CDC_TX_DATA_SIZE when new data is available
+    volatile uint16_t tx_buf_ptr_out; // increment this pointer modulo MICROPY_HW_USB_CDC_TX_DATA_SIZE when data is drained
     uint16_t tx_buf_ptr_out_next; // next position of above once transmission finished
     uint8_t tx_need_empty_packet; // used to flush the USB IN endpoint if the last packet was exactly the endpoint packet size
 

--- a/ports/stm32/usbd_desc.c
+++ b/ports/stm32/usbd_desc.c
@@ -36,46 +36,14 @@
 // need this header just for MP_HAL_UNIQUE_ID_ADDRESS
 #include "py/mphal.h"
 
-// need this header for any overrides to the below constants
+// Need this header for MICROPY_HW_USB_xxx configuration values.
 #include "py/mpconfig.h"
-
-#ifndef USBD_LANGID_STRING
-#define USBD_LANGID_STRING            0x409
-#endif
-
-#ifndef USBD_MANUFACTURER_STRING
-#define USBD_MANUFACTURER_STRING      "MicroPython"
-#endif
-
-#ifndef USBD_PRODUCT_HS_STRING
-#define USBD_PRODUCT_HS_STRING        "Pyboard Virtual Comm Port in HS Mode"
-#endif
-
-#ifndef USBD_PRODUCT_FS_STRING
-#define USBD_PRODUCT_FS_STRING        "Pyboard Virtual Comm Port in FS Mode"
-#endif
-
-#ifndef USBD_CONFIGURATION_HS_STRING
-#define USBD_CONFIGURATION_HS_STRING  "Pyboard Config"
-#endif
-
-#ifndef USBD_INTERFACE_HS_STRING
-#define USBD_INTERFACE_HS_STRING      "Pyboard Interface"
-#endif
-
-#ifndef USBD_CONFIGURATION_FS_STRING
-#define USBD_CONFIGURATION_FS_STRING  "Pyboard Config"
-#endif
-
-#ifndef USBD_INTERFACE_FS_STRING
-#define USBD_INTERFACE_FS_STRING      "Pyboard Interface"
-#endif
 
 __ALIGN_BEGIN static const uint8_t USBD_LangIDDesc[USB_LEN_LANGID_STR_DESC] __ALIGN_END = {
     USB_LEN_LANGID_STR_DESC,
     USB_DESC_TYPE_STRING,
-    LOBYTE(USBD_LANGID_STRING),
-    HIBYTE(USBD_LANGID_STRING),
+    LOBYTE(MICROPY_HW_USB_LANGID_STRING),
+    HIBYTE(MICROPY_HW_USB_LANGID_STRING),
 };
 
 // set the VID, PID and device release number
@@ -140,14 +108,14 @@ STATIC uint8_t *USBD_StrDescriptor(USBD_HandleTypeDef *pdev, uint8_t idx, uint16
             return (uint8_t *)USBD_LangIDDesc; // the data should only be read from this buf
 
         case USBD_IDX_MFC_STR:
-            str = USBD_MANUFACTURER_STRING;
+            str = MICROPY_HW_USB_MANUFACTURER_STRING;
             break;
 
         case USBD_IDX_PRODUCT_STR:
             if (pdev->dev_speed == USBD_SPEED_HIGH) {
-                str = USBD_PRODUCT_HS_STRING;
+                str = MICROPY_HW_USB_PRODUCT_HS_STRING;
             } else {
-                str = USBD_PRODUCT_FS_STRING;
+                str = MICROPY_HW_USB_PRODUCT_FS_STRING;
             }
             break;
 
@@ -174,17 +142,17 @@ STATIC uint8_t *USBD_StrDescriptor(USBD_HandleTypeDef *pdev, uint8_t idx, uint16
 
         case USBD_IDX_CONFIG_STR:
             if (pdev->dev_speed == USBD_SPEED_HIGH) {
-                str = USBD_CONFIGURATION_HS_STRING;
+                str = MICROPY_HW_USB_CONFIGURATION_HS_STRING;
             } else {
-                str = USBD_CONFIGURATION_FS_STRING;
+                str = MICROPY_HW_USB_CONFIGURATION_FS_STRING;
             }
             break;
 
         case USBD_IDX_INTERFACE_STR:
             if (pdev->dev_speed == USBD_SPEED_HIGH) {
-                str = USBD_INTERFACE_HS_STRING;
+                str = MICROPY_HW_USB_INTERFACE_HS_STRING;
             } else {
-                str = USBD_INTERFACE_FS_STRING;
+                str = MICROPY_HW_USB_INTERFACE_FS_STRING;
             }
             break;
 

--- a/tools/insert-usb-ids.py
+++ b/tools/insert-usb-ids.py
@@ -8,6 +8,7 @@ import sys
 import re
 import string
 
+config_prefix = "MICROPY_HW_USB_"
 needed_keys = ("USB_PID_CDC_MSC", "USB_PID_CDC_HID", "USB_PID_CDC", "USB_VID")
 
 
@@ -16,10 +17,10 @@ def parse_usb_ids(filename):
     for line in open(filename).readlines():
         line = line.rstrip("\r\n")
         match = re.match("^#define\s+(\w+)\s+\(0x([0-9A-Fa-f]+)\)$", line)
-        if match and match.group(1).startswith("USBD_"):
-            key = match.group(1).replace("USBD", "USB")
+        if match and match.group(1).startswith(config_prefix):
+            key = match.group(1).replace(config_prefix, "USB_")
             val = match.group(2)
-            print("key =", key, "val =", val)
+            # print("key =", key, "val =", val)
             if key in needed_keys:
                 rv[key] = val
     for k in needed_keys:


### PR DESCRIPTION
For consistency with other board-level config macros that begin with MICROPY_HW_USB.

See discussion in #7594.