### PR TITLE
Disable SD-Card detection in OLIMEX_E407 board

### DIFF
--- a/ports/stm32/boards/OLIMEX_E407/mpconfigboard.h
+++ b/ports/stm32/boards/OLIMEX_E407/mpconfigboard.h
@@ -69,10 +69,10 @@
 #define MICROPY_HW_LED_ON(pin)      (mp_hal_pin_low(pin))
 #define MICROPY_HW_LED_OFF(pin)     (mp_hal_pin_high(pin))
 
-// SD card detect switch
-#define MICROPY_HW_SDCARD_DETECT_PIN        (pin_C11)
-#define MICROPY_HW_SDCARD_DETECT_PULL       (GPIO_PULLUP)
-#define MICROPY_HW_SDCARD_DETECT_PRESENT    (GPIO_PIN_RESET)
+// SD card detect switch (Disabled, as some cards are not correctly detected, with it enabled)
+// #define MICROPY_HW_SDCARD_DETECT_PIN        (pin_C11)
+// #define MICROPY_HW_SDCARD_DETECT_PULL       (GPIO_PULLUP)
+// #define MICROPY_HW_SDCARD_DETECT_PRESENT    (GPIO_PIN_RESET)
 
 // USB config
 #define MICROPY_HW_USB_FS              (1)


### PR DESCRIPTION
Disable SD-Card detection in OLIMEX_E407 board, as some SD-Cards are not detected with it enabled.