### PR TITLE
extmod,unix: Show compiler info in REPL banner.

### DIFF
--- a/extmod/moduplatform.c
+++ b/extmod/moduplatform.c
@@ -29,87 +29,19 @@
 #include "py/objtuple.h"
 #include "py/objstr.h"
 #include "py/mphal.h"
+#include "extmod/moduplatform.h"
 #include "genhdr/mpversion.h"
 
 #if MICROPY_PY_UPLATFORM
 
 // platform - Access to underlying platform's identifying data
 
-// TODO: Add more architectures, compilers and libraries.
-// See: https://sourceforge.net/p/predef/wiki/Home/
-
-#if defined(__ARM_ARCH)
-#define PLATFORM_ARCH   "arm"
-#elif defined(__x86_64__) || defined(_WIN64)
-#define PLATFORM_ARCH   "x86_64"
-#elif defined(__i386__) || defined(_M_IX86)
-#define PLATFORM_ARCH   "x86"
-#elif defined(__xtensa__) || defined(_M_IX86)
-#define PLATFORM_ARCH   "xtensa"
-#else
-#define PLATFORM_ARCH   ""
-#endif
-
-#if defined(__GNUC__)
-#define PLATFORM_COMPILER \
-    "GCC " \
-    MP_STRINGIFY(__GNUC__) "." \
-    MP_STRINGIFY(__GNUC_MINOR__) "." \
-    MP_STRINGIFY(__GNUC_PATCHLEVEL__)
-#elif defined(__ARMCC_VERSION)
-#define PLATFORM_COMPILER \
-    "ARMCC " \
-    MP_STRINGIFY((__ARMCC_VERSION / 1000000)) "." \
-    MP_STRINGIFY((__ARMCC_VERSION / 10000 % 100)) "." \
-    MP_STRINGIFY((__ARMCC_VERSION % 10000))
-#elif defined(_MSC_VER)
-#if defined(_WIN64)
-#define COMPILER_BITS "64 bit"
-#elif defined(_M_IX86)
-#define COMPILER_BITS "32 bit"
-#else
-#define COMPILER_BITS ""
-#endif
-#define PLATFORM_COMPILER \
-    "MSC v." MP_STRINGIFY(_MSC_VER) " " COMPILER_BITS
-#else
-#define PLATFORM_COMPILER       ""
-#endif
-
-#if defined(__GLIBC__)
-#define PLATFORM_LIBC_LIB       "glibc"
-#define PLATFORM_LIBC_VER \
-    MP_STRINGIFY(__GLIBC__) "." \
-    MP_STRINGIFY(__GLIBC_MINOR__)
-#elif defined(__NEWLIB__)
-#define PLATFORM_LIBC_LIB       "newlib"
-#define PLATFORM_LIBC_VER       _NEWLIB_VERSION
-#else
-#define PLATFORM_LIBC_LIB       ""
-#define PLATFORM_LIBC_VER       ""
-#endif
-
-#if defined(__linux)
-#define PLATFORM_SYSTEM     "Linux"
-#elif defined(__unix__)
-#define PLATFORM_SYSTEM     "Unix"
-#elif defined(__CYGWIN__)
-#define PLATFORM_SYSTEM     "Cygwin"
-#elif defined(_WIN32)
-#define PLATFORM_SYSTEM     "Windows"
-#else
-#define PLATFORM_SYSTEM     "MicroPython"
-#endif
-
-#ifndef MICROPY_PLATFORM_VERSION
-#define MICROPY_PLATFORM_VERSION ""
-#endif
-
-STATIC const MP_DEFINE_STR_OBJ(info_platform_obj, PLATFORM_SYSTEM "-" MICROPY_VERSION_STRING "-" \
-    PLATFORM_ARCH "-" MICROPY_PLATFORM_VERSION "-with-" PLATFORM_LIBC_LIB "" PLATFORM_LIBC_VER);
-STATIC const MP_DEFINE_STR_OBJ(info_python_compiler_obj, PLATFORM_COMPILER);
-STATIC const MP_DEFINE_STR_OBJ(info_libc_lib_obj, PLATFORM_LIBC_LIB);
-STATIC const MP_DEFINE_STR_OBJ(info_libc_ver_obj, PLATFORM_LIBC_VER);
+STATIC const MP_DEFINE_STR_OBJ(info_platform_obj, MICROPY_PLATFORM_SYSTEM "-" \
+    MICROPY_VERSION_STRING "-" MICROPY_PLATFORM_ARCH "-" MICROPY_PLATFORM_VERSION "-with-" \
+    MICROPY_PLATFORM_LIBC_LIB "" MICROPY_PLATFORM_LIBC_VER);
+STATIC const MP_DEFINE_STR_OBJ(info_python_compiler_obj, MICROPY_PLATFORM_COMPILER);
+STATIC const MP_DEFINE_STR_OBJ(info_libc_lib_obj, MICROPY_PLATFORM_LIBC_LIB);
+STATIC const MP_DEFINE_STR_OBJ(info_libc_ver_obj, MICROPY_PLATFORM_LIBC_VER);
 STATIC const mp_rom_obj_tuple_t info_libc_tuple_obj = {
     {&mp_type_tuple}, 2, {MP_ROM_PTR(&info_libc_lib_obj), MP_ROM_PTR(&info_libc_ver_obj)}
 };

