### PR TITLE
webassembly: use ROM feature level config, and enable filesystem via VfsPosix

### DIFF
--- a/extmod/vfs_posix.c
+++ b/extmod/vfs_posix.c
@@ -37,9 +37,11 @@
 #error "MICROPY_VFS_POSIX requires MICROPY_ENABLE_FINALISER"
 #endif
 
+#include <errno.h>
 #include <stdio.h>
 #include <string.h>
 #include <sys/stat.h>
+#include <unistd.h>
 #include <dirent.h>
 #ifdef _MSC_VER
 #include <direct.h> // For mkdir etc.

--- a/ports/webassembly/Makefile
+++ b/ports/webassembly/Makefile
@@ -37,7 +37,10 @@ OBJ += $(addprefix $(BUILD)/, $(SRC_SHARED:.c=.o))
 OBJ += $(addprefix $(BUILD)/, $(SRC_C:.c=.o))
 
 JSFLAGS += -s ASYNCIFY
-JSFLAGS += -s EXPORTED_FUNCTIONS="['_mp_js_init', '_mp_js_init_repl', '_mp_js_do_str', '_mp_js_process_char', '_mp_hal_get_interrupt_char', '_mp_sched_keyboard_interrupt']" -s EXPORTED_RUNTIME_METHODS="['ccall', 'cwrap']" -s --memory-init-file 0 --js-library library.js
+JSFLAGS += -s EXPORTED_FUNCTIONS="['_mp_js_init', '_mp_js_init_repl', '_mp_js_do_str', '_mp_js_process_char', '_mp_hal_get_interrupt_char', '_mp_sched_keyboard_interrupt']"
+JSFLAGS += -s EXPORTED_RUNTIME_METHODS="['ccall', 'cwrap', 'FS']"
+JSFLAGS += -s --memory-init-file 0
+JSFLAGS += --js-library library.js
 
 all: $(BUILD)/micropython.js
 

--- a/ports/webassembly/mpconfigport.h
+++ b/ports/webassembly/mpconfigport.h
@@ -3,7 +3,8 @@
  *
  * The MIT License (MIT)
  *
- * Copyright (c) 2013, 2014 Damien P. George and 2017, 2018 Rami Ali
+ * Copyright (c) 2013-2022 Damien P. George
+ * Copyright (c) 2017, 2018 Rami Ali
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -28,129 +29,34 @@
 
 // options to control how MicroPython is built
 
+#define MICROPY_CONFIG_ROM_LEVEL (MICROPY_CONFIG_ROM_LEVEL_EXTRA_FEATURES)
+
 // You can disable the built-in MicroPython compiler by setting the following
 // config option to 0.  If you do this then you won't get a REPL prompt, but you
 // will still be able to execute pre-compiled scripts, compiled with mpy-cross.
 #define MICROPY_ENABLE_COMPILER     (1)
 
-#define MICROPY_QSTR_BYTES_IN_HASH  (2)
 #define MICROPY_ALLOC_PATH_MAX      (256)
-#define MICROPY_ALLOC_PARSE_CHUNK_INIT (16)
-#define MICROPY_EMIT_X64            (0) // BROKEN
-#define MICROPY_EMIT_THUMB          (0) // BROKEN
-#define MICROPY_EMIT_INLINE_THUMB   (0)
-#define MICROPY_COMP_MODULE_CONST   (0)
-#define MICROPY_COMP_CONST          (1)
-#define MICROPY_COMP_DOUBLE_TUPLE_ASSIGN (1)
-#define MICROPY_COMP_TRIPLE_TUPLE_ASSIGN (0)
-#define MICROPY_MEM_STATS           (0) // BROKEN
-#define MICROPY_DEBUG_PRINTERS      (0)
 #define MICROPY_ENABLE_GC           (1)
-#define MICROPY_GC_ALLOC_THRESHOLD  (1)
-#define MICROPY_GC_USES_ALLOCATED_SIZE (1)
+#define MICROPY_ENABLE_PYSTACK      (1)
+#define MICROPY_STACK_CHECK         (0)
+#define MICROPY_KBD_EXCEPTION       (1)
 #define MICROPY_REPL_EVENT_DRIVEN   (1)
-#define MICROPY_HELPER_REPL         (1)
-#define MICROPY_HELPER_LEXER_UNIX   (0)
-#define MICROPY_ENABLE_SOURCE_LINE  (1)
+#define MICROPY_LONGINT_IMPL        (MICROPY_LONGINT_IMPL_MPZ)
 #define MICROPY_ENABLE_DOC_STRING   (1)
 #define MICROPY_WARNINGS            (1)
