### PR TITLE
tests: Add extra gc coverage test.

### DIFF
--- a/ports/unix/main.c
+++ b/ports/unix/main.c
@@ -542,8 +542,10 @@ MP_NOINLINE int main_(int argc, char **argv) {
     #if defined(MICROPY_UNIX_COVERAGE)
     {
         MP_DECLARE_CONST_FUN_OBJ_0(extra_coverage_obj);
+        MP_DECLARE_CONST_FUN_OBJ_0(extra_coverage_gc_obj);
         MP_DECLARE_CONST_FUN_OBJ_0(extra_cpp_coverage_obj);
         mp_store_global(MP_QSTR_extra_coverage, MP_OBJ_FROM_PTR(&extra_coverage_obj));
+        mp_store_global(MP_QSTR_extra_coverage_gc, MP_OBJ_FROM_PTR(&extra_coverage_gc_obj));
         mp_store_global(MP_QSTR_extra_cpp_coverage, MP_OBJ_FROM_PTR(&extra_cpp_coverage_obj));
     }
     #endif

--- a/py/gc.c
+++ b/py/gc.c
@@ -193,8 +193,8 @@ bool gc_is_locked(void) {
 // ptr should be of type void*
 #define VERIFY_PTR(ptr) ( \
     ((uintptr_t)(ptr) & (BYTES_PER_BLOCK - 1)) == 0          /* must be aligned on a block */ \
-    && ptr >= (void *)MP_STATE_MEM(gc_pool_start)        /* must be above start of pool */ \
-    && ptr < (void *)MP_STATE_MEM(gc_pool_end)           /* must be below end of pool */ \
+    && (void *)(ptr) >= (void *)MP_STATE_MEM(gc_pool_start)        /* must be above start of pool */ \
+    && (void *)(ptr) < (void *)MP_STATE_MEM(gc_pool_end)           /* must be below end of pool */ \
     )
 
 #ifndef TRACE_MARK
@@ -221,6 +221,8 @@ STATIC void gc_mark_subtree(size_t block) {
 
         // check this block's children
         void **ptrs = (void **)PTR_FROM_BLOCK(block);
+        assert(VERIFY_PTR(ptrs + (n_blocks - 1) * BYTES_PER_BLOCK / sizeof(void *)));
+
         for (size_t i = n_blocks * BYTES_PER_BLOCK / sizeof(void *); i > 0; i--, ptrs++) {
             void *ptr = *ptrs;
             if (VERIFY_PTR(ptr)) {

--- a/tests/unix/extra_coverage.py
+++ b/tests/unix/extra_coverage.py
@@ -99,3 +99,5 @@ print(buf.read(21))
 from frzqstr import returns_NULL
 
 print(returns_NULL())
+
+extra_coverage_gc()

--- a/tests/unix/extra_coverage.py.exp
+++ b/tests/unix/extra_coverage.py.exp
@@ -176,3 +176,4 @@ frzmpy_pkg2.mod
 ZeroDivisionError
 b'# test frozen package'
 NULL
+# end coverage.c gc test


### PR DESCRIPTION
This test must be separate from the "regular" coverage test, as it
destroys the gc heap, and must exit via exit() rather than returning
to python code.

This test fails due to #7716.

I'm creating this as a separate PR so that Appveyor can run on it and hopefully help diagnose whether it is this change or another part of the change that introduces the NLR-related test failure.

Signed-off-by: Jeff Epler <jepler@gmail.com>