### PR TITLE
.github/workflows/build_mpy_cross.yml: Build various mpy-cross binaries.

### DIFF
--- a/.github/workflows/build_mpy_cross.yml
+++ b/.github/workflows/build_mpy_cross.yml
@@ -1,0 +1,67 @@
+name: Build mpy-cross binaries
+
+on: workflow_dispatch
+
+jobs:
+  build:
+    runs-on: ubuntu-18.04
+    steps:
+    - uses: actions/checkout@v3
+    - name: Install packages
+      run: source tools/ci.sh && ci_mpy_cross_setup
+    - name: Build
+      run: source tools/ci.sh && ci_mpy_cross_build
+    - name: Archive binaries (Linux x64)
+      uses: actions/upload-artifact@v3
+      with:
+        name: mpy-cross-binaries-linux-x64
+        path: mpy-cross/build-linux-x64/mpy-cross
+    - name: Archive binaries (Linux aarch64)
+      uses: actions/upload-artifact@v3
+      with:
+        name: mpy-cross-binaries-linux-aarch64
+        path: mpy-cross/build-linux-aarch64/mpy-cross
+    - name: Archive binaries (Linux armhf)
+      uses: actions/upload-artifact@v3
+      with:
+        name: mpy-cross-binaries-linux-armhf
+        path: mpy-cross/build-linux-armhf/mpy-cross
+    - name: Archive binaries (Windows x64)
+      uses: actions/upload-artifact@v3
+      with:
+        name: mpy-cross-binaries-windows-x64
+        path: mpy-cross/build-windows-x64/mpy-cross.exe
+
+  build-i686:
+    runs-on: ubuntu-18.04
+    steps:
+    - uses: actions/checkout@v3
+    - name: Install packages
+      run: source tools/ci.sh && ci_mpy_cross_i686_setup
+    - name: Build
+      run: source tools/ci.sh && ci_mpy_cross_i686_build
+    - name: Archive binaries (Linux i686)
+      uses: actions/upload-artifact@v3
+      with:
+        name: mpy-cross-binaries-linux-i686
+        path: mpy-cross/build-linux-i686/mpy-cross
+    - name: Archive binaries (Windows i686)
+      uses: actions/upload-artifact@v3
+      with:
+        name: mpy-cross-binaries-windows-i686
+        path: mpy-cross/build-windows-i686/mpy-cross.exe
+
+  macos:
+    runs-on: macos-11.0
+    steps:
+    - uses: actions/checkout@v3
+    - uses: actions/setup-python@v4
+      with:
+        python-version: '3.8'
+    - name: Build
+      run: source tools/ci.sh && ci_mpy_cross_macos_build
+    - name: Archive binaries (macOS x64)
+      uses: actions/upload-artifact@v3
+      with:
+        name: mpy-cross-binaries-macos-x64
+        path: mpy-cross/build-macos-x64/mpy-cross

--- a/tools/ci.sh
+++ b/tools/ci.sh
@@ -703,3 +703,31 @@ function ci_zephyr_build {
     docker exec zephyr-ci west build -p auto -b mimxrt1050_evk
     docker exec zephyr-ci west build -p auto -b nucleo_wb55rg # for bluetooth
 }
+
+########################################################################################
+# mpy-cross
+
+function ci_mpy_cross_setup {
+    sudo apt-get install gcc-arm-linux-gnueabihf gcc-aarch64-linux-gnu gcc-mingw-w64
+}
+
+function ci_mpy_cross_build {
+    make ${MAKEOPTS} -C mpy-cross BUILD=build-linux-x64
+    make ${MAKEOPTS} -C mpy-cross BUILD=build-linux-aarch64 CROSS_COMPILE=aarch64-linux-gnu-
+    make ${MAKEOPTS} -C mpy-cross BUILD=build-linux-armhf CROSS_COMPILE=arm-linux-gnueabihf-
+    make ${MAKEOPTS} -C mpy-cross BUILD=build-windows-x64 CROSS_COMPILE=x86_64-w64-mingw32-
+}
+
+function ci_mpy_cross_i686_setup {
+    sudo apt-get install gcc-multilib gcc-mingw-w64-i686
+    # Note gcc-mingw-w64-i686 renamed to gcc-mingw-w64-i686-win32 in jammy
+}
+
+function ci_mpy_cross_i686_build {
+    make ${MAKEOPTS} -C mpy-cross MICROPY_FORCE_32BIT=1 BUILD=build-linux-i686
+    make ${MAKEOPTS} -C mpy-cross MICROPY_FORCE_32BIT=1 BUILD=build-windows-i686 CROSS_COMPILE=i686-w64-mingw32-
+}
+
+function ci_mpy_cross_macos_build {
+    make ${MAKEOPTS} -C mpy-cross BUILD=build-macos-x64
+}


### PR DESCRIPTION
This provides binaries that will be used to generate mpy-cross binaries for inclusion in a future PyPI package.

Includes Linux (32-bit and 64-bit), Windows (32-bit and 64-bit), aarch64 (e.g. 64-bit Raspberry Pi 4), armhf (e.g. earlier 32-bit Raspberry Pi), macos (x64, works on M1/ARM too). This is the same set that @andrewleech provides currently for https://pypi.org/project/mpy-cross/ via https://gitlab.com/alelec/mpy_cross/-/blob/master/.gitlab-ci.yml

Demo artifacts are here: https://github.com/jimmo/micropython/actions/runs/4259908934
Tested both Windows builds in Wine, armhf on a Raspberry Pi 3 running Buster, macos on an M1.

I have a Raspberry 4, will test the aarch64 build there soon. Can test the Windows builds on real Windows next week.

Currently using Ubuntu Bionic as the build environment (so that it supports older glibc, i.e. Ubuntu Bionic LTS and Debian Buster). This is deprecated, but we can move to Focal when support is removed (which will support the current Debian/Raspbian Bullseye and Ubuntu LTS).

_This work was funded through GitHub Sponsors._
