### PR TITLE
esp32/mpthreadport: Fix TCB cleanup function don't check thread_mutex BUG.

### DIFF
--- a/ports/esp32/mpthreadport.c
+++ b/ports/esp32/mpthreadport.c
@@ -59,14 +59,18 @@ STATIC thread_t *thread = NULL; // root pointer, handled by mp_thread_gc_others
 void mp_thread_init(void *stack, uint32_t stack_len) {
     mp_thread_set_state(&mp_state_ctx.thread);
     // create the first entry in the linked list of all threads
-    thread = &thread_entry0;
-    thread->id = xTaskGetCurrentTaskHandle();
-    thread->ready = 1;
-    thread->arg = NULL;
-    thread->stack = stack;
-    thread->stack_len = stack_len;
-    thread->next = NULL;
+    thread_entry0.id = xTaskGetCurrentTaskHandle();
+    thread_entry0.ready = 1;
+    thread_entry0.arg = NULL;
+    thread_entry0.stack = stack;
+    thread_entry0.stack_len = stack_len;
+    thread_entry0.next = NULL;
     mp_thread_mutex_init(&thread_mutex);
+
+    // memory barrier
+    __sync_synchronize();
+    // vPortCleanUpTCB need the thread ready after thread_mutex
+    thread = &thread_entry0;
 }
 
 void mp_thread_gc_others(void) {


### PR DESCRIPTION
Hi,
    
when i modify the esp32 configs:

    CONFIG_PM_ENABLE=n
    CONFIG_FREERTOS_USE_TICKLESS_IDLE=n

the system crash with error:

> 	I (1520) cpu_start: Starting scheduler on PRO CPU.
> 	I (0) cpu_start: Starting scheduler on APP CPU.
> 	esp-idf/components/freertos/queue.c:1462 (xQueueGenericReceive)- assert failed!
> 
> 	abort() was called at PC 0x4008db6c on core 0

   
It found that it crash by mp_thread_mutex_lock(&thread_mutex, 1)  in vPortCleanUpTCB 
function in ports/esp32/mpthreadport.c.

Because vPortCleanUpTCB called by FreeRTOS idle task, and it checked thread variable, but forgot check the thread_mutex variable.  And if thread is not NULL, but thread_mutex not ready then it will crash with error when call mp_thread_mutex_lock(&thread_mutex, 1):

And i verify this by add this code in vPortCleanUpTCB :

    printf("%p %p %s\n", thread, thread_mutex.handle, pcTaskGetTaskName((TaskHandle_t)tcb));

and print this:

    0x3ffb3c14 0x0 dport

So maybe i turnoff FreeRTOS tickless idle task option , and idle task call vPortCleanUpTCB when mp_thread_init  is running and cause the error.

Signed-off-by: leo chung <gewalalb@gmail.com>