### PR TITLE
esp32/main: Don't call usocket_events_deinit if unavailable.

### DIFF
--- a/ports/esp32/main.c
+++ b/ports/esp32/main.c
@@ -215,7 +215,9 @@ soft_reset_exit:
     // TODO: machine_rmt_deinit_all();
     machine_pins_deinit();
     machine_deinit();
+    #if MICROPY_PY_USOCKET_EVENTS
     usocket_events_deinit();
+    #endif
 
     mp_deinit();
     fflush(stdout);


### PR DESCRIPTION
usocket_events_deinit will only be available if MICROPY_PY_USOCKET_EVENTS is enabled (which is only enabled when webrepl is enabled).
