### PR TITLE
mpremote: Allow user configuration on Windows

### DIFF
--- a/docs/reference/mpremote.rst
+++ b/docs/reference/mpremote.rst
@@ -108,7 +108,7 @@ The full list of supported commands are:
   **Note:** Instead of using the ``connect`` command, there are several
   :ref:`pre-defined shortcuts <mpremote_shortcuts>` for common device paths. For
   example the ``a0`` shortcut command is equivalent to
-  ``connect /dev/ttyACM0`` (Linux), or ``c0`` for ``COM0`` (Windows).
+  ``connect /dev/ttyACM0`` (Linux), or ``c1`` for ``COM1`` (Windows).
 
   **Note:** The ``auto`` option will only detect USB serial ports, i.e. a serial
   port that has an associated USB VID/PID (i.e. CDC/ACM or FTDI-style
@@ -487,9 +487,16 @@ Shortcuts can be defined using the macro system.  Built-in shortcuts are:
 
 - ``cat``, ``edit``, ``ls``, ``cp``, ``rm``, ``mkdir``, ``rmdir``, ``touch``: Aliases for ``fs <sub-command>``
 
-Additional shortcuts can be defined by in user-configuration files, which is
-located at ``.config/mpremote/config.py``. This file should define a
-dictionary named ``commands``. The keys of this dictionary are the shortcuts
+Additional shortcuts can be defined in the user configuration file ``mpremote/config.py``,
+located in the User Configuration Directory.
+The correct location for each OS is determined using the ``platformdirs`` module.
+
+This is typically:
+- ``$XDG_CONFIG_HOME/mpremote/config.py``
+- ``$HOME/.config/mpremote/config.py``
+- ``$env:LOCALAPPDATA/mpremote/config.py``
+
+The ``config.py``` file should define a dictionary named ``commands``. The keys of this dictionary are the shortcuts
 and the values are either a string or a list-of-strings:
 
 .. code-block:: python3

--- a/tools/mpremote/mpremote/main.py
+++ b/tools/mpremote/mpremote/main.py
@@ -22,6 +22,8 @@ import os, sys, time
 from collections.abc import Mapping
 from textwrap import dedent
 
+import platformdirs
+
 from .commands import (
     CommandError,
     do_connect,
@@ -439,13 +441,7 @@ def load_user_config():
     config.commands = {}
 
     # Get config file name.
-    path = os.getenv("XDG_CONFIG_HOME")
-    if path is None:
-        path = os.getenv("HOME")
-        if path is None:
-            return config
-        path = os.path.join(path, ".config")
-    path = os.path.join(path, _PROG)
+    path = platformdirs.user_config_dir(appname=_PROG, appauthor=False)
     config_file = os.path.join(path, "config.py")
 
     # Check if config file exists.
@@ -457,6 +453,9 @@ def load_user_config():
         config_data = f.read()
     prev_cwd = os.getcwd()
     os.chdir(path)
+    # Pass in the config path so that the config file can use it.
+    config.__dict__["config_path"] = path
+    config.__dict__["__file__"] = config_file
     exec(config_data, config.__dict__)
     os.chdir(prev_cwd)
 

--- a/tools/mpremote/requirements.txt
+++ b/tools/mpremote/requirements.txt
@@ -1,2 +1,3 @@
 pyserial >= 3.3
 importlib_metadata >= 1.4; python_version < "3.8"
+platformdirs >= 4.3.7


### PR DESCRIPTION
Simplifies the use of mpremote's user configuration on Windows, by also considering the Windows standard environment variable `APPDATA`, which is the OS default for storing any user/application related file-based configuration. ( changed from USERPROFILE) 

This avoids the need for a Windows user to set the `HOME` or `XDG_CONFIG_HOME` environment variable, both of which are non-standard on Windows.

Per Microsoft documentation:

> The recommended location for a Windows application to store user settings is in the %APPDATA% folder. This folder is a hidden folder in the user's profile directory that is designed to store application-specific data, including user settings.

However Windows users also are used to %USERPROFILE%, which was established as a location in a previous century.
in order to adhere to both recommended usage ( $XDG_CONFIG_HOME and %APPDATA%) as well as common user practices ($HOME and %USERPROFILE%) , all variables used in a scan for a valid configuration file, and this first config file is used.

Simply stated : newer standards are preferred over the older standards, and Linux environment variables take precidence.

| # | ENV_VAR         | env_value                    | Path_checked                              | platform.system()              |  
| - | --------------- | ---------------------------- | ----------------------------------------- | ------------------------------ | 
| 1 | XDG_CONFIG_HOME | $HOME/**.config**            | /home/foo/**.config**/mpremote                | Linux, Windows(MSYS32), Darwin | 
| 2 | HOME            | /home/boo                    | /home/foo/**.config**/mpremote                | Linux, Windows(MSYS32), Darwin | 
| 3 | APPDATA         | C:\Users\foo\AppData\Roaming | C:\Users\foo\AppData\Roaming\mpremote | Windows                        | 
| 4 | USERPROFILE     | C:\Users\foo                 | C:\Users\foo\mpremote                     | Windows                        | 

