### PR TITLE
uasyncio: Add ThreadSafeFlag.clear()

### DIFF
--- a/docs/library/uasyncio.rst
+++ b/docs/library/uasyncio.rst
@@ -150,8 +150,13 @@ class ThreadSafeFlag
 
 .. method:: ThreadSafeFlag.set()
 
-    Set the flag.  If there is a task waiting on the event, it will be scheduled
+    Set the flag.  If there is a task waiting on the flag, it will be scheduled
     to run.
+
+.. method:: ThreadSafeFlag.clear()
+
+    Clear the flag. This may be used to ensure that a possibly previously-set
+    flag is clear before waiting for it.
 
 .. method:: ThreadSafeFlag.wait()
 

--- a/extmod/uasyncio/event.py
+++ b/extmod/uasyncio/event.py
@@ -36,7 +36,7 @@ class Event:
 # MicroPython-extension: This can be set from outside the asyncio event loop,
 # such as other threads, IRQs or scheduler context. Implementation is a stream
 # that asyncio will poll until a flag is set.
-# Note: Unlike Event, this is self-clearing.
+# Note: Unlike Event, this is self-clearing after a wait().
 try:
     import uio
 
@@ -51,6 +51,9 @@ try:
 
         def set(self):
             self._flag = 1
+
+        def clear(self):
+            self._flag = 0
 
         async def wait(self):
             if not self._flag:

--- a/tests/extmod/uasyncio_threadsafeflag.py
+++ b/tests/extmod/uasyncio_threadsafeflag.py
@@ -75,5 +75,24 @@ async def main():
     print("wait task")
     await t
 
+    # Flag set, cleared, and set again.
+    print("set event")
+    flag.set()
+    print("yield")
+    await asyncio.sleep(0)
+    print("clear event")
+    flag.clear()
+    print("yield")
+    await asyncio.sleep(0)
+    t = asyncio.create_task(task(4, flag))
+    print("yield")
+    await asyncio.sleep(0)
+    print("set event")
+    flag.set()
+    print("yield")
+    await asyncio.sleep(0)
+    print("wait task")
+    await t
+
 
 asyncio.run(main())

--- a/tests/extmod/uasyncio_threadsafeflag.py
+++ b/tests/extmod/uasyncio_threadsafeflag.py
@@ -76,6 +76,7 @@ async def main():
     await t
 
     # Flag set, cleared, and set again.
+    print("----")
     print("set event")
     flag.set()
     print("yield")

--- a/tests/extmod/uasyncio_threadsafeflag.py.exp
+++ b/tests/extmod/uasyncio_threadsafeflag.py.exp
@@ -24,6 +24,7 @@ set event
 yield
 clear event
 yield
+yield
 task 4
 set event
 yield

--- a/tests/extmod/uasyncio_threadsafeflag.py.exp
+++ b/tests/extmod/uasyncio_threadsafeflag.py.exp
@@ -19,3 +19,13 @@ yield
 task 3
 task 3 done
 wait task
+----
+set event
+yield
+clear event
+yield
+task 4
+set event
+yield
+wait task
+task 4 done


### PR DESCRIPTION
Sometimes when working with async code it's possible to not wait as expected on an already-set `ThreadSafeFlag` because it's already set.

This PR adds a `.clear()` method that can be used to avoid this problem.

It includes docs and an updated test.