### PR TITLE
py/modmicropython: Make module optional.

### DIFF
--- a/py/modmicropython.c
+++ b/py/modmicropython.c
@@ -32,6 +32,8 @@
 #include "py/gc.h"
 #include "py/mphal.h"
 
+#if MICROPY_PY_MICROPYTHON
+
 // Various builtins specific to MicroPython runtime,
 // living in micropython module
 
@@ -211,3 +213,5 @@ const mp_obj_module_t mp_module_micropython = {
 };
 
 MP_REGISTER_MODULE(MP_QSTR_micropython, mp_module_micropython);
+
+#endif // MICROPY_PY_MICROPYTHON

--- a/py/mpconfig.h
+++ b/py/mpconfig.h
@@ -1311,6 +1311,11 @@ typedef double mp_float_t;
 #define MICROPY_PY_CMATH (MICROPY_CONFIG_ROM_LEVEL_AT_LEAST_EXTRA_FEATURES)
 #endif
 
+// Whether to provide "micropython" module
+#ifndef MICROPY_PY_MICROPYTHON
+#define MICROPY_PY_MICROPYTHON (1)
+#endif
+
 // Whether to provide "gc" module
 #ifndef MICROPY_PY_GC
 #define MICROPY_PY_GC (MICROPY_CONFIG_ROM_LEVEL_AT_LEAST_CORE_FEATURES)

--- a/py/mpconfig.h
+++ b/py/mpconfig.h
@@ -1313,7 +1313,7 @@ typedef double mp_float_t;
 
 // Whether to provide "micropython" module
 #ifndef MICROPY_PY_MICROPYTHON
-#define MICROPY_PY_MICROPYTHON (1)
+#define MICROPY_PY_MICROPYTHON (MICROPY_CONFIG_ROM_LEVEL_AT_LEAST_CORE_FEATURES)
 #endif
 
 // Whether to provide "gc" module

--- a/tests/basics/nanbox_smallint.py
+++ b/tests/basics/nanbox_smallint.py
@@ -1,6 +1,10 @@
 # Test creating small integers without heap allocation in nan-boxing mode.
 
-import micropython
+try:
+    import micropython
+except ImportError:
+    print("SKIP")
+    raise SystemExit
 
 try:
     # Test for nan-box build by allocating a float while heap is locked.


### PR DESCRIPTION
This module is useful, but it is not always needed. Disabling it saves several kilobytes of build size, depending on other config options.

It defaults to `(1)`, so there is no change to existing ports.

Signed-off-by: Laurens Valk <laurens@pybricks.com>