### PR TITLE
docs: fix make linkcheck, consistency updates.

### DIFF
--- a/CODECONVENTIONS.md
+++ b/CODECONVENTIONS.md
@@ -211,7 +211,7 @@ This is :ref:`reference <xref_target>`.
 
 * Linking to external URL:
 ```
-`link text <http://foo.com/...>`_
+`link text <https://foo.com/...>`_
 ```
 
 * Referencing builtin singleton objects:
@@ -230,6 +230,6 @@ This is :ref:`reference <xref_target>`.
 
 More detailed guides and quickrefs:
 
-* http://www.sphinx-doc.org/en/stable/rest.html
-* http://www.sphinx-doc.org/en/stable/markup/inline.html
-* http://docutils.sourceforge.net/docs/user/rst/quickref.html
+* https://www.sphinx-doc.org/en/master/usage/restructuredtext/basics.html
+* https://www.sphinx-doc.org/en/master/usage/restructuredtext/basics.html#inline-markup
+* https://docutils.sourceforge.io/docs/user/rst/quickref.html

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ The MicroPython project
 
 This is the MicroPython project, which aims to put an implementation
 of Python 3.x on microcontrollers and small embedded systems.
-You can find the official website at [micropython.org](http://www.micropython.org).
+You can find the official website at [micropython.org](https://www.micropython.org).
 
 WARNING: this project is in beta stage and is subject to changes of the
 code-base, including project-wide name changes and API changes.
@@ -26,7 +26,7 @@ MicroPython can execute scripts in textual source form or from precompiled
 bytecode, in both cases either from an on-device filesystem or "frozen" into
 the MicroPython executable.
 
-See the repository http://github.com/micropython/pyboard for the MicroPython
+See the repository https://github.com/micropython/pyboard for the MicroPython
 board (PyBoard), the officially supported reference electronic circuit board.
 
 Major components in this repository:
@@ -41,7 +41,7 @@ Major components in this repository:
   to port MicroPython to another microcontroller.
 - tests/ -- test framework and test scripts.
 - docs/ -- user documentation in Sphinx reStructuredText format. Rendered
-  HTML documentation is available at http://docs.micropython.org.
+  HTML documentation is available at https://docs.micropython.org.
 
 Additional components:
 - ports/bare-arm/ -- a bare minimum version of MicroPython for ARM MCUs. Used

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -16,7 +16,7 @@ FORCE         = -E
 
 # User-friendly check for sphinx-build
 ifeq ($(shell which $(SPHINXBUILD) >/dev/null 2>&1; echo $$?), 1)
-$(error The '$(SPHINXBUILD)' command was not found. Make sure you have Sphinx installed, then set the SPHINXBUILD environment variable to point to the full path of the '$(SPHINXBUILD)' executable. Alternatively you can add the directory with the executable to your PATH. If you don't have Sphinx installed, grab it from http://sphinx-doc.org/)
+$(error The '$(SPHINXBUILD)' command was not found. Make sure you have Sphinx installed, then set the SPHINXBUILD environment variable to point to the full path of the '$(SPHINXBUILD)' executable. Alternatively you can add the directory with the executable to your PATH. If you don't have Sphinx installed, grab it from https://sphinx-doc.org/)
 endif
 
 # Internal variables.

--- a/docs/README.md
+++ b/docs/README.md
@@ -2,7 +2,7 @@ MicroPython Documentation
 =========================
 
 The MicroPython documentation can be found at:
-http://docs.micropython.org/en/latest/
+https://docs.micropython.org/en/latest/
 
 The documentation you see there is generated from the files in the docs tree:
 https://github.com/micropython/micropython/tree/master/docs
@@ -33,7 +33,7 @@ BitBucket an alternative to building the docs locally is to sign up for a free
 https://readthedocs.org account. The rough steps to follow are:
 1. sign-up for an account, unless you already have one
 2. in your account settings: add GitHub as a connected service (assuming
-you have forked this repo on github)
+you have forked this repo on GitHub)
 3. in your account projects: import your forked/cloned micropython repository
 into readthedocs
 4. in the project's versions: add the branches you are developing on or

--- a/docs/develop/compiler.rst
+++ b/docs/develop/compiler.rst
@@ -129,7 +129,7 @@ The parser also maintains a table of constants for use in different aspects of p
 `symbol table <https://steemit.com/programming/@drifter1/writing-a-simple-compiler-on-my-own-symbol-table-basic-structure>`_
 does.
 
-Several optimizations like `constant folding <http://compileroptimizations.com/category/constant_folding.htm>`_
+Several optimizations like `constant folding <https://compileroptimizations.com/category/constant_folding.htm>`_
 on integers for most operations e.g. logical, binary, unary, etc, and optimizing enhancements on parenthesis
 around expressions are performed during this phase, along with some optimizations on strings.
 

--- a/docs/develop/gettingstarted.rst
+++ b/docs/develop/gettingstarted.rst
@@ -18,7 +18,7 @@ of Git for your operating system to follow through the rest of the steps.
 .. note::
    For a reference on the installation instructions, please refer to
    the `Git installation instructions <https://git-scm.com/book/en/v2/Getting-Started-Installing-Git>`_.
-   Learn about the basic git commands in this `Git Handbook <https://guides.github.com/introduction/git-handbook/>`_
+   Learn about the basic git commands in this `Git Handbook <https://docs.github.com/en/get-started/using-git/about-git>`_
    or any other sources on the internet.
 
 .. note::
@@ -112,10 +112,10 @@ Check that you have Python available on your system:
 .. code-block:: bash
 
    $ python3
-   Python 3.5.0 (default, Jul 17 2020, 14:04:10) 
+   Python 3.5.0 (default, Jul 17 2020, 14:04:10)
    [GCC 5.4.0 20160609] on linux
    Type "help", "copyright", "credits" or "license" for more information.
-   >>> 
+   >>>
 
 All supported ports have different dependency requirements, see their respective
 `readme files <https://github.com/micropython/micropython/tree/master/ports>`_.
@@ -201,7 +201,7 @@ Building the Windows port
 The Windows port includes a Visual Studio project file micropython.vcxproj that you can use to build micropython.exe.
 It can be opened in Visual Studio or built from the command line using msbuild. Alternatively, it can be built using mingw,
 either in Windows with Cygwin, or on Linux.
-See `windows port documentation <https://github.com/micropython/micropython/tree/master/ports/windows>`_ for more information.
+See `Windows port documentation <https://github.com/micropython/micropython/tree/master/ports/windows>`_ for more information.
 
 Building the STM32 port
 ~~~~~~~~~~~~~~~~~~~~~~~
@@ -314,7 +314,7 @@ extmod
 
 docs
 
-  Has the standard documentation found at https://docs.micropython.org/.
+  Has the standard documentation found at https://docs.micropython.org/en/latest/.
 
 tests
 
@@ -322,7 +322,7 @@ tests
 
 tools
 
-  Contains helper tools including the ``upip`` and the ``pyboard.py`` module.
+  Contains helper tools including the ``upip``, ``mpremote``, and the ``pyboard.py`` module.
 
 examples
 

--- a/docs/differences/python_35.rst
+++ b/docs/differences/python_35.rst
@@ -8,39 +8,39 @@ Below is a list of finalised/accepted PEPs for Python 3.5 grouped into their imp
    +----------------------------------------------------------------------------------------------------------+---------------+
    | **Extensions to the syntax:**                                                                            | **Status**    |
    +--------------------------------------------------------+-------------------------------------------------+---------------+
-   | `PEP 448 <https://www.python.org/dev/peps/pep-0448/>`_ | additional unpacking generalizations            | Partial       |
+   | `PEP 448 <https://peps.python.org/pep-0448/>`_         | additional unpacking generalizations            | Partial       |
    +--------------------------------------------------------+-------------------------------------------------+---------------+
-   | `PEP 465 <https://www.python.org/dev/peps/pep-0465/>`_ | a new matrix multiplication operator            | Completed     |
+   | `PEP 465 <https://peps.python.org/pep-0465/>`_         | a new matrix multiplication operator            | Completed     |
    +--------------------------------------------------------+-------------------------------------------------+---------------+
-   | `PEP 492 <https://www.python.org/dev/peps/pep-0492/>`_ | coroutines with async and await syntax          | Completed     |
+   | `PEP 492 <https://peps.python.org/pep-0492/>`_         | coroutines with async and await syntax          | Completed     |
    +--------------------------------------------------------+-------------------------------------------------+---------------+
    | **Extensions and changes to runtime:**                                                                                   |
    +--------------------------------------------------------+-------------------------------------------------+---------------+
-   | `PEP 461 <https://www.python.org/dev/peps/pep-0461/>`_ | % formatting for binary strings                 | Completed     |
+   | `PEP 461 <https://peps.python.org/pep-0461/>`_         | % formatting for binary strings                 | Completed     |
    +--------------------------------------------------------+-------------------------------------------------+---------------+
-   | `PEP 475 <https://www.python.org/dev/peps/pep-0475/>`_ | retrying system calls that fail with EINTR      | Completed     |
+   | `PEP 475 <https://peps.python.org/pep-0475/>`_         | retrying system calls that fail with EINTR      | Completed     |
    +--------------------------------------------------------+-------------------------------------------------+---------------+
-   | `PEP 479 <https://www.python.org/dev/peps/pep-0479/>`_ | change StopIteration handling inside generators | Completed     |
+   | `PEP 479 <https://peps.python.org/pep-0479/>`_         | change StopIteration handling inside generators | Completed     |
    +--------------------------------------------------------+-------------------------------------------------+---------------+
    | **Standard library changes:**                                                                                            |
    +--------------------------------------------------------+-------------------------------------------------+---------------+
