### PR TITLE
ports/nrf: Reuse mp_hal_stdout_tx_str functions from stdout_helpers.

### DIFF
--- a/ports/nrf/Makefile
+++ b/ports/nrf/Makefile
@@ -234,6 +234,7 @@ SRC_LIB += $(addprefix shared/,\
 	runtime/sys_stdio_mphal.c \
 	runtime/interrupt_char.c \
 	runtime/tinyusb_helpers.c \
+	runtime/stdout_helpers.c \
 	timeutils/timeutils.c \
 	)
 

--- a/ports/nrf/drivers/usb/usb_cdc.c
+++ b/ports/nrf/drivers/usb/usb_cdc.c
@@ -236,18 +236,6 @@ void mp_hal_stdout_tx_strn(const char *str, mp_uint_t len) {
     }
 }
 
-void mp_hal_stdout_tx_strn_cooked(const char *str, mp_uint_t len) {
-
-    for (const char *top = str + len; str < top; str++) {
-        if (*str == '\n') {
-            ringbuf_put((ringbuf_t*)&tx_ringbuf, '\r');
-            usb_cdc_loop();
-        }
-        ringbuf_put((ringbuf_t*)&tx_ringbuf, *str);
-        usb_cdc_loop();
-    }
-}
-
 void USBD_IRQHandler(void) {
     tud_int_handler(0);
 }

--- a/ports/nrf/mphalport.c
+++ b/ports/nrf/mphalport.c
@@ -198,17 +198,7 @@ void mp_hal_stdout_tx_strn(const char *str, mp_uint_t len) {
         uart_tx_strn(MP_STATE_PORT(board_stdio_uart), str, len);
     }
 }
-
-void mp_hal_stdout_tx_strn_cooked(const char *str, mp_uint_t len) {
-    if (MP_STATE_PORT(board_stdio_uart) != NULL) {
-        uart_tx_strn_cooked(MP_STATE_PORT(board_stdio_uart), str, len);
-    }
-}
 #endif
-
-void mp_hal_stdout_tx_str(const char *str) {
-    mp_hal_stdout_tx_strn(str, strlen(str));
-}
 
 #if MICROPY_PY_TIME_TICKS
 


### PR DESCRIPTION
Reduces some of the duplicated code in nrf CDC port.