### PR TITLE
top: Update Python formatting to black "2023 stable style".

### DIFF
--- a/examples/SDdatalogger/datalogger.py
+++ b/examples/SDdatalogger/datalogger.py
@@ -10,7 +10,6 @@ switch = pyb.Switch()
 
 # loop
 while True:
-
     # wait for interrupt
     # this reduces power consumption while waiting for switch press
     pyb.wfi()

--- a/examples/asmsum.py
+++ b/examples/asmsum.py
@@ -1,6 +1,5 @@
 @micropython.asm_thumb
 def asm_sum_words(r0, r1):
-
     # r0 = len
     # r1 = ptr
     # r2 = sum
@@ -25,7 +24,6 @@ def asm_sum_words(r0, r1):
 
 @micropython.asm_thumb
 def asm_sum_bytes(r0, r1):
-
     # r0 = len
     # r1 = ptr
     # r2 = sum

--- a/examples/bluetooth/ble_uart_repl.py
+++ b/examples/bluetooth/ble_uart_repl.py
@@ -20,6 +20,7 @@ if hasattr(machine, "Timer"):
 else:
     _timer = None
 
+
 # Batch writes into 50ms intervals.
 def schedule_in(handler, delay_ms):
     def _wrap(_arg):

--- a/examples/conwaylife.py
+++ b/examples/conwaylife.py
@@ -4,6 +4,7 @@ import pyb
 lcd = pyb.LCD("x")
 lcd.light(1)
 
+
 # do 1 iteration of Conway's Game of Life
 def conway_step():
     for x in range(128):  # loop over x coordinates

--- a/examples/rp2/pio_exec.py
+++ b/examples/rp2/pio_exec.py
@@ -8,6 +8,7 @@ import time
 from machine import Pin
 import rp2
 
+
 # Define an empty program that uses a single set pin.
 @rp2.asm_pio(set_init=rp2.PIO.OUT_LOW)
 def prog():

--- a/examples/rp2/pio_uart_tx.py
+++ b/examples/rp2/pio_uart_tx.py
@@ -33,6 +33,7 @@ for i in range(NUM_UARTS):
     sm.active(1)
     uarts.append(sm)
 
+
 # We can print characters from each UART by pushing them to the TX FIFO
 def pio_uart_print(sm, s):
     for c in s:

--- a/extmod/uasyncio/__init__.py
+++ b/extmod/uasyncio/__init__.py
@@ -18,6 +18,7 @@ _attrs = {
     "StreamWriter": "stream",
 }
 
+
 # Lazy loader, effectively does:
 #   global attr
 #   from .mod import attr

