### PR TITLE
esp32/machine_hw_spi: Use auto DMA channel on S2, S3, C3 chips.

### DIFF
--- a/ports/esp32/machine_hw_spi.c
+++ b/ports/esp32/machine_hw_spi.c
@@ -267,21 +267,15 @@ STATIC void machine_hw_spi_init_internal(
 
     // Select DMA channel based on the hardware SPI host
     int dma_chan = 0;
+    #if CONFIG_IDF_TARGET_ESP32S2 || CONFIG_IDF_TARGET_ESP32S3 || CONFIG_IDF_TARGET_ESP32C3
+    dma_chan = SPI_DMA_CH_AUTO;
+    #else
     if (self->host == HSPI_HOST) {
-        #if CONFIG_IDF_TARGET_ESP32S2 || CONFIG_IDF_TARGET_ESP32S3 || CONFIG_IDF_TARGET_ESP32C3
-        dma_chan = 3;
-        #else
         dma_chan = 1;
-        #endif
-    #ifdef FSPI_HOST
-    } else if (self->host == FSPI_HOST) {
-        dma_chan = 1;
-    #endif
-    #ifdef VSPI_HOST
-    } else if (self->host == VSPI_HOST) {
+    } else {
         dma_chan = 2;
-    #endif
     }
+    #endif
 
     ret = spi_bus_initialize(self->host, &buscfg, dma_chan);
     switch (ret) {


### PR DESCRIPTION
Auto DMA channel is supported in IDF v4.4, and is required to be used on S3 chips, so use this simpler configuration option where possible.

Fixes issue #8634.

