### PR TITLE
tools/mpremote: Improve soft restart mount reliability.

### DIFF
--- a/docs/reference/mpremote.rst
+++ b/docs/reference/mpremote.rst
@@ -135,6 +135,11 @@ The full list of supported commands are:
 
       $ mpremote mount <local-dir>
 
+  During usage, Ctrl-D will soft-reboot and normally reconnect the mount automatically.
+  If the unit has a main.py running at startup however the remount cannot occur. 
+  In this case a raw mode soft reboot can be used: Ctrl-A Ctrl-D to reboot, 
+  then Ctrl-B to get back to normal repl at which point the mount will be ready.
+
 - unmount the local directory from the remote device:
 
   .. code-block:: bash


### PR DESCRIPTION
I ran into an issue where on one of my esp32 boards with the new soft reset handling, the `if t - t_last_activity > QUIET_TIMEOUT:` check was being triggered early before `b">>> "` comes through so the remount doesn't happen.

On this board the `MPY: soft reboot` line comes through immediately (getting the routine past initial timeout) but then there's a slightly longer delay while the board restarts before it prints out the startup header and the repl prompt.

This PR adds some extra pattern monitoring during the timeout loop to track state if a soft restart is actually started.

An additional benefit of this is that before the change the full timeout was basically always being waited before mpremote continues. Now it generally exits earlier after just the (now shorter) QUIET_TIMEOUT period if soft reboot is not in progress, or QUIET_TIMEOUT long after `\n>` comes through.