### PR TITLE
tools/mpremote: Accept both --help and help to show usage.

### DIFF
--- a/tools/mpremote/mpremote/main.py
+++ b/tools/mpremote/mpremote/main.py
@@ -96,6 +96,7 @@ _BUILTIN_COMMAND_EXPANSIONS = {
         "exec",
         "import machine; machine.RTC().datetime((2020, 1, 1, 0, 10, 0, 0, 0))",
     ],
+    "--help": "help",
 }
 
 for port_num in range(4):


### PR DESCRIPTION
For new users, it's hard to find mpremote usagfe details as the standard `--help` command doesn't work.

While using `help` is consistent with all the other commands on `mpremote`, accepting `--help` as well makes it easier to find.