### PR TITLE
esp32: esp8266: Rename dhcp_hostname to hostname

### DIFF
--- a/docs/library/network.WLAN.rst
+++ b/docs/library/network.WLAN.rst
@@ -130,7 +130,7 @@ Methods
    hidden         Whether SSID is hidden (boolean)
    security       Security protocol supported (enumeration, see module constants)
    key            Access key (string)
-   dhcp_hostname  The DHCP hostname to use
+   hostname       The station(access point) hostname to use
    reconnects     Number of reconnect attempts to make (integer, 0=none, -1=unlimited)
    txpower        Maximum transmit power in dBm (integer or float)
    =============  ===========

--- a/docs/library/network.WLAN.rst
+++ b/docs/library/network.WLAN.rst
@@ -130,7 +130,7 @@ Methods
    hidden         Whether SSID is hidden (boolean)
    security       Security protocol supported (enumeration, see module constants)
    key            Access key (string)
-   hostname       The station(access point) hostname to use
+   hostname       The hostname for the station and access point interfaces
    reconnects     Number of reconnect attempts to make (integer, 0=none, -1=unlimited)
    txpower        Maximum transmit power in dBm (integer or float)
    =============  ===========

--- a/ports/esp32/network_wlan.c
+++ b/ports/esp32/network_wlan.c
@@ -452,7 +452,7 @@ STATIC mp_obj_t network_wlan_config(size_t n_args, const mp_obj_t *args, mp_map_
                         cfg.ap.channel = mp_obj_get_int(kwargs->table[i].value);
                         break;
                     }
