### PR TITLE
py/lexer.c: Clear fstring_args vstr on lexer free.

### DIFF
--- a/py/lexer.c
+++ b/py/lexer.c
@@ -878,6 +878,9 @@ void mp_lexer_free(mp_lexer_t *lex) {
     if (lex) {
         lex->reader.close(lex->reader.data);
         vstr_clear(&lex->vstr);
+        #if MICROPY_PY_FSTRINGS
+        vstr_clear(&lex->fstring_args);
+        #endif
         m_del(uint16_t, lex->indent_level, lex->alloc_indent_level);
         m_del_obj(mp_lexer_t, lex);
     }


### PR DESCRIPTION
I missed this in #7649 -- it's not strictly necessary as the GC will clean it anyway, but it's good to pre-emptively gc_free() all the blocks used in lexing/parsing.

+8 bytes on PYBV11.