### PR TITLE
nrf/stdin: Fix background events/schedule while at usb repl.

### DIFF
--- a/ports/nrf/drivers/usb/usb_cdc.c
+++ b/ports/nrf/drivers/usb/usb_cdc.c
@@ -198,6 +198,7 @@ int mp_hal_stdin_rx_chr(void) {
         if (cdc_rx_any()) {
             return cdc_rx_char();
         }
+        MICROPY_EVENT_POLL_HOOK
     }
 
     return 0;

--- a/ports/nrf/drivers/usb/usb_cdc.c
+++ b/ports/nrf/drivers/usb/usb_cdc.c
@@ -34,6 +34,7 @@
 #include "nrfx_power.h"
 #include "nrfx_uart.h"
 #include "py/ringbuf.h"
+#include "py/stream.h"
 
 #ifdef BLUETOOTH_SD
 #include "nrf_sdm.h"
@@ -191,6 +192,17 @@ void usb_cdc_sd_event_handler(uint32_t soc_evt) {
     }
 }
 #endif
+
+uintptr_t mp_hal_stdio_poll(uintptr_t poll_flags) {
+    uintptr_t ret = 0;
+    if (poll_flags & MP_STREAM_POLL_RD) {
+        usb_cdc_loop();
+        if (cdc_rx_any()) {
+            ret |= MP_STREAM_POLL_RD;
+        }
+    }
+    return ret;
+}
 
 int mp_hal_stdin_rx_chr(void) {
     for (;;) {

--- a/ports/nrf/mphalport.c
+++ b/ports/nrf/mphalport.c
@@ -172,7 +172,7 @@ void mp_hal_set_interrupt_char(int c) {
 }
 #endif
 
-#if !MICROPY_PY_BLE_NUS
+#if !MICROPY_PY_BLE_NUS && !MICROPY_HW_USB_CDC
 uintptr_t mp_hal_stdio_poll(uintptr_t poll_flags) {
     uintptr_t ret = 0;
     if ((poll_flags & MP_STREAM_POLL_RD) && MP_STATE_PORT(board_stdio_uart) != NULL
@@ -181,9 +181,7 @@ uintptr_t mp_hal_stdio_poll(uintptr_t poll_flags) {
     }
     return ret;
 }
-#endif
 
-#if !MICROPY_PY_BLE_NUS && !MICROPY_HW_USB_CDC
 int mp_hal_stdin_rx_chr(void) {
     for (;;) {
         if (MP_STATE_PORT(board_stdio_uart) != NULL && uart_rx_any(MP_STATE_PORT(board_stdio_uart))) {


### PR DESCRIPTION
Currently on nrf52 parts with usb cdc backgroung things like tasks started with `micropython.schedule()` aren't working from repl as the events aren't being serviced. This PR fixes this.

I noticed some other ports seem to have similar omissions, eg:
* https://github.com/micropython/micropython/blob/18acd0318f927930dd7f9efd77f08d8e05a43ce8/ports/samd/mphalport.c#L72
* https://github.com/micropython/micropython/blob/18acd0318f927930dd7f9efd77f08d8e05a43ce8/ports/teensy/teensy_hal.c#L38

Still others have a minor sleep in the while loop which I presume would be polling the events, but didn't excplicitely check.

I didn't want to just make this change in the other ports as I don't have a way to test them but this bug possibly/likely exists in them too, highligting that this can be a trap for people setting up new ports. 
