### PR TITLE
ports/nrf/Makefile: Drop unused MPY variables.

### DIFF
--- a/ports/nrf/Makefile
+++ b/ports/nrf/Makefile
@@ -61,8 +61,6 @@ include ../../extmod/extmod.mk
 GIT_SUBMODULES = lib/nrfx lib/tinyusb
 
 MICROPY_VFS_FAT ?= 0
-MPY_CROSS = ../../mpy-cross/mpy-cross
-MPY_TOOL = ../../tools/mpy-tool.py
 
 CROSS_COMPILE ?= arm-none-eabi-
 


### PR DESCRIPTION
The variables MPY_CROSS and MPY_TOOL are no longer used in the nrf Makefile and can be removed.
