### PR TITLE
Added UART interrupt options for ESP32

### DIFF
--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -24,7 +24,9 @@
     <option name="RECENT_GIT_ROOT_PATH" value="$PROJECT_DIR$" />
   </component>
   <component name="ProjectId" id="1ytFC2GJOm7iM3rQK5aMAEWNTPj" />
-  <component name="ProjectLevelVcsManager" settingsEditedManually="true" />
+  <component name="ProjectLevelVcsManager" settingsEditedManually="true">
+    <ConfirmationsSetting value="2" id="Add" />
+  </component>
   <component name="ProjectViewState">
     <option name="hideEmptyMiddlePackages" value="true" />
     <option name="showLibraryContents" value="true" />
@@ -44,13 +46,6 @@
     <property name="node.js.selected.package.eslint" value="(autodetect)" />
     <property name="node.js.selected.package.tslint" value="(autodetect)" />
     <property name="settings.editor.selected.configurable" value="clion.platformio.config" />
-  </component>
-  <component name="RunManager">
-    <configuration default="true" type="CMakeRunConfiguration" factoryName="Application" REDIRECT_INPUT="false" ELEVATE="false" USE_EXTERNAL_CONSOLE="false" PASS_PARENT_ENVS_2="true">
-      <method v="2">
-        <option name="com.jetbrains.cidr.execution.CidrBuildBeforeRunTaskProvider$BuildBeforeRunTask" enabled="true" />
-      </method>
-    </configuration>
   </component>
   <component name="SpellCheckerSettings" RuntimeDictionaries="0" Folders="0" CustomDictionaries="0" DefaultDictionary="application-level" UseSingleDictionary="true" transferred="true" />
   <component name="TaskManager">

--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -10,7 +10,7 @@
   </component>
   <component name="ChangeListManager">
     <list default="true" id="92150e9f-bb9a-411d-85b6-eef406910a19" name="Changes" comment="">
-      <change beforePath="$PROJECT_DIR$/ports/esp32/machine_uart.c" beforeDir="false" afterPath="$PROJECT_DIR$/ports/esp32/machine_uart.c" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/.idea/workspace.xml" beforeDir="false" afterPath="$PROJECT_DIR$/.idea/workspace.xml" afterDir="false" />
     </list>
     <option name="SHOW_DIALOG" value="false" />
     <option name="HIGHLIGHT_CONFLICTS" value="true" />
@@ -64,7 +64,7 @@
       <workItem from="1633063379470" duration="2523000" />
       <workItem from="1633067308077" duration="77000" />
       <workItem from="1633067528543" duration="6434000" />
-      <workItem from="1633509722190" duration="2331000" />
+      <workItem from="1633509722190" duration="3541000" />
     </task>
     <servers />
   </component>

--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -1,0 +1,86 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="AutoImportSettings">
+    <option name="autoReloadType" value="SELECTIVE" />
+  </component>
+  <component name="CMakeSettings">
+    <configurations>
+      <configuration PROFILE_NAME="Debug" ENABLED="true" CONFIG_NAME="Debug" />
+    </configurations>
+  </component>
+  <component name="ChangeListManager">
+    <list default="true" id="92150e9f-bb9a-411d-85b6-eef406910a19" name="Changes" comment="">
+      <change beforePath="$PROJECT_DIR$/ports/esp32/machine_uart.c" beforeDir="false" afterPath="$PROJECT_DIR$/ports/esp32/machine_uart.c" afterDir="false" />
+    </list>
+    <option name="SHOW_DIALOG" value="false" />
+    <option name="HIGHLIGHT_CONFLICTS" value="true" />
+    <option name="HIGHLIGHT_NON_ACTIVE_CHANGELIST" value="false" />
+    <option name="LAST_RESOLUTION" value="IGNORE" />
+  </component>
+  <component name="ClangdSettings">
+    <option name="formatViaClangd" value="false" />
+  </component>
+  <component name="Git.Settings">
+    <option name="RECENT_GIT_ROOT_PATH" value="$PROJECT_DIR$" />
+  </component>
+  <component name="ProjectId" id="1ytFC2GJOm7iM3rQK5aMAEWNTPj" />
+  <component name="ProjectLevelVcsManager" settingsEditedManually="true" />
+  <component name="ProjectViewState">
+    <option name="hideEmptyMiddlePackages" value="true" />
+    <option name="showLibraryContents" value="true" />
+    <option name="showMembers" value="true" />
+  </component>
+  <component name="PropertiesComponent">
+    <property name="ASKED_SHARE_PROJECT_CONFIGURATION_FILES" value="true" />
+    <property name="RunOnceActivity.OpenProjectViewOnStart" value="true" />
+    <property name="RunOnceActivity.ShowReadmeOnStart" value="true" />
+    <property name="RunOnceActivity.cidr.known.project.marker" value="true" />
+    <property name="SHARE_PROJECT_CONFIGURATION_FILES" value="true" />
+    <property name="WebServerToolWindowFactoryState" value="false" />
+    <property name="cf.first.check.clang-format" value="false" />
+    <property name="cidr.known.project.marker" value="true" />
+    <property name="node.js.detected.package.eslint" value="true" />
+    <property name="node.js.detected.package.tslint" value="true" />
+    <property name="node.js.selected.package.eslint" value="(autodetect)" />
+    <property name="node.js.selected.package.tslint" value="(autodetect)" />
+    <property name="settings.editor.selected.configurable" value="clion.platformio.config" />
+  </component>
+  <component name="RunManager">
+    <configuration default="true" type="CMakeRunConfiguration" factoryName="Application" REDIRECT_INPUT="false" ELEVATE="false" USE_EXTERNAL_CONSOLE="false" PASS_PARENT_ENVS_2="true">
+      <method v="2">
+        <option name="com.jetbrains.cidr.execution.CidrBuildBeforeRunTaskProvider$BuildBeforeRunTask" enabled="true" />
+      </method>
+    </configuration>
+  </component>
+  <component name="SpellCheckerSettings" RuntimeDictionaries="0" Folders="0" CustomDictionaries="0" DefaultDictionary="application-level" UseSingleDictionary="true" transferred="true" />
+  <component name="TaskManager">
+    <task active="true" id="Default" summary="Default task">
+      <changelist id="92150e9f-bb9a-411d-85b6-eef406910a19" name="Changes" comment="" />
+      <created>1633062847347</created>
+      <option name="number" value="Default" />
+      <option name="presentableId" value="Default" />
+      <updated>1633062847347</updated>
+      <workItem from="1633062849970" duration="515000" />
+      <workItem from="1633063379470" duration="2523000" />
+      <workItem from="1633067308077" duration="77000" />
+      <workItem from="1633067528543" duration="6434000" />
+      <workItem from="1633509722190" duration="2331000" />
+    </task>
+    <servers />
+  </component>
+  <component name="TypeScriptGeneratedFilesManager">
+    <option name="version" value="3" />
+  </component>
+  <component name="Vcs.Log.Tabs.Properties">
+    <option name="TAB_STATES">
+      <map>
+        <entry key="MAIN">
+          <value>
+            <State />
+          </value>
+        </entry>
+      </map>
+    </option>
+    <option name="oldMeFiltersMigrated" value="true" />
+  </component>
+</project>

--- a/docs/esp32/quickref.rst
+++ b/docs/esp32/quickref.rst
@@ -210,6 +210,29 @@ tx     1      10     17
 rx     3      9      16
 =====  =====  =====  =====
 
+
+Below is the list of all UART initialization parameters
+
+* ``uart_port`` - UART port number
+* ``baudrate`` - UART speed in bps (ex. 9600)
+* ``bits`` - UART data bits
+* ``parity`` - Parity
+* ``stop`` - Stop bits
+* ``tx`` - TX pin
+* ``rx`` - RX pin
+* ``rts`` - RTS pin
+* ``cts`` - CTS pin
+* ``txbuf`` - UART TX ring buffer size
+* ``rxbuf`` - UART RX ring buffer size
+* ``timeout`` - Overall timeout
+* ``timeout_char`` - Timeout between characters
+* ``invert`` - Set UART line inverse mode
+* ``flow`` - Set hardware flow control
+* ``rxfifo_full_thresh`` - UART RX full interrupt threshold
+* ``rx_timeout_thresh`` - UART timeout interrupt threshold (unit: time of sending one byte)
+* ``txfifo_empty_intr_thresh`` - UART TX empty interrupt threshold
+
+
 PWM (pulse width modulation)
 ----------------------------
 
