### PR TITLE
objproperty.c: Add support for fget/fset/fdel.

### DIFF
--- a/py/objproperty.c
+++ b/py/objproperty.c
@@ -82,6 +82,23 @@ STATIC mp_obj_t property_deleter(mp_obj_t self_in, mp_obj_t deleter) {
 
 STATIC MP_DEFINE_CONST_FUN_OBJ_2(property_deleter_obj, property_deleter);
 
+STATIC void property_attr(mp_obj_t self_in, qstr attr, mp_obj_t *dest) {
+    if (dest[0] != MP_OBJ_NULL) {
+        // Read-only.
+        return;
+    }
+    mp_obj_property_t *self = MP_OBJ_TO_PTR(self_in);
+    if (attr == MP_QSTR_fget) {
+        dest[0] = self->proxy[0];
+    } else if (attr == MP_QSTR_fset) {
+        dest[0] = self->proxy[1];
+    } else if (attr == MP_QSTR_fdel) {
+        dest[0] = self->proxy[2];
+    } else {
+        dest[1] = MP_OBJ_SENTINEL;
+    }
+}
+
 STATIC const mp_rom_map_elem_t property_locals_dict_table[] = {
     { MP_ROM_QSTR(MP_QSTR_getter), MP_ROM_PTR(&property_getter_obj) },
     { MP_ROM_QSTR(MP_QSTR_setter), MP_ROM_PTR(&property_setter_obj) },
@@ -94,6 +111,7 @@ const mp_obj_type_t mp_type_property = {
     { &mp_type_type },
     .name = MP_QSTR_property,
     .make_new = property_make_new,
+    .attr = property_attr,
     .locals_dict = (mp_obj_dict_t *)&property_locals_dict,
 };
 


### PR DESCRIPTION
This patch allows a sub-class to override a property setter and call the base class's property setter. Without this, the workaround would be to access what should be a private attribute of the base class (`f._bar`), which is not a good practice. Tested with the following:

```python
paste mode; Ctrl-C to cancel, Ctrl-D to finish
=== class Foo():
===     def __init__(self):
===         self._bar = 0
=== 
===     @property
===     def bar(self):
===         return self._bar
=== 
===     @bar.setter
===     def bar(self, value):
===         self._bar = value
=== 
=== class FooBar(Foo):
===     @Foo.bar.setter
===     def bar(self, value):
===         Foo.bar.fset(self, value)
=== 
=== f = FooBar()
=== f.bar = 5
=== print(f.bar)
5
>>> 
```