### PR TITLE
esp32: Allow Overriding cmake frozen manifest from the command line.

### DIFF
--- a/ports/esp32/CMakeLists.txt
+++ b/ports/esp32/CMakeLists.txt
@@ -24,8 +24,19 @@ include($ENV{IDF_PATH}/tools/cmake/project.cmake)
 # Define the output sdkconfig so it goes in the build directory.
 set(SDKCONFIG ${CMAKE_BINARY_DIR}/sdkconfig)
 
+# Save the manifest file set from the cmake command line.
+set(MICROPY_USER_FROZEN_MANIFEST ${MICROPY_FROZEN_MANIFEST})
+
 # Include board config; this is expected to set SDKCONFIG_DEFAULTS (among other options).
 include(${MICROPY_BOARD_DIR}/mpconfigboard.cmake)
+
+# Set the frozen manifest file. Note if MICROPY_FROZEN_MANIFEST is set from the cmake
+# command line, then it will override the default and any manifest set by the board.
+if (MICROPY_USER_FROZEN_MANIFEST)
+    set(MICROPY_FROZEN_MANIFEST ${MICROPY_USER_FROZEN_MANIFEST})
+elseif (NOT MICROPY_FROZEN_MANIFEST)
+    set(MICROPY_FROZEN_MANIFEST ${MICROPY_PORT_DIR}/boards/manifest.py)
+endif()
 
 # Add sdkconfig fragments that depend on the IDF version.
 if(IDF_VERSION_MAJOR EQUAL 4 AND IDF_VERSION_MINOR LESS 2)

--- a/ports/esp32/boards/ESP32_S2_WROVER/mpconfigboard.cmake
+++ b/ports/esp32/boards/ESP32_S2_WROVER/mpconfigboard.cmake
@@ -6,7 +6,3 @@ set(SDKCONFIG_DEFAULTS
     boards/sdkconfig.usb
     boards/ESP32_S2_WROVER/sdkconfig.board
 )
-
-if(NOT MICROPY_FROZEN_MANIFEST)
-    set(MICROPY_FROZEN_MANIFEST ${MICROPY_PORT_DIR}/boards/manifest.py)
-endif()

--- a/ports/esp32/boards/GENERIC/mpconfigboard.cmake
+++ b/ports/esp32/boards/GENERIC/mpconfigboard.cmake
@@ -2,6 +2,3 @@ set(SDKCONFIG_DEFAULTS
     boards/sdkconfig.base
     boards/sdkconfig.ble
 )
-if(NOT MICROPY_FROZEN_MANIFEST)
-    set(MICROPY_FROZEN_MANIFEST ${MICROPY_PORT_DIR}/boards/manifest.py)
-endif()

--- a/ports/esp32/boards/GENERIC_C3/mpconfigboard.cmake
+++ b/ports/esp32/boards/GENERIC_C3/mpconfigboard.cmake
@@ -4,7 +4,3 @@ set(SDKCONFIG_DEFAULTS
     boards/sdkconfig.base
     boards/sdkconfig.ble
 )
-
-if(NOT MICROPY_FROZEN_MANIFEST)
-    set(MICROPY_FROZEN_MANIFEST ${MICROPY_PORT_DIR}/boards/manifest.py)
-endif()

--- a/ports/esp32/boards/GENERIC_C3_USB/mpconfigboard.cmake
+++ b/ports/esp32/boards/GENERIC_C3_USB/mpconfigboard.cmake
@@ -5,7 +5,3 @@ set(SDKCONFIG_DEFAULTS
     boards/sdkconfig.ble
     boards/GENERIC_C3_USB/sdkconfig.board
 )
-
-if(NOT MICROPY_FROZEN_MANIFEST)
-    set(MICROPY_FROZEN_MANIFEST ${MICROPY_PORT_DIR}/boards/manifest.py)
-endif()

--- a/ports/esp32/boards/GENERIC_D2WD/mpconfigboard.cmake
+++ b/ports/esp32/boards/GENERIC_D2WD/mpconfigboard.cmake
@@ -3,7 +3,3 @@ set(SDKCONFIG_DEFAULTS
     boards/sdkconfig.ble
     boards/GENERIC_D2WD/sdkconfig.board
 )
