### PR TITLE
stm32: LEGO_HUB_NO6 improvements to filesystem

### DIFF
--- a/ports/stm32/boards/LEGO_HUB_NO6/README.md
+++ b/ports/stm32/boards/LEGO_HUB_NO6/README.md
@@ -28,6 +28,26 @@ firmware at 0x08010000.  When mboot is installed it can be entered programatical
 via machine.bootloader(), or by holding down the left arrow button when powering
 on the Hub and waiting until the display says "B" before releasing the button.
 
+Backing up original Hub firmware
+--------------------------------
+
+Before install MicroPython it is advised to backup the original LEGO firmware that
+the Hub comes installed with.  To do this, enter the built-in bootloader by holding
+down the Bluetooth button for 5 seconds while powering up the Hub via USB.  Then
+run the following command from the root of this repository:
+
+    $ cd ports/stm32
+    $ make BOARD=LEGO_HUB_NO6 backup-hub-firmware
+
+This will create a file called `lego_hub_firmware.dfu`.  Put this file in a safe
+location.  To restore it, enter the built-in bootloader again and run:
+
+    $ make BOARD=LEGO_HUB_NO6 restore-hub-firmware
+
+This will restore the original firmware but not the filesystem.  To recreate the
+original filesystem the Hub must be updated using the appropriate LEGO PC
+application.
+
 Installing MicroPython
 ----------------------
 

--- a/ports/stm32/boards/LEGO_HUB_NO6/bdev.c
+++ b/ports/stm32/boards/LEGO_HUB_NO6/bdev.c
@@ -26,25 +26,26 @@
 
 #include "py/obj.h"
 #include "storage.h"
+#include "spi.h"
 
 #define CMD_EXIT_4_BYTE_ADDRESS_MODE (0xE9)
 
