### PR TITLE
ports/nrf|stm32: Don't enable debug info by default if LTO is on.

### DIFF
--- a/ports/nrf/Makefile
+++ b/ports/nrf/Makefile
@@ -138,12 +138,14 @@ LDFLAGS += -Wl,'--defsym=_fs_size=$(FS_SIZE)'
 endif
 
 #Debugging/Optimization
-CFLAGS += -g  # always include debug info in the ELF
 ifeq ($(DEBUG), 1)
 #ASMFLAGS += -g -gtabs+
-CFLAGS += -O0
+CFLAGS += -g -O0
 LDFLAGS += -O0
 else
+ifneq ($(LTO), 1)
+CFLAGS += -g  # always include debug info in the ELF, unless LTO is on
+endif
 CFLAGS += -Os -DNDEBUG
 LDFLAGS += -Os
 endif

--- a/ports/stm32/Makefile
+++ b/ports/stm32/Makefile
@@ -114,13 +114,15 @@ $(BUILD)/stm32_it.o $(BUILD)/pendsv.o: CFLAGS += -fno-lto
 endif
 
 # Debugging/Optimization
-CFLAGS += -g  # always include debug info in the ELF
 ifeq ($(DEBUG), 1)
-CFLAGS += -DPENDSV_DEBUG
+CFLAGS += -g -DPENDSV_DEBUG
 COPT ?= -Og
 # Disable text compression in debug builds
 MICROPY_ROM_TEXT_COMPRESSION = 0
 else
+ifneq ($(LTO), 1)
+CFLAGS += -g  # always include debug info in the ELF, unless LTO is on
+endif
 COPT ?= -Os -DNDEBUG
 endif
 


### PR DESCRIPTION
It seems sometimes gcc with LTO will generate otherwise valid assembly listings that cause 'as' to error out when generating DWARF debug info (EDIT: bug report to binutils 'as' is [here](https://sourceware.org/bugzilla/show_bug.cgi?id=29494)).

Therefore, don't enable -g by default if LTO is on.

Enabling LTO=1 DEBUG=1 is still possible but may result in random errors at link time due to 'as' (the error in this case is "Error: unaligned opcodes detected in executable segment", and the only other easy workaround is CFLAGS+=-fno-jump-tables which may increase code size significantly.)

Follows #8975 which introduced enabling -g always.