### PR TITLE
all: GitHub Action to lint Python code with ruff.

### DIFF
--- a/.github/workflows/ruff.yml
+++ b/.github/workflows/ruff.yml
@@ -1,0 +1,10 @@
+# https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-python
+name: Python code lint with ruff
+on: [push, pull_request]
+jobs:
+  ruff:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - run: pip install --user ruff
+    - run: ruff --format=github .

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,3 +22,27 @@ skip = """
 ./tests,\
 ACKNOWLEDGEMENTS,\
 """
+
+[tool.ruff]
+exclude = ["lib", "tests"]
+extend-select = ["C9", "PLC"]
+ignore = [
+  "E401",
+  "E402",
+  "E722",
+  "E731",
+  "E741",
+  "F401",
+  "F403",
+  "F405",
+  "F821",
+  "PLC1901",
+]
+line-length = 337
+target-version = "py37"
+
+[tool.ruff.mccabe]
+max-complexity = 40
+
+[tool.ruff.per-file-ignores]
+"ports/cc3200/tools/uniflash.py" = ["E711"]


### PR DESCRIPTION
[Ruff](https://beta.ruff.rs) supports [over 500 lint rules](https://beta.ruff.rs/docs/rules) including
flake8, isort, pylint, and pyupgrade and is written in Rust for speed.

The Action uses minimal steps to run in 7 seconds, rapidly providing contributors with intuitive
GitHub Annotations.