### PR TITLE
esp32\modmachine.c: Add BROWNOUT_RESET

### DIFF
--- a/docs/library/machine.rst
+++ b/docs/library/machine.rst
@@ -233,6 +233,7 @@ Constants
           machine.WDT_RESET
           machine.DEEPSLEEP_RESET
           machine.SOFT_RESET
+          machine.BROWNOUT_RESET - (ESP32 specific) A note on hardware: add a decoupling capacitor (10µF - 100µF) or/and increase the power supply capacity.
 
     Reset causes.
 

--- a/ports/esp32/modmachine.c
+++ b/ports/esp32/modmachine.c
@@ -70,6 +70,7 @@
     { MP_ROM_QSTR(MP_QSTR_WDT_RESET), MP_ROM_INT(MP_WDT_RESET) }, \
     { MP_ROM_QSTR(MP_QSTR_DEEPSLEEP_RESET), MP_ROM_INT(MP_DEEPSLEEP_RESET) }, \
     { MP_ROM_QSTR(MP_QSTR_SOFT_RESET), MP_ROM_INT(MP_SOFT_RESET) }, \
+    { MP_ROM_QSTR(MP_QSTR_BROWNOUT_RESET), MP_ROM_INT(MP_BROWNOUT_RESET) }, \
     \
     /* Wake reasons */ \
     { MP_ROM_QSTR(MP_QSTR_wake_reason), MP_ROM_PTR(&machine_wake_reason_obj) }, \
@@ -85,7 +86,8 @@ typedef enum {
     MP_HARD_RESET,
     MP_WDT_RESET,
     MP_DEEPSLEEP_RESET,
-    MP_SOFT_RESET
+    MP_SOFT_RESET,
+    MP_BROWNOUT_RESET
 } reset_reason_t;
 
 static bool is_soft_reset = 0;
@@ -236,8 +238,12 @@ static mp_int_t mp_machine_reset_cause(void) {
     }
     switch (esp_reset_reason()) {
         case ESP_RST_POWERON:
-        case ESP_RST_BROWNOUT:
             return MP_PWRON_RESET;
+            break;
+
+        case ESP_RST_BROWNOUT:
+            return MP_BROWNOUT_RESET;
+            break;
 
         case ESP_RST_INT_WDT:
         case ESP_RST_TASK_WDT:


### PR DESCRIPTION
It helps to detect power supply instability.

EDIT: A note on hardware: add a decoupling capacitor (10µF - 100µF) or/and increase the power supply capacity.