### PR TITLE
samd: Provide always the machine.RTC class.

### DIFF
--- a/ports/samd/mcu/samd21/mpconfigmcu.h
+++ b/ports/samd/mcu/samd21/mpconfigmcu.h
@@ -31,11 +31,6 @@ unsigned long trng_random_u32(int delay);
 #define MICROPY_HW_UART_TXBUF           (1)
 #endif
 
-#ifndef MICROPY_PY_MACHINE_RTC
-#if MICROPY_HW_XOSC32K
-#define MICROPY_PY_MACHINE_RTC          (1)
-#endif
-#endif
 #define MICROPY_PY_UOS_URANDOM          (1)
 
 #ifndef MICROPY_PY_MACHINE_PIN_BOARD_CPU

--- a/ports/samd/mcu/samd51/mpconfigmcu.h
+++ b/ports/samd/mcu/samd51/mpconfigmcu.h
@@ -28,12 +28,6 @@
 #define MICROPY_PY_URANDOM_SEED_INIT_FUNC (trng_random_u32())
 unsigned long trng_random_u32(void);
 
-#ifndef MICROPY_PY_MACHINE_RTC
-#if MICROPY_HW_XOSC32K
-#define MICROPY_PY_MACHINE_RTC          (1)
-#endif
-#endif
-
 #ifndef MICROPY_PY_MACHINE_PIN_BOARD_CPU
 #define MICROPY_PY_MACHINE_PIN_BOARD_CPU (1)
 #endif

--- a/ports/samd/modmachine.h
+++ b/ports/samd/modmachine.h
@@ -27,6 +27,7 @@
 #define MICROPY_INCLUDED_SAMD_MODMACHINE_H
 
 #include "py/obj.h"
+#include "shared/timeutils/timeutils.h"
 
 extern const mp_obj_type_t machine_adc_type;
 extern const mp_obj_type_t machine_dac_type;
@@ -42,5 +43,7 @@ extern const mp_obj_type_t machine_rtc_type;
 #endif
 
 NORETURN mp_obj_t machine_bootloader(size_t n_args, const mp_obj_t *args);
+
+void rtc_gettime(timeutils_struct_time_t *tm);
 
 #endif // MICROPY_INCLUDED_SAMD_MODMACHINE_H

--- a/ports/samd/mpconfigport.h
+++ b/ports/samd/mpconfigport.h
@@ -92,6 +92,7 @@
 #define MICROPY_PY_UZLIB                    (1)
 #define MICROPY_PY_UASYNCIO                 (1)
 #define MICROPY_PY_MACHINE_I2C              (1)
+#define MICROPY_PY_MACHINE_RTC              (1)
 #define MICROPY_PY_MACHINE_SOFTI2C          (1)
 #define MICROPY_PY_MACHINE_SPI              (1)
 #define MICROPY_PY_MACHINE_SOFTSPI          (1)


### PR DESCRIPTION
Even if boards do not have a clock crystal. In that case, the RTC clock quality will be very poor.

This PR removes as well the special code in modutime.c for devices without the RTC class.