### PR TITLE
extmod: Add platform module.

### DIFF
--- a/extmod/moduplatform.c
+++ b/extmod/moduplatform.c
@@ -1,0 +1,136 @@
+/*
+ * This file is part of the MicroPython project, http://micropython.org/
+ *
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2013-2021 Ibrahim Abdelkader <iabdalkader@openmv.io>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ */
+#include <stdint.h>
+#include <string.h>
+
+#include "py/runtime.h"
+#include "py/objtuple.h"
+#include "py/objstr.h"
+#include "genhdr/mpversion.h"
+
+#if MICROPY_PY_UPLATFORM
+#include "mphalport.h"
+/// \module platform -  Access to underlying platform’s identifying data
+
+// TODO: Add more architectures, compilers and libraries.
+// See: https://sourceforge.net/p/predef/wiki/Home/
+
+#if defined(__ARM_ARCH)
+#define PLATFORM_ARCH   "arm"
+#elif defined(__x86_64__)
+#define PLATFORM_ARCH   "x86_64"
+#else
+#define PLATFORM_ARCH   ""
+#endif
+
+#if defined(__GNUC__)
+#define PLATFORM_COMPILER \
+    "GCC " \
+    MP_STRINGIFY(__GNUC__) "." \
+    MP_STRINGIFY(__GNUC_MINOR__) "." \
+    MP_STRINGIFY(__GNUC_PATCHLEVEL__)
+#elif defined(__ARMCC_VERSION)
+#define PLATFORM_COMPILER \
+    "ARMCC " \
+    MP_STRINGIFY((__ARMCC_VERSION / 1000000)) "." \
+    MP_STRINGIFY((__ARMCC_VERSION / 10000 % 100)) "." \
+    MP_STRINGIFY((__ARMCC_VERSION % 10000))
+#else
+#define PLATFORM_COMPILER       ""
+#endif
+
+#if defined(__GLIBC__)
+#define PLATFORM_LIBC_LIB       "glibc"
+#define PLATFORM_LIBC_VER \
+    MP_STRINGIFY(__GLIBC__) "." \
+    MP_STRINGIFY(__GLIBC_MINOR__)
+#elif defined(__NEWLIB__)
+#define PLATFORM_LIBC_LIB       "newlib"
+#define PLATFORM_LIBC_VER       _NEWLIB_VERSION
+#else
+#define PLATFORM_LIBC_LIB       ""
+#define PLATFORM_LIBC_VER       ""
+#endif
+
+#if defined(__linux)
+#define PLATFORM_SYSTEM     "Linux"
+#elif defined(__unix__)
+#define PLATFORM_SYSTEM     "Unix"
+#elif defined(__CYGWIN__)
+#define PLATFORM_SYSTEM     "Cygwin"
+#elif defined(__WIN32__)
+#define PLATFORM_SYSTEM     "Windows"
+#else
+#define PLATFORM_SYSTEM     "MicroPython"
+#endif
+
+#ifndef MICROPY_HW_BOARD_NAME
+#define MICROPY_HW_BOARD_NAME PLATFORM_ARCH
+#endif
+
+#ifndef MICROPY_HW_MCU_NAME
+#define MICROPY_HW_MCU_NAME     ""
+#endif
+
+STATIC const MP_DEFINE_STR_OBJ(info_platform_obj, PLATFORM_SYSTEM "-" MICROPY_VERSION_STRING "-HAL" \
+    MICROPY_HAL_VERSION "-" PLATFORM_ARCH "-with-" PLATFORM_LIBC_LIB "" PLATFORM_LIBC_VER);
+STATIC const MP_DEFINE_STR_OBJ(info_python_compiler_obj, PLATFORM_COMPILER);
+STATIC const MP_DEFINE_STR_OBJ(info_libc_lib_obj, PLATFORM_LIBC_LIB);
+STATIC const MP_DEFINE_STR_OBJ(info_libc_ver_obj, PLATFORM_LIBC_VER);
+STATIC const mp_rom_obj_tuple_t info_libc_tuple_obj = {
+    {&mp_type_tuple}, 2, {MP_ROM_PTR(&info_libc_lib_obj), MP_ROM_PTR(&info_libc_ver_obj)}
+};
+
+STATIC mp_obj_t platform_platform(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
+    return MP_OBJ_FROM_PTR(&info_platform_obj);
+}
+STATIC MP_DEFINE_CONST_FUN_OBJ_KW(platform_platform_obj, 0, platform_platform);
+
+STATIC mp_obj_t platform_python_compiler(void) {
+    return MP_OBJ_FROM_PTR(&info_python_compiler_obj);
+}
+STATIC MP_DEFINE_CONST_FUN_OBJ_0(platform_python_compiler_obj, platform_python_compiler);
+
+STATIC mp_obj_t platform_libc_ver(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
+    return MP_OBJ_FROM_PTR(&info_libc_tuple_obj);
+}
+STATIC MP_DEFINE_CONST_FUN_OBJ_KW(platform_libc_ver_obj, 0, platform_libc_ver);
+
+STATIC const mp_rom_map_elem_t modplatform_globals_table[] = {
+    { MP_ROM_QSTR(MP_QSTR___name__), MP_ROM_QSTR(MP_QSTR_uplatform) },
+    { MP_ROM_QSTR(MP_QSTR_platform), MP_ROM_PTR(&platform_platform_obj) },
+    { MP_ROM_QSTR(MP_QSTR_python_compiler), MP_ROM_PTR(&platform_python_compiler_obj) },
+    { MP_ROM_QSTR(MP_QSTR_libc_ver), MP_ROM_PTR(&platform_libc_ver_obj) },
+};
+
+STATIC MP_DEFINE_CONST_DICT(modplatform_globals, modplatform_globals_table);
+
+const mp_obj_module_t mp_module_uplatform = {
+    .base = { &mp_type_module },
+    .globals = (mp_obj_dict_t *)&modplatform_globals,
+};
+#endif // MICROPY_PY_UPLATFORM

