### PR TITLE
ports/esp8266: Add auto_connect & reconnects options to WLAN.config().

### DIFF
--- a/ports/esp8266/network_wlan.c
+++ b/ports/esp8266/network_wlan.c
@@ -423,6 +423,20 @@ STATIC mp_obj_t esp_config(size_t n_args, const mp_obj_t *args, mp_map_t *kwargs
                         wifi_set_sleep_type(mp_obj_get_int(kwargs->table[i].value));
                         break;
                     }
+                    case MP_QSTR_auto_connect: {
+                        wifi_station_set_auto_connect(mp_obj_is_true(kwargs->table[i].value));
+                        break;
+                    }
+                    case MP_QSTR_reconnects: {
+                        req_if = STATION_IF;
+                        if (self->if_id == STATION_IF) {
+                            int reconnects = mp_obj_get_int(kwargs->table[i].value);
+                            // parameter reconnects == -1 means to retry forever.
+                            wifi_station_set_reconnect_policy((reconnects != 0));
+                            wifi_station_dhcpc_set_maxtry((reconnects == -1) ? 255 : reconnects);
+                        }
+                        break;
+                    }
                     default:
                         goto unknown;
                 }
@@ -492,6 +506,10 @@ STATIC mp_obj_t esp_config(size_t n_args, const mp_obj_t *args, mp_map_t *kwargs
         }
         case MP_QSTR_pm: {
             val = MP_OBJ_NEW_SMALL_INT(wifi_get_sleep_type());
+            break;
+        }
+        case MP_QSTR_auto_connect: {
+            val = mp_obj_new_bool(wifi_station_get_auto_connect());
             break;
         }
         default:


### PR DESCRIPTION
Adds support for:
- disabling/enabling the wifi auto-connect _"feature"_ of the esp8266 (`WLAN.config(auto_connect=True/False)`); and
- setting the _reconnect_ policy for the esp8266 after disconnecting from wifi (`WLAN.config(reconnects=xx)`).

**Motivation**
The auto-connect feature is regarded by some as a mis-feature of the esp8266 and is one source of incompatible behaviour for code running on esp32 and esp8266. The `auto_connect=False` option allows users to ensure their esp8266 device's behaviour is deterministically derived from startup code. The `reconnects` option provides similar (but not the same) functionality to the `reconnects` opton on ESP32.

The semantics of the `reconnects` option differ from the esp32 in important ways:
- reconnects=0:
  - ESP32 and ESP8266: No attempt is made to reconnect after disconnection from AP
- reconnects>=1:
  - ESP32: Sets the maximum number of times the device will attempt to reconnect to AP
  - ESP8266: Sets the number of times device will attempt to retry dhcp after disconnecting.

**Note:** `WLAN.config("reconnects")` is not supported since the esp8266 SDK provide no mechanism for querying the current settings.

**This PR adds:**
- `WLAN.config(auto_connect=True/False)` to enable/disable the ESP8266 from automatically connecting to wifi networks after WLAN.active(True).
- `WLAN.config(reconnects=xx)` where `xx` is an integer to limit the number of times to attempt to reconnect after becoming disconnected from a wifi access point.