### PR TITLE
os.rst: Clarify littlefs requirements.

### DIFF
--- a/docs/library/os.rst
+++ b/docs/library/os.rst
@@ -313,6 +313,12 @@ that the block device supports the extended interface.
        As a minimum ``ioctl(4, ...)`` must be intercepted; for littlefs
        ``ioctl(6, ...)`` must also be intercepted. The need for others is
        hardware dependent.
+       
+       Prior to any call to ``writeblocks(block, ...)`` littlefs issues
+       ``ioctl(6, block)``. This enables a device driver to erase the block
+       prior to a write if the hardware requires it. Alternatively a driver
+       might intercept ``ioctl(6, block)`` and return 0 (success). In this case
+       the driver assumes responsibility for detecting the need for erasure.
 
        Unless otherwise stated ``ioctl(op, arg)`` can return ``None``.
        Consequently an implementation can ignore unused values of ``op``. Where


### PR DESCRIPTION
The doc detailing the need to intercept the **erase block** ioctl call is ambiguous as evidenced by [this thread](https://github.com/peterhinch/micropython_eeprom/issues/8).

This edit is based on inference from test scripts and docs rather than detailed knowledge of littlefs - please check!