### PR TITLE
py/modsys: rename sys.implementation.mpy to _mpy, and add sys.implementation._machine

### DIFF
--- a/docs/library/sys.rst
+++ b/docs/library/sys.rst
@@ -70,6 +70,7 @@ Constants
 
    * *name* - string "micropython"
    * *version* - tuple (major, minor, micro), e.g. (1, 7, 0)
+   * *_mpy* - supported mpy file-format version (optional attribute)
 
    This object is the recommended way to distinguish MicroPython from other
    Python implementations (note that it still may not exist in the very

--- a/docs/library/sys.rst
+++ b/docs/library/sys.rst
@@ -70,6 +70,7 @@ Constants
 
    * *name* - string "micropython"
    * *version* - tuple (major, minor, micro), e.g. (1, 7, 0)
+   * *_machine* - string describing the underlying machine
    * *_mpy* - supported mpy file-format version (optional attribute)
 
    This object is the recommended way to distinguish MicroPython from other

--- a/docs/reference/mpyfiles.rst
+++ b/docs/reference/mpyfiles.rst
@@ -44,7 +44,7 @@ Compatibility is based on the following:
   loading it must support execution of that architecture's code.
 
 If a MicroPython system supports importing .mpy files then the
-``sys.implementation.mpy`` field will exist and return an integer which
+``sys.implementation._mpy`` field will exist and return an integer which
 encodes the version (lower 8 bits), features and native architecture.
 
 Trying to import an .mpy file that fails one of the first four tests will
@@ -58,7 +58,7 @@ If importing an .mpy file fails then try the following:
   by executing::
 
     import sys
-    sys_mpy = sys.implementation.mpy
+    sys_mpy = sys.implementation._mpy
     arch = [None, 'x86', 'x64',
         'armv6', 'armv6m', 'armv7m', 'armv7em', 'armv7emsp', 'armv7emdp',
         'xtensa', 'xtensawin'][sys_mpy >> 10]

--- a/ports/qemu-arm/mpconfigport.h
+++ b/ports/qemu-arm/mpconfigport.h
@@ -34,6 +34,7 @@
 #define MICROPY_PY_IO               (1)
 #define MICROPY_PY_SYS_EXIT         (1)
 #define MICROPY_PY_SYS_MAXSIZE      (1)
+#define MICROPY_PY_SYS_PLATFORM     "qemu-arm"
 #define MICROPY_PY_UERRNO           (1)
 #define MICROPY_PY_UBINASCII        (1)
 #define MICROPY_PY_URANDOM          (1)

--- a/ports/unix/main.c
+++ b/ports/unix/main.c
@@ -179,8 +179,8 @@ STATIC char *strjoin(const char *s1, int sep_char, const char *s2) {
 
 STATIC int do_repl(void) {
     mp_hal_stdout_tx_str(MICROPY_BANNER_NAME_AND_VERSION);
-    mp_hal_stdout_tx_str("; " MICROPY_PY_SYS_PLATFORM " [" MICROPY_PLATFORM_COMPILER "] version\n"
-        "Use Ctrl-D to exit, Ctrl-E for paste mode\n");
+    mp_hal_stdout_tx_str("; " MICROPY_BANNER_MACHINE);
+    mp_hal_stdout_tx_str("\nUse Ctrl-D to exit, Ctrl-E for paste mode\n");
 
     #if MICROPY_USE_READLINE == 1
 

--- a/py/modsys.c
+++ b/py/modsys.c
@@ -36,6 +36,7 @@
 #include "py/smallint.h"
 #include "py/runtime.h"
 #include "py/persistentcode.h"
+#include "extmod/moduplatform.h"
 #include "genhdr/mpversion.h"
 
 #if MICROPY_PY_SYS_SETTRACE
@@ -69,20 +70,24 @@ STATIC const mp_obj_tuple_t mp_sys_implementation_version_info_obj = {
     3,
     { I(MICROPY_VERSION_MAJOR), I(MICROPY_VERSION_MINOR), I(MICROPY_VERSION_MICRO) }
 };
+STATIC const MP_DEFINE_STR_OBJ(mp_sys_implementation_machine_obj, MICROPY_BANNER_MACHINE);
 #if MICROPY_PERSISTENT_CODE_LOAD
 #define SYS_IMPLEMENTATION_ELEMS \
     MP_ROM_QSTR(MP_QSTR_micropython), \
     MP_ROM_PTR(&mp_sys_implementation_version_info_obj), \
+    MP_ROM_PTR(&mp_sys_implementation_machine_obj), \
     MP_ROM_INT(MPY_FILE_HEADER_INT)
 #else
 #define SYS_IMPLEMENTATION_ELEMS \
     MP_ROM_QSTR(MP_QSTR_micropython), \
-    MP_ROM_PTR(&mp_sys_implementation_version_info_obj)
+    MP_ROM_PTR(&mp_sys_implementation_version_info_obj), \
+    MP_ROM_PTR(&mp_sys_implementation_machine_obj)
 #endif
 #if MICROPY_PY_ATTRTUPLE
 STATIC const qstr impl_fields[] = {
     MP_QSTR_name,
     MP_QSTR_version,
+    MP_QSTR__machine,
     #if MICROPY_PERSISTENT_CODE_LOAD
     MP_QSTR__mpy,
     #endif
@@ -90,13 +95,13 @@ STATIC const qstr impl_fields[] = {
 STATIC MP_DEFINE_ATTRTUPLE(
     mp_sys_implementation_obj,
     impl_fields,
-    2 + MICROPY_PERSISTENT_CODE_LOAD,
+    3 + MICROPY_PERSISTENT_CODE_LOAD,
     SYS_IMPLEMENTATION_ELEMS
     );
 #else
 STATIC const mp_rom_obj_tuple_t mp_sys_implementation_obj = {
     {&mp_type_tuple},
-    2 + MICROPY_PERSISTENT_CODE_LOAD,
+    3 + MICROPY_PERSISTENT_CODE_LOAD,
     {
         SYS_IMPLEMENTATION_ELEMS
     }

--- a/py/modsys.c
+++ b/py/modsys.c
@@ -84,7 +84,7 @@ STATIC const qstr impl_fields[] = {
     MP_QSTR_name,
     MP_QSTR_version,
     #if MICROPY_PERSISTENT_CODE_LOAD
-    MP_QSTR_mpy,
+    MP_QSTR__mpy,
     #endif
 };
 STATIC MP_DEFINE_ATTRTUPLE(

--- a/py/mpconfig.h
+++ b/py/mpconfig.h
@@ -1719,6 +1719,15 @@ typedef double mp_float_t;
 #define MICROPY_BANNER_NAME_AND_VERSION "MicroPython " MICROPY_GIT_TAG " on " MICROPY_BUILD_DATE
 #endif
 
+// String used for the second part of the banner, and sys.implementation._machine
+#ifndef MICROPY_BANNER_MACHINE
+#ifdef MICROPY_HW_BOARD_NAME
+#define MICROPY_BANNER_MACHINE MICROPY_HW_BOARD_NAME " with " MICROPY_HW_MCU_NAME
+#else
+#define MICROPY_BANNER_MACHINE MICROPY_PY_SYS_PLATFORM " [" MICROPY_PLATFORM_COMPILER "] version"
+#endif
+#endif
+
 // On embedded platforms, these will typically enable/disable irqs.
 #ifndef MICROPY_BEGIN_ATOMIC_SECTION
 #define MICROPY_BEGIN_ATOMIC_SECTION() (0)

--- a/shared/runtime/pyexec.c
+++ b/shared/runtime/pyexec.c
@@ -402,7 +402,8 @@ STATIC int pyexec_friendly_repl_process_char(int c) {
             // reset friendly REPL
             mp_hal_stdout_tx_str("\r\n");
             mp_hal_stdout_tx_str(MICROPY_BANNER_NAME_AND_VERSION);
-            mp_hal_stdout_tx_str("; " MICROPY_HW_BOARD_NAME " with " MICROPY_HW_MCU_NAME "\r\n");
+            mp_hal_stdout_tx_str("; " MICROPY_BANNER_MACHINE);
+            mp_hal_stdout_tx_str("\r\n");
             #if MICROPY_PY_BUILTINS_HELP
             mp_hal_stdout_tx_str("Type \"help()\" for more information.\r\n");
             #endif
@@ -554,7 +555,8 @@ int pyexec_friendly_repl(void) {
 
 friendly_repl_reset:
     mp_hal_stdout_tx_str(MICROPY_BANNER_NAME_AND_VERSION);
-    mp_hal_stdout_tx_str("; " MICROPY_HW_BOARD_NAME " with " MICROPY_HW_MCU_NAME "\r\n");
+    mp_hal_stdout_tx_str("; " MICROPY_BANNER_MACHINE);
+    mp_hal_stdout_tx_str("\r\n");
     #if MICROPY_PY_BUILTINS_HELP
     mp_hal_stdout_tx_str("Type \"help()\" for more information.\r\n");
     #endif


### PR DESCRIPTION
This PR is based on #8572 and makes two addition changes:
1. rename `sys.implementation.mpy` to `sys.implementation._mpy` to conform with Python, that implementation-specific entries start with an underscore
2. add `sys.implementation._machine`, which is a string that describes the machine, and is the same string used in the second part of the banner.

Examples for `sys.implementation._machine` are:
- on PYBv1.0: `"PYBv1.0 with STM32F405RG"`
- on unix: `"linux [GCC 11.2.0] version"`

This makes `os.uname()` more or less redundant (as discussed in #8572 uPy's current version doesn't match CPython specs, and it's not very portable).