### PR TITLE
ports/rp2: Change WIZNET5K_regs() and Add MICROPY_PY_LWIP setting value.

### DIFF
--- a/extmod/network_wiznet5k.c
+++ b/extmod/network_wiznet5k.c
@@ -768,13 +768,13 @@ STATIC mp_obj_t wiznet5k_make_new(const mp_obj_type_t *type, size_t n_args, size
 STATIC mp_obj_t wiznet5k_regs(mp_obj_t self_in) {
     (void)self_in;
     printf("Wiz CREG:");
-	#if _WIZCHIP_ == 5500
+    #if _WIZCHIP_ == 5500
     for (int i = 0; i < 0x50; ++i) {
-	#elif _WIZCHIP_ == 5105
+    #elif _WIZCHIP_ == 5105
     for (int i = 0; i < 0x90; ++i) {	
-	#else
+    #else
     for (int i = 0; i < 0x60; ++i) {
-	#endif
+    #endif
         if (i % 16 == 0) {
             printf("\n  %04x:", i);
         }
@@ -909,7 +909,7 @@ STATIC mp_obj_t wiznet5k_ifconfig(size_t n_args, const mp_obj_t *args) {
         netutils_parse_ipv4_addr(items[2], self->netinfo.gw, NETUTILS_BIG);
         netutils_parse_ipv4_addr(items[3], self->netinfo.dns, NETUTILS_BIG);
         ctlnetwork(CN_SET_NETINFO, &self->netinfo);
-		return mp_const_none;
+	return mp_const_none;
     }
 }
 STATIC MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(wiznet5k_ifconfig_obj, 1, 2, wiznet5k_ifconfig);

--- a/extmod/network_wiznet5k.c
+++ b/extmod/network_wiznet5k.c
@@ -673,9 +673,7 @@ STATIC void wiznet5k_dhcp_init(wiznet5k_obj_t *self) {
     }
 
     if (ret == DHCP_IP_LEASED) {
-//		NETUNLOCK();
         ctlnetwork(CN_GET_NETINFO, &self->netinfo);
-	//	NETLOCK();
     }
 }
 

--- a/extmod/network_wiznet5k.c
+++ b/extmod/network_wiznet5k.c
@@ -368,15 +368,6 @@ STATIC void wiz_dhcp_conflict(void) {
 }
 
 STATIC void wiznet5k_init(void) {
-    // Configure wiznet provided TCP / socket interface
-
-    reg_dhcp_cbfunc(wiz_dhcp_assign, wiz_dhcp_update, wiz_dhcp_conflict);
-
-    uint8_t sn_size[16] = {2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2};         // 2k buffer for each socket
-    ctlwizchip(CW_INIT_WIZCHIP, sn_size);
-
-    ctlnetwork(CN_SET_NETINFO, (void *)&wiznet5k_obj.netinfo);
-
     // set some sensible default values; they are configurable using ifconfig method
     wiz_NetInfo netinfo = {
         .mac = {0, 0, 0, 0, 0, 0},
@@ -387,6 +378,17 @@ STATIC void wiznet5k_init(void) {
         .dhcp = NETINFO_STATIC,
     };
     wiznet5k_obj.netinfo = netinfo;
+
+    // Configure wiznet provided TCP / socket interface
+
+    reg_dhcp_cbfunc(wiz_dhcp_assign, wiz_dhcp_update, wiz_dhcp_conflict);
+
+    uint8_t sn_size[16] = {2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2};         // 2k buffer for each socket
+    ctlwizchip(CW_INIT_WIZCHIP, sn_size);
+
+    ctlnetwork(CN_SET_NETINFO, (void *)&wiznet5k_obj.netinfo);
+
+
 
     // register with network module
     mod_network_register_nic(&wiznet5k_obj);
@@ -671,7 +673,9 @@ STATIC void wiznet5k_dhcp_init(wiznet5k_obj_t *self) {
     }
 
     if (ret == DHCP_IP_LEASED) {
+//		NETUNLOCK();
         ctlnetwork(CN_GET_NETINFO, &self->netinfo);
+	//	NETLOCK();
     }
 }
 
@@ -766,7 +770,13 @@ STATIC mp_obj_t wiznet5k_make_new(const mp_obj_type_t *type, size_t n_args, size
 STATIC mp_obj_t wiznet5k_regs(mp_obj_t self_in) {
     (void)self_in;
     printf("Wiz CREG:");
+	#if _WIZCHIP_ == 5500
     for (int i = 0; i < 0x50; ++i) {
+	#elif _WIZCHIP_ == 5105
+    for (int i = 0; i < 0x90; ++i) {	
+	#else
+    for (int i = 0; i < 0x60; ++i) {
+	#endif
         if (i % 16 == 0) {
             printf("\n  %04x:", i);
         }
@@ -896,12 +906,12 @@ STATIC mp_obj_t wiznet5k_ifconfig(size_t n_args, const mp_obj_t *args) {
         self->netinfo.dhcp = NETINFO_STATIC;
         mp_obj_t *items;
         mp_obj_get_array_fixed_n(args[1], 4, &items);
-        netutils_parse_ipv4_addr(items[0], netinfo.ip, NETUTILS_BIG);
-        netutils_parse_ipv4_addr(items[1], netinfo.sn, NETUTILS_BIG);
-        netutils_parse_ipv4_addr(items[2], netinfo.gw, NETUTILS_BIG);
-        netutils_parse_ipv4_addr(items[3], netinfo.dns, NETUTILS_BIG);
-        ctlnetwork(CN_SET_NETINFO, &netinfo);
-        return mp_const_none;
+        netutils_parse_ipv4_addr(items[0], self->netinfo.ip, NETUTILS_BIG);
+        netutils_parse_ipv4_addr(items[1], self->netinfo.sn, NETUTILS_BIG);
+        netutils_parse_ipv4_addr(items[2], self->netinfo.gw, NETUTILS_BIG);
+        netutils_parse_ipv4_addr(items[3], self->netinfo.dns, NETUTILS_BIG);
+        ctlnetwork(CN_SET_NETINFO, &self->netinfo);
+		return mp_const_none;
     }
 }
 STATIC MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(wiznet5k_ifconfig_obj, 1, 2, wiznet5k_ifconfig);

--- a/extmod/network_wiznet5k.c
+++ b/extmod/network_wiznet5k.c
@@ -775,7 +775,7 @@ STATIC mp_obj_t wiznet5k_regs(mp_obj_t self_in) {
     #else
     for (int i = 0; i < 0x60; ++i) {
     #endif
-       if (i % 16 == 0) {
+        if (i % 16 == 0) {
             printf("\n  %04x:", i);
         }
         #if _WIZCHIP_ == 5500

--- a/extmod/network_wiznet5k.c
+++ b/extmod/network_wiznet5k.c
@@ -771,11 +771,11 @@ STATIC mp_obj_t wiznet5k_regs(mp_obj_t self_in) {
     #if _WIZCHIP_ == 5500
     for (int i = 0; i < 0x50; ++i) {
     #elif _WIZCHIP_ == 5105
-    for (int i = 0; i < 0x90; ++i) {	
+    for (int i = 0; i < 0x90; ++i) {
     #else
     for (int i = 0; i < 0x60; ++i) {
     #endif
-        if (i % 16 == 0) {
+       if (i % 16 == 0) {
             printf("\n  %04x:", i);
         }
         #if _WIZCHIP_ == 5500
@@ -909,7 +909,7 @@ STATIC mp_obj_t wiznet5k_ifconfig(size_t n_args, const mp_obj_t *args) {
         netutils_parse_ipv4_addr(items[2], self->netinfo.gw, NETUTILS_BIG);
         netutils_parse_ipv4_addr(items[3], self->netinfo.dns, NETUTILS_BIG);
         ctlnetwork(CN_SET_NETINFO, &self->netinfo);
-	return mp_const_none;
+        return mp_const_none;
     }
 }
 STATIC MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(wiznet5k_ifconfig_obj, 1, 2, wiznet5k_ifconfig);

--- a/ports/rp2/CMakeLists.txt
+++ b/ports/rp2/CMakeLists.txt
@@ -199,6 +199,10 @@ if (MICROPY_PY_LWIP)
     target_compile_definitions(${MICROPY_TARGET} PRIVATE
         MICROPY_PY_LWIP=1
     )
+else()
+	target_compile_definitions(${MICROPY_TARGET} PRIVATE
+        MICROPY_PY_LWIP=0
+    )
 endif()
 
 if(MICROPY_PY_BLUETOOTH)

--- a/ports/rp2/Makefile
+++ b/ports/rp2/Makefile
@@ -6,9 +6,14 @@ BOARD ?= PICO
  
 BUILD ?= build-$(BOARD)
 
+LWIP ?= 0
+
+MICROPY_PY_WIZNET5K ?= 5105
+
 $(VERBOSE)MAKESILENT = -s
 
 CMAKE_ARGS = -DMICROPY_BOARD=$(BOARD)
+CMAKE_ARGS += -DMICROPY_PY_WIZNET5K=$(MICROPY_PY_WIZNET5K)
 
 ifdef USER_C_MODULES
 CMAKE_ARGS += -DUSER_C_MODULES=${USER_C_MODULES}
@@ -26,6 +31,7 @@ ifdef BOARD_VARIANT
 CMAKE_ARGS += -DBOARD_VARIANT=${BOARD_VARIANT}
 endif
 
+CMAKE_ARGS += -DMICROPY_PY_LWIP=${LWIP}
 HELP_BUILD_ERROR ?= "See \033[1;31mhttps://github.com/micropython/micropython/wiki/Build-Troubleshooting\033[0m"
 
 all:
@@ -34,6 +40,7 @@ all:
 
 clean:
 	$(RM) -rf $(BUILD)
+	$(RM) -rf out.log
 
 # First ensure that pico-sdk is initialised, then use cmake to pick everything
 # else (including board-specific dependencies).

--- a/ports/rp2/boards/W5100S_EVB_PICO/mpconfigboard.cmake
+++ b/ports/rp2/boards/W5100S_EVB_PICO/mpconfigboard.cmake
@@ -1,4 +1,3 @@
 # cmake file for Wiznet W5100S-EVB-Pico.
 set(PICO_BOARD wiznet_w5100s_evb_pico)
 set(MICROPY_PY_NETWORK_WIZNET5K W5100S)
-set(MICROPY_PY_LWIP 1)

--- a/ports/rp2/boards/W5500_EVB_PICO/mpconfigboard.cmake
+++ b/ports/rp2/boards/W5500_EVB_PICO/mpconfigboard.cmake
@@ -1,4 +1,3 @@
 # cmake file for Wiznet W5500-EVB-Pico.
 set(PICO_BOARD wiznet_w5100s_evb_pico)
 set(MICROPY_PY_NETWORK_WIZNET5K W5500)
-set(MICROPY_PY_LWIP 1)


### PR DESCRIPTION
# Issue

1. Modified the register address area each chip in wiznet5k_regs function

-  When MICROPY_PY_LWIP is set as '0' , it can't read the register value of CREG in wiznet5k_regs function.

1. Change the location of netinfo structure in the wiznet5k_init function
2. Delete the define of MICROPY_PY_LWIP  in the mpconfigboard.cmake of W5100S_EVB_PICO and W5500_EVB_PICO.

- When cmake compile, it can't change the value of MICROPY_PY_LWIP

# To do

- [ ] When MICROPY_PY_LWIP is set as '1' , it can read the register value of CREG in wiznet5k_regs function.

- [ ] When MICROPY_PY_LWIP is set as '1' and DHCP use ,the operation of assigning IP is very slow.
