### PR TITLE
py/builtinimport: Allow built-in modules to be packages (v3)

### DIFF
--- a/docs/library/index.rst
+++ b/docs/library/index.rst
@@ -8,15 +8,17 @@ MicroPython libraries
    Important summary of this section
 
    * MicroPython provides built-in modules that mirror the functionality of the
-     Python standard library (e.g. :mod:`os`, :mod:`time`), as well as
-     MicroPython-specific modules (e.g. :mod:`bluetooth`, :mod:`machine`).
-   * Most standard library modules implement a subset of the functionality of
-     the equivalent Python module, and in a few cases provide some
-     MicroPython-specific extensions (e.g. :mod:`array`, :mod:`os`)
+     :ref:`Python standard library <micropython_lib_python>` (e.g. :mod:`os`,
+     :mod:`time`), as well as :ref:`MicroPython-specific modules <micropython_lib_micropython>`
+     (e.g. :mod:`bluetooth`, :mod:`machine`).
+   * Most Python standard library modules implement a subset of the
+     functionality of the equivalent Python module, and in a few cases provide
+     some MicroPython-specific extensions (e.g. :mod:`array`, :mod:`os`)
    * Due to resource constraints or other limitations, some ports or firmware
      versions may not include all the functionality documented here.
-   * To allow for extensibility, the built-in modules can be extended from
-     Python code loaded onto the device.
+   * To allow for extensibility, some built-in modules can be
+     :ref:`extended from Python code <micropython_lib_extending>` loaded onto
+     the device filesystem.
 
 This chapter describes modules (function and class libraries) which are built
 into MicroPython. This documentation in general aspires to describe all modules
@@ -40,6 +42,8 @@ can be imported by entering the following at the :term:`REPL`::
 Beyond the built-in libraries described in this documentation, many more
 modules from the Python standard library, as well as further MicroPython
 extensions to it, can be found in :term:`micropython-lib`.
+
+.. _micropython_lib_python:
 
 Python standard libraries and micro-libraries
 ---------------------------------------------
@@ -77,6 +81,7 @@ library.
    zlib.rst
    _thread.rst
 
+.. _micropython_lib_micropython:
 
 MicroPython-specific libraries
 ------------------------------
@@ -181,23 +186,48 @@ The following libraries are specific to the Zephyr port.
 
   zephyr.rst
 
+.. _micropython_lib_extending:
+
 Extending built-in libraries from Python
 ----------------------------------------
 
-In most cases, the above modules are actually named ``umodule`` rather than
-``module``, but MicroPython will alias any module prefixed with a ``u`` to the
-non-``u`` version. However a file (or :term:`frozen module`) named
-``module.py`` will take precedence over this alias.
+Many built-in modules are actually named ``umodule`` rather than ``module``, but
+MicroPython will alias any module prefixed with a ``u`` to the non-``u``
+version. This means that, for example, ``import time`` will first attempt to
+resolve from the filesystem, and then failing that will fall back to the
+built-in ``utime``. On the other hand, ``import utime`` will always go directly
+to the built-in.
 
 This allows the user to provide an extended implementation of a built-in library
-(perhaps to provide additional CPython compatibility). The user-provided module
-(in ``module.py``) can still use the built-in functionality by importing
-``umodule`` directly. This is used extensively in :term:`micropython-lib`. See
-:ref:`packages` for more information.
+(perhaps to provide additional CPython compatibility or missing functionality).
+The user-provided module (in ``module.py``) can still use the built-in
+functionality by importing ``umodule`` directly (e.g. typically an extension
+module ``time.py`` will do ``from utime import *``). This is used extensively
+in :term:`micropython-lib`. See :ref:`packages` for more information.
 
-This applies to both the Python standard libraries (e.g. ``os``, ``time``, etc),
-but also the MicroPython libraries too (e.g. ``machine``, ``bluetooth``, etc).
-The main exception is the port-specific libraries (``pyb``, ``esp``, etc).
+This extensibility applies to the following Python standard library modules
+which are built-in to the firmware: ``array``, ``binascii``, ``collections``,
+``errno``, ``hashlib``, ``heapq``, ``io``, ``json``, ``os``, ``platform``,
+``random``, ``re``, ``select``, ``socket``, ``ssl``, ``struct``, ``sys``,
+``time``, ``zlib``, as well as the MicroPython-specific libraries: ``bluepy``,
+``bluetooth``, ``machine``, ``timeq``, ``websocket``. All other built-in
+modules cannot be extended from the filesystem.
 
 *Other than when you specifically want to force the use of the built-in module,
 we recommend always using* ``import module`` *rather than* ``import umodule``.
+
+**Note:** In MicroPython v1.21.0 and higher, it is now possible to force an
+import of the built-in module by clearing ``sys.path`` during the import. For
+example, in ``time.py``, you can write::
+
+  _path = sys.path
+  sys.path = ()
+  try:
+    from time import *
+  finally:
+    sys.path = _path
+    del _path
+
+This is now the preferred way (instead of ``from utime import *``), as the
+``u``-prefix will be removed from the names of built-in modules in a future
+version of MicroPython.

--- a/examples/usercmodule/cexample/examplemodule.c
+++ b/examples/usercmodule/cexample/examplemodule.c
@@ -68,7 +68,7 @@ MP_DEFINE_CONST_OBJ_TYPE(
     locals_dict, &example_Timer_locals_dict
     );
 
-// Define all properties of the module.
+// Define all attributes of the module.
 // Table entries are key/value pairs of the attribute name (a string)
 // and the MicroPython object reference.
 // All identifiers and strings are written as MP_QSTR_xxx and will be

--- a/examples/usercmodule/cexample/micropython.mk
+++ b/examples/usercmodule/cexample/micropython.mk
@@ -1,9 +1,8 @@
-EXAMPLE_MOD_DIR := $(USERMOD_DIR)
+CEXAMPLE_MOD_DIR := $(USERMOD_DIR)
 
 # Add all C files to SRC_USERMOD.
-SRC_USERMOD += $(EXAMPLE_MOD_DIR)/examplemodule.c
+SRC_USERMOD += $(CEXAMPLE_MOD_DIR)/examplemodule.c
 
 # We can add our module folder to include paths if needed
 # This is not actually needed in this example.
-CFLAGS_USERMOD += -I$(EXAMPLE_MOD_DIR)
-CEXAMPLE_MOD_DIR := $(USERMOD_DIR)
+CFLAGS_USERMOD += -I$(CEXAMPLE_MOD_DIR)

--- a/examples/usercmodule/cppexample/examplemodule.c
+++ b/examples/usercmodule/cppexample/examplemodule.c
@@ -4,7 +4,7 @@
 // See example.cpp for the definition.
 STATIC MP_DEFINE_CONST_FUN_OBJ_2(cppfunc_obj, cppfunc);
 
-// Define all properties of the module.
+// Define all attributes of the module.
 // Table entries are key/value pairs of the attribute name (a string)
 // and the MicroPython object reference.
 // All identifiers and strings are written as MP_QSTR_xxx and will be

