### PR TITLE
stm32: Workaround LTO linker order bug in binutils <2.35

### DIFF
--- a/ports/stm32/Makefile
+++ b/ports/stm32/Makefile
@@ -534,6 +534,9 @@ endif
 
 endif
 
+# SRC_O should be placed first to work around this LTO bug with binutils <2.35:
+# https://gcc.gnu.org/bugzilla/show_bug.cgi?id=83967
+OBJ += $(addprefix $(BUILD)/, $(SRC_O))
 OBJ += $(PY_O)
 OBJ += $(addprefix $(BUILD)/, $(LIB_SRC_C:.c=.o))
 OBJ += $(LIBM_O)
@@ -544,7 +547,6 @@ OBJ += $(addprefix $(BUILD)/, $(HAL_SRC_C:.c=.o))
 OBJ += $(addprefix $(BUILD)/, $(USBDEV_SRC_C:.c=.o))
 OBJ += $(addprefix $(BUILD)/, $(SRC_C:.c=.o))
 OBJ += $(addprefix $(BUILD)/, $(SRC_CXX:.cpp=.o))
-OBJ += $(addprefix $(BUILD)/, $(SRC_O))
 OBJ += $(addprefix $(BUILD)/, $(SRC_MOD:.c=.o))
 OBJ += $(BUILD)/pins_$(BOARD).o
 


### PR DESCRIPTION
Due to a bug in binutils <2.35, assembly files with weak symbols need to be linked first to avoid issues with the weak symbols being incorrectly linked instead of strong ones.

See https://gcc.gnu.org/bugzilla/show_bug.cgi?id=83967 and https://bugs.launchpad.net/gcc-arm-embedded/+bug/1747966

This is the workaround suggested in comment 10 of the gcc-arm-embedded bug.

Closes #8908

Introduced from changes in #8733