### PR TITLE
ports/minimal: Heap size increased for Linux.

### DIFF
--- a/ports/minimal/main.c
+++ b/ports/minimal/main.c
@@ -29,7 +29,7 @@ void do_str(const char *src, mp_parse_input_kind_t input_kind) {
 
 static char *stack_top;
 #if MICROPY_ENABLE_GC
-static char heap[2048];
+static char heap[MICROPY_HEAP_SIZE];
 #endif
 
 int main(int argc, char **argv) {

--- a/ports/minimal/mpconfigport.h
+++ b/ports/minimal/mpconfigport.h
@@ -33,11 +33,13 @@ typedef long mp_off_t;
 
 #ifdef __linux__
 #define MICROPY_MIN_USE_STDOUT (1)
+#define MICROPY_HEAP_SIZE      (25600) // heap size 25 kilobytes
 #endif
 
 #ifdef __thumb__
 #define MICROPY_MIN_USE_CORTEX_CPU (1)
 #define MICROPY_MIN_USE_STM32_MCU (1)
+#define MICROPY_HEAP_SIZE      (2048) // heap size 2 kilobytes
 #endif
 
 #define MP_STATE_PORT MP_STATE_VM


### PR DESCRIPTION
I just increased the heap size for the Linux build. A MemoryError issue for Linux is fixed by increasing heap size. issue #10644