### PR TITLE
docs: correction of multiple classes, function perameters and constants

### DIFF
--- a/docs/library/collections.rst
+++ b/docs/library/collections.rst
@@ -12,7 +12,7 @@ hold/accumulate various objects.
 Classes
 -------
 
-.. function:: deque(iterable, maxlen[, flags])
+.. class:: deque(iterable, maxlen[, flags])
 
     Deques (double-ended queues) are a list-like container that support O(1)
     appends and pops from either side of the deque.  New deques are created
@@ -57,7 +57,7 @@ Classes
         print(t1.name)
         assert t2.name == t2[1]
 
-.. function:: OrderedDict(...)
+.. class:: OrderedDict(...)
 
     ``dict`` type subclass which remembers and preserves the order of keys
     added. When ordered dict is iterated over, keys/items are returned in

--- a/docs/library/esp.rst
+++ b/docs/library/esp.rst
@@ -62,6 +62,20 @@ Functions
 
 .. function:: flash_erase(sector_no)
 
+.. function:: osdebug(level)
+
+    Turn esp os debugging messages on or off.
+
+    The *level* parameter sets the threshold for the log messages for all esp components.
+    The log levels are defined as constants:
+       
+        * ``LOG_NONE`` -- No log output
+        * ``LOG_ERROR`` -- Critical errors, software module can not recover on its own
+        * ``LOG_WARN`` -- Error conditions from which recovery measures have been taken
+        * ``LOG_INFO`` -- Information messages which describe normal flow of events
+        * ``LOG_DEBUG`` -- Extra information which is not necessary for normal use (values, pointers, sizes, etc)
+        * ``LOG_VERBOSE`` -- Bigger chunks of debugging information, or frequent messages which can potentially flood the output
+
 .. function:: set_native_code_location(start, length)
 
     **Note**: ESP8266 only

--- a/docs/library/machine.PWM.rst
+++ b/docs/library/machine.PWM.rst
@@ -23,7 +23,7 @@ Example usage::
 Constructors
 ------------
 
-.. class:: PWM(dest, \*, freq, duty_u16, duty_ns)
+.. class:: PWM(dest, *, freq, duty_u16, duty_ns)
 
    Construct and return a new PWM object using the following parameters:
 
@@ -42,7 +42,7 @@ Constructors
 Methods
 -------
 
-.. method:: PWM.init(\*, freq, duty_u16, duty_ns)
+.. method:: PWM.init(*, freq, duty_u16, duty_ns)
 
    Modify settings for the PWM object.  See the above constructor for details
    about the parameters.

--- a/docs/library/machine.Pin.rst
+++ b/docs/library/machine.Pin.rst
@@ -42,7 +42,7 @@ Usage Model::
 Constructors
 ------------
 
-.. class:: Pin(id, mode=-1, pull=-1, *, value, drive, alt)
+.. class:: Pin(id, mode=-1, pull=-1, *, value=None, drive=0, alt=-1)
 
    Access the pin peripheral (GPIO pin) associated with the given ``id``.  If
    additional arguments are given in the constructor then they are used to initialise
@@ -108,7 +108,7 @@ Constructors
 Methods
 -------
 
-.. method:: Pin.init(mode=-1, pull=-1, *, value, drive, alt)
+.. method:: Pin.init(mode=-1, pull=-1, *, value=None, drive=0, alt=-1)
 
    Re-initialise the pin using the given parameters.  Only those arguments that
    are specified will be set.  The rest of the pin peripheral state will remain

--- a/docs/library/machine.SPI.rst
+++ b/docs/library/machine.SPI.rst
@@ -143,9 +143,11 @@ Constants
    for initialising the SPI bus to controller; this is only used for the WiPy
 
 .. data:: SPI.MSB
+          SoftSPI.MSB
 
    set the first bit to be the most significant bit
 
 .. data:: SPI.LSB
+          SoftSPI.LSB
 
    set the first bit to be the least significant bit

--- a/docs/library/machine.WDT.rst
+++ b/docs/library/machine.WDT.rst
@@ -31,7 +31,7 @@ Constructors
 Methods
 -------
 
-.. method:: wdt.feed()
+.. method:: WDT.feed()
 
    Feed the WDT to prevent it from resetting the system. The application
    should place this call in a sensible place ensuring that the WDT is

--- a/docs/library/pyb.DAC.rst
+++ b/docs/library/pyb.DAC.rst
@@ -133,4 +133,4 @@ Constants
 .. data:: DAC.CIRCULAR
 
    CIRCULAR mode does a transmission of the waveform in the data buffer, and wraps around 
-   to    the start of the data buffer every time it reaches the end of the table.
+   to the start of the data buffer every time it reaches the end of the table.

--- a/docs/library/pyb.DAC.rst
+++ b/docs/library/pyb.DAC.rst
@@ -122,3 +122,15 @@ Methods
      dac2 = DAC(2)
      dac1.write_timed(buf1, pyb.Timer(6, freq=100), mode=DAC.CIRCULAR)
      dac2.write_timed(buf2, pyb.Timer(7, freq=200), mode=DAC.CIRCULAR)
+
+Constants
+---------
+
+.. data:: DAC.NORMAL
+
+   NORMAL mode does a single transmission of the waveform in the data buffer, 
+
+.. data:: DAC.CIRCULAR
+
+   CIRCULAR mode does a transmission of the waveform in the data buffer, and wraps around 
+   to    the start of the data buffer every time it reaches the end of the table.

