### PR TITLE
Markdown: Make *.md files markdownlint compliant.

### DIFF
--- a/.markdownlint.jsonc
+++ b/.markdownlint.jsonc
@@ -1,0 +1,9 @@
+// Config file for https://github.com/DavidAnson/markdownlint-cli2
+// Also used by VS Code markdownlint extension.
+{
+    "default": true,
+    "MD013": {
+        "line_length": 180
+    },
+    "no-hard-tabs": false
+}

--- a/CODECONVENTIONS.md
+++ b/CODECONVENTIONS.md
@@ -1,5 +1,6 @@
-Git commit conventions
-======================
+# Micropython Code Conventions
+
+## Git commit conventions
 
 Each commit message should start with a directory or full file path
 prefix, so it was clear which part of codebase a commit affects. If
@@ -14,10 +15,12 @@ change clearly and to the point, and be a grammatical sentence with
 final full stop. First line should fit within 72 characters. Examples
 of good first line of commit messages:
 
-    py/objstr: Add splitlines() method.
-    py: Rename FOO to BAR.
-    docs/machine: Fix typo in reset() description.
-    ports: Switch to use lib/foo instead of duplicated code.
+```text
+py/objstr: Add splitlines() method.
+py: Rename FOO to BAR.
+docs/machine: Fix typo in reset() description.
+ports: Switch to use lib/foo instead of duplicated code.
+```
 
 After the first line add an empty line and in the following lines describe
 the change in a detail, if needed, with lines fitting within 75 characters
@@ -34,28 +37,27 @@ name and email address in the "Author" line, implies your sign-off.  In either
 case, of explicit or implicit sign-off, you are certifying and signing off
 against the following:
 
-* That you wrote the change yourself, or took it from a project with
+- That you wrote the change yourself, or took it from a project with
   a compatible license (in the latter case the commit message, and possibly
   source code should provide reference where the implementation was taken
   from and give credit to the original author, as required by the license).
-* That you are allowed to release these changes to an open-source project
+- That you are allowed to release these changes to an open-source project
   (for example, changes done during paid work for a third party may require
   explicit approval from that third party).
