### PR TITLE
py/persistentcode: Clarify ValueError message when native emitter disabled.

### DIFF
--- a/py/persistentcode.c
+++ b/py/persistentcode.c
@@ -402,7 +402,13 @@ mp_compiled_module_t mp_raw_code_load(mp_reader_t *reader, mp_module_context_t *
     if (MPY_FEATURE_DECODE_ARCH(header[2]) != MP_NATIVE_ARCH_NONE) {
         byte arch = MPY_FEATURE_DECODE_ARCH(header[2]);
         if (!MPY_FEATURE_ARCH_TEST(arch)) {
-            mp_raise_ValueError(MP_ERROR_TEXT("incompatible .mpy arch"));
+            if (MPY_FEATURE_ARCH_TEST(MP_NATIVE_ARCH_NONE)) {
+                // On supported ports this can be resolved by enabling feature, eg
+                // mpconfigboard.h: MICROPY_EMIT_THUMB (1)
+                mp_raise_ValueError(MP_ERROR_TEXT("native code in .mpy unsupported"));
+            } else {
+                mp_raise_ValueError(MP_ERROR_TEXT("incompatible .mpy arch"));
+            }
         }
     }
 


### PR DESCRIPTION
While testing a dynamic native code module in a new project I was running into the error `ValueError: incompatible .mpy arch` while trying to import the mpy.

I spent a fair bit of time examing the build environment of the module, updating the base micropython version of the project, recompiling the module, testing a bunch of things before finally figuring out (while step-by-step debugging) that the project I was trying to run the module on had `#define MICROPY_EMIT_THUMB (0)` defined.

This PR just gives a clearer error message in this case where the native emitter is completely disabled.

I was initially going to replace the existing message with:
``` C
mp_raise_msg_varg(&mp_type_ValueError, MP_ERROR_TEXT("incompatible .mpy arch: (%x), required: (%x)"), arch, MPY_FEATURE_ARCH);
```

Which gives a more broadly helpful message, however makes the build bigger for everyone. I feel that the existing error message (when native is enabled at all) should be enough of a prompter to a native module builder that they're compiling for the wrong arch and a simple examination of the native module Makefile will generally be enough to resolve that.
```
# Architecture to build for (x86, x64, armv7m, xtensa, xtensawin)
ARCH = armv7m
```