### PR TITLE
esp32: Add ca_cert to ussl

### DIFF
--- a/docs/library/ssl.rst
+++ b/docs/library/ssl.rst
@@ -72,7 +72,7 @@ This applies for the esp32
    * *key* server key
    * *cert* server cert
    * *server_hostname* for SNI
-   * *cert_reqs* Or-ed flags from x509.h https://tls.mbed.org/api/x509_8h_source.html which errors NOT to tolerate. If set to zero all cert validation errors are accapted, if set to 0xffffff all errors will raise.
+   * *cert_reqs* Or-ed flags from x509.h https://tls.mbed.org/api/x509_8h_source.html which errors NOT to tolerate. If set to zero all cert validation errors are accapted, if set to 0xffffff all errors will raise, set to 0xffffff to be secure by default which deviates from cpython.
    * *ca_certs* ca certificates
    * *do_handshake* if the handshake should be performed
 

--- a/docs/library/ssl.rst
+++ b/docs/library/ssl.rst
@@ -59,3 +59,23 @@ Constants
           ssl.CERT_REQUIRED
 
     Supported values for *cert_reqs* parameter.
+
+
+MBEDTLS Based Ports
+-------------------
+This applies for the esp32
+
+.. function:: ssl.wrap_socket(sock, server_side=False, key=None, cert=None, server_hostname=None, cert_reqs=0, ca_certs=None, do_handshake=True)
+
+   * *sock* the socket object which gets wrapped
+   * *server_side* if this socket is used as a server
+   * *key* server key
+   * *cert* server cert
+   * *server_hostname* for SNI
+   * *cert_reqs* Or-ed flags from x509.h https://tls.mbed.org/api/x509_8h_source.html which errors NOT to tolerate. If set to zero all cert validation errors are accapted, if set to 0xffffff all errors will raise.
+   * *ca_certs* ca certificates
+   * *do_handshake* if the handshake should be performed
+
+.. warning::
+
+   key, cert and ca_certs are byte objects which include one DER-encoded or one or more concatenated PEM-encoded certificates.

--- a/extmod/modussl_mbedtls.c
+++ b/extmod/modussl_mbedtls.c
@@ -418,7 +418,7 @@ STATIC mp_obj_t mod_ssl_wrap_socket(size_t n_args, const mp_obj_t *pos_args, mp_
         { MP_QSTR_cert, MP_ARG_KW_ONLY | MP_ARG_OBJ, {.u_rom_obj = MP_ROM_NONE} },
         { MP_QSTR_server_side, MP_ARG_KW_ONLY | MP_ARG_BOOL, {.u_bool = false} },
         { MP_QSTR_server_hostname, MP_ARG_KW_ONLY | MP_ARG_OBJ, {.u_rom_obj = MP_ROM_NONE} },
-        { MP_QSTR_cert_reqs, MP_ARG_KW_ONLY | MP_ARG_INT, {.u_int = 0} },
+        { MP_QSTR_cert_reqs, MP_ARG_KW_ONLY | MP_ARG_INT, {.u_int = 0xffffff} },
         { MP_QSTR_ca_certs, MP_ARG_KW_ONLY | MP_ARG_OBJ, {.u_rom_obj = MP_ROM_NONE} },
         { MP_QSTR_do_handshake, MP_ARG_KW_ONLY | MP_ARG_BOOL, {.u_bool = true} },
     };

--- a/tests/esp32/esp32_test_cert.py
+++ b/tests/esp32/esp32_test_cert.py
@@ -1,0 +1,65 @@
+import network
+import socket
+import ussl
+
+CA = b"""-----BEGIN CERTIFICATE-----
+MIIDSjCCAjKgAwIBAgIQRK+wgNajJ7qJMDmGLvhAazANBgkqhkiG9w0BAQUFADA/
+MSQwIgYDVQQKExtEaWdpdGFsIFNpZ25hdHVyZSBUcnVzdCBDby4xFzAVBgNVBAMT
+DkRTVCBSb290IENBIFgzMB4XDTAwMDkzMDIxMTIxOVoXDTIxMDkzMDE0MDExNVow
+PzEkMCIGA1UEChMbRGlnaXRhbCBTaWduYXR1cmUgVHJ1c3QgQ28uMRcwFQYDVQQD
+Ew5EU1QgUm9vdCBDQSBYMzCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEB
+AN+v6ZdQCINXtMxiZfaQguzH0yxrMMpb7NnDfcdAwRgUi+DoM3ZJKuM/IUmTrE4O
+rz5Iy2Xu/NMhD2XSKtkyj4zl93ewEnu1lcCJo6m67XMuegwGMoOifooUMM0RoOEq
+OLl5CjH9UL2AZd+3UWODyOKIYepLYYHsUmu5ouJLGiifSKOeDNoJjj4XLh7dIN9b
+xiqKqy69cK3FCxolkHRyxXtqqzTWMIn/5WgTe1QLyNau7Fqckh49ZLOMxt+/yUFw
+7BZy1SbsOFU5Q9D8/RhcQPGX69Wam40dutolucbY38EVAjqr2m7xPi71XAicPNaD
+aeQQmxkqtilX4+U9m5/wAl0CAwEAAaNCMEAwDwYDVR0TAQH/BAUwAwEB/zAOBgNV
+HQ8BAf8EBAMCAQYwHQYDVR0OBBYEFMSnsaR7LHH62+FLkHX/xBVghYkQMA0GCSqG
+SIb3DQEBBQUAA4IBAQCjGiybFwBcqR7uKGY3Or+Dxz9LwwmglSBd49lZRNI+DT69
+ikugdB/OEIKcdBodfpga3csTS7MgROSR6cz8faXbauX+5v3gTt23ADq1cEmv8uXr
+AvHRAosZy5Q6XkjEGB5YGV8eAlrwDPGxrancWYaLbumR9YbK+rlmM6pZW87ipxZz
+R8srzJmwN0jP41ZL9c8PDHIyh8bwRLtTcm1D9SZImlJnt1ir/md2cXjbDaJWFBM5
+JDGFoqgCWjBH4d1QB7wCCZAA62RjYJsWvIjJEubSfZGL+T0yjWW06XyxV3bqxbYo
+Ob8VZRzI9neWagqNdwvYkQsEjgfbKbYK7p2CNTUQ
+-----END CERTIFICATE-----"""
+
+wlan = network.WLAN(network.STA_IF) # create station interface
+wlan.active(True)       # activate the interface
+wlan.connect('xyz', 'xyz') # connect to an AP
+
+while True:
+    if wlan.isconnected():
+        break
+host = 'letsencrypt.org'
+
+ai = socket.getaddrinfo(host, 443)
+ai = ai[0]
+s = socket.socket()
+s.connect(ai[-1])
+# s.setblocking(False)
+s2 = ussl.wrap_socket(s)
+cert = s2.getpeercert(True)
+print(cert)
+s2.close()
+
+s = socket.socket()
+s.connect(ai[-1])
+s.setblocking(False)
+try:
+    s2 = ussl.wrap_socket(s, server_hostname=host, cert_reqs=0xffffff)
+except OSError:
+    pass
+else:
+    raise 'This should have raised an error!'
+finally:
+    s2.close()
+
+s = socket.socket()
+s.connect(ai[-1])
+s.setblocking(False)
+try:
+    s2 = ussl.wrap_socket(s, server_hostname=host, ca_certs=CA, cert_reqs=0xffffff)
+except OSError:
+    raise Exception('This should not have raised an error!')
+finally:
+    s2.close()

