### PR TITLE
unix/main: Insert script base dir into sys.path rather than replace existing entry.

### DIFF
--- a/ports/unix/main.c
+++ b/ports/unix/main.c
@@ -660,7 +660,7 @@ MP_NOINLINE int main_(int argc, char **argv) {
 
             // Set base dir of the script as first entry in sys.path
             char *p = strrchr(basedir, '/');
-            path_items[0] = mp_obj_new_str_via_qstr(basedir, p - basedir);
+            mp_obj_list_insert(mp_sys_path, 0, mp_obj_new_str_via_qstr(basedir, p - basedir));
             free(pathbuf);
 
             set_sys_argv(argv, argc, a);

--- a/py/obj.h
+++ b/py/obj.h
@@ -899,6 +899,7 @@ mp_int_t mp_obj_tuple_hash(mp_obj_t self_in);
 
 // list
 mp_obj_t mp_obj_list_append(mp_obj_t self_in, mp_obj_t arg);
+mp_obj_t mp_obj_list_insert(mp_obj_t self_in, mp_obj_t idx, mp_obj_t obj);
 mp_obj_t mp_obj_list_remove(mp_obj_t self_in, mp_obj_t value);
 void mp_obj_list_get(mp_obj_t self_in, size_t *len, mp_obj_t **items);
 void mp_obj_list_set_len(mp_obj_t self_in, size_t len);

--- a/py/objlist.c
+++ b/py/objlist.c
@@ -376,7 +376,7 @@ STATIC mp_obj_t list_index(size_t n_args, const mp_obj_t *args) {
     return mp_seq_index_obj(self->items, self->len, n_args, args);
 }
 
-STATIC mp_obj_t list_insert(mp_obj_t self_in, mp_obj_t idx, mp_obj_t obj) {
+mp_obj_t mp_obj_list_insert(mp_obj_t self_in, mp_obj_t idx, mp_obj_t obj) {
     mp_check_self(mp_obj_is_type(self_in, &mp_type_list));
     mp_obj_list_t *self = MP_OBJ_TO_PTR(self_in);
     // insert has its own strange index logic
@@ -430,7 +430,7 @@ STATIC MP_DEFINE_CONST_FUN_OBJ_1(list_clear_obj, list_clear);
 STATIC MP_DEFINE_CONST_FUN_OBJ_1(list_copy_obj, list_copy);
 STATIC MP_DEFINE_CONST_FUN_OBJ_2(list_count_obj, list_count);
 STATIC MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(list_index_obj, 2, 4, list_index);
-STATIC MP_DEFINE_CONST_FUN_OBJ_3(list_insert_obj, list_insert);
+STATIC MP_DEFINE_CONST_FUN_OBJ_3(list_insert_obj, mp_obj_list_insert);
 STATIC MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(list_pop_obj, 1, 2, list_pop);
 STATIC MP_DEFINE_CONST_FUN_OBJ_2(list_remove_obj, mp_obj_list_remove);
 STATIC MP_DEFINE_CONST_FUN_OBJ_1(list_reverse_obj, list_reverse);


### PR DESCRIPTION
This directly addresses issue #2322 in that it preserve the existing empty path entry at the start of `sys.path` which currently acts as frozen import path.

This is a more minimal fix than renaming the import path for frozen in #5057

However, I am personally still very much in support of #5057 being included as well as this change, using the empty path for frozen can be quite confusing to new users; giving it something explicit is worthwhile in my opinion. 

This fix also applies to the windows port.


