### PR TITLE
extmod/uasyncio/funcs: In gather, ensure gather_task is defined.

### DIFF
--- a/extmod/uasyncio/funcs.py
+++ b/extmod/uasyncio/funcs.py
@@ -69,7 +69,6 @@ def gather(*aws, return_exceptions=False):
     def done(t, er):
         # Sub-task "t" has finished, with exception "er".
         nonlocal state
-        nonlocal gather_task
         if gather_task.data is not _Remove:
             # The main gather task has already been scheduled, so do nothing.
             # This happens if another sub-task already raised an exception and


### PR DESCRIPTION
As described in issue:
https://github.com/micropython/micropython/issues/10512

In gather, it is possible for the done method to be called before gather_task is defined, causing NameError. This PR ensures gather_task is defined before it is possible for done to be called.