### PR TITLE
Allow types to use both .attr and .locals_dict

### DIFF
--- a/py/obj.h
+++ b/py/obj.h
@@ -551,6 +551,7 @@ struct _mp_obj_type_t {
     //
     // dest[0] = MP_OBJ_NULL means load
     //  return: for fail, do nothing
+    //          for fail but continue lookup in locals_dict, dest[1] = MP_OBJ_SENTINEL
     //          for attr, dest[0] = value
     //          for method, dest[0] = method, dest[1] = self
     //


### PR DESCRIPTION
This updates #6253. I must have accidentally closed it while moving branches around. I can't seem to re-open it now, so I'll open this one instead.

----

Right now, a type can have either a custom `attr` handler or a `locals_dict`. If it has both,  `attr` gets called and `locals_dict` is not used. 

With this PR, types can use the `attr` handler and `locals_dict` lookups cooperatively. This is useful for types that have both attributes and generic methods.

In essence, it allows you to add the following to your `attr` handler:

```c
void custom_attribute_handler (mp_obj_t self_in, qstr attr, mp_obj_t *dest) {

    // load, store and delete attribute


    // Optional, made possible by this PR:

    // No attribute found, continue lookup in locals dict.
    dest[1] = MP_OBJ_SENTINEL;
}
```

> For your use-case would you prefer #4969 or this here? Ultimately both of the patches could be useful for different things, they can both coexist.

I've been looking at this, and both can technically be achieved with just this updated PR. And since this is the smallest and most generic change, this one makes a bit more sense.