### PR TITLE
ports/esp32: Fix ESP32-C3 deep/light sleep wake on GPIOs support.

### DIFF
--- a/ports/esp32/machine_rtc.c
+++ b/ports/esp32/machine_rtc.c
@@ -73,7 +73,8 @@ STATIC const machine_rtc_obj_t machine_rtc_obj = {{&machine_rtc_type}};
 
 machine_rtc_config_t machine_rtc_config = {
     .ext1_pins = 0,
-    .ext0_pin = -1
+    .ext0_pin = -1,
+    .wake_pins = 0
 };
 
 STATIC mp_obj_t machine_rtc_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *args) {

--- a/ports/esp32/machine_rtc.h
+++ b/ports/esp32/machine_rtc.h
@@ -38,6 +38,8 @@ typedef struct {
     bool ext0_level : 1;
     wake_type_t ext0_wake_types;
     bool ext1_level : 1;
+    uint64_t wake_pins;
+    uint64_t wake_level : 1;
 } machine_rtc_config_t;
 
 extern machine_rtc_config_t machine_rtc_config;

--- a/ports/esp32/modesp32.h
+++ b/ports/esp32/modesp32.h
@@ -30,6 +30,32 @@
     )
     #define RTC_LAST_EXT_PIN 21
 
+#elif CONFIG_IDF_TARGET_ESP32C3
+
+    #define RTC_VALID_EXT_PINS \
+    ( \
+    (1ll << 2) | \
+    (1ll << 3) | \
+    (1ll << 4) | \
+    (1ll << 5) | \
+    (1ll << 6) | \
+    (1ll << 7) | \
+    (1ll << 8) | \
+    (1ll << 9) | \
+    (1ll << 10) | \
+    (1ll << 11) | \
+    (1ll << 12) | \
+    (1ll << 13) | \
+    (1ll << 14) | \
+    (1ll << 15) | \
+    (1ll << 16) | \
+    (1ll << 17) | \
+    (1ll << 18) | \
+    (1ll << 19) | \
+    (1ll << 21)   \
+    )
+    #define RTC_LAST_EXT_PIN 21
+
 #else
 
     #define RTC_VALID_EXT_PINS \

--- a/ports/esp32/modmachine.c
+++ b/ports/esp32/modmachine.c
@@ -160,6 +160,18 @@ STATIC mp_obj_t machine_sleep_helper(wake_type_t wake_type, size_t n_args, const
 
     #endif
 
+    #if CONFIG_IDF_TARGET_ESP32C3
+
+    if (machine_rtc_config.wake_pins != 0) {
+        if (esp_deep_sleep_enable_gpio_wakeup(
+            machine_rtc_config.wake_pins,
+            machine_rtc_config.wake_level ? ESP_GPIO_WAKEUP_GPIO_HIGH : ESP_GPIO_WAKEUP_GPIO_LOW) != ESP_OK) {
+                mp_raise_msg(&mp_type_RuntimeError, MP_ERROR_TEXT("esp_sleep_enable_gpio_wakeup() failed"));
+            }
+    }
+
+    #endif
+
     switch (wake_type) {
         case MACHINE_WAKE_SLEEP:
             esp_light_sleep_start();


### PR DESCRIPTION
Fixed the issue that machine wake up on GPIOs when deep/light sleep failed on esp32c3
after compiling firmware with ESP-IDF v4.4 and higher versions.

Tested with this code passed:
```
>>> import esp32
>>> import machine
>>> esp32.wake_on_pins([machine.Pin(4)], esp32.WAKEUP_ALL_LOW)
>>> machine.deepsleep()

# Let the GPIO4 low.

ESP-ROM:esp32c3-api1-20210207
Build:Feb  7 2021
rst:0x5 (DSLEEP),boot:0xc (SPI_FAST_FLASH_BOOT)
SPIWP:0xee
mode:DIO, clock div:1
load:0x3fcd6100,len:0xe3c
load:0x403ce000,len:0x6f4
load:0x403d0000,len:0x28d8
entry 0x403ce000
MicroPython 963e599ec-dirty on 2022-07-31; ESP32C3 module with ESP32C3
Type "help()" for more information.

>>> 
```