### PR TITLE
tools/pyboard.py: Support for Windows pathname separators.

### DIFF
--- a/tools/pyboard.py
+++ b/tools/pyboard.py
@@ -582,12 +582,12 @@ def filesystem_command(pyb, args, progress_callback=None, verbose=False):
         return src
 
     def fname_cp_dest(src, dest):
-        src = src.rsplit("/", 1)[-1]
+        _, src = os.path.split(src)
         if dest is None or dest == "":
             dest = src
         elif dest == ".":
-            dest = "./" + src
-        elif dest.endswith("/"):
+            dest = os.path.join(".", src)
+        elif dest.endswith(os.path.sep):
             dest += src
         return dest
 


### PR DESCRIPTION
Support issue #9132 .

Windows pathname separators are different from other POSIX ones.

`os.sep` or `os.path.sep` can read the currently used separator. See [#os.sep](https://docs.python.org/3.10/library/os.html#os.sep).

From what I've looked up so far, it works in any python distribution.

I use the following use case test, please ignore the specific pathname and filename：
```
python .\mpremote.py connect COM44 cp D:\temp\test_1.py D:\temp\test_2.py :

python .\mpremote.py connect COM44 cp ..\..\temp\test_1.py :

python .\mpremote.py connect COM44 cp :boot.py D:\temp\

python .\mpremote.py connect COM44 cp :boot.py ..\..\temp\
```

Now both the relative path and the absolute path can be used normally.
