### PR TITLE
CYW43: Allow setting hostname. 

### DIFF
--- a/drivers/cyw43/cyw43.h
+++ b/drivers/cyw43/cyw43.h
@@ -47,6 +47,14 @@
 #define CYW43_LINK_NONET        (-2)
 #define CYW43_LINK_BADAUTH      (-3)
 
+#ifndef MICROPY_BOARD_HOSTNAME
+#define MICROPY_BOARD_HOSTNAME  "PYBD"
+#endif
+
+#ifndef MICROPY_BOARD_HOSTNAME_LENGTH
+#define MICROPY_BOARD_HOSTNAME_LENGTH 16
+#endif
+
 typedef struct _cyw43_t {
     cyw43_ll_t cyw43_ll;
 
@@ -76,6 +84,7 @@ typedef struct _cyw43_t {
     struct netif netif[2];
     struct dhcp dhcp_client;
     dhcp_server_t dhcp_server;
+    char hostname[MICROPY_BOARD_HOSTNAME_LENGTH];
 } cyw43_t;
 
 extern cyw43_t cyw43_state;

--- a/drivers/cyw43/cyw43_ctrl.c
+++ b/drivers/cyw43/cyw43_ctrl.c
@@ -101,6 +101,8 @@ void cyw43_init(cyw43_t *self) {
     self->ap_channel = 3;
     self->ap_ssid_len = 0;
     self->ap_key_len = 0;
+    strncpy(self->hostname, MICROPY_BOARD_HOSTNAME, MICROPY_BOARD_HOSTNAME_LENGTH);
+    self->hostname[MICROPY_BOARD_HOSTNAME_LENGTH - 1] = 0;
 
     cyw43_poll = NULL;
 }

--- a/drivers/cyw43/cyw43_lwip.c
+++ b/drivers/cyw43/cyw43_lwip.c
@@ -117,7 +117,7 @@ void cyw43_tcpip_init(cyw43_t *self, int itf) {
     #else
     netif_add(n, &ipconfig[0], &ipconfig[1], &ipconfig[2], self, cyw43_netif_init, netif_input);
     #endif
-    netif_set_hostname(n, "PYBD");
+    netif_set_hostname(n, self->hostname);
     netif_set_default(n);
     netif_set_up(n);
 
@@ -132,8 +132,9 @@ void cyw43_tcpip_init(cyw43_t *self, int itf) {
     #if LWIP_MDNS_RESPONDER
     // TODO better to call after IP address is set
     char mdns_hostname[9];
-    memcpy(&mdns_hostname[0], "PYBD", 4);
-    mp_hal_get_mac_ascii(MP_HAL_MAC_WLAN0, 8, 4, &mdns_hostname[4]);
+    int len = MIN(strlen(self->hostname), 4);
+    memcpy(&mdns_hostname[0], self->hostname, len);
+    mp_hal_get_mac_ascii(MP_HAL_MAC_WLAN0, 4 + len, 8 - len, &mdns_hostname[len]);
     mdns_hostname[8] = '\0';
     mdns_resp_add_netif(n, mdns_hostname, 60);
     #endif

--- a/extmod/network_cyw43.c
+++ b/extmod/network_cyw43.c
@@ -381,6 +381,9 @@ STATIC mp_obj_t network_cyw43_config(size_t n_args, const mp_obj_t *args, mp_map
                 cyw43_ioctl(self->cyw, CYW43_IOCTL_GET_VAR, 13, buf, self->itf);
                 return MP_OBJ_NEW_SMALL_INT(nw_get_le32(buf) / 4);
             }
+            case MP_QSTR_hostname: {
+                return mp_obj_new_str(self->cyw->hostname, strlen(self->cyw->hostname));
+            }
             default:
                 mp_raise_ValueError(MP_ERROR_TEXT("unknown config param"));
         }
@@ -451,6 +454,12 @@ STATIC mp_obj_t network_cyw43_config(size_t n_args, const mp_obj_t *args, mp_map
                         memcpy(buf, "qtxpower\x00", 9);
                         nw_put_le32(buf + 9, dbm * 4);
                         cyw43_ioctl(self->cyw, CYW43_IOCTL_SET_VAR, 9 + 4, buf, self->itf);
+                        break;
+                    }
+                    case MP_QSTR_hostname: {
+                        const char *hostname = mp_obj_str_get_str(e->value);
+                        strncpy(self->cyw->hostname, hostname, MICROPY_BOARD_HOSTNAME_LENGTH);
+                        self->cyw->hostname[MICROPY_BOARD_HOSTNAME_LENGTH - 1] = 0;
                         break;
                     }
                     default:


### PR DESCRIPTION
* Fixes #8906
* Note I didn't want to use an arbitrary hostname length, so I used `DNS_MAX_NAME_LENGTH` which is 256 bytes, but it can be redefined.
