### PR TITLE
stm32/adc: Fix reading internal ADC channel fails.

### DIFF
--- a/ports/stm32/adc.c
+++ b/ports/stm32/adc.c
@@ -216,6 +216,14 @@ static inline uint32_t adc_get_internal_channel(uint32_t channel) {
     if (channel == 16) {
         channel = ADC_CHANNEL_TEMPSENSOR;
     }
+    #elif defined(STM32L4)
+    if (channel == 0) {
+        channel = ADC_CHANNEL_VREFINT;
+    } else if (channel == 17) {
+        channel = ADC_CHANNEL_TEMPSENSOR;
+    } else if (channel == 18) {
+        channel = ADC_CHANNEL_VBAT;
+    }
     #endif
     return channel;
 }


### PR DESCRIPTION
### MicroPython Version
v1.19.1-555-g67f98ba10

### Environment
NUCLEO-L476RG

### How to reproduce
Execute this code:
```
>>> adc=pyb.ADC(0)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
ValueError: not a valid ADC Channel: 0
>>> adc=pyb.ADC(17)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
ValueError: not a valid ADC Channel: 17
>>> adc=pyb.ADC(18)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
ValueError: not a valid ADC Channel: 18

>>> adcall=pyb.ADCAll(12,0xffe7f)
>>> adcall.read_channel(0)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
ValueError: not a valid ADC Channel: 0
>>> adcall.read_channel(17)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
ValueError: not a valid ADC Channel: 17
>>> adcall.read_channel(18)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
ValueError: not a valid ADC Channel: 18
```

### Detail of changes
For STM32L4 series, the internal sensors are connected to

- ADC1_IN0: Internal voltage reference
- ADC1_IN17: Temperature sensor
- ADC1_IN18: VBAT battery voltage monitoring

but ADC_CHANNEL_VREFINT, ADC_CHANNEL_VBAT, ADC_CHANNEL_TEMPSENSOR are not defined as 0, 17, 18.
This PR converts channel 0, 17, 18 to ADC_CHANNEL_x in adc_get_internal_channel().