### PR TITLE
WIP: py: Implement mp_sched_vm_abort() to force a return to the very top level

### DIFF
--- a/ports/stm32/modmachine.c
+++ b/ports/stm32/modmachine.c
@@ -265,8 +265,12 @@ STATIC mp_obj_t machine_reset(void) {
 MP_DEFINE_CONST_FUN_OBJ_0(machine_reset_obj, machine_reset);
 
 STATIC mp_obj_t machine_soft_reset(void) {
-    pyexec_system_exit = PYEXEC_FORCED_EXIT;
-    mp_raise_type(&mp_type_SystemExit);
+    mp_sched_vm_abort();
+    // Either handle the pending abort, or wait if we aren't the main thread.
+    for (;;) {
+        MICROPY_EVENT_POLL_HOOK;
+    }
+    return mp_const_none;
 }
 MP_DEFINE_CONST_FUN_OBJ_0(machine_soft_reset_obj, machine_soft_reset);
 

--- a/ports/stm32/mpconfigport.h
+++ b/ports/stm32/mpconfigport.h
@@ -76,6 +76,7 @@
 #define MICROPY_FLOAT_IMPL          (MICROPY_FLOAT_IMPL_FLOAT)
 #endif
 #define MICROPY_USE_INTERNAL_ERRNO  (1)
+#define MICROPY_SCHED_VM_ABORT      (1)
 #define MICROPY_SCHEDULER_STATIC_NODES (1)
 #define MICROPY_SCHEDULER_DEPTH     (8)
 #define MICROPY_VFS                 (1)

--- a/py/mpconfig.h
+++ b/py/mpconfig.h
@@ -904,6 +904,11 @@ typedef double mp_float_t;
 #define MICROPY_USE_INTERNAL_PRINTF (1)
 #endif
 
+// Whether to support mp_sched_vm_abort to asynchronously abort to the top level.
+#ifndef MICROPY_SCHED_VM_ABORT
+#define MICROPY_SCHED_VM_ABORT (0)
+#endif
+
 // Support for internal scheduler
 #ifndef MICROPY_ENABLE_SCHEDULER
 #define MICROPY_ENABLE_SCHEDULER (MICROPY_CONFIG_ROM_LEVEL_AT_LEAST_EXTRA_FEATURES)
@@ -1733,6 +1738,10 @@ typedef double mp_float_t;
 
 #ifndef MICROPY_WRAP_MP_SCHED_SCHEDULE
 #define MICROPY_WRAP_MP_SCHED_SCHEDULE(f) f
+#endif
+
+#ifndef MICROPY_WRAP_MP_SCHED_VM_ABORT
+#define MICROPY_WRAP_MP_SCHED_VM_ABORT(f) f
 #endif
 
 /*****************************************************************************/

--- a/py/mpstate.h
+++ b/py/mpstate.h
@@ -26,6 +26,7 @@
 #ifndef MICROPY_INCLUDED_PY_MPSTATE_H
 #define MICROPY_INCLUDED_PY_MPSTATE_H
 
+#include <stdbool.h>
 #include <stdint.h>
 
 #include "py/mpconfig.h"
@@ -293,8 +294,14 @@ extern mp_state_ctx_t mp_state_ctx;
 #if MICROPY_PY_THREAD
 extern mp_state_thread_t *mp_thread_get_state(void);
 #define MP_STATE_THREAD(x) (mp_thread_get_state()->x)
+static inline bool mp_thread_is_main_thread(void) {
+    return mp_thread_get_state() == &mp_state_ctx.thread;
+}
 #else
 #define MP_STATE_THREAD(x)  MP_STATE_MAIN_THREAD(x)
+static inline bool mp_thread_is_main_thread(void) {
+    return true;
+}
 #endif
 
 #endif // MICROPY_INCLUDED_PY_MPSTATE_H

--- a/py/mpstate.h
+++ b/py/mpstate.h
@@ -223,6 +223,11 @@ typedef struct _mp_state_vm_t {
     #endif
     #endif
 
+    #if MICROPY_SCHED_VM_ABORT
+    bool vm_abort;
+    nlr_buf_t *nlr_abort;
+    #endif
+
     #if MICROPY_PY_THREAD_GIL
     // This is a global mutex used to make the VM/runtime thread-safe.
     mp_thread_mutex_t gil_mutex;

--- a/py/mpstate.h
+++ b/py/mpstate.h
@@ -61,11 +61,6 @@ typedef struct mp_dynamic_compiler_t {
 extern mp_dynamic_compiler_t mp_dynamic_compiler;
 #endif
 
-// These are the values for sched_state
-#define MP_SCHED_IDLE (1)
-#define MP_SCHED_LOCKED (-1)
-#define MP_SCHED_PENDING (0) // 0 so it's a quick check in the VM
-
 typedef struct _mp_sched_item_t {
     mp_obj_t func;
     mp_obj_t arg;
@@ -211,7 +206,12 @@ typedef struct _mp_state_vm_t {
     #endif
 
     #if MICROPY_ENABLE_SCHEDULER
-    volatile int16_t sched_state;
+    // This counts the depth of calls to mp_sched_lock/mp_sched_unlock.
+    volatile uint16_t sched_lock_depth;
+
+    // These index sched_queue.
+    uint8_t sched_len;
+    uint8_t sched_idx;
 
     #if MICROPY_SCHEDULER_STATIC_NODES
     // These will usually point to statically allocated memory.  They are not
@@ -220,10 +220,6 @@ typedef struct _mp_state_vm_t {
     struct _mp_sched_node_t *sched_head;
     struct _mp_sched_node_t *sched_tail;
     #endif
-
-    // These index sched_queue.
-    uint8_t sched_len;
-    uint8_t sched_idx;
     #endif
 
     #if MICROPY_PY_THREAD_GIL

--- a/py/nlr.c
+++ b/py/nlr.c
@@ -49,3 +49,10 @@ void nlr_pop(void) {
     nlr_buf_t **top = &MP_STATE_THREAD(nlr_top);
     *top = (*top)->prev;
 }
+
+#if MICROPY_SCHED_VM_ABORT
+NORETURN void nlr_jump_abort(void) {
+    MP_STATE_THREAD(nlr_top) = MP_STATE_VM(nlr_abort);
+    nlr_jump(NULL);
+}
+#endif

--- a/py/nlr.h
+++ b/py/nlr.h
@@ -149,6 +149,12 @@ unsigned int nlr_push_tail(nlr_buf_t *top);
 void nlr_pop(void);
 NORETURN void nlr_jump(void *val);
 
+#if MICROPY_SCHED_VM_ABORT
+#define nlr_set_abort(buf) MP_STATE_VM(nlr_abort) = buf
+#define nlr_get_abort() MP_STATE_VM(nlr_abort)
+NORETURN void nlr_jump_abort(void);
+#endif
+
 // This must be implemented by a port.  It's called by nlr_jump
 // if no nlr buf has been pushed.  It must not return, but rather
 // should bail out with a fatal error.

--- a/py/runtime.c
+++ b/py/runtime.c
@@ -68,16 +68,15 @@ void mp_init(void) {
 
     // no pending exceptions to start with
     MP_STATE_THREAD(mp_pending_exception) = MP_OBJ_NULL;
+
     #if MICROPY_ENABLE_SCHEDULER
     #if MICROPY_SCHEDULER_STATIC_NODES
-    if (MP_STATE_VM(sched_head) == NULL) {
-        // no pending callbacks to start with
-        MP_STATE_VM(sched_state) = MP_SCHED_IDLE;
-    } else {
+    if (MP_STATE_VM(sched_head) != NULL) {
         // pending callbacks are on the list, eg from before a soft reset
-        MP_STATE_VM(sched_state) = MP_SCHED_PENDING;
+        MP_STATE_MAIN_THREAD(mp_pending_exception) = MP_OBJ_SENTINEL;
     }
     #endif
+    MP_STATE_VM(sched_lock_depth) = 0;
     MP_STATE_VM(sched_idx) = 0;
     MP_STATE_VM(sched_len) = 0;
     #endif

--- a/py/runtime.h
+++ b/py/runtime.h
@@ -75,6 +75,9 @@ void mp_deinit(void);
 
 void mp_sched_exception(mp_obj_t exc);
 void mp_sched_keyboard_interrupt(void);
+#if MICROPY_SCHED_VM_ABORT
+void mp_sched_vm_abort(void);
+#endif
 void mp_handle_pending(bool raise_exc);
 
 #if MICROPY_ENABLE_SCHEDULER

--- a/py/vm.c
+++ b/py/vm.c
@@ -1321,17 +1321,9 @@ pending_exception_check:
                 // we can inline the check for the common case where there is
                 // neither.
                 if (
-                #if MICROPY_ENABLE_SCHEDULER
+                    MP_STATE_MAIN_THREAD(mp_pending_exception) != MP_OBJ_NULL
                 #if MICROPY_PY_THREAD
-                    // Scheduler + threading: Scheduler and pending exceptions are independent, check both.
-                    MP_STATE_VM(sched_state) == MP_SCHED_PENDING || MP_STATE_THREAD(mp_pending_exception) != MP_OBJ_NULL
-                #else
-                    // Scheduler + non-threading: Optimisation: pending exception sets sched_state, only check sched_state.
-                    MP_STATE_VM(sched_state) == MP_SCHED_PENDING
-                #endif
-                #else
-                    // No scheduler: Just check pending exception.
-                    MP_STATE_THREAD(mp_pending_exception) != MP_OBJ_NULL
+                    || MP_STATE_THREAD(mp_pending_exception) != MP_OBJ_NULL
                 #endif
                 ) {
                     MARK_EXC_IP_SELECTIVE();
@@ -1349,7 +1341,7 @@ pending_exception_check:
                     #endif
                     #if MICROPY_ENABLE_SCHEDULER
                     // can only switch threads if the scheduler is unlocked
-                    if (MP_STATE_VM(sched_state) == MP_SCHED_IDLE)
+                    if (MP_STATE_VM(sched_lock_depth) == 0)
                     #endif
                     {
                     MP_THREAD_GIL_EXIT();


### PR DESCRIPTION
This is an alternative to #9949 which does a "very long jump" to force the VM to stop and return up to the very top level of code control (usually pyexec).

The idea is for the top level to mark its nlr_buf as the special one to return to.  Then a call to `mp_sched_vm_abort()` will schedule (indicate to) the VM that it should stop immediately.  The VM (actually `mp_handle_pending()` the next time it is run) will then jump to this special nlr_buf (bypassing all those nlr bufs in between).

This approach should work with multiple threads.  Only the main thread handles the abort.