### PR TITLE
rp2: Ensure core1 doesn't hold gc lock in deinit.

### DIFF
--- a/ports/rp2/mpthreadport.c
+++ b/ports/rp2/mpthreadport.c
@@ -47,8 +47,13 @@ void mp_thread_init(void) {
 }
 
 void mp_thread_deinit(void) {
+    assert(get_core_num() == 0);
+    // Must ensure that core1 is not currently holding the GC lock, otherwise
+    // it will be terminated while holding the lock.
+    mp_thread_mutex_lock(&MP_STATE_MEM(gc_mutex), 1);
     multicore_reset_core1();
     core1_entry = NULL;
+    mp_thread_mutex_unlock(&MP_STATE_MEM(gc_mutex));
 }
 
 void mp_thread_gc_others(void) {


### PR DESCRIPTION
This addresses the second comment on https://github.com/micropython/micropython/issues/8494#issuecomment-1089898678

It's easy to reproduce:

```py
import gc, _thread

def collect_thread():
    while True:
        gc.collect()

_thread.start_new_thread(collect_thread, [])
```

after running that, hitting Ctrl-D at the repl will make the device stop responding. With this commit, the issue goes away.
