### PR TITLE
drivers/sdcard: Specify the final SPI baudrate in the constructor.

### DIFF
--- a/drivers/sdcard/sdcard.py
+++ b/drivers/sdcard/sdcard.py
@@ -39,7 +39,7 @@ _TOKEN_DATA = const(0xFE)
 
 
 class SDCard:
-    def __init__(self, spi, cs):
+    def __init__(self, spi, cs, baudrate=1320000):
         self.spi = spi
         self.cs = cs
 
@@ -51,7 +51,7 @@ class SDCard:
         self.dummybuf_memoryview = memoryview(self.dummybuf)
 
         # initialise the card
-        self.init_card()
+        self.init_card(baudrate)
 
     def init_spi(self, baudrate):
         try:
@@ -63,7 +63,8 @@ class SDCard:
             # on pyboard
             self.spi.init(master, baudrate=baudrate, phase=0, polarity=0)
 
-    def init_card(self):
+    def init_card(self, baudrate):
+
         # init CS pin
         self.cs.init(self.cs.OUT, value=1)
 
@@ -111,7 +112,7 @@ class SDCard:
             raise OSError("can't set 512 block size")
 
         # set to high data rate now that it's initialised
-        self.init_spi(1320000)
+        self.init_spi(baudrate)
 
     def init_card_v1(self):
         for i in range(_CMD_TIMEOUT):


### PR DESCRIPTION
This final baudrate is supplied in the constructor. The default is 1320000 as before.

Example:

sd = sdcard.SDCard(spi, cs, baudrate=20_000_000)