--- a/tests/esp32/esp32_test_cert.py
+++ b/tests/esp32/esp32_test_cert.py
@@ -1,6 +1,6 @@
 import network
 import socket
-import ussl
+import ssl
 
 CA = b"""-----BEGIN CERTIFICATE-----
 MIIDSjCCAjKgAwIBAgIQRK+wgNajJ7qJMDmGLvhAazANBgkqhkiG9w0BAQUFADA/
@@ -25,7 +25,10 @@ Ob8VZRzI9neWagqNdwvYkQsEjgfbKbYK7p2CNTUQ
 
 wlan = network.WLAN(network.STA_IF) # create station interface
 wlan.active(True)       # activate the interface
-wlan.connect('xyz', 'xyz') # connect to an AP
+if not wlan.isconnected():
+    if wlan.status() == network.STAT_CONNECTING:
+        wlan.disconnect()
+    wlan.connect('xyz', 'xyz') # connect to an AP
 
 while True:
     if wlan.isconnected():
@@ -37,16 +40,15 @@ ai = ai[0]
 s = socket.socket()
 s.connect(ai[-1])
 # s.setblocking(False)
-s2 = ussl.wrap_socket(s)
+s2 = ssl.wrap_socket(s)
 cert = s2.getpeercert(True)
-print(cert)
 s2.close()
 
 s = socket.socket()
 s.connect(ai[-1])
 s.setblocking(False)
 try:
-    s2 = ussl.wrap_socket(s, server_hostname=host, cert_reqs=0xffffff)
+    s2 = ssl.wrap_socket(s, server_hostname=host, cert_reqs=0xffffff)
 except OSError:
     pass
 else:
@@ -58,7 +60,7 @@ s = socket.socket()
 s.connect(ai[-1])
 s.setblocking(False)
 try:
-    s2 = ussl.wrap_socket(s, server_hostname=host, ca_certs=CA, cert_reqs=0xffffff)
+    s2 = ssl.wrap_socket(s, server_hostname=host, ca_certs=CA, cert_reqs=0xffffff)
 except OSError:
     raise Exception('This should not have raised an error!')
 finally:

--- a/tests/esp32/esp32_test_cert.py
+++ b/tests/esp32/esp32_test_cert.py
@@ -1,4 +1,5 @@
 import network
+import time
 import socket
 import ssl
 
@@ -33,6 +34,7 @@ if not wlan.isconnected():
 while True:
     if wlan.isconnected():
         break
+    time.sleep(0.2)
 host = 'letsencrypt.org'
 
 ai = socket.getaddrinfo(host, 443)
@@ -47,6 +49,7 @@ s2.close()
 s = socket.socket()
 s.connect(ai[-1])
 s.setblocking(False)
+print("Starting connection which should raise, probably you get a message like: \"mbedtls_cert error: 8\"")
 try:
     s2 = ssl.wrap_socket(s, server_hostname=host, cert_reqs=0xffffff)
 except OSError:
@@ -59,6 +62,7 @@ finally:
 s = socket.socket()
 s.connect(ai[-1])
 s.setblocking(False)
+print("Starting connection which should work")
 try:
     s2 = ssl.wrap_socket(s, server_hostname=host, ca_certs=CA, cert_reqs=0xffffff)
 except OSError:


### PR DESCRIPTION
This pull is basically just the same as [5998](https://github.com/micropython/micropython/pull/5998), but since the author [pumelo](https://github.com/pumelo) did not try any rebase I picked it up and applied the changes on the latest master along with some cleanups + I changed the cert_reqs parameter to be "secure by default".

