### PR TITLE
esp32/makeimg.py: Get bootloader and partition offset from sdkconfig.

### DIFF
--- a/ports/esp32/Makefile
+++ b/ports/esp32/Makefile
@@ -33,6 +33,7 @@ endif
 all:
 	idf.py $(IDFPY_FLAGS) build
 	@$(PYTHON) makeimg.py \
+		$(BUILD)/sdkconfig \
 		$(BUILD)/bootloader/bootloader.bin \
 		$(BUILD)/partition_table/partition-table.bin \
     		$(BUILD)/micropython.bin \


### PR DESCRIPTION
So that it works on ESP32C3, which has the bootloader at 0x0.

Fixes issue #7565.
