### PR TITLE
nrf: Call usb_cdc_init() before executing boot.py & main.py.

### DIFF
--- a/ports/nrf/main.c
+++ b/ports/nrf/main.c
@@ -257,14 +257,14 @@ soft_reset:
 
     led_state(1, 0);
 
+    #if MICROPY_HW_USB_CDC
+    usb_cdc_init();
+    #endif
+
     #if MICROPY_VFS || MICROPY_MBFS || MICROPY_MODULE_FROZEN
     // run boot.py and main.py if they exist.
     pyexec_file_if_exists("boot.py");
     pyexec_file_if_exists("main.py");
-    #endif
-
-    #if MICROPY_HW_USB_CDC
-    usb_cdc_init();
     #endif
 
     for (;;) {


### PR DESCRIPTION
Otherwise, there is no USB I/O available when running main.py, and main.py
cannot be interrupted with Ctrl-C.