### PR TITLE
extmod/network_cyw43: Fix setting hostname using config() method.

### DIFF
--- a/extmod/network_cyw43.c
+++ b/extmod/network_cyw43.c
@@ -474,7 +474,7 @@ STATIC mp_obj_t network_cyw43_config(size_t n_args, const mp_obj_t *args, mp_map
                     case MP_QSTR_hostname: {
                         // TODO: Deprecated. Use network.hostname(name) instead.
                         size_t len;
-                        const char *str = mp_obj_str_get_data(args[0], &len);
+                        const char *str = mp_obj_str_get_data(e->value, &len);
                         if (len >= MICROPY_PY_NETWORK_HOSTNAME_MAX_LEN) {
                             mp_raise_ValueError(NULL);
                         }


### PR DESCRIPTION
This bug is probably a typo: args[0] is the cyw43 object itself, while the value of a kwargs is in e->value.