### PR TITLE
corrected pull_thresh docs to use pull instead of push

### DIFF
--- a/docs/library/rp2.StateMachine.rst
+++ b/docs/library/rp2.StateMachine.rst
@@ -55,8 +55,8 @@ Methods
       `PIO.SHIFT_LEFT` or `PIO.SHIFT_RIGHT`.
     - *push_thresh* is the threshold in bits before auto-push or conditional
       re-pushing is triggered.
-    - *pull_thresh* is the threshold in bits before auto-push or conditional
-      re-pushing is triggered.
+    - *pull_thresh* is the threshold in bits before auto-pull or conditional
+      re-pulling is triggered.
 
 .. method:: StateMachine.active([value])
 

--- a/docs/library/rp2.rst
+++ b/docs/library/rp2.rst
@@ -47,8 +47,8 @@ For running PIO programs, see :class:`rp2.StateMachine`.
       `PIO.SHIFT_LEFT` or `PIO.SHIFT_RIGHT`.
     - *push_thresh* is the threshold in bits before auto-push or conditional
       re-pushing is triggered.
-    - *pull_thresh* is the threshold in bits before auto-push or conditional
-      re-pushing is triggered.
+    - *pull_thresh* is the threshold in bits before auto-pull or conditional
+      re-pulling is triggered.
 
     The remaining parameters are:
 


### PR DESCRIPTION
I'm pretty sure there is a copy-paste error in the documentation for `rp2.asm_pio()`.  Below is a snippet from the original docs.  Under the bullet point for `pull_thresh` the verb "push" is used.  I've changed it to use "pull".

> - push_thresh is the threshold in bits before auto-push or conditional re-pushing is triggered.
> - pull_thresh is the threshold in bits before auto-push or conditional re-pushing is triggered.

[https://docs.micropython.org/en/latest/library/rp2.html](https://docs.micropython.org/en/latest/library/rp2.html)

It is possible that I don't understand the function parameter, and that my correction is wrong.  Sorry if that's the case.