### PR TITLE
stm32: update stm32lib and improve MMC support

### DIFF
--- a/ports/stm32/Makefile
+++ b/ports/stm32/Makefile
@@ -432,8 +432,13 @@ endif
 ifeq ($(CMSIS_MCU),$(filter $(CMSIS_MCU),STM32H743xx STM32H750xx STM32H7A3xx STM32H7A3xxQ STM32H7B3xx STM32H7B3xxQ))
     HAL_SRC_C += $(addprefix $(HAL_DIR)/Src/stm32$(MCU_SERIES)xx_, hal_fdcan.c)
 else
-ifeq ($(MCU_SERIES),$(filter $(MCU_SERIES),f0 f4 f7 h7 l4))
+ifeq ($(MCU_SERIES),$(filter $(MCU_SERIES),f0 f4 f7 h7))
     HAL_SRC_C += $(addprefix $(HAL_DIR)/Src/stm32$(MCU_SERIES)xx_, hal_can.c)
+else
+ifeq ($(MCU_SERIES),$(filter $(MCU_SERIES),l4))
+HAL_SRC_C += $(addprefix $(HAL_DIR)/Src/Legacy/stm32$(MCU_SERIES)xx_, hal_can.c)
+$(BUILD)/$(HAL_DIR)/Src/Legacy/stm32$(MCU_SERIES)xx_hal_can.o: CFLAGS += -Wno-error=cpp
+endif
 endif
 endif
 

