### PR TITLE
py/modsys: Append MicroPython git version and build date to sys.version.

### DIFF
--- a/ports/unix/main.c
+++ b/ports/unix/main.c
@@ -178,8 +178,8 @@ STATIC char *strjoin(const char *s1, int sep_char, const char *s2) {
 #endif
 
 STATIC int do_repl(void) {
-    mp_hal_stdout_tx_str("MicroPython " MICROPY_GIT_TAG " on " MICROPY_BUILD_DATE "; "
-        MICROPY_PY_SYS_PLATFORM " [" MICROPY_PLATFORM_COMPILER "] version\n"
+    mp_hal_stdout_tx_str(MICROPY_BANNER_NAME_AND_VERSION);
+    mp_hal_stdout_tx_str("; " MICROPY_PY_SYS_PLATFORM " [" MICROPY_PLATFORM_COMPILER "] version\n"
         "Use Ctrl-D to exit, Ctrl-E for paste mode\n");
 
     #if MICROPY_USE_READLINE == 1

--- a/py/modsys.c
+++ b/py/modsys.c
@@ -36,6 +36,7 @@
 #include "py/smallint.h"
 #include "py/runtime.h"
 #include "py/persistentcode.h"
+#include "genhdr/mpversion.h"
 
 #if MICROPY_PY_SYS_SETTRACE
 #include "py/objmodule.h"
@@ -54,7 +55,7 @@ const mp_print_t mp_sys_stdout_print = {&mp_sys_stdout_obj, mp_stream_write_adap
 #endif
 
 // version - Python language version that this implementation conforms to, as a string
-STATIC const MP_DEFINE_STR_OBJ(mp_sys_version_obj, "3.4.0");
+STATIC const MP_DEFINE_STR_OBJ(mp_sys_version_obj, "3.4.0; " MICROPY_BANNER_NAME_AND_VERSION);
 
 // version_info - Python language version that this implementation conforms to, as a tuple of ints
 #define I(n) MP_OBJ_NEW_SMALL_INT(n)

--- a/py/mpconfig.h
+++ b/py/mpconfig.h
@@ -1714,6 +1714,11 @@ typedef double mp_float_t;
 #define MICROPY_OBJ_BASE_ALIGNMENT
 #endif
 
+// String used for the banner, and sys.version additional information
+#ifndef MICROPY_BANNER_NAME_AND_VERSION
+#define MICROPY_BANNER_NAME_AND_VERSION "MicroPython " MICROPY_GIT_TAG " on " MICROPY_BUILD_DATE
+#endif
+
 // On embedded platforms, these will typically enable/disable irqs.
 #ifndef MICROPY_BEGIN_ATOMIC_SECTION
 #define MICROPY_BEGIN_ATOMIC_SECTION() (0)

--- a/shared/runtime/pyexec.c
+++ b/shared/runtime/pyexec.c
@@ -401,7 +401,8 @@ STATIC int pyexec_friendly_repl_process_char(int c) {
         } else if (ret == CHAR_CTRL_B) {
             // reset friendly REPL
             mp_hal_stdout_tx_str("\r\n");
-            mp_hal_stdout_tx_str("MicroPython " MICROPY_GIT_TAG " on " MICROPY_BUILD_DATE "; " MICROPY_HW_BOARD_NAME " with " MICROPY_HW_MCU_NAME "\r\n");
+            mp_hal_stdout_tx_str(MICROPY_BANNER_NAME_AND_VERSION);
+            mp_hal_stdout_tx_str("; " MICROPY_HW_BOARD_NAME " with " MICROPY_HW_MCU_NAME "\r\n");
             #if MICROPY_PY_BUILTINS_HELP
             mp_hal_stdout_tx_str("Type \"help()\" for more information.\r\n");
             #endif
@@ -552,7 +553,8 @@ int pyexec_friendly_repl(void) {
     vstr_init(&line, 32);
 
 friendly_repl_reset:
-    mp_hal_stdout_tx_str("MicroPython " MICROPY_GIT_TAG " on " MICROPY_BUILD_DATE "; " MICROPY_HW_BOARD_NAME " with " MICROPY_HW_MCU_NAME "\r\n");
+    mp_hal_stdout_tx_str(MICROPY_BANNER_NAME_AND_VERSION);
+    mp_hal_stdout_tx_str("; " MICROPY_HW_BOARD_NAME " with " MICROPY_HW_MCU_NAME "\r\n");
     #if MICROPY_PY_BUILTINS_HELP
     mp_hal_stdout_tx_str("Type \"help()\" for more information.\r\n");
     #endif


### PR DESCRIPTION
To get the MicroPython git hash and build date programatically, the only way to do this currently is to use `os.uname().version`.  This function doesn't exist on unix/windows.  PR #6596 adds `os.uname()` to the unix port, but IMO that isn't the right approach.

Ultimately I think we should deprecate and remove `os.uname()` because:
- it doesn't exist on Windows CPython, so isn't really portable anyway
- it's an ad-hoc function to put in the `os` module
- our current implementation of `os.uname()` doesn't really match what CPython gives on Linux, and that's because `os.uname()` only really makes sense on a POSIX system that provides the `uname()` C function to get the relevant info
- better information is available in the `platform` module and/or the `sys` module

I don't propose to deprecate or remove `os.uname()` now (and maybe that will wait until MicroPython 2.0).  But for now I think it's a good idea to provide a good alternative to it.

The information in `os.uname()` that's currently not available anywhere else is:
- MicroPython git hash and build date
- board name and MCU name

This PR adds the git hash and build date to `sys.version`.  This is allowed according to CPython docs, and is what PyPy does.

Eg on CPython:
```
Python 3.10.4 (main, Mar 23 2022, 23:05:40) [GCC 11.2.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import sys
>>> sys.version
'3.10.4 (main, Mar 23 2022, 23:05:40) [GCC 11.2.0]'
```
and PyPy:
```
Python 2.7.12 (5.6.0+dfsg-4, Nov 20 2016, 10:43:30)
[PyPy 5.6.0 with GCC 6.2.0 20161109] on linux2
Type "help", "copyright", "credits" or "license" for more information.
>>>> import sys
>>>> sys.version
'2.7.12 (5.6.0+dfsg-4, Nov 20 2016, 10:43:30)\n[PyPy 5.6.0 with GCC 6.2.0 20161109]'
```

With this PR on MicroPython we now have:
```
MicroPython v1.18-371-g1bdea1261 on 2022-04-21; linux [GCC 11.2.0] version
Use Ctrl-D to exit, Ctrl-E for paste mode
>>> import sys
>>> sys.version
'3.4.0; MicroPython v1.18-371-g1bdea1261 on 2022-04-21'
```

Note that the start of the banner is the same as the end of `sys.version`.  This helps to keep code size under control because the string can be reused.  Code size change of this PR is:
```
   bare-arm:    +0 +0.000% 
minimal x86:   +12 +0.007% 
   unix x64:   +12 +0.002% 
unix nanbox:   +32 +0.007% 
      stm32:   -16 -0.004% PYBV10
     cc3200:   +24 +0.013% 
    esp8266:   -28 -0.004% GENERIC
      esp32:   +28 +0.002% GENERIC[incl +16(data)]
        nrf:   -20 -0.011% pca10040
        rp2:    +8 +0.002% PICO
       samd:   +16 +0.011% ADAFRUIT_ITSYBITSY_M4_EXPRESS
```