### PR TITLE
rp2/boards: Add WEACTSTUDIO boards with BOARD_VARIANT to select the flash size

### DIFF
--- a/ports/rp2/Makefile
+++ b/ports/rp2/Makefile
@@ -22,6 +22,10 @@ ifeq ($(DEBUG),1)
 CMAKE_ARGS += -DCMAKE_BUILD_TYPE=Debug
 endif
 
+ifdef BOARD_VARIANT
+CMAKE_ARGS += -DBOARD_VARIANT=${BOARD_VARIANT}
+endif
+
 HELP_BUILD_ERROR ?= "See \033[1;31mhttps://github.com/micropython/micropython/wiki/Build-Troubleshooting\033[0m"
 
 all:
@@ -38,3 +42,8 @@ submodules:
 	GIT_SUBMODULES=$$(cmake -B $(BUILD)/submodules -DECHO_SUBMODULES=1 ${CMAKE_ARGS} -S . 2>&1 | \
 	                  grep '^GIT_SUBMODULES=' | cut -d= -f2); \
 	$(MAKE) -f ../../py/mkrules.mk GIT_SUBMODULES="$${GIT_SUBMODULES}" submodules
+
+query-variants:
+	@BOARD_VARIANTS=$$(cmake -B $(BUILD)/variants -DECHO_BOARD_VARIANTS=1 ${CMAKE_ARGS} -S . 2>&1 | \
+	                  grep '^BOARD_VARIANTS=' | cut -d= -f2); \
+	echo "VARIANTS: $${BOARD_VARIANTS}"

