### PR TITLE
esp32/boards: Marge manifest_release modules into standard manifest.

### DIFF
--- a/ports/esp32/boards/manifest.py
+++ b/ports/esp32/boards/manifest.py
@@ -6,3 +6,9 @@ freeze("$(MPY_DIR)/drivers/onewire")
 include("$(MPY_DIR)/extmod/uasyncio/manifest.py")
 include("$(MPY_DIR)/extmod/webrepl/manifest.py")
 include("$(MPY_DIR)/drivers/neopixel/manifest.py")
+
+# Freeze some micropython-lib modules.
+freeze("$(MPY_LIB_DIR)/python-ecosys/urequests", "urequests.py")
+freeze("$(MPY_LIB_DIR)/micropython/upysh", "upysh.py")
+freeze("$(MPY_LIB_DIR)/micropython/umqtt.simple", "umqtt/simple.py")
+freeze("$(MPY_LIB_DIR)/micropython/umqtt.robust", "umqtt/robust.py")

--- a/ports/esp32/boards/manifest_release.py
+++ b/ports/esp32/boards/manifest_release.py
@@ -1,7 +1,0 @@
-include("manifest.py")
-
-freeze("$(MPY_LIB_DIR)/python-ecosys/urequests", "urequests.py")
-
-freeze("$(MPY_LIB_DIR)/micropython/upysh", "upysh.py")
-freeze("$(MPY_LIB_DIR)/micropython/umqtt.simple", "umqtt/simple.py")
-freeze("$(MPY_LIB_DIR)/micropython/umqtt.robust", "umqtt/robust.py")

--- a/tools/autobuild/build-boards.sh
+++ b/tools/autobuild/build-boards.sh
@@ -83,12 +83,7 @@ function build_esp32_boards {
         if idf.py --version | grep -q v4.2; then
             if [ $mcu = esp32 ]; then
                 # build standard esp32-based boards with IDF v4.2
-                if echo $board_json | grep -q GENERIC; then
-                    # traditionally, GENERIC and GENERIC_SPIRAM boards used manifest_release.py
-                    MICROPY_AUTOBUILD_MAKE="$MICROPY_AUTOBUILD_MAKE FROZEN_MANIFEST=$(pwd)/boards/manifest_release.py" build_board $board_json $fw_tag $dest_dir bin elf map
-                else
-                    build_board $board_json $fw_tag $dest_dir bin elf map
-                fi
+                build_board $board_json $fw_tag $dest_dir bin elf map
             fi
         else
             if [ $mcu != esp32 ]; then


### PR DESCRIPTION
Having two separate manifests is confusing.  It's simpler to have the daily builds use the same configuration as the stable, release builds.
