### PR TITLE
tests/run-tests.py: Skip repl tests when running windows underneath.

### DIFF
--- a/tests/run-tests.py
+++ b/tests/run-tests.py
@@ -109,6 +109,10 @@ def run_micropython(pyb, args, test_file, is_special=False):
                         return b"SKIP\n"
                     import select
 
+                    # Even though these might have the pty module, it's unlikely to function.
+                    if sys.platform in ["win32", "msys", "cygwin"]:
+                        return b"SKIP\n"
+
                     def get(required=False):
                         rv = b""
                         while True:


### PR DESCRIPTION
Some versions of Python (for instance: the mingw-w64 version which
can be installed on MSYS2) do include a pty module and claim to be
posix-like (os.name == 'posix'), yet the select.select call used in
run-tests.py hangs forever.  To be on the safe side just exclude
anything which might be running on windows.