### PR TITLE
tools/mpremote: Add `mpremote mip install` to install packages.

### DIFF
--- a/docs/reference/mpremote.rst
+++ b/docs/reference/mpremote.rst
@@ -146,6 +146,14 @@ The full list of supported commands are:
   variable ``$EDITOR``). If the editor exits successfully, the updated file will
   be copied back to the device.
 
+- install packages from :term:`micropython-lib` (or GitHub) using the ``mip`` tool:
+
+  .. code-block:: bash
+
+      $ mpremote mip install <packages...>
+
+  See :ref:`packages` for more information.
+
 - mount the local directory on the remote device:
 
   .. code-block:: bash
@@ -269,3 +277,9 @@ Examples
   mpremote cp -r dir/ :
 
   mpremote cp a.py b.py : + repl
+
+  mpremote mip install aioble
+
+  mpremote mip install github:org/repo@branch
+
+  mpremote mip install --target /flash/third-party functools

--- a/docs/reference/packages.rst
+++ b/docs/reference/packages.rst
@@ -78,17 +78,17 @@ The :term:`mpremote` tool also includes the same functionality as ``mip`` and
 can be used from a host PC to install packages to a locally connected device
 (e.g. via USB or UART)::
 
-    $ mpremote install pkgname
-    $ mpremote install pkgname@x.y
-    $ mpremote install http://example.com/x/y/foo.py
-    $ mpremote install github:org/repo
-    $ mpremote install github:org/repo@branch-or-tag
+    $ mpremote mip install pkgname
+    $ mpremote mip install pkgname@x.y
+    $ mpremote mip install http://example.com/x/y/foo.py
+    $ mpremote mip install github:org/repo
+    $ mpremote mip install github:org/repo@branch-or-tag
 
 The ``--target=path``, ``--no-mpy``, and ``--index`` arguments can be set::
 
-    $ mpremote install --target=/flash/third-party pkgname
-    $ mpremote install --no-mpy pkgname
-    $ mpremote install --index https://host/pi pkgname
+    $ mpremote mip install --target=/flash/third-party pkgname
+    $ mpremote mip install --no-mpy pkgname
+    $ mpremote mip install --index https://host/pi pkgname
 
 Installing packages manually
 ----------------------------

--- a/tools/mpremote/README.md
+++ b/tools/mpremote/README.md
@@ -11,23 +11,28 @@ This will automatically connect to the device and provide an interactive REPL.
 
 The full list of supported commands are:
 
-    mpremote connect <device>        -- connect to given device
-                                        device may be: list, auto, id:x, port:x
-                                        or any valid device name/path
-    mpremote disconnect              -- disconnect current device
-    mpremote mount <local-dir>       -- mount local directory on device
-    mpremote eval <string>           -- evaluate and print the string
-    mpremote exec <string>           -- execute the string
-    mpremote run <file>              -- run the given local script
-    mpremote fs <command> <args...>  -- execute filesystem commands on the device
-                                        command may be: cat, ls, cp, rm, mkdir, rmdir
-                                        use ":" as a prefix to specify a file on the device
-    mpremote repl                    -- enter REPL
-                                        options:
-                                            --capture <file>
-                                            --inject-code <string>
-                                            --inject-file <file>
-    mpremote help                    -- print list of commands and exit
+    mpremote connect <device>         -- connect to given device
+                                         device may be: list, auto, id:x, port:x
+                                         or any valid device name/path
+    mpremote disconnect               -- disconnect current device
+    mpremote mount <local-dir>        -- mount local directory on device
+    mpremote eval <string>            -- evaluate and print the string
+    mpremote exec <string>            -- execute the string
+    mpremote run <file>               -- run the given local script
+    mpremote fs <command> <args...>   -- execute filesystem commands on the device
+                                         command may be: cat, ls, cp, rm, mkdir, rmdir
+                                         use ":" as a prefix to specify a file on the device
+    mpremote repl                     -- enter REPL
+                                         options:
+                                             --capture <file>
+                                             --inject-code <string>
+                                             --inject-file <file>
+    mpremote mip install <package...> -- Install packages (from micropython-lib or third-party sources)
+                                         options:
+                                             --target <path>
+                                             --index <url>
+                                             --no-mpy
+    mpremote help                     -- print list of commands and exit
 
 Multiple commands can be specified and they will be run sequentially.  Connection
 and disconnection will be done automatically at the start and end of the execution
@@ -73,3 +78,5 @@ Examples:
     mpremote cp :main.py .
     mpremote cp main.py :
     mpremote cp -r dir/ :
+    mpremote mip install aioble
+    mpremote mip install github:org/repo@branch

