### PR TITLE
cc3200: Fix compile warnings (as errors).

### DIFF
--- a/drivers/cc3100/src/wlan.c
+++ b/drivers/cc3100/src/wlan.c
@@ -536,10 +536,7 @@ _i16 sl_WlanProfileGet(const _i16 Index,_i8*  pName, _i16 *pNameLen, _u8 *pMacAd
     *pNameLen  = Msg.Rsp.Args.Common.SsidLen;      
     *pPriority = Msg.Rsp.Args.Common.Priority;       
 
-    if (NULL != Msg.Rsp.Args.Common.Bssid)
-    {
-        sl_Memcpy(pMacAddr, Msg.Rsp.Args.Common.Bssid, sizeof(Msg.Rsp.Args.Common.Bssid));
-    }
+    sl_Memcpy(pMacAddr, Msg.Rsp.Args.Common.Bssid, sizeof(Msg.Rsp.Args.Common.Bssid));
 
     sl_Memcpy(pName, EAP_PROFILE_SSID_STRING(&Msg), *pNameLen);
 

--- a/ports/cc3200/Makefile
+++ b/ports/cc3200/Makefile
@@ -25,6 +25,9 @@ CFLAGS += -g -ffunction-sections -fdata-sections -fno-common -fsigned-char -mno-
 CFLAGS += -Iboards/$(BOARD)
 CFLAGS += $(CFLAGS_MOD)
 
+# Workaround gcc 12.1 bug.
+ CFLAGS += -Wno-array-bounds
+
 LDFLAGS = -Wl,-nostdlib -Wl,--gc-sections -Wl,-Map=$@.map
 
 FLASH_SIZE_WIPY = 2M

--- a/ports/cc3200/mods/modwlan.c
+++ b/ports/cc3200/mods/modwlan.c
@@ -641,8 +641,8 @@ STATIC void wlan_set_security (uint8_t auth, const char *key, uint8_t len) {
     if (key != NULL) {
         memcpy(&wlan_obj.key, key, len);
         wlan_obj.key[len] = '\0';
+        _u8 wep_key[32];
         if (auth == SL_SEC_TYPE_WEP) {
-            _u8 wep_key[32];
             wlan_wep_key_unhexlify(key, (char *)&wep_key);
             key = (const char *)&wep_key;
             len /= 2;


### PR DESCRIPTION
1. Add -Wno-array-bounds to avoid false positive on gcc 12.1. #8685
2. Remove always-true not-NULL-check (Msg.Rsp.Args.Common.Bssid is an array not a pointer).
3. Fix pointer-to-freed-stack in wlan_set_security.
