### PR TITLE
extmod/nimble: Add missing C file to makefile.

### DIFF
--- a/extmod/nimble/nimble.mk
+++ b/extmod/nimble/nimble.mk
@@ -84,6 +84,7 @@ LIB_SRC_C += $(addprefix $(NIMBLE_LIB_DIR)/, \
 		ble_uuid.c \
 		) \
 	nimble/host/util/src/addr.c \
+	nimble/host/store/ram/src/ble_store_ram.c \
 	nimble/transport/uart/src/ble_hci_uart.c \
 	$(addprefix porting/nimble/src/, \
 		endian.c \
@@ -94,7 +95,6 @@ LIB_SRC_C += $(addprefix $(NIMBLE_LIB_DIR)/, \
 		os_msys_init.c \
 		) \
 	)
-	# nimble/host/store/ram/src/ble_store_ram.c \
 
 EXTMOD_SRC_C += $(addprefix $(NIMBLE_EXTMOD_DIR)/, \
 	nimble/nimble_npl_os.c \


### PR DESCRIPTION
Without this, I get the following linker fault when compiling with GCC 11.3 on osx:

```
LINK build-PYBD_SF2/firmware.elf
/Applications/ArmGNUToolchain/11.3.rel1/arm-none-eabi/bin/../lib/gcc/arm-none-eabi/11.3.1/../../../../arm-none-eabi/bin/ld: build-PYBD_SF2/lib/mynewt-nimble/porting/nimble/src/nimble_port.o: in function `nimble_port_init':
<<<rootpath>>>/micropython/ports/stm32/../../lib/mynewt-nimble/porting/nimble/src/nimble_port.c:48: undefined reference to `ble_store_ram_init'
```

However, I did not test the ble part of the FW. This specific file was commented out in the nimble makefile by @jimmo, so not sure why that was done, perhaps there needs to be another solution to this?