### PR TITLE
py: Add NLR jump callbacks

### DIFF
--- a/py/builtinevex.c
+++ b/py/builtinevex.c
@@ -45,11 +45,17 @@ STATIC MP_DEFINE_CONST_OBJ_TYPE(
     );
 
 STATIC mp_obj_t code_execute(mp_obj_code_t *self, mp_obj_dict_t *globals, mp_obj_dict_t *locals) {
-    // save context and set new context
-    mp_obj_dict_t *old_globals = mp_globals_get();
-    mp_obj_dict_t *old_locals = mp_locals_get();
+    // save context
+    nlr_jump_callback_node_globals_locals_t ctx;
+    ctx.globals = mp_globals_get();
+    ctx.locals = mp_locals_get();
+
+    // set new context
     mp_globals_set(globals);
     mp_locals_set(locals);
+
+    // set exception handler to restore context if an exception is raised
+    nlr_push_jump_callback(&ctx.callback, mp_globals_locals_set_from_nlr_jump_callback);
 
     // a bit of a hack: fun_bc will re-set globals, so need to make sure it's
     // the correct one
@@ -59,19 +65,13 @@ STATIC mp_obj_t code_execute(mp_obj_code_t *self, mp_obj_dict_t *globals, mp_obj
     }
 
     // execute code
-    nlr_buf_t nlr;
-    if (nlr_push(&nlr) == 0) {
-        mp_obj_t ret = mp_call_function_0(self->module_fun);
-        nlr_pop();
-        mp_globals_set(old_globals);
-        mp_locals_set(old_locals);
-        return ret;
-    } else {
-        // exception; restore context and re-raise same exception
-        mp_globals_set(old_globals);
-        mp_locals_set(old_locals);
-        nlr_jump(nlr.ret_val);
-    }
+    mp_obj_t ret = mp_call_function_0(self->module_fun);
+
+    // deregister exception handler and restore context
+    nlr_pop_jump_callback(true);
+
+    // return value
+    return ret;
 }
 
 STATIC mp_obj_t mp_builtin_compile(size_t n_args, const mp_obj_t *args) {

--- a/py/mpstate.h
+++ b/py/mpstate.h
@@ -271,6 +271,7 @@ typedef struct _mp_state_thread_t {
     mp_obj_dict_t *dict_globals;
 
     nlr_buf_t *nlr_top;
+    nlr_jump_callback_node_t *nlr_jump_callback_top;
 
     // pending exception object (MP_OBJ_NULL if not pending)
     volatile mp_obj_t mp_pending_exception;

--- a/py/nlr.c
+++ b/py/nlr.c
@@ -3,7 +3,7 @@
  *
  * The MIT License (MIT)
  *
- * Copyright (c) 2013-2017 Damien P. George
+ * Copyright (c) 2013-2023 Damien P. George
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -48,6 +48,36 @@ unsigned int nlr_push_tail(nlr_buf_t *nlr) {
 void nlr_pop(void) {
     nlr_buf_t **top = &MP_STATE_THREAD(nlr_top);
     *top = (*top)->prev;
+}
+
+void nlr_push_jump_callback(nlr_jump_callback_node_t *node, nlr_jump_callback_fun_t fun) {
+    nlr_jump_callback_node_t **top = &MP_STATE_THREAD(nlr_jump_callback_top);
+    node->prev = *top;
+    node->fun = fun;
+    *top = node;
+}
+
+void nlr_pop_jump_callback(bool run_callback) {
+    nlr_jump_callback_node_t **top = &MP_STATE_THREAD(nlr_jump_callback_top);
+    nlr_jump_callback_node_t *cur = *top;
+    *top = (*top)->prev;
+    if (run_callback) {
+        cur->fun(cur);
+    }
+}
+
+// This function pops and runs all callbacks that were registered after `nlr`
+// was pushed (via nlr_push).  It assumes:
+//  - a descending C stack,
+//  - that all nlr_jump_callback_node_t's in the linked-list pointed to by
+//    nlr_jump_callback_top are on the C stack
+// It works by popping each node in turn until the next node is NULL or above
+// the `nlr` pointer on the C stack (and so pushed before `nlr` was pushed).
+void nlr_call_jump_callbacks(nlr_buf_t *nlr) {
+    nlr_jump_callback_node_t **top = &MP_STATE_THREAD(nlr_jump_callback_top);
+    while (*top != NULL && (void *)*top < (void *)nlr) {
+        nlr_pop_jump_callback(true);
+    }
 }
 
 #if MICROPY_ENABLE_VM_ABORT

--- a/py/nlr.h
+++ b/py/nlr.h
@@ -171,11 +171,9 @@ NORETURN void nlr_jump_fail(void *val);
 #ifndef MICROPY_DEBUG_NLR
 #define nlr_raise(val) nlr_jump(MP_OBJ_TO_PTR(val))
 #else
-#include "mpstate.h"
+
 #define nlr_raise(val) \
     do { \
-        /*printf("nlr_raise: nlr_top=%p\n", MP_STATE_THREAD(nlr_top)); \
-        fflush(stdout);*/ \
         void *_val = MP_OBJ_TO_PTR(val); \
         assert(_val != NULL); \
         assert(mp_obj_is_exception_instance(val)); \
@@ -185,11 +183,6 @@ NORETURN void nlr_jump_fail(void *val);
 #if !MICROPY_NLR_SETJMP
 #define nlr_push(val) \
     assert(MP_STATE_THREAD(nlr_top) != val), nlr_push(val)
-
-/*
-#define nlr_push(val) \
-    printf("nlr_push: before: nlr_top=%p, val=%p\n", MP_STATE_THREAD(nlr_top), val),assert(MP_STATE_THREAD(nlr_top) != val),nlr_push(val)
-*/
 #endif
 
 #endif

--- a/py/nlr.h
+++ b/py/nlr.h
@@ -3,7 +3,7 @@
  *
  * The MIT License (MIT)
  *
- * Copyright (c) 2013, 2014 Damien P. George
+ * Copyright (c) 2013-2023 Damien P. George
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -31,6 +31,7 @@
 
 #include <limits.h>
 #include <assert.h>
+#include <stdbool.h>
 
 #include "py/mpconfig.h"
 
@@ -123,6 +124,15 @@ struct _nlr_buf_t {
     #endif
 };
 
+typedef void (*nlr_jump_callback_fun_t)(void *ctx);
+
+typedef struct _nlr_jump_callback_node_t nlr_jump_callback_node_t;
+
+struct _nlr_jump_callback_node_t {
+    nlr_jump_callback_node_t *prev;
+    nlr_jump_callback_fun_t fun;
+};
+
 // Helper macros to save/restore the pystack state
 #if MICROPY_ENABLE_PYSTACK
 #define MP_NLR_SAVE_PYSTACK(nlr_buf) (nlr_buf)->pystack = MP_STATE_THREAD(pystack_cur)
@@ -140,6 +150,7 @@ struct _nlr_buf_t {
         nlr_jump_fail(val); \
     } \
     top->ret_val = val; \
+    nlr_call_jump_callbacks(top); \
     MP_NLR_RESTORE_PYSTACK(top); \
     *_top_ptr = top->prev; \
 
@@ -186,5 +197,17 @@ NORETURN void nlr_jump_fail(void *val);
 #endif
 
 #endif
+
+// Push a callback on to the linked-list of NLR jump callbacks.  The `node` pointer must
+// be on the C stack.  The `fun` callback will be executed if an NLR jump is taken which
+// unwinds the C stack through this `node`.
+void nlr_push_jump_callback(nlr_jump_callback_node_t *node, nlr_jump_callback_fun_t fun);
+
+// Pop a callback from the linked-list of NLR jump callbacks.  The corresponding function
+// will be called if `run_callback` is true.
+void nlr_pop_jump_callback(bool run_callback);
+
+// Pop and call all NLR jump callbacks that were registered after `nlr` buffer was pushed.
+void nlr_call_jump_callbacks(nlr_buf_t *nlr);
 
 #endif // MICROPY_INCLUDED_PY_NLR_H

--- a/py/nlrsetjmp.c
+++ b/py/nlrsetjmp.c
@@ -3,7 +3,7 @@
  *
  * The MIT License (MIT)
  *
- * Copyright (c) 2013-2017 Damien P. George
+ * Copyright (c) 2013-2023 Damien P. George
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -29,14 +29,7 @@
 #if MICROPY_NLR_SETJMP
 
 void nlr_jump(void *val) {
-    nlr_buf_t **top_ptr = &MP_STATE_THREAD(nlr_top);
-    nlr_buf_t *top = *top_ptr;
-    if (top == NULL) {
-        nlr_jump_fail(val);
-    }
-    top->ret_val = val;
-    MP_NLR_RESTORE_PYSTACK(top);
-    *top_ptr = top->prev;
+    MP_NLR_JUMP_HEAD(val, top);
     longjmp(top->jmpbuf, 1);
 }
 

--- a/py/runtime.c
+++ b/py/runtime.c
@@ -188,6 +188,12 @@ void mp_deinit(void) {
     #endif
 }
 
+void mp_globals_locals_set_from_nlr_jump_callback(void *ctx_in) {
+    nlr_jump_callback_node_globals_locals_t *ctx = ctx_in;
+    mp_globals_set(ctx->globals);
+    mp_locals_set(ctx->locals);
+}
+
 mp_obj_t MICROPY_WRAP_MP_LOAD_NAME(mp_load_name)(qstr qst) {
     // logic: search locals, globals, builtins
     DEBUG_OP_printf("load name %s\n", qstr_str(qst));
@@ -1582,39 +1588,35 @@ void mp_import_all(mp_obj_t module) {
 
 mp_obj_t mp_parse_compile_execute(mp_lexer_t *lex, mp_parse_input_kind_t parse_input_kind, mp_obj_dict_t *globals, mp_obj_dict_t *locals) {
     // save context
-    mp_obj_dict_t *volatile old_globals = mp_globals_get();
-    mp_obj_dict_t *volatile old_locals = mp_locals_get();
+    nlr_jump_callback_node_globals_locals_t ctx;
+    ctx.globals = mp_globals_get();
+    ctx.locals = mp_locals_get();
 
     // set new context
     mp_globals_set(globals);
     mp_locals_set(locals);
 
-    nlr_buf_t nlr;
-    if (nlr_push(&nlr) == 0) {
-        qstr source_name = lex->source_name;
-        mp_parse_tree_t parse_tree = mp_parse(lex, parse_input_kind);
-        mp_obj_t module_fun = mp_compile(&parse_tree, source_name, parse_input_kind == MP_PARSE_SINGLE_INPUT);
+    // set exception handler to restore context if an exception is raised
+    nlr_push_jump_callback(&ctx.callback, mp_globals_locals_set_from_nlr_jump_callback);
 
-        mp_obj_t ret;
-        if (MICROPY_PY_BUILTINS_COMPILE && globals == NULL) {
-            // for compile only, return value is the module function
-            ret = module_fun;
-        } else {
-            // execute module function and get return value
-            ret = mp_call_function_0(module_fun);
-        }
+    qstr source_name = lex->source_name;
+    mp_parse_tree_t parse_tree = mp_parse(lex, parse_input_kind);
+    mp_obj_t module_fun = mp_compile(&parse_tree, source_name, parse_input_kind == MP_PARSE_SINGLE_INPUT);
 
-        // finish nlr block, restore context and return value
-        nlr_pop();
-        mp_globals_set(old_globals);
-        mp_locals_set(old_locals);
-        return ret;
+    mp_obj_t ret;
+    if (MICROPY_PY_BUILTINS_COMPILE && globals == NULL) {
+        // for compile only, return value is the module function
+        ret = module_fun;
     } else {
-        // exception; restore context and re-raise same exception
-        mp_globals_set(old_globals);
-        mp_locals_set(old_locals);
-        nlr_jump(nlr.ret_val);
+        // execute module function and get return value
+        ret = mp_call_function_0(module_fun);
     }
+
+    // deregister exception handler and restore context
+    nlr_pop_jump_callback(true);
+
+    // return value
+    return ret;
 }
 
 #endif // MICROPY_ENABLE_COMPILER

--- a/py/runtime.h
+++ b/py/runtime.h
@@ -66,6 +66,13 @@ typedef struct _mp_sched_node_t {
     struct _mp_sched_node_t *next;
 } mp_sched_node_t;
 
+// For use with mp_globals_locals_set_from_nlr_jump_callback.
+typedef struct _nlr_jump_callback_node_globals_locals_t {
+    nlr_jump_callback_node_t callback;
+    mp_obj_dict_t *globals;
+    mp_obj_dict_t *locals;
+} nlr_jump_callback_node_globals_locals_t;
+
 // Tables mapping operator enums to qstrs, defined in objtype.c
 extern const byte mp_unary_op_method_name[];
 extern const byte mp_binary_op_method_name[];
@@ -112,6 +119,8 @@ static inline mp_obj_dict_t *mp_globals_get(void) {
 static inline void mp_globals_set(mp_obj_dict_t *d) {
     MP_STATE_THREAD(dict_globals) = d;
 }
+
+void mp_globals_locals_set_from_nlr_jump_callback(void *ctx_in);
 
 mp_obj_t mp_load_name(qstr qst);
 mp_obj_t mp_load_global(qstr qst);


### PR DESCRIPTION
NLR buffers are usually quite large (use lots of C stack) and expensive to push and pop.  Some of the time they are only needed to perform clean up if an exception happens, and then they re-raise the exception.

This PR optimises that scenario by introducing a stack of NLR callbacks that are called only when an exception is raised.  Essentially they are a light-weight NLR handler that can implement a "finally" block, ie clean-up when an exception is raised.

The function `mp_parse_compile_execute()` is optimised to use this new mechanism, as a proof of concept.  There are more places that can benefit from it (eg the two uses of NLR in `builtinevex.c` and `builtinimport.c`).