### PR TITLE
Allow Unix variant to override MICROPY_EVENT_POLL_HOOK

### DIFF
--- a/ports/unix/mpconfigport.h
+++ b/ports/unix/mpconfigport.h
@@ -324,12 +324,14 @@ static inline unsigned long mp_urandom_seed_init(void) {
 #define MICROPY_END_ATOMIC_SECTION(x) (void)x; mp_thread_unix_end_atomic_section()
 #endif
 
+#ifndef MICROPY_EVENT_POLL_HOOK
 #define MICROPY_EVENT_POLL_HOOK \
     do { \
         extern void mp_handle_pending(bool); \
         mp_handle_pending(true); \
         usleep(500); /* equivalent to mp_hal_delay_us(500) */ \
     } while (0);
+#endif
 
 #include <sched.h>
 #define MICROPY_UNIX_MACHINE_IDLE sched_yield();


### PR DESCRIPTION
This allows unix variants to extend or replace more config options:

- extend builtin modules
- extend root pointers
- replace event poll hook