### PR TITLE
esp32/event loop: using new esp event lib API

### DIFF
--- a/ports/esp32/modnetwork.c
+++ b/ports/esp32/modnetwork.c
@@ -139,7 +139,7 @@ STATIC mp_obj_t esp_initialize() {
         esp_netif_init();
         ESP_LOGD("modnetwork", "Initializing Event Loop");
         esp_exceptions(esp_event_loop_create_default());
-		esp_exceptions(esp_event_handler_register(ESP_EVENT_ANY_BASE, ESP_EVENT_ANY_ID, event_handler, NULL));
+        esp_exceptions(esp_event_handler_register(ESP_EVENT_ANY_BASE, ESP_EVENT_ANY_ID, event_handler, NULL));
         ESP_LOGD("modnetwork", "esp_event_loop_init done");
         initialized = 1;
     }

--- a/ports/esp32/modnetwork.c
+++ b/ports/esp32/modnetwork.c
@@ -136,9 +136,10 @@ STATIC mp_obj_t esp_initialize() {
     static int initialized = 0;
     if (!initialized) {
         ESP_LOGD("modnetwork", "Initializing TCP/IP");
-        tcpip_adapter_init();
+        esp_netif_init();
         ESP_LOGD("modnetwork", "Initializing Event Loop");
-        esp_exceptions(esp_event_loop_init(event_handler, NULL));
+        esp_exceptions(esp_event_loop_create_default());
+		esp_exceptions(esp_event_handler_register(ESP_EVENT_ANY_BASE, ESP_EVENT_ANY_ID, event_handler, NULL));
         ESP_LOGD("modnetwork", "esp_event_loop_init done");
         initialized = 1;
     }


### PR DESCRIPTION
Using legacy API for event loop prevents the use of new event loop API. This in turn prevents use of ESP32 WiFi mesh event set up. Changing these calls in the network module allows the IDF to leave the legacy symbols out and then mesh works fine.