### PR TITLE
py/builtinimport: Allow overriding of mp_builtin___import__.

### DIFF
--- a/py/builtin.h
+++ b/py/builtin.h
@@ -64,7 +64,13 @@ MP_DECLARE_CONST_FUN_OBJ_KW(mp_builtin_open_obj);
 
 #endif
 
+// A port can provide its own import handler by defining mp_builtin___import__.
+#ifndef mp_builtin___import__
+#define mp_builtin___import__ mp_builtin___import___default
+#endif
 mp_obj_t mp_builtin___import__(size_t n_args, const mp_obj_t *args);
+mp_obj_t mp_builtin___import___default(size_t n_args, const mp_obj_t *args);
+
 mp_obj_t mp_micropython_mem_info(size_t n_args, const mp_obj_t *args);
 
 MP_DECLARE_CONST_FUN_OBJ_VAR(mp_builtin___build_class___obj);

--- a/py/builtinimport.c
+++ b/py/builtinimport.c
@@ -467,7 +467,7 @@ STATIC mp_obj_t process_import_at_level(qstr full_mod_name, qstr level_mod_name,
     return module_obj;
 }
 
-mp_obj_t mp_builtin___import__(size_t n_args, const mp_obj_t *args) {
+mp_obj_t mp_builtin___import___default(size_t n_args, const mp_obj_t *args) {
     #if DEBUG_PRINT
     DEBUG_printf("__import__:\n");
     for (size_t i = 0; i < n_args; i++) {
@@ -566,7 +566,7 @@ mp_obj_t mp_builtin___import__(size_t n_args, const mp_obj_t *args) {
 
 #else // MICROPY_ENABLE_EXTERNAL_IMPORT
 
-mp_obj_t mp_builtin___import__(size_t n_args, const mp_obj_t *args) {
+mp_obj_t mp_builtin___import___default(size_t n_args, const mp_obj_t *args) {
     // Check that it's not a relative import
     if (n_args >= 5 && MP_OBJ_SMALL_INT_VALUE(args[4]) != 0) {
         mp_raise_NotImplementedError(MP_ERROR_TEXT("relative import"));


### PR DESCRIPTION
This allows MicroPython ports without external imports enabled to override _mp_builtin___import___.

This is useful for MicroPython applications without enough resources to have `MICROPY_ENABLE_EXTERNAL_IMPORT` enabled, but which still want to allow users to do some application-specific imports beyond builtins.

Ports can already provide things like `mp_builtin_open`, so providing `mp_builtin___import__` seems to fit reasonably well.

Instead of doing it this way, it could be made more generic by changing `MICROPY_ENABLE_EXTERNAL_IMPORT`  to a configuration setting `MICROPY_ENABLE_IMPORT` with three options, such as: `MICROPY_ENABLE_IMPORT_EXTERNAL`, `MICROPY_ENABLE_IMPORT_BUILTIN_ONLY`, and  `MICROPY_ENABLE_IMPORT_CUSTOM`. 

----

Context: We are currently [overriding it in MicroPython for Pybricks](https://github.com/pybricks/micropython/commit/2c217f20f86884302fbf2dbc807e69b507b09674). I was considering adding certain new functionality (inspired by https://github.com/micropython/micropython/pull/8381), but overriding it locally without forking would be a bit cleaner and easier to maintain.