### PR TITLE
ESP32: new/reworked GPIO hold functionality

### DIFF
--- a/docs/esp32/quickref.rst
+++ b/docs/esp32/quickref.rst
@@ -177,6 +177,14 @@ safe maximum source/sink currents and approximate internal driver resistances:
  - ``Pin.DRIVE_2``: 20mA / 30 ohm (default strength if not configured)
  - ``Pin.DRIVE_3``: 40mA / 15 ohm
 
+The ``hold=`` keyword argument to ``Pin()`` and ``Pin.init()`` will enable the
+ESP32 "pad hold" feature. When set to ``True``, the pin configuration
+(direction, pull resistors and output value) will be held and any further
+changes (including changing the output level) will not be applied. Setting
+``hold=False`` will immediately apply any outstanding pin configuration changes
+and release the pin. Using ``hold=True`` while a pin is already held will apply
+any configuration changes and then immediately reapply the hold.
+
 Notes:
 
 * Pins 1 and 3 are REPL UART TX and RX respectively
@@ -548,6 +556,10 @@ deep-sleep mode::
     # disable pull-up and put the device to sleep for 10 seconds
     pin.init(pull=None)
     machine.deepsleep(10000)
+
+Output-configured RTC pins will also retain their output direction and level in
+deep-sleep if pad hold is enabled with the ``hold=True`` argument to
+``Pin.init()``.
 
 Non-RTC GPIO pins will be disconnected by default on entering deep-sleep.
 

--- a/docs/esp32/quickref.rst
+++ b/docs/esp32/quickref.rst
@@ -562,6 +562,23 @@ deep-sleep if pad hold is enabled with the ``hold=True`` argument to
 ``Pin.init()``.
 
 Non-RTC GPIO pins will be disconnected by default on entering deep-sleep.
+Configuration of non-RTC pins - including output level - can be retained by
+enabling pad hold on the pin and enabling GPIO pad hold during deep-sleep::
+
+    from machine import Pin, deepsleep
+    import esp32
+
+    opin = Pin(19, Pin.OUT, value=1, hold=True) # hold output level
+    ipin = Pin(21, Pin.IN, Pin.PULL_UP, hold=True) # hold pull-up
+
+    # enable pad hold in deep-sleep for non-RTC GPIO
+    esp32.gpio_deep_sleep_hold(True)
+
+    # put the device to sleep for 10 seconds
+    deepsleep(10000)
+
+The pin configuration - including the pad hold - will be retained on wake from
+sleep. See :ref:`Pins_and_GPIO` above for a further discussion of pad holding.
 
 SD card
 -------

--- a/docs/library/esp32.rst
+++ b/docs/library/esp32.rst
@@ -30,6 +30,11 @@ Functions
     or a tuple/list of valid Pin objects.  *level* should be ``esp32.WAKEUP_ALL_LOW``
     or ``esp32.WAKEUP_ANY_HIGH``.
 
+.. function:: gpio_deep_sleep_hold(enable)
+
+    Configure whether non-RTC GPIO pin configuration is retained during
+    deep-sleep mode for held pads. *enable* should be a boolean value.
+
 .. function:: raw_temperature()
 
     Read the raw value of the internal temperature sensor, returning an integer.

--- a/ports/esp32/boards/UM_TINYPICO/modules/tinypico.py
+++ b/ports/esp32/boards/UM_TINYPICO/modules/tinypico.py
@@ -83,10 +83,11 @@ def set_dotstar_power(state):
     """Set the power for the on-board Dotstar to allow no current draw when not needed."""
     # Set the power pin to the inverse of state
     if state:
-        Pin(DOTSTAR_PWR, Pin.OUT, None)  # Break the PULL_HOLD on the pin
-        Pin(DOTSTAR_PWR).value(False)  # Set the pin to LOW to enable the Transistor
+        Pin(DOTSTAR_PWR, Pin.OUT, None, value=0)  # Drive output to LOW to enable transistor
     else:
