### PR TITLE
tools/mpremote: Support {{template expressions}} for exec.

### DIFF
--- a/docs/reference/mpremote.rst
+++ b/docs/reference/mpremote.rst
@@ -99,17 +99,46 @@ The full list of supported commands are:
   - ``--inject-file <file>``, to specify a file to inject at the REPL when
     Ctrl-K is pressed
 
-- evaluate and print the result of a Python expression:
+- evaluate and print the result of a Python expression on the connected device:
 
   .. code-block:: bash
 
-      $ mpremote eval <string>
+      $ mpremote eval [-e] <string>
 
-- execute the given Python code:
+- execute the given Python code on the connected device:
 
   .. code-block:: bash
 
-      $ mpremote exec <string>
+      $ mpremote exec [-e] <string>
+
+  If the -e option is used, the string can contain one or more expressions enclosed in ``{{ }}``. These {{expressions}} are evaluated on the 
+  host, and replaced by the result(s) before sending the command to the device. 
+  This is used by the setrtc command to set the RTC from the host system time, but can also be used for other purposes.
+
+  The eval is executed with a limited scope, so that the following variables are available:
+    - os, sys, time, datetime
+    - device_name, the name  of the serial port used to connect to the device 
+    - mount_dir, the local directory mounted to the device (if any)
+
+  .. code-block:: bash
+
+      $ mpremote mount ./data  exec -e "import os; print(f'port {{device_name}} connects to {os.uname()[1:3]}, mounted directory: {{host_dir}}')"
+      # prints the host port and the hosts's mounted directory 
+      # import os; print(f'port COM6 connects to {os.uname()}.\nHost directory: ./data')
+      # port COM6 connects to ('pyboard', '1.19.1'), mounted directory: ./data
+
+      $ mpremote exec -e "import time,os; print(os.uname()[1:3],'\n', time.localtime(),'\n', {{time.localtime()[0:8] }})"
+      # compare local time with RTC time
+
+  .. code-block:: bash
+
+      $ mpremote eval -e "f'port {{device_name}} is connected'"      
+
+- set the real time clock (machine.RTC) to the hosts's current time:
+
+  .. code-block:: bash
+
+      $ mpremote setrtc
 
 - run a script from the local filesystem:
 

--- a/tools/mpremote/mpremote/main.py
+++ b/tools/mpremote/mpremote/main.py
@@ -140,6 +140,9 @@ def argparse_repl():
 def argparse_eval():
     cmd_parser = argparse.ArgumentParser(description="evaluate and print the string")
     cmd_parser.add_argument("expr", nargs=1, help="expression to execute")
+    cmd_parser.add_argument(
+        "-e", "--eval", action="store_true", help="evaluate expressions between {{ }}"
+    )
     return cmd_parser
 
 
@@ -149,6 +152,9 @@ def argparse_exec():
         cmd_parser, "follow", "f", True, "follow output until the expression completes (default)"
     )
     cmd_parser.add_argument("expr", nargs=1, help="expression to execute")
+    cmd_parser.add_argument(
+        "-e", "--eval", action="store_true", help="evaluate expressions between {{ }}"
+    )
     return cmd_parser
 
 
@@ -311,7 +317,9 @@ _BUILTIN_COMMAND_EXPANSIONS = {
     },
     "setrtc": [
         "exec",
-        "import machine; machine.RTC().datetime((2020, 1, 1, 0, 10, 0, 0, 0))",
+        "--eval",
+        # transpose cpython datetime to micropython RTC datetime
+        "import machine; machine.RTC().datetime({{time.localtime()[0:3]+(time.localtime().tm_wday,)+time.localtime()[3:6]+(datetime.datetime.now().timetuple()[6],)}})",
     ],
     "--help": "help",
     "--version": "version",


### PR DESCRIPTION
Implements the possibility to create `mpremote eval` command sequences of which commands to be exec-ed can contain elements between double curly brackets `{{ }}`. 
These elements  are  `eval`-ed om the host, and replaced by the outcome.
if the eval results in an error, this is printed ( not raised), but the command is still attempted to be executed.

One example of this is to set the time on a micropython board (close) to the local time on the host.
```
    "setrtc": [
        "exec",
        "-e"
        "import machine; machine.RTC().datetime({{datetime.datetime.now().timetuple()[0:3]+(datetime.datetime.now().timetuple()[6],)+ datetime.datetime.now().timetuple()[3:6]+(0,)}})",
    ],
```
- the section between {{ }} is evaluated , and replaced by its result : `(2022, 11, 6, 6, 23, 6, 51, 0)`
 - the resulting command is then sent to the remote micropython host and executed
   `import machine; machine.RTC().datetime((2022, 11, 6, 6, 23, 6, 51, 0))`

Notes: 
 - replacement is only performed if the `-e` / `--eval` option is specified 
 - the CPython datetime tuple is structured differently from what machine.RTC.datetime expects. 
   the code to reformat this may not be optimal
