### PR TITLE
windows/thread: Add support for win32 micropython _thread.

### DIFF
--- a/ports/windows/Makefile
+++ b/ports/windows/Makefile
@@ -66,6 +66,7 @@ SRC_C = \
 	ports/unix/input.c \
 	ports/unix/gccollect.c \
 	windows_mphal.c \
+	mpthreadport.c \
 	realpath.c \
 	init.c \
 	fmode.c \

--- a/ports/windows/mpconfigport.h
+++ b/ports/windows/mpconfigport.h
@@ -158,6 +158,7 @@
 #define MICROPY_PY_MACHINE_INCLUDEFILE "ports/unix/modmachine.c"
 #define MICROPY_PY_MACHINE_PULSE    (1)
 #define MICROPY_PY_MACHINE_PIN_BASE (1)
+#define MICROPY_PY_THREAD           (1)
 #define MICROPY_MACHINE_MEM_GET_READ_ADDR   mod_machine_mem_get_addr
 #define MICROPY_MACHINE_MEM_GET_WRITE_ADDR  mod_machine_mem_get_addr
 

--- a/ports/windows/mpthreadport.c
+++ b/ports/windows/mpthreadport.c
@@ -1,0 +1,271 @@
+/*
+ * This file is part of the MicroPython project, http://micropython.org/
+ *
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2021 Andrew Leech
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <errno.h>
+
+#include "py/runtime.h"
+#include "py/mpthread.h"
+#include "py/gc.h"
+
+#if MICROPY_PY_THREAD
+
+#include <windows.h>
+#include "shared/runtime/gchelper.h"
+
+// This value seems to be about right for both 32-bit and 64-bit builds.
+#define THREAD_STACK_OVERFLOW_MARGIN (8192)
+
+// this structure forms a linked list, one node per active thread.
+typedef struct _thread_t {
+    DWORD id;               // system id of thread
+    HANDLE handle;          // handle of thread
+    int ready;              // whether the thread is ready and running
+    void *(*entry)(void *); // entrypoint, to be passed into thread wrapper
+    void *arg;              // thread Python args, a GC root pointer
+    struct _thread_t *next;
+} thread_t;
+
+static DWORD tls_key;
+static thread_t *thread;
+static HANDLE criticalSection = INVALID_HANDLE_VALUE;
+
+static DWORD wait_for_event(HANDLE event, bool wait) {
+    // WaitForSingleObjectEx will exit with WAIT_IO_COMPLETION when the thread
+    // runs an APC function (mp_thread_gc below) so we ignore this and wait
+    // for a normal event result.
+    DWORD ret = WAIT_IO_COMPLETION;
+    while (WAIT_IO_COMPLETION == ret) {
+        ret = WaitForSingleObjectEx(event, (wait)?INFINITE:0, TRUE);
+    }
+    return ret;
+}
+
+void mp_thread_windows_begin_atomic_section(void) {
+    if (criticalSection != INVALID_HANDLE_VALUE) {
+        wait_for_event(criticalSection, TRUE);
+    }
+}
+
+void mp_thread_windows_end_atomic_section(void) {
+    if (criticalSection != INVALID_HANDLE_VALUE) {
+        ReleaseMutex(criticalSection);
+    }
+}
+
+void mp_thread_init(void) {
+    tls_key = TlsAlloc();
+    TlsSetValue(tls_key, (LPVOID)&mp_state_ctx.thread);
+
+    // Needs to be a recursive mutex to emulate the behavior of
+    // BEGIN_ATOMIC_SECTION on bare metal. This is the default
+    // behavior of win32 Mutex and CriticalSection objects.
+    criticalSection = CreateMutex(NULL, FALSE, NULL);
+
+    // create first entry in linked list of all threads.
+    thread = malloc(sizeof(thread_t));
+    thread->id = GetCurrentThreadId();
+    thread->ready = 1;
+    thread->arg = NULL;
+    thread->next = NULL;
+
+    // The handle is used for running gc via QueueUserAPC below.
+    thread->handle = OpenThread(THREAD_SET_CONTEXT, FALSE, thread->id);
+}
+
+void mp_thread_deinit(void) {
+    mp_thread_windows_begin_atomic_section();
+    while (thread->next != NULL) {
+        thread_t *th = thread;
+        thread = thread->next;
+        TerminateThread(th->handle, -1);
+        CloseHandle(th->handle);
+        free(th);
+    }
+    mp_thread_windows_end_atomic_section();
+    assert(thread->id == GetCurrentThreadId());
+    CloseHandle(thread->handle);
+    free(thread);
+    CloseHandle(criticalSection);
+    criticalSection = INVALID_HANDLE_VALUE;
+}
+
+// this signal handler is used to scan the regs and stack of a thread.
+static void WINAPI mp_thread_gc(ULONG_PTR parameter) {
+    HANDLE thread_signal_done = (HANDLE)parameter;
+    gc_helper_collect_regs_and_stack();
+    #if MICROPY_ENABLE_PYSTACK
+    void **ptrs = (void **)(void *)MP_STATE_THREAD(pystack_start);
+    gc_collect_root(ptrs, (MP_STATE_THREAD(pystack_cur) - MP_STATE_THREAD(pystack_start)) / sizeof(void *));
+    #endif
+    SetEvent(thread_signal_done);
+}
+
+// This function scans all pointers that are external to the current thread.
+// It does this by signalling all other threads and getting them to scan their
+// own registers and stack.  Note that there may still be some edge cases left
+// with race conditions and root-pointer scanning: a given thread may manipulate
+// the global root pointers (in mp_state_ctx) while another thread is doing a
+// garbage collection and tracing these pointers.
+void mp_thread_gc_others(void) {
+    mp_thread_windows_begin_atomic_section();
+    for (thread_t *th = thread; th != NULL; th = th->next) {
+        gc_collect_root(&th->arg, 1);
+        if (th->id == GetCurrentThreadId()) {
+            continue;
+        }
+        if (!th->ready) {
+            continue;
+        }
+
+        // Used to signal when targeted thread gc is complete.
+        HANDLE thread_signal_done = CreateEvent(NULL, FALSE, FALSE, NULL);
+
+        // Run mp_thread_gc function on target thread (soon).
+        QueueUserAPC(mp_thread_gc, th->handle, (ULONG_PTR)thread_signal_done);
+
+        // wait for it to finish running.
+        wait_for_event(thread_signal_done, TRUE);
+        CloseHandle(thread_signal_done);
+    }
+    mp_thread_windows_end_atomic_section();
+}
+
+mp_state_thread_t *mp_thread_get_state(void) {
+    return (mp_state_thread_t *)TlsGetValue(tls_key);
+}
+
+void mp_thread_set_state(mp_state_thread_t *state) {
+    TlsSetValue(tls_key, (LPVOID)state);
+}
+
+mp_uint_t mp_thread_get_id(void) {
+    return (mp_uint_t)GetCurrentThreadId();
+}
+
+void mp_thread_start(void) {
+    mp_thread_windows_begin_atomic_section();
+    for (thread_t *th = thread; th != NULL; th = th->next) {
+        if (th->id == GetCurrentThreadId()) {
+            th->ready = 1;
+            break;
+        }
+    }
+    mp_thread_windows_end_atomic_section();
+}
+
+static DWORD WINAPI win32_entry(PVOID args) {
+    // Win32 threads require different function form to posix.
+    thread_t *th = (thread_t *)args;
+    th->entry(th->arg);
+    return 0;
+}
+
+mp_uint_t mp_thread_create(void *(*entry)(void *), void *arg, size_t *stack_size) {
+    // default stack size is 8k machine-words.
+    if (*stack_size == 0) {
+        *stack_size = 8192 * sizeof(void *);
+    }
+
+    // ensure there is enough stack to include a stack-overflow margin.
+    if (*stack_size < 2 * THREAD_STACK_OVERFLOW_MARGIN) {
+        *stack_size = 2 * THREAD_STACK_OVERFLOW_MARGIN;
+    }
+
+    mp_thread_windows_begin_atomic_section();
+
+    // create thread
+    DWORD id;
+
+    thread_t *th = malloc(sizeof(thread_t));
+    th->entry = entry;
+    th->arg = arg;
+
+    HANDLE thread_handle = CreateThread(NULL, *stack_size, win32_entry, th, 0, &id);
+
+    if (thread_handle == NULL) {
+        free(th);
+        mp_thread_windows_end_atomic_section();
+        goto er;
+    }
+
+    // adjust stack_size to provide room to recover from hitting the limit.
+    *stack_size -= THREAD_STACK_OVERFLOW_MARGIN;
+
+    // add thread to linked list of all threads.
+    th->id = id;
+    th->handle = thread_handle;
+    th->ready = 0;
+    th->next = thread;
+    thread = th;
+
+    mp_thread_windows_end_atomic_section();
+
+    return (mp_uint_t)id;
+
+er:
+    mp_raise_OSError(-1);
+}
+
+void mp_thread_finish(void) {
+    mp_thread_windows_begin_atomic_section();
+    thread_t *prev = NULL;
+    for (thread_t *th = thread; th != NULL; th = th->next) {
+        if (th->id == GetCurrentThreadId()) {
+            if (prev == NULL) {
+                thread = th->next;
+            } else {
+                prev->next = th->next;
+            }
+            CloseHandle(th->handle);
+            free(th);
+            break;
+        }
+        prev = th;
+    }
+    mp_thread_windows_end_atomic_section();
+}
+
+void mp_thread_mutex_init(mp_thread_mutex_t *mutex) {
+    // The win32 Mutex is re-entrant, unlike the posix equivalent.
+    // To avoid this a semaphore with size of 1 is used.
+    *mutex = CreateSemaphore(NULL, 1, 1, NULL);
+}
+
+int mp_thread_mutex_lock(mp_thread_mutex_t *mutex, int wait) {
+    if (wait_for_event(*mutex, wait) == 0) {
+        return 1;
+    } else {
+        return 0;
+    }
+}
+
+void mp_thread_mutex_unlock(mp_thread_mutex_t *mutex) {
+    ReleaseSemaphore(*mutex, 1, NULL);
+}
+
+#endif // MICROPY_PY_THREAD

--- a/ports/windows/mpthreadport.h
+++ b/ports/windows/mpthreadport.h
@@ -1,0 +1,36 @@
+/*
+ * This file is part of the MicroPython project, http://micropython.org/
+ *
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2021 Andrew Leech
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+typedef void *mp_thread_mutex_t;  // win32 HANDLE
+
+void mp_thread_init(void);
+void mp_thread_deinit(void);
+void mp_thread_gc_others(void);
+
+// Windows version of "enable/disable IRQs".
+// Functions as a port-global lock for any code that must be serialised.
+void mp_thread_windows_begin_atomic_section(void);
+void mp_thread_windows_end_atomic_section(void);

--- a/ports/windows/windows_mphal.c
+++ b/ports/windows/windows_mphal.c
@@ -268,6 +268,7 @@ void msec_sleep(double msec) {
     if (msec < 0.0) {
         msec = 0.0;
     }
+    // Use alertable sleep so APC functions (e.g. mp_thread_gc) can be delivered.
     SleepEx((DWORD)msec, TRUE);
 }
 

--- a/ports/windows/windows_mphal.h
+++ b/ports/windows/windows_mphal.h
@@ -27,13 +27,28 @@
 #include "sleep.h"
 #include "ports/unix/mphalport.h"
 
+// Override the unix atomic section macros with Windows versions.
+#if MICROPY_PY_THREAD
+#undef MICROPY_BEGIN_ATOMIC_SECTION
+#undef MICROPY_END_ATOMIC_SECTION
+#define MICROPY_BEGIN_ATOMIC_SECTION() (mp_thread_windows_begin_atomic_section(), 0xffffffff)
+#define MICROPY_END_ATOMIC_SECTION(x) (void)x; mp_thread_windows_end_atomic_section()
+#endif
+
 // Don't use the unix version of this macro.
 #undef MICROPY_INTERNAL_WFE
 
 #if MICROPY_ENABLE_SCHEDULER
 // Use minimum 1mSec sleep to make sure there is effectively a wait period:
 // something like usleep(500) truncates and ends up calling Sleep(0).
-#define MICROPY_INTERNAL_WFE(TIMEOUT_MS) msec_sleep(MAX(1.0, (double)(TIMEOUT_MS)))
+// Release the GIL during sleep so other threads can run, and use alertable
+// sleep so APC functions (e.g. for GC) can be delivered.
+#define MICROPY_INTERNAL_WFE(TIMEOUT_MS) \
+    do { \
+        MP_THREAD_GIL_EXIT(); \
+        msec_sleep(MAX(1.0, (double)(TIMEOUT_MS))); \
+        MP_THREAD_GIL_ENTER(); \
+    } while (0)
 #else
 #define MICROPY_INTERNAL_WFE(TIMEOUT_MS) /* No-op */
 #endif

