### PR TITLE
zephyr: Upgrade to Zephyr v3.0.0.

### DIFF
--- a/docs/zephyr/tutorial/repl.rst
+++ b/docs/zephyr/tutorial/repl.rst
@@ -31,8 +31,8 @@ With your serial program open (PuTTY, screen, picocom, etc) you may see a
 blank screen with a flashing cursor. Press Enter (or reset the board) and
 you should be presented with the following text::
 
-        *** Booting Zephyr OS build zephyr-v2.7.0  ***
-        MicroPython v1.17-288-gb695f5a70-dirty on 2022-01-03; zephyr-frdm_k64f with mk64f12
+        *** Booting Zephyr OS build zephyr-v3.0.0  ***
+        MicroPython v1.18-169-g665f0e2a6-dirty on 2022-03-02; zephyr-frdm_k64f with mk64f12
         Type "help()" for more information.
         >>>
 

--- a/ports/zephyr/README.md
+++ b/ports/zephyr/README.md
@@ -4,7 +4,7 @@ MicroPython port to Zephyr RTOS
 This is a work-in-progress port of MicroPython to Zephyr RTOS
 (http://zephyrproject.org).
 
-This port requires Zephyr version v2.7.0, and may also work on higher
+This port requires Zephyr version v3.0.0, and may also work on higher
 versions.  All boards supported
 by Zephyr (with standard level of features support, like UART console)
 should work with MicroPython (but not all were tested).
@@ -39,13 +39,13 @@ setup is correct.
 If you already have Zephyr installed but are having issues building the
 MicroPython port then try installing the correct version of Zephyr via:
 
-    $ west init zephyrproject -m https://github.com/zephyrproject-rtos/zephyr --mr v2.7.0
+    $ west init zephyrproject -m https://github.com/zephyrproject-rtos/zephyr --mr v3.0.0
 
 Alternatively, you don't have to redo the Zephyr installation to just
 switch from master to a tagged release, you can instead do:
 
     $ cd zephyrproject/zephyr
-    $ git checkout v2.7.0
+    $ git checkout v3.0.0
     $ west update
 
 With Zephyr installed you may then need to configure your environment,

--- a/ports/zephyr/zephyr_storage.c
+++ b/ports/zephyr/zephyr_storage.c
@@ -32,7 +32,7 @@
 #endif
 
 #ifdef CONFIG_DISK_ACCESS
-#include <disk/disk_access.h>
+#include <storage/disk_access.h>
 #endif
 
 #ifdef CONFIG_FLASH_MAP

--- a/tools/ci.sh
+++ b/tools/ci.sh
@@ -618,7 +618,7 @@ function ci_windows_build {
 
 ZEPHYR_DOCKER_VERSION=v0.21.0
 ZEPHYR_SDK_VERSION=0.13.2
-ZEPHYR_VERSION=v2.7.0
+ZEPHYR_VERSION=v3.0.0
 
 function ci_zephyr_setup {
     docker pull zephyrprojectrtos/ci:${ZEPHYR_DOCKER_VERSION}


### PR DESCRIPTION
Updates the Zephyr port build instructions and CI to use the latest
Zephyr release tag.

Signed-off-by: Maureen Helm <maureen.helm@intel.com>