### PR TITLE
py/py.mk: Separate from extmod.mk.

### DIFF
--- a/docs/develop/porting.rst
+++ b/docs/develop/porting.rst
@@ -95,6 +95,7 @@ We also need a Makefile at this point for the port:
 
    # Include py core make definitions.
    include $(TOP)/py/py.mk
+   include $(TOP)/extmod/extmod.mk
 
    # Set CFLAGS and libraries.
    CFLAGS = -I. -I$(BUILD) -I$(TOP)

--- a/examples/embedding/Makefile.upylib
+++ b/examples/embedding/Makefile.upylib
@@ -9,6 +9,7 @@ UNAME_S := $(shell uname -s)
 
 # include py core make definitions
 include $(MPTOP)/py/py.mk
+include $(MPTOP)/extmod/extmod.mk
 
 INC +=  -I.
 INC +=  -I..

--- a/extmod/extmod.mk
+++ b/extmod/extmod.mk
@@ -1,4 +1,54 @@
-# This makefile fragment provides rules to build 3rd-party components for extmod modules
+# This makefile fragment adds the source code files for the core extmod modules
+# and provides rules to build 3rd-party components for extmod modules.
+
+PY_EXTMOD_O_BASENAME = \
+	extmod/moduasyncio.o \
+	extmod/moductypes.o \
+	extmod/modujson.o \
+	extmod/moduos.o \
+	extmod/modure.o \
+	extmod/moduzlib.o \
+	extmod/moduheapq.o \
+	extmod/modutimeq.o \
+	extmod/moduhashlib.o \
+	extmod/moducryptolib.o \
+	extmod/modubinascii.o \
+	extmod/virtpin.o \
+	extmod/machine_bitstream.o \
+	extmod/machine_mem.o \
+	extmod/machine_pinbase.o \
+	extmod/machine_signal.o \
+	extmod/machine_pulse.o \
+	extmod/machine_pwm.o \
+	extmod/machine_i2c.o \
+	extmod/machine_spi.o \
+	extmod/modbluetooth.o \
+	extmod/modussl_axtls.o \
+	extmod/modussl_mbedtls.o \
+	extmod/moduplatform.o\
+	extmod/modurandom.o \
+	extmod/moduselect.o \
+	extmod/moduwebsocket.o \
+	extmod/modwebrepl.o \
+	extmod/modframebuf.o \
+	extmod/vfs.o \
+	extmod/vfs_blockdev.o \
+	extmod/vfs_reader.o \
+	extmod/vfs_posix.o \
+	extmod/vfs_posix_file.o \
+	extmod/vfs_fat.o \
+	extmod/vfs_fat_diskio.o \
+	extmod/vfs_fat_file.o \
+	extmod/vfs_lfs.o \
+	extmod/utime_mphal.o \
+	extmod/uos_dupterm.o \
+	shared/libc/abort_.o \
+	shared/libc/printf.o \
+
+PY_EXTMOD_O = $(addprefix $(BUILD)/, $(PY_EXTMOD_O_BASENAME))
+
+PY_O += $(PY_EXTMOD_O)
+SRC_QSTR += $(PY_EXTMOD_O_BASENAME:.o=.c)
 
 ################################################################################
 # VFS FAT FS

--- a/ports/cc3200/Makefile
+++ b/ports/cc3200/Makefile
@@ -39,6 +39,7 @@ MICROPY_ROM_TEXT_COMPRESSION ?= 1
 
 # include MicroPython make definitions
 include $(TOP)/py/py.mk
+include $(TOP)/extmod/extmod.mk
 include application.mk
 else
 ifeq ($(BTARGET), bootloader)

--- a/ports/esp8266/Makefile
+++ b/ports/esp8266/Makefile
@@ -30,6 +30,7 @@ FROZEN_MANIFEST ?= boards/manifest.py
 
 # include py core make definitions
 include $(TOP)/py/py.mk
+include $(TOP)/extmod/extmod.mk
 
 GIT_SUBMODULES = lib/axtls lib/berkeley-db-1.xx
 

--- a/ports/javascript/Makefile
+++ b/ports/javascript/Makefile
@@ -5,6 +5,7 @@ CROSS = 0
 QSTR_DEFS = qstrdefsport.h
 
 include $(TOP)/py/py.mk