-   | `PEP 471 <https://www.python.org/dev/peps/pep-0471/>`_ | os.scandir()                                    |               |
+   | `PEP 471 <https://peps.python.org/pep-0471/>`_         | os.scandir()                                    |               |
    +--------------------------------------------------------+-------------------------------------------------+---------------+
-   | `PEP 485 <https://www.python.org/dev/peps/pep-0485/>`_ | math.isclose(), a function for testing          | Completed     |
+   | `PEP 485 <https://peps.python.org/pep-0485/>`_         | math.isclose(), a function for testing          | Completed     |
    |                                                        | approximate equality                            |               |
    +--------------------------------------------------------+-------------------------------------------------+---------------+
    | **Miscellaneous changes:**                                                                                               |
    +--------------------------------------------------------+-------------------------------------------------+---------------+
-   | `PEP 441 <https://www.python.org/dev/peps/pep-0441/>`_ | improved Python zip application support         |               |
+   | `PEP 441 <https://peps.python.org/pep-0441/>`_         | improved Python zip application support         |               |
    +--------------------------------------------------------+-------------------------------------------------+---------------+
-   | `PEP 486 <https://www.python.org/dev/peps/pep-0486/>`_ | make the Python Launcher aware of virtual       | Not relevant  |
+   | `PEP 486 <https://peps.python.org/pep-0486/>`_         | make the Python Launcher aware of virtual       | Not relevant  |
    |                                                        | environments                                    |               |
    +--------------------------------------------------------+-------------------------------------------------+---------------+
-   | `PEP 484 <https://www.python.org/dev/peps/pep-0484/>`_ | type hints (advisory only)                      | In Progress   |
+   | `PEP 484 <https://peps.python.org/pep-0484/>`_         | type hints (advisory only)                      | In Progress   |
    +--------------------------------------------------------+-------------------------------------------------+---------------+
-   | `PEP 488 <https://www.python.org/dev/peps/pep-0488/>`_ | elimination of PYO files                        | Not relevant  |
+   | `PEP 488 <https://peps.python.org/pep-0488/>`_         | elimination of PYO files                        | Not relevant  |
    +--------------------------------------------------------+-------------------------------------------------+---------------+
-   | `PEP 489 <https://www.python.org/dev/peps/pep-0489/>`_ | redesigning extension module loading            |               |
+   | `PEP 489 <https://peps.python.org/pep-0489/>`_         | redesigning extension module loading            |               |
    +--------------------------------------------------------+-------------------------------------------------+---------------+
 
 

--- a/docs/differences/python_36.rst
+++ b/docs/differences/python_36.rst
@@ -8,46 +8,46 @@ Python 3.6 beta 1 was released on 12 Sep 2016, and a summary of the new features
   +-----------------------------------------------------------------------------------------------------------+--------------+
   | **New Syntax Features:**                                                                                  | **Status**   |
   +--------------------------------------------------------+--------------------------------------------------+--------------+
-  | `PEP 498 <https://www.python.org/dev/peps/pep-0498/>`_ | Literal String Formatting                        |              |
+  | `PEP 498 <https://peps.python.org/pep-0498/>`_         | Literal String Formatting                        |              |
   +--------------------------------------------------------+--------------------------------------------------+--------------+
-  | `PEP 515 <https://www.python.org/dev/peps/pep-0515/>`_ | Underscores in Numeric Literals                  |              |
+  | `PEP 515 <https://peps.python.org/pep-0515/>`_         | Underscores in Numeric Literals                  |              |
   +--------------------------------------------------------+--------------------------------------------------+--------------+
-  | `PEP 525 <https://www.python.org/dev/peps/pep-0525/>`_ | Asynchronous Generators                          |              |
+  | `PEP 525 <https://peps.python.org/pep-0525/>`_         | Asynchronous Generators                          |              |
   +--------------------------------------------------------+--------------------------------------------------+--------------+
-  | `PEP 526 <https://www.python.org/dev/peps/pep-0526/>`_ | Syntax for Variable Annotations (provisional)    |              |
+  | `PEP 526 <https://peps.python.org/pep-0526/>`_         | Syntax for Variable Annotations (provisional)    |              |
   +--------------------------------------------------------+--------------------------------------------------+--------------+
-  | `PEP 530 <https://www.python.org/dev/peps/pep-0530/>`_ | Asynchronous Comprehensions                      |              |
+  | `PEP 530 <https://peps.python.org/pep-0530/>`_         | Asynchronous Comprehensions                      |              |
   +--------------------------------------------------------+--------------------------------------------------+--------------+
   | **New Built-in Features:**                                                                                               |
   +--------------------------------------------------------+--------------------------------------------------+--------------+
-  | `PEP 468 <https://www.python.org/dev/peps/pep-0468/>`_ | Preserving the order of *kwargs* in a function   |              |
+  | `PEP 468 <https://peps.python.org/pep-0468/>`_         | Preserving the order of *kwargs* in a function   |              |
   +--------------------------------------------------------+--------------------------------------------------+--------------+
-  | `PEP 487 <https://www.python.org/dev/peps/pep-0487/>`_ | Simpler customization of class creation          |              |
+  | `PEP 487 <https://peps.python.org/pep-0487/>`_         | Simpler customization of class creation          |              |
   +--------------------------------------------------------+--------------------------------------------------+--------------+
-  | `PEP 520 <https://www.python.org/dev/peps/pep-0520/>`_ | Preserving Class Attribute Definition Order      |              |
+  | `PEP 520 <https://peps.python.org/pep-0520/>`_         | Preserving Class Attribute Definition Order      |              |
   +--------------------------------------------------------+--------------------------------------------------+--------------+
   | **Standard Library Changes:**                                                                                            |
   +--------------------------------------------------------+--------------------------------------------------+--------------+
-  | `PEP 495 <https://www.python.org/dev/peps/pep-0495/>`_ | Local Time Disambiguation                        |              |
+  | `PEP 495 <https://peps.python.org/pep-0495/>`_         | Local Time Disambiguation                        |              |
   +--------------------------------------------------------+--------------------------------------------------+--------------+
-  | `PEP 506 <https://www.python.org/dev/peps/pep-0506/>`_ | Adding A Secrets Module To The Standard Library  |              |
+  | `PEP 506 <https://peps.python.org/pep-0506/>`_         | Adding A Secrets Module To The Standard Library  |              |
   +--------------------------------------------------------+--------------------------------------------------+--------------+
-  | `PEP 519 <https://www.python.org/dev/peps/pep-0519/>`_ | Adding a file system path protocol               |              |
+  | `PEP 519 <https://peps.python.org/pep-0519/>`_         | Adding a file system path protocol               |              |
   +--------------------------------------------------------+--------------------------------------------------+--------------+
   | **CPython internals:**                                                                                                   |
   +--------------------------------------------------------+--------------------------------------------------+--------------+
-  | `PEP 509 <https://www.python.org/dev/peps/pep-0509/>`_ | Add a private version to dict                    |              |
+  | `PEP 509 <https://peps.python.org/pep-0509/>`_         | Add a private version to dict                    |              |
   +--------------------------------------------------------+--------------------------------------------------+--------------+
-  | `PEP 523 <https://www.python.org/dev/peps/pep-0523/>`_ | Adding a frame evaluation API to CPython         |              |
+  | `PEP 523 <https://peps.python.org/pep-0523/>`_         | Adding a frame evaluation API to CPython         |              |
   +--------------------------------------------------------+--------------------------------------------------+--------------+
   | **Linux/Window Changes**                                                                                                 |
   +--------------------------------------------------------+--------------------------------------------------+--------------+
-  | `PEP 524 <https://www.python.org/dev/peps/pep-0524/>`_ | Make os.urandom() blocking on Linux              |              |
+  | `PEP 524 <https://peps.python.org/pep-0524/>`_         | Make os.urandom() blocking on Linux              |              |
   |                                                        | (during system startup)                          |              |
   +--------------------------------------------------------+--------------------------------------------------+--------------+
-  | `PEP 528 <https://www.python.org/dev/peps/pep-0528/>`_ | Change Windows console encoding to UTF-8         |              |
+  | `PEP 528 <https://peps.python.org/pep-0528/>`_         | Change Windows console encoding to UTF-8         |              |
   +--------------------------------------------------------+--------------------------------------------------+--------------+
-  | `PEP 529 <https://www.python.org/dev/peps/pep-0529/>`_ | Change Windows filesystem encoding to UTF-8      |              |
+  | `PEP 529 <https://peps.python.org/pep-0529/>`_         | Change Windows filesystem encoding to UTF-8      |              |
   +--------------------------------------------------------+--------------------------------------------------+--------------+
 
 Other Language Changes:

--- a/docs/differences/python_37.rst
+++ b/docs/differences/python_37.rst
@@ -8,30 +8,30 @@ New Features:
   +--------------------------------------------------------+--------------------------------------------------+----------------+
   | **Features:**                                                                                             | **Status**     |
   +--------------------------------------------------------+--------------------------------------------------+----------------+
-  | `PEP 538 <https://www.python.org/dev/peps/pep-0538/>`_ | Coercing the legacy C locale to a UTF-8 based    |                |
+  | `PEP 538 <https://peps.python.org/pep-0538/>`_         | Coercing the legacy C locale to a UTF-8 based    |                |
   |                                                        | locale                                           |                |
   +--------------------------------------------------------+--------------------------------------------------+----------------+
