### PR TITLE
docs: neopixel also included in RP2 builds

### DIFF
--- a/docs/library/neopixel.rst
+++ b/docs/library/neopixel.rst
@@ -6,7 +6,7 @@
 
 This module provides a driver for WS2818 / NeoPixel LEDs.
 
-.. note:: This module is only included by default on the ESP8266 and ESP32
+.. note:: This module is only included by default on the ESP8266, ESP32 and RP2
    ports. On STM32 / Pyboard, you can `download the module
    <https://github.com/micropython/micropython/blob/master/drivers/neopixel/neopixel.py>`_
    and copy it to the filesystem.


### PR DESCRIPTION
See https://github.com/micropython/micropython/blob/master/ports/rp2/boards/manifest.py and https://github.com/micropython/micropython/blob/master/docs/rp2/quickref.rst#neopixel-and-apa106-driver