### PR TITLE
msvc: Fix module freezing

### DIFF
--- a/mpy-cross/main.c
+++ b/mpy-cross/main.c
@@ -182,6 +182,15 @@ STATIC void pre_process_options(int argc, char **argv) {
     }
 }
 
+STATIC char *backslash_to_forwardslash(char *path) {
+    for (char *p = path; p != NULL && *p != '\0'; ++p) {
+        if (*p == '\\') {
+            *p = '/';
+        }
+    }
+    return path;
+}
+
 MP_NOINLINE int main_(int argc, char **argv) {
     mp_stack_set_limit(40000 * (sizeof(void *) / 4));
 
@@ -242,7 +251,7 @@ MP_NOINLINE int main_(int argc, char **argv) {
                     exit(usage(argv));
                 }
                 a += 1;
-                source_file = argv[a];
+                source_file = backslash_to_forwardslash(argv[a]);
             } else if (strncmp(argv[a], "-msmall-int-bits=", sizeof("-msmall-int-bits=") - 1) == 0) {
                 char *end;
                 mp_dynamic_compiler.small_int_bits =
@@ -308,7 +317,7 @@ MP_NOINLINE int main_(int argc, char **argv) {
                 mp_printf(&mp_stderr_print, "multiple input files\n");
                 exit(1);
             }
-            input_file = argv[a];
+            input_file = backslash_to_forwardslash(argv[a]);
         }
     }
 

--- a/ports/windows/.appveyor.yml
+++ b/ports/windows/.appveyor.yml
@@ -34,7 +34,7 @@ before_build:
     <?xml version="1.0" encoding="utf-8"?>
     <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
       <Target Name="Build">
-        <MsBuild BuildInParallel="True" Projects="mpy-cross\mpy-cross.vcxproj;ports\windows\micropython.vcxproj"/>
+        <MsBuild Projects="mpy-cross\mpy-cross.vcxproj;ports\windows\micropython.vcxproj"/>
       </Target>
     </Project>
     "@ | Set-Content build.proj

--- a/ports/windows/msvc/common.props
+++ b/ports/windows/msvc/common.props
@@ -3,14 +3,14 @@
   <!-- Variant support. For compatibility with how it works for the other ports, this gets imported
        early so variants cannot override build options like the ones specified in the rest of this file.
        Use CustomPropsFile (see the .vcxproj file) for that. -->
-  <PropertyGroup>
+  <PropertyGroup Condition="'$(PyBuildingMpyCross)' != 'True'">
     <PyVariant Condition="'$(PyVariant)' == ''">standard</PyVariant>
     <PyBuild Condition="'$(PyBuild)' == ''">build-$(PyVariant)</PyBuild>
     <PyProg Condition="'$(PyProg)' == ''">micropython</PyProg>
   </PropertyGroup>
   <ImportGroup Label="PropertySheets">
     <Import Project="paths.props" Condition="'$(PyPathsIncluded)' != 'True'"/>
-    <Import Project="$(PyVariantDir)mpconfigvariant.props"/>
+    <Import Condition="'$(PyBuildingMpyCross)' != 'True'" Project="$(PyVariantDir)mpconfigvariant.props"/>
   </ImportGroup>
   <PropertyGroup Label="UserMacros" />
   <PropertyGroup>

--- a/ports/windows/msvc/common.props
+++ b/ports/windows/msvc/common.props
@@ -6,6 +6,7 @@
   <PropertyGroup>
     <PyVariant Condition="'$(PyVariant)' == ''">standard</PyVariant>
     <PyBuild Condition="'$(PyBuild)' == ''">build-$(PyVariant)</PyBuild>
+    <PyProg Condition="'$(PyProg)' == ''">micropython</PyProg>
   </PropertyGroup>
   <ImportGroup Label="PropertySheets">
     <Import Project="paths.props" Condition="'$(PyPathsIncluded)' != 'True'"/>

