### PR TITLE
Adding library and example Python script to control ESP8266

### DIFF
--- a/drivers/esp8266/esp8266.py
+++ b/drivers/esp8266/esp8266.py
@@ -1,0 +1,575 @@
+"""
+File name: esp8266.py
+Michal Pindiak, hobbyastro}at[gmail(com
+Inspired by https://github.com/Circuit-Digest/Raspberry_Pi_Pico_Tutorial/tree/main/T7_Interfacing_ESP8266-01_WiFi
+"""
+
+from machine import UART, Pin
+import time
+"""
+Enables controlling the ESP8266 board via Python and in the background AT commands via UART.
+"""
+
+ESP8266_OK_STATUS = "OK\r\n"
+ESP8266_ERROR_STATUS = "ERROR\r\n"
+ESP8266_FAIL_STATUS = "FAIL\r\n"
+ESP8266_WIFI_CONNECTED = "WIFI CONNECTED\r\n"
+ESP8266_WIFI_GOT_IP_CONNECTED = "WIFI GOT IP\r\n"
+ESP8266_WIFI_DISCONNECTED = "WIFI DISCONNECTED\r\n"
+ESP8266_WIFI_AP_NOT_PRESENT = "WIFI AP NOT FOUND\r\n"
+ESP8266_WIFI_AP_WRONG_PWD = "WIFI AP WRONG PASSWORD\r\n"
+ESP8266_BUSY_STATUS = "DEVICE BUSY\r\n"
+UART_Tx_BUFFER_LENGTH = 1024
+UART_Rx_BUFFER_LENGTH = 2048  # increase in case the http responses you are getting are truncated
+received_data = None
+
+
+class ESP8266:
+    """
+    Enables controlling the ESP8266 board via Python and in the background AT commands via UART.
+    """
+
+    def __init__(self, uart_port=0, uart_baud_rate=115200, uart_tx_pin=0, uart_rx_pin=1):
+        """
+        Initialisation.
+
+        Parameters:
+            uart_port (int)
+            uart_baud_rate (int)
+            uart_tx_pin (int)
+            uart_rx_pin (int)
+        """
+
+        self.uart_port = uart_port
+        self.uart_baud_rate = uart_baud_rate
+        self.uart_tx_pin = uart_tx_pin
+        self.uart_rx_pin = uart_rx_pin
+        self.uart_object = UART(uart_port, baudrate=self.uart_baud_rate, tx=Pin(self.uart_tx_pin), rx=Pin(self.uart_rx_pin), txbuf=UART_Tx_BUFFER_LENGTH, rxbuf=UART_Rx_BUFFER_LENGTH)
+
+    def write_to_uart(self, at_command, delay=0.5):
+        """
+        For communicating with ESP8266 board via UART bus.
+        """
+
+        self.received_data = str()
+        self.sent_data = at_command
+        self.uart_object.write(self.sent_data)
+        self.received_data = bytes()
+        time.sleep(delay)
+        while True:
+            if self.uart_object.any() > 0:
+                break
+        while self.uart_object.any() > 0:
+            self.received_data += self.uart_object.read(UART_Rx_BUFFER_LENGTH)
+        if ESP8266_OK_STATUS in self.received_data:
+            return self.received_data
+        elif ESP8266_ERROR_STATUS in self.received_data:
+            return self.received_data
+        elif ESP8266_FAIL_STATUS in self.received_data:
+            return self.received_data
+        elif ESP8266_BUSY_STATUS in self.received_data:
+            return "ESP BUSY\r\n"
+        else:
+            return None
+
+    def initialise_ESP8266(self):
+        """
+        Sending the "AT" command to ESP8266.
+
+        Returns:
+            "Startup ok" on success.
+            "Startup failed" otherwise.
+        """
+
+        received_data = self.write_to_uart("AT\r\n")
+        if(received_data is not None):
+            if ESP8266_OK_STATUS in received_data:
+                return "Startup ok"
+            else:
+                return "Startup failed"
+        else:
+            "Startup failed"
+
+    def reset_ESP8266(self):
+        """
+        Sending the "AT+RST" command to ESP8266. Resets the ESP8266. For restoring the factory settings, use restore_ESP8266().
+
+        Returns:
+            "Reset ok" if reset of ESP8266 was successfull.
+            "Reset failed" otherwise.
+        """
+
+        received_data = self.write_to_uart("AT+RST\r\n")
+        if(received_data is not None):
+            if ESP8266_OK_STATUS in received_data:
+                time.sleep(0.5)
+                return "Reset ok"
+            else:
+                return "Reset failed"
+        else:
+            "Reset failed"
+
+    def echo_commands(self, enable=False):
+        """
+        A function to enable/disable AT command echo.
+
+        Returns:
+            "Echo on" / "Echo off" if the command was successful.
+            "Setting echo failed" if echo off/on command failed.
+        """
+
+        if enable is False:
+            received_data = self.write_to_uart("ATE0\r\n")
+            if(received_data is not None):
+                if ESP8266_OK_STATUS in received_data:
+                    return "Echo off"
+                else:
+                    return "Setting echo failed"
+            else:
+                return "Setting echo failed"
+        else:
+            received_data = self.write_to_uart("ATE1\r\n")
+            if(received_data is not None):
+                if ESP8266_OK_STATUS in received_data:
+                    return "Echo on"
+                else:
+                    return "Setting echo failed"
+            else:
+                return "Setting echo failed"
+
+    def view_version_info(self):
+        """
+        Sending the "AT+GMR" command to ESP8266.
+
+        Returns:
+            Version details on success.
+            None otherwise.
+        """
+
+        received_data = self.write_to_uart("AT+GMR\r\n")
+        if(received_data is not None):
+            if ESP8266_OK_STATUS in received_data:
+                received_data = str(received_data).partition(r"OK")[0]
+                received_data = received_data.split(r"\r\n")
+                received_data[0] = received_data[0].replace("b'", "")
+                received_data = str(received_data[0]+"\r\n"+received_data[1]+"\r\n"+received_data[2])
+                return received_data
+            else:
+                return None
+        else:
+            return None
+
+    def get_status(self):
+        """
+        Command "AT+CIPSTATUS" to get ESP8266 connection status.
+
+        Returns:
+            2: ESP8266 connected to an AP and got an IP address.
+            3: ESP8266 opened a TCP or UDP connection.
+            4: TCP or UDP connection disconnected.
+            5: ESP8266 not connected to any AP.
+            "Getting the connection status failed" on error.
+        """
+
+        received_data = self.write_to_uart("AT+CIPSTATUS\r\n")
+        if(received_data is not None):
+            if ESP8266_OK_STATUS in received_data:
+                received_data = str(received_data).partition(r"OK")[0]
+                received_data = received_data.split(r"\r\n")
+                received_data[0] = received_data[0].replace("b'", "")
+                received_data = str(received_data[0]+"\r\n"+received_data[1]+"\r\n"+received_data[2])
+                if "2" in received_data:
+                    received_status = "2 = ESP8266 is connected to an AP and got an IP address"
+                if "3" in received_data:
+                    received_status = "3 = ESP8266 opened a TCP or UDP connection"
+                if "4" in received_data:
+                    received_status = "4 = TCP or UDP connection was closed"
+                if "5" in received_data:
+                    received_status = "5 = ESP8266 is not connected to any AP"
+                return received_status
+            else:
+                return "Getting the connection status failed"
+        else:
+            return "Getting the connection status failed"
+
+    def get_ip(self):
+        """
+        Command "AT+CIFSR" to get IP addresses of ESP8266 board.
+
+        Returns:
+            +CIFSR:APIP: SoftAP IP address.
+            +CIFSR:APMAC: SoftAP MAC address.
+            +CIFSR:STAIP: Station IP address.
+            +CIFSR:STAMAC: Station MAC address.
+            "Error getting IP addresses" in case of error.
+        """
+
+        received_data = self.write_to_uart("AT+CIFSR\r\n")
+        if(received_data is not None):
+            if ESP8266_OK_STATUS in received_data:
+                received_data = str(received_data).partition(r"OK")[0]
+                received_data = received_data.split(r"\r\n")
+                received_data[0] = received_data[0].replace("b'", "")
+                received_data = str(received_data[0]+"\r\n"+received_data[1]+"\r\n"+received_data[2])
+                return received_data
+            else:
+                return "Error getting IP addresses"
+        else:
+            return "Error getting IP addresses"
+
+    def restore_ESP8266(self):
+        """
+        A function to restore the ESP8266 board into factory settings via "AT+RESTORE" command. For resetting the board, use reset_ESP8266().
+
+        Returns:
+            "Restore ok" if ESP8266 restore was successful.
+            "Restore failed" otherwise.
+        """
+
+        received_data = self.write_to_uart("AT+RESTORE\r\n")
+        if(received_data is not None):
+            if ESP8266_OK_STATUS in received_data:
+                return "Restore ok"
+            else:
+                return "Restore failed"
+        else:
+            return "Restore failed"
+
+    def get_current_mode(self):
+        """
+        Get the current ESP8266 mode via "AT+CWMODE_CUR?".
+
+        Returns:
+            "STA" if the current mode = Station.
+            "SoftAP" if the current mode = SoftAP.
+            "SoftAP+STA" if the current mode = Station & SoftAP.
+            "Getting the current mode failed" if failed to detect the current mode.
+        """
+
+        received_data = self.write_to_uart("AT+CWMODE_CUR?\r\n")
+        if(received_data is not None):
+            if "1" in received_data:
+                return "1 STA"
+            elif "2" in received_data:
+                return "2 SoftAP"
+            elif "3" in received_data:
+                return "3 SoftAP+STA"
+            else:
+                return "Getting the current mode failed"
+        else:
+            return "Getting the current mode failed"
+
+    def set_current_mode(self, mode=3):
+        """
+        A function to set the current ESP8266 WiFi mode via "AT+CWMODE_CUR=" command.
+
+        Parameters:
+            mode (int): (1 = STA, 2: = SoftAP, 3 = SoftAP+STA).
+
+        Returns:
+            True after successfully setting the current mode.
+            False otherwise.
+        """
+
+        transmission_data = "AT+CWMODE_CUR="+str(mode)+"\r\n"
+        received_data = self.write_to_uart(transmission_data)
+        if(received_data is not None):
+            if ESP8266_OK_STATUS in received_data:
+                return True
+            else:
+                return False
+        else:
+            return False
+
+    def get_default_mode(self):
+        """
+        Get the default ESP8266 mode via "AT+CWMODE_DEF?".
+
+        Returns:
+            "STA" if the current mode = Station.
+            "SoftAP" if the default mode = SoftAP.
+            "SoftAP+STA" if the default mode = Station & SoftAP.
+            "Getting the default mode failed" if failed to detect the default mode.
+        """
+
+        received_data = self.write_to_uart("AT+CWMODE_DEF?\r\n")
+        if(received_data is not None):
+            if "1" in received_data:
+                return "1 STA"
+            elif "2" in received_data:
+                return "2 SoftAP"
+            elif "3" in received_data:
+                return "3 SoftAP+STA"
+            else:
+                return "Getting the default mode failed"
+        else:
+            return "Getting the default mode failed"
+
+    def set_default_mode(self, mode=3):
+        """
+        A function to set the default ESP8266 WiFi mode via "AT+CWMODE_DEF=" command.
+
+        Parameters:
+            mode (int): (1 = STA, 2: = SoftAP, 3 = SoftAP+STA).
+
+        Returns:
+            True after successfully setting the default mode.
+            False otherwise.
+        """
+
+        transmission_data = "AT+CWMODE_DEF="+str(mode)+"\r\n"
+        received_data = self.write_to_uart(transmission_data)
+        if(received_data is not None):
+            if ESP8266_OK_STATUS in received_data:
+                return True
+            else:
+                return False
+        else:
+            return False
+
+    def list_available_access_points(self):
+        """
+        A function to list available WiFi access points via "AT+CWLAP" command.
+
+        Returns:
+            List of available access points or None.
+        """
+
+        received_data = str(self.write_to_uart("AT+CWLAP\r\n", delay=10))
+        if(received_data is not None):
+            received_data = received_data.replace("+CWLAP:", "")
+            received_data = received_data.replace(r"\r\n\r\nOK\r\n", "")
+            received_data = received_data.replace(r"\r\n", "@")
+            received_data = received_data.replace("b'(", "(").replace("'", "")
+            received_data = received_data.split("@")
+            received_data = list(received_data)
+            access_points = list()
+
+            for items in received_data:
+                data = str(items).replace("(", "").replace(")", "").split(",")
+                data = tuple(data)
+                access_points.append(data)
+            return access_points
+        else:
+            return None
+
+    def connect_wifi(self, ssid, pwd):
+        """
+        Used to connect ESP8266 board to a WiFi AP via "AT+CWJAP_CUR=" command.
+
+        Parameters:
+            ssid (str)
+            pwd (str)
+
+        Returns:
+            WIFI CONNECTED on success.
+            WIFI AP WRONG PASSWORD for wrong password.
+            WIFI AP NOT FOUND when the specified SSID is not found.
+            WIFI DISCONNECTED when the connection is not successful.
+        """
+
+        transmission_data = "AT+CWJAP_CUR="+'"'+ssid+'"'+','+'"'+pwd+'"'+"\r\n"
+        received_data = self.write_to_uart(transmission_data, delay=15)
+        if(received_data is not None):
+            if "+CWJAP" in received_data:
+                if "1" in received_data:
+                    return ESP8266_WIFI_DISCONNECTED
+                elif "2" in received_data:
+                    return ESP8266_WIFI_AP_WRONG_PWD
+                elif "3" in received_data:
+                    return ESP8266_WIFI_AP_NOT_PRESENT
+                elif "4" in received_data:
+                    return ESP8266_WIFI_DISCONNECTED
+                else:
+                    return None
+            elif ESP8266_WIFI_CONNECTED in received_data:
+                if ESP8266_WIFI_GOT_IP_CONNECTED in received_data:
+                    return ESP8266_WIFI_CONNECTED
+                else:
+                    return ESP8266_WIFI_DISCONNECTED
+            else:
+                return ESP8266_WIFI_DISCONNECTED
+        else:
+            return ESP8266_WIFI_DISCONNECTED
+
+    def disconnect_wifi(self):
+        """
+        Used to disconnect from a connected WiFi AP via "AT+CWQAP" command.
+
+        Returns:
+            "OK" on successful disconnect.
+            "Failed" otherwise.
+        """
+
+        received_data = self.write_to_uart("AT+CWQAP\r\n")
+        if(received_data is not None):
+            if ESP8266_OK_STATUS in received_data:
+                return "OK"
+            else:
+                return "Failed"
+        else:
+            return "Failed"
+
+    def parseHTTP(self, data):
+        """
+        A function to process the response for http requests (get, post, put,...).
+
+        Returns:
+            On success: dict {"code":"", "headers":"", "body":""}
+            On error: dict {"code":"0", "headers":"0", "body":"0"}
+        """
+
+        failsafe = {"code": "0", "headers": "0", "body": "0"}
+        if(data is not None):
+            data = data.decode("utf-8").split("\r\n")
+            raw = []
+            for _ in data:
+                if _ != "":
+                    raw.append(_)
+            try:
+                response_code = (raw[2].split(" "))[1]
+            except IndexError:
+                response_code = "0"
+            try:
+                header = raw[3:-1]
+            except IndexError:
+                header = "0"
+            try:
+                body = raw[-1]
+                if body[-6:] == "CLOSED":
+                    body = body[:-6]
+            except IndexError:
+                body = "0"
+            return {"code": response_code, "headers": header, "body": body}
+        else:
+            return failsafe
+
+    def _createTCPConnection(self, link, port=80):
+        """
+        A function to open a TCP connection between ESP8266 and target.
+
+        Return:
+            True on success.
+            False if failed to create a connection.
+        """
+
+        transmission_data = "AT+CIPSTART="+'"'+"TCP"+'"'+','+'"'+link+'"'+','+str(port)+"\r\n"
+        received_data = self.write_to_uart(transmission_data)
+        if(received_data is not None):
+            if ESP8266_OK_STATUS in received_data:
+                return True
+            else:
+                return False
+        else:
+            False
+
+    def doHttpGet(self, target, path, user_agent="ESP8622", content_type="text/plain", payload="", port=80):
+        """
+        A function to perform a get request.
+
+        Parameters:
+            target (str): target IP (like "192.168.1.1") or URL (like "www.httpbin.org") only, without /path
+            path (str): path ("/get")
+            user-agent (str), optional, default = "ESP8622"
+            content_type (str), optional, default = "text/plain"
+            payload (str), optional, default = ""
+            port (int) optional, default = 80
+
+        Returns:
+            On success: dict {"code":"", "headers":"", "body":""}
+            On error: dict {"code":"0", "headers":"0", "body":"0"}
+        """
+
+        failsafe = {"code": "0", "headers": "0", "body": "0"}
+        if(self._createTCPConnection(target, port) is True):
+            request = "GET "+path+" HTTP/1.1\r\n"+"Host: "+target+"\r\n"+"User-Agent: "+user_agent+"\r\n"+"Content-Type: "+content_type+"\r\n"+"Content-Length: "+str(len(payload))+"\r\n"+"\r\n"+payload+"\r\n"
+            # print(request)
+            transmission_data = "AT+CIPSEND="+str(len(request))+"\r\n"
+            received_data = self.write_to_uart(transmission_data)
+            if(received_data is not None):
+                if ">" in received_data:
+                    received_data = self.write_to_uart(request, delay=1)
+                    self.write_to_uart("AT+CIPCLOSE\r\n")
+                    received_data = self.parseHTTP(received_data)
+                    return received_data
+                else:
+                    return failsafe
+            else:
+                return failsafe
+        else:
+            self.write_to_uart("AT+CIPCLOSE\r\n")
+            return failsafe
+
+    def doHttpPut(self, target, path, user_agent="ESP8622", content_type="text/plain", payload="", port=80):
+        """
+        A function to perform a put request.
+
+        Parameters:
+            target (str): target IP (like "192.168.1.1") or URL (like "www.httpbin.org") only, without /path
+            path (str): path ("/put")
+            user-agent (str), optional, default = "ESP8622"
+            content_type (str), optional, default = "text/plain"
+            payload (str), optional, default = ""
+            port (int) optional, default = 80
+
+        Returns:
+            On success: dict {"code":"", "headers":"", "body":""}
+            On error: dict {"code":"0", "headers":"0", "body":"0"}
+        """
+
+        failsafe = {"code": "0", "headers": "0", "body": "0"}
+        if(self._createTCPConnection(target, port) is True):
+            request = "PUT "+path+" HTTP/1.1\r\n"+"Host: "+target+"\r\n"+"User-Agent: "+user_agent+"\r\n"+"Content-Type: "+content_type+"\r\n"+"Content-Length: "+str(len(payload))+"\r\n"+"\r\n"+payload+"\r\n"
+            # print(request)
+            transmission_data = "AT+CIPSEND="+str(len(request))+"\r\n"
+            received_data = self.write_to_uart(transmission_data)
+            if(received_data is not None):
+                if ">" in received_data:
+                    received_data = self.write_to_uart(request, delay=1)
+                    self.write_to_uart("AT+CIPCLOSE\r\n")
+                    received_data = self.parseHTTP(received_data)
+                    return received_data
+                else:
+                    return failsafe
+            else:
+                return failsafe
+        else:
+            self.write_to_uart("AT+CIPCLOSE\r\n")
+            return failsafe
+
+    def doHttppost(self, target, path, user_agent="ESP8622", content_type="text/plain", payload="", port=80):
+        """
+        A function to perform a post request.
+
+        Parameters:
+            target (str): target IP (like "192.168.1.1") or URL (like "www.httpbin.org") only, without /path
+            path (str): path ("/post")
+            user-agent (str), optional, default = "ESP8622"
+            content_type (str), optional, default = "text/plain"
+            payload (str), optional, default = ""
+            port (int) optional, default = 80
+
+        Returns:
+            On success: dict {"code":"", "headers":"", "body":""}
+            On error: dict {"code":"0", "headers":"0", "body":"0"}
+        """
+
+        failsafe = {"code": "0", "headers": "0", "body": "0"}
+        if(self._createTCPConnection(target, port) is True):
+            request = "POST "+path+" HTTP/1.1\r\n"+"Host: "+target+"\r\n"+"User-Agent: "+user_agent+"\r\n"+"Content-Type: "+content_type+"\r\n"+"Content-Length: "+str(len(payload))+"\r\n"+"\r\n"+payload+"\r\n"
+            # print(request)
+            transmission_data = "AT+CIPSEND="+str(len(request))+"\r\n"
+            received_data = self.write_to_uart(transmission_data)
+            if(received_data is not None):
+                if ">" in received_data:
+                    received_data = self.write_to_uart(request, delay=1)
+                    self.write_to_uart("AT+CIPCLOSE\r\n")
+                    received_data = self.parseHTTP(received_data)
+                    return received_data
+                else:
+                    return failsafe
+            else:
+                return failsafe
+        else:
+            self.write_to_uart("AT+CIPCLOSE\r\n")
+            return failsafe

