### PR TITLE
docs/library/struct: Fix buffer argument description.

### DIFF
--- a/docs/library/struct.rst
+++ b/docs/library/struct.rst
@@ -43,5 +43,5 @@ Functions
 .. function:: unpack_from(fmt, data, offset=0, /)
 
    Unpack from the *data* starting at *offset* according to the format string
-   *fmt*. *offset* may be negative to count from the end of *buffer*. The return
+   *fmt*. *offset* may be negative to count from the end of *data*. The return
    value is a tuple of the unpacked values.


### PR DESCRIPTION
The buffer is the data in this case. There is no buffer argument.

Signed-off-by: Laurens Valk <laurens@pybricks.com>