### PR TITLE
ports/rp2: Allow building MP for Pico-W plus Ethernet.

### DIFF
--- a/ports/rp2/mphalport.c
+++ b/ports/rp2/mphalport.c
@@ -205,8 +205,8 @@ MP_WEAK void mp_hal_get_mac(int idx, uint8_t buf[6]) {
     // This is loaded into the state after the driver is initialised
     // cyw43_hal_generate_laa_mac is only called by the driver to generate a mac if otp is not set
     if (idx == MP_HAL_MAC_WLAN0) {
-       memcpy(buf, cyw43_state.mac, 6);
-       return;
+        memcpy(buf, cyw43_state.mac, 6);
+        return;
     }
     #endif
     mp_hal_generate_laa_mac(idx, buf);

--- a/ports/rp2/mphalport.c
+++ b/ports/rp2/mphalport.c
@@ -204,10 +204,12 @@ MP_WEAK void mp_hal_get_mac(int idx, uint8_t buf[6]) {
     // The mac should come from cyw43 otp when CYW43_USE_OTP_MAC is defined
     // This is loaded into the state after the driver is initialised
     // cyw43_hal_generate_laa_mac is only called by the driver to generate a mac if otp is not set
-    memcpy(buf, cyw43_state.mac, 6);
-    #else
-    mp_hal_generate_laa_mac(idx, buf);
+    if (idx == MP_HAL_MAC_WLAN0) {
+       memcpy(buf, cyw43_state.mac, 6);
+       return;
+    }
     #endif
+    mp_hal_generate_laa_mac(idx, buf);
 }
 
 void mp_hal_get_mac_ascii(int idx, size_t chr_off, size_t chr_len, char *dest) {


### PR DESCRIPTION
When building Micropython for the Pico-W with Wifi nic plus Ethernet nic (WIZNET W5500) there is an issue with the MAC handling in function  `mp_hal_get_mac()` (source file `mphalport.c`). 

Building the Pico-W port needs the `MICROPY_PY_NETWORK_CYW43` flag to be set in order to include building the CYW43 Wifi driver. But with this flag set,  `mp_hal_get_mac()` handles the MAC assignment for all nics the "CYW43 way" (copying the real MAC provided by the HW). This will fail for all other nic types, resulting in an invalid MAC address. And this makes the nic unusable.

So the solution is to add a check for the nic type parameter `idx` and handle the MAC address respectively.