### PR TITLE
ports/esp32: Added HOST connection detection for CDC.

### DIFF
--- a/ports/esp32/usb.c
+++ b/ports/esp32/usb.c
@@ -36,6 +36,7 @@
 #define CDC_ITF TINYUSB_CDC_ACM_0
 
 static uint8_t usb_rx_buf[CONFIG_USB_CDC_RX_BUFSIZE];
+static uint8_t usb_cdc_connected;
 
 static void usb_callback_rx(int itf, cdcacm_event_t *event) {
     // TODO: what happens if more chars come in during this function, are they lost?
@@ -58,6 +59,13 @@ static void usb_callback_rx(int itf, cdcacm_event_t *event) {
     }
 }
 
+void usb_callback_line_state_changed(int itf, cdcacm_event_t *event) {
+    int dtr = event->line_state_changed_data.dtr;
+    int rts = event->line_state_changed_data.rts;
+    // If dtr && rts are both true, the CDC is connected to a HOST.
+    usb_cdc_connected = dtr && rts;
+}
+
 void usb_init(void) {
     // Initialise the USB with defaults.
     tinyusb_config_t tusb_cfg = {0};
@@ -70,13 +78,20 @@ void usb_init(void) {
         .rx_unread_buf_sz = 256,
         .callback_rx = &usb_callback_rx,
         .callback_rx_wanted_char = NULL,
-        .callback_line_state_changed = NULL,
+        .callback_line_state_changed = &usb_callback_line_state_changed,
         .callback_line_coding_changed = NULL
     };
+    usb_cdc_connected = 0;
     ESP_ERROR_CHECK(tusb_cdc_acm_init(&amc_cfg));
+
 }
 
 void usb_tx_strn(const char *str, size_t len) {
+    // If no HOST is connected, we can exit this early.
+    if (usb_cdc_connected == 0) {
+        return;
+    }
+
     while (len) {
         size_t l = len;
         if (l > CONFIG_USB_CDC_TX_BUFSIZE) {


### PR DESCRIPTION
This call back allows us to detect if there is a HOST connected to the CDC or not, so we can skip CDC TX writing and flushing if there is no HOST is connected.

This fixes the issue raised in https://github.com/micropython/micropython/issues/7820

I've tested this on my FeatherS2 and FeatherS2 Neo. 