### PR TITLE
extmod/nimble: Update to NimBLE v1.4 (and use MicroPython fork).

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -28,7 +28,7 @@
 	url = https://github.com/hathach/tinyusb
 [submodule "lib/mynewt-nimble"]
 	path = lib/mynewt-nimble
-	url = https://github.com/apache/mynewt-nimble.git
+	url = https://github.com/micropython/mynewt-nimble.git
 [submodule "lib/btstack"]
 	path = lib/btstack
 	url = https://github.com/bluekitchen/btstack.git

--- a/extmod/nimble/modbluetooth_nimble.c
+++ b/extmod/nimble/modbluetooth_nimble.c
@@ -1747,12 +1747,6 @@ int mp_bluetooth_l2cap_send(uint16_t conn_handle, uint16_t cid, const uint8_t *b
         *stalled = true;
     }
 
-    // Sometimes we see what looks like BLE_HS_EAGAIN (but it's actually
-    // OS_ENOMEM in disguise). Fixed in NimBLE v1.4.
-    if (err == OS_ENOMEM) {
-        err = BLE_HS_ENOMEM;
-    }
-
     // Other error codes such as BLE_HS_EBUSY (we're stalled) or BLE_HS_EBADDATA (bigger than MTU).
     return ble_hs_err_to_errno(err);
 }

--- a/extmod/nimble/nimble/nimble_npl_os.h
+++ b/extmod/nimble/nimble/nimble_npl_os.h
@@ -35,7 +35,11 @@
 // --- Configuration of NimBLE data structures --------------------------------
 
 // This is used at runtime to align allocations correctly.
-#define BLE_NPL_OS_ALIGNMENT (sizeof(uintptr_t))
+#if __WORDSIZE == 64
+#define BLE_NPL_OS_ALIGNMENT 8
+#else
+#define BLE_NPL_OS_ALIGNMENT 4
+#endif
 #define BLE_NPL_TIME_FOREVER (0xffffffff)
 
 // This is used at compile time to force struct member alignment. See


### PR DESCRIPTION
We need to implement a few features in NimBLE (that will hopefully eventually be upstreamed) such as host-side private addressing (for PYBD) and GATT database hashing. A new fork of NimBLE has been created in the micropython org, and this PR updates the submodule to point at it.

While we're here, might as well update to the latest release (v1.4). There are no specific fixes or features of note for MicroPython, but if we're going to be adding features, we might as well do it on the latest version. We have two additional commits to make it work in MicroPython, see https://github.com/apache/mynewt-nimble/pull/998 for background.

The changes to modbluetooth_nimble.c are because the registration for the secret store has been simplified.