### PR TITLE
py/parse: Allow all constant objects to be used in "X = const(o)".

### DIFF
--- a/docs/reference/constrained.rst
+++ b/docs/reference/constrained.rst
@@ -112,7 +112,8 @@ with an underscore as in ``_COLS``: this symbol is not visible outside the
 module so will not occupy RAM.
 
 The argument to ``const()`` may be anything which, at compile time, evaluates
-to an integer e.g. ``0x100`` or ``1 << 8``. It can even include other const
+to a constant e.g. ``0x100``, ``1 << 8`` or ``(True, "string", b"bytes")``
+(see section below for details).  It can even include other const
 symbols that have already been defined, e.g. ``1 << BIT``.
 
 **Constant data structures**

--- a/tests/micropython/const_alltypes.py
+++ b/tests/micropython/const_alltypes.py
@@ -1,0 +1,26 @@
+# Test constant optimisation, with full range of const types.
+# This test will only work when MICROPY_COMP_CONST and MICROPY_COMP_CONST_TUPLE are enabled.
+
+from micropython import const
+
+_INT = const(123)
+_STR = const("str")
+_BYTES = const(b"bytes")
+_TUPLE = const((_INT, _STR, _BYTES))
+_TUPLE2 = const((None, False, True, ..., (), _TUPLE))
+
+print(_INT)
+print(_STR)
+print(_BYTES)
+print(_TUPLE)
+print(_TUPLE2)
+
+x = _TUPLE
+print(x is _TUPLE)
+print(x is (_INT, _STR, _BYTES))
+
+print(hasattr(globals(), "_INT"))
+print(hasattr(globals(), "_STR"))
+print(hasattr(globals(), "_BYTES"))
+print(hasattr(globals(), "_TUPLE"))
+print(hasattr(globals(), "_TUPLE2"))

--- a/tests/micropython/const_alltypes.py.exp
+++ b/tests/micropython/const_alltypes.py.exp
@@ -1,0 +1,12 @@
+123
+str
+b'bytes'
+(123, 'str', b'bytes')
+(None, False, True, Ellipsis, (), (123, 'str', b'bytes'))
+True
+True
+False
+False
+False
+False
+False


### PR DESCRIPTION
Now that constant tuples are supported in the parser (eg `(1, True, "str")`), it's a small step to allow anything that is a constant to be used with the pattern:
```python
from micropython import const

X = const(obj)
```

This PR makes the required changes to allow the following types of constants:
```python
from micropython import const

_INT = const(123)
_FLOAT = const(1.2)
_COMPLEX = const(3.4j)
_STR = const("str")
_BYTES = const(b"bytes")
_TUPLE = const((_INT, _STR, _BYTES))
_TUPLE2 = const((None, False, True, ..., (), _TUPLE))
```

Prior to this, only integers could be used in `const(...)`.