### PR TITLE
tool/gen-cpydiff: Skip Black fmt comments.

### DIFF
--- a/tools/gen-cpydiff.py
+++ b/tools/gen-cpydiff.py
@@ -85,6 +85,16 @@ def readfiles():
             class_, desc, cause, workaround, code = [
                 x.rstrip() for x in list(filter(None, re.split(SPLIT, text)))
             ]
+
+            # remove black `fmt: on/off/skip` comments
+            code = "".join(
+                # skip comments are inline, so we replace just the comment
+                re.sub(r"\s*# fmt: skip", "", x)
+                for x in code.splitlines(keepends=True)
+                # on/off comments are on their own line, so we omit the entire line
+                if not re.match(r"\s*# fmt: (on|off)\s*", x)
+            )
+
             output = Output(test, class_, desc, cause, workaround, code, "", "", "")
             files.append(output)
         except IndexError:


### PR DESCRIPTION
Since cpydiff is code used as documentation, there are cases where we may want to use Black's `fmt: on/off/skip` comments to avoid automatic formatting. However, we don't want these comments to be distracting in the generated documentation.

This rewrites the code to omit these comments when generating the docs.
