### PR TITLE
ESP32: Set maximum heap size in mpconfigport.h.

### DIFF
--- a/ports/esp32/main.c
+++ b/ports/esp32/main.c
@@ -113,6 +113,9 @@ void mp_task(void *pvParameter) {
         default:
             // No SPIRAM, fallback to normal allocation
             mp_task_heap_size = heap_caps_get_largest_free_block(MALLOC_CAP_8BIT);
+            if (mp_task_heap_size > MICROPY_HEAP_SIZE_MAX) {
+                mp_task_heap_size = MICROPY_HEAP_SIZE_MAX;
+            }
             mp_task_heap = malloc(mp_task_heap_size);
             break;
     }
@@ -126,11 +129,17 @@ void mp_task(void *pvParameter) {
     } else {
         // No SPIRAM, fallback to normal allocation
         mp_task_heap_size = heap_caps_get_largest_free_block(MALLOC_CAP_8BIT);
+        if (mp_task_heap_size > MICROPY_HEAP_SIZE_MAX) {
+            mp_task_heap_size = MICROPY_HEAP_SIZE_MAX;
+        }
         mp_task_heap = malloc(mp_task_heap_size);
     }
     #else
     // Allocate the uPy heap using malloc and get the largest available region
     size_t mp_task_heap_size = heap_caps_get_largest_free_block(MALLOC_CAP_8BIT);
+    if (mp_task_heap_size > MICROPY_HEAP_SIZE_MAX) {
+        mp_task_heap_size = MICROPY_HEAP_SIZE_MAX;
+    }
     void *mp_task_heap = malloc(mp_task_heap_size);
     #endif
 

--- a/ports/esp32/mpconfigport.h
+++ b/ports/esp32/mpconfigport.h
@@ -15,6 +15,12 @@
 #define MICROPY_GCREGS_SETJMP               (1)
 #endif
 
+// maximum amount of memory to allocate to micropython heap (bytes)
+// can be overridden in board/XXX/mpconfigboard.h
+#ifndef MICROPY_HEAP_SIZE_MAX
+#define MICROPY_HEAP_SIZE_MAX               (104000)
+#endif
+
 // memory allocation policies
 #define MICROPY_ALLOC_PATH_MAX              (128)
 


### PR DESCRIPTION
### The problem: Too much memory allocated to heap on ESP32S2.

Micropython allocates too much RAM to the microython heap on ESP32S2 leaving insufficient RAM available for other IDF functions (causing panics in networking and espnow code). On the ESP32 101563 bytes is allocated to the heap by default. On the ESP32S2 this is ~120kB.  

NOTE: when this [this bug](https://github.com/espressif/esp-idf/issues/7808) is resolved the default heap size on ESP32S2 will increase to ~160kB.

### This fix: Set a maximum allowed value for the heap size.

Micropython currently allocates the largest available memory block to the micropython heap. This PR allows the maximum allowed heap size to be #defined as MICROPY_HEAP_SIZE_MAX. The default value is set to 104000 in mpconfigport.h and can be overridden in the board definition files: mpconfigboard.h.

With this default setting the espnow and wireless functions no longer generate panics on the ESP32S2.

### Other approaches

https://github.com/micropython/micropython/pull/6785 allows the heap size to be set at run time (from NVS variables) which is a useful and powerful feature.

Nonetheless, it should be possible to deterministically set a reasonable maximum for the heap size"out of the box"  in a compiled image that allows normal operation of an ESP32XX chip irregardless of exactly how the memory on the chip is fragmented.