### PR TITLE
build-boards.sh: Create the .uf2 file for seeed_xiao_nrf52.

### DIFF
--- a/tools/autobuild/build-boards.sh
+++ b/tools/autobuild/build-boards.sh
@@ -99,7 +99,7 @@ function build_mimxrt_boards {
 }
 
 function build_nrf_boards {
-    build_boards nrfx_glue.h $1 $2 bin hex
+    build_boards nrfx_glue.h $1 $2 bin hex uf2
 }
 
 function build_renesas_ra_boards {


### PR DESCRIPTION
And for all other nrf boards that have or get a uf2 build tag.

Note: I forgot that in the initial PR. Tested locally.