### PR TITLE
drivers/ninaw10: Fix isconnected.

### DIFF
--- a/drivers/ninaw10/nina_wifi_drv.c
+++ b/drivers/ninaw10/nina_wifi_drv.c
@@ -469,11 +469,7 @@ int nina_disconnect(void) {
 }
 
 int nina_isconnected(void) {
-    int status = nina_connection_status();
-    if (status == -1) {
-        return -1;
-    }
-    return status == NINA_STATUS_CONNECTED;
+    return nina_connection_status() == NINA_STATUS_CONNECTED;
 }
 
 int nina_connected_sta(uint32_t *sta_ip) {


### PR DESCRIPTION
* If isconnected is called before active, it returns -1, which causes
mp_obj_new_bool return True, indicating the module is connected.