### PR TITLE
stm32wb55/rfcore: Protect against file errors in rfcore firmware update scripts.

### DIFF
--- a/ports/stm32/boards/NUCLEO_WB55/rfcore_makefirmware.py
+++ b/ports/stm32/boards/NUCLEO_WB55/rfcore_makefirmware.py
@@ -30,28 +30,70 @@
 # rfcore_firmware.py as well as instructions on how to use.
 
 import os
+import re
 import struct
 import sys
+from binascii import crc32
+from rfcore_firmware import validate_crc, _OBFUSCATION_KEY
 
-# Must match rfcore_firmware.py.
-_OBFUSCATION_KEY = 0x0573B55AA
 
 _FIRMWARE_FILES = {
     "stm32wb5x_FUS_fw_1_0_2.bin": "fus_102.bin",
     "stm32wb5x_FUS_fw.bin": "fus_110.bin",
     "stm32wb5x_BLE_HCILayer_fw.bin": "ws_ble_hci.bin",
 }
+_RELEASE_NOTES = "Release_Notes.html"
+
+
+def get_details(release_notes, filename):
+    if not release_notes:
+        return None
+    file_details = re.findall(
+        rb"%s,(((0x[\d\S]+?),)+[vV][\d\.]+)[<,]" % filename.encode(),
+        release_notes,
+        flags=re.DOTALL,
+    )
+    # The release note has all past version details also, but current is at top
+    latest_details = file_details[0][0].split(b",")
+    addr_1m, addr_640k, addr_512k, addr_256k, version = latest_details
+    addr_1m = int(addr_1m, 0)
+    addr_640k = int(addr_640k, 0)
+    addr_512k = int(addr_512k, 0)
+    addr_256k = int(addr_256k, 0)
+    version = [int(v) for v in version.lower().lstrip(b"v").split(b".")]
+    return addr_1m, addr_640k, addr_512k, addr_256k, version
 
 
 def main(src_path, dest_path):
-    for src_file, dest_file in _FIRMWARE_FILES.items():
-        src_file = os.path.join(src_path, src_file)
+
+    # Load the release note to parse for important details
+    with open(os.path.join(src_path, _RELEASE_NOTES), "rb") as f:
+        release_notes = f.read()
+    # remove some formatting
+    release_notes = re.sub(rb"</?strong>", b"", release_notes)
+    # flatten tables
+    release_notes = re.sub(
+        rb"</t[dh]>\W*\n*\W*",
+        b",",
+        release_notes.replace(b"<td>", b"").replace(b"<th>", b""),
+    )
+    if (
+        b"Wireless Coprocessor Binary,STM32WB5xxG(1M),STM32WB5xxY(640k),STM32WB5xxE(512K),STM32WB5xxC(256K),Version,"
+        not in release_notes
+    ):
+        raise SystemExit(
+            "Cannot determine binary load address, please confirm Coprocessor folder / Release Notes format."
+        )
+
+    for src_filename, dest_file in _FIRMWARE_FILES.items():
+        src_file = os.path.join(src_path, src_filename)
         dest_file = os.path.join(dest_path, dest_file)
         if not os.path.exists(src_file):
             print("Unable to find: {}".format(src_file))
             continue
         sz = 0
         with open(src_file, "rb") as src:
+            crc = 0
             with open(dest_file, "wb") as dest:
                 while True:
                     b = src.read(4)
@@ -59,9 +101,71 @@ def main(src_path, dest_path):
                         break
                     (v,) = struct.unpack("<I", b)
                     v ^= _OBFUSCATION_KEY
-                    dest.write(struct.pack("<I", v))
+                    vs = struct.pack("<I", v)
+                    dest.write(vs)
+                    crc = crc32(vs, crc)
                     sz += 4
-        print("Written {} ({} bytes)".format(dest_file, sz))
+
+                addr_1m, addr_640k, addr_512k, addr_256k, version = get_details(
+                    release_notes, src_filename
+                )
+
+                footer = struct.pack(
+                    "<37sIIIIbbbI",
+                    src_filename.encode(),
+                    addr_1m,
+                    addr_640k,
+                    addr_512k,
+                    addr_256k,
+                    *version,
+                    _OBFUSCATION_KEY,
+                )
+                assert len(footer) == 60
+                dest.write(footer)
+                crc = crc32(footer, crc)
+                crc = 0xFFFFFFFF & -crc - 1
+                dest.write(struct.pack("<I", crc))
+                sz += 64
+
+        print(
+            f"Written {src_filename} v{version[0]}.{version[1]}.{version[2]} to {dest_file} ({sz} bytes)"
+        )
+        check_file_details(dest_file)
+
+
+def check_file_details(filename):
+    """Should match copy of function in rfcore_firmware.py to confirm operation"""
+    with open(filename, "rb") as f:
+        if not validate_crc(f):
+            raise ValueError("file validation failed: incorrect crc")
+
+        f.seek(-64, 2)
+        footer = f.read()
+        assert len(footer) == 64
+        details = struct.unpack("<37sIIIIbbbII", footer)
+        (
+            src_filename,
+            addr_1m,
+            addr_640k,
+            addr_512k,
+            addr_256k,
+            vers_major,
+            vers_minor,
+            vers_patch,
+            KEY,
+            crc,
+        ) = details
+        if KEY != _OBFUSCATION_KEY:
+            raise ValueError("file validation failed: incorrect key")
+
+    return (
+        src_filename,
+        addr_1m,
+        addr_640k,
+        addr_512k,
+        addr_256k,
+        (vers_major, vers_minor, vers_patch),
+    )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
We've run into a few failures in the wb55 rfcore update procedures lately - mostly caused with the stm gui application, but sometimes from un-recognised failures during bin file transfer to the wb55 prior to running the `rfcore_firmware.py` script - causing corrupted firmware to be flashed to the unit.

Other failures were caused by incorrect load addresses being used, again both from user error copying the address from the html release notes to the gui tool, but also from similarly not updating the address correctly in `rfcore_firmware.py`

To guard against these errors and make it easier to prepare different versions I've added a few features to the rfcore firmware tools:
* When creating the bin file, automatically parse the release note in the folder to get the correct address.
* Add a footer to the bin file containing the name, version, crc, address etc.
* Before flashing rfcore, check if the same version is already installed.
* Verify the crc and obfuscation key before flashing bin.
* log the name and version of file being flashed.