### PR TITLE
zephyr: Upgrade to Zephyr v3.7.0.

### DIFF
--- a/.github/workflows/ports_zephyr.yml
+++ b/.github/workflows/ports_zephyr.yml
@@ -20,6 +20,15 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
+    - uses: jlumbroso/free-disk-space@main
+      with:
+        # Only free up a few things so this step runs quickly.
+        android: false
+        dotnet: true
+        haskell: true
+        large-packages: false
+        docker-images: false
+        swap-storage: false
     - uses: actions/checkout@v4
     - name: Install packages
       run: source tools/ci.sh && ci_zephyr_setup

--- a/docs/zephyr/quickref.rst
+++ b/docs/zephyr/quickref.rst
@@ -36,7 +36,10 @@ Use the :ref:`machine.Pin <machine.Pin>` class::
 
     from machine import Pin
 
-    pin = Pin(("GPIO_1", 21), Pin.IN)   # create input pin on GPIO1
+    gpio1 = "gpio@400ff040"             # GPIO1 device name
+    gpio2 = "gpio@400ff080"             # GPIO2 device name
+
+    pin = Pin((gpio1, 21), Pin.IN)      # create input pin on GPIO1
     print(pin)                          # print pin port and number
 
     pin.init(Pin.OUT, Pin.PULL_UP, value=1)     # reinitialize pin
@@ -47,14 +50,14 @@ Use the :ref:`machine.Pin <machine.Pin>` class::
     pin.on()                            # set pin to high
     pin.off()                           # set pin to low
 
-    pin = Pin(("GPIO_1", 21), Pin.IN)   # create input pin on GPIO1
+    pin = Pin((gpio1, 21), Pin.IN)              # create input pin on GPIO1
 
-    pin = Pin(("GPIO_1", 21), Pin.OUT, value=1)         # set pin high on creation
+    pin = Pin((gpio1, 21), Pin.OUT, value=1)    # set pin high on creation
 
-    pin = Pin(("GPIO_1", 21), Pin.IN, Pin.PULL_UP)      # enable internal pull-up resistor
+    pin = Pin((gpio1, 21), Pin.IN, Pin.PULL_UP) # enable internal pull-up resistor
 
-    switch = Pin(("GPIO_2", 6), Pin.IN)                 # create input pin for a switch
-    switch.irq(lambda t: print("SW2 changed"))          # enable an interrupt when switch state is changed
+    switch = Pin((gpio2, 6), Pin.IN)            # create input pin for a switch
+    switch.irq(lambda t: print("SW2 changed"))  # enable an interrupt when switch state is changed
 
 Hardware I2C bus
 ----------------
@@ -63,7 +66,7 @@ Hardware I2C is accessed via the :ref:`machine.I2C <machine.I2C>` class::
 
     from machine import I2C
 
-    i2c = I2C("I2C_0")          # construct an i2c bus
+    i2c = I2C("i2c@40066000")   # construct an i2c bus
     print(i2c)                  # print device name
 
     i2c.scan()                  # scan the device for available I2C slaves
@@ -84,11 +87,11 @@ Hardware SPI is accessed via the :ref:`machine.SPI <machine.SPI>` class::
 
     from machine import SPI
 
-    spi = SPI("SPI_0")          # construct a spi bus with default configuration
+    spi = SPI("spi@4002c000")   # construct a spi bus with default configuration
     spi.init(baudrate=100000, polarity=0, phase=0, bits=8, firstbit=SPI.MSB) # set configuration
 
     # equivalently, construct spi bus and set configuration at the same time
-    spi = SPI("SPI_0", baudrate=100000, polarity=0, phase=0, bits=8, firstbit=SPI.MSB)
+    spi = SPI("spi@4002c000", baudrate=100000, polarity=0, phase=0, bits=8, firstbit=SPI.MSB)
     print(spi)                  # print device name and bus configuration
 
     spi.read(4)                 # read 4 bytes on MISO
@@ -146,7 +149,7 @@ Use the :ref:`zsensor.Sensor <zsensor.Sensor>` class to access sensor data::
     import zsensor
     from zsensor import Sensor
 
-    accel = Sensor("FXOX8700")    # create sensor object for the accelerometer
+    accel = Sensor("fxos8700@1d") # create sensor object for the accelerometer
 
     accel.measure()               # obtain a measurement reading from the accelerometer
 

--- a/docs/zephyr/quickref.rst
+++ b/docs/zephyr/quickref.rst
@@ -36,10 +36,7 @@ Use the :ref:`machine.Pin <machine.Pin>` class::
 
     from machine import Pin
 
