### PR TITLE
.github/workflows/mpremote.yml: Fetch full history.

### DIFF
--- a/.github/workflows/mpremote.yml
+++ b/.github/workflows/mpremote.yml
@@ -13,11 +13,9 @@ jobs:
     steps:
     - uses: actions/checkout@v3
       with:
-        # Version is determined from git,
-        # should be deep enough to get to latest tag
-        fetch-depth: '1000'
-    - run: |
-        git fetch --prune --unshallow --tags
+        # Setting this to zero means fetch all history and tags,
+        # which hatch-vcs can use to discover the version tag.
+        fetch-depth: 0
     - uses: actions/setup-python@v4
     - name: Install build tools
       run: pip install build


### PR DESCRIPTION
Instead of doing the shallow checkout followed by an unshallow-with-tags, just set fetch-depth=0 to get the full history to start with.

This prevents the issue we saw with the v1.20.0 release where the github checkout action does

```
git fetch --no-tags --prune --progress --no-recurse-submodules --depth=1000 origin +294baf52b346e400e2255c6c1e82af5b978b18f7:refs/tags/v1.20.0
```

(in effect creating a "fake" `v1.20.0` tag in the local repo)

and then our workflow gets the tags and history by doing

```
git fetch --prune --tags --unshallow
```

which then attempts to clobber the `v1.20.0` tag with the real one.