### PR TITLE
esp32,esp8266: Extract qstr from object when comparing keys in config().

### DIFF
--- a/ports/esp32/network_lan.c
+++ b/ports/esp32/network_lan.c
@@ -249,14 +249,13 @@ STATIC mp_obj_t lan_config(size_t n_args, const mp_obj_t *args, mp_map_t *kwargs
         mp_raise_TypeError(MP_ERROR_TEXT("either pos or kw args are allowed"));
     }
     lan_if_obj_t *self = MP_OBJ_TO_PTR(args[0]);
-    #define QS(x) (uintptr_t)MP_OBJ_NEW_QSTR(x)
 
     if (kwargs->used != 0) {
 
         for (size_t i = 0; i < kwargs->alloc; i++) {
             if (mp_map_slot_is_filled(kwargs, i)) {
-                switch ((uintptr_t)kwargs->table[i].key) {
-                    case QS(MP_QSTR_mac): {
+                switch (mp_obj_str_get_qstr(kwargs->table[i].key)) {
+                    case MP_QSTR_mac: {
                         mp_buffer_info_t bufinfo;
                         mp_get_buffer_raise(kwargs->table[i].value, &bufinfo, MP_BUFFER_READ);
                         if (bufinfo.len != 6) {
@@ -279,8 +278,8 @@ STATIC mp_obj_t lan_config(size_t n_args, const mp_obj_t *args, mp_map_t *kwargs
 
     mp_obj_t val = mp_const_none;
 
-    switch ((uintptr_t)args[1]) {
-        case QS(MP_QSTR_mac): {
+    switch (mp_obj_str_get_qstr(args[1])) {
+        case MP_QSTR_mac: {
             uint8_t mac[6];
             esp_eth_ioctl(self->eth_handle, ETH_CMD_G_MAC_ADDR, mac);
             return mp_obj_new_bytes(mac, sizeof(mac));

--- a/ports/esp32/network_wlan.c
+++ b/ports/esp32/network_wlan.c
@@ -391,8 +391,6 @@ STATIC mp_obj_t network_wlan_config(size_t n_args, const mp_obj_t *args, mp_map_
         esp_exceptions(esp_wifi_get_config(self->if_id, &cfg));
     }
 
-    #define QS(x) (uintptr_t)MP_OBJ_NEW_QSTR(x)
-
     if (kwargs->used != 0) {
         if (!is_wifi) {
             goto unknown;
@@ -402,8 +400,8 @@ STATIC mp_obj_t network_wlan_config(size_t n_args, const mp_obj_t *args, mp_map_
             if (mp_map_slot_is_filled(kwargs, i)) {
                 int req_if = -1;
 
-                switch ((uintptr_t)kwargs->table[i].key) {
-                    case QS(MP_QSTR_mac): {
+                switch (mp_obj_str_get_qstr(kwargs->table[i].key)) {
+                    case MP_QSTR_mac: {
                         mp_buffer_info_t bufinfo;
                         mp_get_buffer_raise(kwargs->table[i].value, &bufinfo, MP_BUFFER_READ);
                         if (bufinfo.len != 6) {
@@ -412,7 +410,7 @@ STATIC mp_obj_t network_wlan_config(size_t n_args, const mp_obj_t *args, mp_map_
                         esp_exceptions(esp_wifi_set_mac(self->if_id, bufinfo.buf));
                         break;
                     }
-                    case QS(MP_QSTR_essid): {
+                    case MP_QSTR_essid: {
                         req_if = WIFI_IF_AP;
                         size_t len;
                         const char *s = mp_obj_str_get_data(kwargs->table[i].value, &len);
@@ -421,17 +419,17 @@ STATIC mp_obj_t network_wlan_config(size_t n_args, const mp_obj_t *args, mp_map_
                         cfg.ap.ssid_len = len;
                         break;
                     }
-                    case QS(MP_QSTR_hidden): {
+                    case MP_QSTR_hidden: {
                         req_if = WIFI_IF_AP;
                         cfg.ap.ssid_hidden = mp_obj_is_true(kwargs->table[i].value);
                         break;
                     }
-                    case QS(MP_QSTR_authmode): {
+                    case MP_QSTR_authmode: {
                         req_if = WIFI_IF_AP;
                         cfg.ap.authmode = mp_obj_get_int(kwargs->table[i].value);
                         break;
                     }
-                    case QS(MP_QSTR_password): {
+                    case MP_QSTR_password: {
                         req_if = WIFI_IF_AP;
                         size_t len;
                         const char *s = mp_obj_str_get_data(kwargs->table[i].value, &len);
@@ -440,22 +438,22 @@ STATIC mp_obj_t network_wlan_config(size_t n_args, const mp_obj_t *args, mp_map_
                         cfg.ap.password[len] = 0;
                         break;
                     }
-                    case QS(MP_QSTR_channel): {
+                    case MP_QSTR_channel: {
                         req_if = WIFI_IF_AP;
                         cfg.ap.channel = mp_obj_get_int(kwargs->table[i].value);
                         break;
                     }
-                    case QS(MP_QSTR_dhcp_hostname): {
+                    case MP_QSTR_dhcp_hostname: {
                         const char *s = mp_obj_str_get_str(kwargs->table[i].value);
                         esp_exceptions(tcpip_adapter_set_hostname(self->if_id, s));
                         break;
                     }
-                    case QS(MP_QSTR_max_clients): {
+                    case MP_QSTR_max_clients: {
                         req_if = WIFI_IF_AP;
                         cfg.ap.max_connection = mp_obj_get_int(kwargs->table[i].value);
                         break;
                     }
-                    case QS(MP_QSTR_reconnects): {
+                    case MP_QSTR_reconnects: {
                         int reconnects = mp_obj_get_int(kwargs->table[i].value);
                         req_if = WIFI_IF_STA;
                         // parameter reconnects == -1 means to retry forever.
@@ -488,8 +486,8 @@ STATIC mp_obj_t network_wlan_config(size_t n_args, const mp_obj_t *args, mp_map_
     int req_if = -1;
     mp_obj_t val = mp_const_none;
 
-    switch ((uintptr_t)args[1]) {
-        case QS(MP_QSTR_mac): {
+    switch (mp_obj_str_get_qstr(args[1])) {
+        case MP_QSTR_mac: {
             uint8_t mac[6];
             switch (self->if_id) {
                 case WIFI_IF_AP: // fallthrough intentional
@@ -500,7 +498,7 @@ STATIC mp_obj_t network_wlan_config(size_t n_args, const mp_obj_t *args, mp_map_
                     goto unknown;
             }
         }
-        case QS(MP_QSTR_essid):
+        case MP_QSTR_essid:
             switch (self->if_id) {
                 case WIFI_IF_STA:
                     val = mp_obj_new_str((char *)cfg.sta.ssid, strlen((char *)cfg.sta.ssid));
@@ -512,29 +510,29 @@ STATIC mp_obj_t network_wlan_config(size_t n_args, const mp_obj_t *args, mp_map_
                     req_if = WIFI_IF_AP;
             }
             break;
-        case QS(MP_QSTR_hidden):
+        case MP_QSTR_hidden:
             req_if = WIFI_IF_AP;
             val = mp_obj_new_bool(cfg.ap.ssid_hidden);
             break;
-        case QS(MP_QSTR_authmode):
+        case MP_QSTR_authmode:
             req_if = WIFI_IF_AP;
             val = MP_OBJ_NEW_SMALL_INT(cfg.ap.authmode);
             break;
-        case QS(MP_QSTR_channel):
+        case MP_QSTR_channel:
             req_if = WIFI_IF_AP;
             val = MP_OBJ_NEW_SMALL_INT(cfg.ap.channel);
             break;
-        case QS(MP_QSTR_dhcp_hostname): {
+        case MP_QSTR_dhcp_hostname: {
             const char *s;
             esp_exceptions(tcpip_adapter_get_hostname(self->if_id, &s));
             val = mp_obj_new_str(s, strlen(s));
             break;
         }
-        case QS(MP_QSTR_max_clients): {
+        case MP_QSTR_max_clients: {
             val = MP_OBJ_NEW_SMALL_INT(cfg.ap.max_connection);
             break;
         }
-        case QS(MP_QSTR_reconnects):
+        case MP_QSTR_reconnects:
             req_if = WIFI_IF_STA;
             int rec = conf_wifi_sta_reconnects - 1;
             val = MP_OBJ_NEW_SMALL_INT(rec);
@@ -542,8 +540,6 @@ STATIC mp_obj_t network_wlan_config(size_t n_args, const mp_obj_t *args, mp_map_
         default:
             goto unknown;
     }
-
-#undef QS
 
     // We post-check interface requirements to save on code size
     if (req_if >= 0) {

--- a/ports/esp8266/modnetwork.c
+++ b/ports/esp8266/modnetwork.c
@@ -351,9 +351,8 @@ STATIC mp_obj_t esp_config(size_t n_args, const mp_obj_t *args, mp_map_t *kwargs
 
         for (mp_uint_t i = 0; i < kwargs->alloc; i++) {
             if (mp_map_slot_is_filled(kwargs, i)) {
-                #define QS(x) (uintptr_t)MP_OBJ_NEW_QSTR(x)
-                switch ((uintptr_t)kwargs->table[i].key) {
-                    case QS(MP_QSTR_mac): {
+                switch (mp_obj_str_get_qstr(kwargs->table[i].key)) {
+                    case MP_QSTR_mac: {
                         mp_buffer_info_t bufinfo;
                         mp_get_buffer_raise(kwargs->table[i].value, &bufinfo, MP_BUFFER_READ);
                         if (bufinfo.len != 6) {
@@ -362,7 +361,7 @@ STATIC mp_obj_t esp_config(size_t n_args, const mp_obj_t *args, mp_map_t *kwargs
                         wifi_set_macaddr(self->if_id, bufinfo.buf);
                         break;
                     }
-                    case QS(MP_QSTR_essid): {
+                    case MP_QSTR_essid: {
                         req_if = SOFTAP_IF;
                         size_t len;
                         const char *s = mp_obj_str_get_data(kwargs->table[i].value, &len);
@@ -371,17 +370,17 @@ STATIC mp_obj_t esp_config(size_t n_args, const mp_obj_t *args, mp_map_t *kwargs
                         cfg.ap.ssid_len = len;
                         break;
                     }
-                    case QS(MP_QSTR_hidden): {
+                    case MP_QSTR_hidden: {
                         req_if = SOFTAP_IF;
                         cfg.ap.ssid_hidden = mp_obj_is_true(kwargs->table[i].value);
                         break;
                     }
-                    case QS(MP_QSTR_authmode): {
+                    case MP_QSTR_authmode: {
                         req_if = SOFTAP_IF;
                         cfg.ap.authmode = mp_obj_get_int(kwargs->table[i].value);
                         break;
                     }
-                    case QS(MP_QSTR_password): {
+                    case MP_QSTR_password: {
                         req_if = SOFTAP_IF;
                         size_t len;
                         const char *s = mp_obj_str_get_data(kwargs->table[i].value, &len);
@@ -390,12 +389,12 @@ STATIC mp_obj_t esp_config(size_t n_args, const mp_obj_t *args, mp_map_t *kwargs
                         cfg.ap.password[len] = 0;
                         break;
                     }
-                    case QS(MP_QSTR_channel): {
+                    case MP_QSTR_channel: {
                         req_if = SOFTAP_IF;
                         cfg.ap.channel = mp_obj_get_int(kwargs->table[i].value);
                         break;
                     }
-                    case QS(MP_QSTR_dhcp_hostname): {
+                    case MP_QSTR_dhcp_hostname: {
                         req_if = STATION_IF;
                         if (self->if_id == STATION_IF) {
                             const char *s = mp_obj_str_get_str(kwargs->table[i].value);
@@ -406,7 +405,6 @@ STATIC mp_obj_t esp_config(size_t n_args, const mp_obj_t *args, mp_map_t *kwargs
                     default:
                         goto unknown;
                 }
-#undef QS
             }
         }
 


### PR DESCRIPTION
Following on from a previous fix for the same problem made in 3a431fba50c96cc47d8273a6934e200993197b14.

Fixes issue #8052.