### PR TITLE
tools/mpremote: Fixes for argument handling.

### DIFF
--- a/tools/mpremote/mpremote/commands.py
+++ b/tools/mpremote/mpremote/commands.py
@@ -204,7 +204,7 @@ def do_exec(state, args):
 
 def do_eval(state, args):
     buf = "print(" + args.expr[0] + ")"
-    _do_execbuffer(state, buf, args.follow)
+    _do_execbuffer(state, buf, True)
 
 
 def do_run(state, args):

--- a/tools/mpremote/mpremote/main.py
+++ b/tools/mpremote/mpremote/main.py
@@ -119,30 +119,45 @@ def argparse_mount():
 
 def argparse_repl():
     cmd_parser = argparse.ArgumentParser(description="connect to given device")
-    cmd_parser.add_argument("--capture", type=str, required=False, help="TODO")
-    cmd_parser.add_argument("--inject-code", type=str, required=False, help="TODO")
-    cmd_parser.add_argument("--inject-file", type=str, required=False, help="TODO")
+    cmd_parser.add_argument(
+        "--capture",
+        type=str,
+        required=False,
+        help="saves a copy of the REPL session to the specified path",
+    )
+    cmd_parser.add_argument(
+        "--inject-code", type=str, required=False, help="code to be run when Ctrl-J is pressed"
+    )
+    cmd_parser.add_argument(
+        "--inject-file",
+        type=str,
+        required=False,
+        help="path to file to be run when Ctrl-K is pressed",
+    )
     return cmd_parser
 
 
 def argparse_eval():
     cmd_parser = argparse.ArgumentParser(description="evaluate and print the string")
-    _bool_flag(cmd_parser, "follow", "f", True, "TODO")
     cmd_parser.add_argument("expr", nargs=1, help="expression to execute")
     return cmd_parser
 
 
 def argparse_exec():
     cmd_parser = argparse.ArgumentParser(description="execute the string")
-    _bool_flag(cmd_parser, "follow", "f", True, "TODO")
+    _bool_flag(
+        cmd_parser, "follow", "f", True, "follow output until the expression completes (default)"
+    )
     cmd_parser.add_argument("expr", nargs=1, help="expression to execute")
     return cmd_parser
 
 
 def argparse_run():
     cmd_parser = argparse.ArgumentParser(description="run the given local script")
-    _bool_flag(cmd_parser, "follow", "f", False, "TODO")
-    cmd_parser.add_argument("path", nargs=1, help="expression to execute")
+    _bool_flag(
+        cmd_parser, "follow", "f", True, "follow output until the script completes (default)"
+    )
+    cmd_parser.add_argument("path", nargs=1, help="path to script to execute")
     return cmd_parser
 
 

--- a/tools/mpremote/mpremote/repl.py
+++ b/tools/mpremote/mpremote/repl.py
@@ -61,6 +61,7 @@ def do_repl(state, args):
         print('Capturing session to file "%s"' % capture_file)
         capture_file = open(capture_file, "wb")
     if code_to_inject is not None:
+        code_to_inject = bytes(code_to_inject.replace("\\n", "\r\n"), "utf8")
         print("Use Ctrl-J to inject", code_to_inject)
     if file_to_inject is not None:
         print('Use Ctrl-K to inject file "%s"' % file_to_inject)


### PR DESCRIPTION
- Make --follow the default for "run". (Accidentally changed in 68d094358)
- Add help strings for "repl": --capture --inject-file --inject-code
- Update help strings for "run".
- Fix encoding for --inject-code (Accidentally broken in 68d094358)
- Remove ability to --no-follow for "eval". It was there previously because it shared the same code path with "exec" and "run", but makes no sense for "eval", so might as well remove.

This work was funded through GitHub Sponsors.