--- a/ports/stm32/adc.h
+++ b/ports/stm32/adc.h
@@ -44,7 +44,7 @@ static inline void adc_deselect_vbat(ADC_TypeDef *adc, uint32_t channel) {
 
         #if defined(STM32F0) || defined(STM32WB)
         adc_common = ADC1_COMMON;
-        #elif defined(STM32F4) || defined(STM32L4)
+        #elif defined(STM32F4)
         adc_common = ADC_COMMON_REGISTER(0);
         #elif defined(STM32F7)
         adc_common = ADC123_COMMON;
@@ -52,6 +52,8 @@ static inline void adc_deselect_vbat(ADC_TypeDef *adc, uint32_t channel) {
         adc_common = ADC12_COMMON;
         #elif defined(STM32H7)
         adc_common = adc == ADC3 ? ADC3_COMMON : ADC12_COMMON;
+        #elif defined(STM32L4)
+        adc_common = __LL_ADC_COMMON_INSTANCE(0);
         #endif
 
         adc_common->CCR &= ~LL_ADC_PATH_INTERNAL_VBAT;

--- a/ports/stm32/boards/PYBD_SF2/mpconfigboard.h
+++ b/ports/stm32/boards/PYBD_SF2/mpconfigboard.h
@@ -181,6 +181,9 @@ extern struct _spi_bdev_t spi_bdev2;
 #define MICROPY_HW_SDCARD_DETECT_PRESENT    (GPIO_PIN_RESET)
 #define MICROPY_HW_SDCARD_MOUNT_AT_BOOT     (0)
 
+// MM card: the size is hard-coded to support the WBUS-EMMC add-on
+#define MICROPY_HW_MMCARD_LOG_BLOCK_NBR     (7469056 + 2048)
+
 // USB config
 #define MICROPY_HW_USB_FS           (1)
 #define MICROPY_HW_USB_HS           (1)

--- a/ports/stm32/boards/stm32l4xx_hal_conf_base.h
+++ b/ports/stm32/boards/stm32l4xx_hal_conf_base.h
@@ -26,10 +26,13 @@
 #ifndef MICROPY_INCLUDED_STM32L4XX_HAL_CONF_BASE_H
 #define MICROPY_INCLUDED_STM32L4XX_HAL_CONF_BASE_H
 
+// Needs to be defined before ll_usb.h is included
+#define HAL_PCD_MODULE_ENABLED
+
 // Include various HAL modules for convenience
 #include "stm32l4xx_hal_dma.h"
 #include "stm32l4xx_hal_adc.h"
-#include "stm32l4xx_hal_can.h"
+#include "Legacy/stm32l4xx_hal_can_legacy.h"
 #include "stm32l4xx_hal_cortex.h"
 #include "stm32l4xx_hal_crc.h"
 #include "stm32l4xx_hal_dac.h"
@@ -54,11 +57,12 @@
 #include "stm32l4xx_ll_lpuart.h"
 #include "stm32l4xx_ll_rtc.h"
 #include "stm32l4xx_ll_usart.h"
+#include "stm32l4xx_ll_usb.h"
 
 // Enable various HAL modules
 #define HAL_MODULE_ENABLED
 #define HAL_ADC_MODULE_ENABLED
-#define HAL_CAN_MODULE_ENABLED
+#define HAL_CAN_LEGACY_MODULE_ENABLED
 #define HAL_CORTEX_MODULE_ENABLED
 #define HAL_CRC_MODULE_ENABLED
 #define HAL_DAC_MODULE_ENABLED
@@ -70,7 +74,6 @@
 #define HAL_HCD_MODULE_ENABLED
 #define HAL_I2C_MODULE_ENABLED
 #define HAL_IWDG_MODULE_ENABLED
-#define HAL_PCD_MODULE_ENABLED
 #define HAL_PWR_MODULE_ENABLED
 #define HAL_RCC_MODULE_ENABLED
 #define HAL_RTC_MODULE_ENABLED

--- a/ports/stm32/machine_adc.c
+++ b/ports/stm32/machine_adc.c
@@ -34,10 +34,12 @@
 #define ADC_V2 (0)
 #endif
 
-#if defined(STM32F4) || defined(STM32L4)
+#if defined(STM32F4)
 #define ADCx_COMMON ADC_COMMON_REGISTER(0)
 #elif defined(STM32F7)
 #define ADCx_COMMON ADC123_COMMON
+#elif defined(STM32L4)
+#define ADCx_COMMON __LL_ADC_COMMON_INSTANCE(0)
 #endif
 
 #if defined(STM32F0) || defined(STM32L0)

--- a/ports/stm32/main.c
+++ b/ports/stm32/main.c
@@ -419,7 +419,7 @@ void stm32_main(uint32_t reset_mode) {
     #if MICROPY_PY_PYB_LEGACY && MICROPY_HW_ENABLE_HW_I2C
     i2c_init0();
     #endif
-    #if MICROPY_HW_ENABLE_SDCARD
+    #if MICROPY_HW_ENABLE_SDCARD || MICROPY_HW_ENABLE_MMCARD
     sdcard_init();
     #endif
     #if MICROPY_HW_ENABLE_STORAGE

--- a/ports/stm32/mphalport.h
+++ b/ports/stm32/mphalport.h
@@ -2,21 +2,25 @@
 #include STM32_HAL_H
 #include "pin.h"
 
-// F0-1.9.0+F4-1.16.0+F7-1.7.0+H7-1.6.0+L0-1.11.2+L4-1.8.1+WB-1.10.0
+// F0-1.9.0+F4-1.16.0+F7-1.7.0+G4-1.3.0+H7-1.6.0+L0-1.11.2+L4-1.17.0+WB-1.10.0+WL-1.1.0
 #if defined(STM32F0)
 #define MICROPY_PLATFORM_VERSION "HAL1.9.0"
 #elif defined(STM32F4)
 #define MICROPY_PLATFORM_VERSION "HAL1.16.0"
 #elif defined(STM32F7)
 #define MICROPY_PLATFORM_VERSION "HAL1.7.0"
+#elif defined(STM32G4)
+#define MICROPY_PLATFORM_VERSION "HAL1.3.0"
 #elif defined(STM32H7)
 #define MICROPY_PLATFORM_VERSION "HAL1.6.0"
 #elif defined(STM32L0)
 #define MICROPY_PLATFORM_VERSION "HAL1.11.2"
 #elif defined(STM32L4)
-#define MICROPY_PLATFORM_VERSION "HAL1.8.1"
+#define MICROPY_PLATFORM_VERSION "HAL1.17.0"
 #elif defined(STM32WB)
 #define MICROPY_PLATFORM_VERSION "HAL1.10.0"
+#elif defined(STM32WL)
+#define MICROPY_PLATFORM_VERSION "HAL1.1.0"
 #endif
 
 extern const unsigned char mp_hal_status_to_errno_table[4];

--- a/ports/stm32/sdcard.c
+++ b/ports/stm32/sdcard.c
@@ -309,8 +309,12 @@ STATIC HAL_StatusTypeDef sdmmc_init_mmc(void) {
         return status;
     }
 
-    // As this is an eMMC card, overwrite LogBlockNbr with actual value
-    sdmmc_handle.mmc.MmcCard.LogBlockNbr = 7469056 + 2048;
+    #ifdef MICROPY_HW_MMCARD_LOG_BLOCK_NBR
+    // A board can override the number of logical blocks (card capacity) if needed.
+    // This is needed when a card is high capacity because the extended CSD command
+    // is not supported by the current version of the HAL.
+    sdmmc_handle.mmc.MmcCard.LogBlockNbr = MICROPY_HW_MMCARD_LOG_BLOCK_NBR;
+    #endif
 
     #if MICROPY_HW_SDCARD_BUS_WIDTH >= 4
     // Configure the SDIO bus width for 4/8-bit wide operation

--- a/ports/stm32/sdcard.c
+++ b/ports/stm32/sdcard.c
@@ -60,6 +60,10 @@
 #define STATIC_AF_SDCARD_D1 STATIC_AF_SDMMC2_D1
 #define STATIC_AF_SDCARD_D2 STATIC_AF_SDMMC2_D2
 #define STATIC_AF_SDCARD_D3 STATIC_AF_SDMMC2_D3
+#define STATIC_AF_SDCARD_D4 STATIC_AF_SDMMC2_D4
+#define STATIC_AF_SDCARD_D5 STATIC_AF_SDMMC2_D5
+#define STATIC_AF_SDCARD_D6 STATIC_AF_SDMMC2_D6
+#define STATIC_AF_SDCARD_D7 STATIC_AF_SDMMC2_D7
 #else
 #define SDIO SDMMC1
 #define SDMMC_IRQHandler SDMMC1_IRQHandler
@@ -75,6 +79,10 @@
 #define STATIC_AF_SDCARD_D1 STATIC_AF_SDMMC1_D1
 #define STATIC_AF_SDCARD_D2 STATIC_AF_SDMMC1_D2
 #define STATIC_AF_SDCARD_D3 STATIC_AF_SDMMC1_D3
+#define STATIC_AF_SDCARD_D4 STATIC_AF_SDMMC1_D4
+#define STATIC_AF_SDCARD_D5 STATIC_AF_SDMMC1_D5
+#define STATIC_AF_SDCARD_D6 STATIC_AF_SDMMC1_D6
+#define STATIC_AF_SDCARD_D7 STATIC_AF_SDMMC1_D7
 #endif
 
 // The F7 & L4 series calls the peripheral SDMMC rather than SDIO, so provide some
@@ -120,6 +128,10 @@
 #define STATIC_AF_SDCARD_D1 STATIC_AF_SDIO_D1
 #define STATIC_AF_SDCARD_D2 STATIC_AF_SDIO_D2
 #define STATIC_AF_SDCARD_D3 STATIC_AF_SDIO_D3
+#define STATIC_AF_SDCARD_D4 STATIC_AF_SDIO_D4
+#define STATIC_AF_SDCARD_D5 STATIC_AF_SDIO_D5
+#define STATIC_AF_SDCARD_D6 STATIC_AF_SDIO_D6
+#define STATIC_AF_SDCARD_D7 STATIC_AF_SDIO_D7
 
 #endif
 
@@ -131,6 +143,13 @@
 #define MICROPY_HW_SDCARD_D3 (pin_C11)
 #define MICROPY_HW_SDCARD_CK (pin_C12)
 #define MICROPY_HW_SDCARD_CMD (pin_D2)
+#endif
+
+// Define a constant to select the bus width.
+#if MICROPY_HW_SDCARD_BUS_WIDTH == 4
+#define SDIO_BUS_WIDE_VALUE SDIO_BUS_WIDE_4B
+#elif MICROPY_HW_SDCARD_BUS_WIDTH == 8
+#define SDIO_BUS_WIDE_VALUE SDIO_BUS_WIDE_8B
 #endif
 
 #define PYB_SDMMC_FLAG_SD       (0x01)
@@ -162,10 +181,16 @@ void sdcard_init(void) {
     mp_hal_pin_config_alt_static(MICROPY_HW_SDCARD_CK, MP_HAL_PIN_MODE_ALT, MP_HAL_PIN_PULL_UP, STATIC_AF_SDCARD_CK);
     mp_hal_pin_config_alt_static(MICROPY_HW_SDCARD_CMD, MP_HAL_PIN_MODE_ALT, MP_HAL_PIN_PULL_UP, STATIC_AF_SDCARD_CMD);
     mp_hal_pin_config_alt_static(MICROPY_HW_SDCARD_D0, MP_HAL_PIN_MODE_ALT, MP_HAL_PIN_PULL_UP, STATIC_AF_SDCARD_D0);
-    #if MICROPY_HW_SDCARD_BUS_WIDTH == 4
+    #if MICROPY_HW_SDCARD_BUS_WIDTH >= 4
     mp_hal_pin_config_alt_static(MICROPY_HW_SDCARD_D1, MP_HAL_PIN_MODE_ALT, MP_HAL_PIN_PULL_UP, STATIC_AF_SDCARD_D1);
     mp_hal_pin_config_alt_static(MICROPY_HW_SDCARD_D2, MP_HAL_PIN_MODE_ALT, MP_HAL_PIN_PULL_UP, STATIC_AF_SDCARD_D2);
     mp_hal_pin_config_alt_static(MICROPY_HW_SDCARD_D3, MP_HAL_PIN_MODE_ALT, MP_HAL_PIN_PULL_UP, STATIC_AF_SDCARD_D3);
+    #if MICROPY_HW_SDCARD_BUS_WIDTH == 8
+    mp_hal_pin_config_alt_static(MICROPY_HW_SDCARD_D4, MP_HAL_PIN_MODE_ALT, MP_HAL_PIN_PULL_UP, STATIC_AF_SDCARD_D4);
+    mp_hal_pin_config_alt_static(MICROPY_HW_SDCARD_D5, MP_HAL_PIN_MODE_ALT, MP_HAL_PIN_PULL_UP, STATIC_AF_SDCARD_D5);
+    mp_hal_pin_config_alt_static(MICROPY_HW_SDCARD_D6, MP_HAL_PIN_MODE_ALT, MP_HAL_PIN_PULL_UP, STATIC_AF_SDCARD_D6);
+    mp_hal_pin_config_alt_static(MICROPY_HW_SDCARD_D7, MP_HAL_PIN_MODE_ALT, MP_HAL_PIN_PULL_UP, STATIC_AF_SDCARD_D7);
+    #endif
     #endif
 
     // configure the SD card detect pin
@@ -252,9 +277,9 @@ STATIC HAL_StatusTypeDef sdmmc_init_sd(void) {
         mp_hal_delay_ms(50);
     }
 
-    #if MICROPY_HW_SDCARD_BUS_WIDTH == 4
-    // configure the SD bus width for 4-bit wide operation
-    status = HAL_SD_ConfigWideBusOperation(&sdmmc_handle.sd, SDIO_BUS_WIDE_4B);
+    #if MICROPY_HW_SDCARD_BUS_WIDTH >= 4
+    // configure the SD bus width for 4/8-bit wide operation
+    status = HAL_SD_ConfigWideBusOperation(&sdmmc_handle.sd, SDIO_BUS_WIDE_VALUE);
     if (status != HAL_OK) {
         HAL_SD_DeInit(&sdmmc_handle.sd);
         return status;
@@ -287,12 +312,12 @@ STATIC HAL_StatusTypeDef sdmmc_init_mmc(void) {
     // As this is an eMMC card, overwrite LogBlockNbr with actual value
     sdmmc_handle.mmc.MmcCard.LogBlockNbr = 7469056 + 2048;
 
-    #if MICROPY_HW_SDCARD_BUS_WIDTH == 4
-    // Configure the SDIO bus width for 4-bit wide operation
+    #if MICROPY_HW_SDCARD_BUS_WIDTH >= 4
+    // Configure the SDIO bus width for 4/8-bit wide operation
     #ifdef STM32F7
     sdmmc_handle.mmc.Init.ClockBypass = SDIO_CLOCK_BYPASS_ENABLE;
     #endif
-    status = HAL_MMC_ConfigWideBusOperation(&sdmmc_handle.mmc, SDIO_BUS_WIDE_4B);
+    status = HAL_MMC_ConfigWideBusOperation(&sdmmc_handle.mmc, SDIO_BUS_WIDE_VALUE);
     if (status != HAL_OK) {
         HAL_MMC_DeInit(&sdmmc_handle.mmc);
         return status;

--- a/ports/stm32/stm32_it.c
+++ b/ports/stm32/stm32_it.c
@@ -395,7 +395,9 @@ void OTG_FS_WKUP_IRQHandler(void) {
 
     OTG_CMD_WKUP_Handler(&pcd_fs_handle);
 
-    #if !defined(STM32H7)
+    #if defined(STM32L4)
+    EXTI->PR1 = USB_OTG_FS_WAKEUP_EXTI_LINE;
+    #elif !defined(STM32H7)
     /* Clear EXTI pending Bit*/
     __HAL_USB_FS_EXTI_CLEAR_FLAG();
     #endif


### PR DESCRIPTION
Changes in this new stm32lib version are:
- Update L4 HAL to v1.17.0.
- Add G4 HAL at v1.3.0.
- Add WL HAL at v1.1.0.
- Fix F4 UART and DMA data loss with RX hardware flow control.
- Optimise USB to pass config struct by reference.
- Fix bug in F4 MMC HAL_MMC_Erase function.
- Fix bug setting MMC relative address in F4 and F7 HAL.

Also adds support for 8-bit wide SDMMC buses.