### PR TITLE
mimxrt: Three bug fixes and some improvements.

### DIFF
--- a/ports/mimxrt/Makefile
+++ b/ports/mimxrt/Makefile
@@ -256,6 +256,7 @@ SRC_C += \
 	shared/netutils/dhcpserver.c \
 	shared/readline/readline.c \
 	shared/runtime/gchelper_native.c \
+	shared/runtime/interrupt_char.c \
 	shared/runtime/mpirq.c \
 	shared/runtime/pyexec.c \
 	shared/runtime/stdout_helpers.c \

--- a/ports/mimxrt/board_init.c
+++ b/ports/mimxrt/board_init.c
@@ -100,6 +100,8 @@ void board_init(void) {
     #if MICROPY_PY_MACHINE_I2S
     machine_i2s_init0();
     #endif
+    // RTC
+    machine_rtc_start();
 }
 
 void USB_OTG1_IRQHandler(void) {

--- a/ports/mimxrt/boards/OLIMEX_RT1010/board.json
+++ b/ports/mimxrt/boards/OLIMEX_RT1010/board.json
@@ -1,0 +1,21 @@
+{
+    "deploy": [
+        "../deploy_mimxrt.md"
+    ],
+    "docs": "",
+    "features": [
+        "MicroUSB",
+        "MicroSD",
+        "AudioCodec",
+        "SPDIF",
+        "JLink"
+    ],
+    "images": [
+        "OLIMEX_RT1010Py.jpg"
+    ],
+    "mcu": "mimxrt",
+    "product": "Olimex_RT1010Py",
+    "thumbnail": "",
+    "url": "https://www.olimex.com/Products/ARM/NXP",
+    "vendor": "OLIMEX"
+}

--- a/ports/mimxrt/machine_rtc.c
+++ b/ports/mimxrt/machine_rtc.c
@@ -40,12 +40,30 @@ typedef struct _machine_rtc_obj_t {
 STATIC const machine_rtc_obj_t machine_rtc_obj = {{&machine_rtc_type}};
 uint32_t us_offset = 0;
 
+// Start the RTC Timer.
+void machine_rtc_start(void) {
+
+    SNVS_LP_SRTC_StartTimer(SNVS);
+    // If the date is not set, set it to a more recent start date,
+    // MicroPython's first commit.
+    snvs_lp_srtc_datetime_t srtc_date;
+    SNVS_LP_SRTC_GetDatetime(SNVS, &srtc_date);
+    if (srtc_date.year <= 1970) {
+        srtc_date = (snvs_lp_srtc_datetime_t) {
+            .year = 2013,
+            .month = 10,
+            .day = 14,
+            .hour = 19,
+            .minute = 53,
+            .second = 11,
+        };
+        SNVS_LP_SRTC_SetDatetime(SNVS, &srtc_date);
+    }
+}
+
 STATIC mp_obj_t machine_rtc_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *args) {
     // Check arguments.
     mp_arg_check_num(n_args, n_kw, 0, 0, false);
-
-    // Start up the RTC if needed.
-    SNVS_LP_SRTC_StartTimer(SNVS);
 
     // Return constant object.
     return (mp_obj_t)&machine_rtc_obj;

--- a/ports/mimxrt/machine_spi.c
+++ b/ports/mimxrt/machine_spi.c
@@ -277,6 +277,10 @@ STATIC void machine_spi_transfer(mp_obj_base_t *self_in, size_t len, const uint8
         LPSPI_MasterTransferCreateHandleEDMA(self->spi_inst, &g_master_edma_handle, LPSPI_EDMAMasterCallback, self,
             &lpspiEdmaMasterRxRegToRxDataHandle,
             &lpspiEdmaMasterTxDataToTxRegHandle);
+
+        // Wait a short while for a previous transfer to finish, but not forever
+        for (volatile int j = 0; (j < 5000) && ((LPSPI_GetStatusFlags(self->spi_inst) & kLPSPI_ModuleBusyFlag) != 0); j++) {}
+
         // Start master transfer
         lpspi_transfer_t masterXfer;
         masterXfer.txData = (uint8_t *)src;
@@ -297,12 +301,15 @@ STATIC void machine_spi_transfer(mp_obj_base_t *self_in, size_t len, const uint8
         } else if (src) {
             DCACHE_CleanByRange((uint32_t)src, len);
         }
-        LPSPI_MasterTransferEDMA(self->spi_inst, &g_master_edma_handle, &masterXfer);
-
-        while (self->transfer_busy) {
-            MICROPY_EVENT_POLL_HOOK
+        if (LPSPI_MasterTransferEDMA(self->spi_inst, &g_master_edma_handle, &masterXfer) != kStatus_Success) {
+            L1CACHE_EnableDCache();
+            mp_raise_OSError(EIO);
+        } else {
+            while (self->transfer_busy) {
+                MICROPY_EVENT_POLL_HOOK
+            }
+            L1CACHE_EnableDCache();
         }
-        L1CACHE_EnableDCache();
     }
     // Release DMA channels, even if never allocated.
     if (chan_rx >= 0) {
@@ -313,10 +320,9 @@ STATIC void machine_spi_transfer(mp_obj_base_t *self_in, size_t len, const uint8
     }
 
     if (!use_dma) {
-        // Wait until a previous Transfer is finished
-        while (LPSPI_GetTxFifoCount(self->spi_inst) > 0) {
-            MICROPY_EVENT_POLL_HOOK
-        }
+        // Wait a short while for a previous transfer to finish, but not forever
+        for (volatile int j = 0; (j < 5000) && ((LPSPI_GetStatusFlags(self->spi_inst) & kLPSPI_ModuleBusyFlag) != 0); j++) {}
+
         // Reconfigure the TCR, required after switch between DMA vs. non-DMA
         LPSPI_Enable(self->spi_inst, false);  // Disable first before new settings are applied
         self->spi_inst->TCR = LPSPI_TCR_CPOL(self->master_config->cpol) | LPSPI_TCR_CPHA(self->master_config->cpha) |
@@ -330,7 +336,9 @@ STATIC void machine_spi_transfer(mp_obj_base_t *self_in, size_t len, const uint8
         masterXfer.dataSize = len;
         masterXfer.configFlags = (self->master_config->whichPcs << LPSPI_MASTER_PCS_SHIFT) | kLPSPI_MasterPcsContinuous | kLPSPI_MasterByteSwap;
 
-        LPSPI_MasterTransferBlocking(self->spi_inst, &masterXfer);
+        if (LPSPI_MasterTransferBlocking(self->spi_inst, &masterXfer) != kStatus_Success) {
+            mp_raise_OSError(EIO);
+        }
     }
 }
 

--- a/ports/mimxrt/modmachine.h
+++ b/ports/mimxrt/modmachine.h
@@ -48,5 +48,6 @@ void machine_sdcard_init0(void);
 void mimxrt_sdram_init(void);
 void machine_i2s_init0();
 void machine_i2s_deinit_all(void);
+void machine_rtc_start(void);
 
 #endif // MICROPY_INCLUDED_MIMXRT_MODMACHINE_H

--- a/ports/mimxrt/modules/_boot.py
+++ b/ports/mimxrt/modules/_boot.py
@@ -16,6 +16,7 @@ except:
 os.mount(vfs, "/flash")
 os.chdir("/flash")
 sys.path.append("/flash")
+sys.path.append("/flash/lib")
 
 # do not mount the SD card if SKIPSD exists.
 try:

--- a/ports/mimxrt/mphalport.c
+++ b/ports/mimxrt/mphalport.c
@@ -29,68 +29,82 @@
 #include "py/stream.h"
 #include "py/mphal.h"
 #include "shared/timeutils/timeutils.h"
+#include "shared/runtime/interrupt_char.h"
 #include "extmod/misc.h"
 #include "ticks.h"
 #include "tusb.h"
 #include "fsl_snvs_lp.h"
 
-#if FSL_COMMON_DRIVER_VERSION != 0x020001
-#include "fsl_ocotp.h"
-#else
-void OCOTP_Init(OCOTP_Type *base, uint32_t srcClock_Hz);
+#ifndef MICROPY_HW_STDIN_BUFFER_LEN
+#define MICROPY_HW_STDIN_BUFFER_LEN 512
 #endif
 
 #include CPU_HEADER_H
 
-STATIC uint8_t stdin_ringbuf_array[260];
+STATIC uint8_t stdin_ringbuf_array[MICROPY_HW_STDIN_BUFFER_LEN];
 ringbuf_t stdin_ringbuf = {stdin_ringbuf_array, sizeof(stdin_ringbuf_array), 0, 0};
 
-#if MICROPY_KBD_EXCEPTION
+uint8_t cdc_itf_pending; // keep track of cdc interfaces which need attention to poll
 
-int mp_interrupt_char = -1;
-
-void tud_cdc_rx_wanted_cb(uint8_t itf, char wanted_char) {
-    (void)itf;
-    (void)wanted_char;
-    tud_cdc_read_char(); // discard interrupt char
-    mp_sched_keyboard_interrupt();
+void poll_cdc_interfaces(void) {
+    // any CDC interfaces left to poll?
+    if (cdc_itf_pending && ringbuf_free(&stdin_ringbuf)) {
+        for (uint8_t itf = 0; itf < 8; ++itf) {
+            if (cdc_itf_pending & (1 << itf)) {
+                tud_cdc_rx_cb(itf);
+                if (!cdc_itf_pending) {
+                    break;
+                }
+            }
+        }
+    }
 }
 
-void mp_hal_set_interrupt_char(int c) {
-    mp_interrupt_char = c;
-    tud_cdc_set_wanted_char(c);
-}
 
-#endif
+void tud_cdc_rx_cb(uint8_t itf) {
+    // consume pending USB data immediately to free usb buffer and keep the endpoint from stalling.
+    // in case the ringbuffer is full, mark the CDC interface that need attention later on for polling
+    cdc_itf_pending &= ~(1 << itf);
+    for (uint32_t bytes_avail = tud_cdc_n_available(itf); bytes_avail > 0; --bytes_avail) {
+        if (ringbuf_free(&stdin_ringbuf)) {
+            int data_char = tud_cdc_read_char();
+            if (data_char == mp_interrupt_char) {
+                mp_sched_keyboard_interrupt();
+            } else {
+                ringbuf_put(&stdin_ringbuf, data_char);
+            }
+        } else {
+            cdc_itf_pending |= (1 << itf);
+            return;
+        }
+    }
+}
 
 uintptr_t mp_hal_stdio_poll(uintptr_t poll_flags) {
     uintptr_t ret = 0;
+    poll_cdc_interfaces();
     if ((poll_flags & MP_STREAM_POLL_RD) && ringbuf_peek(&stdin_ringbuf) != -1) {
         ret |= MP_STREAM_POLL_RD;
     }
-    if (tud_cdc_connected() && tud_cdc_available()) {
-        ret |= MP_STREAM_POLL_RD;
-    }
+    #if MICROPY_PY_OS_DUPTERM
+    ret |= mp_uos_dupterm_poll(poll_flags);
+    #endif
     return ret;
 }
 
 int mp_hal_stdin_rx_chr(void) {
     for (;;) {
-        // TODO
-        // if (USARTx->USART.INTFLAG.bit.RXC) {
-        //     return USARTx->USART.DATA.bit.DATA;
-        // }
+        poll_cdc_interfaces();
         int c = ringbuf_get(&stdin_ringbuf);
         if (c != -1) {
             return c;
         }
-        if (tud_cdc_connected() && tud_cdc_available()) {
-            uint8_t buf[1];
-            uint32_t count = tud_cdc_read(buf, sizeof(buf));
-            if (count) {
-                return buf[0];
-            }
+        #if MICROPY_PY_OS_DUPTERM
+        int dupterm_c = mp_uos_dupterm_rx_chr();
+        if (dupterm_c >= 0) {
+            return dupterm_c;
         }
+        #endif
         MICROPY_EVENT_POLL_HOOK
     }
 }
@@ -110,12 +124,9 @@ void mp_hal_stdout_tx_strn(const char *str, mp_uint_t len) {
             i += n2;
         }
     }
+    #if MICROPY_PY_OS_DUPTERM
     mp_uos_dupterm_tx_strn(str, len);
-    // TODO
-    // while (len--) {
-    //     while (!(USARTx->USART.INTFLAG.bit.DRE)) { }
-    //     USARTx->USART.DATA.bit.DATA = *str++;
-    // }
+    #endif
 }
 
 uint64_t mp_hal_time_ns(void) {

--- a/shared/timeutils/timeutils.h
+++ b/shared/timeutils/timeutils.h
@@ -69,6 +69,7 @@ static inline uint64_t timeutils_mktime(mp_uint_t year, mp_int_t month, mp_int_t
 
 static inline uint64_t timeutils_seconds_since_epoch(mp_uint_t year, mp_uint_t month,
     mp_uint_t date, mp_uint_t hour, mp_uint_t minute, mp_uint_t second) {
+    // TODO this will give incorrect results for dates before 2000/1/1
     return timeutils_seconds_since_2000(year, month, date, hour, minute, second) + TIMEUTILS_SECONDS_1970_TO_2000;
 }
 


### PR DESCRIPTION
+ Refactoring of mphalport.c.
   - Fix USB CDC RX handling to not block when unprocessed. The fix
     uses the code implemented by @hoihu for PR #8040.
   - Fix dupterm rx.
   - Remove some obsolete lines in mphalport.c.

+ Some refactoring of machine_spi.c.
   - Change the method of waiting for SPI being not busy.
     Instead of the FIFO size, the TransferBusyFlag is probed.
   - Raise an error if the transfer failed. Even if the SPI transfer should not fail, the NXP library function
     may return an error.

+ Some small changes to the time module.
   - Start the RTC Timer at system boot.
     Otherwise time.time() will advance only, if a RTC() object
     was created.
   - Set the time to a more recent date than Jan 1, 1970, if not already set.
     The time chosen is 2013/10/14, 19:53:11, MicroPython's first commit.
   - Compensate an underflow in timeutils_seconds_since_2000(), called
     by time.time(), if the time is set to a pre-2000 date.

+ Append /flash/lib to the default sys.path.
+ Add the OLIMEX RT1010Py board.json file, such that binaries are built.
