### PR TITLE
Outputs in build directory

### DIFF
--- a/.github/workflows/ports_unix.yml
+++ b/.github/workflows/ports_unix.yml
@@ -35,7 +35,7 @@ jobs:
       env:
         SOURCE_DATE_EPOCH: 1234567890
     - name: Check reproducible build date
-      run: echo | ports/unix/micropython-minimal -i | grep 'on 2009-02-13;'
+      run: echo | ports/unix/build-minimal/micropython-minimal -i | grep 'on 2009-02-13;'
 
   standard:
     runs-on: ubuntu-latest

--- a/examples/embedding/Makefile
+++ b/examples/embedding/Makefile
@@ -1,6 +1,6 @@
 MPTOP = ../..
 CFLAGS = -std=c99 -I. -I$(MPTOP) -DNO_QSTR
-LDFLAGS = -L.
+LDFLAGS = -L./build
 
 hello-embed: hello-embed.o -lmicropython
 

--- a/ports/unix/Makefile
+++ b/ports/unix/Makefile
@@ -304,18 +304,18 @@ include $(TOP)/py/mkrules.mk
 
 .PHONY: test test_full
 
-test: $(PROG) $(TOP)/tests/run-tests.py
+test: $(BUILD)/$(PROG) $(TOP)/tests/run-tests.py
 	$(eval DIRNAME=ports/$(notdir $(CURDIR)))
-	cd $(TOP)/tests && MICROPY_MICROPYTHON=../$(DIRNAME)/$(PROG) ./run-tests.py
+	cd $(TOP)/tests && MICROPY_MICROPYTHON=../$(DIRNAME)/$(BUILD)/$(PROG) ./run-tests.py
 
-test_full: $(PROG) $(TOP)/tests/run-tests.py
+test_full: $(BUILD)/$(PROG) $(TOP)/tests/run-tests.py
 	$(eval DIRNAME=ports/$(notdir $(CURDIR)))
