### PR TITLE
py/modio.c: Remove FileIO & TextIOWrapper from modio.

### DIFF
--- a/extmod/moduos.c
+++ b/extmod/moduos.c
@@ -137,6 +137,9 @@ STATIC const mp_rom_map_elem_t os_module_globals_table[] = {
     { MP_ROM_QSTR(MP_QSTR_stat), MP_ROM_PTR(&mp_vfs_stat_obj) },
     { MP_ROM_QSTR(MP_QSTR_statvfs), MP_ROM_PTR(&mp_vfs_statvfs_obj) },
     { MP_ROM_QSTR(MP_QSTR_unlink), MP_ROM_PTR(&mp_vfs_remove_obj) }, // unlink aliases to remove
+    #if MICROPY_VFS_POSIX
+    { MP_ROM_QSTR(MP_QSTR_fdopen), MP_ROM_PTR(&mp_vfs_open_obj) },
+    #endif
     #endif
 
     // The following are MicroPython extensions.

--- a/extmod/vfs.c
+++ b/extmod/vfs.c
@@ -312,7 +312,7 @@ mp_obj_t mp_vfs_open(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args)
     #if MICROPY_VFS_POSIX
     // If the file is an integer then delegate straight to the POSIX handler
     if (mp_obj_is_small_int(args[ARG_file].u_obj)) {
-        return mp_vfs_posix_file_open(&mp_type_textio, args[ARG_file].u_obj, args[ARG_mode].u_obj);
+        return mp_vfs_posix_file_open(&mp_type_vfs_posix_textio, args[ARG_file].u_obj, args[ARG_mode].u_obj);
     }
     #endif
 

--- a/extmod/vfs_fat_file.c
+++ b/extmod/vfs_fat_file.c
@@ -151,18 +151,67 @@ STATIC mp_uint_t file_obj_ioctl(mp_obj_t o_in, mp_uint_t request, uintptr_t arg,
     }
 }
 
-// Note: encoding is ignored for now; it's also not a valid kwarg for CPython's FileIO,
-// but by adding it here we can use one single mp_arg_t array for open() and FileIO's constructor
-STATIC const mp_arg_t file_open_args[] = {
-    { MP_QSTR_file, MP_ARG_OBJ | MP_ARG_REQUIRED, {.u_rom_obj = MP_ROM_NONE} },
-    { MP_QSTR_mode, MP_ARG_OBJ, {.u_obj = MP_OBJ_NEW_QSTR(MP_QSTR_r)} },
-    { MP_QSTR_encoding, MP_ARG_OBJ | MP_ARG_KW_ONLY, {.u_rom_obj = MP_ROM_NONE} },
-};
-#define FILE_OPEN_NUM_ARGS MP_ARRAY_SIZE(file_open_args)
+// TODO gc hook to close the file if not already closed
 
