### PR TITLE
esp32/machine_i2c: Fix clocks and timeouts for ESP32-C3, ESP32-S3

### DIFF
--- a/ports/esp32/machine_i2c.c
+++ b/ports/esp32/machine_i2c.c
@@ -31,6 +31,7 @@
 #include "modmachine.h"
 
 #include "driver/i2c.h"
+#include "hal/i2c_ll.h"
 
 #ifndef MICROPY_HW_I2C0_SCL
 #define MICROPY_HW_I2C0_SCL (GPIO_NUM_18)
@@ -45,6 +46,14 @@
 #define MICROPY_HW_I2C1_SCL (GPIO_NUM_9)
 #define MICROPY_HW_I2C1_SDA (GPIO_NUM_8)
 #endif
+#endif
+
+#if CONFIG_IDF_TARGET_ESP32C3 || CONFIG_IDF_TARGET_ESP32S3
+#define I2C_SCLK_FREQ XTAL_CLK_FREQ
+#elif CONFIG_IDF_TARGET_ESP32 || CONFIG_IDF_TARGET_ESP32S2
+#define I2C_SCLK_FREQ I2C_APB_CLK_FREQ
+#else
+#error "unsupported I2C for ESP32 SoC variant"
 #endif
 
 #define I2C_DEFAULT_TIMEOUT_US (10000) // 10ms
@@ -71,7 +80,8 @@ STATIC void machine_hw_i2c_init(machine_hw_i2c_obj_t *self, uint32_t freq, uint3
         .master.clk_speed = freq,
     };
     i2c_param_config(self->port, &conf);
-    i2c_set_timeout(self->port, I2C_APB_CLK_FREQ / 1000000 * timeout_us);
+    int timeout = I2C_SCLK_FREQ / 1000000 * timeout_us;
+    i2c_set_timeout(self->port, (timeout > I2C_LL_MAX_TIMEOUT) ? I2C_LL_MAX_TIMEOUT : timeout);
     i2c_driver_install(self->port, I2C_MODE_MASTER, 0, 0, 0);
 }
 
@@ -131,7 +141,7 @@ STATIC void machine_hw_i2c_print(const mp_print_t *print, mp_obj_t self_in, mp_p
     int h, l;
     i2c_get_period(self->port, &h, &l);
     mp_printf(print, "I2C(%u, scl=%u, sda=%u, freq=%u)",
-        self->port, self->scl, self->sda, I2C_APB_CLK_FREQ / (h + l));
+        self->port, self->scl, self->sda, I2C_SCLK_FREQ / (h + l));
 }
 
 mp_obj_t machine_hw_i2c_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *all_args) {


### PR DESCRIPTION
Each SoC family has its own clocks and timings/timeouts. For I2C, the default source clock is either APB (ESP32, ESP32-S2) or XTAL (ESP32-S3, ESP32-C3) as shown in the datasheets. Since machine_i2c.c/machine_hw_i2c_init() uses the default clk_flags (0), the alternate low-power clock source is never selected in ESP-IDF i2c.c/i2c_param_config(). There is not an API in i2c.c to get the source clock frequency, so a compile-time value is used based on SoC family.

Also, the maximum timeout is different across the SoC families, so use the I2C_LL_MAX_TIMEOUT constant to eliminate the warning from i2c_set_timeout().

With these changes, the following results were obtained. The I2C SCL frequencies were measured with a Saleae logic analyzer.

ESP32 (TTGO T Dislay)
I2C(0, scl=22, sda=21, freq=101781)  Measured: 100KHz I2C(0, scl=22, sda=21, freq=430107)  Measured: 400KHz I2C(0, scl=22, sda=21, freq=1212121) Measured: 941KHz

ESP32-S3 (TTGO T-QT)
I2C(0, scl=34, sda=33, freq=111111)  Measured: 107KHz I2C(0, scl=34, sda=33, freq=444444)  Measured: 400KHz I2C(0, scl=34, sda=33, freq=1111111) Measured: 842KHz (esp) mark@sam:~/.../mp_extras/SEEED_XIAO_ESP32C3/examples$

ESP32-C3 (XIAO ESP32C3)
I2C(0, scl=7, sda=6, freq=107816)  Measured: 103KHz I2C(0, scl=7, sda=6, freq=444444)  Measured: 380KHz I2C(0, scl=7, sda=6, freq=1176470) Measured: 800KHz

(ESP32-S2 board was not available for testing.)

Datasheets:

* ESP32 https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-reference/peripherals/i2c.html#source-clock-configuration
* ESP32-C3 https://docs.espressif.com/projects/esp-idf/en/latest/esp32c3/api-reference/peripherals/i2c.html#source-clock-configuration
* ESP32-S2 https://docs.espressif.com/projects/esp-idf/en/latest/esp32s2/api-reference/peripherals/i2c.html#source-clock-configuration
* ESP32-S3 https://docs.espressif.com/projects/esp-idf/en/latest/esp32s3/api-reference/peripherals/i2c.html#source-clock-configuration