### PR TITLE
extmod/uasyncio/core.py: Detect sleep overflow.

### DIFF
--- a/extmod/uasyncio/core.py
+++ b/extmod/uasyncio/core.py
@@ -53,7 +53,10 @@ class SingletonGenerator:
 # Use a SingletonGenerator to do it without allocating on the heap
 def sleep_ms(t, sgen=SingletonGenerator()):
     assert sgen.state is None
-    sgen.state = ticks_add(ticks(), max(0, t))
+    t = max(0, t)
+    if ticks_diff(t, 0) != t:
+        raise ValueError("sleep too long")
+    sgen.state = ticks_add(ticks(), t)
     return sgen
 
 


### PR DESCRIPTION
Use `ticks_diff(t, 0) != t` to detect that `t` is greater than `MICROPY_PY_UTIME_TICKS_PERIOD / 2` which is the largest ticks difference that can be represented.

The current behaviour is that it either ends up sleeping for zero milliseconds (e.g. `await asyncio.sleep(7*86400)` because the diff ends up being negative, or worse, for a "random" amount of time if the diff ends up being positive. I think raising ValueError is preferable in both cases.

An alternative solution would be to make `sleep_ms` (and therefore `sleep` also) into coroutines that could then break up the duration into smaller chunks, but then this would make `await sleep(...)` allocate.

_This work was funded through GitHub Sponsors._
