### PR TITLE
port/esp32s3: IDF 4.4.x is now required for S3 support

### DIFF
--- a/ports/esp32/machine_timer.c
+++ b/ports/esp32/machine_timer.c
@@ -137,7 +137,11 @@ STATIC void machine_timer_isr(void *self_in) {
     #if CONFIG_IDF_TARGET_ESP32
     device->hw_timer[self->index].update = 1;
     #else
+    #if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(4, 4, 0)
+    device->hw_timer[self->index].update.tx_update = 1;
+    #else
     device->hw_timer[self->index].update.update = 1;
+    #endif
     #endif
     timer_ll_clear_intr_status(device, self->index);
     timer_ll_set_alarm_enable(device, self->index, self->repeat);


### PR DESCRIPTION
This is the only fix required so far to get MP building against `ESP-IDF v4.4-dev-2883-gb1f851b8f8`
ESP32S2 builds and deploys fine with this - not tried regular ESP32 or C3.