### PR TITLE
gitignore: Simplify top-level gitignore file.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,48 +1,17 @@
-# Compiled Sources
-###################
-*.o
-*.a
-*.elf
-*.bin
-*.map
-*.hex
-*.dis
-*.exe
-
-# Packages
-############
-
-# Logs and Databases
-######################
-*.log
-
-# VIM Swap Files
-######################
-*.swp
-
 # Build directories
-######################
 build/
 build-*/
+docs/genrst/
 
 # Test failure outputs
-######################
 tests/results/*
 
 # Python cache files
-######################
 __pycache__/
-*.pyc
 
 # Customized Makefile/project overrides
-######################
 GNUmakefile
 user.props
 
-# Generated rst files
-######################
-genrst/
-
 # MacOS desktop metadata files
-######################
 .DS_Store

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,11 @@
+# This .gitignore file is intended to be minimal.
+#
+# If you find that you need additional rules, such as IDE temporary
+# files, please do so either via a global .gitignore file (registered
+# with core.excludesFile), or by adding private repository-specific
+# rules to .git/info/exclude.  See https://git-scm.com/docs/gitignore
+# for more information.
+
 # Build directories
 build/
 build-*/


### PR DESCRIPTION
All build artefacts are now placed in build*/ directories so there's no longer any need to hide files like .o with .gitignore.