-    gpio1 = "gpio@400ff040"             # GPIO1 device name
-    gpio2 = "gpio@400ff080"             # GPIO2 device name
-
-    pin = Pin((gpio1, 21), Pin.IN)      # create input pin on GPIO1
+    pin = Pin(("gpiob", 21), Pin.IN)    # create input pin on GPIO port B
     print(pin)                          # print pin port and number
 
     pin.init(Pin.OUT, Pin.PULL_UP, value=1)     # reinitialize pin
@@ -50,14 +47,14 @@ Use the :ref:`machine.Pin <machine.Pin>` class::
     pin.on()                            # set pin to high
     pin.off()                           # set pin to low
 
-    pin = Pin((gpio1, 21), Pin.IN)              # create input pin on GPIO1
+    pin = Pin(("gpiob", 21), Pin.IN)              # create input pin on GPIO port B
 
-    pin = Pin((gpio1, 21), Pin.OUT, value=1)    # set pin high on creation
+    pin = Pin(("gpiob", 21), Pin.OUT, value=1)    # set pin high on creation
 
-    pin = Pin((gpio1, 21), Pin.IN, Pin.PULL_UP) # enable internal pull-up resistor
+    pin = Pin(("gpiob", 21), Pin.IN, Pin.PULL_UP) # enable internal pull-up resistor
 
-    switch = Pin((gpio2, 6), Pin.IN)            # create input pin for a switch
-    switch.irq(lambda t: print("SW2 changed"))  # enable an interrupt when switch state is changed
+    switch = Pin(("gpioc", 6), Pin.IN)            # create input pin for a switch
+    switch.irq(lambda t: print("SW2 changed"))    # enable an interrupt when switch state is changed
 
 Hardware I2C bus
 ----------------
@@ -66,7 +63,7 @@ Hardware I2C is accessed via the :ref:`machine.I2C <machine.I2C>` class::
 
     from machine import I2C
 
-    i2c = I2C("i2c@40066000")   # construct an i2c bus
+    i2c = I2C("i2c0")           # construct an i2c bus
     print(i2c)                  # print device name
 
     i2c.scan()                  # scan the device for available I2C slaves
@@ -87,11 +84,11 @@ Hardware SPI is accessed via the :ref:`machine.SPI <machine.SPI>` class::
 
     from machine import SPI
 
-    spi = SPI("spi@4002c000")   # construct a spi bus with default configuration
+    spi = SPI("spi0")           # construct a spi bus with default configuration
     spi.init(baudrate=100000, polarity=0, phase=0, bits=8, firstbit=SPI.MSB) # set configuration
 
     # equivalently, construct spi bus and set configuration at the same time
-    spi = SPI("spi@4002c000", baudrate=100000, polarity=0, phase=0, bits=8, firstbit=SPI.MSB)
+    spi = SPI("spi0", baudrate=100000, polarity=0, phase=0, bits=8, firstbit=SPI.MSB)
     print(spi)                  # print device name and bus configuration
 
     spi.read(4)                 # read 4 bytes on MISO
@@ -149,7 +146,7 @@ Use the :ref:`zsensor.Sensor <zsensor.Sensor>` class to access sensor data::
     import zsensor
     from zsensor import Sensor
 
-    accel = Sensor("fxos8700@1d") # create sensor object for the accelerometer
+    accel = Sensor("fxos8700")    # create sensor object for the accelerometer
 
     accel.measure()               # obtain a measurement reading from the accelerometer
 

--- a/docs/zephyr/tutorial/repl.rst
+++ b/docs/zephyr/tutorial/repl.rst
@@ -31,8 +31,8 @@ With your serial program open (PuTTY, screen, picocom, etc) you may see a
 blank screen with a flashing cursor. Press Enter (or reset the board) and
 you should be presented with the following text::
 
-        *** Booting Zephyr OS build zephyr-v3.1.0  ***
-        MicroPython v1.19.1-9-g4fd54a475 on 2022-06-17; zephyr-frdm_k64f with mk64f12
+        *** Booting Zephyr OS build v3.7.0 ***
+        MicroPython v1.24.0-preview.179.g5b85b24bd on 2024-08-05; zephyr-frdm_k64f with mk64f12
         Type "help()" for more information.
         >>>
 

--- a/ports/zephyr/CMakeLists.txt
+++ b/ports/zephyr/CMakeLists.txt
@@ -46,6 +46,7 @@ set(MICROPY_SOURCE_PORT
     modzsensor.c
     mphalport.c
     uart_core.c
+    zephyr_device.c
     zephyr_storage.c
     mpthreadport.c
 )