-  | `PEP 539 <https://www.python.org/dev/peps/pep-0539/>`_ | A New C-API for Thread-Local Storage in CPython  |                |
+  | `PEP 539 <https://peps.python.org/pep-0539/>`_         | A New C-API for Thread-Local Storage in CPython  |                |
   +--------------------------------------------------------+--------------------------------------------------+----------------+
-  | `PEP 540 <https://www.python.org/dev/peps/pep-0540/>`_ | UTF-8 mode                                       |                |
+  | `PEP 540 <https://peps.python.org/pep-0540/>`_         | UTF-8 mode                                       |                |
   +--------------------------------------------------------+--------------------------------------------------+----------------+
-  | `PEP 552 <https://www.python.org/dev/peps/pep-0552/>`_ | Deterministic pyc                                |                |
+  | `PEP 552 <https://peps.python.org/pep-0552/>`_         | Deterministic pyc                                |                |
   +--------------------------------------------------------+--------------------------------------------------+----------------+
-  | `PEP 553 <https://www.python.org/dev/peps/pep-0553/>`_ | Built-in breakpoint()                            |                |
+  | `PEP 553 <https://peps.python.org/pep-0553/>`_         | Built-in breakpoint()                            |                |
   +--------------------------------------------------------+--------------------------------------------------+----------------+
-  | `PEP 557 <https://www.python.org/dev/peps/pep-0557/>`_ | Data Classes                                     |                |
+  | `PEP 557 <https://peps.python.org/pep-0557/>`_         | Data Classes                                     |                |
   +--------------------------------------------------------+--------------------------------------------------+----------------+
-  | `PEP 560 <https://www.python.org/dev/peps/pep-0560/>`_ | Core support for typing module and generic types |                |
+  | `PEP 560 <https://peps.python.org/pep-0560/>`_         | Core support for typing module and generic types |                |
   +--------------------------------------------------------+--------------------------------------------------+----------------+
-  | `PEP 562 <https://www.python.org/dev/peps/pep-0562/>`_ | Module __getattr__ and __dir__                   | Partially done |
+  | `PEP 562 <https://peps.python.org/pep-0562/>`_         | Module __getattr__ and __dir__                   | Partially done |
   +--------------------------------------------------------+--------------------------------------------------+----------------+
-  | `PEP 563 <https://www.python.org/dev/peps/pep-0563/>`_ | Postponed Evaluation of Annotations              |                |
+  | `PEP 563 <https://peps.python.org/pep-0563/>`_         | Postponed Evaluation of Annotations              |                |
   +--------------------------------------------------------+--------------------------------------------------+----------------+
-  | `PEP 564 <https://www.python.org/dev/peps/pep-0564/>`_ | Time functions with nanosecond resolution        |                |
+  | `PEP 564 <https://peps.python.org/pep-0564/>`_         | Time functions with nanosecond resolution        |                |
   +--------------------------------------------------------+--------------------------------------------------+----------------+
-  | `PEP 565 <https://www.python.org/dev/peps/pep-0565/>`_ | Show DeprecationWarning in __main__              |                |
+  | `PEP 565 <https://peps.python.org/pep-0565/>`_         | Show DeprecationWarning in __main__              |                |
   +--------------------------------------------------------+--------------------------------------------------+----------------+
-  | `PEP 567 <https://www.python.org/dev/peps/pep-0567/>`_ | Context Variables                                |                |
+  | `PEP 567 <https://peps.python.org/pep-0567/>`_         | Context Variables                                |                |
   +--------------------------------------------------------+--------------------------------------------------+----------------+
 
 Other Language Changes:

--- a/docs/differences/python_38.rst
+++ b/docs/differences/python_38.rst
@@ -4,24 +4,24 @@ Python 3.8
 ==========
 
 Python 3.8.0 (final) was released on the 14 October 2019. The Features for 3.8
-are defined in `PEP 569 <https://www.python.org/dev/peps/pep-0569/#id9>`_ and
+are defined in `PEP 569 <https://peps.python.org/pep-0569/#features-for-3-8>`_ and
 a detailed description of the changes can be found in What's New in `Python
 3.8. <https://docs.python.org/3/whatsnew/3.8.html>`_
 
   +--------------------------------------------------------+---------------------------------------------------+---------------+
   | **Features:**                                                                                              | Status        |
   +--------------------------------------------------------+---------------------------------------------------+---------------+
-  | `PEP 570 <https://www.python.org/dev/peps/pep-0570/>`_ | Positional-only arguments                         |               |
+  | `PEP 570 <https://peps.python.org/pep-0570/>`_         | Positional-only arguments                         |               |
   +--------------------------------------------------------+---------------------------------------------------+---------------+
-  | `PEP 572 <https://www.python.org/dev/peps/pep-0572/>`_ | Assignment Expressions                            |               |
+  | `PEP 572 <https://peps.python.org/pep-0572/>`_         | Assignment Expressions                            |               |
   +--------------------------------------------------------+---------------------------------------------------+---------------+
-  | `PEP 574 <https://www.python.org/dev/peps/pep-0574/>`_ | Pickle protocol 5 with out-of-band data           |               |
+  | `PEP 574 <https://peps.python.org/pep-0574/>`_         | Pickle protocol 5 with out-of-band data           |               |
   +--------------------------------------------------------+---------------------------------------------------+---------------+
-  | `PEP 578 <https://www.python.org/dev/peps/pep-0578/>`_ | Runtime audit hooks                               |               |
+  | `PEP 578 <https://peps.python.org/pep-0578/>`_         | Runtime audit hooks                               |               |
   +--------------------------------------------------------+---------------------------------------------------+---------------+
-  | `PEP 587 <https://www.python.org/dev/peps/pep-0587/>`_ | Python Initialization Configuration               |               |
+  | `PEP 587 <https://peps.python.org/pep-0587/>`_         | Python Initialization Configuration               |               |
   +--------------------------------------------------------+---------------------------------------------------+---------------+
-  | `PEP 590 <https://www.python.org/dev/peps/pep-0590/>`_ | Vectorcall: a fast calling protocol for CPython   |               |
+  | `PEP 590 <https://peps.python.org/pep-0590/>`_         | Vectorcall: a fast calling protocol for CPython   |               |
   +--------------------------------------------------------+---------------------------------------------------+---------------+
   | **Miscellaneous**                                                                                                          |
   +------------------------------------------------------------------------------------------------------------+---------------+

--- a/docs/differences/python_39.rst
+++ b/docs/differences/python_39.rst
@@ -4,33 +4,33 @@ Python 3.9
 ==========
 
 Python 3.9.0 (final) was released on the 5th October 2020. The Features for 3.9 are
-defined in `PEP 596 <https://www.python.org/dev/peps/pep-0596/#features-for-3-9>`_
+defined in `PEP 596 <https://peps.python.org/pep-0596/#features-for-3-9>`_
 and a detailed description of the changes can be found in
 `What's New in Python 3.9 <https://docs.python.org/3/whatsnew/3.9.html>`_
 
   +--------------------------------------------------------+----------------------------------------------------+--------------+
   | **Features:**                                          |                                                    | **Status**   |
   +--------------------------------------------------------+----------------------------------------------------+--------------+
-  | `PEP 573 <https://www.python.org/dev/peps/pep-0573/>`_ | fast access to module state from methods of C      |              |
+  | `PEP 573 <https://peps.python.org/pep-0573/>`_         | fast access to module state from methods of C      |              |
   |                                                        | extension types                                    |              |
   +--------------------------------------------------------+----------------------------------------------------+--------------+
-  | `PEP 584 <https://www.python.org/dev/peps/pep-0584/>`_ | union operators added to dict                      |              |
+  | `PEP 584 <https://peps.python.org/pep-0584/>`_         | union operators added to dict                      |              |
   +--------------------------------------------------------+----------------------------------------------------+--------------+
-  | `PEP 585 <https://www.python.org/dev/peps/pep-0584/>`_ | type hinting generics in standard collections      |              |
+  | `PEP 585 <https://peps.python.org/pep-0584/>`_         | type hinting generics in standard collections      |              |
   +--------------------------------------------------------+----------------------------------------------------+--------------+
-  | `PEP 593 <https://www.python.org/dev/peps/pep-0593/>`_ | flexible function and variable annotations         |              |
+  | `PEP 593 <https://peps.python.org/pep-0593/>`_         | flexible function and variable annotations         |              |
   +--------------------------------------------------------+----------------------------------------------------+--------------+
-  | `PEP 602 <https://www.python.org/dev/peps/pep-0602/>`_ | CPython adopts an annual release cycle. Instead of |              |
+  | `PEP 602 <https://peps.python.org/pep-0602/>`_         | CPython adopts an annual release cycle. Instead of |              |
   |                                                        | annual, aiming for two month release cycle         |              |
   +--------------------------------------------------------+----------------------------------------------------+--------------+
-  | `PEP 614 <https://www.python.org/dev/peps/pep-0614/>`_ | relaxed grammar restrictions on decorators         |              |
+  | `PEP 614 <https://peps.python.org/pep-0614/>`_         | relaxed grammar restrictions on decorators         |              |
   +--------------------------------------------------------+----------------------------------------------------+--------------+
-  | `PEP 615 <https://www.python.org/dev/peps/pep-0615/>`_ | the IANA Time Zone Database is now present in the  |              |
+  | `PEP 615 <https://peps.python.org/pep-0615/>`_         | the IANA Time Zone Database is now present in the  |              |
   |                                                        | standard library in the zoneinfo module            |              |
   +--------------------------------------------------------+----------------------------------------------------+--------------+
