### PR TITLE
py/gc: Make gc_dump_info/gc_dump_alloc_table take a printer as argument.

### DIFF
--- a/ports/minimal/main.c
+++ b/ports/minimal/main.c
@@ -69,7 +69,7 @@ void gc_collect(void) {
     gc_collect_start();
     gc_collect_root(&dummy, ((mp_uint_t)stack_top - (mp_uint_t)&dummy) / sizeof(mp_uint_t));
     gc_collect_end();
-    gc_dump_info();
+    gc_dump_info(&mp_plat_print);
 }
 #endif
 

--- a/ports/nrf/modules/machine/modmachine.c
+++ b/ports/nrf/modules/machine/modmachine.c
@@ -133,7 +133,7 @@ STATIC mp_obj_t machine_info(mp_uint_t n_args, const mp_obj_t *args) {
 
     if (n_args == 1) {
         // arg given means dump gc allocation table
-        gc_dump_alloc_table();
+        gc_dump_alloc_table(&mp_plat_print);
     }
 
     return mp_const_none;

--- a/ports/powerpc/main.c
+++ b/ports/powerpc/main.c
@@ -108,7 +108,7 @@ void gc_collect(void) {
     gc_collect_start();
     gc_collect_root(&dummy, ((mp_uint_t)stack_top - (mp_uint_t)&dummy) / sizeof(mp_uint_t));
     gc_collect_end();
-    gc_dump_info();
+    gc_dump_info(&mp_plat_print);
 }
 
 mp_lexer_t *mp_lexer_new_from_file(const char *filename) {

--- a/ports/renesas-ra/modmachine.c
+++ b/ports/renesas-ra/modmachine.c
@@ -154,7 +154,7 @@ STATIC mp_obj_t machine_info(size_t n_args, const mp_obj_t *args) {
 
     if (n_args == 1) {
         // arg given means dump gc allocation table
-        gc_dump_alloc_table();
+        gc_dump_alloc_table(&mp_plat_print);
     }
 
     return mp_const_none;

--- a/ports/stm32/modmachine.c
+++ b/ports/stm32/modmachine.c
@@ -244,7 +244,7 @@ STATIC mp_obj_t machine_info(size_t n_args, const mp_obj_t *args) {
 
     if (n_args == 1) {
         // arg given means dump gc allocation table
-        gc_dump_alloc_table();
+        gc_dump_alloc_table(print);
     }
 
     return mp_const_none;

--- a/ports/teensy/modpyb.c
+++ b/ports/teensy/modpyb.c
@@ -111,7 +111,7 @@ STATIC mp_obj_t pyb_info(uint n_args, const mp_obj_t *args) {
 
     if (n_args == 1) {
         // arg given means dump gc allocation table
-        gc_dump_alloc_table();
+        gc_dump_alloc_table(&mp_plat_print);
     }
 
     return mp_const_none;

--- a/ports/unix/gccollect.c
+++ b/ports/unix/gccollect.c
@@ -34,8 +34,6 @@
 #if MICROPY_ENABLE_GC
 
 void gc_collect(void) {
-    // gc_dump_info();
-
     gc_collect_start();
     gc_helper_collect_regs_and_stack();
     #if MICROPY_PY_THREAD
@@ -45,9 +43,6 @@ void gc_collect(void) {
     mp_unix_mark_exec();
     #endif
     gc_collect_end();
-
-    // printf("-----\n");
-    // gc_dump_info();
 }
 
 #endif // MICROPY_ENABLE_GC

--- a/ports/zephyr/main.c
+++ b/ports/zephyr/main.c
@@ -186,7 +186,6 @@ void gc_collect(void) {
     gc_collect_start();
     gc_collect_root(&dummy, ((mp_uint_t)MP_STATE_THREAD(stack_top) - (mp_uint_t)&dummy) / sizeof(mp_uint_t));
     gc_collect_end();
-    // gc_dump_info();
 }
 
 #if !MICROPY_READER_VFS

--- a/py/gc.h
+++ b/py/gc.h
@@ -28,7 +28,7 @@
 
 #include <stdbool.h>
 #include <stddef.h>
-#include "py/mpconfig.h"
+#include "py/mpprint.h"
 
 void gc_init(void *start, void *end);
 
@@ -72,7 +72,7 @@ typedef struct _gc_info_t {
 } gc_info_t;
 
 void gc_info(gc_info_t *info);
-void gc_dump_info(void);
-void gc_dump_alloc_table(void);
+void gc_dump_info(const mp_print_t *print);
+void gc_dump_alloc_table(const mp_print_t *print);
 
 #endif // MICROPY_INCLUDED_PY_GC_H

--- a/py/modmicropython.c
+++ b/py/modmicropython.c
@@ -81,10 +81,10 @@ mp_obj_t mp_micropython_mem_info(size_t n_args, const mp_obj_t *args) {
     mp_printf(&mp_plat_print, "stack: " UINT_FMT "\n", mp_stack_usage());
     #endif
     #if MICROPY_ENABLE_GC
-    gc_dump_info();
+    gc_dump_info(&mp_plat_print);
     if (n_args == 1) {
         // arg given means dump gc allocation table
-        gc_dump_alloc_table();
+        gc_dump_alloc_table(&mp_plat_print);
     }
     #else
     (void)n_args;

--- a/shared/runtime/pyexec.c
+++ b/shared/runtime/pyexec.c
@@ -167,7 +167,7 @@ STATIC int parse_compile_execute(const void *source, mp_parse_input_kind_t input
         #if MICROPY_ENABLE_GC
         // run collection and print GC info
         gc_collect();
-        gc_dump_info();
+        gc_dump_info(&mp_plat_print);
         #endif
     }
     #endif


### PR DESCRIPTION
So that callers can redirect the output if needed.