### PR TITLE
CODECONVENTIONS: Require that commits be signed off by the author.

### DIFF
--- a/CODECONVENTIONS.md
+++ b/CODECONVENTIONS.md
@@ -11,7 +11,7 @@ It's also ok to drop file extensions.
 
 Besides prefix, first line of a commit message should describe a
 change clearly and to the point, and be a grammatical sentence with
-final full stop. First line should fit within 72 characters. Examples
+final full stop. First line must fit within 72 characters. Examples
 of good first line of commit messages:
 
     py/objstr: Add splitlines() method.
@@ -27,12 +27,9 @@ change beyond 5 lines would likely require such detailed description.
 To get good practical examples of good commits and their messages, browse
 the `git log` of the project.
 
-When committing you are encouraged to sign-off your commit by adding
-"Signed-off-by" lines and similar, eg using "git commit -s".  If you don't
-explicitly sign-off in this way then the commit message, which includes your
-name and email address in the "Author" line, implies your sign-off.  In either
-case, of explicit or implicit sign-off, you are certifying and signing off
-against the following:
+When committing you must sign-off your commit by adding "Signed-off-by:"
+line(s) at the end of the commit message, e.g. using `git commit -s`.  You
+are then certifying and signing off against the following:
 
 * That you wrote the change yourself, or took it from a project with
   a compatible license (in the latter case the commit message, and possibly
@@ -49,10 +46,9 @@ against the following:
 * Your contribution including commit message will be publicly and
   indefinitely available for anyone to access, including redistribution
   under the terms of the project's license.
-* Your signature for all of the above, which is the "Signed-off-by" line
-  or the "Author" line in the commit message, includes your full real name and
-  a valid and active email address by which you can be contacted in the
-  foreseeable future.
+* Your signature for all of the above, which is the "Signed-off-by" line,
+  includes your full real name and a valid and active email address by
+  which you can be contacted in the foreseeable future.
 
 Code auto-formatting
 ====================

--- a/tools/verifygitlog.py
+++ b/tools/verifygitlog.py
@@ -49,17 +49,17 @@ def git_log(pretty_format, *args):
 def diagnose_subject_line(subject_line, subject_line_format, err):
     err.error("Subject line: " + subject_line)
     if not subject_line.endswith("."):
-        err.error('* should end with "."')
+        err.error('* must end with "."')
     if not re.match(r"^[^!]+: ", subject_line):
-        err.error('* should start with "path: "')
+        err.error('* must start with "path: "')
     if re.match(r"^[^!]+: *$", subject_line):
-        err.error("* should contain a subject after the path.")
+        err.error("* must contain a subject after the path.")
     m = re.match(r"^[^!]+: ([a-z][^ ]*)", subject_line)
     if m:
-        err.error('* first word of subject ("{}") should be capitalised.'.format(m.group(1)))
+        err.error('* first word of subject ("{}") must be capitalised.'.format(m.group(1)))
     if re.match(r"^[^!]+: [^ ]+$", subject_line):
-        err.error("* subject should contain more than one word.")
-    err.error("* should match: " + repr(subject_line_format))
+        err.error("* subject must contain more than one word.")
+    err.error("* must match: " + repr(subject_line_format))
     err.error('* Example: "py/runtime: Add support for foo to bar."')
 
 
@@ -94,11 +94,11 @@ def verify_message_body(raw_body, err):
     if not re.match(subject_line_format, subject_line):
         diagnose_subject_line(subject_line, subject_line_format, err)
     if len(subject_line) >= 73:
-        err.error("Subject line should be 72 or fewer characters: " + subject_line)
+        err.error("Subject line must be 72 or fewer characters: " + subject_line)
 
     # Second one divides subject and body.
     if len(raw_body) > 1 and raw_body[1]:
-        err.error("Second message line should be empty: " + raw_body[1])
+        err.error("Second message line must be empty: " + raw_body[1])
 
     # Message body lines.
     for line in raw_body[2:]:
@@ -107,7 +107,7 @@ def verify_message_body(raw_body, err):
             err.error("Message lines should be 75 or less characters: " + line)
 
     if not raw_body[-1].startswith("Signed-off-by: ") or "@" not in raw_body[-1]:
-        err.warning('Message should be signed-off. Use "git commit -s".')
+        err.error('Message must be signed-off. Use "git commit -s".')
 
 
 def run(args):


### PR DESCRIPTION
Currently it's encouraged to sign-off commits, and if they are not signed-off then the sign-off is implicit by the fact it was authored by the commit author.

This is a bit too sneaky, because not all contributors are going to read this CODECONVENTIONS file.

This PR changes things so that it's a requirement to sign-off all commits.