### PR TITLE
drivers/sdcard: Fix CSD version 1.0 device size calculation

### DIFF
--- a/drivers/sdcard/sdcard.py
+++ b/drivers/sdcard/sdcard.py
@@ -100,9 +100,10 @@ class SDCard:
         if csd[0] & 0xC0 == 0x40:  # CSD version 2.0
             self.sectors = ((csd[8] << 8 | csd[9]) + 1) * 1024
         elif csd[0] & 0xC0 == 0x00:  # CSD version 1.0 (old, <=2GB)
-            c_size = csd[6] & 0b11 | csd[7] << 2 | (csd[8] & 0b11000000) << 4
-            c_size_mult = ((csd[9] & 0b11) << 1) | csd[10] >> 7
-            self.sectors = (c_size + 1) * (2 ** (c_size_mult + 2))
+            c_size = (csd[6] & 0b11) << 10 | csd[7] << 2 | csd[8] >> 6
+            c_size_mult = (csd[9] & 0b11) << 1 | csd[10] >> 7
+            read_bl_len = csd[5] & 0b1111
+            self.sectors = (c_size + 1) * (2 ** (c_size_mult + 2)) * (2 ** read_bl_len)
         else:
             raise OSError("SD card CSD format not supported")
         # print('sectors', self.sectors)


### PR DESCRIPTION
Just like the CSDv2 calculation, the CSDv1 calculation has been incorrect since it was first written. This PR fixes putting together the value for `c_size` and corrects the calculation to align with specs. (Note that block size used in this driver is actually 1 byte instead of 512 bytes, so no dividing by 512. It's not documented anywhere, and this will be addressed in a separate PR.)

Specs on it are as follows, section 5.3.2 of SD Simplified Specifications Part 1 version 8.00, page 191:

![image](https://user-images.githubusercontent.com/2154355/163103988-56bcb485-b5b7-408f-8202-591e28506c4f.png)
