### PR TITLE
rfc: shared & esp32: Create and use stdin_helper functions.

### DIFF
--- a/ports/esp32/main/CMakeLists.txt
+++ b/ports/esp32/main/CMakeLists.txt
@@ -21,6 +21,7 @@ set(MICROPY_SOURCE_SHARED
     ${MICROPY_DIR}/shared/timeutils/timeutils.c
     ${MICROPY_DIR}/shared/runtime/interrupt_char.c
     ${MICROPY_DIR}/shared/runtime/stdout_helpers.c
+    ${MICROPY_DIR}/shared/runtime/stdin_helpers.c
     ${MICROPY_DIR}/shared/runtime/sys_stdio_mphal.c
     ${MICROPY_DIR}/shared/runtime/pyexec.c
 )

--- a/ports/esp32/moduos.c
+++ b/ports/esp32/moduos.c
@@ -93,7 +93,7 @@ STATIC mp_obj_t os_dupterm_notify(mp_obj_t obj_in) {
         if (c < 0) {
             break;
         }
-        ringbuf_put(&stdin_ringbuf, c);
+        mp_hal_stdin_rx_buff_put(c);
     }
     return mp_const_none;
 }

--- a/ports/esp32/mphalport.h
+++ b/ports/esp32/mphalport.h
@@ -50,8 +50,6 @@
 
 extern TaskHandle_t mp_main_task_handle;
 
-extern ringbuf_t stdin_ringbuf;
-
 // Check the ESP-IDF error code and raise an OSError if it's not ESP_OK.
 void check_esp_err(esp_err_t code);
 

--- a/ports/esp32/uart.c
+++ b/ports/esp32/uart.c
@@ -94,11 +94,6 @@ STATIC void IRAM_ATTR uart_irq_handler(void *arg) {
         #elif CONFIG_IDF_TARGET_ESP32C3 || CONFIG_IDF_TARGET_ESP32S2 || CONFIG_IDF_TARGET_ESP32S3
         uint8_t c = READ_PERI_REG(UART_FIFO_AHB_REG(0)); // UART0
         #endif
-        if (c == mp_interrupt_char) {
-            mp_sched_keyboard_interrupt();
-        } else {
-            // this is an inline function so will be in IRAM
-            ringbuf_put(&stdin_ringbuf, c);
-        }
+        mp_hal_stdin_rx_buff_put(c);
     }
 }

--- a/ports/esp32/usb.c
+++ b/ports/esp32/usb.c
@@ -50,11 +50,7 @@ static void usb_callback_rx(int itf, cdcacm_event_t *event) {
             break;
         }
         for (size_t i = 0; i < len; ++i) {
-            if (usb_rx_buf[i] == mp_interrupt_char) {
-                mp_sched_keyboard_interrupt();
-            } else {
-                ringbuf_put(&stdin_ringbuf, usb_rx_buf[i]);
-            }
+            mp_hal_stdin_rx_buff_put(usb_rx_buf[i]);
         }
     }
 }

