### PR TITLE
ports/webassembly/library: Make use of CustomEvent detail property.

### DIFF
--- a/ports/webassembly/README.md
+++ b/ports/webassembly/README.md
@@ -70,7 +70,7 @@ something to stdout.  The following code demonstrates basic functionality:
     <script>
       document.addEventListener("micropython-print", function(e) {
         let output = document.getElementById("micropython-stdout");
-        output.innerText += e.data;
+        output.innerText += e.detail;
       }, false);
 
       var mp_js_startup = Module["onRuntimeInitialized"];

--- a/ports/webassembly/library.js
+++ b/ports/webassembly/library.js
@@ -33,8 +33,7 @@ mergeInto(LibraryManager.library, {
                 process.stdout.write(b);
             } else {
                 var c = String.fromCharCode(getValue(ptr + i, 'i8'));
-                var printEvent = new CustomEvent('micropython-print');
-                printEvent.data = c;
+                var printEvent = new CustomEvent('micropython-print', { detail: c });
                 document.dispatchEvent(printEvent);
             }
         }


### PR DESCRIPTION
This changes the CustomEvent for stdout to use the existing `detail` property of CustomEvent instead of adding a `data` property.

Followup to https://github.com/micropython/micropython/pull/9752#discussion_r1015542831

cc @ntoll 