### PR TITLE
webassembly/library: Decode string to print as utf-8.

### DIFF
--- a/ports/webassembly/library.js
+++ b/ports/webassembly/library.js
@@ -26,16 +26,12 @@
 
 mergeInto(LibraryManager.library, {
     mp_js_write: function(ptr, len) {
-        for (var i = 0; i < len; ++i) {
-            if (typeof window === 'undefined') {
-                var b = Buffer.alloc(1);
-                b.writeInt8(getValue(ptr + i, 'i8'));
-                process.stdout.write(b);
-            } else {
-                var c = String.fromCharCode(getValue(ptr + i, 'i8'));
-                var printEvent = new CustomEvent('micropython-print', { detail: c });
-                document.dispatchEvent(printEvent);
-            }
+        const buffer = HEAPU8.subarray(ptr, ptr+len)
+        if (typeof window === 'undefined') {
+            process.stdout.write(buffer); 
+        } else {
+            const printEvent = new CustomEvent('micropython-print', { detail: buffer });
+            document.dispatchEvent(printEvent);
         }
     },
 


### PR DESCRIPTION
Current code is looping over bytes, and triggering one event for each. 
We can use UTF8ToString to decode the buffer directly, and send the whole string in one event.
Bonus : this allow to use utf-8 encoded strings in MicroPython and have them displayed correctly.
