### PR TITLE
stm32/wb55: Allow 32KB for mboot if MBOOT_ENABLE_PACKING enabled.

### DIFF
--- a/ports/stm32/boards/NUCLEO_WB55/mpconfigboard.mk
+++ b/ports/stm32/boards/NUCLEO_WB55/mpconfigboard.mk
@@ -5,8 +5,13 @@ STARTUP_FILE = $(STM32LIB_CMSIS_BASE)/Source/Templates/gcc/startup_stm32wb55xx_c
 
 ifeq ($(USE_MBOOT),1)
 # When using Mboot all the text goes together after the bootloader
+ifeq ($(MBOOT_ENABLE_PACKING),1)
+LD_FILES = boards/stm32wb55xg_mbp.ld boards/common_bl.ld
+TEXT0_ADDR = 0x08008000
+else
 LD_FILES = boards/stm32wb55xg.ld boards/common_bl.ld
 TEXT0_ADDR = 0x08004000
+endif
 else
 # When not using Mboot the text goes at the start of flash
 LD_FILES = boards/stm32wb55xg.ld boards/common_basic.ld

--- a/ports/stm32/boards/USBDONGLE_WB55/mpconfigboard.mk
+++ b/ports/stm32/boards/USBDONGLE_WB55/mpconfigboard.mk
@@ -5,8 +5,13 @@ STARTUP_FILE = $(STM32LIB_CMSIS_BASE)/Source/Templates/gcc/startup_stm32wb55xx_c
 
 ifeq ($(USE_MBOOT),1)
 # When using Mboot all the text goes together after the bootloader
+ifeq ($(MBOOT_ENABLE_PACKING),1)
+LD_FILES = boards/stm32wb55xg_mbp.ld boards/common_bl.ld
+TEXT0_ADDR = 0x08008000
+else
 LD_FILES = boards/stm32wb55xg.ld boards/common_bl.ld
 TEXT0_ADDR = 0x08004000
+endif
 else
 # When not using Mboot the text goes at the start of flash
 LD_FILES = boards/stm32wb55xg.ld boards/common_basic.ld

--- a/ports/stm32/boards/stm32wb55xg_mbp.ld
+++ b/ports/stm32/boards/stm32wb55xg_mbp.ld
@@ -1,13 +1,13 @@
 /*
-    GNU linker script for STM32WB55xG
+    GNU linker script for STM32WB55xG with larger bootloader section to fit mboot with packing support.
 */
 
 /* Specify the memory areas */
 MEMORY
 {
     FLASH (rx)      : ORIGIN = 0x08000000, LENGTH = 512K /* sectors 0-127 */
-    FLASH_BL (rx)   : ORIGIN = 0x08000000, LENGTH = 16K /* sectors 0-3, used by the bootloader */
-    FLASH_APP (rx)  : ORIGIN = 0x08004000, LENGTH = 496K /* sectors 4-127 */
+    FLASH_BL (rx)   : ORIGIN = 0x08000000, LENGTH = 32K /* sectors 0-7, used by the bootloader */
+    FLASH_APP (rx)  : ORIGIN = 0x08008000, LENGTH = 464K /* sectors 8-127 */
     FLASH_FS (r)    : ORIGIN = 0x08080000, LENGTH = 256K /* sectors 128-191 */
     RAM (xrw)       : ORIGIN = 0x20000000, LENGTH = 192K /* SRAM1 */
     RAM2A (xrw)     : ORIGIN = 0x20030000, LENGTH = 10K  /* SRAM2A */


### PR DESCRIPTION
The linker settings for stm32wb55 currently set aside 16KB of flash for mboot (if enabled).

If mboot is built with support for packing however (signing/encryption) it needs up to 32KB. 

At the moment, the larger mboot gets compiled and can be flashed, but then the application will partially overwrite it from the 16KB mark.

This PR uses a separate linker file with the 32KB set aside if mboot with packing is enabled.