### PR TITLE
ports/renesas-ra: Update linker script to detect code flash overflow.

### DIFF
--- a/docs/renesas-ra/tutorial/program_in_flash.rst
+++ b/docs/renesas-ra/tutorial/program_in_flash.rst
@@ -18,7 +18,7 @@ As the factory setting, following size is allocated for the file system:
 ---------------  -------------------
  EK-RA4M1           36KB ( 36864B)
  EK-RA4W1           64KB ( 65536B)
- EK-RA6M1          128KB (131072B)
+ EK-RA6M1           64KB ( 65536B)
  EK-RA6M2          128KB (131072B)
  RA4M1 CLICKER      36KB ( 36864B)
 ===============  ===================

--- a/docs/renesas-ra/tutorial/program_in_flash.rst
+++ b/docs/renesas-ra/tutorial/program_in_flash.rst
@@ -19,7 +19,7 @@ As the factory setting, following size is allocated for the file system:
  EK-RA4M1           36KB ( 36864B)
  EK-RA4W1           64KB ( 65536B)
  EK-RA6M1          128KB (131072B)
- EK-RA6M2          256KB (262144B)
+ EK-RA6M2          128KB (131072B)
  RA4M1 CLICKER      36KB ( 36864B)
 ===============  ===================
 

--- a/ports/renesas-ra/boards/RA4M1_CLICKER/ra4m1_clicker.ld
+++ b/ports/renesas-ra/boards/RA4M1_CLICKER/ra4m1_clicker.ld
@@ -5,7 +5,8 @@
 /* Linker script to configure memory regions. */
 MEMORY
 {
-  FLASH (rx)         : ORIGIN = 0x00000000, LENGTH = 0x00040000  /* 256KB */
+  FLASH (rx)         : ORIGIN = 0x00000000, LENGTH = 0x00037000  /* 220KB/256KB */
+  FLASH_FS (r)       : ORIGIN = 0x00037000, LENGTH = 0x00009000  /* 36KB/256KB */
   RAM (rwx)          : ORIGIN = 0x20000000, LENGTH = 0x00008000  /* 32KB */
   DATA_FLASH (rx)    : ORIGIN = 0x40100000, LENGTH = 0x00002000  /* 8KB */
   ID_CODE (rx)       : ORIGIN = 0x01010018, LENGTH = 0x00000020  /* 32bytes */
@@ -296,3 +297,6 @@ _ram_start = ORIGIN(RAM);
 _ram_end = ORIGIN(RAM) + LENGTH(RAM);
 _heap_start = __HeapBase;	/* heap starts just after statically allocated memory */
 _heap_end = __HeapLimit;	/* tunable */
+
+_micropy_hw_internal_flash_storage_start = ORIGIN(FLASH_FS);
+_micropy_hw_internal_flash_storage_end   = ORIGIN(FLASH_FS) + LENGTH(FLASH_FS);

--- a/ports/renesas-ra/boards/RA4M1_EK/ra4m1_ek.ld
+++ b/ports/renesas-ra/boards/RA4M1_EK/ra4m1_ek.ld
@@ -5,7 +5,8 @@
 /* Linker script to configure memory regions. */
 MEMORY
 {
-  FLASH (rx)         : ORIGIN = 0x00000000, LENGTH = 0x00040000  /* 256KB */
+  FLASH (rx)         : ORIGIN = 0x00000000, LENGTH = 0x00037000  /* 220KB/256KB */
+  FLASH_FS (r)       : ORIGIN = 0x00037000, LENGTH = 0x00009000  /* 36KB/256KB */
   RAM (rwx)          : ORIGIN = 0x20000000, LENGTH = 0x00008000  /* 32KB */
   DATA_FLASH (rx)    : ORIGIN = 0x40100000, LENGTH = 0x00002000  /* 8KB */
   ID_CODE (rx)       : ORIGIN = 0x01010018, LENGTH = 0x00000020  /* 32bytes */
@@ -296,3 +297,6 @@ _ram_start = ORIGIN(RAM);
 _ram_end = ORIGIN(RAM) + LENGTH(RAM);
 _heap_start = __HeapBase;	/* heap starts just after statically allocated memory */
 _heap_end = __HeapLimit;	/* tunable */
+
+_micropy_hw_internal_flash_storage_start = ORIGIN(FLASH_FS);
+_micropy_hw_internal_flash_storage_end   = ORIGIN(FLASH_FS) + LENGTH(FLASH_FS);

--- a/ports/renesas-ra/boards/RA4W1_EK/ra4w1_ek.ld
+++ b/ports/renesas-ra/boards/RA4W1_EK/ra4w1_ek.ld
@@ -5,7 +5,8 @@
 /* Linker script to configure memory regions. */
 MEMORY
 {
-  FLASH (rx)         : ORIGIN = 0x00000000, LENGTH = 0x00080000  /* 512KB */
+  FLASH (rx)         : ORIGIN = 0x00000000, LENGTH = 0x00070000  /* 448KB/512KB */
+  FLASH_FS (r)       : ORIGIN = 0x00070000, LENGTH = 0x00010000  /* 64KB/512KB */
   RAM (rwx)          : ORIGIN = 0x20000000, LENGTH = 0x00018000  /* 96KB */
   DATA_FLASH (rx)    : ORIGIN = 0x40100000, LENGTH = 0x00002000  /* 8KB */
   ID_CODE (rx)       : ORIGIN = 0x01010018, LENGTH = 0x00000020  /* 32bytes */
@@ -296,3 +297,6 @@ _ram_start = ORIGIN(RAM);
 _ram_end = ORIGIN(RAM) + LENGTH(RAM);
 _heap_start = __HeapBase;	/* heap starts just after statically allocated memory */
 _heap_end = __HeapLimit;	/* tunable */
+
+_micropy_hw_internal_flash_storage_start = ORIGIN(FLASH_FS);
+_micropy_hw_internal_flash_storage_end   = ORIGIN(FLASH_FS) + LENGTH(FLASH_FS);

--- a/ports/renesas-ra/boards/RA6M1_EK/ra6m1_ek.ld
+++ b/ports/renesas-ra/boards/RA6M1_EK/ra6m1_ek.ld
@@ -5,8 +5,8 @@
 /* Linker script to configure memory regions. */
 MEMORY
 {
-  FLASH (rx)         : ORIGIN = 0x00000000, LENGTH = 0x00060000  /* 384KB/512KB */
-  FLASH_FS (r)       : ORIGIN = 0x00060000, LENGTH = 0x00020000  /* 128KB/512KB */
+  FLASH (rx)         : ORIGIN = 0x00000000, LENGTH = 0x00070000  /* 448KB/512KB */
+  FLASH_FS (r)       : ORIGIN = 0x00070000, LENGTH = 0x00010000  /* 64KB/512KB */
   RAM (rwx)          : ORIGIN = 0x1FFE0000, LENGTH = 0x00040000  /* 256KB */
   DATA_FLASH (rx)    : ORIGIN = 0x40100000, LENGTH = 0x00002000  /* 8KB */
   ID_CODE (rx)       : ORIGIN = 0x0100A150, LENGTH = 0x00000010  /* 32bytes */

--- a/ports/renesas-ra/boards/RA6M1_EK/ra6m1_ek.ld
+++ b/ports/renesas-ra/boards/RA6M1_EK/ra6m1_ek.ld
@@ -5,7 +5,8 @@
 /* Linker script to configure memory regions. */
 MEMORY
 {
-  FLASH (rx)         : ORIGIN = 0x00000000, LENGTH = 0x00080000  /* 512KB */
+  FLASH (rx)         : ORIGIN = 0x00000000, LENGTH = 0x00060000  /* 384KB/512KB */
+  FLASH_FS (r)       : ORIGIN = 0x00060000, LENGTH = 0x00020000  /* 128KB/512KB */
   RAM (rwx)          : ORIGIN = 0x1FFE0000, LENGTH = 0x00040000  /* 256KB */
   DATA_FLASH (rx)    : ORIGIN = 0x40100000, LENGTH = 0x00002000  /* 8KB */
   ID_CODE (rx)       : ORIGIN = 0x0100A150, LENGTH = 0x00000010  /* 32bytes */
@@ -296,3 +297,6 @@ _ram_start = ORIGIN(RAM);
 _ram_end = ORIGIN(RAM) + LENGTH(RAM);
 _heap_start = __HeapBase;	/* heap starts just after statically allocated memory */
 _heap_end = __HeapLimit;	/* tunable */
+
+_micropy_hw_internal_flash_storage_start = ORIGIN(FLASH_FS);
+_micropy_hw_internal_flash_storage_end   = ORIGIN(FLASH_FS) + LENGTH(FLASH_FS);

--- a/ports/renesas-ra/boards/RA6M2_EK/ra6m2_ek.ld
+++ b/ports/renesas-ra/boards/RA6M2_EK/ra6m2_ek.ld
@@ -5,7 +5,8 @@
 /* Linker script to configure memory regions. */
 MEMORY
 {
-  FLASH (rx)         : ORIGIN = 0x00000000, LENGTH = 0x00100000  /* 1MB */
+  FLASH (rx)         : ORIGIN = 0x00000000, LENGTH = 0x000e0000  /* 896KB/1MB */
+  FLASH_FS (r)       : ORIGIN = 0x000e0000, LENGTH = 0x00020000  /* 128KB/1MB */
   RAM (rwx)          : ORIGIN = 0x1FFE0000, LENGTH = 0x00060000  /* 384KB */
   DATA_FLASH (rx)    : ORIGIN = 0x40100000, LENGTH = 0x00008000  /* 32KB */
   ID_CODE (rx)       : ORIGIN = 0x0100A150, LENGTH = 0x00000010  /* 32bytes */
@@ -296,3 +297,6 @@ _ram_start = ORIGIN(RAM);
 _ram_end = ORIGIN(RAM) + LENGTH(RAM);
 _heap_start = __HeapBase;	/* heap starts just after statically allocated memory */
 _heap_end = __HeapLimit;	/* tunable */
+
+_micropy_hw_internal_flash_storage_start = ORIGIN(FLASH_FS);
+_micropy_hw_internal_flash_storage_end   = ORIGIN(FLASH_FS) + LENGTH(FLASH_FS);

--- a/ports/renesas-ra/build_all_boards.sh
+++ b/ports/renesas-ra/build_all_boards.sh
@@ -2,8 +2,8 @@
 set -eu -o pipefail
 export BOARD="RA4M1_CLICKER"
 DT=`date +%Y%m%d%H%M`
-make DEBUG=1 BOARD=${BOARD} clean 2>&1 | tee ${BOARD}_build_${DT}.log
-make DEBUG=1 BOARD=${BOARD}       2>&1 | tee -a ${BOARD}_build_${DT}.log
+make DEBUG=0 BOARD=${BOARD} clean 2>&1 | tee ${BOARD}_build_${DT}.log
+make DEBUG=0 BOARD=${BOARD}       2>&1 | tee -a ${BOARD}_build_${DT}.log
 #
 export BOARD="RA6M2_EK"
 DT=`date +%Y%m%d%H%M`
@@ -12,13 +12,13 @@ make DEBUG=1 BOARD=${BOARD}       2>&1 | tee -a ${BOARD}_build_${DT}.log
 #
 export BOARD="RA4M1_EK"
 DT=`date +%Y%m%d%H%M`
-make DEBUG=1 BOARD=${BOARD} clean 2>&1 | tee ${BOARD}_build_${DT}.log
-make DEBUG=1 BOARD=${BOARD}       2>&1 | tee -a ${BOARD}_build_${DT}.log
+make DEBUG=0 BOARD=${BOARD} clean 2>&1 | tee ${BOARD}_build_${DT}.log
+make DEBUG=0 BOARD=${BOARD}       2>&1 | tee -a ${BOARD}_build_${DT}.log
 #
 export BOARD="RA4W1_EK"
 DT=`date +%Y%m%d%H%M`
-make DEBUG=1 BOARD=${BOARD} clean 2>&1 | tee ${BOARD}_build_${DT}.log
-make DEBUG=1 BOARD=${BOARD}       2>&1 | tee -a ${BOARD}_build_${DT}.log
+make DEBUG=0 BOARD=${BOARD} clean 2>&1 | tee ${BOARD}_build_${DT}.log
+make DEBUG=0 BOARD=${BOARD}       2>&1 | tee -a ${BOARD}_build_${DT}.log
 #
 export BOARD="RA6M1_EK"
 DT=`date +%Y%m%d%H%M`

--- a/ports/renesas-ra/flashbdev.c
+++ b/ports/renesas-ra/flashbdev.c
@@ -34,64 +34,29 @@
 #include "led.h"
 #include "flash.h"
 #include "storage.h"
-#if defined(RA4M1) | defined(RA4M3) | defined(RA4W1) | defined(RA6M1) | defined(RA6M2) | defined(RA6M3)
 #include "ra_flash.h"
-#endif
 
 #if MICROPY_HW_ENABLE_INTERNAL_FLASH_STORAGE
 
-// #define DEBUG_FLASH_BDEV
+// The linker script specifies flash storage locations.
+extern uint8_t _micropy_hw_internal_flash_storage_start;
+extern uint8_t _micropy_hw_internal_flash_storage_end;
 
-// Here we try to automatically configure the location and size of the flash
-// pages to use for the internal storage.  We also configure the location of the
-// cache used for writing.
+#define FLASH_MEM_SEG1_START_ADDR \
+    ((long)&_micropy_hw_internal_flash_storage_start)
+#define FLASH_MEM_SEG1_NUM_BLOCKS \
+    ((&_micropy_hw_internal_flash_storage_end - &_micropy_hw_internal_flash_storage_start) / 512)
 
-#if defined(RA4M1)
-
-STATIC byte flash_cache_mem[0x800] __attribute__((aligned(16))); // 2K
-#define CACHE_MEM_START_ADDR (&flash_cache_mem[0])
+#if defined(RA4M1) | defined(RA4M3) | defined(RA4W1)
 #define FLASH_SECTOR_SIZE_MAX (0x800)           // 2k max
-#define FLASH_MEM_SEG1_START_ADDR (0x37000)     // sector 1
-#define FLASH_MEM_SEG1_NUM_BLOCKS (72)          // sectors 1,2,...,72
-
-#elif defined(RA4M3)
-STATIC byte flash_cache_mem[0x800] __attribute__((aligned(16))); // 2K
-#define CACHE_MEM_START_ADDR (&flash_cache_mem[0])
-#define FLASH_SECTOR_SIZE_MAX (0x800)           // 2k max
-#define FLASH_MEM_SEG1_START_ADDR (0x37000)     // sector 1
-#define FLASH_MEM_SEG1_NUM_BLOCKS (72)          // sectors 1,2,...,72
-
-#elif defined(RA4W1)
-STATIC byte flash_cache_mem[0x800] __attribute__((aligned(16))); // 2K
-#define CACHE_MEM_START_ADDR (&flash_cache_mem[0])
-#define FLASH_SECTOR_SIZE_MAX (0x800)           // 2k max
-#define FLASH_MEM_SEG1_START_ADDR (0x70000)     // sector 1
-#define FLASH_MEM_SEG1_NUM_BLOCKS (128)         // sectors 1,2,...,128
-
-#elif defined(RA6M1)
-STATIC byte flash_cache_mem[0x8000] __attribute__((aligned(16))); // 32K
-#define CACHE_MEM_START_ADDR (&flash_cache_mem[0])
+#elif defined(RA6M1) | defined(RA6M2) | defined(RA6M3)
 #define FLASH_SECTOR_SIZE_MAX (0x8000)          // 32k max
-#define FLASH_MEM_SEG1_START_ADDR (0x60000)     // sector 1
-#define FLASH_MEM_SEG1_NUM_BLOCKS (256)         // sectors 1,2,...,256
-
-#elif defined(RA6M2)
-STATIC byte flash_cache_mem[0x8000] __attribute__((aligned(16))); // 32K
-#define CACHE_MEM_START_ADDR (&flash_cache_mem[0])
-#define FLASH_SECTOR_SIZE_MAX (0x8000)          // 32k max
-#define FLASH_MEM_SEG1_START_ADDR (0xe0000)     // sector 1
-#define FLASH_MEM_SEG1_NUM_BLOCKS (512)         // sectors 1,2,...,512
-
-#elif defined(RA6M3)
-STATIC byte flash_cache_mem[0x8000] __attribute__((aligned(16))); // 32K
-#define CACHE_MEM_START_ADDR (&flash_cache_mem[0])
-#define FLASH_SECTOR_SIZE_MAX (0x8000)          // 32k max
-#define FLASH_MEM_SEG1_START_ADDR (0x60000)     // sector 1
-#define FLASH_MEM_SEG1_NUM_BLOCKS (256)         // sectors 1,2,...,256
-
 #else
 #error "no internal flash storage support for this MCU"
 #endif
+
+STATIC byte flash_cache_mem[FLASH_SECTOR_SIZE_MAX] __attribute__((aligned(16)));
+#define CACHE_MEM_START_ADDR (&flash_cache_mem[0])
 
 #if !defined(FLASH_MEM_SEG2_START_ADDR)
 #define FLASH_MEM_SEG2_START_ADDR (0) // no second segment


### PR DESCRIPTION
This PR solves code flash overflow issue.  
The latest code increases about 6KB on RA4M1 board and code image breaks the internal file system area.
So update followings:

* Update linker script to detect Code Flash overflow.
* Enable configurable ADC, SPI and I2c to reduce code.
* Update optional feature description for RA4M1 boards.
* Fix internal flash file system size for RA6M2 boards.