### PR TITLE
py/objexcept: Add uncatchable SystemAbort exception.

### DIFF
--- a/py/mpconfig.h
+++ b/py/mpconfig.h
@@ -659,7 +659,8 @@
 #endif
 
 // Whether to provide the SystemAbort exception, used to exit MicroPython
-// even if user code catches all exceptions.
+// even if user code catches all exceptions. This also provides
+// mp_sched_system_exit_or_abort() to schedule the mp_system_exception object.
 #ifndef MICROPY_ENABLE_SYSTEM_ABORT
 #define MICROPY_ENABLE_SYSTEM_ABORT (0)
 #endif

--- a/py/mpconfig.h
+++ b/py/mpconfig.h
@@ -658,6 +658,12 @@
 #define MICROPY_KBD_EXCEPTION (MICROPY_CONFIG_ROM_LEVEL_AT_LEAST_EXTRA_FEATURES)
 #endif
 
+// Whether to provide the SystemAbort exception, used to exit MicroPython
+// even if user code catches all exceptions.
+#ifndef MICROPY_ENABLE_SYSTEM_ABORT
+#define MICROPY_ENABLE_SYSTEM_ABORT (0)
+#endif
+
 // Prefer to raise KeyboardInterrupt asynchronously (from signal or interrupt
 // handler) - if supported by a particular port.
 #ifndef MICROPY_ASYNC_KBD_INTR

