### PR TITLE
ports/esp32/cmake: Allow specifying port directory.

### DIFF
--- a/ports/esp32/CMakeLists.txt
+++ b/ports/esp32/CMakeLists.txt
@@ -3,7 +3,9 @@
 cmake_minimum_required(VERSION 3.12)
 
 # Set the location of this port's directory.
-set(MICROPY_PORT_DIR ${CMAKE_SOURCE_DIR})
+if(NOT MICROPY_PORT_DIR)
+    set(MICROPY_PORT_DIR ${CMAKE_SOURCE_DIR})
+endif()
 
 # Set the board if it's not already set.
 if(NOT MICROPY_BOARD)


### PR DESCRIPTION
Presently the use of `CMAKE_SOURCE_DIR` causes problems when using MicroPython as an ESP-IDF component.

This adds a check to see if the value has already been set so as not to override the value.