### PR TITLE
tools/mpremote: During soft reboot wait long enough for 115200 data.

### DIFF
--- a/tools/mpremote/mpremote/pyboardextended.py
+++ b/tools/mpremote/mpremote/pyboardextended.py
@@ -641,7 +641,7 @@ class PyboardExtended(Pyboard):
         while n > 0:
             buf = self.serial.read(n)
             out_callback(buf)
-            time.sleep(0.1)
+            time.sleep(0.2)
             n = self.serial.inWaiting()
         self.serial.write(b"\x01")
         self.exec_(fs_hook_code)


### PR DESCRIPTION
When using mpremote with an esp32 using a standalone Silabs CP210x USB Uart at 115200 on Windows 10 I get a repeatable failure during soft-reboot
```
MPY: soft reboot
Traceback (most recent call last):
  File "W:\home\anl\mpy_iot\src\micropython\tools\mpremote\mpremote.py", line 6, in <module>
    sys.exit(main.main())
  File "W:\home\anl\mpy_iot\src\micropython\tools\mpremote\mpremote\main.py", line 512, in main
    do_repl(pyb, args)
  File "W:\home\anl\mpy_iot\src\micropython\tools\mpremote\mpremote\main.py", line 380, in do_repl
    do_repl_main_loop(
  File "W:\home\anl\mpy_iot\src\micropython\tools\mpremote\mpremote\main.py", line 307, in do_repl_main_loop
    pyb.soft_reset_with_mount(console_out_write)
  File "W:\home\anl\mpy_iot\src\micropython\tools\mpremote\mpremote\pyboardextended.py", line 647, in soft_reset_with_mount
    self.exec_(fs_hook_code)
  File "W:\home\anl\mpy_iot\src\micropython\tools\mpremote\mpremote\pyboard.py", line 465, in exec_
    ret, ret_err = self.exec_raw(command, data_consumer=data_consumer)
  File "W:\home\anl\mpy_iot\src\micropython\tools\mpremote\mpremote\pyboard.py", line 456, in exec_raw
    self.exec_raw_no_follow(command)
  File "W:\home\anl\mpy_iot\src\micropython\tools\mpremote\mpremote\pyboard.py", line 453, in exec_raw_no_follow
    raise PyboardError("could not exec command (response: %r)" % data)
mpremote.pyboard.PyboardError: could not exec command (response: b'R\x01')
```

It appears the startup message flush is being read / timeout too fast, not always waiting long enough for the next byte. 
Simply increasing the per-byte timeout appears to resolve this issue reliably.
