### PR TITLE
Move .frozen to second entry in sys.path

### DIFF
--- a/ports/unix/main.c
+++ b/ports/unix/main.c
@@ -497,7 +497,7 @@ MP_NOINLINE int main_(int argc, char **argv) {
     if (path == NULL) {
         path = MICROPY_PY_SYS_PATH_DEFAULT;
     }
-    size_t path_num = 2; // [0] is frozen, [1] is for current dir (or base dir of the script)
+    size_t path_num = 1; // [0] is for current dir (or base dir of the script)
     if (*path == PATHLIST_SEP_CHAR) {
         path_num++;
     }
@@ -510,11 +510,10 @@ MP_NOINLINE int main_(int argc, char **argv) {
     mp_obj_list_init(MP_OBJ_TO_PTR(mp_sys_path), path_num);
     mp_obj_t *path_items;
     mp_obj_list_get(mp_sys_path, &path_num, &path_items);
-    path_items[0] = MP_OBJ_NEW_QSTR(MP_QSTR__dot_frozen);
-    path_items[1] = MP_OBJ_NEW_QSTR(MP_QSTR_);
+    path_items[0] = MP_OBJ_NEW_QSTR(MP_QSTR_);
     {
         char *p = path;
-        for (mp_uint_t i = 2; i < path_num; i++) {
+        for (mp_uint_t i = 1; i < path_num; i++) {
             char *p1 = strchr(p, PATHLIST_SEP_CHAR);
             if (p1 == NULL) {
                 p1 = p + strlen(p);
@@ -655,9 +654,9 @@ MP_NOINLINE int main_(int argc, char **argv) {
                 break;
             }
 
-            // Set base dir of the script as second entry in sys.path.
+            // Set base dir of the script as first entry in sys.path.
             char *p = strrchr(basedir, '/');
-            path_items[1] = mp_obj_new_str_via_qstr(basedir, p - basedir);
+            path_items[0] = mp_obj_new_str_via_qstr(basedir, p - basedir);
             free(pathbuf);
 
             set_sys_argv(argv, argc, a);

--- a/ports/unix/mpconfigport.h
+++ b/ports/unix/mpconfigport.h
@@ -125,7 +125,7 @@
 #endif
 #endif
 #ifndef MICROPY_PY_SYS_PATH_DEFAULT
-#define MICROPY_PY_SYS_PATH_DEFAULT "~/.micropython/lib:/usr/lib/micropython"
+#define MICROPY_PY_SYS_PATH_DEFAULT ".frozen:~/.micropython/lib:/usr/lib/micropython"
 #endif
 #define MICROPY_PY_SYS_MAXSIZE      (1)
 #define MICROPY_PY_SYS_STDFILES     (1)

--- a/ports/unix/variants/minimal/mpconfigvariant.h
+++ b/ports/unix/variants/minimal/mpconfigvariant.h
@@ -89,7 +89,7 @@
 #define MICROPY_PY_SYS_EXIT         (0)
 #define MICROPY_PY_SYS_PLATFORM     "linux"
 #ifndef MICROPY_PY_SYS_PATH_DEFAULT
-#define MICROPY_PY_SYS_PATH_DEFAULT "~/.micropython/lib:/usr/lib/micropython"
+#define MICROPY_PY_SYS_PATH_DEFAULT ".frozen:~/.micropython/lib:/usr/lib/micropython"
 #endif
 #define MICROPY_PY_SYS_MAXSIZE      (0)
 #define MICROPY_PY_SYS_STDFILES     (0)

--- a/ports/windows/mpconfigport.h
+++ b/ports/windows/mpconfigport.h
@@ -90,7 +90,7 @@
 #define MICROPY_PY_SYS_ATEXIT       (1)
 #define MICROPY_PY_SYS_PLATFORM     "win32"
 #ifndef MICROPY_PY_SYS_PATH_DEFAULT
-#define MICROPY_PY_SYS_PATH_DEFAULT "~/.micropython/lib"
+#define MICROPY_PY_SYS_PATH_DEFAULT ".frozen;~/.micropython/lib"
 #endif
 #define MICROPY_PY_SYS_MAXSIZE      (1)
 #define MICROPY_PY_SYS_STDFILES     (1)

--- a/py/runtime.c
+++ b/py/runtime.c
@@ -124,10 +124,10 @@ void mp_init(void) {
 
     #if MICROPY_PY_SYS_PATH_ARGV_DEFAULTS
     mp_obj_list_init(MP_OBJ_TO_PTR(mp_sys_path), 0);
+    mp_obj_list_append(mp_sys_path, MP_OBJ_NEW_QSTR(MP_QSTR_)); // current dir (or base dir of the script)
     #if MICROPY_MODULE_FROZEN
     mp_obj_list_append(mp_sys_path, MP_OBJ_NEW_QSTR(MP_QSTR__dot_frozen));
     #endif
-    mp_obj_list_append(mp_sys_path, MP_OBJ_NEW_QSTR(MP_QSTR_)); // current dir (or base dir of the script)
     mp_obj_list_init(MP_OBJ_TO_PTR(mp_sys_argv), 0);
     #endif
 

--- a/tests/basics/sys_path.py
+++ b/tests/basics/sys_path.py
@@ -1,0 +1,16 @@
+# test sys.path
+
+try:
+    import usys as sys
+except ImportError:
+    import sys
+
+# check that this script was executed from a file of the same name
+if "__file__" not in globals() or "sys_path.py" not in __file__:
+    print("SKIP")
+    raise SystemExit
+
+# test that sys.path[0] is the directory containing this script
+with open(sys.path[0] + "/sys_path.py") as f:
+    for _ in range(4):
+        print(f.readline())

--- a/tests/run-tests.py
+++ b/tests/run-tests.py
@@ -852,7 +852,7 @@ the last matching regex is used:
 
     if not args.keep_path:
         # clear search path to make sure tests use only builtin modules and those in extmod
-        os.environ["MICROPYPATH"] = os.pathsep + base_path("../extmod")
+        os.environ["MICROPYPATH"] = ".frozen" + os.pathsep + base_path("../extmod")
 
     try:
         os.makedirs(args.result_dir, exist_ok=True)

--- a/tools/upip.py
+++ b/tools/upip.py
@@ -262,6 +262,8 @@ def get_install_path():
     if install_path is None:
         # sys.path[0] is current module's path
         install_path = sys.path[1]
+        if install_path == ".frozen":
+            install_path = sys.path[2]
     install_path = expandhome(install_path)
     return install_path
 
@@ -281,11 +283,11 @@ upip - Simple PyPI package manager for MicroPython
 Usage: micropython -m upip install [-p <path>] <package>... | -r <requirements.txt>
 import upip; upip.install(package_or_list, [<path>])
 
-If <path> is not given, packages will be installed into sys.path[1]
-(can be set from MICROPYPATH environment variable, if current system
-supports that)."""
+If <path> isn't given, packages will be installed to sys.path[1], or
+sys.path[2] if the former is .frozen (path can be set from MICROPYPATH
+environment variable if supported)."""
     )
-    print("Current value of sys.path[1]:", sys.path[1])
+    print("Default install path:", get_install_path())
     print(
         """\
 


### PR DESCRIPTION
The recent change to allow a `".frozen"` entry in `sys.path` to specify the frozen module search order (see #8079) placed this entry at the start of `sys.path`.  This is against the CPython standard/docs/behaviour which requires `sys.path[0]` to be the location of the current script (or `''` if that can't be determined, like at a REPL).

Some scripts will use `sys.path[0]` to find out where they are run from.  And eg `upip` is now broken with `".frozen"` as the first entry.

The reason `".frozen"` was put first was to keep the same behaviour as before for searching frozen modules, namely that frozen code is searched before the filesystem (frozen code was previously searched when `""` was encountered in `sys.path`).  But this behaviour will need to change because it's more important to have `sys.path[0]` being the current script's directory (or the empty string).

This PR does the following:
- moves `".frozen"` to the second entry in `sys.path`
- makes `".frozen"` part of `MICROPY_PY_SYS_PATH_DEFAULT` on the unix and windows ports, so it can be overridden/changed by use of the `MICROPYPATH` environment variable
- adds code to `upip` to skip `".frozen"` because it doesn't make sense to install to `.frozen`

See related #7536.