### PR TITLE
ports/RTC: Attempt to reduce the inconsistencies between the port's RTC implementation.

### DIFF
--- a/docs/esp32/quickref.rst
+++ b/docs/esp32/quickref.rst
@@ -577,7 +577,9 @@ See :ref:`machine.RTC <machine.RTC>` ::
     from machine import RTC
 
     rtc = RTC()
-    rtc.datetime((2017, 8, 23, 1, 12, 48, 0, 0)) # set a specific date and time
+    rtc.datetime((2017, 8, 23, 0, 1, 12, 48, 0)) # set a specific date and
+                                                 # time, eg. 2017/8/23 1:12:48
+                                                 # the day-of-week value is ignored
     rtc.datetime() # get date and time
 
 WDT (Watchdog timer)

--- a/docs/esp8266/quickref.rst
+++ b/docs/esp8266/quickref.rst
@@ -284,7 +284,9 @@ See :ref:`machine.RTC <machine.RTC>` ::
     from machine import RTC
 
     rtc = RTC()
-    rtc.datetime((2017, 8, 23, 1, 12, 48, 0, 0)) # set a specific date and time
+    rtc.datetime((2017, 8, 23, 0, 1, 12, 48, 0)) # set a specific date and
+                                                 # time, eg. 2017/8/23 1:12:48
+                                                 # the day-of-week value is ignored
     rtc.datetime() # get date and time
 
     # synchronize with ntp

--- a/docs/library/machine.RTC.rst
+++ b/docs/library/machine.RTC.rst
@@ -48,6 +48,8 @@ Methods
 
    Get get the current datetime tuple.
 
+   Availability: WiPy.
+
 .. method:: RTC.deinit()
 
    Resets the RTC to the time of January 1, 2015 and starts running it again.

--- a/docs/library/machine.RTC.rst
+++ b/docs/library/machine.RTC.rst
@@ -42,7 +42,14 @@ Methods
 
    Initialise the RTC. Datetime is a tuple of the form:
 
-      ``(year, month, day[, hour[, minute[, second[, microsecond[, tzinfo]]]]])``
+      ``(year, month, day, hour, minute, second, microsecond, tzinfo)``
+
+   All eight arguments must be present. The ``microsecond`` and ``tzinfo``
+   values are currently ignored but might be used in the future.
+
+   Availability: CC3200, ESP32, MIMXRT, SAMD. The rtc.init() method on
+   the stm32 and renesas-ra ports just (re-)starts the RTC and does not
+   accept arguments.
 
 .. method:: RTC.now()
 

--- a/docs/mimxrt/quickref.rst
+++ b/docs/mimxrt/quickref.rst
@@ -429,7 +429,9 @@ See :ref:`machine.RTC <machine.RTC>`::
     from machine import RTC
 
     rtc = RTC()
-    rtc.datetime((2017, 8, 23, 1, 12, 48, 0, 0)) # set a specific date and time
+    rtc.datetime((2017, 8, 23, 0, 1, 12, 48, 0)) # set a specific date and
+                                                 # time, eg. 2017/8/23 1:12:48
+                                                 # the day-of-week value is ignored
     rtc.datetime() # get date and time
     rtc.now() # return date and time in CPython format.
 

--- a/docs/pyboard/quickref.rst
+++ b/docs/pyboard/quickref.rst
@@ -138,7 +138,9 @@ See :ref:`pyb.RTC <pyb.RTC>` ::
     from pyb import RTC
 
     rtc = RTC()
-    rtc.datetime((2017, 8, 23, 1, 12, 48, 0, 0)) # set a specific date and time
+    rtc.datetime((2017, 8, 23, 0, 1, 12, 48, 0)) # set a specific date and
+                                                 # time, eg. 2017/8/23 1:12:48
+                                                 # the day-of-week value is ignored
     rtc.datetime() # get date and time
 
 PWM (pulse width modulation)

--- a/docs/renesas-ra/quickref.rst
+++ b/docs/renesas-ra/quickref.rst
@@ -206,8 +206,9 @@ See :ref:`machine.RTC <machine.RTC>` ::
     from machine import RTC
 
     rtc = RTC()
