### PR TITLE
mimxrt: Implement machine.WDT() and machine.reset_cause().

### DIFF
--- a/ports/mimxrt/Makefile
+++ b/ports/mimxrt/Makefile
@@ -167,6 +167,7 @@ SRC_HAL_IMX_C += \
 	$(MCU_DIR)/drivers/fsl_pit.c \
 	$(MCU_DIR)/drivers/fsl_snvs_lp.c \
 	$(MCU_DIR)/drivers/fsl_trng.c \
+	$(MCU_DIR)/drivers/fsl_wdog.c \
 	$(MCU_DIR)/project_template/clock_config.c \
 	$(MCU_DIR)/system_$(MCU_SERIES).c \
 	$(MCU_DIR)/xip/fsl_flexspi_nor_boot.c \
@@ -196,6 +197,7 @@ SRC_C += \
 	machine_spi.c \
 	machine_timer.c \
 	machine_uart.c \
+	machine_wdt.c \
 	main.c \
 	mimxrt_flash.c \
 	mimxrt_sdram.c \
@@ -342,6 +344,7 @@ SRC_QSTR += \
 	machine_spi.c \
 	machine_timer.c \
 	machine_uart.c \
+	machine_wdt.c \
 	mimxrt_flash.c \
 	modmachine.c \
 	modmimxrt.c \

