### PR TITLE
ports/stm32: PYBD_SFx Allow FROZEN_MANIFEST to be overridden.

### DIFF
--- a/ports/stm32/boards/PYBD_SF2/mpconfigboard.mk
+++ b/ports/stm32/boards/PYBD_SF2/mpconfigboard.mk
@@ -20,4 +20,4 @@ MICROPY_SSL_MBEDTLS = 1
 MICROPY_VFS_LFS2 = 1
 
 # PYBD-specific frozen modules
-FROZEN_MANIFEST = $(BOARD_DIR)/manifest.py
+FROZEN_MANIFEST ?= $(BOARD_DIR)/manifest.py


### PR DESCRIPTION
Because mpconfigboard.mk used `=` rather than `?=` it doesn't
allow FROZEN_MANIFEST to be overridden using a GNUmakefile
or the environment.