### PR TITLE
esp32/machine_bitstream: Reinstate bit-bang implementation.

### DIFF
--- a/docs/esp32/quickref.rst
+++ b/docs/esp32/quickref.rst
@@ -573,6 +573,9 @@ For low-level driving of a NeoPixel::
    400kHz) devices by passing ``timing=0`` when constructing the
    ``NeoPixel`` object.
 
+The low-level driver uses an RMT channel by default.  To configure this see
+`RMT.bitstream_channel`.
+
 APA102 (DotStar) uses a different driver as it has an additional clock pin.
 
 Capacitive touch

--- a/docs/library/esp32.rst
+++ b/docs/library/esp32.rst
@@ -250,6 +250,17 @@ For more details see Espressif's `ESP-IDF RMT documentation.
     new sequence of pulses. Looping sequences longer than 126 pulses is not
     supported by the hardware.
 
+.. staticmethod:: RMT.bitstream_channel([value])
+
+    Select which RMT channel is used by the `machine.bitstream` implementation.
+    *value* can be ``None`` or a valid RMT channel number.  The default RMT
+    channel is the highest numbered one.
+
+    Passing in ``None`` disables the use of RMT and instead selects a bit-banging
+    implementation for `machine.bitstream`.
+
+    Passing in no argument will not change the channel.  This function returns
+    the current channel number.
 
 Ultra-Low-Power co-processor
 ----------------------------

--- a/ports/esp32/machine_bitstream.c
+++ b/ports/esp32/machine_bitstream.c
@@ -26,12 +26,70 @@
 
 #include "py/mpconfig.h"
 #include "py/mphal.h"
+#include "modesp32.h"
 
 #if MICROPY_PY_MACHINE_BITSTREAM
 
-#include "driver/rmt.h"
+/******************************************************************************/
+// Bit-bang implementation
 
-#include "modesp32.h"
+#define NS_TICKS_OVERHEAD (6)
+
+// This is a translation of the cycle counter implementation in ports/stm32/machine_bitstream.c.
+STATIC void IRAM_ATTR machine_bitstream_high_low_bitbang(mp_hal_pin_obj_t pin, uint32_t *timing_ns, const uint8_t *buf, size_t len) {
+    uint32_t pin_mask, gpio_reg_set, gpio_reg_clear;
+    #if !CONFIG_IDF_TARGET_ESP32C3
+    if (pin >= 32) {
+        pin_mask = 1 << (pin - 32);
+        gpio_reg_set = GPIO_OUT1_W1TS_REG;
+        gpio_reg_clear = GPIO_OUT1_W1TC_REG;
+    } else
+    #endif
+    {
+        pin_mask = 1 << pin;
+        gpio_reg_set = GPIO_OUT_W1TS_REG;
+        gpio_reg_clear = GPIO_OUT_W1TC_REG;
+    }
+
+    // Convert ns to cpu ticks [high_time_0, period_0, high_time_1, period_1].
+    uint32_t fcpu_mhz = ets_get_cpu_frequency();
+    for (size_t i = 0; i < 4; ++i) {
+        timing_ns[i] = fcpu_mhz * timing_ns[i] / 1000;
+        if (timing_ns[i] > NS_TICKS_OVERHEAD) {
+            timing_ns[i] -= NS_TICKS_OVERHEAD;
+        }
+        if (i % 2 == 1) {
+            // Convert low_time to period (i.e. add high_time).
+            timing_ns[i] += timing_ns[i - 1];
+        }
+    }
+
+    uint32_t irq_state = mp_hal_quiet_timing_enter();
+
+    for (size_t i = 0; i < len; ++i) {
+        uint8_t b = buf[i];
+        for (size_t j = 0; j < 8; ++j) {
+            GPIO_REG_WRITE(gpio_reg_set, pin_mask);
+            uint32_t start_ticks = mp_hal_ticks_cpu();
+            uint32_t *t = &timing_ns[b >> 6 & 2];
+            while (mp_hal_ticks_cpu() - start_ticks < t[0]) {
+                ;
+            }
+            GPIO_REG_WRITE(gpio_reg_clear, pin_mask);
+            b <<= 1;
+            while (mp_hal_ticks_cpu() - start_ticks < t[1]) {
+                ;
+            }
+        }
+    }
+
+    mp_hal_quiet_timing_exit(irq_state);
+}
+
+/******************************************************************************/
+// RMT implementation
+
+#include "driver/rmt.h"
 
 #if ESP_IDF_VERSION < ESP_IDF_VERSION_VAL(4, 1, 0)
 // This convenience macro was not available in earlier IDF versions.
