### PR TITLE
Add "u" prefix in repr() of usys objects.

### DIFF
--- a/extmod/vfs_fat_file.c
+++ b/extmod/vfs_fat_file.c
@@ -66,7 +66,7 @@ typedef struct _pyb_file_obj_t {
 
 STATIC void file_obj_print(const mp_print_t *print, mp_obj_t self_in, mp_print_kind_t kind) {
     (void)kind;
-    mp_printf(print, "<io.%s %p>", mp_obj_get_type_str(self_in), MP_OBJ_TO_PTR(self_in));
+    mp_printf(print, "<uio.%s %p>", mp_obj_get_type_str(self_in), MP_OBJ_TO_PTR(self_in));
 }
 
 STATIC mp_uint_t file_obj_read(mp_obj_t self_in, void *buf, mp_uint_t size, int *errcode) {

--- a/extmod/vfs_lfsx_file.c
+++ b/extmod/vfs_lfsx_file.c
@@ -41,7 +41,7 @@ STATIC void MP_VFS_LFSx(check_open)(MP_OBJ_VFS_LFSx_FILE * self) {
 STATIC void MP_VFS_LFSx(file_print)(const mp_print_t * print, mp_obj_t self_in, mp_print_kind_t kind) {
     (void)self_in;
     (void)kind;
-    mp_printf(print, "<io.%s>", mp_obj_get_type_str(self_in));
+    mp_printf(print, "<uio.%s>", mp_obj_get_type_str(self_in));
 }
 
 mp_obj_t MP_VFS_LFSx(file_open)(mp_obj_t self_in, mp_obj_t path_in, mp_obj_t mode_in) {

--- a/extmod/vfs_posix_file.c
+++ b/extmod/vfs_posix_file.c
@@ -57,7 +57,7 @@ STATIC void check_fd_is_open(const mp_obj_vfs_posix_file_t *o) {
 STATIC void vfs_posix_file_print(const mp_print_t *print, mp_obj_t self_in, mp_print_kind_t kind) {
     (void)kind;
     mp_obj_vfs_posix_file_t *self = MP_OBJ_TO_PTR(self_in);
-    mp_printf(print, "<io.%s %d>", mp_obj_get_type_str(self_in), self->fd);
+    mp_printf(print, "<uio.%s %d>", mp_obj_get_type_str(self_in), self->fd);
 }
 
 mp_obj_t mp_vfs_posix_file_open(const mp_obj_type_t *type, mp_obj_t file_in, mp_obj_t mode_in) {
@@ -82,7 +82,7 @@ mp_obj_t mp_vfs_posix_file_open(const mp_obj_type_t *type, mp_obj_t file_in, mp_
                 mode_rw = O_RDWR;
                 break;
                 #if MICROPY_PY_IO_FILEIO
-            // If we don't have io.FileIO, then files are in text mode implicitly
+            // If we don't have uio.FileIO, then files are in text mode implicitly
             case 'b':
                 type = &mp_type_vfs_posix_fileio;
                 break;

--- a/py/mpconfig.h
+++ b/py/mpconfig.h
@@ -1139,7 +1139,7 @@ typedef double mp_float_t;
 #define MICROPY_PY_ATTRTUPLE (1)
 #endif
 
-// Whether to provide "collections" module
+// Whether to provide "ucollections" module
 #ifndef MICROPY_PY_COLLECTIONS
 #define MICROPY_PY_COLLECTIONS (1)
 #endif
@@ -1149,7 +1149,7 @@ typedef double mp_float_t;
 #define MICROPY_PY_COLLECTIONS_DEQUE (0)
 #endif
 
-// Whether to provide "collections.OrderedDict" type
+// Whether to provide "ucollections.OrderedDict" type
 #ifndef MICROPY_PY_COLLECTIONS_ORDEREDDICT
 #define MICROPY_PY_COLLECTIONS_ORDEREDDICT (0)
 #endif
@@ -1214,12 +1214,12 @@ typedef double mp_float_t;
 #define MICROPY_PY_GC_COLLECT_RETVAL (0)
 #endif
 
-// Whether to provide "io" module
+// Whether to provide "uio" module
 #ifndef MICROPY_PY_IO
 #define MICROPY_PY_IO (1)
 #endif
 
-// Whether to provide "io.IOBase" class to support user streams
+// Whether to provide "uio.IOBase" class to support user streams
 #ifndef MICROPY_PY_IO_IOBASE
 #define MICROPY_PY_IO_IOBASE (0)
 #endif
@@ -1235,73 +1235,73 @@ typedef double mp_float_t;
 #define MICROPY_PY_IO_RESOURCE_STREAM (0)
 #endif
 
-// Whether to provide "io.FileIO" class
+// Whether to provide "uio.FileIO" class
 #ifndef MICROPY_PY_IO_FILEIO
 #define MICROPY_PY_IO_FILEIO (0)
 #endif
 
-// Whether to provide "io.BytesIO" class
+// Whether to provide "uio.BytesIO" class
 #ifndef MICROPY_PY_IO_BYTESIO
 #define MICROPY_PY_IO_BYTESIO (1)
 #endif
 
-// Whether to provide "io.BufferedWriter" class
+// Whether to provide "uio.BufferedWriter" class
 #ifndef MICROPY_PY_IO_BUFFEREDWRITER
 #define MICROPY_PY_IO_BUFFEREDWRITER (0)
 #endif
 
-// Whether to provide "struct" module
+// Whether to provide "ustruct" module
 #ifndef MICROPY_PY_STRUCT
 #define MICROPY_PY_STRUCT (1)
 #endif
 
-// Whether to provide "sys" module
+// Whether to provide "usys" module
 #ifndef MICROPY_PY_SYS
 #define MICROPY_PY_SYS (1)
 #endif
 
-// Whether to provide "sys.maxsize" constant
+// Whether to provide "usys.maxsize" constant
 #ifndef MICROPY_PY_SYS_MAXSIZE
 #define MICROPY_PY_SYS_MAXSIZE (0)
 #endif
 
-// Whether to provide "sys.modules" dictionary
+// Whether to provide "usys.modules" dictionary
 #ifndef MICROPY_PY_SYS_MODULES
 #define MICROPY_PY_SYS_MODULES (1)
 #endif
 
-// Whether to provide "sys.exc_info" function
+// Whether to provide "usys.exc_info" function
 // Avoid enabling this, this function is Python2 heritage
 #ifndef MICROPY_PY_SYS_EXC_INFO
 #define MICROPY_PY_SYS_EXC_INFO (0)
 #endif
 
-// Whether to provide "sys.exit" function
+// Whether to provide "usys.exit" function
 #ifndef MICROPY_PY_SYS_EXIT
 #define MICROPY_PY_SYS_EXIT (1)
 #endif
 
-// Whether to provide "sys.atexit" function (MicroPython extension)
+// Whether to provide "usys.atexit" function (MicroPython extension)
 #ifndef MICROPY_PY_SYS_ATEXIT
 #define MICROPY_PY_SYS_ATEXIT (0)
 #endif
 
-// Whether to provide "sys.settrace" function
+// Whether to provide "usys.settrace" function
 #ifndef MICROPY_PY_SYS_SETTRACE
 #define MICROPY_PY_SYS_SETTRACE (0)
 #endif
 
-// Whether to provide "sys.getsizeof" function
+// Whether to provide "usys.getsizeof" function
 #ifndef MICROPY_PY_SYS_GETSIZEOF
 #define MICROPY_PY_SYS_GETSIZEOF (0)
 #endif
 
-// Whether to provide sys.{stdin,stdout,stderr} objects
+// Whether to provide usys.{stdin,stdout,stderr} objects
 #ifndef MICROPY_PY_SYS_STDFILES
 #define MICROPY_PY_SYS_STDFILES (0)
 #endif
 
-// Whether to provide sys.{stdin,stdout,stderr}.buffer object
+// Whether to provide usys.{stdin,stdout,stderr}.buffer object
 // This is implemented per-port
 #ifndef MICROPY_PY_SYS_STDIO_BUFFER
 #define MICROPY_PY_SYS_STDIO_BUFFER (0)

--- a/py/objstringio.c
+++ b/py/objstringio.c
@@ -48,7 +48,7 @@ STATIC void check_stringio_is_open(const mp_obj_stringio_t *o) {
 STATIC void stringio_print(const mp_print_t *print, mp_obj_t self_in, mp_print_kind_t kind) {
     (void)kind;
     mp_obj_stringio_t *self = MP_OBJ_TO_PTR(self_in);
-    mp_printf(print, self->base.type == &mp_type_stringio ? "<io.StringIO 0x%x>" : "<io.BytesIO 0x%x>", self);
+    mp_printf(print, self->base.type == &mp_type_stringio ? "<uio.StringIO 0x%x>" : "<uio.BytesIO 0x%x>", self);
 }
 
 STATIC mp_uint_t stringio_read(mp_obj_t o_in, void *buf, mp_uint_t size, int *errcode) {

--- a/shared/runtime/sys_stdio_mphal.c
+++ b/shared/runtime/sys_stdio_mphal.c
@@ -54,7 +54,7 @@ STATIC const sys_stdio_obj_t stdio_buffer_obj;
 
 void stdio_obj_print(const mp_print_t *print, mp_obj_t self_in, mp_print_kind_t kind) {
     sys_stdio_obj_t *self = MP_OBJ_TO_PTR(self_in);
-    mp_printf(print, "<io.FileIO %d>", self->fd);
+    mp_printf(print, "<uio.FileIO %d>", self->fd);
 }
 
 STATIC mp_uint_t stdio_read(mp_obj_t self_in, void *buf, mp_uint_t size, int *errcode) {

--- a/tests/extmod/vfs_fat_fileio1.py
+++ b/tests/extmod/vfs_fat_fileio1.py
@@ -50,7 +50,7 @@ uos.chdir("/ramdisk")
 
 # file IO
 f = open("foo_file.txt", "w")
-print(str(f)[:17], str(f)[-1:])
+print(str(f)[:18], str(f)[-1:])
 f.write("hello!")
 f.flush()
 f.close()

--- a/tests/extmod/vfs_fat_fileio1.py.exp
+++ b/tests/extmod/vfs_fat_fileio1.py.exp
@@ -1,4 +1,4 @@
-<io.TextIOWrapper >
+<uio.TextIOWrapper >
 True
 True
 True

--- a/tests/extmod/vfs_lfs_file.py.exp
+++ b/tests/extmod/vfs_lfs_file.py.exp
@@ -1,6 +1,6 @@
 test <class 'VfsLfs1'>
-<io.TextIOWrapper>
-<io.FileIO>
+<uio.TextIOWrapper>
+<uio.FileIO>
 open OSError
 littlefs
 littlefs
@@ -13,8 +13,8 @@ open OSError
 littlefs
 b'littlefsMORE'
 test <class 'VfsLfs2'>
-<io.TextIOWrapper>
-<io.FileIO>
+<uio.TextIOWrapper>
+<uio.FileIO>
 open OSError
 littlefs
 littlefs

--- a/tests/extmod/vfs_posix.py.exp
+++ b/tests/extmod/vfs_posix.py.exp
@@ -2,7 +2,7 @@
 True
 <class 'tuple'>
 <class 'list'>
-<io.TextIOWrapper 2>
+<uio.TextIOWrapper 2>
 hello
 ['test2']
 ['test2']


### PR DESCRIPTION
This follows up on @stinos' https://github.com/micropython/micropython/pull/6164.

This updates
```python
>>> repr(usys.stdout)
'<io.TextIOWrapper 1>'
```
to
```python
>>> repr(usys.stdout)
'<uio.TextIOWrapper 1>'
```
in order to match the module it is imported from.

I've also updated a few comments in mpconfig to add the prefix.

EDIT: Fix `tests/extmod/vfs_fat_fileio1.py` not passing.