### PR TITLE
ports/esp32: Fixed HW SPI for S2/S3.

### DIFF
--- a/ports/esp32/machine_hw_spi.c
+++ b/ports/esp32/machine_hw_spi.c
@@ -55,6 +55,9 @@
 
 #if CONFIG_IDF_TARGET_ESP32C3
 #define HSPI_HOST SPI2_HOST
+#elif CONFIG_IDF_TARGET_ESP32S3
+#define HSPI_HOST SPI3_HOST
+#define FSPI_HOST SPI2_HOST
 #endif
 
 typedef struct _machine_hw_spi_default_pins_t {
@@ -193,6 +196,9 @@ STATIC void machine_hw_spi_init_internal(
     }
 
     if (self->host != HSPI_HOST
+        #ifdef FSPI_HOST
+        && self->host != FSPI_HOST
+        #endif
         #ifdef VSPI_HOST
         && self->host != VSPI_HOST
         #endif
@@ -231,7 +237,15 @@ STATIC void machine_hw_spi_init_internal(
     // Select DMA channel based on the hardware SPI host
     int dma_chan = 0;
     if (self->host == HSPI_HOST) {
+        #if CONFIG_IDF_TARGET_ESP32S2 || CONFIG_IDF_TARGET_ESP32S3
+        dma_chan = 3;
+        #else
         dma_chan = 1;
+        #endif
+    #ifdef FSPI_HOST
+    } else if (self->host == FSPI_HOST) {
+        dma_chan = 1;
+    #endif
     #ifdef VSPI_HOST
     } else if (self->host == VSPI_HOST) {
         dma_chan = 2;


### PR DESCRIPTION
Added missing HW SPI channel for S2/S3 and fixed wrong DMA channel assignment for S2/S3 that prevented `any` HW SPI from working :(