### PR TITLE
minimal/Makefile: Avoid terminal reset, use BUILD variable.

### DIFF
--- a/ports/minimal/Makefile
+++ b/ports/minimal/Makefile
@@ -102,12 +102,11 @@ deploy: $(BUILD)/firmware.dfu
 
 # Run emulation build on a POSIX system with suitable terminal settings
 run:
-	stty raw opost -echo
-	build/firmware.elf
-	@echo Resetting terminal...
-# This sleep is useful to spot segfaults
-	sleep 1
-	reset
+	@saved_=`stty -g`; \
+	  stty raw opost -echo; \
+	  $(BUILD)/firmware.elf; \
+	  echo "Exit status: $$?"; \
+	  stty $$saved_
 
 test: $(BUILD)/firmware.elf
 	$(Q)/bin/echo -e "print('hello world!', list(x+1 for x in range(10)), end='eol\\\\n')\\r\\n\\x04" | $(BUILD)/firmware.elf | tail -n2 | grep "^hello world! \\[1, 2, 3, 4, 5, 6, 7, 8, 9, 10\\]eol"


### PR DESCRIPTION
stty can provide the current terminal settings, so that they can be
stored in a shell variable and restored after running the firmware. This
avoids the complete "blanking" of the terminal, and thus also removes the
need for the sleep call.

_Tested on a linux system with bash running, though AFAIK this should work basically everywhere._

The run target now references the firmware file using the BUILD variable
instead of using the hard coded "build/" path.