### PR TITLE
ports/esp32-esp8266: Add support for set/get the wifi power saving mode.

### DIFF
--- a/docs/library/network.WLAN.rst
+++ b/docs/library/network.WLAN.rst
@@ -133,4 +133,20 @@ Methods
    hostname       The hostname that will be sent to DHCP (STA interfaces) and mDNS (if supported, both STA and AP). (Deprecated, use :func:`network.hostname` instead)
    reconnects     Number of reconnect attempts to make (integer, 0=none, -1=unlimited)
    txpower        Maximum transmit power in dBm (integer or float)
+   pm             WiFi Power Management setting (see below for allowed values)
    =============  ===========
+
+Constants
+---------
+
+.. data:: WLAN.PM_PERFORMANCE
+        WLAN.PM_POWERSAVE
+        WLAN.PM_NONE
+
+    Allowed values for the ``WLAN.config(pm=...)`` network interface parameter:
+
+        * ``PM_PERFORMANCE``: enable WiFi power management to balance power
+          savings and WiFi performance
+        * ``PM_POWERSAVE``: enable WiFi power management with additional power
+          savings and reduced WiFi performance
+        * ``PM_NONE``: disable wifi power management

--- a/ports/esp32/network_wlan.c
+++ b/ports/esp32/network_wlan.c
@@ -508,6 +508,10 @@ STATIC mp_obj_t network_wlan_config(size_t n_args, const mp_obj_t *args, mp_map_
                         esp_exceptions(esp_wifi_set_protocol(self->if_id, mp_obj_get_int(kwargs->table[i].value)));
                         break;
                     }
+                    case MP_QSTR_pm: {
+                        esp_exceptions(esp_wifi_set_ps(mp_obj_get_int(kwargs->table[i].value)));
+                        break;
+                    }
                     default:
                         goto unknown;
                 }
@@ -602,6 +606,12 @@ STATIC mp_obj_t network_wlan_config(size_t n_args, const mp_obj_t *args, mp_map_
             val = MP_OBJ_NEW_SMALL_INT(protocol_bitmap);
             break;
         }
+        case MP_QSTR_pm: {
+            wifi_ps_type_t ps_type;
+            esp_exceptions(esp_wifi_get_ps(&ps_type));
+            val = MP_OBJ_NEW_SMALL_INT(ps_type);
+            break;
+        }
         default:
             goto unknown;
     }
@@ -627,6 +637,11 @@ STATIC const mp_rom_map_elem_t wlan_if_locals_dict_table[] = {
     { MP_ROM_QSTR(MP_QSTR_isconnected), MP_ROM_PTR(&network_wlan_isconnected_obj) },
     { MP_ROM_QSTR(MP_QSTR_config), MP_ROM_PTR(&network_wlan_config_obj) },
     { MP_ROM_QSTR(MP_QSTR_ifconfig), MP_ROM_PTR(&esp_network_ifconfig_obj) },
+
+    // Constants
+    { MP_ROM_QSTR(MP_QSTR_PM_NONE), MP_ROM_INT(WIFI_PS_NONE) },
+    { MP_ROM_QSTR(MP_QSTR_PM_PERFORMANCE), MP_ROM_INT(WIFI_PS_MIN_MODEM) },
+    { MP_ROM_QSTR(MP_QSTR_PM_POWERSAVE), MP_ROM_INT(WIFI_PS_MAX_MODEM) },
 };
 STATIC MP_DEFINE_CONST_DICT(wlan_if_locals_dict, wlan_if_locals_dict_table);
 

--- a/ports/esp8266/network_wlan.c
+++ b/ports/esp8266/network_wlan.c
@@ -419,6 +419,10 @@ STATIC mp_obj_t esp_config(size_t n_args, const mp_obj_t *args, mp_map_t *kwargs
                         system_phy_set_max_tpw(power);
                         break;
                     }
+                    case MP_QSTR_pm: {
+                        wifi_set_sleep_type(mp_obj_get_int(kwargs->table[i].value));
+                        break;
+                    }
                     default:
                         goto unknown;
                 }
@@ -486,6 +490,10 @@ STATIC mp_obj_t esp_config(size_t n_args, const mp_obj_t *args, mp_map_t *kwargs
             val = mp_obj_new_int(wifi_get_phy_mode());
             break;
         }
+        case MP_QSTR_pm: {
+            val = MP_OBJ_NEW_SMALL_INT(wifi_get_sleep_type());
+            break;
+        }
         default:
             goto unknown;
     }
@@ -511,6 +519,11 @@ STATIC const mp_rom_map_elem_t wlan_if_locals_dict_table[] = {
     { MP_ROM_QSTR(MP_QSTR_isconnected), MP_ROM_PTR(&esp_isconnected_obj) },
     { MP_ROM_QSTR(MP_QSTR_config), MP_ROM_PTR(&esp_config_obj) },
     { MP_ROM_QSTR(MP_QSTR_ifconfig), MP_ROM_PTR(&esp_ifconfig_obj) },
+
+    // Constants
+    { MP_ROM_QSTR(MP_QSTR_PM_NONE), MP_ROM_INT(NONE_SLEEP_T) },
+    { MP_ROM_QSTR(MP_QSTR_PM_PERFORMANCE), MP_ROM_INT(MODEM_SLEEP_T) },
+    { MP_ROM_QSTR(MP_QSTR_PM_POWERSAVE), MP_ROM_INT(LIGHT_SLEEP_T) },
 };
 
 STATIC MP_DEFINE_CONST_DICT(wlan_if_locals_dict, wlan_if_locals_dict_table);


### PR DESCRIPTION
This PR adds support for setting and getting the wifi power saving mode.

Adds the `pm` option to `WLAN.config()` to support setting/getting the wifi power saving mode.

Also adds the `PM_NONE`, `PM_MIN_MODEM` and `PM_MAX_MODEM` constants to the `WLAN` class.

Example:
```
import network
sta = network.WLAN(0); sta.active(True)
sta.connect(ssid, password)
sta.config(pm=sta.PM_NONE)
```

This is especially useful for controlling power consumption on battery powered devices and is also required by PR #6515 (ESPNow support).