### PR TITLE
stm32/boards/SPARKFUN_MICROMOD_STM32: Fix incorrect peripheral configs.

### DIFF
--- a/ports/stm32/boards/SPARKFUN_MICROMOD_STM32/mpconfigboard.h
+++ b/ports/stm32/boards/SPARKFUN_MICROMOD_STM32/mpconfigboard.h
@@ -73,15 +73,15 @@ extern struct _spi_bdev_t spi_bdev;
 #define MICROPY_HW_CAN1_TX (pin_B9)
 #define MICROPY_HW_CAN1_RX (pin_B8)
 
-// I2C1 config (MicroMod I2C)
-#define MICROPY_HW_I2C1_NAME "I2C"
-#define MICROPY_HW_I2C1_SCL (pin_B10)
-#define MICROPY_HW_I2C1_SDA (pin_B11)
+// I2C1 config (MicroMod I2C1)
+#define MICROPY_HW_I2C1_NAME "I2C1"
+#define MICROPY_HW_I2C1_SCL (pin_B6)
+#define MICROPY_HW_I2C1_SDA (pin_B7)
 
-// I2C2 config (MicroMod I2C1)
-#define MICROPY_HW_I2C2_NAME "I2C1"
-#define MICROPY_HW_I2C2_SCL (pin_B6)
-#define MICROPY_HW_I2C2_SDA (pin_B7)
+// I2C2 config (MicroMod I2C)
+#define MICROPY_HW_I2C2_NAME "I2C"
+#define MICROPY_HW_I2C2_SCL (pin_B10)
+#define MICROPY_HW_I2C2_SDA (pin_B11)
 
 // SPI1 config (MicroMod SPI)
 #define MICROPY_HW_SPI1_NAME "SPI"

--- a/ports/stm32/boards/SPARKFUN_MICROMOD_STM32/mpconfigboard.h
+++ b/ports/stm32/boards/SPARKFUN_MICROMOD_STM32/mpconfigboard.h
@@ -63,10 +63,10 @@ extern struct _spi_bdev_t spi_bdev;
 #define MICROPY_HW_RTC_USE_US (0)
 #define MICROPY_HW_RTC_USE_CALOUT (1)
 
-// UART1 config (MicroMod UART1)
-#define MICROPY_HW_UART1_NAME "UART1"
-#define MICROPY_HW_UART1_TX (pin_A2)
-#define MICROPY_HW_UART1_RX (pin_A3)
+// UART2 config (MicroMod UART1)
+#define MICROPY_HW_UART2_NAME "UART1"
+#define MICROPY_HW_UART2_TX (pin_A2)
+#define MICROPY_HW_UART2_RX (pin_A3)
 
 // CAN1 config (MicroMod CAN)
 #define MICROPY_HW_CAN1_NAME "CAN"


### PR DESCRIPTION
Fixes incorrect I2C config on the SparkFun STM32 MicroMod processor board.