### PR TITLE
samd: Some improvements and bug fixes.

### DIFF
--- a/docs/samd/quickref.rst
+++ b/docs/samd/quickref.rst
@@ -254,16 +254,38 @@ an external ADC.
 ADC Constructor
 ```````````````
 
-.. class:: ADC(dest, *, average=16)
+.. class:: ADC(dest, *, average=16, vref=n)
   :noindex:
 
-    Construct and return a new ADC object using the following parameters:
+Construct and return a new ADC object using the following parameters:
 
-      - *dest* is the Pin object on which the ADC is output.
+  - *dest* is the Pin object on which the ADC is output.
 
-    Keyword arguments:
+Keyword arguments:
 
-      - *average* is used to reduce the noise. With a value of 16 the LSB noise is about 1 digit.
+  - *average* is used to reduce the noise. With a value of 16 the LSB noise is about 1 digit.
+  - *vref* sets the reference voltage for the ADC.
+
+    The default setting is for 3.3V. Other values are:
+
+    ==== ==============================  ===============================
+    vref SAMD21                          SAMD51
+    ==== ==============================  ===============================
+    0    1.0V voltage reference          internal bandgap reference (1V)
+    1    1/1.48 Analogue voltage supply  Analogue voltage supply
+    2    1/2 Analogue voltage supply     1/2 Analogue voltage supply
+    3    External reference A            External reference A
+    4    External reference B            External reference B
+    5    -                               External reference C
+    ==== ==============================  ===============================
+
+ADC Methods
+```````````
+
+.. method:: read_u16()
+
+Read a single ADC value as unsigned 16 bit quantity. The voltage range is defined
+by the vref option of the constructor, the resolutions by the bits option.
 
 DAC (digital to analog conversion)
 ----------------------------------
@@ -279,6 +301,32 @@ The DAC class provides a fast digital to analog conversion. Usage example::
 
 The resolution of the DAC is 12 bit for SAMD51 and 10 bit for SAMD21. SAMD21 devices
 have 1 DAC channel at GPIO PA02, SAMD51 devices have 2 DAC channels at GPIO PA02 and PA05.
+
+DAC Constructor
+```````````````
+
+.. class:: DAC(id, *, vref=3)
+  :noindex:
+
+The vref arguments defines the output voltage range, the callback option is used for
+dac_timed(). Suitable values for vref are:
+
+==== ============================  ================================
+vref SAMD21                        SAMD51
+==== ============================  ================================
+0    Internal voltage reference    Internal bandgap reference (~1V)
+1    Analogue voltage supply       Analogue voltage supply
+2    External reference            Unbuffered external reference
+3    -                             Buffered external reference
+==== ============================  ================================
+
+DAC Methods
+```````````
+
+.. method:: write(value)
+
+Write a single value to the selected DAC output. The value range is 0-1023 for
+SAMD21 and 0-4095 for SAMD51. The voltage range depends on the vref setting.
 
 Software SPI bus
 ----------------

--- a/ports/samd/Makefile
+++ b/ports/samd/Makefile
@@ -117,6 +117,7 @@ SHARED_SRC_C += \
 	shared/runtime/stdout_helpers.c \
 	shared/runtime/sys_stdio_mphal.c \
 	shared/timeutils/timeutils.c \
