### PR TITLE
py/runtime: Adjust message for not defined name

### DIFF
--- a/py/runtime.c
+++ b/py/runtime.c
@@ -189,7 +189,7 @@ mp_obj_t MICROPY_WRAP_MP_LOAD_GLOBAL(mp_load_global)(qstr qst) {
             #if MICROPY_ERROR_REPORTING <= MICROPY_ERROR_REPORTING_TERSE
             mp_raise_msg(&mp_type_NameError, MP_ERROR_TEXT("name not defined"));
             #else
-            mp_raise_msg_varg(&mp_type_NameError, MP_ERROR_TEXT("name '%q' isn't defined"), qst);
+            mp_raise_msg_varg(&mp_type_NameError, MP_ERROR_TEXT("name '%q' is not defined"), qst);
             #endif
         }
     }

--- a/tests/micropython/heapalloc_exc_compressed.py
+++ b/tests/micropython/heapalloc_exc_compressed.py
@@ -4,7 +4,7 @@ import micropython
 # mp_obj_new_exception_msg_varg (exception requires decompression at raise-time to format)
 # mp_obj_new_exception_msg (decompression can be deferred)
 
-# NameError uses mp_obj_new_exception_msg_varg for NameError("name '%q' isn't defined")
+# NameError uses mp_obj_new_exception_msg_varg for NameError("name '%q' is not defined")
 # set.pop uses mp_obj_new_exception_msg for KeyError("pop from an empty set")
 
 # Tests that deferred decompression works both via print(e) and accessing the message directly via e.args.

--- a/tests/micropython/heapalloc_exc_compressed.py.exp
+++ b/tests/micropython/heapalloc_exc_compressed.py.exp
@@ -1,6 +1,6 @@
-NameError name 'name' isn't defined
+NameError name 'name' is not defined
 KeyError pop from an empty set
-name 'name' isn't defined
+name 'name' is not defined
 pop from an empty set
 NameError
 KeyError

--- a/tests/micropython/heapalloc_exc_compressed_emg_exc.py.exp
+++ b/tests/micropython/heapalloc_exc_compressed_emg_exc.py.exp
@@ -1,4 +1,4 @@
-NameError name 'name' isn't defined
+NameError name 'name' is not defined
 KeyError pop from an empty set
-name 'name' isn't defined
+name 'name' is not defined
 pop from an empty set

--- a/tests/micropython/native_with.py.exp
+++ b/tests/micropython/native_with.py.exp
@@ -5,5 +5,5 @@ __exit__ None None None
 __init__
 __enter__
 1
-__exit__ <class 'NameError'> name 'fail' isn't defined None
+__exit__ <class 'NameError'> name 'fail' is not defined None
 NameError

--- a/tests/micropython/opt_level_lineno.py.exp
+++ b/tests/micropython/opt_level_lineno.py.exp
@@ -1,3 +1,3 @@
 Traceback (most recent call last):
   File "<string>", line 1, in <module>
-NameError: name 'xyz' isn't defined
+NameError: name 'xyz' is not defined

--- a/tests/micropython/viper_with.py.exp
+++ b/tests/micropython/viper_with.py.exp
@@ -5,5 +5,5 @@ __exit__ None None None
 __init__
 __enter__
 1
-__exit__ <class 'NameError'> name 'fail' isn't defined None
+__exit__ <class 'NameError'> name 'fail' is not defined None
 NameError


### PR DESCRIPTION
For mainstream Python, the message is `name '...' is not defined`:

```
$ python3
Python 3.8.10 (default, Sep 28 2021, 16:10:42)
[GCC 9.3.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> forsuredoesnotexist
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
NameError: name 'forsuredoesnotexist' is not defined
>>>
```

I found this discrepancy when working on a project that uses Python
under the hood, and tried to replace regular Python with MicroPython.
The discrepancy was shown as a difference in behavior between regular
Python and MicroPython, and then I realized that's it's only about
wording in English. I propose unifying this message, for the sake of
bringing both pythons closer to each other.

In theory there's a risk that someone depends on this string, which
would make it a breaking change. However, I assess the risk as
extremely low, and still the change brings consistency with the regular
Python.