### PR TITLE
mpremote/pyboardextended: Add mkdir and rmdir to RemoteFS.

### DIFF
--- a/tools/mpremote/mpremote/pyboardextended.py
+++ b/tools/mpremote/mpremote/pyboardextended.py
@@ -21,6 +21,8 @@ fs_hook_cmds = {
     "CMD_SEEK": 8,
     "CMD_REMOVE": 9,
     "CMD_RENAME": 10,
+    "CMD_MKDIR": 11,
+    "CMD_RMDIR": 12,
 }
 
 fs_hook_code = """\
@@ -254,6 +256,24 @@ class RemoteFS:
         c.begin(CMD_RENAME)
         c.wr_str(self.path + old)
         c.wr_str(self.path + new)
+        res = c.rd_s32()
+        c.end()
+        if res < 0:
+            raise OSError(-res)
+
+    def mkdir(self, path):
+        c = self.cmd
+        c.begin(CMD_MKDIR)
+        c.wr_str(self.path + path)
+        res = c.rd_s32()
+        c.end()
+        if res < 0:
+            raise OSError(-res)
+
+    def rmdir(self, path):
+        c = self.cmd
+        c.begin(CMD_RMDIR)
+        c.wr_str(self.path + path)
         res = c.rd_s32()
         c.end()
         if res < 0:
@@ -495,6 +515,28 @@ class PyboardCommand:
             ret = -abs(er.errno)
         self.wr_s32(ret)
 
+    def do_mkdir(self):
+        path = self.root + self.rd_str()
+        # self.log_cmd(f"mkdir {path}")
+        try:
+            self.path_check(path)
+            os.mkdir(path)
+            ret = 0
+        except OSError as er:
+            ret = -abs(er.errno)
+        self.wr_s32(ret)
+
+    def do_rmdir(self):
+        path = self.root + self.rd_str()
+        # self.log_cmd(f"rmdir {path}")
+        try:
+            self.path_check(path)
+            os.rmdir(path)
+            ret = 0
+        except OSError as er:
+            ret = -abs(er.errno)
+        self.wr_s32(ret)
+
     cmd_table = {
         fs_hook_cmds["CMD_STAT"]: do_stat,
         fs_hook_cmds["CMD_ILISTDIR_START"]: do_ilistdir_start,
@@ -506,6 +548,8 @@ class PyboardCommand:
         fs_hook_cmds["CMD_SEEK"]: do_seek,
         fs_hook_cmds["CMD_REMOVE"]: do_remove,
         fs_hook_cmds["CMD_RENAME"]: do_rename,
+        fs_hook_cmds["CMD_MKDIR"]: do_mkdir,
+        fs_hook_cmds["CMD_RMDIR"]: do_rmdir,
     }
 
 


### PR DESCRIPTION
This allows the remote micropython instance to create and delete
directories from the mounted host filesystem in addition to the already
existing functionality of reading, creating, and modifying files.