@@ -409,14 +432,14 @@ I2S bus
 See :ref:`machine.I2S <machine.I2S>`. ::
 
     from machine import I2S, Pin
-    
+
     i2s = I2S(0, sck=Pin(13), ws=Pin(14), sd=Pin(34), mode=I2S.TX, bits=16, format=I2S.STEREO, rate=44100, ibuf=40000) # create I2S object
     i2s.write(buf)             # write buffer of audio samples to I2S device
-    
+
     i2s = I2S(1, sck=Pin(33), ws=Pin(25), sd=Pin(32), mode=I2S.RX, bits=16, format=I2S.MONO, rate=22050, ibuf=40000) # create I2S object
     i2s.readinto(buf)          # fill buffer with audio samples from I2S device
-    
-The I2S class is currently available as a Technical Preview.  During the preview period, feedback from 
+
+The I2S class is currently available as a Technical Preview.  During the preview period, feedback from
 users is encouraged.  Based on this feedback, the I2S class API and implementation may be changed.
 
 ESP32 has two I2S buses with id=0 and id=1

--- a/docs/library/esp.rst
+++ b/docs/library/esp.rst
@@ -67,7 +67,7 @@ Functions
     **Note**: ESP8266 only
 
     Set the location that native code will be placed for execution after it is
-    compiled.  Native code is emitted when the ``@micropython.native``,
+    compiled.  Native code is emitted when the ``# @micropython.native``,
     ``@micropython.viper`` and ``@micropython.asm_xtensa`` decorators are applied
     to a function.  The ESP8266 must execute code from either iRAM or the lower
     1MByte of flash (which is memory mapped), and this function controls the

--- a/docs/reference/speed_python.rst
+++ b/docs/reference/speed_python.rst
@@ -205,7 +205,7 @@ no adaptation (but see below). It is invoked by means of a function decorator:
 
 .. code:: python
 
-    @micropython.native
+    # @micropython.native
     def foo(self, arg):
         buf = self.linebuf # Cached object
         # code

--- a/drivers/display/lcd160cr.py
+++ b/drivers/display/lcd160cr.py
@@ -1,7 +1,7 @@
 # Driver for official MicroPython LCD160CR display
 # MIT license; Copyright (c) 2017 Damien P. George
 
-from micropython import const
+from src.micropython import const
 from utime import sleep_ms
 from ustruct import calcsize, pack_into
 import uerrno, machine

--- a/drivers/display/ssd1306.py
+++ b/drivers/display/ssd1306.py
@@ -1,6 +1,6 @@
 # MicroPython SSD1306 OLED driver, I2C and SPI interfaces
 
-from micropython import const
+from src.micropython import const
 import framebuf
 
 

--- a/drivers/nrf24l01/nrf24l01.py
+++ b/drivers/nrf24l01/nrf24l01.py
@@ -1,7 +1,7 @@
 """NRF24L01 driver for MicroPython
 """
 
-from micropython import const
+from src.micropython import const
 import utime
 
 # nRF24L01+ registers

--- a/drivers/nrf24l01/nrf24l01test.py
+++ b/drivers/nrf24l01/nrf24l01test.py
@@ -5,7 +5,7 @@ import ustruct as struct
 import utime
 from machine import Pin, SPI
 from nrf24l01 import NRF24L01
-from micropython import const
+from src.micropython import const
 
 # Slave pause between receiving data and checking for further packets.
 _RX_POLL_DELAY = const(15)

--- a/drivers/onewire/ds18x20.py
+++ b/drivers/onewire/ds18x20.py
@@ -1,7 +1,7 @@
 # DS18x20 temperature sensor driver for MicroPython.
 # MIT license; Copyright (c) 2016 Damien P. George
 
-from micropython import const
+from src.micropython import const
 
 _CONVERT = const(0x44)
 _RD_SCRATCH = const(0xBE)

