### PR TITLE
all: Move frozen modules to virtual directory.

### DIFF
--- a/ports/esp32/main.c
+++ b/ports/esp32/main.c
@@ -143,6 +143,9 @@ soft_reset:
     mp_obj_list_init(mp_sys_path, 0);
     mp_obj_list_append(mp_sys_path, MP_OBJ_NEW_QSTR(MP_QSTR_));
     mp_obj_list_append(mp_sys_path, MP_OBJ_NEW_QSTR(MP_QSTR__slash_lib));
+    #if MICROPY_MODULE_FROZEN
+    mp_obj_list_append(mp_sys_path, MP_OBJ_NEW_QSTR(MP_QSTR__pipe_frozen));
+    #endif
     mp_obj_list_init(mp_sys_argv, 0);
     readline_init0();
 

--- a/ports/esp8266/main.c
+++ b/ports/esp8266/main.c
@@ -56,6 +56,9 @@ STATIC void mp_reset(void) {
     mp_obj_list_append(mp_sys_path, MP_OBJ_NEW_QSTR(MP_QSTR_)); // current dir (or base dir of the script)
     mp_obj_list_append(mp_sys_path, MP_OBJ_NEW_QSTR(MP_QSTR__slash_lib));
     mp_obj_list_append(mp_sys_path, MP_OBJ_NEW_QSTR(MP_QSTR__slash_));
+    #if MICROPY_MODULE_FROZEN
+    mp_obj_list_append(mp_sys_path, MP_OBJ_NEW_QSTR(MP_QSTR__pipe_frozen));
+    #endif
     mp_obj_list_init(mp_sys_argv, 0);
     #if MICROPY_EMIT_XTENSA || MICROPY_EMIT_INLINE_XTENSA
     extern void esp_native_code_init(void);

--- a/ports/mimxrt/main.c
+++ b/ports/mimxrt/main.c
@@ -77,6 +77,9 @@ int main(void) {
 
         mp_obj_list_init(MP_OBJ_TO_PTR(mp_sys_path), 0);
         mp_obj_list_append(mp_sys_path, MP_OBJ_NEW_QSTR(MP_QSTR_));
+        #if MICROPY_MODULE_FROZEN
+        mp_obj_list_append(mp_sys_path, MP_OBJ_NEW_QSTR(MP_QSTR__pipe_frozen));
+        #endif
         mp_obj_list_init(MP_OBJ_TO_PTR(mp_sys_argv), 0);
         #if MICROPY_PY_NETWORK
         mod_network_init();

--- a/ports/nrf/main.c
+++ b/ports/nrf/main.c
@@ -252,6 +252,11 @@ soft_reset:
     }
     #endif
 
+    #if MICROPY_MODULE_FROZEN
+    // add frozen virtual directory to path
+    mp_obj_list_append(mp_sys_path, MP_OBJ_NEW_QSTR(MP_QSTR__pipe_frozen));
+    #endif
+
     // Main script is finished, so now go into REPL mode.
     // The REPL mode can change, or it can request a soft reset.
     int ret_code = 0;

--- a/ports/rp2/main.c
+++ b/ports/rp2/main.c
@@ -103,6 +103,9 @@ int main(int argc, char **argv) {
         mp_obj_list_init(MP_OBJ_TO_PTR(mp_sys_path), 0);
         mp_obj_list_append(mp_sys_path, MP_OBJ_NEW_QSTR(MP_QSTR_));
         mp_obj_list_append(mp_sys_path, MP_OBJ_NEW_QSTR(MP_QSTR__slash_lib));
+        #if MICROPY_MODULE_FROZEN
+        mp_obj_list_append(mp_sys_path, MP_OBJ_NEW_QSTR(MP_QSTR__pipe_frozen));
+        #endif
         mp_obj_list_init(MP_OBJ_TO_PTR(mp_sys_argv), 0);
 
         // Initialise sub-systems.

--- a/ports/stm32/main.c
+++ b/ports/stm32/main.c
@@ -561,6 +561,11 @@ soft_reset:
         mp_obj_list_append(mp_sys_path, MP_OBJ_NEW_QSTR(MP_QSTR__slash_flash_slash_lib));
     }
 
+    #if MICROPY_MODULE_FROZEN
+    // add frozen virtual directory to path
+    mp_obj_list_append(mp_sys_path, MP_OBJ_NEW_QSTR(MP_QSTR__pipe_frozen));
+    #endif
+
     // reset config variables; they should be set by boot.py
     MP_STATE_PORT(pyb_config_main) = MP_OBJ_NULL;
 

--- a/ports/teensy/main.c
+++ b/ports/teensy/main.c
@@ -271,6 +271,9 @@ soft_reset:
     mp_init();
     mp_obj_list_init(mp_sys_path, 0);
     mp_obj_list_append(mp_sys_path, MP_OBJ_NEW_QSTR(MP_QSTR_)); // current dir (or base dir of the script)
+    #if MICROPY_MODULE_FROZEN
+    mp_obj_list_append(mp_sys_path, MP_OBJ_NEW_QSTR(MP_QSTR__pipe_frozen));
+    #endif
     mp_obj_list_init(mp_sys_argv, 0);
 
     readline_init0();

--- a/ports/unix/main.c
+++ b/ports/unix/main.c
@@ -498,7 +498,7 @@ MP_NOINLINE int main_(int argc, char **argv) {
         #ifdef MICROPY_PY_SYS_PATH_DEFAULT
         path = MICROPY_PY_SYS_PATH_DEFAULT;
         #else
-        path = "~/.micropython/lib:/usr/lib/micropython";
+        path = "~/.micropython/lib:/usr/lib/micropython:|frozen";
         #endif
     }
     size_t path_num = 1; // [0] is for current dir (or base dir of the script)

--- a/ports/windows/mpconfigport.h
+++ b/ports/windows/mpconfigport.h
@@ -88,7 +88,7 @@
 #define MICROPY_PY_SYS_ATEXIT       (1)
 #define MICROPY_PY_SYS_PLATFORM     "win32"
 #ifndef MICROPY_PY_SYS_PATH_DEFAULT
-#define MICROPY_PY_SYS_PATH_DEFAULT "~/.micropython/lib"
+#define MICROPY_PY_SYS_PATH_DEFAULT "~/.micropython/lib;|frozen"
 #endif
 #define MICROPY_PY_SYS_MAXSIZE      (1)
 #define MICROPY_PY_SYS_STDFILES     (1)

--- a/ports/zephyr/main.c
+++ b/ports/zephyr/main.c
@@ -141,6 +141,9 @@ soft_reset:
     mp_init();
     mp_obj_list_init(mp_sys_path, 0);
     mp_obj_list_append(mp_sys_path, MP_OBJ_NEW_QSTR(MP_QSTR_)); // current dir (or base dir of the script)
+    #if MICROPY_MODULE_FROZEN
+    mp_obj_list_append(mp_sys_path, MP_OBJ_NEW_QSTR(MP_QSTR__pipe_frozen));
+    #endif
     mp_obj_list_init(mp_sys_argv, 0);
 
     #ifdef CONFIG_USB

--- a/py/modio.c
+++ b/py/modio.c
@@ -230,8 +230,11 @@ STATIC mp_obj_t resource_stream(mp_obj_t package_in, mp_obj_t path_in) {
     const char *path = mp_obj_str_get_data(path_in, &len);
     vstr_add_strn(&path_buf, path, len);
 
-    len = path_buf.len;
-    const char *data = mp_find_frozen_str(path_buf.buf, &len);
+    const char *data = NULL;
+    if (strncmp(path_buf.buf, "|frozen/", 8) == 0) {
+        len = path_buf.len - 8;
+        data = mp_find_frozen_str(path_buf.buf + 8, &len); // +8 skips |frozen/
+    }
     if (data != NULL) {
         mp_obj_stringio_t *o = m_new_obj(mp_obj_stringio_t);
         o->base.type = &mp_type_bytesio;

--- a/py/qstrdefs.h
+++ b/py/qstrdefs.h
@@ -47,6 +47,9 @@ Q({:#o})
 Q({:#x})
 #endif
 Q({:#b})
+#if MICROPY_MODULE_FROZEN
+Q(|frozen)
+#endif
 Q( )
 Q(\n)
 Q(maximum recursion depth exceeded)

--- a/shared/upytesthelper/upytesthelper.c
+++ b/shared/upytesthelper/upytesthelper.c
@@ -94,6 +94,9 @@ void upytest_execute_test(const char *src) {
     gc_init(heap_start, heap_end);
     mp_init();
     mp_obj_list_init(mp_sys_path, 0);
+    #if MICROPY_MODULE_FROZEN
+    mp_obj_list_append(mp_sys_path, MP_OBJ_NEW_QSTR(MP_QSTR__pipe_frozen));
+    #endif
     mp_obj_list_init(mp_sys_argv, 0);
 
     nlr_buf_t nlr;

--- a/tests/run-tests.py
+++ b/tests/run-tests.py
@@ -852,7 +852,7 @@ the last matching regex is used:
 
     if not args.keep_path:
         # clear search path to make sure tests use only builtin modules and those in extmod
-        os.environ["MICROPYPATH"] = os.pathsep + base_path("../extmod")
+        os.environ["MICROPYPATH"] = os.pathsep + base_path("../extmod") + os.pathsep + "|frozen"
 
     try:
         os.makedirs(args.result_dir, exist_ok=True)

--- a/tests/unix/extra_coverage.py.exp
+++ b/tests/unix/extra_coverage.py.exp
@@ -162,13 +162,13 @@ cpp None
 5
 (3, 'hellocpp')
 frzstr1
-frzstr1.py
+|frozen/frzstr1.py
 frzmpy1
-frzmpy1.py
+|frozen/frzmpy1.py
 frzstr_pkg1.__init__
-frzstr_pkg1/__init__.py 1
+|frozen/frzstr_pkg1/__init__.py 1
 frzmpy_pkg1.__init__
-frzmpy_pkg1/__init__.py 1
+|frozen/frzmpy_pkg1/__init__.py 1
 frzstr_pkg2.mod
 1
 frzmpy_pkg2.mod


### PR DESCRIPTION
Thie PR is for a fix created by @wnienhaus - I hope you don't mind me patching it and submitting it here (I needed to use it myself).
I've ammended it slightly to change the vpath from `.frozen` to `|frozen` to make it much harder to have a conflict with a real file/folder. I've also added it to the default path for the windows build. Other than that it's as per the original commits at https://github.com/wnienhaus/micropython/commit/450d6d339aba2221915c0700e9b04797b506f3bf and 5559cbd which I've maintained the authorship of. 

I've skipped 29180976cf79223714041fd55b9b52b57d212b68 as it looks like it's doing more / enabling frozen where it wasn't previously?

I'm also interested in discussion / feedback about having the default position of the frozen import at the end of the search path. In general I think this is a sensible default, however it's different to the current behaviour where it's typically first.

---

This change "moves" frozen modules into a virtual directory
called "|frozen". This allows controlling the search order for
frozen modules, relative to other directories.

Before this change, frozen modules were found via the current
directory (i.e. the "" entry in sys.path). However, when a file
is executed from the command line the first entry in sys.path
(which is normally the empty string ""), is replaced by the base
path of the executing file (correct behavior as per CPython).
This made loading frozen modules fail.

With this change, frozen modules have their own entry in
sys.path, which also allows the user to control the order of
search when looking for frozen modules.

By default, the virtual "|frozen" directory is the last entry
in sys.path (i.e. it gets searched last).

Fixes issue #2322.