--- a/ports/mimxrt/machine_wdt.c
+++ b/ports/mimxrt/machine_wdt.c
@@ -1,0 +1,107 @@
+/*
+ * This file is part of the MicroPython project, http://micropython.org/
+ *
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2020-2021 Damien P. George
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#include "py/runtime.h"
+#include "modmachine.h"
+
+#include "fsl_wdog.h"
+
+#define MIN_TIMEOUT    (500)
+#define MAX_TIMEOUT    (128000)
+
+typedef struct _machine_wdt_obj_t {
+    mp_obj_base_t base;
+} machine_wdt_obj_t;
+
+STATIC const machine_wdt_obj_t machine_wdt = {{&machine_wdt_type}};
+
+STATIC mp_obj_t machine_wdt_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *all_args) {
+    enum { ARG_id, ARG_timeout };
+    static const mp_arg_t allowed_args[] = {
+        { MP_QSTR_id, MP_ARG_INT, {.u_int = 0} },
+        { MP_QSTR_timeout, MP_ARG_INT, {.u_int = 5000} },
+    };
+
+    // Parse the arguments.
+    mp_arg_val_t args[MP_ARRAY_SIZE(allowed_args)];
+    mp_arg_parse_all_kw_array(n_args, n_kw, all_args, MP_ARRAY_SIZE(allowed_args), allowed_args, args);
+
+    // Verify the WDT id.
+    mp_int_t id = args[ARG_id].u_int;
+    if (id != 0) {
+        mp_raise_msg_varg(&mp_type_ValueError, MP_ERROR_TEXT("WDT(%d) doesn't exist"), id);
+    }
+
+    // Start the watchdog (timeout is in milliseconds).
+    wdog_config_t config;
+    WDOG_GetDefaultConfig(&config);
+    uint32_t timeout = args[ARG_timeout].u_int;
+    // confine to the valid range
+    if (timeout < MIN_TIMEOUT) {
+        timeout = MIN_TIMEOUT;
+    } else if (timeout > MAX_TIMEOUT) {
+        timeout = MAX_TIMEOUT;
+    }
+    config.timeoutValue = (timeout / 500) - 1;
+    WDOG_Init(WDOG1, &config);
+
+    return MP_OBJ_FROM_PTR(&machine_wdt);
+}
+
+STATIC mp_obj_t machine_wdt_feed(mp_obj_t self_in) {
+    (void)self_in;
+    WDOG_Refresh(WDOG1);
+    return mp_const_none;
+}
+STATIC MP_DEFINE_CONST_FUN_OBJ_1(machine_wdt_feed_obj, machine_wdt_feed);
+
+STATIC mp_obj_t machine_wdt_timeout(mp_obj_t self_in, mp_obj_t timout_in) {
+    uint32_t timeout = mp_obj_get_int(timout_in);
+    // confine to the valid range
+    if (timeout < MIN_TIMEOUT) {
+        timeout = MIN_TIMEOUT;
+    } else if (timeout > MAX_TIMEOUT) {
+        timeout = MAX_TIMEOUT;
+    }
+    timeout = (timeout / 500) - 1;
+    WDOG_SetTimeoutValue(WDOG1, (uint16_t)timeout);
+    WDOG_Refresh(WDOG1);
+    return mp_const_none;
+}
+STATIC MP_DEFINE_CONST_FUN_OBJ_2(machine_wdt_timeout_obj, machine_wdt_timeout);
+
+STATIC const mp_rom_map_elem_t machine_wdt_locals_dict_table[] = {
+    { MP_ROM_QSTR(MP_QSTR_feed), MP_ROM_PTR(&machine_wdt_feed_obj) },
+    { MP_ROM_QSTR(MP_QSTR_timeout), MP_ROM_PTR(&machine_wdt_timeout_obj) },
+};
+STATIC MP_DEFINE_CONST_DICT(machine_wdt_locals_dict, machine_wdt_locals_dict_table);
+
+const mp_obj_type_t machine_wdt_type = {
+    { &mp_type_type },
+    .name = MP_QSTR_WDT,
+    .make_new = machine_wdt_make_new,
+    .locals_dict = (mp_obj_dict_t *)&machine_wdt_locals_dict,
+};

--- a/ports/mimxrt/machine_wdt.c
+++ b/ports/mimxrt/machine_wdt.c
@@ -78,7 +78,7 @@ STATIC mp_obj_t machine_wdt_feed(mp_obj_t self_in) {
 }
 STATIC MP_DEFINE_CONST_FUN_OBJ_1(machine_wdt_feed_obj, machine_wdt_feed);
 
-STATIC mp_obj_t machine_wdt_timeout(mp_obj_t self_in, mp_obj_t timout_in) {
+STATIC mp_obj_t machine_wdt_timeout_ms(mp_obj_t self_in, mp_obj_t timout_in) {
     uint32_t timeout = mp_obj_get_int(timout_in);
     // confine to the valid range
     if (timeout < MIN_TIMEOUT) {
@@ -91,11 +91,11 @@ STATIC mp_obj_t machine_wdt_timeout(mp_obj_t self_in, mp_obj_t timout_in) {
     WDOG_Refresh(WDOG1);
     return mp_const_none;
 }
-STATIC MP_DEFINE_CONST_FUN_OBJ_2(machine_wdt_timeout_obj, machine_wdt_timeout);
+STATIC MP_DEFINE_CONST_FUN_OBJ_2(machine_wdt_timeout_ms_obj, machine_wdt_timeout_ms);
 
 STATIC const mp_rom_map_elem_t machine_wdt_locals_dict_table[] = {
     { MP_ROM_QSTR(MP_QSTR_feed), MP_ROM_PTR(&machine_wdt_feed_obj) },
-    { MP_ROM_QSTR(MP_QSTR_timeout), MP_ROM_PTR(&machine_wdt_timeout_obj) },
+    { MP_ROM_QSTR(MP_QSTR_timeout_ms), MP_ROM_PTR(&machine_wdt_timeout_ms_obj) },
 };
 STATIC MP_DEFINE_CONST_DICT(machine_wdt_locals_dict, machine_wdt_locals_dict_table);
 

--- a/ports/mimxrt/modmachine.c
+++ b/ports/mimxrt/modmachine.c
@@ -36,14 +36,37 @@
 #include "pin.h"
 #include "modmachine.h"
 #include "fsl_clock.h"
+#include "fsl_wdog.h"
 
 #include CPU_HEADER_H
 
+typedef enum {
+    MP_PWRON_RESET = 1,
+    MP_HARD_RESET,
+    MP_WDT_RESET,
+    MP_DEEPSLEEP_RESET,
+    MP_SOFT_RESET
+} reset_reason_t;
+
 STATIC mp_obj_t machine_reset(void) {
-    NVIC_SystemReset();
+    WDOG_TriggerSystemSoftwareReset(WDOG1);
     return mp_const_none;
 }
 MP_DEFINE_CONST_FUN_OBJ_0(machine_reset_obj, machine_reset);
+
+STATIC mp_obj_t machine_reset_cause(void) {
+    uint16_t reset_cause =
+        WDOG_GetStatusFlags(WDOG1) & (kWDOG_PowerOnResetFlag | kWDOG_TimeoutResetFlag | kWDOG_SoftwareResetFlag);
+    if (reset_cause == kWDOG_PowerOnResetFlag) {
+        reset_cause = MP_PWRON_RESET;
+    } else if (reset_cause == kWDOG_TimeoutResetFlag) {
+        reset_cause = MP_WDT_RESET;
+    } else {
+        reset_cause = MP_SOFT_RESET;
+    }
+    return MP_OBJ_NEW_SMALL_INT(reset_cause);
+}
+STATIC MP_DEFINE_CONST_FUN_OBJ_0(machine_reset_cause_obj, machine_reset_cause);
 
 STATIC mp_obj_t machine_freq(void) {
     return MP_OBJ_NEW_SMALL_INT(mp_hal_get_cpu_freq());
@@ -72,6 +95,7 @@ MP_DEFINE_CONST_FUN_OBJ_1(machine_enable_irq_obj, machine_enable_irq);
 STATIC const mp_rom_map_elem_t machine_module_globals_table[] = {
     { MP_ROM_QSTR(MP_QSTR___name__),            MP_ROM_QSTR(MP_QSTR_umachine) },
     { MP_ROM_QSTR(MP_QSTR_reset),               MP_ROM_PTR(&machine_reset_obj) },
+    { MP_ROM_QSTR(MP_QSTR_reset_cause),         MP_ROM_PTR(&machine_reset_cause_obj) },
     { MP_ROM_QSTR(MP_QSTR_freq),                MP_ROM_PTR(&machine_freq_obj) },
     { MP_ROM_QSTR(MP_QSTR_mem8),                MP_ROM_PTR(&machine_mem8_obj) },
     { MP_ROM_QSTR(MP_QSTR_mem16),               MP_ROM_PTR(&machine_mem16_obj) },
@@ -92,7 +116,7 @@ STATIC const mp_rom_map_elem_t machine_module_globals_table[] = {
     { MP_ROM_QSTR(MP_QSTR_I2C),                 MP_ROM_PTR(&machine_i2c_type) },
     { MP_ROM_QSTR(MP_QSTR_SPI),                 MP_ROM_PTR(&machine_spi_type) },
     { MP_ROM_QSTR(MP_QSTR_UART),                MP_ROM_PTR(&machine_uart_type) },
-
+    { MP_ROM_QSTR(MP_QSTR_WDT),                 MP_ROM_PTR(&machine_wdt_type) },
     { MP_ROM_QSTR(MP_QSTR_idle),                MP_ROM_PTR(&machine_idle_obj) },
 
     { MP_ROM_QSTR(MP_QSTR_disable_irq),         MP_ROM_PTR(&machine_disable_irq_obj) },
@@ -102,6 +126,12 @@ STATIC const mp_rom_map_elem_t machine_module_globals_table[] = {
     { MP_ROM_QSTR(MP_QSTR_bitstream),           MP_ROM_PTR(&machine_bitstream_obj) },
     #endif
     { MP_ROM_QSTR(MP_QSTR_time_pulse_us),       MP_ROM_PTR(&machine_time_pulse_us_obj) },
+
+    // Reset reasons
+    { MP_ROM_QSTR(MP_QSTR_PWRON_RESET),         MP_ROM_INT(MP_PWRON_RESET) },
+    { MP_ROM_QSTR(MP_QSTR_WDT_RESET),           MP_ROM_INT(MP_WDT_RESET) },
+    { MP_ROM_QSTR(MP_QSTR_SOFT_RESET),          MP_ROM_INT(MP_SOFT_RESET) },
+
 };
 STATIC MP_DEFINE_CONST_DICT(machine_module_globals, machine_module_globals_table);
 

--- a/ports/mimxrt/modmachine.h
+++ b/ports/mimxrt/modmachine.h
@@ -30,12 +30,13 @@
 #include "py/obj.h"
 
 extern const mp_obj_type_t machine_adc_type;
-extern const mp_obj_type_t machine_timer_type;
-extern const mp_obj_type_t machine_rtc_type;
 extern const mp_obj_type_t machine_i2c_type;
-extern const mp_obj_type_t machine_spi_type;
-extern const mp_obj_type_t machine_uart_type;
+extern const mp_obj_type_t machine_rtc_type;
 extern const mp_obj_type_t machine_sdcard_type;
+extern const mp_obj_type_t machine_spi_type;
+extern const mp_obj_type_t machine_timer_type;
+extern const mp_obj_type_t machine_uart_type;
+extern const mp_obj_type_t machine_wdt_type;
 
 void machine_adc_init(void);
 void machine_pin_irq_deinit(void);


### PR DESCRIPTION
The API follows those of rp2, stm32, esp32.

wdt=machine.WDT(0, timeout)
    timeout is given in ms. The valid range is 500 to 128000
    (128 seconds) with 500 ms granularity. Values outside of that
    range will be silently aligned.

wdt.feed()
    Resets the watchdog timer (feeding).

wdt.timeout(value)
    Sets a new timeout and feeds the watchdog.

reset_cause = machine.reset_cause()
    values returned:
    1  Power-On reset
    3  Watchdog reset
    5  Software reset: state after calling machine.reset()
