### PR TITLE
extmod/uasyncio/core.py: Support alternative timebase.

### DIFF
--- a/extmod/uasyncio/core.py
+++ b/extmod/uasyncio/core.py
@@ -1,7 +1,10 @@
 # MicroPython uasyncio module
 # MIT license; Copyright (c) 2019 Damien P. George
 
-from time import ticks_ms as ticks, ticks_diff, ticks_add
+try:
+    from uasyncio_time import ticks, ticks_diff, ticks_add
+except:
+    from time import ticks_ms as ticks, ticks_diff, ticks_add
 import sys, select
 
 # Import TaskQueue and Task, preferring built-in C code over Python code


### PR DESCRIPTION
The aim is to support power reduction on STM and possibly other platforms.

The script below, when run on ESP32-S2, reduces current consumption by an order of magnitude compared with pure `uasyncio` code. In practice the `lightsleep` time may be changed dynamically to trade off latency against power consumption.

Unfortunately this does not work on STM because during `lightsleep` the `uasyncio` timebase stops. In my fork of `uasyncio V2` I solved this by conditionally importing a timebase which used the RTC as a timing source. The change in this PR copies this approach.

Demo code:
```python
import uasyncio as asyncio
from machine import lightsleep, Pin
blue_led = Pin(13, Pin.OUT)

async def save_power():
    while True:
        await asyncio.sleep_ms(0)
        lightsleep(50)  # Could be variable

async def flash():
    blue_led(1)
    await asyncio.sleep_ms(20)  # In practice duration is the lightsleep time
    blue_led(0)

async def main():
    asyncio.create_task(save_power())
    while True:
        await flash()
        await asyncio.sleep(3)

try:
    asyncio.run(main())
finally:
    asyncio.new_event_loop()
```
Current, when powered from a LiPo, reduces from ~22mA to ~2mA.