### PR TITLE
stm32/nucleo_wb55: Fix mpremote file transfer over uart repl.

### DIFF
--- a/ports/stm32/boards/NUCLEO_WB55/mpconfigboard.h
+++ b/ports/stm32/boards/NUCLEO_WB55/mpconfigboard.h
@@ -65,3 +65,7 @@
 // Bluetooth config
 #define MICROPY_HW_BLE_UART_ID       (0)
 #define MICROPY_HW_BLE_UART_BAUDRATE (115200)
+
+// Configure ram isr / functions for board.
+extern void ram_isr_fn_init();
+#define MICROPY_BOARD_STARTUP ram_isr_fn_init

--- a/ports/stm32/boards/NUCLEO_WB55/mpconfigboard.mk
+++ b/ports/stm32/boards/NUCLEO_WB55/mpconfigboard.mk
@@ -3,13 +3,26 @@ CMSIS_MCU = STM32WB55xx
 AF_FILE = boards/stm32wb55_af.csv
 STARTUP_FILE = $(STM32LIB_CMSIS_BASE)/Source/Templates/gcc/startup_stm32wb55xx_cm4.o
 
+LD_FILES = boards/stm32wb55xg.ld
+
+LD_COMMON_STEM = boards/common
+
+# When enabled, some IRQ (uart/systick) and Flash (erase) functions are moved to ram
+# to allow uart rx to run during flash operations, reducing the likelihood of dropped data.
+# For more details see #8386
+USE_RAM_ISR_UART_FLASH_FN ?= 1
+
+ifeq ($(USE_RAM_ISR_UART_FLASH_FN),1)
+LD_COMMON_STEM = boards/NUCLEO_WB55/ram_isr_fn
+endif
+
 ifeq ($(USE_MBOOT),1)
 # When using Mboot all the text goes together after the bootloader
-LD_FILES = boards/stm32wb55xg.ld boards/common_bl.ld
+LD_FILES += $(LD_COMMON_STEM)_bl.ld
 TEXT0_ADDR = 0x08004000
 else
 # When not using Mboot the text goes at the start of flash
-LD_FILES = boards/stm32wb55xg.ld boards/common_basic.ld
+LD_FILES += $(LD_COMMON_STEM)_basic.ld
 TEXT0_ADDR = 0x08000000
 endif
 

--- a/ports/stm32/boards/NUCLEO_WB55/ram_irq.c
+++ b/ports/stm32/boards/NUCLEO_WB55/ram_irq.c
@@ -1,0 +1,15 @@
+#include <string.h>
+#include <py/mphal.h>
+
+// This is the default MICROPY_BOARD_STARTUP on stm32
+extern void powerctrl_check_enter_bootloader();
+
+void ram_isr_fn_init() {
+
+    // Copy IRQ vector table and other RAM functions to RAM and point VTOR there
+    extern uint32_t _start_init_isr, _start_isr, _end_isr;
+    memcpy(&_start_isr, &_start_init_isr, (&_end_isr - &_start_isr) * sizeof(uint32_t));
+    SCB->VTOR = (uint32_t)&_start_isr;
+
+    powerctrl_check_enter_bootloader();
+}

