### PR TITLE
rp2: Change order of pin operations to prevent glitches.

### DIFF
--- a/ports/rp2/mphalport.h
+++ b/ports/rp2/mphalport.h
@@ -91,22 +91,22 @@ static inline unsigned int mp_hal_pin_name(mp_hal_pin_obj_t pin) {
 }
 
 static inline void mp_hal_pin_input(mp_hal_pin_obj_t pin) {
-    gpio_set_function(pin, GPIO_FUNC_SIO);
     gpio_set_dir(pin, GPIO_IN);
     machine_pin_open_drain_mask &= ~(1 << pin);
+    gpio_set_function(pin, GPIO_FUNC_SIO);
 }
 
 static inline void mp_hal_pin_output(mp_hal_pin_obj_t pin) {
-    gpio_set_function(pin, GPIO_FUNC_SIO);
     gpio_set_dir(pin, GPIO_OUT);
     machine_pin_open_drain_mask &= ~(1 << pin);
+    gpio_set_function(pin, GPIO_FUNC_SIO);
 }
 
 static inline void mp_hal_pin_open_drain(mp_hal_pin_obj_t pin) {
-    gpio_set_function(pin, GPIO_FUNC_SIO);
     gpio_set_dir(pin, GPIO_IN);
     gpio_put(pin, 0);
     machine_pin_open_drain_mask |= 1 << pin;
+    gpio_set_function(pin, GPIO_FUNC_SIO);
 }
 
 static inline void mp_hal_pin_config(mp_hal_pin_obj_t pin, uint32_t mode, uint32_t pull, uint32_t alt) {


### PR DESCRIPTION
Fixes #10226. When switching from a special function like SPI to an input or output, there was a brief period after the function was disabled but before the pin's I/O state was configured, in which the state would be poorly defined. This fixes the problem by switching off the special function after fully configuring the I/O state.

Test code:
```python
from machine import SPI, Pin

sck = Pin(14)
mosi = Pin(15)

sck.init(mode=Pin.IN)
spi = SPI(id=1, baudrate=100000, polarity=0, phase=0, sck=sck, mosi=mosi)
spi.write(bytearray([0xAA]))
sck.init(mode=Pin.OUT, value=0)
sck(1)
```

Before/after this change (with 1k pull-up):
<img src="https://user-images.githubusercontent.com/466760/209589086-019bb45d-1d10-4c02-859e-bbf6a17e1e92.png" width=350><img src="https://user-images.githubusercontent.com/466760/209589697-42285503-228e-4391-a434-58e8c01e67e8.png" width=350>

```python
from machine import SPI, Pin

sck = Pin(14)
mosi = Pin(15)

sck.init(mode=Pin.OUT, value=1)
spi = SPI(id=1, baudrate=100000, polarity=0, phase=0, sck=sck, mosi=mosi)
spi.write(bytearray([0xAA]))

sck.init(mode=Pin.IN, pull=Pin.PULL_DOWN)
sck.init(mode=Pin.OUT, value=1)
```

Before/after this change (with no pull-up):
<img src="https://user-images.githubusercontent.com/466760/209589101-1522bf7f-385a-4cfb-b090-d43c8d8b4a88.png" width=350><img src="https://user-images.githubusercontent.com/466760/209589730-673d2dc6-8341-49d2-aba3-75f4523f6af4.png" width=350>

```python
from machine import SPI, Pin

sck = Pin(14)
mosi = Pin(15)

sck.init(mode=Pin.OUT, value=0)
spi = SPI(id=1, baudrate=100000, polarity=1, phase=0, sck=sck, mosi=mosi)
spi.write(bytearray([0xAA]))

sck.init(mode=Pin.OPEN_DRAIN, value=0)
```

Before/after this change (with 10k pull-up):
<img src="https://user-images.githubusercontent.com/466760/209588753-07d4e101-752b-41cc-9318-7fe0a3017221.png" width=350><img src="https://user-images.githubusercontent.com/466760/209589759-6816503f-4ec6-42cb-84bd-6a2f184055e2.png" width=350>

As I noted in the issue, the last one seems weird since `init` apparently disobeys its value argument in open-drain mode.