### PR TITLE
tests/renesas-ra: Add support for VK-RA4W1, VK_RA6M3 & VK-RA6M5 boards.

### DIFF
--- a/tests/renesas-ra/freq.py
+++ b/tests/renesas-ra/freq.py
@@ -4,13 +4,19 @@
 MACHINE_RA4M1_CLICKER = "RA4M1_CLICKER with RA4M1"
 MACHINE_RA4M1_EK = "RA4M1_EK with RA4M1"
 MACHINE_RA4W1_EK = "RA4W1_EK with RA4W1"
+MACHINE_VK_RA4W1 = "VK-RA4W1 with RA4W1"
 MACHINE_RA6M1_EK = "RA6M1_EK with RA6M1"
 MACHINE_RA6M2_EK = "RA6M2_EK with RA6M2"
+MACHINE_VK_RA6M3 = "VK-RA6M3 with RA6M3"
+MACHINE_VK_RA6M5 = "VK-RA6M5 with RA6M5"
 SYSCLK_RA4M1_CLICKER = 48000000
 SYSCLK_RA4M1_EK = 48000000
 SYSCLK_RA4W1_EK = 48000000
+SYSCLK_VK_RA4W1 = 48000000
 SYSCLK_RA6M1_EK = 120000000
 SYSCLK_RA6M2_EK = 120000000
+SYSCLK_VK_RA6M3 = 120000000
+SYSCLK_VK_RA6M5 = 200000000
 
 #
 # machine
@@ -46,6 +52,12 @@ if m == MACHINE_RA4W1_EK:
     else:
         print("freq: NG")
 
+if m == MACHINE_VK_RA4W1:
+    if f == SYSCLK_VK_RA4W1:
+        print("freq: OK")
+    else:
+        print("freq: NG")
+
 if m == MACHINE_RA6M1_EK:
     if f == SYSCLK_RA6M1_EK:
         print("freq: OK")
@@ -54,6 +66,18 @@ if m == MACHINE_RA6M1_EK:
 
 if m == MACHINE_RA6M2_EK:
     if f == SYSCLK_RA6M2_EK:
+        print("freq: OK")
+    else:
+        print("freq: NG")
+
+if m == MACHINE_VK_RA6M3:
+    if f == SYSCLK_VK_RA6M3:
+        print("freq: OK")
+    else:
+        print("freq: NG")
+
+if m == MACHINE_VK_RA6M5:
+    if f == SYSCLK_VK_RA6M5:
         print("freq: OK")
     else:
         print("freq: NG")

--- a/tests/renesas-ra/i2c.py
+++ b/tests/renesas-ra/i2c.py
@@ -2,13 +2,15 @@ import os
 import time
 
 n = os.uname().machine
-if "RA6M2_EK" in n:
+if ("RA6M2_EK" in n) or ("VK-RA6M5" in n):
     i2c_id = 2
 elif "RA6M1_EK" in n:
     i2c_id = 0
 elif ("RA4M1_CLICKER" in n) or ("RA4M1_EK" in n) or ("RA4W1_EK" in n):
     print("SKIP")
     raise SystemExit
+elif ("VK-RA4W1" in n) or ("VK-RA6M3" in n):
+    i2c_id = 1
 else:
     i2c_id = 0
 

--- a/tests/renesas-ra/spi.py
+++ b/tests/renesas-ra/spi.py
@@ -11,7 +11,11 @@ if (
 ):
     spis = (-1, 0)
 else:
-    spis = (-1, 0, 1)
+    if ("VK-RA4W1" in machine) or ("VK-RA6M3" in machine) or ("VK-RA6M5" in machine):
+        print("SKIP")
+        raise SystemExit
+    else:
+        spis = (-1, 0, 1)
 
 # test we can correctly create by id
 for bus in spis:


### PR DESCRIPTION
`tests/renesas-ra:` Some of specific ra tests fails with the new boards (#10595 #10752 #10943), so this PR handles their testing.
`tests:` Part of existing **renesas-ra** family tests.