### PR TITLE
rp2: Enable optimisations (comp goto, map cache, fast attr).

### DIFF
--- a/ports/rp2/mpconfigport.h
+++ b/ports/rp2/mpconfigport.h
@@ -55,16 +55,11 @@
 #define MICROPY_EMIT_INLINE_THUMB_FLOAT         (0)
 #define MICROPY_EMIT_INLINE_THUMB_ARMV7M        (0)
 
+// Optimisations
+#define MICROPY_OPT_COMPUTED_GOTO               (1)
+
 // Features currently overriden for rp2, planned to be brought in line with
 // other ports
-#define MICROPY_COMP_MODULE_CONST               (0)
-#define MICROPY_COMP_RETURN_IF_EXPR             (0)
-#define MICROPY_COMP_TRIPLE_TUPLE_ASSIGN        (0)
-#define MICROPY_OPT_COMPUTED_GOTO               (0)
-#define MICROPY_OPT_LOAD_ATTR_FAST_PATH         (0)
-#define MICROPY_OPT_MAP_LOOKUP_CACHE            (0)
-#define MICROPY_OPT_MATH_FACTORIAL              (0)
-#define MICROPY_OPT_MPZ_BITWISE                 (0)
 #define MICROPY_PY_BUILTINS_EXECFILE            (0)
 #define MICROPY_PY_BUILTINS_NOTIMPLEMENTED      (0)
 #define MICROPY_REPL_EMACS_KEYS                 (0)


### PR DESCRIPTION
Computed goto costs 1800 bytes for 5-10% performance.

```
$ ./run-perfbench.py -s ~/compgoto-off-rp2 ~/compgoto-on-rp2 
diff of scores (higher is better)
N=100 M=100              /home/jimmo/compgoto-off-rp2 -> /home/jimmo/compgoto-on-rp2         diff      diff% (error%)
bm_chaos.py                  159.47 ->     167.86 :      +8.39 =  +5.261% (+/-0.07%)
bm_fannkuch.py                49.80 ->      55.34 :      +5.54 = +11.124% (+/-0.01%)
bm_fft.py                   1370.25 ->    1559.98 :    +189.73 = +13.846% (+/-0.01%)
bm_float.py                 2811.09 ->    2984.77 :    +173.68 =  +6.178% (+/-0.07%)
bm_hexiom.py                  17.48 ->      18.16 :      +0.68 =  +3.890% (+/-0.04%)
bm_nqueens.py               2134.58 ->    2274.90 :    +140.32 =  +6.574% (+/-0.06%)
bm_pidigits.py               376.14 ->     383.19 :      +7.05 =  +1.874% (+/-0.04%)
misc_aes.py                  199.79 ->     220.60 :     +20.81 = +10.416% (+/-0.09%)
misc_mandel.py              1479.88 ->    1552.32 :     +72.44 =  +4.895% (+/-0.06%)
misc_pystone.py              862.53 ->     909.40 :     +46.87 =  +5.434% (+/-0.10%)
misc_raytrace.py             166.27 ->     173.05 :      +6.78 =  +4.078% (+/-0.06%)
```

Map caching and attr fast path costs 130 bytes for up to 30% (on top of computed goto)

```
$ ./run-perfbench.py -s ~/compgoto-on-rp2 ~/compgoto-on-mapattr-rp2 
diff of scores (higher is better)
N=100 M=100              /home/jimmo/compgoto-on-rp2 -> /home/jimmo/compgoto-on-mapattr-rp2         diff      diff% (error%)
bm_chaos.py                  167.86 ->     185.08 :     +17.22 = +10.259% (+/-0.09%)
bm_fannkuch.py                55.34 ->      55.35 :      +0.01 =  +0.018% (+/-0.01%)
bm_fft.py                   1559.98 ->    1570.36 :     +10.38 =  +0.665% (+/-0.01%)
bm_float.py                 2984.77 ->    3565.83 :    +581.06 = +19.467% (+/-0.09%)
bm_hexiom.py                  18.16 ->      23.43 :      +5.27 = +29.020% (+/-0.04%)
bm_nqueens.py               2274.90 ->    2525.92 :    +251.02 = +11.034% (+/-0.07%)
bm_pidigits.py               383.19 ->     392.96 :      +9.77 =  +2.550% (+/-0.04%)
misc_aes.py                  220.60 ->     257.26 :     +36.66 = +16.618% (+/-0.06%)
misc_mandel.py              1552.32 ->    1881.16 :    +328.84 = +21.184% (+/-0.06%)
misc_pystone.py              909.40 ->    1210.12 :    +300.72 = +33.068% (+/-0.19%)
misc_raytrace.py             173.05 ->     204.20 :     +31.15 = +18.001% (+/-0.06%)
```

Net effect of this PR is:

```
$ ./run-perfbench.py -s ~/compgoto-off-rp2 ~/compgoto-on-mapattr-rp2 
diff of scores (higher is better)
N=100 M=100              /home/jimmo/compgoto-off-rp2 -> /home/jimmo/compgoto-on-mapattr-rp2         diff      diff% (error%)
bm_chaos.py                  159.47 ->     185.08 :     +25.61 = +16.059% (+/-0.09%)
bm_fannkuch.py                49.80 ->      55.35 :      +5.55 = +11.145% (+/-0.01%)
bm_fft.py                   1370.25 ->    1570.36 :    +200.11 = +14.604% (+/-0.01%)
bm_float.py                 2811.09 ->    3565.83 :    +754.74 = +26.849% (+/-0.08%)
bm_hexiom.py                  17.48 ->      23.43 :      +5.95 = +34.039% (+/-0.03%)
bm_nqueens.py               2134.58 ->    2525.92 :    +391.34 = +18.333% (+/-0.06%)
bm_pidigits.py               376.14 ->     392.96 :     +16.82 =  +4.472% (+/-0.03%)
misc_aes.py                  199.79 ->     257.26 :     +57.47 = +28.765% (+/-0.09%)
misc_mandel.py              1479.88 ->    1881.16 :    +401.28 = +27.116% (+/-0.05%)
misc_pystone.py              862.53 ->    1210.12 :    +347.59 = +40.299% (+/-0.20%)
misc_raytrace.py             166.27 ->     204.20 :     +37.93 = +22.812% (+/-0.07%)
```