### PR TITLE
rp2/mpthreadport: Enable Systick for core1.

### DIFF
--- a/ports/rp2/cyw43_configport.h
+++ b/ports/rp2/cyw43_configport.h
@@ -47,8 +47,15 @@
 #define CYW43_THREAD_EXIT               MICROPY_PY_LWIP_EXIT
 #define CYW43_THREAD_LOCK_CHECK
 
-#define CYW43_SDPCM_SEND_COMMON_WAIT    __WFI();
-#define CYW43_DO_IOCTL_WAIT             __WFI();
+#define CYW43_SDPCM_SEND_COMMON_WAIT \
+    if (get_core_num() == 0) { \
+        __WFI(); \
+    } \
+
+#define CYW43_DO_IOCTL_WAIT \
+    if (get_core_num() == 0) { \
+        __WFI(); \
+    } \
 
 #define CYW43_ARRAY_SIZE(a)             MP_ARRAY_SIZE(a)
 


### PR DESCRIPTION
If core1 executes a `__WFI()` (for example when calling `cyw43_do_ioctl` as reported in issue #9597), it will never wake up, since it doesn't have any interrupts enabled by default (other than `SIO_IRQ_PROC1`). This patch enables `SysTick` for core1 to periodically interrupt it, to ensure that it wakes up from `__WFI()` if no other interrupt is enabled. Note each core has its own SysTick register, and SysTick IRQ is not enabled for core0, so this patch should Not affect core0 in any way.