### PR TITLE
stm32/powerctrl: Add USB support to lightsleep.

### DIFF
--- a/ports/stm32/powerctrl.c
+++ b/ports/stm32/powerctrl.c
@@ -30,6 +30,7 @@
 #include "powerctrl.h"
 #include "rtc.h"
 #include "extmod/modbluetooth.h"
+#include "usb.h"
 #ifndef NO_QSTR
 #include "genhdr/pllfreqtable.h"
 #endif
@@ -792,6 +793,13 @@ static void powerctrl_low_power_exit_wb55() {
 #endif
 
 void powerctrl_enter_stop_mode(void) {
+    #if MICROPY_HW_STM_USB_STACK
+    bool usb_connected = pyb_usb_dev_connected();
+    if (usb_connected) {
+        pyb_usb_dev_disconnect();
+    }
+    #endif
+
     // Disable IRQs so that the IRQ that wakes the device from stop mode is not
     // executed until after the clocks are reconfigured
     uint32_t irq_state = disable_irq();
@@ -1047,6 +1055,12 @@ void powerctrl_enter_stop_mode(void) {
 
     // Enable IRQs now that all clocks are reconfigured
     enable_irq(irq_state);
+
+    #if MICROPY_HW_STM_USB_STACK
+    if (usb_connected) {
+        pyb_usb_dev_connect();
+    }
+    #endif
 }
 
 #if defined(STM32N6)

--- a/ports/stm32/usb.c
+++ b/ports/stm32/usb.c
@@ -353,6 +353,19 @@ void pyb_usb_dev_deinit(void) {
     }
 }
 
+bool pyb_usb_dev_connected(void) {
+    usb_device_t *usb_dev = &usb_device;
+    return usb_dev->hUSBDDevice.dev_state == USBD_STATE_CONFIGURED;
+}
+
+void pyb_usb_dev_disconnect(void) {
+    HAL_PCD_DevDisconnect(usb_device.hUSBDDevice.pData);
+}
+
+void pyb_usb_dev_connect(void) {
+    HAL_PCD_DevConnect(usb_device.hUSBDDevice.pData);
+}
+
 bool usb_vcp_is_enabled(void) {
     return usb_device.enabled;
 }

--- a/ports/stm32/usb.h
+++ b/ports/stm32/usb.h
@@ -66,6 +66,9 @@ void pyb_usb_init0(void);
 int pyb_usb_dev_detect(void);
 bool pyb_usb_dev_init(int dev_id, uint16_t vid, uint16_t pid, uint8_t mode, size_t msc_n, const void *msc_unit, USBD_HID_ModeInfoTypeDef *hid_info);
 void pyb_usb_dev_deinit(void);
+bool pyb_usb_dev_connected(void);
+void pyb_usb_dev_disconnect(void);
+void pyb_usb_dev_connect(void);
 bool usb_vcp_is_enabled(void);
 int usb_vcp_recv_byte(uint8_t *c); // if a byte is available, return 1 and put the byte in *c, else return 0
 void usb_vcp_send_strn(const char *str, int len);


### PR DESCRIPTION
Currently on stm32, if usb cdc repl is in use when `machine.lightsleep()` is run, the reply locks up and never recovers.
The micro itself will wake up and continue on with the code, but no data can be read/written to USB.

The PC thinks the USB is still connected, however no data is transferred. 

If the USB is unplugged / replugged the connection recovers - assuming the device is self-powered it continues working with a normal re-connection of the USB, a reboot is not required.

This PR fixes the issue by explicitely disconnecting / reconnecting the USB in code before and after the STOP call.

While it would be nicer to not need the PC connection to disconnect / reconnect I'm not sure this is possible.