### PR TITLE
Allow boards to override the default machine.bootloader behavior.

### DIFF
--- a/ports/nrf/modules/machine/modmachine.c
+++ b/ports/nrf/modules/machine/modmachine.c
@@ -191,6 +191,14 @@ STATIC mp_obj_t machine_disable_irq(void) {
 }
 MP_DEFINE_CONST_FUN_OBJ_0(machine_disable_irq_obj, machine_disable_irq);
 
+NORETURN mp_obj_t machine_bootloader(size_t n_args, const mp_obj_t *args) {
+    MICROPY_BOARD_ENTER_BOOTLOADER(n_args, args);
+    while (1) {
+        ;
+    }
+}
+MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(machine_bootloader_obj, 0, 1, machine_bootloader);
+
 STATIC const mp_rom_map_elem_t machine_module_globals_table[] = {
     { MP_ROM_QSTR(MP_QSTR___name__),           MP_ROM_QSTR(MP_QSTR_umachine) },
     { MP_ROM_QSTR(MP_QSTR_info),               MP_ROM_PTR(&machine_info_obj) },
@@ -242,6 +250,7 @@ STATIC const mp_rom_map_elem_t machine_module_globals_table[] = {
 #if defined(NRF52_SERIES)
     { MP_ROM_QSTR(MP_QSTR_NFC_RESET),          MP_ROM_INT(PYB_RESET_NFC) },
 #endif
+    { MP_ROM_QSTR(MP_QSTR_bootloader),          MP_ROM_PTR(&machine_bootloader_obj) },
 };
 
 STATIC MP_DEFINE_CONST_DICT(machine_module_globals, machine_module_globals_table);

--- a/ports/nrf/modules/machine/modmachine.h
+++ b/ports/nrf/modules/machine/modmachine.h
@@ -38,5 +38,6 @@ MP_DECLARE_CONST_FUN_OBJ_VAR_BETWEEN(machine_info_obj);
 MP_DECLARE_CONST_FUN_OBJ_0(machine_reset_obj);
 MP_DECLARE_CONST_FUN_OBJ_0(machine_lightsleep_obj);
 MP_DECLARE_CONST_FUN_OBJ_0(machine_deepsleep_obj);
+NORETURN mp_obj_t machine_bootloader(size_t n_args, const mp_obj_t *args);
 
 #endif // __MICROPY_INCLUDED_NRF5_MODMACHINE_H__

--- a/ports/nrf/mpconfigport.h
+++ b/ports/nrf/mpconfigport.h
@@ -366,3 +366,7 @@ extern const struct _mp_obj_module_t music_module;
 #ifndef MP_NEED_LOG2
 #define MP_NEED_LOG2                (1)
 #endif
+
+#ifndef MICROPY_BOARD_ENTER_BOOTLOADER
+#define MICROPY_BOARD_ENTER_BOOTLOADER(nargs, args)
+#endif

--- a/ports/renesas-ra/boardctrl.h
+++ b/ports/renesas-ra/boardctrl.h
@@ -37,6 +37,10 @@
 #define MICROPY_BOARD_STARTUP powerctrl_check_enter_bootloader
 #endif
 
+#ifndef MICROPY_BOARD_ENTER_BOOTLOADER
+#define MICROPY_BOARD_ENTER_BOOTLOADER(nargs, args)
+#endif
+
 #ifndef MICROPY_BOARD_EARLY_INIT
 #define MICROPY_BOARD_EARLY_INIT()
 #endif

--- a/ports/renesas-ra/modmachine.c
+++ b/ports/renesas-ra/modmachine.c
@@ -47,6 +47,7 @@
 #include "gccollect.h"
 #include "irq.h"
 #include "powerctrl.h"
+#include "boardctrl.h"
 #include "pybthread.h"
 #include "storage.h"
 #include "pin.h"
@@ -182,12 +183,14 @@ STATIC mp_obj_t machine_soft_reset(void) {
 MP_DEFINE_CONST_FUN_OBJ_0(machine_soft_reset_obj, machine_soft_reset);
 
 // Activate the bootloader without BOOT* pins.
-STATIC NORETURN mp_obj_t machine_bootloader(size_t n_args, const mp_obj_t *args) {
+NORETURN mp_obj_t machine_bootloader(size_t n_args, const mp_obj_t *args) {
     #if MICROPY_HW_ENABLE_STORAGE
     storage_flush();
     #endif
 
     __disable_irq();
+
+    MICROPY_BOARD_ENTER_BOOTLOADER(n_args, args);
 
     #if MICROPY_HW_USES_BOOTLOADER
     // ToDo: need to review how to implement

--- a/ports/renesas-ra/modmachine.h
+++ b/ports/renesas-ra/modmachine.h
@@ -49,6 +49,7 @@ void machine_deinit(void);
 void machine_pin_init(void);
 void machine_pin_deinit(void);
 void machine_i2s_init0(void);
+NORETURN mp_obj_t machine_bootloader(size_t n_args, const mp_obj_t *args);
 
 MP_DECLARE_CONST_FUN_OBJ_VAR_BETWEEN(machine_info_obj);
 MP_DECLARE_CONST_FUN_OBJ_0(machine_unique_id_obj);

--- a/ports/rp2/modmachine.c
+++ b/ports/rp2/modmachine.c
@@ -81,11 +81,14 @@ STATIC mp_obj_t machine_reset_cause(void) {
 }
 STATIC MP_DEFINE_CONST_FUN_OBJ_0(machine_reset_cause_obj, machine_reset_cause);
 
-STATIC mp_obj_t machine_bootloader(void) {
+NORETURN mp_obj_t machine_bootloader(size_t n_args, const mp_obj_t *args) {
+    MICROPY_BOARD_ENTER_BOOTLOADER(n_args, args);
     reset_usb_boot(0, 0);
-    return mp_const_none;
+    while (1) {
+        ;
+    }
 }
-MP_DEFINE_CONST_FUN_OBJ_0(machine_bootloader_obj, machine_bootloader);
+MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(machine_bootloader_obj, 0, 1, machine_bootloader);
 
 STATIC mp_obj_t machine_freq(size_t n_args, const mp_obj_t *args) {
     if (n_args == 0) {

--- a/ports/rp2/modmachine.h
+++ b/ports/rp2/modmachine.h
@@ -18,5 +18,6 @@ void machine_pin_deinit(void);
 void machine_i2s_init0(void);
 
 struct _machine_spi_obj_t *spi_from_mp_obj(mp_obj_t o);
+NORETURN mp_obj_t machine_bootloader(size_t n_args, const mp_obj_t *args);
 
 #endif // MICROPY_INCLUDED_RP2_MODMACHINE_H

--- a/ports/rp2/mpconfigport.h
+++ b/ports/rp2/mpconfigport.h
@@ -130,6 +130,10 @@
 #define mp_type_textio mp_type_vfs_lfs2_textio
 #endif
 
+#ifndef MICROPY_BOARD_ENTER_BOOTLOADER
+#define MICROPY_BOARD_ENTER_BOOTLOADER(nargs, args)
+#endif
+
 #if MICROPY_PY_NETWORK
 #define NETWORK_ROOT_POINTERS               mp_obj_list_t mod_network_nic_list;
 #else

--- a/ports/stm32/boardctrl.h
+++ b/ports/stm32/boardctrl.h
@@ -37,6 +37,10 @@
 #define MICROPY_BOARD_STARTUP powerctrl_check_enter_bootloader
 #endif
 
+#ifndef MICROPY_BOARD_ENTER_BOOTLOADER
+#define MICROPY_BOARD_ENTER_BOOTLOADER(nargs, args)
+#endif
+
 #ifndef MICROPY_BOARD_EARLY_INIT
 #define MICROPY_BOARD_EARLY_INIT()
 #endif

--- a/ports/stm32/boards/ARDUINO_PORTENTA_H7/mpconfigboard.h
+++ b/ports/stm32/boards/ARDUINO_PORTENTA_H7/mpconfigboard.h
@@ -38,7 +38,7 @@ void PORTENTA_board_startup(void);
 #define MICROPY_BOARD_EARLY_INIT    PORTENTA_board_early_init
 void PORTENTA_board_early_init(void);
 
-#define MICROPY_BOARD_ENTER_BOOTLOADER PORTENTA_board_enter_bootloader
+#define MICROPY_BOARD_ENTER_BOOTLOADER(nargs, args) PORTENTA_board_enter_bootloader()
 void PORTENTA_board_enter_bootloader(void);
 
 void PORTENTA_board_low_power(int mode);

--- a/ports/stm32/modmachine.c
+++ b/ports/stm32/modmachine.c
@@ -46,6 +46,7 @@
 #include "gccollect.h"
 #include "irq.h"
 #include "powerctrl.h"
+#include "boardctrl.h"
 #include "pybthread.h"
 #include "rng.h"
 #include "storage.h"
@@ -270,7 +271,7 @@ STATIC mp_obj_t machine_soft_reset(void) {
 MP_DEFINE_CONST_FUN_OBJ_0(machine_soft_reset_obj, machine_soft_reset);
 
 // Activate the bootloader without BOOT* pins.
-STATIC NORETURN mp_obj_t machine_bootloader(size_t n_args, const mp_obj_t *args) {
+NORETURN mp_obj_t machine_bootloader(size_t n_args, const mp_obj_t *args) {
     #if MICROPY_HW_ENABLE_USB
     pyb_usb_dev_deinit();
     #endif
@@ -279,6 +280,8 @@ STATIC NORETURN mp_obj_t machine_bootloader(size_t n_args, const mp_obj_t *args)
     #endif
 
     __disable_irq();
+
+    MICROPY_BOARD_ENTER_BOOTLOADER(n_args, args);
 
     #if MICROPY_HW_USES_BOOTLOADER
     if (n_args == 0 || !mp_obj_is_true(args[0])) {

--- a/ports/stm32/modmachine.h
+++ b/ports/stm32/modmachine.h
@@ -36,6 +36,7 @@ extern const mp_obj_type_t machine_i2s_type;
 void machine_init(void);
 void machine_deinit(void);
 void machine_i2s_init0();
+NORETURN mp_obj_t machine_bootloader(size_t n_args, const mp_obj_t *args);
 
 MP_DECLARE_CONST_FUN_OBJ_VAR_BETWEEN(machine_info_obj);
 MP_DECLARE_CONST_FUN_OBJ_0(machine_unique_id_obj);


### PR DESCRIPTION
This is a follow up to the discussion started in #8547. These changes allow boards to override the default `machine.bootloader()` behavior in way that's consistent across the `nrf`, `rp2`, `renesas-ra` and `stm32` ports.
Additionally, `rp2`'s `machine.bootloader()` was changed to conform to the documented generic `machine.bootloader` [API](https://docs.micropython.org/en/latest/library/machine.html?highlight=bootloader#machine.bootloader) and accept an optional arg (if provided).