-    rtc.datetime((2017, 8, 23, 1, 12, 48, 0, 0)) # set a specific date and time
-                                                 # time, eg 2017/8/23 1:12:48
+    rtc.datetime((2017, 8, 23, 0, 1, 12, 48, 0)) # set a specific date and
+                                                 # time, eg. 2017/8/23 1:12:48
+                                                 # the day-of-week value is ignored
     rtc.datetime() # get date and time
 
 Following functions are not supported at the present::

--- a/docs/rp2/quickref.rst
+++ b/docs/rp2/quickref.rst
@@ -310,8 +310,9 @@ See :ref:`machine.RTC <machine.RTC>` ::
     from machine import RTC
 
     rtc = RTC()
-    rtc.datetime((2017, 8, 23, 2, 12, 48, 0, 0)) # set a specific date and
+    rtc.datetime((2017, 8, 23, 0, 1, 12, 48, 0)) # set a specific date and
                                                  # time, eg. 2017/8/23 1:12:48
+                                                 # the day-of-week value is ignored
     rtc.datetime() # get date and time
 
 WDT (Watchdog timer)

--- a/ports/esp32/machine_rtc.c
+++ b/ports/esp32/machine_rtc.c
@@ -101,7 +101,7 @@ static mp_obj_t machine_rtc_make_new(const mp_obj_type_t *type, size_t n_args, s
     return (mp_obj_t)&machine_rtc_obj;
 }
 
