### PR TITLE
tools/pyboard.py: Use '/' exclusively when dealing with paths.

### DIFF
--- a/tools/pyboard.py
+++ b/tools/pyboard.py
@@ -663,15 +663,16 @@ def filesystem_command(pyb, args, progress_callback=None, verbose=False):
     def fname_remote(src):
         if src.startswith(":"):
             src = src[1:]
-        return src
+        # Convert all path separators to "/", because that's what a remote device uses.
+        return src.replace(os.path.sep, "/")
 
     def fname_cp_dest(src, dest):
         _, src = os.path.split(src)
         if dest is None or dest == "":
             dest = src
         elif dest == ".":
-            dest = os.path.join(".", src)
-        elif dest.endswith(os.path.sep):
+            dest = "/".join(".", src)
+        elif dest.endswith("/"):
             dest += src
         return dest
 


### PR DESCRIPTION
Currently, certain mpremote filesystem operations can fail on Windows due to a mixing of '/' and '\' for path separators.  Eg if filesystem_command() is called with a destination that ends in / then dest.endswith(os.path.sep) will return False, which gives the wrong behaviour (it does end in a path separator).

For similar reasons to 7e9a15966acf80ff50fdf5c52553dd56de164bb3, it's best to use '/' everywhere in pyboard.py and mpremote, because the target device understands only '/'.  mpremote already does this, so the remaining place to fix it is in pyboard.y, to convert all incoming paths to use '/' instead of '\'.

This effectively reverts 57fd66b80f8352e4859e6b71536b6083f9d7279c which tried to fix the problem in a different way.

See also related 1f84440538a017e463aaad9686831ce9527122b5.