### PR TITLE
py/stackctrl: Add gcc pragmas to ignore dangling-pointer warning.

### DIFF
--- a/py/stackctrl.c
+++ b/py/stackctrl.c
@@ -28,8 +28,15 @@
 #include "py/stackctrl.h"
 
 void mp_stack_ctrl_init(void) {
+    #if __GNUC__ >= 13
+    #pragma GCC diagnostic push
+    #pragma GCC diagnostic ignored "-Wdangling-pointer"
+    #endif
     volatile int stack_dummy;
     MP_STATE_THREAD(stack_top) = (char *)&stack_dummy;
+    #if __GNUC__ >= 13
+    #pragma GCC diagnostic pop
+    #endif
 }
 
 void mp_stack_set_top(void *top) {


### PR DESCRIPTION
This warning became apparent in gcc 13.

Note that most bare-metal ports do not use this `mp_stack_ctrl_init()`  function.  Instead they use `mp_stack_set_top()`.