### PR TITLE
tools/mpremote: Improve speed of echoing device data to console.

### DIFF
--- a/docs/reference/mpremote.rst
+++ b/docs/reference/mpremote.rst
@@ -92,6 +92,7 @@ The full list of supported commands are:
 
   Options are:
 
+  - ``--escape-non-printable``, to print non-printable bytes/characters as their hex code
   - ``--capture <file>``, to capture output of the REPL session to the given
     file
   - ``--inject-code <string>``, to specify characters to inject at the REPL when

--- a/tools/mpremote/mpremote/main.py
+++ b/tools/mpremote/mpremote/main.py
@@ -119,6 +119,7 @@ def argparse_mount():
 
 def argparse_repl():
     cmd_parser = argparse.ArgumentParser(description="connect to given device")
+    _bool_flag(cmd_parser, "escape-non-printable", "e", False, "escape non-printable characters")
     cmd_parser.add_argument(
         "--capture",
         type=str,


### PR DESCRIPTION
By reading and writing in chunks.

When connected to a device that is constantly outputting data, this gets mpremote CPU usage down from about 90% to 5% (on my local machine).