### PR TITLE
py/objstr: Fail str.format with invalid precision.

### DIFF
--- a/py/objstr.c
+++ b/py/objstr.c
@@ -1206,11 +1206,15 @@ STATIC vstr_t mp_obj_str_format_helper(const char *str, const char *top, int *ar
             if (*s == '.') {
                 s++;
                 s = str_to_int(s, stop, &precision);
+                if (precision == -1) {
+                    goto invalid_format_specifier;
+                }
             }
             if (istype(*s)) {
                 type = *s++;
             }
             if (*s) {
+            invalid_format_specifier:
                 #if MICROPY_ERROR_REPORTING <= MICROPY_ERROR_REPORTING_TERSE
                 terse_str_format_value_error();
                 #else

--- a/tests/basics/string_format_error.py
+++ b/tests/basics/string_format_error.py
@@ -88,3 +88,19 @@ try:
     '{:X}'.format('zz')
 except ValueError:
     print('ValueError')
+
+# missing precision
+try:
+    '{:.}'.format(2)
+except ValueError:
+    print('ValueError')
+
+try:
+    '{:3.}'.format(2)
+except ValueError:
+    print('ValueError')
+
+try:
+    '{:3.f}'.format(2)
+except ValueError:
+    print('ValueError')


### PR DESCRIPTION
Fixes #9525 (@Neradoc)

`"{:.}".format(x)` (or `f"{x:.}"`) now fails, matching CPython. Add tests.

This is +8 bytes on PYBV11.

_This work was funded through GitHub Sponsors._