### PR TITLE
Add hardware scrolling functionalities.

### DIFF
--- a/drivers/display/ssd1306.py
+++ b/drivers/display/ssd1306.py
@@ -23,10 +23,25 @@ SET_DISP_CLK_DIV = const(0xD5)
 SET_PRECHARGE = const(0xD9)
 SET_VCOM_DESEL = const(0xDB)
 SET_CHARGE_PUMP = const(0x8D)
+SET_HWSCROLL_OFF    = const(0x2e)
+SET_HWSCROLL_ON     = const(0x2f)
+SET_HWSCROLL_RIGHT  = const(0x26)
+SET_HWSCROLL_LEFT   = const(0x27)
+SET_HWSCROLL_VR     = const(0x29)
+SET_HWSCROLL_VL     = const(0x2a)
 
 # Subclassing FrameBuffer provides support for graphics primitives
 # http://docs.micropython.org/en/latest/pyboard/library/framebuf.html
 class SSD1306(framebuf.FrameBuffer):
+    FRAMES_2 = 0x07
+    FRAMES_3 = 0x04
+    FRAMES_4 = 0x05
+    FRAMES_5 = 0x00
+    FRAMES_25 = 0x06
+    FRAMES_64 = 0x01
+    FRAMES_128 = 0x02
+    FRAMES_256 = 0x03
+
     def __init__(self, width, height, external_vcc):
         self.width = width
         self.height = height
@@ -108,6 +123,49 @@ class SSD1306(framebuf.FrameBuffer):
         self.write_cmd(self.pages - 1)
         self.write_data(self.buffer)
 
+    def clear(self):
+        self.fill(0)
+        self.show()
+    
+    def hw_scroll_off(self):
+        self.write_cmd(SET_HWSCROLL_OFF) # turn off scroll
+        
+    def hw_scroll_h(
+        self, 
+        direction=True,    # True/False: right/left
+        interval=FRAMES_5  # one frame ≓ 9.2ms
+    ):
+        self.write_cmd(SET_HWSCROLL_OFF)  # turn off hardware scroll per SSD1306 datasheet
+        if not direction:
+            self.write_cmd(SET_HWSCROLL_LEFT)
+        else:
+            self.write_cmd(SET_HWSCROLL_RIGHT)
+        self.write_cmd(0x00)            # dummy byte
+        self.write_cmd(0x00)            # start page = page 0
+        self.write_cmd(interval)        # interval
+        self.write_cmd(0x07)            # end page = page 7
+        self.write_cmd(0x00)            # dummy byte
+        self.write_cmd(0xff)            # dummy byte
+        self.write_cmd(SET_HWSCROLL_ON) # activate scroll
+
+    def hw_scroll_diag(
+        self, 
+        direction=True,    # True/False: right/left
+        interval=FRAMES_5, # one frame ≓ 9.2ms
+        offset=1           # vertical offset per scroll
+    ):
+
+        self.write_cmd(SET_HWSCROLL_OFF)  # turn off hardware scroll per SSD1306 datasheet
+        if not direction:
+            self.write_cmd(SET_HWSCROLL_VL)
+        else:
+            self.write_cmd(SET_HWSCROLL_VR)
+        self.write_cmd(0x00)            # dummy byte
+        self.write_cmd(0x00)            # start page = page 0
+        self.write_cmd(interval)        # interval
+        self.write_cmd(0x07)            # end page = page 7
+        self.write_cmd(offset)          # vertical offset per scroll
+        self.write_cmd(SET_HWSCROLL_ON) # activate scroll
 
 class SSD1306_I2C(SSD1306):
     def __init__(self, width, height, i2c, addr=0x3C, external_vcc=False):


### PR DESCRIPTION
Changes to be committed:
modified:   drivers/display/ssd1306.py

The scroll method in the MicroPython's ssd1306 class is based on FrameBuffer class's scroll().That may leave a footprint of the previous colors in the FrameBuffer.

By adopting the modified version of the ssd1306 class written by Tim Toliver, we add the following methods to the ssd1306 class:

- clear()：clear the OLED.
- hw_scroll_h(direction=True, interval=FRAMES_5):continuously scroll to right/left.
    - direction: True/False, scroll to right/left.
    - interval:
        - SSD1306.FRAMES_2
        - SSD1306.FRAMES_3
        - SSD130.FRAMES_4
        - SSD130.FRAMES_5
        - SSD130.FRAMES_25
        - SSD130.FRAMES_64
        - SSD130.FRAMES_128
        - SSD130.FRAMES_256
        One frame approximate 9.19ms.
- hw_scroll_diag(direction=True, interval=FRAMES_5, offset=1):continuously scroll to up-right/up-left.
    - offset: vertical offset per scroll.
- hw_scroll_off()：stop scrolling.