### PR TITLE
esp32: Split out WLAN code from modnetwork.c to network_wlan.c.

### DIFF
--- a/ports/esp32/main/CMakeLists.txt
+++ b/ports/esp32/main/CMakeLists.txt
@@ -67,6 +67,7 @@ set(MICROPY_SOURCE_PORT
     ${PROJECT_DIR}/modnetwork.c
     ${PROJECT_DIR}/network_lan.c
     ${PROJECT_DIR}/network_ppp.c
+    ${PROJECT_DIR}/network_wlan.c
     ${PROJECT_DIR}/mpnimbleport.c
     ${PROJECT_DIR}/modsocket.c
     ${PROJECT_DIR}/modesp.c

--- a/ports/esp32/modnetwork.c
+++ b/ports/esp32/modnetwork.c
@@ -31,28 +31,16 @@
  * THE SOFTWARE.
  */
 
-#include <stdio.h>
-#include <stdint.h>
 #include <string.h>
 
-#include "py/nlr.h"
-#include "py/objlist.h"
 #include "py/runtime.h"
-#include "py/mphal.h"
 #include "py/mperrno.h"
 #include "shared/netutils/netutils.h"
-#include "esp_eth.h"
+#include "modnetwork.h"
+
 #include "esp_wifi.h"
 #include "esp_log.h"
 #include "lwip/dns.h"
-#include "mdns.h"
-
-#if !MICROPY_ESP_IDF_4
-#include "esp_wifi_types.h"
-#include "esp_event_loop.h"
-#endif
-
-#include "modnetwork.h"
 
 #if ESP_IDF_VERSION < ESP_IDF_VERSION_VAL(4, 1, 0)
 #define DNS_MAIN TCPIP_ADAPTER_DNS_MAIN
@@ -62,7 +50,7 @@
 
 #define MODNETWORK_INCLUDE_CONSTANTS (1)
 
-NORETURN void _esp_exceptions(esp_err_t e) {
+NORETURN void esp_exceptions_helper(esp_err_t e) {
     switch (e) {
         case ESP_ERR_WIFI_NOT_INIT:
             mp_raise_msg(&mp_type_OSError, MP_ERROR_TEXT("Wifi Not Initialized"));
@@ -107,122 +95,16 @@ NORETURN void _esp_exceptions(esp_err_t e) {
     }
 }
 
-static inline void esp_exceptions(esp_err_t e) {
-    if (e != ESP_OK) {
-        _esp_exceptions(e);
-    }
-}
-
-#define ESP_EXCEPTIONS(x) do { esp_exceptions(x); } while (0);
-
-typedef struct _wlan_if_obj_t {
-    mp_obj_base_t base;
-    int if_id;
-} wlan_if_obj_t;
-
-const mp_obj_type_t wlan_if_type;
-STATIC const wlan_if_obj_t wlan_sta_obj = {{&wlan_if_type}, WIFI_IF_STA};
-STATIC const wlan_if_obj_t wlan_ap_obj = {{&wlan_if_type}, WIFI_IF_AP};
-
-// Set to "true" if esp_wifi_start() was called
-static bool wifi_started = false;
-
-// Set to "true" if the STA interface is requested to be connected by the
-// user, used for automatic reassociation.
-static bool wifi_sta_connect_requested = false;
-
-// Set to "true" if the STA interface is connected to wifi and has IP address.
-static bool wifi_sta_connected = false;
-
-// Store the current status. 0 means None here, safe to do so as first enum value is WIFI_REASON_UNSPECIFIED=1.
-static uint8_t wifi_sta_disconn_reason = 0;
-
-#if MICROPY_HW_ENABLE_MDNS_QUERIES || MICROPY_HW_ENABLE_MDNS_RESPONDER
-// Whether mDNS has been initialised or not
-static bool mdns_initialised = false;
-#endif
-
-static uint8_t conf_wifi_sta_reconnects = 0;
-static uint8_t wifi_sta_reconnects;
-
 // This function is called by the system-event task and so runs in a different
 // thread to the main MicroPython task.  It must not raise any Python exceptions.
 static esp_err_t event_handler(void *ctx, system_event_t *event) {
     switch (event->event_id) {
         case SYSTEM_EVENT_STA_START:
-            ESP_LOGI("wifi", "STA_START");
-            wifi_sta_reconnects = 0;
-            break;
         case SYSTEM_EVENT_STA_CONNECTED:
-            ESP_LOGI("network", "CONNECTED");
-            break;
         case SYSTEM_EVENT_STA_GOT_IP:
-            ESP_LOGI("network", "GOT_IP");
-            wifi_sta_connected = true;
-            wifi_sta_disconn_reason = 0; // Success so clear error. (in case of new error will be replaced anyway)
-            #if MICROPY_HW_ENABLE_MDNS_QUERIES || MICROPY_HW_ENABLE_MDNS_RESPONDER
-            if (!mdns_initialised) {
-                mdns_init();
-                #if MICROPY_HW_ENABLE_MDNS_RESPONDER
-                const char *hostname = NULL;
-                if (tcpip_adapter_get_hostname(WIFI_IF_STA, &hostname) != ESP_OK || hostname == NULL) {
-                    hostname = "esp32";
-                }
-                mdns_hostname_set(hostname);
-                mdns_instance_name_set(hostname);
-                #endif
-                mdns_initialised = true;
-            }
-            #endif
+        case SYSTEM_EVENT_STA_DISCONNECTED:
+            network_wlan_event_handler(event);
             break;
-        case SYSTEM_EVENT_STA_DISCONNECTED: {
-            // This is a workaround as ESP32 WiFi libs don't currently
-            // auto-reassociate.
-            system_event_sta_disconnected_t *disconn = &event->event_info.disconnected;
-            char *message = "";
-            wifi_sta_disconn_reason = disconn->reason;
-            switch (disconn->reason) {
-                case WIFI_REASON_BEACON_TIMEOUT:
-                    // AP has dropped out; try to reconnect.
-                    message = "\nbeacon timeout";
-                    break;
-                case WIFI_REASON_NO_AP_FOUND:
-                    // AP may not exist, or it may have momentarily dropped out; try to reconnect.
-                    message = "\nno AP found";
-                    break;
-                case WIFI_REASON_AUTH_FAIL:
-                    // Password may be wrong, or it just failed to connect; try to reconnect.
-                    message = "\nauthentication failed";
-                    break;
-                default:
-                    // Let other errors through and try to reconnect.
-                    break;
-            }
-            ESP_LOGI("wifi", "STA_DISCONNECTED, reason:%d%s", disconn->reason, message);
-
-            wifi_sta_connected = false;
-            if (wifi_sta_connect_requested) {
-                wifi_mode_t mode;
-                if (esp_wifi_get_mode(&mode) != ESP_OK) {
-                    break;
-                }
-                if (!(mode & WIFI_MODE_STA)) {
-                    break;
-                }
-                if (conf_wifi_sta_reconnects) {
-                    ESP_LOGI("wifi", "reconnect counter=%d, max=%d",
-                        wifi_sta_reconnects, conf_wifi_sta_reconnects);
-                    if (++wifi_sta_reconnects >= conf_wifi_sta_reconnects) {
-                        break;
-                    }
-                }
-                esp_err_t e = esp_wifi_connect();
-                if (e != ESP_OK) {
-                    ESP_LOGI("wifi", "error attempting to reconnect: 0x%04x", e);
-                }
-            }
-            break;
-        }
         case SYSTEM_EVENT_GOT_IP6:
             ESP_LOGI("network", "Got IPv6");
             break;
@@ -248,263 +130,19 @@ static esp_err_t event_handler(void *ctx, system_event_t *event) {
     return ESP_OK;
 }
 
-/*void error_check(bool status, const char *msg) {
-    if (!status) {
-        mp_raise_msg(&mp_type_OSError, msg);
-    }
-}
-*/
-
-STATIC void require_if(mp_obj_t wlan_if, int if_no) {
-    wlan_if_obj_t *self = MP_OBJ_TO_PTR(wlan_if);
-    if (self->if_id != if_no) {
-        mp_raise_msg(&mp_type_OSError, if_no == WIFI_IF_STA ? MP_ERROR_TEXT("STA required") : MP_ERROR_TEXT("AP required"));
-    }
-}
-
-STATIC mp_obj_t get_wlan(size_t n_args, const mp_obj_t *args) {
-    static int initialized = 0;
-    if (!initialized) {
-        wifi_init_config_t cfg = WIFI_INIT_CONFIG_DEFAULT();
-        ESP_LOGD("modnetwork", "Initializing WiFi");
-        ESP_EXCEPTIONS(esp_wifi_init(&cfg));
-        ESP_EXCEPTIONS(esp_wifi_set_storage(WIFI_STORAGE_RAM));
-        ESP_LOGD("modnetwork", "Initialized");
-        initialized = 1;
-    }
-
-    int idx = (n_args > 0) ? mp_obj_get_int(args[0]) : WIFI_IF_STA;
-    if (idx == WIFI_IF_STA) {
-        return MP_OBJ_FROM_PTR(&wlan_sta_obj);
-    } else if (idx == WIFI_IF_AP) {
-        return MP_OBJ_FROM_PTR(&wlan_ap_obj);
-    } else {
-        mp_raise_ValueError(MP_ERROR_TEXT("invalid WLAN interface identifier"));
-    }
-}
-STATIC MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(get_wlan_obj, 0, 1, get_wlan);
-
 STATIC mp_obj_t esp_initialize() {
     static int initialized = 0;
     if (!initialized) {
         ESP_LOGD("modnetwork", "Initializing TCP/IP");
         tcpip_adapter_init();
         ESP_LOGD("modnetwork", "Initializing Event Loop");
-        ESP_EXCEPTIONS(esp_event_loop_init(event_handler, NULL));
+        esp_exceptions(esp_event_loop_init(event_handler, NULL));
         ESP_LOGD("modnetwork", "esp_event_loop_init done");
         initialized = 1;
     }
     return mp_const_none;
 }
 STATIC MP_DEFINE_CONST_FUN_OBJ_0(esp_initialize_obj, esp_initialize);
-
-#if (WIFI_MODE_STA & WIFI_MODE_AP != WIFI_MODE_NULL || WIFI_MODE_STA | WIFI_MODE_AP != WIFI_MODE_APSTA)
-#error WIFI_MODE_STA and WIFI_MODE_AP are supposed to be bitfields!
-#endif
-
-STATIC mp_obj_t esp_active(size_t n_args, const mp_obj_t *args) {
-    wlan_if_obj_t *self = MP_OBJ_TO_PTR(args[0]);
-
-    wifi_mode_t mode;
-    if (!wifi_started) {
-        mode = WIFI_MODE_NULL;
-    } else {
-        ESP_EXCEPTIONS(esp_wifi_get_mode(&mode));
-    }
-
-    int bit = (self->if_id == WIFI_IF_STA) ? WIFI_MODE_STA : WIFI_MODE_AP;
-
-    if (n_args > 1) {
-        bool active = mp_obj_is_true(args[1]);
-        mode = active ? (mode | bit) : (mode & ~bit);
-        if (mode == WIFI_MODE_NULL) {
-            if (wifi_started) {
-                ESP_EXCEPTIONS(esp_wifi_stop());
-                wifi_started = false;
-            }
-        } else {
-            ESP_EXCEPTIONS(esp_wifi_set_mode(mode));
-            if (!wifi_started) {
-                ESP_EXCEPTIONS(esp_wifi_start());
-                wifi_started = true;
-            }
-        }
-    }
-
-    return (mode & bit) ? mp_const_true : mp_const_false;
-}
-
-STATIC MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(esp_active_obj, 1, 2, esp_active);
-
-STATIC mp_obj_t esp_connect(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
-    enum { ARG_ssid, ARG_password, ARG_bssid };
-    static const mp_arg_t allowed_args[] = {
-        { MP_QSTR_, MP_ARG_OBJ, {.u_obj = mp_const_none} },
-        { MP_QSTR_, MP_ARG_OBJ, {.u_obj = mp_const_none} },
-        { MP_QSTR_bssid, MP_ARG_KW_ONLY | MP_ARG_OBJ, {.u_obj = mp_const_none} },
-    };
-
-    // parse args
-    mp_arg_val_t args[MP_ARRAY_SIZE(allowed_args)];
-    mp_arg_parse_all(n_args - 1, pos_args + 1, kw_args, MP_ARRAY_SIZE(allowed_args), allowed_args, args);
-
-    wifi_config_t wifi_sta_config = {0};
-
-    // configure any parameters that are given
-    if (n_args > 1) {
-        size_t len;
-        const char *p;
-        if (args[ARG_ssid].u_obj != mp_const_none) {
-            p = mp_obj_str_get_data(args[ARG_ssid].u_obj, &len);
-            memcpy(wifi_sta_config.sta.ssid, p, MIN(len, sizeof(wifi_sta_config.sta.ssid)));
-        }
-        if (args[ARG_password].u_obj != mp_const_none) {
-            p = mp_obj_str_get_data(args[ARG_password].u_obj, &len);
-            memcpy(wifi_sta_config.sta.password, p, MIN(len, sizeof(wifi_sta_config.sta.password)));
-        }
-        if (args[ARG_bssid].u_obj != mp_const_none) {
-            p = mp_obj_str_get_data(args[ARG_bssid].u_obj, &len);
-            if (len != sizeof(wifi_sta_config.sta.bssid)) {
-                mp_raise_ValueError(NULL);
-            }
-            wifi_sta_config.sta.bssid_set = 1;
-            memcpy(wifi_sta_config.sta.bssid, p, sizeof(wifi_sta_config.sta.bssid));
-        }
-        ESP_EXCEPTIONS(esp_wifi_set_config(ESP_IF_WIFI_STA, &wifi_sta_config));
-    }
-
-    wifi_sta_reconnects = 0;
-    // connect to the WiFi AP
-    MP_THREAD_GIL_EXIT();
-    ESP_EXCEPTIONS(esp_wifi_connect());
-    MP_THREAD_GIL_ENTER();
-    wifi_sta_connect_requested = true;
-
-    return mp_const_none;
-}
-STATIC MP_DEFINE_CONST_FUN_OBJ_KW(esp_connect_obj, 1, esp_connect);
-
-STATIC mp_obj_t esp_disconnect(mp_obj_t self_in) {
-    wifi_sta_connect_requested = false;
-    ESP_EXCEPTIONS(esp_wifi_disconnect());
-    return mp_const_none;
-}
-
-STATIC MP_DEFINE_CONST_FUN_OBJ_1(esp_disconnect_obj, esp_disconnect);
-
-// Cases similar to ESP8266 user_interface.h
-// Error cases are referenced from wifi_err_reason_t in ESP-IDF
-enum {
-    STAT_IDLE       = 1000,
-    STAT_CONNECTING = 1001,
-    STAT_GOT_IP     = 1010,
-};
-
-STATIC mp_obj_t esp_status(size_t n_args, const mp_obj_t *args) {
-    wlan_if_obj_t *self = MP_OBJ_TO_PTR(args[0]);
-    if (n_args == 1) {
-        if (self->if_id == WIFI_IF_STA) {
-            // Case of no arg is only for the STA interface
-            if (wifi_sta_connected) {
-                // Happy path, connected with IP
-                return MP_OBJ_NEW_SMALL_INT(STAT_GOT_IP);
-            } else if (wifi_sta_connect_requested
-                       && (conf_wifi_sta_reconnects == 0
-                           || wifi_sta_reconnects < conf_wifi_sta_reconnects)) {
-                // No connection or error, but is requested = Still connecting
-                return MP_OBJ_NEW_SMALL_INT(STAT_CONNECTING);
-            } else if (wifi_sta_disconn_reason == 0) {
-                // No activity, No error = Idle
-                return MP_OBJ_NEW_SMALL_INT(STAT_IDLE);
-            } else {
-                // Simply pass the error through from ESP-identifier
-                return MP_OBJ_NEW_SMALL_INT(wifi_sta_disconn_reason);
-            }
-        }
-        return mp_const_none;
-    }
-
-    // one argument: return status based on query parameter
-    switch ((uintptr_t)args[1]) {
-        case (uintptr_t)MP_OBJ_NEW_QSTR(MP_QSTR_stations): {
-            // return list of connected stations, only if in soft-AP mode
-            require_if(args[0], WIFI_IF_AP);
-            wifi_sta_list_t station_list;
-            ESP_EXCEPTIONS(esp_wifi_ap_get_sta_list(&station_list));
-            wifi_sta_info_t *stations = (wifi_sta_info_t *)station_list.sta;
-            mp_obj_t list = mp_obj_new_list(0, NULL);
-            for (int i = 0; i < station_list.num; ++i) {
-                mp_obj_tuple_t *t = mp_obj_new_tuple(1, NULL);
-                t->items[0] = mp_obj_new_bytes(stations[i].mac, sizeof(stations[i].mac));
-                mp_obj_list_append(list, t);
-            }
-            return list;
-        }
-        case (uintptr_t)MP_OBJ_NEW_QSTR(MP_QSTR_rssi): {
-            // return signal of AP, only in STA mode
-            require_if(args[0], WIFI_IF_STA);
-
-            wifi_ap_record_t info;
-            ESP_EXCEPTIONS(esp_wifi_sta_get_ap_info(&info));
-            return MP_OBJ_NEW_SMALL_INT(info.rssi);
-        }
-        default:
-            mp_raise_ValueError(MP_ERROR_TEXT("unknown status param"));
-    }
-
-    return mp_const_none;
-}
-STATIC MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(esp_status_obj, 1, 2, esp_status);
-
-STATIC mp_obj_t esp_scan(mp_obj_t self_in) {
-    // check that STA mode is active
-    wifi_mode_t mode;
-    ESP_EXCEPTIONS(esp_wifi_get_mode(&mode));
-    if ((mode & WIFI_MODE_STA) == 0) {
-        mp_raise_msg(&mp_type_OSError, MP_ERROR_TEXT("STA must be active"));
-    }
-
-    mp_obj_t list = mp_obj_new_list(0, NULL);
-    wifi_scan_config_t config = { 0 };
-    config.show_hidden = true;
-    MP_THREAD_GIL_EXIT();
-    esp_err_t status = esp_wifi_scan_start(&config, 1);
-    MP_THREAD_GIL_ENTER();
-    if (status == 0) {
-        uint16_t count = 0;
-        ESP_EXCEPTIONS(esp_wifi_scan_get_ap_num(&count));
-        wifi_ap_record_t *wifi_ap_records = calloc(count, sizeof(wifi_ap_record_t));
-        ESP_EXCEPTIONS(esp_wifi_scan_get_ap_records(&count, wifi_ap_records));
-        for (uint16_t i = 0; i < count; i++) {
-            mp_obj_tuple_t *t = mp_obj_new_tuple(6, NULL);
-            uint8_t *x = memchr(wifi_ap_records[i].ssid, 0, sizeof(wifi_ap_records[i].ssid));
-            int ssid_len = x ? x - wifi_ap_records[i].ssid : sizeof(wifi_ap_records[i].ssid);
-            t->items[0] = mp_obj_new_bytes(wifi_ap_records[i].ssid, ssid_len);
-            t->items[1] = mp_obj_new_bytes(wifi_ap_records[i].bssid, sizeof(wifi_ap_records[i].bssid));
-            t->items[2] = MP_OBJ_NEW_SMALL_INT(wifi_ap_records[i].primary);
-            t->items[3] = MP_OBJ_NEW_SMALL_INT(wifi_ap_records[i].rssi);
-            t->items[4] = MP_OBJ_NEW_SMALL_INT(wifi_ap_records[i].authmode);
-            t->items[5] = mp_const_false; // XXX hidden?
-            mp_obj_list_append(list, MP_OBJ_FROM_PTR(t));
-        }
-        free(wifi_ap_records);
-    }
-    return list;
-}
-
-STATIC MP_DEFINE_CONST_FUN_OBJ_1(esp_scan_obj, esp_scan);
-
-STATIC mp_obj_t esp_isconnected(mp_obj_t self_in) {
-    wlan_if_obj_t *self = MP_OBJ_TO_PTR(self_in);
-    if (self->if_id == WIFI_IF_STA) {
-        return mp_obj_new_bool(wifi_sta_connected);
-    } else {
-        wifi_sta_list_t sta;
-        esp_wifi_ap_get_sta_list(&sta);
-        return mp_obj_new_bool(sta.num != 0);
-    }
-}
-STATIC MP_DEFINE_CONST_FUN_OBJ_1(esp_isconnected_obj, esp_isconnected);
 
 STATIC mp_obj_t esp_ifconfig(size_t n_args, const mp_obj_t *args) {
     wlan_if_obj_t *self = MP_OBJ_TO_PTR(args[0]);
@@ -543,18 +181,18 @@ STATIC mp_obj_t esp_ifconfig(size_t n_args, const mp_obj_t *args) {
             if (self->if_id == WIFI_IF_STA || self->if_id == ESP_IF_ETH) {
                 esp_err_t e = tcpip_adapter_dhcpc_stop(self->if_id);
                 if (e != ESP_OK && e != ESP_ERR_TCPIP_ADAPTER_DHCP_ALREADY_STOPPED) {
-                    _esp_exceptions(e);
+                    esp_exceptions_helper(e);
                 }
-                ESP_EXCEPTIONS(tcpip_adapter_set_ip_info(self->if_id, &info));
-                ESP_EXCEPTIONS(tcpip_adapter_set_dns_info(self->if_id, DNS_MAIN, &dns_info));
+                esp_exceptions(tcpip_adapter_set_ip_info(self->if_id, &info));
+                esp_exceptions(tcpip_adapter_set_dns_info(self->if_id, DNS_MAIN, &dns_info));
             } else if (self->if_id == WIFI_IF_AP) {
                 esp_err_t e = tcpip_adapter_dhcps_stop(WIFI_IF_AP);
                 if (e != ESP_OK && e != ESP_ERR_TCPIP_ADAPTER_DHCP_ALREADY_STOPPED) {
-                    _esp_exceptions(e);
+                    esp_exceptions_helper(e);
                 }
-                ESP_EXCEPTIONS(tcpip_adapter_set_ip_info(WIFI_IF_AP, &info));
-                ESP_EXCEPTIONS(tcpip_adapter_set_dns_info(WIFI_IF_AP, DNS_MAIN, &dns_info));
-                ESP_EXCEPTIONS(tcpip_adapter_dhcps_start(WIFI_IF_AP));
+                esp_exceptions(tcpip_adapter_set_ip_info(WIFI_IF_AP, &info));
+                esp_exceptions(tcpip_adapter_set_dns_info(WIFI_IF_AP, DNS_MAIN, &dns_info));
+                esp_exceptions(tcpip_adapter_dhcps_start(WIFI_IF_AP));
             }
         } else {
             // check for the correct string
@@ -562,212 +200,12 @@ STATIC mp_obj_t esp_ifconfig(size_t n_args, const mp_obj_t *args) {
             if ((self->if_id != WIFI_IF_STA && self->if_id != ESP_IF_ETH) || strcmp("dhcp", mode)) {
                 mp_raise_ValueError(MP_ERROR_TEXT("invalid arguments"));
             }
-            ESP_EXCEPTIONS(tcpip_adapter_dhcpc_start(self->if_id));
+            esp_exceptions(tcpip_adapter_dhcpc_start(self->if_id));
         }
         return mp_const_none;
     }
 }
-
 MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(esp_ifconfig_obj, 1, 2, esp_ifconfig);
-
-STATIC mp_obj_t esp_config(size_t n_args, const mp_obj_t *args, mp_map_t *kwargs) {
-    if (n_args != 1 && kwargs->used != 0) {
-        mp_raise_TypeError(MP_ERROR_TEXT("either pos or kw args are allowed"));
-    }
-
-    wlan_if_obj_t *self = MP_OBJ_TO_PTR(args[0]);
-
-    bool is_wifi = self->if_id == WIFI_IF_AP || self->if_id == WIFI_IF_STA;
-
-    wifi_config_t cfg;
-    if (is_wifi) {
-        ESP_EXCEPTIONS(esp_wifi_get_config(self->if_id, &cfg));
-    }
-
-    #define QS(x) (uintptr_t)MP_OBJ_NEW_QSTR(x)
-
-    if (kwargs->used != 0) {
-        if (!is_wifi) {
-            goto unknown;
-        }
-
-        for (size_t i = 0; i < kwargs->alloc; i++) {
-            if (mp_map_slot_is_filled(kwargs, i)) {
-                int req_if = -1;
-
-                switch ((uintptr_t)kwargs->table[i].key) {
-                    case QS(MP_QSTR_mac): {
-                        mp_buffer_info_t bufinfo;
-                        mp_get_buffer_raise(kwargs->table[i].value, &bufinfo, MP_BUFFER_READ);
-                        if (bufinfo.len != 6) {
-                            mp_raise_ValueError(MP_ERROR_TEXT("invalid buffer length"));
-                        }
-                        ESP_EXCEPTIONS(esp_wifi_set_mac(self->if_id, bufinfo.buf));
-                        break;
-                    }
-                    case QS(MP_QSTR_essid): {
-                        req_if = WIFI_IF_AP;
-                        size_t len;
-                        const char *s = mp_obj_str_get_data(kwargs->table[i].value, &len);
-                        len = MIN(len, sizeof(cfg.ap.ssid));
-                        memcpy(cfg.ap.ssid, s, len);
-                        cfg.ap.ssid_len = len;
-                        break;
-                    }
-                    case QS(MP_QSTR_hidden): {
-                        req_if = WIFI_IF_AP;
-                        cfg.ap.ssid_hidden = mp_obj_is_true(kwargs->table[i].value);
-                        break;
-                    }
-                    case QS(MP_QSTR_authmode): {
-                        req_if = WIFI_IF_AP;
-                        cfg.ap.authmode = mp_obj_get_int(kwargs->table[i].value);
-                        break;
-                    }
-                    case QS(MP_QSTR_password): {
-                        req_if = WIFI_IF_AP;
-                        size_t len;
-                        const char *s = mp_obj_str_get_data(kwargs->table[i].value, &len);
-                        len = MIN(len, sizeof(cfg.ap.password) - 1);
-                        memcpy(cfg.ap.password, s, len);
-                        cfg.ap.password[len] = 0;
-                        break;
-                    }
-                    case QS(MP_QSTR_channel): {
-                        req_if = WIFI_IF_AP;
-                        cfg.ap.channel = mp_obj_get_int(kwargs->table[i].value);
-                        break;
-                    }
-                    case QS(MP_QSTR_dhcp_hostname): {
-                        const char *s = mp_obj_str_get_str(kwargs->table[i].value);
-                        ESP_EXCEPTIONS(tcpip_adapter_set_hostname(self->if_id, s));
-                        break;
-                    }
-                    case QS(MP_QSTR_max_clients): {
-                        req_if = WIFI_IF_AP;
-                        cfg.ap.max_connection = mp_obj_get_int(kwargs->table[i].value);
-                        break;
-                    }
-                    case QS(MP_QSTR_reconnects): {
-                        int reconnects = mp_obj_get_int(kwargs->table[i].value);
-                        req_if = WIFI_IF_STA;
-                        // parameter reconnects == -1 means to retry forever.
-                        // here means conf_wifi_sta_reconnects == 0 to retry forever.
-                        conf_wifi_sta_reconnects = (reconnects == -1) ? 0 : reconnects + 1;
-                        break;
-                    }
-                    default:
-                        goto unknown;
-                }
-
-                // We post-check interface requirements to save on code size
-                if (req_if >= 0) {
-                    require_if(args[0], req_if);
-                }
-            }
-        }
-
-        ESP_EXCEPTIONS(esp_wifi_set_config(self->if_id, &cfg));
-
-        return mp_const_none;
-    }
-
-    // Get config
-
-    if (n_args != 2) {
-        mp_raise_TypeError(MP_ERROR_TEXT("can query only one param"));
-    }
-
-    int req_if = -1;
-    mp_obj_t val = mp_const_none;
-
-    switch ((uintptr_t)args[1]) {
-        case QS(MP_QSTR_mac): {
-            uint8_t mac[6];
-            switch (self->if_id) {
-                case WIFI_IF_AP: // fallthrough intentional
-                case WIFI_IF_STA:
-                    ESP_EXCEPTIONS(esp_wifi_get_mac(self->if_id, mac));
-                    return mp_obj_new_bytes(mac, sizeof(mac));
-                default:
-                    goto unknown;
-            }
-        }
-        case QS(MP_QSTR_essid):
-            switch (self->if_id) {
-                case WIFI_IF_STA:
-                    val = mp_obj_new_str((char *)cfg.sta.ssid, strlen((char *)cfg.sta.ssid));
-                    break;
-                case WIFI_IF_AP:
-                    val = mp_obj_new_str((char *)cfg.ap.ssid, cfg.ap.ssid_len);
-                    break;
-                default:
-                    req_if = WIFI_IF_AP;
-            }
-            break;
-        case QS(MP_QSTR_hidden):
-            req_if = WIFI_IF_AP;
-            val = mp_obj_new_bool(cfg.ap.ssid_hidden);
-            break;
-        case QS(MP_QSTR_authmode):
-            req_if = WIFI_IF_AP;
-            val = MP_OBJ_NEW_SMALL_INT(cfg.ap.authmode);
-            break;
-        case QS(MP_QSTR_channel):
-            req_if = WIFI_IF_AP;
-            val = MP_OBJ_NEW_SMALL_INT(cfg.ap.channel);
-            break;
-        case QS(MP_QSTR_dhcp_hostname): {
-            const char *s;
-            ESP_EXCEPTIONS(tcpip_adapter_get_hostname(self->if_id, &s));
-            val = mp_obj_new_str(s, strlen(s));
-            break;
-        }
-        case QS(MP_QSTR_max_clients): {
-            val = MP_OBJ_NEW_SMALL_INT(cfg.ap.max_connection);
-            break;
-        }
-        case QS(MP_QSTR_reconnects):
-            req_if = WIFI_IF_STA;
-            int rec = conf_wifi_sta_reconnects - 1;
-            val = MP_OBJ_NEW_SMALL_INT(rec);
-            break;
-        default:
-            goto unknown;
-    }
-
-#undef QS
-
-    // We post-check interface requirements to save on code size
-    if (req_if >= 0) {
-        require_if(args[0], req_if);
-    }
-
-    return val;
-
-unknown:
-    mp_raise_ValueError(MP_ERROR_TEXT("unknown config param"));
-}
-MP_DEFINE_CONST_FUN_OBJ_KW(esp_config_obj, 1, esp_config);
-
-STATIC const mp_rom_map_elem_t wlan_if_locals_dict_table[] = {
-    { MP_ROM_QSTR(MP_QSTR_active), MP_ROM_PTR(&esp_active_obj) },
-    { MP_ROM_QSTR(MP_QSTR_connect), MP_ROM_PTR(&esp_connect_obj) },
-    { MP_ROM_QSTR(MP_QSTR_disconnect), MP_ROM_PTR(&esp_disconnect_obj) },
-    { MP_ROM_QSTR(MP_QSTR_status), MP_ROM_PTR(&esp_status_obj) },
-    { MP_ROM_QSTR(MP_QSTR_scan), MP_ROM_PTR(&esp_scan_obj) },
-    { MP_ROM_QSTR(MP_QSTR_isconnected), MP_ROM_PTR(&esp_isconnected_obj) },
-    { MP_ROM_QSTR(MP_QSTR_config), MP_ROM_PTR(&esp_config_obj) },
-    { MP_ROM_QSTR(MP_QSTR_ifconfig), MP_ROM_PTR(&esp_ifconfig_obj) },
-};
-
-STATIC MP_DEFINE_CONST_DICT(wlan_if_locals_dict, wlan_if_locals_dict_table);
-
-const mp_obj_type_t wlan_if_type = {
-    { &mp_type_type },
-    .name = MP_QSTR_WLAN,
-    .locals_dict = (mp_obj_t)&wlan_if_locals_dict,
-};
 
 STATIC mp_obj_t esp_phy_mode(size_t n_args, const mp_obj_t *args) {
     return mp_const_none;
@@ -777,7 +215,10 @@ STATIC MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(esp_phy_mode_obj, 0, 1, esp_phy_mode)
 STATIC const mp_rom_map_elem_t mp_module_network_globals_table[] = {
     { MP_ROM_QSTR(MP_QSTR___name__), MP_ROM_QSTR(MP_QSTR_network) },
     { MP_ROM_QSTR(MP_QSTR___init__), MP_ROM_PTR(&esp_initialize_obj) },
+
+    #if MICROPY_PY_NETWORK_WLAN
     { MP_ROM_QSTR(MP_QSTR_WLAN), MP_ROM_PTR(&get_wlan_obj) },
+    #endif
 
     #if (ESP_IDF_VERSION_MAJOR == 4) && (ESP_IDF_VERSION_MINOR >= 1) && (CONFIG_IDF_TARGET_ESP32)
     { MP_ROM_QSTR(MP_QSTR_LAN), MP_ROM_PTR(&get_lan_obj) },
@@ -786,6 +227,8 @@ STATIC const mp_rom_map_elem_t mp_module_network_globals_table[] = {
     { MP_ROM_QSTR(MP_QSTR_phy_mode), MP_ROM_PTR(&esp_phy_mode_obj) },
 
     #if MODNETWORK_INCLUDE_CONSTANTS
+
+    #if MICROPY_PY_NETWORK_WLAN
     { MP_ROM_QSTR(MP_QSTR_STA_IF), MP_ROM_INT(WIFI_IF_STA)},
     { MP_ROM_QSTR(MP_QSTR_AP_IF), MP_ROM_INT(WIFI_IF_AP)},
 
@@ -804,6 +247,7 @@ STATIC const mp_rom_map_elem_t mp_module_network_globals_table[] = {
     { MP_ROM_QSTR(MP_QSTR_AUTH_WPA2_WPA3_PSK), MP_ROM_INT(WIFI_AUTH_WPA2_WPA3_PSK) },
     #endif
     { MP_ROM_QSTR(MP_QSTR_AUTH_MAX), MP_ROM_INT(WIFI_AUTH_MAX) },
+    #endif
 
     #if (ESP_IDF_VERSION_MAJOR == 4) && (ESP_IDF_VERSION_MINOR >= 1) && (CONFIG_IDF_TARGET_ESP32)
     { MP_ROM_QSTR(MP_QSTR_PHY_LAN8720), MP_ROM_INT(PHY_LAN8720) },

--- a/ports/esp32/modnetwork.h
+++ b/ports/esp32/modnetwork.h
@@ -26,14 +26,39 @@
 #ifndef MICROPY_INCLUDED_ESP32_MODNETWORK_H
 #define MICROPY_INCLUDED_ESP32_MODNETWORK_H
 
+#include "esp_event.h"
+
 enum { PHY_LAN8720, PHY_IP101, PHY_RTL8201, PHY_DP83848, PHY_KSZ8041 };
 enum { ETH_INITIALIZED, ETH_STARTED, ETH_STOPPED, ETH_CONNECTED, ETH_DISCONNECTED, ETH_GOT_IP };
 
+// Cases similar to ESP8266 user_interface.h
+// Error cases are referenced from wifi_err_reason_t in ESP-IDF
+enum {
+    STAT_IDLE       = 1000,
+    STAT_CONNECTING = 1001,
+    STAT_GOT_IP     = 1010,
+};
+
+typedef struct _wlan_if_obj_t {
+    mp_obj_base_t base;
+    int if_id;
+} wlan_if_obj_t;
+
+MP_DECLARE_CONST_FUN_OBJ_VAR_BETWEEN(get_wlan_obj);
 MP_DECLARE_CONST_FUN_OBJ_KW(get_lan_obj);
 MP_DECLARE_CONST_FUN_OBJ_1(ppp_make_new_obj);
 MP_DECLARE_CONST_FUN_OBJ_VAR_BETWEEN(esp_ifconfig_obj);
 MP_DECLARE_CONST_FUN_OBJ_KW(esp_config_obj);
 
+NORETURN void esp_exceptions_helper(esp_err_t e);
+
+static inline void esp_exceptions(esp_err_t e) {
+    if (e != ESP_OK) {
+        esp_exceptions_helper(e);
+    }
+}
+
 void usocket_events_deinit(void);
+void network_wlan_event_handler(system_event_t *event);
 
 #endif

--- a/ports/esp32/mpconfigport.h
+++ b/ports/esp32/mpconfigport.h
@@ -174,6 +174,9 @@
 #ifndef MICROPY_PY_MACHINE_I2S
 #define MICROPY_PY_MACHINE_I2S              (1)
 #endif
+#ifndef MICROPY_PY_NETWORK_WLAN
+#define MICROPY_PY_NETWORK_WLAN             (1)
+#endif
 #ifndef MICROPY_HW_ENABLE_SDCARD
 #define MICROPY_HW_ENABLE_SDCARD            (1)
 #endif

--- a/ports/esp32/network_wlan.c
+++ b/ports/esp32/network_wlan.c
@@ -1,0 +1,578 @@
+/*
+ * This file is part of the MicroPython project, http://micropython.org/
+ *
+ * Development of the code in this file was sponsored by Microbric Pty Ltd
+ * and Mnemote Pty Ltd
+ *
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2016, 2017 Nick Moore @mnemote
+ * Copyright (c) 2017 "Eric Poulsen" <eric@zyxod.com>
+ *
+ * Based on esp8266/modnetwork.c which is Copyright (c) 2015 Paul Sokolovsky
+ * And the ESP IDF example code which is Public Domain / CC0
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#include <string.h>
+
+#include "py/objlist.h"
+#include "py/runtime.h"
+#include "modnetwork.h"
+
+#include "esp_wifi.h"
+#include "esp_log.h"
+#include "mdns.h"
+
+#if MICROPY_PY_NETWORK_WLAN
+
+#if (WIFI_MODE_STA & WIFI_MODE_AP != WIFI_MODE_NULL || WIFI_MODE_STA | WIFI_MODE_AP != WIFI_MODE_APSTA)
+#error WIFI_MODE_STA and WIFI_MODE_AP are supposed to be bitfields!
+#endif
+
+STATIC const mp_obj_type_t wlan_if_type;
+STATIC const wlan_if_obj_t wlan_sta_obj = {{&wlan_if_type}, WIFI_IF_STA};
+STATIC const wlan_if_obj_t wlan_ap_obj = {{&wlan_if_type}, WIFI_IF_AP};
+
+// Set to "true" if esp_wifi_start() was called
+static bool wifi_started = false;
+
+// Set to "true" if the STA interface is requested to be connected by the
+// user, used for automatic reassociation.
+static bool wifi_sta_connect_requested = false;
+
+// Set to "true" if the STA interface is connected to wifi and has IP address.
+static bool wifi_sta_connected = false;
+
+// Store the current status. 0 means None here, safe to do so as first enum value is WIFI_REASON_UNSPECIFIED=1.
+static uint8_t wifi_sta_disconn_reason = 0;
+
+#if MICROPY_HW_ENABLE_MDNS_QUERIES || MICROPY_HW_ENABLE_MDNS_RESPONDER
+// Whether mDNS has been initialised or not
+static bool mdns_initialised = false;
+#endif
+
+static uint8_t conf_wifi_sta_reconnects = 0;
+static uint8_t wifi_sta_reconnects;
+
+// This function is called by the system-event task and so runs in a different
+// thread to the main MicroPython task.  It must not raise any Python exceptions.
+void network_wlan_event_handler(system_event_t *event) {
+    switch (event->event_id) {
+        case SYSTEM_EVENT_STA_START:
+            ESP_LOGI("wifi", "STA_START");
+            wifi_sta_reconnects = 0;
+            break;
+        case SYSTEM_EVENT_STA_CONNECTED:
+            ESP_LOGI("network", "CONNECTED");
+            break;
+        case SYSTEM_EVENT_STA_GOT_IP:
+            ESP_LOGI("network", "GOT_IP");
+            wifi_sta_connected = true;
+            wifi_sta_disconn_reason = 0; // Success so clear error. (in case of new error will be replaced anyway)
+            #if MICROPY_HW_ENABLE_MDNS_QUERIES || MICROPY_HW_ENABLE_MDNS_RESPONDER
+            if (!mdns_initialised) {
+                mdns_init();
+                #if MICROPY_HW_ENABLE_MDNS_RESPONDER
+                const char *hostname = NULL;
+                if (tcpip_adapter_get_hostname(WIFI_IF_STA, &hostname) != ESP_OK || hostname == NULL) {
+                    hostname = "esp32";
+                }
+                mdns_hostname_set(hostname);
+                mdns_instance_name_set(hostname);
+                #endif
+                mdns_initialised = true;
+            }
+            #endif
+            break;
+        case SYSTEM_EVENT_STA_DISCONNECTED: {
+            // This is a workaround as ESP32 WiFi libs don't currently
+            // auto-reassociate.
+            system_event_sta_disconnected_t *disconn = &event->event_info.disconnected;
+            char *message = "";
+            wifi_sta_disconn_reason = disconn->reason;
+            switch (disconn->reason) {
+                case WIFI_REASON_BEACON_TIMEOUT:
+                    // AP has dropped out; try to reconnect.
+                    message = "\nbeacon timeout";
+                    break;
+                case WIFI_REASON_NO_AP_FOUND:
+                    // AP may not exist, or it may have momentarily dropped out; try to reconnect.
+                    message = "\nno AP found";
+                    break;
+                case WIFI_REASON_AUTH_FAIL:
+                    // Password may be wrong, or it just failed to connect; try to reconnect.
+                    message = "\nauthentication failed";
+                    break;
+                default:
+                    // Let other errors through and try to reconnect.
+                    break;
+            }
+            ESP_LOGI("wifi", "STA_DISCONNECTED, reason:%d%s", disconn->reason, message);
+
+            wifi_sta_connected = false;
+            if (wifi_sta_connect_requested) {
+                wifi_mode_t mode;
+                if (esp_wifi_get_mode(&mode) != ESP_OK) {
+                    break;
+                }
+                if (!(mode & WIFI_MODE_STA)) {
+                    break;
+                }
+                if (conf_wifi_sta_reconnects) {
+                    ESP_LOGI("wifi", "reconnect counter=%d, max=%d",
+                        wifi_sta_reconnects, conf_wifi_sta_reconnects);
+                    if (++wifi_sta_reconnects >= conf_wifi_sta_reconnects) {
+                        break;
+                    }
+                }
+                esp_err_t e = esp_wifi_connect();
+                if (e != ESP_OK) {
+                    ESP_LOGI("wifi", "error attempting to reconnect: 0x%04x", e);
+                }
+            }
+            break;
+        }
+        default:
+            break;
+    }
+}
+
+STATIC void require_if(mp_obj_t wlan_if, int if_no) {
+    wlan_if_obj_t *self = MP_OBJ_TO_PTR(wlan_if);
+    if (self->if_id != if_no) {
+        mp_raise_msg(&mp_type_OSError, if_no == WIFI_IF_STA ? MP_ERROR_TEXT("STA required") : MP_ERROR_TEXT("AP required"));
+    }
+}
+
+STATIC mp_obj_t get_wlan(size_t n_args, const mp_obj_t *args) {
+    static int initialized = 0;
+    if (!initialized) {
+        wifi_init_config_t cfg = WIFI_INIT_CONFIG_DEFAULT();
+        ESP_LOGD("modnetwork", "Initializing WiFi");
+        esp_exceptions(esp_wifi_init(&cfg));
+        esp_exceptions(esp_wifi_set_storage(WIFI_STORAGE_RAM));
+        ESP_LOGD("modnetwork", "Initialized");
+        initialized = 1;
+    }
+
+    int idx = (n_args > 0) ? mp_obj_get_int(args[0]) : WIFI_IF_STA;
+    if (idx == WIFI_IF_STA) {
+        return MP_OBJ_FROM_PTR(&wlan_sta_obj);
+    } else if (idx == WIFI_IF_AP) {
+        return MP_OBJ_FROM_PTR(&wlan_ap_obj);
+    } else {
+        mp_raise_ValueError(MP_ERROR_TEXT("invalid WLAN interface identifier"));
+    }
+}
+MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(get_wlan_obj, 0, 1, get_wlan);
+
+STATIC mp_obj_t network_wlan_active(size_t n_args, const mp_obj_t *args) {
+    wlan_if_obj_t *self = MP_OBJ_TO_PTR(args[0]);
+
+    wifi_mode_t mode;
+    if (!wifi_started) {
+        mode = WIFI_MODE_NULL;
+    } else {
+        esp_exceptions(esp_wifi_get_mode(&mode));
+    }
+
+    int bit = (self->if_id == WIFI_IF_STA) ? WIFI_MODE_STA : WIFI_MODE_AP;
+
+    if (n_args > 1) {
+        bool active = mp_obj_is_true(args[1]);
+        mode = active ? (mode | bit) : (mode & ~bit);
+        if (mode == WIFI_MODE_NULL) {
+            if (wifi_started) {
+                esp_exceptions(esp_wifi_stop());
+                wifi_started = false;
+            }
+        } else {
+            esp_exceptions(esp_wifi_set_mode(mode));
+            if (!wifi_started) {
+                esp_exceptions(esp_wifi_start());
+                wifi_started = true;
+            }
+        }
+    }
+
+    return (mode & bit) ? mp_const_true : mp_const_false;
+}
+STATIC MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(network_wlan_active_obj, 1, 2, network_wlan_active);
+
+STATIC mp_obj_t network_wlan_connect(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
+    enum { ARG_ssid, ARG_password, ARG_bssid };
+    static const mp_arg_t allowed_args[] = {
+        { MP_QSTR_, MP_ARG_OBJ, {.u_obj = mp_const_none} },
+        { MP_QSTR_, MP_ARG_OBJ, {.u_obj = mp_const_none} },
+        { MP_QSTR_bssid, MP_ARG_KW_ONLY | MP_ARG_OBJ, {.u_obj = mp_const_none} },
+    };
+
+    // parse args
+    mp_arg_val_t args[MP_ARRAY_SIZE(allowed_args)];
+    mp_arg_parse_all(n_args - 1, pos_args + 1, kw_args, MP_ARRAY_SIZE(allowed_args), allowed_args, args);
+
+    wifi_config_t wifi_sta_config = {0};
+
+    // configure any parameters that are given
+    if (n_args > 1) {
+        size_t len;
+        const char *p;
+        if (args[ARG_ssid].u_obj != mp_const_none) {
+            p = mp_obj_str_get_data(args[ARG_ssid].u_obj, &len);
+            memcpy(wifi_sta_config.sta.ssid, p, MIN(len, sizeof(wifi_sta_config.sta.ssid)));
+        }
+        if (args[ARG_password].u_obj != mp_const_none) {
+            p = mp_obj_str_get_data(args[ARG_password].u_obj, &len);
+            memcpy(wifi_sta_config.sta.password, p, MIN(len, sizeof(wifi_sta_config.sta.password)));
+        }
+        if (args[ARG_bssid].u_obj != mp_const_none) {
+            p = mp_obj_str_get_data(args[ARG_bssid].u_obj, &len);
+            if (len != sizeof(wifi_sta_config.sta.bssid)) {
+                mp_raise_ValueError(NULL);
+            }
+            wifi_sta_config.sta.bssid_set = 1;
+            memcpy(wifi_sta_config.sta.bssid, p, sizeof(wifi_sta_config.sta.bssid));
+        }
+        esp_exceptions(esp_wifi_set_config(ESP_IF_WIFI_STA, &wifi_sta_config));
+    }
+
+    wifi_sta_reconnects = 0;
+    // connect to the WiFi AP
+    MP_THREAD_GIL_EXIT();
+    esp_exceptions(esp_wifi_connect());
+    MP_THREAD_GIL_ENTER();
+    wifi_sta_connect_requested = true;
+
+    return mp_const_none;
+}
+STATIC MP_DEFINE_CONST_FUN_OBJ_KW(network_wlan_connect_obj, 1, network_wlan_connect);
+
+STATIC mp_obj_t network_wlan_disconnect(mp_obj_t self_in) {
+    wifi_sta_connect_requested = false;
+    esp_exceptions(esp_wifi_disconnect());
+    return mp_const_none;
+}
+STATIC MP_DEFINE_CONST_FUN_OBJ_1(network_wlan_disconnect_obj, network_wlan_disconnect);
+
+STATIC mp_obj_t network_wlan_status(size_t n_args, const mp_obj_t *args) {
+    wlan_if_obj_t *self = MP_OBJ_TO_PTR(args[0]);
+    if (n_args == 1) {
+        if (self->if_id == WIFI_IF_STA) {
+            // Case of no arg is only for the STA interface
+            if (wifi_sta_connected) {
+                // Happy path, connected with IP
+                return MP_OBJ_NEW_SMALL_INT(STAT_GOT_IP);
+            } else if (wifi_sta_connect_requested
+                       && (conf_wifi_sta_reconnects == 0
+                           || wifi_sta_reconnects < conf_wifi_sta_reconnects)) {
+                // No connection or error, but is requested = Still connecting
+                return MP_OBJ_NEW_SMALL_INT(STAT_CONNECTING);
+            } else if (wifi_sta_disconn_reason == 0) {
+                // No activity, No error = Idle
+                return MP_OBJ_NEW_SMALL_INT(STAT_IDLE);
+            } else {
+                // Simply pass the error through from ESP-identifier
+                return MP_OBJ_NEW_SMALL_INT(wifi_sta_disconn_reason);
+            }
+        }
+        return mp_const_none;
+    }
+
+    // one argument: return status based on query parameter
+    switch ((uintptr_t)args[1]) {
+        case (uintptr_t)MP_OBJ_NEW_QSTR(MP_QSTR_stations): {
+            // return list of connected stations, only if in soft-AP mode
+            require_if(args[0], WIFI_IF_AP);
+            wifi_sta_list_t station_list;
+            esp_exceptions(esp_wifi_ap_get_sta_list(&station_list));
+            wifi_sta_info_t *stations = (wifi_sta_info_t *)station_list.sta;
+            mp_obj_t list = mp_obj_new_list(0, NULL);
+            for (int i = 0; i < station_list.num; ++i) {
+                mp_obj_tuple_t *t = mp_obj_new_tuple(1, NULL);
+                t->items[0] = mp_obj_new_bytes(stations[i].mac, sizeof(stations[i].mac));
+                mp_obj_list_append(list, t);
+            }
+            return list;
+        }
+        case (uintptr_t)MP_OBJ_NEW_QSTR(MP_QSTR_rssi): {
+            // return signal of AP, only in STA mode
+            require_if(args[0], WIFI_IF_STA);
+
+            wifi_ap_record_t info;
+            esp_exceptions(esp_wifi_sta_get_ap_info(&info));
+            return MP_OBJ_NEW_SMALL_INT(info.rssi);
+        }
+        default:
+            mp_raise_ValueError(MP_ERROR_TEXT("unknown status param"));
+    }
+
+    return mp_const_none;
+}
+STATIC MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(network_wlan_status_obj, 1, 2, network_wlan_status);
+
+STATIC mp_obj_t network_wlan_scan(mp_obj_t self_in) {
+    // check that STA mode is active
+    wifi_mode_t mode;
+    esp_exceptions(esp_wifi_get_mode(&mode));
+    if ((mode & WIFI_MODE_STA) == 0) {
+        mp_raise_msg(&mp_type_OSError, MP_ERROR_TEXT("STA must be active"));
+    }
+
+    mp_obj_t list = mp_obj_new_list(0, NULL);
+    wifi_scan_config_t config = { 0 };
+    config.show_hidden = true;
+    MP_THREAD_GIL_EXIT();
+    esp_err_t status = esp_wifi_scan_start(&config, 1);
+    MP_THREAD_GIL_ENTER();
+    if (status == 0) {
+        uint16_t count = 0;
+        esp_exceptions(esp_wifi_scan_get_ap_num(&count));
+        wifi_ap_record_t *wifi_ap_records = calloc(count, sizeof(wifi_ap_record_t));
+        esp_exceptions(esp_wifi_scan_get_ap_records(&count, wifi_ap_records));
+        for (uint16_t i = 0; i < count; i++) {
+            mp_obj_tuple_t *t = mp_obj_new_tuple(6, NULL);
+            uint8_t *x = memchr(wifi_ap_records[i].ssid, 0, sizeof(wifi_ap_records[i].ssid));
+            int ssid_len = x ? x - wifi_ap_records[i].ssid : sizeof(wifi_ap_records[i].ssid);
+            t->items[0] = mp_obj_new_bytes(wifi_ap_records[i].ssid, ssid_len);
+            t->items[1] = mp_obj_new_bytes(wifi_ap_records[i].bssid, sizeof(wifi_ap_records[i].bssid));
+            t->items[2] = MP_OBJ_NEW_SMALL_INT(wifi_ap_records[i].primary);
+            t->items[3] = MP_OBJ_NEW_SMALL_INT(wifi_ap_records[i].rssi);
+            t->items[4] = MP_OBJ_NEW_SMALL_INT(wifi_ap_records[i].authmode);
+            t->items[5] = mp_const_false; // XXX hidden?
+            mp_obj_list_append(list, MP_OBJ_FROM_PTR(t));
+        }
+        free(wifi_ap_records);
+    }
+    return list;
+}
+STATIC MP_DEFINE_CONST_FUN_OBJ_1(network_wlan_scan_obj, network_wlan_scan);
+
+STATIC mp_obj_t network_wlan_isconnected(mp_obj_t self_in) {
+    wlan_if_obj_t *self = MP_OBJ_TO_PTR(self_in);
+    if (self->if_id == WIFI_IF_STA) {
+        return mp_obj_new_bool(wifi_sta_connected);
+    } else {
+        wifi_sta_list_t sta;
+        esp_wifi_ap_get_sta_list(&sta);
+        return mp_obj_new_bool(sta.num != 0);
+    }
+}
+STATIC MP_DEFINE_CONST_FUN_OBJ_1(network_wlan_isconnected_obj, network_wlan_isconnected);
+
+STATIC mp_obj_t network_wlan_config(size_t n_args, const mp_obj_t *args, mp_map_t *kwargs) {
+    if (n_args != 1 && kwargs->used != 0) {
+        mp_raise_TypeError(MP_ERROR_TEXT("either pos or kw args are allowed"));
+    }
+
+    wlan_if_obj_t *self = MP_OBJ_TO_PTR(args[0]);
+
+    bool is_wifi = self->if_id == WIFI_IF_AP || self->if_id == WIFI_IF_STA;
+
+    wifi_config_t cfg;
+    if (is_wifi) {
+        esp_exceptions(esp_wifi_get_config(self->if_id, &cfg));
+    }
+
+    #define QS(x) (uintptr_t)MP_OBJ_NEW_QSTR(x)
+
+    if (kwargs->used != 0) {
+        if (!is_wifi) {
+            goto unknown;
+        }
+
+        for (size_t i = 0; i < kwargs->alloc; i++) {
+            if (mp_map_slot_is_filled(kwargs, i)) {
+                int req_if = -1;
+
+                switch ((uintptr_t)kwargs->table[i].key) {
+                    case QS(MP_QSTR_mac): {
+                        mp_buffer_info_t bufinfo;
+                        mp_get_buffer_raise(kwargs->table[i].value, &bufinfo, MP_BUFFER_READ);
+                        if (bufinfo.len != 6) {
+                            mp_raise_ValueError(MP_ERROR_TEXT("invalid buffer length"));
+                        }
+                        esp_exceptions(esp_wifi_set_mac(self->if_id, bufinfo.buf));
+                        break;
+                    }
+                    case QS(MP_QSTR_essid): {
+                        req_if = WIFI_IF_AP;
+                        size_t len;
+                        const char *s = mp_obj_str_get_data(kwargs->table[i].value, &len);
+                        len = MIN(len, sizeof(cfg.ap.ssid));
+                        memcpy(cfg.ap.ssid, s, len);
+                        cfg.ap.ssid_len = len;
+                        break;
+                    }
+                    case QS(MP_QSTR_hidden): {
+                        req_if = WIFI_IF_AP;
+                        cfg.ap.ssid_hidden = mp_obj_is_true(kwargs->table[i].value);
+                        break;
+                    }
+                    case QS(MP_QSTR_authmode): {
+                        req_if = WIFI_IF_AP;
+                        cfg.ap.authmode = mp_obj_get_int(kwargs->table[i].value);
+                        break;
+                    }
+                    case QS(MP_QSTR_password): {
+                        req_if = WIFI_IF_AP;
+                        size_t len;
+                        const char *s = mp_obj_str_get_data(kwargs->table[i].value, &len);
+                        len = MIN(len, sizeof(cfg.ap.password) - 1);
+                        memcpy(cfg.ap.password, s, len);
+                        cfg.ap.password[len] = 0;
+                        break;
+                    }
+                    case QS(MP_QSTR_channel): {
+                        req_if = WIFI_IF_AP;
+                        cfg.ap.channel = mp_obj_get_int(kwargs->table[i].value);
+                        break;
+                    }
+                    case QS(MP_QSTR_dhcp_hostname): {
+                        const char *s = mp_obj_str_get_str(kwargs->table[i].value);
+                        esp_exceptions(tcpip_adapter_set_hostname(self->if_id, s));
+                        break;
+                    }
+                    case QS(MP_QSTR_max_clients): {
+                        req_if = WIFI_IF_AP;
+                        cfg.ap.max_connection = mp_obj_get_int(kwargs->table[i].value);
+                        break;
+                    }
+                    case QS(MP_QSTR_reconnects): {
+                        int reconnects = mp_obj_get_int(kwargs->table[i].value);
+                        req_if = WIFI_IF_STA;
+                        // parameter reconnects == -1 means to retry forever.
+                        // here means conf_wifi_sta_reconnects == 0 to retry forever.
+                        conf_wifi_sta_reconnects = (reconnects == -1) ? 0 : reconnects + 1;
+                        break;
+                    }
+                    default:
+                        goto unknown;
+                }
+
+                // We post-check interface requirements to save on code size
+                if (req_if >= 0) {
+                    require_if(args[0], req_if);
+                }
+            }
+        }
+
+        esp_exceptions(esp_wifi_set_config(self->if_id, &cfg));
+
+        return mp_const_none;
+    }
+
+    // Get config
+
+    if (n_args != 2) {
+        mp_raise_TypeError(MP_ERROR_TEXT("can query only one param"));
+    }
+
+    int req_if = -1;
+    mp_obj_t val = mp_const_none;
+
+    switch ((uintptr_t)args[1]) {
+        case QS(MP_QSTR_mac): {
+            uint8_t mac[6];
+            switch (self->if_id) {
+                case WIFI_IF_AP: // fallthrough intentional
+                case WIFI_IF_STA:
+                    esp_exceptions(esp_wifi_get_mac(self->if_id, mac));
+                    return mp_obj_new_bytes(mac, sizeof(mac));
+                default:
+                    goto unknown;
+            }
+        }
+        case QS(MP_QSTR_essid):
+            switch (self->if_id) {
+                case WIFI_IF_STA:
+                    val = mp_obj_new_str((char *)cfg.sta.ssid, strlen((char *)cfg.sta.ssid));
+                    break;
+                case WIFI_IF_AP:
+                    val = mp_obj_new_str((char *)cfg.ap.ssid, cfg.ap.ssid_len);
+                    break;
+                default:
+                    req_if = WIFI_IF_AP;
+            }
+            break;
+        case QS(MP_QSTR_hidden):
+            req_if = WIFI_IF_AP;
+            val = mp_obj_new_bool(cfg.ap.ssid_hidden);
+            break;
+        case QS(MP_QSTR_authmode):
+            req_if = WIFI_IF_AP;
+            val = MP_OBJ_NEW_SMALL_INT(cfg.ap.authmode);
+            break;
+        case QS(MP_QSTR_channel):
+            req_if = WIFI_IF_AP;
+            val = MP_OBJ_NEW_SMALL_INT(cfg.ap.channel);
+            break;
+        case QS(MP_QSTR_dhcp_hostname): {
+            const char *s;
+            esp_exceptions(tcpip_adapter_get_hostname(self->if_id, &s));
+            val = mp_obj_new_str(s, strlen(s));
+            break;
+        }
+        case QS(MP_QSTR_max_clients): {
+            val = MP_OBJ_NEW_SMALL_INT(cfg.ap.max_connection);
+            break;
+        }
+        case QS(MP_QSTR_reconnects):
+            req_if = WIFI_IF_STA;
+            int rec = conf_wifi_sta_reconnects - 1;
+            val = MP_OBJ_NEW_SMALL_INT(rec);
+            break;
+        default:
+            goto unknown;
+    }
+
+#undef QS
+
+    // We post-check interface requirements to save on code size
+    if (req_if >= 0) {
+        require_if(args[0], req_if);
+    }
+
+    return val;
+
+unknown:
+    mp_raise_ValueError(MP_ERROR_TEXT("unknown config param"));
+}
+MP_DEFINE_CONST_FUN_OBJ_KW(network_wlan_config_obj, 1, network_wlan_config);
+
+STATIC const mp_rom_map_elem_t wlan_if_locals_dict_table[] = {
+    { MP_ROM_QSTR(MP_QSTR_active), MP_ROM_PTR(&network_wlan_active_obj) },
+    { MP_ROM_QSTR(MP_QSTR_connect), MP_ROM_PTR(&network_wlan_connect_obj) },
+    { MP_ROM_QSTR(MP_QSTR_disconnect), MP_ROM_PTR(&network_wlan_disconnect_obj) },
+    { MP_ROM_QSTR(MP_QSTR_status), MP_ROM_PTR(&network_wlan_status_obj) },
+    { MP_ROM_QSTR(MP_QSTR_scan), MP_ROM_PTR(&network_wlan_scan_obj) },
+    { MP_ROM_QSTR(MP_QSTR_isconnected), MP_ROM_PTR(&network_wlan_isconnected_obj) },
+    { MP_ROM_QSTR(MP_QSTR_config), MP_ROM_PTR(&network_wlan_config_obj) },
+    { MP_ROM_QSTR(MP_QSTR_ifconfig), MP_ROM_PTR(&esp_ifconfig_obj) },
+};
+STATIC MP_DEFINE_CONST_DICT(wlan_if_locals_dict, wlan_if_locals_dict_table);
+
+STATIC const mp_obj_type_t wlan_if_type = {
+    { &mp_type_type },
+    .name = MP_QSTR_WLAN,
+    .locals_dict = (mp_obj_t)&wlan_if_locals_dict,
+};
+
+#endif // MICROPY_PY_NETWORK_WLAN


### PR DESCRIPTION
To match network_lan.c and network_ppp.c, and make it clear what code is specifically for WLAN support.

Also provide a configuration option MICROPY_PY_NETWORK_WLAN which can be used to fully disable network.WLAN (it's enabled by default).
