### PR TITLE
docs/library pyb.Pin.rst, pyb.Timer.rst: Fix errors and doc use of BK_IN

### DIFF
--- a/docs/library/pyb.Pin.rst
+++ b/docs/library/pyb.Pin.rst
@@ -62,12 +62,6 @@ When a pin has the ``Pin.PULL_UP`` or ``Pin.PULL_DOWN`` pull-mode enabled,
 that pin has an effective 40k Ohm resistor pulling it to 3V3 or GND
 respectively (except pin Y5 which has 11k Ohm resistors).
 
-Now every time a falling edge is seen on the gpio pin, the callback will be
-executed. Caution: mechanical push buttons have "bounce" and pushing or
-releasing a switch will often generate multiple edges.
-See: http://www.eng.utah.edu/~cs5780/debouncing.pdf for a detailed
-explanation, along with various techniques for debouncing.
-
 All pin objects go through the pin mapper to come up with one of the
 gpio pins.
 
@@ -107,7 +101,7 @@ Methods
         - ``Pin.IN`` - configure the pin for input;
         - ``Pin.OUT_PP`` - configure the pin for output, with push-pull control;
         - ``Pin.OUT_OD`` - configure the pin for output, with open-drain control;
-        - ``Pin.AF_PP`` - configure the pin for alternate function, pull-pull;
+        - ``Pin.AF_PP`` - configure the pin for alternate function, push-pull;
         - ``Pin.AF_OD`` - configure the pin for alternate function, open-drain;
         - ``Pin.ANALOG`` - configure the pin for analog.
 

--- a/docs/library/pyb.Pin.rst
+++ b/docs/library/pyb.Pin.rst
@@ -101,6 +101,7 @@ Methods
         - ``Pin.IN`` - configure the pin for input;
         - ``Pin.OUT_PP`` - configure the pin for output, with push-pull control;
         - ``Pin.OUT_OD`` - configure the pin for output, with open-drain control;
+        - ``Pin.ALT`` - configure the pin for alternate function, input or output;
         - ``Pin.AF_PP`` - configure the pin for alternate function, push-pull;
         - ``Pin.AF_OD`` - configure the pin for alternate function, open-drain;
         - ``Pin.ANALOG`` - configure the pin for analog.
@@ -113,8 +114,8 @@ Methods
 
      - *value* if not None will set the port output value before enabling the pin.
 
-     - *alt* can be used when mode is ``Pin.AF_PP`` or ``Pin.AF_OD`` to set the
-       index or name of one of the alternate functions associated with a pin.
+     - *alt* can be used when mode is ``Pin.ALT`` , ``Pin.AF_PP`` or ``Pin.AF_OD`` to
+       set the index or name of one of the alternate functions associated with a pin.
        This arg was previously called *af* which can still be used if needed.
 
    Returns: ``None``.
@@ -177,6 +178,10 @@ Methods
 Constants
 ---------
 
+.. data:: Pin.ALT
+
+   initialise the pin to alternate-function mode for input or output
+
 .. data:: Pin.AF_OD
 
    initialise the pin to alternate-function mode with an open-drain drive
@@ -237,11 +242,11 @@ control is desired.
 
 To configure X3 to expose TIM2_CH3, you could use::
 
-   pin = pyb.Pin(pyb.Pin.board.X3, mode=pyb.Pin.AF_PP, alt=pyb.Pin.AF1_TIM2)
+   pin = pyb.Pin(pyb.Pin.board.X3, mode=pyb.Pin.ALT, alt=pyb.Pin.AF1_TIM2)
 
 or::
 
-   pin = pyb.Pin(pyb.Pin.board.X3, mode=pyb.Pin.AF_PP, alt=1)
+   pin = pyb.Pin(pyb.Pin.board.X3, mode=pyb.Pin.ALT, alt=1)
 
 Methods
 -------

--- a/docs/library/pyb.Timer.rst
+++ b/docs/library/pyb.Timer.rst
@@ -111,7 +111,9 @@ Methods
        the PWM when the ``BRK_IN`` input is asserted. The value of this
        argument determines if break is enabled and what the polarity is, and
        can be one of ``Timer.BRK_OFF``, ``Timer.BRK_LOW`` or
-       ``Timer.BRK_HIGH``.
+       ``Timer.BRK_HIGH``. To select the ``BRK_IN`` pin construct a Pin object with
+       ``mode=Pin.ALT, alt=Pin.AFn_TIMx``. The pin's GPIO input features are
+       available in alt mode - ``pull=`` , ``value()`` and ``irq()``.
 
     You must either specify freq or both of period and prescaler.
 
@@ -203,6 +205,17 @@ Methods
        timer = pyb.Timer(2, freq=1000)
        ch2 = timer.channel(2, pyb.Timer.PWM, pin=pyb.Pin.board.X2, pulse_width=8000)
        ch3 = timer.channel(3, pyb.Timer.PWM, pin=pyb.Pin.board.X3, pulse_width=16000)
+
+   PWM Motor Example with complementary outputs, dead time, break input and break callback::
+
+       from pyb import Timer
+       from machine import Pin # machine.Pin supports alt mode and irq on the same pin.
+       pin_t8_1 = Pin(Pin.board.Y1, mode=Pin.ALT, af=Pin.AF3_TIM8)   # Pin PC6, TIM8_CH1
+       pin_t8_1n = Pin(Pin.board.X8, mode=Pin.ALT, af=Pin.AF3_TIM8)  # Pin PA7, TIM8_CH1N
+       pin_bkin = Pin(Pin.board.X7, mode=Pin.ALT, af=Pin.AF3_TIM8)   # Pin PA6, TIM8_BKIN
+       pin_bkin.irq(handler=break_callabck, trigger=Pin.IRQ_FALLING)
+       timer = pyb.Timer(8, freq=1000, deadtime=1008, brk=Timer.BRK_LOW)
+       ch1 = timer.channel(1, pyb.Timer.PWM, pulse_width_percent=30)
 
 .. method:: Timer.counter([value])
 


### PR DESCRIPTION
Fix two errors in `pyb.Pin.rst`. `pull-pull` -> `push pull`. Delete `Pin.irq` paragraph left from wipy only docs.

It was not obvious how to select a `BK_IN` pin for the `brk mode` of the `Timer`. It required setting an input pin to alt mode using `mode=Pin.AF_PP` which is an output mode. The `machine.Pin` class uses `mode=Pin.ALT` and this also works for `pyb.Pin`.

Document how to specify the `BK_IN` pin. Add a working example of how to use the new dead time and brk features for a motor PWM controller, with BK_IN killing the PWM and generating a callback.