### PR TITLE
ports/rp2: fix lightsleep while wifi is powered off

### DIFF
--- a/ports/rp2/modmachine.c
+++ b/ports/rp2/modmachine.c
@@ -146,7 +146,7 @@ STATIC mp_obj_t machine_lightsleep(size_t n_args, const mp_obj_t *args) {
 
     uint32_t my_interrupts = save_and_disable_interrupts();
     #if MICROPY_PY_NETWORK_CYW43
-    if (cyw43_has_pending) {
+    if (cyw43_has_pending && cyw43_poll != NULL) {
         restore_interrupts(my_interrupts);
         return mp_const_none;
     }


### PR DESCRIPTION
While cyw43 is deinitialized, an interrupt occurs. That is handled with these lines: ports/rp2/mpnetworkport.c#L59-L61 and as pendsv is disabled while in network code, the poll function then just waits there.

When deinit has finished, the poll func is executed, but skipped: src/cyw43_ctrl.c#L222-L225 this skips the `CYW43_POST_POLL_HOOK` which would re-enable interrupts, but also reset `cyw43_has_pending`.

And in that state, the lightsleep code, will skip sleeping as it thinks there is a network packet pending to be handled.

See also: https://github.com/micropython/micropython/pull/9438#issuecomment-1429827995 

With this change applied, lightsleep works as expected for me when the wifi chip is enabled, and when its powered off.