### PR TITLE
rp2: Change the RTS behavior.

### DIFF
--- a/ports/rp2/machine_uart.c
+++ b/ports/rp2/machine_uart.c
@@ -112,8 +112,13 @@ STATIC const char *_invert_name[] = {"None", "INV_TX", "INV_RX", "INV_TX|INV_RX"
 // take all bytes from the fifo and store them, if possible, in the buffer
 STATIC void uart_drain_rx_fifo(machine_uart_obj_t *self) {
     while (uart_is_readable(self->uart)) {
-        // try to write the data, ignore the fail
-        ringbuf_put(&(self->read_buffer), uart_get_hw(self->uart)->dr);
+        // try to get & store the data, but only if space is available.
+        // If no space is available, wait for the buffer to get cleared.
+        if (ringbuf_free(&(self->read_buffer)) > 0) {
+            ringbuf_put(&(self->read_buffer), uart_get_hw(self->uart)->dr);
+        } else {
+            break;
+        }
     }
 }
 


### PR DESCRIPTION
When the buffer is full, the UART fifo will not be cleared now. Tested
with sending 1000 bytes and reading in chunks of 100, 200, 300, 400,
500 bytes with 100 ms delay between the read calls.

The sender may time out if the total overal read rate is too slow. But
in any case the number of bytes sent matches the number of bytes
received.

![read_chunk_100](https://user-images.githubusercontent.com/12476868/152769723-359b082f-98b0-4b1c-9366-2a7bde84e615.png)

![read_chunk_500](https://user-images.githubusercontent.com/12476868/152769754-5818f45e-ebfc-43b3-8c32-86aa1d2af399.png)


