### PR TITLE
stm32/i2c: Fix I2C frequency is faster than specified one.

### DIFF
--- a/docs/library/machine.I2C.rst
+++ b/docs/library/machine.I2C.rst
@@ -91,6 +91,10 @@ General Methods
      - *sda* is a pin object for the SDA line
      - *freq* is the SCL clock rate
 
+   In the case of hardware I2C the actual clock frequency may be lower than the
+   requested frequency. This is dependant on the platform hardware. The actual
+   rate may be determined by printing the i2c object.
+
 .. method:: I2C.deinit()
 
    Turn off the I2C bus.

--- a/docs/library/pyb.I2C.rst
+++ b/docs/library/pyb.I2C.rst
@@ -96,6 +96,10 @@ Methods
        that DMA transfers have more precise timing but currently do not handle bus
        errors properly)
 
+   The actual clock frequency may be lower than the requested frequency.
+   This is dependant on the platform hardware. The actual rate may be determined
+   by printing the i2c object.
+
 .. method:: I2C.is_ready(addr)
 
    Check if an I2C device responds to the given address.  Only valid when in controller mode.

--- a/ports/stm32/i2c.c
+++ b/ports/stm32/i2c.c
@@ -71,9 +71,9 @@ int i2c_init(i2c_t *i2c, mp_hal_pin_obj_t scl, mp_hal_pin_obj_t sda, uint32_t fr
     // SM: MAX(4, PCLK1 / (F * 2))
     // FM, 16:9 duty: 0xc000 | MAX(1, (PCLK1 / (F * (16 + 9))))
     if (freq <= 100000) {
-        i2c->CCR = MAX(4, PCLK1 / (freq * 2));
+        i2c->CCR = MAX(4, ((PCLK1 - 1) / (freq * 2) + 1));
     } else {
-        i2c->CCR = 0xc000 | MAX(1, PCLK1 / (freq * 25));
+        i2c->CCR = 0xc000 | MAX(1, ((PCLK1 - 1) / (freq * 25) + 1));
     }
 
     // SM: 1000ns / (1/PCLK1) + 1 = PCLK1 * 1e-6 + 1


### PR DESCRIPTION
This PR fixes following issue.

The actual I2C frequency is faster than specified one and it may exceededs I2C's specification for Fast mode.
Also, machine.I2C initialize with freq=400000 (I2C Fast mode) by default but actual frequency of SCL is faster than 400KHz.
The frequency of SCL should be less than or equal to 400KHz in Fast mode.

### How to reproduce
Execute this code
```
>>> i2c=machine.I2C(1)
>>> i2c
I2C(1, scl=B8, sda=B9, freq=420000)

>>> i2c = machine.I2C(1, freq=350000)
>>> i2c
I2C(1, scl=B8, sda=B9, freq=420000)
```

### MicroPython Version
v1.19.1

### Environment
NUCLEO-F446RE

### Detail of changes
To set frequency, I2Cx_CCR is set at
https://github.com/micropython/micropython/blob/0e8c2204da377e95b5000a3c708891d98cdeb69c/ports/stm32/i2c.c#L73-L77
but SCL may be faster than expected frequency if PCLK1 is not multiple of 10.
For example, PCLK1 of NUCLEO-F446RE is 42MHz. To get 400KHz or less, CCR should be 5 but actually CCR was set to 4 by the above formula.

pyb.I2C has the same issue, but I think it is a bug of STM32CubeF4.
It was fixed at least STM32CubeF4 v1.24.1, so I also fixed it at this PR:https://github.com/micropython/stm32lib/pull/22.
I also add that the actual frequency may be lower than the specified frequency to the document like SPI.

STM32CubeF4 also fix for Standard mode, so I also fix machine.I2C for standard mode.

After applying this PR, the frequency of SCL is less than 400KHz.
```
>>> i2c=machine.I2C(1)
>>> i2c
I2C(1, scl=B8, sda=B9, freq=336000)
>>> i2c = machine.I2C(1, freq=350000)
>>> i2c
I2C(1, scl=B8, sda=B9, freq=336000)
```