### PR TITLE
stm32: fix bug with disabling of DMA2 in CYW43 SDIO driver

### DIFF
--- a/ports/stm32/dma.c
+++ b/ports/stm32/dma.c
@@ -42,6 +42,10 @@
 
 #define ENABLE_SDIO (MICROPY_HW_ENABLE_SDCARD || MICROPY_HW_ENABLE_MMCARD || MICROPY_PY_NETWORK_CYW43)
 
+// If the CYW43 driver is enabled then SDIO DMA can happen preemptively (on an
+// IRQ) and so the SDIO needs exclusive access to its DMA resource.
+#define SDIO_NEEDS_EXCLUSIVE_DMA_ACCESS (MICROPY_PY_NETWORK_CYW43 && MICROPY_HW_SDIO_SDMMC == 1)
+
 typedef enum {
     dma_id_not_defined=-1,
     dma_id_0,
@@ -298,11 +302,13 @@ const dma_descr_t dma_SPI_1_RX = { DMA2_Stream2, DMA_CHANNEL_3, dma_id_10,  &dma
 #if MICROPY_HW_ENABLE_I2S
 const dma_descr_t dma_I2S_1_RX = { DMA2_Stream2, DMA_CHANNEL_3, dma_id_10,  &dma_init_struct_i2s };
 #endif
-const dma_descr_t dma_SPI_5_RX = { DMA2_Stream3, DMA_CHANNEL_2, dma_id_11,  &dma_init_struct_spi_i2c };
 #if ENABLE_SDIO
 const dma_descr_t dma_SDIO_0 = { DMA2_Stream3, DMA_CHANNEL_4, dma_id_11,  &dma_init_struct_sdio };
 #endif
+#if !SDIO_NEEDS_EXCLUSIVE_DMA_ACCESS
+const dma_descr_t dma_SPI_5_RX = { DMA2_Stream3, DMA_CHANNEL_2, dma_id_11,  &dma_init_struct_spi_i2c };
 const dma_descr_t dma_SPI_4_RX = { DMA2_Stream3, DMA_CHANNEL_5, dma_id_11,  &dma_init_struct_spi_i2c };
+#endif
 const dma_descr_t dma_SPI_5_TX = { DMA2_Stream4, DMA_CHANNEL_2, dma_id_12,  &dma_init_struct_spi_i2c };
 const dma_descr_t dma_SPI_4_TX = { DMA2_Stream4, DMA_CHANNEL_5, dma_id_12,  &dma_init_struct_spi_i2c };
 const dma_descr_t dma_SPI_6_TX = { DMA2_Stream5, DMA_CHANNEL_1, dma_id_13,  &dma_init_struct_spi_i2c };

--- a/ports/stm32/sdio.c
+++ b/ports/stm32/sdio.c
@@ -134,9 +134,6 @@ void sdio_init(uint32_t irq_pri) {
 
 void sdio_deinit(void) {
     SDMMC_CLK_DISABLE();
-    #if defined(STM32F7)
-    __HAL_RCC_DMA2_CLK_DISABLE();
-    #endif
 }
 
 void sdio_reenable(void) {


### PR DESCRIPTION
On PYBD-SF6 it's possible to trigger a bug in the existing code by turning on WLAN and connecting to an AP, pinging the IP address from a PC and running the following code on the PYBD:
    
    def spi_test(s):
        while 1:
            s.write('test')
            s.read(4)
    
    spi_test(machine.SPI(1,100000000))
    
This will eventually fail with `OSError: [Errno 110] ETIMEDOUT` because DMA2 was turned off by the CYW43 driver during the SPI1 transfer.
    
This PR fixes the bug by removing the code that explicitly disables DMA2.  Instead DMA2 will be automatically disabled after an inactivity timeout, see commit a96afae90f6e5d693173382561d06e583b0b5fa5
