### PR TITLE
Improve sys.settrace to help support debugpy / pdb debugging

### DIFF
--- a/ports/unix/variants/standard/mpconfigvariant.h
+++ b/ports/unix/variants/standard/mpconfigvariant.h
@@ -27,5 +27,9 @@
 // Set base feature level.
 #define MICROPY_CONFIG_ROM_LEVEL (MICROPY_CONFIG_ROM_LEVEL_EXTRA_FEATURES)
 
+#ifndef MICROPY_PY_SYS_SETTRACE
+#define MICROPY_PY_SYS_SETTRACE (1)
+#endif
+
 // Enable extra Unix features.
 #include "../mpconfigvariant_common.h"

--- a/py/modsys.c
+++ b/py/modsys.c
@@ -262,6 +262,21 @@ static mp_obj_t mp_sys_settrace(mp_obj_t obj) {
     return mp_prof_settrace(obj);
 }
 MP_DEFINE_CONST_FUN_OBJ_1(mp_sys_settrace_obj, mp_sys_settrace);
+
+static mp_obj_t mp_sys_gettrace(void) {
+    return mp_prof_gettrace();
+}
+MP_DEFINE_CONST_FUN_OBJ_0(mp_sys_gettrace_obj, mp_sys_gettrace);
+
+// _getframe(): Return current frame object.
+static mp_obj_t mp_sys__getframe(size_t n_args, const mp_obj_t *args) {
+    size_t depth = 0;
+    if (n_args == 1) {
+        depth = mp_obj_get_int(args[0]);
+    }
+    return mp_prof_get_frame(depth);
+}
+MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(mp_sys_getframe_obj, 0, 1, mp_sys__getframe);
 #endif // MICROPY_PY_SYS_SETTRACE
 
 #if MICROPY_PY_SYS_PATH && !MICROPY_PY_SYS_ATTR_DELEGATION
