### PR TITLE
Add flag MICROPY_HW_FLASH_DQS

### DIFF
--- a/ports/mimxrt/hal/qspi_nor_flash_config.c
+++ b/ports/mimxrt/hal/qspi_nor_flash_config.c
@@ -29,7 +29,11 @@ const flexspi_nor_config_t qspiflash_config = {
     {
         .tag = FLEXSPI_CFG_BLK_TAG,
         .version = FLEXSPI_CFG_BLK_VERSION,
+#if defined(MICROPY_HW_FLASH_DQS)
+		.readSampleClkSrc = MICROPY_HW_FLASH_DQS,
+#elif
         .readSampleClkSrc = kFlexSPIReadSampleClk_LoopbackFromDqsPad,
+#endif
         .csHoldTime = 3u,
         .csSetupTime = 3u,
         .busyOffset = FLASH_BUSY_STATUS_OFFSET,         // Status bit 0 indicates busy.


### PR DESCRIPTION
Add flag MICROPY_HW_FLASH_DQS in mpconfigboard.mk, values as defined in FlexSPI Read Sample Clock Source definition 
example:
MICROPY_HW_FLASH_DQS = kFlexSPIReadSampleClk_LoopbackInternally