### PR TITLE
uncrustify: Force 1 newline at end of file.

### DIFF
--- a/ports/esp32/modesp.c
+++ b/ports/esp32/modesp.c
@@ -143,4 +143,3 @@ const mp_obj_module_t esp_module = {
     .base = { &mp_type_module },
     .globals = (mp_obj_dict_t *)&esp_module_globals,
 };
-

--- a/ports/nrf/mphalport.h
+++ b/ports/nrf/mphalport.h
@@ -78,4 +78,3 @@ mp_uint_t mp_hal_ticks_ms(void);
 #define mp_hal_ticks_cpu() (0)
 
 #endif
-

--- a/ports/rp2/main.c
+++ b/ports/rp2/main.c
@@ -227,4 +227,3 @@ const char rp2_help_text[] =
     "For further help on a specific object, type help(obj)\n"
     "For a list of available modules, type help('modules')\n"
 ;
-

--- a/ports/stm32/machine_i2s.c
+++ b/ports/stm32/machine_i2s.c
@@ -1123,4 +1123,3 @@ const mp_obj_type_t machine_i2s_type = {
 };
 
 #endif // MICROPY_HW_ENABLE_I2S
-

--- a/ports/stm32/modmachine.c
+++ b/ports/stm32/modmachine.c
@@ -468,4 +468,3 @@ const mp_obj_module_t machine_module = {
     .base = { &mp_type_module },
     .globals = (mp_obj_dict_t *)&machine_module_globals,
 };
-

--- a/ports/stm32/pin_defs_stm32.c
+++ b/ports/stm32/pin_defs_stm32.c
@@ -28,4 +28,3 @@ uint32_t pin_get_pull(const pin_obj_t *pin) {
 uint32_t pin_get_af(const pin_obj_t *pin) {
     return (pin->gpio->AFR[pin->pin >> 3] >> ((pin->pin & 7) * 4)) & 0xf;
 }
-

--- a/ports/stm32/pin_defs_stm32.h
+++ b/ports/stm32/pin_defs_stm32.h
@@ -136,4 +136,3 @@ enum {
 };
 
 typedef GPIO_TypeDef pin_gpio_t;
-

--- a/tools/uncrustify.cfg
+++ b/tools/uncrustify.cfg
@@ -1409,11 +1409,11 @@ nl_start_of_file                = ignore   # ignore/add/remove/force
 nl_start_of_file_min            = 0        # unsigned number
 
 # Add or remove newline at the end of the file.
-nl_end_of_file                  = ignore   # ignore/add/remove/force
+nl_end_of_file                  = force    # ignore/add/remove/force
 
 # The minimum number of newlines at the end of the file (only used if
 # nl_end_of_file is 'add' or 'force').
-nl_end_of_file_min              = 0        # unsigned number
+nl_end_of_file_min              = 1        # unsigned number
 
 # Add or remove newline between '=' and '{'.
 nl_assign_brace                 = ignore   # ignore/add/remove/force


### PR DESCRIPTION
To keep things neat and tidy, we ensure that each file has 1 and only 1 newline at the end of each file.

As a side note, we also use this config for out-of-tree code, which is the main motivation for making the PR. Files with 0 newlines at the end have created odd problems for me throughout the years, so I like to make sure that doesn't happen. But it turns out that MicroPython has done a good job of this and there were only a few files that had 2 newlines at the end and none with 0.