### PR TITLE
drivers/cyw43: Use board-defined BLE UART secondary baudrate.

### DIFF
--- a/drivers/cyw43/cywbt.c
+++ b/drivers/cyw43/cywbt.c
@@ -159,8 +159,8 @@ STATIC int cywbt_download_firmware(const uint8_t *firmware) {
     #endif
 
     mp_bluetooth_hci_uart_set_baudrate(115200);
-    cywbt_set_baudrate(3000000);
-    mp_bluetooth_hci_uart_set_baudrate(3000000);
+    cywbt_set_baudrate(MICROPY_HW_BLE_UART_BAUDRATE_SECONDARY);
+    mp_bluetooth_hci_uart_set_baudrate(MICROPY_HW_BLE_UART_BAUDRATE_SECONDARY);
 
     return 0;
 }
@@ -192,8 +192,8 @@ int mp_bluetooth_hci_controller_init(void) {
     cywbt_hci_cmd(0x03, 0x0003, 0, NULL);
 
     // Change baudrate
-    cywbt_set_baudrate(3000000);
-    mp_bluetooth_hci_uart_set_baudrate(3000000);
+    cywbt_set_baudrate(MICROPY_HW_BLE_UART_BAUDRATE_SECONDARY);
+    mp_bluetooth_hci_uart_set_baudrate(MICROPY_HW_BLE_UART_BAUDRATE_SECONDARY);
 
     cywbt_download_firmware((const uint8_t*)CYWBT_FW_ADDR);
 


### PR DESCRIPTION
* The secondary baudrate was defined but never used in this driver.