### PR TITLE
py/_thread: Add support for lock.acquire timeout.

### DIFF
--- a/ports/cc3200/mpconfigport.h
+++ b/ports/cc3200/mpconfigport.h
@@ -109,6 +109,7 @@
 #define MICROPY_PY_UERRNO_ERRORCODE                 (0)
 #define MICROPY_PY_THREAD                           (1)
 #define MICROPY_PY_THREAD_GIL                       (1)
+#define MICROPY_PY_THREAD_LOCK_TIMEOUT              (1)
 #define MICROPY_PY_UBINASCII                        (1)
 #define MICROPY_PY_UCTYPES                          (0)
 #define MICROPY_PY_UZLIB                            (0)

--- a/ports/esp32/mpconfigport.h
+++ b/ports/esp32/mpconfigport.h
@@ -66,6 +66,7 @@
 #define MICROPY_PY_THREAD                   (1)
 #define MICROPY_PY_THREAD_GIL               (1)
 #define MICROPY_PY_THREAD_GIL_VM_DIVISOR    (32)
+#define MICROPY_PY_THREAD_LOCK_TIMEOUT      (1)
 
 // extended modules
 #ifndef MICROPY_PY_BLUETOOTH

--- a/ports/esp32/mpthreadport.c
+++ b/ports/esp32/mpthreadport.c
@@ -203,9 +203,15 @@ void mp_thread_mutex_init(mp_thread_mutex_t *mutex) {
     xSemaphoreGive(mutex->handle);
 }
 
+#ifdef MICROPY_PY_THREAD_LOCK_TIMEOUT
+int mp_thread_mutex_lock_timeout(mp_thread_mutex_t *mutex, int timeout_us) {
+    return (pdTRUE == xSemaphoreTake(mutex->handle, timeout_us < 0 ? portMAX_DELAY : timeout_us / portTICK_PERIOD_MS / 1000));
+}
+#else
 int mp_thread_mutex_lock(mp_thread_mutex_t *mutex, int wait) {
     return pdTRUE == xSemaphoreTake(mutex->handle, wait ? portMAX_DELAY : 0);
 }
