### PR TITLE
rp2/machine_uart.c: Handle UART RX timeout IRQ.

### DIFF
--- a/ports/rp2/machine_uart.c
+++ b/ports/rp2/machine_uart.c
@@ -126,7 +126,7 @@ STATIC void uart_fill_tx_fifo(machine_uart_obj_t *self) {
 }
 
 STATIC inline void uart_service_interrupt(machine_uart_obj_t *self) {
-    if (uart_get_hw(self->uart)->mis & UART_UARTMIS_RXMIS_BITS) { // rx interrupt?
+    if (uart_get_hw(self->uart)->mis & (UART_UARTMIS_RXMIS_BITS | UART_UARTMIS_RTMIS_BITS)) { // rx interrupt?
         // clear all interrupt bits but tx
         uart_get_hw(self->uart)->icr = UART_UARTICR_BITS & (~UART_UARTICR_TXIC_BITS);
         if (!self->read_lock) {


### PR DESCRIPTION
The pico-sdk 1.3.0 update in #8031 introduced a change that broke RP2 Bluetooth UART, and possibly machine_uart.c in general, which stops working right after UART is initialized. This commit https://github.com/raspberrypi/pico-sdk/commit/2622e9bc292a26cb576a80c3c7c30481dda04181 enables the UART receive timeout (RTIM) IRQ, which is asserted when the receive FIFO is not empty, and no more characters are received for a period of time. This PR makes sure the RTIM IRQ is handled and cleared in `uart_service_interrupt`. 