### PR TITLE
extmod/machine_mem: Add slice support to memory object.

### DIFF
--- a/extmod/machine_mem.c
+++ b/extmod/machine_mem.c
@@ -39,8 +39,8 @@
 // implementations, if the default implementation isn't used.
 
 #if !defined(MICROPY_MACHINE_MEM_GET_READ_ADDR) || !defined(MICROPY_MACHINE_MEM_GET_WRITE_ADDR)
-STATIC uintptr_t machine_mem_get_addr(mp_obj_t addr_o, uint align) {
-    uintptr_t addr = mp_obj_get_int_truncated(addr_o);
+STATIC uintptr_t machine_mem_get_addr(machine_mem_obj_t *self, uintptr_t addr) {
+    uint align = self->elem_size;
     if ((addr & (align - 1)) != 0) {
         mp_raise_msg_varg(&mp_type_ValueError, MP_ERROR_TEXT("address %08x is not aligned to %d bytes"), addr, align);
     }
@@ -54,21 +54,46 @@ STATIC uintptr_t machine_mem_get_addr(mp_obj_t addr_o, uint align) {
 #endif
 #endif
 
+STATIC mp_obj_t machine_mem_new(unsigned elem_size, uintptr_t begin, uintptr_t end) {
+    machine_mem_obj_t *self = m_new_obj(machine_mem_obj_t);
+    self->base.type = &machine_mem_type;
+    self->elem_size = elem_size;
+    self->begin = begin;
+    self->end = end;
+    return MP_OBJ_FROM_PTR(self);
+}
+
 STATIC void machine_mem_print(const mp_print_t *print, mp_obj_t self_in, mp_print_kind_t kind) {
     (void)kind;
     machine_mem_obj_t *self = MP_OBJ_TO_PTR(self_in);
-    mp_printf(print, "<%u-bit memory>", 8 * self->elem_size);
+    mp_printf(print, "<%u-bit memory at %08x address>", 8 * self->elem_size, self->begin);
 }
 
-STATIC mp_obj_t machine_mem_subscr(mp_obj_t self_in, mp_obj_t index, mp_obj_t value) {
+STATIC mp_obj_t machine_mem_subscr(mp_obj_t self_in, mp_obj_t index_in, mp_obj_t value) {
     // TODO support slice index to read/write multiple values at once
     machine_mem_obj_t *self = MP_OBJ_TO_PTR(self_in);
     if (value == MP_OBJ_NULL) {
         // delete
         return MP_OBJ_NULL; // op not supported
-    } else if (value == MP_OBJ_SENTINEL) {
+    }
+    #if MICROPY_PY_BUILTINS_SLICE
+    if (mp_obj_is_type(index_in, &mp_type_slice)) {
+        mp_bound_slice_t slice;
+        if (!mp_seq_get_fast_slice_indexes(INT_MAX, index_in, &slice)) {
+            mp_raise_NotImplementedError(MP_ERROR_TEXT("only slices with step=1 (aka None) are supported"));
+        }
+        if (value == MP_OBJ_SENTINEL) {
+            return machine_mem_new(self->elem_size, slice.start, slice.stop);
+        }
+    }
+    #endif
+    mp_int_t index = mp_obj_get_int_truncated(index_in);
+    if (index < 0 || (self->end - self->begin) <= (uintptr_t)index) {
+        mp_raise_msg_varg(&mp_type_IndexError, MP_ERROR_TEXT("address is out of range"));
+    }
+    if (value == MP_OBJ_SENTINEL) {
         // load
-        uintptr_t addr = MICROPY_MACHINE_MEM_GET_READ_ADDR(index, self->elem_size);
+        uintptr_t addr = MICROPY_MACHINE_MEM_GET_READ_ADDR(self, self->begin + index);
         uint32_t val;
         switch (self->elem_size) {
             case 1:
@@ -84,7 +109,7 @@ STATIC mp_obj_t machine_mem_subscr(mp_obj_t self_in, mp_obj_t index, mp_obj_t va
         return mp_obj_new_int(val);
     } else {
         // store
-        uintptr_t addr = MICROPY_MACHINE_MEM_GET_WRITE_ADDR(index, self->elem_size);
+        uintptr_t addr = MICROPY_MACHINE_MEM_GET_WRITE_ADDR(self, self->begin + index);
         uint32_t val = mp_obj_get_int_truncated(value);
         switch (self->elem_size) {
             case 1:
@@ -109,8 +134,8 @@ MP_DEFINE_CONST_OBJ_TYPE(
     subscr, machine_mem_subscr
     );
 
-const machine_mem_obj_t machine_mem8_obj = {{&machine_mem_type}, 1};
-const machine_mem_obj_t machine_mem16_obj = {{&machine_mem_type}, 2};
-const machine_mem_obj_t machine_mem32_obj = {{&machine_mem_type}, 4};
+const machine_mem_obj_t machine_mem8_obj = {{&machine_mem_type}, 1, 0, UINT_MAX};
+const machine_mem_obj_t machine_mem16_obj = {{&machine_mem_type}, 2, 0, UINT_MAX};
+const machine_mem_obj_t machine_mem32_obj = {{&machine_mem_type}, 4, 0, UINT_MAX};
 
 #endif // MICROPY_PY_MACHINE

--- a/extmod/machine_mem.h
+++ b/extmod/machine_mem.h
@@ -31,6 +31,8 @@
 typedef struct _machine_mem_obj_t {
     mp_obj_base_t base;
     unsigned elem_size; // in bytes
+    uintptr_t begin;
+    uintptr_t end;
 } machine_mem_obj_t;
 
 extern const mp_obj_type_t machine_mem_type;
@@ -40,10 +42,10 @@ extern const machine_mem_obj_t machine_mem16_obj;
 extern const machine_mem_obj_t machine_mem32_obj;
 
 #if defined(MICROPY_MACHINE_MEM_GET_READ_ADDR)
-uintptr_t MICROPY_MACHINE_MEM_GET_READ_ADDR(mp_obj_t addr_o, uint align);
+uintptr_t MICROPY_MACHINE_MEM_GET_READ_ADDR(machine_mem_obj_t *self, uintptr_t addr);
 #endif
 #if defined(MICROPY_MACHINE_MEM_GET_WRITE_ADDR)
-uintptr_t MICROPY_MACHINE_MEM_GET_WRITE_ADDR(mp_obj_t addr_o, uint align);
+uintptr_t MICROPY_MACHINE_MEM_GET_WRITE_ADDR(machine_mem_obj_t *self, uintptr_t addr);
 #endif
 
 #endif // MICROPY_INCLUDED_EXTMOD_MACHINE_MEM_H

--- a/ports/unix/modmachine.c
+++ b/ports/unix/modmachine.c
@@ -46,8 +46,8 @@
 
 #if MICROPY_PY_MACHINE
 
-uintptr_t mod_machine_mem_get_addr(mp_obj_t addr_o, uint align) {
-    uintptr_t addr = mp_obj_get_int_truncated(addr_o);
+uintptr_t mod_machine_mem_get_addr(machine_mem_obj_t *self, uintptr_t addr) {
+    uint align = self->elem_size;
     if ((addr & (align - 1)) != 0) {
         mp_raise_msg_varg(&mp_type_ValueError, MP_ERROR_TEXT("address %08x is not aligned to %d bytes"), addr, align);
     }

--- a/tests/extmod/machine1.py
+++ b/tests/extmod/machine1.py
@@ -28,9 +28,15 @@ except TypeError:
     print("TypeError")
 
 try:
-    machine.mem8[0:1]
-except TypeError:
-    print("TypeError")
+    machine.mem8[-1]
+except IndexError:
+    print("IndexError")
+
+try:
+    mem = machine.mem8[0:1]
+    mem[1]
+except IndexError:
+    print("IndexError")
 
 try:
     machine.mem8[0:1] = 10

--- a/tests/extmod/machine1.py.exp
+++ b/tests/extmod/machine1.py.exp
@@ -1,8 +1,9 @@
-<8-bit memory>
+<8-bit memory at 00000000 address>
 ValueError
 ValueError
 TypeError
-TypeError
+IndexError
+IndexError
 TypeError
 TypeError
 TypeError


### PR DESCRIPTION
Use slice to create a new mem object bound to a fragment of memory address space. It is useful for passing around registers that are relevant to a given peripheral. For example one can create a function that may work on any of STM32 timers by taking as an parameter a memory slice that start at the address of the first timer register.