### PR TITLE
nrf/modules/utime: Add time.sleep().

### DIFF
--- a/ports/nrf/modules/utime/modutime.c
+++ b/ports/nrf/modules/utime/modutime.c
@@ -40,6 +40,7 @@
 STATIC const mp_rom_map_elem_t time_module_globals_table[] = {
     { MP_ROM_QSTR(MP_QSTR___name__), MP_ROM_QSTR(MP_QSTR_utime) },
 
+    { MP_ROM_QSTR(MP_QSTR_sleep), MP_ROM_PTR(&mp_utime_sleep_obj) },
     { MP_ROM_QSTR(MP_QSTR_sleep_ms), MP_ROM_PTR(&mp_utime_sleep_ms_obj) },
     { MP_ROM_QSTR(MP_QSTR_sleep_us), MP_ROM_PTR(&mp_utime_sleep_us_obj) },
     { MP_ROM_QSTR(MP_QSTR_ticks_ms), MP_ROM_PTR(&mp_utime_ticks_ms_obj) },


### PR DESCRIPTION
Add time.sleep() to be consistent with other ports.

Signed-off-by: Stig Bjørlykke <stig@bjorlykke.org>