### PR TITLE
ports/cdc timeout: Add a timeout to mp_hal_stdout_tx_strn().

### DIFF
--- a/ports/esp32/usb.c
+++ b/ports/esp32/usb.c
@@ -88,7 +88,8 @@ void usb_init(void) {
 
 void usb_tx_strn(const char *str, size_t len) {
     // Write out the data to the CDC interface, but only while the USB host is connected.
-    while (usb_cdc_connected && len) {
+    uint64_t timeout = esp_timer_get_time() + (uint64_t)(MICROPY_HW_USB_CDC_TX_TIMEOUT * 1000);
+    while (usb_cdc_connected && len && esp_timer_get_time() < timeout) {
         size_t l = tinyusb_cdcacm_write_queue(CDC_ITF, (uint8_t *)str, len);
         str += l;
         len -= l;

--- a/ports/esp32/usb.h
+++ b/ports/esp32/usb.h
@@ -26,6 +26,7 @@
 #ifndef MICROPY_INCLUDED_ESP32_USB_H
 #define MICROPY_INCLUDED_ESP32_USB_H
 
+#define MICROPY_HW_USB_CDC_TX_TIMEOUT  (500)
 void usb_init(void);
 void usb_tx_strn(const char *str, size_t len);
 

--- a/ports/mimxrt/mphalport.h
+++ b/ports/mimxrt/mphalport.h
@@ -36,6 +36,7 @@
 #define MICROPY_HAL_VERSION             "2.8.0"
 
 #define MP_HAL_PIN_FMT                  "%q"
+#define MICROPY_HW_USB_CDC_TX_TIMEOUT   (500)
 extern ringbuf_t stdin_ringbuf;
 
 // Define an alias fo systick_ms, because the shared softtimer.c uses

--- a/ports/rp2/mphalport.c
+++ b/ports/rp2/mphalport.c
@@ -139,8 +139,13 @@ void mp_hal_stdout_tx_strn(const char *str, mp_uint_t len) {
             if (n > CFG_TUD_CDC_EP_BUFSIZE) {
                 n = CFG_TUD_CDC_EP_BUFSIZE;
             }
-            while (n > tud_cdc_write_available()) {
+            int timeout = 0;
+            // Wait with a max of USC_CDC_TIMEOUT ms
+            while (n > tud_cdc_write_available() && timeout++ < MICROPY_HW_USB_CDC_TX_TIMEOUT) {
                 MICROPY_EVENT_POLL_HOOK
+            }
+            if (timeout >= MICROPY_HW_USB_CDC_TX_TIMEOUT) {
+                break;
             }
             uint32_t n2 = tud_cdc_write(str + i, n);
             tud_cdc_write_flush();

--- a/ports/rp2/mphalport.h
+++ b/ports/rp2/mphalport.h
@@ -33,6 +33,7 @@
 #include "RP2040.h" // cmsis, for __WFI
 
 #define SYSTICK_MAX (0xffffff)
+#define MICROPY_HW_USB_CDC_TX_TIMEOUT (500)
 
 extern int mp_interrupt_char;
 extern ringbuf_t stdin_ringbuf;

--- a/ports/samd/mphalport.c
+++ b/ports/samd/mphalport.c
@@ -194,8 +194,13 @@ void mp_hal_stdout_tx_strn(const char *str, mp_uint_t len) {
             if (n > CFG_TUD_CDC_EP_BUFSIZE) {
                 n = CFG_TUD_CDC_EP_BUFSIZE;
             }
-            while (n > tud_cdc_write_available()) {
+            int timeout = 0;
+            // Wait with a max of USC_CDC_TIMEOUT ms
+            while (n > tud_cdc_write_available() && timeout++ < MICROPY_HW_USB_CDC_TX_TIMEOUT) {
                 MICROPY_EVENT_POLL_HOOK
+            }
+            if (timeout >= MICROPY_HW_USB_CDC_TX_TIMEOUT) {
+                break;
             }
             uint32_t n2 = tud_cdc_write(str + i, n);
             tud_cdc_write_flush();

--- a/ports/samd/mphalport.h
+++ b/ports/samd/mphalport.h
@@ -44,7 +44,7 @@ void mp_hal_set_interrupt_char(int c);
 // Define an alias fo systick_ms, because the shared softtimer.c uses
 // the symbol uwTick for the systick ms counter.
 #define uwTick systick_ms
-
+#define MICROPY_HW_USB_CDC_TX_TIMEOUT (500)
 #define mp_hal_delay_us_fast  mp_hal_delay_us
 
 static inline uint64_t mp_hal_ticks_ms_64(void) {


### PR DESCRIPTION
Addresses Issue #9634.
If USB CDC is connected and the board sends data, but the PC does not receive data, the devices locked up. This PR adds a timeout of 10ms to writing (just to grab a number), after which the to-be-sent data is discarded. Tested with:
- rp2040: rp2 Pico
- mimxrt: Teensy 4.1
- samd: Adafruit ItsyBitsy M4 (SAMD51)
- esp32: UM Feather S2

The 500ms timeout of the STM32 port is unchanged.