### PR TITLE
renesas-ra: Make port-specific modules use MP_REGISTER_MODULES.

### DIFF
--- a/ports/renesas-ra/modmachine.c
+++ b/ports/renesas-ra/modmachine.c
@@ -302,3 +302,5 @@ const mp_obj_module_t mp_module_machine = {
     .base = { &mp_type_module },
     .globals = (mp_obj_dict_t *)&machine_module_globals,
 };
+
+MP_REGISTER_MODULE(MP_QSTR_umachine, mp_module_machine, MICROPY_PY_MACHINE);


### PR DESCRIPTION
* Fix the issue that umachine is not available.

Signed-off-by: Takeo Takahashi <takeo.takahashi.xv@renesas.com>