### PR TITLE
extmod/network_wiznet5k.c: Five small bug fixes.

### DIFF
--- a/extmod/network_wiznet5k.c
+++ b/extmod/network_wiznet5k.c
@@ -177,11 +177,10 @@ STATIC void wiznet5k_lwip_init(wiznet5k_obj_t *self);
 
 STATIC mp_obj_t mpy_wiznet_read_int(mp_obj_t none_in) {
     (void)none_in;
-    wizchip_clrinterrupt(IK_SOCK_0);
-    setSn_IR(0, Sn_IR_RECV);
-
-    // Handle incoming data
-    wiznet5k_try_poll();
+    // Handle incoming data, unless the SPI bus is busy
+    if (mp_hal_pin_read(wiznet5k_obj.cs)) {
+        wiznet5k_try_poll();
+    }
     return mp_const_none;
 }
 STATIC MP_DEFINE_CONST_FUN_OBJ_1(mpy_wiznet_read_int_obj, mpy_wiznet_read_int);
@@ -343,6 +342,7 @@ void wiznet5k_poll(void) {
             }
         }
     }
+    wizchip_clrinterrupt(IK_SOCK_0);
 }
 
 #endif // MICROPY_PY_LWIP

--- a/extmod/network_wiznet5k.c
+++ b/extmod/network_wiznet5k.c
@@ -198,6 +198,16 @@ STATIC void wiznet5k_config_interrupt(bool enabled) {
         );
 }
 
+void wiznet5k_deinit(void) {
+    for (struct netif *netif = netif_list; netif != NULL; netif = netif->next) {
+        if (netif == &wiznet5k_obj.netif) {
+            netif_remove(netif);
+            netif->flags = 0;
+            break;
+        }
+    }
+}
+
 STATIC void wiznet5k_init(void) {
     // Configure wiznet for raw ethernet frame usage.
 
@@ -219,6 +229,9 @@ STATIC void wiznet5k_init(void) {
         wiznet5k_config_interrupt(true);
     }
 
+    // Deinit before a new init to clear the state from a previous activation
+    wiznet5k_deinit();
+
     // Hook the Wiznet into lwIP
     wiznet5k_lwip_init(&wiznet5k_obj);
 
@@ -227,16 +240,6 @@ STATIC void wiznet5k_init(void) {
 
     // register with network module
     mod_network_register_nic(&wiznet5k_obj);
-}
-
-void wiznet5k_deinit(void) {
-    for (struct netif *netif = netif_list; netif != NULL; netif = netif->next) {
-        if (netif == &wiznet5k_obj.netif) {
-            netif_remove(netif);
-            netif->flags = 0;
-            break;
-        }
-    }
 }
 
 STATIC void wiznet5k_send_ethernet(wiznet5k_obj_t *self, size_t len, const uint8_t *buf) {

--- a/extmod/network_wiznet5k.c
+++ b/extmod/network_wiznet5k.c
@@ -693,7 +693,7 @@ STATIC mp_obj_t wiznet5k_make_new(const mp_obj_type_t *type, size_t n_args, size
 
     #ifdef MICROPY_HW_WIZNET_SPI_ID
     // Allow auto-configuration of SPI if defined for board and no args passed
-    if (n_args == 0) {
+    if (n_args == 0 && n_kw == 0) {
         // Initialize SPI.
         mp_obj_t spi_obj = MP_OBJ_NEW_SMALL_INT(MICROPY_HW_WIZNET_SPI_SCK);
         mp_obj_t miso_obj = MP_OBJ_NEW_SMALL_INT(MICROPY_HW_WIZNET_SPI_MISO);

--- a/extmod/network_wiznet5k.c
+++ b/extmod/network_wiznet5k.c
@@ -689,8 +689,6 @@ STATIC mp_obj_t wiznet5k_make_new(const mp_obj_type_t *type, size_t n_args, size
     #endif
 
     #ifdef MICROPY_HW_WIZNET_SPI_ID
-    // check arguments
-    mp_arg_check_num(n_args, n_kw, 0, 3, false);
     // Allow auto-configuration of SPI if defined for board and no args passed
     if (n_args == 0) {
         // Initialize SPI.

--- a/extmod/network_wiznet5k.c
+++ b/extmod/network_wiznet5k.c
@@ -341,6 +341,9 @@ void wiznet5k_poll(void) {
         }
     }
     wizchip_clrinterrupt(IK_SOCK_0);
+    #if _WIZCHIP_ == W5100S
+    setSn_IR(0, Sn_IR_RECV);  // WZ5100S driver bug.
+    #endif
 }
 
 #endif // MICROPY_PY_LWIP

--- a/extmod/network_wiznet5k.c
+++ b/extmod/network_wiznet5k.c
@@ -224,6 +224,9 @@ STATIC void wiznet5k_init(void) {
 
     netif_set_link_up(&wiznet5k_obj.netif);
     netif_set_up(&wiznet5k_obj.netif);
+
+    // register with network module
+    mod_network_register_nic(&wiznet5k_obj);
 }
 
 void wiznet5k_deinit(void) {


### PR DESCRIPTION
Five small commits fixing bugs for WIZNET5K boards:

1. Register the nic with the network module. That was missing, causing the list returned by network.route() to be empty.
2. Drop and obsolete argument check in wiznet5k_make_new(). That prevented specifying a pin for the interrupt signal.
3. Deinit the nic before (re-)initialsation. Without that, calling nic.active(True) more than once in a row could lock up the device. If it was not initialized before, the deinit does not hurt.
4. Schedule clearing of the Interrupt. I was in the IRQ handler, but that caused a problem when a SPI transfer was ongoing at the time of the interrupt, because IRQ clearing starts an SPI transfer itself.
5. Check for the absence of keyword arguments when the constructor is called with default settings, as suggested by @dpgeorge.

Commits 2 though 4 are done in behalf of @omogenot, who asked me to do so.

Commit 3 effectively adds only one line, but looks larger since the deinit() function was moved avoiding a forward declaration.

The changes were tested by @omogenot on a W5500_EVB_PICO board and by me with a RP2040 pico + W5500 breakout combo. Ping times are ~0.7s for "pinging" the board and ~3 second for ping originated from the board, when interrupts are enabled. The MP test suite for Network shows a good result:
```
./run-multitests.py -i pyb:a0 multi_net/*

20 tests performed
17 tests passed
3 tests failed: multi_net/ssl_cert_rsa.py multi_net/tcp_client_rst.py multi_net/uasyncio_tcp_client_rst.py

./run-multitests.py -i micropython -i pyb:a0 multi_net/*

20 tests performed
16 tests passed
2 tests skipped: multi_net/tcp_client_rst.py multi_net/uasyncio_tcp_client_rst.py
2 tests failed: multi_net/uasyncio_tcp_readall.py multi_net/udp_data.py

python run-tests.py --target pyboard net_inet/*.py net_hosted/*.py

17 tests performed (115 individual testcases)
15 tests passed
2 tests failed: connect_nonblock_xfer test_tls_nonblock
```
