### PR TITLE
github/workflows/code_size: Print code size change.

### DIFF
--- a/.github/workflows/code_size.yml
+++ b/.github/workflows/code_size.yml
@@ -28,7 +28,7 @@ jobs:
     - name: Build
       run: source tools/ci.sh && ci_code_size_build
     - name: Compute code size difference
-      run: tools/metrics.py diff ~/size0 ~/size1 | tee > diff
+      run: tools/metrics.py diff ~/size0 ~/size1 | tee diff
     - name: Save PR number
       if: github.event_name == 'pull_request'
       env:


### PR DESCRIPTION
The intention of using `tee` is to both print the code size change in the CI logs and save them to a file. Using redirection to a file caused it to not print the changes.
