### PR TITLE
windows/README: Remove unsupported Python instructions for Cygwin.

### DIFF
--- a/ports/windows/README.md
+++ b/ports/windows/README.md
@@ -25,8 +25,7 @@ Install Cygwin, then install following packages using Cygwin's setup.exe:
 * mingw64-i686-gcc-core
 * mingw64-x86_64-gcc-core
 * make
-
-Also install the python3 package, or install Python globally for Windows (see below).
+* python3
 
 Build using:
 


### PR DESCRIPTION
It's not possible anymore to build MicroPython on Cygwin using a
standard Windows installation of Python so don't advertise that.
Specifically: preprocessing in makeqstrdefs.py fails on the subprocess
call with 'gcc: fatal error: no input files' because one of the flags
contains double quotes and that somehow messes up the commandline.

I'm not sure if there's a way around, tried escaping the quotes with `\` but that also did not work, but it's probably a case which is almost never used (it's since commit 8e94fa0d2eb94483f387b1ae2e081d1998575a7f so almost a year old) so just don't advertise it.