### PR TITLE
py/objstr.c: Don't treat bytes as unicode in str.count.

### DIFF
--- a/py/objstr.c
+++ b/py/objstr.c
@@ -1768,6 +1768,8 @@ STATIC mp_obj_t str_count(size_t n_args, const mp_obj_t *args) {
         return MP_OBJ_NEW_SMALL_INT(utf8_charlen(start, end - start) + 1);
     }
 
+    bool is_str = self_type == &mp_type_str;
+
     // count the occurrences
     mp_int_t num_occurrences = 0;
     for (const byte *haystack_ptr = start; haystack_ptr + needle_len <= end;) {
@@ -1775,7 +1777,7 @@ STATIC mp_obj_t str_count(size_t n_args, const mp_obj_t *args) {
             num_occurrences++;
             haystack_ptr += needle_len;
         } else {
-            haystack_ptr = utf8_next_char(haystack_ptr);
+            haystack_ptr = is_str ? utf8_next_char(haystack_ptr) : haystack_ptr + 1;
         }
     }
 

--- a/tests/basics/bytes_count.py
+++ b/tests/basics/bytes_count.py
@@ -48,6 +48,13 @@ print(b"aaaa".count(b'a', 1, 5))
 print(b"aaaa".count(b'a', -1, 5))
 print(b"abbabba".count(b"abba"))
 
+print(b'\xaa \xaa'.count(b'\xaa'))
+print(b'\xaa \xaa \xaa \xaa'.count(b'\xaa'))
+print(b'\xaa \xaa \xaa \xaa'.count(b'\xaa'), 1)
+print(b'\xaa \xaa \xaa \xaa'.count(b'\xaa'), 2)
+print(b'\xaa \xaa \xaa \xaa'.count(b'\xaa'), 1, 3)
+print(b'\xaa \xaa \xaa \xaa'.count(b'\xaa'), 2, 3)
+
 def t():
     return True
 


### PR DESCRIPTION
`b'\xaa \xaa'.count(b'\xaa')` now (correctly) returns 2 instead of 1.

Fixes #9404 (thanks @rmu75).

_This work was funded through GitHub Sponsors._