--- a/ports/windows/msvc/genhdr.targets
+++ b/ports/windows/msvc/genhdr.targets
@@ -150,7 +150,9 @@ using(var outFile = System.IO.File.CreateText(OutputFile)) {
       <TmpFile>$(QstrGen).tmp</TmpFile>
     </PropertyGroup>
     <Exec Command="$(PyClTool) /nologo /I@(PyIncDirs, ' /I') /D@(PreProcDefs, ' /D') /E $(PyQstrDefs) $(QstrDefs) > $(DestDir)qstrdefs.preprocessed.h"/>
-    <Exec Command="$(PyPython) $(PySrcDir)makeqstrdata.py $(DestDir)qstrdefs.preprocessed.h $(QstrDefsCollected) > $(TmpFile)"/>
+    <!--Because makemanifest.py relies on this file to have all Q() and QCFG() entries.-->
+    <Exec Command="type $(QstrDefsCollected) >> $(DestDir)qstrdefs.preprocessed.h"/>
+    <Exec Command="$(PyPython) $(PySrcDir)makeqstrdata.py $(DestDir)qstrdefs.preprocessed.h > $(TmpFile)"/>
     <MSBuild Projects="$(MSBuildThisFileFullPath)" Targets="CopyFileIfDifferent" Properties="SourceFile=$(TmpFile);DestFile=$(QstrGen)"/>
   </Target>
 
@@ -167,7 +169,7 @@ using(var outFile = System.IO.File.CreateText(OutputFile)) {
     <ItemGroup>
       <ClCompile Include="$(PyBuildDir)frozen_content.c"/>
       <ClCompile>
-        <PreprocessorDefinitions>MICROPY_MODULE_FROZEN_MPY=1;MICROPY_QSTR_EXTRA_POOL=mp_qstr_frozen_const_pool;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+        <PreprocessorDefinitions>MICROPY_MODULE_FROZEN_MPY=1;MICROPY_QSTR_EXTRA_POOL=mp_qstr_frozen_const_pool;MPZ_DIG_SIZE=16;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       </ClCompile>
     </ItemGroup>
     <Exec Command="$(PyPython) $(PyBaseDir)tools\makemanifest.py -v MPY_DIR=$(PyBaseDir) -v MPY_LIB_DIR=$(PyBaseDir)/lib/micropython-lib -v PORT_DIR=$(PyWinDir) -o $(PyBuildDir)frozen_content.c -b $(PyBuildDir) $(FrozenManifest)"/>

--- a/ports/windows/msvc/genhdr.targets
+++ b/ports/windows/msvc/genhdr.targets
@@ -62,7 +62,7 @@ using(var outFile = System.IO.File.CreateText(OutputFile)) {
   </ItemGroup>
 
   <!-- Preprocess changed files, concatenate and feed into makeqstrdefs.py split/cat-->
-  <Target Name="MakeQstrDefs" DependsOnTargets="MakeDestDir" Inputs="@(ClCompile);@(QstrDependencies)" Outputs="$(QstrDefsCollected)">
+  <Target Name="MakeQstrDefs" DependsOnTargets="MakeDestDir;MakeVersionHdr" Inputs="@(ClCompile);@(QstrDependencies)" Outputs="$(QstrDefsCollected)">
     <ItemGroup>
       <PyIncDirs Include="$(PyIncDirs)"/>
       <PreProcDefs Include="%(ClCompile.PreProcessorDefinitions);NO_QSTR"/>

--- a/ports/windows/variants/dev/mpconfigvariant.props
+++ b/ports/windows/variants/dev/mpconfigvariant.props
@@ -1,5 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003" ToolsVersion="14.0">
+  <PropertyGroup>
+    <FrozenManifest>$(PyVariantDir)manifest.py</FrozenManifest>
+  </PropertyGroup>
   <ItemDefinitionGroup>
     <ClCompile>
       <PreprocessorDefinitions>%(PreprocessorDefinitions);MICROPY_ROM_TEXT_COMPRESSION=1</PreprocessorDefinitions>

--- a/ports/windows/variants/dev/mpconfigvariant.props
+++ b/ports/windows/variants/dev/mpconfigvariant.props
@@ -1,8 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003" ToolsVersion="14.0">
-  <PropertyGroup>
-    <PyProg>micropython-dev</PyProg>
-  </PropertyGroup>
   <ItemDefinitionGroup>
     <ClCompile>
       <PreprocessorDefinitions>%(PreprocessorDefinitions);MICROPY_ROM_TEXT_COMPRESSION=1</PreprocessorDefinitions>

--- a/ports/windows/variants/standard/mpconfigvariant.props
+++ b/ports/windows/variants/standard/mpconfigvariant.props
@@ -1,6 +1,3 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003" ToolsVersion="14.0">
-  <PropertyGroup>
-    <PyProg>micropython</PyProg>
-  </PropertyGroup>
 </Project>


### PR DESCRIPTION
Brought up in #10548, freezing of 'real' modules didn't actually work for a couple of reasons; probably implementation was only tested once on a simple file.
Note:
- makemanifest.py relies on qstrdefs.preprocessed.h containing all possible qstrs. This happens to be how py.mk creates qstrdefs.preprocessed.h, but for the msbuild build there were 2 separate files which I now concatenated. Alternative would be to alter makemanifest and give it arguments to pass multiple files but that seems overkill?
- main issue was backslash vs forward slash in paths. In mpy-tool I fixed the occurrences which made building of the dev variant (i.e. freezing of uasyncio) fail and some others I noticed, but I'm not quite sure that's really all of it. Alternative would be to have mpy-cross generate .mpy files with forward slashes only and then everything else probably just works? Would that be preferrable?