### PR TITLE
ports/stm32: Add missing LPUART macros for H7 HAL.

### DIFF
--- a/ports/stm32/boards/stm32h7xx_hal_conf_base.h
+++ b/ports/stm32/boards/stm32h7xx_hal_conf_base.h
@@ -101,4 +101,10 @@
 // HAL parameter assertions are disabled
 #define assert_param(expr) ((void)0)
 
+// The STM32H7xx HAL defines LPUART1 AF macros without numbers.
+#ifndef GPIO_AF3_LPUART1
+#define GPIO_AF3_LPUART1 GPIO_AF3_LPUART
+#define GPIO_AF8_LPUART1 GPIO_AF8_LPUART
+#endif
+
 #endif // MICROPY_INCLUDED_STM32H7XX_HAL_CONF_BASE_H


### PR DESCRIPTION
* The STM32H7xx HAL LPUART AF macros are missing the number, this HAL is the only one that's inconsistent in the way it defines LPUART AF macros, so we only need to define them for H7.

Suggestions for a better place to define those are welcome.