### PR TITLE
esp32/modmachine: wake_ext1_pins() returns which EXT1 pins caused wakeup.

### DIFF
--- a/docs/library/machine.rst
+++ b/docs/library/machine.rst
@@ -166,6 +166,15 @@ Power related functions
 
    Availability: ESP32, WiPy.
 
+.. function:: wake_ext1_pins()
+
+   Returns the GPIO pin numbers of those pins which caused wakeup from deep sleep as a
+   tuple of integers.
+
+   This is a direct interface to the ESP-IDF ``esp_sleep_get_ext1_wakeup_status()`` function.
+
+   Availability: ESP32 (except ESP32C3).
+
 Miscellaneous functions
 -----------------------
 


### PR DESCRIPTION
This had been discussed in the forum => https://forum.micropython.org/viewtopic.php?f=18&t=11272
Is it OK that this is in modmachine.c and not in modesp32 ? 

I still need to test this.
