### PR TITLE
stm32: Move board variant config to mpconfigboard.mk.

### DIFF
--- a/ports/stm32/Makefile
+++ b/ports/stm32/Makefile
@@ -37,6 +37,9 @@ include $(TOP)/extmod/extmod.mk
 
 GIT_SUBMODULES += lib/libhydrogen lib/lwip lib/mbedtls lib/stm32lib
 
+query-variants:
+	$(ECHO) "VARIANTS:" $(BOARD_VARIANTS)
+
 LD_DIR=boards
 USBDEV_DIR=usbdev
 #USBHOST_DIR=usbhost

--- a/ports/stm32/boards/PYBLITEV10/mpconfigboard.mk
+++ b/ports/stm32/boards/PYBLITEV10/mpconfigboard.mk
@@ -4,3 +4,24 @@ AF_FILE = boards/stm32f411_af.csv
 LD_FILES = boards/stm32f411.ld boards/common_ifs.ld
 TEXT0_ADDR = 0x08000000
 TEXT1_ADDR = 0x08020000
+
+# Provide different variants for the downloads page.
+BOARD_VARIANTS += "dp thread dp-thread network"
+
+ifeq ($(BOARD_VARIANT),"dp")
+MICROPY_FLOAT_IMPL=double
+endif
+
+ifeq ($(BOARD_VARIANT),"thread")
+CFLAGS += -DMICROPY_PY_THREAD=1
+endif
+
+ifeq ($(BOARD_VARIANT),"dp-thread")
+MICROPY_FLOAT_IMPL=double
+CFLAGS += -DMICROPY_PY_THREAD=1
+endif
+
+ifeq ($(BOARD_VARIANT),"network")
+MICROPY_PY_NETWORK_WIZNET5K=5200
+MICROPY_PY_CC3K=1
+endif

--- a/ports/stm32/boards/PYBV10/mpconfigboard.mk
+++ b/ports/stm32/boards/PYBV10/mpconfigboard.mk
@@ -14,3 +14,24 @@ endif
 
 # MicroPython settings
 MICROPY_VFS_LFS2 = 1
+
+# Provide different variants for the downloads page.
+BOARD_VARIANTS += "dp thread dp-thread network"
+
+ifeq ($(BOARD_VARIANT),"dp")
+MICROPY_FLOAT_IMPL=double
+endif
+
+ifeq ($(BOARD_VARIANT),"thread")
+CFLAGS += -DMICROPY_PY_THREAD=1
+endif
+
+ifeq ($(BOARD_VARIANT),"dp-thread")
+MICROPY_FLOAT_IMPL=double
+CFLAGS += -DMICROPY_PY_THREAD=1
+endif
+
+ifeq ($(BOARD_VARIANT),"network")
+MICROPY_PY_NETWORK_WIZNET5K=5200
+MICROPY_PY_CC3K=1
+endif

--- a/ports/stm32/boards/PYBV11/mpconfigboard.mk
+++ b/ports/stm32/boards/PYBV11/mpconfigboard.mk
@@ -14,3 +14,24 @@ endif
 
 # MicroPython settings
 MICROPY_VFS_LFS2 = 1
+
+# Provide different variants for the downloads page.
+BOARD_VARIANTS += "dp thread dp-thread network"
+
+ifeq ($(BOARD_VARIANT),"dp")
+MICROPY_FLOAT_IMPL=double
+endif
+
+ifeq ($(BOARD_VARIANT),"thread")
+CFLAGS += -DMICROPY_PY_THREAD=1
+endif
+
+ifeq ($(BOARD_VARIANT),"dp-thread")
+MICROPY_FLOAT_IMPL=double
+CFLAGS += -DMICROPY_PY_THREAD=1
+endif
+
+ifeq ($(BOARD_VARIANT),"network")
+MICROPY_PY_NETWORK_WIZNET5K=5200
+MICROPY_PY_CC3K=1
+endif

