### PR TITLE
ports/esp32: Add 32mb partition templates.

### DIFF
--- a/ports/esp32/partitions-32MiB-ota.csv
+++ b/ports/esp32/partitions-32MiB-ota.csv
@@ -1,0 +1,10 @@
+# Partition table for MicroPython with OTA support using 32MB flash
+# Notes: the offset of the partition table itself is set in
+# $IDF_PATH/components/partition_table/Kconfig.projbuild.
+# Name,   Type, SubType, Offset,   Size,     Flags
+nvs,      data, nvs,     0x9000,   0x4000,
+otadata,  data, ota,     0xd000,   0x2000,
+phy_init, data, phy,     0xf000,   0x1000,
+ota_0,    app,  ota_0,   0x10000,  0x270000,
+ota_1,    app,  ota_1,   0x280000, 0x270000,
+vfs,      data, fat,     0x4f0000, 0x1B10000,

--- a/ports/esp32/partitions-32MiB.csv
+++ b/ports/esp32/partitions-32MiB.csv
@@ -1,0 +1,7 @@
+# Notes: the offset of the partition table itself is set in
+# $IDF_PATH/components/partition_table/Kconfig.projbuild.
+# Name,   Type, SubType, Offset,  Size, Flags
+nvs,      data, nvs,     0x9000,  0x6000,
+phy_init, data, phy,     0xf000,  0x1000,
+factory,  app,  factory, 0x10000, 0x1F0000,
+vfs,      data, fat,     0x200000, 0x1E00000,


### PR DESCRIPTION
Adding 32mb partition table templates for esp32s3-wroom-2 modules.

Signed-off-by: Patrick <patrick@joytech.com.au>