### PR TITLE
esp32: Allow ULP to wake main CPU from deepsleep.

### DIFF
--- a/docs/library/esp32.rst
+++ b/docs/library/esp32.rst
@@ -18,6 +18,11 @@ Functions
     Configure whether or not a touch will wake the device from sleep.
     *wake* should be a boolean value.
 
+.. function:: wake_on_ulp(wake)
+
+    Configure whether or not the Ultra-Low-Power co-processor can wake the
+    device from sleep. *wake* should be a boolean value.
+
 .. function:: wake_on_ext0(pin, level)
 
     Configure how EXT0 wakes the device from sleep.  *pin* can be ``None``

--- a/ports/esp32/machine_rtc.h
+++ b/ports/esp32/machine_rtc.h
@@ -34,6 +34,7 @@ typedef struct {
     uint64_t ext1_pins; // set bit == pin#
     int8_t ext0_pin;   // just the pin#, -1 == None
     bool wake_on_touch : 1;
+    bool wake_on_ulp : 1;
     bool ext0_level : 1;
     wake_type_t ext0_wake_types;
     bool ext1_level : 1;

--- a/ports/esp32/modesp32.c
+++ b/ports/esp32/modesp32.c
@@ -131,6 +131,15 @@ STATIC mp_obj_t esp32_wake_on_ext1(size_t n_args, const mp_obj_t *pos_args, mp_m
 }
 STATIC MP_DEFINE_CONST_FUN_OBJ_KW(esp32_wake_on_ext1_obj, 0, esp32_wake_on_ext1);
 
+STATIC mp_obj_t esp32_wake_on_ulp(const mp_obj_t wake) {
+    if (machine_rtc_config.ext0_pin != -1) {
+        mp_raise_ValueError(MP_ERROR_TEXT("no resources"));
+    }
+    machine_rtc_config.wake_on_ulp = mp_obj_is_true(wake);
+    return mp_const_none;
+}
+STATIC MP_DEFINE_CONST_FUN_OBJ_1(esp32_wake_on_ulp_obj, esp32_wake_on_ulp);
+
 STATIC mp_obj_t esp32_gpio_deep_sleep_hold(const mp_obj_t enable) {
     if (mp_obj_is_true(enable)) {
         gpio_deep_sleep_hold_en();
@@ -197,6 +206,7 @@ STATIC const mp_rom_map_elem_t esp32_module_globals_table[] = {
     { MP_ROM_QSTR(MP_QSTR_wake_on_touch), MP_ROM_PTR(&esp32_wake_on_touch_obj) },
     { MP_ROM_QSTR(MP_QSTR_wake_on_ext0), MP_ROM_PTR(&esp32_wake_on_ext0_obj) },
     { MP_ROM_QSTR(MP_QSTR_wake_on_ext1), MP_ROM_PTR(&esp32_wake_on_ext1_obj) },
+    { MP_ROM_QSTR(MP_QSTR_wake_on_ulp), MP_ROM_PTR(&esp32_wake_on_ulp_obj) },
     { MP_ROM_QSTR(MP_QSTR_gpio_deep_sleep_hold), MP_ROM_PTR(&esp32_gpio_deep_sleep_hold_obj) },
     #if CONFIG_IDF_TARGET_ESP32
     { MP_ROM_QSTR(MP_QSTR_raw_temperature), MP_ROM_PTR(&esp32_raw_temperature_obj) },

--- a/ports/esp32/modmachine.c
+++ b/ports/esp32/modmachine.c
@@ -144,6 +144,12 @@ STATIC mp_obj_t machine_sleep_helper(wake_type_t wake_type, size_t n_args, const
         }
     }
 
+    if (machine_rtc_config.wake_on_ulp) {
+        if (esp_sleep_enable_ulp_wakeup() != ESP_OK) {
+            mp_raise_msg(&mp_type_RuntimeError, MP_ERROR_TEXT("esp_sleep_enable_ulp_wakeup() failed"));
+        }
+    }
+
     #endif
 
     switch (wake_type) {


### PR DESCRIPTION
The attached commit adds the function `wake_on_ulp()` to the `esp32` module, giving access to ESP-IDF function `esp_sleep_enable_ulp_wakeup()`, which is needed to allow the ULP co-processor to wake the main CPU from deep sleep.

Tested on a UM_TINYPICO board, built with ESP-IDF v4.2.2.

**Steps to reproduce:**

Run the following on the REPL:

```python
>>> b = b'ulp\x00\x0c\x00\x1c\x00\x00\x00\x00\x00\x00\x00@t\xff\xff\x00@\xff\xff\x00@\x10\x00\x00t\xff\x00\x06\x85\x01\x00\x00\x90\x00\x00\x00\xb0'
>>> import esp32, machine
>>> ulp = esp32.ULP()
>>> ulp.load_binary(0, b); ulp.run(0); machine.deepsleep(10000)
```

Actual and expected result (before and after): The processor wakes back up after 10 seconds (deepsleep timer), even though the ULP has tried to wake it up earlier.

After: Run the same commands, but with the last line changed to

```python
ulp.load_binary(0, b); ulp.run(0); esp32.wake_on_ulp(True); machine.deepsleep(10000)
```

Expected result: The processor wakes back up after around 4 seconds, when the ULP executes the `wake` instruction.

The ULP program above is the compiled form of

```asm
.text
.global main
main:
	stage_rst
loop:
	wait 65535
	wait 65535
	stage_inc 1
	jumps loop, 255, lt
	wake
	halt
```