### PR TITLE
stm32: automatically build all stm32 boards and provide .dfu and .hex files

### DIFF
--- a/ports/stm32/boards/NUCLEO_WB55/mpconfigboard.mk
+++ b/ports/stm32/boards/NUCLEO_WB55/mpconfigboard.mk
@@ -1,7 +1,3 @@
-# By default this board is configured to use mboot with packing (signing and encryption)
-# enabled.  Mboot must be deployed first.
-USE_MBOOT ?= 1
-
 MCU_SERIES = wb
 CMSIS_MCU = STM32WB55xx
 AF_FILE = boards/stm32wb55_af.csv
@@ -21,6 +17,3 @@ endif
 MICROPY_PY_BLUETOOTH = 1
 MICROPY_BLUETOOTH_NIMBLE = 1
 MICROPY_VFS_LFS2 = 1
-
-# Mboot settings
-MBOOT_ENABLE_PACKING = 1

--- a/ports/stm32/boards/STM32F769DISC/mpconfigboard.mk
+++ b/ports/stm32/boards/STM32F769DISC/mpconfigboard.mk
@@ -1,6 +1,3 @@
-# By default this board is configured to use mboot which must be deployed first
-USE_MBOOT ?= 1
-
 # By default the filesystem is in external QSPI flash.  But by setting the
 # following option this board puts some code into external flash set in XIP mode.
 # USE_MBOOT must be enabled; see f769_qspi.ld for code that goes in QSPI flash

--- a/tools/autobuild/autobuild.sh
+++ b/tools/autobuild/autobuild.sh
@@ -65,9 +65,7 @@ FW_GIT="$(git describe --dirty || echo unknown)"
 FW_TAG="-$FW_DATE-unstable-$FW_GIT"
 
 # build new firmware
-cd ports/stm32
-${AUTODIR}/build-stm32-latest.sh ${FW_TAG} ${LOCAL_FIRMWARE}
-cd ../cc3200
+cd ports/cc3200
 ${AUTODIR}/build-cc3200-latest.sh ${FW_TAG} ${LOCAL_FIRMWARE}
 cd ../esp8266
 ${AUTODIR}/build-esp8266-latest.sh ${FW_TAG} ${LOCAL_FIRMWARE}
@@ -81,6 +79,9 @@ cd ../rp2
 build_rp2_boards ${FW_TAG} ${LOCAL_FIRMWARE}
 cd ../samd
 build_samd_boards ${FW_TAG} ${LOCAL_FIRMWARE}
+cd ../stm32
+build_stm32_boards ${FW_TAG} ${LOCAL_FIRMWARE}
+${AUTODIR}/build-stm32-extra.sh ${FW_TAG} ${LOCAL_FIRMWARE}
 
 popd
 

--- a/tools/autobuild/build-boards.sh
+++ b/tools/autobuild/build-boards.sh
@@ -26,16 +26,17 @@ function build_boards {
         return 1
     fi
 
-    for board_json in $(find boards/ -name board.json); do
+    for board_json in $(find boards/ -name board.json | sort); do
         board=$(echo $board_json | awk -F '/' '{ print $2 }')
         descr=$(cat $board_json | python3 -c "import json,sys; print(json.load(sys.stdin).get('id', '$board'))")
         build_dir=/tmp/micropython-build-$board
 
         echo "building $descr $board"
-        $MICROPY_AUTOBUILD_MAKE BOARD=$board BUILD=$build_dir || return 1
-        for ext in $@; do
-            mv $build_dir/firmware.$ext $dest_dir/$descr$fw_tag.$ext
-        done
+        $MICROPY_AUTOBUILD_MAKE BOARD=$board BUILD=$build_dir && (
+            for ext in $@; do
+                mv $build_dir/firmware.$ext $dest_dir/$descr$fw_tag.$ext
+            done
+        )
         rm -rf $build_dir
     done
 }