-  | `PEP 616 <https://www.python.org/dev/peps/pep-0616/>`_ | string methods to remove prefixes and suffixes     |              |
+  | `PEP 616 <https://peps.python.org/pep-0616/>`_         | string methods to remove prefixes and suffixes     |              |
   +--------------------------------------------------------+----------------------------------------------------+--------------+
-  | `PEP 617 <https://www.python.org/dev/peps/pep-0617/>`_ | CPython now uses a new parser based on PEG         |              |
+  | `PEP 617 <https://peps.python.org/pep-0617/>`_         | CPython now uses a new parser based on PEG         |              |
   +--------------------------------------------------------+----------------------------------------------------+--------------+
 
 Other Language Changes:

--- a/docs/esp32/general.rst
+++ b/docs/esp32/general.rst
@@ -32,7 +32,7 @@ Technical specifications and SoC datasheets
 -------------------------------------------
 
 The datasheets and other reference material for ESP32 chip are available
-from the vendor site: https://www.espressif.com/en/support/download/documents?keys=esp32 .
+from the vendor site: https://www.espressif.com/en/support/documents/technical-documents .
 They are the primary reference for the chip technical specifications, capabilities,
 operating modes, internal functioning, etc.
 
@@ -60,5 +60,5 @@ For more information see the ESP32 datasheet: https://www.espressif.com/sites/de
 
 MicroPython is implemented on top of the ESP-IDF, Espressif's development
 framework for the ESP32.  This is a FreeRTOS based system.  See the
-`ESP-IDF Programming Guide <https://docs.espressif.com/projects/esp-idf/en/latest/index.html>`_
+`ESP-IDF Programming Guide <https://docs.espressif.com/projects/esp-idf/en/latest/esp32/index.html>`_
 for details.

--- a/docs/esp32/quickref.rst
+++ b/docs/esp32/quickref.rst
@@ -233,7 +233,7 @@ PWM (pulse width modulation)
 PWM can be enabled on all output-enabled pins. The base frequency can
 range from 1Hz to 40MHz but there is a tradeoff; as the base frequency
 *increases* the duty resolution *decreases*. See
-`LED Control <https://docs.espressif.com/projects/esp-idf/en/latest/api-reference/peripherals/ledc.html>`_
+`LED Control <https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-reference/peripherals/ledc.html>`_
 for more details.
 
 Use the :ref:`machine.PWM <machine.PWM>` class::
@@ -702,7 +702,7 @@ Note that TouchPads can be used to wake an ESP32 from sleep::
     machine.lightsleep()        # put the MCU to sleep until a touchpad is touched
 
 For more details on touchpads refer to `Espressif Touch Sensor
-<https://docs.espressif.com/projects/esp-idf/en/latest/api-reference/peripherals/touch_pad.html>`_.
+<https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-reference/peripherals/touch_pad.html>`_.
 
 
 DHT driver
@@ -752,5 +752,5 @@ for file transfer (both upload and download).  The web client has buttons for
 the corresponding functions, or you can use the command-line client
 ``webrepl_cli.py`` from the repository above.
 
-See the MicroPython forum for other community-supported alternatives
+See the `MicroPython forum <https://forum.micropython.org>`_ for other community-supported alternatives
 to transfer files to an ESP32 board.

--- a/docs/esp32/tutorial/intro.rst
+++ b/docs/esp32/tutorial/intro.rst
@@ -36,7 +36,7 @@ Getting the firmware
 
 The first thing you need to do is download the most recent MicroPython firmware
 .bin file to load onto your ESP32 device. You can download it from the
-`MicroPython downloads page <https://micropython.org/download#esp32>`_.
+`MicroPython downloads page <https://micropython.org/download/?port=esp32>`_.
 From here, you have 3 main choices:
 
 * Stable firmware builds

--- a/docs/esp8266/general.rst
+++ b/docs/esp8266/general.rst
@@ -38,7 +38,7 @@ Technical specifications and SoC datasheets
 -------------------------------------------
 
 The datasheets and other reference material for ESP8266 chip are available
-from the vendor site: http://bbs.espressif.com/viewtopic.php?f=67&t=225 .
+from the vendor site: https://www.espressif.com/en/support/documents/technical-documents .
 They are the primary reference for the chip technical specifications, capabilities,
 operating modes, internal functioning, etc.
 
@@ -195,7 +195,7 @@ limitation with usage of TLS on the low-memory devices:
    used, with the idea that the most interesting usage for SSL would be
    accessing various REST APIs, which usually require much smaller messages.
    The buffers size is on the order of 5KB, and is adjusted from time to
-   time, taking as a reference being able to access https://google.com .
+   time, taking as a reference being able to access https://www.google.com .
    The smaller buffer however means that some sites can't be accessed using
    it, and it's not possible to stream large amounts of data. axTLS does
    have support for TLS's Max Fragment Size extension, but no HTTPS website

--- a/docs/esp8266/quickref.rst
+++ b/docs/esp8266/quickref.rst
@@ -462,5 +462,5 @@ transfer (both upload and download). Web client has buttons for the
 corresponding functions, or you can use command-line client ``webrepl_cli.py``
 from the repository above.
 
-See the MicroPython forum for other community-supported alternatives
+See the `MicroPython forum <https://forum.micropython.org>`_ for other community-supported alternatives
 to transfer files to ESP8266.

--- a/docs/esp8266/tutorial/intro.rst
+++ b/docs/esp8266/tutorial/intro.rst
@@ -43,7 +43,7 @@ Getting the firmware
 
 The first thing you need to do is download the most recent MicroPython firmware
 .bin file to load onto your ESP8266 device. You can download it from the
-`MicroPython downloads page <http://micropython.org/download#esp8266>`_.
+`MicroPython downloads page <https://micropython.org/download/?port=esp8266>`_.
 From here, you have 3 main choices
 
 * Stable firmware builds for 1024kb modules and above.
@@ -110,7 +110,7 @@ that you have.
 
 For some boards with a particular FlashROM configuration (e.g. some variants of
 a NodeMCU board) you may need to manually set a compatible
-`SPI Flash Mode <https://github.com/espressif/esptool/wiki/SPI-Flash-Modes>`_.
+`SPI Flash Mode <https://docs.espressif.com/projects/esptool/en/latest/esp8266/advanced-topics/spi-flash-modes.html>`_.
 You'd usually pick the fastest option that is compatible with your device, but
 the ``-fm dout`` option (the slowest option) should have the best compatibility::
 
@@ -158,7 +158,7 @@ after it, here are troubleshooting recommendations:
   advised to avoid using unearthed power connections when working with ESP8266
   and other boards. In regard to FlashROM hardware problems, there are independent
   (not related to MicroPython in any way) reports
-  `(e.g.) <http://internetofhomethings.com/homethings/?p=538>`_
+  `(e.g.) <https://internetofhomethings.com/homethings/?p=538>`_
   that on some ESP8266 modules, FlashROM can be programmed as little as 20 times
   before programming errors occur. This is *much* less than 100,000 programming
   cycles cited for FlashROM chips of a type used with ESP8266 by reputable

--- a/docs/esp8266/tutorial/network_tcp.rst
+++ b/docs/esp8266/tutorial/network_tcp.rst
@@ -77,7 +77,7 @@ Let's define a function that can download and print a URL::
 
 Then you can try::
 
-    >>> http_get('http://micropython.org/ks/test.html')
+    >>> http_get('https://micropython.org/ks/test.html')
 
 This should retrieve the webpage and print the HTML to the console.
 

--- a/docs/library/binascii.rst
+++ b/docs/library/binascii.rst
@@ -28,11 +28,11 @@ Functions
 .. function:: a2b_base64(data)
 
    Decode base64-encoded data, ignoring invalid characters in the input.
-   Conforms to `RFC 2045 s.6.8 <https://tools.ietf.org/html/rfc2045#section-6.8>`_.
+   Conforms to `RFC 2045 s.6.8 <https://datatracker.ietf.org/doc/html/rfc2045#section-6.8>`_.
    Returns a bytes object.
 
 .. function:: b2a_base64(data, *, newline=True)
 
    Encode binary data in base64 format, as in `RFC 3548
-   <https://tools.ietf.org/html/rfc3548.html>`_. Returns the encoded data
+   <https://datatracker.ietf.org/doc/html/rfc3548.html>`_. Returns the encoded data
    followed by a newline character if newline is true, as a bytes object.

--- a/docs/library/esp32.rst
+++ b/docs/library/esp32.rst
@@ -183,7 +183,7 @@ with each number, the bitstream is ``0101`` with durations of [100ns, 2000ns,
 100ns, 4000ns].
 
 For more details see Espressif's `ESP-IDF RMT documentation.
-<https://docs.espressif.com/projects/esp-idf/en/latest/api-reference/peripherals/rmt.html>`_.
+<https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-reference/peripherals/rmt.html>`_.
 
 .. Warning::
    The current MicroPython RMT implementation lacks some features, most notably

--- a/docs/library/lcd160cr.rst
+++ b/docs/library/lcd160cr.rst
@@ -6,14 +6,14 @@
 
 This module provides control of the MicroPython LCD160CR display.
 
-.. image:: http://micropython.org/resources/LCD160CRv10-persp.jpg
+.. image:: https://micropython.org/resources/LCD160CRv10-persp.jpg
     :alt: LCD160CRv1.0 picture
     :width: 640px
 
 Further resources are available via the following links:
 
-* `LCD160CRv1.0 reference manual <http://micropython.org/resources/LCD160CRv10-refmanual.pdf>`_ (100KiB PDF)
-* `LCD160CRv1.0 schematics <http://micropython.org/resources/LCD160CRv10-schematics.pdf>`_ (1.6MiB PDF)
+* `LCD160CRv1.0 reference manual <https://micropython.org/resources/LCD160CRv10-refmanual.pdf>`_ (100KiB PDF)
+* `LCD160CRv1.0 schematics <https://micropython.org/resources/LCD160CRv10-schematics.pdf>`_ (1.6MiB PDF)
 
 class LCD160CR
 --------------
