### PR TITLE
rp2: Make networking options consistent.

### DIFF
--- a/ports/rp2/boards/ARDUINO_NANO_RP2040_CONNECT/mpconfigboard.h
+++ b/ports/rp2/boards/ARDUINO_NANO_RP2040_CONNECT/mpconfigboard.h
@@ -4,13 +4,8 @@
 #define MICROPY_HW_BOARD_NAME           "Arduino Nano RP2040 Connect"
 #define MICROPY_HW_FLASH_STORAGE_BYTES  (8 * 1024 * 1024)
 
-// Enable networking and sockets.
+// Enable networking.
 #define MICROPY_PY_NETWORK              (1)
-#define MICROPY_PY_USOCKET              (1)
-#define MICROPY_PY_WEBREPL              (1)
-#define MICROPY_PY_UWEBSOCKET           (1)
-#define MICROPY_PY_UHASHLIB_SHA1        (1)
-#define MICROPY_PY_OS_DUPTERM           (1)
 
 // Disable internal error numbers.
 #define MICROPY_USE_INTERNAL_ERRNO      (0)

--- a/ports/rp2/boards/PICO_W/mpconfigboard.h
+++ b/ports/rp2/boards/PICO_W/mpconfigboard.h
@@ -4,9 +4,8 @@
 // todo: We need something to check our binary size
 #define MICROPY_HW_FLASH_STORAGE_BYTES          (848 * 1024)
 
+// Enable networking.
 #define MICROPY_PY_NETWORK 1
-#define MICROPY_PY_USOCKET 1
-#define MICROPY_PY_USSL 1
 
 // CYW43 driver configuration.
 #define CYW43_USE_SPI (1)

--- a/ports/rp2/boards/W5100S_EVB_PICO/mpconfigboard.h
+++ b/ports/rp2/boards/W5100S_EVB_PICO/mpconfigboard.h
@@ -4,10 +4,8 @@
 #define MICROPY_HW_BOARD_NAME             "W5100S-EVB-Pico"
 #define MICROPY_HW_FLASH_STORAGE_BYTES    (1408 * 1024)
 
-// Enable networking and sockets.
+// Enable networking.
 #define MICROPY_PY_NETWORK                (1)
-#define MICROPY_PY_USOCKET                (1)
-#define MICROPY_PY_USSL                   (1)
 
 // Wiznet HW config.
 #define MICROPY_HW_WIZNET_SPI_ID          (0)

--- a/ports/rp2/mpconfigport.h
+++ b/ports/rp2/mpconfigport.h
@@ -154,6 +154,28 @@ struct _mp_bluetooth_nimble_malloc_t;
 #define MICROPY_PORT_ROOT_POINTER_BLUETOOTH_NIMBLE
 #endif
 
+// By default networking should include sockets, ssl, websockets, webrepl, dupterm.
+#if MICROPY_PY_NETWORK
+#ifndef MICROPY_PY_USOCKET
+#define MICROPY_PY_USOCKET              (1)
+#endif
+#ifndef MICROPY_PY_USSL
+#define MICROPY_PY_USSL                 (1)
+#endif
+#ifndef MICROPY_PY_UWEBSOCKET
+#define MICROPY_PY_UWEBSOCKET           (1)
+#endif
+#ifndef MICROPY_PY_UHASHLIB_SHA1
+#define MICROPY_PY_UHASHLIB_SHA1        (1)
+#endif
+#ifndef MICROPY_PY_WEBREPL
+#define MICROPY_PY_WEBREPL              (1)
+#endif
+#ifndef MICROPY_PY_OS_DUPTERM
+#define MICROPY_PY_OS_DUPTERM           (1)
+#endif
+#endif
+
 #if MICROPY_PY_NETWORK_CYW43
 extern const struct _mp_obj_type_t mp_network_cyw43_type;
 #define MICROPY_HW_NIC_CYW43 \


### PR DESCRIPTION
Enable the same set of networking features on boards with wifi/ethernet.