### PR TITLE
stm32/machine_i2s: Support I2S peripheral mode

### DIFF
--- a/docs/library/machine.I2S.rst
+++ b/docs/library/machine.I2S.rst
@@ -6,7 +6,7 @@ class I2S -- Inter-IC Sound bus protocol
 
 I2S is a synchronous serial protocol used to connect digital audio devices.
 At the physical level, a bus consists of 3 lines: SCK, WS, SD.
-The I2S class supports controller operation.  Peripheral operation is not supported.
+The I2S class supports controller and peripheral operation.
 
 The I2S class is currently available as a Technical Preview.  During the preview period, feedback from
 users is encouraged.  Based on this feedback, the I2S class API and implementation may be changed.
@@ -30,7 +30,7 @@ I2S objects can be created and initialized using::
 
     audio_out = I2S(2,
                     sck=sck_pin, ws=ws_pin, sd=sd_pin,
-                    mode=I2S.TX,
+                    mode=I2S.CONTROLLER_TX,
                     bits=16,
                     format=I2S.MONO,
                     rate=44100,
@@ -38,7 +38,7 @@ I2S objects can be created and initialized using::
 
     audio_in = I2S(2,
                    sck=sck_pin, ws=ws_pin, sd=sd_pin,
-                   mode=I2S.RX,
+                   mode=I2S.CONTROLLER_RX,
                    bits=32,
                    format=I2S.STEREO,
                    rate=22050,
@@ -72,6 +72,10 @@ uasyncio::
    sreader = uasyncio.StreamReader(audio_in)
    num_read = await sreader.readinto(buf)
 
+Controller and peripheral mode are supported.  When a controller, the SCK and WS pins will
+be outputs and the I2S hardware will generate the required signals on these pins.  When a
+peripheral, the SCK and WS signals are inputs and must be generated externally.
+
 Constructor
 -----------
 
@@ -92,11 +96,11 @@ Constructor
      - ``sck`` is a pin object for the serial clock line
      - ``ws`` is a pin object for the word select line
      - ``sd`` is a pin object for the serial data line
-     - ``mode`` specifies receive or transmit
+     - ``mode`` specifies controller or peripheral, and receive or transmit
      - ``bits`` specifies sample size (bits), 16 or 32
      - ``format`` specifies channel format, STEREO or MONO
      - ``rate`` specifies audio sampling rate (Hz);
-       this is the frequency of the ``ws`` signal
+       this is the frequency of the ``ws`` signal, and isn't needed when in peripheral mode
      - ``ibuf`` specifies internal buffer length (bytes)
 
    For all ports, DMA runs continuously in the background and allows user applications to perform other operations while
@@ -144,13 +148,21 @@ Methods
 Constants
 ---------
 
-.. data:: I2S.RX
+.. data:: I2S.CONTROLLER_RX
 
-   for initialising the I2S bus ``mode`` to receive
+   for initialising the I2S bus ``mode`` to receive as a controller
 
-.. data:: I2S.TX
+.. data:: I2S.CONTROLLER_TX
 
-   for initialising the I2S bus ``mode`` to transmit
+   for initialising the I2S bus ``mode`` to transmit as a controller
+
+.. data:: I2S.PERIPHERAL_RX
+
+   for initialising the I2S bus ``mode`` to receive as a peripheral
+
+.. data:: I2S.PERIPHERAL_TX
+
+   for initialising the I2S bus ``mode`` to transmit as a peripheral
 
 .. data:: I2S.STEREO
 

--- a/ports/stm32/machine_i2s.c
+++ b/ports/stm32/machine_i2s.c
@@ -168,6 +168,18 @@ void machine_i2s_init0() {
     }
 }
 
+static inline bool i2s_mode_is_controller(machine_i2s_obj_t *self) {
+    return self->mode == I2S_MODE_MASTER_TX || self->mode == I2S_MODE_MASTER_RX;
+}
+
+static inline bool i2s_mode_is_rx(machine_i2s_obj_t *self) {
+    return self->mode == I2S_MODE_MASTER_RX || self->mode == I2S_MODE_SLAVE_RX;
+}
+
+static inline bool i2s_mode_is_tx(machine_i2s_obj_t *self) {
+    return self->mode == I2S_MODE_MASTER_TX || self->mode == I2S_MODE_SLAVE_TX;
+}
+
 // Ring Buffer
 // Thread safe when used with these constraints:
 // - Single Producer, Single Consumer
@@ -526,7 +538,7 @@ STATIC bool i2s_init(machine_i2s_obj_t *self) {
         self->hi2s.Instance = I2S1;
         __SPI1_CLK_ENABLE();
         // configure DMA streams
-        if (self->mode == I2S_MODE_MASTER_RX || self->mode == I2S_MODE_SLAVE_RX) {
+        if (i2s_mode_is_rx(self)) {
             self->dma_descr_rx = &dma_I2S_1_RX;
         } else {
             self->dma_descr_tx = &dma_I2S_1_TX;
@@ -535,7 +547,7 @@ STATIC bool i2s_init(machine_i2s_obj_t *self) {
         self->hi2s.Instance = I2S2;
         __SPI2_CLK_ENABLE();
         // configure DMA streams
-        if (self->mode == I2S_MODE_MASTER_RX || self->mode == I2S_MODE_SLAVE_RX) {
+        if (i2s_mode_is_rx(self)) {
             self->dma_descr_rx = &dma_I2S_2_RX;
         } else {
             self->dma_descr_tx = &dma_I2S_2_TX;
@@ -570,11 +582,11 @@ STATIC bool i2s_init(machine_i2s_obj_t *self) {
 
     if (HAL_I2S_Init(&self->hi2s) == HAL_OK) {
         // Reset and initialize Tx and Rx DMA channels
-        if (self->mode == I2S_MODE_MASTER_RX || self->mode == I2S_MODE_SLAVE_RX) {
+        if (i2s_mode_is_rx(self)) {
             dma_invalidate_channel(self->dma_descr_rx);
             dma_init(&self->hdma_rx, self->dma_descr_rx, DMA_PERIPH_TO_MEMORY, &self->hi2s);
             self->hi2s.hdmarx = &self->hdma_rx;
-        } else {  // I2S_MODE_MASTER_TX
+        } else {  // I2S_MODE_MASTER_TX or I2S_MODE_SLAVE_TX
             dma_invalidate_channel(self->dma_descr_tx);
             dma_init(&self->hdma_tx, self->dma_descr_tx, DMA_MEMORY_TO_PERIPH, &self->hi2s);
             self->hi2s.hdmatx = &self->hdma_tx;
@@ -760,8 +772,14 @@ STATIC void machine_i2s_init_helper(machine_i2s_obj_t *self, size_t n_pos_args, 
         mp_raise_ValueError(MP_ERROR_TEXT("invalid format"));
     }
 
-    // is Rate valid?
-    // Not checked
+    // set rate if not in passive mode (rate value itself not checked)
+    uint32_t i2s_rate = I2S_AUDIOFREQ_DEFAULT;
+    if (i2s_mode == I2S_MODE_MASTER_TX || i2s_mode == I2S_MODE_MASTER_RX) {
+        if (args[ARG_rate].u_int < 0) {
+            mp_raise_ValueError(MP_ERROR_TEXT("rate required"));
+        }
+        i2s_rate = args[ARG_rate].u_int;
+    }
 
     // is Ibuf valid?
     int32_t ring_buffer_len = args[ARG_ibuf].u_int;
@@ -779,7 +797,7 @@ STATIC void machine_i2s_init_helper(machine_i2s_obj_t *self, size_t n_pos_args, 
     self->mode = i2s_mode;
     self->bits = i2s_bits;
     self->format = i2s_format;
-    self->rate = -1;
+    self->rate = i2s_rate;
     self->ibuf = ring_buffer_len;
     self->callback_for_non_blocking = MP_OBJ_NULL;
     self->non_blocking_descriptor.copy_in_progress = false;
@@ -790,21 +808,12 @@ STATIC void machine_i2s_init_helper(machine_i2s_obj_t *self, size_t n_pos_args, 
     init->Standard = I2S_STANDARD_PHILIPS;
     init->DataFormat = get_dma_bits(self->mode, self->bits);
     init->MCLKOutput = I2S_MCLKOUTPUT_DISABLE;
-    init->AudioFreq = I2S_AUDIOFREQ_DEFAULT;
+    init->AudioFreq = i2s_rate;
     init->CPOL = I2S_CPOL_LOW;
     init->ClockSource = I2S_CLOCK_PLL;
     #if defined(STM32F4)
     init->FullDuplexMode = I2S_FULLDUPLEXMODE_DISABLE;
     #endif
-
-    // set rate if not in passive mode
-    if (i2s_mode == I2S_MODE_MASTER_TX || i2s_mode == I2S_MODE_MASTER_RX) {
-        self->rate = args[ARG_rate].u_int;
-        if (self->rate < 0) {
-            mp_raise_ValueError(MP_ERROR_TEXT("rate required"));
-        }
-        init->AudioFreq = args[ARG_rate].u_int;
-    }
 
     // init the I2S bus
     if (!i2s_init(self)) {
@@ -820,7 +829,7 @@ STATIC void machine_i2s_init_helper(machine_i2s_obj_t *self, size_t n_pos_args, 
     }
 
     HAL_StatusTypeDef status;
-    if (self->mode == I2S_MODE_MASTER_TX || self->mode == I2S_MODE_SLAVE_TX) {
+    if (i2s_mode_is_tx(self)) {
         status = HAL_I2S_Transmit_DMA(&self->hi2s, (void *)self->dma_buffer_dcache_aligned, number_of_samples);
     } else {  // RX
         status = HAL_I2S_Receive_DMA(&self->hi2s, (void *)self->dma_buffer_dcache_aligned, number_of_samples);
@@ -846,7 +855,7 @@ STATIC void machine_i2s_print(const mp_print_t *print, mp_obj_t self_in, mp_prin
         self->mode,
         self->bits, self->format
         );
-    if (self->rate > 0) {
+    if (i2s_mode_is_controller(self)) {
         mp_printf(print, "rate=%d, ", self->rate);
     }
     mp_printf(print, "ibuf=%d)", self->ibuf);
@@ -1016,10 +1025,10 @@ STATIC const mp_rom_map_elem_t machine_i2s_locals_dict_table[] = {
     { MP_ROM_QSTR(MP_QSTR_shift),           MP_ROM_PTR(&machine_i2s_shift_obj) },
 
     // Constants
-    { MP_ROM_QSTR(MP_QSTR_RX),              MP_ROM_INT(I2S_MODE_MASTER_RX) },
-    { MP_ROM_QSTR(MP_QSTR_TX),              MP_ROM_INT(I2S_MODE_MASTER_TX) },
-    { MP_ROM_QSTR(MP_QSTR_RX_PASSIVE),      MP_ROM_INT(I2S_MODE_SLAVE_RX) },
-    { MP_ROM_QSTR(MP_QSTR_TX_PASSIVE),      MP_ROM_INT(I2S_MODE_SLAVE_TX) },
+    { MP_ROM_QSTR(MP_QSTR_CONTROLLER_RX),   MP_ROM_INT(I2S_MODE_MASTER_RX) },
+    { MP_ROM_QSTR(MP_QSTR_CONTROLLER_TX),   MP_ROM_INT(I2S_MODE_MASTER_TX) },
+    { MP_ROM_QSTR(MP_QSTR_PERIPHERAL_RX),   MP_ROM_INT(I2S_MODE_SLAVE_RX) },
+    { MP_ROM_QSTR(MP_QSTR_PERIPHERAL_TX),   MP_ROM_INT(I2S_MODE_SLAVE_TX) },
     { MP_ROM_QSTR(MP_QSTR_STEREO),          MP_ROM_INT(STEREO) },
     { MP_ROM_QSTR(MP_QSTR_MONO),            MP_ROM_INT(MONO) },
 };
@@ -1028,7 +1037,7 @@ MP_DEFINE_CONST_DICT(machine_i2s_locals_dict, machine_i2s_locals_dict_table);
 STATIC mp_uint_t machine_i2s_stream_read(mp_obj_t self_in, void *buf_in, mp_uint_t size, int *errcode) {
     machine_i2s_obj_t *self = MP_OBJ_TO_PTR(self_in);
 
-    if (self->mode != I2S_MODE_MASTER_RX && self->mode != I2S_MODE_SLAVE_RX) {
+    if (!i2s_mode_is_rx(self)) {
         *errcode = MP_EPERM;
         return MP_STREAM_ERROR;
     }
@@ -1061,7 +1070,7 @@ STATIC mp_uint_t machine_i2s_stream_read(mp_obj_t self_in, void *buf_in, mp_uint
 STATIC mp_uint_t machine_i2s_stream_write(mp_obj_t self_in, const void *buf_in, mp_uint_t size, int *errcode) {
     machine_i2s_obj_t *self = MP_OBJ_TO_PTR(self_in);
 
-    if (self->mode != I2S_MODE_MASTER_TX && self->mode != I2S_MODE_SLAVE_TX) {
+    if (!i2s_mode_is_tx(self)) {
         *errcode = MP_EPERM;
         return MP_STREAM_ERROR;
     }

--- a/ports/stm32/machine_i2s.c
+++ b/ports/stm32/machine_i2s.c
@@ -526,7 +526,7 @@ STATIC bool i2s_init(machine_i2s_obj_t *self) {
         self->hi2s.Instance = I2S1;
         __SPI1_CLK_ENABLE();
         // configure DMA streams
-        if (self->mode == I2S_MODE_MASTER_RX) {
+        if (self->mode == I2S_MODE_MASTER_RX || self->mode == I2S_MODE_SLAVE_RX) {
             self->dma_descr_rx = &dma_I2S_1_RX;
         } else {
             self->dma_descr_tx = &dma_I2S_1_TX;
@@ -535,7 +535,7 @@ STATIC bool i2s_init(machine_i2s_obj_t *self) {
         self->hi2s.Instance = I2S2;
         __SPI2_CLK_ENABLE();
         // configure DMA streams
-        if (self->mode == I2S_MODE_MASTER_RX) {
+        if (self->mode == I2S_MODE_MASTER_RX || self->mode == I2S_MODE_SLAVE_RX) {
             self->dma_descr_rx = &dma_I2S_2_RX;
         } else {
             self->dma_descr_tx = &dma_I2S_2_TX;
@@ -570,7 +570,7 @@ STATIC bool i2s_init(machine_i2s_obj_t *self) {
 
     if (HAL_I2S_Init(&self->hi2s) == HAL_OK) {
         // Reset and initialize Tx and Rx DMA channels
-        if (self->mode == I2S_MODE_MASTER_RX) {
+        if (self->mode == I2S_MODE_MASTER_RX || self->mode == I2S_MODE_SLAVE_RX) {
             dma_invalidate_channel(self->dma_descr_rx);
             dma_init(&self->hdma_rx, self->dma_descr_rx, DMA_PERIPH_TO_MEMORY, &self->hi2s);
             self->hi2s.hdmarx = &self->hdma_rx;
@@ -691,7 +691,7 @@ STATIC void machine_i2s_init_helper(machine_i2s_obj_t *self, size_t n_pos_args, 
         { MP_QSTR_mode,     MP_ARG_KW_ONLY | MP_ARG_REQUIRED | MP_ARG_INT,   {.u_int = -1} },
         { MP_QSTR_bits,     MP_ARG_KW_ONLY | MP_ARG_REQUIRED | MP_ARG_INT,   {.u_int = -1} },
         { MP_QSTR_format,   MP_ARG_KW_ONLY | MP_ARG_REQUIRED | MP_ARG_INT,   {.u_int = -1} },
-        { MP_QSTR_rate,     MP_ARG_KW_ONLY | MP_ARG_REQUIRED | MP_ARG_INT,   {.u_int = -1} },
+        { MP_QSTR_rate,     MP_ARG_KW_ONLY | MP_ARG_INT,                     {.u_int = -1} },
         { MP_QSTR_ibuf,     MP_ARG_KW_ONLY | MP_ARG_REQUIRED | MP_ARG_INT,   {.u_int = -1} },
     };
 
@@ -740,7 +740,9 @@ STATIC void machine_i2s_init_helper(machine_i2s_obj_t *self, size_t n_pos_args, 
     // is Mode valid?
     uint16_t i2s_mode = args[ARG_mode].u_int;
     if ((i2s_mode != (I2S_MODE_MASTER_RX)) &&
-        (i2s_mode != (I2S_MODE_MASTER_TX))) {
+        (i2s_mode != (I2S_MODE_MASTER_TX)) &&
+        (i2s_mode != (I2S_MODE_SLAVE_RX)) &&
+        (i2s_mode != (I2S_MODE_SLAVE_TX))) {
         mp_raise_ValueError(MP_ERROR_TEXT("invalid mode"));
     }
 
@@ -777,7 +779,7 @@ STATIC void machine_i2s_init_helper(machine_i2s_obj_t *self, size_t n_pos_args, 
     self->mode = i2s_mode;
     self->bits = i2s_bits;
     self->format = i2s_format;
-    self->rate = args[ARG_rate].u_int;
+    self->rate = -1;
     self->ibuf = ring_buffer_len;
     self->callback_for_non_blocking = MP_OBJ_NULL;
     self->non_blocking_descriptor.copy_in_progress = false;
@@ -788,12 +790,21 @@ STATIC void machine_i2s_init_helper(machine_i2s_obj_t *self, size_t n_pos_args, 
     init->Standard = I2S_STANDARD_PHILIPS;
     init->DataFormat = get_dma_bits(self->mode, self->bits);
     init->MCLKOutput = I2S_MCLKOUTPUT_DISABLE;
-    init->AudioFreq = args[ARG_rate].u_int;
+    init->AudioFreq = I2S_AUDIOFREQ_DEFAULT;
     init->CPOL = I2S_CPOL_LOW;
     init->ClockSource = I2S_CLOCK_PLL;
     #if defined(STM32F4)
     init->FullDuplexMode = I2S_FULLDUPLEXMODE_DISABLE;
     #endif
+
+    // set rate if not in passive mode
+    if (i2s_mode == I2S_MODE_MASTER_TX || i2s_mode == I2S_MODE_MASTER_RX) {
+        self->rate = args[ARG_rate].u_int;
+        if (self->rate < 0) {
+            mp_raise_ValueError(MP_ERROR_TEXT("rate required"));
+        }
+        init->AudioFreq = args[ARG_rate].u_int;
+    }
 
     // init the I2S bus
     if (!i2s_init(self)) {
@@ -809,7 +820,7 @@ STATIC void machine_i2s_init_helper(machine_i2s_obj_t *self, size_t n_pos_args, 
     }
 
     HAL_StatusTypeDef status;
-    if (self->mode == I2S_MODE_MASTER_TX) {
+    if (self->mode == I2S_MODE_MASTER_TX || self->mode == I2S_MODE_SLAVE_TX) {
         status = HAL_I2S_Transmit_DMA(&self->hi2s, (void *)self->dma_buffer_dcache_aligned, number_of_samples);
     } else {  // RX
         status = HAL_I2S_Receive_DMA(&self->hi2s, (void *)self->dma_buffer_dcache_aligned, number_of_samples);
@@ -827,16 +838,18 @@ STATIC void machine_i2s_print(const mp_print_t *print, mp_obj_t self_in, mp_prin
         "ws="MP_HAL_PIN_FMT ",\n"
         "sd="MP_HAL_PIN_FMT ",\n"
         "mode=%u,\n"
-        "bits=%u, format=%u,\n"
-        "rate=%d, ibuf=%d)",
+        "bits=%u, format=%u,\n",
         self->i2s_id,
         mp_hal_pin_name(self->sck),
         mp_hal_pin_name(self->ws),
         mp_hal_pin_name(self->sd),
         self->mode,
-        self->bits, self->format,
-        self->rate, self->ibuf
+        self->bits, self->format
         );
+    if (self->rate > 0) {
+        mp_printf(print, "rate=%d, ", self->rate);
+    }
+    mp_printf(print, "ibuf=%d)", self->ibuf);
 }
 
 STATIC mp_obj_t machine_i2s_make_new(const mp_obj_type_t *type, size_t n_pos_args, size_t n_kw_args, const mp_obj_t *args) {
@@ -1005,6 +1018,8 @@ STATIC const mp_rom_map_elem_t machine_i2s_locals_dict_table[] = {
     // Constants
     { MP_ROM_QSTR(MP_QSTR_RX),              MP_ROM_INT(I2S_MODE_MASTER_RX) },
     { MP_ROM_QSTR(MP_QSTR_TX),              MP_ROM_INT(I2S_MODE_MASTER_TX) },
+    { MP_ROM_QSTR(MP_QSTR_RX_PASSIVE),      MP_ROM_INT(I2S_MODE_SLAVE_RX) },
+    { MP_ROM_QSTR(MP_QSTR_TX_PASSIVE),      MP_ROM_INT(I2S_MODE_SLAVE_TX) },
     { MP_ROM_QSTR(MP_QSTR_STEREO),          MP_ROM_INT(STEREO) },
     { MP_ROM_QSTR(MP_QSTR_MONO),            MP_ROM_INT(MONO) },
 };
@@ -1013,7 +1028,7 @@ MP_DEFINE_CONST_DICT(machine_i2s_locals_dict, machine_i2s_locals_dict_table);
 STATIC mp_uint_t machine_i2s_stream_read(mp_obj_t self_in, void *buf_in, mp_uint_t size, int *errcode) {
     machine_i2s_obj_t *self = MP_OBJ_TO_PTR(self_in);
 
-    if (self->mode != I2S_MODE_MASTER_RX) {
+    if (self->mode != I2S_MODE_MASTER_RX && self->mode != I2S_MODE_SLAVE_RX) {
         *errcode = MP_EPERM;
         return MP_STREAM_ERROR;
     }
@@ -1046,7 +1061,7 @@ STATIC mp_uint_t machine_i2s_stream_read(mp_obj_t self_in, void *buf_in, mp_uint
 STATIC mp_uint_t machine_i2s_stream_write(mp_obj_t self_in, const void *buf_in, mp_uint_t size, int *errcode) {
     machine_i2s_obj_t *self = MP_OBJ_TO_PTR(self_in);
 
-    if (self->mode != I2S_MODE_MASTER_TX) {
+    if (self->mode != I2S_MODE_MASTER_TX && self->mode != I2S_MODE_SLAVE_TX) {
         *errcode = MP_EPERM;
         return MP_STREAM_ERROR;
     }

--- a/tests/extmod/machine_i2s_rate.py
+++ b/tests/extmod/machine_i2s_rate.py
@@ -45,7 +45,7 @@ def test(mode, bits_per_sample, frame_format):
     buf_len_250ms = bits_per_frame // 8 * RATE // 4
 
     # Create test data and preload I2S buffers.
-    if mode == I2S.TX:
+    if mode == I2S.CONTROLLER_TX:
         mode_str = "TX"
         data = TEST_BYTES * (buf_len_250ms // len(TEST_BYTES))
         i2s.write(data)
@@ -57,7 +57,7 @@ def test(mode, bits_per_sample, frame_format):
     # Time how long it takes to read/write 2 lots of data.
     t0 = time.ticks_ms()
     for i in range(2):
-        if mode == I2S.TX:
+        if mode == I2S.CONTROLLER_TX:
             i2s.write(data)
         else:
             i2s.readinto(data)
@@ -70,11 +70,11 @@ def test(mode, bits_per_sample, frame_format):
     print(mode_str, bits_per_sample, channels, abs(dt - 500) <= 4)
 
 
-test(I2S.TX, 16, I2S.MONO)
-test(I2S.TX, 16, I2S.STEREO)
-test(I2S.TX, 32, I2S.MONO)
-test(I2S.TX, 32, I2S.STEREO)
-test(I2S.RX, 16, I2S.MONO)
-test(I2S.RX, 16, I2S.STEREO)
-test(I2S.RX, 32, I2S.MONO)
-test(I2S.RX, 32, I2S.STEREO)
+test(I2S.CONTROLLER_TX, 16, I2S.MONO)
+test(I2S.CONTROLLER_TX, 16, I2S.STEREO)
+test(I2S.CONTROLLER_TX, 32, I2S.MONO)
+test(I2S.CONTROLLER_TX, 32, I2S.STEREO)
+test(I2S.CONTROLLER_RX, 16, I2S.MONO)
+test(I2S.CONTROLLER_RX, 16, I2S.STEREO)
+test(I2S.CONTROLLER_RX, 32, I2S.MONO)
+test(I2S.CONTROLLER_RX, 32, I2S.STEREO)

--- a/tests/multi_machine/i2s_data_transfer.py
+++ b/tests/multi_machine/i2s_data_transfer.py
@@ -101,9 +101,9 @@ def instance0():
             (16, I2S.STEREO, b"2367ABEF2367ABEF2367ABEF2367ABEF"),  # MSBs of L and R channels
             (16, I2S.MONO, b"23AB23AB23AB23AB23AB23AB23AB23AB"),  # MSBs of L channel only
         ):
-        test_rx(I2S.RX_PASSIVE, bits_per_sample, frame_format, 4, 0, expected)
+        test_rx(I2S.PERIPHERAL_RX, bits_per_sample, frame_format, 4, 0, expected)
         multitest.wait("tx done")
-        test_rx(I2S.RX, bits_per_sample, frame_format, 4, 1, expected)
+        test_rx(I2S.CONTROLLER_RX, bits_per_sample, frame_format, 4, 1, expected)
         multitest.broadcast("rx done")
 
 
@@ -121,7 +121,7 @@ def instance1():
             (32, I2S.STEREO, 4),
             (32, I2S.STEREO, 4),
         ):
-        test_tx(I2S.TX, bits_per_sample, frame_format, num_tx + 1)
+        test_tx(I2S.CONTROLLER_TX, bits_per_sample, frame_format, num_tx + 1)
         multitest.broadcast("tx done")
-        test_tx(I2S.TX_PASSIVE, bits_per_sample, frame_format, num_tx)
+        test_tx(I2S.PERIPHERAL_TX, bits_per_sample, frame_format, num_tx)
         multitest.wait("rx done")

--- a/tests/multi_machine/i2s_data_transfer.py
+++ b/tests/multi_machine/i2s_data_transfer.py
@@ -1,0 +1,127 @@
+# Test machine.I2S on PYB/PYBD
+#
+# Writes some bytes over I2S and checks they are received by the other device.
+# Requires wiring up WS, SCK, SD pins between two devices.
+
+import os
+from machine import Pin, I2S
+
+# Configure pins based on the board.
+if "F405" in os.uname().machine:
+    i2s_id = 2
+    ws_pin = Pin("Y5")
+    sck_pin = Pin("Y6")
+    sd_pin = Pin("Y8")
+else:
+    i2s_id = 1
+    ws_pin = Pin("X5")
+    sck_pin = Pin("X6")
+    sd_pin = Pin("X8")
+
+TEST_BYTES = b"0123456789ABCDEF"
+RATE = 8000  # frames/sec
+
+def buf_len(bits_per_sample, frame_format):
+    if frame_format == I2S.MONO:
+        channels = 1
+    else:
+        channels = 2
+    bits_per_frame = bits_per_sample * channels
+    buf_len_100ms = bits_per_frame // 8 * RATE // 10
+    assert buf_len_100ms % len(TEST_BYTES) == 0
+    return buf_len_100ms
+
+def test_tx(mode, bits_per_sample, frame_format, num_tx):
+    i2s = I2S(
+        i2s_id,
+        sck=sck_pin,
+        ws=ws_pin,
+        sd=sd_pin,
+        mode=mode,
+        bits=bits_per_sample,
+        format=frame_format,
+        rate=RATE,
+        ibuf=200,
+    )
+
+    data = TEST_BYTES * (buf_len(bits_per_sample, frame_format) // len(TEST_BYTES))
+    print("tx start")
+    for i in range(num_tx):
+        n = i2s.write(data)
+        print("write", n)
+    print("tx end")
+    i2s.deinit()
+
+
+def test_rx(mode, bits_per_sample, frame_format, num_rx, num_rx_extra, expected):
+    i2s = I2S(
+        i2s_id,
+        sck=sck_pin,
+        ws=ws_pin,
+        sd=sd_pin,
+        mode=mode,
+        bits=bits_per_sample,
+        format=frame_format,
+        rate=RATE,
+        ibuf=200,
+    )
+
+    buf = bytearray(buf_len(bits_per_sample, frame_format))
+    wanted_bytes = expected * 8
+
+    print("rx start")
+
+    for _ in range(num_rx):
+        n = i2s.readinto(buf)
+        if wanted_bytes in buf:
+            print("read", n, True)
+        else:
+            print("read", n, buf[:16], buf[-16:])
+
+    # Extra reads for the case we are driving the clock, so the passive side finishes.
+    for _ in range(num_rx_extra):
+        i2s.readinto(buf)
+
+    print("rx end")
+
+    i2s.deinit()
+
+
+def instance0():
+    multitest.next()
+    for bits_per_sample, frame_format, expected in (
+            # TX and RX transfer full 32-bit stereo
+            (32, I2S.STEREO, b"0123456789ABCDEF0123456789ABCDEF"),
+            # TX writes different formats, RX receives 32-bit stereo
+            (32, I2S.STEREO, b"012301234567456789AB89ABCDEFCDEF"),
+            (32, I2S.STEREO, b"23016745AB89EFCD23016745AB89EFCD"),
+            (32, I2S.STEREO, b"01012323454567678989ABABCDCDEFEF"),  # 16-bit mono (L=R)
+            # TX writes 32-bit stereo, RX receives different formats
+            (32, I2S.MONO, b"012389AB012389AB012389AB012389AB"),  # L channel only
+            (16, I2S.STEREO, b"2367ABEF2367ABEF2367ABEF2367ABEF"),  # MSBs of L and R channels
+            (16, I2S.MONO, b"23AB23AB23AB23AB23AB23AB23AB23AB"),  # MSBs of L channel only
+        ):
+        test_rx(I2S.RX_PASSIVE, bits_per_sample, frame_format, 4, 0, expected)
+        multitest.wait("tx done")
+        test_rx(I2S.RX, bits_per_sample, frame_format, 4, 1, expected)
+        multitest.broadcast("rx done")
+
+
+def instance1():
+    multitest.next()
+    for bits_per_sample, frame_format, num_tx in (
+            # TX and RX transfer full 32-bit stereo
+            (32, I2S.STEREO, 4),
+            # TX writes different formats, RX receives 32-bit stereo
+            (32, I2S.MONO, 4),
+            (16, I2S.STEREO, 8),
+            (16, I2S.MONO, 8),
+            # TX writes 32-bit stereo, RX receives different formats
+            (32, I2S.STEREO, 4),
+            (32, I2S.STEREO, 4),
+            (32, I2S.STEREO, 4),
+        ):
+        test_tx(I2S.TX, bits_per_sample, frame_format, num_tx + 1)
+        multitest.broadcast("tx done")
+        test_tx(I2S.TX_PASSIVE, bits_per_sample, frame_format, num_tx)
+        multitest.wait("rx done")

--- a/tests/multi_machine/i2s_data_transfer.py.exp
+++ b/tests/multi_machine/i2s_data_transfer.py.exp
@@ -1,0 +1,193 @@
+--- instance0 ---
+rx start
+read 6400 True
+read 6400 True
+read 6400 True
+read 6400 True
+rx end
+rx start
+read 6400 True
+read 6400 True
+read 6400 True
+read 6400 True
+rx end
+rx start
+read 6400 True
+read 6400 True
+read 6400 True
+read 6400 True
+rx end
+rx start
+read 6400 True
+read 6400 True
+read 6400 True
+read 6400 True
+rx end
+rx start
+read 6400 True
+read 6400 True
+read 6400 True
+read 6400 True
+rx end
+rx start
+read 6400 True
+read 6400 True
+read 6400 True
+read 6400 True
+rx end
+rx start
+read 6400 True
+read 6400 True
+read 6400 True
+read 6400 True
+rx end
+rx start
+read 6400 True
+read 6400 True
+read 6400 True
+read 6400 True
+rx end
+rx start
+read 3200 True
+read 3200 True
+read 3200 True
+read 3200 True
+rx end
+rx start
+read 3200 True
+read 3200 True
+read 3200 True
+read 3200 True
+rx end
+rx start
+read 3200 True
+read 3200 True
+read 3200 True
+read 3200 True
+rx end
+rx start
+read 3200 True
+read 3200 True
+read 3200 True
+read 3200 True
+rx end
+rx start
+read 1600 True
+read 1600 True
+read 1600 True
+read 1600 True
+rx end
+rx start
+read 1600 True
+read 1600 True
+read 1600 True
+read 1600 True
+rx end
+--- instance1 ---
+tx start
+write 6400
+write 6400
+write 6400
+write 6400
+write 6400
+tx end
+tx start
+write 6400
+write 6400
+write 6400
+write 6400
+tx end
+tx start
+write 3200
+write 3200
+write 3200
+write 3200
+write 3200
+tx end
+tx start
+write 3200
+write 3200
+write 3200
+write 3200
+tx end
+tx start
+write 3200
+write 3200
+write 3200
+write 3200
+write 3200
+write 3200
+write 3200
+write 3200
+write 3200
+tx end
+tx start
+write 3200
+write 3200
+write 3200
+write 3200
+write 3200
+write 3200
+write 3200
+write 3200
+tx end
+tx start
+write 1600
+write 1600
+write 1600
+write 1600
+write 1600
+write 1600
+write 1600
+write 1600
+write 1600
+tx end
+tx start
+write 1600
+write 1600
+write 1600
+write 1600
+write 1600
+write 1600
+write 1600
+write 1600
+tx end
+tx start
+write 6400
+write 6400
+write 6400
+write 6400
+write 6400
+tx end
+tx start
+write 6400
+write 6400
+write 6400
+write 6400
+tx end
+tx start
+write 6400
+write 6400
+write 6400
+write 6400
+write 6400
+tx end
+tx start
+write 6400
+write 6400
+write 6400
+write 6400
+tx end
+tx start
+write 6400
+write 6400
+write 6400
+write 6400
+write 6400
+tx end
+tx start
+write 6400
+write 6400
+write 6400
+write 6400
+tx end


### PR DESCRIPTION
This adds support for passive (aka "slave") mode on stm32 machine.I2S.

Passive mode is pretty much exactly the same as standard/active/master mode except that the other side drives the WS and SCK pins (hence the name passive, the WS and SCK pins are inputs).  I chose the terminology "passive" instead of "peripheral" because I think "passive" is more descriptive here.

To configure passive mode use:
```python
i2s = I2S(id, mode=I2S.RX_PASSIVE, ...)
i2s = I2S(id, mode=I2S.TX_PASSIVE, ...)
```

An alternative way to select passive mode would be a `passive=True` argument to the constructor.  But I think adding two new modes makes more sense.

The changes in this PR are:
- add `I2S.TX_PASSIVE` and `I2S.RX_PASSIVE` constants, and make them work
- `rate` argument is optional when selecting passive mode
- fix `I2S.deinit()` so it can be called multiple times without crashing (due to freeing ringbuf memory twice)
- add a multitest which tests I2S by transferring data from one board to another (one is in active mode, the other is in passive mode)

It could be an option to rename the `I2S.TX` mode to `I2S.TX_ACTIVE` but that would be a breaking change, so I don't suggest to do that (but conceptually this naming helps to understand how the modes work).

Things not done here:
- no docs update
- other ports don't yet support passive mode, only stm32