### PR TITLE
py: introduced tracked alloc/free functions, and use them to replace mbedtls malloc/free

### DIFF
--- a/ports/mimxrt/mbedtls/mbedtls_config.h
+++ b/ports/mimxrt/mbedtls/mbedtls_config.h
@@ -88,10 +88,10 @@
 // Memory allocation hooks
 #include <stdlib.h>
 #include <stdio.h>
-void *m_calloc_mbedtls(size_t nmemb, size_t size);
-void m_free_mbedtls(void *ptr);
-#define MBEDTLS_PLATFORM_STD_CALLOC m_calloc_mbedtls
-#define MBEDTLS_PLATFORM_STD_FREE m_free_mbedtls
+void *m_tracked_calloc(size_t nmemb, size_t size);
+void m_tracked_free(void *ptr);
+#define MBEDTLS_PLATFORM_STD_CALLOC m_tracked_calloc
+#define MBEDTLS_PLATFORM_STD_FREE m_tracked_free
 #define MBEDTLS_PLATFORM_SNPRINTF_MACRO snprintf
 
 #include "mbedtls/check_config.h"

--- a/ports/mimxrt/mbedtls/mbedtls_port.c
+++ b/ports/mimxrt/mbedtls/mbedtls_port.c
@@ -26,63 +26,8 @@
 
 #ifdef MICROPY_SSL_MBEDTLS
 
-#include "py/runtime.h"
-#include "py/gc.h"
 #include "fsl_trng.h"
 #include "mbedtls_config.h"
