### PR TITLE
Adding Pin.toggle() to docs

### DIFF
--- a/docs/library/machine.Pin.rst
+++ b/docs/library/machine.Pin.rst
@@ -162,6 +162,10 @@ Methods
 
    Set pin to "0" output level.
 
+.. method:: Pin.toggle()
+
+   Toggle pin from "0" to "1" or viceversa.
+
 .. method:: Pin.irq(handler=None, trigger=(Pin.IRQ_FALLING | Pin.IRQ_RISING), *, priority=1, wake=None, hard=False)
 
    Configure an interrupt handler to be called when the trigger source of the


### PR DESCRIPTION
`Pin.toggle()` works with the pyboard and the Raspberry Pi Pico (RP2040), so I am adding the method to the documentation.

Apparently it is not working with the ESP32 port #8789, so feel free to move it under this section:

> The following methods are not part of the core Pin API and only implemented on certain ports.