### PR TITLE
mimxrt: A few changes to the documentation.

### DIFF
--- a/docs/mimxrt/general.rst
+++ b/docs/mimxrt/general.rst
@@ -44,6 +44,8 @@ Supported MCUs
 +-------------+--------------------+-------------------------+
 | i.MX RT1020 | Cortex-M7 @500 MHz | 256 kB SRAM             |
 +-------------+--------------------+-------------------------+
+| i.MX RT1015 | Cortex-M7 @500 MHz | 128 kB SRAM             |
++-------------+--------------------+-------------------------+
 | i.MX RT1010 | Cortex-M7 @500 MHz | 128 kB SRAM             |
 +-------------+--------------------+-------------------------+
 
@@ -72,7 +74,7 @@ For your convenience, a few technical specifications are provided below:
 * CPU frequency: up to 600MHz
 * Total RAM available: up to 1 MByte (see table)
 * BootROM: 96KB
-* External FlashROM: code and data, via SPI Flash; usual size 2 - 8 MB
+* External FlashROM: code and data, via SPI Flash; usual size 2 - 16 MB
   Some boards provide additional external RAM and SPI flash.
 * GPIO: up to 124 (GPIOs are multiplexed with other functions, including
   external FlashROM, UART, etc.)
@@ -80,9 +82,9 @@ For your convenience, a few technical specifications are provided below:
   but the boards used for testing do not expose the signals.
 * SPI: 2 or 4 low power SPI interfaces (software implementation available on every pin)
 * I2C: 2 or 4 low power I2C interfaces (software implementation available on every pin)
-* I2S: 3 I2S interfaces
+* I2S: 1 to 3 I2S interfaces
 * ADC: one or two 12-bit SAR ADC converters
-* Ethernet controller
+* Ethernet controller (except i.MX RT1010/-1015)
 * Programming: using BootROM bootloader from USB - due to external FlashROM
   and always-available BootROM bootloader, the MIMXRT is not brickable
 

