### PR TITLE
py/objcomplex: Allow strings of the form -A+Bj.

### DIFF
--- a/tests/float/complex1.py
+++ b/tests/float/complex1.py
@@ -7,6 +7,8 @@ print(complex(1.2j))
 print(complex("1"))
 print(complex("1.2"))
 print(complex("1.2j"))
+print(complex("1+2j"))
+print(complex("-1-2j"))
 print(complex(1, 2))
 print(complex(1j, 2j))
 


### PR DESCRIPTION
Allows parsing of a complex string with a similar result as CPython.

Until now, only strings like `3j` were supported, with strings like `1+2j` giving a syntax error.

The following strings will now also work.

```python
print(complex("1+2j"))
print(complex("+1+2j"))
print(complex("-1+2j"))
```

Cases with only a sign at [0] or no sign at all are treated as they already were.

Checks are added to force A to be real and B to be imaginary. This raises exceptions for the same cases as CPython, like Aj+B, even though MicroPython would otherwise return the correct result.

Fixes this [MicroPython forum post](https://forum.micropython.org/viewtopic.php?t=9216&p=51863).

Edit: Fix commit message < 75 characters per line.

Signed-off-by: Laurens Valk <laurens@pybricks.com>