### PR TITLE
esp8266,esp32: Include hidden networks in WLAN.scan results.

### DIFF
--- a/docs/library/network.WLAN.rst
+++ b/docs/library/network.WLAN.rst
@@ -46,6 +46,8 @@ Methods
 .. method:: WLAN.scan()
 
     Scan for the available wireless networks.
+    Hidden networks -- where the SSID is not broadcast -- will also be scanned
+    if the WLAN interface allows it.
 
     Scanning is only possible on STA interface. Returns list of tuples with
     the information about WiFi access points:

--- a/ports/esp32/modnetwork.c
+++ b/ports/esp32/modnetwork.c
@@ -466,7 +466,7 @@ STATIC mp_obj_t esp_scan(mp_obj_t self_in) {
 
     mp_obj_t list = mp_obj_new_list(0, NULL);
     wifi_scan_config_t config = { 0 };
-    // XXX how do we scan hidden APs (and if we can scan them, are they really hidden?)
+    config.show_hidden = true;
     MP_THREAD_GIL_EXIT();
     esp_err_t status = esp_wifi_scan_start(&config, 1);
     MP_THREAD_GIL_ENTER();

--- a/ports/esp8266/modnetwork.c
+++ b/ports/esp8266/modnetwork.c
@@ -233,7 +233,9 @@ STATIC mp_obj_t esp_scan(mp_obj_t self_in) {
     }
     mp_obj_t list = mp_obj_new_list(0, NULL);
     esp_scan_list = &list;
-    wifi_station_scan(NULL, (scan_done_cb_t)esp_scan_cb);
+    struct scan_config config = {0};
+    config.show_hidden = 1;
+    wifi_station_scan(&config, (scan_done_cb_t)esp_scan_cb);
     while (esp_scan_list != NULL) {
         // our esp_scan_cb is called via ets_loop_iter so it's safe to set the
         // esp_scan_list variable to NULL without disabling interrupts


### PR DESCRIPTION
Addresses issues #2697 and #5329.  In particular see discussion towards the end of #5329 about including hidden networks by default.
