### PR TITLE
extmod/modlwip: Added support for leaving multicast groups.

### DIFF
--- a/extmod/modlwip.c
+++ b/extmod/modlwip.c
@@ -64,6 +64,7 @@
 // All socket options should be globally distinct,
 // because we ignore option levels for efficiency.
 #define IP_ADD_MEMBERSHIP 0x400
+#define IP_DROP_MEMBERSHIP 0x401
 
 // For compatibilily with older lwIP versions.
 #ifndef ip_set_option
@@ -1384,6 +1385,22 @@ STATIC mp_obj_t lwip_socket_setsockopt(size_t n_args, const mp_obj_t *args) {
             break;
         }
 
+        // level: IPPROTO_IP
+        case IP_DROP_MEMBERSHIP: {
+            mp_buffer_info_t bufinfo;
+            mp_get_buffer_raise(args[3], &bufinfo, MP_BUFFER_READ);
+            if (bufinfo.len != sizeof(ip_addr_t) * 2) {
+                mp_raise_ValueError(NULL);
+            }
+
+            // POSIX setsockopt has order: group addr, if addr, lwIP has it vice-versa
+            err_t err = igmp_leavegroup((ip_addr_t *)bufinfo.buf + 1, bufinfo.buf);
+            if (err != ERR_OK) {
+                mp_raise_OSError(error_lookup_table[-err]);
+            }
+            break;
+        }
+
         default:
             printf("Warning: lwip.setsockopt() not implemented\n");
     }
@@ -1764,6 +1781,7 @@ STATIC const mp_rom_map_elem_t mp_module_lwip_globals_table[] = {
 
     { MP_ROM_QSTR(MP_QSTR_IPPROTO_IP), MP_ROM_INT(0) },
     { MP_ROM_QSTR(MP_QSTR_IP_ADD_MEMBERSHIP), MP_ROM_INT(IP_ADD_MEMBERSHIP) },
+    { MP_ROM_QSTR(MP_QSTR_IP_DROP_MEMBERSHIP), MP_ROM_INT(IP_DROP_MEMBERSHIP) },
 };
 
 STATIC MP_DEFINE_CONST_DICT(mp_module_lwip_globals, mp_module_lwip_globals_table);


### PR DESCRIPTION
## Leaving multicast groups

Added support for `IP_DROP_MEMBERSHIP` so you can now properly leave your multicast groups. I found it useful when changing from AP to STA mode for example. `lwip` (at least on esp8266) has this method already implemented so I don't see a reason why MicroPython doesn't expose it.

### Example
```python
self._srv_sock.setsockopt(socket.IPPROTO_IP, socket.IP_ADD_MEMBERSHIP, _aton(grp))
...
self._srv_sock.setsockopt(socket.IPPROTO_IP, socket.IP_DROP_MEMBERSHIP, _aton(grp))
```

### It works!
![Screenshot_20210916_195711](https://user-images.githubusercontent.com/7581790/133661528-85c84504-bee5-4b80-9c4d-3db4e918aa0c.png)

