### PR TITLE
unix: enable `random` module seed initialisation on import

### DIFF
--- a/extmod/modurandom.c
+++ b/extmod/modurandom.c
@@ -216,7 +216,7 @@ STATIC MP_DEFINE_CONST_FUN_OBJ_2(mod_urandom_uniform_obj, mod_urandom_uniform);
 #endif // MICROPY_PY_URANDOM_EXTRA_FUNCS
 
 #if SEED_ON_IMPORT
-STATIC mp_obj_t mod_urandom___init__() {
+STATIC mp_obj_t mod_urandom___init__(void) {
     // This module may be imported by more than one name so need to ensure
     // that it's only ever seeded once.
     static bool seeded = false;

--- a/ports/unix/moduos.c
+++ b/ports/unix/moduos.c
@@ -25,24 +25,11 @@
  * THE SOFTWARE.
  */
 
-#include <fcntl.h>
 #include <stdlib.h>
 #include <string.h>
 
 #include "py/runtime.h"
 #include "py/mphal.h"
-
-#if defined(__GLIBC__) && defined(__GLIBC_PREREQ)
-#if __GLIBC_PREREQ(2, 25)
-#include <sys/random.h>
-#define _HAVE_GETRANDOM
-#endif
-#endif
-
-#if _WIN32
-#include <windows.h>
-#include <bcrypt.h>
-#endif
 
 STATIC mp_obj_t mp_uos_getenv(mp_obj_t var_in) {
     const char *s = getenv(mp_obj_str_get_str(var_in));
@@ -105,21 +92,7 @@ STATIC mp_obj_t mp_uos_urandom(mp_obj_t num) {
     mp_int_t n = mp_obj_get_int(num);
     vstr_t vstr;
     vstr_init_len(&vstr, n);
-    #if _WIN32
-    NTSTATUS result = BCryptGenRandom(NULL, (unsigned char *)vstr.buf, n, BCRYPT_USE_SYSTEM_PREFERRED_RNG);
-    if (!BCRYPT_SUCCESS(result)) {
-        mp_raise_OSError(errno);
-    }
-    #else
-    #ifdef _HAVE_GETRANDOM
-    RAISE_ERRNO(getrandom(vstr.buf, n, 0), errno);
-    #else
-    int fd = open("/dev/urandom", O_RDONLY);
-    RAISE_ERRNO(fd, errno);
-    RAISE_ERRNO(read(fd, vstr.buf, n), errno);
-    close(fd);
-    #endif
-    #endif
+    mp_hal_get_random(n, vstr.buf);
     return mp_obj_new_str_from_vstr(&mp_type_bytes, &vstr);
 }
 STATIC MP_DEFINE_CONST_FUN_OBJ_1(mp_uos_urandom_obj, mp_uos_urandom);

--- a/ports/unix/mpconfigport.h
+++ b/ports/unix/mpconfigport.h
@@ -253,6 +253,17 @@ void mp_unix_mark_exec(void);
 #define MICROPY_FORCE_PLAT_ALLOC_EXEC (1)
 #endif
 
+#ifdef MICROPY_PY_URANDOM_SEED_INIT_FUNC
+// Support for seeding the random module on import.
+#include <stddef.h>
+void mp_hal_get_random(size_t n, void *buf);
+static inline unsigned long mp_urandom_seed_init(void) {
+    unsigned long r;
+    mp_hal_get_random(sizeof(r), &r);
+    return r;
+}
+#endif
+
 #ifdef __linux__
 // Can access physical memory using /dev/mem
 #define MICROPY_PLAT_DEV_MEM  (1)

--- a/ports/unix/mphalport.h
+++ b/ports/unix/mphalport.h
@@ -91,6 +91,8 @@ static inline void mp_hal_delay_us(mp_uint_t us) {
     { if (err_flag == -1) \
       { mp_raise_OSError(error_val); } }
 
+void mp_hal_get_random(size_t n, void *buf);
+
 #if MICROPY_PY_BLUETOOTH
 enum {
     MP_HAL_MAC_BDADDR,

--- a/ports/unix/unix_mphal.c
+++ b/ports/unix/unix_mphal.c
@@ -29,11 +29,19 @@
 #include <string.h>
 #include <time.h>
 #include <sys/time.h>
+#include <fcntl.h>
 
 #include "py/mphal.h"
 #include "py/mpthread.h"
 #include "py/runtime.h"
 #include "extmod/misc.h"
+
+#if defined(__GLIBC__) && defined(__GLIBC_PREREQ)
+#if __GLIBC_PREREQ(2, 25)
+#include <sys/random.h>
+#define _HAVE_GETRANDOM
+#endif
+#endif
 
 #ifndef _WIN32
 #include <signal.h>
@@ -232,5 +240,16 @@ void mp_hal_delay_ms(mp_uint_t ms) {
     // TODO: POSIX et al. define usleep() as guaranteedly capable only of 1s sleep:
     // "The useconds argument shall be less than one million."
     usleep(ms * 1000);
+    #endif
+}
+
+void mp_hal_get_random(size_t n, void *buf) {
+    #ifdef _HAVE_GETRANDOM
+    RAISE_ERRNO(getrandom(buf, n, 0), errno);
+    #else
+    int fd = open("/dev/urandom", O_RDONLY);
+    RAISE_ERRNO(fd, errno);
+    RAISE_ERRNO(read(fd, buf, n), errno);
+    close(fd);
     #endif
 }

--- a/ports/unix/variants/coverage/mpconfigvariant.h
+++ b/ports/unix/variants/coverage/mpconfigvariant.h
@@ -31,7 +31,6 @@
 #define MICROPY_CONFIG_ROM_LEVEL (MICROPY_CONFIG_ROM_LEVEL_EXTRA_FEATURES)
 
 // Disable some features that come enabled by default with the feature level.
-#define MICROPY_MODULE_BUILTIN_INIT             (0)
 #define MICROPY_PY_BUILTINS_EXECFILE            (0)
 #define MICROPY_PY_SYS_STDIO_BUFFER             (0)
 #define MICROPY_PY_USELECT                      (0)
@@ -50,6 +49,7 @@
 #define MICROPY_PY_SYS_GETSIZEOF       (1)
 #define MICROPY_PY_SYS_TRACEBACKLIMIT  (1)
 #define MICROPY_PY_IO_BUFFEREDWRITER (1)
+#define MICROPY_PY_URANDOM_SEED_INIT_FUNC (mp_urandom_seed_init())
 #define MICROPY_PY_URE_DEBUG           (1)
 #define MICROPY_PY_URE_MATCH_GROUPS    (1)
 #define MICROPY_PY_URE_MATCH_SPAN_START_END (1)

--- a/ports/unix/variants/dev/mpconfigvariant.h
+++ b/ports/unix/variants/dev/mpconfigvariant.h
@@ -28,7 +28,6 @@
 #define MICROPY_CONFIG_ROM_LEVEL (MICROPY_CONFIG_ROM_LEVEL_EXTRA_FEATURES)
 
 // Disable some features that come enabled by default with the feature level.
-#define MICROPY_MODULE_BUILTIN_INIT             (0)
 #define MICROPY_PY_BUILTINS_EXECFILE            (0)
 #define MICROPY_PY_SYS_STDIO_BUFFER             (0)
 #define MICROPY_PY_USELECT                      (0)
@@ -37,3 +36,4 @@
 #define MICROPY_REPL_EMACS_WORDS_MOVE           (1)
 #define MICROPY_REPL_EMACS_EXTRA_WORDS_MOVE     (1)
 #define MICROPY_PY_SYS_SETTRACE                 (1)
+#define MICROPY_PY_URANDOM_SEED_INIT_FUNC       (mp_urandom_seed_init())

--- a/ports/windows/windows_mphal.c
+++ b/ports/windows/windows_mphal.c
@@ -32,6 +32,7 @@
 #include <sys/time.h>
 #include <windows.h>
 #include <unistd.h>
+#include <bcrypt.h>
 
 HANDLE std_in = NULL;
 HANDLE con_out = NULL;
@@ -285,4 +286,11 @@ void mp_hal_delay_ms(mp_uint_t ms) {
     #else
     msec_sleep((double)ms);
     #endif
+}
+
+void mp_hal_get_random(size_t n, void *buf) {
+    NTSTATUS result = BCryptGenRandom(NULL, (unsigned char *)buf, n, BCRYPT_USE_SYSTEM_PREFERRED_RNG);
+    if (!BCRYPT_SUCCESS(result)) {
+        mp_raise_OSError(errno);
+    }
 }


### PR DESCRIPTION
This enables random seed initialisation on import of the `random` module, on unix dev and coverage builds.