### PR TITLE
disable repl for esp32

### DIFF
--- a/extmod/moduos.c
+++ b/extmod/moduos.c
@@ -147,6 +147,9 @@ STATIC const mp_rom_map_elem_t os_module_globals_table[] = {
     #if MICROPY_PY_UOS_DUPTERM_NOTIFY
     { MP_ROM_QSTR(MP_QSTR_dupterm_notify), MP_ROM_PTR(&mp_uos_dupterm_notify_obj) },
     #endif
+    #if MICROPY_PY_UOS_DISABLE_REPL
+    { MP_ROM_QSTR(MP_QSTR_disable_repl), MP_ROM_PTR(&os_disable_repl_obj) },
+    #endif
     #if MICROPY_PY_UOS_ERRNO
     { MP_ROM_QSTR(MP_QSTR_errno), MP_ROM_PTR(&mp_uos_errno_obj) },
     #endif

--- a/ports/esp32/moduos.c
+++ b/ports/esp32/moduos.c
@@ -32,6 +32,7 @@
 #include "py/runtime.h"
 #include "py/mphal.h"
 #include "extmod/misc.h"
+#include "uart.h"
 
 STATIC mp_obj_t mp_uos_urandom(mp_obj_t num) {
     mp_int_t n = mp_obj_get_int(num);
@@ -62,4 +63,11 @@ STATIC mp_obj_t mp_uos_dupterm_notify(mp_obj_t obj_in) {
     return mp_const_none;
 }
 STATIC MP_DEFINE_CONST_FUN_OBJ_1(mp_uos_dupterm_notify_obj, mp_uos_dupterm_notify);
+#endif
+
+#if MICROPY_PY_UOS_DISABLE_REPL
+STATIC void os_disable_repl(void) {
+    uart_disable_repl();
+}
+STATIC MP_DEFINE_CONST_FUN_OBJ_0(os_disable_repl_obj, os_disable_repl);
 #endif

--- a/ports/esp32/mpconfigport.h
+++ b/ports/esp32/mpconfigport.h
@@ -75,6 +75,7 @@
 #define MICROPY_PY_UOS_INCLUDEFILE          "ports/esp32/moduos.c"
 #define MICROPY_PY_OS_DUPTERM               (1)
 #define MICROPY_PY_UOS_DUPTERM_NOTIFY       (1)
+#define MICROPY_PY_UOS_DISABLE_REPL       (1)
 #define MICROPY_PY_UOS_UNAME                (1)
 #define MICROPY_PY_UOS_URANDOM              (1)
 #define MICROPY_PY_MACHINE                  (1)

--- a/ports/esp32/uart.c
+++ b/ports/esp32/uart.c
@@ -77,6 +77,10 @@ int uart_stdout_tx_strn(const char *str, size_t len) {
     return len - remaining;
 }
 
+void uart_disable_repl(void) {
+    uart_disable_rx_intr(MICROPY_HW_UART_REPL);
+}
+
 // all code executed in ISR must be in IRAM, and any const data must be in DRAM
 STATIC void IRAM_ATTR uart_irq_handler(void *arg) {
     volatile uart_dev_t *uart = &UART0;

--- a/ports/esp32/uart.h
+++ b/ports/esp32/uart.h
@@ -38,5 +38,5 @@
 
 void uart_stdout_init(void);
 int uart_stdout_tx_strn(const char *str, size_t len);
-
+void uart_disable_repl(void);
 #endif // MICROPY_INCLUDED_ESP32_UART_H


### PR DESCRIPTION
Here's how I do to disable REPL on ESP32 for security purposes，I don't want the main.py to be accessed through REPL。Please check if it'ok to do it this way!