### PR TITLE
py/modsys.c: Add sys._exc_traceback.

### DIFF
--- a/tests/cpydiff/types_exception_traceback.py
+++ b/tests/cpydiff/types_exception_traceback.py
@@ -1,0 +1,16 @@
+"""
+categories: Types,Exception
+description: The ``__traceback__`` attribute of exceptions is a simple list of tuples.
+cause: MicroPython is optimised to reduce code size.
+workaround: Check the type of ``__traceback__`` before using it.
+"""
+
+
+def foo():
+    1 / 0
+
+
+try:
+    foo()
+except Exception as e:
+    print(e.__traceback__)

--- a/tests/micropython/traceback.py
+++ b/tests/micropython/traceback.py
@@ -1,0 +1,26 @@
+# This comment allows test runners like run_script_on_remote_target
+# to safely prepend a line of code without messing up line numbers.
+
+
+def foo():
+    1 / 0
+
+
+def normalize(filename):
+    if filename == "<stdin>":
+        return "traceback.py"
+    return filename.split("/")[-1]
+
+
+try:
+    foo()
+except Exception as e:
+    tb = e.__traceback__
+    for t in tb:
+        print("%s:%d" % (normalize(t[0]), t[1]), *t[2:])
+    e.__traceback__ = None
+    print(e.__traceback__)
+    try:
+        e.args = 77
+    except AttributeError:
+        print("setting args not allowed")

--- a/tests/micropython/traceback.py.exp
+++ b/tests/micropython/traceback.py.exp
@@ -1,0 +1,4 @@
+traceback.py:6 foo
+traceback.py:16 <module>
+[]
+setting args not allowed

--- a/tests/run-tests.py
+++ b/tests/run-tests.py
@@ -80,6 +80,7 @@ via_mpy_tests_to_skip = {
         "misc/sys_settrace_features.py",
         "misc/sys_settrace_generator.py",
         "misc/sys_settrace_loop.py",
+        "micropython/traceback.py",
     ),
 }
 
@@ -108,6 +109,8 @@ emitter_tests_to_skip = {
         "micropython/schedule.py",
         # These require sys.exc_info().
         "misc/sys_exc_info.py",
+        # These require exception tracebacks.
+        "micropython/traceback.py",
         # These require sys.settrace().
         "misc/sys_settrace_cov.py",
         "misc/sys_settrace_features.py",
@@ -125,9 +128,7 @@ platform_tests_to_skip = {
         "stress/list_sort.py",  # watchdog kicks in because it takes too long
     ),
     "minimal": (
-        "basics/class_inplace_op.py",  # all special methods not supported
-        "basics/subclass_native_init.py",  # native subclassing corner cases not support
-        "micropython/opt_level.py",  # don't assume line numbers are stored
+        "micropython/traceback.py",  # no line numbers, no list[N:] syntax
     ),
     "nrf": (
         "basics/io_buffered_writer.py",
@@ -827,6 +828,8 @@ def run_tests(pyb, tests, args, result_dir, num_threads=1):
 
     # Skip platform-specific tests.
     skip_tests.update(platform_tests_to_skip.get(args.platform, ()))
+    if args.build == "minimal":
+        skip_tests.update(platform_tests_to_skip.get(args.build, ()))
 
     # Some tests are known to fail on 64-bit machines
     if pyb is None and platform.architecture()[0] == "64bit":


### PR DESCRIPTION
This new function makes it easier to provide custom formatting of exception stack traces, for example to make them fit on a tiny 16x8-character display.  (Without this, I think you'd have to call `sys.print_exception`, somehow get the output as a string, and then scrape information from that string.)

I'm thinking of this as an experimental function that exposes internal details of MicroPython and therefore might change in the future.  That's why it has the underscore in the name.

Here is an example of its output:

    ['test.py', 4, 'foo', 'test.py', 7, '<module>']

The regular output from `sys.print_exception` for the same exception is:

```text
Traceback (most recent call last):
  File "test.py", line 7, in <module>
  File "test.py", line 4, in foo
ZeroDivisionError: divide by zero
```

Both outputs were generated by the following script:

```text
import sys

def foo():
  1/0

try:
  foo()
except Exception as e:
  sys.print_exception(e)
  print(sys._exc_traceback(e))
 ```

Is this the right approach for getting info about exception stack traces?   I'd be happy to change the name, change the output format, add tests, or add documentation.