### PR TITLE
py/mkrules.mk: Add link to build troubleshooting on failure.

### DIFF
--- a/ports/esp32/Makefile
+++ b/ports/esp32/Makefile
@@ -34,8 +34,10 @@ ifdef FROZEN_MANIFEST
        IDFPY_FLAGS += -D MICROPY_FROZEN_MANIFEST=$(FROZEN_MANIFEST)
 endif
 
+HELP_BUILD_ERROR ?= "See \033[1;31mhttps://github.com/micropython/micropython/wiki/Build-Troubleshooting\033[0m"
+
 all:
-	idf.py $(IDFPY_FLAGS) build
+	idf.py $(IDFPY_FLAGS) build || (echo -e $(HELP_BUILD_ERROR); false)
 	@$(PYTHON) makeimg.py \
 		$(BUILD)/sdkconfig \
 		$(BUILD)/bootloader/bootloader.bin \

--- a/ports/rp2/Makefile
+++ b/ports/rp2/Makefile
@@ -22,9 +22,11 @@ ifeq ($(DEBUG),1)
 CMAKE_ARGS += -DCMAKE_BUILD_TYPE=Debug
 endif
 
+HELP_BUILD_ERROR ?= "See \033[1;31mhttps://github.com/micropython/micropython/wiki/Build-Troubleshooting\033[0m"
+
 all:
 	[ -e $(BUILD)/Makefile ] || cmake -S . -B $(BUILD) -DPICO_BUILD_DOCS=0 ${CMAKE_ARGS}
-	$(MAKE) $(MAKESILENT) -C $(BUILD)
+	$(MAKE) $(MAKESILENT) -C $(BUILD) || (echo -e $(HELP_BUILD_ERROR); false)
 
 clean:
 	$(RM) -rf $(BUILD)

--- a/py/mkrules.mk
+++ b/py/mkrules.mk
@@ -4,6 +4,9 @@ THIS_MAKEFILE = $(lastword $(MAKEFILE_LIST))
 include $(dir $(THIS_MAKEFILE))mkenv.mk
 endif
 
+HELP_BUILD_ERROR ?= "See \033[1;31mhttps://github.com/micropython/micropython/wiki/Build-Troubleshooting\033[0m"
+HELP_MPY_LIB_SUBMODULE ?= "\033[1;31mError: micropython-lib submodule is not initialized.\033[0m Run 'make submodules'"
+
 # Extra deps that need to happen before object compilation.
 OBJ_EXTRA_ORDER_DEPS =
 
@@ -53,7 +56,7 @@ $(BUILD)/%.o: %.s
 
 define compile_c
 $(ECHO) "CC $<"
-$(Q)$(CC) $(CFLAGS) -c -MD -o $@ $<
+$(Q)$(CC) $(CFLAGS) -c -MD -o $@ $< || (echo -e $(HELP_BUILD_ERROR); false)
 @# The following fixes the dependency file.
 @# See http://make.paulandlesley.org/autodep.html for details.
 @# Regex adjusted from the above to play better with Windows paths, etc.
@@ -65,7 +68,7 @@ endef
 
 define compile_cxx
 $(ECHO) "CXX $<"
-$(Q)$(CXX) $(CXXFLAGS) -c -MD -o $@ $<
+$(Q)$(CXX) $(CXXFLAGS) -c -MD -o $@ $< || (echo -e $(HELP_BUILD_ERROR); false)
 @# The following fixes the dependency file.
 @# See http://make.paulandlesley.org/autodep.html for details.
 @# Regex adjusted from the above to play better with Windows paths, etc.
@@ -182,7 +185,7 @@ endif
 
 # to build frozen_content.c from a manifest
 $(BUILD)/frozen_content.c: FORCE $(BUILD)/genhdr/qstrdefs.generated.h $(BUILD)/genhdr/root_pointers.h | $(MICROPY_MPYCROSS_DEPENDENCY)
-	$(Q)test -e "$(MPY_LIB_DIR)/README.md" || (echo "Error: micropython-lib not initialized. Run 'make submodules'"; false)
+	$(Q)test -e "$(MPY_LIB_DIR)/README.md" || (echo -e $(HELP_MPY_LIB_SUBMODULE); false)
 	$(Q)$(MAKE_MANIFEST) -o $@ -v "MPY_DIR=$(TOP)" -v "MPY_LIB_DIR=$(MPY_LIB_DIR)" -v "PORT_DIR=$(shell pwd)" -v "BOARD_DIR=$(BOARD_DIR)" -b "$(BUILD)" $(if $(MPY_CROSS_FLAGS),-f"$(MPY_CROSS_FLAGS)",) --mpy-tool-flags="$(MPY_TOOL_FLAGS)" $(FROZEN_MANIFEST)
 endif
 


### PR DESCRIPTION
This is to help with the transition for https://github.com/micropython/micropython/pull/8813. It prints out a message with a link to [the wiki](https://github.com/micropython/micropython/wiki/Build-Troubleshooting) if the compile fails (see example below that is typical of what happens after #8813 with old type definitions).

I think this will be particularly useful for #8813 but hopefully will help address a whole class of issues that people run into (wrong IDF version, out of date submodules, etc).

I would like to implement this for CMake too, but figured I'd get feedback on the idea first before having to figure out how to do it in CMake.

```
machine_spi.c:154:6: error: 'mp_obj_type_t' {aka 'const struct _mp_obj_type_t'} has no member named 'locals_dict'
  154 |     .locals_dict = (mp_obj_dict_t *)&mp_machine_spi_locals_dict,
      |      ^~~~~~~~~~~
machine_spi.c:154:20: error: initialization of 'unsigned char' from 'mp_obj_dict_t *' {aka 'struct _mp_obj_dict_t *'} makes integer from pointer without a cast [-Werror=int-conversion]
  154 |     .locals_dict = (mp_obj_dict_t *)&mp_machine_spi_locals_dict,
      |                    ^
machine_spi.c:154:20: note: (near initialization for 'machine_hard_spi_type.slot_index_call')
machine_spi.c:154:20: error: initializer element is not computable at load time
machine_spi.c:154:20: note: (near initialization for 'machine_hard_spi_type.slot_index_call')
cc1: all warnings being treated as errors
See https://github.com/micropython/micropython/wiki/Build-Troubleshooting           <-------------------
make: *** [../../py/mkrules.mk:80: build-PYBV11/machine_spi.o] Error 1
```

_This work was funded through GitHub Sponsors._