### PR TITLE
.gitignore: Add section to ignore IDE config files.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,7 @@ genrst/
 # MacOS desktop metadata files
 ######################
 .DS_Store
+
+# IDE configuration files
+######################
+.vscode/


### PR DESCRIPTION
This adds a section to ignore config files for IDEs not used by the core developers. This is helpful for Visual Studio Code users so that their config files don't get in the way of committing fixes.

Signed-off-by: Laurens Valk <laurens@pybricks.com>

-----

This isn't to say that we should never have these files in the repo (it could be nice though), but this conveniently keeps them out of the git tree until then.