### PR TITLE
netutils/dhcpserver.c: Match default DNS to AP IP.

### DIFF
--- a/shared/netutils/dhcpserver.c
+++ b/shared/netutils/dhcpserver.c
@@ -65,7 +65,7 @@
 #define PORT_DHCP_SERVER (67)
 #define PORT_DHCP_CLIENT (68)
 
-#define DEFAULT_DNS MAKE_IP4(8, 8, 8, 8)
+#define DEFAULT_DNS MAKE_IP4(192, 168, 4, 1)
 #define DEFAULT_LEASE_TIME_S (24 * 60 * 60) // in seconds
 
 #define MAC_LEN (6)


### PR DESCRIPTION
Change the default DNS to match the gateway IP of a board running in access point mode.

This fixes the rather meaningless use of "8.8.8.8" as the default DNS server address offered up to access point clients via the DHCP server. Since most (all?) devices wont be able to proxy access to the real "8.8.8.8".

It allows for a DNS responder to run on - for example - the Pico W and provide a catchall response for captive portal functionality, or just a quality-of-life response to a friendly URL for access-point based configuration and other applications.

This does not (as far as I'm aware!) change the default DNS server used in client mode, since it's explicitly set from the ifconfig with `dns_setserver`.