--- a/drivers/sdcard/sdcard.py
+++ b/drivers/sdcard/sdcard.py
@@ -20,7 +20,7 @@ Example usage on ESP8266:
 
 """
 
-from micropython import const
+from src.micropython import const
 import time
 
 

--- a/examples/bluetooth/ble_advertising.py
+++ b/examples/bluetooth/ble_advertising.py
@@ -1,6 +1,6 @@
 # Helpers for generating BLE advertising payloads.
 
-from micropython import const
+from src.micropython import const
 import struct
 import bluetooth
 

--- a/examples/bluetooth/ble_bonding_peripheral.py
+++ b/examples/bluetooth/ble_bonding_peripheral.py
@@ -11,9 +11,11 @@ import struct
 import time
 import json
 import binascii
+
+from src import util
 from ble_advertising import advertising_payload
 
-from micropython import const
+from src.micropython import const
 
 _IRQ_CENTRAL_CONNECT = const(1)
 _IRQ_CENTRAL_DISCONNECT = const(2)
@@ -62,12 +64,12 @@ class BLETemperature:
         self._ble = ble
         self._load_secrets()
         self._ble.irq(self._irq)
-        self._ble.config(bond=True)
-        self._ble.config(le_secure=True)
-        self._ble.config(mitm=True)
-        self._ble.config(io=_IO_CAPABILITY_DISPLAY_YESNO)
+        util.config(bond=True)
+        util.config(le_secure=True)
+        util.config(mitm=True)
+        util.config(io=_IO_CAPABILITY_DISPLAY_YESNO)
         self._ble.active(True)
-        self._ble.config(addr_mode=2)
+        util.config(addr_mode=2)
         ((self._handle,),) = self._ble.gatts_register_services((_ENV_SENSE_SERVICE,))
         self._connections = set()
         self._payload = advertising_payload(
@@ -149,7 +151,7 @@ class BLETemperature:
                     self._ble.gatts_indicate(conn_handle, self._handle)
 
     def _advertise(self, interval_us=500000):
-        self._ble.config(addr_mode=2)
+        util.config(addr_mode=2)
         self._ble.gap_advertise(interval_us, adv_data=self._payload)
 
     def _load_secrets(self):

--- a/examples/bluetooth/ble_simple_central.py
+++ b/examples/bluetooth/ble_simple_central.py
@@ -2,14 +2,11 @@
 # UART service (e.g. ble_simple_peripheral.py).
 
 import bluetooth
-import random
-import struct
 import time
-import micropython
 
 from ble_advertising import decode_services, decode_name
 
-from micropython import const
+from src.micropython import const
 
 _IRQ_CENTRAL_CONNECT = const(1)
 _IRQ_CENTRAL_DISCONNECT = const(2)

--- a/examples/bluetooth/ble_simple_peripheral.py
+++ b/examples/bluetooth/ble_simple_peripheral.py
@@ -1,12 +1,10 @@
 # This example demonstrates a UART periperhal.
 
 import bluetooth
-import random
-import struct
 import time
 from ble_advertising import advertising_payload
 
-from micropython import const
+from src.micropython import const
 
 _IRQ_CENTRAL_CONNECT = const(1)
 _IRQ_CENTRAL_DISCONNECT = const(2)

--- a/examples/bluetooth/ble_temperature.py
+++ b/examples/bluetooth/ble_temperature.py
@@ -9,7 +9,7 @@ import struct
 import time
 from ble_advertising import advertising_payload
 
-from micropython import const
+from src.micropython import const
 
 _IRQ_CENTRAL_CONNECT = const(1)
 _IRQ_CENTRAL_DISCONNECT = const(2)

--- a/examples/bluetooth/ble_temperature_central.py
+++ b/examples/bluetooth/ble_temperature_central.py
@@ -1,14 +1,12 @@
 # This example finds and connects to a BLE temperature sensor (e.g. the one in ble_temperature.py).
 
 import bluetooth
-import random
 import struct
 import time
-import micropython
 
 from ble_advertising import decode_services, decode_name
 
-from micropython import const
+from src.micropython import const
 
 _IRQ_CENTRAL_CONNECT = const(1)
 _IRQ_CENTRAL_DISCONNECT = const(2)

--- a/examples/bluetooth/ble_uart_peripheral.py
+++ b/examples/bluetooth/ble_uart_peripheral.py
@@ -3,7 +3,7 @@
 import bluetooth
 from ble_advertising import advertising_payload
 
-from micropython import const
+from src.micropython import const
 
 _IRQ_CENTRAL_CONNECT = const(1)
 _IRQ_CENTRAL_DISCONNECT = const(2)

--- a/examples/bluetooth/ble_uart_repl.py
+++ b/examples/bluetooth/ble_uart_repl.py
@@ -6,7 +6,7 @@
 import bluetooth
 import io
 import os
-import micropython
+from src import micropython
 import machine
 
 from ble_uart_peripheral import BLEUART

--- a/examples/mandel.py
+++ b/examples/mandel.py
@@ -6,7 +6,7 @@ except:
 
 def mandelbrot():
     # returns True if c, complex, is in the Mandelbrot set
-    # @micropython.native
+    # # @micropython.native
     def in_set(c):
         z = 0
         for i in range(40):

--- a/extmod/webrepl/webrepl.py
+++ b/extmod/webrepl/webrepl.py
@@ -23,7 +23,7 @@ def setup_conn(port, accept_handler):
     if accept_handler:
         listen_s.setsockopt(socket.SOL_SOCKET, 20, accept_handler)
     for i in (network.AP_IF, network.STA_IF):
-        iface = network.WLAN(i)
+        iface = network.nic_wlan_sta(i)
         if iface.active():
             print("WebREPL daemon started on ws://%s:%d" % (iface.ifconfig()[0], port))
     return listen_s

--- a/ports/esp32/README.md
+++ b/ports/esp32/README.md
@@ -184,17 +184,18 @@ for a tutorial.
 The following function can be used to connect to a WiFi access point (you can
 either pass in your own SSID and password, or change the defaults so you can
 quickly call `wlan_connect()` and it just works):
+
 ```python
 def wlan_connect(ssid='MYSSID', password='MYPASS'):
-    import network
-    wlan = network.WLAN(network.STA_IF)
-    if not wlan.active() or not wlan.isconnected():
-        wlan.active(True)
-        print('connecting to:', ssid)
-        wlan.connect(ssid, password)
-        while not wlan.isconnected():
-            pass
-    print('network config:', wlan.ifconfig())
+  import network
+  wlan = network.nic_wlan_sta(network.STA_IF)
+  if not wlan.active() or not wlan.isconnected():
+    wlan.active(True)
+    print('connecting to:', ssid)
+    wlan.connect(ssid, password)
+    while not wlan.isconnected():
+      pass
+  print('network config:', wlan.ifconfig())
 ```
 
 Note that some boards require you to configure the WiFi antenna before using

--- a/ports/esp32/boards/LOLIN_S2_MINI/modules/s2mini.py
+++ b/ports/esp32/boards/LOLIN_S2_MINI/modules/s2mini.py
@@ -1,6 +1,6 @@
 # LOLIN S2 MINI MicroPython Helper Library
 
-from micropython import const
+from src.micropython import const
 from machine import Pin
 
 # Pin Assignments

--- a/ports/esp32/boards/M5STACK_ATOM/modules/atom.py
+++ b/ports/esp32/boards/M5STACK_ATOM/modules/atom.py
@@ -5,7 +5,7 @@
 #       ATOM Lite    https://docs.m5stack.com/en/core/atom_lite
 #       ATOM Matrix  https://docs.m5stack.com/en/core/atom_matrix
 
-from micropython import const
+from src.micropython import const
 from machine import Pin
 import neopixel
 

--- a/ports/esp32/boards/UM_FEATHERS2/modules/feathers2.py
+++ b/ports/esp32/boards/UM_FEATHERS2/modules/feathers2.py
@@ -7,8 +7,8 @@
 # 2021-Mar-21 - v0.1 - Initial implementation
 
 # Import required libraries
-from micropython import const
-from machine import Pin, SPI, ADC
+from src.micropython import const
+from machine import Pin, ADC
 import machine, time
 
 # FeatherS2 Hardware Pin Assignments

--- a/ports/esp32/boards/UM_FEATHERS2NEO/modules/feathers2neo.py
+++ b/ports/esp32/boards/UM_FEATHERS2NEO/modules/feathers2neo.py
@@ -7,9 +7,9 @@
 # 2021-Sep-04 - v0.1 - Initial implementation
 
 # Import required libraries
-from micropython import const
+from src.micropython import const
 from machine import Pin, ADC
-import machine, time
+import machine
 
 # FeatherS2 Neo Hardware Pin Assignments
 

--- a/ports/esp32/boards/UM_TINYPICO/modules/tinypico.py
+++ b/ports/esp32/boards/UM_TINYPICO/modules/tinypico.py
@@ -9,9 +9,9 @@
 # 2019-Oct-23 - v1.1 - Removed temp sensor code, prep for frozen modules
 
 # Import required libraries
-from micropython import const
-from machine import Pin, SPI, ADC
-import machine, time, esp32
+from src.micropython import const
+from machine import Pin, ADC
+import machine, time
 
 # TinyPICO Hardware Pin Assignments
 

--- a/ports/esp32/boards/UM_TINYS2/modules/tinys2.py
+++ b/ports/esp32/boards/UM_TINYS2/modules/tinys2.py
@@ -7,9 +7,9 @@
 # 2021-Apr-10 - v0.1 - Initial implementation
 
 # Import required libraries
-from micropython import const
-from machine import Pin, SPI, ADC
-import machine, time
+from src.micropython import const
+from machine import Pin, ADC
+import machine
 
 # TinyS2 Hardware Pin Assignments
 

--- a/ports/esp32/machine_uart.c
+++ b/ports/esp32/machine_uart.c
@@ -51,6 +51,12 @@
 
 #define UART_INV_MASK (UART_INV_TX | UART_INV_RX | UART_INV_RTS | UART_INV_CTS)
 
+//#define UART_INTR_RXFIFO_FULL  (0x1<<0)
+//#define UART_INTR_RXFIFO_TOUT (0x01<<8)
+//#define UART_INTR_RXFIFO_OVF (0x01<<4)
+//#define UART_INTR_BRK_DET (0x01<<7)
+//#define UART_INTR_PARITY_ERR (0x01<<6)
+
 #define UART_INTR_CONFIG_FLAG ((UART_INTR_RXFIFO_FULL) \
                                     | (UART_INTR_RXFIFO_TOUT) \
                                     | (UART_INTR_RXFIFO_OVF) \

--- a/ports/esp8266/modules/inisetup.py
+++ b/ports/esp8266/modules/inisetup.py
@@ -8,7 +8,7 @@ from flashbdev import bdev
 def wifi():
     import ubinascii
 
-    ap_if = network.WLAN(network.AP_IF)
+    ap_if = network.nic_wlan_sta(network.AP_IF)
     essid = b"MicroPython-%s" % ubinascii.hexlify(util.config("mac")[-3:])
     util.config(essid=essid, authmode=network.AUTH_WPA_WPA2_PSK, password=b"micropythoN")
 

--- a/ports/esp8266/modules/inisetup.py
+++ b/ports/esp8266/modules/inisetup.py
@@ -1,5 +1,7 @@
 import uos
 import network
+
+from src import util
 from flashbdev import bdev
 
 
@@ -7,8 +9,8 @@ def wifi():
     import ubinascii
 
     ap_if = network.WLAN(network.AP_IF)
-    essid = b"MicroPython-%s" % ubinascii.hexlify(ap_if.config("mac")[-3:])
-    ap_if.config(essid=essid, authmode=network.AUTH_WPA_WPA2_PSK, password=b"micropythoN")
+    essid = b"MicroPython-%s" % ubinascii.hexlify(util.config("mac")[-3:])
+    util.config(essid=essid, authmode=network.AUTH_WPA_WPA2_PSK, password=b"micropythoN")
 
 
 def check_bootsec():

--- a/ports/esp8266/modules/port_diag.py
+++ b/ports/esp8266/modules/port_diag.py
@@ -24,8 +24,8 @@ def main():
     print(esp.check_fw())
 
     print("\nNetworking:")
-    print("STA ifconfig:", network.WLAN(network.STA_IF).ifconfig())
-    print("AP ifconfig:", network.WLAN(network.AP_IF).ifconfig())
+    print("STA ifconfig:", network.nic_wlan_sta(network.STA_IF).ifconfig())
+    print("AP ifconfig:", network.nic_wlan_sta(network.AP_IF).ifconfig())
     print("Free WiFi driver buffers of type:")
     for i, comm in enumerate(
         ("1,2 TX", "4 Mngmt TX(len: 0x41-0x100)", "5 Mngmt TX (len: 0-0x40)", "7", "8 RX")

--- a/ports/qemu-arm/test-frzmpy/native_frozen_align.py
+++ b/ports/qemu-arm/test-frzmpy/native_frozen_align.py
@@ -1,16 +1,13 @@
-import micropython
-
-
-@micropython.native
+# @micropython.native
 def native_x(x):
     print(x + 1)
 
 
-@micropython.native
+# @micropython.native
 def native_y(x):
     print(x + 1)
 
 
-@micropython.native
+# @micropython.native
 def native_z(x):
     print(x + 1)

--- a/ports/rp2/modules/rp2.py
+++ b/ports/rp2/modules/rp2.py
@@ -2,7 +2,7 @@
 # MIT license; Copyright (c) 2020-2021 Damien P. George
 
 from _rp2 import *
-from micropython import const
+from src.micropython import const
 
 _PROG_DATA = const(0)
 _PROG_OFFSET_PIO0 = const(1)

--- a/ports/stm32/boards/NUCLEO_WB55/rfcore_firmware.py
+++ b/ports/stm32/boards/NUCLEO_WB55/rfcore_firmware.py
@@ -63,7 +63,7 @@
 
 import struct, os
 import machine, stm
-from micropython import const
+from src.micropython import const
 
 _OGF_VENDOR = const(0x3F)
 

--- a/ports/stm32/boards/STM32F4DISC/staccel.py
+++ b/ports/stm32/boards/STM32F4DISC/staccel.py
@@ -14,7 +14,7 @@ See:
     STM32Cube_FW_F4_V1.1.0/Projects/STM32F4-Discovery/Demonstrations/Src/main.c
 """
 
