### PR TITLE
Update test env. to CPython 3.10.

### DIFF
--- a/.github/workflows/ports_qemu-arm.yml
+++ b/.github/workflows/ports_qemu-arm.yml
@@ -18,6 +18,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
+    - uses: actions/setup-python@v2
+      with:
+        python-version: '3.10'
     - name: Install packages
       run: source tools/ci.sh && ci_qemu_arm_setup
     - name: Build and run test suite

--- a/.github/workflows/ports_unix.yml
+++ b/.github/workflows/ports_unix.yml
@@ -41,6 +41,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
+    - uses: actions/setup-python@v2
+      with:
+        python-version: '3.10'
     - name: Build
       run: source tools/ci.sh && ci_unix_standard_build
     - name: Run main test suite
@@ -53,6 +56,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
+    - uses: actions/setup-python@v2
+      with:
+        python-version: '3.10'
     - name: Build
       run: source tools/ci.sh && ci_unix_dev_build
     - name: Run main test suite
@@ -65,8 +71,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
-    - name: Install packages
-      run: source tools/ci.sh && ci_unix_coverage_setup
+    - uses: actions/setup-python@v2
+      with:
+        python-version: '3.10'
+    - name: Install python dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install setuptools pyelftools
+    - name: Print environment version
+      run: source tools/ci.sh && ci_unix_coverage_print_env
     - name: Build
       run: source tools/ci.sh && ci_unix_coverage_build
     - name: Run main test suite
@@ -92,6 +105,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
+    - uses: actions/setup-python@v2
+      with:
+        python-version: '3.10'
+    - name: Install python dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install setuptools pyelftools
     - name: Install packages
       run: source tools/ci.sh && ci_unix_32bit_setup
     - name: Build
@@ -110,6 +130,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
+    - uses: actions/setup-python@v2
+      with:
+        python-version: '3.10'
     - name: Install packages
       run: source tools/ci.sh && ci_unix_32bit_setup
     - name: Build
@@ -124,6 +147,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
+    - uses: actions/setup-python@v2
+      with:
+        python-version: '3.10'
     - name: Build
       run: source tools/ci.sh && ci_unix_float_build
     - name: Run main test suite
@@ -136,6 +162,9 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
     - uses: actions/checkout@v2
+    - uses: actions/setup-python@v2
+      with:
+        python-version: '3.10'
     - name: Install packages
       run: source tools/ci.sh && ci_unix_clang_setup
     - name: Build
@@ -150,6 +179,9 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
     - uses: actions/checkout@v2
+    - uses: actions/setup-python@v2
+      with:
+        python-version: '3.10'
     - name: Install packages
       run: source tools/ci.sh && ci_unix_clang_setup
     - name: Build
@@ -164,6 +196,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
+    - uses: actions/setup-python@v2
+      with:
+        python-version: '3.10'
     - name: Build
       run: source tools/ci.sh && ci_unix_settrace_build
     - name: Run main test suite
@@ -176,6 +211,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
+    - uses: actions/setup-python@v2
+      with:
+        python-version: '3.10'
     - name: Build
       run: source tools/ci.sh && ci_unix_settrace_stackless_build
     - name: Run main test suite
@@ -190,7 +228,7 @@ jobs:
     - uses: actions/checkout@v2
     - uses: actions/setup-python@v2
       with:
-        python-version: '3.8'
+        python-version: '3.10'
     - name: Build
       run: source tools/ci.sh && ci_unix_macos_build
     - name: Run tests
@@ -203,6 +241,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
+    - uses: actions/setup-python@v2
+      with:
+        python-version: '3.10'
     - name: Install packages
       run: source tools/ci.sh && ci_unix_qemu_mips_setup
     - name: Build
@@ -217,6 +258,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
+    - uses: actions/setup-python@v2
+      with:
+        python-version: '3.10'
     - name: Install packages
       run: source tools/ci.sh && ci_unix_qemu_arm_setup
     - name: Build

--- a/ports/windows/.appveyor.yml
+++ b/ports/windows/.appveyor.yml
@@ -1,10 +1,10 @@
-image: Visual Studio 2017
+image: Visual Studio 2019
 clone_depth: 1
 skip_tags: true
 
 environment:
   # Python version used
-  MICROPY_CPYTHON3: c:/python38/python.exe
+  MICROPY_CPYTHON3: c:/python310/python.exe
   # The variants.
   matrix:
     - PyVariant: dev

--- a/tools/ci.sh
+++ b/tools/ci.sh
@@ -436,9 +436,7 @@ function ci_unix_dev_run_tests {
     ci_unix_run_tests_helper VARIANT=dev
 }
 
-function ci_unix_coverage_setup {
-    sudo pip3 install setuptools
-    sudo pip3 install pyelftools
+function ci_unix_coverage_print_env {
     gcc --version
     python3 --version
 }
@@ -461,8 +459,6 @@ function ci_unix_32bit_setup {
     sudo dpkg --add-architecture i386
     sudo apt-get update
     sudo apt-get install gcc-multilib g++-multilib libffi-dev:i386
-    sudo pip3 install setuptools
-    sudo pip3 install pyelftools
     gcc --version
     python2 --version
     python3 --version


### PR DESCRIPTION
Update both the Unix and Windows test environment to CPython 3.10.

The reason for this PR, I think that it brings more value to test against regular CPython compared to `.py.exp` files when developing features from 3.9 or 3.10.