--- a/examples/usercmodule/subpackage/README.md
+++ b/examples/usercmodule/subpackage/README.md
@@ -1,0 +1,1 @@
+This is an example of a user C module that includes subpackages.

--- a/examples/usercmodule/subpackage/micropython.cmake
+++ b/examples/usercmodule/subpackage/micropython.cmake
@@ -1,0 +1,19 @@
+# Create an INTERFACE library for our C module.
+add_library(usermod_subpackage_example INTERFACE)
+
+# Add our source files to the lib
+target_sources(usermod_subpackage_example INTERFACE
+    ${CMAKE_CURRENT_LIST_DIR}/examplemodule.c
+)
+
+# Add the current directory as an include directory.
+target_include_directories(usermod_subpackage_example INTERFACE
+    ${CMAKE_CURRENT_LIST_DIR}
+)
+
+target_compile_definitions(usermod_subpackage_example INTERFACE
+    MICROPY_MODULE_BUILTIN_SUBPACKAGES=1
+)
+
+# Link our INTERFACE library to the usermod target.
+target_link_libraries(usermod INTERFACE usermod_subpackage_example)

--- a/examples/usercmodule/subpackage/micropython.mk
+++ b/examples/usercmodule/subpackage/micropython.mk
@@ -1,0 +1,10 @@
+SUBPACKAGE_EXAMPLE_MOD_DIR := $(USERMOD_DIR)
+
+# Add all C files to SRC_USERMOD.
+SRC_USERMOD += $(SUBPACKAGE_EXAMPLE_MOD_DIR)/modexamplepackage.c
+
+# We can add our module folder to include paths if needed
+# This is not actually needed in this example.
+CFLAGS_USERMOD += -I$(SUBPACKAGE_EXAMPLE_MOD_DIR) -DMICROPY_MODULE_BUILTIN_SUBPACKAGES=1
+
+QSTR_DEFS += $(SUBPACKAGE_EXAMPLE_MOD_DIR)/qstrdefsexamplepackage.h

--- a/examples/usercmodule/subpackage/modexamplepackage.c
+++ b/examples/usercmodule/subpackage/modexamplepackage.c
@@ -1,0 +1,84 @@
+// Include MicroPython API.
+#include "py/runtime.h"
+
+// Define example_package.foo.bar.f()
+STATIC mp_obj_t example_package_foo_bar_f(void) {
+    mp_printf(&mp_plat_print, "example_package.foo.bar.f\n");
+    return mp_const_none;
+}
+STATIC MP_DEFINE_CONST_FUN_OBJ_0(example_package_foo_bar_f_obj, example_package_foo_bar_f);
+
+// Define all attributes of the second-level sub-package (example_package.foo.bar).
+STATIC const mp_rom_map_elem_t example_package_foo_bar_globals_table[] = {
+    { MP_ROM_QSTR(MP_QSTR___name__), MP_ROM_QSTR(MP_QSTR_example_package_dot_foo_dot_bar) },
+    { MP_ROM_QSTR(MP_QSTR_f), MP_ROM_PTR(&example_package_foo_bar_f_obj) },
+};
+STATIC MP_DEFINE_CONST_DICT(example_package_foo_bar_globals, example_package_foo_bar_globals_table);
+
+// Define example_package.foo.bar module object.
+const mp_obj_module_t example_package_foo_bar_user_cmodule = {
+    .base = { &mp_type_module },
+    .globals = (mp_obj_dict_t *)&example_package_foo_bar_globals,
+};
+
+// Define example_package.foo.f()
+STATIC mp_obj_t example_package_foo_f(void) {
+    mp_printf(&mp_plat_print, "example_package.foo.f\n");
+    return mp_const_none;
+}
+STATIC MP_DEFINE_CONST_FUN_OBJ_0(example_package_foo_f_obj, example_package_foo_f);
+
+// Define all attributes of the first-level sub-package (example_package.foo).
+STATIC const mp_rom_map_elem_t example_package_foo_globals_table[] = {
+    { MP_ROM_QSTR(MP_QSTR___name__), MP_ROM_QSTR(MP_QSTR_example_package_dot_foo) },
+    { MP_ROM_QSTR(MP_QSTR_bar), MP_ROM_PTR(&example_package_foo_bar_user_cmodule) },
+    { MP_ROM_QSTR(MP_QSTR_f), MP_ROM_PTR(&example_package_foo_f_obj) },
+};
+STATIC MP_DEFINE_CONST_DICT(example_package_foo_globals, example_package_foo_globals_table);
+
+// Define example_package.foo module object.
+const mp_obj_module_t example_package_foo_user_cmodule = {
+    .base = { &mp_type_module },
+    .globals = (mp_obj_dict_t *)&example_package_foo_globals,
+};
+
+// Define example_package.f()
+STATIC mp_obj_t example_package_f(void) {
+    mp_printf(&mp_plat_print, "example_package.f\n");
+    return mp_const_none;
+}
+STATIC MP_DEFINE_CONST_FUN_OBJ_0(example_package_f_obj, example_package_f);
+
+STATIC mp_obj_t example_package___init__(void) {
+    if (!MP_STATE_VM(example_package_initialised)) {
+        // __init__ for builtins is called each time the module is imported,
+        //   so ensure that initialisation only happens once.
+        MP_STATE_VM(example_package_initialised) = true;
+        mp_printf(&mp_plat_print, "example_package.__init__\n");
+    }
+    return mp_const_none;
+}
+STATIC MP_DEFINE_CONST_FUN_OBJ_0(example_package___init___obj, example_package___init__);
+
+// The "initialised" state is stored on mp_state so that it is cleared on soft
+// reset.
+MP_REGISTER_ROOT_POINTER(int example_package_initialised);
+
+// Define all attributes of the top-level package (example_package).
+STATIC const mp_rom_map_elem_t example_package_globals_table[] = {
+    { MP_ROM_QSTR(MP_QSTR___name__), MP_ROM_QSTR(MP_QSTR_example_package) },
+    { MP_ROM_QSTR(MP_QSTR___init__), MP_ROM_PTR(&example_package___init___obj) },
+    { MP_ROM_QSTR(MP_QSTR_foo), MP_ROM_PTR(&example_package_foo_user_cmodule) },
+    { MP_ROM_QSTR(MP_QSTR_f), MP_ROM_PTR(&example_package_f_obj) },
+};
+STATIC MP_DEFINE_CONST_DICT(example_package_globals, example_package_globals_table);
+
+// Define module object.
+const mp_obj_module_t example_package_user_cmodule = {
+    .base = { &mp_type_module },
+    .globals = (mp_obj_dict_t *)&example_package_globals,
+};
+
+// Register the module to make it available in Python.
+// Note: subpackages should not be registered with MP_REGISTER_MODULE.
+MP_REGISTER_MODULE(MP_QSTR_example_package, example_package_user_cmodule);

