### PR TITLE
Allow the git tag and git hash info to come from environment variables

### DIFF
--- a/py/makeversionhdr.py
+++ b/py/makeversionhdr.py
@@ -86,8 +86,11 @@ def get_version_info_from_mpconfig(repo_path):
 
 
 def make_version_header(repo_path, filename):
-    # Get version info using git, with fallback to py/mpconfig.h
-    info = get_version_info_from_git(repo_path)
+    info = None
+    if "MICROPY_GIT_TAG" in os.environ:
+        info = [os.environ["MICROPY_GIT_TAG"], os.environ["MICROPY_GIT_HASH"]]
+    if info is None:
+        info = get_version_info_from_git(repo_path)
     if info is None:
         info = get_version_info_from_mpconfig(repo_path)
 


### PR DESCRIPTION
This is handy when you are doing builds outside of the Git repository but still want to record that information.

I'm using the [fetchFromGitHub](https://nixos.org/manual/nixpkgs/stable/#fetchfromgithub) function from Nixpkgs to fetch the MicroPython source code, and it is like downloading a ZIP file from GitHub: it doesn't (by default) have a .git folder with tag and commit info in it.