### PR TITLE
pyboard: Fix espxx boards hanging in bootloader after reset button.

### DIFF
--- a/tools/pyboard.py
+++ b/tools/pyboard.py
@@ -287,11 +287,15 @@ class Pyboard:
             for attempt in range(wait + 1):
                 try:
                     if os.name == "nt":
-                        # Windows does not set DTR or RTS by default
                         self.serial = serial.Serial(**serial_kwargs)
-                        self.serial.dtr = True
-                        self.serial.rts = False
                         self.serial.port = device
+                        portinfo = list(serial.tools.list_ports.grep(device))  # type: ignore
+                        if portinfo and portinfo[0].manufacturer != "Microsoft":
+                            # ESP8266/ESP32 boards use RTS/CTS for flashing and boot mode selection.
+                            # DTR False: to avoid using the reset button will hang the MCU in bootloader mode
+                            # RTS False: to prevent pulses on rts on serial.close() that would POWERON_RESET an ESPxx
+                            self.serial.dtr = False  # DTR False = gpio0 High = Normal boot
+                            self.serial.rts = False  # RTS False = EN High = MCU enabled
                         self.serial.open()
                     else:
                         self.serial = serial.Serial(device, **serial_kwargs)


### PR DESCRIPTION
## Updated Logic
The updated logic will only set the dtr/rts signals for boards that do not use standard Microsoft drivers( based on the manufacturer)
It would also be possible to check against a list of known driver manufactures (like 'wch.cn' or 'Silicon Labs' ) but this would require a list of known drivers for all ports. (which I do not have)

fixes: https://github.com/micropython/micropython/issues/11075
