### PR TITLE
tools/mpremote: Add manifest function.

### DIFF
--- a/docs/reference/mpremote.rst
+++ b/docs/reference/mpremote.rst
@@ -365,6 +365,39 @@ The full list of supported commands are:
     local directory that is mounted.  This option disables this check for symbolic
     links, allowing the device to follow symbolic links outside of the local directory.
 
+.. _mpremote_command_manifest:
+
+- **manifest** -- compile a manifest.py and add output to device ``sys.path``:
+
+  .. code-block:: bash
+
+      $ mpremote manifest <path> [options]
+
+  This processes a MicroPython manifest file (as used by the build system's
+  freeze mechanism), compiles all ``.py`` files to ``.mpy`` using ``mpy-cross``,
+  and places the output in a local build directory (default ``_manifest``).
+  The build directory is then added to ``sys.path`` on the device, making the
+  compiled modules available for import.
+
+  When combined with ``mount``, the compiled modules are accessible alongside
+  the mounted local directory:
+
+  .. code-block:: bash
+
+      $ mpremote manifest . mount .
+
+  A soft-reset (Ctrl-D) will re-process the manifest file to include any
+  local updates.
+
+  The ``MPY_DIR``, ``MPY_LIB_DIR``, and ``PORT_DIR`` environment variables can
+  be set to control manifest path resolution.
+
+  Options are:
+
+  - ``-o``, ``--output``: Output directory for compiled ``.mpy`` files
+    (default: ``_manifest``).
+  - ``--mpy-cross-flags``: Additional flags to pass to ``mpy-cross``.
+
 .. _mpremote_command_unmount:
 
 - **unmount** -- unmount the local directory from the remote device:

--- a/tools/mpremote/mpremote/commands.py
+++ b/tools/mpremote/mpremote/commands.py
@@ -515,6 +515,140 @@ def do_run(state, args):
     _do_execbuffer(state, buf, args.follow)
 
 
