### PR TITLE
Fix uninitialised reads in px/lexer and py/objdeque

### DIFF
--- a/py/lexer.c
+++ b/py/lexer.c
@@ -828,6 +828,7 @@ mp_lexer_t *mp_lexer_new(qstr src_name, mp_reader_t reader) {
     lex->indent_level = m_new(uint16_t, lex->alloc_indent_level);
     vstr_init(&lex->vstr, 32);
     #if MICROPY_PY_FSTRINGS
+    lex->fstring_args_idx = 0;
     vstr_init(&lex->fstring_args, 0);
     #endif
 

--- a/py/objdeque.c
+++ b/py/objdeque.c
@@ -64,6 +64,8 @@ STATIC mp_obj_t deque_make_new(const mp_obj_type_t *type, size_t n_args, size_t 
 
     if (n_args > 2) {
         o->flags = mp_obj_get_int(args[2]);
+    } else {
+        o->flags = 0;
     }
 
     return MP_OBJ_FROM_PTR(o);


### PR DESCRIPTION
While debugging with valgrind it found these values that are left uninitialised in the lexer and deque object.