### PR TITLE
pyexec: Include interrupt_char.h to remove compiler warning.

### DIFF
--- a/shared/runtime/pyexec.c
+++ b/shared/runtime/pyexec.c
@@ -25,9 +25,7 @@
  */
 
 #include <stdlib.h>
-#include <stdio.h>
 #include <stdint.h>
-#include <string.h>
 
 #include "py/compile.h"
 #include "py/runtime.h"
@@ -42,6 +40,7 @@
 #include "shared/readline/readline.h"
 #include "shared/runtime/pyexec.h"
 #include "genhdr/mpversion.h"
+#include "interrupt_char.h"
 
 pyexec_mode_kind_t pyexec_mode_kind = PYEXEC_MODE_FRIENDLY_REPL;
 int pyexec_system_exit = 0;


### PR DESCRIPTION
Include `interrupt_char.h` to remove 'implicit declaration' warning for function `mp_hal_set_interrupt_char`, besides unused header files are also removed.