### PR TITLE
stm32: Support USB and mboot on G0 MCUs

### DIFF
--- a/ports/stm32/boards/NUCLEO_G0B1RE/mpconfigboard.h
+++ b/ports/stm32/boards/NUCLEO_G0B1RE/mpconfigboard.h
@@ -6,6 +6,7 @@
 #define MICROPY_HW_ENABLE_RNG       (0)
 #define MICROPY_HW_ENABLE_RTC       (1)
 #define MICROPY_HW_ENABLE_DAC       (0)
+#define MICROPY_HW_ENABLE_USB       (0) // can be enabled if USB cable connected to PA11/PA12
 #define MICROPY_PY_PYB_LEGACY       (0)
 
 #define MICROPY_HW_ENABLE_INTERNAL_FLASH_STORAGE (1)
@@ -87,3 +88,9 @@
 #define MICROPY_HW_LED1             (pin_A5) // Green LD2 LED on Nucleo
 #define MICROPY_HW_LED_ON(pin)      (mp_hal_pin_high(pin))
 #define MICROPY_HW_LED_OFF(pin)     (mp_hal_pin_low(pin))
+
+// USB config
+#define MICROPY_HW_USB_FS           (1)
+#define MICROPY_HW_USB_MAIN_DEV     (USB_PHY_FS_ID)
+#define MICROPY_HW_USB_MSC          (0)
+#define MICROPY_HW_USB_HID          (0)

--- a/ports/stm32/boards/NUCLEO_G0B1RE/mpconfigboard.mk
+++ b/ports/stm32/boards/NUCLEO_G0B1RE/mpconfigboard.mk
@@ -1,7 +1,13 @@
 MCU_SERIES = g0
 CMSIS_MCU = STM32G0B1xx
 AF_FILE = boards/stm32g0b1_af.csv
+
+ifeq ($(USE_MBOOT),1)
+LD_FILES = boards/stm32g0b1xe.ld boards/common_bl.ld
+TEXT0_ADDR = 0x08008000
+else
 LD_FILES = boards/stm32g0b1xe.ld boards/common_basic.ld
+endif
 
 # LTO reduces final binary size, may be slower to build depending on gcc version and hardware
 LTO ?= 1

--- a/ports/stm32/boards/stm32g0b1xe.ld
+++ b/ports/stm32/boards/stm32g0b1xe.ld
@@ -3,6 +3,7 @@ MEMORY
 {
     RAM (xrw)       : ORIGIN = 0x20000000, LENGTH = 128K
     FLASH (rx)      : ORIGIN = 0x08000000, LENGTH = 352K
+    FLASH_APP (rx)  : ORIGIN = 0x08008000, LENGTH = 320K
     FLASH_FS (rx)   : ORIGIN = 0x08058000, LENGTH = 160K  /* starting @ 352K */
 }
 

--- a/ports/stm32/boards/stm32g0xx_hal_conf_base.h
+++ b/ports/stm32/boards/stm32g0xx_hal_conf_base.h
@@ -27,16 +27,42 @@
 #ifndef MICROPY_INCLUDED_STM32G0XX_HAL_CONF_BASE_H
 #define MICROPY_INCLUDED_STM32G0XX_HAL_CONF_BASE_H
 
+// Enable various HAL modules
+#define HAL_MODULE_ENABLED
+#define HAL_ADC_MODULE_ENABLED
+#define HAL_CORTEX_MODULE_ENABLED
+#define HAL_DMA_MODULE_ENABLED
+#define HAL_EXTI_MODULE_ENABLED
+#define HAL_FLASH_MODULE_ENABLED
+#define HAL_GPIO_MODULE_ENABLED
+#define HAL_I2C_MODULE_ENABLED
+#define HAL_PCD_MODULE_ENABLED
+#define HAL_PWR_MODULE_ENABLED
+#define HAL_RCC_MODULE_ENABLED
+#define HAL_RTC_MODULE_ENABLED
+#define HAL_SPI_MODULE_ENABLED
+#define HAL_TIM_MODULE_ENABLED
+#define HAL_UART_MODULE_ENABLED
+#define HAL_USART_MODULE_ENABLED
+
 // Oscillator values in Hz
