### PR TITLE
boards/ADAFRUIT_F405_EXPRESS: Use external SPI flash for storage.

### DIFF
--- a/ports/stm32/boards/ADAFRUIT_F405_EXPRESS/bdev.c
+++ b/ports/stm32/boards/ADAFRUIT_F405_EXPRESS/bdev.c
@@ -1,0 +1,28 @@
+#include "py/obj.h"
+#include "storage.h"
+#include "spi.h"
+
+#if !MICROPY_HW_ENABLE_INTERNAL_FLASH_STORAGE
+
+STATIC const spi_proto_cfg_t spi_bus = {
+    .spi = &spi_obj[0], // SPI1
+    .baudrate = 25000000,
+    .polarity = 0,
+    .phase = 0,
+    .bits = 8,
+    .firstbit = SPI_FIRSTBIT_MSB,
+};
+
+STATIC mp_spiflash_cache_t spi_bdev_cache;
+
+const mp_spiflash_config_t spiflash_config = {
+    .bus_kind = MP_SPIFLASH_BUS_SPI,
+    .bus.u_spi.cs = MICROPY_HW_SPIFLASH_CS,
+    .bus.u_spi.data = (void *)&spi_bus,
+    .bus.u_spi.proto = &spi_proto,
+    .cache = &spi_bdev_cache,
+};
+
+spi_bdev_t spi_bdev;
+
+#endif

--- a/ports/stm32/boards/ADAFRUIT_F405_EXPRESS/mpconfigboard.h
+++ b/ports/stm32/boards/ADAFRUIT_F405_EXPRESS/mpconfigboard.h
@@ -11,6 +11,7 @@
 #define MICROPY_HW_ENABLE_DAC       (1)
 #define MICROPY_HW_ENABLE_USB       (1)
 #define MICROPY_HW_ENABLE_SDCARD    (1)
+#define MICROPY_HW_ENABLE_INTERNAL_FLASH_STORAGE (0)
 
 // HSE is 12MHz
 #define MICROPY_HW_CLK_PLLM (12)
@@ -50,14 +51,39 @@
 // SPI buses
 #define MICROPY_HW_SPI1_NAME "SPIFLASH"
 #define MICROPY_HW_SPI1_NSS  (pin_A15) // FLASH CS
-#define MICROPY_HW_SPI1_SCK  (pin_B3) // FLASH CLK
-#define MICROPY_HW_SPI1_MISO (pin_B4) // FLASH MISO
-#define MICROPY_HW_SPI1_MOSI (pin_B5) // FLASH MOSI
+#define MICROPY_HW_SPI1_SCK  (pin_B3)  // FLASH CLK
+#define MICROPY_HW_SPI1_MISO (pin_B4)  // FLASH MISO
+#define MICROPY_HW_SPI1_MOSI (pin_B5)  // FLASH MOSI
+
 #define MICROPY_HW_SPI2_NAME "SPI1"
 #define MICROPY_HW_SPI2_NSS  (pin_B12) // SD DETECT
 #define MICROPY_HW_SPI2_SCK  (pin_B13) // SCK
 #define MICROPY_HW_SPI2_MISO (pin_B14) // MISO
 #define MICROPY_HW_SPI2_MOSI (pin_B15) // MOSI
+
+// External SPI Flash config
+#if !MICROPY_HW_ENABLE_INTERNAL_FLASH_STORAGE
+
+#define MICROPY_HW_SPIFLASH_SIZE_BITS (16 * 1024 * 1024) // 16 Mbit (2 MByte)
+
+#define MICROPY_HW_SPIFLASH_CS      (MICROPY_HW_SPI1_NSS)
+#define MICROPY_HW_SPIFLASH_SCK     (MICROPY_HW_SPI1_SCK)
+#define MICROPY_HW_SPIFLASH_MISO    (MICROPY_HW_SPI1_MISO)
+#define MICROPY_HW_SPIFLASH_MOSI    (MICROPY_HW_SPI1_MOSI)
+
+extern const struct _mp_spiflash_config_t spiflash_config;
+extern struct _spi_bdev_t spi_bdev;
+#define MICROPY_HW_SPIFLASH_ENABLE_CACHE (1)
+#define MICROPY_HW_BDEV_IOCTL(op, arg) ( \
+    (op) == BDEV_IOCTL_NUM_BLOCKS ? (MICROPY_HW_SPIFLASH_SIZE_BITS / 8 / FLASH_BLOCK_SIZE) : \
+    (op) == BDEV_IOCTL_INIT ? spi_bdev_ioctl(&spi_bdev, (op), (uint32_t)&spiflash_config) : \
+    spi_bdev_ioctl(&spi_bdev, (op), (arg)) \
+)
+#define MICROPY_HW_BDEV_READBLOCKS(dest, bl, n) spi_bdev_readblocks(&spi_bdev, (dest), (bl), (n))
+#define MICROPY_HW_BDEV_WRITEBLOCKS(src, bl, n) spi_bdev_writeblocks(&spi_bdev, (src), (bl), (n))
+#define MICROPY_HW_BDEV_SPIFLASH_EXTENDED (&spi_bdev) // for extended block protocol
+
+#endif // !MICROPY_HW_ENABLE_INTERNAL_FLASH_STORAGE
 
 // CAN buses
 #define MICROPY_HW_CAN1_NAME "CAN1"


### PR DESCRIPTION
* Fixes #8553