### PR TITLE
mimxrt: Add the bitstream class to machine.

### DIFF
--- a/ports/mimxrt/Makefile
+++ b/ports/mimxrt/Makefile
@@ -150,6 +150,7 @@ SRC_C += \
 	machine_spi.c \
 	machine_timer.c \
 	machine_uart.c \
+	machine_bitstream.c \
 	mimxrt_flash.c \
 	modutime.c \
 	modmachine.c \

--- a/ports/mimxrt/machine_bitstream.c
+++ b/ports/mimxrt/machine_bitstream.c
@@ -1,0 +1,75 @@
+/*
+ * This file is part of the MicroPython project, http://micropython.org/
+ *
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2021 Jim Mussared
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+// This is a translation of the cycle counter implementation in ports/stm32/machine_bitstream.c.
+
+#include "py/mpconfig.h"
+#include "py/mphal.h"
+
+#if MICROPY_PY_MACHINE_BITSTREAM
+
+#define NS_TICKS_OVERHEAD (6)
+
+void machine_bitstream_high_low(mp_hal_pin_obj_t pin, uint32_t *timing_ns, const uint8_t *buf, size_t len) __attribute__((section(".ram_functions")));
+void machine_bitstream_high_low(mp_hal_pin_obj_t pin, uint32_t *timing_ns, const uint8_t *buf, size_t len) {
+    uint32_t fcpu_mhz = mp_hal_get_cpu_freq() / 1000000;
+    // Convert ns to us ticks [high_time_0, period_0, high_time_1, period_1].
+    for (size_t i = 0; i < 4; ++i) {
+        timing_ns[i] = fcpu_mhz * timing_ns[i] / 1000;
+        if (timing_ns[i] > NS_TICKS_OVERHEAD) {
+            timing_ns[i] -= NS_TICKS_OVERHEAD;
+        }
+        if (i % 2 == 1) {
+            // Convert low_time to period (i.e. add high_time).
+            timing_ns[i] += timing_ns[i - 1];
+        }
+    }
+    // Enable the CPU cycle counter, which is not always enable
+    mp_hal_ticks_cpu_init();
+
+    uint32_t irq_state = mp_hal_quiet_timing_enter();
+
+    for (size_t i = 0; i < len; ++i) {
+        uint8_t b = buf[i];
+        for (size_t j = 0; j < 8; ++j) {
+            uint32_t start_ticks = mp_hal_ticks_cpu();
+            mp_hal_pin_high(pin);
+            uint32_t *t = &timing_ns[b >> 6 & 2];
+            while ((mp_hal_ticks_cpu() - start_ticks) < t[0]) {
+                ;
+            }
+            mp_hal_pin_low(pin);
+            b <<= 1;
+            while ((mp_hal_ticks_cpu() - start_ticks) < t[1]) {
+                ;
+            }
+        }
+    }
+
+    mp_hal_quiet_timing_exit(irq_state);
+}
+
+#endif // MICROPY_PY_MACHINE_BITSTREAM

--- a/ports/mimxrt/modmachine.c
+++ b/ports/mimxrt/modmachine.c
@@ -31,6 +31,7 @@
 #include "extmod/machine_pulse.h"
 #include "extmod/machine_signal.h"
 #include "extmod/machine_spi.h"
+#include "extmod/machine_bitstream.h"
 #include "led.h"
 #include "pin.h"
 #include "modmachine.h"
@@ -45,7 +46,7 @@ STATIC mp_obj_t machine_reset(void) {
 MP_DEFINE_CONST_FUN_OBJ_0(machine_reset_obj, machine_reset);
 
 STATIC mp_obj_t machine_freq(void) {
-    return MP_OBJ_NEW_SMALL_INT(CLOCK_GetFreq(kCLOCK_CpuClk));
+    return MP_OBJ_NEW_SMALL_INT(mp_hal_get_cpu_freq());
 }
 MP_DEFINE_CONST_FUN_OBJ_0(machine_freq_obj, machine_freq);
 
@@ -95,6 +96,9 @@ STATIC const mp_rom_map_elem_t machine_module_globals_table[] = {
     { MP_ROM_QSTR(MP_QSTR_enable_irq),          MP_ROM_PTR(&machine_enable_irq_obj) },
 
     { MP_ROM_QSTR(MP_QSTR_time_pulse_us),       MP_ROM_PTR(&machine_time_pulse_us_obj) },
+    #if MICROPY_PY_MACHINE_BITSTREAM
+    { MP_ROM_QSTR(MP_QSTR_bitstream),           MP_ROM_PTR(&machine_bitstream_obj) },
+    #endif
 };
 STATIC MP_DEFINE_CONST_DICT(machine_module_globals, machine_module_globals_table);
 

--- a/ports/mimxrt/mpconfigport.h
+++ b/ports/mimxrt/mpconfigport.h
@@ -131,6 +131,7 @@ uint32_t trng_random_u32(void);
 #define MICROPY_PY_MACHINE_SOFTSPI          (1)
 #define MICROPY_PY_FRAMEBUF                 (1)
 #define MICROPY_PY_ONEWIRE                  (1)
+#define MICROPY_PY_MACHINE_BITSTREAM        (1)
 
 // Use VfsLfs2's types for fileio/textio
 #define mp_type_fileio mp_type_vfs_lfs2_fileio

--- a/ports/mimxrt/mphalport.h
+++ b/ports/mimxrt/mphalport.h
@@ -30,6 +30,7 @@
 #include <stdint.h>
 #include "ticks.h"
 #include "pin.h"
+#include "fsl_clock.h"
 
 #define MP_HAL_PIN_FMT                  "%q"
 
@@ -39,8 +40,8 @@
 #define mp_hal_pin_input(p) machine_pin_set_mode(p, PIN_MODE_IN);
 #define mp_hal_pin_output(p) machine_pin_set_mode(p, PIN_MODE_OUT);
 #define mp_hal_pin_open_drain(p) machine_pin_set_mode(p, PIN_MODE_OPEN_DRAIN);
-#define mp_hal_pin_high(p) (GPIO_PinWrite(p->gpio, p->pin, 1U))
-#define mp_hal_pin_low(p) (GPIO_PinWrite(p->gpio, p->pin, 0U))
+#define mp_hal_pin_high(p) (p->gpio->DR_SET = 1 << p->pin)
+#define mp_hal_pin_low(p) (p->gpio->DR_CLEAR = 1 << p->pin)
 #define mp_hal_pin_write(p, value) (GPIO_PinWrite(p->gpio, p->pin, value))
 #define mp_hal_pin_toggle(p) (GPIO_PortToggle(p->gpio, (1 << p->pin)))
 #define mp_hal_pin_read(p) (GPIO_PinReadPadStatus(p->gpio, p->pin))
@@ -72,8 +73,16 @@ static inline void mp_hal_delay_us(mp_uint_t us) {
 
 #define mp_hal_delay_us_fast(us) mp_hal_delay_us(us)
 
+static inline void mp_hal_ticks_cpu_init(void) {
+    DWT->CTRL |= DWT_CTRL_CYCCNTENA_Msk;
+}
+
 static inline mp_uint_t mp_hal_ticks_cpu(void) {
-    return 0;
+    return DWT->CYCCNT;
+}
+
+static inline mp_uint_t mp_hal_get_cpu_freq(void) {
+    return CLOCK_GetCpuClkFreq();
 }
 
 


### PR DESCRIPTION
Following the code example for ESP32 of @jimmo. 

Tested with Teensy 4.0, MIMXRT1010_EVK, MIMXRT1020_EVK and MINXRT1050_EVKB.
The timing is pretty acceptable. The high phase is about 10ns longer, the low phase about 10 ns shorter than set. The timing was checked with an oscilloscope. Neopixel devices also worked well using the neopixel.py module.

Implementation note: 
It uses the CPU clock cycle counter register for the timing. Since mp_hal_ticks_cpu() was implemented, time.ticks_cpu() now returns reasonable values as well. The internal functions mp_hal_pin_high() and mp_hal_pin_low() were changed for symmetry of their timing.