-
-if(NOT MICROPY_FROZEN_MANIFEST)
-    set(MICROPY_FROZEN_MANIFEST ${MICROPY_PORT_DIR}/boards/manifest.py)
-endif()

--- a/ports/esp32/boards/GENERIC_OTA/mpconfigboard.cmake
+++ b/ports/esp32/boards/GENERIC_OTA/mpconfigboard.cmake
@@ -3,7 +3,3 @@ set(SDKCONFIG_DEFAULTS
     boards/sdkconfig.ble
     boards/GENERIC_OTA/sdkconfig.board
 )
-
-if(NOT MICROPY_FROZEN_MANIFEST)
-    set(MICROPY_FROZEN_MANIFEST ${MICROPY_PORT_DIR}/boards/manifest.py)
-endif()

--- a/ports/esp32/boards/GENERIC_S2/mpconfigboard.cmake
+++ b/ports/esp32/boards/GENERIC_S2/mpconfigboard.cmake
@@ -4,7 +4,3 @@ set(SDKCONFIG_DEFAULTS
     boards/sdkconfig.base
     boards/sdkconfig.usb
 )
-
-if(NOT MICROPY_FROZEN_MANIFEST)
-    set(MICROPY_FROZEN_MANIFEST ${MICROPY_PORT_DIR}/boards/manifest.py)
-endif()

--- a/ports/esp32/boards/GENERIC_S3/mpconfigboard.cmake
+++ b/ports/esp32/boards/GENERIC_S3/mpconfigboard.cmake
@@ -6,7 +6,3 @@ set(SDKCONFIG_DEFAULTS
     boards/sdkconfig.ble
     boards/GENERIC_S3/sdkconfig.board
 )
-
-if(NOT MICROPY_FROZEN_MANIFEST)
-    set(MICROPY_FROZEN_MANIFEST ${MICROPY_PORT_DIR}/boards/manifest.py)
-endif()

--- a/ports/esp32/boards/GENERIC_S3_SPIRAM/mpconfigboard.cmake
+++ b/ports/esp32/boards/GENERIC_S3_SPIRAM/mpconfigboard.cmake
@@ -6,7 +6,3 @@ set(SDKCONFIG_DEFAULTS
     boards/sdkconfig.spiram_sx
     boards/GENERIC_S3_SPIRAM/sdkconfig.board
 )
-
-if(NOT MICROPY_FROZEN_MANIFEST)
-    set(MICROPY_FROZEN_MANIFEST ${MICROPY_PORT_DIR}/boards/manifest.py)
-endif()

--- a/ports/esp32/boards/GENERIC_SPIRAM/mpconfigboard.cmake
+++ b/ports/esp32/boards/GENERIC_SPIRAM/mpconfigboard.cmake
@@ -3,7 +3,3 @@ set(SDKCONFIG_DEFAULTS
     boards/sdkconfig.ble
     boards/sdkconfig.spiram
 )
-
-if(NOT MICROPY_FROZEN_MANIFEST)
-    set(MICROPY_FROZEN_MANIFEST ${MICROPY_PORT_DIR}/boards/manifest.py)
-endif()

--- a/ports/esp32/boards/LILYGO_TTGO_LORA32/mpconfigboard.cmake
+++ b/ports/esp32/boards/LILYGO_TTGO_LORA32/mpconfigboard.cmake
@@ -2,6 +2,5 @@ set(SDKCONFIG_DEFAULTS
     boards/sdkconfig.base
     boards/sdkconfig.ble
 )
-if(NOT MICROPY_FROZEN_MANIFEST)
-    set(MICROPY_FROZEN_MANIFEST ${MICROPY_BOARD_DIR}/manifest.py)
-endif()
+
+set(MICROPY_FROZEN_MANIFEST ${MICROPY_BOARD_DIR}/manifest.py)

--- a/ports/esp32/boards/LOLIN_C3_MINI/mpconfigboard.cmake
+++ b/ports/esp32/boards/LOLIN_C3_MINI/mpconfigboard.cmake
@@ -6,6 +6,4 @@ set(SDKCONFIG_DEFAULTS
     boards/LOLIN_C3_MINI/sdkconfig.board
 )
 
