### PR TITLE
tests/cpydiff: Clarify f-string diffs.

### DIFF
--- a/tests/cpydiff/core_fstring_concat.py
+++ b/tests/cpydiff/core_fstring_concat.py
@@ -1,12 +1,13 @@
 """
 categories: Core
-description: f-strings don't support concatenation with adjacent literals if the adjacent literals contain braces
+description: f-strings don't support concatenation with adjacent literals if the adjacent literals contain braces or are f-strings
 cause: MicroPython is optimised for code space.
-workaround: Use the + operator between literal strings when either is an f-string
+workaround: Use the + operator between literal strings when either or both are f-strings
 """
 
-x = 1
-print("aa" f"{x}")
-print(f"{x}" "ab")
-print("a{}a" f"{x}")
-print(f"{x}" "a{}b")
+x, y = 1, 2
+print("aa" f"{x}")  # works
+print(f"{x}" "ab")  # works
+print("a{}a" f"{x}")  # fails
+print(f"{x}" "a{}b")  # fails
+print(f"{x}" f"{y}")  # fails

--- a/tests/cpydiff/core_fstring_parser.py
+++ b/tests/cpydiff/core_fstring_parser.py
@@ -1,9 +1,10 @@
 """
 categories: Core
-description: f-strings cannot support expressions that require parsing to resolve nested braces
+description: f-strings cannot support expressions that require parsing to resolve nested braces or colons
 cause: MicroPython is optimised for code space.
 workaround: Only use simple expressions inside f-strings
 """
 
 f'{"hello {} world"}'
 f"{repr({})}"
+f"{x[1:3]}"


### PR DESCRIPTION
- Concatenation of any literals (including f-strings) should be avoided.

- The colon symbol anywhere in the expression will trigger end of expression.