### PR TITLE
stm32wb55/flash: Use Sem7 for flash cpu synchronisation.

### DIFF
--- a/ports/stm32/rfcore.c
+++ b/ports/stm32/rfcore.c
@@ -76,6 +76,9 @@
 #define OCF_C2_FLASH_ERASE_ACTIVITY       (0x69)
 #define OCF_C2_SET_FLASH_ACTIVITY_CONTROL (0x73)
 
+#define FLASH_ACTIVITY_CONTROL_PES        (0)
+#define FLASH_ACTIVITY_CONTROL_SEM7       (1)
+
 #define HCI_OPCODE(ogf, ocf) ((ogf) << 10 | (ocf))
 
 #define HCI_KIND_BT_CMD (0x01) // <kind=1>...?
@@ -615,8 +618,8 @@ void rfcore_ble_init(void) {
         rfcore_ble_reset();
     }
 
-    // Enable PES rather than SEM7 to moderate flash access between the cores.
-    uint8_t buf = 0; // FLASH_ACTIVITY_CONTROL_PES
+    // Enable SEM7 rather than PES to moderate flash access between the cores.
+    uint8_t buf = FLASH_ACTIVITY_CONTROL_SEM7;
     tl_sys_hci_cmd_resp(HCI_OPCODE(OGF_VENDOR, OCF_C2_SET_FLASH_ACTIVITY_CONTROL), &buf, 1, 0);
 }
 


### PR DESCRIPTION
We've seen an issue with a WB55 aioble peripheral application where trying to connect to the device with nrf-connect on phone results in a lockup / timeout during the discovery phase.

The device firmware has a logging module that writes directly to flash, which has some output during the connecting phase.

Degugging shows that during this lockup, the wb55 is stuck on:
``` c
        // Wait for PES (if it's enabled, no-op if not).
        while (LL_FLASH_IsActiveFlag_OperationSuspended()) {
        }
```
This is after it's been locked up for over a second; indeed the red led on the WB55 nucleo that's currently linked to flash operation is solid on during this lockup.

Looking at the git history I think the existing sync code was written from AN5289 Rev 3? 
Referring to the current AN5289 Rev 6, Chapter 4.7, I see:
> The drawback is that if the PESD bit is set by CPU2 at the same time when CPU1 starts a
write or erase operation, CPU1 can fetch code but cannot read literals from the memory,
even if the code to be executed requires this action. It is very difficult to control whether
CPU1 will be stalled or not when the PESD mechanism is used. Additionally, there is no
interrupt signal on PESD bit release by CPU2, so asynchronous software flow is not
possible.

I'm not sure if this is definitely the cause of my issue, however the v1.13.0 reference example in https://github.com/STMicroelectronics/STM32CubeWB/blob/master/Projects/P-NUCLEO-WB55.Nucleo/Applications/BLE/BLE_RfWithFlash/Core/Src/flash_driver.c switches to SEM7 sync.

This PR switches from PES to SEM7 for the sync and attempts to more closely match the current Fig 10 from AN5289 Rev 6: 
* checks SEM6 as well, more for future protection as it shouldn't be possible to set elsewhere in current codebase.
* performs erase/flash with interrupts disabled (to guarantee minimum lock time).
* ensures that only one page is erased per sync / lock cycle.

These last two changes to flash and erase are particularly invasive, however AN5289 Rev 12 page 27 states:
> The CPU1 must get Sem7 before writing or erasing. Sem7 must be taken and released for each single write or erase operation, but for not more than 0.5 ms in addition to the write/erase timing. To comply with this requirement the code must be executed in the critical section. 

I really don't love the amount of duplication in erase, perhaps it would be better to keep it all in one "main" erase function but #ifdef in a wrapper loop function for wb55?

@jimmo I think it was you who built the original syncronisation mechanism here? Do you remember if PES was chosen for a particular reason, or just was the default recommendation at the time?
