### PR TITLE
ports/unix/unix_mphal: Allow overriding hal time functions.

### DIFF
--- a/ports/unix/unix_mphal.c
+++ b/ports/unix/unix_mphal.c
@@ -199,6 +199,7 @@ void mp_hal_stdout_tx_str(const char *str) {
     mp_hal_stdout_tx_strn(str, strlen(str));
 }
 
+#ifndef mp_hal_ticks_ms
 mp_uint_t mp_hal_ticks_ms(void) {
     #if (defined(_POSIX_TIMERS) && _POSIX_TIMERS > 0) && defined(_POSIX_MONOTONIC_CLOCK)
     struct timespec tv;
@@ -210,7 +211,9 @@ mp_uint_t mp_hal_ticks_ms(void) {
     return tv.tv_sec * 1000 + tv.tv_usec / 1000;
     #endif
 }
+#endif
 
+#ifndef mp_hal_ticks_us
 mp_uint_t mp_hal_ticks_us(void) {
     #if (defined(_POSIX_TIMERS) && _POSIX_TIMERS > 0) && defined(_POSIX_MONOTONIC_CLOCK)
     struct timespec tv;
@@ -222,13 +225,17 @@ mp_uint_t mp_hal_ticks_us(void) {
     return tv.tv_sec * 1000000 + tv.tv_usec;
     #endif
 }
+#endif
 
+#ifndef mp_hal_time_ns
 uint64_t mp_hal_time_ns(void) {
     struct timeval tv;
     gettimeofday(&tv, NULL);
     return (uint64_t)tv.tv_sec * 1000000000ULL + (uint64_t)tv.tv_usec * 1000ULL;
 }
+#endif
 
+#ifndef mp_hal_delay_ms
 void mp_hal_delay_ms(mp_uint_t ms) {
     #ifdef MICROPY_EVENT_POLL_HOOK
     mp_uint_t start = mp_hal_ticks_ms();
@@ -242,6 +249,7 @@ void mp_hal_delay_ms(mp_uint_t ms) {
     usleep(ms * 1000);
     #endif
 }
+#endif
 
 void mp_hal_get_random(size_t n, void *buf) {
     #ifdef _HAVE_GETRANDOM


### PR DESCRIPTION
This adds `#ifdefs` around each of the `mp_hal_*` time functions for the unix port. This allows variants to override individual functions as needed.

A use case for this is to create a "virtual" clock to allow tests that depend on the passage of time to run as fast as possible without having to wait for the time on the wall clock to elapse.