### PR TITLE
py/gc: MICROPY_GC_HOOK_LOOP improvements.

### DIFF
--- a/py/mpconfig.h
+++ b/py/mpconfig.h
@@ -617,8 +617,9 @@
 #endif
 
 // Hook to run code during time consuming garbage collector operations
+// *i* is the loop index variable (e.g. can be used to run every x loops)
 #ifndef MICROPY_GC_HOOK_LOOP
-#define MICROPY_GC_HOOK_LOOP
+#define MICROPY_GC_HOOK_LOOP(i)
 #endif
 
 // Whether to provide m_tracked_calloc, m_tracked_free functions


### PR DESCRIPTION
- Add MICROPY_GC_HOOK_LOOP to gc_info() and gc_alloc(). Both of these can be long running (many milliseconds) which is too long to be blocking in some applications.
- Pass loop variable to MICROPY_GC_HOOK_LOOP(i) macro so that implementers can use it, e.g. to improve performance by only calling a function every X number of iterations.
- Drop outer call to MICROPY_GC_HOOK_LOOP in gc_mark_subtree().