### PR TITLE
esp32: Use check_esp_err() for get error message.

### DIFF
--- a/docs/esp32/quickref.rst
+++ b/docs/esp32/quickref.rst
@@ -806,3 +806,29 @@ the corresponding functions, or you can use the command-line client
 
 See the MicroPython forum for other community-supported alternatives
 to transfer files to an ESP32 board.
+
+Error handling
+--------------
+
+To raise eroor from MicroPython module::
+
+    import errno
+    raise(OSError(errno.ETIMEDOUT))
+
+    >>> OSError: [Errno 116] ETIMEDOUT
+
+or::
+
+    raise(ValueError('Must be positive'))
+
+    >>> ValueError: Must be positive
+
+Internally in C code esp-idf raises ecceptions in format::
+
+    >>> OSError: (-12293, 0x3005, 'ESP_ERR_WIFI_MODE')
+
+Additional information about error codes see on Espressif esp-idf
+`esp_err.h <https://github.com/espressif/esp-idf/blob/master/components/esp_common/include/esp_err.h>`_,
+`esp_wifi.h <https://github.com/espressif/esp-idf/blob/master/components/esp_wifi/include/esp_wifi.h>`_,
+`esp_netif_types.h <https://github.com/espressif/esp-idf/blob/master/components/esp_netif/include/esp_netif_types.h>`_
+etc.

--- a/ports/esp32/network_common.c
+++ b/ports/esp32/network_common.c
@@ -44,6 +44,7 @@
 // #include "lwip/dns.h"
 
 NORETURN void esp_exceptions_helper(esp_err_t e) {
+    /*
     switch (e) {
         case ESP_ERR_WIFI_NOT_INIT:
             mp_raise_msg(&mp_type_OSError, MP_ERROR_TEXT("Wifi Not Initialized"));
@@ -78,6 +79,8 @@ NORETURN void esp_exceptions_helper(esp_err_t e) {
         default:
             mp_raise_msg_varg(&mp_type_RuntimeError, MP_ERROR_TEXT("Wifi Unknown Error 0x%04x"), e);
     }
+    */
+    mp_raise_msg(&mp_type_OSError, esp_err_to_name(e));
 }
 
 STATIC mp_obj_t esp_initialize() {


### PR DESCRIPTION
I suggest making the path to understanding the error easier.

First, all esp-idf errors will have native error messages. For example:
ESP_ERR_ESP_NETIF_DNS_NOT_CONFIGURED will be output, not 
Wifi Unknown Error 0x500A

Second, ESP_ERR_XXX_XXX error codes have more info in Google search requests.