### PR TITLE
rp2/thread: Fix memory corruption when thread is created in core1.

### DIFF
--- a/ports/rp2/mpthreadport.c
+++ b/ports/rp2/mpthreadport.c
@@ -53,15 +53,11 @@ void mp_thread_deinit(void) {
 
 void mp_thread_gc_others(void) {
     if (core1_entry != NULL) {
+        // Collect core1's stack if it is active.
         gc_collect_root((void **)&core1_stack, 1);
         gc_collect_root((void **)&core1_arg, 1);
     }
-    if (get_core_num() == 0) {
-        // GC running on core0, trace core1's stack, if it's running.
-        if (core1_entry != NULL) {
-            gc_collect_root((void **)core1_stack, core1_stack_num_words);
-        }
-    } else {
+    if (get_core_num() == 1) {
         // GC running on core1, trace core0's stack.
         gc_collect_root((void **)&__StackBottom, (&__StackTop - &__StackBottom) / sizeof(uintptr_t));
     }

--- a/ports/rp2/mpthreadport.c
+++ b/ports/rp2/mpthreadport.c
@@ -57,11 +57,15 @@ void mp_thread_deinit(void) {
 }
 
 void mp_thread_gc_others(void) {
-    // GC collect on core1, regardless of which thread this is called from.
+    // trace core1's stack, regardless of which thread this is called from.
     if (core1_entry != NULL) {
         mp_thread_mutex_lock(&thread_mutex, 1);
         gc_collect_root((void **)&core1_stack, core1_stack_num_words);
         mp_thread_mutex_unlock(&thread_mutex);
+    }
+    if (get_core_num() == 1) {
+        // GC running on core1, trace core0's stack.
+        gc_collect_root((void **)&__StackBottom, (&__StackTop - &__StackBottom) / sizeof(uintptr_t));
     }
 }
 

--- a/ports/rp2/mpthreadport.c
+++ b/ports/rp2/mpthreadport.c
@@ -52,14 +52,9 @@ void mp_thread_deinit(void) {
 }
 
 void mp_thread_gc_others(void) {
-    if (get_core_num() == 0) {
-        // GC running on core0, trace core1's stack, if it's running.
-        if (core1_entry != NULL) {
-            gc_collect_root((void **)core1_stack, core1_stack_num_words);
-        }
-    } else {
-        // GC running on core1, trace core0's stack.
-        gc_collect_root((void **)&__StackBottom, (&__StackTop - &__StackBottom) / sizeof(uintptr_t));
+    // GC collect on core1, regardless of which thread this is called from.
+    if (core1_entry != NULL) {
+        gc_collect_root((void **)&core1_stack, core1_stack_num_words);
     }
 }
 


### PR DESCRIPTION
This PR try to fix #7124 and #7981 among others.

There were many issues reported about multicore in the forums and some of them are memory corruption. The problem I narrowed down was that GC was not correctly working on core1. I tried to fix this problem and so far it is working fine in my own tests. But as I am not sure if I am touching something sensitive correctly. 
Hope someone with knowledge on GC to take a look.

Test code 1
```python
from machine import UART, Pin
import time
import _thread
import gc

def _test():
    count = 0
    uart = UART(0, 115200 , parity=None, stop=1, bits=8, tx=Pin(0), rx=Pin(1), txbuf=32, timeout=10)
    while True:
        m = f'{count} '* 10 + '\r\n'
        uart.write(m)
        count += 1
        if count % 200 == 0:
            print(f'count: {count}, mem_free({gc.mem_free()}).')
            #gc.collect()

def count_count():
	n = 1
	while True:
		print(gc.mem_free())
		#gc.collect()
		print("Count Count counts", n)
		n += 1
		time.sleep(1)

_thread.start_new_thread(_test, ())
count_count()
```

Test code 2:
```python

def test():
    for i in range(0x1800):
        print(gc.mem_free())
        bytes(0)
    print("finished")

_thread.start_new_thread(test, ())
```

