### PR TITLE
library/time.rst: Correct error re epoch.

### DIFF
--- a/docs/library/time.rst
+++ b/docs/library/time.rst
@@ -10,8 +10,8 @@ The ``time`` module provides functions for getting the current time and date,
 measuring time intervals, and for delays.
 
 **Time Epoch**: Unix port uses standard for POSIX systems epoch of
-1970-01-01 00:00:00 UTC. However, embedded ports use epoch of
-2000-01-01 00:00:00 UTC.
+1970-01-01 00:00:00 UTC. However, some embedded ports use epoch of
+2000-01-01 00:00:00 UTC. Epoch year may be determined with ``gmtime(0)[0]``.
 
 **Maintaining actual calendar date/time**: This requires a
 Real Time Clock (RTC). On systems with underlying OS (including some


### PR DESCRIPTION
Some embedded targets use 1970 epoch.