### PR TITLE
stm32/i2c: Add hardware I2C implementation for STM32L4.

### DIFF
--- a/ports/stm32/i2c.c
+++ b/ports/stm32/i2c.c
@@ -276,6 +276,9 @@ int i2c_write(i2c_t *i2c, const uint8_t *src, size_t len, size_t next_len) {
 #elif defined(STM32L4)
 #define APB1ENR            APB1ENR1
 #define RCC_APB1ENR_I2C1EN RCC_APB1ENR1_I2C1EN
+#if defined(STM32L432xx)
+#define I2C2_BASE (APB1PERIPH_BASE + 0x5800UL)
+#endif
 #endif
 
 STATIC uint16_t i2c_timeout_ms[MICROPY_HW_MAX_I2C];

--- a/ports/stm32/machine_i2c.c
+++ b/ports/stm32/machine_i2c.c
@@ -38,7 +38,7 @@
 
 #define I2C_POLL_DEFAULT_TIMEOUT_US (50000) // 50ms
 
-#if defined(STM32F0) || defined(STM32F4) || defined(STM32F7) || defined(STM32H7)
+#if defined(STM32F0) || defined(STM32F4) || defined(STM32F7) || defined(STM32H7) || defined(STM32L4)
 
 typedef struct _machine_hard_i2c_obj_t {
     mp_obj_base_t base;
@@ -186,7 +186,7 @@ STATIC void machine_hard_i2c_init(machine_hard_i2c_obj_t *self, uint32_t freq, u
 /******************************************************************************/
 /* MicroPython bindings for machine API                                       */
 
-#if defined(STM32F0) || defined(STM32F7) || defined(STM32H7)
+#if defined(STM32F0) || defined(STM32F7) || defined(STM32H7) || defined(STM32L4)
 #define MACHINE_I2C_TIMINGR (1)
 #else
 #define MACHINE_I2C_TIMINGR (0)

--- a/ports/stm32/pyb_i2c.c
+++ b/ports/stm32/pyb_i2c.c
@@ -208,11 +208,14 @@ const pyb_i2c_obj_t pyb_i2c_obj[] = {
 
 #elif defined(STM32L4)
 
-// The value 0x90112626 was obtained from the DISCOVERY_I2C1_TIMING constant
-// defined in the STM32L4Cube file Drivers/BSP/STM32L476G-Discovery/stm32l476g_discovery.h
-#define MICROPY_HW_I2C_BAUDRATE_TIMING {{PYB_I2C_SPEED_STANDARD, 0x90112626}}
-#define MICROPY_HW_I2C_BAUDRATE_DEFAULT (PYB_I2C_SPEED_STANDARD)
-#define MICROPY_HW_I2C_BAUDRATE_MAX (PYB_I2C_SPEED_STANDARD)
+// generated using CubeMX
+#define MICROPY_HW_I2C_BAUDRATE_TIMING { \
+        {PYB_I2C_SPEED_STANDARD, 0x10909CEC}, \
+        {PYB_I2C_SPEED_FULL, 0x00702991}, \
+        {PYB_I2C_SPEED_FAST, 0x00300F33}, \
+}
+#define MICROPY_HW_I2C_BAUDRATE_DEFAULT (PYB_I2C_SPEED_FULL)
+#define MICROPY_HW_I2C_BAUDRATE_MAX (PYB_I2C_SPEED_FAST)
 
 #else
 #error "no I2C timings for this MCU"


### PR DESCRIPTION
For STM32L4, hardware I2C can implement by using TIMINGR.
This PR makes to be able to:

- Use of hardware I2C in machine.I2C.
- Specify frequency greater than or equal to 400KHz with pyb.I2C.

In pyb_i2c.c, TIMINGR for STM32L4 is defined as:
https://github.com/micropython/micropython/blob/68f166dae9ad6dfd94038d5f4394defbb44238af/ports/stm32/pyb_i2c.c#L209-L216
but according to STM32CubeIDE, the value of TIMINGR for standard mode is the same with NUCLEO-476RG and STM32L476G-Discovery.
So it can be replaced with the value genereted by STM32CubeIDE.

Tested on NUCLEO-L476RG.