### PR TITLE
ports/stm32: Leave DFU mode after download.

### DIFF
--- a/ports/stm32/Makefile
+++ b/ports/stm32/Makefile
@@ -546,7 +546,7 @@ define RUN_DFU
 	$(ECHO) "Writing $(1) to the board"
 	$(if $(filter $(USE_PYDFU),1),\
 	$(Q)$(PYTHON) $(PYDFU) --vid $(BOOTLOADER_DFU_USB_VID) --pid $(BOOTLOADER_DFU_USB_PID) -u $(1),
-	$(Q)$(DFU_UTIL) -a 0 -d $(BOOTLOADER_DFU_USB_VID):$(BOOTLOADER_DFU_USB_PID) -D $(1))
+	$(Q)$(DFU_UTIL) -a 0 -d $(BOOTLOADER_DFU_USB_VID):$(BOOTLOADER_DFU_USB_PID) -D $(1) -s :leave)
 endef
 
 define RUN_STLINK


### PR DESCRIPTION
* Not all DFU bootloaders exit after download, this modifier is required for some boards to reset, otherwise they sit idle in DFU mode.
* Doesn't seem to have any effect on `PYBD_SF2`.