### PR TITLE
extmod/moduplatform: Remove _M_IX86 test for xtensa.

### DIFF
--- a/extmod/moduplatform.h
+++ b/extmod/moduplatform.h
@@ -41,7 +41,7 @@
 #define MICROPY_PLATFORM_ARCH   "x86_64"
 #elif defined(__i386__) || defined(_M_IX86)
 #define MICROPY_PLATFORM_ARCH   "x86"
-#elif defined(__xtensa__) || defined(_M_IX86)
+#elif defined(__xtensa__)
 #define MICROPY_PLATFORM_ARCH   "xtensa"
 #else
 #define MICROPY_PLATFORM_ARCH   ""

--- a/extmod/moduplatform.h
+++ b/extmod/moduplatform.h
@@ -37,7 +37,7 @@
 
 #if defined(__ARM_ARCH)
 #define MICROPY_PLATFORM_ARCH   "arm"
-#elif defined(__x86_64__) || defined(_WIN64)
+#elif defined(__x86_64__) || defined(_M_X64)
 #define MICROPY_PLATFORM_ARCH   "x86_64"
 #elif defined(__i386__) || defined(_M_IX86)
 #define MICROPY_PLATFORM_ARCH   "x86"


### PR DESCRIPTION
Since `_M_IX86` is already being checked in the x86 case, it will never be true in the xtensa case and can be removed.