@@ -93,8 +151,8 @@ STATIC void IRAM_ATTR bitstream_high_low_rmt_adapter(const void *src, rmt_item32
 }
 
 // Use the reserved RMT channel to stream high/low data on the specified pin.
-void machine_bitstream_high_low(mp_hal_pin_obj_t pin, uint32_t *timing_ns, const uint8_t *buf, size_t len) {
-    rmt_config_t config = RMT_DEFAULT_CONFIG_TX(pin, MICROPY_HW_ESP32_RMT_CHANNEL_BITSTREAM);
+STATIC void machine_bitstream_high_low_rmt(mp_hal_pin_obj_t pin, uint32_t *timing_ns, const uint8_t *buf, size_t len, uint8_t channel_id) {
+    rmt_config_t config = RMT_DEFAULT_CONFIG_TX(pin, channel_id);
 
     // Use 40MHz clock (although 2MHz would probably be sufficient).
     config.clk_div = 2;
@@ -136,6 +194,17 @@ void machine_bitstream_high_low(mp_hal_pin_obj_t pin, uint32_t *timing_ns, const
 
     // Cancel RMT output to GPIO pin.
     gpio_matrix_out(pin, SIG_GPIO_OUT_IDX, false, false);
+}
+
+/******************************************************************************/
+// Interface to machine.bitstream
+
+void machine_bitstream_high_low(mp_hal_pin_obj_t pin, uint32_t *timing_ns, const uint8_t *buf, size_t len) {
+    if (esp32_rmt_bitstream_channel_id < 0) {
+        machine_bitstream_high_low_bitbang(pin, timing_ns, buf, len);
+    } else {
+        machine_bitstream_high_low_rmt(pin, timing_ns, buf, len, esp32_rmt_bitstream_channel_id);
+    }
 }
 
 #endif // MICROPY_PY_MACHINE_BITSTREAM

--- a/ports/esp32/modesp32.h
+++ b/ports/esp32/modesp32.h
@@ -26,13 +26,12 @@
 #define RTC_LAST_EXT_PIN 39
 #define RTC_IS_VALID_EXT_PIN(pin_id) ((1ll << (pin_id)) & RTC_VALID_EXT_PINS)
 
+extern int8_t esp32_rmt_bitstream_channel_id;
+
 extern const mp_obj_type_t esp32_nvs_type;
 extern const mp_obj_type_t esp32_partition_type;
 extern const mp_obj_type_t esp32_rmt_type;
 extern const mp_obj_type_t esp32_ulp_type;
-
-// Reserve the last channel for machine.bitstream.
-#define MICROPY_HW_ESP32_RMT_CHANNEL_BITSTREAM (RMT_CHANNEL_MAX - 1)
 
 esp_err_t rmt_driver_install_core1(uint8_t channel_id);
 


### PR DESCRIPTION
The new esp32 bitstream/neopixel driver based on RMT can have glitches when WiFi is enabled.  It's not currently known why this happens, but for now here is a patch which reinstates the previous bit-bang implementation.

It's now possible to select bit-bang or RMT via:
```python
esp32.RMT.bitstream_channel(channel_to_use_for_bitstream)
```
The default is to use bit-banging.