### PR TITLE
Docs: Describe restriction on ThreadSafeFlag.

### DIFF
--- a/docs/library/uasyncio.rst
+++ b/docs/library/uasyncio.rst
@@ -149,7 +149,8 @@ class ThreadSafeFlag
 
     Create a new flag which can be used to synchronise a task with code running
     outside the uasyncio loop, such as other threads, IRQs, or scheduler
-    callbacks.  Flags start in the cleared state.
+    callbacks.  Flags start in the cleared state.  The class does not currently
+    work under the Unix build of MicroPython.
 
 .. method:: ThreadSafeFlag.set()
 


### PR DESCRIPTION
As per https://github.com/micropython/micropython/issues/7965 this class does not work on the Unix build.