### PR TITLE
tools/pyboard.py : Set DTR on Windows to avoid ESPxx hard reset.

### DIFF
--- a/tools/pyboard.py
+++ b/tools/pyboard.py
@@ -286,7 +286,15 @@ class Pyboard:
             delayed = False
             for attempt in range(wait + 1):
                 try:
-                    self.serial = serial.Serial(device, **serial_kwargs)
+                    if os.name == "nt":
+                        # Windows does not set DTR or RTS by default
+                        self.serial = serial.Serial(**serial_kwargs)
+                        self.serial.dtr = True
+                        self.serial.rts = False
+                        self.serial.port = device
+                        self.serial.open()
+                    else:
+                        self.serial = serial.Serial(device, **serial_kwargs)
                     break
                 except (OSError, IOError):  # Py2 and Py3 have different errors
                     if wait == 0:


### PR DESCRIPTION
Fixes https://github.com/micropython/micropython/issues/9659

Based on @mgsb's proposal in https://github.com/micropython/micropython/issues/9659#issuecomment-1312791767  with added logic to _only apply the fix to Windows hosts_ 

## Tests

Tested on : 
| Host | MCU  |  result  |
|---|---|---|
| Windows  | ESP32  | ✅ |
| Windows  | ESP8266 | ✅ |
| Windows  | PYBD v1 | ✅ |
| Windows  | rp2 | ✅ |
| Windows  | samd | ✅ |
| Ubuntu 22.04 | ESP32  | ✅ |
| Ubuntu 22.04 | ESP8266 | ✅ |
| Ubuntu 22.04  | PYBD v1 | ✅ |
| Ubuntu 22.04  | rp2 | ✅ |
| Ubuntu 22.04 | samd | ✅ |

As there are currently no tests for mpremote in the repo I have created a stand alone test for this using pytest :
https://gist.github.com/Josverl/57159ee096dc941f294c745056fe341c

Happy to add test, but currently the build / test process for mpremote is not clear to me