### PR TITLE
unix: add -X realtime option for macOS precision timers

### DIFF
--- a/docs/unix/quickref.rst
+++ b/docs/unix/quickref.rst
@@ -73,6 +73,8 @@ General options:
     - ``-X heapsize=<n>[w][K|M]`` sets the heap size for the garbage collector.
       The suffix ``w`` means words instead of bytes. ``K`` means x1024 and ``M``
       means x1024x1024.
+    - ``-X realtime`` sets thread priority to realtime. This can be used to
+      improve timer precision. Only available on macOS.
 
 
 

--- a/ports/unix/main.c
+++ b/ports/unix/main.c
@@ -328,6 +328,10 @@ STATIC void print_help(char **argv) {
         , heap_size);
     impl_opts_cnt++;
     #endif
+    #if defined(__APPLE__)
+    printf("  realtime -- set thread priority to realtime\n");
+    impl_opts_cnt++;
+    #endif
 
     if (impl_opts_cnt == 0) {
         printf("  (none)\n");
@@ -398,6 +402,15 @@ STATIC void pre_process_options(int argc, char **argv) {
                     if (heap_size < 700) {
                         goto invalid_arg;
                     }
+                #endif
+                #if defined(__APPLE__)
+                } else if (strcmp(argv[a + 1], "realtime") == 0) {
+                    #if MICROPY_PY_THREAD
+                    mp_thread_is_realtime_enabled = true;
+                    #endif
+                    // main thread was already intialized before the option
+                    // was parsed, so we have to enable realtime here.
+                    mp_thread_set_realtime();
                 #endif
                 } else {
                 invalid_arg:

--- a/ports/unix/mpthreadport.c
+++ b/ports/unix/mpthreadport.c
@@ -53,12 +53,12 @@
 #define THREAD_STACK_OVERFLOW_MARGIN (8192)
 
 // this structure forms a linked list, one node per active thread
-typedef struct _thread_t {
+typedef struct _mp_thread_t {
     pthread_t id;           // system id of thread
     int ready;              // whether the thread is ready and running
     void *arg;              // thread Python args, a GC root pointer
-    struct _thread_t *next;
-} thread_t;
+    struct _mp_thread_t *next;
+} mp_thread_t;
 
 STATIC pthread_key_t tls_key;
 
@@ -66,7 +66,7 @@ STATIC pthread_key_t tls_key;
 // Specifically for thread management, access to the linked list is one example.
 // But also, e.g. scheduler state.
 STATIC pthread_mutex_t thread_mutex;
-STATIC thread_t *thread;
+STATIC mp_thread_t *thread;
 
 // this is used to synchronise the signal handler of the thread
 // it's needed because we can't use any pthread calls in a signal handler
@@ -119,7 +119,7 @@ void mp_thread_init(void) {
     pthread_mutex_init(&thread_mutex, &thread_mutex_attr);
 
     // create first entry in linked list of all threads
-    thread = malloc(sizeof(thread_t));
+    thread = malloc(sizeof(mp_thread_t));
     thread->id = pthread_self();
     thread->ready = 1;
     thread->arg = NULL;
@@ -143,7 +143,7 @@ void mp_thread_init(void) {
 void mp_thread_deinit(void) {
     mp_thread_unix_begin_atomic_section();
     while (thread->next != NULL) {
-        thread_t *th = thread;
+        mp_thread_t *th = thread;
         thread = thread->next;
         pthread_cancel(th->id);
         free(th);
@@ -165,7 +165,7 @@ void mp_thread_deinit(void) {
 // garbage collection and tracing these pointers.
 void mp_thread_gc_others(void) {
     mp_thread_unix_begin_atomic_section();
-    for (thread_t *th = thread; th != NULL; th = th->next) {
+    for (mp_thread_t *th = thread; th != NULL; th = th->next) {
         gc_collect_root(&th->arg, 1);
         if (th->id == pthread_self()) {
             continue;
@@ -194,7 +194,7 @@ void mp_thread_set_state(mp_state_thread_t *state) {
 void mp_thread_start(void) {
     pthread_setcanceltype(PTHREAD_CANCEL_ASYNCHRONOUS, NULL);
     mp_thread_unix_begin_atomic_section();
-    for (thread_t *th = thread; th != NULL; th = th->next) {
+    for (mp_thread_t *th = thread; th != NULL; th = th->next) {
         if (th->id == pthread_self()) {
             th->ready = 1;
             break;
@@ -249,7 +249,7 @@ void mp_thread_create(void *(*entry)(void *), void *arg, size_t *stack_size) {
     *stack_size -= THREAD_STACK_OVERFLOW_MARGIN;
 
     // add thread to linked list of all threads
-    thread_t *th = malloc(sizeof(thread_t));
+    mp_thread_t *th = malloc(sizeof(mp_thread_t));
     th->id = id;
     th->ready = 0;
     th->arg = arg;
@@ -266,8 +266,8 @@ er:
 
 void mp_thread_finish(void) {
     mp_thread_unix_begin_atomic_section();
-    thread_t *prev = NULL;
-    for (thread_t *th = thread; th != NULL; th = th->next) {
+    mp_thread_t *prev = NULL;
+    for (mp_thread_t *th = thread; th != NULL; th = th->next) {
         if (th->id == pthread_self()) {
             if (prev == NULL) {
                 thread = th->next;

--- a/ports/unix/mpthreadport.h
+++ b/ports/unix/mpthreadport.h
@@ -25,6 +25,7 @@
  */
 
 #include <pthread.h>
+#include <stdbool.h>
 
 typedef pthread_mutex_t mp_thread_mutex_t;
 
@@ -36,3 +37,9 @@ void mp_thread_gc_others(void);
 // Functions as a port-global lock for any code that must be serialised.
 void mp_thread_unix_begin_atomic_section(void);
 void mp_thread_unix_end_atomic_section(void);
+
+// for `-X realtime` command line option
+#if defined(__APPLE__)
+extern bool mp_thread_is_realtime_enabled;
+void mp_thread_set_realtime(void);
+#endif

--- a/tests/run-tests.py
+++ b/tests/run-tests.py
@@ -249,6 +249,8 @@ def run_micropython(pyb, args, test_file, is_special=False):
             cmdlist = [MICROPYTHON, "-X", "emit=" + args.emit]
             if args.heapsize is not None:
                 cmdlist.extend(["-X", "heapsize=" + args.heapsize])
+            if sys.platform == "darwin":
+                cmdlist.extend(["-X", "realtime"])
 
             # if running via .mpy, first compile the .py file
             if args.via_mpy:

--- a/tools/ci.sh
+++ b/tools/ci.sh
@@ -572,10 +572,9 @@ function ci_unix_macos_build {
 
 function ci_unix_macos_run_tests {
     # Issues with macOS tests:
-    # - OSX has poor time resolution and these uasyncio tests do not have correct output
     # - import_pkg7 has a problem with relative imports
     # - urandom_basic has a problem with getrandbits(0)
-    (cd tests && ./run-tests.py --exclude 'uasyncio_(basic|gather|heaplock|lock|wait_task)' --exclude 'import_pkg7.py' --exclude 'urandom_basic.py')
+    (cd tests && ./run-tests.py --exclude 'import_pkg7.py' --exclude 'urandom_basic.py')
 }
 
 function ci_unix_qemu_mips_setup {


### PR DESCRIPTION
The reasoning for this has already been discussed in https://github.com/micropython/micropython/issues/8621.

There is also an additional commit to fix a conflicting type name that caused a compile error when `mach` headers were included.