### PR TITLE
docs: Add details about connect command

### DIFF
--- a/docs/reference/mpremote.rst
+++ b/docs/reference/mpremote.rst
@@ -42,7 +42,7 @@ The full list of supported commands are:
 
   .. code-block:: bash
 
-      $ mpremote connect <device>
+      $ mpremote connect <device> [command]
 
   ``<device>`` may be one of:
 
@@ -53,6 +53,8 @@ The full list of supported commands are:
     command)
   - ``port:<path>``: connect to the device with the given path
   - any valid device name/path, to connect to that device
+
+  ``[command]`` can be used to run a command on the device, default is ``repl``
 
 - disconnect current device:
 
@@ -226,6 +228,8 @@ Examples
   mpremote a1
 
   mpremote connect /dev/ttyUSB0 repl
+
+  mpremote connect /dev/ttyUSB0 run local_script.py
 
   mpremote ls
 

--- a/tools/mpremote/README.md
+++ b/tools/mpremote/README.md
@@ -11,9 +11,11 @@ This will automatically connect to the device and provide an interactive REPL.
 
 The full list of supported commands are:
 
-    mpremote connect <device>        -- connect to given device
+    mpremote connect <device> [cmd]  -- connect to given device
                                         device may be: list, auto, id:x, port:x
                                         or any valid device name/path
+                                        cmd may be provided to run a command
+                                        on the given device, default is 'repl'
     mpremote disconnect              -- disconnect current device
     mpremote mount <local-dir>       -- mount local directory on device
     mpremote eval <string>           -- evaluate and print the string
@@ -62,6 +64,7 @@ Examples:
     mpremote
     mpremote a1
     mpremote connect /dev/ttyUSB0 repl
+    mpremote connect /dev/ttyUSB0 run local_script.py
     mpremote ls
     mpremote a1 ls
     mpremote exec "import micropython; micropython.mem_info()"

--- a/tools/mpremote/mpremote/main.py
+++ b/tools/mpremote/mpremote/main.py
@@ -5,16 +5,16 @@ MIT license; Copyright (c) 2019-2022 Damien P. George
 This program provides a set of utilities to interact with and automate a
 MicroPython device over a serial connection.  Commands supported are:
 
-    mpremote                         -- auto-detect, connect and enter REPL
-    mpremote <device-shortcut>       -- connect to given device
-    mpremote connect <device>        -- connect to given device
-    mpremote disconnect              -- disconnect current device
-    mpremote mount <local-dir>       -- mount local directory on device
-    mpremote eval <string>           -- evaluate and print the string
-    mpremote exec <string>           -- execute the string
-    mpremote run <script>            -- run the given local script
-    mpremote fs <command> <args...>  -- execute filesystem commands on the device
-    mpremote repl                    -- enter REPL
+    mpremote                              -- auto-detect, connect and enter REPL
+    mpremote <device-shortcut>            -- connect to given device
+    mpremote connect <device> [command]   -- connect to device and enter REPL or execute command
+    mpremote disconnect                   -- disconnect current device
+    mpremote mount <local-dir>            -- mount local directory on device
+    mpremote eval <string>                -- evaluate and print the string
+    mpremote exec <string>                -- execute the string
+    mpremote run <script>                 -- run the given local script
+    mpremote fs <command> <args...>       -- execute filesystem commands on the device
+    mpremote repl                         -- enter REPL
 """
 
 import os, sys


### PR DESCRIPTION
It's not immediately obvious from the documentation that `mpremote connect` accepts commands to execute on the device.

This PR adds an example of `mpremote connect` with a command other than `repl` and updates the supported commands list in the mpremote.rst, mpremote/README.md and mpremote/main.py files.