### PR TITLE
zephyr: Upgrade to Zephyr v3.1.0.

### DIFF
--- a/docs/zephyr/tutorial/repl.rst
+++ b/docs/zephyr/tutorial/repl.rst
@@ -31,8 +31,8 @@ With your serial program open (PuTTY, screen, picocom, etc) you may see a
 blank screen with a flashing cursor. Press Enter (or reset the board) and
 you should be presented with the following text::
 
-        *** Booting Zephyr OS build zephyr-v3.0.0  ***
-        MicroPython v1.18-169-g665f0e2a6-dirty on 2022-03-02; zephyr-frdm_k64f with mk64f12
+        *** Booting Zephyr OS build zephyr-v3.1.0  ***
+        MicroPython v1.19-2-g0b0cb27f0-dirty on 2022-06-16; zephyr-frdm_k64f with mk64f12
         Type "help()" for more information.
         >>>
 

--- a/ports/zephyr/README.md
+++ b/ports/zephyr/README.md
@@ -4,7 +4,7 @@ MicroPython port to Zephyr RTOS
 This is a work-in-progress port of MicroPython to Zephyr RTOS
 (http://zephyrproject.org).
 
-This port requires Zephyr version v3.0.0, and may also work on higher
+This port requires Zephyr version v3.1.0, and may also work on higher
 versions.  All boards supported
 by Zephyr (with standard level of features support, like UART console)
 should work with MicroPython (but not all were tested).
@@ -39,13 +39,13 @@ setup is correct.
 If you already have Zephyr installed but are having issues building the
 MicroPython port then try installing the correct version of Zephyr via:
 
-    $ west init zephyrproject -m https://github.com/zephyrproject-rtos/zephyr --mr v3.0.0
+    $ west init zephyrproject -m https://github.com/zephyrproject-rtos/zephyr --mr v3.1.0
 
 Alternatively, you don't have to redo the Zephyr installation to just
 switch from master to a tagged release, you can instead do:
 
     $ cd zephyrproject/zephyr
-    $ git checkout v3.0.0
+    $ git checkout v3.1.0
     $ west update
 
 With Zephyr installed you may then need to configure your environment,

--- a/ports/zephyr/machine_i2c.c
+++ b/ports/zephyr/machine_i2c.c
@@ -29,8 +29,8 @@
 #include <stdint.h>
 #include <string.h>
 
-#include <zephyr.h>
-#include <drivers/i2c.h>
+#include <zephyr/zephyr.h>
+#include <zephyr/drivers/i2c.h>
 
 #include "py/runtime.h"
 #include "py/gc.h"

--- a/ports/zephyr/machine_pin.c
+++ b/ports/zephyr/machine_pin.c
@@ -29,8 +29,8 @@
 #include <stdint.h>
 #include <string.h>
 
-#include <zephyr.h>
-#include <drivers/gpio.h>
+#include <zephyr/zephyr.h>
+#include <zephyr/drivers/gpio.h>
 
 #include "py/runtime.h"
 #include "py/gc.h"

--- a/ports/zephyr/machine_spi.c
+++ b/ports/zephyr/machine_spi.c
@@ -28,8 +28,8 @@
 #include <stdint.h>
 #include <string.h>
 
-#include <zephyr.h>
-#include <drivers/spi.h>
+#include <zephyr/zephyr.h>
+#include <zephyr/drivers/spi.h>
 
 #include "py/runtime.h"
 #include "py/gc.h"

--- a/ports/zephyr/machine_uart.c
+++ b/ports/zephyr/machine_uart.c
@@ -29,8 +29,8 @@
 #include <stdint.h>
 #include <string.h>
 
-#include <zephyr.h>
-#include <drivers/uart.h>
+#include <zephyr/zephyr.h>
+#include <zephyr/drivers/uart.h>
 
 #include "py/runtime.h"
 #include "py/stream.h"

--- a/ports/zephyr/main.c
+++ b/ports/zephyr/main.c
@@ -29,16 +29,16 @@
 #include <stdio.h>
 #include <string.h>
 
-#include <zephyr.h>
+#include <zephyr/zephyr.h>
 #ifdef CONFIG_NETWORKING
-#include <net/net_context.h>
+#include <zephyr/net/net_context.h>
 #endif
 
 #ifdef CONFIG_USB_DEVICE_STACK
-#include <usb/usb_device.h>
+#include <zephyr/usb/usb_device.h>
 #endif
 
-#include <storage/flash_map.h>
+#include <zephyr/storage/flash_map.h>
 
 #include "py/mperrno.h"
 #include "py/builtin.h"

--- a/ports/zephyr/modmachine.c
+++ b/ports/zephyr/modmachine.c
@@ -28,7 +28,7 @@
 
 #include <stdint.h>
 #include <stdio.h>
-#include <sys/reboot.h>
+#include <zephyr/sys/reboot.h>
 
 #include "py/obj.h"
 #include "py/runtime.h"

--- a/ports/zephyr/modusocket.c
+++ b/ports/zephyr/modusocket.c
@@ -31,14 +31,14 @@
 #include "py/stream.h"
 
 #include <stdio.h>
-#include <zephyr.h>
+#include <zephyr/zephyr.h>
 // Zephyr's generated version header
 #include <version.h>
-#include <net/net_context.h>
-#include <net/net_pkt.h>
-#include <net/dns_resolve.h>
+#include <zephyr/net/net_context.h>
+#include <zephyr/net/net_pkt.h>
+#include <zephyr/net/dns_resolve.h>
 #ifdef CONFIG_NET_SOCKETS
-#include <net/socket.h>
+#include <zephyr/net/socket.h>
 #endif
 
 #define DEBUG_PRINT 0

--- a/ports/zephyr/modutime.c
+++ b/ports/zephyr/modutime.c
@@ -28,7 +28,7 @@
 #include "py/mpconfig.h"
 #if MICROPY_PY_UTIME
 
-#include <zephyr.h>
+#include <zephyr/zephyr.h>
 
 #include "py/runtime.h"
 #include "py/smallint.h"

--- a/ports/zephyr/modzephyr.c
+++ b/ports/zephyr/modzephyr.c
@@ -29,10 +29,10 @@
 #if MICROPY_PY_ZEPHYR
 
 #include <stdio.h>
-#include <zephyr.h>
-#include <debug/thread_analyzer.h>
-#include <shell/shell.h>
-#include <shell/shell_uart.h>
+#include <zephyr/zephyr.h>
+#include <zephyr/debug/thread_analyzer.h>
+#include <zephyr/shell/shell.h>
+#include <zephyr/shell/shell_uart.h>
 
 #include "modzephyr.h"
 #include "py/runtime.h"

--- a/ports/zephyr/modzsensor.c
+++ b/ports/zephyr/modzsensor.c
@@ -28,8 +28,8 @@
 
 #include "py/runtime.h"
 
-#include <zephyr.h>
-#include <drivers/sensor.h>
+#include <zephyr/zephyr.h>
+#include <zephyr/drivers/sensor.h>
 
 #if MICROPY_PY_ZSENSOR
 

--- a/ports/zephyr/mpconfigport.h
+++ b/ports/zephyr/mpconfigport.h
@@ -28,8 +28,8 @@
 // Include Zephyr's autoconf.h, which should be made first by Zephyr makefiles
 #include "autoconf.h"
 // Included here to get basic Zephyr environment (macros, etc.)
-#include <zephyr.h>
-#include <drivers/spi.h>
+#include <zephyr/zephyr.h>
+#include <zephyr/drivers/spi.h>
 
 // Usually passed from Makefile
 #ifndef MICROPY_HEAP_SIZE

--- a/ports/zephyr/mphalport.h
+++ b/ports/zephyr/mphalport.h
@@ -1,4 +1,4 @@
-#include <zephyr.h>
+#include <zephyr/zephyr.h>
 #include "shared/runtime/interrupt_char.h"
 
 void mp_hal_init(void);

--- a/ports/zephyr/src/zephyr_getchar.c
+++ b/ports/zephyr/src/zephyr_getchar.c
@@ -14,10 +14,10 @@
  * limitations under the License.
  */
 
-#include <zephyr.h>
-#include <drivers/uart.h>
-#include <drivers/console/uart_console.h>
-#include <sys/printk.h>
+#include <zephyr/zephyr.h>
+#include <zephyr/drivers/uart.h>
+#include <zephyr/drivers/console/uart_console.h>
+#include <zephyr/sys/printk.h>
 #include "zephyr_getchar.h"
 
 extern int mp_interrupt_char;

--- a/ports/zephyr/src/zephyr_start.c
+++ b/ports/zephyr/src/zephyr_start.c
@@ -23,8 +23,8 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-#include <zephyr.h>
-#include <console/console.h>
+#include <zephyr/zephyr.h>
+#include <zephyr/console/console.h>
 #include "zephyr_getchar.h"
 
 int real_main(void);

--- a/ports/zephyr/uart_core.c
+++ b/ports/zephyr/uart_core.c
@@ -27,8 +27,8 @@
 #include "py/mpconfig.h"
 #include "src/zephyr_getchar.h"
 // Zephyr headers
-#include <drivers/uart.h>
-#include <console/console.h>
+#include <zephyr/drivers/uart.h>
+#include <zephyr/console/console.h>
 
 /*
  * Core UART functions to implement for a port

--- a/ports/zephyr/zephyr_storage.c
+++ b/ports/zephyr/zephyr_storage.c
@@ -32,11 +32,11 @@
 #endif
 
 #ifdef CONFIG_DISK_ACCESS
-#include <storage/disk_access.h>
+#include <zephyr/storage/disk_access.h>
 #endif
 
 #ifdef CONFIG_FLASH_MAP
-#include <storage/flash_map.h>
+#include <zephyr/storage/flash_map.h>
 #endif
 
 #ifdef CONFIG_DISK_ACCESS

--- a/tools/ci.sh
+++ b/tools/ci.sh
@@ -670,7 +670,7 @@ function ci_windows_build {
 
 ZEPHYR_DOCKER_VERSION=v0.21.0
 ZEPHYR_SDK_VERSION=0.13.2
-ZEPHYR_VERSION=v3.0.0
+ZEPHYR_VERSION=v3.1.0
 
 function ci_zephyr_setup {
     docker pull zephyrprojectrtos/ci:${ZEPHYR_DOCKER_VERSION}


### PR DESCRIPTION
Updates the Zephyr port build instructions and CI to use the latest
Zephyr release tag.

Tested on frdm_k64f.

Signed-off-by: Maureen Helm <maureen.helm@intel.com>