-
-#define DEBUG (0)
-
-#if DEBUG
-static size_t count_links(uint32_t *nb) {
-    void **p = MP_STATE_PORT(mbedtls_memory);
-    size_t n = 0;
-    *nb = 0;
-    while (p != NULL) {
-        ++n;
-        *nb += gc_nbytes(p);
-        p = (void **)p[1];
-    }
-    return n;
-}
-#endif
-
-void *m_calloc_mbedtls(size_t nmemb, size_t size) {
-    void **ptr = m_malloc0(nmemb * size + 2 * sizeof(uintptr_t));
-    #if DEBUG
-    uint32_t nb;
-    size_t n = count_links(&nb);
-    printf("mbed_alloc(%u, %u) -> (%u;%u) %p\n", nmemb, size, n, (uint)nb, ptr);
-    #endif
-    if (MP_STATE_PORT(mbedtls_memory) != NULL) {
-        MP_STATE_PORT(mbedtls_memory)[0] = ptr;
-    }
-    ptr[0] = NULL;
-    ptr[1] = MP_STATE_PORT(mbedtls_memory);
-    MP_STATE_PORT(mbedtls_memory) = ptr;
-    return &ptr[2];
-}
-
-void m_free_mbedtls(void *ptr_in) {
-    if (ptr_in == NULL) {
-        return;
-    }
-    void **ptr = &((void **)ptr_in)[-2];
-    #if DEBUG
-    uint32_t nb;
-    size_t n = count_links(&nb);
-    printf("mbed_free(%p, [%p, %p], nbytes=%u, links=%u;%u)\n", ptr, ptr[0], ptr[1], gc_nbytes(ptr), n, (uint)nb);
-    #endif
-    if (ptr[1] != NULL) {
-        ((void **)ptr[1])[0] = ptr[0];
-    }
-    if (ptr[0] != NULL) {
-        ((void **)ptr[0])[1] = ptr[1];
-    } else {
-        MP_STATE_PORT(mbedtls_memory) = ptr[1];
-    }
-    m_free(ptr);
-}
 
 int mbedtls_hardware_poll(void *data, unsigned char *output, size_t len, size_t *olen) {
 

--- a/ports/mimxrt/mpconfigport.h
+++ b/ports/mimxrt/mpconfigport.h
@@ -48,6 +48,7 @@ uint32_t trng_random_u32(void);
 #define MICROPY_OPT_MAP_LOOKUP_CACHE        (1)
 
 // Python internal features
+#define MICROPY_TRACKED_ALLOC               (MICROPY_SSL_MBEDTLS)
 #define MICROPY_READER_VFS                  (1)
 #define MICROPY_ENABLE_GC                   (1)
 #define MICROPY_ENABLE_FINALISER            (1)
@@ -250,12 +251,6 @@ extern const struct _mp_obj_module_t mp_module_network;
 #define SOCKET_BUILTIN_MODULE
 #endif
 
-#if MICROPY_SSL_MBEDTLS
-#define MICROPY_PORT_ROOT_POINTER_MBEDTLS void **mbedtls_memory;
-#else
-#define MICROPY_PORT_ROOT_POINTER_MBEDTLS
-#endif
-
 #if defined(MICROPY_HW_ETH_MDC)
 extern const struct _mp_obj_type_t network_lan_type;
 #define MICROPY_HW_NIC_ETH                  { MP_ROM_QSTR(MP_QSTR_LAN), MP_ROM_PTR(&network_lan_type) },
@@ -290,10 +285,8 @@ extern const struct _mp_obj_type_t network_lan_type;
     void *machine_pin_irq_objects[MICROPY_HW_NUM_PIN_IRQS]; \
     /* list of registered NICs */ \
     mp_obj_list_t mod_network_nic_list; \
-    /* root pointers for sub-systems */ \
-    MICROPY_PORT_ROOT_POINTER_MBEDTLS \
     /* root pointers defined by a board */ \
-        MICROPY_BOARD_ROOT_POINTERS \
+    MICROPY_BOARD_ROOT_POINTERS \
 
 #define MP_STATE_PORT MP_STATE_VM
 

--- a/ports/stm32/mbedtls/mbedtls_config.h
+++ b/ports/stm32/mbedtls/mbedtls_config.h
@@ -89,10 +89,10 @@
 // Memory allocation hooks
 #include <stdlib.h>
 #include <stdio.h>
-void *m_calloc_mbedtls(size_t nmemb, size_t size);
-void m_free_mbedtls(void *ptr);
-#define MBEDTLS_PLATFORM_STD_CALLOC m_calloc_mbedtls
-#define MBEDTLS_PLATFORM_STD_FREE m_free_mbedtls
+void *m_tracked_calloc(size_t nmemb, size_t size);
+void m_tracked_free(void *ptr);
+#define MBEDTLS_PLATFORM_STD_CALLOC m_tracked_calloc
+#define MBEDTLS_PLATFORM_STD_FREE m_tracked_free
 #define MBEDTLS_PLATFORM_SNPRINTF_MACRO snprintf
 
 #include "mbedtls/check_config.h"

--- a/ports/stm32/mbedtls/mbedtls_port.c
+++ b/ports/stm32/mbedtls/mbedtls_port.c
@@ -24,63 +24,8 @@
  * THE SOFTWARE.
  */
 
-#include "py/runtime.h"
-#include "py/gc.h"
 #include "rng.h"
 #include "mbedtls_config.h"
-
-#define DEBUG (0)
-
-#if DEBUG
-static size_t count_links(uint32_t *nb) {
-    void **p = MP_STATE_PORT(mbedtls_memory);
-    size_t n = 0;
-    *nb = 0;
-    while (p != NULL) {
-        ++n;
-        *nb += gc_nbytes(p);
-        p = (void **)p[1];
-    }
-    return n;
-}
-#endif
-
-void *m_calloc_mbedtls(size_t nmemb, size_t size) {
-    void **ptr = m_malloc0(nmemb * size + 2 * sizeof(uintptr_t));
-    #if DEBUG
-    uint32_t nb;
-    size_t n = count_links(&nb);
-    printf("mbed_alloc(%u, %u) -> (%u;%u) %p\n", nmemb, size, n, (uint)nb, ptr);
-    #endif
-    if (MP_STATE_PORT(mbedtls_memory) != NULL) {
-        MP_STATE_PORT(mbedtls_memory)[0] = ptr;
-    }
-    ptr[0] = NULL;
-    ptr[1] = MP_STATE_PORT(mbedtls_memory);
-    MP_STATE_PORT(mbedtls_memory) = ptr;
-    return &ptr[2];
-}
-
-void m_free_mbedtls(void *ptr_in) {
-    if (ptr_in == NULL) {
-        return;
-    }
-    void **ptr = &((void **)ptr_in)[-2];
-    #if DEBUG
-    uint32_t nb;
-    size_t n = count_links(&nb);
-    printf("mbed_free(%p, [%p, %p], nbytes=%u, links=%u;%u)\n", ptr, ptr[0], ptr[1], gc_nbytes(ptr), n, (uint)nb);
-    #endif
-    if (ptr[1] != NULL) {
-        ((void **)ptr[1])[0] = ptr[0];
-    }
-    if (ptr[0] != NULL) {
-        ((void **)ptr[0])[1] = ptr[1];
-    } else {
-        MP_STATE_PORT(mbedtls_memory) = ptr[1];
-    }
-    m_free(ptr);
-}
 
 int mbedtls_hardware_poll(void *data, unsigned char *output, size_t len, size_t *olen) {
     uint32_t val = 0;

--- a/ports/stm32/mpconfigport.h
+++ b/ports/stm32/mpconfigport.h
@@ -65,6 +65,7 @@
 #endif
 
 // Python internal features
+#define MICROPY_TRACKED_ALLOC       (MICROPY_SSL_MBEDTLS)
 #define MICROPY_READER_VFS          (1)
 #define MICROPY_ENABLE_GC           (1)
 #define MICROPY_ENABLE_EMERGENCY_EXCEPTION_BUF (1)
@@ -293,12 +294,6 @@ extern const struct _mod_network_nic_type_t mod_network_nic_type_cc3k;
 
 #define MP_STATE_PORT MP_STATE_VM
 
-#if MICROPY_SSL_MBEDTLS
-#define MICROPY_PORT_ROOT_POINTER_MBEDTLS void **mbedtls_memory;
-#else
-#define MICROPY_PORT_ROOT_POINTER_MBEDTLS
-#endif
-
 #if MICROPY_BLUETOOTH_NIMBLE
 struct _mp_bluetooth_nimble_root_pointers_t;
 struct _mp_bluetooth_nimble_malloc_t;
@@ -354,7 +349,6 @@ struct _mp_bluetooth_btstack_root_pointers_t;
     mp_obj_list_t mod_network_nic_list; \
     \
     /* root pointers for sub-systems */ \
-    MICROPY_PORT_ROOT_POINTER_MBEDTLS \
     MICROPY_PORT_ROOT_POINTER_BLUETOOTH_NIMBLE \
     MICROPY_PORT_ROOT_POINTER_BLUETOOTH_BTSTACK \
     \

--- a/ports/unix/variants/coverage/mpconfigvariant.h
+++ b/ports/unix/variants/coverage/mpconfigvariant.h
@@ -38,6 +38,7 @@
 
 // Enable additional features.
 #define MICROPY_DEBUG_PARSE_RULE_NAME  (1)
+#define MICROPY_TRACKED_ALLOC           (1)
 #define MICROPY_FLOAT_HIGH_QUALITY_HASH (1)
 #define MICROPY_REPL_EMACS_WORDS_MOVE  (1)
 #define MICROPY_REPL_EMACS_EXTRA_WORDS_MOVE (1)

--- a/py/misc.h
+++ b/py/misc.h
@@ -103,6 +103,13 @@ void m_free(void *ptr);
 #endif
 NORETURN void m_malloc_fail(size_t num_bytes);
 
+#if MICROPY_TRACKED_ALLOC
+// These alloc/free functions track the pointers in a linked list so the GC does not reclaim
+// them.  They can be used by code that requires traditional C malloc/free semantics.
+void *m_tracked_calloc(size_t nmemb, size_t size);
+void m_tracked_free(void *ptr_in);
+#endif
+
 #if MICROPY_MEM_STATS
 size_t m_get_total_bytes_allocated(void);
 size_t m_get_current_bytes_allocated(void);

--- a/py/mpconfig.h
+++ b/py/mpconfig.h
@@ -621,6 +621,11 @@
 #define MICROPY_GC_HOOK_LOOP
 #endif
 
+// Whether to provide m_tracked_calloc, m_tracked_free functions
+#ifndef MICROPY_TRACKED_ALLOC
+#define MICROPY_TRACKED_ALLOC (0)
+#endif
+
 // Whether to enable finalisers in the garbage collector (ie call __del__)
 #ifndef MICROPY_ENABLE_FINALISER
 #define MICROPY_ENABLE_FINALISER (MICROPY_CONFIG_ROM_LEVEL_AT_LEAST_EXTRA_FEATURES)

--- a/py/mpstate.h
+++ b/py/mpstate.h
@@ -125,6 +125,10 @@ typedef struct _mp_state_vm_t {
 
     qstr_pool_t *last_pool;
 
+    #if MICROPY_TRACKED_ALLOC
+    struct _m_tracked_node_t *m_tracked_head;
+    #endif
+
     // non-heap memory for creating an exception if we can't allocate RAM
     mp_obj_exception_t mp_emergency_exception_obj;
 

--- a/tests/unix/extra_coverage.py.exp
+++ b/tests/unix/extra_coverage.py.exp
@@ -17,6 +17,25 @@ abc
 # GC
 0
 0
+# tracked allocation
+m_tracked_head = 0
+0 1
+1 1
+2 1
+3 1
+4 1
+5 1
+6 1
+7 1
+0 1
+1 1
+2 1
+3 1
+4 1
+5 1
+6 1
+7 1
+m_tracked_head = 0
 # vstr
 tests
 sts


### PR DESCRIPTION
This consolidates the duplicated malloc/free functions in `mimxrt/mbedtls/mbedtls_port.c` and `stm32/mbedtls/mbedtls_port.c`, but putting these common functions in `py/malloc.c` and making them generally available to all ports if needed.

This PR has one subtle change to functionality: the new malloc now returns NULL if it fails, instead of raising an exception.  This matches the C malloc semantics and mbedtls has checks for NULL returned from malloc, and returns a suitable error code.  That means that ssl code that previously raised a `MemoryError` will now raise `OSError(...)`.