### PR TITLE
esp32/modnetwork.c: WIFI_AUTH_MAX is 9 in idf v4.3, not 8 as in v4.2

### DIFF
--- a/ports/esp32/modnetwork.c
+++ b/ports/esp32/modnetwork.c
@@ -212,7 +212,7 @@ STATIC mp_obj_t esp_phy_mode(size_t n_args, const mp_obj_t *args) {
 }
 STATIC MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(esp_phy_mode_obj, 0, 1, esp_phy_mode);
 
-#if ESP_IDF_VERSION > ESP_IDF_VERSION_VAL(4, 3, 0)
+#if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(4, 3, 0)
 #define TEST_WIFI_AUTH_MAX 9
 #else
 #define TEST_WIFI_AUTH_MAX 8


### PR DESCRIPTION
    ESP-IDF changed WIFI_AUTH_XXX constants between v4.2 and v4.3.   When using esp-idf v4.3, WIFI_AUTH_MAX is 9, not 8.
 
    see: https://github.com/espressif/esp-idf/blob/0786d1a337ae3b190497347bab87b509297dcc0f/components/esp_wifi/include/esp_wifi_types.h#L68

Signed-off-by: marcidy <marcidy@gmail.com>