### PR TITLE
Math.gcd new function

### DIFF
--- a/.github/workflows/ports_qemu-arm.yml
+++ b/.github/workflows/ports_qemu-arm.yml
@@ -18,6 +18,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
+    - uses: actions/setup-python@v2
+      with:
+        python-version: '3.9'
     - name: Install packages
       run: source tools/ci.sh && ci_qemu_arm_setup
     - name: Build and run test suite

--- a/.github/workflows/ports_unix.yml
+++ b/.github/workflows/ports_unix.yml
@@ -41,6 +41,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
+    - uses: actions/setup-python@v2
+      with:
+        python-version: '3.9'
     - name: Build
       run: source tools/ci.sh && ci_unix_standard_build
     - name: Run main test suite
@@ -53,6 +56,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
+    - uses: actions/setup-python@v2
+      with:
+        python-version: '3.9'
     - name: Build
       run: source tools/ci.sh && ci_unix_dev_build
     - name: Run main test suite
@@ -65,8 +71,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
-    - name: Install packages
-      run: source tools/ci.sh && ci_unix_coverage_setup
+    - uses: actions/setup-python@v2
+      with:
+        python-version: '3.9'
+    - name: Install python dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install setuptools pyelftools
+    - name: Print environment version
+      run: source tools/ci.sh && ci_unix_coverage_print_env
     - name: Build
       run: source tools/ci.sh && ci_unix_coverage_build
     - name: Run main test suite
@@ -92,6 +105,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
+    - uses: actions/setup-python@v2
+      with:
+        python-version: '3.9'
+    - name: Install python dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install setuptools pyelftools
     - name: Install packages
       run: source tools/ci.sh && ci_unix_32bit_setup
     - name: Build
@@ -110,6 +130,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
+    - uses: actions/setup-python@v2
+      with:
+        python-version: '3.9'
     - name: Install packages
       run: source tools/ci.sh && ci_unix_32bit_setup
     - name: Build
@@ -124,6 +147,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
+    - uses: actions/setup-python@v2
+      with:
+        python-version: '3.9'
     - name: Build
       run: source tools/ci.sh && ci_unix_float_build
     - name: Run main test suite
@@ -136,6 +162,9 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
     - uses: actions/checkout@v2
+    - uses: actions/setup-python@v2
+      with:
+        python-version: '3.9'
     - name: Install packages
       run: source tools/ci.sh && ci_unix_clang_setup
     - name: Build
@@ -150,6 +179,9 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
     - uses: actions/checkout@v2
+    - uses: actions/setup-python@v2
+      with:
+        python-version: '3.9'
     - name: Install packages
       run: source tools/ci.sh && ci_unix_clang_setup
     - name: Build
@@ -164,6 +196,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
+    - uses: actions/setup-python@v2
+      with:
+        python-version: '3.9'
     - name: Build
       run: source tools/ci.sh && ci_unix_settrace_build
     - name: Run main test suite
@@ -176,6 +211,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
+    - uses: actions/setup-python@v2
+      with:
+        python-version: '3.9'
     - name: Build
       run: source tools/ci.sh && ci_unix_settrace_stackless_build
     - name: Run main test suite
@@ -190,7 +228,7 @@ jobs:
     - uses: actions/checkout@v2
     - uses: actions/setup-python@v2
       with:
-        python-version: '3.8'
+        python-version: '3.9'
     - name: Build
       run: source tools/ci.sh && ci_unix_macos_build
     - name: Run tests
@@ -203,6 +241,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
+    - uses: actions/setup-python@v2
+      with:
+        python-version: '3.9'
     - name: Install packages
       run: source tools/ci.sh && ci_unix_qemu_mips_setup
     - name: Build
@@ -217,6 +258,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
+    - uses: actions/setup-python@v2
+      with:
+        python-version: '3.9'
     - name: Install packages
       run: source tools/ci.sh && ci_unix_qemu_arm_setup
     - name: Build

--- a/docs/differences/python_35.rst
+++ b/docs/differences/python_35.rst
@@ -101,7 +101,7 @@ Changes to built-in modules:
    +-----------------------------------------------------------------------------------------------------------+---------------+
    | A new function *isclose()* provides a way to test for approximate equality.                               |               |
    +-----------------------------------------------------------------------------------------------------------+---------------+
-   | A new *gcd()* function has been added. The *fractions.gcd()* function is now deprecated.                  |               |
+   | A new *gcd()* function has been added. The *fractions.gcd()* function is now deprecated.                  | Completed     |
    +-----------------------------------------------------------------------------------------------------------+---------------+
    | `os <https://docs.python.org/3/whatsnew/3.5.html#os>`_                                                                    |
    +-----------------------------------------------------------------------------------------------------------+---------------+

--- a/docs/differences/python_39.rst
+++ b/docs/differences/python_39.rst
@@ -90,7 +90,7 @@ Changes to built-in modules:
   +---------------------------------------------------------------------------------------------------------------+---------------+
   | `math`                                                                                                                        |
   +---------------------------------------------------------------------------------------------------------------+---------------+
