### PR TITLE
py/obj.h: Add m_new_obj_with_type macro.

### DIFF
--- a/extmod/machine_i2c.c
+++ b/extmod/machine_i2c.c
@@ -668,8 +668,7 @@ STATIC void mp_machine_soft_i2c_init(mp_obj_base_t *self_in, size_t n_args, cons
 
 STATIC mp_obj_t mp_machine_soft_i2c_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *args) {
     // create new soft I2C object
-    machine_i2c_obj_t *self = m_new_obj(machine_i2c_obj_t);
-    self->base.type = &mp_machine_soft_i2c_type;
+    machine_i2c_obj_t *self = mp_obj_malloc(machine_i2c_obj_t, &mp_machine_soft_i2c_type);
     mp_map_t kw_args;
     mp_map_init_fixed_table(&kw_args, n_kw, args + n_args);
     mp_machine_soft_i2c_init(&self->base, n_args, args, &kw_args);

--- a/extmod/machine_signal.c
+++ b/extmod/machine_signal.c
@@ -108,8 +108,7 @@ STATIC mp_obj_t signal_make_new(const mp_obj_type_t *type, size_t n_args, size_t
         }
     }
 
-    machine_signal_t *o = m_new_obj(machine_signal_t);
-    o->base.type = type;
+    machine_signal_t *o = mp_obj_malloc(machine_signal_t, type);
     o->pin = pin;
     o->invert = invert;
     return MP_OBJ_FROM_PTR(o);

