### PR TITLE
Added tx set tx power for ESP8266

### DIFF
--- a/ports/esp8266/modnetwork.c
+++ b/ports/esp8266/modnetwork.c
@@ -410,6 +410,11 @@ STATIC mp_obj_t esp_config(size_t n_args, const mp_obj_t *args, mp_map_t *kwargs
                         wifi_set_phy_mode(mp_obj_get_int(kwargs->table[i].value));
                         break;
                     }
+                    case MP_QSTR_txpower: {
+                        int8_t power = (mp_obj_get_float(kwargs->table[i].value) * 4);
+                        system_phy_set_max_tpw(power);
+                        break;
+                    }
                     default:
                         goto unknown;
                 }


### PR DESCRIPTION
Hello I added the set of tx power for ESP8266, only set method are available by espressif API.
The dBm quantization are always 0.25, but respect to ESP32 the range in input is [0 - 82] corresponding to [0 - 20.5] dBm
