### PR TITLE
py/objarray: Raise error on out-of-bound memoryview slice start.

### DIFF
--- a/py/objarray.c
+++ b/py/objarray.c
@@ -53,6 +53,7 @@
 #if MICROPY_PY_BUILTINS_MEMORYVIEW
 #define TYPECODE_MASK (0x7f)
 #define memview_offset free
+#define memview_offset_max ((1LL << MP_OBJ_ARRAY_FREE_SIZE_BITS) - 1)
 #else
 // make (& TYPECODE_MASK) a null operation if memorview not enabled
 #define TYPECODE_MASK (~(size_t)0)
@@ -522,6 +523,9 @@ STATIC mp_obj_t array_subscr(mp_obj_t self_in, mp_obj_t index_in, mp_obj_t value
             assert(sz > 0);
             #if MICROPY_PY_BUILTINS_MEMORYVIEW
             if (o->base.type == &mp_type_memoryview) {
+                if (slice.start > memview_offset_max) {
+                    mp_raise_msg(&mp_type_OverflowError, MP_ERROR_TEXT("memoryview offset too large"));
+                }
                 res = m_new_obj(mp_obj_array_t);
                 *res = *o;
                 res->memview_offset += slice.start;

--- a/py/objarray.h
+++ b/py/objarray.h
@@ -32,6 +32,9 @@
 // Used only for memoryview types, set in "typecode" to indicate a writable memoryview
 #define MP_OBJ_ARRAY_TYPECODE_FLAG_RW (0x80)
 
+// Bit size used for mp_obj_array_t.free member.
+#define MP_OBJ_ARRAY_FREE_SIZE_BITS (8 * sizeof(size_t) - 8)
+
 // This structure is used for all of bytearray, array.array, memoryview
 // objects.  Note that memoryview has different meaning for some fields,
 // see comment at the beginning of objarray.c.
@@ -44,7 +47,7 @@ typedef struct _mp_obj_array_t {
     // parent object. (Union is not used to not go into a complication of
     // union-of-bitfields with different toolchains). See comments in
     // objarray.c.
-    size_t free : (8 * sizeof(size_t) - 8);
+    size_t free : MP_OBJ_ARRAY_FREE_SIZE_BITS;
     size_t len; // in elements
     void *items;
 } mp_obj_array_t;

--- a/tests/basics/memoryview_slice_size.py
+++ b/tests/basics/memoryview_slice_size.py
@@ -1,0 +1,27 @@
+# test memoryview slicing beyond the limit of what memoryview can internally index
+
+try:
+    from sys import maxsize
+    from uctypes import bytearray_at
+
+    memoryview
+except:
+    print("SKIP")
+    raise SystemExit
+
+if maxsize <= 0xFFFF_FFFF:
+    slice_max = 0xFF_FFFF
+else:
+    slice_max = 0xFF_FFFF_FFFF_FFFF
+
+buf = bytearray_at(0, slice_max + 2)
+mv = memoryview(buf)
+
+# this should work
+print(mv[slice_max : slice_max + 1])
+
+# this should overflow the internal index for memoryview slicing
+try:
+    print(mv[slice_max + 1 : slice_max + 2])
+except OverflowError:
+    print("OverflowError")

--- a/tests/basics/memoryview_slice_size.py.exp
+++ b/tests/basics/memoryview_slice_size.py.exp
@@ -1,0 +1,2 @@
+<memoryview>
+OverflowError


### PR DESCRIPTION
32 bit platforms only support a slice offset start of 24 bit max due to the limited size of https://github.com/micropython/micropython/blob/9dfabcd6d3d080aced888e8474e921f11dc979bb/py/objarray.h#L47

As it stands, if a memoryview object is sliced with a start index of 16MB or more then it's aliased back to the start of the array providing incorrect results.

I initially tried to increase the size of `size_t free` in the link above when used on a 32bit platform, however this breaks a lot more. Not sure why, presuably the total size of that structure is hardcoded / assumed elsewhere perhaps?

For now, this PR just raises an exception if the start index is too high to prevent accidental use of the wrong data.
