### PR TITLE
extmod/uasyncio: Fix bug in gather with edge case of cancellation

### DIFF
--- a/extmod/uasyncio/funcs.py
+++ b/extmod/uasyncio/funcs.py
@@ -61,9 +61,13 @@ class _Remove:
 
 async def gather(*aws, return_exceptions=False):
     def done(t, er):
+        # Sub-task "t" has finished, with exception "er".
         nonlocal state
-        if type(state) is not int:
-            # A sub-task already raised an exception, so do nothing.
+        if gather_task.data is not _Remove:
+            # The main gather task has already been scheduled, so do nothing.
+            # This happens if another sub-task already raised an exception and
+            # woke the main gather task (via this done function), or if the main
+            # gather task was cancelled externally.
             return
         elif not return_exceptions and not isinstance(er, StopIteration):
             # A sub-task raised an exception, indicate that to the gather task.

--- a/extmod/uasyncio/task.py
+++ b/extmod/uasyncio/task.py
@@ -100,10 +100,10 @@ class TaskQueue:
         return self.heap
 
     def push_sorted(self, v, key):
+        assert v.ph_child is None
+        assert v.ph_next is None
         v.data = None
         v.ph_key = key
-        v.ph_child = None
-        v.ph_next = None
         self.heap = ph_meld(v, self.heap)
 
     def push_head(self, v):
@@ -111,7 +111,9 @@ class TaskQueue:
 
     def pop_head(self):
         v = self.heap
-        self.heap = ph_pairing(self.heap.ph_child)
+        assert v.ph_next is None
+        self.heap = ph_pairing(v.ph_child)
+        v.ph_child = None
         return v
 
     def remove(self, v):

--- a/tests/extmod/uasyncio_gather.py
+++ b/tests/extmod/uasyncio_gather.py
@@ -20,9 +20,9 @@ async def factorial(name, number):
     return f
 
 
-async def task(id):
+async def task(id, t=0.02):
     print("start", id)
-    await asyncio.sleep(0.02)
+    await asyncio.sleep(t)
     print("end", id)
     return id
 
@@ -95,6 +95,15 @@ async def main():
     await asyncio.sleep(0.01)
     t.cancel()
     await asyncio.sleep(0.04)
+
+    # Test edge cases where the gather is cancelled just as tasks are created and ending.
+    for i in range(1, 4):
+        print("====")
+        t = asyncio.create_task(gather_task(task(1, t=0), task(2, t=0)))
+        for _ in range(i):
+            await asyncio.sleep(0)
+        t.cancel()
+        await asyncio.sleep(0.2)
 
 
 asyncio.run(main())

--- a/tests/extmod/uasyncio_gather.py.exp
+++ b/tests/extmod/uasyncio_gather.py.exp
@@ -36,3 +36,19 @@ True True
 gather_task
 start 1
 start 2
+====
+gather_task
+start 1
+start 2
+====
+gather_task
+start 1
+start 2
+end 1
+end 2
+====
+gather_task
+start 1
+start 2
+end 1
+end 2

--- a/tests/run-tests.py
+++ b/tests/run-tests.py
@@ -13,6 +13,9 @@ from multiprocessing.pool import ThreadPool
 import threading
 import tempfile
 
+# Maximum time to run a PC-based test, in seconds.
+TEST_TIMEOUT = 30
+
 # See stackoverflow.com/questions/2632199: __file__ nor sys.argv[0]
 # are guaranteed to always work, this one should though.
 BASEPATH = os.path.dirname(os.path.abspath(inspect.getsourcefile(lambda: None)))
@@ -178,10 +181,15 @@ def run_micropython(pyb, args, test_file, is_special=False):
 
             # run the actual test
             try:
-                output_mupy = subprocess.check_output(cmdlist, stderr=subprocess.STDOUT)
+                output_mupy = subprocess.check_output(
+                    cmdlist, stderr=subprocess.STDOUT, timeout=TEST_TIMEOUT
+                )
             except subprocess.CalledProcessError as er:
                 had_crash = True
                 output_mupy = er.output + b"CRASH"
+            except subprocess.TimeoutExpired as er:
+                had_crash = True
+                output_mupy = (er.output or b"") + b"TIMEOUT"
 
             # clean up if we had an intermediate .mpy file
             if args.via_mpy:

--- a/tools/ci.sh
+++ b/tools/ci.sh
@@ -561,7 +561,7 @@ function ci_unix_macos_run_tests {
     # - OSX has poor time resolution and these uasyncio tests do not have correct output
     # - import_pkg7 has a problem with relative imports
     # - urandom_basic has a problem with getrandbits(0)
-    (cd tests && ./run-tests.py --exclude 'uasyncio_(basic|heaplock|lock|wait_task)' --exclude 'import_pkg7.py' --exclude 'urandom_basic.py')
+    (cd tests && ./run-tests.py --exclude 'uasyncio_(basic|gather|heaplock|lock|wait_task)' --exclude 'import_pkg7.py' --exclude 'urandom_basic.py')
 }
 
 function ci_unix_qemu_mips_setup {


### PR DESCRIPTION
So the test suite runs to completion, even if the interpreter locks up.

Hopefully this helps to debug recent macOS CI failures.