-from micropython import const
+from src.micropython import const
 from pyb import Pin
 from pyb import SPI
 

--- a/ports/stm32/mboot/fwupdate.py
+++ b/ports/stm32/mboot/fwupdate.py
@@ -1,7 +1,7 @@
 # Update Mboot or MicroPython from a .dfu.gz file on the board's filesystem
 # MIT license; Copyright (c) 2019-2020 Damien P. George
 
-from micropython import const
+from src.micropython import const
 import struct, time
 import uzlib, machine, stm
 

--- a/tests/basics/builtin_help.py
+++ b/tests/basics/builtin_help.py
@@ -10,7 +10,8 @@ help() # no args
 help(help) # help for a function
 help(int) # help for a class
 help(1) # help for an instance
-import micropython
+from src import micropython
+
 help(micropython) # help for a module
 help('modules') # list available modules
 

--- a/tests/esp32/check_err_str.py
+++ b/tests/esp32/check_err_str.py
@@ -1,6 +1,6 @@
 try:
     from esp32 import Partition as p
-    import micropython
+    from src import micropython
 except ImportError:
     print("SKIP")
     raise SystemExit

--- a/tests/extmod/uasyncio_heaplock.py
+++ b/tests/extmod/uasyncio_heaplock.py
@@ -1,6 +1,6 @@
 # test that basic scheduling of tasks, and uasyncio.sleep_ms, does not use the heap
 
-import micropython
+from src import micropython
 
 # strict stackless builds can't call functions without allocating a frame on the heap
 try:

--- a/tests/extmod/uasyncio_threadsafeflag.py
+++ b/tests/extmod/uasyncio_threadsafeflag.py
@@ -6,8 +6,7 @@ except ImportError:
     print("SKIP")
     raise SystemExit
 
-
-import micropython
+from src import micropython
 
 try:
     micropython.schedule

--- a/tests/extmod/vfs_fat_finaliser.py
+++ b/tests/extmod/vfs_fat_finaliser.py
@@ -44,7 +44,7 @@ vfs = uos.VfsFat(bdev)
 # is a special case because file objects use a finaliser and allocating with a
 # finaliser is a different path to normal allocation.  It would be better to
 # test this in the core tests but there are no core objects that use finaliser.
-import micropython
+from src import micropython
 
 micropython.heap_lock()
 try:

--- a/tests/feature_check/native_check.py
+++ b/tests/feature_check/native_check.py
@@ -1,5 +1,5 @@
 # this test for the availability of native emitter
-@micropython.native
+# @micropython.native
 def f():
     pass
 

--- a/tests/micropython/const.py
+++ b/tests/micropython/const.py
@@ -1,6 +1,6 @@
 # test constant optimisation
 
-from micropython import const
+from src.micropython import const
 
 X = const(123)
 Y = const(X + 456)

--- a/tests/micropython/const2.py
+++ b/tests/micropython/const2.py
@@ -1,13 +1,13 @@
 # check that consts are not replaced in anything except standalone identifiers
 
-from micropython import const
+from src.micropython import const
 
 X = const(1)
 Y = const(2)
 Z = const(3)
 
 # import that uses a constant
-import micropython as X
+from src import micropython as X
 
 print(globals()["X"])
 

--- a/tests/micropython/const_error.py
+++ b/tests/micropython/const_error.py
@@ -1,7 +1,5 @@
 # make sure syntax error works correctly for bad const definition
 
-from micropython import const
-
 
 def test_syntax(code):
     try:

--- a/tests/micropython/const_intbig.py
+++ b/tests/micropython/const_intbig.py
@@ -1,6 +1,6 @@
 # test constant optimisation, with consts that are bignums
 
-from micropython import const
+from src.micropython import const
 
 # check we can make consts from bignums
 Z1 = const(0xFFFFFFFF)

--- a/tests/micropython/emg_exc.py
+++ b/tests/micropython/emg_exc.py
@@ -1,6 +1,6 @@
 # test that emergency exceptions work
 
-import micropython
+from src import micropython
 import usys
 
 try:

--- a/tests/micropython/extreme_exc.py
+++ b/tests/micropython/extreme_exc.py
@@ -1,6 +1,6 @@
 # test some extreme cases of allocating exceptions and tracebacks
 
-import micropython
+from src import micropython
 
 # Check for stackless build, which can't call functions without
 # allocating a frame on the heap.

--- a/tests/micropython/heap_lock.py
+++ b/tests/micropython/heap_lock.py
@@ -1,6 +1,6 @@
 # check that heap_lock/heap_unlock work as expected
 
-import micropython
+from src import micropython
 
 l = []
 l2 = list(range(100))

--- a/tests/micropython/heap_locked.py
+++ b/tests/micropython/heap_locked.py
@@ -1,6 +1,6 @@
 # test micropython.heap_locked()
 
-import micropython
+from src import micropython
 
 if not hasattr(micropython, "heap_locked"):
     print("SKIP")

--- a/tests/micropython/heapalloc.py
+++ b/tests/micropython/heapalloc.py
@@ -1,6 +1,6 @@
 # check that we can do certain things without allocating heap memory
 
-import micropython
+from src import micropython
 
 # Check for stackless build, which can't call functions without
 # allocating a frame on heap.

--- a/tests/micropython/heapalloc_bytesio.py
+++ b/tests/micropython/heapalloc_bytesio.py
@@ -4,7 +4,7 @@ except ImportError:
     print("SKIP")
     raise SystemExit
 
-import micropython
+from src import micropython
 
 data = b"1234" * 16
 buf = uio.BytesIO(64)