--- a/drivers/esp8266/example.py
+++ b/drivers/esp8266/example.py
@@ -1,0 +1,114 @@
+"""
+File name: example.py
+Michal Pindiak, hobbyastro}at[gmail(com
+Inspired by https://github.com/Circuit-Digest/Raspberry_Pi_Pico_Tutorial/tree/main/T7_Interfacing_ESP8266-01_WiFi
+"""
+
+from esp8266 import ESP8266
+import time
+import sys
+from settings import *
+
+def start():
+    print("OS version: ", sys.implementation.name, sys.version)
+    esp8622board = ESP8266(uart_port, uart_baud_rate, uart_tx_pin, uart_rx_pin)
+    print("\nESP8266 initialisation: ", esp8622board.initialise_ESP8266())
+    # print("\nESP8266 Reset: ",esp8622board.reset_ESP8266())
+    # print("\nESP8266 Restore: ",esp8622board.restore_ESP8266())
+    print("\nESP8266 AT commands echoing: ", esp8622board.echo_commands())
+    # Set the current WiFi mode
+    # 1: Station mode
+    # 2: SoftAP mode
+    # 3: SoftAP+Station mode
+    status = esp8622board.get_status()
+    print("\nESP8266 current status: ", status)
+    return(esp8622board)
+
+def view_ESP8266_version():
+    # Show ESP8266 AT command version and SDK details
+    version = esp8622board.view_version_info()
+    if(version is not None):
+        print("\nESP8266 version info:")
+        print(version)
+
+def scan_for_networks():
+    # List available WiFi networks
+    print("\nScanning for WiFi networks")
+    access_points = esp8622board.list_available_access_points()
+    print("Found WiFi networks:")
+    for items in access_points:
+        print(items)
+
+def connect_wifi():
+    # Connects to WiFi
+    print("\nTrying to connect to WiFi with SSID: {ssid}".format(ssid=ssid))
+    message = esp8622board.connect_wifi(ssid, password)
+    status = esp8622board.get_status()
+    ip = esp8622board.get_ip()
+    print(message)
+    print("\nESP8266 current status: ", status)
+    print(ip)
+
+def disconnect_wifi():
+    # Disconnects from WiFi
+    print("\nTrying to disconnect from WiFi: ", esp8622board.disconnect_wifi())
+    status = esp8622board.get_status()
+    print("ESP8266 current status: ", status)
+
+def get_default_mode():
+    # Get the default ESP8266 mode
+    message = esp8622board.get_default_mode()
+    print("\nDefault ESP8266 mode: ", message)
+
+def get_current_mode():
+    # Get the current ESP8266 mode
+    message = esp8622board.get_current_mode()
+    print("\nCurrent ESP8266 mode: ", message)
+
+def http_get(gethost, getpath, getuseragent, getcontenttype, getpayload, getport):
+    # HTTP Get
+    print("\nHTTP Get")
+    response = esp8622board.doHttpGet(gethost, getpath, getuseragent, getcontenttype, getpayload, getport)
+    print("Response code:", response["code"], "\n")
+    print("Response headers:\n")
+    for _ in response["headers"]:
+        print(_)
+    print("\n")
+    print("Response body:")
+    print(response["body"], "\n")
+
+def http_put(puthost, putpath, putuseragent, putcontenttype, putpayload, putport):
+    # HTTP Put
+    print("\nHTTP Put")
+    response = esp8622board.doHttpPut(puthost, putpath, putuseragent, putcontenttype, putpayload, putport)
+    print("Response code:", response["code"], "\n")
+    print("Response headers:\n")
+    for _ in response["headers"]:
+        print(_)
+    print("\n")
+    print("Response body:")
+    print(response["body"], "\n")
+
+def http_post(posthost, postpath, postuseragent, postcontenttype, postpayload, postport):
+    # HTTP post
+    print("\nHTTP Post")
+    response = esp8622board.doHttppost(posthost, postpath, postuseragent, postcontenttype, postpayload, postport)
+    print("Response code:", response["code"], "\n")
+    print("Response headers:\n")
+    for _ in response["headers"]:
+        print(_)
+    print("\n")
+    print("Response body:")
+    print(response["body"], "\n")
+
+
+esp8622board = start()
+view_ESP8266_version()
+scan_for_networks()
+connect_wifi()
+get_default_mode()
+get_current_mode()
+http_get(gethost, getpath, getuseragent, getcontenttype, getpayload, getport)
+http_put(puthost, putpath, putuseragent, putcontenttype, putpayload, putport)
+http_post(posthost, postpath, postuseragent, postcontenttype, postpayload, postport)
+disconnect_wifi()