+	shared/tinyusb/mp_cdc_common.c \
 
 ASF4_SRC_C += $(addprefix lib/asf4/$(MCU_SERIES_LOWER)/,\
 	hal/src/hal_atomic.c \

--- a/ports/samd/boards/SEEED_XIAO/mpconfigboard.h
+++ b/ports/samd/boards/SEEED_XIAO/mpconfigboard.h
@@ -2,3 +2,4 @@
 #define MICROPY_HW_MCU_NAME   "SAMD21G18A"
 
 #define MICROPY_HW_XOSC32K  (1)
+#define MICROPY_HW_ADC_VREF (2)

--- a/ports/samd/machine_i2c.c
+++ b/ports/samd/machine_i2c.c
@@ -35,7 +35,7 @@
 #include "clock_config.h"
 
 #define DEFAULT_I2C_FREQ  (400000)
-#define RISETIME_NS       (300)
+#define RISETIME_NS       (200)
 #define I2C_TIMEOUT       (100)
 
 #define IS_BUS_BUSY       (i2c->I2CM.STATUS.bit.BUSSTATE == 3)
@@ -184,7 +184,14 @@ mp_obj_t machine_i2c_make_new(const mp_obj_type_t *type, size_t n_args, size_t n
     // baud = peripheral_freq / (2 * baudrate) - 5 - (rise_time * peripheral_freq) / 2
     // Just set the minimal configuration for standard and fast mode.
     // Set Baud. Assume ~300ns rise time. Maybe set later by a keyword argument.
-    i2c->I2CM.BAUD.reg = get_peripheral_freq() / (2 * self->freq) - 5 - (get_peripheral_freq() / 1000000) * RISETIME_NS / 2000;
+    int32_t baud = get_peripheral_freq() / (2 * self->freq) - 5 - (get_peripheral_freq() / 1000000) * RISETIME_NS / 2000;
+    if (baud < 0) {
+        baud = 0;
+    }
+    if (baud > 255) {
+        baud = 255;
+    }
+    i2c->I2CM.BAUD.reg = baud;
 
     // Enable interrupts
     sercom_register_irq(self->id, &common_i2c_irq_handler);

--- a/ports/samd/machine_spi.c
+++ b/ports/samd/machine_spi.c
@@ -208,7 +208,13 @@ STATIC void machine_spi_init(mp_obj_base_t *self_in, size_t n_args, const mp_obj
 
         // SPI is driven by the clock of GCLK Generator 2, freq by get_peripheral_freq()
         // baud = bus_freq / (2 * baudrate) - 1
-        uint32_t baud = get_peripheral_freq() / (2 * self->baudrate) - 1;
+        uint32_t baud = get_peripheral_freq() / (2 * self->baudrate);
+        if (baud > 0) {  // Avoid underflow
+            baud -= 1;
+        }
+        if (baud > 255) { // Avoid overflow
+            baud = 255;
+        }
         spi->SPI.BAUD.reg = baud; // Set Baud
 
         // Enable RXC interrupt only if miso is defined

--- a/ports/samd/machine_spi.c
+++ b/ports/samd/machine_spi.c
@@ -296,7 +296,7 @@ STATIC void machine_spi_transfer(mp_obj_base_t *self_in, size_t len, const uint8
         if (self->miso == 0xff) {
             mp_raise_ValueError(MP_ERROR_TEXT("read is not enabled"));
         }
-        spi->SPI.INTENSET.bit.RXC = 1;
+        spi->SPI.INTENSET.reg = SERCOM_SPI_INTENSET_RXC;
         self->dest = dest;
         self->rxlen = len;
     }
@@ -317,7 +317,7 @@ STATIC void machine_spi_transfer(mp_obj_base_t *self_in, size_t len, const uint8
             timeout--;
             MICROPY_EVENT_POLL_HOOK
         }
-        spi->SPI.INTENCLR.bit.RXC = 1;
+        spi->SPI.INTENCLR.reg = SERCOM_SPI_INTENCLR_RXC;
     } else {
         // Wait for the data being shifted out.
         while (!spi->SPI.INTFLAG.bit.TXC) {

--- a/ports/samd/machine_uart.c
+++ b/ports/samd/machine_uart.c
@@ -263,8 +263,11 @@ STATIC mp_obj_t machine_uart_init_helper(machine_uart_obj_t *self, size_t n_args
         #if defined(MCU_SAMD21)
         if (self->tx_pad_config.pad_nr == 2) { // Map pad 2 to TXPO = 1
             txpo = 1;
-        }
+        } else
         #endif
+        if (self->tx_pad_config.pad_nr != 0) {
+            mp_raise_ValueError(MP_ERROR_TEXT("invalid tx pin"));
+        }
 
         uart->USART.CTRLA.reg =
             SERCOM_USART_CTRLA_DORD // Data order

--- a/ports/samd/machine_uart.c
+++ b/ports/samd/machine_uart.c
@@ -95,7 +95,7 @@ void common_uart_irq_handler(int uart_id) {
                 uart->USART.DATA.bit.DATA = ringbuf_get(&self->write_buffer);
             } else {
                 // Stop the interrupt if there is no more data
-                uart->USART.INTENCLR.bit.DRE = 1;
+                uart->USART.INTENCLR.reg = SERCOM_USART_INTENCLR_DRE;
             }
             #endif
         } else {
@@ -291,7 +291,7 @@ STATIC mp_obj_t machine_uart_init_helper(machine_uart_obj_t *self, size_t n_args
         sercom_register_irq(self->id, &common_uart_irq_handler);
 
         // Enable RXC interrupt
-        uart->USART.INTENSET.bit.RXC = 1;
+        uart->USART.INTENSET.reg = SERCOM_USART_INTENSET_RXC;
         #if defined(MCU_SAMD21)
         NVIC_EnableIRQ(SERCOM0_IRQn + self->id);
         #elif defined(MCU_SAMD51)
@@ -452,7 +452,7 @@ STATIC mp_uint_t machine_uart_read(mp_obj_t self_in, void *buf_in, mp_uint_t siz
             MICROPY_EVENT_POLL_HOOK
         }
         *dest++ = ringbuf_get(&(self->read_buffer));
-        t = mp_hal_ticks_ms() + timeout_char;
+        t = mp_hal_ticks_ms_64() + timeout_char;
     }
     return size;
 }
@@ -481,7 +481,7 @@ STATIC mp_uint_t machine_uart_write(mp_obj_t self_in, const void *buf_in, mp_uin
         }
         ringbuf_put(&(self->write_buffer), *src++);
         i++;
-        uart->USART.INTENSET.bit.DRE = 1; // kick off the IRQ
+        uart->USART.INTENSET.reg = SERCOM_USART_INTENSET_DRE; // kick off the IRQ
     }
 
     #else

--- a/ports/samd/modmachine.c
+++ b/ports/samd/modmachine.c
@@ -74,15 +74,14 @@ STATIC mp_obj_t machine_reset(void) {
 }
 MP_DEFINE_CONST_FUN_OBJ_0(machine_reset_obj, machine_reset);
 
-STATIC mp_obj_t machine_bootloader(void) {
+NORETURN mp_obj_t machine_bootloader(size_t n_args, const mp_obj_t *args) {
     *DBL_TAP_ADDR = DBL_TAP_MAGIC_LOADER;
     #ifdef DBL_TAP_ADDR_ALT
     *DBL_TAP_ADDR_ALT = DBL_TAP_MAGIC_LOADER;
     #endif
     NVIC_SystemReset();
-    return mp_const_none;
 }
-MP_DEFINE_CONST_FUN_OBJ_0(machine_bootloader_obj, machine_bootloader);
+STATIC MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(machine_bootloader_obj, 0, 1, machine_bootloader);
 
 STATIC mp_obj_t machine_freq(size_t n_args, const mp_obj_t *args) {
     if (n_args == 0) {

--- a/ports/samd/modmachine.h
+++ b/ports/samd/modmachine.h
@@ -41,4 +41,6 @@ extern const mp_obj_type_t machine_wdt_type;
 extern const mp_obj_type_t machine_rtc_type;
 #endif
 
+NORETURN mp_obj_t machine_bootloader(size_t n_args, const mp_obj_t *args);
+
 #endif // MICROPY_INCLUDED_SAMD_MODMACHINE_H

--- a/ports/samd/mpconfigport.h
+++ b/ports/samd/mpconfigport.h
@@ -125,7 +125,7 @@ __attribute__((always_inline)) static inline uint32_t disable_irq(void) {
     do { \
         extern void mp_handle_pending(bool); \
         mp_handle_pending(true); \
-        __WFI(); \
+        __WFE(); \
     } while (0);
 
 #define MICROPY_MAKE_POINTER_CALLABLE(p) ((void *)((mp_uint_t)(p) | 1))

--- a/ports/samd/mpconfigport.h
+++ b/ports/samd/mpconfigport.h
@@ -93,6 +93,8 @@
 #define MICROPY_PY_MACHINE_SOFTI2C          (1)
 #define MICROPY_PY_MACHINE_SPI              (1)
 #define MICROPY_PY_MACHINE_SOFTSPI          (1)
+#define MICROPY_HW_SOFTSPI_MIN_DELAY        (1)
+#define MICROPY_HW_SOFTSPI_MAX_BAUDRATE     (1000000)
 #define MICROPY_PY_MACHINE_TIMER            (1)
 #define MICROPY_PY_OS_DUPTERM               (3)
 #define MICROPY_PY_MACHINE_BITSTREAM        (1)

--- a/ports/samd/mpconfigport.h
+++ b/ports/samd/mpconfigport.h
@@ -58,7 +58,9 @@
 #define MICROPY_PY_BUILTINS_HELP_TEXT       samd_help_text
 #define MICROPY_PY_BUILTINS_HELP_MODULES    (1)
 #define MICROPY_ENABLE_SCHEDULER            (1)
+#define MICROPY_SCHEDULER_STATIC_NODES      (1)
 #define MICROPY_MODULE_WEAK_LINKS           (1)
+#define MICROPY_HW_USB_CDC_1200BPS_TOUCH    (1)
 
 // Control over Python builtins
 #define MICROPY_PY_BUILTINS_BYTES_HEX       (1)


### PR DESCRIPTION
- Support MICROPY_HW_SOFTSPI_MIN_DELAY, increasing the SoftSPI baudrate to about 500kHz.
- Use __WFE() in the MICROPY_EVENT_POLL_HOOK, which reduces the wait time at the end of SPI read from up to 1 ms to a few µs.
- Avoid under-/overflow in the baudrate calculation. The underflow caused  a baud rate setting of 48MHz resulting in a baud rate of ~100kHz.
- Fix UART IRQ flag setting and clearing. Without that fix, writing UART would disable the UART receive interrupt.
- Simplify machine_uart.c, by removing the call to uart_drain_rx_fifo() from machine_uart_any() and machine_uart_read(). It is not required, and may cause a race condition.
method. Simplifies _boot.py as well
- Check the UART tx Pin assignment.
- Fix uart.deinit() and do not use the finaliser with the machine_uart object.
- Add a vref=n option to machine.ADC and machine.DAC. Some boards do not have the AREF input wired, which was used as default input. With the vref option, the reference source can be selected, e.g. to Vcc or to the internal reference.
- Support touch1200bps to start bootloader mode.

The first three changes are more inconveniences, which could be avoided in the Python scripts or "just" affect the timing. Nr. 4, 5, and 7 fix bugs, Nr. 6 is an additional test, Nr. 8 is for some boards a bug fix and in general an extension.