### PR TITLE
rp2/CMakeLists.txt: Use armv6m mpy-cross arch for rp2.

### DIFF
--- a/ports/rp2/CMakeLists.txt
+++ b/ports/rp2/CMakeLists.txt
@@ -323,7 +323,7 @@ list(APPEND MICROPY_SOURCE_QSTR
 )
 
 # Define mpy-cross flags
-set(MICROPY_CROSS_FLAGS -march=armv7m)
+set(MICROPY_CROSS_FLAGS -march=armv6m)
 
 # Set the frozen manifest file
 if (MICROPY_USER_FROZEN_MANIFEST)


### PR DESCRIPTION
0e28a1f0e made it possible to set -march=armv6m. We need to use it when freezing for rp2.

See https://github.com/micropython/micropython/issues/7616 for background.