--- a/tools/mpremote/mpremote/commands.py
+++ b/tools/mpremote/mpremote/commands.py
@@ -1,0 +1,261 @@
+import os
+import sys
+import tempfile
+
+import serial.tools.list_ports
+
+from . import pyboardextended as pyboard
+
+
+class CommandError(Exception):
+    pass
+
+    do_disconnect(state)
+
+    try:
+        if dev == "list":
+            # List attached devices.
+            for p in sorted(serial.tools.list_ports.comports()):
+                print(
+                    "{} {} {:04x}:{:04x} {} {}".format(
+                        p.device,
+                        p.serial_number,
+                        p.vid if isinstance(p.vid, int) else 0,
+                        p.pid if isinstance(p.pid, int) else 0,
+                        p.manufacturer,
+                        p.product,
+                    )
+                )
+            # Don't do implicit REPL command.
+            state.did_action()
+        elif dev == "auto":
+            # Auto-detect and auto-connect to the first available device.
+            for p in sorted(serial.tools.list_ports.comports()):
+                try:
+                    state.pyb = pyboard.PyboardExtended(p.device, baudrate=115200)
+                    return
+                except pyboard.PyboardError as er:
+                    if not er.args[0].startswith("failed to access"):
+                        raise er
+            raise pyboard.PyboardError("no device found")
+        elif dev.startswith("id:"):
+            # Search for a device with the given serial number.
+            serial_number = dev[len("id:") :]
+            dev = None
+            for p in serial.tools.list_ports.comports():
+                if p.serial_number == serial_number:
+                    state.pyb = pyboard.PyboardExtended(p.device, baudrate=115200)
+                    return
+            raise pyboard.PyboardError("no device with serial number {}".format(serial_number))
+        else:
+            # Connect to the given device.
+            if dev.startswith("port:"):
+                dev = dev[len("port:") :]
+            state.pyb = pyboard.PyboardExtended(dev, baudrate=115200)
+            return
+    except pyboard.PyboardError as er:
+        msg = er.args[0]
+        if msg.startswith("failed to access"):
+            msg += " (it may be in use by another program)"
+        print(msg)
+        sys.exit(1)
+
+
+def do_disconnect(state, _args=None):
+    if not state.pyb:
+        return
+
+    try:
+        if state.pyb.mounted:
+            if not state.pyb.in_raw_repl:
+                state.pyb.enter_raw_repl(soft_reset=False)
+            state.pyb.umount_local()
+        if state.pyb.in_raw_repl:
+            state.pyb.exit_raw_repl()
+    except OSError:
+        # Ignore any OSError exceptions when shutting down, eg:
+        # - pyboard.filesystem_command will close the connecton if it had an error
+        # - umounting will fail if serial port disappeared
+        pass
+    state.pyb.close()
+    state.pyb = None
+    state._auto_soft_reset = True
+
+
+def show_progress_bar(size, total_size, op="copying"):
+    if not sys.stdout.isatty():
+        return
+    verbose_size = 2048
+    bar_length = 20
+    if total_size < verbose_size:
+        return
+    elif size >= total_size:
+        # Clear progress bar when copy completes
+        print("\r" + " " * (13 + len(op) + bar_length) + "\r", end="")
+    else:
+        bar = size * bar_length // total_size
+        progress = size * 100 // total_size
+        print(
+            "\r ... {} {:3d}% [{}{}]".format(op, progress, "#" * bar, "-" * (bar_length - bar)),
+            end="",
+        )
+
+
+# Get all args up to the terminator ("+").
+# The passed args will be updated with these ones removed.
+def _get_fs_args(args):
+    n = 0
+    for src in args:
+        if src == "+":
+            break
+        n += 1
+    fs_args = args[:n]
+    args[:] = args[n + 1 :]
+    return fs_args
+
+
+def do_filesystem(state, args):
+    state.ensure_raw_repl()
+    state.did_action()
+
+    def _list_recursive(files, path):
+        if os.path.isdir(path):
+            for entry in os.listdir(path):
+                _list_recursive(files, "/".join((path, entry)))
+        else:
+            files.append(os.path.split(path))
+
+    fs_args = _get_fs_args(args)
+
+    # Don't be verbose when using cat, so output can be redirected to something.
+    verbose = fs_args[0] != "cat"
+
+    if fs_args[0] == "cp" and fs_args[1] == "-r":
+        fs_args.pop(0)
+        fs_args.pop(0)
+        if fs_args[-1] != ":":
+            print(f"{_PROG}: 'cp -r' destination must be ':'")
+            sys.exit(1)
+        fs_args.pop()
+        src_files = []
+        for path in fs_args:
+            if path.startswith(":"):
+                raise CommandError("'cp -r' source files must be local")
+            _list_recursive(src_files, path)
+        known_dirs = {""}
+        state.pyb.exec_("import uos")
+        for dir, file in src_files:
+            dir_parts = dir.split("/")
+            for i in range(len(dir_parts)):
+                d = "/".join(dir_parts[: i + 1])
+                if d not in known_dirs:
+                    state.pyb.exec_("try:\n uos.mkdir('%s')\nexcept OSError as e:\n print(e)" % d)
+                    known_dirs.add(d)
+            pyboard.filesystem_command(
+                state.pyb,
+                ["cp", "/".join((dir, file)), ":" + dir + "/"],
+                progress_callback=show_progress_bar,
+                verbose=verbose,
+            )
+    else:
+        try:
+            pyboard.filesystem_command(
+                state.pyb, fs_args, progress_callback=show_progress_bar, verbose=verbose
+            )
+        except OSError as er:
+            raise CommandError(er)
+
+
+def do_edit(state, args):
+    state.ensure_raw_repl()
+    state.did_action()
+
+    if not os.getenv("EDITOR"):
+        raise pyboard.PyboardError("edit: $EDITOR not set")
+    for src in _get_fs_args(args):
+        src = src.lstrip(":")
+        dest_fd, dest = tempfile.mkstemp(suffix=os.path.basename(src))
+        try:
+            print("edit :%s" % (src,))
+            os.close(dest_fd)
+            state.pyb.fs_touch(src)
+            state.pyb.fs_get(src, dest, progress_callback=show_progress_bar)
+            if os.system("$EDITOR '%s'" % (dest,)) == 0:
+                state.pyb.fs_put(dest, src, progress_callback=show_progress_bar)
+        finally:
+            os.unlink(dest)
+
+
+def _get_follow_arg(args):
+    if args[0] == "--no-follow":
+        args.pop(0)
+        return False
+    else:
+        return True
+
+
+def _do_execbuffer(state, buf, follow):
+    state.ensure_raw_repl()
+    state.did_action()
+
+    try:
+        state.pyb.exec_raw_no_follow(buf)
+        if follow:
+            ret, ret_err = state.pyb.follow(timeout=None, data_consumer=pyboard.stdout_write_bytes)
+            if ret_err:
+                pyboard.stdout_write_bytes(ret_err)
+                sys.exit(1)
+    except pyboard.PyboardError as er:
+        print(er)
+        sys.exit(1)
+    except KeyboardInterrupt:
+        sys.exit(1)
+
+
+def do_exec(state, args):
+    follow = _get_follow_arg(args)
+    buf = args.pop(0)
+    _do_execbuffer(state, buf, follow)
+
+
+def do_eval(state, args):
+    follow = _get_follow_arg(args)
+    buf = "print(" + args.pop(0) + ")"
+    _do_execbuffer(state, buf, follow)
+
+
+def do_run(state, args):
+    follow = _get_follow_arg(args)
+    filename = args.pop(0)
+    try:
+        with open(filename, "rb") as f:
+            buf = f.read()
+    except OSError:
+        raise CommandError(f"could not read file '{filename}'")
+        sys.exit(1)
+    _do_execbuffer(state, buf, follow)
+
+
+def do_mount(state, args):
+    state.ensure_raw_repl()
+
+    unsafe_links = False
+    if args[0] == "--unsafe-links" or args[0] == "-l":
+        args.pop(0)
+        unsafe_links = True
+    path = args.pop(0)
+    state.pyb.mount_local(path, unsafe_links=unsafe_links)
+    print(f"Local directory {path} is mounted at /remote")
+
+
+def do_umount(state, path):
+    state.ensure_raw_repl()
+    state.pyb.umount_local()
+
+
+def do_resume(state, _args=None):
+    state._auto_soft_reset = False
+
+
+def do_soft_reset(state, _args=None):
+    state.ensure_raw_repl(soft_reset=True)

