### PR TITLE
mbedtls: Enable time cert validation.

### DIFF
--- a/ports/mimxrt/mbedtls/mbedtls_config.h
+++ b/ports/mimxrt/mbedtls/mbedtls_config.h
@@ -84,6 +84,8 @@
 #define MBEDTLS_SSL_TLS_C
 #define MBEDTLS_X509_CRT_PARSE_C
 #define MBEDTLS_X509_USE_C
+#define MBEDTLS_HAVE_TIME
+#define MBEDTLS_HAVE_TIME_DATE
 
 // Memory allocation hooks
 #include <stdlib.h>
@@ -93,6 +95,13 @@ void m_tracked_free(void *ptr);
 #define MBEDTLS_PLATFORM_STD_CALLOC m_tracked_calloc
 #define MBEDTLS_PLATFORM_STD_FREE m_tracked_free
 #define MBEDTLS_PLATFORM_SNPRINTF_MACRO snprintf
+
+// Time hook
+time_t platform_mbedtls_time(time_t *timer);
+#define MBEDTLS_PLATFORM_TIME_MACRO platform_mbedtls_time
+#define MBEDTLS_PLATFORM_GMTIME_R_ALT
+typedef time_t mbedtls_time_t;
+struct tm *mbedtls_platform_gmtime_r(const mbedtls_time_t *timer, struct tm *tm_buf);
 
 #include "mbedtls/check_config.h"
 

--- a/ports/mimxrt/mbedtls/mbedtls_port.c
+++ b/ports/mimxrt/mbedtls/mbedtls_port.c
@@ -26,8 +26,23 @@
 
 #ifdef MICROPY_SSL_MBEDTLS
 
+#include "py/runtime.h"
 #include "fsl_trng.h"
 #include "mbedtls_config.h"