+include $(TOP)/extmod/extmod.mk
 
 CC = emcc
 LD = emcc

--- a/ports/mimxrt/Makefile
+++ b/ports/mimxrt/Makefile
@@ -42,6 +42,7 @@ MICROPY_VFS_FAT ?= 1
 
 # Include py core make definitions
 include $(TOP)/py/py.mk
+include $(TOP)/extmod/extmod.mk
 
 GIT_SUBMODULES = lib/tinyusb lib/nxp_driver lib/lwip lib/mbedtls
 

--- a/ports/nrf/Makefile
+++ b/ports/nrf/Makefile
@@ -56,6 +56,7 @@ FROZEN_MANIFEST ?= modules/manifest.py
 
 # include py core make definitions
 include ../../py/py.mk
+include ../../extmod/extmod.mk
 
 GIT_SUBMODULES = lib/nrfx lib/tinyusb
 

--- a/ports/pic16bit/Makefile
+++ b/ports/pic16bit/Makefile
@@ -5,6 +5,7 @@ QSTR_DEFS = qstrdefsport.h
 
 # include py core make definitions
 include $(TOP)/py/py.mk
+include $(TOP)/extmod/extmod.mk
 
 XCVERSION ?= 1.35
 XC16 ?= /opt/microchip/xc16/v$(XCVERSION)

--- a/ports/powerpc/Makefile
+++ b/ports/powerpc/Makefile
@@ -5,6 +5,7 @@ QSTR_DEFS = qstrdefsport.h
 
 # include py core make definitions
 include $(TOP)/py/py.mk
+include $(TOP)/extmod/extmod.mk
 
 # potato or lpc_serial
 UART ?= potato

--- a/ports/qemu-arm/Makefile
+++ b/ports/qemu-arm/Makefile
@@ -9,6 +9,7 @@ MICROPY_ROM_TEXT_COMPRESSION ?= 1
 
 # include py core make definitions
 include $(TOP)/py/py.mk
+include $(TOP)/extmod/extmod.mk
 
 BOARD ?= mps2-an385
 

--- a/ports/renesas-ra/Makefile
+++ b/ports/renesas-ra/Makefile
@@ -67,6 +67,7 @@ FROZEN_MANIFEST ?= boards/manifest.py
 
 # include py core make definitions
 include $(TOP)/py/py.mk
+include $(TOP)/extmod/extmod.mk
 
 GIT_SUBMODULES += lib/fsp
 

--- a/ports/samd/Makefile
+++ b/ports/samd/Makefile
@@ -22,6 +22,7 @@ FROZEN_MANIFEST ?= boards/manifest.py
 
 # Include py core make definitions
 include $(TOP)/py/py.mk
+include $(TOP)/extmod/extmod.mk
 
 GIT_SUBMODULES = lib/asf4 lib/tinyusb
 

--- a/ports/stm32/Makefile
+++ b/ports/stm32/Makefile
@@ -33,6 +33,7 @@ MBOOT_TEXT0_ADDR ?= 0x08000000
 
 # include py core make definitions
 include $(TOP)/py/py.mk
+include $(TOP)/extmod/extmod.mk
 
 GIT_SUBMODULES += lib/libhydrogen lib/lwip lib/mbedtls lib/stm32lib
 

--- a/ports/teensy/Makefile
+++ b/ports/teensy/Makefile
@@ -44,6 +44,7 @@ endif # USE_FROZEN
 
 # include py core make definitions
 include $(TOP)/py/py.mk
+include $(TOP)/extmod/extmod.mk
 
 # If you set USE_ARDUINO_TOOLCHAIN=1 then this makefile will attempt to use
 # the toolchain that comes with Teensyduino

--- a/ports/unix/Makefile
+++ b/ports/unix/Makefile
@@ -28,6 +28,7 @@ UNAME_S := $(shell uname -s)
 
 # include py core make definitions
 include $(TOP)/py/py.mk
+include $(TOP)/extmod/extmod.mk
 
 GIT_SUBMODULES += lib/axtls lib/berkeley-db-1.xx lib/libffi
 

