### PR TITLE
esp32: make I2C more efficient by using write-then-read transfers

### DIFF
--- a/extmod/machine_i2c.c
+++ b/extmod/machine_i2c.c
@@ -514,6 +514,21 @@ STATIC int read_mem(mp_obj_t self_in, uint16_t addr, uint32_t memaddr, uint8_t a
     uint8_t memaddr_buf[4];
     size_t memaddr_len = fill_memaddr_buf(&memaddr_buf[0], memaddr, addrsize);
 
+    #if MICROPY_PY_MACHINE_I2C_TRANSFER_WRITE1
+
+    // Create partial write and read buffers
+    mp_machine_i2c_buf_t bufs[2] = {
+        {.len = memaddr_len, .buf = memaddr_buf},
+        {.len = len, .buf = buf},
+    };
+
+    // Do write+read I2C transfer
+    mp_machine_i2c_p_t *i2c_p = (mp_machine_i2c_p_t *)self->type->protocol;
+    return i2c_p->transfer(self, addr, 2, bufs,
+        MP_MACHINE_I2C_FLAG_WRITE1 | MP_MACHINE_I2C_FLAG_READ | MP_MACHINE_I2C_FLAG_STOP);
+
+    #else
+
     int ret = mp_machine_i2c_writeto(self, addr, memaddr_buf, memaddr_len, false);
     if (ret != memaddr_len) {
         // must generate STOP
@@ -521,6 +536,8 @@ STATIC int read_mem(mp_obj_t self_in, uint16_t addr, uint32_t memaddr, uint8_t a
         return ret;
     }
     return mp_machine_i2c_readfrom(self, addr, buf, len, true);
+
+    #endif
 }
 
 STATIC int write_mem(mp_obj_t self_in, uint16_t addr, uint32_t memaddr, uint8_t addrsize, const uint8_t *buf, size_t len) {

--- a/extmod/machine_i2c.h
+++ b/extmod/machine_i2c.h
@@ -45,6 +45,11 @@
 #define MP_MACHINE_I2C_FLAG_READ (0x01) // if not set then it's a write
 #define MP_MACHINE_I2C_FLAG_STOP (0x02)
 
+#if MICROPY_PY_MACHINE_I2C_TRANSFER_WRITE1
+// If set, the first mp_machine_i2c_buf_t in a transfer is a write.
+#define MP_MACHINE_I2C_FLAG_WRITE1 (0x04)
+#endif
+
 typedef struct _mp_machine_i2c_buf_t {
     size_t len;
     uint8_t *buf;

--- a/ports/esp32/machine_i2c.c
+++ b/ports/esp32/machine_i2c.c
@@ -79,10 +79,20 @@ int machine_hw_i2c_transfer(mp_obj_base_t *self_in, uint16_t addr, size_t n, mp_
     machine_hw_i2c_obj_t *self = MP_OBJ_TO_PTR(self_in);
 
     i2c_cmd_handle_t cmd = i2c_cmd_link_create();
+    int data_len = 0;
+
+    if (flags & MP_MACHINE_I2C_FLAG_WRITE1) {
+        i2c_master_start(cmd);
+        i2c_master_write_byte(cmd, addr << 1, true);
+        i2c_master_write(cmd, bufs->buf, bufs->len, true);
+        data_len += bufs->len;
+        --n;
+        ++bufs;
+    }
+
     i2c_master_start(cmd);
     i2c_master_write_byte(cmd, addr << 1 | (flags & MP_MACHINE_I2C_FLAG_READ), true);
 
-    int data_len = 0;
     for (; n--; ++bufs) {
         if (flags & MP_MACHINE_I2C_FLAG_READ) {
             i2c_master_read(cmd, bufs->buf, bufs->len, n == 0 ? I2C_MASTER_LAST_NACK : I2C_MASTER_ACK);

--- a/ports/esp32/mpconfigport.h
+++ b/ports/esp32/mpconfigport.h
@@ -87,6 +87,7 @@
 #define MICROPY_PY_MACHINE_PWM_DUTY_U16_NS  (1)
 #define MICROPY_PY_MACHINE_PWM_INCLUDEFILE  "ports/esp32/machine_pwm.c"
 #define MICROPY_PY_MACHINE_I2C              (1)
+#define MICROPY_PY_MACHINE_I2C_TRANSFER_WRITE1 (1)
 #define MICROPY_PY_MACHINE_SOFTI2C          (1)
 #define MICROPY_PY_MACHINE_SPI              (1)
 #define MICROPY_PY_MACHINE_SPI_MSB          (0)

--- a/py/mpconfig.h
+++ b/py/mpconfig.h
@@ -1585,6 +1585,11 @@ typedef double mp_float_t;
 #define MICROPY_PY_MACHINE_I2C (0)
 #endif
 
+// Whether the low-level I2C transfer function supports a separate write as the first transfer
+#ifndef MICROPY_PY_MACHINE_I2C_TRANSFER_WRITE1
+#define MICROPY_PY_MACHINE_I2C_TRANSFER_WRITE1 (0)
+#endif
+
 // Whether to provide the "machine.SoftI2C" class
 #ifndef MICROPY_PY_MACHINE_SOFTI2C
 #define MICROPY_PY_MACHINE_SOFTI2C (0)


### PR DESCRIPTION
This is an alternative to #8682 that just improves the I2C transfer function for ports that need it, eg esp32.

This addresses #7134, and also #8135 (even though that is now fixed in a newer IDF version).