+def _get_mpy_cross():
+    """Find or locate the mpy-cross compiler."""
+    # Try the repo's mpy-cross module first.
+    tools_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), "../../.."))
+    sys.path.insert(0, os.path.join(tools_dir, "mpy-cross"))
+    try:
+        import mpy_cross
+
+        return mpy_cross
+    except ImportError:
+        pass
+    finally:
+        sys.path.pop(0)
+
+    # Try the pip-installed mpy-cross package.
+    try:
+        import mpy_cross
+
+        return mpy_cross
+    except ImportError:
+        pass
+
+    return None
+
+
+def _build_manifest(manifest_path, build_dir, mpy_cross_flags=""):
+    """Process a manifest file and compile .py files to .mpy.
+
+    Returns list of all output .mpy files and list of newly compiled files.
+    """
+    tools_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), "../../.."))
+    sys.path.insert(0, tools_dir)
+    try:
+        import manifestfile
+    except ImportError:
+        raise CommandError(
+            "manifest: cannot import manifestfile module"
+            " (must be run from a MicroPython source tree)"
+        )
+    finally:
+        sys.path.pop(0)
+
+    mpy_cross = _get_mpy_cross()
+    if mpy_cross is None:
+        raise CommandError("manifest: mpy-cross not found (build it or pip install mpy-cross)")
+
+    # Set up path variables for manifest resolution.
+    path_vars = {
+        "MPY_DIR": os.environ.get("MPY_DIR", tools_dir),
+        "MPY_LIB_DIR": os.environ.get(
+            "MPY_LIB_DIR", os.path.join(tools_dir, "lib/micropython-lib")
+        ),
+    }
+    port_dir = os.environ.get("PORT_DIR")
+    if port_dir:
+        path_vars["PORT_DIR"] = port_dir
+
+    manifest = manifestfile.ManifestFile(manifestfile.MODE_COMPILE, path_vars)
+
+    if os.path.isdir(manifest_path):
+        manifest_path = os.path.join(manifest_path, "manifest.py")
+
+    try:
+        manifest.execute(manifest_path)
+    except manifestfile.ManifestFileError as er:
+        raise CommandError(f'manifest: error executing "{manifest_path}": {er.args[0]}')
+
+    all_files = []
+    new_files = []
+    for result in manifest.files():
+        if result.kind != manifestfile.KIND_COMPILE_AS_MPY:
+            continue
+
+        infile = result.full_path
+        outfile = os.path.join(build_dir, result.target_path[:-3] + ".mpy")
+
+        # Check if recompilation is needed.
+        try:
+            ts_in = os.stat(infile).st_mtime
+            ts_out = os.stat(outfile).st_mtime
+        except OSError:
+            ts_in = 1
+            ts_out = 0
+
+        if ts_in >= ts_out:
+            os.makedirs(os.path.dirname(outfile), exist_ok=True)
+            try:
+                mpy_cross.compile(
+                    infile,
+                    dest=outfile,
+                    src_path=result.target_path,
+                    opt=result.opt,
+                    extra_args=mpy_cross_flags.split() if mpy_cross_flags else [],
+                )
+            except mpy_cross.CrossCompileError as ex:
+                raise CommandError(f"manifest: error compiling {result.target_path}: {ex.args[0]}")
+            new_files.append(outfile)
+            print("MPY", result.target_path)
+
+        all_files.append(outfile)
+
+    return all_files, new_files
+
+
+def do_manifest(state, args):
+    state.ensure_raw_repl()
+
+    manifest_path = args.path[0]
+    build_dir = args.output or "_manifest"
+
+    all_files, new_files = _build_manifest(manifest_path, build_dir, args.mpy_cross_flags or "")
+
+    # Store manifest info on the transport for remount support.
+    state.transport.manifest_path = manifest_path
+    state.transport.manifest_dir = build_dir
+    state.transport.manifest_mpy_cross_flags = args.mpy_cross_flags or ""
+
+    # Inject the manifest output directory into sys.path on the device.
+    # When mount is active, the device sees local files at /remote/, so
+    # the manifest dir is accessible at /remote/<build_dir>.
+    # When mount is not active, inject the fs_hook_code so __manifest_path
+    # is available, though the files won't be accessible until mount runs.
+    if not state.transport.eval('"RemoteFS" in globals()'):
+        from .transport_serial import fs_hook_code
+
+        state.transport.exec(fs_hook_code)
+
+    if state.transport.mounted:
+        device_path = f"{SerialTransport.fs_hook_mount}/{build_dir}"
+        state.transport.exec(f"__manifest_path('{device_path}')")
+
+    print(f"Manifest built: {len(all_files)} files ({len(new_files)} compiled)")
+
+
 def do_mount(state, args):
     state.ensure_raw_repl()
     path = args.path[0]

--- a/tools/mpremote/mpremote/main.py
+++ b/tools/mpremote/mpremote/main.py
@@ -30,6 +30,7 @@ from .commands import (
     do_disconnect,
     do_edit,
     do_filesystem,
+    do_manifest,
     do_mount,
     do_umount,
     do_exec,
@@ -128,6 +129,29 @@ def argparse_mount():
         "follow symbolic links pointing outside of local directory",
     )
     cmd_parser.add_argument("path", nargs=1, help="local path to mount")
+    return cmd_parser
+
+
+def argparse_manifest():
+    cmd_parser = argparse.ArgumentParser(
+        description="compile a manifest.py and add output to device sys.path"
+    )
+    cmd_parser.add_argument(
+        "path", nargs=1, help="path to manifest.py or directory containing one"
+    )
+    cmd_parser.add_argument(
+        "--output",
+        "-o",
+        type=str,
+        default="_manifest",
+        help="output directory for compiled .mpy files (default: _manifest)",
+    )
+    cmd_parser.add_argument(
+        "--mpy-cross-flags",
+        type=str,
+        default="",
+        help="flags to pass to mpy-cross",
+    )
     return cmd_parser
 
 
