### PR TITLE
windows/msvc: Remove variant suffix from executable filename.

### DIFF
--- a/ports/windows/msvc/common.props
+++ b/ports/windows/msvc/common.props
@@ -6,6 +6,7 @@
   <PropertyGroup>
     <PyVariant Condition="'$(PyVariant)' == ''">standard</PyVariant>
     <PyBuild Condition="'$(PyBuild)' == ''">build-$(PyVariant)</PyBuild>
+    <PyProg Condition="'$(PyProg)' == ''">micropython</PyProg>
   </PropertyGroup>
   <ImportGroup Label="PropertySheets">
     <Import Project="paths.props" Condition="'$(PyPathsIncluded)' != 'True'"/>

--- a/ports/windows/variants/dev/mpconfigvariant.props
+++ b/ports/windows/variants/dev/mpconfigvariant.props
@@ -1,8 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003" ToolsVersion="14.0">
-  <PropertyGroup>
-    <PyProg>micropython-dev</PyProg>
-  </PropertyGroup>
   <ItemDefinitionGroup>
     <ClCompile>
       <PreprocessorDefinitions>%(PreprocessorDefinitions);MICROPY_ROM_TEXT_COMPRESSION=1</PreprocessorDefinitions>

--- a/ports/windows/variants/standard/mpconfigvariant.props
+++ b/ports/windows/variants/standard/mpconfigvariant.props
@@ -1,6 +1,3 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003" ToolsVersion="14.0">
-  <PropertyGroup>
-    <PyProg>micropython</PyProg>
-  </PropertyGroup>
 </Project>


### PR DESCRIPTION
This is in line with the change made for other ports in d53c3b6a: since the default output directory already includes the variant name in it there's no need to add it to the executable as well.

Sorry I completely looked over this both for #7780 and #10133. Or perhaps thought there was a good reason to not change it, but currently I don't see any :)