### PR TITLE
esp32/main: Support SPRAM allocated using malloc

### DIFF
--- a/ports/esp32/main.c
+++ b/ports/esp32/main.c
@@ -100,7 +100,10 @@ void mp_task(void *pvParameter) {
     size_t mp_task_heap_size;
     void *mp_task_heap = NULL;
 
-    #if CONFIG_ESP32_SPIRAM_SUPPORT
+    #if CONFIG_SPIRAM_USE_MALLOC
+    // SPRAM is issued using MALLOC, fallback to normal allocation rules
+    mp_task_heap = NULL;
+    #elif CONFIG_ESP32_SPIRAM_SUPPORT
     // Try to use the entire external SPIRAM directly for the heap
     mp_task_heap = (void *)SOC_EXTRAM_DATA_LOW;
     switch (esp_spiram_get_chip_size()) {


### PR DESCRIPTION
Integrating with the esp32-camera for example requires that ESP32 SPRAM be allocatable using the esp-idf
capabilities aware allocation functions.  In the case of esp32-camera its for the framebuffer.

Detect when CONFIG_SPIRAM_USE_MALLOC is in use and use the standard automatic configuration of leaving 1/2
of the SPRAM available to other FreeRTOS tasks.

My original thought was to allow the board config to control how much the micropython heap was reduced but I've read some of the other related issues and pull requests and it seems that an algorithm/heuristic is the preferred approach.

Here I just add a new no-op block that will in the case the esp32 is  configured to allocate psram using malloc to skip past the normal MMAP allocation strategy and use the non-psram allocation strategy.

I've used this patch locally to build a firmware for esp32-cam-mb and m5-timer-camera:
https://github.com/mocleiri/tensorflow-micropython-examples/tree/feature/59-integrate-esp32-camera-acquisition
https://github.com/mocleiri/tensorflow-micropython-examples/issues/59

--
This patch  adds this case into the logic added here: 23b1a4e0b6c6f538d6622359aba0740dfe14c44d for non spram heap sizing.

Related:
#7214 (except that our case is when the other idf modules in use need to use the idf capabilities allocation functions where malloc can allocate them parts of psram)