### PR TITLE
docs: Update links for Arm GCC toolchain.

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,7 +156,7 @@ The STM32 version
 The "stm32" port requires an ARM compiler, arm-none-eabi-gcc, and associated
 bin-utils.  For those using Arch Linux, you need arm-none-eabi-binutils,
 arm-none-eabi-gcc and arm-none-eabi-newlib packages.  Otherwise, try here:
-https://developer.arm.com/tools-and-software/open-source-software/developer-tools/gnu-toolchain/gnu-rm
+https://developer.arm.com/downloads/-/arm-gnu-toolchain-downloads
 
 To build:
 

--- a/docs/develop/gettingstarted.rst
+++ b/docs/develop/gettingstarted.rst
@@ -103,7 +103,7 @@ For the stm32 port, the ARM cross-compiler is required:
    $ sudo apt-get install arm-none-eabi-gcc arm-none-eabi-binutils arm-none-eabi-newlib
 
 See the `ARM GCC
-toolchain <https://developer.arm.com/tools-and-software/open-source-software/developer-tools/gnu-toolchain/gnu-rm>`_
+toolchain <https://developer.arm.com/downloads/-/arm-gnu-toolchain-downloads>`_
 for the latest details.
 
 Python is also required. Python 2 is supported for now, but we recommend using Python 3.

--- a/ports/qemu-arm/README.md
+++ b/ports/qemu-arm/README.md
@@ -16,7 +16,7 @@ The purposes of this port are to enable:
       process in terms of plugging things together, pressing buttons, etc.
 
 This port will only work with the [GNU ARM Embedded Toolchain](
-https://developer.arm.com/tools-and-software/open-source-software/developer-tools/gnu-toolchain/gnu-rm)
+https://developer.arm.com/downloads/-/arm-gnu-toolchain-downloads
  and not with CodeSourcery toolchain. You will need to modify
 `LDFLAGS` if you want to use CodeSourcery's version of `arm-none-eabi`.
 The difference is that CodeSourcery needs `-T generic-m-hosted.ld` while

--- a/ports/renesas-ra/README.md
+++ b/ports/renesas-ra/README.md
@@ -36,7 +36,7 @@ All other commands below should be executed from the ports/renesas-ra/ directory
 * Arm compiler
 An `Arm compiler` is required for the build, along with the associated binary
 utilities.  The default compiler is `arm-none-eabi-gcc`, which is available for
-Arch Linux and Windows hosts via https://developer.arm.com/tools-and-software/open-source-software/developer-tools/gnu-toolchain/gnu-rm/downloads.
+Linux, Mac and Windows hosts via https://developer.arm.com/downloads/-/arm-gnu-toolchain-downloads.
 The compiler can be changed using the `CROSS_COMPILE` variable
 when invoking `make`.
 


### PR DESCRIPTION
The separate A and RM toolchains have been discontinued and replaced by a single toolchain. This updates the links to the RM toolchain to the new toolchain.
