### PR TITLE
drivers/NINAW10: Allow for an argument at WLAN() and BLE() for hardware wiring.

### DIFF
--- a/docs/library/bluetooth.rst
+++ b/docs/library/bluetooth.rst
@@ -25,9 +25,15 @@ class BLE
 Constructor
 -----------
 
-.. class:: BLE()
+.. class:: BLE([wiring])
 
-    Returns the singleton BLE object.
+    Returns the singleton BLE object. At ports which allow to connect an
+    external Bluetooth device like the NINA W102, the optional paramter
+    wiring ``'wiring'`` can be supplied to define the physical connection
+    to the Bluetooth module, like the UART object and control pins.
+    The number and type of parameters depend on the Bluetooth module and
+    are checked by it's driver. So typically ``'wiring'`` is a tuple
+    of several items.
 
 Configuration
 -------------

--- a/docs/library/network.WLAN.rst
+++ b/docs/library/network.WLAN.rst
@@ -15,13 +15,25 @@ This class provides a driver for WiFi network processors.  Example usage::
 
 Constructors
 ------------
-.. class:: WLAN(interface_id)
+.. class:: WLAN(interface_id [, wiring=paramter])
 
 Create a WLAN network interface object. Supported interfaces are
 ``network.STA_IF`` (station aka client, connects to upstream WiFi access
 points) and ``network.AP_IF`` (access point, allows other WiFi clients to
 connect). Availability of the methods below depends on interface type.
 For example, only STA interface may `WLAN.connect()` to an access point.
+At ports which allow to connect an external WLAN device like the
+NINA W102, the optional paramter wiring ``wiring`` can be supplied
+to define the physical connection to the WLAN module, like the SPI
+object and control pins. The number and type of parameters depend
+on the WLAN module and are checked by it's driver. So typically 
+``wiring`` is a tuple of several items. Example for the NINA W102::
+
+    import network
+    # enable station interface with wiring
+    nic = network.WLAN(network.STA_IF, wiring=(SPI_obj, CS_pin, Busy_pin, RST_pin, GP0_pin))
+
+
 
 Methods
 -------

--- a/drivers/ninaw10/nina_wifi_bsp.c
+++ b/drivers/ninaw10/nina_wifi_bsp.c
@@ -68,12 +68,27 @@ int nina_bsp_init(void) {
     mp_hal_pin_input(MICROPY_HW_NINA_GPIO0);
 
     // Initialize SPI.
+    #ifdef MICROPY_HW_WIFI_SPI_SCK
+    mp_obj_t spi_obj = MP_OBJ_NEW_SMALL_INT(MICROPY_HW_WIFI_SPI_SCK);
+    mp_obj_t miso_obj = MP_OBJ_NEW_SMALL_INT(MICROPY_HW_WIFI_SPI_MISO);
+    mp_obj_t mosi_obj = MP_OBJ_NEW_SMALL_INT(MICROPY_HW_WIFI_SPI_MOSI);
+    mp_obj_t args[] = {
+        MP_OBJ_NEW_SMALL_INT(MICROPY_HW_WIFI_SPI_ID),
+        MP_OBJ_NEW_SMALL_INT(MICROPY_HW_WIFI_SPI_BAUDRATE),
+        MP_ROM_QSTR(MP_QSTR_sck), mp_pin_make_new(NULL, 1, 0, &spi_obj),
+        MP_ROM_QSTR(MP_QSTR_miso), mp_pin_make_new(NULL, 1, 0, &miso_obj),
+        MP_ROM_QSTR(MP_QSTR_mosi), mp_pin_make_new(NULL, 1, 0, &mosi_obj),
+    };
+    MP_STATE_PORT(mp_wifi_spi) = MP_OBJ_TYPE_GET_SLOT(&machine_spi_type, make_new)(
+        (mp_obj_t)&machine_spi_type, 2, 3, args);
+    #else
     mp_obj_t args[] = {
         MP_OBJ_NEW_SMALL_INT(MICROPY_HW_WIFI_SPI_ID),
         MP_OBJ_NEW_SMALL_INT(MICROPY_HW_WIFI_SPI_BAUDRATE),
     };
-
-    MP_STATE_PORT(mp_wifi_spi) = MP_OBJ_TYPE_GET_SLOT(&machine_spi_type, make_new)((mp_obj_t)&machine_spi_type, 2, 0, args);
+    MP_STATE_PORT(mp_wifi_spi) = MP_OBJ_TYPE_GET_SLOT(&machine_spi_type, make_new)(
+        (mp_obj_t)&machine_spi_type, 2, 0, args);
+    #endif
     return 0;
 }
 

