### PR TITLE
rp2/boards: Fix Pimoroni Pico LiPo 16MB flash bytes.

### DIFF
--- a/ports/rp2/boards/PIMORONI_PICOLIPO_16MB/mpconfigboard.h
+++ b/ports/rp2/boards/PIMORONI_PICOLIPO_16MB/mpconfigboard.h
@@ -1,7 +1,7 @@
 // https://shop.pimoroni.com/products/pimoroni-pico-lipo?variant=39335427080275
 
 #define MICROPY_HW_BOARD_NAME          "Pimoroni Pico LiPo 16MB"
-#define MICROPY_HW_FLASH_STORAGE_BYTES (7 * 1024 * 1024)
+#define MICROPY_HW_FLASH_STORAGE_BYTES (15 * 1024 * 1024)
 
 #define MICROPY_HW_USB_VID (0x2E8A)
 #define MICROPY_HW_USB_PID (0x1003)


### PR DESCRIPTION
Was incorrectly added as 7MB for an 8MB SPI flash, but this board has a 16MB chip, not 8MB, so it should be 15MB leaving 1MB for MicroPython.

Thanks @robert-hh

Discovered in: https://forum.micropython.org/viewtopic.php?f=21&t=11438#p62570