### PR TITLE
docs/reference/speed_python.rst: Slicing a memoryview causes allocation.

### DIFF
--- a/docs/reference/speed_python.rst
+++ b/docs/reference/speed_python.rst
@@ -91,9 +91,10 @@ code these should be pre-allocated and passed as arguments or as bound objects.
 
 When passing slices of objects such as `bytearray` instances, Python creates
 a copy which involves allocation of the size proportional to the size of slice.
-This can be alleviated using a `memoryview` object. `memoryview` itself
-is allocated on heap, but is a small, fixed-size object, regardless of the size
-of slice it points too.
+This can be alleviated using a `memoryview` object. The `memoryview` itself
+is allocated on the heap, but is a small, fixed-size object, regardless of the size
+of slice it points too. Slicing a `memoryview` creates a new `memoryview`, so this
+cannot be done in an interrupt service routine.
 
 .. code:: python
 


### PR DESCRIPTION
Clarify the reason why this can't be done in an ISR.