### PR TITLE
lib/libm: Use __asm__ instead of asm.

### DIFF
--- a/lib/libm/thumb_vfp_sqrtf.c
+++ b/lib/libm/thumb_vfp_sqrtf.c
@@ -3,7 +3,7 @@
 #include <math.h>
 
 float sqrtf(float x) {
-    asm volatile (
+    __asm__ volatile (
             "vsqrt.f32  %[r], %[x]\n"
             : [r] "=t" (x)
             : [x] "t"  (x));

--- a/lib/libm_dbl/thumb_vfp_sqrt.c
+++ b/lib/libm_dbl/thumb_vfp_sqrt.c
@@ -2,7 +2,7 @@
 
 double sqrt(double x) {
     double ret;
-    asm volatile (
+    __asm__ volatile (
             "vsqrt.f64  %P0, %P1\n"
             : "=w" (ret)
             : "w"  (x));


### PR DESCRIPTION
`asm` is not part of the C standard and causes a complier error when `-std=c99` is used. `__asm__` is the recommended alternative.

https://gcc.gnu.org/onlinedocs/gcc/extensions-to-the-c-language-family/alternate-keywords.html
