### PR TITLE
py/scheduler: Fix race with scheduler and pending exceptions.

### DIFF
--- a/py/runtime.c
+++ b/py/runtime.c
@@ -64,7 +64,7 @@ MP_REGISTER_MODULE(MP_QSTR___main__, mp_module___main__);
 void mp_init(void) {
     qstr_init();
 
-    // no pending exceptions to start with
+    // No pending exceptions to start with
     MP_STATE_THREAD(mp_pending_exception) = MP_OBJ_NULL;
     #if MICROPY_ENABLE_SCHEDULER
     #if MICROPY_SCHEDULER_STATIC_NODES

--- a/py/runtime.h
+++ b/py/runtime.h
@@ -76,11 +76,11 @@ void mp_deinit(void);
 void mp_sched_exception(mp_obj_t exc);
 void mp_sched_keyboard_interrupt(void);
 void mp_handle_pending(bool raise_exc);
-void mp_handle_pending_tail(mp_uint_t atomic_state);
 
 #if MICROPY_ENABLE_SCHEDULER
 void mp_sched_lock(void);
 void mp_sched_unlock(void);
+void mp_sched_run_pending(void);
 #define mp_sched_num_pending() (MP_STATE_VM(sched_len))
 bool mp_sched_schedule(mp_obj_t function, mp_obj_t arg);
 bool mp_sched_schedule_node(mp_sched_node_t *node, mp_sched_callback_t callback);

--- a/py/scheduler.c
+++ b/py/scheduler.c
@@ -32,7 +32,11 @@
 // sources such as interrupts and UNIX signal handlers).
 void MICROPY_WRAP_MP_SCHED_EXCEPTION(mp_sched_exception)(mp_obj_t exc) {
     MP_STATE_MAIN_THREAD(mp_pending_exception) = exc;
-    #if MICROPY_ENABLE_SCHEDULER
+
+    #if MICROPY_ENABLE_SCHEDULER && !MICROPY_PY_THREAD
+    // Optimisation for the case where we have scheduler but no threading.
+    // Allows the VM to do a single check to exclude both pending exception
+    // and queued tasks.
     if (MP_STATE_VM(sched_state) == MP_SCHED_IDLE) {
         MP_STATE_VM(sched_state) = MP_SCHED_PENDING;
     }
@@ -62,33 +66,19 @@ static inline bool mp_sched_empty(void) {
     return mp_sched_num_pending() == 0;
 }
 
-// A variant of this is inlined in the VM at the pending exception check
-void mp_handle_pending(bool raise_exc) {
-    if (MP_STATE_VM(sched_state) == MP_SCHED_PENDING) {
-        mp_uint_t atomic_state = MICROPY_BEGIN_ATOMIC_SECTION();
-        // Re-check state is still pending now that we're in the atomic section.
-        if (MP_STATE_VM(sched_state) == MP_SCHED_PENDING) {
-            mp_obj_t obj = MP_STATE_THREAD(mp_pending_exception);
-            if (obj != MP_OBJ_NULL) {
-                MP_STATE_THREAD(mp_pending_exception) = MP_OBJ_NULL;
-                if (!mp_sched_num_pending()) {
-                    MP_STATE_VM(sched_state) = MP_SCHED_IDLE;
-                }
-                if (raise_exc) {
-                    MICROPY_END_ATOMIC_SECTION(atomic_state);
-                    nlr_raise(obj);
-                }
-            }
-            mp_handle_pending_tail(atomic_state);
-        } else {
-            MICROPY_END_ATOMIC_SECTION(atomic_state);
-        }
+// This function should only be called by mp_handle_pending, or by the VM's
+// inlined version, after checking that the scheduler state is pending.
+void mp_sched_run_pending(void) {
+    mp_uint_t atomic_state = MICROPY_BEGIN_ATOMIC_SECTION();
+    if (MP_STATE_VM(sched_state) != MP_SCHED_PENDING) {
+        // Something else (e.g. hard IRQ) locked the scheduler while we
+        // acquired the lock.
+        MICROPY_END_ATOMIC_SECTION(atomic_state);
+        return;
     }
-}
 
-// This function should only be called by mp_handle_pending,
-// or by the VM's inlined version of that function.
-void mp_handle_pending_tail(mp_uint_t atomic_state) {
+    // Equivalent to mp_sched_lock(), but we're already in the atomic
+    // section and know that we're pending.
     MP_STATE_VM(sched_state) = MP_SCHED_LOCKED;
 
     #if MICROPY_SCHEDULER_STATIC_NODES
@@ -118,14 +108,21 @@ void mp_handle_pending_tail(mp_uint_t atomic_state) {
         MICROPY_END_ATOMIC_SECTION(atomic_state);
     }
 
+    // Restore MP_STATE_VM(sched_state) to idle (or pending if there are still
+    // tasks in the queue).
     mp_sched_unlock();
 }
 
+// Locking the scheduler prevents tasks from executing (does not prevent new
+// tasks from being added). We lock the scheduler while executing scheduled
+// tasks and also in hard interrupts or GC finalisers.
 void mp_sched_lock(void) {
     mp_uint_t atomic_state = MICROPY_BEGIN_ATOMIC_SECTION();
     if (MP_STATE_VM(sched_state) < 0) {
+        // Already locked, increment lock (recursive lock).
         --MP_STATE_VM(sched_state);
     } else {
+        // Pending or idle.
         MP_STATE_VM(sched_state) = MP_SCHED_LOCKED;
     }
     MICROPY_END_ATOMIC_SECTION(atomic_state);
@@ -135,12 +132,17 @@ void mp_sched_unlock(void) {
     mp_uint_t atomic_state = MICROPY_BEGIN_ATOMIC_SECTION();
     assert(MP_STATE_VM(sched_state) < 0);
     if (++MP_STATE_VM(sched_state) == 0) {
-        // vm became unlocked
-        if (MP_STATE_THREAD(mp_pending_exception) != MP_OBJ_NULL
-            #if MICROPY_SCHEDULER_STATIC_NODES
-            || MP_STATE_VM(sched_head) != NULL
+        // Scheduler became unlocked. Check if there are still tasks in the
+        // queue and set sched_state accordingly.
+        if (
+            #if !MICROPY_PY_THREAD
+            // See optimisation in mp_sched_exception.
+            MP_STATE_THREAD(mp_pending_exception) != MP_OBJ_NULL ||
             #endif
-            || mp_sched_num_pending()) {
+            #if MICROPY_SCHEDULER_STATIC_NODES
+            MP_STATE_VM(sched_head) != NULL ||
+            #endif
+            mp_sched_num_pending()) {
             MP_STATE_VM(sched_state) = MP_SCHED_PENDING;
         } else {
             MP_STATE_VM(sched_state) = MP_SCHED_IDLE;
@@ -196,9 +198,9 @@ bool mp_sched_schedule_node(mp_sched_node_t *node, mp_sched_callback_t callback)
 }
 #endif
 
-#else // MICROPY_ENABLE_SCHEDULER
+#endif // MICROPY_ENABLE_SCHEDULER
 
-// A variant of this is inlined in the VM at the pending exception check
+// This is also inlined in the VM at the pending exception check.
 void mp_handle_pending(bool raise_exc) {
     if (MP_STATE_THREAD(mp_pending_exception) != MP_OBJ_NULL) {
         mp_obj_t obj = MP_STATE_THREAD(mp_pending_exception);
@@ -207,6 +209,9 @@ void mp_handle_pending(bool raise_exc) {
             nlr_raise(obj);
         }
     }
+    #if MICROPY_ENABLE_SCHEDULER
+    if (MP_STATE_VM(sched_state) == MP_SCHED_PENDING) {
+        mp_sched_run_pending();
+    }
+    #endif
 }
-
-#endif // MICROPY_ENABLE_SCHEDULER


### PR DESCRIPTION
Alternative to #8838 that keeps per-thread pending exceptions. cc @dlech

The optimisation that allows a single check in the VM for either a pending exception or non-empty scheduler queue doesn't work when threading is enabled, as one thread can clear the sched_state if it has no pending exception, meaning the thread with the pending exception will never see it.
    
This removes that optimisation for threaded builds, ~and also makes it so the scheduler only runs on the main thread (matching CPython behaviour). See https://github.com/micropython/micropython/pull/8838#issuecomment-1171382689 for more background.~

This retains the single-check optimisation for the non-threading build, so performance is unaffected (actually marginally better). I will check on other ports.

The code size diff for PYBV11 is -56 bytes.

```
$ ./run-perfbench.py -s ~/sched-split-baseline ~/sched-split-v4
diff of scores (higher is better)
N=100 M=100                /home/jimmo/sched-split-baseline -> /home/jimmo/sched-split-v4         diff      diff% (error%)
bm_chaos.py                    359.51 ->     362.73 :      +3.22 =  +0.896% (+/-0.01%)
bm_fannkuch.py                  77.39 ->      77.32 :      -0.07 =  -0.090% (+/-0.00%)
bm_fft.py                     2517.61 ->    2527.57 :      +9.96 =  +0.396% (+/-0.00%)
bm_float.py                   5720.17 ->    5801.24 :     +81.07 =  +1.417% (+/-0.00%)
bm_hexiom.py                    46.21 ->      46.35 :      +0.14 =  +0.303% (+/-0.00%)
bm_nqueens.py                 4394.03 ->    4427.44 :     +33.41 =  +0.760% (+/-0.00%)
bm_pidigits.py                 634.95 ->     634.96 :      +0.01 =  +0.002% (+/-0.35%)
misc_aes.py                    406.40 ->     411.67 :      +5.27 =  +1.297% (+/-0.01%)
misc_mandel.py                3478.51 ->    3487.97 :      +9.46 =  +0.272% (+/-0.00%)
misc_pystone.py               2424.89 ->    2426.23 :      +1.34 =  +0.055% (+/-0.01%)
misc_raytrace.py               371.76 ->     377.60 :      +5.84 =  +1.571% (+/-0.00%)
```