### PR TITLE
unix: switch default build to use mbedtls (not axtls)

### DIFF
--- a/examples/embedding/Makefile.upylib
+++ b/examples/embedding/Makefile.upylib
@@ -172,7 +172,7 @@ else
 CROSS_COMPILE_HOST =
 endif
 
-deplibs: libffi axtls
+deplibs: libffi
 
 # install-exec-recursive & install-data-am targets are used to avoid building
 # docs and depending on makeinfo
@@ -182,13 +182,3 @@ libffi:
 	mkdir -p $(MPTOP)/lib/libffi/build_dir; cd $(MPTOP)/lib/libffi/build_dir; \
 	../configure $(CROSS_COMPILE_HOST) --prefix=$$PWD/out CC="$(CC)" CXX="$(CXX)" LD="$(LD)"; \
 	make install-exec-recursive; make -C include install-data-am
-
-axtls: $(MPTOP)/lib/axtls/README
-	cd $(MPTOP)/lib/axtls; cp config/upyconfig config/.config
-	cd $(MPTOP)/lib/axtls; make oldconfig -B
-	cd $(MPTOP)/lib/axtls; make clean
-	cd $(MPTOP)/lib/axtls; make all CC="$(CC)" LD="$(LD)"
-
-$(MPTOP)/lib/axtls/README:
-	@echo "You cloned without --recursive, fetching submodules for you."
-	(cd $(MPTOP); git submodule update --init --recursive)

