### PR TITLE
mpremote: Support bytecode raw paste for 'mpremote run module.mpy'

### DIFF
--- a/tools/pyboard.py
+++ b/tools/pyboard.py
@@ -659,9 +659,11 @@ class _FS:
     return self.File()
 uos.mount(_FS(), '/_')
 uos.chdir('/_')
-from _injected import *
-uos.umount('/_')
-del _injected_buf, _FS
+try:
+  from _injected import *
+finally:
+  uos.umount('/_')
+  del _injected_buf, _FS
 """
 
 

--- a/tools/pyboard.py
+++ b/tools/pyboard.py
@@ -407,10 +407,10 @@ class Pyboard:
             # escape any characters that need to be escaped. Note this doesn't
             # count towards the window size, as unescaping happens before filling
             # the window buffer in the device
-            NUM_ESCAPED = 8  # this values has to match value in pyexec.c
+            RAWCODE_PASTE_NUM_ESCAPED = 8  # value has to match the same constant in pyexec.c
             b = re.sub(
-                rb"[" + bytes(range(NUM_ESCAPED)) + rb"]",
-                lambda c: bytes((0x06, c.group()[0] + NUM_ESCAPED)),
+                rb"[" + bytes(range(RAWCODE_PASTE_NUM_ESCAPED)) + rb"]",
+                lambda c: bytes((0x06, c.group()[0] + RAWCODE_PASTE_NUM_ESCAPED)),
                 b,
             )
 


### PR DESCRIPTION
For resource constrained devices without `mpremote mount` support, it is useful to be able to directly run precompiled bytecode (`mpremote run`) when developing, rather having to send source code each time.

Currently this is possible using pyboard.py - the implementation loads some loader Python and injects the bytecode as a variable. This approach reduces RAM usage further by using the "raw paste" window to paste into the same code path that loads and executes .mpy files (thanks Damien for this tip).

## Summary of changes

- Adds a new raw paste command 'B' for 'raw paste bytecode' (raw paste command 'A' is the current/default paste command)
- Adds an escaping mechanism (`<char>` is escaped as `Ctrl-F` `<char + 8>`) during raw paste so byte values less than 8 can be sent without triggering Ctrl-C or Ctrl-D handlers. The two-byte escape sequence still counts as one byte in the paste window.
- Adds relevant support to mpremote.py
- Adds the same "loader Python" approach to mpremote.py which is already in pyboard.py, for devices without raw paste support. Unclear how useful this is, I think it's only needed if using newer mpremote.py with older firmware, but there's no device-side changes and minimal host changes.

## Impact

Building for PYBV11 with default settings, .text segment +128 bytes.

## TODOs

- [x] ~~My understanding might be wrong, but this still currently streams the entire module into a memory buffer (mp_raw_code_load, mp_make_function_from_raw_code) and then executes it ( mp_call_function_0). Maybe this can be made to execute it in chunks as each Python statement completes, meaning less RAM usage for modules which execute some statements on import and don't need to keep those around. But I'm very new to this and haven't dug right into it, could be way off.~~ (I think the soft reset before run makes this a bit of a moot point, although there are still potential savings for 'run'-ing a bytecode that doesn't define any code.)
- [x] Set up some protocol macro defines in the code so all of the possible command sequences are grouped together, to make the protocol easier to understand from the top down.
- [x] ~~Test this works with `MICROPY_REPL_EVENT_DRIVEN`~~ (Seems only JavaScript port uses this method, at least by default, and it doesn't support mpremote - if I should test this on a different port, let me know.)
- [x] Test this works with 'Ctrl-K inject file'
- [x] Set up compilation guards for ports which don't support .mpy loading
- [x] Check for regressions due to the new escape sequences anywhere that pyboard.py calls raw paste routines
- [x] Implement sending of bytecode without raw paste in mpremote (can add the 'injected variable' approach from pyboard.py into mpremote)
- [x] Measure actual memory usage (currently testing on a board with no mem_info)
- [x] Check for memory leaks (I'm not yet across how this rawcode buffer gets cleaned up if you load another one...)

## Compatibility

I believe this approach is compatible between different mpremote.py and MicroPython versions:

* Newer mpremote.py will detect that older MicroPython can't support the "bytecode raw paste" command ("B")
* Old mpremote.py will not try to send this data at all.

Except for the case of anyone who was sending a raw Ctrl-F character as-is in a raw paste, in which case that will stop working as expected if the mprempote.py + firmware versions don't match (due to the Ctrl-F escape handler).
