### PR TITLE
unix: Add user-defined hooks in main.c.

### DIFF
--- a/ports/unix/main.c
+++ b/ports/unix/main.c
@@ -76,6 +76,9 @@ const mp_print_t mp_stderr_print = {NULL, stderr_print_strn};
 // and lower 8 bits are SystemExit value. For all other exceptions,
 // return 1.
 STATIC int handle_uncaught_exception(mp_obj_base_t *exc) {
+    // Hook for adding custom unhandled exception code.
+    MICROPY_UNIX_UNCAUGHT_EXCEPTION();
+
     // check for SystemExit
     if (mp_obj_is_subclass_fast(MP_OBJ_FROM_PTR(exc->type), MP_OBJ_FROM_PTR(&mp_type_SystemExit))) {
         // None is an exit value of 0; an int is its value; anything else is 1
@@ -458,6 +461,9 @@ MP_NOINLINE int main_(int argc, char **argv) {
     stack_limit *= 2;
     #endif
     mp_stack_set_limit(stack_limit);
+
+    // Hook for injecting custom code in early init.
+    MICROPY_UNIX_EARLY_INIT();
 
     pre_process_options(argc, argv);
 

--- a/ports/unix/mpconfigport.h
+++ b/ports/unix/mpconfigport.h
@@ -30,6 +30,8 @@
 // Variant-specific definitions.
 #include "mpconfigvariant.h"
 
+#include "mpconfigunix.h"
+
 // The minimal variant's config covers everything.
 // If we're building the minimal variant, ignore the rest of this file.
 #ifndef MICROPY_UNIX_MINIMAL

--- a/ports/unix/mpconfigunix.h
+++ b/ports/unix/mpconfigunix.h
@@ -1,0 +1,12 @@
+
+// Unix port-specific configuration options.
+
+// Hooks for main.c
+
+#ifndef MICROPY_UNIX_EARLY_INIT
+#define MICROPY_UNIX_EARLY_INIT()
+#endif
+
+#ifndef MICROPY_UNIX_UNCAUGHT_EXCEPTION
+#define MICROPY_UNIX_UNCAUGHT_EXCEPTION()
+#endif

--- a/ports/windows/mpconfigport.h
+++ b/ports/windows/mpconfigport.h
@@ -29,6 +29,8 @@
 // Variant-specific definitions.
 #include "mpconfigvariant.h"
 
+#include "../unix/mpconfigunix.h"
+
 // By default use MicroPython version of readline
 #ifndef MICROPY_USE_READLINE
 #define MICROPY_USE_READLINE        (1)


### PR DESCRIPTION
This adds a couple of hooks to the unix port main.c file where it is useful to inject custom variant code. For example, we are using the unhandled exception hook to stop motors when a program crashes.