### PR TITLE
tests/run-multitests: Make paths more deterministic.

### DIFF
--- a/tests/run-multitests.py
+++ b/tests/run-multitests.py
@@ -15,15 +15,24 @@ import itertools
 import subprocess
 import tempfile
 
-sys.path.append("../tools")
+test_dir = os.path.abspath(os.path.dirname(__file__))
+
+if os.path.abspath(sys.path[0]) == test_dir:
+    # remove the micropython/tests dir from path to avoid
+    # accidentally importing tests like micropython/const.py
+    sys.path.pop(0)
+
+sys.path.insert(0, test_dir + "/../tools")
 import pyboard
 
 if os.name == "nt":
     CPYTHON3 = os.getenv("MICROPY_CPYTHON3", "python3.exe")
-    MICROPYTHON = os.getenv("MICROPY_MICROPYTHON", "../ports/windows/micropython.exe")
+    MICROPYTHON = os.getenv("MICROPY_MICROPYTHON", test_dir + "/../ports/windows/micropython.exe")
 else:
     CPYTHON3 = os.getenv("MICROPY_CPYTHON3", "python3")
-    MICROPYTHON = os.getenv("MICROPY_MICROPYTHON", "../ports/unix/build-standard/micropython")
+    MICROPYTHON = os.getenv(
+        "MICROPY_MICROPYTHON", test_dir + "/../ports/unix/build-standard/micropython"
+    )
 
 # For diff'ing test output
 DIFF = os.getenv("MICROPY_DIFF", "diff -u")
@@ -508,7 +517,7 @@ def main():
     cmd_args = cmd_parser.parse_args()
 
     # clear search path to make sure tests use only builtin modules and those in extmod
-    os.environ["MICROPYPATH"] = os.pathsep + "../extmod"
+    os.environ["MICROPYPATH"] = os.pathsep.join(("", ".frozen", "../extmod"))
 
     test_files = prepare_test_file_list(cmd_args.files)
     max_instances = max(t[1] for t in test_files)

--- a/tests/run-multitests.py
+++ b/tests/run-multitests.py
@@ -3,6 +3,11 @@
 # This file is part of the MicroPython project, http://micropython.org/
 # The MIT License (MIT)
 # Copyright (c) 2020 Damien P. George
+#
+# run-multitests.py
+# Runs a test suite that relies on two micropython instances/devices
+# interacting in some way. Typically used to test networking / bluetooth etc.
+
 
 import sys, os, time, re, select
 import argparse
@@ -471,7 +476,10 @@ def run_tests(test_files, instances_truth, instances_test):
 def main():
     global cmd_args
 
-    cmd_parser = argparse.ArgumentParser(description="Run network tests for MicroPython")
+    cmd_parser = argparse.ArgumentParser(
+        description="Run network tests for MicroPython",
+        formatter_class=argparse.RawTextHelpFormatter,
+    )
     cmd_parser.add_argument(
         "-s", "--show-output", action="store_true", help="show test output after running"
     )
@@ -487,6 +495,14 @@ def main():
         type=int,
         default=1,
         help="repeat the test with this many permutations of the instance order",
+    )
+    cmd_parser.epilog = (
+        "Supported instance types:\r\n"
+        " -i pyb:<port>   physical device (eg. pyboard) on provided repl port.\n"
+        " -i micropython  unix micropython instance, path customised with MICROPY_MICROPYTHON env.\n"
+        " -i cpython      desktop python3 instance, path customised with MICROPY_CPYTHON3 env.\n"
+        " -i exec:<path>  custom program run on provided path.\n"
+        "Each instance arg can optionally have custom env provided, eg. <cmd>,ENV=VAR,ENV=VAR...\n"
     )
     cmd_parser.add_argument("files", nargs="+", help="input test files")
     cmd_args = cmd_parser.parse_args()


### PR DESCRIPTION
Make relative paths used internally to the mutlitest runner tool correctly relative to the script file itself, rather than current working directory. Allows running multitests from different directory as well as making some errors more consistent.

This path cleanup "improves" confusions like https://ptb.discord.com/channels/574275045187125269/1012732018183913513/1019879446066515968 by avoiding accidental imports of test scripts, so instead of `TypeError: 'module' object is not callable` when cpython imports micropython/consts.py test it now gives `ModuleNotFoundError: No module named 'micropython'` which makes more sense.

For reference I was using multitest with aioble tests and found it easier to be able to run from the target test folders. 
```
cd lib/micropython-lib/micropython/bluetooth/aioble/multitests

MICROPY_MICROPYTHON=~/micropython/ports/unix/build-ble/micropython ~/micropython/tests/run-multitests.py -t -i micropython,MICROPYBTUART=/dev/ttyACM0,MICROPYPATH=".frozen:$(pwd)/.." -i micropython,MICROPYBTUART=/dev/ttyACM1,MICROPYPATH=".frozen:$(pwd)/.." ble_write_order.py
```

I've also added some extra help messaging to the tool to make it easier to use / remember how to use.


---
This work was funded by Planet Innovation.