### PR TITLE
docs/manifest: Add link to details about opt levels used in freeze.

### DIFF
--- a/docs/reference/manifest.rst
+++ b/docs/reference/manifest.rst
@@ -57,7 +57,8 @@ Freezing source code
     directory then all files in that directory will be frozen.
 
     *opt* is the optimisation level to pass to mpy-cross when compiling ``.py``
-    to ``.mpy``.
+    to ``.mpy``. These levels are described in 
+    :ref:`micropython.opt_level`
 
 .. function:: freeze_as_str(path)
 


### PR DESCRIPTION
It took me a while to find the description of the different opt levels available, so thought a link would help. 
I hope this link works though, I'm not entirely certain the anchor name is enough for cross page links?