### PR TITLE
esp32: Fix TouchPad on esp32s2 and esp32s3.

### DIFF
--- a/ports/esp32/modmachine.c
+++ b/ports/esp32/modmachine.c
@@ -309,7 +309,7 @@ STATIC const mp_rom_map_elem_t machine_module_globals_table[] = {
     { MP_ROM_QSTR(MP_QSTR_DEEPSLEEP), MP_ROM_INT(MACHINE_WAKE_DEEPSLEEP) },
     { MP_ROM_QSTR(MP_QSTR_Pin), MP_ROM_PTR(&machine_pin_type) },
     { MP_ROM_QSTR(MP_QSTR_Signal), MP_ROM_PTR(&machine_signal_type) },
-    #if CONFIG_IDF_TARGET_ESP32
+    #if CONFIG_IDF_TARGET_ESP32 || CONFIG_IDF_TARGET_ESP32S2 || CONFIG_IDF_TARGET_ESP32S3
     { MP_ROM_QSTR(MP_QSTR_TouchPad), MP_ROM_PTR(&machine_touchpad_type) },
     #endif
     { MP_ROM_QSTR(MP_QSTR_ADC), MP_ROM_PTR(&machine_adc_type) },


### PR DESCRIPTION
Fixed the issue that TouchPad failed on esp32s2 and esp32s3 
after compiling firmware with ESP-IDF v4.4 and higher versions.

Addresses issue #8048 .

Solution proposed by this contributor https://github.com/micropython/micropython/issues/8048#issuecomment-1107432527 .

Tested with this code passed:

```python=
from machine import TouchPad, Pin
# ESP32S3 TouchPad on GPIO 1~14
t = TouchPad(Pin(i))
print(t.read())
```

Specific readings depend on the PCB and its peripherals.
