### PR TITLE
docs/library/uasyncio.rst: fix description of ThreadSafeFlag

### DIFF
--- a/docs/library/uasyncio.rst
+++ b/docs/library/uasyncio.rst
@@ -159,7 +159,7 @@ class ThreadSafeFlag
 .. method:: ThreadSafeFlag.wait()
 
     Wait for the flag to be set.  If the flag is already set then it returns
-    immediately.
+    immediately. The flag is automatically reset upon return from ``wait``.
 
     A flag may only be waited on by a single task at a time.
 


### PR DESCRIPTION
When a task waits on a ThreadSafeFlag (and the wait method returns), the
flag is immediately reset. This was not clear in the documentation, which
appeared to copy the description of the wait method from the Event class.
