### PR TITLE
extmod/machine_i2c: Only use WRITE1 option if transfer supports it.

### DIFF
--- a/extmod/machine_i2c.c
+++ b/extmod/machine_i2c.c
@@ -515,19 +515,20 @@ STATIC int read_mem(mp_obj_t self_in, uint16_t addr, uint32_t memaddr, uint8_t a
     size_t memaddr_len = fill_memaddr_buf(&memaddr_buf[0], memaddr, addrsize);
 
     #if MICROPY_PY_MACHINE_I2C_TRANSFER_WRITE1
-
-    // Create partial write and read buffers
-    mp_machine_i2c_buf_t bufs[2] = {
-        {.len = memaddr_len, .buf = memaddr_buf},
-        {.len = len, .buf = buf},
-    };
-
-    // Do write+read I2C transfer
+    // The I2C transfer function may support the MP_MACHINE_I2C_FLAG_WRITE1 option
     mp_machine_i2c_p_t *i2c_p = (mp_machine_i2c_p_t *)self->type->protocol;
-    return i2c_p->transfer(self, addr, 2, bufs,
-        MP_MACHINE_I2C_FLAG_WRITE1 | MP_MACHINE_I2C_FLAG_READ | MP_MACHINE_I2C_FLAG_STOP);
+    if (i2c_p->transfer_supports_write1) {
+        // Create partial write and read buffers
+        mp_machine_i2c_buf_t bufs[2] = {
+            {.len = memaddr_len, .buf = memaddr_buf},
+            {.len = len, .buf = buf},
+        };
 
-    #else
+        // Do write+read I2C transfer
+        return i2c_p->transfer(self, addr, 2, bufs,
+            MP_MACHINE_I2C_FLAG_WRITE1 | MP_MACHINE_I2C_FLAG_READ | MP_MACHINE_I2C_FLAG_STOP);
+    }
+    #endif
 
     int ret = mp_machine_i2c_writeto(self, addr, memaddr_buf, memaddr_len, false);
     if (ret != memaddr_len) {
@@ -536,8 +537,6 @@ STATIC int read_mem(mp_obj_t self_in, uint16_t addr, uint32_t memaddr, uint8_t a
         return ret;
     }
     return mp_machine_i2c_readfrom(self, addr, buf, len, true);
-
-    #endif
 }
 
 STATIC int write_mem(mp_obj_t self_in, uint16_t addr, uint32_t memaddr, uint8_t addrsize, const uint8_t *buf, size_t len) {

--- a/extmod/machine_i2c.h
+++ b/extmod/machine_i2c.h
@@ -61,6 +61,9 @@ typedef struct _mp_machine_i2c_buf_t {
 // - transfer must be non-NULL
 // - transfer_single only needs to be set if transfer=mp_machine_i2c_transfer_adaptor
 typedef struct _mp_machine_i2c_p_t {
+    #if MICROPY_PY_MACHINE_I2C_TRANSFER_WRITE1
+    bool transfer_supports_write1;
+    #endif
     void (*init)(mp_obj_base_t *obj, size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args);
     int (*start)(mp_obj_base_t *obj);
     int (*stop)(mp_obj_base_t *obj);

--- a/ports/esp32/machine_i2c.c
+++ b/ports/esp32/machine_i2c.c
@@ -188,6 +188,7 @@ mp_obj_t machine_hw_i2c_make_new(const mp_obj_type_t *type, size_t n_args, size_
 }
 
 STATIC const mp_machine_i2c_p_t machine_hw_i2c_p = {
+    .transfer_supports_write1 = true,
     .transfer = machine_hw_i2c_transfer,
 };
 


### PR DESCRIPTION
When MICROPY_PY_MACHINE_I2C_TRANSFER_WRITE1 is enabled the port's hardware
I2C transfer functions should support the MP_MACHINE_I2C_FLAG_WRITE1
option, but software I2C will not.  So add a flag to the I2C protocol
struct so each individual protocol can indicate whether it supports this
option or not.

Fixes issue #8765.
