### PR TITLE
mimxrt: Five small service type changes.

### DIFF
--- a/docs/mimxrt/pinout.rst
+++ b/docs/mimxrt/pinout.rst
@@ -322,7 +322,8 @@ Olimex RT1010Py             -                 CS0/-/SDO/SDI/SCK        SDCARD wi
 Seeed ARCH MIX     J4_12/-/J4_14/J4_13/J4_15  J3_09/J3_05/J3_08_J3_11
 =================  =========================  =======================  ===============
 
-Pins denoted with (*) are by default not wired at the board.
+Pins denoted with (*) are by default not wired at the board. The CS0 and CS1 signals
+are enabled with the keyword option cs=0 or cs=1 of the SPI object constructor.
 
 .. _mimxrt_i2c_pinout:
 

--- a/docs/mimxrt/quickref.rst
+++ b/docs/mimxrt/quickref.rst
@@ -301,13 +301,16 @@ There are up to four hardware SPI channels that allow faster transmission
 rates (up to 30Mhz).  Hardware SPI is accessed via the
 :ref:`machine.SPI <machine.SPI>` class and has the same methods as software SPI above::
 
-    from machine import SPI
+    from machine import SPI, Pin
 
-    spi = SPI(0, 10000000)
+    cs_pin = Pin(6, Pin.OUT, value=1)
     spi.write('Hello World')
 
 For the assignment of Pins to SPI signals, refer to
 :ref:`Hardware SPI pinout <mimxrt_spi_pinout>`.
+The keyword option cs=n can be used to enable the cs pin 0 or 1 for an automatic cs signal. The
+default is cs=0. Using cs=-1 the automatic cs signal is not created. 
+In that case, cs has to be set by the script. Clearing that assignment requires a power cycle.
 
 Notes:
 

--- a/docs/mimxrt/quickref.rst
+++ b/docs/mimxrt/quickref.rst
@@ -303,13 +303,16 @@ rates (up to 30Mhz).  Hardware SPI is accessed via the
 
     from machine import SPI, Pin
 
+    spi = SPI(0, 10000000)
     cs_pin = Pin(6, Pin.OUT, value=1)
+    cs_pin(0)
     spi.write('Hello World')
+    cs_pin(1)
 
 For the assignment of Pins to SPI signals, refer to
 :ref:`Hardware SPI pinout <mimxrt_spi_pinout>`.
 The keyword option cs=n can be used to enable the cs pin 0 or 1 for an automatic cs signal. The
-default is cs=0. Using cs=-1 the automatic cs signal is not created. 
+default is cs=-1. Using cs=-1 the automatic cs signal is not created. 
 In that case, cs has to be set by the script. Clearing that assignment requires a power cycle.
 
 Notes:

--- a/ports/mimxrt/Makefile
+++ b/ports/mimxrt/Makefile
@@ -128,7 +128,7 @@ SRC_HAL_IMX_C += \
 	$(MCU_DIR)/drivers/fsl_trng.c \
 	$(MCU_DIR)/drivers/fsl_wdog.c \
 	$(MCU_DIR)/system_$(MCU_SERIES).c \
-	$(MCU_DIR)/xip/fsl_flexspi_nor_boot.c \
+	hal/fsl_flexspi_nor_boot.c \
 
 ifeq ($(MICROPY_HW_SDRAM_AVAIL),1)
 SRC_HAL_IMX_C += $(MCU_DIR)/drivers/fsl_semc.c

--- a/ports/mimxrt/boards/common.ld
+++ b/ports/mimxrt/boards/common.ld
@@ -207,7 +207,7 @@ SECTIONS
     __ram_function_end__ = .;
   } > m_itcm  
 
