### PR TITLE
extmod/extmod.cmake: Require components to be explicitly enabled.

### DIFF
--- a/extmod/extmod.cmake
+++ b/extmod/extmod.cmake
@@ -54,9 +54,9 @@ set(MICROPY_SOURCE_EXTMOD
 
 # Library for btree module and associated code
 
-set(MICROPY_LIB_BERKELEY_DIR "${MICROPY_DIR}/lib/berkeley-db-1.xx")
+if(MICROPY_PY_BTREE)
+    set(MICROPY_LIB_BERKELEY_DIR "${MICROPY_DIR}/lib/berkeley-db-1.xx")
 
-if(EXISTS "${MICROPY_LIB_BERKELEY_DIR}/btree/bt_close.c")
     add_library(micropy_extmod_btree OBJECT
         ${MICROPY_LIB_BERKELEY_DIR}/btree/bt_close.c
         ${MICROPY_LIB_BERKELEY_DIR}/btree/bt_conv.c
@@ -100,10 +100,10 @@ endif()
 
 # Library for mbedtls
 
-set(MICROPY_LIB_MBEDTLS_DIR "${MICROPY_DIR}/lib/mbedtls")
-
-if(EXISTS "${MICROPY_LIB_MBEDTLS_DIR}/library/aes.c")
+if(MICROPY_SSL_MBEDTLS)
     add_library(micropy_lib_mbedtls INTERFACE)
+
+    set(MICROPY_LIB_MBEDTLS_DIR "${MICROPY_DIR}/lib/mbedtls")
 
     target_include_directories(micropy_lib_mbedtls INTERFACE
         ${MICROPY_LIB_MBEDTLS_DIR}/include
@@ -194,10 +194,10 @@ endif()
 
 # Library for lwIP network stack
 
-set(MICROPY_LIB_LWIP_DIR "${MICROPY_DIR}/lib/lwip/src")
-
-if(EXISTS "${MICROPY_LIB_LWIP_DIR}/core/def.c")
+if(MICROPY_PY_LWIP)
     add_library(micropy_lib_lwip INTERFACE)
+
+    set(MICROPY_LIB_LWIP_DIR "${MICROPY_DIR}/lib/lwip/src")
 
     target_include_directories(micropy_lib_lwip INTERFACE
         ${MICROPY_LIB_LWIP_DIR}/include

--- a/ports/esp32/main/CMakeLists.txt
+++ b/ports/esp32/main/CMakeLists.txt
@@ -7,6 +7,10 @@ endif()
 include(${MICROPY_DIR}/py/py.cmake)
 
 if(NOT CMAKE_BUILD_EARLY_EXPANSION)
+    # Enable extmod components that will be configured by extmod.cmake.
+    # A board may also have enabled additional components.
+    set(MICROPY_PY_BTREE ON)
+
     include(${MICROPY_DIR}/py/usermod.cmake)
     include(${MICROPY_DIR}/extmod/extmod.cmake)
 endif()

--- a/ports/rp2/CMakeLists.txt
+++ b/ports/rp2/CMakeLists.txt
@@ -43,6 +43,10 @@ if(NOT PICO_BOARD)
     string(TOLOWER ${MICROPY_BOARD} PICO_BOARD)
 endif()
 
+# Enable extmod components that will be configured by extmod.cmake.
+# A board may also have enabled additional components.
+set(MICROPY_SSL_MBEDTLS ON)
+
 # Include component cmake fragments
 include(${MICROPY_DIR}/py/py.cmake)
 include(${MICROPY_DIR}/extmod/extmod.cmake)


### PR DESCRIPTION
Otherwise include directories are added unconditionally to the build
variables if the component (submodule) is checked out.  This can lead to,
eg, the esp32 build using lib/lwip header files, instead of lwip header
files from the IDF.

Fixes issue #8727.

