### PR TITLE
bluetooth: remove hardcoded generic attribute service.

### DIFF
--- a/extmod/btstack/modbluetooth_btstack.c
+++ b/extmod/btstack/modbluetooth_btstack.c
@@ -917,9 +917,6 @@ int mp_bluetooth_gatts_register_service_begin(bool append) {
         uint16_t handle = att_db_util_add_characteristic_uuid16(GAP_DEVICE_NAME_UUID, ATT_PROPERTY_READ | ATT_PROPERTY_DYNAMIC, ATT_SECURITY_NONE, ATT_SECURITY_NONE, NULL, 0);
         assert(handle == BTSTACK_GAP_DEVICE_NAME_HANDLE);
         (void)handle;
-
-        att_db_util_add_service_uuid16(0x1801);
-        att_db_util_add_characteristic_uuid16(0x2a05, ATT_PROPERTY_READ, ATT_SECURITY_NONE, ATT_SECURITY_NONE, NULL, 0);
     }
 
     return 0;

--- a/extmod/nimble/modbluetooth_nimble.c
+++ b/extmod/nimble/modbluetooth_nimble.c
@@ -40,7 +40,6 @@
 #include "nimble/ble.h"
 #include "nimble/nimble_port.h"
 #include "services/gap/ble_svc_gap.h"
-#include "services/gatt/ble_svc_gatt.h"
 
 #if MICROPY_PY_BLUETOOTH_ENABLE_L2CAP_CHANNELS
 // We need the definition of "struct ble_l2cap_chan".
@@ -643,12 +642,11 @@ int mp_bluetooth_init(void) {
 
     DEBUG_printf("mp_bluetooth_init: starting services\n");
 
-    // By default, just register the default gap/gatt service.
+    // By default, just register the default gap service.
     ble_svc_gap_init();
-    ble_svc_gatt_init();
-    // The preceeding two calls allocate service definitions on the heap,
-    // then we must now call gatts_start to register those services
-    // and free the heap memory.
+    // The preceeding call allocates the service definition on the heap,
+    // we must now call gatts_start to register the service and free 
+    // the heap memory.
     // Otherwise it will be realloc'ed on the next stack startup.
     ble_gatts_start();
 
@@ -908,9 +906,8 @@ int mp_bluetooth_gatts_register_service_begin(bool append) {
     // Reset the gatt characteristic value db.
     mp_bluetooth_gatts_db_reset(MP_STATE_PORT(bluetooth_nimble_root_pointers)->gatts_db);
 
-    // By default, just register the default gap/gatt service.
+    // By default, just register the default gap service.
     ble_svc_gap_init();
-    ble_svc_gatt_init();
 
     // Unref any previous service definitions.
     for (size_t i = 0; i < MP_STATE_PORT(bluetooth_nimble_root_pointers)->n_services; ++i) {


### PR DESCRIPTION
Allows it be be defined & managed in python code if needed, eg with https://github.com/micropython/micropython-lib/pull/439