### PR TITLE
esp32/modesp32: Add raw_temperature for S3 chips

### DIFF
--- a/ports/esp32/modesp32.c
+++ b/ports/esp32/modesp32.c
@@ -178,6 +178,28 @@ STATIC MP_DEFINE_CONST_FUN_OBJ_0(esp32_hall_sensor_obj, esp32_hall_sensor);
 
 #endif
 
+#if CONFIG_IDF_TARGET_ESP32S3
+
+#include "driver/temp_sensor.h"
+
+STATIC mp_obj_t esp32_raw_temperature(void) {
+
+    temp_sensor_config_t temp_sensor = {
+    	.dac_offset = TSENS_DAC_L2,
+    	.clk_div = 6,
+	};
+	temp_sensor_set_config(temp_sensor);
+	temp_sensor_start();
+	float tsens_out;
+	temp_sensor_read_celsius(&tsens_out);
+	temp_sensor_stop();
+
+    return mp_obj_new_float(tsens_out);
+}
+STATIC MP_DEFINE_CONST_FUN_OBJ_0(esp32_raw_temperature_obj, esp32_raw_temperature);
+
+#endif
+
 STATIC mp_obj_t esp32_idf_heap_info(const mp_obj_t cap_in) {
     mp_int_t cap = mp_obj_get_int(cap_in);
     multi_heap_info_t info;
@@ -212,6 +234,10 @@ STATIC const mp_rom_map_elem_t esp32_module_globals_table[] = {
     { MP_ROM_QSTR(MP_QSTR_raw_temperature), MP_ROM_PTR(&esp32_raw_temperature_obj) },
     { MP_ROM_QSTR(MP_QSTR_hall_sensor), MP_ROM_PTR(&esp32_hall_sensor_obj) },
     #endif
+    #if CONFIG_IDF_TARGET_ESP32S3
+    { MP_ROM_QSTR(MP_QSTR_raw_temperature), MP_ROM_PTR(&esp32_raw_temperature_obj) },
+    #endif
+
     { MP_ROM_QSTR(MP_QSTR_idf_heap_info), MP_ROM_PTR(&esp32_idf_heap_info_obj) },
 
     { MP_ROM_QSTR(MP_QSTR_NVS), MP_ROM_PTR(&esp32_nvs_type) },

--- a/ports/esp32/modesp32.c
+++ b/ports/esp32/modesp32.c
@@ -188,11 +188,11 @@ STATIC mp_obj_t esp32_raw_temperature(void) {
     	.dac_offset = TSENS_DAC_L2,
     	.clk_div = 6,
 	};
-	temp_sensor_set_config(temp_sensor);
-	temp_sensor_start();
-	float tsens_out;
-	temp_sensor_read_celsius(&tsens_out);
-	temp_sensor_stop();
+    temp_sensor_set_config(temp_sensor);
+    temp_sensor_start();
+    float tsens_out;
+    temp_sensor_read_celsius(&tsens_out);
+    temp_sensor_stop();
 
     return mp_obj_new_float(tsens_out);
 }

--- a/ports/esp32/modesp32.c
+++ b/ports/esp32/modesp32.c
@@ -178,15 +178,15 @@ STATIC MP_DEFINE_CONST_FUN_OBJ_0(esp32_hall_sensor_obj, esp32_hall_sensor);
 
 #endif
 
-#if CONFIG_IDF_TARGET_ESP32S3
+#if CONFIG_IDF_TARGET_ESP32S3 
 
 #include "driver/temp_sensor.h"
 
 STATIC mp_obj_t esp32_raw_temperature(void) {
 
     temp_sensor_config_t temp_sensor = {
-    	.dac_offset = TSENS_DAC_L2,
-    	.clk_div = 6,
+         .dac_offset = TSENS_DAC_L2,
+         .clk_div = 6,
     };
     temp_sensor_set_config(temp_sensor);
     temp_sensor_start();

--- a/ports/esp32/modesp32.c
+++ b/ports/esp32/modesp32.c
@@ -187,7 +187,7 @@ STATIC mp_obj_t esp32_raw_temperature(void) {
     temp_sensor_config_t temp_sensor = {
     	.dac_offset = TSENS_DAC_L2,
     	.clk_div = 6,
-	};
+    };
     temp_sensor_set_config(temp_sensor);
     temp_sensor_start();
     float tsens_out;

--- a/ports/esp32/modesp32.c
+++ b/ports/esp32/modesp32.c
@@ -185,8 +185,8 @@ STATIC MP_DEFINE_CONST_FUN_OBJ_0(esp32_hall_sensor_obj, esp32_hall_sensor);
 STATIC mp_obj_t esp32_raw_temperature(void) {
 
     temp_sensor_config_t temp_sensor = {
-         .dac_offset = TSENS_DAC_L2,
-         .clk_div = 6,
+            .dac_offset = TSENS_DAC_L2,
+            .clk_div = 6,
     };
     temp_sensor_set_config(temp_sensor);
     temp_sensor_start();


### PR DESCRIPTION
The ESP32S3 chips have an internal temperature sensor similar to the ESP32.