### PR TITLE
Backport py3.11 asyncio's taskgroups.

### DIFF
--- a/docs/library/asyncio.rst
+++ b/docs/library/asyncio.rst
@@ -112,7 +112,7 @@ class Task
     ignore this exception.  Cleanup code may be run by trapping it, or via
     ``try ... finally``.
 
-class Taskgroup
+class TaskGroup
 ---------------
 
 See Nathaniel J. Smith's `essay on Structured Concurrency
@@ -124,10 +124,10 @@ for an introduction why you should use taskgroups instead of starting
     His "nursery" objects are called "taskgroup" in asyncio; the
     equivalent of a "go statement" is `Loop.create_task`.
 
-.. class:: Taskgroup()
+.. class:: TaskGroup()
 
     This object is an async context managed holding a group of tasks.
-    Tasks can be added to the group using `Taskgroup.create_task`.
+    Tasks can be added to the group using `TaskGroup.create_task`.
 
     If a task belonging to the group fails, the remaining tasks in the
     group are cancelled with an :exc:`asyncio.CancelledError` exception.
@@ -138,13 +138,13 @@ for an introduction why you should use taskgroups instead of starting
     the taskgroup's member tasks to end before proceeding. It does not
     cancel these tasks and does not prevent the creation of new tasks.
 
-.. method:: Taskgroup.create_task(coroutine)
+.. method:: TaskGroup.create_task(coroutine)
 
     Create a subtask that executes *coroutine* as part of this taskgroup.
 
     Returns the new task.
 
-.. method:: Taskgroup.cancel()
+.. method:: TaskGroup.cancel()
 
     Stop the taskgroup, i.e. cancel all its tasks.
 

--- a/docs/library/asyncio.rst
+++ b/docs/library/asyncio.rst
@@ -289,7 +289,9 @@ TCP stream connections
     accepted connection, *callback* will be called in a new task with
     2 arguments: reader and writer streams for the connection.
 
-    If you use taskgroups, you should use `run_server` instead.
+    This function does **not** co-operate well with taskgroups.
+    If you use them, you should use a function like `run_server`
+    (supplied in ``examples/run_server.py``) instead.
 
     If *ssl* is a `ssl.SSLContext` object, this context is used to create the transport.
 

--- a/examples/run_server.py
+++ b/examples/run_server.py
@@ -1,0 +1,41 @@
+import asyncio
+import socket
+
+# Helper to run a TCP stream server.
+# Callbacks (i.e. connection handlers) may run in a different taskgroup.
+async def run_server(cb, host, port, backlog=5, taskgroup=None):
+
+    # Create and bind server socket.
+    host = socket.getaddrinfo(host, port)[0]  # TODO this is blocking!
+    s = socket.socket()
+    s.setblocking(False)
+    s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+    s.bind(host[-1])
+    s.listen(backlog)
+
+    if taskgroup is None:
+        from asyncio import TaskGroup
+
+        async with TaskGroup() as tg:
+            await _run_server(tg, s, cb)
+    else:
+        await _run_server(taskgroup, s, cb)
+
+
+async def _run_server(tg, s, cb):
+    try:
+        while True:
+            yield asyncio._io_queue.queue_read(s)
+            try:
+                s2, addr = s.accept()
+            except Exception:
+                # Ignore a failed accept
+                continue
+
+            s2.setblocking(False)
+            s2s = Stream(s2, {"peername": addr})
+            tg.create_task(cb(s2s, s2s))
+    finally:
+        s.close()
+
+

--- a/extmod/asyncio/__init__.py
+++ b/extmod/asyncio/__init__.py
@@ -14,8 +14,10 @@ _attrs = {
     "Lock": "lock",
     "open_connection": "stream",
     "start_server": "stream",
+    "run_server": "stream",
     "StreamReader": "stream",
     "StreamWriter": "stream",
+    "TaskGroup": "taskgroup",
 }
 
 

