### PR TITLE
extmod/machine_i2c: Extend I2C transfer func to support write then read.

### DIFF
--- a/extmod/machine_i2c.h
+++ b/extmod/machine_i2c.h
@@ -61,7 +61,7 @@ typedef struct _mp_machine_i2c_p_t {
     int (*stop)(mp_obj_base_t *obj);
     int (*read)(mp_obj_base_t *obj, uint8_t *dest, size_t len, bool nack);
     int (*write)(mp_obj_base_t *obj, const uint8_t *src, size_t len);
-    int (*transfer)(mp_obj_base_t *obj, uint16_t addr, size_t n, mp_machine_i2c_buf_t *bufs, unsigned int flags);
+    int (*transfer)(mp_obj_base_t *obj, uint16_t addr, size_t nwrite, size_t nread, mp_machine_i2c_buf_t *bufs, unsigned int flags);
     int (*transfer_single)(mp_obj_base_t *obj, uint16_t addr, size_t len, uint8_t *buf, unsigned int flags);
 } mp_machine_i2c_p_t;
 
@@ -76,7 +76,7 @@ typedef struct _mp_machine_soft_i2c_obj_t {
 extern const mp_obj_type_t mp_machine_soft_i2c_type;
 extern const mp_obj_dict_t mp_machine_i2c_locals_dict;
 
-int mp_machine_i2c_transfer_adaptor(mp_obj_base_t *self, uint16_t addr, size_t n, mp_machine_i2c_buf_t *bufs, unsigned int flags);
-int mp_machine_soft_i2c_transfer(mp_obj_base_t *self, uint16_t addr, size_t n, mp_machine_i2c_buf_t *bufs, unsigned int flags);
+int mp_machine_i2c_transfer_adaptor(mp_obj_base_t *self, uint16_t addr, size_t nwrite, size_t nread, mp_machine_i2c_buf_t *bufs, unsigned int flags);
+int mp_machine_soft_i2c_transfer(mp_obj_base_t *self, uint16_t addr, size_t nwrite, size_t nread, mp_machine_i2c_buf_t *bufs, unsigned int flags);
 
 #endif // MICROPY_INCLUDED_EXTMOD_MACHINE_I2C_H

--- a/ports/rp2/machine_i2c.c
+++ b/ports/rp2/machine_i2c.c
@@ -142,7 +142,7 @@ STATIC int machine_i2c_transfer_single(mp_obj_base_t *self_in, uint16_t addr, si
             };
             mp_hal_pin_open_drain(self->scl);
             mp_hal_pin_open_drain(self->sda);
-            ret = mp_machine_soft_i2c_transfer(&soft_i2c.base, addr, 1, &bufs, flags);
+            ret = mp_machine_soft_i2c_transfer(&soft_i2c.base, addr, 1, 0, &bufs, flags);
             gpio_set_function(self->scl, GPIO_FUNC_I2C);
             gpio_set_function(self->sda, GPIO_FUNC_I2C);
             return ret;


### PR DESCRIPTION
This PR aims to fix #8135, and optimise I2C as per #7134.

The general I2C transfer function has changed from:
```
transfer(self, addr, n, bufs, flags)
```
to:
```
transfer(self, addr, nwrite, nread, bufs, flags)
```
That means it supports 0 or more writes followed by 0 or more reads, in one "transaction".