--- a/tools/autobuild/build-stm32-extra.sh
+++ b/tools/autobuild/build-stm32-extra.sh
@@ -7,12 +7,15 @@ function do_build() {
     board=$2
     shift
     shift
-    echo "building $descr $board"
-    build_dir=/tmp/stm-build-$board
-    $MICROPY_AUTOBUILD_MAKE $@ BOARD=$board BUILD=$build_dir || exit 1
-    mv $build_dir/firmware.dfu $dest_dir/$descr$fw_tag.dfu
-    mv $build_dir/firmware.hex $dest_dir/$descr$fw_tag.hex
-    rm -rf $build_dir
+    for variant in `$MICROPY_AUTOBUILD_MAKE BOARD=$board query-variants | grep VARIANTS: | cut -d' ' -f2-`; do
+        target=$descr-$variant
+        echo "building $target $board"
+        build_dir=/tmp/stm-build-$board
+        $MICROPY_AUTOBUILD_MAKE $@ BOARD=$board BOARD_VARIANT=$variant BUILD=$build_dir || exit 1
+        mv $build_dir/firmware.dfu $dest_dir/$target$fw_tag.dfu
+        mv $build_dir/firmware.hex $dest_dir/$target$fw_tag.hex
+        rm -rf $build_dir
+    done
 }
 
 # check/get parameters
@@ -30,18 +33,7 @@ if [ ! -r modpyb.c ]; then
     exit 1
 fi
 
-# build the versions
-do_build pybv3 PYBV3
-do_build pybv3-network PYBV3 MICROPY_PY_NETWORK_WIZNET5K=5200 MICROPY_PY_CC3K=1
-do_build pybv10-dp PYBV10 MICROPY_FLOAT_IMPL=double
-do_build pybv10-thread PYBV10 CFLAGS_EXTRA='-DMICROPY_PY_THREAD=1'
-do_build pybv10-dp-thread PYBV10 MICROPY_FLOAT_IMPL=double CFLAGS_EXTRA='-DMICROPY_PY_THREAD=1'
-do_build pybv10-network PYBV10 MICROPY_PY_NETWORK_WIZNET5K=5200 MICROPY_PY_CC3K=1
-do_build pybv11-dp PYBV11 MICROPY_FLOAT_IMPL=double
-do_build pybv11-thread PYBV11 CFLAGS_EXTRA='-DMICROPY_PY_THREAD=1'
-do_build pybv11-dp-thread PYBV11 MICROPY_FLOAT_IMPL=double CFLAGS_EXTRA='-DMICROPY_PY_THREAD=1'
-do_build pybv11-network PYBV11 MICROPY_PY_NETWORK_WIZNET5K=5200 MICROPY_PY_CC3K=1
-do_build pyblitev10-dp PYBLITEV10 MICROPY_FLOAT_IMPL=double
-do_build pyblitev10-thread PYBLITEV10 CFLAGS_EXTRA='-DMICROPY_PY_THREAD=1'
-do_build pyblitev10-dp-thread PYBLITEV10 MICROPY_FLOAT_IMPL=double CFLAGS_EXTRA='-DMICROPY_PY_THREAD=1'
-do_build pyblitev10-network PYBLITEV10 MICROPY_PY_NETWORK_WIZNET5K=5200 MICROPY_PY_CC3K=1
+# build the variants for each board
+do_build pybv10 PYBV10
+do_build pybv11 PYBV11
+do_build pyblitev10 PYBLITEV10


### PR DESCRIPTION
There's a little-known feature in the scripts that build firmware for micropython.org/download that allows a board to have multiple "variants" defined. For example "PYBV11 with threading".

This currently works by having the autobuild script explicitly know about the variants and what arguments to pass to make. Then the board.json knows about the generated filenames.

I want to:
a) Standardise this across ports.
b) Move the definition of variants into the board config.
c) Use it for existing boards that are very similar but we currently have separate board definitions for (e.g. boards that are identical other than their flash size, e.g. https://github.com/micropython/micropython/tree/master/ports/rp2/boards/PIMORONI_PICOLIPO_4MB, or for identical boards with different external components, e.g. https://github.com/micropython/micropython/tree/master/ports/rp2/boards/W5500_EVB_PICO vs the 5100S). 

Rather than having the autobuild know about the particular variants, this PR makes the board's mpconfigboard.mk describe them and have the autobuild discover them automatically.

The implementation is that a board can configure the `BOARD_VARIANTS` variable, and a new `query-variants` target is added stm32/Makefile get this. Then the board's mpconfigboard.mk can use the value of the optional `BOARD_VARIANT` variable to configure as required.

This is just a first step towards the goals above, and just implements it for stm32 -- the next step would be:
- Move the query-variants target to the common makefile, and also implement for cmake targets.
- Remove `build-stm32-extra.sh` and add the variant loop to `build-boards.sh`.

Also removes pybv3 from the autobuild as this isn't use by the downloads page.