### PR TITLE
Add freq arguement in machine.Timer.rst

### DIFF
--- a/docs/library/machine.Timer.rst
+++ b/docs/library/machine.Timer.rst
@@ -38,12 +38,15 @@ Constructors
 Methods
 -------
 
-.. method:: Timer.init(*, mode=Timer.PERIODIC, period=-1, callback=None)
+.. method:: Timer.init(*, mode=Timer.PERIODIC, freq=-1, period=-1, callback=None)
 
    Initialise the timer. Example::
 
        def mycallback(t):
            pass
+
+       # periodic at 1kHz
+       tim.init(mode=Timer.PERIODIC, freq=1000, callback=mycallback)
 
        # periodic with 100ms period
        tim.init(period=100, callback=mycallback)
@@ -59,6 +62,11 @@ Methods
          period of the channel expires.
        - ``Timer.PERIODIC`` - The timer runs periodically at the configured
          frequency of the channel.
+
+     - ``freq`` - The timer frequency, in units of Hz.  The upper bound of
+       the frequency is dependent on the port.  When both the ``freq`` and
+       ``period`` arguments are given, ``freq`` has a higher priority and
+       ``period`` is ignored.
 
      - ``period`` - The timer period, in milliseconds.
 


### PR DESCRIPTION
Timer has a `freq` arguement which is not methoned in the document.

- The timer class method ``timer_settime(tid, hz)`` has a frequency arguments. And the period is in nano second accuracy.
- Timer is triggered by Crystal Oscillator (XOSC). The STARTUP_DELAY register specifies how many clock cycles must be seen from the crystal before it can be used. This is specified in multiples of 256. That means in theory the max frequency is 12 MHz (crystal frequency) divided by 256, which is 46.875 MHz.

The following code is tested on Respberry Pi pico, using RP2040 microcontrollers.
```python
from machine import  Timer
speed = 2000 
tim = Timer()
tim.init(freq=speed, mode=Timer.PERIODIC, callback=testSeqCallback)
```
Result supports arguement `freq`, and outputs correct signal.