### PR TITLE
unix/Makefile: Use -Og instead of -O0 for debug builds.

### DIFF
--- a/extmod/modure.c
+++ b/extmod/modure.c
@@ -454,11 +454,16 @@ const mp_obj_module_t mp_module_ure = {
 // only if module is enabled by config setting.
 
 #define re1_5_fatal(x) assert(!x)
+
 #include "lib/re1.5/compilecode.c"
-#if MICROPY_PY_URE_DEBUG
-#include "lib/re1.5/dumpcode.c"
-#endif
 #include "lib/re1.5/recursiveloop.c"
 #include "lib/re1.5/charclass.c"
+
+#if MICROPY_PY_URE_DEBUG
+// Make sure the output print statements go to the same output as other Python output.
+#define printf(...) mp_printf(&mp_plat_print, __VA_ARGS__)
+#include "lib/re1.5/dumpcode.c"
+#undef printf
+#endif
 
 #endif // MICROPY_PY_URE

--- a/ports/unix/Makefile
+++ b/ports/unix/Makefile
@@ -44,7 +44,7 @@ CFLAGS += $(INC) $(CWARN) -std=gnu99 -DUNIX $(CFLAGS_MOD) $(COPT) -I$(VARIANT_DI
 
 # Debugging/Optimization
 ifdef DEBUG
-COPT ?= -O0
+COPT ?= -Og
 else
 COPT ?= -Os
 COPT += -DNDEBUG

--- a/ports/unix/coverage.c
+++ b/ports/unix/coverage.c
@@ -153,7 +153,7 @@ STATIC void pairheap_test(size_t nops, int *ops) {
         mp_pairheap_init_node(pairheap_lt, &node[i]);
     }
     mp_pairheap_t *heap = mp_pairheap_new(pairheap_lt);
-    printf("create:");
+    mp_printf(&mp_plat_print, "create:");
     for (size_t i = 0; i < nops; ++i) {
         if (ops[i] >= 0) {
             heap = mp_pairheap_push(pairheap_lt, heap, &node[ops[i]]);
@@ -167,13 +167,13 @@ STATIC void pairheap_test(size_t nops, int *ops) {
             ;
         }
     }
-    printf("\npop all:");
+    mp_printf(&mp_plat_print, "\npop all:");
     while (!mp_pairheap_is_empty(pairheap_lt, heap)) {
         mp_printf(&mp_plat_print, " %d", mp_pairheap_peek(pairheap_lt, heap) - &node[0]);
         ;
         heap = mp_pairheap_pop(pairheap_lt, heap);
     }
-    printf("\n");
+    mp_printf(&mp_plat_print, "\n");
 }
 
 // function to run extra tests for things that can't be checked by scripts


### PR DESCRIPTION
For the coverage build this reduces the binary size to about 1/4 of its size, and seems to help gcov/lcov coverage analysis so that it doesn't miss lines (which causes incorrect reports of decreased coverage).