### PR TITLE
py/modmath: New function math hypot.

### DIFF
--- a/py/modmath.c
+++ b/py/modmath.c
@@ -199,7 +199,24 @@ MATH_FUN_1(erfc, erfc)
 MATH_FUN_1(gamma, tgamma)
 // lgamma(x): return the natural logarithm of the gamma function of x
 MATH_FUN_1(lgamma, lgamma)
+
+STATIC mp_obj_t mp_math_hypot(size_t n_args, const mp_obj_t *args) {
+    mp_float_t a;
+    mp_float_t a_pow2;
+    mp_float_t ans;
+    ans = (mp_float_t)0.0;
+    for (size_t i = 0; i < n_args; i++) {
+        a = mp_obj_get_float(args[i]);
+        a_pow2 = MICROPY_FLOAT_C_FUN(pow)(a, 2);
+        ans += a_pow2;
+    }
+    return mp_obj_new_float(MICROPY_FLOAT_C_FUN(sqrt)(ans));
+}
+
+MP_DEFINE_CONST_FUN_OBJ_VAR(mp_math_hypot_obj, 2, mp_math_hypot);
+
 #endif
+
 // TODO: fsum
 
 #if MICROPY_PY_MATH_ISCLOSE
@@ -425,6 +442,7 @@ STATIC const mp_rom_map_elem_t mp_module_math_globals_table[] = {
     { MP_ROM_QSTR(MP_QSTR_erfc), MP_ROM_PTR(&mp_math_erfc_obj) },
     { MP_ROM_QSTR(MP_QSTR_gamma), MP_ROM_PTR(&mp_math_gamma_obj) },
     { MP_ROM_QSTR(MP_QSTR_lgamma), MP_ROM_PTR(&mp_math_lgamma_obj) },
+    { MP_ROM_QSTR(MP_QSTR_hypot), MP_ROM_PTR(&mp_math_hypot_obj) },
     #endif
 };
 

--- a/tests/float/math_fun_special.py
+++ b/tests/float/math_fun_special.py
@@ -50,3 +50,20 @@ for function_name, function, test_vals in functions:
             print("{:.4g}".format(function(value)))
         except ValueError as e:
             print(str(e))
+
+hypot_func_var_args = [
+    (
+        "hypot",
+        hypot,
+        (
+            (12.0, 5.0),
+            (12, 5),
+            (bool(1), bool(0), bool(1), bool(1)),
+            (0.0, 0.0),
+            (-10.5),
+            (),
+            (1.5, 1.5, 0.5),
+            (1.5, 0.5, 1.5),
+        ),
+    ),
+]


### PR DESCRIPTION
Implement the math.hypot function.
This implementation covers the Change in CPython 3.8,  Multidimensional support of math.hypot(). https://github.com/python/cpython/pull/8474
This was worked on with the assistance of @wang3450