### PR TITLE
machine_uart: Implement a uart.flush() method,

### DIFF
--- a/docs/library/machine.UART.rst
+++ b/docs/library/machine.UART.rst
@@ -165,6 +165,20 @@ Methods
 
    Availability: WiPy.
 
+.. method:: UART.flush([timeout_ms])
+
+   Waits up to timeout_ms until all data has been sent. It returns True, if all data
+   has been sent, and False in case of a timeout. The default value for timeout_ms
+   is 1 hour. Using a timeout_ms value of 0 the method can be used to test without waiting,
+   whether all data has been sent.
+
+   Restrictions: At the esp8266 port the call returns, while the last byte is sent. At the RP2040
+   port the call returns, while the last byte is sent, if the message is shorted than 6 bytes. If
+   required, a one character wait time has to be added in the script.
+
+   Availability: STM32, RP2040, ESP32, ESP8266, MIMXRT
+
+
 Constants
 ---------
 

--- a/ports/cc3200/mods/pybuart.c
+++ b/ports/cc3200/mods/pybuart.c
@@ -558,6 +558,30 @@ invalid_args:
 }
 STATIC MP_DEFINE_CONST_FUN_OBJ_KW(pyb_uart_irq_obj, 1, pyb_uart_irq);
 
+// uart.flush()
+
+#define UART_FLUSH_TIMEOUT      (3600000)   // 1 hour
+
+STATIC mp_obj_t pyb_uart_flush(size_t n_args, const mp_obj_t *args) {
+    pyb_uart_obj_t *self = args[0];
+    uint32_t timeout = UART_FLUSH_TIMEOUT;
+
+    if (n_args > 1) {
+        timeout = mp_obj_get_int(args[1]);
+    }
+    timeout += mp_hal_ticks_ms();
+
+    do {
+        if (MAP_UARTBusy(self->reg) == false) {
+            return mp_const_true;
+        }
+        MICROPY_EVENT_POLL_HOOK
+    } while (mp_hal_ticks_ms() < timeout);
+
+    return mp_const_false;
+}
+STATIC MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(pyb_uart_flush_obj, 1, 2, pyb_uart_flush);
+
 STATIC const mp_rom_map_elem_t pyb_uart_locals_dict_table[] = {
     // instance methods
     { MP_ROM_QSTR(MP_QSTR_init),        MP_ROM_PTR(&pyb_uart_init_obj) },
@@ -565,6 +589,7 @@ STATIC const mp_rom_map_elem_t pyb_uart_locals_dict_table[] = {
     { MP_ROM_QSTR(MP_QSTR_any),         MP_ROM_PTR(&pyb_uart_any_obj) },
     { MP_ROM_QSTR(MP_QSTR_sendbreak),   MP_ROM_PTR(&pyb_uart_sendbreak_obj) },
     { MP_ROM_QSTR(MP_QSTR_irq),         MP_ROM_PTR(&pyb_uart_irq_obj) },
+    { MP_ROM_QSTR(MP_QSTR_flush),       MP_ROM_PTR(&pyb_uart_flush_obj) },
 
     /// \method read([nbytes])
     { MP_ROM_QSTR(MP_QSTR_read),        MP_ROM_PTR(&mp_stream_read_obj) },

--- a/ports/esp32/machine_uart.c
+++ b/ports/esp32/machine_uart.c
@@ -426,10 +426,26 @@ STATIC mp_obj_t machine_uart_sendbreak(mp_obj_t self_in) {
 }
 STATIC MP_DEFINE_CONST_FUN_OBJ_1(machine_uart_sendbreak_obj, machine_uart_sendbreak);
 
+#define UART_FLUSH_TIMEOUT      (3600000)   // 1 hour
+
+STATIC mp_obj_t machine_uart_flush(size_t n_args, const mp_obj_t *args) {
+    machine_uart_obj_t *self = args[0];
+
+    uint32_t timeout = UART_FLUSH_TIMEOUT;
+    if (n_args > 1) {
+        timeout = mp_obj_get_int(args[1]);
+    }
+    int rc = uart_wait_tx_done(self->uart_num, timeout);
+
+    return (rc == ESP_OK) ? mp_const_true : mp_const_false;
+}
+STATIC MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(machine_uart_flush_obj, 1, 2, machine_uart_flush);
+
 STATIC const mp_rom_map_elem_t machine_uart_locals_dict_table[] = {
     { MP_ROM_QSTR(MP_QSTR_init), MP_ROM_PTR(&machine_uart_init_obj) },
     { MP_ROM_QSTR(MP_QSTR_deinit), MP_ROM_PTR(&machine_uart_deinit_obj) },
     { MP_ROM_QSTR(MP_QSTR_any), MP_ROM_PTR(&machine_uart_any_obj) },
+    { MP_ROM_QSTR(MP_QSTR_flush), MP_ROM_PTR(&machine_uart_flush_obj) },
     { MP_ROM_QSTR(MP_QSTR_read), MP_ROM_PTR(&mp_stream_read_obj) },
     { MP_ROM_QSTR(MP_QSTR_readline), MP_ROM_PTR(&mp_stream_unbuffered_readline_obj) },
     { MP_ROM_QSTR(MP_QSTR_readinto), MP_ROM_PTR(&mp_stream_readinto_obj) },

--- a/ports/esp8266/esp_mphal.c
+++ b/ports/esp8266/esp_mphal.c
@@ -87,7 +87,7 @@ void mp_hal_debug_str(const char *str) {
     while (*str) {
         uart_tx_one_char(UART0, *str++);
     }
-    uart_flush(UART0);
+    uart_flush(UART0, 3600000);
 }
 #endif
 

--- a/ports/esp8266/uart.c
+++ b/ports/esp8266/uart.c
@@ -111,13 +111,17 @@ void uart_tx_one_char(uint8 uart, uint8 TxChar) {
     WRITE_PERI_REG(UART_FIFO(uart), TxChar);
 }
 
-void uart_flush(uint8 uart) {
-    while (true) {
+int uart_flush(uint8 uart, uint32_t timeout) {
+    uint64_t t = system_get_time() + timeout * 1000;
+    do {
         uint32 fifo_cnt = READ_PERI_REG(UART_STATUS(uart)) & (UART_TXFIFO_CNT << UART_TXFIFO_CNT_S);
         if ((fifo_cnt >> UART_TXFIFO_CNT_S & UART_TXFIFO_CNT) == 0) {
-            break;
+            return true;
         }
-    }
+        ets_event_poll();
+    } while (system_get_time() < t);
+
+    return false;
 }
 
 /******************************************************************************

--- a/ports/esp8266/uart.h
+++ b/ports/esp8266/uart.h
@@ -100,7 +100,7 @@ int uart0_rx(void);
 bool uart_rx_wait(uint32_t timeout_us);
 int uart_rx_char(void);
 void uart_tx_one_char(uint8 uart, uint8 TxChar);
-void uart_flush(uint8 uart);
+int uart_flush(uint8 uart, uint32_t timeout);
 void uart_os_config(int uart);
 void uart_setup(uint8 uart);
 int uart0_get_rxbuf_len(void);

--- a/ports/mimxrt/machine_uart.c
+++ b/ports/mimxrt/machine_uart.c
@@ -308,10 +308,32 @@ STATIC mp_obj_t machine_uart_sendbreak(mp_obj_t self_in) {
 }
 STATIC MP_DEFINE_CONST_FUN_OBJ_1(machine_uart_sendbreak_obj, machine_uart_sendbreak);
 
+#define UART_FLUSH_TIMEOUT      (3600000)   // 1 hour
+
+STATIC mp_obj_t machine_uart_flush(size_t n_args, const mp_obj_t *args) {
+    machine_uart_obj_t *self = args[0];
+    uint64_t timeout = UART_FLUSH_TIMEOUT * 1000ll;
+
+    if (n_args > 1) {
+        timeout = (uint64_t)mp_obj_get_int(args[1]) * 1000;
+    }
+    timeout += ticks_us64();
+    do {
+        if (self->tx_status == kStatus_LPUART_TxIdle) {
+            return mp_const_true;
+        }
+        MICROPY_EVENT_POLL_HOOK
+    } while (ticks_us64() < timeout);
+
+    return mp_const_false;
+}
+STATIC MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(machine_uart_flush_obj, 1, 2, machine_uart_flush);
+
 STATIC const mp_rom_map_elem_t machine_uart_locals_dict_table[] = {
     { MP_ROM_QSTR(MP_QSTR_init), MP_ROM_PTR(&machine_uart_init_obj) },
 
     { MP_ROM_QSTR(MP_QSTR_any), MP_ROM_PTR(&machine_uart_any_obj) },
+    { MP_ROM_QSTR(MP_QSTR_flush), MP_ROM_PTR(&machine_uart_flush_obj) },
 
     { MP_ROM_QSTR(MP_QSTR_read), MP_ROM_PTR(&mp_stream_read_obj) },
     { MP_ROM_QSTR(MP_QSTR_readline), MP_ROM_PTR(&mp_stream_unbuffered_readline_obj) },

--- a/ports/nrf/modules/machine/uart.c
+++ b/ports/nrf/modules/machine/uart.c
@@ -292,6 +292,13 @@ STATIC mp_obj_t machine_hard_uart_sendbreak(mp_obj_t self_in) {
 }
 STATIC MP_DEFINE_CONST_FUN_OBJ_1(machine_hard_uart_sendbreak_obj, machine_hard_uart_sendbreak);
 
+// uart.flush()
+// Added for compatibility as an empty function
+STATIC mp_obj_t machine_uart_flush(size_t n_args, const mp_obj_t *args) {
+    return mp_const_true;
+}
+STATIC MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(machine_uart_flush_obj, 1, 2, machine_uart_flush);
+
 STATIC const mp_rom_map_elem_t machine_hard_uart_locals_dict_table[] = {
     // instance methods
     { MP_ROM_QSTR(MP_QSTR_read), MP_ROM_PTR(&mp_stream_read_obj) },
@@ -302,6 +309,7 @@ STATIC const mp_rom_map_elem_t machine_hard_uart_locals_dict_table[] = {
     { MP_ROM_QSTR(MP_QSTR_writechar), MP_ROM_PTR(&machine_hard_uart_writechar_obj) },
     { MP_ROM_QSTR(MP_QSTR_readchar), MP_ROM_PTR(&machine_hard_uart_readchar_obj) },
     { MP_ROM_QSTR(MP_QSTR_sendbreak), MP_ROM_PTR(&machine_hard_uart_sendbreak_obj) },
+    { MP_ROM_QSTR(MP_QSTR_flush), MP_ROM_PTR(&machine_uart_flush_obj) },
 
     // class constants
 /*

--- a/ports/stm32/machine_uart.c
+++ b/ports/stm32/machine_uart.c
@@ -523,12 +523,20 @@ STATIC mp_obj_t pyb_uart_irq(size_t n_args, const mp_obj_t *pos_args, mp_map_t *
 }
 STATIC MP_DEFINE_CONST_FUN_OBJ_KW(pyb_uart_irq_obj, 1, pyb_uart_irq);
 
+#define UART_FLUSH_TIMEOUT      (3600000)   // 1 hour
+
+STATIC mp_obj_t machine_uart_flush(size_t n_args, const mp_obj_t *args) {
+    return mp_const_true;
+}
+STATIC MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(machine_uart_flush_obj, 1, 2, machine_uart_flush);
+
 STATIC const mp_rom_map_elem_t pyb_uart_locals_dict_table[] = {
     // instance methods
 
     { MP_ROM_QSTR(MP_QSTR_init), MP_ROM_PTR(&pyb_uart_init_obj) },
     { MP_ROM_QSTR(MP_QSTR_deinit), MP_ROM_PTR(&pyb_uart_deinit_obj) },
     { MP_ROM_QSTR(MP_QSTR_any), MP_ROM_PTR(&pyb_uart_any_obj) },
+    { MP_ROM_QSTR(MP_QSTR_flush), MP_ROM_PTR(&machine_uart_flush_obj) },
 
     /// \method read([nbytes])
     { MP_ROM_QSTR(MP_QSTR_read), MP_ROM_PTR(&mp_stream_read_obj) },


### PR DESCRIPTION
uart.flush waits until data, which has been transferred has been sent. Regularly, users ask in the forum for a function like this. API:

rc = uart.flush([timeout])

rc is True, if all data has been sent within the timeout period, false otherwise. The default value for timeout is 1 hour (just a long time). Using a timeout value of 0 the method can be used to test, whether a transfer is ongoing. Supported ports:

-  rp2: For messages shorter than 6 bytes, uart.flush() returns while the last byte is transferred. 
- esp8266
- esp32
- stm32: for the stm32 port, uart.flush() is a dummy function which always returns True,  because uart.write() itself does not return before all data has been sent.
- mimxrt
- nrf: For the nrf port uart.flush() is a dummy function as well, returning always True while the last byte is sent.
- cc3200
- samd: Implemented and kept in the 2nd level commit queue.
