### PR TITLE
extmod/extmod.cmake: Add MICROPY_PY_BTREE compiler definition.

### DIFF
--- a/extmod/extmod.cmake
+++ b/extmod/extmod.cmake
@@ -93,6 +93,7 @@ if(MICROPY_PY_BTREE)
     )
 
     list(APPEND MICROPY_DEF_CORE
+        MICROPY_PY_BTREE=1
         __DBINTERFACE_PRIVATE=1
         "virt_fd_t=void*"
     )

--- a/ports/esp32/mpconfigport.h
+++ b/ports/esp32/mpconfigport.h
@@ -123,7 +123,6 @@
 #define MICROPY_PY_USSL_FINALISER           (1)
 #define MICROPY_PY_UWEBSOCKET               (1)
 #define MICROPY_PY_WEBREPL                  (1)
-#define MICROPY_PY_BTREE                    (1)
 #define MICROPY_PY_ONEWIRE                  (1)
 #define MICROPY_PY_UPLATFORM                (1)
 #define MICROPY_PY_USOCKET_EVENTS           (MICROPY_PY_WEBREPL)


### PR DESCRIPTION
Instead of defining `MICROPY_PY_BTREE` in `mpconfigport.h` we can define it via CMake similar to how other ports that use Makefiles define it in `mpconfigport.mk`.
