### PR TITLE
Explicitly compare comparison ops

### DIFF
--- a/py/emitnative.c
+++ b/py/emitnative.c
@@ -2365,14 +2365,13 @@ STATIC void emit_native_binary_op(emit_t *emit, mp_binary_op_t op) {
         } else if (op == MP_BINARY_OP_MULTIPLY) {
             ASM_MUL_REG_REG(emit->as, REG_ARG_2, reg_rhs);
             emit_post_push_reg(emit, vtype_lhs, REG_ARG_2);
-        } else if (MP_BINARY_OP_LESS <= op && op <= MP_BINARY_OP_NOT_EQUAL) {
-            // comparison ops are (in enum order):
-            //  MP_BINARY_OP_LESS
-            //  MP_BINARY_OP_MORE
-            //  MP_BINARY_OP_EQUAL
-            //  MP_BINARY_OP_LESS_EQUAL
-            //  MP_BINARY_OP_MORE_EQUAL
-            //  MP_BINARY_OP_NOT_EQUAL
+        } else if (MP_BINARY_OP_LESS == op ||
+                   MP_BINARY_OP_MORE == op ||
+                   MP_BINARY_OP_EQUAL == op ||
+                   MP_BINARY_OP_LESS_EQUAL == op ||
+                   MP_BINARY_OP_MORE_EQUAL == op ||
+                   MP_BINARY_OP_NOT_EQUAL == op) {
+            // comparison ops
 
             if (vtype_lhs != vtype_rhs) {
                 EMIT_NATIVE_VIPER_TYPE_ERROR(emit, MP_ERROR_TEXT("comparison of int and uint"));


### PR DESCRIPTION
Without this I am getting this rather mysterious error
```
../../micropython/py/emitnative.c: In function 'emit_native_binary_op':
../../micropython/py/emitnative.c:2367:38: error: comparison is always true due to limited range of data type [-Werror=type-limits]
 2367 |         } else if (MP_BINARY_OP_LESS <= op && op <= MP_BINARY_OP_NOT_EQUAL) {
      |                                      ^~
```