### PR TITLE
rp2: fix lightsleep after cyw43 deinit

### DIFF
--- a/ports/rp2/modmachine.c
+++ b/ports/rp2/modmachine.c
@@ -146,7 +146,7 @@ STATIC mp_obj_t machine_lightsleep(size_t n_args, const mp_obj_t *args) {
 
     uint32_t my_interrupts = save_and_disable_interrupts();
     #if MICROPY_PY_NETWORK_CYW43
-    if (cyw43_has_pending) {
+    if (cyw43_has_pending && (cyw43_poll != NULL)) {
         restore_interrupts(my_interrupts);
         return mp_const_none;
     }


### PR DESCRIPTION
Addressing a corner case in the commit 439298be1 by felix@dogcraft.de.

Problem occurs when wifi is enabled using:

> rp2.country('CA')
> wlan = network.WLAN(STA_IF)
> wlan.config(pm = 0xa11140)
> wlan.active(True)
 wlan.connect('secretSSID','secretPW')

Then disabled using:
>wlan.disconnect()
>wlan.active(False)
>wlan.deinit()

Note: There example in the github and raspberrypi forums where GPIO pin 23 is manipulated from micropython to power down and power up the cyw43 chip.
This is not necessary. The call to wlan.deinit() will power down the cyw43 and any future access to the cyw43 hardware will power it back up again.

After the wlan.deinit() a call machine.lightsleep(60000) will return immediately rather than sleeping for 60 seconds.

The root cause of the problem is code in the cyw43 driver. While wlan.deinit() executes one interrupt always occurs. The IRQ runs and schedules a pending event.
Before the pending event can be processed variable cyw43_poll is set to null.
The poll function cyw43_poll_func() checks cyw43_poll and returns. As a result, the global cyw43_has_pending is set to 1 and never gets cleared.

My fix in modmachine.c is to ignore cyw43_has_pending when cyw43_poll is NULL.

Probably it would be better to fix this with a change to the cyw43 driver. I am hesitant, I feel I would need to test on at least one other platform that uses the cyw43 driver and I only have access to PICO_W.

I tested on PICO_W with a loop that: connected, published MQTT data, disconnected, did lightsleep(60000).
Timestamps from mqtt server confirm lightsleep was full duration.