### PR TITLE
ports/rp2: Add board overclock config.

### DIFF
--- a/ports/rp2/CMakeLists.txt
+++ b/ports/rp2/CMakeLists.txt
@@ -171,6 +171,7 @@ set(PICO_SDK_COMPONENTS
     hardware_uart
     hardware_watchdog
     hardware_xosc
+    hardware_vreg
     pico_base_headers
     pico_binary_info
     pico_bootrom

--- a/ports/rp2/main.c
+++ b/ports/rp2/main.c
@@ -78,6 +78,10 @@ bi_decl(bi_program_feature_group_with_flags(BINARY_INFO_TAG_MICROPYTHON,
     BI_NAMED_GROUP_SEPARATE_COMMAS | BI_NAMED_GROUP_SORT_ALPHA));
 
 int main(int argc, char **argv) {
+    vreg_set_voltage(MICROPY_HW_VREG_VOLTAGE);
+    sleep_ms(10); // Allow vreg time to stabalize
+    set_sys_clock_khz(MICROPY_HW_CLOCK_KHZ, true);
+
     #if MICROPY_HW_ENABLE_UART_REPL
     bi_decl(bi_program_feature("UART REPL"))
     setup_default_uart();

--- a/ports/rp2/mpconfigport.h
+++ b/ports/rp2/mpconfigport.h
@@ -29,6 +29,7 @@
 #include <stdint.h>
 #include "hardware/spi.h"
 #include "hardware/sync.h"
+#include "hardware/vreg.h"
 #include "pico/binary_info.h"
 #include "pico/multicore.h"
 #include "mpconfigboard.h"
@@ -43,6 +44,15 @@
 
 #ifndef MICROPY_CONFIG_ROM_LEVEL
 #define MICROPY_CONFIG_ROM_LEVEL                (MICROPY_CONFIG_ROM_LEVEL_EXTRA_FEATURES)
+#endif
+
+// RP2 specific clock & vreg configuration
+#ifndef MICROPY_HW_CLOCK_KHZ
+#define MICROPY_HW_CLOCK_KHZ                    133000
+#endif
+
+#ifndef MICROPY_HW_VREG_VOLTAGE
+#define MICROPY_HW_VREG_VOLTAGE                 VREG_VOLTAGE_DEFAULT
 #endif
 
 // Memory allocation policies


### PR DESCRIPTION
This is a first shot at implementing #8208

Some points for discussion:

* Naming things, ugh, what should these variables be called?
* The 10ms delay for vreg stabilization is... entirely without experimentation. It's what we use in PicoSystem but that number may have to be higher/lower for other frequencies. Looking at people pushing the limits of clock speed and there are delays anywhere from 1 to 1000ms. There's no SDK function or register we can poll to wait for a stable vreg. (@kilograham do you have any insight into a sensible approach here?)
* Should the delay even happen if the vreg is set to default? It could be optimized out with an ifdef.

It's worth noting that since `machine.freq(250_000_000)` does not apply an overvolt, it's suboptimal for actually *overclocking* the RP2040 since some chips (we found this out when testing PicoSystem) do not run stably without at least a modest overvolt. A default overclock for boards that benefit from it would "guarantee" (insomuch as we can do so) that a board will run at the given frequency.

The change intends to clean up this hack - https://github.com/pimoroni/micropython/commit/10c57803c032754e4323977cc815e24e092a4a5d

This will permit us to ship some more overclocked MicroPython firmware variants for boards where it makes sense- mostly stuff that does a lot of pixel-pushing like Galactic Unicorn, PicoSystem and Plasma 2040. The end-user can always use `machine.freq()` to *downclock* if they prefer power savings over raw performance.