### PR TITLE
rp2: Fix build for boards using ninaw or mpbthciport.

### DIFF
--- a/drivers/ninaw10/nina_wifi_bsp.c
+++ b/drivers/ninaw10/nina_wifi_bsp.c
@@ -150,8 +150,4 @@ int nina_bsp_spi_transfer(const uint8_t *tx_buf, uint8_t *rx_buf, uint32_t size)
     return 0;
 }
 
-MP_REGISTER_ROOT_POINTER(struct _machine_spi_obj_t *mp_wifi_spi);
-MP_REGISTER_ROOT_POINTER(struct _machine_timer_obj_t *mp_wifi_timer);
-MP_REGISTER_ROOT_POINTER(struct _mp_obj_list_t *mp_wifi_sockpoll_list);
-
 #endif // MICROPY_PY_NETWORK_NINAW10

--- a/extmod/network_ninaw10.c
+++ b/extmod/network_ninaw10.c
@@ -797,4 +797,8 @@ const mod_network_nic_type_t mod_network_nic_type_nina = {
     .ioctl = network_ninaw10_socket_ioctl,
 };
 
+MP_REGISTER_ROOT_POINTER(struct _machine_spi_obj_t *mp_wifi_spi);
+MP_REGISTER_ROOT_POINTER(struct _machine_timer_obj_t *mp_wifi_timer);
+MP_REGISTER_ROOT_POINTER(struct _mp_obj_list_t *mp_wifi_sockpoll_list);
+
 #endif // #if MICROPY_PY_BLUETOOTH && MICROPY_PY_NETWORK_NINAW10

--- a/ports/rp2/mpbthciport.c
+++ b/ports/rp2/mpbthciport.c
@@ -100,8 +100,10 @@ int mp_bluetooth_hci_uart_init(uint32_t port, uint32_t baudrate) {
         MP_OBJ_NEW_QSTR(MP_QSTR_timeout), MP_OBJ_NEW_SMALL_INT(1000),
     };
 
+    // This is a statically-allocated UART (see machine_uart.c), and doesn't
+    // contain any heap pointers other than the ringbufs (which are already
+    // root pointers), so no need to track this as a root pointer.
     mp_bthci_uart = machine_uart_type.make_new((mp_obj_t)&machine_uart_type, 2, 2, args);
-    MP_STATE_PORT(mp_bthci_uart) = mp_bthci_uart;
 
     // Start the HCI polling to process any initial events/packets.
     mp_bluetooth_hci_start_polling();
@@ -196,7 +198,5 @@ MP_WEAK int mp_bluetooth_hci_controller_wakeup(void) {
     debug_printf("mp_bluetooth_hci_controller_wakeup (default)\n");
     return 0;
 }
-
-MP_REGISTER_ROOT_POINTER(struct _machine_uart_obj_t *mp_bthci_uart);
 
 #endif // MICROPY_PY_BLUETOOTH

--- a/ports/rp2/mpconfigport.h
+++ b/ports/rp2/mpconfigport.h
@@ -176,7 +176,6 @@ extern const struct _mp_obj_type_t mp_network_cyw43_type;
 #ifndef MICROPY_PY_USOCKET_EXTENDED_STATE
 #define MICROPY_PY_USOCKET_EXTENDED_STATE   (1)
 #endif
-// It also requires an additional root pointer for the SPI object.
 extern const struct _mod_network_nic_type_t mod_network_nic_type_nina;
 #define MICROPY_HW_NIC_NINAW10              { MP_ROM_QSTR(MP_QSTR_WLAN), MP_ROM_PTR(&mod_network_nic_type_nina) },
 #else


### PR DESCRIPTION
https://github.com/micropython/micropython/pull/8849 added some uses of `MP_REGISTER_ROOT_POINTER` in code (in drivers/) that isn't part of QSTR discovery (and therefore doesn't get module or root pointer registration). Makes sense to move this to the extmod bindings anyway.

Also rp2/mpbthciport.c isn't part of QSTR discovery. This would be easy to add to CMakeLists.txt but it appears this root pointer is unnecessary anyway.

cc @iabdalkader 