### PR TITLE
stm32/boards: Fix typo in OLIMEX H407 board.

### DIFF
--- a/ports/stm32/boards/OLIMEX_H407/board.json
+++ b/ports/stm32/boards/OLIMEX_H407/board.json
@@ -6,7 +6,7 @@
     "features": [],
     "images": [],
     "mcu": "stm32f4",
-    "product": "E407",
+    "product": "H407",
     "thumbnail": "",
     "url": "",
     "vendor": "OLIMEX"


### PR DESCRIPTION
Appears incorrectly as E407 in download manager