--- a/extmod/moduplatform.h
+++ b/extmod/moduplatform.h
@@ -1,0 +1,105 @@
+/*
+ * This file is part of the MicroPython project, http://micropython.org/
+ *
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2013-2021 Ibrahim Abdelkader <iabdalkader@openmv.io>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+#ifndef MICROPY_INCLUDED_MODUPLATFORM_H
+#define MICROPY_INCLUDED_MODUPLATFORM_H
+
+#include "py/misc.h"  // For MP_STRINGIFY.
+#include "py/mpconfig.h"
+
+// Preprocessor directives indentifying the platform.
+// The (u)platform module itself is guarded by MICROPY_PY_UPLATFORM, see the
+// .c file, but these are made available because they're generally usable.
+// TODO: Add more architectures, compilers and libraries.
+// See: https://sourceforge.net/p/predef/wiki/Home/
+
+#if defined(__ARM_ARCH)
+#define MICROPY_PLATFORM_ARCH   "arm"
+#elif defined(__x86_64__) || defined(_WIN64)
+#define MICROPY_PLATFORM_ARCH   "x86_64"
+#elif defined(__i386__) || defined(_M_IX86)
+#define MICROPY_PLATFORM_ARCH   "x86"
+#elif defined(__xtensa__) || defined(_M_IX86)
+#define MICROPY_PLATFORM_ARCH   "xtensa"
+#else
+#define MICROPY_PLATFORM_ARCH   ""
+#endif
+
+#if defined(__GNUC__)
+#define MICROPY_PLATFORM_COMPILER \
+    "GCC " \
+    MP_STRINGIFY(__GNUC__) "." \
+    MP_STRINGIFY(__GNUC_MINOR__) "." \
+    MP_STRINGIFY(__GNUC_PATCHLEVEL__)
+#elif defined(__ARMCC_VERSION)
+#define MICROPY_PLATFORM_COMPILER \
+    "ARMCC " \
+    MP_STRINGIFY((__ARMCC_VERSION / 1000000)) "." \
+    MP_STRINGIFY((__ARMCC_VERSION / 10000 % 100)) "." \
+    MP_STRINGIFY((__ARMCC_VERSION % 10000))
+#elif defined(_MSC_VER)
+#if defined(_WIN64)
+#define MICROPY_PLATFORM_COMPILER_BITS  "64 bit"
+#elif defined(_M_IX86)
+#define MICROPY_PLATFORM_COMPILER_BITS  "32 bit"
+#else
+#define MICROPY_PLATFORM_COMPILER_BITS  ""
+#endif
+#define MICROPY_PLATFORM_COMPILER \
+    "MSC v." MP_STRINGIFY(_MSC_VER) " " MICROPY_PLATFORM_COMPILER_BITS
+#else
+#define MICROPY_PLATFORM_COMPILER       ""
+#endif
+
+#if defined(__GLIBC__)
+#define MICROPY_PLATFORM_LIBC_LIB       "glibc"
+#define MICROPY_PLATFORM_LIBC_VER \
+    MP_STRINGIFY(__GLIBC__) "." \
+    MP_STRINGIFY(__GLIBC_MINOR__)
+#elif defined(__NEWLIB__)
+#define MICROPY_PLATFORM_LIBC_LIB       "newlib"
+#define MICROPY_PLATFORM_LIBC_VER       _NEWLIB_VERSION
+#else
+#define MICROPY_PLATFORM_LIBC_LIB       ""
+#define MICROPY_PLATFORM_LIBC_VER       ""
+#endif
+
+#if defined(__linux)
+#define MICROPY_PLATFORM_SYSTEM         "Linux"
+#elif defined(__unix__)
+#define MICROPY_PLATFORM_SYSTEM         "Unix"
+#elif defined(__CYGWIN__)
+#define MICROPY_PLATFORM_SYSTEM         "Cygwin"
+#elif defined(_WIN32)
+#define MICROPY_PLATFORM_SYSTEM         "Windows"
+#else
+#define MICROPY_PLATFORM_SYSTEM         "MicroPython"
+#endif
+
+#ifndef MICROPY_PLATFORM_VERSION
+#define MICROPY_PLATFORM_VERSION ""
+#endif
+
+#endif // MICROPY_INCLUDED_MODUPLATFORM_H

--- a/ports/unix/main.c
+++ b/ports/unix/main.c
@@ -47,6 +47,7 @@
 #include "py/mphal.h"
 #include "py/mpthread.h"
 #include "extmod/misc.h"
+#include "extmod/moduplatform.h"
 #include "extmod/vfs.h"
 #include "extmod/vfs_posix.h"
 #include "genhdr/mpversion.h"
@@ -178,7 +179,8 @@ STATIC char *strjoin(const char *s1, int sep_char, const char *s2) {
 
 STATIC int do_repl(void) {
     mp_hal_stdout_tx_str("MicroPython " MICROPY_GIT_TAG " on " MICROPY_BUILD_DATE "; "
-        MICROPY_PY_SYS_PLATFORM " version\nUse Ctrl-D to exit, Ctrl-E for paste mode\n");
+        MICROPY_PY_SYS_PLATFORM " [" MICROPY_PLATFORM_COMPILER "] version\n"
+        "Use Ctrl-D to exit, Ctrl-E for paste mode\n");
 
     #if MICROPY_USE_READLINE == 1
 


### PR DESCRIPTION
When testing out things I normally work in a single codebase, shared across different compiler/platform combinations (e.g. unix+clang+gcc, windows+msvc, migw+clang+gcc) which makes it easy to lose track of which micropython executable is being started. This fixes that just like CPython does.

It's not strictly needed to expose mp_platform_info_python_compiler_obj via a header, a less intrusive alternative would be for `do_repl` to get the `platform` module directly, but I'm not sure if that pattern is used somewhere else? Would look like:
```
extern const mp_obj_module_t mp_module_uplatform;
mp_obj_t fun = mp_obj_dict_get(mp_module_uplatform.globals, MP_ROM_QSTR(MP_QSTR_python_compiler));
mp_obj_t info_str = mp_call_function_0(fun);
...
```

Result looks like:
> MicroPython v1.18 on 2022-02-17; win32 [MSC v.1930 64 bit] version

or

> MicroPython v1.18 on 2022-02-17; win32 [GCC 11.2.0] version