### PR TITLE
rp2/rp2_flash.c: Disable IRQs before calling flash_erase/program.

### DIFF
--- a/ports/rp2/rp2_flash.c
+++ b/ports/rp2/rp2_flash.c
@@ -95,12 +95,20 @@ STATIC mp_obj_t rp2_flash_writeblocks(size_t n_args, const mp_obj_t *args) {
     mp_buffer_info_t bufinfo;
     mp_get_buffer_raise(args[2], &bufinfo, MP_BUFFER_READ);
     if (n_args == 3) {
+        // Flash erase/program must run in an atomic section because the XIP bit gets disabled.
+        mp_uint_t atomic_state = MICROPY_BEGIN_ATOMIC_SECTION();
         flash_range_erase(self->flash_base + offset, bufinfo.len);
+        MICROPY_END_ATOMIC_SECTION(atomic_state);
+        MICROPY_EVENT_POLL_HOOK
         // TODO check return value
     } else {
         offset += mp_obj_get_int(args[3]);
     }
+    // Flash erase/program must run in an atomic section because the XIP bit gets disabled.
+    mp_uint_t atomic_state = MICROPY_BEGIN_ATOMIC_SECTION();
     flash_range_program(self->flash_base + offset, bufinfo.buf, bufinfo.len);
+    MICROPY_END_ATOMIC_SECTION(atomic_state);
+    MICROPY_EVENT_POLL_HOOK
     // TODO check return value
     return mp_const_none;
 }
@@ -122,7 +130,10 @@ STATIC mp_obj_t rp2_flash_ioctl(mp_obj_t self_in, mp_obj_t cmd_in, mp_obj_t arg_
             return MP_OBJ_NEW_SMALL_INT(BLOCK_SIZE_BYTES);
         case MP_BLOCKDEV_IOCTL_BLOCK_ERASE: {
             uint32_t offset = mp_obj_get_int(arg_in) * BLOCK_SIZE_BYTES;
+            // Flash erase/program must run in an atomic section because the XIP bit gets disabled.
+            mp_uint_t atomic_state = MICROPY_BEGIN_ATOMIC_SECTION();
             flash_range_erase(self->flash_base + offset, BLOCK_SIZE_BYTES);
+            MICROPY_END_ATOMIC_SECTION(atomic_state);
             // TODO check return value
             return MP_OBJ_NEW_SMALL_INT(0);
         }


### PR DESCRIPTION
Flash erase/program functions disable the XIP bit. If any code runs from flash at the same time (ex an IRQ or code it calls) it will fail and cause a lockup.

Example using pio example + file write:

```Python
import time
from machine import Pin
import rp2


@rp2.asm_pio(set_init=rp2.PIO.OUT_LOW)
def blink_1hz():
    # fmt: off
    # Cycles: 1 + 1 + 6 + 32 * (30 + 1) = 1000
    irq(rel(0))
    set(pins, 1)
    set(x, 31)                  [5]
    label("delay_high")
    nop()                       [29]
    jmp(x_dec, "delay_high")

    # Cycles: 1 + 7 + 32 * (30 + 1) = 1000
    set(pins, 0)
    set(x, 31)                  [6]
    label("delay_low")
    nop()                       [29]
    jmp(x_dec, "delay_low")
    # fmt: on


# Create the StateMachine with the blink_1hz program, outputting on Pin(25).
sm = rp2.StateMachine(0, blink_1hz, freq=4000, set_base=Pin(25))

# Set the IRQ handler to print the millisecond timestamp.
sm.irq(lambda p: print("SM IRQ:", time.ticks_ms()))

# Start the StateMachine.
sm.active(1)

# buffer must be large enough to make sure it triggers erase/program each time.
f = open("test.txt", "w")
buf = b'a' * 16 * 1024  
for i in range(0, 10):
    f.write(buf)
f.close()
```

Output:
```
<irq>
True
SM IRQ: 5417
16384
16384
```

Followed by a lockup.