--- a/extmod/uasyncio/core.py
+++ b/extmod/uasyncio/core.py
@@ -30,6 +30,7 @@ _exc_context = {"message": "Task exception wasn't retrieved", "exception": None,
 ################################################################################
 # Sleep functions
 
+
 # "Yield" once, then raise StopIteration
 class SingletonGenerator:
     def __init__(self):
@@ -131,6 +132,7 @@ class IOQueue:
 
 ################################################################################
 # Main run loop
+
 
 # Ensure the awaitable is a task
 def _promote_to_task(aw):

--- a/extmod/uasyncio/event.py
+++ b/extmod/uasyncio/event.py
@@ -3,6 +3,7 @@
 
 from . import core
 
+
 # Event class for primitive events that can be waited on, set, and cleared
 class Event:
     def __init__(self):

--- a/extmod/uasyncio/lock.py
+++ b/extmod/uasyncio/lock.py
@@ -3,6 +3,7 @@
 
 from . import core
 
+
 # Lock class for primitive mutex capability
 class Lock:
     def __init__(self):

--- a/ports/esp32/boards/UM_FEATHERS2/modules/feathers2.py
+++ b/ports/esp32/boards/UM_FEATHERS2/modules/feathers2.py
@@ -39,6 +39,7 @@ AMB_LIGHT = const(4)
 
 # Helper functions
 
+
 # LED & Ambient Light Sensor control
 def set_led(state):
     l = Pin(LED, Pin.OUT)

--- a/ports/esp32/boards/UM_FEATHERS2NEO/modules/feathers2neo.py
+++ b/ports/esp32/boards/UM_FEATHERS2NEO/modules/feathers2neo.py
@@ -38,6 +38,7 @@ I2C_SCL = const(9)
 DAC1 = const(17)
 DAC2 = const(18)
 
+
 # Helper functions
 def set_pixel_power(state):
     """Enable or Disable power to the onboard NeoPixel to either show colour, or to reduce power for deep sleep."""

--- a/ports/esp32/boards/UM_FEATHERS3/modules/feathers3.py
+++ b/ports/esp32/boards/UM_FEATHERS3/modules/feathers3.py
@@ -32,6 +32,7 @@ I2C_SCL = const(9)
 
 # Helper functions
 
+
 # LED & Ambient Light Sensor control
 def led_set(state):
     """Set the state of the BLUE LED on IO13"""

--- a/ports/esp32/boards/UM_PROS3/modules/pros3.py
+++ b/ports/esp32/boards/UM_PROS3/modules/pros3.py
@@ -28,6 +28,7 @@ SPI_CLK = const(36)
 I2C_SDA = const(8)
 I2C_SCL = const(9)
 
+
 # Helper functions
 def set_ldo2_power(state):
     """Enable or Disable power to the second LDO"""

--- a/ports/esp32/boards/UM_TINYPICO/modules/tinypico.py
+++ b/ports/esp32/boards/UM_TINYPICO/modules/tinypico.py
@@ -39,6 +39,7 @@ DAC2 = const(26)
 
 # Helper functions
 
+
 # Get a *rough* estimate of the current battery voltage
 # If the battery is not present, the charge IC will still report it's trying to charge at X voltage
 # so it will still show a voltage.

--- a/ports/esp32/boards/UM_TINYS3/modules/tinys3.py
+++ b/ports/esp32/boards/UM_TINYS3/modules/tinys3.py
@@ -28,6 +28,7 @@ SPI_CLK = const(36)
 I2C_SDA = const(8)
 I2C_SCL = const(9)
 
+
 # Helper functions
 def set_pixel_power(state):
     """Enable or Disable power to the onboard NeoPixel to either show colour, or to reduce power for deep sleep."""

--- a/ports/esp8266/makeimg.py
+++ b/ports/esp8266/makeimg.py
@@ -14,7 +14,6 @@ assert len(sys.argv) == 4
 md5 = hashlib.md5()
 
 with open(sys.argv[3], "wb") as fout:
-
     with open(sys.argv[1], "rb") as f:
         data_flash = f.read()
         fout.write(data_flash)

--- a/ports/esp8266/modules/port_diag.py
+++ b/ports/esp8266/modules/port_diag.py
@@ -5,7 +5,6 @@ import lwip
 
 
 def main():
-
     ROM = uctypes.bytearray_at(0x40200000, 16)
     fid = esp.flash_id()
 

--- a/ports/mimxrt/boards/make-flexram-config.py
+++ b/ports/mimxrt/boards/make-flexram-config.py
@@ -53,6 +53,7 @@ According to AN12077:
 """
 ocram_min_size = 0x00010000  # 64 KB
 
+
 # Value parser
 def mimxrt_default_parser(defines_file, features_file, ld_script):
     with open(ld_script, "r") as input_file:

--- a/ports/nrf/examples/powerup.py
+++ b/ports/nrf/examples/powerup.py
@@ -187,7 +187,6 @@ class PowerUp3:
         self.old_speed = 0
 
         while True:
-
             time.sleep_ms(100)
 
             # read out new angle

--- a/ports/stm32/boards/NUCLEO_WB55/rfcore_makefirmware.py
+++ b/ports/stm32/boards/NUCLEO_WB55/rfcore_makefirmware.py
@@ -65,7 +65,6 @@ def get_details(release_notes, filename):
 
 
 def main(src_path, dest_path):
-
     # Load the release note to parse for important details
     with open(os.path.join(src_path, _RELEASE_NOTES), "rb") as f:
         release_notes = f.read()

--- a/ports/stm32/boards/make-pins.py
+++ b/ports/stm32/boards/make-pins.py
@@ -506,7 +506,6 @@ class Pins(object):
 
     def print_af_defs(self, af_defs_filename, cmp_strings):
         with open(af_defs_filename, "wt") as af_defs_file:
-
             STATIC_AF_TOKENS = {}
             for named_pin in self.cpu_pins:
                 for af in named_pin.pin().alt_fn:

--- a/ports/stm32/make-stmconst.py
+++ b/ports/stm32/make-stmconst.py
@@ -29,6 +29,7 @@ elif platform.python_version_tuple()[0] == "3":
 
 # end compatibility code
 
+
 # given a list of (name,regex) pairs, find the first one that matches the given line
 def re_match_first(regexs, line):
     for name, regex in regexs:

--- a/py/makeqstrdata.py
+++ b/py/makeqstrdata.py
@@ -222,6 +222,7 @@ static_qstr_list = [
     "zip",
 ]
 
+
 # this must match the equivalent function in qstr.c
 def compute_hash(qstr, bytes_hash):
     hash = 5381

--- a/tests/esp32/esp32_idf_heap_info.py
+++ b/tests/esp32/esp32_idf_heap_info.py
@@ -5,6 +5,7 @@ except ImportError:
     print("SKIP")
     raise SystemExit
 
+
 # region tuple is: (size, free, largest free, min free)
 # we check that each region's size is > 0 and that the free amounts are smaller than the size
 def chk_heap(kind, regions):

--- a/tests/extmod/framebuf_subclass.py
+++ b/tests/extmod/framebuf_subclass.py
@@ -34,6 +34,7 @@ fb.pixel(2, 2, 0x0708)
 fb2.blit(fb, 0, 0)
 print(bytes(fb2))
 
+
 # Test that blitting something that isn't a subclass fails with TypeError.
 class NotAFrameBuf:
     pass

--- a/tests/extmod/uasyncio_exception.py
+++ b/tests/extmod/uasyncio_exception.py
@@ -9,6 +9,7 @@ except ImportError:
         print("SKIP")
         raise SystemExit
 
+
 # main task raising an exception
 async def main():
     print("main start")
@@ -20,6 +21,7 @@ try:
     asyncio.run(main())
 except ValueError as er:
     print("ValueError", er.args[0])
+
 
 # sub-task raising an exception
 async def task():
@@ -39,6 +41,7 @@ try:
     asyncio.run(main())
 except ValueError as er:
     print("ValueError", er.args[0])
+
 
 # main task raising an exception with sub-task not yet scheduled
 # TODO not currently working, task is never scheduled

--- a/tests/extmod/vfs_fat_fileio1.py
+++ b/tests/extmod/vfs_fat_fileio1.py
@@ -13,7 +13,6 @@ except AttributeError:
 
 
 class RAMFS:
-
     SEC_SIZE = 512
 
     def __init__(self, blocks):

--- a/tests/extmod/vfs_fat_fileio2.py
+++ b/tests/extmod/vfs_fat_fileio2.py
@@ -13,7 +13,6 @@ except AttributeError:
 
 
 class RAMFS:
-
     SEC_SIZE = 512
 
     def __init__(self, blocks):

--- a/tests/extmod/vfs_fat_more.py
+++ b/tests/extmod/vfs_fat_more.py
@@ -12,7 +12,6 @@ except AttributeError:
 
 
 class RAMFS:
-
     SEC_SIZE = 512
 
     def __init__(self, blocks):

--- a/tests/extmod/vfs_fat_oldproto.py
+++ b/tests/extmod/vfs_fat_oldproto.py
@@ -13,7 +13,6 @@ except AttributeError:
 
 
 class RAMFS_OLD:
-
     SEC_SIZE = 512
 
     def __init__(self, blocks):

--- a/tests/extmod/vfs_fat_ramdisk.py
+++ b/tests/extmod/vfs_fat_ramdisk.py
@@ -13,7 +13,6 @@ except AttributeError:
 
 
 class RAMFS:
-
     SEC_SIZE = 512
 
     def __init__(self, blocks):

--- a/tests/extmod/vfs_fat_ramdisklarge.py
+++ b/tests/extmod/vfs_fat_ramdisklarge.py
@@ -14,7 +14,6 @@ except AttributeError:
 
 
 class RAMBDevSparse:
-
     SEC_SIZE = 512
 
     def __init__(self, blocks):

--- a/tests/extmod/websocket_basic.py
+++ b/tests/extmod/websocket_basic.py
@@ -6,6 +6,7 @@ except ImportError:
     print("SKIP")
     raise SystemExit
 
+
 # put raw data in the stream and do a websocket read
 def ws_read(msg, sz):
     ws = uwebsocket.websocket(uio.BytesIO(msg))

--- a/tests/import/module_getattr.py
+++ b/tests/import/module_getattr.py
@@ -8,6 +8,7 @@ try:
 except AttributeError:
     pass
 
+
 # define __getattr__
 def __getattr__(attr):
     if attr == "does_not_exist":

--- a/tests/inlineasm/asmsum.py
+++ b/tests/inlineasm/asmsum.py
@@ -1,6 +1,5 @@
 @micropython.asm_thumb
 def asm_sum_words(r0, r1):
-
     # r0 = len
     # r1 = ptr
     # r2 = sum
@@ -25,7 +24,6 @@ def asm_sum_words(r0, r1):
 
 @micropython.asm_thumb
 def asm_sum_bytes(r0, r1):
-
     # r0 = len
     # r1 = ptr
     # r2 = sum

--- a/tests/micropython/const2.py
+++ b/tests/micropython/const2.py
@@ -11,12 +11,14 @@ import micropython as X
 
 print(globals()["X"])
 
+
 # function name that matches a constant
 def X():
     print("function X", X)
 
 
 globals()["X"]()
+
 
 # arguments that match a constant
 def f(X, *Y, **Z):
@@ -25,6 +27,7 @@ def f(X, *Y, **Z):
 
 f(1)
 
+
 # class name that matches a constant
 class X:
     def f(self):
@@ -32,6 +35,7 @@ class X:
 
 
 globals()["X"]().f()
+
 
 # constant within a class
 class A:

--- a/tests/micropython/heapalloc_yield_from.py
+++ b/tests/micropython/heapalloc_yield_from.py
@@ -2,6 +2,7 @@
 
 import micropython
 
+
 # Yielding from a function generator
 def sub_gen(a):
     for i in range(a):
@@ -17,6 +18,7 @@ micropython.heap_lock()
 print(next(g))
 print(next(g))
 micropython.heap_unlock()
+
 
 # Yielding from a user iterator
 class G:

--- a/tests/micropython/native_closure.py
+++ b/tests/micropython/native_closure.py
@@ -1,5 +1,6 @@
 # test native emitter can handle closures correctly
 
+
 # basic closure
 @micropython.native
 def f():
@@ -15,6 +16,7 @@ def f():
 
 print(f()())
 
+
 # closing over an argument
 @micropython.native
 def f(x):
@@ -27,6 +29,7 @@ def f(x):
 
 
 print(f(2)())
+
 
 # closing over an argument and a normal local
 @micropython.native

--- a/tests/micropython/native_gen.py
+++ b/tests/micropython/native_gen.py
@@ -1,5 +1,6 @@
 # test for native generators
 
+
 # simple generator with yield and return
 @micropython.native
 def gen1(x):
@@ -15,6 +16,7 @@ try:
     next(g)
 except StopIteration as e:
     print(e.args[0])
+
 
 # using yield from
 @micropython.native

--- a/tests/micropython/native_misc.py
+++ b/tests/micropython/native_misc.py
@@ -1,5 +1,6 @@
 # tests for natively compiled functions
 
+
 # basic test
 @micropython.native
 def native_test(x):
@@ -14,6 +15,7 @@ import gc
 gc.collect()
 native_test(3)
 
+
 # native with 2 args
 @micropython.native
 def f(a, b):
@@ -22,6 +24,7 @@ def f(a, b):
 
 f(1, 2)
 
+
 # native with 3 args
 @micropython.native
 def f(a, b, c):
@@ -29,6 +32,7 @@ def f(a, b, c):
 
 
 f(1, 2, 3)
+
 
 # check not operator
 @micropython.native

--- a/tests/micropython/native_try.py
+++ b/tests/micropython/native_try.py
@@ -1,5 +1,6 @@
 # test native try handling
 
+
 # basic try-finally
 @micropython.native
 def f():
@@ -14,6 +15,7 @@ try:
 except NameError:
     print("NameError")
 
+
 # nested try-except with try-finally
 @micropython.native
 def f():
@@ -27,6 +29,7 @@ def f():
 
 
 f()
+
 
 # check that locals written to in try blocks keep their values
 @micropython.native

--- a/tests/micropython/native_try_deep.py
+++ b/tests/micropython/native_try_deep.py
@@ -1,5 +1,6 @@
 # test native try handling
 
+
 # deeply nested try (9 deep)
 @micropython.native
 def f():

--- a/tests/micropython/native_with.py
+++ b/tests/micropython/native_with.py
@@ -21,6 +21,7 @@ def f():
 
 f()
 
+
 # nested with and try-except
 @micropython.native
 def f():

--- a/tests/micropython/viper_args.py
+++ b/tests/micropython/viper_args.py
@@ -56,6 +56,7 @@ def f6(x1: int, x2: int, x3: int, x4: int, x5: int, x6: int):
 
 f6(1, 2, 3, 4, 5, 6)
 
+
 # test compiling *x, **x, * args (currently unsupported at runtime)
 @micropython.viper
 def f(*x, **y):

--- a/tests/micropython/viper_cond.py
+++ b/tests/micropython/viper_cond.py
@@ -10,6 +10,7 @@ def f():
 
 f()
 
+
 # using True as a conditional
 @micropython.viper
 def f():
@@ -20,6 +21,7 @@ def f():
 
 f()
 
+
 # using an int as a conditional
 @micropython.viper
 def g():
@@ -29,6 +31,7 @@ def g():
 
 
 g()
+
 
 # using an int as a conditional that has the lower 16-bits clear
 @micropython.viper

--- a/tests/micropython/viper_misc.py
+++ b/tests/micropython/viper_misc.py
@@ -1,5 +1,6 @@
 import micropython
 
+
 # viper function taking and returning ints
 @micropython.viper
 def viper_int(x: int, y: int) -> int:
@@ -7,6 +8,7 @@ def viper_int(x: int, y: int) -> int:
 
 
 print(viper_int(1, 2))
+
 
 # viper function taking and returning objects
 @micropython.viper
@@ -16,6 +18,7 @@ def viper_object(x: object, y: object) -> object:
 
 print(viper_object(1, 2))
 
+
 # return None as non-object (should return 0)
 @micropython.viper
 def viper_ret_none() -> int:
@@ -23,6 +26,7 @@ def viper_ret_none() -> int:
 
 
 print(viper_ret_none())
+
 
 # return Ellipsis as object
 @micropython.viper
@@ -32,6 +36,7 @@ def viper_ret_ellipsis() -> object:
 
 print(viper_ret_ellipsis())
 
+
 # 3 args
 @micropython.viper
 def viper_3args(a: int, b: int, c: int) -> int:
@@ -39,6 +44,7 @@ def viper_3args(a: int, b: int, c: int) -> int:
 
 
 print(viper_3args(1, 2, 3))
+
 
 # 4 args
 @micropython.viper
@@ -49,6 +55,7 @@ def viper_4args(a: int, b: int, c: int, d: int) -> int:
 # viper call with 4 args not yet supported
 # print(viper_4args(1, 2, 3, 4))
 
+
 # a local (should have automatic type int)
 @micropython.viper
 def viper_local(x: int) -> int:
@@ -58,6 +65,7 @@ def viper_local(x: int) -> int:
 
 print(viper_local(3))
 
+
 # without type annotation, types should default to object
 @micropython.viper
 def viper_no_annotation(x, y):
@@ -65,6 +73,7 @@ def viper_no_annotation(x, y):
 
 
 print(viper_no_annotation(4, 5))
+
 
 # a for loop
 @micropython.viper
@@ -77,6 +86,7 @@ def viper_for(a: int, b: int) -> int:
 
 print(viper_for(10, 10000))
 
+
 # accessing a global
 @micropython.viper
 def viper_access_global():
@@ -87,6 +97,7 @@ def viper_access_global():
 
 print(viper_access_global(), gl)
 
+
 # calling print with object and int types
 @micropython.viper
 def viper_print(x, y: int):
@@ -94,6 +105,7 @@ def viper_print(x, y: int):
 
 
 viper_print(1, 2)
+
 
 # convert constants to objects in tuple
 @micropython.viper
@@ -103,6 +115,7 @@ def viper_tuple_consts(x):
 
 print(viper_tuple_consts(0))
 
+
 # making a tuple from an object and an int
 @micropython.viper
 def viper_tuple(x, y: int):
@@ -110,6 +123,7 @@ def viper_tuple(x, y: int):
 
 
 print(viper_tuple(1, 2))
+
 
 # making a list from an object and an int
 @micropython.viper
@@ -119,6 +133,7 @@ def viper_list(x, y: int):
 
 print(viper_list(1, 2))
 
+
 # making a set from an object and an int
 @micropython.viper
 def viper_set(x, y: int):
@@ -126,6 +141,7 @@ def viper_set(x, y: int):
 
 
 print(sorted(list(viper_set(1, 2))))
+
 
 # raising an exception
 @micropython.viper
@@ -137,6 +153,7 @@ try:
     viper_raise(1)
 except OSError as e:
     print(repr(e))
+
 
 # calling GC after defining the function
 @micropython.viper

--- a/tests/micropython/viper_misc2.py
+++ b/tests/micropython/viper_misc2.py
@@ -1,5 +1,6 @@
 # Miscellaneous viper tests
 
+
 # Test correct use of registers in load and store
 @micropython.viper
 def expand(dest: ptr8, source: ptr8, length: int):

--- a/tests/micropython/viper_misc_intbig.py
+++ b/tests/micropython/viper_misc_intbig.py
@@ -1,5 +1,6 @@
 import micropython
 
+
 # unsigned ints
 @micropython.viper
 def viper_uint() -> uint:

--- a/tests/micropython/viper_try.py
+++ b/tests/micropython/viper_try.py
@@ -1,5 +1,6 @@
 # test try handling within a viper function
 
+
 # basic try-finally
 @micropython.viper
 def f():
@@ -14,6 +15,7 @@ try:
 except NameError:
     print("NameError")
 
+
 # nested try-except with try-finally
 @micropython.viper
 def f():
@@ -27,6 +29,7 @@ def f():
 
 
 f()
+
 
 # check that locals written to in try blocks keep their values
 @micropython.viper

--- a/tests/micropython/viper_types.py
+++ b/tests/micropython/viper_types.py
@@ -2,6 +2,7 @@
 
 import micropython
 
+
 # converting incoming arg to bool
 @micropython.viper
 def f1(x: bool):
@@ -13,6 +14,7 @@ f1(1)
 f1([])
 f1([1])
 
+
 # taking and returning a bool
 @micropython.viper
 def f2(x: bool) -> bool:
@@ -21,6 +23,7 @@ def f2(x: bool) -> bool:
 
 print(f2([]))
 print(f2([1]))
+
 
 # converting to bool within function
 @micropython.viper

--- a/tests/micropython/viper_with.py
+++ b/tests/micropython/viper_with.py
@@ -21,6 +21,7 @@ def f():
 
 f()
 
+
 # nested with and try-except
 @micropython.viper
 def f():

--- a/tests/misc/non_compliant.py
+++ b/tests/misc/non_compliant.py
@@ -117,6 +117,7 @@ try:
 except NotImplementedError:
     print("NotImplementedError")
 
+
 # can't assign attributes to a function
 def f():
     pass
@@ -133,6 +134,7 @@ try:
 except TypeError:
     print("TypeError")
 
+
 # test when object explicitly listed at not-last position in parent tuple
 # this is not compliant with CPython because of illegal MRO
 class A:
@@ -145,6 +147,7 @@ class B(object, A):
 
 
 B().foo()
+
 
 # can't assign property (or other special accessors) to already-subclassed class
 class A:

--- a/tests/misc/print_exception.py
+++ b/tests/misc/print_exception.py
@@ -40,6 +40,7 @@ except Exception as e:
     print("caught")
     print_exc(e)
 
+
 # exception message with more than 1 source-code line
 def f():
     g()
@@ -76,6 +77,7 @@ try:
 except Exception as e:
     print("caught")
     print_exc(e)
+
 
 # Here we have a function with lots of bytecode generated for a single source-line, and
 # there is an error right at the end of the bytecode.  It should report the correct line.

--- a/tests/misc/sys_settrace_generator.py
+++ b/tests/misc/sys_settrace_generator.py
@@ -48,11 +48,9 @@ def test_generator():
     gen = make_gen()
     r = 0
     try:
-
         r += gen.send(None)
 
         while True:
-
             r += gen.send(None)
 
     except StopIteration as e:

--- a/tests/misc/sys_settrace_generator.py.exp
+++ b/tests/misc/sys_settrace_generator.py.exp
@@ -1,195 +1,195 @@
 ### trace_handler::main event: call
  0:   @__main__:test_generator => sys_settrace_generator.py:41
- 1:   @__main__:<module> => sys_settrace_generator.py:69
+ 1:   @__main__:<module> => sys_settrace_generator.py:67
 ### trace_handler::main event: line
  0:   @__main__:test_generator => sys_settrace_generator.py:42
- 1:   @__main__:<module> => sys_settrace_generator.py:69
+ 1:   @__main__:<module> => sys_settrace_generator.py:67
 ### trace_handler::main event: line
  0:   @__main__:test_generator => sys_settrace_generator.py:48
- 1:   @__main__:<module> => sys_settrace_generator.py:69
+ 1:   @__main__:<module> => sys_settrace_generator.py:67
 ### trace_handler::main event: line
  0:   @__main__:test_generator => sys_settrace_generator.py:49
- 1:   @__main__:<module> => sys_settrace_generator.py:69
+ 1:   @__main__:<module> => sys_settrace_generator.py:67
 ### trace_handler::main event: line
  0:   @__main__:test_generator => sys_settrace_generator.py:50
- 1:   @__main__:<module> => sys_settrace_generator.py:69
+ 1:   @__main__:<module> => sys_settrace_generator.py:67
 ### trace_handler::main event: line
- 0:   @__main__:test_generator => sys_settrace_generator.py:52
- 1:   @__main__:<module> => sys_settrace_generator.py:69
+ 0:   @__main__:test_generator => sys_settrace_generator.py:51
+ 1:   @__main__:<module> => sys_settrace_generator.py:67
 ### trace_handler::main event: call
  0:   @__main__:make_gen => sys_settrace_generator.py:42
- 1:   @__main__:test_generator => sys_settrace_generator.py:52
- 2:   @__main__:<module> => sys_settrace_generator.py:69
+ 1:   @__main__:test_generator => sys_settrace_generator.py:51
+ 2:   @__main__:<module> => sys_settrace_generator.py:67
 ### trace_handler::main event: line
  0:   @__main__:make_gen => sys_settrace_generator.py:43
- 1:   @__main__:test_generator => sys_settrace_generator.py:52
- 2:   @__main__:<module> => sys_settrace_generator.py:69
+ 1:   @__main__:test_generator => sys_settrace_generator.py:51
+ 2:   @__main__:<module> => sys_settrace_generator.py:67
 ### trace_handler::main event: return
  0:   @__main__:make_gen => sys_settrace_generator.py:43
- 1:   @__main__:test_generator => sys_settrace_generator.py:52
- 2:   @__main__:<module> => sys_settrace_generator.py:69
+ 1:   @__main__:test_generator => sys_settrace_generator.py:51
+ 2:   @__main__:<module> => sys_settrace_generator.py:67
 ### trace_handler::main event: line
- 0:   @__main__:test_generator => sys_settrace_generator.py:56
- 1:   @__main__:<module> => sys_settrace_generator.py:69
+ 0:   @__main__:test_generator => sys_settrace_generator.py:54
+ 1:   @__main__:<module> => sys_settrace_generator.py:67
 ### trace_handler::main event: call
  0:   @__main__:make_gen => sys_settrace_generator.py:43
- 1:   @__main__:test_generator => sys_settrace_generator.py:56
- 2:   @__main__:<module> => sys_settrace_generator.py:69
+ 1:   @__main__:test_generator => sys_settrace_generator.py:54
+ 2:   @__main__:<module> => sys_settrace_generator.py:67
 ### trace_handler::main event: line
  0:   @__main__:make_gen => sys_settrace_generator.py:43
- 1:   @__main__:test_generator => sys_settrace_generator.py:56
- 2:   @__main__:<module> => sys_settrace_generator.py:69
+ 1:   @__main__:test_generator => sys_settrace_generator.py:54
+ 2:   @__main__:<module> => sys_settrace_generator.py:67
 ### trace_handler::main event: line
  0:   @__main__:make_gen => sys_settrace_generator.py:44
- 1:   @__main__:test_generator => sys_settrace_generator.py:56
- 2:   @__main__:<module> => sys_settrace_generator.py:69
+ 1:   @__main__:test_generator => sys_settrace_generator.py:54
+ 2:   @__main__:<module> => sys_settrace_generator.py:67
 ### trace_handler::main event: return
  0:   @__main__:make_gen => sys_settrace_generator.py:44
- 1:   @__main__:test_generator => sys_settrace_generator.py:56
- 2:   @__main__:<module> => sys_settrace_generator.py:69
+ 1:   @__main__:test_generator => sys_settrace_generator.py:54
+ 2:   @__main__:<module> => sys_settrace_generator.py:67
 ### trace_handler::main event: call
  0:   @__main__:make_gen => sys_settrace_generator.py:44
- 1:   @__main__:test_generator => sys_settrace_generator.py:56
- 2:   @__main__:<module> => sys_settrace_generator.py:69
+ 1:   @__main__:test_generator => sys_settrace_generator.py:54
+ 2:   @__main__:<module> => sys_settrace_generator.py:67
 ### trace_handler::main event: line
  0:   @__main__:make_gen => sys_settrace_generator.py:44
- 1:   @__main__:test_generator => sys_settrace_generator.py:56
- 2:   @__main__:<module> => sys_settrace_generator.py:69
+ 1:   @__main__:test_generator => sys_settrace_generator.py:54
+ 2:   @__main__:<module> => sys_settrace_generator.py:67
 ### trace_handler::main event: line
  0:   @__main__:make_gen => sys_settrace_generator.py:45
- 1:   @__main__:test_generator => sys_settrace_generator.py:56
- 2:   @__main__:<module> => sys_settrace_generator.py:69
+ 1:   @__main__:test_generator => sys_settrace_generator.py:54
+ 2:   @__main__:<module> => sys_settrace_generator.py:67
 ### trace_handler::main event: return
  0:   @__main__:make_gen => sys_settrace_generator.py:45
- 1:   @__main__:test_generator => sys_settrace_generator.py:56
- 2:   @__main__:<module> => sys_settrace_generator.py:69
+ 1:   @__main__:test_generator => sys_settrace_generator.py:54
+ 2:   @__main__:<module> => sys_settrace_generator.py:67
 ### trace_handler::main event: call
  0:   @__main__:make_gen => sys_settrace_generator.py:45
- 1:   @__main__:test_generator => sys_settrace_generator.py:56
- 2:   @__main__:<module> => sys_settrace_generator.py:69
+ 1:   @__main__:test_generator => sys_settrace_generator.py:54
+ 2:   @__main__:<module> => sys_settrace_generator.py:67
 ### trace_handler::main event: line
  0:   @__main__:make_gen => sys_settrace_generator.py:45
- 1:   @__main__:test_generator => sys_settrace_generator.py:56
- 2:   @__main__:<module> => sys_settrace_generator.py:69
+ 1:   @__main__:test_generator => sys_settrace_generator.py:54
+ 2:   @__main__:<module> => sys_settrace_generator.py:67
 ### trace_handler::main event: line
  0:   @__main__:make_gen => sys_settrace_generator.py:46
- 1:   @__main__:test_generator => sys_settrace_generator.py:56
- 2:   @__main__:<module> => sys_settrace_generator.py:69
+ 1:   @__main__:test_generator => sys_settrace_generator.py:54
+ 2:   @__main__:<module> => sys_settrace_generator.py:67
 ### trace_handler::main event: return
  0:   @__main__:make_gen => sys_settrace_generator.py:46
- 1:   @__main__:test_generator => sys_settrace_generator.py:56
- 2:   @__main__:<module> => sys_settrace_generator.py:69
+ 1:   @__main__:test_generator => sys_settrace_generator.py:54
+ 2:   @__main__:<module> => sys_settrace_generator.py:67
 ### trace_handler::main event: exception
+ 0:   @__main__:test_generator => sys_settrace_generator.py:54
+ 1:   @__main__:<module> => sys_settrace_generator.py:67
+### trace_handler::main event: line
  0:   @__main__:test_generator => sys_settrace_generator.py:56
- 1:   @__main__:<module> => sys_settrace_generator.py:69
+ 1:   @__main__:<module> => sys_settrace_generator.py:67
 ### trace_handler::main event: line
- 0:   @__main__:test_generator => sys_settrace_generator.py:58
- 1:   @__main__:<module> => sys_settrace_generator.py:69
-### trace_handler::main event: line
- 0:   @__main__:test_generator => sys_settrace_generator.py:59
- 1:   @__main__:<module> => sys_settrace_generator.py:69
+ 0:   @__main__:test_generator => sys_settrace_generator.py:57
+ 1:   @__main__:<module> => sys_settrace_generator.py:67
 test_generator 7 8
 ### trace_handler::main event: line
+ 0:   @__main__:test_generator => sys_settrace_generator.py:59
+ 1:   @__main__:<module> => sys_settrace_generator.py:67
+### trace_handler::main event: line
+ 0:   @__main__:test_generator => sys_settrace_generator.py:60
+ 1:   @__main__:<module> => sys_settrace_generator.py:67
+### trace_handler::main event: line
  0:   @__main__:test_generator => sys_settrace_generator.py:61
- 1:   @__main__:<module> => sys_settrace_generator.py:69
-### trace_handler::main event: line
- 0:   @__main__:test_generator => sys_settrace_generator.py:62
- 1:   @__main__:<module> => sys_settrace_generator.py:69
-### trace_handler::main event: line
- 0:   @__main__:test_generator => sys_settrace_generator.py:63
- 1:   @__main__:<module> => sys_settrace_generator.py:69
+ 1:   @__main__:<module> => sys_settrace_generator.py:67
 ### trace_handler::main event: call
  0:   @__main__:make_gen => sys_settrace_generator.py:42
- 1:   @__main__:test_generator => sys_settrace_generator.py:63
- 2:   @__main__:<module> => sys_settrace_generator.py:69
+ 1:   @__main__:test_generator => sys_settrace_generator.py:61
+ 2:   @__main__:<module> => sys_settrace_generator.py:67
 ### trace_handler::main event: line
  0:   @__main__:make_gen => sys_settrace_generator.py:43
- 1:   @__main__:test_generator => sys_settrace_generator.py:63
- 2:   @__main__:<module> => sys_settrace_generator.py:69
+ 1:   @__main__:test_generator => sys_settrace_generator.py:61
+ 2:   @__main__:<module> => sys_settrace_generator.py:67
 ### trace_handler::main event: return
  0:   @__main__:make_gen => sys_settrace_generator.py:43
- 1:   @__main__:test_generator => sys_settrace_generator.py:63
- 2:   @__main__:<module> => sys_settrace_generator.py:69
+ 1:   @__main__:test_generator => sys_settrace_generator.py:61
+ 2:   @__main__:<module> => sys_settrace_generator.py:67
 ### trace_handler::main event: line
- 0:   @__main__:test_generator => sys_settrace_generator.py:63
- 1:   @__main__:<module> => sys_settrace_generator.py:69
+ 0:   @__main__:test_generator => sys_settrace_generator.py:61
+ 1:   @__main__:<module> => sys_settrace_generator.py:67
 ### trace_handler::main event: line
- 0:   @__main__:test_generator => sys_settrace_generator.py:64
- 1:   @__main__:<module> => sys_settrace_generator.py:69
+ 0:   @__main__:test_generator => sys_settrace_generator.py:62
+ 1:   @__main__:<module> => sys_settrace_generator.py:67
 ### trace_handler::main event: line
- 0:   @__main__:test_generator => sys_settrace_generator.py:63
- 1:   @__main__:<module> => sys_settrace_generator.py:69
+ 0:   @__main__:test_generator => sys_settrace_generator.py:61
+ 1:   @__main__:<module> => sys_settrace_generator.py:67
 ### trace_handler::main event: call
  0:   @__main__:make_gen => sys_settrace_generator.py:43
- 1:   @__main__:test_generator => sys_settrace_generator.py:63
- 2:   @__main__:<module> => sys_settrace_generator.py:69
+ 1:   @__main__:test_generator => sys_settrace_generator.py:61
+ 2:   @__main__:<module> => sys_settrace_generator.py:67
 ### trace_handler::main event: line
  0:   @__main__:make_gen => sys_settrace_generator.py:43
- 1:   @__main__:test_generator => sys_settrace_generator.py:63
- 2:   @__main__:<module> => sys_settrace_generator.py:69
+ 1:   @__main__:test_generator => sys_settrace_generator.py:61
+ 2:   @__main__:<module> => sys_settrace_generator.py:67
 ### trace_handler::main event: line
  0:   @__main__:make_gen => sys_settrace_generator.py:44
- 1:   @__main__:test_generator => sys_settrace_generator.py:63
- 2:   @__main__:<module> => sys_settrace_generator.py:69
+ 1:   @__main__:test_generator => sys_settrace_generator.py:61
+ 2:   @__main__:<module> => sys_settrace_generator.py:67
 ### trace_handler::main event: return
  0:   @__main__:make_gen => sys_settrace_generator.py:44
- 1:   @__main__:test_generator => sys_settrace_generator.py:63
- 2:   @__main__:<module> => sys_settrace_generator.py:69
+ 1:   @__main__:test_generator => sys_settrace_generator.py:61
+ 2:   @__main__:<module> => sys_settrace_generator.py:67
 ### trace_handler::main event: line
- 0:   @__main__:test_generator => sys_settrace_generator.py:63
- 1:   @__main__:<module> => sys_settrace_generator.py:69
+ 0:   @__main__:test_generator => sys_settrace_generator.py:61
+ 1:   @__main__:<module> => sys_settrace_generator.py:67
 ### trace_handler::main event: line
- 0:   @__main__:test_generator => sys_settrace_generator.py:64
- 1:   @__main__:<module> => sys_settrace_generator.py:69
+ 0:   @__main__:test_generator => sys_settrace_generator.py:62
+ 1:   @__main__:<module> => sys_settrace_generator.py:67
 ### trace_handler::main event: line
- 0:   @__main__:test_generator => sys_settrace_generator.py:63
- 1:   @__main__:<module> => sys_settrace_generator.py:69
+ 0:   @__main__:test_generator => sys_settrace_generator.py:61
+ 1:   @__main__:<module> => sys_settrace_generator.py:67
 ### trace_handler::main event: call
  0:   @__main__:make_gen => sys_settrace_generator.py:44
- 1:   @__main__:test_generator => sys_settrace_generator.py:63
- 2:   @__main__:<module> => sys_settrace_generator.py:69
+ 1:   @__main__:test_generator => sys_settrace_generator.py:61
+ 2:   @__main__:<module> => sys_settrace_generator.py:67
 ### trace_handler::main event: line
  0:   @__main__:make_gen => sys_settrace_generator.py:44
- 1:   @__main__:test_generator => sys_settrace_generator.py:63
- 2:   @__main__:<module> => sys_settrace_generator.py:69
+ 1:   @__main__:test_generator => sys_settrace_generator.py:61
+ 2:   @__main__:<module> => sys_settrace_generator.py:67
 ### trace_handler::main event: line
  0:   @__main__:make_gen => sys_settrace_generator.py:45
- 1:   @__main__:test_generator => sys_settrace_generator.py:63
- 2:   @__main__:<module> => sys_settrace_generator.py:69
+ 1:   @__main__:test_generator => sys_settrace_generator.py:61
+ 2:   @__main__:<module> => sys_settrace_generator.py:67
 ### trace_handler::main event: return
  0:   @__main__:make_gen => sys_settrace_generator.py:45
- 1:   @__main__:test_generator => sys_settrace_generator.py:63
- 2:   @__main__:<module> => sys_settrace_generator.py:69
+ 1:   @__main__:test_generator => sys_settrace_generator.py:61
+ 2:   @__main__:<module> => sys_settrace_generator.py:67
 ### trace_handler::main event: line
- 0:   @__main__:test_generator => sys_settrace_generator.py:63
- 1:   @__main__:<module> => sys_settrace_generator.py:69
+ 0:   @__main__:test_generator => sys_settrace_generator.py:61
+ 1:   @__main__:<module> => sys_settrace_generator.py:67
 ### trace_handler::main event: line
- 0:   @__main__:test_generator => sys_settrace_generator.py:64
- 1:   @__main__:<module> => sys_settrace_generator.py:69
+ 0:   @__main__:test_generator => sys_settrace_generator.py:62
+ 1:   @__main__:<module> => sys_settrace_generator.py:67
 ### trace_handler::main event: line
- 0:   @__main__:test_generator => sys_settrace_generator.py:63
- 1:   @__main__:<module> => sys_settrace_generator.py:69
+ 0:   @__main__:test_generator => sys_settrace_generator.py:61
+ 1:   @__main__:<module> => sys_settrace_generator.py:67
 ### trace_handler::main event: call
  0:   @__main__:make_gen => sys_settrace_generator.py:45
- 1:   @__main__:test_generator => sys_settrace_generator.py:63
- 2:   @__main__:<module> => sys_settrace_generator.py:69
+ 1:   @__main__:test_generator => sys_settrace_generator.py:61
+ 2:   @__main__:<module> => sys_settrace_generator.py:67
 ### trace_handler::main event: line
  0:   @__main__:make_gen => sys_settrace_generator.py:45
- 1:   @__main__:test_generator => sys_settrace_generator.py:63
- 2:   @__main__:<module> => sys_settrace_generator.py:69
+ 1:   @__main__:test_generator => sys_settrace_generator.py:61
+ 2:   @__main__:<module> => sys_settrace_generator.py:67
 ### trace_handler::main event: line
  0:   @__main__:make_gen => sys_settrace_generator.py:46
- 1:   @__main__:test_generator => sys_settrace_generator.py:63
- 2:   @__main__:<module> => sys_settrace_generator.py:69
+ 1:   @__main__:test_generator => sys_settrace_generator.py:61
+ 2:   @__main__:<module> => sys_settrace_generator.py:67
 ### trace_handler::main event: return
  0:   @__main__:make_gen => sys_settrace_generator.py:46
- 1:   @__main__:test_generator => sys_settrace_generator.py:63
- 2:   @__main__:<module> => sys_settrace_generator.py:69
+ 1:   @__main__:test_generator => sys_settrace_generator.py:61
+ 2:   @__main__:<module> => sys_settrace_generator.py:67
 ### trace_handler::main event: line
- 0:   @__main__:test_generator => sys_settrace_generator.py:65
- 1:   @__main__:<module> => sys_settrace_generator.py:69
+ 0:   @__main__:test_generator => sys_settrace_generator.py:63
+ 1:   @__main__:<module> => sys_settrace_generator.py:67
 7
 ### trace_handler::main event: return
- 0:   @__main__:test_generator => sys_settrace_generator.py:65
- 1:   @__main__:<module> => sys_settrace_generator.py:69
+ 0:   @__main__:test_generator => sys_settrace_generator.py:63
+ 1:   @__main__:<module> => sys_settrace_generator.py:67
 Total traces executed:  54

--- a/tests/misc/sys_settrace_subdir/sys_settrace_generic.py
+++ b/tests/misc/sys_settrace_subdir/sys_settrace_generic.py
@@ -1,5 +1,6 @@
 print("Now comes the language constructions tests.")
 
+
 # function
 def test_func():
     def test_sub_func():

--- a/tests/multi_net/ssl_cert_rsa.py
+++ b/tests/multi_net/ssl_cert_rsa.py
@@ -125,6 +125,7 @@ key = binascii.unhexlify(
     b"8b17a330a306a6fbcf51ba83563aed85a4f886fff1a22423748d83798c"
 )
 
+
 # Server
 def instance0():
     multitest.globals(IP=multitest.get_network_ip())

--- a/tests/multi_net/ssl_data.py
+++ b/tests/multi_net/ssl_data.py
@@ -39,6 +39,7 @@ cert = binascii.unhexlify(
     b"979b57f0b3"
 )
 
+
 # Server
 def instance0():
     multitest.globals(IP=multitest.get_network_ip())

--- a/tests/multi_net/tcp_data.py
+++ b/tests/multi_net/tcp_data.py
@@ -4,6 +4,7 @@ import socket
 
 PORT = 8000
 
+
 # Server
 def instance0():
     multitest.globals(IP=multitest.get_network_ip())

--- a/tests/perf_bench/bm_nqueens.py
+++ b/tests/perf_bench/bm_nqueens.py
@@ -5,6 +5,7 @@
 # author: collinwinter@google.com (Collin Winter)
 # n_queens function: Copyright 2009 Raymond Hettinger
 
+
 # Pure-Python implementation of itertools.permutations().
 def permutations(iterable, r=None):
     """permutations(range(3), 2) --> (0,1) (0,2) (1,0) (1,2) (2,0) (2,1)"""

--- a/tests/perf_bench/misc_aes.py
+++ b/tests/perf_bench/misc_aes.py
@@ -33,6 +33,7 @@ aes_s_box_table = bytes((
 ))
 # fmt: on
 
+
 # multiplication of polynomials modulo x^8 + x^4 + x^3 + x + 1 = 0x11b
 def aes_gf8_mul_2(x):
     if x & 0x80:
@@ -63,6 +64,7 @@ def aes_r_con(a):
 
 ##################################################################
 # basic AES algorithm; see FIPS-197
+
 
 # all inputs must be size 16
 def aes_add_round_key(state, w):

--- a/tests/pyb/rtc.py
+++ b/tests/pyb/rtc.py
@@ -55,6 +55,7 @@ set_and_print_calib(-511)
 # restore existing calibration value
 rtc.calibration(cal_tmp)
 
+
 # Check register settings for wakeup
 def set_and_print_wakeup(ms):
     try:

--- a/tests/pyb/timer_callback.py
+++ b/tests/pyb/timer_callback.py
@@ -3,6 +3,7 @@
 import pyb
 from pyb import Timer
 
+
 # callback function that disables the callback when called
 def cb1(t):
     print("cb1")

--- a/tests/run-internalbench.py
+++ b/tests/run-internalbench.py
@@ -28,7 +28,6 @@ def run_tests(pyb, test_dict):
     for base_test, tests in sorted(test_dict.items()):
         print(base_test + ":")
         for test_file in tests:
-
             # run MicroPython
             if pyb is None:
                 # run on PC

--- a/tests/stress/qstr_limit.py
+++ b/tests/stress/qstr_limit.py
@@ -17,6 +17,7 @@ for l in range(254, 259):
         continue
     print(var in g)
 
+
 # calling a function with kwarg
 def f(**k):
     print(k)
@@ -35,6 +36,7 @@ for l in range(254, 259):
         print(type(id, (), {}).__name__)
     except RuntimeError:
         print("RuntimeError", l)
+
 
 # hasattr, setattr, getattr
 class A:

--- a/tests/stress/recursive_gen.py
+++ b/tests/stress/recursive_gen.py
@@ -1,5 +1,6 @@
 # test deeply recursive generators
 
+
 # simple "yield from" recursion
 def gen():
     yield from gen()
@@ -9,6 +10,7 @@ try:
     list(gen())
 except RuntimeError:
     print("RuntimeError")
+
 
 # recursion via an iterator over a generator
 def gen2():

--- a/tests/thread/mutate_bytearray.py
+++ b/tests/thread/mutate_bytearray.py
@@ -7,6 +7,7 @@ import _thread
 # the shared bytearray
 ba = bytearray()
 
+
 # main thread function
 def th(n, lo, hi):
     for repeat in range(n):

--- a/tests/thread/mutate_dict.py
+++ b/tests/thread/mutate_dict.py
@@ -7,6 +7,7 @@ import _thread
 # the shared dict
 di = {"a": "A", "b": "B", "c": "C", "d": "D"}
 
+
 # main thread function
 def th(n, lo, hi):
     for repeat in range(n):

--- a/tests/thread/mutate_instance.py
+++ b/tests/thread/mutate_instance.py
@@ -4,6 +4,7 @@
 
 import _thread
 
+
 # the shared user class and instance
 class User:
     def __init__(self):
@@ -13,6 +14,7 @@ class User:
 
 
 user = User()
+
 
 # main thread function
 def th(n, lo, hi):

--- a/tests/thread/mutate_list.py
+++ b/tests/thread/mutate_list.py
@@ -7,6 +7,7 @@ import _thread
 # the shared list
 li = list()
 
+
 # main thread function
 def th(n, lo, hi):
     for repeat in range(n):

--- a/tests/thread/mutate_set.py
+++ b/tests/thread/mutate_set.py
@@ -7,6 +7,7 @@ import _thread
 # the shared set
 se = set([-1, -2, -3, -4])
 
+
 # main thread function
 def th(n, lo, hi):
     for repeat in range(n):

--- a/tests/thread/stress_aes.py
+++ b/tests/thread/stress_aes.py
@@ -38,6 +38,7 @@ aes_s_box_table = bytes((
 ))
 # fmt: on
 
+
 # multiplication of polynomials modulo x^8 + x^4 + x^3 + x + 1 = 0x11b
 def aes_gf8_mul_2(x):
     if x & 0x80:
@@ -79,6 +80,7 @@ def aes_r_con(a):
 # provides such a sequence.  En/de-cryption is implemented here
 # using OCB, where the sequence is xored against the plaintext.
 # Care must be taken to (almost) always choose a different IV.
+
 
 # all inputs must be size 16
 def aes_add_round_key(state, w):

--- a/tests/thread/thread_qstr1.py
+++ b/tests/thread/thread_qstr1.py
@@ -8,6 +8,7 @@ except ImportError:
     import time
 import _thread
 
+
 # function to check the interned string
 def check(s, val):
     assert type(s) == str

--- a/tests/unicode/unicode_id.py
+++ b/tests/unicode/unicode_id.py
@@ -10,6 +10,7 @@ bβ = 3
 βb = 4
 print(α, αβγ, bβ, βb)
 
+
 # function, argument, local identifiers
 def α(β, γ):
     δ = β + γ
@@ -17,6 +18,7 @@ def α(β, γ):
 
 
 α(1, 2)
+
 
 # class, method identifiers
 class φ:


### PR DESCRIPTION
See https://black.readthedocs.io/en/stable/the_black_code_style/index.html#stability-policy

Anyone installing `black` from PyPI will now get the 2023 version (i.e. black 23.x.x) and get formatting diffs. This is what is currently happening on our CI, causing it to fail.

I'm mostly opening this for discussion, not sure we should merge this yet. For anyone who gets `black` from their system package manager, it might take a while to catch up (e.g. if using Ubuntu, but even Arch hasn't got it yet either for example although won't take long).

But in general, I think we need to pin a version, and so the decision we should make is to either:
 - Move to 23.x.x, and pin that in the CI and have codeformat.py verify the version. This means that, e.g. Ubuntu users, must find a different way to get `black` in their path for MicroPython (e.g. pip).
 - Stay at 22.x.x, and pin that in the CI and have codeformat.py verify the version. This means that, e.g. Arch users, must find a different way to get `black` in their path for MicroPython (e.g. pip).
 - Make our own "MicroPython Code Formatting tool" package on PyPI (which rolls up black and uncrustify and codeformat.py) and require users to run that instead.

`pipx` could provide a useful way to solve this. We could make codeformat.py use pipx to invoke black at a particular version.

(We also have the exact same problem with uncrustify. See discussion in https://github.com/micropython/micropython/pull/9980. cc @dlech)