@@ -69,7 +69,7 @@ Constructors
         - "YX" is for the left-side and uses:
           ``pwr=Pin("Y4")``, ``i2c=I2C("X")``, ``spi=SPI("Y")``
 
-    See `this image <http://micropython.org/resources/LCD160CRv10-positions.jpg>`_
+    See `this image <https://micropython.org/resources/LCD160CRv10-positions.jpg>`_
     for how the display can be connected to the pyboard.
 
 Static methods

--- a/docs/library/os.rst
+++ b/docs/library/os.rst
@@ -218,10 +218,10 @@ represented by VFS classes.
     .. note:: There are reports of littlefs v2 failing in certain situations,
               for details see `littlefs issue 295`_.
 
-.. _littlefs v1 filesystem format: https://github.com/ARMmbed/littlefs/tree/v1
-.. _littlefs v2 filesystem format: https://github.com/ARMmbed/littlefs
-.. _littlefs issue 295: https://github.com/ARMmbed/littlefs/issues/295
-.. _littlefs issue 347: https://github.com/ARMmbed/littlefs/issues/347
+.. _littlefs v1 filesystem format: https://github.com/littlefs-project/littlefs/tree/v1
+.. _littlefs v2 filesystem format: https://github.com/littlefs-project/littlefs
+.. _littlefs issue 295: https://github.com/littlefs-project/littlefs/issues/295
+.. _littlefs issue 347: https://github.com/littlefs-project/littlefs/issues/347
 
 Block devices
 -------------

--- a/docs/library/pyb.ExtInt.rst
+++ b/docs/library/pyb.ExtInt.rst
@@ -21,7 +21,7 @@ Note: ExtInt will automatically configure the gpio line as an input. ::
 Now every time a falling edge is seen on the X1 pin, the callback will be
 called. Caution: mechanical pushbuttons have "bounce" and pushing or
 releasing a switch will often generate multiple edges.
-See: http://www.eng.utah.edu/~cs5780/debouncing.pdf for a detailed
+See: https://my.eng.utah.edu/~cs5780/debouncing.pdf for a detailed
 explanation, along with various techniques for debouncing.
 
 Trying to register 2 callbacks onto the same pin will throw an exception.

--- a/docs/library/pyb.Pin.rst
+++ b/docs/library/pyb.Pin.rst
@@ -65,7 +65,7 @@ respectively (except pin Y5 which has 11k Ohm resistors).
 Now every time a falling edge is seen on the gpio pin, the callback will be
 executed. Caution: mechanical push buttons have "bounce" and pushing or
 releasing a switch will often generate multiple edges.
-See: http://www.eng.utah.edu/~cs5780/debouncing.pdf for a detailed
+See: https://www.eng.utah.edu/~cs5780/debouncing.pdf for a detailed
 explanation, along with various techniques for debouncing.
 
 All pin objects go through the pin mapper to come up with one of the

--- a/docs/library/rp2.rst
+++ b/docs/library/rp2.rst
@@ -10,7 +10,7 @@ The ``rp2`` module contains functions and classes specific to the RP2040, as
 used in the Raspberry Pi Pico.
 
 See the `RP2040 Python datasheet
-<https://datasheets.raspberrypi.org/pico/raspberry-pi-pico-python-sdk.pdf>`_
+<https://datasheets.raspberrypi.com/pico/raspberry-pi-pico-python-sdk.pdf>`_
 for more information, and `pico-micropython-examples
 <https://github.com/raspberrypi/pico-micropython-examples/tree/master/pio>`_
 for example code.

--- a/docs/library/zephyr.DiskAccess.rst
+++ b/docs/library/zephyr.DiskAccess.rst
@@ -4,7 +4,7 @@
 class DiskAccess -- access to disk storage
 ==========================================
 
-Uses `Zephyr Disk Access API <https://docs.zephyrproject.org/latest/reference/storage/disk/access.html>`_.
+Uses `Zephyr Disk Access API <https://docs.zephyrproject.org/latest/services/storage/disk/access.html>`_.
 
 This class allows access to storage devices on the board, such as support for SD card controllers and
 interfacing with SD cards via SPI. Disk devices are automatically detected and initialized on boot using

--- a/docs/library/zephyr.FlashArea.rst
+++ b/docs/library/zephyr.FlashArea.rst
@@ -4,7 +4,7 @@
 class FlashArea -- access to built-in flash storage
 ===================================================
 
-Uses `Zephyr flash map API <https://docs.zephyrproject.org/latest/reference/storage/flash_map/flash_map.html#flash-map>`_.
+Uses `Zephyr flash map API <https://docs.zephyrproject.org/latest/services/storage/flash_map/flash_map.html>`_.
 
 This class allows access to device flash partition data.
 Flash area structs consist of a globally unique ID number, the name of the flash device the partition is in,

--- a/docs/library/zephyr.rst
+++ b/docs/library/zephyr.rst
@@ -33,14 +33,14 @@ Functions
 
    This function can only be accessed if ``CONFIG_THREAD_ANALYZER`` is configured for the port in ``zephyr/prj.conf``.
    For more infomation, see documentation for Zephyr `thread analyzer
-   <https://docs.zephyrproject.org/latest/guides/debug_tools/thread-analyzer.html#thread-analyzer>`_.
+   <https://docs.zephyrproject.org/latest/services/debugging/thread-analyzer.html>`_.
 
 .. function:: shell_exec(cmd_in)
 
    Executes the given command on an UART backend. This function can only be accessed if ``CONFIG_SHELL_BACKEND_SERIAL``
    is configured for the port in ``zephyr/prj.conf``.
 
-   A list of possible commands can be found in the documentation for Zephyr `shell commands <https://docs.zephyrproject.org/latest/reference/shell/index.html?highlight=shell_execute_cmd#commands>`_.
+   A list of possible commands can be found in the documentation for Zephyr `shell commands <https://docs.zephyrproject.org/latest/services/shell/index.html#commands>`_.
 
 Classes
 -------

--- a/docs/library/zephyr.zsensor.rst
+++ b/docs/library/zephyr.zsensor.rst
@@ -15,7 +15,7 @@ class Sensor --- sensor control for the Zephyr port
 
 Use this class to access data from sensors on your board.
 See Zephyr documentation for sensor usage here: `Sensors
-<https://docs.zephyrproject.org/latest/reference/peripherals/sensor.html?highlight=sensor#sensors>`_.
+<hhttps://docs.zephyrproject.org/latest/hardware/peripherals/sensor.html>`_.
 
 Sensors are defined in the Zephyr devicetree for each board. The quantities that a given sensor can
 measure are called a sensor channels. Sensors can have multiple channels to represent different axes

--- a/docs/license.rst
+++ b/docs/license.rst
@@ -3,7 +3,7 @@ MicroPython license information
 
 The MIT License (MIT)
 
-Copyright (c) 2013-2017 Damien P. George, and others
+Copyright (c) 2013-2022 Damien P. George, and others
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/docs/make.bat
+++ b/docs/make.bat
@@ -57,7 +57,7 @@ if errorlevel 9009 (
 	echo.may add the Sphinx directory to PATH.
 	echo.
 	echo.If you don't have Sphinx installed, grab it from
-	echo.http://sphinx-doc.org/
+	echo.https://sphinx-doc.org/
 	exit /b 1
 )
 

--- a/docs/mimxrt/quickref.rst
+++ b/docs/mimxrt/quickref.rst
@@ -859,6 +859,7 @@ Transferring files
 ------------------
 
 Files can be transferred to the i.MXRT devices for instance with the ``mpremote``
-tool or using an SD card.  If Ethernet is available, you can also use ftp.
-See the MicroPython forum for the FTP server or other community-supported
-alternatives to transfer files to an i.MXRT board, like rshell or Thonny.
+tool or using an SD card.  If Ethernet is available, you can also use FTP.
+See the `MicroPython forum <https://forum.micropython.org>`_  for the FTP server
+or other community-supported alternatives to transfer files to an i.MXRT board, like
+``rshell`` or Thonny.

--- a/docs/pyboard/general.rst
+++ b/docs/pyboard/general.rst
@@ -77,7 +77,7 @@ Guide for using the pyboard with Windows
 The following PDF guide gives information about using the pyboard with Windows,
 including setting up the serial prompt and downloading new firmware using
 DFU programming:
-`PDF guide <http://micropython.org/resources/Micro-Python-Windows-setup.pdf>`__.
+`PDF guide <https://micropython.org/resources/Micro-Python-Windows-setup.pdf>`__.
 
 .. _hardware_index:
 

--- a/docs/pyboard/hardware/index.rst
+++ b/docs/pyboard/hardware/index.rst
@@ -6,26 +6,26 @@ For the pyboard:
 * v1.1
     * `PYBv1.1 schematics and layout <https://micropython.org/resources/PYBv11.pdf>`_ (2.9MiB PDF)
 * v1.0
