### PR TITLE
extmod/uasyncio/funcs.py: Handle gather with no awaitables.

### DIFF
--- a/extmod/uasyncio/funcs.py
+++ b/extmod/uasyncio/funcs.py
@@ -62,6 +62,9 @@ class _Remove:
 
 
 async def gather(*aws, return_exceptions=False):
+    if not aws:
+        return aws
+
     def done(t, er):
         # Sub-task "t" has finished, with exception "er".
         nonlocal state

--- a/tests/extmod/uasyncio_gather.py
+++ b/tests/extmod/uasyncio_gather.py
@@ -53,6 +53,11 @@ async def main():
 
     print("====")
 
+    # Gather with no awaitables
+    print(await asyncio.gather())
+
+    print("====")
+
     # Test return_exceptions, where one task is cancelled and the other finishes normally
     tasks = [asyncio.create_task(task(1)), asyncio.create_task(task(2))]
     tasks[0].cancel()

--- a/tests/extmod/uasyncio_gather.py.exp
+++ b/tests/extmod/uasyncio_gather.py.exp
@@ -9,6 +9,8 @@ Task C: Compute factorial(4)...
 Task C: factorial(4) = 24
 [2, 6, 24]
 ====
+()
+====
 start 2
 end 2
 [CancelledError(), 2]


### PR DESCRIPTION
This previously resulted in gather() yielding but with no way to be resumed.

Fixes #8937