### PR TITLE
rp2/fatfs_port.c: Fix the modification date of files.

### DIFF
--- a/ports/rp2/fatfs_port.c
+++ b/ports/rp2/fatfs_port.c
@@ -30,5 +30,5 @@
 MP_WEAK DWORD get_fattime(void) {
     datetime_t t;
     rtc_get_datetime(&t);
-    return ((2000 + t.year - 1980) << 25) | ((t.month) << 21) | ((t.day) << 16) | ((t.hour) << 11) | ((t.min) << 5) | (t.sec / 2);
+    return ((t.year - 1980) << 25) | ((t.month) << 21) | ((t.day) << 16) | ((t.hour) << 11) | ((t.min) << 5) | (t.sec / 2);
 }


### PR DESCRIPTION
It was off by 2000 % 128 == 80 years..
Addresses issue #9535.