### PR TITLE
extmod/network_ninaw10.c: Add missing raw socket type to socket().

### DIFF
--- a/extmod/network_ninaw10.c
+++ b/extmod/network_ninaw10.c
@@ -497,6 +497,10 @@ STATIC int network_ninaw10_socket_socket(mod_network_socket_obj_t *socket, int *
             socket_type = NINA_SOCKET_TYPE_UDP;
             break;
 
+        case MOD_NETWORK_SOCK_RAW:
+            socket_type = NINA_SOCKET_TYPE_RAW;
+            break;
+
         default:
             *_errno = MP_EINVAL;
             return -1;


### PR DESCRIPTION
This was dropped from commit 3d46fe67bf0bfc848741a76e945b16b2e45e74cb