### PR TITLE
tools/mpremote: allow to run mpremote with `python -m`.

### DIFF
--- a/tools/mpremote/mpremote/__main__.py
+++ b/tools/mpremote/mpremote/__main__.py
@@ -1,0 +1,6 @@
+#!/usr/bin/env python3
+
+import sys
+from mpremote import main
+
+sys.exit(main.main())


### PR DESCRIPTION
This is helpful because some scripts are likely to use mpremote with specific python path.