### PR TITLE
esp32/uart: Correctly init uart driver for repl.

### DIFF
--- a/ports/esp32/main.c
+++ b/ports/esp32/main.c
@@ -93,7 +93,7 @@ void mp_task(void *pvParameter) {
     #elif CONFIG_ESP_CONSOLE_USB_SERIAL_JTAG
     usb_serial_jtag_init();
     #else
-    uart_init();
+    uart_stdout_init();
     #endif
     machine_init();
 

--- a/ports/esp32/mphalport.c
+++ b/ports/esp32/mphalport.c
@@ -33,16 +33,6 @@
 #include "freertos/FreeRTOS.h"
 #include "freertos/task.h"
 
-#if CONFIG_IDF_TARGET_ESP32
-#include "esp32/rom/uart.h"
-#elif CONFIG_IDF_TARGET_ESP32C3
-#include "esp32c3/rom/uart.h"
-#elif CONFIG_IDF_TARGET_ESP32S2
-#include "esp32s2/rom/uart.h"
-#elif CONFIG_IDF_TARGET_ESP32S3
-#include "esp32s3/rom/uart.h"
-#endif
-
 #include "py/obj.h"
 #include "py/objstr.h"
 #include "py/stream.h"
@@ -54,6 +44,7 @@
 #include "mphalport.h"
 #include "usb.h"
 #include "usb_serial_jtag.h"
+#include "uart.h"
 
 TaskHandle_t mp_main_task_handle;
 
@@ -122,9 +113,7 @@ void mp_hal_stdout_tx_strn(const char *str, size_t len) {
     #elif CONFIG_ESP_CONSOLE_USB_SERIAL_JTAG
     usb_serial_jtag_tx_strn(str, len);
     #else
-    for (uint32_t i = 0; i < len; ++i) {
-        uart_tx_one_char(str[i]);
-    }
+    uart_stdout_tx_strn(str, len);
     #endif
     if (release_gil) {
         MP_THREAD_GIL_ENTER();

--- a/ports/esp32/uart.c
+++ b/ports/esp32/uart.c
@@ -27,19 +27,61 @@
  */
 
 #include <stdio.h>
-
+#include "uart.h"
 #include "driver/uart.h"
 #include "soc/uart_periph.h"
 
 #include "py/runtime.h"
 #include "py/mphal.h"
 
+#ifndef MICROPY_HW_UART_REPL
+#define MICROPY_HW_UART_REPL   UART_NUM_0
+#endif
+
+#ifndef MICROPY_HW_UART_REPL_BAUD
+#define MICROPY_HW_UART_REPL_BAUD   115200
+#endif
+
 STATIC void uart_irq_handler(void *arg);
 
-void uart_init(void) {
+void uart_stdout_init(void) {
+    uart_config_t uartcfg = {
+        .baud_rate = MICROPY_HW_UART_REPL_BAUD,
+        .data_bits = UART_DATA_8_BITS,
+        .parity = UART_PARITY_DISABLE,
+        .stop_bits = UART_STOP_BITS_1,
+        .flow_ctrl = UART_HW_FLOWCTRL_DISABLE,
+        .rx_flow_ctrl_thresh = 0
+    };
+    uart_param_config(MICROPY_HW_UART_REPL, &uartcfg);
+
+    const uint32_t rxbuf = 129; // IDF requires > 128 min
+    const uint32_t txbuf = 0;
+
+    uart_driver_install(MICROPY_HW_UART_REPL, rxbuf, txbuf, 0, NULL, 0);
+
     uart_isr_handle_t handle;
-    uart_isr_register(UART_NUM_0, uart_irq_handler, NULL, ESP_INTR_FLAG_LOWMED | ESP_INTR_FLAG_IRAM, &handle);
-    uart_enable_rx_intr(UART_NUM_0);
+    uart_isr_free(MICROPY_HW_UART_REPL);
+    uart_isr_register(MICROPY_HW_UART_REPL, uart_irq_handler, NULL, ESP_INTR_FLAG_LOWMED | ESP_INTR_FLAG_IRAM, &handle);
+    uart_enable_rx_intr(MICROPY_HW_UART_REPL);
+}
+
+int uart_stdout_tx_strn(const char *str, size_t len) {
+    size_t remaining = len;
+    // TODO add a timeout
+    while (1) {
+        int ret = uart_tx_chars(MICROPY_HW_UART_REPL, str, remaining);
+        if (ret == -1) {
+            return -1;
+        }
+        remaining -= ret;
+        if (remaining <= 0) {
+            break;
+        }
+        str += ret;
+        ulTaskNotifyTake(pdFALSE, 1);
+    }
+    return len - remaining;
 }
 
 // all code executed in ISR must be in IRAM, and any const data must be in DRAM

--- a/ports/esp32/uart.h
+++ b/ports/esp32/uart.h
@@ -28,6 +28,7 @@
 #ifndef MICROPY_INCLUDED_ESP32_UART_H
 #define MICROPY_INCLUDED_ESP32_UART_H
 
-void uart_init(void);
+void uart_stdout_init(void);
+int uart_stdout_tx_strn(const char *str, size_t len);
 
 #endif // MICROPY_INCLUDED_ESP32_UART_H


### PR DESCRIPTION
Initial attempt to replace the low level "raw" uart driver in uart0 (repl) with the standard high level idf uart driver.

There's some code cleanup (include files) still required, and possibly removal of the ringbuffer still in use for usb / dupterm?
Not sure if any of the other uart event queue types would be useful for anything (example code commented out currently).

Tested with the following test script:
```
import uos
import time
def run_test():
    start = time.ticks_us()
    loops = 5
    for _ in range(loops):

        uos.listdir('.')
        with open('micropython.map', 'r') as f:
            for line in f.readline():
                pass

    end = time.ticks_us()
    taken = time.ticks_diff(end, start) / 5
    print(f"taken: {taken/1000}us", )
```

with `mpremote mount .`

on master: 
```
Local directory . is mounted at /remote
Connected to MicroPython at COM3
Use Ctrl-] to exit this shell
>
MicroPython v1.18-74-gfeeeb5ea3-dirty on 2022-02-09; ESP32 module with ESP32
Type "help()" for more information.
>>> import test;test.run_test()
taken: 1826.761us
>>> import test;test.run_test()
taken: 1824.004us
```

With this branch:
```
Local directory . is mounted at /remote
Connected to MicroPython at COM3
Use Ctrl-] to exit this shell
>
MicroPython v1.18-75-gc1bfd6616-dirty on 2022-02-09; ESP32 module with ESP32
Type "help()" for more information.
>>> import test;test.run_test()
taken: 1701.49us
>>> import test;test.run_test()
taken: 1704.198us
```

Ctrl-C seems to work from repl, eg
```
>>> import time
>>> while 1:
...     time.sleep(1)
...     print(1)
...
1
1
Traceback (most recent call last):
  File "<stdin>", line 2, in <module>
KeyboardInterrupt:
```

For related information see https://github.com/micropython/micropython/pull/8255 and https://github.com/micropython/micropython/issues/8277