### PR TITLE
rp2: Fix setting of UART LCR parameters.

### DIFF
--- a/ports/rp2/machine_uart.c
+++ b/ports/rp2/machine_uart.c
@@ -336,7 +336,9 @@ STATIC void machine_uart_init_helper(machine_uart_obj_t *self, size_t n_args, co
 
         uart_init(self->uart, self->baudrate);
         uart_set_format(self->uart, self->bits, self->stop, self->parity);
+        __DSB(); // make sure UARTLCR_H register is written to
         uart_set_fifo_enabled(self->uart, true);
+        __DSB(); // make sure UARTLCR_H register is written to
         gpio_set_function(self->tx, GPIO_FUNC_UART);
         gpio_set_function(self->rx, GPIO_FUNC_UART);
         if (self->invert & UART_INVERT_RX) {


### PR DESCRIPTION
As reported by issue #10976, setting of UART parameters like parity, stop bits or data bits was not possible. I verified that using a RPi PICO and PICO W.  Strange enough, the problem shows up only at baud rates >9600. With 9600 baud it always works fine. With 19200 sometimes. Beyond that never, at least in my handful attempts.

Adding a small delay after uart_set_format() fixes that problem. The delay duration was determined by short experiments. 100µs was too short, 1000µs is fine, 10000 way too large. The reason for the problem is unclear. I found no notes about it in the documentation. Tested with baud rates between 9600 and 115200 baud.