### PR TITLE
lib/re1.5: Add support for named classes in class sets.

### DIFF
--- a/lib/re1.5/charclass.c
+++ b/lib/re1.5/charclass.c
@@ -6,7 +6,15 @@ int _re1_5_classmatch(const char *pc, const char *sp)
     int is_positive = (pc[-1] == Class);
     int cnt = *pc++;
     while (cnt--) {
-        if (*sp >= *pc && *sp <= pc[1]) return is_positive;
+        if (*pc == RE15_CLASS_NAMED_CLASS_INDICATOR) {
+            if (_re1_5_namedclassmatch(pc + 1, sp)) {
+                return is_positive;
+            }
+        } else {
+            if (*sp >= *pc && *sp <= pc[1]) {
+                return is_positive;
+            }
+        }
         pc += 2;
     }
     return !is_positive;

--- a/lib/re1.5/compilecode.c
+++ b/lib/re1.5/compilecode.c
@@ -66,14 +66,21 @@ static const char *_compilecode(const char *re, ByteProg *prog, int sizecode)
             PC++; // Skip # of pair byte
             prog->len++;
             for (cnt = 0; *re != ']'; re++, cnt++) {
-                if (*re == '\\') {
+                char c = *re;
+                if (c == '\\') {
                     ++re;
+                    c = *re;
+                    if (MATCH_NAMED_CLASS_CHAR(c)) {
+                        c = RE15_CLASS_NAMED_CLASS_INDICATOR;
+                        goto emit_char_pair;
+                    }
                 }
-                if (!*re) return NULL;
-                EMIT(PC++, *re);
+                if (!c) return NULL;
                 if (re[1] == '-' && re[2] != ']') {
                     re += 2;
                 }
+            emit_char_pair:
+                EMIT(PC++, c);
                 EMIT(PC++, *re);
             }
             EMIT_CHECKED(term + 1, cnt);

--- a/lib/re1.5/compilecode.c
+++ b/lib/re1.5/compilecode.c
@@ -4,6 +4,9 @@
 
 #include "re1.5.h"
 
+// Matches: DSWdsw
+#define MATCH_NAMED_CLASS_CHAR(c) (((c) | 0x20) == 'd' || ((c) | 0x24) == 'w')
+
 #define INSERT_CODE(at, num, pc) \
     ((code ? memmove(code + at + num, code + at, pc - at) : 0), pc += num)
 #define REL(at, to) (to - at - 2)
@@ -31,7 +34,7 @@ static const char *_compilecode(const char *re, ByteProg *prog, int sizecode)
         case '\\':
             re++;
             if (!*re) return NULL; // Trailing backslash
-            if ((*re | 0x20) == 'd' || (*re | 0x20) == 's' || (*re | 0x20) == 'w') {
+            if (MATCH_NAMED_CLASS_CHAR(*re)) {
                 term = PC;
                 EMIT(PC++, NamedClass);
                 EMIT(PC++, *re);

--- a/lib/re1.5/re1.5.h
+++ b/lib/re1.5/re1.5.h
@@ -138,6 +138,7 @@ struct Subject {
 
 #define NON_ANCHORED_PREFIX 5
 #define HANDLE_ANCHORED(bytecode, is_anchored) ((is_anchored) ? (bytecode) + NON_ANCHORED_PREFIX : (bytecode))
+#define RE15_CLASS_NAMED_CLASS_INDICATOR 0
 
 int re1_5_backtrack(ByteProg*, Subject*, const char**, int, int);
 int re1_5_pikevm(ByteProg*, Subject*, const char**, int, int);

--- a/tests/extmod/ure_namedclass.py
+++ b/tests/extmod/ure_namedclass.py
@@ -15,7 +15,7 @@ def print_groups(match):
     try:
         i = 0
         while True:
-            print(m.group(i))
+            print(match.group(i))
             i += 1
     except IndexError:
         pass
@@ -32,3 +32,8 @@ print_groups(m)
 
 m = re.match(r"(([0-9]*)([a-z]*)\d*)", "1234hello567")
 print_groups(m)
+
+# named class within a class set
+print_groups(re.match("([^\s]+)\s*([^\s]+)", "1 23"))
+print_groups(re.match("([\s\d]+)([\W]+)", "1  2-+="))
+print_groups(re.match("([\W]+)([^\W]+)([^\S]+)([^\D]+)", " a_1 23"))


### PR DESCRIPTION
Addresses issue #7920.

TODO:
- [x] add more tests
- [x] reduce code size
- [x] test how escape chars work for non named classes, eg `\n` -- they don't work, they never have in uPy