--- a/extmod/machine_spi.c
+++ b/extmod/machine_spi.c
@@ -175,8 +175,7 @@ STATIC mp_obj_t mp_machine_soft_spi_make_new(const mp_obj_type_t *type, size_t n
     mp_arg_parse_all_kw_array(n_args, n_kw, all_args, MP_ARRAY_SIZE(allowed_args), allowed_args, args);
 
     // create new object
-    mp_machine_soft_spi_obj_t *self = m_new_obj(mp_machine_soft_spi_obj_t);
-    self->base.type = &mp_machine_soft_spi_type;
+    mp_machine_soft_spi_obj_t *self = mp_obj_malloc(mp_machine_soft_spi_obj_t, &mp_machine_soft_spi_type);
 
     // set parameters
     self->spi.delay_half = baudrate_to_delay_half(args[ARG_baudrate].u_int);

--- a/extmod/modbluetooth.c
+++ b/extmod/modbluetooth.c
@@ -97,8 +97,7 @@ STATIC mp_obj_t bluetooth_uuid_make_new(const mp_obj_type_t *type, size_t n_args
 
     mp_arg_check_num(n_args, n_kw, 1, 1, false);
 
-    mp_obj_bluetooth_uuid_t *self = m_new_obj(mp_obj_bluetooth_uuid_t);
-    self->base.type = &mp_type_bluetooth_uuid;
+    mp_obj_bluetooth_uuid_t *self = mp_obj_malloc(mp_obj_bluetooth_uuid_t, &mp_type_bluetooth_uuid);
 
     if (mp_obj_is_int(all_args[0])) {
         self->type = MP_BLUETOOTH_UUID_TYPE_16;

--- a/extmod/modbtree.c
+++ b/extmod/modbtree.c
@@ -67,8 +67,7 @@ void __dbpanic(DB *db) {
 }
 
 STATIC mp_obj_btree_t *btree_new(DB *db, mp_obj_t stream) {
-    mp_obj_btree_t *o = m_new_obj(mp_obj_btree_t);
-    o->base.type = &btree_type;
+    mp_obj_btree_t *o = mp_obj_malloc(mp_obj_btree_t, &btree_type);
     o->stream = stream;
     o->db = db;
     o->start_key = mp_const_none;

--- a/extmod/modframebuf.c
+++ b/extmod/modframebuf.c
@@ -266,8 +266,7 @@ STATIC void fill_rect(const mp_obj_framebuf_t *fb, int x, int y, int w, int h, u
 STATIC mp_obj_t framebuf_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *args) {
     mp_arg_check_num(n_args, n_kw, 4, 5, false);
 
-    mp_obj_framebuf_t *o = m_new_obj(mp_obj_framebuf_t);
-    o->base.type = type;
+    mp_obj_framebuf_t *o = mp_obj_malloc(mp_obj_framebuf_t, type);
     o->buf_obj = args[0];
 
     mp_buffer_info_t bufinfo;
@@ -628,8 +627,7 @@ STATIC const mp_obj_type_t mp_type_framebuf = {
 
 // this factory function is provided for backwards compatibility with old FrameBuffer1 class
 STATIC mp_obj_t legacy_framebuffer1(size_t n_args, const mp_obj_t *args) {
-    mp_obj_framebuf_t *o = m_new_obj(mp_obj_framebuf_t);
-    o->base.type = &mp_type_framebuf;
+    mp_obj_framebuf_t *o = mp_obj_malloc(mp_obj_framebuf_t, &mp_type_framebuf);
 
     mp_buffer_info_t bufinfo;
     mp_get_buffer_raise(args[0], &bufinfo, MP_BUFFER_WRITE);

--- a/extmod/moduasyncio.c
+++ b/extmod/moduasyncio.c
@@ -87,8 +87,7 @@ STATIC int task_lt(mp_pairheap_t *n1, mp_pairheap_t *n2) {
 STATIC mp_obj_t task_queue_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *args) {
     (void)args;
     mp_arg_check_num(n_args, n_kw, 0, 0, false);
-    mp_obj_task_queue_t *self = m_new_obj(mp_obj_task_queue_t);
-    self->base.type = type;
+    mp_obj_task_queue_t *self = mp_obj_malloc(mp_obj_task_queue_t, type);
     self->heap = (mp_obj_task_t *)mp_pairheap_new(task_lt);
     return MP_OBJ_FROM_PTR(self);
 }

--- a/extmod/moducryptolib.c
+++ b/extmod/moducryptolib.c
@@ -228,8 +228,7 @@ STATIC mp_obj_t ucryptolib_aes_make_new(const mp_obj_type_t *type, size_t n_args
             mp_raise_ValueError(MP_ERROR_TEXT("mode"));
     }
 
-    mp_obj_aes_t *o = m_new_obj_var(mp_obj_aes_t, struct ctr_params, !!is_ctr_mode(block_mode));
-    o->base.type = type;
+    mp_obj_aes_t *o = mp_obj_malloc_var(mp_obj_aes_t, struct ctr_params, !!is_ctr_mode(block_mode), type);
 
     o->block_mode = block_mode;
     o->key_type = AES_KEYTYPE_NONE;

--- a/extmod/moductypes.c
+++ b/extmod/moductypes.c
@@ -95,8 +95,7 @@ STATIC NORETURN void syntax_error(void) {
 
 STATIC mp_obj_t uctypes_struct_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *args) {
     mp_arg_check_num(n_args, n_kw, 2, 3, false);
-    mp_obj_uctypes_struct_t *o = m_new_obj(mp_obj_uctypes_struct_t);
-    o->base.type = type;
+    mp_obj_uctypes_struct_t *o = mp_obj_malloc(mp_obj_uctypes_struct_t, type);
     o->addr = (void *)(uintptr_t)mp_obj_int_get_truncated(args[0]);
     o->desc = args[1];
     o->flags = LAYOUT_NATIVE;
@@ -463,8 +462,7 @@ STATIC mp_obj_t uctypes_struct_attr_op(mp_obj_t self_in, qstr attr, mp_obj_t set
 
     switch (agg_type) {
         case STRUCT: {
-            mp_obj_uctypes_struct_t *o = m_new_obj(mp_obj_uctypes_struct_t);
-            o->base.type = &uctypes_struct_type;
+            mp_obj_uctypes_struct_t *o = mp_obj_malloc(mp_obj_uctypes_struct_t, &uctypes_struct_type);
             o->desc = sub->items[1];
             o->addr = self->addr + offset;
             o->flags = self->flags;
@@ -479,8 +477,7 @@ STATIC mp_obj_t uctypes_struct_attr_op(mp_obj_t self_in, qstr attr, mp_obj_t set
             MP_FALLTHROUGH
         }
         case PTR: {
-            mp_obj_uctypes_struct_t *o = m_new_obj(mp_obj_uctypes_struct_t);
-            o->base.type = &uctypes_struct_type;
+            mp_obj_uctypes_struct_t *o = mp_obj_malloc(mp_obj_uctypes_struct_t, &uctypes_struct_type);
             o->desc = MP_OBJ_FROM_PTR(sub);
             o->addr = self->addr + offset;
             o->flags = self->flags;
@@ -552,8 +549,7 @@ STATIC mp_obj_t uctypes_struct_subscr(mp_obj_t self_in, mp_obj_t index_in, mp_ob
             } else if (value == MP_OBJ_SENTINEL) {
                 mp_uint_t dummy = 0;
                 mp_uint_t size = uctypes_struct_size(t->items[2], self->flags, &dummy);
-                mp_obj_uctypes_struct_t *o = m_new_obj(mp_obj_uctypes_struct_t);
-                o->base.type = &uctypes_struct_type;
+                mp_obj_uctypes_struct_t *o = mp_obj_malloc(mp_obj_uctypes_struct_t, &uctypes_struct_type);
                 o->desc = t->items[2];
                 o->addr = self->addr + size * index;
                 o->flags = self->flags;
@@ -570,8 +566,7 @@ STATIC mp_obj_t uctypes_struct_subscr(mp_obj_t self_in, mp_obj_t index_in, mp_ob
             } else {
                 mp_uint_t dummy = 0;
                 mp_uint_t size = uctypes_struct_size(t->items[1], self->flags, &dummy);
-                mp_obj_uctypes_struct_t *o = m_new_obj(mp_obj_uctypes_struct_t);
-                o->base.type = &uctypes_struct_type;
+                mp_obj_uctypes_struct_t *o = mp_obj_malloc(mp_obj_uctypes_struct_t, &uctypes_struct_type);
                 o->desc = t->items[1];
                 o->addr = p + size * index;
                 o->flags = self->flags;

--- a/extmod/moduhashlib.c
+++ b/extmod/moduhashlib.c
@@ -83,8 +83,7 @@ STATIC mp_obj_t uhashlib_sha256_update(mp_obj_t self_in, mp_obj_t arg);
 
 STATIC mp_obj_t uhashlib_sha256_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *args) {
     mp_arg_check_num(n_args, n_kw, 0, 1, false);
-    mp_obj_hash_t *o = m_new_obj_var(mp_obj_hash_t, char, sizeof(mbedtls_sha256_context));
-    o->base.type = type;
+    mp_obj_hash_t *o = mp_obj_malloc_var(mp_obj_hash_t, char, sizeof(mbedtls_sha256_context), type);
     o->final = false;
     mbedtls_sha256_init((mbedtls_sha256_context *)&o->state);
     mbedtls_sha256_starts_ret((mbedtls_sha256_context *)&o->state, 0);
@@ -119,8 +118,7 @@ STATIC mp_obj_t uhashlib_sha256_digest(mp_obj_t self_in) {
 
 STATIC mp_obj_t uhashlib_sha256_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *args) {
     mp_arg_check_num(n_args, n_kw, 0, 1, false);
-    mp_obj_hash_t *o = m_new_obj_var(mp_obj_hash_t, char, sizeof(CRYAL_SHA256_CTX));
-    o->base.type = type;
+    mp_obj_hash_t *o = mp_obj_malloc_var(mp_obj_hash_t, char, sizeof(CRYAL_SHA256_CTX), type);
     o->final = false;
     sha256_init((CRYAL_SHA256_CTX *)o->state);
     if (n_args == 1) {
@@ -173,8 +171,7 @@ STATIC mp_obj_t uhashlib_sha1_update(mp_obj_t self_in, mp_obj_t arg);
 #if MICROPY_SSL_AXTLS
 STATIC mp_obj_t uhashlib_sha1_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *args) {
     mp_arg_check_num(n_args, n_kw, 0, 1, false);
-    mp_obj_hash_t *o = m_new_obj_var(mp_obj_hash_t, char, sizeof(SHA1_CTX));
-    o->base.type = type;
+    mp_obj_hash_t *o = mp_obj_malloc_var(mp_obj_hash_t, char, sizeof(SHA1_CTX), type);
     o->final = false;
     SHA1_Init((SHA1_CTX *)o->state);
     if (n_args == 1) {
@@ -213,8 +210,7 @@ STATIC mp_obj_t uhashlib_sha1_digest(mp_obj_t self_in) {
 
 STATIC mp_obj_t uhashlib_sha1_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *args) {
     mp_arg_check_num(n_args, n_kw, 0, 1, false);
-    mp_obj_hash_t *o = m_new_obj_var(mp_obj_hash_t, char, sizeof(mbedtls_sha1_context));
-    o->base.type = type;
+    mp_obj_hash_t *o = mp_obj_malloc_var(mp_obj_hash_t, char, sizeof(mbedtls_sha1_context), type);
     o->final = false;
     mbedtls_sha1_init((mbedtls_sha1_context *)o->state);
     mbedtls_sha1_starts_ret((mbedtls_sha1_context *)o->state);
@@ -268,8 +264,7 @@ STATIC mp_obj_t uhashlib_md5_update(mp_obj_t self_in, mp_obj_t arg);
 #if MICROPY_SSL_AXTLS
 STATIC mp_obj_t uhashlib_md5_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *args) {
     mp_arg_check_num(n_args, n_kw, 0, 1, false);
-    mp_obj_hash_t *o = m_new_obj_var(mp_obj_hash_t, char, sizeof(MD5_CTX));
-    o->base.type = type;
+    mp_obj_hash_t *o = mp_obj_malloc_var(mp_obj_hash_t, char, sizeof(MD5_CTX), type);
     o->final = false;
     MD5_Init((MD5_CTX *)o->state);
     if (n_args == 1) {
@@ -308,8 +303,7 @@ STATIC mp_obj_t uhashlib_md5_digest(mp_obj_t self_in) {
 
 STATIC mp_obj_t uhashlib_md5_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *args) {
     mp_arg_check_num(n_args, n_kw, 0, 1, false);
-    mp_obj_hash_t *o = m_new_obj_var(mp_obj_hash_t, char, sizeof(mbedtls_md5_context));
-    o->base.type = type;
+    mp_obj_hash_t *o = mp_obj_malloc_var(mp_obj_hash_t, char, sizeof(mbedtls_md5_context), type);
     o->final = false;
     mbedtls_md5_init((mbedtls_md5_context *)o->state);
     mbedtls_md5_starts_ret((mbedtls_md5_context *)o->state);

--- a/extmod/modure.c
+++ b/extmod/modure.c
@@ -406,8 +406,7 @@ STATIC mp_obj_t mod_re_compile(size_t n_args, const mp_obj_t *args) {
     if (size == -1) {
         goto error;
     }
-    mp_obj_re_t *o = m_new_obj_var(mp_obj_re_t, char, size);
-    o->base.type = &re_type;
+    mp_obj_re_t *o = mp_obj_malloc_var(mp_obj_re_t, char, size, &re_type);
     #if MICROPY_PY_URE_DEBUG
     int flags = 0;
     if (n_args > 1) {

--- a/extmod/moduselect.c
+++ b/extmod/moduselect.c
@@ -346,8 +346,7 @@ STATIC const mp_obj_type_t mp_type_poll = {
 
 // poll()
 STATIC mp_obj_t select_poll(void) {
-    mp_obj_poll_t *poll = m_new_obj(mp_obj_poll_t);
-    poll->base.type = &mp_type_poll;
+    mp_obj_poll_t *poll = mp_obj_malloc(mp_obj_poll_t, &mp_type_poll);
     mp_map_init(&poll->poll_map, 0);
     poll->iter_cnt = 0;
     poll->ret_tuple = MP_OBJ_NULL;

--- a/extmod/modutimeq.c
+++ b/extmod/modutimeq.c
@@ -77,8 +77,7 @@ STATIC bool time_less_than(struct qentry *item, struct qentry *parent) {
 STATIC mp_obj_t utimeq_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *args) {
     mp_arg_check_num(n_args, n_kw, 1, 1, false);
     mp_uint_t alloc = mp_obj_get_int(args[0]);
-    mp_obj_utimeq_t *o = m_new_obj_var(mp_obj_utimeq_t, struct qentry, alloc);
-    o->base.type = type;
+    mp_obj_utimeq_t *o = mp_obj_malloc_var(mp_obj_utimeq_t, struct qentry, alloc, type);
     memset(o->items, 0, sizeof(*o->items) * alloc);
     o->alloc = alloc;
     o->len = 0;

--- a/extmod/moduwebsocket.c
+++ b/extmod/moduwebsocket.c
@@ -60,8 +60,7 @@ STATIC mp_uint_t websocket_write(mp_obj_t self_in, const void *buf, mp_uint_t si
 STATIC mp_obj_t websocket_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *args) {
     mp_arg_check_num(n_args, n_kw, 1, 2, false);
     mp_get_stream_raise(args[0], MP_STREAM_OP_READ | MP_STREAM_OP_WRITE | MP_STREAM_OP_IOCTL);
-    mp_obj_websocket_t *o = m_new_obj(mp_obj_websocket_t);
-    o->base.type = type;
+    mp_obj_websocket_t *o = mp_obj_malloc(mp_obj_websocket_t, type);
     o->sock = args[0];
     o->state = FRAME_HEADER;
     o->to_recv = 2;

--- a/extmod/moduzlib.c
+++ b/extmod/moduzlib.c
@@ -69,8 +69,7 @@ STATIC int read_src_stream(TINF_DATA *data) {
 STATIC mp_obj_t decompio_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *args) {
     mp_arg_check_num(n_args, n_kw, 1, 2, false);
     mp_get_stream_raise(args[0], MP_STREAM_OP_READ);
-    mp_obj_decompio_t *o = m_new_obj(mp_obj_decompio_t);
-    o->base.type = type;
+    mp_obj_decompio_t *o = mp_obj_malloc(mp_obj_decompio_t, type);
     memset(&o->decomp, 0, sizeof(o->decomp));
     o->decomp.readSource = read_src_stream;
     o->src_stream = args[0];

--- a/extmod/modwebrepl.c
+++ b/extmod/modwebrepl.c
@@ -97,8 +97,7 @@ STATIC mp_obj_t webrepl_make_new(const mp_obj_type_t *type, size_t n_args, size_
     mp_arg_check_num(n_args, n_kw, 1, 2, false);
     mp_get_stream_raise(args[0], MP_STREAM_OP_READ | MP_STREAM_OP_WRITE | MP_STREAM_OP_IOCTL);
     DEBUG_printf("sizeof(struct webrepl_file) = %lu\n", sizeof(struct webrepl_file));
-    mp_obj_webrepl_t *o = m_new_obj(mp_obj_webrepl_t);
-    o->base.type = type;
+    mp_obj_webrepl_t *o = mp_obj_malloc(mp_obj_webrepl_t, type);
     o->sock = args[0];
     o->hdr_to_recv = sizeof(struct webrepl_file);
     o->data_to_recv = 0;

--- a/extmod/vfs.c
+++ b/extmod/vfs.c
@@ -417,8 +417,7 @@ mp_obj_t mp_vfs_ilistdir(size_t n_args, const mp_obj_t *args) {
 
     if (vfs == MP_VFS_ROOT) {
         // list the root directory
-        mp_vfs_ilistdir_it_t *iter = m_new_obj(mp_vfs_ilistdir_it_t);
-        iter->base.type = &mp_type_polymorph_iter;
+        mp_vfs_ilistdir_it_t *iter = mp_obj_malloc(mp_vfs_ilistdir_it_t, &mp_type_polymorph_iter);
         iter->iternext = mp_vfs_ilistdir_it_iternext;
         iter->cur.vfs = MP_STATE_VM(vfs_mount_table);
         iter->is_str = mp_obj_get_type(path_in) == &mp_type_str;

--- a/extmod/vfs_fat.c
+++ b/extmod/vfs_fat.c
@@ -66,8 +66,7 @@ STATIC mp_obj_t fat_vfs_make_new(const mp_obj_type_t *type, size_t n_args, size_
     mp_arg_check_num(n_args, n_kw, 1, 1, false);
 
     // create new object
-    fs_user_mount_t *vfs = m_new_obj(fs_user_mount_t);
-    vfs->base.type = type;
+    fs_user_mount_t *vfs = mp_obj_malloc(fs_user_mount_t, type);
     vfs->fatfs.drv = vfs;
 
     // Initialise underlying block device
@@ -177,8 +176,7 @@ STATIC mp_obj_t fat_vfs_ilistdir_func(size_t n_args, const mp_obj_t *args) {
     }
 
     // Create a new iterator object to list the dir
-    mp_vfs_fat_ilistdir_it_t *iter = m_new_obj(mp_vfs_fat_ilistdir_it_t);
-    iter->base.type = &mp_type_polymorph_iter;
+    mp_vfs_fat_ilistdir_it_t *iter = mp_obj_malloc(mp_vfs_fat_ilistdir_it_t, &mp_type_polymorph_iter);
     iter->iternext = mp_vfs_fat_ilistdir_it_iternext;
     iter->is_str = is_str_type;
     FRESULT res = f_opendir(&self->fatfs, &iter->dir, path);

--- a/extmod/vfs_lfsx.c
+++ b/extmod/vfs_lfsx.c
@@ -203,8 +203,7 @@ STATIC mp_obj_t MP_VFS_LFSx(ilistdir_func)(size_t n_args, const mp_obj_t *args) 
         path = vstr_null_terminated_str(&self->cur_dir);
     }
 
-    MP_VFS_LFSx(ilistdir_it_t) * iter = m_new_obj(MP_VFS_LFSx(ilistdir_it_t));
-    iter->base.type = &mp_type_polymorph_iter;
+    MP_VFS_LFSx(ilistdir_it_t) * iter = mp_obj_malloc(MP_VFS_LFSx(ilistdir_it_t), &mp_type_polymorph_iter);
     iter->iternext = MP_VFS_LFSx(ilistdir_it_iternext);
     iter->is_str = is_str_type;
     iter->vfs = self;

--- a/extmod/vfs_posix.c
+++ b/extmod/vfs_posix.c
@@ -98,8 +98,7 @@ STATIC mp_import_stat_t mp_vfs_posix_import_stat(void *self_in, const char *path
 STATIC mp_obj_t vfs_posix_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *args) {
     mp_arg_check_num(n_args, n_kw, 0, 1, false);
 
-    mp_obj_vfs_posix_t *vfs = m_new_obj(mp_obj_vfs_posix_t);
-    vfs->base.type = type;
+    mp_obj_vfs_posix_t *vfs = mp_obj_malloc(mp_obj_vfs_posix_t, type);
     vstr_init(&vfs->root, 0);
     if (n_args == 1) {
         vstr_add_str(&vfs->root, mp_obj_str_get_str(args[0]));
@@ -229,8 +228,7 @@ STATIC mp_obj_t vfs_posix_ilistdir_it_iternext(mp_obj_t self_in) {
 
 STATIC mp_obj_t vfs_posix_ilistdir(mp_obj_t self_in, mp_obj_t path_in) {
     mp_obj_vfs_posix_t *self = MP_OBJ_TO_PTR(self_in);
-    vfs_posix_ilistdir_it_t *iter = m_new_obj(vfs_posix_ilistdir_it_t);
-    iter->base.type = &mp_type_polymorph_iter;
+    vfs_posix_ilistdir_it_t *iter = mp_obj_malloc(vfs_posix_ilistdir_it_t, &mp_type_polymorph_iter);
     iter->iternext = vfs_posix_ilistdir_it_iternext;
     iter->is_str = mp_obj_get_type(path_in) == &mp_type_str;
     const char *path = vfs_posix_get_path_str(self, path_in);

--- a/ports/cc3200/misc/mpirq.c
+++ b/ports/cc3200/misc/mpirq.c
@@ -62,8 +62,7 @@ void mp_irq_init0 (void) {
 }
 
 mp_obj_t mp_irq_new (mp_obj_t parent, mp_obj_t handler, const mp_irq_methods_t *methods) {
-    mp_irq_obj_t *self = m_new_obj(mp_irq_obj_t);
-    self->base.type = &mp_irq_type;
+    mp_irq_obj_t *self = mp_obj_malloc(mp_irq_obj_t, &mp_irq_type);
     self->handler = handler;
     self->parent = parent;
     self->methods = (mp_irq_methods_t *)methods;

--- a/ports/cc3200/mods/pybsleep.c
+++ b/ports/cc3200/mods/pybsleep.c
@@ -210,8 +210,7 @@ void pyb_sleep_signal_soft_reset (void) {
 }
 
 void pyb_sleep_add (const mp_obj_t obj, WakeUpCB_t wakeup) {
-    pyb_sleep_obj_t *sleep_obj = m_new_obj(pyb_sleep_obj_t);
-    sleep_obj->base.type = &pyb_sleep_type;
+    pyb_sleep_obj_t *sleep_obj = mp_obj_malloc(pyb_sleep_obj_t, &pyb_sleep_type);
     sleep_obj->obj = obj;
     sleep_obj->wakeup = wakeup;
     // remove it in case it was already registered

--- a/ports/cc3200/mods/pybtimer.c
+++ b/ports/cc3200/mods/pybtimer.c
@@ -406,8 +406,7 @@ STATIC mp_obj_t pyb_timer_channel(size_t n_args, const mp_obj_t *pos_args, mp_ma
     }
 
     // allocate a new timer channel
-    pyb_timer_channel_obj_t *ch = m_new_obj(pyb_timer_channel_obj_t);
-    ch->base.type = &pyb_timer_channel_type;
+    pyb_timer_channel_obj_t *ch = mp_obj_malloc(pyb_timer_channel_obj_t, &pyb_timer_channel_type);
     ch->timer = tim;
     ch->channel = channel_n;
 

--- a/ports/esp32/esp32_nvs.c
+++ b/ports/esp32/esp32_nvs.c
@@ -44,8 +44,7 @@ typedef struct _esp32_nvs_obj_t {
 
 // *esp32_nvs_new allocates a python NVS object given a handle to an esp-idf namespace C obj.
 STATIC esp32_nvs_obj_t *esp32_nvs_new(nvs_handle_t namespace) {
-    esp32_nvs_obj_t *self = m_new_obj(esp32_nvs_obj_t);
-    self->base.type = &esp32_nvs_type;
+    esp32_nvs_obj_t *self = mp_obj_malloc(esp32_nvs_obj_t, &esp32_nvs_type);
     self->namespace = namespace;
     return self;
 }

--- a/ports/esp32/esp32_partition.c
+++ b/ports/esp32/esp32_partition.c
@@ -57,8 +57,7 @@ STATIC esp32_partition_obj_t *esp32_partition_new(const esp_partition_t *part, u
     if (part == NULL) {
         mp_raise_OSError(MP_ENOENT);
     }
-    esp32_partition_obj_t *self = m_new_obj(esp32_partition_obj_t);
-    self->base.type = &esp32_partition_type;
+    esp32_partition_obj_t *self = mp_obj_malloc(esp32_partition_obj_t, &esp32_partition_type);
     self->part = part;
     self->block_size = block_size;
     if (self->block_size < NATIVE_BLOCK_SIZE_BYTES) {

--- a/ports/esp32/machine_i2s.c
+++ b/ports/esp32/machine_i2s.c
@@ -533,9 +533,8 @@ STATIC mp_obj_t machine_i2s_make_new(const mp_obj_type_t *type, size_t n_pos_arg
 
     machine_i2s_obj_t *self;
     if (MP_STATE_PORT(machine_i2s_obj)[port] == NULL) {
-        self = m_new_obj(machine_i2s_obj_t);
+        self = mp_obj_malloc(machine_i2s_obj_t, &machine_i2s_type);
         MP_STATE_PORT(machine_i2s_obj)[port] = self;
-        self->base.type = &machine_i2s_type;
         self->port = port;
     } else {
         self = MP_STATE_PORT(machine_i2s_obj)[port];

--- a/ports/esp32/machine_pwm.c
+++ b/ports/esp32/machine_pwm.c
@@ -556,8 +556,7 @@ STATIC mp_obj_t mp_machine_pwm_make_new(const mp_obj_type_t *type,
     gpio_num_t pin_id = machine_pin_get_id(args[0]);
 
     // create PWM object from the given pin
-    machine_pwm_obj_t *self = m_new_obj(machine_pwm_obj_t);
-    self->base.type = &machine_pwm_type;
+    machine_pwm_obj_t *self = mp_obj_malloc(machine_pwm_obj_t, &machine_pwm_type);
     self->pin = pin_id;
     self->active = false;
     self->mode = -1;

--- a/ports/esp32/machine_timer.c
+++ b/ports/esp32/machine_timer.c
@@ -105,8 +105,7 @@ STATIC mp_obj_t machine_timer_make_new(const mp_obj_type_t *type, size_t n_args,
         }
     }
 
-    machine_timer_obj_t *self = m_new_obj(machine_timer_obj_t);
-    self->base.type = &machine_timer_type;
+    machine_timer_obj_t *self = mp_obj_malloc(machine_timer_obj_t, &machine_timer_type);
     self->group = group;
     self->index = index;
 

--- a/ports/esp32/machine_uart.c
+++ b/ports/esp32/machine_uart.c
@@ -315,8 +315,7 @@ STATIC mp_obj_t machine_uart_make_new(const mp_obj_type_t *type, size_t n_args, 
     };
 
     // create instance
-    machine_uart_obj_t *self = m_new_obj(machine_uart_obj_t);
-    self->base.type = &machine_uart_type;
+    machine_uart_obj_t *self = mp_obj_malloc(machine_uart_obj_t, &machine_uart_type);
     self->uart_num = uart_num;
     self->bits = 8;
     self->parity = 0;

--- a/ports/esp8266/machine_hspi.c
+++ b/ports/esp8266/machine_hspi.c
@@ -159,8 +159,7 @@ mp_obj_t machine_hspi_make_new(const mp_obj_type_t *type, size_t n_args, size_t 
         mp_raise_ValueError(NULL);
     }
 
-    machine_hspi_obj_t *self = m_new_obj(machine_hspi_obj_t);
-    self->base.type = &machine_hspi_type;
+    machine_hspi_obj_t *self = mp_obj_malloc(machine_hspi_obj_t, &machine_hspi_type);
     // set defaults
     self->baudrate = 80000000L;
     self->polarity = 0;

--- a/ports/esp8266/machine_pwm.c
+++ b/ports/esp8266/machine_pwm.c
@@ -82,8 +82,7 @@ STATIC mp_obj_t mp_machine_pwm_make_new(const mp_obj_type_t *type, size_t n_args
     pyb_pin_obj_t *pin = mp_obj_get_pin_obj(args[0]);
 
     // create PWM object from the given pin
-    machine_pwm_obj_t *self = m_new_obj(machine_pwm_obj_t);
-    self->base.type = &machine_pwm_type;
+    machine_pwm_obj_t *self = mp_obj_malloc(machine_pwm_obj_t, &machine_pwm_type);
     self->pin = pin;
     self->active = 0;
     self->channel = -1;

--- a/ports/esp8266/machine_uart.c
+++ b/ports/esp8266/machine_uart.c
@@ -202,8 +202,7 @@ STATIC mp_obj_t pyb_uart_make_new(const mp_obj_type_t *type, size_t n_args, size
     }
 
     // create instance
-    pyb_uart_obj_t *self = m_new_obj(pyb_uart_obj_t);
-    self->base.type = &pyb_uart_type;
+    pyb_uart_obj_t *self = mp_obj_malloc(pyb_uart_obj_t, &pyb_uart_type);
     self->uart_id = uart_id;
     self->baudrate = 115200;
     self->bits = 8;

--- a/ports/esp8266/modmachine.c
+++ b/ports/esp8266/modmachine.c
@@ -229,8 +229,7 @@ STATIC void esp_timer_print(const mp_print_t *print, mp_obj_t self_in, mp_print_
 
 STATIC mp_obj_t esp_timer_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *args) {
     mp_arg_check_num(n_args, n_kw, 1, 1, false);
-    esp_timer_obj_t *tim = m_new_obj(esp_timer_obj_t);
-    tim->base.type = &esp_timer_type;
+    esp_timer_obj_t *tim = mp_obj_malloc(esp_timer_obj_t, &esp_timer_type);
     return tim;
 }
 

--- a/ports/mimxrt/machine_adc.c
+++ b/ports/mimxrt/machine_adc.c
@@ -80,8 +80,7 @@ STATIC mp_obj_t adc_obj_make_new(const mp_obj_type_t *type, size_t n_args, size_
     ADC_SetChannelConfig(adc_instance, 0UL, &channel_config);  // NOTE: we always choose channel group '0' since we only perform software triggered conversion
 
     // Create ADC Instance
-    machine_adc_obj_t *o = m_new_obj(machine_adc_obj_t);
-    o->base.type = &machine_adc_type;
+    machine_adc_obj_t *o = mp_obj_malloc(machine_adc_obj_t, &machine_adc_type);
     o->adc = adc_instance;
     o->channel = (uint8_t)channel;
     o->channel_group = 0;

--- a/ports/mimxrt/machine_i2c.c
+++ b/ports/mimxrt/machine_i2c.c
@@ -113,8 +113,7 @@ mp_obj_t machine_i2c_make_new(const mp_obj_type_t *type, size_t n_args, size_t n
     }
 
     // Get I2C Object.
-    machine_i2c_obj_t *self = m_new_obj(machine_i2c_obj_t);
-    self->base.type = &machine_i2c_type;
+    machine_i2c_obj_t *self = mp_obj_malloc(machine_i2c_obj_t, &machine_i2c_type);
     self->i2c_id = i2c_id;
     self->i2c_hw_id = i2c_index_table[i2c_id];  // the hw i2c number 1..n
     self->i2c_inst = i2c_base_ptr_table[self->i2c_hw_id];

--- a/ports/mimxrt/machine_i2s.c
+++ b/ports/mimxrt/machine_i2s.c
@@ -953,9 +953,8 @@ STATIC mp_obj_t machine_i2s_make_new(const mp_obj_type_t *type, size_t n_pos_arg
 
     machine_i2s_obj_t *self;
     if (MP_STATE_PORT(machine_i2s_obj)[i2s_id_zero_base] == NULL) {
-        self = m_new_obj(machine_i2s_obj_t);
+        self = mp_obj_malloc(machine_i2s_obj_t, &machine_i2s_type);
         MP_STATE_PORT(machine_i2s_obj)[i2s_id_zero_base] = self;
-        self->base.type = &machine_i2s_type;
         self->i2s_id = i2s_id;
         self->edmaTcd = &edmaTcd[i2s_id_zero_base];
     } else {

--- a/ports/mimxrt/machine_pwm.c
+++ b/ports/mimxrt/machine_pwm.c
@@ -494,8 +494,7 @@ STATIC mp_obj_t mp_machine_pwm_make_new(const mp_obj_type_t *type, size_t n_args
     }
 
     // Create and populate the PWM object.
-    machine_pwm_obj_t *self = m_new_obj(machine_pwm_obj_t);
-    self->base.type = &machine_pwm_type;
+    machine_pwm_obj_t *self = mp_obj_malloc(machine_pwm_obj_t, &machine_pwm_type);
     self->is_flexpwm = is_flexpwm;
     self->instance = af_obj1->instance;
     self->module = module;

--- a/ports/mimxrt/machine_spi.c
+++ b/ports/mimxrt/machine_spi.c
@@ -153,8 +153,7 @@ mp_obj_t machine_spi_make_new(const mp_obj_type_t *type, size_t n_args, size_t n
 
     // Get peripheral object.
     uint8_t spi_hw_id = spi_index_table[spi_id];  // the hw spi number 1..n
-    machine_spi_obj_t *self = m_new_obj(machine_spi_obj_t);
-    self->base.type = &machine_spi_type;
+    machine_spi_obj_t *self = mp_obj_malloc(machine_spi_obj_t, &machine_spi_type);
     self->spi_id = spi_id;
     self->spi_inst = spi_base_ptr_table[spi_hw_id];
     self->spi_hw_id = spi_hw_id;

--- a/ports/mimxrt/machine_uart.c
+++ b/ports/mimxrt/machine_uart.c
@@ -277,8 +277,7 @@ STATIC mp_obj_t machine_uart_make_new(const mp_obj_type_t *type, size_t n_args, 
 
     // Create the UART object and fill it with defaults.
     uint8_t uart_hw_id = uart_index_table[uart_id];  // the hw uart number 1..n
-    machine_uart_obj_t *self = m_new_obj(machine_uart_obj_t);
-    self->base.type = &machine_uart_type;
+    machine_uart_obj_t *self = mp_obj_malloc(machine_uart_obj_t, &machine_uart_type);
     self->id = uart_id;
     self->lpuart = uart_base_ptr_table[uart_hw_id];
     self->invert = false;

--- a/ports/nrf/boards/microbit/modules/iters.c
+++ b/ports/nrf/boards/microbit/modules/iters.c
@@ -60,8 +60,7 @@ const mp_obj_type_t microbit_repeat_iterator_type = {
 };
 
 mp_obj_t microbit_repeat_iterator(mp_obj_t iterable) {
-    repeat_iterator_t *result = m_new_obj(repeat_iterator_t);
-    result->base.type = &microbit_repeat_iterator_type;
+    repeat_iterator_t *result = mp_obj_malloc(repeat_iterator_t, &microbit_repeat_iterator_type);
     result->iterable = iterable;
     result->index = -1;
     return result;

--- a/ports/nrf/boards/microbit/modules/microbitimage.c
+++ b/ports/nrf/boards/microbit/modules/microbitimage.c
@@ -113,8 +113,7 @@ mp_int_t imageHeight(microbit_image_obj_t * p_image) {
 }
 
 STATIC greyscale_t *greyscale_new(mp_int_t w, mp_int_t h) {
-    greyscale_t *result = m_new_obj_var(greyscale_t, uint8_t, (w*h+1)>>1);
-    result->base.type = &microbit_image_type;
+    greyscale_t *result = mp_obj_malloc_var(greyscale_t, uint8_t, (w*h+1)>>1, &microbit_image_type);
     result->five = 0;
     result->width = w;
     result->height = h;
@@ -722,8 +721,7 @@ extern const mp_obj_type_t microbit_scrolling_string_type;
 extern const mp_obj_type_t microbit_scrolling_string_iterator_type;
 
 mp_obj_t scrolling_string_image_iterable(const char* str, mp_uint_t len, mp_obj_t ref, bool monospace, bool repeat) {
-    scrolling_string_t *result = m_new_obj(scrolling_string_t);
-    result->base.type = &microbit_scrolling_string_type;
+    scrolling_string_t *result = mp_obj_malloc(scrolling_string_t, &microbit_scrolling_string_type);
     result->str = str;
     result->len = len;
     result->ref = ref;
@@ -771,8 +769,7 @@ static void restart(scrolling_string_iterator_t *iter) {
 STATIC mp_obj_t get_microbit_scrolling_string_iter(mp_obj_t o_in, mp_obj_iter_buf_t *iter_buf) {
     (void)iter_buf;
     scrolling_string_t *str = (scrolling_string_t *)o_in;
-    scrolling_string_iterator_t *result = m_new_obj(scrolling_string_iterator_t);
-    result->base.type = &microbit_scrolling_string_iterator_type;
+    scrolling_string_iterator_t *result = mp_obj_malloc(scrolling_string_iterator_t, &microbit_scrolling_string_iterator_type);
     result->img = greyscale_new(5,5);
     result->start = str->str;
     result->ref = str->ref;
@@ -923,8 +920,7 @@ typedef struct _facade_iterator_t {
 } facade_iterator_t;
 
 mp_obj_t microbit_string_facade(mp_obj_t string) {
-    string_image_facade_t *result = m_new_obj(string_image_facade_t);
-    result->base.type = &string_image_facade_type;
+    string_image_facade_t *result = mp_obj_malloc(string_image_facade_t, &string_image_facade_type);
     result->string = string;
     result->image = greyscale_new(5,5);
     return result;

--- a/ports/nrf/modules/machine/temp.c
+++ b/ports/nrf/modules/machine/temp.c
@@ -70,9 +70,7 @@ STATIC mp_obj_t machine_temp_make_new(const mp_obj_type_t *type, size_t n_args, 
     mp_arg_val_t args[MP_ARRAY_SIZE(allowed_args)];
     mp_arg_parse_all_kw_array(n_args, n_kw, all_args, MP_ARRAY_SIZE(allowed_args), allowed_args, args);
 
-    machine_temp_obj_t *self = m_new_obj(machine_temp_obj_t);
-
-    self->base.type = &machine_temp_type;
+    machine_temp_obj_t *self = mp_obj_malloc(machine_temp_obj_t, &machine_temp_type);
 
     return MP_OBJ_FROM_PTR(self);
 }

--- a/ports/nrf/modules/nrf/flashbdev.c
+++ b/ports/nrf/modules/nrf/flashbdev.c
@@ -165,8 +165,7 @@ STATIC mp_obj_t nrf_flashbdev_make_new(const mp_obj_type_t *type, size_t n_args,
         return MP_OBJ_FROM_PTR(&nrf_flash_obj);
     }
 
-    nrf_flash_obj_t *self = m_new_obj(nrf_flash_obj_t);
-    self->base.type = &nrf_flashbdev_type;
+    nrf_flash_obj_t *self = mp_obj_malloc(nrf_flash_obj_t, &nrf_flashbdev_type);
 
     mp_int_t start = args[ARG_start].u_int;
     mp_int_t len = args[ARG_len].u_int;

--- a/ports/nrf/modules/ubluepy/ubluepy_characteristic.c
+++ b/ports/nrf/modules/ubluepy/ubluepy_characteristic.c
@@ -50,8 +50,7 @@ STATIC mp_obj_t ubluepy_characteristic_make_new(const mp_obj_type_t *type, size_
     mp_arg_val_t args[MP_ARRAY_SIZE(allowed_args)];
     mp_arg_parse_all_kw_array(n_args, n_kw, all_args, MP_ARRAY_SIZE(allowed_args), allowed_args, args);
 
-    ubluepy_characteristic_obj_t *s = m_new_obj(ubluepy_characteristic_obj_t);
-    s->base.type = type;
+    ubluepy_characteristic_obj_t *s = mp_obj_malloc(ubluepy_characteristic_obj_t, type);
 
     mp_obj_t uuid_obj = args[0].u_obj;
 

--- a/ports/nrf/modules/ubluepy/ubluepy_delegate.c
+++ b/ports/nrf/modules/ubluepy/ubluepy_delegate.c
@@ -38,8 +38,7 @@ STATIC void ubluepy_delegate_print(const mp_print_t *print, mp_obj_t o, mp_print
 }
 
 STATIC mp_obj_t ubluepy_delegate_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *all_args) {
-    ubluepy_delegate_obj_t *s = m_new_obj(ubluepy_delegate_obj_t);
-    s->base.type = type;
+    ubluepy_delegate_obj_t *s = mp_obj_malloc(ubluepy_delegate_obj_t, type);
 
     return MP_OBJ_FROM_PTR(s);
 }

--- a/ports/nrf/modules/ubluepy/ubluepy_descriptor.c
+++ b/ports/nrf/modules/ubluepy/ubluepy_descriptor.c
@@ -53,8 +53,7 @@ STATIC mp_obj_t ubluepy_descriptor_make_new(const mp_obj_type_t *type, size_t n_
     mp_arg_val_t args[MP_ARRAY_SIZE(allowed_args)];
     mp_arg_parse_all_kw_array(n_args, n_kw, all_args, MP_ARRAY_SIZE(allowed_args), allowed_args, args);
 
-    ubluepy_descriptor_obj_t * s = m_new_obj(ubluepy_descriptor_obj_t);
-    s->base.type = type;
+    ubluepy_descriptor_obj_t * s = mp_obj_malloc(ubluepy_descriptor_obj_t, type);
 
     mp_obj_t uuid_obj = args[ARG_NEW_UUID].u_obj;
 

--- a/ports/nrf/modules/ubluepy/ubluepy_peripheral.c
+++ b/ports/nrf/modules/ubluepy/ubluepy_peripheral.c
@@ -114,8 +114,7 @@ STATIC mp_obj_t ubluepy_peripheral_make_new(const mp_obj_type_t *type, size_t n_
     mp_arg_val_t args[MP_ARRAY_SIZE(allowed_args)];
     mp_arg_parse_all_kw_array(n_args, n_kw, all_args, MP_ARRAY_SIZE(allowed_args), allowed_args, args);
 
-    ubluepy_peripheral_obj_t *s = m_new_obj(ubluepy_peripheral_obj_t);
-    s->base.type = type;
+    ubluepy_peripheral_obj_t *s = mp_obj_malloc(ubluepy_peripheral_obj_t, type);
 
     s->delegate      = mp_const_none;
     s->conn_handler  = mp_const_none;
@@ -291,11 +290,9 @@ STATIC MP_DEFINE_CONST_FUN_OBJ_1(ubluepy_peripheral_get_services_obj, peripheral
 #if MICROPY_PY_UBLUEPY_CENTRAL
 
 void static disc_add_service(mp_obj_t self, ble_drv_service_data_t * p_service_data) {
-    ubluepy_service_obj_t * p_service = m_new_obj(ubluepy_service_obj_t);
-    p_service->base.type = &ubluepy_service_type;
+    ubluepy_service_obj_t * p_service = mp_obj_malloc(ubluepy_service_obj_t, &ubluepy_service_type);
 
-    ubluepy_uuid_obj_t * p_uuid = m_new_obj(ubluepy_uuid_obj_t);
-    p_uuid->base.type = &ubluepy_uuid_type;
+    ubluepy_uuid_obj_t * p_uuid = mp_obj_malloc(ubluepy_uuid_obj_t, &ubluepy_uuid_type);
 
     p_service->p_uuid = p_uuid;
 
@@ -314,11 +311,9 @@ void static disc_add_service(mp_obj_t self, ble_drv_service_data_t * p_service_d
 
 void static disc_add_char(mp_obj_t service_in, ble_drv_char_data_t * p_desc_data) {
     ubluepy_service_obj_t        * p_service   = MP_OBJ_TO_PTR(service_in);
-    ubluepy_characteristic_obj_t * p_char = m_new_obj(ubluepy_characteristic_obj_t);
-    p_char->base.type = &ubluepy_characteristic_type;
+    ubluepy_characteristic_obj_t * p_char = mp_obj_malloc(ubluepy_characteristic_obj_t, &ubluepy_characteristic_type);
 
-    ubluepy_uuid_obj_t * p_uuid = m_new_obj(ubluepy_uuid_obj_t);
-    p_uuid->base.type = &ubluepy_uuid_type;
+    ubluepy_uuid_obj_t * p_uuid = mp_obj_malloc(ubluepy_uuid_obj_t, &ubluepy_uuid_type);
 
     p_char->p_uuid = p_uuid;
 

--- a/ports/nrf/modules/ubluepy/ubluepy_scanner.c
+++ b/ports/nrf/modules/ubluepy/ubluepy_scanner.c
@@ -38,8 +38,7 @@
 STATIC void adv_event_handler(mp_obj_t self_in, uint16_t event_id, ble_drv_adv_data_t * data) {
     ubluepy_scanner_obj_t *self = MP_OBJ_TO_PTR(self_in);
 
-    ubluepy_scan_entry_obj_t * item = m_new_obj(ubluepy_scan_entry_obj_t);
-    item->base.type = &ubluepy_scan_entry_type;
+    ubluepy_scan_entry_obj_t * item = mp_obj_malloc(ubluepy_scan_entry_obj_t, &ubluepy_scan_entry_type);
 
     vstr_t vstr;
     vstr_init(&vstr, 17);
@@ -78,8 +77,7 @@ STATIC mp_obj_t ubluepy_scanner_make_new(const mp_obj_type_t *type, size_t n_arg
     mp_arg_val_t args[MP_ARRAY_SIZE(allowed_args)];
     mp_arg_parse_all_kw_array(n_args, n_kw, all_args, MP_ARRAY_SIZE(allowed_args), allowed_args, args);
 
-    ubluepy_scanner_obj_t * s = m_new_obj(ubluepy_scanner_obj_t);
-    s->base.type = type;
+    ubluepy_scanner_obj_t * s = mp_obj_malloc(ubluepy_scanner_obj_t, type);
 
     return MP_OBJ_FROM_PTR(s);
 }

--- a/ports/nrf/modules/ubluepy/ubluepy_service.c
+++ b/ports/nrf/modules/ubluepy/ubluepy_service.c
@@ -52,8 +52,7 @@ STATIC mp_obj_t ubluepy_service_make_new(const mp_obj_type_t *type, size_t n_arg
     mp_arg_val_t args[MP_ARRAY_SIZE(allowed_args)];
     mp_arg_parse_all_kw_array(n_args, n_kw, all_args, MP_ARRAY_SIZE(allowed_args), allowed_args, args);
 
-    ubluepy_service_obj_t *s = m_new_obj(ubluepy_service_obj_t);
-    s->base.type = type;
+    ubluepy_service_obj_t *s = mp_obj_malloc(ubluepy_service_obj_t, type);
 
     mp_obj_t uuid_obj = args[ARG_NEW_UUID].u_obj;
 

--- a/ports/nrf/modules/ubluepy/ubluepy_uuid.c
+++ b/ports/nrf/modules/ubluepy/ubluepy_uuid.c
@@ -57,8 +57,7 @@ STATIC mp_obj_t ubluepy_uuid_make_new(const mp_obj_type_t *type, size_t n_args, 
     mp_arg_val_t args[MP_ARRAY_SIZE(allowed_args)];
     mp_arg_parse_all_kw_array(n_args, n_kw, all_args, MP_ARRAY_SIZE(allowed_args), allowed_args, args);
 
-    ubluepy_uuid_obj_t *s = m_new_obj(ubluepy_uuid_obj_t);
-    s->base.type = type;
+    ubluepy_uuid_obj_t *s = mp_obj_malloc(ubluepy_uuid_obj_t, type);
 
     mp_obj_t uuid_obj = args[ARG_NEW_UUID].u_obj;
 

--- a/ports/nrf/modules/uos/microbitfs.c
+++ b/ports/nrf/modules/uos/microbitfs.c
@@ -360,12 +360,7 @@ STATIC file_descriptor_obj *microbit_file_open(const char *name, size_t name_len
 }
 
 STATIC file_descriptor_obj *microbit_file_descriptor_new(uint8_t start_chunk, bool write, bool binary) {
-    file_descriptor_obj *res = m_new_obj(file_descriptor_obj);
-    if (binary) {
-        res->base.type = &uos_mbfs_fileio_type;
-    } else {
-        res->base.type = &uos_mbfs_textio_type;
-    }
+    file_descriptor_obj *res = m_new_obj(file_descriptor_obj, binary ? &uos_mbfs_fileio_type : &uos_mbfs_textio_type);
     res->start_chunk = start_chunk;
     res->seek_chunk = start_chunk;
     res->seek_offset = file_system_chunks[start_chunk].header.name_len+2;
@@ -595,8 +590,7 @@ STATIC mp_obj_t uos_mbfs_ilistdir_it_iternext(mp_obj_t self_in) {
 }
 
 STATIC mp_obj_t uos_mbfs_ilistdir(void) {
-    uos_mbfs_ilistdir_it_t *iter = m_new_obj(uos_mbfs_ilistdir_it_t);
-    iter->base.type = &mp_type_polymorph_iter;
+    uos_mbfs_ilistdir_it_t *iter = mp_obj_malloc(uos_mbfs_ilistdir_it_t, &mp_type_polymorph_iter);
     iter->iternext = uos_mbfs_ilistdir_it_iternext;
     iter->index = 1;
 

--- a/ports/renesas-ra/extint.c
+++ b/ports/renesas-ra/extint.c
@@ -352,9 +352,8 @@ STATIC mp_obj_t extint_make_new(const mp_obj_type_t *type, size_t n_args, size_t
     mp_arg_val_t vals[PYB_EXTINT_MAKE_NEW_NUM_ARGS];
     mp_arg_parse_all_kw_array(n_args, n_kw, args, PYB_EXTINT_MAKE_NEW_NUM_ARGS, pyb_extint_make_new_args, vals);
 
-    extint_obj_t *self = m_new_obj(extint_obj_t);
+    extint_obj_t *self = mp_obj_malloc(extint_obj_t, type);
     machine_pin_obj_t *pin = vals[0].u_obj;
-    self->base.type = type;
     self->pin_idx = pin->pin;
     self->irq_no = extint_register(vals[0].u_obj, vals[1].u_int, vals[2].u_int, vals[3].u_obj, false);
 

--- a/ports/renesas-ra/machine_adc.c
+++ b/ports/renesas-ra/machine_adc.c
@@ -88,8 +88,7 @@ STATIC mp_obj_t machine_adc_make_new(const mp_obj_type_t *type, size_t n_args, s
         pin = pin_obj->pin;
     }
     ra_adc_init();
-    machine_adc_obj_t *o = m_new_obj(machine_adc_obj_t);
-    o->base.type = &machine_adc_type;
+    machine_adc_obj_t *o = mp_obj_malloc(machine_adc_obj_t, &machine_adc_type);
     o->adc = (ADC_TypeDef *)NULL;
     o->channel = channel;
     o->pin = pin;

--- a/ports/renesas-ra/storage.c
+++ b/ports/renesas-ra/storage.c
@@ -273,8 +273,7 @@ STATIC mp_obj_t pyb_flash_make_new(const mp_obj_type_t *type, size_t n_args, siz
         return MP_OBJ_FROM_PTR(&pyb_flash_obj);
     }
 
-    pyb_flash_obj_t *self = m_new_obj(pyb_flash_obj_t);
-    self->base.type = &pyb_flash_type;
+    pyb_flash_obj_t *self = mp_obj_malloc(pyb_flash_obj_t, &pyb_flash_type);
 
     uint32_t bl_len = (storage_get_block_count() - FLASH_PART1_START_BLOCK) * FLASH_BLOCK_SIZE;
 

--- a/ports/rp2/machine_adc.c
+++ b/ports/rp2/machine_adc.c
@@ -93,8 +93,7 @@ STATIC mp_obj_t machine_adc_make_new(const mp_obj_type_t *type, size_t n_args, s
     }
 
     // Create ADC object.
-    machine_adc_obj_t *o = m_new_obj(machine_adc_obj_t);
-    o->base.type = &machine_adc_type;
+    machine_adc_obj_t *o = mp_obj_malloc(machine_adc_obj_t, &machine_adc_type);
     o->channel = channel;
 
     return MP_OBJ_FROM_PTR(o);

--- a/ports/rp2/machine_i2s.c
+++ b/ports/rp2/machine_i2s.c
@@ -897,9 +897,8 @@ STATIC mp_obj_t machine_i2s_make_new(const mp_obj_type_t *type, size_t n_pos_arg
 
     machine_i2s_obj_t *self;
     if (MP_STATE_PORT(machine_i2s_obj[i2s_id]) == NULL) {
-        self = m_new_obj(machine_i2s_obj_t);
+        self = mp_obj_malloc(machine_i2s_obj_t, &machine_i2s_type);
         MP_STATE_PORT(machine_i2s_obj[i2s_id]) = self;
-        self->base.type = &machine_i2s_type;
         self->i2s_id = i2s_id;
     } else {
         self = MP_STATE_PORT(machine_i2s_obj[i2s_id]);

--- a/ports/stm32/adc.c
+++ b/ports/stm32/adc.c
@@ -842,8 +842,7 @@ STATIC mp_obj_t adc_all_make_new(const mp_obj_type_t *type, size_t n_args, size_
     mp_arg_check_num(n_args, n_kw, 1, 2, false);
 
     // make ADCAll object
-    pyb_adc_all_obj_t *o = m_new_obj(pyb_adc_all_obj_t);
-    o->base.type = &pyb_adc_all_type;
+    pyb_adc_all_obj_t *o = mp_obj_malloc(pyb_adc_all_obj_t, &pyb_adc_all_type);
     mp_int_t res = mp_obj_get_int(args[0]);
     uint32_t en_mask = 0xffffffff;
     if (n_args > 1) {

--- a/ports/stm32/extint.c
+++ b/ports/stm32/extint.c
@@ -627,8 +627,7 @@ STATIC mp_obj_t extint_make_new(const mp_obj_type_t *type, size_t n_args, size_t
     mp_arg_val_t vals[PYB_EXTINT_MAKE_NEW_NUM_ARGS];
     mp_arg_parse_all_kw_array(n_args, n_kw, args, PYB_EXTINT_MAKE_NEW_NUM_ARGS, pyb_extint_make_new_args, vals);
 
-    extint_obj_t *self = m_new_obj(extint_obj_t);
-    self->base.type = type;
+    extint_obj_t *self = mp_obj_malloc(extint_obj_t, type);
     self->line = extint_register(vals[0].u_obj, vals[1].u_int, vals[2].u_int, vals[3].u_obj, false);
 
     return MP_OBJ_FROM_PTR(self);

--- a/ports/stm32/lcd.c
+++ b/ports/stm32/lcd.c
@@ -200,8 +200,7 @@ STATIC mp_obj_t pyb_lcd_make_new(const mp_obj_type_t *type, size_t n_args, size_
     const char *lcd_id = mp_obj_str_get_str(args[0]);
 
     // create lcd object
-    pyb_lcd_obj_t *lcd = m_new_obj(pyb_lcd_obj_t);
-    lcd->base.type = &pyb_lcd_type;
+    pyb_lcd_obj_t *lcd = mp_obj_malloc(pyb_lcd_obj_t, &pyb_lcd_type);
 
     // configure pins
     // TODO accept an SPI object and pin objects for full customisation

--- a/ports/stm32/machine_adc.c
+++ b/ports/stm32/machine_adc.c
@@ -461,8 +461,7 @@ STATIC mp_obj_t machine_adc_make_new(const mp_obj_type_t *type, size_t n_args, s
 
     adc_config(adc, 12);
 
-    machine_adc_obj_t *o = m_new_obj(machine_adc_obj_t);
-    o->base.type = &machine_adc_type;
+    machine_adc_obj_t *o = mp_obj_malloc(machine_adc_obj_t, &machine_adc_type);
     o->adc = adc;
     o->channel = channel;
     o->sample_time = sample_time;

--- a/ports/stm32/machine_i2s.c
+++ b/ports/stm32/machine_i2s.c
@@ -859,9 +859,8 @@ STATIC mp_obj_t machine_i2s_make_new(const mp_obj_type_t *type, size_t n_pos_arg
 
     machine_i2s_obj_t *self;
     if (MP_STATE_PORT(machine_i2s_obj)[i2s_id_zero_base] == NULL) {
-        self = m_new_obj(machine_i2s_obj_t);
+        self = mp_obj_malloc(machine_i2s_obj_t, &machine_i2s_type);
         MP_STATE_PORT(machine_i2s_obj)[i2s_id_zero_base] = self;
-        self->base.type = &machine_i2s_type;
         self->i2s_id = i2s_id;
     } else {
         self = MP_STATE_PORT(machine_i2s_obj)[i2s_id_zero_base];

--- a/ports/stm32/pyb_can.c
+++ b/ports/stm32/pyb_can.c
@@ -323,8 +323,7 @@ STATIC mp_obj_t pyb_can_make_new(const mp_obj_type_t *type, size_t n_args, size_
 
     pyb_can_obj_t *self;
     if (MP_STATE_PORT(pyb_can_obj_all)[can_idx - 1] == NULL) {
-        self = m_new_obj(pyb_can_obj_t);
-        self->base.type = &pyb_can_type;
+        self = mp_obj_malloc(pyb_can_obj_t, &pyb_can_type);
         self->can_id = can_idx;
         self->is_enabled = false;
         MP_STATE_PORT(pyb_can_obj_all)[can_idx - 1] = self;

--- a/ports/stm32/storage.c
+++ b/ports/stm32/storage.c
@@ -302,8 +302,7 @@ STATIC mp_obj_t pyb_flash_make_new(const mp_obj_type_t *type, size_t n_args, siz
         return MP_OBJ_FROM_PTR(&pyb_flash_obj);
     }
 
-    pyb_flash_obj_t *self = m_new_obj(pyb_flash_obj_t);
-    self->base.type = &pyb_flash_type;
+    pyb_flash_obj_t *self = mp_obj_malloc(pyb_flash_obj_t, &pyb_flash_type);
     self->use_native_block_size = false;
 
     uint32_t bl_len = (storage_get_block_count() - FLASH_PART1_START_BLOCK) * FLASH_BLOCK_SIZE;

--- a/ports/teensy/servo.c
+++ b/ports/teensy/servo.c
@@ -197,8 +197,7 @@ static const mp_obj_type_t servo_obj_type = {
 
 mp_obj_t pyb_Servo(void) {
     uint16_t mask;
-    pyb_servo_obj_t *self = m_new_obj(pyb_servo_obj_t);
-    self->base.type = &servo_obj_type;
+    pyb_servo_obj_t *self = mp_obj_malloc(pyb_servo_obj_t, &servo_obj_type);
     self->min_usecs = MIN_PULSE_WIDTH;
     self->max_usecs = MAX_PULSE_WIDTH;
 

--- a/ports/teensy/uart.c
+++ b/ports/teensy/uart.c
@@ -314,8 +314,7 @@ STATIC mp_obj_t pyb_uart_make_new(const mp_obj_type_t *type, uint n_args, uint n
     mp_arg_check_num(n_args, n_kw, 1, MP_OBJ_FUN_ARGS_MAX, true);
 
     // create object
-    pyb_uart_obj_t *o = m_new_obj(pyb_uart_obj_t);
-    o->base.type = &pyb_uart_type;
+    pyb_uart_obj_t *o = mp_obj_malloc(pyb_uart_obj_t, &pyb_uart_type);
 
     // work out port
     o->uart_id = 0;

--- a/ports/unix/coverage.c
+++ b/ports/unix/coverage.c
@@ -639,14 +639,12 @@ STATIC mp_obj_t extra_coverage(void) {
 
     mp_printf(&mp_plat_print, "# end coverage.c\n");
 
-    mp_obj_streamtest_t *s = m_new_obj(mp_obj_streamtest_t);
-    s->base.type = &mp_type_stest_fileio;
+    mp_obj_streamtest_t *s = mp_obj_malloc(mp_obj_streamtest_t, &mp_type_stest_fileio);
     s->buf = NULL;
     s->len = 0;
     s->pos = 0;
     s->error_code = 0;
-    mp_obj_streamtest_t *s2 = m_new_obj(mp_obj_streamtest_t);
-    s2->base.type = &mp_type_stest_textio2;
+    mp_obj_streamtest_t *s2 = mp_obj_malloc(mp_obj_streamtest_t, &mp_type_stest_textio2);
 
     // return a tuple of data for testing on the Python side
     mp_obj_t items[] = {(mp_obj_t)&str_no_hash_obj, (mp_obj_t)&bytes_no_hash_obj, MP_OBJ_FROM_PTR(s), MP_OBJ_FROM_PTR(s2)};

--- a/ports/unix/modffi.c
+++ b/ports/unix/modffi.c
@@ -226,8 +226,7 @@ STATIC mp_obj_t make_func(mp_obj_t rettype_in, void *func, mp_obj_t argtypes_in)
     const char *argtypes = mp_obj_str_get_str(argtypes_in);
 
     mp_int_t nparams = MP_OBJ_SMALL_INT_VALUE(mp_obj_len_maybe(argtypes_in));
-    mp_obj_ffifunc_t *o = m_new_obj_var(mp_obj_ffifunc_t, ffi_type *, nparams);
-    o->base.type = &ffifunc_type;
+    mp_obj_ffifunc_t *o = mp_obj_malloc_var(mp_obj_ffifunc_t, ffi_type *, nparams, &ffifunc_type);
 
     o->func = func;
     o->rettype = *rettype;
@@ -334,8 +333,7 @@ STATIC mp_obj_t mod_ffi_callback(size_t n_args, const mp_obj_t *pos_args, mp_map
     const char *rettype = mp_obj_str_get_str(rettype_in);
 
     mp_int_t nparams = MP_OBJ_SMALL_INT_VALUE(mp_obj_len_maybe(paramtypes_in));
-    mp_obj_fficallback_t *o = m_new_obj_var(mp_obj_fficallback_t, ffi_type *, nparams);
-    o->base.type = &fficallback_type;
+    mp_obj_fficallback_t *o = mp_obj_malloc_var(mp_obj_fficallback_t, ffi_type *, nparams, &fficallback_type);
 
     o->clo = ffi_closure_alloc(sizeof(ffi_closure), &o->func);
 
@@ -374,8 +372,7 @@ STATIC mp_obj_t ffimod_var(mp_obj_t self_in, mp_obj_t vartype_in, mp_obj_t symna
     if (sym == NULL) {
         mp_raise_OSError(MP_ENOENT);
     }
-    mp_obj_ffivar_t *o = m_new_obj(mp_obj_ffivar_t);
-    o->base.type = &ffivar_type;
+    mp_obj_ffivar_t *o = mp_obj_malloc(mp_obj_ffivar_t, &ffivar_type);
 
     o->var = sym;
     o->type = *rettype;
@@ -408,8 +405,7 @@ STATIC mp_obj_t ffimod_make_new(const mp_obj_type_t *type, size_t n_args, size_t
     if (mod == NULL) {
         mp_raise_OSError(errno);
     }
-    mp_obj_ffimod_t *o = m_new_obj(mp_obj_ffimod_t);
-    o->base.type = type;
+    mp_obj_ffimod_t *o = mp_obj_malloc(mp_obj_ffimod_t, type);
     o->handle = mod;
     return MP_OBJ_FROM_PTR(o);
 }

--- a/ports/unix/modjni.c
+++ b/ports/unix/modjni.c
@@ -145,8 +145,7 @@ STATIC void jclass_attr(mp_obj_t self_in, qstr attr_in, mp_obj_t *dest) {
         // JJ1(ExceptionDescribe);
         JJ1(ExceptionClear);
 
-        mp_obj_jmethod_t *o = m_new_obj(mp_obj_jmethod_t);
-        o->base.type = &jmethod_type;
+        mp_obj_jmethod_t *o = mp_obj_malloc(mp_obj_jmethod_t, &jmethod_type);
         o->name = attr_in;
         o->meth = NULL;
         o->obj = self->cls;
@@ -183,8 +182,7 @@ STATIC const mp_obj_type_t jclass_type = {
 };
 
 STATIC mp_obj_t new_jclass(jclass jc) {
-    mp_obj_jclass_t *o = m_new_obj(mp_obj_jclass_t);
-    o->base.type = &jclass_type;
+    mp_obj_jclass_t *o = mp_obj_malloc(mp_obj_jclass_t, &jclass_type);
     o->cls = jc;
     return MP_OBJ_FROM_PTR(o);
 }
@@ -223,8 +221,7 @@ STATIC void jobject_attr(mp_obj_t self_in, qstr attr_in, mp_obj_t *dest) {
         // JJ1(ExceptionDescribe);
         JJ1(ExceptionClear);
 
-        mp_obj_jmethod_t *o = m_new_obj(mp_obj_jmethod_t);
-        o->base.type = &jmethod_type;
+        mp_obj_jmethod_t *o = mp_obj_malloc(mp_obj_jmethod_t, &jmethod_type);
         o->name = attr_in;
         o->meth = NULL;
         o->obj = self->obj;
@@ -343,8 +340,7 @@ STATIC mp_obj_t new_jobject(jobject jo) {
     } else if (JJ(IsInstanceOf, jo, Class_class)) {
         return new_jclass(jo);
     } else {
-        mp_obj_jobject_t *o = m_new_obj(mp_obj_jobject_t);
-        o->base.type = &jobject_type;
+        mp_obj_jobject_t *o = mp_obj_malloc(mp_obj_jobject_t, &jobject_type);
         o->obj = jo;
         return MP_OBJ_FROM_PTR(o);
     }
@@ -644,8 +640,7 @@ STATIC mp_obj_t mod_jni_cls(mp_obj_t cls_name_in) {
     }
     jclass cls = JJ(FindClass, cls_name);
 
-    mp_obj_jclass_t *o = m_new_obj(mp_obj_jclass_t);
-    o->base.type = &jclass_type;
+    mp_obj_jclass_t *o = mp_obj_malloc(mp_obj_jclass_t, &jclass_type);
     o->cls = cls;
     return MP_OBJ_FROM_PTR(o);
 }

--- a/ports/unix/moduselect.c
+++ b/ports/unix/moduselect.c
@@ -324,8 +324,7 @@ STATIC mp_obj_t select_poll(size_t n_args, const mp_obj_t *args) {
     if (n_args > 0) {
         alloc = mp_obj_get_int(args[0]);
     }
-    mp_obj_poll_t *poll = m_new_obj(mp_obj_poll_t);
-    poll->base.type = &mp_type_poll;
+    mp_obj_poll_t *poll = mp_obj_malloc(mp_obj_poll_t, &mp_type_poll);
     poll->entries = m_new(struct pollfd, alloc);
     poll->alloc = alloc;
     poll->len = 0;

--- a/ports/unix/modusocket.c
+++ b/ports/unix/modusocket.c
@@ -80,8 +80,7 @@ static inline mp_obj_t mp_obj_from_sockaddr(const struct sockaddr *addr, socklen
 }
 
 STATIC mp_obj_socket_t *socket_new(int fd) {
-    mp_obj_socket_t *o = m_new_obj(mp_obj_socket_t);
-    o->base.type = &mp_type_socket;
+    mp_obj_socket_t *o = mp_obj_malloc(mp_obj_socket_t, &mp_type_socket);
     o->fd = fd;
     o->blocking = true;
     return o;

--- a/ports/zephyr/machine_i2c.c
+++ b/ports/zephyr/machine_i2c.c
@@ -84,9 +84,7 @@ mp_obj_t machine_hard_i2c_make_new(const mp_obj_type_t *type, size_t n_args, siz
         mp_raise_NotImplementedError(MP_ERROR_TEXT("explicit choice of timeout is not implemented"));
     }
 
-    machine_hard_i2c_obj_t *self = m_new_obj(machine_hard_i2c_obj_t);
-
-    self->base.type = &machine_hard_i2c_type;
+    machine_hard_i2c_obj_t *self = mp_obj_malloc(machine_hard_i2c_obj_t, &machine_hard_i2c_type);
     self->dev = dev;
     self->restart = false;
 

--- a/ports/zephyr/machine_spi.c
+++ b/ports/zephyr/machine_spi.c
@@ -106,9 +106,7 @@ mp_obj_t machine_hard_spi_make_new(const mp_obj_type_t *type, size_t n_args, siz
         .cs = NULL
     };
 
-    machine_hard_spi_obj_t *self = m_new_obj(machine_hard_spi_obj_t);
-
-    self->base.type = &machine_hard_spi_type;
+    machine_hard_spi_obj_t *self = mp_obj_malloc(machine_hard_spi_obj_t, &machine_hard_spi_type);
     self->dev = dev;
     self->config = cfg;
 

--- a/ports/zephyr/machine_uart.c
+++ b/ports/zephyr/machine_uart.c
@@ -77,8 +77,7 @@ STATIC mp_obj_t machine_uart_make_new(const mp_obj_type_t *type, size_t n_args, 
     mp_arg_check_num(n_args, n_kw, 1, MP_OBJ_FUN_ARGS_MAX, true);
     GET_STR_DATA_LEN(args[0], name, name_len);
 
-    machine_uart_obj_t *self = m_new_obj(machine_uart_obj_t);
-    self->base.type = &machine_uart_type;
+    machine_uart_obj_t *self = mp_obj_malloc(machine_uart_obj_t, &machine_uart_type);
     self->dev = device_get_binding(name);
     if (!self->dev) {
         mp_raise_ValueError(MP_ERROR_TEXT("Bad device name"));

--- a/ports/zephyr/modzsensor.c
+++ b/ports/zephyr/modzsensor.c
@@ -40,8 +40,7 @@ typedef struct _mp_obj_sensor_t {
 
 STATIC mp_obj_t sensor_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *args) {
     mp_arg_check_num(n_args, n_kw, 1, 1, false);
-    mp_obj_sensor_t *o = m_new_obj(mp_obj_sensor_t);
-    o->base.type = type;
+    mp_obj_sensor_t *o = mp_obj_malloc(mp_obj_sensor_t, type);
     o->dev = device_get_binding(mp_obj_str_get_str(args[0]));
     if (o->dev == NULL) {
         mp_raise_ValueError(MP_ERROR_TEXT("dev not found"));

--- a/ports/zephyr/zephyr_storage.c
+++ b/ports/zephyr/zephyr_storage.c
@@ -54,8 +54,7 @@ STATIC void zephyr_disk_access_print(const mp_print_t *print, mp_obj_t self_in, 
 
 STATIC mp_obj_t zephyr_disk_access_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *args) {
     mp_arg_check_num(n_args, n_kw, 1, 1, false);
-    zephyr_disk_access_obj_t *self = m_new_obj(zephyr_disk_access_obj_t);
-    self->base.type = type;
+    zephyr_disk_access_obj_t *self = mp_obj_malloc(zephyr_disk_access_obj_t, type);
     self->pdrv = mp_obj_str_get_str(args[0]);
 
     if (disk_access_init(self->pdrv) != 0) {
@@ -156,8 +155,7 @@ STATIC void zephyr_flash_area_print(const mp_print_t *print, mp_obj_t self_in, m
 
 STATIC mp_obj_t zephyr_flash_area_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *args) {
     mp_arg_check_num(n_args, n_kw, 2, 2, false);
-    zephyr_flash_area_obj_t *self = m_new_obj(zephyr_flash_area_obj_t);
-    self->base.type = type;
+    zephyr_flash_area_obj_t *self = mp_obj_malloc(zephyr_flash_area_obj_t, type);
     self->id = mp_obj_get_int(args[0]);
     self->block_size = mp_obj_get_int(args[1]);
 

--- a/py/builtinevex.c
+++ b/py/builtinevex.c
@@ -103,8 +103,7 @@ STATIC mp_obj_t mp_builtin_compile(size_t n_args, const mp_obj_t *args) {
             mp_raise_ValueError(MP_ERROR_TEXT("bad compile mode"));
     }
 
-    mp_obj_code_t *code = m_new_obj(mp_obj_code_t);
-    code->base.type = &mp_type_code;
+    mp_obj_code_t *code = mp_obj_malloc(mp_obj_code_t, &mp_type_code);
     code->module_fun = mp_parse_compile_execute(lex, parse_input_kind, NULL, NULL);
     return MP_OBJ_FROM_PTR(code);
 }

--- a/py/dynruntime.h
+++ b/py/dynruntime.h
@@ -126,6 +126,8 @@ static inline void *m_realloc_dyn(void *ptr, size_t new_num_bytes) {
 #define mp_obj_get_array(o, len, items)     (mp_obj_get_array_dyn((o), (len), (items)))
 #define mp_obj_list_append(list, item)      (mp_fun_table.list_append((list), (item)))
 
+#define mp_obj_malloc_helper(n, t)          (mp_obj_malloc_helper_dyn(n, t))
+
 static inline mp_obj_t mp_obj_new_str_of_type_dyn(const mp_obj_type_t *type, const byte *data, size_t len) {
     if (type == &mp_type_str) {
         return mp_obj_new_str((const char *)data, len);
@@ -161,6 +163,12 @@ static inline void *mp_obj_str_get_data_dyn(mp_obj_t o, size_t *l) {
 static inline mp_obj_t mp_obj_len_dyn(mp_obj_t o) {
     // If bytes implemented MP_UNARY_OP_LEN could use: mp_unary_op(MP_UNARY_OP_LEN, o)
     return mp_fun_table.call_function_n_kw(mp_fun_table.load_name(MP_QSTR_len), 1, &o);
+}
+
+static inline void *mp_obj_malloc_helper_dyn(size_t num_bytes, const mp_obj_type_t *type) {
+    mp_obj_base_t *base = (mp_obj_base_t *)m_malloc(num_bytes);
+    base->type = type;
+    return base;
 }
 
 /******************************************************************************/

--- a/py/modio.c
+++ b/py/modio.c
@@ -121,8 +121,7 @@ typedef struct _mp_obj_bufwriter_t {
 STATIC mp_obj_t bufwriter_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *args) {
     mp_arg_check_num(n_args, n_kw, 2, 2, false);
     size_t alloc = mp_obj_get_int(args[1]);
-    mp_obj_bufwriter_t *o = m_new_obj_var(mp_obj_bufwriter_t, byte, alloc);
-    o->base.type = type;
+    mp_obj_bufwriter_t *o = mp_obj_malloc_var(mp_obj_bufwriter_t, byte, alloc, type);
     o->stream = args[0];
     o->alloc = alloc;
     o->len = 0;

--- a/py/modthread.c
+++ b/py/modthread.c
@@ -54,8 +54,7 @@ typedef struct _mp_obj_thread_lock_t {
 } mp_obj_thread_lock_t;
 
 STATIC mp_obj_thread_lock_t *mp_obj_new_thread_lock(void) {
-    mp_obj_thread_lock_t *self = m_new_obj(mp_obj_thread_lock_t);
-    self->base.type = &mp_type_thread_lock;
+    mp_obj_thread_lock_t *self = mp_obj_malloc(mp_obj_thread_lock_t, &mp_type_thread_lock);
     mp_thread_mutex_init(&self->mutex);
     self->locked = false;
     return self;

--- a/py/obj.c
+++ b/py/obj.c
@@ -37,6 +37,13 @@
 #include "py/stackctrl.h"
 #include "py/stream.h" // for mp_obj_print
 
+// Allocates an object and also sets type, for mp_obj_malloc{,_var} macros.
+void *mp_obj_malloc_helper(size_t num_bytes, const mp_obj_type_t *type) {
+    mp_obj_base_t *base = (mp_obj_base_t *)m_malloc(num_bytes);
+    base->type = type;
+    return base;
+}
+
 const mp_obj_type_t *MICROPY_WRAP_MP_OBJ_GET_TYPE(mp_obj_get_type)(mp_const_obj_t o_in) {
     #if MICROPY_OBJ_IMMEDIATE_OBJS && MICROPY_OBJ_REPR == MICROPY_OBJ_REPR_A
 

--- a/py/obj.h
+++ b/py/obj.h
@@ -732,6 +732,12 @@ extern const struct _mp_obj_exception_t mp_const_GeneratorExit_obj;
 
 // General API for objects
 
+// Helper versions of m_new_obj when you need to immediately set base.type.
+// Implementing this as a call rather than inline saves 8 bytes per usage.
+#define mp_obj_malloc(struct_type, obj_type) ((struct_type *)mp_obj_malloc_helper(sizeof(struct_type), obj_type))
+#define mp_obj_malloc_var(struct_type, var_type, var_num, obj_type) ((struct_type *)mp_obj_malloc_helper(sizeof(struct_type) + sizeof(var_type) * (var_num), obj_type))
+void *mp_obj_malloc_helper(size_t num_bytes, const mp_obj_type_t *type);
+
 // These macros are derived from more primitive ones and are used to
 // check for more specific object types.
 // Note: these are kept as macros because inline functions sometimes use much

--- a/py/objarray.c
+++ b/py/objarray.c
@@ -639,8 +639,7 @@ mp_obj_t mp_obj_new_bytearray(size_t n, void *items) {
 
 // Create bytearray which references specified memory area
 mp_obj_t mp_obj_new_bytearray_by_ref(size_t n, void *items) {
-    mp_obj_array_t *o = m_new_obj(mp_obj_array_t);
-    o->base.type = &mp_type_bytearray;
+    mp_obj_array_t *o = mp_obj_malloc(mp_obj_array_t, &mp_type_bytearray);
     o->typecode = BYTEARRAY_TYPECODE;
     o->free = 0;
     o->len = n;

--- a/py/objattrtuple.c
+++ b/py/objattrtuple.c
@@ -71,8 +71,7 @@ STATIC void mp_obj_attrtuple_attr(mp_obj_t self_in, qstr attr, mp_obj_t *dest) {
 }
 
 mp_obj_t mp_obj_new_attrtuple(const qstr *fields, size_t n, const mp_obj_t *items) {
-    mp_obj_tuple_t *o = m_new_obj_var(mp_obj_tuple_t, mp_obj_t, n + 1);
-    o->base.type = &mp_type_attrtuple;
+    mp_obj_tuple_t *o = mp_obj_malloc_var(mp_obj_tuple_t, mp_obj_t, n + 1, &mp_type_attrtuple);
     o->len = n;
     for (size_t i = 0; i < n; i++) {
         o->items[i] = items[i];

--- a/py/objboundmeth.c
+++ b/py/objboundmeth.c
@@ -108,8 +108,7 @@ STATIC const mp_obj_type_t mp_type_bound_meth = {
 };
 
 mp_obj_t mp_obj_new_bound_meth(mp_obj_t meth, mp_obj_t self) {
-    mp_obj_bound_meth_t *o = m_new_obj(mp_obj_bound_meth_t);
-    o->base.type = &mp_type_bound_meth;
+    mp_obj_bound_meth_t *o = mp_obj_malloc(mp_obj_bound_meth_t, &mp_type_bound_meth);
     o->meth = meth;
     o->self = self;
     return MP_OBJ_FROM_PTR(o);

--- a/py/objcell.c
+++ b/py/objcell.c
@@ -64,8 +64,7 @@ STATIC const mp_obj_type_t mp_type_cell = {
 };
 
 mp_obj_t mp_obj_new_cell(mp_obj_t obj) {
-    mp_obj_cell_t *o = m_new_obj(mp_obj_cell_t);
-    o->base.type = &mp_type_cell;
+    mp_obj_cell_t *o = mp_obj_malloc(mp_obj_cell_t, &mp_type_cell);
     o->obj = obj;
     return MP_OBJ_FROM_PTR(o);
 }

--- a/py/objclosure.c
+++ b/py/objclosure.c
@@ -89,8 +89,7 @@ const mp_obj_type_t mp_type_closure = {
 };
 
 mp_obj_t mp_obj_new_closure(mp_obj_t fun, size_t n_closed_over, const mp_obj_t *closed) {
-    mp_obj_closure_t *o = m_new_obj_var(mp_obj_closure_t, mp_obj_t, n_closed_over);
-    o->base.type = &mp_type_closure;
+    mp_obj_closure_t *o = mp_obj_malloc_var(mp_obj_closure_t, mp_obj_t, n_closed_over, &mp_type_closure);
     o->fun = fun;
     o->n_closed = n_closed_over;
     memcpy(o->closed, closed, n_closed_over * sizeof(mp_obj_t));

--- a/py/objcomplex.c
+++ b/py/objcomplex.c
@@ -162,8 +162,7 @@ const mp_obj_type_t mp_type_complex = {
 };
 
 mp_obj_t mp_obj_new_complex(mp_float_t real, mp_float_t imag) {
-    mp_obj_complex_t *o = m_new_obj(mp_obj_complex_t);
-    o->base.type = &mp_type_complex;
+    mp_obj_complex_t *o = mp_obj_malloc(mp_obj_complex_t, &mp_type_complex);
     o->real = real;
     o->imag = imag;
     return MP_OBJ_FROM_PTR(o);

--- a/py/objdeque.c
+++ b/py/objdeque.c
@@ -57,8 +57,7 @@ STATIC mp_obj_t deque_make_new(const mp_obj_type_t *type, size_t n_args, size_t 
         mp_raise_ValueError(NULL);
     }
 
-    mp_obj_deque_t *o = m_new_obj(mp_obj_deque_t);
-    o->base.type = type;
+    mp_obj_deque_t *o = mp_obj_malloc(mp_obj_deque_t, type);
     o->alloc = maxlen + 1;
     o->i_get = o->i_put = 0;
     o->items = m_new0(mp_obj_t, o->alloc);

--- a/py/objdict.c
+++ b/py/objdict.c
@@ -521,8 +521,7 @@ STATIC const mp_obj_type_t mp_type_dict_view = {
 };
 
 STATIC mp_obj_t mp_obj_new_dict_view(mp_obj_t dict, mp_dict_view_kind_t kind) {
-    mp_obj_dict_view_t *o = m_new_obj(mp_obj_dict_view_t);
-    o->base.type = &mp_type_dict_view;
+    mp_obj_dict_view_t *o = mp_obj_malloc(mp_obj_dict_view_t, &mp_type_dict_view);
     o->dict = dict;
     o->kind = kind;
     return MP_OBJ_FROM_PTR(o);

--- a/py/objenumerate.c
+++ b/py/objenumerate.c
@@ -54,14 +54,12 @@ STATIC mp_obj_t enumerate_make_new(const mp_obj_type_t *type, size_t n_args, siz
         MP_ARRAY_SIZE(allowed_args), allowed_args, (mp_arg_val_t *)&arg_vals);
 
     // create enumerate object
-    mp_obj_enumerate_t *o = m_new_obj(mp_obj_enumerate_t);
-    o->base.type = type;
+    mp_obj_enumerate_t *o = mp_obj_malloc(mp_obj_enumerate_t, type);
     o->iter = mp_getiter(arg_vals.iterable.u_obj, NULL);
     o->cur = arg_vals.start.u_int;
     #else
     mp_arg_check_num(n_args, n_kw, 1, 2, false);
-    mp_obj_enumerate_t *o = m_new_obj(mp_obj_enumerate_t);
-    o->base.type = type;
+    mp_obj_enumerate_t *o = mp_obj_malloc(mp_obj_enumerate_t, type);
     o->iter = mp_getiter(args[0], NULL);
     o->cur = n_args > 1 ? mp_obj_get_int(args[1]) : 0;
     #endif

--- a/py/objfilter.c
+++ b/py/objfilter.c
@@ -36,8 +36,7 @@ typedef struct _mp_obj_filter_t {
 
 STATIC mp_obj_t filter_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *args) {
     mp_arg_check_num(n_args, n_kw, 2, 2, false);
-    mp_obj_filter_t *o = m_new_obj(mp_obj_filter_t);
-    o->base.type = type;
+    mp_obj_filter_t *o = mp_obj_malloc(mp_obj_filter_t, type);
     o->fun = args[0];
     o->iter = mp_getiter(args[1], NULL);
     return MP_OBJ_FROM_PTR(o);

--- a/py/objfloat.c
+++ b/py/objfloat.c
@@ -195,7 +195,8 @@ const mp_obj_type_t mp_type_float = {
 #if MICROPY_OBJ_REPR != MICROPY_OBJ_REPR_C && MICROPY_OBJ_REPR != MICROPY_OBJ_REPR_D
 
 mp_obj_t mp_obj_new_float(mp_float_t value) {
-    mp_obj_float_t *o = m_new(mp_obj_float_t, 1);
+    // Don't use mp_obj_malloc here to avoid extra function call overhead.
+    mp_obj_float_t *o = m_new_obj(mp_obj_float_t);
     o->base.type = &mp_type_float;
     o->value = value;
     return MP_OBJ_FROM_PTR(o);

--- a/py/objfun.c
+++ b/py/objfun.c
@@ -393,8 +393,7 @@ mp_obj_t mp_obj_new_fun_bc(const mp_obj_t *def_args, const byte *code, const mp_
         def_kw_args = def_args[1];
         n_extra_args += 1;
     }
-    mp_obj_fun_bc_t *o = m_new_obj_var(mp_obj_fun_bc_t, mp_obj_t, n_extra_args);
-    o->base.type = &mp_type_fun_bc;
+    mp_obj_fun_bc_t *o = mp_obj_malloc_var(mp_obj_fun_bc_t, mp_obj_t, n_extra_args, &mp_type_fun_bc);
     o->bytecode = code;
     o->context = context;
     o->child_table = child_table;
@@ -536,8 +535,7 @@ STATIC const mp_obj_type_t mp_type_fun_asm = {
 };
 
 mp_obj_t mp_obj_new_fun_asm(size_t n_args, const void *fun_data, mp_uint_t type_sig) {
-    mp_obj_fun_asm_t *o = m_new_obj(mp_obj_fun_asm_t);
-    o->base.type = &mp_type_fun_asm;
+    mp_obj_fun_asm_t *o = mp_obj_malloc(mp_obj_fun_asm_t, &mp_type_fun_asm);
     o->n_args = n_args;
     o->fun_data = fun_data;
     o->type_sig = type_sig;

--- a/py/objgenerator.c
+++ b/py/objgenerator.c
@@ -59,9 +59,9 @@ STATIC mp_obj_t gen_wrap_call(mp_obj_t self_in, size_t n_args, size_t n_kw, cons
     MP_BC_PRELUDE_SIG_DECODE(ip);
 
     // allocate the generator object, with room for local stack and exception stack
-    mp_obj_gen_instance_t *o = m_new_obj_var(mp_obj_gen_instance_t, byte,
-        n_state * sizeof(mp_obj_t) + n_exc_stack * sizeof(mp_exc_stack_t));
-    o->base.type = &mp_type_gen_instance;
+    mp_obj_gen_instance_t *o = mp_obj_malloc_var(mp_obj_gen_instance_t, byte,
+        n_state * sizeof(mp_obj_t) + n_exc_stack * sizeof(mp_exc_stack_t),
+        &mp_type_gen_instance);
 
     o->pend_exc = mp_const_none;
     o->code_state.fun_bc = self_fun;
@@ -106,8 +106,7 @@ STATIC mp_obj_t native_gen_wrap_call(mp_obj_t self_in, size_t n_args, size_t n_k
     MP_BC_PRELUDE_SIG_DECODE(ip);
 
     // Allocate the generator object, with room for local stack (exception stack not needed).
-    mp_obj_gen_instance_t *o = m_new_obj_var(mp_obj_gen_instance_t, byte, n_state * sizeof(mp_obj_t));
-    o->base.type = &mp_type_gen_instance;
+    mp_obj_gen_instance_t *o = mp_obj_malloc_var(mp_obj_gen_instance_t, byte, n_state * sizeof(mp_obj_t), &mp_type_gen_instance);
 
     // Parse the input arguments and set up the code state
     o->pend_exc = mp_const_none;

--- a/py/objint_longlong.c
+++ b/py/objint_longlong.c
@@ -243,8 +243,7 @@ mp_obj_t mp_obj_new_int_from_uint(mp_uint_t value) {
 }
 
 mp_obj_t mp_obj_new_int_from_ll(long long val) {
-    mp_obj_int_t *o = m_new_obj(mp_obj_int_t);
-    o->base.type = &mp_type_int;
+    mp_obj_int_t *o = mp_obj_malloc(mp_obj_int_t, &mp_type_int);
     o->val = val;
     return o;
 }
@@ -254,8 +253,7 @@ mp_obj_t mp_obj_new_int_from_ull(unsigned long long val) {
     if (val >> (sizeof(unsigned long long) * 8 - 1) != 0) {
         mp_raise_msg(&mp_type_OverflowError, MP_ERROR_TEXT("ulonglong too large"));
     }
-    mp_obj_int_t *o = m_new_obj(mp_obj_int_t);
-    o->base.type = &mp_type_int;
+    mp_obj_int_t *o = mp_obj_malloc(mp_obj_int_t, &mp_type_int);
     o->val = val;
     return o;
 }
@@ -263,8 +261,7 @@ mp_obj_t mp_obj_new_int_from_ull(unsigned long long val) {
 mp_obj_t mp_obj_new_int_from_str_len(const char **str, size_t len, bool neg, unsigned int base) {
     // TODO this does not honor the given length of the string, but it all cases it should anyway be null terminated
     // TODO check overflow
-    mp_obj_int_t *o = m_new_obj(mp_obj_int_t);
-    o->base.type = &mp_type_int;
+    mp_obj_int_t *o = mp_obj_malloc(mp_obj_int_t, &mp_type_int);
     char *endptr;
     o->val = strtoll(*str, &endptr, base);
     *str = endptr;

--- a/py/objint_mpz.c
+++ b/py/objint_mpz.c
@@ -75,8 +75,7 @@ const mp_obj_int_t mp_sys_maxsize_obj = {
 #endif
 
 mp_obj_int_t *mp_obj_int_new_mpz(void) {
-    mp_obj_int_t *o = m_new_obj(mp_obj_int_t);
-    o->base.type = &mp_type_int;
+    mp_obj_int_t *o = mp_obj_malloc(mp_obj_int_t, &mp_type_int);
     mpz_init_zero(&o->mpz);
     return o;
 }

--- a/py/objmap.c
+++ b/py/objmap.c
@@ -38,8 +38,7 @@ typedef struct _mp_obj_map_t {
 
 STATIC mp_obj_t map_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *args) {
     mp_arg_check_num(n_args, n_kw, 2, MP_OBJ_FUN_ARGS_MAX, false);
-    mp_obj_map_t *o = m_new_obj_var(mp_obj_map_t, mp_obj_t, n_args - 1);
-    o->base.type = type;
+    mp_obj_map_t *o = mp_obj_malloc_var(mp_obj_map_t, mp_obj_t, n_args - 1, type);
     o->n_iters = n_args - 1;
     o->fun = args[0];
     for (size_t i = 0; i < n_args - 1; i++) {

--- a/py/objobject.c
+++ b/py/objobject.c
@@ -36,8 +36,7 @@ typedef struct _mp_obj_object_t {
 STATIC mp_obj_t object_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *args) {
     (void)args;
     mp_arg_check_num(n_args, n_kw, 0, 0, false);
-    mp_obj_object_t *o = m_new_obj(mp_obj_object_t);
-    o->base.type = type;
+    mp_obj_object_t *o = mp_obj_malloc(mp_obj_object_t, type);
     return MP_OBJ_FROM_PTR(o);
 }
 

--- a/py/objproperty.c
+++ b/py/objproperty.c
@@ -47,8 +47,7 @@ STATIC mp_obj_t property_make_new(const mp_obj_type_t *type, size_t n_args, size
     mp_arg_val_t vals[MP_ARRAY_SIZE(allowed_args)];
     mp_arg_parse_all_kw_array(n_args, n_kw, args, MP_ARRAY_SIZE(allowed_args), allowed_args, vals);
 
-    mp_obj_property_t *o = m_new_obj(mp_obj_property_t);
-    o->base.type = type;
+    mp_obj_property_t *o = mp_obj_malloc(mp_obj_property_t, type);
     o->proxy[0] = vals[ARG_fget].u_obj;
     o->proxy[1] = vals[ARG_fset].u_obj;
     o->proxy[2] = vals[ARG_fdel].u_obj;

--- a/py/objrange.c
+++ b/py/objrange.c
@@ -92,8 +92,7 @@ STATIC void range_print(const mp_print_t *print, mp_obj_t self_in, mp_print_kind
 STATIC mp_obj_t range_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *args) {
     mp_arg_check_num(n_args, n_kw, 1, 3, false);
 
-    mp_obj_range_t *o = m_new_obj(mp_obj_range_t);
-    o->base.type = type;
+    mp_obj_range_t *o = mp_obj_malloc(mp_obj_range_t, type);
     o->start = 0;
     o->step = 1;
 
@@ -168,8 +167,7 @@ STATIC mp_obj_t range_subscr(mp_obj_t self_in, mp_obj_t index, mp_obj_t value) {
         if (mp_obj_is_type(index, &mp_type_slice)) {
             mp_bound_slice_t slice;
             mp_seq_get_fast_slice_indexes(len, index, &slice);
-            mp_obj_range_t *o = m_new_obj(mp_obj_range_t);
-            o->base.type = &mp_type_range;
+            mp_obj_range_t *o = mp_obj_malloc(mp_obj_range_t, &mp_type_range);
             o->start = self->start + slice.start * self->step;
             o->stop = self->start + slice.stop * self->step;
             o->step = slice.step * self->step;

--- a/py/objreversed.c
+++ b/py/objreversed.c
@@ -47,8 +47,7 @@ STATIC mp_obj_t reversed_make_new(const mp_obj_type_t *type, size_t n_args, size
         return mp_call_method_n_kw(0, 0, dest);
     }
 
-    mp_obj_reversed_t *o = m_new_obj(mp_obj_reversed_t);
-    o->base.type = type;
+    mp_obj_reversed_t *o = mp_obj_malloc(mp_obj_reversed_t, type);
     o->seq = args[0];
     o->cur_index = mp_obj_get_int(mp_obj_len(args[0])); // start at the end of the sequence
 

--- a/py/objset.c
+++ b/py/objset.c
@@ -174,8 +174,7 @@ STATIC MP_DEFINE_CONST_FUN_OBJ_1(set_clear_obj, set_clear);
 STATIC mp_obj_t set_copy(mp_obj_t self_in) {
     check_set_or_frozenset(self_in);
     mp_obj_set_t *self = MP_OBJ_TO_PTR(self_in);
-    mp_obj_set_t *other = m_new_obj(mp_obj_set_t);
-    other->base.type = self->base.type;
+    mp_obj_set_t *other = mp_obj_malloc(mp_obj_set_t, self->base.type);
     mp_set_init(&other->set, self->set.alloc);
     other->set.used = self->set.used;
     memcpy(other->set.table, self->set.table, self->set.alloc * sizeof(mp_obj_t));
@@ -579,8 +578,7 @@ const mp_obj_type_t mp_type_frozenset = {
 #endif
 
 mp_obj_t mp_obj_new_set(size_t n_args, mp_obj_t *items) {
-    mp_obj_set_t *o = m_new_obj(mp_obj_set_t);
-    o->base.type = &mp_type_set;
+    mp_obj_set_t *o = mp_obj_malloc(mp_obj_set_t, &mp_type_set);
     mp_set_init(&o->set, n_args);
     for (size_t i = 0; i < n_args; i++) {
         mp_set_lookup(&o->set, items[i], MP_MAP_LOOKUP_ADD_IF_NOT_FOUND);

--- a/py/objslice.c
+++ b/py/objslice.c
@@ -104,8 +104,7 @@ const mp_obj_type_t mp_type_slice = {
 };
 
 mp_obj_t mp_obj_new_slice(mp_obj_t ostart, mp_obj_t ostop, mp_obj_t ostep) {
-    mp_obj_slice_t *o = m_new_obj(mp_obj_slice_t);
-    o->base.type = &mp_type_slice;
+    mp_obj_slice_t *o = mp_obj_malloc(mp_obj_slice_t, &mp_type_slice);
     o->start = ostart;
     o->stop = ostop;
     o->step = ostep;

--- a/py/objstr.c
+++ b/py/objstr.c
@@ -2026,8 +2026,7 @@ const mp_obj_str_t mp_const_empty_bytes_obj = {{&mp_type_bytes}, 0, 0, (const by
 // the data is copied across.  This function should only be used if the type is bytes,
 // or if the type is str and the string data is known to be not interned.
 mp_obj_t mp_obj_new_str_copy(const mp_obj_type_t *type, const byte *data, size_t len) {
-    mp_obj_str_t *o = m_new_obj(mp_obj_str_t);
-    o->base.type = type;
+    mp_obj_str_t *o = mp_obj_malloc(mp_obj_str_t, type);
     o->len = len;
     if (data) {
         o->hash = qstr_compute_hash(data, len);
@@ -2070,8 +2069,7 @@ mp_obj_t mp_obj_new_str_from_vstr(const mp_obj_type_t *type, vstr_t *vstr) {
     }
 
     // make a new str/bytes object
-    mp_obj_str_t *o = m_new_obj(mp_obj_str_t);
-    o->base.type = type;
+    mp_obj_str_t *o = mp_obj_malloc(mp_obj_str_t, type);
     o->len = vstr->len;
     o->hash = qstr_compute_hash((byte *)vstr->buf, vstr->len);
     if (vstr->len + 1 == vstr->alloc) {

--- a/py/objstringio.c
+++ b/py/objstringio.c
@@ -177,8 +177,7 @@ STATIC mp_obj_t stringio___exit__(size_t n_args, const mp_obj_t *args) {
 STATIC MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(stringio___exit___obj, 4, 4, stringio___exit__);
 
 STATIC mp_obj_stringio_t *stringio_new(const mp_obj_type_t *type) {
-    mp_obj_stringio_t *o = m_new_obj(mp_obj_stringio_t);
-    o->base.type = type;
+    mp_obj_stringio_t *o = mp_obj_malloc(mp_obj_stringio_t, type);
     o->pos = 0;
     o->ref_obj = MP_OBJ_NULL;
     return o;

--- a/py/objtuple.c
+++ b/py/objtuple.c
@@ -243,8 +243,7 @@ mp_obj_t mp_obj_new_tuple(size_t n, const mp_obj_t *items) {
     if (n == 0) {
         return mp_const_empty_tuple;
     }
-    mp_obj_tuple_t *o = m_new_obj_var(mp_obj_tuple_t, mp_obj_t, n);
-    o->base.type = &mp_type_tuple;
+    mp_obj_tuple_t *o = mp_obj_malloc_var(mp_obj_tuple_t, mp_obj_t, n, &mp_type_tuple);
     o->len = n;
     if (items) {
         for (size_t i = 0; i < n; i++) {

--- a/py/objtype.c
+++ b/py/objtype.c
@@ -99,8 +99,7 @@ STATIC
 mp_obj_instance_t *mp_obj_new_instance(const mp_obj_type_t *class, const mp_obj_type_t **native_base) {
     size_t num_native_bases = instance_count_native_bases(class, native_base);
     assert(num_native_bases < 2);
-    mp_obj_instance_t *o = m_new_obj_var(mp_obj_instance_t, mp_obj_t, num_native_bases);
-    o->base.type = class;
+    mp_obj_instance_t *o = mp_obj_malloc_var(mp_obj_instance_t, mp_obj_t, num_native_bases, class);
     mp_map_init(&o->members, 0);
     // Initialise the native base-class slot (should be 1 at most) with a valid
     // object.  It doesn't matter which object, so long as it can be uniquely

--- a/py/objzip.c
+++ b/py/objzip.c
@@ -39,8 +39,7 @@ typedef struct _mp_obj_zip_t {
 STATIC mp_obj_t zip_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *args) {
     mp_arg_check_num(n_args, n_kw, 0, MP_OBJ_FUN_ARGS_MAX, false);
 
-    mp_obj_zip_t *o = m_new_obj_var(mp_obj_zip_t, mp_obj_t, n_args);
-    o->base.type = type;
+    mp_obj_zip_t *o = mp_obj_malloc_var(mp_obj_zip_t, mp_obj_t, n_args, type);
     o->n_iters = n_args;
     for (size_t i = 0; i < n_args; i++) {
         o->iters[i] = mp_getiter(args[i], NULL);

--- a/py/runtime.c
+++ b/py/runtime.c
@@ -1067,8 +1067,7 @@ STATIC const mp_obj_type_t mp_type_checked_fun = {
 };
 
 STATIC mp_obj_t mp_obj_new_checked_fun(const mp_obj_type_t *type, mp_obj_t fun) {
-    mp_obj_checked_fun_t *o = m_new_obj(mp_obj_checked_fun_t);
-    o->base.type = &mp_type_checked_fun;
+    mp_obj_checked_fun_t *o = mp_obj_malloc(mp_obj_checked_fun_t, &mp_type_checked_fun);
     o->type = type;
     o->fun = fun;
     return MP_OBJ_FROM_PTR(o);


### PR DESCRIPTION
This is to replace the following:

```
mp_foo_obj_t *self = m_new_obj(mp_foo_obj_t);
self->base.type = &mp_type_foo;
```

with:

```
mp_foo_obj_t *self = m_new_obj_with_type(mp_foo_obj_t, &mp_type_foo);
```

Calling the function is less code than inlining setting the type everywhere, adds up to 100 bytes on PYBV11. Small, but every byte counts, right? :p

It also helps to avoid an easy mistake of forgetting to set the type.

Perf impact is negligible, possibly even improved? I specifically excluded `mp_obj_new_float` from using this (otherwise there was about a 1% decrease across the fp-heavy tests).

```
$ ./run-perfbench.py -s ~/obj-type-pybv11-baseline ~/obj-type-pybv11-helper-float 
diff of scores (higher is better)
N=100 M=100                /home/jimmo/obj-type-pybv11-baseline -> /home/jimmo/obj-type-pybv11-helper-float         diff      diff% (error%)
bm_chaos.py                    358.07 ->     366.90 :      +8.83 =  +2.466% (+/-0.01%)
bm_fannkuch.py                  76.62 ->      77.21 :      +0.59 =  +0.770% (+/-0.01%)
bm_fft.py                     2542.13 ->    2527.94 :     -14.19 =  -0.558% (+/-0.00%)
bm_float.py                   5916.09 ->    6066.47 :    +150.38 =  +2.542% (+/-0.02%)
bm_hexiom.py                    43.71 ->      43.80 :      +0.09 =  +0.206% (+/-0.00%)
bm_nqueens.py                 4398.49 ->    4363.18 :     -35.31 =  -0.803% (+/-0.00%)
bm_pidigits.py                 640.04 ->     637.61 :      -2.43 =  -0.380% (+/-0.22%)
misc_aes.py                    412.97 ->     421.05 :      +8.08 =  +1.957% (+/-0.01%)
misc_mandel.py                3520.42 ->    3521.73 :      +1.31 =  +0.037% (+/-0.00%)
misc_pystone.py               2275.25 ->    2302.60 :     +27.35 =  +1.202% (+/-0.00%)
misc_raytrace.py               376.95 ->     386.30 :      +9.35 =  +2.480% (+/-0.01%)
```