### PR TITLE
py: Fix saving/loading/freezing of .mpy when prelude is bytes object.

### DIFF
--- a/py/bc.h
+++ b/py/bc.h
@@ -28,6 +28,7 @@
 #define MICROPY_INCLUDED_PY_BC_H
 
 #include "py/runtime.h"
+#include "py/objstr.h"
 
 // bytecode layout:
 //
@@ -253,6 +254,21 @@ typedef struct _mp_code_state_t {
     // Variable-length, never accessed by name, only as (void*)(state + n_state)
     // mp_exc_stack_t exc_state[0];
 } mp_code_state_t;
+
+#if MICROPY_EMIT_NATIVE
+static inline const uint8_t *mp_get_prelude(const uint8_t *fun_data, const mp_module_context_t *context, size_t prelude_offset) {
+    #if MICROPY_EMIT_NATIVE_PRELUDE_AS_BYTES_OBJ
+    // Prelude is in bytes object in const_table, at index prelude_offset.
+    (void)fun_data;
+    mp_obj_str_t *prelude_bytes = MP_OBJ_TO_PTR(context->constants.obj_table[prelude_offset]);
+    return prelude_bytes->data;
+    #else
+    // Prelude is in the function data, at offset prelude_offset.
+    (void)context;
+    return fun_data + prelude_offset;
+    #endif
+}
+#endif
 
 // Allocator may return NULL, in which case data is not stored (can be used to compute size).
 typedef uint8_t *(*mp_encode_uint_allocator_t)(void *env, size_t nbytes);

--- a/py/emitnative.c
+++ b/py/emitnative.c
@@ -737,7 +737,11 @@ STATIC bool emit_native_end_pass(emit_t *emit) {
             emit->emit_common->children,
             #if MICROPY_PERSISTENT_CODE_SAVE
             emit->emit_common->ct_cur_child,
+            #if N_PRELUDE_AS_BYTES_OBJ
+            emit->prelude_const_table_offset,
+            #else
             emit->prelude_offset,
+            #endif
             emit->qstr_link_cur, emit->qstr_link,
             #endif
             emit->scope->scope_flags, 0, 0);

--- a/py/objgenerator.c
+++ b/py/objgenerator.c
@@ -93,13 +93,7 @@ STATIC mp_obj_t native_gen_wrap_call(mp_obj_t self_in, size_t n_args, size_t n_k
 
     // Determine start of prelude.
     uintptr_t prelude_offset = ((uintptr_t *)self_fun->bytecode)[0];
-    #if MICROPY_EMIT_NATIVE_PRELUDE_AS_BYTES_OBJ
-    // Prelude is in bytes object in const_table, at index prelude_offset
-    mp_obj_str_t *prelude_bytes = MP_OBJ_TO_PTR(self_fun->context->constants.obj_table[prelude_offset]);
-    const uint8_t *prelude_ptr = prelude_bytes->data;
-    #else
-    const uint8_t *prelude_ptr = self_fun->bytecode + prelude_offset;
-    #endif
+    const uint8_t *prelude_ptr = mp_get_prelude(self_fun->bytecode, self_fun->context, prelude_offset);
 
     // Extract n_state from the prelude.
     const uint8_t *ip = prelude_ptr;


### PR DESCRIPTION
Fixes issue #8474.

I'm not sure I like this fix.  The alternative is to just revert 7e8222ae063d78ae8f901bb0f9fef663edd2edb6