### PR TITLE
stm32: only freeze LCD160CR driver in PYB board firmware, and don't include tests

### DIFF
--- a/docs/pyboard/tutorial/lcd160cr_skin.rst
+++ b/docs/pyboard/tutorial/lcd160cr_skin.rst
@@ -40,9 +40,9 @@ Testing the display
 
 There is a test program which you can use to test the features of the display,
 and which also serves as a basis to start creating your own code that uses the
-LCD.  This test program is included in recent versions of the pyboard firmware
-and is also available on GitHub
+LCD.  This test program is available on GitHub
 `here <https://github.com/micropython/micropython/blob/master/drivers/display/lcd160cr_test.py>`__.
+Copy it to the board over USB mass storage, or by using `mpremote`.
 
 To run the test from the MicroPython prompt do::
 

--- a/docs/reference/mpremote.rst
+++ b/docs/reference/mpremote.rst
@@ -1,3 +1,5 @@
+.. _mpremote:
+
 MicroPython remote control: mpremote
 ====================================
 

--- a/drivers/display/manifest.py
+++ b/drivers/display/manifest.py
@@ -1,5 +1,5 @@
 # TODO: Split these into separate directories with their own manifests.
-options.defaults(lcd160cr=False, ssd1306=False, test=True)
+options.defaults(lcd160cr=False, ssd1306=False, test=False)
 
 if options.lcd160cr:
     module("lcd160cr.py", opt=3)

--- a/ports/stm32/boards/PYBLITEV10/mpconfigboard.mk
+++ b/ports/stm32/boards/PYBLITEV10/mpconfigboard.mk
@@ -24,3 +24,6 @@ endif
 ifeq ($(BOARD_VARIANT),"network")
 MICROPY_PY_NETWORK_WIZNET5K=5200
 endif
+
+# PYB-specific frozen modules
+FROZEN_MANIFEST ?= boards/PYBV10/manifest.py

--- a/ports/stm32/boards/PYBV10/manifest.py
+++ b/ports/stm32/boards/PYBV10/manifest.py
@@ -1,3 +1,2 @@
 include("$(PORT_DIR)/boards/manifest.py")
 include("$(PORT_DIR)/boards/manifest_pyboard.py")
-include("$(MPY_DIR)/extmod/webrepl")

--- a/ports/stm32/boards/PYBV10/mpconfigboard.mk
+++ b/ports/stm32/boards/PYBV10/mpconfigboard.mk
@@ -34,3 +34,6 @@ endif
 ifeq ($(BOARD_VARIANT),"network")
 MICROPY_PY_NETWORK_WIZNET5K=5200
 endif
+
+# PYB-specific frozen modules
+FROZEN_MANIFEST ?= $(BOARD_DIR)/manifest.py

--- a/ports/stm32/boards/PYBV11/mpconfigboard.mk
+++ b/ports/stm32/boards/PYBV11/mpconfigboard.mk
@@ -34,3 +34,6 @@ endif
 ifeq ($(BOARD_VARIANT),"network")
 MICROPY_PY_NETWORK_WIZNET5K=5200
 endif
+
+# PYB-specific frozen modules
+FROZEN_MANIFEST ?= boards/PYBV10/manifest.py

--- a/ports/stm32/boards/manifest.py
+++ b/ports/stm32/boards/manifest.py
@@ -1,5 +1,4 @@
 include("$(MPY_DIR)/extmod/uasyncio")
 
 include("$(MPY_DIR)/drivers/dht")
-include("$(MPY_DIR)/drivers/display", lcd160cr=True, test=True)
 include("$(MPY_DIR)/drivers/onewire", ds18x20=False)

--- a/ports/stm32/boards/manifest_pyboard.py
+++ b/ports/stm32/boards/manifest_pyboard.py
@@ -1,0 +1,1 @@
+include("$(MPY_DIR)/drivers/display", lcd160cr=True)


### PR DESCRIPTION
Fixes issue #8056.