### PR TITLE
extmod/uasyncio: Fix syntax of generator functions

### DIFF
--- a/extmod/uasyncio/event.py
+++ b/extmod/uasyncio/event.py
@@ -23,7 +23,8 @@ class Event:
     def clear(self):
         self.state = False
 
-    async def wait(self):
+    # async
+    def wait(self):
         if not self.state:
             # Event not set, put the calling task on the event's waiting queue
             self.waiting.push(core.cur_task)

--- a/extmod/uasyncio/funcs.py
+++ b/extmod/uasyncio/funcs.py
@@ -4,7 +4,7 @@
 from . import core
 
 
-def _run(waiter, aw):
+async def _run(waiter, aw):
     try:
         result = await aw
         status = True
@@ -61,7 +61,8 @@ class _Remove:
         pass
 
 
-async def gather(*aws, return_exceptions=False):
+# async
+def gather(*aws, return_exceptions=False):
     if not aws:
         return []
 

--- a/extmod/uasyncio/lock.py
+++ b/extmod/uasyncio/lock.py
@@ -28,7 +28,8 @@ class Lock:
             # No Task waiting so unlock
             self.state = 0
 
-    async def acquire(self):
+    # async
+    def acquire(self):
         if self.state != 0:
             # Lock unavailable, put the calling Task on the waiting queue
             self.waiting.push(core.cur_task)

--- a/extmod/uasyncio/stream.py
+++ b/extmod/uasyncio/stream.py
@@ -26,7 +26,8 @@ class Stream:
         # TODO yield?
         self.s.close()
 
-    async def read(self, n=-1):
+    # async
+    def read(self, n=-1):
         r = b""
         while True:
             yield core._io_queue.queue_read(self.s)
@@ -38,11 +39,13 @@ class Stream:
                     return r
                 r += r2
 
-    async def readinto(self, buf):
+    # async
+    def readinto(self, buf):
         yield core._io_queue.queue_read(self.s)
         return self.s.readinto(buf)
 
-    async def readexactly(self, n):
+    # async
+    def readexactly(self, n):
         r = b""
         while n:
             yield core._io_queue.queue_read(self.s)
@@ -54,7 +57,8 @@ class Stream:
                 n -= len(r2)
         return r
 
-    async def readline(self):
+    # async
+    def readline(self):
         l = b""
         while True:
             yield core._io_queue.queue_read(self.s)
@@ -73,10 +77,11 @@ class Stream:
                 buf = buf[ret:]
         self.out_buf += buf
 
-    async def drain(self):
+    # async
+    def drain(self):
         if not self.out_buf:
             # Drain must always yield, so a tight loop of write+drain can't block the scheduler.
-            return await core.sleep_ms(0)
+            return (yield from core.sleep_ms(0))
         mv = memoryview(self.out_buf)
         off = 0
         while off < len(mv):
@@ -93,7 +98,9 @@ StreamWriter = Stream
 
 
 # Create a TCP stream connection to a remote host
-async def open_connection(host, port):
+#
+# async
+def open_connection(host, port):
     from uerrno import EINPROGRESS
     import usocket as socket
 


### PR DESCRIPTION
### What?

Fix the syntax of generator functions in the `uasyncio` package:

* `await` is only valid in an `async` function
* `async` functions that use `yield` are actually async generators (a construct not supported by the compiler right now)

### Why?

The compiler is not picky right now, but these are actually all syntax errors.
