### PR TITLE
ports/README.md: Update with Docker build instructions.

### DIFF
--- a/ports/esp32/README.md
+++ b/ports/esp32/README.md
@@ -1,5 +1,4 @@
-MicroPython port to the ESP32
-=============================
+# MicroPython port to the ESP32
 
 This is a port of MicroPython to the Espressif ESP32 series of
 microcontrollers.  It uses the ESP-IDF framework and MicroPython runs as
@@ -19,8 +18,9 @@ Supported features include:
 
 Initial development of this ESP32 port was sponsored in part by Microbric Pty Ltd.
 
-Setting up ESP-IDF and the build environment
---------------------------------------------
+## Build instructions
+
+### Setting up ESP-IDF and the build environment
 
 MicroPython on ESP32 requires the Espressif IDF version 4 (IoT development
 framework, aka SDK).  The ESP-IDF includes the libraries and RTOS needed to
@@ -80,8 +80,7 @@ please ensure you are using the following required IDF versions:
 - ESP32-S3 currently requires `v4.4` or later.
 - ESP32-S2 and ESP32-C3 require `v4.3.1` or later.
 
-Building the firmware
----------------------
+### Building the firmware
 
 The MicroPython cross-compiler must be built to pre-compile some of the
 built-in scripts to bytecode.  This can be done by (from the root of
@@ -147,8 +146,20 @@ $ idf.py -D MICROPY_BOARD=GENERIC_SPIRAM build
 $ idf.py flash
 ```
 
-Getting a Python prompt on the device
--------------------------------------
+### Container builds
+
+An alternative to building directly on your host computer is to use containers.
+Docker is a popular containerization system and can be used to build MicroPython
+without the need to install anything - except Docker - on your host system.
+
+Create a clone of MicroPython on your host but build, in a similar way to the
+description above, inside the container:
+
+```bash
+$ docker run -ti --rm -v /your/micropython/clone:/code -w /code espressif/idf:release-v4.4 bash -c "make -C mpy-cross && make -C ports/esp32 submodules all BOARD=GENERIC_SPIRAM"
+```
+
+## Getting a Python prompt on the device
 
 You can get a prompt via the serial port, via UART0, which is the same UART
 that is used for programming the firmware.  The baudrate for the REPL is
@@ -166,8 +177,7 @@ $ miniterm.py /dev/ttyUSB0 115200
 
 You can also use `idf.py monitor`.
 
-Configuring the WiFi and using the board
-----------------------------------------
+## Configuring the WiFi and using the board
 
 The ESP32 port is designed to be (almost) equivalent to the ESP8266 in
 terms of the modules and user-facing API.  There are some small differences,
@@ -205,8 +215,7 @@ import machine
 antenna = machine.Pin(16, machine.Pin.OUT, value=0)
 ```
 
-Defining a custom ESP32 board
------------------------------
+## Defining a custom ESP32 board
 
 The default ESP-IDF configuration settings are provided by the `GENERIC`
 board definition in the directory `boards/GENERIC`. For a custom configuration
@@ -222,9 +231,7 @@ also define custom ones in your board directory.
 
 See existing board definitions for further examples of configuration.
 
-Configuration
-Troubleshooting
----------------
+## Configuration Troubleshooting
 
 * Continuous reboots after programming: Ensure `CONFIG_ESPTOOLPY_FLASHMODE` is
   correct for your board (e.g. ESP-WROOM-32 should be DIO). Then perform a

--- a/ports/mimxrt/README.md
+++ b/ports/mimxrt/README.md
@@ -69,6 +69,19 @@ Then to build the board's firmware run:
 The above command should produce binary images in the `build-SEEED_ARCH_MIX/`
 subdirectory (or the equivalent directory for the board specified).
 
+## Container builds
+
+An alternative to building directly on your host computer is to use containers.
+Docker is a popular containerization system and can be used to build MicroPython
+without the need to install anything - except Docker - on your host system.
+
+Create a clone of MicroPython on your host but build, in a similar way to the
+description above, inside the container:
+
+```bash
+$ docker run -ti --rm -v /your/micropython/clone:/code -w /code micropython/build-micropython-arm bash -c "make -C mpy-cross && make -C ports/mimxrt submodules all BOARD=SEEED_ARCH_MIX"
+```
+
 ## Flashing
 
 Deploy the firmware following the instructions here

--- a/ports/nrf/README.md
+++ b/ports/nrf/README.md
@@ -129,6 +129,19 @@ For example:
 
     make BOARD=pca10056 MICROPY_VFS_LFS2=1
 
+## Container builds
+
+An alternative to building directly on your host computer is to use containers.
+Docker is a popular containerization system and can be used to build MicroPython
+without the need to install anything - except Docker - on your host system.
+
+Create a clone of MicroPython on your host but build, in a similar way to the
+description above, inside the container:
+
+```bash
+$ docker run -ti --rm -v /your/micropython/clone:/code -w /code micropython/build-micropython-arm bash -c "make -C mpy-cross && make -C ports/nrf submodules all BOARD=pca10040"
+```
+
 ## Set file system size
 
 The size of the file system on the internal flash is configured by the linker

--- a/ports/renesas-ra/README.md
+++ b/ports/renesas-ra/README.md
@@ -58,6 +58,19 @@ passed as the argument to `BOARD=`; for example `RA4M1_CLICKER`, `RA4M1_EK`,
 The above command should produce binary images `firmware.hex` in the
 build-RA6M2_EK/` subdirectory (or the equivalent directory for the board specified).
 
+## Container builds
+
+An alternative to building directly on your host computer is to use containers.
+Docker is a popular containerization system and can be used to build MicroPython
+without the need to install anything - except Docker - on your host system.
+
+Create a clone of MicroPython on your host but build, in a similar way to the
+description above, inside the container:
+
+```bash
+$ docker run -ti --rm -v /your/micropython/clone:/code -w /code micropython/build-micropython-arm bash -c "make -C mpy-cross && make -C ports/renesas-ra submodules all BOARD=RA6M2_EK"
+```
+
 ## Supported/Unsupprted funtions
 Please refer to the `renesas-ra` quick reference.
 

--- a/ports/rp2/README.md
+++ b/ports/rp2/README.md
@@ -44,6 +44,19 @@ pass the board name to the build; e.g. for Raspberry Pi Pico W:
     $ make BOARD=PICO_W clean
     $ make BOARD=PICO_W
 
+## Container builds
+
+An alternative to building directly on your host computer is to use containers.
+Docker is a popular containerization system and can be used to build MicroPython
+without the need to install anything - except Docker - on your host system.
+
+Create a clone of MicroPython on your host but build, in a similar way to the
+description above, inside the container:
+
+```bash
+$ docker run -ti --rm -v /your/micropython/clone:/code -w /code micropython/build-micropython-arm bash -c "make -C mpy-cross && make -C ports/rp2 submodules all BOARD=PICO_W"
+```
+
 ## Deploying firmware to the device
 
 Firmware can be deployed to the device by putting it into bootloader mode

--- a/ports/samd/README.md
+++ b/ports/samd/README.md
@@ -52,6 +52,19 @@ The above command produces binary images in the
 `build-ADAFRUIT_ITSYBITSY_M4_EXPRESS/` subdirectory (or the equivalent
 directory for the board specified).
 
+## Container builds
+
+An alternative to building directly on your host computer is to use containers.
+Docker is a popular containerization system and can be used to build MicroPython
+without the need to install anything - except Docker - on your host system.
+
+Create a clone of MicroPython on your host but build, in a similar way to the
+description above, inside the container:
+
+```bash
+$ docker run -ti --rm -v /your/micropython/clone:/code -w /code micropython/build-micropython-arm bash -c "make -C mpy-cross && make -C ports/samd submodules all BOARD=ADAFRUIT_ITSYBITSY_M4_EXPRESS"
+```
+
 ### Flashing the Firmware
 
 Most SAMD21 and SAMD51 boards have a built in firmware loader. To start it, push

--- a/ports/stm32/README.md
+++ b/ports/stm32/README.md
@@ -1,5 +1,4 @@
-MicroPython port to STM32 MCUs
-==============================
+# MicroPython port to STM32 MCUs
 
 This directory contains the port of MicroPython to ST's line of STM32
 microcontrollers.  Supported MCU series are: STM32F0, STM32F4, STM32F7,
@@ -22,8 +21,7 @@ not work and none of the advanced features of the STM32H7 are yet supported,
 such as the clock tree.  At this point the STM32H7 should be considered as a
 fast version of the STM32F7.
 
-Build instructions
-------------------
+## Build instructions
 
 Before building the firmware for a given board the MicroPython cross-compiler
 must be built; it will be used to pre-compile some of the built-in scripts to
@@ -85,6 +83,19 @@ To disable LTO, pass `LTO=0` in the same way.
 
 Note that `make clean BOARD=boardname` will be needed before changing the `LTO`
 setting of a firmware that is already built.
+
+## Container builds
+
+An alternative to building directly on your host computer is to use containers.
+Docker is a popular containerization system and can be used to build MicroPython
+without the need to install anything - except Docker - on your host system.
+
+Create a clone of MicroPython on your host but build, in a similar way to the
+description above, inside the container:
+
+```bash
+$ docker run -ti --rm -v /your/micropython/clone:/code -w /code micropython/build-micropython-arm bash -c "make -C mpy-cross && make -C ports/samd submodules all BOARD=PYBV11"
+```
 
 ### Flashing the Firmware using DFU mode
 

--- a/ports/unix/README.md
+++ b/ports/unix/README.md
@@ -72,3 +72,16 @@ deplibs`. To actually enable/disable use of dependencies, edit the
 `ports/unix/mpconfigport.mk` file, which has inline descriptions of the
 options. For example, to build the SSL module, `MICROPY_PY_USSL` should be
 set to 1.
+
+## Container builds
+
+An alternative to building directly on your host computer is to use containers.
+Docker is a popular containerization system and can be used to build MicroPython
+without the need to install anything - except Docker - on your host system.
+
+Create a clone of MicroPython on your host but build, in a similar way to the
+description above, inside the container:
+
+```bash
+$ docker run -ti --rm -v /your/micropython/clone:/code -w /code micropython/build-micropython-unix bash -c "make -C mpy-cross && make -C ports/unix submodules all -j4"
+```

--- a/ports/webassembly/README.md
+++ b/ports/webassembly/README.md
@@ -25,6 +25,18 @@ To generate the minified file micropython.min.js, run:
 
     $ make min
 
+Container builds
+----------------
+
+An alternative to building directly on your host computer is to use containers.
+Docker is a popular containerization system and can be used to build MicroPython
+without the need to install anything - except Docker - on your host system.
+
+Create a clone of MicroPython on your host but build, in a similar way to the
+description above, inside the container:
+
+    $ docker run -ti --rm -v /your/micropython/clone:/code -w /code emscripten/emsdk bash -c "make -C ports/webassembly all"
+
 Running with Node.js
 --------------------
 
@@ -51,6 +63,14 @@ var mp_js = require('./build/micropython.js');
 mp_js_init(64 * 1024);
 mp_js_do_str("print('hello world')\n");
 ```
+
+Running with Node.js in a container
+-----------------------------------
+
+As above but execute the command inside the container, for example:
+
+    $ docker run -ti --rm -v /your/micropython/clone:/code -w /code emscripten/emsdk node ports/webassembly/build/micropython.js
+
 
 Running with HTML
 -----------------


### PR DESCRIPTION
Added simple build instructions to use Docker containers on many ports.

May be worth adding a more detailed markdown page to explain further details about Docker (how it works, podman as an alternative, the command-line options used, setting up convenient alias' etc). But perhaps that can come later. Looking for feedback on what devs would like to see with Docker info!