### PR TITLE
tools/ci.sh: Add build of W5500_EVB_PICO board to rp2 CI.

### DIFF
--- a/tools/ci.sh
+++ b/tools/ci.sh
@@ -283,6 +283,8 @@ function ci_rp2_build {
     make ${MAKEOPTS} -C ports/rp2 USER_C_MODULES=../../examples/usercmodule/micropython.cmake
     make ${MAKEOPTS} -C ports/rp2 BOARD=W5100S_EVB_PICO submodules
     make ${MAKEOPTS} -C ports/rp2 BOARD=W5100S_EVB_PICO
+    make ${MAKEOPTS} -C ports/rp2 BOARD=W5500_EVB_PICO submodules
+    make ${MAKEOPTS} -C ports/rp2 BOARD=W5500_EVB_PICO
 }
 
 ########################################################################################


### PR DESCRIPTION
update ci.sh since https://github.com/micropython/micropython/pull/8962 was merged
