### PR TITLE
ports/rp2 implement dupterm_notify

### DIFF
--- a/ports/rp2/modos.c
+++ b/ports/rp2/modos.c
@@ -38,3 +38,19 @@ STATIC mp_obj_t mp_os_urandom(mp_obj_t num) {
     return mp_obj_new_bytes_from_vstr(&vstr);
 }
 STATIC MP_DEFINE_CONST_FUN_OBJ_1(mp_os_urandom_obj, mp_os_urandom);
+
+#if MICROPY_PY_OS_DUPTERM_NOTIFY
+#include "mphalport.h"
+STATIC mp_obj_t mp_os_dupterm_notify(mp_obj_t obj_in) {
+    (void)obj_in;
+    for (;;) {
+        int c = mp_os_dupterm_rx_chr();
+        if (c < 0) {
+            break;
+        }
+        ringbuf_put(&stdin_ringbuf, c);
+    }
+    return mp_const_none;
+}
+STATIC MP_DEFINE_CONST_FUN_OBJ_1(mp_os_dupterm_notify_obj, mp_os_dupterm_notify);
+#endif

--- a/ports/rp2/mpconfigport.h
+++ b/ports/rp2/mpconfigport.h
@@ -163,6 +163,12 @@
 #ifndef MICROPY_PY_WEBREPL
 #define MICROPY_PY_WEBREPL              (1)
 #endif
+#ifndef MICROPY_PY_OS_DUPTERM
+#define MICROPY_PY_OS_DUPTERM           (1)
+#endif
+#ifndef MICROPY_PY_OS_DUPTERM_NOTIFY
+#define MICROPY_PY_OS_DUPTERM_NOTIFY    (1)
+#endif
 #endif
 
 #if MICROPY_PY_NETWORK_CYW43


### PR DESCRIPTION
`dupterm_notify` allows to send data (especially keyboard interrupts) via a dupterm mechanism (most notably webrepl). This callback is already implemented for `esp32`, `esp8266` and `mimxrt`. This pull request implements the same logic for the `rp2`-port.