--- a/extmod/asyncio/__init__.py
+++ b/extmod/asyncio/__init__.py
@@ -14,7 +14,6 @@ _attrs = {
     "Lock": "lock",
     "open_connection": "stream",
     "start_server": "stream",
-    "run_server": "stream",
     "StreamReader": "stream",
     "StreamWriter": "stream",
     "TaskGroup": "taskgroup",

--- a/extmod/asyncio/core.py
+++ b/extmod/asyncio/core.py
@@ -16,11 +16,22 @@ except:
 
 
 class BaseExceptionGroup(BaseException):
-    pass
+    def split(self, typ):
+        a, b = [], []
+        if isinstance(typ, (BaseException, tuple)):
+            for err in self.args[1]:
+                (a if isinstance(err, typ) else b).append(err)
+        else:
+            for err in self.args[1]:
+                (a if typ(err) else b).append(err)
+        return a, b
 
 
 class ExceptionGroup(Exception):  # TODO cannot also inherit from BaseExceptionGroup
     pass
+
+
+ExceptionGroup.split = BaseExceptionGroup.split
 
 
 class CancelledError(BaseException):

--- a/extmod/asyncio/core.py
+++ b/extmod/asyncio/core.py
@@ -40,7 +40,7 @@ _exc_context = {"message": "Task exception wasn't retrieved", "exception": None,
 
 
 # "Yield" once, then raise StopIteration
-class SingletonGenerator:
+class SleepHandler:
     def __init__(self):
         self.state = None
         self.exc = StopIteration()
@@ -59,9 +59,10 @@ class SingletonGenerator:
 
 
 # Pause task execution for the given time (integer in milliseconds, MicroPython extension)
-# Use a SingletonGenerator to do it without allocating on the heap
-def sleep_ms(t, sgen=SingletonGenerator()):
-    assert sgen.state is None
+# Try not to allocate a SleepHandler on the heap if possible.
+def sleep_ms(t, sgen=SleepHandler()):
+    if sgen.state is not None:  # the static one is busy
+        sgen = SleepHandler()
     sgen.state = ticks_add(ticks(), max(0, t))
     return sgen
 

--- a/extmod/asyncio/core.py
+++ b/extmod/asyncio/core.py
@@ -15,6 +15,14 @@ except:
 # Exceptions
 
 
+class BaseExceptionGroup(BaseException):
+    pass
+
+
+class ExceptionGroup(Exception):  # TODO cannot also inherit from BaseExceptionGroup
+    pass
+
+
 class CancelledError(BaseException):
     pass
 

--- a/extmod/asyncio/manifest.py
+++ b/extmod/asyncio/manifest.py
@@ -9,6 +9,7 @@ package(
         "funcs.py",
         "lock.py",
         "stream.py",
+        "taskgroup.py",
     ),
     base_path="..",
     opt=3,

--- a/extmod/asyncio/stream.py
+++ b/extmod/asyncio/stream.py
@@ -13,6 +13,13 @@ class Stream:
     def get_extra_info(self, v):
         return self.e[v]
 
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        self.s.close()
+        pass
+
     def close(self):
         pass
 

--- a/extmod/asyncio/taskgroup.py
+++ b/extmod/asyncio/taskgroup.py
@@ -1,0 +1,278 @@
+# Adapted with permission from the EdgeDB project.
+# Adapted for MicroPython
+
+
+__all__ = ["TaskGroup"]
+
+from . import core
+from . import Event
+
+DEBUG = False
+
+
+class _TaskCancel:
+    # The purpose of this class is to process cancelling a task that has
+    # not even started, without performing surgery on uasyncio.
+    #
+    def __init__(self, tg, task):
+        self.tg = tg
+        self.task = task
+
+    def remove(self, task):
+        # Called while processing a cancellation of a task that has not yet
+        # run.
+        # The pending task is on the main run queue. uasyncio doesn't
+        # expect that at this point, thus we remove it.
+        core._task_queue.remove(task)
+        # It is also in the taskgroup's list of tasks.
+        tg = self.tg
+        tg._tasks.remove(task)
+        # Wake up the taskgroup if its last child just got terminated.
+        if tg._tasks and tg._on_completed is not None:
+            tg._on_completed.set()
+
+    def __bool__(self):
+        # Called when the uasyncio main loop determines whether to throw an
+        # exception into the new task.
+        # After this point the new task will definitely start, thus the
+        # "TaskGroup._run_task" wrapper will take over and we can remove
+        # this hack.
+        self.task.data = None
+        return False
+
+
+class TaskGroup:
+    def __init__(self):
+        self._entered = False
+        self._exiting = False
+        self._aborting = False
+        self._loop = None
+        self._parent_task = None
+        self._parent_cancel_requested = False
+        self._tasks = set()
+        self._errors = []
+        self._base_error = None
+        self._on_completed = None
+
+    def __repr__(self):
+        info = [""]
+        if self._tasks:
+            info.append(f"tasks={len(self._tasks)}")
+        if self._errors:
+            info.append(f"errors={len(self._errors)}")
+        if self._aborting:
+            info.append("cancelling")
+        elif self._entered:
+            info.append("entered")
+
+        info_str = " ".join(info)
+        return f"<TaskGroup{info_str}>"
+
+    async def __aenter__(self):
+        if self._entered:
+            raise RuntimeError(f"TaskGroup {repr(self)} has been already entered")
+        self._entered = True
+
+        if self._loop is None:
+            self._loop = core.get_event_loop()
+
+        self._parent_task = core.current_task()
+        if self._parent_task is None:
+            raise RuntimeError(f"TaskGroup {repr(self)} cannot determine the parent task")
+
+        return self
+
+    async def __aexit__(self, et, exc, tb):
+        self._exiting = True
+        propagate_cancellation_error = None
+
+        if exc is not None and self._is_base_error(exc) and self._base_error is None:
+            self._base_error = exc
+
+        if et is not None:
+            if et is core.CancelledError:
+                # micropython doesn't have an uncancel counter
+                if self._parent_cancel_requested:
+                    # Do nothing, i.e. swallow the error.
+                    pass
+                else:
+                    propagate_cancellation_error = exc
+
+            if not self._aborting:
+                # Our parent task is being cancelled:
+                #
+                #    async with TaskGroup() as g:
+                #        g.create_task(...)
+                #        await ...  # <- CancelledError
+                #
+                # or there's an exception in "async with":
+                #
+                #    async with TaskGroup() as g:
+                #        g.create_task(...)
+                #        1 / 0
+                #
+                self._abort()
+
+        # We use a while-loop here because the wait on "self._on_completed"
+        # can be cancelled multiple times if our parent task
+        # is being cancelled repeatedly (or even once, when
+        # our own cancellation is already in progress)
+        while self._tasks:
+            if self._on_completed is None:
+                self._on_completed = Event()
+
+            try:
+                await self._on_completed.wait()
+            except core.CancelledError as ex:
+                if not self._aborting:
+                    # Our parent task is being cancelled:
+                    #
+                    #    async def wrapper():
+                    #        async with TaskGroup() as g:
+                    #            g.create_task(foo)
+                    #
+                    # "wrapper" is being cancelled while "foo" is
+                    # still running.
+                    propagate_cancellation_error = ex
+                    self._abort()
+
+            self._on_completed = None
+
+        assert not self._tasks
+
+        if self._base_error is not None:
+            raise self._base_error
+
+        if propagate_cancellation_error is not None:
+            # The wrapping task was cancelled; since we're done with
+            # closing all child tasks, just propagate the cancellation
+            # request now.
+            raise propagate_cancellation_error
+
+        if et is not None and et is not core.CancelledError:
+            self._errors.append(exc)
+
+        if self._errors:
+            errors = self._errors
+            self._errors = None
+
+            if len(errors) == 1:
+                me = errors[0]
+            else:
+                EGroup = core.ExceptionGroup
+                for err in errors:
+                    if not isinstance(err, Exception):
+                        EGroup = core.baseExceptionGroup
+                        break
+                me = EGroup("unhandled errors in a TaskGroup", errors)
+            raise me
+
+        # at this point, if we're cancelled we don't propagate the
+        # exception. So, well, don't.
+        return et is core.CancelledError
+
+    def create_task(self, coro):
+        if not self._entered:
+            raise RuntimeError(f"TaskGroup {repr(self)} has not been entered")
+        if self._exiting and not self._tasks:
+            raise RuntimeError(f"TaskGroup {repr(self)} is finished")
+
+        k = [None]
+        t = self._loop.create_task(self._run_task(k, coro))
+        t.data = _TaskCancel(self, t)
+        k[0] = t  # pass the task to itself
+
+        self._tasks.add(t)
+        return t
+
+    def cancel(self):
+        # Extension (not in CPython): cancel a taskgroup
+        # TODO this waits for the parent to die before killing the child
+        # tasks. Shouldn't that be the other way round?
+        try:
+            self._parent_task.cancel()
+        except RuntimeError:
+            self._parent_cancel_requested = True
+            raise core.CancelledError()
+
+    # Since Python 3.8 Tasks propagate all exceptions correctly,
+    # except for KeyboardInterrupt and SystemExit which are
+    # still considered special.
+
+    def _is_base_error(self, exc: BaseException) -> bool:
+        assert isinstance(exc, BaseException)
+        return isinstance(exc, (SystemExit, KeyboardInterrupt))
+
+    def _abort(self):
+        self._aborting = True
+
+        for t in self._tasks:
+            if not t.done():
+                t.cancel()
+
+    async def _run_task(self, k, coro):
+        task = k[0]
+        assert task is not None
+
+        try:
+            await coro
+        except core.CancelledError as e:
+            exc = e
+        except BaseException as e:
+            if DEBUG:
+                import sys
+
+                sys.print_exception(e)
+
+            exc = e
+        else:
+            exc = None
+        finally:
+            self._tasks.discard(task)
+            if self._on_completed is not None and not self._tasks:
+                self._on_completed.set()
+
+        if type(exc) is core.CancelledError:
+            return
+
+        if exc is None:
+            return
+
+        self._errors.append(exc)
+        if self._is_base_error(exc) and self._base_error is None:
+            self._base_error = exc
+
+        if self._parent_task.done():
+            # Not sure if this case is possible, but we want to handle
+            # it anyways.
+            self._loop.call_exception_handler(
+                {
+                    "message": f"Task {repr(task)} has errored out but its parent task {self._parent_task} is already completed",
+                    "exception": exc,
+                    "task": task,
+                }
+            )
+            return
+
+        if not self._aborting and not self._parent_cancel_requested:
+            # If parent task *is not* being cancelled, it means that we want
+            # to manually cancel it to abort whatever is being run right now
+            # in the TaskGroup.  But we want to mark parent task as
+            # "not cancelled" later in __aexit__.  Example situation that
+            # we need to handle:
+            #
+            #    async def foo():
+            #        try:
+            #            async with TaskGroup() as g:
+            #                g.create_task(crash_soon())
+            #                await something  # <- this needs to be canceled
+            #                                 #    by the TaskGroup, e.g.
+            #                                 #    foo() needs to be cancelled
+            #        except Exception:
+            #            # Ignore any exceptions raised in the TaskGroup
+            #            pass
+            #        await something_else     # this line has to be called
+            #                                 # after TaskGroup is finished.
+            self._abort()
+            self._parent_cancel_requested = True
+            self._parent_task.cancel()

--- a/extmod/asyncio/taskgroup.py
+++ b/extmod/asyncio/taskgroup.py
@@ -148,7 +148,7 @@ class TaskGroup:
                 EGroup = core.ExceptionGroup
                 for err in errors:
                     if not isinstance(err, Exception):
-                        EGroup = core.baseExceptionGroup
+                        EGroup = core.BaseExceptionGroup
                         break
                 me = EGroup("unhandled errors in a TaskGroup", errors)
             raise me

--- a/extmod/asyncio/taskgroup.py
+++ b/extmod/asyncio/taskgroup.py
@@ -214,10 +214,10 @@ class TaskGroup:
             if self._on_completed is not None and not self._tasks:
                 self._on_completed.set()
 
-        if type(exc) is core.CancelledError:
+        if exc is None:
             return
 
-        if exc is None:
+        if type(exc) is core.CancelledError:
             return
 
         self._errors.append(exc)

--- a/extmod/asyncio/taskgroup.py
+++ b/extmod/asyncio/taskgroup.py
@@ -121,12 +121,6 @@ class TaskGroup:
             # SystemExit and Keyboardinterrupt get propagated as they are
             raise self._base_error
 
-        if propagate_cancellation_error is not None:
-            # The wrapping task was cancelled; since we're done with
-            # closing all child tasks, just propagate the cancellation
-            # request now.
-            raise propagate_cancellation_error
-
         if et is not None and et is not core.CancelledError:
             self._errors.append(exc)
 
@@ -153,11 +147,11 @@ class TaskGroup:
                 me = EGroup("unhandled errors in a TaskGroup", errors)
             raise me
 
-#       elif propagate_cancellation_error is not None:
-#           # The wrapping task was cancelled; since we're done with
-#           # closing all child tasks, just propagate the cancellation
-#           # request now.
-#           raise propagate_cancellation_error
+        elif propagate_cancellation_error is not None:
+            # The wrapping task was cancelled; since we're done with
+            # closing all child tasks, just propagate the cancellation
+            # request now.
+            raise propagate_cancellation_error
 
     def create_task(self, coro):
         if self._state == _s_new:

--- a/extmod/asyncio/taskgroup.py
+++ b/extmod/asyncio/taskgroup.py
@@ -176,7 +176,8 @@ class TaskGroup:
         try:
             self._parent_task.cancel()
         except RuntimeError:
-            raise core.CancelledError()
+            self._abort()
+            self._parent_cancel_requested = True
 
     def _is_base_error(self, exc: BaseException) -> bool:
         # KeyboardInterrupt and SystemExit are "special": they should

--- a/extmod/asyncio/taskgroup.py
+++ b/extmod/asyncio/taskgroup.py
@@ -123,6 +123,11 @@ class TaskGroup:
             raise self._base_error
 
         if et is not None and et is not core.CancelledError:
+            if _DEBUG:
+                import sys
+
+                print("*** ERR ", repr(exc), file=sys.stderr)
+                sys.print_exception(exc, sys.stderr)
             self._errors.append(exc)
 
         if self._errors:
@@ -139,7 +144,7 @@ class TaskGroup:
                     import sys
 
                     for err in errors:
-                        sys.print_exception(err)
+                        sys.print_exception(err, sys.stderr)
                 EGroup = core.ExceptionGroup
                 for err in errors:
                     if not isinstance(err, Exception):
@@ -205,7 +210,8 @@ class TaskGroup:
             if _DEBUG:
                 import sys
 
-                sys.print_exception(e)
+                print("*** ERR ", repr(e), file=sys.stderr)
+                sys.print_exception(e, sys.stderr)
 
             exc = e
         else:

--- a/extmod/asyncio/taskgroup.py
+++ b/extmod/asyncio/taskgroup.py
@@ -116,6 +116,7 @@ class TaskGroup:
             self._on_completed = None
 
         assert not self._tasks
+        self._parent_task = None
 
         if self._base_error is not None:
             # SystemExit and Keyboardinterrupt get propagated as they are
@@ -169,9 +170,9 @@ class TaskGroup:
         return t
 
     def cancel(self):
-        # Extension (not in CPython): kill off a whole taskgroup
-        # TODO this waits for the parent to die before killing the child
-        # tasks. Shouldn't that be the other way round?
+        # Extension (not in CPython): Stop a whole taskgroup
+        if self._parent_task is None:
+            return
         try:
             self._parent_task.cancel()
         except RuntimeError:

--- a/extmod/asyncio/taskgroup.py
+++ b/extmod/asyncio/taskgroup.py
@@ -156,7 +156,9 @@ class TaskGroup:
     def create_task(self, coro):
         if self._state == _s_new:
             raise RuntimeError("TaskGroup has not been entered")
-        if self._state == _s_aborting and not self._tasks:
+        if self._state == _s_exiting and not self._tasks:
+            raise RuntimeError("TaskGroup is finished")
+        if self._state == _s_aborting:
             raise RuntimeError("TaskGroup is finished")
 
         k = [None]

--- a/extmod/modasyncio.c
+++ b/extmod/modasyncio.c
@@ -302,6 +302,15 @@ static mp_obj_t task_iternext(mp_obj_t self_in) {
     return mp_const_none;
 }
 
+static mp_obj_t task_unary_op(mp_unary_op_t op, mp_obj_t self_in) {
+    switch (op) {
+        case MP_UNARY_OP_HASH:
+            return MP_OBJ_NEW_SMALL_INT((mp_uint_t)self_in);
+        default:
+            return MP_OBJ_NULL;      // op not supported
+    }
+}
+
 static const mp_getiter_iternext_custom_t task_getiter_iternext = {
     .getiter = task_getiter,
     .iternext = task_iternext,
@@ -312,6 +321,7 @@ static MP_DEFINE_CONST_OBJ_TYPE(
     MP_QSTR_Task,
     MP_TYPE_FLAG_ITER_IS_CUSTOM,
     make_new, task_make_new,
+    unary_op, task_unary_op,
     attr, task_attr,
     iter, &task_getiter_iternext
     );

--- a/ports/webassembly/asyncio/__init__.py
+++ b/ports/webassembly/asyncio/__init__.py
@@ -5,5 +5,6 @@ from .core import *
 from .funcs import wait_for, wait_for_ms, gather
 from .event import Event
 from .lock import Lock
+from .taskgroup import TaskGroup
 
-__version__ = (3, 0, 0)
+__version__ = (3, 0, 1)

--- a/ports/webassembly/asyncio/core.py
+++ b/ports/webassembly/asyncio/core.py
@@ -12,6 +12,25 @@ from _asyncio import TaskQueue, Task
 # Exceptions
 
 
+class BaseExceptionGroup(BaseException):
+    def split(self, typ):
+        a, b = [], []
+        if isinstance(typ, (BaseException, tuple)):
+            for err in self.args[1]:
+                (a if isinstance(err, typ) else b).append(err)
+        else:
+            for err in self.args[1]:
+                (a if typ(err) else b).append(err)
+        return a, b
+
+
+class ExceptionGroup(Exception):  # TODO cannot also inherit from BaseExceptionGroup
+    pass
+
+
+ExceptionGroup.split = BaseExceptionGroup.split
+
+
 class CancelledError(BaseException):
     pass
 

--- a/ports/webassembly/variants/manifest.py
+++ b/ports/webassembly/variants/manifest.py
@@ -8,6 +8,7 @@ package(
         "event.py",
         "funcs.py",
         "lock.py",
+        "taskgroup.py",
     ),
     base_path="$(MPY_DIR)/extmod",
     opt=3,

--- a/tests/extmod/asyncio_as_uasyncio.py
+++ b/tests/extmod/asyncio_as_uasyncio.py
@@ -4,6 +4,8 @@ except ImportError:
     print("SKIP")
     raise SystemExit
 
+x = set(dir(uasyncio))
+y = set(dir(uasyncio)) - set(["event", "lock", "stream", "funcs", "taskgroup"])
 
 # Sample of public symbols we expect to see from `asyncio`. Verify they're all
 # available on `uasyncio`.

--- a/tests/extmod/asyncio_taskgroup.py
+++ b/tests/extmod/asyncio_taskgroup.py
@@ -1,6 +1,4 @@
-# test asyncio.TaskGroup functions
-
-# Origin: a straightforward translation of the uasyncio.gather test script.
+# Test Lock class
 
 import sys
 
@@ -9,145 +7,831 @@ try:
 except ImportError:
     print("SKIP")
     raise SystemExit
+try:
+    ExceptionGroup
+except NameError:
+    ExceptionGroup = asyncio.ExceptionGroup
 
 
-async def factorial(name, number):
-    f = 1
-    for i in range(2, number + 1):
-        print("Task {}: Compute factorial({})...".format(name, i))
-        await asyncio.sleep(0.01)
-        f *= i
-    print("Task {}: factorial({}) = {}".format(name, number, f))
-    return f
+class MyExc(Exception):
+    pass
 
 
-async def task(id, t=0.1):
-    print("start", id)
-    await asyncio.sleep(t)
-    print("end", id)
-    return id
+async def test_taskgroup_01():
+    T1 = T2 = 0
+
+    async def foo1():
+        nonlocal T1
+        await asyncio.sleep(0.1)
+        T1 = 42
+
+    async def foo2():
+        nonlocal T2
+        await asyncio.sleep(0.2)
+        T2 = 11
+
+    async with asyncio.TaskGroup() as g:
+        t1 = g.create_task(foo1())
+        t2 = g.create_task(foo2())
+
+    print("T1", T1)
+    print("T2", T2)
 
 
-async def task_loop(id):
-    print("task_loop start", id)
-    while True:
+async def test_taskgroup_02():
+    T1 = T2 = 0
+
+    async def foo1():
+        nonlocal T1
+        await asyncio.sleep(0.1)
+        T1 = 42
+
+    async def foo2():
+        nonlocal T2
+        await asyncio.sleep(0.2)
+        T2 = 11
+
+    async with asyncio.TaskGroup() as g:
+        t1 = g.create_task(foo1())
+        await asyncio.sleep(0.15)
+        t2 = g.create_task(foo2())
+
+    print("T1", T1)
+    print("T2", T2)
+
+
+async def test_taskgroup_03():
+    T1 = T2 = 0
+
+    async def foo1():
+        nonlocal T1
+        await asyncio.sleep(1)
+        T1 = 42
+
+    async def foo2():
+        nonlocal T2
+        await asyncio.sleep(0.2)
+        T2 = 11
+
+    async with asyncio.TaskGroup() as g:
+        t1 = g.create_task(foo1())
+        await asyncio.sleep(0.15)
+        # cancel t1 explicitly, i.e. everything should continue
+        # working as expected.
+        t1.cancel()
+
+        t2 = g.create_task(foo2())
+
+    print("T1", T1)  # 0
+    print("T2", T2)
+
+
+async def test_taskgroup_04():
+    NUM = 0
+    t2_cancel = False
+    t2 = None
+
+    async def foo1():
+        await asyncio.sleep(0.1)
+        1 / 0
+
+    async def foo2():
+        nonlocal NUM, t2_cancel
         try:
-            await asyncio.sleep(0.1)
+            await asyncio.sleep(1)
         except asyncio.CancelledError:
-            print("task_loop cancelled", id)
+            t2_cancel = True
             raise
-        print("task_loop loop", id)
+        NUM += 1
 
+    async def runner():
+        nonlocal NUM, t2
 
-async def task_loop_nc(id):
-    print("task_loop_nc start", id)
-    for _ in range(id):
-        try:
-            await asyncio.sleep(0.1)
-        except asyncio.CancelledError:
-            print("task_loop_nc persists", id)
-            continue
-        print("task_loop_nc loop", id)
+        async with asyncio.TaskGroup() as g:
+            g.create_task(foo1())
+            t2 = g.create_task(foo2())
 
+        NUM += 10
 
-async def task_raise(id, t=0.1):
-    print("task_raise start", id)
     try:
-        await asyncio.sleep(t)
+        await asyncio.get_event_loop().create_task(runner())
+    except ZeroDivisionError:
+        print("ZERO")
+    except ExceptionGroup as exc:
+        a, b = exc.split(ZeroDivisionError)
+        if a and not b:
+            print("ZERO")
+        else:
+            raise exc
+
+    print("NUM", NUM)
+    print("T2C", t2_cancel)
+
+
+async def test_taskgroup_05():
+    NUM = 0
+    t2_cancel = False
+    runner_cancel = False
+
+    async def foo1():
+        await asyncio.sleep(0.1)
+        1 / 0
+
+    async def foo2():
+        nonlocal NUM, t2_cancel
+        try:
+            await asyncio.sleep(5)
+        except asyncio.CancelledError:
+            t2_cancel = True
+            raise
+        NUM += 1
+
+    async def runner():
+        nonlocal NUM, runner_cancel
+
+        async with asyncio.TaskGroup() as g:
+            g.create_task(foo1())
+            g.create_task(foo1())
+            g.create_task(foo1())
+            g.create_task(foo2())
+            try:
+                await asyncio.sleep(10)
+            except asyncio.CancelledError as exc:
+                runner_cancel = True
+                raise exc
+
+        NUM += 10
+
+    # The 3 foo1 sub tasks can be racy when the host is busy - if the
+    # cancellation happens in the middle, we'll see partial sub errors here
+    try:
+        await asyncio.get_event_loop().create_task(runner())
     except asyncio.CancelledError:
-        pass
-    print("task_raise raise", id)
-    raise ValueError(id)
+        print("CANCEL")
+    except ZeroDivisionError:
+        print("ZERO")
+    except ExceptionGroup as exc:
+        a, b = exc.split(ZeroDivisionError)
+        if a and not b:
+            print("ZERO")
+        else:
+            raise exc
+
+    print("NUM", NUM)
+    print("T2", t2_cancel)
+    print("RUN", runner_cancel)
 
 
-def check_done(tasks):
-    for t in tasks:
-        if not t.done():
-            print("FAIL running", t)
+async def test_taskgroup_06():
+    NUM = 0
+
+    async def foo():
+        nonlocal NUM
+        try:
+            await asyncio.sleep(5)
+        except asyncio.CancelledError:
+            NUM += 1
+            raise
+
+    async def runner():
+        async with asyncio.TaskGroup() as g:
+            for _ in range(5):
+                g.create_task(foo())
+
+    r = asyncio.get_event_loop().create_task(runner())
+    await asyncio.sleep(0.1)
+
+    print("D", r.done())
+    r.cancel()
+    try:
+        await r
+    except asyncio.CancelledError:
+        print("CANCEL")
+    except ZeroDivisionError:
+        print("ZERO")
+
+    print("NUM", NUM)
+
+
+async def test_taskgroup_07():
+    NUM = 0
+
+    async def foo():
+        nonlocal NUM
+        try:
+            await asyncio.sleep(5)
+        except asyncio.CancelledError:
+            NUM += 1
+            raise
+
+    async def runner():
+        nonlocal NUM
+        async with asyncio.TaskGroup() as g:
+            for _ in range(5):
+                g.create_task(foo())
+
+            try:
+                await asyncio.sleep(10)
+            except asyncio.CancelledError:
+                NUM += 10
+                raise
+
+    r = asyncio.get_event_loop().create_task(runner())
+    await asyncio.sleep(0.1)
+
+    print("D", r.done())
+    r.cancel()
+    try:
+        await r
+    except asyncio.CancelledError:
+        print("CANCEL")
+
+    print("NUM", NUM)
+
+
+async def test_taskgroup_08():
+    if sys.implementation.name != "micropython":
+        print("Not handled: divide by zero")
+
+    async def foo():
+        await asyncio.sleep(0.1)
+        1 / 0
+
+    async def runner():
+        async with asyncio.TaskGroup() as g:
+            for _ in range(5):
+                g.create_task(foo())
+
+            await asyncio.sleep(10)
+
+    r = asyncio.get_event_loop().create_task(runner())
+    await asyncio.sleep(0.2)
+
+    print("D", r.done())
+    r.cancel()
+    try:
+        await r
+    except asyncio.CancelledError:
+        print("CANCEL")
+    except ZeroDivisionError:
+        print("ZERO")
+    except ExceptionGroup as exc:
+        a, b = exc.split(ZeroDivisionError)
+        if a and not b:
+            print("ZERO")
+        else:
+            raise exc
+
+
+async def test_taskgroup_09():
+    t1 = t2 = None
+    T1 = T2 = 0
+
+    async def foo1():
+        nonlocal T1
+        await asyncio.sleep(1)
+        T1 = 42
+
+    async def foo2():
+        nonlocal T2
+        await asyncio.sleep(2)
+        T2 = 11
+
+    async def runner():
+        nonlocal t1, t2
+        async with asyncio.TaskGroup() as g:
+            t1 = g.create_task(foo1())
+            t2 = g.create_task(foo2())
+            await asyncio.sleep(0.1)
+            1 / 0
+
+    try:
+        await runner()
+    except ZeroDivisionError:
+        print("ZERO")
+    except ExceptionGroup as exc:
+        a, b = exc.split(ZeroDivisionError)
+        if a and not b:
+            print("ZERO")
+        else:
+            raise exc
+
+    print("T1", T1)
+    print("T2", T2)
+
+
+async def test_taskgroup_10():
+    t1 = t2 = None
+    T1 = T2 = 0
+
+    async def foo1():
+        nonlocal T1
+        await asyncio.sleep(1)
+        T1 = 42
+
+    async def foo2():
+        nonlocal T2
+        await asyncio.sleep(2)
+        T2 = 11
+
+    async def runner():
+        nonlocal t1, t2
+        async with asyncio.TaskGroup() as g:
+            t1 = g.create_task(foo1())
+            t2 = g.create_task(foo2())
+            1 / 0
+
+    try:
+        await runner()
+    except ZeroDivisionError:
+        print("ZERO")
+    except ExceptionGroup as exc:
+        a, b = exc.split(ZeroDivisionError)
+        if a and not b:
+            print("ZERO")
+        else:
+            raise exc
+
+    print("T1", T1)
+    print("T2", T2)
+
+
+async def test_taskgroup_11():
+    if sys.implementation.name != "micropython":
+        print("Not handled: divide by zero")
+
+    async def foo():
+        await asyncio.sleep(0.1)
+        1 / 0
+
+    async def runner():
+        async with asyncio.TaskGroup():
+            async with asyncio.TaskGroup() as g2:
+                for _ in range(5):
+                    g2.create_task(foo())
+
+                try:
+                    await asyncio.sleep(10)
+                except asyncio.CancelledError:
+                    raise
+
+    r = asyncio.get_event_loop().create_task(runner())
+    await asyncio.sleep(0.2)
+
+    print("D", r.done())
+    r.cancel()
+    try:
+        await r
+    except asyncio.CancelledError:
+        print("CANCEL")
+    except ZeroDivisionError:
+        print("ZERO")
+    except ExceptionGroup as exc:
+        a, b = exc.split(ZeroDivisionError)
+        if a and not b:
+            print("ZERO")
+        else:
+            raise exc
+
+
+async def test_taskgroup_12():
+    if sys.implementation.name != "micropython":
+        print("Not handled: divide by zero")
+
+    async def foo():
+        await asyncio.sleep(0.1)
+        1 / 0
+
+    async def runner():
+        async with asyncio.TaskGroup() as g1:
+            g1.create_task(asyncio.sleep(10))
+
+            async with asyncio.TaskGroup() as g2:
+                for _ in range(5):
+                    g2.create_task(foo())
+
+                try:
+                    await asyncio.sleep(10)
+                except asyncio.CancelledError:
+                    raise
+
+    r = asyncio.get_event_loop().create_task(runner())
+    await asyncio.sleep(0.2)
+
+    print("R", r.done())
+    r.cancel()
+    try:
+        await r
+    except asyncio.CancelledError:
+        print("CANCEL")
+    except ZeroDivisionError:
+        print("ZERO")
+    except ExceptionGroup as exc:
+        a, b = exc.split(ZeroDivisionError)
+        if a and not b:
+            print("ZERO")
+        else:
+            raise exc
+
+
+async def test_taskgroup_13():
+    async def crash_after(t):
+        await asyncio.sleep(t)
+        raise ValueError(t)
+
+    async def runner():
+        async with asyncio.TaskGroup() as g1:
+            g1.create_task(crash_after(0.1))
+
+            async with asyncio.TaskGroup() as g2:
+                g2.create_task(crash_after(0.2))
+                print("E1")
+            print("E2")
+        print("E3")
+
+    r = asyncio.get_event_loop().create_task(runner())
+    try:
+        await r
+    except asyncio.CancelledError:
+        print("CANCEL")
+    except ValueError:
+        print("VAL")
+    except ExceptionGroup as exc:
+        a, b = exc.split(ValueError)
+        if a and not b:
+            print("VAL")
+        else:
+            raise exc
+
+
+async def test_taskgroup_14():
+    async def crash_after(t):
+        await asyncio.sleep(t)
+        raise ValueError(t)
+
+    async def runner():
+        async with asyncio.TaskGroup() as g1:
+            g1.create_task(crash_after(0.2))
+
+            async with asyncio.TaskGroup() as g2:
+                g2.create_task(crash_after(0.1))
+
+    r = asyncio.get_event_loop().create_task(runner())
+    try:
+        await r
+    except ValueError:
+        print("VAL")
+    except ExceptionGroup as exc:
+        a, b = exc.split(ValueError)
+        if a and not b:
+            print("VAL")
+        else:
+            raise exc
+
+
+async def test_taskgroup_15():
+    async def crash_soon():
+        await asyncio.sleep(0.3)
+        1 / 0
+
+    async def runner():
+        async with asyncio.TaskGroup() as g1:
+            g1.create_task(crash_soon())
+            try:
+                await asyncio.sleep(10)
+            except asyncio.CancelledError:
+                await asyncio.sleep(0.5)
+                raise
+
+    r = asyncio.get_event_loop().create_task(runner())
+    await asyncio.sleep(0.1)
+
+    print("R", r.done())
+    r.cancel()
+    try:
+        await r
+    except asyncio.CancelledError:
+        print("CANCEL")
+    except ZeroDivisionError:
+        print("ZERO")
+    except ExceptionGroup as exc:
+        a, b = exc.split(ZeroDivisionError)
+        if a and not b:
+            print("ZERO")
+        else:
+            raise exc
+
+
+async def test_taskgroup_16():
+    async def crash_soon():
+        await asyncio.sleep(0.3)
+        1 / 0
+
+    async def nested_runner():
+        async with asyncio.TaskGroup() as g1:
+            g1.create_task(crash_soon())
+            try:
+                await asyncio.sleep(10)
+            except asyncio.CancelledError:
+                await asyncio.sleep(0.5)
+                raise
+
+    async def runner():
+        t = asyncio.get_event_loop().create_task(nested_runner())
+        await t
+
+    r = asyncio.get_event_loop().create_task(runner())
+    await asyncio.sleep(0.1)
+
+    print("R", r.done())
+    r.cancel()
+    try:
+        await r
+    except asyncio.CancelledError:
+        print("CANCEL")
+    except ZeroDivisionError:
+        print("ZERO")
+    except ExceptionGroup as exc:
+        a, b = exc.split(ZeroDivisionError)
+        if a and not b:
+            print("ZERO")
+        else:
+            raise exc
+
+
+async def test_taskgroup_17():
+    NUM = 0
+
+    async def runner():
+        nonlocal NUM
+        async with asyncio.TaskGroup():
+            try:
+                await asyncio.sleep(10)
+            except asyncio.CancelledError:
+                NUM += 10
+                raise
+
+    r = asyncio.get_event_loop().create_task(runner())
+    await asyncio.sleep(0.1)
+
+    print("R", r.done())
+    r.cancel()
+    try:
+        await r
+    except asyncio.CancelledError:
+        print("CANCEL")
+
+    print("NUM", NUM)
+
+
+async def test_taskgroup_18():
+    NUM = 0
+
+    async def runner():
+        nonlocal NUM
+        async with asyncio.TaskGroup():
+            try:
+                await asyncio.sleep(10)
+            except asyncio.CancelledError:
+                NUM += 10
+                # This isn't a good idea, but we have to support
+                # this weird case.
+                raise MyExc
+
+    r = asyncio.get_event_loop().create_task(runner())
+    await asyncio.sleep(0.1)
+
+    print("R", r.done())
+    r.cancel()
+
+    try:
+        await r
+    except MyExc:
+        print("EXC")
+    except ExceptionGroup as exc:
+        a, b = exc.split(MyExc)
+        if a and not b:
+            print("EXC")
+        else:
+            raise exc
+
+    print("NUM", NUM)
+
+
+async def test_taskgroup_19():
+    async def crash_soon():
+        await asyncio.sleep(0.1)
+        1 / 0
+
+    async def nested():
+        try:
+            await asyncio.sleep(10)
+        finally:
+            raise MyExc
+
+    async def runner():
+        async with asyncio.TaskGroup() as g:
+            g.create_task(crash_soon())
+            await nested()
+
+    r = asyncio.get_event_loop().create_task(runner())
+    try:
+        await r
+    except ExceptionGroup:
+        print("EXC OK")
+
+
+async def test_taskgroup_20():
+    if sys.implementation.name != "micropython":
+        # fake this test
+        print("KBD")
+        return
+
+    async def crash_soon():
+        await asyncio.sleep(0.1)
+        1 / 0
+
+    async def nested():
+        try:
+            await asyncio.sleep(10)
+        finally:
+            raise KeyboardInterrupt
+
+    async def runner():
+        async with asyncio.TaskGroup() as g:
+            g.create_task(crash_soon())
+            await nested()
+
+    try:
+        await runner()
+    except KeyboardInterrupt:
+        print("KBD")
+
+
+async def test_taskgroup_21():
+    if sys.implementation.name != "micropython":
+        # fake this test
+        print("KBD")
+        return
+
+    async def crash_soon():
+        await asyncio.sleep(0.1)
+        raise KeyboardInterrupt
+
+    async def nested():
+        try:
+            await asyncio.sleep(10)
+        finally:
+            raise TypeError
+
+    async def runner():
+        async with asyncio.TaskGroup() as g:
+            g.create_task(crash_soon())
+            await nested()
+
+    try:
+        await runner()
+    except KeyboardInterrupt:
+        print("KBD")
+
+
+async def test_taskgroup_22():
+    T1 = T2 = 0
+
+    async def foo1():
+        nonlocal T1
+        await asyncio.sleep(1)
+        T1 = 42
+
+    async def foo2():
+        nonlocal T2
+        await asyncio.sleep(2)
+        T2 = 11
+
+    async def runner():
+        async with asyncio.TaskGroup() as g:
+            g.create_task(foo1())
+            g.create_task(foo2())
+
+    r = asyncio.get_event_loop().create_task(runner())
+    await asyncio.sleep(0.05)
+    r.cancel()
+
+    try:
+        await r
+    except asyncio.CancelledError:
+        print("Cancelled")
+
+    print("T1", T1)
+    print("T2", T2)
+
+
+async def test_taskgroup_23():
+    async def do_job(delay):
+        await asyncio.sleep(delay)
+
+    async with asyncio.TaskGroup() as g:
+        for count in range(10):
+            await asyncio.sleep(0.1)
+            g.create_task(do_job(0.3))
+            if count == 5 and len(g._tasks) >= 5:
+                print("FAIL")
+        await asyncio.sleep(1.35)
+        print("END", len(g._tasks))
+
+
+async def test_taskgroup_24():
+    async def die():
+        await asyncio.sleep(0.1)
+        raise ValueError()
+
+    async def nodie():
+        await asyncio.sleep(0.3)
+
+    try:
+        async with asyncio.TaskGroup() as g:
+            g.create_task(die())
+    except ValueError:
+        print("VAL")
+    else:
+        print("NO")
+
+    try:
+        async with asyncio.TaskGroup() as g:
+            g.create_task(die())
+            await asyncio.sleep(0.2)
+    except ValueError:
+        print("VAL")
+    else:
+        print("NO")
+
+    try:
+        async with asyncio.TaskGroup() as g:
+            g.create_task(die())
+            g.create_task(nodie())
+            await asyncio.sleep(0.2)
+    except ValueError:
+        print("VAL")
+    else:
+        print("NO")
+
+
+def exc_handler(loop, ctx):
+    print("Not handled:", str(ctx["exception"]))
 
 
 async def main():
-    # Simple gather with return values
-    async with asyncio.TaskGroup() as tg:
-        tasks = [
-            tg.create_task(factorial("A", 2)),
-            tg.create_task(factorial("B", 3)),
-            tg.create_task(factorial("C", 4)),
-        ]
-    check_done(tasks)
-
-    try:
-        # Test cancellation, where one task is cancelled and the other finishes normally
-        await asyncio.sleep(0.1)
-        async with asyncio.TaskGroup() as tg:
-            await asyncio.sleep(0.1)
-            tasks = [tg.create_task(task(1)), tg.create_task(task(2))]
-            tasks[0].cancel()
-        check_done(tasks)
-        print("====")
-    except BaseException as ex:
-        print("FAIL", repr(ex))
-
-    try:
-        async with asyncio.TaskGroup() as tg:
-            tasks = [tg.create_task(task(1)), tg.create_task(task_raise(2))]
-    except ValueError as er:
-        print("OK", repr(er))
-    else:
-        print("FAIL no error raised")
-    check_done(tasks)
-
-    print("====")
-
-    # Test case where one task raises an exception and other task keeps running.
-    try:
-        async with asyncio.TaskGroup() as tg:
-            tasks = [tg.create_task(task_loop_nc(3)), tg.create_task(task_raise(2))]
-    except ValueError as er:
-        print("OK", repr(er))
-    else:
-        print("FAIL passed")
-    check_done(tasks)
-
-    print("====")
-
-    # Test case where both tasks raise an exception.
-    # Use t=0 so they raise one after the other, between the gather starting and finishing.
-    try:
-        async with asyncio.TaskGroup() as tg:
-            tasks = [tg.create_task(task_raise(1, t=0)), tg.create_task(task_raise(2, t=0))]
-    except asyncio.ExceptionGroup as er:
-        print("OK", repr(er))
-    except ValueError as er:
-        # we'd hit this case if "task_raise" wouldn't ignore cancellations
-        print("FAIL", repr(er))
-    else:
-        print("FAIL passed")
-    check_done(tasks)
-
-    print("====")
-
-    # Cancel a taskgroup.
-    async with asyncio.TaskGroup() as tg:
-        tasks = [tg.create_task(task(1)), tg.create_task(task(2))]
-        await asyncio.sleep(0.05)
-        tg.cancel()
-    check_done(tasks)
-
-    # Test edge cases where the gather is cancelled just as tasks are created and ending.
-    for i in range(1, 4):
-        print("====")
-        async with asyncio.TaskGroup() as tg:
-            tasks = [tg.create_task(task(1, t=0)), tg.create_task(task(2, t=0))]
-            for _ in range(i):
-                await asyncio.sleep(0)
-            tg.cancel()
-        check_done(tasks)
-    print("====")
-
-    # Test that the system still works and doesn't save any cancellations
-    await asyncio.sleep(0.1)
-    print("====")
+    asyncio.get_event_loop().set_exception_handler(exc_handler)
+    # Basics
+    print("--- 01")
+    await test_taskgroup_01()
+    print("--- 02")
+    await test_taskgroup_02()
+    print("--- 03")
+    await test_taskgroup_03()
+    print("--- 04")
+    await test_taskgroup_04()
+    print("--- 05")
+    await test_taskgroup_05()
+    print("--- 06")
+    await test_taskgroup_06()
+    print("--- 07")
+    await test_taskgroup_07()
+    print("--- 08")
+    await test_taskgroup_08()
+    print("--- 09")
+    await test_taskgroup_09()
+    print("--- 10")
+    await test_taskgroup_10()
+    print("--- 11")
+    await test_taskgroup_11()
+    print("--- 12")
+    await test_taskgroup_12()
+    print("--- 13")
+    await test_taskgroup_13()
+    print("--- 14")
+    await test_taskgroup_14()
+    print("--- 15")
+    await test_taskgroup_15()
+    print("--- 16")
+    await test_taskgroup_16()
+    print("--- 17")
+    await test_taskgroup_17()
+    print("--- 18")
+    await test_taskgroup_18()
+    print("--- 19")
+    await test_taskgroup_19()
+    print("--- 20")
+    await test_taskgroup_20()
+    print("--- 21")
+    await test_taskgroup_21()
+    print("--- 22")
+    await test_taskgroup_22()
+    print("--- 23")
+    await test_taskgroup_23()
+    print("--- 24")
+    await test_taskgroup_24()
+    print("--- END")
 
 
 asyncio.run(main())

--- a/tests/extmod/asyncio_taskgroup.py
+++ b/tests/extmod/asyncio_taskgroup.py
@@ -760,6 +760,8 @@ async def test_taskgroup_24():
         async with asyncio.TaskGroup() as g:
             g.create_task(die())
             await asyncio.sleep(0.2)
+    except asyncio.CancelledError:
+        print("CANC")
     except ValueError:
         print("VAL")
     else:
@@ -770,6 +772,8 @@ async def test_taskgroup_24():
             g.create_task(die())
             g.create_task(nodie())
             await asyncio.sleep(0.2)
+    except asyncio.CancelledError:
+        print("CANC")
     except ValueError:
         print("VAL")
     else:

--- a/tests/extmod/asyncio_taskgroup.py
+++ b/tests/extmod/asyncio_taskgroup.py
@@ -1,0 +1,153 @@
+# test asyncio.TaskGroup functions
+
+# Origin: a straightforward translation of the uasyncio.gather test script.
+
+import sys
+
+try:
+    import asyncio
+except ImportError:
+    print("SKIP")
+    raise SystemExit
+
+
+async def factorial(name, number):
+    f = 1
+    for i in range(2, number + 1):
+        print("Task {}: Compute factorial({})...".format(name, i))
+        await asyncio.sleep(0.01)
+        f *= i
+    print("Task {}: factorial({}) = {}".format(name, number, f))
+    return f
+
+
+async def task(id, t=0.1):
+    print("start", id)
+    await asyncio.sleep(t)
+    print("end", id)
+    return id
+
+
+async def task_loop(id):
+    print("task_loop start", id)
+    while True:
+        try:
+            await asyncio.sleep(0.1)
+        except asyncio.CancelledError:
+            print("task_loop cancelled", id)
+            raise
+        print("task_loop loop", id)
+
+
+async def task_loop_nc(id):
+    print("task_loop_nc start", id)
+    for _ in range(id):
+        try:
+            await asyncio.sleep(0.1)
+        except asyncio.CancelledError:
+            print("task_loop_nc persists", id)
+            continue
+        print("task_loop_nc loop", id)
+
+
+async def task_raise(id, t=0.1):
+    print("task_raise start", id)
+    try:
+        await asyncio.sleep(t)
+    except asyncio.CancelledError:
+        pass
+    print("task_raise raise", id)
+    raise ValueError(id)
+
+
+def check_done(tasks):
+    for t in tasks:
+        if not t.done():
+            print("FAIL running", t)
+
+
+async def main():
+    # Simple gather with return values
+    async with asyncio.TaskGroup() as tg:
+        tasks = [
+            tg.create_task(factorial("A", 2)),
+            tg.create_task(factorial("B", 3)),
+            tg.create_task(factorial("C", 4)),
+        ]
+    check_done(tasks)
+
+    try:
+        # Test cancellation, where one task is cancelled and the other finishes normally
+        await asyncio.sleep(0.1)
+        async with asyncio.TaskGroup() as tg:
+            await asyncio.sleep(0.1)
+            tasks = [tg.create_task(task(1)), tg.create_task(task(2))]
+            tasks[0].cancel()
+        check_done(tasks)
+        print("====")
+    except BaseException as ex:
+        print("FAIL", repr(ex))
+
+    try:
+        async with asyncio.TaskGroup() as tg:
+            tasks = [tg.create_task(task(1)), tg.create_task(task_raise(2))]
+    except ValueError as er:
+        print("OK", repr(er))
+    else:
+        print("FAIL no error raised")
+    check_done(tasks)
+
+    print("====")
+
+    # Test case where one task raises an exception and other task keeps running.
+    try:
+        async with asyncio.TaskGroup() as tg:
+            tasks = [tg.create_task(task_loop_nc(3)), tg.create_task(task_raise(2))]
+    except ValueError as er:
+        print("OK", repr(er))
+    else:
+        print("FAIL passed")
+    check_done(tasks)
+
+    print("====")
+
+    # Test case where both tasks raise an exception.
+    # Use t=0 so they raise one after the other, between the gather starting and finishing.
+    try:
+        async with asyncio.TaskGroup() as tg:
+            tasks = [tg.create_task(task_raise(1, t=0)), tg.create_task(task_raise(2, t=0))]
+    except asyncio.ExceptionGroup as er:
+        print("OK", repr(er))
+    except ValueError as er:
+        # we'd hit this case if "task_raise" wouldn't ignore cancellations
+        print("FAIL", repr(er))
+    else:
+        print("FAIL passed")
+    check_done(tasks)
+
+    print("====")
+
+    # Cancel a taskgroup.
+    async with asyncio.TaskGroup() as tg:
+        tasks = [tg.create_task(task(1)), tg.create_task(task(2))]
+        await asyncio.sleep(0.05)
+        tg.cancel()
+    check_done(tasks)
+
+    # Test edge cases where the gather is cancelled just as tasks are created and ending.
+    for i in range(1, 4):
+        print("====")
+        async with asyncio.TaskGroup() as tg:
+            tasks = [tg.create_task(task(1, t=0)), tg.create_task(task(2, t=0))]
+            for _ in range(i):
+                await asyncio.sleep(0)
+            tg.cancel()
+        check_done(tasks)
+    print("====")
+
+    # Test that the system still works and doesn't save any cancellations
+    await asyncio.sleep(0.1)
+    print("====")
+
+
+asyncio.run(main())

--- a/tests/extmod/asyncio_taskgroup.py.exp
+++ b/tests/extmod/asyncio_taskgroup.py.exp
@@ -1,0 +1,49 @@
+Task A: Compute factorial(2)...
+Task B: Compute factorial(2)...
+Task C: Compute factorial(2)...
+Task A: factorial(2) = 2
+Task B: Compute factorial(3)...
+Task C: Compute factorial(3)...
+Task B: factorial(3) = 6
+Task C: Compute factorial(4)...
+Task C: factorial(4) = 24
+start 2
+end 2
+====
+start 1
+task_raise start 2
+end 1
+task_raise raise 2
+OK ValueError(2,)
+====
+task_loop_nc start 3
+task_raise start 2
+task_loop_nc loop 3
+task_raise raise 2
+task_loop_nc persists 3
+task_loop_nc loop 3
+OK ValueError(2,)
+====
+task_raise start 1
+task_raise start 2
+task_raise raise 1
+task_raise raise 2
+OK ExceptionGroup('unhandled errors in a TaskGroup', [ValueError(1,), ValueError(2,)])
+====
+start 1
+start 2
+====
+start 1
+start 2
+====
+start 1
+start 2
+end 1
+end 2
+====
+start 1
+start 2
+end 1
+end 2
+====
+====

--- a/tests/extmod/asyncio_taskgroup.py.exp
+++ b/tests/extmod/asyncio_taskgroup.py.exp
@@ -1,49 +1,82 @@
-Task A: Compute factorial(2)...
-Task B: Compute factorial(2)...
-Task C: Compute factorial(2)...
-Task A: factorial(2) = 2
-Task B: Compute factorial(3)...
-Task C: Compute factorial(3)...
-Task B: factorial(3) = 6
-Task C: Compute factorial(4)...
-Task C: factorial(4) = 24
-start 2
-end 2
-====
-start 1
-task_raise start 2
-end 1
-task_raise raise 2
-OK ValueError(2,)
-====
-task_loop_nc start 3
-task_raise start 2
-task_loop_nc loop 3
-task_raise raise 2
-task_loop_nc persists 3
-task_loop_nc loop 3
-OK ValueError(2,)
-====
-task_raise start 1
-task_raise start 2
-task_raise raise 1
-task_raise raise 2
-OK ExceptionGroup('unhandled errors in a TaskGroup', [ValueError(1,), ValueError(2,)])
-====
-start 1
-start 2
-====
-start 1
-start 2
-====
-start 1
-start 2
-end 1
-end 2
-====
-start 1
-start 2
-end 1
-end 2
-====
-====
+--- 01
+T1 42
+T2 11
+--- 02
+T1 42
+T2 11
+--- 03
+T1 0
+T2 11
+--- 04
+ZERO
+NUM 0
+T2C True
+--- 05
+ZERO
+NUM 0
+T2 True
+RUN True
+--- 06
+D False
+CANCEL
+NUM 5
+--- 07
+D False
+CANCEL
+NUM 15
+--- 08
+Not handled: divide by zero
+D True
+ZERO
+--- 09
+ZERO
+T1 0
+T2 0
+--- 10
+ZERO
+T1 0
+T2 0
+--- 11
+Not handled: divide by zero
+D True
+ZERO
+--- 12
+Not handled: divide by zero
+R True
+ZERO
+--- 13
+E1
+VAL
+--- 14
+VAL
+--- 15
+R False
+ZERO
+--- 16
+R False
+ZERO
+--- 17
+R False
+CANCEL
+NUM 10
+--- 18
+R False
+EXC
+NUM 10
+--- 19
+EXC OK
+--- 20
+KBD
+--- 21
+KBD
+--- 22
+Cancelled
+T1 0
+T2 0
+--- 23
+END 0
+--- 24
+VAL
+VAL
+VAL
+--- END


### PR DESCRIPTION
This backports 3.11's TaskGroup class to uasyncio.

I don't care much about the `except *` stuff, not in µPy context anyway, but sane error recovery is crucial and taskgroups make this job a whole lot easier, not to mention *much* less bug prone. (Writing from a lot of Trio and anyio experience here.)

Bottom line: I refuse to write async code without using taskgroups. So here you are.

~TODO: Write a couple of tests.~

Closes #8508.