### PR TITLE
ports/stm32: Downgrade SPIHandle definitions to static.

### DIFF
--- a/ports/stm32/spi.c
+++ b/ports/stm32/spi.c
@@ -47,22 +47,22 @@
 // SPI6_RX: DMA2_Stream6.CHANNEL_1
 
 #if defined(MICROPY_HW_SPI1_SCK)
-SPI_HandleTypeDef SPIHandle1 = {.Instance = NULL};
+STATIC SPI_HandleTypeDef SPIHandle1 = {.Instance = NULL};
 #endif
 #if defined(MICROPY_HW_SPI2_SCK)
-SPI_HandleTypeDef SPIHandle2 = {.Instance = NULL};
+STATIC SPI_HandleTypeDef SPIHandle2 = {.Instance = NULL};
 #endif
 #if defined(MICROPY_HW_SPI3_SCK)
-SPI_HandleTypeDef SPIHandle3 = {.Instance = NULL};
+STATIC SPI_HandleTypeDef SPIHandle3 = {.Instance = NULL};
 #endif
 #if defined(MICROPY_HW_SPI4_SCK)
-SPI_HandleTypeDef SPIHandle4 = {.Instance = NULL};
+STATIC SPI_HandleTypeDef SPIHandle4 = {.Instance = NULL};
 #endif
 #if defined(MICROPY_HW_SPI5_SCK)
-SPI_HandleTypeDef SPIHandle5 = {.Instance = NULL};
+STATIC SPI_HandleTypeDef SPIHandle5 = {.Instance = NULL};
 #endif
 #if defined(MICROPY_HW_SPI6_SCK)
-SPI_HandleTypeDef SPIHandle6 = {.Instance = NULL};
+STATIC SPI_HandleTypeDef SPIHandle6 = {.Instance = NULL};
 #endif
 
 const spi_t spi_obj[6] = {

--- a/ports/stm32/spi.h
+++ b/ports/stm32/spi.h
@@ -54,13 +54,6 @@ typedef struct _machine_hard_spi_obj_t {
     const spi_t *spi;
 } machine_hard_spi_obj_t;
 
-extern SPI_HandleTypeDef SPIHandle1;
-extern SPI_HandleTypeDef SPIHandle2;
-extern SPI_HandleTypeDef SPIHandle3;
-extern SPI_HandleTypeDef SPIHandle4;
-extern SPI_HandleTypeDef SPIHandle5;
-extern SPI_HandleTypeDef SPIHandle6;
-
 extern const spi_t spi_obj[6];
 
 extern const mp_spi_proto_t spi_proto;


### PR DESCRIPTION
Small cleanup. These seem unused outside of spi.c, spi_obj[] array is the expected way to iterate these.

This work was funded through GitHub Sponsors.
