### PR TITLE
.github/ISSUE_TEMPLATE: Minor improvements to placeholder text.

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -7,9 +7,7 @@ assignees: ''
 
 ---
 
-* Remove all placeholder text below before submitting.
-
-* Please search existing issues before raising a new issue. For questions about MicroPython or for help using MicroPython, please see the MicroPython Forum -- https://forum.micropython.org/
+* Please search existing issues before raising a new issue. For questions about MicroPython or for help using MicroPython, or any sort of "how do I?" requests, please see the MicroPython Forum (https://forum.micropython.org/) or raise a documentation request instead.
 
 * In your issue, please include a clear and concise description of what the bug is, the expected output, and how to replicate it.
 
@@ -23,3 +21,5 @@ assignees: ''
  - firmware file name
  - git commit hash and port/board
  - version information shown in the REPL (hit Ctrl-B to see the startup message)
+
+* Remove all placeholder text above before submitting.

--- a/.github/ISSUE_TEMPLATE/documentation.md
+++ b/.github/ISSUE_TEMPLATE/documentation.md
@@ -7,10 +7,10 @@ assignees: ''
 
 ---
 
-* Remove all placeholder text below before submitting.
-
-* Please search existing issues before raising a new issue. For questions about MicroPython or for help using MicroPython, please see the MicroPython Forum -- https://forum.micropython.org/
+* Please search existing issues before raising a new issue. For questions about MicroPython or for help using MicroPython, or any sort of "how do I?" requests, please see the MicroPython Forum -- https://forum.micropython.org/
 
 * Describe what was missing from the documentation and/or what was incorrect/incomplete.
 
 * If possible, please link to the relevant page on https://docs.micropython.org/
+
+* Remove all placeholder text above before submitting.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -7,9 +7,7 @@ assignees: ''
 
 ---
 
-* Remove all placeholder text below before submitting.
-
-* Please search existing issues before raising a new issue. For questions about MicroPython or for help using MicroPython, please see the MicroPython Forum -- https://forum.micropython.org/
+* Please search existing issues before raising a new issue. For questions about MicroPython or for help using MicroPython, or any sort of "how do I?" requests, please see the MicroPython Forum (https://forum.micropython.org/) or raise a documentation request instead.
 
 * Describe the feature you'd like to see added to MicroPython. In particular, what does this feature enable and why is it useful. MicroPython aims to strike a balance between functionality and code size, so please consider whether this feature can be optionally enabled and whether it can be provided in other ways (e.g. pure-Python library).
 
@@ -22,3 +20,5 @@ assignees: ''
 * For drivers (e.g. for external hardware), please link to datasheets and/or existing drivers from other sources.
 
 * Who do you expect will implement the feature you are requesting? Would you be willing to sponsor this work?
+
+* Remove all placeholder text above before submitting.

--- a/.github/ISSUE_TEMPLATE/security.md
+++ b/.github/ISSUE_TEMPLATE/security.md
@@ -7,10 +7,10 @@ assignees: ''
 
 ---
 
-* Remove all placeholder text before submitting the new issue.
-
 * If you need to raise this issue privately with the MicroPython team, please email contact@micropython.org instead.
 
 * Include a clear and concise description of what the security issue is.
 
 * What does this issue allow an attacker to do?
+
+* Remove all placeholder text above before submitting.


### PR DESCRIPTION
* Move the "delete placeholder" to the end.
* Some inspiration from [Espressif's placeholder](https://github.com/espressif/esp-idf/blob/master/.github/ISSUE_TEMPLATE/bug_report.md) which calls out "how do I?" questions.