### PR TITLE
py/persistentcode: Only emit sub-version if native.

### DIFF
--- a/py/persistentcode.c
+++ b/py/persistentcode.c
@@ -591,21 +591,18 @@ void mp_raw_code_save(mp_compiled_module_t *cm, mp_print_t *print) {
     // header contains:
     //  byte  'M'
     //  byte  version
-    //  byte  feature flags
+    //  byte  native arch (and sub-version if native)
     //  byte  number of bits in a small int
     byte header[4] = {
         'M',
         MPY_VERSION,
-        MPY_FEATURE_ENCODE_SUB_VERSION(MPY_SUB_VERSION),
+        cm->has_native ? MPY_FEATURE_ENCODE_SUB_VERSION(MPY_SUB_VERSION) | MPY_FEATURE_ENCODE_ARCH(MPY_FEATURE_ARCH_DYNAMIC) : 0,
         #if MICROPY_DYNAMIC_COMPILER
         mp_dynamic_compiler.small_int_bits,
         #else
         MP_SMALL_INT_BITS,
         #endif
     };
-    if (cm->has_native) {
-        header[2] |= MPY_FEATURE_ENCODE_ARCH(MPY_FEATURE_ARCH_DYNAMIC);
-    }
     mp_print_bytes(print, header, sizeof(header));
 
     // Number of entries in constant table.

--- a/tools/mpy-tool.py
+++ b/tools/mpy-tool.py
@@ -1676,7 +1676,7 @@ def merge_mpy(compiled_modules, output_file):
         header = bytearray(4)
         header[0] = ord("M")
         header[1] = config.MPY_VERSION
-        header[2] = config.native_arch << 2 | config.MPY_SUB_VERSION
+        header[2] = config.native_arch << 2 | config.MPY_SUB_VERSION if config.native_arch else 0
         header[3] = config.mp_small_int_bits
         merged_mpy.extend(header)
 


### PR DESCRIPTION
Fixes an incompatibility introduced in https://github.com/micropython/micropython/pull/9341 -- we meant to only set the sub-version when the .mpy contains native code. However, because it always sets it, the v1.19.1 is unable to load .mpy files generated from the current master.

This will fix https://github.com/orgs/micropython/discussions/9680

---

In order for v1.19.1 to load a .mpy, the formerly-feature-flags which are now used for the sub-version must be zero.

The sub-version is only used to indicate a native version change, so it should be zero when emitting bytecode-only .mpy files.

_This work was funded through GitHub Sponsors._
