### PR TITLE
Fix for windows console 8192 characters limitation stm32 build

### DIFF
--- a/ports/stm32/Makefile
+++ b/ports/stm32/Makefile
@@ -617,7 +617,9 @@ endef
 
 define GENERATE_ELF
 	$(ECHO) "LINK $(1)"
-	$(Q)$(LD) $(LDFLAGS) -o $(1) $(2) $(LDFLAGS_MOD) $(LIBS)
+	$(Q)$(ECHO) $(LDFLAGS_MOD) > $(BUILD)/ldflags_mod.objs
+	$(Q)$(ECHO) $(LIBS) > $(BUILD)/libs.objs
+	$(Q)$(LD) $(LDFLAGS) -o $(1) $(2) @$(BUILD)/ldflags_mod.objs @$(BUILD)/libs.objs
 	$(Q)$(SIZE) $(1)
 	$(if $(filter-out $(TEXT0_ADDR),0x08000000), \
 		$(ECHO) "INFO: this build requires mboot to be installed first")

--- a/py/makemoduledefs.py
+++ b/py/makemoduledefs.py
@@ -93,13 +93,15 @@ def main():
     parser.add_argument(
         "--vpath", default=".", help="comma separated list of folders to search for c files in"
     )
-    parser.add_argument("files", nargs="*", help="list of c files to search")
+    parser.add_argument("cfiles", default="", help="filepath of file containing list of c files to search")
+
     args = parser.parse_args()
 
     vpath = [p.strip() for p in args.vpath.split(",")]
+    cfiles = io.open(args.cfiles).read().split(' ')
 
     modules = set()
-    for obj_file in args.files:
+    for obj_file in cfiles:
         c_file = find_c_file(obj_file, vpath)
         modules |= find_module_registrations(c_file)
 

--- a/py/py.mk
+++ b/py/py.mk
@@ -267,9 +267,11 @@ $(HEADER_BUILD)/compressed.data.h: $(HEADER_BUILD)/compressed.collected
 	$(Q)$(PYTHON) $(PY_SRC)/makecompresseddata.py $< > $@
 
 # build a list of registered modules for py/objmodule.c.
+ABS_PATH=$(shell $(PYTHON) -c "import os;print(os.getcwd())")
 $(HEADER_BUILD)/moduledefs.h: $(SRC_QSTR) $(QSTR_GLOBAL_DEPENDENCIES) | $(HEADER_BUILD)/mpversion.h
 	@$(ECHO) "GEN $@"
-	$(Q)$(PYTHON) $(PY_SRC)/makemoduledefs.py --vpath="., $(TOP), $(USER_C_MODULES)" $(SRC_QSTR) > $@
+	$(Q)$(ECHO) $(SRC_QSTR) > $(BUILD)/src_qstr.objs
+	$(Q)$(PYTHON) $(PY_SRC)/makemoduledefs.py --vpath="., $(TOP), $(USER_C_MODULES)" "$(ABS_PATH)/$(BUILD)/src_qstr.objs" > $@
 
 # Standard C functions like memset need to be compiled with special flags so
 # the compiler does not optimise these functions in terms of themselves.


### PR DESCRIPTION
This PR provides a fix for building STM32 ports on Windows using mingw.

The problem:
- Windows Console has a 8192 character limit, which has broken the build process by causing truncation of commands
- The linker command as well as the makemoduledefs commmand can exceed this limit
- See issue: [issue 7687](https://github.com/micropython/micropython/issues/7687) and [issue 7012](https://github.com/micropython/micropython/issues/7012)

The solution
- Storing the collection of files to be passed to linker and makemodulesfs in objs files in the build directory
- See related [Circuit-Python commit](https://github.com/adafruit/circuitpython/commit/7831be5a55baeecb98779fb1c9b62a014f89bdf4)