### PR TITLE
rp2: Do not format the file system in response to Ctrl+C.

### DIFF
--- a/ports/esp32/main.c
+++ b/ports/esp32/main.c
@@ -161,7 +161,7 @@ soft_reset:
     #endif
 
     // run boot-up scripts
-    pyexec_frozen_module("_boot.py");
+    pyexec_frozen_module("_boot.py", false);
     pyexec_file_if_exists("boot.py");
     if (pyexec_mode_kind == PYEXEC_MODE_FRIENDLY_REPL) {
         int ret = pyexec_file_if_exists("main.py");

--- a/ports/esp8266/main.c
+++ b/ports/esp8266/main.c
@@ -74,7 +74,7 @@ STATIC void mp_reset(void) {
     }
 
     #if MICROPY_MODULE_FROZEN
-    pyexec_frozen_module("_boot.py");
+    pyexec_frozen_module("_boot.py", false);
     pyexec_file_if_exists("boot.py");
     if (pyexec_mode_kind == PYEXEC_MODE_FRIENDLY_REPL) {
         pyexec_file_if_exists("main.py");

--- a/ports/mimxrt/main.c
+++ b/ports/mimxrt/main.c
@@ -85,7 +85,7 @@ int main(void) {
         readline_init0();
 
         // Execute _boot.py to set up the filesystem.
-        pyexec_frozen_module("_boot.py");
+        pyexec_frozen_module("_boot.py", false);
 
         // Execute user scripts.
         int ret = pyexec_file_if_exists("boot.py");

--- a/ports/minimal/main.c
+++ b/ports/minimal/main.c
@@ -55,7 +55,7 @@ int main(int argc, char **argv) {
     // do_str("print('hello world!', list(x+1 for x in range(10)), end='eol\\n')", MP_PARSE_SINGLE_INPUT);
     // do_str("for i in range(10):\r\n  print(i)", MP_PARSE_FILE_INPUT);
     #else
-    pyexec_frozen_module("frozentest.py");
+    pyexec_frozen_module("frozentest.py", false);
     #endif
     mp_deinit();
     return 0;

--- a/ports/nrf/main.c
+++ b/ports/nrf/main.c
@@ -184,7 +184,7 @@ soft_reset:
     int ret = mp_vfs_mount_and_chdir_protected((mp_obj_t)&nrf_flash_obj, mount_point);
 
     if ((ret == -MP_ENODEV) || (ret == -MP_EIO)) {
-        pyexec_frozen_module("_mkfs.py"); // Frozen script for formatting flash filesystem.
+        pyexec_frozen_module("_mkfs.py", false); // Frozen script for formatting flash filesystem.
         ret = mp_vfs_mount_and_chdir_protected((mp_obj_t)&nrf_flash_obj, mount_point);
     }
 

--- a/ports/powerpc/main.c
+++ b/ports/powerpc/main.c
@@ -95,7 +95,7 @@ int main(int argc, char **argv) {
     pyexec_friendly_repl();
     #endif
     #else
-    pyexec_frozen_module("frozentest.py");
+    pyexec_frozen_module("frozentest.py", false);
     #endif
     mp_deinit();
     return 0;

--- a/ports/renesas-ra/main.c
+++ b/ports/renesas-ra/main.c
@@ -325,7 +325,7 @@ soft_reset:
 
     // Run optional frozen boot code.
     #ifdef MICROPY_BOARD_FROZEN_BOOT_FILE
-    pyexec_frozen_module(MICROPY_BOARD_FROZEN_BOOT_FILE);
+    pyexec_frozen_module(MICROPY_BOARD_FROZEN_BOOT_FILE, false);
     #endif
 
     // Run boot.py (or whatever else a board configures at this stage).

--- a/ports/rp2/main.c
+++ b/ports/rp2/main.c
@@ -168,9 +168,9 @@ int main(int argc, char **argv) {
 
         // Execute _boot.py to set up the filesystem.
         #if MICROPY_VFS_FAT && MICROPY_HW_USB_MSC
-        pyexec_frozen_module("_boot_fat.py");
+        pyexec_frozen_module("_boot_fat.py", false);
         #else
-        pyexec_frozen_module("_boot.py");
+        pyexec_frozen_module("_boot.py", false);
         #endif
 
         // Execute user scripts.

--- a/ports/samd/main.c
+++ b/ports/samd/main.c
@@ -52,7 +52,7 @@ void samd_main(void) {
         readline_init0();
 
         // Execute _boot.py to set up the filesystem.
-        pyexec_frozen_module("_boot.py");
+        pyexec_frozen_module("_boot.py", false);
 
         // Execute user scripts.
         int ret = pyexec_file_if_exists("boot.py");

--- a/ports/stm32/main.c
+++ b/ports/stm32/main.c
@@ -559,7 +559,7 @@ soft_reset:
 
     // Run optional frozen boot code.
     #ifdef MICROPY_BOARD_FROZEN_BOOT_FILE
-    pyexec_frozen_module(MICROPY_BOARD_FROZEN_BOOT_FILE);
+    pyexec_frozen_module(MICROPY_BOARD_FROZEN_BOOT_FILE, false);
     #endif
 
     // Run boot.py (or whatever else a board configures at this stage).

--- a/ports/teensy/main.c
+++ b/ports/teensy/main.c
@@ -298,7 +298,7 @@ soft_reset:
     #endif
 
     #if MICROPY_MODULE_FROZEN
-    pyexec_frozen_module("boot.py");
+    pyexec_frozen_module("boot.py", false);
     #else
     if (!pyexec_file_if_exists("/boot.py")) {
         flash_error(4);
@@ -310,7 +310,7 @@ soft_reset:
 
     // run main script
     #if MICROPY_MODULE_FROZEN
-    pyexec_frozen_module("main.py");
+    pyexec_frozen_module("main.py", true);
     #else
     {
         vstr_t *vstr = vstr_new(16);

--- a/shared/runtime/pyexec.c
+++ b/shared/runtime/pyexec.c
@@ -57,6 +57,7 @@ STATIC bool repl_display_debugging_info = 0;
 #define EXEC_FLAG_SOURCE_IS_VSTR        (1 << 4)
 #define EXEC_FLAG_SOURCE_IS_FILENAME    (1 << 5)
 #define EXEC_FLAG_SOURCE_IS_READER      (1 << 6)
+#define EXEC_FLAG_NO_INTERRUPT          (1 << 7)
 
 // parses, compiles and executes the code in the lexer
 // frees the lexer before returning
@@ -113,7 +114,9 @@ STATIC int parse_compile_execute(const void *source, mp_parse_input_kind_t input
         }
 
         // execute code
-        mp_hal_set_interrupt_char(CHAR_CTRL_C); // allow ctrl-C to interrupt us
+        if (!(exec_flags & EXEC_FLAG_NO_INTERRUPT)) {
+            mp_hal_set_interrupt_char(CHAR_CTRL_C);
+        }
         #if MICROPY_REPL_INFO
         start = mp_hal_ticks_ms();
         #endif
@@ -686,7 +689,7 @@ int pyexec_file(const char *filename) {
 int pyexec_file_if_exists(const char *filename) {
     #if MICROPY_MODULE_FROZEN
     if (mp_find_frozen_module(filename, NULL, NULL) == MP_IMPORT_STAT_FILE) {
-        return pyexec_frozen_module(filename);
+        return pyexec_frozen_module(filename, true);
     }
     #endif
     if (mp_import_stat(filename) != MP_IMPORT_STAT_FILE) {
@@ -696,20 +699,22 @@ int pyexec_file_if_exists(const char *filename) {
 }
 
 #if MICROPY_MODULE_FROZEN
-int pyexec_frozen_module(const char *name) {
+int pyexec_frozen_module(const char *name, bool allow_keyboard_interrupt) {
     void *frozen_data;
     int frozen_type;
     mp_find_frozen_module(name, &frozen_type, &frozen_data);
+    mp_uint_t exec_flags = allow_keyboard_interrupt ? 0 : EXEC_FLAG_NO_INTERRUPT;
 
     switch (frozen_type) {
         #if MICROPY_MODULE_FROZEN_STR
         case MP_FROZEN_STR:
-            return parse_compile_execute(frozen_data, MP_PARSE_FILE_INPUT, 0);
+            return parse_compile_execute(frozen_data, MP_PARSE_FILE_INPUT, exec_flags);
         #endif
 
         #if MICROPY_MODULE_FROZEN_MPY
         case MP_FROZEN_MPY:
-            return parse_compile_execute(frozen_data, MP_PARSE_FILE_INPUT, EXEC_FLAG_SOURCE_IS_RAW_CODE);
+            return parse_compile_execute(frozen_data, MP_PARSE_FILE_INPUT, exec_flags |
+                EXEC_FLAG_SOURCE_IS_RAW_CODE);
         #endif
 
         default:

--- a/shared/runtime/pyexec.h
+++ b/shared/runtime/pyexec.h
@@ -46,7 +46,7 @@ int pyexec_raw_repl(void);
 int pyexec_friendly_repl(void);
 int pyexec_file(const char *filename);
 int pyexec_file_if_exists(const char *filename);
-int pyexec_frozen_module(const char *name);
+int pyexec_frozen_module(const char *name, bool allow_keyboard_interrupt);
 void pyexec_event_repl_init(void);
 int pyexec_event_repl_process_char(int c);
 extern uint8_t pyexec_repl_active;


### PR DESCRIPTION
I noticed that the @mu-editor sends Ctrl+A followed by Ctrl+D to reboot the board, and then it very quickly sends a Ctrl+C character, interrupting the code in `_boot.py` or `_boot_fat.py` while it is trying to mount the root file system.  The `except:` clause in those files catches the `KeyboardInterrupt` and destroys the existing file system.

~~This pull request fixes the problem by only catching exceptions that inherit from the `Exception` class, which does not include `KeyboardInterrupt`.  In the future, maybe the `except` clause should be restricted further, since formatting the file system is so destructive and it only makes sense to do it if we have confirmed that the file system is invalid.~~

~~Note that this pull request is not sufficient to actually get Mu to work with an RP2040: the errant Ctrl+C will interrupt the booting process and leave the interpreter in a state where it does not have a root file system.~~