--- a/docs/mimxrt/pinout.rst
+++ b/docs/mimxrt/pinout.rst
@@ -1,0 +1,380 @@
+.. _mimxrt_pinout:
+
+Pinout for the i.MXRT machine modules
+=====================================
+
+.. _mimxrt_uart_pinout:
+
+|
+
+UART pin assignment
+-------------------
+
+The pin assignment of UARTs to pins is fixed.
+The UARTs are numbered 0..8.  The rx/tx pins are assigned according to the
+tables below:
+
+================  ===========  ===========  ===========  ===========
+Board / Pin           UART0        UART1        UART2        UART3
+================  ===========  ===========  ===========  ===========
+Teensy 4.0             -            0/1          7/8         14/15
+Teensy 4.1             -            0/1          7/8         14/15
+MIMXRT1010-EVK     Debug USB      D0/D1        D7/D6           -
+MIMXRT1015-EVK     Debug USB      D0/D1        D7/A1           -
+MIMXRT1020-EVK     Debug USB      D0/D1        D9/D6       D10/D13
+MIMXRT1050-EVK     Debug USB      D0/D1        D7/D6        D8/D9
+MIMXRT1050-EVKB    Debug USB      D0/D1        D7/D6        D8/D9
+MIMXRT1060-EVK     Debug USB      D0/D1        D7/D6        D8/D9
+MIMXRT1064-EVK     Debug USB      D0/D1        D7/D6        D8/D9
+MIMXRT1170-EVK     Debug USB      D0/D1       D12/D11      D10/D13
+Olimex RT1010Py       -          RxD/TxD       D5/D6           -
+Seeed ARCH MIX        -        J3_19/J3_20  J4_16/J4_17  J4_06/J4_07
+================  ===========  ===========  ===========  ===========
+
+|
+
+================  ===========  ===========  =======  =======  =====
+Board / Pin           UART4        UART5      UART6   UART7   UART8
+================  ===========  ===========  =======  =======  =====
+Teensy 4.0            16/17        21/20     25/24    28/29      -
+Teensy 4.1            16/17        21/20     25/24    28/29    34/35
+MIMXRT1010-EVK         -            -         -        -        -
+MIMXRT1015-EVK         -            -         -        -        -
+MIMXRT1020-EVK      D15/D14       A1/A0       -        -        -
+MIMXRT1050-EVK       A1/A0          -         -        -        -
+MIMXRT1050-EVKB      A1/A0          -         -        -        -
+MIMXRT1060-EVK       A1/A0          -         -        -        -
+MIMXRT1064-EVK       A1/A0          -         -        -        -
+MIMXRT1170-EVK      D15/D14      D25/D26    D33/D34  D35/D36    -
+Olimex RT1010Py        -            -         -        -        -
+Seeed ARCH MIX    J4_10/J4_11  J5_08/J5_12    -        -        -
+================  ===========  ===========  =======  =======  =====
+
+.. _mimxrt_pwm_pinout:
+
+|
+|
+
+PWM pin assignment
+------------------
+
+Pins are specified in the same way as for the Pin class.  The following tables show
+the assignment of the board Pins to PWM modules:
+
+===========   ==========   ==========   ======    ==============   ======
+Pin/ MIMXRT   1010         1015         1020      1050/1060/1064   1170
+===========   ==========   ==========   ======    ==============   ======
+D0            -            Q1/1         F1/1/B    -                -
+D1            -            Q1/0         F1/1/A    -                -
+D2            F1/3/B       F1/3/A       -         F1/3/B           -
+D3            F1/3/A       F1/0/A       F2/3/B    F4/0/A           F1/2/A
+D4            F1/3/A (*)   Q1/2         Q2/1      F2/3/A           Q4/2
+D5            F1/0/B (*)   F1/0/B       F2/3/A    F1/3/A           F1/2/B
+D6            -            F1/2/B       F2/0/A    Q3/2             F1/0/A
+D7            -            -            F1/0/A    Q3/3             -
+D8            F1/0/A       F1/1/B       F1/0/B    F1/1/X           Q4/3
+D9            F1/1/B (*)   F1/2/A       F2/0/B    F1/0/X           F1/0/B
+D10           F1/3/B       -            F2/2/B    F1/0/B (*)       F2/2/B
+D11           F1/2/A       -            F2/1/A    F1/1/A (*)       -
+D12           F1/2/B       -            F2/1/B    F1/1/B (*)       -
+D13           F1/3/A       -            F2/2/A    F1/0/A (*)       F2/2/A
+D14           F1/0/B       -            -         F2/3/B           -
+D15           F1/0/A       -            -         F2/3/A           -
+A0            -            -            F1/2/A    -                -
+A1            F1/3/X       F1/3/B       F1/2/B    -                -
+A2            F1/2/X       F1/3/A       F1/3/A    -                -
+A3            -            F1/2/A       F1/3/B    -                -
+A4            -            -            -         Q3/1             -
+A5            -            -            -         Q3/0             -
+D31           -            -            -         -                F1/2/B
+D32           -            -            -         -                F1/2/A
+D33           -            -            -         -                F1/1/B
+D34           -            -            -         -                F1/1/A
+D35           -            -            -         -                F1/0/B
+D36           -            -            -         -                F1/0/A
+===========   ==========   ==========   ======    ==============   ======
+
+Pins denoted with (*) are by default not wired at the board.
+
+====   ==========  ====   ==========
+Pin    Teensy 4.0  Pin    Teensy 4.1
+====   ==========  ====   ==========
+0      F1/1/X      0      F1/1/X
+1      F1/0/X      1      F1/0/X
+2      F4/2/A      2      F4/2/A
+3      F4/2/B      3      F4/2/B
+4      F2/0/A      4      F2/0/A
+5      F2/1/A      5      F2/1/A
+6      F2/2/A      6      F2/2/A
+7      F1/3/B      7      F1/3/B
+8      F1/3/A      8      F1/3/A
+9      F2/2/B      9      F2/2/B
+10     Q1/0        10     Q1/0
+11     Q1/2        11     Q1/2
+12     Q1/1        12     Q1/1
+13     Q2/0        13     Q2/0
+14     Q3/2        14     Q3/2
+15     Q3/3        15     Q3/3
+18     Q3/1        18     Q3/1
+19     Q3/0        19     Q3/0
+22     F4/0/A      22     F4/0/A
+23     F4/1/A      23     F4/1/A
+24     F1/2/X      24     F1/2/X
+25     F1/3/X      25     F1/3/X
+28     F3/1/B      28     F3/1/B
+29     F3/1/A      29     F3/1/A
+33     F2/0/B      33     F2/0/B
+-      -           36     F2/3/A
+-      -           37     F2/3/B
+DAT1   F1/1/B      42     F1/1/B
+DAT0   F1/1/A      43     F1/1/A
+CLK    F1/0/B      44     F1/0/B
+CMD    F1/0/A      45     F1/0/A
+DAT2   F1/2/A      46     F1/2/A
+DAT3   F1/2/B      47     F1/2/B
+-      -           48     F1/0/B
+-      -           49     F1/2/A
+-      -           50     F1/2/B
+-      -           51     F3/3/B
+-      -           52     F1/1/B
+-      -           53     F1/1/A
+-      -           54     F3/0/A
+====   ==========  ====   ==========
+
+|
+
+=========  ==============
+Pin        Seeed ARCH MIX
+=========  ==============
+J3_04      Q4/3
+J3_10      Q1/3
+J3_12      Q2/3
+J3_13      Q3/3
+J3_16      Q3/0
+J3_17      Q3/1
+J3_19      F1/3/X
+J3_20      F1/2/X
+J4_08      F4/0/A
+J4_09      F4/1/A
+J4_16      Q3/2
+J4_17      Q3/3
+J5_32      Q1/0
+J5_28      Q1/1
+J5_29      Q1/2
+J5_30      Q2/0
+J5_04      Q2/1
+J5_05      Q2/3
+J5_06      F2/0/A
+J5_07      F2/0/B
+J5_08      F2/1/A
+J5_12      F2/1/B
+J5_13      F2/2/A
+J5_14      F2/2/B
+J5_23      F1/3/A
+J5_24      F1/3/B
+J5_25      F2/3/A
+J5_26      F2/3/B
+J5_42      Q3/0
+J5_43      Q3/1
+J5_50      F1/0/X
+LED_RED    F2/3/A
+LED_GREEN  F1/3/A
+LED_BLUE   F1/3/B
+=========  ==============
+
+|
+
+=========  ===============
+Pin        Olimex RT1010PY
+=========  ===============
+D0           -
+D1         F1/0/B
+D2         F1/0/A
+D3         F1/1/B
+D4         F1/1/A
+D5         F1/2/B
+D6         F1/2/A
+D7         F1/3/B
+D8         F1/3/A
+D9            -
+D10        F1/0/B
+D11        F1/0/A
+D12        F1/1/B
+D13        F1/1/A
+D14           -
+A0            -
+A1         F1/2/B
+A2         F1/2/A
+A3         F1/3/B
+A4         F1/3/A
+SDI        F1/3/X
+SDO        F1/2/X
+CS0        F1/1/X
+SCK        F1/0/X
+=========  ===============
+
+Legend:
+
+* Qm/n:    QTMR module m, channel n
+* Fm/n/l:  FLEXPWM module m, submodule n, channel l. The pulse at a X channel
+  is always aligned to the period start.
+
+Pins without a PWM signal are not listed.  A signal may be available at more
+than one Pin.  FlexPWM pins may also be pure CPU pin, not assigned to a board
+signal.  In that case the PWM output is disabled.  The PWM channel of a submodule
+0 may still be used as synchronization source for other channels of the same
+module, unless used by another peripheral.
+
+Submodule 0 pins for i.MX RT1011:
+
+==================  =======
+Pin                 Channel
+==================  =======
+Pin.cpu.GPIO_01     B
+Pin.cpu.GPIO_02     A
+Pin.cpu.GPIO_AD_12  X
+Pin.cpu.GPIO_SD_01  B
+Pin.cpu.GPIO_SD_02  A
+==================  =======
+
+Submodule 0 pins for i.MX RT1021:
+
+=====================  ==================
+Pin                    Module & Channel
+=====================  ==================
+Pin.cpu.GPIO_AD_B1_06  FLEXPWM1 Channel A
+Pin.cpu.GPIO_AD_B1_07  FLEXPWM1 Channel B
+Pin.cpu.GPIO_EMC_26    FLEXPWM1 Channel A
+Pin.cpu.GPIO_EMC_27    FLEXPWM1 Channel B
+Pin.cpu.GPIO_AD_B0_14  FLEXPWM2 Channel A
+Pin.cpu.GPIO_AD_B0_15  FLEXPWM2 Channel B
+Pin.cpu.GPIO_EMC_10    FLEXPWM2 Channel X
+Pin.cpu.GPIO_EMC_38    FLEXPWM2 Channel A
+Pin.cpu.GPIO_EMC_39    FLEXPWM2 Channel B
+=====================  ==================
+
+Submodule 0 pins for i.MX RT1052, i.MX RT1062 and i.MX RT1064:
+
+=====================  ==================
+Pin                    Module & Channel
+=====================  ==================
+Pin.cpu.GPIO_AD_B0_02  FLEXPWM1 Channel X
+Pin.cpu.GPIO_EMC_23    FLEXPWM1 Channel A
+Pin.cpu.GPIO_EMC_24    FLEXPWM1 Channel B
+Pin.cpu.GPIO_SD_B0_00  FLEXPWM1 Channel A
+Pin.cpu.GPIO_SD_B0_01  FLEXPWM1 Channel B
+Pin.cpu.GPIO_B0_06     FLEXPWM2 Channel A
+Pin.cpu.GPIO_B0_07     FLEXPWM2 Channel B
+Pin.cpu.GPIO_EMC_06    FLEXPWM2 Channel A
+Pin.cpu.GPIO_EMC_07    FLEXPWM2 Channel B
+Pin.cpu.GPIO_EMC_29    FLEXPWM3 Channel A
+Pin.cpu.GPIO_EMC_30    FLEXPWM3 Channel B
+Pin.cpu.GPIO_AD_B1_08  FLEXPWM4 Channel A
+Pin.cpu.GPIO_EMC_00    FLEXPWM4 Channel A
+Pin.cpu.GPIO_EMC_01    FLEXPWM4 Channel B
+=====================  ==================
+
+Submodule 0 pins for i.MX RT1176
+
+======================  ======================
+Pin                     Module & Channel
+======================  ======================
+Pin.cpu.GPIO_EMC_B1_00  FLEXPWM4 Channel A (*)
+Pin.cpu.GPIO_EMC_B1_01  FLEXPWM4 Channel B (*)
+Pin.cpu.GPIO_EMC_B1_06  FLEXPWM2 Channel A (*)
+Pin.cpu.GPIO_EMC_B1_07  FLEXPWM2 Channel B (*)
+Pin.cpu.GPIO_EMC_B1_23  FLEXPWM1 Channel A (*)
+Pin.cpu.GPIO_EMC_B1_24  FLEXPWM1 Channel B (*)
+Pin.cpu.GPIO_EMC_B1_29  FLEXPWM3 Channel A (*)
+Pin.cpu.GPIO_EMC_B1_30  FLEXPWM3 Channel B (*)
+Pin.cpu.GPIO_AD_00      FLEXPWM1 Channel A
+Pin.cpu.GPIO_AD_01      FLEXPWM1 Channel B
+Pin.cpu.GPIO_AD_24      FLEXPWM2 Channel A
+Pin.cpu.GPIO_AD_25      FLEXPWM2 Channel B
+======================  ======================
+
+.. _mimxrt_spi_pinout:
+
+|
+|
+
+Hardware SPI pin assignment
+---------------------------
+
+The SPI signals have fixed assignments to GPIO pins.
+It depends on the board design, which SPI's signals are exposed to the user, as
+detailed in the table below.  The signal order in the table is: CS0, CS1, MOSI, MISO, CLK.
+
+=================  =========================  =======================  ===============
+Board / Pin        SPI0                       SPI1                     SPI2
+=================  =========================  =======================  ===============
+Teensy 4.0         10/-/11/12/13              0/-/26/1/27                    -
+Teensy 4.1         10/37/11/12/13             0/-/26/1/27              -/29/50/54/49
+MIXMXRT1010-EVK    D10/D7/D11/D12/D13                -                       -
+MIXMXRT1015-EVK    D10/-/D11/D12/D13                 -                       -
+MIXMXRT1020-EVK    D10/-/D11/D12/D13          A3/D0/A5/A4/A0                 -
+MIXMXRT1050-EVK    D10/-/D11/D12/D13 (*)            -                        -
+MIXMXRT1050-EVKB   D10/-/D11/D12/D13 (*)            -                        -
+MIXMXRT1060-EVK    D10/-/D11/D12/D13 (*)            -                        -
+MIXMXRT1064-EVK    D10/-/D11/D12/D13 (*)            -                        -
+MIXMXRT1170-EVK    D10/-/D11/D12/D13          D28/-/D25/D24/D26        -/-/D14/D15/D24
+Olimex RT1010Py             -                 CS0/-/SDO/SDI/SCK        SDCARD with CS1
+Seeed ARCH MIX     J4_12/-/J4_14/J4_13/J4_15  J3_09/J3_05/J3_08_J3_11
+=================  =========================  =======================  ===============
+
+Pins denoted with (*) are by default not wired at the board.
+
+.. _mimxrt_i2c_pinout:
+
+|
+|
+
+Hardware I2C pin assignment
+---------------------------
+
+The I2C signals have fixed assignments to GPIO pins.
+It depends on the board design, which I2C's signals are exposed to the user, as
+detailed in the table below.  The signal order in the table is: SDA, SCL.
+
+=================  ===========  ===========  ===========  =======  =======
+Board / Pin        I2C 0        I2C 1        I2C 2        I2C 3    I2C 4
+=================  ===========  ===========  ===========  =======  =======
+Teensy 4.0         18/19        17/16        25/24         -        -
+Teensy 4.1         18/19        17/16        25/24         -        -
+MIXMXRT1010-EVK    D14/D15      D0/D1         -            -        -
+MIXMXRT1015-EVK    D14/D15       -            -            -        -
+MIXMXRT1020-EVK    D14/D15      A4/A5        D0/D1         -        -
+MIXMXRT1050-EVK    A4/A5        D1/D0         -            -        -
+MIXMXRT1050-EVKB   A4/A5        D1/D0         -            -        -
+MIXMXRT1060-EVK    A4/A5        D1/D0         -            -        -
+MIXMXRT1064-EVK    A4/A5        D1/D0         -            -        -
+MIXMXRT1170-EVK    D14/D15      D1/D0        A4/A5        D26/D25  D19/D18
+Olimex RT1010Py      -          SDA1/SCL1    SDA2/SCL2     -        -
+Seeed ARCH MIX     J3_17/J3_16  J4_06/J4_07  J5_05/J5_04   -        -
+=================  ===========  ===========  ===========  =======  =======
+
+.. _mimxrt_i2s_pinout:
+
+|
+|
+
+Hardware I2S pin assignment
+---------------------------
+
+Pin assignments for a few MIMXRT boards:
+
+===============  ==  =====  ======== ======= ======= ======== ======= =======
+Board            ID  MCK    SCK_TX   WS_TX   SD_TX   SCK_RX   WS_RX   SD_RX
+===============  ==  =====  ======== ======= ======= ======== ======= =======
+Teensy 4.0       1   23     26       27      7       21       20      8
+Teensy 4.0       2   33     4        3       2       -        -       5
+Teensy 4.1       1   23     26       27      7       21       20      8
+Teensy 4.1       2   33     4        3       2       -        -       5
+Seeed Arch MIX   1   J4_09  J4_14    J4_15   J14_13  J4_11    J4_10   J4_10
+Olimex RT1010Py  1   D8     D6       D7      D4      D1       D2      D3
+Olimex RT1010Py  3   -      D10      D9      D11     -        -       -
+MIMXRT_DEV       1   "MCK"  "SCK_TX" "WS_TX" "SD_TX" "SCK_RX" "WS_RX" "SD_RX"
+===============  ==  =====  ======== ======= ======= ======== ======= =======
+
+Symbolic pin names are provided for the MIMXRT_10xx_DEV boards.
+These are provided for the other boards as well.

