### PR TITLE
py/mkrules.mk: Do submodule sync in "make submodules".

### DIFF
--- a/ports/rp2/Makefile
+++ b/ports/rp2/Makefile
@@ -20,3 +20,8 @@ all:
 
 clean:
 	$(RM) -rf $(BUILD)
+
+GIT_SUBMODULES += lib/pico-sdk lib/tinyusb
+
+submodules:
+	$(MAKE) -f ../../py/mkrules.mk GIT_SUBMODULES="$(GIT_SUBMODULES)" submodules

--- a/ports/rp2/README.md
+++ b/ports/rp2/README.md
@@ -29,6 +29,7 @@ Building of the RP2 firmware is done entirely using CMake, although a simple
 Makefile is also provided as a convenience.  To build the firmware run (from
 this directory):
 
+    $ make submodules
     $ make clean
     $ make
 

--- a/py/mkrules.mk
+++ b/py/mkrules.mk
@@ -214,6 +214,7 @@ endif
 submodules:
 	$(ECHO) "Updating submodules: $(GIT_SUBMODULES)"
 ifneq ($(GIT_SUBMODULES),)
+	$(Q)git submodule sync $(addprefix $(TOP)/,$(GIT_SUBMODULES))
 	$(Q)git submodule update --init $(addprefix $(TOP)/,$(GIT_SUBMODULES))
 endif
 .PHONY: submodules


### PR DESCRIPTION
See discussion in https://github.com/micropython/micropython/issues/7665#issuecomment-899201251 -- If we change the remote for a submodule, then this allows the "make submodules" target to update them correctly.

Also adds a submodules target for rp2 (for pico-sdk and tinyusb), and instructions to README.md.