--- a/drivers/ninaw10/nina_wifi_bsp.c
+++ b/drivers/ninaw10/nina_wifi_bsp.c
@@ -48,60 +48,104 @@
 #define debug_printf(...)
 #endif
 
+#define PIN_NOT_SET     (0)
+
+nina_wiring_t nina_wiring = {
+    NULL,
+    PIN_NOT_SET,
+    PIN_NOT_SET,
+    PIN_NOT_SET,
+    PIN_NOT_SET,
+};
+
+void nina_bsp_wiring(mp_obj_type_t *spi, mp_obj_type_t *gpio1, mp_obj_type_t *ack, mp_obj_type_t *reset, mp_obj_type_t *gpio0) {
+    nina_wiring.spi = spi;
+    nina_wiring.gpio1 = mp_hal_get_pin_obj(gpio1);
+    nina_wiring.ack = mp_hal_get_pin_obj(ack);
+    nina_wiring.reset = mp_hal_get_pin_obj(reset);
+    nina_wiring.gpio0 = mp_hal_get_pin_obj(gpio0);
+}
+
 int nina_bsp_init(void) {
-    mp_hal_pin_output(MICROPY_HW_NINA_GPIO1);
-    mp_hal_pin_input(MICROPY_HW_NINA_ACK);
-    mp_hal_pin_output(MICROPY_HW_NINA_RESET);
-    mp_hal_pin_output(MICROPY_HW_NINA_GPIO0);
+    #ifdef MICROPY_HW_NINA_GPIO1
+    if (nina_wiring.gpio1 == PIN_NOT_SET) {
+        nina_wiring.gpio1 = MICROPY_HW_NINA_GPIO1;
+    }
+    #endif
+    #ifdef MICROPY_HW_NINA_ACK
+    if (nina_wiring.ack == PIN_NOT_SET) {
+        nina_wiring.ack = MICROPY_HW_NINA_ACK;
+    }
+    #endif
+    #ifdef MICROPY_HW_NINA_GPIO0
+    if (nina_wiring.gpio0 == PIN_NOT_SET) {
+        nina_wiring.gpio0 = MICROPY_HW_NINA_GPIO0;
+    }
+    #endif
+    #ifdef MICROPY_HW_NINA_RESET
+    if (nina_wiring.reset == PIN_NOT_SET) {
+        nina_wiring.reset = MICROPY_HW_NINA_RESET;
+    }
+    #endif
+    mp_hal_pin_output(nina_wiring.gpio1);
+    mp_hal_pin_input(nina_wiring.ack);
+    mp_hal_pin_output(nina_wiring.reset);
+    mp_hal_pin_output(nina_wiring.gpio0);
 
     // Reset module in WiFi mode
-    mp_hal_pin_write(MICROPY_HW_NINA_GPIO1, 1);
-    mp_hal_pin_write(MICROPY_HW_NINA_GPIO0, 1);
+    mp_hal_pin_write(nina_wiring.gpio1, 1);
+    mp_hal_pin_write(nina_wiring.gpio0, 1);
 
-    mp_hal_pin_write(MICROPY_HW_NINA_RESET, 0);
+    mp_hal_pin_write(nina_wiring.reset, 0);
     mp_hal_delay_ms(100);
 
-    mp_hal_pin_write(MICROPY_HW_NINA_RESET, 1);
+    mp_hal_pin_write(nina_wiring.reset, 1);
     mp_hal_delay_ms(750);
 
-    mp_hal_pin_write(MICROPY_HW_NINA_GPIO0, 0);
-    mp_hal_pin_input(MICROPY_HW_NINA_GPIO0);
-
     // Initialize SPI.
-    #ifdef MICROPY_HW_WIFI_SPI_SCK
-    mp_obj_t spi_obj = MP_OBJ_NEW_SMALL_INT(MICROPY_HW_WIFI_SPI_SCK);
-    mp_obj_t miso_obj = MP_OBJ_NEW_SMALL_INT(MICROPY_HW_WIFI_SPI_MISO);
-    mp_obj_t mosi_obj = MP_OBJ_NEW_SMALL_INT(MICROPY_HW_WIFI_SPI_MOSI);
-    mp_obj_t args[] = {
-        MP_OBJ_NEW_SMALL_INT(MICROPY_HW_WIFI_SPI_ID),
-        MP_OBJ_NEW_SMALL_INT(MICROPY_HW_WIFI_SPI_BAUDRATE),
-        MP_ROM_QSTR(MP_QSTR_sck), mp_pin_make_new(NULL, 1, 0, &spi_obj),
-        MP_ROM_QSTR(MP_QSTR_miso), mp_pin_make_new(NULL, 1, 0, &miso_obj),
-        MP_ROM_QSTR(MP_QSTR_mosi), mp_pin_make_new(NULL, 1, 0, &mosi_obj),
-    };
-    MP_STATE_PORT(mp_wifi_spi) = MP_OBJ_TYPE_GET_SLOT(&machine_spi_type, make_new)(
-        (mp_obj_t)&machine_spi_type, 2, 3, args);
-    #else
-    mp_obj_t args[] = {
-        MP_OBJ_NEW_SMALL_INT(MICROPY_HW_WIFI_SPI_ID),
-        MP_OBJ_NEW_SMALL_INT(MICROPY_HW_WIFI_SPI_BAUDRATE),
-    };
-    MP_STATE_PORT(mp_wifi_spi) = MP_OBJ_TYPE_GET_SLOT(&machine_spi_type, make_new)(
-        (mp_obj_t)&machine_spi_type, 2, 0, args);
-    #endif
+    if (nina_wiring.spi == NULL) {
+        // use the hard-coded setting
+        #ifdef MICROPY_HW_WIFI_SPI_ID
+        #ifdef MICROPY_HW_WIFI_SPI_SCK
+        mp_obj_t spi_obj = MP_OBJ_NEW_SMALL_INT(MICROPY_HW_WIFI_SPI_SCK);
+        mp_obj_t miso_obj = MP_OBJ_NEW_SMALL_INT(MICROPY_HW_WIFI_SPI_MISO);
+        mp_obj_t mosi_obj = MP_OBJ_NEW_SMALL_INT(MICROPY_HW_WIFI_SPI_MOSI);
+        mp_obj_t args[] = {
+            MP_OBJ_NEW_SMALL_INT(MICROPY_HW_WIFI_SPI_ID),
+            MP_OBJ_NEW_SMALL_INT(MICROPY_HW_WIFI_SPI_BAUDRATE),
+            MP_ROM_QSTR(MP_QSTR_sck), mp_pin_make_new(NULL, 1, 0, &spi_obj),
+            MP_ROM_QSTR(MP_QSTR_miso), mp_pin_make_new(NULL, 1, 0, &miso_obj),
+            MP_ROM_QSTR(MP_QSTR_mosi), mp_pin_make_new(NULL, 1, 0, &mosi_obj),
+        };
+        MP_STATE_PORT(mp_wifi_spi) = MP_OBJ_TYPE_GET_SLOT(&machine_spi_type, make_new)(
+            (mp_obj_t)&machine_spi_type, 2, 3, args);
+        #else  // MICROPY_HW_WIFI_SPI_SCK
+        mp_obj_t args[] = {
+            MP_OBJ_NEW_SMALL_INT(MICROPY_HW_WIFI_SPI_ID),
+            MP_OBJ_NEW_SMALL_INT(MICROPY_HW_WIFI_SPI_BAUDRATE),
+        };
+        MP_STATE_PORT(mp_wifi_spi) = MP_OBJ_TYPE_GET_SLOT(&machine_spi_type, make_new)(
+            (mp_obj_t)&machine_spi_type, 2, 0, args);
+        #endif  // MICROPY_HW_WIFI_SPI_SCK
+        #else  //  MICROPY_HW_WIFI_SPI_ID
+        mp_raise_ValueError(MP_ERROR_TEXT("missing NINA wiring definition"));
+        #endif  //  MICROPY_HW_WIFI_SPI_ID
+    } else {
+        MP_STATE_PORT(mp_wifi_spi) = (struct _machine_spi_obj_t *)nina_wiring.spi;
+    }
     return 0;
 }
 
 int nina_bsp_deinit(void) {
-    mp_hal_pin_output(MICROPY_HW_NINA_GPIO1);
-    mp_hal_pin_write(MICROPY_HW_NINA_GPIO1, 1);
+    mp_hal_pin_output(nina_wiring.gpio1);
+    mp_hal_pin_write(nina_wiring.gpio1, 1);
 
-    mp_hal_pin_output(MICROPY_HW_NINA_RESET);
-    mp_hal_pin_write(MICROPY_HW_NINA_RESET, 0);
+    mp_hal_pin_output(nina_wiring.reset);
+    mp_hal_pin_write(nina_wiring.reset, 0);
     mp_hal_delay_ms(100);
 
-    mp_hal_pin_output(MICROPY_HW_NINA_GPIO0);
-    mp_hal_pin_write(MICROPY_HW_NINA_GPIO0, 1);
+    mp_hal_pin_output(nina_wiring.gpio0);
+    mp_hal_pin_write(nina_wiring.gpio0, 1);
     return 0;
 }
 
