### PR TITLE
fix URL for esp-idf installation

### DIFF
--- a/ports/esp32/README.md
+++ b/ports/esp32/README.md
@@ -32,7 +32,7 @@ Currently MicroPython supports v4.0.2, v4.1.1 and v4.2,
 although other IDF v4 versions may also work.
 
 To install the ESP-IDF the full instructions can be found at the
-[Espressif Getting Started guide](https://docs.espressif.com/projects/esp-idf/en/v4.0.2/get-started/index.html#installation-step-by-step).
+[Espressif Getting Started guide](https://docs.espressif.com/projects/esp-idf/en/latest/esp32/get-started/index.html#installation-step-by-step).
 
 If you are on a Windows machine then the [Windows Subsystem for
 Linux](https://msdn.microsoft.com/en-au/commandline/wsl/install_guide) is the


### PR DESCRIPTION
Tiny change that fixes the esp32/README to point to the current IDF installation document (currently it's 404)