### PR TITLE
esp32/boards/GENERIC_S3_SPIRAM: Enable BLE.

### DIFF
--- a/ports/esp32/boards/GENERIC_S3_SPIRAM/mpconfigboard.h
+++ b/ports/esp32/boards/GENERIC_S3_SPIRAM/mpconfigboard.h
@@ -1,7 +1,6 @@
 #define MICROPY_HW_BOARD_NAME               "ESP32S3 module (spiram)"
 #define MICROPY_HW_MCU_NAME                 "ESP32S3"
 
-#define MICROPY_PY_BLUETOOTH                (0)
 #define MICROPY_PY_MACHINE_DAC              (0)
 
 // Enable UART REPL for modules that have an external USB-UART and don't use native USB.


### PR DESCRIPTION
This fixes the issue reported here https://github.com/micropython/micropython/commit/8a91c719668b9aa652d1c055208a9b04e5c682df#commitcomment-90581176

Follow up to 8a91c719 to no longer explicitly disable BLE in mpconfigport.h.

_This work was funded through GitHub Sponsors._