### PR TITLE
stm32: fix build without MICROPY_ENABLE_SCHEDULER

### DIFF
--- a/ports/mimxrt/systick.c
+++ b/ports/mimxrt/systick.c
@@ -48,9 +48,11 @@ void SysTick_Handler(void) {
         f(uw_tick);
     }
 
+    #if MICROPY_ENABLE_SCHEDULER
     if (soft_timer_next == uw_tick) {
         pendsv_schedule_dispatch(PENDSV_DISPATCH_SOFT_TIMER, soft_timer_handler);
     }
+    #endif
 }
 
 bool systick_has_passed(uint32_t start_tick, uint32_t delay_ms) {

--- a/ports/renesas-ra/systick.c
+++ b/ports/renesas-ra/systick.c
@@ -60,9 +60,11 @@ void SysTick_Handler(void) {
         f(uw_tick);
     }
 
+    #if MICROPY_ENABLE_SCHEDULER
     if (soft_timer_next == uw_tick) {
         pendsv_schedule_dispatch(PENDSV_DISPATCH_SOFT_TIMER, soft_timer_handler);
     }
+    #endif
 
     #if MICROPY_PY_THREAD
     if (pyb_thread_enabled) {

--- a/ports/samd/samd_isr.c
+++ b/ports/samd/samd_isr.c
@@ -94,9 +94,11 @@ void SysTick_Handler(void) {
     uint32_t next_tick = systick_ms + 1;
     systick_ms = next_tick;
 
+    #if MICROPY_ENABLE_SCHEDULER
     if (soft_timer_next == next_tick) {
         pendsv_schedule_dispatch(PENDSV_DISPATCH_SOFT_TIMER, soft_timer_handler);
     }
+    #endif
 }
 
 void us_timer_IRQ(void) {

--- a/ports/stm32/gccollect.c
+++ b/ports/stm32/gccollect.c
@@ -53,7 +53,9 @@ void gc_collect(void) {
     #endif
 
     // trace soft timer nodes
+    #if MICROPY_ENABLE_SCHEDULER
     soft_timer_gc_mark_all();
+    #endif
 
     // end the GC
     gc_collect_end();

--- a/ports/stm32/systick.c
+++ b/ports/stm32/systick.c
@@ -54,9 +54,11 @@ void SysTick_Handler(void) {
         f(uw_tick);
     }
 
+    #if MICROPY_ENABLE_SCHEDULER
     if (soft_timer_next == uw_tick) {
         pendsv_schedule_dispatch(PENDSV_DISPATCH_SOFT_TIMER, soft_timer_handler);
     }
+    #endif
 
     #if MICROPY_PY_THREAD
     if (pyb_thread_enabled) {


### PR DESCRIPTION
Without the scheduler the build fails with:
```
 ports/stm32/softtimer.c: In function 'soft_timer_handler':
 ports/stm32/softtimer.c:87:13: error: implicit declaration of function 'mp_sched_schedule' [-Werror=implicit-function-declaration]
             mp_sched_schedule(entry->py_callback, MP_OBJ_FROM_PTR(entry));
             ^~~~~~~~~~~~~~~~~
```