### PR TITLE
tools/mpremote/pyboardextended.py: Handle FileNotFound in listdir.

### DIFF
--- a/tools/mpremote/mpremote/pyboardextended.py
+++ b/tools/mpremote/mpremote/pyboardextended.py
@@ -428,12 +428,11 @@ class PyboardCommand:
         path = self.root + self.rd_str()
         try:
             self.path_check(path)
+            self.data_ilistdir[0] = path
+            self.data_ilistdir[1] = os.listdir(path)
             self.wr_s8(0)
         except OSError as er:
             self.wr_s8(-abs(er.errno))
-        else:
-            self.data_ilistdir[0] = path
-            self.data_ilistdir[1] = os.listdir(path)
 
     def do_ilistdir_next(self):
         if self.data_ilistdir[1]:


### PR DESCRIPTION
The except handler for OSError didn't include the line that actually calls os.listdir, so an invalid path wasn't handled correctly.

Thanks @Josverl for the report on Discord.
