### PR TITLE
docs: Fix a few typos

### DIFF
--- a/drivers/cc3000/src/evnt_handler.c
+++ b/drivers/cc3000/src/evnt_handler.c
@@ -604,7 +604,7 @@ INT32 hci_unsol_event_handler(CHAR *event_hdr)
 				{
 					//data[0] represents the socket id, for which FIN was received by remote.
 					//Upon receiving this event, the user can close the socket, or else the 
-					//socket will be closded after inacvitity timeout (by default 60 seconds)
+					//socket will be closed after inacvitity timeout (by default 60 seconds)
 					tSLInformation.sWlanCB(event_type, data, 1);
 				}
 			}

--- a/ports/mimxrt/hal/flexspi_flash_config.h
+++ b/ports/mimxrt/hal/flexspi_flash_config.h
@@ -18,7 +18,7 @@
 #define FSL_XIP_BOARD_DRIVER_VERSION (MAKE_VERSION(2, 0, 0))
 /*@}*/
 
-/* FLEXSPI memory config block related defintions */
+/* FLEXSPI memory config block related definitions */
 #define FLEXSPI_CFG_BLK_TAG     (0x42464346UL) // ascii "FCFB" Big Endian
 #define FLEXSPI_CFG_BLK_VERSION (0x56010400UL) // V1.4.0
 #define FLEXSPI_CFG_BLK_SIZE    (512)
@@ -26,7 +26,7 @@
 /* FLEXSPI Feature related definitions */
 #define FLEXSPI_FEATURE_HAS_PARALLEL_MODE 1
 
-/* Lookup table related defintions */
+/* Lookup table related definitions */
 #define CMD_INDEX_READ        0
 #define CMD_INDEX_READSTATUS  1
 #define CMD_INDEX_WRITEENABLE 2

--- a/ports/stm32/adc.c
+++ b/ports/stm32/adc.c
@@ -50,7 +50,7 @@
 ///     val = adc.read_core_vbat()      # read MCU VBAT
 ///     val = adc.read_core_vref()      # read MCU VREF
 
-/* ADC defintions */
+/* ADC definitions */
 #define ADCx                    (ADC1)
 #define PIN_ADC_MASK            PIN_ADC1
 #define pin_adc_table           pin_adc1
@@ -171,8 +171,8 @@
 #define EOC_TIMEOUT (10)
 
 /* Core temperature sensor definitions */
-#define CORE_TEMP_V25          (943)  /* (0.76v/3.3v)*(2^ADC resoultion) */
-#define CORE_TEMP_AVG_SLOPE    (3)    /* (2.5mv/3.3v)*(2^ADC resoultion) */
+#define CORE_TEMP_V25          (943)  /* (0.76v/3.3v)*(2^ADC resolution) */
+#define CORE_TEMP_AVG_SLOPE    (3)    /* (2.5mv/3.3v)*(2^ADC resolution) */
 
 // scale and calibration values for VBAT and VREF
 #define ADC_SCALE (ADC_SCALE_V / ((1 << ADC_CAL_BITS) - 1))

--- a/ports/teensy/core/pins_teensy.c
+++ b/ports/teensy/core/pins_teensy.c
@@ -181,7 +181,7 @@ void portb_isr(void)
 
 void portc_isr(void)
 {
-	// TODO: these are inefficent.  Use CLZ somehow....
+	// TODO: these are inefficient.  Use CLZ somehow....
 	uint32_t isfr = PORTC_ISFR;
 	PORTC_ISFR = isfr;
 	if ((isfr & CORE_PIN9_BITMASK) && intFunc[9]) intFunc[9]();


### PR DESCRIPTION
There are small typos in:
- drivers/cc3000/src/evnt_handler.c
- ports/mimxrt/hal/flexspi_flash_config.h
- ports/stm32/adc.c
- ports/teensy/core/pins_teensy.c

Fixes:
- Should read `definitions` rather than `defintions`.
- Should read `resolution` rather than `resoultion`.
- Should read `inefficient` rather than `inefficent`.
- Should read `closed` rather than `closded`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md