### PR TITLE
rp2: Fix crash in a pin.irq handler.

### DIFF
--- a/ports/rp2/machine_pin.c
+++ b/ports/rp2/machine_pin.c
@@ -423,7 +423,7 @@ STATIC machine_pin_irq_obj_t *machine_pin_get_irq(mp_hal_pin_obj_t pin) {
         irq = m_new_obj(machine_pin_irq_obj_t);
         irq->base.base.type = &mp_irq_type;
         irq->base.methods = (mp_irq_methods_t *)&machine_pin_irq_methods;
-        irq->base.parent = MP_OBJ_FROM_PTR(&machine_pin_cpu_pins[pin]);
+        irq->base.parent = MP_OBJ_FROM_PTR(machine_pin_cpu_pins[pin]);
         irq->base.handler = mp_const_none;
         irq->base.ishard = false;
         MP_STATE_PORT(machine_pin_irq_obj[pin]) = irq;


### PR DESCRIPTION
When accessing the argument of the irq function. Fixes issue #10547.