--- a/ports/zephyr/README.md
+++ b/ports/zephyr/README.md
@@ -107,7 +107,7 @@ To blink an LED:
     import time
     from machine import Pin
 
-    LED = Pin(("gpio@400ff040", 21), Pin.OUT)
+    LED = Pin(("gpiob", 21), Pin.OUT)
     while True:
         LED.value(1)
         time.sleep(0.5)
@@ -115,18 +115,18 @@ To blink an LED:
         time.sleep(0.5)
 
 The above code uses an LED location for a FRDM-K64F board (port B, pin 21;
-following Zephyr conventions port are identified by "GPIO_x", where *x*
-starts from 0). You will need to adjust it for another board (using board's
-reference materials). To execute the above sample, copy it to clipboard, in
-MicroPython REPL enter "paste mode" using Ctrl+E, paste clipboard, press
-Ctrl+D to finish paste mode and start execution.
+following Zephyr conventions port are identified by their devicetree node
+label. You will need to adjust it for another board (using board's reference
+materials). To execute the above sample, copy it to clipboard, in MicroPython
+REPL enter "paste mode" using Ctrl+E, paste clipboard, press Ctrl+D to finish
+paste mode and start execution.
 
 To respond to Pin change IRQs, on a FRDM-K64F board run:
 
     from machine import Pin
 
-    SW2 = Pin(("gpio@400ff080", 6), Pin.IN)
-    SW3 = Pin(("gpio@400ff000", 4), Pin.IN)
+    SW2 = Pin(("gpioc", 6), Pin.IN)
+    SW3 = Pin(("gpioa", 4), Pin.IN)
 
     SW2.irq(lambda t: print("SW2 changed"))
     SW3.irq(lambda t: print("SW3 changed"))
@@ -138,14 +138,14 @@ Example of using I2C to scan for I2C slaves:
 
     from machine import I2C
 
-    i2c = I2C("i2c@40066000")
+    i2c = I2C("i2c0")
     i2c.scan()
 
 Example of using SPI to write a buffer to the MOSI pin:
 
     from machine import SPI
 
-    spi = SPI("spi@4002c000")
+    spi = SPI("spi0")
     spi.init(baudrate=500000, polarity=1, phase=1, bits=8, firstbit=SPI.MSB)
     spi.write(b'abcd')
 

--- a/ports/zephyr/README.md
+++ b/ports/zephyr/README.md
@@ -107,7 +107,7 @@ To blink an LED:
     import time
     from machine import Pin
 
-    LED = Pin(("GPIO_1", 21), Pin.OUT)
+    LED = Pin(("gpio@400ff040", 21), Pin.OUT)
     while True:
         LED.value(1)
         time.sleep(0.5)
@@ -125,8 +125,8 @@ To respond to Pin change IRQs, on a FRDM-K64F board run:
 
     from machine import Pin
 
-    SW2 = Pin(("GPIO_2", 6), Pin.IN)
-    SW3 = Pin(("GPIO_0", 4), Pin.IN)
+    SW2 = Pin(("gpio@400ff080", 6), Pin.IN)
+    SW3 = Pin(("gpio@400ff000", 4), Pin.IN)
 
     SW2.irq(lambda t: print("SW2 changed"))
     SW3.irq(lambda t: print("SW3 changed"))
@@ -138,14 +138,14 @@ Example of using I2C to scan for I2C slaves:
 
     from machine import I2C
 
-    i2c = I2C("I2C_0")
+    i2c = I2C("i2c@40066000")
     i2c.scan()
 
 Example of using SPI to write a buffer to the MOSI pin:
 
     from machine import SPI
 
-    spi = SPI("SPI_0")
+    spi = SPI("spi@4002c000")
     spi.init(baudrate=500000, polarity=1, phase=1, bits=8, firstbit=SPI.MSB)
     spi.write(b'abcd')
 

