### PR TITLE
nrf/bluetooth: Add handling for PHY_UPDATE messages, used in Bluetooth 5

### DIFF
--- a/ports/nrf/drivers/bluetooth/ble_drv.c
+++ b/ports/nrf/drivers/bluetooth/ble_drv.c
@@ -1136,6 +1136,24 @@ static void ble_evt_handler(ble_evt_t * p_ble_evt) {
             sd_ble_gap_data_length_update(p_ble_evt->evt.gap_evt.conn_handle, NULL, NULL);
             break;
 
+        case BLE_GAP_EVT_PHY_UPDATE_REQUEST:
+            BLE_DRIVER_LOG("BLE_GAP_EVT_PHY_UPDATE_REQUEST\n");
+            ble_gap_phys_t const phys =
+            {
+                BLE_GAP_PHY_AUTO,
+                BLE_GAP_PHY_AUTO,
+            };
+            sd_ble_gap_phy_update(p_ble_evt->evt.gap_evt.conn_handle, &phys);
+            break;
+
+        case BLE_GAP_EVT_PHY_UPDATE:
+            BLE_DRIVER_LOG("BLE_GAP_EVT_PHY_UPDATE -- unhandled!\n");
+            break;
+
+        case BLE_GAP_EVT_DATA_LENGTH_UPDATE:
+            BLE_DRIVER_LOG("BLE_GAP_EVT_DATA_LENGTH_UPDATE -- unhandled!\n");
+            break;
+
 #endif // (BLUETOOTH_SD == 132) || (BLUETOOTH_SD == 140)
 
         default:


### PR DESCRIPTION
Some devices, such as the LightBlue BTLE app on iOS, try to use Bluetooth 5 when connecting to a device.
This means that they will send a BLE_GAP_EVT_PHY_UPDATE_REQUEST message a shift to a new physical layer.
Since micropython doesn't handle this event, what this means is that LightBlue (and likely other Bluetooth 5.0 central devices) will try to connect and then fail, staying in "Connecting..." state forever.
As per [Nordic documentation](https://infocenter.nordicsemi.com/index.jsp?topic=%2Fcom.nordic.infocenter.s132.api.v6.0.0%2Fgroup___b_l_e___g_a_p___e_n_u_m_e_r_a_t_i_o_n_s.html&anchor=ggada486dd3c0cce897b23a887bed284fefa72dff3660a5414e3f7abddd844070e55) of the BLE_GAP_EVT_PHY_UPDATE_REQUEST message, and in the S140 SoftDevice v6.1.1 API that we're using, this message should be replied to with sd_ble_gap_phy_update.
(This requirement to reply thus is also documented in drivers/bluetooth/s140_nrf52_6.1.1/s140_nrf52_6.1.1_API/include/ble_gap.h once fetched.)
Taking inspiration from [Nordic's ble-image-transfer-demo](https://github.com/NordicPlayground/nrf52-ble-image-transfer-demo/blob/b1338a7eb983aa5794fffa956c5928a0074f70c6/main.c#L401) code, we handle this message as instructed.
With this patch applied, LightBlue can now successfully connect to a BTLE device on a P10059 nRF52840 dongle being run by micropython.
We also receive two other events, 0x22 and 0x24, which equate to BLE_GAP_EVT_PHY_UPDATE and BLE_GAP_EVT_DATA_LENGTH_UPDATE. It is not clear whether these are advisory, or whether we're meant to do something with the updated information they convey; if we need to use the information in these events then there will need to be further patching.