### PR TITLE
samd/mphalport: Fix USB CDC RX handling to not block when unprocessed.

### DIFF
--- a/ports/samd/Makefile
+++ b/ports/samd/Makefile
@@ -103,6 +103,7 @@ SRC_C = \
 	shared/libc/string0.c \
 	shared/readline/readline.c \
 	shared/runtime/gchelper_native.c \
+	shared/runtime/interrupt_char.c \
 	shared/runtime/pyexec.c \
 	shared/runtime/stdout_helpers.c \
 	shared/runtime/sys_stdio_mphal.c \

--- a/ports/samd/Makefile
+++ b/ports/samd/Makefile
@@ -57,7 +57,7 @@ LIBS = $(shell $(CC) $(CFLAGS) -print-libgcc-file-name)
 
 # Tune for Debugging or Optimization
 ifeq ($(DEBUG),1)
-CFLAGS += -O0 -ggdb
+CFLAGS += -Og -ggdb
 else
 CFLAGS += -Os -DNDEBUG
 LDFLAGS += --gc-sections

--- a/ports/samd/boards/ADAFRUIT_ITSYBITSY_M4_EXPRESS/mpconfigboard.h
+++ b/ports/samd/boards/ADAFRUIT_ITSYBITSY_M4_EXPRESS/mpconfigboard.h
@@ -19,8 +19,8 @@
 
 // Please consult the SAM_D51 Datasheet, I/O Multiplexing and Considerations.
 // USART pin assignments: Tx=TX_D1=PA17=SERCOM3/PAD[0], Rx=RX_D0=PA16=SERCOM3/PAD[1]
-#define CPU_FREQ (48000000) // For selecting Baud from clock.
-#define MP_PIN_GRP 1 // A-D=0-3
+#define CPU_FREQ (120000000) // For selecting Baud from clock.
+#define MP_PIN_GRP 0 // A-D=0-3
 #define MP_TX_PIN 17
 #define MP_RX_PIN 16 // 'n'
 #define MP_PERIPHERAL_MUX 8 // 'n'th group of 2 pins

--- a/ports/samd/boards/MINISAM_M4/mpconfigboard.h
+++ b/ports/samd/boards/MINISAM_M4/mpconfigboard.h
@@ -19,7 +19,7 @@
 
 // Please consult the SAM_D51 Datasheet, I/O Multiplexing and Considerations.
 // USART pin assignments: Tx=TX_D1=PA17=SERCOM3/PAD[0], Rx=RX_D0=PA16=SERCOM3/PAD[1]
-#define CPU_FREQ (48000000) // For selecting Baud from clock.
+#define CPU_FREQ (120000000) // For selecting Baud from clock.
 #define MP_PIN_GRP 0 // A-D=0-3
 #define MP_TX_PIN 17
 #define MP_RX_PIN 16 // 'n'

--- a/ports/samd/boards/SEEED_WIO_TERMINAL/mpconfigboard.h
+++ b/ports/samd/boards/SEEED_WIO_TERMINAL/mpconfigboard.h
@@ -19,7 +19,7 @@
 
 // Please consult the SAM_D51 Datasheet, I/O Multiplexing and Considerations.
 // WIO_Terminal USART pin assignments: Tx=BCM14=PB27=SERCOM2/PAD[0], Rx=BCM15=PB26=SERCOM2/PAD[1]
-#define CPU_FREQ (48000000) // For selecting Baud from clock.
+#define CPU_FREQ (120000000) // For selecting Baud from clock.
 #define MP_PIN_GRP 1 // A-D=0-3
 #define MP_TX_PIN 27
 #define MP_RX_PIN 26 // 'n'

--- a/ports/samd/mpconfigport.h
+++ b/ports/samd/mpconfigport.h
@@ -29,6 +29,12 @@
 // Board specific definitions
 #include "mpconfigboard.h"
 
