### PR TITLE
ports/rp2: Mark gc_heap NOLOAD for faster boot.

### DIFF
--- a/ports/rp2/main.c
+++ b/ports/rp2/main.c
@@ -66,7 +66,7 @@
 #endif
 
 extern uint8_t __StackTop, __StackBottom;
-static char gc_heap[MICROPY_GC_HEAP_SIZE];
+__attribute__((section(".uninitialized_bss"))) static char gc_heap[MICROPY_GC_HEAP_SIZE];
 
 // Embed version info in the binary in machine readable form
 bi_decl(bi_program_version_string(MICROPY_GIT_TAG));

--- a/ports/rp2/memmap_mp.ld
+++ b/ports/rp2/memmap_mp.ld
@@ -180,6 +180,12 @@ SECTIONS
         *(.uninitialized_data*)
     } > RAM
 
+    /* bss without zero init on startup */
+    .uninitialized_bss (NOLOAD): {
+        . = ALIGN(4);
+        *(.uninitialized_bss*)
+    } > RAM
+
     /* Start and end symbols must be word-aligned */
     .scratch_x : {
         __scratch_x_start__ = .;


### PR DESCRIPTION
I've been doing a fair bit of prodding and poking with MicroPython's startup, and there are a few speed gains to be had.

Notably the zero fill for BSS takes a *long* time, and the SRAM copy for initialized data *even longer*, since these both happen before ROSC is configured to any appreciable speed.

Editing Pico SDK's `crt0.S` entry point and configuring ROSC to ~48MHz dramatically reduces the time these copies take- reducing a MicroPython Pico W cold boot (including our libraries) from ~200ms to ~50ms. This is not something that's easy to do for MicroPython and for our own builds I'm hot patching `crt0.S` with some extra features...

Instead we can skip zeroing of `gc_heap.` This change doesn't get us as far as the clock config, but saves ~30ms by marking `gc_heap` as `.noinit` which, in turn, ensures it is not zero-filled at startup.

This takes startup from a measured ~156ms down to ~120ms.


Before:
![image](https://user-images.githubusercontent.com/1746967/183041221-b67c44b9-8084-4fdc-a692-8d024cd5c90b.png)


After:
![image](https://user-images.githubusercontent.com/1746967/183041308-2fbcbf57-cfa6-4df4-b786-a27e777c9ab0.png)




This change was suggested by @jimmo on https://github.com/raspberrypi/pico-sdk/issues/959