-                    case MP_QSTR_dhcp_hostname: {
+                    case MP_QSTR_hostname: {
                         const char *s = mp_obj_str_get_str(kwargs->table[i].value);
                         esp_exceptions(tcpip_adapter_set_hostname(self->if_id, s));
                         break;
@@ -538,7 +538,7 @@ STATIC mp_obj_t network_wlan_config(size_t n_args, const mp_obj_t *args, mp_map_
             req_if = WIFI_IF_AP;
             val = MP_OBJ_NEW_SMALL_INT(cfg.ap.channel);
             break;
-        case MP_QSTR_dhcp_hostname: {
+        case MP_QSTR_hostname: {
             const char *s;
             esp_exceptions(tcpip_adapter_get_hostname(self->if_id, &s));
             val = mp_obj_new_str(s, strlen(s));

--- a/ports/esp32/network_wlan.c
+++ b/ports/esp32/network_wlan.c
@@ -453,7 +453,7 @@ STATIC mp_obj_t network_wlan_config(size_t n_args, const mp_obj_t *args, mp_map_
                         break;
                     }
                     case MP_QSTR_hostname:
-                    case MP_QSTR_dhcp_hostname : {
+                    case MP_QSTR_dhcp_hostname: {
                         const char *s = mp_obj_str_get_str(kwargs->table[i].value);
                         esp_exceptions(tcpip_adapter_set_hostname(self->if_id, s));
                         break;
@@ -540,7 +540,7 @@ STATIC mp_obj_t network_wlan_config(size_t n_args, const mp_obj_t *args, mp_map_
             val = MP_OBJ_NEW_SMALL_INT(cfg.ap.channel);
             break;
         case MP_QSTR_hostname:
-        case MP_QSTR_dhcp_hostname : {
+        case MP_QSTR_dhcp_hostname: {
             const char *s;
             esp_exceptions(tcpip_adapter_get_hostname(self->if_id, &s));
             val = mp_obj_new_str(s, strlen(s));

--- a/ports/esp32/network_wlan.c
+++ b/ports/esp32/network_wlan.c
@@ -452,7 +452,8 @@ STATIC mp_obj_t network_wlan_config(size_t n_args, const mp_obj_t *args, mp_map_
                         cfg.ap.channel = mp_obj_get_int(kwargs->table[i].value);
                         break;
                     }
-                    case MP_QSTR_hostname: {
+                    case MP_QSTR_hostname:
+                    case MP_QSTR_dhcp_hostname : {
                         const char *s = mp_obj_str_get_str(kwargs->table[i].value);
                         esp_exceptions(tcpip_adapter_set_hostname(self->if_id, s));
                         break;
@@ -538,7 +539,8 @@ STATIC mp_obj_t network_wlan_config(size_t n_args, const mp_obj_t *args, mp_map_
             req_if = WIFI_IF_AP;
             val = MP_OBJ_NEW_SMALL_INT(cfg.ap.channel);
             break;
-        case MP_QSTR_hostname: {
+        case MP_QSTR_hostname:
+        case MP_QSTR_dhcp_hostname : {
             const char *s;
             esp_exceptions(tcpip_adapter_get_hostname(self->if_id, &s));
             val = mp_obj_new_str(s, strlen(s));

--- a/ports/esp8266/modnetwork.c
+++ b/ports/esp8266/modnetwork.c
@@ -397,7 +397,7 @@ STATIC mp_obj_t esp_config(size_t n_args, const mp_obj_t *args, mp_map_t *kwargs
                         cfg.ap.channel = mp_obj_get_int(kwargs->table[i].value);
                         break;
                     }
-                    case MP_QSTR_dhcp_hostname: {
+                    case MP_QSTR_hostname: {
                         req_if = STATION_IF;
                         if (self->if_id == STATION_IF) {
                             const char *s = mp_obj_str_get_str(kwargs->table[i].value);
@@ -461,7 +461,7 @@ STATIC mp_obj_t esp_config(size_t n_args, const mp_obj_t *args, mp_map_t *kwargs
             req_if = SOFTAP_IF;
             val = MP_OBJ_NEW_SMALL_INT(cfg.ap.channel);
             break;
-        case MP_QSTR_dhcp_hostname: {
+        case MP_QSTR_hostname: {
             req_if = STATION_IF;
             char *s = wifi_station_get_hostname();
             if (s == NULL) {

--- a/ports/esp8266/modnetwork.c
+++ b/ports/esp8266/modnetwork.c
@@ -397,7 +397,8 @@ STATIC mp_obj_t esp_config(size_t n_args, const mp_obj_t *args, mp_map_t *kwargs
                         cfg.ap.channel = mp_obj_get_int(kwargs->table[i].value);
                         break;
                     }
-                    case MP_QSTR_hostname: {
+                    case MP_QSTR_hostname:
+                    case MP_QSTR_dhcp_hostname : {
                         req_if = STATION_IF;
                         if (self->if_id == STATION_IF) {
                             const char *s = mp_obj_str_get_str(kwargs->table[i].value);
@@ -461,7 +462,8 @@ STATIC mp_obj_t esp_config(size_t n_args, const mp_obj_t *args, mp_map_t *kwargs
             req_if = SOFTAP_IF;
             val = MP_OBJ_NEW_SMALL_INT(cfg.ap.channel);
             break;
-        case MP_QSTR_hostname: {
+        case MP_QSTR_hostname:
+        case MP_QSTR_dhcp_hostname : {
             req_if = STATION_IF;
             char *s = wifi_station_get_hostname();
             if (s == NULL) {

--- a/ports/esp8266/modnetwork.c
+++ b/ports/esp8266/modnetwork.c
@@ -398,7 +398,7 @@ STATIC mp_obj_t esp_config(size_t n_args, const mp_obj_t *args, mp_map_t *kwargs
                         break;
                     }
                     case MP_QSTR_hostname:
-                    case MP_QSTR_dhcp_hostname : {
+                    case MP_QSTR_dhcp_hostname: {
                         req_if = STATION_IF;
                         if (self->if_id == STATION_IF) {
                             const char *s = mp_obj_str_get_str(kwargs->table[i].value);
@@ -463,7 +463,7 @@ STATIC mp_obj_t esp_config(size_t n_args, const mp_obj_t *args, mp_map_t *kwargs
             val = MP_OBJ_NEW_SMALL_INT(cfg.ap.channel);
             break;
         case MP_QSTR_hostname:
-        case MP_QSTR_dhcp_hostname : {
+        case MP_QSTR_dhcp_hostname: {
             req_if = STATION_IF;
             char *s = wifi_station_get_hostname();
             if (s == NULL) {


### PR DESCRIPTION
This resolve misunderstanding from #8792
IRL dhcp_hostname is station or access point name.
