### PR TITLE
py/obj: Add support for __float__ converter function.

### DIFF
--- a/py/obj.c
+++ b/py/obj.c
@@ -412,7 +412,20 @@ bool mp_obj_get_complex_maybe(mp_obj_t arg, mp_float_t *real, mp_float_t *imag) 
     } else if (mp_obj_is_type(arg, &mp_type_complex)) {
         mp_obj_complex_get(arg, real, imag);
     } else {
-        return false;
+        // Call __complex__() function if it exists.
+        mp_obj_t dest[2];
+        mp_load_method_maybe(arg, MP_QSTR___complex__, dest);
+        if (dest[0] == MP_OBJ_NULL) {
+            // No conversion to complex available
+            return false;
+        }
+        arg = mp_call_method_n_kw(0, 0, dest);
+        if (mp_obj_is_type(arg, &mp_type_complex)) {
+            mp_obj_complex_get(arg, real, imag);
+        } else {
+            // __complex__ returned non-complex value
+            return false;
+        }
     }
     return true;
 }

--- a/py/obj.c
+++ b/py/obj.c
@@ -355,9 +355,22 @@ bool mp_obj_get_float_maybe(mp_obj_t arg, mp_float_t *value) {
     } else if (mp_obj_is_float(arg)) {
         val = mp_obj_float_get(arg);
     } else {
-        return false;
+        // Call __float__() function if it exists.
+        mp_obj_t dest[2];
+        mp_load_method_maybe(arg, MP_QSTR___float__, dest);
+        if (dest[0] != MP_OBJ_NULL) {
+            arg = mp_call_method_n_kw(0, 0, dest);
+            if (mp_obj_is_float(arg)) {
+                val = mp_obj_float_get(arg);
+            } else {
+                // __float__ returned non-float value
+                return false;
+            }
+        } else {
+            // No conversion to float available
+            return false;
+        }
     }
-
     *value = val;
     return true;
 }

--- a/py/objcomplex.c
+++ b/py/objcomplex.c
@@ -88,6 +88,10 @@ STATIC mp_obj_t complex_make_new(const mp_obj_type_t *type_in, size_t n_args, si
                 // a complex, just return it
                 return args[0];
             } else {
+                mp_float_t real, imag;
+                if (mp_obj_get_complex_maybe(args[0], &real, &imag)) {
+                    return mp_obj_new_complex(real, imag);
+                }
                 // something else, try to cast it to a complex
                 return mp_obj_new_complex(mp_obj_get_float(args[0]), 0);
             }

--- a/tests/float/complex_dunder.py
+++ b/tests/float/complex_dunder.py
@@ -1,0 +1,40 @@
+# test __complex__ function support
+
+
+class TestComplex:
+    def __complex__(self):
+        return (1j + 10)
+
+
+class TestStrComplex:
+    def __complex__(self):
+        return "a"
+
+
+class TestNonComplex:
+    def __complex__(self):
+        return 6
+
+
+class Test:
+    pass
+
+
+print(complex(TestComplex()))
+
+try:
+    print(complex(TestStrComplex()))
+except TypeError:
+    print("TypeError")
+
+
+try:
+    print(complex(TestNonComplex()))
+except TypeError:
+    print("TypeError")
+
+
+try:
+    print(complex(Test()))
+except TypeError:
+    print("TypeError")

--- a/tests/float/float_dunder.py
+++ b/tests/float/float_dunder.py
@@ -1,0 +1,40 @@
+# test __float__ function support
+
+
+class TestFloat:
+    def __float__(self):
+        return 10.0
+
+
+class TestStrFloat:
+    def __float__(self):
+        return "a"
+
+
+class TestNonFloat:
+    def __float__(self):
+        return 6
+
+
+class Test:
+    pass
+
+
+print("%.1f" % float(TestFloat()))
+
+try:
+    print(float(TestStrFloat()))
+except TypeError:
+    print("TypeError")
+
+
+try:
+    print(float(TestNonFloat()))
+except TypeError:
+    print("TypeError")
+
+
+try:
+    print(float(Test()))
+except TypeError:
+    print("TypeError")


### PR DESCRIPTION
I've run into a number of situation where I'm using a custom class that's intended to wrap an integer or float value, eg. https://github.com/micropython/micropython-lib/pull/502

It's confusing that other dunder converter functions like `__int__` and `__str__` work but not `__float__`. This PR resolves this, though in a different way to these other functions.

Another similar question was raised here: https://forum.micropython.org/viewtopic.php?f=2&t=6467

