### PR TITLE
ports/stm32: Allow overriding COPT in Makefile.

### DIFF
--- a/ports/stm32/Makefile
+++ b/ports/stm32/Makefile
@@ -106,11 +106,11 @@ LDFLAGS += --gc-sections
 # Debugging/Optimization
 ifeq ($(DEBUG), 1)
 CFLAGS += -g -DPENDSV_DEBUG
-COPT = -Og
+COPT ?= -Og
 # Disable text compression in debug builds
 MICROPY_ROM_TEXT_COMPRESSION = 0
 else
-COPT += -Os -DNDEBUG
+COPT ?= -Os -DNDEBUG
 endif
 
 # Flags for optional C++ source code


### PR DESCRIPTION
Can now be set in mpconfigboard.mk or on make command line.

When building with DEBUG=1 on some boards -Og is still too big, needing -Os to work. This makes it easier to override on demand.