### PR TITLE
mpremote/mip: Allow version override in package.

### DIFF
--- a/tools/mpremote/mpremote/mip.py
+++ b/tools/mpremote/mpremote/mip.py
@@ -106,7 +106,10 @@ def _install_json(pyb, package_json_url, index, target, version, mpy):
         _download_file(pyb, file_url, fs_target_path)
     for target_path, url in package_json.get("urls", ()):
         fs_target_path = target + "/" + target_path
-        _download_file(pyb, _rewrite_url(url, version), fs_target_path)
+        _version = version
+        if url.startswith("github:") and "@" in url:
+            url, _version = url.split("@")
+        _download_file(pyb, _rewrite_url(url, _version), fs_target_path)
     for dep, dep_version in package_json.get("deps", ()):
         _install_package(pyb, dep, index, target, dep_version, mpy)
 

--- a/tools/mpremote/mpremote/mip.py
+++ b/tools/mpremote/mpremote/mip.py
@@ -5,6 +5,7 @@
 import urllib.error
 import urllib.request
 import json
+import re
 import tempfile
 import os
 
@@ -120,14 +121,16 @@ def _install_package(pyb, package, index, target, version, mpy):
         or package.startswith("https://")
         or package.startswith("github:")
     ):
-        if package.endswith(".py") or package.endswith(".mpy"):
+        match = re.search(r"(\.\w+)", package)
+        package_ext = match.group() if match else ""
+        if package_ext in (".py", ".mpy", ".txt", ".bin",".fon"):
             print(f"Downloading {package} to {target}")
             _download_file(
-                pyb, _rewrite_url(package, version), target + "/" + package.rsplit("/")[-1]
+                    pyb, _rewrite_url(package, version), target + "/" + package.rsplit("/")[-1]
             )
             return
         else:
-            if not package.endswith(".json"):
+            if package_ext != ".json":
                 if not package.endswith("/"):
                     package += "/"
                 package += "package.json"


### PR DESCRIPTION
Adds the capability for a mip package.json to include urls to github hosted files that are versioned 
This change allows explicit versions/branches to be specified at the `url` level.
This allows a package to combine files from different branches, in the same repo, and across different repo's as well.
The default behavior's remains to 'inherit' an explicit version specified at the package level using the `@branch-or-tag` notation,

Example package: 
``` json
{
    "urls": [
        [ "foo.py", "github:my/repo/folder/foo.py@foo-beta"],
        [ "bar.py", "github:my/repo/folder/bar.py" ]
    ],
    "deps": [],
    "version": "1.2.3"
}
```
allows mip to install the packages files from two different branches
- `mpremote mip install github:my/repo`
   - `foo.py`  from branch `foo-beta`
   - `bar.py` from branch `master`

- `mpremote mip install github:my/repo@foo-beta`
   - `foo.py`  from branch `foo-beta`
   - `bar.py` from branch `foo-beta`

- `mpremote mip install github:my/repo@bar-alfa`
   - `foo.py`  from branch `foo-beta`
   - `bar.py` from branch `bar-alfa`

also see: Discord: https://discord.com/channels/574275045187125269/1024252597839859734/1078727025596059698