--- a/docs/mimxrt/quickref.rst
+++ b/docs/mimxrt/quickref.rst
@@ -17,6 +17,7 @@ working with this board it may be useful to get an overview of the microcontroll
 
    general.rst
    tutorial/intro.rst
+   pinout.rst
 
 
 Installing MicroPython
@@ -128,43 +129,9 @@ See :ref:`machine.UART <machine.UART>`. ::
     uart1.read(5)         # read up to 5 bytes
 
 The i.MXRT has up to eight hardware UARTs, but not every board exposes all
-TX and RX pins for users.  The pin assignment of UARTs to pins is fixed.
-The UARTs are numbered 1..8.  The rx/tx pins are assigned according to the
-tables below:
+TX and RX pins for users. For the assignment of Pins to UART signals,
+refer to the :ref:`UART pinout <mimxrt_uart_pinout>`.
 
-================  ===========  ===========  ===========  ===========
-Board / Pin           UART0        UART1        UART2        UART3
-================  ===========  ===========  ===========  ===========
-Teensy 4.0             -            0/1          7/8         14/15
-Teensy 4.1             -            0/1          7/8         14/15
-MIMXRT1010-EVK     Debug USB      D0/D1        D7/D6           -
-MIMXRT1015-EVK     Debug USB      D0/D1        D7/A1           -
-MIMXRT1020-EVK     Debug USB      D0/D1        D9/D6       D10/D13
-MIMXRT1050-EVK     Debug USB      D0/D1        D7/D6        D8/D9
-MIMXRT1050-EVKB    Debug USB      D0/D1        D7/D6        D8/D9
-MIMXRT1060-EVK     Debug USB      D0/D1        D7/D6        D8/D9
-MIMXRT1064-EVK     Debug USB      D0/D1        D7/D6        D8/D9
-MIMXRT1170-EVK     Debug USB      D0/D1       D12/D11      D10/D13
-Olimex RT1010Py       -          RxD/TxD       D5/D6           -
-Seeed ARCH MIX        -        J3_19/J3_20  J4_16/J4_17  J4_06/J4_07
-================  ===========  ===========  ===========  ===========
-
-================  ===========  ===========  =======  =======  =====
-Board / Pin           UART4        UART5      UART6    UART7   UART8
-================  ===========  ===========  =======  =======  =====
-Teensy 4.0            16/17        21/20     25/24    28/29      -
-Teensy 4.1            16/17        21/20     25/24    28/29    34/35
-MIMXRT1010-EVK         -            -         -        -        -
-MIMXRT1015-EVK         -            -         -        -        -
-MIMXRT1020-EVK      D15/D14       A1/A0       -        -        -
-MIMXRT1050-EVK       A1/A0          -         -        -        -
-MIMXRT1050-EVKB      A1/A0          -         -        -        -
-MIMXRT1060-EVK       A1/A0          -         -        -        -
-MIMXRT1064-EVK       A1/A0          -         -        -        -
-MIMXRT1170-EVK      D15/D14      D25/D26    D33/D34  D35/D36    -
-Olimex RT1010Py        -            -         -        -        -
-Seeed ARCH MIX    J4_10/J4_11  J5_08/J5_12    -        -        -
-================  ===========  ===========  =======  =======  =====
 
 PWM (pulse width modulation)
 ----------------------------
