### PR TITLE
esp32,esp8266: Change network.WLAN from a function to a type.

### DIFF
--- a/ports/esp32/modnetwork.h
+++ b/ports/esp32/modnetwork.h
@@ -45,6 +45,8 @@ typedef struct _wlan_if_obj_t {
     int if_id;
 } wlan_if_obj_t;
 
+extern const mp_obj_type_t esp_network_wlan_type;
+
 MP_DECLARE_CONST_FUN_OBJ_0(esp_network_initialize_obj);
 MP_DECLARE_CONST_FUN_OBJ_VAR_BETWEEN(esp_network_get_wlan_obj);
 MP_DECLARE_CONST_FUN_OBJ_KW(esp_network_get_lan_obj);

--- a/ports/esp32/modnetwork_globals.h
+++ b/ports/esp32/modnetwork_globals.h
@@ -1,7 +1,7 @@
 { MP_ROM_QSTR(MP_QSTR___init__), MP_ROM_PTR(&esp_network_initialize_obj) },
 
 #if MICROPY_PY_NETWORK_WLAN
-{ MP_ROM_QSTR(MP_QSTR_WLAN), MP_ROM_PTR(&esp_network_get_wlan_obj) },
+{ MP_ROM_QSTR(MP_QSTR_WLAN), MP_ROM_PTR(&esp_network_wlan_type) },
 #endif
 
 #if MICROPY_PY_NETWORK_LAN

--- a/ports/esp32/network_wlan.c
+++ b/ports/esp32/network_wlan.c
@@ -171,7 +171,9 @@ void esp_initialise_wifi() {
     }
 }
 
-STATIC mp_obj_t get_wlan(size_t n_args, const mp_obj_t *args) {
+STATIC mp_obj_t network_wlan_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *args) {
+    mp_arg_check_num(n_args, n_kw, 0, 1, false);
+
     esp_initialise_wifi();
 
     int idx = (n_args > 0) ? mp_obj_get_int(args[0]) : WIFI_IF_STA;
@@ -183,7 +185,6 @@ STATIC mp_obj_t get_wlan(size_t n_args, const mp_obj_t *args) {
         mp_raise_ValueError(MP_ERROR_TEXT("invalid WLAN interface identifier"));
     }
 }
-MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(esp_network_get_wlan_obj, 0, 1, get_wlan);
 
 STATIC mp_obj_t network_wlan_active(size_t n_args, const mp_obj_t *args) {
     wlan_if_obj_t *self = MP_OBJ_TO_PTR(args[0]);
@@ -646,13 +647,14 @@ STATIC const mp_rom_map_elem_t wlan_if_locals_dict_table[] = {
 STATIC MP_DEFINE_CONST_DICT(wlan_if_locals_dict, wlan_if_locals_dict_table);
 
 MP_DEFINE_CONST_OBJ_TYPE(
-    wlan_if_type,
+    esp_network_wlan_type,
     MP_QSTR_WLAN,
     MP_TYPE_FLAG_NONE,
+    make_new, network_wlan_make_new,
     locals_dict, &wlan_if_locals_dict
     );
 
-STATIC const wlan_if_obj_t wlan_sta_obj = {{&wlan_if_type}, WIFI_IF_STA};
-STATIC const wlan_if_obj_t wlan_ap_obj = {{&wlan_if_type}, WIFI_IF_AP};
+STATIC const wlan_if_obj_t wlan_sta_obj = {{&esp_network_wlan_type}, WIFI_IF_STA};
+STATIC const wlan_if_obj_t wlan_ap_obj = {{&esp_network_wlan_type}, WIFI_IF_AP};
 
 #endif // MICROPY_PY_NETWORK_WLAN

--- a/ports/esp8266/modnetwork.h
+++ b/ports/esp8266/modnetwork.h
@@ -1,2 +1,3 @@
-MP_DECLARE_CONST_FUN_OBJ_VAR_BETWEEN(esp_network_get_wlan_obj);
+extern const mp_obj_type_t esp_network_wlan_type;
+
 MP_DECLARE_CONST_FUN_OBJ_VAR_BETWEEN(esp_network_phy_mode_obj);

--- a/ports/esp8266/modnetwork_globals.h
+++ b/ports/esp8266/modnetwork_globals.h
@@ -1,4 +1,4 @@
-{ MP_ROM_QSTR(MP_QSTR_WLAN), MP_ROM_PTR(&esp_network_get_wlan_obj) },
+{ MP_ROM_QSTR(MP_QSTR_WLAN), MP_ROM_PTR(&esp_network_wlan_type) },
 { MP_ROM_QSTR(MP_QSTR_phy_mode), MP_ROM_PTR(&esp_network_phy_mode_obj) },
 
 { MP_ROM_QSTR(MP_QSTR_STA_IF), MP_ROM_INT(STATION_IF)},

--- a/ports/esp8266/network_wlan.c
+++ b/ports/esp8266/network_wlan.c
@@ -39,6 +39,7 @@
 #include "spi_flash.h"
 #include "ets_alt_task.h"
 #include "lwip/dns.h"
+#include "modnetwork.h"
 
 typedef struct _wlan_if_obj_t {
     mp_obj_base_t base;
@@ -46,11 +47,10 @@ typedef struct _wlan_if_obj_t {
 } wlan_if_obj_t;
 
 void error_check(bool status, const char *msg);
-const mp_obj_type_t wlan_if_type;
 
 STATIC const wlan_if_obj_t wlan_objs[] = {
-    {{&wlan_if_type}, STATION_IF},
-    {{&wlan_if_type}, SOFTAP_IF},
+    {{&esp_network_wlan_type}, STATION_IF},
+    {{&esp_network_wlan_type}, SOFTAP_IF},
 };
 
 STATIC void require_if(mp_obj_t wlan_if, int if_no) {
@@ -60,7 +60,8 @@ STATIC void require_if(mp_obj_t wlan_if, int if_no) {
     }
 }
 
-STATIC mp_obj_t get_wlan(size_t n_args, const mp_obj_t *args) {
+STATIC mp_obj_t esp_wlan_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *args) {
+    mp_arg_check_num(n_args, n_kw, 0, 1, false);
     int idx = 0;
     if (n_args > 0) {
         idx = mp_obj_get_int(args[0]);
@@ -70,7 +71,6 @@ STATIC mp_obj_t get_wlan(size_t n_args, const mp_obj_t *args) {
     }
     return MP_OBJ_FROM_PTR(&wlan_objs[idx]);
 }
-MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(esp_network_get_wlan_obj, 0, 1, get_wlan);
 
 STATIC mp_obj_t esp_active(size_t n_args, const mp_obj_t *args) {
     wlan_if_obj_t *self = MP_OBJ_TO_PTR(args[0]);
@@ -529,9 +529,10 @@ STATIC const mp_rom_map_elem_t wlan_if_locals_dict_table[] = {
 STATIC MP_DEFINE_CONST_DICT(wlan_if_locals_dict, wlan_if_locals_dict_table);
 
 MP_DEFINE_CONST_OBJ_TYPE(
-    wlan_if_type,
+    esp_network_wlan_type,
     MP_QSTR_WLAN,
     MP_TYPE_FLAG_NONE,
+    make_new, esp_wlan_make_new,
     locals_dict, &wlan_if_locals_dict
     );
 


### PR DESCRIPTION
When the network module was first introduced in the esp8266 port in ee3fec3167db6e28869d37fb60058c884fb36264 there was only one interface (STA) and, to save flash, the WLAN object was aliased to the network module, which had just static methods for WLAN operations.  This was subsequently changed in 9e8396accbcb695e2fe9def666bfb31b26efde06 when the AP interface was introduced, and the WLAN object became a true class.

But, network.WLAN remained a function that returned either the STA or AP object and was never upgraded to the type itself.  This scheme was then copied over to the esp32 port when it was first introduced.

This commit changes network.WLAN from a function to a reference to the WLAN type.  This makes it consistent with other ports and network objects, and allows accessing constants of network.WLAN without creating an instance.