--- a/ports/esp32/usb_serial_jtag.c
+++ b/ports/esp32/usb_serial_jtag.c
@@ -48,17 +48,13 @@ static void usb_serial_jtag_isr_handler(void *arg) {
 
     if (flags & USB_SERIAL_JTAG_INTR_SERIAL_OUT_RECV_PKT) {
         usb_serial_jtag_ll_clr_intsts_mask(USB_SERIAL_JTAG_INTR_SERIAL_OUT_RECV_PKT);
-        size_t req_len = ringbuf_free(&stdin_ringbuf);
+        size_t req_len = mp_hal_stdin_rx_buff_free();
         if (req_len > USB_SERIAL_JTAG_BUF_SIZE) {
             req_len = USB_SERIAL_JTAG_BUF_SIZE;
         }
         size_t len = usb_serial_jtag_ll_read_rxfifo(rx_buf, req_len);
         for (size_t i = 0; i < len; ++i) {
-            if (rx_buf[i] == mp_interrupt_char) {
-                mp_sched_keyboard_interrupt();
-            } else {
-                ringbuf_put(&stdin_ringbuf, rx_buf[i]);
-            }
+            mp_hal_stdin_rx_buff_put(rx_buf[i]);
         }
         mp_hal_wake_main_task_from_isr();
     }

--- a/py/mphal.h
+++ b/py/mphal.h
@@ -55,6 +55,22 @@ void mp_hal_stdout_tx_strn(const char *str, size_t len);
 void mp_hal_stdout_tx_strn_cooked(const char *str, size_t len);
 #endif
 
+#ifndef mp_hal_stdin_rx_buff_poll
+uintptr_t mp_hal_stdin_rx_buff_poll(uintptr_t poll_flags);
+#endif
+
+#ifndef mp_hal_stdin_rx_buff_get
+int mp_hal_stdin_rx_buff_get(void);
+#endif
+
+#ifndef mp_hal_stdin_rx_buff_put
+int mp_hal_stdin_rx_buff_put(char c);
+#endif
+
+#ifndef mp_hal_stdin_rx_buff_free
+size_t mp_hal_stdin_rx_buff_free();
+#endif
+
 #ifndef mp_hal_delay_ms
 void mp_hal_delay_ms(mp_uint_t ms);
 #endif

--- a/shared/runtime/stdin_helpers.c
+++ b/shared/runtime/stdin_helpers.c
@@ -1,0 +1,77 @@
+/*
+ * This file is part of the MicroPython project, http://micropython.org/
+ *
+ * Development of the code in this file was sponsored by Microbric Pty Ltd
+ *
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2014 Damien P. George
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#include <stdio.h>
+#include "py/runtime.h"
+#include "py/ringbuf.h"
+#include "py/stream.h"
+
+#if MICROPY_KBD_EXCEPTION
+#include "interrupt_char.h"
+#endif
+
+#ifndef MICROPY_STDIN_BUFF_SIZE
+#define MICROPY_STDIN_BUFF_SIZE 260
+#endif
+
+STATIC uint8_t stdin_ringbuf_array[MICROPY_STDIN_BUFF_SIZE];
+static ringbuf_t stdin_ringbuf = {stdin_ringbuf_array, sizeof(stdin_ringbuf_array), 0, 0};
+
+uintptr_t mp_hal_stdin_rx_buff_poll(uintptr_t poll_flags) {
+    if (poll_flags & MP_STREAM_POLL_RD) {
+        if (stdin_ringbuf.iget != stdin_ringbuf.iput) {
+            return MP_STREAM_POLL_RD;
+        }
+    }
+    return 0;
+}
+
+int mp_hal_stdin_rx_buff_get(void) {
+    int c = ringbuf_get(&stdin_ringbuf);
+    #ifdef MICROPY_EVENT_POLL_HOOK
+    if (c != -1) {
+        return c;
+    }
+    MICROPY_EVENT_POLL_HOOK
+    #endif
+    return c;
+}
+
+int mp_hal_stdin_rx_buff_put(char c) {
+    #if MICROPY_KBD_EXCEPTION
+    if (c == mp_interrupt_char) {
+        mp_sched_keyboard_interrupt();
+        return 0;
+    }
+    #endif
+    return ringbuf_put(&stdin_ringbuf, c);
+}
+
+size_t mp_hal_stdin_rx_buff_free() {
+    return ringbuf_free(&stdin_ringbuf);
+}


### PR DESCRIPTION
I put this together during the implementation of https://github.com/micropython/micropython/pull/8279 and after noticing a lot of re-implementations of stdin / interrupt char handling, often with discrepancies (eg. #8316)

Not every port is likely to need the ringbuffer, depending on the hardware involved, but I think some level of consolidation would be really useful - plus taking this further with features like:
* directly integrating dupterm when enabled, ensure repl uart/usb/etc is consistently configurable
* stdout tx now vs. wait for connection (where possible, like on stm32 to show banner upon usb repl connection)