-STATIC mp_obj_t file_open(fs_user_mount_t *vfs, const mp_obj_type_t *type, mp_arg_val_t *args) {
+STATIC const mp_rom_map_elem_t vfs_fat_rawfile_locals_dict_table[] = {
+    { MP_ROM_QSTR(MP_QSTR_read), MP_ROM_PTR(&mp_stream_read_obj) },
+    { MP_ROM_QSTR(MP_QSTR_readinto), MP_ROM_PTR(&mp_stream_readinto_obj) },
+    { MP_ROM_QSTR(MP_QSTR_readline), MP_ROM_PTR(&mp_stream_unbuffered_readline_obj) },
+    { MP_ROM_QSTR(MP_QSTR_readlines), MP_ROM_PTR(&mp_stream_unbuffered_readlines_obj) },
+    { MP_ROM_QSTR(MP_QSTR_write), MP_ROM_PTR(&mp_stream_write_obj) },
+    { MP_ROM_QSTR(MP_QSTR_flush), MP_ROM_PTR(&mp_stream_flush_obj) },
+    { MP_ROM_QSTR(MP_QSTR_close), MP_ROM_PTR(&mp_stream_close_obj) },
+    { MP_ROM_QSTR(MP_QSTR_seek), MP_ROM_PTR(&mp_stream_seek_obj) },
+    { MP_ROM_QSTR(MP_QSTR_tell), MP_ROM_PTR(&mp_stream_tell_obj) },
+    { MP_ROM_QSTR(MP_QSTR___del__), MP_ROM_PTR(&mp_stream_close_obj) },
+    { MP_ROM_QSTR(MP_QSTR___enter__), MP_ROM_PTR(&mp_identity_obj) },
+    { MP_ROM_QSTR(MP_QSTR___exit__), MP_ROM_PTR(&file_obj___exit___obj) },
+};
+
+STATIC MP_DEFINE_CONST_DICT(vfs_fat_rawfile_locals_dict, vfs_fat_rawfile_locals_dict_table);
+
+#if MICROPY_PY_IO_FILEIO
+STATIC const mp_stream_p_t vfs_fat_fileio_stream_p = {
+    .read = file_obj_read,
+    .write = file_obj_write,
+    .ioctl = file_obj_ioctl,
+};
+
+const mp_obj_type_t mp_type_vfs_fat_fileio = {
+    { &mp_type_type },
+    .name = MP_QSTR_FileIO,
+    .print = file_obj_print,
+    .getiter = mp_identity_getiter,
+    .iternext = mp_stream_unbuffered_iter,
+    .protocol = &vfs_fat_fileio_stream_p,
+    .locals_dict = (mp_obj_dict_t *)&vfs_fat_rawfile_locals_dict,
+};
+#endif
+
+STATIC const mp_stream_p_t vfs_fat_textio_stream_p = {
+    .read = file_obj_read,
+    .write = file_obj_write,
+    .ioctl = file_obj_ioctl,
+    .is_text = true,
+};
+
+const mp_obj_type_t mp_type_vfs_fat_textio = {
+    { &mp_type_type },
+    .name = MP_QSTR_TextIOWrapper,
+    .print = file_obj_print,
+    .getiter = mp_identity_getiter,
+    .iternext = mp_stream_unbuffered_iter,
+    .protocol = &vfs_fat_textio_stream_p,
+    .locals_dict = (mp_obj_dict_t *)&vfs_fat_rawfile_locals_dict,
+};
+
+// Factory function for I/O stream classes
+STATIC mp_obj_t fat_vfs_open(mp_obj_t self_in, mp_obj_t path_in, mp_obj_t mode_in) {
+    fs_user_mount_t *self = MP_OBJ_TO_PTR(self_in);
+
+    const mp_obj_type_t *type = &mp_type_vfs_fat_textio;
     int mode = 0;
-    const char *mode_s = mp_obj_str_get_str(args[1].u_obj);
+    const char *mode_s = mp_obj_str_get_str(mode_in);
     // TODO make sure only one of r, w, x, a, and b, t are specified
     while (*mode_s) {
         switch (*mode_s++) {
@@ -195,9 +244,8 @@ STATIC mp_obj_t file_open(fs_user_mount_t *vfs, const mp_obj_type_t *type, mp_ar
     pyb_file_obj_t *o = m_new_obj_with_finaliser(pyb_file_obj_t);
     o->base.type = type;
 
-    const char *fname = mp_obj_str_get_str(args[0].u_obj);
-    assert(vfs != NULL);
-    FRESULT res = f_open(&vfs->fatfs, &o->fp, fname, mode);
+    const char *fname = mp_obj_str_get_str(path_in);
+    FRESULT res = f_open(&self->fatfs, &o->fp, fname, mode);
     if (res != FR_OK) {
         m_del_obj(pyb_file_obj_t, o);
         mp_raise_OSError(fresult_to_errno_table[res]);
@@ -210,79 +258,6 @@ STATIC mp_obj_t file_open(fs_user_mount_t *vfs, const mp_obj_type_t *type, mp_ar
 
     return MP_OBJ_FROM_PTR(o);
 }
-
-STATIC mp_obj_t file_obj_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *args) {
-    mp_arg_val_t arg_vals[FILE_OPEN_NUM_ARGS];
-    mp_arg_parse_all_kw_array(n_args, n_kw, args, FILE_OPEN_NUM_ARGS, file_open_args, arg_vals);
-    return file_open(NULL, type, arg_vals);
-}
-
-// TODO gc hook to close the file if not already closed
-
-STATIC const mp_rom_map_elem_t vfs_fat_rawfile_locals_dict_table[] = {
-    { MP_ROM_QSTR(MP_QSTR_read), MP_ROM_PTR(&mp_stream_read_obj) },
-    { MP_ROM_QSTR(MP_QSTR_readinto), MP_ROM_PTR(&mp_stream_readinto_obj) },
-    { MP_ROM_QSTR(MP_QSTR_readline), MP_ROM_PTR(&mp_stream_unbuffered_readline_obj) },
-    { MP_ROM_QSTR(MP_QSTR_readlines), MP_ROM_PTR(&mp_stream_unbuffered_readlines_obj) },
-    { MP_ROM_QSTR(MP_QSTR_write), MP_ROM_PTR(&mp_stream_write_obj) },
-    { MP_ROM_QSTR(MP_QSTR_flush), MP_ROM_PTR(&mp_stream_flush_obj) },
-    { MP_ROM_QSTR(MP_QSTR_close), MP_ROM_PTR(&mp_stream_close_obj) },
-    { MP_ROM_QSTR(MP_QSTR_seek), MP_ROM_PTR(&mp_stream_seek_obj) },
-    { MP_ROM_QSTR(MP_QSTR_tell), MP_ROM_PTR(&mp_stream_tell_obj) },
-    { MP_ROM_QSTR(MP_QSTR___del__), MP_ROM_PTR(&mp_stream_close_obj) },
-    { MP_ROM_QSTR(MP_QSTR___enter__), MP_ROM_PTR(&mp_identity_obj) },
-    { MP_ROM_QSTR(MP_QSTR___exit__), MP_ROM_PTR(&file_obj___exit___obj) },
-};
-
-STATIC MP_DEFINE_CONST_DICT(vfs_fat_rawfile_locals_dict, vfs_fat_rawfile_locals_dict_table);
-
-#if MICROPY_PY_IO_FILEIO
-STATIC const mp_stream_p_t vfs_fat_fileio_stream_p = {
-    .read = file_obj_read,
-    .write = file_obj_write,
-    .ioctl = file_obj_ioctl,
-};
-
-const mp_obj_type_t mp_type_vfs_fat_fileio = {
-    { &mp_type_type },
-    .name = MP_QSTR_FileIO,
-    .print = file_obj_print,
-    .make_new = file_obj_make_new,
-    .getiter = mp_identity_getiter,
-    .iternext = mp_stream_unbuffered_iter,
-    .protocol = &vfs_fat_fileio_stream_p,
-    .locals_dict = (mp_obj_dict_t *)&vfs_fat_rawfile_locals_dict,
-};
-#endif
-
-STATIC const mp_stream_p_t vfs_fat_textio_stream_p = {
-    .read = file_obj_read,
-    .write = file_obj_write,
-    .ioctl = file_obj_ioctl,
-    .is_text = true,
-};
-
-const mp_obj_type_t mp_type_vfs_fat_textio = {
-    { &mp_type_type },
-    .name = MP_QSTR_TextIOWrapper,
-    .print = file_obj_print,
-    .make_new = file_obj_make_new,
-    .getiter = mp_identity_getiter,
-    .iternext = mp_stream_unbuffered_iter,
-    .protocol = &vfs_fat_textio_stream_p,
-    .locals_dict = (mp_obj_dict_t *)&vfs_fat_rawfile_locals_dict,
-};
-
-// Factory function for I/O stream classes
-STATIC mp_obj_t fatfs_builtin_open_self(mp_obj_t self_in, mp_obj_t path, mp_obj_t mode) {
-    // TODO: analyze buffering args and instantiate appropriate type
-    fs_user_mount_t *self = MP_OBJ_TO_PTR(self_in);
-    mp_arg_val_t arg_vals[FILE_OPEN_NUM_ARGS];
-    arg_vals[0].u_obj = path;
-    arg_vals[1].u_obj = mode;
-    arg_vals[2].u_obj = mp_const_none;
-    return file_open(self, &mp_type_vfs_fat_textio, arg_vals);
-}
-MP_DEFINE_CONST_FUN_OBJ_3(fat_vfs_open_obj, fatfs_builtin_open_self);
+MP_DEFINE_CONST_FUN_OBJ_3(fat_vfs_open_obj, fat_vfs_open);
 
 #endif // MICROPY_VFS && MICROPY_VFS_FAT

--- a/extmod/vfs_posix.c
+++ b/extmod/vfs_posix.c
@@ -138,7 +138,7 @@ STATIC mp_obj_t vfs_posix_open(mp_obj_t self_in, mp_obj_t path_in, mp_obj_t mode
     if (!mp_obj_is_small_int(path_in)) {
         path_in = vfs_posix_get_path_obj(self, path_in);
     }
-    return mp_vfs_posix_file_open(&mp_type_textio, path_in, mode_in);
+    return mp_vfs_posix_file_open(&mp_type_vfs_posix_textio, path_in, mode_in);
 }
 STATIC MP_DEFINE_CONST_FUN_OBJ_3(vfs_posix_open_obj, vfs_posix_open);
 

--- a/extmod/vfs_posix_file.c
+++ b/extmod/vfs_posix_file.c
@@ -111,17 +111,6 @@ mp_obj_t mp_vfs_posix_file_open(const mp_obj_type_t *type, mp_obj_t file_in, mp_
     return MP_OBJ_FROM_PTR(o);
 }
 
-STATIC mp_obj_t vfs_posix_file_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *args) {
-    static const mp_arg_t allowed_args[] = {
-        { MP_QSTR_file, MP_ARG_OBJ | MP_ARG_REQUIRED, {.u_rom_obj = MP_ROM_NONE} },
-        { MP_QSTR_mode, MP_ARG_OBJ, {.u_rom_obj = MP_ROM_QSTR(MP_QSTR_r)} },
-    };
-
-    mp_arg_val_t arg_vals[MP_ARRAY_SIZE(allowed_args)];
-    mp_arg_parse_all_kw_array(n_args, n_kw, args, MP_ARRAY_SIZE(allowed_args), allowed_args, arg_vals);
-    return mp_vfs_posix_file_open(type, arg_vals[0].u_obj, arg_vals[1].u_obj);
-}
-
 STATIC mp_obj_t vfs_posix_file_fileno(mp_obj_t self_in) {
     mp_obj_vfs_posix_file_t *self = MP_OBJ_TO_PTR(self_in);
     check_fd_is_open(self);
@@ -268,7 +257,6 @@ const mp_obj_type_t mp_type_vfs_posix_fileio = {
     { &mp_type_type },
     .name = MP_QSTR_FileIO,
     .print = vfs_posix_file_print,
-    .make_new = vfs_posix_file_make_new,
     .getiter = mp_identity_getiter,
     .iternext = mp_stream_unbuffered_iter,
     .protocol = &vfs_posix_fileio_stream_p,
@@ -287,15 +275,14 @@ const mp_obj_type_t mp_type_vfs_posix_textio = {
     { &mp_type_type },
     .name = MP_QSTR_TextIOWrapper,
     .print = vfs_posix_file_print,
-    .make_new = vfs_posix_file_make_new,
     .getiter = mp_identity_getiter,
     .iternext = mp_stream_unbuffered_iter,
     .protocol = &vfs_posix_textio_stream_p,
     .locals_dict = (mp_obj_dict_t *)&vfs_posix_rawfile_locals_dict,
 };
 
-const mp_obj_vfs_posix_file_t mp_sys_stdin_obj = {{&mp_type_textio}, STDIN_FILENO};
-const mp_obj_vfs_posix_file_t mp_sys_stdout_obj = {{&mp_type_textio}, STDOUT_FILENO};
-const mp_obj_vfs_posix_file_t mp_sys_stderr_obj = {{&mp_type_textio}, STDERR_FILENO};
+const mp_obj_vfs_posix_file_t mp_sys_stdin_obj = {{&mp_type_vfs_posix_textio}, STDIN_FILENO};
+const mp_obj_vfs_posix_file_t mp_sys_stdout_obj = {{&mp_type_vfs_posix_textio}, STDOUT_FILENO};
+const mp_obj_vfs_posix_file_t mp_sys_stderr_obj = {{&mp_type_vfs_posix_textio}, STDERR_FILENO};
 
 #endif // MICROPY_VFS_POSIX || MICROPY_VFS_POSIX_FILE

--- a/ports/cc3200/mpconfigport.h
+++ b/ports/cc3200/mpconfigport.h
@@ -131,10 +131,6 @@
     X(EINVAL) \
     X(ETIMEDOUT) \
 
-// TODO these should be generic, not bound to fatfs
-#define mp_type_fileio mp_type_vfs_fat_fileio
-#define mp_type_textio mp_type_vfs_fat_textio
-
 // extra constants
 #define MICROPY_PORT_CONSTANTS \
     { MP_ROM_QSTR(MP_QSTR_umachine),     MP_ROM_PTR(&mp_module_machine) },  \

--- a/ports/esp32/mpconfigport.h
+++ b/ports/esp32/mpconfigport.h
@@ -135,8 +135,6 @@
 #define MICROPY_FATFS_RPATH                 (2)
 #define MICROPY_FATFS_MAX_SS                (4096)
 #define MICROPY_FATFS_LFN_CODE_PAGE         437 /* 1=SFN/ANSI 437=LFN/U.S.(OEM) */
-#define mp_type_fileio                      mp_type_vfs_fat_fileio
-#define mp_type_textio                      mp_type_vfs_fat_textio
 
 #define MP_STATE_PORT MP_STATE_VM
 

--- a/ports/esp8266/mpconfigport.h
+++ b/ports/esp8266/mpconfigport.h
@@ -134,17 +134,6 @@ void *esp_native_code_commit(void *, size_t, void *);
 // printer for debugging output, goes to UART only
 extern const struct _mp_print_t mp_debug_print;
 
-#if MICROPY_VFS_FAT
-#define mp_type_fileio mp_type_vfs_fat_fileio
-#define mp_type_textio mp_type_vfs_fat_textio
-#elif MICROPY_VFS_LFS1
-#define mp_type_fileio mp_type_vfs_lfs1_fileio
-#define mp_type_textio mp_type_vfs_lfs1_textio
-#elif MICROPY_VFS_LFS2
-#define mp_type_fileio mp_type_vfs_lfs2_fileio
-#define mp_type_textio mp_type_vfs_lfs2_textio
-#endif
-
 #define MP_STATE_PORT MP_STATE_VM
 
 // We need an implementation of the log2 function which is not a macro

--- a/ports/mimxrt/mpconfigport.h
+++ b/ports/mimxrt/mpconfigport.h
@@ -184,10 +184,6 @@ uint32_t trng_random_u32(void);
 #define MICROPY_PY_PENDSV_REENTER atomic_state = raise_irq_pri(IRQ_PRI_PENDSV);
 #define MICROPY_PY_PENDSV_EXIT    restore_irq_pri(atomic_state);
 
-// Use VfsLfs2's types for fileio/textio
-#define mp_type_fileio mp_type_vfs_lfs2_fileio
-#define mp_type_textio mp_type_vfs_lfs2_textio
-
 // Hooks to add builtins
 
 __attribute__((always_inline)) static inline void enable_irq(uint32_t state) {

--- a/ports/nrf/mpconfigport.h
+++ b/ports/nrf/mpconfigport.h
@@ -133,23 +133,6 @@
     #define MICROPY_FATFS_MAX_SS       (4096)
 #endif
 
-#if MICROPY_VFS
-// TODO these should be generic, not bound to a particular FS implementation
-#if MICROPY_VFS_FAT
-#define mp_type_fileio mp_type_vfs_fat_fileio
-#define mp_type_textio mp_type_vfs_fat_textio
-#elif MICROPY_VFS_LFS1
-#define mp_type_fileio mp_type_vfs_lfs1_fileio
-#define mp_type_textio mp_type_vfs_lfs1_textio
-#elif MICROPY_VFS_LFS2
-#define mp_type_fileio mp_type_vfs_lfs2_fileio
-#define mp_type_textio mp_type_vfs_lfs2_textio
-#endif
-#else // !MICROPY_VFS_FAT
-#define mp_type_fileio fatfs_type_fileio
-#define mp_type_textio fatfs_type_textio
-#endif
-
 // Use port specific uos module rather than extmod variant.
 #define MICROPY_PY_UOS              (0)
 

--- a/ports/renesas-ra/mpconfigport.h
+++ b/ports/renesas-ra/mpconfigport.h
@@ -137,18 +137,6 @@
 #define MICROPY_FATFS_RPATH            (2)
 #define MICROPY_FATFS_MULTI_PARTITION  (1)
 
-// TODO these should be generic, not bound to a particular FS implementation
-#if MICROPY_VFS_FAT
-#define mp_type_fileio mp_type_vfs_fat_fileio
-#define mp_type_textio mp_type_vfs_fat_textio
-#elif MICROPY_VFS_LFS1
-#define mp_type_fileio mp_type_vfs_lfs1_fileio
-#define mp_type_textio mp_type_vfs_lfs1_textio
-#elif MICROPY_VFS_LFS2
-#define mp_type_fileio mp_type_vfs_lfs2_fileio
-#define mp_type_textio mp_type_vfs_lfs2_textio
-#endif
-
 #if MICROPY_PY_MACHINE
 #define MACHINE_BUILTIN_MODULE_CONSTANTS \
     { MP_ROM_QSTR(MP_QSTR_umachine), MP_ROM_PTR(&mp_module_machine) }, \

--- a/ports/rp2/mpconfigport.h
+++ b/ports/rp2/mpconfigport.h
@@ -122,15 +122,6 @@
 #define MICROPY_FATFS_MAX_SS                    (FLASH_SECTOR_SIZE)
 #endif
 
-#if MICROPY_VFS_FAT && MICROPY_HW_USB_MSC
-#define mp_type_fileio mp_type_vfs_fat_fileio
-#define mp_type_textio mp_type_vfs_fat_textio
-#elif MICROPY_VFS_LFS2
-// Use VfsLfs2's types for fileio/textio
-#define mp_type_fileio mp_type_vfs_lfs2_fileio
-#define mp_type_textio mp_type_vfs_lfs2_textio
-#endif
-
 #ifndef MICROPY_BOARD_ENTER_BOOTLOADER
 #define MICROPY_BOARD_ENTER_BOOTLOADER(nargs, args)
 #endif

--- a/ports/samd/mpconfigport.h
+++ b/ports/samd/mpconfigport.h
@@ -95,10 +95,6 @@
 #define MICROPY_PY_UZLIB                    (1)
 #define MICROPY_PY_UASYNCIO                 (1)
 
-// Use VfsLfs's types for fileio/textio
-#define mp_type_fileio mp_type_vfs_lfs1_fileio
-#define mp_type_textio mp_type_vfs_lfs1_textio
-
 #define MP_STATE_PORT MP_STATE_VM
 
 // Miscellaneous settings

--- a/ports/stm32/mpconfigport.h
+++ b/ports/stm32/mpconfigport.h
@@ -151,18 +151,6 @@
 #define MICROPY_FATFS_RPATH            (2)
 #define MICROPY_FATFS_MULTI_PARTITION  (1)
 
-// TODO these should be generic, not bound to a particular FS implementation
-#if MICROPY_VFS_FAT
-#define mp_type_fileio mp_type_vfs_fat_fileio
-#define mp_type_textio mp_type_vfs_fat_textio
-#elif MICROPY_VFS_LFS1
-#define mp_type_fileio mp_type_vfs_lfs1_fileio
-#define mp_type_textio mp_type_vfs_lfs1_textio
-#elif MICROPY_VFS_LFS2
-#define mp_type_fileio mp_type_vfs_lfs2_fileio
-#define mp_type_textio mp_type_vfs_lfs2_textio
-#endif
-
 #if MICROPY_PY_PYB
 extern const struct _mp_obj_module_t pyb_module;
 #define PYB_BUILTIN_MODULE_CONSTANTS \

--- a/ports/unix/mpconfigport.h
+++ b/ports/unix/mpconfigport.h
@@ -220,9 +220,6 @@ extern const struct _mp_print_t mp_stderr_print;
 #define MICROPY_EMERGENCY_EXCEPTION_BUF_SIZE  (256)
 #define MICROPY_ASYNC_KBD_INTR      (1)
 
-#define mp_type_fileio mp_type_vfs_posix_fileio
-#define mp_type_textio mp_type_vfs_posix_textio
-
 // type definitions for the specific machine
 
 // For size_t and ssize_t

--- a/ports/unix/variants/minimal/mpconfigvariant.h
+++ b/ports/unix/variants/minimal/mpconfigvariant.h
@@ -107,9 +107,6 @@
 #define MICROPY_PY_UHASHLIB         (0)
 #define MICROPY_PY_UBINASCII        (0)
 
-#define mp_type_fileio mp_type_vfs_posix_fileio
-#define mp_type_textio mp_type_vfs_posix_textio
-
 //////////////////////////////////////////
 // Do not change anything beyond this line
 //////////////////////////////////////////

--- a/ports/windows/mpconfigport.h
+++ b/ports/windows/mpconfigport.h
@@ -176,9 +176,6 @@ extern const struct _mp_print_t mp_stderr_print;
 #define MICROPY_EMERGENCY_EXCEPTION_BUF_SIZE     (256)
 #define MICROPY_KBD_EXCEPTION       (1)
 
-#define mp_type_fileio mp_type_vfs_posix_fileio
-#define mp_type_textio mp_type_vfs_posix_textio
-
 #define MICROPY_PORT_INIT_FUNC      init()
 #define MICROPY_PORT_DEINIT_FUNC    deinit()
 

--- a/py/modio.c
+++ b/py/modio.c
@@ -37,9 +37,6 @@
 
 #if MICROPY_PY_IO
 
-extern const mp_obj_type_t mp_type_fileio;
-extern const mp_obj_type_t mp_type_textio;
-
 #if MICROPY_PY_IO_IOBASE
 
 STATIC const mp_obj_type_t mp_type_iobase;
@@ -210,12 +207,6 @@ STATIC const mp_rom_map_elem_t mp_module_io_globals_table[] = {
     { MP_ROM_QSTR(MP_QSTR_open), MP_ROM_PTR(&mp_builtin_open_obj) },
     #if MICROPY_PY_IO_IOBASE
     { MP_ROM_QSTR(MP_QSTR_IOBase), MP_ROM_PTR(&mp_type_iobase) },
-    #endif
-    #if MICROPY_PY_IO_FILEIO
-    { MP_ROM_QSTR(MP_QSTR_FileIO), MP_ROM_PTR(&mp_type_fileio) },
-    #if MICROPY_CPYTHON_COMPAT
-    { MP_ROM_QSTR(MP_QSTR_TextIOWrapper), MP_ROM_PTR(&mp_type_textio) },
-    #endif
     #endif
     { MP_ROM_QSTR(MP_QSTR_StringIO), MP_ROM_PTR(&mp_type_stringio) },
     #if MICROPY_PY_IO_BYTESIO

--- a/tests/extmod/vfs_posix.py
+++ b/tests/extmod/vfs_posix.py
@@ -43,7 +43,7 @@ f.close()
 f.close()
 
 # construct a file object using the type constructor, with a raw fileno
-f = type(f)(2)
+f = uos.fdopen(2)
 print(f)
 
 # file read


### PR DESCRIPTION
This PR removes `io.FileIO` and `io.TextIOWrapper`. These are the same same type as the default filesystem's file type (FAT on devices, Posix on Unix). Now that we have devices with LFS+FAT both enabled, they will be FAT type even if the device is using LFS.

Furthermore, `make_new` wasn't supported for LFS fileio, and it crashed for FAT fileio. The one use case of creating a (Posix) TextIOWrapper from a file handle is better supported with CPython-compatible `os.fdopen` (also added in this PR as an alias for `open`). (Note: technically fdopen should verify that the first argument is an integer, not sure this is necessary?)

Saves -116 bytes on PYBV11 and also has the benefit of further simplifying mpconfigport.h.