### PR TITLE
esp32: enable platform module

### DIFF
--- a/extmod/moduplatform.c
+++ b/extmod/moduplatform.c
@@ -44,6 +44,8 @@
 #define PLATFORM_ARCH   "x86_64"
 #elif defined(__i386__) || defined(_M_IX86)
 #define PLATFORM_ARCH   "x86"
+#elif defined(__xtensa__) || defined(_M_IX86)
+#define PLATFORM_ARCH   "xtensa"
 #else
 #define PLATFORM_ARCH   ""
 #endif

--- a/ports/esp32/mpconfigport.h
+++ b/ports/esp32/mpconfigport.h
@@ -195,6 +195,7 @@
 #define MICROPY_PY_FRAMEBUF                 (1)
 #define MICROPY_PY_BTREE                    (1)
 #define MICROPY_PY_ONEWIRE                  (1)
+#define MICROPY_PY_UPLATFORM                (1)
 #define MICROPY_PY_USOCKET_EVENTS           (MICROPY_PY_WEBREPL)
 #define MICROPY_PY_BLUETOOTH_RANDOM_ADDR    (1)
 #define MICROPY_PY_BLUETOOTH_DEFAULT_GAP_NAME ("ESP32")

--- a/ports/esp32/mphalport.h
+++ b/ports/esp32/mphalport.h
@@ -35,6 +35,8 @@
 #include "freertos/FreeRTOS.h"
 #include "freertos/task.h"
 
+#define MICROPY_PLATFORM_VERSION "IDF" IDF_VER
+
 // The core that the MicroPython task(s) are pinned to.
 // Until we move to IDF 4.2+, we need NimBLE on core 0, and for synchronisation
 // with the ringbuffer and scheduler MP needs to be on the same core.


### PR DESCRIPTION
Output looks like this:
    
        >>> import platform
        >>> platform.libc_ver()
        ('newlib', '3.0.0')
        >>> platform.platform()
        'MicroPython-1.17.0-xtensa-IDFv4.2.2-with-newlib3.0.0'
        >>> platform.python_compiler()
        'GCC 8.4.0'
