### PR TITLE
Add I2C1 and I2C2 to the NUCLEO-F429ZI

### DIFF
--- a/ports/stm32/boards/NUCLEO_F429ZI/mpconfigboard.h
+++ b/ports/stm32/boards/NUCLEO_F429ZI/mpconfigboard.h
@@ -40,6 +40,12 @@
 #define MICROPY_HW_UART_REPL_BAUD   115200
 
 // I2C buses
+#define MICROPY_HW_I2C1_SCL (pin_B8)  // Pin 2 on CN7
+#define MICROPY_HW_I2C1_SDA (pin_B9)  // Pin 4 on CN7
+
+#define MICROPY_HW_I2C2_SCL (pin_B10) // Pin 32 on CN10
+#define MICROPY_HW_I2C2_SDA (pin_B11) // Pin 34 on CN10
+
 #define MICROPY_HW_I2C3_SCL (pin_A8)
 #define MICROPY_HW_I2C3_SDA (pin_C9)
 


### PR DESCRIPTION
ports/stm32/boards/NUCLEO_F429ZI: Add I2C1 & I2C2 to the NUCLEO-F429ZI.

The datasheet on page 55 shows PF0 (SCL) and PF1 (SDA) are the pins for
  I2C2, but these pins do not work.

Checking the MBED pinout for the NUCLEO-F429ZI shows:

  I2C1: PB8 (SCL) and PB9 (SDA).
  I2C2: PB10 (SCL) and PB11 (SDA).

Both of these work perfectly and both can be scanned and find devices
  connected to them. In addition, I connected an Adafruit BNO055 IMU
  breakout to each bus and everything works as expected.

Signed-off-by: Dale Weber <hybotics.sd@gmail.com>.