### PR TITLE
tinyusb: Update to the recent master.

### DIFF
--- a/ports/mimxrt/Makefile
+++ b/ports/mimxrt/Makefile
@@ -91,7 +91,7 @@ SRC_TINYUSB_C += \
 	lib/tinyusb/src/common/tusb_fifo.c \
 	lib/tinyusb/src/device/usbd.c \
 	lib/tinyusb/src/device/usbd_control.c \
-	lib/tinyusb/src/portable/nxp/transdimension/dcd_transdimension.c \
+	lib/tinyusb/src/portable/chipidea/ci_hs/dcd_ci_hs.c \
 	lib/tinyusb/src/tusb.c
 
 # All settings for Ethernet support are controller by the value of MICROPY_PY_LWIP

--- a/ports/nrf/mpconfigport.h
+++ b/ports/nrf/mpconfigport.h
@@ -311,6 +311,7 @@ typedef long mp_off_t;
 #define MP_STATE_PORT MP_STATE_VM
 
 #if MICROPY_HW_USB_CDC
+#include "device/usbd.h"
 #define MICROPY_HW_USBDEV_TASK_HOOK extern void tud_task(void); tud_task();
 #else
 #define MICROPY_HW_USBDEV_TASK_HOOK ;

--- a/ports/rp2/mpconfigport.h
+++ b/ports/rp2/mpconfigport.h
@@ -220,7 +220,7 @@ extern void mp_thread_end_atomic_section(uint32_t);
 #define MICROPY_PY_LWIP_EXIT    lwip_lock_release();
 
 #if MICROPY_HW_ENABLE_USBDEV
-#define MICROPY_HW_USBDEV_TASK_HOOK extern void tud_task(void); tud_task();
+#define MICROPY_HW_USBDEV_TASK_HOOK extern void tud_task_ext(uint32_t, bool); tud_task_ext(0, false);
 #define MICROPY_VM_HOOK_COUNT (10)
 #define MICROPY_VM_HOOK_INIT static uint vm_hook_divisor = MICROPY_VM_HOOK_COUNT;
 #define MICROPY_VM_HOOK_POLL if (get_core_num() == 0 && --vm_hook_divisor == 0) { \


### PR DESCRIPTION
This update requires changes to the rp2, nrf and mimxrt ports.
    
- rp2: change tud_task() into tud_task_ext() in mpconfigport.h
- nrf: include device/usbd.h in mpconfigport.h, for a backward compatible use of tud_task().
- mimxrt: use
    lib/tinyusb/src/portable/chipidea/ci_hs/dcd_ci_hs.c instead of
    lib/tinyusb/src/portable/nxp/transdimension/dcd_transdimension.c
    and change a #define.
    
The topics I know which are fixed with this version:
- fix the SAMD USB lock-up. (issue  #8521).
- support the MIMXRT11XX series of MCUs.
- fix a wrong pin definition for MIMXRT1050_EVKB.

Tested with the MIMXRT boards, Pico RP2, SAMD boards. Builds with the nrf port.
