### PR TITLE
STM32: Deinitialize DACs on soft-reboot.

### DIFF
--- a/ports/stm32/dac.c
+++ b/ports/stm32/dac.c
@@ -131,6 +131,13 @@ STATIC void dac_deinit(uint32_t dac_channel) {
     #endif
 }
 
+void dac_deinit_all(void) {
+    dac_deinit(DAC_CHANNEL_1);
+    #if !defined(STM32L452xx)
+    dac_deinit(DAC_CHANNEL_2);
+    #endif
+}
+
 STATIC void dac_config_channel(uint32_t dac_channel, uint32_t trig, uint32_t outbuf) {
     DAC->CR &= ~(DAC_CR_EN1 << dac_channel);
     uint32_t cr_off = DAC_CR_DMAEN1 | DAC_CR_MAMP1 | DAC_CR_WAVE1 | DAC_CR_TSEL1 | DAC_CR_TEN1;

--- a/ports/stm32/dac.h
+++ b/ports/stm32/dac.h
@@ -27,5 +27,6 @@
 #define MICROPY_INCLUDED_STM32_DAC_H
 
 extern const mp_obj_type_t pyb_dac_type;
+void dac_deinit_all(void);
 
 #endif // MICROPY_INCLUDED_STM32_DAC_H

--- a/ports/stm32/main.c
+++ b/ports/stm32/main.c
@@ -654,6 +654,9 @@ soft_reset_exit:
     #if MICROPY_HW_ENABLE_CAN
     can_deinit_all();
     #endif
+    #if MICROPY_HW_ENABLE_DAC
+    dac_deinit_all();
+    #endif
     machine_deinit();
 
     #if MICROPY_PY_THREAD


### PR DESCRIPTION
* Output a waveform on DAC, example:
```Python
import math
from pyb import DAC

# create a buffer containing a sine-wave
buf = bytearray(100)
for i in range(len(buf)):
    buf[i] = 128 + int(127 * math.sin(2 * math.pi * i / len(buf)))

# output the sine-wave at 400Hz
dac = DAC(1)
dac.write_timed(buf, 400 * len(buf), mode=DAC.CIRCULAR)
```
* Ctrl-D for a soft-reboot.
* DAC is still running (using collected/free'd memory).

* NOTE: Should probably stop TIM6 too.