### PR TITLE
esp32: Enable the timeout_char argument.

### DIFF
--- a/ports/esp32/machine_uart.c
+++ b/ports/esp32/machine_uart.c
@@ -273,7 +273,9 @@ STATIC void machine_uart_init_helper(machine_uart_obj_t *self, size_t n_args, co
         uint32_t char_time_ms = 12000 / baudrate + 1;
         uint32_t rx_timeout = self->timeout_char / char_time_ms;
         if (rx_timeout < 1) {
+            #if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(4, 1, 0)
             uart_set_rx_full_threshold(self->uart_num, 1);
+            #endif
             uart_set_rx_timeout(self->uart_num, 1);
         } else {
             uart_set_rx_timeout(self->uart_num, rx_timeout);

--- a/ports/esp32/machine_uart.c
+++ b/ports/esp32/machine_uart.c
@@ -267,12 +267,16 @@ STATIC void machine_uart_init_helper(machine_uart_obj_t *self, size_t n_args, co
     }
 
     // set timeout_char
-    // make sure it is at least as long as a whole character (13 bits to be safe)
+    // make sure it is at least as long as a whole character (12 bits here)
     if (args[ARG_timeout_char].u_int != -1) {
         self->timeout_char = args[ARG_timeout_char].u_int;
-        uint32_t min_timeout_char = 13000 / baudrate + 1;
-        if (self->timeout_char < min_timeout_char) {
-            self->timeout_char = min_timeout_char;
+        uint32_t char_time_ms = 12000 / baudrate + 1;
+        uint32_t rx_timeout = self->timeout_char / char_time_ms;
+        if (rx_timeout < 1) {
+            uart_set_rx_full_threshold(self->uart_num, 1);
+            uart_set_rx_timeout(self->uart_num, 1);
+        } else {
+            uart_set_rx_timeout(self->uart_num, rx_timeout);
         }
     }
 


### PR DESCRIPTION
Using it for the rx timeout_char. The value is given as ms, which is then
converted to character times. A value of less than a character time
will result in the rx call to return immediately after one character being received.

Addresses issue #8778 and is an alternative to PR #7883.