--- a/ports/windows/Makefile
+++ b/ports/windows/Makefile
@@ -25,6 +25,7 @@ QSTR_GLOBAL_DEPENDENCIES = $(VARIANT_DIR)/mpconfigvariant.h
 
 # include py core make definitions
 include $(TOP)/py/py.mk
+include $(TOP)/extmod/extmod.mk
 
 INC += -I.
 INC += -I$(TOP)

--- a/py/py.mk
+++ b/py/py.mk
@@ -172,56 +172,11 @@ PY_CORE_O_BASENAME = $(addprefix py/,\
 	frozenmod.o \
 	)
 
-PY_EXTMOD_O_BASENAME = \
-	extmod/moduasyncio.o \
-	extmod/moductypes.o \
-	extmod/modujson.o \
-	extmod/moduos.o \
-	extmod/modure.o \
-	extmod/moduzlib.o \
-	extmod/moduheapq.o \
-	extmod/modutimeq.o \
-	extmod/moduhashlib.o \
-	extmod/moducryptolib.o \
-	extmod/modubinascii.o \
-	extmod/virtpin.o \
-	extmod/machine_bitstream.o \
-	extmod/machine_mem.o \
-	extmod/machine_pinbase.o \
-	extmod/machine_signal.o \
-	extmod/machine_pulse.o \
-	extmod/machine_pwm.o \
-	extmod/machine_i2c.o \
-	extmod/machine_spi.o \
-	extmod/modbluetooth.o \
-	extmod/modussl_axtls.o \
-	extmod/modussl_mbedtls.o \
-	extmod/moduplatform.o\
-	extmod/modurandom.o \
-	extmod/moduselect.o \
-	extmod/moduwebsocket.o \
-	extmod/modwebrepl.o \
-	extmod/modframebuf.o \
-	extmod/vfs.o \
-	extmod/vfs_blockdev.o \
-	extmod/vfs_reader.o \
-	extmod/vfs_posix.o \
-	extmod/vfs_posix_file.o \
-	extmod/vfs_fat.o \
-	extmod/vfs_fat_diskio.o \
-	extmod/vfs_fat_file.o \
-	extmod/vfs_lfs.o \
-	extmod/utime_mphal.o \
-	extmod/uos_dupterm.o \
-	shared/libc/abort_.o \
-	shared/libc/printf.o \
-
 # prepend the build destination prefix to the py object files
 PY_CORE_O = $(addprefix $(BUILD)/, $(PY_CORE_O_BASENAME))
-PY_EXTMOD_O = $(addprefix $(BUILD)/, $(PY_EXTMOD_O_BASENAME))
 
 # this is a convenience variable for ports that want core, extmod and frozen code
-PY_O = $(PY_CORE_O) $(PY_EXTMOD_O)
+PY_O += $(PY_CORE_O) 
 
 # object file for frozen code specified via a manifest
 ifneq ($(FROZEN_MANIFEST),)
@@ -230,7 +185,7 @@ endif
 
 # Sources that may contain qstrings
 SRC_QSTR_IGNORE = py/nlr%
-SRC_QSTR += $(SRC_MOD) $(filter-out $(SRC_QSTR_IGNORE),$(PY_CORE_O_BASENAME:.o=.c)) $(PY_EXTMOD_O_BASENAME:.o=.c)
+SRC_QSTR += $(SRC_MOD) $(filter-out $(SRC_QSTR_IGNORE),$(PY_CORE_O_BASENAME:.o=.c))
 
 # Anything that depends on FORCE will be considered out-of-date
 FORCE:
@@ -285,6 +240,3 @@ $(PY_BUILD)/vm.o: CFLAGS += $(CSUPEROPT)
 # http://hg.python.org/cpython/file/b127046831e2/Python/ceval.c#l828
 # http://www.emulators.com/docs/nx25_nostradamus.htm
 #-fno-crossjumping
-
-# Include rules for extmod related code
-include $(TOP)/extmod/extmod.mk


### PR DESCRIPTION
This separates `extmod` from `py.mk`. Previously, `py.mk` assumed that every consumer of the `py/` directory also wanted to include `extmod/`. However, this is not the case.  For example, building `mpy-cross` uses `py/` but doesn't need `extmod/`.

This moves all `extmod`-specific items from `py.mk` to `extmod.mk` and explicitly includes `extmod.mk` in ports that use it instead.
