### PR TITLE
stm32/machine_i2c: Use hardware I2C for STM32H7.

### DIFF
--- a/ports/stm32/i2c.c
+++ b/ports/stm32/i2c.c
@@ -268,7 +268,12 @@ int i2c_write(i2c_t *i2c, const uint8_t *src, size_t len, size_t next_len) {
     return num_acks;
 }
 
-#elif defined(STM32F0) || defined(STM32F7)
+#elif defined(STM32F0) || defined(STM32F7) || defined(STM32H7)
+
+#if defined(STM32H7)
+#define APB1ENR            APB1LENR
+#define RCC_APB1ENR_I2C1EN RCC_APB1LENR_I2C1EN
+#endif
 
 STATIC uint16_t i2c_timeout_ms[MICROPY_HW_MAX_I2C];
 
@@ -468,7 +473,7 @@ int i2c_write(i2c_t *i2c, const uint8_t *src, size_t len, size_t next_len) {
 
 #endif
 
-#if defined(STM32F0) || defined(STM32F4) || defined(STM32F7)
+#if defined(STM32F0) || defined(STM32F4) || defined(STM32F7) || defined(STM32H7)
 
 int i2c_readfrom(i2c_t *i2c, uint16_t addr, uint8_t *dest, size_t len, bool stop) {
     int ret;

--- a/ports/stm32/machine_i2c.c
+++ b/ports/stm32/machine_i2c.c
@@ -38,7 +38,7 @@
 
 #define I2C_POLL_DEFAULT_TIMEOUT_US (50000) // 50ms
 
-#if defined(STM32F0) || defined(STM32F4) || defined(STM32F7)
+#if defined(STM32F0) || defined(STM32F4) || defined(STM32F7) || defined(STM32H7)
 
 typedef struct _machine_hard_i2c_obj_t {
     mp_obj_base_t base;


### PR DESCRIPTION
I don't see any reason why the HW I2C code can't be used for the H7, I tested scan, read and write with an RTC and seems to be working fine, please let me know if there are more tests to do.. Note for the 1MHz case (FM+) to work some bits need to be set in SYSCFG PMC register per peripheral/pin to enable it for the STM32F76x, STM32F77x and all H7s.