### PR TITLE
stm32/boards/NUCELO_WB55: Fix LED ordering.

### DIFF
--- a/ports/stm32/boards/NUCLEO_WB55/mpconfigboard.h
+++ b/ports/stm32/boards/NUCLEO_WB55/mpconfigboard.h
@@ -51,9 +51,9 @@
 #define MICROPY_HW_USRSW_PRESSED    (0)
 
 // LEDs
-#define MICROPY_HW_LED1             (pin_B1) // red
+#define MICROPY_HW_LED1             (pin_B5) // blue
 #define MICROPY_HW_LED2             (pin_B0) // green
-#define MICROPY_HW_LED3             (pin_B5) // blue
+#define MICROPY_HW_LED3             (pin_B1) // red
 #define MICROPY_HW_LED_ON(pin)      (mp_hal_pin_high(pin))
 #define MICROPY_HW_LED_OFF(pin)     (mp_hal_pin_low(pin))
 


### PR DESCRIPTION
These were commented correctly by their colour, but in the wrong order with respect to the PCB silkscreen.

Fixes #8054