@@ -50,4 +51,8 @@ function build_rp2_boards {
 
 function build_samd_boards {
     build_boards $1 $2 samd_soc.c uf2
+}
+
+function build_stm32_boards {
+    build_boards $1 $2 modpyb.c dfu hex
 }

--- a/tools/autobuild/build-stm32-extra.sh
+++ b/tools/autobuild/build-stm32-extra.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# Build additional variants of pyboard firmware (base variants are built by build-boards.sh).
 
 # function for building firmware
 function do_build() {
@@ -10,6 +11,7 @@ function do_build() {
     build_dir=/tmp/stm-build-$board
     $MICROPY_AUTOBUILD_MAKE $@ BOARD=$board BUILD=$build_dir || exit 1
     mv $build_dir/firmware.dfu $dest_dir/$descr$fw_tag.dfu
+    mv $build_dir/firmware.hex $dest_dir/$descr$fw_tag.hex
     rm -rf $build_dir
 }
 
@@ -31,26 +33,15 @@ fi
 # build the versions
 do_build pybv3 PYBV3
 do_build pybv3-network PYBV3 MICROPY_PY_WIZNET5K=5200 MICROPY_PY_CC3K=1
-do_build pybv10 PYBV10
 do_build pybv10-dp PYBV10 MICROPY_FLOAT_IMPL=double
 do_build pybv10-thread PYBV10 CFLAGS_EXTRA='-DMICROPY_PY_THREAD=1'
 do_build pybv10-dp-thread PYBV10 MICROPY_FLOAT_IMPL=double CFLAGS_EXTRA='-DMICROPY_PY_THREAD=1'
 do_build pybv10-network PYBV10 MICROPY_PY_WIZNET5K=5200 MICROPY_PY_CC3K=1
-do_build pybv11 PYBV11
 do_build pybv11-dp PYBV11 MICROPY_FLOAT_IMPL=double
 do_build pybv11-thread PYBV11 CFLAGS_EXTRA='-DMICROPY_PY_THREAD=1'
 do_build pybv11-dp-thread PYBV11 MICROPY_FLOAT_IMPL=double CFLAGS_EXTRA='-DMICROPY_PY_THREAD=1'
 do_build pybv11-network PYBV11 MICROPY_PY_WIZNET5K=5200 MICROPY_PY_CC3K=1
-do_build pyblitev10 PYBLITEV10
 do_build pyblitev10-dp PYBLITEV10 MICROPY_FLOAT_IMPL=double
 do_build pyblitev10-thread PYBLITEV10 CFLAGS_EXTRA='-DMICROPY_PY_THREAD=1'
 do_build pyblitev10-dp-thread PYBLITEV10 MICROPY_FLOAT_IMPL=double CFLAGS_EXTRA='-DMICROPY_PY_THREAD=1'
 do_build pyblitev10-network PYBLITEV10 MICROPY_PY_WIZNET5K=5200 MICROPY_PY_CC3K=1
-do_build PYBD-SF2 PYBD_SF2
-do_build PYBD-SF3 PYBD_SF3
-do_build PYBD-SF6 PYBD_SF6
-
-for board in boards/{NUCLEO_*,STM32F*DISC,B_L*,USBDONGLE_WB55,ESPRUINO_PICO} ; do
-    bd=$(basename $board)
-    do_build $bd $bd USE_MBOOT=0 MBOOT_ENABLE_PACKING=0
-done

--- a/tools/ci.sh
+++ b/tools/ci.sh
@@ -282,12 +282,16 @@ function ci_stm32_nucleo_build {
     make ${MAKEOPTS} -C mpy-cross
     make ${MAKEOPTS} -C ports/stm32 submodules
     git submodule update --init lib/mynewt-nimble
+
+    # Test building various MCU families, some with additional options.
     make ${MAKEOPTS} -C ports/stm32 BOARD=NUCLEO_F091RC
     make ${MAKEOPTS} -C ports/stm32 BOARD=NUCLEO_H743ZI CFLAGS_EXTRA='-DMICROPY_PY_THREAD=1'
     make ${MAKEOPTS} -C ports/stm32 BOARD=NUCLEO_L073RZ
     make ${MAKEOPTS} -C ports/stm32 BOARD=NUCLEO_L476RG DEBUG=1
-    make ${MAKEOPTS} -C ports/stm32 BOARD=NUCLEO_WB55
-    make ${MAKEOPTS} -C ports/stm32/mboot BOARD=NUCLEO_WB55
+
+    # Test building a board with mboot packing enabled (encryption, signing, compression).
+    make ${MAKEOPTS} -C ports/stm32 BOARD=NUCLEO_WB55 USE_MBOOT=1 MBOOT_ENABLE_PACKING=1
+    make ${MAKEOPTS} -C ports/stm32/mboot BOARD=NUCLEO_WB55 USE_MBOOT=1 MBOOT_ENABLE_PACKING=1
     # Test mboot_pack_dfu.py created a valid file, and that its unpack-dfu command works.
     BOARD_WB55=ports/stm32/boards/NUCLEO_WB55
     BUILD_WB55=ports/stm32/build-NUCLEO_WB55


### PR DESCRIPTION
Changes in this PR:
- NUCLEO_WB55 and STM32F769DISC no longer enable mboot by default
- all stm32 boards with a board.json file are automatically built
- all stm32 boards now provide .dfu and .hex firmware (see issue #8018) 