### PR TITLE
MICROPY_PY_USELECT: Add poll function to vfs_posix_file_ioctl and unix socket_ioctl.

### DIFF
--- a/extmod/vfs_posix_file.c
+++ b/extmod/vfs_posix_file.c
@@ -37,6 +37,8 @@
 
 #ifdef _WIN32
 #define fsync _commit
+#else
+#include <poll.h>
 #endif
 
 typedef struct _mp_obj_vfs_posix_file_t {
@@ -206,6 +208,30 @@ STATIC mp_uint_t vfs_posix_file_ioctl(mp_obj_t o_in, mp_uint_t request, uintptr_
             return 0;
         case MP_STREAM_GET_FILENO:
             return o->fd;
+        case MP_STREAM_POLL: {
+            #ifdef _WIN32
+            mp_raise_NotImplementedError(MP_ERROR_TEXT("poll on file not available on win32"));
+            #else
+            mp_uint_t ret = 0;
+            uint8_t pollevents = 0;
+            if (arg & MP_STREAM_POLL_RD) {
+                pollevents |= POLLIN;
+            }
+            if (arg & MP_STREAM_POLL_WR) {
+                pollevents |= POLLOUT;
+            }
+            struct pollfd pfd = { .fd = o->fd, .events = pollevents };
+            if (poll(&pfd, 1, 0) > 0) {
+                if (pfd.revents & POLLIN) {
+                    ret |= MP_STREAM_POLL_RD;
+                }
+                if (pfd.revents & POLLOUT) {
+                    ret |= MP_STREAM_POLL_WR;
+                }
+            }
+            return ret;
+            #endif
+        }
         default:
             *errcode = EINVAL;
             return MP_STREAM_ERROR;

--- a/ports/unix/modusocket.c
+++ b/ports/unix/modusocket.c
@@ -46,6 +46,7 @@
 #include "py/builtin.h"
 #include "py/mphal.h"
 #include "py/mpthread.h"
+#include <poll.h>
 
 /*
   The idea of this module is to implement reasonable minimum of
@@ -143,6 +144,27 @@ STATIC mp_uint_t socket_ioctl(mp_obj_t o_in, mp_uint_t request, uintptr_t arg, i
 
         case MP_STREAM_GET_FILENO:
             return self->fd;
+
+        case MP_STREAM_POLL: {
+            mp_uint_t ret = 0;
+            uint8_t pollevents = 0;
+            if (arg & MP_STREAM_POLL_RD) {
+                pollevents |= POLLIN;
+            }
+            if (arg & MP_STREAM_POLL_WR) {
+                pollevents |= POLLOUT;
+            }
+            struct pollfd pfd = { .fd = self->fd, .events = pollevents };
+            if (poll(&pfd, 1, 0) > 0) {
+                if (pfd.revents & POLLIN) {
+                    ret |= MP_STREAM_POLL_RD;
+                }
+                if (pfd.revents & POLLOUT) {
+                    ret |= MP_STREAM_POLL_WR;
+                }
+            }
+            return ret;
+        }
 
         default:
             *errcode = MP_EINVAL;


### PR DESCRIPTION
Allows asyncio reading of sys.stdin when micropython select is used in build configuration.

To test / work-on unix port BLE support I had to switch to the micropython select rather than posix select, eg.
```
#define MICROPY_PY_USELECT_POSIX (0)
#define MICROPY_PY_USELECT (1)
```

Once that change was made however, I ran into the following exception:
```
Traceback (most recent call last):
  File "./src/firmware/main.py", line 67, in main
  File "/home/anl/reader_app/src/firmware/reader.py", line 421, in run
  File "/home/anl/reader_app/src/firmware/reader.py", line 450, in run_reader
  File "uasyncio/core.py", line 249, in run_until_complete
  File "uasyncio/core.py", line 167, in run_until_complete
  File "uasyncio/core.py", line 113, in wait_io_event
OSError: [Errno 22] EINVAL
```

When trying to asyncio read from stdin with the following code:
```
async def monitor_repl():
        repl = sys.stdin
        sreader = asyncio.StreamReader(repl)
        while not stop:
            b = await sreader.read(1)
            ...
```

This PR adds (linux at least) poll support to the posix file handler used behind the scenes here to enable this functionality.

A second closely related commit has been added to provide the same support to unix socket.