### PR TITLE
py/mpz: Fix bugs with bitwise of -0 by ensuring all 0's are positive.

### DIFF
--- a/py/mpz.h
+++ b/py/mpz.h
@@ -91,6 +91,7 @@ typedef int8_t mpz_dbl_dig_signed_t;
 #define MPZ_NUM_DIG_FOR_LL ((sizeof(long long) * 8 + MPZ_DIG_SIZE - 1) / MPZ_DIG_SIZE)
 
 typedef struct _mpz_t {
+    // Zero has neg=0, len=0.  Negative zero is not allowed.
     size_t neg : 1;
     size_t fixed_dig : 1;
     size_t alloc : (8 * sizeof(size_t) - 2);
@@ -119,7 +120,7 @@ static inline bool mpz_is_zero(const mpz_t *z) {
     return z->len == 0;
 }
 static inline bool mpz_is_neg(const mpz_t *z) {
-    return z->len != 0 && z->neg != 0;
+    return z->neg != 0;
 }
 int mpz_cmp(const mpz_t *lhs, const mpz_t *rhs);
 

--- a/tests/basics/int_big_cmp.py
+++ b/tests/basics/int_big_cmp.py
@@ -1,10 +1,13 @@
 # test bignum comparisons
 
 i = 1 << 65
+cases = (0, 1, -1, i, -i, i + 1, -(i + 1))
 
-print(i == 0)
-print(i != 0)
-print(i < 0)
-print(i > 0)
-print(i <= 0)
-print(i >= 0)
+for lhs in cases:
+    for rhs in cases:
+        print("{} == {} = {}".format(lhs, rhs, lhs == rhs))
+        print("{} != {} = {}".format(lhs, rhs, lhs != rhs))
+        print("{} < {} = {}".format(lhs, rhs, lhs < rhs))
+        print("{} > {} = {}".format(lhs, rhs, lhs > rhs))
+        print("{} <= {} = {}".format(lhs, rhs, lhs <= rhs))
+        print("{} >= {} = {}".format(lhs, rhs, lhs >= rhs))

--- a/tests/basics/int_big_zeroone.py
+++ b/tests/basics/int_big_zeroone.py
@@ -1,4 +1,4 @@
-# test [0,-0,1,-1] edge cases of bignum
+# test [0,1,-1] edge cases of bignum
 
 long_zero = (2**64) >> 65
 long_neg_zero = -long_zero
@@ -13,7 +13,7 @@ print([~c for c in cases])
 print([c >> 1 for c in cases])
 print([c << 1 for c in cases])
 
-# comparison of 0/-0/+0
+# comparison of 0
 print(long_zero == 0)
 print(long_neg_zero == 0)
 print(long_one - 1 == 0)
@@ -26,3 +26,40 @@ print(long_neg_zero < 1)
 print(long_neg_zero < -1)
 print(long_neg_zero > 1)
 print(long_neg_zero > -1)
+
+# generate zeros that involve negative numbers
+large = 1 << 70
+large_plus_one = large + 1
+zeros = (
+    large - large,
+    -large + large,
+    large + -large,
+    -(large - large),
+    large - large_plus_one + 1,
+    -large & (large - large),
+    -large ^ -large,
+    -large * (large - large),
+    (large - large) // -large,
+    -large // -large_plus_one,
+    -(large + large) % large,
+    (large + large) % -large,
+    -(large + large) % -large,
+)
+print(zeros)
+
+# compute arithmetic operations that may have problems with -0
+# (this checks that -0 is never generated in the zeros tuple)
+cases = (0, 1, -1) + zeros
+for lhs in cases:
+    print("-{} = {}".format(lhs, -lhs))
+    print("~{} = {}".format(lhs, ~lhs))
+    print("{} >> 1 = {}".format(lhs, lhs >> 1))
+    print("{} << 1 = {}".format(lhs, lhs << 1))
+    for rhs in cases:
+        print("{} == {} = {}".format(lhs, rhs, lhs == rhs))
+        print("{} + {} = {}".format(lhs, rhs, lhs + rhs))
+        print("{} - {} = {}".format(lhs, rhs, lhs - rhs))
+        print("{} * {} = {}".format(lhs, rhs, lhs * rhs))
+        print("{} | {} = {}".format(lhs, rhs, lhs | rhs))
+        print("{} & {} = {}".format(lhs, rhs, lhs & rhs))
+        print("{} ^ {} = {}".format(lhs, rhs, lhs ^ rhs))


### PR DESCRIPTION
This patch makes sure that whenever a -0 big-int is generated (eg by -1 * 0) it is converted to a positive 0.  That in turn ensures that all bitwise operations work correctly (because they don't work with a -0 as an argument).

Fixes issue #8042.

To do:
- [x] check if there are any other cases of `mpz->neg = <something>` that need fixing
- [x] make sure there is a test for each line that is fixed