### PR TITLE
stm32,esp32/I2S: Transmit null samples during underflow situations.

### DIFF
--- a/ports/esp32/machine_i2s.c
+++ b/ports/esp32/machine_i2s.c
@@ -448,6 +448,7 @@ STATIC void machine_i2s_init_helper(machine_i2s_obj_t *self, size_t n_pos_args, 
     i2s_config.dma_buf_count = get_dma_buf_count(mode, bits, format, self->ibuf);
     i2s_config.dma_buf_len = DMA_BUF_LEN_IN_I2S_FRAMES;
     i2s_config.use_apll = false;
+    i2s_config.tx_desc_auto_clear = true;
 
     // I2S queue size equals the number of DMA buffers
     check_esp_err(i2s_driver_install(self->port, &i2s_config, i2s_config.dma_buf_count, &self->i2s_event_queue));

--- a/ports/stm32/machine_i2s.c
+++ b/ports/stm32/machine_i2s.c
@@ -509,6 +509,9 @@ STATIC void feed_dma(machine_i2s_obj_t *self, ping_pong_t dma_ping_pong) {
         if (self->bits == 32) {
             reformat_32_bit_samples((int32_t *)dma_buffer_p, SIZEOF_HALF_DMA_BUFFER_IN_BYTES / (sizeof(uint32_t)));
         }
+    } else {
+        // underflow.  clear buffer to transmit "silence" on the I2S bus
+        memset(dma_buffer_p, 0, SIZEOF_HALF_DMA_BUFFER_IN_BYTES);
     }
 
     // flush cache to RAM so DMA can read the sample data


### PR DESCRIPTION
Eliminate noise data from being sent to the I2S peripheral
when the transmitted sample stream is stopped.