### PR TITLE
Tiny fix for string quoting consistency

### DIFF
--- a/docs/esp32/quickref.rst
+++ b/docs/esp32/quickref.rst
@@ -589,7 +589,7 @@ See :ref:`machine.SDCard <machine.SDCard>`. ::
 
     # Slot 2 uses pins sck=18, cs=5, miso=19, mosi=23
     sd = machine.SDCard(slot=2)
-    os.mount(sd, "/sd")  # mount
+    os.mount(sd, '/sd')  # mount
 
     os.listdir('/sd')    # list directory contents
 


### PR DESCRIPTION
It appears that strings in the documentation are typically single quoted, while the command

os.mount(sd, "/sd")  # mount

in the SDCard documentation (ESP32 quick reference) is double quoted. This fix changes it to

os.mount(sd, '/sd')  # mount