### PR TITLE
Fix default implementation of MP_OBJ_TO_PTR and MP_OBJ_FROM_PTR with an expression as argument

### DIFF
--- a/py/obj.h
+++ b/py/obj.h
@@ -313,12 +313,12 @@ typedef union _mp_rom_obj_t {
 
 // Cast mp_obj_t to object pointer
 #ifndef MP_OBJ_TO_PTR
-#define MP_OBJ_TO_PTR(o) ((void *)o)
+#define MP_OBJ_TO_PTR(o) ((void *)(o))
 #endif
 
 // Cast object pointer to mp_obj_t
 #ifndef MP_OBJ_FROM_PTR
-#define MP_OBJ_FROM_PTR(p) ((mp_obj_t)p)
+#define MP_OBJ_FROM_PTR(p) ((mp_obj_t)(p))
 #endif
 
 // Macros to create objects that are stored in ROM.


### PR DESCRIPTION
Unless MICROPY_OBJ_REPR == MICROPY_OBJ_REPR_D, these macros only work with values and `->`/`.` expressions as their sole argument. In other words, the macros are broken with expressions which contain operations of lower precedence than the cast operator.

Depending on situation, the old code either results in a compiler error:

     MP_OBJ_TO_PTR(flag ? o1 : o2) expands into "(void *)flag ? o1 : o2",
     which some compiler configurations will reject (e.g. GCC -Wint-conversion
     -Wint-to-pointer-cast -Werror)

Or in an incorrect address calculation:

    For ptr declared as "uint8_t *" the MP_OBJ_FROM_PTR(ptr + off)
    expands into "((mp_obj_t)ptr) + off", resulting in an obviously
    wrong address.