### PR TITLE
drivers/sdcard: Add ioctl 5 (block size) handling

### DIFF
--- a/drivers/sdcard/sdcard.py
+++ b/drivers/sdcard/sdcard.py
@@ -281,3 +281,5 @@ class SDCard:
     def ioctl(self, op, arg):
         if op == 4:  # get number of blocks
             return self.sectors
+        elif op == 5:  # get block size
+            return 1


### PR DESCRIPTION
During the course of me trying to use the driver, I got very confused why my rather innocuous block reads keep on failing. Turns out the driver, being non-conformant with the `os.AbstractBlockDev` interface, actually uses 1 byte as the block size instead of 512 bytes without advertising that fact. While it'd be nice to write this into the documentation somewhere, I'm not sure if this is the case for other `SDCard` board-specific implementations, so in the least I added handling for ioctl 5 so code that actually use this ioctl will behave properly.