### PR TITLE
esp32: Avoid crash when calling wlan.ifconfig() before wlan.connect().

### DIFF
--- a/ports/esp32/network_wlan.c
+++ b/ports/esp32/network_wlan.c
@@ -35,6 +35,7 @@
 
 #include "py/objlist.h"
 #include "py/runtime.h"
+#include "py/mphal.h"
 #include "modnetwork.h"
 
 #include "esp_wifi.h"
@@ -210,6 +211,12 @@ STATIC mp_obj_t network_wlan_active(size_t n_args, const mp_obj_t *args) {
                 wifi_started = true;
             }
         }
+        // This delay is a band-aid patch for issues #8289, #8792 and #9236,
+        // allowing the esp data structures to settle. It looks like some
+        // kind of race condition, which is not yet found. But at least
+        // this small delay seems not hurt much, since wlan.active() is
+        // usually not called in a time critical part of the code.
+        mp_hal_delay_ms(1);
     }
 
     return (mode & bit) ? mp_const_true : mp_const_false;


### PR DESCRIPTION
By adding a delay of 1 ms at the end of wlan.ifconfig(). It avoids the crashes reported by the issues #8289, #8792 and #9236 with esp-idf versions >= 4.2, but does not solve an underlying problem in the esp-idf with esp_wifi_start(). But that function seems to be located in a binary blob and not available for further analysis.