### PR TITLE
stm32/sdram: Clean D-cache before disabling it to flush cache.

### DIFF
--- a/ports/stm32/sdram.c
+++ b/ports/stm32/sdram.c
@@ -303,6 +303,7 @@ bool __attribute__((optimize("O0"))) sdram_test(bool exhaustive) {
     }
 
     if (SCB->CCR & (uint32_t)SCB_CCR_DC_Msk) {
+        SCB_CleanDCache();
         SCB_DisableDCache();
         d_cache_disabled = true;
     }


### PR DESCRIPTION
Otherwise any variables (eg the "exhaustive" argument) could be lost when disabling the D-cache.
