### PR TITLE
docs/zephyr/quickref.rst: Fixed Zsensor API get_xxx value function in docs examples.

### DIFF
--- a/docs/zephyr/quickref.rst
+++ b/docs/zephyr/quickref.rst
@@ -151,7 +151,7 @@ Use the :ref:`zsensor.Sensor <zsensor.Sensor>` class to access sensor data::
     accel.measure()               # obtain a measurement reading from the accelerometer
 
     # each of these prints the value taken by measure()
-    accel.float(zsensor.ACCEL_X)  # print measurement value for accelerometer X-axis sensor channel as float
-    accel.millis(zsensor.ACCEL_Y) # print measurement value for accelerometer Y-axis sensor channel in millionths
-    accel.micro(zsensor.ACCEL_Z)  # print measurement value for accelerometer Z-axis sensor channel in thousandths
-    accel.int(zsensor.ACCEL_X)    # print measurement integer value only for accelerometer X-axis sensor channel
+    accel.get_float(zsensor.ACCEL_X)  # print measurement value for accelerometer X-axis sensor channel as float
+    accel.get_millis(zsensor.ACCEL_Y) # print measurement value for accelerometer Y-axis sensor channel in millionths
+    accel.get_micro(zsensor.ACCEL_Z)  # print measurement value for accelerometer Z-axis sensor channel in thousandths
+    accel.get_int(zsensor.ACCEL_X)    # print measurement integer value only for accelerometer X-axis sensor channel


### PR DESCRIPTION
Minor fix in documentation. The examples of the zephyr zsensor section in the quick reference are not showing the right module function calls for sensor value printing. 