### PR TITLE
tests/extmod: Increase timing on uasyncio tests to make more reliable.

### DIFF
--- a/tests/extmod/uasyncio_basic.py
+++ b/tests/extmod/uasyncio_basic.py
@@ -32,18 +32,18 @@ async def main():
     print("after sleep")
 
     t0 = ticks()
-    await delay_print(0.02, "short")
+    await delay_print(0.2, "short")
     t1 = ticks()
-    await delay_print(0.04, "long")
+    await delay_print(0.4, "long")
     t2 = ticks()
     await delay_print(-1, "negative")
     t3 = ticks()
 
     print(
         "took {} {} {}".format(
-            round(ticks_diff(t1, t0), -1),
-            round(ticks_diff(t2, t1), -1),
-            round(ticks_diff(t3, t2), -1),
+            round(ticks_diff(t1, t0), -2),
+            round(ticks_diff(t2, t1), -2),
+            round(ticks_diff(t3, t2), -2),
         )
     )
 

--- a/tests/extmod/uasyncio_basic.py.exp
+++ b/tests/extmod/uasyncio_basic.py.exp
@@ -3,4 +3,4 @@ after sleep
 short
 long
 negative
-took 20 40 0
+took 200 400 0

--- a/tests/extmod/uasyncio_gather.py
+++ b/tests/extmod/uasyncio_gather.py
@@ -20,7 +20,7 @@ async def factorial(name, number):
     return f
 
 
-async def task(id, t=0.02):
+async def task(id, t=0.1):
     print("start", id)
     await asyncio.sleep(t)
     print("end", id)
@@ -30,11 +30,11 @@ async def task(id, t=0.02):
 async def task_loop(id):
     print("task_loop start", id)
     while True:
-        await asyncio.sleep(0.02)
+        await asyncio.sleep(0.1)
         print("task_loop loop", id)
 
 
-async def task_raise(id, t=0.02):
+async def task_raise(id, t=0.1):
     print("task_raise start", id)
     await asyncio.sleep(t)
     print("task_raise raise", id)
@@ -75,7 +75,7 @@ async def main():
     print(tasks[0].done(), tasks[1].done())
     for t in tasks:
         t.cancel()
-    await asyncio.sleep(0.04)
+    await asyncio.sleep(0.2)
 
     print("====")
 
@@ -92,9 +92,9 @@ async def main():
 
     # Cancel a multi gather.
     t = asyncio.create_task(gather_task(task(1), task(2)))
-    await asyncio.sleep(0.01)
+    await asyncio.sleep(0.05)
     t.cancel()
-    await asyncio.sleep(0.04)
+    await asyncio.sleep(0.2)
 
     # Test edge cases where the gather is cancelled just as tasks are created and ending.
     for i in range(1, 4):

--- a/tests/extmod/uasyncio_heaplock.py
+++ b/tests/extmod/uasyncio_heaplock.py
@@ -29,15 +29,15 @@ async def task(id, n, t):
 
 
 async def main():
-    t1 = asyncio.create_task(task(1, 4, 20))
-    t2 = asyncio.create_task(task(2, 2, 50))
+    t1 = asyncio.create_task(task(1, 4, 100))
+    t2 = asyncio.create_task(task(2, 2, 250))
 
     micropython.heap_lock()
 
     print("start")
-    await asyncio.sleep_ms(1)
+    await asyncio.sleep_ms(5)
     print("sleep")
-    await asyncio.sleep_ms(70)
+    await asyncio.sleep_ms(350)
     print("finish")
 
     micropython.heap_unlock()

--- a/tests/extmod/uasyncio_wait_task.py
+++ b/tests/extmod/uasyncio_wait_task.py
@@ -54,8 +54,8 @@ async def main():
     print("----")
 
     # Create 2 tasks
-    ts1 = asyncio.create_task(delay_print(0.04, "hello"))
-    ts2 = asyncio.create_task(delay_print(0.08, "world"))
+    ts1 = asyncio.create_task(delay_print(0.2, "hello"))
+    ts2 = asyncio.create_task(delay_print(0.4, "world"))
 
     # Time how long the tasks take to finish, they should execute in parallel
     print("start")
@@ -64,7 +64,7 @@ async def main():
     t1 = ticks()
     await ts2
     t2 = ticks()
-    print("took {} {}".format(round(ticks_diff(t1, t0), -1), round(ticks_diff(t2, t1), -1)))
+    print("took {} {}".format(round(ticks_diff(t1, t0), -2), round(ticks_diff(t2, t1), -2)))
 
     # Wait on a task that raises an exception
     t = asyncio.create_task(task_raise())

--- a/tests/extmod/uasyncio_wait_task.py.exp
+++ b/tests/extmod/uasyncio_wait_task.py.exp
@@ -5,6 +5,6 @@ task 2
 start
 hello
 world
-took 40 40
+took 200 200
 task_raise
 ValueError


### PR DESCRIPTION
This aims to fix #8301, where uasyncio tests can fail on Windows.  But they also fail sometimes on Linux, and also regularly on macOS.  So increasing the timing seems to be a reasonable solution.