### PR TITLE
MSC exclusive access support.

### DIFF
--- a/extmod/vfs.h
+++ b/extmod/vfs.h
@@ -51,6 +51,7 @@
 #define MP_BLOCKDEV_IOCTL_BLOCK_COUNT   (4)
 #define MP_BLOCKDEV_IOCTL_BLOCK_SIZE    (5)
 #define MP_BLOCKDEV_IOCTL_BLOCK_ERASE   (6)
+#define MP_BLOCKDEV_IOCTL_STATUS        (7)
 
 // At the moment the VFS protocol just has import_stat, but could be extended to other methods
 typedef struct _mp_vfs_proto_t {

--- a/ports/rp2/main.c
+++ b/ports/rp2/main.c
@@ -82,7 +82,6 @@ int main(int argc, char **argv) {
 
     #if MICROPY_HW_ENABLE_USBDEV
     bi_decl(bi_program_feature("USB REPL"))
-    tusb_init();
     #endif
 
     #if MICROPY_PY_THREAD
@@ -145,6 +144,12 @@ int main(int argc, char **argv) {
         pyexec_frozen_module("_boot_fat.py");
         #else
         pyexec_frozen_module("_boot.py");
+        #endif
+
+        #if MICROPY_HW_ENABLE_USBDEV
+        if (!tusb_inited()) {
+            tusb_init();
+        }
         #endif
 
         // Execute user scripts.

--- a/ports/rp2/mpconfigport.h
+++ b/ports/rp2/mpconfigport.h
@@ -116,6 +116,7 @@
 #if MICROPY_HW_USB_MSC
 #define MICROPY_FATFS_USE_LABEL                 (1)
 #define MICROPY_FATFS_MULTI_PARTITION           (1)
+#define MICROPY_HW_USB_MSC_EXCLUSIVE_ACCESS     (1)
 // Set FatFS block size to flash sector size to avoid caching
 // the flash sector in memory to support smaller block sizes.
 #define MICROPY_FATFS_MAX_SS                    (FLASH_SECTOR_SIZE)

--- a/ports/rp2/rp2_flash.c
+++ b/ports/rp2/rp2_flash.c
@@ -42,6 +42,8 @@
 #define MICROPY_HW_FLASH_STORAGE_BASE (PICO_FLASH_SIZE_BYTES - MICROPY_HW_FLASH_STORAGE_BYTES)
 #endif
 
+extern bool tud_msc_ejected;
+
 static_assert(MICROPY_HW_FLASH_STORAGE_BYTES <= PICO_FLASH_SIZE_BYTES, "MICROPY_HW_FLASH_STORAGE_BYTES too big");
 static_assert(MICROPY_HW_FLASH_STORAGE_BASE + MICROPY_HW_FLASH_STORAGE_BYTES <= PICO_FLASH_SIZE_BYTES, "MICROPY_HW_FLASH_STORAGE_BYTES too big");
 
@@ -137,6 +139,12 @@ STATIC mp_obj_t rp2_flash_ioctl(mp_obj_t self_in, mp_obj_t cmd_in, mp_obj_t arg_
             // TODO check return value
             return MP_OBJ_NEW_SMALL_INT(0);
         }
+        case MP_BLOCKDEV_IOCTL_STATUS:
+            #if MICROPY_HW_USB_MSC
+            return MP_OBJ_NEW_SMALL_INT(!tud_msc_ejected);
+            #else
+            return MP_OBJ_NEW_SMALL_INT(false);
+            #endif
         default:
             return mp_const_none;
     }


### PR DESCRIPTION
### For review & feedback

This is just a new idea/proposal/RFC for MSC exclusive access (mainly for ports using Tinyusb). Exclusive access is enforced from higher-level VFS functions, and works like the following:

* `STATUS` disk `ioctl` is implemented and returns "protected" if the block device is used by MSC (mounted by PC).
* Any write access from the device is denied, by higher-level VFS functions when the disk is protected.
* When the storage is ejected, the filesystem is remounted, to update the filesystem for the device (and this is done in mp_sched/VM context to avoid critical sections).
* Any following write access to the filesystem works, because the MSC has released the block device.
* USB enable/init is moved after `_boot.py` runs to allow any `mkfs` calls from `_boot.py` to create a filesystem, however once USB/MSC is enabled, the ioctl will return protected when status is queried.
* Finally, the exclusive access is configurable with the macro  `MICROPY_HW_USB_MSC_EXCLUSIVE_ACCESS`.

Example:

```python
>>> import os
>>> os.listdir()
['test.txt', 'README.txt', 'microdot_asyncio.py', 'microdot.py', 'main.py']

>>> f = open("test.txt", "w")
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
OSError: 30

# === NOTE: Disk ejected at this point, debug output:
>>> tinyusb_helpers.c: Disk ejected, remount read/write

>>> f = open("test.txt", "w")
>>> f.write("HelloWorld!")
11
>>> f.close()
```