### PR TITLE
lib: Add micropython-lib submodule.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -53,3 +53,6 @@
 [submodule "lib/cyw43-driver"]
 	path = lib/cyw43-driver
 	url = https://github.com/georgerobotics/cyw43-driver.git
+[submodule "lib/micropython-lib"]
+	path = lib/micropython-lib
+	url = https://github.com/micropython/micropython-lib.git

--- a/ports/esp32/Makefile
+++ b/ports/esp32/Makefile
@@ -14,7 +14,7 @@ BAUD ?= 460800
 
 PYTHON ?= python3
 
-GIT_SUBMODULES = lib/berkeley-db-1.xx
+GIT_SUBMODULES += lib/berkeley-db-1.xx
 
 .PHONY: all clean deploy erase submodules FORCE
 

--- a/ports/esp32/Makefile
+++ b/ports/esp32/Makefile
@@ -14,7 +14,11 @@ BAUD ?= 460800
 
 PYTHON ?= python3
 
-GIT_SUBMODULES += lib/berkeley-db-1.xx
+# Would be good to use cmake to discover submodules (see how rp2/Makefile does
+# it), but on ESP32 the same trick doesn't work because "idf.py build" fails
+# on berkeley-db dependency before printing out the submodule list.
+# For now just force the submodule dependencies here.
+GIT_SUBMODULES += lib/berkeley-db-1.xx lib/micropython-lib
 
 .PHONY: all clean deploy erase submodules FORCE
 
@@ -52,4 +56,4 @@ erase:
 	idf.py $(IDFPY_FLAGS) -p $(PORT) -b $(BAUD) erase_flash
 
 submodules:
-	git submodule update --init $(addprefix ../../,$(GIT_SUBMODULES))
+	$(MAKE) -f ../../py/mkrules.mk GIT_SUBMODULES="$(GIT_SUBMODULES)" submodules

--- a/ports/esp8266/Makefile
+++ b/ports/esp8266/Makefile
@@ -32,7 +32,7 @@ FROZEN_MANIFEST ?= boards/manifest.py
 include $(TOP)/py/py.mk
 include $(TOP)/extmod/extmod.mk
 
-GIT_SUBMODULES = lib/axtls lib/berkeley-db-1.xx
+GIT_SUBMODULES += lib/axtls lib/berkeley-db-1.xx
 
 FWBIN = $(BUILD)/firmware-combined.bin
 PORT ?= /dev/ttyACM0

--- a/ports/mimxrt/Makefile
+++ b/ports/mimxrt/Makefile
@@ -7,7 +7,7 @@ BOARD_DIR ?= boards/$(BOARD)
 BUILD ?= build-$(BOARD)
 PORT ?= /dev/ttyACM0
 CROSS_COMPILE ?= arm-none-eabi-
-GIT_SUBMODULES = lib/tinyusb lib/nxp_driver lib/lwip lib/mbedtls
+GIT_SUBMODULES += lib/tinyusb lib/nxp_driver lib/lwip lib/mbedtls
 
 # MicroPython feature configurations
 FROZEN_MANIFEST ?= boards/manifest.py

--- a/ports/nrf/Makefile
+++ b/ports/nrf/Makefile
@@ -58,7 +58,7 @@ FROZEN_MANIFEST ?= modules/manifest.py
 include ../../py/py.mk
 include ../../extmod/extmod.mk
 
-GIT_SUBMODULES = lib/nrfx lib/tinyusb
+GIT_SUBMODULES += lib/nrfx lib/tinyusb
 
 MICROPY_VFS_FAT ?= 0
 

--- a/ports/rp2/CMakeLists.txt
+++ b/ports/rp2/CMakeLists.txt
@@ -54,6 +54,10 @@ if (MICROPY_PY_NETWORK_CYW43)
     set(PICO_CYW43_DRIVER_PATH ${MICROPY_DIR}/lib/cyw43-driver)
 endif()
 