--- a/py/mpstate.h
+++ b/py/mpstate.h
@@ -165,6 +165,11 @@ typedef struct _mp_state_vm_t {
     mp_obj_exception_t mp_kbd_exception;
     #endif
 
+    #if MICROPY_ENABLE_SYSTEM_ABORT
+    // exception object of type SystemExit or SystemAbort
+    mp_obj_exception_t mp_system_exception;
+    #endif
+
     // dictionary with loaded modules (may be exposed as sys.modules)
     mp_obj_dict_t mp_loaded_modules_dict;
 

--- a/py/obj.h
+++ b/py/obj.h
@@ -860,6 +860,9 @@ extern const mp_obj_type_t mp_type_UnicodeError;
 extern const mp_obj_type_t mp_type_ValueError;
 extern const mp_obj_type_t mp_type_ViperTypeError;
 extern const mp_obj_type_t mp_type_ZeroDivisionError;
+#if MICROPY_ENABLE_SYSTEM_ABORT
+extern const mp_obj_type_t mp_type_SystemAbort;
+#endif
 
 // Constant objects, globally accessible: None, False, True
 // These should always be accessed via the below macros.

--- a/py/objexcept.c
+++ b/py/objexcept.c
@@ -376,6 +376,12 @@ MP_DEFINE_EXCEPTION(Exception, BaseException)
     MP_DEFINE_EXCEPTION(ResourceWarning, Warning)
     */
 
+#if MICROPY_ENABLE_SYSTEM_ABORT
+// Exception that can't be raised or caught by user code, not even with a
+// bare except. Can be used to force MicroPython to exit from C code.
+MP_DEFINE_EXCEPTION(SystemAbort, BaseException)
+#endif
+
 // *FORMAT-ON*
 
 mp_obj_t mp_obj_new_exception(const mp_obj_type_t *exc_type) {

--- a/py/objexcept.c
+++ b/py/objexcept.c
@@ -377,8 +377,9 @@ MP_DEFINE_EXCEPTION(Exception, BaseException)
     */
 
 #if MICROPY_ENABLE_SYSTEM_ABORT
-// Exception that can't be raised or caught by user code, not even with a
-// bare except. Can be used to force MicroPython to exit from C code.
+// Exception that can't be raised or caught by user code, not even with a bare
+// except. Do not raise directly but use mp_sched_system_exit_or_abort(true) to
+// schedule it on the main thread.
 MP_DEFINE_EXCEPTION(SystemAbort, BaseException)
 #endif
 

--- a/py/runtime.c
+++ b/py/runtime.c
@@ -95,6 +95,14 @@ void mp_init(void) {
     MP_STATE_VM(mp_kbd_exception).args = (mp_obj_tuple_t *)&mp_const_empty_tuple_obj;
     #endif
 
+    #if MICROPY_ENABLE_SYSTEM_ABORT
+    // initialise the exception object for raising SystemExit or SystemAbort
+    MP_STATE_VM(mp_system_exception).traceback_alloc = 0;
+    MP_STATE_VM(mp_system_exception).traceback_len = 0;
+    MP_STATE_VM(mp_system_exception).traceback_data = NULL;
+    MP_STATE_VM(mp_system_exception).args = (mp_obj_tuple_t *)&mp_const_empty_tuple_obj;
+    #endif
+
     #if MICROPY_ENABLE_COMPILER
     // optimization disabled by default
     MP_STATE_VM(mp_optimise_value) = 0;

--- a/py/runtime.h
+++ b/py/runtime.h
@@ -75,6 +75,9 @@ void mp_deinit(void);
 
 void mp_sched_exception(mp_obj_t exc);
 void mp_sched_keyboard_interrupt(void);
+#if MICROPY_ENABLE_SYSTEM_ABORT
+void mp_sched_system_exit_or_abort(bool abort);
+#endif
 void mp_handle_pending(bool raise_exc);
 
 #if MICROPY_ENABLE_SCHEDULER

--- a/py/scheduler.c
+++ b/py/scheduler.c
@@ -51,6 +51,17 @@ void MICROPY_WRAP_MP_SCHED_KEYBOARD_INTERRUPT(mp_sched_keyboard_interrupt)(void)
 }
 #endif
 
+#if MICROPY_ENABLE_SYSTEM_ABORT
+// Schedules SystemExit or SystemAbort on the main thread. Can be used by
+// async sources to exit MicroPython. Use abort=true if the MicroPython script
+// must not be able to catch it, not even with a bare except.
+void MICROPY_WRAP_MP_SCHED_EXCEPTION(mp_sched_system_exit_or_abort)(bool abort) {
+    MP_STATE_VM(mp_system_exception).base.type = abort ?
+        &mp_type_SystemAbort : &mp_type_SystemExit;
+    mp_sched_exception(MP_OBJ_FROM_PTR(&MP_STATE_VM(mp_system_exception)));
+}
+#endif
+
 #if MICROPY_ENABLE_SCHEDULER
 
 #define IDX_MASK(i) ((i) & (MICROPY_SCHEDULER_DEPTH - 1))

--- a/py/vm.c
+++ b/py/vm.c
@@ -1441,8 +1441,12 @@ unwind_loop:
                 POP_EXC_BLOCK();
             }
 
-            if (exc_sp >= exc_stack) {
-                // catch exception and pass to byte code
+            if (exc_sp >= exc_stack
+            #if MICROPY_ENABLE_SYSTEM_ABORT
+            && !mp_obj_exception_match(MP_OBJ_FROM_PTR(nlr.ret_val), MP_OBJ_FROM_PTR(&mp_type_SystemAbort))
+            #endif
+            ) {
+                // catch exception (but not SystemAbort) and pass to byte code
                 code_state->ip = exc_sp->handler;
                 mp_obj_t *sp = MP_TAGPTR_PTR(exc_sp->val_sp);
                 // save this exception in the stack so it can be used in a reraise, if needed


### PR DESCRIPTION
This adds an exception type that forces MicroPython to exit even if the user MicroPython script catches all exceptions.

This exception can be raised by C code to force MicroPython to exit for safety reasons, such as very low battery or very high temperatures.

I did not add it to the builtins dictionary to avoid adding new non-Python features to the language so it's just for internal use. Should there be a feature guard to avoid increasing codesize?

This is my first time looking around in `vm.c` so I'm not quite sure this is the right way to do it. Feel free to consider this as a draft for alternative implementations.

-----

**Context**

This issue was briefly discussed in the most recent MicroPython meetup. Damien's comments are at [26:00 onwards](https://youtu.be/M4m2V6FFuA8?t=1558).

![image](https://user-images.githubusercontent.com/12326241/201668040-2accfb24-7cc8-40dd-a132-82f6ba7e2767.png)