-  | Expanded the *math.gcd()* function to handle multiple arguments. Formerly, it only supported two arguments    |               |
+  | Expanded the *math.gcd()* function to handle multiple arguments. Formerly, it only supported two arguments    | Completed     |
   +---------------------------------------------------------------------------------------------------------------+---------------+
   | Added *math.lcm()*: return the least common multiple of specified arguments                                   |               |
   +---------------------------------------------------------------------------------------------------------------+---------------+

--- a/docs/library/math.rst
+++ b/docs/library/math.rst
@@ -104,6 +104,10 @@ Functions
 
    Return the gamma function of ``x``.
 
+.. function:: gcd(x, y, ...)
+
+   Return the greatest common divisor of any amount of numbers with minimum of 2 arguments.
+
 .. function:: isfinite(x)
 
    Return ``True`` if ``x`` is finite.

--- a/ports/windows/.appveyor.yml
+++ b/ports/windows/.appveyor.yml
@@ -1,10 +1,10 @@
-image: Visual Studio 2017
+image: Visual Studio 2019
 clone_depth: 1
 skip_tags: true
 
 environment:
   # Python version used
-  MICROPY_CPYTHON3: c:/python38/python.exe
+  MICROPY_CPYTHON3: c:/python39/python.exe
   # The variants.
   matrix:
     - PyVariant: dev

--- a/tests/float/math_fun_special.py
+++ b/tests/float/math_fun_special.py
@@ -50,3 +50,57 @@ for function_name, function, test_vals in functions:
             print("{:.4g}".format(function(value)))
         except ValueError as e:
             print(str(e))
+
+
+# Tests for gcd mostly duplicated from
+# https://github.com/python/cpython/blob/main/Lib/test/test_math.py
+
+
+def assertRaises(exception, func, *args):
+    try:
+        print(func(*args))
+        assert False
+    except exception:
+        pass
+
+
+print(gcd(0, 0))
+print(gcd(1, 0))
+print(gcd(-1, 0))
+print(gcd(0, 1))
+print(gcd(0, -1))
+print(gcd(7, 1))
+print(gcd(7, -1))
+print(gcd(-23, 15))
+print(gcd(120, 84))
+print(gcd(84, -120))
+print(gcd(1216342683557601535506311712, 436522681849110124616458784))
+
+x = 434610456570399902378880679233098819019853229470286994367836600566
+y = 1064502245825115327754847244914921553977
+for c in (652560, 576559230871654959816130551884856912003141446781646602790216406874):
+    a = x * c
+    b = y * c
+    print(gcd(a, b))
+    print(gcd(b, a))
+    print(gcd(-a, b))
+    print(gcd(b, -a))
+    print(gcd(a, -b))
+    print(gcd(-b, a))
+    print(gcd(-a, -b))
+    print(gcd(-b, -a))
+
+# In MP minimum argument count is 2
+# self.assertEqual(gcd(), 0)
+# self.assertEqual(gcd(120), 120)
+# self.assertEqual(gcd(-120), 120)
+
+print(gcd(120, 84, 102))
+print(gcd(120, 1, 84))
+print(gcd(6, 30, 40, -60, 20, 40))
+print(gcd(12345678912345678912345678911561561658135153135135135, 123456))
+
+assertRaises(TypeError, gcd, 120.0)
+assertRaises(TypeError, gcd, 120.0, 84)
+assertRaises(TypeError, gcd, 120, 84.0)
+assertRaises(TypeError, gcd, 120, 1, 84.0)

--- a/tools/ci.sh
+++ b/tools/ci.sh
@@ -434,9 +434,7 @@ function ci_unix_dev_run_tests {
     ci_unix_run_tests_helper VARIANT=dev
 }
 
-function ci_unix_coverage_setup {
-    sudo pip3 install setuptools
-    sudo pip3 install pyelftools
+function ci_unix_coverage_print_env {
     gcc --version
     python3 --version
 }
@@ -459,8 +457,6 @@ function ci_unix_32bit_setup {
     sudo dpkg --add-architecture i386
     sudo apt-get update
     sudo apt-get install gcc-multilib g++-multilib libffi-dev:i386
-    sudo pip3 install setuptools
-    sudo pip3 install pyelftools
     gcc --version
     python2 --version
     python3 --version


### PR DESCRIPTION
Implement the greatest common divisor function in the global math module. I found it best placed under the definition of `MICROPY_PY_MATH_SPECIAL_FUNCTIONS` please suggest if needed to place it elsewhere.

The implementation covers the change in CPython 3.5 https://docs.python.org/3/whatsnew/3.5.html#math and as well as the more recent change in version 3.9 https://docs.python.org/3/whatsnew/3.9.html#math.

~~As a consequence the github pipelines need to run Python version 3.9, the image "ubuntu-latest (20.04)" is running on 3.8. So I added the necessary changes.
However, those changes do have some side effect including problems with dependencies to elftools in the coverage pipelines. My first guess is that the pip library is installing elftools for Python 3.8 (as it is the default Python version in ubuntu-latest) which is not found while running Python 3.9. How would you like this handled?~~

Edit: not relevant anymore. 
The Github Actions configuration files have been updated to use version 3.9. As well as the Windows port.

This was worked on with the assistance of @wang3450