### PR TITLE
zephyr: Upgrade to Zephyr v2.7.0.

### DIFF
--- a/docs/zephyr/tutorial/repl.rst
+++ b/docs/zephyr/tutorial/repl.rst
@@ -31,8 +31,8 @@ With your serial program open (PuTTY, screen, picocom, etc) you may see a
 blank screen with a flashing cursor. Press Enter (or reset the board) and
 you should be presented with the following text::
 
-        *** Booting Zephyr OS build v2.6.0-rc1-416-g3056c5ec30ad  ***
-        MicroPython v2.6.0-rc1-416-g3056c5ec30 on 2021-06-24; zephyr-frdm_k64f with mk64f12
+        *** Booting Zephyr OS build zephyr-v2.7.0  ***
+        MicroPython v1.17-288-gb695f5a70-dirty on 2022-01-03; zephyr-frdm_k64f with mk64f12
         Type "help()" for more information.
         >>>
 

--- a/ports/zephyr/CMakeLists.txt
+++ b/ports/zephyr/CMakeLists.txt
@@ -22,7 +22,7 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
 
-cmake_minimum_required(VERSION 3.13.1)
+cmake_minimum_required(VERSION 3.20.0)
 
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(micropython)

--- a/ports/zephyr/README.md
+++ b/ports/zephyr/README.md
@@ -4,7 +4,7 @@ MicroPython port to Zephyr RTOS
 This is a work-in-progress port of MicroPython to Zephyr RTOS
 (http://zephyrproject.org).
 
-This port requires Zephyr version v2.6.0, and may also work on higher
+This port requires Zephyr version v2.7.0, and may also work on higher
 versions.  All boards supported
 by Zephyr (with standard level of features support, like UART console)
 should work with MicroPython (but not all were tested).
@@ -39,13 +39,13 @@ setup is correct.
 If you already have Zephyr installed but are having issues building the
 MicroPython port then try installing the correct version of Zephyr via:
 
-    $ west init zephyrproject -m https://github.com/zephyrproject-rtos/zephyr --mr v2.6.0
+    $ west init zephyrproject -m https://github.com/zephyrproject-rtos/zephyr --mr v2.7.0
 
 Alternatively, you don't have to redo the Zephyr installation to just
 switch from master to a tagged release, you can instead do:
 
     $ cd zephyrproject/zephyr
-    $ git checkout v2.6.0
+    $ git checkout v2.7.0
     $ west update
 
 With Zephyr installed you may then need to configure your environment,

--- a/ports/zephyr/boards/mimxrt1050_evk.conf
+++ b/ports/zephyr/boards/mimxrt1050_evk.conf
@@ -1,7 +1,6 @@
 # Required for zephyr.DiskAccess block devices
 CONFIG_DISK_ACCESS=y
 
-CONFIG_USB=y
 CONFIG_USB_DEVICE_STACK=y
 CONFIG_USB_DEVICE_PRODUCT="Zephyr MicroPython"
 CONFIG_USB_MASS_STORAGE=y

--- a/ports/zephyr/main.c
+++ b/ports/zephyr/main.c
@@ -34,7 +34,7 @@
 #include <net/net_context.h>
 #endif
 
-#ifdef CONFIG_USB
+#ifdef CONFIG_USB_DEVICE_STACK
 #include <usb/usb_device.h>
 #endif
 
@@ -140,7 +140,7 @@ soft_reset:
     #endif
     mp_init();
 
-    #ifdef CONFIG_USB
+    #ifdef CONFIG_USB_DEVICE_STACK
     usb_enable(NULL);
     #endif
 

--- a/ports/zephyr/modmachine.c
+++ b/ports/zephyr/modmachine.c
@@ -28,7 +28,7 @@
 
 #include <stdint.h>
 #include <stdio.h>
-#include <power/reboot.h>
+#include <sys/reboot.h>
 
 #include "py/obj.h"
 #include "py/runtime.h"

--- a/ports/zephyr/uart_core.c
+++ b/ports/zephyr/uart_core.c
@@ -53,10 +53,8 @@ void mp_hal_stdout_tx_strn(const char *str, mp_uint_t len) {
         }
     }
     #else
-    static const struct device *uart_console_dev;
-    if (uart_console_dev == NULL) {
-        uart_console_dev = device_get_binding(CONFIG_UART_CONSOLE_ON_DEV_NAME);
-    }
+    static const struct device *uart_console_dev =
+        DEVICE_DT_GET(DT_CHOSEN(zephyr_console));
 
     while (len--) {
         uart_poll_out(uart_console_dev, *str++);

--- a/tools/ci.sh
+++ b/tools/ci.sh
@@ -605,6 +605,7 @@ function ci_windows_build {
 
 ZEPHYR_DOCKER_VERSION=v0.21.0
 ZEPHYR_SDK_VERSION=0.13.2
+ZEPHYR_VERSION=v2.7.0
 
 function ci_zephyr_setup {
     docker pull zephyrprojectrtos/ci:${ZEPHYR_DOCKER_VERSION}
@@ -619,7 +620,7 @@ function ci_zephyr_setup {
 }
 
 function ci_zephyr_install {
-    docker exec zephyr-ci west init --mr v2.6.0 /zephyrproject
+    docker exec zephyr-ci west init --mr ${ZEPHYR_VERSION} /zephyrproject
     docker exec -w /zephyrproject zephyr-ci west update
     docker exec -w /zephyrproject zephyr-ci west zephyr-export
 }

--- a/tools/ci.sh
+++ b/tools/ci.sh
@@ -603,15 +603,18 @@ function ci_windows_build {
 ########################################################################################
 # ports/zephyr
 
+ZEPHYR_DOCKER_VERSION=v0.21.0
+ZEPHYR_SDK_VERSION=0.13.2
+
 function ci_zephyr_setup {
-    docker pull zephyrprojectrtos/ci:v0.17.3
+    docker pull zephyrprojectrtos/ci:${ZEPHYR_DOCKER_VERSION}
     docker run --name zephyr-ci -d -it \
       -v "$(pwd)":/micropython \
-      -e ZEPHYR_SDK_INSTALL_DIR=/opt/toolchains/zephyr-sdk-0.12.4 \
+      -e ZEPHYR_SDK_INSTALL_DIR=/opt/toolchains/zephyr-sdk-${ZEPHYR_SDK_VERSION} \
       -e ZEPHYR_TOOLCHAIN_VARIANT=zephyr \
       -e ZEPHYR_BASE=/zephyrproject/zephyr \
       -w /micropython/ports/zephyr \
-      zephyrprojectrtos/ci:v0.17.3
+      zephyrprojectrtos/ci:${ZEPHYR_DOCKER_VERSION}
     docker ps -a
 }
 


### PR DESCRIPTION
Updates the Zephyr port build instructions and CI to use the latest
Zephyr release tag.

Signed-off-by: Maureen Helm <maureen.helm@intel.com>