--- a/tools/mpremote/mpremote/main.py
+++ b/tools/mpremote/mpremote/main.py
@@ -19,45 +19,101 @@ MicroPython device over a serial connection.  Commands supported are:
 
 import os, sys
 from collections.abc import Mapping
-import tempfile
 from textwrap import dedent
 
-import serial.tools.list_ports
-
-from . import pyboardextended as pyboard
-from .console import Console, ConsolePosix
+from .commands import (
+    CommandError,
+    do_connect,
+    do_disconnect,
+    do_edit,
+    do_filesystem,
+    do_mount,
+    do_umount,
+    do_exec,
+    do_eval,
+    do_run,
+    do_resume,
+    do_soft_reset,
+)
+from .repl import do_repl
 
 _PROG = "mpremote"
 
-# (need_raw_repl, is_action, num_args_min, help_text)
+
+def do_help(state, _args=None):
+    def print_commands_help(cmds, help_idx):
+        max_command_len = max(len(cmd) for cmd in cmds.keys())
+        for cmd in sorted(cmds.keys()):
+            help_message_lines = dedent(cmds[cmd][help_idx]).split("\n")
+            help_message = help_message_lines[0]
+            for line in help_message_lines[1:]:
+                help_message = "{}\n{}{}".format(help_message, " " * (max_command_len + 4), line)
+            print("  ", cmd, " " * (max_command_len - len(cmd) + 2), help_message, sep="")
+
+    print(_PROG, "-- MicroPython remote control")
+    print("See https://docs.micropython.org/en/latest/reference/mpremote.html")
+
+    print("\nList of commands:")
+    print_commands_help(_COMMANDS, 1)
+
+    print("\nList of shortcuts:")
+    print_commands_help(_command_expansions, 2)
+
+    sys.exit(0)
+
+
+def do_version(state, _args=None):
+    from . import __version__
+
+    print(f"{_PROG} {__version__}")
+    sys.exit(0)
+
+
+# Map of "command" to tuple of (num_args_min, help_text, handler).
 _COMMANDS = {
     "connect": (
-        False,
-        False,
         1,
         """\
         connect to given device
         device may be: list, auto, id:x, port:x
         or any valid device name/path""",
+        do_connect,
     ),
-    "disconnect": (False, False, 0, "disconnect current device"),
-    "edit": (True, True, 1, "edit files on the device"),
-    "resume": (False, False, 0, "resume a previous mpremote session (will not auto soft-reset)"),
-    "soft-reset": (False, True, 0, "perform a soft-reset of the device"),
+    "disconnect": (
+        0,
+        "disconnect current device",
+        do_disconnect,
+    ),
+    "edit": (
+        1,
+        "edit files on the device",
+        do_edit,
+    ),
+    "resume": (
+        0,
+        "resume a previous mpremote session (will not auto soft-reset)",
+        do_resume,
+    ),
+    "soft-reset": (
+        0,
+        "perform a soft-reset of the device",
+        do_soft_reset,
+    ),
     "mount": (
-        True,
-        False,
         1,
         """\
         mount local directory on device
         options:
             --unsafe-links, -l
                 follow symbolic links pointing outside of local directory""",
+        do_mount,
     ),
-    "umount": (True, False, 0, "unmount the local directory"),
+    "umount": (
+        0,
+        "unmount the local directory",
+        do_umount,
+    ),
     "repl": (
-        False,
-        True,
         0,
         """\
         enter REPL
@@ -65,15 +121,45 @@ _COMMANDS = {
             --capture <file>
             --inject-code <string>
             --inject-file <file>""",
+        do_repl,
     ),
-    "eval": (True, True, 1, "evaluate and print the string"),
-    "exec": (True, True, 1, "execute the string"),
-    "run": (True, True, 1, "run the given local script"),
-    "fs": (True, True, 1, "execute filesystem commands on the device"),
-    "help": (False, False, 0, "print help and exit"),
-    "version": (False, False, 0, "print version and exit"),
+    "eval": (
+        1,
+        "evaluate and print the string",
+        do_eval,
+    ),
+    "exec": (
+        1,
+        "execute the string",
+        do_exec,
+    ),
+    "run": (
+        1,
+        "run the given local script",
+        do_run,
+    ),
+    "fs": (
+        1,
+        "execute filesystem commands on the device",
+        do_filesystem,
+    ),
+    "help": (
+        0,
+        "print help and exit",
+        do_help,
+    ),
+    "version": (
+        0,
+        "print version and exit",
+        do_version,
+    ),
 }
 
