### PR TITLE
stm32/flash.c: Fix get_bank function for STM32H750.

### DIFF
--- a/ports/stm32/flash.c
+++ b/ports/stm32/flash.c
@@ -133,7 +133,7 @@ static const flash_layout_t flash_layout[] = {
 #error Unsupported processor
 #endif
 
-#if defined(STM32H723xx)
+#if defined(STM32H723xx) || defined(STM32H750xx)
 
 // get the bank of a given flash address
 static uint32_t get_bank(uint32_t addr) {


### PR DESCRIPTION
STM32H750 has only 1 flash bank so function get_bank always returns FLASH_BANK_1.