### PR TITLE
py/builtinimport: Look in every directory of PATH.

### DIFF
--- a/py/builtinimport.c
+++ b/py/builtinimport.c
@@ -142,9 +142,9 @@ STATIC mp_import_stat_t stat_top_level_dir_or_file(qstr mod_name, vstr_t *dest) 
             rest = qstr_str(mod_name);
             dot = strchr(rest, '.');
             while (dot) {
-                vstr_add_strn(dest, rest, dot-rest);
+                vstr_add_strn(dest, rest, dot - rest);
                 vstr_add_char(dest, PATH_SEP_CHAR[0]);
-                rest=dot+1;
+                rest = dot + 1;
                 dot = strchr(rest, '.');
             }
             vstr_add_str(dest, rest);

--- a/tests/cpydiff/core_import_split_ns_pkgs.py
+++ b/tests/cpydiff/core_import_split_ns_pkgs.py
@@ -1,15 +1,22 @@
 """
 categories: Core,import
-description: MicroPython does't support namespace packages split across filesystem.
-cause: MicroPython's import system is highly optimized for simplicity, minimal memory usage, and minimal filesystem search overhead.
-workaround: Don't install modules belonging to the same namespace package in different directories. For MicroPython, it's recommended to have at most 3-component module search paths: for your current application, per-user (writable), system-wide (non-writable).
+description: MicroPython loads non-namespace packages split across filesystems.
+cause: MicroPython's import system is optimized for simplicity.
+workaround: Not required.
 """
 import sys
 
 sys.path.append(sys.path[1] + "/modules")
 sys.path.append(sys.path[1] + "/modules2")
 
-import subpkg.foo
+# import from the second subpackage first
 import subpkg.bar
+import subpkg.foo
 
-print("Two modules of a split namespace package imported")
+print("Two modules of a split non-namespace package imported")
+
+import subpkg
+assert subpkg.one == 1
+assert not hasattr(subpkg,"two")
+
+print("The first module's __init__ is used")

--- a/tests/cpydiff/core_import_split_ns_pkgs.py
+++ b/tests/cpydiff/core_import_split_ns_pkgs.py
@@ -16,7 +16,8 @@ import subpkg.foo
 print("Two modules of a split non-namespace package imported")
 
 import subpkg
+
 assert subpkg.one == 1
-assert not hasattr(subpkg,"two")
+assert not hasattr(subpkg, "two")
 
 print("The first module's __init__ is used")

--- a/tests/cpydiff/modules/subpkg/__init__.py
+++ b/tests/cpydiff/modules/subpkg/__init__.py
@@ -1,0 +1,2 @@
+# Not a namespace package
+one = 1

--- a/tests/cpydiff/modules2/subpkg/__init__.py
+++ b/tests/cpydiff/modules2/subpkg/__init__.py
@@ -1,0 +1,2 @@
+# Not a namespace package
+two = 2


### PR DESCRIPTION
Scan all elements of "usys.path" for (sub)modules.

Previously, this scan was only done for toplevel modules, which prevented selectively overriding a submodule. This was a problem in low-memory situations, particularly when debugging.

Closes #10813.

NB, while this is somewhat less efficient than the previous code, the overhead should be negligible compared to reading the file and possibly byte-compiling it. The speed loss is also offset by the fact that you can now selectively override single submodules instead of copying the whole module tree to the device (assuming that this is possible in the first place).