### PR TITLE
samd: A set of small changes and improvements.

### DIFF
--- a/docs/samd/quickref.rst
+++ b/docs/samd/quickref.rst
@@ -42,8 +42,10 @@ The :mod:`machine` module::
     machine.freq(96_000_000)  # set the CPU frequency to 96 MHz
 
 The range accepted by the function call is 1_000_000 to 200_000_000 (1 MHz to 200 MHz)
-for SAMD51 and 1_000_000 to 48_000_000 (1 MHz to 48 MHz) for SAMD21. The safe
-range for SAMD51 according to the data sheet is 96 MHz to 120 MHz.
+for SAMD51 and 1_000_000 to 54_000_000 (1 MHz to 54 MHz) for SAMD21. The safe
+range for SAMD51 according to the data sheet is up to 120 MHz, for the SAMD21 up to 48Mhz.
+Frequencies below 48Mhz are set by dividing 48Mhz by an integer, limiting the number of
+discrete frequencies to 24Mhz, 16Mhz, 12MHz, and so on.
 At frequencies below 8 MHz USB will be disabled. Changing the frequency below 48 MHz
 impacts the baud rates of UART, I2C and SPI. These have to be set again after
 changing the CPU frequency. The ms and µs timers are not affected by the frequency

--- a/ports/samd/boards/ADAFRUIT_FEATHER_M0_EXPRESS/pins.csv
+++ b/ports/samd/boards/ADAFRUIT_FEATHER_M0_EXPRESS/pins.csv
@@ -1,8 +1,6 @@
 # Pin rows contain Pin number and pin name.
 # Pin rows start with PIN_
-# LED rows start with LED_
 # If the pin name is omitted, the pin number is added as name.
-# Rows for empty entries have to start with '-'
 # Empty lines and lines starting with # are ignored
 
 PIN_PA27,LED_TX

--- a/ports/samd/boards/ADAFRUIT_FEATHER_M4_EXPRESS/pins.csv
+++ b/ports/samd/boards/ADAFRUIT_FEATHER_M4_EXPRESS/pins.csv
@@ -1,9 +1,7 @@
 # Pin rows contain Pin number and pin name.
 # Pin rows start with PIN_
-# LED rows start with LED_
 # If the pin name is omitted, the pin number is added as name.
-# Rows for empty entries have to start with '-'
-# Empty lines and lines starting with PIN_ or LED_ are ignored
+# Empty lines and lines not starting with PIN_ are ignored
 
 PIN_PB17,D0
 PIN_PB16,D1

--- a/ports/samd/boards/ADAFRUIT_ITSYBITSY_M0_EXPRESS/pins.csv
+++ b/ports/samd/boards/ADAFRUIT_ITSYBITSY_M0_EXPRESS/pins.csv
@@ -1,9 +1,7 @@
 # Pin rows contain Pin number and pin name.
 # Pin rows start with PIN_
-# LED rows start with LED_
 # If the pin name is omitted, the pin number is added as name.
-# Rows for empty entries have to start with '-'
-# Empty lines and lines not starting with PIN_ or LED_ are ignored
+# Empty lines and lines not starting with PIN_ are ignored
 
 PIN_PA11,D0
 PIN_PA10,D1

--- a/ports/samd/boards/ADAFRUIT_ITSYBITSY_M4_EXPRESS/pins.csv
+++ b/ports/samd/boards/ADAFRUIT_ITSYBITSY_M4_EXPRESS/pins.csv
@@ -1,9 +1,7 @@
 # Pin rows contain Pin number and pin name.
 # Pin rows start with PIN_
-# LED rows start with LED_
 # If the pin name is omitted, the pin number is added as name.
-# Rows for empty entries have to start with '-'
-# Empty lines and lines starting with # are ignored
+# Empty lines and lines not starting with PIN_ are ignored
 
 PIN_PA16,D0
 PIN_PA17,D1

--- a/ports/samd/boards/ADAFRUIT_TRINKET_M0/pins.csv
+++ b/ports/samd/boards/ADAFRUIT_TRINKET_M0/pins.csv
@@ -1,9 +1,7 @@
 # Pin rows contain Pin number and pin name.
 # Pin rows start with PIN_
-# LED rows start with LED_
 # If the pin name is omitted, the pin number is added as name.
-# Rows for empty entries have to start with '-'
-# Empty lines and lines starting with # are ignored
+# Empty lines and lines not starting with PIN_ are ignored
 
 PIN_PA08,D0
 PIN_PA02,D1

