### PR TITLE
modusocket settimeout on unbound sockets.

### DIFF
--- a/extmod/modusocket.c
+++ b/extmod/modusocket.c
@@ -85,6 +85,13 @@ STATIC void socket_select_nic(mod_network_socket_obj_t *self, const byte *ip) {
         if (self->nic_type->socket(self, &_errno) != 0) {
             mp_raise_OSError(_errno);
         }
+
+        #if MICROPY_PY_USOCKET_EXTENDED_STATE
+        // if a timeout was set before binding a NIC, call settimeout to reset it.
+        if (self->timeout != 0 && self->nic_type->settimeout(self, self->timeout, &_errno) != 0) {
+            mp_raise_OSError(_errno);
+        }
+        #endif
     }
 }
 
@@ -317,10 +324,6 @@ STATIC MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(socket_setsockopt_obj, 4, 4, socket_s
 // otherwise, timeout is in seconds
 STATIC mp_obj_t socket_settimeout(mp_obj_t self_in, mp_obj_t timeout_in) {
     mod_network_socket_obj_t *self = MP_OBJ_TO_PTR(self_in);
-    if (self->nic == MP_OBJ_NULL) {
-        // not connected
-        mp_raise_OSError(MP_ENOTCONN);
-    }
     mp_uint_t timeout;
     if (timeout_in == mp_const_none) {
         timeout = -1;
@@ -331,9 +334,19 @@ STATIC mp_obj_t socket_settimeout(mp_obj_t self_in, mp_obj_t timeout_in) {
         timeout = 1000 * mp_obj_get_int(timeout_in);
         #endif
     }
-    int _errno;
-    if (self->nic_type->settimeout(self, timeout, &_errno) != 0) {
-        mp_raise_OSError(_errno);
+    if (self->nic == MP_OBJ_NULL) {
+        #if MICROPY_PY_USOCKET_EXTENDED_STATE
+        // store the timeout in the socket state until a NIC is bound.
+        self->timeout = timeout;
+        #else
+        // not connected
+        mp_raise_OSError(MP_ENOTCONN);
+        #endif
+    } else {
+        int _errno;
+        if (self->nic_type->settimeout(self, timeout, &_errno) != 0) {
+            mp_raise_OSError(_errno);
+        }
     }
     return mp_const_none;
 }

--- a/extmod/modusocket.c
+++ b/extmod/modusocket.c
@@ -150,6 +150,16 @@ STATIC mp_obj_t socket_accept(mp_obj_t self_in) {
     socket2->base.type = &socket_type;
     socket2->nic = MP_OBJ_NULL;
     socket2->nic_type = NULL;
+    // set the same address family, socket type and protocol as parent.
+    socket2->domain = self->domain;
+    socket2->type = self->type;
+    socket2->proto = self->proto;
+    socket2->bound = false;
+    socket2->fileno = -1;
+    #if MICROPY_PY_USOCKET_EXTENDED_STATE
+    socket2->timeout = 0;
+    socket2->state = NULL;
+    #endif
 
     // accept incoming connection
     uint8_t ip[MOD_NETWORK_IPADDR_BUF_SIZE];

--- a/extmod/network_ninaw10.c
+++ b/extmod/network_ninaw10.c
@@ -350,9 +350,8 @@ STATIC int network_ninaw10_socket_socket(mod_network_socket_obj_t *socket, int *
         return -1;
     }
 
-    // store state of this socket
+    // set socket state
     socket->fileno = fd;
-    socket->timeout = 0; // blocking
     socket->bound = false;
     return 0;
 }
@@ -413,9 +412,8 @@ STATIC int network_ninaw10_socket_accept(mod_network_socket_obj_t *socket,
         return -1;
     }
 
-    // Set default socket timeout.
+    // set socket state
     socket2->fileno = fd;
-    socket2->timeout = 0;
     socket2->bound = false;
     return 0;
 }


### PR DESCRIPTION
* For extended state socket, if `settimeout()` is called before a NIC is bound, save the timeout until the NIC is bound.
* Allow setting timeout on unbound sockets.
* Initialise accepted socket state.
* Use socket timeout preset in modusocket.
