### PR TITLE
Optimize __rem_pio2_large

### DIFF
--- a/lib/libm_dbl/__rem_pio2_large.c
+++ b/lib/libm_dbl/__rem_pio2_large.c
@@ -366,9 +366,9 @@ recompute:
 
 	/* chop off zero terms */
 	if (z == 0.0) {
+		t = jz;
 		while (iq[--jz] == 0);
 		q0 -= (t - jz) * 24;
-
 	} else { /* break z into 24-bit if necessary */
 		z = scalbn(z,-q0);
 		if (z >= 0x1p24) {


### PR DESCRIPTION
We need to process `fq` twice, but each subsequent item depends on previous one. That's why you previously were using two loops.

But it can be optimized to use only one loop:

For example, given `jz = 10`
At first, we process items # (in pairs):
  - (10, 9)
  - (9, 8) Now we can run simple loop that will process those pairs independently:
  - (10, 9), (8, 7)
  - (9, 8), (7, 6)
  - (8, 7), (6, 5)
  - so on...

This way, we can process each pair twice with only one loop