### PR TITLE
tools/upip.py: add urls parameter to install from alternative index urls

### DIFF
--- a/tools/upip.py
+++ b/tools/upip.py
@@ -82,7 +82,7 @@ def install_tar(f, prefix):
         # print(info)
         fname = info.name
         try:
-            fname = fname[fname.index("/") + 1 :]
+            fname = fname[fname.index("/") + 1:]
         except ValueError:
             fname = ""
 
@@ -171,8 +171,11 @@ def url_open(url):
     return s
 
 
-def get_pkg_metadata(name):
-    for url in index_urls:
+def get_pkg_metadata(name, urls=[]):
+    if not len(urls):
+        urls = index_urls
+
+    for url in urls:
         try:
             f = url_open("%s/%s/json" % (url, name))
         except NotFoundError:
@@ -191,9 +194,9 @@ def fatal(msg, exc=None):
     sys.exit(1)
 
 
-def install_pkg(pkg_spec, install_path):
+def install_pkg(pkg_spec, install_path, urls=[]):
     package = pkg_spec.split("==")
-    data = get_pkg_metadata(package[0])
+    data = get_pkg_metadata(package[0], urls)
 
     if len(package) == 1:
         latest_ver = data["info"]["version"]
@@ -205,7 +208,6 @@ def install_pkg(pkg_spec, install_path):
     assert len(packages) == 1
     package_url = packages[0]["url"]
     print("Installing %s %s from %s" % (pkg_spec, latest_ver, package_url))
-    package_fname = op_basename(package_url)
     f1 = url_open(package_url)
     try:
         f2 = uzlib.DecompIO(f1, gzdict_sz)
@@ -219,7 +221,7 @@ def install_pkg(pkg_spec, install_path):
     return meta
 
 
-def install(to_install, install_path=None):
+def install(to_install, install_path=None, urls=[]):
     # Calculate gzip dictionary size to use
     global gzdict_sz
     sz = gc.mem_free() + gc.mem_alloc()
@@ -242,7 +244,7 @@ def install(to_install, install_path=None):
             pkg_spec = to_install.pop(0)
             if pkg_spec in installed:
                 continue
-            meta = install_pkg(pkg_spec, install_path)
+            meta = install_pkg(pkg_spec, install_path, urls)
             installed.append(pkg_spec)
             if debug:
                 print(meta)


### PR DESCRIPTION
* add urls parameter to install_pkg, install and get_pkg_metadata function
* fix a PEP8 warning by removing the unused variable "package_fname"

Usage example on a ESP32 board 

```python
MicroPython v1.18 on 2022-01-17; ESP32 module (spiram) with ESP32
Type "help()" for more information.
>>> 
>>> import upip3
>>>
>>> # default usage with the currently defined index urls of micropython.org and pypi.org 
>>> upip3.install('micropython-winbond')
Installing to: /lib/
Installing micropython-winbond 0.2.0 from https://files.pythonhosted.org/packages/d1/c0/7509bfb068055f853b81604e228a9147abbdd85be8e1ec1e9f767ab2b2a1/micropython-winbond-0.2.0.tar.gz
>>> 
>>> # with this feature implemented, installing with the package from test.pypi.org
>>> upip3.install('micropython-winbond', urls=['https://test.pypi.org/pypi'])
Installing to: /lib/
Warning: test.pypi.org SSL certificate is not validated
Installing micropython-winbond 0.2.0 from https://test-files.pythonhosted.org/packages/d1/c0/7509bfb068055f853b81604e228a9147abbdd85be8e1ec1e9f767ab2b2a1/micropython-winbond-0.2.0.tar.gz
>>>
```