### PR TITLE
extmod/network_wiznet5k: allow SPI object to be more generic

### DIFF
--- a/ports/rp2/machine_spi.c
+++ b/ports/rp2/machine_spi.c
@@ -269,15 +269,6 @@ STATIC void machine_spi_transfer(mp_obj_base_t *self_in, size_t len, const uint8
     }
 }
 
-machine_spi_obj_t *spi_from_mp_obj(mp_obj_t o) {
-    if (mp_obj_is_type(o, &machine_spi_type)) {
-        machine_spi_obj_t *self = MP_OBJ_TO_PTR(o);
-        return self;
-    } else {
-        mp_raise_TypeError(MP_ERROR_TEXT("expecting an SPI object"));
-    }
-}
-
 STATIC const mp_machine_spi_p_t machine_spi_p = {
     .init = machine_spi_init,
     .transfer = machine_spi_transfer,
@@ -291,3 +282,17 @@ const mp_obj_type_t machine_spi_type = {
     .protocol = &machine_spi_p,
     .locals_dict = (mp_obj_dict_t *)&mp_machine_spi_locals_dict,
 };
+
+mp_obj_base_t *mp_hal_get_spi_obj(mp_obj_t o) {
+    if (mp_obj_is_type(o, &machine_spi_type)) {
+        return MP_OBJ_TO_PTR(o);
+    }
+    #if MICROPY_PY_MACHINE_SOFTSPI
+    else if (mp_obj_is_type(o, &mp_machine_soft_spi_type)) {
+        return MP_OBJ_TO_PTR(o);
+    }
+    #endif
+    else {
+        mp_raise_TypeError(MP_ERROR_TEXT("expecting an SPI object"));
+    }
+}

--- a/ports/rp2/mphalport.h
+++ b/ports/rp2/mphalport.h
@@ -148,6 +148,8 @@ enum mp_hal_pin_interrupt_trigger {
 
 void mp_hal_pin_interrupt(mp_hal_pin_obj_t pin, mp_obj_t handler, mp_uint_t trigger, bool hard);
 
+mp_obj_base_t *mp_hal_get_spi_obj(mp_obj_t spi_in);
+
 enum {
     MP_HAL_MAC_WLAN0 = 0,
     MP_HAL_MAC_BDADDR,


### PR DESCRIPTION
This allows the SPI object used to communicate with the WIZNET5K hardware to be `SoftSPI` or hardware SPI, or anything that has the SPI protocol (at the C level).

To facilitate #9021.