### PR TITLE
stm32/boards/STM32F769DISC: Fix building with USE_QSPI_XIP=1.

### DIFF
--- a/ports/stm32/boards/STM32F769DISC/board_init.c
+++ b/ports/stm32/boards/STM32F769DISC/board_init.c
@@ -3,13 +3,17 @@
 
 // This configuration is needed for mboot to be able to write to the external QSPI flash
 
+#if MICROPY_HW_SPIFLASH_ENABLE_CACHE
 STATIC mp_spiflash_cache_t spi_bdev_cache;
+#endif
 
 const mp_spiflash_config_t spiflash_config = {
     .bus_kind = MP_SPIFLASH_BUS_QSPI,
     .bus.u_qspi.data = NULL,
     .bus.u_qspi.proto = &qspi_proto,
+    #if MICROPY_HW_SPIFLASH_ENABLE_CACHE
     .cache = &spi_bdev_cache,
+    #endif
 };
 
 spi_bdev_t spi_bdev;


### PR DESCRIPTION
A minor Makefile issue was identified during the development of https://github.com/micropython/micropython/pull/9054

STM32F769DISC has a feature to use its qspi flash in XIP (execute in place) mode:
```
# By default the filesystem is in external QSPI flash.  But by setting the
# following option this board puts some code into external flash set in XIP mode.
# USE_MBOOT must be enabled; see f769_qspi.ld for code that goes in QSPI flash
USE_QSPI_XIP ?= 0
```
However...
```
$ make BOARD=STM32F769DISC -j24 USE_QSPI_XIP=1
...
boards/STM32F769DISC/board_init.c:6:8: error: unknown type name 'mp_spiflash_cache_t'
 STATIC mp_spiflash_cache_t spi_bdev_cache;
        ^~~~~~~~~~~~~~~~~~~
boards/STM32F769DISC/board_init.c:12:6: error: 'const struct _mp_spiflash_config_t' has no member named 'cache'
     .cache = &spi_bdev_cache,
      ^~~~~
boards/STM32F769DISC/board_init.c:12:14: error: excess elements in struct initializer [-Werror]
     .cache = &spi_bdev_cache,
              ^
boards/STM32F769DISC/board_init.c:12:14: note: (near initialization for 'spiflash_config')
cc1: all warnings being treated as errors
-e See https://github.com/micropython/micropython/wiki/Build-Troubleshooting
make: *** [../../py/mkrules.mk:83: build-STM32F769DISC/boards/STM32F769DISC/board_init.o] Error 1
make: *** Waiting for unfinished jobs....
```

This PR fixes the spi cache config setting and the firmware now builds.

Note: I don't have this hardware so the fix hasn't been physically tested.