### PR TITLE
docs/library: Minor style and typo fix.

### DIFF
--- a/docs/library/index.rst
+++ b/docs/library/index.rst
@@ -195,4 +195,4 @@ but also the MicroPython libraries too (e.g. ``machine``, ``bluetooth``, etc).
 The main exception is the port-specific libraries (``pyb``, ``esp``, etc).
 
 *Other than when you specifically want to force the use of the built-in module,
-we recommend always using ``import module`` rather than ``import umodule``.*
+we recommend always using* ``import module`` *rather than* ``import umodule``.

--- a/docs/library/micropython.rst
+++ b/docs/library/micropython.rst
@@ -9,7 +9,7 @@ Functions
 
 .. function:: const(expr)
 
-   Used to declare that the expression is a constant so that the compile can
+   Used to declare that the expression is a constant so that the compiler can
    optimise it.  The use of this function should be as follows::
 
     from micropython import const


### PR DESCRIPTION
This changes

![image](https://user-images.githubusercontent.com/12326241/186253124-656e6e7e-1797-44fb-a552-1ab1b9a8cef5.png)

to

![image](https://user-images.githubusercontent.com/12326241/186252957-b2e2b053-b70e-44e5-842f-6ee97547ef76.png)

Also fix a small typo while at it.

EDIT: Looks like some of this will be going away anyway, so most of this might be irrelevant.