### PR TITLE
Ninaw10 driver fixes

### DIFF
--- a/drivers/ninaw10/nina_wifi_drv.c
+++ b/drivers/ninaw10/nina_wifi_drv.c
@@ -496,16 +496,17 @@ int nina_ifconfig(nina_ifconfig_t *ifconfig, bool set) {
                 ARG_BYTE(3),         // Valid number of args.
                 {ip_len,  ifconfig->ip_addr},
                 {gw_len,  ifconfig->gateway_addr},
-                {sub_len, ifconfig->subnet_addr})) != SPI_ACK) {
+                {sub_len, ifconfig->subnet_addr})) != 0) {
             return -1;
         }
 
+        uint8_t dns2[4] = {8, 8, 8, 8};
         if (nina_send_command_read_ack(NINA_CMD_SET_DNS_CONFIG,
             3, ARG_8BITS,
             NINA_ARGS(
                 ARG_BYTE(1),         // Valid number of args.
                 {dns_len, ifconfig->dns_addr},
-                {dns_len, ifconfig->dns_addr})) != SPI_ACK) {
+                {dns_len, dns2})) != SPI_ACK) {
             return -1;
         }
 

--- a/extmod/network_ninaw10.c
+++ b/extmod/network_ninaw10.c
@@ -173,6 +173,11 @@ STATIC mp_obj_t network_ninaw10_connect(mp_uint_t n_args, const mp_obj_t *pos_ar
         mp_raise_msg(&mp_type_OSError, MP_ERROR_TEXT("Key can't be empty!"));
     }
 
+    // Disconnect active connections first.
+    if (nina_isconnected()) {
+        nina_disconnect();
+    }
+
     if (self->itf == MOD_NETWORK_STA_IF) {
         // Initialize WiFi in Station mode.
         if (nina_connect(ssid, security, key, 0) != 0) {

--- a/extmod/network_ninaw10.c
+++ b/extmod/network_ninaw10.c
@@ -58,25 +58,20 @@ typedef struct _nina_obj_t {
 
 static uint16_t bind_port = BIND_PORT_RANGE_MIN;
 const mod_network_nic_type_t mod_network_nic_type_nina;
-static nina_obj_t nina_obj = {{(mp_obj_type_t *)&mod_network_nic_type_nina}, false, MOD_NETWORK_STA_IF};
+static nina_obj_t network_nina_wl_sta = {{(mp_obj_type_t *)&mod_network_nic_type_nina}, false, MOD_NETWORK_STA_IF};
+static nina_obj_t network_nina_wl_ap = {{(mp_obj_type_t *)&mod_network_nic_type_nina}, false, MOD_NETWORK_AP_IF};
 
 STATIC mp_obj_t network_ninaw10_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *args) {
     mp_arg_check_num(n_args, n_kw, 0, 1, false);
-
-    nina_obj.active = false;
-    if (n_args == 0) {
-        nina_obj.itf = MOD_NETWORK_STA_IF;
+    mp_obj_t nina_obj;
+    if (n_args == 0 || mp_obj_get_int(args[0]) == MOD_NETWORK_STA_IF) {
+        nina_obj = MP_OBJ_FROM_PTR(&network_nina_wl_sta);
     } else {
-        nina_obj.itf = mp_obj_get_int(args[0]);
+        nina_obj = MP_OBJ_FROM_PTR(&network_nina_wl_ap);
     }
-
-    // Reset autobind port.
-    bind_port = BIND_PORT_RANGE_MIN;
-
     // Register with network module
-    mod_network_register_nic(MP_OBJ_FROM_PTR(&nina_obj));
-
-    return MP_OBJ_FROM_PTR(&nina_obj);
+    mod_network_register_nic(nina_obj);
+    return nina_obj;
 }
 
 STATIC mp_obj_t network_ninaw10_active(size_t n_args, const mp_obj_t *args) {

--- a/extmod/network_ninaw10.c
+++ b/extmod/network_ninaw10.c
@@ -435,7 +435,7 @@ STATIC mp_uint_t network_ninaw10_socket_send(mod_network_socket_obj_t *socket, c
     if (ret == NINA_ERROR_TIMEOUT) {
         // The socket is Not closed on timeout when calling functions that accept a timeout.
         *_errno = MP_ETIMEDOUT;
-        return 0;
+        return -1;
     } else if (ret < 0) {
         // Close the socket on any other errors.
         *_errno = ret;
@@ -450,7 +450,7 @@ STATIC mp_uint_t network_ninaw10_socket_recv(mod_network_socket_obj_t *socket, b
     if (ret == NINA_ERROR_TIMEOUT) {
         // The socket is Not closed on timeout when calling functions that accept a timeout.
         *_errno = MP_ETIMEDOUT;
-        return 0;
+        return -1;
     } else if (ret < 0) {
         // Close the socket on any other errors.
         *_errno = ret;
@@ -482,7 +482,7 @@ STATIC mp_uint_t network_ninaw10_socket_sendto(mod_network_socket_obj_t *socket,
     if (ret == NINA_ERROR_TIMEOUT) {
         // The socket is Not closed on timeout when calling functions that accept a timeout.
         *_errno = MP_ETIMEDOUT;
-        return 0;
+        return -1;
     } else if (ret < 0) {
         *_errno = ret;
         network_ninaw10_socket_close(socket);
@@ -502,7 +502,7 @@ STATIC mp_uint_t network_ninaw10_socket_recvfrom(mod_network_socket_obj_t *socke
     if (ret == NINA_ERROR_TIMEOUT) {
         // The socket is Not closed on timeout when calling functions that accept a timeout.
         *_errno = MP_ETIMEDOUT;
-        return 0;
+        return -1;
     } else if (ret < 0) {
         // Close the socket on any other errors.
         *_errno = ret;


### PR DESCRIPTION
Following a discussion in #7668 a few small fixes and improvements:

* Allow recv() and recvfrom() to be used interchangeably on TCP/UDP sockets.
* Return -1 on timeout error from recv(), recvfrom(), send() and sendto().
* Make NIC state persistent.
* Disable active connections before connecting/reconnecting.
* Fix manual DNS bug.
* Set secondary DNS server.