### PR TITLE
docs/library/time.rst: fix description of return results in time.mktime()

### DIFF
--- a/docs/library/time.rst
+++ b/docs/library/time.rst
@@ -61,7 +61,8 @@ Functions
 
    This is inverse function of localtime. It's argument is a full 8-tuple
    which expresses a time as per localtime. It returns an integer which is
-   the number of seconds since Jan 1, 2000.
+   the number of seconds since the epoch - usually Jan 1, 1970 (Epoch year 
+   may be determined with ``gmtime(0)[0]``).
 
 .. function:: sleep(seconds)
 


### PR DESCRIPTION
Currently it states that the result is the number of seconds since
Jan 1, 2000 - however at least on RP2040 that isn't the case 
and further up the same page of documentation it is stated that 
the epoch is usually Jan 1, 1970.