### PR TITLE
uasyncio/stream.py: Handle cancellation before server start.

### DIFF
--- a/tests/net_hosted/asyncio_start_server.py
+++ b/tests/net_hosted/asyncio_start_server.py
@@ -22,6 +22,44 @@ async def test():
         print("sleep")
         await asyncio.sleep(0)
 
+    # Test that cancellation works before the server starts if
+    # the subsequent code raises.
+    print("create server3")
+    server3 = await asyncio.start_server(None, "0.0.0.0", 8000)
+    try:
+        async with server3:
+            raise OSError
+    except OSError as er:
+        print("OSError")
+
+    # Test that closing doesn't raise CancelledError.
+    print("create server4")
+    server4 = await asyncio.start_server(None, "0.0.0.0", 8000)
+    server4.close()
+    await server4.wait_closed()
+    print("server4 closed")
+
+    # Test that cancelling the task will still raise CancelledError, checking
+    # edge cases around how many times the tasks have been re-scheduled by
+    # sleep.
+    async def task(n):
+        print("create task server", n)
+        srv = await asyncio.start_server(None, "0.0.0.0", 8000)
+        await srv.wait_closed()
+        # This should be unreachable.
+        print("task finished")
+
+    for num_sleep in range(0, 5):
+        print("sleep", num_sleep)
+        t = asyncio.create_task(task(num_sleep))
+        for _ in range(num_sleep):
+            await asyncio.sleep(0)
+        t.cancel()
+        try:
+            await t
+        except asyncio.CancelledError:
+            print("CancelledError")
+
     print("done")
 
 

--- a/tests/net_hosted/asyncio_start_server.py.exp
+++ b/tests/net_hosted/asyncio_start_server.py.exp
@@ -2,4 +2,22 @@ create server1
 create server2
 OSError
 sleep
+create server3
+OSError
+create server4
+server4 closed
+sleep 0
+CancelledError
+sleep 1
+create task server 1
+CancelledError
+sleep 2
+create task server 2
+CancelledError
+sleep 3
+create task server 3
+CancelledError
+sleep 4
+create task server 4
+CancelledError
 done


### PR DESCRIPTION
Originally reported here: https://forum.micropython.org/viewtopic.php?f=20&t=12678&p=68845#p68791

The following code:

```py
  server = await asyncio.start_server(...)
  async with server:
    ... code that raises ...
```

would lose the original exception because the server's task would not have had a chance to be scheduled yet, and so awaiting the task in wait_closed would raise the cancellation instead of the original exception.

In this case the code that raised was calling `server.serve_forever()` which we don't support.