### PR TITLE
rp2: Check for the maximum timeout value of machine.WDT().

### DIFF
--- a/docs/library/machine.WDT.rst
+++ b/docs/library/machine.WDT.rst
@@ -15,7 +15,7 @@ Example usage::
     wdt = WDT(timeout=2000)  # enable it with a timeout of 2s
     wdt.feed()
 
-Availability of this class: pyboard, WiPy, esp8266, esp32.
+Availability of this class: pyboard, WiPy, esp8266, esp32, rp2040, mimxrt.
 
 Constructors
 ------------
@@ -26,7 +26,8 @@ Constructors
    Once it is running the timeout cannot be changed and the WDT cannot be stopped either.
 
    Notes: On the esp32 the minimum timeout is 1 second. On the esp8266 a timeout
-   cannot be specified, it is determined by the underlying system.
+   cannot be specified, it is determined by the underlying system. On rp2040 devices,
+   the maximum timeout is 8338 ms.
 
 Methods
 -------

--- a/docs/rp2/quickref.rst
+++ b/docs/rp2/quickref.rst
@@ -296,6 +296,7 @@ See :ref:`machine.WDT <machine.WDT>`. ::
     wdt = WDT(timeout=5000)
     wdt.feed()
 
+The maximum value for timeout is 8388 ms.
 
 OneWire driver
 --------------

--- a/ports/rp2/machine_wdt.c
+++ b/ports/rp2/machine_wdt.c
@@ -29,6 +29,8 @@
 
 #include "hardware/watchdog.h"
 
+#define WDT_TIMEOUT_MAX    (8388)
+
 typedef struct _machine_wdt_obj_t {
     mp_obj_base_t base;
 } machine_wdt_obj_t;
@@ -53,7 +55,11 @@ STATIC mp_obj_t machine_wdt_make_new(const mp_obj_type_t *type, size_t n_args, s
     }
 
     // Start the watchdog (timeout is in milliseconds).
-    watchdog_enable(args[ARG_timeout].u_int, false);
+    uint32_t timeout = args[ARG_timeout].u_int;
+    if (timeout > WDT_TIMEOUT_MAX) {
+        mp_raise_msg_varg(&mp_type_ValueError, MP_ERROR_TEXT("Timeout exceeds %d."), WDT_TIMEOUT_MAX);
+    }
+    watchdog_enable(timeout, false);
 
     return MP_OBJ_FROM_PTR(&machine_wdt);
 }


### PR DESCRIPTION
The value will be checked for timeout <= 8388.
Notes were added to the documentation.