--- a/tests/micropython/heapalloc_bytesio2.py
+++ b/tests/micropython/heapalloc_bytesio2.py
@@ -2,7 +2,7 @@
 # copy its content.
 try:
     import uio
-    import micropython
+    from src import micropython
 
     micropython.mem_total
 except (ImportError, AttributeError):

--- a/tests/micropython/heapalloc_exc_compressed.py
+++ b/tests/micropython/heapalloc_exc_compressed.py
@@ -1,4 +1,4 @@
-import micropython
+from src import micropython
 
 # Tests both code paths for built-in exception raising.
 # mp_obj_new_exception_msg_varg (exception requires decompression at raise-time to format)

--- a/tests/micropython/heapalloc_exc_compressed_emg_exc.py
+++ b/tests/micropython/heapalloc_exc_compressed_emg_exc.py
@@ -1,4 +1,4 @@
-import micropython
+from src import micropython
 
 # Does the full test from heapalloc_exc_compressed.py but while the heap is
 # locked (this can only work when the emergency exception buf is enabled).

--- a/tests/micropython/heapalloc_exc_raise.py
+++ b/tests/micropython/heapalloc_exc_raise.py
@@ -1,6 +1,6 @@
 # Test that we can raise and catch (preallocated) exception
 # without memory allocation.
-import micropython
+from src import micropython
 
 e = ValueError("error")
 

--- a/tests/micropython/heapalloc_fail_bytearray.py
+++ b/tests/micropython/heapalloc_fail_bytearray.py
@@ -1,6 +1,6 @@
 # test handling of failed heap allocation with bytearray
 
-import micropython
+from src import micropython
 
 
 class GetSlice:

--- a/tests/micropython/heapalloc_fail_dict.py
+++ b/tests/micropython/heapalloc_fail_dict.py
@@ -1,6 +1,6 @@
 # test handling of failed heap allocation with dict
 
-import micropython
+from src import micropython
 
 # create dict
 x = 1

--- a/tests/micropython/heapalloc_fail_list.py
+++ b/tests/micropython/heapalloc_fail_list.py
@@ -1,6 +1,6 @@
 # test handling of failed heap allocation with list
 
-import micropython
+from src import micropython
 
 
 class GetSlice:

--- a/tests/micropython/heapalloc_fail_memoryview.py
+++ b/tests/micropython/heapalloc_fail_memoryview.py
@@ -1,6 +1,6 @@
 # test handling of failed heap allocation with memoryview
 
-import micropython
+from src import micropython
 
 
 class GetSlice:

--- a/tests/micropython/heapalloc_fail_set.py
+++ b/tests/micropython/heapalloc_fail_set.py
@@ -1,6 +1,6 @@
 # test handling of failed heap allocation with set
 
-import micropython
+from src import micropython
 
 # create set
 x = 1

--- a/tests/micropython/heapalloc_fail_tuple.py
+++ b/tests/micropython/heapalloc_fail_tuple.py
@@ -1,6 +1,6 @@
 # test handling of failed heap allocation with tuple
 
-import micropython
+from src import micropython
 
 # create tuple
 x = 1

--- a/tests/micropython/heapalloc_inst_call.py
+++ b/tests/micropython/heapalloc_inst_call.py
@@ -1,6 +1,6 @@
 # Test that calling clazz.__call__() with up to at least 3 arguments
 # doesn't require heap allocation.
-import micropython
+from src import micropython
 
 
 class Foo0:

--- a/tests/micropython/heapalloc_int_from_bytes.py
+++ b/tests/micropython/heapalloc_int_from_bytes.py
@@ -1,6 +1,6 @@
 # Test that int.from_bytes() for small number of bytes generates
 # small int.
-import micropython
+from src import micropython
 
 micropython.heap_lock()
 print(int.from_bytes(b"1", "little"))

--- a/tests/micropython/heapalloc_iter.py
+++ b/tests/micropython/heapalloc_iter.py
@@ -14,7 +14,7 @@ except ImportError:
         raise SystemExit
 
 try:
-    from micropython import heap_lock, heap_unlock
+    from src.micropython import heap_lock, heap_unlock
 except (ImportError, AttributeError):
     heap_lock = heap_unlock = lambda: 0
 

--- a/tests/micropython/heapalloc_str.py
+++ b/tests/micropython/heapalloc_str.py
@@ -1,5 +1,5 @@
 # String operations which don't require allocation
-import micropython
+from src import micropython
 
 micropython.heap_lock()
 

--- a/tests/micropython/heapalloc_super.py
+++ b/tests/micropython/heapalloc_super.py
@@ -1,5 +1,5 @@
 # test super() operations which don't require allocation
-import micropython
+from src import micropython
 
 # Check for stackless build, which can't call functions without
 # allocating a frame on heap.

--- a/tests/micropython/heapalloc_traceback.py
+++ b/tests/micropython/heapalloc_traceback.py
@@ -1,6 +1,6 @@
 # test that we can generate a traceback without allocating
 
-import micropython
+from src import micropython
 import usys
 
 try:

--- a/tests/micropython/heapalloc_yield_from.py
+++ b/tests/micropython/heapalloc_yield_from.py
@@ -1,6 +1,7 @@
 # Check that yield-from can work without heap allocation
 
-import micropython
+from src import micropython
+
 
 # Yielding from a function generator
 def sub_gen(a):

--- a/tests/micropython/kbd_intr.py
+++ b/tests/micropython/kbd_intr.py
@@ -1,6 +1,6 @@
 # test the micropython.kbd_intr() function
 
-import micropython
+from src import micropython
 
 try:
     micropython.kbd_intr

--- a/tests/micropython/meminfo.py
+++ b/tests/micropython/meminfo.py
@@ -1,6 +1,6 @@
 # tests meminfo functions in micropython module
 
-import micropython
+from src import micropython
 
 # these functions are not always available
 if not hasattr(micropython, "mem_info"):

--- a/tests/micropython/memstats.py
+++ b/tests/micropython/memstats.py
@@ -1,6 +1,6 @@
 # tests meminfo functions in micropython module
 
-import micropython
+from src import micropython
 
 # these functions are not always available
 if not hasattr(micropython, "mem_total"):

--- a/tests/micropython/native_closure.py
+++ b/tests/micropython/native_closure.py
@@ -1,11 +1,11 @@
 # test native emitter can handle closures correctly
 
 # basic closure
-@micropython.native
+# @micropython.native
 def f():
     x = 1
 
-    @micropython.native
+    # @micropython.native
     def g():
         nonlocal x
         return x
@@ -16,9 +16,9 @@ def f():
 print(f()())
 
 # closing over an argument
-@micropython.native
+# @micropython.native
 def f(x):
-    @micropython.native
+    # @micropython.native
     def g():
         nonlocal x
         return x
@@ -29,11 +29,11 @@ def f(x):
 print(f(2)())
 
 # closing over an argument and a normal local
-@micropython.native
+# @micropython.native
 def f(x):
     y = 2 * x
 
-    @micropython.native
+    # @micropython.native
     def g(z):
         return x + y + z
 

--- a/tests/micropython/native_const.py
+++ b/tests/micropython/native_const.py
@@ -1,7 +1,7 @@
 # test loading constants in native functions
 
 
-@micropython.native
+# @micropython.native
 def f():
     return b"bytes"
 
@@ -9,9 +9,9 @@ def f():
 print(f())
 
 
-@micropython.native
+# @micropython.native
 def f():
-    @micropython.native
+    # @micropython.native
     def g():
         return 123
 

--- a/tests/micropython/native_const_intbig.py
+++ b/tests/micropython/native_const_intbig.py
@@ -1,7 +1,7 @@
 # check loading constants
 
 
-@micropython.native
+# @micropython.native
 def f():
     return 123456789012345678901234567890
 

--- a/tests/micropython/native_for.py
+++ b/tests/micropython/native_for.py
@@ -1,7 +1,7 @@
 # test for native for loops
 
 
-@micropython.native
+# @micropython.native
 def f1(n):
     for i in range(n):
         print(i)
@@ -10,7 +10,7 @@ def f1(n):
 f1(4)
 
 
-@micropython.native
+# @micropython.native
 def f2(r):
     for i in r:
         print(i)

