### PR TITLE
esp32: update to use IDF v4.4

### DIFF
--- a/ports/esp32/README.md
+++ b/ports/esp32/README.md
@@ -28,7 +28,7 @@ manage the ESP32 microcontroller, as well as a way to manage the required
 build environment and toolchains needed to build the firmware.
 
 The ESP-IDF changes quickly and MicroPython only supports certain versions.
-Currently MicroPython supports v4.0.2, v4.1.1 and v4.2,
+Currently MicroPython supports v4.0.2, v4.1.1, v4.2.2, v4.3.2 and v4.4,
 although other IDF v4 versions may also work.
 
 To install the ESP-IDF the full instructions can be found at the
@@ -50,7 +50,7 @@ To check out a copy of the IDF use git clone:
 $ git clone -b v4.0.2 --recursive https://github.com/espressif/esp-idf.git
 ```
 
-You can replace `v4.0.2` with `v4.1.1` or `v4.2` or any other supported version.
+You can replace `v4.0.2` with `v4.2.2` or `v4.4` or any other supported version.
 (You don't need a full recursive clone; see the `ci_esp32_setup` function in
 `tools/ci.sh` in this repository for more detailed set-up commands.)
 
@@ -77,8 +77,7 @@ The `install.sh` step only needs to be done once. You will need to source
 
 **Note:** If you are building MicroPython for the ESP32-S2, ESP32-C3 or ESP32-S3,
 please ensure you are using the following required IDF versions:
-- ESP32-S3 currently requires latest `master`, but eventually `v4.4` or later when
-  it's available.
+- ESP32-S3 currently requires `v4.4` or later.
 - ESP32-S2 and ESP32-C3 require `v4.3.1` or later.
 
 Building the firmware

--- a/tools/ci.sh
+++ b/tools/ci.sh
@@ -107,8 +107,7 @@ function ci_esp32_idf402_setup {
 }
 
 function ci_esp32_idf44_setup {
-    # This commit is just before v5.0-dev
-    ci_esp32_setup_helper 142bb32c50fa9875b8b69fa539a2d59559460d72
+    ci_esp32_setup_helper v4.4
 }
 
 function ci_esp32_build {


### PR DESCRIPTION
IDF v4.4 was officially released about a month ago.