### PR TITLE
extmod/uzlib: Fix parsing zlib header dict size.

### DIFF
--- a/extmod/moduzlib.c
+++ b/extmod/moduzlib.c
@@ -77,7 +77,7 @@ STATIC mp_obj_t decompio_make_new(const mp_obj_type_t *type, size_t n_args, size
     o->eof = false;
 
     mp_int_t dict_opt = 0;
-    int dict_sz;
+    uint dict_sz;
     if (n_args > 1) {
         dict_opt = mp_obj_get_int(args[1]);
     }
@@ -94,7 +94,10 @@ STATIC mp_obj_t decompio_make_new(const mp_obj_type_t *type, size_t n_args, size
         header_error:
             mp_raise_ValueError(MP_ERROR_TEXT("compression header"));
         }
-        dict_sz = 1 << dict_opt;
+        // RFC 1950 section 2.2:
+        // CINFO is the base-2 logarithm of the LZ77 window size,
+        // minus eight (CINFO=7 indicates a 32K window size)
+        dict_sz = 1 << (dict_opt + 8);
     } else {
         dict_sz = 1 << -dict_opt;
     }
@@ -116,6 +119,7 @@ STATIC mp_uint_t decompio_read(mp_obj_t o_in, void *buf, mp_uint_t size, int *er
         o->eof = true;
     }
     if (st < 0) {
+        DEBUG_printf("uncompress error=" INT_FMT "\n", st);
         *errcode = MP_EINVAL;
         return MP_STREAM_ERROR;
     }


### PR DESCRIPTION
This fixes failures to decompress data with an zlib-header using DecompIO.

CINFO is the field in the zlib header used to determine how big the dictionary should be. From [RFC 1950 section 2.2](https://www.rfc-editor.org/rfc/rfc1950#page-5):
> CINFO is the base-2 logarithm of the LZ77 window size, minus eight (CINFO=7 indicates a 32K window size)

The MicroPython uzlib implementation missed the "minus eight" part, causing a significantly smaller dictionary to be allocated.

I suppose the tests didn't catch this since they are only decompressing a very small piece of data, which doesn't use up enough dictionary slots for the issue to be exposed. Didn't include an extra test with this commit, as that would mean adding some large blobs just so we can test decompressing with them, or crafting custom blobs with unusual dictionary sizes to basically test nothing else than that we correctly interpret this field. If one is still desired, I can look into adding it.