### PR TITLE
windows/appveyor: Build mpy-cross only once for mingw-w64.

### DIFF
--- a/ports/windows/.appveyor.yml
+++ b/ports/windows/.appveyor.yml
@@ -68,17 +68,16 @@ after_test:
     }
     $env:MSYSTEM = if ($platform -eq 'x86') {'MINGW32'} else {'MINGW64'}
     $env:CHERE_INVOKING = 'enabled_from_arguments'
-    cd (Join-Path $env:APPVEYOR_BUILD_FOLDER 'ports/windows')
-    C:\msys64\usr\bin\bash.exe -l -c "make -B -j4 V=1 VARIANT=$($env:PyVariant)"
-    if ($LASTEXITCODE -ne 0) {
-      throw "$env:MSYSTEM build exited with code $LASTEXITCODE"
-    }
     cd (Join-Path $env:APPVEYOR_BUILD_FOLDER 'mpy-cross')
     C:\msys64\usr\bin\bash.exe -l -c "make -B -j4 V=1"
     if ($LASTEXITCODE -ne 0) {
       throw "$env:MSYSTEM mpy_cross build exited with code $LASTEXITCODE"
     }
     cd (Join-Path $env:APPVEYOR_BUILD_FOLDER 'ports/windows')
+    C:\msys64\usr\bin\bash.exe -l -c "make -B -j4 V=1 MICROPY_MPYCROSS=../../mpy-cross/mpy-cross.exe VARIANT=$($env:PyVariant)"
+    if ($LASTEXITCODE -ne 0) {
+      throw "$env:MSYSTEM build exited with code $LASTEXITCODE"
+    }
     C:\msys64\usr\bin\bash.exe -l -c "make V=1 test_full VARIANT=$($env:PyVariant)"
     if ($LASTEXITCODE -ne 0) {
       & $env:MICROPY_CPYTHON3 run-tests.py --print-failures


### PR DESCRIPTION
The main Makefile builds the mpy-cross executable automatically if
it doesn't exist since 78718fffb1f3010c7a40bb4c29c6ddf5b8dadaa3,
so build it first to make sure it doesn't get needlessly rebuilt.