### PR TITLE
mpremote: support 'cp :a :b'

### DIFF
--- a/docs/reference/mpremote.rst
+++ b/docs/reference/mpremote.rst
@@ -262,6 +262,8 @@ Examples
 
   mpremote cp main.py :
 
+  mpremote cp :a.py :b.py
+
   mpremote cp -r dir/ :
 
   mpremote cp a.py b.py : + repl

--- a/tools/mpremote/mpremote/main.py
+++ b/tools/mpremote/mpremote/main.py
@@ -333,10 +333,15 @@ def do_filesystem(pyb, args):
     if fs_args[0] == "cp" and fs_args[1] == "-r":
         fs_args.pop(0)
         fs_args.pop(0)
-        assert fs_args[-1] == ":"
+        if fs_args[-1] != ":":
+            print(f"{_PROG}: 'cp -r' destination must be ':'")
+            sys.exit(1)
         fs_args.pop()
         src_files = []
         for path in fs_args:
+            if path.startswith(":"):
+                print(f"{_PROG}: 'cp -r' source files must be local")
+                sys.exit(1)
             _list_recursive(src_files, path)
         known_dirs = {""}
         pyb.exec_("import uos")

--- a/tools/mpremote/mpremote/main.py
+++ b/tools/mpremote/mpremote/main.py
@@ -354,9 +354,13 @@ def do_filesystem(pyb, args):
                 verbose=verbose,
             )
     else:
-        pyboard.filesystem_command(
-            pyb, fs_args, progress_callback=show_progress_bar, verbose=verbose
-        )
+        try:
+            pyboard.filesystem_command(
+                pyb, fs_args, progress_callback=show_progress_bar, verbose=verbose
+            )
+        except OSError as er:
+            print(f"{_PROG}: {er}")
+            sys.exit(1)
 
 
 def do_edit(pyb, args):

--- a/tools/pyboard.py
+++ b/tools/pyboard.py
@@ -583,7 +583,7 @@ def filesystem_command(pyb, args, progress_callback=None, verbose=False):
         if cmd == "cp":
             srcs = args[:-1]
             dest = args[-1]
-            if srcs[0].startswith("./") or dest.startswith(":"):
+            if dest.startswith(":"):
                 op = pyb.fs_put
                 fmt = "cp %s :%s"
                 dest = fname_remote(dest)


### PR DESCRIPTION
The 'cp' command now supports device-to-device file copy.  As part of this the `cp` command no longer adds any implicit ':' to its arguments.

See related #7602.