### PR TITLE
esp32/machine_uart: Added half-duplex mode

### DIFF
--- a/docs/library/machine.UART.rst
+++ b/docs/library/machine.UART.rst
@@ -79,6 +79,11 @@ Methods
            CTS input pin signals that the receiver is running low on buffer space.
          - ``UART.RTS | UART.CTS`` will enable both, for full hardware flow control.
 
+   On the esp32 only the following keyword-only parameter is supported:
+
+     - *half_duplex* if set to true activates the half-duplex driver to control the direction pin (rts).
+       Useful if you want to control a rs485 compatible peripheral device.
+
    On the WiPy only the following keyword-only parameter is supported:
 
      - *pins* is a 4 or 2 item list indicating the TX, RX, RTS and CTS pins (in that order).


### PR DESCRIPTION
I added this mode to enable hardware-side direction control via the mode provided by the idf library. This mode is very useful if you need to communicate via rs485. Generally, the libraries currently available try to estimate the time the packets are sent and activate the direction pin at that time. This is an approach I also used, until I came across a microprocessor with a really fast response time. In this case, the direction pin remained active for too long and some packets did not reach the device. With the mode I entered, I no longer had this problem.