### PR TITLE
stm32/uart_repl: Disable irq flash erase/write if uart repl enabled.

### DIFF
--- a/ports/stm32/flashbdev.c
+++ b/ports/stm32/flashbdev.c
@@ -89,7 +89,9 @@ int32_t flash_bdev_ioctl(uint32_t op, uint32_t arg) {
             return FLASH_MEM_SEG1_NUM_BLOCKS + FLASH_MEM_SEG2_NUM_BLOCKS;
 
         case BDEV_IOCTL_IRQ_HANDLER:
+            #if MICROPY_HW_FLASH_BACKGROUND_CACHE
             flash_bdev_irq_handler();
+            #endif
             return 0;
 
         case BDEV_IOCTL_SYNC: {

--- a/ports/stm32/mpconfigport.h
+++ b/ports/stm32/mpconfigport.h
@@ -144,6 +144,16 @@
 #define MICROPY_PY_UPLATFORM        (1)
 #endif
 
+#ifndef MICROPY_HW_FLASH_BACKGROUND_CACHE
+#if defined(MICROPY_HW_UART_REPL)
+// When UART repl is in use background erase / cache flush of
+// internal flash is unsafe.
+#define MICROPY_HW_FLASH_BACKGROUND_CACHE  (0)
+#else
+#define MICROPY_HW_FLASH_BACKGROUND_CACHE  (1)
+#endif
+#endif
+
 // fatfs configuration used in ffconf.h
 #define MICROPY_FATFS_ENABLE_LFN       (1)
 #define MICROPY_FATFS_LFN_CODE_PAGE    437 /* 1=SFN/ANSI 437=LFN/U.S.(OEM) */

--- a/ports/stm32/storage.c
+++ b/ports/stm32/storage.c
@@ -64,7 +64,9 @@ void storage_init(void) {
         // Enable the flash IRQ, which is used to also call our storage IRQ handler
         // It must go at the same priority as USB (see comment in irq.h).
         NVIC_SetPriority(FLASH_IRQn, IRQ_PRI_FLASH);
+        #if (MICROPY_HW_FLASH_BACKGROUND_CACHE) || defined(MICROPY_HW_BDEV2_IOCTL)
         HAL_NVIC_EnableIRQ(FLASH_IRQn);
+        #endif
     }
 }
 


### PR DESCRIPTION
Uart repl stdin loses data when the background flash erase / cache flush happens during communication.

This change forces all erase / write operations to happen during file sync/close instead.

This change can be overridden by defining MICROPY_HW_FLASH_BACKGROUND_CACHE (1) in board config.

For more details see: [mpremote cannot cp files to stm32wb55 nucleo on stlink/com port. #8386](https://github.com/micropython/micropython/issues/8386)

I'm not sure if there are likely to be other unintended side-effects of disabling this flash irq however?