--- a/ports/zephyr/README.md
+++ b/ports/zephyr/README.md
@@ -4,7 +4,7 @@ MicroPython port to Zephyr RTOS
 This is a work-in-progress port of MicroPython to Zephyr RTOS
 (http://zephyrproject.org).
 
-This port requires Zephyr version v3.1.0, and may also work on higher
+This port requires Zephyr version v3.7.0, and may also work on higher
 versions.  All boards supported
 by Zephyr (with standard level of features support, like UART console)
 should work with MicroPython (but not all were tested).
@@ -39,13 +39,13 @@ setup is correct.
 If you already have Zephyr installed but are having issues building the
 MicroPython port then try installing the correct version of Zephyr via:
 
-    $ west init zephyrproject -m https://github.com/zephyrproject-rtos/zephyr --mr v3.1.0
+    $ west init zephyrproject -m https://github.com/zephyrproject-rtos/zephyr --mr v3.7.0
 
 Alternatively, you don't have to redo the Zephyr installation to just
 switch from master to a tagged release, you can instead do:
 
     $ cd zephyrproject/zephyr
-    $ git checkout v3.1.0
+    $ git checkout v3.7.0
     $ west update
 
 With Zephyr installed you may then need to configure your environment,

--- a/ports/zephyr/machine_i2c.c
+++ b/ports/zephyr/machine_i2c.c
@@ -29,7 +29,7 @@
 #include <stdint.h>
 #include <string.h>
 
-#include <zephyr/zephyr.h>
+#include <zephyr/kernel.h>
 #include <zephyr/drivers/i2c.h>
 
 #include "py/runtime.h"

--- a/ports/zephyr/machine_i2c.c
+++ b/ports/zephyr/machine_i2c.c
@@ -37,6 +37,7 @@
 #include "py/mphal.h"
 #include "py/mperrno.h"
 #include "extmod/modmachine.h"
+#include "zephyr_device.h"
 
 #if MICROPY_PY_MACHINE_I2C
 
@@ -64,12 +65,7 @@ mp_obj_t machine_hard_i2c_make_new(const mp_obj_type_t *type, size_t n_args, siz
     mp_arg_val_t args[MP_ARRAY_SIZE(allowed_args)];
     mp_arg_parse_all_kw_array(n_args, n_kw, all_args, MP_ARRAY_SIZE(allowed_args), allowed_args, args);
 
-    const char *dev_name = mp_obj_str_get_str(args[ARG_id].u_obj);
-    const struct device *dev = device_get_binding(dev_name);
-
-    if (dev == NULL) {
-        mp_raise_ValueError(MP_ERROR_TEXT("device not found"));
-    }
+    const struct device *dev = zephyr_device_find(args[ARG_id].u_obj);
 
     if ((args[ARG_scl].u_obj != MP_OBJ_NULL) || (args[ARG_sda].u_obj != MP_OBJ_NULL)) {
         mp_raise_NotImplementedError(MP_ERROR_TEXT("explicit choice of scl/sda is not implemented"));

--- a/ports/zephyr/machine_pin.c
+++ b/ports/zephyr/machine_pin.c
@@ -29,7 +29,7 @@
 #include <stdint.h>
 #include <string.h>
 
-#include <zephyr/zephyr.h>
+#include <zephyr/kernel.h>
 #include <zephyr/drivers/gpio.h>
 
 #include "py/runtime.h"

--- a/ports/zephyr/machine_pin.c
+++ b/ports/zephyr/machine_pin.c
@@ -38,6 +38,7 @@
 #include "extmod/modmachine.h"
 #include "shared/runtime/mpirq.h"
 #include "modmachine.h"
+#include "zephyr_device.h"
 
 #if MICROPY_PY_MACHINE
 
@@ -131,12 +132,8 @@ mp_obj_t mp_pin_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, 
     }
     mp_obj_t *items;
     mp_obj_get_array_fixed_n(args[0], 2, &items);
-    const char *drv_name = mp_obj_str_get_str(items[0]);
+    const struct device *wanted_port = zephyr_device_find(items[0]);
     int wanted_pin = mp_obj_get_int(items[1]);
-    const struct device *wanted_port = device_get_binding(drv_name);
-    if (!wanted_port) {
-        mp_raise_ValueError(MP_ERROR_TEXT("invalid port"));
-    }
 
     machine_pin_obj_t *pin = m_new_obj(machine_pin_obj_t);
     pin->base = machine_pin_obj_template;

--- a/ports/zephyr/machine_spi.c
+++ b/ports/zephyr/machine_spi.c
@@ -28,7 +28,7 @@
 #include <stdint.h>
 #include <string.h>
 
-#include <zephyr/zephyr.h>
+#include <zephyr/kernel.h>
 #include <zephyr/drivers/spi.h>
 
 #include "py/runtime.h"

--- a/ports/zephyr/machine_spi.c
+++ b/ports/zephyr/machine_spi.c
@@ -102,7 +102,7 @@ mp_obj_t machine_hard_spi_make_new(const mp_obj_type_t *type, size_t n_args, siz
                 args[ARG_bits].u_int << 5 |
                 SPI_LINES_SINGLE),
         .slave = 0,
-        .cs = NULL
+        .cs = {},
     };
 
     machine_hard_spi_obj_t *self = mp_obj_malloc(machine_hard_spi_obj_t, &machine_spi_type);
@@ -157,7 +157,7 @@ static void machine_hard_spi_init(mp_obj_base_t *obj, size_t n_args, const mp_ob
         .frequency = baudrate,
         .operation = operation,
         .slave = 0,
-        .cs = NULL
+        .cs = {},
     };
 
     self->config = cfg;

--- a/ports/zephyr/machine_spi.c
+++ b/ports/zephyr/machine_spi.c
@@ -36,6 +36,7 @@
 #include "py/mphal.h"
 #include "py/mperrno.h"
 #include "extmod/modmachine.h"
+#include "zephyr_device.h"
 
 #if MICROPY_PY_MACHINE_SPI
 
@@ -81,12 +82,7 @@ mp_obj_t machine_hard_spi_make_new(const mp_obj_type_t *type, size_t n_args, siz
     mp_arg_val_t args[MP_ARRAY_SIZE(allowed_args)];
     mp_arg_parse_all_kw_array(n_args, n_kw, all_args, MP_ARRAY_SIZE(allowed_args), allowed_args, args);
 
-    const char *dev_name = mp_obj_str_get_str(args[ARG_id].u_obj);
-    const struct device *dev = device_get_binding(dev_name);
-
-    if (dev == NULL) {
-        mp_raise_ValueError(MP_ERROR_TEXT("device not found"));
-    }
+    const struct device *dev = zephyr_device_find(args[ARG_id].u_obj);
 
     if ((args[ARG_sck].u_obj != MP_OBJ_NULL) || (args[ARG_miso].u_obj != MP_OBJ_NULL) || (args[ARG_mosi].u_obj != MP_OBJ_NULL)) {
         mp_raise_NotImplementedError(MP_ERROR_TEXT("explicit choice of sck/miso/mosi is not implemented"));

--- a/ports/zephyr/machine_uart.c
+++ b/ports/zephyr/machine_uart.c
@@ -28,7 +28,7 @@
 // This file is never compiled standalone, it's included directly from
 // extmod/machine_uart.c via MICROPY_PY_MACHINE_UART_INCLUDEFILE.
 
-#include <zephyr/zephyr.h>
+#include <zephyr/kernel.h>
 #include <zephyr/drivers/uart.h>
 
 #include "py/mperrno.h"

--- a/ports/zephyr/machine_uart.c
+++ b/ports/zephyr/machine_uart.c
@@ -32,6 +32,7 @@
 #include <zephyr/drivers/uart.h>
 
 #include "py/mperrno.h"
+#include "zephyr_device.h"
 
 // The UART class doesn't have any constants for this port.
 #define MICROPY_PY_MACHINE_UART_CLASS_CONSTANTS
@@ -75,10 +76,7 @@ static mp_obj_t mp_machine_uart_make_new(const mp_obj_type_t *type, size_t n_arg
     mp_arg_check_num(n_args, n_kw, 1, MP_OBJ_FUN_ARGS_MAX, true);
 
     machine_uart_obj_t *self = mp_obj_malloc(machine_uart_obj_t, &machine_uart_type);
-    self->dev = device_get_binding(mp_obj_str_get_str(args[0]));
-    if (!self->dev) {
-        mp_raise_ValueError(MP_ERROR_TEXT("Bad device name"));
-    }
+    self->dev = zephyr_device_find(args[0]);
 
     mp_map_t kw_args;
     mp_map_init_fixed_table(&kw_args, n_kw, args + n_args);

--- a/ports/zephyr/main.c
+++ b/ports/zephyr/main.c
@@ -29,7 +29,7 @@
 #include <stdio.h>
 #include <string.h>
 
-#include <zephyr/zephyr.h>
+#include <zephyr/kernel.h>
 #ifdef CONFIG_NETWORKING
 #include <zephyr/net/net_context.h>
 #endif

--- a/ports/zephyr/main.c
+++ b/ports/zephyr/main.c
@@ -100,8 +100,8 @@ static void vfs_init(void) {
     mp_obj_t args[] = { mp_obj_new_str_from_cstr(CONFIG_SDMMC_VOLUME_NAME) };
     bdev = MP_OBJ_TYPE_GET_SLOT(&zephyr_disk_access_type, make_new)(&zephyr_disk_access_type, ARRAY_SIZE(args), 0, args);
     mount_point_str = "/sd";
-    #elif defined(CONFIG_FLASH_MAP) && FLASH_AREA_LABEL_EXISTS(storage)
-    mp_obj_t args[] = { MP_OBJ_NEW_SMALL_INT(FLASH_AREA_ID(storage)), MP_OBJ_NEW_SMALL_INT(4096) };
+    #elif defined(CONFIG_FLASH_MAP) && FIXED_PARTITION_EXISTS(storage_partition)
+    mp_obj_t args[] = { MP_OBJ_NEW_SMALL_INT(FIXED_PARTITION_ID(storage_partition)), MP_OBJ_NEW_SMALL_INT(4096) };
     bdev = MP_OBJ_TYPE_GET_SLOT(&zephyr_flash_area_type, make_new)(&zephyr_flash_area_type, ARRAY_SIZE(args), 0, args);
     mount_point_str = "/flash";
     #endif

--- a/ports/zephyr/modbluetooth_zephyr.c
+++ b/ports/zephyr/modbluetooth_zephyr.c
@@ -31,8 +31,8 @@
 
 #if MICROPY_PY_BLUETOOTH
 
-#include <bluetooth/bluetooth.h>
-#include <bluetooth/hci.h>
+#include <zephyr/bluetooth/bluetooth.h>
+#include <zephyr/bluetooth/hci.h>
 #include "extmod/modbluetooth.h"
 
 #define DEBUG_printf(...) // printk("BLE: " __VA_ARGS__)

--- a/ports/zephyr/modsocket.c
+++ b/ports/zephyr/modsocket.c
@@ -31,7 +31,7 @@
 #include "py/stream.h"
 
 #include <stdio.h>
-#include <zephyr/zephyr.h>
+#include <zephyr/kernel.h>
 // Zephyr's generated version header
 #include <version.h>
 #include <zephyr/net/net_context.h>

--- a/ports/zephyr/modtime.c
+++ b/ports/zephyr/modtime.c
@@ -25,7 +25,7 @@
  * THE SOFTWARE.
  */
 
-#include <zephyr/zephyr.h>
+#include <zephyr/kernel.h>
 
 #include "py/obj.h"
 

--- a/ports/zephyr/modzephyr.c
+++ b/ports/zephyr/modzephyr.c
@@ -29,7 +29,7 @@
 #if MICROPY_PY_ZEPHYR
 
 #include <stdio.h>
-#include <zephyr/zephyr.h>
+#include <zephyr/kernel.h>
 #include <zephyr/debug/thread_analyzer.h>
 #include <zephyr/shell/shell.h>
 #include <zephyr/shell/shell_uart.h>

--- a/ports/zephyr/modzsensor.c
+++ b/ports/zephyr/modzsensor.c
@@ -28,7 +28,7 @@
 
 #include "py/runtime.h"
 
-#include <zephyr/zephyr.h>
+#include <zephyr/kernel.h>
 #include <zephyr/drivers/sensor.h>
 
 #if MICROPY_PY_ZSENSOR

--- a/ports/zephyr/modzsensor.c
+++ b/ports/zephyr/modzsensor.c
@@ -30,6 +30,7 @@
 
 #include <zephyr/kernel.h>
 #include <zephyr/drivers/sensor.h>
+#include "zephyr_device.h"
 
 #if MICROPY_PY_ZSENSOR
 
@@ -41,10 +42,7 @@ typedef struct _mp_obj_sensor_t {
 static mp_obj_t sensor_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *args) {
     mp_arg_check_num(n_args, n_kw, 1, 1, false);
     mp_obj_sensor_t *o = mp_obj_malloc(mp_obj_sensor_t, type);
-    o->dev = device_get_binding(mp_obj_str_get_str(args[0]));
-    if (o->dev == NULL) {
-        mp_raise_ValueError(MP_ERROR_TEXT("dev not found"));
-    }
+    o->dev = zephyr_device_find(args[0]);
     return MP_OBJ_FROM_PTR(o);
 }
 

--- a/ports/zephyr/mpconfigport.h
+++ b/ports/zephyr/mpconfigport.h
@@ -28,7 +28,7 @@
 // Include Zephyr's autoconf.h, which should be made first by Zephyr makefiles
 #include "autoconf.h"
 // Included here to get basic Zephyr environment (macros, etc.)
-#include <zephyr/zephyr.h>
+#include <zephyr/kernel.h>
 #include <zephyr/drivers/spi.h>
 
 // Usually passed from Makefile

--- a/ports/zephyr/mpconfigport_minimal.h
+++ b/ports/zephyr/mpconfigport_minimal.h
@@ -28,7 +28,7 @@
 // Include Zephyr's autoconf.h, which should be made first by Zephyr makefiles
 #include "autoconf.h"
 // Included here to get basic Zephyr environment (macros, etc.)
-#include <zephyr/zephyr.h>
+#include <zephyr/kernel.h>
 
 // Usually passed from Makefile
 #ifndef MICROPY_HEAP_SIZE

--- a/ports/zephyr/mpconfigport_minimal.h
+++ b/ports/zephyr/mpconfigport_minimal.h
@@ -28,7 +28,7 @@
 // Include Zephyr's autoconf.h, which should be made first by Zephyr makefiles
 #include "autoconf.h"
 // Included here to get basic Zephyr environment (macros, etc.)
-#include <zephyr.h>
+#include <zephyr/zephyr.h>
 
 // Usually passed from Makefile
 #ifndef MICROPY_HEAP_SIZE

--- a/ports/zephyr/mphalport.h
+++ b/ports/zephyr/mphalport.h
@@ -1,4 +1,4 @@
-#include <zephyr/zephyr.h>
+#include <zephyr/kernel.h>
 #include "shared/runtime/interrupt_char.h"
 
 #define MICROPY_BEGIN_ATOMIC_SECTION irq_lock

--- a/ports/zephyr/mpthreadport.h
+++ b/ports/zephyr/mpthreadport.h
@@ -29,7 +29,7 @@
 #ifndef MICROPY_INCLUDED_ZEPHYR_MPTHREADPORT_H
 #define MICROPY_INCLUDED_ZEPHYR_MPTHREADPORT_H
 
-#include <zephyr/zephyr.h>
+#include <zephyr/kernel.h>
 
 typedef struct _mp_thread_mutex_t {
     struct k_sem handle;

--- a/ports/zephyr/prj.conf
+++ b/ports/zephyr/prj.conf
@@ -16,6 +16,8 @@ CONFIG_FPU=y
 CONFIG_MAIN_STACK_SIZE=4736
 CONFIG_POLL=y
 
+CONFIG_DEVICE_DT_METADATA=y
+
 # Enable sensor subsystem (doesn't add code if not used).
 # Specific sensors should be enabled per-board.
 CONFIG_SENSOR=y

--- a/ports/zephyr/src/zephyr_getchar.c
+++ b/ports/zephyr/src/zephyr_getchar.c
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-#include <zephyr/zephyr.h>
+#include <zephyr/kernel.h>
 #include <zephyr/drivers/uart.h>
 #include <zephyr/drivers/console/uart_console.h>
 #include <zephyr/sys/printk.h>

--- a/ports/zephyr/src/zephyr_start.c
+++ b/ports/zephyr/src/zephyr_start.c
@@ -23,7 +23,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-#include <zephyr/zephyr.h>
+#include <zephyr/kernel.h>
 #include "zephyr_getchar.h"
 
 int real_main(void);

--- a/ports/zephyr/src/zephyr_start.c
+++ b/ports/zephyr/src/zephyr_start.c
@@ -29,11 +29,13 @@
 int real_main(void);
 int mp_console_init(void);
 
-void main(void) {
+int main(void) {
     #ifdef CONFIG_CONSOLE_SUBSYS
     mp_console_init();
     #else
     zephyr_getchar_init();
     #endif
     real_main();
+
+    return 0;
 }

--- a/ports/zephyr/uart_core.c
+++ b/ports/zephyr/uart_core.c
@@ -28,7 +28,7 @@
 #include "py/runtime.h"
 #include "src/zephyr_getchar.h"
 // Zephyr headers
-#include <zephyr/zephyr.h>
+#include <zephyr/kernel.h>
 #include <zephyr/device.h>
 #include <zephyr/console/console.h>
 #include <zephyr/console/tty.h>

--- a/ports/zephyr/zephyr_device.c
+++ b/ports/zephyr/zephyr_device.c
@@ -31,6 +31,12 @@ const struct device *zephyr_device_find(mp_obj_t name) {
     const char *dev_name = mp_obj_str_get_str(name);
     const struct device *dev = device_get_binding(dev_name);
 
+    #ifdef CONFIG_DEVICE_DT_METADATA
+    if (dev == NULL) {
+        dev = device_get_by_dt_nodelabel(dev_name);
+    }
+    #endif
+
     if (dev == NULL) {
         #if MICROPY_ERROR_REPORTING <= MICROPY_ERROR_REPORTING_TERSE
         mp_raise_ValueError(MP_ERROR_TEXT("device not found"));

--- a/ports/zephyr/zephyr_device.c
+++ b/ports/zephyr/zephyr_device.c
@@ -1,0 +1,43 @@
+/*
+ * This file is part of the MicroPython project, http://micropython.org/
+ *
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2024 Analog Devices, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#include "zephyr_device.h"
+#include "py/runtime.h"
+
+const struct device *zephyr_device_find(mp_obj_t name) {
+    const char *dev_name = mp_obj_str_get_str(name);
+    const struct device *dev = device_get_binding(dev_name);
+
+    if (dev == NULL) {
+        #if MICROPY_ERROR_REPORTING <= MICROPY_ERROR_REPORTING_TERSE
+        mp_raise_ValueError(MP_ERROR_TEXT("device not found"));
+        #else
+        mp_raise_msg_varg(&mp_type_ValueError, MP_ERROR_TEXT("device %s not found"), dev_name);
+        #endif
+    }
+
+    return dev;
+}

--- a/ports/zephyr/zephyr_device.h
+++ b/ports/zephyr/zephyr_device.h
@@ -1,0 +1,30 @@
+/*
+ * This file is part of the MicroPython project, http://micropython.org/
+ *
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2024 Analog Devices, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#include <zephyr/device.h>
+#include "py/obj.h"
+
+const struct device *zephyr_device_find(mp_obj_t name);

--- a/ports/zephyr/zephyr_storage.c
+++ b/ports/zephyr/zephyr_storage.c
@@ -244,8 +244,8 @@ static const mp_rom_map_elem_t zephyr_flash_area_locals_dict_table[] = {
     { MP_ROM_QSTR(MP_QSTR_readblocks), MP_ROM_PTR(&zephyr_flash_area_readblocks_obj) },
     { MP_ROM_QSTR(MP_QSTR_writeblocks), MP_ROM_PTR(&zephyr_flash_area_writeblocks_obj) },
     { MP_ROM_QSTR(MP_QSTR_ioctl), MP_ROM_PTR(&zephyr_flash_area_ioctl_obj) },
-    #if FLASH_AREA_LABEL_EXISTS(storage)
-    { MP_ROM_QSTR(MP_QSTR_STORAGE), MP_ROM_INT(FLASH_AREA_ID(storage)) },
+    #if FIXED_PARTITION_EXISTS(storage_partition)
+    { MP_ROM_QSTR(MP_QSTR_STORAGE), MP_ROM_INT(FIXED_PARTITION_ID(storage_partition)) },
     #endif
 };
 static MP_DEFINE_CONST_DICT(zephyr_flash_area_locals_dict, zephyr_flash_area_locals_dict_table);

--- a/tools/ci.sh
+++ b/tools/ci.sh
@@ -729,7 +729,7 @@ function ci_windows_build {
 
 ZEPHYR_DOCKER_VERSION=v0.26.13
 ZEPHYR_SDK_VERSION=0.16.8
-ZEPHYR_VERSION=v3.1.0
+ZEPHYR_VERSION=v3.7.0
 
 function ci_zephyr_setup {
     docker pull zephyrprojectrtos/ci:${ZEPHYR_DOCKER_VERSION}

--- a/tools/ci.sh
+++ b/tools/ci.sh
@@ -727,8 +727,8 @@ function ci_windows_build {
 ########################################################################################
 # ports/zephyr
 
-ZEPHYR_DOCKER_VERSION=v0.21.0
-ZEPHYR_SDK_VERSION=0.13.2
+ZEPHYR_DOCKER_VERSION=v0.26.13
+ZEPHYR_SDK_VERSION=0.16.8
 ZEPHYR_VERSION=v3.1.0
 
 function ci_zephyr_setup {


### PR DESCRIPTION
Updates the Zephyr port build instructions and CI to use the latest
Zephyr release tag.

Tested on frdm_k64f.

~~In draft status until the Zephyr release is finalized (currently in release candidate / stabilization phase).~~
[Zephyr v3.2.0](https://github.com/zephyrproject-rtos/zephyr/releases/tag/v3.2.0) was released on Sep 30 2022.
[Zephyr v3.3.0](https://github.com/zephyrproject-rtos/zephyr/releases/tag/v3.3.0) was released on Feb 19 2023.
[Zephyr v3.4.0](https://github.com/zephyrproject-rtos/zephyr/releases/tag/v3.4.0) was released on Jun 16 2023.
[Zephyr v3.5.0](https://github.com/zephyrproject-rtos/zephyr/releases/tag/v3.5.0) was released on Oct 20 2023.
[Zephyr v3.6.0](https://github.com/zephyrproject-rtos/zephyr/releases/tag/v3.6.0) was released on Feb 23 2024.
[Zephyr v3.7.0](https://github.com/zephyrproject-rtos/zephyr/releases/tag/v3.7.0) was released on Jul 26 2024.

Fixes #9115