-// These must come before the HAL headers because stm32g0xx_ll_rcc.h will define HSI_VALUE unless already defined
 #define HSI_VALUE    (16000000)
 #define LSI_VALUE    (32000)
 #if defined(STM32G0C1xx) || defined(STM32G0B1xx) || defined(STM32G0B0xx)
 #define HSI48_VALUE   48000000
 #endif
 
-// Include various HAL modules for convenience
+// SysTick has the highest priority
+#define TICK_INT_PRIORITY (0x00)
 
+// Miscellaneous HAL settings
+#define  USE_RTOS                     0
+#define  PREFETCH_ENABLE              1
+#define  INSTRUCTION_CACHE_ENABLE     1
+#define  USE_SPI_CRC                  1
+#define  USE_HAL_CRYP_SUSPEND_RESUME  1
+
+// Include various HAL modules for convenience
 #include "stm32g0xx_hal_rcc.h"
 #include "stm32g0xx_hal_gpio.h"
 #include "stm32g0xx_hal_dma.h"
@@ -68,37 +94,9 @@
 #include "stm32g0xx_hal_uart.h"
 #include "stm32g0xx_hal_usart.h"
 #include "stm32g0xx_hal_wwdg.h"
-
 #include "stm32g0xx_ll_lpuart.h"
 #include "stm32g0xx_ll_rtc.h"
 #include "stm32g0xx_ll_usart.h"
-
-// Enable various HAL modules
-#define HAL_MODULE_ENABLED
-#define HAL_ADC_MODULE_ENABLED
-#define HAL_CORTEX_MODULE_ENABLED
-#define HAL_DMA_MODULE_ENABLED
-#define HAL_EXTI_MODULE_ENABLED
-#define HAL_FLASH_MODULE_ENABLED
-#define HAL_GPIO_MODULE_ENABLED
-#define HAL_I2C_MODULE_ENABLED
-#define HAL_PWR_MODULE_ENABLED
-#define HAL_RCC_MODULE_ENABLED
-#define HAL_RTC_MODULE_ENABLED
-#define HAL_SPI_MODULE_ENABLED
-#define HAL_TIM_MODULE_ENABLED
-#define HAL_UART_MODULE_ENABLED
-#define HAL_USART_MODULE_ENABLED
-
-// SysTick has the highest priority
-#define TICK_INT_PRIORITY (0x00)
-
-// Miscellaneous HAL settings
-#define  USE_RTOS                     0
-#define  PREFETCH_ENABLE              1
-#define  INSTRUCTION_CACHE_ENABLE     1
-#define  USE_SPI_CRC                  1
-#define  USE_HAL_CRYP_SUSPEND_RESUME  1
 
 // HAL parameter assertions are disabled
 #define assert_param(expr) ((void)0)

