### PR TITLE
esp32/machine_pin: fix ESP32C3 build with IDFv4.4.1

### DIFF
--- a/ports/esp32/machine_pin.c
+++ b/ports/esp32/machine_pin.c
@@ -41,7 +41,7 @@
 #include "modesp32.h"
 
 #if CONFIG_IDF_TARGET_ESP32C3
-#include "hal/gpio_ll.h"
+#include "soc/usb_serial_jtag_reg.h"
 #endif
 
 // Used to implement a range of pull capabilities
@@ -290,7 +290,7 @@ STATIC mp_obj_t machine_pin_obj_init_helper(const machine_pin_obj_t *self, size_
 
     #if CONFIG_IDF_TARGET_ESP32C3
     if (self->id == 18 || self->id == 19) {
-        CLEAR_PERI_REG_MASK(USB_DEVICE_CONF0_REG, USB_DEVICE_USB_PAD_ENABLE);
+        CLEAR_PERI_REG_MASK(USB_SERIAL_JTAG_CONF0_REG, USB_SERIAL_JTAG_USB_PAD_ENABLE);
     }
     #endif
 


### PR DESCRIPTION
The build for the ESP32C3 was broken with IDFv4.4.1 due to some constants no longer being defined.

```
../machine_pin.c: In function 'machine_pin_obj_init_helper':
../machine_pin.c:293:29: error: 'USB_DEVICE_CONF0_REG' undeclared
../machine_pin.c:293:51: error: 'USB_DEVICE_USB_PAD_ENABLE' undeclared
```

Constants in question were used to make the pins normally used by JTAG available as general GPIO pins.

[espressif/esp-idf@`b25fb1`](https://github.com/espressif/esp-idf/commit/b25fb1111d6167e78bdbdb3d2a36fc783ec3bb12#diff-9ee9ace9d5e6342c5fbce93d7f3889a77b974e905f749d767711e814178c4909) removed said constants, and also showcases which constants can now be used instead.

EDIT: Previously typed 4.4, but of course that should be 4.4.1. :)