### PR TITLE
tools/mpy-tool.py: Initialize line_info_top

### DIFF
--- a/tools/mpy-tool.py
+++ b/tools/mpy-tool.py
@@ -937,6 +937,10 @@ class RawCode(object):
                 % (self.escaped_name, self.offset_line_info)
             )
             print(
+                "        .line_info_top = fun_data_%s + %u,"
+                % (self.escaped_name, self.offset_closure_info)
+            )
+            print(
                 "        .opcodes = fun_data_%s + %u," % (self.escaped_name, self.offset_opcodes)
             )
             print("    },")


### PR DESCRIPTION
Somewhere between 1.17 and 1.19 (probably f2040bfc7ee033e48acef9f289790f3b4e6b74e5) line number mapping stopped working for frozen modules, this seems to make it work again.