### PR TITLE
stm32/Makefile: Automatically rebuild if make MBOOT=0/1 changed.

### DIFF
--- a/ports/stm32/Makefile
+++ b/ports/stm32/Makefile
@@ -690,6 +690,9 @@ SRC_QSTR += $(SRC_C) $(SRC_CXX) $(SHARED_SRC_C) $(GEN_PINS_SRC)
 # which source files might need it.
 $(OBJ): | $(GEN_PINS_HDR)
 
+# Automatically rebuild if specific settings are changed on command line
+$(OBJ): $(call depend_var, USE_MBOOT)
+
 # With conditional pins, we may need to regenerate qstrdefs.h when config
 # options change.
 $(HEADER_BUILD)/qstrdefs.generated.h: $(BOARD_DIR)/mpconfigboard.h

--- a/py/mkenv.mk
+++ b/py/mkenv.mk
@@ -14,6 +14,11 @@ TOP := $(patsubst %/py/mkenv.mk,%,$(THIS_MAKEFILE))
 
 include $(TOP)/py/verbose.mk
 
+# depend_var is a function that can be used to add a virtual dependency
+# to a target based on the given make variable.
+# eg. $(OBJ): $(call depend_var, MY_VAR)
+depend_var = $(BUILD)/dependvar/$(strip $(1))+$(shell echo $($(strip $(1))) | md5sum | cut -d ' ' -f 1)
+
 # default settings; can be overridden in main Makefile
 
 PY_SRC ?= $(TOP)/py

--- a/py/mkrules.mk
+++ b/py/mkrules.mk
@@ -46,6 +46,14 @@ QSTR_GEN_CFLAGS += $(QSTR_GEN_FLAGS)
 QSTR_GEN_CXXFLAGS := $(CXXFLAGS)
 QSTR_GEN_CXXFLAGS += $(QSTR_GEN_FLAGS)
 
+# depend_var is a function that can be used to add a virtual dependency
+# to a target based on the given make variable.
+# eg. $(OBJ): $(call depend_var, MY_VAR)
+$(BUILD)/dependvar/%:
+	@mkdir -p $(BUILD)/dependvar
+	@rm -f $(BUILD)/dependvar/$(firstword $(subst +, ,$*))+*
+	$(Q)echo $($(firstword $(subst +, ,$*))) > $@
+
 # This file expects that OBJ contains a list of all of the object files.
 # The directory portion of each object file is used to locate the source
 # and should not contain any ..'s but rather be relative to the top of the


### PR DESCRIPTION
py/Makefile: Add helper to declare variables as dependencies.

`depend_var` is a new Make function that can be used to add a virtual dependency
to a target based on the given make variable, eg:
``` Makefile
$(OBJ): $(call depend_var, MY_VAR)
```

This is then used for:
stm32/Makefile: Automatically rebuild if make MBOOT=0/1 changed.

