### PR TITLE
extmod/btstack: Implement gap_passkey(...)

### DIFF
--- a/extmod/btstack/modbluetooth_btstack.c
+++ b/extmod/btstack/modbluetooth_btstack.c
@@ -1240,7 +1240,26 @@ int mp_bluetooth_gap_pair(uint16_t conn_handle) {
 
 int mp_bluetooth_gap_passkey(uint16_t conn_handle, uint8_t action, mp_int_t passkey) {
     DEBUG_printf("mp_bluetooth_gap_passkey: conn_handle=%d action=%d passkey=%d\n", conn_handle, action, (int)passkey);
-    return MP_EOPNOTSUPP;
+    switch (action) {
+        case MP_BLUETOOTH_PASSKEY_ACTION_INPUT: {
+            sm_passkey_input(conn_handle, passkey);
+            break;
+        }
+        case MP_BLUETOOTH_PASSKEY_ACTION_DISPLAY: {
+            sm_use_fixed_passkey_in_display_role(passkey);
+            break;
+        }
+        case MP_BLUETOOTH_PASSKEY_ACTION_NUMERIC_COMPARISON: {
+            if (passkey != 0) {
+                sm_numeric_comparison_confirm(conn_handle);
+            }
+            break;
+        }
+        default: {
+            return MP_EINVAL;
+        }
+    }
+    return 0;
 }
 
 #endif // MICROPY_PY_BLUETOOTH_ENABLE_PAIRING_BONDING


### PR DESCRIPTION
Adds NimBLE-like behavior to `BLE.gap_passkey(conn_handle, action, passkey)` when using BTstack.

I've successfully tested the `_PASSKEY_ACTION_INPUT` action with #10739, a Pico W, and a Blackmagic Camera.  I can't test the other two actions on hardware but they were implemented with respect to the [BTstack Security Manager API](https://bluekitchen-gmbh.com/btstack/#appendix/sm/#_top).