### PR TITLE
extmod/network_cyw43: Get RSSI from driver using status() method.

### DIFF
--- a/extmod/network_cyw43.c
+++ b/extmod/network_cyw43.c
@@ -314,6 +314,14 @@ STATIC mp_obj_t network_cyw43_status(size_t n_args, const mp_obj_t *args) {
 
     // one argument: return status based on query parameter
     switch (mp_obj_str_get_qstr(args[1])) {
+        case MP_QSTR_rssi: {
+            if (self->itf != CYW43_ITF_STA) {
+                mp_raise_ValueError(MP_ERROR_TEXT("STA required"));
+            }
+            int32_t rssi;
+            cyw43_wifi_get_rssi(self->cyw, &rssi);
+            return mp_obj_new_int(rssi);
+        }
         case MP_QSTR_stations: {
             // return list of connected stations
             if (self->itf != CYW43_ITF_AP) {


### PR DESCRIPTION
This code enables the use of WLAN(0).status('rssi') to get current RSSI.