### PR TITLE
ports/rp2: Provide direct memory access to PIO FIFOs via proxy arrays.

### DIFF
--- a/ports/rp2/machine_spi.c
+++ b/ports/rp2/machine_spi.c
@@ -302,6 +302,18 @@ STATIC void machine_spi_transfer(mp_obj_base_t *self_in, size_t len, const uint8
     }
 }
 
+// Buffer protocol implementation for SPI.
+// The buffer represents the SPI data FIFO.
+STATIC mp_int_t machine_spi_get_buffer(mp_obj_t o_in, mp_buffer_info_t *bufinfo, mp_uint_t flags) {
+    machine_spi_obj_t *self = MP_OBJ_TO_PTR(o_in);
+
+    bufinfo->len = 4;
+    bufinfo->typecode = 'I';
+    bufinfo->buf = (void *)&spi_get_hw(self->spi_inst)->dr;
+
+    return 0;
+}
+
 STATIC const mp_machine_spi_p_t machine_spi_p = {
     .init = machine_spi_init,
     .transfer = machine_spi_transfer,
@@ -314,6 +326,7 @@ MP_DEFINE_CONST_OBJ_TYPE(
     make_new, machine_spi_make_new,
     print, machine_spi_print,
     protocol, &machine_spi_p,
+    buffer, machine_spi_get_buffer,
     locals_dict, &mp_machine_spi_locals_dict
     );
 

--- a/ports/rp2/rp2_dma.c
+++ b/ports/rp2/rp2_dma.c
@@ -86,7 +86,7 @@ STATIC const uint32_t rp2_dma_ctrl_field_count = MP_ARRAY_SIZE(rp2_dma_ctrl_fiel
 STATIC uint32_t rp2_dma_register_value_from_obj(mp_obj_t o, int reg_type) {
     if (reg_type == REG_TYPE_ADDR_READ || reg_type == REG_TYPE_ADDR_WRITE) {
         mp_buffer_info_t buf_info;
-        mp_uint_t flags = MP_BUFFER_READ;
+        mp_uint_t flags = (reg_type == REG_TYPE_ADDR_READ) ? MP_BUFFER_READ : MP_BUFFER_WRITE;
         if (mp_get_buffer(o, &buf_info, flags)) {
             return (uint32_t)buf_info.buf;
         }

--- a/ports/rp2/rp2_pio.c
+++ b/ports/rp2/rp2_pio.c
@@ -809,6 +809,23 @@ STATIC mp_obj_t rp2_state_machine_tx_fifo(mp_obj_t self_in) {
 }
 STATIC MP_DEFINE_CONST_FUN_OBJ_1(rp2_state_machine_tx_fifo_obj, rp2_state_machine_tx_fifo);
 
+// Buffer protocol implementation for StateMachine.
+// The buffer represents one of the FIFO ports of the state machine. Note that a different
+// pointer is returned depending on if this is for reading or writing.
+STATIC mp_int_t rp2_state_machine_get_buffer(mp_obj_t o_in, mp_buffer_info_t *bufinfo, mp_uint_t flags) {
+    rp2_state_machine_obj_t *self = MP_OBJ_TO_PTR(o_in);
+
+    bufinfo->len = 4;
+    bufinfo->typecode = 'I';
+
+    if (flags & MP_BUFFER_WRITE) {
+        bufinfo->buf = (void *)&self->pio->txf[self->sm];
+    } else {
+        bufinfo->buf = (void *)&self->pio->rxf[self->sm];
+    }
+    return 0;
+}
+
 // StateMachine.irq(handler=None, trigger=0|1, hard=False)
 STATIC mp_obj_t rp2_state_machine_irq(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
     enum { ARG_handler, ARG_trigger, ARG_hard };
@@ -884,6 +901,7 @@ MP_DEFINE_CONST_OBJ_TYPE(
     MP_TYPE_FLAG_NONE,
     make_new, rp2_state_machine_make_new,
     print, rp2_state_machine_print,
+    buffer, rp2_state_machine_get_buffer,
     locals_dict, &rp2_state_machine_locals_dict
     );
 


### PR DESCRIPTION
As per the discussion in #7641, this PR adds a new `get_fifo_proxy()` method to `rp2.StateMachine` that allows a user to get a memory proxy for either the TX or RX FIFO of an instance. This can either be used directly to gain non-blocking access to the FIFO values or it can be passed to an `rp2.DMA` instance for the `read` or `write` values. For example:
```
my_sm = rp2.StateMachine(0, ...)
d = rp2.DMA()
a = bytearray(256)

c = d.default_ctrl
c.inc_read = False    # Fetch all the values from the same FIFO address
c.treq_sel = 8        # Flow control from the RX fifo for state machine 0

rx_fifo_proxy = my_sm.get_fifo_proxy(True)    # True for RX FIFO

d.config(read=rx_fifo_proxy, write=a, count=len(a)//4, ctrl=c, trigger=True)
```
