### PR TITLE
ports/esp32: Remove ID from TTGO Lora32 board.

### DIFF
--- a/ports/esp32/boards/LILYGO_TTGO_LORA32/board.json
+++ b/ports/esp32/boards/LILYGO_TTGO_LORA32/board.json
@@ -11,7 +11,6 @@
         "USB-MICRO",
         "WiFi"
     ],
-    "id": "esp32",
     "images": [
         "lilygo-ttgo-lora-32-v1-6.jpg"
     ],


### PR DESCRIPTION
Generic ID creates an incorrect link on the Micropython download
page, remove the ID to fix the link.

Signed-off-by: Algy Tynan <algy@tynan.io>