### PR TITLE
Only include poll.h when building with uselect

### DIFF
--- a/extmod/vfs_posix_file.c
+++ b/extmod/vfs_posix_file.c
@@ -38,7 +38,9 @@
 #ifdef _WIN32
 #define fsync _commit
 #else
+#if MICROPY_PY_USELECT
 #include <poll.h>
+#endif
 #endif
 
 typedef struct _mp_obj_vfs_posix_file_t {


### PR DESCRIPTION
poll.h is only used for `MP_STREAM_POLL` ioctl, which only makes sense when `uselect` is enabled.

This makes it easier to compile MicroPython for POSIX-like targets that lack support for poll() or select().