### PR TITLE
stm32/adc: Fix ADCAll can specify invalid channel.

### DIFF
--- a/ports/stm32/adc.c
+++ b/ports/stm32/adc.c
@@ -856,6 +856,9 @@ STATIC mp_obj_t adc_all_make_new(const mp_obj_type_t *type, size_t n_args, size_
 STATIC mp_obj_t adc_all_read_channel(mp_obj_t self_in, mp_obj_t channel) {
     pyb_adc_all_obj_t *self = MP_OBJ_TO_PTR(self_in);
     uint32_t chan = adc_get_internal_channel(mp_obj_get_int(channel));
+    if (!is_adcx_channel(chan)) {
+        mp_raise_msg_varg(&mp_type_ValueError, MP_ERROR_TEXT("not a valid ADC Channel: %d"), chan);
+    }
     uint32_t data = adc_config_and_read_channel(&self->handle, chan);
     return mp_obj_new_int(data);
 }


### PR DESCRIPTION
This PR fixes following problem.

### Problem:
ADCAll can specify invalid channel.

### MicroPython Version
v1.19.1

### Environment
NUCLEO-F446RE

### How to reproduce
Executing this code
```
adcall=pyb.ADCAll(12, 0xffd3)
adcall.read_channel(99)
```
can get integer value.

### Detail of changes
pyb.ADC(channel) checks whether specified channel is valid or have ADC capability like this code:
`adcx=pyb.ADC(99)`
and got result
```
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
ValueError: not a valid ADC Channel: 99
```

but pyb.ADCAll().read_channel() does not check channel and return integer value like this code:
```
adcall=pyb.ADCAll(12, 0xffd3)
adcall.read_channel(99)
```

ADCAll.read_channel() should tell that specified channel is invalid like pyb.ADC().
This change adds checking whether specified channel is valid and throw ValueError if channel is invalid.
This is same as pyb.ADC().

### Effect of changes
Be able to get ValueError exception when invalid channel is specified.
```
adc=pyb.ADCAll(12,0xd3)
adc.read_channel(99)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
ValueError: not a valid ADC Channel: 99
```