### PR TITLE
ports/nrf/mpconfigport.h: Remove obsolete modules declarations.

### DIFF
--- a/ports/nrf/mpconfigport.h
+++ b/ports/nrf/mpconfigport.h
@@ -295,14 +295,6 @@ typedef int mp_int_t; // must be pointer size
 typedef unsigned int mp_uint_t; // must be pointer size
 typedef long mp_off_t;
 
-// extra built in modules to add to the list of known ones
-extern const struct _mp_obj_module_t board_module;
-extern const struct _mp_obj_module_t nrf_module;
-extern const struct _mp_obj_module_t mp_module_utime;
-extern const struct _mp_obj_module_t mp_module_uos;
-extern const struct _mp_obj_module_t mp_module_ubluepy;
-extern const struct _mp_obj_module_t music_module;
-
 #if BOARD_SPECIFIC_MODULES
 #include "boardmodules.h"
 #endif // BOARD_SPECIFIC_MODULES
@@ -314,7 +306,6 @@ extern const struct _mp_obj_module_t music_module;
 
 // extra constants
 #define MICROPY_PORT_CONSTANTS \
-    { MP_ROM_QSTR(MP_QSTR_board), MP_ROM_PTR(&board_module) }, \
     { MP_ROM_QSTR(MP_QSTR_machine), MP_ROM_PTR(&mp_module_machine) }, \
 
 #define MP_STATE_PORT MP_STATE_VM


### PR DESCRIPTION
* extern modules declarations are no longer used/needed after the introduction of MP_REGISTER_MODULE macro.
* With weak links enabled, umachine can be imported as machine, and MICROPY_PORT_CONSTANTS is also not required.