@@ -278,237 +245,9 @@ signal.
 
 PWM Pin Assignment
 ``````````````````
+Pins are specified in the same way as for the Pin class.  For the assignment of Pins
+to PWM signals, refer to the :ref:`PWM pinout <mimxrt_pwm_pinout>`.
 
-Pins are specified in the same way as for the Pin class.  The following tables show
-the assignment of the board Pins to PWM modules:
-
-===========   ==========   ==========   ======    ==============   ======
-Pin/ MIMXRT   1010         1015         1020      1050/1060/1064   1170
-===========   ==========   ==========   ======    ==============   ======
-D0            -            Q1/1         F1/1/B    -                -
-D1            -            Q1/0         F1/1/A    -                -
-D2            F1/3/B       F1/3/A       -         F1/3/B           -
-D3            F1/3/A       F1/0/A       F2/3/B    F4/0/A           F1/2/A
-D4            F1/3/A (*)   Q1/2         Q2/1      F2/3/A           Q4/2
-D5            F1/0/B (*)   F1/0/B       F2/3/A    F1/3/A           F1/2/B
-D6            -            F1/2/B       F2/0/A    Q3/2             F1/0/A
-D7            -            -            F1/0/A    Q3/3             -
-D8            F1/0/A       F1/1/B       F1/0/B    F1/1/X           Q4/3
-D9            F1/1/B (*)   F1/2/A       F2/0/B    F1/0/X           F1/0/B
-D10           F1/3/B       -            F2/2/B    F1/0/B (*)       F2/2/B
-D11           F1/2/A       -            F2/1/A    F1/1/A (*)       -
-D12           F1/2/B       -            F2/1/B    F1/1/B (*)       -
-D13           F1/3/A       -            F2/2/A    F1/0/A (*)       F2/2/A
-D14           F1/0/B       -            -         F2/3/B           -
-D15           F1/0/A       -            -         F2/3/A           -
-A0            -            -            F1/2/A    -                -
-A1            F1/3/X       F1/3/B       F1/2/B    -                -
-A2            F1/2/X       F1/3/A       F1/3/A    -                -
-A3            -            F1/2/A       F1/3/B    -                -
-A4            -            -            -         Q3/1             -
-A5            -            -            -         Q3/0             -
-D31           -            -            -         -                F1/2/B
-D32           -            -            -         -                F1/2/A
-D33           -            -            -         -                F1/1/B
-D34           -            -            -         -                F1/1/A
-D35           -            -            -         -                F1/0/B
-D36           -            -            -         -                F1/0/A
-===========   ==========   ==========   ======    ==============   ======
-
-Pins denoted with (*) are by default not wired at the board.
-
-====   ==========  ====   ==========
-Pin    Teensy 4.0  Pin    Teensy 4.1
-====   ==========  ====   ==========
-0      F1/1/X      0      F1/1/X
-1      F1/0/X      1      F1/0/X
-2      F4/2/A      2      F4/2/A
-3      F4/2/B      3      F4/2/B
-4      F2/0/A      4      F2/0/A
-5      F2/1/A      5      F2/1/A
-6      F2/2/A      6      F2/2/A
-7      F1/3/B      7      F1/3/B
-8      F1/3/A      8      F1/3/A
-9      F2/2/B      9      F2/2/B
-10     Q1/0        10     Q1/0
-11     Q1/2        11     Q1/2
-12     Q1/1        12     Q1/1
-13     Q2/0        13     Q2/0
-14     Q3/2        14     Q3/2
-15     Q3/3        15     Q3/3
-18     Q3/1        18     Q3/1
-19     Q3/0        19     Q3/0
-22     F4/0/A      22     F4/0/A
-23     F4/1/A      23     F4/1/A
-24     F1/2/X      24     F1/2/X
-25     F1/3/X      25     F1/3/X
-28     F3/1/B      28     F3/1/B
-29     F3/1/A      29     F3/1/A
-33     F2/0/B      33     F2/0/B
--      -           36     F2/3/A
--      -           37     F2/3/B
-DAT1   F1/1/B      42     F1/1/B
-DAT0   F1/1/A      43     F1/1/A
-CLK    F1/0/B      44     F1/0/B
-CMD    F1/0/A      45     F1/0/A
-DAT2   F1/2/A      46     F1/2/A
-DAT3   F1/2/B      47     F1/2/B
--      -           48     F1/0/B
--      -           49     F1/2/A
--      -           50     F1/2/B
--      -           51     F3/3/B
--      -           52     F1/1/B
--      -           53     F1/1/A
--      -           54     F3/0/A
-====   ==========  ====   ==========
-
-=========  ==============
-Pin        Seeed ARCH MIX
-=========  ==============
-J3_04      Q4/3
-J3_10      Q1/3
-J3_12      Q2/3
-J3_13      Q3/3
-J3_16      Q3/0
-J3_17      Q3/1
-J3_19      F1/3/X
-J3_20      F1/2/X
-J4_08      F4/0/A
-J4_09      F4/1/A
-J4_16      Q3/2
-J4_17      Q3/3
-J5_32      Q1/0
-J5_28      Q1/1
-J5_29      Q1/2
-J5_30      Q2/0
-J5_04      Q2/1
-J5_05      Q2/3
-J5_06      F2/0/A
-J5_07      F2/0/B
-J5_08      F2/1/A
-J5_12      F2/1/B
-J5_13      F2/2/A
-J5_14      F2/2/B
-J5_23      F1/3/A
-J5_24      F1/3/B
-J5_25      F2/3/A
-J5_26      F2/3/B
-J5_42      Q3/0
-J5_43      Q3/1
-J5_50      F1/0/X
-LED_RED    F2/3/A
-LED_GREEN  F1/3/A
-LED_BLUE   F1/3/B
-=========  ==============
-
-=========  ===============
-Pin        Olimex RT1010PY
-=========  ===============
-D0           -
-D1         F1/0/B
-D2         F1/0/A
-D3         F1/1/B
-D4         F1/1/A
-D5         F1/2/B
-D6         F1/2/A
-D7         F1/3/B
-D8         F1/3/A
-D9            -
-D10        F1/0/B
-D11        F1/0/A
-D12        F1/1/B
-D13        F1/1/A
-D14           -
-A0            -
-A1         F1/2/B
-A2         F1/2/A
-A3         F1/3/B
-A4         F1/3/A
-SDI        F1/3/X
-SDO        F1/2/X
-CS0        F1/1/X
-SCK        F1/0/X
-=========  ===============
-
-Legend:
-
-* Qm/n:    QTMR module m, channel n
-* Fm/n/l:  FLEXPWM module m, submodule n, channel l. The pulse at a X channel
-  is always aligned to the period start.
-
-Pins without a PWM signal are not listed.  A signal may be available at more
-than one Pin.  FlexPWM pins may also be pure CPU pin, not assigned to a board
-signal.  In that case the PWM output is disabled.  The PWM channel of a submodule
-0 may still be used as synchronization source for other channels of the same
-module, unless used by another peripheral.
-
-Submodule 0 pins for i.MX RT1011:
-
-==================  =======
-Pin                 Channel
-==================  =======
-Pin.cpu.GPIO_01     B
-Pin.cpu.GPIO_02     A
-Pin.cpu.GPIO_AD_12  X
-Pin.cpu.GPIO_SD_01  B
-Pin.cpu.GPIO_SD_02  A
-==================  =======
-
-Submodule 0 pins for i.MX RT1021:
-
-=====================  ==================
-Pin                    Module & Channel
-=====================  ==================
-Pin.cpu.GPIO_AD_B1_06  FLEXPWM1 Channel A
-Pin.cpu.GPIO_AD_B1_07  FLEXPWM1 Channel B
-Pin.cpu.GPIO_EMC_26    FLEXPWM1 Channel A
-Pin.cpu.GPIO_EMC_27    FLEXPWM1 Channel B
-Pin.cpu.GPIO_AD_B0_14  FLEXPWM2 Channel A
-Pin.cpu.GPIO_AD_B0_15  FLEXPWM2 Channel B
-Pin.cpu.GPIO_EMC_10    FLEXPWM2 Channel X
-Pin.cpu.GPIO_EMC_38    FLEXPWM2 Channel A
-Pin.cpu.GPIO_EMC_39    FLEXPWM2 Channel B
-=====================  ==================
-
-Submodule 0 pins for i.MX RT1052, i.MX RT1062 and i.MX RT1064:
-
-=====================  ==================
-Pin                    Module & Channel
-=====================  ==================
-Pin.cpu.GPIO_AD_B0_02  FLEXPWM1 Channel X
-Pin.cpu.GPIO_EMC_23    FLEXPWM1 Channel A
-Pin.cpu.GPIO_EMC_24    FLEXPWM1 Channel B
-Pin.cpu.GPIO_SD_B0_00  FLEXPWM1 Channel A
-Pin.cpu.GPIO_SD_B0_01  FLEXPWM1 Channel B
-Pin.cpu.GPIO_B0_06     FLEXPWM2 Channel A
-Pin.cpu.GPIO_B0_07     FLEXPWM2 Channel B
-Pin.cpu.GPIO_EMC_06    FLEXPWM2 Channel A
-Pin.cpu.GPIO_EMC_07    FLEXPWM2 Channel B
-Pin.cpu.GPIO_EMC_29    FLEXPWM3 Channel A
-Pin.cpu.GPIO_EMC_30    FLEXPWM3 Channel B
-Pin.cpu.GPIO_AD_B1_08  FLEXPWM4 Channel A
-Pin.cpu.GPIO_EMC_00    FLEXPWM4 Channel A
-Pin.cpu.GPIO_EMC_01    FLEXPWM4 Channel B
-=====================  ==================
-
-Submodule 0 pins for i.MX RT1176
-
-======================  ======================
-Pin                     Module & Channel
-======================  ======================
-Pin.cpu.GPIO_EMC_B1_00  FLEXPWM4 Channel A (*)
-Pin.cpu.GPIO_EMC_B1_01  FLEXPWM4 Channel B (*)
-Pin.cpu.GPIO_EMC_B1_06  FLEXPWM2 Channel A (*)
-Pin.cpu.GPIO_EMC_B1_07  FLEXPWM2 Channel B (*)
-Pin.cpu.GPIO_EMC_B1_23  FLEXPWM1 Channel A (*)
-Pin.cpu.GPIO_EMC_B1_24  FLEXPWM1 Channel B (*)
-Pin.cpu.GPIO_EMC_B1_29  FLEXPWM3 Channel A (*)
-Pin.cpu.GPIO_EMC_B1_30  FLEXPWM3 Channel B (*)
-Pin.cpu.GPIO_AD_00      FLEXPWM1 Channel A
-Pin.cpu.GPIO_AD_01      FLEXPWM1 Channel B
-Pin.cpu.GPIO_AD_24      FLEXPWM2 Channel A
-Pin.cpu.GPIO_AD_25      FLEXPWM2 Channel B
-======================  ======================
 
 (*) Pin used for SDRAM
 
