### PR TITLE
stm32/i2c: Add hardware I2C implementation for STM32L1.

### DIFF
--- a/ports/stm32/i2c.c
+++ b/ports/stm32/i2c.c
@@ -31,7 +31,7 @@
 
 #if MICROPY_HW_ENABLE_HW_I2C
 
-#if defined(STM32F4)
+#if defined(STM32F4) || defined(STM32L1)
 
 STATIC uint16_t i2c_timeout_ms[MICROPY_HW_MAX_I2C];
 

--- a/ports/stm32/machine_i2c.c
+++ b/ports/stm32/machine_i2c.c
@@ -38,7 +38,7 @@
 
 #define I2C_POLL_DEFAULT_TIMEOUT_US (50000) // 50ms
 
-#if defined(STM32F0) || defined(STM32F4) || defined(STM32F7) || defined(STM32H7)
+#if defined(STM32F0) || defined(STM32F4) || defined(STM32F7) || defined(STM32H7) || defined(STM32L1)
 
 typedef struct _machine_hard_i2c_obj_t {
     mp_obj_base_t base;
@@ -65,7 +65,7 @@ STATIC const machine_hard_i2c_obj_t machine_hard_i2c_obj[MICROPY_HW_MAX_I2C] = {
 STATIC void machine_hard_i2c_print(const mp_print_t *print, mp_obj_t self_in, mp_print_kind_t kind) {
     machine_hard_i2c_obj_t *self = MP_OBJ_TO_PTR(self_in);
 
-    #if defined(STM32F4)
+    #if defined(STM32F4) || defined(STM32L1)
 
     uint32_t freq = self->i2c->CR2 & 0x3f;
     uint32_t ccr = self->i2c->CCR;


### PR DESCRIPTION
For STM32L1, hardware I2C can implement same as STM32F4 for machine.I2C.
This PR makes to be able to use of hardware I2C in machine.I2C.

Tested on NUCLEO-L152RE.