### PR TITLE
top: Fix ruff rules: E721,F524,F541,F632

### DIFF
--- a/extmod/uasyncio/funcs.py
+++ b/extmod/uasyncio/funcs.py
@@ -123,7 +123,7 @@ def gather(*aws, return_exceptions=False):
 
     # Either this gather was cancelled, or one of the sub-tasks raised an exception with
     # return_exceptions==False, so reraise the exception here.
-    if state is not 0:
+    if state:
         raise state
 
     # Return the list of return values of each sub-task.

--- a/ports/cc3200/boards/make-pins.py
+++ b/ports/cc3200/boards/make-pins.py
@@ -124,7 +124,7 @@ class Pins:
                     continue
                 if not row[pin_col].isdigit():
                     raise ValueError(
-                        "Invalid pin number {:s} in row {:s}".format(row[pin_col]), row
+                        "Invalid pin number {:s} in row {:s}".format(row[pin_col], row)
                     )
                 # Pin numbers must start from 0 when used with the TI API
                 pin_num = int(row[pin_col]) - 1

--- a/ports/stm32/boards/NUCLEO_WB55/rfcore_firmware.py
+++ b/ports/stm32/boards/NUCLEO_WB55/rfcore_firmware.py
@@ -704,7 +704,7 @@ def check_for_updates(force=False):
     if fus_uptodate and ws_uptodate and not force:
         log(f"Already up to date: fus: {current_version_fus}, ws: {current_version_ws}")
     else:
-        log(f"Starting firmware update")
+        log("Starting firmware update")
         log(f" - fus: {current_version_fus} -> {vers_fus}")
         log(f" - ws:  {current_version_ws} -> {vers_ws}")
         _write_state(_STATE_WAITING_FOR_FUS)

--- a/shared/memzip/make-memzip.py
+++ b/shared/memzip/make-memzip.py
@@ -36,7 +36,7 @@ def create_c_from_file(c_filename, zip_filename):
                     break
                 print('   ', end='', file=c_file)
                 for byte in buf:
-                    if type(byte) is types.StringType:
+                    if isinstance(byte, types.StringType):
                         print(' 0x{:02x},'.format(ord(byte)), end='', file=c_file)
                     else:
                         print(' 0x{:02x},'.format(byte), end='', file=c_file)


### PR DESCRIPTION
Fixes for:
* type-comparison (E721)
    * Do not compare types, use `isinstance()`
* string-dot-format-missing-arguments (F524)
    * `.format` call is missing argument(s) for placeholder(s): {message}
* f-string-missing-placeholders (F541)
* is-literal (F632)
    * Use `==` to compare constant literals
    * Use `!=` to compare constant literals
 
When we have a `pyproject.toml` (#10977) we will need to ignore some test files that directly check these issues.
```
[tool.ruff.per-file-ignores]
"tests/basics/is_isnot_literal.py" = ["F632"]
"tests/basics/string_fstring.py" = ["F541"]
"tests/cpydiff/core_fstring_raw.py" = ["F541"]
```