### PR TITLE
esp32/machine_pin.c: Allow small int argument in machine_pin_get_id().

### DIFF
--- a/ports/esp32/machine_pin.c
+++ b/ports/esp32/machine_pin.c
@@ -243,8 +243,10 @@ STATIC void machine_pin_isr_handler(void *arg) {
 STATIC const machine_pin_obj_t *find_pin_obj(int wanted_pin) {
     // get the wanted pin object
     const machine_pin_obj_t *self = NULL;
-    if (0 <= wanted_pin && wanted_pin < MP_ARRAY_SIZE(machine_pin_obj)) {
-        self = (machine_pin_obj_t *)&machine_pin_obj[wanted_pin];
+    if (GPIO_IS_VALID_GPIO(wanted_pin)) {
+        if (0 <= wanted_pin && wanted_pin < MP_ARRAY_SIZE(machine_pin_obj)) {
+            self = (machine_pin_obj_t *)&machine_pin_obj[wanted_pin];
+        }
     }
     if (self == NULL || self->base.type == NULL) {
         mp_raise_ValueError(MP_ERROR_TEXT("invalid pin"));


### PR DESCRIPTION
pwm = PWM(Pin(4)) will equal to  pwm = PWM(4)
enc = Encoder(5, phase_a=Pin(26), phase_b=Pin(25)) will equal to enc = Encoder(5, phase_a=26, phase_b=25)

Inspired by **esp32/machine_sdcard.c: Invalid pin numbers are allowwed.** #8112
Wil be use **ESP32: New hardware PCNT Counter() and Encoder().** #6639


