### PR TITLE
actions/mpremote:Update actions to remove warning.

### DIFF
--- a/.github/workflows/mpremote.yml
+++ b/.github/workflows/mpremote.yml
@@ -11,20 +11,20 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         # Version is determined from git,
         # should be deep enough to get to latest tag
         fetch-depth: '1000'
     - run: |
         git fetch --prune --unshallow --tags
-    - uses: actions/setup-python@v1
+    - uses: actions/setup-python@v4
     - name: Install build tools
       run: pip install build
     - name: Build mpremote wheel
       run: cd tools/mpremote && python -m build --wheel
     - name: Archive mpremote wheel
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: mpremote
         path: |


### PR DESCRIPTION
Update the workflow to use recent versions of actions rather than older Node v12 action that are depricated.
- action/checkout@v3
- actions/setuppython@4
- actions/upload-artifact@v3 

For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/.
