### PR TITLE
extmod/uasyncio/core: Remember an "unhandled" exception.

### DIFF
--- a/extmod/uasyncio/core.py
+++ b/extmod/uasyncio/core.py
@@ -222,6 +222,9 @@ def run_until_complete(main_task=None):
                 _exc_context["exception"] = exc
                 _exc_context["future"] = t
                 Loop.call_exception_handler(_exc_context)
+                # XXX if we do await it later,
+                # leaving t.data as None will cause a fault.
+                t.data = exc
 
 
 # Create a new task from a coroutine and run it until it finishes

--- a/tests/extmod/uasyncio_wait_task.py
+++ b/tests/extmod/uasyncio_wait_task.py
@@ -36,6 +36,10 @@ async def task_raise():
     raise ValueError
 
 
+def exc_handler(loop, ctx):
+    print("Not handled:", repr(ctx["exception"]))
+
+
 async def main():
     print("start")
 
@@ -69,6 +73,16 @@ async def main():
     # Wait on a task that raises an exception
     t = asyncio.create_task(task_raise())
     try:
+        await t
+    except ValueError:
+        print("ValueError")
+
+    # Delay waiting. This complains that "Task exception wasn't retrieved"
+    # even though we do, but MicroPython doesn't have a __del__ handler ...
+    asyncio.get_event_loop().set_exception_handler(exc_handler)
+    t = asyncio.create_task(task_raise())
+    try:
+        await asyncio.sleep(0.1)
         await t
     except ValueError:
         print("ValueError")

--- a/tests/extmod/uasyncio_wait_task.py.exp
+++ b/tests/extmod/uasyncio_wait_task.py.exp
@@ -8,3 +8,6 @@ world
 took 200 200
 task_raise
 ValueError
+task_raise
+Not handled: ValueError()
+ValueError


### PR DESCRIPTION
If a task raises an exception that isn't caught immediately, we still need to remember the exception so that the user's code can handle it later.

This is not optimal – but we can't use CPython's solution, which is a `__del__` handler.

The attached test causes a nice little segmentation fault in `modasyncio.c` if `uasyncio/core.py` is not modified.