### PR TITLE
ports/mimxrt: Implement machine.bootloader().

### DIFF
--- a/ports/mimxrt/Makefile
+++ b/ports/mimxrt/Makefile
@@ -136,6 +136,7 @@ SRC_HAL_IMX_C += \
 	$(MCU_DIR)/drivers/fsl_lpuart.c \
 	$(MCU_DIR)/drivers/fsl_pit.c \
 	$(MCU_DIR)/drivers/fsl_pwm.c \
+	$(MCU_DIR)/drivers/fsl_romapi.c \
 	$(MCU_DIR)/drivers/fsl_sai.c \
 	$(MCU_DIR)/drivers/fsl_snvs_lp.c \
 	$(MCU_DIR)/drivers/fsl_wdog.c \


### PR DESCRIPTION
* If a board defines a custom bootloader entry function it will be called first, if not and the ROM API supports RUN bootloader API, then `machine.bootloader()` will jump to the ROM serial downloader in USB mode.