### PR TITLE
rp2/boards/PICO: Add USB VID/PID.

### DIFF
--- a/ports/rp2/boards/PICO/mpconfigboard.h
+++ b/ports/rp2/boards/PICO/mpconfigboard.h
@@ -1,3 +1,10 @@
-// Board and hardware specific configuration
-#define MICROPY_HW_BOARD_NAME                   "Raspberry Pi Pico"
-#define MICROPY_HW_FLASH_STORAGE_BYTES          (1408 * 1024) 
+// https://www.raspberrypi.org/products/raspberry-pi-pico/
+#define MICROPY_HW_BOARD_NAME          "Raspberry Pi Pico"
+#define MICROPY_HW_FLASH_STORAGE_BYTES (1408 * 1024)
+
+#define MICROPY_HW_USB_VID (0x239A)
+#define MICROPY_HW_USB_PID (0x80F4)
+
+// Green user LED GPIO25
+// VBUS_SENSE GPIO24
+// VOLTAGE_MONITOR GPIO29 (A3)


### PR DESCRIPTION
Added VID/PID as per [CircuitPython board def](https://github.com/adafruit/circuitpython/blob/main/ports/raspberrypi/boards/raspberry_pi_pico/mpconfigboard.mk)