### PR TITLE
ports/[arm|xtensa]: Always include debug information in the ELF.

### DIFF
--- a/ports/esp8266/Makefile
+++ b/ports/esp8266/Makefile
@@ -68,8 +68,8 @@ LIBGCC_FILE_NAME = $(shell $(CC) $(CFLAGS) -print-libgcc-file-name)
 LIBS += -L$(dir $(LIBGCC_FILE_NAME)) -lgcc
 
 # Debugging/Optimization
+CFLAGS += -g  # always include debug info in the ELF
 ifeq ($(DEBUG), 1)
-CFLAGS += -g
 COPT = -O0
 else
 CFLAGS += -fdata-sections -ffunction-sections

--- a/ports/mimxrt/Makefile
+++ b/ports/mimxrt/Makefile
@@ -297,8 +297,9 @@ SRC_QSTR += \
 # Compiler Flags
 # =============================================================================
 
+CFLAGS += -g  # always include debug info in the ELF
 ifeq ($(DEBUG),1)
-CFLAGS += -Og -ggdb
+CFLAGS += -Og
 else
 CFLAGS += -Os -DNDEBUG
 endif

--- a/ports/minimal/Makefile
+++ b/ports/minimal/Makefile
@@ -34,8 +34,9 @@ endif
 CSUPEROPT = -Os # save some code space
 
 # Tune for Debugging or Optimization
+CFLAGS += -g  # always include debug info in the ELF
 ifeq ($(DEBUG), 1)
-CFLAGS += -O0 -ggdb
+CFLAGS += -O0
 else
 CFLAGS += -Os -DNDEBUG
 CFLAGS += -fdata-sections -ffunction-sections

--- a/ports/nrf/Makefile
+++ b/ports/nrf/Makefile
@@ -124,7 +124,7 @@ endif
 
 
 CFLAGS += $(CFLAGS_MCU_$(MCU_SERIES))
-CFLAGS += $(INC) -Wall -Werror -g -ansi -std=c11 -nostdlib $(COPT) $(NRF_DEFINES) $(CFLAGS_MOD) $(CFLAGS_EXTRA)
+CFLAGS += $(INC) -Wall -Werror -ansi -std=c11 -nostdlib $(COPT) $(NRF_DEFINES) $(CFLAGS_MOD) $(CFLAGS_EXTRA)
 CFLAGS += -fno-strict-aliasing
 CFLAGS += -Iboards/$(BOARD)
 CFLAGS += -DNRF5_HAL_H='<$(MCU_VARIANT)_hal.h>'
@@ -138,9 +138,10 @@ LDFLAGS += -Wl,'--defsym=_fs_size=$(FS_SIZE)'
 endif
 
 #Debugging/Optimization
+CFLAGS += -g  # always include debug info in the ELF
 ifeq ($(DEBUG), 1)
 #ASMFLAGS += -g -gtabs+
-CFLAGS += -O0 -ggdb
+CFLAGS += -O0
 LDFLAGS += -O0
 else
 CFLAGS += -Os -DNDEBUG

--- a/ports/renesas-ra/Makefile
+++ b/ports/renesas-ra/Makefile
@@ -148,8 +148,9 @@ CFLAGS += -fdata-sections -ffunction-sections
 LDFLAGS += --gc-sections
 
 # Debugging/Optimization
+CFLAGS += -g  # always include debug info in the ELF
 ifeq ($(DEBUG), 1)
-CFLAGS += -g -DPENDSV_DEBUG
+CFLAGS += -DPENDSV_DEBUG
 #COPT = -Og
 COPT = -Os
 # Disable text compression in debug builds

--- a/ports/samd/Makefile
+++ b/ports/samd/Makefile
@@ -57,8 +57,9 @@ LDFLAGS += $(LDFLAGS_MOD)
 LIBS = $(shell $(CC) $(CFLAGS) -print-libgcc-file-name)
 
 # Tune for Debugging or Optimization
+CFLAGS += -g  # always include debug info in the ELF
 ifeq ($(DEBUG),1)
-CFLAGS += -O0 -ggdb
+CFLAGS += -O0
 else
 CFLAGS += -Os -DNDEBUG
 LDFLAGS += --gc-sections

--- a/ports/stm32/Makefile
+++ b/ports/stm32/Makefile
@@ -114,8 +114,9 @@ $(BUILD)/stm32_it.o $(BUILD)/pendsv.o: CFLAGS += -fno-lto
 endif
 
 # Debugging/Optimization
+CFLAGS += -g  # always include debug info in the ELF
 ifeq ($(DEBUG), 1)
-CFLAGS += -g -DPENDSV_DEBUG
+CFLAGS += -DPENDSV_DEBUG
 COPT ?= -Og
 # Disable text compression in debug builds
 MICROPY_ROM_TEXT_COMPRESSION = 0

--- a/ports/teensy/Makefile
+++ b/ports/teensy/Makefile
@@ -105,8 +105,9 @@ LIBS += -L $(dir $(LIBC_FILE_NAME)) -lc
 LIBS += -L $(dir $(LIBGCC_FILE_NAME)) -lgcc
 
 #Debugging/Optimization
+CFLAGS += -g  # always include debug info in the ELF
 ifdef DEBUG
-CFLAGS += -Og -ggdb
+CFLAGS += -Og
 else
 CFLAGS += -Os #-DNDEBUG
 endif


### PR DESCRIPTION
For bare metal ARM & xtensa targets, passing -g will make the ELF file larger but doesn't change the binary size. However, this means tools like gdb, addr2line, etc can extract source-level information from the ELF.

Also standardise -ggdb to -g, these produce the exact same ELF file for me on arm-none-eabi-gcc and will use DWARF format for all these ports.