### PR TITLE
add set_stream to DecompIO

### DIFF
--- a/docs/library/zlib.rst
+++ b/docs/library/zlib.rst
@@ -36,3 +36,15 @@ Functions
 
       This class is MicroPython extension. It's included on provisional
       basis and may be changed considerably or removed in later versions.
+
+.. function:: DecompIO.set_stream(obj, stream, wbits=0, /)
+
+   Update a `DecompIO` to use a new stream object.  This is exactly like
+   creating a new `DecompIO` object, except the buffer (usually 32k) is
+   reused and therefore doesn't have to be reallocated.  This can 
+   prevent random `MemoryError`s due to memory fragmentation when
+   processing large numbers of streams.
+   
+   The buffer sizes of the two streams must match, or this will throw
+   a `ValueError`.
+

--- a/docs/library/zlib.rst
+++ b/docs/library/zlib.rst
@@ -42,7 +42,7 @@ Functions
    Update a `DecompIO` to use a new stream object.  This is exactly like
    creating a new `DecompIO` object, except the buffer (usually 32k) is
    reused and therefore doesn't have to be reallocated.  This can 
-   prevent random `MemoryError`s due to memory fragmentation when
+   prevent a random `MemoryError` due to memory fragmentation when
    processing large numbers of streams.
    
    The buffer sizes of the two streams must match, or this will throw

--- a/extmod/moduzlib.c
+++ b/extmod/moduzlib.c
@@ -147,14 +147,14 @@ STATIC mp_obj_t mod_uzlib_set_stream(size_t n_args, const mp_obj_t *args) {
         dict_opt = mp_obj_get_int(args[2]);
     }
     uint dict_sz = calc_dict_sz(dict_opt, o);
-    
+
     if (dict_sz != dict_size) {
         mp_raise_ValueError(MP_ERROR_TEXT("compression header buffer sizes must match (to reuse buffer)"));
     }
 
 //    dict_opt = uzlib_zlib_parse_header(decomp);
-    for (uint i=0; i<dict_size; ++i) {
-      dict_ring[i] = 0;
+    for (uint i = 0; i < dict_size; ++i) {
+        dict_ring[i] = 0;
     }
     decomp->eof = 0;
     decomp->bitcount = 0;

--- a/extmod/moduzlib.c
+++ b/extmod/moduzlib.c
@@ -129,7 +129,7 @@ STATIC mp_uint_t decompio_read(mp_obj_t o_in, void *buf, mp_uint_t size, int *er
     return o->decomp.dest - (byte *)buf;
 }
 
-STATIC mp_obj_t mod_uzlib_reset(size_t n_args, const mp_obj_t *args) {
+STATIC mp_obj_t mod_uzlib_set_stream(size_t n_args, const mp_obj_t *args) {
     mp_get_stream_raise(args[1], MP_STREAM_OP_READ);
     mp_obj_decompio_t *o = args[0];
     TINF_DATA *decomp = &o->decomp;
@@ -164,12 +164,12 @@ STATIC mp_obj_t mod_uzlib_reset(size_t n_args, const mp_obj_t *args) {
     decomp->curlen = 0;
     return o;
 }
-STATIC MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(mod_uzlib_reset_obj, 1, 3, mod_uzlib_reset);
+STATIC MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(mod_uzlib_set_stream_obj, 1, 3, mod_uzlib_set_stream);
 
 #if !MICROPY_ENABLE_DYNRUNTIME
 STATIC const mp_rom_map_elem_t decompio_locals_dict_table[] = {
     { MP_ROM_QSTR(MP_QSTR_read), MP_ROM_PTR(&mp_stream_read_obj) },
-    { MP_ROM_QSTR(MP_QSTR_reset), MP_ROM_PTR(&mod_uzlib_reset_obj) },
+    { MP_ROM_QSTR(MP_QSTR_set_stream), MP_ROM_PTR(&mod_uzlib_set_stream_obj) },
     { MP_ROM_QSTR(MP_QSTR_readinto), MP_ROM_PTR(&mp_stream_readinto_obj) },
     { MP_ROM_QSTR(MP_QSTR_readline), MP_ROM_PTR(&mp_stream_unbuffered_readline_obj) },
 };

--- a/tests/extmod/uzlib_decompio.py
+++ b/tests/extmod/uzlib_decompio.py
@@ -31,11 +31,8 @@ try:
     print(inp.read())
 except OSError as e:
     print(repr(e))
-    
 
-inp = zlib.DecompIO(io.BytesIO(b'x\x9c+.)JM\xcc5\x04\x00\x0b\xe0\x02\xbe'))
-assert inp.read()==b'stream1'
-inp.set_stream(io.BytesIO(b'x\x9c+.)JM\xcc5\x02\x00\x0b\xe1\x02\xbf'))
-assert inp.read()==b'stream2'
-
-
+inp = zlib.DecompIO(io.BytesIO(b"x\x9c+.)JM\xcc5\x04\x00\x0b\xe0\x02\xbe"))
+assert inp.read() == b"stream1"
+inp.set_stream(io.BytesIO(b"x\x9c+.)JM\xcc5\x02\x00\x0b\xe1\x02\xbf"))
+assert inp.read() == b"stream2"

--- a/tests/extmod/uzlib_decompio.py
+++ b/tests/extmod/uzlib_decompio.py
@@ -31,3 +31,11 @@ try:
     print(inp.read())
 except OSError as e:
     print(repr(e))
+    
+
+inp = zlib.DecompIO(io.BytesIO(b'x\x9c+.)JM\xcc5\x04\x00\x0b\xe0\x02\xbe'))
+assert inp.read()==b'stream1'
+inp.reset(io.BytesIO(b'x\x9c+.)JM\xcc5\x02\x00\x0b\xe1\x02\xbf'))
+assert inp.read()==b'stream2'
+
+

--- a/tests/extmod/uzlib_decompio.py
+++ b/tests/extmod/uzlib_decompio.py
@@ -35,7 +35,7 @@ except OSError as e:
 
 inp = zlib.DecompIO(io.BytesIO(b'x\x9c+.)JM\xcc5\x04\x00\x0b\xe0\x02\xbe'))
 assert inp.read()==b'stream1'
-inp.reset(io.BytesIO(b'x\x9c+.)JM\xcc5\x02\x00\x0b\xe1\x02\xbf'))
+inp.set_stream(io.BytesIO(b'x\x9c+.)JM\xcc5\x02\x00\x0b\xe1\x02\xbf'))
 assert inp.read()==b'stream2'
 
 


### PR DESCRIPTION
This adds a new function to DecompIO to change the stream being read from.  It's similar to creating a new DecompIO, but reuses the existing 32k buffer.  This is useful for processing large numbers of zlib streams (like what a git client does during a clone operation).

Feature discussed here: https://github.com/micropython/micropython/issues/11146