### PR TITLE
docs/library/bluetooth.rst: Add link to aioble.

### DIFF
--- a/docs/library/bluetooth.rst
+++ b/docs/library/bluetooth.rst
@@ -13,6 +13,9 @@ concurrently. Pairing (and bonding) is supported on some ports.
 This API is intended to match the low-level Bluetooth protocol and provide
 building-blocks for higher-level abstractions such as specific device types.
 
+.. note:: For most applications, we recommend using the higher-level
+          `aioble library <https://github.com/micropython/micropython-lib/tree/master/micropython/bluetooth/aioble>`_.
+
 .. note:: This module is still under development and its classes, functions,
           methods and constants are subject to change.
 


### PR DESCRIPTION
Aim is to encourage more people to use aioble rather than the low-level `bluetooth` module. aioble has seen extensive use in real-world projects and makes it much simpler to use BLE.