### PR TITLE
tinyusb: Update the tinyusb lib to the latest master.

### DIFF
--- a/ports/mimxrt/Makefile
+++ b/ports/mimxrt/Makefile
@@ -91,7 +91,7 @@ SRC_TINYUSB_C += \
 	lib/tinyusb/src/common/tusb_fifo.c \
 	lib/tinyusb/src/device/usbd.c \
 	lib/tinyusb/src/device/usbd_control.c \
-	lib/tinyusb/src/portable/nxp/transdimension/dcd_transdimension.c \
+	lib/tinyusb/src/portable/chipidea/ci_hs/dcd_ci_hs.c \
 	lib/tinyusb/src/tusb.c
 
 # All settings for Ethernet support are controller by the value of MICROPY_PY_LWIP

--- a/ports/rp2/mpconfigport.h
+++ b/ports/rp2/mpconfigport.h
@@ -235,7 +235,7 @@ extern const struct _mod_network_nic_type_t mod_network_nic_type_wiznet5k;
 #define MICROPY_PY_LWIP_EXIT    lwip_lock_release();
 
 #if MICROPY_HW_ENABLE_USBDEV
-#define MICROPY_HW_USBDEV_TASK_HOOK extern void tud_task(void); tud_task();
+#define MICROPY_HW_USBDEV_TASK_HOOK extern void tud_task_ext(uint32_t, bool); tud_task_ext(1000, false);
 #define MICROPY_VM_HOOK_COUNT (10)
 #define MICROPY_VM_HOOK_INIT static uint vm_hook_divisor = MICROPY_VM_HOOK_COUNT;
 #define MICROPY_VM_HOOK_POLL if (--vm_hook_divisor == 0) { \


### PR DESCRIPTION
That update caused changes to the rp2 and mimxrt ports.

rp2: change tud_task() into tud_task_ext()
mimxrt: use lib/tinyusb/src/portable/chipidea/ci_hs/dcd_ci_hs.c instead
        of lib/tinyusb/src/portable/nxp/transdimension/dcd_transdimension.c

Build/run tested with rp2-pico, rp2-arduino-nano-connect, boards with mimxrt1011, mimxrt1020, mimxrt1052, and mimxrt1062 (teensy). According to CI, the nrf branch has built fine.

I'm not sure if today's state of the tinyusb lib is the release which Ha Tach mentioned.