### PR TITLE
unix/Makefile: Allow users to specify the C++ standard used.

### DIFF
--- a/examples/usercmodule/cppexample/micropython.mk
+++ b/examples/usercmodule/cppexample/micropython.mk
@@ -6,7 +6,7 @@ SRC_USERMOD_CXX += $(CPPEXAMPLE_MOD_DIR)/example.cpp
 
 # Add our module directory to the include path.
 CFLAGS_USERMOD += -I$(CPPEXAMPLE_MOD_DIR)
-CXXFLAGS_USERMOD += -I$(CPPEXAMPLE_MOD_DIR)
+CXXFLAGS_USERMOD += -I$(CPPEXAMPLE_MOD_DIR) -std=c++11
 
 # We use C++ features so have to link against the standard library.
 LDFLAGS_USERMOD += -lstdc++

--- a/ports/unix/Makefile
+++ b/ports/unix/Makefile
@@ -270,12 +270,6 @@ CFLAGS += -DMPZ_DIG_SIZE=16 # force 16 bits to work on both 32 and 64 bit archs
 CFLAGS += -DMICROPY_MODULE_FROZEN_STR
 endif
 
-HASCPP17 = $(shell expr `$(CC) -dumpversion | cut -f1 -d.` \>= 7)
-ifeq ($(HASCPP17), 1)
-	CXXFLAGS += -std=c++17
-else
-	CXXFLAGS += -std=c++11
-endif
 CXXFLAGS += $(filter-out -Wmissing-prototypes -Wold-style-definition -std=gnu99,$(CFLAGS) $(CXXFLAGS_MOD))
 
 ifeq ($(MICROPY_FORCE_32BIT),1)

--- a/ports/windows/Makefile
+++ b/ports/windows/Makefile
@@ -91,6 +91,8 @@ ifneq ($(FROZEN_MANIFEST),)
 CFLAGS += -DMICROPY_QSTR_EXTRA_POOL=mp_qstr_frozen_const_pool -DMICROPY_MODULE_FROZEN_MPY=1 -DMPZ_DIG_SIZE=16
 endif
 
+CXXFLAGS += $(filter-out -std=gnu99,$(CFLAGS) $(CXXFLAGS_MOD))
+
 include $(TOP)/py/mkrules.mk
 
 .PHONY: test test_full


### PR DESCRIPTION
Mainly for user modules.

Actually, I'm not sure the whole `HASCPP17` part should even be there: it's not needed for the MicroPython source itself (that just needs at least c++11 because the usercmodule example uses that). I'd be happy to remove it, but it's maybe too late for that now (as in: people relying on it)?