### PR TITLE
zephyr: Replace zephyr/zephyr.h with zephyr/kernel.h

### DIFF
--- a/ports/zephyr/machine_i2c.c
+++ b/ports/zephyr/machine_i2c.c
@@ -29,7 +29,7 @@
 #include <stdint.h>
 #include <string.h>
 
-#include <zephyr/zephyr.h>
+#include <zephyr/kernel.h>
 #include <zephyr/drivers/i2c.h>
 
 #include "py/runtime.h"

--- a/ports/zephyr/machine_pin.c
+++ b/ports/zephyr/machine_pin.c
@@ -29,7 +29,7 @@
 #include <stdint.h>
 #include <string.h>
 
-#include <zephyr/zephyr.h>
+#include <zephyr/kernel.h>
 #include <zephyr/drivers/gpio.h>
 
 #include "py/runtime.h"

--- a/ports/zephyr/machine_spi.c
+++ b/ports/zephyr/machine_spi.c
@@ -28,7 +28,7 @@
 #include <stdint.h>
 #include <string.h>
 
-#include <zephyr/zephyr.h>
+#include <zephyr/kernel.h>
 #include <zephyr/drivers/spi.h>
 
 #include "py/runtime.h"

--- a/ports/zephyr/machine_uart.c
+++ b/ports/zephyr/machine_uart.c
@@ -29,7 +29,7 @@
 #include <stdint.h>
 #include <string.h>
 
-#include <zephyr/zephyr.h>
+#include <zephyr/kernel.h>
 #include <zephyr/drivers/uart.h>
 
 #include "py/runtime.h"

--- a/ports/zephyr/main.c
+++ b/ports/zephyr/main.c
@@ -29,7 +29,7 @@
 #include <stdio.h>
 #include <string.h>
 
-#include <zephyr/zephyr.h>
+#include <zephyr/kernel.h>
 #ifdef CONFIG_NETWORKING
 #include <zephyr/net/net_context.h>
 #endif

--- a/ports/zephyr/modusocket.c
+++ b/ports/zephyr/modusocket.c
@@ -31,7 +31,7 @@
 #include "py/stream.h"
 
 #include <stdio.h>
-#include <zephyr/zephyr.h>
+#include <zephyr/kernel.h>
 // Zephyr's generated version header
 #include <version.h>
 #include <zephyr/net/net_context.h>

--- a/ports/zephyr/modutime.c
+++ b/ports/zephyr/modutime.c
@@ -28,7 +28,7 @@
 #include "py/mpconfig.h"
 #if MICROPY_PY_UTIME
 
-#include <zephyr/zephyr.h>
+#include <zephyr/kernel.h>
 
 #include "py/runtime.h"
 #include "py/smallint.h"

--- a/ports/zephyr/modzephyr.c
+++ b/ports/zephyr/modzephyr.c
@@ -29,7 +29,7 @@
 #if MICROPY_PY_ZEPHYR
 
 #include <stdio.h>
-#include <zephyr/zephyr.h>
+#include <zephyr/kernel.h>
 #include <zephyr/debug/thread_analyzer.h>
 #include <zephyr/shell/shell.h>
 #include <zephyr/shell/shell_uart.h>

--- a/ports/zephyr/modzsensor.c
+++ b/ports/zephyr/modzsensor.c
@@ -28,7 +28,7 @@
 
 #include "py/runtime.h"
 
-#include <zephyr/zephyr.h>
+#include <zephyr/kernel.h>
 #include <zephyr/drivers/sensor.h>
 
 #if MICROPY_PY_ZSENSOR

--- a/ports/zephyr/mpconfigport.h
+++ b/ports/zephyr/mpconfigport.h
@@ -28,7 +28,7 @@
 // Include Zephyr's autoconf.h, which should be made first by Zephyr makefiles
 #include "autoconf.h"
 // Included here to get basic Zephyr environment (macros, etc.)
-#include <zephyr/zephyr.h>
+#include <zephyr/kernel.h>
 #include <zephyr/drivers/spi.h>
 
 // Usually passed from Makefile

--- a/ports/zephyr/mphalport.h
+++ b/ports/zephyr/mphalport.h
@@ -1,4 +1,4 @@
-#include <zephyr/zephyr.h>
+#include <zephyr/kernel.h>
 #include "shared/runtime/interrupt_char.h"
 
 void mp_hal_init(void);

--- a/ports/zephyr/src/zephyr_getchar.c
+++ b/ports/zephyr/src/zephyr_getchar.c
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-#include <zephyr/zephyr.h>
+#include <zephyr/kernel.h>
 #include <zephyr/drivers/uart.h>
 #include <zephyr/drivers/console/uart_console.h>
 #include <zephyr/sys/printk.h>

--- a/ports/zephyr/src/zephyr_start.c
+++ b/ports/zephyr/src/zephyr_start.c
@@ -23,7 +23,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-#include <zephyr/zephyr.h>
+#include <zephyr/kernel.h>
 #include <zephyr/console/console.h>
 #include "zephyr_getchar.h"
 


### PR DESCRIPTION
zephyr/zephyr.h is now deprecated, and should be replaced with zephyr/kernel.h.

Signed-off-by: Yonatan Schachter <yonatan.schachter@gmail.com>