### PR TITLE
rp2: fix missing heapq

### DIFF
--- a/ports/rp2/mpconfigport.h
+++ b/ports/rp2/mpconfigport.h
@@ -120,6 +120,7 @@
 #define MICROPY_PY_URE_MATCH_GROUPS             (1)
 #define MICROPY_PY_URE_MATCH_SPAN_START_END     (1)
 #define MICROPY_PY_URE_SUB                      (1)
+#define MICROPY_PY_UHEAPQ                       (1)
 #define MICROPY_PY_UHASHLIB                     (1)
 #define MICROPY_PY_UBINASCII                    (1)
 #define MICROPY_PY_UBINASCII_CRC32              (1)


### PR DESCRIPTION
Added missing MICROPY_PY_UHEAPQ to rp2 port. (#7746)
Now can do
```
import heapq
heapq.heappush([1,2,3], 3)
```
in rp2040.
