### PR TITLE
stm32/cyw43_configport.h: Add missing SDIO function.

### DIFF
--- a/ports/stm32/cyw43_configport.h
+++ b/ports/stm32/cyw43_configport.h
@@ -131,6 +131,10 @@ static inline void cyw43_sdio_set_irq(bool enable) {
     sdio_enable_irq(enable);
 }
 
+static inline void cyw43_sdio_enable_high_speed_4bit(void) {
+    sdio_enable_high_speed_4bit();
+}
+
 static inline int cyw43_sdio_transfer(uint32_t cmd, uint32_t arg, uint32_t *resp) {
     return sdio_transfer(cmd, arg, resp);
 }


### PR DESCRIPTION
I think this function was just forgotten. It did not compile without it. And WLAN works as expected after adding it. I tested this on our custom board with STM32H7 and CYW43 "1DX" WLAN hardware.