### PR TITLE
stm32/qspi.c: Updates and fixes.

### DIFF
--- a/ports/stm32/qspi.c
+++ b/ports/stm32/qspi.c
@@ -224,6 +224,10 @@ STATIC void qspi_write_cmd_data(void *self_in, uint8_t cmd, size_t len, uint32_t
                 | cmd << QUADSPI_CCR_INSTRUCTION_Pos // write opcode
         ;
 
+        // Wait for at least 1 free byte location in the FIFO.
+        while (!(QUADSPI->SR & QUADSPI_SR_FTF)) {
+        }
+
         // This assumes len==2
         *(uint16_t *)&QUADSPI->DR = data;
     }


### PR DESCRIPTION
* Add MPU support for common QSPI flash sizes (<1MB up to 256MBs).
* Wait for at least 1 free FIFO location before writing to DR.
* Workaround for issue  #5441 (can be reproduced on the Portenta (H747) board).

Note the SR issue is reproducible on H743, H747 with flash part numbers W25Q256JV and MX25L12833F. I'll send board support for Portenta H7 later, which can be used to reproduce the issue.