### PR TITLE
nrf/modules/nrf: Add function to enable/disable DCDC.

### DIFF
--- a/ports/nrf/nrfx_glue.h
+++ b/ports/nrf/nrfx_glue.h
@@ -27,7 +27,14 @@
 #ifndef NRFX_GLUE_H
 #define NRFX_GLUE_H
 
+#include "py/mpconfig.h"
+#include "py/misc.h"
+
 #include <soc/nrfx_irqs.h>
+
+#ifndef ARRAY_SIZE
+#define ARRAY_SIZE MP_ARRAY_SIZE
+#endif
 
 #define NRFX_STATIC_ASSERT(expression)
 


### PR DESCRIPTION
This is a rework of #4301 against latest master (which now includes an `nrf` module).