### PR TITLE
Operator `in` cast to boolean like CPython

### DIFF
--- a/py/objtype.c
+++ b/py/objtype.c
@@ -549,6 +549,7 @@ retry:;
     } else if (dest[0] != MP_OBJ_NULL) {
         dest[2] = rhs_in;
         res = mp_call_method_n_kw(1, 0, dest);
+        res = op == MP_BINARY_OP_CONTAINS ? mp_obj_new_bool(mp_obj_is_true(res)) : res;
     } else {
         // If this was an inplace method, fallback to normal method
         // https://docs.python.org/3/reference/datamodel.html#object.__iadd__ :

--- a/tests/basics/class_contains.py
+++ b/tests/basics/class_contains.py
@@ -21,3 +21,27 @@ b = B([1, 2])
 print(1 in b)
 print(2 in b)
 print(3 in b)
+
+
+class C:
+    def __contains__(self, arg):
+        return arg
+
+
+print(C().__contains__(0))
+print(C().__contains__(1))
+print(C().__contains__(''))
+print(C().__contains__('foo'))
+print(C().__contains__(None))
+
+print(0 in C())
+print(1 in C())
+print('' in C())
+print('foo' in C())
+print(None in C())
+
+print(0 not in C())
+print(1 not in C())
+print('' not in C())
+print('foo' not in C())
+print(None not in C())


### PR DESCRIPTION
This PR implements two possible fixes for this problem described here: https://github.com/micropython/micropython/issues/7884

One suggestion is a hack during the emit, changing `in` -> `not not in` which forces the result to being a boolean.

The other suggestion of a fix is to do it during runtime, casting the result to boolean there.

Note: this includes two suggestions to fix the same problem so one suggestion will be removed after feedback has been provided.