### PR TITLE
py/scheduler: De-inline and fix race with pending exception / scheduler (v2)

### DIFF
--- a/py/runtime.h
+++ b/py/runtime.h
@@ -76,7 +76,6 @@ void mp_deinit(void);
 void mp_sched_exception(mp_obj_t exc);
 void mp_sched_keyboard_interrupt(void);
 void mp_handle_pending(bool raise_exc);
-void mp_handle_pending_tail(mp_uint_t atomic_state);
 
 #if MICROPY_ENABLE_SCHEDULER
 void mp_sched_lock(void);

--- a/py/scheduler.c
+++ b/py/scheduler.c
@@ -32,7 +32,11 @@
 // sources such as interrupts and UNIX signal handlers).
 void MICROPY_WRAP_MP_SCHED_EXCEPTION(mp_sched_exception)(mp_obj_t exc) {
     MP_STATE_MAIN_THREAD(mp_pending_exception) = exc;
-    #if MICROPY_ENABLE_SCHEDULER
+
+    #if MICROPY_ENABLE_SCHEDULER && !MICROPY_PY_THREAD
+    // Optimisation for the case where we have scheduler but no threading.
+    // Allows the VM to do a single check to exclude both pending exception
+    // and queued tasks.
     if (MP_STATE_VM(sched_state) == MP_SCHED_IDLE) {
         MP_STATE_VM(sched_state) = MP_SCHED_PENDING;
     }
@@ -62,33 +66,17 @@ static inline bool mp_sched_empty(void) {
     return mp_sched_num_pending() == 0;
 }
 
-// A variant of this is inlined in the VM at the pending exception check
-void mp_handle_pending(bool raise_exc) {
-    if (MP_STATE_VM(sched_state) == MP_SCHED_PENDING) {
-        mp_uint_t atomic_state = MICROPY_BEGIN_ATOMIC_SECTION();
-        // Re-check state is still pending now that we're in the atomic section.
-        if (MP_STATE_VM(sched_state) == MP_SCHED_PENDING) {
-            mp_obj_t obj = MP_STATE_THREAD(mp_pending_exception);
-            if (obj != MP_OBJ_NULL) {
-                MP_STATE_THREAD(mp_pending_exception) = MP_OBJ_NULL;
-                if (!mp_sched_num_pending()) {
-                    MP_STATE_VM(sched_state) = MP_SCHED_IDLE;
-                }
-                if (raise_exc) {
-                    MICROPY_END_ATOMIC_SECTION(atomic_state);
-                    nlr_raise(obj);
-                }
-            }
-            mp_handle_pending_tail(atomic_state);
-        } else {
-            MICROPY_END_ATOMIC_SECTION(atomic_state);
-        }
+static inline void mp_sched_run_pending(void) {
+    mp_uint_t atomic_state = MICROPY_BEGIN_ATOMIC_SECTION();
+    if (MP_STATE_VM(sched_state) != MP_SCHED_PENDING) {
+        // Something else (e.g. hard IRQ) locked the scheduler while we
+        // acquired the lock.
+        MICROPY_END_ATOMIC_SECTION(atomic_state);
+        return;
     }
-}
 
-// This function should only be called by mp_handle_pending,
-// or by the VM's inlined version of that function.
-void mp_handle_pending_tail(mp_uint_t atomic_state) {
+    // Equivalent to mp_sched_lock(), but we're already in the atomic
+    // section and know that we're pending.
     MP_STATE_VM(sched_state) = MP_SCHED_LOCKED;
 
     #if MICROPY_SCHEDULER_STATIC_NODES
@@ -118,14 +106,21 @@ void mp_handle_pending_tail(mp_uint_t atomic_state) {
         MICROPY_END_ATOMIC_SECTION(atomic_state);
     }
 
+    // Restore MP_STATE_VM(sched_state) to idle (or pending if there are still
+    // tasks in the queue).
     mp_sched_unlock();
 }
 
+// Locking the scheduler prevents tasks from executing (does not prevent new
+// tasks from being added). We lock the scheduler while executing scheduled
+// tasks and also in hard interrupts or GC finalisers.
 void mp_sched_lock(void) {
     mp_uint_t atomic_state = MICROPY_BEGIN_ATOMIC_SECTION();
     if (MP_STATE_VM(sched_state) < 0) {
+        // Already locked, increment lock (recursive lock).
         --MP_STATE_VM(sched_state);
     } else {
+        // Pending or idle.
         MP_STATE_VM(sched_state) = MP_SCHED_LOCKED;
     }
     MICROPY_END_ATOMIC_SECTION(atomic_state);
@@ -135,12 +130,17 @@ void mp_sched_unlock(void) {
     mp_uint_t atomic_state = MICROPY_BEGIN_ATOMIC_SECTION();
     assert(MP_STATE_VM(sched_state) < 0);
     if (++MP_STATE_VM(sched_state) == 0) {
-        // vm became unlocked
-        if (MP_STATE_THREAD(mp_pending_exception) != MP_OBJ_NULL
-            #if MICROPY_SCHEDULER_STATIC_NODES
-            || MP_STATE_VM(sched_head) != NULL
+        // Scheduler became unlocked. Check if there are still tasks in the
+        // queue and set sched_state accordingly.
+        if (
+            #if !MICROPY_PY_THREAD
+            // See optimisation in mp_sched_exception.
+            MP_STATE_THREAD(mp_pending_exception) != MP_OBJ_NULL ||
             #endif
-            || mp_sched_num_pending()) {
+            #if MICROPY_SCHEDULER_STATIC_NODES
+            MP_STATE_VM(sched_head) != NULL ||
+            #endif
+            mp_sched_num_pending()) {
             MP_STATE_VM(sched_state) = MP_SCHED_PENDING;
         } else {
             MP_STATE_VM(sched_state) = MP_SCHED_IDLE;
@@ -196,17 +196,26 @@ bool mp_sched_schedule_node(mp_sched_node_t *node, mp_sched_callback_t callback)
 }
 #endif
 
-#else // MICROPY_ENABLE_SCHEDULER
+#endif // MICROPY_ENABLE_SCHEDULER
 
-// A variant of this is inlined in the VM at the pending exception check
+// Called periodically from the VM or from "waiting" code (e.g. sleep) to
+// process background tasks and pending exceptions (e.g. KeyboardInterrupt).
 void mp_handle_pending(bool raise_exc) {
     if (MP_STATE_THREAD(mp_pending_exception) != MP_OBJ_NULL) {
+        mp_uint_t atomic_state = MICROPY_BEGIN_ATOMIC_SECTION();
         mp_obj_t obj = MP_STATE_THREAD(mp_pending_exception);
-        MP_STATE_THREAD(mp_pending_exception) = MP_OBJ_NULL;
-        if (raise_exc) {
-            nlr_raise(obj);
+        if (obj != MP_OBJ_NULL) {
+            MP_STATE_THREAD(mp_pending_exception) = MP_OBJ_NULL;
+            if (raise_exc) {
+                MICROPY_END_ATOMIC_SECTION(atomic_state);
+                nlr_raise(obj);
+            }
         }
+        MICROPY_END_ATOMIC_SECTION(atomic_state);
     }
+    #if MICROPY_ENABLE_SCHEDULER
+    if (MP_STATE_VM(sched_state) == MP_SCHED_PENDING) {
+        mp_sched_run_pending();
+    }
+    #endif
 }
-
-#endif // MICROPY_ENABLE_SCHEDULER


### PR DESCRIPTION
This is an alternative to #8845 that applies the same fix but also de-inlines this code from the VM.

Justification for de-inlining is that it improves performance (likely by reducing overall size of mp_execute_bytecode), reduces code size (-72 bytes overall), and reduces complexity. There should be no impact on scheduled task execution, but for the case of raising a pending exception the C-stack usage is slightly higher as there's now a function call (and a full NLR jump) rather than the inlined code before. (I think this is worth it as it only applies when there's a pending exception and doesn't impact the common case).

Performance results for pybv11 (non-threading)

```
$ ./run-perfbench.py -s ~/sched-fix-baseline ~/sched-fix-v1
diff of scores (higher is better)
N=100 M=100                /home/jimmo/sched-fix-baseline -> /home/jimmo/sched-fix-v1         diff      diff% (error%)
bm_chaos.py                    359.45 ->     365.76 :      +6.31 =  +1.755% (+/-0.00%)
bm_fannkuch.py                  77.39 ->      78.22 :      +0.83 =  +1.072% (+/-0.00%)
bm_fft.py                     2517.50 ->    2556.19 :     +38.69 =  +1.537% (+/-0.00%)
bm_float.py                   5720.43 ->    5872.82 :    +152.39 =  +2.664% (+/-0.01%)
bm_hexiom.py                    46.21 ->      46.66 :      +0.45 =  +0.974% (+/-0.00%)
bm_nqueens.py                 4393.94 ->    4468.55 :     +74.61 =  +1.698% (+/-0.00%)
bm_pidigits.py                 633.47 ->     640.35 :      +6.88 =  +1.086% (+/-0.24%)
misc_aes.py                    406.41 ->     417.71 :     +11.30 =  +2.780% (+/-0.00%)
misc_mandel.py                3478.31 ->    3520.85 :     +42.54 =  +1.223% (+/-0.01%)
misc_pystone.py               2424.83 ->    2467.74 :     +42.91 =  +1.770% (+/-0.01%)
misc_raytrace.py               371.74 ->     379.20 :      +7.46 =  +2.007% (+/-0.01%)
```

For pybv11 (with threading) (note: the previous code was incorrect on non-GIL builds)

```
$ ./run-perfbench.py -s ~/sched-fix-baseline-thread ~/sched-fix-v1-thread 
diff of scores (higher is better)
N=100 M=100                /home/jimmo/sched-fix-baseline-thread -> /home/jimmo/sched-fix-v1-thread         diff      diff% (error%)
bm_chaos.py                    352.09 ->     347.38 :      -4.71 =  -1.338% (+/-0.06%)
bm_fannkuch.py                  76.03 ->      75.32 :      -0.71 =  -0.934% (+/-0.01%)
bm_fft.py                     2488.77 ->    2457.25 :     -31.52 =  -1.266% (+/-0.00%)
bm_float.py                   5731.78 ->    5640.76 :     -91.02 =  -1.588% (+/-0.00%)
bm_hexiom.py                    45.78 ->      45.42 :      -0.36 =  -0.786% (+/-0.00%)
bm_nqueens.py                 4201.08 ->    4161.82 :     -39.26 =  -0.935% (+/-0.00%)
bm_pidigits.py                 633.47 ->     630.27 :      -3.20 =  -0.505% (+/-0.26%)
misc_aes.py                    400.97 ->     405.59 :      +4.62 =  +1.152% (+/-0.01%)
misc_mandel.py                3397.27 ->    3349.65 :     -47.62 =  -1.402% (+/-0.00%)
misc_pystone.py               2305.62 ->    2308.08 :      +2.46 =  +0.107% (+/-0.01%)
misc_raytrace.py               367.85 ->     363.13 :      -4.72 =  -1.283% (+/-0.00%)
```

---

The optimisation that allows a single check in the VM for either a pending
exception or non-empty scheduler queue doesn't work when threading is
enabled, as one thread can clear the sched_state if it has no pending
exception, meaning the thread with the pending exception will never see it.

This removes that optimisation for threaded builds.

Also fixes a race in non-scheduler builds where get-and-clear of the
pending exception is not protected by the atomic section.

Also removes the bulk of the inlining of pending exceptions and scheduler
handling from the VM. This just costs code size and complexity at no
performance benefit.