### PR TITLE
all: Add ruff to pre-commit.

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,3 +11,7 @@ repos:
         language: python
         verbose: true
         stages: [commit-msg]
+  - repo: https://github.com/charliermarsh/ruff-pre-commit
+    rev: v0.0.265
+    hooks:
+      - id: ruff


### PR DESCRIPTION
This does not align with the other pre-commit jobs which are local custom code but it should run accurately and quickly.

https://beta.ruff.rs/docs/usage