### PR TITLE
py/gc: Speed up incremental GC cycles by tracking the high watermark.

### DIFF
--- a/py/mpstate.h
+++ b/py/mpstate.h
@@ -93,6 +93,7 @@ typedef struct _mp_state_mem_area_t {
     byte *gc_pool_end;
 
     size_t gc_last_free_atb_index;
+    size_t gc_last_used_block; // The block ID of the highest block allocated in the area
 } mp_state_mem_area_t;
 
 // This structure hold information about the memory allocation system.


### PR DESCRIPTION
### Why?

In applications that use little memory and run GC regularly, the cost of the sweep phase quickly becomes prohibitive as the amount of RAM increases.

On an ESP32-S3 with 2 MB of external SPIRAM, for example, a trivial GC cycle takes a minimum of 20 ms, a big part of it in the sweep phase.

Similarly, on the UNIX port with 1 GB of heap, a trivial GC takes 47 ms, virtually all of it in the sweep phase.

### What?

Speed up the sweep phase in the case most of the heap is empty by keeping track of the ID of the highest block we allocated in an area since the last GC.