### PR TITLE
stm32/usbd_conf: Remove disable of SYSCFG clock

### DIFF
--- a/ports/stm32/usbd_conf.c
+++ b/ports/stm32/usbd_conf.c
@@ -215,7 +215,6 @@ void HAL_PCD_MspDeInit(PCD_HandleTypeDef *hpcd) {
     if (hpcd->Instance == USB_OTG_FS) {
         /* Disable USB FS Clocks */
         __USB_OTG_FS_CLK_DISABLE();
-        __SYSCFG_CLK_DISABLE();
         return;
     }
     #endif
@@ -224,7 +223,6 @@ void HAL_PCD_MspDeInit(PCD_HandleTypeDef *hpcd) {
     if (hpcd->Instance == USB_OTG_HS) {
         /* Disable USB FS Clocks */
         __USB_OTG_HS_CLK_DISABLE();
-        __SYSCFG_CLK_DISABLE();
     }
     #endif
 


### PR DESCRIPTION
System config block contains hardware unrelated to USB. So calling
`__SYSCFG_CLK_DISABLE()` during `HAL_PCD_MspDeInit()` has an adverse
effect on other system functionality.

Removing call to `__SYSCFG_CLK_DISABLE()` to rectify this issue.