### PR TITLE
py/modmath: Fix two-argument math function domain check.

### DIFF
--- a/py/modmath.c
+++ b/py/modmath.c
@@ -54,7 +54,7 @@ STATIC mp_obj_t math_generic_2(mp_obj_t x_obj, mp_obj_t y_obj, mp_float_t (*f)(m
     mp_float_t x = mp_obj_get_float(x_obj);
     mp_float_t y = mp_obj_get_float(y_obj);
     mp_float_t ans = f(x, y);
-    if ((isnan(ans) && !isnan(x) && !isnan(y)) || (isinf(ans) && !isinf(x))) {
+    if ((isnan(ans) && !isnan(x) && !isnan(y)) || (isinf(ans) && !isinf(x) && !isinf(y))) {
         math_error();
     }
     return mp_obj_new_float(ans);

--- a/tests/float/math_domain.py
+++ b/tests/float/math_domain.py
@@ -39,7 +39,26 @@ for name, f, args in (
 
 # double argument functions
 for name, f, args in (
-    ("pow", math.pow, ((0, 2), (-1, 2), (0, -1), (-1, 2.3), (nan, 0), (1, nan))),
+    (
+        "pow",
+        math.pow,
+        (
+            (0, 2),
+            (-1, 2),
+            (0, -1),
+            (-1, 2.3),
+            (0.5, inf),
+            (-0.5, inf),
+            (0.5, -inf),
+            (-0.5, -inf),
+            (1.5, inf),
+            (-1.5, inf),
+            (1.5, -inf),
+            (-1.5, -inf),
+            (nan, 0),
+            (1, nan),
+        ),
+    ),
     ("log", math.log, ()),
     ("fmod", math.fmod, ((1.2, inf), (1.2, -inf), (1.2, 0), (inf, 1.2))),
     ("atan2", math.atan2, ((0, 0), (-inf, inf), (-inf, -inf), (inf, -inf))),


### PR DESCRIPTION
Prior to this fix, pow(1.5, inf) and pow(0.5, -inf) (among other things) would incorrectly raise a ValueError, because the result is inf with the first argument being finite.  This commit fixes this by allowing the result to be infinite if the first or second (or both) argument is infinite.

This fix doesn't affect the other three math functions that have two arguments:
- atan2 never returns inf, so always fails isinf(ans)
- copysign returns inf only if the first argument x is inf, so will never reach the isinf(y) check
- fmod never returns inf, so always fails isinf(ans)