### PR TITLE
extmod/nimble: Add CCCD bonding support.

### DIFF
--- a/extmod/modbluetooth.c
+++ b/extmod/modbluetooth.c
@@ -1146,8 +1146,8 @@ static mp_obj_t invoke_irq_handler_run(uint16_t event,
     const uint8_t **data, uint16_t *data_len, size_t n_data) {
 
     mp_obj_array_t mv_addr;
-    mp_obj_array_t mv_data[2];
-    assert(n_data <= 2);
+    mp_obj_array_t mv_data[3];
+    assert(n_data <= 3);
 
     mp_obj_tuple_t *data_tuple = mp_local_alloc(sizeof(mp_obj_tuple_t) + sizeof(mp_obj_t) * MICROPY_PY_BLUETOOTH_MAX_EVENT_DATA_TUPLE_LEN);
     data_tuple->base.type = &mp_type_tuple;
@@ -1325,9 +1325,11 @@ void mp_bluetooth_gatts_on_encryption_update(uint16_t conn_handle, bool encrypte
     invoke_irq_handler(MP_BLUETOOTH_IRQ_ENCRYPTION_UPDATE, args, 5, 0, NULL_ADDR, NULL_UUID, NULL_DATA, NULL_DATA_LEN, 0);
 }
 
-bool mp_bluetooth_gap_on_get_secret(uint8_t type, uint8_t index, const uint8_t *key, uint16_t key_len, const uint8_t **value, size_t *value_len) {
+bool mp_bluetooth_gap_on_get_secret(uint8_t type, uint8_t index, const uint8_t *key, uint16_t key_len, const uint8_t *key2, uint16_t key2_len, const uint8_t **value, size_t *value_len) {
     mp_int_t args[] = {type, index};
-    mp_obj_t result = invoke_irq_handler(MP_BLUETOOTH_IRQ_GET_SECRET, args, 2, 0, NULL_ADDR, NULL_UUID, &key, &key_len, 1);
+    const uint8_t *data[] = {key, key2};
+    uint16_t data_len[] = {key_len, key2_len};
+    mp_obj_t result = invoke_irq_handler(MP_BLUETOOTH_IRQ_GET_SECRET, args, 2, 0, NULL_ADDR, NULL_UUID, data, data_len, 2);
     if (result == mp_const_none) {
         return false;
     }
@@ -1338,11 +1340,11 @@ bool mp_bluetooth_gap_on_get_secret(uint8_t type, uint8_t index, const uint8_t *
     return true;
 }
 
-bool mp_bluetooth_gap_on_set_secret(uint8_t type, const uint8_t *key, size_t key_len, const uint8_t *value, size_t value_len) {
+bool mp_bluetooth_gap_on_set_secret(uint8_t type, const uint8_t *key, size_t key_len, const uint8_t *key2, size_t key2_len, const uint8_t *value, size_t value_len) {
     mp_int_t args[] = { type };
-    const uint8_t *data[] = {key, value};
-    uint16_t data_len[] = {key_len, value_len};
-    mp_obj_t result = invoke_irq_handler(MP_BLUETOOTH_IRQ_SET_SECRET, args, 1, 0, NULL_ADDR, NULL_UUID, data, data_len, 2);
+    const uint8_t *data[] = {key, key2, value};
+    uint16_t data_len[] = {key_len, key2_len, value_len};
+    mp_obj_t result = invoke_irq_handler(MP_BLUETOOTH_IRQ_SET_SECRET, args, 1, 0, NULL_ADDR, NULL_UUID, data, data_len, 3);
     return mp_obj_is_true(result);
 }
 

--- a/extmod/modbluetooth.h
+++ b/extmod/modbluetooth.h
@@ -426,8 +426,8 @@ void mp_bluetooth_gatts_on_encryption_update(uint16_t conn_handle, bool encrypte
 // For get, if key is NULL, then the implementation must return the index'th matching key. Otherwise it should return a specific key.
 // For set, if value is NULL, then delete.
 // The "type" is stack-specific, but could also be used to implement versioning.
-bool mp_bluetooth_gap_on_get_secret(uint8_t type, uint8_t index, const uint8_t *key, uint16_t key_len, const uint8_t **value, size_t *value_len);
-bool mp_bluetooth_gap_on_set_secret(uint8_t type, const uint8_t *key, size_t key_len, const uint8_t *value, size_t value_len);
+bool mp_bluetooth_gap_on_get_secret(uint8_t type, uint8_t index, const uint8_t *key, uint16_t key_len, const uint8_t *key2, uint16_t key2_len, const uint8_t **value, size_t *value_len);
+bool mp_bluetooth_gap_on_set_secret(uint8_t type, const uint8_t *key, size_t key_len, const uint8_t *key2, size_t key2_len, const uint8_t *value, size_t value_len);
 
 // Call this when a passkey verification needs to be processed.
 void mp_bluetooth_gap_on_passkey_action(uint16_t conn_handle, uint8_t action, mp_int_t passkey);

--- a/extmod/nimble/modbluetooth_nimble.c
+++ b/extmod/nimble/modbluetooth_nimble.c
@@ -287,7 +287,7 @@ static int load_irk(void) {
     int rc;
     const uint8_t *irk;
     size_t irk_len;
-    if (mp_bluetooth_gap_on_get_secret(SECRET_TYPE_OUR_IRK, 0, key, sizeof(key), &irk, &irk_len) && irk_len == 16) {
+    if (mp_bluetooth_gap_on_get_secret(SECRET_TYPE_OUR_IRK, 0, key, sizeof(key), NULL, 0, &irk, &irk_len) && irk_len == 16) {
         DEBUG_printf("load_irk: Applying IRK from store.\n");
         rc = ble_hs_pvcy_set_our_irk(irk);
         if (rc) {
@@ -301,7 +301,7 @@ static int load_irk(void) {
             return rc;
         }
         DEBUG_printf("load_irk: Saving new IRK.\n");
-        if (!mp_bluetooth_gap_on_set_secret(SECRET_TYPE_OUR_IRK, key, sizeof(key), rand_irk, 16)) {
+        if (!mp_bluetooth_gap_on_set_secret(SECRET_TYPE_OUR_IRK, key, sizeof(key), NULL, 0, rand_irk, 16)) {
             // Code that doesn't implement pairing/bonding won't support set/get secret.
             // So they'll just get the default fixed IRK.
             return 0;
@@ -1923,8 +1923,11 @@ int mp_bluetooth_hci_cmd(uint16_t ogf, uint16_t ocf, const uint8_t *req, size_t 
 
 static int ble_secret_store_read(int obj_type, const union ble_store_key *key, union ble_store_value *value) {
     DEBUG_printf("ble_secret_store_read: %d\n", obj_type);
-    const uint8_t *key_data;
-    size_t key_data_len;
+    const uint8_t *key_data = NULL;
+    const uint8_t *key2_data = NULL;
+    size_t key_data_len = 0;
+    size_t key2_data_len = 0;
+    uint8_t skip = 0;
 
     switch (obj_type) {
         case BLE_STORE_OBJ_TYPE_PEER_SEC: {
@@ -1937,8 +1940,7 @@ static int ble_secret_store_read(int obj_type, const union ble_store_key *key, u
             } else {
                 // <type=peer,*> (with index)
                 // Iterate all known peers.
-                key_data = NULL;
-                key_data_len = 0;
+                skip = key->sec.idx;
             }
             break;
         }
@@ -1952,9 +1954,23 @@ static int ble_secret_store_read(int obj_type, const union ble_store_key *key, u
             break;
         }
         case BLE_STORE_OBJ_TYPE_CCCD: {
-            // TODO: Implement CCCD persistence.
-            DEBUG_printf("ble_secret_store_read: CCCD not supported.\n");
-            return -1;
+            if (ble_addr_cmp(&key->cccd.peer_addr, BLE_ADDR_ANY)) {
+                // <type=peer,addr,*> (single)
+                // Find the entry for this specific peer.
+                key_data = (const uint8_t *)&key->cccd.chr_val_handle;
+                key_data_len = sizeof(key->cccd.chr_val_handle);
+                key2_data = (const uint8_t *)&key->cccd.peer_addr;
+                key2_data_len = sizeof(key->cccd.peer_addr);
+                // There can be multiple CCCD entried per chr_val_handle
+                skip = key->cccd.idx;
+            } else {
+                // <type=peer,*> (with index)
+                // Iterate all known peers.
+                key_data = (const uint8_t *)&key->cccd.chr_val_handle;
+                key_data_len = sizeof(key->cccd.chr_val_handle);
+                skip = key->cccd.idx;
+            }
+            break;
         }
         default:
             return BLE_HS_ENOTSUP;
@@ -1962,17 +1978,34 @@ static int ble_secret_store_read(int obj_type, const union ble_store_key *key, u
 
     const uint8_t *value_data;
     size_t value_data_len;
-    if (!mp_bluetooth_gap_on_get_secret(obj_type, key->sec.idx, key_data, key_data_len, &value_data, &value_data_len)) {
-        DEBUG_printf("ble_secret_store_read: Key not found: type=%d, index=%u, key=0x%p, len=" UINT_FMT "\n", obj_type, key->sec.idx, key_data, key_data_len);
+    if (!mp_bluetooth_gap_on_get_secret(obj_type, skip, key_data, key_data_len, key2_data, key2_data_len, &value_data, &value_data_len)) {
+        DEBUG_printf("ble_secret_store_read: Key not found: type=%d, index=%u, key=0x%p, len=" UINT_FMT "\n", obj_type, skip, key_data, key_data_len);
         return BLE_HS_ENOENT;
     }
 
-    if (value_data_len != sizeof(struct ble_store_value_sec)) {
+    size_t expected_len;
+    uint8_t *dest;
+    switch (obj_type) {
+        case BLE_STORE_OBJ_TYPE_OUR_SEC:
+        case BLE_STORE_OBJ_TYPE_PEER_SEC:
+            expected_len = sizeof(struct ble_store_value_sec);
+            dest = (uint8_t *)&value->sec;
+            break;
+
+        case BLE_STORE_OBJ_TYPE_CCCD:
+            expected_len = sizeof(struct ble_store_value_cccd);
+            dest = (uint8_t *)&value->cccd;
+            break;
+
+        default:
+            return BLE_HS_ENOTSUP;
+
+    }
+    if (value_data_len != expected_len) {
         DEBUG_printf("ble_secret_store_read: Invalid key data: actual=" UINT_FMT " expected=" UINT_FMT "\n", value_data_len, sizeof(struct ble_store_value_sec));
         return BLE_HS_ENOENT;
     }
-
-    memcpy((uint8_t *)&value->sec, value_data, sizeof(struct ble_store_value_sec));
+    memcpy(dest, value_data, expected_len);
 
     DEBUG_printf("ble_secret_store_read: found secret\n");
 
@@ -1992,7 +2025,7 @@ static int ble_secret_store_write(int obj_type, const union ble_store_value *val
 
             assert(ble_addr_cmp(&key_sec.peer_addr, BLE_ADDR_ANY)); // Must have address.
 
-            if (!mp_bluetooth_gap_on_set_secret(obj_type, (const uint8_t *)&key_sec.peer_addr, sizeof(ble_addr_t), (const uint8_t *)value_sec, sizeof(struct ble_store_value_sec))) {
+            if (!mp_bluetooth_gap_on_set_secret(obj_type, (const uint8_t *)&key_sec.peer_addr, sizeof(ble_addr_t), NULL, 0, (const uint8_t *)value_sec, sizeof(struct ble_store_value_sec))) {
                 DEBUG_printf("Failed to write key: type=%d\n", obj_type);
                 return BLE_HS_ESTORE_CAP;
             }
@@ -2002,9 +2035,25 @@ static int ble_secret_store_write(int obj_type, const union ble_store_value *val
             return 0;
         }
         case BLE_STORE_OBJ_TYPE_CCCD: {
-            // TODO: Implement CCCD persistence.
-            DEBUG_printf("ble_secret_store_write: CCCD not supported.\n");
-            // Just pretend we wrote it.
+            struct ble_store_key_cccd key_cccd;
+            const struct ble_store_value_cccd *value_cccd = &val->cccd;
+            ble_store_key_from_value_cccd(&key_cccd, value_cccd);
+
+            assert(ble_addr_cmp(&key_cccd.peer_addr, BLE_ADDR_ANY)); // Must have address, don't support store by chr_val_handle.
+
+            // CCCD are keyed of both chr handle and peer addr.
+            const uint8_t *key_data = (const uint8_t *)&key_cccd.chr_val_handle;
+            size_t key_data_len = sizeof(key_cccd.chr_val_handle);
+            const uint8_t *key2_data = (const uint8_t *)&key_cccd.peer_addr;
+            size_t key2_data_len = sizeof(key_cccd.peer_addr);
+
+            if (!mp_bluetooth_gap_on_set_secret(obj_type, key_data, key_data_len, key2_data, key2_data_len, (const uint8_t *)value_cccd, sizeof(struct ble_store_value_cccd))) {
+                DEBUG_printf("Failed to write cccd key: type=%d\n", obj_type);
+                return BLE_HS_ESTORE_CAP;
+            }
+
+            DEBUG_printf("ble_secret_store_write: wrote cccd\n");
+
             return 0;
         }
         default:
@@ -2020,7 +2069,7 @@ static int ble_secret_store_delete(int obj_type, const union ble_store_key *key)
             // <type=peer,addr,*>
             assert(ble_addr_cmp(&key->sec.peer_addr, BLE_ADDR_ANY)); // Must have address.
 
-            if (!mp_bluetooth_gap_on_set_secret(obj_type, (const uint8_t *)&key->sec.peer_addr, sizeof(ble_addr_t), NULL, 0)) {
+            if (!mp_bluetooth_gap_on_set_secret(obj_type, (const uint8_t *)&key->sec.peer_addr, sizeof(ble_addr_t), NULL, 0, NULL, 0)) {
                 DEBUG_printf("Failed to delete key: type=%d\n", obj_type);
                 return BLE_HS_ENOENT;
             }
@@ -2030,10 +2079,20 @@ static int ble_secret_store_delete(int obj_type, const union ble_store_key *key)
             return 0;
         }
         case BLE_STORE_OBJ_TYPE_CCCD: {
-            // TODO: Implement CCCD persistence.
-            DEBUG_printf("ble_secret_store_delete: CCCD not supported.\n");
-            // Just pretend it wasn't there.
-            return BLE_HS_ENOENT;
+            assert(ble_addr_cmp(&key->cccd.peer_addr, BLE_ADDR_ANY)); // Must have address.
+
+            // There can be one CCCD per char per host.
+            size_t key_data_len = sizeof(&key->cccd.peer_addr) + sizeof(&key->cccd.chr_val_handle);
+
+            if (!mp_bluetooth_gap_on_set_secret(obj_type, (const uint8_t *)&key->cccd.peer_addr, key_data_len, NULL, 0, NULL, 0)) {
+                DEBUG_printf("Failed to delete key: type=%d\n", obj_type);
+                return BLE_HS_ENOENT;
+            }
+
+            DEBUG_printf("ble_secret_store_delete: deleted secret\n");
+
+            return 0;
+
         }
         default:
             return BLE_HS_ENOTSUP;


### PR DESCRIPTION
This adds basic support for CCCD bonding in nimble BLE. 

It requires updates to aioble however as there can be multiple CCCD entries stored for any particular address, so the existing dict based storage in aioble doesn't work; both because the order isn't controlled and multiple entries with the same key replace each other.