--- a/ports/samd/boards/MINISAM_M4/pins.csv
+++ b/ports/samd/boards/MINISAM_M4/pins.csv
@@ -1,9 +1,7 @@
 # Pin rows contain Pin number and pin name.
 # Pin rows start with PIN_
-# LED rows start with LED_
 # If the pin name is omitted, the pin number is added as name.
-# Rows for empty entries have to start with '-'
-# Empty lines and lines starting with # are ignored
+# Empty lines and lines not starting with PIN_ are ignored
 
 PIN_PA02,A0_D9
 PIN_PB08,A1_D10

--- a/ports/samd/boards/SAMD21_XPLAINED_PRO/pins.csv
+++ b/ports/samd/boards/SAMD21_XPLAINED_PRO/pins.csv
@@ -1,9 +1,7 @@
 # Pin rows contain Pin number and pin name.
 # Pin rows start with PIN_
-# LED rows start with LED_
 # If the pin name is omitted, the pin number is added as name.
-# Rows for empty entries have to start with '-'
-# Empty lines and lines starting with # are ignored
+# Empty lines and lines not starting with PIN_ are ignored
 
 # EXT1
 PIN_PB00,EXT1_PIN3

--- a/ports/samd/boards/SEEED_WIO_TERMINAL/pins.csv
+++ b/ports/samd/boards/SEEED_WIO_TERMINAL/pins.csv
@@ -1,9 +1,7 @@
 # Pin rows contain Pin number and pin name.
 # Pin rows start with PIN_
-# LED rows start with LED_
 # If the pin name is omitted, the pin number is added as name.
-# Rows for empty entries have to start with '-'
-# Empty lines and lines starting with # are ignored
+# Empty lines and lines not starting with PIN_ are ignored
 
 PIN_PB08,A0_D0
 PIN_PB09,A1_D1

--- a/ports/samd/boards/SEEED_XIAO_SAMD21/pins.csv
+++ b/ports/samd/boards/SEEED_XIAO_SAMD21/pins.csv
@@ -1,9 +1,7 @@
 # Pin rows contain Pin number and pin name.
 # Pin rows start with PIN_
-# LED rows start with LED_
 # If the pin name is omitted, the pin number is added as name.
-# Rows for empty entries have to start with '-'
-# Empty lines and lines starting with # are ignored
+# Empty lines and lines not starting with PIN_ are ignored
 
 PIN_PA02,A0_D0
 PIN_PA04,A1_D1

--- a/ports/samd/boards/SPARKFUN_SAMD51_THING_PLUS/pins.csv
+++ b/ports/samd/boards/SPARKFUN_SAMD51_THING_PLUS/pins.csv
@@ -1,14 +1,10 @@
 # Pin rows contain Pin number and pin name.
 # Pin rows start with PIN_
-# LED rows start with LED_
 # If the pin name is omitted, the pin number is added as name.
-# Rows for empty entries have to start with '-'
-# Empty lines and lines not starting with PIN_ or LED_ are ignored
+# Empty lines and lines not starting with PIN_ are ignored
 
 PIN_PA13,D0
 PIN_PA12,D1
-PIN_PB23,RXD
-PIN_PB22,TXD
 PIN_PA06,D4
 PIN_PA15,D5
 PIN_PA20,D6

