### PR TITLE
rp2: Use pico-sdk's pin defaults for I2C/SPI.

### DIFF
--- a/ports/rp2/boards/ADAFRUIT_FEATHER_RP2040/mpconfigboard.h
+++ b/ports/rp2/boards/ADAFRUIT_FEATHER_RP2040/mpconfigboard.h
@@ -7,14 +7,6 @@
 #define MICROPY_HW_USB_VID (0x239A)
 #define MICROPY_HW_USB_PID (0x80F2)
 
-// STEMMA QT / Qwiic on I2C1
-#define MICROPY_HW_I2C1_SCL  (3)
-#define MICROPY_HW_I2C1_SDA  (2)
-
-#define MICROPY_HW_SPI0_SCK  (18)
-#define MICROPY_HW_SPI0_MOSI (19)
-#define MICROPY_HW_SPI0_MISO (20)
-
 // NeoPixel GPIO16, power not toggleable
 
 // Red user LED GPIO13

--- a/ports/rp2/boards/ADAFRUIT_ITSYBITSY_RP2040/mpconfigboard.h
+++ b/ports/rp2/boards/ADAFRUIT_ITSYBITSY_RP2040/mpconfigboard.h
@@ -7,13 +7,6 @@
 #define MICROPY_HW_USB_VID (0x239A)
 #define MICROPY_HW_USB_PID (0x80FE)
 
-#define MICROPY_HW_I2C0_SCL  (3)
-#define MICROPY_HW_I2C0_SDA  (2)
-
-#define MICROPY_HW_SPI0_SCK  (18)
-#define MICROPY_HW_SPI0_MOSI (19)
-#define MICROPY_HW_SPI0_MISO (20)
-
 // NeoPixel data GPIO17, power GPIO16
 
 // Red user LED GPIO11

--- a/ports/rp2/boards/ADAFRUIT_QTPY_RP2040/mpconfigboard.h
+++ b/ports/rp2/boards/ADAFRUIT_QTPY_RP2040/mpconfigboard.h
@@ -12,16 +12,9 @@
 #define MICROPY_HW_UART1_CTS (10)
 #define MICROPY_HW_UART1_RTS (7)
 
-#define MICROPY_HW_I2C0_SCL  (25)
-#define MICROPY_HW_I2C0_SDA  (24)
-
-// STEMMA QT / Qwiic on I2C1
+// STEMMA QT / Qwiic on (non-default) I2C1
 #define MICROPY_HW_I2C1_SCL  (23)
 #define MICROPY_HW_I2C1_SDA  (22)
-
-#define MICROPY_HW_SPI0_SCK  (6)
-#define MICROPY_HW_SPI0_MOSI (3)
-#define MICROPY_HW_SPI0_MISO (4)
 
 // NeoPixel data GPIO12, power GPIO11
 

--- a/ports/rp2/boards/ARDUINO_NANO_RP2040_CONNECT/mpconfigboard.h
+++ b/ports/rp2/boards/ARDUINO_NANO_RP2040_CONNECT/mpconfigboard.h
@@ -22,16 +22,12 @@
 #define MICROPY_HW_UART1_CTS            (10)
 #define MICROPY_HW_UART1_RTS            (11)
 
-// SPI 1 config.
+// SPI 1 config (non-default).
 #define MICROPY_HW_SPI1_SCK             (14)
 #define MICROPY_HW_SPI1_MOSI            (11)
 #define MICROPY_HW_SPI1_MISO            (8)
 
-// I2C0 config.
-#define MICROPY_HW_I2C0_SCL             (13)
-#define MICROPY_HW_I2C0_SDA             (12)
-
-// I2C1 config.
+// I2C1 config (non-default).
 #define MICROPY_HW_I2C1_SCL             (27)
 #define MICROPY_HW_I2C1_SDA             (26)
 

--- a/ports/rp2/boards/GARATRONIC_PYBSTICK26_RP2040/mpconfigboard.cmake
+++ b/ports/rp2/boards/GARATRONIC_PYBSTICK26_RP2040/mpconfigboard.cmake
@@ -1,3 +1,1 @@
 # cmake file
-
-set(PICO_BOARD garatronic_pybstick26_rp2040)

--- a/ports/rp2/boards/PICO_W/mpconfigboard.cmake
+++ b/ports/rp2/boards/PICO_W/mpconfigboard.cmake
@@ -1,6 +1,4 @@
 # cmake file for Raspberry Pi Pico W
-set(MICROPY_BOARD PICO_W)
-
 set(MICROPY_PY_LWIP ON)
 set(MICROPY_PY_NETWORK_CYW43 ON)
 

--- a/ports/rp2/boards/PIMORONI_PICOLIPO_16MB/mpconfigboard.h
+++ b/ports/rp2/boards/PIMORONI_PICOLIPO_16MB/mpconfigboard.h
@@ -11,14 +11,6 @@
 #define MICROPY_HW_UART1_CTS (10)
 #define MICROPY_HW_UART1_RTS (11)
 
