### PR TITLE
Adds Melopero Shake RP2040 board definition 

### DIFF
--- a/ports/rp2/boards/MELOPERO_SHAKE_RP2040/mpconfigboard.cmake
+++ b/ports/rp2/boards/MELOPERO_SHAKE_RP2040/mpconfigboard.cmake
@@ -1,0 +1,1 @@
+# cmake file for Melopero shake

--- a/ports/rp2/boards/MELOPERO_SHAKE_RP2040/mpconfigboard.h
+++ b/ports/rp2/boards/MELOPERO_SHAKE_RP2040/mpconfigboard.h
@@ -1,0 +1,15 @@
+// Board and hardware specific configuration
+#define MICROPY_HW_BOARD_NAME                   "Melopero Shake RP2040"
+#define MICROPY_HW_FLASH_STORAGE_BYTES          (15 * 1024 * 1024)
+
+#define MICROPY_HW_USB_VID (0x2E8A)
+#define MICROPY_HW_USB_PID (0x1005)
+
+// Qwiic on I2C1
+#define MICROPY_HW_I2C1_SCL  (3)
+#define MICROPY_HW_I2C1_SDA  (2)
+
+#define MICROPY_HW_SPI0_SCK  (18)
+#define MICROPY_HW_SPI0_MOSI (19)
+#define MICROPY_HW_SPI0_MISO (20)
+

--- a/ports/rp2/boards/MELOPERO_SHAKE_RP2040/mpconfigboard.h
+++ b/ports/rp2/boards/MELOPERO_SHAKE_RP2040/mpconfigboard.h
@@ -1,4 +1,6 @@
-// Board and hardware specific configuration
+// Board and hardware specific configuration for Melopero Shake RP2040
+// https://www.melopero.com/melopero-shake-rp2040
+
 #define MICROPY_HW_BOARD_NAME                   "Melopero Shake RP2040"
 #define MICROPY_HW_FLASH_STORAGE_BYTES          (15 * 1024 * 1024)
 


### PR DESCRIPTION
Hi, this PR adds all the necessary files to build Micropython for the upcoming Melopero Shake RP2040 development board. We tested it and it builds and runs fine.
Thank you very much. 