+#endif
 
 void mp_thread_mutex_unlock(mp_thread_mutex_t *mutex) {
     xSemaphoreGive(mutex->handle);

--- a/ports/stm32/mpthreadport.h
+++ b/ports/stm32/mpthreadport.h
@@ -44,9 +44,16 @@ static inline void mp_thread_mutex_init(mp_thread_mutex_t *m) {
     pyb_mutex_init(m);
 }
 
+#ifdef MICROPY_PY_THREAD_LOCK_TIMEOUT
+static inline int mp_thread_mutex_lock_timeout(mp_thread_mutex_t *mutex, int timeout_us) {
+    // TODO timeout_us
+    return pyb_mutex_lock(m, wait);
+}
+#else
 static inline int mp_thread_mutex_lock(mp_thread_mutex_t *m, int wait) {
     return pyb_mutex_lock(m, wait);
 }
+#endif
 
 static inline void mp_thread_mutex_unlock(mp_thread_mutex_t *m) {
     pyb_mutex_unlock(m);

--- a/ports/unix/mpconfigport.h
+++ b/ports/unix/mpconfigport.h
@@ -221,10 +221,12 @@ static inline unsigned long mp_urandom_seed_init(void) {
 #include <stdio.h>
 #endif
 
-// If threading is enabled, configure the atomic section.
 #if MICROPY_PY_THREAD
+// If threading is enabled, configure the atomic section.
 #define MICROPY_BEGIN_ATOMIC_SECTION() (mp_thread_unix_begin_atomic_section(), 0xffffffff)
 #define MICROPY_END_ATOMIC_SECTION(x) (void)x; mp_thread_unix_end_atomic_section()
+// Enable lock timeout support
+#define MICROPY_PY_THREAD_LOCK_TIMEOUT  (1)
 #endif
 
 // In lieu of a WFI(), slow down polling from being a tight loop.

--- a/ports/unix/mpthreadport.c
+++ b/ports/unix/mpthreadport.c
@@ -39,6 +39,11 @@
 #include <sched.h>
 #include <semaphore.h>
 
+#ifdef MICROPY_PY_THREAD_LOCK_TIMEOUT
+#include <math.h>
+#include <sys/time.h>
+#endif
+
 #include "shared/runtime/gchelper.h"
 
 // Some platforms don't have SIGRTMIN but if we do have it, use it to avoid
@@ -293,6 +298,41 @@ void mp_thread_mutex_init(mp_thread_mutex_t *mutex) {
     pthread_mutex_init(mutex, NULL);
 }
 
+#ifdef MICROPY_PY_THREAD_LOCK_TIMEOUT
+int mp_thread_mutex_lock_timeout(mp_thread_mutex_t *mutex, int timeout_us) {
+    int ret;
+    if (timeout_us < 0) {
+        ret = pthread_mutex_lock(mutex);
+        if (ret == 0) {
+            return 1;
+        }
+    } else if (timeout_us == 0) {
+        ret = pthread_mutex_trylock(mutex);
+        if (ret == 0) {
+            return 1;
+        } else if (ret == EBUSY) {
+            return 0;
+        }
+    } else /* if (timeout_us > 0) */ {
+        struct timeval _timeval;
+        struct timezone _timezone;
+        gettimeofday(&_timeval, &_timezone);
+        uint32_t _timeout_sec = timeout_us / 1000000;
+        uint32_t _timeout_nano = 1000 * (timeout_us % 1000000 + _timeval.tv_usec);
+        struct timespec _timespec = {
+                .tv_sec = _timeout_sec + _timeval.tv_sec + (_timeout_nano / 1000000000),
+                .tv_nsec = _timeout_nano % 1000000000
+        };
+        ret = pthread_mutex_timedlock(mutex, &_timespec);
+        if (ret == 0) {
+            return 1;
+        } else if (ret == ETIMEDOUT) {
+            return 0;
+        }
+    }
+    return -ret;
+}
+#else
 int mp_thread_mutex_lock(mp_thread_mutex_t *mutex, int wait) {
     int ret;
     if (wait) {
@@ -310,6 +350,7 @@ int mp_thread_mutex_lock(mp_thread_mutex_t *mutex, int wait) {
     }
     return -ret;
 }
+#endif
 
 void mp_thread_mutex_unlock(mp_thread_mutex_t *mutex) {
     pthread_mutex_unlock(mutex);

--- a/py/mpthread.h
+++ b/py/mpthread.h
@@ -44,7 +44,12 @@ void mp_thread_create(void *(*entry)(void *), void *arg, size_t *stack_size);
 void mp_thread_start(void);
 void mp_thread_finish(void);
 void mp_thread_mutex_init(mp_thread_mutex_t *mutex);
+#ifdef MICROPY_PY_THREAD_LOCK_TIMEOUT
+int mp_thread_mutex_lock_timeout(mp_thread_mutex_t *mutex, int timeout_us);
+#define mp_thread_mutex_lock(mutex, wait) mp_thread_mutex_lock_timeout(mutex, wait ? -1 : 0 )
+#else
 int mp_thread_mutex_lock(mp_thread_mutex_t *mutex, int wait);
+#endif
 void mp_thread_mutex_unlock(mp_thread_mutex_t *mutex);
 
 #endif // MICROPY_PY_THREAD

--- a/tests/thread/thread_locktimed1.py
+++ b/tests/thread/thread_locktimed1.py
@@ -1,0 +1,40 @@
+# test timed _thread lock object using a single thread
+#
+# MIT license; Copyright (c) 2016 Damien P. George on behalf of Pycom Ltd
+
+import _thread
+
+# create lock
+lock = _thread.allocate_lock()
+
+print(type(lock) == _thread.LockType)
+
+# should be unlocked
+print(lock.locked())
+
+# try acquire
+print(lock.acquire())
+print(lock.locked())
+
+# this fail with timeout
+print(lock.acquire(1, 0.1))
+print(lock.locked())
+
+# this will fail with negative timeout
+print(lock.acquire(0, -1))
+print(lock.locked())
+
+# these will raise value errors
+try:
+    print(lock.acquire(0, 1))
+except ValueError:
+    print("can't specify a timeout for a non-blocking call")
+
+try:
+    print(lock.acquire(0, 0))
+except ValueError:
+    print("can't specify a timeout for a non-blocking call")
+
+print(lock.locked())
+lock.release()
+print(lock.locked())

--- a/tests/thread/thread_locktimed2.py
+++ b/tests/thread/thread_locktimed2.py
@@ -1,0 +1,35 @@
+# test timed _thread lock object using multiple threads
+#
+# MIT license; Copyright (c) 2016 Damien P. George on behalf of Pycom Ltd
+try:
+    import utime as time
+except ImportError:
+    import time
+import _thread
+
+# create lock
+lock = _thread.allocate_lock()
+
+def thread_entry():
+    lock.acquire()
+    time.sleep(1)
+    print('have it')
+    lock.release()
+
+# spawn the threads
+for i in range(4):
+    _thread.start_new_thread(thread_entry, ())
+
+# wait for threads to start
+time.sleep(.1)
+
+# will timeout and roughly measure time
+start = time.time()
+lock.acquire(1, 2.5)
+stop = time.time()
+print((stop - start) > 2)
+print((stop - start) < 3)
+
+# wait for threads to finish
+lock.acquire()
+print('done')


### PR DESCRIPTION
This working on https://github.com/micropython/micropython-lib/pull/503 I ran into the limitation that while the `_thread.Lock.acquire()` function supports the `waitflag` argument, it doesn't handle the `timeout` arg - while you can pass it it's silently ignored and instead blocks forever.

This PR adds support for the `timeout` arg. It does so in a fairly naive way I feel... but it does work.
1. try to get lock (unblocking)
2. if success, return True
3. if fail, sleep 1ms
4. if timeout expired, return False
5. else go back to 1.

Ref: https://docs.python.org/3/library/_thread.html#thread.lock.acquire

Similarly the test is not exactly best practice, what with having a static sleep in the middle, but it does test the behaviour.