@@ -346,6 +361,8 @@ static const mp_rom_map_elem_t mp_module_sys_globals_table[] = {
 
     #if MICROPY_PY_SYS_SETTRACE
     { MP_ROM_QSTR(MP_QSTR_settrace), MP_ROM_PTR(&mp_sys_settrace_obj) },
+    { MP_ROM_QSTR(MP_QSTR_gettrace), MP_ROM_PTR(&mp_sys_gettrace_obj) },
+    { MP_ROM_QSTR(MP_QSTR__getframe), MP_ROM_PTR(&mp_sys_getframe_obj) },
     #endif
 
     #if MICROPY_PY_SYS_STDFILES

--- a/py/profile.c
+++ b/py/profile.c
@@ -184,7 +184,24 @@ static mp_obj_t mp_prof_callback_invoke(mp_obj_t callback, prof_callback_args_t 
     mp_prof_is_executing = true;
 
     mp_obj_t a[3] = {MP_OBJ_FROM_PTR(args->frame), args->event, args->arg};
+
+    // The callback may raise, and the exception is allowed to propagate into
+    // the traced program (that is how a debugger unwinds a target out of a
+    // frame it is stopped in). The recursion guard and the trace callback must
+    // still be brought back to a sane state on that path: an nlr jump straight
+    // out of here would leave mp_prof_is_executing set, which every trace hook
+    // in the VM tests, so a single raise would silently disable tracing for the
+    // rest of the process with no way to re-enable it. CPython unsets the trace
+    // function when it raises; do the same, so the state after a raise is one
+    // sys.settrace() can recover from.
+    nlr_buf_t nlr;
+    if (nlr_push(&nlr) != 0) {
+        mp_prof_is_executing = false;
+        prof_trace_cb = MP_OBJ_NULL;
+        nlr_jump(nlr.ret_val);
+    }
     mp_obj_t top = mp_call_function_n_kw(callback, 3, 0, a);
+    nlr_pop();
 
     mp_prof_is_executing = false;
 

--- a/py/profile.h
+++ b/py/profile.h
@@ -43,6 +43,7 @@ typedef struct _mp_obj_frame_t {
     mp_uint_t lasti;
     mp_uint_t lineno;
     bool trace_opcodes;
+    mp_obj_t f_trace;
 } mp_obj_frame_t;
 
 uint mp_prof_bytecode_lineno(const mp_raw_code_t *rc, size_t bc);
@@ -52,7 +53,9 @@ mp_obj_t mp_obj_new_frame(const mp_code_state_t *code_state);
 
 // This is the implementation for the sys.settrace
 mp_obj_t mp_prof_settrace(mp_obj_t callback);
+mp_obj_t mp_prof_gettrace(void);
 
+mp_obj_t mp_prof_get_frame(size_t depth);
 mp_obj_t mp_prof_frame_enter(mp_code_state_t *code_state);
 mp_obj_t mp_prof_frame_update(const mp_code_state_t *code_state);
 

--- a/py/vm.c
+++ b/py/vm.c
@@ -182,7 +182,8 @@
     if (!mp_prof_is_executing && code_state->frame && MP_STATE_THREAD(prof_trace_callback)) { \
         MP_PROF_INSTR_DEBUG_PRINT(code_state->ip); \
     } \
-    if (!mp_prof_is_executing && code_state->frame && code_state->frame->callback) { \
+    if (!mp_prof_is_executing && code_state->frame && code_state->frame->callback \
+        && MP_STATE_THREAD(prof_trace_callback)) { \
         mp_prof_instr_tick(code_state, is_exception); \
     } \
 } while(0)

--- a/tests/misc/sys__getframe.py
+++ b/tests/misc/sys__getframe.py
@@ -1,0 +1,27 @@
+import sys
+
+try:
+    sys._getframe
+except AttributeError:
+    print("SKIP")
+    raise SystemExit
+
+top_frame = sys._getframe()
+
+print(top_frame.f_code.co_name == "<module>")
+
+
+def new_frame():
+    curr_frame = sys._getframe()
+    prev_frame = sys._getframe(1)
+
+    print(curr_frame.f_code.co_name == "new_frame")
+
+    print(prev_frame.f_code.co_name == "<module>")
+    print(curr_frame.f_back.f_code.co_name == "<module>")
+
+    print(prev_frame.f_lineno == curr_frame.f_back.f_lineno)
+    print(prev_frame.f_code.co_filename == curr_frame.f_back.f_code.co_filename)
+
+
+new_frame()

--- a/tests/misc/sys_settrace_features.py.exp
+++ b/tests/misc/sys_settrace_features.py.exp
@@ -1,0 +1,738 @@
+### trace_handler::main event: call
+ 0:   @__main__:do_tests => sys_settrace_features.py:105
+ 1:   @__main__:<module> => sys_settrace_features.py:117
+### trace_handler::main event: line
+ 0:   @__main__:do_tests => sys_settrace_features.py:107
+ 1:   @__main__:<module> => sys_settrace_features.py:117
+Who loves the sun?
+### trace_handler::main event: line
+ 0:   @__main__:do_tests => sys_settrace_features.py:108
+ 1:   @__main__:<module> => sys_settrace_features.py:117
+### trace_handler::main event: call
+ 0:   @__main__:factorial => sys_settrace_features.py:98
+ 1:   @__main__:do_tests => sys_settrace_features.py:108
+ 2:   @__main__:<module> => sys_settrace_features.py:117
+### trace_handler::Alice event: line
+ 0:   @__main__:factorial => sys_settrace_features.py:99
+ 1:   @__main__:do_tests => sys_settrace_features.py:108
+ 2:   @__main__:<module> => sys_settrace_features.py:117
+### trace_handler::Alice event: line
+ 0:   @__main__:factorial => sys_settrace_features.py:102
+ 1:   @__main__:do_tests => sys_settrace_features.py:108
+ 2:   @__main__:<module> => sys_settrace_features.py:117
+### trace_handler::main event: call
+ 0:   @__main__:factorial => sys_settrace_features.py:98
+ 1:   @__main__:factorial => sys_settrace_features.py:102
+ 2:   @__main__:do_tests => sys_settrace_features.py:108
+ 3:   @__main__:<module> => sys_settrace_features.py:117
+### trace_handler::Bob event: line
+ 0:   @__main__:factorial => sys_settrace_features.py:99
+ 1:   @__main__:factorial => sys_settrace_features.py:102
+ 2:   @__main__:do_tests => sys_settrace_features.py:108
+ 3:   @__main__:<module> => sys_settrace_features.py:117
+### trace_handler::Bob event: line
+ 0:   @__main__:factorial => sys_settrace_features.py:102
+ 1:   @__main__:factorial => sys_settrace_features.py:102
+ 2:   @__main__:do_tests => sys_settrace_features.py:108
+ 3:   @__main__:<module> => sys_settrace_features.py:117
+### trace_handler::main event: call
+ 0:   @__main__:factorial => sys_settrace_features.py:98
+ 1:   @__main__:factorial => sys_settrace_features.py:102
+ 2:   @__main__:factorial => sys_settrace_features.py:102
+ 3:   @__main__:do_tests => sys_settrace_features.py:108
+ 4:   @__main__:<module> => sys_settrace_features.py:117
+### trace_handler::main event: line
+ 0:   @__main__:factorial => sys_settrace_features.py:99
+ 1:   @__main__:factorial => sys_settrace_features.py:102
+ 2:   @__main__:factorial => sys_settrace_features.py:102
+ 3:   @__main__:do_tests => sys_settrace_features.py:108
+ 4:   @__main__:<module> => sys_settrace_features.py:117
+### trace_handler::main event: line
+ 0:   @__main__:factorial => sys_settrace_features.py:102
+ 1:   @__main__:factorial => sys_settrace_features.py:102
+ 2:   @__main__:factorial => sys_settrace_features.py:102
+ 3:   @__main__:do_tests => sys_settrace_features.py:108
+ 4:   @__main__:<module> => sys_settrace_features.py:117
+### trace_handler::main event: call
+ 0:   @__main__:factorial => sys_settrace_features.py:98
+ 1:   @__main__:factorial => sys_settrace_features.py:102
+ 2:   @__main__:factorial => sys_settrace_features.py:102
+ 3:   @__main__:factorial => sys_settrace_features.py:102
+ 4:   @__main__:do_tests => sys_settrace_features.py:108
+ 5:   @__main__:<module> => sys_settrace_features.py:117
+### trace_handler::main event: line
+ 0:   @__main__:factorial => sys_settrace_features.py:99
+ 1:   @__main__:factorial => sys_settrace_features.py:102
+ 2:   @__main__:factorial => sys_settrace_features.py:102
+ 3:   @__main__:factorial => sys_settrace_features.py:102
+ 4:   @__main__:do_tests => sys_settrace_features.py:108
+ 5:   @__main__:<module> => sys_settrace_features.py:117
+### trace_handler::main event: line
+ 0:   @__main__:factorial => sys_settrace_features.py:100
+ 1:   @__main__:factorial => sys_settrace_features.py:102
+ 2:   @__main__:factorial => sys_settrace_features.py:102
+ 3:   @__main__:factorial => sys_settrace_features.py:102
+ 4:   @__main__:do_tests => sys_settrace_features.py:108
+ 5:   @__main__:<module> => sys_settrace_features.py:117
+### trace_handler::main event: return
+ 0:   @__main__:factorial => sys_settrace_features.py:100
+ 1:   @__main__:factorial => sys_settrace_features.py:102
+ 2:   @__main__:factorial => sys_settrace_features.py:102
+ 3:   @__main__:factorial => sys_settrace_features.py:102
+ 4:   @__main__:do_tests => sys_settrace_features.py:108
+ 5:   @__main__:<module> => sys_settrace_features.py:117
+### trace_handler::main event: return
+ 0:   @__main__:factorial => sys_settrace_features.py:102
+ 1:   @__main__:factorial => sys_settrace_features.py:102
+ 2:   @__main__:factorial => sys_settrace_features.py:102
+ 3:   @__main__:do_tests => sys_settrace_features.py:108
+ 4:   @__main__:<module> => sys_settrace_features.py:117
+### trace_handler::Bob event: return
+ 0:   @__main__:factorial => sys_settrace_features.py:102
+ 1:   @__main__:factorial => sys_settrace_features.py:102
+ 2:   @__main__:do_tests => sys_settrace_features.py:108
+ 3:   @__main__:<module> => sys_settrace_features.py:117
+### trace_handler::Alice event: return
+ 0:   @__main__:factorial => sys_settrace_features.py:102
+ 1:   @__main__:do_tests => sys_settrace_features.py:108
+ 2:   @__main__:<module> => sys_settrace_features.py:117
+Not every- 6
+### trace_handler::main event: line
+ 0:   @__main__:do_tests => sys_settrace_features.py:110
+ 1:   @__main__:<module> => sys_settrace_features.py:117
+### trace_handler::main event: call
+ 0:   @sys_settrace_subdir.sys_settrace_generic:<module> => sys_settrace_generic.py:1
+ 1:   @__main__:do_tests => sys_settrace_features.py:110
+ 2:   @__main__:<module> => sys_settrace_features.py:117
+### trace_handler::main event: line
+ 0:   @sys_settrace_subdir.sys_settrace_generic:<module> => sys_settrace_generic.py:1
+ 1:   @__main__:do_tests => sys_settrace_features.py:110
+ 2:   @__main__:<module> => sys_settrace_features.py:117
+Now comes the language constructions tests.
+### trace_handler::main event: line
+ 0:   @sys_settrace_subdir.sys_settrace_generic:<module> => sys_settrace_generic.py:5
+ 1:   @__main__:do_tests => sys_settrace_features.py:110
+ 2:   @__main__:<module> => sys_settrace_features.py:117
+### trace_handler::main event: line
+ 0:   @sys_settrace_subdir.sys_settrace_generic:<module> => sys_settrace_generic.py:13
+ 1:   @__main__:do_tests => sys_settrace_features.py:110
+ 2:   @__main__:<module> => sys_settrace_features.py:117
+### trace_handler::main event: line
+ 0:   @sys_settrace_subdir.sys_settrace_generic:<module> => sys_settrace_generic.py:21
+ 1:   @__main__:do_tests => sys_settrace_features.py:110
+ 2:   @__main__:<module> => sys_settrace_features.py:117
+### trace_handler::main event: line
+ 0:   @sys_settrace_subdir.sys_settrace_generic:<module> => sys_settrace_generic.py:33
+ 1:   @__main__:do_tests => sys_settrace_features.py:110
+ 2:   @__main__:<module> => sys_settrace_features.py:117
+### trace_handler::main event: line
+ 0:   @sys_settrace_subdir.sys_settrace_generic:<module> => sys_settrace_generic.py:38
+ 1:   @__main__:do_tests => sys_settrace_features.py:110
+ 2:   @__main__:<module> => sys_settrace_features.py:117
+### trace_handler::main event: line
+ 0:   @sys_settrace_subdir.sys_settrace_generic:<module> => sys_settrace_generic.py:44
+ 1:   @__main__:do_tests => sys_settrace_features.py:110
+ 2:   @__main__:<module> => sys_settrace_features.py:117
+### trace_handler::main event: line
+ 0:   @sys_settrace_subdir.sys_settrace_generic:<module> => sys_settrace_generic.py:52
+ 1:   @__main__:do_tests => sys_settrace_features.py:110
+ 2:   @__main__:<module> => sys_settrace_features.py:117
+### trace_handler::main event: call
+ 0:   @sys_settrace_subdir.sys_settrace_generic:TLClass => sys_settrace_generic.py:52
+ 1:   @sys_settrace_subdir.sys_settrace_generic:<module> => sys_settrace_generic.py:52
+ 2:   @__main__:do_tests => sys_settrace_features.py:110
+ 3:   @__main__:<module> => sys_settrace_features.py:117
+### trace_handler::main event: line
+ 0:   @sys_settrace_subdir.sys_settrace_generic:TLClass => sys_settrace_generic.py:52
+ 1:   @sys_settrace_subdir.sys_settrace_generic:<module> => sys_settrace_generic.py:52
+ 2:   @__main__:do_tests => sys_settrace_features.py:110
+ 3:   @__main__:<module> => sys_settrace_features.py:117
+### trace_handler::main event: line
+ 0:   @sys_settrace_subdir.sys_settrace_generic:TLClass => sys_settrace_generic.py:53
+ 1:   @sys_settrace_subdir.sys_settrace_generic:<module> => sys_settrace_generic.py:52
+ 2:   @__main__:do_tests => sys_settrace_features.py:110
+ 3:   @__main__:<module> => sys_settrace_features.py:117
+### trace_handler::main event: line
+ 0:   @sys_settrace_subdir.sys_settrace_generic:TLClass => sys_settrace_generic.py:56
+ 1:   @sys_settrace_subdir.sys_settrace_generic:<module> => sys_settrace_generic.py:52
+ 2:   @__main__:do_tests => sys_settrace_features.py:110
+ 3:   @__main__:<module> => sys_settrace_features.py:117
+### trace_handler::main event: return
+ 0:   @sys_settrace_subdir.sys_settrace_generic:TLClass => sys_settrace_generic.py:56
+ 1:   @sys_settrace_subdir.sys_settrace_generic:<module> => sys_settrace_generic.py:52
+ 2:   @__main__:do_tests => sys_settrace_features.py:110
+ 3:   @__main__:<module> => sys_settrace_features.py:117
+### trace_handler::main event: line
+ 0:   @sys_settrace_subdir.sys_settrace_generic:<module> => sys_settrace_generic.py:59
+ 1:   @__main__:do_tests => sys_settrace_features.py:110
+ 2:   @__main__:<module> => sys_settrace_features.py:117
+### trace_handler::main event: line
+ 0:   @sys_settrace_subdir.sys_settrace_generic:<module> => sys_settrace_generic.py:82
+ 1:   @__main__:do_tests => sys_settrace_features.py:110
+ 2:   @__main__:<module> => sys_settrace_features.py:117
+### trace_handler::main event: line
+ 0:   @sys_settrace_subdir.sys_settrace_generic:<module> => sys_settrace_generic.py:93
+ 1:   @__main__:do_tests => sys_settrace_features.py:110
+ 2:   @__main__:<module> => sys_settrace_features.py:117
+And it's done!
+### trace_handler::main event: return
+ 0:   @sys_settrace_subdir.sys_settrace_generic:<module> => sys_settrace_generic.py:93
+ 1:   @__main__:do_tests => sys_settrace_features.py:110
+ 2:   @__main__:<module> => sys_settrace_features.py:117
+### trace_handler::main event: line
+ 0:   @__main__:do_tests => sys_settrace_features.py:112
+ 1:   @__main__:<module> => sys_settrace_features.py:117
+### trace_handler::main event: call
+ 0:   @sys_settrace_subdir.sys_settrace_generic:run_tests => sys_settrace_generic.py:82
+ 1:   @__main__:do_tests => sys_settrace_features.py:112
+ 2:   @__main__:<module> => sys_settrace_features.py:117
+### trace_handler::main event: line
+ 0:   @sys_settrace_subdir.sys_settrace_generic:run_tests => sys_settrace_generic.py:83
+ 1:   @__main__:do_tests => sys_settrace_features.py:112
+ 2:   @__main__:<module> => sys_settrace_features.py:117
+### trace_handler::main event: call
+ 0:   @sys_settrace_subdir.sys_settrace_generic:test_func => sys_settrace_generic.py:5
+ 1:   @sys_settrace_subdir.sys_settrace_generic:run_tests => sys_settrace_generic.py:83
+ 2:   @__main__:do_tests => sys_settrace_features.py:112
+ 3:   @__main__:<module> => sys_settrace_features.py:117
+### trace_handler::main event: line
+ 0:   @sys_settrace_subdir.sys_settrace_generic:test_func => sys_settrace_generic.py:6
+ 1:   @sys_settrace_subdir.sys_settrace_generic:run_tests => sys_settrace_generic.py:83
+ 2:   @__main__:do_tests => sys_settrace_features.py:112
+ 3:   @__main__:<module> => sys_settrace_features.py:117
+### trace_handler::main event: line
+ 0:   @sys_settrace_subdir.sys_settrace_generic:test_func => sys_settrace_generic.py:9
+ 1:   @sys_settrace_subdir.sys_settrace_generic:run_tests => sys_settrace_generic.py:83
+ 2:   @__main__:do_tests => sys_settrace_features.py:112
+ 3:   @__main__:<module> => sys_settrace_features.py:117
+### trace_handler::main event: call
+ 0:   @sys_settrace_subdir.sys_settrace_generic:test_sub_func => sys_settrace_generic.py:6
+ 1:   @sys_settrace_subdir.sys_settrace_generic:test_func => sys_settrace_generic.py:9
+ 2:   @sys_settrace_subdir.sys_settrace_generic:run_tests => sys_settrace_generic.py:83
+ 3:   @__main__:do_tests => sys_settrace_features.py:112
+ 4:   @__main__:<module> => sys_settrace_features.py:117
+### trace_handler::main event: line
+ 0:   @sys_settrace_subdir.sys_settrace_generic:test_sub_func => sys_settrace_generic.py:7
+ 1:   @sys_settrace_subdir.sys_settrace_generic:test_func => sys_settrace_generic.py:9
+ 2:   @sys_settrace_subdir.sys_settrace_generic:run_tests => sys_settrace_generic.py:83
+ 3:   @__main__:do_tests => sys_settrace_features.py:112
+ 4:   @__main__:<module> => sys_settrace_features.py:117
+test_function
+### trace_handler::main event: return
+ 0:   @sys_settrace_subdir.sys_settrace_generic:test_sub_func => sys_settrace_generic.py:7
+ 1:   @sys_settrace_subdir.sys_settrace_generic:test_func => sys_settrace_generic.py:9
+ 2:   @sys_settrace_subdir.sys_settrace_generic:run_tests => sys_settrace_generic.py:83
+ 3:   @__main__:do_tests => sys_settrace_features.py:112
+ 4:   @__main__:<module> => sys_settrace_features.py:117
+### trace_handler::main event: return
+ 0:   @sys_settrace_subdir.sys_settrace_generic:test_func => sys_settrace_generic.py:9
+ 1:   @sys_settrace_subdir.sys_settrace_generic:run_tests => sys_settrace_generic.py:83
+ 2:   @__main__:do_tests => sys_settrace_features.py:112
+ 3:   @__main__:<module> => sys_settrace_features.py:117
+### trace_handler::main event: line
+ 0:   @sys_settrace_subdir.sys_settrace_generic:run_tests => sys_settrace_generic.py:84
+ 1:   @__main__:do_tests => sys_settrace_features.py:112
+ 2:   @__main__:<module> => sys_settrace_features.py:117
+### trace_handler::main event: call
+ 0:   @sys_settrace_subdir.sys_settrace_generic:test_closure => sys_settrace_generic.py:13
+ 1:   @sys_settrace_subdir.sys_settrace_generic:run_tests => sys_settrace_generic.py:84
+ 2:   @__main__:do_tests => sys_settrace_features.py:112
+ 3:   @__main__:<module> => sys_settrace_features.py:117
+### trace_handler::main event: line
+ 0:   @sys_settrace_subdir.sys_settrace_generic:test_closure => sys_settrace_generic.py:14
+ 1:   @sys_settrace_subdir.sys_settrace_generic:run_tests => sys_settrace_generic.py:84
+ 2:   @__main__:do_tests => sys_settrace_features.py:112
+ 3:   @__main__:<module> => sys_settrace_features.py:117
+### trace_handler::main event: line
+ 0:   @sys_settrace_subdir.sys_settrace_generic:test_closure => sys_settrace_generic.py:17
+ 1:   @sys_settrace_subdir.sys_settrace_generic:run_tests => sys_settrace_generic.py:84
+ 2:   @__main__:do_tests => sys_settrace_features.py:112
+ 3:   @__main__:<module> => sys_settrace_features.py:117
+### trace_handler::main event: return
+ 0:   @sys_settrace_subdir.sys_settrace_generic:test_closure => sys_settrace_generic.py:17
+ 1:   @sys_settrace_subdir.sys_settrace_generic:run_tests => sys_settrace_generic.py:84
+ 2:   @__main__:do_tests => sys_settrace_features.py:112
+ 3:   @__main__:<module> => sys_settrace_features.py:117
+### trace_handler::main event: line
+ 0:   @sys_settrace_subdir.sys_settrace_generic:run_tests => sys_settrace_generic.py:85
+ 1:   @__main__:do_tests => sys_settrace_features.py:112
+ 2:   @__main__:<module> => sys_settrace_features.py:117
+### trace_handler::main event: call
+ 0:   @sys_settrace_subdir.sys_settrace_generic:make_closure => sys_settrace_generic.py:14
+ 1:   @sys_settrace_subdir.sys_settrace_generic:run_tests => sys_settrace_generic.py:85
+ 2:   @__main__:do_tests => sys_settrace_features.py:112
+ 3:   @__main__:<module> => sys_settrace_features.py:117
+### trace_handler::main event: line
+ 0:   @sys_settrace_subdir.sys_settrace_generic:make_closure => sys_settrace_generic.py:15
+ 1:   @sys_settrace_subdir.sys_settrace_generic:run_tests => sys_settrace_generic.py:85
+ 2:   @__main__:do_tests => sys_settrace_features.py:112
+ 3:   @__main__:<module> => sys_settrace_features.py:117
+test_closure
+### trace_handler::main event: return
+ 0:   @sys_settrace_subdir.sys_settrace_generic:make_closure => sys_settrace_generic.py:15
+ 1:   @sys_settrace_subdir.sys_settrace_generic:run_tests => sys_settrace_generic.py:85
+ 2:   @__main__:do_tests => sys_settrace_features.py:112
+ 3:   @__main__:<module> => sys_settrace_features.py:117
+### trace_handler::main event: line
+ 0:   @sys_settrace_subdir.sys_settrace_generic:run_tests => sys_settrace_generic.py:86
+ 1:   @__main__:do_tests => sys_settrace_features.py:112
+ 2:   @__main__:<module> => sys_settrace_features.py:117
+### trace_handler::main event: call
+ 0:   @sys_settrace_subdir.sys_settrace_generic:test_exception => sys_settrace_generic.py:21
+ 1:   @sys_settrace_subdir.sys_settrace_generic:run_tests => sys_settrace_generic.py:86
+ 2:   @__main__:do_tests => sys_settrace_features.py:112
+ 3:   @__main__:<module> => sys_settrace_features.py:117
+### trace_handler::main event: line
+ 0:   @sys_settrace_subdir.sys_settrace_generic:test_exception => sys_settrace_generic.py:22
+ 1:   @sys_settrace_subdir.sys_settrace_generic:run_tests => sys_settrace_generic.py:86
+ 2:   @__main__:do_tests => sys_settrace_features.py:112
+ 3:   @__main__:<module> => sys_settrace_features.py:117
+### trace_handler::main event: line
+ 0:   @sys_settrace_subdir.sys_settrace_generic:test_exception => sys_settrace_generic.py:23
+ 1:   @sys_settrace_subdir.sys_settrace_generic:run_tests => sys_settrace_generic.py:86
+ 2:   @__main__:do_tests => sys_settrace_features.py:112
+ 3:   @__main__:<module> => sys_settrace_features.py:117
+### trace_handler::main event: exception
+ 0:   @sys_settrace_subdir.sys_settrace_generic:test_exception => sys_settrace_generic.py:23
+ 1:   @sys_settrace_subdir.sys_settrace_generic:run_tests => sys_settrace_generic.py:86
+ 2:   @__main__:do_tests => sys_settrace_features.py:112
+ 3:   @__main__:<module> => sys_settrace_features.py:117
+### trace_handler::main event: line
+ 0:   @sys_settrace_subdir.sys_settrace_generic:test_exception => sys_settrace_generic.py:25
+ 1:   @sys_settrace_subdir.sys_settrace_generic:run_tests => sys_settrace_generic.py:86
+ 2:   @__main__:do_tests => sys_settrace_features.py:112
+ 3:   @__main__:<module> => sys_settrace_features.py:117
+### trace_handler::main event: line
+ 0:   @sys_settrace_subdir.sys_settrace_generic:test_exception => sys_settrace_generic.py:26
+ 1:   @sys_settrace_subdir.sys_settrace_generic:run_tests => sys_settrace_generic.py:86
+ 2:   @__main__:do_tests => sys_settrace_features.py:112
+ 3:   @__main__:<module> => sys_settrace_features.py:117
+### trace_handler::main event: line
+ 0:   @sys_settrace_subdir.sys_settrace_generic:test_exception => sys_settrace_generic.py:29
+ 1:   @sys_settrace_subdir.sys_settrace_generic:run_tests => sys_settrace_generic.py:86
+ 2:   @__main__:do_tests => sys_settrace_features.py:112
+ 3:   @__main__:<module> => sys_settrace_features.py:117
+### trace_handler::main event: return
+ 0:   @sys_settrace_subdir.sys_settrace_generic:test_exception => sys_settrace_generic.py:29
+ 1:   @sys_settrace_subdir.sys_settrace_generic:run_tests => sys_settrace_generic.py:86
+ 2:   @__main__:do_tests => sys_settrace_features.py:112
+ 3:   @__main__:<module> => sys_settrace_features.py:117
+### trace_handler::main event: line
+ 0:   @sys_settrace_subdir.sys_settrace_generic:run_tests => sys_settrace_generic.py:87
+ 1:   @__main__:do_tests => sys_settrace_features.py:112
+ 2:   @__main__:<module> => sys_settrace_features.py:117
+### trace_handler::main event: call
+ 0:   @sys_settrace_subdir.sys_settrace_generic:test_listcomp => sys_settrace_generic.py:33
+ 1:   @sys_settrace_subdir.sys_settrace_generic:run_tests => sys_settrace_generic.py:87
+ 2:   @__main__:do_tests => sys_settrace_features.py:112
+ 3:   @__main__:<module> => sys_settrace_features.py:117
+### trace_handler::main event: line
+ 0:   @sys_settrace_subdir.sys_settrace_generic:test_listcomp => sys_settrace_generic.py:34
+ 1:   @sys_settrace_subdir.sys_settrace_generic:run_tests => sys_settrace_generic.py:87
+ 2:   @__main__:do_tests => sys_settrace_features.py:112
+ 3:   @__main__:<module> => sys_settrace_features.py:117
+### trace_handler::main event: call
+ 0:   @sys_settrace_subdir.sys_settrace_generic:<listcomp> => sys_settrace_generic.py:34
+ 1:   @sys_settrace_subdir.sys_settrace_generic:test_listcomp => sys_settrace_generic.py:34
+ 2:   @sys_settrace_subdir.sys_settrace_generic:run_tests => sys_settrace_generic.py:87
+ 3:   @__main__:do_tests => sys_settrace_features.py:112
+ 4:   @__main__:<module> => sys_settrace_features.py:117
+### trace_handler::main event: line
+ 0:   @sys_settrace_subdir.sys_settrace_generic:<listcomp> => sys_settrace_generic.py:34
+ 1:   @sys_settrace_subdir.sys_settrace_generic:test_listcomp => sys_settrace_generic.py:34
+ 2:   @sys_settrace_subdir.sys_settrace_generic:run_tests => sys_settrace_generic.py:87
+ 3:   @__main__:do_tests => sys_settrace_features.py:112
+ 4:   @__main__:<module> => sys_settrace_features.py:117
+### trace_handler::main event: line
+ 0:   @sys_settrace_subdir.sys_settrace_generic:<listcomp> => sys_settrace_generic.py:34
+ 1:   @sys_settrace_subdir.sys_settrace_generic:test_listcomp => sys_settrace_generic.py:34
+ 2:   @sys_settrace_subdir.sys_settrace_generic:run_tests => sys_settrace_generic.py:87
+ 3:   @__main__:do_tests => sys_settrace_features.py:112
+ 4:   @__main__:<module> => sys_settrace_features.py:117
+### trace_handler::main event: line
+ 0:   @sys_settrace_subdir.sys_settrace_generic:<listcomp> => sys_settrace_generic.py:34
+ 1:   @sys_settrace_subdir.sys_settrace_generic:test_listcomp => sys_settrace_generic.py:34
+ 2:   @sys_settrace_subdir.sys_settrace_generic:run_tests => sys_settrace_generic.py:87
+ 3:   @__main__:do_tests => sys_settrace_features.py:112
+ 4:   @__main__:<module> => sys_settrace_features.py:117
+### trace_handler::main event: line
+ 0:   @sys_settrace_subdir.sys_settrace_generic:<listcomp> => sys_settrace_generic.py:34
+ 1:   @sys_settrace_subdir.sys_settrace_generic:test_listcomp => sys_settrace_generic.py:34
+ 2:   @sys_settrace_subdir.sys_settrace_generic:run_tests => sys_settrace_generic.py:87
+ 3:   @__main__:do_tests => sys_settrace_features.py:112
+ 4:   @__main__:<module> => sys_settrace_features.py:117
+### trace_handler::main event: return
+ 0:   @sys_settrace_subdir.sys_settrace_generic:<listcomp> => sys_settrace_generic.py:34
+ 1:   @sys_settrace_subdir.sys_settrace_generic:test_listcomp => sys_settrace_generic.py:34
+ 2:   @sys_settrace_subdir.sys_settrace_generic:run_tests => sys_settrace_generic.py:87
+ 3:   @__main__:do_tests => sys_settrace_features.py:112
+ 4:   @__main__:<module> => sys_settrace_features.py:117
+test_listcomp [0, 1, 2]
+### trace_handler::main event: return
+ 0:   @sys_settrace_subdir.sys_settrace_generic:test_listcomp => sys_settrace_generic.py:34
+ 1:   @sys_settrace_subdir.sys_settrace_generic:run_tests => sys_settrace_generic.py:87
+ 2:   @__main__:do_tests => sys_settrace_features.py:112
+ 3:   @__main__:<module> => sys_settrace_features.py:117
+### trace_handler::main event: line
+ 0:   @sys_settrace_subdir.sys_settrace_generic:run_tests => sys_settrace_generic.py:88
+ 1:   @__main__:do_tests => sys_settrace_features.py:112
+ 2:   @__main__:<module> => sys_settrace_features.py:117
+### trace_handler::main event: call
+ 0:   @sys_settrace_subdir.sys_settrace_generic:test_lambda => sys_settrace_generic.py:38
+ 1:   @sys_settrace_subdir.sys_settrace_generic:run_tests => sys_settrace_generic.py:88
+ 2:   @__main__:do_tests => sys_settrace_features.py:112
+ 3:   @__main__:<module> => sys_settrace_features.py:117
+### trace_handler::main event: line
+ 0:   @sys_settrace_subdir.sys_settrace_generic:test_lambda => sys_settrace_generic.py:39
+ 1:   @sys_settrace_subdir.sys_settrace_generic:run_tests => sys_settrace_generic.py:88
+ 2:   @__main__:do_tests => sys_settrace_features.py:112
+ 3:   @__main__:<module> => sys_settrace_features.py:117
+### trace_handler::main event: line
+ 0:   @sys_settrace_subdir.sys_settrace_generic:test_lambda => sys_settrace_generic.py:40
+ 1:   @sys_settrace_subdir.sys_settrace_generic:run_tests => sys_settrace_generic.py:88
+ 2:   @__main__:do_tests => sys_settrace_features.py:112
+ 3:   @__main__:<module> => sys_settrace_features.py:117
+### trace_handler::main event: call
+ 0:   @sys_settrace_subdir.sys_settrace_generic:<lambda> => sys_settrace_generic.py:39
+ 1:   @sys_settrace_subdir.sys_settrace_generic:test_lambda => sys_settrace_generic.py:40
+ 2:   @sys_settrace_subdir.sys_settrace_generic:run_tests => sys_settrace_generic.py:88
+ 3:   @__main__:do_tests => sys_settrace_features.py:112
+ 4:   @__main__:<module> => sys_settrace_features.py:117
+### trace_handler::main event: line
+ 0:   @sys_settrace_subdir.sys_settrace_generic:<lambda> => sys_settrace_generic.py:39
+ 1:   @sys_settrace_subdir.sys_settrace_generic:test_lambda => sys_settrace_generic.py:40
+ 2:   @sys_settrace_subdir.sys_settrace_generic:run_tests => sys_settrace_generic.py:88
+ 3:   @__main__:do_tests => sys_settrace_features.py:112
+ 4:   @__main__:<module> => sys_settrace_features.py:117
+### trace_handler::main event: return
+ 0:   @sys_settrace_subdir.sys_settrace_generic:<lambda> => sys_settrace_generic.py:39
+ 1:   @sys_settrace_subdir.sys_settrace_generic:test_lambda => sys_settrace_generic.py:40
+ 2:   @sys_settrace_subdir.sys_settrace_generic:run_tests => sys_settrace_generic.py:88
+ 3:   @__main__:do_tests => sys_settrace_features.py:112
+ 4:   @__main__:<module> => sys_settrace_features.py:117
+30
+### trace_handler::main event: return
+ 0:   @sys_settrace_subdir.sys_settrace_generic:test_lambda => sys_settrace_generic.py:40
+ 1:   @sys_settrace_subdir.sys_settrace_generic:run_tests => sys_settrace_generic.py:88
+ 2:   @__main__:do_tests => sys_settrace_features.py:112
+ 3:   @__main__:<module> => sys_settrace_features.py:117
+### trace_handler::main event: line
+ 0:   @sys_settrace_subdir.sys_settrace_generic:run_tests => sys_settrace_generic.py:89
+ 1:   @__main__:do_tests => sys_settrace_features.py:112
+ 2:   @__main__:<module> => sys_settrace_features.py:117
+### trace_handler::main event: call
+ 0:   @sys_settrace_subdir.sys_settrace_generic:test_class => sys_settrace_generic.py:59
+ 1:   @sys_settrace_subdir.sys_settrace_generic:run_tests => sys_settrace_generic.py:89
+ 2:   @__main__:do_tests => sys_settrace_features.py:112
+ 3:   @__main__:<module> => sys_settrace_features.py:117
+### trace_handler::main event: line
+ 0:   @sys_settrace_subdir.sys_settrace_generic:test_class => sys_settrace_generic.py:60
+ 1:   @sys_settrace_subdir.sys_settrace_generic:run_tests => sys_settrace_generic.py:89
+ 2:   @__main__:do_tests => sys_settrace_features.py:112
+ 3:   @__main__:<module> => sys_settrace_features.py:117
+### trace_handler::main event: call
+ 0:   @sys_settrace_subdir.sys_settrace_generic:TestClass => sys_settrace_generic.py:60
+ 1:   @sys_settrace_subdir.sys_settrace_generic:test_class => sys_settrace_generic.py:60
+ 2:   @sys_settrace_subdir.sys_settrace_generic:run_tests => sys_settrace_generic.py:89
+ 3:   @__main__:do_tests => sys_settrace_features.py:112
+ 4:   @__main__:<module> => sys_settrace_features.py:117
+### trace_handler::main event: line
+ 0:   @sys_settrace_subdir.sys_settrace_generic:TestClass => sys_settrace_generic.py:60
+ 1:   @sys_settrace_subdir.sys_settrace_generic:test_class => sys_settrace_generic.py:60
+ 2:   @sys_settrace_subdir.sys_settrace_generic:run_tests => sys_settrace_generic.py:89
+ 3:   @__main__:do_tests => sys_settrace_features.py:112
+ 4:   @__main__:<module> => sys_settrace_features.py:117
+### trace_handler::main event: line
+ 0:   @sys_settrace_subdir.sys_settrace_generic:TestClass => sys_settrace_generic.py:61
+ 1:   @sys_settrace_subdir.sys_settrace_generic:test_class => sys_settrace_generic.py:60
+ 2:   @sys_settrace_subdir.sys_settrace_generic:run_tests => sys_settrace_generic.py:89
+ 3:   @__main__:do_tests => sys_settrace_features.py:112
+ 4:   @__main__:<module> => sys_settrace_features.py:117
+### trace_handler::main event: line
+ 0:   @sys_settrace_subdir.sys_settrace_generic:TestClass => sys_settrace_generic.py:63
+ 1:   @sys_settrace_subdir.sys_settrace_generic:test_class => sys_settrace_generic.py:60
+ 2:   @sys_settrace_subdir.sys_settrace_generic:run_tests => sys_settrace_generic.py:89
+ 3:   @__main__:do_tests => sys_settrace_features.py:112
+ 4:   @__main__:<module> => sys_settrace_features.py:117
+### trace_handler::main event: line
+ 0:   @sys_settrace_subdir.sys_settrace_generic:TestClass => sys_settrace_generic.py:67
+ 1:   @sys_settrace_subdir.sys_settrace_generic:test_class => sys_settrace_generic.py:60
+ 2:   @sys_settrace_subdir.sys_settrace_generic:run_tests => sys_settrace_generic.py:89
+ 3:   @__main__:do_tests => sys_settrace_features.py:112
+ 4:   @__main__:<module> => sys_settrace_features.py:117
+### trace_handler::main event: line
+ 0:   @sys_settrace_subdir.sys_settrace_generic:TestClass => sys_settrace_generic.py:70
+ 1:   @sys_settrace_subdir.sys_settrace_generic:test_class => sys_settrace_generic.py:60
+ 2:   @sys_settrace_subdir.sys_settrace_generic:run_tests => sys_settrace_generic.py:89
+ 3:   @__main__:do_tests => sys_settrace_features.py:112
+ 4:   @__main__:<module> => sys_settrace_features.py:117
+### trace_handler::main event: line
+ 0:   @sys_settrace_subdir.sys_settrace_generic:TestClass => sys_settrace_generic.py:73
+ 1:   @sys_settrace_subdir.sys_settrace_generic:test_class => sys_settrace_generic.py:60
+ 2:   @sys_settrace_subdir.sys_settrace_generic:run_tests => sys_settrace_generic.py:89
+ 3:   @__main__:do_tests => sys_settrace_features.py:112
+ 4:   @__main__:<module> => sys_settrace_features.py:117
+### trace_handler::main event: return
+ 0:   @sys_settrace_subdir.sys_settrace_generic:TestClass => sys_settrace_generic.py:73
+ 1:   @sys_settrace_subdir.sys_settrace_generic:test_class => sys_settrace_generic.py:60
+ 2:   @sys_settrace_subdir.sys_settrace_generic:run_tests => sys_settrace_generic.py:89
+ 3:   @__main__:do_tests => sys_settrace_features.py:112
+ 4:   @__main__:<module> => sys_settrace_features.py:117
+### trace_handler::main event: line
+ 0:   @sys_settrace_subdir.sys_settrace_generic:test_class => sys_settrace_generic.py:75
+ 1:   @sys_settrace_subdir.sys_settrace_generic:run_tests => sys_settrace_generic.py:89
+ 2:   @__main__:do_tests => sys_settrace_features.py:112
+ 3:   @__main__:<module> => sys_settrace_features.py:117
+### trace_handler::main event: line
+ 0:   @sys_settrace_subdir.sys_settrace_generic:test_class => sys_settrace_generic.py:76
+ 1:   @sys_settrace_subdir.sys_settrace_generic:run_tests => sys_settrace_generic.py:89
+ 2:   @__main__:do_tests => sys_settrace_features.py:112
+ 3:   @__main__:<module> => sys_settrace_features.py:117
+### trace_handler::main event: call
+ 0:   @sys_settrace_subdir.sys_settrace_generic:method => sys_settrace_generic.py:63
+ 1:   @sys_settrace_subdir.sys_settrace_generic:test_class => sys_settrace_generic.py:76
+ 2:   @sys_settrace_subdir.sys_settrace_generic:run_tests => sys_settrace_generic.py:89
+ 3:   @__main__:do_tests => sys_settrace_features.py:112
+ 4:   @__main__:<module> => sys_settrace_features.py:117
+### trace_handler::main event: line
+ 0:   @sys_settrace_subdir.sys_settrace_generic:method => sys_settrace_generic.py:64
+ 1:   @sys_settrace_subdir.sys_settrace_generic:test_class => sys_settrace_generic.py:76
+ 2:   @sys_settrace_subdir.sys_settrace_generic:run_tests => sys_settrace_generic.py:89
+ 3:   @__main__:do_tests => sys_settrace_features.py:112
+ 4:   @__main__:<module> => sys_settrace_features.py:117
+test_class_method
+### trace_handler::main event: line
+ 0:   @sys_settrace_subdir.sys_settrace_generic:method => sys_settrace_generic.py:65
+ 1:   @sys_settrace_subdir.sys_settrace_generic:test_class => sys_settrace_generic.py:76
+ 2:   @sys_settrace_subdir.sys_settrace_generic:run_tests => sys_settrace_generic.py:89
+ 3:   @__main__:do_tests => sys_settrace_features.py:112
+ 4:   @__main__:<module> => sys_settrace_features.py:117
+### trace_handler::main event: return
+ 0:   @sys_settrace_subdir.sys_settrace_generic:method => sys_settrace_generic.py:65
+ 1:   @sys_settrace_subdir.sys_settrace_generic:test_class => sys_settrace_generic.py:76
+ 2:   @sys_settrace_subdir.sys_settrace_generic:run_tests => sys_settrace_generic.py:89
+ 3:   @__main__:do_tests => sys_settrace_features.py:112
+ 4:   @__main__:<module> => sys_settrace_features.py:117
+### trace_handler::main event: line
+ 0:   @sys_settrace_subdir.sys_settrace_generic:test_class => sys_settrace_generic.py:77
+ 1:   @sys_settrace_subdir.sys_settrace_generic:run_tests => sys_settrace_generic.py:89
+ 2:   @__main__:do_tests => sys_settrace_features.py:112
+ 3:   @__main__:<module> => sys_settrace_features.py:117
+### trace_handler::main event: call
+ 0:   @sys_settrace_subdir.sys_settrace_generic:prprty_getter => sys_settrace_generic.py:67
+ 1:   @sys_settrace_subdir.sys_settrace_generic:test_class => sys_settrace_generic.py:77
+ 2:   @sys_settrace_subdir.sys_settrace_generic:run_tests => sys_settrace_generic.py:89
+ 3:   @__main__:do_tests => sys_settrace_features.py:112
+ 4:   @__main__:<module> => sys_settrace_features.py:117
+### trace_handler::main event: line
+ 0:   @sys_settrace_subdir.sys_settrace_generic:prprty_getter => sys_settrace_generic.py:68
+ 1:   @sys_settrace_subdir.sys_settrace_generic:test_class => sys_settrace_generic.py:77
+ 2:   @sys_settrace_subdir.sys_settrace_generic:run_tests => sys_settrace_generic.py:89
+ 3:   @__main__:do_tests => sys_settrace_features.py:112
+ 4:   @__main__:<module> => sys_settrace_features.py:117
+### trace_handler::main event: return
+ 0:   @sys_settrace_subdir.sys_settrace_generic:prprty_getter => sys_settrace_generic.py:68
+ 1:   @sys_settrace_subdir.sys_settrace_generic:test_class => sys_settrace_generic.py:77
+ 2:   @sys_settrace_subdir.sys_settrace_generic:run_tests => sys_settrace_generic.py:89
+ 3:   @__main__:do_tests => sys_settrace_features.py:112
+ 4:   @__main__:<module> => sys_settrace_features.py:117
+test_class_property -8
+### trace_handler::main event: line
+ 0:   @sys_settrace_subdir.sys_settrace_generic:test_class => sys_settrace_generic.py:78
+ 1:   @sys_settrace_subdir.sys_settrace_generic:run_tests => sys_settrace_generic.py:89
+ 2:   @__main__:do_tests => sys_settrace_features.py:112
+ 3:   @__main__:<module> => sys_settrace_features.py:117
+### trace_handler::main event: call
+ 0:   @sys_settrace_subdir.sys_settrace_generic:prprty_setter => sys_settrace_generic.py:70
+ 1:   @sys_settrace_subdir.sys_settrace_generic:test_class => sys_settrace_generic.py:78
+ 2:   @sys_settrace_subdir.sys_settrace_generic:run_tests => sys_settrace_generic.py:89
+ 3:   @__main__:do_tests => sys_settrace_features.py:112
+ 4:   @__main__:<module> => sys_settrace_features.py:117
+### trace_handler::main event: line
+ 0:   @sys_settrace_subdir.sys_settrace_generic:prprty_setter => sys_settrace_generic.py:71
+ 1:   @sys_settrace_subdir.sys_settrace_generic:test_class => sys_settrace_generic.py:78
+ 2:   @sys_settrace_subdir.sys_settrace_generic:run_tests => sys_settrace_generic.py:89
+ 3:   @__main__:do_tests => sys_settrace_features.py:112
+ 4:   @__main__:<module> => sys_settrace_features.py:117
+### trace_handler::main event: return
+ 0:   @sys_settrace_subdir.sys_settrace_generic:prprty_setter => sys_settrace_generic.py:71
+ 1:   @sys_settrace_subdir.sys_settrace_generic:test_class => sys_settrace_generic.py:78
+ 2:   @sys_settrace_subdir.sys_settrace_generic:run_tests => sys_settrace_generic.py:89
+ 3:   @__main__:do_tests => sys_settrace_features.py:112
+ 4:   @__main__:<module> => sys_settrace_features.py:117
+### trace_handler::main event: line
+ 0:   @sys_settrace_subdir.sys_settrace_generic:test_class => sys_settrace_generic.py:79
+ 1:   @sys_settrace_subdir.sys_settrace_generic:run_tests => sys_settrace_generic.py:89
+ 2:   @__main__:do_tests => sys_settrace_features.py:112
+ 3:   @__main__:<module> => sys_settrace_features.py:117
+### trace_handler::main event: call
+ 0:   @sys_settrace_subdir.sys_settrace_generic:prprty_getter => sys_settrace_generic.py:67
+ 1:   @sys_settrace_subdir.sys_settrace_generic:test_class => sys_settrace_generic.py:79
+ 2:   @sys_settrace_subdir.sys_settrace_generic:run_tests => sys_settrace_generic.py:89
+ 3:   @__main__:do_tests => sys_settrace_features.py:112
+ 4:   @__main__:<module> => sys_settrace_features.py:117
+### trace_handler::main event: line
+ 0:   @sys_settrace_subdir.sys_settrace_generic:prprty_getter => sys_settrace_generic.py:68
+ 1:   @sys_settrace_subdir.sys_settrace_generic:test_class => sys_settrace_generic.py:79
+ 2:   @sys_settrace_subdir.sys_settrace_generic:run_tests => sys_settrace_generic.py:89
+ 3:   @__main__:do_tests => sys_settrace_features.py:112
+ 4:   @__main__:<module> => sys_settrace_features.py:117
+### trace_handler::main event: return
+ 0:   @sys_settrace_subdir.sys_settrace_generic:prprty_getter => sys_settrace_generic.py:68
+ 1:   @sys_settrace_subdir.sys_settrace_generic:test_class => sys_settrace_generic.py:79
+ 2:   @sys_settrace_subdir.sys_settrace_generic:run_tests => sys_settrace_generic.py:89
+ 3:   @__main__:do_tests => sys_settrace_features.py:112
+ 4:   @__main__:<module> => sys_settrace_features.py:117
+test_class_property 12
+### trace_handler::main event: return
+ 0:   @sys_settrace_subdir.sys_settrace_generic:test_class => sys_settrace_generic.py:79
+ 1:   @sys_settrace_subdir.sys_settrace_generic:run_tests => sys_settrace_generic.py:89
+ 2:   @__main__:do_tests => sys_settrace_features.py:112
+ 3:   @__main__:<module> => sys_settrace_features.py:117
+### trace_handler::main event: line
+ 0:   @sys_settrace_subdir.sys_settrace_generic:run_tests => sys_settrace_generic.py:90
+ 1:   @__main__:do_tests => sys_settrace_features.py:112
+ 2:   @__main__:<module> => sys_settrace_features.py:117
+### trace_handler::main event: call
+ 0:   @sys_settrace_subdir.sys_settrace_generic:test_import => sys_settrace_generic.py:44
+ 1:   @sys_settrace_subdir.sys_settrace_generic:run_tests => sys_settrace_generic.py:90
+ 2:   @__main__:do_tests => sys_settrace_features.py:112
+ 3:   @__main__:<module> => sys_settrace_features.py:117
+### trace_handler::main event: line
+ 0:   @sys_settrace_subdir.sys_settrace_generic:test_import => sys_settrace_generic.py:45
+ 1:   @sys_settrace_subdir.sys_settrace_generic:run_tests => sys_settrace_generic.py:90
+ 2:   @__main__:do_tests => sys_settrace_features.py:112
+ 3:   @__main__:<module> => sys_settrace_features.py:117
+### trace_handler::main event: call
+ 0:   @sys_settrace_subdir.sys_settrace_importme:<module> => sys_settrace_importme.py:1
+ 1:   @sys_settrace_subdir.sys_settrace_generic:test_import => sys_settrace_generic.py:45
+ 2:   @sys_settrace_subdir.sys_settrace_generic:run_tests => sys_settrace_generic.py:90
+ 3:   @__main__:do_tests => sys_settrace_features.py:112
+ 4:   @__main__:<module> => sys_settrace_features.py:117
+### trace_handler::main event: line
+ 0:   @sys_settrace_subdir.sys_settrace_importme:<module> => sys_settrace_importme.py:1
+ 1:   @sys_settrace_subdir.sys_settrace_generic:test_import => sys_settrace_generic.py:45
+ 2:   @sys_settrace_subdir.sys_settrace_generic:run_tests => sys_settrace_generic.py:90
+ 3:   @__main__:do_tests => sys_settrace_features.py:112
+ 4:   @__main__:<module> => sys_settrace_features.py:117
+Yep, I got imported.
+### trace_handler::main event: line
+ 0:   @sys_settrace_subdir.sys_settrace_importme:<module> => sys_settrace_importme.py:3
+ 1:   @sys_settrace_subdir.sys_settrace_generic:test_import => sys_settrace_generic.py:45
+ 2:   @sys_settrace_subdir.sys_settrace_generic:run_tests => sys_settrace_generic.py:90
+ 3:   @__main__:do_tests => sys_settrace_features.py:112
+ 4:   @__main__:<module> => sys_settrace_features.py:117
+### trace_handler::main event: line
+ 0:   @sys_settrace_subdir.sys_settrace_importme:<module> => sys_settrace_importme.py:11
+ 1:   @sys_settrace_subdir.sys_settrace_generic:test_import => sys_settrace_generic.py:45
+ 2:   @sys_settrace_subdir.sys_settrace_generic:run_tests => sys_settrace_generic.py:90
+ 3:   @__main__:do_tests => sys_settrace_features.py:112
+ 4:   @__main__:<module> => sys_settrace_features.py:117
+### trace_handler::main event: line
+ 0:   @sys_settrace_subdir.sys_settrace_importme:<module> => sys_settrace_importme.py:18
+ 1:   @sys_settrace_subdir.sys_settrace_generic:test_import => sys_settrace_generic.py:45
+ 2:   @sys_settrace_subdir.sys_settrace_generic:run_tests => sys_settrace_generic.py:90
+ 3:   @__main__:do_tests => sys_settrace_features.py:112
+ 4:   @__main__:<module> => sys_settrace_features.py:117
+### trace_handler::main event: line
+ 0:   @sys_settrace_subdir.sys_settrace_importme:<module> => sys_settrace_importme.py:19
+ 1:   @sys_settrace_subdir.sys_settrace_generic:test_import => sys_settrace_generic.py:45
+ 2:   @sys_settrace_subdir.sys_settrace_generic:run_tests => sys_settrace_generic.py:90
+ 3:   @__main__:do_tests => sys_settrace_features.py:112
+ 4:   @__main__:<module> => sys_settrace_features.py:117
+### trace_handler::main event: line
+ 0:   @sys_settrace_subdir.sys_settrace_importme:<module> => sys_settrace_importme.py:22
+ 1:   @sys_settrace_subdir.sys_settrace_generic:test_import => sys_settrace_generic.py:45
+ 2:   @sys_settrace_subdir.sys_settrace_generic:run_tests => sys_settrace_generic.py:90
+ 3:   @__main__:do_tests => sys_settrace_features.py:112
+ 4:   @__main__:<module> => sys_settrace_features.py:117
+### trace_handler::main event: line
+ 0:   @sys_settrace_subdir.sys_settrace_importme:<module> => sys_settrace_importme.py:26
+ 1:   @sys_settrace_subdir.sys_settrace_generic:test_import => sys_settrace_generic.py:45
+ 2:   @sys_settrace_subdir.sys_settrace_generic:run_tests => sys_settrace_generic.py:90
+ 3:   @__main__:do_tests => sys_settrace_features.py:112
+ 4:   @__main__:<module> => sys_settrace_features.py:117
+### trace_handler::main event: line
+ 0:   @sys_settrace_subdir.sys_settrace_importme:<module> => sys_settrace_importme.py:30
+ 1:   @sys_settrace_subdir.sys_settrace_generic:test_import => sys_settrace_generic.py:45
+ 2:   @sys_settrace_subdir.sys_settrace_generic:run_tests => sys_settrace_generic.py:90
+ 3:   @__main__:do_tests => sys_settrace_features.py:112
+ 4:   @__main__:<module> => sys_settrace_features.py:117
+### trace_handler::main event: line
+ 0:   @sys_settrace_subdir.sys_settrace_importme:<module> => sys_settrace_importme.py:34
+ 1:   @sys_settrace_subdir.sys_settrace_generic:test_import => sys_settrace_generic.py:45
+ 2:   @sys_settrace_subdir.sys_settrace_generic:run_tests => sys_settrace_generic.py:90
+ 3:   @__main__:do_tests => sys_settrace_features.py:112
+ 4:   @__main__:<module> => sys_settrace_features.py:117
+Yep, got here
+### trace_handler::main event: return
+ 0:   @sys_settrace_subdir.sys_settrace_importme:<module> => sys_settrace_importme.py:34
+ 1:   @sys_settrace_subdir.sys_settrace_generic:test_import => sys_settrace_generic.py:45
+ 2:   @sys_settrace_subdir.sys_settrace_generic:run_tests => sys_settrace_generic.py:90
+ 3:   @__main__:do_tests => sys_settrace_features.py:112
+ 4:   @__main__:<module> => sys_settrace_features.py:117
+### trace_handler::main event: line
+ 0:   @sys_settrace_subdir.sys_settrace_generic:test_import => sys_settrace_generic.py:47
+ 1:   @sys_settrace_subdir.sys_settrace_generic:run_tests => sys_settrace_generic.py:90
+ 2:   @__main__:do_tests => sys_settrace_features.py:112
+ 3:   @__main__:<module> => sys_settrace_features.py:117
+### trace_handler::main event: call
+ 0:   @sys_settrace_subdir.sys_settrace_importme:dummy => sys_settrace_importme.py:22
+ 1:   @sys_settrace_subdir.sys_settrace_generic:test_import => sys_settrace_generic.py:47
+ 2:   @sys_settrace_subdir.sys_settrace_generic:run_tests => sys_settrace_generic.py:90
+ 3:   @__main__:do_tests => sys_settrace_features.py:112
+ 4:   @__main__:<module> => sys_settrace_features.py:117
+### trace_handler::main event: line
+ 0:   @sys_settrace_subdir.sys_settrace_importme:dummy => sys_settrace_importme.py:23
+ 1:   @sys_settrace_subdir.sys_settrace_generic:test_import => sys_settrace_generic.py:47
+ 2:   @sys_settrace_subdir.sys_settrace_generic:run_tests => sys_settrace_generic.py:90
+ 3:   @__main__:do_tests => sys_settrace_features.py:112
+ 4:   @__main__:<module> => sys_settrace_features.py:117
+### trace_handler::main event: return
+ 0:   @sys_settrace_subdir.sys_settrace_importme:dummy => sys_settrace_importme.py:23
+ 1:   @sys_settrace_subdir.sys_settrace_generic:test_import => sys_settrace_generic.py:47
+ 2:   @sys_settrace_subdir.sys_settrace_generic:run_tests => sys_settrace_generic.py:90
+ 3:   @__main__:do_tests => sys_settrace_features.py:112
+ 4:   @__main__:<module> => sys_settrace_features.py:117
+### trace_handler::main event: line
+ 0:   @sys_settrace_subdir.sys_settrace_generic:test_import => sys_settrace_generic.py:48
+ 1:   @sys_settrace_subdir.sys_settrace_generic:run_tests => sys_settrace_generic.py:90
+ 2:   @__main__:do_tests => sys_settrace_features.py:112
+ 3:   @__main__:<module> => sys_settrace_features.py:117
+### trace_handler::main event: call
+ 0:   @sys_settrace_subdir.sys_settrace_importme:saysomething => sys_settrace_importme.py:26
+ 1:   @sys_settrace_subdir.sys_settrace_generic:test_import => sys_settrace_generic.py:48
+ 2:   @sys_settrace_subdir.sys_settrace_generic:run_tests => sys_settrace_generic.py:90
+ 3:   @__main__:do_tests => sys_settrace_features.py:112
+ 4:   @__main__:<module> => sys_settrace_features.py:117
+### trace_handler::main event: line
+ 0:   @sys_settrace_subdir.sys_settrace_importme:saysomething => sys_settrace_importme.py:27
+ 1:   @sys_settrace_subdir.sys_settrace_generic:test_import => sys_settrace_generic.py:48
+ 2:   @sys_settrace_subdir.sys_settrace_generic:run_tests => sys_settrace_generic.py:90
+ 3:   @__main__:do_tests => sys_settrace_features.py:112
+ 4:   @__main__:<module> => sys_settrace_features.py:117
+There, I said it.
+### trace_handler::main event: return
+ 0:   @sys_settrace_subdir.sys_settrace_importme:saysomething => sys_settrace_importme.py:27
+ 1:   @sys_settrace_subdir.sys_settrace_generic:test_import => sys_settrace_generic.py:48
+ 2:   @sys_settrace_subdir.sys_settrace_generic:run_tests => sys_settrace_generic.py:90
+ 3:   @__main__:do_tests => sys_settrace_features.py:112
+ 4:   @__main__:<module> => sys_settrace_features.py:117
+### trace_handler::main event: return
+ 0:   @sys_settrace_subdir.sys_settrace_generic:test_import => sys_settrace_generic.py:48
+ 1:   @sys_settrace_subdir.sys_settrace_generic:run_tests => sys_settrace_generic.py:90
+ 2:   @__main__:do_tests => sys_settrace_features.py:112
+ 3:   @__main__:<module> => sys_settrace_features.py:117
+### trace_handler::main event: return
+ 0:   @sys_settrace_subdir.sys_settrace_generic:run_tests => sys_settrace_generic.py:90
+ 1:   @__main__:do_tests => sys_settrace_features.py:112
+ 2:   @__main__:<module> => sys_settrace_features.py:117
+### trace_handler::main event: line
+ 0:   @__main__:do_tests => sys_settrace_features.py:113
+ 1:   @__main__:<module> => sys_settrace_features.py:117
+### trace_handler::main event: return
+ 0:   @__main__:do_tests => sys_settrace_features.py:113
+ 1:   @__main__:<module> => sys_settrace_features.py:117
+
+------------------ script exited ------------------
+Total traces executed:  140

--- a/tests/misc/sys_settrace_raise.py
+++ b/tests/misc/sys_settrace_raise.py
@@ -1,0 +1,105 @@
+# test that an exception raised by a sys.settrace callback propagates into the
+# traced program, and that tracing can be re-established afterwards
+
+import sys
+
+try:
+    sys.settrace
+except AttributeError:
+    print("SKIP")
+    raise SystemExit
+
+
+class Unwind(BaseException):
+    pass
+
+
+calls = 0
+raise_at = None
+
+
+def trace_handler(frame, event, arg):
+    global calls
+    calls += 1
+    if raise_at is not None and calls >= raise_at:
+        raise Unwind()
+    return trace_handler
+
+
+def work():
+    total = 0
+    for i in range(3):
+        total += i
+    return total
+
+
+def traced(label):
+    global calls
+    calls = 0
+    sys.settrace(trace_handler)
+    try:
+        result = work()
+        print(label, "returned", result)
+    except Unwind:
+        print(label, "unwound")
+    finally:
+        sys.settrace(None)
+    return calls
+
+
+# A callback that does not raise traces the whole call.
+raise_at = None
+baseline = traced("baseline")
+print("baseline traced:", baseline > 0)
+
+# A callback that raises unwinds the traced program.
+raise_at = 2
+traced("raising")
+
+# The raise unsets the trace function, as it does on CPython.
+print("gettrace after raise:", sys.gettrace())
+
+# ...and tracing is re-establishable: a stuck recursion guard inside the VM
+# would leave the callback silently never invoked again.
+raise_at = None
+after = traced("after")
+print("re-armed:", after == baseline)
+
+# A BaseException subclass is not swallowed by a target's `except Exception`,
+# which is what makes this usable as a debugger's unwind.
+raise_at = 2
+calls = 0
+
+
+def swallowing():
+    try:
+        return work()
+    except Exception as er:
+        return "swallowed " + type(er).__name__
+
+
+sys.settrace(trace_handler)
+try:
+    print("swallowing returned", swallowing())
+except Unwind:
+    print("swallowing unwound")
+finally:
+    sys.settrace(None)
+
+# sys.settrace(None) called from inside a traced frame stops tracing that frame
+# too, not just frames entered afterwards.
+raise_at = None
+calls = 0
+
+
+def stops_tracing():
+    sys.settrace(None)
+    at_stop = calls
+    work()
+    return at_stop
+
+
+sys.settrace(trace_handler)
+at_stop = stops_tracing()
+sys.settrace(None)
+print("no further calls after settrace(None):", calls == at_stop)

--- a/tests/ports/unix/extra_coverage.py.exp
+++ b/tests/ports/unix/extra_coverage.py.exp
@@ -81,11 +81,12 @@ me
 micropython     machine         marshal         math
 
 argv            atexit          byteorder       exc_info
-executable      exit            getsizeof       implementation
-intern          maxsize         modules         path
-platform        print_exception                 ps1
-ps2             settrace        stderr          stdin
-stdout          tracebacklimit  version         version_info
+executable      exit            getsizeof       gettrace
+implementation  intern          maxsize         modules
+path            platform        print_exception
+ps1             ps2             settrace        stderr
+stdin           stdout          tracebacklimit  version
+version_info
 ementation
 # attrtuple
 (start=1, stop=2, step=3)

--- a/tests/run-tests.py
+++ b/tests/run-tests.py
@@ -109,7 +109,8 @@ emitter_tests_to_skip = {
         "micropython/schedule.py",
         # These require sys.exc_info().
         "misc/sys_exc_info.py",
-        # These require sys.settrace().
+        # These require sys.settrace() / sys._getframe().
+        "misc/sys__getframe.py",
         "misc/sys_settrace_cov.py",
         "misc/sys_settrace_features.py",
         "misc/sys_settrace_generator.py",
@@ -873,7 +874,7 @@ def run_tests(pyb, tests, args, result_dir, num_threads=1):
     def run_one_test(test_file):
         test_file_abspath = os.path.abspath(test_file).replace("\\", "/")
         # If test_file is one of our own tests always make it relative to our tests/ dir and
-        # otherwise use the abosulte path, irregardless of actual path passed,
+        # otherwise use the absolute path, regardless of actual path passed,
         # such that display and result output is always the same.
         try:
             test_file_relpath = os.path.relpath(test_file, start=base_path())


### PR DESCRIPTION
Companion support for https://github.com/micropython/micropython-lib/pull/1022 & https://github.com/micropython/micropython-lib/pull/499

Requires micropython be built with `MICROPY_PY_SYS_SETTRACE` eg. [unix standard variant](https://github.com/micropython/micropython/blob/d7919ea71e7b7cc203ca984cc2f4a55019634835/ports/unix/variants/standard/mpconfigvariant.h#L32)

Includes:
* sys/settrace: Add sys._getframe() function.
  Refer to https://docs.python.org/3/library/sys.html#sys._getframe

* sys/settrace: Add frame.f_trace object support. 
  `f_trace` holds a python obj on the frame, used in `bdb` to track active trace function for call stack.