### PR TITLE
Clean up configuration of `mp_import_stat` and `mp_builtin_open`

### DIFF
--- a/examples/embedding/hello-embed.c
+++ b/examples/embedding/hello-embed.c
@@ -28,6 +28,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 
+#include "py/builtin.h"
 #include "py/compile.h"
 #include "py/runtime.h"
 #include "py/gc.h"

--- a/extmod/vfs.h
+++ b/extmod/vfs.h
@@ -26,7 +26,7 @@
 #ifndef MICROPY_INCLUDED_EXTMOD_VFS_H
 #define MICROPY_INCLUDED_EXTMOD_VFS_H
 
-#include "py/lexer.h"
+#include "py/builtin.h"
 #include "py/obj.h"
 
 // return values of mp_vfs_lookup_path

--- a/mpy-cross/main.c
+++ b/mpy-cross/main.c
@@ -29,6 +29,7 @@
 #include <stdlib.h>
 #include <unistd.h>
 
+#include "py/builtin.h"
 #include "py/compile.h"
 #include "py/persistentcode.h"
 #include "py/runtime.h"

--- a/ports/cc3200/mpconfigport.h
+++ b/ports/cc3200/mpconfigport.h
@@ -135,15 +135,6 @@
 #define mp_type_fileio mp_type_vfs_fat_fileio
 #define mp_type_textio mp_type_vfs_fat_textio
 
-// use vfs's functions for import stat and builtin open
-#define mp_import_stat mp_vfs_import_stat
-#define mp_builtin_open mp_vfs_open
-#define mp_builtin_open_obj mp_vfs_open_obj
-
-// extra built in names to add to the global namespace
-#define MICROPY_PORT_BUILTINS \
-    { MP_ROM_QSTR(MP_QSTR_open),  MP_ROM_PTR(&mp_builtin_open_obj) },   \
-
 // extra constants
 #define MICROPY_PORT_CONSTANTS \
     { MP_ROM_QSTR(MP_QSTR_umachine),     MP_ROM_PTR(&mp_module_machine) },  \

--- a/ports/esp32/mpconfigport.h
+++ b/ports/esp32/mpconfigport.h
@@ -126,16 +126,6 @@
 #define mp_type_fileio                      mp_type_vfs_fat_fileio
 #define mp_type_textio                      mp_type_vfs_fat_textio
 
-// use vfs's functions for import stat and builtin open
-#define mp_import_stat mp_vfs_import_stat
-#define mp_builtin_open mp_vfs_open
-#define mp_builtin_open_obj mp_vfs_open_obj
-
-// extra built in names to add to the global namespace
-#define MICROPY_PORT_BUILTINS \
-    { MP_OBJ_NEW_QSTR(MP_QSTR_input), (mp_obj_t)&mp_builtin_input_obj }, \
-    { MP_OBJ_NEW_QSTR(MP_QSTR_open), (mp_obj_t)&mp_builtin_open_obj },
-
 #define MP_STATE_PORT MP_STATE_VM
 
 struct _machine_timer_obj_t;

--- a/ports/esp8266/main.c
+++ b/ports/esp8266/main.c
@@ -28,6 +28,7 @@
 #include <stdio.h>
 #include <string.h>
 
+#include "py/builtin.h"
 #include "py/compile.h"
 #include "py/runtime.h"
 #include "py/stackctrl.h"

--- a/ports/esp8266/mpconfigport.h
+++ b/ports/esp8266/mpconfigport.h
@@ -150,15 +150,6 @@ extern const struct _mp_print_t mp_debug_print;
 #define mp_type_textio mp_type_vfs_lfs2_textio
 #endif
 
-// use vfs's functions for import stat and builtin open
-#define mp_import_stat mp_vfs_import_stat
-#define mp_builtin_open mp_vfs_open
-#define mp_builtin_open_obj mp_vfs_open_obj
-
-// extra built in names to add to the global namespace
-#define MICROPY_PORT_BUILTINS \
-    { MP_ROM_QSTR(MP_QSTR_open), MP_ROM_PTR(&mp_builtin_open_obj) },
-
 #define MP_STATE_PORT MP_STATE_VM
 
 #define MICROPY_PORT_ROOT_POINTERS \

--- a/ports/javascript/main.c
+++ b/ports/javascript/main.c
@@ -29,6 +29,7 @@
 #include <stdlib.h>
 #include <string.h>
 