@@ -562,45 +301,25 @@ Hardware SPI bus
 ----------------
 
 There are up to four hardware SPI channels that allow faster transmission
-rates (up to 90Mhz).  The SPI signals have fixed assignments to GPIO pins.
-It depends on the board design, which SPI's signals are exposed to the user, as
-detailed in the table below.  The signal order in the table is: CS0, CS1, MOSI, MISO, CLK.
-
-=================  =========================  =======================  ===============
-Board / Pin        SPI0                       SPI1                     SPI2
-=================  =========================  =======================  ===============
-Teensy 4.0         10/-/11/12/13              0/-/26/1/27                    -
-Teensy 4.1         10/37/11/12/13             0/-/26/1/27              -/29/50/54/49
-MIXMXRT1010-EVK    D10/D7/D11/D12/D13                -                       -
-MIXMXRT1015-EVK    D10/-/D11/D12/D13                 -                       -
-MIXMXRT1020-EVK    D10/-/D11/D12/D13          A3/D0/A5/A4/A0                 -
-MIXMXRT1050-EVK    D10/-/D11/D12/D13 (*)            -                        -
-MIXMXRT1050-EVKB   D10/-/D11/D12/D13 (*)            -                        -
-MIXMXRT1060-EVK    D10/-/D11/D12/D13 (*)            -                        -
-MIXMXRT1064-EVK    D10/-/D11/D12/D13 (*)            -                        -
-MIXMXRT1170-EVK    D10/-/D11/D12/D13          D28/-/D25/D24/D26        -/-/D14/D15/D24
-Olimex RT1010Py             -                 CS0/-/SDO/SDI/SCK        SDCARD with CS1
-Seeed ARCH MIX     J4_12/-/J4_14/J4_13/J4_15  J3_09/J3_05/J3_08_J3_11
-=================  =========================  =======================  ===============
-
-Pins denoted with (*) are by default not wired at the board.
-
-Hardware SPI is accessed via the :ref:`machine.SPI <machine.SPI>` class and
-has the same methods as software SPI above::
+rates (up to 30Mhz).  Hardware SPI is accessed via the 
+:ref:`machine.SPI <machine.SPI>` class and has the same methods as software SPI above::
 
     from machine import SPI
 
     spi = SPI(0, 10000000)
     spi.write('Hello World')
 