--- a/ports/rp2/boards/WEACTSTUDIO/README.md
+++ b/ports/rp2/boards/WEACTSTUDIO/README.md
@@ -1,0 +1,34 @@
+# WeAct Studio RP2040
+
+The WeAct Studio RP2040 Board is based on the Raspberry Pi RP2040 and can be
+purchased with 2/4/8/16 MiB of flash.
+
+These boards are available from a number of resellers and often have the name
+"Pico Board RP2040". WeAct maintain the [WeActStudio.RP2040CoreBoard](https://github.com/WeActTC/WeActStudio.RP2040CoreBoard/tree/master)
+repository containing information on the board.
+
+## Build notes
+
+Builds can be configured with the `BOARD_VARIANT` parameter. Valid variants
+can be displayed with the `query-variant` target. An example:
+
+```bash
+> cd ports/rp2
+> make BOARD=WEACTSTUDIO query-variants
+VARIANTS: flash_2mb flash_4mb flash_8mb flash_16mb
+> make BOARD=WEACTSTUDIO BOARD_VARIANT=flash_8mb submodules all  # Build the 8 MiB variant
+```
+
+`flash_16mb` is the default if `BOARD_VARIANT` is not supplied.
+
+## Board-specific modules
+
+The `board` module contains definitions for the onboard LED and user button.
+
+Example:
+
+```python
+> import board
+> board.led.toggle()  # Toggles the state of the on-board LED
+> board.key.value()  # Returns 0 or 1 corresponding to the state of the user key
+```

--- a/ports/rp2/boards/WEACTSTUDIO/board.json
+++ b/ports/rp2/boards/WEACTSTUDIO/board.json
@@ -1,0 +1,23 @@
+{
+    "deploy": [
+        "deploy.md"
+    ],
+    "docs": "",
+    "features": [
+        "Breadboard Friendly",
+        "SPI Flash",
+        "USB-C"
+    ],
+    "images": [
+        "weact_rp2040.jpg"
+    ],
+    "mcu": "rp2040",
+    "product": "WeAct Studio RP2040",
+    "url": "https://github.com/WeActTC/WeActStudio.RP2040CoreBoard",
+    "variants": {
+        "flash_2mb": "2 MiB Flash",
+        "flash_4mb": "4 MiB Flash",
+        "flash_8mb": "8 MiB Flash"
+    },
+    "vendor": "WeAct"
+}

--- a/ports/rp2/boards/WEACTSTUDIO/deploy.md
+++ b/ports/rp2/boards/WEACTSTUDIO/deploy.md
@@ -1,0 +1,8 @@
+### Flashing via UF2 bootloader
+
+To get the board in bootloader mode ready for the firmware update, execute
+`machine.bootloader()` at the MicroPython REPL.  Alternatively, hold
+down the BOOTSEL button while pressing reset (NRST).  The uf2 file below
+should then be copied to the USB mass storage device that appears.  Once
+programming of the new firmware is complete the device will automatically reset
+and be ready for use.

--- a/ports/rp2/boards/WEACTSTUDIO/manifest.py
+++ b/ports/rp2/boards/WEACTSTUDIO/manifest.py
@@ -1,0 +1,2 @@
+include("$(PORT_DIR)/boards/manifest.py")
+freeze("./modules")

--- a/ports/rp2/boards/WEACTSTUDIO/modules/board.py
+++ b/ports/rp2/boards/WEACTSTUDIO/modules/board.py
@@ -1,0 +1,4 @@
+from machine import Pin
+
+led = Pin(25, Pin.OUT, value=0)
+key = Pin(23, Pin.IN, Pin.PULL_UP)

--- a/ports/rp2/boards/WEACTSTUDIO/mpconfigboard.cmake
+++ b/ports/rp2/boards/WEACTSTUDIO/mpconfigboard.cmake
@@ -1,0 +1,26 @@
+# CMake file for WeAct Studio RP2040 boards
+
+# The WeAct Studio boards don't have official pico-sdk support so we define it
+# See also: https://github.com/raspberrypi/pico-sdk/tree/master/src/boards/include/boards
+list(APPEND PICO_BOARD_HEADER_DIRS ${MICROPY_BOARD_DIR})
+
+# Freeze board.py
+set(MICROPY_FROZEN_MANIFEST ${MICROPY_BOARD_DIR}/manifest.py)
+
+# Provide different variants for the downloads page
+set(BOARD_VARIANTS "flash_2mb flash_4mb flash_8mb flash_16mb")
+
+# Select the 16MB variant as the default
+set(PICO_BOARD "weactstudio_16mb")
+
+if("${BOARD_VARIANT}" STREQUAL "flash_2mb")
+    set(PICO_BOARD "weactstudio_2mb")
+endif()
+
+if("${BOARD_VARIANT}" STREQUAL "flash_4mb")
+set(PICO_BOARD "weactstudio_4mb")
+endif()
+
+if("${BOARD_VARIANT}" STREQUAL "flash_8mb")
+set(PICO_BOARD "weactstudio_8mb")
+endif()

--- a/ports/rp2/boards/WEACTSTUDIO/mpconfigboard.h
+++ b/ports/rp2/boards/WEACTSTUDIO/mpconfigboard.h
@@ -1,0 +1,4 @@
+#define MICROPY_HW_BOARD_NAME "WeAct Studio RP2040"
+
+// Allow 1MB for the firmware image itself, allocate the remainder to the filesystem
+#define MICROPY_HW_FLASH_STORAGE_BYTES (PICO_FLASH_SIZE_BYTES - (1 * 1024 * 1024))

--- a/ports/rp2/boards/WEACTSTUDIO/weactstudio_16mb.h
+++ b/ports/rp2/boards/WEACTSTUDIO/weactstudio_16mb.h
@@ -1,0 +1,18 @@
+// A pico-sdk board definition is required since the WeAct Studio boards are
+// not officially supported.
+//
+// Officially supported boards:
+//     https://github.com/raspberrypi/pico-sdk/tree/master/src/boards/include/boards
+
+#ifndef _BOARDS_WEACTSTUDIO_16MB_H
+#define _BOARDS_WEACTSTUDIO_16MB_H
+
+#include "weactstudio_common.h"
+
+#define WEACTSTUDIO_16MB
+
+#ifndef PICO_FLASH_SIZE_BYTES
+#define PICO_FLASH_SIZE_BYTES (16 * 1024 * 1024)
+#endif
+
+#endif

--- a/ports/rp2/boards/WEACTSTUDIO/weactstudio_2mb.h
+++ b/ports/rp2/boards/WEACTSTUDIO/weactstudio_2mb.h
@@ -1,0 +1,18 @@
+// A pico-sdk board definition is required since the WeAct Studio boards are
+// not officially supported.
+//
+// Officially supported boards:
+//     https://github.com/raspberrypi/pico-sdk/tree/master/src/boards/include/boards
+
+#ifndef _BOARDS_WEACTSTUDIO_2MB_H
+#define _BOARDS_WEACTSTUDIO_2MB_H
+
+#include "weactstudio_common.h"
+
+#define WEACTSTUDIO_2MB
+
+#ifndef PICO_FLASH_SIZE_BYTES
+#define PICO_FLASH_SIZE_BYTES (2 * 1024 * 1024)
+#endif
+
+#endif

--- a/ports/rp2/boards/WEACTSTUDIO/weactstudio_4mb.h
+++ b/ports/rp2/boards/WEACTSTUDIO/weactstudio_4mb.h
@@ -1,0 +1,18 @@
+// A pico-sdk board definition is required since the WeAct Studio boards are
+// not officially supported.
+//
+// Officially supported boards:
+//     https://github.com/raspberrypi/pico-sdk/tree/master/src/boards/include/boards
+
+#ifndef _BOARDS_WEACTSTUDIO_4MB_H
+#define _BOARDS_WEACTSTUDIO_4MB_H
+
+#include "weactstudio_common.h"
+
+#define WEACTSTUDIO_4MB
+
+#ifndef PICO_FLASH_SIZE_BYTES
+#define PICO_FLASH_SIZE_BYTES (4 * 1024 * 1024)
+#endif
+
+#endif

--- a/ports/rp2/boards/WEACTSTUDIO/weactstudio_8mb.h
+++ b/ports/rp2/boards/WEACTSTUDIO/weactstudio_8mb.h
@@ -1,0 +1,18 @@
+// A pico-sdk board definition is required since the WeAct Studio boards are
+// not officially supported.
+//
+// Officially supported boards:
+//     https://github.com/raspberrypi/pico-sdk/tree/master/src/boards/include/boards
+
+#ifndef _BOARDS_WEACTSTUDIO_8MB_H
+#define _BOARDS_WEACTSTUDIO_8MB_H
+
+#include "weactstudio_common.h"
+
+#define WEACTSTUDIO_8MB
+
+#ifndef PICO_FLASH_SIZE_BYTES
+#define PICO_FLASH_SIZE_BYTES (8 * 1024 * 1024)
+#endif
+
+#endif

--- a/ports/rp2/boards/WEACTSTUDIO/weactstudio_common.h
+++ b/ports/rp2/boards/WEACTSTUDIO/weactstudio_common.h
@@ -1,0 +1,62 @@
+// Common configuration to all WeAct Studio boards (only flash size differs)
+
+#ifndef _BOARDS_WEACTSTUDIO_COMMON_H
+#define _BOARDS_WEACTSTUDIO_COMMON_H
+
+// --- UART ---
+#ifndef PICO_DEFAULT_UART
+#define PICO_DEFAULT_UART 0
+#endif
+#ifndef PICO_DEFAULT_UART_TX_PIN
+#define PICO_DEFAULT_UART_TX_PIN 0
+#endif
+#ifndef PICO_DEFAULT_UART_RX_PIN
+#define PICO_DEFAULT_UART_RX_PIN 1
+#endif
+
+// --- LED ---
+#ifndef PICO_DEFAULT_LED_PIN
+#define PICO_DEFAULT_LED_PIN 25
+#endif
+
+// --- I2C ---
+#ifndef PICO_DEFAULT_I2C
+#define PICO_DEFAULT_I2C 0
+#endif
+#ifndef PICO_DEFAULT_I2C_SDA_PIN
+#define PICO_DEFAULT_I2C_SDA_PIN 4
+#endif
+#ifndef PICO_DEFAULT_I2C_SCL_PIN
+#define PICO_DEFAULT_I2C_SCL_PIN 5
+#endif
+
+// --- SPI ---
+#ifndef PICO_DEFAULT_SPI
+#define PICO_DEFAULT_SPI 0
+#endif
+#ifndef PICO_DEFAULT_SPI_SCK_PIN
+#define PICO_DEFAULT_SPI_SCK_PIN 18
+#endif
+#ifndef PICO_DEFAULT_SPI_TX_PIN
+#define PICO_DEFAULT_SPI_TX_PIN 19
+#endif
+#ifndef PICO_DEFAULT_SPI_RX_PIN
+#define PICO_DEFAULT_SPI_RX_PIN 16
+#endif
+#ifndef PICO_DEFAULT_SPI_CSN_PIN
+#define PICO_DEFAULT_SPI_CSN_PIN 17
+#endif
+
+// --- FLASH ---
+#define PICO_BOOT_STAGE2_CHOOSE_W25Q080 1
+
+#ifndef PICO_FLASH_SPI_CLKDIV
+#define PICO_FLASH_SPI_CLKDIV 2
+#endif
+
+// All boards have B1 RP2040
+#ifndef PICO_RP2040_B0_SUPPORTED
+#define PICO_RP2040_B0_SUPPORTED 0
+#endif
+
+#endif

--- a/py/mkrules.cmake
+++ b/py/mkrules.cmake
@@ -223,3 +223,9 @@ if(ECHO_SUBMODULES)
     execute_process(COMMAND ${CMAKE_COMMAND} -E echo "GIT_SUBMODULES=${GIT_SUBMODULES}")
     message(FATAL_ERROR "Done")
 endif()
+
+# Display BOARD_VARIANTS
+if(ECHO_BOARD_VARIANTS)
+    execute_process(COMMAND ${CMAKE_COMMAND} -E echo "BOARD_VARIANTS=${BOARD_VARIANTS}")
+    message(FATAL_ERROR "Done")
+endif()


### PR DESCRIPTION
This is adding a board definition for the [Wavgat Pico Board RP2040](https://www.aliexpress.com/item/1005003843712530.html). This is for the 16MB version; once this PR is in good shape I'll create the 2/4/8 MB versions too.

Note that `lib/mbedtls` has been added as a submodule; this has _nothing to do with this board_ - it appears to be necessary for the rp2 port?

Also of note: I'm not aware of any VID/PID for the Wavgat boards so I left these defines out. It seems to work but I'm not sure that's the right thing to do...?

Finally, it was somewhat unexpected that pico-sdk typically has [definitions for each supported board](https://github.com/raspberrypi/pico-sdk/tree/master/src/boards/include/boards). This is the first MicroPython example of a board that is defined _outside_ of the pico-sdk repository (by specifying `PICO_BOARD_HEADER_DIRS` and creating `wavgat_16mb.h` locally).