### PR TITLE
py/builtinimport.c: Implement a "frozen overlay" using the filesystem.

### DIFF
--- a/py/misc.h
+++ b/py/misc.h
@@ -211,6 +211,7 @@ void vstr_add_str(vstr_t *vstr, const char *str);
 void vstr_add_strn(vstr_t *vstr, const char *str, size_t len);
 void vstr_ins_byte(vstr_t *vstr, size_t byte_pos, byte b);
 void vstr_ins_char(vstr_t *vstr, size_t char_pos, unichar chr);
+void vstr_ins_strn(vstr_t *vstr, size_t char_pos, const char *str, size_t len);
 void vstr_cut_head_bytes(vstr_t *vstr, size_t bytes_to_cut);
 void vstr_cut_tail_bytes(vstr_t *vstr, size_t bytes_to_cut);
 void vstr_cut_out_bytes(vstr_t *vstr, size_t byte_pos, size_t bytes_to_cut);

--- a/py/modmicropython.c
+++ b/py/modmicropython.c
@@ -164,6 +164,14 @@ STATIC mp_obj_t mp_micropython_schedule(mp_obj_t function, mp_obj_t arg) {
 STATIC MP_DEFINE_CONST_FUN_OBJ_2(mp_micropython_schedule_obj, mp_micropython_schedule);
 #endif
 
+#if MICROPY_ENABLE_FROZEN_OVERLAY
+STATIC mp_obj_t mp_micropython_frozen_overlay(mp_obj_t frozen_overlay_path_in) {
+    MP_STATE_VM(frozen_overlay_path) = frozen_overlay_path_in;
+    return mp_const_none;
+}
+STATIC MP_DEFINE_CONST_FUN_OBJ_1(mp_micropython_frozen_overlay_obj, mp_micropython_frozen_overlay);
+#endif
+
 STATIC const mp_rom_map_elem_t mp_module_micropython_globals_table[] = {
     { MP_ROM_QSTR(MP_QSTR___name__), MP_ROM_QSTR(MP_QSTR_micropython) },
     { MP_ROM_QSTR(MP_QSTR_const), MP_ROM_PTR(&mp_identity_obj) },
@@ -200,6 +208,9 @@ STATIC const mp_rom_map_elem_t mp_module_micropython_globals_table[] = {
     #endif
     #if MICROPY_ENABLE_SCHEDULER
     { MP_ROM_QSTR(MP_QSTR_schedule), MP_ROM_PTR(&mp_micropython_schedule_obj) },
+    #endif
+    #if MICROPY_ENABLE_FROZEN_OVERLAY
+    { MP_ROM_QSTR(MP_QSTR_frozen_overlay), MP_ROM_PTR(&mp_micropython_frozen_overlay_obj) },
     #endif
 };
 

--- a/py/mpconfig.h
+++ b/py/mpconfig.h
@@ -909,6 +909,11 @@ typedef double mp_float_t;
 #define MICROPY_SCHEDULER_DEPTH (4)
 #endif
 
+// Whether to allow filesystem overlay of frozen code via micropython.frozen_overlay()
+#ifndef MICROPY_ENABLE_FROZEN_OVERLAY
+#define MICROPY_ENABLE_FROZEN_OVERLAY (MICROPY_CONFIG_ROM_LEVEL_AT_LEAST_EVERYTHING)
+#endif
+
 // Support for generic VFS sub-system
 #ifndef MICROPY_VFS
 #define MICROPY_VFS (0)

--- a/py/mpstate.h
+++ b/py/mpstate.h
@@ -158,6 +158,10 @@ typedef struct _mp_state_vm_t {
     mp_obj_dict_t *mp_module_builtins_override_dict;
     #endif
 
+    #if MICROPY_ENABLE_FROZEN_OVERLAY
+    mp_obj_t frozen_overlay_path;
+    #endif
+
     // Include any root pointers registered with MP_REGISTER_ROOT_POINTER().
     #ifndef NO_QSTR
     // Only include root pointer definitions when not doing qstr extraction, because

--- a/py/vstr.c
+++ b/py/vstr.c
@@ -210,6 +210,11 @@ void vstr_ins_char(vstr_t *vstr, size_t char_pos, unichar chr) {
     *s = chr;
 }
 
+void vstr_ins_strn(vstr_t *vstr, size_t char_pos, const char *str, size_t len) {
+    char *s = vstr_ins_blank_bytes(vstr, char_pos, 1);
+    memcpy(s, str, len);
+}
+
 void vstr_cut_head_bytes(vstr_t *vstr, size_t bytes_to_cut) {
     vstr_cut_out_bytes(vstr, 0, bytes_to_cut);
 }


### PR DESCRIPTION
Draft/WIP.

Haven't given much thought to code size (especially when the feature is disabled). The `allow_frozen` flag to the `stat_` methods in particular needs some thought.

I considered a few other ways of implementing this, in particular making it detect the filesystem version of the file while searching sys.path but this creates a complicated interaction with things like loading the parent modules. Instead this approach says "a frozen file can be overridden by a filesystem file" rather than interfering with file discovery.

Filesystem means "VFS", so note this would work with `mpremote mount` too... (perhaps via #[8914](https://github.com/micropython/micropython/pull/8914) we could have a way to make mpremote construct this "files that have changed relative to freezing" directory to mount)

---

This allows frozen files to be overridden by filesystem .py or .mpy files from a specific path specified in `micropython.frozen_overlay`.

The idea is that during development, a whole directory tree might be frozen
but for fast testing iteration it can be useful to just replace a couple
of files. This allows the same directory structure to be defined, but any
time a file is about to be loaded from frozen, the same path is attempted
in the overlay path.

Note: the overlay path should not be part of sys.path, otherwise it will
prevent the frozen path from being found.