-// Qwiic on I2C0
-#define MICROPY_HW_I2C0_SCL  (4)
-#define MICROPY_HW_I2C0_SDA  (5)
-
-#define MICROPY_HW_SPI0_SCK  (18)
-#define MICROPY_HW_SPI0_MOSI (19)
-#define MICROPY_HW_SPI0_MISO (16)
-
 // User LED GPIO25
 
 // VBUS_SENSE GPIO24

--- a/ports/rp2/boards/PIMORONI_PICOLIPO_4MB/mpconfigboard.h
+++ b/ports/rp2/boards/PIMORONI_PICOLIPO_4MB/mpconfigboard.h
@@ -11,14 +11,6 @@
 #define MICROPY_HW_UART1_CTS (10)
 #define MICROPY_HW_UART1_RTS (11)
 
-// Qwiic on I2C0
-#define MICROPY_HW_I2C0_SCL  (4)
-#define MICROPY_HW_I2C0_SDA  (5)
-
-#define MICROPY_HW_SPI0_SCK  (18)
-#define MICROPY_HW_SPI0_MOSI (19)
-#define MICROPY_HW_SPI0_MISO (16)
-
 // User LED GPIO25
 
 // VBUS_SENSE GPIO24

--- a/ports/rp2/boards/PIMORONI_TINY2040/mpconfigboard.h
+++ b/ports/rp2/boards/PIMORONI_TINY2040/mpconfigboard.h
@@ -6,6 +6,7 @@
 #define MICROPY_HW_USB_VID (0x16D0)
 #define MICROPY_HW_USB_PID (0x08C7)
 
+// I2C0 (non-default)
 #define MICROPY_HW_I2C0_SCL  (4)
 #define MICROPY_HW_I2C0_SDA  (5)
 

--- a/ports/rp2/boards/SPARKFUN_PROMICRO/mpconfigboard.h
+++ b/ports/rp2/boards/SPARKFUN_PROMICRO/mpconfigboard.h
@@ -11,12 +11,4 @@
 #define MICROPY_HW_UART1_CTS (10)
 #define MICROPY_HW_UART1_RTS (11)
 
-// Qwiic on I2C0
-#define MICROPY_HW_I2C0_SCL  (17)
-#define MICROPY_HW_I2C0_SDA  (16)
-
-#define MICROPY_HW_SPI0_SCK  (22)
-#define MICROPY_HW_SPI0_MOSI (23)
-#define MICROPY_HW_SPI0_MISO (20)
-
 // NeoPixel data GPIO25, power not toggleable

--- a/ports/rp2/boards/SPARKFUN_THINGPLUS/mpconfigboard.h
+++ b/ports/rp2/boards/SPARKFUN_THINGPLUS/mpconfigboard.h
@@ -9,15 +9,7 @@
 #define MICROPY_HW_I2C0_SCL  (17)
 #define MICROPY_HW_I2C0_SDA  (16)
 
-// Qwiic on I2C1
-#define MICROPY_HW_I2C1_SCL  (7)
-#define MICROPY_HW_I2C1_SDA  (6)
-
-#define MICROPY_HW_SPI0_SCK  (2)
-#define MICROPY_HW_SPI0_MOSI (3)
-#define MICROPY_HW_SPI0_MISO (4)
-
-// MicroSD on SPI1
+// MicroSD on SPI1 (non-default)
 #define MICROPY_HW_SPI1_SCK  (14)
 #define MICROPY_HW_SPI1_MOSI (15)
 #define MICROPY_HW_SPI1_MISO (12)

--- a/ports/rp2/boards/W5100S_EVB_PICO/mpconfigboard.cmake
+++ b/ports/rp2/boards/W5100S_EVB_PICO/mpconfigboard.cmake
@@ -1,4 +1,4 @@
 # cmake file for Wiznet W5100S-EVB-Pico.
-set(PICO_BOARD pico)
+set(PICO_BOARD wiznet_w5100s_evb_pico)
 set(MICROPY_PY_NETWORK_WIZNET5K W5100S)
 set(MICROPY_PY_LWIP 1)

--- a/ports/rp2/boards/W5500_EVB_PICO/mpconfigboard.cmake
+++ b/ports/rp2/boards/W5500_EVB_PICO/mpconfigboard.cmake
@@ -1,4 +1,4 @@
 # cmake file for Wiznet W5500-EVB-Pico.
-set(PICO_BOARD pico)
+set(PICO_BOARD wiznet_w5100s_evb_pico)
 set(MICROPY_PY_NETWORK_WIZNET5K W5500)
 set(MICROPY_PY_LWIP 1)