--- a/tests/micropython/native_gen.py
+++ b/tests/micropython/native_gen.py
@@ -1,7 +1,7 @@
 # test for native generators
 
 # simple generator with yield and return
-@micropython.native
+# @micropython.native
 def gen1(x):
     yield x
     yield x + 1
@@ -17,7 +17,7 @@ except StopIteration as e:
     print(e.args[0])
 
 # using yield from
-@micropython.native
+# @micropython.native
 def gen2(x):
     yield from range(x)
 

--- a/tests/micropython/native_misc.py
+++ b/tests/micropython/native_misc.py
@@ -1,7 +1,7 @@
 # tests for natively compiled functions
 
 # basic test
-@micropython.native
+# @micropython.native
 def native_test(x):
     print(1, [], x)
 
@@ -15,7 +15,7 @@ gc.collect()
 native_test(3)
 
 # native with 2 args
-@micropython.native
+# @micropython.native
 def f(a, b):
     print(a + b)
 
@@ -23,7 +23,7 @@ def f(a, b):
 f(1, 2)
 
 # native with 3 args
-@micropython.native
+# @micropython.native
 def f(a, b, c):
     print(a + b + c)
 
@@ -31,7 +31,7 @@ def f(a, b, c):
 f(1, 2, 3)
 
 # check not operator
-@micropython.native
+# @micropython.native
 def f(a):
     print(not a)
 
@@ -41,7 +41,7 @@ f(True)
 
 
 # stack settling in branch
-@micropython.native
+# @micropython.native
 def f(a):
     print(1, 2, 3, 4 if a else 5)
 

--- a/tests/micropython/native_try.py
+++ b/tests/micropython/native_try.py
@@ -1,7 +1,7 @@
 # test native try handling
 
 # basic try-finally
-@micropython.native
+# @micropython.native
 def f():
     try:
         fail
@@ -15,7 +15,7 @@ except NameError:
     print("NameError")
 
 # nested try-except with try-finally
-@micropython.native
+# @micropython.native
 def f():
     try:
         try:
@@ -29,7 +29,7 @@ def f():
 f()
 
 # check that locals written to in try blocks keep their values
-@micropython.native
+# @micropython.native
 def f():
     a = 100
     try:

--- a/tests/micropython/native_try_deep.py
+++ b/tests/micropython/native_try_deep.py
@@ -1,7 +1,7 @@
 # test native try handling
 
 # deeply nested try (9 deep)
-@micropython.native
+# @micropython.native
 def f():
     try:
         try:

--- a/tests/micropython/native_with.py
+++ b/tests/micropython/native_with.py
@@ -13,7 +13,7 @@ class C:
 
 
 # basic with
-@micropython.native
+# @micropython.native
 def f():
     with C():
         print(1)
@@ -22,7 +22,7 @@ def f():
 f()
 
 # nested with and try-except
-@micropython.native
+# @micropython.native
 def f():
     try:
         with C():

--- a/tests/micropython/opt_level.py
+++ b/tests/micropython/opt_level.py
@@ -1,4 +1,4 @@
-import micropython as micropython
+from src import micropython as micropython
 
 # check we can get and set the level
 micropython.opt_level(0)

--- a/tests/micropython/opt_level_lineno.py
+++ b/tests/micropython/opt_level_lineno.py
@@ -1,4 +1,4 @@
-import micropython as micropython
+from src import micropython as micropython
 
 # check that level 3 doesn't store line numbers
 # the expected output is that any line is printed as "line 1"

--- a/tests/micropython/schedule.py
+++ b/tests/micropython/schedule.py
@@ -1,6 +1,6 @@
 # test micropython.schedule() function
 
-import micropython
+from src import micropython
 
 try:
     micropython.schedule

--- a/tests/micropython/stack_use.py
+++ b/tests/micropython/stack_use.py
@@ -1,5 +1,5 @@
 # tests stack_use function in micropython module
-import micropython
+from src import micropython
 
 if not hasattr(micropython, "stack_use"):
     print("SKIP")

--- a/tests/micropython/viper_import.py
+++ b/tests/micropython/viper_import.py
@@ -3,11 +3,11 @@
 
 @micropython.viper
 def f():
-    import micropython
+    from src import micropython
 
     print(micropython.const(1))
 
-    from micropython import const
+    from src.micropython import const
 
     print(const(2))
 

--- a/tests/micropython/viper_misc.py
+++ b/tests/micropython/viper_misc.py
@@ -1,4 +1,5 @@
-import micropython
+from src import micropython
+
 
 # viper function taking and returning ints
 @micropython.viper

--- a/tests/micropython/viper_misc_intbig.py
+++ b/tests/micropython/viper_misc_intbig.py
@@ -1,4 +1,5 @@
-import micropython
+from src import micropython
+
 
 # unsigned ints
 @micropython.viper

--- a/tests/micropython/viper_types.py
+++ b/tests/micropython/viper_types.py
@@ -1,6 +1,7 @@
 # test various type conversions
 
-import micropython
+from src import micropython
+
 
 # converting incoming arg to bool
 @micropython.viper

--- a/tests/multi_bluetooth/ble_characteristic.py
+++ b/tests/multi_bluetooth/ble_characteristic.py
@@ -1,6 +1,6 @@
 # Test characteristic read/write/notify from both GATTS and GATTC.
-
-from micropython import const
+from src import util
+from src.micropython import const
 import time, machine, bluetooth
 
 TIMEOUT_MS = 5000
@@ -84,7 +84,7 @@ def wait_for_event(event, timeout_ms):
 
 # Acting in peripheral role.
 def instance0():
-    multitest.globals(BDADDR=ble.config("mac"))
+    multitest.globals(BDADDR=util.config("mac"))
     ((char_handle,),) = ble.gatts_register_services(SERVICES)
     print("gap_advertise")
     ble.gap_advertise(20_000, b"\x02\x01\x06\x04\xffMPY")

--- a/tests/multi_bluetooth/ble_gap_advertise.py
+++ b/tests/multi_bluetooth/ble_gap_advertise.py
@@ -1,6 +1,6 @@
 # Test BLE GAP advertising and scanning
-
-from micropython import const
+from src import util
+from src.micropython import const
 import time, machine, bluetooth
 
 _IRQ_SCAN_RESULT = const(5)
@@ -10,7 +10,7 @@ ADV_TIME_S = 3
 
 
 def instance0():
-    multitest.globals(BDADDR=ble.config("mac"))
+    multitest.globals(BDADDR=util.config("mac"))
     multitest.next()
 
     print("gap_advertise(100_000, connectable=False)")
@@ -47,7 +47,7 @@ def instance1():
             finished = True
 
     try:
-        ble.config(rxbuf=2000)
+        util.config(rxbuf=2000)
     except:
         pass
     ble.irq(irq)

--- a/tests/multi_bluetooth/ble_gap_connect.py
+++ b/tests/multi_bluetooth/ble_gap_connect.py
@@ -1,6 +1,6 @@
 # Test BLE GAP connect/disconnect
-
-from micropython import const
+from src import util
+from src.micropython import const
 import time, machine, bluetooth
 
 TIMEOUT_MS = 4000
@@ -40,7 +40,7 @@ def wait_for_event(event, timeout_ms):
 
 # Acting in peripheral role.
 def instance0():
-    multitest.globals(BDADDR=ble.config("mac"))
+    multitest.globals(BDADDR=util.config("mac"))
     print("gap_advertise")
     ble.gap_advertise(20_000, b"\x02\x01\x06\x04\xffMPY")
     multitest.next()

--- a/tests/multi_bluetooth/ble_gap_device_name.py
+++ b/tests/multi_bluetooth/ble_gap_device_name.py
@@ -1,6 +1,6 @@
 # Test BLE GAP device name get/set
-
-from micropython import const
+from src import util
+from src.micropython import const
 import time, machine, bluetooth
 
 TIMEOUT_MS = 5000
@@ -56,11 +56,11 @@ def wait_for_event(event, timeout_ms):
 
 # Acting in peripheral role.
 def instance0():
