### PR TITLE
Update Arduino Nano RP2040 Connect for consistency

### DIFF
--- a/ports/rp2/boards/ARDUINO_NANO_RP2040_CONNECT/board.json
+++ b/ports/rp2/boards/ARDUINO_NANO_RP2040_CONNECT/board.json
@@ -17,7 +17,7 @@
     "images": [
         "ABX00052_01.iso_999x750.jpg"
     ],
-    "mcu": "RP2040",
+    "mcu": "rp2040",
     "product": "Arduino Nano RP2040 Connect",
     "thumbnail": "",
     "url": "https://store-usa.arduino.cc/products/arduino-nano-rp2040-connect",


### PR DESCRIPTION
Change Arduino Nano RP2040 Connect's mcu string to be lowercase like all of the other RP2040 boards.
I was just exploring the downloads page, and this bothered me.