+For the assignment of Pins to SPI signals, refer to
+:ref:`Hardware SPI pinout <mimxrt_spi_pinout>`.
+
 Notes:
 
-1. Even if the highest supported baud rate at the moment is 90 Mhz,
+1. Even if the highest reliable baud rate at the moment is about 30 Mhz,
    setting a baud rate will not always result in exactly that
    frequency, especially at high baud rates.
 
-2. Sending at 90 MHz is possible, but in the tests receiving
-   only worked up to 60 MHz.
+2. Sending at higher baud rate is possible. In the tests receiving
+   worked up to 60 MHz, sending up to 90 MHz.
 
 Software I2C bus
 ----------------
@@ -627,25 +346,7 @@ Hardware I2C bus
 
 There are up to four hardware I2C channels that allow faster transmission rates
 and support the full I2C protocol.  The I2C signals have fixed assignments to GPIO pins.
-It depends on the board design, which I2C's signals are exposed to the user, as
-detailed in the table below.  The signal order in the table is: SDA, SCL.
-
-=================  ===========  ===========  ===========  =======  =======
-Board / Pin        I2C 0        I2C 1        I2C 2        I2C 3    I2C 4
-=================  ===========  ===========  ===========  =======  =======
-Teensy 4.0         18/19        17/16        25/24         -        -
-Teensy 4.1         18/19        17/16        25/24         -        -
-MIXMXRT1010-EVK    D14/D15      D0/D1         -            -        -
-MIXMXRT1015-EVK    D14/D15       -            -            -        -
-MIXMXRT1020-EVK    D14/D15      A4/A5        D0/D1         -        -
-MIXMXRT1050-EVK    A4/A5        D1/D0         -            -        -
-MIXMXRT1050-EVKB   A4/A5        D1/D0         -            -        -
-MIXMXRT1060-EVK    A4/A5        D1/D0         -            -        -
-MIXMXRT1064-EVK    A4/A5        D1/D0         -            -        -
-MIXMXRT1170-EVK    D14/D15      D1/D0        A4/A5        D26/D25  D19/D18
-Olimex RT1010Py      -          SDA1/SCL1    SDA2/SCL2     -        -
-Seeed ARCH MIX     J3_17/J3_16  J4_06/J4_07  J5_05/J5_04   -        -
-=================  ===========  ===========  ===========  =======  =======
+For the assignment of Pins to I2C signals, refer to :ref:`Hardware I2C pinout <mimxrt_i2c_pinout>`.
 
 Hardware I2C is accessed via the :ref:`machine.I2C <machine.I2C>` class and
 has the same methods as software SPI above::