-    multitest.globals(BDADDR=ble.config("mac"))
+    multitest.globals(BDADDR=util.config("mac"))
 
     # Test setting and getting the GAP device name before registering services.
-    ble.config(gap_name="GAP_NAME")
-    print(ble.config("gap_name"))
+    util.config(gap_name="GAP_NAME")
+    print(util.config("gap_name"))
 
     # Create an empty service and start advertising.
     ble.gatts_register_services([])
@@ -71,8 +71,8 @@ def instance0():
         # Do multiple iterations to test changing the name.
         for iteration in range(2):
             # Set the GAP device name and start advertising.
-            ble.config(gap_name="GAP_NAME{}".format(iteration))
-            print(ble.config("gap_name"))
+            util.config(gap_name="GAP_NAME{}".format(iteration))
+            print(util.config("gap_name"))
             ble.gap_advertise(20_000)
 
             # Wait for central to connect, then wait for it to disconnect.

--- a/tests/multi_bluetooth/ble_gap_pair.py
+++ b/tests/multi_bluetooth/ble_gap_pair.py
@@ -1,7 +1,7 @@
 # Test BLE GAP connect/disconnect with pairing, and read an encrypted characteristic
 # TODO: add gap_passkey testing
-
-from micropython import const
+from src import util
+from src.micropython import const
 import time, machine, bluetooth
 
 if not hasattr(bluetooth.BLE, "gap_pair"):
@@ -72,7 +72,7 @@ def wait_for_event(event, timeout_ms):
 
 # Acting in peripheral role.
 def instance0():
-    multitest.globals(BDADDR=ble.config("mac"))
+    multitest.globals(BDADDR=util.config("mac"))
     ((char_handle,),) = ble.gatts_register_services((SERVICE,))
     ble.gatts_write(char_handle, "encrypted")
     print("gap_advertise")
@@ -128,6 +128,6 @@ def instance1():
 
 
 ble = bluetooth.BLE()
-ble.config(mitm=True, le_secure=True, bond=False)
+util.config(mitm=True, le_secure=True, bond=False)
 ble.active(1)
 ble.irq(irq)

--- a/tests/multi_bluetooth/ble_gap_pair_bond.py
+++ b/tests/multi_bluetooth/ble_gap_pair_bond.py
@@ -1,8 +1,8 @@
 # Test BLE GAP connect/disconnect with pairing and bonding, and read an encrypted
 # characteristic
 # TODO: reconnect after bonding to test that the secrets persist
-
-from micropython import const
+from src import util
+from src.micropython import const
 import time, machine, bluetooth
 
 if not hasattr(bluetooth.BLE, "gap_pair"):
@@ -77,7 +77,7 @@ def wait_for_event(event, timeout_ms):
 
 # Acting in peripheral role.
 def instance0():
-    multitest.globals(BDADDR=ble.config("mac"))
+    multitest.globals(BDADDR=util.config("mac"))
     ((char_handle,),) = ble.gatts_register_services((SERVICE,))
     ble.gatts_write(char_handle, "encrypted")
     print("gap_advertise")
@@ -133,6 +133,6 @@ def instance1():
 
 
 ble = bluetooth.BLE()
-ble.config(mitm=True, le_secure=True, bond=True)
+util.config(mitm=True, le_secure=True, bond=True)
 ble.active(1)
 ble.irq(irq)

--- a/tests/multi_bluetooth/ble_gatt_data_transfer.py
+++ b/tests/multi_bluetooth/ble_gatt_data_transfer.py
@@ -1,6 +1,6 @@
 # Test GATTC/S data transfer between peripheral and central, and use of gatts_set_buffer()
-
-from micropython import const
+from src import util
+from src.micropython import const
 import time, machine, bluetooth
 
 TIMEOUT_MS = 5000
@@ -83,7 +83,7 @@ def wait_for_event(event, timeout_ms):
 
 # Acting in peripheral role.
 def instance0():
-    multitest.globals(BDADDR=ble.config("mac"))
+    multitest.globals(BDADDR=util.config("mac"))
     ((char_ctrl_handle, char_rx_handle, char_tx_handle),) = ble.gatts_register_services(SERVICES)
 
     # Increase the size of the rx buffer and enable append mode.

--- a/tests/multi_bluetooth/ble_gattc_discover_services.py
+++ b/tests/multi_bluetooth/ble_gattc_discover_services.py
@@ -1,6 +1,6 @@
 # Test BLE GAP connect/disconnect
-
-from micropython import const
+from src import util
+from src.micropython import const
 import time, machine, bluetooth
 
 TIMEOUT_MS = 5000
@@ -62,7 +62,7 @@ def wait_for_event(event, timeout_ms):
 
 # Acting in peripheral role.
 def instance0():
-    multitest.globals(BDADDR=ble.config("mac"))
+    multitest.globals(BDADDR=util.config("mac"))
     ble.gatts_register_services(SERVICES)
     print("gap_advertise")
     ble.gap_advertise(20_000, b"\x02\x01\x06\x04\xffMPY")

--- a/tests/multi_bluetooth/ble_l2cap.py
+++ b/tests/multi_bluetooth/ble_l2cap.py
@@ -3,8 +3,8 @@
 # Sends a sequence of varying-sized payloads from central->peripheral, and
 # verifies that the other device sees the same data, then does the same thing
 # peripheral->central.
-
-from micropython import const
+from src import util
+from src.micropython import const
 import time, machine, bluetooth, random
 
 if not hasattr(bluetooth.BLE, "l2cap_connect"):
@@ -113,7 +113,7 @@ def recv_data(ble, conn_handle, cid):
 
 # Acting in peripheral role.
 def instance0():
-    multitest.globals(BDADDR=ble.config("mac"))
+    multitest.globals(BDADDR=util.config("mac"))
     print("gap_advertise")
     ble.gap_advertise(20_000, b"\x02\x01\x06\x04\xffMPY")
     multitest.next()

--- a/tests/multi_bluetooth/ble_mtu.py
+++ b/tests/multi_bluetooth/ble_mtu.py
@@ -18,8 +18,8 @@
 # Note: This currently fails on btstack for two reasons:
 # - btstack doesn't truncate writes to the MTU (it fails instead)
 # - btstack (in central mode) doesn't handle the peripheral initiating the MTU exchange
-
-from micropython import const
+from src import util
+from src.micropython import const
 import time, machine, bluetooth
 
 TIMEOUT_MS = 5000
@@ -94,7 +94,7 @@ def wait_for_event(event, timeout_ms):
 
 # Acting in peripheral role.
 def instance0():
-    multitest.globals(BDADDR=ble.config("mac"))
+    multitest.globals(BDADDR=util.config("mac"))
     ((char_handle,),) = ble.gatts_register_services(SERVICES)
     ble.gatts_set_buffer(char_handle, 500, False)
     print("gap_advertise")
@@ -103,16 +103,16 @@ def instance0():
     try:
         for i in range(7):
             if i == 1:
-                ble.config(mtu=200)
+                util.config(mtu=200)
             elif i == 2:
-                ble.config(mtu=400)
+                util.config(mtu=400)
             elif i == 3:
-                ble.config(mtu=50)
+                util.config(mtu=50)
             elif i >= 4:
-                ble.config(mtu=290)
+                util.config(mtu=290)
             else:
                 # This is the NimBLE default.
-                ble.config(mtu=256)
+                util.config(mtu=256)
 
             # Wait for central to connect to us.
             conn_handle = wait_for_event(_IRQ_CENTRAL_CONNECT, TIMEOUT_MS)
@@ -149,13 +149,13 @@ def instance1():
     try:
         for i in range(7):
             if i < 4:
-                ble.config(mtu=300)
+                util.config(mtu=300)
             elif i == 5:
-                ble.config(mtu=190)
+                util.config(mtu=190)
             elif i == 6:
-                ble.config(mtu=350)
+                util.config(mtu=350)
             else:
-                ble.config(mtu=256)
+                util.config(mtu=256)
 
             # Connect to peripheral and then disconnect.
             # Extra scan timeout allows for the peripheral to receive the previous disconnect

