### PR TITLE
py: Implement decorator syntax relaxation from CPython 3.9.

### DIFF
--- a/py/grammar.h
+++ b/py/grammar.h
@@ -51,7 +51,9 @@ DEF_RULE_NC(file_input_3, or(2), tok(NEWLINE), rule(stmt))
 DEF_RULE_NC(eval_input, and_ident(2), rule(testlist), opt_rule(eval_input_2))
 DEF_RULE_NC(eval_input_2, and(1), tok(NEWLINE))
 
-// decorator: '@' dotted_name [ '(' [arglist] ')' ] NEWLINE
+// decorator: '@' decorator_arg NEWLINE
+// decorator_arg: built_in_decorator | namedexpr_test
+// built_in_decorator: 'micropython' '.' NAME
 // decorators: decorator+
 // decorated: decorators (classdef | funcdef | async_funcdef)
 // funcdef: 'def' NAME parameters ['->' test] ':' suite
@@ -62,7 +64,9 @@ DEF_RULE_NC(eval_input_2, and(1), tok(NEWLINE))
 // varargslist: vfpdef ['=' test] (',' vfpdef ['=' test])* [',' ['*' [vfpdef] (',' vfpdef ['=' test])* [',' '**' vfpdef] | '**' vfpdef]] |  '*' [vfpdef] (',' vfpdef ['=' test])* [',' '**' vfpdef] | '**' vfpdef
 // vfpdef: NAME
 
-DEF_RULE_NC(decorator, and(4), tok(OP_AT), rule(dotted_name), opt_rule(trailer_paren), tok(NEWLINE))
+DEF_RULE_NC(decorator, and(3), tok(OP_AT), rule(decorator_arg), tok(NEWLINE))
+DEF_RULE_NC(decorator_arg, or(2), rule(built_in_decorator), rule(namedexpr_test))
+DEF_RULE_NC(built_in_decorator, and(3), tok(NAME), tok(DEL_PERIOD), tok(NAME))
 DEF_RULE_NC(decorators, one_or_more, rule(decorator))
 DEF_RULE(decorated, c(decorated), and_ident(2), rule(decorators), rule(decorated_body))
 #if MICROPY_PY_ASYNC_AWAIT

