### PR TITLE
py/makeversionhdr.py: Allow running outside of repo.

### DIFF
--- a/py/makeversionhdr.py
+++ b/py/makeversionhdr.py
@@ -6,13 +6,14 @@ This script works with Python 2.6, 2.7, 3.3 and 3.4.
 
 from __future__ import print_function
 
+import argparse
 import sys
 import os
 import datetime
 import subprocess
 
 
-def get_version_info_from_git():
+def get_version_info_from_git(repo_path):
     # Python 2.6 doesn't have check_output, so check for that
     try:
         subprocess.check_output
@@ -24,6 +25,7 @@ def get_version_info_from_git():
     try:
         git_tag = subprocess.check_output(
             ["git", "describe", "--tags", "--dirty", "--always", "--match", "v[1-9].*"],
+            cwd=repo_path,
             stderr=subprocess.STDOUT,
             universal_newlines=True,
         ).strip()
@@ -37,6 +39,7 @@ def get_version_info_from_git():
     try:
         git_hash = subprocess.check_output(
             ["git", "rev-parse", "--short", "HEAD"],
+            cwd=repo_path,
             stderr=subprocess.STDOUT,
             universal_newlines=True,
         ).strip()
@@ -48,11 +51,15 @@ def get_version_info_from_git():
     try:
         # Check if there are any modified files.
         subprocess.check_call(
-            ["git", "diff", "--no-ext-diff", "--quiet", "--exit-code"], stderr=subprocess.STDOUT
+            ["git", "diff", "--no-ext-diff", "--quiet", "--exit-code"],
+            cwd=repo_path,
+            stderr=subprocess.STDOUT,
         )
         # Check if there are any staged files.
         subprocess.check_call(
-            ["git", "diff-index", "--cached", "--quiet", "HEAD", "--"], stderr=subprocess.STDOUT
+            ["git", "diff-index", "--cached", "--quiet", "HEAD", "--"],
+            cwd=repo_path,
+            stderr=subprocess.STDOUT,
         )
     except subprocess.CalledProcessError:
         git_hash += "-dirty"
@@ -62,8 +69,8 @@ def get_version_info_from_git():
     return git_tag, git_hash
 
 
-def get_version_info_from_mpconfig():
-    with open(os.path.join(os.path.dirname(sys.argv[0]), "..", "py", "mpconfig.h")) as f:
+def get_version_info_from_mpconfig(repo_path):
+    with open(os.path.join(repo_path, "py", "mpconfig.h")) as f:
         for line in f:
             if line.startswith("#define MICROPY_VERSION_MAJOR "):
                 ver_major = int(line.strip().split()[2])
@@ -78,11 +85,11 @@ def get_version_info_from_mpconfig():
     return None
 
 
-def make_version_header(filename):
+def make_version_header(repo_path, filename):
     # Get version info using git, with fallback to py/mpconfig.h
-    info = get_version_info_from_git()
+    info = get_version_info_from_git(repo_path)
     if info is None:
-        info = get_version_info_from_mpconfig()
+        info = get_version_info_from_mpconfig(repo_path)
 
     git_tag, git_hash = info
 
@@ -119,5 +126,21 @@ def make_version_header(filename):
             f.write(file_data)
 
 
+def main():
+    parser = argparse.ArgumentParser()
+    # makeversionheader.py lives in repo/py, so default repo_path to the
+    # parent of sys.argv[0]'s directory.
+    parser.add_argument(
+        "-r",
+        "--repo-path",
+        default=os.path.join(os.path.dirname(sys.argv[0]), ".."),
+        help="path to MicroPython Git repo to query for version",
+    )
+    parser.add_argument("dest", nargs=1, help="output file path")
+    args = parser.parse_args()
+
+    make_version_header(args.repo_path, args.dest[0])
+
+
 if __name__ == "__main__":
-    make_version_header(sys.argv[1])
+    main()


### PR DESCRIPTION
This fixes the issue reported here https://github.com/micropython/micropython/commit/8a91c719668b9aa652d1c055208a9b04e5c682df#commitcomment-90581176
where the ESP32 (and rp2) nightly builds report the release version (without the git commit count and commit hash).

---

If a CMake-build is run with `make BUILD=/outside/path` then makeversionheader.py is run with the CWD set to the build directory, which means the git version lookup will fail and silently fall back to the mpconfig.h mode (giving the wrong result).

This commit:
 - Uses the location of makeversionheader.py to find the repo path.
 - Allows overriding this path via --repo-path.

_This work was funded through GitHub Sponsors._
