### PR TITLE
tests/misc/cexample_class: Fix timing sensitivity.

### DIFF
--- a/tests/misc/cexample_class.py
+++ b/tests/misc/cexample_class.py
@@ -7,14 +7,18 @@ except ImportError:
     print("SKIP")
     raise SystemExit
 
-t = cexample.Timer()
 
-print(t)
-print(t.time() <= 1)
+SLEEP_MS = 100
+TOLERANCE_MS = 20
+
+timer = cexample.Timer()
+
+t_start = timer.time()
 
 time.sleep_ms(100)
 
-elapsed = t.time()
+t_end = timer.time()
 
-if not (99 <= elapsed <= 110):
-    print("Elapsed time should be approx. 100ms but it is", elapsed)
+print(timer)
+print(0 <= t_start <= TOLERANCE_MS)
+print(SLEEP_MS - TOLERANCE_MS <= t_end <= SLEEP_MS + TOLERANCE_MS)

--- a/tests/misc/cexample_class.py.exp
+++ b/tests/misc/cexample_class.py.exp
@@ -1,2 +1,3 @@
 <Timer>
 True
+True

--- a/tests/misc/cexample_module.py
+++ b/tests/misc/cexample_module.py
@@ -7,8 +7,10 @@ except ImportError:
     raise SystemExit
 
 print(cexample)
+print(cexample.__name__)
 
 d = dir(cexample)
 d.index("add_ints")
+d.index("Timer")
 
 print(cexample.add_ints(1, 3))

--- a/tests/misc/cexample_module.py.exp
+++ b/tests/misc/cexample_module.py.exp
@@ -1,2 +1,3 @@
 <module 'cexample'>
+cexample
 4


### PR DESCRIPTION
This test could occasionally fail because some operations take longer than expected. This relaxes the timing constraints and defers printing until the very end.

Signed-off-by: Laurens Valk <laurens@pybricks.com>

------

This fixes a follow-up issue raised in https://github.com/micropython/micropython/pull/10038

------

Edit: While we are looking at this code, I've also added the `Timer` to the `cexample` module test.