### PR TITLE
moduos: Add os.utime() support to vfs layer and LFS2, FAT and posix filesystems.

### DIFF
--- a/docs/library/os.rst
+++ b/docs/library/os.rst
@@ -84,6 +84,14 @@ Filesystem access
 
    Get the status of a file or directory.
 
+.. function:: utime(path, times=None)
+
+   Set the access and modification times of a file or directory, where ``times``
+   is:
+
+        * ``(atime, mtime)``: a tuple of timestamps as integers; or
+        * ``None``: atime and mtime will be set to the current system time.
+
 .. function:: statvfs(path)
 
    Get the status of a fileystem.

--- a/extmod/moduos.c
+++ b/extmod/moduos.c
@@ -137,6 +137,7 @@ STATIC const mp_rom_map_elem_t os_module_globals_table[] = {
     { MP_ROM_QSTR(MP_QSTR_stat), MP_ROM_PTR(&mp_vfs_stat_obj) },
     { MP_ROM_QSTR(MP_QSTR_statvfs), MP_ROM_PTR(&mp_vfs_statvfs_obj) },
     { MP_ROM_QSTR(MP_QSTR_unlink), MP_ROM_PTR(&mp_vfs_remove_obj) }, // unlink aliases to remove
+    { MP_ROM_QSTR(MP_QSTR_utime), MP_ROM_PTR(&mp_vfs_utime_obj) },
     #endif
 
     // The following are MicroPython extensions.

--- a/extmod/vfs.h
+++ b/extmod/vfs.h
@@ -101,6 +101,7 @@ mp_obj_t mp_vfs_rename(mp_obj_t old_path_in, mp_obj_t new_path_in);
 mp_obj_t mp_vfs_rmdir(mp_obj_t path_in);
 mp_obj_t mp_vfs_stat(mp_obj_t path_in);
 mp_obj_t mp_vfs_statvfs(mp_obj_t path_in);
+mp_obj_t mp_vfs_utime(size_t n_args, const mp_obj_t *args);
 
 int mp_vfs_mount_and_chdir_protected(mp_obj_t bdev, mp_obj_t mount_point);
 
@@ -117,5 +118,6 @@ MP_DECLARE_CONST_FUN_OBJ_2(mp_vfs_rename_obj);
 MP_DECLARE_CONST_FUN_OBJ_1(mp_vfs_rmdir_obj);
 MP_DECLARE_CONST_FUN_OBJ_1(mp_vfs_stat_obj);
 MP_DECLARE_CONST_FUN_OBJ_1(mp_vfs_statvfs_obj);
+MP_DECLARE_CONST_FUN_OBJ_VAR_BETWEEN(mp_vfs_utime_obj);
 
 #endif // MICROPY_INCLUDED_EXTMOD_VFS_H

--- a/ports/webassembly/mphalport.c
+++ b/ports/webassembly/mphalport.c
@@ -55,6 +55,11 @@ mp_uint_t mp_hal_ticks_cpu(void) {
     return 0;
 }
 
+uint64_t mp_hal_time_ns(void) {
+    // Not currently implemented.
+    return 0;
+}
+
 extern int mp_interrupt_char;
 
 int mp_hal_get_interrupt_char(void) {

--- a/tests/extmod/vfs_basic.py
+++ b/tests/extmod/vfs_basic.py
@@ -49,6 +49,9 @@ class Filesystem:
         print(self.id, "stat", path)
         return (self.id,)
 
+    def utime(self, path, times):
+        print(self.id, "utime", path, times)
+
     def statvfs(self, path):
         print(self.id, "statvfs", path)
         return (self.id,)
@@ -134,6 +137,7 @@ uos.remove("test_file")
 uos.rename("test_file", "test_file2")
 uos.rmdir("test_dir")
 print(uos.stat("test_file"))
+uos.utime("test_file", (365 * 24 * 60 * 60, 2 * 365 * 24 * 60 * 60))
 print(uos.statvfs("/test_mnt"))
 open("test_file")
 open("test_file", "wb")

--- a/tests/extmod/vfs_basic.py.exp
+++ b/tests/extmod/vfs_basic.py.exp
@@ -41,6 +41,7 @@ OSError
 1 rmdir test_dir
 1 stat test_file
 (1,)
+1 utime test_file (31536000, 63072000)
 1 statvfs /
 (1,)
 1 open test_file r

--- a/tests/extmod/vfs_fat_utime.py
+++ b/tests/extmod/vfs_fat_utime.py
@@ -1,0 +1,79 @@
+# Test for VfsFat using a RAM device, mtime feature
+
+try:
+    import utime, uos
+
+    utime.time
+    utime.sleep
+    uos.VfsFat
+except (ImportError, AttributeError):
+    print("SKIP")
+    raise SystemExit
+
+
+class RAMBlockDevice:
+    ERASE_BLOCK_SIZE = 512
+
+    def __init__(self, blocks):
+        self.data = bytearray(blocks * self.ERASE_BLOCK_SIZE)
+
+    def readblocks(self, block, buf):
+        addr = block * self.ERASE_BLOCK_SIZE
+        for i in range(len(buf)):
+            buf[i] = self.data[addr + i]
+
+    def writeblocks(self, block, buf):
+        addr = block * self.ERASE_BLOCK_SIZE
+        for i in range(len(buf)):
+            self.data[addr + i] = buf[i]
+
+    def ioctl(self, op, arg):
+        if op == 4:  # block count
+            return len(self.data) // self.ERASE_BLOCK_SIZE
+        if op == 5:  # block size
+            return self.ERASE_BLOCK_SIZE
+
+
+def test(bdev, vfs_class):
+    print("test", vfs_class)
+
+    # Initial format of block device.
+    vfs_class.mkfs(bdev)
+
+    # construction
+    vfs = vfs_class(bdev)
+
+    # Create an empty file, should have a timestamp.
+    vfs.open("test1", "wt").close()
+
+    # Create an empty file, should have a timestamp.
+    vfs.open("test1", "wt").close()
+
+    # Stat the file before and after setting mtime with os.utime().
+    stat1 = vfs.stat("test1")
+    tm = utime.mktime((2010, 1, 1, 11, 49, 1, 0, 0))
+    vfs.utime("test1", (tm, tm))
+    stat2 = vfs.stat("test1")
+    # Note FAT time granularity only valid to two seconds
+    print(stat1[8] != 0, stat2[8] != stat1[8], abs(stat2[8] - tm) < 2)
+
+    # Check for invalid arguments: should all raise OSError.
+    try:
+        vfs.utime("test1", None)
+    except OSError:
+        print("OSError")
+    try:
+        vfs.utime("test1", (None, None))
+    except TypeError:
+        print("TypeError")
+    try:
+        vfs.utime("test1", (None, "Invalid"))
+    except TypeError:
+        print("TypeError")
+
+    # Unmount.
+    vfs.umount()
+
+
+bdev = RAMBlockDevice(50)
+test(bdev, uos.VfsFat)

--- a/tests/extmod/vfs_fat_utime.py.exp
+++ b/tests/extmod/vfs_fat_utime.py.exp
@@ -1,0 +1,5 @@
+test <class 'VfsFat'>
+True True True
+OSError
+TypeError
+TypeError

--- a/tests/extmod/vfs_lfs_utime.py
+++ b/tests/extmod/vfs_lfs_utime.py
@@ -1,0 +1,92 @@
+# Test for VfsLfs using a RAM device, mtime feature
+
+try:
+    import utime, uos
+
+    utime.time
+    utime.sleep
+    uos.VfsLfs2
+except (ImportError, AttributeError):
+    print("SKIP")
+    raise SystemExit
+
+
+class RAMBlockDevice:
+    ERASE_BLOCK_SIZE = 1024
+
+    def __init__(self, blocks):
+        self.data = bytearray(blocks * self.ERASE_BLOCK_SIZE)
+
+    def readblocks(self, block, buf, off):
+        addr = block * self.ERASE_BLOCK_SIZE + off
+        for i in range(len(buf)):
+            buf[i] = self.data[addr + i]
+
+    def writeblocks(self, block, buf, off):
+        addr = block * self.ERASE_BLOCK_SIZE + off
+        for i in range(len(buf)):
+            self.data[addr + i] = buf[i]
+
+    def ioctl(self, op, arg):
+        if op == 4:  # block count
+            return len(self.data) // self.ERASE_BLOCK_SIZE
+        if op == 5:  # block size
+            return self.ERASE_BLOCK_SIZE
+        if op == 6:  # erase block
+            return 0
+
+
+def test(bdev, vfs_class):
+    print("test", vfs_class)
+
+    # Initial format of block device.
+    vfs_class.mkfs(bdev)
+
+    # construction
+    print("mtime=True")
+    vfs = vfs_class(bdev, mtime=True)
+
+    # Create an empty file, should have a timestamp.
+    vfs.open("test1", "wt").close()
+
+    # Stat the file before and after setting mtime with os.utime().
+    stat1 = vfs.stat("test1")
+    tm = utime.mktime((2010, 1, 1, 11, 49, 1, 0, 0))
+    vfs.utime("test1", (tm, tm))
+    stat2 = vfs.stat("test1")
+    print(stat1[8] != 0, stat2[8] != stat1[8], stat2[8] == tm)
+
+    # Check for invalid arguments: should all raise OSError.
+    try:
+        vfs.utime("test1", None)
+    except OSError:
+        print("OSError")
+    try:
+        vfs.utime("test1", (None, None))
+    except TypeError:
+        print("TypeError")
+    try:
+        vfs.utime("test1", (None, "Invalid"))
+    except TypeError:
+        print("TypeError")
+
+    # Unmount.
+    vfs.umount()
+
+    # Check that remounting with mtime=False raises errors on utime().
+    print("mtime=False")
+    vfs = vfs_class(bdev, mtime=False)
+    print(vfs.stat("test1") == stat2)
+
+    # Should fail with OSError(EPERM)
+    try:
+        vfs.utime("test1", (2000, 2000))
+    except OSError:
+        print("OSError")
+
+    print(vfs.stat("test1") == stat2)
+    vfs.umount()
+
+
+bdev = RAMBlockDevice(30)
+test(bdev, uos.VfsLfs2)

--- a/tests/extmod/vfs_lfs_utime.py.exp
+++ b/tests/extmod/vfs_lfs_utime.py.exp
@@ -1,0 +1,10 @@
+test <class 'VfsLfs2'>
+mtime=True
+True True True
+OSError
+TypeError
+TypeError
+mtime=False
+True
+OSError
+True

--- a/tests/extmod/vfs_posix_utime.py
+++ b/tests/extmod/vfs_posix_utime.py
@@ -1,0 +1,58 @@
+# Test for VfsPosix
+
+try:
+    import uos
+    import utime
+
+    uos.VfsPosix
+except (ImportError, AttributeError):
+    print("SKIP")
+    raise SystemExit
+
+# We need a directory for testing that doesn't already exist.
+# Skip the test if it does exist.
+temp_dir = "micropy_test_dir"
+try:
+    uos.stat(temp_dir)
+    print("SKIP")
+    raise SystemExit
+except OSError:
+    pass
+
+# mkdir
+uos.mkdir(temp_dir)
+
+test1 = temp_dir + "/test1"
+
+# Create an empty file, should have a timestamp.
+open(test1, "wt").close()
+
+# Stat the file before and after setting mtime with os.utime().
+stat1 = uos.stat(test1)
+tm = utime.mktime((2010, 1, 1, 11, 49, 1, 0, 0))
+uos.utime(test1, (tm, tm))
+stat2 = uos.stat(test1)
+print(stat1[8] != 0, stat2[8] != stat1[8], stat2[8] == tm)
+
+# Check that uos.utime(f) and uos.utime(f, None) set mtime to current time
+current_time = utime.time()
+uos.utime(test1)
+stat3 = uos.stat(test1)
+print(stat3[8] - current_time < 100)
+uos.utime(test1, (0, 0))
+uos.utime(test1, None)
+stat4 = uos.stat(test1)
+print(stat4[8] - current_time < 100)
+
+# Check for invalid arguments: should raise TypeError.
+try:
+    uos.utime(test1, (None, None))
+except TypeError:
+    print("TypeError")
+try:
+    uos.utime(test1, (None, "Invalid"))
+except TypeError:
+    print("TypeError")
+
+uos.remove(test1)
+uos.rmdir(temp_dir)

--- a/tests/extmod/vfs_posix_utime.py.exp
+++ b/tests/extmod/vfs_posix_utime.py.exp
@@ -1,0 +1,5 @@
+True True True
+True
+True
+TypeError
+TypeError


### PR DESCRIPTION
This PR adds support for `os.utime(filename, (atime, mtime))`.

This is especially useful for preserving timestamps of files and directory stuctures copied onto (or sunchronised) between micropython boards and host systems or for managing file timestamps.

Support is provided for LittleFS2, FAT and posix filesystems.