### PR TITLE
rp2/uart: Fix UART RTS not working.

### DIFF
--- a/ports/rp2/machine_uart.c
+++ b/ports/rp2/machine_uart.c
@@ -109,10 +109,10 @@ STATIC const char *_invert_name[] = {"None", "INV_TX", "INV_RX", "INV_TX|INV_RX"
 /******************************************************************************/
 // IRQ and buffer handling
 
-// take all bytes from the fifo and store them, if possible, in the buffer
+// take all bytes from the fifo and store them in the buffer
 STATIC void uart_drain_rx_fifo(machine_uart_obj_t *self) {
-    while (uart_is_readable(self->uart)) {
-        // try to write the data, ignore the fail
+    while (uart_is_readable(self->uart) && ringbuf_free(&self->read_buffer) > 0) {
+        // get a byte from uart and put into the buffer
         ringbuf_put(&(self->read_buffer), uart_get_hw(self->uart)->dr);
     }
 }


### PR DESCRIPTION
UART HW flow control in RP2 port is not working. Receive FIFO is always fetched and RTS is never deasserted.

This is not a problem when HW flow control is not used: Normally, if receive FIFO is full, UART Receiver won't receive data into FIFO anymore but current implementation fetch from FIFO and discard it instead. Problem is data is discarded even when RTS is enabled.

Can be tested simply with loopback (connect GPIO0 to GPIO1 and GIPO2 to GPIO3):
```python
# assuming UART loopback 
from machine import Pin, UART
cts = Pin(2)
rts = Pin(3)
u = UART(0, cts=cts, rts=rts, timeout=100, flow=UART.CTS|UART.RTS)
d = b'A'*255+b'#'
u.write(b'A'*256 + b'?'*256) # => 512. actually, the latter '?' bytes are discarded.
# subsequent write calls always returns success but data is discarded.
u.write(b'A'*256 + b'?'*256) # => 512. Should return None
rts.value() # is 0. should be 1
u.read(512) # => 256 'A' bytes
u.read(512) # => None
```