-  __NDATA_ROM = __DATA_ROM + (__ram_function_end__ - __data_start__);
+  __NDATA_ROM = __RAM_FUNCTIONS_ROM + (__ram_function_end__ - __ram_function_start__);
   .ncache.init : AT(__NDATA_ROM)
   {
     __noncachedata_start__ = .;   /* create a global symbol at ncache data start */
@@ -223,7 +223,8 @@ SECTIONS
     __noncachedata_end__ = .;     /* define a global symbol at ncache data end */
   } > m_dtcm
 
-  __DATA_END = __NDATA_ROM + (__noncachedata_init_end__ - __noncachedata_start__);
+  __DATA_END = __NDATA_ROM + (__noncachedata_end__ - __noncachedata_start__);
+  __FLASH_DATA_END = __NDATA_ROM + (__noncachedata_init_end__ - __noncachedata_start__);
   text_end = ORIGIN(m_text) + LENGTH(m_text);
   ASSERT(__DATA_END <= text_end, "region m_text overflowed with text and data")
 
@@ -261,6 +262,8 @@ SECTIONS
     . = ALIGN(8);
     . += STACK_SIZE;
   } > m_dtcm
+
+ 	_flashimagelen = __FLASH_DATA_END - flash_start;
 
   /* Initializes stack on the end of block */
   __StackTop   = ORIGIN(m_dtcm) + LENGTH(m_dtcm);

--- a/ports/mimxrt/hal/fsl_flexspi_nor_boot.c
+++ b/ports/mimxrt/hal/fsl_flexspi_nor_boot.c
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2017 NXP
+ * All rights reserved.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#include "fsl_flexspi_nor_boot.h"
+extern unsigned long _flashimagelen;
+extern unsigned long __etext;
+
+/* Component ID definition, used by tools. */
+#ifndef FSL_COMPONENT_ID
+#define FSL_COMPONENT_ID "platform.drivers.xip_device"
+#endif
+
+#if defined(XIP_BOOT_HEADER_ENABLE) && (XIP_BOOT_HEADER_ENABLE == 1)
+#if defined(__CC_ARM) || defined(__ARMCC_VERSION) || defined(__GNUC__)
+__attribute__((section(".boot_hdr.ivt")))
+#elif defined(__ICCARM__)
+#pragma location=".boot_hdr.ivt"
+#endif
+
+
+/*************************************
+ *  IVT Data
+ *************************************/
+const ivt image_vector_table = {
+    IVT_HEADER,                       /* IVT Header */
+    IMAGE_ENTRY_ADDRESS,              /* Image Entry Function */
+    IVT_RSVD,                         /* Reserved = 0 */
+    (uint32_t)DCD_ADDRESS,            /* Address where DCD information is stored */
+    (uint32_t)BOOT_DATA_ADDRESS,      /* Address where BOOT Data Structure is stored */
+    (uint32_t)&image_vector_table,    /* Pointer to IVT Self (absolute address */
+    (uint32_t)CSF_ADDRESS,            /* Address where CSF file is stored */
+    IVT_RSVD                          /* Reserved = 0 */
+};
+
+#if defined(__CC_ARM) || defined(__ARMCC_VERSION) || defined(__GNUC__)
+__attribute__((section(".boot_hdr.boot_data")))
+#elif defined(__ICCARM__)
+#pragma location=".boot_hdr.boot_data"
+#endif
+/*************************************
+ *  Boot Data
+ *************************************/
+const BOOT_DATA_T boot_data = {
+    FLASH_BASE,               /* boot start location */
+    (uint32_t)&_flashimagelen, /* Image size */
+    PLUGIN_FLAG,              /* Plugin flag*/
+    0xFFFFFFFF                            /* empty - extra data word */
+};
+#endif

