### PR TITLE
Strings shouldn't support any divide-like binary op.

### DIFF
--- a/py/objstr.c
+++ b/py/objstr.c
@@ -372,6 +372,16 @@ mp_obj_t mp_obj_str_binary_op(mp_binary_op_t op, mp_obj_t lhs_in, mp_obj_t rhs_i
         return mp_obj_new_str_type_from_vstr(lhs_type, &vstr);
     }
 
+    // check for divides
+    if (
+        op == MP_BINARY_OP_TRUE_DIVIDE
+        || op == MP_BINARY_OP_FLOOR_DIVIDE
+        || op == MP_BINARY_OP_INPLACE_FLOOR_DIVIDE
+        || op == MP_BINARY_OP_INPLACE_TRUE_DIVIDE
+        ) {
+        return MP_OBJ_NULL; // op not supported
+    }
+
     // From now on all operations allow:
     //    - str with str
     //    - bytes with bytes
@@ -403,7 +413,7 @@ mp_obj_t mp_obj_str_binary_op(mp_binary_op_t op, mp_obj_t lhs_in, mp_obj_t rhs_i
     } else {
         // LHS is str and RHS has an incompatible type
         // (except if operation is EQUAL, but that's handled by mp_obj_equal)
-        return MP_OBJ_NULL;
+        bad_implicit_conversion(rhs_in);
     }
 
     switch (op) {

--- a/py/objstr.c
+++ b/py/objstr.c
@@ -372,6 +372,16 @@ mp_obj_t mp_obj_str_binary_op(mp_binary_op_t op, mp_obj_t lhs_in, mp_obj_t rhs_i
         return mp_obj_new_str_type_from_vstr(lhs_type, &vstr);
     }
 
+    // check for divides
+    if (
+        op == MP_BINARY_OP_TRUE_DIVIDE
+        || op == MP_BINARY_OP_FLOOR_DIVIDE
+        || op == MP_BINARY_OP_INPLACE_FLOOR_DIVIDE
+        || op == MP_BINARY_OP_INPLACE_TRUE_DIVIDE
+        ) {
+        return MP_OBJ_NULL; // op not supported
+    }
+
     // From now on all operations allow:
     //    - str with str
     //    - bytes with bytes

--- a/py/objstr.c
+++ b/py/objstr.c
@@ -372,16 +372,6 @@ mp_obj_t mp_obj_str_binary_op(mp_binary_op_t op, mp_obj_t lhs_in, mp_obj_t rhs_i
         return mp_obj_new_str_type_from_vstr(lhs_type, &vstr);
     }
 
-    // check for divides
-    if (
-        op == MP_BINARY_OP_TRUE_DIVIDE
-        || op == MP_BINARY_OP_FLOOR_DIVIDE
-        || op == MP_BINARY_OP_INPLACE_FLOOR_DIVIDE
-        || op == MP_BINARY_OP_INPLACE_TRUE_DIVIDE
-        ) {
-        return MP_OBJ_NULL; // op not supported
-    }
-
     // From now on all operations allow:
     //    - str with str
     //    - bytes with bytes
@@ -413,7 +403,7 @@ mp_obj_t mp_obj_str_binary_op(mp_binary_op_t op, mp_obj_t lhs_in, mp_obj_t rhs_i
     } else {
         // LHS is str and RHS has an incompatible type
         // (except if operation is EQUAL, but that's handled by mp_obj_equal)
-        bad_implicit_conversion(rhs_in);
+        return MP_OBJ_NULL;
     }
 
     switch (op) {

--- a/tests/basics/string_div.py
+++ b/tests/basics/string_div.py
@@ -1,0 +1,35 @@
+class DivClass:
+    def __truediv__(self, other):
+        return "truediv"
+
+    def __rtruediv__(self, other):
+        return "rtruediv"
+
+    def __floordiv__(self, other):
+        return "floordiv"
+
+    def __rfloordiv__(self, other):
+        return "rfloordiv"
+
+
+print(DivClass() / "")  # truediv
+print("" / DivClass())  # rtruediv
+print(DivClass() // "")  # floordiv
+print("" // DivClass())  # rfloordiv
+
+# Test inplace
+val = DivClass()
+val /= ""
+print(val)  # truediv
+
+val = ""
+val /= DivClass()
+print(val)  # rtruediv
+
+val = DivClass()
+val //= ""
+print(val)  # floordiv
+
+val = ""
+val //= DivClass()
+print(val)  # rfloordiv


### PR DESCRIPTION
This allows for the correct implementation of `__rtruediv__` for classes like `pathlib.Path`.

See related discussion:

https://github.com/micropython/micropython-lib/issues/621