### PR TITLE
Minor fixes and improvements

### DIFF
--- a/py/compile.c
+++ b/py/compile.c
@@ -1115,14 +1115,19 @@ STATIC void do_import_name(compiler_t *comp, mp_parse_node_t pn, qstr *q_base) {
             if (!is_as) {
                 *q_base = MP_PARSE_NODE_LEAF_ARG(pns->nodes[0]);
             }
-            int n = MP_PARSE_NODE_STRUCT_NUM_NODES(pns);
-            int len = n - 1;
-            for (int i = 0; i < n; i++) {
+            size_t n = MP_PARSE_NODE_STRUCT_NUM_NODES(pns);
+            if (n == 0) {
+                // There must be at least one node in this PN_dotted_name.
+                // Let the compiler know this so it doesn't warn, and can generate better code.
+                MP_UNREACHABLE;
+            }
+            size_t len = n - 1;
+            for (size_t i = 0; i < n; i++) {
                 len += qstr_len(MP_PARSE_NODE_LEAF_ARG(pns->nodes[i]));
             }
             char *q_ptr = mp_local_alloc(len);
             char *str_dest = q_ptr;
-            for (int i = 0; i < n; i++) {
+            for (size_t i = 0; i < n; i++) {
                 if (i > 0) {
                     *str_dest++ = '.';
                 }
@@ -1135,7 +1140,7 @@ STATIC void do_import_name(compiler_t *comp, mp_parse_node_t pn, qstr *q_base) {
             mp_local_free(q_ptr);
             EMIT_ARG(import, q_full, MP_EMIT_IMPORT_NAME);
             if (is_as) {
-                for (int i = 1; i < n; i++) {
+                for (size_t i = 1; i < n; i++) {
                     EMIT_ARG(attr, MP_PARSE_NODE_LEAF_ARG(pns->nodes[i]), MP_EMIT_ATTR_LOAD);
                 }
             }

--- a/py/makemoduledefs.py
+++ b/py/makemoduledefs.py
@@ -1,9 +1,9 @@
-#!/usr/bin/env python
-
-# This pre-processor parses a single file containing a list of
-# MP_REGISTER_MODULE(module_name, obj_module)
-# These are used to generate a header with the required entries for
-# "mp_rom_map_elem_t mp_builtin_module_table[]" in py/objmodule.c
+"""
+This pre-processor parses a single file containing a list of
+MP_REGISTER_MODULE(module_name, obj_module)
+These are used to generate a header with the required entries for
+"mp_rom_map_elem_t mp_builtin_module_table[]" in py/objmodule.c
+"""
 
 from __future__ import print_function
 

--- a/tests/stress/bytecode_limit.py
+++ b/tests/stress/bytecode_limit.py
@@ -2,6 +2,16 @@
 
 body = " with f()()() as a:\n  try:\n   f()()()\n  except Exception:\n   pass\n"
 
+# Test overflow of jump offset.
+for n in (430, 431, 432, 433):
+    try:
+        exec("cond = 0\nif cond:\n" + body * n + "else:\n print('cond false')\n")
+    except MemoryError:
+        print("SKIP")
+        raise SystemExit
+    except RuntimeError:
+        print("RuntimeError")
+
 # Test changing size of code info (source line/bytecode mapping) due to changing
 # bytecode size in the final passes.  This test is very specific to how the
 # code info is encoded, and how jump offsets shrink in the final passes.  This
@@ -24,10 +34,3 @@ x = [1 if x else 123]
 print(x)
 """
 )
-
-# Test overflow of jump offset.
-for n in (430, 431, 432, 433):
-    try:
-        exec("cond = 0\nif cond:\n" + body * n + "else:\n print('cond false')\n")
-    except RuntimeError:
-        print("RuntimeError")

--- a/tests/stress/bytecode_limit.py.exp
+++ b/tests/stress/bytecode_limit.py.exp
@@ -1,5 +1,5 @@
+cond false
+cond false
+RuntimeError
+RuntimeError
 [123]
-cond false
-cond false
-RuntimeError
-RuntimeError

--- a/tools/ci.sh
+++ b/tools/ci.sh
@@ -320,7 +320,7 @@ function ci_stm32_nucleo_build {
 
     # Test building various MCU families, some with additional options.
     make ${MAKEOPTS} -C ports/stm32 BOARD=NUCLEO_F091RC
-    make ${MAKEOPTS} -C ports/stm32 BOARD=NUCLEO_H743ZI CFLAGS_EXTRA='-DMICROPY_PY_THREAD=1'
+    make ${MAKEOPTS} -C ports/stm32 BOARD=NUCLEO_H743ZI COPT=-O2 CFLAGS_EXTRA='-DMICROPY_PY_THREAD=1'
     make ${MAKEOPTS} -C ports/stm32 BOARD=NUCLEO_L073RZ
     make ${MAKEOPTS} -C ports/stm32 BOARD=NUCLEO_L476RG DEBUG=1
 


### PR DESCRIPTION
- remove gcc 11 warning in `py/compile.c` when -O2 used
- make `py/makemoduledefs.py` consistent with other preprocessor scripts
- make `bytecode_limit.py` test SKIPable on targets that don't have enough memory
- build NUCLEO_H7443ZI with -O2 for CI test