+#include "shared/timeutils/timeutils.h"
+#include "extmod/utime_mphal.h"
+#include "fsl_snvs_lp.h"
+
+struct tm {
+    uint16_t tm_year;        // i.e. 2014
+    uint8_t tm_mon;          // 1..12
+    uint8_t tm_mday;         // 1..31
+    uint8_t tm_hour;         // 0..23
+    uint8_t tm_min;          // 0..59
+    uint8_t tm_sec;          // 0..59
+    uint8_t tm_wday;         // 0..6  0 = Monday
+    uint16_t tm_yday;        // 1..366
+};
 
 int mbedtls_hardware_poll(void *data, unsigned char *output, size_t len, size_t *olen) {
 
@@ -36,6 +51,47 @@ int mbedtls_hardware_poll(void *data, unsigned char *output, size_t len, size_t 
     TRNG_GetRandomData(TRNG, output, len);
 
     return 0;
+}
+
+
+time_t platform_mbedtls_time(time_t *timer) {
+    // mbedtls_time requires time in seconds from EPOCH 1970
+    snvs_lp_srtc_datetime_t t;
+    SNVS_LP_SRTC_GetDatetime(SNVS, &t);
+    // EPOCH is 1970 for this port, which leads to the following trouble:
+    // timeutils_seconds_since_epoch() calls timeutils_seconds_since_2000(), and
+    // timeutils_seconds_since_2000() subtracts 2000 from year, but uses
+    // an unsigned number for seconds, That causes an underrun, which is not
+    // fixed by adding the TIMEUTILS_SECONDS_1970_TO_2000.
+    // Masking it to 32 bit for year < 2000 fixes it.
+    return timeutils_seconds_since_epoch(t.year, t.month, t.day, t.hour, t.minute, t.second)
+           & (t.year < 2000 ? 0xffffffff : 0xffffffffffff);
+}
+
+
+struct tm *mbedtls_platform_gmtime_r(const mbedtls_time_t *tt, struct tm *tm_buf) {
+    /**
+     * \param tt     Pointer to an object containing time (in seconds) since the
+     *               epoch to be converted
+     * \param tm_buf Pointer to an object where the results will be stored
+     *
+     * \return      Pointer to an object of type struct tm on success, otherwise
+     *              NULL
+     */
+    int seconds = *tt;
+    timeutils_struct_time_t tmd;
+    timeutils_seconds_since_epoch_to_struct_time(seconds, &tmd);
+    tm_buf->tm_year = tmd.tm_year;
+    tm_buf->tm_mon = tmd.tm_mon;
+    tm_buf->tm_mday = tmd.tm_mday;
+    tm_buf->tm_hour = tmd.tm_hour;
+    tm_buf->tm_min = tmd.tm_min;
+    tm_buf->tm_sec = tmd.tm_sec;
+    tm_buf->tm_wday = tmd.tm_wday;
+    tm_buf->tm_yday = tmd.tm_yday;
+
+
+    return tm_buf;
 }
 
 #endif

--- a/ports/stm32/mbedtls/mbedtls_config.h
+++ b/ports/stm32/mbedtls/mbedtls_config.h
@@ -85,6 +85,9 @@
 #define MBEDTLS_TLS_DEFAULT_ALLOW_SHA1_IN_KEY_EXCHANGE
 #define MBEDTLS_X509_CRT_PARSE_C
 #define MBEDTLS_X509_USE_C
+#define MBEDTLS_HAVE_TIME
+#define MBEDTLS_HAVE_TIME_DATE
+
 
 // Memory allocation hooks
 #include <stdlib.h>
@@ -94,6 +97,13 @@ void m_tracked_free(void *ptr);
 #define MBEDTLS_PLATFORM_STD_CALLOC m_tracked_calloc
 #define MBEDTLS_PLATFORM_STD_FREE m_tracked_free
 #define MBEDTLS_PLATFORM_SNPRINTF_MACRO snprintf
+
+// Time hook
+time_t platform_mbedtls_time(time_t *timer);
+#define MBEDTLS_PLATFORM_TIME_MACRO platform_mbedtls_time
+#define MBEDTLS_PLATFORM_GMTIME_R_ALT
+typedef time_t mbedtls_time_t;
+struct tm *mbedtls_platform_gmtime_r(const mbedtls_time_t *timer, struct tm *tm_buf);
 
 #include "mbedtls/check_config.h"
 

--- a/ports/stm32/mbedtls/mbedtls_port.c
+++ b/ports/stm32/mbedtls/mbedtls_port.c
@@ -26,6 +26,19 @@
 
 #include "rng.h"
 #include "mbedtls_config.h"
+#include "rtc.h"
+#include "shared/timeutils/timeutils.h"
+
+struct tm {
+    uint16_t tm_year;        // i.e. 2014
+    uint8_t tm_mon;          // 1..12
+    uint8_t tm_mday;         // 1..31
+    uint8_t tm_hour;         // 0..23
+    uint8_t tm_min;          // 0..59
+    uint8_t tm_sec;          // 0..59
+    uint8_t tm_wday;         // 0..6  0 = Monday
+    uint16_t tm_yday;        // 1..366
+};
 
 int mbedtls_hardware_poll(void *data, unsigned char *output, size_t len, size_t *olen) {
     uint32_t val = 0;
@@ -41,4 +54,40 @@ int mbedtls_hardware_poll(void *data, unsigned char *output, size_t len, size_t 
         --n;
     }
     return 0;
+}
+
+time_t platform_mbedtls_time(time_t *timer) {
+    // mbedtls_time requires time in seconds from EPOCH 1970
+    rtc_init_finalise();
+    RTC_DateTypeDef date;
+    RTC_TimeTypeDef time;
+    HAL_RTC_GetTime(&RTCHandle, &time, RTC_FORMAT_BIN);
+    HAL_RTC_GetDate(&RTCHandle, &date, RTC_FORMAT_BIN);
+    return timeutils_seconds_since_epoch(2000 + date.Year, date.Month, date.Date, time.Hours, time.Minutes, time.Seconds) + TIMEUTILS_SECONDS_1970_TO_2000;
+}
+
+
+struct tm *mbedtls_platform_gmtime_r(const mbedtls_time_t *tt, struct tm *tm_buf) {
+    /**
+     * \param tt     Pointer to an object containing time (in seconds) since the
+     *               epoch to be converted
+     * \param tm_buf Pointer to an object where the results will be stored
+     *
+     * \return      Pointer to an object of type struct tm on success, otherwise
+     *              NULL
+     */
+    int seconds = *tt;
+    timeutils_struct_time_t tmd;
+    timeutils_seconds_since_epoch_to_struct_time(seconds, &tmd);
+    tm_buf->tm_year = tmd.tm_year;
+    tm_buf->tm_mon = tmd.tm_mon;
+    tm_buf->tm_mday = tmd.tm_mday;
+    tm_buf->tm_hour = tmd.tm_hour;
+    tm_buf->tm_min = tmd.tm_min;
+    tm_buf->tm_sec = tmd.tm_sec;
+    tm_buf->tm_wday = tmd.tm_wday;
+    tm_buf->tm_yday = tmd.tm_yday;
+
+
+    return tm_buf;
 }

--- a/ports/unix/mbedtls/mbedtls_config.h
+++ b/ports/unix/mbedtls/mbedtls_config.h
@@ -88,6 +88,8 @@
 #define MBEDTLS_TLS_DEFAULT_ALLOW_SHA1_IN_KEY_EXCHANGE
 #define MBEDTLS_X509_CRT_PARSE_C
 #define MBEDTLS_X509_USE_C
+#define MBEDTLS_HAVE_TIME
+#define MBEDTLS_HAVE_TIME_DATE
 
 #include "mbedtls/check_config.h"
 


### PR DESCRIPTION
This enables date/time certificate validation for UNIX, STM32* and MIMXRT* ports.

I'm not sure if in STM32 or MIMXRT ports work (I have not tested it since I do not have the required hardware) but if that is not the case it should be close (I hope).

The problem with these two ports is that they do not include `<time.h>` which is required for `MBED_TLS_HAVE_TIME_DATE` to work. From mbedtls `config.h`
```
* \def MBEDTLS_HAVE_TIME_DATE
* System has time.h, time(), and an implementation for
 * mbedtls_platform_gmtime_r() (see below).
 * The time needs to be correct (not necessarily very accurate, but at least
 * the date should be correct). This is used to verify the validity period of
 * X.509 certificates.
 *
 * Comment if your system does not have a correct clock.
 *
 * \note mbedtls_platform_gmtime_r() is an abstraction in platform_util.h that
 * behaves similarly to the gmtime_r() function from the C standard. Refer to
 * the documentation for mbedtls_platform_gmtime_r() for more information.
 *
 * \note It is possible to configure an implementation for
 * mbedtls_platform_gmtime_r() at compile-time by using the macro
 * MBEDTLS_PLATFORM_GMTIME_R_ALT.
 */
```
The solution is to use this macro `MBEDTLS_PLATFORM_GMTIME_R_ALT`

```
/**
 * Uncomment the macro to let Mbed TLS use your alternate implementation of
 * mbedtls_platform_gmtime_r(). This replaces the default implementation in
 * platform_util.c.
 *
 * gmtime() is not a thread-safe function as defined in the C standard. The
 * library will try to use safer implementations of this function, such as
 * gmtime_r() when available. However, if Mbed TLS cannot identify the target
 * system, the implementation of mbedtls_platform_gmtime_r() will default to
 * using the standard gmtime(). In this case, calls from the library to
 * gmtime() will be guarded by the global mutex mbedtls_threading_gmtime_mutex
 * if MBEDTLS_THREADING_C is enabled. We recommend that calls from outside the
 * library are also guarded with this mutex to avoid race conditions. However,
 * if the macro MBEDTLS_PLATFORM_GMTIME_R_ALT is defined, Mbed TLS will
 * unconditionally use the implementation for mbedtls_platform_gmtime_r()
 * supplied at compile time.
 */
//#define MBEDTLS_PLATFORM_GMTIME_R_ALT
```

So I tried to implement this function in both ports following `modutime.c` but not sure if it would work as expected. If anyone with the required hardware could do a test, it would be nice. 👍🏼 

For ESP32 port I have a working solution in #8968 , but it cannot be implemented yet I guess. 