--- a/ports/rp2/machine_i2c.c
+++ b/ports/rp2/machine_i2c.c
@@ -35,13 +35,23 @@
 #define DEFAULT_I2C_FREQ (400000)
 
 #ifndef MICROPY_HW_I2C0_SCL
+#if PICO_DEFAULT_I2C == 0
+#define MICROPY_HW_I2C0_SCL (PICO_DEFAULT_I2C_SCL_PIN)
+#define MICROPY_HW_I2C0_SDA (PICO_DEFAULT_I2C_SDA_PIN)
+#else
 #define MICROPY_HW_I2C0_SCL (9)
 #define MICROPY_HW_I2C0_SDA (8)
 #endif
+#endif
 
 #ifndef MICROPY_HW_I2C1_SCL
+#if PICO_DEFAULT_I2C == 1
+#define MICROPY_HW_I2C1_SCL (PICO_DEFAULT_I2C_SCL_PIN)
+#define MICROPY_HW_I2C1_SDA (PICO_DEFAULT_I2C_SDA_PIN)
+#else
 #define MICROPY_HW_I2C1_SCL (7)
 #define MICROPY_HW_I2C1_SDA (6)
+#endif
 #endif
 
 // SDA/SCL on even/odd pins, I2C0/I2C1 on even/odd pairs of pins.

--- a/ports/rp2/machine_spi.c
+++ b/ports/rp2/machine_spi.c
@@ -40,20 +40,36 @@
 #define DEFAULT_SPI_FIRSTBIT    (SPI_MSB_FIRST)
 
 #ifndef MICROPY_HW_SPI0_SCK
+#if PICO_DEFAULT_SPI == 0
+#define MICROPY_HW_SPI0_SCK     (PICO_DEFAULT_SPI_SCK_PIN)
+#define MICROPY_HW_SPI0_MOSI    (PICO_DEFAULT_SPI_TX_PIN)
+#define MICROPY_HW_SPI0_MISO    (PICO_DEFAULT_SPI_RX_PIN)
+#else
 #define MICROPY_HW_SPI0_SCK     (6)
 #define MICROPY_HW_SPI0_MOSI    (7)
 #define MICROPY_HW_SPI0_MISO    (4)
 #endif
+#endif
 
 #ifndef MICROPY_HW_SPI1_SCK
+#if PICO_DEFAULT_SPI == 1
+#define MICROPY_HW_SPI1_SCK     (PICO_DEFAULT_SPI_SCK_PIN)
+#define MICROPY_HW_SPI1_MOSI    (PICO_DEFAULT_SPI_TX_PIN)
+#define MICROPY_HW_SPI1_MISO    (PICO_DEFAULT_SPI_RX_PIN)
+#else
 #define MICROPY_HW_SPI1_SCK     (10)
 #define MICROPY_HW_SPI1_MOSI    (11)
 #define MICROPY_HW_SPI1_MISO    (8)
 #endif
+#endif
 
+// SPI0 can be GP{0..7,16..23}, SPI1 can be GP{8..15,24..29}.
 #define IS_VALID_PERIPH(spi, pin)   ((((pin) & 8) >> 3) == (spi))
+// GP{2,6,10,14,...}
 #define IS_VALID_SCK(spi, pin)      (((pin) & 3) == 2 && IS_VALID_PERIPH(spi, pin))
+// GP{3,7,11,15,...}
 #define IS_VALID_MOSI(spi, pin)     (((pin) & 3) == 3 && IS_VALID_PERIPH(spi, pin))
+// GP{0,4,8,10,...}
 #define IS_VALID_MISO(spi, pin)     (((pin) & 3) == 0 && IS_VALID_PERIPH(spi, pin))
 
 typedef struct _machine_spi_obj_t {


### PR DESCRIPTION
In summary, this PR makes it so that if you do:

```py
spi = machine.SPI(n, <baud>)
```

or equivalently for `machine.I2C`, where `n` is `PICO_DEFAULT_SPI` (or `PICO_DEFAULT_I2C`) then the default pins defined in the pico-sdk's board definition header file will be used.

The rationale is that someone should be able to follow the pinout, e.g. https://datasheets.raspberrypi.com/pico/Pico-R3-A4-Pinout.pdf, and see that SPI0 uses pins 18,19,16 and therefore safely assume that `machine.SPI(0)` will match that. Before this PR, you'd get 6,7,4.

This was reported originally in the Discord as `network.WIZNET5K(machine.SPI(0, 10_000_000), cs, rst)` which causes the wiznet driver to hang as it's using the wrong pins (that's a separate issue...). This may also be related to https://github.com/orgs/micropython/discussions/9199

So this PR:
 - Makes sure all rp2 boards use the correct pico-sdk board (via the `PICO_BOARD` cmake variable).
 - Make `machine.SPI` and `machine.I2C` use the pico-sdk pins for the board's default SPI and I2C instances.
 - Remove any overrides from mpconfigport.h that set the pins for the default instances.