### PR TITLE
ports/esp32/esp32_rmt.c: Fix looping behavior for RMT

### DIFF
--- a/ports/esp32/esp32_rmt.c
+++ b/ports/esp32/esp32_rmt.c
@@ -325,13 +325,15 @@ STATIC mp_obj_t esp32_rmt_write_pulses(size_t n_args, const mp_obj_t *args) {
         }
         check_esp_err(rmt_wait_tx_done(self->channel_id, portMAX_DELAY));
     }
-
-    check_esp_err(rmt_write_items(self->channel_id, self->items, num_items, false));
-
+    
     if (self->loop_en) {
         check_esp_err(rmt_set_tx_intr_en(self->channel_id, false));
         check_esp_err(rmt_set_tx_loop_mode(self->channel_id, true));
     }
+
+    check_esp_err(rmt_write_items(self->channel_id, self->items, num_items, false));
+
+
 
     return mp_const_none;
 }


### PR DESCRIPTION
Issue link: https://github.com/micropython/micropython/issues/11213

Problem:
This code below doesn't loop correctly on the ESP32-S3 (tested). It works fine on the ESP32 (also tested).
```
import esp32
from machine import Pin

r = esp32.RMT(0, pin=Pin(2), clock_div=255)
r.loop(1)
r.write_pulses((32767, 32767)) 
```

To fix this I changed the order of `check_esp_err(rmt_write_items(self->channel_id, self->items, num_items, false));`

I am not sure about the history behind this module so it may be that this PR has something wrong with it - very open to learning about it. Submitting it for the moment since it fixes the issue for me - tested on ESP32 and ESP32-S3.

Hardware ESP32: ESP32 DEVKIT V1
Hardware ESP32S3: [LuatOS ESP32-S3](https://wiki.luatos.com/chips/esp32s3/board.html) running MicroPython v1.19.1-995-g0a3600a9a on 2023-03-31; ESP32S3 module (spiram octal) with ESP32S3

Firmware binaries after the change was made
Firmware bin for ESP32: [esp32-rmt-loop-fix.zip](https://github.com/micropython/micropython/files/11222666/esp32-rmt-loop-fix.zip)
Firmware bin for ESP32-S3 OCTAL SPIRAM: [firmware-rmt-esp32s3-loop.zip](https://github.com/micropython/micropython/files/11176402/firmware-rmt-esp32s3-loop.zip)

I almost feel like this section could be simplified but didn't do it since I didn't want to accidentally break something. Let me know if we prefer the simplified version.

Current version where the only difference compared to current code is I changed the order of `rmt_write_items` 
```
    if (self->loop_en) {
        bool loop_en;
        check_esp_err(rmt_get_tx_loop_mode(self->channel_id, &loop_en));
        if (loop_en) {
            check_esp_err(rmt_set_tx_intr_en(self->channel_id, true));
            check_esp_err(rmt_set_tx_loop_mode(self->channel_id, false));
        }
        check_esp_err(rmt_wait_tx_done(self->channel_id, portMAX_DELAY));
    }

    if (self->loop_en) {
        check_esp_err(rmt_set_tx_intr_en(self->channel_id, false));
        check_esp_err(rmt_set_tx_loop_mode(self->channel_id, true));
    }

    check_esp_err(rmt_write_items(self->channel_id, self->items, num_items, false));
```

Simplified version
```
    if (self->loop_en) {
        check_esp_err(rmt_wait_tx_done(self->channel_id, portMAX_DELAY));
    }

    check_esp_err(rmt_write_items(self->channel_id, self->items, num_items, false));
```

Happy to run more tests if needed, let me know.