-        Pin(13, Pin.IN, Pin.PULL_HOLD)  # Set PULL_HOLD on the pin to allow the 3V3 pull-up to work
+        Pin(
+            DOTSTAR_PWR, Pin.IN, None
+        )  # Disable output and allow external pull-up to disable transistor
 
     Pin(
         DOTSTAR_CLK, Pin.OUT if state else Pin.IN

--- a/ports/esp32/machine_pin.c
+++ b/ports/esp32/machine_pin.c
@@ -47,7 +47,6 @@
 // Used to implement a range of pull capabilities
 #define GPIO_PULL_DOWN (1)
 #define GPIO_PULL_UP   (2)
-#define GPIO_PULL_HOLD (4)
 
 #if CONFIG_IDF_TARGET_ESP32
 #define GPIO_FIRST_NON_OUTPUT (34)
@@ -253,14 +252,15 @@ STATIC void machine_pin_print(const mp_print_t *print, mp_obj_t self_in, mp_prin
     mp_printf(print, "Pin(%u)", self->id);
 }
 
-// pin.init(mode=None, pull=-1, *, value, drive)
+// pin.init(mode=None, pull=-1, *, value, drive, hold)
 STATIC mp_obj_t machine_pin_obj_init_helper(const machine_pin_obj_t *self, size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
-    enum { ARG_mode, ARG_pull, ARG_value, ARG_drive };
+    enum { ARG_mode, ARG_pull, ARG_value, ARG_drive, ARG_hold };
     static const mp_arg_t allowed_args[] = {
         { MP_QSTR_mode, MP_ARG_OBJ, {.u_obj = mp_const_none}},
         { MP_QSTR_pull, MP_ARG_OBJ, {.u_obj = MP_OBJ_NEW_SMALL_INT(-1)}},
         { MP_QSTR_value, MP_ARG_KW_ONLY | MP_ARG_OBJ, {.u_obj = MP_OBJ_NULL}},
         { MP_QSTR_drive, MP_ARG_KW_ONLY | MP_ARG_OBJ, {.u_obj = MP_OBJ_NULL}},
+        { MP_QSTR_hold, MP_ARG_KW_ONLY | MP_ARG_OBJ, {.u_obj = MP_OBJ_NULL}},
     };
 
     // parse args
@@ -325,10 +325,15 @@ STATIC mp_obj_t machine_pin_obj_init_helper(const machine_pin_obj_t *self, size_
         } else {
             gpio_pullup_dis(self->id);
         }
-        if (mode & GPIO_PULL_HOLD) {
+    }
+
+    // configure pad hold
+    if (args[ARG_hold].u_obj != MP_OBJ_NULL && GPIO_IS_VALID_OUTPUT_GPIO(self->id)) {
+        // always disable pad hold to apply outstanding config changes
+        gpio_hold_dis(self->id);
+        // (re-)enable pad hold if requested
+        if (mp_obj_is_true(args[ARG_hold].u_obj)) {
             gpio_hold_en(self->id);
-        } else if (GPIO_IS_VALID_OUTPUT_GPIO(self->id)) {
-            gpio_hold_dis(self->id);
         }
     }
 
@@ -480,7 +485,6 @@ STATIC const mp_rom_map_elem_t machine_pin_locals_dict_table[] = {
     { MP_ROM_QSTR(MP_QSTR_OPEN_DRAIN), MP_ROM_INT(GPIO_MODE_INPUT_OUTPUT_OD) },
     { MP_ROM_QSTR(MP_QSTR_PULL_UP), MP_ROM_INT(GPIO_PULL_UP) },
     { MP_ROM_QSTR(MP_QSTR_PULL_DOWN), MP_ROM_INT(GPIO_PULL_DOWN) },
-    { MP_ROM_QSTR(MP_QSTR_PULL_HOLD), MP_ROM_INT(GPIO_PULL_HOLD) },
     { MP_ROM_QSTR(MP_QSTR_IRQ_RISING), MP_ROM_INT(GPIO_PIN_INTR_POSEDGE) },
     { MP_ROM_QSTR(MP_QSTR_IRQ_FALLING), MP_ROM_INT(GPIO_PIN_INTR_NEGEDGE) },
     { MP_ROM_QSTR(MP_QSTR_WAKE_LOW), MP_ROM_INT(GPIO_PIN_INTR_LOLEVEL) },

--- a/ports/esp32/modesp32.c
+++ b/ports/esp32/modesp32.c
@@ -131,6 +131,16 @@ STATIC mp_obj_t esp32_wake_on_ext1(size_t n_args, const mp_obj_t *pos_args, mp_m
 }
 STATIC MP_DEFINE_CONST_FUN_OBJ_KW(esp32_wake_on_ext1_obj, 0, esp32_wake_on_ext1);
 
+STATIC mp_obj_t esp32_gpio_deep_sleep_hold(const mp_obj_t enable) {
+    if (mp_obj_is_true(enable)) {
+        gpio_deep_sleep_hold_en();
+    } else {
+        gpio_deep_sleep_hold_dis();
+    }
+    return mp_const_none;
+}
+STATIC MP_DEFINE_CONST_FUN_OBJ_1(esp32_gpio_deep_sleep_hold_obj, esp32_gpio_deep_sleep_hold);
+
 #if CONFIG_IDF_TARGET_ESP32
 
 #include "soc/sens_reg.h"
@@ -187,6 +197,7 @@ STATIC const mp_rom_map_elem_t esp32_module_globals_table[] = {
     { MP_ROM_QSTR(MP_QSTR_wake_on_touch), MP_ROM_PTR(&esp32_wake_on_touch_obj) },
     { MP_ROM_QSTR(MP_QSTR_wake_on_ext0), MP_ROM_PTR(&esp32_wake_on_ext0_obj) },
     { MP_ROM_QSTR(MP_QSTR_wake_on_ext1), MP_ROM_PTR(&esp32_wake_on_ext1_obj) },
+    { MP_ROM_QSTR(MP_QSTR_gpio_deep_sleep_hold), MP_ROM_PTR(&esp32_gpio_deep_sleep_hold_obj) },
     #if CONFIG_IDF_TARGET_ESP32
     { MP_ROM_QSTR(MP_QSTR_raw_temperature), MP_ROM_PTR(&esp32_raw_temperature_obj) },
     { MP_ROM_QSTR(MP_QSTR_hall_sensor), MP_ROM_PTR(&esp32_hall_sensor_obj) },


### PR DESCRIPTION
The current `pull=Pin.PULL_HOLD` argument doesn't make a lot of sense in the context of what it actually does vs what the ESP32 quickref document says it does.

This patch proposes dumping this and adding a new `hold=True|False` keyword argument to `Pin()`/`Pin.init()`. Setting this to `True` will cause the ESP32 to lock the configuration of the pin – including direction, output value, drive strength, pull-up/-down – such that it can't be accidentally changed and will be retained through a watchdog or internal reset.

In addition, a new `gpio_deep_sleep_hold(True|False)` function in the `esp32` module allows this behaviour to be extended to entering and waking from deep-sleep.

~~Support for configuring output drive strength is also added through the standard `drive` keyword argument and constants:~~

- ~~`Pin.DRIVE_WEAK`~~
- ~~`Pin.DRIVE_LOW`~~
- ~~`Pin.DRIVE_MED` (default pin drive strength)~~
- ~~`Pin.DRIVE_HIGH`~~

**Edit: see comment below about moving of drive strength commits**

Will write documentation if this looks like being accepted.

I'm also happy to put back in some kind of legacy compatibility for `pull=Pin.PULL_HOLD` if there's concern that this is being used in the wild for what it actually does (rather than what it's documented as doing).

Fixes #8283