### PR TITLE
ports/esp32: Updated readme with req IDF vers for ESP32-S2, C3 and S3.

### DIFF
--- a/ports/esp32/README.md
+++ b/ports/esp32/README.md
@@ -75,6 +75,11 @@ $ source export.sh   # (or export.bat on Windows)
 The `install.sh` step only needs to be done once. You will need to source
 `export.sh` for every new session.
 
+**Note:** If you are building MicroPython for the ESP32-S2, ESP32-C3 or ESP32-S3, please ensure you are using the following required IDF versions:
+- ESP32-S3 currently requires `Latest master`, but eventually `v4.4` or later when it's available
+- ESP32-S2 & ESP32-C3 require `v4.3.1` or later
+
+
 Building the firmware
 ---------------------
 


### PR DESCRIPTION
Added a note in the readme that states the require minimum IDF versions when building S2, C3 and S3 firmware.