--- a/drivers/esp8266/readme.md
+++ b/drivers/esp8266/readme.md
@@ -1,0 +1,29 @@
+# Controlling ESP8266 via Micropython
+
+Enables controlling the ESP8266 board via Python and - in the background - AT commands.
+
+## Content
+esp8266.py: ESP8266 library.
+Handles UART-based communication to ESP8266 board, translates Python commands to AT+ commands for ESP8266 and processes responses.
+
+settings.py:
+To define UART parameters (hardware setup), WiFi parameters (ssid and password), and parameters for get / put / post requests.
+
+example.py:
+Example file, showing how to connect to the ESP8266 board, list WiFi access points, connect to WiFi, perform a get / put / post request, etc.
+
+## Usage
+Copy all 3 files:
+  esp8266.py
+  settings.py
+  example.py
+to the root of your micropython board.
+
+Edit the settings.py file:
+  - UART parameters (hardware setup),
+  - WiFi parameters (ssid and password),
+  - parameters for get / put / post requests.
+
+Launch example.py
+
+Tested with Raspberry Pico + Waveshare ESP8266

--- a/drivers/esp8266/settings.py
+++ b/drivers/esp8266/settings.py
@@ -1,0 +1,33 @@
+# Define UART connection to match your hardware setup
+uart_port = 0
+uart_baud_rate = 115200
+uart_tx_pin = 0
+uart_rx_pin = 1
+
+# Define WiFi parameters, ssid and password
+ssid = "your wifi ssid here"
+password = "your wifi password here"
+
+# Define get request parameters
+gethost = "httpbin.org"
+getpath = "/get"
+getuseragent = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.106 Safari/537.36"
+getcontenttype = "text/plain"  # "application/json", "application/x-www-form-urlencoded", "text/plain",...
+getpayload = ""
+getport = 80
+
+# Define put request parameters
+puthost = "httpbin.org"
+putpath = "/put"
+putuseragent = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.106 Safari/537.36"
+putcontenttype = "text/plain"  # "application/json", "application/x-www-form-urlencoded", "text/plain",...
+putpayload = ""
+putport = 80
+
+# Define post request parameters
+posthost = "www.httpbin.org"
+postpath = "/post"
+postuseragent = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.106 Safari/537.36"
+postcontenttype = "application/json"  # "application/json", "application/x-www-form-urlencoded", "text/plain",...
+postpayload = "{'key':'value'}"
+postport = 80


### PR DESCRIPTION
Files added into /drivers/esp8266 to enable controlling the ESP8266 board via Python and - in the background - AT commands via UART.

## Content
esp8266.py: ESP8266 library.
Handles UART-based communication to ESP8266 board, translates Python commands to AT+ commands for ESP8266 and processes responses.

settings.py:
To define UART parameters (hardware setup), WiFi parameters (ssid and password), and parameters for get / put / post requests.

example.py:
Example file, showing how to connect to the ESP8266 board, list WiFi access points, connect to WiFi, perform a get / put / post request, etc.

## Usage
Copy all 3 files:
  esp8266.py
  settings.py
  example.py
to the root of your micropython board.

Edit the settings.py file:
  - UART parameters (hardware setup),
  - WiFi parameters (ssid and password),
  - parameters for get / put / post requests.

Launch example.py

Tested with Raspberry Pico + Waveshare ESP8266