### PR TITLE
rp2: WIZNET5K network chip using lwip using interrupt pin.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,17 +46,3 @@ genrst/
 # MacOS desktop metadata files
 ######################
 .DS_Store
-
-# VSCODE
-.vscode/*
-!.vscode/settings.json
-!.vscode/tasks.json
-!.vscode/launch.json
-!.vscode/extensions.json
-!.vscode/*.code-snippets
-
-# Local History for Visual Studio Code
-.history/
-
-# Built Visual Studio Code Extensions
-*.vsix

--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,17 @@ genrst/
 # MacOS desktop metadata files
 ######################
 .DS_Store
+
+# VSCODE
+.vscode/*
+!.vscode/settings.json
+!.vscode/tasks.json
+!.vscode/launch.json
+!.vscode/extensions.json
+!.vscode/*.code-snippets
+
+# Local History for Visual Studio Code
+.history/
+
+# Built Visual Studio Code Extensions
+*.vsix

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,4 @@
+{
+    "makefile.extensionOutputFolder": "./.vscode",
+    "cmake.configureOnOpen": false
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,4 +1,0 @@
-{
-    "makefile.extensionOutputFolder": "./.vscode",
-    "cmake.configureOnOpen": false
-}

--- a/extmod/network_wiznet5k.c
+++ b/extmod/network_wiznet5k.c
@@ -177,7 +177,14 @@ STATIC void wiznet5k_lwip_init(wiznet5k_obj_t *self);
 
 STATIC mp_obj_t mpy_wiznet_read_int(mp_obj_t none_in) {
     (void)none_in;
+    /*
     wizchip_clrinterrupt(IK_SOCK_0);
+    ** The original wizchip_clrinterrupt seems a bit buggy and if forgets to reset 
+    ** the socket irq flag register SIR but on the other hand it clears ALL flags 
+    ** for ALL sockets in Sn_IR registers.
+    ** For the time being let do it manually.
+    */
+    setSIR(0x01);
     setSn_IR(0, Sn_IR_RECV);
 
     // Handle incoming data

--- a/extmod/network_wiznet5k.c
+++ b/extmod/network_wiznet5k.c
@@ -687,7 +687,6 @@ STATIC mp_obj_t wiznet5k_make_new(const mp_obj_type_t *type, size_t n_args, size
 
     #ifdef MICROPY_HW_WIZNET_SPI_ID
     // check arguments
-    mp_arg_check_num(n_args, n_kw, 0, 3, false);
     // Allow auto-configuration of SPI if defined for board and no args passed
     if (n_args == 0) {
         // Initialize SPI.

--- a/ports/rp2/boards/W5500_EVB_PICO/board.json
+++ b/ports/rp2/boards/W5500_EVB_PICO/board.json
@@ -1,0 +1,20 @@
+{
+    "deploy": [
+        "../deploy.md"
+    ],
+    "docs": "",
+    "features": [
+        "Breadboard Friendly",
+        "Castellated Pads",
+        "Ethernet",
+        "Micro USB"
+    ],
+    "images": [
+        "W5500-EVB-Pico.jpg"
+    ],
+    "mcu": "rp2040",
+    "product": "Wiznet W5500-EVB-Pico",
+    "thumbnail": "",
+    "url": "https://www.wiznet.io/product-item/w5500-evb-pico/",
+    "vendor": "Wiznet"
+}

--- a/ports/rp2/boards/W5500_EVB_PICO/mpconfigboard.cmake
+++ b/ports/rp2/boards/W5500_EVB_PICO/mpconfigboard.cmake
@@ -1,0 +1,4 @@
+# cmake file for Wiznet W5500-EVB-Pico.
+set(PICO_BOARD pico)
+set(MICROPY_PY_NETWORK_WIZNET5K W5500)
+set(MICROPY_PY_LWIP 1)

--- a/ports/rp2/boards/W5500_EVB_PICO/mpconfigboard.h
+++ b/ports/rp2/boards/W5500_EVB_PICO/mpconfigboard.h
@@ -1,0 +1,19 @@
+// Board config for Wiznet W5500-EVB-Pico.
+
+// Board and hardware specific configuration
+#define MICROPY_HW_BOARD_NAME             "W5500-EVB-Pico"
+#define MICROPY_HW_FLASH_STORAGE_BYTES    (1408 * 1024)
+
+// Enable networking.
+#define MICROPY_PY_NETWORK                (1)
+
+// Wiznet HW config.
+#define MICROPY_HW_WIZNET_SPI_ID          (0)
+#define MICROPY_HW_WIZNET_SPI_BAUDRATE    (20 * 1000 * 1000)
+#define MICROPY_HW_WIZNET_SPI_SCK         (18)
+#define MICROPY_HW_WIZNET_SPI_MOSI        (19)
+#define MICROPY_HW_WIZNET_SPI_MISO        (16)
+#define MICROPY_HW_WIZNET_PIN_CS          (17)
+#define MICROPY_HW_WIZNET_PIN_RST         (20)
+// Connecting the INTN pin enables RECV interrupt handling of incoming data.
+#define MICROPY_HW_WIZNET_PIN_INTN        (21)

--- a/ports/rp2/boards/W5500_EVB_PICO/readme.md
+++ b/ports/rp2/boards/W5500_EVB_PICO/readme.md
@@ -1,0 +1,15 @@
+# Wiznet W5500-EVB-Pico
+
+## Network Example
+
+To use network / socket based code, connect ethernet port to network with DHCP running:
+
+```
+>>> import network
+>>> nic = network.WIZNET5K()
+>>> nic.ifconfig()
+('192.168.0.18', '255.255.255.0', '192.168.0.1', '8.8.8.8')
+>>> nic.dhcp(True)
+('192.168.0.10', '255.255.255.0', '192.168.0.1', '192.168.0.1')
+```
+At this point standard network communications libraries should work.


### PR DESCRIPTION
The original code was implementing an optional fourth parameter to the `WIZNET5K` object creation, to declare a pin that would trigger an interrupt upon TCP data reception.
This feature was blocked by a small mistake in the original function that was parsing arguments limited to 3 before allowing a 4th one.
On the other hand, the IRQ management is using a clear interrupt flags function provided by Wiznet, but according to the chip data sheet, it looks a bit buggy.
By allowing this feature, a ping request to the PICO board would go from up to 65 ms to less than a ms.