-    * `PYBv1.0 schematics and layout <http://micropython.org/resources/PYBv10b.pdf>`_ (2.4MiB PDF)
-    * `PYBv1.0 metric dimensions <http://micropython.org/resources/PYBv10b-metric-dimensions.pdf>`_ (360KiB PDF)
-    * `PYBv1.0 imperial dimensions <http://micropython.org/resources/PYBv10b-imperial-dimensions.pdf>`_ (360KiB PDF)
+    * `PYBv1.0 schematics and layout <https://micropython.org/resources/PYBv10b.pdf>`_ (2.4MiB PDF)
+    * `PYBv1.0 metric dimensions <https://micropython.org/resources/PYBv10b-metric-dimensions.pdf>`_ (360KiB PDF)
+    * `PYBv1.0 imperial dimensions <https://micropython.org/resources/PYBv10b-imperial-dimensions.pdf>`_ (360KiB PDF)
 
 For the official skin modules:
 
-* `LCD32MKv1.0 schematics <http://micropython.org/resources/LCD32MKv10-schematics.pdf>`_ (194KiB PDF)
-* `AMPv1.0 schematics <http://micropython.org/resources/AMPv10-schematics.pdf>`_ (209KiB PDF)
+* `LCD32MKv1.0 schematics <https://micropython.org/resources/LCD32MKv10-schematics.pdf>`_ (194KiB PDF)
+* `AMPv1.0 schematics <https://micropython.org/resources/AMPv10-schematics.pdf>`_ (209KiB PDF)
 * LCD160CRv1.0: see :mod:`lcd160cr`
 
 Datasheets for the components on the pyboard
 --------------------------------------------
 
