### PR TITLE
Update make-stmconst.py

### DIFF
--- a/ports/stm32/make-stmconst.py
+++ b/ports/stm32/make-stmconst.py
@@ -72,7 +72,7 @@ class Lexer:
         ("}", re.compile(r"}$")),
         (
             "} TypeDef",
-            re.compile(r"} *(?P<id>[A-Z][A-Za-z0-9_]+)_(?P<global>([A-Za-z0-9_]+)?)TypeDef;$"),
+            re.compile(r"} *(?P<id>[A-Z][A-Za-z0-9_]*)_(?P<global>([A-Za-z0-9_]+)?)TypeDef;$"),
         ),
         (
             "IO reg",


### PR DESCRIPTION
Update the regex to fix the parse error when building the STM32CubeU5 library

see [#9299](https://github.com/micropython/micropython/discussions/9299#discussion-4387347)