### PR TITLE
py/builtinimport: Fix unix port build with external imports disabled.

### DIFF
--- a/py/builtinimport.c
+++ b/py/builtinimport.c
@@ -574,6 +574,10 @@ mp_obj_t mp_builtin___import___default(size_t n_args, const mp_obj_t *args) {
 
 #else // MICROPY_ENABLE_EXTERNAL_IMPORT
 
+bool mp_obj_is_package(mp_obj_t module) {
+    return false;
+}
+
 mp_obj_t mp_builtin___import___default(size_t n_args, const mp_obj_t *args) {
     // Check that it's not a relative import
     if (n_args >= 5 && MP_OBJ_SMALL_INT_VALUE(args[4]) != 0) {


### PR DESCRIPTION
Without this, building the unix port variants gives: 

```ports/unix/main.c:667: undefined reference to `mp_obj_is_package'```,

when `MICROPY_ENABLE_EXTERNAL_IMPORT` is set to `0`.

An alternate solution would be to not call `mp_obj_is_package` from the unix `main.c` in this build scenario.

Use case: This allows us to make a unix build that is quite close to our embedded builds, for easier debugging.