### PR TITLE
tools/ci.sh: Use a specific ESP IDF v4.4 commit.

### DIFF
--- a/tools/ci.sh
+++ b/tools/ci.sh
@@ -107,7 +107,8 @@ function ci_esp32_idf402_setup {
 }
 
 function ci_esp32_idf44_setup {
-    ci_esp32_setup_helper master
+    # This commit is just before v5.0-dev
+    ci_esp32_setup_helper 142bb32c50fa9875b8b69fa539a2d59559460d72
 }
 
 function ci_esp32_build {


### PR DESCRIPTION
There is no release of IDF v4.4 yet but master is now on v5.0-dev so a specific commit must be chosen to stick to v4.4.
