### PR TITLE
Portenta / Nano Connect: Use default aioble package.

### DIFF
--- a/ports/rp2/boards/ARDUINO_NANO_RP2040_CONNECT/manifest.py
+++ b/ports/rp2/boards/ARDUINO_NANO_RP2040_CONNECT/manifest.py
@@ -11,4 +11,4 @@ require("espflash")
 require("logging")
 
 # Bluetooth
-require("aioble", client=True, central=True, l2cap=True, security=True)
+require("aioble")

--- a/ports/stm32/boards/ARDUINO_PORTENTA_H7/manifest.py
+++ b/ports/stm32/boards/ARDUINO_PORTENTA_H7/manifest.py
@@ -7,4 +7,4 @@ require("bundle-networking")
 require("logging")
 
 # Bluetooth
-require("aioble", client=True, central=True, l2cap=True, security=True)
+require("aioble")


### PR DESCRIPTION
This is a no-op change, just updates the `require()` to use the "everything" aioble package.