### PR TITLE
ports/unix/Makefile: Only checkout and build libffi submodule when used.

### DIFF
--- a/ports/unix/Makefile
+++ b/ports/unix/Makefile
@@ -30,7 +30,7 @@ UNAME_S := $(shell uname -s)
 include $(TOP)/py/py.mk
 include $(TOP)/extmod/extmod.mk
 
-GIT_SUBMODULES += lib/berkeley-db-1.xx lib/libffi
+GIT_SUBMODULES += lib/berkeley-db-1.xx
 
 INC +=  -I.
 INC +=  -I$(TOP)
@@ -202,6 +202,9 @@ endif
 ifeq ($(MICROPY_PY_FFI),1)
 
 ifeq ($(MICROPY_STANDALONE),1)
+# Use MicroPython fork for libffi.
+GIT_SUBMODULES += lib/libffi
+DEPLIBS += libffi
 LIBFFI_CFLAGS_MOD := -I$(shell ls -1d $(BUILD)/lib/libffi/out/lib/libffi-*/include)
  ifeq ($(MICROPY_FORCE_32BIT),1)
   LIBFFI_LDFLAGS_MOD = $(BUILD)/lib/libffi/out/lib32/libffi.a
@@ -209,6 +212,7 @@ LIBFFI_CFLAGS_MOD := -I$(shell ls -1d $(BUILD)/lib/libffi/out/lib/libffi-*/inclu
   LIBFFI_LDFLAGS_MOD = $(BUILD)/lib/libffi/out/lib/libffi.a
  endif
 else
+# Use system version of libffi.
 LIBFFI_CFLAGS_MOD := $(shell pkg-config --cflags libffi)
 LIBFFI_LDFLAGS_MOD := $(shell pkg-config --libs libffi)
 endif
@@ -325,7 +329,7 @@ else
 CROSS_COMPILE_HOST =
 endif
 
-deplibs: libffi
+deplibs: $(DEPLIBS)
 
 libffi: $(BUILD)/lib/libffi/include/ffi.h
 


### PR DESCRIPTION
This moves the `libffi` submodule variable modifier inside of the if statement where it is actually used so that the submodule will  only be checked out and built if it is actually being used.