### PR TITLE
rp2/CMakeLists.txt: Check required submodules.

### DIFF
--- a/ports/rp2/CMakeLists.txt
+++ b/ports/rp2/CMakeLists.txt
@@ -59,6 +59,9 @@ include(${PICO_SDK_PATH}/pico_sdk_init.cmake)
 # Define the top-level project
 project(${MICROPY_TARGET})
 
+if(MICROPY_BLUETOOTH_NIMBLE)
+endif()
+
 pico_sdk_init()
 
 include(${MICROPY_DIR}/py/usermod.cmake)
@@ -206,6 +209,11 @@ if(MICROPY_PY_BLUETOOTH)
 endif()
 
 if(MICROPY_BLUETOOTH_NIMBLE)
+    string(CONCAT GIT_SUBMODULES "${GIT_SUBMODULES} " lib/mynewt-nimble)
+    if(NOT (${ECHO_SUBMODULES}) AND NOT EXISTS ${MICROPY_DIR}/lib/mynewt-nimble/nimble/host/include/host/ble_hs.h)
+        message(FATAL_ERROR " mynewt-nimble not initialized.\n Run 'make BOARD=${MICROPY_BOARD} submodules'")
+    endif()
+
     list(APPEND MICROPY_SOURCE_PORT mpnimbleport.c)
     target_compile_definitions(${MICROPY_TARGET} PRIVATE
         MICROPY_BLUETOOTH_NIMBLE=1
@@ -223,6 +231,9 @@ endif()
 
 if (MICROPY_PY_NETWORK_CYW43)
     string(CONCAT GIT_SUBMODULES "${GIT_SUBMODULES} " lib/cyw43-driver)
+    if((NOT (${ECHO_SUBMODULES})) AND NOT EXISTS ${MICROPY_DIR}/lib/cyw43-driver/src/cyw43.h)
+        message(FATAL_ERROR " cyw43-driver not initialized.\n Run 'make BOARD=${MICROPY_BOARD} submodules'")
+    endif()
 
     target_compile_definitions(${MICROPY_TARGET} PRIVATE
         MICROPY_PY_NETWORK_CYW43=1

--- a/ports/rp2/CMakeLists.txt
+++ b/ports/rp2/CMakeLists.txt
@@ -16,8 +16,6 @@ endif()
 
 # Use the local tinyusb instead of the one in pico-sdk
 set(PICO_TINYUSB_PATH ${MICROPY_DIR}/lib/tinyusb)
-# Use the local cyw43_driver instead of the one in pico-sdk
-set(PICO_CYW43_DRIVER_PATH ${MICROPY_DIR}/lib/cyw43-driver)
 # Use the local lwip instead of the one in pico-sdk
 set(PICO_LWIP_PATH ${MICROPY_DIR}/lib/lwip)
 
@@ -50,6 +48,11 @@ endif()
 # Enable extmod components that will be configured by extmod.cmake.
 # A board may also have enabled additional components.
 set(MICROPY_SSL_MBEDTLS ON)
+
+# Use the local cyw43_driver instead of the one in pico-sdk
+if (MICROPY_PY_NETWORK_CYW43)
+    set(PICO_CYW43_DRIVER_PATH ${MICROPY_DIR}/lib/cyw43-driver)
+endif()
 
 # Include component cmake fragments
 include(${MICROPY_DIR}/py/py.cmake)

--- a/ports/rp2/Makefile
+++ b/ports/rp2/Makefile
@@ -23,7 +23,7 @@ CMAKE_ARGS += -DCMAKE_BUILD_TYPE=Debug
 endif
 
 all:
-	[ -e $(BUILD)/CMakeCache.txt ] || cmake -S . -B $(BUILD) -DPICO_BUILD_DOCS=0 ${CMAKE_ARGS}
+	[ -e $(BUILD)/Makefile ] || cmake -S . -B $(BUILD) -DPICO_BUILD_DOCS=0 ${CMAKE_ARGS}
 	$(MAKE) $(MAKESILENT) -C $(BUILD)
 
 clean:


### PR DESCRIPTION
See https://forum.micropython.org/viewtopic.php?f=3&t=12633

This makes the cmake generation fail if the required submodules (cyw43 and nimble) are not initialised, and also makes `make BOARD=... submodules` find them.

I also found that the cmake output wasn't regenerated after failing, because CMakeCache.txt was present even after failure. So this PR also makes the cmake regeneration conditional on the generated Makefile instead.