### PR TITLE
RP2: Add networking support.

### DIFF
--- a/extmod/extmod.cmake
+++ b/extmod/extmod.cmake
@@ -32,6 +32,8 @@ set(MICROPY_SOURCE_EXTMOD
     ${MICROPY_EXTMOD_DIR}/modutimeq.c
     ${MICROPY_EXTMOD_DIR}/moduwebsocket.c
     ${MICROPY_EXTMOD_DIR}/moduzlib.c
+    ${MICROPY_EXTMOD_DIR}/modusocket.c
+    ${MICROPY_EXTMOD_DIR}/modnetwork.c
     ${MICROPY_EXTMOD_DIR}/modwebrepl.c
     ${MICROPY_EXTMOD_DIR}/uos_dupterm.c
     ${MICROPY_EXTMOD_DIR}/utime_mphal.c

--- a/extmod/modusocket.c
+++ b/extmod/modusocket.c
@@ -35,7 +35,7 @@
 #include "shared/netutils/netutils.h"
 #include "modnetwork.h"
 
-#if MICROPY_PY_USOCKET && !MICROPY_PY_LWIP
+#if MICROPY_PY_NETWORK && MICROPY_PY_USOCKET && !MICROPY_PY_LWIP
 
 /******************************************************************************/
 // socket class
@@ -517,4 +517,4 @@ const mp_obj_module_t mp_module_usocket = {
     .globals = (mp_obj_dict_t *)&mp_module_usocket_globals,
 };
 
-#endif // MICROPY_PY_USOCKET && !MICROPY_PY_LWIP
+#endif // MICROPY_PY_NETWORK && MICROPY_PY_USOCKET && !MICROPY_PY_LWIP

--- a/ports/rp2/CMakeLists.txt
+++ b/ports/rp2/CMakeLists.txt
@@ -66,6 +66,7 @@ set(MICROPY_SOURCE_LIB
     ${MICROPY_DIR}/lib/littlefs/lfs2_util.c
     ${MICROPY_DIR}/lib/oofatfs/ff.c
     ${MICROPY_DIR}/lib/oofatfs/ffunicode.c
+    ${MICROPY_DIR}/shared/netutils/netutils.c
     ${MICROPY_DIR}/shared/readline/readline.c
     ${MICROPY_DIR}/shared/runtime/gchelper_m0.s
     ${MICROPY_DIR}/shared/runtime/gchelper_native.c

--- a/ports/rp2/main.c
+++ b/ports/rp2/main.c
@@ -40,6 +40,7 @@
 #include "modmachine.h"
 #include "modrp2.h"
 #include "genhdr/mpversion.h"
+#include "extmod/modnetwork.h"
 
 #include "pico/stdlib.h"
 #include "pico/binary_info.h"
@@ -107,6 +108,10 @@ int main(int argc, char **argv) {
         machine_pin_init();
         rp2_pio_init();
 
+        #if MICROPY_PY_NETWORK
+        mod_network_init();
+        #endif
+
         // Execute _boot.py to set up the filesystem.
         pyexec_frozen_module("_boot.py");
 
@@ -136,6 +141,9 @@ int main(int argc, char **argv) {
 
     soft_reset_exit:
         mp_printf(MP_PYTHON_PRINTER, "MPY: soft reboot\n");
+        #if MICROPY_PY_NETWORK
+        mod_network_deinit();
+        #endif
         rp2_pio_deinit();
         machine_pin_deinit();
         #if MICROPY_PY_THREAD

--- a/ports/rp2/mpconfigport.h
+++ b/ports/rp2/mpconfigport.h
@@ -170,6 +170,21 @@ extern const struct _mp_obj_module_t mp_module_onewire;
 extern const struct _mp_obj_module_t mp_module_rp2;
 extern const struct _mp_obj_module_t mp_module_uos;
 extern const struct _mp_obj_module_t mp_module_utime;
+extern const struct _mp_obj_module_t mp_module_usocket;
+extern const struct _mp_obj_module_t mp_module_network;
+
+#if MICROPY_PY_USOCKET
+#define SOCKET_BUILTIN_MODULE               { MP_ROM_QSTR(MP_QSTR_usocket), MP_ROM_PTR(&mp_module_usocket) },
+#else
+#define SOCKET_BUILTIN_MODULE
+#endif
+#if MICROPY_PY_NETWORK
+#define NETWORK_BUILTIN_MODULE              { MP_ROM_QSTR(MP_QSTR_network), MP_ROM_PTR(&mp_module_network) },
+#define NETWORK_ROOT_POINTERS               mp_obj_list_t mod_network_nic_list;
+#else
+#define NETWORK_BUILTIN_MODULE
+#define NETWORK_ROOT_POINTERS
+#endif
 
 #define MICROPY_PORT_BUILTIN_MODULES \
     { MP_OBJ_NEW_QSTR(MP_QSTR_machine), (mp_obj_t)&mp_module_machine }, \
@@ -177,10 +192,14 @@ extern const struct _mp_obj_module_t mp_module_utime;
     { MP_OBJ_NEW_QSTR(MP_QSTR__rp2), (mp_obj_t)&mp_module_rp2 }, \
     { MP_ROM_QSTR(MP_QSTR_uos), MP_ROM_PTR(&mp_module_uos) }, \
     { MP_ROM_QSTR(MP_QSTR_utime), MP_ROM_PTR(&mp_module_utime) }, \
+    SOCKET_BUILTIN_MODULE \
+    NETWORK_BUILTIN_MODULE \
 
 #ifndef MICROPY_BOARD_ROOT_POINTERS
 #define MICROPY_BOARD_ROOT_POINTERS
 #endif
+
+#define MICROPY_PORT_NETWORK_INTERFACES \
 
 #define MICROPY_PORT_ROOT_POINTERS \
     const char *readline_hist[8]; \
@@ -189,7 +208,8 @@ extern const struct _mp_obj_module_t mp_module_utime;
     void *rp2_state_machine_irq_obj[8]; \
     void *rp2_uart_rx_buffer[2]; \
     void *rp2_uart_tx_buffer[2]; \
-    MICROPY_BOARD_ROOT_POINTERS \
+    NETWORK_ROOT_POINTERS \
+        MICROPY_BOARD_ROOT_POINTERS \
 
 #define MP_STATE_PORT MP_STATE_VM
 


### PR DESCRIPTION
Add basic generic networking module support. This serves as a placeholder for adding specific NICs/WiFi drivers later.