--- a/ports/stm32/i2cslave.h
+++ b/ports/stm32/i2cslave.h
@@ -43,6 +43,10 @@ static inline void i2c_slave_init(i2c_slave_t *i2c, int irqn, int irq_pri, int a
     RCC->APB1ENR |= 1 << (RCC_APB1ENR_I2C1EN_Pos + i2c_idx);
     volatile uint32_t tmp = RCC->APB1ENR; // Delay after enabling clock
     (void)tmp;
+    #elif defined(STM32G0)
+    RCC->APBENR1 |= 1 << (RCC_APBENR1_I2C1EN_Pos + i2c_idx);
+    volatile uint32_t tmp = RCC->APBENR1; // Delay after enabling clock
+    (void)tmp;
     #elif defined(STM32H7)
     RCC->APB1LENR |= 1 << (RCC_APB1LENR_I2C1EN_Pos + i2c_idx);
     volatile uint32_t tmp = RCC->APB1LENR; // Delay after enabling clock

--- a/ports/stm32/mboot/Makefile
+++ b/ports/stm32/mboot/Makefile
@@ -134,7 +134,12 @@ SRC_C += \
 SRC_O += \
 	$(STARTUP_FILE) \
 	$(SYSTEM_FILE) \
-	ports/stm32/resethandler.o \
+
+ifeq ($(MCU_SERIES),$(filter $(MCU_SERIES),f0 g0 l0))
+SRC_O += ports/stm32/resethandler_m0.o
+else
+SRC_O += ports/stm32/resethandler.o
+endif
 
 ifeq ($(MBOOT_ENABLE_PACKING), 1)
 

--- a/ports/stm32/mboot/main.c
+++ b/ports/stm32/mboot/main.c
@@ -371,6 +371,9 @@ void SystemClock_Config(void) {
 #if defined(STM32F4) || defined(STM32F7)
 #define AHBxENR AHB1ENR
 #define AHBxENR_GPIOAEN_Pos RCC_AHB1ENR_GPIOAEN_Pos
+#elif defined(STM32G0)
+#define AHBxENR IOPENR
+#define AHBxENR_GPIOAEN_Pos RCC_IOPENR_GPIOAEN_Pos
 #elif defined(STM32H7)
 #define AHBxENR AHB4ENR
 #define AHBxENR_GPIOAEN_Pos RCC_AHB4ENR_GPIOAEN_Pos
@@ -406,7 +409,9 @@ void mp_hal_pin_config_speed(uint32_t port_pin, uint32_t speed) {
 /******************************************************************************/
 // FLASH
 
-#if defined(STM32WB)
+#if defined(STM32G0)
+#define FLASH_END (FLASH_BASE + FLASH_SIZE - 1)
+#elif defined(STM32WB)
 #define FLASH_END FLASH_END_ADDR
 #endif
 
@@ -426,6 +431,8 @@ void mp_hal_pin_config_speed(uint32_t port_pin, uint32_t speed) {
 #define FLASH_LAYOUT_STR "@Internal Flash  /0x08000000/04*016Kg,01*064Kg,07*128Kg" MBOOT_SPIFLASH_LAYOUT MBOOT_SPIFLASH2_LAYOUT
 #elif defined(STM32F765xx) || defined(STM32F767xx) || defined(STM32F769xx)
 #define FLASH_LAYOUT_STR "@Internal Flash  /0x08000000/04*032Kg,01*128Kg,07*256Kg" MBOOT_SPIFLASH_LAYOUT MBOOT_SPIFLASH2_LAYOUT
+#elif defined(STM32G0)
+#define FLASH_LAYOUT_STR "@Internal Flash  /0x08000000/256*02Kg" MBOOT_SPIFLASH_LAYOUT MBOOT_SPIFLASH2_LAYOUT
 #elif defined(STM32H743xx)
 #define FLASH_LAYOUT_STR "@Internal Flash  /0x08000000/16*128Kg" MBOOT_SPIFLASH_LAYOUT MBOOT_SPIFLASH2_LAYOUT
 #elif defined(STM32H750xx)
@@ -1349,7 +1356,9 @@ void stm32_main(uint32_t initial_r0) {
     #endif
     #endif
 
+    #if __CORTEX_M >= 0x03
     NVIC_SetPriorityGrouping(NVIC_PRIORITYGROUP_4);
+    #endif
 
     #if USE_CACHE && defined(STM32F7)
     SCB_EnableICache();
@@ -1547,7 +1556,13 @@ void I2Cx_EV_IRQHandler(void) {
 
 #if !USE_USB_POLLING
 
-#if defined(STM32WB)
+#if defined(STM32G0)
+
+void USB_UCPD1_2_IRQHandler(void) {
+    HAL_PCD_IRQHandler(&pcd_fs_handle);
+}
+
+#elif defined(STM32WB)
 
 void USB_LP_IRQHandler(void) {
     HAL_PCD_IRQHandler(&pcd_fs_handle);

--- a/ports/stm32/powerctrlboot.c
+++ b/ports/stm32/powerctrlboot.c
@@ -173,15 +173,14 @@ void SystemClock_Config(void) {
 
     #if MICROPY_HW_ENABLE_RNG || MICROPY_HW_ENABLE_USB
     // Enable the 48MHz internal oscillator
-    RCC->CRRCR |= RCC_CRRCR_HSI48ON;
-    RCC->APB2ENR |= RCC_APB2ENR_SYSCFGEN;
-    SYSCFG->CFGR3 |= SYSCFG_CFGR3_ENREF_HSI48;
-    while (!(RCC->CRRCR & RCC_CRRCR_HSI48RDY)) {
+    RCC->CR |= RCC_CR_HSI48ON;
+    RCC->APBENR2 |= RCC_APBENR2_SYSCFGEN;
+    while (!(RCC->CR & RCC_CR_HSI48RDY)) {
         // Wait for HSI48 to be ready
     }
 
-    // Select RC48 as HSI48 for USB and RNG
-    RCC->CCIPR |= RCC_CCIPR_HSI48SEL;
+    // Select HSI48 for USB
+    RCC->CCIPR2 &= ~(3 << RCC_CCIPR2_USBSEL_Pos);
 
     #if MICROPY_HW_ENABLE_USB
     // Synchronise HSI48 with 1kHz USB SoF

--- a/ports/stm32/stm32_it.c
+++ b/ports/stm32/stm32_it.c
@@ -296,7 +296,15 @@ void DebugMon_Handler(void) {
 /*  file (startup_stm32f4xx.s).                                               */
 /******************************************************************************/
 
-#if defined(STM32L0) || defined(STM32L432xx)
+#if defined(STM32G0)
+
+#if MICROPY_HW_USB_FS
+void USB_UCPD1_2_IRQHandler(void) {
+    HAL_PCD_IRQHandler(&pcd_fs_handle);
+}
+#endif
+
+#elif defined(STM32L0) || defined(STM32L432xx)
 
 #if MICROPY_HW_USB_FS
 void USB_IRQHandler(void) {

--- a/ports/stm32/usb.c
+++ b/ports/stm32/usb.c
@@ -67,7 +67,7 @@
 #define MAX_ENDPOINT(dev_id) ((dev_id) == USB_PHY_FS_ID ? 3 : 5)
 #elif defined(STM32F7)
 #define MAX_ENDPOINT(dev_id) ((dev_id) == USB_PHY_FS_ID ? 5 : 8)
-#elif defined(STM32H7)
+#elif defined(STM32G0) || defined(STM32H7)
 #define MAX_ENDPOINT(dev_id) (8)
 #endif
 

--- a/ports/stm32/usbd_conf.c
+++ b/ports/stm32/usbd_conf.c
@@ -49,6 +49,10 @@ PCD_HandleTypeDef pcd_hs_handle;
 #define USB_OTG_FS USB
 #endif
 
+#if defined(STM32G0)
+#define USB_OTG_FS USB_DRD_FS
+#endif
+
 /*******************************************************************************
                        PCD BSP Routines
 *******************************************************************************/
@@ -61,6 +65,22 @@ PCD_HandleTypeDef pcd_hs_handle;
 void HAL_PCD_MspInit(PCD_HandleTypeDef *hpcd) {
     #if MICROPY_HW_USB_FS
     if (hpcd->Instance == USB_OTG_FS) {
+        // Configure USB GPIO's.
+
+        #if defined(STM32G0)
+
+        // These MCUs don't have an alternate function for USB but rather require
+        // the pins to be disconnected from all peripherals, ie put in analog mode.
+
+        mp_hal_pin_config(pin_A11, MP_HAL_PIN_MODE_ANALOG, MP_HAL_PIN_PULL_NONE, 0);
+        mp_hal_pin_config_speed(pin_A11, GPIO_SPEED_FREQ_VERY_HIGH);
+        mp_hal_pin_config(pin_A12, MP_HAL_PIN_MODE_ANALOG, MP_HAL_PIN_PULL_NONE, 0);
+        mp_hal_pin_config_speed(pin_A12, GPIO_SPEED_FREQ_VERY_HIGH);
+
+        #else
+
+        // Other MCUs have an alternate function for GPIO's to be in USB mode.
+
         #if defined(STM32H7)
         const uint32_t otg_alt = GPIO_AF10_OTG1_FS;
         #elif defined(STM32L0)
@@ -78,6 +98,8 @@ void HAL_PCD_MspInit(PCD_HandleTypeDef *hpcd) {
         mp_hal_pin_config(pin_A12, MP_HAL_PIN_MODE_ALT, MP_HAL_PIN_PULL_NONE, otg_alt);
         mp_hal_pin_config_speed(pin_A12, GPIO_SPEED_FREQ_VERY_HIGH);
 
+        #endif
+
         #if defined(MICROPY_HW_USB_VBUS_DETECT_PIN)
         // USB VBUS detect pin is always A9
         mp_hal_pin_config(MICROPY_HW_USB_VBUS_DETECT_PIN, MP_HAL_PIN_MODE_INPUT, MP_HAL_PIN_PULL_NONE, 0);
@@ -88,14 +110,16 @@ void HAL_PCD_MspInit(PCD_HandleTypeDef *hpcd) {
         mp_hal_pin_config(MICROPY_HW_USB_OTG_ID_PIN, MP_HAL_PIN_MODE_ALT_OPEN_DRAIN, MP_HAL_PIN_PULL_UP, otg_alt);
         #endif
 
-        #if defined(STM32H7)
+        #if defined(STM32G0)
+        __HAL_RCC_USB_CLK_SLEEP_ENABLE();
+        #elif defined(STM32H7)
         // Keep USB clock running during sleep or else __WFI() will disable the USB
         __HAL_RCC_USB2_OTG_FS_CLK_SLEEP_ENABLE();
         __HAL_RCC_USB2_OTG_FS_ULPI_CLK_SLEEP_DISABLE();
         #endif
 
         // Enable USB FS Clocks
-        #if !MICROPY_HW_USB_IS_MULTI_OTG
+        #if !MICROPY_HW_USB_IS_MULTI_OTG || defined(STM32G0)
         __HAL_RCC_USB_CLK_ENABLE();
         #else
         __USB_OTG_FS_CLK_ENABLE();
@@ -113,7 +137,10 @@ void HAL_PCD_MspInit(PCD_HandleTypeDef *hpcd) {
         #endif
 
         // Configure and enable USB FS interrupt
-        #if defined(STM32L0)
+        #if defined(STM32G0)
+        NVIC_SetPriority(USB_UCPD1_2_IRQn, IRQ_PRI_OTG_FS);
+        HAL_NVIC_EnableIRQ(USB_UCPD1_2_IRQn);
+        #elif defined(STM32L0)
         NVIC_SetPriority(USB_IRQn, IRQ_PRI_OTG_FS);
         HAL_NVIC_EnableIRQ(USB_IRQn);
         #elif defined(STM32L432xx)
@@ -235,7 +262,11 @@ void HAL_PCD_MspDeInit(PCD_HandleTypeDef *hpcd) {
     #if MICROPY_HW_USB_FS
     if (hpcd->Instance == USB_OTG_FS) {
         /* Disable USB FS Clocks */
+        #if defined(STM32G0)
+        __HAL_RCC_USB_CLK_DISABLE();
+        #else
         __USB_OTG_FS_CLK_DISABLE();
+        #endif
         return;
     }
     #endif
@@ -413,7 +444,9 @@ USBD_StatusTypeDef USBD_LL_Init(USBD_HandleTypeDef *pdev, int high_speed, const 
         pcd_fs_handle.Init.lpm_enable = DISABLE;
         pcd_fs_handle.Init.battery_charging_enable = DISABLE;
         #if MICROPY_HW_USB_IS_MULTI_OTG
+        #if !defined(STM32G0)
         pcd_fs_handle.Init.use_dedicated_ep1 = 0;
+        #endif
         pcd_fs_handle.Init.dma_enable = 0;
         #if !defined(MICROPY_HW_USB_VBUS_DETECT_PIN)
         pcd_fs_handle.Init.vbus_sensing_enable = 0; // No VBUS Sensing on USB0
@@ -430,7 +463,7 @@ USBD_StatusTypeDef USBD_LL_Init(USBD_HandleTypeDef *pdev, int high_speed, const 
         HAL_PCD_Init(&pcd_fs_handle);
 
         // Set FIFO buffer sizes
-        #if !MICROPY_HW_USB_IS_MULTI_OTG
+        #if !MICROPY_HW_USB_IS_MULTI_OTG || defined(STM32G0)
         uint32_t fifo_offset = USBD_PMA_RESERVE; // need to reserve some data at start of FIFO
         for (size_t i = 0; i < USBD_PMA_NUM_FIFO; ++i) {
             uint16_t ep_addr = ((i & 1) * 0x80) | (i >> 1);


### PR DESCRIPTION
This adds support for enabling USB on STM32G0 MCUs.  And also building mboot for these MCUs.

The NUCLEO_G0B1RE was used for testing, with a USB cable attached to PA11/PA12.