### PR TITLE
ports/rp2: Set CYW43_EVENT_POLL_HOOK.

### DIFF
--- a/ports/rp2/cyw43_configport.h
+++ b/ports/rp2/cyw43_configport.h
@@ -95,4 +95,6 @@ static inline void cyw43_delay_ms(uint32_t ms) {
     }
 }
 
+#define CYW43_EVENT_POLL_HOOK MICROPY_EVENT_POLL_HOOK
+
 #endif // MICROPY_INCLUDED_RP2_CYW43_CONFIGPORT_H


### PR DESCRIPTION
This should allow USB to work while we're loading firmware

Requires: https://github.com/georgerobotics/cyw43-driver/pull/12
Fixes: #8904