### PR TITLE
ports/rp2: Use nano.specs for C++ modules.

### DIFF
--- a/examples/usercmodule/cppexample/micropython.cmake
+++ b/examples/usercmodule/cppexample/micropython.cmake
@@ -14,3 +14,14 @@ target_include_directories(usermod_cppexample INTERFACE
 
 # Link our INTERFACE library to the usermod target.
 target_link_libraries(usermod INTERFACE usermod_cppexample)
+
+# Do not include stack unwinding & exception handling for C++ user modules
+# This can dramatically reduce build size on embedded ports like rp2
+# target_compile_definitions(usermod INTERFACE PICO_CXX_ENABLE_EXCEPTIONS=0)
+# target_compile_options(usermod INTERFACE $<$<COMPILE_LANGUAGE:CXX>:
+#    -fno-exceptions
+#    -fno-unwind-tables
+#    -fno-rtti
+#    -fno-use-cxa-atexit
+# >)
+# target_link_options(usermod INTERFACE -specs=nano.specs)


### PR DESCRIPTION
Remove C++ stack unwinding and exception handling in all cases on user C++ modules. There's no hook to surface exceptions to MicroPython so they're basically useless?

Set options as per https://github.com/raspberrypi/pico-sdk/blob/master/src/rp2_common/pico_cxx_options/CMakeLists.txt

Despite the options linked above, without the addition of `-specs=nano.specs`, this doesn't make much difference. Since Pico SDK sets `nosys.specs` elsewhere this is slightly odd, but I'm in a little over my head. Does anyone know what could be happening here?

Save around 10,880 bytes of RAM in our Pico builds (with a number of C++ modules) and returns it to MicroPython's heap for end-users.