### PR TITLE
tools/ci: Drop ppa requirement.

### DIFF
--- a/.github/workflows/code_formatting.yml
+++ b/.github/workflows/code_formatting.yml
@@ -4,7 +4,7 @@ on: [push, pull_request]
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
     - uses: actions/checkout@v2
     - uses: actions/setup-python@v1

--- a/tools/ci.sh
+++ b/tools/ci.sh
@@ -18,7 +18,6 @@ function ci_gcc_arm_setup {
 # code formatting
 
 function ci_code_formatting_setup {
-    sudo apt-add-repository --yes --update ppa:pybricks/ppa
     sudo apt-get install uncrustify
     pip3 install black
     uncrustify --version


### PR DESCRIPTION
We were using a PPA to get a backported version of uncrustify on Ubuntu 20.04. However, this causes CI to intermittently fail due to connection issues to launchpad.net or the GPG key server.

Ubuntu 22.04 has a newer version of uncrustify removing the need for the PPA. Ubuntu 22.04 is now in beta on GitHub actions, so we should be able to use that instead.
