### PR TITLE
esp32: Enable BLE on ESP32 S3.

### DIFF
--- a/ports/esp32/boards/GENERIC_S3/mpconfigboard.cmake
+++ b/ports/esp32/boards/GENERIC_S3/mpconfigboard.cmake
@@ -3,6 +3,7 @@ set(IDF_TARGET esp32s3)
 set(SDKCONFIG_DEFAULTS
     boards/sdkconfig.base
     boards/sdkconfig.usb
+    boards/sdkconfig.ble
     boards/GENERIC_S3/sdkconfig.board
 )
 

--- a/ports/esp32/boards/GENERIC_S3/mpconfigboard.h
+++ b/ports/esp32/boards/GENERIC_S3/mpconfigboard.h
@@ -1,7 +1,6 @@
 #define MICROPY_HW_BOARD_NAME               "ESP32S3 module"
 #define MICROPY_HW_MCU_NAME                 "ESP32S3"
 
-#define MICROPY_PY_BLUETOOTH                (0)
 #define MICROPY_HW_ENABLE_SDCARD            (0)
 #define MICROPY_PY_MACHINE_DAC              (0)
 


### PR DESCRIPTION
I don't have an S3 board to test this with, but wondering if there was a reason this was disabled to begin with, in which case it would be good to add a comment explaining why. (Possibly copied from the S2 board definition? @UnexpectedMaker do you know more?)