-STATIC const mp_soft_spi_obj_t soft_spi_bus = {
-    .delay_half = MICROPY_HW_SOFTSPI_MIN_DELAY,
+STATIC const spi_proto_cfg_t spi_bus = {
+    .spi = &spi_obj[1], // SPI2 hardware peripheral
+    .baudrate = 25000000,
     .polarity = 0,
     .phase = 0,
-    .sck = MICROPY_HW_SPIFLASH_SCK,
-    .mosi = MICROPY_HW_SPIFLASH_MOSI,
-    .miso = MICROPY_HW_SPIFLASH_MISO,
+    .bits = 8,
+    .firstbit = SPI_FIRSTBIT_MSB,
 };
 
 STATIC mp_spiflash_cache_t spi_bdev_cache;
 
 const mp_spiflash_config_t spiflash_config = {
     .bus_kind = MP_SPIFLASH_BUS_SPI,
-    .bus.u_spi.cs = MICROPY_HW_SPIFLASH_NSS,
-    .bus.u_spi.data = (void *)&soft_spi_bus,
-    .bus.u_spi.proto = &mp_soft_spi_proto,
+    .bus.u_spi.cs = MICROPY_HW_SPIFLASH_CS,
+    .bus.u_spi.data = (void *)&spi_bus,
+    .bus.u_spi.proto = &spi_proto,
     .cache = &spi_bdev_cache,
 };
 
@@ -55,9 +56,9 @@ int32_t board_bdev_ioctl(void) {
 
     // Exit 4-byte address mode
     uint8_t cmd = CMD_EXIT_4_BYTE_ADDRESS_MODE;
-    mp_hal_pin_write(MICROPY_HW_SPIFLASH_NSS, 0);
-    mp_soft_spi_proto.transfer(MP_OBJ_FROM_PTR(&soft_spi_bus), 1, &cmd, NULL);
-    mp_hal_pin_write(MICROPY_HW_SPIFLASH_NSS, 1);
+    mp_hal_pin_write(MICROPY_HW_SPIFLASH_CS, 0);
+    spi_proto.transfer(MP_OBJ_FROM_PTR(&spi_bus), 1, &cmd, NULL);
+    mp_hal_pin_write(MICROPY_HW_SPIFLASH_CS, 1);
 
     return ret;
 }

--- a/ports/stm32/boards/LEGO_HUB_NO6/mpconfigboard.h
+++ b/ports/stm32/boards/LEGO_HUB_NO6/mpconfigboard.h
@@ -61,6 +61,10 @@
 #define MICROPY_HW_SPI1_SCK                      (pin_A5) // shared with DAC
 #define MICROPY_HW_SPI1_MISO                     (pin_A6)
 #define MICROPY_HW_SPI1_MOSI                     (pin_A7)
+#define MICROPY_HW_SPI2_NSS                      (pin_B12)
+#define MICROPY_HW_SPI2_SCK                      (pin_B13)
+#define MICROPY_HW_SPI2_MISO                     (pin_C2)
+#define MICROPY_HW_SPI2_MOSI                     (pin_C3)
 
 // USB config
 #define MICROPY_HW_USB_VBUS_DETECT_PIN           (pin_A9)
@@ -76,10 +80,10 @@
 // SPI flash, for R/W storage
 #define MICROPY_HW_SPIFLASH_ENABLE_CACHE         (1)
 #define MICROPY_HW_SPIFLASH_SIZE_BITS            (256 * 1024 * 1024)
-#define MICROPY_HW_SPIFLASH_NSS                  (pin_B12)
-#define MICROPY_HW_SPIFLASH_SCK                  (pin_B13)
-#define MICROPY_HW_SPIFLASH_MISO                 (pin_C2)
-#define MICROPY_HW_SPIFLASH_MOSI                 (pin_C3)
+#define MICROPY_HW_SPIFLASH_CS                   (MICROPY_HW_SPI2_NSS)
+#define MICROPY_HW_SPIFLASH_SCK                  (MICROPY_HW_SPI2_SCK)
+#define MICROPY_HW_SPIFLASH_MISO                 (MICROPY_HW_SPI2_MISO)
+#define MICROPY_HW_SPIFLASH_MOSI                 (MICROPY_HW_SPI2_MOSI)
 
 // SPI flash, block device config
 extern int32_t board_bdev_ioctl(void);

--- a/ports/stm32/boards/LEGO_HUB_NO6/mpconfigboard.h
+++ b/ports/stm32/boards/LEGO_HUB_NO6/mpconfigboard.h
@@ -10,7 +10,7 @@
 #define MICROPY_HW_MCU_NAME                      "STM32F413"
 
 #define MICROPY_HW_HAS_SWITCH                    (0)
-#define MICROPY_HW_HAS_FLASH                     (0)
+#define MICROPY_HW_HAS_FLASH                     (1)
 #define MICROPY_PY_PYB_LEGACY                    (0)
 #define MICROPY_HW_ENTER_BOOTLOADER_VIA_RESET    (0)
 #define MICROPY_HW_ENABLE_INTERNAL_FLASH_STORAGE (0)
@@ -78,8 +78,12 @@
 #define MICROPY_HW_BLE_BTSTACK_CHIPSET_INSTANCE  btstack_chipset_cc256x_instance()
 
 // SPI flash, for R/W storage
+// The first 1MiB is skipped because it's used by the built-in bootloader
+#define MICROPY_HW_SPIFLASH_OFFSET_BYTES         (1024 * 1024)
+#define MICROPY_HW_SPIFLASH_BLOCKMAP(bl)         ((bl) + MICROPY_HW_SPIFLASH_OFFSET_BYTES / FLASH_BLOCK_SIZE)
+#define MICROPY_HW_SPIFLASH_BLOCKMAP_EXT(bl)     ((bl) + MICROPY_HW_SPIFLASH_OFFSET_BYTES / MP_SPIFLASH_ERASE_BLOCK_SIZE)
 #define MICROPY_HW_SPIFLASH_ENABLE_CACHE         (1)
-#define MICROPY_HW_SPIFLASH_SIZE_BITS            (256 * 1024 * 1024)
+#define MICROPY_HW_SPIFLASH_SIZE_BITS            (256 * 1024 * 1024 - MICROPY_HW_SPIFLASH_OFFSET_BYTES * 8)
 #define MICROPY_HW_SPIFLASH_CS                   (MICROPY_HW_SPI2_NSS)
 #define MICROPY_HW_SPIFLASH_SCK                  (MICROPY_HW_SPI2_SCK)
 #define MICROPY_HW_SPIFLASH_MISO                 (MICROPY_HW_SPI2_MISO)
@@ -89,15 +93,25 @@
 extern int32_t board_bdev_ioctl(void);
 extern struct _spi_bdev_t spi_bdev;
 #define MICROPY_HW_BDEV_IOCTL(op, arg) ( \
-    (op) == BDEV_IOCTL_NUM_BLOCKS ? (MICROPY_HW_SPIFLASH_SIZE_BITS / 8 / FLASH_BLOCK_SIZE - 1) : \
+    (op) == BDEV_IOCTL_NUM_BLOCKS ? (MICROPY_HW_SPIFLASH_SIZE_BITS / 8 / FLASH_BLOCK_SIZE) : \
     (op) == BDEV_IOCTL_INIT ? board_bdev_ioctl() : \
     spi_bdev_ioctl(&spi_bdev, (op), (arg)) \
     )
 
