### PR TITLE
stm32/timer: Cannot specify timer callbacks using callback().

### DIFF
--- a/ports/stm32/timer.c
+++ b/ports/stm32/timer.c
@@ -1576,6 +1576,7 @@ STATIC mp_obj_t pyb_timer_channel_callback(mp_obj_t self_in, mp_obj_t callback) 
         switch (self->mode) {
             case CHANNEL_MODE_PWM_NORMAL:
             case CHANNEL_MODE_PWM_INVERTED:
+                HAL_TIM_PWM_Stop_IT(&self->timer->tim, TIMER_CHANNEL(self));
                 HAL_TIM_PWM_Start_IT(&self->timer->tim, TIMER_CHANNEL(self));
                 break;
             case CHANNEL_MODE_OC_TIMING:
@@ -1584,9 +1585,11 @@ STATIC mp_obj_t pyb_timer_channel_callback(mp_obj_t self_in, mp_obj_t callback) 
             case CHANNEL_MODE_OC_TOGGLE:
             case CHANNEL_MODE_OC_FORCED_ACTIVE:
             case CHANNEL_MODE_OC_FORCED_INACTIVE:
+                HAL_TIM_OC_Stop_IT(&self->timer->tim, TIMER_CHANNEL(self));
                 HAL_TIM_OC_Start_IT(&self->timer->tim, TIMER_CHANNEL(self));
                 break;
             case CHANNEL_MODE_IC:
+                HAL_TIM_IC_Stop_IT(&self->timer->tim, TIMER_CHANNEL(self));
                 HAL_TIM_IC_Start_IT(&self->timer->tim, TIMER_CHANNEL(self));
                 break;
         }


### PR DESCRIPTION
This PR fixes issue #8732.

### MicroPython Version
v1.19.1

### How to reproduce
Execute attached in #8732.
Specified callback is not called.

### Detail of changes
Since HAL version 1.17.0, HAL_TIM_IC_Start_IT() checks whether specified channel of timer is busy or not.
```
+HAL_StatusTypeDef HAL_TIM_IC_Start_IT(TIM_HandleTypeDef *htim, uint32_t Channel)
 {
+  uint32_t tmpsmcr;
+  HAL_TIM_ChannelStateTypeDef channel_state = TIM_CHANNEL_STATE_GET(htim, Channel);
+  HAL_TIM_ChannelStateTypeDef complementary_channel_state = TIM_CHANNEL_N_STATE_GET(htim, Channel);
+
   /* Check the parameters */
   assert_param(IS_TIM_CCX_INSTANCE(htim->Instance, Channel));

+  /* Check the TIM channel state */
+  if ((channel_state != HAL_TIM_CHANNEL_STATE_READY)
+      || (complementary_channel_state != HAL_TIM_CHANNEL_STATE_READY))
+  {
+    return HAL_ERROR;
+  }
+
+  /* Set the TIM channel state */
+  TIM_CHANNEL_STATE_SET(htim, Channel, HAL_TIM_CHANNEL_STATE_BUSY);
+  TIM_CHANNEL_N_STATE_SET(htim, Channel, HAL_TIM_CHANNEL_STATE_BUSY);
+
```
For more detail of changes, see `git diff 540ae5c5 9153dc73 STM32L4xx_HAL_Driver/Src/stm32l4xx_hal_tim.c` in lib/stm32lib.

timer.c calls HAL_TIM_IC_Start() when callback parameter is not specified.
https://github.com/micropython/micropython/blob/0b26efe73dd3396bdc2b77651a78d9f2edeb9004/ports/stm32/timer.c#L1249-L1253
After callback() is called by python, call HAL_TIM_IC_Start_IT() at
https://github.com/micropython/micropython/blob/0b26efe73dd3396bdc2b77651a78d9f2edeb9004/ports/stm32/timer.c#L1589-L1591
but the timer is already running, so HAL_TIM_IC_Start_IT() returns HAL_ERROR and irq of timer is not enabled here.

This issue is not occurred if Timer.channel() is called with paramerter 'callback' because HAL_TIM_IC_Start_IT() is called in pyb_timer_channel_callback() and irq of timer is enabled.

To prevent this error, call HAL_TIM_IC_Stop_IT() before HAL_TIM_IC_Start_IT().
Mode PWM and OC have same issue, so I also fixed those.