--- a/ports/stm32/boards/NUCLEO_WB55/ram_isr_fn_basic.ld
+++ b/ports/stm32/boards/NUCLEO_WB55/ram_isr_fn_basic.ld
@@ -1,0 +1,61 @@
+/* Memory layout for basic configuration with isr ram functions:
+
+    FLASH       .isr_vector
+    FLASH       .text
+    FLASH       .data
+
+    RAM         .data
+    RAM         .bss
+    RAM         .heap
+    RAM         .stack
+*/
+
+ENTRY(Reset_Handler)
+
+/* define output sections */
+SECTIONS
+{
+    /* The startup code here is run from RAM */
+    .isr_vector :
+    {
+        . = ALIGN(4);
+        _start_isr = .;
+        KEEP(*(.isr_vector)) /* Startup code */
+
+        /* These functions need to run from ram.
+           Defining them here ensures they're copied from
+           flash (in ram_irq.c) along with the isr_vector above.
+        */
+        . = ALIGN(4);
+        *(.text.pendsv_kbd_intr)
+        *(.text.pendsv_schedule_dispatch)
+        *(.text.UART*_IRQHandler)
+        *(.text.USART*_IRQHandler)
+        *(.text.storage_systick_callback)
+        *(.text.SysTick_Handler)
+        *(.text.uart_irq_handler)
+        *(.text.HAL_GetTick)
+        *(.text.FLASH_PageErase)
+        *(.text.FLASH_WaitForLastOperation)
+        *(.text.HAL_FLASHEx_Erase)
+        _end_isr = .;
+        . = ALIGN(4);
+    } >RAM AT >FLASH
+    _start_init_isr = LOADADDR(.isr_vector); /* Used by the start-up code to initialise data */
+
+    /* The program code and other data goes into FLASH */
+    .text :
+    {
+        . = ALIGN(4);
+        *(.text*)          /* .text* sections (code) */
+        *(.rodata*)        /* .rodata* sections (constants, strings, etc.) */
+    /*  *(.glue_7)   */    /* glue arm to thumb code */
+    /*  *(.glue_7t)  */    /* glue thumb to arm code */
+
+        . = ALIGN(4);
+        _etext = .;        /* define a global symbol at end of code */
+    } >FLASH
+
+    INCLUDE common_extratext_data_in_flash.ld
+    INCLUDE common_bss_heap_stack.ld
+}

--- a/ports/stm32/boards/NUCLEO_WB55/ram_isr_fn_bl.ld
+++ b/ports/stm32/boards/NUCLEO_WB55/ram_isr_fn_bl.ld
@@ -1,0 +1,61 @@
+/* Memory layout for bootloader configuration with isr ram functions:
+
+    FLASH_APP   .isr_vector
+    FLASH_APP   .text
+    FLASH_APP   .data
+
+    RAM         .data
+    RAM         .bss
+    RAM         .heap
+    RAM         .stack
+*/
+
+ENTRY(Reset_Handler)
+
+/* define output sections */
+SECTIONS
+{
+    /* The startup code here is run from RAM */
+    .isr_vector :
+    {
+        . = ALIGN(4);
+        _start_isr = .;
+        KEEP(*(.isr_vector)) /* Startup code */
+
+        /* These functions need to run from ram.
+           Defining them here ensures they're copied from
+           flash (in ram_irq.c) along with the isr_vector above.
+        */
+        . = ALIGN(4);
+        *(.text.pendsv_kbd_intr)
+        *(.text.pendsv_schedule_dispatch)
+        *(.text.UART*_IRQHandler)
+        *(.text.USART*_IRQHandler)
+        *(.text.storage_systick_callback)
+        *(.text.SysTick_Handler)
+        *(.text.uart_irq_handler)
+        *(.text.HAL_GetTick)
+        *(.text.FLASH_PageErase)
+        *(.text.FLASH_WaitForLastOperation)
+        *(.text.HAL_FLASHEx_Erase)
+        _end_isr = .;
+        . = ALIGN(4);
+    } >RAM AT >FLASH_APP
+    _start_init_isr = LOADADDR(.isr_vector); /* Used by the start-up code to initialise data */
+
+    /* The program code and other data goes into FLASH */
+    .text :
+    {
+        . = ALIGN(4);
+        *(.text*)          /* .text* sections (code) */
+        *(.rodata*)        /* .rodata* sections (constants, strings, etc.) */
+    /*  *(.glue_7)   */    /* glue arm to thumb code */
+    /*  *(.glue_7t)  */    /* glue thumb to arm code */
+
+        . = ALIGN(4);
+        _etext = .;        /* define a global symbol at end of code */
+    } >FLASH_APP
+
+    INCLUDE common_extratext_data_in_flash_app.ld
+    INCLUDE common_bss_heap_stack.ld
+}


### PR DESCRIPTION
Runs some isr and flash erase functions from ram so the uart rx is not blocked by background flash operations.

This is intended to demonstrate an alternate solution to fixing #8386 on a per board/project basis.