-// Jump over first block (bl + 1) as it is cleared by bootloader
-#define MICROPY_HW_BDEV_READBLOCKS(dest, bl, n) spi_bdev_readblocks(&spi_bdev, (dest), (bl + 1), (n))
-#define MICROPY_HW_BDEV_WRITEBLOCKS(src, bl, n) spi_bdev_writeblocks(&spi_bdev, (src), (bl + 1), (n))
-#define MICROPY_HW_BDEV_SPIFLASH_EXTENDED (&spi_bdev) // for extended block protocol
+// Configuration for stardard block protocol (block size FLASH_BLOCK_SIZE).
+#define MICROPY_HW_BDEV_READBLOCKS(dest, bl, n) \
+    spi_bdev_readblocks(&spi_bdev, (dest), MICROPY_HW_SPIFLASH_BLOCKMAP(bl), (n))
+#define MICROPY_HW_BDEV_WRITEBLOCKS(src, bl, n) \
+    spi_bdev_writeblocks(&spi_bdev, (src), MICROPY_HW_SPIFLASH_BLOCKMAP(bl), (n))
+
+// Configuration for extended block protocol (block size MP_SPIFLASH_ERASE_BLOCK_SIZE).
+#define MICROPY_HW_BDEV_BLOCKSIZE_EXT (MP_SPIFLASH_ERASE_BLOCK_SIZE)
+#define MICROPY_HW_BDEV_READBLOCKS_EXT(dest, bl, off, len) \
+    (spi_bdev_readblocks_raw(&spi_bdev, (dest), MICROPY_HW_SPIFLASH_BLOCKMAP_EXT(bl), (off), (len)))
+#define MICROPY_HW_BDEV_WRITEBLOCKS_EXT(src, bl, off, len) \
+    (spi_bdev_writeblocks_raw(&spi_bdev, (src), MICROPY_HW_SPIFLASH_BLOCKMAP_EXT(bl), (off), (len)))
+#define MICROPY_HW_BDEV_ERASEBLOCKS_EXT(bl, len) \
+    (spi_bdev_eraseblocks_raw(&spi_bdev, MICROPY_HW_SPIFLASH_BLOCKMAP_EXT(bl), (len)))
 
 // Board control config
 #define MICROPY_BOARD_STARTUP                    board_init

