### PR TITLE
nrf: A few small fixes and changes.

### DIFF
--- a/ports/nrf/Makefile
+++ b/ports/nrf/Makefile
@@ -233,11 +233,6 @@ SRC_LIB_C += $(addprefix lib/,\
         libm/roundf.c \
         )
 
-SRC_NRFX += $(addprefix lib/nrfx/drivers/src/,\
-        nrfx_uarte.c \
-        nrfx_twim.c \
-        )
-
 include drivers/secureboot/secureboot.mk
 
 endif
@@ -263,11 +258,13 @@ endif
 SRC_NRFX += $(addprefix lib/nrfx/drivers/src/,\
 	prs/nrfx_prs.c \
 	nrfx_uart.c \
+        nrfx_uarte.c \
 	nrfx_adc.c \
 	nrfx_saadc.c \
 	nrfx_temp.c \
 	nrfx_rng.c \
 	nrfx_twi.c \
+        nrfx_twim.c \
 	nrfx_spi.c \
 	nrfx_spim.c \
 	nrfx_rtc.c \
@@ -319,6 +316,7 @@ SRC_C += $(addprefix lib/tinyusb/src/,\
 	tusb.c \
 	portable/nordic/nrf5x/dcd_nrf5x.c \
 	)
+
 endif
 
 DRIVERS_SRC_C += $(addprefix modules/,\

--- a/ports/nrf/modules/machine/uart.c
+++ b/ports/nrf/modules/machine/uart.c
@@ -77,6 +77,7 @@ typedef struct _machine_hard_uart_buf_t {
 #define NRF_UART_HWFC_DISABLED    NRF_UARTE_HWFC_DISABLED
 #define NRF_UART_PARITY_EXCLUDED  NRF_UARTE_PARITY_EXCLUDED
 #define NRFX_UART_EVT_RX_DONE     NRFX_UARTE_EVT_RX_DONE
+#define NRFX_UART_EVT_ERROR       NRFX_UARTE_EVT_ERROR
 
 #define NRF_UART_BAUDRATE_1200    NRF_UARTE_BAUDRATE_1200
 #define NRF_UART_BAUDRATE_2400    NRF_UARTE_BAUDRATE_2400
@@ -136,6 +137,9 @@ STATIC void uart_event_handler(nrfx_uart_event_t const *p_event, void *p_context
         {
             ringbuf_put((ringbuf_t *)&self->buf.rx_ringbuf, chr);
         }
+    } else if (p_event->type == NRFX_UART_EVT_ERROR) {
+        // Perform a read to unlock UART in case of an error
+        nrfx_uart_rx(self->p_uart, &self->buf.rx_buf[0], 1);
     }
 }
 

--- a/ports/nrf/nrfx_config.h
+++ b/ports/nrf/nrfx_config.h
@@ -74,14 +74,16 @@
 #endif
 #endif
 
-#if defined(NRF51) || defined(NRF52_SERIES)
+#if defined(NRF51)
   #define NRFX_UART_ENABLED 1
   #define NRFX_UART0_ENABLED 1
   #define NRFX_UART1_ENABLED 1
 #elif defined(NRF52_SERIES)
   #define NRFX_UARTE_ENABLED 1
   #define NRFX_UARTE0_ENABLED 1
+  #if NRF52840 || NRF52840_XXAA
   #define NRFX_UARTE1_ENABLED 1
+  #endif
 #else
   #define NRFX_UARTE_ENABLED 1
   #define NRFX_UARTE0_ENABLED 1


### PR DESCRIPTION
- Move the pwm_seq array to the p_config data structure. That prevents potential resource collisions between PWM devices.
- Rename the PWM keyword argument 'id' to 'device'. That's consistent with the SAMD port as the other port allowing to specify it, and maybe more ports like the ESP32 will allow to select a device.
- Use UARTE for nrf52xxx devices. The change in the prevous PR was incomplete.
- Prevent UART lock-up after a receive error like frame error, overrun, etc. 
  The fix was provided by @ricksorensen.