### PR TITLE
ports/zephyr: Add board and features 

### DIFF
--- a/ports/zephyr/boards/beagleconnect_freedom.conf
+++ b/ports/zephyr/boards/beagleconnect_freedom.conf
@@ -1,0 +1,7 @@
+# Flash drivers
+CONFIG_FLASH=y
+CONFIG_FLASH_MAP=y
+
+# Hardware features
+CONFIG_I2C=y
+CONFIG_SPI=y


### PR DESCRIPTION
Add BeagleConnect Freedom board: https://github.com/jadonk/beagleconnect and enable hardware features like SPI and I2C for
interfacing.
