### PR TITLE
esp32: create .uf2 builds where possible

### DIFF
--- a/ports/esp32/Makefile
+++ b/ports/esp32/Makefile
@@ -36,8 +36,9 @@ all:
 		$(BUILD)/sdkconfig \
 		$(BUILD)/bootloader/bootloader.bin \
 		$(BUILD)/partition_table/partition-table.bin \
-    		$(BUILD)/micropython.bin \
-    		$(BUILD)/firmware.bin
+		$(BUILD)/micropython.bin \
+		$(BUILD)/firmware.bin \
+		$(BUILD)/micropython.uf2
 
 $(BUILD)/bootloader/bootloader.bin $(BUILD)/partition_table/partition-table.bin $(BUILD)/micropython.bin: FORCE
 

--- a/ports/esp32/modules/flashbdev.py
+++ b/ports/esp32/modules/flashbdev.py
@@ -1,4 +1,7 @@
 from esp32 import Partition
 
+# MicroPython's partition table uses "vfs", TinyUF2 uses "ffat".
 bdev = Partition.find(Partition.TYPE_DATA, label="vfs")
+if not bdev:
+    bdev = Partition.find(Partition.TYPE_DATA, label="ffat")
 bdev = bdev[0] if bdev else None

--- a/tools/autobuild/build-boards.sh
+++ b/tools/autobuild/build-boards.sh
@@ -30,8 +30,8 @@ function build_board {
             dest=$dest_dir/$descr$fw_tag.$ext
             if [ -r $build_dir/firmware.$ext ]; then
                 mv $build_dir/firmware.$ext $dest
-            else
-                # esp32 has micropython.elf and micropython.map
+            elif [ -r $build_dir/micropython.$ext ]; then
+                # esp32 has micropython.elf, etc
                 mv $build_dir/micropython.$ext $dest
             fi
         done
@@ -93,7 +93,7 @@ function build_esp32_boards {
         else
             if [ $mcu != esp32 ]; then
                 # build esp32-s2/s3/c3 based boards with IDF v4.4+
-                build_board $board_json $fw_tag $dest_dir bin elf map
+                build_board $board_json $fw_tag $dest_dir bin elf map uf2
             fi
         fi
     done

--- a/tools/uf2families.json
+++ b/tools/uf2families.json
@@ -1,0 +1,192 @@
+[
+    {
+        "id": "0x16573617",
+        "short_name": "ATMEGA32",
+        "description": "Microchip (Atmel) ATmega32"
+    },
+    {
+        "id": "0x1851780a",
+        "short_name": "SAML21",
+        "description": "Microchip (Atmel) SAML21"
+    },
+    {
+        "id": "0x1b57745f",
+        "short_name": "NRF52",
+        "description": "Nordic NRF52"
+    },
+    {
+        "id": "0x1c5f21b0",
+        "short_name": "ESP32",
+        "description": "ESP32"
+    },
+    {
+        "id": "0x1e1f432d",
+        "short_name": "STM32L1",
+        "description": "ST STM32L1xx"
+    },
+    {
+        "id": "0x202e3a91",
+        "short_name": "STM32L0",
+        "description": "ST STM32L0xx"
+    },
+    {
+        "id": "0x21460ff0",
+        "short_name": "STM32WL",
+        "description": "ST STM32WLxx"
+    },
+    {
+        "id": "0x2abc77ec",
+        "short_name": "LPC55",
+        "description": "NXP LPC55xx"
+    },
+    {
+        "id": "0x300f5633",
+        "short_name": "STM32G0",
+        "description": "ST STM32G0xx"
+    },
+    {
+        "id": "0x31d228c6",
+        "short_name": "GD32F350",
+        "description": "GD32F350"
+    },
+    {
+        "id": "0x04240bdf",
+        "short_name": "STM32L5",
+        "description": "ST STM32L5xx"
+    },
+    {
+        "id": "0x4c71240a",
+        "short_name": "STM32G4",
+        "description": "ST STM32G4xx"
+    },
+    {
+        "id": "0x4fb2d5bd",
+        "short_name": "MIMXRT10XX",
+        "description": "NXP i.MX RT10XX"
+    },
+    {
+        "id": "0x53b80f00",
+        "short_name": "STM32F7",
+        "description": "ST STM32F7xx"
+    },
+    {
+        "id": "0x55114460",
+        "short_name": "SAMD51",
+        "description": "Microchip (Atmel) SAMD51"
+    },
+    {
+        "id": "0x57755a57",
+        "short_name": "STM32F4",
+        "description": "ST STM32F401"
+    },
+    {
+        "id": "0x5a18069b",
+        "short_name": "FX2",
+        "description": "Cypress FX2"
+    },
+    {
+        "id": "0x5d1a0a2e",
+        "short_name": "STM32F2",
+        "description": "ST STM32F2xx"
+    },
+    {
+        "id": "0x5ee21072",
+        "short_name": "STM32F1",
+        "description": "ST STM32F103"
+    },
+    {
+        "id": "0x621e937a",
+        "short_name": "NRF52833",
+        "description": "Nordic NRF52833"
+    },
+    {
+        "id": "0x647824b6",
+        "short_name": "STM32F0",
+        "description": "ST STM32F0xx"
+    },
+    {
+        "id": "0x68ed2b88",
+        "short_name": "SAMD21",
+        "description": "Microchip (Atmel) SAMD21"
+    },
+    {
+        "id": "0x6b846188",
+        "short_name": "STM32F3",
+        "description": "ST STM32F3xx"
+    },
+    {
+        "id": "0x6d0922fa",
+        "short_name": "STM32F407",
+        "description": "ST STM32F407"
+    },
+    {
+        "id": "0x6db66082",
+        "short_name": "STM32H7",
+        "description": "ST STM32H7xx"
+    },
+    {
+        "id": "0x70d16653",
+        "short_name": "STM32WB",
+        "description": "ST STM32WBxx"
+    },
+    {
+        "id": "0x7eab61ed",
+        "short_name": "ESP8266",
+        "description": "ESP8266"
+    },
+    {
+        "id": "0x7f83e793",
+        "short_name": "KL32L2",
+        "description": "NXP KL32L2x"
+    },
+    {
+        "id": "0x8fb060fe",
+        "short_name": "STM32F407VG",
+        "description": "ST STM32F407VG"
+    },
+    {
+        "id": "0xada52840",
+        "short_name": "NRF52840",
+        "description": "Nordic NRF52840"
+    },
+    {
+        "id": "0xbfdd4eee",
+        "short_name": "ESP32S2",
+        "description": "ESP32-S2"
+    },
+    {
+        "id": "0xc47e5767",
+        "short_name": "ESP32S3",
+        "description": "ESP32-S3"
+    },
+    {
+        "id": "0xd42ba06c",
+        "short_name": "ESP32C3",
+        "description": "ESP32-C3"
+    },
+    {
+        "id": "0x2b88d29c",
+        "short_name": "ESP32C2",
+        "description": "ESP32-C2"
+    },
+    {
+        "id": "0x332726f6",
+        "short_name": "ESP32H2",
+        "description": "ESP32-H2"
+    },
+    {
+        "id": "0xe48bff56",
+        "short_name": "RP2040",
+        "description": "Raspberry Pi RP2040"
+    },
+    {
+        "id": "0x00ff6919",
+        "short_name": "STM32L4",
+        "description": "ST STM32L4xx"
+    },
+    {
+        "id": "0x9af03e33",
+        "short_name": "GD32VF103",
+        "description": "GigaDevice GD32VF103"
+    }
+]


### PR DESCRIPTION
- support both `"vfs"` and `"ffat"` for the name of the filesytem partition
- update uf2conv.py to the latest version
- build `micropython.uf2` image as part of the standard esp32 build
- make above firmware available in autobuild