### PR TITLE
esp32/machine_bitstream.c: Fix signal duplication on output pins.

### DIFF
--- a/ports/esp32/machine_bitstream.c
+++ b/ports/esp32/machine_bitstream.c
@@ -133,6 +133,8 @@ void machine_bitstream_high_low(mp_hal_pin_obj_t pin, uint32_t *timing_ns, const
 
     // Uninstall the driver.
     check_esp_err(rmt_driver_uninstall(config.channel));
+    // Cancel RMT output to GPIO pin
+    gpio_matrix_out(pin, SIG_GPIO_OUT_IDX, false, false);
 }
 
 #endif // MICROPY_PY_MACHINE_BITSTREAM


### PR DESCRIPTION
After changing the bitstream implementation to use the RMT driver in commit
72d86158121e32bbabaeade08f449d507bf40f9a ("esp32/machine_bitstream.c:
Replace with RMT-based driver."), using multiple `Neopixel` instances shows
signal duplication between the instances (i.e.  a `write()` on one instance
is written to all instances).

On invocation, the rmt driver configures the GPIO matrix to route the output
signal to the respective GPIO pin.  When called for a different `Neopixel`
instance using a different pin, the new route is established, but the old
route still exists.  Now, the RMT output signal is sent to both pins.

Fix this by setting the standard GPIO output function for the current
pin after uninstalling the RMT driver.