### PR TITLE
windows/schedule: Add micropython.schedule to windows port.

### DIFF
--- a/ports/windows/mpconfigport.h
+++ b/ports/windows/mpconfigport.h
@@ -128,6 +128,9 @@
 #define MICROPY_ERROR_PRINTER       (&mp_stderr_print)
 #define MICROPY_WARNINGS            (1)
 #define MICROPY_PY_STR_BYTES_CMP_WARN (1)
+#ifndef MICROPY_ENABLE_SCHEDULER
+#define MICROPY_ENABLE_SCHEDULER    (1)
+#endif
 
 // VFS stat functions should return time values relative to 1970/1/1
 #define MICROPY_EPOCH_IS_1970       (1)
@@ -200,6 +203,15 @@ extern const struct _mp_obj_module_t mp_module_time;
 #define MP_STATE_PORT               MP_STATE_VM
 
 #define MICROPY_MPHALPORT_H         "windows_mphal.h"
+
+#if MICROPY_ENABLE_SCHEDULER
+#define MICROPY_EVENT_POLL_HOOK \
+    do { \
+        extern void mp_handle_pending(bool); \
+        mp_handle_pending(true); \
+        mp_hal_delay_us(500); \
+    } while (0);
+#endif
 
 // We need to provide a declaration/definition of alloca()
 #include <malloc.h>

--- a/ports/windows/windows_mphal.c
+++ b/ports/windows/windows_mphal.c
@@ -262,8 +262,14 @@ uint64_t mp_hal_time_ns(void) {
     return (uint64_t)tv.tv_sec * 1000000000ULL + (uint64_t)tv.tv_usec * 1000ULL;
 }
 
-// TODO: POSIX et al. define usleep() as guaranteedly capable only of 1s sleep:
-// "The useconds argument shall be less than one million."
 void mp_hal_delay_ms(mp_uint_t ms) {
-    usleep((ms) * 1000);
+    #ifdef MICROPY_EVENT_POLL_HOOK
+    mp_uint_t start = mp_hal_ticks_ms();
+    while (mp_hal_ticks_ms() - start < ms) {
+        // MICROPY_EVENT_POLL_HOOK does mp_hal_delay_us(500) (i.e. usleep(500)).
+        MICROPY_EVENT_POLL_HOOK
+    }
+    #else
+    SleepEx(ms, TRUE);
+    #endif
 }


### PR DESCRIPTION
Thie PR adds the basic hooks to allow `micropython.schedule()` to work correctly on the windows port.

It works (runs commands immediately) when run from repl.

Both mingw and mscv build passes `tests/micropython/schedule.py`
