### PR TITLE
py: Fix explicit allocation for empty namedtuple

### DIFF
--- a/py/objnamedtuple.c
+++ b/py/objnamedtuple.c
@@ -108,9 +108,10 @@ STATIC mp_obj_t namedtuple_make_new(const mp_obj_type_t *type_in, size_t n_args,
         #endif
     }
 
-    // Create a tuple and set the type to this namedtuple
-    mp_obj_tuple_t *tuple = MP_OBJ_TO_PTR(mp_obj_new_tuple(num_fields, NULL));
-    tuple->base.type = type_in;
+    // Create a namedtuple with explicit malloc. Calling mp_obj_new_tuple
+    // with num_fields=0 returns a read-only object.
+    mp_obj_tuple_t *tuple = mp_obj_malloc_var(mp_obj_tuple_t, mp_obj_t, num_fields, type_in);
+    tuple->len = num_fields;
 
     // Copy the positional args into the first slots of the namedtuple
     memcpy(&tuple->items[0], args, sizeof(mp_obj_t) * n_args);

--- a/tests/basics/namedtuple1.py
+++ b/tests/basics/namedtuple1.py
@@ -85,3 +85,8 @@ print(t.foo, t.bar)
 # Not implemented so far
 #T2 = namedtuple("TupComma", "foo,bar")
 #t = T2(1, 2)
+
+# Creating an empty namedtuple should not segfault
+T5 = namedtuple("TupEmpty", [])
+t = T5()
+print(t)


### PR DESCRIPTION
The empty tuple is usually a constant object, but named tuples
must be allocated to allow modification.

Also added a regression test to verify creating an empty named tuple works.

Fixes issue #7870.