### PR TITLE
Update to docs for FrameBuffer.rect

### DIFF
--- a/docs/library/framebuf.rst
+++ b/docs/library/framebuf.rst
@@ -77,12 +77,13 @@ The following methods draw shapes onto the FrameBuffer.
     methods draw horizontal and vertical lines respectively up to
     a given length.
 
-.. method:: FrameBuffer.rect(x, y, w, h, c[, f])
+.. method:: FrameBuffer.rect(x, y, w, h, c)
 
     Draw a rectangle at the given location, size and color.
 
-    The optional *f* parameter can be set to ``True`` to fill the rectangle.
-    Otherwise just a one pixel outline is drawn.
+.. method:: FrameBuffer.fill_rect(x, y, w, h, c)
+
+    Draw a filled rectangle at the given location, size and color.
 
 .. method:: FrameBuffer.ellipse(x, y, xr, yr, c[, f, m])
 


### PR DESCRIPTION
* Added `FrameBuffer.fill_rect()` method
* amended `FrameBuffer.rect()` method to remove the `f` parameter