### PR TITLE
multitests: support output metrics

### DIFF
--- a/tests/multi_bluetooth/perf_gatt_char_write.py
+++ b/tests/multi_bluetooth/perf_gatt_char_write.py
@@ -128,7 +128,7 @@ def instance1():
             ticks_end = time.ticks_ms()
             ticks_total = time.ticks_diff(ticks_end, ticks_start)
 
-            print(
+            multitest.output_metric(
                 "Did {} writes in {} ms. {} ms/write, {} bytes/sec".format(
                     _NUM_NOTIFICATIONS,
                     ticks_total,

--- a/tests/multi_bluetooth/perf_gatt_notify.py
+++ b/tests/multi_bluetooth/perf_gatt_notify.py
@@ -90,7 +90,7 @@ def instance0():
 
         ticks_end = time.ticks_ms()
         ticks_total = time.ticks_diff(ticks_end, ticks_start)
-        print(
+        multitest.output_metric(
             "Acknowledged {} notifications in {} ms. {} ms/notification.".format(
                 _NUM_NOTIFICATIONS, ticks_total, ticks_total // _NUM_NOTIFICATIONS
             )

--- a/tests/multi_bluetooth/perf_gatt_notify.py.exp
+++ b/tests/multi_bluetooth/perf_gatt_notify.py.exp
@@ -1,0 +1,5 @@
+--- instance0 ---
+gap_advertise
+gap_disconnect: True
+--- instance1 ---
+gap_connect

--- a/tests/multi_bluetooth/perf_l2cap.py
+++ b/tests/multi_bluetooth/perf_l2cap.py
@@ -134,7 +134,7 @@ def instance1():
         ble.l2cap_disconnect(conn_handle, cid)
         wait_for_event(_IRQ_L2CAP_DISCONNECT, TIMEOUT_MS)
 
-        print(
+        multitest.output_metric(
             "Received {}/{} bytes in {} ms. {} B/s".format(
                 recv_bytes, recv_correct, total_ticks, recv_bytes * 1000 // total_ticks
             )

--- a/tests/multi_bluetooth/perf_l2cap.py.exp
+++ b/tests/multi_bluetooth/perf_l2cap.py.exp
@@ -1,0 +1,4 @@
+--- instance0 ---
+
+--- instance1 ---
+


### PR DESCRIPTION
If a multitest calls `multitest.output_metric(...)` then that output will be collected separately, not considered as part of the test verification output, and instead be printed at the end.  This is useful for tests that want to output performance/timing metrics that may change from one run to the next.

This allows the existing BLE performance tests to "pass" properly when run.