### PR TITLE
tools: Remove unused import of serial

### DIFF
--- a/tools/mpremote/mpremote/pyboardextended.py
+++ b/tools/mpremote/mpremote/pyboardextended.py
@@ -1,4 +1,4 @@
-import io, os, re, serial, struct, time
+import io, os, re, struct, time
 from errno import EPERM
 from .console import VT_ENABLED
 


### PR DESCRIPTION
This instance is a combination of an unused import and then a function parameter on line 576 with the same name.
```
tools/mpremote/mpremote/pyboardextended.py:1:20: F401 [*] `serial` imported but unused
tools/mpremote/mpremote/pyboardextended.py:576:24: F811 Redefinition of unused `serial` from line 1
```