--- a/ports/samd/mcu/samd21/clock_config.c
+++ b/ports/samd/mcu/samd21/clock_config.c
@@ -166,7 +166,7 @@ void init_clocks(uint32_t cpu_freq) {
     // GCLK0: 48MHz, source: DFLL48M or FDPLL96M, usage: CPU
     // GCLK1: 32kHz, source: XOSC32K or OSCULP32K, usage: FDPLL96M reference
     // GCLK2: 1-48MHz, source: DFLL48M, usage: Peripherals
-    // GCLK3: 1Mhz,  source: DFLL48M, usage: us-counter (TC4/TC5)
+    // GCLK3: 2Mhz,  source: DFLL48M, usage: us-counter (TC4/TC5)
     // GCLK4: 32kHz, source: XOSC32K, if crystal present, usage: DFLL48M reference
     // GCLK5: 48MHz, source: DFLL48M, usage: USB
     // GCLK8: 1kHz,  source: XOSC32K or OSCULP32K, usage: WDT and RTC
@@ -291,8 +291,8 @@ void init_clocks(uint32_t cpu_freq) {
 
     set_cpu_freq(cpu_freq);
 
-    // Enable GCLK output: 1MHz on GCLK3 for TC4
-    GCLK->GENDIV.reg = GCLK_GENDIV_ID(3) | GCLK_GENDIV_DIV(48);
+    // Enable GCLK output: 2MHz on GCLK3 for TC4
+    GCLK->GENDIV.reg = GCLK_GENDIV_ID(3) | GCLK_GENDIV_DIV(24);
     GCLK->GENCTRL.reg = GCLK_GENCTRL_GENEN | GCLK_GENCTRL_SRC_DFLL48M | GCLK_GENCTRL_ID(3);
     while (GCLK->STATUS.bit.SYNCBUSY) {
     }

--- a/ports/samd/mcu/samd21/clock_config.c
+++ b/ports/samd/mcu/samd21/clock_config.c
@@ -78,8 +78,9 @@ void set_cpu_freq(uint32_t cpu_freq_arg) {
         // CtrlB: Set the ref ource to GCLK, set the Wakup-Fast Flag.
         SYSCTRL->DPLLCTRLB.reg = SYSCTRL_DPLLCTRLB_REFCLK_GCLK | SYSCTRL_DPLLCTRLB_WUF;
         // Set the FDPLL ratio and enable the DPLL.
-        int ldr = cpu_freq_arg / FDPLL_REF_FREQ - 1;
-        SYSCTRL->DPLLRATIO.reg = SYSCTRL_DPLLRATIO_LDR(ldr);
+        int ldr = cpu_freq / FDPLL_REF_FREQ;
+        int frac = ((cpu_freq - ldr * FDPLL_REF_FREQ) / (FDPLL_REF_FREQ / 16)) & 0x0f;
+        SYSCTRL->DPLLRATIO.reg = SYSCTRL_DPLLRATIO_LDR((frac << 16 | ldr) - 1);
         SYSCTRL->DPLLCTRLA.reg = SYSCTRL_DPLLCTRLA_ENABLE;
         // Wait for the DPLL lock.
         while (!SYSCTRL->DPLLSTATUS.bit.LOCK) {

--- a/ports/samd/mcu/samd21/mpconfigmcu.h
+++ b/ports/samd/mcu/samd21/mpconfigmcu.h
@@ -22,8 +22,8 @@
 #define MICROPY_PY_CMATH                (0)
 #endif
 
-#define MICROPY_PY_URANDOM_SEED_INIT_FUNC (trng_random_u32())
-unsigned long trng_random_u32(void);
+#define MICROPY_PY_URANDOM_SEED_INIT_FUNC (trng_random_u32(300))
+unsigned long trng_random_u32(int delay);
 
 #define VFS_BLOCK_SIZE_BYTES            (1536) // 24x 64B flash pages;
 
@@ -36,6 +36,7 @@ unsigned long trng_random_u32(void);
 #define MICROPY_PY_MACHINE_RTC          (1)
 #endif
 #endif
+#define MICROPY_PY_UOS_URANDOM          (1)
 
 #ifndef MICROPY_PY_MACHINE_PIN_BOARD_CPU
 #define MICROPY_PY_MACHINE_PIN_BOARD_CPU (1)

--- a/ports/samd/mcu/samd21/mpconfigmcu.h
+++ b/ports/samd/mcu/samd21/mpconfigmcu.h
@@ -22,6 +22,9 @@
 #define MICROPY_PY_CMATH                (0)
 #endif
 
+#define MICROPY_PY_URANDOM_SEED_INIT_FUNC (trng_random_u32())
+unsigned long trng_random_u32(void);
+
 #define VFS_BLOCK_SIZE_BYTES            (1536) // 24x 64B flash pages;
 
 #ifndef MICROPY_HW_UART_TXBUF

--- a/ports/samd/mcu/samd21/mpconfigmcu.h
+++ b/ports/samd/mcu/samd21/mpconfigmcu.h
@@ -40,7 +40,8 @@
 
 #define CPU_FREQ                        (48000000)
 #define DFLL48M_FREQ                    (48000000)
-#define MAX_CPU_FREQ                    (48000000)
+#define MAX_CPU_FREQ                    (54000000)
+#define FDPLL_REF_FREQ                  (32768)
 
 #define IRQ_PRI_PENDSV                  ((1 << __NVIC_PRIO_BITS) - 1)
 

--- a/ports/samd/mcu/samd51/clock_config.c
+++ b/ports/samd/mcu/samd51/clock_config.c
@@ -187,12 +187,16 @@ void init_clocks(uint32_t cpu_freq) {
     dfll48m_calibration = 0; // please the compiler
 
     // SAMD51 clock settings
-    // GCLK0: 48MHz from DFLL48M or 48 - 200 MHz from DPLL0 (SAMD51)
-    // GCLK1: 32768 Hz from 32KULP or DFLL48M
-    // GCLK2: 8-48MHz from DFLL48M for Peripheral devices
-    // GCLK3: 16Mhz for the us-counter (TC0/TC1)
-    // GCLK4: 32kHz from crystal, if present
-    // GCLK5: 48MHz from DFLL48M for USB
+    //
+    // GCLK0: 48MHz, source: 48 - 200 MHz from DPLL0, usage: CPU
+    // GCLK1: 32kHz, source: OSCULP32K or DFLL48M, usage: ref_clk DPLL0
+    // GCLK2: 1-48MHz, source:DFLL48M, usage: Peripheral devices
+    // GCLK3: 16Mhz, source: DLLL48M, usage: us-counter (TC0/TC1)
+    // GCLK4: 32kHz, source: XOSC32K, if crystal present, usage: DFLL48M reference
+    // GCLK5: 48MHz, source: DFLL48M, usage: USB
+    // DFLL48M: Reference sources:
+    //          - in closed loop mode: eiter XOSC32K or OSCULP32K or USB clock
+    //          - in open loop mode: None
     // DPLL0: 48 - 200 MHz
 
     // Steps to set up clocks:

--- a/ports/samd/mphalport.c
+++ b/ports/samd/mphalport.c
@@ -147,7 +147,7 @@ uint64_t mp_hal_ticks_us_64(void) {
         us64_upper++;
     }
     #if defined(MCU_SAMD21)
-    return ((uint64_t)us64_upper << 32) | us64_lower;
+    return ((uint64_t)us64_upper << 31) | (us64_lower >> 1);
     #elif defined(MCU_SAMD51)
     return ((uint64_t)us64_upper << 28) | (us64_lower >> 4);
     #endif

--- a/ports/samd/mphalport.h
+++ b/ports/samd/mphalport.h
@@ -54,11 +54,7 @@ static inline mp_uint_t mp_hal_ticks_ms(void) {
 }
 
 static inline mp_uint_t mp_hal_ticks_us(void) {
-    #if defined(MCU_SAMD21)
-    return REG_TC4_COUNT32_COUNT;
-    #else
     return (mp_uint_t)mp_hal_ticks_us_64();
-    #endif
 }
 
 #if defined(MCU_SAMD21)

--- a/ports/samd/samd_isr.c
+++ b/ports/samd/samd_isr.c
@@ -96,7 +96,7 @@ void Default_Handler(void) {
 void SysTick_Handler(void) {
     #if defined(MCU_SAMD21)
     // Use the phase jitter between the clocks to get some entropy
-    // and accumulate the random number register.
+    // and accumulate the random number register with a "spiced" LCG.
     rng_state = (rng_state * 32310901 + 1) ^ (REG_TC4_COUNT32_COUNT >> 1);
     #endif
 
@@ -107,13 +107,6 @@ void SysTick_Handler(void) {
         pendsv_schedule_dispatch(PENDSV_DISPATCH_SOFT_TIMER, soft_timer_handler);
     }
 }
-
-#if defined(MCU_SAMD21)
-uint32_t trng_random_u32(void) {
-    mp_hal_delay_ms(320); // wait for ten cycles of the rng_seed register
-    return rng_state;
-}
-#endif
 
 void us_timer_IRQ(void) {
     #if defined(MCU_SAMD21)


### PR DESCRIPTION
This is the next service-pack type PR. Commits:
- some clean-up of the pins.csv files, like removing non-existing pins, rename of critical names, remove LED_ names.
- Rework the comments in clock_config.c to make the settings done in the code more clear.
- Use the FDPLL96M clock for the SAMD21 CPU, useful for generating a RNG entropy source from  the jitter between DFLL48M and FDPLL96M. As a side effect, the clock can be increased a little bit up to 54 MHz.
- Implement a hardware seed for the SAMD21 random module by using the phase jitter between the DFLL48M clock and the FDPLL96M  clock. Even if both use the same reference source, they have a different jitter. Systick is driven by FDPLL96M, the us counter by DFLL48M. As random source, the us counter is read out on every systick and the value is used to accumulate a simple multiply & xor register.  According to my test it creates about 30 bit random bit-flips per second. That mechanism passes quite a few Diehard tests and the AIS31 test suite.
- Set the SAMD21 us-counter to 2 MHz for better resolution. It turned out that the result of calling ticks_us() was always either odd or even, depending on some internal state during boot. So the us-counter was set to a 2 MHz input and the result shifted by 1. The counting period is still long enough, since internally a (now) 63 bit value is used for us.
- Enable uos.urandom() using the RNG. Add 80 bytes of flash.