### PR TITLE
esp32: Enable BLE for GENERIC_S3_SPIRAM

### DIFF
--- a/ports/esp32/boards/GENERIC_S3_SPIRAM/mpconfigboard.cmake
+++ b/ports/esp32/boards/GENERIC_S3_SPIRAM/mpconfigboard.cmake
@@ -3,6 +3,7 @@ set(IDF_TARGET esp32s3)
 set(SDKCONFIG_DEFAULTS
     boards/sdkconfig.base
     boards/sdkconfig.usb
+    boards/sdkconfig.ble   
     boards/sdkconfig.spiram_sx
     boards/GENERIC_S3_SPIRAM/sdkconfig.board
 )


### PR DESCRIPTION
BLE support is missing in esp32 GENERIC_S3_SPIRAM while it's enabled in GENERIC_S3, UM_FEATHERS3 or UM_PROS3