### PR TITLE
tools/mpremote: Correctly manage mounted flag during soft-reset.

### DIFF
--- a/tools/mpremote/mpremote/pyboardextended.py
+++ b/tools/mpremote/mpremote/pyboardextended.py
@@ -614,10 +614,10 @@ class PyboardExtended(Pyboard):
 
     def mount_local(self, path):
         fout = self.serial
-        self.mounted = True
         if self.eval('"RemoteFS" in globals()') == b"False":
             self.exec_(fs_hook_code)
         self.exec_("__mount()")
+        self.mounted = True
         self.cmd = PyboardCommand(self.serial, fout, path)
         self.serial = SerialIntercept(self.serial, self.cmd)
 
@@ -625,6 +625,8 @@ class PyboardExtended(Pyboard):
         self.serial.write(b"\x04")
         if not self.mounted:
             return
+        # Clear this while board reboots, it will be re-set once mounted.
+        self.mounted = False
 
         # Wait for a response to the soft-reset command.
         for i in range(10):
@@ -646,6 +648,7 @@ class PyboardExtended(Pyboard):
         self.serial.write(b"\x01")
         self.exec_(fs_hook_code)
         self.exec_("__mount()")
+        self.mounted = True
         self.exit_raw_repl()
         self.read_until(4, b">>> ")
         self.serial = SerialIntercept(self.serial, self.cmd)


### PR DESCRIPTION
Currently in mpremote if an error occurs during soft-reboot, there can be a chained exception such as:
```
MPY: soft reboot
Traceback (most recent call last):
  File "c:\python39\lib\site-packages\mpremote\main.py", line 507, in main
    do_repl(pyb, args)
  File "c:\python39\lib\site-packages\mpremote\main.py", line 367, in do_repl
    do_repl_main_loop(
  File "c:\python39\lib\site-packages\mpremote\main.py", line 294, in do_repl_main_loop
    pyb.soft_reset_with_mount(console_out_write)
  File "c:\python39\lib\site-packages\mpremote\pyboardextended.py", line 686, in soft_reset_with_mount
    self.exec_(fs_hook_code)
  File "c:\python39\lib\site-packages\mpremote\pyboard.py", line 465, in exec_
    ret, ret_err = self.exec_raw(command, data_consumer=data_consumer)
  File "c:\python39\lib\site-packages\mpremote\pyboard.py", line 456, in exec_raw
    self.exec_raw_no_follow(command)
  File "c:\python39\lib\site-packages\mpremote\pyboard.py", line 453, in exec_raw_no_follow
    raise PyboardError("could not exec command (response: %r)" % data)
mpremote.pyboard.PyboardError: could not exec command (response: b'R\x01')

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "c:\python39\lib\runpy.py", line 197, in _run_module_as_main
    return _run_code(code, main_globals, None,
  File "c:\python39\lib\runpy.py", line 87, in _run_code
    exec(code, run_globals)
  File "C:\Python39\Scripts\mpremote.exe\__main__.py", line 7, in <module>
  File "c:\python39\lib\site-packages\mpremote\main.py", line 510, in main
    do_disconnect(pyb)
  File "c:\python39\lib\site-packages\mpremote\main.py", line 262, in do_disconnect
    pyb.umount_local()
  File "c:\python39\lib\site-packages\mpremote\pyboardextended.py", line 703, in umount_local
    self.exec_('uos.umount("/remote")')
  File "c:\python39\lib\site-packages\mpremote\pyboard.py", line 467, in exec_
    raise PyboardError("exception", ret, ret_err)
mpremote.pyboard.PyboardError: ('exception', b'', b'Traceback (most recent call last):\r\n  File "<stdin>", line 1, in <module>\r\nOSError: [Errno 22] EINVAL\r\n')
```

The second exception here is from an attempt to umount during the `PyboardError` handler, however it hasn't yet been re-mounted during soft-reset.

This PR simply ignores errors during umount, I can't think of any situations where this would realistically cause issues?