### PR TITLE
rp2: Override mpconfigboard.cmake manifest from the command line.

### DIFF
--- a/ports/rp2/CMakeLists.txt
+++ b/ports/rp2/CMakeLists.txt
@@ -33,7 +33,9 @@ if(NOT EXISTS ${MICROPY_BOARD_DIR}/mpconfigboard.cmake)
     message(FATAL_ERROR "Invalid MICROPY_BOARD specified: ${MICROPY_BOARD}")
 endif()
 
-# Include board config
+set(MICROPY_USER_FROZEN_MANIFEST ${MICROPY_FROZEN_MANIFEST})
+
+# Include board config, it may override MICROPY_FROZEN_MANIFEST
 include(${MICROPY_BOARD_DIR}/mpconfigboard.cmake) 
 
 # Set the PICO_BOARD if it's not already set (allow a board to override it).
@@ -217,9 +219,13 @@ if (MICROPY_PY_NETWORK_NINAW10)
     )
 endif()
 
-# Define mpy-cross flags and frozen manifest
+# Define mpy-cross flags
 set(MICROPY_CROSS_FLAGS -march=armv7m)
-if (NOT MICROPY_FROZEN_MANIFEST)
+
+# Set the frozen manifest file
+if (MICROPY_USER_FROZEN_MANIFEST)
+    set(MICROPY_FROZEN_MANIFEST ${MICROPY_USER_FROZEN_MANIFEST})
+elseif (NOT MICROPY_FROZEN_MANIFEST)
     set(MICROPY_FROZEN_MANIFEST ${PROJECT_SOURCE_DIR}/boards/manifest.py)
 endif()
 


### PR DESCRIPTION
* Make cmd FROZEN_MANIFEST override both the default and board manifests.