### PR TITLE
Remove mp_js_stdout requirement in webassembly port

### DIFF
--- a/ports/webassembly/Makefile
+++ b/ports/webassembly/Makefile
@@ -15,7 +15,7 @@ INC += -I$(TOP)
 INC += -I$(BUILD)
 
 CFLAGS += -std=c99 -Wall -Werror -Wdouble-promotion -Wfloat-conversion
-CFLAGS += -O3 -DNDEBUG
+CFLAGS += -Os -DNDEBUG
 CFLAGS += $(INC)
 
 SRC_SHARED = $(addprefix shared/,\

--- a/ports/webassembly/library.js
+++ b/ports/webassembly/library.js
@@ -33,10 +33,9 @@ mergeInto(LibraryManager.library, {
                 process.stdout.write(b);
             } else {
                 var c = String.fromCharCode(getValue(ptr + i, 'i8'));
-                var mp_js_stdout = document.getElementById('mp_js_stdout');
-                var print = new Event('print');
-                print.data = c;
-                mp_js_stdout.dispatchEvent(print);
+                var printEvent = new CustomEvent('micropython-print');
+                printEvent.data = c;
+                document.dispatchEvent(printEvent);
             }
         }
     },


### PR DESCRIPTION
This PR introduces four changes:

* Remove need for an element with the id `mp_js_stdout` in the DOM.
* Dispatch the print event via the `document` object.
* Namespace the event as `micropython-print`.
* More efficient compilation flag (`-Os`).