+#ifndef MICROPY_CONFIG_ROM_LEVEL
+#define MICROPY_CONFIG_ROM_LEVEL            (MICROPY_CONFIG_ROM_LEVEL_BASIC_FEATURES)
+#endif
+
+#define MICROPY_HW_ENABLE_UART_REPL         (1)
+
 // Memory allocation policies
 #define MICROPY_GC_STACK_ENTRY_TYPE         uint16_t
 #define MICROPY_GC_ALLOC_THRESHOLD          (0)
@@ -36,8 +42,11 @@
 #define MICROPY_ALLOC_PATH_MAX              (256)
 #define MICROPY_QSTR_BYTES_IN_HASH          (1)
 
+// MicroPython emitters
+#define MICROPY_PERSISTENT_CODE_LOAD        (1)
+
 // Compiler configuration
-#define MICROPY_COMP_CONST                  (0)
+#define MICROPY_COMP_CONST                  (1)
 
 // Python internal features
 #define MICROPY_ENABLE_GC                   (1)
@@ -55,21 +64,22 @@
 // fixes sys/usys import issue
 #define MICROPY_MODULE_WEAK_LINKS           (1)
 // Control over Python builtins
+#define MICROPY_PY_BUILTINS_STR_UNICODE     (1)
 #define MICROPY_PY_ASYNC_AWAIT              (0)
 #define MICROPY_PY_BUILTINS_STR_COUNT       (0)
 #define MICROPY_PY_BUILTINS_MEMORYVIEW      (1)
 #define MICROPY_PY_BUILTINS_SET             (0)
 #define MICROPY_PY_BUILTINS_FROZENSET       (0)
 #define MICROPY_PY_BUILTINS_PROPERTY        (0)
-#define MICROPY_PY_BUILTINS_ENUMERATE       (0)
+#define MICROPY_PY_BUILTINS_ENUMERATE       (1)
 #define MICROPY_PY_BUILTINS_FILTER          (0)
 #define MICROPY_PY_BUILTINS_REVERSED        (0)
 #define MICROPY_PY_BUILTINS_NOTIMPLEMENTED  (1)
-#define MICROPY_PY_BUILTINS_MIN_MAX         (0)
+#define MICROPY_PY_BUILTINS_MIN_MAX         (1)
 #define MICROPY_PY___FILE__                 (0)
 #define MICROPY_PY_MICROPYTHON_MEM_INFO     (1)
 #define MICROPY_PY_ARRAY_SLICE_ASSIGN       (1)
-#define MICROPY_PY_ATTRTUPLE                (0)
+#define MICROPY_PY_ATTRTUPLE                (1)
 #define MICROPY_PY_COLLECTIONS              (0)
 #define MICROPY_PY_SYS                      (1)
 #define MICROPY_PY_SYS_PLATFORM             "samd"

