### PR TITLE
esp32/machine_bitstream.c: Remove dead code.

### DIFF
--- a/ports/esp32/machine_bitstream.c
+++ b/ports/esp32/machine_bitstream.c
@@ -69,13 +69,11 @@ void IRAM_ATTR machine_bitstream_high_low(mp_hal_pin_obj_t pin, uint32_t *timing
             GPIO_REG_WRITE(gpio_reg_set, pin_mask);
             uint32_t start_ticks = mp_hal_ticks_cpu();
             uint32_t *t = &timing_ns[b >> 6 & 2];
-            uint32_t end_ticks = start_ticks + t[0];
             while (mp_hal_ticks_cpu() - start_ticks < t[0]) {
                 ;
             }
             GPIO_REG_WRITE(gpio_reg_clear, pin_mask);
             b <<= 1;
-            end_ticks += t[1];
             while (mp_hal_ticks_cpu() - start_ticks < t[1]) {
                 ;
             }

--- a/ports/esp8266/machine_bitstream.c
+++ b/ports/esp8266/machine_bitstream.c
@@ -57,13 +57,11 @@ void machine_bitstream_high_low(mp_hal_pin_obj_t pin, uint32_t *timing_ns, const
             GPIO_REG_WRITE(GPIO_OUT_W1TS_ADDRESS, pin_mask);
             uint32_t start_ticks = mp_hal_ticks_cpu();
             uint32_t *t = &timing_ns[b >> 6 & 2];
-            uint32_t end_ticks = start_ticks + t[0];
             while (mp_hal_ticks_cpu() - start_ticks < t[0]) {
                 ;
             }
             GPIO_REG_WRITE(GPIO_OUT_W1TC_ADDRESS, pin_mask);
             b <<= 1;
-            end_ticks += t[1];
             while (mp_hal_ticks_cpu() - start_ticks < t[1]) {
                 ;
             }


### PR DESCRIPTION
Same on esp8266 -- I had originally planned to use end_ticks, but it was faster to adjust t[1] to be the whole period.

The compiler was optimising this out already so it's a no-op change. Checked that both esp8266 and esp32 generate the exact same code with and without this change (on esp8266 hte binary has the same sha1, on esp32 the disassembly for this function is the same).

Thanks @robert-hh for pointing this out.