### PR TITLE
esp32: GENERIC_S3_SPIRAM add BLE support.

### DIFF
--- a/ports/esp32/boards/GENERIC_S3_SPIRAM/mpconfigboard.cmake
+++ b/ports/esp32/boards/GENERIC_S3_SPIRAM/mpconfigboard.cmake
@@ -3,6 +3,7 @@ set(IDF_TARGET esp32s3)
 set(SDKCONFIG_DEFAULTS
     boards/sdkconfig.base
     boards/sdkconfig.usb
+    boards/sdkconfig.ble
     boards/sdkconfig.spiram_sx
     boards/GENERIC_S3_SPIRAM/sdkconfig.board
 )


### PR DESCRIPTION
GENERIC_S3_SPIRAM has BLE support disabled while GENERIC_S3, UM_FEATHERS3 or UM_PROS3 has BLE enabled