--- a/extmod/extmod.cmake
+++ b/extmod/extmod.cmake
@@ -114,6 +114,7 @@ if(MICROPY_SSL_MBEDTLS)
     )
 
     target_sources(micropy_lib_mbedtls INTERFACE
+        ${MICROPY_DIR}/lib/mbedtls_errors/mp_mbedtls_errors.c
         ${MICROPY_LIB_MBEDTLS_DIR}/library/aes.c
         ${MICROPY_LIB_MBEDTLS_DIR}/library/aesni.c
         ${MICROPY_LIB_MBEDTLS_DIR}/library/arc4.c
@@ -141,7 +142,6 @@ if(MICROPY_SSL_MBEDTLS)
         ${MICROPY_LIB_MBEDTLS_DIR}/library/ecp_curves.c
         ${MICROPY_LIB_MBEDTLS_DIR}/library/entropy.c
         ${MICROPY_LIB_MBEDTLS_DIR}/library/entropy_poll.c
-        ${MICROPY_LIB_MBEDTLS_DIR}/library/error.c
         ${MICROPY_LIB_MBEDTLS_DIR}/library/gcm.c
         ${MICROPY_LIB_MBEDTLS_DIR}/library/havege.c
         ${MICROPY_LIB_MBEDTLS_DIR}/library/hmac_drbg.c

--- a/extmod/extmod.mk
+++ b/extmod/extmod.mk
@@ -119,6 +119,7 @@ SRC_MOD += $(addprefix $(AXTLS_DIR)/,\
 else ifeq ($(MICROPY_SSL_MBEDTLS),1)
 MBEDTLS_DIR = lib/mbedtls
 CFLAGS_MOD += -DMICROPY_SSL_MBEDTLS=1 -I$(TOP)/$(MBEDTLS_DIR)/include
+SRC_MOD += lib/mbedtls_errors/mp_mbedtls_errors.c
 SRC_MOD += $(addprefix $(MBEDTLS_DIR)/library/,\
 	aes.c \
 	aesni.c \
@@ -147,7 +148,6 @@ SRC_MOD += $(addprefix $(MBEDTLS_DIR)/library/,\
 	ecp_curves.c \
 	entropy.c \
 	entropy_poll.c \
-	error.c \
 	gcm.c \
 	havege.c \
 	hmac_drbg.c \

--- a/ports/mimxrt/Makefile
+++ b/ports/mimxrt/Makefile
@@ -96,15 +96,13 @@ SRC_TINYUSB_C += \
 
 # All settings for Ethernet support are controller by the value of MICROPY_PY_LWIP
 ifeq ($(MICROPY_PY_LWIP),1)
-SRC_MOD := $(filter-out %/mbedtls/library/error.c, $(SRC_MOD))
 SRC_ETH_C += \
 	$(MCU_DIR)/drivers/fsl_enet.c \
 	hal/phy/device/phydp83825/fsl_phydp83825.c \
 	hal/phy/device/phydp83848/fsl_phydp83848.c \
 	hal/phy/device/phyksz8081/fsl_phyksz8081.c \
 	hal/phy/device/phylan8720/fsl_phylan8720.c \
-	hal/phy/mdio/enet/fsl_enet_mdio.c \
-	lib/mbedtls_errors/mp_mbedtls_errors.c
+	hal/phy/mdio/enet/fsl_enet_mdio.c
 endif
 
 # NXP SDK sources

--- a/ports/rp2/CMakeLists.txt
+++ b/ports/rp2/CMakeLists.txt
@@ -77,7 +77,6 @@ set(MICROPY_SOURCE_LIB
     ${MICROPY_DIR}/lib/littlefs/lfs1_util.c
     ${MICROPY_DIR}/lib/littlefs/lfs2.c
     ${MICROPY_DIR}/lib/littlefs/lfs2_util.c
-    ${MICROPY_DIR}/lib/mbedtls_errors/mp_mbedtls_errors.c
     ${MICROPY_DIR}/lib/oofatfs/ff.c
     ${MICROPY_DIR}/lib/oofatfs/ffunicode.c
     ${MICROPY_DIR}/shared/netutils/dhcpserver.c
@@ -342,12 +341,6 @@ target_sources(${MICROPY_TARGET} PRIVATE
 )
 
 target_link_libraries(${MICROPY_TARGET} micropy_lib_mbedtls)
-
-# Filter out library/error.c as we're using mp_mbedtls_errors.c instead.
-set_source_files_properties(${MICROPY_LIB_MBEDTLS_DIR}/library/error.c
-    TARGET_DIRECTORY micropy_lib_mbedtls
-    PROPERTIES HEADER_FILE_ONLY ON
-)
 
 target_link_libraries(${MICROPY_TARGET} usermod)
 

--- a/ports/stm32/Makefile
+++ b/ports/stm32/Makefile
@@ -499,9 +499,6 @@ endif
 ifeq ($(MICROPY_SSL_MBEDTLS),1)
 CFLAGS_MOD += -DMBEDTLS_CONFIG_FILE='"mbedtls/mbedtls_config.h"'
 SRC_MOD += mbedtls/mbedtls_port.c
-# replace mbedtls' error.c by ours
-SRC_MOD := $(filter-out %/mbedtls/library/error.c, $(SRC_MOD))
-LIB_SRC_C += lib/mbedtls_errors/mp_mbedtls_errors.c
 endif
 
 ifeq ($(MICROPY_PY_BLUETOOTH),1)

--- a/ports/unix/Makefile
+++ b/ports/unix/Makefile
@@ -140,9 +140,6 @@ endif
 ifeq ($(MICROPY_SSL_MBEDTLS),1)
 GIT_SUBMODULES += lib/mbedtls
 CFLAGS_MOD += -DMBEDTLS_CONFIG_FILE='"mbedtls/mbedtls_config.h"'
-# replace mbedtls' error.c by ours
-SRC_MOD := $(filter-out %/mbedtls/library/error.c, $(SRC_MOD))
-LIB_SRC_C += lib/mbedtls_errors/mp_mbedtls_errors.c
 endif
 endif
 

--- a/ports/unix/Makefile
+++ b/ports/unix/Makefile
@@ -30,7 +30,7 @@ UNAME_S := $(shell uname -s)
 include $(TOP)/py/py.mk
 include $(TOP)/extmod/extmod.mk
 
-GIT_SUBMODULES += lib/axtls lib/berkeley-db-1.xx lib/libffi
+GIT_SUBMODULES += lib/berkeley-db-1.xx lib/libffi
 
 INC +=  -I.
 INC +=  -I$(TOP)
@@ -134,6 +134,9 @@ LDFLAGS_MOD += $(LIBPTHREAD)
 endif
 
 ifeq ($(MICROPY_PY_USSL),1)
+ifeq ($(MICROPY_SSL_AXTLS),1)
+GIT_SUBMODULES += lib/axtls
+endif
 ifeq ($(MICROPY_SSL_MBEDTLS),1)
 GIT_SUBMODULES += lib/mbedtls
 CFLAGS_MOD += -DMBEDTLS_CONFIG_FILE='"mbedtls/mbedtls_config.h"'
@@ -325,7 +328,7 @@ else
 CROSS_COMPILE_HOST =
 endif
 
-deplibs: libffi axtls
+deplibs: libffi
 
 libffi: $(BUILD)/lib/libffi/include/ffi.h
 
@@ -338,12 +341,6 @@ $(BUILD)/lib/libffi/include/ffi.h: $(TOP)/lib/libffi/configure
 	mkdir -p $(BUILD)/lib/libffi; cd $(BUILD)/lib/libffi; \
 	$(abspath $(TOP))/lib/libffi/configure $(CROSS_COMPILE_HOST) --prefix=$$PWD/out --disable-structs CC="$(CC)" CXX="$(CXX)" LD="$(LD)" CFLAGS="-Os -fomit-frame-pointer -fstrict-aliasing -ffast-math -fno-exceptions"; \
 	$(MAKE) install-exec-recursive; $(MAKE) -C include install-data-am
-
-axtls: $(TOP)/lib/axtls/README
-
-$(TOP)/lib/axtls/README:
-	@echo "You cloned without --recursive, fetching submodules for you."
-	(cd $(TOP); git submodule update --init --recursive)
 
 PREFIX = /usr/local
 BINDIR = $(DESTDIR)$(PREFIX)/bin

--- a/ports/unix/Makefile
+++ b/ports/unix/Makefile
@@ -133,6 +133,16 @@ CFLAGS_MOD += -DMICROPY_PY_THREAD=1 -DMICROPY_PY_THREAD_GIL=0
 LDFLAGS_MOD += $(LIBPTHREAD)
 endif
 
+ifeq ($(MICROPY_PY_USSL),1)
+ifeq ($(MICROPY_SSL_MBEDTLS),1)
+GIT_SUBMODULES += lib/mbedtls
+CFLAGS_MOD += -DMBEDTLS_CONFIG_FILE='"mbedtls/mbedtls_config.h"'
+# replace mbedtls' error.c by ours
+SRC_MOD := $(filter-out %/mbedtls/library/error.c, $(SRC_MOD))
+LIB_SRC_C += lib/mbedtls_errors/mp_mbedtls_errors.c
+endif
+endif
+
 # If the variant enables it, enable modbluetooth.
 ifeq ($(MICROPY_PY_BLUETOOTH),1)
 

--- a/ports/unix/mbedtls/mbedtls_config.h
+++ b/ports/unix/mbedtls/mbedtls_config.h
@@ -1,0 +1,94 @@
+/*
+ * This file is part of the MicroPython project, http://micropython.org/
+ *
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2018-2019 Damien P. George
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+#ifndef MICROPY_INCLUDED_MBEDTLS_CONFIG_H
+#define MICROPY_INCLUDED_MBEDTLS_CONFIG_H
+
+// If you want to debug MBEDTLS uncomment the following and
+// Pass 3 to mbedtls_debug_set_threshold in socket_new
+// #define MBEDTLS_DEBUG_C
+
+// Set mbedtls configuration
+#define MBEDTLS_DEPRECATED_REMOVED
+#define MBEDTLS_AES_ROM_TABLES
+#define MBEDTLS_CIPHER_MODE_CBC
+#define MBEDTLS_CIPHER_MODE_CTR // needed for MICROPY_PY_UCRYPTOLIB_CTR
+#define MBEDTLS_ECP_DP_SECP192R1_ENABLED
+#define MBEDTLS_ECP_DP_SECP224R1_ENABLED
+#define MBEDTLS_ECP_DP_SECP256R1_ENABLED
+#define MBEDTLS_ECP_DP_SECP384R1_ENABLED
+#define MBEDTLS_ECP_DP_SECP521R1_ENABLED
+#define MBEDTLS_ECP_DP_SECP192K1_ENABLED
+#define MBEDTLS_ECP_DP_SECP224K1_ENABLED
+#define MBEDTLS_ECP_DP_SECP256K1_ENABLED
+#define MBEDTLS_ECP_DP_BP256R1_ENABLED
+#define MBEDTLS_ECP_DP_BP384R1_ENABLED
+#define MBEDTLS_ECP_DP_BP512R1_ENABLED
+#define MBEDTLS_ECP_DP_CURVE25519_ENABLED
+#define MBEDTLS_KEY_EXCHANGE_RSA_ENABLED
+#define MBEDTLS_NO_PLATFORM_ENTROPY
+#define MBEDTLS_PKCS1_V15
+#define MBEDTLS_SHA256_SMALLER
+#define MBEDTLS_SSL_PROTO_TLS1
+#define MBEDTLS_SSL_PROTO_TLS1_1
+#define MBEDTLS_SSL_PROTO_TLS1_2
+#define MBEDTLS_SSL_SERVER_NAME_INDICATION
+
+// Use a smaller output buffer to reduce size of SSL context
+#define MBEDTLS_SSL_MAX_CONTENT_LEN (16384)
+#define MBEDTLS_SSL_IN_CONTENT_LEN  (MBEDTLS_SSL_MAX_CONTENT_LEN)
+#define MBEDTLS_SSL_OUT_CONTENT_LEN (4096)
+
+// Enable mbedtls modules
+#define MBEDTLS_AES_C
+#define MBEDTLS_ASN1_PARSE_C
+#define MBEDTLS_BIGNUM_C
+#define MBEDTLS_CIPHER_C
+#define MBEDTLS_CTR_DRBG_C
+#define MBEDTLS_ENTROPY_C
+#define MBEDTLS_ERROR_C
+#define MBEDTLS_HAVEGE_C
+#define MBEDTLS_MD_C
+#define MBEDTLS_MD5_C
+#define MBEDTLS_OID_C
+#define MBEDTLS_PKCS5_C
+#define MBEDTLS_PK_C
+#define MBEDTLS_PK_PARSE_C
+#define MBEDTLS_PLATFORM_C
+#define MBEDTLS_RSA_C
+#define MBEDTLS_SHA1_C
+#define MBEDTLS_SHA256_C
+#define MBEDTLS_SHA512_C
+#define MBEDTLS_SSL_CLI_C
+#define MBEDTLS_SSL_SRV_C
+#define MBEDTLS_SSL_TLS_C
+#define MBEDTLS_TIMING_C
+#define MBEDTLS_TLS_DEFAULT_ALLOW_SHA1_IN_KEY_EXCHANGE
+#define MBEDTLS_X509_CRT_PARSE_C
+#define MBEDTLS_X509_USE_C
+
+#include "mbedtls/check_config.h"
+
+#endif /* MICROPY_INCLUDED_MBEDTLS_CONFIG_H */

--- a/ports/unix/mpconfigport.h
+++ b/ports/unix/mpconfigport.h
@@ -328,7 +328,7 @@ static inline unsigned long mp_urandom_seed_init(void) {
     do { \
         extern void mp_handle_pending(bool); \
         mp_handle_pending(true); \
-        mp_hal_delay_us(500); \
+        usleep(500); /* equivalent to mp_hal_delay_us(500) */ \
     } while (0);
 
 #include <sched.h>

--- a/ports/unix/mpconfigport.mk
+++ b/ports/unix/mpconfigport.mk
@@ -27,10 +27,10 @@ MICROPY_PY_FFI = 1
 MICROPY_PY_USSL = 1
 # axTLS has minimal size but implements only a subset of modern TLS
 # functionality, so may have problems with some servers.
-MICROPY_SSL_AXTLS = 1
+MICROPY_SSL_AXTLS = 0
 # mbedTLS is more up to date and complete implementation, but also
 # more bloated.
-MICROPY_SSL_MBEDTLS = 0
+MICROPY_SSL_MBEDTLS = 1
 
 # jni module requires JVM/JNI
 MICROPY_PY_JNI = 0

--- a/ports/unix/unix_mphal.c
+++ b/ports/unix/unix_mphal.c
@@ -233,7 +233,7 @@ void mp_hal_delay_ms(mp_uint_t ms) {
     #ifdef MICROPY_EVENT_POLL_HOOK
     mp_uint_t start = mp_hal_ticks_ms();
     while (mp_hal_ticks_ms() - start < ms) {
-        // MICROPY_EVENT_POLL_HOOK does mp_hal_delay_us(500) (i.e. usleep(500)).
+        // MICROPY_EVENT_POLL_HOOK does usleep(500).
         MICROPY_EVENT_POLL_HOOK
     }
     #else

--- a/tests/extmod/ussl_basic.py.exp
+++ b/tests/extmod/ussl_basic.py.exp
@@ -1,7 +1,8 @@
-wrap_socket: OSError(-256, 'CONN_LOST')
+OSError: client
 <_SSLSocket 
-4
-b''
-read: OSError(-261,)
-read: OSError(9,)
-write: OSError(9,)
+TestSocket.setblocking(False)
+TestSocket.setblocking(True)
+TestSocket.ioctl 4 0
+TestSocket.ioctl 4 0
+OSError: read
+OSError: write


### PR DESCRIPTION
This PR:
- adds custom mbedtls config to the unix port which matches closely the bare-metal configs (eg stm32, rp2)
- switches unix to build with mbedtls by default, instead of axtls

Switching from axtls to mbedtls increases the unix build by about 134k on x64 architectures.

The reasons to make this switch are:
1. axtls is not being maintained/updated, mbedtls is.
2. So CI and tests can run against mbedtls, which is now the main TLS library used by the ports (eg stm32, rp2, mimxrt, esp32).  Only esp8266 uses axtls.