### PR TITLE
stm32/boards/LEGO_HUB_NO6: Update manifest to new format.

### DIFF
--- a/ports/stm32/boards/LEGO_HUB_NO6/manifest.py
+++ b/ports/stm32/boards/LEGO_HUB_NO6/manifest.py
@@ -3,5 +3,6 @@
 include("$(PORT_DIR)/boards/manifest.py")
 
 # Modules for application firmware update.
-freeze("$(PORT_DIR)/mboot", "fwupdate.py", opt=3)
-freeze("$(BOARD_DIR)", ("spiflash.py", "appupdate.py"), opt=3)
+module("fwupdate.py", base_path="$(PORT_DIR)/mboot", opt=3)
+module("spiflash.py", opt=3)
+module("appupdate.py", opt=3)


### PR DESCRIPTION
This was added after 203dae41f and missed in the rebase.
