### PR TITLE
extmod/uos: Expose stream ioctl constants, an ioctl() function

### DIFF
--- a/tests/extmod/uos_ioctl.py
+++ b/tests/extmod/uos_ioctl.py
@@ -1,0 +1,37 @@
+import uos
+import uio
+
+class TestIO(uio.IOBase):
+    def __init__(self):
+        self._read_rdy = False
+        self._write_rdy = False
+
+    def ioctl(self, req, arg):
+        if req == uos.STREAM_POLL:
+            ret = 0
+            if arg & uos.STREAM_POLL_RD and self._read_rdy:
+                ret |= uos.STREAM_POLL_RD
+            if arg & uos.STREAM_POLL_WR and self._write_rdy:
+                ret |= uos.STREAM_POLL_WR
+            return ret
+
+        raise Exception("Foo")
+
+
+f = TestIO()
+
+def _assert_ioctl_poll(expected):
+    assert f.ioctl(uos.STREAM_POLL, uos.STREAM_POLL_RD | uos.STREAM_POLL_WR) == expected
+
+_assert_ioctl_poll(0)
+f._read_rdy = True
+_assert_ioctl_poll(uos.STREAM_POLL_RD)
+f._write_rdy = True
+_assert_ioctl_poll(uos.STREAM_POLL_RD | uos.STREAM_POLL_WR)
+
+try:
+    uos.ioctl(f, 666, 0)
+except Exception as exc:
+    assert repr(exc) == "Exception('Foo',)"
+else:
+    assert False


### PR DESCRIPTION
This PR exposes a new `uos.ioctl()` function, and the related ioctl constants.

I have three reasons to do this:

* It would allow us to write unit tests for #9871;
* It would remove the need for each custom implementation of `io.IOBase` to re-define all these constants;
* It enables advanced use cases where an user-space implementation of `ioctl(MP_STREAM_POLL)` needs to forward that request to an underlying stream (like `ussl` has to do)