--- a/py/parse.c
+++ b/py/parse.c
@@ -980,6 +980,11 @@ mp_parse_tree_t mp_parse(mp_lexer_t *lex, mp_parse_input_kind_t input_kind) {
                         mp_token_kind_t tok_kind = rule_arg[i] & RULE_ARG_ARG_MASK;
                         if (lex->tok_kind == tok_kind) {
                             // matched token
+                            if (rule_id == RULE_built_in_decorator && i == 0 && qstr_from_strn(lex->vstr.buf, lex->vstr.len) != MP_QSTR_micropython) {
+                                // The first NAME of a built-in decorator must be "micropython"
+                                backtrack = true;
+                                goto next_rule;
+                            }
                             if (tok_kind == MP_TOKEN_NAME) {
                                 push_result_token(&parser, rule_id);
                             }

--- a/tests/basics/decorator.py
+++ b/tests/basics/decorator.py
@@ -1,5 +1,71 @@
-# test decorators
+### Test decorator syntax.
 
+###############################################################################
+### Test for syntax errors.
+###############################################################################
+def test_for_syntax_error(code):
+    try:
+        exec(code)
+    except SyntaxError:
+        print("SyntaxError")
+
+decs = [
+    "x,",
+    "x, y",
+    "x = y",
+    "pass",
+    "import sys",
+    "@dec"
+]
+
+for dec in decs:
+    code = "@{}\ndef foo(): pass".format(dec)
+    test_for_syntax_error(code)
+
+###############################################################################
+### Test for type errors (previously syntax errors before Python 3.9).
+###############################################################################
+def test_for_type_error(code):
+    try:
+        exec(code)
+    except TypeError:
+        print("TypeError")
+
+decs = [
+    "[1, 2][-1]",
+    "(1, 2)",
+    "True",
+    "...",
+    "None"
+]
+
+for dec in decs:
+    code = "@{}\ndef foo(): pass".format(dec)
+    test_for_type_error(code)
+
+###############################################################################
+### Test for name errors. Tests added to make sure the compiler does not
+### confuse anything as a built-in decorator.
+###############################################################################
+def test_for_name_error(code):
+    try:
+        exec(code)
+    except NameError:
+        print("NameError")
+
+decs = [
+    "some",
+    "some.dotted",
+    "some.dotted.name"
+]
+
+for dec in decs:
+    code = "@{}\ndef foo(): pass".format(dec)
+    test_for_name_error(code)
+
+###############################################################################
+### Test valid decorators.
+###############################################################################
 def dec(f):
     print('dec')
     return f

--- a/tests/basics/decorator.py.exp
+++ b/tests/basics/decorator.py.exp
@@ -1,0 +1,17 @@
+SyntaxError
+SyntaxError
+SyntaxError
+SyntaxError
+SyntaxError
+SyntaxError
+TypeError
+TypeError
+TypeError
+TypeError
+TypeError
+NameError
+NameError
+NameError
+dec
+dec_arg
+dec

--- a/tests/cmdline/cmd_parsetree.py.exp
+++ b/tests/cmdline/cmd_parsetree.py.exp
@@ -32,11 +32,11 @@
            id(h)
 [  13]     \(rule\|atom_expr_normal\)(44) (n=2)
 [  13]       literal const(\.\+)
-[  13]       \(rule\|atom_expr_trailers\)(142) (n=2)
+[  13]       \(rule\|atom_expr_trailers\)(144) (n=2)
 [  13]         \(rule\|trailer_period\)(50) (n=1)
                  id(format)
 [  13]         \(rule\|trailer_paren\)(48) (n=1)
-[  13]           \(rule\|arglist\)(164) (n=1)
+[  13]           \(rule\|arglist\)(166) (n=1)
                    id(b)
 ----------------
 File cmdline/cmd_parsetree.py, code block '<module>' (descriptor: \.\+, bytecode @\.\+ 62 bytes)


### PR DESCRIPTION
**Synopsis:** Implements the decorator syntax relaxation added to CPython 3.9 (any expression can be a decorator argument, syntactically).

**Details:** Details and rationale are provided below, on a per file change basis.

py/grammar.h: The grammar file hosts the core change associated with this pull request. The decorator rule is changed to match a `namedexpr_test` rule rather than a `dotted_name` rule. However, since the compiler currently relies on the `dotted_name` rule to easily detect built-in decorators (e.g. `@micropython.bytecode`), a new way of detecting these built-ins needed to be found:

1. [DISCARDED] One possibility is to have the parser try to match a `dotted_name` (or proxy thereof) first and a `namedexpr_test` second, but since the parser does not backtrack through lexical tokens, it is not obvious to me how to accomplish this.
2. [DISCARDED] Another possibility is to write code in the compiler to visit the AST rooted at the `namedexpr_test` rule of a given decorator and determine whether said decorator is a built-in that way. This could potentially be an expensive operation and/or lead to a significant increase in code size.
3. [SELECTED] A third option is to introduce a grammar rule `built_in_decorator` that tries to match a `"micropython"` string, and backtracks into a `namedexpr_test` rule if there is no match. This relies on the fact that all built-in decorators start with `"micropython"`. One possible concern is that any decorator starting with the `"micropython"` NAME token must match with a built-in decorator, otherwise a syntax error is issued. This is, however, congruent with current behavior: this is exactly what the `compile_built_in_decorator` function would do (before this commit).

py/parse.c: A check is added to attempt to match the `"micropython"` string to a NAME token when parsing a `built_in_decrator` rule.

py/compile.c: Since the `compile_built_in_decorator` function is not used anywhere else, this function can be simplified to match the new grammar.

tests/basics: ~~The old decorator.py test is renamed to decorator_minimal.py. A new set of tests are added in decorator_full.py.~~ The decorator.py test is amended with additional tests for syntax, type and name errors. A ~~decorator_full.py.exp~~ decorator.py.exp file is added to work out of the box with CPython versions older than 3.9.

tests/cmdline/cmd_parsetree.py.exp: Updated the expected rule IDs since the grammar is changed.

~~tools/ci.sh: Excludes the decorator_full.py test from the minimal build since it uses several unsupported features (e.g. decimal/complex numbers).~~

~~ports/qemu_arm/Makefile.test: Excludes the decorator_full.py test here as well.~~

Signed-off-by: Rayane Chatrieux <rayane.chatrieux@gmail.com>