### PR TITLE
nrf: Check for keyboard interrupt.

### DIFF
--- a/ports/nrf/drivers/bluetooth/ble_uart.c
+++ b/ports/nrf/drivers/bluetooth/ble_uart.c
@@ -193,9 +193,9 @@ STATIC void gatts_event_handler(mp_obj_t self_in, uint16_t event_id, uint16_t at
             for (uint16_t i = 0; i < length; i++) {
                 #if MICROPY_KBD_EXCEPTION
                 if (data[i] == mp_interrupt_char) {
-                    mp_sched_keyboard_interrupt();
                     m_rx_ring_buffer.start = 0;
                     m_rx_ring_buffer.end = 0;
+                    mp_sched_keyboard_interrupt();
                 } else
                 #endif
                 {

--- a/ports/nrf/drivers/usb/usb_cdc.c
+++ b/ports/nrf/drivers/usb/usb_cdc.c
@@ -46,7 +46,7 @@
 
 extern void tusb_hal_nrf_power_event(uint32_t event);
 
-static void cdc_task(void);
+static void cdc_task(bool tx);
 
 static uint8_t rx_ringbuf_array[1024];
 static uint8_t tx_ringbuf_array[1024];
@@ -121,7 +121,7 @@ static int cdc_tx_char(void) {
     return ringbuf_get((ringbuf_t*)&tx_ringbuf);
 }
 
-static void cdc_task(void)
+static void cdc_task(bool tx)
 {
     if ( tud_cdc_connected() ) {
         // connected and there are data available
@@ -138,24 +138,30 @@ static void cdc_task(void)
             }
         }
 
-        int chars = 0;
-        while (cdc_tx_any()) {
-            if (chars < 64) {
-               tud_cdc_write_char(cdc_tx_char());
-               chars++;
-            } else {
-               chars = 0;
-               tud_cdc_write_flush();
+        if (tx) {
+            int chars = 0;
+            while (cdc_tx_any()) {
+                if (chars < 64) {
+                tud_cdc_write_char(cdc_tx_char());
+                chars++;
+                } else {
+                chars = 0;
+                tud_cdc_write_flush();
+                }
             }
-        }
 
-        tud_cdc_write_flush();
+            tud_cdc_write_flush();
+        }
     }
 }
 
 static void usb_cdc_loop(void) {
     tud_task();
-    cdc_task();
+    cdc_task(true);
+}
+
+void tud_cdc_rx_cb(uint8_t itf) {
+    cdc_task(false);
 }
 
 int usb_cdc_init(void)

--- a/ports/nrf/drivers/usb/usb_cdc.c
+++ b/ports/nrf/drivers/usb/usb_cdc.c
@@ -155,12 +155,13 @@ static void cdc_task(bool tx)
     }
 }
 
-static void usb_cdc_loop(void) {
+void usb_cdc_loop(void) {
     tud_task();
     cdc_task(true);
 }
 
 void tud_cdc_rx_cb(uint8_t itf) {
+    tud_task();
     cdc_task(false);
 }
 

--- a/ports/nrf/drivers/usb/usb_cdc.c
+++ b/ports/nrf/drivers/usb/usb_cdc.c
@@ -126,9 +126,7 @@ static void cdc_task(bool tx)
     if ( tud_cdc_connected() ) {
         // connected and there are data available
         while (tud_cdc_available()) {
-            int c;
-            uint32_t count = tud_cdc_read(&c, 1);
-            (void)count;
+            int c = tud_cdc_read_char();
             if (c == mp_interrupt_char) {
                 rx_ringbuf.iget = 0;
                 rx_ringbuf.iput = 0;
@@ -161,7 +159,6 @@ void usb_cdc_loop(void) {
 }
 
 void tud_cdc_rx_cb(uint8_t itf) {
-    tud_task();
     cdc_task(false);
 }
 

--- a/ports/nrf/modules/machine/uart.c
+++ b/ports/nrf/modules/machine/uart.c
@@ -128,6 +128,8 @@ STATIC void uart_event_handler(nrfx_uart_event_t const *p_event, void *p_context
         nrfx_uart_rx(self->p_uart, &self->buf->rx_buf[0], 1);
         #if !MICROPY_PY_BLE_NUS && MICROPY_KBD_EXCEPTION
         if (chr == mp_interrupt_char) {
+            self->buf->rx_ringbuf.iget = 0;
+            self->buf->rx_ringbuf.iput = 0;
             mp_sched_keyboard_interrupt();
         } else
         #endif

--- a/ports/nrf/mpconfigport.h
+++ b/ports/nrf/mpconfigport.h
@@ -356,6 +356,7 @@ extern const struct _mp_obj_module_t music_module;
     void *async_data[2]; \
 
 #if MICROPY_HW_USB_CDC
+#include "device/usbd.h"
 #define MICROPY_HW_USBDEV_TASK_HOOK extern void tud_task(void); tud_task();
 #else
 #define MICROPY_HW_USBDEV_TASK_HOOK ;

--- a/ports/nrf/mpconfigport.h
+++ b/ports/nrf/mpconfigport.h
@@ -355,8 +355,15 @@ extern const struct _mp_obj_module_t music_module;
     /* micro:bit root pointers */ \
     void *async_data[2]; \
 
+#if MICROPY_HW_USB_CDC
+#define MICROPY_HW_USBDEV_TASK_HOOK extern void tud_task(void); tud_task();
+#else
+#define MICROPY_HW_USBDEV_TASK_HOOK ;
+#endif
+
 #define MICROPY_EVENT_POLL_HOOK \
     do { \
+        MICROPY_HW_USBDEV_TASK_HOOK \
         extern void mp_handle_pending(bool); \
         mp_handle_pending(true); \
         __WFI(); \


### PR DESCRIPTION
By adding the required hooks into usb_cdc.c and mpconfigport.h.

Side change: clear the input buffer when the keyboard interrupt happens as well for the other places in the code.

Thanks to @hoihu for the initial fix at the rp2 port, @iabdalkader for testing, and @dpgeorge for hints.