### PR TITLE
stm32/boards/make-pins.py: Use cpu pins to define static alt-fun macros.

### DIFF
--- a/ports/stm32/boards/make-pins.py
+++ b/ports/stm32/boards/make-pins.py
@@ -504,7 +504,7 @@ class Pins(object):
         with open(af_defs_filename, "wt") as af_defs_file:
 
             STATIC_AF_TOKENS = {}
-            for named_pin in self.board_pins:
+            for named_pin in self.cpu_pins:
                 for af in named_pin.pin().alt_fn:
                     func = "%s%d" % (af.func, af.fn_num) if af.fn_num else af.func
                     pin_type = (af.pin_type or "NULL").split("(")[0]


### PR DESCRIPTION
Instead of board pins, so that pins which have only the CPU specified in pins.csv can still be used with mp_hal_pin_config_alt_static().

I checked that the PYBV10 and PYBD_SF6 builds are binary equivalent with this change.