-#define MICROPY_BUILTIN_METHOD_CHECK_SELF_ARG (1)
-#define MICROPY_PY_ASYNC_AWAIT      (1)
-#define MICROPY_PY_BUILTINS_BYTEARRAY (1)
-#define MICROPY_PY_BUILTINS_MEMORYVIEW (1)
-#define MICROPY_PY_BUILTINS_ENUMERATE (1)
-#define MICROPY_PY_BUILTINS_FILTER  (1)
-#define MICROPY_PY_BUILTINS_FROZENSET (1)
-#define MICROPY_PY_BUILTINS_REVERSED (1)
-#define MICROPY_PY_BUILTINS_SET     (1)
-#define MICROPY_PY_BUILTINS_SLICE   (1)
-#define MICROPY_PY_BUILTINS_PROPERTY (1)
-#define MICROPY_PY_BUILTINS_MIN_MAX (1)
-#define MICROPY_PY___FILE__         (1)
-#define MICROPY_PY_GC               (1)
-#define MICROPY_PY_ARRAY            (1)
-#define MICROPY_PY_ATTRTUPLE        (1)
-#define MICROPY_PY_COLLECTIONS      (1)
-#define MICROPY_PY_MATH             (1)
-#define MICROPY_PY_MATH_SPECIAL_FUNCTIONS (1)
-#define MICROPY_PY_MATH_ISCLOSE     (1)
-#define MICROPY_PY_CMATH            (1)
-#define MICROPY_PY_IO               (1)
-#define MICROPY_PY_STRUCT           (1)
-#define MICROPY_PY_SYS              (1)
-#define MICROPY_PY_SYS_MAXSIZE      (1)
-#define MICROPY_CPYTHON_COMPAT      (1)
-#define MICROPY_LONGINT_IMPL        (MICROPY_LONGINT_IMPL_MPZ)
 #define MICROPY_FLOAT_IMPL          (MICROPY_FLOAT_IMPL_DOUBLE)
-
-#define MICROPY_USE_INTERNAL_PRINTF (0)
-#define MICROPY_ENABLE_PYSTACK      (1)
-#define MICROPY_KBD_EXCEPTION       (1)
-#define MICROPY_PY_UTIME_MP_HAL     (1)
-#define MICROPY_REPL_AUTO_INDENT    (1)
-#define MICROPY_PY_FUNCTION_ATTRS   (1)
-#define MICROPY_PY_BUILTINS_BYTES_HEX (1)
-#define MICROPY_PY_BUILTINS_STR_UNICODE (1)
-#define MICROPY_PY_BUILTINS_STR_CENTER (1)
-#define MICROPY_PY_BUILTINS_STR_PARTITION (1)
-#define MICROPY_PY_BUILTINS_STR_SPLITLINES (1)
-#define MICROPY_PY_BUILTINS_SLICE_ATTRS (1)
-#define MICROPY_PY_ALL_SPECIAL_METHODS (1)
-#define MICROPY_PY_BUILTINS_COMPILE (1)
-#define MICROPY_PY_BUILTINS_EXECFILE (1)
-#define MICROPY_PY_BUILTINS_INPUT (1)
-#define MICROPY_PY_BUILTINS_POW3 (1)
-#define MICROPY_PY_BUILTINS_HELP (1)
-#define MICROPY_PY_BUILTINS_HELP_MODULES (1)
-#define MICROPY_PY_MICROPYTHON_MEM_INFO (1)
-#define MICROPY_PY_ARRAY_SLICE_ASSIGN (1)
-#define MICROPY_PY_COLLECTIONS_ORDEREDDICT (1)
-#define MICROPY_PY_SYS_PLATFORM     "webassembly"
-#define MICROPY_PY_UERRNO           (1)
-#define MICROPY_PY_UCTYPES          (1)
-#define MICROPY_PY_UZLIB            (1)
-#define MICROPY_PY_UJSON            (1)
-#define MICROPY_PY_URE              (1)
-#define MICROPY_PY_UHEAPQ           (1)
-#define MICROPY_PY_UHASHLIB         (1)
-#define MICROPY_PY_UBINASCII        (1)
-#define MICROPY_PY_URANDOM          (1)
-#define MICROPY_PY_URANDOM_EXTRA_FUNCS (1)
-#define MICROPY_PY_USELECT          (1)
-#define MICROPY_PY_FRAMEBUF         (1)
-#define MICROPY_STREAMS_NON_BLOCK   (1)
-#define MICROPY_MODULE_WEAK_LINKS   (1)
-#define MICROPY_CAN_OVERRIDE_BUILTINS (1)
 #define MICROPY_USE_INTERNAL_ERRNO  (1)
-#define MICROPY_ENABLE_SCHEDULER    (1)
-#define MICROPY_SCHEDULER_DEPTH     (1)
+#define MICROPY_USE_INTERNAL_PRINTF (0)
+#define MICROPY_PY_UTIME_MP_HAL     (1)
+#define MICROPY_PY_SYS_PLATFORM     "webassembly"
+#define MICROPY_PY_SYS_STDFILES     (0)
 
