### PR TITLE
tools/pyboard.py: Remove Python 3.9 dependency.

### DIFF
--- a/tools/pyboard.py
+++ b/tools/pyboard.py
@@ -673,10 +673,17 @@ def main():
         action="store_false",
         dest="follow",
     )
-    cmd_parser.add_argument(
-        "--no-exclusive",
+    group = cmd_parser.add_mutually_exclusive_group()
+    group.add_argument(
+        "--exclusive",
         action="store_true",
-        help="Do not try to open the serial device for exclusive access.",
+        default=True,
+        help="Open the serial device for exclusive access.",
+    )
+    group.add_argument(
+        "--no-exclusive",
+        action="store_false",
+        dest="exclusive",
     )
     cmd_parser.add_argument(
         "-f",
@@ -691,7 +698,7 @@ def main():
     # open the connection to the pyboard
     try:
         pyb = Pyboard(
-            args.device, args.baudrate, args.user, args.password, args.wait, not args.no_exclusive
+            args.device, args.baudrate, args.user, args.password, args.wait, args.exclusive
         )
     except PyboardError as er:
         print(er)

--- a/tools/pyboard.py
+++ b/tools/pyboard.py
@@ -655,11 +655,17 @@ def main():
         type=int,
         help="seconds to wait for USB connected board to become available",
     )
-    cmd_parser.add_argument(
+    group = cmd_parser.add_mutually_exclusive_group()
+    group.add_argument(
         "--soft-reset",
         default=True,
-        action=argparse.BooleanOptionalAction,
+        action="store_true",
         help="Whether to perform a soft reset when connecting to the board.",
+    )
+    group.add_argument(
+        "--no-soft-reset",
+        action="store_false",
+        dest="soft_reset",
     )
     group = cmd_parser.add_mutually_exclusive_group()
     group.add_argument(

--- a/tools/pyboard.py
+++ b/tools/pyboard.py
@@ -665,12 +665,13 @@ def main():
     group.add_argument(
         "--follow",
         action="store_true",
+        default=None,
         help="follow the output after running the scripts [default if no scripts given]",
     )
     group.add_argument(
         "--no-follow",
-        action="store_true",
-        help="Do not follow the output after running the scripts.",
+        action="store_false",
+        dest="follow",
     )
     cmd_parser.add_argument(
         "--no-exclusive",
@@ -709,13 +710,13 @@ def main():
 
         def execbuffer(buf):
             try:
-                if args.no_follow:
-                    pyb.exec_raw_no_follow(buf)
-                    ret_err = None
-                else:
+                if args.follow is None or args.follow:
                     ret, ret_err = pyb.exec_raw(
                         buf, timeout=None, data_consumer=stdout_write_bytes
                     )
+                else:
+                    pyb.exec_raw_no_follow(buf)
+                    ret_err = None
             except PyboardError as er:
                 print(er)
                 pyb.close()

--- a/tools/pyboard.py
+++ b/tools/pyboard.py
@@ -672,7 +672,7 @@ def main():
         action="store_true",
         help="Do not follow the output after running the scripts.",
     )
-    group.add_argument(
+    cmd_parser.add_argument(
         "--no-exclusive",
         action="store_true",
         help="Do not try to open the serial device for exclusive access.",

--- a/tools/pyboard.py
+++ b/tools/pyboard.py
@@ -655,13 +655,13 @@ def main():
         type=int,
         help="seconds to wait for USB connected board to become available",
     )
-    group = cmd_parser.add_mutually_exclusive_group()
-    group.add_argument(
+    cmd_parser.add_argument(
         "--soft-reset",
         default=True,
         action=argparse.BooleanOptionalAction,
         help="Whether to perform a soft reset when connecting to the board.",
     )
+    group = cmd_parser.add_mutually_exclusive_group()
     group.add_argument(
         "--follow",
         action="store_true",

--- a/tools/pyboard.py
+++ b/tools/pyboard.py
@@ -660,7 +660,7 @@ def main():
         "--soft-reset",
         default=True,
         action="store_true",
-        help="Whether to perform a soft reset when connecting to the board.",
+        help="Whether to perform a soft reset when connecting to the board [default]",
     )
     group.add_argument(
         "--no-soft-reset",
@@ -684,7 +684,7 @@ def main():
         "--exclusive",
         action="store_true",
         default=True,
-        help="Open the serial device for exclusive access.",
+        help="Open the serial device for exclusive access [default]",
     )
     group.add_argument(
         "--no-exclusive",


### PR DESCRIPTION
Changes the use of BooleanOptionalAction to a way that works on previous Python versions.

Fixes #7700 and https://github.com/micropython/micropython/pull/7459#issuecomment-876421056