### PR TITLE
uasyncio.stream.py: Enable allocation-free write.

### DIFF
--- a/docs/library/uasyncio.rst
+++ b/docs/library/uasyncio.rst
@@ -262,11 +262,14 @@ TCP stream connections
 
     This is a coroutine.
 
-.. method:: Stream.write(buf)
+.. method:: Stream.write(buf, copy=True)
 
     Accumulated *buf* to the output buffer.  The data is only flushed when
     `Stream.drain` is called.  It is recommended to call `Stream.drain` immediately
-    after calling this function.
+    after calling this function. With ``copy=True`` the buffer is copied to the
+    output buffer which implies allocation. Setting ``copy=False`` causes
+    `Stream.drain` to use the buffer directly, but the buffer contents should not
+    be altered until `Stream.drain` has terminated.
 
 .. method:: Stream.drain()
 

--- a/extmod/uasyncio/stream.py
+++ b/extmod/uasyncio/stream.py
@@ -55,8 +55,11 @@ class Stream:
             if not l2 or l[-1] == 10:  # \n (check l in case l2 is str)
                 return l
 
-    def write(self, buf):
-        self.out_buf += buf
+    def write(self, buf, copy=True):
+        if copy:
+            self.out_buf += buf
+        else:
+            self.out_buf = buf
 
     async def drain(self):
         mv = memoryview(self.out_buf)

--- a/tests/multi_net/uasyncio_tcp_server_client_noalloc.py
+++ b/tests/multi_net/uasyncio_tcp_server_client_noalloc.py
@@ -1,0 +1,58 @@
+# Test uasyncio TCP server and client using start_server() and open_connection()
+
+try:
+    import uasyncio as asyncio
+except ImportError:
+    try:
+        import asyncio
+    except ImportError:
+        print("SKIP")
+        raise SystemExit
+
+PORT = 8000
+
+
+async def handle_connection(reader, writer):
+    # Test that peername exists (but don't check its value, it changes)
+    writer.get_extra_info("peername")
+
+    data = await reader.read(100)
+    print("echo:", data)
+    writer.write(data)
+    await writer.drain()
+
+    print("close")
+    writer.close()
+    await writer.wait_closed()
+
+    print("done")
+    ev.set()
+
+
+async def tcp_server():
+    global ev
+    ev = asyncio.Event()
+    server = await asyncio.start_server(handle_connection, "0.0.0.0", PORT)
+    print("server running")
+    multitest.next()
+    async with server:
+        await asyncio.wait_for(ev.wait(), 10)
+
+
+async def tcp_client(message):
+    reader, writer = await asyncio.open_connection(IP, PORT)
+    print("write:", message)
+    writer.write(message, False)
+    await writer.drain()
+    data = await reader.read(100)
+    print("read:", data)
+
+
+def instance0():
+    multitest.globals(IP=multitest.get_network_ip())
+    asyncio.run(tcp_server())
+
+
+def instance1():
+    multitest.next()
+    asyncio.run(tcp_client(b"client data"))

--- a/tests/multi_net/uasyncio_tcp_server_client_noalloc.py.exp
+++ b/tests/multi_net/uasyncio_tcp_server_client_noalloc.py.exp
@@ -1,0 +1,8 @@
+--- instance0 ---
+server running
+echo: b'client data'
+close
+done
+--- instance1 ---
+write: b'client data'
+read: b'client data'


### PR DESCRIPTION
By default `stream.write()` copies the passed buffer, resulting in allocation. Where the buffer is large, this can result in application failure due to fragmentation. The `copy` arg enables allocation to be suppressed, supporting the use of a pre-allocated buffer. The doc is updated to clarify the fact that in this case the user must not modify the buffer until `drain` has completed.

This PR results from a collaboration with Mike Teachman - an attempt to create a demo of a GUI-based player for CD quality music. Buffer sizes are on the order of 10-20KB.