### PR TITLE
bugfix: ADAFRUIT_ITSYBITSY_M4_EXPRESS Use hardware RTC

### DIFF
--- a/ports/samd/boards/ADAFRUIT_ITSYBITSY_M4_EXPRESS/mpconfigboard.h
+++ b/ports/samd/boards/ADAFRUIT_ITSYBITSY_M4_EXPRESS/mpconfigboard.h
@@ -1,4 +1,4 @@
 #define MICROPY_HW_BOARD_NAME "ItsyBitsy M4 Express"
 #define MICROPY_HW_MCU_NAME   "SAMD51G19A"
 
-#define MICROPY_HW_DFLL_USB_SYNC    (1)
+#define MICROPY_HW_XOSC32K          (1)


### PR DESCRIPTION
i.e. enable use thereof, since is part of SAMD51