### PR TITLE
py/objstr: fstring: Allow conversion specifiers like !r

### DIFF
--- a/py/lexer.c
+++ b/py/lexer.c
@@ -367,7 +367,10 @@ STATIC void parse_string_literal(mp_lexer_t *lex, bool is_raw, bool is_fstring) 
                     // Python syntax and will not handle any expression containing '}' or ':'.
                     // e.g. f'{"}"}' or f'{foo({})}'.
                     unsigned int nested_bracket_level = 0;
-                    while (!is_end(lex) && (nested_bracket_level != 0 || !is_char_or(lex, ':', '}'))) {
+                    while (!is_end(lex) && (nested_bracket_level != 0 || (
+                                !is_char_or(lex, ':', '}')
+                            && !(is_char(lex, '!') && !is_char_following(lex, '='))
+                    ))) {
                         unichar c = CUR_CHAR(lex);
                         if (c == '[' || c == '{') {
                             nested_bracket_level += 1;

--- a/py/lexer.c
+++ b/py/lexer.c
@@ -367,10 +367,12 @@ STATIC void parse_string_literal(mp_lexer_t *lex, bool is_raw, bool is_fstring) 
                     // Python syntax and will not handle any expression containing '}' or ':'.
                     // e.g. f'{"}"}' or f'{foo({})}'.
                     unsigned int nested_bracket_level = 0;
-                    while (!is_end(lex) && (nested_bracket_level != 0 || (
-                                !is_char_or(lex, ':', '}')
-                            && !(is_char(lex, '!') && !is_char_following(lex, '='))
-                    ))) {
+                    while (!is_end(lex) && (nested_bracket_level != 0
+                        || !(is_char_or(lex, ':', '}')
+                            || (is_char(lex, '!')
+                                && is_char_following_or(lex, 'r', 's')
+                                && is_char_following_following_or(lex, ':', '}'))))
+                    ) {
                         unichar c = CUR_CHAR(lex);
                         if (c == '[' || c == '{') {
                             nested_bracket_level += 1;

--- a/tests/basics/string_fstring.py
+++ b/tests/basics/string_fstring.py
@@ -61,3 +61,6 @@ except (ValueError, SyntaxError):
 print(f"a {1,} b")
 print(f"a {x,y,} b")
 print(f"a {x,1} b")
+
+print(f"{'None'!r}" == "'None'")
+print(f"{'None'!s}" == "None")

--- a/tests/cpydiff/core_fstring_repr.py
+++ b/tests/cpydiff/core_fstring_repr.py
@@ -1,18 +1,8 @@
 """
 categories: Core
-description: f-strings don't support the !r, !s, and !a conversions
-cause: MicroPython is optimised for code space.
-workaround: Use repr(), str(), and ascii() explictly.
+description: f-strings don't support !a conversions
+cause: MicropPython does not implement ascii()
+workaround: Unknown
 """
 
-
-class X:
-    def __repr__(self):
-        return "repr"
-
-    def __str__(self):
-        return "str"
-
-
-print(f"{X()!r}")
-print(f"{X()!s}")
+f"{'unicode text'!a}"


### PR DESCRIPTION
PEP-498 allows for conversion specifiers like !r and !s to convert the expression declared in braces to be passed through `repr()` and `str()` respectively.

According to the PEP implementing them is not required because `{a!r}` could be written as `{repr(a)}`, but this will add greater compatibility with CPython.