### PR TITLE
drivers/neopixel/neopixel.py: Optimize fill() and reduce code size.

### DIFF
--- a/drivers/neopixel/neopixel.py
+++ b/drivers/neopixel/neopixel.py
@@ -37,8 +37,11 @@ class NeoPixel:
         return tuple(self.buf[offset + self.ORDER[i]] for i in range(self.bpp))
 
     def fill(self, color):
-        for i in range(self.n):
-            self[i] = color
+        for i in range(self.bpp):
+            c = color[i]
+            b = self.buf
+            for j in range(self.ORDER[i], len(self.buf), self.bpp):
+                b[j] = c
 
     def write(self):
         bitstream(self.pin, _BITSTREAM_TYPE_HIGH_LOW, self.timing, self.buf)

--- a/drivers/neopixel/neopixel.py
+++ b/drivers/neopixel/neopixel.py
@@ -1,15 +1,11 @@
 # NeoPixel driver for MicroPython
 # MIT license; Copyright (c) 2016 Damien P. George, 2021 Jim Mussared
 
-from micropython import const
 from machine import bitstream
-
-_BITSTREAM_TYPE_HIGH_LOW = const(0)
-_TIMING_WS2818_800 = (400, 850, 800, 450)
-_TIMING_WS2818_400 = (800, 1700, 1600, 900)
 
 
 class NeoPixel:
+    # G R B W
     ORDER = (1, 0, 2, 3)
 
     def __init__(self, pin, n, bpp=3, timing=1):
@@ -18,8 +14,10 @@ class NeoPixel:
         self.bpp = bpp
         self.buf = bytearray(n * bpp)
         self.pin.init(pin.OUT)
+        # Timing arg can either be 1 for 800kHz or 0 for 400kHz,
+        # or a user-specified timing ns tuple (high_0, low_0, high_1, low_1).
         self.timing = (
-            (_TIMING_WS2818_800 if timing else _TIMING_WS2818_400)
+            ((400, 850, 800, 450) if timing else (800, 1700, 1600, 900))
             if isinstance(timing, int)
             else timing
         )
@@ -27,21 +25,22 @@ class NeoPixel:
     def __len__(self):
         return self.n
 
-    def __setitem__(self, index, val):
-        offset = index * self.bpp
+    def __setitem__(self, i, v):
+        offset = i * self.bpp
         for i in range(self.bpp):
-            self.buf[offset + self.ORDER[i]] = val[i]
+            self.buf[offset + self.ORDER[i]] = v[i]
 
-    def __getitem__(self, index):
-        offset = index * self.bpp
+    def __getitem__(self, i):
+        offset = i * self.bpp
         return tuple(self.buf[offset + self.ORDER[i]] for i in range(self.bpp))
 
-    def fill(self, color):
+    def fill(self, v):
+        b = self.buf
         for i in range(self.bpp):
-            c = color[i]
-            b = self.buf
+            c = v[i]
             for j in range(self.ORDER[i], len(self.buf), self.bpp):
                 b[j] = c
 
     def write(self):
-        bitstream(self.pin, _BITSTREAM_TYPE_HIGH_LOW, self.timing, self.buf)
+        # BITSTREAM_TYPE_HIGH_LOW = 0
+        bitstream(self.pin, 0, self.timing, self.buf)


### PR DESCRIPTION
@robert-hh pointed out the subtle behavior of the fill method here: https://github.com/micropython/micropython/commit/71f4faac2732d932dcc03bdbc9f80434e5757edb#commitcomment-55180052

Although it works, this can be optimized significantly.

For a 200-LED RGB strip, a single fill() was taking 14.4ms on PYBV11 (12.4ms on SF6). It now takes 2.0ms (and 1.5ms). For comparison a write takes 1.1ms. This costs 40 bytes (bytecode).

The second commit does some renaming to reduce generated code size by 83 bytes, so the net impact of this PR is negative.