### PR TITLE
ports/mimxrt: Allow configuring different network interfaces.

### DIFF
--- a/ports/mimxrt/eth.c
+++ b/ports/mimxrt/eth.c
@@ -31,7 +31,7 @@
 #include "py/mperrno.h"
 #include "ticks.h"
 
-#if defined(MICROPY_HW_ETH_MDC)
+#if defined(IOMUX_TABLE_ENET)
 
 #include "pin.h"
 #include "shared/netutils/netutils.h"
@@ -639,4 +639,4 @@ void eth_low_power_mode(eth_t *self, bool enable) {
     ENET_EnableSleepMode(ENET, enable);
     #endif
 }
-#endif // defined(MICROPY_HW_ETH_MDC)
+#endif // defined(IOMUX_TABLE_ENET)

--- a/ports/mimxrt/mpconfigport.h
+++ b/ports/mimxrt/mpconfigport.h
@@ -102,16 +102,19 @@ uint32_t trng_random_u32(void);
 #define MICROPY_FATFS_MAX_SS                (4096)
 #define MICROPY_FATFS_LFN_CODE_PAGE         437 /* 1=SFN/ANSI 437=LFN/U.S.(OEM) */
 
-// If MICROPY_PY_LWIP is defined, add network support
-#if MICROPY_PY_LWIP
-
+#ifndef MICROPY_PY_NETWORK
 #define MICROPY_PY_NETWORK                  (1)
+#endif
+#ifndef MICROPY_PY_USOCKET
 #define MICROPY_PY_USOCKET                  (1)
-#define MICROPY_PY_UWEBSOCKET               (1)
-#define MICROPY_PY_WEBREPL                  (1)
-#define MICROPY_PY_UHASHLIB_SHA1            (1)
-#define MICROPY_PY_LWIP_SOCK_RAW            (1)
-#define MICROPY_HW_ETH_MDC                  (1)
+#endif
+#define MICROPY_PY_UWEBSOCKET               (MICROPY_PY_LWIP)
+#define MICROPY_PY_WEBREPL                  (MICROPY_PY_LWIP)
+#define MICROPY_PY_LWIP_SOCK_RAW            (MICROPY_PY_LWIP)
+#define MICROPY_PY_USSL_FINALISER           (MICROPY_PY_USSL)
+// #define MICROPY_PY_UHASHLIB_MD5             (MICROPY_PY_USSL)
+#define MICROPY_PY_UHASHLIB_SHA1            (MICROPY_PY_USSL)
+// #define MICROPY_PY_UCRYPTOLIB               (MICROPY_PY_USSL)
 
 // Prevent the "LWIP task" from running.
 #define MICROPY_PY_LWIP_ENTER   MICROPY_PY_PENDSV_ENTER
@@ -120,8 +123,6 @@ uint32_t trng_random_u32(void);
 
 #ifndef MICROPY_PY_NETWORK_HOSTNAME_DEFAULT
 #define MICROPY_PY_NETWORK_HOSTNAME_DEFAULT "mpy-mimxrt"
-#endif
-
 #endif
 
 // For regular code that wants to prevent "background tasks" from running.
@@ -165,7 +166,7 @@ static inline void restore_irq_pri(uint32_t basepri) {
 #define MICROPY_BEGIN_ATOMIC_SECTION()     disable_irq()
 #define MICROPY_END_ATOMIC_SECTION(state)  enable_irq(state)
 
-#if defined(MICROPY_HW_ETH_MDC)
+#if defined(IOMUX_TABLE_ENET)
 extern const struct _mp_obj_type_t network_lan_type;
 #define MICROPY_HW_NIC_ETH                  { MP_ROM_QSTR(MP_QSTR_LAN), MP_ROM_PTR(&network_lan_type) },
 #else

--- a/ports/mimxrt/network_lan.c
+++ b/ports/mimxrt/network_lan.c
@@ -28,7 +28,7 @@
 #include "py/mphal.h"
 #include "extmod/modnetwork.h"
 
-#if defined(MICROPY_HW_ETH_MDC)
+#if defined(IOMUX_TABLE_ENET)
 
 #include "fsl_phy.h"
 #include "eth.h"
@@ -264,4 +264,4 @@ MP_DEFINE_CONST_OBJ_TYPE(
     );
 
 
-#endif // defined(MICROPY_HW_ETH_MDC)
+#endif // defined(IOMUX_TABLE_ENET)


### PR DESCRIPTION
This patch allows boards to disable Ethernet and keep the networking stack enabled, to use an alternate networking
interface, such as WiFi.