### PR TITLE
esp32/esp32_rmt: Install RMT driver on core 1.

### DIFF
--- a/ports/esp32/machine_bitstream.c
+++ b/ports/esp32/machine_bitstream.c
@@ -101,7 +101,7 @@ void machine_bitstream_high_low(mp_hal_pin_obj_t pin, uint32_t *timing_ns, const
 
     // Install the driver on this channel & pin.
     check_esp_err(rmt_config(&config));
-    check_esp_err(rmt_driver_install(config.channel, 0, 0));
+    check_esp_err(rmt_driver_install_core1(config.channel));
 
     // Get the tick rate in kHz (this will likely be 40000).
     uint32_t counter_clk_khz = 0;

--- a/ports/esp32/modesp32.h
+++ b/ports/esp32/modesp32.h
@@ -34,4 +34,6 @@ extern const mp_obj_type_t esp32_ulp_type;
 // Reserve the last channel for machine.bitstream.
 #define MICROPY_HW_ESP32_RMT_CHANNEL_BITSTREAM (RMT_CHANNEL_MAX - 1)
 
+esp_err_t rmt_driver_install_core1(uint8_t channel_id);
+
 #endif // MICROPY_INCLUDED_ESP32_MODESP32_H


### PR DESCRIPTION
MicroPython currently runs on core 0 of the esp32.  Calling
rmt_driver_install will mean that the RMT interrupt handler is also
serviced on core 0.  This can lead to glitches in the RMT output if
WiFi is enabled (for esp32.RMT and machine.bitstream).

This patch calls rmt_driver_install on core 1, ensuring that the RMT
interrupt handler is serviced on core 1.  This prevents glitches.

Fixes issue #8161.