@@ -306,6 +330,10 @@ _COMMANDS = {
     "soft-reset": (
         do_soft_reset,
         argparse_none("perform a soft-reset of the device"),
+    ),
+    "manifest": (
+        do_manifest,
+        argparse_manifest,
     ),
     "mount": (
         do_mount,

--- a/tools/mpremote/mpremote/transport_serial.py
+++ b/tools/mpremote/mpremote/transport_serial.py
@@ -54,6 +54,9 @@ class SerialTransport(Transport):
         self.use_raw_paste = True
         self.device_name = device
         self.mounted = False
+        self.manifest_path = None
+        self.manifest_dir = None
+        self.manifest_mpy_cross_flags = ""
 
         # Set options, and exclusive if pyserial supports it
         serial_kwargs = {
@@ -321,13 +324,16 @@ class SerialTransport(Transport):
         if not self.eval('"RemoteFS" in globals()'):
             self.exec(fs_hook_code)
         self.exec("__mount()")
+        if self.manifest_path:
+            device_path = f"{self.fs_hook_mount}/{self.manifest_dir}"
+            self.exec(f"__manifest_path('{device_path}')")
         self.mounted = True
         self.cmd = PyboardCommand(self.serial, fout, path, unsafe_links=unsafe_links)
         self.serial = SerialIntercept(self.serial, self.cmd)
 
     def write_ctrl_d(self, out_callback):
         self.serial.write(b"\x04")
-        if not self.mounted:
+        if not self.mounted and not self.manifest_path:
             return
 
         # Read response from the device until it is quiet (with a timeout).
@@ -391,28 +397,46 @@ class SerialTransport(Transport):
             prompt = data_all.rsplit(b"\r\n", 1)[-1]
 
         # Clear state while board remounts, it will be re-set once mounted.
+        do_mount = self.mounted
         self.mounted = False
-        self.serial = self.serial.orig_serial
+        if hasattr(self.serial, "orig_serial"):
+            self.serial = self.serial.orig_serial
 
-        # Provide a message about the remount.
-        out_callback(
-            bytes(
-                f"\r\nRemount local directory {self.cmd.root} at {self.fs_hook_mount}\r\n", "utf8"
-            )
-        )
-
-        # Enter raw REPL and re-mount the remote filesystem.
+        # Enter raw REPL and re-run remote hooks.
         self.serial.write(b"\x01")
         self.exec(fs_hook_code)
-        self.exec("__mount()")
-        self.mounted = True
+
+        if do_mount:
+            # Provide a message about the remount.
+            out_callback(
+                bytes(
+                    f"\r\nRemount local directory {self.cmd.root} at {self.fs_hook_mount}\r\n",
+                    "utf8",
+                )
+            )
+            self.exec("__mount()")
+            self.mounted = True
+
+        if self.manifest_path:
+            from .commands import _build_manifest
+
+            _build_manifest(
+                self.manifest_path,
+                self.manifest_dir,
+                self.manifest_mpy_cross_flags,
+            )
+            if self.mounted:
+                device_path = f"{self.fs_hook_mount}/{self.manifest_dir}"
+                self.exec(f"__manifest_path('{device_path}')")
+            out_callback(b"\r\nRe-built manifest\r\n")
 
         # Exit raw REPL if needed, and wait for the friendly REPL prompt.
         if in_friendly_repl:
             self.exit_raw_repl()
         self.read_until(len(prompt), prompt)
         out_callback(prompt)
-        self.serial = SerialIntercept(self.serial, self.cmd)
+        if self.mounted:
+            self.serial = SerialIntercept(self.serial, self.cmd)
 
     def umount_local(self):
         if self.mounted:
@@ -772,6 +796,12 @@ class RemoteFS:
 def __mount():
     os.mount(RemoteFS(RemoteCommand()), '{SerialTransport.fs_hook_mount}')
     os.chdir('{SerialTransport.fs_hook_mount}')
+
+
+def __manifest_path(path):
+    import sys
+    if path not in sys.path:
+        sys.path.insert(0, path)
 """
 
 # Apply basic compression on hook code.


### PR DESCRIPTION
Add manifest command to mpremote which will compile a manifest.py from the specified folder, eg:

``` bash
      $ MPY_DIR=../../micropython 
      $ PORT_DIR=../../micropython/ports/esp32
      $ mpremote manifest .
  ```
  This will assemble / mpy-cross everything specified in the manifest.py into the folder `_manifest`.
  If the current folder is also mounted, this folder will automatically be added to the path, eg:

``` bash
      $ mpremote manifest . mount .
```
  
Alternatively, the built folder can by copied / synched to the device, in which case 
  the copied folder will be added to the path:

``` bash
      $ mpremote manifest -s . 
```
  A soft-reset will re-process the manifest file to include any local updates allowing fast development of local files in a larger project without needing to copy / import-over-mount all files every reset.


Ideally, if the `mpy_cross` python package is installed from pypi, the local `MPY_DIR=../../micropython` variables will not need to be specified (unless your local manifest uses them directly`