### PR TITLE
Fix bug encountered in py/qstr.c

### DIFF
--- a/py/qstr.c
+++ b/py/qstr.c
@@ -154,6 +154,13 @@ STATIC qstr qstr_add(const byte *q_ptr) {
         qstr_pool_t *pool = m_new_obj_var_maybe(qstr_pool_t, const char *, new_alloc);
         if (pool == NULL) {
             QSTR_EXIT();
+            /* Keep qstr_last_chunk consistent with qstr_pool_t:
+             * qstr_last_chunk is not scanned at garbage collection
+             * since it's also stored in qstr_pool_t. If qstr_pool_t
+             * allocation failed, qstr_last_chunk needs to be
+             * nullified. Otherwise, it would become a dangling pointer
+             * at the next garbage collection. */
+            MP_STATE_VM(qstr_last_chunk) = NULL;
             m_malloc_fail(new_alloc);
         }
         pool->prev = MP_STATE_VM(last_pool);


### PR DESCRIPTION
The qstr_last_chunk is not collected by the garbage collector. This relies on the assertion that qstr_pool_t also references the qstr_last_chunk. If an exception is raised while allocating the qstr_pool_t, qstr_last_chunk has to be invalidated not to become a dangling reference at the next garbage collection.