--- a/tests/multi_bluetooth/ble_subscribe.py
+++ b/tests/multi_bluetooth/ble_subscribe.py
@@ -1,6 +1,6 @@
 # Test for sending notifications to subscribed clients.
-
-from micropython import const
+from src import util
+from src.micropython import const
 import time, machine, bluetooth
 
 TIMEOUT_MS = 5000
@@ -94,7 +94,7 @@ def wait_for_event(event, timeout_ms):
 
 # Acting in peripheral role.
 def instance0():
-    multitest.globals(BDADDR=ble.config("mac"))
+    multitest.globals(BDADDR=util.config("mac"))
     ((char_handle,),) = ble.gatts_register_services(SERVICES)
     print("gap_advertise")
     ble.gap_advertise(20_000, b"\x02\x01\x06\x04\xffMPY")  # \x04\x09MPY

--- a/tests/multi_bluetooth/perf_gatt_char_write.py
+++ b/tests/multi_bluetooth/perf_gatt_char_write.py
@@ -1,6 +1,6 @@
 # Write characteristic from central to peripheral and time data rate.
-
-from micropython import const
+from src import util
+from src.micropython import const
 import time, machine, bluetooth
 
 TIMEOUT_MS = 2000
@@ -70,7 +70,7 @@ def wait_for_event(event, timeout_ms):
 
 # Acting in peripheral role.
 def instance0():
-    multitest.globals(BDADDR=ble.config("mac"))
+    multitest.globals(BDADDR=util.config("mac"))
     ((char_handle,),) = ble.gatts_register_services(SERVICES)
     ble.gatts_set_buffer(char_handle, _CHAR_SIZE)
     print("gap_advertise")
@@ -94,7 +94,7 @@ def instance1():
     try:
         # Connect to peripheral and then disconnect.
         print("gap_connect")
-        ble.config(mtu=_MTU_SIZE)
+        util.config(mtu=_MTU_SIZE)
         ble.gap_connect(*BDADDR)
         conn_handle = wait_for_event(_IRQ_PERIPHERAL_CONNECT, TIMEOUT_MS)
         ble.gattc_exchange_mtu(conn_handle)

--- a/tests/multi_bluetooth/perf_gatt_notify.py
+++ b/tests/multi_bluetooth/perf_gatt_notify.py
@@ -1,6 +1,6 @@
 # Ping-pong GATT notifications between two devices.
-
-from micropython import const
+from src import util
+from src.micropython import const
 import time, machine, bluetooth
 
 TIMEOUT_MS = 2000
@@ -64,7 +64,7 @@ def wait_for_event(event, timeout_ms):
 
 # Acting in peripheral role.
 def instance0():
-    multitest.globals(BDADDR=ble.config("mac"))
+    multitest.globals(BDADDR=util.config("mac"))
     ((char_handle,),) = ble.gatts_register_services(SERVICES)
     print("gap_advertise")
     ble.gap_advertise(20_000, b"\x02\x01\x06\x04\xffMPY")

--- a/tests/multi_bluetooth/perf_l2cap.py
+++ b/tests/multi_bluetooth/perf_l2cap.py
@@ -1,6 +1,6 @@
 # Send L2CAP data as fast as possible and time it.
-
-from micropython import const
+from src import util
+from src.micropython import const
 import time, machine, bluetooth, random
 
 if not hasattr(bluetooth.BLE, "l2cap_connect"):
@@ -91,7 +91,7 @@ def recv_data(ble, conn_handle, cid):
 
 # Acting in peripheral role.
 def instance0():
-    multitest.globals(BDADDR=ble.config("mac"))
+    multitest.globals(BDADDR=util.config("mac"))
     ble.gap_advertise(20_000, b"\x02\x01\x06\x04\xffMPY")
     multitest.next()
     try:

--- a/tests/multi_bluetooth/stress_log_filesystem.py
+++ b/tests/multi_bluetooth/stress_log_filesystem.py
@@ -1,8 +1,8 @@
 # Test concurrency between filesystem access and BLE host. This is
 # particularly relevant on STM32WB where the second core is stalled while
 # flash operations are in progress.
-
-from micropython import const
+from src import util
+from src.micropython import const
 import time, machine, bluetooth, os
 
 TIMEOUT_MS = 10000
@@ -121,7 +121,7 @@ def instance0():
     write_log("start")
     ble.active(1)
     ble.irq(irq)
-    multitest.globals(BDADDR=ble.config("mac"))
+    multitest.globals(BDADDR=util.config("mac"))
     ((char_handle,),) = ble.gatts_register_services(SERVICES)
     multitest.next()
     try:

--- a/tests/net_inet/tls_num_errors.py
+++ b/tests/net_inet/tls_num_errors.py
@@ -5,7 +5,7 @@ try:
 except:
     import socket, ssl, sys
 try:
-    from micropython import alloc_emergency_exception_buf, heap_lock, heap_unlock
+    from src.micropython import alloc_emergency_exception_buf, heap_lock, heap_unlock
 except:
     print("SKIP")
     raise SystemExit

--- a/tests/perf_bench/viper_call0.py
+++ b/tests/perf_bench/viper_call0.py
@@ -3,7 +3,7 @@ def f0():
     pass
 
 
-@micropython.native
+# @micropython.native
 def call(r):
     f = f0
     for _ in r:

--- a/tests/perf_bench/viper_call1a.py
+++ b/tests/perf_bench/viper_call1a.py
@@ -3,7 +3,7 @@ def f1a(x):
     return x
 
 
-@micropython.native
+# @micropython.native
 def call(r):
     f = f1a
     for _ in r:

--- a/tests/perf_bench/viper_call1b.py
+++ b/tests/perf_bench/viper_call1b.py
@@ -3,7 +3,7 @@ def f1b(x) -> int:
     return int(x)
 
 
-@micropython.native
+# @micropython.native
 def call(r):
     f = f1b
     for _ in r:

--- a/tests/perf_bench/viper_call1c.py
+++ b/tests/perf_bench/viper_call1c.py
@@ -3,7 +3,7 @@ def f1c(x: int) -> int:
     return x
 
 
-@micropython.native
+# @micropython.native
 def call(r):
     f = f1c
     for _ in r:

--- a/tests/perf_bench/viper_call2a.py
+++ b/tests/perf_bench/viper_call2a.py
@@ -3,7 +3,7 @@ def f2a(x, y):
     return x
 
 
-@micropython.native
+# @micropython.native
 def call(r):
     f = f2a
     for _ in r:

--- a/tests/perf_bench/viper_call2b.py
+++ b/tests/perf_bench/viper_call2b.py
@@ -3,7 +3,7 @@ def f2b(x: int, y: int) -> int:
     return x + y
 
 
-@micropython.native
+# @micropython.native
 def call(r):
     f = f2b
     for _ in r:

--- a/tests/pyb/can.py
+++ b/tests/pyb/can.py
@@ -5,7 +5,7 @@ except ImportError:
     raise SystemExit
 
 from array import array
-import micropython
+from src import micropython
 import pyb
 
 # test we can correctly create by id (2 handled in can2.py test)

--- a/tests/pybnative/while.py
+++ b/tests/pybnative/while.py
@@ -1,7 +1,7 @@
 import time, pyb
 
 
-@micropython.native
+# @micropython.native
 def f(led, n, d):
     led.off()
     i = 0

--- a/tests/thread/stress_schedule.py
+++ b/tests/thread/stress_schedule.py
@@ -3,7 +3,7 @@
 
 import _thread
 import utime
-import micropython
+from src import micropython
 import gc
 
 try:

--- a/tests/thread/thread_heap_lock.py
+++ b/tests/thread/thread_heap_lock.py
@@ -1,6 +1,7 @@
 # test interaction of micropython.heap_lock with threads
 
-import _thread, micropython
+import _thread
+from src import micropython
 
 lock1 = _thread.allocate_lock()
 lock2 = _thread.allocate_lock()


### PR DESCRIPTION
Added support to ESP32 UART interrupt configuration, a.k.a - `uart_intr_config` sdk call.
Some small and or slow baud rate configuration does not return the number of bytes read in the `read` call.
And lowering the `rxfifo_full_thresh` parameter fix this behavior.
Fix #7833