### PR TITLE
tools/mpremote: Fix "fs cp -r" on Windows.

### DIFF
--- a/tools/mpremote/mpremote/main.py
+++ b/tools/mpremote/mpremote/main.py
@@ -268,7 +268,7 @@ def do_filesystem(pyb, args):
     def _list_recursive(files, path):
         if os.path.isdir(path):
             for entry in os.listdir(path):
-                _list_recursive(files, os.path.join(path, entry))
+                _list_recursive(files, "/".join((path, entry)))
         else:
             files.append(os.path.split(path))
 
@@ -289,7 +289,7 @@ def do_filesystem(pyb, args):
                 if d not in known_dirs:
                     pyb.exec_("try:\n uos.mkdir('%s')\nexcept OSError as e:\n print(e)" % d)
                     known_dirs.add(d)
-            pyboard.filesystem_command(pyb, ["cp", os.path.join(dir, file), ":" + dir + "/"])
+            pyboard.filesystem_command(pyb, ["cp", "/".join((dir, file)), ":" + dir + "/"])
     else:
         pyboard.filesystem_command(pyb, args)
     args.clear()


### PR DESCRIPTION
Currently when using `mpremote fs cp -r _manifest :` on windows, it does not correctly handle the `\` path separator, resulting in things like 
```
cp _manifest\config_def.mpy :_manifest/_manifest\art.mpy
```

which gets even worse on-device:
```
os.listdir("/_manifest")
['_manifest\x07rt.mpy', ...]
```

Changing to a simply `'/',join()` appears to fix this problem cleanly.