### PR TITLE
extmod/modlwip: Fix close and clean up of UDP and raw sockets.

### DIFF
--- a/extmod/modlwip.c
+++ b/extmod/modlwip.c
@@ -1502,16 +1502,16 @@ STATIC mp_uint_t lwip_socket_ioctl(mp_obj_t self_in, mp_uint_t request, uintptr_
             return 0;
         }
 
-        // Deregister callback (pcb.tcp is set to NULL below so must deregister now)
-        tcp_arg(socket->pcb.tcp, NULL);
-        tcp_err(socket->pcb.tcp, NULL);
-        tcp_recv(socket->pcb.tcp, NULL);
-
         // Free any incoming buffers or connections that are stored
         lwip_socket_free_incoming(socket);
 
         switch (socket->type) {
             case MOD_NETWORK_SOCK_STREAM: {
+                // Deregister callback (pcb.tcp is set to NULL below so must deregister now)
+                tcp_arg(socket->pcb.tcp, NULL);
+                tcp_err(socket->pcb.tcp, NULL);
+                tcp_recv(socket->pcb.tcp, NULL);
+
                 if (socket->pcb.tcp->state != LISTEN) {
                     // Schedule a callback to abort the connection if it's not cleanly closed after
                     // the given timeout.  The callback must be set before calling tcp_close since
@@ -1525,10 +1525,12 @@ STATIC mp_uint_t lwip_socket_ioctl(mp_obj_t self_in, mp_uint_t request, uintptr_
                 break;
             }
             case MOD_NETWORK_SOCK_DGRAM:
+                udp_recv(socket->pcb.udp, NULL, NULL);
                 udp_remove(socket->pcb.udp);
                 break;
             #if MICROPY_PY_LWIP_SOCK_RAW
             case MOD_NETWORK_SOCK_RAW:
+                raw_recv(socket->pcb.raw, NULL, NULL);
                 raw_remove(socket->pcb.raw);
                 break;
             #endif

--- a/tests/multi_net/udp_data.py
+++ b/tests/multi_net/udp_data.py
@@ -1,0 +1,35 @@
+# Simple test of a UDP server and client transferring data
+
+import socket
+
+NUM_NEW_SOCKETS = 4
+NUM_TRANSFERS = 4
+PORT = 8000
+
+# Server
+def instance0():
+    multitest.globals(IP=multitest.get_network_ip())
+    multitest.next()
+    for i in range(NUM_NEW_SOCKETS):
+        s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+        s.bind(socket.getaddrinfo("0.0.0.0", PORT)[0][-1])
+        multitest.broadcast("server ready")
+        for j in range(NUM_TRANSFERS):
+            data, addr = s.recvfrom(1000)
+            print(data)
+            s.sendto(b"server to client %d %d" % (i, j), addr)
+        s.close()
+
+
+# Client
+def instance1():
+    multitest.next()
+    ai = socket.getaddrinfo(IP, PORT)[0][-1]
+    for i in range(NUM_NEW_SOCKETS):
+        s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+        multitest.wait("server ready")
+        for j in range(NUM_TRANSFERS):
+            s.sendto(b"client to server %d %d" % (i, j), ai)
+            data, addr = s.recvfrom(1000)
+            print(data)
+        s.close()


### PR DESCRIPTION
The correct callback-deregister functions must be called dependent on the socket type, otherwise resources may not be freed correctly.

This fixes possible bugs in UDP sockets on stm32 where lwIP could get into a state where it had no packet-buffer memory left and could not receive ETH packets.

Note: the multi test requires #7644 to run.