--- a/ports/stm32/boards/LEGO_HUB_NO6/mpconfigboard.mk
+++ b/ports/stm32/boards/LEGO_HUB_NO6/mpconfigboard.mk
@@ -20,3 +20,26 @@ endif
 # Bootloader settings
 MBOOT_TEXT0_ADDR = 0x08008000
 MBOOT_LD_FILES = ../boards/LEGO_HUB_NO6/mboot_memory.ld stm32_sections.ld
+
+# Backup/restore original Hub firmware
+
+HUB_FIRMWARE = lego_hub_firmware.dfu
+HUB_FIRMWARE_ADDR = $(MBOOT_TEXT0_ADDR)
+HUB_FIRMWARE_SIZE = 0xf8000
+
+backup-hub-firmware:
+	$(Q)$(DFU_UTIL) -a 0 \
+		-d $(BOOTLOADER_DFU_USB_VID):$(BOOTLOADER_DFU_USB_PID) \
+		-U $(HUB_FIRMWARE).bin \
+		-s $(HUB_FIRMWARE_ADDR):$(HUB_FIRMWARE_SIZE)
+	$(Q)$(PYTHON) $(DFU) \
+		-b $(HUB_FIRMWARE_ADDR):$(HUB_FIRMWARE).bin \
+		-D $(BOOTLOADER_DFU_USB_VID):$(BOOTLOADER_DFU_USB_PID) \
+		$(HUB_FIRMWARE)
+	$(Q)$(RM) $(HUB_FIRMWARE).bin
+	$(ECHO) "Backup created in $(HUB_FIRMWARE)"
+
+restore-hub-firmware:
+	$(Q)$(DFU_UTIL) -a 0 \
+		-d $(BOOTLOADER_DFU_USB_VID):$(BOOTLOADER_DFU_USB_PID) \
+		-D $(HUB_FIRMWARE)

--- a/ports/stm32/flashbdev.c
+++ b/ports/stm32/flashbdev.c
@@ -157,6 +157,7 @@ int32_t flash_bdev_ioctl(uint32_t op, uint32_t arg) {
             return 0;
 
         case BDEV_IOCTL_NUM_BLOCKS:
+            // Units are FLASH_BLOCK_SIZE
             return FLASH_MEM_SEG1_NUM_BLOCKS + FLASH_MEM_SEG2_NUM_BLOCKS;
 
         case BDEV_IOCTL_IRQ_HANDLER:

--- a/ports/stm32/storage.h
+++ b/ports/stm32/storage.h
@@ -35,8 +35,7 @@
 enum {
     BDEV_IOCTL_INIT = 1,
     BDEV_IOCTL_SYNC = 3,
-    BDEV_IOCTL_NUM_BLOCKS = 4,
-    BDEV_IOCTL_BLOCK_ERASE = 6,
+    BDEV_IOCTL_NUM_BLOCKS = 4, // units are FLASH_BLOCK_SIZE
     BDEV_IOCTL_IRQ_HANDLER = 7,
 };
 
@@ -70,6 +69,7 @@ int spi_bdev_writeblocks(spi_bdev_t *bdev, const uint8_t *src, uint32_t block_nu
 // These raw functions bypass the cache and go directly to SPI flash
 int spi_bdev_readblocks_raw(spi_bdev_t *bdev, uint8_t *dest, uint32_t block_num, uint32_t block_offset, uint32_t num_bytes);
 int spi_bdev_writeblocks_raw(spi_bdev_t *bdev, const uint8_t *src, uint32_t block_num, uint32_t block_offset, uint32_t num_bytes);
+int spi_bdev_eraseblocks_raw(spi_bdev_t *bdev, uint32_t block_num, uint32_t num_bytes);
 
 extern const struct _mp_obj_type_t pyb_flash_type;
 extern const struct _pyb_flash_obj_t pyb_flash_obj;


### PR DESCRIPTION
This PR has a commit to make extended-block-device more configurable for all stm32 boards.

And then for the LEGO_HUB_NO6 board it does the following:
- Change SPI flash storage to use hardware SPI.
- Skip first 1MiB of SPI flash for storage.
- Add make commands to backup/restore firmware.