### PR TITLE
Ipv6 support for cyw43/rp2

### DIFF
--- a/extmod/network_cyw43.c
+++ b/extmod/network_cyw43.c
@@ -78,13 +78,14 @@ STATIC void network_cyw43_print(const mp_print_t *print, mp_obj_t self_in, mp_pr
     } else {
         status_str = "fail";
     }
+    ip4_addr_t *addr = ip_2_ip4(&netif->ip_addr);
     mp_printf(print, "<CYW43 %s %s %u.%u.%u.%u>",
         self->itf == CYW43_ITF_STA ? "STA" : "AP",
         status_str,
-        netif->ip_addr.addr & 0xff,
-        netif->ip_addr.addr >> 8 & 0xff,
-        netif->ip_addr.addr >> 16 & 0xff,
-        netif->ip_addr.addr >> 24
+        addr->addr & 0xff,
+        addr->addr >> 8 & 0xff,
+        addr->addr >> 16 & 0xff,
+        addr->addr >> 24
         );
 }
 

--- a/extmod/network_wiznet5k.c
+++ b/extmod/network_wiznet5k.c
@@ -305,11 +305,11 @@ STATIC err_t wiznet5k_netif_init(struct netif *netif) {
 
 STATIC void wiznet5k_lwip_init(wiznet5k_obj_t *self) {
     ip_addr_t ipconfig[4];
-    ipconfig[0].addr = 0;
-    ipconfig[1].addr = 0;
-    ipconfig[2].addr = 0;
-    ipconfig[3].addr = 0;
-    netif_add(&self->netif, &ipconfig[0], &ipconfig[1], &ipconfig[2], self, wiznet5k_netif_init, ethernet_input);
+    IP_ADDR4(&ipconfig[0], 0, 0, 0, 0);
+    IP_ADDR4(&ipconfig[1], 0, 0, 0, 0);
+    IP_ADDR4(&ipconfig[2], 0, 0, 0, 0);
+    IP_ADDR4(&ipconfig[3], 0, 0, 0, 0);
+    netif_add(&self->netif, ip_2_ip4(&ipconfig[0]), ip_2_ip4(&ipconfig[1]), ip_2_ip4(&ipconfig[2]), self, wiznet5k_netif_init, ethernet_input);
     self->netif.name[0] = 'e';
     self->netif.name[1] = '0';
     netif_set_default(&self->netif);
@@ -802,7 +802,7 @@ STATIC mp_obj_t wiznet5k_isconnected(mp_obj_t self_in) {
         wizphy_getphylink() == PHY_LINK_ON
         && IS_ACTIVE(self)
         #if WIZNET5K_WITH_LWIP_STACK
-        && self->netif.ip_addr.addr != 0
+        && ip_2_ip4(&self->netif.ip_addr)->addr != 0
         #endif
         );
 }


### PR DESCRIPTION
With these changes ipv6 on rp2 works perfectly for me.

Things I've tested:
- [x] Neighbor solicitation for v6 link local address
- [x] Ping of v6 link-local address
- [x] Receiving a SLAAC address via router advertisement
- [x] Ping a v6 address allocated via SLAAC
- [x] Perform an outgoing connection to a routed v6-address (via default gateway)
- [x] Create a listening ipv6 wildcard socked bound to `::`, and trying to access it via link-local, slaac, and ipv4 (to ensure the dual-stack binding works)

Things that could be improved:
- [ ] `socket.socket().getaddrinfo` only returns the v4 address. It could also return v6 addresses.
  - I've understood the behavior of `getaddrinfo` now: It is actively programmed to only return a single address. And this is the v4-address by default: https://github.com/lwip-tcpip/lwip/blob/089697bb1cadf2d208ed43f936a9e4e4bd9b0b3b/src/core/dns.c#L1552 So dns only returns the v4 address and falls back to the v6 address if both are enabled, which seems fine for most cases, though I personally might prefer v6 over v4, but I guess the default is fine as-is.

If you don't want to enable ipv6 in rpi2 by default at all, I think the changes are still a valuable contribution.