### PR TITLE
top: Make board metadata have lowercase "mcu" family field.

### DIFF
--- a/ports/renesas-ra/boards/RA4M1_CLICKER/board.json
+++ b/ports/renesas-ra/boards/RA4M1_CLICKER/board.json
@@ -14,7 +14,7 @@
         "ra4m1_clicker_board.jpg",
         "ra4m1_clicker_pins.jpg"
     ],
-    "mcu": "RA4M1",
+    "mcu": "ra4m1",
     "product": "Mikroe RA4M1 Clicker",
     "thumbnail": "",
     "url": "https://www.mikroe.com/ra4m1-clicker",

--- a/ports/renesas-ra/boards/RA4M1_EK/board.json
+++ b/ports/renesas-ra/boards/RA4M1_EK/board.json
@@ -13,7 +13,7 @@
     "images": [
         "ek_ra4m1_board.jpg"
     ],
-    "mcu": "RA4M1",
+    "mcu": "ra4m1",
     "product": "EK-RA4M1",
     "thumbnail": "",
     "url": "https://www.renesas.com/products/microcontrollers-microprocessors/ra-cortex-m-mcus/ek-ra4m1-evaluation-kit-ra4m1-mcu-group",

--- a/ports/renesas-ra/boards/RA4W1_EK/board.json
+++ b/ports/renesas-ra/boards/RA4W1_EK/board.json
@@ -13,7 +13,7 @@
     "images": [
         "ek_ra4w1_board.jpg"
     ],
-    "mcu": "RA4W1",
+    "mcu": "ra4w1",
     "product": "EK-RA4W1",
     "thumbnail": "",
     "url": "https://www.renesas.com/products/microcontrollers-microprocessors/ra-cortex-m-mcus/ek-ra4w1-evaluation-kit-ra4w1-mcu-group",

--- a/ports/renesas-ra/boards/RA6M1_EK/board.json
+++ b/ports/renesas-ra/boards/RA6M1_EK/board.json
@@ -13,7 +13,7 @@
     "images": [
         "ek_ra6m1_board.jpg"
     ],
-    "mcu": "RA6M1",
+    "mcu": "ra6m1",
     "product": "EK-RA6M1",
     "thumbnail": "",
     "url": "https://www.renesas.com/products/microcontrollers-microprocessors/ra-cortex-m-mcus/ek-ra6m1-evaluation-kit-ra6m1-mcu-group",

--- a/ports/renesas-ra/boards/RA6M2_EK/board.json
+++ b/ports/renesas-ra/boards/RA6M2_EK/board.json
@@ -17,7 +17,7 @@
         "ek_ra6m2_j3_pins.jpg",
         "ek_ra6m2_j4_pins.jpg"
     ],
-    "mcu": "RA6M2",
+    "mcu": "ra6m2",
     "product": "EK-RA6M2",
     "thumbnail": "",
     "url": "https://www.renesas.com/products/microcontrollers-microprocessors/ra-cortex-m-mcus/ek-ra6m2-evaluation-kit-ra6m2-mcu-group",

--- a/ports/rp2/boards/ARDUINO_NANO_RP2040_CONNECT/board.json
+++ b/ports/rp2/boards/ARDUINO_NANO_RP2040_CONNECT/board.json
@@ -17,7 +17,7 @@
     "images": [
         "ABX00052_01.iso_999x750.jpg"
     ],
-    "mcu": "RP2040",
+    "mcu": "rp2040",
     "product": "Arduino Nano RP2040 Connect",
     "thumbnail": "",
     "url": "https://store-usa.arduino.cc/products/arduino-nano-rp2040-connect",

--- a/ports/stm32/boards/ARDUINO_PORTENTA_H7/board.json
+++ b/ports/stm32/boards/ARDUINO_PORTENTA_H7/board.json
@@ -16,7 +16,7 @@
     "images": [
         "ABX00042_01.iso_1000x750.jpg"
     ],
-    "mcu": "STM32H747",
+    "mcu": "stm32h7",
     "product": "Arduino Portenta H7",
     "thumbnail": "",
     "url": "https://store.arduino.cc/products/portenta-h7",


### PR DESCRIPTION
For consistency on the downloads page. See #8630

Applies mostly to the RA port, but also the two new Arduino boards. Additionally the "mcu" field should be just the family, e.g. "stm32f4" (not the specific model, e.g. "stm32f405").

Alternatively we could make case conversion happen automatically in build-downloads.py, but it's probably best to just be consistent.

It's worth noting that making the "mcu" field lower case was a bit of an arbitrary decision in the first place, mostly to match the "port" field... you could probably argue that they all should be upper case?