### PR TITLE
tools/pyboard.py: Prevent non-blocking serial reads.

### DIFF
--- a/tools/pyboard.py
+++ b/tools/pyboard.py
@@ -268,7 +268,7 @@ class Pyboard:
             import serial
 
             # Set options, and exclusive if pyserial supports it
-            serial_kwargs = {"baudrate": baudrate, "interCharTimeout": 1}
+            serial_kwargs = {"baudrate": baudrate, "interCharTimeout": 1, "timeout": 10}
             if serial.__version__ >= "3.3":
                 serial_kwargs["exclusive"] = exclusive
 


### PR DESCRIPTION
Added timeout to avoid blocking call to read()
preventing the test runner to wait forever
for incoming data from a irresponsive target.

Signed-off-by: jaenrig-ifx <enriquezgarcia.external@infineon.com>