### PR TITLE
stm32wb55/powerctrl: Add BLE support to deepsleep.

### DIFF
--- a/ports/stm32/boards/stm32wbxx_hal_conf_base.h
+++ b/ports/stm32/boards/stm32wbxx_hal_conf_base.h
@@ -42,6 +42,7 @@
 #include "stm32wbxx_hal_uart.h"
 #include "stm32wbxx_hal_usart.h"
 #include "stm32wbxx_ll_adc.h"
+#include "stm32wbxx_ll_hsem.h"
 #include "stm32wbxx_ll_lpuart.h"
 #include "stm32wbxx_ll_rtc.h"
 #include "stm32wbxx_ll_usart.h"
@@ -78,5 +79,42 @@
 
 // HAL parameter assertions are disabled
 #define assert_param(expr) ((void)0)
+
+// Hardware Semaphores - ref: AN5289
+
+// Used to prevent conflicts after standby / sleep.
+// Each CPUs takes this semaphore at standby wakeup until conflicting elements are restored.
+// Note: this is used in WB55 reference examples, but not listed in AN5289 Rev 6
+#define CFG_HW_PWR_STANDBY_SEMID                10
+
+// Ensures that CPU2 does not update the BLE persistent data in SRAM2 when CPU1 is reading them
+#define CFG_HW_THREAD_NVM_SRAM_SEMID            9
+
+// Ensures that CPU2 does not update the Thread persistent data in SRAM2 when CPU1 is reading them
+#define CFG_HW_BLE_NVM_SRAM_SEMID               8
+
+// Used by CPU2 to prevent CPU1 from writing/erasing data in Flash memory
+#define CFG_HW_BLOCK_FLASH_REQ_BY_CPU2_SEMID    7
+
+// Used by CPU1 to prevent CPU2 from writing/erasing data in Flash memory
+#define CFG_HW_BLOCK_FLASH_REQ_BY_CPU1_SEMID    6
+
+// Used to manage the CLK48 clock configuration (RCC_CRRCR, RCC_CCIPR)
+#define CFG_HW_CLK48_CONFIG_SEMID               5
+
+// Used to manage the entry Stop Mode procedure
+#define CFG_HW_ENTRY_STOP_MODE_SEMID            4
+
+// Used to access the RCC (RCC_CR, RCC_EXTCFGR, RCC_CFGR, RCC_SMPSCR)
+#define CFG_HW_RCC_SEMID                        3
+
+// Used to access the FLASH (all registers)
+#define CFG_HW_FLASH_SEMID                      2
+
+// Used to access the PKA (all registers)
+#define CFG_HW_PKA_SEMID                        1
+
+// Used to access the RNG (all registers)
+#define CFG_HW_RNG_SEMID                        0
 
 #endif // MICROPY_INCLUDED_STM32WBXX_HAL_CONF_BASE_H

