### PR TITLE
tests/extmod/uasyncio_gather: Make double-raise gather test reliable.

### DIFF
--- a/tests/extmod/uasyncio_gather.py
+++ b/tests/extmod/uasyncio_gather.py
@@ -34,9 +34,10 @@ async def task_loop(id):
         print("task_loop loop", id)
 
 
-async def task_raise(id):
+async def task_raise(id, t=0.02):
     print("task_raise start", id)
-    await asyncio.sleep(0.02)
+    await asyncio.sleep(t)
+    print("task_raise raise", id)
     raise ValueError(id)
 
 
@@ -79,7 +80,8 @@ async def main():
     print("====")
 
     # Test case where both tasks raise an exception.
-    tasks = [asyncio.create_task(task_raise(1)), asyncio.create_task(task_raise(2))]
+    # Use t=0 so they raise one after the other, between the gather starting and finishing.
+    tasks = [asyncio.create_task(task_raise(1, t=0)), asyncio.create_task(task_raise(2, t=0))]
     try:
         await asyncio.gather(*tasks)
     except ValueError as er:

--- a/tests/extmod/uasyncio_gather.py.exp
+++ b/tests/extmod/uasyncio_gather.py.exp
@@ -16,16 +16,20 @@ end 2
 start 1
 task_raise start 2
 end 1
+task_raise raise 2
 [1, ValueError(2,)]
 ====
 task_loop start 1
 task_raise start 2
 task_loop loop 1
+task_raise raise 2
 ValueError(2,)
 False True
 ====
 task_raise start 1
 task_raise start 2
+task_raise raise 1
+task_raise raise 2
 ValueError(1,)
 True True
 ====


### PR DESCRIPTION
This double-raise test could fail when task[0] raises and stops the gather before task[1] raises, then task[1] is left to raise later on and spoil the test.

This should fix a lot of the spurious CI failures that have come up lately.