### PR TITLE
py/objarray: Detect bytearray(str) without an encoding.

### DIFF
--- a/py/objarray.c
+++ b/py/objarray.c
@@ -192,6 +192,14 @@ STATIC mp_obj_t bytearray_make_new(const mp_obj_type_t *type_in, size_t n_args, 
         return MP_OBJ_FROM_PTR(o);
     } else {
         // 1 arg: construct the bytearray from that
+        if (mp_obj_is_str(args[0]) && n_args == 1) {
+            #if MICROPY_ERROR_REPORTING <= MICROPY_ERROR_REPORTING_TERSE
+            // Match bytes_make_new.
+            mp_raise_TypeError(MP_ERROR_TEXT("wrong number of arguments"));
+            #else
+            mp_raise_TypeError(MP_ERROR_TEXT("string argument without an encoding"));
+            #endif
+        }
         return array_construct(BYTEARRAY_TYPECODE, args[0]);
     }
 }

--- a/py/objstr.c
+++ b/py/objstr.c
@@ -233,7 +233,11 @@ STATIC mp_obj_t bytes_make_new(const mp_obj_type_t *type_in, size_t n_args, size
 
     if (mp_obj_is_str(args[0])) {
         if (n_args < 2 || n_args > 3) {
+            #if MICROPY_ERROR_REPORTING <= MICROPY_ERROR_REPORTING_TERSE
             goto wrong_args;
+            #else
+            mp_raise_TypeError(MP_ERROR_TEXT("string argument without an encoding"));
+            #endif
         }
         GET_STR_DATA_LEN(args[0], str_data, str_len);
         GET_STR_HASH(args[0], str_hash);

--- a/tests/basics/bytearray_construct.py
+++ b/tests/basics/bytearray_construct.py
@@ -5,3 +5,8 @@ print(bytearray('1234', 'utf-8'))
 print(bytearray('12345', 'utf-8', 'strict'))
 print(bytearray((1, 2)))
 print(bytearray([1, 2]))
+
+try:
+    print(bytearray('1234'))
+except TypeError:
+    print("TypeError")

--- a/tests/micropython/viper_addr.py
+++ b/tests/micropython/viper_addr.py
@@ -21,7 +21,7 @@ def memsum(src: ptr8, n: int) -> int:
 
 
 # create array and get its address
-ar = bytearray("0000")
+ar = bytearray(b"0000")
 addr = get_addr(ar)
 print(type(ar))
 print(type(addr))


### PR DESCRIPTION
This prevents a very subtle bug caused by writing e.g. `bytearray('\xfd')` which gives you `(0xc3, 0xbd)`. CPython doesn't allow you to do this.

Reported in https://github.com/orgs/micropython/discussions/9844

Unfortunately it's +60 bytes. Can undo the change to objstr.c and make it also use the `"wrong number of arguments"` error, but that only gets it down to +44 bytes. Could also hide this behind `MICROPY_CPYTHON_COMPAT`.

_This work was funded through GitHub Sponsors._
