### PR TITLE
ports/unix/moduos: Include errno.h.

### DIFF
--- a/ports/unix/moduos.c
+++ b/ports/unix/moduos.c
@@ -25,6 +25,7 @@
  * THE SOFTWARE.
  */
 
+#include <errno.h>
 #include <stdlib.h>
 #include <string.h>
 


### PR DESCRIPTION
The file `ports/unix/moduos.c` uses `errno` so it need to include `errno.h`, otherwise a compiler error can occur.
