### PR TITLE
rp2: Add the machine.bitstream() function.

### DIFF
--- a/ports/rp2/CMakeLists.txt
+++ b/ports/rp2/CMakeLists.txt
@@ -84,6 +84,7 @@ set(MICROPY_SOURCE_DRIVERS
 set(MICROPY_SOURCE_PORT
     fatfs_port.c
     machine_adc.c
+    machine_bitstream.c
     machine_i2c.c
     machine_i2s.c
     machine_pin.c

--- a/ports/rp2/boards/manifest.py
+++ b/ports/rp2/boards/manifest.py
@@ -1,3 +1,4 @@
 freeze("$(PORT_DIR)/modules")
 freeze("$(MPY_DIR)/drivers/onewire")
 include("$(MPY_DIR)/extmod/uasyncio/manifest.py")
+include("$(MPY_DIR)/drivers/neopixel/manifest.py")

--- a/ports/rp2/machine_bitstream.c
+++ b/ports/rp2/machine_bitstream.c
@@ -1,0 +1,71 @@
+/*
+ * This file is part of the MicroPython project, http://micropython.org/
+ *
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2021 Jim Mussared
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+// This is a translation of the cycle counter implementation in ports/stm32/machine_bitstream.c.
+
+#include "py/mpconfig.h"
+#include "py/mphal.h"
+
+#if MICROPY_PY_MACHINE_BITSTREAM
+
+void __time_critical_func(machine_bitstream_high_low)(mp_hal_pin_obj_t pin, uint32_t *timing_ns, const uint8_t *buf, size_t len) {
+    uint32_t fcpu_mhz = mp_hal_get_cpu_freq() / 1000000;
+    // Convert ns to clock ticks [high_time_0, period_0, high_time_1, period_1].
+    for (size_t i = 0; i < 4; ++i) {
+        timing_ns[i] = fcpu_mhz * timing_ns[i] / 1000;
+        if (timing_ns[i] > MP_HAL_BITSTREAM_NS_OVERHEAD) {
+            timing_ns[i] -= MP_HAL_BITSTREAM_NS_OVERHEAD;
+        }
+        if (i % 2 == 1) {
+            // Convert low_time to period (i.e. add high_time).
+            timing_ns[i] += timing_ns[i - 1];
+        }
+    }
+    mp_hal_pin_output(pin);
+    // Enable the systick counter, source CPU clock.
+    mp_hal_ticks_cpu_init();
+
+    uint32_t irq_state = mp_hal_quiet_timing_enter();
+
+    for (size_t i = 0; i < len; ++i) {
+        uint8_t b = buf[i];
+        for (size_t j = 0; j < 8; ++j) {
+            uint32_t start_ticks = mp_hal_ticks_cpu_reset();
+            uint32_t *t = &timing_ns[b >> 6 & 2];
+            mp_hal_pin_high(pin);
+            while ((mp_hal_ticks_cpu() - start_ticks) < t[0]) {
+            }
+            b <<= 1;
+            mp_hal_pin_low(pin);
+            while ((mp_hal_ticks_cpu() - start_ticks) < t[1]) {
+            }
+        }
+    }
+
+    mp_hal_quiet_timing_exit(irq_state);
+}
+
+#endif // MICROPY_PY_MACHINE_BITSTREAM

--- a/ports/rp2/machine_bitstream.c
+++ b/ports/rp2/machine_bitstream.c
@@ -49,7 +49,7 @@ void __time_critical_func(machine_bitstream_high_low)(mp_hal_pin_obj_t pin, uint
     }
     mp_hal_pin_output(pin);
     // Enable the systick counter, source CPU clock.
-    mp_hal_ticks_cpu_init();
+    systick_hw->csr = 5;
 
     uint32_t irq_state = mp_hal_quiet_timing_enter();
 
@@ -57,7 +57,7 @@ void __time_critical_func(machine_bitstream_high_low)(mp_hal_pin_obj_t pin, uint
         uint8_t b = buf[i];
         for (size_t j = 0; j < 8; ++j) {
             uint32_t *t = &timing_ns[b >> 6 & 2];
-            uint32_t start_ticks = (systick_hw->cvr = SYSTICK_MAX);
+            uint32_t start_ticks = systick_hw->cvr = SYSTICK_MAX;
             mp_hal_pin_high(pin);
             while ((start_ticks - systick_hw->cvr) < t[0]) {
             }

--- a/ports/rp2/modmachine.c
+++ b/ports/rp2/modmachine.c
@@ -27,6 +27,7 @@
 #include "py/runtime.h"
 #include "py/mphal.h"
 #include "shared/runtime/pyexec.h"
+#include "extmod/machine_bitstream.h"
 #include "extmod/machine_i2c.h"
 #include "extmod/machine_mem.h"
 #include "extmod/machine_pulse.h"
@@ -86,7 +87,7 @@ MP_DEFINE_CONST_FUN_OBJ_0(machine_bootloader_obj, machine_bootloader);
 
 STATIC mp_obj_t machine_freq(size_t n_args, const mp_obj_t *args) {
     if (n_args == 0) {
-        return MP_OBJ_NEW_SMALL_INT(clock_get_hz(clk_sys));
+        return MP_OBJ_NEW_SMALL_INT(mp_hal_get_cpu_freq());
     } else {
         mp_int_t freq = mp_obj_get_int(args[0]);
         if (!set_sys_clock_khz(freq / 1000, false)) {
@@ -154,6 +155,9 @@ STATIC const mp_rom_map_elem_t machine_module_globals_table[] = {
     { MP_ROM_QSTR(MP_QSTR_disable_irq),         MP_ROM_PTR(&machine_disable_irq_obj) },
     { MP_ROM_QSTR(MP_QSTR_enable_irq),          MP_ROM_PTR(&machine_enable_irq_obj) },
 
+    #if MICROPY_PY_MACHINE_BITSTREAM
+    { MP_ROM_QSTR(MP_QSTR_bitstream),           MP_ROM_PTR(&machine_bitstream_obj) },
+    #endif
     { MP_ROM_QSTR(MP_QSTR_time_pulse_us),       MP_ROM_PTR(&machine_time_pulse_us_obj) },
 
     { MP_ROM_QSTR(MP_QSTR_mem8),                MP_ROM_PTR(&machine_mem8_obj) },

--- a/ports/rp2/mpconfigport.h
+++ b/ports/rp2/mpconfigport.h
@@ -86,6 +86,7 @@
 #define MICROPY_PY_URANDOM_SEED_INIT_FUNC       (rosc_random_u32())
 #define MICROPY_PY_MACHINE                      (1)
 #define MICROPY_PY_MACHINE_PIN_MAKE_NEW         mp_pin_make_new
+#define MICROPY_PY_MACHINE_BITSTREAM            (1)
 #define MICROPY_PY_MACHINE_PULSE                (1)
 #define MICROPY_PY_MACHINE_PWM                  (1)
 #define MICROPY_PY_MACHINE_PWM_DUTY_U16_NS      (1)

--- a/ports/rp2/mphalport.h
+++ b/ports/rp2/mphalport.h
@@ -77,8 +77,6 @@ static inline mp_uint_t mp_hal_get_cpu_freq(void) {
     return clock_get_hz(clk_sys);
 }
 
-#define MP_HAL_BITSTREAM_NS_OVERHEAD  (9)
-
 // C-level pin HAL
 
 #include "py/obj.h"

--- a/ports/rp2/mphalport.h
+++ b/ports/rp2/mphalport.h
@@ -60,17 +60,7 @@ static inline mp_uint_t mp_hal_ticks_ms(void) {
 static inline mp_uint_t mp_hal_ticks_cpu(void) {
     // ticks_cpu() is defined as using the highest-resolution timing source
     // in the system. This is usually a CPU clock, but doesn't have to be.
-    return SYSTICK_MAX - systick_hw->cvr;
-}
-
-static inline void mp_hal_ticks_cpu_init(void) {
-    systick_hw->csr = 5;
-}
-
-static inline mp_uint_t mp_hal_ticks_cpu_reset(void) {
-    // Resets the cpu_ticks counter and returns the start value
-    systick_hw->cvr = 0;
-    return 0;
+    return time_us_32();
 }
 
 static inline mp_uint_t mp_hal_get_cpu_freq(void) {

--- a/ports/rp2/mphalport.h
+++ b/ports/rp2/mphalport.h
@@ -28,6 +28,10 @@
 #include "py/mpconfig.h"
 #include "py/ringbuf.h"
 #include "pico/time.h"
+#include "hardware/clocks.h"
+#include "hardware/structs/systick.h"
+
+#define SYSTICK_MAX (0xffffff)
 
 extern int mp_interrupt_char;
 extern ringbuf_t stdin_ringbuf;
@@ -56,8 +60,24 @@ static inline mp_uint_t mp_hal_ticks_ms(void) {
 static inline mp_uint_t mp_hal_ticks_cpu(void) {
     // ticks_cpu() is defined as using the highest-resolution timing source
     // in the system. This is usually a CPU clock, but doesn't have to be.
-    return time_us_32();
+    return SYSTICK_MAX - systick_hw->cvr;
 }
+
+static inline void mp_hal_ticks_cpu_init(void) {
+    systick_hw->csr = 5;
+}
+
+static inline mp_uint_t mp_hal_ticks_cpu_reset(void) {
+    // Resets the cpu_ticks counter and returns the start value
+    systick_hw->cvr = 0;
+    return 0;
+}
+
+static inline mp_uint_t mp_hal_get_cpu_freq(void) {
+    return clock_get_hz(clk_sys);
+}
+
+#define MP_HAL_BITSTREAM_NS_OVERHEAD  (9)
 
 // C-level pin HAL
 
@@ -108,6 +128,14 @@ static inline void mp_hal_pin_od_low(mp_hal_pin_obj_t pin) {
 
 static inline void mp_hal_pin_od_high(mp_hal_pin_obj_t pin) {
     gpio_set_dir(pin, GPIO_IN);
+}
+
+static inline void mp_hal_pin_low(mp_hal_pin_obj_t pin) {
+    gpio_clr_mask(1 << pin);
+}
+
+static inline void mp_hal_pin_high(mp_hal_pin_obj_t pin) {
+    gpio_set_mask(1 << pin);
 }
 
 #endif // MICROPY_INCLUDED_RP2_MPHALPORT_H


### PR DESCRIPTION
The API is identical to the one of the other ports. The timing accuracy is <20ns at 125MHz and <10ns at 250 MHz.
