### PR TITLE
shared/runtime/gchelper_native: Fix pointer cast on x86_64.

### DIFF
--- a/shared/runtime/gchelper_native.c
+++ b/shared/runtime/gchelper_native.c
@@ -41,7 +41,7 @@ MP_NOINLINE void gc_helper_collect_regs_and_stack(void) {
     uintptr_t sp = gc_helper_get_regs_and_sp(regs);
 
     // trace the stack, including the registers (since they live on the stack in this function)
-    gc_collect_root((void **)sp, ((uint32_t)MP_STATE_THREAD(stack_top) - sp) / sizeof(uint32_t));
+    gc_collect_root((void **)sp, ((uintptr_t)MP_STATE_THREAD(stack_top) - sp) / sizeof(uintptr_t));
 }
 
 #endif


### PR DESCRIPTION
`gc_helper_collect_regs_and_stack()` is casting a pointer to `uint32_t`; the variables involved are always pointers so it should be using `uintptr_t`.