### PR TITLE
minimal/mpconfigport.h: Disable features that are not needed.

### DIFF
--- a/ports/minimal/mpconfigport.h
+++ b/ports/minimal/mpconfigport.h
@@ -15,17 +15,9 @@
 #define MICROPY_HELPER_REPL               (1)
 #define MICROPY_MODULE_FROZEN_MPY         (1)
 #define MICROPY_ENABLE_EXTERNAL_IMPORT    (1)
-#define MICROPY_PY_MATH                   (1)
 
 #define MICROPY_ALLOC_PATH_MAX            (256)
 #define MICROPY_ALLOC_PARSE_CHUNK_INIT    (16)
-
-#define MICROPY_COMP_CONST_FOLDING        (1)
-#define MICROPY_COMP_CONST_LITERAL        (1)
-#define MICROPY_FULL_CHECKS               (1)
-#define MICROPY_MULTIPLE_INHERITANCE      (1)
-#define MICROPY_PY_GENERATOR_PEND_THROW   (1)
-#define MICROPY_PY_BUILTINS_RANGE_ATTRS   (1)
 
 // type definitions for the specific machine
 


### PR DESCRIPTION
Now that there are feature levels, and that this port uses MICROPY_CONFIG_ROM_LEVEL_MINIMUM, it's easy to see what optional features can be disabled.  And this commit disables them.