@@ -716,25 +417,11 @@ essential since MCK is needed for its I2C operation and is provided by the I2S
 controller.
 
 MIMXRT boards may have 1 or 2 I2S buses available at the board connectors.
-On MIMXRT1010 devices the bus numbers are 1 and 3.
+On MIMXRT1010 devices the bus numbers are 1 and 3. The I2S signals have
+fixed assignments to GPIO pins. For the assignment of Pins to I2S signals,
+refer to :ref:`I2S pinout <mimxrt_i2s_pinout>`.
 
-Pin assignments for a few MIMXRT boards:
 
-===============  ==  =====  ======== ======= ======= ======== ======= =======
-Board            ID  MCK    SCK_TX   WS_TX   SD_TX   SCK_RX   WS_RX   SD_RX
-===============  ==  =====  ======== ======= ======= ======== ======= =======
-Teensy 4.0       1   23     26       27      7       21       20      8
-Teensy 4.0       2   33     4        3       2       -        -       5
-Teensy 4.1       1   23     26       27      7       21       20      8
-Teensy 4.1       2   33     4        3       2       -        -       5
-Seeed Arch MIX   1   J4_09  J4_14    J4_15   J14_13  J4_11    J4_10   J4_10
-Olimex RT1010Py  1   D8     D6       D7      D4      D1       D2      D3
-Olimex RT1010Py  3   -      D10      D9      D11     -        -       -
-MIMXRT_DEV       1   "MCK"  "SCK_TX" "WS_TX" "SD_TX" "SCK_RX" "WS_RX" "SD_RX"
-===============  ==  =====  ======== ======= ======= ======== ======= =======
-
-Symbolic pin names are provided for the MIMXRT_10xx_DEV boards.
-These are provided for the other boards as well.
 
 Real time clock (RTC)
 ---------------------