-* That you (or your employer) agree to release the changes under
+- That you (or your employer) agree to release the changes under
   MicroPython's license, which is the MIT license. Note that you retain
   copyright for your changes (for smaller changes, the commit message
   conveys your copyright; if you make significant changes to a particular
   source module, you're welcome to add your name to the file header).
-* Your contribution including commit message will be publicly and
+- Your contribution including commit message will be publicly and
   indefinitely available for anyone to access, including redistribution
   under the terms of the project's license.
-* Your signature for all of the above, which is the "Signed-off-by" line
+- Your signature for all of the above, which is the "Signed-off-by" line
   or the "Author" line in the commit message, includes your full real name and
   a valid and active email address by which you can be contacted in the
   foreseeable future.
 
-Code auto-formatting
-====================
+## Code auto-formatting
 
 Both C and Python code are auto-formatted using the `tools/codeformat.py`
 script.  This uses [uncrustify](https://github.com/uncrustify/uncrustify) to
@@ -65,14 +67,14 @@ changes to the correct style.  Without arguments this tool will reformat all
 source code (and may take some time to run).  Otherwise pass as arguments to
 the tool the files that changed and it will only reformat those.
 
-Python code conventions
-=======================
+## Python code conventions
 
 Python code follows [PEP 8](https://legacy.python.org/dev/peps/pep-0008/) and
 is auto-formatted using [black](https://github.com/psf/black) with a line-length
 of 99 characters.
 
 Naming conventions:
+
 - Module names are short and all lowercase; eg pyb, stm.
 - Class names are CamelCase, with abbreviations all uppercase; eg I2C, not
   I2c.
@@ -81,8 +83,7 @@ Naming conventions:
 - Constants are all uppercase with words separated by a single underscore;
   eg GPIO_IDR.
 
-C code conventions
-==================
+## C code conventions
 
 C code is auto-formatted using [uncrustify](https://github.com/uncrustify/uncrustify)
 and the corresponding configuration file `tools/uncrustify.cfg`, with a few
@@ -92,6 +93,7 @@ The main conventions, and things not enforceable via the auto-formatter, are
 described below.
 
 White space:
+
 - Expand tabs to 4 spaces.
 - Don't leave trailing whitespace at the end of a line.
 - For control blocks (if, for, while), put 1 space between the
@@ -99,6 +101,7 @@ White space:
 - Put 1 space after a comma, and 1 space around operators.
 
 Braces:
+
 - Use braces for all blocks, even no-line and single-line pieces of
   code.
 - Put opening braces on the end of the line it belongs to, not on
@@ -107,10 +110,12 @@ Braces:
   closing brace.
 
 Header files:
+
 - Header files should be protected from multiple inclusion with #if
   directives. See an existing header for naming convention.
 
 Names:
+
 - Use underscore_case, not camelCase for all names.
 - Use CAPS_WITH_UNDERSCORE for enums and macros.
 - When defining a type use underscore_case and put '_t' after it.
@@ -118,6 +123,7 @@ Names:
 Integer types: MicroPython runs on 16, 32, and 64 bit machines, so it's
 important to use the correctly-sized (and signed) integer types.  The
 general guidelines are:
+
 - For most cases use mp_int_t for signed and mp_uint_t for unsigned
   integer values.  These are guaranteed to be machine-word sized and
   therefore big enough to hold the value from a MicroPython small-int
@@ -127,18 +133,20 @@ general guidelines are:
 - If in doubt, use mp_int_t/mp_uint_t.
 
 Comments:
+
 - Be concise and only write comments for things that are not obvious.
-- Use `// ` prefix, NOT `/* ... */`. No extra fluff.
+- Use `//` prefix, NOT `/* ... */`. No extra fluff.
 
 Memory allocation:
+
 - Use m_new, m_renew, m_del (and friends) to allocate and free heap memory.
   These macros are defined in py/misc.h.
 
-Examples
---------
+### Examples
 
 Braces, spaces, names and comments:
 
+```c
     #define TO_ADD (123)
 
     // This function will always recurse indefinitely and is only used to show
@@ -153,33 +161,35 @@ Braces, spaces, names and comments:
         for (int my_counter = 0; my_counter < x; ++my_counter) {
         }
     }
+```
 
 Type declarations:
 
+```c
     typedef struct _my_struct_t {
         int member;
         void *data;
     } my_struct_t;
+```
 
-Documentation conventions
-=========================
+## Documentation conventions
 
 MicroPython generally follows CPython in documentation process and
 conventions. reStructuredText syntax is used for the documention.
 
 Specific conventions/suggestions:
 
-* Use `*` markup to refer to arguments of a function, e.g.:
+- Use `*` markup to refer to arguments of a function, e.g.:
 
-```
+```restructuredtext
 .. method:: poll.unregister(obj)
 
    Unregister *obj* from polling.
 ```
 
-* Use following syntax for cross-references/cross-links:
+- Use following syntax for cross-references/cross-links:
 
-```
+```restructuredtext
 :func:`foo` - function foo in current module
 :func:`module1.foo` - function foo in module "module1"
     (similarly for other referent types)
@@ -197,8 +207,9 @@ Specific conventions/suggestions:
     above
 ```
 
-* Cross-referencing arbitrary locations
-~~~
+- Cross-referencing arbitrary locations
+
+```restructuredtext
 .. _xref_target:
 
 Normal non-indented text.
@@ -207,29 +218,31 @@ This is :ref:`reference <xref_target>`.
 
 (If xref target is followed by section title, can be just
 :ref:`xref_target`).
-~~~
-
-* Linking to external URL:
 ```
+
+- Linking to external URL:
+
+```restructuredtext
 `link text <http://foo.com/...>`_
 ```
 
-* Referencing builtin singleton objects:
-```
+- Referencing builtin singleton objects:
+
+```restructuredtext
 ``None``, ``True``, ``False``
 ```
 
-* Use following syntax to create common description for more than one element:
-~~~
+- Use following syntax to create common description for more than one element:
+
+```restructuredtext
 .. function:: foo(x)
               bar(y)
 
    Description common to foo() and bar().
-~~~
-
+```
 
 More detailed guides and quickrefs:
 
-* http://www.sphinx-doc.org/en/stable/rest.html
-* http://www.sphinx-doc.org/en/stable/markup/inline.html
-* http://docutils.sourceforge.net/docs/user/rst/quickref.html
+- <http://www.sphinx-doc.org/en/stable/rest.html>
+- <http://www.sphinx-doc.org/en/stable/markup/inline.html>
+- <http://docutils.sourceforge.net/docs/user/rst/quickref.html>

--- a/CODEOFCONDUCT.md
+++ b/CODEOFCONDUCT.md
@@ -50,4 +50,5 @@ Attribution-ShareAlike 3.0 Unported License.
 Attributions
 ------------
 
-Based on the Python code of conduct found at https://www.python.org/psf/conduct/
+Based on the Python code of conduct found at
+<https://www.python.org/psf/conduct/>

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,8 +1,10 @@
+# Contributing
+
 When reporting an issue and especially submitting a pull request, please
 make sure that you are acquainted with Contributor Guidelines:
 
-https://github.com/micropython/micropython/wiki/ContributorGuidelines
+<https://github.com/micropython/micropython/wiki/ContributorGuidelines>
 
 as well as the Code Conventions, which includes details of how to commit:
 
-https://github.com/micropython/micropython/blob/master/CODECONVENTIONS.md
+<https://github.com/micropython/micropython/blob/master/CODECONVENTIONS.md>

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
-[![CI badge](https://github.com/micropython/micropython/workflows/unix%20port/badge.svg)](https://github.com/micropython/micropython/actions?query=branch%3Amaster+event%3Apush) [![codecov](https://codecov.io/gh/micropython/micropython/branch/master/graph/badge.svg?token=I92PfD05sD)](https://codecov.io/gh/micropython/micropython)
-
 The MicroPython project
 =======================
-<p align="center">
-  <img src="https://raw.githubusercontent.com/micropython/micropython/master/logo/upython-with-micro.jpg" alt="MicroPython Logo"/>
-</p>
+
+[![CI badge](https://github.com/micropython/micropython/workflows/unix%20port/badge.svg)](https://github.com/micropython/micropython/actions?query=branch%3Amaster+event%3Apush)
+[![codecov](https://codecov.io/gh/micropython/micropython/branch/master/graph/badge.svg?token=I92PfD05sD)](https://codecov.io/gh/micropython/micropython)
+
+![Micropython Logo](https://raw.githubusercontent.com/micropython/micropython/master/logo/upython-with-micro.jpg)
 
 This is the MicroPython project, which aims to put an implementation
 of Python 3.x on microcontrollers and small embedded systems.
@@ -26,10 +26,11 @@ MicroPython can execute scripts in textual source form or from precompiled
 bytecode, in both cases either from an on-device filesystem or "frozen" into
 the MicroPython executable.
 
-See the repository http://github.com/micropython/pyboard for the MicroPython
+See the repository <http://github.com/micropython/pyboard> for the MicroPython
 board (PyBoard), the officially supported reference electronic circuit board.
 
 Major components in this repository:
+
 - py/ -- the core Python implementation, including compiler, runtime, and
   core library.
 - mpy-cross/ -- the MicroPython cross-compiler which is used to turn scripts
@@ -41,9 +42,10 @@ Major components in this repository:
   to port MicroPython to another microcontroller.
 - tests/ -- test framework and test scripts.
 - docs/ -- user documentation in Sphinx reStructuredText format. Rendered
-  HTML documentation is available at http://docs.micropython.org.
+  HTML documentation is available at <http://docs.micropython.org>.
 
 Additional components:
+
 - ports/bare-arm/ -- a bare minimum version of MicroPython for ARM MCUs. Used
   mostly to control code size.
 - ports/teensy/ -- a version of MicroPython that runs on the Teensy 3.1
@@ -72,8 +74,8 @@ program, called mpy-cross, is used to pre-compile Python scripts to .mpy
 files which can then be included (frozen) into the firmware/executable for
 a port.  To build mpy-cross use:
 
-    $ cd mpy-cross
-    $ make
+    cd mpy-cross
+    make
 
 The Unix version
 ----------------
@@ -86,9 +88,9 @@ Alternatively, fallback implementation based on setjmp/longjmp can be used.
 
 To build (see section below for required dependencies):
 
-    $ cd ports/unix
-    $ make submodules
-    $ make
+    cd ports/unix
+    make submodules
+    make
 
 Then to give it a try:
 
@@ -99,16 +101,16 @@ Use `CTRL-D` (i.e. EOF) to exit the shell.
 Learn about command-line options (in particular, how to increase heap size
 which may be needed for larger applications):
 
-    $ ./micropython -h
+    ./micropython -h
 
 Run complete testsuite:
 
-    $ make test
+    make test
 
 Unix version comes with a builtin package manager called upip, e.g.:
 
-    $ ./micropython -m upip install micropython-pystone
-    $ ./micropython -m pystone
+    ./micropython -m upip install micropython-pystone
+    ./micropython -m pystone
 
 Browse available modules on
 [PyPI](https://pypi.python.org/pypi?%3Aaction=search&term=micropython).
@@ -130,13 +132,13 @@ versions of MicroPython, these may be enabled by default. To build
 these additional dependencies, in the port directory you're
 interested in (e.g. `ports/unix/`) first execute:
 
-    $ make submodules
+    make submodules
 
 This will fetch all the relevant git submodules (sub repositories) that
 the port needs.  Use the same command to get the latest versions of
 submodules as they are updated from time to time. After that execute:
 
-    $ make deplibs
+    make deplibs
 
 This will build all available dependencies (regardless whether they
 are used or not). If you intend to build MicroPython with additional
@@ -156,13 +158,13 @@ The STM32 version
 The "stm32" port requires an ARM compiler, arm-none-eabi-gcc, and associated
 bin-utils.  For those using Arch Linux, you need arm-none-eabi-binutils,
 arm-none-eabi-gcc and arm-none-eabi-newlib packages.  Otherwise, try here:
-https://launchpad.net/gcc-arm-embedded
+<https://launchpad.net/gcc-arm-embedded>
 
 To build:
 
-    $ cd ports/stm32
-    $ make submodules
-    $ make
+    cd ports/stm32
+    make submodules
+    make
 
 You then need to get your board into DFU mode.  On the pyboard, connect the
 3V3 pin to the P1/DFU pin with a wire (on PYBv1.0 they are next to each other
@@ -170,7 +172,7 @@ on the bottom left of the board, second row from the bottom).
 
 Then to flash the code via USB DFU to your device:
 
-    $ make deploy
+    make deploy
 
 This will use the included `tools/pydfu.py` script.  If flashing the firmware
 does not work it may be because you don't have the correct permissions, and

--- a/docs/README.md
+++ b/docs/README.md
@@ -2,10 +2,10 @@ MicroPython Documentation
 =========================
 
 The MicroPython documentation can be found at:
-http://docs.micropython.org/en/latest/
+<http://docs.micropython.org/en/latest/>
 
 The documentation you see there is generated from the files in the docs tree:
-https://github.com/micropython/micropython/tree/master/docs
+<https://github.com/micropython/micropython/tree/master/docs>
 
 Building the documentation locally
 ----------------------------------
@@ -30,15 +30,16 @@ Having readthedocs.org build the documentation
 
 If you would like to have docs for forks/branches hosted on GitHub, GitLab or
 BitBucket an alternative to building the docs locally is to sign up for a free
-https://readthedocs.org account. The rough steps to follow are:
+<https://readthedocs.org> account. The rough steps to follow are:
+
 1. sign-up for an account, unless you already have one
-2. in your account settings: add GitHub as a connected service (assuming
-you have forked this repo on github)
+2. in your account settings: add GitHub as a connected service (assuming you
+   have forked this repo on github)
 3. in your account projects: import your forked/cloned micropython repository
-into readthedocs
-4. in the project's versions: add the branches you are developing on or
-for which you'd like readthedocs to auto-generate docs whenever you
-push a change
+   into readthedocs
+4. in the project's versions: add the branches you are developing on or for
+   which you'd like readthedocs to auto-generate docs whenever you push a
+   change
 
 PDF manual generation
 ---------------------

--- a/drivers/README.md
+++ b/drivers/README.md
@@ -1,2 +1,4 @@
+# Drivers
+
 This directory contains drivers for specific hardware.  The drivers are
 intended to work across multiple ports.

--- a/drivers/wiznet5k/README.md
+++ b/drivers/wiznet5k/README.md
@@ -1,6 +1,8 @@
+# WIZnet5x00 Ethernet Driver
+
 This is the driver for the WIZnet5x00 series of Ethernet controllers.
 
 Adapted for MicroPython.
 
-Original source: https://github.com/Wiznet/W5500_EVB/tree/master/ioLibrary
+Original source: <https://github.com/Wiznet/W5500_EVB/tree/master/ioLibrary>
 Taken on: 30 August 2014

--- a/examples/SDdatalogger/README.md
+++ b/examples/SDdatalogger/README.md
@@ -1,4 +1,10 @@
-This is a SDdatalogger, to log data from the accelerometer to the SD-card. It also functions as card reader, so you can easily get the data on your PC.
+# SD Data Logger
 
-To run, put the boot.py, cardreader.py and datalogger.py files on either the flash or the SD-card of your pyboard.
-Upon reset, the datalogger script is run and logs the data. If you press the user button after reset and hold it until the orange LED goes out, you enter the cardreader mode and the filesystem is mounted to your PC.
+This is a SDdatalogger, to log data from the accelerometer to the SD-card. It
+also functions as card reader, so you can easily get the data on your PC.
+
+To run, put the boot.py, cardreader.py and datalogger.py files on either the
+flash or the SD-card of your pyboard. Upon reset, the datalogger script is run
+and logs the data. If you press the user button after reset and hold it until
+the orange LED goes out, you enter the cardreader mode and the filesystem is
+mounted to your PC.

--- a/examples/embedding/README.md
+++ b/examples/embedding/README.md
@@ -7,31 +7,32 @@ in an existing C application.
 A C application is represented by the file `hello-embed.c`. It executes a simple
 Python statement which prints to the standard output.
 
-
 Building the example
 --------------------
 
 Building the example is as simple as running:
 
-    make
+```bash
+make
+```
 
 It's worth to trace what's happening behind the scenes though:
 
 1. As a first step, a MicroPython library is built. This is handled by a
-separate makefile, `Makefile.upylib`. It is more or less complex, but the
-good news is that you won't need to change anything in it, just use it
-as is, the main `Makefile` shows how. What may require editing though is
-a MicroPython configuration file. MicroPython is highly configurable, so
-you would need to build a library suiting your application well, while
-not bloating its size. Check the options in the file `mpconfigport.h`.
-Included is a copy of the "minimal" Unix port, which should be a good start
-for minimal embedding. For the list of all available options, see
-`py/mpconfig.h`.
+   separate makefile, `Makefile.upylib`. It is more or less complex, but the
+   good news is that you won't need to change anything in it, just use it as
+   is, the main `Makefile` shows how. What may require editing though is a
+   MicroPython configuration file. MicroPython is highly configurable, so you
+   would need to build a library suiting your application well, while not
+   bloating its size. Check the options in the file `mpconfigport.h`. Included
+   is a copy of the "minimal" Unix port, which should be a good start for
+   minimal embedding. For the list of all available options, see
+   `py/mpconfig.h`.
 
-2. Once the MicroPython library is built, your application is compiled
-and linked it. The main Makefile is very simple and shows that the changes
-you would need to do to your application's `Makefile` (or other build
-configuration) are also simple:
+2. Once the MicroPython library is built, your application is compiled and
+   linked it. The main Makefile is very simple and shows that the changes you
+   would need to do to your application's `Makefile` (or other build
+   configuration) are also simple:
 
 a) You would need to use C99 standard (you're using this 15+ years old
 standard already, not a 25+ years old one, right?).
@@ -41,7 +42,6 @@ b) You need to provide a path to MicroPython's top-level dir, for includes.
 c) You need to include `-DNO_QSTR` compile-time flag.
 
 d) Otherwise, just link with the MicroPython library produced in step 1.
-
 
 Out of tree build
 -----------------
@@ -57,11 +57,11 @@ A practical way to embed MicroPython in your application is to include it
 as a git submodule. Suppose you included it as `libs/micropython`. Then in
 your main Makefile you would have something like:
 
-~~~
+```make
 MPTOP = libs/micropython
 
 my_app: $(MY_OBJS) -lmicropython
 
 -lmicropython:
-	$(MAKE) -f $(MPTOP)/examples/embedding/Makefile.upylib MPTOP=$(MPTOP)
-~~~
+    $(MAKE) -f $(MPTOP)/examples/embedding/Makefile.upylib MPTOP=$(MPTOP)
+```

--- a/examples/hwapi/README.md
+++ b/examples/hwapi/README.md
@@ -1,3 +1,5 @@
+# Micropython Hardware API
+
 This directory shows the best practices for using MicroPython hardware API
 (`machine` module). `machine` module strives to provide consistent API
 across various boards, with the aim to enable writing portable applications,
@@ -47,7 +49,6 @@ application of this idea would look like:
         utime.sleep_ms(500)
         LED.value(0)
         utime.sleep_ms(500)
-
 
 To deploy this application to a particular board, a user will need:
 

--- a/mpy-cross/README.md
+++ b/mpy-cross/README.md
@@ -6,11 +6,11 @@ Unix-like system and compiles .py scripts into .mpy files.
 
 Build it as usual:
 
-    $ make
+    make
 
 The compiler is called `mpy-cross`.  Invoke it as:
 
-    $ ./mpy-cross foo.py
+    ./mpy-cross foo.py
 
 This will create a file foo.mpy which can then be copied to a place accessible
 by the target MicroPython runtime (eg onto a pyboard's filesystem), and then
@@ -25,4 +25,4 @@ specify `-march` to match the target architecture.
 Run `./mpy-cross -h` to get a full list of options.
 
 The optimisation level is 0 by default. Optimisation levels are detailed in
-https://docs.micropython.org/en/latest/library/micropython.html#micropython.opt_level
+<https://docs.micropython.org/en/latest/library/micropython.html#micropython.opt_level>

--- a/ports/cc3200/README.md
+++ b/ports/cc3200/README.md
@@ -1,5 +1,4 @@
-MicroPython port to CC3200 WiFi SoC
-===================================
+# MicroPython port to CC3200 WiFi SoC
 
 This is a MicroPython port to Texas Instruments CC3200 WiFi SoC (ARM Cortex-M4
 architecture). This port supports 2 boards: WiPy and TI CC3200-LAUNCHXL.
@@ -19,13 +18,13 @@ support is provided by TI itself.
 
 Building the bootloader:
 
-```
+```bash
 make BTARGET=bootloader BTYPE=release BOARD=LAUNCHXL
 ```
 
 Building the "release" image:
 
-```
+```bash
 make BTARGET=application BTYPE=release BOARD=LAUNCHXL
 ```
 
@@ -35,7 +34,7 @@ In order to debug the port specific code, optimizations need to be disabled on t
 port file (check the Makefile for specific details). You can use CCS from TI.
 Use the CC3200.ccxml file supplied with this distribution for the debuuger configuration.
 
-```
+```bash
 make BTARGET=application BTYPE=debug BOARD=LAUNCHXL
 ```
 
@@ -53,7 +52,7 @@ below).
 - Wait few seconds.
 - Run "make deploy" and immediately press Reset button on the device.
 - You are recommended to install the latest vendor WiFi firmware
-  servicepack from http://www.ti.com/tool/cc3200sdk. Download
+  servicepack from <http://www.ti.com/tool/cc3200sdk>. Download
   CC3200SDK-SERVICEPACK package, install it, and locate `ota_*.ucf`
   and `ota_*.ucf.signed.bin` files. Copy them to the port's directory
   and run "make servicepack", with immediate press of Reset button.
@@ -61,7 +60,7 @@ below).
 
 Flashing process using TI Uniflash:
 
-- Open CCS_Uniflash and connect to the board (by default on port 22). 
+- Open CCS_Uniflash and connect to the board (by default on port 22).
 - Format the serial flash (select 1MB size in case of the CC3200-LAUNCHXL, 2MB in case of the WiPy, leave the rest unchecked).
 - Mark the following files for erasing: `/cert/ca.pem`, `/cert/client.pem`, `/cert/private.key` and `/tmp/pac.bin`.
 - Add a new file with the name of /sys/mcuimg.bin, and select the URL to point to cc3200\bootmgr\build\<BOARD_NAME>\bootloader.bin.
@@ -70,37 +69,37 @@ Flashing process using TI Uniflash:
 - Flash the latest service pack (servicepack_1.0.0.10.0.bin) using the "Service Pack Update" button.
 - Close CCS_Uniflash, remove the SOP2 jumper and reset the board.
 
-## Playing with MicroPython and the CC3200:
+## Playing with MicroPython and the CC3200
 
 Once the software is running, you have two options to access the MicroPython REPL:
 
 - Through telnet.
-  * Connect to the network created by the board (as boots up in AP mode), **ssid = "wipy-wlan", key = "www.wipy.io"**.
-    * You can also reinitialize the WLAN in station mode and connect to another AP, or in AP mode but with a
+  - Connect to the network created by the board (as boots up in AP mode), **ssid = "wipy-wlan", key = "www.wipy.io"**.
+    - You can also reinitialize the WLAN in station mode and connect to another AP, or in AP mode but with a
       different ssid and/or key.
-  * Use your favourite telnet client with the following settings: **host = 192.168.1.1, port = 23.**
-  * Log in with **user = "micro" and password = "python"**
+  - Use your favourite telnet client with the following settings: **host = 192.168.1.1, port = 23.**
+  - Log in with **user = "micro" and password = "python"**
 
 - Through UART (serial).
-  * This is enabled by default in the standard configuration, for UART0 (speed 115200).
-  * For CC3200-LAUNCHXL, you will need to configure Linux `ftdi_sio` driver as described
+  - This is enabled by default in the standard configuration, for UART0 (speed 115200).
+  - For CC3200-LAUNCHXL, you will need to configure Linux `ftdi_sio` driver as described
     in the [blog post](http://www.achanceofbrainshowers.com/blog/tech/2014/8/19/cc3200-development-under-linux/).
     After that, connecting a board will create two `/dev/ttyUSB*` devices, a serial
     console is available on the 2nd one (usually `/dev/ttyUSB1`).
-  * WiPy doesn't have onboard USB-UART converter, so you will need an external one,
+  - WiPy doesn't have onboard USB-UART converter, so you will need an external one,
     connected to GPIO01 (Tx) and GPIO02 (Rx).
-  * Usage of UART port for REPL is controlled by MICROPY_STDIO_UART setting (and
+  - Usage of UART port for REPL is controlled by MICROPY_STDIO_UART setting (and
     is done at the high level, using a suitable call to `os.dupterm()` function
     in boot.py, so you can override it at runtime regardless of MICROPY_STDIO_UART
     setting).
 
-The board has a small file system of 192K (WiPy) or 64K (Launchpad) located in the serial flash connected to the CC3200. 
+The board has a small file system of 192K (WiPy) or 64K (Launchpad) located in the serial flash connected to the CC3200.
 SD cards are also supported, you can connect any SD card and configure the pinout using the SD class API.
 
-## Uploading scripts:
+## Uploading scripts
 
 To upload your MicroPython scripts to the FTP server, open your FTP client of choice and connect to:
-**ftp://192.168.1.1, user = "micro", password = "python"**
+**<ftp://192.168.1.1>, user = "micro", password = "python"**
 
 Tested FTP clients are: FileZilla, FireFTP, FireFox, IE and Chrome. Other
 clients should work as well, but you may need to configure them to use a
@@ -124,25 +123,30 @@ machine.reset()
 
 There's a script which automates this process from the host side:
 
-- Make sure the board is running and connected to the same network as the computer.
+- Make sure the board is running and connected to the same network as the
+  computer.
 
 ```bash
-make BTARGET=application BTYPE=release BOARD=LAUNCHXL WIPY_IP=192.168.1.1 WIPY_USER=micro WIPY_PWD=python deploy-ota
+make BTARGET=application BTYPE=release BOARD=LAUNCHXL WIPY_IP=192.168.1.1
+WIPY_USER=micro WIPY_PWD=python deploy-ota
 ```
 
-If `WIPY_IP`, `WIPY_USER` or `WIPY_PWD` are omitted the default values (the ones shown above) will be used.
-
+If `WIPY_IP`, `WIPY_USER` or `WIPY_PWD` are omitted the default values (the
+ones shown above) will be used.
 
 ## Notes and known issues
 
 ## Regarding old revisions of the CC3200-LAUNCHXL
 
-First silicon (pre-release) revisions of the CC3200 had issues with the ram blocks, and MicroPython cannot run
-there. Make sure to use a **v4.1 (or higher) LAUNCHXL board** when trying this port, otherwise it won't work.
+First silicon (pre-release) revisions of the CC3200 had issues with the ram
+blocks, and MicroPython cannot run there. Make sure to use a **v4.1 (or
+higher) LAUNCHXL board** when trying this port, otherwise it won't work.
 
 ### Note regarding FileZilla
 
-Do not use the quick connect button, instead, open the site manager and create a new configuration. In the "General" tab make 
-sure that encryption is set to: "Only use plain FTP (insecure)". In the Transfer Settings tab limit the max number of connections 
-to one, otherwise FileZilla will try to open a second command connection when retrieving and saving files, and for simplicity and 
-to reduce code size, only one command and one data connections are possible.
+Do not use the quick connect button, instead, open the site manager and create
+a new configuration. In the "General" tab make sure that encryption is set to:
+"Only use plain FTP (insecure)". In the Transfer Settings tab limit the max
+number of connections to one, otherwise FileZilla will try to open a second
+command connection when retrieving and saving files, and for simplicity and to
+reduce code size, only one command and one data connections are possible.

--- a/ports/esp32/README.md
+++ b/ports/esp32/README.md
@@ -6,6 +6,7 @@ microcontrollers.  It uses the ESP-IDF framework and MicroPython runs as
 a task under FreeRTOS.
 
 Supported features include:
+
 - REPL (Python prompt) over UART0.
 - 16k stack for the MicroPython task and approximately 100k Python heap.
 - Many of MicroPython's features are enabled: unicode, arbitrary-precision
@@ -47,7 +48,7 @@ The steps to take are summarised below.
 To check out a copy of the IDF use git clone:
 
 ```bash
-$ git clone -b v4.0.2 --recursive https://github.com/espressif/esp-idf.git
+git clone -b v4.0.2 --recursive https://github.com/espressif/esp-idf.git
 ```
 
 You can replace `v4.0.2` with `v4.1.1` or `v4.2` or any other supported version.
@@ -58,28 +59,22 @@ If you already have a copy of the IDF then checkout a version compatible with
 MicroPython and update the submodules using:
 
 ```bash
-$ cd esp-idf
-$ git checkout v4.2
-$ git submodule update --init --recursive
+cd esp-idf
+git checkout v4.2
+git submodule update --init --recursive
 ```
 
 After you've cloned and checked out the IDF to the correct version, run the
 `install.sh` script:
 
 ```bash
-$ cd esp-idf
-$ ./install.sh       # (or install.bat on Windows)
-$ source export.sh   # (or export.bat on Windows)
+cd esp-idf
+./install.sh       # (or install.bat on Windows)
+source export.sh   # (or export.bat on Windows)
 ```
 
 The `install.sh` step only needs to be done once. You will need to source
 `export.sh` for every new session.
-
-**Note:** If you are building MicroPython for the ESP32-S2, ESP32-C3 or ESP32-S3,
-please ensure you are using the following required IDF versions:
-- ESP32-S3 currently requires latest `master`, but eventually `v4.4` or later when
-  it's available.
-- ESP32-S2 and ESP32-C3 require `v4.3.1` or later.
 
 Building the firmware
 ---------------------
@@ -89,15 +84,15 @@ built-in scripts to bytecode.  This can be done by (from the root of
 this repository):
 
 ```bash
-$ make -C mpy-cross
+make -C mpy-cross
 ```
 
 Then to build MicroPython for the ESP32 run:
 
 ```bash
-$ cd ports/esp32
-$ make submodules
-$ make
+cd ports/esp32
+make submodules
+make
 ```
 
 This will produce a combined `firmware.bin` image in the `build-GENERIC/`
@@ -113,7 +108,7 @@ rebooting or logging out and in again. (Note: on some distributions this may
 be the `uucp` group, run `ls -la /dev/ttyUSB0` to check.)
 
 ```bash
-$ sudo adduser <username> dialout
+sudo adduser <username> dialout
 ```
 
 If you are installing MicroPython to your module for the first time, or
@@ -121,13 +116,13 @@ after installing any other firmware, you should first erase the flash
 completely:
 
 ```bash
-$ make erase
+make erase
 ```
 
 To flash the MicroPython firmware to your ESP32 use:
 
 ```bash
-$ make deploy
+make deploy
 ```
 
 The default ESP32 board build by the above commands is the `GENERIC` one, which
@@ -135,7 +130,7 @@ should work on most ESP32 modules.  You can specify a different board by passing
 `BOARD=<board>` to the make commands, for example:
 
 ```bash
-$ make BOARD=GENERIC_SPIRAM
+make BOARD=GENERIC_SPIRAM
 ```
 
 Note: the above "make" commands are thin wrappers for the underlying `idf.py`
@@ -143,9 +138,9 @@ build tool that is part of the ESP-IDF.  You can instead use `idf.py` directly,
 for example:
 
 ```bash
-$ idf.py build
-$ idf.py -D MICROPY_BOARD=GENERIC_SPIRAM build
-$ idf.py flash
+idf.py build
+idf.py -D MICROPY_BOARD=GENERIC_SPIRAM build
+idf.py flash
 ```
 
 Getting a Python prompt on the device
@@ -156,13 +151,13 @@ that is used for programming the firmware.  The baudrate for the REPL is
 115200 and you can use a command such as:
 
 ```bash
-$ picocom -b 115200 /dev/ttyUSB0
+picocom -b 115200 /dev/ttyUSB0
 ```
 
 or
 
 ```bash
-$ miniterm.py /dev/ttyUSB0 115200
+miniterm.py /dev/ttyUSB0 115200
 ```
 
 You can also use `idf.py monitor`.
@@ -177,13 +172,14 @@ point when booting up.  But for the most part the documentation and tutorials
 for the ESP8266 should apply to the ESP32 (at least for the components that
 are implemented).
 
-See http://docs.micropython.org/en/latest/esp8266/esp8266/quickref.html for
-a quick reference, and http://docs.micropython.org/en/latest/esp8266/esp8266/tutorial/intro.html
+See <http://docs.micropython.org/en/latest/esp8266/esp8266/quickref.html> for
+a quick reference, and <http://docs.micropython.org/en/latest/esp8266/esp8266/tutorial/intro.html>
 for a tutorial.
 
 The following function can be used to connect to a WiFi access point (you can
 either pass in your own SSID and password, or change the defaults so you can
 quickly call `wlan_connect()` and it just works):
+
 ```python
 def wlan_connect(ssid='MYSSID', password='MYPASS'):
     import network
@@ -201,6 +197,7 @@ Note that some boards require you to configure the WiFi antenna before using
 the WiFi.  On Pycom boards like the LoPy and WiPy 2.0 you need to execute the
 following code to select the internal antenna (best to put this line in your
 boot.py file):
+
 ```python
 import machine
 antenna = machine.Pin(16, machine.Pin.OUT, value=0)
@@ -227,6 +224,6 @@ Configuration
 Troubleshooting
 ---------------
 
-* Continuous reboots after programming: Ensure `CONFIG_ESPTOOLPY_FLASHMODE` is
+- Continuous reboots after programming: Ensure `CONFIG_ESPTOOLPY_FLASHMODE` is
   correct for your board (e.g. ESP-WROOM-32 should be DIO). Then perform a
   `make clean`, rebuild, redeploy.

--- a/ports/esp32/README.ulp.md
+++ b/ports/esp32/README.ulp.md
@@ -1,7 +1,8 @@
-﻿# ULP
+# Ultra Low Power (ULP) Coprocessor
 
-To compile binarys for the ulp you need the ulp toolkit. Download it from https://github.com/espressif/binutils-esp32ulp/wiki#downloads
-Then extract it, then add ```esp32ulp-elf-binutils/bin``` to your PATH
+To compile binaries for the ulp you need the ulp toolkit. Download it from
+<https://github.com/espressif/binutils-esp32ulp/wiki#downloads> Then extract
+it, then add `esp32ulp-elf-binutils/bin` to your PATH
 
 ## Example Makefile
 
@@ -13,7 +14,7 @@ ULP_LD_SCRIPT := esp32.ulp.ld
 SRC_PATH := src
 BUILD_PATH := build
 
-include $(ESPIDF)/components/ulp/Makefile.projbuild 
+include $(ESPIDF)/components/ulp/Makefile.projbuild
 
 ULP_ELF := $(ULP_APP_NAME).elf
 ULP_MAP := $(ULP_ELF:.elf=.map)
@@ -29,7 +30,7 @@ ULP_LISTINGS := $(notdir $(ULP_S_SOURCES:.S=.ulp.lst))
 
 .PHONY: all clean
 
-all: $(BUILD_PATH) $(BUILD_PATH)/$(ULP_BIN) 
+all: $(BUILD_PATH) $(BUILD_PATH)/$(ULP_BIN)
 
 clean:
 	rm -rf $(BUILD_PATH)
@@ -42,7 +43,7 @@ $(BUILD_PATH)/$(ULP_APP_NAME).ld: $(SRC_PATH)/$(ULP_LD_SCRIPT)
 	cpp -P $< -o $@
 
 # Generate preprocessed assembly files.
-# To inspect these preprocessed files, add a ".PRECIOUS: %.ulp.pS" rule. 
+# To inspect these preprocessed files, add a ".PRECIOUS: %.ulp.pS" rule.
 $(BUILD_PATH)/%.ulp.pS: $(SRC_PATH)/%.S
 	cpp $< -o $@
 
@@ -58,16 +59,17 @@ $(BUILD_PATH)/$(ULP_ELF): $(BUILD_PATH)/$(ULP_OBJECTS) $(BUILD_PATH)/$(ULP_APP_N
 $(ULP_SYM): $(ULP_ELF)
 	$(ULP_NM) -g -f posix $< > $@
 
-# Dump the binary for inclusion into the project 
+# Dump the binary for inclusion into the project
 $(BUILD_PATH)/$(ULP_BIN): $(BUILD_PATH)/$(ULP_ELF)
 	$(ULP_OBJCOPY) -O binary $< $@
 ```
 
 ## Example linker script for the ulp
-```
-#define ULP_BIN_MAGIC		0x00706c75
-#define HEADER_SIZE			12
-#define CONFIG_ULP_COPROC_RESERVE_MEM	4096
+
+```ld
+#define ULP_BIN_MAGIC                  0x00706c75
+#define HEADER_SIZE                    12
+#define CONFIG_ULP_COPROC_RESERVE_MEM  4096
 
 MEMORY
 {
@@ -90,11 +92,11 @@ SECTIONS
         . = ALIGN(4);
         *(.bss)
     } >ram
-    
+
     .header : AT(0)
     {
         LONG(ULP_BIN_MAGIC)
-        SHORT(LOADADDR(.text)) 
+        SHORT(LOADADDR(.text))
         SHORT(SIZEOF(.text))
         SHORT(SIZEOF(.data))
         SHORT(SIZEOF(.bss))
@@ -103,6 +105,7 @@ SECTIONS
 ```
 
 ## Example ulp code
+
 ```asm
 move R3, 99
 move R0, 10
@@ -114,6 +117,7 @@ HALT
 ```
 
 ## Example python code using the ulp
+
 ```python
 import esp32
 import time

--- a/ports/esp8266/README.md
+++ b/ports/esp8266/README.md
@@ -1,5 +1,4 @@
-MicroPython port to ESP8266
-===========================
+# MicroPython port to ESP8266
 
 This is an experimental port of MicroPython for the WiFi modules based
 on Espressif ESP8266 chip.
@@ -7,6 +6,7 @@ on Espressif ESP8266 chip.
 WARNING: The port is experimental and many APIs are subject to change.
 
 Supported features include:
+
 - REPL (Python prompt) over UART0.
 - Garbage collector, exceptions.
 - Unicode support.
@@ -18,57 +18,63 @@ Supported features include:
 - GPIO and bit-banging I2C, SPI support.
 - 1-Wire and WS2812 (aka Neopixel) protocols support.
 - Internal filesystem using the flash.
-- WebREPL over WiFi from a browser (clients at https://github.com/micropython/webrepl).
+- WebREPL over WiFi from a browser (clients at <https://github.com/micropython/webrepl>).
 - Modules for HTTP, MQTT, many other formats and protocols via
-  https://github.com/micropython/micropython-lib .
+  <https://github.com/micropython/micropython-lib> .
 
-Documentation is available at http://docs.micropython.org/en/latest/esp8266/quickref.html.
+Documentation is available at <http://docs.micropython.org/en/latest/esp8266/quickref.html>.
 
-Build instructions
-------------------
+## Build instructions
 
 You need the esp-open-sdk toolchain (which provides both the compiler and libraries), which
 you can obtain using one of the following two options:
 
- - Use a Docker image with a pre-built toolchain (**recommended**).
-   To use this, install Docker, then prepend
-   `docker run --rm -v $HOME:$HOME -u $UID -w $PWD larsks/esp-open-sdk ` to the start
-   of the mpy-cross and firmware `make` commands below. This will run the commands using the
-   toolchain inside the container but using the files on your local filesystem.
+- Use a Docker image with a pre-built toolchain (**recommended**). To use
+  this, install Docker, then prepend `docker run --rm -v $HOME:$HOME -u $UID
+  -w $PWD larsks/esp-open-sdk` to the start of the mpy-cross and firmware
+  `make` commands below. This will run the commands using the toolchain inside
+  the container but using the files on your local filesystem.
 
- - or, install the esp-open-sdk directly on your PC, which can be found at
-   <https://github.com/pfalcon/esp-open-sdk>. Clone this repository and
-   run `make` in its directory to build and install the SDK locally.  Make sure
-   to add toolchain bin directory to your PATH.  Read esp-open-sdk's README for
-   additional important information on toolchain setup.
-   If you use this approach, then the command below will work exactly.
+- or, install the esp-open-sdk directly on your PC, which can be found at
+  <https://github.com/pfalcon/esp-open-sdk>. Clone this repository and
+  run `make` in its directory to build and install the SDK locally.  Make sure
+  to add toolchain bin directory to your PATH.  Read esp-open-sdk's README for
+  additional important information on toolchain setup.
+  If you use this approach, then the command below will work exactly.
 
 Add the external dependencies to the MicroPython repository checkout:
+
 ```bash
-$ make -C ports/esp8266 submodules
+make -C ports/esp8266 submodules
 ```
+
 See the README in the repository root for more information about external
 dependencies.
 
 The MicroPython cross-compiler must be built to pre-compile some of the
 built-in scripts to bytecode.  This can be done using:
+
 ```bash
-$ make -C mpy-cross
+make -C mpy-cross
 ```
+
 (Prepend the Docker command if using Docker, see above)
 
 Then, to build MicroPython for the ESP8266, just run:
+
 ```bash
-$ cd ports/esp8266
-$ make
+cd ports/esp8266
+make
 ```
+
 (Prepend the Docker command if using Docker, see above)
 
 This will produce binary images in the `build-GENERIC/` subdirectory. If you
 install MicroPython to your module for the first time, or after installing any
 other firmware, you should erase flash completely:
+
 ```bash
-$ esptool.py --port /dev/ttyXXX erase_flash
+esptool.py --port /dev/ttyXXX erase_flash
 ```
 
 You can install esptool.py either from your system package manager or from PyPi.
@@ -77,9 +83,11 @@ Erasing the flash is also useful as a troubleshooting measure, if a module doesn
 behave as expected.
 
 To flash MicroPython image to your ESP8266, use:
+
 ```bash
-$ make deploy
+make deploy
 ```
+
 (This should not be run inside Docker as it will need access to the serial port.)
 
 This will use the `esptool.py` script to download the images.  You must have
@@ -88,9 +96,11 @@ The default serial port is `/dev/ttyACM0`, flash mode is `qio` and flash size is
 `detect` (auto-detect based on Flash ID).
 
 To specify other values for `esptool.py`, use, e.g.:
+
 ```bash
-$ make PORT=/dev/ttyUSB0 FLASH_MODE=qio FLASH_SIZE=32m deploy
+make PORT=/dev/ttyUSB0 FLASH_MODE=qio FLASH_SIZE=32m deploy
 ```
+
 (note that flash size is in megabits)
 
 If you want to flash manually using `esptool.py` directly, the image produced is
@@ -100,11 +110,12 @@ The default board definition is the directory `boards/GENERIC`.
 For a custom configuration you can define your own board in the directory `boards/`.
 
 The `BOARD` variable can be set on the make command line, for example:
+
 ```bash
-$ make BOARD=GENERIC_512K
+make BOARD=GENERIC_512K
 ```
 
-__512KB FlashROM version__
+### 512KB FlashROM version
 
 The normal build described above requires modules with at least 1MB of FlashROM
 onboard. There's a special configuration for 512KB modules, which can be
@@ -114,22 +125,23 @@ suitable for advanced users who are interested to fine-tune options to achieve a
 required setup. If you are an end user, please consider using a module with at
 least 1MB of FlashROM.
 
-First start
------------
+## First start
 
 Be sure to change ESP8266's WiFi access point password ASAP, see below.
 
-__Serial prompt__
+### Serial prompt
 
 You can access the REPL (Python prompt) over UART (the same as used for
 programming).
+
 - Baudrate: 115200
 
 Run `help()` for some basic information.
 
-__WiFi__
+### WiFi
 
 Initially, the device configures itself as a WiFi access point (AP).
+
 - ESSID: MicroPython-xxxxxx (x’s are replaced with part of the MAC address).
 - Password: micropythoN (note the upper-case N).
 - IP address of the board: 192.168.4.1.
@@ -137,20 +149,21 @@ Initially, the device configures itself as a WiFi access point (AP).
 - Please be sure to change the password to something non-guessable
   immediately. `help()` gives information how.
 
-__WebREPL__
+### WebREPL
 
 Python prompt over WiFi, connecting through a browser.
-- Hosted at http://micropython.org/webrepl.
-- GitHub repository https://github.com/micropython/webrepl.
+
+- Hosted at <http://micropython.org/webrepl>.
+- GitHub repository <https://github.com/micropython/webrepl>.
   Please follow the instructions there.
 
-__upip__
+### upip
 
 The ESP8266 port comes with builtin `upip` package manager, which can
 be used to install additional modules (see the main README for more
 information):
 
-```
+```python
 >>> import upip
 >>> upip.install("micropython-pystone_lowmem")
 [...]
@@ -161,16 +174,14 @@ information):
 Downloading and installing packages may requite a lot of free memory,
 if you get an error, retry immediately after the hard reset.
 
-Documentation
--------------
+## Documentation
 
 More detailed documentation and instructions can be found at
-http://docs.micropython.org/en/latest/esp8266/ , which includes Quick
+<http://docs.micropython.org/en/latest/esp8266/> , which includes Quick
 Reference, Tutorial, General Information related to ESP8266 port, and
 to MicroPython in general.
 
-Troubleshooting
----------------
+## Troubleshooting
 
 While the port is in beta, it's known to be generally stable. If you
 experience strange bootloops, crashes, lockups, here's a list to check against:

--- a/ports/javascript/README.md
+++ b/ports/javascript/README.md
@@ -14,28 +14,38 @@ Build instructions
 
 In order to build micropython.js, run:
 
-    $ make
+```bash
+make
+```
 
 To generate the minified file micropython.min.js, run:
 
-    $ make min
+```bash
+make min
+```
 
 Running with Node.js
 --------------------
 
 Access the repl with:
 
-    $ node build/micropython.js
+```bash
+node build/micropython.js
+```
 
 Stack size may be modified using:
 
-    $ node build/micropython.js -X stack=64K
+```bash
+node build/micropython.js -X stack=64K
+```
 
 Where stack size may be represented in Bytes, KiB or MiB.
 
 MicroPython scripts may be executed using:
 
-    $ node build/micropython.js hello.py
+```bash
+node build/micropython.js hello.py
+```
 
 Alternatively micropython.js may by accessed by other javascript programs in node
 using the require command and the general API outlined below. For example:
@@ -83,34 +93,36 @@ Testing
 
 Run the test suite using:
 
-    $ make test
+```bash
+make test
+```
 
 API
 ---
 
 The following functions have been exposed to javascript.
 
-```
+```javascript
 mp_js_init(stack_size)
 ```
 
 Initialize MicroPython with the given stack size in bytes. This must be
 called before attempting to interact with MicroPython.
 
-```
+```javascript
 mp_js_do_str(code)
 ```
 
 Execute the input code. `code` must be a `string`.
 
-```
+```javascript
 mp_js_init_repl()
 ```
 
 Initialize MicroPython repl. Must be called before entering characters into
 the repl.
 
-```
+```javascript
 mp_js_process_char(char)
 ```
 

--- a/ports/mimxrt/README.md
+++ b/ports/mimxrt/README.md
@@ -6,26 +6,28 @@ MIMXRT1010_EVK, MIMXRT1020_EVK, MIMXRT1050_EVK, MIMXRT1060_EVK and
 MIMXRT1064_EVK boards.
 
 Features:
-  - REPL over USB VCP
-  - machine.ADC
-  - machine.I2C
-  - machine.LED
-  - machine.Pin
-  - machine.PWM
-  - machine.RTC
-  - machine.SDCard
-  - machine.SPI
-  - machine.Signal
-  - machine.SoftI2C
-  - machine.SoftSPI
-  - machine.Timer
-  - machine.UART
-  - LFS2 file system at the internal Flash
-  - SDCard support (not on MIMXRT1010_EVK)
-  - Ethernet (not on Teensy 4.0 and MIMXRT1010_EVK)
+
+- REPL over USB VCP
+- machine.ADC
+- machine.I2C
+- machine.LED
+- machine.Pin
+- machine.PWM
+- machine.RTC
+- machine.SDCard
+- machine.SPI
+- machine.Signal
+- machine.SoftI2C
+- machine.SoftSPI
+- machine.Timer
+- machine.UART
+- LFS2 file system at the internal Flash
+- SDCard support (not on MIMXRT1010_EVK)
+- Ethernet (not on Teensy 4.0 and MIMXRT1010_EVK)
 
 Known issues:
 
 TODO:
-  - More peripherals (Counter, I2S, CAN, etc)
-  - More Python options
+
+- More peripherals (Counter, I2S, CAN, etc)
+- More Python options

--- a/ports/minimal/README.md
+++ b/ports/minimal/README.md
@@ -7,11 +7,11 @@ It can run under Linux (or similar) and on any STM32F4xx MCU (eg the pyboard).
 
 By default the port will be built for the host machine:
 
-    $ make
+    make
 
 To run the executable and get a basic working REPL do:
 
-    $ make run
+    make run
 
 ## Building for an STM32 MCU
 
@@ -19,7 +19,7 @@ The Makefile has the ability to build for a Cortex-M CPU, and by default
 includes some start-up code for an STM32F4xx MCU and also enables a UART
 for communication.  To build:
 
-    $ make CROSS=1
+    make CROSS=1
 
 If you previously built the Linux version, you will need to first run
 `make clean` to get rid of incompatible object files.
@@ -27,7 +27,7 @@ If you previously built the Linux version, you will need to first run
 Building will produce the build/firmware.dfu file which can be programmed
 to an MCU using:
 
-    $ make CROSS=1 deploy
+    make CROSS=1 deploy
 
 This version of the build will work out-of-the-box on a pyboard (and
 anything similar), and will give you a MicroPython REPL on UART1 at 9600

--- a/ports/nrf/README.md
+++ b/ports/nrf/README.md
@@ -54,7 +54,8 @@ Prerequisite steps for building the nrf port:
     cd micropython
     make -C mpy-cross
 
-By default, the PCA10040 (nrf52832) is used as compile target. To build and flash issue the following command inside the ports/nrf/ folder:
+By default, the PCA10040 (nrf52832) is used as compile target. To build and
+flash issue the following command inside the ports/nrf/ folder:
 
     make submodules
     make
@@ -90,11 +91,15 @@ If the Bluetooth stacks has been downloaded, compile the target with the followi
 
     make BOARD=pca10040 SD=s132
 
-The **make sd** will trigger a flash of the bluetooth stack before that application is flashed. Note that **make sd** will perform a full erase of the chip, which could cause 3rd party bootloaders to also be wiped.
+The **make sd** will trigger a flash of the bluetooth stack before that
+application is flashed. Note that **make sd** will perform a full erase of the
+chip, which could cause 3rd party bootloaders to also be wiped.
 
     make BOARD=pca10040 SD=s132 sd
 
-Note: further tuning of features to include in bluetooth or even setting up the device to use REPL over Bluetooth can be configured in the `bluetooth_conf.h`.
+Note: further tuning of features to include in bluetooth or even setting up
+the device to use REPL over Bluetooth can be configured in the
+`bluetooth_conf.h`.
 
 ## Compile with frozen modules
 
@@ -127,7 +132,12 @@ In case of using the target board's makefile, add a line similar to this:
 In these two examples, the manual `make` invocation will have precedence.
 
 ## Enable MICROPY_VFS_FAT
-As the `oofatfs` module is not having header guards that can exclude the implementation compile time, this port provides a flag to enable it explicitly. The MICROPY_VFS_FAT is by default set to 0 and has to be set to 1 if `oofatfs` files should be compiled. This will be in addition of setting `MICROPY_VFS` in mpconfigport.h.
+
+As the `oofatfs` module is not having header guards that can exclude the
+implementation compile time, this port provides a flag to enable it
+explicitly. The MICROPY_VFS_FAT is by default set to 0 and has to be set to 1
+if `oofatfs` files should be compiled. This will be in addition of setting
+`MICROPY_VFS` in mpconfigport.h.
 
 For example:
 
@@ -193,7 +203,6 @@ Install the necessary tools to flash and debug using IDAP-M/IDAP-Link CMSIS-DAP 
 [IDAPnRFProg for OSX](https://sourceforge.net/projects/idaplinkfirmware/files/OSX/IDAPnRFProg_1_7_190320.zip/download)
 [IDAPnRFProg for Windows](https://sourceforge.net/projects/idaplinkfirmware/files/Windows/IDAPnRFProg_1_7_190320.zip/download)
 
-
 ## Segger Targets
 
 Install the necessary tools to flash and debug using Segger:
@@ -202,7 +211,8 @@ Install the necessary tools to flash and debug using Segger:
 
 [nrfjprog Download](https://www.nordicsemi.com/Software-and-Tools/Development-Tools/nRF5-Command-Line-Tools/Download#infotabs)
 
-note: On Linux it might be required to link SEGGER's `libjlinkarm.so` inside nrfjprog's folder.
+note: On Linux it might be required to link SEGGER's `libjlinkarm.so` inside
+nrfjprog's folder.
 
 ## PyOCD/OpenOCD Targets
 
@@ -221,7 +231,8 @@ for more tips about using the BMP with GDB.
 
 ## nRFUtil Targets
 
-Install the necessary Python packages that will be used for flashing using the bootloader:
+Install the necessary Python packages that will be used for flashing using the
+bootloader:
 
     sudo pip install nrfutil
     sudo pip install intelhex
@@ -246,19 +257,29 @@ the `sd` target instead of `deploy`. For example:
 
 ## Bluetooth LE REPL
 
-The port also implements a BLE REPL driver. This feature is disabled by default, as it will deactivate the UART REPL when activated. As some of the nRF devices only have one UART, using the BLE REPL free's the UART instance such that it can be used as a general UART peripheral not bound to REPL.
+The port also implements a BLE REPL driver. This feature is disabled by
+default, as it will deactivate the UART REPL when activated. As some of the
+nRF devices only have one UART, using the BLE REPL free's the UART instance
+such that it can be used as a general UART peripheral not bound to REPL.
 
-The configuration can be enabled by editing the `bluetooth_conf.h` and set `MICROPY_PY_BLE_NUS` to 1.
+The configuration can be enabled by editing the `bluetooth_conf.h` and set
+`MICROPY_PY_BLE_NUS` to 1.
 
 When enabled you have different options to test it:
+
 * [NUS Console for Linux](https://github.com/tralamazza/nus_console) (recommended)
 * [WebBluetooth REPL](https://aykevl.nl/apps/nus/) (experimental)
 
 Other:
+
 * nRF UART application for IPhone/Android
 
-WebBluetooth mode can also be configured by editing `bluetooth_conf.h` and set `BLUETOOTH_WEBBLUETOOTH_REPL` to 1. This will alternate advertisement between Eddystone URL and regular connectable advertisement. The Eddystone URL will point the phone or PC to download [WebBluetooth REPL](https://aykevl.nl/apps/nus/) (experimental), which subsequently can be used to connect to the Bluetooth REPL from the PC or Phone browser.
-
+WebBluetooth mode can also be configured by editing `bluetooth_conf.h` and set
+`BLUETOOTH_WEBBLUETOOTH_REPL` to 1. This will alternate advertisement between
+Eddystone URL and regular connectable advertisement. The Eddystone URL will
+point the phone or PC to download [WebBluetooth
+REPL](https://aykevl.nl/apps/nus/) (experimental), which subsequently can be
+used to connect to the Bluetooth REPL from the PC or Phone browser.
 
 ## Pin numbering scheme for nrf52840-based boards
 

--- a/ports/nrf/boards/nrf52840-mdk-usb-dongle/README.md
+++ b/ports/nrf/boards/nrf52840-mdk-usb-dongle/README.md
@@ -16,7 +16,6 @@ Open Bootloader, the flash and memory layout must be adjusted slightly (details
 from the typical nRF build; this board definition ensure the appropriate build
 configuration is used for MicroPython.
 
-
 Pinout
 ------
 
@@ -28,7 +27,6 @@ available in MicroPython, using the pin numbers labelled in the diagram
 
 The three LEDs are available either through the usual `Pin` mechanism - pins
 22-24 - or by `board.LED(n)` where n can be 1, 2 or 3.
-
 
 Build instructions
 ------------------
@@ -45,4 +43,4 @@ built, the target can be deployed to the device as described in
 An alternative way to deploy to the device, is to open `firmware.hex` using
 *nRF Connect* and select *Write*. Detailed instructions can be found on the
 [developer
-wiki](https://wiki.makerdiary.com/nrf52840-mdk-usb-dongle/programming/). 
+wiki](https://wiki.makerdiary.com/nrf52840-mdk-usb-dongle/programming/).

--- a/ports/powerpc/README.md
+++ b/ports/powerpc/README.md
@@ -8,11 +8,11 @@ potato UART.
 
 By default the port will be built with the potato uart for microwatt:
 
-    $ make
+    make
 
 To instead build for a machine with LPC serial, such as QEMU powernv:
 
-    $ make UART=lpc_serial
+    make UART=lpc_serial
 
 ## Cross compilation for POWERPC
 
@@ -21,24 +21,25 @@ compiler (not powerpc or powerpc64).
 
 On Ubuntu (18.04) you'll want:
 
-    $ apt install gcc-powerpc64le-linux-gnu
+    apt install gcc-powerpc64le-linux-gnu
 
-*(Use CROSS_COMPILE=powerpc64le-linux-gnu-)*
+- *(Use CROSS_COMPILE=powerpc64le-linux-gnu-)*
 
 If your distro doesn't have cross compilers, you can get cross compilers here:
-- https://toolchains.bootlin.com/
-*(use CROSS_COMPILE=powerpc64le-buildroot-linux-gnu-)*
+<https://toolchains.bootlin.com/>
+
+- *(use CROSS_COMPILE=powerpc64le-buildroot-linux-gnu-)*
 
 (Avoid musl libc as it defines __assert_fail() differently to glibc
 which breaks the micropython powerpc code)
 
 Then do:
 
-    $ make CROSS_COMPILE=<compiler prefix>
+    make CROSS_COMPILE=<compiler prefix>
 
 Building will produce the build/firmware.bin file which can be used
 QEMU or [microwatt](https://github.com/antonblanchard/microwatt).
 
 To run in QEMU use:
 
-    $ ./qemu-system-ppc64 -M powernv -cpu POWER9 -nographic -bios build/firmware.bin
+    ./qemu-system-ppc64 -M powernv -cpu POWER9 -nographic -bios build/firmware.bin

--- a/ports/qemu-arm/README.md
+++ b/ports/qemu-arm/README.md
@@ -1,5 +1,7 @@
+# The QEMU Port
+
 This is experimental, community-supported port for Cortex-M emulation as
-provided by QEMU (http://qemu.org).
+provided by QEMU (<http://qemu.org>).
 
 The purposes of this port are to enable:
 

--- a/ports/rp2/README.md
+++ b/ports/rp2/README.md
@@ -20,7 +20,9 @@ The MicroPython cross-compiler must be built first, which will be used to
 pre-compile (freeze) built-in Python code.  This cross-compiler is built and
 run on the host machine using:
 
-    $ make -C mpy-cross
+```bash
+make -C mpy-cross
+```
 
 This command should be executed from the root directory of this repository.
 All other commands below should be executed from the ports/rp2/ directory.
@@ -29,9 +31,11 @@ Building of the RP2 firmware is done entirely using CMake, although a simple
 Makefile is also provided as a convenience.  To build the firmware run (from
 this directory):
 
-    $ make submodules
-    $ make clean
-    $ make
+```bash
+make submodules
+make clean
+make
+```
 
 You can also build the standard CMake way.  The final firmware is found in
 the top-level of the CMake build directory (`build` by default) and is

--- a/ports/samd/README.md
+++ b/ports/samd/README.md
@@ -4,4 +4,5 @@ Port of MicroPython to Microchip SAMD MCUs
 Supports SAMD21 and SAMD51.
 
 Features:
+
 - REPL over USB VCP

--- a/ports/stm32/README.md
+++ b/ports/stm32/README.md
@@ -1,5 +1,4 @@
-MicroPython port to STM32 MCUs
-==============================
+# MicroPython port to STM32 MCUs
 
 This directory contains the port of MicroPython to ST's line of STM32
 microcontrollers.  Supported MCU series are: STM32F0, STM32F4, STM32F7,
@@ -22,15 +21,16 @@ not work and none of the advanced features of the STM32H7 are yet supported,
 such as the clock tree.  At this point the STM32H7 should be considered as a
 fast version of the STM32F7.
 
-Build instructions
-------------------
+## Build instructions
 
 Before building the firmware for a given board the MicroPython cross-compiler
 must be built; it will be used to pre-compile some of the built-in scripts to
 bytecode.  The cross-compiler is built and run on the host machine, using:
+
 ```bash
-$ make -C mpy-cross
+make -C mpy-cross
 ```
+
 This command should be executed from the root directory of this repository.
 All other commands below should be executed from the ports/stm32/ directory.
 
@@ -50,11 +50,15 @@ All boards require certain submodules to be obtained before they can be built.
 The correct set of submodules can be initialised using (with `PYBV11` as an
 example of the selected board):
 
-    $ make BOARD=PYBV11 submodules
+```bash
+make BOARD=PYBV11 submodules
+```
 
 Then to build the board's firmware run:
 
-    $ make BOARD=PYBV11
+```bash
+make BOARD=PYBV11
+```
 
 The above command should produce binary images in the `build-PYBV11/`
 subdirectory (or the equivalent directory for the board specified).
@@ -64,10 +68,11 @@ before flashing the main firmware.  For such boards an information message
 about this will be printed at the end of the main firmware build.  Mboot
 can be built via:
 
-    $ make -C mboot BOARD=STM32F769DISC
+```bash
+make -C mboot BOARD=STM32F769DISC
+```
 
 For more information about mboot see mboot/README.md.
-
 
 ### Flashing the Firmware using DFU mode
 
@@ -94,23 +99,30 @@ is in USB DFU mode.
 
 Once the board is in DFU mode, flash the firmware using the command:
 
-    $ make BOARD=PYBV11 deploy
+```bash
+make BOARD=PYBV11 deploy
+```
 
 This will use the included `tools/pydfu.py` script.  You can use instead the
 `dfu-util` program (available [here](http://dfu-util.sourceforge.net/)) by
 passing `USE_PYDFU=0`:
 
-    $ make BOARD=PYBV11 USE_PYDFU=0 deploy
+```bash
+make BOARD=PYBV11 USE_PYDFU=0 deploy
+```
 
 If flashing the firmware does not work it may be because you don't have the
 correct permissions.  Try then:
 
-    $ sudo make BOARD=PYBV11 deploy
+```bash
+sudo make BOARD=PYBV11 deploy
+```
 
 Or using `dfu-util` directly:
 
-    $ sudo dfu-util -a 0 -d 0483:df11 -D build-PYBV11/firmware.dfu
-
+```bash
+sudo dfu-util -a 0 -d 0483:df11 -D build-PYBV11/firmware.dfu
+```
 
 ### Flashing the Firmware with stlink
 
@@ -122,19 +134,22 @@ with a mini USB cable to its ST-LINK USB port and then use the make target
 `deploy-stlink`. For example, if you have the STM32F4DISCOVERY board, you can
 run:
 
-    $ make BOARD=STM32F4DISC deploy-stlink
+```bash
+make BOARD=STM32F4DISC deploy-stlink
+```
 
 The `st-flash` program should detect the USB connection to the board
 automatically. If not, run `lsusb` to determine its USB bus and device number
 and set the `STLINK_DEVICE` environment variable accordingly, using the format
 `<USB_BUS>:<USB_ADDR>`. Example:
 
-    $ lsusb
-    [...]
-    Bus 002 Device 035: ID 0483:3748 STMicroelectronics ST-LINK/V2
-    $ export STLINK_DEVICE="002:0035"
-    $ make BOARD=STM32F4DISC deploy-stlink
-
+```bash
+$ lsusb
+[...]
+Bus 002 Device 035: ID 0483:3748 STMicroelectronics ST-LINK/V2
+$ export STLINK_DEVICE="002:0035"
+$ make BOARD=STM32F4DISC deploy-stlink
+```
 
 ### Flashing the Firmware with OpenOCD
 
@@ -143,7 +158,9 @@ ST-LINK interface uses [OpenOCD](http://openocd.org/). Connect the board with
 a mini USB cable to its ST-LINK USB port and then use the make target
 `deploy-openocd`. For example, if you have the STM32F4DISCOVERY board:
 
-    $ make BOARD=STM32F4DISC deploy-openocd
+```bash
+make BOARD=STM32F4DISC deploy-openocd
+```
 
 The `openocd` program, which writes the firmware to the target board's flash,
 is configured via the file `ports/stm32/boards/openocd_stm32f4.cfg`. This
@@ -151,15 +168,18 @@ configuration should work for all boards based on a STM32F4xx MCU with a
 ST-LINKv2 interface. You can override the path to this configuration by setting
 `OPENOCD_CONFIG` in your Makefile or on the command line.
 
-Accessing the board
--------------------
+## Accessing the board
 
 Once built and deployed, access the MicroPython REPL (the Python prompt) via USB
 serial or UART, depending on the board.  There are many ways to do this, one of
 which is via `mpremote` (install it using `pip install mpremote`):
 
-    $ mpremote
+```bash
+mpremote
+```
 
 Other options are `picocom` and `screen`, for example:
 
-    $ picocom /dev/ttyACM0
+```bash
+picocom /dev/ttyACM0
+```

--- a/ports/stm32/boards/LEGO_HUB_NO6/README.md
+++ b/ports/stm32/boards/LEGO_HUB_NO6/README.md
@@ -8,6 +8,7 @@ it is plugged in to, and powered by, its USB port.  But without the battery the 
 and power on the Powered Up ports will not function.
 
 Features that are currently supported:
+
 - standard MicroPython
 - machine and bluetooth modules
 - filesystem
@@ -36,13 +37,17 @@ the Hub comes installed with.  To do this, enter the built-in bootloader by hold
 down the Bluetooth button for 5 seconds while powering up the Hub via USB.  Then
 run the following command from the root of this repository:
 
-    $ cd ports/stm32
-    $ make BOARD=LEGO_HUB_NO6 backup-hub-firmware
+```bash
+cd ports/stm32
+make BOARD=LEGO_HUB_NO6 backup-hub-firmware
+```
 
 This will create a file called `lego_hub_firmware.dfu`.  Put this file in a safe
 location.  To restore it, enter the built-in bootloader again and run:
 
-    $ make BOARD=LEGO_HUB_NO6 restore-hub-firmware
+```bash
+make BOARD=LEGO_HUB_NO6 restore-hub-firmware
+```
 
 This will restore the original firmware but not the filesystem.  To recreate the
 original filesystem the Hub must be updated using the appropriate LEGO PC
@@ -54,13 +59,17 @@ Installing MicroPython
 You first need to build and install mboot, which only needs to be done once.  From
 the root of this repository run:
 
-    $ cd ports/stm32/mboot
-    $ make BOARD=LEGO_HUB_NO6
+```bash
+cd ports/stm32/mboot
+make BOARD=LEGO_HUB_NO6
+```
 
 Now enter the built-in bootloader by holding down the Bluetooth button for 5
 seconds while powering up the Hub via USB.  Then run:
 
-    $ make BOARD=LEGO_HUB_NO6 deploy
+```bash
+make BOARD=LEGO_HUB_NO6 deploy
+```
 
 mboot should now be installed.  Enter mboot by holding down the left arrow
 button when powering up the Hub.  The display will cycle the letters: N, S, F, B.
@@ -69,16 +78,20 @@ blinks the centre button red once per second, and appears as a USB DFU device.
 
 Now build MicroPython (start at the root of this repository):
 
-    $ cd mpy-cross
-    $ make
-    $ cd ../ports/stm32
-    $ make submodules
-    $ make BOARD=LEGO_HUB_NO6
+```bash
+cd mpy-cross
+make
+cd ../ports/stm32
+make submodules
+make BOARD=LEGO_HUB_NO6
+```
 
 And deploy to the Hub (making sure mboot is active, the centre button is blinking
 red):
 
-    $ make BOARD=LEGO_HUB_NO6 deploy
+```bash
+make BOARD=LEGO_HUB_NO6 deploy
+```
 
 If successful, the Hub should now appear as a USB serial and mass storage device.
 
@@ -90,10 +103,12 @@ serial terminal program.
 
 To scan for BLE devices:
 
-    >>> import bluetooth
-    >>> ble = bluetooth.BLE()
-    >>> ble.irq(lambda *x: print(*x))
-    >>> ble.active(1)
-    >>> ble.gap_scan(2000, 625, 625)
+```python
+>>> import bluetooth
+>>> ble = bluetooth.BLE()
+>>> ble.irq(lambda *x: print(*x))
+>>> ble.active(1)
+>>> ble.gap_scan(2000, 625, 625)
+```
 
 Use help("modules") to see available built-in modules.

--- a/ports/stm32/boards/OLIMEX_H407/README.md
+++ b/ports/stm32/boards/OLIMEX_H407/README.md
@@ -2,7 +2,7 @@ OLIMEX H407 board
 =================
 
 This board definition supports the OLIMEX H407 board:
-https://www.olimex.com/Products/ARM/ST/STM32-H407/
+<https://www.olimex.com/Products/ARM/ST/STM32-H407/>
 
 A REPL is available at the U3BOOT connector with 115200 baud and on the
 micro USB socket.

--- a/ports/teensy/README.md
+++ b/ports/teensy/README.md
@@ -21,6 +21,7 @@ ARDUINO=~/arduino-1.0.5 make
 To upload MicroPython to the Teensy 3.1.
 
 Press the Program button on the Teensy 3.1
+
 ```bash
 sudo ARDUINO=~/arduino-1.0.5/ make deploy
 ```
@@ -34,17 +35,22 @@ minicom -D /dev/ttyACM0
 ## TIPS
 
 ### Install 49-teensy.rules into /etc/udev/rules.d
-If you install the 49-teensy.rules file from http://www.pjrc.com/teensy/49-teensy.rules
+
+If you install the 49-teensy.rules file from <http://www.pjrc.com/teensy/49-teensy.rules>
 into your ```/etc/udev/rules.d``` folder then you won't need to use sudo:
+
 ```bash
 sudo cp ~/Downloads/49-teensy.rules /etc/udev/rules.d
 sudo udevadm control --reload-rules
 ```
+
 Unplug and replug the teensy board, and then you can use: ```ARDUINO=~/arduino-1.0.5/ make deploy```
 
-### Create a GNUmakefile to hold your ARDUINO setting.
+### Create a GNUmakefile to hold your ARDUINO setting
+
 Create a file call GNUmakefile (note the lowercase m) in the teensy folder
 with the following contents:
+
 ```make
 $(info Executing GNUmakefile)
 
@@ -53,6 +59,7 @@ $(info ARDUINO=${ARDUINO})
 
 include Makefile
 ```
+
 GNUmakefile is not checked into the source code control system, so it will
 retain your settings when updating your source tree. You can also add
 additional Makefile customizations this way.
@@ -60,12 +67,13 @@ additional Makefile customizations this way.
 ### Tips for OSX
 
 Set the ARDUINO environment variable to the location where Arduino with TeensyDuino is installed.
+
 ```bash
 export ARDUINO=~/Downloads/Arduino.app/Contents/Java/
 ```
 
 Search /dev/ for USB port name, which will be cu.usbmodem followed by a few numbers. The name of the port maybe different depending on the version of OSX.
-To access the Python prompt type: 
+To access the Python prompt type:
 
 ```bash
 screen <devicename> 115200

--- a/ports/windows/README.md
+++ b/ports/windows/README.md
@@ -1,3 +1,5 @@
+# Micropython Windows Port
+
 This is the experimental, community-supported Windows port of MicroPython.
 It is based on Unix port, and expected to remain so.
 The port requires additional testing, debugging, and patches. Please
@@ -9,23 +11,20 @@ getting obsolete and is not actively supported by MicroPython.
 
 Build instruction assume you're in the ports/windows directory.
 
-Building on Debian/Ubuntu Linux system
----------------------------------------
+## Building on Debian/Ubuntu Linux system
 
     sudo apt-get install python3 build-essential gcc-mingw-w64
     make -C ../../mpy-cross
     make CROSS_COMPILE=i686-w64-mingw32-
 
-
-Building under Cygwin
----------------------
+## Building under Cygwin
 
 Install Cygwin, then install following packages using Cygwin's setup.exe:
 
-* mingw64-i686-gcc-core
-* mingw64-x86_64-gcc-core
-* make
-* python3
+- mingw64-i686-gcc-core
+- mingw64-x86_64-gcc-core
+- make
+- python3
 
 Build using:
 
@@ -37,12 +36,10 @@ Or for 64bit:
     make -C ../../mpy-cross CROSS_COMPILE=x86_64-w64-mingw32-
     make CROSS_COMPILE=x86_64-w64-mingw32-
 
+## Building under MSYS2
 
-Building under MSYS2
---------------------
-
-Install MSYS2 from http://repo.msys2.org/distrib, start the msys2.exe shell and
-install the build tools:
+Install MSYS2 from <http://repo.msys2.org/distrib>, start the msys2.exe shell
+and install the build tools:
 
     pacman -Syuu
     pacman -S make mingw-w64-x86_64-gcc pkg-config python3
@@ -52,46 +49,50 @@ Start the mingw64.exe shell and build:
     make -C ../../mpy-cross STRIP=echo SIZE=echo
     make
 
+## Building using MS Visual Studio 2013 (or higher)
 
-Building using MS Visual Studio 2013 (or higher)
-------------------------------------------------
-
-Install Python. There are several ways to do this, for example: download and install the
-latest Python 3 release from https://www.python.org/downloads/windows or from
-https://docs.conda.io/en/latest/miniconda.html,
-or open the Microsoft Store app and search for Python and install it.
+Install Python. There are several ways to do this, for example: download and
+install the latest Python 3 release from
+<https://www.python.org/downloads/windows> or from
+<https://docs.conda.io/en/latest/miniconda.html>, or open the Microsoft Store
+app and search for Python and install it.
 
 Install Visual Studio and the C++ toolset (for recent versions: install
 the free Visual Studio Community edition and the *Desktop development with C++* workload).
 
-In the IDE, open `micropython-cross.vcxproj` and `micropython.vcxproj` and build.
+In the IDE, open `micropython-cross.vcxproj` and `micropython.vcxproj` and
+build.
 
 To build from the command line:
 
     msbuild ../../mpy-cross/mpy-cross.vcxproj
     msbuild micropython.vcxproj
 
-__Stack usage__
+### Stack usage
 
-The msvc compiler is quite stack-hungry which might result in a "maximum recursion depth exceeded"
-RuntimeError for code with lots of nested function calls.
-There are several ways to deal with this:
-- increase the threshold used for detection by altering the argument to `mp_stack_set_limit` in `ports/unix/main.c`
-- disable detection all together by setting `MICROPY_STACK_CHECK` to "0" in `ports/windows/mpconfigport.h`
-- disable the /GL compiler flag by setting `WholeProgramOptimization` to "false"
+The msvc compiler is quite stack-hungry which might result in a "maximum
+recursion depth exceeded" RuntimeError for code with lots of nested function
+calls. There are several ways to deal with this:
 
-See [issue 2927](https://github.com/micropython/micropython/issues/2927) for more information.
+- increase the threshold used for detection by altering the argument to
+  `mp_stack_set_limit` in `ports/unix/main.c`
+- disable detection all together by setting `MICROPY_STACK_CHECK` to "0" in
+  `ports/windows/mpconfigport.h`
+- disable the /GL compiler flag by setting `WholeProgramOptimization` to
+  "false"
 
+See [issue 2927](https://github.com/micropython/micropython/issues/2927) for
+more information.
 
-Running the tests
------------------
+## Running the tests
 
 This is similar for all ports:
 
     cd ../../tests
     python ./run-tests.py
 
-Though when running on Cygwin and using Cygwin's Python installation you'll need:
+Though when running on Cygwin and using Cygwin's Python installation you'll
+need:
 
     python3 ./run-tests.py
 
@@ -99,9 +100,7 @@ Depending on the combination of platform and Python version used it might be
 needed to first set the MICROPY_MICROPYTHON environment variable to
 the full path of micropython.exe.
 
-
-Running on Linux using Wine
----------------------------
+## Running on Linux using Wine
 
 The default build (MICROPY_USE_READLINE=1) uses extended Windows console
 functions and thus should be ran using the `wineconsole` tool. Depending
@@ -110,7 +109,7 @@ backend which has the look&feel of a standard Unix console:
 
     wineconsole --backend=curses ./micropython.exe
 
-For more info, see https://www.winehq.org/docs/wineusr-guide/cui-programs .
+For more info, see <https://www.winehq.org/docs/wineusr-guide/cui-programs> .
 
 If built without line editing and history capabilities
 (MICROPY_USE_READLINE=0), the resulting binary can be run using the standard

--- a/ports/zephyr/README.md
+++ b/ports/zephyr/README.md
@@ -2,7 +2,7 @@ MicroPython port to Zephyr RTOS
 ===============================
 
 This is a work-in-progress port of MicroPython to Zephyr RTOS
-(http://zephyrproject.org).
+(<http://zephyrproject.org>).
 
 This port requires Zephyr version v2.6.0, and may also work on higher
 versions.  All boards supported
@@ -25,28 +25,31 @@ Features supported at this time:
 
 Over time, bindings for various Zephyr subsystems may be added.
 
-
 Building
 --------
 
 Follow to Zephyr web site for Getting Started instruction of installing
 Zephyr SDK, getting Zephyr source code, and setting up development
 environment. (Direct link:
-https://docs.zephyrproject.org/latest/getting_started/index.html).
+<https://docs.zephyrproject.org/latest/getting_started/index.html>).
 You may want to build Zephyr's own sample applications to make sure your
 setup is correct.
 
 If you already have Zephyr installed but are having issues building the
 MicroPython port then try installing the correct version of Zephyr via:
 
-    $ west init zephyrproject -m https://github.com/zephyrproject-rtos/zephyr --mr v2.6.0
+```bash
+west init zephyrproject -m https://github.com/zephyrproject-rtos/zephyr --mr v2.6.0
+```
 
 Alternatively, you don't have to redo the Zephyr installation to just
 switch from master to a tagged release, you can instead do:
 
-    $ cd zephyrproject/zephyr
-    $ git checkout v2.6.0
-    $ west update
+```bash
+cd zephyrproject/zephyr
+git checkout v2.6.0
+west update
+```
 
 With Zephyr installed you may then need to configure your environment,
 for example by sourcing `zephyrproject/zephyr/zephyr-env.sh`.
@@ -57,11 +60,15 @@ not have to be in the `ports/zephyr` directory. Assuming you have cloned the
 MicroPython repository into your home directory, you can build the Zephyr port
 for a frdm_k64f board like this:
 
-    $ west build -b frdm_k64f ~/micropython/ports/zephyr
+```bash
+west build -b frdm_k64f ~/micropython/ports/zephyr
+```
 
 To build for QEMU instead:
 
-    $ west build -b qemu_x86 ~/micropython/ports/zephyr
+```bash
+west build -b qemu_x86 ~/micropython/ports/zephyr
+```
 
 Consult the Zephyr documentation above for the list of
 supported boards.  Board configuration files appearing in `ports/zephyr/boards/`
@@ -73,23 +80,31 @@ Running
 
 To flash the resulting firmware to your board:
 
-    $ west flash
+```bash
+west flash
+```
 
 Or, to flash it to your board and start a gdb debug session:
 
-    $ west debug
+```bash
+west debug
+```
 
 To run the resulting firmware in QEMU (for BOARDs like qemu_x86,
 qemu_cortex_m3):
 
-    $ west build -t run
+```bash
+west build -t run
+```
 
 Networking is enabled with the default configuration, so you need to follow
 instructions in
-https://docs.zephyrproject.org/latest/guides/networking/qemu_setup.html#networking-with-qemu
+<https://docs.zephyrproject.org/latest/guides/networking/qemu_setup.html#networking-with-qemu>
 to setup the host side of TAP/SLIP networking. If you get an error like:
 
-    could not connect serial device to character backend 'unix:/tmp/slip.sock'
+```bash
+could not connect serial device to character backend 'unix:/tmp/slip.sock'
+```
 
 it's a sign that you didn't follow the instructions above. If you would like
 to just run it quickly without extra setup, see "minimal" build below.
@@ -99,15 +114,17 @@ Quick example
 
 To blink an LED:
 
-    import time
-    from machine import Pin
+```python
+import time
+from machine import Pin
 
-    LED = Pin(("GPIO_1", 21), Pin.OUT)
-    while True:
-        LED.value(1)
-        time.sleep(0.5)
-        LED.value(0)
-        time.sleep(0.5)
+LED = Pin(("GPIO_1", 21), Pin.OUT)
+while True:
+    LED.value(1)
+    time.sleep(0.5)
+    LED.value(0)
+    time.sleep(0.5)
+```
 
 The above code uses an LED location for a FRDM-K64F board (port B, pin 21;
 following Zephyr conventions port are identified by "GPIO_x", where *x*
@@ -118,32 +135,37 @@ Ctrl+D to finish paste mode and start execution.
 
 To respond to Pin change IRQs, on a FRDM-K64F board run:
 
-    from machine import Pin
+```python
+from machine import Pin
 
-    SW2 = Pin(("GPIO_2", 6), Pin.IN)
-    SW3 = Pin(("GPIO_0", 4), Pin.IN)
+SW2 = Pin(("GPIO_2", 6), Pin.IN)
+SW3 = Pin(("GPIO_0", 4), Pin.IN)
 
-    SW2.irq(lambda t: print("SW2 changed"))
-    SW3.irq(lambda t: print("SW3 changed"))
+SW2.irq(lambda t: print("SW2 changed"))
+SW3.irq(lambda t: print("SW3 changed"))
 
-    while True:
-        pass
+while True:
+    pass
+```
 
 Example of using I2C to scan for I2C slaves:
 
-    from machine import I2C
+```python
+from machine import I2C
 
-    i2c = I2C("I2C_0")
-    i2c.scan()
+i2c = I2C("I2C_0")
+i2c.scan()
+```
 
 Example of using SPI to write a buffer to the MOSI pin:
 
-    from machine import SPI
+```python
+from machine import SPI
 
-    spi = SPI("SPI_0")
-    spi.init(baudrate=500000, polarity=1, phase=1, bits=8, firstbit=SPI.MSB)
-    spi.write(b'abcd')
-
+spi = SPI("SPI_0")
+spi.init(baudrate=500000, polarity=1, phase=1, bits=8, firstbit=SPI.MSB)
+spi.write(b'abcd')
+```
 
 Minimal build
 -------------
@@ -161,10 +183,13 @@ enabled over time.
 
 To make a minimal build:
 
-    $ west build -b qemu_x86 ~/micropython/ports/zephyr -- -DCONF_FILE=prj_minimal.conf
+```bash
+west build -b qemu_x86 ~/micropython/ports/zephyr -- -DCONF_FILE=prj_minimal.conf
+```
 
 To run a minimal build in QEMU without requiring TAP networking setup
 run the following after you built an image with the previous command:
 
-    $ west build -t run
-
+```bash
+west build -t run
+```

--- a/shared/README.md
+++ b/shared/README.md
@@ -1,3 +1,5 @@
+# Micropython Shared Libraries, Utilities and Helpers
+
 This directory contains libraries, utilities and helper code developed
 specifically for this project.  The code is intended to be portable and
 usable by any port.

--- a/shared/memzip/README.md
+++ b/shared/memzip/README.md
@@ -1,4 +1,4 @@
-MEMZIP - a simple readonly file system
+# MEMZIP - a simple readonly file system
 
 memzip takes a zip file which is comprised of uncompressed files and
 and presents it as a filesystem, allowing Python files to be imported.
@@ -8,7 +8,8 @@ containing uncompressed files found in the directory. It will then generate
 a C file which contains the data from the zip file.
 
 A typical addition to a makefile would look like:
-```
+
+```make
 SRC_C += \
     shared/memzip/import.c \
     shared/memzip/lexermemzip.c \
@@ -25,4 +26,3 @@ $(BUILD)/memzip-files.c: $(shell find ${MEMZIP_DIR} -type f)
     @$(ECHO) "Creating $@"
     $(Q)$(PYTHON) $(MAKE_MEMZIP) --zip-file $(BUILD)/memzip-files.zip --c-file $@ $(MEMZIP_DIR)
 ```
-

--- a/tools/mpremote/README.md
+++ b/tools/mpremote/README.md
@@ -5,28 +5,32 @@ and automate a MicroPython device over a serial connection.
 
 The simplest way to use this tool is:
 
-    mpremote
+```bash
+mpremote
+```
 
 This will automatically connect to the device and provide an interactive REPL.
 
 The full list of supported commands are:
 
-    mpremote connect <device>        -- connect to given device
-                                        device may be: list, auto, id:x, port:x
-                                        or any valid device name/path
-    mpremote disconnect              -- disconnect current device
-    mpremote mount <local-dir>       -- mount local directory on device
-    mpremote eval <string>           -- evaluate and print the string
-    mpremote exec <string>           -- execute the string
-    mpremote run <file>              -- run the given local script
-    mpremote fs <command> <args...>  -- execute filesystem commands on the device
-                                        command may be: cat, ls, cp, rm, mkdir, rmdir
-                                        use ":" as a prefix to specify a file on the device
-    mpremote repl                    -- enter REPL
-                                        options:
-                                            --capture <file>
-                                            --inject-code <string>
-                                            --inject-file <file>
+```bash
+mpremote connect <device>        -- connect to given device
+                                    device may be: list, auto, id:x, port:x
+                                    or any valid device name/path
+mpremote disconnect              -- disconnect current device
+mpremote mount <local-dir>       -- mount local directory on device
+mpremote eval <string>           -- evaluate and print the string
+mpremote exec <string>           -- execute the string
+mpremote run <file>              -- run the given local script
+mpremote fs <command> <args...>  -- execute filesystem commands on the device
+                                    command may be: cat, ls, cp, rm, mkdir, rmdir
+                                    use ":" as a prefix to specify a file on the device
+mpremote repl                    -- enter REPL
+                                    options:
+                                        --capture <file>
+                                        --inject-code <string>
+                                        --inject-file <file>
+```
 
 Multiple commands can be specified and they will be run sequentially.  Connection
 and disconnection will be done automatically at the start and end of the execution
@@ -46,26 +50,30 @@ Shortcuts can be defined using the macro system.  Built-in shortcuts are:
 Any user configuration, including user-defined shortcuts, can be placed in
 .config/mpremote/config.py.  For example:
 
-    # Custom macro commands
-    commands = {
-        "c33": "connect id:334D335C3138",
-        "bl": "bootloader",
-        "double x=4": "eval x*2",
-    }
+```python
+# Custom macro commands
+commands = {
+    "c33": "connect id:334D335C3138",
+    "bl": "bootloader",
+    "double x=4": "eval x*2",
+}
+```
 
 Examples:
 
-    mpremote
-    mpremote a1
-    mpremote connect /dev/ttyUSB0 repl
-    mpremote ls
-    mpremote a1 ls
-    mpremote exec "import micropython; micropython.mem_info()"
-    mpremote eval 1/2 eval 3/4
-    mpremote mount .
-    mpremote mount . exec "import local_script"
-    mpremote ls
-    mpremote cat boot.py
-    mpremote cp :main.py .
-    mpremote cp main.py :
-    mpremote cp -r dir/ :
+```bash
+mpremote
+mpremote a1
+mpremote connect /dev/ttyUSB0 repl
+mpremote ls
+mpremote a1 ls
+mpremote exec "import micropython; micropython.mem_info()"
+mpremote eval 1/2 eval 3/4
+mpremote mount .
+mpremote mount . exec "import local_script"
+mpremote ls
+mpremote cat boot.py
+mpremote cp :main.py .
+mpremote cp main.py :
+mpremote cp -r dir/ :
+```


### PR DESCRIPTION
This PR makes the various micropython **/*.md file markdownlint compliant.

This is motivated by occasional failures by various markdown processors to render the micropython **/*.md files correctly from a local folder (eg. from VS Code) and to improve rendering of code snippets in markdown files.

The main fixups were:

- [MD003 - Heading style](https://github.com/DavidAnson/markdownlint/blob/main/doc/Rules.md#md003---heading-style) - Inconsistent use of markdown heading styles in a document.
- [MD004 - Unordered list style](https://github.com/DavidAnson/markdownlint/blob/main/doc/Rules.md#md004---unordered-list-style) - Inconsistent use of lists starting with '-' and '*' in a document
- [MD014 - Dollar signs used before commands without showing output](https://github.com/DavidAnson/markdownlint/blob/main/doc/Rules.md#md014---dollar-signs-used-before-commands-without-showing-output)
- [MD022 - Headings should be surrounded by blank lines](https://github.com/DavidAnson/markdownlint/blob/main/doc/Rules.md#md022---headings-should-be-surrounded-by-blank-lines)
- [MD031 - Fenced code blocks should be surrounded by blank lines](https://github.com/DavidAnson/markdownlint/blob/main/doc/Rules.md#md031---fenced-code-blocks-should-be-surrounded-by-blank-lines)
- [MD032 - Lists should be surrounded by blank lines](https://github.com/DavidAnson/markdownlint/blob/main/doc/Rules.md#md032---lists-should-be-surrounded-by-blank-lines)
- [MD034 - Bare URL used](https://github.com/DavidAnson/markdownlint/blob/main/doc/Rules.md#md034---bare-url-used)
- [MD040 - Fenced code blocks should have a language specified](https://github.com/DavidAnson/markdownlint/blob/main/doc/Rules.md#md040---fenced-code-blocks-should-have-a-language-specified)
- [MD041 - First line in a file should be a top-level heading](https://github.com/DavidAnson/markdownlint/blob/main/doc/Rules.md#md041---first-line-in-a-file-should-be-a-top-level-heading)
- [MD046 - Code block style](https://github.com/DavidAnson/markdownlint/blob/main/doc/Rules.md#md046---code-block-style) - Inconsistent style for code blocks (mixing use of indented code blocks and ``` code fences)
- and a few paragraphs written on a single line overflowing the max line length.

A new configuration file `.markdownlint.jsonc` is added to the top-level directory to override a few necessary defaults:
- Set 'no-hard-tabs' to false so that Makefile snippets with embedded TAB characters are accepted.
- Set max line length to 180 characters to accommodate a few necessarily long lines.

To test, run:

```bash
markdownlint-cli2 `find . -path ./lib -prune -o -name '*.md' -print`
```

This also supports the VS Code `markdownlint` extension.

See https://github.com/DavidAnson/markdownlint-cli2