### PR TITLE
py/mkrules.cmake: Force build mpversion.h and frozen_content.c.

### DIFF
--- a/py/mkrules.cmake
+++ b/py/mkrules.cmake
@@ -54,19 +54,13 @@ target_sources(${MICROPY_TARGET} PRIVATE
 
 # Command to force the build of another command
 
-add_custom_command(
-    OUTPUT MICROPY_FORCE_BUILD
-    COMMENT ""
-    COMMAND echo -n
-)
-
 # Generate mpversion.h
 
-add_custom_command(
-    OUTPUT ${MICROPY_MPVERSION}
+add_custom_target(
+    BUILD_VERSION_HEADER ALL
+    BYPRODUCTS ${MICROPY_MPVERSION}
     COMMAND ${CMAKE_COMMAND} -E make_directory ${MICROPY_GENHDR_DIR}
     COMMAND ${Python3_EXECUTABLE} ${MICROPY_DIR}/py/makeversionhdr.py ${MICROPY_MPVERSION}
-    DEPENDS MICROPY_FORCE_BUILD
 )
 
 # Generate qstrs
@@ -203,10 +197,11 @@ if(MICROPY_FROZEN_MANIFEST)
         )
     endif()
 
-    add_custom_command(
-        OUTPUT ${MICROPY_FROZEN_CONTENT}
+    add_custom_target(
+        BUILD_FROZEN_CONTENT ALL
+        BYPRODUCTS ${MICROPY_FROZEN_CONTENT}
         COMMAND ${Python3_EXECUTABLE} ${MICROPY_DIR}/tools/makemanifest.py -o ${MICROPY_FROZEN_CONTENT} -v "MPY_DIR=${MICROPY_DIR}" -v "MPY_LIB_DIR=${MICROPY_LIB_DIR}" -v "PORT_DIR=${MICROPY_PORT_DIR}" -v "BOARD_DIR=${MICROPY_BOARD_DIR}" -b "${CMAKE_BINARY_DIR}" -f${MICROPY_CROSS_FLAGS} --mpy-tool-flags=${MICROPY_MPY_TOOL_FLAGS} ${MICROPY_FROZEN_MANIFEST}
-        DEPENDS MICROPY_FORCE_BUILD
+        DEPENDS
             ${MICROPY_QSTRDEFS_GENERATED}
             ${MICROPY_ROOT_POINTERS}
             ${MICROPY_MPYCROSS_DEPENDENCY}


### PR DESCRIPTION
This ensures that all builds unconditionally run makeversionhdr.py and makemanifest.py to generate mpversion.h and frozen_content.c respectively. This now matches the Makefile behavior, and in particular this fixes the issue on ESP32 builds that changes in code-to-be-frozen will cause the build to update. Both these already tools know not to touch their output if there is no change.

Fixes #7753 (and several reports in discussions)

_This work was funded through GitHub Sponsors._
