### PR TITLE
stm32: enable GPIO clock when constructing a Pin, and don't unconditionally enable GPIO A-D on start up

### DIFF
--- a/ports/stm32/main.c
+++ b/ports/stm32/main.c
@@ -369,14 +369,6 @@ void stm32_main(uint32_t reset_mode) {
     // set the system clock to be HSE
     SystemClock_Config();
 
-    // enable GPIO clocks
-    __HAL_RCC_GPIOA_CLK_ENABLE();
-    __HAL_RCC_GPIOB_CLK_ENABLE();
-    __HAL_RCC_GPIOC_CLK_ENABLE();
-    #if defined(GPIOD)
-    __HAL_RCC_GPIOD_CLK_ENABLE();
-    #endif
-
     #if defined(STM32F4) || defined(STM32F7)
     #if defined(__HAL_RCC_DTCMRAMEN_CLK_ENABLE)
     // The STM32F746 doesn't really have CCM memory, but it does have DTCM,

--- a/ports/stm32/pin.c
+++ b/ports/stm32/pin.c
@@ -256,6 +256,9 @@ mp_obj_t mp_pin_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, 
         mp_map_t kw_args;
         mp_map_init_fixed_table(&kw_args, n_kw, args + n_args);
         pin_obj_init_helper(pin, n_args - 1, args + 1, &kw_args);
+    } else {
+        // enable the peripheral clock so pin reading at least works
+        mp_hal_gpio_clock_enable(pin->gpio);
     }
 
     return MP_OBJ_FROM_PTR(pin);


### PR DESCRIPTION
Fixes issue #7363.