### PR TITLE
wait for >>> when attempting to enter_raw_repl

### DIFF
--- a/tools/pyboard.py
+++ b/tools/pyboard.py
@@ -67,10 +67,10 @@ Or:
 
 """
 
+import ast
+import os
 import sys
 import time
-import os
-import ast
 
 try:
     stdout = sys.stdout.buffer
@@ -212,8 +212,9 @@ class ProcessPtyToTerminal:
     this PTY."""
 
     def __init__(self, cmd):
-        import subprocess
         import re
+        import subprocess
+
         import serial
 
         self.subp = subprocess.Popen(
@@ -323,13 +324,14 @@ class Pyboard:
         return data
 
     def enter_raw_repl(self, soft_reset=True):
-        self.serial.write(b"\r\x03\x03")  # ctrl-C twice: interrupt any running program
-
         # flush input (without relying on serial.flushInput())
         n = self.serial.inWaiting()
         while n > 0:
             self.serial.read(n)
             n = self.serial.inWaiting()
+        self.serial.write(b"\r\x03\x03")  # ctrl-C twice: interrupt any running program
+        self.exit_raw_repl()  # if device is already in raw_repl, b'>>>' won't be printed.
+        self.read_until(1, b">>>")
 
         self.serial.write(b"\r\x01")  # ctrl-A: enter raw REPL
 


### PR DESCRIPTION
On some boards (notably esp32), `pyboard.py` hangs when attempting to enter raw repl mode. As outlined [in this thread](https://github.com/BrianPugh/belay/issues/38) and [this PR](https://github.com/BrianPugh/belay/pull/41), @roaldarbol and I have resolved this issue. Basically, the issue/solution is this:

1. After pressing ctrl+c twice, some boards take a while to respond (up to ~2 or ~3 seconds).
2. Attempting to enter raw repl during this time will result in the command being ignored.
3. To detect the board responding, the new change is to wait until the `>>>` prompt is sent from device.
4. If the device is already in raw repl mode, the `>>>` prompt will **not** be sent. To mitigate this, we will attempt to exit raw repl mode. If not in raw repl mode, this will do nothing.
5. Once the `>>>` prompt is reached, we know the device is ready for more commands and we can set the device in raw repl mode.

This should also mitigate the issue in [some other very old issues](https://github.com/scientifichackers/ampy/issues/19#issuecomment-317126363). This change is working well in Belay, but I didn't really test this exact PR for micropython.