### PR TITLE
tools: Import errno to fix undefined name in pyboard.py.

### DIFF
--- a/tools/pyboard.py
+++ b/tools/pyboard.py
@@ -68,6 +68,7 @@ Or:
 """
 
 import ast
+import errno
 import os
 import struct
 import sys


### PR DESCRIPTION
This will keep line 96 from raising a `NameError` instead of returning an `OSError`.
> return OSError(errno.ENOENT, info)

https://docs.python.org/3/library/errno.html