### PR TITLE
ninaw10: Add NIC-level ioctl function.

### DIFF
--- a/drivers/ninaw10/nina_wifi_drv.c
+++ b/drivers/ninaw10/nina_wifi_drv.c
@@ -701,6 +701,33 @@ int nina_gethostbyname(const char *name, uint8_t *out_ip) {
     return 0;
 }
 
+int nina_ioctl(uint32_t cmd, size_t len, uint8_t *buf, uint32_t iface) {
+    switch (cmd) {
+        case NINA_CMD_SET_PIN_MODE:
+            if (len != 2 || nina_send_command_read_ack(NINA_CMD_SET_PIN_MODE,
+                2, ARG_8BITS, NINA_ARGS(ARG_BYTE(buf[0]), ARG_BYTE(buf[1]))) != SPI_ACK) {
+                return -1;
+            }
+            break;
+        case NINA_CMD_SET_DIGITAL_WRITE:
+            if (len != 2 || nina_send_command_read_ack(NINA_CMD_SET_DIGITAL_WRITE,
+                2, ARG_8BITS, NINA_ARGS(ARG_BYTE(buf[0]), ARG_BYTE(buf[1]))) != SPI_ACK) {
+                return -1;
+            }
+            break;
+        case NINA_CMD_GET_DIGITAL_READ:
+            if (len != 1 || nina_send_command_read_vals(NINA_CMD_GET_DIGITAL_READ,
+                1, ARG_8BITS, NINA_ARGS(ARG_BYTE(buf[0])),
+                1, ARG_8BITS, NINA_VALS({(uint16_t *)&len, buf})) != 0) {
+                return -1;
+            }
+            break;
+        default:
+            return 0;
+    }
+    return 0;
+}
+
 int nina_socket_socket(uint8_t type) {
     uint16_t size = 1;
     uint8_t sock = 0;

--- a/drivers/ninaw10/nina_wifi_drv.h
+++ b/drivers/ninaw10/nina_wifi_drv.h
@@ -100,6 +100,7 @@ int nina_get_rssi(void);
 int nina_fw_version(uint8_t *fw_ver);
 int nina_set_hostname(const char *name);
 int nina_gethostbyname(const char *name, uint8_t *out_ip);
+int nina_ioctl(uint32_t cmd, size_t len, uint8_t *buf, uint32_t iface);
 int nina_socket_socket(uint8_t type);
 int nina_socket_close(int fd);
 int nina_socket_bind(int fd, uint8_t *ip, uint16_t port, int type);

--- a/extmod/network_ninaw10.c
+++ b/extmod/network_ninaw10.c
@@ -317,6 +317,15 @@ STATIC mp_obj_t network_ninaw10_status(size_t n_args, const mp_obj_t *args) {
 }
 STATIC MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(network_ninaw10_status_obj, 1, 2, network_ninaw10_status);
 
+STATIC mp_obj_t network_ninaw10_ioctl(mp_obj_t self_in, mp_obj_t cmd_in, mp_obj_t buf_in) {
+    nina_obj_t *self = MP_OBJ_TO_PTR(self_in);
+    mp_buffer_info_t buf;
+    mp_get_buffer_raise(buf_in, &buf, MP_BUFFER_READ | MP_BUFFER_WRITE);
+    nina_ioctl(mp_obj_get_int(cmd_in), buf.len, buf.buf, self->itf);
+    return mp_const_none;
+}
+STATIC MP_DEFINE_CONST_FUN_OBJ_3(network_ninaw10_ioctl_obj, network_ninaw10_ioctl);
+
 STATIC int network_ninaw10_gethostbyname(mp_obj_t nic, const char *name, mp_uint_t len, uint8_t *out_ip) {
     return nina_gethostbyname(name, out_ip);
 }
@@ -586,6 +595,7 @@ static const mp_rom_map_elem_t nina_locals_dict_table[] = {
     { MP_ROM_QSTR(MP_QSTR_ifconfig),            MP_ROM_PTR(&network_ninaw10_ifconfig_obj) },
     { MP_ROM_QSTR(MP_QSTR_config),              MP_ROM_PTR(&network_ninaw10_config_obj) },
     { MP_ROM_QSTR(MP_QSTR_status),              MP_ROM_PTR(&network_ninaw10_status_obj) },
+    { MP_ROM_QSTR(MP_QSTR_ioctl),               MP_ROM_PTR(&network_ninaw10_ioctl_obj) },
 
     // Network is not secured.
     { MP_ROM_QSTR(MP_QSTR_OPEN),                MP_ROM_INT(NINA_SEC_OPEN) },


### PR DESCRIPTION
* Adds support for irregular commands, such as controlling GPIO pins.
* Currently supports setting GPIO pin mode, and GPIO pin read/write value.

Example usage to blink LED connected to GPIO pin:

```Python
import network, time
wlan = network.WLAN()
wlan.active(True)

GPIO_MODE = 0x50
GPIO_WRITE = 0x51
GPIO_OUTPUT= 1
wlan.ioctl(GPIO_MODE, bytearray((26, GPIO_OUTPUT)))
while (True):
    wlan.ioctl(GPIO_WRITE, bytearray((26, 0)))
    time.sleep_ms(250)
    wlan.ioctl(GPIO_WRITE, bytearray((26, 1)))
    time.sleep_ms(250)
```