--- a/examples/usercmodule/subpackage/qstrdefsexamplepackage.h
+++ b/examples/usercmodule/subpackage/qstrdefsexamplepackage.h
@@ -1,0 +1,2 @@
+Q(example_package.foo)
+Q(example_package.foo.bar)

--- a/ports/unix/main.c
+++ b/ports/unix/main.c
@@ -664,8 +664,9 @@ MP_NOINLINE int main_(int argc, char **argv) {
                     return handle_uncaught_exception(nlr.ret_val) & 0xff;
                 }
 
+                // If this module is a package, see if it has a `__main__.py`.
                 mp_obj_t dest[2];
-                mp_load_method_maybe(mod, MP_QSTR___path__, dest);
+                mp_load_method_protected(mod, MP_QSTR___path__, dest, true);
                 if (dest[0] != MP_OBJ_NULL && !subpkg_tried) {
                     subpkg_tried = true;
                     vstr_t vstr;

--- a/ports/unix/main.c
+++ b/ports/unix/main.c
@@ -664,7 +664,9 @@ MP_NOINLINE int main_(int argc, char **argv) {
                     return handle_uncaught_exception(nlr.ret_val) & 0xff;
                 }
 
-                if (mp_obj_is_package(mod) && !subpkg_tried) {
+                mp_obj_t dest[2];
+                mp_load_method_maybe(mod, MP_QSTR___path__, dest);
+                if (dest[0] != MP_OBJ_NULL && !subpkg_tried) {
                     subpkg_tried = true;
                     vstr_t vstr;
                     int len = strlen(argv[a + 1]);

--- a/py/builtinimport.c
+++ b/py/builtinimport.c
@@ -62,39 +62,39 @@ STATIC qstr make_weak_link_name(vstr_t *buffer, qstr name) {
 // Virtual sys.path entry that maps to the frozen modules.
 #define MP_FROZEN_PATH_PREFIX ".frozen/"
 
-bool mp_obj_is_package(mp_obj_t module) {
-    mp_obj_t dest[2];
-    mp_load_method_maybe(module, MP_QSTR___path__, dest);
-    return dest[0] != MP_OBJ_NULL;
-}
-
 // Wrapper for mp_import_stat (which is provided by the port, and typically
 // uses mp_vfs_import_stat) to also search frozen modules. Given an exact
 // path to a file or directory (e.g. "foo/bar", foo/bar.py" or "foo/bar.mpy"),
 // will return whether the path is a file, directory, or doesn't exist.
-STATIC mp_import_stat_t stat_path_or_frozen(const char *path) {
+STATIC mp_import_stat_t stat_path(const char *path) {
     #if MICROPY_MODULE_FROZEN
     // Only try and load as a frozen module if it starts with .frozen/.
     const int frozen_path_prefix_len = strlen(MP_FROZEN_PATH_PREFIX);
     if (strncmp(path, MP_FROZEN_PATH_PREFIX, frozen_path_prefix_len) == 0) {
+        // Just stat (which is the return value), don't get the data.
         return mp_find_frozen_module(path + frozen_path_prefix_len, NULL, NULL);
     }
     #endif
     return mp_import_stat(path);
 }
 
-// Given a path to a .py file, try and find this path as either a .py or .mpy
-// in either the filesystem or frozen modules.
+// Stat a given filesystem path to a .py file. If the file does not exist,
+// then attempt to stat the corresponding .mpy file, and update the path
+// argument. This is the logic that makes .py files take precedent over .mpy
+// files. This uses stat_path above, rather than mp_import_stat directly, so
+// that the .frozen path prefix is handled.
 STATIC mp_import_stat_t stat_file_py_or_mpy(vstr_t *path) {
-    mp_import_stat_t stat = stat_path_or_frozen(vstr_null_terminated_str(path));
+    mp_import_stat_t stat = stat_path(vstr_null_terminated_str(path));
     if (stat == MP_IMPORT_STAT_FILE) {
         return stat;
     }
 
     #if MICROPY_PERSISTENT_CODE_LOAD
     // Didn't find .py -- try the .mpy instead by inserting an 'm' into the '.py'.
+    // Note: There's no point doing this if it's a frozen path, but adding the check
+    // would be extra code, and no harm letting mp_find_frozen_module fail instead.
     vstr_ins_byte(path, path->len - 2, 'm');
-    stat = stat_path_or_frozen(vstr_null_terminated_str(path));
+    stat = stat_path(vstr_null_terminated_str(path));
     if (stat == MP_IMPORT_STAT_FILE) {
         return stat;
     }
@@ -104,15 +104,17 @@ STATIC mp_import_stat_t stat_file_py_or_mpy(vstr_t *path) {
 }
 
 // Given an import path (e.g. "foo/bar"), try and find "foo/bar" (a directory)
-// or "foo/bar.(m)py" in either the filesystem or frozen modules.
-STATIC mp_import_stat_t stat_dir_or_file(vstr_t *path) {
-    mp_import_stat_t stat = stat_path_or_frozen(vstr_null_terminated_str(path));
+// or "foo/bar.(m)py" in either the filesystem or frozen modules. If the
+// result is a file, the path argument will be updated to include the file
+// extension.
+STATIC mp_import_stat_t stat_module(vstr_t *path) {
+    mp_import_stat_t stat = stat_path(vstr_null_terminated_str(path));
     DEBUG_printf("stat %s: %d\n", vstr_str(path), stat);
     if (stat == MP_IMPORT_STAT_DIR) {
         return stat;
     }
 
-    // not a directory, add .py and try as a file
+    // Not a directory, add .py and try as a file.
     vstr_add_str(path, ".py");
     return stat_file_py_or_mpy(path);
 }
@@ -120,8 +122,8 @@ STATIC mp_import_stat_t stat_dir_or_file(vstr_t *path) {
 // Given a top-level module name, try and find it in each of the sys.path
 // entries. Note: On success, the dest argument will be updated to the matching
 // path (i.e. "<entry>/mod_name(.py)").
-STATIC mp_import_stat_t stat_top_level_dir_or_file(qstr mod_name, vstr_t *dest) {
-    DEBUG_printf("stat_top_level_dir_or_file: '%s'\n", qstr_str(mod_name));
+STATIC mp_import_stat_t stat_top_level(qstr mod_name, vstr_t *dest) {
+    DEBUG_printf("stat_top_level: '%s'\n", qstr_str(mod_name));
     #if MICROPY_PY_SYS
     size_t path_num;
     mp_obj_t *path_items;
@@ -138,7 +140,7 @@ STATIC mp_import_stat_t stat_top_level_dir_or_file(qstr mod_name, vstr_t *dest) 
             vstr_add_char(dest, PATH_SEP_CHAR[0]);
         }
         vstr_add_str(dest, qstr_str(mod_name));
-        mp_import_stat_t stat = stat_dir_or_file(dest);
+        mp_import_stat_t stat = stat_module(dest);
         if (stat != MP_IMPORT_STAT_NO_EXIST) {
             return stat;
         }
@@ -152,7 +154,7 @@ STATIC mp_import_stat_t stat_top_level_dir_or_file(qstr mod_name, vstr_t *dest) 
 
     // mp_sys_path is not enabled, so just stat the given path directly.
     vstr_add_str(dest, qstr_str(mod_name));
-    return stat_dir_or_file(dest);
+    return stat_module(dest);
 
     #endif
 }
@@ -350,128 +352,168 @@ STATIC void evaluate_relative_import(mp_int_t level, const char **module_name, s
 }
 
 // Load a module at the specified absolute path, possibly as a submodule of the given outer module.
-// full_mod_name:    The full absolute path to this module (e.g. "foo.bar.baz").
+// full_mod_name:    The full absolute path up to this level (e.g. "foo.bar.baz").
 // level_mod_name:   The final component of the path (e.g. "baz").
 // outer_module_obj: The parent module (we need to store this module as an
 //                   attribute on it) (or MP_OBJ_NULL for top-level).
-// path:             The filesystem path where we found the parent module
-//                   (or empty for a top level module).
 // override_main:    Whether to set the __name__ to "__main__" (and use __main__
 //                   for the actual path).
-STATIC mp_obj_t process_import_at_level(qstr full_mod_name, qstr level_mod_name, mp_obj_t outer_module_obj, vstr_t *path, bool override_main) {
+STATIC mp_obj_t process_import_at_level(qstr full_mod_name, qstr level_mod_name, mp_obj_t outer_module_obj, bool override_main) {
+    // Immediately return if the module at this level is already loaded.
+    mp_map_elem_t *elem;
+
+    #if MICROPY_PY_SYS
+    // If sys.path is empty, the intention is to force using a built-in. This
+    // means we should also ignore any loaded modules with the same name
+    // which may have come from the filesystem.
+    size_t path_num;
+    mp_obj_t *path_items;
+    mp_obj_list_get(mp_sys_path, &path_num, &path_items);
+    if (path_num)
+    #endif
+    {
+        elem = mp_map_lookup(&MP_STATE_VM(mp_loaded_modules_dict).map, MP_OBJ_NEW_QSTR(full_mod_name), MP_MAP_LOOKUP);
+        if (elem) {
+            return elem->value;
+        }
+    }
+
+    VSTR_FIXED(path, MICROPY_ALLOC_PATH_MAX);
     mp_import_stat_t stat = MP_IMPORT_STAT_NO_EXIST;
-
-    // Exact-match of built-in (or already-loaded) takes priority.
-    mp_obj_t module_obj = mp_module_get_loaded_or_builtin(full_mod_name);
-
-    // Even if we find the module, go through the motions of searching for it
-    // because we may actually be in the process of importing a sub-module.
-    // So we need to (re-)find the correct path to be finding the sub-module
-    // on the next iteration of process_import_at_level.
+    mp_obj_t module_obj;
 
     if (outer_module_obj == MP_OBJ_NULL) {
         DEBUG_printf("Searching for top-level module\n");
 
+        // An exact match of a built-in will always bypass the filesystem.
+        // Note that CPython-compatible built-ins are named e.g. utime, so this
+        // means that an exact match is only for `import utime`, so `import
+        // time` will search the filesystem and failing that hit the weak
+        // link handling below. Whereas micropython-specific built-ins like
+        // `micropython`, `pyb`, `network`, etc will match exactly and cannot
+        // be overridden by the filesystem.
+        module_obj = mp_module_get_builtin(level_mod_name);
+        if (module_obj != MP_OBJ_NULL) {
+            return module_obj;
+        }
+
+        #if MICROPY_PY_SYS
+        // Never allow sys to be overridden from the filesystem. If weak links
+        // are disabled, then this also provides a default weak link so that
+        // `import sys` is treated like `import usys` (and therefore bypasses
+        // the filesystem).
+        if (level_mod_name == MP_QSTR_sys) {
+            return MP_OBJ_FROM_PTR(&mp_module_sys);
+        }
+        #endif
+
         // First module in the dotted-name; search for a directory or file
         // relative to all the locations in sys.path.
-        stat = stat_top_level_dir_or_file(full_mod_name, path);
+        stat = stat_top_level(level_mod_name, &path);
 
-        // If the module "foo" doesn't exist on the filesystem, and it's not a
-        // builtin, try and find "ufoo" as a built-in. (This feature was
-        // formerly known as "weak links").
         #if MICROPY_MODULE_WEAK_LINKS
-        if (stat == MP_IMPORT_STAT_NO_EXIST && module_obj == MP_OBJ_NULL) {
-            qstr umodule_name = make_weak_link_name(path, level_mod_name);
+        if (stat == MP_IMPORT_STAT_NO_EXIST) {
+            // No match on the filesystem. (And not a built-in either).
+            // If "foo" was requested, then try "ufoo" as a built-in. This
+            // allows `import time` to use built-in `utime`, unless `time`
+            // exists on the filesystem. This feature was formerly known
+            // as "weak links".
+            qstr umodule_name = make_weak_link_name(&path, level_mod_name);
             module_obj = mp_module_get_builtin(umodule_name);
-        }
-        #elif MICROPY_PY_SYS
-        if (stat == MP_IMPORT_STAT_NO_EXIST && module_obj == MP_OBJ_NULL && level_mod_name == MP_QSTR_sys) {
-            module_obj = MP_OBJ_FROM_PTR(&mp_module_sys);
+            if (module_obj != MP_OBJ_NULL) {
+                return module_obj;
+            }
         }
         #endif
     } else {
         DEBUG_printf("Searching for sub-module\n");
 
-        // Add the current part of the module name to the path.
-        vstr_add_char(path, PATH_SEP_CHAR[0]);
-        vstr_add_str(path, qstr_str(level_mod_name));
+        // If the outer module is a package, it will have __path__ set.
+        // We can use that as the path to search inside.
+        mp_obj_t dest[2];
+        mp_load_method_maybe(outer_module_obj, MP_QSTR___path__, dest);
+        if (dest[0] != MP_OBJ_NULL) {
+            // e.g. __path__ will be "<matched search path>/foo/bar"
+            vstr_add_str(&path, mp_obj_str_get_str(dest[0]));
 
-        // Because it's not top level, we already know which path the parent was found in.
-        stat = stat_dir_or_file(path);
+            // Add the level module name to the path to get "<matched search path>/foo/bar/baz".
+            vstr_add_char(&path, PATH_SEP_CHAR[0]);
+            vstr_add_str(&path, qstr_str(level_mod_name));
+
+            stat = stat_module(&path);
+        }
     }
-    DEBUG_printf("Current path: %.*s\n", (int)vstr_len(path), vstr_str(path));
 
-    if (module_obj == MP_OBJ_NULL) {
-        // Not a built-in and not already-loaded.
+    // Not already loaded, and not a built-in, so look at the stat result from the filesystem/frozen.
 
-        if (stat == MP_IMPORT_STAT_NO_EXIST) {
-            // And the file wasn't found -- fail.
-            #if MICROPY_ERROR_REPORTING <= MICROPY_ERROR_REPORTING_TERSE
-            mp_raise_msg(&mp_type_ImportError, MP_ERROR_TEXT("module not found"));
-            #else
-            mp_raise_msg_varg(&mp_type_ImportError, MP_ERROR_TEXT("no module named '%q'"), full_mod_name);
-            #endif
+    if (stat == MP_IMPORT_STAT_NO_EXIST) {
+        // Not found -- fail.
+        #if MICROPY_ERROR_REPORTING <= MICROPY_ERROR_REPORTING_TERSE
+        mp_raise_msg(&mp_type_ImportError, MP_ERROR_TEXT("module not found"));
+        #else
+        mp_raise_msg_varg(&mp_type_ImportError, MP_ERROR_TEXT("no module named '%q'"), full_mod_name);
+        #endif
+    }
+
+    // Module was found on the filesystem/frozen, try and load it.
+    DEBUG_printf("Found path to load: %.*s\n", (int)vstr_len(&path), vstr_str(&path));
+
+    // Prepare for loading from the filesystem. Create a new shell module.
+    module_obj = mp_obj_new_module(full_mod_name);
+
+    #if MICROPY_MODULE_OVERRIDE_MAIN_IMPORT
+    // If this module is being loaded via -m on unix, then
+    // override __name__ to "__main__". Do this only for *modules*
+    // however - packages never have their names replaced, instead
+    // they're -m'ed using a special __main__ submodule in them. (This all
+    // apparently is done to not touch the package name itself, which is
+    // important for future imports).
+    if (override_main && stat != MP_IMPORT_STAT_DIR) {
+        mp_obj_module_t *o = MP_OBJ_TO_PTR(module_obj);
+        mp_obj_dict_store(MP_OBJ_FROM_PTR(o->globals), MP_OBJ_NEW_QSTR(MP_QSTR___name__), MP_OBJ_NEW_QSTR(MP_QSTR___main__));
+        #if MICROPY_CPYTHON_COMPAT
+        // Store module as "__main__" in the dictionary of loaded modules (returned by sys.modules).
+        mp_obj_dict_store(MP_OBJ_FROM_PTR(&MP_STATE_VM(mp_loaded_modules_dict)), MP_OBJ_NEW_QSTR(MP_QSTR___main__), module_obj);
+        // Store real name in "__main__" attribute. Need this for
+        // resolving relative imports later. "__main__ was chosen
+        // semi-randonly, to reuse existing qstr's.
+        mp_obj_dict_store(MP_OBJ_FROM_PTR(o->globals), MP_OBJ_NEW_QSTR(MP_QSTR___main__), MP_OBJ_NEW_QSTR(full_mod_name));
+        #endif
+    }
+    #endif // MICROPY_MODULE_OVERRIDE_MAIN_IMPORT
+
+    if (stat == MP_IMPORT_STAT_DIR) {
+        // Directory (i.e. a package).
+        DEBUG_printf("%.*s is dir\n", (int)vstr_len(&path), vstr_str(&path));
+
+        // Store the __path__ attribute onto this module.
+        // https://docs.python.org/3/reference/import.html
+        // "Specifically, any module that contains a __path__ attribute is considered a package."
+        // This gets used later to locate any subpackages of this module.
+        mp_store_attr(module_obj, MP_QSTR___path__, mp_obj_new_str(vstr_str(&path), vstr_len(&path)));
+        size_t orig_path_len = path.len;
+        vstr_add_str(&path, PATH_SEP_CHAR "__init__.py");
+
+        // execute "path/__init__.py" (if available).
+        if (stat_file_py_or_mpy(&path) == MP_IMPORT_STAT_FILE) {
+            do_load(MP_OBJ_TO_PTR(module_obj), &path);
+        } else {
+            // No-op. Nothing to load.
+            // mp_warning("%s is imported as namespace package", vstr_str(&path));
         }
-
-        // Not a built-in but found on the filesystem, try and load it.
-
-        DEBUG_printf("Found path: %.*s\n", (int)vstr_len(path), vstr_str(path));
-
-        // Prepare for loading from the filesystem. Create a new shell module.
-        module_obj = mp_obj_new_module(full_mod_name);
-
-        #if MICROPY_MODULE_OVERRIDE_MAIN_IMPORT
-        // If this module is being loaded via -m on unix, then
-        // override __name__ to "__main__". Do this only for *modules*
-        // however - packages never have their names replaced, instead
-        // they're -m'ed using a special __main__ submodule in them. (This all
-        // apparently is done to not touch the package name itself, which is
-        // important for future imports).
-        if (override_main && stat != MP_IMPORT_STAT_DIR) {
-            mp_obj_module_t *o = MP_OBJ_TO_PTR(module_obj);
-            mp_obj_dict_store(MP_OBJ_FROM_PTR(o->globals), MP_OBJ_NEW_QSTR(MP_QSTR___name__), MP_OBJ_NEW_QSTR(MP_QSTR___main__));
-            #if MICROPY_CPYTHON_COMPAT
-            // Store module as "__main__" in the dictionary of loaded modules (returned by sys.modules).
-            mp_obj_dict_store(MP_OBJ_FROM_PTR(&MP_STATE_VM(mp_loaded_modules_dict)), MP_OBJ_NEW_QSTR(MP_QSTR___main__), module_obj);
-            // Store real name in "__main__" attribute. Need this for
-            // resolving relative imports later. "__main__ was chosen
-            // semi-randonly, to reuse existing qstr's.
-            mp_obj_dict_store(MP_OBJ_FROM_PTR(o->globals), MP_OBJ_NEW_QSTR(MP_QSTR___main__), MP_OBJ_NEW_QSTR(full_mod_name));
-            #endif
-        }
-        #endif // MICROPY_MODULE_OVERRIDE_MAIN_IMPORT
-
-        if (stat == MP_IMPORT_STAT_DIR) {
-            // Directory -- execute "path/__init__.py".
-            DEBUG_printf("%.*s is dir\n", (int)vstr_len(path), vstr_str(path));
-            // Store the __path__ attribute onto this module.
-            // https://docs.python.org/3/reference/import.html
-            // "Specifically, any module that contains a __path__ attribute is considered a package."
-            mp_store_attr(module_obj, MP_QSTR___path__, mp_obj_new_str(vstr_str(path), vstr_len(path)));
-            size_t orig_path_len = path->len;
-            vstr_add_str(path, PATH_SEP_CHAR "__init__.py");
-            if (stat_file_py_or_mpy(path) == MP_IMPORT_STAT_FILE) {
-                do_load(MP_OBJ_TO_PTR(module_obj), path);
-            } else {
-                // No-op. Nothing to load.
-                // mp_warning("%s is imported as namespace package", vstr_str(&path));
-            }
-            // Remove /__init__.py suffix.
-            path->len = orig_path_len;
-        } else { // MP_IMPORT_STAT_FILE
-            // File -- execute "path.(m)py".
-            do_load(MP_OBJ_TO_PTR(module_obj), path);
-            // Note: This should be the last component in the import path.  If
-            // there are remaining components then it's an ImportError
-            // because the current path(the module that was just loaded) is
-            // not a package.  This will be caught on the next iteration
-            // because the file will not exist.
-        }
+        // Remove /__init__.py suffix from path.
+        path.len = orig_path_len;
+    } else { // MP_IMPORT_STAT_FILE
+        // File -- execute "path.(m)py".
+        do_load(MP_OBJ_TO_PTR(module_obj), &path);
+        // Note: This should be the last component in the import path. If
+        // there are remaining components then in the next call to
+        // process_import_at_level will detect that it doesn't have
+        // a __path__ attribute, and not attempt to stat it.
     }
 
     if (outer_module_obj != MP_OBJ_NULL) {
-        // If it's a sub-module (not a built-in one), then make it available on
-        // the parent module.
+        // If it's a sub-module then make it available on the parent module.
         mp_store_attr(outer_module_obj, level_mod_name, module_obj);
     }
 
@@ -504,7 +546,6 @@ mp_obj_t mp_builtin___import___default(size_t n_args, const mp_obj_t *args) {
     // i.e. "from . import foo" --> level=1
     // i.e. "from ...foo.bar import baz" --> level=3
     mp_int_t level = 0;
-
     if (n_args >= 4) {
         fromtuple = args[3];
         if (n_args >= 5) {
@@ -519,8 +560,10 @@ mp_obj_t mp_builtin___import___default(size_t n_args, const mp_obj_t *args) {
     const char *module_name = mp_obj_str_get_data(module_name_obj, &module_name_len);
 
     if (level != 0) {
-        // Turn "foo.bar" into "<current module minus 3 components>.foo.bar".
+        // Turn "foo.bar" with level=3 into "<current module 3 components>.foo.bar".
+        // Current module name is extracted from globals().__name__.
         evaluate_relative_import(level, &module_name, &module_name_len);
+        // module_name is now an absolute module path.
     }
 
     if (module_name_len == 0) {
@@ -529,11 +572,12 @@ mp_obj_t mp_builtin___import___default(size_t n_args, const mp_obj_t *args) {
 
     DEBUG_printf("Starting module search for '%s'\n", module_name);
 
-    VSTR_FIXED(path, MICROPY_ALLOC_PATH_MAX)
     mp_obj_t top_module_obj = MP_OBJ_NULL;
     mp_obj_t outer_module_obj = MP_OBJ_NULL;
 
-    // Search for the end of each component.
+    // Iterate the absolute path, finding the end of each component of the path.
+    // foo.bar.baz
+    //    ^   ^   ^
     size_t current_component_start = 0;
     for (size_t i = 1; i <= module_name_len; i++) {
         if (i == module_name_len || module_name[i] == '.') {
@@ -543,18 +587,18 @@ mp_obj_t mp_builtin___import___default(size_t n_args, const mp_obj_t *args) {
             qstr level_mod_name = qstr_from_strn(module_name + current_component_start, i - current_component_start);
 
             DEBUG_printf("Processing module: '%s' at level '%s'\n", qstr_str(full_mod_name), qstr_str(level_mod_name));
-            DEBUG_printf("Previous path: =%.*s=\n", (int)vstr_len(&path), vstr_str(&path));
 
             #if MICROPY_MODULE_OVERRIDE_MAIN_IMPORT
-            // On unix, if this is being loaded via -m (magic mp_const_false),
-            // then handle that if it's the final component.
+            // On unix, if this is being loaded via -m (indicated by sentinel
+            // fromtuple=mp_const_false), then handle that if it's the final
+            // component.
             bool override_main = (i == module_name_len && fromtuple == mp_const_false);
             #else
             bool override_main = false;
             #endif
 
             // Import this module.
-            mp_obj_t module_obj = process_import_at_level(full_mod_name, level_mod_name, outer_module_obj, &path, override_main);
+            mp_obj_t module_obj = process_import_at_level(full_mod_name, level_mod_name, outer_module_obj, override_main);
 
             // Set this as the parent module, and remember the top-level module if it's the first.
             outer_module_obj = module_obj;
@@ -577,30 +621,37 @@ mp_obj_t mp_builtin___import___default(size_t n_args, const mp_obj_t *args) {
 
 #else // MICROPY_ENABLE_EXTERNAL_IMPORT
 
-bool mp_obj_is_package(mp_obj_t module) {
-    return false;
-}
-
 mp_obj_t mp_builtin___import___default(size_t n_args, const mp_obj_t *args) {
-    // Check that it's not a relative import
+    // Check that it's not a relative import.
     if (n_args >= 5 && MP_OBJ_SMALL_INT_VALUE(args[4]) != 0) {
         mp_raise_NotImplementedError(MP_ERROR_TEXT("relative import"));
     }
 
-    // Check if module already exists, and return it if it does
+    // Check if the module is already loaded.
+    mp_map_elem_t *elem = mp_map_lookup(&MP_STATE_VM(mp_loaded_modules_dict).map, args[0], MP_MAP_LOOKUP);
+    if (elem) {
+        return elem->value;
+    }
+
+    // Try the name directly as a built-in.
     qstr module_name_qstr = mp_obj_str_get_qstr(args[0]);
-    mp_obj_t module_obj = mp_module_get_loaded_or_builtin(module_name_qstr);
+    mp_obj_t module_obj = mp_module_get_builtin(module_name_qstr);
     if (module_obj != MP_OBJ_NULL) {
         return module_obj;
     }
 
     #if MICROPY_MODULE_WEAK_LINKS
-    // Check if there is a weak link to this module
+    // Check if the u-prefixed name is a built-in.
     VSTR_FIXED(umodule_path, MICROPY_ALLOC_PATH_MAX);
     qstr umodule_name_qstr = make_weak_link_name(&umodule_path, module_name_qstr);
-    module_obj = mp_module_get_loaded_or_builtin(umodule_name_qstr);
+    module_obj = mp_module_get_builtin(umodule_name_qstr);
     if (module_obj != MP_OBJ_NULL) {
         return module_obj;
+    }
+    #elif MICROPY_PY_SYS
+    // Special handling to make `import sys` work even if weak links aren't enabled.
+    if (module_name_qstr == MP_QSTR_sys) {
+        return MP_OBJ_FROM_PTR(&mp_module_sys);
     }
     #endif
 

--- a/py/mpconfig.h
+++ b/py/mpconfig.h
@@ -845,7 +845,9 @@ typedef double mp_float_t;
 #define MICROPY_MODULE_ATTR_DELEGATION (MICROPY_CONFIG_ROM_LEVEL_AT_LEAST_EXTRA_FEATURES)
 #endif
 
-// Whether to call __init__ when importing builtin modules for the first time
+// Whether to call __init__ when importing builtin modules for the first time.
+// Modules using this need to handle the possibility that __init__ might be
+// called multiple times.
 #ifndef MICROPY_MODULE_BUILTIN_INIT
 #define MICROPY_MODULE_BUILTIN_INIT (MICROPY_CONFIG_ROM_LEVEL_AT_LEAST_EXTRA_FEATURES)
 #endif

--- a/py/mpconfig.h
+++ b/py/mpconfig.h
@@ -850,6 +850,20 @@ typedef double mp_float_t;
 #define MICROPY_MODULE_BUILTIN_INIT (MICROPY_CONFIG_ROM_LEVEL_AT_LEAST_EXTRA_FEATURES)
 #endif
 
+// Whether to allow built-in modules to have sub-packages (by making the
+// sub-package a member of their locals dict). Sub-packages should not be
+// registered with MP_REGISTER_MODULE, instead they should be added as
+// members of the parent's globals dict. To match CPython behavior,
+// their __name__ should be "foo.bar"(i.e. QSTR_foo_dot_bar) which will
+// require an entry in qstrdefs, although it does also work to just call
+// it "bar". Also, because subpackages can be accessed without being
+// imported (e.g. as foo.bar after `import foo`), they should not
+// have __init__ methods. Instead, the top-level package's __init__ should
+// initialise all sub-packages.
+#ifndef MICROPY_MODULE_BUILTIN_SUBPACKAGES
+#define MICROPY_MODULE_BUILTIN_SUBPACKAGES (MICROPY_CONFIG_ROM_LEVEL_AT_LEAST_EVERYTHING)
+#endif
+
 // Whether to support module-level __getattr__ (see PEP 562)
 #ifndef MICROPY_MODULE_GETATTR
 #define MICROPY_MODULE_GETATTR (MICROPY_CONFIG_ROM_LEVEL_AT_LEAST_CORE_FEATURES)

--- a/py/obj.h
+++ b/py/obj.h
@@ -1201,8 +1201,6 @@ typedef struct _mp_obj_module_t {
 static inline mp_obj_dict_t *mp_obj_module_get_globals(mp_obj_t module) {
     return ((mp_obj_module_t *)MP_OBJ_TO_PTR(module))->globals;
 }
-// check if given module object is a package
-bool mp_obj_is_package(mp_obj_t module);
 
 // staticmethod and classmethod types; defined here so we can make const versions
 // this structure is used for instances of both staticmethod and classmethod

--- a/py/objmodule.c
+++ b/py/objmodule.c
@@ -40,10 +40,6 @@
 #include "genhdr/moduledefs.h"
 #endif
 
-#if MICROPY_MODULE_BUILTIN_INIT
-STATIC void mp_module_call_init(mp_obj_t module_name, mp_obj_t module_obj);
-#endif
-
 STATIC void module_print(const mp_print_t *print, mp_obj_t self_in, mp_print_kind_t kind) {
     (void)kind;
     mp_obj_module_t *self = MP_OBJ_TO_PTR(self_in);
@@ -176,9 +172,8 @@ STATIC const mp_rom_map_elem_t mp_builtin_module_table[] = {
 
 MP_DEFINE_CONST_MAP(mp_builtin_module_map, mp_builtin_module_table);
 
-// Attempts to find (and initialise) a builtin, otherwise returns MP_OBJ_NULL.
-// This must only be called after first checking the loaded modules,
-// otherwise the module will be re-initialised.
+// Attempts to find (and initialise) a builtin, otherwise returns
+// MP_OBJ_NULL.
 mp_obj_t mp_module_get_builtin(qstr module_name) {
     mp_map_elem_t *elem = mp_map_lookup((mp_map_t *)&mp_builtin_module_map, MP_OBJ_NEW_QSTR(module_name), MP_MAP_LOOKUP);
     if (!elem) {
@@ -186,33 +181,18 @@ mp_obj_t mp_module_get_builtin(qstr module_name) {
     }
 
     #if MICROPY_MODULE_BUILTIN_INIT
-    // If found, it's a newly loaded built-in, so init it.
-    mp_module_call_init(MP_OBJ_NEW_QSTR(module_name), elem->value);
+    // If found, it's a newly loaded built-in, so init it. This can run
+    // multiple times, so the module must ensure that it handles being
+    // initialised multiple times.
+    mp_obj_t dest[2];
+    mp_load_method_maybe(elem->value, MP_QSTR___init__, dest);
+    if (dest[0] != MP_OBJ_NULL) {
+        mp_call_method_n_kw(0, 0, dest);
+    }
     #endif
 
     return elem->value;
 }
-
-#if MICROPY_MODULE_BUILTIN_INIT
-STATIC void mp_module_register(mp_obj_t module_name, mp_obj_t module) {
-    mp_map_t *mp_loaded_modules_map = &MP_STATE_VM(mp_loaded_modules_dict).map;
-    mp_map_lookup(mp_loaded_modules_map, module_name, MP_MAP_LOOKUP_ADD_IF_NOT_FOUND)->value = module;
-}
-
-STATIC void mp_module_call_init(mp_obj_t module_name, mp_obj_t module_obj) {
-    // Look for __init__ and call it if it exists
-    mp_obj_t dest[2];
-    mp_load_method_maybe(module_obj, MP_QSTR___init__, dest);
-    if (dest[0] != MP_OBJ_NULL) {
-        mp_call_method_n_kw(0, 0, dest);
-        // Register module so __init__ is not called again.
-        // If a module can be referenced by more than one name (eg due to weak links)
-        // then __init__ will still be called for each distinct import, and it's then
-        // up to the particular module to make sure it's __init__ code only runs once.
-        mp_module_register(module_name, module_obj);
-    }
-}
-#endif
 
 void mp_module_generic_attr(qstr attr, mp_obj_t *dest, const uint16_t *keys, mp_obj_t *values) {
     for (size_t i = 0; keys[i] != MP_QSTRnull; ++i) {

--- a/py/objmodule.h
+++ b/py/objmodule.h
@@ -33,10 +33,7 @@
 
 extern const mp_map_t mp_builtin_module_map;
 
-mp_obj_t mp_module_get_loaded_or_builtin(qstr module_name);
-#if MICROPY_MODULE_WEAK_LINKS
 mp_obj_t mp_module_get_builtin(qstr module_name);
-#endif
 
 void mp_module_generic_attr(qstr attr, mp_obj_t *dest, const uint16_t *keys, mp_obj_t *values);
 

--- a/py/runtime.c
+++ b/py/runtime.c
@@ -1531,7 +1531,8 @@ mp_obj_t mp_import_from(mp_obj_t module, qstr name) {
     #if MICROPY_ENABLE_EXTERNAL_IMPORT
 
     // See if it's a package, then can try FS import
-    if (!mp_obj_is_package(module)) {
+    mp_load_method_maybe(module, MP_QSTR___path__, dest);
+    if (dest[0] == MP_OBJ_NULL) {
         goto import_error;
     }
 

--- a/tests/import/builtin_ext.py
+++ b/tests/import/builtin_ext.py
@@ -1,0 +1,36 @@
+import sys
+
+print(sys, hasattr(sys, "__file__"))
+
+sys.path.clear()
+sys.path.append("ext")
+
+# All three should only get builtins, despite sys.py, usys.py, and
+# micropython.py being in the path.
+import micropython
+
+print(micropython, hasattr(micropython, "__file__"))
+import sys
+
+print(sys, hasattr(sys, "__file__"))
+import usys
+
+print(usys, hasattr(usys, "__file__"))
+
+# This should get os.py, which uses uos to get the builtin.
+import os
+
+print(os, hasattr(os, "__file__"), os.sep, os.extra)
+
+# This should get time.py, which uses empty sys.path to get the builtin.
+import time
+
+print(time, hasattr(time, "__file__"), time.sleep, time.extra)
+
+# These should get the builtins.
+import uos
+
+print(uos, hasattr(uos, "__file__"), hasattr(uos, "extra"))
+import utime
+
+print(utime, hasattr(utime, "__file__"), hasattr(utime, "extra"))

--- a/tests/import/builtin_ext.py.exp
+++ b/tests/import/builtin_ext.py.exp
@@ -1,0 +1,10 @@
+<module 'sys'> False
+<module 'micropython'> False
+<module 'sys'> False
+<module 'sys'> False
+os from filesystem
+<module 'os' from 'ext/os.py'> True / 1
+time from filesystem
+<module 'time' from 'ext/time.py'> True <function> 1
+<module 'uos'> False False
+<module 'utime'> False False

--- a/tests/import/ext/micropython.py
+++ b/tests/import/ext/micropython.py
@@ -1,0 +1,2 @@
+# micropython is always builtin and cannot be overriden by the filesystem.
+print("ERROR: micropython from filesystem")

--- a/tests/import/ext/os.py
+++ b/tests/import/ext/os.py
@@ -1,0 +1,5 @@
+print("os from filesystem")
+
+from uos import *
+
+extra = 1

--- a/tests/import/ext/sys.py
+++ b/tests/import/ext/sys.py
@@ -1,0 +1,2 @@
+# sys is always builtin and cannot be overriden by the filesystem.
+print("ERROR: sys from filesystem")

--- a/tests/import/ext/time.py
+++ b/tests/import/ext/time.py
@@ -1,0 +1,14 @@
+print("time from filesystem")
+
+# Tests the CPython-compatible / non-u-prefix way of forcing a builtin
+# import.
+import sys
+
+_path = sys.path[:]
+sys.path.clear()
+from time import *
+
+sys.path.extend(_path)
+del _path
+
+extra = 1

--- a/tests/import/ext/usys.py
+++ b/tests/import/ext/usys.py
@@ -1,0 +1,3 @@
+# usys (and any u-prefix) is always builtin and cannot be overriden by the
+# filesystem.
+print("ERROR: usys from filesystem")

--- a/tests/import/import_pkg9.py
+++ b/tests/import/import_pkg9.py
@@ -1,0 +1,16 @@
+# tests that import only sets subpackage attribute on first import
+
+import pkg9
+
+pkg9.mod1()
+pkg9.mod2()
+
+import pkg9.mod1
+
+pkg9.mod1()
+pkg9.mod2()
+
+import pkg9.mod2
+
+pkg9.mod1()
+print(pkg9.mod2.__name__, type(pkg9.mod2).__name__)

--- a/tests/import/pkg9/__init__.py
+++ b/tests/import/pkg9/__init__.py
@@ -1,0 +1,5 @@
+from .mod1 import mod1
+
+
+def mod2():
+    print("mod2")

--- a/tests/import/pkg9/mod1.py
+++ b/tests/import/pkg9/mod1.py
@@ -1,0 +1,2 @@
+def mod1():
+    print("mod1")

--- a/tests/import/pkg9/mod2.py
+++ b/tests/import/pkg9/mod2.py
@@ -1,0 +1,1 @@
+from . import mod2

--- a/tests/unix/extra_coverage.py
+++ b/tests/unix/extra_coverage.py
@@ -96,3 +96,20 @@ print(returns_NULL())
 import frozentest
 
 print(frozentest.__file__)
+
+# test for builtin sub-packages
+from example_package.foo import bar
+
+print(bar)
+bar.f()
+import example_package
+
+print(example_package, example_package.foo, example_package.foo.bar)
+example_package.f()
+example_package.foo.f()
+example_package.foo.bar.f()
+print(bar == example_package.foo.bar)
+from example_package.foo import f as foo_f
+
+foo_f()
+print(foo_f == example_package.foo.f)

--- a/tests/unix/extra_coverage.py.exp
+++ b/tests/unix/extra_coverage.py.exp
@@ -52,13 +52,14 @@ mport
 
 builtins        micropython     _thread         _uasyncio
 btree           cexample        cmath           cppexample
-ffi             framebuf        gc              math
-termios         uarray          ubinascii       ucollections
-ucryptolib      uctypes         uerrno          uhashlib
-uheapq          uio             ujson           umachine
-uos             urandom         ure             uselect
-usocket         ussl            ustruct         usys
-utime           utimeq          uwebsocket      uzlib
+example_package                 ffi             framebuf
+gc              math            termios         uarray
+ubinascii       ucollections    ucryptolib      uctypes
+uerrno          uhashlib        uheapq          uio
+ujson           umachine        uos             urandom
+ure             uselect         usocket         ussl
+ustruct         usys            utime           utimeq
+uwebsocket      uzlib
 ime
 
 utime           utimeq
@@ -211,3 +212,13 @@ b'bytes 1234\x01'
 2
 3
 frozentest.py
+example_package.__init__
+<module 'example_package.foo.bar'>
+example_package.foo.bar.f
+<module 'example_package'> <module 'example_package.foo'> <module 'example_package.foo.bar'>
+example_package.f
+example_package.foo.f
+example_package.foo.bar.f
+True
+example_package.foo.f
+True


### PR DESCRIPTION
See #5701 (v2), #4731 (v1), and https://github.com/adafruit/circuitpython/pull/2657 (inspiration for v2 & v3).

There are two parts. See the commit messages for more details.
 - Rework the import mechanism slightly to make sub-package importing generally a bit easier to follow and not do so many stats. This also gives a small code size improvement.
 - Simple addition to allow a built-in module to add a sub-module to its globals dict.

One area from the first commit is worth digging into... We've discussed many times the future of the feature-formerly-known-as-weak-links. I still strongly feel that we should remove weak links and u-prefixed modules. See recent discussion in #9018 (and PR in #9069). One of the sticking points was that u-modules provide a mechanism to extend built-in modules. I proposed a few alternative options in #9018, including a generic mechanism that also allows extending filesystem modules, however this PR gives a new option thanks to fixing the CPython incompatibility with sys.path. If you do, e.g. in `os.py`

```py
saved_path = sys.path[:]
sys.path.clear()
try:
  from os import *
finally:
  sys.path.extend(saved_path)
  del saved_path
```

then this will force the import to be from the built-in.

Edit: See https://github.com/micropython/micropython/pull/11456#issuecomment-1545297629 for a summary of changes of behavior relative to v1.20.