### PR TITLE
stm32/dma: Add functions for external users of DMA to enable clock.

### DIFF
--- a/ports/stm32/dma.c
+++ b/ports/stm32/dma.c
@@ -1233,3 +1233,13 @@ void dma_nohal_start(const dma_descr_t *descr, uint32_t src_addr, uint32_t dst_a
 }
 
 #endif
+
+#define DMA_ID_FROM_CONTROLLER_STREAM(c, s) ((s) + (c) * NSTREAMS_PER_CONTROLLER)
+
+void dma_external_acquire(uint32_t controller, uint32_t stream) {
+    dma_enable_clock(DMA_ID_FROM_CONTROLLER_STREAM(controller, stream));
+}
+
+void dma_external_release(uint32_t controller, uint32_t stream) {
+    dma_disable_clock(DMA_ID_FROM_CONTROLLER_STREAM(controller, stream));
+}

--- a/ports/stm32/dma.h
+++ b/ports/stm32/dma.h
@@ -102,13 +102,21 @@ extern const dma_descr_t dma_I2C_4_RX;
 
 #endif
 
+// API that configures the DMA via the HAL.
 void dma_init(DMA_HandleTypeDef *dma, const dma_descr_t *dma_descr, uint32_t dir, void *data);
 void dma_init_handle(DMA_HandleTypeDef *dma, const dma_descr_t *dma_descr, uint32_t dir, void *data);
 void dma_deinit(const dma_descr_t *dma_descr);
 void dma_invalidate_channel(const dma_descr_t *dma_descr);
 
+// API that configures the DMA directly and does not use the HAL.
 void dma_nohal_init(const dma_descr_t *descr, uint32_t config);
 void dma_nohal_deinit(const dma_descr_t *descr);
 void dma_nohal_start(const dma_descr_t *descr, uint32_t src_addr, uint32_t dst_addr, uint16_t len);
+
+// API to be used if DMA is controlled externally, to ensure the clock remains enabled.
+// - controller: should be 0 or 1, corresponding to DMA1 or DMA2
+// - stream: should be 0 to N, corresponding to Stream0..StreamN, or Channel1..ChannelN
+void dma_external_acquire(uint32_t controller, uint32_t stream);
+void dma_external_release(uint32_t controller, uint32_t stream);
 
 #endif // MICROPY_INCLUDED_STM32_DMA_H


### PR DESCRIPTION
Any external user of DMA (eg a board with a custom DMA driver) must call dma_external_acquire() for their DMA controller/stream to ensure that the DMA clock is not automatically turned off while it's still being used
externally.
