### PR TITLE
mpremote: Fix listing when VID/PID are none, and add "devs" shortcut

### DIFF
--- a/tools/mpremote/mpremote/main.py
+++ b/tools/mpremote/mpremote/main.py
@@ -27,6 +27,7 @@ _PROG = "mpremote"
 
 _BUILTIN_COMMAND_EXPANSIONS = {
     # Device connection shortcuts.
+    "devs": "connect list",
     "a0": "connect /dev/ttyACM0",
     "a1": "connect /dev/ttyACM1",
     "a2": "connect /dev/ttyACM2",

--- a/tools/mpremote/mpremote/main.py
+++ b/tools/mpremote/mpremote/main.py
@@ -166,7 +166,12 @@ def do_connect(args):
             for p in sorted(serial.tools.list_ports.comports()):
                 print(
                     "{} {} {:04x}:{:04x} {} {}".format(
-                        p.device, p.serial_number, p.vid, p.pid, p.manufacturer, p.product
+                        p.device,
+                        p.serial_number,
+                        p.vid if isinstance(p.vid, int) else 0,
+                        p.pid if isinstance(p.pid, int) else 0,
+                        p.manufacturer,
+                        p.product,
                     )
                 )
             return None


### PR DESCRIPTION
Fixes #7636 , and implements "devs" as per discussion in #7480.