### PR TITLE
all: ruff --fix W605 Invalid_escape_sequences

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -233,7 +233,7 @@ latex_elements = {
 # Additional stuff for the LaTeX preamble.
 #'preamble': '',
 # Include 3 levels of headers in PDF ToC
-'preamble': '\setcounter{tocdepth}{2}',
+'preamble': r'\setcounter{tocdepth}{2}',
 }
 
 # Grouping the document tree into LaTeX files. List of tuples

--- a/ports/cc3200/tools/uniflash.py
+++ b/ports/cc3200/tools/uniflash.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 
-"""
+r"""
 Flash the WiPy (format, update service pack and program).
 
 Example:

--- a/tools/insert-usb-ids.py
+++ b/tools/insert-usb-ids.py
@@ -16,7 +16,7 @@ def parse_usb_ids(filename):
     rv = dict()
     for line in open(filename).readlines():
         line = line.rstrip("\r\n")
-        match = re.match("^#define\s+(\w+)\s+\(0x([0-9A-Fa-f]+)\)$", line)
+        match = re.match(r"^#define\s+(\w+)\s+\(0x([0-9A-Fa-f]+)\)$", line)
         if match and match.group(1).startswith(config_prefix):
             key = match.group(1).replace(config_prefix, "USB_")
             val = match.group(2)

--- a/tools/uf2conv.py
+++ b/tools/uf2conv.py
@@ -271,7 +271,7 @@ def get_drives():
             ]
         )
         for line in to_str(r).split("\n"):
-            words = re.split("\s+", line)
+            words = re.split(r"\s+", line)
             if len(words) >= 3 and words[1] == "2" and words[2] == "FAT":
                 drives.append(words[0])
     else:


### PR DESCRIPTION
% `ruff --select=W605 --exclude=tests --fix .`
```
Found 17 errors (17 fixed, 0 remaining).
```
% `ruff rule W605`
# invalid-escape-sequence (W605)

Derived from the **pycodestyle** linter.

Autofix is always available.

Message formats:
* Invalid escape sequence: `\{char}`

These will also appear as warnings in pytest.
https://beta.ruff.rs