### PR TITLE
ports/unix/main: Restore tty settings on nlr_jump_fail().

### DIFF
--- a/ports/unix/main.c
+++ b/ports/unix/main.c
@@ -737,6 +737,9 @@ MP_NOINLINE int main_(int argc, char **argv) {
 }
 
 void nlr_jump_fail(void *val) {
+    #if MICROPY_USE_READLINE == 1
+    mp_hal_stdio_mode_orig();
+    #endif
     fprintf(stderr, "FATAL: uncaught NLR %p\n", val);
     exit(1);
 }


### PR DESCRIPTION
Since `nlr_jump_fail()` exits the process, it can leave the terminal in raw mode which means characters are not echoed. You can blindly type `reset` to reset the terminal, but it is nicer if MicroPython resets before exiting.
