### PR TITLE
stm32/btstack: Add support for btstack on WB55 / rfcore.

### DIFF
--- a/extmod/btstack/modbluetooth_btstack.c
+++ b/extmod/btstack/modbluetooth_btstack.c
@@ -35,7 +35,8 @@
 
 #include "lib/btstack/src/btstack.h"
 
-#define DEBUG_printf(...) // printf("btstack: " __VA_ARGS__)
+#include <stdio.h>
+#define DEBUG_printf(...) printf("btstack: " __VA_ARGS__)
 
 #ifndef MICROPY_PY_BLUETOOTH_DEFAULT_GAP_NAME
 #define MICROPY_PY_BLUETOOTH_DEFAULT_GAP_NAME "MPY BTSTACK"
@@ -368,7 +369,7 @@ STATIC void btstack_packet_handler(uint8_t packet_type, uint8_t *packet, uint8_t
                event_type == SM_EVENT_PAIRING_COMPLETE ||
                // event_type == GAP_EVENT_DEDICATED_BONDING_COMPLETED || // No conn_handle
                event_type == HCI_EVENT_ENCRYPTION_CHANGE) {
-        DEBUG_printf("  --> enc/auth/pair/bond change\n", );
+        DEBUG_printf("  --> enc/auth/pair/bond change\n");
         #if MICROPY_PY_BLUETOOTH_ENABLE_PAIRING_BONDING
         uint16_t conn_handle;
         switch (event_type) {

--- a/ports/stm32/mpbtstackport.c
+++ b/ports/stm32/mpbtstackport.c
@@ -104,6 +104,104 @@ static const btstack_run_loop_t mp_btstack_runloop_stm32 = {
     &mp_btstack_runloop_get_time_ms,
 };
 
+
+// #if defined(STM32WB)
+
+// /******************************************************************************/
+// // HCI over IPCC
+
+// #include "rfcore.h"
+
+// static void (*transport_packet_handler)(uint8_t packet_type, uint8_t *packet, uint16_t size);
+// static int hci_acl_can_send_now;
+
+
+// STATIC void rfcore_transport_init(const void *transport_config){
+//     rfcore_init();
+// }
+
+// STATIC int rfcore_transport_open(void){
+//     return 0;
+// }
+
+// STATIC int rfcore_transport_close(void){
+//     return 0;
+// }
+
+
+// STATIC void rfcore_transport_register_packet_handler(void (*handler)(uint8_t packet_type, uint8_t *packet, uint16_t size)){
+//     transport_packet_handler = handler;
+// }
+
+// STATIC int rfcore_transport_can_send_packet_now(uint8_t packet_type) {
+//     // if (cpu2_state != CPU2_STATE_READY) return 0;
+//     // switch (packet_type)
+//     // {
+//     //     case HCI_COMMAND_DATA_PACKET:
+//     //         return 1;
+
+//     //     case HCI_ACL_DATA_PACKET:
+//     //         return hci_acl_can_send_now;
+//     // }
+//     return 1;
+// }
+
+// STATIC int rfcore_transport_send_packet(uint8_t packet_type, uint8_t *packet, int size){
+// 	TL_CmdPacket_t *ble_cmd_buff = &BleCmdBuffer;
+
+//     switch (packet_type){
+//         case HCI_COMMAND_DATA_PACKET:
+//             ble_cmd_buff->cmdserial.type = packet_type;
+//             ble_cmd_buff->cmdserial.cmd.plen = size;
+//             memcpy((void *)&ble_cmd_buff->cmdserial.cmd, packet, size);
+//             TL_BLE_SendCmd(NULL, 0);
+//             transport_notify_packet_send();
+//             break;
+
+//         case HCI_ACL_DATA_PACKET:
+//             hci_acl_can_send_now = 0;
+//             ((TL_AclDataPacket_t *)HciAclDataBuffer)->AclDataSerial.type = packet_type;
+//             memcpy((void *)&(((TL_AclDataPacket_t *)HciAclDataBuffer)->AclDataSerial.handle),packet, size);
+//             TL_BLE_SendAclData(NULL, 0);
+//             transport_notify_packet_send();
+//             break;
+
+//         default:
+//             transport_send_hardware_error(0x01);  // invalid HCI packet
+//             break;
+//     }
+//     return 0;
+// }
+
+// STATIC const hci_transport_t hci_wb55_transport = {
+//     "stm32wb-vhci",
+//     &rfcore_transport_init,
+//     &rfcore_transport_open,
+//     &rfcore_transport_close,
+//     &rfcore_transport_register_packet_handler,
+//     &rfcore_transport_can_send_packet_now,
+//     &rfcore_transport_send_packet,
+//     NULL, // set baud rate
+//     NULL, // reset link
+//     NULL, // set SCO config
+// };
+
+// void mp_bluetooth_btstack_port_init(void) {
+//     btstack_run_loop_init(&mp_btstack_runloop_stm32);
+
+//     // hci_dump_open(NULL, HCI_DUMP_STDOUT);
+//     hci_init(&hci_wb55_transport, NULL);
+// }
+
+// #else
+
+/******************************************************************************/
+// HCI over UART
+
+#ifndef MICROPY_HW_BLE_UART_BAUDRATE_SECONDARY
+#define MICROPY_HW_BLE_UART_BAUDRATE_SECONDARY MICROPY_HW_BLE_UART_BAUDRATE
+#endif
+
 STATIC const hci_transport_config_uart_t hci_transport_config_uart = {
     HCI_TRANSPORT_CONFIG_UART,
     MICROPY_HW_BLE_UART_BAUDRATE,
@@ -162,5 +260,6 @@ void mp_bluetooth_btstack_port_deinit(void) {
 void mp_bluetooth_btstack_port_start(void) {
     hci_power_control(HCI_POWER_ON);
 }
+
 
 #endif // MICROPY_PY_BLUETOOTH && MICROPY_BLUETOOTH_BTSTACK

--- a/ports/stm32/rfcore.c
+++ b/ports/stm32/rfcore.c
@@ -45,8 +45,6 @@
 #if MICROPY_BLUETOOTH_NIMBLE
 // For mp_bluetooth_nimble_hci_uart_wfi
 #include "nimble/nimble_npl.h"
-#else
-#error "STM32WB must use NimBLE."
 #endif
 
 #if !MICROPY_PY_BLUETOOTH_USE_SYNC_EVENTS
@@ -413,9 +411,10 @@ STATIC size_t tl_process_msg(volatile tl_list_node_t *head, unsigned int ch, par
     bool added_to_free_queue = false;
     size_t len = 0;
     while (cur != head) {
+        volatile tl_list_node_t *next = tl_list_unlink(cur);
+        
         len += tl_parse_hci_msg((uint8_t *)cur->body, parse);
 
-        volatile tl_list_node_t *next = tl_list_unlink(cur);
 
         // If this node is allocated from the memmgr event pool, then place it into the free buffer.
         if ((uint8_t *)cur >= ipcc_membuf_memmgr_evt_pool && (uint8_t *)cur < ipcc_membuf_memmgr_evt_pool + sizeof(ipcc_membuf_memmgr_evt_pool)) {


### PR DESCRIPTION
This MR allows building stm32wb55 boards with `MICROPY_BLUETOOTH_NIMBLE = 0` / `MICROPY_BLUETOOTH_BTSTACK = 1`