--- a/ports/mimxrt/boards/OLIMEX_RT1010/board.json
+++ b/ports/mimxrt/boards/OLIMEX_RT1010/board.json
@@ -1,6 +1,6 @@
 {
     "deploy": [
-        "../deploy_mimxrt.md"
+        "deploy_olimex.md"
     ],
     "docs": "",
     "features": [

--- a/ports/mimxrt/boards/OLIMEX_RT1010/deploy_olimex.md
+++ b/ports/mimxrt/boards/OLIMEX_RT1010/deploy_olimex.md
@@ -1,0 +1,38 @@
+For initial deploying the firmware a few preparation steps are required, which
+have to be done once.
+
+1. Get the files ufconv.py and uf2families.json from the micropython/tools directory,
+e.g. at https://github.com/micropython/micropython/tree/master/tools.
+2. Get the NXP program sdphost for your operating system, e.g. from
+https://github.com/adafruit/tinyuf2/tree/master/ports/mimxrt10xx/sdphost. You can as well get them from the
+NXP web sites.
+3. Get the UF2 boot-loader package https://github.com/adafruit/tinyuf2/releases/download/0.9.0/tinyuf2-imxrt1010_evk-0.9.0.zip
+and extract the file tinyuf2-imxrt1010_evk-0.9.0.bin.
+
+Now you have all files at hand that you will need for updating.
+
+1. Get the firmware you want to upload from the MicroPython download page.
+
+2. Push and hold the "Boot" button, then press "Reset", and release both buttons.
+
+3. Run the commands: 
+
+```
+sudo ./sdphost -u 0x1fc9,0x0145 -- write-file 0x20206400 tinyuf2-imxrt1010_evk-0.9.0.bin 
+sudo ./sdphost -u 0x1fc9,0x0145 -- jump-address 0x20207000 
+```
+Wait until a drive icon appears on the computer, and then run:
+```
+python3 uf2conv.py <firmware_xx.yy.zz.hex> --base 0x60000400 -f 0x4fb2d5bd
+```
+You can put all of that in a script. Just add a short wait before the 3rd command to let the drive connect.
+
+4. Once the upload is finished, push Reset again.
+
+Using sudo is Linux specific. You may not need it at all, if the access rights are set properly,
+and you will not need it for Windows. 
+
+Once the generic boot-loader is available, this procedure is only required for the first
+firmware load or in case that the flash is corrupted and the existing firmware is not functioning any
+more.
+

--- a/ports/mimxrt/boards/deploy_teensy.md
+++ b/ports/mimxrt/boards/deploy_teensy.md
@@ -11,4 +11,9 @@ or for Teensy 4.1:
 teensy_loader_cli --mcu=imxrt1062 -v -w TEENSY41-<date_version_tag>.hex
 ```
 
-When loading the firmware the PJRC boot loader will erase the content of the board file system.
+Instead of imxrt1062 with the --mcu option, you can as well use the board specic names
+TEENSY40, TEENSY41 or TEENSY_MICROMOD. When loading the firmware the PJRC boot loader
+will erase the board file system.
+
+Note: If the Teensy board is equipped with Teensy bootloader v1.07 and up, the first attempt to
+upload the firmware may fail. In that case try again.


### PR DESCRIPTION
- Mention i.MX RT1015 in the quick reference.
- Move the pinout tables to a separate document.
- Add a specific deploy procedure for Olimex RT1010 board.
- Update the deploy procedure for Teensy boards. 