### PR TITLE
all: ruff --fix F841 Local variable assigned to but never used.

### DIFF
--- a/examples/network/http_server_simplistic.py
+++ b/examples/network/http_server_simplistic.py
@@ -28,7 +28,6 @@ def main():
     while True:
         res = s.accept()
         client_s = res[0]
-        client_addr = res[1]
         req = client_s.recv(4096)
         print("Request:")
         print(req)

--- a/ports/cc3200/tools/update-wipy.py
+++ b/ports/cc3200/tools/update-wipy.py
@@ -109,7 +109,7 @@ def reset_board(args):
     finally:
         try:
             tn.close()
-        except Exception as e:
+        except Exception:
             pass
         return success
 
@@ -167,7 +167,7 @@ def verify_update(args):
     finally:
         try:
             tn.close()
-        except Exception as e:
+        except Exception:
             pass
         return success
 

--- a/ports/mimxrt/boards/make-pins.py
+++ b/ports/mimxrt/boards/make-pins.py
@@ -226,7 +226,6 @@ class Pins(object):
             # Extract indexes from header row
             pad_col = header.index("Pad")
             adc_col = header.index("ADC")
-            acmp_col = header.index("ACMP")
             #
             for idx, row in enumerate(rows):
                 pad = row[pad_col]

--- a/ports/nrf/examples/seeed_tft.py
+++ b/ports/nrf/examples/seeed_tft.py
@@ -216,8 +216,6 @@ class ILI9341:
 
         self.write_cmd(0x2C)
 
-        num_of_pixels = self.height * self.width
-
         for row in range(0, self.pages):
             for pixel_pos in range(0, 8):
                 for col in range(0, self.width):

--- a/ports/rp2/boards/make-pins.py
+++ b/ports/rp2/boards/make-pins.py
@@ -207,7 +207,7 @@ class Pins(object):
             for row in rows:
                 try:
                     pin_num = parse_pin(row[pinname_col])
-                except Exception as e:
+                except Exception:
                     # import traceback; traceback.print_exc()
                     continue
                 pin = Pin(pin_num)
@@ -228,7 +228,7 @@ class Pins(object):
 
                 cpu_pin_name = row[1]
                 try:
-                    pin_num = parse_pin(cpu_pin_name)
+                    parse_pin(cpu_pin_name)
                 except:
                     # import traceback; traceback.print_exc()
                     continue

--- a/ports/stm32/make-stmconst.py
+++ b/ports/stm32/make-stmconst.py
@@ -265,7 +265,6 @@ def main():
         reg_defs["GPIO"].append(["BSRRL", 0x18, 16, "legacy register"])
         reg_defs["GPIO"].append(["BSRRH", 0x1A, 16, "legacy register"])
 
-    modules = []
     needed_qstrs = set()
     needed_mpzs = set()
 

--- a/ports/stm32/mboot/mboot.py
+++ b/ports/stm32/mboot/mboot.py
@@ -38,7 +38,7 @@ class Bootloader:
                 self.i2c.readfrom_into(self.addr, self.buf1)
                 n = self.buf1[0]
                 break
-            except OSError as er:
+            except OSError:
                 time.sleep_us(500)
             if time.ticks_diff(time.ticks_ms(), start) > 5000:
                 raise Exception("timeout")

--- a/tools/mpremote/mpremote/console.py
+++ b/tools/mpremote/mpremote/console.py
@@ -172,5 +172,5 @@ else:
     try:
         set_conout_mode(mode, mask)
         VT_ENABLED = True
-    except WindowsError as e:
+    except WindowsError:
         VT_ENABLED = False

--- a/tools/mpremote/mpremote/pyboardextended.py
+++ b/tools/mpremote/mpremote/pyboardextended.py
@@ -449,7 +449,7 @@ class PyboardCommand:
             try:
                 stat = os.lstat(self.data_ilistdir[0] + "/" + entry)
                 mode = stat.st_mode & 0xC000
-            except OSError as er:
+            except OSError:
                 mode = 0
             self.wr_str(entry)
             self.wr_u32(mode)

--- a/tools/mpy-tool.py
+++ b/tools/mpy-tool.py
@@ -1120,7 +1120,6 @@ class RawCodeNative(RawCode):
 
         i_top = len(self.fun_data)
         i = 0
-        qi = 0
         while i < i_top:
             # copy machine code (max 16 bytes)
             i16 = min(i + 16, i_top)
@@ -1276,7 +1275,7 @@ def read_raw_code(reader, parent_name, qstr_table, obj_table, segments):
                 if native_scope_flags & MP_SCOPE_FLAG_VIPERRODATA:
                     rodata_size = reader.read_uint()
                 if native_scope_flags & MP_SCOPE_FLAG_VIPERBSS:
-                    bss_size = reader.read_uint()
+                    reader.read_uint()  # bss_size
                 if native_scope_flags & MP_SCOPE_FLAG_VIPERRODATA:
                     reader.read_bytes(rodata_size)
                 if native_scope_flags & MP_SCOPE_FLAG_VIPERRELOC:
@@ -1285,10 +1284,10 @@ def read_raw_code(reader, parent_name, qstr_table, obj_table, segments):
                         if op == 0xFF:
                             break
                         if op & 1:
-                            addr = reader.read_uint()
+                            reader.read_uint()  # addr
                         op >>= 1
                         if op <= 5 and op & 1:
-                            n = reader.read_uint()
+                            reader.read_uint()  # n
             else:
                 assert kind == MP_CODE_NATIVE_ASM
                 native_n_pos_args = reader.read_uint()

--- a/tools/mpy_ld.py
+++ b/tools/mpy_ld.py
@@ -471,7 +471,6 @@ def do_relocation_text(env, text_addr, r):
     # Extract relevant info about symbol that's being relocated
     s = r.sym
     s_bind = s.entry["st_info"]["bind"]
-    s_shndx = s.entry["st_shndx"]
     s_type = s.entry["st_info"]["type"]
     r_offset = r["r_offset"] + text_addr
     r_info_type = r["r_info_type"]


### PR DESCRIPTION
% `ruff rule F841`
# unused-variable (F841)

Derived from the **Pyflakes** linter.

Autofix is always available.

## What it does
Checks for the presence of unused variables in function scopes.

## Why is this bad?
A variable that is defined but not used is likely a mistake, and should
be removed to avoid confusion.

If a variable is intentionally defined-but-not-used, it should be
prefixed with an underscore, or some other value that adheres to the
[`dummy-variable-rgx`] pattern.

## Options
- `dummy-variable-rgx`

## Example
```python
def foo():
    x = 1
    y = 2
    return x
```

Use instead:
```python
def foo():
    x = 1
    return x
```