### PR TITLE
esp32: Sleep in MICROPY_EVENT_POLL_HOOK to free up GIL and cycles for other threads

### DIFF
--- a/ports/esp32/mpconfigport.h
+++ b/ports/esp32/mpconfigport.h
@@ -195,6 +195,7 @@ void *esp_native_code_commit(void *, size_t, void *);
         mp_handle_pending(true); \
         MICROPY_PY_USOCKET_EVENTS_HANDLER \
         MP_THREAD_GIL_EXIT(); \
+        ulTaskNotifyTake(pdFALSE, 1); \
         MP_THREAD_GIL_ENTER(); \
     } while (0);
 #else

--- a/ports/esp32/mphalport.c
+++ b/ports/esp32/mphalport.c
@@ -98,7 +98,6 @@ int mp_hal_stdin_rx_chr(void) {
             return c;
         }
         MICROPY_EVENT_POLL_HOOK
-        ulTaskNotifyTake(pdFALSE, 1);
     }
 }
 


### PR DESCRIPTION
Currently on the ESP32 the REPL holds the GIL while sleeping in wait for input, blocking other threads significantly.

This can easily be observed by running a thread that is both busy and regularly releases the GIL (for example a loop doing something then sleeping a few ms after each iteration). When the main task is at the REPL, the thread is significantly stalled. If the main task is manually made to release the GIL (for example, by calling `utime.sleep_ms(500)`) the other thread can be seen immediately working at the expected speed again.

~This change releases the GIL while sleeping and waiting for a new character, thus allowing other threads to acquire the GIL in the meantime and resolving the issue.~

~Note that `MICROPY_EVENT_POLL_HOOK` already releases and re-acquires the GIL. So an optional improvements might be using an alternative version of that hook here, so we don't have to release and acquire the lock twice. Left that out for now to keep the patch simple.~

EDIT:
Additionally, there are various instances in where blocking functions run `MICROPY_EVENT_POLL_HOOK` in a loop while they wait for a certain event / condition. For example the `uselect` methods poll objects to determine whether data is available, but uses 100% of CPU while it does, constantly calling `MICROPY_EVENT_POLL_HOOK` in the process.

The `MICROPY_EVENT_POLL_HOOK` macro is only ever used in waiting loops, where (if threads are enabled) it makes sense to yield for at a single tick so that these loops do not consume all CPU cycles but instead other threads may execute. (In fact, the thing these loops wait for may even indirectly or directly depend on another task being able to run.)

This change moves the sleep that was inside the REPL input function to inside the `MICROPY_EVENT_POLL_HOOK` macro, where the GIL is already being released, solving both the blocking REPL issue and the 100% CPU use issue at the same time.