-* The microcontroller: `STM32F405RGT6 <http://www.st.com/web/catalog/mmc/FM141/SC1169/SS1577/LN1035/PF252144>`_ (link to manufacturer's site)
-* The accelerometer: `Freescale MMA7660 <http://micropython.org/resources/datasheets/MMA7660FC.pdf>`_ (800kiB PDF)
-* The LDO voltage regulator: `Microchip MCP1802 <http://micropython.org/resources/datasheets/MCP1802-22053C.pdf>`_ (400kiB PDF)
+* The microcontroller: `STM32F405RGT6 <https://www.st.com/en/microcontrollers-microprocessors/stm32f405rg.html>`_ (link to manufacturer's site)
+* The accelerometer: `Freescale MMA7660 <https://micropython.org/resources/datasheets/MMA7660FC.pdf>`_ (800kiB PDF)
+* The LDO voltage regulator: `Microchip MCP1802 <https://micropython.org/resources/datasheets/MCP1802-22053C.pdf>`_ (400kiB PDF)
 
 Datasheets for other components
 -------------------------------
 
-* The LCD display on the LCD touch-sensor skin: `Newhaven Display NHD-C12832A1Z-FSW-FBW-3V3 <http://micropython.org/resources/datasheets/NHD-C12832A1Z-FSW-FBW-3V3.pdf>`_ (460KiB PDF)
-* The touch sensor chip on the LCD touch-sensor skin: `Freescale MPR121 <http://micropython.org/resources/datasheets/MPR121.pdf>`_ (280KiB PDF)
-* The digital potentiometer on the audio skin: `Microchip MCP4541 <http://micropython.org/resources/datasheets/MCP4541-22107B.pdf>`_ (2.7MiB PDF)
+* The LCD display on the LCD touch-sensor skin: `Newhaven Display NHD-C12832A1Z-FSW-FBW-3V3 <https://micropython.org/resources/datasheets/NHD-C12832A1Z-FSW-FBW-3V3.pdf>`_ (460KiB PDF)
+* The touch sensor chip on the LCD touch-sensor skin: `Freescale MPR121 <https://micropython.org/resources/datasheets/MPR121.pdf>`_ (280KiB PDF)
+* The digital potentiometer on the audio skin: `Microchip MCP4541 <https://micropython.org/resources/datasheets/MCP4541-22107B.pdf>`_ (2.7MiB PDF)

--- a/docs/pyboard/quickref.rst
+++ b/docs/pyboard/quickref.rst
@@ -5,19 +5,19 @@ Quick reference for the pyboard
 
 The below pinout is for PYBv1.1.  You can also view pinouts for
 other versions of the pyboard:
-`PYBv1.0 <http://micropython.org/resources/pybv10-pinout.jpg>`__
-or `PYBLITEv1.0-AC <http://micropython.org/resources/pyblitev10ac-pinout.jpg>`__
-or `PYBLITEv1.0 <http://micropython.org/resources/pyblitev10-pinout.jpg>`__.
+`PYBv1.0 <https://micropython.org/resources/pybv10-pinout.jpg>`__
+or `PYBLITEv1.0-AC <https://micropython.org/resources/pyblitev10ac-pinout.jpg>`__
+or `PYBLITEv1.0 <https://micropython.org/resources/pyblitev10-pinout.jpg>`__.
 
 .. only:: not latex
 
-   .. image:: http://micropython.org/resources/pybv11-pinout.jpg
+   .. image:: https://micropython.org/resources/pybv11-pinout.jpg
       :alt: PYBv1.1 pinout
       :width: 700px
 
 .. only:: latex
 
-   .. image:: http://micropython.org/resources/pybv11-pinout-800px.jpg
+   .. image:: https://micropython.org/resources/pybv11-pinout-800px.jpg
       :alt: PYBv1.1 pinout
 
 Below is a quick reference for the pyboard.  If it is your first time working with

--- a/docs/pyboard/tutorial/amp_skin.rst
+++ b/docs/pyboard/tutorial/amp_skin.rst
@@ -15,7 +15,7 @@ The following video shows how to solder the headers, microphone and speaker onto
 
 .. raw:: html
 
-    <iframe style="margin-left:3em;" width="560" height="315" src="http://www.youtube.com/embed/fjB1DuZRveo?rel=0" frameborder="0" allowfullscreen></iframe>
+    <iframe style="margin-left:3em;" width="560" height="315" src="https://www.youtube.com/embed/fjB1DuZRveo?rel=0" frameborder="0" allowfullscreen></iframe>
 
 For circuit schematics and datasheets for the components on the skin see :ref:`hardware_index`.
 
@@ -53,10 +53,10 @@ For example::
     dac.write_timed(buf, 400 * len(buf), mode=DAC.CIRCULAR)
 
 You can also play WAV files using the Python ``wave`` module.  You can get
-the wave module `here <http://micropython.org/resources/examples/wave.py>`__ and you will also need
-the chunk module available `here <http://micropython.org/resources/examples/chunk.py>`__.  Put these
+the wave module `here <https://micropython.org/resources/examples/wave.py>`__ and you will also need
+the chunk module available `here <https://micropython.org/resources/examples/chunk.py>`__.  Put these
 on your pyboard (either on the flash or the SD card in the top-level directory).  You will need an
-8-bit WAV file to play, such as `this one <http://micropython.org/resources/examples/test.wav>`_,
+8-bit WAV file to play, such as `this one <https://micropython.org/resources/examples/test.wav>`_,
 or to convert any file you have with the command::
 
     avconv -i original.wav -ar 22050 -codec pcm_u8 test.wav

--- a/docs/pyboard/tutorial/fading_led.rst
+++ b/docs/pyboard/tutorial/fading_led.rst
@@ -1,11 +1,11 @@
 Fading LEDs
 ===========
 
-In addition to turning LEDs on and off, it is also possible to control the brightness of an LED using `Pulse-Width Modulation (PWM) <http://en.wikipedia.org/wiki/Pulse-width_modulation>`_, a common technique for obtaining variable output from a digital pin. This allows us to fade an LED:
+In addition to turning LEDs on and off, it is also possible to control the brightness of an LED using `Pulse-Width Modulation (PWM) <https://en.wikipedia.org/wiki/Pulse-width_modulation>`_, a common technique for obtaining variable output from a digital pin. This allows us to fade an LED:
 
 .. only:: not latex
 
-   .. image:: http://upload.wikimedia.org/wikipedia/commons/a/a9/Fade.gif
+   .. image:: https://upload.wikimedia.org/wikipedia/commons/a/a9/Fade.gif
 
 Components
 ----------
@@ -15,7 +15,7 @@ You will need:
 - Standard 5 or 3 mm LED
 - 100 Ohm resistor
 - Wires
-- `Breadboard <http://en.wikipedia.org/wiki/Breadboard>`_ (optional, but makes things easier)
+- `Breadboard <https://en.wikipedia.org/wiki/Breadboard>`_ (optional, but makes things easier)
 
 Connecting Things Up
 --------------------
@@ -82,7 +82,7 @@ If we want to have a breathing effect, where the LED fades from dim to bright th
 Advanced Exercise
 -----------------
 
-You may have noticed that the LED brightness seems to fade slowly, but increases quickly. This is because our eyes interprets brightness logarithmically (`Weber's Law <http://www.telescope-optics.net/eye_intensity_response.htm>`_
+You may have noticed that the LED brightness seems to fade slowly, but increases quickly. This is because our eyes interprets brightness logarithmically (`Weber's Law <https://www.telescope-optics.net/eye_intensity_response.htm>`_
 ), while the LED's brightness changes linearly, that is by the same amount each time. How do you solve this problem? (Hint: what is the opposite of the logarithmic function?)
 
 Addendum

--- a/docs/pyboard/tutorial/lcd160cr_skin.rst
+++ b/docs/pyboard/tutorial/lcd160cr_skin.rst
@@ -3,7 +3,7 @@ The LCD160CR skin
 
 This tutorial shows how to get started using the LCD160CR skin.
 
-.. image:: http://micropython.org/resources/LCD160CRv10-positions.jpg
+.. image:: https://micropython.org/resources/LCD160CRv10-positions.jpg
     :alt: LCD160CRv1.0 picture
     :width: 800px
 
@@ -25,7 +25,7 @@ Getting the driver
 You can control the display directly using a power/enable pin and an I2C
 bus, but it is much more convenient to use the driver provided by the
 :mod:`lcd160cr` module.  This driver is included in recent version of the
-pyboard firmware (see `here <http://micropython.org/download>`__).  You
+pyboard firmware (see `here <https://micropython.org/download>`__).  You
 can also find the driver in the GitHub repository
 `here <https://github.com/micropython/micropython/blob/master/drivers/display/lcd160cr.py>`__, and to use this version you will need to copy the file to your
 board, into a directory that is searched by import (usually the lib/

--- a/docs/pyboard/tutorial/lcd_skin.rst
+++ b/docs/pyboard/tutorial/lcd_skin.rst
@@ -16,7 +16,7 @@ At the end of the video, it shows you how to correctly connect the LCD skin to t
 
 .. raw:: html
 
-    <iframe style="margin-left:3em;" width="560" height="315" src="http://www.youtube.com/embed/PowCzdLYbFM?rel=0" frameborder="0" allowfullscreen></iframe>
+    <iframe style="margin-left:3em;" width="560" height="315" src="https://www.youtube.com/embed/PowCzdLYbFM?rel=0" frameborder="0" allowfullscreen></iframe>
 
 For circuit schematics and datasheets for the components on the skin see :ref:`hardware_index`.
 
@@ -60,7 +60,7 @@ enables the 4 touch sensors.  The third line reads the touch
 status and the ``touch`` variable holds the state of the 4 touch
 buttons (A, B, X, Y).
 
-There is a simple driver `here <http://micropython.org/resources/examples/mpr121.py>`__
+There is a simple driver `here <https://micropython.org/resources/examples/mpr121.py>`__
 which allows you to set the threshold and debounce parameters, and
 easily read the touch status and electrode voltage levels.  Copy
 this script to your pyboard (either flash or SD card, in the top
@@ -83,4 +83,4 @@ initialise the I2C bus using::
     >>> m = mpr121.MPR121(pyb.I2C(2, pyb.I2C.CONTROLLER))
 
 There is also a demo which uses the LCD and the touch sensors together,
-and can be found `here <http://micropython.org/resources/examples/lcddemo.py>`__.
+and can be found `here <https://micropython.org/resources/examples/lcddemo.py>`__.

--- a/docs/pyboard/tutorial/repl.rst
+++ b/docs/pyboard/tutorial/repl.rst
@@ -24,19 +24,19 @@ navigate to the pyboard's USB drive, and select that.  It should then install.
 After installing, go back to the Device Manager to find the installed pyboard,
 and see which COM port it is (eg COM4).
 More comprehensive instructions can be found in the
-`Guide for pyboard on Windows (PDF) <http://micropython.org/resources/Micro-Python-Windows-setup.pdf>`_.
+`Guide for pyboard on Windows (PDF) <https://micropython.org/resources/Micro-Python-Windows-setup.pdf>`_.
 Please consult this guide if you are having problems installing the driver.
 
 You now need to run your terminal program.  You can use HyperTerminal if you
 have it installed, or download the free program PuTTY:
-`putty.exe <http://www.chiark.greenend.org.uk/~sgtatham/putty/download.html>`_.
+`putty.exe <https://www.chiark.greenend.org.uk/~sgtatham/putty/latest.html>`_.
 Using your serial program you must connect to the COM port that you found in the
 previous step.  With PuTTY, click on "Session" in the left-hand panel, then click
 the "Serial" radio button on the right, then enter you COM port (eg COM4) in the
 "Serial Line" box.  Finally, click the "Open" button.
 
-Mac OS X
---------
+macOS
+-----
 
 Open a terminal and run::
 
@@ -95,7 +95,7 @@ Resetting the board
 If something goes wrong, you can reset the board in two ways. The first is to press CTRL-D
 at the MicroPython prompt, which performs a soft reset.  You will see a message something like ::
 
-    >>> 
+    >>>
     MPY: sync filesystems
     MPY: soft reboot
     Micro Python v1.0 on 2014-05-03; PYBv1.0 with STM32F405RG

--- a/docs/pyboard/tutorial/script.rst
+++ b/docs/pyboard/tutorial/script.rst
@@ -46,16 +46,16 @@ a window (or command line) should be showing the files on the pyboard drive.
 The drive you are looking at is known as ``/flash`` by the pyboard, and should contain
 the following 4 files:
 
-* `boot.py <http://micropython.org/resources/fresh-pyboard/boot.py>`_ -- the various configuration options for the pyboard.
+* `boot.py <https://micropython.org/resources/fresh-pyboard/boot.py>`_ -- the various configuration options for the pyboard.
     It is executed when the pyboard boots up.
 
-* `main.py <http://micropython.org/resources/fresh-pyboard/main.py>`_ -- the Python program to be run.
+* `main.py <https://micropython.org/resources/fresh-pyboard/main.py>`_ -- the Python program to be run.
     It is executed after ``boot.py``.
 
-* `README.txt <http://micropython.org/resources/fresh-pyboard/README.txt>`_ -- basic information about getting started with the pyboard.
+* `README.txt <https://micropython.org/resources/fresh-pyboard/README.txt>`_ -- basic information about getting started with the pyboard.
     This provides pointers for new users and can be safely deleted.
 
-* `pybcdc.inf <http://micropython.org/resources/fresh-pyboard/pybcdc.inf>`_ -- the Windows driver file to configure the serial USB device.
+* `pybcdc.inf <https://micropython.org/resources/fresh-pyboard/pybcdc.inf>`_ -- the Windows driver file to configure the serial USB device.
     More about this in the next tutorial.
 
 Editing ``main.py``

--- a/docs/pyboard/tutorial/servo.rst
+++ b/docs/pyboard/tutorial/servo.rst
@@ -3,7 +3,7 @@ Controlling hobby servo motors
 
 There are 4 dedicated connection points on the pyboard for connecting up
 hobby servo motors (see eg
-`Wikipedia <http://en.wikipedia.org/wiki/Servo_%28radio_control%29>`__).
+`Wikipedia <https://en.wikipedia.org/wiki/Servo_%28radio_control%29>`__).
 These motors have 3 wires: ground, power and signal.  On the pyboard you
 can connect them in the bottom right corner, with the signal pin on the
 far right.  Pins X1, X2, X3 and X4 are the 4 dedicated servo signal pins.

--- a/docs/reference/asm_thumb2_index.rst
+++ b/docs/reference/asm_thumb2_index.rst
@@ -62,12 +62,12 @@ References
 
 -  :ref:`Assembler Tutorial <pyboard_tutorial_assembler>`
 -  `Wiki hints and tips
-   <http://wiki.micropython.org/platforms/boards/pyboard/assembler>`__
+   <https://wiki.micropython.org/platforms/boards/pyboard/assembler>`__
 -  `uPy Inline Assembler source-code,
    emitinlinethumb.c <https://github.com/micropython/micropython/blob/master/py/emitinlinethumb.c>`__
 -  `ARM Thumb2 Instruction Set Quick Reference
-   Card <http://infocenter.arm.com/help/topic/com.arm.doc.qrc0001l/QRC0001_UAL.pdf>`__
+   Card <https://developer.arm.com/documentation/qrc0001/l/QRC0001_UAL.pdf>`__
 -  `RM0090 Reference
-   Manual <http://www.google.ae/url?sa=t&rct=j&q=&esrc=s&source=web&cd=1&cad=rja&uact=8&sqi=2&ved=0CBoQFjAA&url=http%3A%2F%2Fwww.st.com%2Fst-web-ui%2Fstatic%2Factive%2Fen%2Fresource%2Ftechnical%2Fdocument%2Freference_manual%2FDM00031020.pdf&ei=G0rSU66xFeuW0QWYwoD4CQ&usg=AFQjCNFuW6TgzE4QpahO_U7g3f3wdwecAg&sig2=iET-R0y9on_Pbflzf9aYDw&bvm=bv.71778758,bs.1,d.bGQ>`__
+   Manual <https://www.google.ae/url?sa=t&rct=j&q=&esrc=s&source=web&cd=1&cad=rja&uact=8&sqi=2&ved=0CBoQFjAA&url=http%3A%2F%2Fwww.st.com%2Fst-web-ui%2Fstatic%2Factive%2Fen%2Fresource%2Ftechnical%2Fdocument%2Freference_manual%2FDM00031020.pdf&ei=G0rSU66xFeuW0QWYwoD4CQ&usg=AFQjCNFuW6TgzE4QpahO_U7g3f3wdwecAg&sig2=iET-R0y9on_Pbflzf9aYDw&bvm=bv.71778758,bs.1,d.bGQ>`__
 -  ARM v7-M Architecture Reference Manual (Available on the
    ARM site after a simple registration procedure. Also available on academic sites but beware of out of date versions.)

--- a/docs/reference/isr_rules.rst
+++ b/docs/reference/isr_rules.rst
@@ -391,7 +391,7 @@ use an object termed a mutex (name derived from the notion of mutual exclusion).
 before running the critical section and unlocks it at the end. The ISR tests whether the mutex is locked. If it is,
 it avoids the critical section and returns. The design challenge is defining what the ISR should do in the event
 that access to the critical variables is denied. A simple example of a mutex may be found
-`here <https://github.com/peterhinch/micropython-samples.git>`_. Note that the mutex code does disable interrupts,
+`here <https://github.com/peterhinch/micropython-samples>`_. Note that the mutex code does disable interrupts,
 but only for the duration of eight machine instructions: the benefit of this approach is that other interrupts are
 virtually unaffected.
 

--- a/docs/reference/packages.rst
+++ b/docs/reference/packages.rst
@@ -309,6 +309,6 @@ to all resource files::
 References
 ----------
 
-* Python Packaging User Guide: https://packaging.python.org/
-* Setuptools documentation: https://setuptools.readthedocs.io/
+* Python Packaging User Guide: https://packaging.python.org/en/latest/
+* Setuptools documentation: https://setuptools.pypa.io/en/latest/
 * Distutils documentation: https://docs.python.org/3/library/distutils.html

--- a/docs/reference/speed_python.rst
+++ b/docs/reference/speed_python.rst
@@ -239,7 +239,7 @@ bit manipulations. It is invoked using a decorator:
 
 As the above fragment illustrates it is beneficial to use Python type hints to assist the Viper optimiser.
 Type hints provide information on the data types of arguments and of the return value; these
-are a standard Python language feature formally defined here `PEP0484 <https://www.python.org/dev/peps/pep-0484/>`_.
+are a standard Python language feature formally defined here `PEP0484 <https://peps.python.org/pep-0484/>`_.
 Viper supports its own set of types namely ``int``, ``uint`` (unsigned integer), ``ptr``, ``ptr8``,
 ``ptr16`` and ``ptr32``. The ``ptrX`` types are discussed below. Currently the ``uint`` type serves
 a single purpose: as a type hint for a function return value. If such a function returns ``0xffffffff``

--- a/docs/rp2/general.rst
+++ b/docs/rp2/general.rst
@@ -11,7 +11,7 @@ Technical specifications and SoC datasheets
 -------------------------------------------
 
 For detailed technical specifications, please refer to the `datasheets
-<https://datasheets.raspberrypi.org/rp2040/rp2040-datasheet.pdf>`_
+<https://datasheets.raspberrypi.com/rp2040/rp2040-datasheet.pdf>`_
 
 The RP2040 microcontroller is manufactured on a 40 nm silicon process in a 7x7mm
 QFN-56 SMD package. The key features include:

--- a/docs/templates/topindex.html
+++ b/docs/templates/topindex.html
@@ -115,11 +115,11 @@
   <table class="contentstable"><tr>
     <td width="40%" style="padding-left:2em;">
       <p class="biglink">
-      <a class="biglink" href="http://micropython.org">MicroPython homepage</a><br/>
+      <a class="biglink" href="https://micropython.org">MicroPython homepage</a><br/>
         <span class="linkdescr">the official MicroPython site</span>
       </p>
       <p class="biglink">
-        <a class="biglink" href="http://forum.micropython.org">MicroPython forum</a><br/>
+        <a class="biglink" href="https://forum.micropython.org">MicroPython forum</a><br/>
         <span class="linkdescr">community discussion for all things related to MicroPython</span>
       </p>
     </td>

--- a/docs/wipy/general.rst
+++ b/docs/wipy/general.rst
@@ -69,7 +69,7 @@ For example, on a linux shell::
    $ ftp 192.168.1.1
 
 The FTP server on the WiPy doesn't support active mode, only passive, therefore,
-if using the native unix ftp client, just after logging in do::
+if using the native unix ``ftp`` client, just after logging in do::
 
     ftp> passive
 
@@ -207,7 +207,7 @@ You can also configure the Pin to generate interrupts. For instance::
 Now every time a falling edge is seen on the gpio pin, the callback will be
 executed. Caution: mechanical push buttons have "bounce" and pushing or
 releasing a switch will often generate multiple edges.
-See: http://www.eng.utah.edu/~cs5780/debouncing.pdf for a detailed
+See: https://www.eng.utah.edu/~cs5780/debouncing.pdf for a detailed
 explanation, along with various techniques for debouncing.
 
 All pin objects go through the pin mapper to come up with one of the

--- a/docs/wipy/tutorial/repl.rst
+++ b/docs/wipy/tutorial/repl.rst
@@ -26,7 +26,7 @@ Windows
 
 First you need to install the FTDI drivers for the expansion board's USB to serial
 converter. Then you need a terminal software. The best option is to download the
-free program PuTTY: `putty.exe <http://www.chiark.greenend.org.uk/~sgtatham/putty/download.html>`_.
+free program PuTTY: `putty.exe <https://www.chiark.greenend.org.uk/~sgtatham/putty/download.html>`_.
 
 **In order to get to the telnet REPL:**
 
@@ -41,8 +41,8 @@ previous step.  With PuTTY, click on "Session" in the left-hand panel, then clic
 the "Serial" radio button on the right, then enter you COM port (eg COM4) in the
 "Serial Line" box.  Finally, click the "Open" button.
 
-Mac OS X
---------
+macOS
+-----
 
 Open a terminal and run::
 
@@ -119,7 +119,7 @@ Resetting the board
 If something goes wrong, you can reset the board in two ways. The first is to press CTRL-D
 at the MicroPython prompt, which performs a soft reset.  You will see a message something like::
 
-    >>> 
+    >>>
     MPY: soft reboot
     MicroPython v1.4.6-146-g1d8b5e5 on 2015-10-21; WiPy with CC3200
     Type "help()" for more information.

--- a/docs/zephyr/general.rst
+++ b/docs/zephyr/general.rst
@@ -3,7 +3,7 @@
 General information about the Zephyr port
 =========================================
 
-The Zephyr Project is a Linux Foundation hosted Collaboration Project. It’s an open
+The Zephyr Project is a Linux Foundation hosted Collaboration Project. It is an open
 source collaborative effort uniting developers and users in building a
 small, scalable, real-time operating system (RTOS) optimized for resource-constrained
 devices, across multiple architectures.

--- a/docs/zephyr/tutorial/intro.rst
+++ b/docs/zephyr/tutorial/intro.rst
@@ -22,8 +22,8 @@ further details.
 Getting and deploying the firmware
 ----------------------------------
 
-The first step you will need to do is either clone the `MicroPython repository <https://github.com/micropython/micropython.git>`_
-or download it from the `MicroPython downloads page <http://micropython.org/download>`_. If you are an end user of MicroPython,
+The first step you will need to do is either clone the `MicroPython repository <https://github.com/micropython/micropython>`_
+or download it from the `MicroPython downloads page <https://micropython.org/download>`_. If you are an end user of MicroPython,
 it is recommended to start with the stable firmware builds. If you would like to work on development, you may follow the daily
 builds on git.
 

--- a/docs/zephyr/tutorial/storage.rst
+++ b/docs/zephyr/tutorial/storage.rst
@@ -12,7 +12,7 @@ Disk Access
 -----------
 
 The :ref:`zephyr.DiskAccess <zephyr.DiskAccess>` class can be used to access storage devices, such as SD cards.
-This class uses `Zephyr Disk Access API <https://docs.zephyrproject.org/latest/reference/storage/disk/access.html>`_ and
+This class uses `Zephyr Disk Access API <https://docs.zephyrproject.org/latest/services/storage/disk/access.html>`_ and
 implements the `os.AbstractBlockDev` protocol.
 
 For use with SD card controllers, SD cards must be present at boot & not removed; they will
@@ -38,7 +38,7 @@ The :ref:`zephyr.FlashArea <zephyr.FlashArea>` class can be used to implement a 
 customize filesystem configurations. To store persistent data on the device, using a higher-level filesystem
 API is recommended (see below).
 
-This class uses `Zephyr Flash map API <https://docs.zephyrproject.org/latest/reference/storage/flash_map/flash_map.html#>`_ and
+This class uses `Zephyr Flash map API <https://docs.zephyrproject.org/latest/services/storage/flash_map/flash_map.html>`_ and
 implements the `os.AbstractBlockDev` protocol.
 
 Example usage with the internal flash on the reel_board or the rv32m1_vega_ri5cy board::


### PR DESCRIPTION
This is a patch that hits a good chunk of the documentation, as well as a couple of build files related to the documentation. Although it covers a lot of files, the majority of the updates are pretty straightforward.

I ran `make linkcheck` on the documentation, in order to identify broken or substantially outdated links.

Primarily the updates consist of:

- terminology consistency (Windows, GitHub, MicroPython, macOS)
- fixed http - >https where appropriate (including in Makefile output)
- updated URLs to match redirects / fix 404s
- updated PEP links in differences tables
- added `mpremote` tool reference to develop docs
- updated the Copyright dates in the docs

Outstanding small issues:
- reference/packages.rst line 204-228, sdist-upip does not exist
- a link to an older "Gollum" wiki page remains in the asm docs
- a very small number of non-SSL http links remain, to pages or sites that still do not support HTTPS

I've built and tested the documentation locally on latest HEAD using Sphinx and RTD, and re-run linkcheck after making the changes (NB `make linkcheck` itself runs, and leaves output/records in `docs/build/linkcheck`, but the output of the build is error 1, which may be intentional, I've not dug deeply on that). I've also manually re-confirmed that the links I've touched within this PR are valid and current.

Noting that there are a number of other PRs that currently touch the documentation, this PR does not take account of any of those, this is an effort to tidy up and bring docs up-to-date for external links etc.
