### PR TITLE
drivers/onewire/manifest.py: Include ds18x20 by default.

### DIFF
--- a/drivers/onewire/manifest.py
+++ b/drivers/onewire/manifest.py
@@ -1,4 +1,4 @@
-options.defaults(ds18x20=False)
+options.defaults(ds18x20=True)
 
 module("onewire.py", opt=3)
 


### PR DESCRIPTION
Ports that don't use ds18x20 explicitly set the option to false.

Fixes #9232

(Prefer to merge #9220 though which also includes this fix).