+# Additional commands aliases.
+# The value can either be:
+#   - A command string.
+#   - A list of command strings, each command will be executed sequentially.
+#   - A dict of command: { [], help: ""}
 _BUILTIN_COMMAND_EXPANSIONS = {
     # Device connection shortcuts.
     "devs": {
@@ -117,6 +203,8 @@ _BUILTIN_COMMAND_EXPANSIONS = {
     "--version": "version",
 }
 
+# Add "a0", "a1", ..., "u0", "u1", ..., "c0", "c1", ... as aliases
+# for "connect /dev/ttyACMn" (and /dev/ttyUSBn, COMn) etc.
 for port_num in range(4):
     for prefix, port in [("a", "/dev/ttyACM"), ("u", "/dev/ttyUSB"), ("c", "COM")]:
         _BUILTIN_COMMAND_EXPANSIONS["{}{}".format(prefix, port_num)] = {
@@ -220,307 +308,33 @@ def do_command_expansion(args):
         args[0:0] = ["exec", ";".join(pre)]
 
 
-def do_connect(args):
-    dev = args.pop(0)
-    try:
-        if dev == "list":
-            # List attached devices.
-            for p in sorted(serial.tools.list_ports.comports()):
-                print(
-                    "{} {} {:04x}:{:04x} {} {}".format(
-                        p.device,
-                        p.serial_number,
-                        p.vid if isinstance(p.vid, int) else 0,
-                        p.pid if isinstance(p.pid, int) else 0,
-                        p.manufacturer,
-                        p.product,
-                    )
-                )
-            return None
-        elif dev == "auto":
-            # Auto-detect and auto-connect to the first available device.
-            for p in sorted(serial.tools.list_ports.comports()):
-                try:
-                    return pyboard.PyboardExtended(p.device, baudrate=115200)
-                except pyboard.PyboardError as er:
-                    if not er.args[0].startswith("failed to access"):
-                        raise er
-            raise pyboard.PyboardError("no device found")
-        elif dev.startswith("id:"):
-            # Search for a device with the given serial number.
-            serial_number = dev[len("id:") :]
-            dev = None
-            for p in serial.tools.list_ports.comports():
-                if p.serial_number == serial_number:
-                    return pyboard.PyboardExtended(p.device, baudrate=115200)
-            raise pyboard.PyboardError("no device with serial number {}".format(serial_number))
-        else:
-            # Connect to the given device.
-            if dev.startswith("port:"):
-                dev = dev[len("port:") :]
-            return pyboard.PyboardExtended(dev, baudrate=115200)
-    except pyboard.PyboardError as er:
-        msg = er.args[0]
-        if msg.startswith("failed to access"):
-            msg += " (it may be in use by another program)"
-        print(msg)
-        sys.exit(1)
+class State:
+    def __init__(self):
+        self.pyb = None
+        self._did_action = False
+        self._auto_soft_reset = True
 
+    def did_action(self):
+        self._did_action = True
 
-def do_disconnect(pyb):
-    try:
-        if pyb.mounted:
-            if not pyb.in_raw_repl:
-                pyb.enter_raw_repl(soft_reset=False)
-            pyb.umount_local()
-        if pyb.in_raw_repl:
-            pyb.exit_raw_repl()
-    except OSError:
-        # Ignore any OSError exceptions when shutting down, eg:
-        # - pyboard.filesystem_command will close the connecton if it had an error
-        # - umounting will fail if serial port disappeared
-        pass
-    pyb.close()
+    def run_repl_on_completion(self):
+        return not self._did_action
 
+    def ensure_connected(self):
+        if self.pyb is None:
+            do_connect(self, ["auto"])
 
-def show_progress_bar(size, total_size):
-    if not sys.stdout.isatty():
-        return
-    verbose_size = 2048
-    bar_length = 20
-    if total_size < verbose_size:
-        return
-    elif size >= total_size:
-        # Clear progress bar when copy completes
-        print("\r" + " " * (20 + bar_length) + "\r", end="")
-    else:
-        progress = size / total_size
-        bar = round(progress * bar_length)
-        print(
-            "\r ... copying {:3.0f}% [{}{}]".format(
-                progress * 100, "#" * bar, "-" * (bar_length - bar)
-            ),
-            end="",
-        )
+    def ensure_raw_repl(self, soft_reset=None):
+        self.ensure_connected()
+        soft_reset = self._auto_soft_reset if soft_reset is None else soft_reset
+        if soft_reset or not self.pyb.in_raw_repl:
+            self.pyb.enter_raw_repl(soft_reset=soft_reset)
+            self._auto_soft_reset = False
 
-
-# Get all args up to the terminator ("+").
-# The passed args will be updated with these ones removed.
-def get_fs_args(args):
-    n = 0
-    for src in args:
-        if src == "+":
-            break
-        n += 1
-    fs_args = args[:n]
-    args[:] = args[n + 1 :]
-    return fs_args
-
-
-def do_filesystem(pyb, args):
-    def _list_recursive(files, path):
-        if os.path.isdir(path):
-            for entry in os.listdir(path):
-                _list_recursive(files, "/".join((path, entry)))
-        else:
-            files.append(os.path.split(path))
-
-    fs_args = get_fs_args(args)
-
-    # Don't be verbose when using cat, so output can be redirected to something.
-    verbose = fs_args[0] != "cat"
-
-    if fs_args[0] == "cp" and fs_args[1] == "-r":
-        fs_args.pop(0)
-        fs_args.pop(0)
-        if fs_args[-1] != ":":
-            print(f"{_PROG}: 'cp -r' destination must be ':'")
-            sys.exit(1)
-        fs_args.pop()
-        src_files = []
-        for path in fs_args:
-            if path.startswith(":"):
-                print(f"{_PROG}: 'cp -r' source files must be local")
-                sys.exit(1)
-            _list_recursive(src_files, path)
-        known_dirs = {""}
-        pyb.exec_("import uos")
-        for dir, file in src_files:
-            dir_parts = dir.split("/")
-            for i in range(len(dir_parts)):
-                d = "/".join(dir_parts[: i + 1])
-                if d not in known_dirs:
-                    pyb.exec_("try:\n uos.mkdir('%s')\nexcept OSError as e:\n print(e)" % d)
-                    known_dirs.add(d)
-            pyboard.filesystem_command(
-                pyb,
-                ["cp", "/".join((dir, file)), ":" + dir + "/"],
-                progress_callback=show_progress_bar,
-                verbose=verbose,
-            )
-    else:
-        try:
-            pyboard.filesystem_command(
-                pyb, fs_args, progress_callback=show_progress_bar, verbose=verbose
-            )
-        except OSError as er:
-            print(f"{_PROG}: {er}")
-            sys.exit(1)
-
-
-def do_edit(pyb, args):
-    if not os.getenv("EDITOR"):
-        raise pyboard.PyboardError("edit: $EDITOR not set")
-    for src in get_fs_args(args):
-        src = src.lstrip(":")
-        dest_fd, dest = tempfile.mkstemp(suffix=os.path.basename(src))
-        try:
-            print("edit :%s" % (src,))
-            os.close(dest_fd)
-            pyb.fs_touch(src)
-            pyb.fs_get(src, dest, progress_callback=show_progress_bar)
-            if os.system("$EDITOR '%s'" % (dest,)) == 0:
-                pyb.fs_put(dest, src, progress_callback=show_progress_bar)
-        finally:
-            os.unlink(dest)
-
-
-def do_repl_main_loop(pyb, console_in, console_out_write, *, code_to_inject, file_to_inject):
-    while True:
-        console_in.waitchar(pyb.serial)
-        c = console_in.readchar()
-        if c:
-            if c == b"\x1d":  # ctrl-], quit
-                break
-            elif c == b"\x04":  # ctrl-D
-                # special handling needed for ctrl-D if filesystem is mounted
-                pyb.write_ctrl_d(console_out_write)
-            elif c == b"\x0a" and code_to_inject is not None:  # ctrl-j, inject code
-                pyb.serial.write(code_to_inject)
-            elif c == b"\x0b" and file_to_inject is not None:  # ctrl-k, inject script
-                console_out_write(bytes("Injecting %s\r\n" % file_to_inject, "utf8"))
-                pyb.enter_raw_repl(soft_reset=False)
-                with open(file_to_inject, "rb") as f:
-                    pyfile = f.read()
-                try:
-                    pyb.exec_raw_no_follow(pyfile)
-                except pyboard.PyboardError as er:
-                    console_out_write(b"Error:\r\n")
-                    console_out_write(er)
-                pyb.exit_raw_repl()
-            else:
-                pyb.serial.write(c)
-
-        try:
-            n = pyb.serial.inWaiting()
-        except OSError as er:
-            if er.args[0] == 5:  # IO error, device disappeared
-                print("device disconnected")
-                break
-
-        if n > 0:
-            c = pyb.serial.read(1)
-            if c is not None:
-                # pass character through to the console
-                oc = ord(c)
-                if oc in (8, 9, 10, 13, 27) or 32 <= oc <= 126:
-                    console_out_write(c)
-                else:
-                    console_out_write(b"[%02x]" % ord(c))
-
-
-def do_repl(pyb, args):
-    capture_file = None
-    code_to_inject = None
-    file_to_inject = None
-
-    while len(args):
-        if args[0] == "--capture":
-            args.pop(0)
-            capture_file = args.pop(0)
-        elif args[0] == "--inject-code":
-            args.pop(0)
-            code_to_inject = bytes(args.pop(0).replace("\\n", "\r\n"), "utf8")
-        elif args[0] == "--inject-file":
-            args.pop(0)
-            file_to_inject = args.pop(0)
-        else:
-            break
-
-    print("Connected to MicroPython at %s" % pyb.device_name)
-    print("Use Ctrl-] to exit this shell")
-    if capture_file is not None:
-        print('Capturing session to file "%s"' % capture_file)
-        capture_file = open(capture_file, "wb")
-    if code_to_inject is not None:
-        print("Use Ctrl-J to inject", code_to_inject)
-    if file_to_inject is not None:
-        print('Use Ctrl-K to inject file "%s"' % file_to_inject)
-
-    console = Console()
-    console.enter()
-
-    def console_out_write(b):
-        console.write(b)
-        if capture_file is not None:
-            capture_file.write(b)
-            capture_file.flush()
-
-    try:
-        do_repl_main_loop(
-            pyb,
-            console,
-            console_out_write,
-            code_to_inject=code_to_inject,
-            file_to_inject=file_to_inject,
-        )
-    finally:
-        console.exit()
-        if capture_file is not None:
-            capture_file.close()
-
-
-def execbuffer(pyb, buf, follow):
-    ret_val = 0
-    try:
-        pyb.exec_raw_no_follow(buf)
-        if follow:
-            ret, ret_err = pyb.follow(timeout=None, data_consumer=pyboard.stdout_write_bytes)
-            if ret_err:
-                pyboard.stdout_write_bytes(ret_err)
-                ret_val = 1
-    except pyboard.PyboardError as er:
-        print(er)
-        ret_val = 1
-    except KeyboardInterrupt:
-        ret_val = 1
-    return ret_val
-
-
-def print_help():
-    def print_commands_help(cmds, help_idx):
-        max_command_len = max(len(cmd) for cmd in cmds.keys())
-        for cmd in sorted(cmds.keys()):
-            help_message_lines = dedent(cmds[cmd][help_idx]).split("\n")
-            help_message = help_message_lines[0]
-            for line in help_message_lines[1:]:
-                help_message = "{}\n{}{}".format(help_message, " " * (max_command_len + 4), line)
-            print("  ", cmd, " " * (max_command_len - len(cmd) + 2), help_message, sep="")
-
-    print(_PROG, "-- MicroPython remote control")
-    print("See https://docs.micropython.org/en/latest/reference/mpremote.html")
-
-    print("\nList of commands:")
-    print_commands_help(_COMMANDS, 3)
-
-    print("\nList of shortcuts:")
-    print_commands_help(_command_expansions, 2)
-
-
-def print_version():
-    from . import __version__
-
-    print(f"{_PROG} {__version__}")
+    def ensure_friendly_repl(self):
+        self.ensure_connected()
+        if self.pyb.in_raw_repl:
+            self.pyb.exit_raw_repl()
 
 
 def main():
@@ -528,106 +342,31 @@ def main():
     prepare_command_expansions(config)
 
     args = sys.argv[1:]
-    pyb = None
-    auto_soft_reset = True
-    did_action = False
+    state = State()
 
     try:
         while args:
             do_command_expansion(args)
             cmd = args.pop(0)
             try:
-                need_raw_repl, is_action, num_args_min, _ = _COMMANDS[cmd]
+                num_args_min, _help, handler = _COMMANDS[cmd]
             except KeyError:
-                print(f"{_PROG}: '{cmd}' is not a command")
-                return 1
+                raise CommandError(f"'{cmd}' is not a command")
 
             if len(args) < num_args_min:
                 print(f"{_PROG}: '{cmd}' neads at least {num_args_min} argument(s)")
                 return 1
 
-            if cmd == "connect":
-                if pyb is not None:
-                    do_disconnect(pyb)
-                pyb = do_connect(args)
-                if pyb is None:
-                    did_action = True
-                continue
-            elif cmd == "help":
-                print_help()
-                sys.exit(0)
-            elif cmd == "version":
-                print_version()
-                sys.exit(0)
-            elif cmd == "resume":
-                auto_soft_reset = False
-                continue
+            handler(state, args)
 
-            # The following commands need a connection, and either a raw or friendly REPL.
 
-            if pyb is None:
-                pyb = do_connect(["auto"])
+        # If no commands were "actions" then implicitly finish with the REPL.
+        if state.run_repl_on_completion():
+            do_repl(state, args)
 
-            if need_raw_repl:
-                if not pyb.in_raw_repl:
-                    pyb.enter_raw_repl(soft_reset=auto_soft_reset)
-                    auto_soft_reset = False
-            else:
-                if pyb.in_raw_repl:
-                    pyb.exit_raw_repl()
-            if is_action:
-                did_action = True
-
-            if cmd == "disconnect":
-                do_disconnect(pyb)
-                pyb = None
-                auto_soft_reset = True
-            elif cmd == "soft-reset":
-                pyb.enter_raw_repl(soft_reset=True)
-                auto_soft_reset = False
-            elif cmd == "mount":
-                unsafe_links = False
-                if args[0] == "--unsafe-links" or args[0] == "-l":
-                    args.pop(0)
-                    unsafe_links = True
-                path = args.pop(0)
-                pyb.mount_local(path, unsafe_links=unsafe_links)
-                print(f"Local directory {path} is mounted at /remote")
-            elif cmd == "umount":
-                pyb.umount_local()
-            elif cmd in ("exec", "eval", "run"):
-                follow = True
-                if args[0] == "--no-follow":
-                    args.pop(0)
-                    follow = False
-                if cmd == "exec":
-                    buf = args.pop(0)
-                elif cmd == "eval":
-                    buf = "print(" + args.pop(0) + ")"
-                else:
-                    filename = args.pop(0)
-                    try:
-                        with open(filename, "rb") as f:
-                            buf = f.read()
-                    except OSError:
-                        print(f"{_PROG}: could not read file '{filename}'")
-                        return 1
-                ret = execbuffer(pyb, buf, follow)
-                if ret:
-                    return ret
-            elif cmd == "fs":
-                do_filesystem(pyb, args)
-            elif cmd == "edit":
-                do_edit(pyb, args)
-            elif cmd == "repl":
-                do_repl(pyb, args)
-
-        if not did_action:
-            if pyb is None:
-                pyb = do_connect(["auto"])
-            if pyb.in_raw_repl:
-                pyb.exit_raw_repl()
-            do_repl(pyb, args)
+        return 0
+    except CommandError as e:
+        print(f"{_PROG}: {e}", file=sys.stderr)
+        return 1
     finally:
-        if pyb is not None:
-            do_disconnect(pyb)
+        do_disconnect(state)

--- a/tools/mpremote/mpremote/main.py
+++ b/tools/mpremote/mpremote/main.py
@@ -36,6 +36,7 @@ from .commands import (
     do_resume,
     do_soft_reset,
 )
+from .mip import do_mip
 from .repl import do_repl
 
 _PROG = "mpremote"
@@ -162,6 +163,29 @@ def argparse_filesystem():
     return cmd_parser
 
 
+def argparse_mip():
+    cmd_parser = argparse.ArgumentParser(
+        description="install packages from micropython-lib or third-party sources"
+    )
+    _bool_flag(cmd_parser, "mpy", "m", True, "download as compiled .mpy files (default)")
+    cmd_parser.add_argument(
+        "--target", type=str, required=False, help="destination direction on the device"
+    )
+    cmd_parser.add_argument(
+        "--index",
+        type=str,
+        required=False,
+        help="package index to use (defaults to micropython-lib)",
+    )
+    cmd_parser.add_argument("command", nargs=1, help="mip command (e.g. install)")
+    cmd_parser.add_argument(
+        "packages",
+        nargs="+",
+        help="list package specifications, e.g. name, name@version, github:org/repo, github:org/repo@branch",
+    )
+    return cmd_parser
+
+
 def argparse_none(description):
     return lambda: argparse.ArgumentParser(description=description)
 
@@ -215,6 +239,10 @@ _COMMANDS = {
     "fs": (
         do_filesystem,
         argparse_filesystem,
+    ),
+    "mip": (
+        do_mip,
+        argparse_mip,
     ),
     "help": (
         do_help,

--- a/tools/mpremote/mpremote/mip.py
+++ b/tools/mpremote/mpremote/mip.py
@@ -1,0 +1,191 @@
+# Micropython package installer
+# Ported from micropython-lib/micropython/mip/mip.py.
+# MIT license; Copyright (c) 2022 Jim Mussared
+
+import urllib.error
+import urllib.request
+import json
+import tempfile
+import os
+
+from .commands import CommandError, show_progress_bar
+
+
+_PACKAGE_INDEX = "https://micropython.org/pi/v2"
+_CHUNK_SIZE = 128
+
+
+# This implements os.makedirs(os.dirname(path))
+def _ensure_path_exists(pyb, path):
+    import os
+
+    split = path.split("/")
+
+    # Handle paths starting with "/".
+    if not split[0]:
+        split.pop(0)
+        split[0] = "/" + split[0]
+
+    prefix = ""
+    for i in range(len(split) - 1):
+        prefix += split[i]
+        if not pyb.fs_exists(prefix):
+            pyb.fs_mkdir(prefix)
+        prefix += "/"
+
+
+# Copy from src (stream) to dest (function-taking-bytes)
+def _chunk(src, dest, length=None, op="downloading"):
+    buf = memoryview(bytearray(_CHUNK_SIZE))
+    total = 0
+    if length:
+        show_progress_bar(0, length, op)
+    while True:
+        n = src.readinto(buf)
+        if n == 0:
+            break
+        dest(buf if n == _CHUNK_SIZE else buf[:n])
+        total += n
+        if length:
+            show_progress_bar(total, length, op)
+
+
+def _rewrite_url(url, branch=None):
+    if not branch:
+        branch = "HEAD"
+    if url.startswith("github:"):
+        url = url[7:].split("/")
+        url = (
+            "https://raw.githubusercontent.com/"
+            + url[0]
+            + "/"
+            + url[1]
+            + "/"
+            + branch
+            + "/"
+            + "/".join(url[2:])
+        )
+    return url
+
+
+def _download_file(pyb, url, dest):
+    try:
+        with urllib.request.urlopen(url) as src:
+            fd, path = tempfile.mkstemp()
+            try:
+                print("Installing:", dest)
+                with os.fdopen(fd, "wb") as f:
+                    _chunk(src, f.write, src.length)
+                _ensure_path_exists(pyb, dest)
+                pyb.fs_put(path, dest, progress_callback=show_progress_bar)
+            finally:
+                os.unlink(path)
+    except urllib.error.HTTPError as e:
+        if e.status == 404:
+            raise CommandError(f"File not found: {url}")
+        else:
+            raise CommandError(f"Error {e.status} requesting {url}")
+    except urllib.error.URLError as e:
+        raise CommandError(f"{e.reason} requesting {url}")
+
+
+def _install_json(pyb, package_json_url, index, target, version, mpy):
+    try:
+        with urllib.request.urlopen(_rewrite_url(package_json_url, version)) as response:
+            package_json = json.load(response)
+    except urllib.error.HTTPError as e:
+        if e.status == 404:
+            raise CommandError(f"Package not found: {package_json_url}")
+        else:
+            raise CommandError(f"Error {e.status} requesting {package_json_url}")
+    except urllib.error.URLError as e:
+        raise CommandError(f"{e.reason} requesting {package_json_url}")
+    for target_path, short_hash in package_json.get("hashes", ()):
+        fs_target_path = target + "/" + target_path
+        file_url = f"{index}/file/{short_hash[:2]}/{short_hash}"
+        _download_file(pyb, file_url, fs_target_path)
+    for target_path, url in package_json.get("urls", ()):
+        fs_target_path = target + "/" + target_path
+        _download_file(pyb, _rewrite_url(url, version), fs_target_path)
+    for dep, dep_version in package_json.get("deps", ()):
+        _install_package(pyb, dep, index, target, dep_version, mpy)
+
+
+def _install_package(pyb, package, index, target, version, mpy):
+    if (
+        package.startswith("http://")
+        or package.startswith("https://")
+        or package.startswith("github:")
+    ):
+        if package.endswith(".py") or package.endswith(".mpy"):
+            print(f"Downloading {package} to {target}")
+            _download_file(
+                pyb, _rewrite_url(package, version), target + "/" + package.rsplit("/")[-1]
+            )
+            return
+        else:
+            if not package.endswith(".json"):
+                if not package.endswith("/"):
+                    package += "/"
+                package += "package.json"
+            print(f"Installing {package} to {target}")
+    else:
+        if not version:
+            version = "latest"
+        print(f"Installing {package} ({version}) from {index} to {target}")
+
+        mpy_version = "py"
+        if mpy:
+            pyb.exec("import sys")
+            mpy_version = (
+                int(pyb.eval("getattr(sys.implementation, '_mpy', 0) & 0xFF").decode()) or "py"
+            )
+
+        package = f"{index}/package/{mpy_version}/{package}/{version}.json"
+
+    _install_json(pyb, package, index, target, version, mpy)
+
+
+def do_mip(state, args):
+    state.did_action()
+
+    if args.command[0] == "install":
+        state.ensure_raw_repl()
+
+        for package in args.packages:
+            version = None
+            if "@" in package:
+                package, version = package.split("@")
+
+            print("Install", package)
+
+            if args.index is None:
+                args.index = _PACKAGE_INDEX
+
+            if args.target is None:
+                state.pyb.exec("import sys")
+                lib_paths = (
+                    state.pyb.eval("'\\n'.join(p for p in sys.path if p.endswith('/lib'))")
+                    .decode()
+                    .split("\n")
+                )
+                if lib_paths and lib_paths[0]:
+                    args.target = lib_paths[0]
+                else:
+                    raise CommandError(
+                        "Unable to find lib dir in sys.path, use --target to override"
+                    )
+
+            if args.mpy is None:
+                args.mpy = True
+
+            try:
+                _install_package(
+                    state.pyb, package, args.index.rstrip("/"), args.target, version, args.mpy
+                )
+            except CommandError:
+                print("Package may be partially installed")
+                raise
+            print("Done")
+    else:
+        raise CommandError(f"mip: '{args.command[0]}' is not a command")

--- a/tools/mpremote/mpremote/repl.py
+++ b/tools/mpremote/mpremote/repl.py
@@ -51,22 +51,9 @@ def do_repl(state, args):
     state.ensure_friendly_repl()
     state.did_action()
 
-    capture_file = None
-    code_to_inject = None
-    file_to_inject = None
-
-    while len(args):
-        if args[0] == "--capture":
-            args.pop(0)
-            capture_file = args.pop(0)
-        elif args[0] == "--inject-code":
-            args.pop(0)
-            code_to_inject = bytes(args.pop(0).replace("\\n", "\r\n"), "utf8")
-        elif args[0] == "--inject-file":
-            args.pop(0)
-            file_to_inject = args.pop(0)
-        else:
-            break
+    capture_file = args.capture
+    code_to_inject = args.inject_code
+    file_to_inject = args.inject_file
 
     print("Connected to MicroPython at %s" % state.pyb.device_name)
     print("Use Ctrl-] to exit this shell")

--- a/tools/mpremote/mpremote/repl.py
+++ b/tools/mpremote/mpremote/repl.py
@@ -1,0 +1,101 @@
+from .console import Console, ConsolePosix
+
+from . import pyboardextended as pyboard
+
+
+def do_repl_main_loop(state, console_in, console_out_write, *, code_to_inject, file_to_inject):
+    while True:
+        console_in.waitchar(state.pyb.serial)
+        c = console_in.readchar()
+        if c:
+            if c == b"\x1d":  # ctrl-], quit
+                break
+            elif c == b"\x04":  # ctrl-D
+                # special handling needed for ctrl-D if filesystem is mounted
+                state.pyb.write_ctrl_d(console_out_write)
+            elif c == b"\x0a" and code_to_inject is not None:  # ctrl-j, inject code
+                state.pyb.serial.write(code_to_inject)
+            elif c == b"\x0b" and file_to_inject is not None:  # ctrl-k, inject script
+                console_out_write(bytes("Injecting %s\r\n" % file_to_inject, "utf8"))
+                state.pyb.enter_raw_repl(soft_reset=False)
+                with open(file_to_inject, "rb") as f:
+                    pyfile = f.read()
+                try:
+                    state.pyb.exec_raw_no_follow(pyfile)
+                except pyboard.PyboardError as er:
+                    console_out_write(b"Error:\r\n")
+                    console_out_write(er)
+                state.pyb.exit_raw_repl()
+            else:
+                state.pyb.serial.write(c)
+
+        try:
+            n = state.pyb.serial.inWaiting()
+        except OSError as er:
+            if er.args[0] == 5:  # IO error, device disappeared
+                print("device disconnected")
+                break
+
+        if n > 0:
+            c = state.pyb.serial.read(1)
+            if c is not None:
+                # pass character through to the console
+                oc = ord(c)
+                if oc in (8, 9, 10, 13, 27) or 32 <= oc <= 126:
+                    console_out_write(c)
+                else:
+                    console_out_write(b"[%02x]" % ord(c))
+
+
+def do_repl(state, args):
+    state.ensure_friendly_repl()
+    state.did_action()
+
+    capture_file = None
+    code_to_inject = None
+    file_to_inject = None
+
+    while len(args):
+        if args[0] == "--capture":
+            args.pop(0)
+            capture_file = args.pop(0)
+        elif args[0] == "--inject-code":
+            args.pop(0)
+            code_to_inject = bytes(args.pop(0).replace("\\n", "\r\n"), "utf8")
+        elif args[0] == "--inject-file":
+            args.pop(0)
+            file_to_inject = args.pop(0)
+        else:
+            break
+
+    print("Connected to MicroPython at %s" % state.pyb.device_name)
+    print("Use Ctrl-] to exit this shell")
+    if capture_file is not None:
+        print('Capturing session to file "%s"' % capture_file)
+        capture_file = open(capture_file, "wb")
+    if code_to_inject is not None:
+        print("Use Ctrl-J to inject", code_to_inject)
+    if file_to_inject is not None:
+        print('Use Ctrl-K to inject file "%s"' % file_to_inject)
+
+    console = Console()
+    console.enter()
+
+    def console_out_write(b):
+        console.write(b)
+        if capture_file is not None:
+            capture_file.write(b)
+            capture_file.flush()
+
+    try:
+        do_repl_main_loop(
+            state,
+            console,
+            console_out_write,
+            code_to_inject=code_to_inject,
+            file_to_inject=file_to_inject,
+        )
+    finally:
+        console.exit()
+        if capture_file is not None:
+            capture_file.close()

--- a/tools/pyboard.py
+++ b/tools/pyboard.py
@@ -476,6 +476,13 @@ class Pyboard:
         t = str(self.eval("pyb.RTC().datetime()"), encoding="utf8")[1:-1].split(", ")
         return int(t[4]) * 3600 + int(t[5]) * 60 + int(t[6])
 
+    def fs_exists(self, src):
+        try:
+            self.exec_("import uos\nuos.stat(%s)" % (("'%s'" % src) if src else ""))
+            return True
+        except PyboardError:
+            return False
+
     def fs_ls(self, src):
         cmd = (
             "import uos\nfor f in uos.ilistdir(%s):\n"

--- a/tools/pyboard.py
+++ b/tools/pyboard.py
@@ -621,23 +621,28 @@ def filesystem_command(pyb, args, progress_callback=None, verbose=False):
                 dest2 = fname_cp_dest(src2, fname_remote(dest))
                 op(src2, dest2, progress_callback=progress_callback)
         else:
-            op = {
+            ops = {
                 "cat": pyb.fs_cat,
                 "ls": pyb.fs_ls,
                 "mkdir": pyb.fs_mkdir,
                 "rm": pyb.fs_rm,
                 "rmdir": pyb.fs_rmdir,
                 "touch": pyb.fs_touch,
-            }[cmd]
+            }
+            if cmd not in ops:
+                raise PyboardError("'{}' is not a filesystem command".format(cmd))
             if cmd == "ls" and not args:
                 args = [""]
             for src in args:
                 src = fname_remote(src)
                 if verbose:
                     print("%s :%s" % (cmd, src))
-                op(src)
+                ops[cmd](src)
     except PyboardError as er:
-        print(str(er.args[2], "ascii"))
+        if len(er.args) > 1:
+            print(str(er.args[2], "ascii"))
+        else:
+            print(er)
         pyb.exit_raw_repl()
         pyb.close()
         sys.exit(1)


### PR DESCRIPTION
This supports the same package sources as the new `mip` tool. (https://github.com/micropython/micropython-lib/pull/542)
 - micropython-lib (by name)
 - http(s) & github packages with json description
 - directly downloading a .py/.mpy file

The version is specified with an optional `@version` on the end of the package name.

Also adds support for optional --args to multi-arg commands like "edit" and the filesystem commands (and now "install"). This allows `--mpy`/`--no-mpy` and `--target` to be specified to the `install` command.

_This work was funded through GitHub Sponsors._