--- a/ports/samd/mphalport.h
+++ b/ports/samd/mphalport.h
@@ -49,10 +49,11 @@ static inline mp_uint_t mp_hal_ticks_us(void) {
 static inline mp_uint_t mp_hal_ticks_cpu(void) {
     return 0;
 }
-
+#ifndef NDEBUG
 static inline uint64_t mp_hal_time_ns(void) {
     return systick_ms * 1000000;
 }
+#endif
 // C-level pin HAL
 
 #include "py/obj.h"

--- a/ports/samd/mphalport.h
+++ b/ports/samd/mphalport.h
@@ -41,13 +41,18 @@ void mp_hal_set_interrupt_char(int c);
 static inline mp_uint_t mp_hal_ticks_ms(void) {
     return systick_ms;
 }
+
 static inline mp_uint_t mp_hal_ticks_us(void) {
     return systick_ms * 1000;
 }
+
 static inline mp_uint_t mp_hal_ticks_cpu(void) {
     return 0;
 }
 
+static inline uint64_t mp_hal_time_ns(void) {
+    return systick_ms * 1000000;
+}
 // C-level pin HAL
 
 #include "py/obj.h"

--- a/ports/samd/samd_soc.c
+++ b/ports/samd/samd_soc.c
@@ -35,11 +35,14 @@
 #include "samd_soc.h"
 #include "tusb.h"
 
+uint8_t enable_uart_repl = false;
+
 // "MP" macros defined in "boards/$(BOARD)/mpconfigboard.h"
 mp_obj_t machine_uart_init(void) {
     // Firstly, assign alternate function SERCOM PADs to GPIO pins.
     PORT->Group[MP_PIN_GRP].PINCFG[MP_TX_PIN].bit.PMUXEN = 1; // Enable
-    PORT->Group[MP_PIN_GRP].PINCFG[MP_RX_PIN].bit.PMUXEN = 1; // Enable
+    PORT->Group[MP_PIN_GRP].PINCFG[MP_RX_PIN].bit.PULLEN = 1; // Enable Pull avoiding crosstalk
+    PORT->Group[MP_PIN_GRP].PINCFG[MP_RX_PIN].bit.PMUXEN = 1; // Enable MUX
     PORT->Group[MP_PIN_GRP].PMUX[MP_PERIPHERAL_MUX].reg = MP_PORT_FUNC; // Sets PMUXE & PMUXO in 1 hit.
     uint32_t rxpo = MP_RXPO_PAD; // 1=Pad1,3=Pad3 Rx data
     uint32_t txpo = MP_TXPO_PAD; // 0=pad0,1=Pad2 Tx data
@@ -90,15 +93,18 @@ mp_obj_t machine_uart_init(void) {
     while (USARTx->USART.SYNCBUSY.bit.ENABLE) {
     }
 
+    enable_uart_repl = true;
     return mp_const_none;
 }
 
 // Disconnect SERCOM from GPIO pins. (Can't SWRST, as that will totally kill USART).
 mp_obj_t machine_uart_deinit(void) {
     // Reset
+    enable_uart_repl = false;
     printf("Disabling the Alt-Funct, releasing the USART pins for GPIO... \n");
     PORT->Group[MP_PIN_GRP].PINCFG[MP_TX_PIN].bit.PMUXEN = 0; // Disable
     PORT->Group[MP_PIN_GRP].PINCFG[MP_RX_PIN].bit.PMUXEN = 0; // Disable
+    PORT->Group[MP_PIN_GRP].PINCFG[MP_RX_PIN].bit.PULLEN = 0; // Disable Pull
 
     return mp_const_none;
 }
@@ -168,6 +174,8 @@ void samd_init(void) {
     #endif
 
     SysTick_Config(CPU_FREQ / 1000);
+    #if MICROPY_HW_ENABLE_UART_REPL
     machine_uart_init();
+    #endif
     usb_init();
 }

--- a/ports/samd/samd_soc.h
+++ b/ports/samd/samd_soc.h
@@ -38,4 +38,6 @@ void USB_1_Handler_wrapper(void);
 void USB_2_Handler_wrapper(void);
 void USB_3_Handler_wrapper(void);
 
+extern uint8_t enable_uart_repl;
+
 #endif // MICROPY_INCLUDED_SAMD_SAMD_SOC_H

--- a/ports/samd/tusb_config.h
+++ b/ports/samd/tusb_config.h
@@ -41,7 +41,8 @@
 
 #define CFG_TUD_ENDOINT0_SIZE       (64)
 #define CFG_TUD_CDC                 (1)
-#define CFG_TUD_CDC_RX_BUFSIZE      (64)
-#define CFG_TUD_CDC_TX_BUFSIZE      (64)
+#define CFG_TUD_CDC_EP_BUFSIZE      (256)
+#define CFG_TUD_CDC_RX_BUFSIZE      (256)
+#define CFG_TUD_CDC_TX_BUFSIZE      (256)
 
 #endif // MICROPY_INCLUDED_SAMD_TUSB_CONFIG_H


### PR DESCRIPTION
** Draft **

Porting PR #8040 of @hoihu for SAMD, following the commit
587339022689187a1acbccc1d0e2425a67385ff7.

---

Issue:

This PR unveils an issue of the port and is made to have a working
example for easily reproducing the fault.
USB locks up almost immediately if charaters at the input arrive too
fast, when they are echoed. That happens for instance in REPL.
This issue is present in the actual master branch as well, but requires
much higher input symbol frequency and is hard to reproce.

Addition:

Temporary add  a function mp_hal_time_ns() to please the linker when
built with DEBUG=1.