--- a/tests/run-tests.py
+++ b/tests/run-tests.py
@@ -187,6 +187,10 @@ platform_tests_to_skip = {
         "micropython/extreme_exc.py",
         "micropython/heapalloc_exc_compressed_emg_exc.py",
     ),
+    "win32": (
+        "thread/thread_stacksize1.py",  # stack too small for debug builds
+        "thread/thread_stdin.py",  # stdin polling not supported in threads
+    ),
     "WiPy": (
         "misc/print_exception.py",  # requires error reporting full
     ),
@@ -873,7 +877,7 @@ def run_tests(pyb, tests, args, result_dir, num_threads=1):
     def run_one_test(test_file):
         test_file_abspath = os.path.abspath(test_file).replace("\\", "/")
         # If test_file is one of our own tests always make it relative to our tests/ dir and
-        # otherwise use the abosulte path, irregardless of actual path passed,
+        # otherwise use the absolute path, regardless of actual path passed,
         # such that display and result output is always the same.
         try:
             test_file_relpath = os.path.relpath(test_file, start=base_path())


### PR DESCRIPTION
This PR adds support for thread to the windows port with both mingw and msvc compilers.

Passes the test suite:
```
C:\Users\andrewleech\src\micropython\tests>py run-tests.py -d thread
pass  thread/mutate_bytearray.py
pass  thread/mutate_instance.py
pass  thread/stress_recurse.py
skip  thread/stress_schedule.py
pass  thread/thread_exc1.py
pass  thread/mutate_list.py
pass  thread/mutate_dict.py
pass  thread/thread_gc1.py
pass  thread/thread_heap_lock.py
pass  thread/thread_ident1.py
pass  thread/thread_lock1.py
pass  thread/mutate_set.py
pass  thread/stress_create.py
pass  thread/thread_exc2.py
pass  thread/thread_lock5.py
pass  thread/thread_lock3.py
pass  thread/thread_shared1.py
pass  thread/thread_shared2.py
pass  thread/thread_exit1.py
pass  thread/thread_stacksize1.py
pass  thread/thread_exit2.py
pass  thread/thread_lock2.py
pass  thread/thread_lock4.py
pass  thread/thread_qstr1.py
pass  thread/thread_start1.py
pass  thread/thread_start2.py
pass  thread/stress_heap.py
pass  thread/thread_sleep1.py
pass  thread/stress_aes.py
28 tests performed (141 individual testcases)
28 tests passed
1 tests skipped: stress_schedule
```