### PR TITLE
Include filename in OSError's when loading .py and saving .mpy, in mpy-cross

### DIFF
--- a/py/persistentcode.c
+++ b/py/persistentcode.c
@@ -644,6 +644,9 @@ void mp_raw_code_save_file(mp_compiled_module_t *cm, const char *filename) {
     MP_THREAD_GIL_EXIT();
     int fd = open(filename, O_WRONLY | O_CREAT | O_TRUNC, 0644);
     MP_THREAD_GIL_ENTER();
+    if (fd < 0) {
+        mp_raise_OSError_with_filename(errno, filename);
+    }
     mp_print_t fd_print = {(void *)(intptr_t)fd, fd_print_strn};
     mp_raw_code_save(cm, &fd_print);
     MP_THREAD_GIL_EXIT();

--- a/py/reader.c
+++ b/py/reader.c
@@ -139,7 +139,7 @@ void mp_reader_new_file(mp_reader_t *reader, const char *filename) {
     int fd = open(filename, O_RDONLY, 0644);
     MP_THREAD_GIL_ENTER();
     if (fd < 0) {
-        mp_raise_OSError(errno);
+        mp_raise_OSError_with_filename(errno, filename);
     }
     mp_reader_new_file_from_fd(reader, fd, true);
 }

--- a/py/runtime.c
+++ b/py/runtime.c
@@ -1692,6 +1692,15 @@ NORETURN void mp_raise_OSError(int errno_) {
     mp_raise_type_arg(&mp_type_OSError, MP_OBJ_NEW_SMALL_INT(errno_));
 }
 
+NORETURN void mp_raise_OSError_with_filename(int errno_, const char *filename) {
+    vstr_t vstr;
+    vstr_init(&vstr, 32);
+    vstr_printf(&vstr, "can't open %s", filename);
+    mp_obj_t o_str = mp_obj_new_str_from_vstr(&vstr);
+    mp_obj_t args[2] = { MP_OBJ_NEW_SMALL_INT(errno_), MP_OBJ_FROM_PTR(o_str)};
+    nlr_raise(mp_obj_exception_make_new(&mp_type_OSError, 2, 0, args));
+}
+
 #if MICROPY_STACK_CHECK || MICROPY_ENABLE_PYSTACK
 NORETURN void mp_raise_recursion_depth(void) {
     mp_raise_type_arg(&mp_type_RuntimeError, MP_OBJ_NEW_QSTR(MP_QSTR_maximum_space_recursion_space_depth_space_exceeded));

--- a/py/runtime.h
+++ b/py/runtime.h
@@ -196,6 +196,7 @@ NORETURN void mp_raise_NotImplementedError(mp_rom_error_text_t msg);
 NORETURN void mp_raise_type_arg(const mp_obj_type_t *exc_type, mp_obj_t arg);
 NORETURN void mp_raise_StopIteration(mp_obj_t arg);
 NORETURN void mp_raise_OSError(int errno_);
+NORETURN void mp_raise_OSError_with_filename(int errno_, const char *filename);
 NORETURN void mp_raise_recursion_depth(void);
 
 #if MICROPY_BUILTIN_METHOD_CHECK_SELF_ARG


### PR DESCRIPTION
This improves error messages in mpy-cross:
- When loading a .py file that doesn't exist (or can't be opened) it now includes the filename in the OSError.
- When saving a .mpy file that can't be opened it now raises an exception (prior, it would silently fail), and includes the filename in the OSError.

Eg, prior to this PR:
```
$ mpy-cross bad
OSError: 2
```
With this PR:
```
$ mpy-cross bad
OSError: (2, "can't open bad")
```