### PR TITLE
ports/unix: Disable the shared library of libffi

### DIFF
--- a/ports/unix/Makefile
+++ b/ports/unix/Makefile
@@ -294,7 +294,7 @@ $(TOP)/lib/libffi/configure: $(TOP)/lib/libffi/autogen.sh
 # docs and depending on makeinfo
 $(BUILD)/lib/libffi/include/ffi.h: $(TOP)/lib/libffi/configure
 	mkdir -p $(BUILD)/lib/libffi; cd $(BUILD)/lib/libffi; \
-	$(abspath $(TOP))/lib/libffi/configure $(CROSS_COMPILE_HOST) --prefix=$$PWD/out --disable-structs CC="$(CC)" CXX="$(CXX)" LD="$(LD)" CFLAGS="-Os -fomit-frame-pointer -fstrict-aliasing -ffast-math -fno-exceptions"; \
+	$(abspath $(TOP))/lib/libffi/configure $(CROSS_COMPILE_HOST) --prefix=$$PWD/out --disable-shared --disable-structs CC="$(CC)" CXX="$(CXX)" LD="$(LD)" CFLAGS="-Os -fomit-frame-pointer -fstrict-aliasing -ffast-math -fno-exceptions"; \
 	$(MAKE) install-exec-recursive; $(MAKE) -C include install-data-am
 
 PREFIX = /usr/local


### PR DESCRIPTION
Hi, I was trying to build an static copy of MicroPython with zig as crosscompiler and I saw a problem building the shared library in the bundled copy of libffi. MicroPython doesn't need the shared library, so I disabled it in the configure.

The change was tested with gcc and clang and both pass the tests.