### PR TITLE
mimxrt: reformat boards and hal source files

### DIFF
--- a/ports/mimxrt/boards/MIMXRT1010_EVK/evkmimxrt1010_flexspi_nor_config.h
+++ b/ports/mimxrt/boards/MIMXRT1010_EVK/evkmimxrt1010_flexspi_nor_config.h
@@ -75,9 +75,9 @@
 
 #define FLEXSPI_LUT_SEQ(cmd0, pad0, op0, cmd1, pad1, op1)                                                              \
     (FLEXSPI_LUT_OPERAND0(op0) | FLEXSPI_LUT_NUM_PADS0(pad0) | FLEXSPI_LUT_OPCODE0(cmd0) | FLEXSPI_LUT_OPERAND1(op1) | \
-     FLEXSPI_LUT_NUM_PADS1(pad1) | FLEXSPI_LUT_OPCODE1(cmd1))
+    FLEXSPI_LUT_NUM_PADS1(pad1) | FLEXSPI_LUT_OPCODE1(cmd1))
 
-//!@brief Definitions for FlexSPI Serial Clock Frequency
+// !@brief Definitions for FlexSPI Serial Clock Frequency
 typedef enum _FlexSpiSerialClockFreq
 {
     kFlexSpiSerialClk_30MHz  = 1,
@@ -90,14 +90,14 @@ typedef enum _FlexSpiSerialClockFreq
     kFlexSpiSerialClk_133MHz = 8,
 } flexspi_serial_clk_freq_t;
 
-//!@brief FlexSPI clock configuration type
+// !@brief FlexSPI clock configuration type
 enum
 {
-    kFlexSpiClk_SDR, //!< Clock configure for SDR mode
-    kFlexSpiClk_DDR, //!< Clock configurat for DDR mode
+    kFlexSpiClk_SDR, // !< Clock configure for SDR mode
+    kFlexSpiClk_DDR, // !< Clock configurat for DDR mode
 };
 
-//!@brief FlexSPI Read Sample Clock Source definition
+// !@brief FlexSPI Read Sample Clock Source definition
 typedef enum _FlashReadSampleClkSource
 {
     kFlexSPIReadSampleClk_LoopbackInternally      = 0,
@@ -106,29 +106,29 @@ typedef enum _FlashReadSampleClkSource
     kFlexSPIReadSampleClk_ExternalInputFromDqsPad = 3,
 } flexspi_read_sample_clk_t;
 
-//!@brief Misc feature bit definitions
+// !@brief Misc feature bit definitions
 enum
 {
-    kFlexSpiMiscOffset_DiffClkEnable            = 0, //!< Bit for Differential clock enable
-    kFlexSpiMiscOffset_Ck2Enable                = 1, //!< Bit for CK2 enable
-    kFlexSpiMiscOffset_ParallelEnable           = 2, //!< Bit for Parallel mode enable
-    kFlexSpiMiscOffset_WordAddressableEnable    = 3, //!< Bit for Word Addressable enable
-    kFlexSpiMiscOffset_SafeConfigFreqEnable     = 4, //!< Bit for Safe Configuration Frequency enable
-    kFlexSpiMiscOffset_PadSettingOverrideEnable = 5, //!< Bit for Pad setting override enable
-    kFlexSpiMiscOffset_DdrModeEnable            = 6, //!< Bit for DDR clock confiuration indication.
+    kFlexSpiMiscOffset_DiffClkEnable            = 0, // !< Bit for Differential clock enable
+    kFlexSpiMiscOffset_Ck2Enable                = 1, // !< Bit for CK2 enable
+    kFlexSpiMiscOffset_ParallelEnable           = 2, // !< Bit for Parallel mode enable
+    kFlexSpiMiscOffset_WordAddressableEnable    = 3, // !< Bit for Word Addressable enable
+    kFlexSpiMiscOffset_SafeConfigFreqEnable     = 4, // !< Bit for Safe Configuration Frequency enable
+    kFlexSpiMiscOffset_PadSettingOverrideEnable = 5, // !< Bit for Pad setting override enable
+    kFlexSpiMiscOffset_DdrModeEnable            = 6, // !< Bit for DDR clock confiuration indication.
 };
 
-//!@brief Flash Type Definition
+// !@brief Flash Type Definition
 enum
 {
-    kFlexSpiDeviceType_SerialNOR    = 1,    //!< Flash devices are Serial NOR
-    kFlexSpiDeviceType_SerialNAND   = 2,    //!< Flash devices are Serial NAND
-    kFlexSpiDeviceType_SerialRAM    = 3,    //!< Flash devices are Serial RAM/HyperFLASH
-    kFlexSpiDeviceType_MCP_NOR_NAND = 0x12, //!< Flash device is MCP device, A1 is Serial NOR, A2 is Serial NAND
-    kFlexSpiDeviceType_MCP_NOR_RAM  = 0x13, //!< Flash deivce is MCP device, A1 is Serial NOR, A2 is Serial RAMs
+    kFlexSpiDeviceType_SerialNOR    = 1,    // !< Flash devices are Serial NOR
+    kFlexSpiDeviceType_SerialNAND   = 2,    // !< Flash devices are Serial NAND
+    kFlexSpiDeviceType_SerialRAM    = 3,    // !< Flash devices are Serial RAM/HyperFLASH
+    kFlexSpiDeviceType_MCP_NOR_NAND = 0x12, // !< Flash device is MCP device, A1 is Serial NOR, A2 is Serial NAND
+    kFlexSpiDeviceType_MCP_NOR_RAM  = 0x13, // !< Flash deivce is MCP device, A1 is Serial NOR, A2 is Serial RAMs
 };
 
-//!@brief Flash Pad Definitions
+// !@brief Flash Pad Definitions
 enum
 {
     kSerialFlash_1Pad  = 1,
@@ -137,77 +137,77 @@ enum
     kSerialFlash_8Pads = 8,
 };
 
-//!@brief FlexSPI LUT Sequence structure
+// !@brief FlexSPI LUT Sequence structure
 typedef struct _lut_sequence
 {
-    uint8_t seqNum; //!< Sequence Number, valid number: 1-16
-    uint8_t seqId;  //!< Sequence Index, valid number: 0-15
+    uint8_t seqNum; // !< Sequence Number, valid number: 1-16
+    uint8_t seqId;  // !< Sequence Index, valid number: 0-15
     uint16_t reserved;
 } flexspi_lut_seq_t;
 
-//!@brief Flash Configuration Command Type
+// !@brief Flash Configuration Command Type
 enum
 {
-    kDeviceConfigCmdType_Generic,    //!< Generic command, for example: configure dummy cycles, drive strength, etc
-    kDeviceConfigCmdType_QuadEnable, //!< Quad Enable command
-    kDeviceConfigCmdType_Spi2Xpi,    //!< Switch from SPI to DPI/QPI/OPI mode
-    kDeviceConfigCmdType_Xpi2Spi,    //!< Switch from DPI/QPI/OPI to SPI mode
-    kDeviceConfigCmdType_Spi2NoCmd,  //!< Switch to 0-4-4/0-8-8 mode
-    kDeviceConfigCmdType_Reset,      //!< Reset device command
+    kDeviceConfigCmdType_Generic,    // !< Generic command, for example: configure dummy cycles, drive strength, etc
+    kDeviceConfigCmdType_QuadEnable, // !< Quad Enable command
+    kDeviceConfigCmdType_Spi2Xpi,    // !< Switch from SPI to DPI/QPI/OPI mode
+    kDeviceConfigCmdType_Xpi2Spi,    // !< Switch from DPI/QPI/OPI to SPI mode
+    kDeviceConfigCmdType_Spi2NoCmd,  // !< Switch to 0-4-4/0-8-8 mode
+    kDeviceConfigCmdType_Reset,      // !< Reset device command
 };
 
-//!@brief FlexSPI Memory Configuration Block
+// !@brief FlexSPI Memory Configuration Block
 typedef struct _FlexSPIConfig
 {
-    uint32_t tag;               //!< [0x000-0x003] Tag, fixed value 0x42464346UL
-    uint32_t version;           //!< [0x004-0x007] Version,[31:24] -'V', [23:16] - Major, [15:8] - Minor, [7:0] - bugfix
-    uint32_t reserved0;         //!< [0x008-0x00b] Reserved for future use
-    uint8_t readSampleClkSrc;   //!< [0x00c-0x00c] Read Sample Clock Source, valid value: 0/1/3
-    uint8_t csHoldTime;         //!< [0x00d-0x00d] CS hold time, default value: 3
-    uint8_t csSetupTime;        //!< [0x00e-0x00e] CS setup time, default value: 3
-    uint8_t columnAddressWidth; //!< [0x00f-0x00f] Column Address with, for HyperBus protocol, it is fixed to 3, For
-    //! Serial NAND, need to refer to datasheet
-    uint8_t deviceModeCfgEnable; //!< [0x010-0x010] Device Mode Configure enable flag, 1 - Enable, 0 - Disable
-    uint8_t deviceModeType; //!< [0x011-0x011] Specify the configuration command type:Quad Enable, DPI/QPI/OPI switch,
-    //! Generic configuration, etc.
-    uint16_t waitTimeCfgCommands; //!< [0x012-0x013] Wait time for all configuration commands, unit: 100us, Used for
-    //! DPI/QPI/OPI switch or reset command
-    flexspi_lut_seq_t deviceModeSeq; //!< [0x014-0x017] Device mode sequence info, [7:0] - LUT sequence id, [15:8] - LUt
-    //! sequence number, [31:16] Reserved
-    uint32_t deviceModeArg;    //!< [0x018-0x01b] Argument/Parameter for device configuration
-    uint8_t configCmdEnable;   //!< [0x01c-0x01c] Configure command Enable Flag, 1 - Enable, 0 - Disable
-    uint8_t configModeType[3]; //!< [0x01d-0x01f] Configure Mode Type, similar as deviceModeTpe
+    uint32_t tag;               // !< [0x000-0x003] Tag, fixed value 0x42464346UL
+    uint32_t version;           // !< [0x004-0x007] Version,[31:24] -'V', [23:16] - Major, [15:8] - Minor, [7:0] - bugfix
+    uint32_t reserved0;         // !< [0x008-0x00b] Reserved for future use
+    uint8_t readSampleClkSrc;   // !< [0x00c-0x00c] Read Sample Clock Source, valid value: 0/1/3
+    uint8_t csHoldTime;         // !< [0x00d-0x00d] CS hold time, default value: 3
+    uint8_t csSetupTime;        // !< [0x00e-0x00e] CS setup time, default value: 3
+    uint8_t columnAddressWidth; // !< [0x00f-0x00f] Column Address with, for HyperBus protocol, it is fixed to 3, For
+    // ! Serial NAND, need to refer to datasheet
+    uint8_t deviceModeCfgEnable; // !< [0x010-0x010] Device Mode Configure enable flag, 1 - Enable, 0 - Disable
+    uint8_t deviceModeType; // !< [0x011-0x011] Specify the configuration command type:Quad Enable, DPI/QPI/OPI switch,
+    // ! Generic configuration, etc.
+    uint16_t waitTimeCfgCommands; // !< [0x012-0x013] Wait time for all configuration commands, unit: 100us, Used for
+    // ! DPI/QPI/OPI switch or reset command
+    flexspi_lut_seq_t deviceModeSeq; // !< [0x014-0x017] Device mode sequence info, [7:0] - LUT sequence id, [15:8] - LUt
+    // ! sequence number, [31:16] Reserved
+    uint32_t deviceModeArg;    // !< [0x018-0x01b] Argument/Parameter for device configuration
+    uint8_t configCmdEnable;   // !< [0x01c-0x01c] Configure command Enable Flag, 1 - Enable, 0 - Disable
+    uint8_t configModeType[3]; // !< [0x01d-0x01f] Configure Mode Type, similar as deviceModeTpe
     flexspi_lut_seq_t
-        configCmdSeqs[3]; //!< [0x020-0x02b] Sequence info for Device Configuration command, similar as deviceModeSeq
-    uint32_t reserved1;   //!< [0x02c-0x02f] Reserved for future use
-    uint32_t configCmdArgs[3];     //!< [0x030-0x03b] Arguments/Parameters for device Configuration commands
-    uint32_t reserved2;            //!< [0x03c-0x03f] Reserved for future use
-    uint32_t controllerMiscOption; //!< [0x040-0x043] Controller Misc Options, see Misc feature bit definitions for more
-    //! details
-    uint8_t deviceType;    //!< [0x044-0x044] Device Type:  See Flash Type Definition for more details
-    uint8_t sflashPadType; //!< [0x045-0x045] Serial Flash Pad Type: 1 - Single, 2 - Dual, 4 - Quad, 8 - Octal
-    uint8_t serialClkFreq; //!< [0x046-0x046] Serial Flash Frequencey, device specific definitions, See System Boot
-    //! Chapter for more details
-    uint8_t lutCustomSeqEnable; //!< [0x047-0x047] LUT customization Enable, it is required if the program/erase cannot
-    //! be done using 1 LUT sequence, currently, only applicable to HyperFLASH
-    uint32_t reserved3[2];           //!< [0x048-0x04f] Reserved for future use
-    uint32_t sflashA1Size;           //!< [0x050-0x053] Size of Flash connected to A1
-    uint32_t sflashA2Size;           //!< [0x054-0x057] Size of Flash connected to A2
-    uint32_t sflashB1Size;           //!< [0x058-0x05b] Size of Flash connected to B1
-    uint32_t sflashB2Size;           //!< [0x05c-0x05f] Size of Flash connected to B2
-    uint32_t csPadSettingOverride;   //!< [0x060-0x063] CS pad setting override value
-    uint32_t sclkPadSettingOverride; //!< [0x064-0x067] SCK pad setting override value
-    uint32_t dataPadSettingOverride; //!< [0x068-0x06b] data pad setting override value
-    uint32_t dqsPadSettingOverride;  //!< [0x06c-0x06f] DQS pad setting override value
-    uint32_t timeoutInMs;            //!< [0x070-0x073] Timeout threshold for read status command
-    uint32_t commandInterval;        //!< [0x074-0x077] CS deselect interval between two commands
-    uint16_t dataValidTime[2]; //!< [0x078-0x07b] CLK edge to data valid time for PORT A and PORT B, in terms of 0.1ns
-    uint16_t busyOffset;       //!< [0x07c-0x07d] Busy offset, valid value: 0-31
-    uint16_t busyBitPolarity;  //!< [0x07e-0x07f] Busy flag polarity, 0 - busy flag is 1 when flash device is busy, 1 -
-    //! busy flag is 0 when flash device is busy
-    uint32_t lookupTable[64];           //!< [0x080-0x17f] Lookup table holds Flash command sequences
-    flexspi_lut_seq_t lutCustomSeq[12]; //!< [0x180-0x1af] Customizable LUT Sequences
-    uint32_t reserved4[4];              //!< [0x1b0-0x1bf] Reserved for future use
+        configCmdSeqs[3]; // !< [0x020-0x02b] Sequence info for Device Configuration command, similar as deviceModeSeq
+    uint32_t reserved1;   // !< [0x02c-0x02f] Reserved for future use
+    uint32_t configCmdArgs[3];     // !< [0x030-0x03b] Arguments/Parameters for device Configuration commands
+    uint32_t reserved2;            // !< [0x03c-0x03f] Reserved for future use
+    uint32_t controllerMiscOption; // !< [0x040-0x043] Controller Misc Options, see Misc feature bit definitions for more
+    // ! details
+    uint8_t deviceType;    // !< [0x044-0x044] Device Type:  See Flash Type Definition for more details
+    uint8_t sflashPadType; // !< [0x045-0x045] Serial Flash Pad Type: 1 - Single, 2 - Dual, 4 - Quad, 8 - Octal
+    uint8_t serialClkFreq; // !< [0x046-0x046] Serial Flash Frequencey, device specific definitions, See System Boot
+    // ! Chapter for more details
+    uint8_t lutCustomSeqEnable; // !< [0x047-0x047] LUT customization Enable, it is required if the program/erase cannot
+    // ! be done using 1 LUT sequence, currently, only applicable to HyperFLASH
+    uint32_t reserved3[2];           // !< [0x048-0x04f] Reserved for future use
+    uint32_t sflashA1Size;           // !< [0x050-0x053] Size of Flash connected to A1
+    uint32_t sflashA2Size;           // !< [0x054-0x057] Size of Flash connected to A2
+    uint32_t sflashB1Size;           // !< [0x058-0x05b] Size of Flash connected to B1
+    uint32_t sflashB2Size;           // !< [0x05c-0x05f] Size of Flash connected to B2
+    uint32_t csPadSettingOverride;   // !< [0x060-0x063] CS pad setting override value
+    uint32_t sclkPadSettingOverride; // !< [0x064-0x067] SCK pad setting override value
+    uint32_t dataPadSettingOverride; // !< [0x068-0x06b] data pad setting override value
+    uint32_t dqsPadSettingOverride;  // !< [0x06c-0x06f] DQS pad setting override value
+    uint32_t timeoutInMs;            // !< [0x070-0x073] Timeout threshold for read status command
+    uint32_t commandInterval;        // !< [0x074-0x077] CS deselect interval between two commands
+    uint16_t dataValidTime[2]; // !< [0x078-0x07b] CLK edge to data valid time for PORT A and PORT B, in terms of 0.1ns
+    uint16_t busyOffset;       // !< [0x07c-0x07d] Busy offset, valid value: 0-31
+    uint16_t busyBitPolarity;  // !< [0x07e-0x07f] Busy flag polarity, 0 - busy flag is 1 when flash device is busy, 1 -
+    // ! busy flag is 0 when flash device is busy
+    uint32_t lookupTable[64];           // !< [0x080-0x17f] Lookup table holds Flash command sequences
+    flexspi_lut_seq_t lutCustomSeq[12]; // !< [0x180-0x1af] Customizable LUT Sequences
+    uint32_t reserved4[4];              // !< [0x1b0-0x1bf] Reserved for future use
 } flexspi_mem_config_t;
 
 /*  */
@@ -230,18 +230,18 @@ typedef struct _FlexSPIConfig
  */
 typedef struct _flexspi_nor_config
 {
-    flexspi_mem_config_t memConfig; //!< Common memory configuration info via FlexSPI
-    uint32_t pageSize;              //!< Page size of Serial NOR
-    uint32_t sectorSize;            //!< Sector size of Serial NOR
-    uint8_t ipcmdSerialClkFreq;     //!< Clock frequency for IP command
-    uint8_t isUniformBlockSize;     //!< Sector/Block size is the same
-    uint8_t reserved0[2];           //!< Reserved for future use
-    uint8_t serialNorType;          //!< Serial NOR Flash type: 0/1/2/3
-    uint8_t needExitNoCmdMode;      //!< Need to exit NoCmd mode before other IP command
-    uint8_t halfClkForNonReadCmd;   //!< Half the Serial Clock for non-read command: true/false
-    uint8_t needRestoreNoCmdMode;   //!< Need to Restore NoCmd mode after IP commmand execution
-    uint32_t blockSize;             //!< Block size
-    uint32_t reserve2[11];          //!< Reserved for future use
+    flexspi_mem_config_t memConfig; // !< Common memory configuration info via FlexSPI
+    uint32_t pageSize;              // !< Page size of Serial NOR
+    uint32_t sectorSize;            // !< Sector size of Serial NOR
+    uint8_t ipcmdSerialClkFreq;     // !< Clock frequency for IP command
+    uint8_t isUniformBlockSize;     // !< Sector/Block size is the same
+    uint8_t reserved0[2];           // !< Reserved for future use
+    uint8_t serialNorType;          // !< Serial NOR Flash type: 0/1/2/3
+    uint8_t needExitNoCmdMode;      // !< Need to exit NoCmd mode before other IP command
+    uint8_t halfClkForNonReadCmd;   // !< Half the Serial Clock for non-read command: true/false
+    uint8_t needRestoreNoCmdMode;   // !< Need to Restore NoCmd mode after IP commmand execution
+    uint32_t blockSize;             // !< Block size
+    uint32_t reserve2[11];          // !< Reserved for future use
 } flexspi_nor_config_t;
 
 #define FLASH_BUSY_STATUS_POL 0

--- a/ports/mimxrt/boards/MIMXRT1010_EVK/flash_config.c
+++ b/ports/mimxrt/boards/MIMXRT1010_EVK/flash_config.c
@@ -26,99 +26,99 @@ __attribute__((section(".boot_hdr.conf")))
 
 const flexspi_nor_config_t qspiflash_config = {
     .memConfig =
+    {
+        .tag = FLEXSPI_CFG_BLK_TAG,
+        .version = FLEXSPI_CFG_BLK_VERSION,
+        .readSampleClkSrc = kFlexSPIReadSampleClk_LoopbackFromDqsPad,
+        .csHoldTime = 3u,
+        .csSetupTime = 3u,
+        .sflashPadType = kSerialFlash_4Pads,
+        .serialClkFreq = kFlexSpiSerialClk_100MHz,
+        .sflashA1Size = 16u * 1024u * 1024u,
+        .lookupTable =
         {
-            .tag              = FLEXSPI_CFG_BLK_TAG,
-            .version          = FLEXSPI_CFG_BLK_VERSION,
-            .readSampleClkSrc = kFlexSPIReadSampleClk_LoopbackFromDqsPad,
-            .csHoldTime       = 3u,
-            .csSetupTime      = 3u,
-            .sflashPadType    = kSerialFlash_4Pads,
-            .serialClkFreq    = kFlexSpiSerialClk_100MHz,
-            .sflashA1Size     = 16u * 1024u * 1024u,
-            .lookupTable =
-                {
-                    // 0 Read LUTs 0 -> 0
-                    FLEXSPI_LUT_SEQ(CMD_SDR, FLEXSPI_1PAD, 0xEB, RADDR_SDR, FLEXSPI_4PAD, 0x18),
-                    FLEXSPI_LUT_SEQ(DUMMY_SDR, FLEXSPI_4PAD, 0x06, READ_SDR, FLEXSPI_4PAD, 0x04),
-                    FLEXSPI_LUT_SEQ(0, 0, 0, 0, 0, 0), // Filler
-                    FLEXSPI_LUT_SEQ(0, 0, 0, 0, 0, 0), // Filler
+            // 0 Read LUTs 0 -> 0
+            FLEXSPI_LUT_SEQ(CMD_SDR, FLEXSPI_1PAD, 0xEB, RADDR_SDR, FLEXSPI_4PAD, 0x18),
+            FLEXSPI_LUT_SEQ(DUMMY_SDR, FLEXSPI_4PAD, 0x06, READ_SDR, FLEXSPI_4PAD, 0x04),
+            FLEXSPI_LUT_SEQ(0, 0, 0, 0, 0, 0),         // Filler
+            FLEXSPI_LUT_SEQ(0, 0, 0, 0, 0, 0),         // Filler
 
-                    // 1 Read status register -> 1
-                    FLEXSPI_LUT_SEQ(CMD_SDR, FLEXSPI_1PAD, 0x05, READ_SDR, FLEXSPI_1PAD, 0x01),
-                    FLEXSPI_LUT_SEQ(0, 0, 0, 0, 0, 0), // Filler
-                    FLEXSPI_LUT_SEQ(0, 0, 0, 0, 0, 0), // Filler
-                    FLEXSPI_LUT_SEQ(0, 0, 0, 0, 0, 0), // Filler
+            // 1 Read status register -> 1
+            FLEXSPI_LUT_SEQ(CMD_SDR, FLEXSPI_1PAD, 0x05, READ_SDR, FLEXSPI_1PAD, 0x01),
+            FLEXSPI_LUT_SEQ(0, 0, 0, 0, 0, 0),         // Filler
+            FLEXSPI_LUT_SEQ(0, 0, 0, 0, 0, 0),         // Filler
+            FLEXSPI_LUT_SEQ(0, 0, 0, 0, 0, 0),         // Filler
 
-                    // 2 Fast read quad mode - SDR
-                    FLEXSPI_LUT_SEQ(CMD_SDR, FLEXSPI_1PAD, 0x6B, RADDR_SDR, FLEXSPI_1PAD, 0x18),
-                    FLEXSPI_LUT_SEQ(DUMMY_SDR, FLEXSPI_4PAD, 0x08, READ_SDR, FLEXSPI_4PAD, 0x04),
-                    FLEXSPI_LUT_SEQ(0, 0, 0, 0, 0, 0), // Filler
-                    FLEXSPI_LUT_SEQ(0, 0, 0, 0, 0, 0), // Filler
+            // 2 Fast read quad mode - SDR
+            FLEXSPI_LUT_SEQ(CMD_SDR, FLEXSPI_1PAD, 0x6B, RADDR_SDR, FLEXSPI_1PAD, 0x18),
+            FLEXSPI_LUT_SEQ(DUMMY_SDR, FLEXSPI_4PAD, 0x08, READ_SDR, FLEXSPI_4PAD, 0x04),
+            FLEXSPI_LUT_SEQ(0, 0, 0, 0, 0, 0),         // Filler
+            FLEXSPI_LUT_SEQ(0, 0, 0, 0, 0, 0),         // Filler
 
-                    // 3 Write Enable -> 3
-                    FLEXSPI_LUT_SEQ(CMD_SDR, FLEXSPI_1PAD, 0x06, STOP, FLEXSPI_1PAD, 0),
-                    FLEXSPI_LUT_SEQ(0, 0, 0, 0, 0, 0), // Filler
-                    FLEXSPI_LUT_SEQ(0, 0, 0, 0, 0, 0), // Filler
-                    FLEXSPI_LUT_SEQ(0, 0, 0, 0, 0, 0), // Filler
+            // 3 Write Enable -> 3
+            FLEXSPI_LUT_SEQ(CMD_SDR, FLEXSPI_1PAD, 0x06, STOP, FLEXSPI_1PAD, 0),
+            FLEXSPI_LUT_SEQ(0, 0, 0, 0, 0, 0),         // Filler
+            FLEXSPI_LUT_SEQ(0, 0, 0, 0, 0, 0),         // Filler
+            FLEXSPI_LUT_SEQ(0, 0, 0, 0, 0, 0),         // Filler
 
-                    // 4 Read extend parameters
-                    FLEXSPI_LUT_SEQ(CMD_SDR, FLEXSPI_1PAD, 0x81, READ_SDR, FLEXSPI_1PAD, 0x04),
-                    FLEXSPI_LUT_SEQ(0, 0, 0, 0, 0, 0), // Filler
-                    FLEXSPI_LUT_SEQ(0, 0, 0, 0, 0, 0), // Filler
-                    FLEXSPI_LUT_SEQ(0, 0, 0, 0, 0, 0), // Filler
+            // 4 Read extend parameters
+            FLEXSPI_LUT_SEQ(CMD_SDR, FLEXSPI_1PAD, 0x81, READ_SDR, FLEXSPI_1PAD, 0x04),
+            FLEXSPI_LUT_SEQ(0, 0, 0, 0, 0, 0),         // Filler
+            FLEXSPI_LUT_SEQ(0, 0, 0, 0, 0, 0),         // Filler
+            FLEXSPI_LUT_SEQ(0, 0, 0, 0, 0, 0),         // Filler
 
-                    // 5 Erase Sector -> 5
-                    FLEXSPI_LUT_SEQ(CMD_SDR, FLEXSPI_1PAD, 0x20, RADDR_SDR, FLEXSPI_1PAD, 24),
-                    FLEXSPI_LUT_SEQ(0, 0, 0, 0, 0, 0), // Filler
-                    FLEXSPI_LUT_SEQ(0, 0, 0, 0, 0, 0), // Filler
-                    FLEXSPI_LUT_SEQ(0, 0, 0, 0, 0, 0), // Filler
+            // 5 Erase Sector -> 5
+            FLEXSPI_LUT_SEQ(CMD_SDR, FLEXSPI_1PAD, 0x20, RADDR_SDR, FLEXSPI_1PAD, 24),
+            FLEXSPI_LUT_SEQ(0, 0, 0, 0, 0, 0),         // Filler
+            FLEXSPI_LUT_SEQ(0, 0, 0, 0, 0, 0),         // Filler
+            FLEXSPI_LUT_SEQ(0, 0, 0, 0, 0, 0),         // Filler
 
-                    // 6 Write Status Reg
-                    FLEXSPI_LUT_SEQ(CMD_SDR, FLEXSPI_1PAD, 0x01, WRITE_SDR, FLEXSPI_1PAD, 0x04),
-                    FLEXSPI_LUT_SEQ(0, 0, 0, 0, 0, 0), // Filler
-                    FLEXSPI_LUT_SEQ(0, 0, 0, 0, 0, 0), // Filler
-                    FLEXSPI_LUT_SEQ(0, 0, 0, 0, 0, 0), // Filler
+            // 6 Write Status Reg
+            FLEXSPI_LUT_SEQ(CMD_SDR, FLEXSPI_1PAD, 0x01, WRITE_SDR, FLEXSPI_1PAD, 0x04),
+            FLEXSPI_LUT_SEQ(0, 0, 0, 0, 0, 0),         // Filler
+            FLEXSPI_LUT_SEQ(0, 0, 0, 0, 0, 0),         // Filler
+            FLEXSPI_LUT_SEQ(0, 0, 0, 0, 0, 0),         // Filler
 
-                    // 7 Page Program - quad mode (-> 9)
-                    FLEXSPI_LUT_SEQ(CMD_SDR, FLEXSPI_1PAD, 0x32, RADDR_SDR, FLEXSPI_1PAD, 0x18),
-                    FLEXSPI_LUT_SEQ(WRITE_SDR, FLEXSPI_4PAD, 0x04, STOP, FLEXSPI_1PAD, 0),
-                    FLEXSPI_LUT_SEQ(0, 0, 0, 0, 0, 0), // Filler
-                    FLEXSPI_LUT_SEQ(0, 0, 0, 0, 0, 0), // Filler
+            // 7 Page Program - quad mode (-> 9)
+            FLEXSPI_LUT_SEQ(CMD_SDR, FLEXSPI_1PAD, 0x32, RADDR_SDR, FLEXSPI_1PAD, 0x18),
+            FLEXSPI_LUT_SEQ(WRITE_SDR, FLEXSPI_4PAD, 0x04, STOP, FLEXSPI_1PAD, 0),
+            FLEXSPI_LUT_SEQ(0, 0, 0, 0, 0, 0),         // Filler
+            FLEXSPI_LUT_SEQ(0, 0, 0, 0, 0, 0),         // Filler
 
-                    // 8 Read ID
-                    FLEXSPI_LUT_SEQ(CMD_SDR, FLEXSPI_1PAD, 0x90, DUMMY_SDR, FLEXSPI_1PAD, 24),
-                    FLEXSPI_LUT_SEQ(READ_SDR, FLEXSPI_1PAD, 0x00, 0, 0, 0),
-                    FLEXSPI_LUT_SEQ(0, 0, 0, 0, 0, 0), // Filler
-                    FLEXSPI_LUT_SEQ(0, 0, 0, 0, 0, 0), // Filler
+            // 8 Read ID
+            FLEXSPI_LUT_SEQ(CMD_SDR, FLEXSPI_1PAD, 0x90, DUMMY_SDR, FLEXSPI_1PAD, 24),
+            FLEXSPI_LUT_SEQ(READ_SDR, FLEXSPI_1PAD, 0x00, 0, 0, 0),
+            FLEXSPI_LUT_SEQ(0, 0, 0, 0, 0, 0),         // Filler
+            FLEXSPI_LUT_SEQ(0, 0, 0, 0, 0, 0),         // Filler
 
-                    // 9 Page Program - single mode -> 9
-                    FLEXSPI_LUT_SEQ(CMD_SDR, FLEXSPI_1PAD, 0x02, RADDR_SDR, FLEXSPI_1PAD, 24),
-                    FLEXSPI_LUT_SEQ(WRITE_SDR, FLEXSPI_1PAD, 0, 0, 0, 0),
-                    FLEXSPI_LUT_SEQ(0, 0, 0, 0, 0, 0), // Filler
-                    FLEXSPI_LUT_SEQ(0, 0, 0, 0, 0, 0), // Filler
+            // 9 Page Program - single mode -> 9
+            FLEXSPI_LUT_SEQ(CMD_SDR, FLEXSPI_1PAD, 0x02, RADDR_SDR, FLEXSPI_1PAD, 24),
+            FLEXSPI_LUT_SEQ(WRITE_SDR, FLEXSPI_1PAD, 0, 0, 0, 0),
+            FLEXSPI_LUT_SEQ(0, 0, 0, 0, 0, 0),         // Filler
+            FLEXSPI_LUT_SEQ(0, 0, 0, 0, 0, 0),         // Filler
 
-                    // 10 Enter QPI mode
-                    FLEXSPI_LUT_SEQ(CMD_SDR, FLEXSPI_1PAD, 0x35, STOP, FLEXSPI_1PAD, 0),
-                    FLEXSPI_LUT_SEQ(0, 0, 0, 0, 0, 0), // Filler
-                    FLEXSPI_LUT_SEQ(0, 0, 0, 0, 0, 0), // Filler
-                    FLEXSPI_LUT_SEQ(0, 0, 0, 0, 0, 0), // Filler
+            // 10 Enter QPI mode
+            FLEXSPI_LUT_SEQ(CMD_SDR, FLEXSPI_1PAD, 0x35, STOP, FLEXSPI_1PAD, 0),
+            FLEXSPI_LUT_SEQ(0, 0, 0, 0, 0, 0),         // Filler
+            FLEXSPI_LUT_SEQ(0, 0, 0, 0, 0, 0),         // Filler
+            FLEXSPI_LUT_SEQ(0, 0, 0, 0, 0, 0),         // Filler
 
-                    // 11 Erase Chip
-                    FLEXSPI_LUT_SEQ(CMD_SDR, FLEXSPI_1PAD, 0x60, STOP, FLEXSPI_1PAD, 0),
-                    FLEXSPI_LUT_SEQ(0, 0, 0, 0, 0, 0), // Filler
-                    FLEXSPI_LUT_SEQ(0, 0, 0, 0, 0, 0), // Filler
-                    FLEXSPI_LUT_SEQ(0, 0, 0, 0, 0, 0), // Filler
+            // 11 Erase Chip
+            FLEXSPI_LUT_SEQ(CMD_SDR, FLEXSPI_1PAD, 0x60, STOP, FLEXSPI_1PAD, 0),
+            FLEXSPI_LUT_SEQ(0, 0, 0, 0, 0, 0),         // Filler
+            FLEXSPI_LUT_SEQ(0, 0, 0, 0, 0, 0),         // Filler
+            FLEXSPI_LUT_SEQ(0, 0, 0, 0, 0, 0),         // Filler
 
-                    // 12 Exit QPI mode
-                    FLEXSPI_LUT_SEQ(CMD_SDR, FLEXSPI_4PAD, 0xF5, STOP, FLEXSPI_1PAD, 0),
-                    FLEXSPI_LUT_SEQ(0, 0, 0, 0, 0, 0), // Filler
-                    FLEXSPI_LUT_SEQ(0, 0, 0, 0, 0, 0), // Filler
-                    FLEXSPI_LUT_SEQ(0, 0, 0, 0, 0, 0), // Filler
-                },
+            // 12 Exit QPI mode
+            FLEXSPI_LUT_SEQ(CMD_SDR, FLEXSPI_4PAD, 0xF5, STOP, FLEXSPI_1PAD, 0),
+            FLEXSPI_LUT_SEQ(0, 0, 0, 0, 0, 0),         // Filler
+            FLEXSPI_LUT_SEQ(0, 0, 0, 0, 0, 0),         // Filler
+            FLEXSPI_LUT_SEQ(0, 0, 0, 0, 0, 0),         // Filler
         },
-    .pageSize           = 256u,
-    .sectorSize         = 4u * 1024u,
-    .blockSize          = 256u * 1024u,
+    },
+    .pageSize = 256u,
+    .sectorSize = 4u * 1024u,
+    .blockSize = 256u * 1024u,
     .isUniformBlockSize = false,
 };
 #endif /* XIP_BOOT_HEADER_ENABLE */

--- a/ports/mimxrt/boards/MIMXRT1010_EVK/mpconfigboard.h
+++ b/ports/mimxrt/boards/MIMXRT1010_EVK/mpconfigboard.h
@@ -33,7 +33,7 @@
     { IOMUXC_GPIO_AD_04_LPSPI1_SDO }, { IOMUXC_GPIO_AD_03_LPSPI1_SDI },
 
 #define DMA_REQ_SRC_RX { 0, kDmaRequestMuxLPSPI1Rx, kDmaRequestMuxLPSPI2Rx }
-#define DMA_REQ_SRC_TX { 0, kDmaRequestMuxLPSPI1Tx, kDmaRequestMuxLPSPI2Tx } 
+#define DMA_REQ_SRC_TX { 0, kDmaRequestMuxLPSPI1Tx, kDmaRequestMuxLPSPI2Tx }
 
 // Define mapping hardware I2C # to logical I2C #
 // SDA/SCL  HW-I2C    Logical I2C

--- a/ports/mimxrt/boards/MIMXRT1020_EVK/evkmimxrt1020_flexspi_nor_config.h
+++ b/ports/mimxrt/boards/MIMXRT1020_EVK/evkmimxrt1020_flexspi_nor_config.h
@@ -75,9 +75,9 @@
 
 #define FLEXSPI_LUT_SEQ(cmd0, pad0, op0, cmd1, pad1, op1)                                                              \
     (FLEXSPI_LUT_OPERAND0(op0) | FLEXSPI_LUT_NUM_PADS0(pad0) | FLEXSPI_LUT_OPCODE0(cmd0) | FLEXSPI_LUT_OPERAND1(op1) | \
-     FLEXSPI_LUT_NUM_PADS1(pad1) | FLEXSPI_LUT_OPCODE1(cmd1))
+    FLEXSPI_LUT_NUM_PADS1(pad1) | FLEXSPI_LUT_OPCODE1(cmd1))
 
-//!@brief Definitions for FlexSPI Serial Clock Frequency
+// !@brief Definitions for FlexSPI Serial Clock Frequency
 typedef enum _FlexSpiSerialClockFreq
 {
     kFlexSpiSerialClk_30MHz  = 1,
@@ -91,14 +91,14 @@ typedef enum _FlexSpiSerialClockFreq
     kFlexSpiSerialClk_200MHz = 9,
 } flexspi_serial_clk_freq_t;
 
-//!@brief FlexSPI clock configuration type
+// !@brief FlexSPI clock configuration type
 enum
 {
-    kFlexSpiClk_SDR, //!< Clock configure for SDR mode
-    kFlexSpiClk_DDR, //!< Clock configurat for DDR mode
+    kFlexSpiClk_SDR, // !< Clock configure for SDR mode
+    kFlexSpiClk_DDR, // !< Clock configurat for DDR mode
 };
 
-//!@brief FlexSPI Read Sample Clock Source definition
+// !@brief FlexSPI Read Sample Clock Source definition
 typedef enum _FlashReadSampleClkSource
 {
     kFlexSPIReadSampleClk_LoopbackInternally      = 0,
@@ -107,29 +107,29 @@ typedef enum _FlashReadSampleClkSource
     kFlexSPIReadSampleClk_ExternalInputFromDqsPad = 3,
 } flexspi_read_sample_clk_t;
 
-//!@brief Misc feature bit definitions
+// !@brief Misc feature bit definitions
 enum
 {
-    kFlexSpiMiscOffset_DiffClkEnable            = 0, //!< Bit for Differential clock enable
-    kFlexSpiMiscOffset_Ck2Enable                = 1, //!< Bit for CK2 enable
-    kFlexSpiMiscOffset_ParallelEnable           = 2, //!< Bit for Parallel mode enable
-    kFlexSpiMiscOffset_WordAddressableEnable    = 3, //!< Bit for Word Addressable enable
-    kFlexSpiMiscOffset_SafeConfigFreqEnable     = 4, //!< Bit for Safe Configuration Frequency enable
-    kFlexSpiMiscOffset_PadSettingOverrideEnable = 5, //!< Bit for Pad setting override enable
-    kFlexSpiMiscOffset_DdrModeEnable            = 6, //!< Bit for DDR clock confiuration indication.
+    kFlexSpiMiscOffset_DiffClkEnable            = 0, // !< Bit for Differential clock enable
+    kFlexSpiMiscOffset_Ck2Enable                = 1, // !< Bit for CK2 enable
+    kFlexSpiMiscOffset_ParallelEnable           = 2, // !< Bit for Parallel mode enable
+    kFlexSpiMiscOffset_WordAddressableEnable    = 3, // !< Bit for Word Addressable enable
+    kFlexSpiMiscOffset_SafeConfigFreqEnable     = 4, // !< Bit for Safe Configuration Frequency enable
+    kFlexSpiMiscOffset_PadSettingOverrideEnable = 5, // !< Bit for Pad setting override enable
+    kFlexSpiMiscOffset_DdrModeEnable            = 6, // !< Bit for DDR clock confiuration indication.
 };
 
-//!@brief Flash Type Definition
+// !@brief Flash Type Definition
 enum
 {
-    kFlexSpiDeviceType_SerialNOR    = 1,    //!< Flash devices are Serial NOR
-    kFlexSpiDeviceType_SerialNAND   = 2,    //!< Flash devices are Serial NAND
-    kFlexSpiDeviceType_SerialRAM    = 3,    //!< Flash devices are Serial RAM/HyperFLASH
-    kFlexSpiDeviceType_MCP_NOR_NAND = 0x12, //!< Flash device is MCP device, A1 is Serial NOR, A2 is Serial NAND
-    kFlexSpiDeviceType_MCP_NOR_RAM  = 0x13, //!< Flash deivce is MCP device, A1 is Serial NOR, A2 is Serial RAMs
+    kFlexSpiDeviceType_SerialNOR    = 1,    // !< Flash devices are Serial NOR
+    kFlexSpiDeviceType_SerialNAND   = 2,    // !< Flash devices are Serial NAND
+    kFlexSpiDeviceType_SerialRAM    = 3,    // !< Flash devices are Serial RAM/HyperFLASH
+    kFlexSpiDeviceType_MCP_NOR_NAND = 0x12, // !< Flash device is MCP device, A1 is Serial NOR, A2 is Serial NAND
+    kFlexSpiDeviceType_MCP_NOR_RAM  = 0x13, // !< Flash deivce is MCP device, A1 is Serial NOR, A2 is Serial RAMs
 };
 
-//!@brief Flash Pad Definitions
+// !@brief Flash Pad Definitions
 enum
 {
     kSerialFlash_1Pad  = 1,
@@ -138,77 +138,77 @@ enum
     kSerialFlash_8Pads = 8,
 };
 
-//!@brief FlexSPI LUT Sequence structure
+// !@brief FlexSPI LUT Sequence structure
 typedef struct _lut_sequence
 {
-    uint8_t seqNum; //!< Sequence Number, valid number: 1-16
-    uint8_t seqId;  //!< Sequence Index, valid number: 0-15
+    uint8_t seqNum; // !< Sequence Number, valid number: 1-16
+    uint8_t seqId;  // !< Sequence Index, valid number: 0-15
     uint16_t reserved;
 } flexspi_lut_seq_t;
 
-//!@brief Flash Configuration Command Type
+// !@brief Flash Configuration Command Type
 enum
 {
-    kDeviceConfigCmdType_Generic,    //!< Generic command, for example: configure dummy cycles, drive strength, etc
-    kDeviceConfigCmdType_QuadEnable, //!< Quad Enable command
-    kDeviceConfigCmdType_Spi2Xpi,    //!< Switch from SPI to DPI/QPI/OPI mode
-    kDeviceConfigCmdType_Xpi2Spi,    //!< Switch from DPI/QPI/OPI to SPI mode
-    kDeviceConfigCmdType_Spi2NoCmd,  //!< Switch to 0-4-4/0-8-8 mode
-    kDeviceConfigCmdType_Reset,      //!< Reset device command
+    kDeviceConfigCmdType_Generic,    // !< Generic command, for example: configure dummy cycles, drive strength, etc
+    kDeviceConfigCmdType_QuadEnable, // !< Quad Enable command
+    kDeviceConfigCmdType_Spi2Xpi,    // !< Switch from SPI to DPI/QPI/OPI mode
+    kDeviceConfigCmdType_Xpi2Spi,    // !< Switch from DPI/QPI/OPI to SPI mode
+    kDeviceConfigCmdType_Spi2NoCmd,  // !< Switch to 0-4-4/0-8-8 mode
+    kDeviceConfigCmdType_Reset,      // !< Reset device command
 };
 
-//!@brief FlexSPI Memory Configuration Block
+// !@brief FlexSPI Memory Configuration Block
 typedef struct _FlexSPIConfig
 {
-    uint32_t tag;               //!< [0x000-0x003] Tag, fixed value 0x42464346UL
-    uint32_t version;           //!< [0x004-0x007] Version,[31:24] -'V', [23:16] - Major, [15:8] - Minor, [7:0] - bugfix
-    uint32_t reserved0;         //!< [0x008-0x00b] Reserved for future use
-    uint8_t readSampleClkSrc;   //!< [0x00c-0x00c] Read Sample Clock Source, valid value: 0/1/3
-    uint8_t csHoldTime;         //!< [0x00d-0x00d] CS hold time, default value: 3
-    uint8_t csSetupTime;        //!< [0x00e-0x00e] CS setup time, default value: 3
-    uint8_t columnAddressWidth; //!< [0x00f-0x00f] Column Address with, for HyperBus protocol, it is fixed to 3, For
-    //! Serial NAND, need to refer to datasheet
-    uint8_t deviceModeCfgEnable; //!< [0x010-0x010] Device Mode Configure enable flag, 1 - Enable, 0 - Disable
-    uint8_t deviceModeType; //!< [0x011-0x011] Specify the configuration command type:Quad Enable, DPI/QPI/OPI switch,
-    //! Generic configuration, etc.
-    uint16_t waitTimeCfgCommands; //!< [0x012-0x013] Wait time for all configuration commands, unit: 100us, Used for
-    //! DPI/QPI/OPI switch or reset command
-    flexspi_lut_seq_t deviceModeSeq; //!< [0x014-0x017] Device mode sequence info, [7:0] - LUT sequence id, [15:8] - LUt
-    //! sequence number, [31:16] Reserved
-    uint32_t deviceModeArg;    //!< [0x018-0x01b] Argument/Parameter for device configuration
-    uint8_t configCmdEnable;   //!< [0x01c-0x01c] Configure command Enable Flag, 1 - Enable, 0 - Disable
-    uint8_t configModeType[3]; //!< [0x01d-0x01f] Configure Mode Type, similar as deviceModeTpe
+    uint32_t tag;               // !< [0x000-0x003] Tag, fixed value 0x42464346UL
+    uint32_t version;           // !< [0x004-0x007] Version,[31:24] -'V', [23:16] - Major, [15:8] - Minor, [7:0] - bugfix
+    uint32_t reserved0;         // !< [0x008-0x00b] Reserved for future use
+    uint8_t readSampleClkSrc;   // !< [0x00c-0x00c] Read Sample Clock Source, valid value: 0/1/3
+    uint8_t csHoldTime;         // !< [0x00d-0x00d] CS hold time, default value: 3
+    uint8_t csSetupTime;        // !< [0x00e-0x00e] CS setup time, default value: 3
+    uint8_t columnAddressWidth; // !< [0x00f-0x00f] Column Address with, for HyperBus protocol, it is fixed to 3, For
+    // ! Serial NAND, need to refer to datasheet
+    uint8_t deviceModeCfgEnable; // !< [0x010-0x010] Device Mode Configure enable flag, 1 - Enable, 0 - Disable
+    uint8_t deviceModeType; // !< [0x011-0x011] Specify the configuration command type:Quad Enable, DPI/QPI/OPI switch,
+    // ! Generic configuration, etc.
+    uint16_t waitTimeCfgCommands; // !< [0x012-0x013] Wait time for all configuration commands, unit: 100us, Used for
+    // ! DPI/QPI/OPI switch or reset command
+    flexspi_lut_seq_t deviceModeSeq; // !< [0x014-0x017] Device mode sequence info, [7:0] - LUT sequence id, [15:8] - LUt
+    // ! sequence number, [31:16] Reserved
+    uint32_t deviceModeArg;    // !< [0x018-0x01b] Argument/Parameter for device configuration
+    uint8_t configCmdEnable;   // !< [0x01c-0x01c] Configure command Enable Flag, 1 - Enable, 0 - Disable
+    uint8_t configModeType[3]; // !< [0x01d-0x01f] Configure Mode Type, similar as deviceModeTpe
     flexspi_lut_seq_t
-        configCmdSeqs[3]; //!< [0x020-0x02b] Sequence info for Device Configuration command, similar as deviceModeSeq
-    uint32_t reserved1;   //!< [0x02c-0x02f] Reserved for future use
-    uint32_t configCmdArgs[3];     //!< [0x030-0x03b] Arguments/Parameters for device Configuration commands
-    uint32_t reserved2;            //!< [0x03c-0x03f] Reserved for future use
-    uint32_t controllerMiscOption; //!< [0x040-0x043] Controller Misc Options, see Misc feature bit definitions for more
-    //! details
-    uint8_t deviceType;    //!< [0x044-0x044] Device Type:  See Flash Type Definition for more details
-    uint8_t sflashPadType; //!< [0x045-0x045] Serial Flash Pad Type: 1 - Single, 2 - Dual, 4 - Quad, 8 - Octal
-    uint8_t serialClkFreq; //!< [0x046-0x046] Serial Flash Frequencey, device specific definitions, See System Boot
-    //! Chapter for more details
-    uint8_t lutCustomSeqEnable; //!< [0x047-0x047] LUT customization Enable, it is required if the program/erase cannot
-    //! be done using 1 LUT sequence, currently, only applicable to HyperFLASH
-    uint32_t reserved3[2];           //!< [0x048-0x04f] Reserved for future use
-    uint32_t sflashA1Size;           //!< [0x050-0x053] Size of Flash connected to A1
-    uint32_t sflashA2Size;           //!< [0x054-0x057] Size of Flash connected to A2
-    uint32_t sflashB1Size;           //!< [0x058-0x05b] Size of Flash connected to B1
-    uint32_t sflashB2Size;           //!< [0x05c-0x05f] Size of Flash connected to B2
-    uint32_t csPadSettingOverride;   //!< [0x060-0x063] CS pad setting override value
-    uint32_t sclkPadSettingOverride; //!< [0x064-0x067] SCK pad setting override value
-    uint32_t dataPadSettingOverride; //!< [0x068-0x06b] data pad setting override value
-    uint32_t dqsPadSettingOverride;  //!< [0x06c-0x06f] DQS pad setting override value
-    uint32_t timeoutInMs;            //!< [0x070-0x073] Timeout threshold for read status command
-    uint32_t commandInterval;        //!< [0x074-0x077] CS deselect interval between two commands
-    uint16_t dataValidTime[2]; //!< [0x078-0x07b] CLK edge to data valid time for PORT A and PORT B, in terms of 0.1ns
-    uint16_t busyOffset;       //!< [0x07c-0x07d] Busy offset, valid value: 0-31
-    uint16_t busyBitPolarity;  //!< [0x07e-0x07f] Busy flag polarity, 0 - busy flag is 1 when flash device is busy, 1 -
-    //! busy flag is 0 when flash device is busy
-    uint32_t lookupTable[64];           //!< [0x080-0x17f] Lookup table holds Flash command sequences
-    flexspi_lut_seq_t lutCustomSeq[12]; //!< [0x180-0x1af] Customizable LUT Sequences
-    uint32_t reserved4[4];              //!< [0x1b0-0x1bf] Reserved for future use
+        configCmdSeqs[3]; // !< [0x020-0x02b] Sequence info for Device Configuration command, similar as deviceModeSeq
+    uint32_t reserved1;   // !< [0x02c-0x02f] Reserved for future use
+    uint32_t configCmdArgs[3];     // !< [0x030-0x03b] Arguments/Parameters for device Configuration commands
+    uint32_t reserved2;            // !< [0x03c-0x03f] Reserved for future use
+    uint32_t controllerMiscOption; // !< [0x040-0x043] Controller Misc Options, see Misc feature bit definitions for more
+    // ! details
+    uint8_t deviceType;    // !< [0x044-0x044] Device Type:  See Flash Type Definition for more details
+    uint8_t sflashPadType; // !< [0x045-0x045] Serial Flash Pad Type: 1 - Single, 2 - Dual, 4 - Quad, 8 - Octal
+    uint8_t serialClkFreq; // !< [0x046-0x046] Serial Flash Frequencey, device specific definitions, See System Boot
+    // ! Chapter for more details
+    uint8_t lutCustomSeqEnable; // !< [0x047-0x047] LUT customization Enable, it is required if the program/erase cannot
+    // ! be done using 1 LUT sequence, currently, only applicable to HyperFLASH
+    uint32_t reserved3[2];           // !< [0x048-0x04f] Reserved for future use
+    uint32_t sflashA1Size;           // !< [0x050-0x053] Size of Flash connected to A1
+    uint32_t sflashA2Size;           // !< [0x054-0x057] Size of Flash connected to A2
+    uint32_t sflashB1Size;           // !< [0x058-0x05b] Size of Flash connected to B1
+    uint32_t sflashB2Size;           // !< [0x05c-0x05f] Size of Flash connected to B2
+    uint32_t csPadSettingOverride;   // !< [0x060-0x063] CS pad setting override value
+    uint32_t sclkPadSettingOverride; // !< [0x064-0x067] SCK pad setting override value
+    uint32_t dataPadSettingOverride; // !< [0x068-0x06b] data pad setting override value
+    uint32_t dqsPadSettingOverride;  // !< [0x06c-0x06f] DQS pad setting override value
+    uint32_t timeoutInMs;            // !< [0x070-0x073] Timeout threshold for read status command
+    uint32_t commandInterval;        // !< [0x074-0x077] CS deselect interval between two commands
+    uint16_t dataValidTime[2]; // !< [0x078-0x07b] CLK edge to data valid time for PORT A and PORT B, in terms of 0.1ns
+    uint16_t busyOffset;       // !< [0x07c-0x07d] Busy offset, valid value: 0-31
+    uint16_t busyBitPolarity;  // !< [0x07e-0x07f] Busy flag polarity, 0 - busy flag is 1 when flash device is busy, 1 -
+    // ! busy flag is 0 when flash device is busy
+    uint32_t lookupTable[64];           // !< [0x080-0x17f] Lookup table holds Flash command sequences
+    flexspi_lut_seq_t lutCustomSeq[12]; // !< [0x180-0x1af] Customizable LUT Sequences
+    uint32_t reserved4[4];              // !< [0x1b0-0x1bf] Reserved for future use
 } flexspi_mem_config_t;
 
 /*  */
@@ -231,18 +231,18 @@ typedef struct _FlexSPIConfig
  */
 typedef struct _flexspi_nor_config
 {
-    flexspi_mem_config_t memConfig; //!< Common memory configuration info via FlexSPI
-    uint32_t pageSize;              //!< Page size of Serial NOR
-    uint32_t sectorSize;            //!< Sector size of Serial NOR
-    uint8_t ipcmdSerialClkFreq;     //!< Clock frequency for IP command
-    uint8_t isUniformBlockSize;     //!< Sector/Block size is the same
-    uint8_t reserved0[2];           //!< Reserved for future use
-    uint8_t serialNorType;          //!< Serial NOR Flash type: 0/1/2/3
-    uint8_t needExitNoCmdMode;      //!< Need to exit NoCmd mode before other IP command
-    uint8_t halfClkForNonReadCmd;   //!< Half the Serial Clock for non-read command: true/false
-    uint8_t needRestoreNoCmdMode;   //!< Need to Restore NoCmd mode after IP commmand execution
-    uint32_t blockSize;             //!< Block size
-    uint32_t reserve2[11];          //!< Reserved for future use
+    flexspi_mem_config_t memConfig; // !< Common memory configuration info via FlexSPI
+    uint32_t pageSize;              // !< Page size of Serial NOR
+    uint32_t sectorSize;            // !< Sector size of Serial NOR
+    uint8_t ipcmdSerialClkFreq;     // !< Clock frequency for IP command
+    uint8_t isUniformBlockSize;     // !< Sector/Block size is the same
+    uint8_t reserved0[2];           // !< Reserved for future use
+    uint8_t serialNorType;          // !< Serial NOR Flash type: 0/1/2/3
+    uint8_t needExitNoCmdMode;      // !< Need to exit NoCmd mode before other IP command
+    uint8_t halfClkForNonReadCmd;   // !< Half the Serial Clock for non-read command: true/false
+    uint8_t needRestoreNoCmdMode;   // !< Need to Restore NoCmd mode after IP commmand execution
+    uint32_t blockSize;             // !< Block size
+    uint32_t reserve2[11];          // !< Reserved for future use
 } flexspi_nor_config_t;
 
 #define FLASH_BUSY_STATUS_POL 0

--- a/ports/mimxrt/boards/MIMXRT1020_EVK/flash_config.c
+++ b/ports/mimxrt/boards/MIMXRT1020_EVK/flash_config.c
@@ -26,110 +26,110 @@ __attribute__((section(".boot_hdr.conf")))
 
 const flexspi_nor_config_t qspiflash_config = {
     .memConfig =
-        {
-            .tag              = FLEXSPI_CFG_BLK_TAG,
-            .version          = FLEXSPI_CFG_BLK_VERSION,
-            .readSampleClkSrc = kFlexSPIReadSampleClk_LoopbackFromDqsPad,
-            .csHoldTime       = 3u,
-            .csSetupTime      = 3u,
-            .busyOffset = FLASH_BUSY_STATUS_OFFSET,     // Status bit 0 indicates busy.
-            .busyBitPolarity = FLASH_BUSY_STATUS_POL,   // Busy when the bit is 1.
-            .deviceModeCfgEnable = 1u,
-            .deviceModeType = kDeviceConfigCmdType_QuadEnable,
-            .deviceModeSeq = {
-                .seqId = 4u,
-                .seqNum = 1u,
-            },
-            .deviceModeArg = 0x40,
-            // Enable DDR mode, Wordaddassable, Safe configuration, Differential clock
-            .deviceType = kFlexSpiDeviceType_SerialNOR,
-            .sflashPadType = kSerialFlash_4Pads,
-            .serialClkFreq = kFlexSpiSerialClk_30MHz,
-            .sflashA1Size  = 8u * 1024u * 1024u,
-            .lookupTable =
-                {
-                    // 0 Read LUTs 0 -> 0
-                    FLEXSPI_LUT_SEQ(CMD_SDR, FLEXSPI_1PAD, 0xEB, RADDR_SDR, FLEXSPI_4PAD, 0x18),
-                    FLEXSPI_LUT_SEQ(DUMMY_SDR, FLEXSPI_4PAD, 0x06, READ_SDR, FLEXSPI_4PAD, 0x04),
-                    FLEXSPI_LUT_SEQ(0, 0, 0, 0, 0, 0), // Filler
-                    FLEXSPI_LUT_SEQ(0, 0, 0, 0, 0, 0), // Filler
-
-                    // 1 Read status register -> 1
-                    FLEXSPI_LUT_SEQ(CMD_SDR, FLEXSPI_1PAD, 0x05, READ_SDR, FLEXSPI_1PAD, 0x01),
-                    FLEXSPI_LUT_SEQ(0, 0, 0, 0, 0, 0), // Filler
-                    FLEXSPI_LUT_SEQ(0, 0, 0, 0, 0, 0), // Filler
-                    FLEXSPI_LUT_SEQ(0, 0, 0, 0, 0, 0), // Filler
-
-                    // 2 Fast read quad mode - SDR
-                    FLEXSPI_LUT_SEQ(CMD_SDR, FLEXSPI_1PAD, 0x6B, RADDR_SDR, FLEXSPI_1PAD, 0x18),
-                    FLEXSPI_LUT_SEQ(DUMMY_SDR, FLEXSPI_4PAD, 0x08, READ_SDR, FLEXSPI_4PAD, 0x04),
-                    FLEXSPI_LUT_SEQ(0, 0, 0, 0, 0, 0), // Filler
-                    FLEXSPI_LUT_SEQ(0, 0, 0, 0, 0, 0), // Filler
-
-                    // 3 Write Enable -> 3
-                    FLEXSPI_LUT_SEQ(CMD_SDR, FLEXSPI_1PAD, 0x06, STOP, FLEXSPI_1PAD, 0),
-                    FLEXSPI_LUT_SEQ(0, 0, 0, 0, 0, 0), // Filler
-                    FLEXSPI_LUT_SEQ(0, 0, 0, 0, 0, 0), // Filler
-                    FLEXSPI_LUT_SEQ(0, 0, 0, 0, 0, 0), // Filler
-
-                    // 4 Read extend parameters
-                    FLEXSPI_LUT_SEQ(CMD_SDR, FLEXSPI_1PAD, 0x81, READ_SDR, FLEXSPI_1PAD, 0x04),
-                    FLEXSPI_LUT_SEQ(0, 0, 0, 0, 0, 0), // Filler
-                    FLEXSPI_LUT_SEQ(0, 0, 0, 0, 0, 0), // Filler
-                    FLEXSPI_LUT_SEQ(0, 0, 0, 0, 0, 0), // Filler
-
-                    // 5 Erase Sector -> 5
-                    FLEXSPI_LUT_SEQ(CMD_SDR, FLEXSPI_1PAD, 0x20, RADDR_SDR, FLEXSPI_1PAD, 24),
-                    FLEXSPI_LUT_SEQ(0, 0, 0, 0, 0, 0), // Filler
-                    FLEXSPI_LUT_SEQ(0, 0, 0, 0, 0, 0), // Filler
-                    FLEXSPI_LUT_SEQ(0, 0, 0, 0, 0, 0), // Filler
-
-                    // 6 Write Status Reg
-                    FLEXSPI_LUT_SEQ(CMD_SDR, FLEXSPI_1PAD, 0x01, WRITE_SDR, FLEXSPI_1PAD, 0x04),
-                    FLEXSPI_LUT_SEQ(0, 0, 0, 0, 0, 0), // Filler
-                    FLEXSPI_LUT_SEQ(0, 0, 0, 0, 0, 0), // Filler
-                    FLEXSPI_LUT_SEQ(0, 0, 0, 0, 0, 0), // Filler
-
-                    // 7 Page Program - quad mode (-> 9)
-                    FLEXSPI_LUT_SEQ(CMD_SDR, FLEXSPI_1PAD, 0x32, RADDR_SDR, FLEXSPI_1PAD, 0x18),
-                    FLEXSPI_LUT_SEQ(WRITE_SDR, FLEXSPI_4PAD, 0x04, STOP, FLEXSPI_1PAD, 0),
-                    FLEXSPI_LUT_SEQ(0, 0, 0, 0, 0, 0), // Filler
-                    FLEXSPI_LUT_SEQ(0, 0, 0, 0, 0, 0), // Filler
-
-                    // 8 Read ID
-                    FLEXSPI_LUT_SEQ(CMD_SDR, FLEXSPI_1PAD, 0x90, DUMMY_SDR, FLEXSPI_1PAD, 24),
-                    FLEXSPI_LUT_SEQ(READ_SDR, FLEXSPI_1PAD, 0x00, 0, 0, 0),
-                    FLEXSPI_LUT_SEQ(0, 0, 0, 0, 0, 0), // Filler
-                    FLEXSPI_LUT_SEQ(0, 0, 0, 0, 0, 0), // Filler
-
-                    // 9 Page Program - single mode -> 9
-                    FLEXSPI_LUT_SEQ(CMD_SDR, FLEXSPI_1PAD, 0x02, RADDR_SDR, FLEXSPI_1PAD, 24),
-                    FLEXSPI_LUT_SEQ(WRITE_SDR, FLEXSPI_1PAD, 0, 0, 0, 0),
-                    FLEXSPI_LUT_SEQ(0, 0, 0, 0, 0, 0), // Filler
-                    FLEXSPI_LUT_SEQ(0, 0, 0, 0, 0, 0), // Filler
-
-                    // 10 Enter QPI mode
-                    FLEXSPI_LUT_SEQ(CMD_SDR, FLEXSPI_1PAD, 0x35, STOP, FLEXSPI_1PAD, 0),
-                    FLEXSPI_LUT_SEQ(0, 0, 0, 0, 0, 0), // Filler
-                    FLEXSPI_LUT_SEQ(0, 0, 0, 0, 0, 0), // Filler
-                    FLEXSPI_LUT_SEQ(0, 0, 0, 0, 0, 0), // Filler
-
-                    // 11 Erase Chip
-                    FLEXSPI_LUT_SEQ(CMD_SDR, FLEXSPI_1PAD, 0x60, STOP, FLEXSPI_1PAD, 0),
-                    FLEXSPI_LUT_SEQ(0, 0, 0, 0, 0, 0), // Filler
-                    FLEXSPI_LUT_SEQ(0, 0, 0, 0, 0, 0), // Filler
-                    FLEXSPI_LUT_SEQ(0, 0, 0, 0, 0, 0), // Filler
-
-                    // 12 Exit QPI mode
-                    FLEXSPI_LUT_SEQ(CMD_SDR, FLEXSPI_4PAD, 0xF5, STOP, FLEXSPI_1PAD, 0),
-                    FLEXSPI_LUT_SEQ(0, 0, 0, 0, 0, 0), // Filler
-                    FLEXSPI_LUT_SEQ(0, 0, 0, 0, 0, 0), // Filler
-                    FLEXSPI_LUT_SEQ(0, 0, 0, 0, 0, 0), // Filler
-                },
+    {
+        .tag = FLEXSPI_CFG_BLK_TAG,
+        .version = FLEXSPI_CFG_BLK_VERSION,
+        .readSampleClkSrc = kFlexSPIReadSampleClk_LoopbackFromDqsPad,
+        .csHoldTime = 3u,
+        .csSetupTime = 3u,
+        .busyOffset = FLASH_BUSY_STATUS_OFFSET,         // Status bit 0 indicates busy.
+        .busyBitPolarity = FLASH_BUSY_STATUS_POL,       // Busy when the bit is 1.
+        .deviceModeCfgEnable = 1u,
+        .deviceModeType = kDeviceConfigCmdType_QuadEnable,
+        .deviceModeSeq = {
+            .seqId = 4u,
+            .seqNum = 1u,
         },
-    .pageSize           = 256u,
-    .sectorSize         = 4u * 1024u,
-    .blockSize          = 256u * 1024u,
+        .deviceModeArg = 0x40,
+        // Enable DDR mode, Wordaddassable, Safe configuration, Differential clock
+        .deviceType = kFlexSpiDeviceType_SerialNOR,
+        .sflashPadType = kSerialFlash_4Pads,
+        .serialClkFreq = kFlexSpiSerialClk_30MHz,
+        .sflashA1Size = 8u * 1024u * 1024u,
+        .lookupTable =
+        {
+            // 0 Read LUTs 0 -> 0
+            FLEXSPI_LUT_SEQ(CMD_SDR, FLEXSPI_1PAD, 0xEB, RADDR_SDR, FLEXSPI_4PAD, 0x18),
+            FLEXSPI_LUT_SEQ(DUMMY_SDR, FLEXSPI_4PAD, 0x06, READ_SDR, FLEXSPI_4PAD, 0x04),
+            FLEXSPI_LUT_SEQ(0, 0, 0, 0, 0, 0),         // Filler
+            FLEXSPI_LUT_SEQ(0, 0, 0, 0, 0, 0),         // Filler
+
+            // 1 Read status register -> 1
+            FLEXSPI_LUT_SEQ(CMD_SDR, FLEXSPI_1PAD, 0x05, READ_SDR, FLEXSPI_1PAD, 0x01),
+            FLEXSPI_LUT_SEQ(0, 0, 0, 0, 0, 0),         // Filler
+            FLEXSPI_LUT_SEQ(0, 0, 0, 0, 0, 0),         // Filler
+            FLEXSPI_LUT_SEQ(0, 0, 0, 0, 0, 0),         // Filler
+
+            // 2 Fast read quad mode - SDR
+            FLEXSPI_LUT_SEQ(CMD_SDR, FLEXSPI_1PAD, 0x6B, RADDR_SDR, FLEXSPI_1PAD, 0x18),
+            FLEXSPI_LUT_SEQ(DUMMY_SDR, FLEXSPI_4PAD, 0x08, READ_SDR, FLEXSPI_4PAD, 0x04),
+            FLEXSPI_LUT_SEQ(0, 0, 0, 0, 0, 0),         // Filler
+            FLEXSPI_LUT_SEQ(0, 0, 0, 0, 0, 0),         // Filler
+
+            // 3 Write Enable -> 3
+            FLEXSPI_LUT_SEQ(CMD_SDR, FLEXSPI_1PAD, 0x06, STOP, FLEXSPI_1PAD, 0),
+            FLEXSPI_LUT_SEQ(0, 0, 0, 0, 0, 0),         // Filler
+            FLEXSPI_LUT_SEQ(0, 0, 0, 0, 0, 0),         // Filler
+            FLEXSPI_LUT_SEQ(0, 0, 0, 0, 0, 0),         // Filler
+
+            // 4 Read extend parameters
+            FLEXSPI_LUT_SEQ(CMD_SDR, FLEXSPI_1PAD, 0x81, READ_SDR, FLEXSPI_1PAD, 0x04),
+            FLEXSPI_LUT_SEQ(0, 0, 0, 0, 0, 0),         // Filler
+            FLEXSPI_LUT_SEQ(0, 0, 0, 0, 0, 0),         // Filler
+            FLEXSPI_LUT_SEQ(0, 0, 0, 0, 0, 0),         // Filler
+
+            // 5 Erase Sector -> 5
+            FLEXSPI_LUT_SEQ(CMD_SDR, FLEXSPI_1PAD, 0x20, RADDR_SDR, FLEXSPI_1PAD, 24),
+            FLEXSPI_LUT_SEQ(0, 0, 0, 0, 0, 0),         // Filler
+            FLEXSPI_LUT_SEQ(0, 0, 0, 0, 0, 0),         // Filler
+            FLEXSPI_LUT_SEQ(0, 0, 0, 0, 0, 0),         // Filler
+
+            // 6 Write Status Reg
+            FLEXSPI_LUT_SEQ(CMD_SDR, FLEXSPI_1PAD, 0x01, WRITE_SDR, FLEXSPI_1PAD, 0x04),
+            FLEXSPI_LUT_SEQ(0, 0, 0, 0, 0, 0),         // Filler
+            FLEXSPI_LUT_SEQ(0, 0, 0, 0, 0, 0),         // Filler
+            FLEXSPI_LUT_SEQ(0, 0, 0, 0, 0, 0),         // Filler
+
+            // 7 Page Program - quad mode (-> 9)
+            FLEXSPI_LUT_SEQ(CMD_SDR, FLEXSPI_1PAD, 0x32, RADDR_SDR, FLEXSPI_1PAD, 0x18),
+            FLEXSPI_LUT_SEQ(WRITE_SDR, FLEXSPI_4PAD, 0x04, STOP, FLEXSPI_1PAD, 0),
+            FLEXSPI_LUT_SEQ(0, 0, 0, 0, 0, 0),         // Filler
+            FLEXSPI_LUT_SEQ(0, 0, 0, 0, 0, 0),         // Filler
+
+            // 8 Read ID
+            FLEXSPI_LUT_SEQ(CMD_SDR, FLEXSPI_1PAD, 0x90, DUMMY_SDR, FLEXSPI_1PAD, 24),
+            FLEXSPI_LUT_SEQ(READ_SDR, FLEXSPI_1PAD, 0x00, 0, 0, 0),
+            FLEXSPI_LUT_SEQ(0, 0, 0, 0, 0, 0),         // Filler
+            FLEXSPI_LUT_SEQ(0, 0, 0, 0, 0, 0),         // Filler
+
+            // 9 Page Program - single mode -> 9
+            FLEXSPI_LUT_SEQ(CMD_SDR, FLEXSPI_1PAD, 0x02, RADDR_SDR, FLEXSPI_1PAD, 24),
+            FLEXSPI_LUT_SEQ(WRITE_SDR, FLEXSPI_1PAD, 0, 0, 0, 0),
+            FLEXSPI_LUT_SEQ(0, 0, 0, 0, 0, 0),         // Filler
+            FLEXSPI_LUT_SEQ(0, 0, 0, 0, 0, 0),         // Filler
+
+            // 10 Enter QPI mode
+            FLEXSPI_LUT_SEQ(CMD_SDR, FLEXSPI_1PAD, 0x35, STOP, FLEXSPI_1PAD, 0),
+            FLEXSPI_LUT_SEQ(0, 0, 0, 0, 0, 0),         // Filler
+            FLEXSPI_LUT_SEQ(0, 0, 0, 0, 0, 0),         // Filler
+            FLEXSPI_LUT_SEQ(0, 0, 0, 0, 0, 0),         // Filler
+
+            // 11 Erase Chip
+            FLEXSPI_LUT_SEQ(CMD_SDR, FLEXSPI_1PAD, 0x60, STOP, FLEXSPI_1PAD, 0),
+            FLEXSPI_LUT_SEQ(0, 0, 0, 0, 0, 0),         // Filler
+            FLEXSPI_LUT_SEQ(0, 0, 0, 0, 0, 0),         // Filler
+            FLEXSPI_LUT_SEQ(0, 0, 0, 0, 0, 0),         // Filler
+
+            // 12 Exit QPI mode
+            FLEXSPI_LUT_SEQ(CMD_SDR, FLEXSPI_4PAD, 0xF5, STOP, FLEXSPI_1PAD, 0),
+            FLEXSPI_LUT_SEQ(0, 0, 0, 0, 0, 0),         // Filler
+            FLEXSPI_LUT_SEQ(0, 0, 0, 0, 0, 0),         // Filler
+            FLEXSPI_LUT_SEQ(0, 0, 0, 0, 0, 0),         // Filler
+        },
+    },
+    .pageSize = 256u,
+    .sectorSize = 4u * 1024u,
+    .blockSize = 256u * 1024u,
     .isUniformBlockSize = false,
     .ipcmdSerialClkFreq = kFlexSpiSerialClk_30MHz,
 };

--- a/ports/mimxrt/boards/MIMXRT1020_EVK/mpconfigboard.h
+++ b/ports/mimxrt/boards/MIMXRT1020_EVK/mpconfigboard.h
@@ -43,13 +43,13 @@
     { 0 }, { 0 }, \
     { 0 }, { 0 }, \
     { IOMUXC_GPIO_AD_B1_12_LPSPI3_SCK }, { IOMUXC_GPIO_AD_B1_13_LPSPI3_PCS0 }, \
-    { IOMUXC_GPIO_AD_B1_14_LPSPI3_SDO }, { IOMUXC_GPIO_AD_B1_15_LPSPI3_SDI }, 
+    { IOMUXC_GPIO_AD_B1_14_LPSPI3_SDO }, { IOMUXC_GPIO_AD_B1_15_LPSPI3_SDI },
 
 #define DMA_REQ_SRC_RX { 0, kDmaRequestMuxLPSPI1Rx, kDmaRequestMuxLPSPI2Rx, \
-                            kDmaRequestMuxLPSPI3Rx, kDmaRequestMuxLPSPI4Rx }
+                         kDmaRequestMuxLPSPI3Rx, kDmaRequestMuxLPSPI4Rx }
 
 #define DMA_REQ_SRC_TX { 0, kDmaRequestMuxLPSPI1Tx, kDmaRequestMuxLPSPI2Tx, \
-                            kDmaRequestMuxLPSPI3Tx, kDmaRequestMuxLPSPI4Tx } 
+                         kDmaRequestMuxLPSPI3Tx, kDmaRequestMuxLPSPI4Tx }
 
 // Define mapping hardware I2C # to logical I2C #
 // SDA/SCL  HW-I2C    Logical I2C
@@ -65,14 +65,14 @@
     { 0 }, { 0 }, \
     { IOMUXC_GPIO_SD_B1_02_LPI2C4_SCL }, { IOMUXC_GPIO_SD_B1_03_LPI2C4_SDA },
 
-#define USDHC_DUMMY_PIN NULL , 0
+#define USDHC_DUMMY_PIN NULL, 0
 #define MICROPY_USDHC1 \
     { \
         .cmd = {GPIO_SD_B0_02_USDHC1_CMD}, \
         .clk = { GPIO_SD_B0_03_USDHC1_CLK }, \
-        .cd_b = { GPIO_SD_B0_06_USDHC1_CD_B },\
-        .data0 = { GPIO_SD_B0_04_USDHC1_DATA0 },\
-        .data1 = { GPIO_SD_B0_05_USDHC1_DATA1 },\
-        .data2 = { GPIO_SD_B0_00_USDHC1_DATA2 },\
-        .data3 = { GPIO_SD_B0_01_USDHC1_DATA3 },\
+        .cd_b = { GPIO_SD_B0_06_USDHC1_CD_B }, \
+        .data0 = { GPIO_SD_B0_04_USDHC1_DATA0 }, \
+        .data1 = { GPIO_SD_B0_05_USDHC1_DATA1 }, \
+        .data2 = { GPIO_SD_B0_00_USDHC1_DATA2 }, \
+        .data3 = { GPIO_SD_B0_01_USDHC1_DATA3 }, \
     }

--- a/ports/mimxrt/boards/MIMXRT1050_EVK/evkmimxrt1050_flexspi_nor_config.h
+++ b/ports/mimxrt/boards/MIMXRT1050_EVK/evkmimxrt1050_flexspi_nor_config.h
@@ -73,9 +73,9 @@
 
 #define FLEXSPI_LUT_SEQ(cmd0, pad0, op0, cmd1, pad1, op1)                                                              \
     (FLEXSPI_LUT_OPERAND0(op0) | FLEXSPI_LUT_NUM_PADS0(pad0) | FLEXSPI_LUT_OPCODE0(cmd0) | FLEXSPI_LUT_OPERAND1(op1) | \
-     FLEXSPI_LUT_NUM_PADS1(pad1) | FLEXSPI_LUT_OPCODE1(cmd1))
+    FLEXSPI_LUT_NUM_PADS1(pad1) | FLEXSPI_LUT_OPCODE1(cmd1))
 
-//!@brief Definitions for FlexSPI Serial Clock Frequency
+// !@brief Definitions for FlexSPI Serial Clock Frequency
 typedef enum _FlexSpiSerialClockFreq
 {
     kFlexSpiSerialClk_30MHz  = 1,
@@ -88,14 +88,14 @@ typedef enum _FlexSpiSerialClockFreq
     kFlexSpiSerialClk_166MHz = 8,
 } flexspi_serial_clk_freq_t;
 
-//!@brief FlexSPI clock configuration type
+// !@brief FlexSPI clock configuration type
 enum
 {
-    kFlexSpiClk_SDR, //!< Clock configure for SDR mode
-    kFlexSpiClk_DDR, //!< Clock configurat for DDR mode
+    kFlexSpiClk_SDR, // !< Clock configure for SDR mode
+    kFlexSpiClk_DDR, // !< Clock configurat for DDR mode
 };
 
-//!@brief FlexSPI Read Sample Clock Source definition
+// !@brief FlexSPI Read Sample Clock Source definition
 typedef enum _FlashReadSampleClkSource
 {
     kFlexSPIReadSampleClk_LoopbackInternally      = 0,
@@ -104,29 +104,29 @@ typedef enum _FlashReadSampleClkSource
     kFlexSPIReadSampleClk_ExternalInputFromDqsPad = 3,
 } flexspi_read_sample_clk_t;
 
-//!@brief Misc feature bit definitions
+// !@brief Misc feature bit definitions
 enum
 {
-    kFlexSpiMiscOffset_DiffClkEnable            = 0, //!< Bit for Differential clock enable
-    kFlexSpiMiscOffset_Ck2Enable                = 1, //!< Bit for CK2 enable
-    kFlexSpiMiscOffset_ParallelEnable           = 2, //!< Bit for Parallel mode enable
-    kFlexSpiMiscOffset_WordAddressableEnable    = 3, //!< Bit for Word Addressable enable
-    kFlexSpiMiscOffset_SafeConfigFreqEnable     = 4, //!< Bit for Safe Configuration Frequency enable
-    kFlexSpiMiscOffset_PadSettingOverrideEnable = 5, //!< Bit for Pad setting override enable
-    kFlexSpiMiscOffset_DdrModeEnable            = 6, //!< Bit for DDR clock confiuration indication.
+    kFlexSpiMiscOffset_DiffClkEnable            = 0, // !< Bit for Differential clock enable
+    kFlexSpiMiscOffset_Ck2Enable                = 1, // !< Bit for CK2 enable
+    kFlexSpiMiscOffset_ParallelEnable           = 2, // !< Bit for Parallel mode enable
+    kFlexSpiMiscOffset_WordAddressableEnable    = 3, // !< Bit for Word Addressable enable
+    kFlexSpiMiscOffset_SafeConfigFreqEnable     = 4, // !< Bit for Safe Configuration Frequency enable
+    kFlexSpiMiscOffset_PadSettingOverrideEnable = 5, // !< Bit for Pad setting override enable
+    kFlexSpiMiscOffset_DdrModeEnable            = 6, // !< Bit for DDR clock confiuration indication.
 };
 
-//!@brief Flash Type Definition
+// !@brief Flash Type Definition
 enum
 {
-    kFlexSpiDeviceType_SerialNOR    = 1,    //!< Flash devices are Serial NOR
-    kFlexSpiDeviceType_SerialNAND   = 2,    //!< Flash devices are Serial NAND
-    kFlexSpiDeviceType_SerialRAM    = 3,    //!< Flash devices are Serial RAM/HyperFLASH
-    kFlexSpiDeviceType_MCP_NOR_NAND = 0x12, //!< Flash device is MCP device, A1 is Serial NOR, A2 is Serial NAND
-    kFlexSpiDeviceType_MCP_NOR_RAM  = 0x13, //!< Flash deivce is MCP device, A1 is Serial NOR, A2 is Serial RAMs
+    kFlexSpiDeviceType_SerialNOR    = 1,    // !< Flash devices are Serial NOR
+    kFlexSpiDeviceType_SerialNAND   = 2,    // !< Flash devices are Serial NAND
+    kFlexSpiDeviceType_SerialRAM    = 3,    // !< Flash devices are Serial RAM/HyperFLASH
+    kFlexSpiDeviceType_MCP_NOR_NAND = 0x12, // !< Flash device is MCP device, A1 is Serial NOR, A2 is Serial NAND
+    kFlexSpiDeviceType_MCP_NOR_RAM  = 0x13, // !< Flash deivce is MCP device, A1 is Serial NOR, A2 is Serial RAMs
 };
 
-//!@brief Flash Pad Definitions
+// !@brief Flash Pad Definitions
 enum
 {
     kSerialFlash_1Pad  = 1,
@@ -135,77 +135,77 @@ enum
     kSerialFlash_8Pads = 8,
 };
 
-//!@brief FlexSPI LUT Sequence structure
+// !@brief FlexSPI LUT Sequence structure
 typedef struct _lut_sequence
 {
-    uint8_t seqNum; //!< Sequence Number, valid number: 1-16
-    uint8_t seqId;  //!< Sequence Index, valid number: 0-15
+    uint8_t seqNum; // !< Sequence Number, valid number: 1-16
+    uint8_t seqId;  // !< Sequence Index, valid number: 0-15
     uint16_t reserved;
 } flexspi_lut_seq_t;
 
-//!@brief Flash Configuration Command Type
+// !@brief Flash Configuration Command Type
 enum
 {
-    kDeviceConfigCmdType_Generic,    //!< Generic command, for example: configure dummy cycles, drive strength, etc
-    kDeviceConfigCmdType_QuadEnable, //!< Quad Enable command
-    kDeviceConfigCmdType_Spi2Xpi,    //!< Switch from SPI to DPI/QPI/OPI mode
-    kDeviceConfigCmdType_Xpi2Spi,    //!< Switch from DPI/QPI/OPI to SPI mode
-    kDeviceConfigCmdType_Spi2NoCmd,  //!< Switch to 0-4-4/0-8-8 mode
-    kDeviceConfigCmdType_Reset,      //!< Reset device command
+    kDeviceConfigCmdType_Generic,    // !< Generic command, for example: configure dummy cycles, drive strength, etc
+    kDeviceConfigCmdType_QuadEnable, // !< Quad Enable command
+    kDeviceConfigCmdType_Spi2Xpi,    // !< Switch from SPI to DPI/QPI/OPI mode
+    kDeviceConfigCmdType_Xpi2Spi,    // !< Switch from DPI/QPI/OPI to SPI mode
+    kDeviceConfigCmdType_Spi2NoCmd,  // !< Switch to 0-4-4/0-8-8 mode
+    kDeviceConfigCmdType_Reset,      // !< Reset device command
 };
 
-//!@brief FlexSPI Memory Configuration Block
+// !@brief FlexSPI Memory Configuration Block
 typedef struct _FlexSPIConfig
 {
-    uint32_t tag;               //!< [0x000-0x003] Tag, fixed value 0x42464346UL
-    uint32_t version;           //!< [0x004-0x007] Version,[31:24] -'V', [23:16] - Major, [15:8] - Minor, [7:0] - bugfix
-    uint32_t reserved0;         //!< [0x008-0x00b] Reserved for future use
-    uint8_t readSampleClkSrc;   //!< [0x00c-0x00c] Read Sample Clock Source, valid value: 0/1/3
-    uint8_t csHoldTime;         //!< [0x00d-0x00d] CS hold time, default value: 3
-    uint8_t csSetupTime;        //!< [0x00e-0x00e] CS setup time, default value: 3
-    uint8_t columnAddressWidth; //!< [0x00f-0x00f] Column Address with, for HyperBus protocol, it is fixed to 3, For
-    //! Serial NAND, need to refer to datasheet
-    uint8_t deviceModeCfgEnable; //!< [0x010-0x010] Device Mode Configure enable flag, 1 - Enable, 0 - Disable
-    uint8_t deviceModeType; //!< [0x011-0x011] Specify the configuration command type:Quad Enable, DPI/QPI/OPI switch,
-    //! Generic configuration, etc.
-    uint16_t waitTimeCfgCommands; //!< [0x012-0x013] Wait time for all configuration commands, unit: 100us, Used for
-    //! DPI/QPI/OPI switch or reset command
-    flexspi_lut_seq_t deviceModeSeq; //!< [0x014-0x017] Device mode sequence info, [7:0] - LUT sequence id, [15:8] - LUt
-    //! sequence number, [31:16] Reserved
-    uint32_t deviceModeArg;    //!< [0x018-0x01b] Argument/Parameter for device configuration
-    uint8_t configCmdEnable;   //!< [0x01c-0x01c] Configure command Enable Flag, 1 - Enable, 0 - Disable
-    uint8_t configModeType[3]; //!< [0x01d-0x01f] Configure Mode Type, similar as deviceModeTpe
+    uint32_t tag;               // !< [0x000-0x003] Tag, fixed value 0x42464346UL
+    uint32_t version;           // !< [0x004-0x007] Version,[31:24] -'V', [23:16] - Major, [15:8] - Minor, [7:0] - bugfix
+    uint32_t reserved0;         // !< [0x008-0x00b] Reserved for future use
+    uint8_t readSampleClkSrc;   // !< [0x00c-0x00c] Read Sample Clock Source, valid value: 0/1/3
+    uint8_t csHoldTime;         // !< [0x00d-0x00d] CS hold time, default value: 3
+    uint8_t csSetupTime;        // !< [0x00e-0x00e] CS setup time, default value: 3
+    uint8_t columnAddressWidth; // !< [0x00f-0x00f] Column Address with, for HyperBus protocol, it is fixed to 3, For
+    // ! Serial NAND, need to refer to datasheet
+    uint8_t deviceModeCfgEnable; // !< [0x010-0x010] Device Mode Configure enable flag, 1 - Enable, 0 - Disable
+    uint8_t deviceModeType; // !< [0x011-0x011] Specify the configuration command type:Quad Enable, DPI/QPI/OPI switch,
+    // ! Generic configuration, etc.
+    uint16_t waitTimeCfgCommands; // !< [0x012-0x013] Wait time for all configuration commands, unit: 100us, Used for
+    // ! DPI/QPI/OPI switch or reset command
+    flexspi_lut_seq_t deviceModeSeq; // !< [0x014-0x017] Device mode sequence info, [7:0] - LUT sequence id, [15:8] - LUt
+    // ! sequence number, [31:16] Reserved
+    uint32_t deviceModeArg;    // !< [0x018-0x01b] Argument/Parameter for device configuration
+    uint8_t configCmdEnable;   // !< [0x01c-0x01c] Configure command Enable Flag, 1 - Enable, 0 - Disable
+    uint8_t configModeType[3]; // !< [0x01d-0x01f] Configure Mode Type, similar as deviceModeTpe
     flexspi_lut_seq_t
-        configCmdSeqs[3]; //!< [0x020-0x02b] Sequence info for Device Configuration command, similar as deviceModeSeq
-    uint32_t reserved1;   //!< [0x02c-0x02f] Reserved for future use
-    uint32_t configCmdArgs[3];     //!< [0x030-0x03b] Arguments/Parameters for device Configuration commands
-    uint32_t reserved2;            //!< [0x03c-0x03f] Reserved for future use
-    uint32_t controllerMiscOption; //!< [0x040-0x043] Controller Misc Options, see Misc feature bit definitions for more
-    //! details
-    uint8_t deviceType;    //!< [0x044-0x044] Device Type:  See Flash Type Definition for more details
-    uint8_t sflashPadType; //!< [0x045-0x045] Serial Flash Pad Type: 1 - Single, 2 - Dual, 4 - Quad, 8 - Octal
-    uint8_t serialClkFreq; //!< [0x046-0x046] Serial Flash Frequencey, device specific definitions, See System Boot
-    //! Chapter for more details
-    uint8_t lutCustomSeqEnable; //!< [0x047-0x047] LUT customization Enable, it is required if the program/erase cannot
-    //! be done using 1 LUT sequence, currently, only applicable to HyperFLASH
-    uint32_t reserved3[2];           //!< [0x048-0x04f] Reserved for future use
-    uint32_t sflashA1Size;           //!< [0x050-0x053] Size of Flash connected to A1
-    uint32_t sflashA2Size;           //!< [0x054-0x057] Size of Flash connected to A2
-    uint32_t sflashB1Size;           //!< [0x058-0x05b] Size of Flash connected to B1
-    uint32_t sflashB2Size;           //!< [0x05c-0x05f] Size of Flash connected to B2
-    uint32_t csPadSettingOverride;   //!< [0x060-0x063] CS pad setting override value
-    uint32_t sclkPadSettingOverride; //!< [0x064-0x067] SCK pad setting override value
-    uint32_t dataPadSettingOverride; //!< [0x068-0x06b] data pad setting override value
-    uint32_t dqsPadSettingOverride;  //!< [0x06c-0x06f] DQS pad setting override value
-    uint32_t timeoutInMs;            //!< [0x070-0x073] Timeout threshold for read status command
-    uint32_t commandInterval;        //!< [0x074-0x077] CS deselect interval between two commands
-    uint16_t dataValidTime[2]; //!< [0x078-0x07b] CLK edge to data valid time for PORT A and PORT B, in terms of 0.1ns
-    uint16_t busyOffset;       //!< [0x07c-0x07d] Busy offset, valid value: 0-31
-    uint16_t busyBitPolarity;  //!< [0x07e-0x07f] Busy flag polarity, 0 - busy flag is 1 when flash device is busy, 1 -
-    //! busy flag is 0 when flash device is busy
-    uint32_t lookupTable[64];           //!< [0x080-0x17f] Lookup table holds Flash command sequences
-    flexspi_lut_seq_t lutCustomSeq[12]; //!< [0x180-0x1af] Customizable LUT Sequences
-    uint32_t reserved4[4];              //!< [0x1b0-0x1bf] Reserved for future use
+        configCmdSeqs[3]; // !< [0x020-0x02b] Sequence info for Device Configuration command, similar as deviceModeSeq
+    uint32_t reserved1;   // !< [0x02c-0x02f] Reserved for future use
+    uint32_t configCmdArgs[3];     // !< [0x030-0x03b] Arguments/Parameters for device Configuration commands
+    uint32_t reserved2;            // !< [0x03c-0x03f] Reserved for future use
+    uint32_t controllerMiscOption; // !< [0x040-0x043] Controller Misc Options, see Misc feature bit definitions for more
+    // ! details
+    uint8_t deviceType;    // !< [0x044-0x044] Device Type:  See Flash Type Definition for more details
+    uint8_t sflashPadType; // !< [0x045-0x045] Serial Flash Pad Type: 1 - Single, 2 - Dual, 4 - Quad, 8 - Octal
+    uint8_t serialClkFreq; // !< [0x046-0x046] Serial Flash Frequencey, device specific definitions, See System Boot
+    // ! Chapter for more details
+    uint8_t lutCustomSeqEnable; // !< [0x047-0x047] LUT customization Enable, it is required if the program/erase cannot
+    // ! be done using 1 LUT sequence, currently, only applicable to HyperFLASH
+    uint32_t reserved3[2];           // !< [0x048-0x04f] Reserved for future use
+    uint32_t sflashA1Size;           // !< [0x050-0x053] Size of Flash connected to A1
+    uint32_t sflashA2Size;           // !< [0x054-0x057] Size of Flash connected to A2
+    uint32_t sflashB1Size;           // !< [0x058-0x05b] Size of Flash connected to B1
+    uint32_t sflashB2Size;           // !< [0x05c-0x05f] Size of Flash connected to B2
+    uint32_t csPadSettingOverride;   // !< [0x060-0x063] CS pad setting override value
+    uint32_t sclkPadSettingOverride; // !< [0x064-0x067] SCK pad setting override value
+    uint32_t dataPadSettingOverride; // !< [0x068-0x06b] data pad setting override value
+    uint32_t dqsPadSettingOverride;  // !< [0x06c-0x06f] DQS pad setting override value
+    uint32_t timeoutInMs;            // !< [0x070-0x073] Timeout threshold for read status command
+    uint32_t commandInterval;        // !< [0x074-0x077] CS deselect interval between two commands
+    uint16_t dataValidTime[2]; // !< [0x078-0x07b] CLK edge to data valid time for PORT A and PORT B, in terms of 0.1ns
+    uint16_t busyOffset;       // !< [0x07c-0x07d] Busy offset, valid value: 0-31
+    uint16_t busyBitPolarity;  // !< [0x07e-0x07f] Busy flag polarity, 0 - busy flag is 1 when flash device is busy, 1 -
+    // ! busy flag is 0 when flash device is busy
+    uint32_t lookupTable[64];           // !< [0x080-0x17f] Lookup table holds Flash command sequences
+    flexspi_lut_seq_t lutCustomSeq[12]; // !< [0x180-0x1af] Customizable LUT Sequences
+    uint32_t reserved4[4];              // !< [0x1b0-0x1bf] Reserved for future use
 } flexspi_mem_config_t;
 
 /*  */
@@ -228,18 +228,18 @@ typedef struct _FlexSPIConfig
  */
 typedef struct _flexspi_nor_config
 {
-    flexspi_mem_config_t memConfig; //!< Common memory configuration info via FlexSPI
-    uint32_t pageSize;              //!< Page size of Serial NOR
-    uint32_t sectorSize;            //!< Sector size of Serial NOR
-    uint8_t ipcmdSerialClkFreq;     //!< Clock frequency for IP command
-    uint8_t isUniformBlockSize;     //!< Sector/Block size is the same
-    uint8_t reserved0[2];           //!< Reserved for future use
-    uint8_t serialNorType;          //!< Serial NOR Flash type: 0/1/2/3
-    uint8_t needExitNoCmdMode;      //!< Need to exit NoCmd mode before other IP command
-    uint8_t halfClkForNonReadCmd;   //!< Half the Serial Clock for non-read command: true/false
-    uint8_t needRestoreNoCmdMode;   //!< Need to Restore NoCmd mode after IP commmand execution
-    uint32_t blockSize;             //!< Block size
-    uint32_t reserve2[11];          //!< Reserved for future use
+    flexspi_mem_config_t memConfig; // !< Common memory configuration info via FlexSPI
+    uint32_t pageSize;              // !< Page size of Serial NOR
+    uint32_t sectorSize;            // !< Sector size of Serial NOR
+    uint8_t ipcmdSerialClkFreq;     // !< Clock frequency for IP command
+    uint8_t isUniformBlockSize;     // !< Sector/Block size is the same
+    uint8_t reserved0[2];           // !< Reserved for future use
+    uint8_t serialNorType;          // !< Serial NOR Flash type: 0/1/2/3
+    uint8_t needExitNoCmdMode;      // !< Need to exit NoCmd mode before other IP command
+    uint8_t halfClkForNonReadCmd;   // !< Half the Serial Clock for non-read command: true/false
+    uint8_t needRestoreNoCmdMode;   // !< Need to Restore NoCmd mode after IP commmand execution
+    uint32_t blockSize;             // !< Block size
+    uint32_t reserve2[11];          // !< Reserved for future use
 } flexspi_nor_config_t;
 
 #define FLASH_BUSY_STATUS_POL 0

--- a/ports/mimxrt/boards/MIMXRT1050_EVK/flash_config.c
+++ b/ports/mimxrt/boards/MIMXRT1050_EVK/flash_config.c
@@ -24,105 +24,105 @@ __attribute__((section(".boot_hdr.conf")))
 
 const flexspi_nor_config_t qspiflash_config = {
     .memConfig =
+    {
+        .tag = FLEXSPI_CFG_BLK_TAG,
+        .version = FLEXSPI_CFG_BLK_VERSION,
+        .readSampleClkSrc = kFlexSPIReadSampleClk_ExternalInputFromDqsPad,
+        .csHoldTime = 3u,
+        .csSetupTime = 3u,
+        .columnAddressWidth = 3u,
+        // Enable DDR mode, Wordaddassable, Safe configuration, Differential clock
+        .controllerMiscOption =
+            (1u << kFlexSpiMiscOffset_DdrModeEnable) | (1u << kFlexSpiMiscOffset_WordAddressableEnable) |
+            (1u << kFlexSpiMiscOffset_SafeConfigFreqEnable) | (1u << kFlexSpiMiscOffset_DiffClkEnable),
+        .sflashPadType = kSerialFlash_8Pads,
+        .serialClkFreq = kFlexSpiSerialClk_133MHz,
+        .sflashA1Size = 64u * 1024u * 1024u,
+        .dataValidTime = {16u, 16u},
+        .lookupTable =
         {
-            .tag                = FLEXSPI_CFG_BLK_TAG,
-            .version            = FLEXSPI_CFG_BLK_VERSION,
-            .readSampleClkSrc   = kFlexSPIReadSampleClk_ExternalInputFromDqsPad,
-            .csHoldTime         = 3u,
-            .csSetupTime        = 3u,
-            .columnAddressWidth = 3u,
-            // Enable DDR mode, Wordaddassable, Safe configuration, Differential clock
-            .controllerMiscOption =
-                (1u << kFlexSpiMiscOffset_DdrModeEnable) | (1u << kFlexSpiMiscOffset_WordAddressableEnable) |
-                (1u << kFlexSpiMiscOffset_SafeConfigFreqEnable) | (1u << kFlexSpiMiscOffset_DiffClkEnable),
-            .sflashPadType = kSerialFlash_8Pads,
-            .serialClkFreq = kFlexSpiSerialClk_133MHz,
-            .sflashA1Size  = 64u * 1024u * 1024u,
-            .dataValidTime = {16u, 16u},
-            .lookupTable =
-                {
-                    // 0 Read LUTs 0 -> 0
-                    FLEXSPI_LUT_SEQ(CMD_SDR, FLEXSPI_1PAD, 0xEB, RADDR_SDR, FLEXSPI_4PAD, 0x18),
-                    FLEXSPI_LUT_SEQ(DUMMY_SDR, FLEXSPI_4PAD, 0x06, READ_SDR, FLEXSPI_4PAD, 0x04),
-                    FLEXSPI_LUT_SEQ(0, 0, 0, 0, 0, 0), // Filler
-                    FLEXSPI_LUT_SEQ(0, 0, 0, 0, 0, 0), // Filler
+            // 0 Read LUTs 0 -> 0
+            FLEXSPI_LUT_SEQ(CMD_SDR, FLEXSPI_1PAD, 0xEB, RADDR_SDR, FLEXSPI_4PAD, 0x18),
+            FLEXSPI_LUT_SEQ(DUMMY_SDR, FLEXSPI_4PAD, 0x06, READ_SDR, FLEXSPI_4PAD, 0x04),
+            FLEXSPI_LUT_SEQ(0, 0, 0, 0, 0, 0),         // Filler
+            FLEXSPI_LUT_SEQ(0, 0, 0, 0, 0, 0),         // Filler
 
-                    // 1 Read status register -> 1
-                    FLEXSPI_LUT_SEQ(CMD_SDR, FLEXSPI_1PAD, 0x05, READ_SDR, FLEXSPI_1PAD, 0x01),
-                    FLEXSPI_LUT_SEQ(0, 0, 0, 0, 0, 0), // Filler
-                    FLEXSPI_LUT_SEQ(0, 0, 0, 0, 0, 0), // Filler
-                    FLEXSPI_LUT_SEQ(0, 0, 0, 0, 0, 0), // Filler
+            // 1 Read status register -> 1
+            FLEXSPI_LUT_SEQ(CMD_SDR, FLEXSPI_1PAD, 0x05, READ_SDR, FLEXSPI_1PAD, 0x01),
+            FLEXSPI_LUT_SEQ(0, 0, 0, 0, 0, 0),         // Filler
+            FLEXSPI_LUT_SEQ(0, 0, 0, 0, 0, 0),         // Filler
+            FLEXSPI_LUT_SEQ(0, 0, 0, 0, 0, 0),         // Filler
 
-                    // 2 Fast read quad mode - SDR
-                    FLEXSPI_LUT_SEQ(CMD_SDR, FLEXSPI_1PAD, 0x6B, RADDR_SDR, FLEXSPI_1PAD, 0x18),
-                    FLEXSPI_LUT_SEQ(DUMMY_SDR, FLEXSPI_4PAD, 0x08, READ_SDR, FLEXSPI_4PAD, 0x04),
-                    FLEXSPI_LUT_SEQ(0, 0, 0, 0, 0, 0), // Filler
-                    FLEXSPI_LUT_SEQ(0, 0, 0, 0, 0, 0), // Filler
+            // 2 Fast read quad mode - SDR
+            FLEXSPI_LUT_SEQ(CMD_SDR, FLEXSPI_1PAD, 0x6B, RADDR_SDR, FLEXSPI_1PAD, 0x18),
+            FLEXSPI_LUT_SEQ(DUMMY_SDR, FLEXSPI_4PAD, 0x08, READ_SDR, FLEXSPI_4PAD, 0x04),
+            FLEXSPI_LUT_SEQ(0, 0, 0, 0, 0, 0),         // Filler
+            FLEXSPI_LUT_SEQ(0, 0, 0, 0, 0, 0),         // Filler
 
-                    // 3 Write Enable -> 3
-                    FLEXSPI_LUT_SEQ(CMD_SDR, FLEXSPI_1PAD, 0x06, STOP, FLEXSPI_1PAD, 0),
-                    FLEXSPI_LUT_SEQ(0, 0, 0, 0, 0, 0), // Filler
-                    FLEXSPI_LUT_SEQ(0, 0, 0, 0, 0, 0), // Filler
-                    FLEXSPI_LUT_SEQ(0, 0, 0, 0, 0, 0), // Filler
+            // 3 Write Enable -> 3
+            FLEXSPI_LUT_SEQ(CMD_SDR, FLEXSPI_1PAD, 0x06, STOP, FLEXSPI_1PAD, 0),
+            FLEXSPI_LUT_SEQ(0, 0, 0, 0, 0, 0),         // Filler
+            FLEXSPI_LUT_SEQ(0, 0, 0, 0, 0, 0),         // Filler
+            FLEXSPI_LUT_SEQ(0, 0, 0, 0, 0, 0),         // Filler
 
-                    // 4 Read extend parameters
-                    FLEXSPI_LUT_SEQ(CMD_SDR, FLEXSPI_1PAD, 0x81, READ_SDR, FLEXSPI_1PAD, 0x04),
-                    FLEXSPI_LUT_SEQ(0, 0, 0, 0, 0, 0), // Filler
-                    FLEXSPI_LUT_SEQ(0, 0, 0, 0, 0, 0), // Filler
-                    FLEXSPI_LUT_SEQ(0, 0, 0, 0, 0, 0), // Filler
+            // 4 Read extend parameters
+            FLEXSPI_LUT_SEQ(CMD_SDR, FLEXSPI_1PAD, 0x81, READ_SDR, FLEXSPI_1PAD, 0x04),
+            FLEXSPI_LUT_SEQ(0, 0, 0, 0, 0, 0),         // Filler
+            FLEXSPI_LUT_SEQ(0, 0, 0, 0, 0, 0),         // Filler
+            FLEXSPI_LUT_SEQ(0, 0, 0, 0, 0, 0),         // Filler
 
-                    // 5 Erase Sector -> 5
-                    FLEXSPI_LUT_SEQ(CMD_SDR, FLEXSPI_1PAD, 0x20, RADDR_SDR, FLEXSPI_1PAD, 24),
-                    FLEXSPI_LUT_SEQ(0, 0, 0, 0, 0, 0), // Filler
-                    FLEXSPI_LUT_SEQ(0, 0, 0, 0, 0, 0), // Filler
-                    FLEXSPI_LUT_SEQ(0, 0, 0, 0, 0, 0), // Filler
+            // 5 Erase Sector -> 5
+            FLEXSPI_LUT_SEQ(CMD_SDR, FLEXSPI_1PAD, 0x20, RADDR_SDR, FLEXSPI_1PAD, 24),
+            FLEXSPI_LUT_SEQ(0, 0, 0, 0, 0, 0),         // Filler
+            FLEXSPI_LUT_SEQ(0, 0, 0, 0, 0, 0),         // Filler
+            FLEXSPI_LUT_SEQ(0, 0, 0, 0, 0, 0),         // Filler
 
-                    // 6 Write Status Reg
-                    FLEXSPI_LUT_SEQ(CMD_SDR, FLEXSPI_1PAD, 0x01, WRITE_SDR, FLEXSPI_1PAD, 0x04),
-                    FLEXSPI_LUT_SEQ(0, 0, 0, 0, 0, 0), // Filler
-                    FLEXSPI_LUT_SEQ(0, 0, 0, 0, 0, 0), // Filler
-                    FLEXSPI_LUT_SEQ(0, 0, 0, 0, 0, 0), // Filler
+            // 6 Write Status Reg
+            FLEXSPI_LUT_SEQ(CMD_SDR, FLEXSPI_1PAD, 0x01, WRITE_SDR, FLEXSPI_1PAD, 0x04),
+            FLEXSPI_LUT_SEQ(0, 0, 0, 0, 0, 0),         // Filler
+            FLEXSPI_LUT_SEQ(0, 0, 0, 0, 0, 0),         // Filler
+            FLEXSPI_LUT_SEQ(0, 0, 0, 0, 0, 0),         // Filler
 
-                    // 7 Page Program - quad mode (-> 9)
-                    FLEXSPI_LUT_SEQ(CMD_SDR, FLEXSPI_1PAD, 0x32, RADDR_SDR, FLEXSPI_1PAD, 0x18),
-                    FLEXSPI_LUT_SEQ(WRITE_SDR, FLEXSPI_4PAD, 0x04, STOP, FLEXSPI_1PAD, 0),
-                    FLEXSPI_LUT_SEQ(0, 0, 0, 0, 0, 0), // Filler
-                    FLEXSPI_LUT_SEQ(0, 0, 0, 0, 0, 0), // Filler
+            // 7 Page Program - quad mode (-> 9)
+            FLEXSPI_LUT_SEQ(CMD_SDR, FLEXSPI_1PAD, 0x32, RADDR_SDR, FLEXSPI_1PAD, 0x18),
+            FLEXSPI_LUT_SEQ(WRITE_SDR, FLEXSPI_4PAD, 0x04, STOP, FLEXSPI_1PAD, 0),
+            FLEXSPI_LUT_SEQ(0, 0, 0, 0, 0, 0),         // Filler
+            FLEXSPI_LUT_SEQ(0, 0, 0, 0, 0, 0),         // Filler
 
-                    // 8 Read ID
-                    FLEXSPI_LUT_SEQ(CMD_SDR, FLEXSPI_1PAD, 0x90, DUMMY_SDR, FLEXSPI_1PAD, 24),
-                    FLEXSPI_LUT_SEQ(READ_SDR, FLEXSPI_1PAD, 0x00, 0, 0, 0),
-                    FLEXSPI_LUT_SEQ(0, 0, 0, 0, 0, 0), // Filler
-                    FLEXSPI_LUT_SEQ(0, 0, 0, 0, 0, 0), // Filler
+            // 8 Read ID
+            FLEXSPI_LUT_SEQ(CMD_SDR, FLEXSPI_1PAD, 0x90, DUMMY_SDR, FLEXSPI_1PAD, 24),
+            FLEXSPI_LUT_SEQ(READ_SDR, FLEXSPI_1PAD, 0x00, 0, 0, 0),
+            FLEXSPI_LUT_SEQ(0, 0, 0, 0, 0, 0),         // Filler
+            FLEXSPI_LUT_SEQ(0, 0, 0, 0, 0, 0),         // Filler
 
-                    // 9 Page Program - single mode -> 9
-                    FLEXSPI_LUT_SEQ(CMD_SDR, FLEXSPI_1PAD, 0x02, RADDR_SDR, FLEXSPI_1PAD, 24),
-                    FLEXSPI_LUT_SEQ(WRITE_SDR, FLEXSPI_1PAD, 0, 0, 0, 0),
-                    FLEXSPI_LUT_SEQ(0, 0, 0, 0, 0, 0), // Filler
-                    FLEXSPI_LUT_SEQ(0, 0, 0, 0, 0, 0), // Filler
+            // 9 Page Program - single mode -> 9
+            FLEXSPI_LUT_SEQ(CMD_SDR, FLEXSPI_1PAD, 0x02, RADDR_SDR, FLEXSPI_1PAD, 24),
+            FLEXSPI_LUT_SEQ(WRITE_SDR, FLEXSPI_1PAD, 0, 0, 0, 0),
+            FLEXSPI_LUT_SEQ(0, 0, 0, 0, 0, 0),         // Filler
+            FLEXSPI_LUT_SEQ(0, 0, 0, 0, 0, 0),         // Filler
 
-                    // 10 Enter QPI mode
-                    FLEXSPI_LUT_SEQ(CMD_SDR, FLEXSPI_1PAD, 0x35, STOP, FLEXSPI_1PAD, 0),
-                    FLEXSPI_LUT_SEQ(0, 0, 0, 0, 0, 0), // Filler
-                    FLEXSPI_LUT_SEQ(0, 0, 0, 0, 0, 0), // Filler
-                    FLEXSPI_LUT_SEQ(0, 0, 0, 0, 0, 0), // Filler
+            // 10 Enter QPI mode
+            FLEXSPI_LUT_SEQ(CMD_SDR, FLEXSPI_1PAD, 0x35, STOP, FLEXSPI_1PAD, 0),
+            FLEXSPI_LUT_SEQ(0, 0, 0, 0, 0, 0),         // Filler
+            FLEXSPI_LUT_SEQ(0, 0, 0, 0, 0, 0),         // Filler
+            FLEXSPI_LUT_SEQ(0, 0, 0, 0, 0, 0),         // Filler
 
-                    // 11 Erase Chip
-                    FLEXSPI_LUT_SEQ(CMD_SDR, FLEXSPI_1PAD, 0x60, STOP, FLEXSPI_1PAD, 0),
-                    FLEXSPI_LUT_SEQ(0, 0, 0, 0, 0, 0), // Filler
-                    FLEXSPI_LUT_SEQ(0, 0, 0, 0, 0, 0), // Filler
-                    FLEXSPI_LUT_SEQ(0, 0, 0, 0, 0, 0), // Filler
+            // 11 Erase Chip
+            FLEXSPI_LUT_SEQ(CMD_SDR, FLEXSPI_1PAD, 0x60, STOP, FLEXSPI_1PAD, 0),
+            FLEXSPI_LUT_SEQ(0, 0, 0, 0, 0, 0),         // Filler
+            FLEXSPI_LUT_SEQ(0, 0, 0, 0, 0, 0),         // Filler
+            FLEXSPI_LUT_SEQ(0, 0, 0, 0, 0, 0),         // Filler
 
-                    // 12 Exit QPI mode
-                    FLEXSPI_LUT_SEQ(CMD_SDR, FLEXSPI_4PAD, 0xF5, STOP, FLEXSPI_1PAD, 0),
-                    FLEXSPI_LUT_SEQ(0, 0, 0, 0, 0, 0), // Filler
-                    FLEXSPI_LUT_SEQ(0, 0, 0, 0, 0, 0), // Filler
-                    FLEXSPI_LUT_SEQ(0, 0, 0, 0, 0, 0), // Filler
-                },
+            // 12 Exit QPI mode
+            FLEXSPI_LUT_SEQ(CMD_SDR, FLEXSPI_4PAD, 0xF5, STOP, FLEXSPI_1PAD, 0),
+            FLEXSPI_LUT_SEQ(0, 0, 0, 0, 0, 0),         // Filler
+            FLEXSPI_LUT_SEQ(0, 0, 0, 0, 0, 0),         // Filler
+            FLEXSPI_LUT_SEQ(0, 0, 0, 0, 0, 0),         // Filler
         },
-    .pageSize           = 512u,
-    .sectorSize         = 256u * 1024u,
-    .blockSize          = 256u * 1024u,
+    },
+    .pageSize = 512u,
+    .sectorSize = 256u * 1024u,
+    .blockSize = 256u * 1024u,
     .isUniformBlockSize = true,
 };
 

--- a/ports/mimxrt/boards/MIMXRT1050_EVK/mpconfigboard.h
+++ b/ports/mimxrt/boards/MIMXRT1050_EVK/mpconfigboard.h
@@ -38,10 +38,10 @@
     { IOMUXC_GPIO_SD_B0_02_LPSPI1_SDO }, { IOMUXC_GPIO_SD_B0_03_LPSPI1_SDI },
 
 #define DMA_REQ_SRC_RX { 0, kDmaRequestMuxLPSPI1Rx, kDmaRequestMuxLPSPI2Rx, \
-                            kDmaRequestMuxLPSPI3Rx, kDmaRequestMuxLPSPI4Rx }
+                         kDmaRequestMuxLPSPI3Rx, kDmaRequestMuxLPSPI4Rx }
 
 #define DMA_REQ_SRC_TX { 0, kDmaRequestMuxLPSPI1Tx, kDmaRequestMuxLPSPI2Tx, \
-                            kDmaRequestMuxLPSPI3Tx, kDmaRequestMuxLPSPI4Tx } 
+                         kDmaRequestMuxLPSPI3Tx, kDmaRequestMuxLPSPI4Tx }
 
 // Define the mapping hardware I2C # to logical I2C #
 // SDA/SCL  HW-I2C    Logical I2C
@@ -60,9 +60,9 @@
     { \
         .cmd = {GPIO_SD_B0_00_USDHC1_CMD}, \
         .clk = { GPIO_SD_B0_01_USDHC1_CLK }, \
-        .cd_b = { GPIO_B1_12_USDHC1_CD_B },\
-        .data0 = { GPIO_SD_B0_02_USDHC1_DATA0 },\
-        .data1 = { GPIO_SD_B0_03_USDHC1_DATA1 },\
-        .data2 = { GPIO_SD_B0_04_USDHC1_DATA2 },\
-        .data3 = { GPIO_SD_B0_05_USDHC1_DATA3 },\
+        .cd_b = { GPIO_B1_12_USDHC1_CD_B }, \
+        .data0 = { GPIO_SD_B0_02_USDHC1_DATA0 }, \
+        .data1 = { GPIO_SD_B0_03_USDHC1_DATA1 }, \
+        .data2 = { GPIO_SD_B0_04_USDHC1_DATA2 }, \
+        .data3 = { GPIO_SD_B0_05_USDHC1_DATA3 }, \
     }

--- a/ports/mimxrt/boards/MIMXRT1050_EVKB/evkbmimxrt1050_flexspi_nor_config.h
+++ b/ports/mimxrt/boards/MIMXRT1050_EVKB/evkbmimxrt1050_flexspi_nor_config.h
@@ -73,9 +73,9 @@
 
 #define FLEXSPI_LUT_SEQ(cmd0, pad0, op0, cmd1, pad1, op1)                                                              \
     (FLEXSPI_LUT_OPERAND0(op0) | FLEXSPI_LUT_NUM_PADS0(pad0) | FLEXSPI_LUT_OPCODE0(cmd0) | FLEXSPI_LUT_OPERAND1(op1) | \
-     FLEXSPI_LUT_NUM_PADS1(pad1) | FLEXSPI_LUT_OPCODE1(cmd1))
+    FLEXSPI_LUT_NUM_PADS1(pad1) | FLEXSPI_LUT_OPCODE1(cmd1))
 
-//!@brief Definitions for FlexSPI Serial Clock Frequency
+// !@brief Definitions for FlexSPI Serial Clock Frequency
 typedef enum _FlexSpiSerialClockFreq
 {
     kFlexSpiSerialClk_30MHz  = 1,
@@ -88,14 +88,14 @@ typedef enum _FlexSpiSerialClockFreq
     kFlexSpiSerialClk_166MHz = 8,
 } flexspi_serial_clk_freq_t;
 
-//!@brief FlexSPI clock configuration type
+// !@brief FlexSPI clock configuration type
 enum
 {
-    kFlexSpiClk_SDR, //!< Clock configure for SDR mode
-    kFlexSpiClk_DDR, //!< Clock configurat for DDR mode
+    kFlexSpiClk_SDR, // !< Clock configure for SDR mode
+    kFlexSpiClk_DDR, // !< Clock configurat for DDR mode
 };
 
-//!@brief FlexSPI Read Sample Clock Source definition
+// !@brief FlexSPI Read Sample Clock Source definition
 typedef enum _FlashReadSampleClkSource
 {
     kFlexSPIReadSampleClk_LoopbackInternally      = 0,
@@ -104,29 +104,29 @@ typedef enum _FlashReadSampleClkSource
     kFlexSPIReadSampleClk_ExternalInputFromDqsPad = 3,
 } flexspi_read_sample_clk_t;
 
-//!@brief Misc feature bit definitions
+// !@brief Misc feature bit definitions
 enum
 {
-    kFlexSpiMiscOffset_DiffClkEnable            = 0, //!< Bit for Differential clock enable
-    kFlexSpiMiscOffset_Ck2Enable                = 1, //!< Bit for CK2 enable
-    kFlexSpiMiscOffset_ParallelEnable           = 2, //!< Bit for Parallel mode enable
-    kFlexSpiMiscOffset_WordAddressableEnable    = 3, //!< Bit for Word Addressable enable
-    kFlexSpiMiscOffset_SafeConfigFreqEnable     = 4, //!< Bit for Safe Configuration Frequency enable
-    kFlexSpiMiscOffset_PadSettingOverrideEnable = 5, //!< Bit for Pad setting override enable
-    kFlexSpiMiscOffset_DdrModeEnable            = 6, //!< Bit for DDR clock confiuration indication.
+    kFlexSpiMiscOffset_DiffClkEnable            = 0, // !< Bit for Differential clock enable
+    kFlexSpiMiscOffset_Ck2Enable                = 1, // !< Bit for CK2 enable
+    kFlexSpiMiscOffset_ParallelEnable           = 2, // !< Bit for Parallel mode enable
+    kFlexSpiMiscOffset_WordAddressableEnable    = 3, // !< Bit for Word Addressable enable
+    kFlexSpiMiscOffset_SafeConfigFreqEnable     = 4, // !< Bit for Safe Configuration Frequency enable
+    kFlexSpiMiscOffset_PadSettingOverrideEnable = 5, // !< Bit for Pad setting override enable
+    kFlexSpiMiscOffset_DdrModeEnable            = 6, // !< Bit for DDR clock confiuration indication.
 };
 
-//!@brief Flash Type Definition
+// !@brief Flash Type Definition
 enum
 {
-    kFlexSpiDeviceType_SerialNOR    = 1,    //!< Flash devices are Serial NOR
-    kFlexSpiDeviceType_SerialNAND   = 2,    //!< Flash devices are Serial NAND
-    kFlexSpiDeviceType_SerialRAM    = 3,    //!< Flash devices are Serial RAM/HyperFLASH
-    kFlexSpiDeviceType_MCP_NOR_NAND = 0x12, //!< Flash device is MCP device, A1 is Serial NOR, A2 is Serial NAND
-    kFlexSpiDeviceType_MCP_NOR_RAM  = 0x13, //!< Flash deivce is MCP device, A1 is Serial NOR, A2 is Serial RAMs
+    kFlexSpiDeviceType_SerialNOR    = 1,    // !< Flash devices are Serial NOR
+    kFlexSpiDeviceType_SerialNAND   = 2,    // !< Flash devices are Serial NAND
+    kFlexSpiDeviceType_SerialRAM    = 3,    // !< Flash devices are Serial RAM/HyperFLASH
+    kFlexSpiDeviceType_MCP_NOR_NAND = 0x12, // !< Flash device is MCP device, A1 is Serial NOR, A2 is Serial NAND
+    kFlexSpiDeviceType_MCP_NOR_RAM  = 0x13, // !< Flash deivce is MCP device, A1 is Serial NOR, A2 is Serial RAMs
 };
 
-//!@brief Flash Pad Definitions
+// !@brief Flash Pad Definitions
 enum
 {
     kSerialFlash_1Pad  = 1,
@@ -135,77 +135,77 @@ enum
     kSerialFlash_8Pads = 8,
 };
 
-//!@brief FlexSPI LUT Sequence structure
+// !@brief FlexSPI LUT Sequence structure
 typedef struct _lut_sequence
 {
-    uint8_t seqNum; //!< Sequence Number, valid number: 1-16
-    uint8_t seqId;  //!< Sequence Index, valid number: 0-15
+    uint8_t seqNum; // !< Sequence Number, valid number: 1-16
+    uint8_t seqId;  // !< Sequence Index, valid number: 0-15
     uint16_t reserved;
 } flexspi_lut_seq_t;
 
-//!@brief Flash Configuration Command Type
+// !@brief Flash Configuration Command Type
 enum
 {
-    kDeviceConfigCmdType_Generic,    //!< Generic command, for example: configure dummy cycles, drive strength, etc
-    kDeviceConfigCmdType_QuadEnable, //!< Quad Enable command
-    kDeviceConfigCmdType_Spi2Xpi,    //!< Switch from SPI to DPI/QPI/OPI mode
-    kDeviceConfigCmdType_Xpi2Spi,    //!< Switch from DPI/QPI/OPI to SPI mode
-    kDeviceConfigCmdType_Spi2NoCmd,  //!< Switch to 0-4-4/0-8-8 mode
-    kDeviceConfigCmdType_Reset,      //!< Reset device command
+    kDeviceConfigCmdType_Generic,    // !< Generic command, for example: configure dummy cycles, drive strength, etc
+    kDeviceConfigCmdType_QuadEnable, // !< Quad Enable command
+    kDeviceConfigCmdType_Spi2Xpi,    // !< Switch from SPI to DPI/QPI/OPI mode
+    kDeviceConfigCmdType_Xpi2Spi,    // !< Switch from DPI/QPI/OPI to SPI mode
+    kDeviceConfigCmdType_Spi2NoCmd,  // !< Switch to 0-4-4/0-8-8 mode
+    kDeviceConfigCmdType_Reset,      // !< Reset device command
 };
 
-//!@brief FlexSPI Memory Configuration Block
+// !@brief FlexSPI Memory Configuration Block
 typedef struct _FlexSPIConfig
 {
-    uint32_t tag;               //!< [0x000-0x003] Tag, fixed value 0x42464346UL
-    uint32_t version;           //!< [0x004-0x007] Version,[31:24] -'V', [23:16] - Major, [15:8] - Minor, [7:0] - bugfix
-    uint32_t reserved0;         //!< [0x008-0x00b] Reserved for future use
-    uint8_t readSampleClkSrc;   //!< [0x00c-0x00c] Read Sample Clock Source, valid value: 0/1/3
-    uint8_t csHoldTime;         //!< [0x00d-0x00d] CS hold time, default value: 3
-    uint8_t csSetupTime;        //!< [0x00e-0x00e] CS setup time, default value: 3
-    uint8_t columnAddressWidth; //!< [0x00f-0x00f] Column Address with, for HyperBus protocol, it is fixed to 3, For
-    //! Serial NAND, need to refer to datasheet
-    uint8_t deviceModeCfgEnable; //!< [0x010-0x010] Device Mode Configure enable flag, 1 - Enable, 0 - Disable
-    uint8_t deviceModeType; //!< [0x011-0x011] Specify the configuration command type:Quad Enable, DPI/QPI/OPI switch,
-    //! Generic configuration, etc.
-    uint16_t waitTimeCfgCommands; //!< [0x012-0x013] Wait time for all configuration commands, unit: 100us, Used for
-    //! DPI/QPI/OPI switch or reset command
-    flexspi_lut_seq_t deviceModeSeq; //!< [0x014-0x017] Device mode sequence info, [7:0] - LUT sequence id, [15:8] - LUt
-    //! sequence number, [31:16] Reserved
-    uint32_t deviceModeArg;    //!< [0x018-0x01b] Argument/Parameter for device configuration
-    uint8_t configCmdEnable;   //!< [0x01c-0x01c] Configure command Enable Flag, 1 - Enable, 0 - Disable
-    uint8_t configModeType[3]; //!< [0x01d-0x01f] Configure Mode Type, similar as deviceModeTpe
+    uint32_t tag;               // !< [0x000-0x003] Tag, fixed value 0x42464346UL
+    uint32_t version;           // !< [0x004-0x007] Version,[31:24] -'V', [23:16] - Major, [15:8] - Minor, [7:0] - bugfix
+    uint32_t reserved0;         // !< [0x008-0x00b] Reserved for future use
+    uint8_t readSampleClkSrc;   // !< [0x00c-0x00c] Read Sample Clock Source, valid value: 0/1/3
+    uint8_t csHoldTime;         // !< [0x00d-0x00d] CS hold time, default value: 3
+    uint8_t csSetupTime;        // !< [0x00e-0x00e] CS setup time, default value: 3
+    uint8_t columnAddressWidth; // !< [0x00f-0x00f] Column Address with, for HyperBus protocol, it is fixed to 3, For
+    // ! Serial NAND, need to refer to datasheet
+    uint8_t deviceModeCfgEnable; // !< [0x010-0x010] Device Mode Configure enable flag, 1 - Enable, 0 - Disable
+    uint8_t deviceModeType; // !< [0x011-0x011] Specify the configuration command type:Quad Enable, DPI/QPI/OPI switch,
+    // ! Generic configuration, etc.
+    uint16_t waitTimeCfgCommands; // !< [0x012-0x013] Wait time for all configuration commands, unit: 100us, Used for
+    // ! DPI/QPI/OPI switch or reset command
+    flexspi_lut_seq_t deviceModeSeq; // !< [0x014-0x017] Device mode sequence info, [7:0] - LUT sequence id, [15:8] - LUt
+    // ! sequence number, [31:16] Reserved
+    uint32_t deviceModeArg;    // !< [0x018-0x01b] Argument/Parameter for device configuration
+    uint8_t configCmdEnable;   // !< [0x01c-0x01c] Configure command Enable Flag, 1 - Enable, 0 - Disable
+    uint8_t configModeType[3]; // !< [0x01d-0x01f] Configure Mode Type, similar as deviceModeTpe
     flexspi_lut_seq_t
-        configCmdSeqs[3]; //!< [0x020-0x02b] Sequence info for Device Configuration command, similar as deviceModeSeq
-    uint32_t reserved1;   //!< [0x02c-0x02f] Reserved for future use
-    uint32_t configCmdArgs[3];     //!< [0x030-0x03b] Arguments/Parameters for device Configuration commands
-    uint32_t reserved2;            //!< [0x03c-0x03f] Reserved for future use
-    uint32_t controllerMiscOption; //!< [0x040-0x043] Controller Misc Options, see Misc feature bit definitions for more
-    //! details
-    uint8_t deviceType;    //!< [0x044-0x044] Device Type:  See Flash Type Definition for more details
-    uint8_t sflashPadType; //!< [0x045-0x045] Serial Flash Pad Type: 1 - Single, 2 - Dual, 4 - Quad, 8 - Octal
-    uint8_t serialClkFreq; //!< [0x046-0x046] Serial Flash Frequencey, device specific definitions, See System Boot
-    //! Chapter for more details
-    uint8_t lutCustomSeqEnable; //!< [0x047-0x047] LUT customization Enable, it is required if the program/erase cannot
-    //! be done using 1 LUT sequence, currently, only applicable to HyperFLASH
-    uint32_t reserved3[2];           //!< [0x048-0x04f] Reserved for future use
-    uint32_t sflashA1Size;           //!< [0x050-0x053] Size of Flash connected to A1
-    uint32_t sflashA2Size;           //!< [0x054-0x057] Size of Flash connected to A2
-    uint32_t sflashB1Size;           //!< [0x058-0x05b] Size of Flash connected to B1
-    uint32_t sflashB2Size;           //!< [0x05c-0x05f] Size of Flash connected to B2
-    uint32_t csPadSettingOverride;   //!< [0x060-0x063] CS pad setting override value
-    uint32_t sclkPadSettingOverride; //!< [0x064-0x067] SCK pad setting override value
-    uint32_t dataPadSettingOverride; //!< [0x068-0x06b] data pad setting override value
-    uint32_t dqsPadSettingOverride;  //!< [0x06c-0x06f] DQS pad setting override value
-    uint32_t timeoutInMs;            //!< [0x070-0x073] Timeout threshold for read status command
-    uint32_t commandInterval;        //!< [0x074-0x077] CS deselect interval between two commands
-    uint16_t dataValidTime[2]; //!< [0x078-0x07b] CLK edge to data valid time for PORT A and PORT B, in terms of 0.1ns
-    uint16_t busyOffset;       //!< [0x07c-0x07d] Busy offset, valid value: 0-31
-    uint16_t busyBitPolarity;  //!< [0x07e-0x07f] Busy flag polarity, 0 - busy flag is 1 when flash device is busy, 1 -
-    //! busy flag is 0 when flash device is busy
-    uint32_t lookupTable[64];           //!< [0x080-0x17f] Lookup table holds Flash command sequences
-    flexspi_lut_seq_t lutCustomSeq[12]; //!< [0x180-0x1af] Customizable LUT Sequences
-    uint32_t reserved4[4];              //!< [0x1b0-0x1bf] Reserved for future use
+        configCmdSeqs[3]; // !< [0x020-0x02b] Sequence info for Device Configuration command, similar as deviceModeSeq
+    uint32_t reserved1;   // !< [0x02c-0x02f] Reserved for future use
+    uint32_t configCmdArgs[3];     // !< [0x030-0x03b] Arguments/Parameters for device Configuration commands
+    uint32_t reserved2;            // !< [0x03c-0x03f] Reserved for future use
+    uint32_t controllerMiscOption; // !< [0x040-0x043] Controller Misc Options, see Misc feature bit definitions for more
+    // ! details
+    uint8_t deviceType;    // !< [0x044-0x044] Device Type:  See Flash Type Definition for more details
+    uint8_t sflashPadType; // !< [0x045-0x045] Serial Flash Pad Type: 1 - Single, 2 - Dual, 4 - Quad, 8 - Octal
+    uint8_t serialClkFreq; // !< [0x046-0x046] Serial Flash Frequencey, device specific definitions, See System Boot
+    // ! Chapter for more details
+    uint8_t lutCustomSeqEnable; // !< [0x047-0x047] LUT customization Enable, it is required if the program/erase cannot
+    // ! be done using 1 LUT sequence, currently, only applicable to HyperFLASH
+    uint32_t reserved3[2];           // !< [0x048-0x04f] Reserved for future use
+    uint32_t sflashA1Size;           // !< [0x050-0x053] Size of Flash connected to A1
+    uint32_t sflashA2Size;           // !< [0x054-0x057] Size of Flash connected to A2
+    uint32_t sflashB1Size;           // !< [0x058-0x05b] Size of Flash connected to B1
+    uint32_t sflashB2Size;           // !< [0x05c-0x05f] Size of Flash connected to B2
+    uint32_t csPadSettingOverride;   // !< [0x060-0x063] CS pad setting override value
+    uint32_t sclkPadSettingOverride; // !< [0x064-0x067] SCK pad setting override value
+    uint32_t dataPadSettingOverride; // !< [0x068-0x06b] data pad setting override value
+    uint32_t dqsPadSettingOverride;  // !< [0x06c-0x06f] DQS pad setting override value
+    uint32_t timeoutInMs;            // !< [0x070-0x073] Timeout threshold for read status command
+    uint32_t commandInterval;        // !< [0x074-0x077] CS deselect interval between two commands
+    uint16_t dataValidTime[2]; // !< [0x078-0x07b] CLK edge to data valid time for PORT A and PORT B, in terms of 0.1ns
+    uint16_t busyOffset;       // !< [0x07c-0x07d] Busy offset, valid value: 0-31
+    uint16_t busyBitPolarity;  // !< [0x07e-0x07f] Busy flag polarity, 0 - busy flag is 1 when flash device is busy, 1 -
+    // ! busy flag is 0 when flash device is busy
+    uint32_t lookupTable[64];           // !< [0x080-0x17f] Lookup table holds Flash command sequences
+    flexspi_lut_seq_t lutCustomSeq[12]; // !< [0x180-0x1af] Customizable LUT Sequences
+    uint32_t reserved4[4];              // !< [0x1b0-0x1bf] Reserved for future use
 } flexspi_mem_config_t;
 
 /*  */
@@ -236,18 +236,18 @@ typedef struct _FlexSPIConfig
  */
 typedef struct _flexspi_nor_config
 {
-    flexspi_mem_config_t memConfig; //!< Common memory configuration info via FlexSPI
-    uint32_t pageSize;              //!< Page size of Serial NOR
-    uint32_t sectorSize;            //!< Sector size of Serial NOR
-    uint8_t ipcmdSerialClkFreq;     //!< Clock frequency for IP command
-    uint8_t isUniformBlockSize;     //!< Sector/Block size is the same
-    uint8_t reserved0[2];           //!< Reserved for future use
-    uint8_t serialNorType;          //!< Serial NOR Flash type: 0/1/2/3
-    uint8_t needExitNoCmdMode;      //!< Need to exit NoCmd mode before other IP command
-    uint8_t halfClkForNonReadCmd;   //!< Half the Serial Clock for non-read command: true/false
-    uint8_t needRestoreNoCmdMode;   //!< Need to Restore NoCmd mode after IP commmand execution
-    uint32_t blockSize;             //!< Block size
-    uint32_t reserve2[11];          //!< Reserved for future use
+    flexspi_mem_config_t memConfig; // !< Common memory configuration info via FlexSPI
+    uint32_t pageSize;              // !< Page size of Serial NOR
+    uint32_t sectorSize;            // !< Sector size of Serial NOR
+    uint8_t ipcmdSerialClkFreq;     // !< Clock frequency for IP command
+    uint8_t isUniformBlockSize;     // !< Sector/Block size is the same
+    uint8_t reserved0[2];           // !< Reserved for future use
+    uint8_t serialNorType;          // !< Serial NOR Flash type: 0/1/2/3
+    uint8_t needExitNoCmdMode;      // !< Need to exit NoCmd mode before other IP command
+    uint8_t halfClkForNonReadCmd;   // !< Half the Serial Clock for non-read command: true/false
+    uint8_t needRestoreNoCmdMode;   // !< Need to Restore NoCmd mode after IP commmand execution
+    uint32_t blockSize;             // !< Block size
+    uint32_t reserve2[11];          // !< Reserved for future use
 } flexspi_nor_config_t;
 
 #define FLASH_BUSY_STATUS_POL 0

--- a/ports/mimxrt/boards/MIMXRT1050_EVKB/flash_config.c
+++ b/ports/mimxrt/boards/MIMXRT1050_EVKB/flash_config.c
@@ -24,162 +24,162 @@ __attribute__((section(".boot_hdr.conf")))
 
 const flexspi_nor_config_t qspiflash_config = {
     .memConfig =
+    {
+        .tag = FLEXSPI_CFG_BLK_TAG,
+        .version = FLEXSPI_CFG_BLK_VERSION,
+        .readSampleClkSrc = kFlexSPIReadSampleClk_ExternalInputFromDqsPad,
+        .csHoldTime = 3u,
+        .csSetupTime = 3u,
+        .columnAddressWidth = 3u,
+        // Enable DDR mode, Wordaddressable, Safe configuration, Differential clock
+        .controllerMiscOption =
+            (1u << kFlexSpiMiscOffset_DdrModeEnable) | (1u << kFlexSpiMiscOffset_WordAddressableEnable) |
+            (1u << kFlexSpiMiscOffset_SafeConfigFreqEnable) | (1u << kFlexSpiMiscOffset_DiffClkEnable),
+        .sflashPadType = kSerialFlash_8Pads,
+        .serialClkFreq = kFlexSpiSerialClk_133MHz,
+        .sflashA1Size = 64u * 1024u * 1024u,
+        .dataValidTime = {16u, 16u},
+        .lookupTable =
         {
-            .tag                = FLEXSPI_CFG_BLK_TAG,
-            .version            = FLEXSPI_CFG_BLK_VERSION,
-            .readSampleClkSrc   = kFlexSPIReadSampleClk_ExternalInputFromDqsPad,
-            .csHoldTime         = 3u,
-            .csSetupTime        = 3u,
-            .columnAddressWidth = 3u,
-            // Enable DDR mode, Wordaddressable, Safe configuration, Differential clock
-            .controllerMiscOption =
-                (1u << kFlexSpiMiscOffset_DdrModeEnable) | (1u << kFlexSpiMiscOffset_WordAddressableEnable) |
-                (1u << kFlexSpiMiscOffset_SafeConfigFreqEnable) | (1u << kFlexSpiMiscOffset_DiffClkEnable),
-            .sflashPadType = kSerialFlash_8Pads,
-            .serialClkFreq = kFlexSpiSerialClk_133MHz,
-            .sflashA1Size  = 64u * 1024u * 1024u,
-            .dataValidTime = {16u, 16u},
-            .lookupTable =
-                {
-                    /* 0 Read Data */
-                    [4 * HYPERFLASH_CMD_LUT_SEQ_IDX_READDATA] =
-                        FLEXSPI_LUT_SEQ(kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0xA0, kFLEXSPI_Command_RADDR_DDR, kFLEXSPI_8PAD, 0x18),
-                    [4 * HYPERFLASH_CMD_LUT_SEQ_IDX_READDATA + 1] = FLEXSPI_LUT_SEQ(
-                        kFLEXSPI_Command_CADDR_DDR, kFLEXSPI_8PAD, 0x10, kFLEXSPI_Command_READ_DDR, kFLEXSPI_8PAD, 0x04),
+            /* 0 Read Data */
+            [4 * HYPERFLASH_CMD_LUT_SEQ_IDX_READDATA] =
+                FLEXSPI_LUT_SEQ(kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0xA0, kFLEXSPI_Command_RADDR_DDR, kFLEXSPI_8PAD, 0x18),
+            [4 * HYPERFLASH_CMD_LUT_SEQ_IDX_READDATA + 1] = FLEXSPI_LUT_SEQ(
+                kFLEXSPI_Command_CADDR_DDR, kFLEXSPI_8PAD, 0x10, kFLEXSPI_Command_READ_DDR, kFLEXSPI_8PAD, 0x04),
 
-                    /* 1 Write Data */
-                    [4 * HYPERFLASH_CMD_LUT_SEQ_IDX_WRITEDATA] =
-                        FLEXSPI_LUT_SEQ(kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0x20, kFLEXSPI_Command_RADDR_DDR, kFLEXSPI_8PAD, 0x18),
-                    [4 * HYPERFLASH_CMD_LUT_SEQ_IDX_WRITEDATA + 1] = FLEXSPI_LUT_SEQ(
-                        kFLEXSPI_Command_CADDR_DDR, kFLEXSPI_8PAD, 0x10, kFLEXSPI_Command_WRITE_DDR, kFLEXSPI_8PAD, 0x02),
+            /* 1 Write Data */
+            [4 * HYPERFLASH_CMD_LUT_SEQ_IDX_WRITEDATA] =
+                FLEXSPI_LUT_SEQ(kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0x20, kFLEXSPI_Command_RADDR_DDR, kFLEXSPI_8PAD, 0x18),
+            [4 * HYPERFLASH_CMD_LUT_SEQ_IDX_WRITEDATA + 1] = FLEXSPI_LUT_SEQ(
+                kFLEXSPI_Command_CADDR_DDR, kFLEXSPI_8PAD, 0x10, kFLEXSPI_Command_WRITE_DDR, kFLEXSPI_8PAD, 0x02),
 
-                    /* 2 Read Status */
-                    [4 * HYPERFLASH_CMD_LUT_SEQ_IDX_READSTATUS] =
-                        FLEXSPI_LUT_SEQ(kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0x00, kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0x00),
-                    [4 * HYPERFLASH_CMD_LUT_SEQ_IDX_READSTATUS + 1] = FLEXSPI_LUT_SEQ(
-                        kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0x00, kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0xAA), // ADDR 0x555
-                    [4 * HYPERFLASH_CMD_LUT_SEQ_IDX_READSTATUS + 2] =
-                        FLEXSPI_LUT_SEQ(kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0x00, kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0x05),
-                    [4 * HYPERFLASH_CMD_LUT_SEQ_IDX_READSTATUS + 3] = FLEXSPI_LUT_SEQ(
-                        kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0x00, kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0x70), // DATA 0x70
-                    // +1
-                    [4 * HYPERFLASH_CMD_LUT_SEQ_IDX_READSTATUS + 4] =
-                        FLEXSPI_LUT_SEQ(kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0xA0, kFLEXSPI_Command_RADDR_DDR, kFLEXSPI_8PAD, 0x18),
-                    [4 * HYPERFLASH_CMD_LUT_SEQ_IDX_READSTATUS + 5] = FLEXSPI_LUT_SEQ(
-                        kFLEXSPI_Command_CADDR_DDR, kFLEXSPI_8PAD, 0x10, kFLEXSPI_Command_DUMMY_RWDS_DDR, kFLEXSPI_8PAD, 0x0B),
-                    [4 * HYPERFLASH_CMD_LUT_SEQ_IDX_READSTATUS + 6] =
-                        FLEXSPI_LUT_SEQ(kFLEXSPI_Command_READ_DDR, kFLEXSPI_8PAD, 0x04, kFLEXSPI_Command_STOP, kFLEXSPI_1PAD, 0x0),
+            /* 2 Read Status */
+            [4 * HYPERFLASH_CMD_LUT_SEQ_IDX_READSTATUS] =
+                FLEXSPI_LUT_SEQ(kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0x00, kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0x00),
+            [4 * HYPERFLASH_CMD_LUT_SEQ_IDX_READSTATUS + 1] = FLEXSPI_LUT_SEQ(
+                kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0x00, kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0xAA),         // ADDR 0x555
+            [4 * HYPERFLASH_CMD_LUT_SEQ_IDX_READSTATUS + 2] =
+                FLEXSPI_LUT_SEQ(kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0x00, kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0x05),
+            [4 * HYPERFLASH_CMD_LUT_SEQ_IDX_READSTATUS + 3] = FLEXSPI_LUT_SEQ(
+                kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0x00, kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0x70),         // DATA 0x70
+            // +1
+            [4 * HYPERFLASH_CMD_LUT_SEQ_IDX_READSTATUS + 4] =
+                FLEXSPI_LUT_SEQ(kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0xA0, kFLEXSPI_Command_RADDR_DDR, kFLEXSPI_8PAD, 0x18),
+            [4 * HYPERFLASH_CMD_LUT_SEQ_IDX_READSTATUS + 5] = FLEXSPI_LUT_SEQ(
+                kFLEXSPI_Command_CADDR_DDR, kFLEXSPI_8PAD, 0x10, kFLEXSPI_Command_DUMMY_RWDS_DDR, kFLEXSPI_8PAD, 0x0B),
+            [4 * HYPERFLASH_CMD_LUT_SEQ_IDX_READSTATUS + 6] =
+                FLEXSPI_LUT_SEQ(kFLEXSPI_Command_READ_DDR, kFLEXSPI_8PAD, 0x04, kFLEXSPI_Command_STOP, kFLEXSPI_1PAD, 0x0),
 
-                    /* 4 Write Enable */
-                    [4 * HYPERFLASH_CMD_LUT_SEQ_IDX_WRITEENABLE] =
-                        FLEXSPI_LUT_SEQ(kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0x20, kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0x00),
-                    [4 * HYPERFLASH_CMD_LUT_SEQ_IDX_WRITEENABLE + 1] = FLEXSPI_LUT_SEQ(
-                        kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0x00, kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0xAA), // ADDR 0x555
-                    [4 * HYPERFLASH_CMD_LUT_SEQ_IDX_WRITEENABLE + 2] =
-                        FLEXSPI_LUT_SEQ(kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0x00, kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0x05),
-                    [4 * HYPERFLASH_CMD_LUT_SEQ_IDX_WRITEENABLE + 3] = FLEXSPI_LUT_SEQ(
-                        kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0x00, kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0xAA), // DATA 0xAA
-                    // +1
-                    [4 * HYPERFLASH_CMD_LUT_SEQ_IDX_WRITEENABLE + 4] =
-                        FLEXSPI_LUT_SEQ(kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0x20, kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0x00),
-                    [4 * HYPERFLASH_CMD_LUT_SEQ_IDX_WRITEENABLE + 5] =
-                        FLEXSPI_LUT_SEQ(kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0x00, kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0x55),
-                    [4 * HYPERFLASH_CMD_LUT_SEQ_IDX_WRITEENABLE + 6] =
-                        FLEXSPI_LUT_SEQ(kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0x00, kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0x02),
-                    [4 * HYPERFLASH_CMD_LUT_SEQ_IDX_WRITEENABLE + 7] =
-                        FLEXSPI_LUT_SEQ(kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0x00, kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0x55),
+            /* 4 Write Enable */
+            [4 * HYPERFLASH_CMD_LUT_SEQ_IDX_WRITEENABLE] =
+                FLEXSPI_LUT_SEQ(kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0x20, kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0x00),
+            [4 * HYPERFLASH_CMD_LUT_SEQ_IDX_WRITEENABLE + 1] = FLEXSPI_LUT_SEQ(
+                kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0x00, kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0xAA),         // ADDR 0x555
+            [4 * HYPERFLASH_CMD_LUT_SEQ_IDX_WRITEENABLE + 2] =
+                FLEXSPI_LUT_SEQ(kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0x00, kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0x05),
+            [4 * HYPERFLASH_CMD_LUT_SEQ_IDX_WRITEENABLE + 3] = FLEXSPI_LUT_SEQ(
+                kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0x00, kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0xAA),         // DATA 0xAA
+            // +1
+            [4 * HYPERFLASH_CMD_LUT_SEQ_IDX_WRITEENABLE + 4] =
+                FLEXSPI_LUT_SEQ(kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0x20, kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0x00),
+            [4 * HYPERFLASH_CMD_LUT_SEQ_IDX_WRITEENABLE + 5] =
+                FLEXSPI_LUT_SEQ(kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0x00, kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0x55),
+            [4 * HYPERFLASH_CMD_LUT_SEQ_IDX_WRITEENABLE + 6] =
+                FLEXSPI_LUT_SEQ(kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0x00, kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0x02),
+            [4 * HYPERFLASH_CMD_LUT_SEQ_IDX_WRITEENABLE + 7] =
+                FLEXSPI_LUT_SEQ(kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0x00, kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0x55),
 
-                    /* 6 Erase Sector  */
-                    [4 * HYPERFLASH_CMD_LUT_SEQ_IDX_ERASESECTOR] =
-                        FLEXSPI_LUT_SEQ(kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0x00, kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0x00),
-                    [4 * HYPERFLASH_CMD_LUT_SEQ_IDX_ERASESECTOR + 1] = FLEXSPI_LUT_SEQ(
-                        kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0x00, kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0xAA), // ADDR 0x555
-                    [4 * HYPERFLASH_CMD_LUT_SEQ_IDX_ERASESECTOR + 2] =
-                        FLEXSPI_LUT_SEQ(kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0x00, kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0x05),
-                    [4 * HYPERFLASH_CMD_LUT_SEQ_IDX_ERASESECTOR + 3] = FLEXSPI_LUT_SEQ(
-                        kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0x00, kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0x80), // DATA 0x80
-                    // +1
-                    [4 * HYPERFLASH_CMD_LUT_SEQ_IDX_ERASESECTOR + 4] =
-                        FLEXSPI_LUT_SEQ(kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0x00, kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0x00),
-                    [4 * HYPERFLASH_CMD_LUT_SEQ_IDX_ERASESECTOR + 5] =
-                        FLEXSPI_LUT_SEQ(kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0x00, kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0xAA),
-                    [4 * HYPERFLASH_CMD_LUT_SEQ_IDX_ERASESECTOR + 6] =
-                        FLEXSPI_LUT_SEQ(kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0x00, kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0x05),
-                    [4 * HYPERFLASH_CMD_LUT_SEQ_IDX_ERASESECTOR + 7] = FLEXSPI_LUT_SEQ(
-                        kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0x00, kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0xAA), // ADDR 0x555
-                    // +2
-                    [4 * HYPERFLASH_CMD_LUT_SEQ_IDX_ERASESECTOR + 8] =
-                        FLEXSPI_LUT_SEQ(kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0x00, kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0x00),
-                    [4 * HYPERFLASH_CMD_LUT_SEQ_IDX_ERASESECTOR + 9] =
-                        FLEXSPI_LUT_SEQ(kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0x00, kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0x55),
-                    [4 * HYPERFLASH_CMD_LUT_SEQ_IDX_ERASESECTOR + 10] =
-                        FLEXSPI_LUT_SEQ(kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0x00, kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0x02),
-                    [4 * HYPERFLASH_CMD_LUT_SEQ_IDX_ERASESECTOR + 11] =
-                        FLEXSPI_LUT_SEQ(kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0x00, kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0x55),
-                    // +3
-                    [4 * HYPERFLASH_CMD_LUT_SEQ_IDX_ERASESECTOR + 12] =
-                        FLEXSPI_LUT_SEQ(kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0x00, kFLEXSPI_Command_RADDR_DDR, kFLEXSPI_8PAD, 0x18),
-                    [4 * HYPERFLASH_CMD_LUT_SEQ_IDX_ERASESECTOR + 13] =
-                        FLEXSPI_LUT_SEQ(kFLEXSPI_Command_CADDR_DDR, kFLEXSPI_8PAD, 0x10, kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0x00),
-                    [4 * HYPERFLASH_CMD_LUT_SEQ_IDX_ERASESECTOR + 14] =
-                        FLEXSPI_LUT_SEQ(kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0x30, kFLEXSPI_Command_STOP, kFLEXSPI_1PAD, 0x00),
+            /* 6 Erase Sector  */
+            [4 * HYPERFLASH_CMD_LUT_SEQ_IDX_ERASESECTOR] =
+                FLEXSPI_LUT_SEQ(kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0x00, kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0x00),
+            [4 * HYPERFLASH_CMD_LUT_SEQ_IDX_ERASESECTOR + 1] = FLEXSPI_LUT_SEQ(
+                kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0x00, kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0xAA),         // ADDR 0x555
+            [4 * HYPERFLASH_CMD_LUT_SEQ_IDX_ERASESECTOR + 2] =
+                FLEXSPI_LUT_SEQ(kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0x00, kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0x05),
+            [4 * HYPERFLASH_CMD_LUT_SEQ_IDX_ERASESECTOR + 3] = FLEXSPI_LUT_SEQ(
+                kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0x00, kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0x80),         // DATA 0x80
+            // +1
+            [4 * HYPERFLASH_CMD_LUT_SEQ_IDX_ERASESECTOR + 4] =
+                FLEXSPI_LUT_SEQ(kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0x00, kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0x00),
+            [4 * HYPERFLASH_CMD_LUT_SEQ_IDX_ERASESECTOR + 5] =
+                FLEXSPI_LUT_SEQ(kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0x00, kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0xAA),
+            [4 * HYPERFLASH_CMD_LUT_SEQ_IDX_ERASESECTOR + 6] =
+                FLEXSPI_LUT_SEQ(kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0x00, kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0x05),
+            [4 * HYPERFLASH_CMD_LUT_SEQ_IDX_ERASESECTOR + 7] = FLEXSPI_LUT_SEQ(
+                kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0x00, kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0xAA),         // ADDR 0x555
+            // +2
+            [4 * HYPERFLASH_CMD_LUT_SEQ_IDX_ERASESECTOR + 8] =
+                FLEXSPI_LUT_SEQ(kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0x00, kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0x00),
+            [4 * HYPERFLASH_CMD_LUT_SEQ_IDX_ERASESECTOR + 9] =
+                FLEXSPI_LUT_SEQ(kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0x00, kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0x55),
+            [4 * HYPERFLASH_CMD_LUT_SEQ_IDX_ERASESECTOR + 10] =
+                FLEXSPI_LUT_SEQ(kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0x00, kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0x02),
+            [4 * HYPERFLASH_CMD_LUT_SEQ_IDX_ERASESECTOR + 11] =
+                FLEXSPI_LUT_SEQ(kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0x00, kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0x55),
+            // +3
+            [4 * HYPERFLASH_CMD_LUT_SEQ_IDX_ERASESECTOR + 12] =
+                FLEXSPI_LUT_SEQ(kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0x00, kFLEXSPI_Command_RADDR_DDR, kFLEXSPI_8PAD, 0x18),
+            [4 * HYPERFLASH_CMD_LUT_SEQ_IDX_ERASESECTOR + 13] =
+                FLEXSPI_LUT_SEQ(kFLEXSPI_Command_CADDR_DDR, kFLEXSPI_8PAD, 0x10, kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0x00),
+            [4 * HYPERFLASH_CMD_LUT_SEQ_IDX_ERASESECTOR + 14] =
+                FLEXSPI_LUT_SEQ(kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0x30, kFLEXSPI_Command_STOP, kFLEXSPI_1PAD, 0x00),
 
-                    /* 10 program page with word program command sequence */
-                    [4 * HYPERFLASH_CMD_LUT_SEQ_IDX_PAGEPROGRAM] =
-                        FLEXSPI_LUT_SEQ(kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0x20, kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0x00),
-                    [4 * HYPERFLASH_CMD_LUT_SEQ_IDX_PAGEPROGRAM + 1] = FLEXSPI_LUT_SEQ(
-                        kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0x00, kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0xAA), // ADDR 0x555
-                    [4 * HYPERFLASH_CMD_LUT_SEQ_IDX_PAGEPROGRAM + 2] =
-                        FLEXSPI_LUT_SEQ(kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0x00, kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0x05),
-                    [4 * HYPERFLASH_CMD_LUT_SEQ_IDX_PAGEPROGRAM + 3] = FLEXSPI_LUT_SEQ(
-                        kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0x00, kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0xA0), // DATA 0xA0
-                    // +1
-                    [4 * HYPERFLASH_CMD_LUT_SEQ_IDX_PAGEPROGRAM + 4] =
-                        FLEXSPI_LUT_SEQ(kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0x20, kFLEXSPI_Command_RADDR_DDR, kFLEXSPI_8PAD, 0x18),
-                    [4 * HYPERFLASH_CMD_LUT_SEQ_IDX_PAGEPROGRAM + 5] = FLEXSPI_LUT_SEQ(
-                        kFLEXSPI_Command_CADDR_DDR, kFLEXSPI_8PAD, 0x10, kFLEXSPI_Command_WRITE_DDR, kFLEXSPI_8PAD, 0x80),
+            /* 10 program page with word program command sequence */
+            [4 * HYPERFLASH_CMD_LUT_SEQ_IDX_PAGEPROGRAM] =
+                FLEXSPI_LUT_SEQ(kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0x20, kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0x00),
+            [4 * HYPERFLASH_CMD_LUT_SEQ_IDX_PAGEPROGRAM + 1] = FLEXSPI_LUT_SEQ(
+                kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0x00, kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0xAA),         // ADDR 0x555
+            [4 * HYPERFLASH_CMD_LUT_SEQ_IDX_PAGEPROGRAM + 2] =
+                FLEXSPI_LUT_SEQ(kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0x00, kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0x05),
+            [4 * HYPERFLASH_CMD_LUT_SEQ_IDX_PAGEPROGRAM + 3] = FLEXSPI_LUT_SEQ(
+                kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0x00, kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0xA0),         // DATA 0xA0
+            // +1
+            [4 * HYPERFLASH_CMD_LUT_SEQ_IDX_PAGEPROGRAM + 4] =
+                FLEXSPI_LUT_SEQ(kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0x20, kFLEXSPI_Command_RADDR_DDR, kFLEXSPI_8PAD, 0x18),
+            [4 * HYPERFLASH_CMD_LUT_SEQ_IDX_PAGEPROGRAM + 5] = FLEXSPI_LUT_SEQ(
+                kFLEXSPI_Command_CADDR_DDR, kFLEXSPI_8PAD, 0x10, kFLEXSPI_Command_WRITE_DDR, kFLEXSPI_8PAD, 0x80),
 
-                    /* 12 Erase chip */
-                    [4 * HYPERFLASH_CMD_LUT_SEQ_IDX_ERASECHIP] =
-                        FLEXSPI_LUT_SEQ(kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0x00, kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0x00),
-                    [4 * HYPERFLASH_CMD_LUT_SEQ_IDX_ERASECHIP + 1] =
-                        FLEXSPI_LUT_SEQ(kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0x00, kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0xAA),
-                    [4 * HYPERFLASH_CMD_LUT_SEQ_IDX_ERASECHIP + 2] =
-                        FLEXSPI_LUT_SEQ(kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0x00, kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0x05),
-                    [4 * HYPERFLASH_CMD_LUT_SEQ_IDX_ERASECHIP + 3] =
-                        FLEXSPI_LUT_SEQ(kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0x00, kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0x80),
-                    // +1
-                    [4 * HYPERFLASH_CMD_LUT_SEQ_IDX_ERASECHIP + 4] =
-                        FLEXSPI_LUT_SEQ(kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0x00, kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0x00),
-                    [4 * HYPERFLASH_CMD_LUT_SEQ_IDX_ERASECHIP + 5] =
-                        FLEXSPI_LUT_SEQ(kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0x00, kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0xAA),
-                    [4 * HYPERFLASH_CMD_LUT_SEQ_IDX_ERASECHIP + 6] =
-                        FLEXSPI_LUT_SEQ(kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0x00, kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0x05),
-                    [4 * HYPERFLASH_CMD_LUT_SEQ_IDX_ERASECHIP + 7] =
-                        FLEXSPI_LUT_SEQ(kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0x00, kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0xAA),
-                    // +2
-                    [4 * HYPERFLASH_CMD_LUT_SEQ_IDX_ERASECHIP + 8] =
-                        FLEXSPI_LUT_SEQ(kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0x00, kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0x00),
-                    [4 * HYPERFLASH_CMD_LUT_SEQ_IDX_ERASECHIP + 9] =
-                        FLEXSPI_LUT_SEQ(kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0x00, kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0x55),
-                    [4 * HYPERFLASH_CMD_LUT_SEQ_IDX_ERASECHIP + 10] =
-                        FLEXSPI_LUT_SEQ(kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0x00, kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0x02),
-                    [4 * HYPERFLASH_CMD_LUT_SEQ_IDX_ERASECHIP + 11] =
-                        FLEXSPI_LUT_SEQ(kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0x00, kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0x55),
-                    // +3
-                    [4 * HYPERFLASH_CMD_LUT_SEQ_IDX_ERASECHIP + 12] =
-                        FLEXSPI_LUT_SEQ(kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0x00, kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0x00),
-                    [4 * HYPERFLASH_CMD_LUT_SEQ_IDX_ERASECHIP + 13] =
-                        FLEXSPI_LUT_SEQ(kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0x00, kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0xAA),
-                    [4 * HYPERFLASH_CMD_LUT_SEQ_IDX_ERASECHIP + 14] =
-                        FLEXSPI_LUT_SEQ(kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0x00, kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0x05),
-                    [4 * HYPERFLASH_CMD_LUT_SEQ_IDX_ERASECHIP + 15] =
-                        FLEXSPI_LUT_SEQ(kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0x00, kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0x10),
-                },
+            /* 12 Erase chip */
+            [4 * HYPERFLASH_CMD_LUT_SEQ_IDX_ERASECHIP] =
+                FLEXSPI_LUT_SEQ(kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0x00, kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0x00),
+            [4 * HYPERFLASH_CMD_LUT_SEQ_IDX_ERASECHIP + 1] =
+                FLEXSPI_LUT_SEQ(kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0x00, kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0xAA),
+            [4 * HYPERFLASH_CMD_LUT_SEQ_IDX_ERASECHIP + 2] =
+                FLEXSPI_LUT_SEQ(kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0x00, kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0x05),
+            [4 * HYPERFLASH_CMD_LUT_SEQ_IDX_ERASECHIP + 3] =
+                FLEXSPI_LUT_SEQ(kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0x00, kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0x80),
+            // +1
+            [4 * HYPERFLASH_CMD_LUT_SEQ_IDX_ERASECHIP + 4] =
+                FLEXSPI_LUT_SEQ(kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0x00, kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0x00),
+            [4 * HYPERFLASH_CMD_LUT_SEQ_IDX_ERASECHIP + 5] =
+                FLEXSPI_LUT_SEQ(kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0x00, kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0xAA),
+            [4 * HYPERFLASH_CMD_LUT_SEQ_IDX_ERASECHIP + 6] =
+                FLEXSPI_LUT_SEQ(kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0x00, kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0x05),
+            [4 * HYPERFLASH_CMD_LUT_SEQ_IDX_ERASECHIP + 7] =
+                FLEXSPI_LUT_SEQ(kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0x00, kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0xAA),
+            // +2
+            [4 * HYPERFLASH_CMD_LUT_SEQ_IDX_ERASECHIP + 8] =
+                FLEXSPI_LUT_SEQ(kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0x00, kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0x00),
+            [4 * HYPERFLASH_CMD_LUT_SEQ_IDX_ERASECHIP + 9] =
+                FLEXSPI_LUT_SEQ(kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0x00, kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0x55),
+            [4 * HYPERFLASH_CMD_LUT_SEQ_IDX_ERASECHIP + 10] =
+                FLEXSPI_LUT_SEQ(kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0x00, kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0x02),
+            [4 * HYPERFLASH_CMD_LUT_SEQ_IDX_ERASECHIP + 11] =
+                FLEXSPI_LUT_SEQ(kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0x00, kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0x55),
+            // +3
+            [4 * HYPERFLASH_CMD_LUT_SEQ_IDX_ERASECHIP + 12] =
+                FLEXSPI_LUT_SEQ(kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0x00, kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0x00),
+            [4 * HYPERFLASH_CMD_LUT_SEQ_IDX_ERASECHIP + 13] =
+                FLEXSPI_LUT_SEQ(kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0x00, kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0xAA),
+            [4 * HYPERFLASH_CMD_LUT_SEQ_IDX_ERASECHIP + 14] =
+                FLEXSPI_LUT_SEQ(kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0x00, kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0x05),
+            [4 * HYPERFLASH_CMD_LUT_SEQ_IDX_ERASECHIP + 15] =
+                FLEXSPI_LUT_SEQ(kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0x00, kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0x10),
         },
-    .pageSize           = 512u,
-    .sectorSize         = 256u * 1024u,
-    .blockSize          = 256u * 1024u,
+    },
+    .pageSize = 512u,
+    .sectorSize = 256u * 1024u,
+    .blockSize = 256u * 1024u,
     .isUniformBlockSize = true,
 };
 

--- a/ports/mimxrt/boards/MIMXRT1050_EVKB/mpconfigboard.h
+++ b/ports/mimxrt/boards/MIMXRT1050_EVKB/mpconfigboard.h
@@ -38,10 +38,10 @@
     { IOMUXC_GPIO_SD_B0_02_LPSPI1_SDO }, { IOMUXC_GPIO_SD_B0_03_LPSPI1_SDI },
 
 #define DMA_REQ_SRC_RX { 0, kDmaRequestMuxLPSPI1Rx, kDmaRequestMuxLPSPI2Rx, \
-                            kDmaRequestMuxLPSPI3Rx, kDmaRequestMuxLPSPI4Rx }
+                         kDmaRequestMuxLPSPI3Rx, kDmaRequestMuxLPSPI4Rx }
 
 #define DMA_REQ_SRC_TX { 0, kDmaRequestMuxLPSPI1Tx, kDmaRequestMuxLPSPI2Tx, \
-                            kDmaRequestMuxLPSPI3Tx, kDmaRequestMuxLPSPI4Tx } 
+                         kDmaRequestMuxLPSPI3Tx, kDmaRequestMuxLPSPI4Tx }
 
 // Define the mapping hardware I2C # to logical I2C #
 // SDA/SCL  HW-I2C    Logical I2C
@@ -55,14 +55,14 @@
     { 0 }, { 0 }, \
     { IOMUXC_GPIO_AD_B1_07_LPI2C3_SCL }, { IOMUXC_GPIO_AD_B1_06_LPI2C3_SDA },
 
-#define USDHC_DUMMY_PIN NULL , 0
+#define USDHC_DUMMY_PIN NULL, 0
 #define MICROPY_USDHC1 \
     { \
         .cmd = {GPIO_SD_B0_00_USDHC1_CMD}, \
         .clk = { GPIO_SD_B0_01_USDHC1_CLK }, \
-        .cd_b = { GPIO_B1_12_USDHC1_CD_B },\
-        .data0 = { GPIO_SD_B0_02_USDHC1_DATA0 },\
-        .data1 = { GPIO_SD_B0_03_USDHC1_DATA1 },\
-        .data2 = { GPIO_SD_B0_04_USDHC1_DATA2 },\
-        .data3 = { GPIO_SD_B0_05_USDHC1_DATA3 },\
+        .cd_b = { GPIO_B1_12_USDHC1_CD_B }, \
+        .data0 = { GPIO_SD_B0_02_USDHC1_DATA0 }, \
+        .data1 = { GPIO_SD_B0_03_USDHC1_DATA1 }, \
+        .data2 = { GPIO_SD_B0_04_USDHC1_DATA2 }, \
+        .data3 = { GPIO_SD_B0_05_USDHC1_DATA3 }, \
     }

--- a/ports/mimxrt/boards/MIMXRT1060_EVK/evkmimxrt1060_flexspi_nor_config.h
+++ b/ports/mimxrt/boards/MIMXRT1060_EVK/evkmimxrt1060_flexspi_nor_config.h
@@ -73,9 +73,9 @@
 
 #define FLEXSPI_LUT_SEQ(cmd0, pad0, op0, cmd1, pad1, op1)                                                              \
     (FLEXSPI_LUT_OPERAND0(op0) | FLEXSPI_LUT_NUM_PADS0(pad0) | FLEXSPI_LUT_OPCODE0(cmd0) | FLEXSPI_LUT_OPERAND1(op1) | \
-     FLEXSPI_LUT_NUM_PADS1(pad1) | FLEXSPI_LUT_OPCODE1(cmd1))
+    FLEXSPI_LUT_NUM_PADS1(pad1) | FLEXSPI_LUT_OPCODE1(cmd1))
 
-//!@brief Definitions for FlexSPI Serial Clock Frequency
+// !@brief Definitions for FlexSPI Serial Clock Frequency
 typedef enum _FlexSpiSerialClockFreq
 {
     kFlexSpiSerialClk_30MHz  = 1,
@@ -89,14 +89,14 @@ typedef enum _FlexSpiSerialClockFreq
     kFlexSpiSerialClk_166MHz = 9,
 } flexspi_serial_clk_freq_t;
 
-//!@brief FlexSPI clock configuration type
+// !@brief FlexSPI clock configuration type
 enum
 {
-    kFlexSpiClk_SDR, //!< Clock configure for SDR mode
-    kFlexSpiClk_DDR, //!< Clock configurat for DDR mode
+    kFlexSpiClk_SDR, // !< Clock configure for SDR mode
+    kFlexSpiClk_DDR, // !< Clock configurat for DDR mode
 };
 
-//!@brief FlexSPI Read Sample Clock Source definition
+// !@brief FlexSPI Read Sample Clock Source definition
 typedef enum _FlashReadSampleClkSource
 {
     kFlexSPIReadSampleClk_LoopbackInternally      = 0,
@@ -105,29 +105,29 @@ typedef enum _FlashReadSampleClkSource
     kFlexSPIReadSampleClk_ExternalInputFromDqsPad = 3,
 } flexspi_read_sample_clk_t;
 
-//!@brief Misc feature bit definitions
+// !@brief Misc feature bit definitions
 enum
 {
-    kFlexSpiMiscOffset_DiffClkEnable            = 0, //!< Bit for Differential clock enable
-    kFlexSpiMiscOffset_Ck2Enable                = 1, //!< Bit for CK2 enable
-    kFlexSpiMiscOffset_ParallelEnable           = 2, //!< Bit for Parallel mode enable
-    kFlexSpiMiscOffset_WordAddressableEnable    = 3, //!< Bit for Word Addressable enable
-    kFlexSpiMiscOffset_SafeConfigFreqEnable     = 4, //!< Bit for Safe Configuration Frequency enable
-    kFlexSpiMiscOffset_PadSettingOverrideEnable = 5, //!< Bit for Pad setting override enable
-    kFlexSpiMiscOffset_DdrModeEnable            = 6, //!< Bit for DDR clock confiuration indication.
+    kFlexSpiMiscOffset_DiffClkEnable            = 0, // !< Bit for Differential clock enable
+    kFlexSpiMiscOffset_Ck2Enable                = 1, // !< Bit for CK2 enable
+    kFlexSpiMiscOffset_ParallelEnable           = 2, // !< Bit for Parallel mode enable
+    kFlexSpiMiscOffset_WordAddressableEnable    = 3, // !< Bit for Word Addressable enable
+    kFlexSpiMiscOffset_SafeConfigFreqEnable     = 4, // !< Bit for Safe Configuration Frequency enable
+    kFlexSpiMiscOffset_PadSettingOverrideEnable = 5, // !< Bit for Pad setting override enable
+    kFlexSpiMiscOffset_DdrModeEnable            = 6, // !< Bit for DDR clock confiuration indication.
 };
 
-//!@brief Flash Type Definition
+// !@brief Flash Type Definition
 enum
 {
-    kFlexSpiDeviceType_SerialNOR    = 1,    //!< Flash devices are Serial NOR
-    kFlexSpiDeviceType_SerialNAND   = 2,    //!< Flash devices are Serial NAND
-    kFlexSpiDeviceType_SerialRAM    = 3,    //!< Flash devices are Serial RAM/HyperFLASH
-    kFlexSpiDeviceType_MCP_NOR_NAND = 0x12, //!< Flash device is MCP device, A1 is Serial NOR, A2 is Serial NAND
-    kFlexSpiDeviceType_MCP_NOR_RAM  = 0x13, //!< Flash deivce is MCP device, A1 is Serial NOR, A2 is Serial RAMs
+    kFlexSpiDeviceType_SerialNOR    = 1,    // !< Flash devices are Serial NOR
+    kFlexSpiDeviceType_SerialNAND   = 2,    // !< Flash devices are Serial NAND
+    kFlexSpiDeviceType_SerialRAM    = 3,    // !< Flash devices are Serial RAM/HyperFLASH
+    kFlexSpiDeviceType_MCP_NOR_NAND = 0x12, // !< Flash device is MCP device, A1 is Serial NOR, A2 is Serial NAND
+    kFlexSpiDeviceType_MCP_NOR_RAM  = 0x13, // !< Flash deivce is MCP device, A1 is Serial NOR, A2 is Serial RAMs
 };
 
-//!@brief Flash Pad Definitions
+// !@brief Flash Pad Definitions
 enum
 {
     kSerialFlash_1Pad  = 1,
@@ -136,77 +136,77 @@ enum
     kSerialFlash_8Pads = 8,
 };
 
-//!@brief FlexSPI LUT Sequence structure
+// !@brief FlexSPI LUT Sequence structure
 typedef struct _lut_sequence
 {
-    uint8_t seqNum; //!< Sequence Number, valid number: 1-16
-    uint8_t seqId;  //!< Sequence Index, valid number: 0-15
+    uint8_t seqNum; // !< Sequence Number, valid number: 1-16
+    uint8_t seqId;  // !< Sequence Index, valid number: 0-15
     uint16_t reserved;
 } flexspi_lut_seq_t;
 
-//!@brief Flash Configuration Command Type
+// !@brief Flash Configuration Command Type
 enum
 {
-    kDeviceConfigCmdType_Generic,    //!< Generic command, for example: configure dummy cycles, drive strength, etc
-    kDeviceConfigCmdType_QuadEnable, //!< Quad Enable command
-    kDeviceConfigCmdType_Spi2Xpi,    //!< Switch from SPI to DPI/QPI/OPI mode
-    kDeviceConfigCmdType_Xpi2Spi,    //!< Switch from DPI/QPI/OPI to SPI mode
-    kDeviceConfigCmdType_Spi2NoCmd,  //!< Switch to 0-4-4/0-8-8 mode
-    kDeviceConfigCmdType_Reset,      //!< Reset device command
+    kDeviceConfigCmdType_Generic,    // !< Generic command, for example: configure dummy cycles, drive strength, etc
+    kDeviceConfigCmdType_QuadEnable, // !< Quad Enable command
+    kDeviceConfigCmdType_Spi2Xpi,    // !< Switch from SPI to DPI/QPI/OPI mode
+    kDeviceConfigCmdType_Xpi2Spi,    // !< Switch from DPI/QPI/OPI to SPI mode
+    kDeviceConfigCmdType_Spi2NoCmd,  // !< Switch to 0-4-4/0-8-8 mode
+    kDeviceConfigCmdType_Reset,      // !< Reset device command
 };
 
-//!@brief FlexSPI Memory Configuration Block
+// !@brief FlexSPI Memory Configuration Block
 typedef struct _FlexSPIConfig
 {
-    uint32_t tag;               //!< [0x000-0x003] Tag, fixed value 0x42464346UL
-    uint32_t version;           //!< [0x004-0x007] Version,[31:24] -'V', [23:16] - Major, [15:8] - Minor, [7:0] - bugfix
-    uint32_t reserved0;         //!< [0x008-0x00b] Reserved for future use
-    uint8_t readSampleClkSrc;   //!< [0x00c-0x00c] Read Sample Clock Source, valid value: 0/1/3
-    uint8_t csHoldTime;         //!< [0x00d-0x00d] CS hold time, default value: 3
-    uint8_t csSetupTime;        //!< [0x00e-0x00e] CS setup time, default value: 3
-    uint8_t columnAddressWidth; //!< [0x00f-0x00f] Column Address with, for HyperBus protocol, it is fixed to 3, For
-    //! Serial NAND, need to refer to datasheet
-    uint8_t deviceModeCfgEnable; //!< [0x010-0x010] Device Mode Configure enable flag, 1 - Enable, 0 - Disable
-    uint8_t deviceModeType; //!< [0x011-0x011] Specify the configuration command type:Quad Enable, DPI/QPI/OPI switch,
-    //! Generic configuration, etc.
-    uint16_t waitTimeCfgCommands; //!< [0x012-0x013] Wait time for all configuration commands, unit: 100us, Used for
-    //! DPI/QPI/OPI switch or reset command
-    flexspi_lut_seq_t deviceModeSeq; //!< [0x014-0x017] Device mode sequence info, [7:0] - LUT sequence id, [15:8] - LUt
-    //! sequence number, [31:16] Reserved
-    uint32_t deviceModeArg;    //!< [0x018-0x01b] Argument/Parameter for device configuration
-    uint8_t configCmdEnable;   //!< [0x01c-0x01c] Configure command Enable Flag, 1 - Enable, 0 - Disable
-    uint8_t configModeType[3]; //!< [0x01d-0x01f] Configure Mode Type, similar as deviceModeTpe
+    uint32_t tag;               // !< [0x000-0x003] Tag, fixed value 0x42464346UL
+    uint32_t version;           // !< [0x004-0x007] Version,[31:24] -'V', [23:16] - Major, [15:8] - Minor, [7:0] - bugfix
+    uint32_t reserved0;         // !< [0x008-0x00b] Reserved for future use
+    uint8_t readSampleClkSrc;   // !< [0x00c-0x00c] Read Sample Clock Source, valid value: 0/1/3
+    uint8_t csHoldTime;         // !< [0x00d-0x00d] CS hold time, default value: 3
+    uint8_t csSetupTime;        // !< [0x00e-0x00e] CS setup time, default value: 3
+    uint8_t columnAddressWidth; // !< [0x00f-0x00f] Column Address with, for HyperBus protocol, it is fixed to 3, For
+    // ! Serial NAND, need to refer to datasheet
+    uint8_t deviceModeCfgEnable; // !< [0x010-0x010] Device Mode Configure enable flag, 1 - Enable, 0 - Disable
+    uint8_t deviceModeType; // !< [0x011-0x011] Specify the configuration command type:Quad Enable, DPI/QPI/OPI switch,
+    // ! Generic configuration, etc.
+    uint16_t waitTimeCfgCommands; // !< [0x012-0x013] Wait time for all configuration commands, unit: 100us, Used for
+    // ! DPI/QPI/OPI switch or reset command
+    flexspi_lut_seq_t deviceModeSeq; // !< [0x014-0x017] Device mode sequence info, [7:0] - LUT sequence id, [15:8] - LUt
+    // ! sequence number, [31:16] Reserved
+    uint32_t deviceModeArg;    // !< [0x018-0x01b] Argument/Parameter for device configuration
+    uint8_t configCmdEnable;   // !< [0x01c-0x01c] Configure command Enable Flag, 1 - Enable, 0 - Disable
+    uint8_t configModeType[3]; // !< [0x01d-0x01f] Configure Mode Type, similar as deviceModeTpe
     flexspi_lut_seq_t
-        configCmdSeqs[3]; //!< [0x020-0x02b] Sequence info for Device Configuration command, similar as deviceModeSeq
-    uint32_t reserved1;   //!< [0x02c-0x02f] Reserved for future use
-    uint32_t configCmdArgs[3];     //!< [0x030-0x03b] Arguments/Parameters for device Configuration commands
-    uint32_t reserved2;            //!< [0x03c-0x03f] Reserved for future use
-    uint32_t controllerMiscOption; //!< [0x040-0x043] Controller Misc Options, see Misc feature bit definitions for more
-    //! details
-    uint8_t deviceType;    //!< [0x044-0x044] Device Type:  See Flash Type Definition for more details
-    uint8_t sflashPadType; //!< [0x045-0x045] Serial Flash Pad Type: 1 - Single, 2 - Dual, 4 - Quad, 8 - Octal
-    uint8_t serialClkFreq; //!< [0x046-0x046] Serial Flash Frequencey, device specific definitions, See System Boot
-    //! Chapter for more details
-    uint8_t lutCustomSeqEnable; //!< [0x047-0x047] LUT customization Enable, it is required if the program/erase cannot
-    //! be done using 1 LUT sequence, currently, only applicable to HyperFLASH
-    uint32_t reserved3[2];           //!< [0x048-0x04f] Reserved for future use
-    uint32_t sflashA1Size;           //!< [0x050-0x053] Size of Flash connected to A1
-    uint32_t sflashA2Size;           //!< [0x054-0x057] Size of Flash connected to A2
-    uint32_t sflashB1Size;           //!< [0x058-0x05b] Size of Flash connected to B1
-    uint32_t sflashB2Size;           //!< [0x05c-0x05f] Size of Flash connected to B2
-    uint32_t csPadSettingOverride;   //!< [0x060-0x063] CS pad setting override value
-    uint32_t sclkPadSettingOverride; //!< [0x064-0x067] SCK pad setting override value
-    uint32_t dataPadSettingOverride; //!< [0x068-0x06b] data pad setting override value
-    uint32_t dqsPadSettingOverride;  //!< [0x06c-0x06f] DQS pad setting override value
-    uint32_t timeoutInMs;            //!< [0x070-0x073] Timeout threshold for read status command
-    uint32_t commandInterval;        //!< [0x074-0x077] CS deselect interval between two commands
-    uint16_t dataValidTime[2]; //!< [0x078-0x07b] CLK edge to data valid time for PORT A and PORT B, in terms of 0.1ns
-    uint16_t busyOffset;       //!< [0x07c-0x07d] Busy offset, valid value: 0-31
-    uint16_t busyBitPolarity;  //!< [0x07e-0x07f] Busy flag polarity, 0 - busy flag is 1 when flash device is busy, 1 -
-    //! busy flag is 0 when flash device is busy
-    uint32_t lookupTable[64];           //!< [0x080-0x17f] Lookup table holds Flash command sequences
-    flexspi_lut_seq_t lutCustomSeq[12]; //!< [0x180-0x1af] Customizable LUT Sequences
-    uint32_t reserved4[4];              //!< [0x1b0-0x1bf] Reserved for future use
+        configCmdSeqs[3]; // !< [0x020-0x02b] Sequence info for Device Configuration command, similar as deviceModeSeq
+    uint32_t reserved1;   // !< [0x02c-0x02f] Reserved for future use
+    uint32_t configCmdArgs[3];     // !< [0x030-0x03b] Arguments/Parameters for device Configuration commands
+    uint32_t reserved2;            // !< [0x03c-0x03f] Reserved for future use
+    uint32_t controllerMiscOption; // !< [0x040-0x043] Controller Misc Options, see Misc feature bit definitions for more
+    // ! details
+    uint8_t deviceType;    // !< [0x044-0x044] Device Type:  See Flash Type Definition for more details
+    uint8_t sflashPadType; // !< [0x045-0x045] Serial Flash Pad Type: 1 - Single, 2 - Dual, 4 - Quad, 8 - Octal
+    uint8_t serialClkFreq; // !< [0x046-0x046] Serial Flash Frequencey, device specific definitions, See System Boot
+    // ! Chapter for more details
+    uint8_t lutCustomSeqEnable; // !< [0x047-0x047] LUT customization Enable, it is required if the program/erase cannot
+    // ! be done using 1 LUT sequence, currently, only applicable to HyperFLASH
+    uint32_t reserved3[2];           // !< [0x048-0x04f] Reserved for future use
+    uint32_t sflashA1Size;           // !< [0x050-0x053] Size of Flash connected to A1
+    uint32_t sflashA2Size;           // !< [0x054-0x057] Size of Flash connected to A2
+    uint32_t sflashB1Size;           // !< [0x058-0x05b] Size of Flash connected to B1
+    uint32_t sflashB2Size;           // !< [0x05c-0x05f] Size of Flash connected to B2
+    uint32_t csPadSettingOverride;   // !< [0x060-0x063] CS pad setting override value
+    uint32_t sclkPadSettingOverride; // !< [0x064-0x067] SCK pad setting override value
+    uint32_t dataPadSettingOverride; // !< [0x068-0x06b] data pad setting override value
+    uint32_t dqsPadSettingOverride;  // !< [0x06c-0x06f] DQS pad setting override value
+    uint32_t timeoutInMs;            // !< [0x070-0x073] Timeout threshold for read status command
+    uint32_t commandInterval;        // !< [0x074-0x077] CS deselect interval between two commands
+    uint16_t dataValidTime[2]; // !< [0x078-0x07b] CLK edge to data valid time for PORT A and PORT B, in terms of 0.1ns
+    uint16_t busyOffset;       // !< [0x07c-0x07d] Busy offset, valid value: 0-31
+    uint16_t busyBitPolarity;  // !< [0x07e-0x07f] Busy flag polarity, 0 - busy flag is 1 when flash device is busy, 1 -
+    // ! busy flag is 0 when flash device is busy
+    uint32_t lookupTable[64];           // !< [0x080-0x17f] Lookup table holds Flash command sequences
+    flexspi_lut_seq_t lutCustomSeq[12]; // !< [0x180-0x1af] Customizable LUT Sequences
+    uint32_t reserved4[4];              // !< [0x1b0-0x1bf] Reserved for future use
 } flexspi_mem_config_t;
 
 /*  */
@@ -237,18 +237,18 @@ typedef struct _FlexSPIConfig
  */
 typedef struct _flexspi_nor_config
 {
-    flexspi_mem_config_t memConfig; //!< Common memory configuration info via FlexSPI
-    uint32_t pageSize;              //!< Page size of Serial NOR
-    uint32_t sectorSize;            //!< Sector size of Serial NOR
-    uint8_t ipcmdSerialClkFreq;     //!< Clock frequency for IP command
-    uint8_t isUniformBlockSize;     //!< Sector/Block size is the same
-    uint8_t reserved0[2];           //!< Reserved for future use
-    uint8_t serialNorType;          //!< Serial NOR Flash type: 0/1/2/3
-    uint8_t needExitNoCmdMode;      //!< Need to exit NoCmd mode before other IP command
-    uint8_t halfClkForNonReadCmd;   //!< Half the Serial Clock for non-read command: true/false
-    uint8_t needRestoreNoCmdMode;   //!< Need to Restore NoCmd mode after IP commmand execution
-    uint32_t blockSize;             //!< Block size
-    uint32_t reserve2[11];          //!< Reserved for future use
+    flexspi_mem_config_t memConfig; // !< Common memory configuration info via FlexSPI
+    uint32_t pageSize;              // !< Page size of Serial NOR
+    uint32_t sectorSize;            // !< Sector size of Serial NOR
+    uint8_t ipcmdSerialClkFreq;     // !< Clock frequency for IP command
+    uint8_t isUniformBlockSize;     // !< Sector/Block size is the same
+    uint8_t reserved0[2];           // !< Reserved for future use
+    uint8_t serialNorType;          // !< Serial NOR Flash type: 0/1/2/3
+    uint8_t needExitNoCmdMode;      // !< Need to exit NoCmd mode before other IP command
+    uint8_t halfClkForNonReadCmd;   // !< Half the Serial Clock for non-read command: true/false
+    uint8_t needRestoreNoCmdMode;   // !< Need to Restore NoCmd mode after IP commmand execution
+    uint32_t blockSize;             // !< Block size
+    uint32_t reserve2[11];          // !< Reserved for future use
 } flexspi_nor_config_t;
 
 #define FLASH_BUSY_STATUS_POL 0

--- a/ports/mimxrt/boards/MIMXRT1060_EVK/flash_config.c
+++ b/ports/mimxrt/boards/MIMXRT1060_EVK/flash_config.c
@@ -24,162 +24,162 @@ __attribute__((section(".boot_hdr.conf")))
 
 const flexspi_nor_config_t qspiflash_config = {
     .memConfig =
+    {
+        .tag = FLEXSPI_CFG_BLK_TAG,
+        .version = FLEXSPI_CFG_BLK_VERSION,
+        .readSampleClkSrc = kFlexSPIReadSampleClk_ExternalInputFromDqsPad,
+        .csHoldTime = 3u,
+        .csSetupTime = 3u,
+        .columnAddressWidth = 3u,
+        // Enable DDR mode, Wordaddressable, Safe configuration, Differential clock
+        .controllerMiscOption =
+            (1u << kFlexSpiMiscOffset_DdrModeEnable) | (1u << kFlexSpiMiscOffset_WordAddressableEnable) |
+            (1u << kFlexSpiMiscOffset_SafeConfigFreqEnable) | (1u << kFlexSpiMiscOffset_DiffClkEnable),
+        .sflashPadType = kSerialFlash_8Pads,
+        .serialClkFreq = kFlexSpiSerialClk_133MHz,
+        .sflashA1Size = 64u * 1024u * 1024u,
+        .dataValidTime = {16u, 16u},
+        .lookupTable =
         {
-            .tag                = FLEXSPI_CFG_BLK_TAG,
-            .version            = FLEXSPI_CFG_BLK_VERSION,
-            .readSampleClkSrc   = kFlexSPIReadSampleClk_ExternalInputFromDqsPad,
-            .csHoldTime         = 3u,
-            .csSetupTime        = 3u,
-            .columnAddressWidth = 3u,
-            // Enable DDR mode, Wordaddressable, Safe configuration, Differential clock
-            .controllerMiscOption =
-                (1u << kFlexSpiMiscOffset_DdrModeEnable) | (1u << kFlexSpiMiscOffset_WordAddressableEnable) |
-                (1u << kFlexSpiMiscOffset_SafeConfigFreqEnable) | (1u << kFlexSpiMiscOffset_DiffClkEnable),
-            .sflashPadType = kSerialFlash_8Pads,
-            .serialClkFreq = kFlexSpiSerialClk_133MHz,
-            .sflashA1Size  = 64u * 1024u * 1024u,
-            .dataValidTime = {16u, 16u},
-            .lookupTable =
-                {
-                    /* 0 Read Data */
-                    [4 * HYPERFLASH_CMD_LUT_SEQ_IDX_READDATA] =
-                        FLEXSPI_LUT_SEQ(kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0xA0, kFLEXSPI_Command_RADDR_DDR, kFLEXSPI_8PAD, 0x18),
-                    [4 * HYPERFLASH_CMD_LUT_SEQ_IDX_READDATA + 1] = FLEXSPI_LUT_SEQ(
-                        kFLEXSPI_Command_CADDR_DDR, kFLEXSPI_8PAD, 0x10, kFLEXSPI_Command_READ_DDR, kFLEXSPI_8PAD, 0x04),
+            /* 0 Read Data */
+            [4 * HYPERFLASH_CMD_LUT_SEQ_IDX_READDATA] =
+                FLEXSPI_LUT_SEQ(kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0xA0, kFLEXSPI_Command_RADDR_DDR, kFLEXSPI_8PAD, 0x18),
+            [4 * HYPERFLASH_CMD_LUT_SEQ_IDX_READDATA + 1] = FLEXSPI_LUT_SEQ(
+                kFLEXSPI_Command_CADDR_DDR, kFLEXSPI_8PAD, 0x10, kFLEXSPI_Command_READ_DDR, kFLEXSPI_8PAD, 0x04),
 
-                    /* 1 Write Data */
-                    [4 * HYPERFLASH_CMD_LUT_SEQ_IDX_WRITEDATA] =
-                        FLEXSPI_LUT_SEQ(kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0x20, kFLEXSPI_Command_RADDR_DDR, kFLEXSPI_8PAD, 0x18),
-                    [4 * HYPERFLASH_CMD_LUT_SEQ_IDX_WRITEDATA + 1] = FLEXSPI_LUT_SEQ(
-                        kFLEXSPI_Command_CADDR_DDR, kFLEXSPI_8PAD, 0x10, kFLEXSPI_Command_WRITE_DDR, kFLEXSPI_8PAD, 0x02),
+            /* 1 Write Data */
+            [4 * HYPERFLASH_CMD_LUT_SEQ_IDX_WRITEDATA] =
+                FLEXSPI_LUT_SEQ(kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0x20, kFLEXSPI_Command_RADDR_DDR, kFLEXSPI_8PAD, 0x18),
+            [4 * HYPERFLASH_CMD_LUT_SEQ_IDX_WRITEDATA + 1] = FLEXSPI_LUT_SEQ(
+                kFLEXSPI_Command_CADDR_DDR, kFLEXSPI_8PAD, 0x10, kFLEXSPI_Command_WRITE_DDR, kFLEXSPI_8PAD, 0x02),
 
-                    /* 2 Read Status */
-                    [4 * HYPERFLASH_CMD_LUT_SEQ_IDX_READSTATUS] =
-                        FLEXSPI_LUT_SEQ(kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0x00, kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0x00),
-                    [4 * HYPERFLASH_CMD_LUT_SEQ_IDX_READSTATUS + 1] = FLEXSPI_LUT_SEQ(
-                        kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0x00, kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0xAA), // ADDR 0x555
-                    [4 * HYPERFLASH_CMD_LUT_SEQ_IDX_READSTATUS + 2] =
-                        FLEXSPI_LUT_SEQ(kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0x00, kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0x05),
-                    [4 * HYPERFLASH_CMD_LUT_SEQ_IDX_READSTATUS + 3] = FLEXSPI_LUT_SEQ(
-                        kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0x00, kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0x70), // DATA 0x70
-                    // +1
-                    [4 * HYPERFLASH_CMD_LUT_SEQ_IDX_READSTATUS + 4] =
-                        FLEXSPI_LUT_SEQ(kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0xA0, kFLEXSPI_Command_RADDR_DDR, kFLEXSPI_8PAD, 0x18),
-                    [4 * HYPERFLASH_CMD_LUT_SEQ_IDX_READSTATUS + 5] = FLEXSPI_LUT_SEQ(
-                        kFLEXSPI_Command_CADDR_DDR, kFLEXSPI_8PAD, 0x10, kFLEXSPI_Command_DUMMY_RWDS_DDR, kFLEXSPI_8PAD, 0x0B),
-                    [4 * HYPERFLASH_CMD_LUT_SEQ_IDX_READSTATUS + 6] =
-                        FLEXSPI_LUT_SEQ(kFLEXSPI_Command_READ_DDR, kFLEXSPI_8PAD, 0x04, kFLEXSPI_Command_STOP, kFLEXSPI_1PAD, 0x0),
+            /* 2 Read Status */
+            [4 * HYPERFLASH_CMD_LUT_SEQ_IDX_READSTATUS] =
+                FLEXSPI_LUT_SEQ(kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0x00, kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0x00),
+            [4 * HYPERFLASH_CMD_LUT_SEQ_IDX_READSTATUS + 1] = FLEXSPI_LUT_SEQ(
+                kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0x00, kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0xAA),         // ADDR 0x555
+            [4 * HYPERFLASH_CMD_LUT_SEQ_IDX_READSTATUS + 2] =
+                FLEXSPI_LUT_SEQ(kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0x00, kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0x05),
+            [4 * HYPERFLASH_CMD_LUT_SEQ_IDX_READSTATUS + 3] = FLEXSPI_LUT_SEQ(
+                kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0x00, kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0x70),         // DATA 0x70
+            // +1
+            [4 * HYPERFLASH_CMD_LUT_SEQ_IDX_READSTATUS + 4] =
+                FLEXSPI_LUT_SEQ(kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0xA0, kFLEXSPI_Command_RADDR_DDR, kFLEXSPI_8PAD, 0x18),
+            [4 * HYPERFLASH_CMD_LUT_SEQ_IDX_READSTATUS + 5] = FLEXSPI_LUT_SEQ(
+                kFLEXSPI_Command_CADDR_DDR, kFLEXSPI_8PAD, 0x10, kFLEXSPI_Command_DUMMY_RWDS_DDR, kFLEXSPI_8PAD, 0x0B),
+            [4 * HYPERFLASH_CMD_LUT_SEQ_IDX_READSTATUS + 6] =
+                FLEXSPI_LUT_SEQ(kFLEXSPI_Command_READ_DDR, kFLEXSPI_8PAD, 0x04, kFLEXSPI_Command_STOP, kFLEXSPI_1PAD, 0x0),
 
-                    /* 4 Write Enable */
-                    [4 * HYPERFLASH_CMD_LUT_SEQ_IDX_WRITEENABLE] =
-                        FLEXSPI_LUT_SEQ(kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0x20, kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0x00),
-                    [4 * HYPERFLASH_CMD_LUT_SEQ_IDX_WRITEENABLE + 1] = FLEXSPI_LUT_SEQ(
-                        kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0x00, kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0xAA), // ADDR 0x555
-                    [4 * HYPERFLASH_CMD_LUT_SEQ_IDX_WRITEENABLE + 2] =
-                        FLEXSPI_LUT_SEQ(kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0x00, kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0x05),
-                    [4 * HYPERFLASH_CMD_LUT_SEQ_IDX_WRITEENABLE + 3] = FLEXSPI_LUT_SEQ(
-                        kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0x00, kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0xAA), // DATA 0xAA
-                    // +1
-                    [4 * HYPERFLASH_CMD_LUT_SEQ_IDX_WRITEENABLE + 4] =
-                        FLEXSPI_LUT_SEQ(kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0x20, kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0x00),
-                    [4 * HYPERFLASH_CMD_LUT_SEQ_IDX_WRITEENABLE + 5] =
-                        FLEXSPI_LUT_SEQ(kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0x00, kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0x55),
-                    [4 * HYPERFLASH_CMD_LUT_SEQ_IDX_WRITEENABLE + 6] =
-                        FLEXSPI_LUT_SEQ(kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0x00, kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0x02),
-                    [4 * HYPERFLASH_CMD_LUT_SEQ_IDX_WRITEENABLE + 7] =
-                        FLEXSPI_LUT_SEQ(kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0x00, kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0x55),
+            /* 4 Write Enable */
+            [4 * HYPERFLASH_CMD_LUT_SEQ_IDX_WRITEENABLE] =
+                FLEXSPI_LUT_SEQ(kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0x20, kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0x00),
+            [4 * HYPERFLASH_CMD_LUT_SEQ_IDX_WRITEENABLE + 1] = FLEXSPI_LUT_SEQ(
+                kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0x00, kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0xAA),         // ADDR 0x555
+            [4 * HYPERFLASH_CMD_LUT_SEQ_IDX_WRITEENABLE + 2] =
+                FLEXSPI_LUT_SEQ(kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0x00, kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0x05),
+            [4 * HYPERFLASH_CMD_LUT_SEQ_IDX_WRITEENABLE + 3] = FLEXSPI_LUT_SEQ(
+                kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0x00, kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0xAA),         // DATA 0xAA
+            // +1
+            [4 * HYPERFLASH_CMD_LUT_SEQ_IDX_WRITEENABLE + 4] =
+                FLEXSPI_LUT_SEQ(kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0x20, kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0x00),
+            [4 * HYPERFLASH_CMD_LUT_SEQ_IDX_WRITEENABLE + 5] =
+                FLEXSPI_LUT_SEQ(kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0x00, kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0x55),
+            [4 * HYPERFLASH_CMD_LUT_SEQ_IDX_WRITEENABLE + 6] =
+                FLEXSPI_LUT_SEQ(kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0x00, kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0x02),
+            [4 * HYPERFLASH_CMD_LUT_SEQ_IDX_WRITEENABLE + 7] =
+                FLEXSPI_LUT_SEQ(kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0x00, kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0x55),
 
-                    /* 6 Erase Sector  */
-                    [4 * HYPERFLASH_CMD_LUT_SEQ_IDX_ERASESECTOR] =
-                        FLEXSPI_LUT_SEQ(kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0x00, kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0x00),
-                    [4 * HYPERFLASH_CMD_LUT_SEQ_IDX_ERASESECTOR + 1] = FLEXSPI_LUT_SEQ(
-                        kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0x00, kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0xAA), // ADDR 0x555
-                    [4 * HYPERFLASH_CMD_LUT_SEQ_IDX_ERASESECTOR + 2] =
-                        FLEXSPI_LUT_SEQ(kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0x00, kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0x05),
-                    [4 * HYPERFLASH_CMD_LUT_SEQ_IDX_ERASESECTOR + 3] = FLEXSPI_LUT_SEQ(
-                        kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0x00, kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0x80), // DATA 0x80
-                    // +1
-                    [4 * HYPERFLASH_CMD_LUT_SEQ_IDX_ERASESECTOR + 4] =
-                        FLEXSPI_LUT_SEQ(kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0x00, kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0x00),
-                    [4 * HYPERFLASH_CMD_LUT_SEQ_IDX_ERASESECTOR + 5] =
-                        FLEXSPI_LUT_SEQ(kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0x00, kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0xAA),
-                    [4 * HYPERFLASH_CMD_LUT_SEQ_IDX_ERASESECTOR + 6] =
-                        FLEXSPI_LUT_SEQ(kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0x00, kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0x05),
-                    [4 * HYPERFLASH_CMD_LUT_SEQ_IDX_ERASESECTOR + 7] = FLEXSPI_LUT_SEQ(
-                        kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0x00, kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0xAA), // ADDR 0x555
-                    // +2
-                    [4 * HYPERFLASH_CMD_LUT_SEQ_IDX_ERASESECTOR + 8] =
-                        FLEXSPI_LUT_SEQ(kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0x00, kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0x00),
-                    [4 * HYPERFLASH_CMD_LUT_SEQ_IDX_ERASESECTOR + 9] =
-                        FLEXSPI_LUT_SEQ(kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0x00, kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0x55),
-                    [4 * HYPERFLASH_CMD_LUT_SEQ_IDX_ERASESECTOR + 10] =
-                        FLEXSPI_LUT_SEQ(kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0x00, kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0x02),
-                    [4 * HYPERFLASH_CMD_LUT_SEQ_IDX_ERASESECTOR + 11] =
-                        FLEXSPI_LUT_SEQ(kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0x00, kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0x55),
-                    // +3
-                    [4 * HYPERFLASH_CMD_LUT_SEQ_IDX_ERASESECTOR + 12] =
-                        FLEXSPI_LUT_SEQ(kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0x00, kFLEXSPI_Command_RADDR_DDR, kFLEXSPI_8PAD, 0x18),
-                    [4 * HYPERFLASH_CMD_LUT_SEQ_IDX_ERASESECTOR + 13] =
-                        FLEXSPI_LUT_SEQ(kFLEXSPI_Command_CADDR_DDR, kFLEXSPI_8PAD, 0x10, kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0x00),
-                    [4 * HYPERFLASH_CMD_LUT_SEQ_IDX_ERASESECTOR + 14] =
-                        FLEXSPI_LUT_SEQ(kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0x30, kFLEXSPI_Command_STOP, kFLEXSPI_1PAD, 0x00),
+            /* 6 Erase Sector  */
+            [4 * HYPERFLASH_CMD_LUT_SEQ_IDX_ERASESECTOR] =
+                FLEXSPI_LUT_SEQ(kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0x00, kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0x00),
+            [4 * HYPERFLASH_CMD_LUT_SEQ_IDX_ERASESECTOR + 1] = FLEXSPI_LUT_SEQ(
+                kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0x00, kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0xAA),         // ADDR 0x555
+            [4 * HYPERFLASH_CMD_LUT_SEQ_IDX_ERASESECTOR + 2] =
+                FLEXSPI_LUT_SEQ(kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0x00, kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0x05),
+            [4 * HYPERFLASH_CMD_LUT_SEQ_IDX_ERASESECTOR + 3] = FLEXSPI_LUT_SEQ(
+                kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0x00, kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0x80),         // DATA 0x80
+            // +1
+            [4 * HYPERFLASH_CMD_LUT_SEQ_IDX_ERASESECTOR + 4] =
+                FLEXSPI_LUT_SEQ(kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0x00, kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0x00),
+            [4 * HYPERFLASH_CMD_LUT_SEQ_IDX_ERASESECTOR + 5] =
+                FLEXSPI_LUT_SEQ(kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0x00, kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0xAA),
+            [4 * HYPERFLASH_CMD_LUT_SEQ_IDX_ERASESECTOR + 6] =
+                FLEXSPI_LUT_SEQ(kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0x00, kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0x05),
+            [4 * HYPERFLASH_CMD_LUT_SEQ_IDX_ERASESECTOR + 7] = FLEXSPI_LUT_SEQ(
+                kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0x00, kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0xAA),         // ADDR 0x555
+            // +2
+            [4 * HYPERFLASH_CMD_LUT_SEQ_IDX_ERASESECTOR + 8] =
+                FLEXSPI_LUT_SEQ(kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0x00, kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0x00),
+            [4 * HYPERFLASH_CMD_LUT_SEQ_IDX_ERASESECTOR + 9] =
+                FLEXSPI_LUT_SEQ(kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0x00, kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0x55),
+            [4 * HYPERFLASH_CMD_LUT_SEQ_IDX_ERASESECTOR + 10] =
+                FLEXSPI_LUT_SEQ(kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0x00, kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0x02),
+            [4 * HYPERFLASH_CMD_LUT_SEQ_IDX_ERASESECTOR + 11] =
+                FLEXSPI_LUT_SEQ(kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0x00, kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0x55),
+            // +3
+            [4 * HYPERFLASH_CMD_LUT_SEQ_IDX_ERASESECTOR + 12] =
+                FLEXSPI_LUT_SEQ(kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0x00, kFLEXSPI_Command_RADDR_DDR, kFLEXSPI_8PAD, 0x18),
+            [4 * HYPERFLASH_CMD_LUT_SEQ_IDX_ERASESECTOR + 13] =
+                FLEXSPI_LUT_SEQ(kFLEXSPI_Command_CADDR_DDR, kFLEXSPI_8PAD, 0x10, kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0x00),
+            [4 * HYPERFLASH_CMD_LUT_SEQ_IDX_ERASESECTOR + 14] =
+                FLEXSPI_LUT_SEQ(kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0x30, kFLEXSPI_Command_STOP, kFLEXSPI_1PAD, 0x00),
 
-                    /* 10 program page with word program command sequence */
-                    [4 * HYPERFLASH_CMD_LUT_SEQ_IDX_PAGEPROGRAM] =
-                        FLEXSPI_LUT_SEQ(kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0x20, kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0x00),
-                    [4 * HYPERFLASH_CMD_LUT_SEQ_IDX_PAGEPROGRAM + 1] = FLEXSPI_LUT_SEQ(
-                        kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0x00, kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0xAA), // ADDR 0x555
-                    [4 * HYPERFLASH_CMD_LUT_SEQ_IDX_PAGEPROGRAM + 2] =
-                        FLEXSPI_LUT_SEQ(kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0x00, kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0x05),
-                    [4 * HYPERFLASH_CMD_LUT_SEQ_IDX_PAGEPROGRAM + 3] = FLEXSPI_LUT_SEQ(
-                        kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0x00, kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0xA0), // DATA 0xA0
-                    // +1
-                    [4 * HYPERFLASH_CMD_LUT_SEQ_IDX_PAGEPROGRAM + 4] =
-                        FLEXSPI_LUT_SEQ(kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0x20, kFLEXSPI_Command_RADDR_DDR, kFLEXSPI_8PAD, 0x18),
-                    [4 * HYPERFLASH_CMD_LUT_SEQ_IDX_PAGEPROGRAM + 5] = FLEXSPI_LUT_SEQ(
-                        kFLEXSPI_Command_CADDR_DDR, kFLEXSPI_8PAD, 0x10, kFLEXSPI_Command_WRITE_DDR, kFLEXSPI_8PAD, 0x80),
+            /* 10 program page with word program command sequence */
+            [4 * HYPERFLASH_CMD_LUT_SEQ_IDX_PAGEPROGRAM] =
+                FLEXSPI_LUT_SEQ(kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0x20, kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0x00),
+            [4 * HYPERFLASH_CMD_LUT_SEQ_IDX_PAGEPROGRAM + 1] = FLEXSPI_LUT_SEQ(
+                kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0x00, kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0xAA),         // ADDR 0x555
+            [4 * HYPERFLASH_CMD_LUT_SEQ_IDX_PAGEPROGRAM + 2] =
+                FLEXSPI_LUT_SEQ(kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0x00, kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0x05),
+            [4 * HYPERFLASH_CMD_LUT_SEQ_IDX_PAGEPROGRAM + 3] = FLEXSPI_LUT_SEQ(
+                kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0x00, kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0xA0),         // DATA 0xA0
+            // +1
+            [4 * HYPERFLASH_CMD_LUT_SEQ_IDX_PAGEPROGRAM + 4] =
+                FLEXSPI_LUT_SEQ(kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0x20, kFLEXSPI_Command_RADDR_DDR, kFLEXSPI_8PAD, 0x18),
+            [4 * HYPERFLASH_CMD_LUT_SEQ_IDX_PAGEPROGRAM + 5] = FLEXSPI_LUT_SEQ(
+                kFLEXSPI_Command_CADDR_DDR, kFLEXSPI_8PAD, 0x10, kFLEXSPI_Command_WRITE_DDR, kFLEXSPI_8PAD, 0x80),
 
-                    /* 12 Erase chip */
-                    [4 * HYPERFLASH_CMD_LUT_SEQ_IDX_ERASECHIP] =
-                        FLEXSPI_LUT_SEQ(kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0x00, kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0x00),
-                    [4 * HYPERFLASH_CMD_LUT_SEQ_IDX_ERASECHIP + 1] =
-                        FLEXSPI_LUT_SEQ(kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0x00, kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0xAA),
-                    [4 * HYPERFLASH_CMD_LUT_SEQ_IDX_ERASECHIP + 2] =
-                        FLEXSPI_LUT_SEQ(kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0x00, kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0x05),
-                    [4 * HYPERFLASH_CMD_LUT_SEQ_IDX_ERASECHIP + 3] =
-                        FLEXSPI_LUT_SEQ(kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0x00, kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0x80),
-                    // +1
-                    [4 * HYPERFLASH_CMD_LUT_SEQ_IDX_ERASECHIP + 4] =
-                        FLEXSPI_LUT_SEQ(kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0x00, kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0x00),
-                    [4 * HYPERFLASH_CMD_LUT_SEQ_IDX_ERASECHIP + 5] =
-                        FLEXSPI_LUT_SEQ(kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0x00, kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0xAA),
-                    [4 * HYPERFLASH_CMD_LUT_SEQ_IDX_ERASECHIP + 6] =
-                        FLEXSPI_LUT_SEQ(kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0x00, kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0x05),
-                    [4 * HYPERFLASH_CMD_LUT_SEQ_IDX_ERASECHIP + 7] =
-                        FLEXSPI_LUT_SEQ(kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0x00, kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0xAA),
-                    // +2
-                    [4 * HYPERFLASH_CMD_LUT_SEQ_IDX_ERASECHIP + 8] =
-                        FLEXSPI_LUT_SEQ(kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0x00, kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0x00),
-                    [4 * HYPERFLASH_CMD_LUT_SEQ_IDX_ERASECHIP + 9] =
-                        FLEXSPI_LUT_SEQ(kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0x00, kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0x55),
-                    [4 * HYPERFLASH_CMD_LUT_SEQ_IDX_ERASECHIP + 10] =
-                        FLEXSPI_LUT_SEQ(kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0x00, kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0x02),
-                    [4 * HYPERFLASH_CMD_LUT_SEQ_IDX_ERASECHIP + 11] =
-                        FLEXSPI_LUT_SEQ(kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0x00, kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0x55),
-                    // +3
-                    [4 * HYPERFLASH_CMD_LUT_SEQ_IDX_ERASECHIP + 12] =
-                        FLEXSPI_LUT_SEQ(kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0x00, kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0x00),
-                    [4 * HYPERFLASH_CMD_LUT_SEQ_IDX_ERASECHIP + 13] =
-                        FLEXSPI_LUT_SEQ(kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0x00, kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0xAA),
-                    [4 * HYPERFLASH_CMD_LUT_SEQ_IDX_ERASECHIP + 14] =
-                        FLEXSPI_LUT_SEQ(kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0x00, kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0x05),
-                    [4 * HYPERFLASH_CMD_LUT_SEQ_IDX_ERASECHIP + 15] =
-                        FLEXSPI_LUT_SEQ(kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0x00, kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0x10),
-                },
+            /* 12 Erase chip */
+            [4 * HYPERFLASH_CMD_LUT_SEQ_IDX_ERASECHIP] =
+                FLEXSPI_LUT_SEQ(kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0x00, kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0x00),
+            [4 * HYPERFLASH_CMD_LUT_SEQ_IDX_ERASECHIP + 1] =
+                FLEXSPI_LUT_SEQ(kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0x00, kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0xAA),
+            [4 * HYPERFLASH_CMD_LUT_SEQ_IDX_ERASECHIP + 2] =
+                FLEXSPI_LUT_SEQ(kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0x00, kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0x05),
+            [4 * HYPERFLASH_CMD_LUT_SEQ_IDX_ERASECHIP + 3] =
+                FLEXSPI_LUT_SEQ(kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0x00, kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0x80),
+            // +1
+            [4 * HYPERFLASH_CMD_LUT_SEQ_IDX_ERASECHIP + 4] =
+                FLEXSPI_LUT_SEQ(kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0x00, kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0x00),
+            [4 * HYPERFLASH_CMD_LUT_SEQ_IDX_ERASECHIP + 5] =
+                FLEXSPI_LUT_SEQ(kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0x00, kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0xAA),
+            [4 * HYPERFLASH_CMD_LUT_SEQ_IDX_ERASECHIP + 6] =
+                FLEXSPI_LUT_SEQ(kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0x00, kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0x05),
+            [4 * HYPERFLASH_CMD_LUT_SEQ_IDX_ERASECHIP + 7] =
+                FLEXSPI_LUT_SEQ(kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0x00, kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0xAA),
+            // +2
+            [4 * HYPERFLASH_CMD_LUT_SEQ_IDX_ERASECHIP + 8] =
+                FLEXSPI_LUT_SEQ(kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0x00, kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0x00),
+            [4 * HYPERFLASH_CMD_LUT_SEQ_IDX_ERASECHIP + 9] =
+                FLEXSPI_LUT_SEQ(kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0x00, kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0x55),
+            [4 * HYPERFLASH_CMD_LUT_SEQ_IDX_ERASECHIP + 10] =
+                FLEXSPI_LUT_SEQ(kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0x00, kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0x02),
+            [4 * HYPERFLASH_CMD_LUT_SEQ_IDX_ERASECHIP + 11] =
+                FLEXSPI_LUT_SEQ(kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0x00, kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0x55),
+            // +3
+            [4 * HYPERFLASH_CMD_LUT_SEQ_IDX_ERASECHIP + 12] =
+                FLEXSPI_LUT_SEQ(kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0x00, kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0x00),
+            [4 * HYPERFLASH_CMD_LUT_SEQ_IDX_ERASECHIP + 13] =
+                FLEXSPI_LUT_SEQ(kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0x00, kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0xAA),
+            [4 * HYPERFLASH_CMD_LUT_SEQ_IDX_ERASECHIP + 14] =
+                FLEXSPI_LUT_SEQ(kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0x00, kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0x05),
+            [4 * HYPERFLASH_CMD_LUT_SEQ_IDX_ERASECHIP + 15] =
+                FLEXSPI_LUT_SEQ(kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0x00, kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0x10),
         },
-    .pageSize           = 512u,
-    .sectorSize         = 256u * 1024u,
-    .blockSize          = 256u * 1024u,
+    },
+    .pageSize = 512u,
+    .sectorSize = 256u * 1024u,
+    .blockSize = 256u * 1024u,
     .isUniformBlockSize = true,
 };
 

--- a/ports/mimxrt/boards/MIMXRT1060_EVK/mpconfigboard.h
+++ b/ports/mimxrt/boards/MIMXRT1060_EVK/mpconfigboard.h
@@ -38,10 +38,10 @@
     { IOMUXC_GPIO_SD_B0_02_LPSPI1_SDO }, { IOMUXC_GPIO_SD_B0_03_LPSPI1_SDI },
 
 #define DMA_REQ_SRC_RX { 0, kDmaRequestMuxLPSPI1Rx, kDmaRequestMuxLPSPI2Rx, \
-                            kDmaRequestMuxLPSPI3Rx, kDmaRequestMuxLPSPI4Rx }
+                         kDmaRequestMuxLPSPI3Rx, kDmaRequestMuxLPSPI4Rx }
 
 #define DMA_REQ_SRC_TX { 0, kDmaRequestMuxLPSPI1Tx, kDmaRequestMuxLPSPI2Tx, \
-                            kDmaRequestMuxLPSPI3Tx, kDmaRequestMuxLPSPI4Tx } 
+                         kDmaRequestMuxLPSPI3Tx, kDmaRequestMuxLPSPI4Tx }
 
 // Define the mapping hardware I2C # to logical I2C #
 // SDA/SCL  HW-I2C    Logical I2C
@@ -60,9 +60,9 @@
     { \
         .cmd = {GPIO_SD_B0_00_USDHC1_CMD}, \
         .clk = { GPIO_SD_B0_01_USDHC1_CLK }, \
-        .cd_b = { GPIO_B1_12_USDHC1_CD_B },\
-        .data0 = { GPIO_SD_B0_02_USDHC1_DATA0 },\
-        .data1 = { GPIO_SD_B0_03_USDHC1_DATA1 },\
-        .data2 = { GPIO_SD_B0_04_USDHC1_DATA2 },\
-        .data3 = { GPIO_SD_B0_05_USDHC1_DATA3 },\
+        .cd_b = { GPIO_B1_12_USDHC1_CD_B }, \
+        .data0 = { GPIO_SD_B0_02_USDHC1_DATA0 }, \
+        .data1 = { GPIO_SD_B0_03_USDHC1_DATA1 }, \
+        .data2 = { GPIO_SD_B0_04_USDHC1_DATA2 }, \
+        .data3 = { GPIO_SD_B0_05_USDHC1_DATA3 }, \
     }

--- a/ports/mimxrt/boards/MIMXRT1064_EVK/evkmimxrt1064_flexspi_nor_config.h
+++ b/ports/mimxrt/boards/MIMXRT1064_EVK/evkmimxrt1064_flexspi_nor_config.h
@@ -73,9 +73,9 @@
 
 #define FLEXSPI_LUT_SEQ(cmd0, pad0, op0, cmd1, pad1, op1)                                                              \
     (FLEXSPI_LUT_OPERAND0(op0) | FLEXSPI_LUT_NUM_PADS0(pad0) | FLEXSPI_LUT_OPCODE0(cmd0) | FLEXSPI_LUT_OPERAND1(op1) | \
-     FLEXSPI_LUT_NUM_PADS1(pad1) | FLEXSPI_LUT_OPCODE1(cmd1))
+    FLEXSPI_LUT_NUM_PADS1(pad1) | FLEXSPI_LUT_OPCODE1(cmd1))
 
-//!@brief Definitions for FlexSPI Serial Clock Frequency
+// !@brief Definitions for FlexSPI Serial Clock Frequency
 typedef enum _FlexSpiSerialClockFreq
 {
     kFlexSpiSerialClk_30MHz  = 1,
@@ -89,14 +89,14 @@ typedef enum _FlexSpiSerialClockFreq
     kFlexSpiSerialClk_166MHz = 9,
 } flexspi_serial_clk_freq_t;
 
-//!@brief FlexSPI clock configuration type
+// !@brief FlexSPI clock configuration type
 enum
 {
-    kFlexSpiClk_SDR, //!< Clock configure for SDR mode
-    kFlexSpiClk_DDR, //!< Clock configurat for DDR mode
+    kFlexSpiClk_SDR, // !< Clock configure for SDR mode
+    kFlexSpiClk_DDR, // !< Clock configurat for DDR mode
 };
 
-//!@brief FlexSPI Read Sample Clock Source definition
+// !@brief FlexSPI Read Sample Clock Source definition
 typedef enum _FlashReadSampleClkSource
 {
     kFlexSPIReadSampleClk_LoopbackInternally      = 0,
@@ -105,29 +105,29 @@ typedef enum _FlashReadSampleClkSource
     kFlexSPIReadSampleClk_ExternalInputFromDqsPad = 3,
 } flexspi_read_sample_clk_t;
 
-//!@brief Misc feature bit definitions
+// !@brief Misc feature bit definitions
 enum
 {
-    kFlexSpiMiscOffset_DiffClkEnable            = 0, //!< Bit for Differential clock enable
-    kFlexSpiMiscOffset_Ck2Enable                = 1, //!< Bit for CK2 enable
-    kFlexSpiMiscOffset_ParallelEnable           = 2, //!< Bit for Parallel mode enable
-    kFlexSpiMiscOffset_WordAddressableEnable    = 3, //!< Bit for Word Addressable enable
-    kFlexSpiMiscOffset_SafeConfigFreqEnable     = 4, //!< Bit for Safe Configuration Frequency enable
-    kFlexSpiMiscOffset_PadSettingOverrideEnable = 5, //!< Bit for Pad setting override enable
-    kFlexSpiMiscOffset_DdrModeEnable            = 6, //!< Bit for DDR clock confiuration indication.
+    kFlexSpiMiscOffset_DiffClkEnable            = 0, // !< Bit for Differential clock enable
+    kFlexSpiMiscOffset_Ck2Enable                = 1, // !< Bit for CK2 enable
+    kFlexSpiMiscOffset_ParallelEnable           = 2, // !< Bit for Parallel mode enable
+    kFlexSpiMiscOffset_WordAddressableEnable    = 3, // !< Bit for Word Addressable enable
+    kFlexSpiMiscOffset_SafeConfigFreqEnable     = 4, // !< Bit for Safe Configuration Frequency enable
+    kFlexSpiMiscOffset_PadSettingOverrideEnable = 5, // !< Bit for Pad setting override enable
+    kFlexSpiMiscOffset_DdrModeEnable            = 6, // !< Bit for DDR clock confiuration indication.
 };
 
-//!@brief Flash Type Definition
+// !@brief Flash Type Definition
 enum
 {
-    kFlexSpiDeviceType_SerialNOR    = 1,    //!< Flash devices are Serial NOR
-    kFlexSpiDeviceType_SerialNAND   = 2,    //!< Flash devices are Serial NAND
-    kFlexSpiDeviceType_SerialRAM    = 3,    //!< Flash devices are Serial RAM/HyperFLASH
-    kFlexSpiDeviceType_MCP_NOR_NAND = 0x12, //!< Flash device is MCP device, A1 is Serial NOR, A2 is Serial NAND
-    kFlexSpiDeviceType_MCP_NOR_RAM  = 0x13, //!< Flash deivce is MCP device, A1 is Serial NOR, A2 is Serial RAMs
+    kFlexSpiDeviceType_SerialNOR    = 1,    // !< Flash devices are Serial NOR
+    kFlexSpiDeviceType_SerialNAND   = 2,    // !< Flash devices are Serial NAND
+    kFlexSpiDeviceType_SerialRAM    = 3,    // !< Flash devices are Serial RAM/HyperFLASH
+    kFlexSpiDeviceType_MCP_NOR_NAND = 0x12, // !< Flash device is MCP device, A1 is Serial NOR, A2 is Serial NAND
+    kFlexSpiDeviceType_MCP_NOR_RAM  = 0x13, // !< Flash deivce is MCP device, A1 is Serial NOR, A2 is Serial RAMs
 };
 
-//!@brief Flash Pad Definitions
+// !@brief Flash Pad Definitions
 enum
 {
     kSerialFlash_1Pad  = 1,
@@ -136,77 +136,77 @@ enum
     kSerialFlash_8Pads = 8,
 };
 
-//!@brief FlexSPI LUT Sequence structure
+// !@brief FlexSPI LUT Sequence structure
 typedef struct _lut_sequence
 {
-    uint8_t seqNum; //!< Sequence Number, valid number: 1-16
-    uint8_t seqId;  //!< Sequence Index, valid number: 0-15
+    uint8_t seqNum; // !< Sequence Number, valid number: 1-16
+    uint8_t seqId;  // !< Sequence Index, valid number: 0-15
     uint16_t reserved;
 } flexspi_lut_seq_t;
 
-//!@brief Flash Configuration Command Type
+// !@brief Flash Configuration Command Type
 enum
 {
-    kDeviceConfigCmdType_Generic,    //!< Generic command, for example: configure dummy cycles, drive strength, etc
-    kDeviceConfigCmdType_QuadEnable, //!< Quad Enable command
-    kDeviceConfigCmdType_Spi2Xpi,    //!< Switch from SPI to DPI/QPI/OPI mode
-    kDeviceConfigCmdType_Xpi2Spi,    //!< Switch from DPI/QPI/OPI to SPI mode
-    kDeviceConfigCmdType_Spi2NoCmd,  //!< Switch to 0-4-4/0-8-8 mode
-    kDeviceConfigCmdType_Reset,      //!< Reset device command
+    kDeviceConfigCmdType_Generic,    // !< Generic command, for example: configure dummy cycles, drive strength, etc
+    kDeviceConfigCmdType_QuadEnable, // !< Quad Enable command
+    kDeviceConfigCmdType_Spi2Xpi,    // !< Switch from SPI to DPI/QPI/OPI mode
+    kDeviceConfigCmdType_Xpi2Spi,    // !< Switch from DPI/QPI/OPI to SPI mode
+    kDeviceConfigCmdType_Spi2NoCmd,  // !< Switch to 0-4-4/0-8-8 mode
+    kDeviceConfigCmdType_Reset,      // !< Reset device command
 };
 
-//!@brief FlexSPI Memory Configuration Block
+// !@brief FlexSPI Memory Configuration Block
 typedef struct _FlexSPIConfig
 {
-    uint32_t tag;               //!< [0x000-0x003] Tag, fixed value 0x42464346UL
-    uint32_t version;           //!< [0x004-0x007] Version,[31:24] -'V', [23:16] - Major, [15:8] - Minor, [7:0] - bugfix
-    uint32_t reserved0;         //!< [0x008-0x00b] Reserved for future use
-    uint8_t readSampleClkSrc;   //!< [0x00c-0x00c] Read Sample Clock Source, valid value: 0/1/3
-    uint8_t csHoldTime;         //!< [0x00d-0x00d] CS hold time, default value: 3
-    uint8_t csSetupTime;        //!< [0x00e-0x00e] CS setup time, default value: 3
-    uint8_t columnAddressWidth; //!< [0x00f-0x00f] Column Address with, for HyperBus protocol, it is fixed to 3, For
-    //! Serial NAND, need to refer to datasheet
-    uint8_t deviceModeCfgEnable; //!< [0x010-0x010] Device Mode Configure enable flag, 1 - Enable, 0 - Disable
-    uint8_t deviceModeType; //!< [0x011-0x011] Specify the configuration command type:Quad Enable, DPI/QPI/OPI switch,
-    //! Generic configuration, etc.
-    uint16_t waitTimeCfgCommands; //!< [0x012-0x013] Wait time for all configuration commands, unit: 100us, Used for
-    //! DPI/QPI/OPI switch or reset command
-    flexspi_lut_seq_t deviceModeSeq; //!< [0x014-0x017] Device mode sequence info, [7:0] - LUT sequence id, [15:8] - LUt
-    //! sequence number, [31:16] Reserved
-    uint32_t deviceModeArg;    //!< [0x018-0x01b] Argument/Parameter for device configuration
-    uint8_t configCmdEnable;   //!< [0x01c-0x01c] Configure command Enable Flag, 1 - Enable, 0 - Disable
-    uint8_t configModeType[3]; //!< [0x01d-0x01f] Configure Mode Type, similar as deviceModeTpe
+    uint32_t tag;               // !< [0x000-0x003] Tag, fixed value 0x42464346UL
+    uint32_t version;           // !< [0x004-0x007] Version,[31:24] -'V', [23:16] - Major, [15:8] - Minor, [7:0] - bugfix
+    uint32_t reserved0;         // !< [0x008-0x00b] Reserved for future use
+    uint8_t readSampleClkSrc;   // !< [0x00c-0x00c] Read Sample Clock Source, valid value: 0/1/3
+    uint8_t csHoldTime;         // !< [0x00d-0x00d] CS hold time, default value: 3
+    uint8_t csSetupTime;        // !< [0x00e-0x00e] CS setup time, default value: 3
+    uint8_t columnAddressWidth; // !< [0x00f-0x00f] Column Address with, for HyperBus protocol, it is fixed to 3, For
+    // ! Serial NAND, need to refer to datasheet
+    uint8_t deviceModeCfgEnable; // !< [0x010-0x010] Device Mode Configure enable flag, 1 - Enable, 0 - Disable
+    uint8_t deviceModeType; // !< [0x011-0x011] Specify the configuration command type:Quad Enable, DPI/QPI/OPI switch,
+    // ! Generic configuration, etc.
+    uint16_t waitTimeCfgCommands; // !< [0x012-0x013] Wait time for all configuration commands, unit: 100us, Used for
+    // ! DPI/QPI/OPI switch or reset command
+    flexspi_lut_seq_t deviceModeSeq; // !< [0x014-0x017] Device mode sequence info, [7:0] - LUT sequence id, [15:8] - LUt
+    // ! sequence number, [31:16] Reserved
+    uint32_t deviceModeArg;    // !< [0x018-0x01b] Argument/Parameter for device configuration
+    uint8_t configCmdEnable;   // !< [0x01c-0x01c] Configure command Enable Flag, 1 - Enable, 0 - Disable
+    uint8_t configModeType[3]; // !< [0x01d-0x01f] Configure Mode Type, similar as deviceModeTpe
     flexspi_lut_seq_t
-        configCmdSeqs[3]; //!< [0x020-0x02b] Sequence info for Device Configuration command, similar as deviceModeSeq
-    uint32_t reserved1;   //!< [0x02c-0x02f] Reserved for future use
-    uint32_t configCmdArgs[3];     //!< [0x030-0x03b] Arguments/Parameters for device Configuration commands
-    uint32_t reserved2;            //!< [0x03c-0x03f] Reserved for future use
-    uint32_t controllerMiscOption; //!< [0x040-0x043] Controller Misc Options, see Misc feature bit definitions for more
-    //! details
-    uint8_t deviceType;    //!< [0x044-0x044] Device Type:  See Flash Type Definition for more details
-    uint8_t sflashPadType; //!< [0x045-0x045] Serial Flash Pad Type: 1 - Single, 2 - Dual, 4 - Quad, 8 - Octal
-    uint8_t serialClkFreq; //!< [0x046-0x046] Serial Flash Frequencey, device specific definitions, See System Boot
-    //! Chapter for more details
-    uint8_t lutCustomSeqEnable; //!< [0x047-0x047] LUT customization Enable, it is required if the program/erase cannot
-    //! be done using 1 LUT sequence, currently, only applicable to HyperFLASH
-    uint32_t reserved3[2];           //!< [0x048-0x04f] Reserved for future use
-    uint32_t sflashA1Size;           //!< [0x050-0x053] Size of Flash connected to A1
-    uint32_t sflashA2Size;           //!< [0x054-0x057] Size of Flash connected to A2
-    uint32_t sflashB1Size;           //!< [0x058-0x05b] Size of Flash connected to B1
-    uint32_t sflashB2Size;           //!< [0x05c-0x05f] Size of Flash connected to B2
-    uint32_t csPadSettingOverride;   //!< [0x060-0x063] CS pad setting override value
-    uint32_t sclkPadSettingOverride; //!< [0x064-0x067] SCK pad setting override value
-    uint32_t dataPadSettingOverride; //!< [0x068-0x06b] data pad setting override value
-    uint32_t dqsPadSettingOverride;  //!< [0x06c-0x06f] DQS pad setting override value
-    uint32_t timeoutInMs;            //!< [0x070-0x073] Timeout threshold for read status command
-    uint32_t commandInterval;        //!< [0x074-0x077] CS deselect interval between two commands
-    uint16_t dataValidTime[2]; //!< [0x078-0x07b] CLK edge to data valid time for PORT A and PORT B, in terms of 0.1ns
-    uint16_t busyOffset;       //!< [0x07c-0x07d] Busy offset, valid value: 0-31
-    uint16_t busyBitPolarity;  //!< [0x07e-0x07f] Busy flag polarity, 0 - busy flag is 1 when flash device is busy, 1 -
-    //! busy flag is 0 when flash device is busy
-    uint32_t lookupTable[64];           //!< [0x080-0x17f] Lookup table holds Flash command sequences
-    flexspi_lut_seq_t lutCustomSeq[12]; //!< [0x180-0x1af] Customizable LUT Sequences
-    uint32_t reserved4[4];              //!< [0x1b0-0x1bf] Reserved for future use
+        configCmdSeqs[3]; // !< [0x020-0x02b] Sequence info for Device Configuration command, similar as deviceModeSeq
+    uint32_t reserved1;   // !< [0x02c-0x02f] Reserved for future use
+    uint32_t configCmdArgs[3];     // !< [0x030-0x03b] Arguments/Parameters for device Configuration commands
+    uint32_t reserved2;            // !< [0x03c-0x03f] Reserved for future use
+    uint32_t controllerMiscOption; // !< [0x040-0x043] Controller Misc Options, see Misc feature bit definitions for more
+    // ! details
+    uint8_t deviceType;    // !< [0x044-0x044] Device Type:  See Flash Type Definition for more details
+    uint8_t sflashPadType; // !< [0x045-0x045] Serial Flash Pad Type: 1 - Single, 2 - Dual, 4 - Quad, 8 - Octal
+    uint8_t serialClkFreq; // !< [0x046-0x046] Serial Flash Frequencey, device specific definitions, See System Boot
+    // ! Chapter for more details
+    uint8_t lutCustomSeqEnable; // !< [0x047-0x047] LUT customization Enable, it is required if the program/erase cannot
+    // ! be done using 1 LUT sequence, currently, only applicable to HyperFLASH
+    uint32_t reserved3[2];           // !< [0x048-0x04f] Reserved for future use
+    uint32_t sflashA1Size;           // !< [0x050-0x053] Size of Flash connected to A1
+    uint32_t sflashA2Size;           // !< [0x054-0x057] Size of Flash connected to A2
+    uint32_t sflashB1Size;           // !< [0x058-0x05b] Size of Flash connected to B1
+    uint32_t sflashB2Size;           // !< [0x05c-0x05f] Size of Flash connected to B2
+    uint32_t csPadSettingOverride;   // !< [0x060-0x063] CS pad setting override value
+    uint32_t sclkPadSettingOverride; // !< [0x064-0x067] SCK pad setting override value
+    uint32_t dataPadSettingOverride; // !< [0x068-0x06b] data pad setting override value
+    uint32_t dqsPadSettingOverride;  // !< [0x06c-0x06f] DQS pad setting override value
+    uint32_t timeoutInMs;            // !< [0x070-0x073] Timeout threshold for read status command
+    uint32_t commandInterval;        // !< [0x074-0x077] CS deselect interval between two commands
+    uint16_t dataValidTime[2]; // !< [0x078-0x07b] CLK edge to data valid time for PORT A and PORT B, in terms of 0.1ns
+    uint16_t busyOffset;       // !< [0x07c-0x07d] Busy offset, valid value: 0-31
+    uint16_t busyBitPolarity;  // !< [0x07e-0x07f] Busy flag polarity, 0 - busy flag is 1 when flash device is busy, 1 -
+    // ! busy flag is 0 when flash device is busy
+    uint32_t lookupTable[64];           // !< [0x080-0x17f] Lookup table holds Flash command sequences
+    flexspi_lut_seq_t lutCustomSeq[12]; // !< [0x180-0x1af] Customizable LUT Sequences
+    uint32_t reserved4[4];              // !< [0x1b0-0x1bf] Reserved for future use
 } flexspi_mem_config_t;
 
 /*  */
@@ -237,18 +237,18 @@ typedef struct _FlexSPIConfig
  */
 typedef struct _flexspi_nor_config
 {
-    flexspi_mem_config_t memConfig; //!< Common memory configuration info via FlexSPI
-    uint32_t pageSize;              //!< Page size of Serial NOR
-    uint32_t sectorSize;            //!< Sector size of Serial NOR
-    uint8_t ipcmdSerialClkFreq;     //!< Clock frequency for IP command
-    uint8_t isUniformBlockSize;     //!< Sector/Block size is the same
-    uint8_t reserved0[2];           //!< Reserved for future use
-    uint8_t serialNorType;          //!< Serial NOR Flash type: 0/1/2/3
-    uint8_t needExitNoCmdMode;      //!< Need to exit NoCmd mode before other IP command
-    uint8_t halfClkForNonReadCmd;   //!< Half the Serial Clock for non-read command: true/false
-    uint8_t needRestoreNoCmdMode;   //!< Need to Restore NoCmd mode after IP commmand execution
-    uint32_t blockSize;             //!< Block size
-    uint32_t reserve2[11];          //!< Reserved for future use
+    flexspi_mem_config_t memConfig; // !< Common memory configuration info via FlexSPI
+    uint32_t pageSize;              // !< Page size of Serial NOR
+    uint32_t sectorSize;            // !< Sector size of Serial NOR
+    uint8_t ipcmdSerialClkFreq;     // !< Clock frequency for IP command
+    uint8_t isUniformBlockSize;     // !< Sector/Block size is the same
+    uint8_t reserved0[2];           // !< Reserved for future use
+    uint8_t serialNorType;          // !< Serial NOR Flash type: 0/1/2/3
+    uint8_t needExitNoCmdMode;      // !< Need to exit NoCmd mode before other IP command
+    uint8_t halfClkForNonReadCmd;   // !< Half the Serial Clock for non-read command: true/false
+    uint8_t needRestoreNoCmdMode;   // !< Need to Restore NoCmd mode after IP commmand execution
+    uint32_t blockSize;             // !< Block size
+    uint32_t reserve2[11];          // !< Reserved for future use
 } flexspi_nor_config_t;
 
 #define FLASH_BUSY_STATUS_POL 0

--- a/ports/mimxrt/boards/MIMXRT1064_EVK/flash_config.c
+++ b/ports/mimxrt/boards/MIMXRT1064_EVK/flash_config.c
@@ -24,162 +24,162 @@ __attribute__((section(".boot_hdr.conf")))
 
 const flexspi_nor_config_t qspiflash_config = {
     .memConfig =
+    {
+        .tag = FLEXSPI_CFG_BLK_TAG,
+        .version = FLEXSPI_CFG_BLK_VERSION,
+        .readSampleClkSrc = kFlexSPIReadSampleClk_ExternalInputFromDqsPad,
+        .csHoldTime = 3u,
+        .csSetupTime = 3u,
+        .columnAddressWidth = 3u,
+        // Enable DDR mode, Wordaddressable, Safe configuration, Differential clock
+        .controllerMiscOption =
+            (1u << kFlexSpiMiscOffset_DdrModeEnable) | (1u << kFlexSpiMiscOffset_WordAddressableEnable) |
+            (1u << kFlexSpiMiscOffset_SafeConfigFreqEnable) | (1u << kFlexSpiMiscOffset_DiffClkEnable),
+        .sflashPadType = kSerialFlash_8Pads,
+        .serialClkFreq = kFlexSpiSerialClk_133MHz,
+        .sflashA1Size = 64u * 1024u * 1024u,
+        .dataValidTime = {16u, 16u},
+        .lookupTable =
         {
-            .tag                = FLEXSPI_CFG_BLK_TAG,
-            .version            = FLEXSPI_CFG_BLK_VERSION,
-            .readSampleClkSrc   = kFlexSPIReadSampleClk_ExternalInputFromDqsPad,
-            .csHoldTime         = 3u,
-            .csSetupTime        = 3u,
-            .columnAddressWidth = 3u,
-            // Enable DDR mode, Wordaddressable, Safe configuration, Differential clock
-            .controllerMiscOption =
-                (1u << kFlexSpiMiscOffset_DdrModeEnable) | (1u << kFlexSpiMiscOffset_WordAddressableEnable) |
-                (1u << kFlexSpiMiscOffset_SafeConfigFreqEnable) | (1u << kFlexSpiMiscOffset_DiffClkEnable),
-            .sflashPadType = kSerialFlash_8Pads,
-            .serialClkFreq = kFlexSpiSerialClk_133MHz,
-            .sflashA1Size  = 64u * 1024u * 1024u,
-            .dataValidTime = {16u, 16u},
-            .lookupTable =
-                {
-                    /* 0 Read Data */
-                    [4 * HYPERFLASH_CMD_LUT_SEQ_IDX_READDATA] =
-                        FLEXSPI_LUT_SEQ(kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0xA0, kFLEXSPI_Command_RADDR_DDR, kFLEXSPI_8PAD, 0x18),
-                    [4 * HYPERFLASH_CMD_LUT_SEQ_IDX_READDATA + 1] = FLEXSPI_LUT_SEQ(
-                        kFLEXSPI_Command_CADDR_DDR, kFLEXSPI_8PAD, 0x10, kFLEXSPI_Command_READ_DDR, kFLEXSPI_8PAD, 0x04),
+            /* 0 Read Data */
+            [4 * HYPERFLASH_CMD_LUT_SEQ_IDX_READDATA] =
+                FLEXSPI_LUT_SEQ(kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0xA0, kFLEXSPI_Command_RADDR_DDR, kFLEXSPI_8PAD, 0x18),
+            [4 * HYPERFLASH_CMD_LUT_SEQ_IDX_READDATA + 1] = FLEXSPI_LUT_SEQ(
+                kFLEXSPI_Command_CADDR_DDR, kFLEXSPI_8PAD, 0x10, kFLEXSPI_Command_READ_DDR, kFLEXSPI_8PAD, 0x04),
 
-                    /* 1 Write Data */
-                    [4 * HYPERFLASH_CMD_LUT_SEQ_IDX_WRITEDATA] =
-                        FLEXSPI_LUT_SEQ(kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0x20, kFLEXSPI_Command_RADDR_DDR, kFLEXSPI_8PAD, 0x18),
-                    [4 * HYPERFLASH_CMD_LUT_SEQ_IDX_WRITEDATA + 1] = FLEXSPI_LUT_SEQ(
-                        kFLEXSPI_Command_CADDR_DDR, kFLEXSPI_8PAD, 0x10, kFLEXSPI_Command_WRITE_DDR, kFLEXSPI_8PAD, 0x02),
+            /* 1 Write Data */
+            [4 * HYPERFLASH_CMD_LUT_SEQ_IDX_WRITEDATA] =
+                FLEXSPI_LUT_SEQ(kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0x20, kFLEXSPI_Command_RADDR_DDR, kFLEXSPI_8PAD, 0x18),
+            [4 * HYPERFLASH_CMD_LUT_SEQ_IDX_WRITEDATA + 1] = FLEXSPI_LUT_SEQ(
+                kFLEXSPI_Command_CADDR_DDR, kFLEXSPI_8PAD, 0x10, kFLEXSPI_Command_WRITE_DDR, kFLEXSPI_8PAD, 0x02),
 
-                    /* 2 Read Status */
-                    [4 * HYPERFLASH_CMD_LUT_SEQ_IDX_READSTATUS] =
-                        FLEXSPI_LUT_SEQ(kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0x00, kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0x00),
-                    [4 * HYPERFLASH_CMD_LUT_SEQ_IDX_READSTATUS + 1] = FLEXSPI_LUT_SEQ(
-                        kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0x00, kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0xAA), // ADDR 0x555
-                    [4 * HYPERFLASH_CMD_LUT_SEQ_IDX_READSTATUS + 2] =
-                        FLEXSPI_LUT_SEQ(kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0x00, kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0x05),
-                    [4 * HYPERFLASH_CMD_LUT_SEQ_IDX_READSTATUS + 3] = FLEXSPI_LUT_SEQ(
-                        kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0x00, kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0x70), // DATA 0x70
-                    // +1
-                    [4 * HYPERFLASH_CMD_LUT_SEQ_IDX_READSTATUS + 4] =
-                        FLEXSPI_LUT_SEQ(kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0xA0, kFLEXSPI_Command_RADDR_DDR, kFLEXSPI_8PAD, 0x18),
-                    [4 * HYPERFLASH_CMD_LUT_SEQ_IDX_READSTATUS + 5] = FLEXSPI_LUT_SEQ(
-                        kFLEXSPI_Command_CADDR_DDR, kFLEXSPI_8PAD, 0x10, kFLEXSPI_Command_DUMMY_RWDS_DDR, kFLEXSPI_8PAD, 0x0B),
-                    [4 * HYPERFLASH_CMD_LUT_SEQ_IDX_READSTATUS + 6] =
-                        FLEXSPI_LUT_SEQ(kFLEXSPI_Command_READ_DDR, kFLEXSPI_8PAD, 0x04, kFLEXSPI_Command_STOP, kFLEXSPI_1PAD, 0x0),
+            /* 2 Read Status */
+            [4 * HYPERFLASH_CMD_LUT_SEQ_IDX_READSTATUS] =
+                FLEXSPI_LUT_SEQ(kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0x00, kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0x00),
+            [4 * HYPERFLASH_CMD_LUT_SEQ_IDX_READSTATUS + 1] = FLEXSPI_LUT_SEQ(
+                kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0x00, kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0xAA),         // ADDR 0x555
+            [4 * HYPERFLASH_CMD_LUT_SEQ_IDX_READSTATUS + 2] =
+                FLEXSPI_LUT_SEQ(kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0x00, kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0x05),
+            [4 * HYPERFLASH_CMD_LUT_SEQ_IDX_READSTATUS + 3] = FLEXSPI_LUT_SEQ(
+                kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0x00, kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0x70),         // DATA 0x70
+            // +1
+            [4 * HYPERFLASH_CMD_LUT_SEQ_IDX_READSTATUS + 4] =
+                FLEXSPI_LUT_SEQ(kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0xA0, kFLEXSPI_Command_RADDR_DDR, kFLEXSPI_8PAD, 0x18),
+            [4 * HYPERFLASH_CMD_LUT_SEQ_IDX_READSTATUS + 5] = FLEXSPI_LUT_SEQ(
+                kFLEXSPI_Command_CADDR_DDR, kFLEXSPI_8PAD, 0x10, kFLEXSPI_Command_DUMMY_RWDS_DDR, kFLEXSPI_8PAD, 0x0B),
+            [4 * HYPERFLASH_CMD_LUT_SEQ_IDX_READSTATUS + 6] =
+                FLEXSPI_LUT_SEQ(kFLEXSPI_Command_READ_DDR, kFLEXSPI_8PAD, 0x04, kFLEXSPI_Command_STOP, kFLEXSPI_1PAD, 0x0),
 
-                    /* 4 Write Enable */
-                    [4 * HYPERFLASH_CMD_LUT_SEQ_IDX_WRITEENABLE] =
-                        FLEXSPI_LUT_SEQ(kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0x20, kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0x00),
-                    [4 * HYPERFLASH_CMD_LUT_SEQ_IDX_WRITEENABLE + 1] = FLEXSPI_LUT_SEQ(
-                        kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0x00, kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0xAA), // ADDR 0x555
-                    [4 * HYPERFLASH_CMD_LUT_SEQ_IDX_WRITEENABLE + 2] =
-                        FLEXSPI_LUT_SEQ(kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0x00, kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0x05),
-                    [4 * HYPERFLASH_CMD_LUT_SEQ_IDX_WRITEENABLE + 3] = FLEXSPI_LUT_SEQ(
-                        kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0x00, kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0xAA), // DATA 0xAA
-                    // +1
-                    [4 * HYPERFLASH_CMD_LUT_SEQ_IDX_WRITEENABLE + 4] =
-                        FLEXSPI_LUT_SEQ(kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0x20, kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0x00),
-                    [4 * HYPERFLASH_CMD_LUT_SEQ_IDX_WRITEENABLE + 5] =
-                        FLEXSPI_LUT_SEQ(kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0x00, kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0x55),
-                    [4 * HYPERFLASH_CMD_LUT_SEQ_IDX_WRITEENABLE + 6] =
-                        FLEXSPI_LUT_SEQ(kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0x00, kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0x02),
-                    [4 * HYPERFLASH_CMD_LUT_SEQ_IDX_WRITEENABLE + 7] =
-                        FLEXSPI_LUT_SEQ(kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0x00, kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0x55),
+            /* 4 Write Enable */
+            [4 * HYPERFLASH_CMD_LUT_SEQ_IDX_WRITEENABLE] =
+                FLEXSPI_LUT_SEQ(kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0x20, kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0x00),
+            [4 * HYPERFLASH_CMD_LUT_SEQ_IDX_WRITEENABLE + 1] = FLEXSPI_LUT_SEQ(
+                kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0x00, kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0xAA),         // ADDR 0x555
+            [4 * HYPERFLASH_CMD_LUT_SEQ_IDX_WRITEENABLE + 2] =
+                FLEXSPI_LUT_SEQ(kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0x00, kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0x05),
+            [4 * HYPERFLASH_CMD_LUT_SEQ_IDX_WRITEENABLE + 3] = FLEXSPI_LUT_SEQ(
+                kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0x00, kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0xAA),         // DATA 0xAA
+            // +1
+            [4 * HYPERFLASH_CMD_LUT_SEQ_IDX_WRITEENABLE + 4] =
+                FLEXSPI_LUT_SEQ(kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0x20, kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0x00),
+            [4 * HYPERFLASH_CMD_LUT_SEQ_IDX_WRITEENABLE + 5] =
+                FLEXSPI_LUT_SEQ(kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0x00, kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0x55),
+            [4 * HYPERFLASH_CMD_LUT_SEQ_IDX_WRITEENABLE + 6] =
+                FLEXSPI_LUT_SEQ(kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0x00, kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0x02),
+            [4 * HYPERFLASH_CMD_LUT_SEQ_IDX_WRITEENABLE + 7] =
+                FLEXSPI_LUT_SEQ(kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0x00, kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0x55),
 
-                    /* 6 Erase Sector  */
-                    [4 * HYPERFLASH_CMD_LUT_SEQ_IDX_ERASESECTOR] =
-                        FLEXSPI_LUT_SEQ(kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0x00, kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0x00),
-                    [4 * HYPERFLASH_CMD_LUT_SEQ_IDX_ERASESECTOR + 1] = FLEXSPI_LUT_SEQ(
-                        kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0x00, kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0xAA), // ADDR 0x555
-                    [4 * HYPERFLASH_CMD_LUT_SEQ_IDX_ERASESECTOR + 2] =
-                        FLEXSPI_LUT_SEQ(kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0x00, kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0x05),
-                    [4 * HYPERFLASH_CMD_LUT_SEQ_IDX_ERASESECTOR + 3] = FLEXSPI_LUT_SEQ(
-                        kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0x00, kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0x80), // DATA 0x80
-                    // +1
-                    [4 * HYPERFLASH_CMD_LUT_SEQ_IDX_ERASESECTOR + 4] =
-                        FLEXSPI_LUT_SEQ(kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0x00, kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0x00),
-                    [4 * HYPERFLASH_CMD_LUT_SEQ_IDX_ERASESECTOR + 5] =
-                        FLEXSPI_LUT_SEQ(kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0x00, kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0xAA),
-                    [4 * HYPERFLASH_CMD_LUT_SEQ_IDX_ERASESECTOR + 6] =
-                        FLEXSPI_LUT_SEQ(kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0x00, kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0x05),
-                    [4 * HYPERFLASH_CMD_LUT_SEQ_IDX_ERASESECTOR + 7] = FLEXSPI_LUT_SEQ(
-                        kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0x00, kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0xAA), // ADDR 0x555
-                    // +2
-                    [4 * HYPERFLASH_CMD_LUT_SEQ_IDX_ERASESECTOR + 8] =
-                        FLEXSPI_LUT_SEQ(kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0x00, kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0x00),
-                    [4 * HYPERFLASH_CMD_LUT_SEQ_IDX_ERASESECTOR + 9] =
-                        FLEXSPI_LUT_SEQ(kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0x00, kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0x55),
-                    [4 * HYPERFLASH_CMD_LUT_SEQ_IDX_ERASESECTOR + 10] =
-                        FLEXSPI_LUT_SEQ(kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0x00, kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0x02),
-                    [4 * HYPERFLASH_CMD_LUT_SEQ_IDX_ERASESECTOR + 11] =
-                        FLEXSPI_LUT_SEQ(kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0x00, kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0x55),
-                    // +3
-                    [4 * HYPERFLASH_CMD_LUT_SEQ_IDX_ERASESECTOR + 12] =
-                        FLEXSPI_LUT_SEQ(kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0x00, kFLEXSPI_Command_RADDR_DDR, kFLEXSPI_8PAD, 0x18),
-                    [4 * HYPERFLASH_CMD_LUT_SEQ_IDX_ERASESECTOR + 13] =
-                        FLEXSPI_LUT_SEQ(kFLEXSPI_Command_CADDR_DDR, kFLEXSPI_8PAD, 0x10, kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0x00),
-                    [4 * HYPERFLASH_CMD_LUT_SEQ_IDX_ERASESECTOR + 14] =
-                        FLEXSPI_LUT_SEQ(kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0x30, kFLEXSPI_Command_STOP, kFLEXSPI_1PAD, 0x00),
+            /* 6 Erase Sector  */
+            [4 * HYPERFLASH_CMD_LUT_SEQ_IDX_ERASESECTOR] =
+                FLEXSPI_LUT_SEQ(kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0x00, kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0x00),
+            [4 * HYPERFLASH_CMD_LUT_SEQ_IDX_ERASESECTOR + 1] = FLEXSPI_LUT_SEQ(
+                kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0x00, kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0xAA),         // ADDR 0x555
+            [4 * HYPERFLASH_CMD_LUT_SEQ_IDX_ERASESECTOR + 2] =
+                FLEXSPI_LUT_SEQ(kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0x00, kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0x05),
+            [4 * HYPERFLASH_CMD_LUT_SEQ_IDX_ERASESECTOR + 3] = FLEXSPI_LUT_SEQ(
+                kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0x00, kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0x80),         // DATA 0x80
+            // +1
+            [4 * HYPERFLASH_CMD_LUT_SEQ_IDX_ERASESECTOR + 4] =
+                FLEXSPI_LUT_SEQ(kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0x00, kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0x00),
+            [4 * HYPERFLASH_CMD_LUT_SEQ_IDX_ERASESECTOR + 5] =
+                FLEXSPI_LUT_SEQ(kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0x00, kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0xAA),
+            [4 * HYPERFLASH_CMD_LUT_SEQ_IDX_ERASESECTOR + 6] =
+                FLEXSPI_LUT_SEQ(kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0x00, kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0x05),
+            [4 * HYPERFLASH_CMD_LUT_SEQ_IDX_ERASESECTOR + 7] = FLEXSPI_LUT_SEQ(
+                kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0x00, kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0xAA),         // ADDR 0x555
+            // +2
+            [4 * HYPERFLASH_CMD_LUT_SEQ_IDX_ERASESECTOR + 8] =
+                FLEXSPI_LUT_SEQ(kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0x00, kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0x00),
+            [4 * HYPERFLASH_CMD_LUT_SEQ_IDX_ERASESECTOR + 9] =
+                FLEXSPI_LUT_SEQ(kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0x00, kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0x55),
+            [4 * HYPERFLASH_CMD_LUT_SEQ_IDX_ERASESECTOR + 10] =
+                FLEXSPI_LUT_SEQ(kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0x00, kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0x02),
+            [4 * HYPERFLASH_CMD_LUT_SEQ_IDX_ERASESECTOR + 11] =
+                FLEXSPI_LUT_SEQ(kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0x00, kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0x55),
+            // +3
+            [4 * HYPERFLASH_CMD_LUT_SEQ_IDX_ERASESECTOR + 12] =
+                FLEXSPI_LUT_SEQ(kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0x00, kFLEXSPI_Command_RADDR_DDR, kFLEXSPI_8PAD, 0x18),
+            [4 * HYPERFLASH_CMD_LUT_SEQ_IDX_ERASESECTOR + 13] =
+                FLEXSPI_LUT_SEQ(kFLEXSPI_Command_CADDR_DDR, kFLEXSPI_8PAD, 0x10, kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0x00),
+            [4 * HYPERFLASH_CMD_LUT_SEQ_IDX_ERASESECTOR + 14] =
+                FLEXSPI_LUT_SEQ(kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0x30, kFLEXSPI_Command_STOP, kFLEXSPI_1PAD, 0x00),
 
-                    /* 10 program page with word program command sequence */
-                    [4 * HYPERFLASH_CMD_LUT_SEQ_IDX_PAGEPROGRAM] =
-                        FLEXSPI_LUT_SEQ(kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0x20, kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0x00),
-                    [4 * HYPERFLASH_CMD_LUT_SEQ_IDX_PAGEPROGRAM + 1] = FLEXSPI_LUT_SEQ(
-                        kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0x00, kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0xAA), // ADDR 0x555
-                    [4 * HYPERFLASH_CMD_LUT_SEQ_IDX_PAGEPROGRAM + 2] =
-                        FLEXSPI_LUT_SEQ(kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0x00, kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0x05),
-                    [4 * HYPERFLASH_CMD_LUT_SEQ_IDX_PAGEPROGRAM + 3] = FLEXSPI_LUT_SEQ(
-                        kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0x00, kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0xA0), // DATA 0xA0
-                    // +1
-                    [4 * HYPERFLASH_CMD_LUT_SEQ_IDX_PAGEPROGRAM + 4] =
-                        FLEXSPI_LUT_SEQ(kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0x20, kFLEXSPI_Command_RADDR_DDR, kFLEXSPI_8PAD, 0x18),
-                    [4 * HYPERFLASH_CMD_LUT_SEQ_IDX_PAGEPROGRAM + 5] = FLEXSPI_LUT_SEQ(
-                        kFLEXSPI_Command_CADDR_DDR, kFLEXSPI_8PAD, 0x10, kFLEXSPI_Command_WRITE_DDR, kFLEXSPI_8PAD, 0x80),
+            /* 10 program page with word program command sequence */
+            [4 * HYPERFLASH_CMD_LUT_SEQ_IDX_PAGEPROGRAM] =
+                FLEXSPI_LUT_SEQ(kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0x20, kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0x00),
+            [4 * HYPERFLASH_CMD_LUT_SEQ_IDX_PAGEPROGRAM + 1] = FLEXSPI_LUT_SEQ(
+                kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0x00, kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0xAA),         // ADDR 0x555
+            [4 * HYPERFLASH_CMD_LUT_SEQ_IDX_PAGEPROGRAM + 2] =
+                FLEXSPI_LUT_SEQ(kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0x00, kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0x05),
+            [4 * HYPERFLASH_CMD_LUT_SEQ_IDX_PAGEPROGRAM + 3] = FLEXSPI_LUT_SEQ(
+                kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0x00, kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0xA0),         // DATA 0xA0
+            // +1
+            [4 * HYPERFLASH_CMD_LUT_SEQ_IDX_PAGEPROGRAM + 4] =
+                FLEXSPI_LUT_SEQ(kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0x20, kFLEXSPI_Command_RADDR_DDR, kFLEXSPI_8PAD, 0x18),
+            [4 * HYPERFLASH_CMD_LUT_SEQ_IDX_PAGEPROGRAM + 5] = FLEXSPI_LUT_SEQ(
+                kFLEXSPI_Command_CADDR_DDR, kFLEXSPI_8PAD, 0x10, kFLEXSPI_Command_WRITE_DDR, kFLEXSPI_8PAD, 0x80),
 
-                    /* 12 Erase chip */
-                    [4 * HYPERFLASH_CMD_LUT_SEQ_IDX_ERASECHIP] =
-                        FLEXSPI_LUT_SEQ(kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0x00, kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0x00),
-                    [4 * HYPERFLASH_CMD_LUT_SEQ_IDX_ERASECHIP + 1] =
-                        FLEXSPI_LUT_SEQ(kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0x00, kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0xAA),
-                    [4 * HYPERFLASH_CMD_LUT_SEQ_IDX_ERASECHIP + 2] =
-                        FLEXSPI_LUT_SEQ(kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0x00, kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0x05),
-                    [4 * HYPERFLASH_CMD_LUT_SEQ_IDX_ERASECHIP + 3] =
-                        FLEXSPI_LUT_SEQ(kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0x00, kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0x80),
-                    // +1
-                    [4 * HYPERFLASH_CMD_LUT_SEQ_IDX_ERASECHIP + 4] =
-                        FLEXSPI_LUT_SEQ(kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0x00, kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0x00),
-                    [4 * HYPERFLASH_CMD_LUT_SEQ_IDX_ERASECHIP + 5] =
-                        FLEXSPI_LUT_SEQ(kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0x00, kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0xAA),
-                    [4 * HYPERFLASH_CMD_LUT_SEQ_IDX_ERASECHIP + 6] =
-                        FLEXSPI_LUT_SEQ(kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0x00, kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0x05),
-                    [4 * HYPERFLASH_CMD_LUT_SEQ_IDX_ERASECHIP + 7] =
-                        FLEXSPI_LUT_SEQ(kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0x00, kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0xAA),
-                    // +2
-                    [4 * HYPERFLASH_CMD_LUT_SEQ_IDX_ERASECHIP + 8] =
-                        FLEXSPI_LUT_SEQ(kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0x00, kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0x00),
-                    [4 * HYPERFLASH_CMD_LUT_SEQ_IDX_ERASECHIP + 9] =
-                        FLEXSPI_LUT_SEQ(kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0x00, kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0x55),
-                    [4 * HYPERFLASH_CMD_LUT_SEQ_IDX_ERASECHIP + 10] =
-                        FLEXSPI_LUT_SEQ(kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0x00, kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0x02),
-                    [4 * HYPERFLASH_CMD_LUT_SEQ_IDX_ERASECHIP + 11] =
-                        FLEXSPI_LUT_SEQ(kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0x00, kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0x55),
-                    // +3
-                    [4 * HYPERFLASH_CMD_LUT_SEQ_IDX_ERASECHIP + 12] =
-                        FLEXSPI_LUT_SEQ(kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0x00, kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0x00),
-                    [4 * HYPERFLASH_CMD_LUT_SEQ_IDX_ERASECHIP + 13] =
-                        FLEXSPI_LUT_SEQ(kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0x00, kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0xAA),
-                    [4 * HYPERFLASH_CMD_LUT_SEQ_IDX_ERASECHIP + 14] =
-                        FLEXSPI_LUT_SEQ(kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0x00, kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0x05),
-                    [4 * HYPERFLASH_CMD_LUT_SEQ_IDX_ERASECHIP + 15] =
-                        FLEXSPI_LUT_SEQ(kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0x00, kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0x10),
-                },
+            /* 12 Erase chip */
+            [4 * HYPERFLASH_CMD_LUT_SEQ_IDX_ERASECHIP] =
+                FLEXSPI_LUT_SEQ(kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0x00, kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0x00),
+            [4 * HYPERFLASH_CMD_LUT_SEQ_IDX_ERASECHIP + 1] =
+                FLEXSPI_LUT_SEQ(kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0x00, kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0xAA),
+            [4 * HYPERFLASH_CMD_LUT_SEQ_IDX_ERASECHIP + 2] =
+                FLEXSPI_LUT_SEQ(kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0x00, kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0x05),
+            [4 * HYPERFLASH_CMD_LUT_SEQ_IDX_ERASECHIP + 3] =
+                FLEXSPI_LUT_SEQ(kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0x00, kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0x80),
+            // +1
+            [4 * HYPERFLASH_CMD_LUT_SEQ_IDX_ERASECHIP + 4] =
+                FLEXSPI_LUT_SEQ(kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0x00, kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0x00),
+            [4 * HYPERFLASH_CMD_LUT_SEQ_IDX_ERASECHIP + 5] =
+                FLEXSPI_LUT_SEQ(kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0x00, kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0xAA),
+            [4 * HYPERFLASH_CMD_LUT_SEQ_IDX_ERASECHIP + 6] =
+                FLEXSPI_LUT_SEQ(kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0x00, kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0x05),
+            [4 * HYPERFLASH_CMD_LUT_SEQ_IDX_ERASECHIP + 7] =
+                FLEXSPI_LUT_SEQ(kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0x00, kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0xAA),
+            // +2
+            [4 * HYPERFLASH_CMD_LUT_SEQ_IDX_ERASECHIP + 8] =
+                FLEXSPI_LUT_SEQ(kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0x00, kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0x00),
+            [4 * HYPERFLASH_CMD_LUT_SEQ_IDX_ERASECHIP + 9] =
+                FLEXSPI_LUT_SEQ(kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0x00, kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0x55),
+            [4 * HYPERFLASH_CMD_LUT_SEQ_IDX_ERASECHIP + 10] =
+                FLEXSPI_LUT_SEQ(kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0x00, kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0x02),
+            [4 * HYPERFLASH_CMD_LUT_SEQ_IDX_ERASECHIP + 11] =
+                FLEXSPI_LUT_SEQ(kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0x00, kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0x55),
+            // +3
+            [4 * HYPERFLASH_CMD_LUT_SEQ_IDX_ERASECHIP + 12] =
+                FLEXSPI_LUT_SEQ(kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0x00, kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0x00),
+            [4 * HYPERFLASH_CMD_LUT_SEQ_IDX_ERASECHIP + 13] =
+                FLEXSPI_LUT_SEQ(kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0x00, kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0xAA),
+            [4 * HYPERFLASH_CMD_LUT_SEQ_IDX_ERASECHIP + 14] =
+                FLEXSPI_LUT_SEQ(kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0x00, kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0x05),
+            [4 * HYPERFLASH_CMD_LUT_SEQ_IDX_ERASECHIP + 15] =
+                FLEXSPI_LUT_SEQ(kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0x00, kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0x10),
         },
-    .pageSize           = 512u,
-    .sectorSize         = 256u * 1024u,
-    .blockSize          = 256u * 1024u,
+    },
+    .pageSize = 512u,
+    .sectorSize = 256u * 1024u,
+    .blockSize = 256u * 1024u,
     .isUniformBlockSize = true,
 };
 

--- a/ports/mimxrt/boards/MIMXRT1064_EVK/mpconfigboard.h
+++ b/ports/mimxrt/boards/MIMXRT1064_EVK/mpconfigboard.h
@@ -36,10 +36,10 @@
     { IOMUXC_GPIO_SD_B0_02_LPSPI1_SDO }, { IOMUXC_GPIO_SD_B0_03_LPSPI1_SDI },
 
 #define DMA_REQ_SRC_RX { 0, kDmaRequestMuxLPSPI1Rx, kDmaRequestMuxLPSPI2Rx, \
-                            kDmaRequestMuxLPSPI3Rx, kDmaRequestMuxLPSPI4Rx }
+                         kDmaRequestMuxLPSPI3Rx, kDmaRequestMuxLPSPI4Rx }
 
 #define DMA_REQ_SRC_TX { 0, kDmaRequestMuxLPSPI1Tx, kDmaRequestMuxLPSPI2Tx, \
-                            kDmaRequestMuxLPSPI3Tx, kDmaRequestMuxLPSPI4Tx } 
+                         kDmaRequestMuxLPSPI3Tx, kDmaRequestMuxLPSPI4Tx }
 
 // Define the mapping hardware I2C # to logical I2C #
 // SDA/SCL  HW-I2C    Logical I2C
@@ -58,9 +58,9 @@
     { \
         .cmd = {GPIO_SD_B0_00_USDHC1_CMD}, \
         .clk = { GPIO_SD_B0_01_USDHC1_CLK }, \
-        .cd_b = { GPIO_B1_12_USDHC1_CD_B },\
-        .data0 = { GPIO_SD_B0_02_USDHC1_DATA0 },\
-        .data1 = { GPIO_SD_B0_03_USDHC1_DATA1 },\
-        .data2 = { GPIO_SD_B0_04_USDHC1_DATA2 },\
-        .data3 = { GPIO_SD_B0_05_USDHC1_DATA3 },\
+        .cd_b = { GPIO_B1_12_USDHC1_CD_B }, \
+        .data0 = { GPIO_SD_B0_02_USDHC1_DATA0 }, \
+        .data1 = { GPIO_SD_B0_03_USDHC1_DATA1 }, \
+        .data2 = { GPIO_SD_B0_04_USDHC1_DATA2 }, \
+        .data3 = { GPIO_SD_B0_05_USDHC1_DATA3 }, \
     }

--- a/ports/mimxrt/boards/TEENSY40/flash_config.c
+++ b/ports/mimxrt/boards/TEENSY40/flash_config.c
@@ -26,119 +26,119 @@ __attribute__((section(".boot_hdr.conf")))
 
 const flexspi_nor_config_t qspiflash_config = {
     .memConfig =
-        {
-            .tag              = FLEXSPI_CFG_BLK_TAG,
-            .version          = FLEXSPI_CFG_BLK_VERSION,
-            .readSampleClkSrc = kFlexSPIReadSampleClk_LoopbackFromDqsPad,
-            .csHoldTime       = 3u,
-            .csSetupTime      = 3u,
+    {
+        .tag = FLEXSPI_CFG_BLK_TAG,
+        .version = FLEXSPI_CFG_BLK_VERSION,
+        .readSampleClkSrc = kFlexSPIReadSampleClk_LoopbackFromDqsPad,
+        .csHoldTime = 3u,
+        .csSetupTime = 3u,
 
-            .busyOffset = FLASH_BUSY_STATUS_OFFSET,     // Status bit 0 indicates busy.
-            .busyBitPolarity = FLASH_BUSY_STATUS_POL,   // Busy when the bit is 1.
+        .busyOffset = FLASH_BUSY_STATUS_OFFSET,         // Status bit 0 indicates busy.
+        .busyBitPolarity = FLASH_BUSY_STATUS_POL,       // Busy when the bit is 1.
 
-            .deviceModeCfgEnable = 1u,
-            .deviceModeType = kDeviceConfigCmdType_QuadEnable,
-            .deviceModeSeq = {
-                .seqId = 4u,
-                .seqNum = 1u,
-            },
-            .deviceModeArg = 0x0200,
-            .configCmdEnable = 1u,
-            .configModeType[0] = kDeviceConfigCmdType_Generic,
-            .configCmdSeqs[0] = {
-                .seqId = 2u,
-                .seqNum = 1u,
-            },
-            .deviceType = kFlexSpiDeviceType_SerialNOR,
-            // Enable DDR mode, Wordaddassable, Safe configuration, Differential clock
-            .sflashPadType = kSerialFlash_4Pads,
-            .serialClkFreq = kFlexSpiSerialClk_60MHz,
-            .sflashA1Size  = 2u * 1024u * 1024u,
-            .lookupTable =
-                {
-                    // 0 Read LUTs 0 -> 0
-                    FLEXSPI_LUT_SEQ(CMD_SDR, FLEXSPI_1PAD, 0xEB, RADDR_SDR, FLEXSPI_4PAD, 0x18),
-                    FLEXSPI_LUT_SEQ(DUMMY_SDR, FLEXSPI_4PAD, 0x06, READ_SDR, FLEXSPI_4PAD, 0x04),
-                    FLEXSPI_LUT_SEQ(0, 0, 0, 0, 0, 0), // Filler
-                    FLEXSPI_LUT_SEQ(0, 0, 0, 0, 0, 0), // Filler
-
-                    // 1 Read status register -> 1
-                    FLEXSPI_LUT_SEQ(CMD_SDR, FLEXSPI_1PAD, 0x05, READ_SDR, FLEXSPI_1PAD, 0x01),
-                    FLEXSPI_LUT_SEQ(0, 0, 0, 0, 0, 0), // Filler
-                    FLEXSPI_LUT_SEQ(0, 0, 0, 0, 0, 0), // Filler
-                    FLEXSPI_LUT_SEQ(0, 0, 0, 0, 0, 0), // Filler
-
-                    // 2 Fast read quad mode - SDR
-                    FLEXSPI_LUT_SEQ(CMD_SDR, FLEXSPI_1PAD, 0x6B, RADDR_SDR, FLEXSPI_1PAD, 0x18),
-                    FLEXSPI_LUT_SEQ(DUMMY_SDR, FLEXSPI_4PAD, 0x08, READ_SDR, FLEXSPI_4PAD, 0x04),
-                    FLEXSPI_LUT_SEQ(0, 0, 0, 0, 0, 0), // Filler
-                    FLEXSPI_LUT_SEQ(0, 0, 0, 0, 0, 0), // Filler
-
-                    // 3 Write Enable -> 3
-                    FLEXSPI_LUT_SEQ(CMD_SDR, FLEXSPI_1PAD, 0x06, STOP, FLEXSPI_1PAD, 0),
-                    FLEXSPI_LUT_SEQ(0, 0, 0, 0, 0, 0), // Filler
-                    FLEXSPI_LUT_SEQ(0, 0, 0, 0, 0, 0), // Filler
-                    FLEXSPI_LUT_SEQ(0, 0, 0, 0, 0, 0), // Filler
-
-                    // 4 Read extend parameters
-                    FLEXSPI_LUT_SEQ(CMD_SDR, FLEXSPI_1PAD, 0x81, READ_SDR, FLEXSPI_1PAD, 0x04),
-                    FLEXSPI_LUT_SEQ(0, 0, 0, 0, 0, 0), // Filler
-                    FLEXSPI_LUT_SEQ(0, 0, 0, 0, 0, 0), // Filler
-                    FLEXSPI_LUT_SEQ(0, 0, 0, 0, 0, 0), // Filler
-
-                    // 5 Erase Sector -> 5
-                    FLEXSPI_LUT_SEQ(CMD_SDR, FLEXSPI_1PAD, 0x20, RADDR_SDR, FLEXSPI_1PAD, 24),
-                    FLEXSPI_LUT_SEQ(0, 0, 0, 0, 0, 0), // Filler
-                    FLEXSPI_LUT_SEQ(0, 0, 0, 0, 0, 0), // Filler
-                    FLEXSPI_LUT_SEQ(0, 0, 0, 0, 0, 0), // Filler
-
-                    // 6 Write Status Reg
-                    FLEXSPI_LUT_SEQ(CMD_SDR, FLEXSPI_1PAD, 0x01, WRITE_SDR, FLEXSPI_1PAD, 0x04),
-                    FLEXSPI_LUT_SEQ(0, 0, 0, 0, 0, 0), // Filler
-                    FLEXSPI_LUT_SEQ(0, 0, 0, 0, 0, 0), // Filler
-                    FLEXSPI_LUT_SEQ(0, 0, 0, 0, 0, 0), // Filler
-
-                    // 7 Page Program - quad mode (-> 9)
-                    FLEXSPI_LUT_SEQ(CMD_SDR, FLEXSPI_1PAD, 0x32, RADDR_SDR, FLEXSPI_1PAD, 0x18),
-                    FLEXSPI_LUT_SEQ(WRITE_SDR, FLEXSPI_4PAD, 0x04, STOP, FLEXSPI_1PAD, 0),
-                    FLEXSPI_LUT_SEQ(0, 0, 0, 0, 0, 0), // Filler
-                    FLEXSPI_LUT_SEQ(0, 0, 0, 0, 0, 0), // Filler
-
-                    // 8 Read ID
-                    FLEXSPI_LUT_SEQ(CMD_SDR, FLEXSPI_1PAD, 0x90, DUMMY_SDR, FLEXSPI_1PAD, 24),
-                    FLEXSPI_LUT_SEQ(READ_SDR, FLEXSPI_1PAD, 0x00, 0, 0, 0),
-                    FLEXSPI_LUT_SEQ(0, 0, 0, 0, 0, 0), // Filler
-                    FLEXSPI_LUT_SEQ(0, 0, 0, 0, 0, 0), // Filler
-
-                    // 9 Page Program - single mode -> 9
-                    FLEXSPI_LUT_SEQ(CMD_SDR, FLEXSPI_1PAD, 0x02, RADDR_SDR, FLEXSPI_1PAD, 24),
-                    FLEXSPI_LUT_SEQ(WRITE_SDR, FLEXSPI_1PAD, 0, 0, 0, 0),
-                    FLEXSPI_LUT_SEQ(0, 0, 0, 0, 0, 0), // Filler
-                    FLEXSPI_LUT_SEQ(0, 0, 0, 0, 0, 0), // Filler
-
-                    // 10 Enter QPI mode
-                    FLEXSPI_LUT_SEQ(CMD_SDR, FLEXSPI_1PAD, 0x35, STOP, FLEXSPI_1PAD, 0),
-                    FLEXSPI_LUT_SEQ(0, 0, 0, 0, 0, 0), // Filler
-                    FLEXSPI_LUT_SEQ(0, 0, 0, 0, 0, 0), // Filler
-                    FLEXSPI_LUT_SEQ(0, 0, 0, 0, 0, 0), // Filler
-
-                    // 11 Erase Chip
-                    FLEXSPI_LUT_SEQ(CMD_SDR, FLEXSPI_1PAD, 0x60, STOP, FLEXSPI_1PAD, 0),
-                    FLEXSPI_LUT_SEQ(0, 0, 0, 0, 0, 0), // Filler
-                    FLEXSPI_LUT_SEQ(0, 0, 0, 0, 0, 0), // Filler
-                    FLEXSPI_LUT_SEQ(0, 0, 0, 0, 0, 0), // Filler
-
-                    // 12 Exit QPI mode
-                    FLEXSPI_LUT_SEQ(CMD_SDR, FLEXSPI_4PAD, 0xF5, STOP, FLEXSPI_1PAD, 0),
-                    FLEXSPI_LUT_SEQ(0, 0, 0, 0, 0, 0), // Filler
-                    FLEXSPI_LUT_SEQ(0, 0, 0, 0, 0, 0), // Filler
-                    FLEXSPI_LUT_SEQ(0, 0, 0, 0, 0, 0), // Filler
-                },
+        .deviceModeCfgEnable = 1u,
+        .deviceModeType = kDeviceConfigCmdType_QuadEnable,
+        .deviceModeSeq = {
+            .seqId = 4u,
+            .seqNum = 1u,
         },
-    .pageSize           = 256u,
-    .sectorSize         = 4u * 1024u,
+        .deviceModeArg = 0x0200,
+        .configCmdEnable = 1u,
+        .configModeType[0] = kDeviceConfigCmdType_Generic,
+        .configCmdSeqs[0] = {
+            .seqId = 2u,
+            .seqNum = 1u,
+        },
+        .deviceType = kFlexSpiDeviceType_SerialNOR,
+        // Enable DDR mode, Wordaddassable, Safe configuration, Differential clock
+        .sflashPadType = kSerialFlash_4Pads,
+        .serialClkFreq = kFlexSpiSerialClk_60MHz,
+        .sflashA1Size = 2u * 1024u * 1024u,
+        .lookupTable =
+        {
+            // 0 Read LUTs 0 -> 0
+            FLEXSPI_LUT_SEQ(CMD_SDR, FLEXSPI_1PAD, 0xEB, RADDR_SDR, FLEXSPI_4PAD, 0x18),
+            FLEXSPI_LUT_SEQ(DUMMY_SDR, FLEXSPI_4PAD, 0x06, READ_SDR, FLEXSPI_4PAD, 0x04),
+            FLEXSPI_LUT_SEQ(0, 0, 0, 0, 0, 0),         // Filler
+            FLEXSPI_LUT_SEQ(0, 0, 0, 0, 0, 0),         // Filler
+
+            // 1 Read status register -> 1
+            FLEXSPI_LUT_SEQ(CMD_SDR, FLEXSPI_1PAD, 0x05, READ_SDR, FLEXSPI_1PAD, 0x01),
+            FLEXSPI_LUT_SEQ(0, 0, 0, 0, 0, 0),         // Filler
+            FLEXSPI_LUT_SEQ(0, 0, 0, 0, 0, 0),         // Filler
+            FLEXSPI_LUT_SEQ(0, 0, 0, 0, 0, 0),         // Filler
+
+            // 2 Fast read quad mode - SDR
+            FLEXSPI_LUT_SEQ(CMD_SDR, FLEXSPI_1PAD, 0x6B, RADDR_SDR, FLEXSPI_1PAD, 0x18),
+            FLEXSPI_LUT_SEQ(DUMMY_SDR, FLEXSPI_4PAD, 0x08, READ_SDR, FLEXSPI_4PAD, 0x04),
+            FLEXSPI_LUT_SEQ(0, 0, 0, 0, 0, 0),         // Filler
+            FLEXSPI_LUT_SEQ(0, 0, 0, 0, 0, 0),         // Filler
+
+            // 3 Write Enable -> 3
+            FLEXSPI_LUT_SEQ(CMD_SDR, FLEXSPI_1PAD, 0x06, STOP, FLEXSPI_1PAD, 0),
+            FLEXSPI_LUT_SEQ(0, 0, 0, 0, 0, 0),         // Filler
+            FLEXSPI_LUT_SEQ(0, 0, 0, 0, 0, 0),         // Filler
+            FLEXSPI_LUT_SEQ(0, 0, 0, 0, 0, 0),         // Filler
+
+            // 4 Read extend parameters
+            FLEXSPI_LUT_SEQ(CMD_SDR, FLEXSPI_1PAD, 0x81, READ_SDR, FLEXSPI_1PAD, 0x04),
+            FLEXSPI_LUT_SEQ(0, 0, 0, 0, 0, 0),         // Filler
+            FLEXSPI_LUT_SEQ(0, 0, 0, 0, 0, 0),         // Filler
+            FLEXSPI_LUT_SEQ(0, 0, 0, 0, 0, 0),         // Filler
+
+            // 5 Erase Sector -> 5
+            FLEXSPI_LUT_SEQ(CMD_SDR, FLEXSPI_1PAD, 0x20, RADDR_SDR, FLEXSPI_1PAD, 24),
+            FLEXSPI_LUT_SEQ(0, 0, 0, 0, 0, 0),         // Filler
+            FLEXSPI_LUT_SEQ(0, 0, 0, 0, 0, 0),         // Filler
+            FLEXSPI_LUT_SEQ(0, 0, 0, 0, 0, 0),         // Filler
+
+            // 6 Write Status Reg
+            FLEXSPI_LUT_SEQ(CMD_SDR, FLEXSPI_1PAD, 0x01, WRITE_SDR, FLEXSPI_1PAD, 0x04),
+            FLEXSPI_LUT_SEQ(0, 0, 0, 0, 0, 0),         // Filler
+            FLEXSPI_LUT_SEQ(0, 0, 0, 0, 0, 0),         // Filler
+            FLEXSPI_LUT_SEQ(0, 0, 0, 0, 0, 0),         // Filler
+
+            // 7 Page Program - quad mode (-> 9)
+            FLEXSPI_LUT_SEQ(CMD_SDR, FLEXSPI_1PAD, 0x32, RADDR_SDR, FLEXSPI_1PAD, 0x18),
+            FLEXSPI_LUT_SEQ(WRITE_SDR, FLEXSPI_4PAD, 0x04, STOP, FLEXSPI_1PAD, 0),
+            FLEXSPI_LUT_SEQ(0, 0, 0, 0, 0, 0),         // Filler
+            FLEXSPI_LUT_SEQ(0, 0, 0, 0, 0, 0),         // Filler
+
+            // 8 Read ID
+            FLEXSPI_LUT_SEQ(CMD_SDR, FLEXSPI_1PAD, 0x90, DUMMY_SDR, FLEXSPI_1PAD, 24),
+            FLEXSPI_LUT_SEQ(READ_SDR, FLEXSPI_1PAD, 0x00, 0, 0, 0),
+            FLEXSPI_LUT_SEQ(0, 0, 0, 0, 0, 0),         // Filler
+            FLEXSPI_LUT_SEQ(0, 0, 0, 0, 0, 0),         // Filler
+
+            // 9 Page Program - single mode -> 9
+            FLEXSPI_LUT_SEQ(CMD_SDR, FLEXSPI_1PAD, 0x02, RADDR_SDR, FLEXSPI_1PAD, 24),
+            FLEXSPI_LUT_SEQ(WRITE_SDR, FLEXSPI_1PAD, 0, 0, 0, 0),
+            FLEXSPI_LUT_SEQ(0, 0, 0, 0, 0, 0),         // Filler
+            FLEXSPI_LUT_SEQ(0, 0, 0, 0, 0, 0),         // Filler
+
+            // 10 Enter QPI mode
+            FLEXSPI_LUT_SEQ(CMD_SDR, FLEXSPI_1PAD, 0x35, STOP, FLEXSPI_1PAD, 0),
+            FLEXSPI_LUT_SEQ(0, 0, 0, 0, 0, 0),         // Filler
+            FLEXSPI_LUT_SEQ(0, 0, 0, 0, 0, 0),         // Filler
+            FLEXSPI_LUT_SEQ(0, 0, 0, 0, 0, 0),         // Filler
+
+            // 11 Erase Chip
+            FLEXSPI_LUT_SEQ(CMD_SDR, FLEXSPI_1PAD, 0x60, STOP, FLEXSPI_1PAD, 0),
+            FLEXSPI_LUT_SEQ(0, 0, 0, 0, 0, 0),         // Filler
+            FLEXSPI_LUT_SEQ(0, 0, 0, 0, 0, 0),         // Filler
+            FLEXSPI_LUT_SEQ(0, 0, 0, 0, 0, 0),         // Filler
+
+            // 12 Exit QPI mode
+            FLEXSPI_LUT_SEQ(CMD_SDR, FLEXSPI_4PAD, 0xF5, STOP, FLEXSPI_1PAD, 0),
+            FLEXSPI_LUT_SEQ(0, 0, 0, 0, 0, 0),         // Filler
+            FLEXSPI_LUT_SEQ(0, 0, 0, 0, 0, 0),         // Filler
+            FLEXSPI_LUT_SEQ(0, 0, 0, 0, 0, 0),         // Filler
+        },
+    },
+    .pageSize = 256u,
+    .sectorSize = 4u * 1024u,
     .ipcmdSerialClkFreq = kFlexSpiSerialClk_30MHz,
-    .blockSize          = 0x00010000,
+    .blockSize = 0x00010000,
     .isUniformBlockSize = false,
 };
 #endif /* XIP_BOOT_HEADER_ENABLE */

--- a/ports/mimxrt/boards/TEENSY40/mpconfigboard.h
+++ b/ports/mimxrt/boards/TEENSY40/mpconfigboard.h
@@ -39,10 +39,10 @@
     { IOMUXC_GPIO_B0_02_LPSPI4_SDO }, { IOMUXC_GPIO_B0_01_LPSPI4_SDI },
 
 #define DMA_REQ_SRC_RX { 0, kDmaRequestMuxLPSPI1Rx, kDmaRequestMuxLPSPI2Rx, \
-                            kDmaRequestMuxLPSPI3Rx, kDmaRequestMuxLPSPI4Rx }
+                         kDmaRequestMuxLPSPI3Rx, kDmaRequestMuxLPSPI4Rx }
 
 #define DMA_REQ_SRC_TX { 0, kDmaRequestMuxLPSPI1Tx, kDmaRequestMuxLPSPI2Tx, \
-                            kDmaRequestMuxLPSPI3Tx, kDmaRequestMuxLPSPI4Tx } 
+                         kDmaRequestMuxLPSPI3Tx, kDmaRequestMuxLPSPI4Tx }
 
 // Define mapping hardware I2C # to logical I2C #
 // SDA/SCL  HW-I2C    Logical I2C
@@ -63,9 +63,9 @@
     { \
         .cmd = {GPIO_SD_B0_00_USDHC1_CMD}, \
         .clk = { GPIO_SD_B0_01_USDHC1_CLK }, \
-        .cd_b = { USDHC_DUMMY_PIN },\
-        .data0 = { GPIO_SD_B0_02_USDHC1_DATA0 },\
-        .data1 = { GPIO_SD_B0_03_USDHC1_DATA1 },\
-        .data2 = { GPIO_SD_B0_04_USDHC1_DATA2 },\
-        .data3 = { GPIO_SD_B0_05_USDHC1_DATA3 },\
+        .cd_b = { USDHC_DUMMY_PIN }, \
+        .data0 = { GPIO_SD_B0_02_USDHC1_DATA0 }, \
+        .data1 = { GPIO_SD_B0_03_USDHC1_DATA1 }, \
+        .data2 = { GPIO_SD_B0_04_USDHC1_DATA2 }, \
+        .data3 = { GPIO_SD_B0_05_USDHC1_DATA3 }, \
     }

--- a/ports/mimxrt/boards/TEENSY40/teensy40_flexspi_nor_config.h
+++ b/ports/mimxrt/boards/TEENSY40/teensy40_flexspi_nor_config.h
@@ -76,9 +76,9 @@
 
 #define FLEXSPI_LUT_SEQ(cmd0, pad0, op0, cmd1, pad1, op1)                                                              \
     (FLEXSPI_LUT_OPERAND0(op0) | FLEXSPI_LUT_NUM_PADS0(pad0) | FLEXSPI_LUT_OPCODE0(cmd0) | FLEXSPI_LUT_OPERAND1(op1) | \
-     FLEXSPI_LUT_NUM_PADS1(pad1) | FLEXSPI_LUT_OPCODE1(cmd1))
+    FLEXSPI_LUT_NUM_PADS1(pad1) | FLEXSPI_LUT_OPCODE1(cmd1))
 
-//!@brief Definitions for FlexSPI Serial Clock Frequency
+// !@brief Definitions for FlexSPI Serial Clock Frequency
 typedef enum _FlexSpiSerialClockFreq
 {
     kFlexSpiSerialClk_30MHz  = 1,
@@ -92,14 +92,14 @@ typedef enum _FlexSpiSerialClockFreq
     kFlexSpiSerialClk_166MHz = 9,
 } flexspi_serial_clk_freq_t;
 
-//!@brief FlexSPI clock configuration type
+// !@brief FlexSPI clock configuration type
 enum
 {
-    kFlexSpiClk_SDR, //!< Clock configure for SDR mode
-    kFlexSpiClk_DDR, //!< Clock configurat for DDR mode
+    kFlexSpiClk_SDR, // !< Clock configure for SDR mode
+    kFlexSpiClk_DDR, // !< Clock configurat for DDR mode
 };
 
-//!@brief FlexSPI Read Sample Clock Source definition
+// !@brief FlexSPI Read Sample Clock Source definition
 typedef enum _FlashReadSampleClkSource
 {
     kFlexSPIReadSampleClk_LoopbackInternally      = 0,
@@ -108,29 +108,29 @@ typedef enum _FlashReadSampleClkSource
     kFlexSPIReadSampleClk_ExternalInputFromDqsPad = 3,
 } flexspi_read_sample_clk_t;
 
-//!@brief Misc feature bit definitions
+// !@brief Misc feature bit definitions
 enum
 {
-    kFlexSpiMiscOffset_DiffClkEnable            = 0, //!< Bit for Differential clock enable
-    kFlexSpiMiscOffset_Ck2Enable                = 1, //!< Bit for CK2 enable
-    kFlexSpiMiscOffset_ParallelEnable           = 2, //!< Bit for Parallel mode enable
-    kFlexSpiMiscOffset_WordAddressableEnable    = 3, //!< Bit for Word Addressable enable
-    kFlexSpiMiscOffset_SafeConfigFreqEnable     = 4, //!< Bit for Safe Configuration Frequency enable
-    kFlexSpiMiscOffset_PadSettingOverrideEnable = 5, //!< Bit for Pad setting override enable
-    kFlexSpiMiscOffset_DdrModeEnable            = 6, //!< Bit for DDR clock confiuration indication.
+    kFlexSpiMiscOffset_DiffClkEnable            = 0, // !< Bit for Differential clock enable
+    kFlexSpiMiscOffset_Ck2Enable                = 1, // !< Bit for CK2 enable
+    kFlexSpiMiscOffset_ParallelEnable           = 2, // !< Bit for Parallel mode enable
+    kFlexSpiMiscOffset_WordAddressableEnable    = 3, // !< Bit for Word Addressable enable
+    kFlexSpiMiscOffset_SafeConfigFreqEnable     = 4, // !< Bit for Safe Configuration Frequency enable
+    kFlexSpiMiscOffset_PadSettingOverrideEnable = 5, // !< Bit for Pad setting override enable
+    kFlexSpiMiscOffset_DdrModeEnable            = 6, // !< Bit for DDR clock confiuration indication.
 };
 
-//!@brief Flash Type Definition
+// !@brief Flash Type Definition
 enum
 {
-    kFlexSpiDeviceType_SerialNOR    = 1,    //!< Flash devices are Serial NOR
-    kFlexSpiDeviceType_SerialNAND   = 2,    //!< Flash devices are Serial NAND
-    kFlexSpiDeviceType_SerialRAM    = 3,    //!< Flash devices are Serial RAM/HyperFLASH
-    kFlexSpiDeviceType_MCP_NOR_NAND = 0x12, //!< Flash device is MCP device, A1 is Serial NOR, A2 is Serial NAND
-    kFlexSpiDeviceType_MCP_NOR_RAM  = 0x13, //!< Flash deivce is MCP device, A1 is Serial NOR, A2 is Serial RAMs
+    kFlexSpiDeviceType_SerialNOR    = 1,    // !< Flash devices are Serial NOR
+    kFlexSpiDeviceType_SerialNAND   = 2,    // !< Flash devices are Serial NAND
+    kFlexSpiDeviceType_SerialRAM    = 3,    // !< Flash devices are Serial RAM/HyperFLASH
+    kFlexSpiDeviceType_MCP_NOR_NAND = 0x12, // !< Flash device is MCP device, A1 is Serial NOR, A2 is Serial NAND
+    kFlexSpiDeviceType_MCP_NOR_RAM  = 0x13, // !< Flash deivce is MCP device, A1 is Serial NOR, A2 is Serial RAMs
 };
 
-//!@brief Flash Pad Definitions
+// !@brief Flash Pad Definitions
 enum
 {
     kSerialFlash_1Pad  = 1,
@@ -139,77 +139,77 @@ enum
     kSerialFlash_8Pads = 8,
 };
 
-//!@brief FlexSPI LUT Sequence structure
+// !@brief FlexSPI LUT Sequence structure
 typedef struct _lut_sequence
 {
-    uint8_t seqNum; //!< Sequence Number, valid number: 1-16
-    uint8_t seqId;  //!< Sequence Index, valid number: 0-15
+    uint8_t seqNum; // !< Sequence Number, valid number: 1-16
+    uint8_t seqId;  // !< Sequence Index, valid number: 0-15
     uint16_t reserved;
 } flexspi_lut_seq_t;
 
-//!@brief Flash Configuration Command Type
+// !@brief Flash Configuration Command Type
 enum
 {
-    kDeviceConfigCmdType_Generic,    //!< Generic command, for example: configure dummy cycles, drive strength, etc
-    kDeviceConfigCmdType_QuadEnable, //!< Quad Enable command
-    kDeviceConfigCmdType_Spi2Xpi,    //!< Switch from SPI to DPI/QPI/OPI mode
-    kDeviceConfigCmdType_Xpi2Spi,    //!< Switch from DPI/QPI/OPI to SPI mode
-    kDeviceConfigCmdType_Spi2NoCmd,  //!< Switch to 0-4-4/0-8-8 mode
-    kDeviceConfigCmdType_Reset,      //!< Reset device command
+    kDeviceConfigCmdType_Generic,    // !< Generic command, for example: configure dummy cycles, drive strength, etc
+    kDeviceConfigCmdType_QuadEnable, // !< Quad Enable command
+    kDeviceConfigCmdType_Spi2Xpi,    // !< Switch from SPI to DPI/QPI/OPI mode
+    kDeviceConfigCmdType_Xpi2Spi,    // !< Switch from DPI/QPI/OPI to SPI mode
+    kDeviceConfigCmdType_Spi2NoCmd,  // !< Switch to 0-4-4/0-8-8 mode
+    kDeviceConfigCmdType_Reset,      // !< Reset device command
 };
 
-//!@brief FlexSPI Memory Configuration Block
+// !@brief FlexSPI Memory Configuration Block
 typedef struct _FlexSPIConfig
 {
-    uint32_t tag;               //!< [0x000-0x003] Tag, fixed value 0x42464346UL
-    uint32_t version;           //!< [0x004-0x007] Version,[31:24] -'V', [23:16] - Major, [15:8] - Minor, [7:0] - bugfix
-    uint32_t reserved0;         //!< [0x008-0x00b] Reserved for future use
-    uint8_t readSampleClkSrc;   //!< [0x00c-0x00c] Read Sample Clock Source, valid value: 0/1/3
-    uint8_t csHoldTime;         //!< [0x00d-0x00d] CS hold time, default value: 3
-    uint8_t csSetupTime;        //!< [0x00e-0x00e] CS setup time, default value: 3
-    uint8_t columnAddressWidth; //!< [0x00f-0x00f] Column Address with, for HyperBus protocol, it is fixed to 3, For
-    //! Serial NAND, need to refer to datasheet
-    uint8_t deviceModeCfgEnable; //!< [0x010-0x010] Device Mode Configure enable flag, 1 - Enable, 0 - Disable
-    uint8_t deviceModeType; //!< [0x011-0x011] Specify the configuration command type:Quad Enable, DPI/QPI/OPI switch,
-    //! Generic configuration, etc.
-    uint16_t waitTimeCfgCommands; //!< [0x012-0x013] Wait time for all configuration commands, unit: 100us, Used for
-    //! DPI/QPI/OPI switch or reset command
-    flexspi_lut_seq_t deviceModeSeq; //!< [0x014-0x017] Device mode sequence info, [7:0] - LUT sequence id, [15:8] - LUt
-    //! sequence number, [31:16] Reserved
-    uint32_t deviceModeArg;    //!< [0x018-0x01b] Argument/Parameter for device configuration
-    uint8_t configCmdEnable;   //!< [0x01c-0x01c] Configure command Enable Flag, 1 - Enable, 0 - Disable
-    uint8_t configModeType[3]; //!< [0x01d-0x01f] Configure Mode Type, similar as deviceModeTpe
+    uint32_t tag;               // !< [0x000-0x003] Tag, fixed value 0x42464346UL
+    uint32_t version;           // !< [0x004-0x007] Version,[31:24] -'V', [23:16] - Major, [15:8] - Minor, [7:0] - bugfix
+    uint32_t reserved0;         // !< [0x008-0x00b] Reserved for future use
+    uint8_t readSampleClkSrc;   // !< [0x00c-0x00c] Read Sample Clock Source, valid value: 0/1/3
+    uint8_t csHoldTime;         // !< [0x00d-0x00d] CS hold time, default value: 3
+    uint8_t csSetupTime;        // !< [0x00e-0x00e] CS setup time, default value: 3
+    uint8_t columnAddressWidth; // !< [0x00f-0x00f] Column Address with, for HyperBus protocol, it is fixed to 3, For
+    // ! Serial NAND, need to refer to datasheet
+    uint8_t deviceModeCfgEnable; // !< [0x010-0x010] Device Mode Configure enable flag, 1 - Enable, 0 - Disable
+    uint8_t deviceModeType; // !< [0x011-0x011] Specify the configuration command type:Quad Enable, DPI/QPI/OPI switch,
+    // ! Generic configuration, etc.
+    uint16_t waitTimeCfgCommands; // !< [0x012-0x013] Wait time for all configuration commands, unit: 100us, Used for
+    // ! DPI/QPI/OPI switch or reset command
+    flexspi_lut_seq_t deviceModeSeq; // !< [0x014-0x017] Device mode sequence info, [7:0] - LUT sequence id, [15:8] - LUt
+    // ! sequence number, [31:16] Reserved
+    uint32_t deviceModeArg;    // !< [0x018-0x01b] Argument/Parameter for device configuration
+    uint8_t configCmdEnable;   // !< [0x01c-0x01c] Configure command Enable Flag, 1 - Enable, 0 - Disable
+    uint8_t configModeType[3]; // !< [0x01d-0x01f] Configure Mode Type, similar as deviceModeTpe
     flexspi_lut_seq_t
-        configCmdSeqs[3]; //!< [0x020-0x02b] Sequence info for Device Configuration command, similar as deviceModeSeq
-    uint32_t reserved1;   //!< [0x02c-0x02f] Reserved for future use
-    uint32_t configCmdArgs[3];     //!< [0x030-0x03b] Arguments/Parameters for device Configuration commands
-    uint32_t reserved2;            //!< [0x03c-0x03f] Reserved for future use
-    uint32_t controllerMiscOption; //!< [0x040-0x043] Controller Misc Options, see Misc feature bit definitions for more
-    //! details
-    uint8_t deviceType;    //!< [0x044-0x044] Device Type:  See Flash Type Definition for more details
-    uint8_t sflashPadType; //!< [0x045-0x045] Serial Flash Pad Type: 1 - Single, 2 - Dual, 4 - Quad, 8 - Octal
-    uint8_t serialClkFreq; //!< [0x046-0x046] Serial Flash Frequencey, device specific definitions, See System Boot
-    //! Chapter for more details
-    uint8_t lutCustomSeqEnable; //!< [0x047-0x047] LUT customization Enable, it is required if the program/erase cannot
-    //! be done using 1 LUT sequence, currently, only applicable to HyperFLASH
-    uint32_t reserved3[2];           //!< [0x048-0x04f] Reserved for future use
-    uint32_t sflashA1Size;           //!< [0x050-0x053] Size of Flash connected to A1
-    uint32_t sflashA2Size;           //!< [0x054-0x057] Size of Flash connected to A2
-    uint32_t sflashB1Size;           //!< [0x058-0x05b] Size of Flash connected to B1
-    uint32_t sflashB2Size;           //!< [0x05c-0x05f] Size of Flash connected to B2
-    uint32_t csPadSettingOverride;   //!< [0x060-0x063] CS pad setting override value
-    uint32_t sclkPadSettingOverride; //!< [0x064-0x067] SCK pad setting override value
-    uint32_t dataPadSettingOverride; //!< [0x068-0x06b] data pad setting override value
-    uint32_t dqsPadSettingOverride;  //!< [0x06c-0x06f] DQS pad setting override value
-    uint32_t timeoutInMs;            //!< [0x070-0x073] Timeout threshold for read status command
-    uint32_t commandInterval;        //!< [0x074-0x077] CS deselect interval between two commands
-    uint16_t dataValidTime[2]; //!< [0x078-0x07b] CLK edge to data valid time for PORT A and PORT B, in terms of 0.1ns
-    uint16_t busyOffset;       //!< [0x07c-0x07d] Busy offset, valid value: 0-31
-    uint16_t busyBitPolarity;  //!< [0x07e-0x07f] Busy flag polarity, 0 - busy flag is 1 when flash device is busy, 1 -
-    //! busy flag is 0 when flash device is busy
-    uint32_t lookupTable[64];           //!< [0x080-0x17f] Lookup table holds Flash command sequences
-    flexspi_lut_seq_t lutCustomSeq[12]; //!< [0x180-0x1af] Customizable LUT Sequences
-    uint32_t reserved4[4];              //!< [0x1b0-0x1bf] Reserved for future use
+        configCmdSeqs[3]; // !< [0x020-0x02b] Sequence info for Device Configuration command, similar as deviceModeSeq
+    uint32_t reserved1;   // !< [0x02c-0x02f] Reserved for future use
+    uint32_t configCmdArgs[3];     // !< [0x030-0x03b] Arguments/Parameters for device Configuration commands
+    uint32_t reserved2;            // !< [0x03c-0x03f] Reserved for future use
+    uint32_t controllerMiscOption; // !< [0x040-0x043] Controller Misc Options, see Misc feature bit definitions for more
+    // ! details
+    uint8_t deviceType;    // !< [0x044-0x044] Device Type:  See Flash Type Definition for more details
+    uint8_t sflashPadType; // !< [0x045-0x045] Serial Flash Pad Type: 1 - Single, 2 - Dual, 4 - Quad, 8 - Octal
+    uint8_t serialClkFreq; // !< [0x046-0x046] Serial Flash Frequencey, device specific definitions, See System Boot
+    // ! Chapter for more details
+    uint8_t lutCustomSeqEnable; // !< [0x047-0x047] LUT customization Enable, it is required if the program/erase cannot
+    // ! be done using 1 LUT sequence, currently, only applicable to HyperFLASH
+    uint32_t reserved3[2];           // !< [0x048-0x04f] Reserved for future use
+    uint32_t sflashA1Size;           // !< [0x050-0x053] Size of Flash connected to A1
+    uint32_t sflashA2Size;           // !< [0x054-0x057] Size of Flash connected to A2
+    uint32_t sflashB1Size;           // !< [0x058-0x05b] Size of Flash connected to B1
+    uint32_t sflashB2Size;           // !< [0x05c-0x05f] Size of Flash connected to B2
+    uint32_t csPadSettingOverride;   // !< [0x060-0x063] CS pad setting override value
+    uint32_t sclkPadSettingOverride; // !< [0x064-0x067] SCK pad setting override value
+    uint32_t dataPadSettingOverride; // !< [0x068-0x06b] data pad setting override value
+    uint32_t dqsPadSettingOverride;  // !< [0x06c-0x06f] DQS pad setting override value
+    uint32_t timeoutInMs;            // !< [0x070-0x073] Timeout threshold for read status command
+    uint32_t commandInterval;        // !< [0x074-0x077] CS deselect interval between two commands
+    uint16_t dataValidTime[2]; // !< [0x078-0x07b] CLK edge to data valid time for PORT A and PORT B, in terms of 0.1ns
+    uint16_t busyOffset;       // !< [0x07c-0x07d] Busy offset, valid value: 0-31
+    uint16_t busyBitPolarity;  // !< [0x07e-0x07f] Busy flag polarity, 0 - busy flag is 1 when flash device is busy, 1 -
+    // ! busy flag is 0 when flash device is busy
+    uint32_t lookupTable[64];           // !< [0x080-0x17f] Lookup table holds Flash command sequences
+    flexspi_lut_seq_t lutCustomSeq[12]; // !< [0x180-0x1af] Customizable LUT Sequences
+    uint32_t reserved4[4];              // !< [0x1b0-0x1bf] Reserved for future use
 } flexspi_mem_config_t;
 
 /*  */
@@ -232,18 +232,18 @@ typedef struct _FlexSPIConfig
  */
 typedef struct _flexspi_nor_config
 {
-    flexspi_mem_config_t memConfig; //!< Common memory configuration info via FlexSPI
-    uint32_t pageSize;              //!< Page size of Serial NOR
-    uint32_t sectorSize;            //!< Sector size of Serial NOR
-    uint8_t ipcmdSerialClkFreq;     //!< Clock frequency for IP command
-    uint8_t isUniformBlockSize;     //!< Sector/Block size is the same
-    uint8_t reserved0[2];           //!< Reserved for future use
-    uint8_t serialNorType;          //!< Serial NOR Flash type: 0/1/2/3
-    uint8_t needExitNoCmdMode;      //!< Need to exit NoCmd mode before other IP command
-    uint8_t halfClkForNonReadCmd;   //!< Half the Serial Clock for non-read command: true/false
-    uint8_t needRestoreNoCmdMode;   //!< Need to Restore NoCmd mode after IP commmand execution
-    uint32_t blockSize;             //!< Block size
-    uint32_t reserve2[11];          //!< Reserved for future use
+    flexspi_mem_config_t memConfig; // !< Common memory configuration info via FlexSPI
+    uint32_t pageSize;              // !< Page size of Serial NOR
+    uint32_t sectorSize;            // !< Sector size of Serial NOR
+    uint8_t ipcmdSerialClkFreq;     // !< Clock frequency for IP command
+    uint8_t isUniformBlockSize;     // !< Sector/Block size is the same
+    uint8_t reserved0[2];           // !< Reserved for future use
+    uint8_t serialNorType;          // !< Serial NOR Flash type: 0/1/2/3
+    uint8_t needExitNoCmdMode;      // !< Need to exit NoCmd mode before other IP command
+    uint8_t halfClkForNonReadCmd;   // !< Half the Serial Clock for non-read command: true/false
+    uint8_t needRestoreNoCmdMode;   // !< Need to Restore NoCmd mode after IP commmand execution
+    uint32_t blockSize;             // !< Block size
+    uint32_t reserve2[11];          // !< Reserved for future use
 } flexspi_nor_config_t;
 
 #define FLASH_BUSY_STATUS_POL 0

--- a/ports/mimxrt/boards/TEENSY41/flash_config.c
+++ b/ports/mimxrt/boards/TEENSY41/flash_config.c
@@ -26,119 +26,119 @@ __attribute__((section(".boot_hdr.conf")))
 
 const flexspi_nor_config_t qspiflash_config = {
     .memConfig =
-        {
-            .tag              = FLEXSPI_CFG_BLK_TAG,
-            .version          = FLEXSPI_CFG_BLK_VERSION,
-            .readSampleClkSrc = kFlexSPIReadSampleClk_LoopbackFromDqsPad,
-            .csHoldTime       = 3u,
-            .csSetupTime      = 3u,
+    {
+        .tag = FLEXSPI_CFG_BLK_TAG,
+        .version = FLEXSPI_CFG_BLK_VERSION,
+        .readSampleClkSrc = kFlexSPIReadSampleClk_LoopbackFromDqsPad,
+        .csHoldTime = 3u,
+        .csSetupTime = 3u,
 
-            .busyOffset = FLASH_BUSY_STATUS_OFFSET,     // Status bit 0 indicates busy.
-            .busyBitPolarity = FLASH_BUSY_STATUS_POL,   // Busy when the bit is 1.
+        .busyOffset = FLASH_BUSY_STATUS_OFFSET,         // Status bit 0 indicates busy.
+        .busyBitPolarity = FLASH_BUSY_STATUS_POL,       // Busy when the bit is 1.
 
-            .deviceModeCfgEnable = 1u,
-            .deviceModeType = kDeviceConfigCmdType_QuadEnable,
-            .deviceModeSeq = {
-                .seqId = 4u,
-                .seqNum = 1u,
-            },
-            .deviceModeArg = 0x0200,
-            .configCmdEnable = 1u,
-            .configModeType[0] = kDeviceConfigCmdType_Generic,
-            .configCmdSeqs[0] = {
-                .seqId = 2u,
-                .seqNum = 1u,
-            },
-            .deviceType = kFlexSpiDeviceType_SerialNOR,
-            // Enable DDR mode, Wordaddassable, Safe configuration, Differential clock
-            .sflashPadType = kSerialFlash_4Pads,
-            .serialClkFreq = kFlexSpiSerialClk_60MHz,
-            .sflashA1Size  = 8u * 1024u * 1024u,
-            .lookupTable =
-                {
-                    // 0 Read LUTs 0 -> 0
-                    FLEXSPI_LUT_SEQ(CMD_SDR, FLEXSPI_1PAD, 0xEB, RADDR_SDR, FLEXSPI_4PAD, 0x18),
-                    FLEXSPI_LUT_SEQ(DUMMY_SDR, FLEXSPI_4PAD, 0x06, READ_SDR, FLEXSPI_4PAD, 0x04),
-                    FLEXSPI_LUT_SEQ(0, 0, 0, 0, 0, 0), // Filler
-                    FLEXSPI_LUT_SEQ(0, 0, 0, 0, 0, 0), // Filler
-
-                    // 1 Read status register -> 1
-                    FLEXSPI_LUT_SEQ(CMD_SDR, FLEXSPI_1PAD, 0x05, READ_SDR, FLEXSPI_1PAD, 0x01),
-                    FLEXSPI_LUT_SEQ(0, 0, 0, 0, 0, 0), // Filler
-                    FLEXSPI_LUT_SEQ(0, 0, 0, 0, 0, 0), // Filler
-                    FLEXSPI_LUT_SEQ(0, 0, 0, 0, 0, 0), // Filler
-
-                    // 2 Fast read quad mode - SDR
-                    FLEXSPI_LUT_SEQ(CMD_SDR, FLEXSPI_1PAD, 0x6B, RADDR_SDR, FLEXSPI_1PAD, 0x18),
-                    FLEXSPI_LUT_SEQ(DUMMY_SDR, FLEXSPI_4PAD, 0x08, READ_SDR, FLEXSPI_4PAD, 0x04),
-                    FLEXSPI_LUT_SEQ(0, 0, 0, 0, 0, 0), // Filler
-                    FLEXSPI_LUT_SEQ(0, 0, 0, 0, 0, 0), // Filler
-
-                    // 3 Write Enable -> 3
-                    FLEXSPI_LUT_SEQ(CMD_SDR, FLEXSPI_1PAD, 0x06, STOP, FLEXSPI_1PAD, 0),
-                    FLEXSPI_LUT_SEQ(0, 0, 0, 0, 0, 0), // Filler
-                    FLEXSPI_LUT_SEQ(0, 0, 0, 0, 0, 0), // Filler
-                    FLEXSPI_LUT_SEQ(0, 0, 0, 0, 0, 0), // Filler
-
-                    // 4 Read extend parameters
-                    FLEXSPI_LUT_SEQ(CMD_SDR, FLEXSPI_1PAD, 0x81, READ_SDR, FLEXSPI_1PAD, 0x04),
-                    FLEXSPI_LUT_SEQ(0, 0, 0, 0, 0, 0), // Filler
-                    FLEXSPI_LUT_SEQ(0, 0, 0, 0, 0, 0), // Filler
-                    FLEXSPI_LUT_SEQ(0, 0, 0, 0, 0, 0), // Filler
-
-                    // 5 Erase Sector -> 5
-                    FLEXSPI_LUT_SEQ(CMD_SDR, FLEXSPI_1PAD, 0x20, RADDR_SDR, FLEXSPI_1PAD, 24),
-                    FLEXSPI_LUT_SEQ(0, 0, 0, 0, 0, 0), // Filler
-                    FLEXSPI_LUT_SEQ(0, 0, 0, 0, 0, 0), // Filler
-                    FLEXSPI_LUT_SEQ(0, 0, 0, 0, 0, 0), // Filler
-
-                    // 6 Write Status Reg
-                    FLEXSPI_LUT_SEQ(CMD_SDR, FLEXSPI_1PAD, 0x01, WRITE_SDR, FLEXSPI_1PAD, 0x04),
-                    FLEXSPI_LUT_SEQ(0, 0, 0, 0, 0, 0), // Filler
-                    FLEXSPI_LUT_SEQ(0, 0, 0, 0, 0, 0), // Filler
-                    FLEXSPI_LUT_SEQ(0, 0, 0, 0, 0, 0), // Filler
-
-                    // 7 Page Program - quad mode (-> 9)
-                    FLEXSPI_LUT_SEQ(CMD_SDR, FLEXSPI_1PAD, 0x32, RADDR_SDR, FLEXSPI_1PAD, 0x18),
-                    FLEXSPI_LUT_SEQ(WRITE_SDR, FLEXSPI_4PAD, 0x04, STOP, FLEXSPI_1PAD, 0),
-                    FLEXSPI_LUT_SEQ(0, 0, 0, 0, 0, 0), // Filler
-                    FLEXSPI_LUT_SEQ(0, 0, 0, 0, 0, 0), // Filler
-
-                    // 8 Read ID
-                    FLEXSPI_LUT_SEQ(CMD_SDR, FLEXSPI_1PAD, 0x90, DUMMY_SDR, FLEXSPI_1PAD, 24),
-                    FLEXSPI_LUT_SEQ(READ_SDR, FLEXSPI_1PAD, 0x00, 0, 0, 0),
-                    FLEXSPI_LUT_SEQ(0, 0, 0, 0, 0, 0), // Filler
-                    FLEXSPI_LUT_SEQ(0, 0, 0, 0, 0, 0), // Filler
-
-                    // 9 Page Program - single mode -> 9
-                    FLEXSPI_LUT_SEQ(CMD_SDR, FLEXSPI_1PAD, 0x02, RADDR_SDR, FLEXSPI_1PAD, 24),
-                    FLEXSPI_LUT_SEQ(WRITE_SDR, FLEXSPI_1PAD, 0, 0, 0, 0),
-                    FLEXSPI_LUT_SEQ(0, 0, 0, 0, 0, 0), // Filler
-                    FLEXSPI_LUT_SEQ(0, 0, 0, 0, 0, 0), // Filler
-
-                    // 10 Enter QPI mode
-                    FLEXSPI_LUT_SEQ(CMD_SDR, FLEXSPI_1PAD, 0x35, STOP, FLEXSPI_1PAD, 0),
-                    FLEXSPI_LUT_SEQ(0, 0, 0, 0, 0, 0), // Filler
-                    FLEXSPI_LUT_SEQ(0, 0, 0, 0, 0, 0), // Filler
-                    FLEXSPI_LUT_SEQ(0, 0, 0, 0, 0, 0), // Filler
-
-                    // 11 Erase Chip
-                    FLEXSPI_LUT_SEQ(CMD_SDR, FLEXSPI_1PAD, 0x60, STOP, FLEXSPI_1PAD, 0),
-                    FLEXSPI_LUT_SEQ(0, 0, 0, 0, 0, 0), // Filler
-                    FLEXSPI_LUT_SEQ(0, 0, 0, 0, 0, 0), // Filler
-                    FLEXSPI_LUT_SEQ(0, 0, 0, 0, 0, 0), // Filler
-
-                    // 12 Exit QPI mode
-                    FLEXSPI_LUT_SEQ(CMD_SDR, FLEXSPI_4PAD, 0xF5, STOP, FLEXSPI_1PAD, 0),
-                    FLEXSPI_LUT_SEQ(0, 0, 0, 0, 0, 0), // Filler
-                    FLEXSPI_LUT_SEQ(0, 0, 0, 0, 0, 0), // Filler
-                    FLEXSPI_LUT_SEQ(0, 0, 0, 0, 0, 0), // Filler
-                },
+        .deviceModeCfgEnable = 1u,
+        .deviceModeType = kDeviceConfigCmdType_QuadEnable,
+        .deviceModeSeq = {
+            .seqId = 4u,
+            .seqNum = 1u,
         },
-    .pageSize           = 256u,
-    .sectorSize         = 4u * 1024u,
+        .deviceModeArg = 0x0200,
+        .configCmdEnable = 1u,
+        .configModeType[0] = kDeviceConfigCmdType_Generic,
+        .configCmdSeqs[0] = {
+            .seqId = 2u,
+            .seqNum = 1u,
+        },
+        .deviceType = kFlexSpiDeviceType_SerialNOR,
+        // Enable DDR mode, Wordaddassable, Safe configuration, Differential clock
+        .sflashPadType = kSerialFlash_4Pads,
+        .serialClkFreq = kFlexSpiSerialClk_60MHz,
+        .sflashA1Size = 8u * 1024u * 1024u,
+        .lookupTable =
+        {
+            // 0 Read LUTs 0 -> 0
+            FLEXSPI_LUT_SEQ(CMD_SDR, FLEXSPI_1PAD, 0xEB, RADDR_SDR, FLEXSPI_4PAD, 0x18),
+            FLEXSPI_LUT_SEQ(DUMMY_SDR, FLEXSPI_4PAD, 0x06, READ_SDR, FLEXSPI_4PAD, 0x04),
+            FLEXSPI_LUT_SEQ(0, 0, 0, 0, 0, 0),         // Filler
+            FLEXSPI_LUT_SEQ(0, 0, 0, 0, 0, 0),         // Filler
+
+            // 1 Read status register -> 1
+            FLEXSPI_LUT_SEQ(CMD_SDR, FLEXSPI_1PAD, 0x05, READ_SDR, FLEXSPI_1PAD, 0x01),
+            FLEXSPI_LUT_SEQ(0, 0, 0, 0, 0, 0),         // Filler
+            FLEXSPI_LUT_SEQ(0, 0, 0, 0, 0, 0),         // Filler
+            FLEXSPI_LUT_SEQ(0, 0, 0, 0, 0, 0),         // Filler
+
+            // 2 Fast read quad mode - SDR
+            FLEXSPI_LUT_SEQ(CMD_SDR, FLEXSPI_1PAD, 0x6B, RADDR_SDR, FLEXSPI_1PAD, 0x18),
+            FLEXSPI_LUT_SEQ(DUMMY_SDR, FLEXSPI_4PAD, 0x08, READ_SDR, FLEXSPI_4PAD, 0x04),
+            FLEXSPI_LUT_SEQ(0, 0, 0, 0, 0, 0),         // Filler
+            FLEXSPI_LUT_SEQ(0, 0, 0, 0, 0, 0),         // Filler
+
+            // 3 Write Enable -> 3
+            FLEXSPI_LUT_SEQ(CMD_SDR, FLEXSPI_1PAD, 0x06, STOP, FLEXSPI_1PAD, 0),
+            FLEXSPI_LUT_SEQ(0, 0, 0, 0, 0, 0),         // Filler
+            FLEXSPI_LUT_SEQ(0, 0, 0, 0, 0, 0),         // Filler
+            FLEXSPI_LUT_SEQ(0, 0, 0, 0, 0, 0),         // Filler
+
+            // 4 Read extend parameters
+            FLEXSPI_LUT_SEQ(CMD_SDR, FLEXSPI_1PAD, 0x81, READ_SDR, FLEXSPI_1PAD, 0x04),
+            FLEXSPI_LUT_SEQ(0, 0, 0, 0, 0, 0),         // Filler
+            FLEXSPI_LUT_SEQ(0, 0, 0, 0, 0, 0),         // Filler
+            FLEXSPI_LUT_SEQ(0, 0, 0, 0, 0, 0),         // Filler
+
+            // 5 Erase Sector -> 5
+            FLEXSPI_LUT_SEQ(CMD_SDR, FLEXSPI_1PAD, 0x20, RADDR_SDR, FLEXSPI_1PAD, 24),
+            FLEXSPI_LUT_SEQ(0, 0, 0, 0, 0, 0),         // Filler
+            FLEXSPI_LUT_SEQ(0, 0, 0, 0, 0, 0),         // Filler
+            FLEXSPI_LUT_SEQ(0, 0, 0, 0, 0, 0),         // Filler
+
+            // 6 Write Status Reg
+            FLEXSPI_LUT_SEQ(CMD_SDR, FLEXSPI_1PAD, 0x01, WRITE_SDR, FLEXSPI_1PAD, 0x04),
+            FLEXSPI_LUT_SEQ(0, 0, 0, 0, 0, 0),         // Filler
+            FLEXSPI_LUT_SEQ(0, 0, 0, 0, 0, 0),         // Filler
+            FLEXSPI_LUT_SEQ(0, 0, 0, 0, 0, 0),         // Filler
+
+            // 7 Page Program - quad mode (-> 9)
+            FLEXSPI_LUT_SEQ(CMD_SDR, FLEXSPI_1PAD, 0x32, RADDR_SDR, FLEXSPI_1PAD, 0x18),
+            FLEXSPI_LUT_SEQ(WRITE_SDR, FLEXSPI_4PAD, 0x04, STOP, FLEXSPI_1PAD, 0),
+            FLEXSPI_LUT_SEQ(0, 0, 0, 0, 0, 0),         // Filler
+            FLEXSPI_LUT_SEQ(0, 0, 0, 0, 0, 0),         // Filler
+
+            // 8 Read ID
+            FLEXSPI_LUT_SEQ(CMD_SDR, FLEXSPI_1PAD, 0x90, DUMMY_SDR, FLEXSPI_1PAD, 24),
+            FLEXSPI_LUT_SEQ(READ_SDR, FLEXSPI_1PAD, 0x00, 0, 0, 0),
+            FLEXSPI_LUT_SEQ(0, 0, 0, 0, 0, 0),         // Filler
+            FLEXSPI_LUT_SEQ(0, 0, 0, 0, 0, 0),         // Filler
+
+            // 9 Page Program - single mode -> 9
+            FLEXSPI_LUT_SEQ(CMD_SDR, FLEXSPI_1PAD, 0x02, RADDR_SDR, FLEXSPI_1PAD, 24),
+            FLEXSPI_LUT_SEQ(WRITE_SDR, FLEXSPI_1PAD, 0, 0, 0, 0),
+            FLEXSPI_LUT_SEQ(0, 0, 0, 0, 0, 0),         // Filler
+            FLEXSPI_LUT_SEQ(0, 0, 0, 0, 0, 0),         // Filler
+
+            // 10 Enter QPI mode
+            FLEXSPI_LUT_SEQ(CMD_SDR, FLEXSPI_1PAD, 0x35, STOP, FLEXSPI_1PAD, 0),
+            FLEXSPI_LUT_SEQ(0, 0, 0, 0, 0, 0),         // Filler
+            FLEXSPI_LUT_SEQ(0, 0, 0, 0, 0, 0),         // Filler
+            FLEXSPI_LUT_SEQ(0, 0, 0, 0, 0, 0),         // Filler
+
+            // 11 Erase Chip
+            FLEXSPI_LUT_SEQ(CMD_SDR, FLEXSPI_1PAD, 0x60, STOP, FLEXSPI_1PAD, 0),
+            FLEXSPI_LUT_SEQ(0, 0, 0, 0, 0, 0),         // Filler
+            FLEXSPI_LUT_SEQ(0, 0, 0, 0, 0, 0),         // Filler
+            FLEXSPI_LUT_SEQ(0, 0, 0, 0, 0, 0),         // Filler
+
+            // 12 Exit QPI mode
+            FLEXSPI_LUT_SEQ(CMD_SDR, FLEXSPI_4PAD, 0xF5, STOP, FLEXSPI_1PAD, 0),
+            FLEXSPI_LUT_SEQ(0, 0, 0, 0, 0, 0),         // Filler
+            FLEXSPI_LUT_SEQ(0, 0, 0, 0, 0, 0),         // Filler
+            FLEXSPI_LUT_SEQ(0, 0, 0, 0, 0, 0),         // Filler
+        },
+    },
+    .pageSize = 256u,
+    .sectorSize = 4u * 1024u,
     .ipcmdSerialClkFreq = kFlexSpiSerialClk_30MHz,
-    .blockSize          = 0x00010000,
+    .blockSize = 0x00010000,
     .isUniformBlockSize = false,
 };
 #endif /* XIP_BOOT_HEADER_ENABLE */

--- a/ports/mimxrt/boards/TEENSY41/mpconfigboard.h
+++ b/ports/mimxrt/boards/TEENSY41/mpconfigboard.h
@@ -39,10 +39,10 @@
     { IOMUXC_GPIO_B0_02_LPSPI4_SDO }, { IOMUXC_GPIO_B0_01_LPSPI4_SDI },
 
 #define DMA_REQ_SRC_RX { 0, kDmaRequestMuxLPSPI1Rx, kDmaRequestMuxLPSPI2Rx, \
-                            kDmaRequestMuxLPSPI3Rx, kDmaRequestMuxLPSPI4Rx }
+                         kDmaRequestMuxLPSPI3Rx, kDmaRequestMuxLPSPI4Rx }
 
 #define DMA_REQ_SRC_TX { 0, kDmaRequestMuxLPSPI1Tx, kDmaRequestMuxLPSPI2Tx, \
-                            kDmaRequestMuxLPSPI3Tx, kDmaRequestMuxLPSPI4Tx } 
+                         kDmaRequestMuxLPSPI3Tx, kDmaRequestMuxLPSPI4Tx }
 
 // Define mapping hardware I2C # to logical I2C #
 // SDA/SCL  HW-I2C    Logical I2C
@@ -63,9 +63,9 @@
     { \
         .cmd = {GPIO_SD_B0_00_USDHC1_CMD}, \
         .clk = { GPIO_SD_B0_01_USDHC1_CLK }, \
-        .cd_b = { USDHC_DUMMY_PIN },\
-        .data0 = { GPIO_SD_B0_02_USDHC1_DATA0 },\
-        .data1 = { GPIO_SD_B0_03_USDHC1_DATA1 },\
-        .data2 = { GPIO_SD_B0_04_USDHC1_DATA2 },\
-        .data3 = { GPIO_SD_B0_05_USDHC1_DATA3 },\
+        .cd_b = { USDHC_DUMMY_PIN }, \
+        .data0 = { GPIO_SD_B0_02_USDHC1_DATA0 }, \
+        .data1 = { GPIO_SD_B0_03_USDHC1_DATA1 }, \
+        .data2 = { GPIO_SD_B0_04_USDHC1_DATA2 }, \
+        .data3 = { GPIO_SD_B0_05_USDHC1_DATA3 }, \
     }

--- a/ports/mimxrt/boards/TEENSY41/teensy41_flexspi_nor_config.h
+++ b/ports/mimxrt/boards/TEENSY41/teensy41_flexspi_nor_config.h
@@ -76,9 +76,9 @@
 
 #define FLEXSPI_LUT_SEQ(cmd0, pad0, op0, cmd1, pad1, op1)                                                              \
     (FLEXSPI_LUT_OPERAND0(op0) | FLEXSPI_LUT_NUM_PADS0(pad0) | FLEXSPI_LUT_OPCODE0(cmd0) | FLEXSPI_LUT_OPERAND1(op1) | \
-     FLEXSPI_LUT_NUM_PADS1(pad1) | FLEXSPI_LUT_OPCODE1(cmd1))
+    FLEXSPI_LUT_NUM_PADS1(pad1) | FLEXSPI_LUT_OPCODE1(cmd1))
 
-//!@brief Definitions for FlexSPI Serial Clock Frequency
+// !@brief Definitions for FlexSPI Serial Clock Frequency
 typedef enum _FlexSpiSerialClockFreq
 {
     kFlexSpiSerialClk_30MHz  = 1,
@@ -92,14 +92,14 @@ typedef enum _FlexSpiSerialClockFreq
     kFlexSpiSerialClk_166MHz = 9,
 } flexspi_serial_clk_freq_t;
 
-//!@brief FlexSPI clock configuration type
+// !@brief FlexSPI clock configuration type
 enum
 {
-    kFlexSpiClk_SDR, //!< Clock configure for SDR mode
-    kFlexSpiClk_DDR, //!< Clock configurat for DDR mode
+    kFlexSpiClk_SDR, // !< Clock configure for SDR mode
+    kFlexSpiClk_DDR, // !< Clock configurat for DDR mode
 };
 
-//!@brief FlexSPI Read Sample Clock Source definition
+// !@brief FlexSPI Read Sample Clock Source definition
 typedef enum _FlashReadSampleClkSource
 {
     kFlexSPIReadSampleClk_LoopbackInternally      = 0,
@@ -108,29 +108,29 @@ typedef enum _FlashReadSampleClkSource
     kFlexSPIReadSampleClk_ExternalInputFromDqsPad = 3,
 } flexspi_read_sample_clk_t;
 
-//!@brief Misc feature bit definitions
+// !@brief Misc feature bit definitions
 enum
 {
-    kFlexSpiMiscOffset_DiffClkEnable            = 0, //!< Bit for Differential clock enable
-    kFlexSpiMiscOffset_Ck2Enable                = 1, //!< Bit for CK2 enable
-    kFlexSpiMiscOffset_ParallelEnable           = 2, //!< Bit for Parallel mode enable
-    kFlexSpiMiscOffset_WordAddressableEnable    = 3, //!< Bit for Word Addressable enable
-    kFlexSpiMiscOffset_SafeConfigFreqEnable     = 4, //!< Bit for Safe Configuration Frequency enable
-    kFlexSpiMiscOffset_PadSettingOverrideEnable = 5, //!< Bit for Pad setting override enable
-    kFlexSpiMiscOffset_DdrModeEnable            = 6, //!< Bit for DDR clock confiuration indication.
+    kFlexSpiMiscOffset_DiffClkEnable            = 0, // !< Bit for Differential clock enable
+    kFlexSpiMiscOffset_Ck2Enable                = 1, // !< Bit for CK2 enable
+    kFlexSpiMiscOffset_ParallelEnable           = 2, // !< Bit for Parallel mode enable
+    kFlexSpiMiscOffset_WordAddressableEnable    = 3, // !< Bit for Word Addressable enable
+    kFlexSpiMiscOffset_SafeConfigFreqEnable     = 4, // !< Bit for Safe Configuration Frequency enable
+    kFlexSpiMiscOffset_PadSettingOverrideEnable = 5, // !< Bit for Pad setting override enable
+    kFlexSpiMiscOffset_DdrModeEnable            = 6, // !< Bit for DDR clock confiuration indication.
 };
 
-//!@brief Flash Type Definition
+// !@brief Flash Type Definition
 enum
 {
-    kFlexSpiDeviceType_SerialNOR    = 1,    //!< Flash devices are Serial NOR
-    kFlexSpiDeviceType_SerialNAND   = 2,    //!< Flash devices are Serial NAND
-    kFlexSpiDeviceType_SerialRAM    = 3,    //!< Flash devices are Serial RAM/HyperFLASH
-    kFlexSpiDeviceType_MCP_NOR_NAND = 0x12, //!< Flash device is MCP device, A1 is Serial NOR, A2 is Serial NAND
-    kFlexSpiDeviceType_MCP_NOR_RAM  = 0x13, //!< Flash deivce is MCP device, A1 is Serial NOR, A2 is Serial RAMs
+    kFlexSpiDeviceType_SerialNOR    = 1,    // !< Flash devices are Serial NOR
+    kFlexSpiDeviceType_SerialNAND   = 2,    // !< Flash devices are Serial NAND
+    kFlexSpiDeviceType_SerialRAM    = 3,    // !< Flash devices are Serial RAM/HyperFLASH
+    kFlexSpiDeviceType_MCP_NOR_NAND = 0x12, // !< Flash device is MCP device, A1 is Serial NOR, A2 is Serial NAND
+    kFlexSpiDeviceType_MCP_NOR_RAM  = 0x13, // !< Flash deivce is MCP device, A1 is Serial NOR, A2 is Serial RAMs
 };
 
-//!@brief Flash Pad Definitions
+// !@brief Flash Pad Definitions
 enum
 {
     kSerialFlash_1Pad  = 1,
@@ -139,77 +139,77 @@ enum
     kSerialFlash_8Pads = 8,
 };
 
-//!@brief FlexSPI LUT Sequence structure
+// !@brief FlexSPI LUT Sequence structure
 typedef struct _lut_sequence
 {
-    uint8_t seqNum; //!< Sequence Number, valid number: 1-16
-    uint8_t seqId;  //!< Sequence Index, valid number: 0-15
+    uint8_t seqNum; // !< Sequence Number, valid number: 1-16
+    uint8_t seqId;  // !< Sequence Index, valid number: 0-15
     uint16_t reserved;
 } flexspi_lut_seq_t;
 
-//!@brief Flash Configuration Command Type
+// !@brief Flash Configuration Command Type
 enum
 {
-    kDeviceConfigCmdType_Generic,    //!< Generic command, for example: configure dummy cycles, drive strength, etc
-    kDeviceConfigCmdType_QuadEnable, //!< Quad Enable command
-    kDeviceConfigCmdType_Spi2Xpi,    //!< Switch from SPI to DPI/QPI/OPI mode
-    kDeviceConfigCmdType_Xpi2Spi,    //!< Switch from DPI/QPI/OPI to SPI mode
-    kDeviceConfigCmdType_Spi2NoCmd,  //!< Switch to 0-4-4/0-8-8 mode
-    kDeviceConfigCmdType_Reset,      //!< Reset device command
+    kDeviceConfigCmdType_Generic,    // !< Generic command, for example: configure dummy cycles, drive strength, etc
+    kDeviceConfigCmdType_QuadEnable, // !< Quad Enable command
+    kDeviceConfigCmdType_Spi2Xpi,    // !< Switch from SPI to DPI/QPI/OPI mode
+    kDeviceConfigCmdType_Xpi2Spi,    // !< Switch from DPI/QPI/OPI to SPI mode
+    kDeviceConfigCmdType_Spi2NoCmd,  // !< Switch to 0-4-4/0-8-8 mode
+    kDeviceConfigCmdType_Reset,      // !< Reset device command
 };
 
-//!@brief FlexSPI Memory Configuration Block
+// !@brief FlexSPI Memory Configuration Block
 typedef struct _FlexSPIConfig
 {
-    uint32_t tag;               //!< [0x000-0x003] Tag, fixed value 0x42464346UL
-    uint32_t version;           //!< [0x004-0x007] Version,[31:24] -'V', [23:16] - Major, [15:8] - Minor, [7:0] - bugfix
-    uint32_t reserved0;         //!< [0x008-0x00b] Reserved for future use
-    uint8_t readSampleClkSrc;   //!< [0x00c-0x00c] Read Sample Clock Source, valid value: 0/1/3
-    uint8_t csHoldTime;         //!< [0x00d-0x00d] CS hold time, default value: 3
-    uint8_t csSetupTime;        //!< [0x00e-0x00e] CS setup time, default value: 3
-    uint8_t columnAddressWidth; //!< [0x00f-0x00f] Column Address with, for HyperBus protocol, it is fixed to 3, For
-    //! Serial NAND, need to refer to datasheet
-    uint8_t deviceModeCfgEnable; //!< [0x010-0x010] Device Mode Configure enable flag, 1 - Enable, 0 - Disable
-    uint8_t deviceModeType; //!< [0x011-0x011] Specify the configuration command type:Quad Enable, DPI/QPI/OPI switch,
-    //! Generic configuration, etc.
-    uint16_t waitTimeCfgCommands; //!< [0x012-0x013] Wait time for all configuration commands, unit: 100us, Used for
-    //! DPI/QPI/OPI switch or reset command
-    flexspi_lut_seq_t deviceModeSeq; //!< [0x014-0x017] Device mode sequence info, [7:0] - LUT sequence id, [15:8] - LUt
-    //! sequence number, [31:16] Reserved
-    uint32_t deviceModeArg;    //!< [0x018-0x01b] Argument/Parameter for device configuration
-    uint8_t configCmdEnable;   //!< [0x01c-0x01c] Configure command Enable Flag, 1 - Enable, 0 - Disable
-    uint8_t configModeType[3]; //!< [0x01d-0x01f] Configure Mode Type, similar as deviceModeTpe
+    uint32_t tag;               // !< [0x000-0x003] Tag, fixed value 0x42464346UL
+    uint32_t version;           // !< [0x004-0x007] Version,[31:24] -'V', [23:16] - Major, [15:8] - Minor, [7:0] - bugfix
+    uint32_t reserved0;         // !< [0x008-0x00b] Reserved for future use
+    uint8_t readSampleClkSrc;   // !< [0x00c-0x00c] Read Sample Clock Source, valid value: 0/1/3
+    uint8_t csHoldTime;         // !< [0x00d-0x00d] CS hold time, default value: 3
+    uint8_t csSetupTime;        // !< [0x00e-0x00e] CS setup time, default value: 3
+    uint8_t columnAddressWidth; // !< [0x00f-0x00f] Column Address with, for HyperBus protocol, it is fixed to 3, For
+    // ! Serial NAND, need to refer to datasheet
+    uint8_t deviceModeCfgEnable; // !< [0x010-0x010] Device Mode Configure enable flag, 1 - Enable, 0 - Disable
+    uint8_t deviceModeType; // !< [0x011-0x011] Specify the configuration command type:Quad Enable, DPI/QPI/OPI switch,
+    // ! Generic configuration, etc.
+    uint16_t waitTimeCfgCommands; // !< [0x012-0x013] Wait time for all configuration commands, unit: 100us, Used for
+    // ! DPI/QPI/OPI switch or reset command
+    flexspi_lut_seq_t deviceModeSeq; // !< [0x014-0x017] Device mode sequence info, [7:0] - LUT sequence id, [15:8] - LUt
+    // ! sequence number, [31:16] Reserved
+    uint32_t deviceModeArg;    // !< [0x018-0x01b] Argument/Parameter for device configuration
+    uint8_t configCmdEnable;   // !< [0x01c-0x01c] Configure command Enable Flag, 1 - Enable, 0 - Disable
+    uint8_t configModeType[3]; // !< [0x01d-0x01f] Configure Mode Type, similar as deviceModeTpe
     flexspi_lut_seq_t
-        configCmdSeqs[3]; //!< [0x020-0x02b] Sequence info for Device Configuration command, similar as deviceModeSeq
-    uint32_t reserved1;   //!< [0x02c-0x02f] Reserved for future use
-    uint32_t configCmdArgs[3];     //!< [0x030-0x03b] Arguments/Parameters for device Configuration commands
-    uint32_t reserved2;            //!< [0x03c-0x03f] Reserved for future use
-    uint32_t controllerMiscOption; //!< [0x040-0x043] Controller Misc Options, see Misc feature bit definitions for more
-    //! details
-    uint8_t deviceType;    //!< [0x044-0x044] Device Type:  See Flash Type Definition for more details
-    uint8_t sflashPadType; //!< [0x045-0x045] Serial Flash Pad Type: 1 - Single, 2 - Dual, 4 - Quad, 8 - Octal
-    uint8_t serialClkFreq; //!< [0x046-0x046] Serial Flash Frequencey, device specific definitions, See System Boot
-    //! Chapter for more details
-    uint8_t lutCustomSeqEnable; //!< [0x047-0x047] LUT customization Enable, it is required if the program/erase cannot
-    //! be done using 1 LUT sequence, currently, only applicable to HyperFLASH
-    uint32_t reserved3[2];           //!< [0x048-0x04f] Reserved for future use
-    uint32_t sflashA1Size;           //!< [0x050-0x053] Size of Flash connected to A1
-    uint32_t sflashA2Size;           //!< [0x054-0x057] Size of Flash connected to A2
-    uint32_t sflashB1Size;           //!< [0x058-0x05b] Size of Flash connected to B1
-    uint32_t sflashB2Size;           //!< [0x05c-0x05f] Size of Flash connected to B2
-    uint32_t csPadSettingOverride;   //!< [0x060-0x063] CS pad setting override value
-    uint32_t sclkPadSettingOverride; //!< [0x064-0x067] SCK pad setting override value
-    uint32_t dataPadSettingOverride; //!< [0x068-0x06b] data pad setting override value
-    uint32_t dqsPadSettingOverride;  //!< [0x06c-0x06f] DQS pad setting override value
-    uint32_t timeoutInMs;            //!< [0x070-0x073] Timeout threshold for read status command
-    uint32_t commandInterval;        //!< [0x074-0x077] CS deselect interval between two commands
-    uint16_t dataValidTime[2]; //!< [0x078-0x07b] CLK edge to data valid time for PORT A and PORT B, in terms of 0.1ns
-    uint16_t busyOffset;       //!< [0x07c-0x07d] Busy offset, valid value: 0-31
-    uint16_t busyBitPolarity;  //!< [0x07e-0x07f] Busy flag polarity, 0 - busy flag is 1 when flash device is busy, 1 -
-    //! busy flag is 0 when flash device is busy
-    uint32_t lookupTable[64];           //!< [0x080-0x17f] Lookup table holds Flash command sequences
-    flexspi_lut_seq_t lutCustomSeq[12]; //!< [0x180-0x1af] Customizable LUT Sequences
-    uint32_t reserved4[4];              //!< [0x1b0-0x1bf] Reserved for future use
+        configCmdSeqs[3]; // !< [0x020-0x02b] Sequence info for Device Configuration command, similar as deviceModeSeq
+    uint32_t reserved1;   // !< [0x02c-0x02f] Reserved for future use
+    uint32_t configCmdArgs[3];     // !< [0x030-0x03b] Arguments/Parameters for device Configuration commands
+    uint32_t reserved2;            // !< [0x03c-0x03f] Reserved for future use
+    uint32_t controllerMiscOption; // !< [0x040-0x043] Controller Misc Options, see Misc feature bit definitions for more
+    // ! details
+    uint8_t deviceType;    // !< [0x044-0x044] Device Type:  See Flash Type Definition for more details
+    uint8_t sflashPadType; // !< [0x045-0x045] Serial Flash Pad Type: 1 - Single, 2 - Dual, 4 - Quad, 8 - Octal
+    uint8_t serialClkFreq; // !< [0x046-0x046] Serial Flash Frequencey, device specific definitions, See System Boot
+    // ! Chapter for more details
+    uint8_t lutCustomSeqEnable; // !< [0x047-0x047] LUT customization Enable, it is required if the program/erase cannot
+    // ! be done using 1 LUT sequence, currently, only applicable to HyperFLASH
+    uint32_t reserved3[2];           // !< [0x048-0x04f] Reserved for future use
+    uint32_t sflashA1Size;           // !< [0x050-0x053] Size of Flash connected to A1
+    uint32_t sflashA2Size;           // !< [0x054-0x057] Size of Flash connected to A2
+    uint32_t sflashB1Size;           // !< [0x058-0x05b] Size of Flash connected to B1
+    uint32_t sflashB2Size;           // !< [0x05c-0x05f] Size of Flash connected to B2
+    uint32_t csPadSettingOverride;   // !< [0x060-0x063] CS pad setting override value
+    uint32_t sclkPadSettingOverride; // !< [0x064-0x067] SCK pad setting override value
+    uint32_t dataPadSettingOverride; // !< [0x068-0x06b] data pad setting override value
+    uint32_t dqsPadSettingOverride;  // !< [0x06c-0x06f] DQS pad setting override value
+    uint32_t timeoutInMs;            // !< [0x070-0x073] Timeout threshold for read status command
+    uint32_t commandInterval;        // !< [0x074-0x077] CS deselect interval between two commands
+    uint16_t dataValidTime[2]; // !< [0x078-0x07b] CLK edge to data valid time for PORT A and PORT B, in terms of 0.1ns
+    uint16_t busyOffset;       // !< [0x07c-0x07d] Busy offset, valid value: 0-31
+    uint16_t busyBitPolarity;  // !< [0x07e-0x07f] Busy flag polarity, 0 - busy flag is 1 when flash device is busy, 1 -
+    // ! busy flag is 0 when flash device is busy
+    uint32_t lookupTable[64];           // !< [0x080-0x17f] Lookup table holds Flash command sequences
+    flexspi_lut_seq_t lutCustomSeq[12]; // !< [0x180-0x1af] Customizable LUT Sequences
+    uint32_t reserved4[4];              // !< [0x1b0-0x1bf] Reserved for future use
 } flexspi_mem_config_t;
 
 /*  */
@@ -232,18 +232,18 @@ typedef struct _FlexSPIConfig
  */
 typedef struct _flexspi_nor_config
 {
-    flexspi_mem_config_t memConfig; //!< Common memory configuration info via FlexSPI
-    uint32_t pageSize;              //!< Page size of Serial NOR
-    uint32_t sectorSize;            //!< Sector size of Serial NOR
-    uint8_t ipcmdSerialClkFreq;     //!< Clock frequency for IP command
-    uint8_t isUniformBlockSize;     //!< Sector/Block size is the same
-    uint8_t reserved0[2];           //!< Reserved for future use
-    uint8_t serialNorType;          //!< Serial NOR Flash type: 0/1/2/3
-    uint8_t needExitNoCmdMode;      //!< Need to exit NoCmd mode before other IP command
-    uint8_t halfClkForNonReadCmd;   //!< Half the Serial Clock for non-read command: true/false
-    uint8_t needRestoreNoCmdMode;   //!< Need to Restore NoCmd mode after IP commmand execution
-    uint32_t blockSize;             //!< Block size
-    uint32_t reserve2[11];          //!< Reserved for future use
+    flexspi_mem_config_t memConfig; // !< Common memory configuration info via FlexSPI
+    uint32_t pageSize;              // !< Page size of Serial NOR
+    uint32_t sectorSize;            // !< Sector size of Serial NOR
+    uint8_t ipcmdSerialClkFreq;     // !< Clock frequency for IP command
+    uint8_t isUniformBlockSize;     // !< Sector/Block size is the same
+    uint8_t reserved0[2];           // !< Reserved for future use
+    uint8_t serialNorType;          // !< Serial NOR Flash type: 0/1/2/3
+    uint8_t needExitNoCmdMode;      // !< Need to exit NoCmd mode before other IP command
+    uint8_t halfClkForNonReadCmd;   // !< Half the Serial Clock for non-read command: true/false
+    uint8_t needRestoreNoCmdMode;   // !< Need to Restore NoCmd mode after IP commmand execution
+    uint32_t blockSize;             // !< Block size
+    uint32_t reserve2[11];          // !< Reserved for future use
 } flexspi_nor_config_t;
 
 #define FLASH_BUSY_STATUS_POL 0

--- a/ports/mimxrt/hal/flexspi_hyper_flash.c
+++ b/ports/mimxrt/hal/flexspi_hyper_flash.c
@@ -16,14 +16,15 @@
 __attribute__((always_inline)) static inline void clock_set_div(clock_div_t divider, uint32_t value) {
     uint32_t busyShift;
 
-    busyShift                   = CCM_TUPLE_BUSY_SHIFT(divider);
+    busyShift = CCM_TUPLE_BUSY_SHIFT(divider);
     CCM_TUPLE_REG(CCM, divider) = (CCM_TUPLE_REG(CCM, divider) & (~CCM_TUPLE_MASK(divider))) |
-                                  (((uint32_t)((value) << CCM_TUPLE_SHIFT(divider))) & CCM_TUPLE_MASK(divider));
+        (((uint32_t)((value) << CCM_TUPLE_SHIFT(divider))) & CCM_TUPLE_MASK(divider));
 
     /* Clock switch need Handshake? */
     if (CCM_NO_BUSY_WAIT != busyShift) {
         /* Wait until CCM internal handshake finish. */
-        while (CCM->CDHIPR & (1U << busyShift)) {}
+        while (CCM->CDHIPR & (1U << busyShift)) {
+        }
     }
 }
 
@@ -32,7 +33,7 @@ __attribute__((always_inline)) static inline void clock_control_gate(clock_ip_na
     uint32_t shift = ((uint32_t)name) & 0x1FU;
     volatile uint32_t *reg;
 
-    reg  = ((volatile uint32_t *)&CCM->CCGR0) + index;
+    reg = ((volatile uint32_t *)&CCM->CCGR0) + index;
     *reg = ((*reg) & ~(3U << shift)) | (((uint32_t)value) << shift);
 }
 
@@ -44,9 +45,9 @@ __attribute__((always_inline)) static inline void clock_disable_clock(clock_ip_n
     clock_control_gate(name, kCLOCK_ClockNotNeeded);
 }
 
-#define DIV_PAGE_PGM	4
-#define DIV_ERASE_PGM	4
-#define DIV_READ		0
+#define DIV_PAGE_PGM    4
+#define DIV_ERASE_PGM   4
+#define DIV_READ                0
 
 static void SetFlexSPIDiv(uint32_t div) __attribute__((section(".ram_functions")));
 static void SetFlexSPIDiv(uint32_t div) {
@@ -54,7 +55,7 @@ static void SetFlexSPIDiv(uint32_t div) {
     clock_disable_clock(kCLOCK_FlexSpi);
     clock_set_div(kCLOCK_FlexspiDiv, div); /* flexspi clock 332M, DDR mode, internal clock 166M. */
     clock_enable_clock(kCLOCK_FlexSpi);
-    FLEXSPI_Enable(FLEXSPI, true);	
+    FLEXSPI_Enable(FLEXSPI, true);
 }
 
 status_t flexspi_nor_hyperbus_read(FLEXSPI_Type *base, uint32_t addr, uint32_t *buffer, uint32_t bytes) __attribute__((section(".ram_functions")));
@@ -63,13 +64,13 @@ status_t flexspi_nor_hyperbus_read(FLEXSPI_Type *base, uint32_t addr, uint32_t *
     status_t status;
 
     flashXfer.deviceAddress = addr * 2;
-    flashXfer.port          = kFLEXSPI_PortA1;
-    flashXfer.cmdType       = kFLEXSPI_Read;
-    flashXfer.SeqNumber     = 1;
-    flashXfer.seqIndex      = HYPERFLASH_CMD_LUT_SEQ_IDX_READDATA;
-    flashXfer.data          = buffer;
-    flashXfer.dataSize      = bytes;
-    status                  = FLEXSPI_TransferBlocking(base, &flashXfer);
+    flashXfer.port = kFLEXSPI_PortA1;
+    flashXfer.cmdType = kFLEXSPI_Read;
+    flashXfer.SeqNumber = 1;
+    flashXfer.seqIndex = HYPERFLASH_CMD_LUT_SEQ_IDX_READDATA;
+    flashXfer.data = buffer;
+    flashXfer.dataSize = bytes;
+    status = FLEXSPI_TransferBlocking(base, &flashXfer);
 
     return status;
 }
@@ -80,13 +81,13 @@ status_t flexspi_nor_hyperbus_write(FLEXSPI_Type *base, uint32_t addr, uint32_t 
     status_t status;
 
     flashXfer.deviceAddress = addr * 2;
-    flashXfer.port          = kFLEXSPI_PortA1;
-    flashXfer.cmdType       = kFLEXSPI_Write;
-    flashXfer.SeqNumber     = 1;
-    flashXfer.seqIndex      = HYPERFLASH_CMD_LUT_SEQ_IDX_WRITEDATA;
-    flashXfer.data          = buffer;
-    flashXfer.dataSize      = bytes;
-    status                  = FLEXSPI_TransferBlocking(base, &flashXfer);
+    flashXfer.port = kFLEXSPI_PortA1;
+    flashXfer.cmdType = kFLEXSPI_Write;
+    flashXfer.SeqNumber = 1;
+    flashXfer.seqIndex = HYPERFLASH_CMD_LUT_SEQ_IDX_WRITEDATA;
+    flashXfer.data = buffer;
+    flashXfer.dataSize = bytes;
+    status = FLEXSPI_TransferBlocking(base, &flashXfer);
 
     return status;
 }
@@ -98,10 +99,10 @@ status_t flexspi_nor_write_enable(FLEXSPI_Type *base, uint32_t baseAddr) {
 
     /* Write enable */
     flashXfer.deviceAddress = baseAddr;
-    flashXfer.port          = kFLEXSPI_PortA1;
-    flashXfer.cmdType       = kFLEXSPI_Command;
-    flashXfer.SeqNumber     = 2;
-    flashXfer.seqIndex      = HYPERFLASH_CMD_LUT_SEQ_IDX_WRITEENABLE;
+    flashXfer.port = kFLEXSPI_PortA1;
+    flashXfer.cmdType = kFLEXSPI_Command;
+    flashXfer.SeqNumber = 2;
+    flashXfer.seqIndex = HYPERFLASH_CMD_LUT_SEQ_IDX_WRITEENABLE;
 
     status = FLEXSPI_TransferBlocking(base, &flashXfer);
 
@@ -117,12 +118,12 @@ status_t flexspi_nor_wait_bus_busy(FLEXSPI_Type *base) {
     flexspi_transfer_t flashXfer;
 
     flashXfer.deviceAddress = 0;
-    flashXfer.port          = kFLEXSPI_PortA1;
-    flashXfer.cmdType       = kFLEXSPI_Read;
-    flashXfer.SeqNumber     = 2;
-    flashXfer.seqIndex      = HYPERFLASH_CMD_LUT_SEQ_IDX_READSTATUS;
-    flashXfer.data          = &readValue;
-    flashXfer.dataSize      = 2;
+    flashXfer.port = kFLEXSPI_PortA1;
+    flashXfer.cmdType = kFLEXSPI_Read;
+    flashXfer.SeqNumber = 2;
+    flashXfer.seqIndex = HYPERFLASH_CMD_LUT_SEQ_IDX_READSTATUS;
+    flashXfer.data = &readValue;
+    flashXfer.dataSize = 2;
 
     do {
         status = FLEXSPI_TransferBlocking(base, &flashXfer);
@@ -159,11 +160,11 @@ status_t flexspi_nor_flash_erase_sector(FLEXSPI_Type *base, uint32_t address) {
     }
 
     flashXfer.deviceAddress = address;
-    flashXfer.port          = kFLEXSPI_PortA1;
-    flashXfer.cmdType       = kFLEXSPI_Command;
-    flashXfer.SeqNumber     = 4;
-    flashXfer.seqIndex      = HYPERFLASH_CMD_LUT_SEQ_IDX_ERASESECTOR;
-    status                  = FLEXSPI_TransferBlocking(base, &flashXfer);
+    flashXfer.port = kFLEXSPI_PortA1;
+    flashXfer.cmdType = kFLEXSPI_Command;
+    flashXfer.SeqNumber = 4;
+    flashXfer.seqIndex = HYPERFLASH_CMD_LUT_SEQ_IDX_ERASESECTOR;
+    status = FLEXSPI_TransferBlocking(base, &flashXfer);
 
     if (status != kStatus_Success) {
         return status;
@@ -174,13 +175,13 @@ status_t flexspi_nor_flash_erase_sector(FLEXSPI_Type *base, uint32_t address) {
     return status;
 }
 
-status_t flexspi_nor_flash_page_program(FLEXSPI_Type *base, uint32_t address, const uint32_t *src,  uint32_t size ) __attribute__((section(".ram_functions")));
+status_t flexspi_nor_flash_page_program(FLEXSPI_Type *base, uint32_t address, const uint32_t *src,  uint32_t size) __attribute__((section(".ram_functions")));
 status_t flexspi_nor_flash_page_program(FLEXSPI_Type *base, uint32_t address, const uint32_t *src,  uint32_t size) {
     status_t status;
     flexspi_transfer_t flashXfer;
 
     /* Speed down flexspi clock */
-	SetFlexSPIDiv(DIV_PAGE_PGM);
+    SetFlexSPIDiv(DIV_PAGE_PGM);
 
     /* Write enable */
     status = flexspi_nor_write_enable(base, address);
@@ -191,13 +192,13 @@ status_t flexspi_nor_flash_page_program(FLEXSPI_Type *base, uint32_t address, co
 
     /* Prepare page program command */
     flashXfer.deviceAddress = address;
-    flashXfer.port          = kFLEXSPI_PortA1;
-    flashXfer.cmdType       = kFLEXSPI_Write;
-    flashXfer.SeqNumber     = 2;
-    flashXfer.seqIndex      = HYPERFLASH_CMD_LUT_SEQ_IDX_PAGEPROGRAM;
-    flashXfer.data          = (uint32_t *)src;
-    flashXfer.dataSize      = size;
-    status                  = FLEXSPI_TransferBlocking(base, &flashXfer);
+    flashXfer.port = kFLEXSPI_PortA1;
+    flashXfer.cmdType = kFLEXSPI_Write;
+    flashXfer.SeqNumber = 2;
+    flashXfer.seqIndex = HYPERFLASH_CMD_LUT_SEQ_IDX_PAGEPROGRAM;
+    flashXfer.data = (uint32_t *)src;
+    flashXfer.dataSize = size;
+    status = FLEXSPI_TransferBlocking(base, &flashXfer);
 
     if (status != kStatus_Success) {
         return status;
@@ -205,7 +206,7 @@ status_t flexspi_nor_flash_page_program(FLEXSPI_Type *base, uint32_t address, co
 
     status = flexspi_nor_wait_bus_busy(base);
 
-	SetFlexSPIDiv(DIV_READ);
+    SetFlexSPIDiv(DIV_READ);
 
     return status;
 }
@@ -219,7 +220,7 @@ status_t flexspi_nor_hyperflash_cfi(FLEXSPI_Type *base) {
     status_t status;
     uint32_t buffer[2];
     uint8_t data[4] = {0x00, 0x98};
-    status          = flexspi_nor_hyperbus_write(base, 0x555, (uint32_t *)data, 2);
+    status = flexspi_nor_hyperbus_write(base, 0x555, (uint32_t *)data, 2);
     if (status != kStatus_Success) {
         return status;
     }
@@ -238,7 +239,7 @@ status_t flexspi_nor_hyperflash_cfi(FLEXSPI_Type *base) {
     }
     // ASO Exit 0xF000
     data[1] = 0xF0;
-    status  = flexspi_nor_hyperbus_write(base, 0x0, (uint32_t *)data, 2);
+    status = flexspi_nor_hyperbus_write(base, 0x0, (uint32_t *)data, 2);
     if (status != kStatus_Success) {
         return status;
     }

--- a/ports/mimxrt/hal/flexspi_nor_flash.c
+++ b/ports/mimxrt/hal/flexspi_nor_flash.c
@@ -41,8 +41,7 @@ void flexspi_nor_reset(FLEXSPI_Type *base) __attribute__((section(".ram_function
 void flexspi_nor_reset(FLEXSPI_Type *base) {
     // Using content of FLEXSPI_SoftwareReset directly to prevent issues when compiler does not inline function
     base->MCR0 |= FLEXSPI_MCR0_SWRESET_MASK;
-    while (base->MCR0 & FLEXSPI_MCR0_SWRESET_MASK)
-    {
+    while (base->MCR0 & FLEXSPI_MCR0_SWRESET_MASK) {
     }
 }
 
@@ -63,7 +62,7 @@ status_t flexspi_nor_write_enable(FLEXSPI_Type *base, uint32_t baseAddr) {
     return status;
 }
 
-status_t flexspi_nor_wait_bus_busy(FLEXSPI_Type *base) __attribute__((section(".ram_functions"))) ;
+status_t flexspi_nor_wait_bus_busy(FLEXSPI_Type *base) __attribute__((section(".ram_functions")));
 status_t flexspi_nor_wait_bus_busy(FLEXSPI_Type *base) {
     /* Wait status ready. */
     bool isBusy;
@@ -103,7 +102,7 @@ status_t flexspi_nor_wait_bus_busy(FLEXSPI_Type *base) {
     return status;
 }
 
-status_t flexspi_nor_enable_quad_mode(FLEXSPI_Type *base) __attribute__((section(".ram_functions"))) ;
+status_t flexspi_nor_enable_quad_mode(FLEXSPI_Type *base) __attribute__((section(".ram_functions")));
 status_t flexspi_nor_enable_quad_mode(FLEXSPI_Type *base) {
     flexspi_transfer_t flashXfer;
     status_t status;
@@ -135,7 +134,7 @@ status_t flexspi_nor_enable_quad_mode(FLEXSPI_Type *base) {
     return status;
 }
 
-status_t flexspi_nor_flash_erase_sector(FLEXSPI_Type *base, uint32_t address) __attribute__((section(".ram_functions"))) ;
+status_t flexspi_nor_flash_erase_sector(FLEXSPI_Type *base, uint32_t address) __attribute__((section(".ram_functions")));
 status_t flexspi_nor_flash_erase_sector(FLEXSPI_Type *base, uint32_t address) {
     status_t status;
     flexspi_transfer_t flashXfer;
@@ -166,7 +165,7 @@ status_t flexspi_nor_flash_erase_sector(FLEXSPI_Type *base, uint32_t address) {
     return status;
 }
 
-status_t flexspi_nor_flash_page_program(FLEXSPI_Type *base, uint32_t dstAddr, const uint32_t *src, uint32_t size) __attribute__((section(".ram_functions"))) ;
+status_t flexspi_nor_flash_page_program(FLEXSPI_Type *base, uint32_t dstAddr, const uint32_t *src, uint32_t size) __attribute__((section(".ram_functions")));
 status_t flexspi_nor_flash_page_program(FLEXSPI_Type *base, uint32_t dstAddr, const uint32_t *src, uint32_t size) {
     status_t status;
     flexspi_transfer_t flashXfer;
@@ -184,7 +183,7 @@ status_t flexspi_nor_flash_page_program(FLEXSPI_Type *base, uint32_t dstAddr, co
     flashXfer.cmdType = kFLEXSPI_Write;
     flashXfer.SeqNumber = 1;
     flashXfer.seqIndex = NOR_CMD_LUT_SEQ_IDX_PAGEPROGRAM_QUAD;
-    flashXfer.data = (uint32_t *) src;
+    flashXfer.data = (uint32_t *)src;
     flashXfer.dataSize = size;
     status = FLEXSPI_TransferBlocking(base, &flashXfer);
 
@@ -199,7 +198,7 @@ status_t flexspi_nor_flash_page_program(FLEXSPI_Type *base, uint32_t dstAddr, co
     return status;
 }
 
-status_t flexspi_nor_get_vendor_id(FLEXSPI_Type *base, uint8_t *vendorId) __attribute__((section(".ram_functions"))) ;
+status_t flexspi_nor_get_vendor_id(FLEXSPI_Type *base, uint8_t *vendorId) __attribute__((section(".ram_functions")));
 status_t flexspi_nor_get_vendor_id(FLEXSPI_Type *base, uint8_t *vendorId) {
     uint32_t temp;
     flexspi_transfer_t flashXfer;

--- a/tools/codeformat.py
+++ b/tools/codeformat.py
@@ -44,6 +44,7 @@ PATHS = [
     "shared/runtime/*.[ch]",
     "mpy-cross/*.[ch]",
     "ports/*/*.[ch]",
+    "ports/mimxrt/**/*.[ch]",
     "ports/windows/msvc/**/*.[ch]",
     "ports/nrf/modules/nrf/*.[ch]",
     "py/*.[ch]",


### PR DESCRIPTION
@robert-hh @alphaFred I realised that some of the code in mimxrt is not being caught by the auto-formatter.  We should fix this before more code is committed so that new code is formatted correctly.

I understand that some code in this port is copied from the NXP SDK, but it'd still be nice for consistency reasons to reformat it.  After all, if code needs to be copied from the SDK into the port then it's because it needs to be customised and so we are free to reformat it.

To minimise diff, an alternative to this PR is for all the new code in #7767 to be formatted correctly, then when formatting is enabled the diff will be smaller.