### PR TITLE
esp8266/machine_wdt: Remove deinit method for watchdog.

### DIFF
--- a/ports/esp8266/etshal.h
+++ b/ports/esp8266/etshal.h
@@ -9,8 +9,6 @@
 void ets_isr_mask(uint32_t mask);
 void ets_isr_unmask(uint32_t mask);
 
-void ets_wdt_disable(void);
-
 // Opaque structure
 #ifndef MD5_CTX
 typedef char MD5_CTX[88];

--- a/ports/esp8266/machine_wdt.c
+++ b/ports/esp8266/machine_wdt.c
@@ -64,16 +64,8 @@ STATIC mp_obj_t machine_wdt_feed(mp_obj_t self_in) {
 }
 STATIC MP_DEFINE_CONST_FUN_OBJ_1(machine_wdt_feed_obj, machine_wdt_feed);
 
-STATIC mp_obj_t machine_wdt_deinit(mp_obj_t self_in) {
-    (void)self_in;
-    ets_wdt_disable();
-    return mp_const_none;
-}
-STATIC MP_DEFINE_CONST_FUN_OBJ_1(machine_wdt_deinit_obj, machine_wdt_deinit);
-
 STATIC const mp_rom_map_elem_t machine_wdt_locals_dict_table[] = {
     { MP_ROM_QSTR(MP_QSTR_feed), MP_ROM_PTR(&machine_wdt_feed_obj) },
-    { MP_ROM_QSTR(MP_QSTR_deinit), MP_ROM_PTR(&machine_wdt_deinit_obj) },
 };
 STATIC MP_DEFINE_CONST_DICT(machine_wdt_locals_dict, machine_wdt_locals_dict_table);
 


### PR DESCRIPTION
Reasons for removal:
- It did not work properly because it stopped the hardware watchdog
  timer while keeping the software watchdog running (issue https://github.com/micropython/micropython/issues/8597).
- There isn't a deinit method for the WDT in any other port.
- "The watchdog is not intended to be stopped. That is a feature."
  (See https://github.com/micropython/micropython/issues/8600.)