### PR TITLE
stm32/usb: Use a table of allowed values to simplify usb_mode get/set.

### DIFF
--- a/ports/stm32/qstrdefsport.h
+++ b/ports/stm32/qstrdefsport.h
@@ -38,7 +38,19 @@ Q(/)
 
 #if MICROPY_HW_ENABLE_USB
 // for usb modes
-Q(MSC+HID)
+Q(VCP)
+Q(MSC)
 Q(VCP+MSC)
 Q(VCP+HID)
+Q(VCP+MSC+HID)
+#if MICROPY_HW_USB_CDC_NUM >= 2
+Q(2xVCP)
+Q(2xVCP+MSC)
+Q(2xVCP+MSC+HID)
+#endif
+#if MICROPY_HW_USB_CDC_NUM >= 3
+Q(3xVCP)
+Q(3xVCP+MSC)
+Q(3xVCP+MSC+HID)
+#endif
 #endif


### PR DESCRIPTION
This reduces code size and code duplication, and fixes `pyb.usb_mode()` so
that it now returns the correct string when in multi-VCP mode (before, it
would return None when in one of these modes).
