### PR TITLE
esp32/mphalport: Add _FUNCTION_, _LINE_, _FILE_ info to check_esp_err().

### DIFF
--- a/ports/esp32/mphalport.c
+++ b/ports/esp32/mphalport.c
@@ -53,7 +53,12 @@ STATIC uint8_t stdin_ringbuf_array[260];
 ringbuf_t stdin_ringbuf = {stdin_ringbuf_array, sizeof(stdin_ringbuf_array), 0, 0};
 
 // Check the ESP-IDF error code and raise an OSError if it's not ESP_OK.
-void check_esp_err(esp_err_t code) {
+#if MICROPY_ERROR_REPORTING <= MICROPY_ERROR_REPORTING_NORMAL
+void check_esp_err_(esp_err_t code)
+#else
+void check_esp_err_(esp_err_t code, const char *func, const int line, const char *file)
+#endif
+{
     if (code != ESP_OK) {
         // map esp-idf error code to posix error code
         uint32_t pcode = -code;
@@ -75,7 +80,16 @@ void check_esp_err(esp_err_t code) {
             return;
         }
         o_str->base.type = &mp_type_str;
+        #if MICROPY_ERROR_REPORTING > MICROPY_ERROR_REPORTING_NORMAL
+        char err_msg[64];
+        esp_err_to_name_r(code, err_msg, sizeof(err_msg));
+        vstr_t vstr;
+        vstr_init(&vstr, 80);
+        vstr_printf(&vstr, "0x%04X %s in function '%s' at line %d in file '%s'", code, err_msg, func, line, file);
+        o_str->data = (const byte *)vstr_null_terminated_str(&vstr);
+        #else
         o_str->data = (const byte *)esp_err_to_name(code); // esp_err_to_name ret's ptr to const str
+        #endif
         o_str->len = strlen((char *)o_str->data);
         o_str->hash = qstr_compute_hash(o_str->data, o_str->len);
         // raise

--- a/ports/esp32/mphalport.h
+++ b/ports/esp32/mphalport.h
@@ -55,7 +55,13 @@ extern TaskHandle_t mp_main_task_handle;
 extern ringbuf_t stdin_ringbuf;
 
 // Check the ESP-IDF error code and raise an OSError if it's not ESP_OK.
-void check_esp_err(esp_err_t code);
+#if MICROPY_ERROR_REPORTING <= MICROPY_ERROR_REPORTING_NORMAL
+#define check_esp_err(code) check_esp_err_(code)
+void check_esp_err_(esp_err_t code);
+#else
+#define check_esp_err(code) check_esp_err_(code, __FUNCTION__, __LINE__, __FILE__)
+void check_esp_err_(esp_err_t code, const char *func, const int line, const char *file);
+#endif
 
 uint32_t mp_hal_ticks_us(void);
 __attribute__((always_inline)) static inline uint32_t mp_hal_ticks_cpu(void) {


### PR DESCRIPTION
This PR can be useful for ESP32 developers.

Now check_esp_err() raises an exception without a location in the source code.
```
Traceback (most recent call last):
  File "<stdin>", line 8, in <module>
OSError: (-258, 'ESP_ERR_INVALID_ARG')
```

This PR adds debugging information to the exception and will be useful during code development.
Info about __FUNCTION__, __LINE__, __FILE__ may be added.

During the development change the 
https://github.com/micropython/micropython/blob/3637252b7bc3e85ea92038161e008a550991d1f4/ports/esp32/mpconfigport.h#L50
to the
#define MICROPY_ERROR_REPORTING             (MICROPY_ERROR_REPORTING_DETAILED)

REPL output may look like 
```
Exception from function 'configure_channel' at line 233 in file './machine_pwm.c'
Traceback (most recent call last):
  File "<stdin>", line 8, in <module>
OSError: (-258, 'ESP_ERR_INVALID_ARG')
```
or in a different way.
Discussion is welcome.

Edited:
If MICROPY_ERROR_REPORTING is equal to the MICROPY_ERROR_REPORTING_NORMAL during final compilation
then the size of the binary code is not increased.

If MICROPY_ERROR_REPORTING is equal to the MICROPY_ERROR_REPORTING_DETAILED during development
then FUNCTION, LINE, FILE information is added to the output.

Edited:
With last commit output like:
```
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
OSError: -258, 0x0102, 'ESP_ERR_INVALID_ARG' in function 'set_duty_u16' at line 342 in file './machine_pwm.c'
```

Edited:
With last commit output like:
```
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
OSError: (-258, "0x0102 ESP_ERR_INVALID_ARG in function 'set_duty_u16' at line 342 in file './machine_pwm.c'")
```