### PR TITLE
multi_net/tcp_accept_recv.py: Fix test when using system error numbers.

### DIFF
--- a/tests/multi_net/tcp_accept_recv.py
+++ b/tests/multi_net/tcp_accept_recv.py
@@ -17,7 +17,7 @@ def instance0():
     try:
         print("recv", s.recv(10))  # should raise Errno 107 ENOTCONN
     except OSError as er:
-        print(er.errno)
+        print(er.errno in (107, 128))
     s.close()
 
 


### PR DESCRIPTION
If a port is Not using internal error numbers, which match both LWIP and Linux error numbers, `ENTOCONN` from standard libraries errno.h equals 128 not 107.

To reproduce this issue on `PYBD_SF2`, disable the `MICROPY_USE_INTERNAL_ERRNO` macro in `stm32/mpconfigport.h` and run the test with pyboard as the server:

```diff
./run-multitests.py -i pyb:a0 multi_net/tcp_accept_recv.py
multi_net/tcp_accept_recv.py on ttyACM0|micropython: FAIL
### TEST ###
--- instance0 ---
128
--- instance1 ---

### TRUTH ###
--- instance0 ---
107
--- instance1 ---

### DIFF ###
--- /tmp/tmpxv59qd5m	2022-05-17 15:40:41.287993866 +0200
+++ /tmp/tmpd86miwdh	2022-05-17 15:40:41.287993866 +0200
@@ -1,4 +1,4 @@
 --- instance0 ---
-107
+128
 --- instance1 ---
 
1 tests performed
0 tests passed
1 tests failed: multi_net/tcp_accept_recv.py
```