### PR TITLE
github/code_size_comment: Update existing comments.

### DIFF
--- a/.github/workflows/code_size_comment.yml
+++ b/.github/workflows/code_size_comment.yml
@@ -62,14 +62,44 @@ jobs:
           script: |
             const fs = require('fs');
 
-            github.rest.issues.createComment({
-              issue_number: Number(fs.readFileSync('pr_number')),
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              body: `Code size report:
+            const prNumber = Number(fs.readFileSync('pr_number'));
+            const codeSizeReport = `Code size report:
 
             \`\`\`
             ${fs.readFileSync('diff')}
             \`\`\`
-            `,
-            });
+            `;
+
+            const comments = await github.paginate(
+              github.rest.issues.listComments,
+              {
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: prNumber,
+              }
+            );
+
+            comments.reverse();
+
+            const previousComment = comments.find(comment =>
+              comment.user.login === 'github-actions[bot]'
+            )
+
+            // if github-actions[bot] already made a comment, update it,
+            // otherwise create a new comment.
+
+            if (previousComment) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: previousComment.id,
+                body: codeSizeReport,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: prNumber,
+                body: codeSizeReport,
+              });
+            }


### PR DESCRIPTION
This modifies the automated code size comment to edit an existing comment if one already exists instead of always creating a new comment. This reduces noise on pull requests that are repeatedly updated.

This is tested working as seen at https://github.com/dlech/micropython/pull/4#issuecomment-1356986269 (you can tell because the comment is marked as edited). Also from testing, it appears that if the comment is identical to the previous, it won't appear as edited, but I don't see that as a problem.

Note: as before, changes don't take effect until this commit is pushed to default (master) branch since the workflow has repository write privileges.