### PR TITLE
RFC: py/objstr: Expose str_modulo_format() as mp_obj_str_modulo_format().

### DIFF
--- a/py/objstr.c
+++ b/py/objstr.c
@@ -34,10 +34,6 @@
 #include "py/runtime.h"
 #include "py/stackctrl.h"
 
-#if MICROPY_PY_BUILTINS_STR_OP_MODULO
-STATIC mp_obj_t str_modulo_format(mp_obj_t pattern, size_t n_args, const mp_obj_t *args, mp_obj_t dict);
-#endif
-
 STATIC mp_obj_t mp_obj_new_bytes_iterator(mp_obj_t str, mp_obj_iter_buf_t *iter_buf);
 STATIC NORETURN void bad_implicit_conversion(mp_obj_t self_in);
 
@@ -339,7 +335,7 @@ mp_obj_t mp_obj_str_binary_op(mp_binary_op_t op, mp_obj_t lhs_in, mp_obj_t rhs_i
         } else if (mp_obj_is_type(rhs_in, &mp_type_dict)) {
             dict = rhs_in;
         }
-        return str_modulo_format(lhs_in, n_args, args, dict);
+        return mp_obj_str_modulo_format(lhs_in, n_args, args, dict);
         #else
         return MP_OBJ_NULL;
         #endif
@@ -1436,7 +1432,7 @@ mp_obj_t mp_obj_str_format(size_t n_args, const mp_obj_t *args, mp_map_t *kwargs
 MP_DEFINE_CONST_FUN_OBJ_KW(str_format_obj, 1, mp_obj_str_format);
 
 #if MICROPY_PY_BUILTINS_STR_OP_MODULO
-STATIC mp_obj_t str_modulo_format(mp_obj_t pattern, size_t n_args, const mp_obj_t *args, mp_obj_t dict) {
+mp_obj_t mp_obj_str_modulo_format(mp_obj_t pattern, size_t n_args, const mp_obj_t *args, mp_obj_t dict) {
     check_is_str_or_bytes(pattern);
 
     GET_STR_DATA_LEN(pattern, str, len);

--- a/py/objstr.h
+++ b/py/objstr.h
@@ -87,6 +87,9 @@ const byte *mp_obj_str_get_data_no_check(mp_obj_t self_in, size_t *len);
 mp_obj_t mp_obj_str_make_new(const mp_obj_type_t *type_in, size_t n_args, size_t n_kw, const mp_obj_t *args);
 void mp_str_print_json(const mp_print_t *print, const byte *str_data, size_t str_len);
 mp_obj_t mp_obj_str_format(size_t n_args, const mp_obj_t *args, mp_map_t *kwargs);
+#if MICROPY_PY_BUILTINS_STR_OP_MODULO
+mp_obj_t mp_obj_str_modulo_format(mp_obj_t pattern, size_t n_args, const mp_obj_t *args, mp_obj_t dict);
+#endif
 mp_obj_t mp_obj_str_split(size_t n_args, const mp_obj_t *args);
 mp_obj_t mp_obj_new_str_copy(const mp_obj_type_t *type, const byte *data, size_t len); // for type=str, input data must be valid utf-8
 mp_obj_t mp_obj_new_str_of_type(const mp_obj_type_t *type, const byte *data, size_t len); // for type=str, will check utf-8 (raises UnicodeError)


### PR DESCRIPTION
This is needed to be able to write a [logging module](https://github.com/nomis/aurora-coriolis/blob/3a43b5e4ba9be67c318b8ee281b6f33dd2075a84/src/ulogging.cpp#L119-L126) in C.

I can work around this but I'd have to duplicate my args array as a tuple:
```
mp_obj_str_binary_op(MP_BINARY_OP_MODULO, args[0], mp_obj_new_tuple(n_args - 1, &args[1]));
```