### PR TITLE
py/objboundmeth: Add binary_op method.

### DIFF
--- a/tests/basics/boundmeth1.py
+++ b/tests/basics/boundmeth1.py
@@ -28,3 +28,8 @@ try:
     A().f.x = 1
 except AttributeError:
     print('AttributeError')
+
+# bound method comparison
+m = A()
+print(m.f == m.f)  # should result in True
+print(m.f != m.g)  # should result in False


### PR DESCRIPTION
This PR adds a dedicated `.binary_op` method to `bound_method` objects. In current versions of MicroPython, comparing bound methods always returns `False`.

This PR resolves the issue mentioned in https://github.com/micropython/micropython/issues/5233

Example to validate

```python
class A:
    def a(self):
        pass

    def b(self):
        pass


class B:
    def a(self):
        pass

    def b(self):
        pass


a = A()
b = B()

print('a.a == a.a', a.a == a.a)
print('a.a == a.b', a.a == a.b)
print('b.a == b.b', b.a == b.b)
print('b.b == b.b', b.b == b.b)
print('a.b == b.b', a.b == b.b)
```

Results on CPython
```
a.a == a.a True
a.a == a.b False
b.a == b.b False
b.b == b.b True
a.b == b.b False
```

Original Results on MicroPython
```
a.a == a.a False
a.a == a.b False
b.a == b.b False
b.b == b.b False
a.b == b.b False
```

Results with binary op on MicroPython
```
a.a == a.a True
a.a == a.b False
b.a == b.b False
b.b == b.b True
a.b == b.b False
```