### PR TITLE
Topic: Add I2C1 and I2C2 to the NUCLEO-F429ZI.

### DIFF
--- a/ports/stm32/boards/NUCLEO_F429ZI/mpconfigboard.h
+++ b/ports/stm32/boards/NUCLEO_F429ZI/mpconfigboard.h
@@ -40,6 +40,12 @@
 #define MICROPY_HW_UART_REPL_BAUD   115200
 
 // I2C buses
+#define MICROPY_HW_I2C1_SCL (pin_B8)
+#define MICROPY_HW_I2C1_SDA (pin_B9)
+
+#define MICROPY_HW_I2C2_SCL (pin_B10)
+#define MICROPY_HW_I2C2_SDA (pin_B11)
+
 #define MICROPY_HW_I2C3_SCL (pin_A8)
 #define MICROPY_HW_I2C3_SDA (pin_C9)
 


### PR DESCRIPTION
Path: ports/stm32/boards/NUCLEO_F429ZI/mpconfigboard.h

Signed-off-by: Dale Weber <hybotics.sd@gmail.com>.