### PR TITLE
py/modsys: Add sys.executable.

### DIFF
--- a/ports/unix/main.c
+++ b/ports/unix/main.c
@@ -43,6 +43,7 @@
 #include "py/builtin.h"
 #include "py/repl.h"
 #include "py/gc.h"
+#include "py/objstr.h"
 #include "py/stackctrl.h"
 #include "py/mphal.h"
 #include "py/mpthread.h"
@@ -435,6 +436,16 @@ STATIC void set_sys_argv(char *argv[], int argc, int start_arg) {
     }
 }
 
+#if MICROPY_PY_SYS_EXECUTABLE
+STATIC char executable_path[MICROPY_ALLOC_PATH_MAX];
+STATIC void sys_set_excecutable(char *argv0) {
+    extern mp_obj_str_t mp_sys_executable_obj;
+    if (realpath(argv0, executable_path)) {
+        mp_obj_str_set_data(&mp_sys_executable_obj, (byte *)executable_path, strlen(executable_path));
+    }
+}
+#endif
+
 #ifdef _WIN32
 #define PATHLIST_SEP_CHAR ';'
 #else
@@ -597,6 +608,10 @@ MP_NOINLINE int main_(int argc, char **argv) {
     printf("    cur   %d\n", m_get_current_bytes_allocated());
     printf("    peak  %d\n", m_get_peak_bytes_allocated());
     */
+
+    #if MICROPY_PY_SYS_EXECUTABLE
+    sys_set_excecutable(argv[0]);
+    #endif
 
     const int NOTHING_EXECUTED = -2;
     int ret = NOTHING_EXECUTED;

--- a/ports/unix/mpconfigport.h
+++ b/ports/unix/mpconfigport.h
@@ -154,6 +154,9 @@ typedef long mp_off_t;
 // Don't default sys.argv because we do that in main.
 #define MICROPY_PY_SYS_PATH_ARGV_DEFAULTS (0)
 
+// Enable sys.executable.
+#define MICROPY_PY_SYS_EXECUTABLE (1)
+
 #define MICROPY_PY_USOCKET_LISTEN_BACKLOG_DEFAULT (SOMAXCONN < 128 ? SOMAXCONN : 128)
 
 // Bare-metal ports don't have stderr. Printing debug to stderr may give tests

--- a/py/modsys.c
+++ b/py/modsys.c
@@ -115,6 +115,12 @@ STATIC const mp_rom_obj_tuple_t mp_sys_implementation_obj = {
 STATIC const MP_DEFINE_STR_OBJ(mp_sys_platform_obj, MICROPY_PY_SYS_PLATFORM);
 #endif
 
+#ifdef MICROPY_PY_SYS_EXECUTABLE
+// executable - the path to the micropython binary
+// This object is non-const and is populated at startup in main()
+MP_DEFINE_STR_OBJ(mp_sys_executable_obj, "");
+#endif
+
 // exit([retval]): raise SystemExit, with optional argument given to the exception
 STATIC mp_obj_t mp_sys_exit(size_t n_args, const mp_obj_t *args) {
     if (n_args == 0) {
@@ -260,6 +266,10 @@ STATIC const mp_rom_map_elem_t mp_module_sys_globals_table[] = {
     #endif
     #if MICROPY_PY_SYS_GETSIZEOF
     { MP_ROM_QSTR(MP_QSTR_getsizeof), MP_ROM_PTR(&mp_sys_getsizeof_obj) },
+    #endif
+
+    #if MICROPY_PY_SYS_EXECUTABLE
+    { MP_ROM_QSTR(MP_QSTR_executable), MP_ROM_PTR(&mp_sys_executable_obj) },
     #endif
 
     /*

--- a/py/mpconfig.h
+++ b/py/mpconfig.h
@@ -1372,6 +1372,13 @@ typedef double mp_float_t;
 #define MICROPY_PY_SYS_EXC_INFO (0)
 #endif
 
+// Whether to provide "sys.executable", which is the absolute path to the
+// micropython binary
+// Intended for use on the "OS" ports (e.g. Unix)
+#ifndef MICROPY_PY_SYS_EXECUTABLE
+#define MICROPY_PY_SYS_EXECUTABLE (0)
+#endif
+
 // Whether to provide "sys.exit" function
 #ifndef MICROPY_PY_SYS_EXIT
 #define MICROPY_PY_SYS_EXIT (1)

--- a/py/objstr.c
+++ b/py/objstr.c
@@ -2045,6 +2045,12 @@ mp_int_t mp_obj_str_get_buffer(mp_obj_t self_in, mp_buffer_info_t *bufinfo, mp_u
     }
 }
 
+void mp_obj_str_set_data(mp_obj_str_t *str, const byte *data, size_t len) {
+    str->data = data;
+    str->len = len;
+    str->hash = qstr_compute_hash(data, len);
+}
+
 // This locals table is used for the following types: str, bytes, bytearray, array.array.
 // Each type takes a different section (start to end offset) of this table.
 STATIC const mp_rom_map_elem_t array_bytearray_str_bytes_locals_table[] = {

--- a/py/objstr.h
+++ b/py/objstr.h
@@ -94,6 +94,8 @@ mp_obj_t mp_obj_new_str_of_type(const mp_obj_type_t *type, const byte *data, siz
 mp_obj_t mp_obj_str_binary_op(mp_binary_op_t op, mp_obj_t lhs_in, mp_obj_t rhs_in);
 mp_int_t mp_obj_str_get_buffer(mp_obj_t self_in, mp_buffer_info_t *bufinfo, mp_uint_t flags);
 
+void mp_obj_str_set_data(mp_obj_str_t *str, const byte *data, size_t len);
+
 const byte *str_index_to_ptr(const mp_obj_type_t *type, const byte *self_data, size_t self_len,
     mp_obj_t index, bool is_slice);
 const byte *find_subbytes(const byte *haystack, size_t hlen, const byte *needle, size_t nlen, int direction);

--- a/tests/unix/extra_coverage.py.exp
+++ b/tests/unix/extra_coverage.py.exp
@@ -62,10 +62,11 @@ ime
 utime           utimeq
 
 argv            atexit          byteorder       exc_info
-exit            getsizeof       implementation  maxsize
-modules         path            platform        print_exception
-ps1             ps2             stderr          stdin
-stdout          tracebacklimit  version         version_info
+executable      exit            getsizeof       implementation
+maxsize         modules         path            platform
+print_exception                 ps1             ps2
+stderr          stdin           stdout          tracebacklimit
+version         version_info
 ementation
 # attrtuple
 (start=1, stop=2, step=3)


### PR DESCRIPTION
Only supported on Unix, matches CPython. Gives the absolute path to the micropython binary.

Intended to support https://github.com/micropython/micropython-lib/pull/544

_This work was funded through GitHub Sponsors._