### PR TITLE
stm32/mbedtls: Add NULL pointer check in m_free_mbedtls.

### DIFF
--- a/ports/mimxrt/mbedtls/mbedtls_port.c
+++ b/ports/mimxrt/mbedtls/mbedtls_port.c
@@ -64,6 +64,9 @@ void *m_calloc_mbedtls(size_t nmemb, size_t size) {
 }
 
 void m_free_mbedtls(void *ptr_in) {
+    if (ptr_in == NULL) {
+        return;
+    }
     void **ptr = &((void **)ptr_in)[-2];
     #if DEBUG
     uint32_t nb;

--- a/ports/stm32/mbedtls/mbedtls_port.c
+++ b/ports/stm32/mbedtls/mbedtls_port.c
@@ -62,6 +62,9 @@ void *m_calloc_mbedtls(size_t nmemb, size_t size) {
 }
 
 void m_free_mbedtls(void *ptr_in) {
+    if (ptr_in == NULL) {
+        return;
+    }
     void **ptr = &((void**)ptr_in)[-2];
     #if DEBUG
     uint32_t nb;


### PR DESCRIPTION
When enabling additional features in mbedtls it is possible for `m_free_mbedtls` to receive a NULL pointer.
This check is also required for `free` to be conforming to the C standard ([which mbedtls expects][1]):

The specific features which lead to a NULL pointer crash in my case:

```
#define MBEDTLS_ASN1_WRITE_C
#define MBEDTLS_BASE64_C
#define MBEDTLS_CIPHER_MODE_CTR
#define MBEDTLS_KEY_EXCHANGE_ECDHE_ECDSA_ENABLED
#define MBEDTLS_ECDH_C
#define MBEDTLS_ECDSA_C
#define MBEDTLS_ECP_C
#define MBEDTLS_GCM_C
#define MBEDTLS_SSL_PROTO_TLS1_2
```

These features where enabled for `ussl` to support `MBEDTLS_TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256` client sockets (with which the crash occurred)

[1]: https://tls.mbed.org/discussions/bug-report-issues/using-mbedtls_free-with-null-pointer