### PR TITLE
tools/verifygitlog: Ignore line length if URL.

### DIFF
--- a/tools/verifygitlog.py
+++ b/tools/verifygitlog.py
@@ -69,7 +69,8 @@ def verify(sha):
 
     # Message body lines.
     for line in raw_body[2:]:
-        if len(line) >= 76:
+        # Long lines with URLs are exempt from the line length rule.
+        if len(line) >= 76 and "://" not in line:
             error("Message lines should be 75 or less characters: " + line)
 
     if not raw_body[-1].startswith("Signed-off-by: ") or "@" not in raw_body[-1]:


### PR DESCRIPTION
This changes the git commit message line length check to ignore lines that contain URLs since these cannot be wrapped without breaking tools that detect URLs and create a link.

Example of CI failure: https://github.com/micropython/micropython/runs/5128475481?check_suite_focus=true#step:4:11