-#define MP_SSIZE_MAX (0x7fffffff)
-
-// #define MICROPY_EVENT_POLL_HOOK {ets_event_poll();}
-#if MICROPY_PY_THREAD
-#define MICROPY_EVENT_POLL_HOOK \
-    do { \
-        extern void mp_handle_pending(bool); \
-        mp_handle_pending(true); \
-        if (pyb_thread_enabled) { \
-            MP_THREAD_GIL_EXIT(); \
-            pyb_thread_yield(); \
-            MP_THREAD_GIL_ENTER(); \
-        } else { \
-        } \
-    } while (0);
-
-#define MICROPY_THREAD_YIELD() pyb_thread_yield()
-#else
 #define MICROPY_EVENT_POLL_HOOK \
     do { \
         extern void mp_handle_pending(bool); \
         mp_handle_pending(true); \
     } while (0);
-
-#define MICROPY_THREAD_YIELD()
-#endif
 
 #define MICROPY_VM_HOOK_COUNT (10)
 #define MICROPY_VM_HOOK_INIT static uint vm_hook_divisor = MICROPY_VM_HOOK_COUNT;
@@ -164,7 +70,7 @@
 
 // type definitions for the specific machine
 
-// #define MICROPY_MAKE_POINTER_CALLABLE(p) ((void*)((mp_uint_t)(p) | 1))
+#define MP_SSIZE_MAX (0x7fffffff)
 
 // This port is intended to be 32-bit, but unfortunately, int32_t for
 // different targets may be defined in different ways - either as int
@@ -175,9 +81,6 @@
 typedef int mp_int_t; // must be pointer size
 typedef unsigned mp_uint_t; // must be pointer size
 typedef long mp_off_t;
-
-// We need to provide a declaration/definition of alloca()
-#include <alloca.h>
 
 #define MICROPY_HW_BOARD_NAME "JS"
 #define MICROPY_HW_MCU_NAME "Emscripten"

--- a/ports/webassembly/mpconfigport.h
+++ b/ports/webassembly/mpconfigport.h
@@ -37,6 +37,7 @@
 #define MICROPY_ENABLE_COMPILER     (1)
 
 #define MICROPY_ALLOC_PATH_MAX      (256)
+#define MICROPY_READER_VFS          (MICROPY_VFS)
 #define MICROPY_ENABLE_GC           (1)
 #define MICROPY_ENABLE_PYSTACK      (1)
 #define MICROPY_STACK_CHECK         (0)
@@ -48,6 +49,10 @@
 #define MICROPY_FLOAT_IMPL          (MICROPY_FLOAT_IMPL_DOUBLE)
 #define MICROPY_USE_INTERNAL_ERRNO  (1)
 #define MICROPY_USE_INTERNAL_PRINTF (0)
+#ifndef MICROPY_VFS
+#define MICROPY_VFS                 (1)
+#endif
+#define MICROPY_VFS_POSIX           (MICROPY_VFS)
 #define MICROPY_PY_UTIME_MP_HAL     (1)
 #define MICROPY_PY_SYS_PLATFORM     "webassembly"
 #define MICROPY_PY_SYS_STDFILES     (0)
@@ -86,3 +91,8 @@ typedef long mp_off_t;
 #define MICROPY_HW_MCU_NAME "Emscripten"
 
 #define MP_STATE_PORT MP_STATE_VM
+
+#if MICROPY_VFS
+// _GNU_SOURCE must be defined to get definitions of DT_xxx symbols from dirent.h.
+#define _GNU_SOURCE
+#endif

--- a/ports/webassembly/mphalport.h
+++ b/ports/webassembly/mphalport.h
@@ -37,3 +37,26 @@ mp_uint_t mp_hal_ticks_us(void);
 mp_uint_t mp_hal_ticks_cpu(void);
 
 int mp_hal_get_interrupt_char(void);
+
+#if MICROPY_VFS_POSIX
+
+#include <errno.h>
+
+// This macro is used to implement PEP 475 to retry specified syscalls on EINTR
+#define MP_HAL_RETRY_SYSCALL(ret, syscall, raise) \
+    { \
+        for (;;) { \
+            ret = syscall; \
+            if (ret == -1) { \
+                int err = errno; \
+                if (err == EINTR) { \
+                    mp_handle_pending(true); \
+                    continue; \
+                } \
+                raise; \
+            } \
+            break; \
+        } \
+    }
+
+#endif


### PR DESCRIPTION
This PR does two things:
- switches mpconfigport.h to use `MICROPY_CONFIG_ROM_LEVEL_EXTRA_FEATURES` and simplifies the config
- enables `MICROPY_VFS` and `MICROPY_VFS_POSIX` on this port, to get a filesystem (provided by Emscripten)

The filesystem is tested to work in Node and in the browser.