### PR TITLE
docs/Makefile: Enable parallel compilation for Sphinx.

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -3,7 +3,7 @@
 
 # You can set these variables from the command line.
 PYTHON        = python3
-SPHINXOPTS    = -W --keep-going
+SPHINXOPTS    = -W --keep-going -j auto
 SPHINXBUILD   = sphinx-build
 PAPER         =
 BUILDDIR      = build/$(MICROPY_PORT)


### PR DESCRIPTION
This has a fairly dramatic (nearly 3x on a 6-core machine, 21.896s --> 8.955s) speedup for docs compilation, with no impact on correctness.