### PR TITLE
tools: Make dfu.py work with python3 again.

### DIFF
--- a/tools/dfu.py
+++ b/tools/dfu.py
@@ -20,7 +20,7 @@ def consume(fmt, data, names):
 
 
 def cstring(string):
-    return string.split("\0", 1)[0]
+    return string.split(b"\0", 1)[0]
 
 
 def compute_crc(data):


### PR DESCRIPTION
Without this change, running:
```
python3 ../../tools/dfu.py -d build-PYBV11/firmware.dfu
```
produces the following error:
```
File: "build-PYBV11/firmware.dfu"
b'DfuSe' v1, image size: 367757, targets: 1
Traceback (most recent call last):
  File "../../tools/dfu.py", line 160, in <module>
    parse(infile, dump_images=options.dump_images)
  File "../../tools/dfu.py", line 42, in parse
    tprefix["name"] = cstring(tprefix["name"])
  File "../../tools/dfu.py", line 23, in cstring
    return string.split("\0", 1)[0]
TypeError: a bytes-like object is required, not 'str'
```

With the PR applied, the following output is produced:
```
File: "build-PYBV11/firmware.dfu"
b'DfuSe' v1, image size: 367757, targets: 1
b'Target' 0, alt setting: 0, name: "b'ST...'", size: 367472, elements: 2
  0, address: 0x08000000, size: 14632
    DUMPED IMAGE TO "build-PYBV11/firmware.dfu.target0.image0.bin"
  1, address: 0x08020000, size: 352824
    DUMPED IMAGE TO "build-PYBV11/firmware.dfu.target0.image1.bin"
usb: 0483:df11, device: 0x0000, dfu: 0x011a, b'UFD', 16, 0x1264d2f5
```