### PR TITLE
windows/uasyncio: Add support for uasyncio to windows dev variant.

### DIFF
--- a/ports/windows/Makefile
+++ b/ports/windows/Makefile
@@ -61,7 +61,18 @@ SRC_C = \
 	$(SRC_MOD) \
 	$(wildcard $(VARIANT_DIR)/*.c)
 
+SHARED_SRC_C += $(addprefix shared/,\
+	$(SHARED_SRC_C_EXTRA) \
+	)
+
+SRC_CXX += \
+	$(SRC_MOD_CXX)
+
 OBJ = $(PY_O) $(addprefix $(BUILD)/, $(SRC_C:.c=.o))
+OBJ += $(addprefix $(BUILD)/, $(SRC_CXX:.cpp=.o))
+OBJ += $(addprefix $(BUILD)/, $(SHARED_SRC_C:.c=.o))
+OBJ += $(addprefix $(BUILD)/, $(EXTMOD_SRC_C:.c=.o))
+OBJ += $(addprefix $(BUILD)/, $(LIB_SRC_C:.c=.o))
 
 ifeq ($(MICROPY_USE_READLINE),1)
 CFLAGS_MOD += -DMICROPY_USE_READLINE=1
@@ -71,7 +82,7 @@ endif
 LIB += -lws2_32
 
 # List of sources for qstr extraction
-SRC_QSTR += $(SRC_C)
+SRC_QSTR += $(SRC_C) $(SRC_CXX) $(SHARED_SRC_C) $(EXTMOD_SRC_C)
 # Append any auto-generated sources that are needed by sources listed in
 # SRC_QSTR
 SRC_QSTR_AUTO_DEPS +=

--- a/ports/windows/msvc/sources.props
+++ b/ports/windows/msvc/sources.props
@@ -7,6 +7,7 @@
     <PyExtModSource Include="$(PyBaseDir)extmod\machine_pinbase.c" />
     <PyExtModSource Include="$(PyBaseDir)extmod\machine_pulse.c" />
     <PyExtModSource Include="$(PyBaseDir)extmod\machine_signal.c" />
+    <PyExtModSource Include="$(PyBaseDir)extmod\moduasyncio.c" />
     <PyExtModSource Include="$(PyBaseDir)extmod\modubinascii.c" />
     <PyExtModSource Include="$(PyBaseDir)extmod\moductypes.c" />
     <PyExtModSource Include="$(PyBaseDir)extmod\moduhashlib.c" />

--- a/ports/windows/msvc/sources.props
+++ b/ports/windows/msvc/sources.props
@@ -14,6 +14,7 @@
     <PyExtModSource Include="$(PyBaseDir)extmod\modujson.c" />
     <PyExtModSource Include="$(PyBaseDir)extmod\modurandom.c" />
     <PyExtModSource Include="$(PyBaseDir)extmod\modure.c" />
+    <PyExtModSource Include="$(PyBaseDir)extmod\moduselect.c" />
     <PyExtModSource Include="$(PyBaseDir)extmod\modutimeq.c" />
     <PyExtModSource Include="$(PyBaseDir)extmod\moduzlib.c" />
     <PyExtModSource Include="$(PyBaseDir)extmod\utime_mphal.c" />

--- a/ports/windows/variants/dev/manifest.py
+++ b/ports/windows/variants/dev/manifest.py
@@ -1,1 +1,2 @@
 include("$(PORT_DIR)/variants/manifest.py")
+include("$(MPY_DIR)/extmod/uasyncio/manifest.py")

--- a/ports/windows/variants/dev/mpconfigvariant.h
+++ b/ports/windows/variants/dev/mpconfigvariant.h
@@ -36,3 +36,4 @@
 #define MICROPY_COMP_CONST                      (0)
 #define MICROPY_PY_URANDOM_EXTRA_FUNCS          (1)
 #define MICROPY_PY_BUILTINS_SLICE_INDICES       (1)
+#define MICROPY_PY_USELECT                      (1)

--- a/ports/windows/variants/dev/mpconfigvariant.h
+++ b/ports/windows/variants/dev/mpconfigvariant.h
@@ -37,3 +37,7 @@
 #define MICROPY_PY_URANDOM_EXTRA_FUNCS          (1)
 #define MICROPY_PY_BUILTINS_SLICE_INDICES       (1)
 #define MICROPY_PY_USELECT                      (1)
+
+#ifndef MICROPY_PY_UASYNCIO
+#define MICROPY_PY_UASYNCIO                     (1)
+#endif


### PR DESCRIPTION
This PR enables the micropython `uselect` module on the windows port to allow freezing uasyncio into the `dev` variant.

This is built on top of https://github.com/micropython/micropython/pull/7780 so includes the commits from there too because github doesn't give any way to declare / separate dependent PR's.

This does also require https://github.com/micropython/micropython/pull/7999 to be merged first