### PR TITLE
ports/unix/main.c: Fix a memory leak

### DIFF
--- a/ports/unix/main.c
+++ b/ports/unix/main.c
@@ -701,6 +701,7 @@ MP_NOINLINE int main_(int argc, char **argv) {
                 mp_printf(&mp_stderr_print, "%s: can't open file '%s': [Errno %d] %s\n", argv[0], argv[a], errno, strerror(errno));
                 // CPython exits with 2 in such case
                 ret = 2;
+                free(pathbuf);
                 break;
             }
 


### PR DESCRIPTION
There is a memory leak in the original code：
![image](https://user-images.githubusercontent.com/51477609/197320081-be90cedc-5ef9-4e9f-9836-17c0ed48321f.png)
