### PR TITLE
shared/runtime/gchelper: Drop cpu directive from Arm helpers.

### DIFF
--- a/ports/cc3200/application.mk
+++ b/ports/cc3200/application.mk
@@ -162,7 +162,7 @@ APP_STM_SRC_C = $(addprefix ports/stm32/,\
 OBJ = $(PY_O) $(addprefix $(BUILD)/, $(APP_FATFS_SRC_C:.c=.o) $(APP_RTOS_SRC_C:.c=.o) $(APP_FTP_SRC_C:.c=.o) $(APP_HAL_SRC_C:.c=.o) $(APP_MISC_SRC_C:.c=.o))
 OBJ += $(addprefix $(BUILD)/, $(APP_MODS_SRC_C:.c=.o) $(APP_CC3100_SRC_C:.c=.o) $(APP_SL_SRC_C:.c=.o) $(APP_TELNET_SRC_C:.c=.o) $(APP_UTIL_SRC_C:.c=.o) $(APP_UTIL_SRC_S:.s=.o))
 OBJ += $(addprefix $(BUILD)/, $(APP_MAIN_SRC_C:.c=.o) $(APP_SHARED_SRC_C:.c=.o) $(APP_LIB_SRC_C:.c=.o) $(APP_STM_SRC_C:.c=.o))
-OBJ += $(BUILD)/shared/runtime/gchelper_m3.o
+OBJ += $(BUILD)/shared/runtime/gchelper_thumb2.o
 OBJ += $(BUILD)/pins.o
 
 # List of sources for qstr extraction

--- a/ports/mimxrt/Makefile
+++ b/ports/mimxrt/Makefile
@@ -262,7 +262,7 @@ SRC_SS = \
 	$(MCU_DIR)/gcc/startup_$(MCU_SERIES)$(MCU_CORE).S \
 	hal/resethandler_MIMXRT10xx.S
 
-SRC_S += shared/runtime/gchelper_m3.s \
+SRC_S += shared/runtime/gchelper_thumb2.s \
 
 # =============================================================================
 # QSTR Sources

--- a/ports/qemu-arm/Makefile
+++ b/ports/qemu-arm/Makefile
@@ -17,7 +17,7 @@ ifeq ($(BOARD),netduino2)
 CFLAGS += -mthumb -mcpu=cortex-m3 -mfloat-abi=soft
 CFLAGS += -DQEMU_SOC_STM32
 LDSCRIPT = stm32.ld
-SRC_BOARD_O = shared/runtime/gchelper_native.o shared/runtime/gchelper_m3.o
+SRC_BOARD_O = shared/runtime/gchelper_native.o shared/runtime/gchelper_thumb2.o
 MPY_CROSS_FLAGS += -march=armv7m
 endif
 
@@ -26,7 +26,7 @@ CFLAGS += -mthumb -mcpu=cortex-m0 -mfloat-abi=soft
 CFLAGS += -DQEMU_SOC_NRF51
 LDSCRIPT = nrf51.ld
 QEMU_EXTRA = -global nrf51-soc.flash-size=1048576 -global nrf51-soc.sram-size=262144
-SRC_BOARD_O = shared/runtime/gchelper_native.o shared/runtime/gchelper_m0.o
+SRC_BOARD_O = shared/runtime/gchelper_native.o shared/runtime/gchelper_thumb1.o
 MPY_CROSS_FLAGS += -march=armv7m
 endif
 
@@ -34,7 +34,7 @@ ifeq ($(BOARD),mps2-an385)
 CFLAGS += -mthumb -mcpu=cortex-m3 -mfloat-abi=soft
 CFLAGS += -DQEMU_SOC_MPS2
 LDSCRIPT = mps2.ld
-SRC_BOARD_O = shared/runtime/gchelper_native.o shared/runtime/gchelper_m3.o
+SRC_BOARD_O = shared/runtime/gchelper_native.o shared/runtime/gchelper_thumb2.o
 MPY_CROSS_FLAGS += -march=armv7m
 endif
 

--- a/ports/renesas-ra/Makefile
+++ b/ports/renesas-ra/Makefile
@@ -335,7 +335,7 @@ SRC_O += \
 	$(SYSTEM_FILE)
 
 SRC_O += \
-	shared/runtime/gchelper_m3.o
+	shared/runtime/gchelper_thumb2.o
 
 HAL_SRC_C += $(addprefix $(HAL_DIR)/ra/board/$(BOARD_LOW)/,\
 	board_init.c \

--- a/ports/rp2/CMakeLists.txt
+++ b/ports/rp2/CMakeLists.txt
@@ -87,7 +87,7 @@ set(MICROPY_SOURCE_LIB
     ${MICROPY_DIR}/shared/netutils/netutils.c
     ${MICROPY_DIR}/shared/netutils/trace.c
     ${MICROPY_DIR}/shared/readline/readline.c
-    ${MICROPY_DIR}/shared/runtime/gchelper_m0.s
+    ${MICROPY_DIR}/shared/runtime/gchelper_thumb1.s
     ${MICROPY_DIR}/shared/runtime/gchelper_native.c
     ${MICROPY_DIR}/shared/runtime/interrupt_char.c
     ${MICROPY_DIR}/shared/runtime/mpirq.c

--- a/ports/samd/mcu/samd21/mpconfigmcu.mk
+++ b/ports/samd/mcu/samd21/mpconfigmcu.mk
@@ -2,7 +2,7 @@ CFLAGS_MCU += -mtune=cortex-m0plus -mcpu=cortex-m0plus -msoft-float
 
 MPY_CROSS_MCU_ARCH = armv6m
 
-SRC_S += shared/runtime/gchelper_m0.s
+SRC_S += shared/runtime/gchelper_thumb1.s
 
 LIBM_SRC_C +=  $(addprefix lib/libm/,\
 	acoshf.c \

--- a/ports/samd/mcu/samd51/mpconfigmcu.mk
+++ b/ports/samd/mcu/samd51/mpconfigmcu.mk
@@ -6,7 +6,7 @@ MICROPY_VFS_LFS2 ?= 1
 MICROPY_VFS_FAT ?= 1
 FROZEN_MANIFEST ?= mcu/$(MCU_SERIES_LOWER)/manifest.py
 
-SRC_S += shared/runtime/gchelper_m3.s
+SRC_S += shared/runtime/gchelper_thumb2.s
 
 SRC_C += \
 	fatfs_port.c \

--- a/ports/stm32/Makefile
+++ b/ports/stm32/Makefile
@@ -362,18 +362,18 @@ ifeq ($(MCU_SERIES),$(filter $(MCU_SERIES),f0 g0 l0))
 CSUPEROPT = -Os # save some code space
 SRC_O += \
 	resethandler_m0.o \
-	shared/runtime/gchelper_m0.o
+	shared/runtime/gchelper_thumb1.o
 else
 ifeq ($(MCU_SERIES),l1)
 CFLAGS += -DUSE_HAL_DRIVER
 SRC_O += \
 	resethandler_m3.o \
-	shared/runtime/gchelper_m3.o
+	shared/runtime/gchelper_thumb2.o
 else
 SRC_O += \
 	system_stm32.o \
 	resethandler.o \
-	shared/runtime/gchelper_m3.o
+	shared/runtime/gchelper_thumb2.o
 endif
 endif
 

--- a/ports/teensy/Makefile
+++ b/ports/teensy/Makefile
@@ -169,7 +169,7 @@ OBJ += $(addprefix $(BUILD)/, $(SRC_C:.c=.o))
 OBJ += $(addprefix $(BUILD)/, $(STM_SRC_C:.c=.o))
 OBJ += $(addprefix $(BUILD)/, $(SRC_TEENSY:.c=.o))
 OBJ += $(addprefix $(BUILD)/, $(SHARED_SRC_C:.c=.o))
-OBJ += $(BUILD)/shared/runtime/gchelper_m3.o
+OBJ += $(BUILD)/shared/runtime/gchelper_thumb2.o
 OBJ += $(GEN_PINS_SRC:.c=.o)
 
 all: hex

--- a/shared/runtime/gchelper_generic.c
+++ b/shared/runtime/gchelper_generic.c
@@ -98,7 +98,7 @@ STATIC void gc_helper_get_regs(gc_helper_regs_t arr) {
 
 #elif defined(__thumb2__) || defined(__thumb__) || defined(__arm__)
 
-// Fallback implementation, prefer gchelper_m0.s or gchelper_m3.s
+// Fallback implementation, prefer gchelper_thumb1.s or gchelper_thumb2.s
 
 STATIC void gc_helper_get_regs(gc_helper_regs_t arr) {
     register long r4 asm ("r4");

--- a/shared/runtime/gchelper_thumb1.s
+++ b/shared/runtime/gchelper_thumb1.s
@@ -3,7 +3,7 @@
  *
  * The MIT License (MIT)
  *
- * Copyright (c) 2013-2014 Damien P. George
+ * Copyright (c) 2018 Damien P. George
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -25,31 +25,39 @@
  */
 
     .syntax unified
-    .cpu cortex-m3
     .thumb
 
     .section .text
-    .align  2
+    .align 2
 
     .global gc_helper_get_regs_and_sp
     .type gc_helper_get_regs_and_sp, %function
 
+@ This function will compile on processors like Cortex M0 that don't support
+@ newer Thumb-2 instructions.
+
 @ uint gc_helper_get_regs_and_sp(r0=uint regs[10])
 gc_helper_get_regs_and_sp:
     @ store registers into given array
-    str     r4, [r0], #4
-    str     r5, [r0], #4
-    str     r6, [r0], #4
-    str     r7, [r0], #4
-    str     r8, [r0], #4
-    str     r9, [r0], #4
-    str     r10, [r0], #4
-    str     r11, [r0], #4
-    str     r12, [r0], #4
-    str     r13, [r0], #4
+    str    r4, [r0, #0]
+    str    r5, [r0, #4]
+    str    r6, [r0, #8]
+    str    r7, [r0, #12]
+    mov    r1, r8
+    str    r1, [r0, #16]
+    mov    r1, r9
+    str    r1, [r0, #20]
+    mov    r1, r10
+    str    r1, [r0, #24]
+    mov    r1, r11
+    str    r1, [r0, #28]
+    mov    r1, r12
+    str    r1, [r0, #32]
+    mov    r1, r13
+    str    r1, [r0, #36]
 
     @ return the sp
-    mov     r0, sp
-    bx      lr
+    mov    r0, sp
+    bx     lr
 
     .size gc_helper_get_regs_and_sp, .-gc_helper_get_regs_and_sp

--- a/shared/runtime/gchelper_thumb2.s
+++ b/shared/runtime/gchelper_thumb2.s
@@ -3,7 +3,7 @@
  *
  * The MIT License (MIT)
  *
- * Copyright (c) 2018 Damien P. George
+ * Copyright (c) 2013-2014 Damien P. George
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -25,37 +25,32 @@
  */
 
     .syntax unified
-    .cpu cortex-m0
     .thumb
 
     .section .text
-    .align 2
+    .align  2
 
     .global gc_helper_get_regs_and_sp
     .type gc_helper_get_regs_and_sp, %function
 
+@ This function requires Thumb-2 instruction support, e.g. Cortex M3/M4.
+
 @ uint gc_helper_get_regs_and_sp(r0=uint regs[10])
 gc_helper_get_regs_and_sp:
     @ store registers into given array
-    str    r4, [r0, #0]
-    str    r5, [r0, #4]
-    str    r6, [r0, #8]
-    str    r7, [r0, #12]
-    mov    r1, r8
-    str    r1, [r0, #16]
-    mov    r1, r9
-    str    r1, [r0, #20]
-    mov    r1, r10
-    str    r1, [r0, #24]
-    mov    r1, r11
-    str    r1, [r0, #28]
-    mov    r1, r12
-    str    r1, [r0, #32]
-    mov    r1, r13
-    str    r1, [r0, #36]
+    str     r4, [r0], #4
+    str     r5, [r0], #4
+    str     r6, [r0], #4
+    str     r7, [r0], #4
+    str     r8, [r0], #4
+    str     r9, [r0], #4
+    str     r10, [r0], #4
+    str     r11, [r0], #4
+    str     r12, [r0], #4
+    str     r13, [r0], #4
 
     @ return the sp
-    mov    r0, sp
-    bx     lr
+    mov     r0, sp
+    bx      lr
 
     .size gc_helper_get_regs_and_sp, .-gc_helper_get_regs_and_sp


### PR DESCRIPTION
This drops the `.cpu` directive from the Arm gchelper_*.s files. This broke the linker when targeting older CPUs (e.g. it broke `-mthumb -mthumb-interwork` for `-mcpu=arm7tdmi`). The actual target CPU should be determined by the compiler options.

The exact CPU doesn't actually matter, but rather the supported assembly instruction set. So we rename the files to *_thumb1.s and *thumb2.s to indicate the instruction set support instead of the CPU support.