--- a/ports/mimxrt/hal/fsl_flexspi_nor_boot.h
+++ b/ports/mimxrt/hal/fsl_flexspi_nor_boot.h
@@ -1,0 +1,114 @@
+/*
+ * Copyright 2017 NXP
+ * All rights reserved.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#ifndef __FLEXSPI_NOR_BOOT_H__
+#define __FLEXSPI_NOR_BOOT_H__
+
+#include <stdint.h>
+#include "board.h"
+
+/*! @name Driver version */
+/*@{*/
+/*! @brief XIP_DEVICE driver version 2.0.0. */
+#define FSL_XIP_DEVICE_DRIVER_VERSION (MAKE_VERSION(2, 0, 0))
+/*@}*/
+
+/*************************************
+ *  IVT Data
+ *************************************/
+typedef struct _ivt_ {
+    /** @ref hdr with tag #HAB_TAG_IVT, length and HAB version fields
+     *  (see @ref data)
+     */
+    uint32_t hdr;
+    /** Absolute address of the first instruction to execute from the
+     *  image
+     */
+    uint32_t entry;
+    /** Reserved in this version of HAB: should be NULL. */
+    uint32_t reserved1;
+    /** Absolute address of the image DCD: may be NULL. */
+    uint32_t dcd;
+    /** Absolute address of the Boot Data: may be NULL, but not interpreted
+     *  any further by HAB
+     */
+    uint32_t boot_data;
+    /** Absolute address of the IVT.*/
+    uint32_t self;
+    /** Absolute address of the image CSF.*/
+    uint32_t csf;
+    /** Reserved in this version of HAB: should be zero. */
+    uint32_t reserved2;
+} ivt;
+
+#define IVT_MAJOR_VERSION           0x4
+#define IVT_MAJOR_VERSION_SHIFT     0x4
+#define IVT_MAJOR_VERSION_MASK      0xF
+#define IVT_MINOR_VERSION           0x3
+#define IVT_MINOR_VERSION_SHIFT     0x0
+#define IVT_MINOR_VERSION_MASK      0xF
+
+#define IVT_VERSION(major, minor)   \
+    ((((major) & IVT_MAJOR_VERSION_MASK) << IVT_MAJOR_VERSION_SHIFT) |  \
+    (((minor) & IVT_MINOR_VERSION_MASK) << IVT_MINOR_VERSION_SHIFT))
+
+/* IVT header */
+#define IVT_TAG_HEADER        0xD1       /**< Image Vector Table */
+#define IVT_SIZE              0x2000
+#define IVT_PAR               IVT_VERSION(IVT_MAJOR_VERSION, IVT_MINOR_VERSION)
+#define IVT_HEADER           (IVT_TAG_HEADER | (IVT_SIZE << 8) | (IVT_PAR << 24))
+
+/* Set resume entry */
+#if defined(__CC_ARM) || defined(__ARMCC_VERSION)
+extern uint32_t __Vectors[];
+extern uint32_t Image$$RW_m_config_text$$Base[];
+#define IMAGE_ENTRY_ADDRESS ((uint32_t)__Vectors)
+#define FLASH_BASE ((uint32_t)Image$$RW_m_config_text$$Base)
+#elif defined(__MCUXPRESSO)
+extern uint32_t __Vectors[];
+extern uint32_t __boot_hdr_start__[];
+#define IMAGE_ENTRY_ADDRESS ((uint32_t)__Vectors)
+#define FLASH_BASE          ((uint32_t)__boot_hdr_start__)
+#elif defined(__ICCARM__)
+extern uint32_t __VECTOR_TABLE[];
+extern uint32_t m_boot_hdr_conf_start[];
+#define IMAGE_ENTRY_ADDRESS ((uint32_t)__VECTOR_TABLE)
+#define FLASH_BASE ((uint32_t)m_boot_hdr_conf_start)
+#elif defined(__GNUC__)
+extern uint32_t __VECTOR_TABLE[];
+extern uint32_t __FLASH_BASE[];
+#define IMAGE_ENTRY_ADDRESS ((uint32_t)__VECTOR_TABLE)
+#define FLASH_BASE ((uint32_t)__FLASH_BASE)
+#endif
+
+#define DCD_ADDRESS           dcd_data
+#define BOOT_DATA_ADDRESS     &boot_data
+#define CSF_ADDRESS           0
+#define IVT_RSVD             (uint32_t)(0x00000000)
+
+/*************************************
+ *  Boot Data
+ *************************************/
+typedef struct _boot_data_ {
+    uint32_t start;         /* boot start location */
+    uint32_t size;          /* size */
+    uint32_t plugin;        /* plugin flag - 1 if downloaded application is plugin */
+    uint32_t placeholder;       /* placehoder to make even 0x10 size */
+}BOOT_DATA_T;
+
+#if defined(BOARD_FLASH_SIZE)
+#define FLASH_SIZE            BOARD_FLASH_SIZE
+#else
+#error "Please define macro BOARD_FLASH_SIZE"
+#endif
+#define PLUGIN_FLAG           (uint32_t)0
+
+/* External Variables */
+const BOOT_DATA_T boot_data;
+extern const uint8_t dcd_data[];
+
+#endif /* __FLEXSPI_NOR_BOOT_H__ */

