### PR TITLE
stm32/mboot: Make all mboot sectors erase/write protected.

### DIFF
--- a/ports/stm32/boards/LEGO_HUB_NO6/mboot_memory.ld
+++ b/ports/stm32/boards/LEGO_HUB_NO6/mboot_memory.ld
@@ -8,3 +8,6 @@ MEMORY
     RAM (xrw)       : ORIGIN = 0x20000000, LENGTH = 120K
 }
 
+/* Location from which mboot is allowed to write to flash.
+   Must be the start of a flash erase sector. */
+_mboot_writable_flash_start = ORIGIN(FLASH_BL) + LENGTH(FLASH_BL);

--- a/ports/stm32/mboot/mboot.h
+++ b/ports/stm32/mboot/mboot.h
@@ -169,6 +169,7 @@ typedef uint32_t mboot_addr_t;
 
 extern volatile uint32_t systick_ms;
 extern uint8_t _estack[ELEM_DATA_SIZE];
+extern int32_t first_writable_flash_sector;
 
 void systick_init(void);
 void led_init(void);

--- a/ports/stm32/mboot/stm32_memory.ld
+++ b/ports/stm32/mboot/stm32_memory.ld
@@ -8,3 +8,7 @@ MEMORY
     FLASH_BL (rx)   : ORIGIN = 0x08000000, LENGTH = 32K
     RAM (xrw)       : ORIGIN = 0x20000000, LENGTH = 120K
 }
+
+/* Location from which mboot is allowed to write to flash.
+   Must be the start of a flash erase sector. */
+_mboot_writable_flash_start = ORIGIN(FLASH_BL) + LENGTH(FLASH_BL);


### PR DESCRIPTION
Prior to this, only sector 0 was erase/write protected, which may not be enough to protect all of mboot (especially if mboot lives at a higher address than the start of flash).

This change makes sure all internal flash sectors that mboot lives in are protected from erasing and writing.  The linker script must define _mboot_writable_flash_start for this to work.

