### PR TITLE
py/dynruntime.mk: Allow building assembly source in natmods.

### DIFF
--- a/py/dynruntime.mk
+++ b/py/dynruntime.mk
@@ -35,7 +35,7 @@ CFLAGS += -U _FORTIFY_SOURCE # prevent use of __*_chk libc functions
 
 MPY_CROSS_FLAGS += -march=$(ARCH)
 
-SRC_O += $(addprefix $(BUILD)/, $(patsubst %.c,%.o,$(filter %.c,$(SRC))))
+SRC_O += $(addprefix $(BUILD)/, $(patsubst %.c,%.o,$(filter %.c,$(SRC))) $(patsubst %.S,%.o,$(filter %.S,$(SRC))))
 SRC_MPY += $(addprefix $(BUILD)/, $(patsubst %.py,%.mpy,$(filter %.py,$(SRC))))
 
 ################################################################################
@@ -132,6 +132,11 @@ $(CONFIG_H): $(SRC)
 # Build .o from .c source files
 $(BUILD)/%.o: %.c $(CONFIG_H) Makefile
 	$(ECHO) "CC $<"
+	$(Q)$(CROSS)gcc $(CFLAGS) -o $@ -c $<
+
+# Build .o from .S source files
+$(BUILD)/%.o: %.S $(CONFIG_H) Makefile
+	$(ECHO) "AS $<"
 	$(Q)$(CROSS)gcc $(CFLAGS) -o $@ -c $<
 
 # Build .mpy from .py source files


### PR DESCRIPTION
Allow inclusion of assembly source files in dynamic native modules.

I was following the advice in #5629 and wanted to include an assembly implementation of a function in my dynamic natmod, but found the makefile would not build my assembly source files. 