-	cd $(TOP)/tests && MICROPY_MICROPYTHON=../$(DIRNAME)/$(PROG) ./run-tests.py
-	cd $(TOP)/tests && MICROPY_MICROPYTHON=../$(DIRNAME)/$(PROG) ./run-tests.py -d thread
-	cd $(TOP)/tests && MICROPY_MICROPYTHON=../$(DIRNAME)/$(PROG) ./run-tests.py --emit native
-	cd $(TOP)/tests && MICROPY_MICROPYTHON=../$(DIRNAME)/$(PROG) ./run-tests.py --via-mpy $(RUN_TESTS_MPY_CROSS_FLAGS) -d basics float micropython
-	cd $(TOP)/tests && MICROPY_MICROPYTHON=../$(DIRNAME)/$(PROG) ./run-tests.py --via-mpy $(RUN_TESTS_MPY_CROSS_FLAGS) --emit native -d basics float micropython
-	cat $(TOP)/tests/basics/0prelim.py | ./$(PROG) | grep -q 'abc'
+	cd $(TOP)/tests && MICROPY_MICROPYTHON=../$(DIRNAME)/$(BUILD)/$(PROG) ./run-tests.py
+	cd $(TOP)/tests && MICROPY_MICROPYTHON=../$(DIRNAME)/$(BUILD)/$(PROG) ./run-tests.py -d thread
+	cd $(TOP)/tests && MICROPY_MICROPYTHON=../$(DIRNAME)/$(BUILD)/$(PROG) ./run-tests.py --emit native
+	cd $(TOP)/tests && MICROPY_MICROPYTHON=../$(DIRNAME)/$(BUILD)/$(PROG) ./run-tests.py --via-mpy $(RUN_TESTS_MPY_CROSS_FLAGS) -d basics float micropython
+	cd $(TOP)/tests && MICROPY_MICROPYTHON=../$(DIRNAME)/$(BUILD)/$(PROG) ./run-tests.py --via-mpy $(RUN_TESTS_MPY_CROSS_FLAGS) --emit native -d basics float micropython
+	cat $(TOP)/tests/basics/0prelim.py | ./$(BUILD)/$(PROG) | grep -q 'abc'
 
 test_gcov: test_full
 	gcov -o $(BUILD)/py $(TOP)/py/*.c
@@ -346,9 +346,9 @@ $(BUILD)/lib/libffi/include/ffi.h: $(TOP)/lib/libffi/configure
 PREFIX = /usr/local
 BINDIR = $(DESTDIR)$(PREFIX)/bin
 
-install: $(PROG)
+install: $(BUILD)/$(PROG)
 	install -d $(BINDIR)
-	install $(PROG) $(BINDIR)/$(PROG)
+	install $(BUILD)/$(PROG) $(BINDIR)/$(PROG)
 
 uninstall:
 	-rm $(BINDIR)/$(PROG)

--- a/py/dynruntime.mk
+++ b/py/dynruntime.mk
@@ -7,7 +7,7 @@ ECHO = @echo
 RM = /bin/rm
 MKDIR = /bin/mkdir
 PYTHON = python3
-MPY_CROSS = $(MPY_DIR)/mpy-cross/mpy-cross
+MPY_CROSS = $(MPY_DIR)/mpy-cross/build/mpy-cross
 MPY_TOOL = $(PYTHON) $(MPY_DIR)/tools/mpy-tool.py
 MPY_LD = $(PYTHON) $(MPY_DIR)/tools/mpy_ld.py
 

--- a/py/mkenv.mk
+++ b/py/mkenv.mk
@@ -61,8 +61,8 @@ MPY_LIB_SUBMODULE_DIR = $(TOP)/lib/micropython-lib
 MPY_LIB_DIR = $(MPY_LIB_SUBMODULE_DIR)
 
 ifeq ($(MICROPY_MPYCROSS),)
-MICROPY_MPYCROSS = $(TOP)/mpy-cross/mpy-cross
-MICROPY_MPYCROSS_DEPENDENCY = $(MICROPY_MPYCROSS)
+MICROPY_MPYCROSS = $(TOP)/mpy-cross/build/mpy-cross
+MICROPY_MPYCROSS_DEPENDENCY = $(TOP)/mpy-cross/build/mpy-cross
 endif
 
 all:

--- a/py/mkrules.cmake
+++ b/py/mkrules.cmake
@@ -193,7 +193,7 @@ if(MICROPY_FROZEN_MANIFEST)
     # to automatically build mpy-cross if needed.
     set(MICROPY_MPYCROSS $ENV{MICROPY_MPYCROSS})
     if(NOT MICROPY_MPYCROSS)
-        set(MICROPY_MPYCROSS_DEPENDENCY ${MICROPY_DIR}/mpy-cross/mpy-cross)
+        set(MICROPY_MPYCROSS_DEPENDENCY ${MICROPY_DIR}/mpy-cross/build/mpy-cross)
         if(NOT MICROPY_MAKE_EXECUTABLE)
             set(MICROPY_MAKE_EXECUTABLE make)
         endif()

--- a/py/mkrules.mk
+++ b/py/mkrules.mk
@@ -159,11 +159,9 @@ $(OBJ_DIRS):
 $(HEADER_BUILD):
 	$(MKDIR) -p $@
 
-ifneq ($(MICROPY_MPYCROSS_DEPENDENCY),)
 # to automatically build mpy-cross, if needed
-$(MICROPY_MPYCROSS_DEPENDENCY):
-	$(MAKE) -C $(dir $@)
-endif
+$(TOP)/mpy-cross/build/mpy-cross:
+	$(MAKE) -C $(TOP)/mpy-cross
 
 ifneq ($(FROZEN_DIR),)
 $(error Support for FROZEN_DIR was removed. Please use manifest.py instead, see https://docs.micropython.org/en/latest/reference/manifest.html)

--- a/py/mkrules.mk
+++ b/py/mkrules.mk
@@ -196,9 +196,9 @@ ifneq (,$(findstring mingw,$(COMPILER_TARGET)))
 PROG := $(PROG).exe
 endif
 
-all: $(PROG)
+all: $(BUILD)/$(PROG)
 
-$(PROG): $(OBJ)
+$(BUILD)/$(PROG): $(OBJ)
 	$(ECHO) "LINK $@"
 # Do not pass COPT here - it's *C* compiler optimizations. For example,
 # we may want to compile using Thumb, but link with non-Thumb libc.
@@ -210,8 +210,8 @@ endif
 
 clean: clean-prog
 clean-prog:
-	$(RM) -f $(PROG)
-	$(RM) -f $(PROG).map
+	$(RM) -f $(BUILD)/$(PROG)
+	$(RM) -f $(BUILD)/$(PROG).map
 
 .PHONY: clean-prog
 endif
@@ -231,8 +231,8 @@ LIBMICROPYTHON = libmicropython.a
 # with 3rd-party projects which don't have proper dependency
 # tracking. Then LIBMICROPYTHON_EXTRA_CMD can e.g. touch some
 # other file to cause needed effect, e.g. relinking with new lib.
-lib $(LIBMICROPYTHON): $(OBJ)
-	$(Q)$(AR) rcs $(LIBMICROPYTHON) $^
+lib $(BUILD)/$(LIBMICROPYTHON): $(OBJ)
+	$(Q)$(AR) rcs $(BUILD)/$(LIBMICROPYTHON) $^
 	$(LIBMICROPYTHON_EXTRA_CMD)
 
 clean:

--- a/tests/run-natmodtests.py
+++ b/tests/run-natmodtests.py
@@ -14,7 +14,7 @@ import pyboard
 
 # Paths for host executables
 CPYTHON3 = os.getenv("MICROPY_CPYTHON3", "python3")
-MICROPYTHON = os.getenv("MICROPY_MICROPYTHON", "../ports/unix/micropython-coverage")
+MICROPYTHON = os.getenv("MICROPY_MICROPYTHON", "../ports/unix/build-coverage/micropython-coverage")
 
 NATMOD_EXAMPLE_DIR = "../examples/natmod/"
 

--- a/tests/run-tests.py
+++ b/tests/run-tests.py
@@ -31,18 +31,20 @@ def base_path(*p):
 if os.name == "nt":
     CPYTHON3 = os.getenv("MICROPY_CPYTHON3", "python")
     MICROPYTHON = os.getenv("MICROPY_MICROPYTHON", base_path("../ports/windows/micropython.exe"))
+    # mpy-cross is only needed if --via-mpy command-line arg is passed
+    MPYCROSS = os.getenv("MICROPY_MPYCROSS", base_path("../mpy-cross/mpy-cross.exe"))
 else:
     CPYTHON3 = os.getenv("MICROPY_CPYTHON3", "python3")
     MICROPYTHON = os.getenv(
         "MICROPY_MICROPYTHON", base_path("../ports/unix/build-standard/micropython")
     )
+    # mpy-cross is only needed if --via-mpy command-line arg is passed
+    MPYCROSS = os.getenv("MICROPY_MPYCROSS", base_path("../mpy-cross/build/mpy-cross"))
 
 # Use CPython options to not save .pyc files, to only access the core standard library
 # (not site packages which may clash with u-module names), and improve start up time.
 CPYTHON3_CMD = [CPYTHON3, "-BS"]
 
-# mpy-cross is only needed if --via-mpy command-line arg is passed
-MPYCROSS = os.getenv("MICROPY_MPYCROSS", base_path("../mpy-cross/build/mpy-cross"))
 
 # For diff'ing test output
 DIFF = os.getenv("MICROPY_DIFF", "diff -u")

--- a/tests/run-tests.py
+++ b/tests/run-tests.py
@@ -33,14 +33,16 @@ if os.name == "nt":
     MICROPYTHON = os.getenv("MICROPY_MICROPYTHON", base_path("../ports/windows/micropython.exe"))
 else:
     CPYTHON3 = os.getenv("MICROPY_CPYTHON3", "python3")
-    MICROPYTHON = os.getenv("MICROPY_MICROPYTHON", base_path("../ports/unix/micropython"))
+    MICROPYTHON = os.getenv(
+        "MICROPY_MICROPYTHON", base_path("../ports/unix/build-standard/micropython")
+    )
 
 # Use CPython options to not save .pyc files, to only access the core standard library
 # (not site packages which may clash with u-module names), and improve start up time.
 CPYTHON3_CMD = [CPYTHON3, "-BS"]
 
 # mpy-cross is only needed if --via-mpy command-line arg is passed
-MPYCROSS = os.getenv("MICROPY_MPYCROSS", base_path("../mpy-cross/mpy-cross"))
+MPYCROSS = os.getenv("MICROPY_MPYCROSS", base_path("../mpy-cross/build/mpy-cross"))
 
 # For diff'ing test output
 DIFF = os.getenv("MICROPY_DIFF", "diff -u")

--- a/tools/ci.sh
+++ b/tools/ci.sh
@@ -293,6 +293,7 @@ function ci_samd_setup {
 }
 
 function ci_samd_build {
+    make ${MAKEOPTS} -C mpy-cross
     make ${MAKEOPTS} -C ports/samd submodules
     make ${MAKEOPTS} -C ports/samd
 }
@@ -356,6 +357,7 @@ function ci_teensy_setup {
 }
 
 function ci_teensy_build {
+    make ${MAKEOPTS} -C mpy-cross
     make ${MAKEOPTS} -C ports/teensy submodules
     make ${MAKEOPTS} -C ports/teensy
 }

--- a/tools/ci.sh
+++ b/tools/ci.sh
@@ -409,9 +409,9 @@ function ci_unix_run_tests_full_helper {
     variant=$1
     shift
     if [ $variant = standard ]; then
-        micropython=micropython
+        micropython=build-$variant/micropython
     else
-        micropython=micropython-$variant
+        micropython=build-$variant/micropython-$variant
     fi
     make -C ports/unix VARIANT=$variant "$@" test_full
     (cd tests && MICROPY_CPYTHON3=python3 MICROPY_MICROPYTHON=../ports/unix/$micropython ./run-multitests.py multi_net/*.py)
@@ -444,7 +444,7 @@ function ci_unix_minimal_build {
 }
 
 function ci_unix_minimal_run_tests {
-    (cd tests && MICROPY_CPYTHON3=python3 MICROPY_MICROPYTHON=../ports/unix/micropython-minimal ./run-tests.py -e exception_chain -e self_type_check -e subclass_native_init -d basics)
+    (cd tests && MICROPY_CPYTHON3=python3 MICROPY_MICROPYTHON=../ports/unix/build-minimal/micropython-minimal ./run-tests.py -e exception_chain -e self_type_check -e subclass_native_init -d basics)
 }
 
 function ci_unix_standard_build {
@@ -491,21 +491,21 @@ function ci_unix_coverage_run_mpy_merge_tests {
         test=$(basename $inpy .py)
         echo $test
         outmpy=$outdir/$test.mpy
-        $mptop/mpy-cross/mpy-cross -o $outmpy $inpy
-        (cd $outdir && $mptop/ports/unix/micropython-coverage -m $test >> out-individual)
+        $mptop/mpy-cross/build/mpy-cross -o $outmpy $inpy
+        (cd $outdir && $mptop/ports/unix/build-coverage/micropython-coverage -m $test >> out-individual)
         allmpy+=($outmpy)
     done
 
     # Merge all the tests into one .mpy file, and then execute it.
     python3 $mptop/tools/mpy-tool.py --merge -o $outdir/merged.mpy ${allmpy[@]}
-    (cd $outdir && $mptop/ports/unix/micropython-coverage -m merged > out-merged)
+    (cd $outdir && $mptop/ports/unix/build-coverage/micropython-coverage -m merged > out-merged)
 
     # Make sure the outputs match.
     diff $outdir/out-individual $outdir/out-merged && /bin/rm -rf $outdir
 }
 
 function ci_unix_coverage_run_native_mpy_tests {
-    MICROPYPATH=examples/natmod/features2 ./ports/unix/micropython-coverage -m features2
+    MICROPYPATH=examples/natmod/features2 ./ports/unix/build-coverage/micropython-coverage -m features2
     (cd tests && ./run-natmodtests.py "$@" extmod/{btree*,framebuf*,uheapq*,urandom*,ure*,uzlib*}.py)
 }
 
@@ -614,7 +614,7 @@ function ci_unix_macos_run_tests {
     # Issues with macOS tests:
     # - import_pkg7 has a problem with relative imports
     # - urandom_basic has a problem with getrandbits(0)
-    (cd tests && ./run-tests.py --exclude 'import_pkg7.py' --exclude 'urandom_basic.py')
+    (cd tests && MICROPY_MICROPYTHON=../ports/unix/build-standard/micropython ./run-tests.py --exclude 'import_pkg7.py' --exclude 'urandom_basic.py')
 }
 
 function ci_unix_qemu_mips_setup {
@@ -634,7 +634,7 @@ function ci_unix_qemu_mips_run_tests {
     # - (i)listdir does not work, it always returns the empty list (it's an issue with the underlying C call)
     # - ffi tests do not work
     file ./ports/unix/micropython-coverage
-    (cd tests && MICROPY_MICROPYTHON=../ports/unix/micropython-coverage ./run-tests.py --exclude 'vfs_posix.py' --exclude 'ffi_(callback|float|float2).py')
+    (cd tests && MICROPY_MICROPYTHON=../ports/unix/build-coverage/micropython-coverage ./run-tests.py --exclude 'vfs_posix.py' --exclude 'ffi_(callback|float|float2).py')
 }
 
 function ci_unix_qemu_arm_setup {
@@ -654,7 +654,7 @@ function ci_unix_qemu_arm_run_tests {
     # - (i)listdir does not work, it always returns the empty list (it's an issue with the underlying C call)
     export QEMU_LD_PREFIX=/usr/arm-linux-gnueabi
     file ./ports/unix/micropython-coverage
-    (cd tests && MICROPY_MICROPYTHON=../ports/unix/micropython-coverage ./run-tests.py --exclude 'vfs_posix.py')
+    (cd tests && MICROPY_MICROPYTHON=../ports/unix/build-coverage/micropython-coverage ./run-tests.py --exclude 'vfs_posix.py')
 }
 
 ########################################################################################

--- a/tools/makemanifest.py
+++ b/tools/makemanifest.py
@@ -329,7 +329,7 @@ def main():
         sys.exit(1)
 
     # Get paths to tools
-    MPY_CROSS = VARS["MPY_DIR"] + "/mpy-cross/mpy-cross"
+    MPY_CROSS = VARS["MPY_DIR"] + "/mpy-cross/build/mpy-cross"
     if sys.platform == "win32":
         MPY_CROSS += ".exe"
     MPY_CROSS = os.getenv("MICROPY_MPYCROSS", MPY_CROSS)


### PR DESCRIPTION
Commits to address https://github.com/micropython/micropython/issues/9009

First commit changes `py/mkrules.mk` to place build outputs (`$(PROG)` and `$(LIBMICROPYTHON)`) in the build directory `$(BUILD)`. 

Second commit attempts to fix all paths that assumed the build outputs to be in the working directory of the corresponding build, changing these paths to use the binaries from the respective build directory. It also changes the build rule for the mpy-cross dependency! See below for information why.

Third commit was originally made to work around an issue regarding failing builds for teensy and samd; the mpy-cross was no longer automatically generated in those ci builds. It is now not strictly necessary ... but IMO would be clearer to force this build step (as is done in the ci rules for other ports).

Reason for the issues around the mpy-cross build was that I (orignally, not in these commits!) changed the `MICROPY_MPYCROSS_DEPENDENCY` to point to `$(TOP)/mpy-cross/` .. however this directory (ofc) exists, and thus (since `MICROPY_MPYCROSS_DEPENDENCY` only shows up as an order-only dependency) the rule to build the dependency (using a sub make call) was not run, and thus we had no mpy-cross.
I then set `MICROPY_MPYCROSS_DEPENDENCY` to `$(TOP)/mpy-cross/-non-exist-dummy-` .. which "worked" but caused the rule to be run everytime. This caused the windows and qemu builds to fail, because there the additional run of the build for mpy-cross tried to use the cross-compiler ... which complained about wrong file format / target architecture.
So now I changed the build rule to be explicitly about building the mpy-cross from the repository, which seems like the most sane solution here to me.


