### PR TITLE
ports/minimal: Don't force 32-bit.

### DIFF
--- a/ports/minimal/Makefile
+++ b/ports/minimal/Makefile
@@ -27,8 +27,8 @@ CFLAGS = $(INC) -Wall -Werror -std=c99 -nostdlib $(CFLAGS_CORTEX_M4) $(COPT)
 LDFLAGS = -nostdlib -T stm32f405.ld -Map=$@.map --cref --gc-sections
 else
 LD = gcc
-CFLAGS = -m32 $(INC) -Wall -Werror -Wdouble-promotion -Wfloat-conversion -std=c99 $(COPT)
-LDFLAGS = -m32 -Wl,-Map=$@.map,--cref -Wl,--gc-sections
+CFLAGS = $(INC) -Wall -Werror -Wdouble-promotion -Wfloat-conversion -std=c99 $(COPT)
+LDFLAGS = -Wl,-Map=$@.map,--cref -Wl,--gc-sections
 endif
 
 CSUPEROPT = -Os # save some code space


### PR DESCRIPTION
Word-size specific configuration is now done automatically, so it no longer
requires this to match the ARM configuration.

Also it's less common to have 32-bit compilation support installed, so this
will make it work "out of the box" for more people.

This addresses #5584.