### PR TITLE
nrf/random: Unleash seeding of the PRNG by a hardware RNG.

### DIFF
--- a/ports/nrf/mpconfigport.h
+++ b/ports/nrf/mpconfigport.h
@@ -277,6 +277,11 @@ typedef int mp_int_t; // must be pointer size
 typedef unsigned int mp_uint_t; // must be pointer size
 typedef long mp_off_t;
 
+#if MICROPY_HW_ENABLE_RNG
+#define MICROPY_PY_URANDOM_SEED_INIT_FUNC (rng_generate_random_word())
+long unsigned int rng_generate_random_word(void);
+#endif
+
 #if BOARD_SPECIFIC_MODULES
 #include "boardmodules.h"
 #endif // BOARD_SPECIFIC_MODULES


### PR DESCRIPTION
A suitable function already existed, so just the declaration was needed.