### PR TITLE
nrf/manifest: Include uasyncio in default manifest for nrf port.

### DIFF
--- a/ports/nrf/modules/manifest.py
+++ b/ports/nrf/modules/manifest.py
@@ -1,1 +1,2 @@
 freeze("$(PORT_DIR)/modules/scripts", "_mkfs.py")
+include("$(MPY_DIR)/extmod/uasyncio/manifest.py")


### PR DESCRIPTION
nrf port builds were not including `uasyncio` package, this PR adds it to the default manifest.py for the port.