### PR TITLE
esp32: Change the sendbreak duration to >= 15 bit times.

### DIFF
--- a/ports/esp32/machine_uart.c
+++ b/ports/esp32/machine_uart.c
@@ -401,8 +401,10 @@ STATIC mp_obj_t machine_uart_sendbreak(mp_obj_t self_in) {
     // Save settings
     uart_word_length_t word_length;
     uart_parity_t parity;
+    uint32_t baudrate;
     uart_get_word_length(self->uart_num, &word_length);
     uart_get_parity(self->uart_num, &parity);
+    uart_get_baudrate(self->uart_num, &baudrate);
 
     // Synthesise the break condition by either a longer word or using even parity
     uart_wait_tx_done(self->uart_num, pdMS_TO_TICKS(1000));
@@ -414,6 +416,7 @@ STATIC mp_obj_t machine_uart_sendbreak(mp_obj_t self_in) {
         // Cannot synthesise break
         mp_raise_OSError(MP_EPERM);
     }
+    uart_set_baudrate(self->uart_num, baudrate * 2 / 3);
     char buf[1] = {0};
     uart_write_bytes(self->uart_num, buf, 1);
     uart_wait_tx_done(self->uart_num, pdMS_TO_TICKS(1000));
@@ -421,6 +424,7 @@ STATIC mp_obj_t machine_uart_sendbreak(mp_obj_t self_in) {
     // Restore original settings
     uart_set_word_length(self->uart_num, word_length);
     uart_set_parity(self->uart_num, parity);
+    uart_set_baudrate(self->uart_num, baudrate);
 
     return mp_const_none;
 }

--- a/ports/esp32/machine_uart.c
+++ b/ports/esp32/machine_uart.c
@@ -399,31 +399,18 @@ STATIC mp_obj_t machine_uart_sendbreak(mp_obj_t self_in) {
     machine_uart_obj_t *self = MP_OBJ_TO_PTR(self_in);
 
     // Save settings
-    uart_word_length_t word_length;
-    uart_parity_t parity;
     uint32_t baudrate;
-    uart_get_word_length(self->uart_num, &word_length);
-    uart_get_parity(self->uart_num, &parity);
     uart_get_baudrate(self->uart_num, &baudrate);
 
-    // Synthesise the break condition by either a longer word or using even parity
+    // Synthesise the break condition by reducing the baud rate
+    // Cater for the worst case of 5 data bits, no parity.
     uart_wait_tx_done(self->uart_num, pdMS_TO_TICKS(1000));
-    if (word_length != UART_DATA_8_BITS) {
-        uart_set_word_length(self->uart_num, UART_DATA_8_BITS);
-    } else if (parity == UART_PARITY_DISABLE) {
-        uart_set_parity(self->uart_num, UART_PARITY_EVEN);
-    } else {
-        // Cannot synthesise break
-        mp_raise_OSError(MP_EPERM);
-    }
-    uart_set_baudrate(self->uart_num, baudrate * 2 / 3);
+    uart_set_baudrate(self->uart_num, baudrate * 6 / 15);
     char buf[1] = {0};
     uart_write_bytes(self->uart_num, buf, 1);
     uart_wait_tx_done(self->uart_num, pdMS_TO_TICKS(1000));
 
-    // Restore original settings
-    uart_set_word_length(self->uart_num, word_length);
-    uart_set_parity(self->uart_num, parity);
+    // Restore original setting
     uart_set_baudrate(self->uart_num, baudrate);
 
     return mp_const_none;


### PR DESCRIPTION
It used to be 10 bit times, which is too short. The break state must be longer than a regular character time, at least 13 bit times. May be longer. This is implemented by changing the baud rate for sendbreak() to 2/3 of what has been configured.

Tested with a GENERIC_SPIRAM, GENERIC_C3 and UM_TINYS2 board.