### PR TITLE
mimxrt: Set MICROPY_GC_STACK_ENTRY_TYPE to uint32_t for large RAM.

### DIFF
--- a/ports/mimxrt/mpconfigport.h
+++ b/ports/mimxrt/mpconfigport.h
@@ -37,7 +37,11 @@ uint32_t trng_random_u32(void);
 #define MICROPY_CONFIG_ROM_LEVEL (MICROPY_CONFIG_ROM_LEVEL_FULL_FEATURES)
 
 // Memory allocation policies
+#if MICROPY_HW_SDRAM_AVAIL
+#define MICROPY_GC_STACK_ENTRY_TYPE         uint32_t
+#else
 #define MICROPY_GC_STACK_ENTRY_TYPE         uint16_t
+#endif
 #define MICROPY_ALLOC_PARSE_CHUNK_INIT      (32)
 #define MICROPY_ALLOC_PATH_MAX              (256)
 


### PR DESCRIPTION
It was uint16_t. The change sets it to uint32_t for devices with large SDRAM. Fixes issue #10366.