### PR TITLE
py/smallint: Introduce MP_SMALL_INT_BITS macro.

### DIFF
--- a/py/persistentcode.c
+++ b/py/persistentcode.c
@@ -48,21 +48,6 @@
 #define MPY_FEATURE_ARCH_DYNAMIC MPY_FEATURE_ARCH
 #endif
 
-#if MICROPY_PERSISTENT_CODE_LOAD || (MICROPY_PERSISTENT_CODE_SAVE && !MICROPY_DYNAMIC_COMPILER)
-// The bytecode will depend on the number of bits in a small-int, and
-// this function computes that (could make it a fixed constant, but it
-// would need to be defined in mpconfigport.h).
-STATIC int mp_small_int_bits(void) {
-    mp_int_t i = MP_SMALL_INT_MAX;
-    int n = 1;
-    while (i != 0) {
-        i >>= 1;
-        ++n;
-    }
-    return n;
-}
-#endif
-
 typedef struct _bytecode_prelude_t {
     uint n_state;
     uint n_exc_stack;
@@ -420,7 +405,7 @@ mp_compiled_module_t mp_raw_code_load(mp_reader_t *reader, mp_module_context_t *
     if (header[0] != 'M'
         || header[1] != MPY_VERSION
         || MPY_FEATURE_DECODE_FLAGS(header[2]) != MPY_FEATURE_FLAGS
-        || header[3] > mp_small_int_bits()) {
+        || header[3] > MP_SMALL_INT_BITS) {
         mp_raise_ValueError(MP_ERROR_TEXT("incompatible .mpy file"));
     }
     if (MPY_FEATURE_DECODE_ARCH(header[2]) != MP_NATIVE_ARCH_NONE) {
@@ -609,7 +594,7 @@ void mp_raw_code_save(mp_compiled_module_t *cm, mp_print_t *print) {
         #if MICROPY_DYNAMIC_COMPILER
         mp_dynamic_compiler.small_int_bits,
         #else
-        mp_small_int_bits(),
+        MP_SMALL_INT_BITS,
         #endif
     };
     if (cm->has_native) {

--- a/py/smallint.h
+++ b/py/smallint.h
@@ -61,6 +61,13 @@
 
 #define MP_SMALL_INT_MAX ((mp_int_t)(~(MP_SMALL_INT_MIN)))
 
+// https://stackoverflow.com/a/4589384/1976323
+/* Number of bits in inttype_MAX, or in any (1<<k)-1 where 0 <= k < 2040 */
+#define MP_IMAX_BITS(m) ((m) / ((m) % 255 + 1) / 255 % 255 * 8 + 7 - 86 / ((m) % 255 + 12))
+
+// The number of bits in a MP_SMALL_INT including the sign bit.
+#define MP_SMALL_INT_BITS (MP_IMAX_BITS(MP_SMALL_INT_MAX) + 1)
+
 bool mp_small_int_mul_overflow(mp_int_t x, mp_int_t y);
 mp_int_t mp_small_int_modulo(mp_int_t dividend, mp_int_t divisor);
 mp_int_t mp_small_int_floor_divide(mp_int_t num, mp_int_t denom);


### PR DESCRIPTION
This adds a new `MP_SMALL_INT_BITS` macro that is a compile-time constant that contains the number of bits available in an
`MP_SMALL_INT`.

We can use this in place of the runtime function `mp_small_int_bits()`.
