### PR TITLE
py/py.mk: Add MICROPY_EXCLUDE_EXTMOD make file option.

### DIFF
--- a/mpy-cross/Makefile
+++ b/mpy-cross/Makefile
@@ -9,6 +9,8 @@ QSTR_DEFS = qstrdefsport.h
 # OS name, for simple autoconfig
 UNAME_S := $(shell uname -s)
 
+MICROPY_EXCLUDE_EXTMOD = 1
+
 # include py core make definitions
 include $(TOP)/py/py.mk
 

--- a/ports/minimal/Makefile
+++ b/ports/minimal/Makefile
@@ -7,6 +7,7 @@ QSTR_DEFS = qstrdefsport.h
 
 # MicroPython feature configurations
 MICROPY_ROM_TEXT_COMPRESSION ?= 1
+MICROPY_EXCLUDE_EXTMOD = 1
 
 # include py core make definitions
 include $(TOP)/py/py.mk

--- a/py/py.mk
+++ b/py/py.mk
@@ -221,7 +221,11 @@ PY_CORE_O = $(addprefix $(BUILD)/, $(PY_CORE_O_BASENAME))
 PY_EXTMOD_O = $(addprefix $(BUILD)/, $(PY_EXTMOD_O_BASENAME))
 
 # this is a convenience variable for ports that want core, extmod and frozen code
-PY_O = $(PY_CORE_O) $(PY_EXTMOD_O)
+PY_O = $(PY_CORE_O)
+
+ifneq ($(MICROPY_EXCLUDE_EXTMOD),1)
+PY_O += $(PY_EXTMOD_O)
+endif
 
 # object file for frozen code specified via a manifest
 ifneq ($(FROZEN_MANIFEST),)
@@ -230,7 +234,11 @@ endif
 
 # Sources that may contain qstrings
 SRC_QSTR_IGNORE = py/nlr%
-SRC_QSTR += $(SRC_MOD) $(filter-out $(SRC_QSTR_IGNORE),$(PY_CORE_O_BASENAME:.o=.c)) $(PY_EXTMOD_O_BASENAME:.o=.c)
+SRC_QSTR += $(SRC_MOD) $(filter-out $(SRC_QSTR_IGNORE),$(PY_CORE_O_BASENAME:.o=.c))
+
+ifneq ($(MICROPY_EXCLUDE_EXTMOD),1)
+SRC_QSTR += $(PY_EXTMOD_O_BASENAME:.o=.c)
+endif
 
 # Anything that depends on FORCE will be considered out-of-date
 FORCE:
@@ -287,4 +295,6 @@ $(PY_BUILD)/vm.o: CFLAGS += $(CSUPEROPT)
 #-fno-crossjumping
 
 # Include rules for extmod related code
+ifneq ($(MICROPY_EXCLUDE_EXTMOD),1)
 include $(TOP)/extmod/extmod.mk
+endif


### PR DESCRIPTION
This adds a new `MICROPY_EXCLUDE_EXTMOD` make file option to make compiling `extmod` optional.  For example, we don't need to build `extmod` when building `mpy-cross`.  I have also added it to the minimal port to show that it is not required for ports either.
