### PR TITLE
tools/autobuild: Update for ports/renesas-ra.

### DIFF
--- a/tools/autobuild/autobuild.sh
+++ b/tools/autobuild/autobuild.sh
@@ -74,6 +74,8 @@ cd ../esp32
 (source ${IDF_PATH_V44}/export.sh && build_esp32_boards ${FW_TAG} ${LOCAL_FIRMWARE})
 cd ../mimxrt
 build_mimxrt_boards ${FW_TAG} ${LOCAL_FIRMWARE}
+cd ../renesas-ra
+build_renesas_ra_boards ${FW_TAG} ${LOCAL_FIRMWARE}
 cd ../rp2
 build_rp2_boards ${FW_TAG} ${LOCAL_FIRMWARE}
 cd ../samd

--- a/tools/autobuild/build-boards.sh
+++ b/tools/autobuild/build-boards.sh
@@ -103,6 +103,10 @@ function build_mimxrt_boards {
     build_boards modmimxrt.c $1 $2 bin hex
 }
 
+function build_renesas_ra_boards {
+    build_boards ra_it.c $1 $2 hex
+}
+
 function build_rp2_boards {
     build_boards modrp2.c $1 $2 uf2
 }


### PR DESCRIPTION
This patch is for autobuild of ports/renesas-ra.

* Add build_renesas_ra_boards call in autobuild.sh
* Add build_renesas_ra_boards function to generate firmware.hex.

Signed-off-by: Takeo Takahashi <takeo.takahashi.xv@renesas.com>