+# Necessary submodules for all boards.
+string(CONCAT GIT_SUBMODULES "${GIT_SUBMODULES} " lib/mbedtls)
+string(CONCAT GIT_SUBMODULES "${GIT_SUBMODULES} " lib/tinyusb)
+
 # Include component cmake fragments
 include(${MICROPY_DIR}/py/py.cmake)
 include(${MICROPY_DIR}/extmod/extmod.cmake)
@@ -278,6 +282,11 @@ if (MICROPY_PY_NETWORK_NINAW10)
 endif()
 
 if (MICROPY_PY_NETWORK_WIZNET5K)
+    string(CONCAT GIT_SUBMODULES "${GIT_SUBMODULES} " lib/wiznet5k)
+    if((NOT (${ECHO_SUBMODULES})) AND NOT EXISTS ${MICROPY_DIR}/lib/wiznet5k/README.md)
+        message(FATAL_ERROR " wiznet5k not initialized.\n Run 'make BOARD=${MICROPY_BOARD} submodules'")
+    endif()
+
     target_compile_definitions(${MICROPY_TARGET} PRIVATE
         MICROPY_PY_NETWORK_WIZNET5K=1
         WIZCHIP_PREFIXED_EXPORTS=1
@@ -312,8 +321,6 @@ if (MICROPY_PY_NETWORK_WIZNET5K)
     list(APPEND MICROPY_SOURCE_EXTMOD
         ${MICROPY_DIR}/extmod/network_wiznet5k.c
     )
-
-    string(CONCAT GIT_SUBMODULES "${GIT_SUBMODULES} " lib/wiznet5k)
 endif()
 
 # Add qstr sources for extmod and usermod, in case they are modified by components above.

--- a/ports/rp2/Makefile
+++ b/ports/rp2/Makefile
@@ -29,17 +29,10 @@ all:
 clean:
 	$(RM) -rf $(BUILD)
 
-GIT_SUBMODULES += lib/mbedtls lib/tinyusb
-
+# First ensure that pico-sdk is initialised, then use cmake to pick everything
+# else (including board-specific dependencies).
 submodules:
-	# lib/pico-sdk is required for the cmake build to function (as used for boards other than PICO below)
 	$(MAKE) -f ../../py/mkrules.mk GIT_SUBMODULES="lib/pico-sdk" submodules
-ifeq ($(BOARD),PICO)
-	# Run the standard submodules target with minimum required submodules above
-	$(MAKE) -f ../../py/mkrules.mk GIT_SUBMODULES="$(GIT_SUBMODULES)" submodules
-else
-	# Run submodules task through cmake interface to pick up any board specific dependencies.
-	GIT_SUBMODULES=$$(cmake -B $(BUILD)/submodules -DECHO_SUBMODULES=1 -DGIT_SUBMODULES="$(GIT_SUBMODULES)" ${CMAKE_ARGS} -S . 2>&1 | \
-	    grep 'GIT_SUBMODULES=' | cut -d= -f2); \
+	GIT_SUBMODULES=$$(cmake -B $(BUILD)/submodules -DECHO_SUBMODULES=1 ${CMAKE_ARGS} -S . 2>&1 | \
+	                  grep '^GIT_SUBMODULES=' | cut -d= -f2); \
 	$(MAKE) -f ../../py/mkrules.mk GIT_SUBMODULES="$${GIT_SUBMODULES}" submodules
-endif

--- a/ports/samd/Makefile
+++ b/ports/samd/Makefile
@@ -24,7 +24,7 @@ FROZEN_MANIFEST ?= boards/manifest.py
 include $(TOP)/py/py.mk
 include $(TOP)/extmod/extmod.mk
 
-GIT_SUBMODULES = lib/asf4 lib/tinyusb
+GIT_SUBMODULES += lib/asf4 lib/tinyusb
 
 INC += -I.
 INC += -I$(TOP)

--- a/ports/windows/.appveyor.yml
+++ b/ports/windows/.appveyor.yml
@@ -74,6 +74,10 @@ after_test:
       throw "$env:MSYSTEM mpy_cross build exited with code $LASTEXITCODE"
     }
     cd (Join-Path $env:APPVEYOR_BUILD_FOLDER 'ports/windows')
