### PR TITLE
Fix compile error for the TEENSY41 board

### DIFF
--- a/ports/mimxrt/mphalport.c
+++ b/ports/mimxrt/mphalport.c
@@ -140,8 +140,8 @@ uint64_t mp_hal_time_ns(void) {
 // MAC address
 
 void mp_hal_get_unique_id(uint8_t id[]) {
-    *(uint32_t *)&id[0] = OCOTP->CFG0;
-    *(uint32_t *)&id[4] = OCOTP->CFG1;
+    *(uint32_t *)id = OCOTP->CFG0;
+    *(uint32_t *)(id + 4) = OCOTP->CFG1;
 }
 
 // Generate a random locally administered MAC address (LAA)
@@ -150,12 +150,12 @@ void mp_hal_generate_laa_mac(int idx, uint8_t buf[6]) {
     unsigned char id[8];
     mp_hal_get_unique_id(id);
 
-    uint32_t pt1 = *(uint32_t *)&id[0];
-    uint32_t pt2 = *(uint32_t *)&id[4];
+    uint32_t *pt1 = (uint32_t *) id;
+    uint32_t *pt2 = (uint32_t *) (id + 4);
 
     buf[0] = 0x02; // Locally Administered MAC
-    *(uint32_t *)&buf[1] = pt1 ^ (pt1 >> 8);
-    *(uint16_t *)&buf[4] = (uint16_t)(pt2 ^ pt2 >> 16);
+    *(uint32_t *)&buf[1] = *pt1 ^ (*pt1 >> 8);
+    *(uint16_t *)&buf[4] = (uint16_t)(*pt2 ^ *pt2 >> 16);
     buf[5] ^= (uint8_t)idx;
 }
 


### PR DESCRIPTION
I was unable to build the `mimxrt` port for the TEENSY41 board and needed to make these changes.

My process:
```sh
cd ports/mimxrt
export ARDUINO=/path/to/arduino-1.8.15/
export PATH=$PATH:$ARDUINO/hardware/tools/arm/bin
make BOARD=TEENSY41
```

My build environment:
Ubuntu 20.04 on ARM64 (Apple M1) via Parallels
Arduino v1.8.15
Teensyduino v154

The build error:
```
...
CC mphalport.c
mphalport.c: In function 'mp_hal_generate_laa_mac':
mphalport.c:153:5: error: dereferencing type-punned pointer will break strict-aliasing rules [-Werror=strict-aliasing]
     uint32_t pt1 = *(uint32_t *)&id[0];
     ^
mphalport.c:154:5: error: dereferencing type-punned pointer will break strict-aliasing rules [-Werror=strict-aliasing]
     uint32_t pt2 = *(uint32_t *)&id[4];
     ^
cc1: all warnings being treated as errors
```