### PR TITLE
tools/mpremote: Fix auto-connection bug in macOS and add config option to filter ports eligible for auto-connection.

### DIFF
--- a/docs/reference/mpremote.rst
+++ b/docs/reference/mpremote.rst
@@ -179,6 +179,15 @@ the execution of the tool, if such commands are not explicitly given.  Automatic
 connection will search for the first available serial device. If no action is
 specified then the REPL will be entered.
 
+It is possible to filter the serial devices eligible for auto connection by defining
+``autoconnect_regexp`` in ``.config/mpremote/config.py``:
+
+.. code-block:: python3
+
+    # regular expression used to filter ports eligible for auto connect:
+    autoconnect_regexp = '/dev/cu.usb' # for macOS
+
+
 Once connected to a device, ``mpremote`` will automatically soft-reset the
 device if needed.  This clears the Python heap and restarts the interpreter,
 making sure that subsequent Python code executes in a fresh environment.  Auto
@@ -229,6 +238,8 @@ Any user configuration, including user-defined shortcuts, can be placed in the f
     """,],
         "test": ["mount", ".", "exec", "import test"],
     }
+    
+    autoconnect_regexp = '/dev/cu.usb' # for macOS
 
 
 Examples

--- a/docs/reference/mpremote.rst
+++ b/docs/reference/mpremote.rst
@@ -185,7 +185,7 @@ It is possible to filter the serial devices eligible for auto connection by defi
 .. code-block:: python3
 
     # regular expression used to filter ports eligible for auto connect:
-    autoconnect_regexp = '/dev/cu.usb' # for macOS
+    autoconnect_regexp = '/dev/cu.usbmodem'
 
 
 Once connected to a device, ``mpremote`` will automatically soft-reset the
@@ -238,8 +238,6 @@ Any user configuration, including user-defined shortcuts, can be placed in the f
     """,],
         "test": ["mount", ".", "exec", "import test"],
     }
-    
-    autoconnect_regexp = '/dev/cu.usb' # for macOS
 
 
 Examples

--- a/tools/mpremote/mpremote/main.py
+++ b/tools/mpremote/mpremote/main.py
@@ -240,9 +240,9 @@ def do_connect(args):
         elif dev == "auto":
             # Auto-detect and auto-connect to the first available device.
             try:
-                autoconnect_regexp = load_user_config().__dict__['autoconnect_regexp']
+                autoconnect_regexp = load_user_config().__dict__["autoconnect_regexp"]
             except KeyError:
-                autoconnect_regexp = ''
+                autoconnect_regexp = ""
             for p in sorted(serial.tools.list_ports.grep(autoconnect_regexp)):
                 try:
                     return pyboard.PyboardExtended(p.device, baudrate=115200)

--- a/tools/mpremote/mpremote/main.py
+++ b/tools/mpremote/mpremote/main.py
@@ -242,7 +242,10 @@ def do_connect(args):
             try:
                 autoconnect_regexp = load_user_config().__dict__["autoconnect_regexp"]
             except KeyError:
-                autoconnect_regexp = ""
+                if sys.platform == 'darwin':
+                    autoconnect_regexp = "/dev/cu.usb"
+                else:
+                    autoconnect_regexp = ""
             for p in sorted(serial.tools.list_ports.grep(autoconnect_regexp)):
                 try:
                     return pyboard.PyboardExtended(p.device, baudrate=115200)

--- a/tools/mpremote/mpremote/main.py
+++ b/tools/mpremote/mpremote/main.py
@@ -242,7 +242,7 @@ def do_connect(args):
             try:
                 autoconnect_regexp = load_user_config().__dict__["autoconnect_regexp"]
             except KeyError:
-                if sys.platform == 'darwin':
+                if sys.platform == "darwin":
                     autoconnect_regexp = "/dev/cu.usb"
                 else:
                     autoconnect_regexp = ""

--- a/tools/mpremote/mpremote/main.py
+++ b/tools/mpremote/mpremote/main.py
@@ -239,7 +239,11 @@ def do_connect(args):
             return None
         elif dev == "auto":
             # Auto-detect and auto-connect to the first available device.
-            for p in sorted(serial.tools.list_ports.comports()):
+            try:
+                autoconnect_regexp = load_user_config().__dict__['autoconnect_regexp']
+            except KeyError:
+                autoconnect_regexp = ''
+            for p in sorted(serial.tools.list_ports.grep(autoconnect_regexp)):
                 try:
                     return pyboard.PyboardExtended(p.device, baudrate=115200)
                 except pyboard.PyboardError as er:


### PR DESCRIPTION
Signed-off-by: Mathieu Daëron <mathieu@daeron.fr>