### PR TITLE
py/objslice: Avoid heap-allocating slices for built-ins.

### DIFF
--- a/py/mpstate.h
+++ b/py/mpstate.h
@@ -268,6 +268,8 @@ typedef struct _mp_state_thread_t {
     // Locking of the GC is done per thread.
     uint16_t gc_lock_depth;
 
+    mp_obj_slice_t slice;
+
     ////////////////////////////////////////////////////////////
     // START ROOT POINTER SECTION
     // Everything that needs GC scanning must start here, and

--- a/py/obj.c
+++ b/py/obj.c
@@ -534,6 +534,13 @@ mp_obj_t mp_obj_subscr(mp_obj_t base, mp_obj_t index, mp_obj_t value) {
     const mp_obj_type_t *type = mp_obj_get_type(base);
     if (MP_OBJ_TYPE_HAS_SLOT(type, subscr)) {
         mp_obj_t ret = MP_OBJ_TYPE_GET_SLOT(type, subscr)(base, index, value);
+
+        // If the slice was a thread-local slice (see mp_obj_new_slice), then
+        // mark it as no longer "pending" (i.e. it's now safe to re-use the
+        // thread-local slot).
+        mp_obj_slice_t *o = &MP_STATE_THREAD(slice);
+        o->base.type = NULL;
+
         if (ret != MP_OBJ_NULL) {
             return ret;
         }

--- a/tests/basics/builtin_slice.py
+++ b/tests/basics/builtin_slice.py
@@ -1,11 +1,43 @@
 # test builtin slice
 
+# ensures that slices passed to user types are heap-allocated and can be
+# safely stored as well as not overriden by subsequent slices.
+
 # print slice
 class A:
     def __getitem__(self, idx):
-        print(idx)
+        print("get", idx)
+        print("abc"[1:])
+        print("get", idx)
         return idx
-s = A()[1:2:3]
+
+    def __setitem__(self, idx, value):
+        print("set", idx)
+        print("abc"[1:])
+        print("set", idx)
+        self.saved_idx = idx
+        return idx
+
+    def __delitem__(self, idx):
+        print("del", idx)
+        print("abc"[1:])
+        print("del", idx)
+        return idx
+
+a = A()
+s = a[1:2:3]
+a[4:5:6] = s
+del a[7:8:9]
+
+print(a.saved_idx)
+
+# nested slicing
+print(A()[1:A()[A()[2:3:4]:5]])
+
+# tuple slicing
+a[1:2,4:5,7:8]
+a[1,4:5,7:8,2]
 
 # check type
 print(type(s) is slice)
+

--- a/tests/micropython/heapalloc_slice.py
+++ b/tests/micropython/heapalloc_slice.py
@@ -1,0 +1,18 @@
+# slice operations that don't require allocation
+try:
+    from micropython import heap_lock, heap_unlock
+except (ImportError, AttributeError):
+    heap_lock = heap_unlock = lambda: 0
+
+b = bytearray(range(10))
+
+m = memoryview(b)
+
+heap_lock()
+
+b[3:5] = b"aa"
+m[5:7] = b"bb"
+
+heap_unlock()
+
+print(b)


### PR DESCRIPTION
Assume that a slice object (created by the `BUILD_SLICE` op-code or the native emitter via `mp_obj_new_slice`) will be used to slice a built-in type. This assumes that all built-in type->subscr functions will:
1. Not cause another slice to be allocated in the meantime.
2. Not save a reference to the slice.

This prevents a heap allocation, which for some cases (e.g. memoryview assignment) prevents allocation altogether.

Only when this assumption is incorrect (i.e. slicing a user-defined type via the `__{get,set,del}item__` methods), then heap-allocate the slice object.

This adds +156 bytes on PYBV11 (and +16 bytes .bss). Much of this is handling the tuple slice case -- you don't know at slice creation whether its going to be directly passed to `{LOAD,STORE}_SUBSCR` or whether it's potentially one of multiple slices about to be placed into a tuple.

This was based on a suggestion from @damz in Discord which I think was along the lines of combining the `BUILD_SLICE` op with `{LOAD,STORE}_SUBSCR`, but I think the approach in this PR achieves the same goal with smaller code size and without having to change the bytecode.

_This work was funded through GitHub Sponsors._