### PR TITLE
py/persistentcode: Introduce .mpy sub-version.

### DIFF
--- a/mpy-cross/main.c
+++ b/mpy-cross/main.c
@@ -228,7 +228,7 @@ MP_NOINLINE int main_(int argc, char **argv) {
                 a += 1;
             } else if (strcmp(argv[a], "--version") == 0) {
                 printf("MicroPython " MICROPY_GIT_TAG " on " MICROPY_BUILD_DATE
-                    "; mpy-cross emitting mpy v" MP_STRINGIFY(MPY_VERSION) "\n");
+                    "; mpy-cross emitting mpy v" MP_STRINGIFY(MPY_VERSION) "." MP_STRINGIFY(MPY_SUB_VERSION) "\n");
                 return 0;
             } else if (strcmp(argv[a], "-v") == 0) {
                 mp_verbose_flag++;

--- a/py/persistentcode.c
+++ b/py/persistentcode.c
@@ -393,14 +393,14 @@ STATIC mp_raw_code_t *load_raw_code(mp_reader_t *reader, mp_module_context_t *co
 mp_compiled_module_t mp_raw_code_load(mp_reader_t *reader, mp_module_context_t *context) {
     byte header[4];
     read_bytes(reader, header, sizeof(header));
+    byte arch = MPY_FEATURE_DECODE_ARCH(header[2]);
     if (header[0] != 'M'
         || header[1] != MPY_VERSION
-        || MPY_FEATURE_DECODE_FLAGS(header[2]) != MPY_FEATURE_FLAGS
+        || (arch != MP_NATIVE_ARCH_NONE && MPY_FEATURE_DECODE_SUB_VERSION(header[2]) != MPY_SUB_VERSION)
         || header[3] > MP_SMALL_INT_BITS) {
         mp_raise_ValueError(MP_ERROR_TEXT("incompatible .mpy file"));
     }
     if (MPY_FEATURE_DECODE_ARCH(header[2]) != MP_NATIVE_ARCH_NONE) {
-        byte arch = MPY_FEATURE_DECODE_ARCH(header[2]);
         if (!MPY_FEATURE_ARCH_TEST(arch)) {
             if (MPY_FEATURE_ARCH_TEST(MP_NATIVE_ARCH_NONE)) {
                 // On supported ports this can be resolved by enabling feature, eg
@@ -596,7 +596,7 @@ void mp_raw_code_save(mp_compiled_module_t *cm, mp_print_t *print) {
     byte header[4] = {
         'M',
         MPY_VERSION,
-        MPY_FEATURE_ENCODE_FLAGS(MPY_FEATURE_FLAGS_DYNAMIC),
+        MPY_FEATURE_ENCODE_SUB_VERSION(MPY_SUB_VERSION),
         #if MICROPY_DYNAMIC_COMPILER
         mp_dynamic_compiler.small_int_bits,
         #else

--- a/py/persistentcode.h
+++ b/py/persistentcode.h
@@ -30,23 +30,22 @@
 #include "py/reader.h"
 #include "py/emitglue.h"
 
-// The current version of .mpy files
+// The current version of .mpy files. A bytecode-only .mpy file can be loaded
+// as long as MPY_VERSION matches, but a native .mpy (i.e. one with an arch
+// set) must also match MPY_SUB_VERSION. This allows 3 additional updates to
+// the native ABI per bytecode revision.
 #define MPY_VERSION 6
+#define MPY_SUB_VERSION 1
 
-// Macros to encode/decode flags to/from the feature byte
-#define MPY_FEATURE_ENCODE_FLAGS(flags) (flags)
-#define MPY_FEATURE_DECODE_FLAGS(feat) ((feat) & 3)
+// Macros to encode/decode sub-version to/from the feature byte. This replaces
+// the bits previously used to encode the flags (map caching and unicode)
+// which are no longer used starting at .mpy version 6.
+#define MPY_FEATURE_ENCODE_SUB_VERSION(version) (version)
+#define MPY_FEATURE_DECODE_SUB_VERSION(feat) ((feat) & 3)
 
 // Macros to encode/decode native architecture to/from the feature byte
 #define MPY_FEATURE_ENCODE_ARCH(arch) ((arch) << 2)
 #define MPY_FEATURE_DECODE_ARCH(feat) ((feat) >> 2)
-
-// The feature flag bits encode the compile-time config options that affect
-// the generate bytecode. Note: no longer used.
-// (formerly MICROPY_OPT_CACHE_MAP_LOOKUP_IN_BYTECODE and MICROPY_PY_BUILTINS_STR_UNICODE).
-#define MPY_FEATURE_FLAGS (0)
-// This is a version of the flags that can be configured at runtime.
-#define MPY_FEATURE_FLAGS_DYNAMIC (0)
 
 // Define the host architecture
 #if MICROPY_EMIT_X86
@@ -82,7 +81,7 @@
 
 // 16-bit little-endian integer with the second and third bytes of supported .mpy files
 #define MPY_FILE_HEADER_INT (MPY_VERSION \
-    | (MPY_FEATURE_ENCODE_FLAGS(MPY_FEATURE_FLAGS) | MPY_FEATURE_ENCODE_ARCH(MPY_FEATURE_ARCH)) << 8)
+    | (MPY_FEATURE_ENCODE_SUB_VERSION(MPY_SUB_VERSION) | MPY_FEATURE_ENCODE_ARCH(MPY_FEATURE_ARCH)) << 8)
 
 enum {
     MP_NATIVE_ARCH_NONE = 0,

--- a/tools/mpy-tool.py
+++ b/tools/mpy-tool.py
@@ -88,6 +88,7 @@ class FreezeError(Exception):
 
 class Config:
     MPY_VERSION = 6
+    MPY_SUB_VERSION = 1
     MICROPY_LONGINT_IMPL_NONE = 0
     MICROPY_LONGINT_IMPL_LONGLONG = 1
     MICROPY_LONGINT_IMPL_MPZ = 2
@@ -1335,6 +1336,9 @@ def read_mpy(filename):
         feature_byte = header[2]
         mpy_native_arch = feature_byte >> 2
         if mpy_native_arch != MP_NATIVE_ARCH_NONE:
+            mpy_sub_version = feature_byte & 3
+            if mpy_sub_version != config.MPY_SUB_VERSION:
+                raise MPYReadError(filename, "incompatible .mpy sub-version")
             if config.native_arch == MP_NATIVE_ARCH_NONE:
                 config.native_arch = mpy_native_arch
             elif config.native_arch != mpy_native_arch:
@@ -1658,7 +1662,9 @@ def merge_mpy(compiled_modules, output_file):
     else:
         main_cm_idx = None
         for idx, cm in enumerate(compiled_modules):
-            if cm.header[2]:
+            feature_byte = cm.header[2]
+            mpy_native_arch = feature_byte >> 2
+            if mpy_native_arch:
                 # Must use qstr_table and obj_table from this raw_code
                 if main_cm_idx is not None:
                     raise Exception("can't merge files when more than one contains native code")
@@ -1670,7 +1676,7 @@ def merge_mpy(compiled_modules, output_file):
         header = bytearray(4)
         header[0] = ord("M")
         header[1] = config.MPY_VERSION
-        header[2] = config.native_arch << 2
+        header[2] = config.native_arch << 2 | config.MPY_SUB_VERSION
         header[3] = config.mp_small_int_bits
         merged_mpy.extend(header)
 

--- a/tools/mpy_ld.py
+++ b/tools/mpy_ld.py
@@ -36,6 +36,7 @@ import makeqstrdata as qstrutil
 
 # MicroPython constants
 MPY_VERSION = 6
+MPY_SUB_VERSION = 1
 MP_CODE_BYTECODE = 2
 MP_CODE_NATIVE_VIPER = 4
 MP_NATIVE_ARCH_X86 = 1
@@ -917,7 +918,7 @@ def build_mpy(env, entry_offset, fmpy, native_qstr_vals, native_qstr_objs):
     out.open(fmpy)
 
     # MPY: header
-    out.write_bytes(bytearray([ord("M"), MPY_VERSION, env.arch.mpy_feature, MP_SMALL_INT_BITS]))
+    out.write_bytes(bytearray([ord("M"), MPY_VERSION, env.arch.mpy_feature | MPY_SUB_VERSION, MP_SMALL_INT_BITS]))
 
     # MPY: n_qstr
     out.write_uint(1 + len(native_qstr_vals))


### PR DESCRIPTION
This is an alternative to #9303.

The intent is to allow us to make breaking changes to the native ABI (e.g. changes to dynruntime.h) without needing the bytecode version to increment.

With this commit the two bits previously used for the feature flags (but now unused as of .mpy version 6) encode a sub-version. A bytecode-only .mpy file can be loaded as long as `MPY_VERSION` matches, but a native .mpy (i.e. one with an arch set) must also match `MPY_SUB_VERSION`. This allows 3 additional updates to the native ABI per bytecode revision.

_This work was funded through GitHub Sponsors._