### PR TITLE
CI: explicitly install python2

### DIFF
--- a/.github/workflows/mpy_format.yml
+++ b/.github/workflows/mpy_format.yml
@@ -5,6 +5,8 @@ on:
   pull_request:
     paths:
       - '.github/workflows/*.yml'
+      - 'examples/**'
+      - 'tests/**'
       - 'tools/**'
 
 jobs:

--- a/.github/workflows/mpy_format.yml
+++ b/.github/workflows/mpy_format.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   test:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04 # use 20.04 to get python2
     steps:
     - uses: actions/checkout@v3
     - name: Install packages

--- a/.github/workflows/ports_unix.yml
+++ b/.github/workflows/ports_unix.yml
@@ -98,7 +98,7 @@ jobs:
       run: tests/run-tests.py --print-failures
 
   nanbox:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04 # use 20.04 to get python2
     steps:
     - uses: actions/checkout@v3
     - name: Install packages

--- a/tools/ci.sh
+++ b/tools/ci.sh
@@ -512,7 +512,6 @@ function ci_unix_32bit_setup {
     sudo pip3 install setuptools
     sudo pip3 install pyelftools
     gcc --version
-    python2 --version
     python3 --version
 }
 


### PR DESCRIPTION
Some CI builds need python2 installed, it seems like the default build environment no longer includes Python 2.