### PR TITLE
tools/makemanifest.py: Force the repo version of the mpy_cross package.

### DIFF
--- a/tools/makemanifest.py
+++ b/tools/makemanifest.py
@@ -29,7 +29,8 @@ import sys
 import os
 import subprocess
 
-sys.path.append(os.path.join(os.path.dirname(__file__), "../mpy-cross"))
+# Always use the mpy-cross from this repo.
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../mpy-cross"))
 import mpy_cross
 
 import manifestfile


### PR DESCRIPTION
In case the version from pypi is installed or some other version is available in sys.path, prepend `$(TOP)/mpy-cross` to sys.path instead.

Fixes #9255

FYI @andrewleech 
