### PR TITLE
STM32: Double flash filesystem space on NUCLEO_H743ZI and NUCLEO_H743ZI2 boards

### DIFF
--- a/ports/stm32/boards/NUCLEO_H743ZI/mpconfigboard.mk
+++ b/ports/stm32/boards/NUCLEO_H743ZI/mpconfigboard.mk
@@ -9,12 +9,12 @@ AF_FILE = boards/stm32h743_af.csv
 ifeq ($(USE_MBOOT),1)
 # When using Mboot all the text goes together after the filesystem
 LD_FILES = boards/stm32h743.ld boards/common_blifs.ld
-TEXT0_ADDR = 0x08040000
+TEXT0_ADDR = 0x08060000
 else
 # When not using Mboot the ISR text goes first, then the rest after the filesystem
 LD_FILES = boards/stm32h743.ld boards/common_ifs.ld
 TEXT0_ADDR = 0x08000000
-TEXT1_ADDR = 0x08040000
+TEXT1_ADDR = 0x08060000
 endif
 
 # MicroPython settings

--- a/ports/stm32/boards/NUCLEO_H743ZI2/mpconfigboard.mk
+++ b/ports/stm32/boards/NUCLEO_H743ZI2/mpconfigboard.mk
@@ -1,1 +1,5 @@
 include boards/NUCLEO_H743ZI/mpconfigboard.mk
+
+# MicroPython settings
+# Include LittleFS
+MICROPY_VFS_LFS2 = 1

--- a/ports/stm32/boards/stm32h743.ld
+++ b/ports/stm32/boards/stm32h743.ld
@@ -7,8 +7,8 @@ MEMORY
 {
     FLASH (rx)      : ORIGIN = 0x08000000, LENGTH = 2048K
     FLASH_ISR (rx)  : ORIGIN = 0x08000000, LENGTH = 128K    /* sector 0, 128K */
-    FLASH_FS (r)    : ORIGIN = 0x08020000, LENGTH = 128K    /* sector 1, 128K */
-    FLASH_TEXT (rx) : ORIGIN = 0x08040000, LENGTH = 1792K   /* sectors 6*128 + 8*128 */
+    FLASH_FS (r)    : ORIGIN = 0x08020000, LENGTH = 256K    /* sector 1, 128K */
+    FLASH_TEXT (rx) : ORIGIN = 0x08060000, LENGTH = 1654K   /* sectors 6*128 + 8*128 */
     DTCM (xrw)      : ORIGIN = 0x20000000, LENGTH = 128K    /* Used for storage cache */
     RAM (xrw)       : ORIGIN = 0x24000000, LENGTH = 512K    /* AXI SRAM */    
     RAM_D2 (xrw)    : ORIGIN = 0x30000000, LENGTH = 288K

--- a/ports/stm32/boards/stm32h743.ld
+++ b/ports/stm32/boards/stm32h743.ld
@@ -8,7 +8,7 @@ MEMORY
     FLASH (rx)      : ORIGIN = 0x08000000, LENGTH = 2048K
     FLASH_ISR (rx)  : ORIGIN = 0x08000000, LENGTH = 128K    /* sector 0, 128K */
     FLASH_FS (r)    : ORIGIN = 0x08020000, LENGTH = 256K    /* sector 1, 128K */
-    FLASH_TEXT (rx) : ORIGIN = 0x08060000, LENGTH = 1654K   /* sectors 6*128 + 8*128 */
+    FLASH_TEXT (rx) : ORIGIN = 0x08060000, LENGTH = 1654K   /* sectors 5*128 + 8*128 */
     DTCM (xrw)      : ORIGIN = 0x20000000, LENGTH = 128K    /* Used for storage cache */
     RAM (xrw)       : ORIGIN = 0x24000000, LENGTH = 512K    /* AXI SRAM */    
     RAM_D2 (xrw)    : ORIGIN = 0x30000000, LENGTH = 288K

--- a/ports/stm32/flashbdev.c
+++ b/ports/stm32/flashbdev.c
@@ -109,6 +109,8 @@ STATIC byte flash_cache_mem[0x4000] __attribute__((aligned(4))); // 16k
 #define FLASH_SECTOR_SIZE_MAX (0x20000) // 128k max
 #define FLASH_MEM_SEG1_START_ADDR (0x08020000) // sector 1
 #define FLASH_MEM_SEG1_NUM_BLOCKS (256) // Sector 1: 128k / 512b = 256 blocks
+#define FLASH_MEM_SEG2_START_ADDR (0x08040000) // sector 2
+#define FLASH_MEM_SEG2_NUM_BLOCKS (256) // Sector 2: 128k / 512b = 256 blocks
 
 #elif defined(STM32L432xx) || \
     defined(STM32L451xx) || defined(STM32L452xx) || defined(STM32L462xx) || \


### PR DESCRIPTION
This PR extends the flash filesystem space to 256K on STM32 NUCLEO_H743ZI* boards.

It also adds LittleFS to the NUCLEO_H743ZI2 board.