### PR TITLE
rp2040: Fix sm restart behavior.

### DIFF
--- a/ports/rp2/rp2_pio.c
+++ b/ports/rp2/rp2_pio.c
@@ -469,8 +469,8 @@ STATIC mp_obj_t rp2_state_machine_init_helper(const rp2_state_machine_obj_t *sel
     if (offset < 0) {
         rp2_pio_add_program(&rp2_pio_obj[PIO_NUM(self->pio)], args[ARG_prog].u_obj);
         offset = mp_obj_get_int(prog[PROG_OFFSET_PIO0 + PIO_NUM(self->pio)]);
-        rp2_state_machine_initial_pc[self->id] = offset;
     }
+    rp2_state_machine_initial_pc[self->id] = offset;
 
     // Compute the clock divider.
     uint16_t clkdiv_int;


### PR DESCRIPTION
The state machines were not properly restarted.
See https://forum.micropython.org/viewtopic.php?f=21&t=12776&p=69464#p69464

I have a de-ja-vue feeling about it. It may have been fixed already before.