### PR TITLE
stm32/factoryreset.c: Init vfs flags before calling pyb_flash_init_vfs.

### DIFF
--- a/ports/stm32/factoryreset.c
+++ b/ports/stm32/factoryreset.c
@@ -109,6 +109,7 @@ MP_WEAK int factory_reset_create_filesystem(void) {
     uint32_t start_tick = HAL_GetTick();
 
     fs_user_mount_t vfs;
+    vfs.blockdev.flags = 0;
     pyb_flash_init_vfs(&vfs);
     uint8_t working_buf[FF_MAX_SS];
     FRESULT res = f_mkfs(&vfs.fatfs, FM_FAT, 0, working_buf, sizeof(working_buf));


### PR DESCRIPTION
* vfs->blockdev.flags could have any random value from stack.
```C
void pyb_flash_init_vfs(fs_user_mount_t *vfs) {
    vfs->base.type = &mp_fat_vfs_type;
    vfs->blockdev.flags |= MP_BLOCKDEV_FLAG_NATIVE | MP_BLOCKDEV_FLAG_HAVE_IOCTL;
    vfs->fatfs.drv = vfs;
```