### PR TITLE
drivers/ninaw10: Fix machine_pin GPIO read.

### DIFF
--- a/drivers/ninaw10/machine_pin_nina.c
+++ b/drivers/ninaw10/machine_pin_nina.c
@@ -68,6 +68,7 @@ bool machine_pin_ext_get(machine_pin_obj_t *self) {
     if (self->id >= 0 && self->id < MICROPY_HW_PIN_EXT_COUNT) {
         uint8_t buf[] = {pin_map[self->id]};
         nina_ioctl(NINA_GPIO_READ, sizeof(buf), buf, 0);
+        value = buf[0];
     }
     return value;
 }


### PR DESCRIPTION
The value returned from the ioctl call was not set in the returned value 🤦🏼‍♂️ 