### PR TITLE
zephyr: Construct Pin object with a port instance number.

### DIFF
--- a/docs/zephyr/quickref.rst
+++ b/docs/zephyr/quickref.rst
@@ -36,7 +36,7 @@ Use the :ref:`machine.Pin <machine.Pin>` class::
 
     from machine import Pin
 
-    pin = Pin(("GPIO_1", 21), Pin.IN)   # create input pin on GPIO1
+    pin = Pin((1, 21), Pin.IN)          # create input pin on GPIO1
     print(pin)                          # print pin port and number
 
     pin.init(Pin.OUT, Pin.PULL_UP, value=1)     # reinitialize pin
@@ -47,13 +47,13 @@ Use the :ref:`machine.Pin <machine.Pin>` class::
     pin.on()                            # set pin to high
     pin.off()                           # set pin to low
 
-    pin = Pin(("GPIO_1", 21), Pin.IN)   # create input pin on GPIO1
+    pin = Pin((1, 21), Pin.IN)                  # create input pin on GPIO1
 
-    pin = Pin(("GPIO_1", 21), Pin.OUT, value=1)         # set pin high on creation
+    pin = Pin((1, 21), Pin.OUT, value=1)        # set pin high on creation
 
-    pin = Pin(("GPIO_1", 21), Pin.IN, Pin.PULL_UP)      # enable internal pull-up resistor
+    pin = Pin((1, 21), Pin.IN, Pin.PULL_UP)     # enable internal pull-up resistor
 
-    switch = Pin(("GPIO_2", 6), Pin.IN)                 # create input pin for a switch
+    switch = Pin((2, 6), Pin.IN)                        # create input pin for a switch
     switch.irq(lambda t: print("SW2 changed"))          # enable an interrupt when switch state is changed
 
 Hardware I2C bus

--- a/ports/zephyr/README.md
+++ b/ports/zephyr/README.md
@@ -102,7 +102,7 @@ To blink an LED:
     import time
     from machine import Pin
 
-    LED = Pin(("GPIO_1", 21), Pin.OUT)
+    LED = Pin((1, 21), Pin.OUT)
     while True:
         LED.value(1)
         time.sleep(0.5)
@@ -120,8 +120,8 @@ To respond to Pin change IRQs, on a FRDM-K64F board run:
 
     from machine import Pin
 
-    SW2 = Pin(("GPIO_2", 6), Pin.IN)
-    SW3 = Pin(("GPIO_0", 4), Pin.IN)
+    SW2 = Pin((2, 6), Pin.IN)
+    SW3 = Pin((0, 4), Pin.IN)
 
     SW2.irq(lambda t: print("SW2 changed"))
     SW3.irq(lambda t: print("SW3 changed"))

--- a/ports/zephyr/boards/frdm_k64f.overlay
+++ b/ports/zephyr/boards/frdm_k64f.overlay
@@ -1,0 +1,15 @@
+/*
+ * Copyright (c) 2023 Intel Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/ {
+	chosen {
+		micropython,machine-pin0 = &gpioa;
+		micropython,machine-pin1 = &gpiob;
+		micropython,machine-pin2 = &gpioc;
+		micropython,machine-pin3 = &gpiod;
+		micropython,machine-pin4 = &gpioe;
+	};
+};

--- a/ports/zephyr/modmachine.h
+++ b/ports/zephyr/modmachine.h
@@ -3,6 +3,13 @@
 
 #include "py/obj.h"
 
+#define MICROPYTHON_CHOSEN(prop, i)                         \
+    DT_CHOSEN(DT_CAT3(micropython_, prop, i))
+
+#define MICROPYTHON_CHOSEN_DEVICE(prop, i, _)               \
+    IF_ENABLED(DT_NODE_EXISTS(MICROPYTHON_CHOSEN(prop, i)), \
+               (DEVICE_DT_GET(MICROPYTHON_CHOSEN(prop, i)),))
+
 extern const mp_obj_type_t machine_pin_type;
 extern const mp_obj_type_t machine_i2c_type;
 extern const mp_obj_type_t machine_spi_type;


### PR DESCRIPTION
Adds support for constructing a Pin object with a port instance number, where the available instances are defined by devicetree chosen nodes. Existing support for constructing a Pin object with a device name string remains, but device names will become less user-friendly when upgrading to Zephyr v3.2.0 due to deprecation of the devicetree label property.