### PR TITLE
py/modmath: Rename modules to umath and ucmath.

### DIFF
--- a/py/modcmath.c
+++ b/py/modcmath.c
@@ -113,7 +113,7 @@ STATIC mp_obj_t mp_cmath_sin(mp_obj_t z_obj) {
 STATIC MP_DEFINE_CONST_FUN_OBJ_1(mp_cmath_sin_obj, mp_cmath_sin);
 
 STATIC const mp_rom_map_elem_t mp_module_cmath_globals_table[] = {
-    { MP_ROM_QSTR(MP_QSTR___name__), MP_ROM_QSTR(MP_QSTR_cmath) },
+    { MP_ROM_QSTR(MP_QSTR___name__), MP_ROM_QSTR(MP_QSTR_ucmath) },
     { MP_ROM_QSTR(MP_QSTR_e), mp_const_float_e },
     { MP_ROM_QSTR(MP_QSTR_pi), mp_const_float_pi },
     { MP_ROM_QSTR(MP_QSTR_phase), MP_ROM_PTR(&mp_cmath_phase_obj) },
@@ -149,6 +149,6 @@ const mp_obj_module_t mp_module_cmath = {
     .globals = (mp_obj_dict_t *)&mp_module_cmath_globals,
 };
 
-MP_REGISTER_MODULE(MP_QSTR_cmath, mp_module_cmath);
+MP_REGISTER_MODULE(MP_QSTR_ucmath, mp_module_cmath);
 
 #endif // MICROPY_PY_BUILTINS_FLOAT && MICROPY_PY_BUILTINS_COMPLEX && MICROPY_PY_CMATH

--- a/py/modmath.c
+++ b/py/modmath.c
@@ -368,7 +368,7 @@ STATIC MP_DEFINE_CONST_FUN_OBJ_1(mp_math_factorial_obj, mp_math_factorial);
 #endif
 
 STATIC const mp_rom_map_elem_t mp_module_math_globals_table[] = {
-    { MP_ROM_QSTR(MP_QSTR___name__), MP_ROM_QSTR(MP_QSTR_math) },
+    { MP_ROM_QSTR(MP_QSTR___name__), MP_ROM_QSTR(MP_QSTR_umath) },
     { MP_ROM_QSTR(MP_QSTR_e), mp_const_float_e },
     { MP_ROM_QSTR(MP_QSTR_pi), mp_const_float_pi },
     #if MICROPY_PY_MATH_CONSTANTS
@@ -435,6 +435,6 @@ const mp_obj_module_t mp_module_math = {
     .globals = (mp_obj_dict_t *)&mp_module_math_globals,
 };
 
-MP_REGISTER_MODULE(MP_QSTR_math, mp_module_math);
+MP_REGISTER_MODULE(MP_QSTR_umath, mp_module_math);
 
 #endif // MICROPY_PY_BUILTINS_FLOAT && MICROPY_PY_MATH

--- a/tests/float/cmath_fun.py
+++ b/tests/float/cmath_fun.py
@@ -1,7 +1,10 @@
 # test the functions imported from cmath
 
 try:
-    from cmath import *
+    try:
+        from ucmath import *
+    except ImportError:
+        from cmath import *
 except ImportError:
     print("SKIP")
     raise SystemExit

--- a/tests/float/cmath_fun_special.py
+++ b/tests/float/cmath_fun_special.py
@@ -1,7 +1,10 @@
 # test the special functions imported from cmath
 
 try:
-    from cmath import *
+    try:
+        from ucmath import *
+    except ImportError:
+        from cmath import *
 
     log10
 except (ImportError, NameError):

--- a/tests/float/math_constants.py
+++ b/tests/float/math_constants.py
@@ -1,7 +1,11 @@
 # Tests various constants of the math module.
 try:
-    import math
-    from math import exp, cos
+    try:
+        import umath as math
+        from umath import exp, cos
+    except ImportError:
+        import math
+        from math import exp, cos
 except ImportError:
     print("SKIP")
     raise SystemExit

--- a/tests/float/math_constants_extra.py
+++ b/tests/float/math_constants_extra.py
@@ -1,7 +1,12 @@
 # Tests constants of the math module available only with MICROPY_PY_MATH_CONSTANTS.
+
 try:
-    import math
-    from math import isnan
+    try:
+        import umath as math
+        from umath import isnan
+    except ImportError:
+        import math
+        from math import isnan
 
     math.tau
 except (ImportError, AttributeError):

--- a/tests/float/math_domain.py
+++ b/tests/float/math_domain.py
@@ -1,7 +1,10 @@
 # Tests domain errors in math functions
 
 try:
-    import math
+    try:
+        import umath as math
+    except ImportError:
+        import math
 except ImportError:
     print("SKIP")
     raise SystemExit

--- a/tests/float/math_domain_special.py
+++ b/tests/float/math_domain_special.py
@@ -1,7 +1,10 @@
 # Tests domain errors in special math functions
 
 try:
-    import math
+    try:
+        import umath as math
+    except ImportError:
+        import math
 
     math.erf
 except (ImportError, AttributeError):

--- a/tests/float/math_factorial_intbig.py
+++ b/tests/float/math_factorial_intbig.py
@@ -1,5 +1,8 @@
 try:
-    import math
+    try:
+        import umath as math
+    except ImportError:
+        import math
 
     math.factorial
 except (ImportError, AttributeError):

--- a/tests/float/math_fun.py
+++ b/tests/float/math_fun.py
@@ -1,7 +1,10 @@
 # Tests the functions imported from math
 
 try:
-    from math import *
+    try:
+        from umath import *
+    except ImportError:
+        from math import *
 except ImportError:
     print("SKIP")
     raise SystemExit

--- a/tests/float/math_fun_bool.py
+++ b/tests/float/math_fun_bool.py
@@ -1,7 +1,10 @@
 # Test the bool functions from math
 
 try:
-    from math import isfinite, isnan, isinf
+    try:
+        from umath import isfinite, isnan, isinf
+    except ImportError:
+        from math import isfinite, isnan, isinf
 except ImportError:
     print("SKIP")
     raise SystemExit

--- a/tests/float/math_fun_int.py
+++ b/tests/float/math_fun_int.py
@@ -1,7 +1,10 @@
 # test the math functions that return ints
 
 try:
-    import math
+    try:
+        import umath as math
+    except ImportError:
+        import math
 except ImportError:
     print("SKIP")
     raise SystemExit

--- a/tests/float/math_fun_intbig.py
+++ b/tests/float/math_fun_intbig.py
@@ -1,7 +1,10 @@
 # test the math functions that return ints, with very large results
 
 try:
-    import math
+    try:
+        import umath as math
+    except ImportError:
+        import math
 except ImportError:
     print("SKIP")
     raise SystemExit

--- a/tests/float/math_fun_special.py
+++ b/tests/float/math_fun_special.py
@@ -1,7 +1,10 @@
 # test the special functions imported from math
 
 try:
-    from math import *
+    try:
+        from umath import *
+    except ImportError:
+        from math import *
 
     erf
 except (ImportError, NameError):

--- a/tests/float/math_isclose.py
+++ b/tests/float/math_isclose.py
@@ -1,7 +1,10 @@
 # test math.isclose (appeared in Python 3.5)
 
 try:
-    from math import isclose
+    try:
+        from umath import isclose
+    except ImportError:
+        from math import isclose
 except ImportError:
     print("SKIP")
     raise SystemExit

--- a/tests/misc/rge_sm.py
+++ b/tests/misc/rge_sm.py
@@ -1,7 +1,10 @@
 # evolve the RGEs of the standard model from electroweak scale up
 # by dpgeorge
 
-import math
+try:
+    import umath as math
+except ImportError:
+    import math
 
 
 class RungeKutta(object):

--- a/tests/unix/extra_coverage.py.exp
+++ b/tests/unix/extra_coverage.py.exp
@@ -49,11 +49,11 @@ ame__
 mport 
 
 builtins        micropython     _thread         _uasyncio
-btree           cexample        cmath           cppexample
-ffi             framebuf        gc              math
-termios         uarray          ubinascii       ucollections
-ucryptolib      uctypes         uerrno          uhashlib
-uheapq          uio             ujson           umachine
+btree           cexample        cppexample      ffi
+framebuf        gc              termios         uarray
+ubinascii       ucmath          ucollections    ucryptolib
+uctypes         uerrno          uhashlib        uheapq
+uio             ujson           umachine        umath
 uos             urandom         ure             uselect
 usocket         ussl            ustruct         usys
 utime           utimeq          uwebsocket      uzlib


### PR DESCRIPTION
Most MicroPython modules with the same name as a Python standard library module have the "u" prefix. This changes `math` and `cmath` to to follow this pattern.

Issue: https://github.com/micropython/micropython/issues/7499