### PR TITLE
[stm32] run optional frozen module at boot

### DIFF
--- a/ports/stm32/main.c
+++ b/ports/stm32/main.c
@@ -562,6 +562,9 @@ soft_reset:
     MP_STATE_PORT(pyb_config_main) = MP_OBJ_NULL;
 
     // Run boot.py (or whatever else a board configures at this stage).
+    #ifdef MICROPY_BOARD_RUN_FROZEN_AT_BOOT
+    pyexec_frozen_module(MICROPY_BOARD_RUN_FROZEN_AT_BOOT);
+    #endif
     if (MICROPY_BOARD_RUN_BOOT_PY(&state) == BOARDCTRL_GOTO_SOFT_RESET_EXIT) {
         goto soft_reset_exit;
     }

--- a/ports/stm32/main.c
+++ b/ports/stm32/main.c
@@ -561,10 +561,12 @@ soft_reset:
     // reset config variables; they should be set by boot.py
     MP_STATE_PORT(pyb_config_main) = MP_OBJ_NULL;
 
-    // Run boot.py (or whatever else a board configures at this stage).
-    #ifdef MICROPY_BOARD_RUN_FROZEN_AT_BOOT
-    pyexec_frozen_module(MICROPY_BOARD_RUN_FROZEN_AT_BOOT);
+    // Run optional frozen boot code.
+    #ifdef MICROPY_BOARD_FROZEN_BOOT_FILE
+    pyexec_frozen_module(MICROPY_BOARD_FROZEN_BOOT_FILE);
     #endif
+
+    // Run boot.py (or whatever else a board configures at this stage).
     if (MICROPY_BOARD_RUN_BOOT_PY(&state) == BOARDCTRL_GOTO_SOFT_RESET_EXIT) {
         goto soft_reset_exit;
     }


### PR DESCRIPTION
Inspired by the `esp32` port:
https://github.com/micropython/micropython/blob/bbbdef4cc1d2cb3a3f6c2d067b6988534773b2a6/ports/esp32/main.c#L156

This change is optional, and can be switched on in build if 2 conditions are met:

- Your module is frozen into the firmware (ie: `manifest.py` populated, and can be imported)
- `MICROPY_BOARD_FROZEN_BOOT_FILE` switch is set to string:

For example, you create a `_boot.py` file:

```python
import pyb, time
led = led.LED(1)
for _ in range(10):
    led.toggle()
    time.sleep(0.2)
```

Add it to the `manifest.py`:

```python
freeze('_boot.py', opt=0)
```

Specify `_boot.py` in `MICROPY_BOARD_FROZEN_BOOT_FILE`

```c
#define MICROPY_BOARD_FROZEN_BOOT_FILE "_boot.py"
```

