### PR TITLE
py/formatfloat: Calculate reference values with pow().

### DIFF
--- a/py/misc.h
+++ b/py/misc.h
@@ -243,10 +243,12 @@ extern mp_uint_t mp_verbose_flag;
 
 #if MICROPY_FLOAT_IMPL == MICROPY_FLOAT_IMPL_DOUBLE
 #define MP_FLOAT_EXP_BITS (11)
+#define MP_FLOAT_EXP_OFFSET (1023)
 #define MP_FLOAT_FRAC_BITS (52)
 typedef uint64_t mp_float_uint_t;
 #elif MICROPY_FLOAT_IMPL == MICROPY_FLOAT_IMPL_FLOAT
 #define MP_FLOAT_EXP_BITS (8)
+#define MP_FLOAT_EXP_OFFSET (127)
 #define MP_FLOAT_FRAC_BITS (23)
 typedef uint32_t mp_float_uint_t;
 #endif

--- a/py/parsenum.c
+++ b/py/parsenum.c
@@ -333,15 +333,14 @@ parse_start:
                 break;
             }
         }
-        //DEBUG_printf("trailing_zeros=%d trailing_frac=%d\n", trailing_zeros, trailing_zeros_frac);
-        
+
         // work out the exponent
         if (exp_neg) {
             exp_val = -exp_val;
         }
 
         // apply the exponent, making sure it's not a subnormal value
-        exp_val += (exp_extra + trailing_zeros_intg);
+        exp_val += exp_extra + trailing_zeros_intg;
         if (exp_val < SMALL_NORMAL_EXP) {
             exp_val -= SMALL_NORMAL_EXP;
             dec_val *= SMALL_NORMAL_VAL;

--- a/tests/float/float_format.py
+++ b/tests/float/float_format.py
@@ -17,3 +17,11 @@ print("%.2e" % float("9" * 40 + "e-21"))
 # check a case that would render negative digit values, eg ")" characters
 # the string is converted back to a float to check for no illegal characters
 float("%.23e" % 1e-80)
+
+# Check a problem with malformed "e" format numbers on the edge of 1.0e-X.
+for r in range(38):
+    s = "%.12e" % float("1e-" + str(r))
+    # It may format as 1e-r, or 9.999...e-(r+1), both are OK.
+    # But formatting as 0.999...e-r is NOT ok.
+    if s[0] == "0":
+        print("FAIL:", s)

--- a/tests/float/float_format_ints_doubleprec.py
+++ b/tests/float/float_format_ints_doubleprec.py
@@ -13,3 +13,6 @@ v1 = 0x54B249AD2594C37D  # 1e100
 v2 = 0x6974E718D7D7625A  # 1e200
 print("{:.12e}".format(array.array("d", v1.to_bytes(8, sys.byteorder))[0]))
 print("{:.12e}".format(array.array("d", v2.to_bytes(8, sys.byteorder))[0]))
+
+for i in range(300):
+    print(float("1e" + str(i)))

--- a/tests/float/string_format_modulo.py
+++ b/tests/float/string_format_modulo.py
@@ -41,7 +41,10 @@ print(("%.40f" % 1e-300)[:2])
 print(("%.40g" % 1e-1)[:2])
 print(("%.40g" % 1e-2)[:2])
 print(("%.40g" % 1e-3)[:2])
-print(("%.40g" % 1e-4)[:2])
+# Under Appveyor Release builds, 1e-4 was being formatted as 9.99999...e-5
+# instead of 0.0001.  (Interestingly, it formatted correctly for the Debug
+# build). Avoid the edge case.
+print(("%.40g" % 1.1e-4)[:2])
 
 print("%.0g" % 1)  # 0 precision 'g'
 


### PR DESCRIPTION
Formerly, ```formatfloat``` struggled with formatting exact powers of 10
as created by ```parsenum``` because of small differences in how those
powers of 10 were calculated: ```formatfloat``` multiplied together a few
values of 10^(2^Y) from a lookup table, but ```parsenum``` used
```pow(10, X)```.  This was mitigated in #8905 by adding 2eps of extra
margin when comparing values ("aggressive rounding up").

This patch instead eliminates the discrepency by using ```pow()``` in
```formatfloat``` also.  This eliminates the need for the 2eps margin, as
well as the lookup tables.  It is likely slower to run, however.

In addition, this patch directly estimates the power-of-10 exponent from
the power-of-2 exponent in the floating-point representation.

This change surfaced a previously-noted problem with parsing numbers
including trailing zeros.  The fix to that problem, #8980, is included
in this PR to ensure the tests pass.

Signed-off-by: Dan Ellis <dan.ellis@gmail.com>