### PR TITLE
stm32/pyb_i2c: Fix pyb.i2c() with dma=True does not work.

### DIFF
--- a/ports/stm32/pyb_i2c.c
+++ b/ports/stm32/pyb_i2c.c
@@ -472,6 +472,17 @@ void i2c_ev_irq_handler(mp_uint_t i2c_id) {
 
     #if defined(STM32F4)
 
+    if (hi2c->Instance->SR1 & I2C_FLAG_SB) {
+        if (hi2c->State == HAL_I2C_STATE_BUSY_TX) {
+            hi2c->Instance->DR = I2C_7BIT_ADD_WRITE(hi2c->Devaddress);
+        } else {
+            hi2c->Instance->DR = I2C_7BIT_ADD_READ(hi2c->Devaddress);
+        }
+    } else if (hi2c->Instance->SR1 & I2C_FLAG_ADDR) {
+        __IO uint32_t tmp_sr2;
+        tmp_sr2 = hi2c->Instance->SR2;
+        UNUSED(tmp_sr2);
+    } else
     if (hi2c->Instance->SR1 & I2C_FLAG_BTF && hi2c->State == HAL_I2C_STATE_BUSY_TX) {
         if (hi2c->XferCount != 0U) {
             hi2c->Instance->DR = *hi2c->pBuffPtr++;


### PR DESCRIPTION
This PR fixes following problem.

### Problem:
pyb.i2c with dma=True does not work.
This issue was posted #2643.

### MicroPython Version
v1.19.1

### Envirionment
NUCLEO-F446RE

### How to reproduce
Excuting this code
```
i2c = I2C(1, I2C.CONTROLLER, dma=True)
i2c.send(data, addr=i2c_addr)
```
i2c.send() does not return and the board needs reset.
This code works when dma=False.

### Detail of changes
According to the specification, I2Cx_EV_IRQHandler should
 - Write DR to address when Start condition generated.
 - Clear ADDR by reading SR2 after reading SR2 when address sent. 

These processes are included in HAL_I2C_EV_IRQHandler(), however the executable file size increses about 2KB if HAL_I2C_EV_IRQHandler is called.

This change adds above processes to i2c_ev_irq_handler.

### Effect of changes
Be able to use pyb.i2c with dma=True.
The case of NUCLEO-F446RE, the executable file size increases less than 100Byte.