--- a/docs/library/pyb.Pin.rst
+++ b/docs/library/pyb.Pin.rst
@@ -98,7 +98,7 @@ Class methods
 Methods
 -------
 
-.. method:: Pin.init(mode, pull=Pin.PULL_NONE, \*, value=None, alt=-1)
+.. method:: Pin.init(mode, pull=Pin.PULL_NONE, *, value=None, alt=-1)
 
    Initialise the pin:
 

--- a/docs/library/pyb.SPI.rst
+++ b/docs/library/pyb.SPI.rst
@@ -51,7 +51,7 @@ Methods
 
    Turn off the SPI bus.
 
-.. method:: SPI.init(mode, baudrate=328125, *, prescaler, polarity=1, phase=0, bits=8, firstbit=SPI.MSB, ti=False, crc=None)
+.. method:: SPI.init(mode, baudrate=328125, *, prescaler=0, polarity=1, phase=0, bits=8, firstbit=SPI.MSB, ti=False, crc=None)
 
    Initialise the SPI bus with the given parameters:
 

--- a/docs/library/pyb.Timer.rst
+++ b/docs/library/pyb.Timer.rst
@@ -262,3 +262,14 @@ Methods
    for which the pulse is active.  The value can be an integer or
    floating-point number for more accuracy.  For example, a value of 25 gives
    a duty cycle of 25%.
+
+
+Constants
+---------
+
+.. data:: Timer.UP
+          Timer.DOWN
+          Timer.CENTER
+
+   Configures the timer to count Up, Down, or from 0 to ARR and then back down to 0.
+

--- a/docs/library/pyb.rst
+++ b/docs/library/pyb.rst
@@ -298,6 +298,15 @@ Miscellaneous functions
    The *high_speed* parameter, when set to ``True``, enables USB HS mode if
    it is supported by the hardware.
 
+Constants
+---------
+
+.. data:: pyb.hid_mouse
+          pyb.hid_keyboard
+
+   A tuple of (subclass, protocol, max packet length, polling interval, report descriptor) to set appropriate values for a USB
+   mouse or keyboard.
+
 Classes
 -------
 

--- a/docs/library/socket.rst
+++ b/docs/library/socket.rst
@@ -66,19 +66,6 @@ Tuple address format for ``socket`` module:
 Functions
 ---------
 
-.. function:: socket(af=AF_INET, type=SOCK_STREAM, proto=IPPROTO_TCP, /)
-
-   Create a new socket using the given address family, socket type and
-   protocol number. Note that specifying *proto* in most cases is not
-   required (and not recommended, as some MicroPython ports may omit
-   ``IPPROTO_*`` constants). Instead, *type* argument will select needed
-   protocol automatically::
-
-        # Create STREAM TCP socket
-        socket(AF_INET, SOCK_STREAM)
-        # Create DGRAM UDP socket
-        socket(AF_INET, SOCK_DGRAM)
-
 .. function:: getaddrinfo(host, port, af=0, type=0, proto=0, flags=0, /)
 
    Translate the host/port argument into a sequence of 5-tuples that contain all the
@@ -175,6 +162,18 @@ Constants specific to WiPy:
 
 class socket
 ============
+.. class:: socket(af=AF_INET, type=SOCK_STREAM, proto=IPPROTO_TCP, /)
+
+   Create a new socket using the given address family, socket type and
+   protocol number. Note that specifying *proto* in most cases is not
+   required (and not recommended, as some MicroPython ports may omit
+   ``IPPROTO_*`` constants). Instead, *type* argument will select needed
+   protocol automatically::
+
+        # Create STREAM TCP socket
+        socket(AF_INET, SOCK_STREAM)
+        # Create DGRAM UDP socket
+        socket(AF_INET, SOCK_DGRAM)
 
 Methods
 -------

--- a/docs/wipy/general.rst
+++ b/docs/wipy/general.rst
@@ -345,7 +345,7 @@ Example::
 
    Create a server instance, see ``init`` for parameters of initialization.
 
-.. method:: server.init(\*, login=('micro', 'python'), timeout=300)
+.. method:: server.init(*, login=('micro', 'python'), timeout=300)
 
    Init (and effectively start the server). Optionally a new ``user``, ``password``
    and ``timeout`` (in seconds) can be passed.
@@ -368,7 +368,7 @@ Adhoc VFS-like support
 WiPy doesn't implement full MicroPython VFS support, instead following
 functions are defined in ``os`` module:
 
-.. function:: mount(block_device, mount_point, \*, readonly=False)
+.. function:: mount(block_device, mount_point, *, readonly=False)
 
    Mounts a block device (like an ``SD`` object) in the specified mount
    point. Example::


### PR DESCRIPTION
I have would like to propose the following improvements and corrections to the library documentation :

- a number of classes were incorrectly documented as a function
  - docs/library/usocket.rst - class socket 
  - docs/library/ucollections.rst  - 2 classes 

-  use correct * 'keyword only' notation in class description 
  - docs/library/machine.PWM.rst
  - docs/library/pyb.Pin.rst
  - docs/wipy/general.rst
 
- add Timer class constants 
 - docs/library/pyb.Timer.rst

- add pyb.hid_mouse and hid_keyboard constants
  - docs/library/pyb.rst
  
- Add DAC class constants
  - docs/library/pyb.DAC.rst
  
-  Add SoftSPI.MSB and LSB constants 
  - docs/library/machine.SPI.rst
  
- fix: WDT.feed casing
 -  docs/library/machine.WDT.rst