### PR TITLE
cyw43: fix support for WiFi networks with open security

### DIFF
--- a/extmod/network_cyw43.c
+++ b/extmod/network_cyw43.c
@@ -244,13 +244,18 @@ STATIC mp_obj_t network_cyw43_connect(size_t n_args, const mp_obj_t *pos_args, m
         args[ARG_security] = args[ARG_auth];
     }
 
+    // Extract the SSID.
     mp_buffer_info_t ssid;
     mp_get_buffer_raise(args[ARG_ssid].u_obj, &ssid, MP_BUFFER_READ);
+
+    // Extract the key, if given.
     mp_buffer_info_t key;
     key.buf = NULL;
     if (args[ARG_key].u_obj != mp_const_none) {
         mp_get_buffer_raise(args[ARG_key].u_obj, &key, MP_BUFFER_READ);
     }
+
+    // Extract the BSSID, if given.
     mp_buffer_info_t bssid;
     bssid.buf = NULL;
     if (args[ARG_bssid].u_obj != mp_const_none) {
@@ -259,8 +264,26 @@ STATIC mp_obj_t network_cyw43_connect(size_t n_args, const mp_obj_t *pos_args, m
             mp_raise_ValueError(NULL);
         }
     }
+
+    // Extract the security type, if given.
+    uint32_t auth_type;
+    if (args[ARG_security].u_int == -1) {
+        if (key.buf == NULL || key.len == 0) {
+            auth_type = 0; // open security
+        } else {
+            #if MICROPY_PY_NETWORK_CYW43_USE_LIB_DRIVER
+            auth_type = CYW43_AUTH_WPA2_MIXED_PSK;
+            #else
+            auth_type = 0x008006; // WPA2_MIXED_PSK
+            #endif
+        }
+    } else {
+        auth_type = args[ARG_security].u_int;
+    }
+
+    // Start the WiFi join procedure.  It will run in the background.
     int ret = cyw43_wifi_join(self->cyw, ssid.len, ssid.buf, key.len, key.buf,
-        args[ARG_security].u_int, bssid.buf, args[ARG_channel].u_int);
+        auth_type, bssid.buf, args[ARG_channel].u_int);
     if (ret != 0) {
         mp_raise_OSError(-ret);
     }


### PR DESCRIPTION
Prior to this fix, the default security=-1 would be passed directly through to the cyw43 driver to auto-detect the security type, but that driver did not correctly handle the case of open security.
    
The cyw43 driver has now been changed to no longer support auto-detection, rather it is up to the caller to always select the security type.  The defaults are now implemented in the Python bindings and are:
- if no key is given then it selects open security
- if a key is given then it selects WPA2_MIXED_PSK
    
Calling `wlan.connect(<ssid>)` will now connect to an open network, on both rp2 and stm32 ports.  The form `wlan.connect(<ssid>, <key>)` will connect to a WPA2 network.
    
Fixes issue #9016.
