### PR TITLE
lan_iptest: Fit tests/run-multitests.py to the LAN interface.

### DIFF
--- a/tests/run-multitests.py
+++ b/tests/run-multitests.py
@@ -64,7 +64,10 @@ class multitest:
     def get_network_ip():
         try:
             import network
-            ip = network.WLAN().ifconfig()[0]
+            if hasattr(network, "WLAN"):
+                ip = network.WLAN().ifconfig()[0]
+            else:
+                ip = network.LAN().ifconfig()[0]
         except:
             ip = HOST_IP
         return ip


### PR DESCRIPTION
Previously, only for WLAN the board's IP address was properly fetched. This PR addresses one error reported by #8681. The other two required fixes are covered by https://github.com/micropython/micropython/pull/8684 and #8678.
Indeed, many PRs for what seemed to be a single topic.