### PR TITLE
ports/rp2: Fix lightsleep to work with interrupts and cyw43.

### DIFF
--- a/ports/rp2/cyw43_configport.h
+++ b/ports/rp2/cyw43_configport.h
@@ -49,12 +49,12 @@
 
 #define CYW43_SDPCM_SEND_COMMON_WAIT \
     if (get_core_num() == 0) { \
-        __WFI(); \
+        cyw43_yield(); \
     } \
 
 #define CYW43_DO_IOCTL_WAIT \
     if (get_core_num() == 0) { \
-        __WFI(); \
+        cyw43_yield(); \
     } \
 
 #define CYW43_ARRAY_SIZE(a)             MP_ARRAY_SIZE(a)
@@ -88,6 +88,15 @@
 #define cyw43_schedule_internal_poll_dispatch(func) pendsv_schedule_dispatch(PENDSV_DISPATCH_CYW43, func)
 
 void cyw43_post_poll_hook(void);
+extern volatile int cyw43_has_pending;
+
+static inline void cyw43_yield(void) {
+    uint32_t my_interrupts = save_and_disable_interrupts();
+    if (!cyw43_has_pending) {
+        __WFI();
+    }
+    restore_interrupts(my_interrupts);
+}
 
 static inline void cyw43_delay_us(uint32_t us) {
     uint32_t start = mp_hal_ticks_us();
@@ -99,7 +108,7 @@ static inline void cyw43_delay_ms(uint32_t ms) {
     uint32_t us = ms * 1000;
     int32_t start = mp_hal_ticks_us();
     while (mp_hal_ticks_us() - start < us) {
-        __WFI();
+        cyw43_yield();
         MICROPY_EVENT_POLL_HOOK_FAST;
     }
 }

--- a/ports/rp2/mpnetworkport.c
+++ b/ports/rp2/mpnetworkport.c
@@ -48,6 +48,7 @@ static alarm_id_t lwip_alarm_id = -1;
 #define CYW43_SHARED_IRQ_HANDLER_PRIORITY PICO_SHARED_IRQ_HANDLER_HIGHEST_ORDER_PRIORITY
 
 uint32_t cyw43_country_code = CYW43_COUNTRY_WORLDWIDE;
+volatile int cyw43_has_pending = 0;
 
 static void gpio_irq_handler(void) {
     uint32_t events = gpio_get_irq_event_mask(CYW43_PIN_WL_HOST_WAKE);
@@ -56,6 +57,7 @@ static void gpio_irq_handler(void) {
         // So disable the interrupt until this is done.  It's re-enabled again by
         // CYW43_POST_POLL_HOOK which is called at the end of cyw43_poll_func.
         gpio_set_irq_enabled(CYW43_PIN_WL_HOST_WAKE, CYW43_IRQ_LEVEL, false);
+        cyw43_has_pending = 1;
         pendsv_schedule_dispatch(PENDSV_DISPATCH_CYW43, cyw43_poll);
         CYW43_STAT_INC(IRQ_COUNT);
     }
@@ -68,6 +70,7 @@ void cyw43_irq_init(void) {
 }
 
 void cyw43_post_poll_hook(void) {
+    cyw43_has_pending = 0;
     gpio_set_irq_enabled(CYW43_PIN_WL_HOST_WAKE, CYW43_IRQ_LEVEL, true);
 }
 


### PR DESCRIPTION
This PR prevents micropython from "hanging" when using `lightsleep` while the wifi chip is active. A bit more rationale for the changes:
Whenever the wifi chip wants to interrupt the microcontroller to notify it for a new package, it sets the `CYW43_PIN_WL_HOST_WAKE` pin to high, triggering an IRQ. However, as polling the chip cannot happen in an interrupt handler, it subsequently notifies the `pendsv`-service to do a poll as soon as the interrupt handler ended. In order to prevent a new interrupt from happening immediately afterwards, even before the poll has run, the irq handler disables interrupts from the pin:
https://github.com/micropython/micropython/blob/bdbc44474f92db19a40b5f710a140a0bf70fb0ec/ports/rp2/mpnetworkport.c#L58

The first problem occurs, when a wifi package arrives while the main loop is in cyw43-code. In order to prevent concurrent access of the hardware,  the network code blocks pendsv from running again while entering lwip code: https://github.com/micropython/micropython/blob/99c25897783122003550d58f8d31b4a8fecc8611/ports/rp2/mpnetworkport.c#L95
The same holds for direct cyw43 code (like changing the cyw43-gpios, i.e. the LED on the pico W). While the pendsv is disabled, interrupts can still occur to schedule a poll (and disable further interrupts), but it will not run. This can happen while the microcontroller is anywhere in rp2040 code.

In order to preserve power while waiting for cyw43 responses, `cyw43_configport.h` defines `CYW43_DO_IOCTL_WAIT` and `CYW43_SDPCM_SEND_COMMON_WAIT` to `__WFI()`. While this might work in most cases, there are 2 edge cases where it fails:
- When an interrupt has already been received by the cyw43 stack, for example due to an incoming ethernet packet (I observed this deadlock on a SWP stacktrace).
- When the interrupt from the cyw43 response comes before the microcontroller entered the `__WFI()` instruction.

When that happens, `wfi` will just block forever as no further interrupts are received. The only way to safely use `wfi` to wake up from an interrupt is inside a critical section, as this delays interrupts until the `wfi` is entered, possibly resuming immediately until interrupts are reenabled and the interrupt handler is run. Additionally this critical section needs to check whether the interrupt has already been disabled and pendsv was triggered, as in such a case, `wfi` can never be woken up, and needs to be skipped, because there is already a package from the network chip waiting. Note that this turns `cyw43_yield` into a nop (and thereby the cyw43-loops into busy waits) from the second time onwards, as after the first call, a pendsv request will definitely be pending. More logic could be added, to explicitly enable the interrupt in this case.

Regarding `lightsleep`: This code has a similar problem. When an interrupt occurs during lightsleep, the IRQ and pendsv handler and thereby poll are run immediately, with the clocks still disabled, causing the spi transfers to fail. If we don't want to add complex logic inside the IRQ handler we need to protect the whole lightsleep procedure form interrupts with a critical section, exiting out early if an interrupt is pending for whatever reason. Only then we can start to shut down clocks and only enable interrupts when the system is ready again. Other interrupt handlers might also be happy, that they are only run when the system is fully operational.

I've tested the changes on a pico W which I send into lightsleep within an endless loop and pinging from extern. With these changes the pico doesn't lock up anymore but wakes up, processes the packages correctly, and goes back to lightsleep.