-static mp_obj_t machine_rtc_datetime_helper(mp_uint_t n_args, const mp_obj_t *args) {
+static mp_obj_t machine_rtc_datetime_helper(mp_uint_t n_args, const mp_obj_t *args, int hour_index) {
     if (n_args == 1) {
         // Get time
 
@@ -131,7 +131,14 @@ static mp_obj_t machine_rtc_datetime_helper(mp_uint_t n_args, const mp_obj_t *ar
         mp_obj_get_array_fixed_n(args[1], 8, &items);
 
         struct timeval tv = {0};
-        tv.tv_sec = timeutils_seconds_since_epoch(mp_obj_get_int(items[0]), mp_obj_get_int(items[1]), mp_obj_get_int(items[2]), mp_obj_get_int(items[4]), mp_obj_get_int(items[5]), mp_obj_get_int(items[6]));
+        tv.tv_sec = timeutils_seconds_since_epoch(
+            mp_obj_get_int(items[0]),
+            mp_obj_get_int(items[1]),
+            mp_obj_get_int(items[2]),
+            mp_obj_get_int(items[hour_index]),
+            mp_obj_get_int(items[hour_index + 1]),
+            mp_obj_get_int(items[hour_index + 2])
+            );
         tv.tv_usec = mp_obj_get_int(items[7]);
         settimeofday(&tv, NULL);
 
@@ -139,13 +146,13 @@ static mp_obj_t machine_rtc_datetime_helper(mp_uint_t n_args, const mp_obj_t *ar
     }
 }
 static mp_obj_t machine_rtc_datetime(size_t n_args, const mp_obj_t *args) {
-    return machine_rtc_datetime_helper(n_args, args);
+    return machine_rtc_datetime_helper(n_args, args, 4);
 }
 static MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(machine_rtc_datetime_obj, 1, 2, machine_rtc_datetime);
 
 static mp_obj_t machine_rtc_init(mp_obj_t self_in, mp_obj_t date) {
     mp_obj_t args[2] = {self_in, date};
-    machine_rtc_datetime_helper(2, args);
+    machine_rtc_datetime_helper(2, args, 3);
 
     return mp_const_none;
 }

--- a/ports/mimxrt/machine_rtc.c
+++ b/ports/mimxrt/machine_rtc.c
@@ -230,25 +230,6 @@ static mp_obj_t machine_rtc_datetime(mp_uint_t n_args, const mp_obj_t *args) {
 }
 static MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(machine_rtc_datetime_obj, 1, 2, machine_rtc_datetime);
 
-static mp_obj_t machine_rtc_now(mp_obj_t self_in) {
-    // Get date and time in CPython order.
-    snvs_lp_srtc_datetime_t srtc_date;
-    SNVS_LP_SRTC_GetDatetime(SNVS, &srtc_date);
-
-    mp_obj_t tuple[8] = {
-        mp_obj_new_int(srtc_date.year),
-        mp_obj_new_int(srtc_date.month),
-        mp_obj_new_int(srtc_date.day),
-        mp_obj_new_int(srtc_date.hour),
-        mp_obj_new_int(srtc_date.minute),
-        mp_obj_new_int(srtc_date.second),
-        mp_obj_new_int(0),
-        mp_const_none,
-    };
-    return mp_obj_new_tuple(8, tuple);
-}
-static MP_DEFINE_CONST_FUN_OBJ_1(machine_rtc_now_obj, machine_rtc_now);
-
 static mp_obj_t machine_rtc_init(mp_obj_t self_in, mp_obj_t date) {
     mp_obj_t args[2] = {self_in, date};
     machine_rtc_datetime_helper(2, args);
@@ -389,7 +370,6 @@ static MP_DEFINE_CONST_FUN_OBJ_KW(machine_rtc_irq_obj, 1, machine_rtc_irq);
 static const mp_rom_map_elem_t machine_rtc_locals_dict_table[] = {
     { MP_ROM_QSTR(MP_QSTR_init), MP_ROM_PTR(&machine_rtc_init_obj) },
     { MP_ROM_QSTR(MP_QSTR_datetime), MP_ROM_PTR(&machine_rtc_datetime_obj) },
-    { MP_ROM_QSTR(MP_QSTR_now), MP_ROM_PTR(&machine_rtc_now_obj) },
     { MP_ROM_QSTR(MP_QSTR_calibration), MP_ROM_PTR(&machine_rtc_calibration_obj) },
     { MP_ROM_QSTR(MP_QSTR_alarm), MP_ROM_PTR(&machine_rtc_alarm_obj) },
     { MP_ROM_QSTR(MP_QSTR_alarm_left), MP_ROM_PTR(&machine_rtc_alarm_left_obj) },

--- a/ports/mimxrt/machine_rtc.c
+++ b/ports/mimxrt/machine_rtc.c
@@ -185,7 +185,7 @@ static mp_obj_t machine_rtc_make_new(const mp_obj_type_t *type, size_t n_args, s
     return (mp_obj_t)&machine_rtc_obj;
 }
 
-static mp_obj_t machine_rtc_datetime_helper(size_t n_args, const mp_obj_t *args) {
+static mp_obj_t machine_rtc_datetime_helper(size_t n_args, const mp_obj_t *args, int hour_index) {
     if (n_args == 1) {
         // Get date and time.
         snvs_lp_srtc_datetime_t srtc_date;
@@ -214,9 +214,9 @@ static mp_obj_t machine_rtc_datetime_helper(size_t n_args, const mp_obj_t *args)
         srtc_date.month = mp_obj_get_int(items[1]);
         srtc_date.day = mp_obj_get_int(items[2]);
         // Ignore weekday at items[3]
-        srtc_date.hour = mp_obj_get_int(items[4]);
-        srtc_date.minute = mp_obj_get_int(items[5]);
-        srtc_date.second = mp_obj_get_int(items[6]);
+        srtc_date.hour = mp_obj_get_int(items[hour_index]);
+        srtc_date.minute = mp_obj_get_int(items[hour_index + 1]);
+        srtc_date.second = mp_obj_get_int(items[hour_index + 2]);
         if (SNVS_LP_SRTC_SetDatetime(SNVS, &srtc_date) != kStatus_Success) {
             mp_raise_ValueError(NULL);
         }
@@ -226,13 +226,13 @@ static mp_obj_t machine_rtc_datetime_helper(size_t n_args, const mp_obj_t *args)
 }
 
 static mp_obj_t machine_rtc_datetime(mp_uint_t n_args, const mp_obj_t *args) {
-    return machine_rtc_datetime_helper(n_args, args);
+    return machine_rtc_datetime_helper(n_args, args, 4);
 }
 static MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(machine_rtc_datetime_obj, 1, 2, machine_rtc_datetime);
 
 static mp_obj_t machine_rtc_init(mp_obj_t self_in, mp_obj_t date) {
     mp_obj_t args[2] = {self_in, date};
-    machine_rtc_datetime_helper(2, args);
+    machine_rtc_datetime_helper(2, args, 3);
     return mp_const_none;
 }
 static MP_DEFINE_CONST_FUN_OBJ_2(machine_rtc_init_obj, machine_rtc_init);

--- a/ports/samd/machine_rtc.c
+++ b/ports/samd/machine_rtc.c
@@ -93,7 +93,7 @@ static mp_obj_t machine_rtc_make_new(const mp_obj_type_t *type, size_t n_args, s
     return (mp_obj_t)&machine_rtc_obj;
 }
 
-static mp_obj_t machine_rtc_datetime_helper(size_t n_args, const mp_obj_t *args) {
+static mp_obj_t machine_rtc_datetime_helper(size_t n_args, const mp_obj_t *args, int hour_index) {
     // Rtc *rtc = RTC;
     if (n_args == 1) {
         // Get date and time.
@@ -120,9 +120,9 @@ static mp_obj_t machine_rtc_datetime_helper(size_t n_args, const mp_obj_t *args)
             RTC_MODE2_CLOCK_YEAR(mp_obj_get_int(items[0]) % 100) |
             RTC_MODE2_CLOCK_MONTH(mp_obj_get_int(items[1])) |
             RTC_MODE2_CLOCK_DAY(mp_obj_get_int(items[2])) |
-            RTC_MODE2_CLOCK_HOUR(mp_obj_get_int(items[4])) |
-            RTC_MODE2_CLOCK_MINUTE(mp_obj_get_int(items[5])) |
-            RTC_MODE2_CLOCK_SECOND(mp_obj_get_int(items[6]));
+            RTC_MODE2_CLOCK_HOUR(mp_obj_get_int(items[hour_index])) |
+            RTC_MODE2_CLOCK_MINUTE(mp_obj_get_int(items[hour_index + 1])) |
+            RTC_MODE2_CLOCK_SECOND(mp_obj_get_int(items[hour_index + 2]));
 
         RTC->MODE2.CLOCK.reg = date;
         #if defined(MCU_SAMD21)
@@ -138,13 +138,13 @@ static mp_obj_t machine_rtc_datetime_helper(size_t n_args, const mp_obj_t *args)
 }
 
 static mp_obj_t machine_rtc_datetime(mp_uint_t n_args, const mp_obj_t *args) {
-    return machine_rtc_datetime_helper(n_args, args);
+    return machine_rtc_datetime_helper(n_args, args, 4);
 }
 static MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(machine_rtc_datetime_obj, 1, 2, machine_rtc_datetime);
 
 static mp_obj_t machine_rtc_init(mp_obj_t self_in, mp_obj_t date) {
     mp_obj_t args[2] = {self_in, date};
-    machine_rtc_datetime_helper(2, args);
+    machine_rtc_datetime_helper(2, args, 3);
     return mp_const_none;
 }
 static MP_DEFINE_CONST_FUN_OBJ_2(machine_rtc_init_obj, machine_rtc_init);


### PR DESCRIPTION
This PR follows the issue #10578 and #5553 and other discussions about the topic. It consists of the commits:

- `docs/quickref: Fix the documentation of rtc.datetime()`, which makes the documentation of rtc.datetime() consistent to the implementation for all ports.
- `mimxrt/machine_rtc.c: Drop rtc.now()` Keep it at the WiPy port for legacy,
- `ports/RTC: Rework the availability and interface of rtc.init()`, which  drops rtc.init() from the SAMD port and makes it consistent to the documentation and the WiPy port for the ports ESP32 and MIMXRT. But rtc.init() could as well be dropped for the latter ones and just kept for WiPy.