### PR TITLE
tools/pyboard.py: Add fs_listdir/fs_readfile/fs_writefile and a parse kwarg to eval.

### DIFF
--- a/tools/pyboard.py
+++ b/tools/pyboard.py
@@ -457,10 +457,15 @@ class Pyboard:
         self.exec_raw_no_follow(command)
         return self.follow(timeout, data_consumer)
 
-    def eval(self, expression):
-        ret = self.exec_("print({})".format(expression))
-        ret = ret.strip()
-        return ret
+    def eval(self, expression, parse=False):
+        if parse:
+            ret = self.exec_("print(repr({}))".format(expression))
+            ret = ret.strip()
+            return ast.literal_eval(ret.decode())
+        else:
+            ret = self.exec_("print({})".format(expression))
+            ret = ret.strip()
+            return ret
 
     def exec_(self, command, data_consumer=None):
         ret, ret_err = self.exec_raw(command, data_consumer=data_consumer)

--- a/tools/pyboard.py
+++ b/tools/pyboard.py
@@ -67,10 +67,11 @@ Or:
 
 """
 
+import ast
+import os
+import struct
 import sys
 import time
-import os
-import ast
 
 try:
     stdout = sys.stdout.buffer
@@ -379,7 +380,7 @@ class Pyboard:
     def raw_paste_write(self, command_bytes):
         # Read initial header, with window size.
         data = self.serial.read(2)
-        window_size = data[0] | data[1] << 8
+        window_size = struct.unpack("<H", data)[0]
         window_remain = window_size
 
         # Write out the command_bytes data.


### PR DESCRIPTION
This is to make it easier to use pyboard.py as a library. The existing eval/fs_ls/fs_cat are really only useful right now when using it from the command line.

- fs_listdir returns a list of tuples, in the same format as os.ilistdir().
- fs_readfile returns the contents of a file as a bytes object.
- fs_writefile allows writing a bytes object to a file.
- eval(..., parse=True) will evaluate the result into a Python object. This works for any Python literal (i.e. that can be understood by `ast.parse_literal`).

```
>>> pyb.eval("1+1", parse=True)
2
>>> pyb.eval("{'a': '\x00'}", parse=True)
{'a': '\x00'}
```

fs_listdir in particular might be useful to use in mpremote for future recursive operations. Another example is that mpremote/mip does `int(pyb.eval("getattr(sys.implementation, '_mpy', 0) & 0xFF").decode())` which could now become `pyb.eval("getattr(sys.implementation, '_mpy', 0) & 0xFF", parse=True)`.

_This work was funded through GitHub Sponsors._