--- a/ports/stm32/mpconfigport.h
+++ b/ports/stm32/mpconfigport.h
@@ -221,6 +221,9 @@
 #ifndef MICROPY_PY_ONEWIRE
 #define MICROPY_PY_ONEWIRE          (1)
 #endif
+#ifndef MICROPY_PY_UPLATFORM
+#define MICROPY_PY_UPLATFORM        (1)
+#endif
 
 // fatfs configuration used in ffconf.h
 #define MICROPY_FATFS_ENABLE_LFN       (1)

--- a/ports/stm32/mphalport.h
+++ b/ports/stm32/mphalport.h
@@ -2,6 +2,23 @@
 #include STM32_HAL_H
 #include "pin.h"
 
+// F0-1.9.0+F4-1.16.0+F7-1.7.0+H7-1.6.0+L0-1.11.2+L4-1.8.1+WB-1.10.0
+#if defined(STM32F0)
+#define MICROPY_HAL_VERSION "1.9.0"
+#elif defined(STM32F4)
+#define MICROPY_HAL_VERSION "1.16.0"
+#elif defined(STM32F7)
+#define MICROPY_HAL_VERSION "1.7.0"
+#elif defined(STM32H7)
+#define MICROPY_HAL_VERSION "1.6.0"
+#elif defined(STM32L0)
+#define MICROPY_HAL_VERSION "1.11.2"
+#elif defined(STM32L4)
+#define MICROPY_HAL_VERSION "1.8.1"
+#elif defined(STM32WB)
+#define MICROPY_HAL_VERSION "1.10.0"
+#endif
+
 extern const unsigned char mp_hal_status_to_errno_table[4];
 
 static inline int mp_hal_status_to_neg_errno(HAL_StatusTypeDef status) {

--- a/py/builtin.h
+++ b/py/builtin.h
@@ -124,6 +124,7 @@ extern const mp_obj_module_t mp_module_webrepl;
 extern const mp_obj_module_t mp_module_framebuf;
 extern const mp_obj_module_t mp_module_btree;
 extern const mp_obj_module_t mp_module_ubluetooth;
+extern const mp_obj_module_t mp_module_uplatform;
 
 extern const char MICROPY_PY_BUILTINS_HELP_TEXT[];
 

--- a/py/objmodule.c
+++ b/py/objmodule.c
@@ -230,6 +230,9 @@ STATIC const mp_rom_map_elem_t mp_builtin_module_table[] = {
     #if MICROPY_PY_BLUETOOTH
     { MP_ROM_QSTR(MP_QSTR_ubluetooth), MP_ROM_PTR(&mp_module_ubluetooth) },
     #endif
+    #if MICROPY_PY_UPLATFORM
+    { MP_ROM_QSTR(MP_QSTR_uplatform), MP_ROM_PTR(&mp_module_uplatform) },
+    #endif
 
     // extra builtin modules as defined by a port
     MICROPY_PORT_BUILTIN_MODULES

--- a/py/py.mk
+++ b/py/py.mk
@@ -199,6 +199,7 @@ PY_EXTMOD_O_BASENAME = \
 	extmod/moduwebsocket.o \
 	extmod/modwebrepl.o \
 	extmod/modframebuf.o \
+	extmod/moduplatform.o\
 	extmod/vfs.o \
 	extmod/vfs_blockdev.o \
 	extmod/vfs_reader.o \


### PR DESCRIPTION
First attempt... Example stm32 port:

```Python
MicroPython v1.16-246-ga3ce8f08e-dirty on 2021-08-29; PYBD-SF2W with STM32F722IEK
Type "help()" for more information.
>>> import platform
>>> platform.architecture()
(32, 'elf')
>>> platform.machine()
'PYBD-SF2W'
>>> platform.platform()
'MicroPython-1.16.0-arm-with-newlib3.3.0'
>>> platform.python_compiler()
'GCC 10.2.1'
>>> platform.python_version()
'3.4.0'
>>> platform.libc_ver()
('newlib', '3.3.0')
>>> platform.system()
'MicroPython'
>>> platform.uname()
(system='MicroPython', node='pyboard', release='1.16.0', version='v1.16-246-ga3ce8f08e-dirty on 2021-08-29', machine='PYBD-SF2W', processor='STM32F722IEK')```
```

Unix port:
```Python
MicroPython v1.16-246-ga3ce8f08e-dirty on 2021-08-29; linux version
Use Ctrl-D to exit, Ctrl-E for paste mode
>>> import platform
>>> platform.architecture()
(64, 'elf')
>>> platform.machine()
'x86_64'
>>> platform.platform()
'Linux-1.16.0-x86_64-with-glibc2.33'
>>> platform.python_compiler()
'GCC 11.1.0'
>>> platform.python_version()
'3.4.0'
>>> platform.libc_ver()
('glibc', '2.33')
>>> platform.system()
'Linux'
>>> platform.uname()
(system='Linux', node='pyboard', release='1.16.0', version='v1.16-246-ga3ce8f08e-dirty on 2021-08-29', machine='x86_64', processor='')
```

See discussion in
* #7702

See: https://docs.python.org/3/library/platform.html
See: https://sourceforge.net/p/predef/wiki/Home/

Note: `MICROPY_HAL_VERSION` should be defined in mphalport.h, hard-coded for ports that don't define SDK/HAL major/minor/patch. For stm32, these numbers are defined but unfortunately they are defined in .C file, stm32xxx_hal.c . Maybe there's a way to parse these numbers @dpgeorge ?
For example see:
stm32h7xx_hal.c

```C
#define __STM32H7xx_HAL_VERSION_MAIN   (0x01UL) /*!< [31:24] main version */
#define __STM32H7xx_HAL_VERSION_SUB1   (0x09UL) /*!< [23:16] sub1 version */
#define __STM32H7xx_HAL_VERSION_SUB2   (0x00UL) /*!< [15:8]  sub2 version */
#define __STM32H7xx_HAL_VERSION_RC     (0x00UL) /*!< [7:0]  release candidate */
#define __STM32H7xx_HAL_VERSION         ((__STM32H7xx_HAL_VERSION_MAIN << 24)\
                                        |(__STM32H7xx_HAL_VERSION_SUB1 << 16)\
                                        |(__STM32H7xx_HAL_VERSION_SUB2 << 8 )\
                                        |(__STM32H7xx_HAL_VERSION_RC))

````