+    C:\msys64\usr\bin\bash.exe -l -c "make -B VARIANT=$($env:PyVariant) submodules"
+    if ($LASTEXITCODE -ne 0) {
+      throw "$env:MSYSTEM build exited with code $LASTEXITCODE"
+    }
     C:\msys64\usr\bin\bash.exe -l -c "make -B -j4 V=1 MICROPY_MPYCROSS=../../mpy-cross/mpy-cross.exe VARIANT=$($env:PyVariant)"
     if ($LASTEXITCODE -ne 0) {
       throw "$env:MSYSTEM build exited with code $LASTEXITCODE"

--- a/ports/windows/msvc/genhdr.targets
+++ b/ports/windows/msvc/genhdr.targets
@@ -139,7 +139,7 @@ using(var outFile = System.IO.File.CreateText(OutputFile)) {
         <PreprocessorDefinitions>MICROPY_MODULE_FROZEN_MPY=1;MICROPY_QSTR_EXTRA_POOL=mp_qstr_frozen_const_pool;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       </ClCompile>
     </ItemGroup>
-    <Exec Command="$(PyPython) $(PyBaseDir)tools\makemanifest.py -v MPY_DIR=$(PyBaseDir) -v MPY_LIB_DIR=$(PyBaseDir)../micropython-lib -v PORT_DIR=$(PyWinDir) -o $(PyBuildDir)frozen_content.c -b $(PyBuildDir) $(FrozenManifest)"/>
+    <Exec Command="$(PyPython) $(PyBaseDir)tools\makemanifest.py -v MPY_DIR=$(PyBaseDir) -v MPY_LIB_DIR=$(PyBaseDir)/lib/micropython-lib -v PORT_DIR=$(PyWinDir) -o $(PyBuildDir)frozen_content.c -b $(PyBuildDir) $(FrozenManifest)"/>
     <WriteLinesToFile File="$(TLogLocation)frozen.read.1.tlog" Lines="$(FrozenManifest)" Overwrite="True"/>
   </Target>
 

--- a/py/mkenv.mk
+++ b/py/mkenv.mk
@@ -57,7 +57,8 @@ MAKE_MANIFEST = $(PYTHON) $(TOP)/tools/makemanifest.py
 MAKE_FROZEN = $(PYTHON) $(TOP)/tools/make-frozen.py
 MPY_TOOL = $(PYTHON) $(TOP)/tools/mpy-tool.py
 
-MPY_LIB_DIR = $(TOP)/../micropython-lib
+MPY_LIB_SUBMODULE_DIR = $(TOP)/lib/micropython-lib
+MPY_LIB_DIR = $(MPY_LIB_SUBMODULE_DIR)
 
 ifeq ($(MICROPY_MPYCROSS),)
 MICROPY_MPYCROSS = $(TOP)/mpy-cross/mpy-cross

--- a/py/mkrules.cmake
+++ b/py/mkrules.cmake
@@ -151,7 +151,12 @@ if(MICROPY_FROZEN_MANIFEST)
     # Note: target_compile_definitions already added earlier.
 
     if(NOT MICROPY_LIB_DIR)
-        set(MICROPY_LIB_DIR ${MICROPY_DIR}/../micropython-lib)
+        string(CONCAT GIT_SUBMODULES "${GIT_SUBMODULES} " lib/micropython-lib)
+        set(MICROPY_LIB_DIR ${MICROPY_DIR}/lib/micropython-lib)
+    endif()
+
+    if(NOT (${ECHO_SUBMODULES}) AND NOT EXISTS ${MICROPY_LIB_DIR}/README.md)
+        message(FATAL_ERROR " micropython-lib not initialized.\n Run 'make BOARD=${MICROPY_BOARD} submodules'")
     endif()
 
     # If MICROPY_MPYCROSS is not explicitly defined in the environment (which

--- a/py/mkrules.mk
+++ b/py/mkrules.mk
@@ -164,8 +164,15 @@ $(error Support for FROZEN_MPY_DIR was removed. Please use manifest.py instead, 
 endif
 
 ifneq ($(FROZEN_MANIFEST),)
+# If we're using the default submodule path for micropython-lib, then make
+# sure it's included in "make submodules".
+ifeq ($(MPY_LIB_DIR),$(MPY_LIB_SUBMODULE_DIR))
+GIT_SUBMODULES += lib/micropython-lib
+endif
+
 # to build frozen_content.c from a manifest
 $(BUILD)/frozen_content.c: FORCE $(BUILD)/genhdr/qstrdefs.generated.h | $(MICROPY_MPYCROSS_DEPENDENCY)
+	$(Q)test -e "$(MPY_LIB_DIR)/README.md" || (echo "Error: micropython-lib not initialized. Run 'make submodules'"; false)
 	$(Q)$(MAKE_MANIFEST) -o $@ -v "MPY_DIR=$(TOP)" -v "MPY_LIB_DIR=$(MPY_LIB_DIR)" -v "PORT_DIR=$(shell pwd)" -v "BOARD_DIR=$(BOARD_DIR)" -b "$(BUILD)" $(if $(MPY_CROSS_FLAGS),-f"$(MPY_CROSS_FLAGS)",) --mpy-tool-flags="$(MPY_TOOL_FLAGS)" $(FROZEN_MANIFEST)
 endif
 

--- a/tools/ci.sh
+++ b/tools/ci.sh
@@ -245,8 +245,10 @@ function ci_qemu_arm_setup {
 
 function ci_qemu_arm_build {
     make ${MAKEOPTS} -C mpy-cross
+    make ${MAKEOPTS} -C ports/qemu-arm submodules
     make ${MAKEOPTS} -C ports/qemu-arm CFLAGS_EXTRA=-DMP_ENDIANNESS_BIG=1
     make ${MAKEOPTS} -C ports/qemu-arm clean
+    make ${MAKEOPTS} -C ports/qemu-arm -f Makefile.test submodules
     make ${MAKEOPTS} -C ports/qemu-arm -f Makefile.test test
     make ${MAKEOPTS} -C ports/qemu-arm -f Makefile.test clean
     make ${MAKEOPTS} -C ports/qemu-arm -f Makefile.test BOARD=sabrelite test
@@ -354,6 +356,7 @@ function ci_teensy_setup {
 }
 
 function ci_teensy_build {
+    make ${MAKEOPTS} -C ports/teensy submodules
     make ${MAKEOPTS} -C ports/teensy
 }
 
@@ -577,6 +580,7 @@ function ci_unix_float_clang_run_tests {
 
 function ci_unix_settrace_build {
     make ${MAKEOPTS} -C mpy-cross
+    make ${MAKEOPTS} -C ports/unix submodules
     make ${MAKEOPTS} -C ports/unix "${CI_UNIX_OPTS_SYS_SETTRACE[@]}"
 }
 
@@ -586,6 +590,7 @@ function ci_unix_settrace_run_tests {
 
 function ci_unix_settrace_stackless_build {
     make ${MAKEOPTS} -C mpy-cross
+    make ${MAKEOPTS} -C ports/unix submodules
     make ${MAKEOPTS} -C ports/unix "${CI_UNIX_OPTS_SYS_SETTRACE_STACKLESS[@]}"
 }
 
@@ -661,6 +666,7 @@ function ci_windows_setup {
 
 function ci_windows_build {
     make ${MAKEOPTS} -C mpy-cross
+    make ${MAKEOPTS} -C ports/windows submodules
     make ${MAKEOPTS} -C ports/windows CROSS_COMPILE=i686-w64-mingw32-
 }
 


### PR DESCRIPTION
As discussed in #8860.

Most of this PR is handling how to make `make submodules` behave sensibly.
The rule I've chosen is that if you are using a frozen manifest, then micropython-lib should be included.

This was trivial in Make (although I needed to make all updates of the `GIT_SUBMODULES` variable appends rather than overwrites), but it was a total pain in CMake.

For micropython-lib honestly it would be probably fine to just always unconditionally include in in `make submodules` but I kind of wanted to sort this out so that board-specific dependencies become possible.

In the end it works for rp2, but for esp32 I had to just force it to always use micropython-lib (honestly this makes sense anyway) and we'll need to revisit this if we want to do board-specific submodules on ESP32.