### PR TITLE
py: Implement mp_sched_vm_abort() to force a return to the very top level (v2)

### DIFF
--- a/py/mpconfig.h
+++ b/py/mpconfig.h
@@ -909,6 +909,11 @@ typedef double mp_float_t;
 #define MICROPY_INTERNAL_PRINTF_PRINTER (&mp_plat_print)
 #endif
 
+// Whether to support mp_sched_vm_abort to asynchronously abort to the top level.
+#ifndef MICROPY_ENABLE_VM_ABORT
+#define MICROPY_ENABLE_VM_ABORT (0)
+#endif
+
 // Support for internal scheduler
 #ifndef MICROPY_ENABLE_SCHEDULER
 #define MICROPY_ENABLE_SCHEDULER (MICROPY_CONFIG_ROM_LEVEL_AT_LEAST_EXTRA_FEATURES)
@@ -1738,6 +1743,10 @@ typedef double mp_float_t;
 
 #ifndef MICROPY_WRAP_MP_SCHED_SCHEDULE
 #define MICROPY_WRAP_MP_SCHED_SCHEDULE(f) f
+#endif
+
+#ifndef MICROPY_WRAP_MP_SCHED_VM_ABORT
+#define MICROPY_WRAP_MP_SCHED_VM_ABORT(f) f
 #endif
 
 /*****************************************************************************/

--- a/py/mpstate.h
+++ b/py/mpstate.h
@@ -226,6 +226,11 @@ typedef struct _mp_state_vm_t {
     uint8_t sched_idx;
     #endif
 
+    #if MICROPY_ENABLE_VM_ABORT
+    bool vm_abort;
+    nlr_buf_t *nlr_abort;
+    #endif
+
     #if MICROPY_PY_THREAD_GIL
     // This is a global mutex used to make the VM/runtime thread-safe.
     mp_thread_mutex_t gil_mutex;

--- a/py/mpstate.h
+++ b/py/mpstate.h
@@ -297,8 +297,10 @@ extern mp_state_ctx_t mp_state_ctx;
 #if MICROPY_PY_THREAD
 extern mp_state_thread_t *mp_thread_get_state(void);
 #define MP_STATE_THREAD(x) (mp_thread_get_state()->x)
+#define mp_thread_is_main_thread() (mp_thread_get_state() == &mp_state_ctx.thread)
 #else
 #define MP_STATE_THREAD(x)  MP_STATE_MAIN_THREAD(x)
+#define mp_thread_is_main_thread() (true)
 #endif
 
 #endif // MICROPY_INCLUDED_PY_MPSTATE_H

--- a/py/nlr.c
+++ b/py/nlr.c
@@ -49,3 +49,10 @@ void nlr_pop(void) {
     nlr_buf_t **top = &MP_STATE_THREAD(nlr_top);
     *top = (*top)->prev;
 }
+
+#if MICROPY_ENABLE_VM_ABORT
+NORETURN void nlr_jump_abort(void) {
+    MP_STATE_THREAD(nlr_top) = MP_STATE_VM(nlr_abort);
+    nlr_jump(NULL);
+}
+#endif

--- a/py/runtime.h
+++ b/py/runtime.h
@@ -75,6 +75,9 @@ void mp_deinit(void);
 
 void mp_sched_exception(mp_obj_t exc);
 void mp_sched_keyboard_interrupt(void);
+#if MICROPY_ENABLE_VM_ABORT
+void mp_sched_vm_abort(void);
+#endif
 void mp_handle_pending(bool raise_exc);
 
 #if MICROPY_ENABLE_SCHEDULER

--- a/py/vm.c
+++ b/py/vm.c
@@ -1333,6 +1333,10 @@ pending_exception_check:
                     // No scheduler: Just check pending exception.
                     MP_STATE_THREAD(mp_pending_exception) != MP_OBJ_NULL
                 #endif
+                #if MICROPY_ENABLE_VM_ABORT
+                    // Check if the VM should abort execution.
+                    || MP_STATE_VM(vm_abort)
+                #endif
                 ) {
                     MARK_EXC_IP_SELECTIVE();
                     mp_handle_pending(true);


### PR DESCRIPTION
This is an alternative and simpler version of #10241, which adds a way to forcefully abort the VM from an IRQ handler (or from the main running thread).

The version here is very simple because it just has a flag `MP_STATE_VM(vm_abort)` which is set (eg by an IRQ handler) when the VM should abort.  The VM checks this flag when it checks the pending exception variable.  This adds some small overhead to the VM, but keeps things simple and easy to reason about.  It would be possible to combine all the ways of interrupting the VM (exception, scheduled callback, VM abort) into a single flag, but that's not done in this PR (possibly could be done in the future).

The approach here is able to abort pretty much anything:
- an infinite Python loop
- an infinite Python loop running in a (soft) scheduled callback
- an infinite Python loop running in a hard interrupt

If using this feature, one thing to be careful of is trying to abort the REPL when it's not running any code.  In that case it will most likely lead to an uncaught NLR hard fault, because there is no outer NLR context to catch the VM abort.