### PR TITLE
py/misc: Remove use of bitfield from vstr_t.

### DIFF
--- a/py/misc.h
+++ b/py/misc.h
@@ -179,7 +179,7 @@ typedef struct _vstr_t {
     size_t alloc;
     size_t len;
     char *buf;
-    bool fixed_buf : 1;
+    bool fixed_buf;
 } vstr_t;
 
 // convenience macro to declare a vstr with a fixed size buffer on the stack


### PR DESCRIPTION
Since there is only one flag, we don't need to use a bitfield in vstr_t. Compilers (at least Arm GCC) emit extra instructions to access a bitfield, so this should reduce the binary size a small amount (and possibly increase performance a very small amount).