### PR TITLE
extmod: Revert accidental usocket->socket rename.

### DIFF
--- a/extmod/modlwip.c
+++ b/extmod/modlwip.c
@@ -1781,6 +1781,6 @@ const mp_obj_module_t mp_module_lwip = {
 MP_REGISTER_MODULE(MP_QSTR_lwip, mp_module_lwip, MICROPY_PY_LWIP);
 
 // On LWIP-ports, this is the usocket module (replaces extmod/modusocket.c).
-MP_REGISTER_MODULE(MP_QSTR_socket, mp_module_lwip, MICROPY_PY_LWIP);
+MP_REGISTER_MODULE(MP_QSTR_usocket, mp_module_lwip, MICROPY_PY_LWIP);
 
 #endif // MICROPY_PY_LWIP

--- a/extmod/modusocket.c
+++ b/extmod/modusocket.c
@@ -588,6 +588,6 @@ const mp_obj_module_t mp_module_usocket = {
     .globals = (mp_obj_dict_t *)&mp_module_usocket_globals,
 };
 
-MP_REGISTER_MODULE(MP_QSTR_socket, mp_module_usocket, MICROPY_PY_NETWORK && MICROPY_PY_USOCKET && !MICROPY_PY_LWIP);
+MP_REGISTER_MODULE(MP_QSTR_usocket, mp_module_usocket, MICROPY_PY_NETWORK && MICROPY_PY_USOCKET && !MICROPY_PY_LWIP);
 
 #endif // MICROPY_PY_NETWORK && MICROPY_PY_USOCKET && !MICROPY_PY_LWIP


### PR DESCRIPTION
Raised by @robert-hh here https://github.com/micropython/micropython/pull/8566#issuecomment-1132641699

The registration of the `usocket` module was accidentally changed to `socket` in the move to `MP_REGISTER_MODULE` in bb794f05b7fef75696118ea1eb03a769a9fac40d.