--- a/ports/stm32/main.c
+++ b/ports/stm32/main.c
@@ -298,6 +298,9 @@ STATIC bool init_sdcard_fs(void) {
 #endif
 
 void stm32_main(uint32_t reset_mode) {
+    // Low-level MCU initialisation.
+    stm32_system_init();
+
     #if !defined(STM32F0) && defined(MICROPY_HW_VTOR)
     // Change IRQ vector table if configured differently
     SCB->VTOR = MICROPY_HW_VTOR;

--- a/ports/stm32/mboot/main.c
+++ b/ports/stm32/mboot/main.c
@@ -1311,6 +1311,9 @@ extern PCD_HandleTypeDef pcd_fs_handle;
 extern PCD_HandleTypeDef pcd_hs_handle;
 
 void stm32_main(uint32_t initial_r0) {
+    // Low-level MCU initialisation.
+    stm32_system_init();
+
     #if defined(STM32H7)
     // Configure write-once power options, and wait for voltage levels to be ready
     PWR->CR3 = PWR_CR3_LDOEN;

--- a/ports/stm32/mpbthciport.c
+++ b/ports/stm32/mpbthciport.c
@@ -116,7 +116,7 @@ int mp_bluetooth_hci_uart_init(uint32_t port, uint32_t baudrate) {
 
 int mp_bluetooth_hci_uart_deinit(void) {
     DEBUG_printf("mp_bluetooth_hci_uart_deinit (stm32 rfcore)\n");
-
+    rfcore_ble_reset();
     return 0;
 }
 

--- a/ports/stm32/powerctrl.c
+++ b/ports/stm32/powerctrl.c
@@ -29,6 +29,7 @@
 #include "powerctrl.h"
 #include "rtc.h"
 #include "genhdr/pllfreqtable.h"
+#include "extmod/modbluetooth.h"
 
 #if defined(STM32H7)
 #define RCC_SR          RSR
@@ -945,6 +946,10 @@ void powerctrl_enter_standby_mode(void) {
         while (!__HAL_PWR_GET_FLAG(PWR_FLAG_VOSRDY)) {
         }
     }
+    #endif
+
+    #if defined(STM32WB) && MICROPY_PY_BLUETOOTH
+    mp_bluetooth_deinit();
     #endif
 
     // We need to clear the PWR wake-up-flag before entering standby, since

--- a/ports/stm32/powerctrl.h
+++ b/ports/stm32/powerctrl.h
@@ -29,6 +29,14 @@
 #include <stdbool.h>
 #include <stdint.h>
 
+#if defined(STM32WB)
+void stm32_system_init(void);
+#else
+static inline void stm32_system_init(void) {
+    SystemInit();
+}
+#endif
+
 void SystemClock_Config(void);
 
 NORETURN void powerctrl_mcu_reset(void);

--- a/ports/stm32/resethandler.s
+++ b/ports/stm32/resethandler.s
@@ -62,8 +62,7 @@ Reset_Handler:
     cmp  r1, r2
     bcc  .bss_zero_loop
 
-    /* Initialise the system and jump to the main code */
-    bl   SystemInit
+    /* Jump to the main code */
     mov  r0, r4
     b    stm32_main
 

--- a/ports/stm32/resethandler_m0.s
+++ b/ports/stm32/resethandler_m0.s
@@ -66,8 +66,7 @@ Reset_Handler:
     cmp  r1, r2
     bcc  .bss_zero_loop
 
-    /* Initialise the system and jump to the main code */
-    bl   SystemInit
+    /* Jump to the main code */
     mov  r0, r4
     bl   stm32_main
 

--- a/ports/stm32/resethandler_m3.s
+++ b/ports/stm32/resethandler_m3.s
@@ -67,8 +67,7 @@ Reset_Handler:
     cmp  r1, r2
     bcc  .bss_zero_loop
 
-    /* Initialise the system and jump to the main code */
-    bl   SystemInit
+    /* Jump to the main code */
     mov  r0, r4
     bl   stm32_main
 

--- a/ports/stm32/rfcore.c
+++ b/ports/stm32/rfcore.c
@@ -600,16 +600,36 @@ static const struct {
 void rfcore_ble_init(void) {
     DEBUG_printf("rfcore_ble_init\n");
 
-    // Clear any outstanding messages from ipcc_init.
-    tl_check_msg(&ipcc_mem_sys_queue, IPCC_CH_SYS, NULL);
-
     // Configure and reset the BLE controller.
-    tl_sys_hci_cmd_resp(HCI_OPCODE(OGF_VENDOR, OCF_BLE_INIT), (const uint8_t *)&ble_init_params, sizeof(ble_init_params), 0);
-    tl_ble_hci_cmd_resp(HCI_OPCODE(0x03, 0x0003), NULL, 0);
+    if (!rfcore_ble_reset()) {
+        // ble init can fail if core2 has previously locked up. Reset HSI & rfcore to retry.
+        LL_RCC_HSI_Disable();
+        mp_hal_delay_ms(100);
+        LL_RCC_HSI_Enable();
+
+        rfcore_init();
+        rfcore_ble_reset();
+    }
 
     // Enable PES rather than SEM7 to moderate flash access between the cores.
     uint8_t buf = 0; // FLASH_ACTIVITY_CONTROL_PES
     tl_sys_hci_cmd_resp(HCI_OPCODE(OGF_VENDOR, OCF_C2_SET_FLASH_ACTIVITY_CONTROL), &buf, 1, 0);
+}
+
+bool rfcore_ble_reset(void) {
+    DEBUG_printf("rfcore_ble_reset\n");
+
+    // Clear any outstanding messages from ipcc_init.
+    tl_check_msg(&ipcc_mem_sys_queue, IPCC_CH_SYS, NULL);
+
+    // Configure and reset the BLE controller.
+    int ret = tl_sys_hci_cmd_resp(HCI_OPCODE(OGF_VENDOR, OCF_BLE_INIT), (const uint8_t *)&ble_init_params, sizeof(ble_init_params), 500);
+
+    if (ret == -MP_ETIMEDOUT) {
+        return false;
+    }
+    tl_ble_hci_cmd_resp(HCI_OPCODE(0x03, 0x0003), NULL, 0);
+    return true;
 }
 
 void rfcore_ble_hci_cmd(size_t len, const uint8_t *src) {

--- a/ports/stm32/rfcore.h
+++ b/ports/stm32/rfcore.h
@@ -33,6 +33,7 @@ typedef void (*rfcore_ble_msg_callback_t)(void *, const uint8_t *, size_t);
 void rfcore_init(void);
 
 void rfcore_ble_init(void);
+bool rfcore_ble_reset(void);
 void rfcore_ble_hci_cmd(size_t len, const uint8_t *src);
 size_t rfcore_ble_check_msg(rfcore_ble_msg_callback_t cb, void *env);
 void rfcore_ble_set_txpower(uint8_t level);

--- a/tests/multi_bluetooth/ble_deepsleep.py
+++ b/tests/multi_bluetooth/ble_deepsleep.py
@@ -1,0 +1,96 @@
+# Test BLE re-connect after peripheral deepsleep.
+# instance0 needs to be a device capable of deepsleep without disconnecting the
+# REPL, eg. STM32WB55 Nucleo board with REPL on UART port.
+
+from micropython import const
+import time, machine, bluetooth
+
+TIMEOUT_MS = 4000
+
+_IRQ_CENTRAL_CONNECT = const(1)
+_IRQ_CENTRAL_DISCONNECT = const(2)
+_IRQ_PERIPHERAL_CONNECT = const(7)
+_IRQ_PERIPHERAL_DISCONNECT = const(8)
+
+waiting_events = {}
+
+
+def irq(event, data):
+    if event == _IRQ_CENTRAL_CONNECT:
+        print("_IRQ_CENTRAL_CONNECT")
+        waiting_events[event] = data[0]
+    elif event == _IRQ_CENTRAL_DISCONNECT:
+        print("_IRQ_CENTRAL_DISCONNECT")
+    elif event == _IRQ_PERIPHERAL_CONNECT:
+        print("_IRQ_PERIPHERAL_CONNECT")
+        waiting_events[event] = data[0]
+    elif event == _IRQ_PERIPHERAL_DISCONNECT:
+        print("_IRQ_PERIPHERAL_DISCONNECT")
+
+    if event not in waiting_events:
+        waiting_events[event] = None
+
+
+def wait_for_event(event, timeout_ms):
+    t0 = time.ticks_ms()
+    while time.ticks_diff(time.ticks_ms(), t0) < timeout_ms:
+        if event in waiting_events:
+            return waiting_events.pop(event)
+        machine.idle()
+    raise ValueError("Timeout waiting for {}".format(event))
+
+
+# Acting in peripheral role.
+def instance0():
+    multitest.globals(BDADDR=ble.config("mac"))
+    print("gap_advertise")
+    ble.gap_advertise(20_000, b"\x02\x01\x06\x04\tMPY")
+    multitest.next()
+    # Wait for central to connect, then wait for it to disconnect.
+    wait_for_event(_IRQ_CENTRAL_CONNECT, TIMEOUT_MS)
+    wait_for_event(_IRQ_CENTRAL_DISCONNECT, TIMEOUT_MS)
+
+    multitest.expect_reboot(resume="instance0_resume", delay_ms=100)
+    machine.deepsleep(100)
+
+
+# Acting in peripheral role.
+def instance0_resume():
+    # continue here after reboot
+    print("restarted")
+    print("gap_advertise")
+    ble.gap_advertise(20_000, b"\x02\x01\x06\x04\tMPY")
+    try:
+        # Wait for central to connect, then disconnect it.
+        conn_handle = wait_for_event(_IRQ_CENTRAL_CONNECT, TIMEOUT_MS)
+        print("gap_disconnect:", ble.gap_disconnect(conn_handle))
+        wait_for_event(_IRQ_CENTRAL_DISCONNECT, TIMEOUT_MS)
+    finally:
+        ble.active(0)
+
+
+# Acting in central role.
+def instance1():
+    multitest.next()
+    try:
+        # Connect to peripheral and then disconnect.
+        print("gap_connect")
+        ble.gap_connect(*BDADDR)
+        conn_handle = wait_for_event(_IRQ_PERIPHERAL_CONNECT, TIMEOUT_MS)
+        print("gap_disconnect:", ble.gap_disconnect(conn_handle))
+        wait_for_event(_IRQ_PERIPHERAL_DISCONNECT, TIMEOUT_MS)
+
+        # Connect to peripheral and then let the peripheral disconnect us.
+        # Extra scan timeout allows for the peripheral to receive the disconnect
+        # event and start advertising again.
+        print("gap_connect")
+        ble.gap_connect(BDADDR[0], BDADDR[1], 5000)
+        wait_for_event(_IRQ_PERIPHERAL_CONNECT, TIMEOUT_MS)
+        wait_for_event(_IRQ_PERIPHERAL_DISCONNECT, TIMEOUT_MS)
+    finally:
+        ble.active(0)
+
+
+ble = bluetooth.BLE()
+ble.active(1)
+ble.irq(irq)

--- a/tests/multi_bluetooth/ble_deepsleep.py.exp
+++ b/tests/multi_bluetooth/ble_deepsleep.py.exp
@@ -1,0 +1,18 @@
+--- instance0 ---
+gap_advertise
+_IRQ_CENTRAL_CONNECT
+_IRQ_CENTRAL_DISCONNECT
+WAIT_FOR_REBOOT instance0_resume 100
+restarted
+gap_advertise
+_IRQ_CENTRAL_CONNECT
+gap_disconnect: True
+_IRQ_CENTRAL_DISCONNECT
+--- instance1 ---
+gap_connect
+_IRQ_PERIPHERAL_CONNECT
+gap_disconnect: True
+_IRQ_PERIPHERAL_DISCONNECT
+gap_connect
+_IRQ_PERIPHERAL_CONNECT
+_IRQ_PERIPHERAL_DISCONNECT

--- a/tests/run-multitests.py
+++ b/tests/run-multitests.py
@@ -90,6 +90,9 @@ class multitest:
             except:
                 ip = HOST_IP
         return ip
+    @staticmethod
+    def expect_reboot(resume, delay_ms=0):
+        print("WAIT_FOR_REBOOT", resume, delay_ms)
 
 {}
 
@@ -378,6 +381,21 @@ def run_test_on_instances(test_file, num_instances, instances):
                 last_read_time[idx] = time.time()
                 if out is not None and not any(m in out for m in IGNORE_OUTPUT_MATCHES):
                     trace_instance_output(idx, out)
+                    if out.startswith("WAIT_FOR_REBOOT"):
+                        _, resume, delay_ms = out.split(" ")
+
+                        if wait_for_reboot(instance, delay_ms):
+                            # Restart the test code, resuming from requested instance block
+                            if not resume.startswith("instance{}".format(idx)):
+                                raise SystemExit(
+                                    'ERROR: resume function must start with "instance{}"'.format(
+                                        idx
+                                    )
+                                )
+                            append_code = APPEND_CODE_TEMPLATE.format(injected_globals, resume[8:])
+                            instance.start_file(test_file, append=append_code)
+                            last_read_time[idx] = time.time()
+
                     if out.startswith("BROADCAST "):
                         for instance2 in instances:
                             if instance2 is not instance:
@@ -404,6 +422,38 @@ def run_test_on_instances(test_file, num_instances, instances):
         output_str += "\n".join(lines) + "\n"
 
     return error, skip, output_str
+
+
+def wait_for_reboot(instance, extra_timeout_ms=0):
+    # Monitor device responses for reboot banner, waiting for idle.
+    extra_timeout = float(extra_timeout_ms) * 1000
+    INITIAL_TIMEOUT = 1 + extra_timeout
+    FULL_TIMEOUT = 5 + extra_timeout
+    t_start = t_last_activity = time.monotonic()
+    while True:
+        t = time.monotonic()
+        out, err = instance.readline()
+        if err is not None:
+            print("Reboot: communication error", err)
+            return False
+        if out:
+            t_last_activity = t
+            # Check for reboot banner, see py/pyexec.c "reset friendly REPL"
+            if re.match(r"^MicroPython v\d+\.\d+\.\d+.* on .*; .* with .*$", out):
+                time.sleep(0.1)
+                break
+
+        if t_last_activity == t_start:
+            if t - t_start > INITIAL_TIMEOUT:
+                print("Reboot: missed initial Timeout")
+                return False
+        else:
+            if t - t_start > FULL_TIMEOUT:
+                print("Reboot: Timeout")
+                return False
+
+    instance.pyb.enter_raw_repl()
+    return True
 
 
 def print_diff(a, b):


### PR DESCRIPTION
We've found a rather thorny WB55 issue that I've been investigating for much of the past week - deepsleep (standby).

After deepsleep is used, BLE cannot be enabled again. 

A colleague first hit this on one of our active projects trying to use low power support. 
In his case (on mpy 1.18) after this failure occurs even a reset will not fix it, neither machine.reset() nor physical reset switch, it needs a hard power off / on.


```
MicroPython v1.18-129-g1133d1ee5-dirty on 2022-02-21; NUCLEO-WB55 with STM32WB55RGV6
Type "help()" for more information.
>>> import machine, bluetooth
>>> ble = bluetooth.BLE()
>>> ble.active(1)
>>> ble.gap_advertise(20_000, b'\x02\x01\x06\x04\tMPY')
>>> ble.active(0)
>>> machine.deepsleep(1000)
MicroPython v1.18-129-g1133d1ee5-dirty on 2022-02-21; NUCLEO-WB55 with STM32WB55RGV6
Type "help()" for more information.
>>> import machine, bluetooth;ble = bluetooth.BLE();ble.active(1);ble.gap_advertise(20_000, b'\x02\x01\x06\x04\tMPY');ble.active(0)
rfcore: rfcore_ble_init
tl_sys_wait_ack: timeout
tl_ble_wait_resp: timeout
tl_sys_wait_ack: timeout
rfcore: rfcore_ble_hci_cmd
rfcore: rfcore_ble_init
tl_sys_wait_ack: timeout
tl_ble_wait_resp: timeout
tl_sys_wait_ack: timeout
rfcore: rfcore_ble_hci_cmd
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
OSError: [Errno 110] ETIMEDOUT
```

I've tested on ble hci radio firmware 1.12 and 1.13.1 and both appear to behave the same, though this current commit here has only been tested on 1.13.1 so far. 

There's supposed to be extra code needed to wake Core2 after standby as the PWR_CR4_C2BOOT flag only works on cold boot.
https://community.st.com/s/question/0D53W00000A28aPSAR/stm32wb55-implement-standby-mode-in-a-ble-application
Just adding this interrupt trigger isn't enough to solve the issue for me though.

I've got a number of changes and commented out tests in this PR, largely inspired by posts on the stm forums and this official example project which has sleep / suspend support: https://github.com/STMicroelectronics/STM32CubeWB/tree/master/Projects/P-NUCLEO-WB55.Nucleo/Applications/BLE/BLE_HeartRate 

As it stands in the current commit, deepsleep support appears to be fixed, as long as BLE is disabled. I've got this set up to automatically disable BLE whenever deepsleep is called.

Alternatively, BLE can be left enabled (with future potential to have it used to wake from sleep) with boot code to detect the post-standby startup, at which point NVIC_SystemReset() is run. This does "solve" the timeout problem, but is feels like a pretty nasty hack (even if it's a suggested workaround by STM employees on forum posts).

On a side note, if I replace HAL_PWR_EnterSTANDBYMode() with HAL_PWR_EnterSHUTDOWNMode() the problem is also fixed, and you get slightly lowever power use - however BLE cannot be left enabled in this case, so the fix as committed here is likely better.

On a related note, this solution seems quite fragile. Pretty much all the individual changes included here appear to be required, swapping out pretty much any of them brings the problem back. I suspect there could be timing issues too, if the BLE deinit / shutdown isn't done early enough before standby is entered, the problem remains.

I haven't had any luck finding a means to inspect core2 / ble firmware to know what state it's in? If it's possible to check / know when it's disabled / low power before interring standby on core1 that would be better?

Separately, it'd be awesome to add a multi-test for this feature - however I've failed to get one to work so far as the test harness drops out when the chip reboots. Has any work been done previously anywhere to add support to auto re-connect and continue a test? Or should we extend mpremote soft-reboot handling to also detect sleep/reboots and then use it for muiltitest?
