### PR TITLE
esp32: Expose pin 20 for ESP32.

### DIFF
--- a/ports/esp32/machine_pin.c
+++ b/ports/esp32/machine_pin.c
@@ -93,7 +93,11 @@ STATIC const machine_pin_obj_t machine_pin_obj[] = {
     #endif
     {{&machine_pin_type}, GPIO_NUM_18},
     {{&machine_pin_type}, GPIO_NUM_19},
+    #if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(4, 1, 0)
     {{&machine_pin_type}, GPIO_NUM_20},
+    #else
+    {{NULL}, -1},
+    #endif
     {{&machine_pin_type}, GPIO_NUM_21},
     {{&machine_pin_type}, GPIO_NUM_22},
     {{&machine_pin_type}, GPIO_NUM_23},

--- a/ports/esp32/machine_pin.c
+++ b/ports/esp32/machine_pin.c
@@ -93,7 +93,7 @@ STATIC const machine_pin_obj_t machine_pin_obj[] = {
     #endif
     {{&machine_pin_type}, GPIO_NUM_18},
     {{&machine_pin_type}, GPIO_NUM_19},
-    {{NULL}, -1},
+    {{&machine_pin_type}, GPIO_NUM_20},
     {{&machine_pin_type}, GPIO_NUM_21},
     {{&machine_pin_type}, GPIO_NUM_22},
     {{&machine_pin_type}, GPIO_NUM_23},


### PR DESCRIPTION
Signed-off-by: Kattni Rembor <kattni@adafruit.com>

Fixes https://github.com/micropython/micropython/issues/8393