### PR TITLE
mpremote: only auto connect to serial device with USB VID/PID

### DIFF
--- a/docs/reference/mpremote.rst
+++ b/docs/reference/mpremote.rst
@@ -19,10 +19,10 @@ The simplest way to use this tool is just by invoking it without any arguments:
 
     mpremote
 
-This command automatically detects and connects to the first available serial
-device and provides an interactive REPL.  Serial ports are opened in exclusive
-mode, so running a second (or third, etc) instance of ``mpremote`` will connect
-to subsequent serial devices, if any are available.
+This command automatically detects and connects to the first available USB
+serial device and provides an interactive REPL.  Serial ports are opened in
+exclusive mode, so running a second (or third, etc) instance of ``mpremote``
+will connect to subsequent serial devices, if any are available.
 
 
 Commands
@@ -52,7 +52,7 @@ The full list of supported commands are:
   ``<device>`` may be one of:
 
   - ``list``: list available devices
-  - ``auto``: connect to the first available device
+  - ``auto``: connect to the first available USB serial port
   - ``id:<serial>``: connect to the device with USB serial number
     ``<serial>`` (the second entry in the output from the ``connect list``
     command)
@@ -186,8 +186,8 @@ Auto connection and soft-reset
 
 Connection and disconnection will be done automatically at the start and end of
 the execution of the tool, if such commands are not explicitly given.  Automatic
-connection will search for the first available serial device. If no action is
-specified then the REPL will be entered.
+connection will search for the first available USB serial device. If no action
+is specified then the REPL will be entered.
 
 Once connected to a device, ``mpremote`` will automatically soft-reset the
 device if needed.  This clears the Python heap and restarts the interpreter,

--- a/tools/mpremote/README.md
+++ b/tools/mpremote/README.md
@@ -7,7 +7,7 @@ The simplest way to use this tool is:
 
     mpremote
 
-This will automatically connect to the device and provide an interactive REPL.
+This will automatically connect to a USB serial port and provide an interactive REPL.
 
 The full list of supported commands are:
 

--- a/tools/mpremote/mpremote/commands.py
+++ b/tools/mpremote/mpremote/commands.py
@@ -32,14 +32,15 @@ def do_connect(state, args=None):
             # Don't do implicit REPL command.
             state.did_action()
         elif dev == "auto":
-            # Auto-detect and auto-connect to the first available device.
+            # Auto-detect and auto-connect to the first available USB serial port.
             for p in sorted(serial.tools.list_ports.comports()):
-                try:
-                    state.pyb = pyboard.PyboardExtended(p.device, baudrate=115200)
-                    return
-                except pyboard.PyboardError as er:
-                    if not er.args[0].startswith("failed to access"):
-                        raise er
+                if p.vid is not None and p.pid is not None:
+                    try:
+                        state.pyb = pyboard.PyboardExtended(p.device, baudrate=115200)
+                        return
+                    except pyboard.PyboardError as er:
+                        if not er.args[0].startswith("failed to access"):
+                            raise er
             raise pyboard.PyboardError("no device found")
         elif dev.startswith("id:"):
             # Search for a device with the given serial number.


### PR DESCRIPTION
On MacOS and Windows there are a few default serial devices that are returned by `serial.tools.list_ports.comports()`. For example on MacOS:

```
{'description': 'n/a',
 'device': '/dev/cu.Bluetooth-Incoming-Port',
 'hwid': 'n/a',
 'interface': None,
 'location': None,
 'manufacturer': None,
 'name': 'cu.Bluetooth-Incoming-Port',
 'pid': None,
 'product': None,
 'serial_number': None,
 'vid': None}

{'description': 'n/a',
 'device': '/dev/cu.wlan-debug',
 'hwid': 'n/a',
 'interface': None,
 'location': None,
 'manufacturer': None,
 'name': 'cu.wlan-debug',
 'pid': None,
 'product': None,
 'serial_number': None,
 'vid': None}
```

Users of mpremote most likely do not want to connect to these ports. It would be desireable if mpremote did not select this ports when using the auto connect behavior. These serial ports do not have USB VID or PID values and serial ports for Micropython boards with FTDI/serial-to- USB adaptors or native USB CDC/ACM support do.

Check for the presence of a USB VID / PID int value when selecting a serial port to auto connect to. All serial ports will still be listed by the `list` command and can still be selected by name when connecting.