### PR TITLE
urandom: Discard first number after seeding.

### DIFF
--- a/extmod/modurandom.c
+++ b/extmod/modurandom.c
@@ -115,6 +115,7 @@ STATIC mp_obj_t mod_urandom_seed(size_t n_args, const mp_obj_t *args) {
     yasmarang_n = 69;
     yasmarang_d = 233;
     yasmarang_dat = 0;
+    (void)yasmarang();
     return mp_const_none;
 }
 STATIC MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(mod_urandom_seed_obj, 0, 1, mod_urandom_seed);


### PR DESCRIPTION
This is in some sense an incompatible change, as it alters the sequence of random values for any particular given seed.

It was brought to my attention that the very first number after seeding is highly non-uniform. This is exposed by a program like the following, which tries 10,000 different random seeds and records the out come of `randint(0,2)` for each seed:
```python
try:
    import random
except ImportError:
    import urandom as random

s = [0] * 3
for i in range(10000):
    random.seed(i)
    s[random.randint(0, 2)] += 1

print(s)
```

Ideally, the values of `s` would all be approximately equal. However, before this change, the outcome is
```
[5008, 0, 4992]
```
After this commit, which discards the first result after each seeding, the result is
```
[3542, 3332, 3126]
```

Only the very first value seems to be so extremely uneven in distribution.

Signed-off-by: Jeff Epler <jepler@gmail.com>