### PR TITLE
ports/esp32: ADC adcblock bit setting fix for ESP32-S3.

### DIFF
--- a/ports/esp32/machine_adcblock.c
+++ b/ports/esp32/machine_adcblock.c
@@ -40,10 +40,10 @@
 #define DEFAULT_VREF 1100
 
 madcblock_obj_t madcblock_obj[] = {
-    #if CONFIG_IDF_TARGET_ESP32 || CONFIG_IDF_TARGET_ESP32C3
+    #if CONFIG_IDF_TARGET_ESP32 || CONFIG_IDF_TARGET_ESP32C3 || CONFIG_IDF_TARGET_ESP32S3
     {{&machine_adcblock_type}, ADC_UNIT_1, 12, -1, {0}},
     {{&machine_adcblock_type}, ADC_UNIT_2, 12, -1, {0}},
-    #elif CONFIG_IDF_TARGET_ESP32S2 || CONFIG_IDF_TARGET_ESP32S3
+    #elif CONFIG_IDF_TARGET_ESP32S2
     {{&machine_adcblock_type}, ADC_UNIT_1, 13, -1, {0}},
     {{&machine_adcblock_type}, ADC_UNIT_2, 13, -1, {0}},
     #endif


### PR DESCRIPTION
The bit was set wrong for ESP32-S3 - It's not 13bit like the S2, but 12bit.

That said, ADC is busted, at least on the S3 - Initial read (or read_uv) works, then every subsequent read returns 0.
I've not had a chance to test S2 or ESP32 yet