+#include "py/builtin.h"
 #include "py/compile.h"
 #include "py/runtime.h"
 #include "py/repl.h"

--- a/ports/javascript/mpconfigport.h
+++ b/ports/javascript/mpconfigport.h
@@ -175,10 +175,6 @@ typedef int mp_int_t; // must be pointer size
 typedef unsigned mp_uint_t; // must be pointer size
 typedef long mp_off_t;
 
-// extra built in names to add to the global namespace
-#define MICROPY_PORT_BUILTINS \
-    { MP_ROM_QSTR(MP_QSTR_open), MP_ROM_PTR(&mp_builtin_open_obj) },
-
 // We need to provide a declaration/definition of alloca()
 #include <alloca.h>
 

--- a/ports/mimxrt/mpconfigport.h
+++ b/ports/mimxrt/mpconfigport.h
@@ -188,11 +188,6 @@ uint32_t trng_random_u32(void);
 #define mp_type_fileio mp_type_vfs_lfs2_fileio
 #define mp_type_textio mp_type_vfs_lfs2_textio
 
-// Use VFS's functions for import stat and builtin open
-#define mp_import_stat mp_vfs_import_stat
-#define mp_builtin_open mp_vfs_open
-#define mp_builtin_open_obj mp_vfs_open_obj
-
 // Hooks to add builtins
 
 __attribute__((always_inline)) static inline void enable_irq(uint32_t state) {
@@ -224,9 +219,6 @@ static inline void restore_irq_pri(uint32_t basepri) {
 
 #define MICROPY_BEGIN_ATOMIC_SECTION()     disable_irq()
 #define MICROPY_END_ATOMIC_SECTION(state)  enable_irq(state)
-
-#define MICROPY_PORT_BUILTINS \
-    { MP_ROM_QSTR(MP_QSTR_open), MP_ROM_PTR(&mp_builtin_open_obj) },
 
 #if defined(MICROPY_HW_ETH_MDC)
 extern const struct _mp_obj_type_t network_lan_type;

--- a/ports/minimal/main.c
+++ b/ports/minimal/main.c
@@ -81,11 +81,6 @@ mp_import_stat_t mp_import_stat(const char *path) {
     return MP_IMPORT_STAT_NO_EXIST;
 }
 
-mp_obj_t mp_builtin_open(size_t n_args, const mp_obj_t *args, mp_map_t *kwargs) {
-    return mp_const_none;
-}
-MP_DEFINE_CONST_FUN_OBJ_KW(mp_builtin_open_obj, 1, mp_builtin_open);
-
 void nlr_jump_fail(void *val) {
     while (1) {
         ;

--- a/ports/minimal/main.c
+++ b/ports/minimal/main.c
@@ -2,6 +2,7 @@
 #include <stdio.h>
 #include <string.h>
 
+#include "py/builtin.h"
 #include "py/compile.h"
 #include "py/runtime.h"
 #include "py/repl.h"

--- a/ports/minimal/mpconfigport.h
+++ b/ports/minimal/mpconfigport.h
@@ -25,10 +25,6 @@ typedef intptr_t mp_int_t; // must be pointer size
 typedef uintptr_t mp_uint_t; // must be pointer size
 typedef long mp_off_t;
 
-// extra built in names to add to the global namespace
-#define MICROPY_PORT_BUILTINS \
-    { MP_ROM_QSTR(MP_QSTR_open), MP_ROM_PTR(&mp_builtin_open_obj) },
-
 // We need to provide a declaration/definition of alloca()
 #include <alloca.h>
 

--- a/ports/nrf/modules/uos/microbitfs.h
+++ b/ports/nrf/modules/uos/microbitfs.h
@@ -27,6 +27,7 @@
 #ifndef __MICROPY_INCLUDED_FILESYSTEM_H__
 #define __MICROPY_INCLUDED_FILESYSTEM_H__
 
+#include "py/builtin.h"
 #include "py/obj.h"
 #include "py/lexer.h"
 

--- a/ports/nrf/mpconfigport.h
+++ b/ports/nrf/mpconfigport.h
@@ -85,13 +85,6 @@
 #define mp_type_fileio fatfs_type_fileio
 #define mp_type_textio fatfs_type_textio
 
-// use vfs's functions for import stat and builtin open
-#if MICROPY_VFS
-#define mp_import_stat mp_vfs_import_stat
-#define mp_builtin_open mp_vfs_open
-#define mp_builtin_open_obj mp_vfs_open_obj
-#endif
-
 // Enable micro:bit filesystem by default.
 #ifndef MICROPY_MBFS
 #define MICROPY_MBFS (1)

--- a/ports/powerpc/main.c
+++ b/ports/powerpc/main.c
@@ -26,6 +26,7 @@
 
 #include <stdio.h>
 
+#include "py/builtin.h"
 #include "py/compile.h"
 #include "py/runtime.h"
 #include "py/repl.h"

--- a/ports/qemu-arm/main.c
+++ b/ports/qemu-arm/main.c
@@ -45,15 +45,6 @@ mp_lexer_t *mp_lexer_new_from_file(const char *filename) {
     mp_raise_OSError(MP_ENOENT);
 }
 
-mp_import_stat_t mp_import_stat(const char *path) {
-    return MP_IMPORT_STAT_NO_EXIST;
-}
-
-mp_obj_t mp_builtin_open(size_t n_args, const mp_obj_t *args, mp_map_t *kwargs) {
-    return mp_const_none;
-}
-MP_DEFINE_CONST_FUN_OBJ_KW(mp_builtin_open_obj, 1, mp_builtin_open);
-
 void nlr_jump_fail(void *val) {
     printf("uncaught NLR\n");
     exit(1);

--- a/ports/qemu-arm/mpconfigport.h
+++ b/ports/qemu-arm/mpconfigport.h
@@ -61,10 +61,6 @@ typedef int32_t mp_int_t; // must be pointer size
 typedef uint32_t mp_uint_t; // must be pointer size
 typedef long mp_off_t;
 
-// extra built in names to add to the global namespace
-#define MICROPY_PORT_BUILTINS \
-    { MP_ROM_QSTR(MP_QSTR_open), MP_ROM_PTR(&mp_builtin_open_obj) },
-
 // We need to provide a declaration/definition of alloca()
 #include <alloca.h>
 

--- a/ports/qemu-arm/test_main.c
+++ b/ports/qemu-arm/test_main.c
@@ -5,7 +5,7 @@
 #include <malloc.h>
 #include <setjmp.h>
 
-#include "py/obj.h"
+#include "py/builtin.h"
 #include "py/compile.h"
 #include "py/runtime.h"
 #include "py/stackctrl.h"

--- a/ports/qemu-arm/test_main.c
+++ b/ports/qemu-arm/test_main.c
@@ -5,7 +5,6 @@
 #include <malloc.h>
 #include <setjmp.h>
 
-#include "py/builtin.h"
 #include "py/compile.h"
 #include "py/runtime.h"
 #include "py/stackctrl.h"
@@ -38,15 +37,6 @@ void gc_collect(void) {
 mp_lexer_t *mp_lexer_new_from_file(const char *filename) {
     mp_raise_OSError(MP_ENOENT);
 }
-
-mp_import_stat_t mp_import_stat(const char *path) {
-    return MP_IMPORT_STAT_NO_EXIST;
-}
-
-mp_obj_t mp_builtin_open(size_t n_args, const mp_obj_t *args, mp_map_t *kwargs) {
-    return mp_const_none;
-}
-MP_DEFINE_CONST_FUN_OBJ_KW(mp_builtin_open_obj, 1, mp_builtin_open);
 
 void nlr_jump_fail(void *val) {
     printf("uncaught NLR\n");

--- a/ports/renesas-ra/mpconfigport.h
+++ b/ports/renesas-ra/mpconfigport.h
@@ -149,15 +149,6 @@
 #define mp_type_textio mp_type_vfs_lfs2_textio
 #endif
 
-// use vfs's functions for import stat and builtin open
-#define mp_import_stat mp_vfs_import_stat
-#define mp_builtin_open mp_vfs_open
-#define mp_builtin_open_obj mp_vfs_open_obj
-
-// extra built in names to add to the global namespace
-#define MICROPY_PORT_BUILTINS \
-    { MP_ROM_QSTR(MP_QSTR_open), MP_ROM_PTR(&mp_builtin_open_obj) },
-
 #if MICROPY_PY_MACHINE
 #define MACHINE_BUILTIN_MODULE_CONSTANTS \
     { MP_ROM_QSTR(MP_QSTR_umachine), MP_ROM_PTR(&mp_module_machine) }, \

--- a/ports/rp2/mpconfigport.h
+++ b/ports/rp2/mpconfigport.h
@@ -125,15 +125,6 @@
 #define mp_type_textio mp_type_vfs_lfs2_textio
 #endif
 
-// Use VFS's functions for import stat and builtin open
-#define mp_import_stat mp_vfs_import_stat
-#define mp_builtin_open_obj mp_vfs_open_obj
-
-// Hooks to add builtins
-
-#define MICROPY_PORT_BUILTINS \
-    { MP_ROM_QSTR(MP_QSTR_open), MP_ROM_PTR(&mp_builtin_open_obj) },
-
 #if MICROPY_PY_NETWORK
 #define NETWORK_ROOT_POINTERS               mp_obj_list_t mod_network_nic_list;
 #else

--- a/ports/samd/main.c
+++ b/ports/samd/main.c
@@ -73,23 +73,6 @@ void gc_collect(void) {
     gc_collect_end();
 }
 
-/*
-mp_lexer_t *mp_lexer_new_from_file(const char *filename) {
-    mp_raise_OSError(MP_ENOENT);
-}
-*/
-
-#if !MICROPY_VFS
-mp_import_stat_t mp_import_stat(const char *path) {
-    return MP_IMPORT_STAT_NO_EXIST;
-}
-
-mp_obj_t mp_builtin_open(size_t n_args, const mp_obj_t *args, mp_map_t *kwargs) {
-    return mp_const_none;
-}
-MP_DEFINE_CONST_FUN_OBJ_KW(mp_builtin_open_obj, 1, mp_builtin_open);
-#endif
-
 void nlr_jump_fail(void *val) {
     for (;;) {
     }

--- a/ports/samd/mpconfigport.h
+++ b/ports/samd/mpconfigport.h
@@ -99,15 +99,6 @@
 #define mp_type_fileio mp_type_vfs_lfs1_fileio
 #define mp_type_textio mp_type_vfs_lfs1_textio
 
-// Use VFS's functions for import stat and builtin open
-#define mp_import_stat mp_vfs_import_stat
-#define mp_builtin_open_obj mp_vfs_open_obj
-
-// Hooks to add builtins
-
-#define MICROPY_PORT_BUILTINS \
-    { MP_ROM_QSTR(MP_QSTR_open), MP_ROM_PTR(&mp_builtin_open_obj) },
-
 #define MICROPY_PORT_ROOT_POINTERS \
     const char *readline_hist[8];
 

--- a/ports/stm32/mpconfigport.h
+++ b/ports/stm32/mpconfigport.h
@@ -163,15 +163,6 @@
 #define mp_type_textio mp_type_vfs_lfs2_textio
 #endif
 
-// use vfs's functions for import stat and builtin open
-#define mp_import_stat mp_vfs_import_stat
-#define mp_builtin_open mp_vfs_open
-#define mp_builtin_open_obj mp_vfs_open_obj
-
-// extra built in names to add to the global namespace
-#define MICROPY_PORT_BUILTINS \
-    { MP_ROM_QSTR(MP_QSTR_open), MP_ROM_PTR(&mp_builtin_open_obj) },
-
 #if MICROPY_PY_PYB
 extern const struct _mp_obj_module_t pyb_module;
 #define PYB_BUILTIN_MODULE_CONSTANTS \

--- a/ports/teensy/lexerfrozen.c
+++ b/ports/teensy/lexerfrozen.c
@@ -1,5 +1,6 @@
 #include <stdio.h>
 
+#include "py/builtin.h"
 #include "py/lexer.h"
 #include "py/runtime.h"
 #include "py/mperrno.h"

--- a/ports/unix/mpconfigport.h
+++ b/ports/unix/mpconfigport.h
@@ -214,8 +214,6 @@ extern const struct _mp_print_t mp_stderr_print;
 #define MICROPY_EMERGENCY_EXCEPTION_BUF_SIZE  (256)
 #define MICROPY_ASYNC_KBD_INTR      (1)
 
-#define mp_import_stat mp_vfs_import_stat
-#define mp_builtin_open_obj mp_vfs_open_obj
 #define mp_type_fileio mp_type_vfs_posix_fileio
 #define mp_type_textio mp_type_vfs_posix_textio
 
@@ -272,9 +270,6 @@ void mp_unix_mark_exec(void);
 #define nan(x) NAN
 #endif
 #endif
-
-#define MICROPY_PORT_BUILTINS \
-    { MP_ROM_QSTR(MP_QSTR_open), MP_ROM_PTR(&mp_builtin_open_obj) },
 
 #define MP_STATE_PORT MP_STATE_VM
 

--- a/ports/unix/variants/minimal/mpconfigvariant.h
+++ b/ports/unix/variants/minimal/mpconfigvariant.h
@@ -109,7 +109,6 @@
 
 #define MICROPY_PORT_ROOT_POINTERS \
 
-#define mp_import_stat mp_vfs_import_stat
 #define mp_type_fileio mp_type_vfs_posix_fileio
 #define mp_type_textio mp_type_vfs_posix_textio
 

--- a/ports/windows/mpconfigport.h
+++ b/ports/windows/mpconfigport.h
@@ -171,8 +171,6 @@ extern const struct _mp_print_t mp_stderr_print;
 #define MICROPY_EMERGENCY_EXCEPTION_BUF_SIZE     (256)
 #define MICROPY_KBD_EXCEPTION       (1)
 
-#define mp_import_stat mp_vfs_import_stat
-#define mp_builtin_open_obj mp_vfs_open_obj
 #define mp_type_fileio mp_type_vfs_posix_fileio
 #define mp_type_textio mp_type_vfs_posix_textio
 
@@ -211,9 +209,6 @@ typedef long long mp_off_t;
 #else
 typedef long mp_off_t;
 #endif
-
-#define MICROPY_PORT_BUILTINS \
-    { MP_ROM_QSTR(MP_QSTR_open), MP_ROM_PTR(&mp_builtin_open_obj) },
 
 #if MICROPY_USE_READLINE == 1
 #define MICROPY_PORT_ROOT_POINTERS \

--- a/ports/zephyr/main.c
+++ b/ports/zephyr/main.c
@@ -195,22 +195,16 @@ mp_lexer_t *mp_lexer_new_from_file(const char *filename) {
 }
 #endif
 
+#if !MICROPY_VFS
 mp_import_stat_t mp_import_stat(const char *path) {
-    #if MICROPY_VFS
-    return mp_vfs_import_stat(path);
-    #else
     return MP_IMPORT_STAT_NO_EXIST;
-    #endif
 }
 
 mp_obj_t mp_builtin_open(size_t n_args, const mp_obj_t *args, mp_map_t *kwargs) {
-    #if MICROPY_VFS
-    return mp_vfs_open(n_args, args, kwargs);
-    #else
     return mp_const_none;
-    #endif
 }
 MP_DEFINE_CONST_FUN_OBJ_KW(mp_builtin_open_obj, 1, mp_builtin_open);
+#endif
 
 NORETURN void nlr_jump_fail(void *val) {
     while (1) {

--- a/ports/zephyr/main.c
+++ b/ports/zephyr/main.c
@@ -41,6 +41,7 @@
 #include <storage/flash_map.h>
 
 #include "py/mperrno.h"
+#include "py/builtin.h"
 #include "py/compile.h"
 #include "py/runtime.h"
 #include "py/repl.h"

--- a/py/builtin.h
+++ b/py/builtin.h
@@ -28,8 +28,43 @@
 
 #include "py/obj.h"
 
-mp_obj_t mp_builtin___import__(size_t n_args, const mp_obj_t *args);
+typedef enum {
+    MP_IMPORT_STAT_NO_EXIST,
+    MP_IMPORT_STAT_DIR,
+    MP_IMPORT_STAT_FILE,
+} mp_import_stat_t;
+
+#if MICROPY_VFS
+
+// Delegate to the VFS for import stat and builtin open.
+
+#define mp_builtin_open_obj mp_vfs_open_obj
+
+mp_import_stat_t mp_vfs_import_stat(const char *path);
+mp_obj_t mp_vfs_open(size_t n_args, const mp_obj_t *args, mp_map_t *kwargs);
+
+MP_DECLARE_CONST_FUN_OBJ_KW(mp_vfs_open_obj);
+
+static inline mp_import_stat_t mp_import_stat(const char *path) {
+    return mp_vfs_import_stat(path);
+}
+
+static inline mp_obj_t mp_builtin_open(size_t n_args, const mp_obj_t *args, mp_map_t *kwargs) {
+    return mp_vfs_open(n_args, args, kwargs);
+}
+
+#else
+
+// A port can provide implementations of these functions.
+mp_import_stat_t mp_import_stat(const char *path);
 mp_obj_t mp_builtin_open(size_t n_args, const mp_obj_t *args, mp_map_t *kwargs);
+
+// A port can provide this object.
+MP_DECLARE_CONST_FUN_OBJ_KW(mp_builtin_open_obj);
+
+#endif
+
+mp_obj_t mp_builtin___import__(size_t n_args, const mp_obj_t *args);
 mp_obj_t mp_micropython_mem_info(size_t n_args, const mp_obj_t *args);
 
 MP_DECLARE_CONST_FUN_OBJ_VAR(mp_builtin___build_class___obj);
@@ -76,9 +111,7 @@ MP_DECLARE_CONST_FUN_OBJ_1(mp_builtin_repr_obj);
 MP_DECLARE_CONST_FUN_OBJ_VAR_BETWEEN(mp_builtin_round_obj);
 MP_DECLARE_CONST_FUN_OBJ_KW(mp_builtin_sorted_obj);
 MP_DECLARE_CONST_FUN_OBJ_VAR_BETWEEN(mp_builtin_sum_obj);
-// Defined by a port, but declared here for simplicity
 MP_DECLARE_CONST_FUN_OBJ_VAR_BETWEEN(mp_builtin_input_obj);
-MP_DECLARE_CONST_FUN_OBJ_KW(mp_builtin_open_obj);
 
 MP_DECLARE_CONST_FUN_OBJ_2(mp_namedtuple_obj);
 

--- a/py/frozenmod.h
+++ b/py/frozenmod.h
@@ -27,7 +27,7 @@
 #ifndef MICROPY_INCLUDED_PY_FROZENMOD_H
 #define MICROPY_INCLUDED_PY_FROZENMOD_H
 
-#include "py/lexer.h"
+#include "py/builtin.h"
 
 enum {
     MP_FROZEN_NONE,

--- a/py/lexer.h
+++ b/py/lexer.h
@@ -189,24 +189,15 @@ typedef struct _mp_lexer_t {
 mp_lexer_t *mp_lexer_new(qstr src_name, mp_reader_t reader);
 mp_lexer_t *mp_lexer_new_from_str_len(qstr src_name, const char *str, size_t len, size_t free_len);
 
-void mp_lexer_free(mp_lexer_t *lex);
-void mp_lexer_to_next(mp_lexer_t *lex);
-
-/******************************************************************/
-// platform specific import function; must be implemented for a specific port
-// TODO tidy up, rename, or put elsewhere
-
-typedef enum {
-    MP_IMPORT_STAT_NO_EXIST,
-    MP_IMPORT_STAT_DIR,
-    MP_IMPORT_STAT_FILE,
-} mp_import_stat_t;
-
-mp_import_stat_t mp_import_stat(const char *path);
+// If MICROPY_READER_POSIX or MICROPY_READER_VFS aren't enabled then
+// this function must be implemented by the port.
 mp_lexer_t *mp_lexer_new_from_file(const char *filename);
 
 #if MICROPY_HELPER_LEXER_UNIX
 mp_lexer_t *mp_lexer_new_from_fd(qstr filename, int fd, bool close_fd);
 #endif
+
+void mp_lexer_free(mp_lexer_t *lex);
+void mp_lexer_to_next(mp_lexer_t *lex);
 
 #endif // MICROPY_INCLUDED_PY_LEXER_H

--- a/py/modbuiltins.c
+++ b/py/modbuiltins.c
@@ -729,6 +729,9 @@ STATIC const mp_rom_map_elem_t mp_module_builtins_globals_table[] = {
     #endif
     { MP_ROM_QSTR(MP_QSTR_next), MP_ROM_PTR(&mp_builtin_next_obj) },
     { MP_ROM_QSTR(MP_QSTR_oct), MP_ROM_PTR(&mp_builtin_oct_obj) },
+    #if MICROPY_PY_IO
+    { MP_ROM_QSTR(MP_QSTR_open), MP_ROM_PTR(&mp_builtin_open_obj) },
+    #endif
     { MP_ROM_QSTR(MP_QSTR_ord), MP_ROM_PTR(&mp_builtin_ord_obj) },
     { MP_ROM_QSTR(MP_QSTR_pow), MP_ROM_PTR(&mp_builtin_pow_obj) },
     { MP_ROM_QSTR(MP_QSTR_print), MP_ROM_PTR(&mp_builtin_print_obj) },


### PR DESCRIPTION
This consolidates configuration of `mp_import_stat` and `mp_builtin_open` to the core, which by default will now use the VFS versions of these functions.  It will also include `open()` in the list of built-ins if `MICROPY_PY_IO` is enabled.

This helps to eliminate a lot of duplicate config code in the ports.