### PR TITLE
stm32/adc: Fix ADCAll.read_core_temp() returns incorrect value.

### DIFF
--- a/ports/stm32/adc.c
+++ b/ports/stm32/adc.c
@@ -852,9 +852,9 @@ float adc_read_core_temp_float(ADC_HandleTypeDef *adcHandle) {
         return 0;
     }
     #else
-    #if defined(STM32L1)
+    #if defined(STM32L1) || defined(STM32L4)
     // Update the reference correction factor before reading tempsensor
-    // because TS_CAL1 and TS_CAL2 of STM32L1 are at VDDA=3.0V
+    // because TS_CAL1 and TS_CAL2 of STM32L1/L4 are at VDDA=3.0V
     adc_read_core_vref(adcHandle);
     #endif
     int32_t raw_value = adc_config_and_read_ref(adcHandle, ADC_CHANNEL_TEMPSENSOR);


### PR DESCRIPTION
### MicroPython Version
v1.19.1-555-g67f98ba10

### Environment
NUCLEO-L476RG

### How to reproduce
Execute this code **after reset or before calling ADCAll.read_core_vref()**:

```
>>> adcall=pyb.ADCAll(12,0xffe7f)
>>> adcall.read_core_temp()
-0.4761906
```

### Detail of changes
TS_CAL1 and TS_CAL2 of STM32L4 are at VDDA=3.0V, so the reference correction factor should be updated before reading tempsensor.
This PR updates the reference correction factor using adc_read_core_vref().