### PR TITLE
stm32/wb55: Add usb/bluetooth transparent mode to stm32wb55.

### DIFF
--- a/ports/stm32/modstm.c
+++ b/ports/stm32/modstm.c
@@ -50,6 +50,9 @@ STATIC const mp_rom_map_elem_t stm_module_globals_table[] = {
     { MP_ROM_QSTR(MP_QSTR_rfcore_status), MP_ROM_PTR(&rfcore_status_obj) },
     { MP_ROM_QSTR(MP_QSTR_rfcore_fw_version), MP_ROM_PTR(&rfcore_fw_version_obj) },
     { MP_ROM_QSTR(MP_QSTR_rfcore_sys_hci), MP_ROM_PTR(&rfcore_sys_hci_obj) },
+    #if MICROPY_HW_STM32WB_TRANSPARENT_MODE
+    { MP_ROM_QSTR(MP_QSTR_rfcore_transparent), MP_ROM_PTR(&rfcore_transparent_obj) },
+    #endif
     #endif
 };
 

--- a/ports/stm32/rfcore.c
+++ b/ports/stm32/rfcore.c
@@ -45,6 +45,8 @@
 #if MICROPY_BLUETOOTH_NIMBLE
 // For mp_bluetooth_nimble_hci_uart_wfi
 #include "nimble/nimble_npl.h"
+// For mp_bluetooth_nimble_ble_state
+#include "modbluetooth_nimble.h"
 #else
 #error "STM32WB must use NimBLE."
 #endif
@@ -261,9 +263,6 @@ void ipcc_init(uint32_t irq_pri) {
     // Enable receive IRQ on the BLE channel.
     LL_C1_IPCC_EnableIT_RXO(IPCC);
     LL_C1_IPCC_DisableReceiveChannel(IPCC, LL_IPCC_CHANNEL_1 | LL_IPCC_CHANNEL_2 | LL_IPCC_CHANNEL_3 | LL_IPCC_CHANNEL_4 | LL_IPCC_CHANNEL_5 | LL_IPCC_CHANNEL_6);
-    #if !MICROPY_HW_STM32WB_TRANSPARENT_MODE
-    LL_C1_IPCC_EnableReceiveChannel(IPCC, IPCC_CH_BLE);
-    #endif
     NVIC_SetPriority(IPCC_C1_RX_IRQn, irq_pri);
     HAL_NVIC_EnableIRQ(IPCC_C1_RX_IRQn);
 
@@ -449,12 +448,10 @@ STATIC void tl_check_msg(volatile tl_list_node_t *head, unsigned int ch, parse_h
         // Clear receive channel (allows RF core to send more data to us).
         LL_C1_IPCC_ClearFlag_CHx(IPCC, ch);
 
-        #if !MICROPY_HW_STM32WB_TRANSPARENT_MODE
-        if (ch == IPCC_CH_BLE) {
+        if (ch == IPCC_CH_BLE && (mp_bluetooth_nimble_ble_state != MP_BLUETOOTH_NIMBLE_BLE_STATE_OFF)) {
             // Renable IRQs for BLE now that we've cleared the flag.
             LL_C1_IPCC_EnableReceiveChannel(IPCC, IPCC_CH_BLE);
         }
-        #endif
     }
 }
 
@@ -589,6 +586,10 @@ static const struct {
 void rfcore_ble_init(void) {
     DEBUG_printf("rfcore_ble_init\n");
 
+    if (mp_bluetooth_nimble_ble_state != MP_BLUETOOTH_NIMBLE_BLE_STATE_OFF) {
+        LL_C1_IPCC_EnableReceiveChannel(IPCC, IPCC_CH_BLE);
+    }
+
     // Clear any outstanding messages from ipcc_init.
     tl_check_msg(&ipcc_mem_sys_queue, IPCC_CH_SYS, NULL);
 
@@ -646,7 +647,7 @@ void rfcore_ble_hci_cmd(size_t len, const uint8_t *src) {
                 break;
             }
             #if MICROPY_PY_BLUETOOTH && MICROPY_BLUETOOTH_NIMBLE
-            if (LL_C1_IPCC_IsEnabledReceiveChannel(IPCC, IPCC_CH_BLE)) {
+            if (mp_bluetooth_nimble_ble_state != MP_BLUETOOTH_NIMBLE_BLE_STATE_OFF) {
                 mp_bluetooth_nimble_hci_uart_wfi();
             }
             #endif

--- a/ports/stm32/rfcore.h
+++ b/ports/stm32/rfcore.h
@@ -41,5 +41,7 @@ void rfcore_end_flash_erase(void);
 MP_DECLARE_CONST_FUN_OBJ_0(rfcore_status_obj);
 MP_DECLARE_CONST_FUN_OBJ_1(rfcore_fw_version_obj);
 MP_DECLARE_CONST_FUN_OBJ_VAR_BETWEEN(rfcore_sys_hci_obj);
-
+#if MICROPY_HW_STM32WB_TRANSPARENT_MODE
+MP_DECLARE_CONST_FUN_OBJ_0(rfcore_transparent_obj);
+#endif
 #endif // MICROPY_INCLUDED_STM32_RFCORE_H

--- a/ports/stm32/rfcore.h
+++ b/ports/stm32/rfcore.h
@@ -34,6 +34,9 @@ void rfcore_ble_init(void);
 void rfcore_ble_hci_cmd(size_t len, const uint8_t *src);
 void rfcore_ble_check_msg(int (*cb)(void *, const uint8_t *, size_t), void *env);
 void rfcore_ble_set_txpower(uint8_t level);
+#if MICROPY_HW_STM32WB_TRANSPARENT_MODE
+void rfcore_ble_disable_ble_rx_interrupt(void);
+#endif
 
 void rfcore_start_flash_erase(void);
 void rfcore_end_flash_erase(void);


### PR DESCRIPTION
This PR allows the usage of a stm32wb55 board (eg. nucleo or dongle) as a USB/UART Bluetooth HCI Dongle. This allows it to be used to provide bluetooth functionality with the unix micropython port.

This functionality was written by @jimmo, I've sinply debugged to resolve some glitches and submitted it here.

This will disable normal BLE Stack usage and allow forwarding all HCI from stdin to BLE code.

To enable, build with the following define.
#define MICROPY_HW_STM32WB_TRANSPARENT_MODE (1)

Alternatively, it can be built with
```
cd micropython/ports/stm32
make CFLAGS_EXTRA="-DMICROPY_HW_STM32WB_TRANSPARENT_MODE=1" BOARD=USBDONGLE_WB55'",
```

When running on the board, it can be started with:
``` python
import stm
stm.rfcore_transparent()
```
or this can be added to main.py to make it start automatically.