### PR TITLE
esp32/boards/UM_FEATHERS3: Use correct sdkconfig.board

### DIFF
--- a/ports/esp32/boards/UM_FEATHERS3/mpconfigboard.cmake
+++ b/ports/esp32/boards/UM_FEATHERS3/mpconfigboard.cmake
@@ -6,7 +6,7 @@ set(SDKCONFIG_DEFAULTS
     boards/sdkconfig.ble
     boards/sdkconfig.240mhz
     boards/sdkconfig.spiram_sx
-    boards/UM_TINYS3/sdkconfig.board
+    boards/UM_FEATHERS3/sdkconfig.board
 )
 
 set(MICROPY_FROZEN_MANIFEST ${MICROPY_BOARD_DIR}/manifest.py)


### PR DESCRIPTION
Was using sdkconfig.board from TINYS3 by mistake.