### PR TITLE
stm32: Fixed compile error in mbedtls_port.c.

### DIFF
--- a/ports/stm32/mbedtls/mbedtls_port.c
+++ b/ports/stm32/mbedtls/mbedtls_port.c
@@ -80,7 +80,7 @@ void m_free_mbedtls(void *ptr_in) {
 }
 
 int mbedtls_hardware_poll(void *data, unsigned char *output, size_t len, size_t *olen) {
-    uint32_t val;
+    uint32_t val = 0;
     int n = 0;
     *olen = len;
     while (len--) {


### PR DESCRIPTION
Building with `BOARD=NUCLEO_H743ZI DEBUG=1` died with a compile error:
```
mbedtls/mbedtls_port.c: In function 'mbedtls_hardware_poll':
mbedtls/mbedtls_port.c:92:13: error: 'val' may be used uninitialized in this function [-Werror=maybe-uninitialized]
   92 |         val >>= 8;
      |         ~~~~^~~~~
cc1: all warnings being treated as errors
```
This PR fixes this error.