-if(NOT MICROPY_FROZEN_MANIFEST)
-    set(MICROPY_FROZEN_MANIFEST ${MICROPY_BOARD_DIR}/manifest.py)
-endif()
+set(MICROPY_FROZEN_MANIFEST ${MICROPY_BOARD_DIR}/manifest.py)

--- a/ports/esp32/boards/LOLIN_S2_MINI/mpconfigboard.cmake
+++ b/ports/esp32/boards/LOLIN_S2_MINI/mpconfigboard.cmake
@@ -6,6 +6,4 @@ set(SDKCONFIG_DEFAULTS
     boards/sdkconfig.usb
 )
 
-if(NOT MICROPY_FROZEN_MANIFEST)
-    set(MICROPY_FROZEN_MANIFEST ${MICROPY_BOARD_DIR}/manifest.py)
-endif()
+set(MICROPY_FROZEN_MANIFEST ${MICROPY_BOARD_DIR}/manifest.py)

--- a/ports/esp32/boards/LOLIN_S2_PICO/mpconfigboard.cmake
+++ b/ports/esp32/boards/LOLIN_S2_PICO/mpconfigboard.cmake
@@ -6,6 +6,4 @@ set(SDKCONFIG_DEFAULTS
     boards/sdkconfig.usb
 )
 
-if(NOT MICROPY_FROZEN_MANIFEST)
-    set(MICROPY_FROZEN_MANIFEST ${MICROPY_BOARD_DIR}/manifest.py)
-endif()
+set(MICROPY_FROZEN_MANIFEST ${MICROPY_BOARD_DIR}/manifest.py)

--- a/ports/esp32/boards/M5STACK_ATOM/mpconfigboard.cmake
+++ b/ports/esp32/boards/M5STACK_ATOM/mpconfigboard.cmake
@@ -5,6 +5,4 @@ set(SDKCONFIG_DEFAULTS
     boards/M5STACK_ATOM/sdkconfig.board
 )
 
-if(NOT MICROPY_FROZEN_MANIFEST)
-    set(MICROPY_FROZEN_MANIFEST ${MICROPY_BOARD_DIR}/manifest.py)
-endif()
+set(MICROPY_FROZEN_MANIFEST ${MICROPY_BOARD_DIR}/manifest.py)

--- a/ports/esp32/boards/SIL_WESP32/mpconfigboard.cmake
+++ b/ports/esp32/boards/SIL_WESP32/mpconfigboard.cmake
@@ -4,7 +4,3 @@ set(SDKCONFIG_DEFAULTS
     boards/sdkconfig.240mhz
     boards/SIL_WESP32/sdkconfig.board
 )
-
-if(NOT MICROPY_FROZEN_MANIFEST)
-    set(MICROPY_FROZEN_MANIFEST ${MICROPY_PORT_DIR}/boards/manifest.py)
-endif()

--- a/ports/esp32/boards/UM_TINYPICO/mpconfigboard.cmake
+++ b/ports/esp32/boards/UM_TINYPICO/mpconfigboard.cmake
@@ -6,6 +6,4 @@ set(SDKCONFIG_DEFAULTS
     boards/UM_TINYPICO/sdkconfig.board
 )
 
-if(NOT MICROPY_FROZEN_MANIFEST)
-    set(MICROPY_FROZEN_MANIFEST ${MICROPY_BOARD_DIR}/manifest.py)
-endif()
+set(MICROPY_FROZEN_MANIFEST ${MICROPY_BOARD_DIR}/manifest.py)

--- a/ports/esp32/boards/UM_TINYS2/mpconfigboard.cmake
+++ b/ports/esp32/boards/UM_TINYS2/mpconfigboard.cmake
@@ -4,5 +4,3 @@ set(SDKCONFIG_DEFAULTS
     boards/sdkconfig.spiram_sx
     boards/sdkconfig.usb
 )
-
-set(MICROPY_FROZEN_MANIFEST ${MICROPY_PORT_DIR}/boards/manifest.py)


### PR DESCRIPTION
* If MICROPY_FROZEN_MANIFEST is set from the cmake command line, then it will override the default and any manifest set by the board.
* Following #8399