### PR TITLE
ports/esp32: Deinit wifi peripheral on soft_reset and stop wifi before light/deep sleep.

### DIFF
--- a/ports/esp32/main.c
+++ b/ports/esp32/main.c
@@ -190,6 +190,8 @@ soft_reset_exit:
     mp_bluetooth_deinit();
     #endif
 
+    network_wlan_deinit_wifi();
+
     machine_timer_deinit_all();
 
     #if MICROPY_PY_THREAD

--- a/ports/esp32/modmachine.c
+++ b/ports/esp32/modmachine.c
@@ -57,6 +57,7 @@
 #include "extmod/machine_i2c.h"
 #include "extmod/machine_spi.h"
 #include "modmachine.h"
+#include "modnetwork.h"
 #include "machine_rtc.h"
 
 #if MICROPY_PY_MACHINE
@@ -172,11 +173,13 @@ STATIC mp_obj_t machine_sleep_helper(wake_type_t wake_type, size_t n_args, const
 }
 
 STATIC mp_obj_t machine_lightsleep(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
+    network_wlan_stop_wifi();  // Else wlan may be unusable after wakeup
     return machine_sleep_helper(MACHINE_WAKE_SLEEP, n_args, pos_args, kw_args);
 };
 STATIC MP_DEFINE_CONST_FUN_OBJ_KW(machine_lightsleep_obj, 0, machine_lightsleep);
 
 STATIC mp_obj_t machine_deepsleep(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
+    network_wlan_stop_wifi();  // Else wlan may be unusable after wakeup
     return machine_sleep_helper(MACHINE_WAKE_DEEPSLEEP, n_args, pos_args, kw_args);
 };
 STATIC MP_DEFINE_CONST_FUN_OBJ_KW(machine_deepsleep_obj, 0,  machine_deepsleep);

--- a/ports/esp32/modnetwork.h
+++ b/ports/esp32/modnetwork.h
@@ -60,5 +60,8 @@ static inline void esp_exceptions(esp_err_t e) {
 
 void usocket_events_deinit(void);
 void network_wlan_event_handler(system_event_t *event);
+void network_wlan_init_wifi();
+void network_wlan_deinit_wifi();
+void network_wlan_stop_wifi();
 
 #endif


### PR DESCRIPTION
This PR adds support for deinitialising the wifi peripheral prior to performing a soft reset. Besides calling esp_wifi_deinit(), it also resets the static state variables in network_wlan.c to their default values.

In this way, the wifi peripheral is always in a known state after a soft reset.

Adds:

- `network_wlan_deinit_wifi()`, `network_wlan_stop_wifi()`, and `network_wlan_init_wifi()` to `network_wlan.c`;
- `WLAN.deinit()` method;
  - so users can invoke a reset of the wifi peripheral and module state 
  - (as well as freeing wifi and mdns resources).
- call to `network_wlan_deinit_wifi()` before soft_reset in `main.c`; and
- calls to `network_wlan_stop_wifi()` before light or deep sleep in `machine.c`;
  - as recommended in [Wifi/Bluetooth and Sleep Modes](https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-reference/system/sleep_modes.html#wi-fi-bluetooth-and-sleep-modes)
    - else the wifi peripheral **may** become unusable after light/deep sleep.


Resolves #8994.