### PR TITLE
windows/mpconfigport.h: Allow overriding MICROPY_PORT_BUILTINS.

### DIFF
--- a/py/modbuiltins.c
+++ b/py/modbuiltins.c
@@ -775,6 +775,7 @@ STATIC const mp_rom_map_elem_t mp_module_builtins_globals_table[] = {
 
     // Extra builtins as defined by a port
     MICROPY_PORT_BUILTINS
+    MICROPY_PORT_EXTRA_BUILTINS
 };
 
 MP_DEFINE_CONST_DICT(mp_module_builtins_globals, mp_module_builtins_globals_table);

--- a/py/mpconfig.h
+++ b/py/mpconfig.h
@@ -1581,6 +1581,12 @@ typedef double mp_float_t;
 #define MICROPY_PORT_BUILTINS
 #endif
 
+// Additional builtin function definitions for extension by commandine or variants.
+// See modbuiltins.c:mp_module_builtins_globals_table for format.
+#ifndef MICROPY_PORT_EXTRA_BUILTINS
+#define MICROPY_PORT_EXTRA_BUILTINS
+#endif
+
 // Additional builtin module definitions - see objmodule.c:mp_builtin_module_table for format.
 #ifndef MICROPY_PORT_BUILTIN_MODULES
 #define MICROPY_PORT_BUILTIN_MODULES


### PR DESCRIPTION
I'm trying to convert a custom MicroPython version, which is essentially a bunch of additional definitions in mpconfgport.h and extra source files, into a variant. I need a couple of extra Python exceptions available (`ConnectionError` and `TimeoutError` etc) so until now I did that by adding an extra source file with `MP_DEFINE_EXCEPTION(ConnectionError, OSError)` and then adding `{ MP_ROM_QSTR(MP_QSTR_ConnectionError), MP_ROM_PTR(&mp_type_ConnectionError) }, \` to `MICROPY_PORT_BUILTINS`.

- is there another way to achieve this?
- perhaps better to not force the variant to completely redefine, but instead introduce e.g.

```
#define MICROPY_PORT_BUILTINS \
    { MP_ROM_QSTR(MP_QSTR_open), MP_ROM_PTR(&mp_builtin_open_obj) }, \
    MICROPY_PORT_BUILTINS_EXTRA
```
- should we immediately apply a similar change for MICROPY_PORT_BUILTIN_MODULES as well?
- and apply same changes to the unix port as well?