--- a/ports/mimxrt/machine_spi.c
+++ b/ports/mimxrt/machine_spi.c
@@ -77,7 +77,7 @@ static const iomux_table_t iomux_table[] = {
     IOMUX_TABLE_SPI
 };
 
-bool lpspi_set_iomux(int8_t spi, uint8_t drive, uint8_t cs) {
+bool lpspi_set_iomux(int8_t spi, uint8_t drive, int8_t cs) {
     int index = (spi - 1) * 5;
 
     if (SCK.muxRegister != 0) {
@@ -93,7 +93,7 @@ bool lpspi_set_iomux(int8_t spi, uint8_t drive, uint8_t cs) {
             IOMUXC_SetPinMux(CS1.muxRegister, CS1.muxMode, CS1.inputRegister, CS1.inputDaisy, CS1.configRegister, 0U);
             IOMUXC_SetPinConfig(CS1.muxRegister, CS1.muxMode, CS1.inputRegister, CS1.inputDaisy, CS1.configRegister,
                 pin_generate_config(PIN_PULL_UP_100K, PIN_MODE_OUT, drive, CS1.configRegister));
-        } else {
+        } else if (cs != -1) {
             mp_raise_ValueError(MP_ERROR_TEXT("The chosen CS is not available"));
         }
 
@@ -173,8 +173,9 @@ mp_obj_t machine_spi_make_new(const mp_obj_type_t *type, size_t n_args, size_t n
     }
     self->master_config->lastSckToPcsDelayInNanoSec = self->master_config->betweenTransferDelayInNanoSec;
     self->master_config->pcsToSckDelayInNanoSec = self->master_config->betweenTransferDelayInNanoSec;
-    uint8_t cs = args[ARG_cs].u_int;
-    if (cs <= 1) {
+    int8_t cs = args[ARG_cs].u_int;
+    // The default value 0 is set already, so only cs=1 has to be set.
+    if (cs == 1) {
         self->master_config->whichPcs = cs;
     }
     LPSPI_MasterInit(self->spi_inst, self->master_config, BOARD_BOOTCLOCKRUN_LPSPI_CLK_ROOT);

--- a/ports/mimxrt/machine_spi.c
+++ b/ports/mimxrt/machine_spi.c
@@ -131,7 +131,7 @@ mp_obj_t machine_spi_make_new(const mp_obj_type_t *type, size_t n_args, size_t n
         { MP_QSTR_firstbit, MP_ARG_KW_ONLY | MP_ARG_INT, {.u_int = DEFAULT_SPI_FIRSTBIT} },
         { MP_QSTR_gap_ns,   MP_ARG_KW_ONLY | MP_ARG_INT, {.u_int = -1} },
         { MP_QSTR_drive,    MP_ARG_KW_ONLY | MP_ARG_INT, {.u_int = DEFAULT_SPI_DRIVE} },
-        { MP_QSTR_cs,       MP_ARG_KW_ONLY | MP_ARG_INT, {.u_int = 0} },
+        { MP_QSTR_cs,       MP_ARG_KW_ONLY | MP_ARG_INT, {.u_int = -1} },
     };
 
     // Parse the arguments.
@@ -174,7 +174,9 @@ mp_obj_t machine_spi_make_new(const mp_obj_type_t *type, size_t n_args, size_t n
     self->master_config->lastSckToPcsDelayInNanoSec = self->master_config->betweenTransferDelayInNanoSec;
     self->master_config->pcsToSckDelayInNanoSec = self->master_config->betweenTransferDelayInNanoSec;
     int8_t cs = args[ARG_cs].u_int;
-    // The default value 0 is set already, so only cs=1 has to be set.
+    // In the SPI master_config for automatic CS the value cs=0 is set already,
+    // so only cs=1 has to be addressed here. The case cs == -1 for manual CS is handled
+    // in the function spi_set_iomux() and the value in the master_config can stay at 0.
     if (cs == 1) {
         self->master_config->whichPcs = cs;
     }

--- a/ports/mimxrt/machine_uart.c
+++ b/ports/mimxrt/machine_uart.c
@@ -396,7 +396,7 @@ STATIC mp_uint_t machine_uart_write(mp_obj_t self_in, const void *buf_in, mp_uin
 
         // Wait at least the number of character times for this chunk.
         t = ticks_us64() + (uint64_t)xfer.dataSize * (13000000 / self->config.baudRate_Bps + 1000);
-        while (self->handle.txDataSize) {
+        while (self->tx_status != kStatus_LPUART_TxIdle) {
             // Wait for the first/next character to be sent.
             if (ticks_us64() > t) { // timed out
                 if (self->handle.txDataSize >= size) {

--- a/ports/mimxrt/machine_uart.c
+++ b/ports/mimxrt/machine_uart.c
@@ -245,11 +245,6 @@ STATIC mp_obj_t machine_uart_init_helper(machine_uart_obj_t *self, size_t n_args
         self->lpuart->STAT |= 1 << LPUART_STAT_BRK13_SHIFT;
         LPUART_EnableTx(self->lpuart, true);
 
-        // Allocate the TX ring buffer. Not used yet, but maybe later.
-
-        // ringbuf_alloc(&(self->write_buffer), txbuf_len + 1);
-        // MP_STATE_PORT(rp2_uart_tx_buffer[uart_id]) = self->write_buffer.buf;
-
     }
 
     return MP_OBJ_FROM_PTR(self);

--- a/ports/mimxrt/machine_uart.c
+++ b/ports/mimxrt/machine_uart.c
@@ -438,7 +438,7 @@ STATIC mp_uint_t machine_uart_ioctl(mp_obj_t self_in, mp_uint_t request, mp_uint
                 ret |= MP_STREAM_POLL_RD;
             }
         }
-        if ((flags & MP_STREAM_POLL_WR)) {
+        if ((flags & MP_STREAM_POLL_WR) && (self->tx_status == kStatus_LPUART_TxIdle)) {
             ret |= MP_STREAM_POLL_WR;
         }
     } else if (request == MP_STREAM_FLUSH) {


### PR DESCRIPTION
1. Remove a few commented code lines from machine_uart.c
2. Change the header of the load image to match the new teensy loader, which does not erase the file system any more, given that the header version is 4.3 and the final binary size is properly set in the header. The new Teensy loader will be installed at the device is any sketch is loaded to the Teensy device using the up-to-date teensyduino package. This change would not be needed to keep the file system if #8229 was merged, which is the better solution as being uniform for all boards.
3. Alllow the keyword option cs=-1 for the machine SPI class. In that case, the hardware CS pin will not be controlled by the SPI controller, but has to be set by the application. That allows for arbitrary pins being used for cs.
4. Set the uart ioctl write poll flag properly. It now will be set when the send buffer is empty. Before, it always returned that writing is possible.
5. Fix a regression bug in uart.write() causing data to be sent incomplete.
