### PR TITLE
py/persistentcode.h: Split the native and bytecode ABI version.

### DIFF
--- a/mpy-cross/main.c
+++ b/mpy-cross/main.c
@@ -228,7 +228,7 @@ MP_NOINLINE int main_(int argc, char **argv) {
                 a += 1;
             } else if (strcmp(argv[a], "--version") == 0) {
                 printf("MicroPython " MICROPY_GIT_TAG " on " MICROPY_BUILD_DATE
-                    "; mpy-cross emitting mpy v" MP_STRINGIFY(MPY_VERSION) "\n");
+                    "; mpy-cross emitting mpy v" MP_STRINGIFY(MPY_VERSION_BYTECODE) "-v" MP_STRINGIFY(MPY_VERSION_NATIVE) "\n");
                 return 0;
             } else if (strcmp(argv[a], "-v") == 0) {
                 mp_verbose_flag++;

--- a/py/persistentcode.h
+++ b/py/persistentcode.h
@@ -30,8 +30,16 @@
 #include "py/reader.h"
 #include "py/emitglue.h"
 
-// The current version of .mpy files
-#define MPY_VERSION 6
+// The current version of .mpy files. For a bytecode only .mpy file (i.e. arch
+// set to 0), we will load any file with a version between MPY_VERSION_BYTECODE
+// and MPY_VERSION_NATIVE. When an arch is set (i.e. it used emit=native, or the
+// native dectorator, or was a dynamic native module), then it must exactly
+// match MPY_VERSION_NATIVE.
+// This lets us advance the native ABI (e.g. dynruntime.h) without needing
+// to break compatibility for bytecode-only .mpy files.
+// Must be kept in sync with tools/mpy-tool.py and tools/mpy_ld.py.
+#define MPY_VERSION_BYTECODE 6
+#define MPY_VERSION_NATIVE 6
 
 // Macros to encode/decode flags to/from the feature byte
 #define MPY_FEATURE_ENCODE_FLAGS(flags) (flags)
@@ -81,7 +89,7 @@
 #endif
 
 // 16-bit little-endian integer with the second and third bytes of supported .mpy files
-#define MPY_FILE_HEADER_INT (MPY_VERSION \
+#define MPY_FILE_HEADER_INT (MPY_VERSION_NATIVE \
     | (MPY_FEATURE_ENCODE_FLAGS(MPY_FEATURE_FLAGS) | MPY_FEATURE_ENCODE_ARCH(MPY_FEATURE_ARCH)) << 8)
 
 enum {

--- a/tools/mpy_ld.py
+++ b/tools/mpy_ld.py
@@ -34,8 +34,12 @@ from elftools.elf import elffile
 sys.path.append(os.path.dirname(__file__) + "/../py")
 import makeqstrdata as qstrutil
 
+# Must be kept in sync with py/persistentcode.h.
+# See comments there for bytecode vs native version.
+MPY_VERSION_BYTECODE = 6
+MPY_VERSION_NATIVE = 6
+
 # MicroPython constants
-MPY_VERSION = 6
 MP_CODE_BYTECODE = 2
 MP_CODE_NATIVE_VIPER = 4
 MP_NATIVE_ARCH_X86 = 1
@@ -917,7 +921,9 @@ def build_mpy(env, entry_offset, fmpy, native_qstr_vals, native_qstr_objs):
     out.open(fmpy)
 
     # MPY: header
-    out.write_bytes(bytearray([ord("M"), MPY_VERSION, env.arch.mpy_feature, MP_SMALL_INT_BITS]))
+    out.write_bytes(
+        bytearray([ord("M"), MPY_VERSION_NATIVE, env.arch.mpy_feature, MP_SMALL_INT_BITS])
+    )
 
     # MPY: n_qstr
     out.write_uint(1 + len(native_qstr_vals))


### PR DESCRIPTION
The intent is to allow us to make breaking changes to the native ABI (e.g. changes to dynruntime.h) without needing the bytecode version to increment.

With this commit, there's now a supported bytecode .mpy version and a native .mpy version.

When generating an .mpy, if it has any native code then it gets the native version, otherwise the bytecode version.

When loading an .mpy, if it has native code, then it must match the native version exactly. If it has only bytecode, then any version between the current bytecode version and native version will be loaded.

e.g. MicroPython v1.19 will load any future bytecode .mpy until we increment `MPY_VERSION_BYTECODE`, but will only load v6 native mpy files.

The main driver for this is https://github.com/micropython/micropython/pull/8813 however I think this is generally useful. There have been cases where we haven't added a useful feature to dynruntime.h because we don't want to break bytecode compatibility.

_This work was funded through GitHub Sponsors._