@@ -120,24 +164,24 @@ int nina_bsp_atomic_exit(void) {
 }
 
 int nina_bsp_read_irq(void) {
-    return mp_hal_pin_read(MICROPY_HW_NINA_GPIO0);
+    return mp_hal_pin_read(nina_wiring.gpio0);
 }
 
 int nina_bsp_spi_slave_select(uint32_t timeout) {
     // Wait for ACK to go low.
-    for (mp_uint_t start = mp_hal_ticks_ms(); mp_hal_pin_read(MICROPY_HW_NINA_ACK) == 1; mp_hal_delay_ms(1)) {
+    for (mp_uint_t start = mp_hal_ticks_ms(); mp_hal_pin_read(nina_wiring.ack) == 1; mp_hal_delay_ms(1)) {
         if (timeout && ((mp_hal_ticks_ms() - start) >= timeout)) {
             return -1;
         }
     }
 
     // Chip select.
-    mp_hal_pin_write(MICROPY_HW_NINA_GPIO1, 0);
+    mp_hal_pin_write(nina_wiring.gpio1, 0);
 
     // Wait for ACK to go high.
-    for (mp_uint_t start = mp_hal_ticks_ms(); mp_hal_pin_read(MICROPY_HW_NINA_ACK) == 0; mp_hal_delay_ms(1)) {
+    for (mp_uint_t start = mp_hal_ticks_ms(); mp_hal_pin_read(nina_wiring.ack) == 0; mp_hal_delay_ms(1)) {
         if ((mp_hal_ticks_ms() - start) >= 100) {
-            mp_hal_pin_write(MICROPY_HW_NINA_GPIO1, 1);
+            mp_hal_pin_write(nina_wiring.gpio1, 1);
             return -1;
         }
     }
@@ -146,7 +190,7 @@ int nina_bsp_spi_slave_select(uint32_t timeout) {
 }
 
 int nina_bsp_spi_slave_deselect(void) {
-    mp_hal_pin_write(MICROPY_HW_NINA_GPIO1, 1);
+    mp_hal_pin_write(nina_wiring.gpio1, 1);
     return 0;
 }
 

--- a/drivers/ninaw10/nina_wifi_drv.h
+++ b/drivers/ninaw10/nina_wifi_drv.h
@@ -105,6 +105,14 @@ typedef struct {
     uint8_t bssid[NINA_MAC_ADDR_LEN];
 } nina_netinfo_t;
 
+typedef struct {
+    mp_obj_type_t *spi;
+    mp_hal_pin_obj_t gpio1;
+    mp_hal_pin_obj_t ack;
+    mp_hal_pin_obj_t reset;
+    mp_hal_pin_obj_t gpio0;
+} nina_wiring_t;
+
 typedef int (*nina_scan_callback_t)(nina_scan_result_t *, void *);
 
 int nina_init(void);
@@ -140,4 +148,5 @@ int nina_socket_poll(int fd, uint8_t *flags);
 int nina_socket_setsockopt(int fd, uint32_t level, uint32_t opt, const void *optval, uint16_t optlen);
 int nina_socket_getsockopt(int fd, uint32_t level, uint32_t opt, void *optval, uint16_t optlen);
 int nina_socket_getpeername(int fd, uint8_t *ip, uint16_t *port);
+void nina_bsp_wiring(mp_obj_type_t *spi, mp_obj_type_t *gpio1, mp_obj_type_t *ack, mp_obj_type_t *reset, mp_obj_type_t *gpio0);
 #endif // MICROPY_INCLUDED_DRIVERS_NINAW10_NINA_WIFI_DRV_H

--- a/extmod/modbluetooth.c
+++ b/extmod/modbluetooth.c
@@ -84,6 +84,8 @@ typedef struct {
 
 STATIC const mp_obj_type_t mp_type_bluetooth_ble;
 
+mp_obj_t mp_bluetooth_interface_config = 0;
+
 // TODO: this seems like it could be generic?
 STATIC mp_obj_t bluetooth_handle_errno(int err) {
     if (err != 0) {
@@ -264,6 +266,9 @@ STATIC mp_obj_t bluetooth_ble_make_new(const mp_obj_type_t *type, size_t n_args,
     (void)n_kw;
     (void)all_args;
     if (MP_STATE_VM(bluetooth) == MP_OBJ_NULL) {
+        if (n_args > 0) {  // Store the argument and check it when needed.
+            mp_bluetooth_interface_config = all_args[0];
+        }
         mp_obj_bluetooth_ble_t *o = m_new0(mp_obj_bluetooth_ble_t, 1);
         o->base.type = &mp_type_bluetooth_ble;
 

--- a/extmod/network_ninaw10.c
+++ b/extmod/network_ninaw10.c
@@ -171,7 +171,7 @@ STATIC mp_obj_t network_ninaw10_make_new(const mp_obj_type_t *type, size_t n_arg
                   mp_obj_is_type(items[1], &machine_pin_type) &&
                   mp_obj_is_type(items[2], &machine_pin_type) &&
                   mp_obj_is_type(items[3], &machine_pin_type) &&
-                  mp_obj_is_type(items[4], &machine_pin_type))) {
+                  (mp_obj_is_type(items[4], &machine_pin_type) || items[4] == mp_const_none))) {
                 mp_raise_TypeError(MP_ERROR_TEXT("wrong argument type"));
             }
             nina_bsp_wiring(items[0], items[1], items[2], items[3], items[4]);


### PR DESCRIPTION
This PR allows to supply an additional argument to the WLAN() and BLE() constructors defining the
way, a WIFI/BLE module is connected to the board. An example for such a module is a ESP32 device with NINA firmware, like of course the ublox NINA W102, Adafruit Airlift or any genuine ESP32 board.
If these are not already assembled to a MP board, the wiring of the WIFI/BLE module is not contained in the board definition files, but must be supplied at runtime.
The approach for checking these parameters is different. Since the WLAN() module is a specific NINA W10 one, the parameters are checked in the constructor code. For BLE() is is not possible, since that constructor is not specific for a single board. So the argument is just taken and stored, and the check for validity is done by the hardware specific driver, when it is used.