### PR TITLE
rp2: Run USB stack task exclusively from core 0.

### DIFF
--- a/ports/rp2/mpconfigport.h
+++ b/ports/rp2/mpconfigport.h
@@ -238,7 +238,7 @@ extern const struct _mod_network_nic_type_t mod_network_nic_type_wiznet5k;
 #define MICROPY_HW_USBDEV_TASK_HOOK extern void tud_task(void); tud_task();
 #define MICROPY_VM_HOOK_COUNT (10)
 #define MICROPY_VM_HOOK_INIT static uint vm_hook_divisor = MICROPY_VM_HOOK_COUNT;
-#define MICROPY_VM_HOOK_POLL if (--vm_hook_divisor == 0) { \
+#define MICROPY_VM_HOOK_POLL if (get_core_num() == 0 && --vm_hook_divisor == 0) { \
         vm_hook_divisor = MICROPY_VM_HOOK_COUNT; \
         MICROPY_HW_USBDEV_TASK_HOOK \
 }
@@ -250,7 +250,7 @@ extern const struct _mod_network_nic_type_t mod_network_nic_type_wiznet5k;
 
 #define MICROPY_EVENT_POLL_HOOK_FAST \
     do { \
-        MICROPY_HW_USBDEV_TASK_HOOK \
+        if (get_core_num() == 0) { MICROPY_HW_USBDEV_TASK_HOOK } \
         extern void mp_handle_pending(bool); \
         mp_handle_pending(true); \
     } while (0)


### PR DESCRIPTION
The goal is to avoid a situation where core 1 is shut down while holding
the tinyusb spinlock, which could happen during soft reset if
mp_thread_deinit is called while core1 is running tud_task().

This also fixes a latent race where the two cores are competing to
decrement and compare `vm_hook_divisor` with no mem fence or atomic
protection -- only core0 will now do this.

This addresses the first comment on https://github.com/micropython/micropython/issues/8494#issue-1193665837

It's easy to reproduce with exactly the minimal example from #8494. If I copy that over as main.py, then I get a lock up about 4 times out of 5 on soft reset at the repl.

Some notes for discussion:
 - There are potentially other ways that core1 could acquire the usb lock. Perhaps we should solve this more like #8835 where we require core0 to acquire the tinyusb lock during mp_thread_deinit.
 - Are there any disadvantages to only running tud_task on core0?
 - Can we solve this more generally, given that there are other locks that need to survive soft reset? (e.g. LWIP is the next on my list to investigate). Something along the lines of having core1 permanently hold a mutex that it bounces in MICROPY_EVENT_POLL_HOOK or MICROPY_VM_HOOK_POLL, and deinit acquires that lock before shutdown. Therefore it would only ever be shutdown in a "safe" location.