### PR TITLE
Rp2 Port - exec sideset

### DIFF
--- a/docs/library/rp2.rst
+++ b/docs/library/rp2.rst
@@ -58,7 +58,7 @@ For running PIO programs, see :class:`rp2.StateMachine`.
       combined into a single 8-word FIFO for one direction only. The options
       are `PIO.JOIN_NONE`, `PIO.JOIN_RX` and `PIO.JOIN_TX`.
 
-.. function:: asm_pio_encode(instr, sideset_count)
+.. function:: asm_pio_encode(instr, sideset_count, sideset_opt=False)
 
     Assemble a single PIO instruction. You usually want to use `asm_pio()`
     instead.

--- a/ports/rp2/rp2_pio.c
+++ b/ports/rp2/rp2_pio.c
@@ -613,7 +613,12 @@ STATIC mp_obj_t rp2_state_machine_exec(mp_obj_t self_in, mp_obj_t instr_in) {
     mp_obj_t rp2_module = mp_import_name(MP_QSTR_rp2, mp_const_none, MP_OBJ_NEW_SMALL_INT(0));
     mp_obj_t asm_pio_encode = mp_load_attr(rp2_module, MP_QSTR_asm_pio_encode);
     uint32_t sideset_count = self->pio->sm[self->sm].pinctrl >> PIO_SM0_PINCTRL_SIDESET_COUNT_LSB;
-    mp_obj_t encoded_obj = mp_call_function_2(asm_pio_encode, instr_in, MP_OBJ_NEW_SMALL_INT(sideset_count));
+    uint8_t sideset_opt = !!(self->pio->sm[self->sm].execctrl & (1 << PIO_SM0_EXECCTRL_SIDE_EN_LSB));
+    mp_obj_t args[3];
+    args[0] = instr_in;
+    args[1] = MP_OBJ_NEW_SMALL_INT(sideset_count);
+    args[2] = MP_OBJ_NEW_SMALL_INT(sideset_opt);
+    mp_obj_t encoded_obj = mp_call_function_n_kw(asm_pio_encode, 3, 0, args);
     mp_int_t encoded = mp_obj_get_int(encoded_obj);
     pio_sm_exec(self->pio, self->sm, encoded);
     return mp_const_none;


### PR DESCRIPTION
The rp2.StateMachine.exec errors when supplying a sideset action
This patch passes the sideset_opt from the StateMachine though to the parser
Adds some value validation to the sideset operator
Adds the word method to the exec to allow any other unsupported opcodes