### PR TITLE
github/workflows: Don't try to comment on master branch builds.

### DIFF
--- a/.github/workflows/code_size_comment.yml
+++ b/.github/workflows/code_size_comment.yml
@@ -4,6 +4,7 @@ on:
   workflow_run:
     workflows: [Check code size]
     types: [completed]
+    branches-ignore: [master]
 
 jobs:
   comment:


### PR DESCRIPTION
All pushes to master have been failing because they cannot comment.  What actually fails is this:
```
Run unzip code-size-report.zip
  unzip code-size-report.zip
  shell: /usr/bin/bash -e {0}
unzip:  cannot find or open code-size-report.zip, code-size-report.zip.zip or code-size-report.zip.ZIP.
Error: Process completed with exit code 9.
```

This PR attempts to fix this (it's untested) by ignoring master branch for code size comments.

@dlech  FYI