### PR TITLE
Tools: Add support for pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,13 @@
+repos:
+  - repo: local
+    hooks:
+      - id: codeformat
+        name: MicroPython codeformat.py for changed files
+        entry: tools/codeformat.py -v -f
+        language: python
+      - id: verifygitlog
+        name: MicroPython git commit message format checker
+        entry: tools/verifygitlog.py --check-file --ignore-rebase
+        language: python
+        verbose: true
+        stages: [commit-msg]

--- a/CODECONVENTIONS.md
+++ b/CODECONVENTIONS.md
@@ -65,6 +65,10 @@ changes to the correct style.  Without arguments this tool will reformat all
 source code (and may take some time to run).  Otherwise pass as arguments to
 the tool the files that changed and it will only reformat those.
 
+**Important**: Use only [uncrustify](https://github.com/uncrustify/uncrustify)
+v0.71 or v0.72 for MicroPython. Different uncrustify versions produce slightly
+different formatting, and the configuration file formats are often incompatible.
+
 Python code conventions
 =======================
 

--- a/CODECONVENTIONS.md
+++ b/CODECONVENTIONS.md
@@ -69,6 +69,38 @@ the tool the files that changed and it will only reformat those.
 v0.71 or v0.72 for MicroPython. Different uncrustify versions produce slightly
 different formatting, and the configuration file formats are often incompatible.
 
+Automatic Pre-Commit Hooks
+==========================
+
+To have code formatting and commit message conventions automatically checked
+using [pre-commit](https://pre-commit.com/), run the following commands in your
+local MicroPython directory:
+
+```
+$ pip install pre-commit
+
+$ pre-commit install
+
+$ pre-commit install --hook-type commit-msg
+```
+
+pre-commit will now automatically run during `git commit` for both code and
+commit message formatting.
+
+The same formatting checks will be run by CI for any Pull Request submitted to
+MicroPython. Pre-commit allows you to see any failure more quickly, and in many
+cases will automatically correct it in your local working copy.
+
+Tips:
+
+* To skip pre-commit checks on a single commit, use `git commit -n` (for
+  `--no-verify`).
+* To ignore the pre-commit message format check temporarily, start the commit
+  message subject line with "WIP" (for "Work In Progress").
+
+(It is also possible to install pre-commit using Brew or other sources, see
+[the docs](https://pre-commit.com/index.html#install) for details.)
+
 Python code conventions
 =======================
 

--- a/tools/codeformat.py
+++ b/tools/codeformat.py
@@ -151,6 +151,11 @@ def main():
     cmd_parser.add_argument("-c", action="store_true", help="Format C code only")
     cmd_parser.add_argument("-p", action="store_true", help="Format Python code only")
     cmd_parser.add_argument("-v", action="store_true", help="Enable verbose output")
+    cmd_parser.add_argument(
+        "-f",
+        action="store_true",
+        help="Filter files provided on the command line against the default list of files to check.",
+    )
     cmd_parser.add_argument("files", nargs="*", help="Run on specific globs")
     args = cmd_parser.parse_args()
 
@@ -162,6 +167,16 @@ def main():
     files = []
     if args.files:
         files = list_files(args.files)
+        if args.f:
+            # Filter against the default list of files. This is a little fiddly
+            # because we need to apply both the inclusion globs given in PATHS
+            # as well as the EXCLUSIONS, and use absolute paths
+            files = set(os.path.abspath(f) for f in files)
+            all_files = set(list_files(PATHS, EXCLUSIONS, TOP))
+            if args.v:  # In verbose mode, log any files we're skipping
+                for f in files - all_files:
+                    print("Not checking: {}".format(f))
+            files = list(files & all_files)
     else:
         files = list_files(PATHS, EXCLUSIONS, TOP)
 

--- a/tools/uncrustify.cfg
+++ b/tools/uncrustify.cfg
@@ -1,5 +1,8 @@
 # Uncrustify-0.71.0_f
 
+# IMPORTANT: Output is different if using Uncrustify 0.73 or newer, and config file format has changed in newer versions.
+# Use version 0.71 or 0.72 to get matching code formatting.
+
 #
 # General options
 #

--- a/tools/verifygitlog.py
+++ b/tools/verifygitlog.py
@@ -7,6 +7,8 @@ import sys
 verbosity = 0  # Show what's going on, 0 1 or 2.
 suggestions = 1  # Set to 0 to not include lengthy suggestions in error messages.
 
+ignore_prefixes = []
+
 
 def verbose(*args):
     if verbosity:
@@ -50,12 +52,21 @@ def verify(sha):
 
     # Message body.
     raw_body = list(git_log("%B", sha, "-n1"))
+    verify_message_body(raw_body, error, warning)
+    return errors, warnings
+
+
+def verify_message_body(raw_body, error, warning):
     if not raw_body:
         error("Message is empty")
-        return errors, warnings
+        return
 
     # Subject line.
     subject_line = raw_body[0]
+    for prefix in ignore_prefixes:
+        if subject_line.startswith(prefix):
+            verbose("Skipping ignored commit message")
+            return
     very_verbose("subject_line", subject_line)
     subject_line_format = r"^[^!]+: [A-Z]+.+ .+\.$"
     if not re.match(subject_line_format, subject_line):
@@ -76,21 +87,23 @@ def verify(sha):
     if not raw_body[-1].startswith("Signed-off-by: ") or "@" not in raw_body[-1]:
         warning("Message should be signed-off")
 
-    return errors, warnings
-
 
 def run(args):
     verbose("run", *args)
     has_errors = False
     has_warnings = False
-    for sha in git_log("%h", *args):
-        errors, warnings = verify(sha)
-        has_errors |= any(errors)
-        has_warnings |= any(warnings)
-        for err in errors:
-            print("error:", err)
-        for err in warnings:
-            print("warning:", err)
+
+    if "--check-file" in args:
+        has_errors, has_warnings = run_check_file(args[-1])
+    else:  # Normal operation
+        for sha in git_log("%h", *args):
+            errors, warnings = verify(sha)
+            has_errors |= any(errors)
+            has_warnings |= any(warnings)
+            for err in errors:
+                print("error:", err)
+            for err in warnings:
+                print("warning:", err)
     if has_errors or has_warnings:
         if suggestions:
             print("See https://github.com/micropython/micropython/blob/master/CODECONVENTIONS.md")
@@ -100,11 +113,40 @@ def run(args):
         sys.exit(1)
 
 
+def run_check_file(filename):
+    verbose("checking commit message from", filename)
+    errors = []
+    warnings = []
+
+    def error(err):
+        errors.append(err)
+
+    def warning(err):
+        warnings.append(err)
+
+    with open(args[-1]) as f:
+        lines = [l.rstrip("\r\n") for l in f]
+        verify_message_body(lines, error, warning)
+
+    for err in errors:
+        print("error:", err)
+    for err in warnings:
+        print("warning:", err)
+
+    return any(errors), any(warnings)
+
+
 def show_help():
-    print("usage: verifygitlog.py [-v -n -h] ...")
+    print("usage: verifygitlog.py [-v -n -h --check-file] ...")
     print("-v  : increase verbosity, can be speficied multiple times")
     print("-n  : do not print multi-line suggestions")
     print("-h  : print this help message and exit")
+    print(
+        "--check-file : Pass a single argument which is a file containing a candidate commit message"
+    )
+    print(
+        "--ignore-rebase : Skip checking commits with git rebase autosquash prefixes or WIP as a prefix"
+    )
     print("... : arguments passed to git log to retrieve commits to verify")
     print("      see https://www.git-scm.com/docs/git-log")
     print("      passing no arguments at all will verify all commits")
@@ -117,6 +159,10 @@ if __name__ == "__main__":
     args = sys.argv[1:]
     verbosity = args.count("-v")
     suggestions = args.count("-n") == 0
+    if "--ignore-rebase" in args:
+        args.remove("--ignore-rebase")
+        ignore_prefixes = ["squash!", "fixup!", "amend!", "WIP"]
+
     if "-h" in args:
         show_help()
     else:


### PR DESCRIPTION
Adds documented support for [pre-commit](https://pre-commit.com/) as an easy way to run the CI code formatting & commit message checks locally.

I went the long way around here, originally trying to adapt existing pre-commit plugins to the MicroPython CI requirements but in the end it was easier to tweak `tools/codeformat.py` and `tools/verifygitlog.py` so they could be easily run from pre-commit.

Also add some documentation about the supported uncrustify versions, as it turns out they are not all the same.

## Extra Information

<details>
<summary>Some notes about differences between existing pre-commit hooks and the MicroPython CI checks here.</summary>


These notes are only for future reference in case anyone wants to try again to use hooks in the future. It's unclear what the benefit would be, unless there are other useful pre-commit hooks added then it's useful to run pre-commit both in CI and locally and get the exact same results.

**uncrustify** has some additional fixups applied by the `fixup_c` function in codeformat.py that will be hard to recreate. Maybe astyle or another tool would be able to approximate them, though?

**black** pretty much works out of the box, some work to adapt file exclusions & inclusions to a multi-line regex, i.e.
```yaml
  - repo: https://github.com/psf/black
    rev: 22.6.0
    hooks:
      - id: black
        args: [ --fast, --line-length=99 ]
        # If adding exclusions here, also add them in tools/codeformat.py
        exclude: |
            (?x)^(
                tests/.+/repl_.+|
                tests/basics/.+
            )$
```
(This currently applies to all .py files, whereas codeformat.py only looks in some directories.)

[gitlint](https://jorisroovers.com/gitlint/) works but is a bit fiddly to configure some of the message requirements exactly the same as verifygitlog.py, for example allowing long lines that contain URLs. A work in progress .gitlint file is:

```
[general]
contrib=contrib-body-requires-signed-off-by

[title-max-length]
line-length=72

[body-max-line-length]
line-length=75

[title-match-regex]
regex=^[^!]+: [A-Z]+.+ .+\.$

[author-valid-email]
regex=(?!noreply)
```
</details>

*This work was funded through GitHub Sponsors.*