### PR TITLE
extmod/machine_i2c.c: Call MICROPY_PY_EVENT_HOOK during i2c.scan().

### DIFF
--- a/extmod/machine_i2c.c
+++ b/extmod/machine_i2c.c
@@ -328,6 +328,9 @@ STATIC mp_obj_t machine_i2c_scan(mp_obj_t self_in) {
         if (ret == 0) {
             mp_obj_list_append(list, MP_OBJ_NEW_SMALL_INT(addr));
         }
+        #ifdef MICROPY_EVENT_POLL_HOOK
+        MICROPY_EVENT_POLL_HOOK
+        #endif
     }
     return list;
 }


### PR DESCRIPTION
Avoiding a watchdog reset during i2c.scan() if the hardware is not
properly set up and allowing to stop with Keyboard Interrupt.