### PR TITLE
Fix processing of CPP output from GreenHills C/C++ compiler

### DIFF
--- a/py/makeqstrdefs.py
+++ b/py/makeqstrdefs.py
@@ -86,7 +86,8 @@ def write_out(fname, output):
 
 
 def process_file(f):
-    re_line = re.compile(r"#[line]*\s\d+\s\"([^\"]+)\"")
+    # match gcc-like output (# n "file") and msvc-like output (#line n "file")
+    re_line = re.compile(r"^#(?:line)?\s+\d+\s\"([^\"]+)\"")
     if args.mode == _MODE_QSTR:
         re_match = re.compile(r"MP_QSTR_[_a-zA-Z0-9]+")
     elif args.mode == _MODE_COMPRESS:
@@ -100,10 +101,8 @@ def process_file(f):
     for line in f:
         if line.isspace():
             continue
-        # match gcc-like output (# n "file") and msvc-like output (#line n "file")
-        if line.startswith(("# ", "#line")):
-            m = re_line.match(line)
-            assert m is not None
+        m = re_line.match(line)
+        if m:
             fname = m.group(1)
             if not is_c_source(fname) and not is_cxx_source(fname):
                 continue


### PR DESCRIPTION
The regular expression used to distinguish between "# <number> file..." and "#line <number> file..." was incorrect and actually matched lines containing a "#", followed by any  number of 'l','i','n', and 'e' characters.

The `line.startswith` does not work for anything but "# ": the second argument is converted to a number, which is always 0. It is a starting position, not an alternative match.

Edit: the `line.startswith` was actually correct: the method was called with one argument, a tuple of prefixes.
Edit: the real cause for `makeqstrdefs.py` not accepting output from this preprocessor is that it sometimes outputs a `#line` directive without a file name, which `startswith` accepts, but `re_line` regex does not match.