### PR TITLE
docs/library/machine.Timer: Add freq arguement in machine.Timer.

### DIFF
--- a/docs/library/machine.Timer.rst
+++ b/docs/library/machine.Timer.rst
@@ -61,6 +61,9 @@ Methods
          frequency of the channel.
 
      - ``period`` - The timer period, in milliseconds.
+     
+     - ``freq`` - The timer freq, recommended less than 10 MHz. Theoretical
+        upper bound is 46.875 MHz.
 
      - ``callback`` - The callable to call upon expiration of the timer period.
        The callback must take one argument, which is passed the Timer object.

--- a/docs/library/machine.Timer.rst
+++ b/docs/library/machine.Timer.rst
@@ -62,8 +62,8 @@ Methods
 
      - ``period`` - The timer period, in milliseconds.
      
-     - ``freq`` - The timer freq, recommended less than 10 MHz. Theoretical
-        upper bound is 46.875 MHz.
+     - ``freq`` - The timer freq, the upper bound of frequency is dependent on
+	 port. Please refer to specific microcontroller datasheet.
 
      - ``callback`` - The callable to call upon expiration of the timer period.
        The callback must take one argument, which is passed the Timer object.


### PR DESCRIPTION
Timer has a `freq` arguement which is not methoned in the document.

- The timer class method ``timer_settime(tid, hz)`` has a frequency arguments. And the period is in nano second accuracy.
- Timer is triggered by Crystal Oscillator (XOSC). The STARTUP_DELAY register specifies how many clock cycles must be seen from the crystal before it can be used. This is specified in multiples of 256. That means in theory the max frequency is 12 MHz (crystal frequency) divided by 256, which is 46.875 MHz.

The following code is tested on Respberry Pi pico, using RP2040 microcontrollers.
```python
from machine import  Timer
speed = 2000 
tim = Timer()
tim.init(freq=speed, mode=Timer.PERIODIC, callback=testSeqCallback)
```
Result supports arguement `freq`, and outputs correct signal.