### PR TITLE
ports/esp32/machine_sdcard.c: Fix ESP_ERR_INVALID_ARG on SDCard init on ESP32-S3 (Change DMA channel)

### DIFF
--- a/ports/esp32/machine_sdcard.c
+++ b/ports/esp32/machine_sdcard.c
@@ -211,7 +211,7 @@ STATIC mp_obj_t machine_sdcard_make_new(const mp_obj_type_t *type, size_t n_args
                 .gpio_cs = GPIO_NUM_34,
                 .gpio_cd = SDSPI_SLOT_NO_CD,
                 .gpio_wp = SDSPI_SLOT_NO_WP,
-                .dma_channel = 2
+                .dma_channel = SPI_DMA_CH_AUTO
             },
             SDSPI_SLOT_CONFIG_DEFAULT()
         };


### PR DESCRIPTION
This pull request solves the problem that initialization of SDCard objects with SPI fails on ESP32-S3.

### Problem
Creating `SDCard` object with SPI (slot=2 or 3) causes `ESP_ERR_INVALID_ARG` error.

```
[0;31mE (34340) spi: spi_bus_initialize(762): invalid dma channel, chip only support spi dma channel auto-alloc[0m
[0;31mE (34340) sdspi_host: spi_bus_initialize failed with rc=0x102[0m
```
The code below can reproduce this.
```py
import os
from machine import Pin, SDCard

card = SDCard(slot=2, sck=Pin(17), miso=Pin(18), mosi=Pin(16), cs=Pin(15)) # <- ESP_ERR_INVALID_ARG

```
### Reason
In ports/esp32/machine_sdcard.c, SPI slot configurations are defined. However, the DMA channel specified in the configuration for ESP32-S3 is inappropriate. In ESP-IDF, the only available channel for ESP32S3 is `SPI_DMA_CH_AUTO`=3.

[esp-idf/components/driver/spi_common.c](https://github.com/espressif/esp-idf/blob/8a7f6af6256f4c954053e08e819f55b93ddc1ff1/components/driver/spi_common.c#L764)

### Solution
Specifying DMA channel 3 instead of 2 fixes the problem. I have confirmed the problem and the solution on ESP32-S3-DevKitC-1 board.