### PR TITLE
Add stateless auto configuration for IPv4

### DIFF
--- a/docs/library/network.rst
+++ b/docs/library/network.rst
@@ -124,6 +124,11 @@ parameter should be `id`.
          server via DHCP. This method does not block and wait for an address
          to be obtained. To check if an address was obtained, use the read-only
          property ``has_dhcp4``.
+       * ``autoconf4`` (``True/False``) obtain an IPv4 address randomly in the
+         169.254.0.0/16 address space. This method does not block and wait for
+         an address to be selected and confirmed to be unused on the network. To
+         check if an address has been selected, use the read-only property
+         ``has_autoconf4``.
        * ``gw4`` Get/set the IPv4 default-gateway.
        * ``dhcp6`` (``True/False``) obtain a DNS server via stateless DHCPv6.
          Obtaining IP Addresses via DHCPv6 is currently not implemented.


### PR DESCRIPTION
Auto IP configuration is a method of picking a random IP address in the 169.254.0.0/16 subnet. It is analogous to the IPv6 stateless autoconfiguration on link-local and other interfaces.

I might be the only one who would like this sort of thing, but I'm looking to implement a setup with lots of the devices on the network and do not want to use a DHCP server and also do not care what address will be used by the devices because they will connect to a server on the local, layer-2 network with a well known address (like, e.g. 169.254.0.1/16).

Currently only implemented for the LWIP software IP stack.