### PR TITLE
py\obj.c: Get 64-bit integer arg.

### DIFF
--- a/py/obj.h
+++ b/py/obj.h
@@ -1036,6 +1036,7 @@ static inline bool mp_obj_is_integer(mp_const_obj_t o) {
     return mp_obj_is_int(o) || mp_obj_is_bool(o);
 }
 
+int64_t mp_obj_get_ll_int(mp_obj_t arg);
 mp_int_t mp_obj_get_int(mp_const_obj_t arg);
 mp_int_t mp_obj_get_int_truncated(mp_const_obj_t arg);
 bool mp_obj_get_int_maybe(mp_const_obj_t arg, mp_int_t *value);


### PR DESCRIPTION
Add **int64_t mp_obj_get_ll_int(mp_obj_t arg_in)** function.

It's a pair to the **mp_obj_t mp_obj_new_int_from_ll(long long val)**

It uses in the 
ESP32: New hardware PCNT Counter() and Encoder(). #6639

