### PR TITLE
extmod/uasyncio: Use list of bytes in readexactly() and readline() of StreamReader.

### DIFF
--- a/extmod/uasyncio/stream.py
+++ b/extmod/uasyncio/stream.py
@@ -35,16 +35,18 @@ class Stream:
         return self.s.readinto(buf)
 
     async def readexactly(self, n):
-        r = b""
+        r = []
         while n:
             yield core._io_queue.queue_read(self.s)
             r2 = self.s.read(n)
             if r2 is not None:
                 if not len(r2):
                     raise EOFError
-                r += r2
+                r.append(r2)
                 n -= len(r2)
-        return r
+        if len(r) == 1:
+            return r[0]
+        return b"".join(r)
 
     async def readline(self):
         l = b""


### PR DESCRIPTION
This PR changes the way `StreamReader.readexactly()` stashes data in order to read a certain number of bytes and effects on projects which use `readexactly()` in their specific protocol. The new method creates a list and append retrieved values from stream to the list and joins them at the end. I also do a benchmark in order to compare these two method. The benchmark source is accessible from [here](https://gist.github.com/AmirHmZz/329460daea0d6de0b4c1e14dad089214) and the results on `ESP-32-WROOM32` running on `micropython1.19` were:
```
MAX_PART_SIZES = 128 ( 10 calls to s.read() )
1000 calls to readexactly1 to read 1024 bytes took 230085437 CPU Ticks
1000 calls to readexactly2 to read 1024 bytes took 181515566 CPU Ticks
Calling readexactly1 to read 1024B allocated 6032B of RAM
Calling readexactly2 to read 1024B allocated 2384B of RAM

MAX_PART_SIZES = 512 ( 5 calls to s.read() )
1000 calls to readexactly1 to read 1024 bytes took 156249813 CPU Ticks
1000 calls to readexactly2 to read 1024 bytes took 124077059 CPU Ticks
Calling readexactly1 to read 1024B allocated 2192B of RAM
Calling readexactly2 to read 1024B allocated 2176B of RAM

MAX_PART_SIZES = 1024 ( 1 call to s.read() )
1000 calls to readexactly1 to read 1024 bytes took 89548003 CPU Ticks
1000 calls to readexactly2 to read 1024 bytes took 79781526 CPU Ticks
Calling readexactly1 to read 1024B allocated 1104B of RAM
Calling readexactly2 to read 1024B allocated 1088B of RAM

```
`readexactly1` is the current implementation and `readexactly2` is the PR implementation of `readexactly()` method. As you can see multiple calls to the `s.read()` can result multiple concatenating bytes process and allocating another bytes object with bigger size each time. This method also allocates less RAM which can reduce RAM fragmentation.