### PR TITLE
drivers/lsm6dsox: Add support for SPI mode.

### DIFF
--- a/drivers/lsm6dsox/lsm6dsox_basic.py
+++ b/drivers/lsm6dsox/lsm6dsox_basic.py
@@ -5,6 +5,8 @@ from lsm6dsox import LSM6DSOX
 from machine import Pin, I2C
 
 lsm = LSM6DSOX(I2C(0, scl=Pin(13), sda=Pin(12)))
+# Or init in SPI mode.
+# lsm = LSM6DSOX(SPI(5), cs_pin=Pin(10))
 
 while True:
     print("Accelerometer: x:{:>8.3f} y:{:>8.3f} z:{:>8.3f}".format(*lsm.read_accel()))


### PR DESCRIPTION
Note: Tested both the basic and MLC examples in I2C and SPI modes.