### PR TITLE
py/objint_mpz: Catch and reject @ and @= operating on big integers.

### DIFF
--- a/py/objint_mpz.c
+++ b/py/objint_mpz.c
@@ -296,8 +296,7 @@ mp_obj_t mp_obj_int_binary_op(mp_binary_op_t op, mp_obj_t lhs_in, mp_obj_t rhs_i
                 mpz_pow_inpl(&res->mpz, zlhs, zrhs);
                 break;
 
-            default: {
-                assert(op == MP_BINARY_OP_DIVMOD);
+            case MP_BINARY_OP_DIVMOD: {
                 if (mpz_is_zero(zrhs)) {
                     goto zero_division_error;
                 }
@@ -306,6 +305,9 @@ mp_obj_t mp_obj_int_binary_op(mp_binary_op_t op, mp_obj_t lhs_in, mp_obj_t rhs_i
                 mp_obj_t tuple[2] = {MP_OBJ_FROM_PTR(quo), MP_OBJ_FROM_PTR(res)};
                 return mp_obj_new_tuple(2, tuple);
             }
+
+            default:
+                return MP_OBJ_NULL; // op not supported
         }
 
         return MP_OBJ_FROM_PTR(res);

--- a/tests/basics/int_big_error.py
+++ b/tests/basics/int_big_error.py
@@ -8,6 +8,16 @@ except ValueError:
     print("ValueError")
 
 try:
+    i @ 0
+except TypeError:
+    print("TypeError")
+
+try:
+    i @= 0
+except TypeError:
+    print("TypeError")
+
+try:
     len(i)
 except TypeError:
     print("TypeError")


### PR DESCRIPTION
This will also catch / and /= when float support is disabled.

Fixes issue #10544.

Code size change on PYBV10 is +0 bytes.  On esp8266 it's -4 bytes.  I didn't check other ports.