### PR TITLE
ports/windows/appveyor: Fix printing failures.

### DIFF
--- a/ports/windows/.appveyor.yml
+++ b/ports/windows/.appveyor.yml
@@ -80,6 +80,7 @@ after_test:
     }
     C:\msys64\usr\bin\bash.exe -l -c "make V=1 test_full VARIANT=$($env:PyVariant)"
     if ($LASTEXITCODE -ne 0) {
+      cd (Join-Path $env:APPVEYOR_BUILD_FOLDER 'tests')
       & $env:MICROPY_CPYTHON3 run-tests.py --print-failures
       throw "Test failure"
     }


### PR DESCRIPTION
In the `after_test` section, the current directory is `ports/windows` when tests are run, so running `run-tests.py` without changing the directory or specifying a path causes a file not found error.

Example: https://ci.appveyor.com/project/dpgeorge/micropython/builds/42496556/job/rbst16l9n98v52q8#L4525

This fixes the problem by changing the directory before calling `run-tests.py`.
