### PR TITLE
Fix comparison to None and True plus test for membership

### DIFF
--- a/ports/cc3200/tools/update-wipy.py
+++ b/ports/cc3200/tools/update-wipy.py
@@ -45,7 +45,7 @@ def transfer_file(args):
             if "250" in ftp.cwd("/flash"):
                 if not ftp_directory_exists(ftp, "sys"):
                     print("/flash/sys directory does not exist")
-                    if not "550" in ftp.mkd("sys"):
+                    if "550" not in ftp.mkd("sys"):
                         print("/flash/sys directory created")
                     else:
                         print("Error: cannot create /flash/sys directory")

--- a/ports/nrf/examples/powerup.py
+++ b/ports/nrf/examples/powerup.py
@@ -120,13 +120,13 @@ class PowerUp3:
         return int(self.char_batt_lvl.read()[0])
 
     def speed(self, new_speed=None):
-        if new_speed == None:
+        if new_speed is None:
             return int(self.char_control_speed.read()[0])
         else:
             self.char_control_speed.write(bytearray([new_speed]))
 
     def angle(self, new_angle=None):
-        if new_angle == None:
+        if new_angle is None:
             return int(self.char_control_angle.read()[0])
         else:
             self.char_control_angle.write(bytearray([new_angle]))

--- a/ports/rp2/modules/rp2.py
+++ b/ports/rp2/modules/rp2.py
@@ -116,7 +116,7 @@ class PIOASMEmit:
             if label is None:
                 label = 0
             else:
-                if not label in self.labels:
+                if label not in self.labels:
                     raise PIOASMError("unknown label {}".format(label))
                 label = self.labels[label]
             self.prog[_PROG_DATA].append(instr | label)

--- a/ports/stm32/boards/pllvalues.py
+++ b/ports/stm32/boards/pllvalues.py
@@ -94,7 +94,7 @@ def compute_pll2(hse, sys, relax_pll48):
     fallback = None
     for P in mcu.range_p:
         # VCO_OUT must be between 192MHz and 432MHz
-        if not sys * P in mcu.range_vco_out:
+        if sys * P not in mcu.range_vco_out:
             continue
         NbyM = float(sys * P) / hse  # float for Python 2
         # scan M

--- a/tools/mpremote/mpremote/commands.py
+++ b/tools/mpremote/mpremote/commands.py
@@ -122,9 +122,9 @@ def do_filesystem(state, args):
     if command == "cat":
         # Don't be verbose by default when using cat, so output can be
         # redirected to something.
-        verbose = args.verbose == True
+        verbose = args.verbose is True
     else:
-        verbose = args.verbose != False
+        verbose = args.verbose is not False
 
     if command == "cp" and args.recursive:
         if paths[-1] != ":":

--- a/tools/uf2conv.py
+++ b/tools/uf2conv.py
@@ -85,9 +85,9 @@ def convert_from_uf2(buf):
         if datalen > 476:
             assert False, "Invalid UF2 data size at " + ptr
         newaddr = hd[3]
-        if (hd[2] & 0x2000) and (currfamilyid == None):
+        if (hd[2] & 0x2000) and (currfamilyid is None):
             currfamilyid = hd[7]
-        if curraddr == None or ((hd[2] & 0x2000) and hd[7] != currfamilyid):
+        if curraddr is None or ((hd[2] & 0x2000) and hd[7] != currfamilyid):
             currfamilyid = hd[7]
             curraddr = newaddr
             if familyid == 0x0 or familyid == hd[7]:
@@ -111,7 +111,7 @@ def convert_from_uf2(buf):
                     families_found[hd[7]] = newaddr
             else:
                 families_found[hd[7]] = newaddr
-        if prev_flag == None:
+        if prev_flag is None:
             prev_flag = hd[2]
         if prev_flag != hd[2]:
             all_flags_same = False
@@ -234,7 +234,7 @@ def convert_from_hex_to_uf2(buf):
             break
         elif tp == 0:
             addr = upper + ((rec[1] << 8) | rec[2])
-            if appstartaddr == None:
+            if appstartaddr is None:
                 appstartaddr = addr
             i = 4
             while i < len(rec) - 1:
@@ -419,7 +419,7 @@ def main():
             )
         if args.convert or ext != "uf2":
             drives = []
-            if args.output == None:
+            if args.output is None:
                 args.output = "flash." + ext
         else:
             drives = get_drives()


### PR DESCRIPTION
Fix some basic PEP8 issues with https://beta.ruff.rs

$ `ruff --exclude=tests,ports/cc3200/tools/uniflash.py --select=E711,E712,E713 --statistics .`
```
7	E711	[*] Comparison to `None` should be `cond is None`
2	E712	[*] Comparison to `True` should be `cond is True`
3	E713	[*] Test for membership should be `not in`
```
### `ruff --fix .`
$ `ruff --exclude=tests,ports/cc3200/tools/uniflash.py --select=E711,E712,E713 --fix .`
```
Found 12 errors (12 fixed, 0 remaining).
```