### PR TITLE
renesas-ra: Add the UART methods uart.txdone() and uart.flush().

### DIFF
--- a/docs/library/machine.UART.rst
+++ b/docs/library/machine.UART.rst
@@ -188,7 +188,7 @@ Methods
        For the rp2, esp8266 and nrf ports the call returns while the last byte is sent.
        If required, a one character wait time has to be added in the calling script.
 
-   Availability: rp2, esp32, esp8266, mimxrt, cc3200, stm32, nrf ports
+   Availability: rp2, esp32, esp8266, mimxrt, cc3200, stm32, nrf ports, renesas-ra
 
 .. method:: UART.txdone()
 
@@ -201,7 +201,7 @@ Methods
        of a transfer is still being sent. If required, a one character wait time has to be
        added in the calling script.
 
-   Availability: rp2, esp32, esp8266, mimxrt, cc3200, stm32, nrf ports
+   Availability: rp2, esp32, esp8266, mimxrt, cc3200, stm32, nrf ports, renesas-ra
 
 Constants
 ---------

--- a/ports/renesas-ra/ra/ra_sci.c
+++ b/ports/renesas-ra/ra/ra_sci.c
@@ -1026,6 +1026,16 @@ int ra_sci_tx_wait(uint32_t ch) {
     return (int)(tx_fifo[idx].len != (tx_fifo[idx].size - 1));
 }
 
+int ra_sci_tx_busy(uint32_t ch) {
+    uint32_t idx = ch_to_idx[ch];
+    return (int)(tx_fifo[idx].busy);
+}
+
+int ra_sci_tx_bufsize(uint32_t ch) {
+    uint32_t idx = ch_to_idx[ch];
+    return (int)(tx_fifo[idx].size - 1);
+}
+
 void ra_sci_tx_break(uint32_t ch) {
     uint32_t idx = ch_to_idx[ch];
     R_SCI0_Type *sci_reg = sci_regs[idx];

--- a/ports/renesas-ra/ra/ra_sci.h
+++ b/ports/renesas-ra/ra/ra_sci.h
@@ -52,6 +52,8 @@ bool ra_sci_is_rxirq_enable(uint32_t ch);
 void ra_sci_isr_te(uint32_t ch);
 int ra_sci_rx_ch(uint32_t ch);
 int ra_sci_rx_any(uint32_t ch);
+int ra_sci_tx_busy(uint32_t ch);
+int ra_sci_tx_bufsize(uint32_t ch);
 void ra_sci_tx_ch(uint32_t ch, int c);
 int ra_sci_tx_wait(uint32_t ch);
 void ra_sci_tx_break(uint32_t ch);

--- a/ports/renesas-ra/uart.c
+++ b/ports/renesas-ra/uart.c
@@ -420,6 +420,16 @@ mp_uint_t uart_tx_avail(machine_uart_obj_t *self) {
     return ra_sci_tx_wait(ch);
 }
 
+mp_uint_t uart_tx_busy(machine_uart_obj_t *self) {
+    int ch = (int)self->uart_id;
+    return ra_sci_tx_busy(ch);
+}
+
+mp_uint_t uart_tx_txbuf(machine_uart_obj_t *self) {
+    int ch = (int)self->uart_id;
+    return ra_sci_tx_bufsize(ch);
+}
+
 // Waits at most timeout milliseconds for at least 1 char to become ready for
 // reading (from buf or for direct reading).
 // Returns true if something available, false if not.

--- a/ports/renesas-ra/uart.h
+++ b/ports/renesas-ra/uart.h
@@ -106,6 +106,8 @@ void uart_attach_to_repl(machine_uart_obj_t *self, bool attached);
 uint32_t uart_get_baudrate(machine_uart_obj_t *self);
 mp_uint_t uart_rx_any(machine_uart_obj_t *uart_obj);
 mp_uint_t uart_tx_avail(machine_uart_obj_t *uart_obj);
+mp_uint_t uart_tx_busy(machine_uart_obj_t *uart_obj);
+mp_uint_t uart_tx_txbuf(machine_uart_obj_t *self);
 bool uart_rx_wait(machine_uart_obj_t *self, uint32_t timeout);
 int uart_rx_char(machine_uart_obj_t *uart_obj);
 bool uart_tx_wait(machine_uart_obj_t *self, uint32_t timeout);


### PR DESCRIPTION
The API is consistent to the other ports. flush() returns after the last byte has been sent, and txdone() also reports True after the last byte has been sent.

This required to add two very simple functions down the stack to uart.c and ra.sci.c.

- One for telling, whether the transmission is busy.
- One for reporting the size of the TX buffer. There is no txbuf option for setting the bufger size, so the actually used buffer size had to be retrieved.

Tested with a EK-RA6M2 board by me and with all boards from the port's boards directory by @TakeoTakahashi2020.