### PR TITLE
tests/run-tests.py: Ensure correct cwd for mpy tests.

### DIFF
--- a/tests/io/file1.py
+++ b/tests/io/file1.py
@@ -1,20 +1,20 @@
-f = open("io/data/file1")
+f = open("data/file1")
 print(f.read(5))
 print(f.readline())
 print(f.read())
-f = open("io/data/file1")
+f = open("data/file1")
 print(f.readlines())
-f = open("io/data/file1", "r")
+f = open("data/file1", "r")
 print(f.readlines())
-f = open("io/data/file1", "rb")
+f = open("data/file1", "rb")
 print(f.readlines())
-f = open("io/data/file1", mode="r")
+f = open("data/file1", mode="r")
 print(f.readlines())
-f = open("io/data/file1", mode="rb")
+f = open("data/file1", mode="rb")
 print(f.readlines())
 
 # write() error
-f = open("io/data/file1", "r")
+f = open("data/file1", "r")
 try:
     f.write("x")
 except OSError:
@@ -22,7 +22,7 @@ except OSError:
 f.close()
 
 # read(n) error on binary file
-f = open("io/data/file1", "ab")
+f = open("data/file1", "ab")
 try:
     f.read(1)
 except OSError:
@@ -30,7 +30,7 @@ except OSError:
 f.close()
 
 # read(n) error on text file
-f = open("io/data/file1", "at")
+f = open("data/file1", "at")
 try:
     f.read(1)
 except OSError:
@@ -38,7 +38,7 @@ except OSError:
 f.close()
 
 # read() w/o args error
-f = open("io/data/file1", "ab")
+f = open("data/file1", "ab")
 try:
     f.read()
 except OSError:

--- a/tests/io/file_iter.py
+++ b/tests/io/file_iter.py
@@ -1,3 +1,3 @@
-f = open("io/data/file1")
+f = open("data/file1")
 for l in f:
     print(l)

--- a/tests/io/file_long_read.py
+++ b/tests/io/file_long_read.py
@@ -1,3 +1,3 @@
-f = open("io/data/file1")
+f = open("data/file1")
 b = f.read(100)
 print(len(b))

--- a/tests/io/file_long_read2.py
+++ b/tests/io/file_long_read2.py
@@ -1,4 +1,4 @@
-f = open("io/data/bigfile1")
+f = open("data/bigfile1")
 b = f.read()
 print(len(b))
 print(b)

--- a/tests/io/file_long_read3.py
+++ b/tests/io/file_long_read3.py
@@ -1,4 +1,4 @@
-f = open("io/data/bigfile1", "rb")
+f = open("data/bigfile1", "rb")
 b = f.read(512)
 print(len(b))
 print(b)

--- a/tests/io/file_readinto.py
+++ b/tests/io/file_readinto.py
@@ -1,13 +1,13 @@
 b = bytearray(30)
-f = open("io/data/file1", "rb")
+f = open("data/file1", "rb")
 print(f.readinto(b))
 print(b)
-f = open("io/data/file2", "rb")
+f = open("data/file2", "rb")
 print(f.readinto(b))
 print(b)
 
 # readinto() on writable file
-f = open("io/data/file1", "ab")
+f = open("data/file1", "ab")
 try:
     f.readinto(bytearray(4))
 except OSError:

--- a/tests/io/file_readinto_len.py
+++ b/tests/io/file_readinto_len.py
@@ -1,10 +1,10 @@
 b = bytearray(30)
-f = open("io/data/file1", "rb")
+f = open("data/file1", "rb")
 # 2nd arg (length to read) is extension to CPython
 print(f.readinto(b, 8))
 print(b)
 
 b = bytearray(4)
-f = open("io/data/file1", "rb")
+f = open("data/file1", "rb")
 print(f.readinto(b, 8))
 print(b)

--- a/tests/io/file_readline.py
+++ b/tests/io/file_readline.py
@@ -1,4 +1,4 @@
-f = open("io/data/file1")
+f = open("data/file1")
 print(f.readline())
 print(f.readline(3))
 print(f.readline(4))
@@ -6,7 +6,7 @@ print(f.readline(5))
 print(f.readline())
 
 # readline() on writable file
-f = open("io/data/file1", "ab")
+f = open("data/file1", "ab")
 try:
     f.readline()
 except OSError:

--- a/tests/io/file_seek.py
+++ b/tests/io/file_seek.py
@@ -1,4 +1,4 @@
-f = open("io/data/file1", "rb")
+f = open("data/file1", "rb")
 print(f.seek(6))
 print(f.read(5))
 print(f.tell())
@@ -18,14 +18,14 @@ print(f.tell())
 f.close()
 
 # test text mode
-f = open("io/data/file1", "rt")
+f = open("data/file1", "rt")
 print(f.seek(6))
 print(f.read(5))
 print(f.tell())
 f.close()
 
 # seek closed file
-f = open("io/data/file1", "r")
+f = open("data/file1", "r")
 f.close()
 try:
     f.seek(1)

--- a/tests/io/file_with.py
+++ b/tests/io/file_with.py
@@ -1,4 +1,4 @@
-f = open("io/data/file1")
+f = open("data/file1")
 
 with f as f2:
     print(f2.read())

--- a/tests/unicode/file1.py
+++ b/tests/unicode/file1.py
@@ -1,4 +1,4 @@
-f = open("unicode/data/utf-8_1.txt", encoding="utf-8")
+f = open("data/utf-8_1.txt", encoding="utf-8")
 l = f.readline()
 print(l)
 print(len(l))

--- a/tests/unicode/file2.py
+++ b/tests/unicode/file2.py
@@ -6,7 +6,7 @@ def do(mode):
         enc = None
     else:
         enc = "utf-8"
-    f = open("unicode/data/utf-8_2.txt", mode=mode, encoding=enc)
+    f = open("data/utf-8_2.txt", mode=mode, encoding=enc)
     print(f.read(1))
     print(f.read(1))
     print(f.read(2))

--- a/tests/unicode/file_invalid.py
+++ b/tests/unicode/file_invalid.py
@@ -1,5 +1,5 @@
 try:
-    f = open("unicode/data/utf-8_invalid.txt", encoding="utf-8")
+    f = open("data/utf-8_invalid.txt", encoding="utf-8")
     f.read()
 except UnicodeError:
     print("UnicodeError")


### PR DESCRIPTION
This is necessary for #11456 which currently fails the --via-mpy tests due `import micropython` now attempting to import tests/micropython, but I think it's overall a good fix to improve consistency anyway.

Previously when using --via-mpy, the file was compiled to tests/<tmp>.mpy and then run using `micropython -m <tmp>` in the current cwd (usually tests/). This meant that an import in the test would be resolved relative to tests/.

This is different to regular (non-via-mpy) tests, where we run (for example) `micropython basics/test.py` which means that an import would be resolved relative to basics/.

Now --via-mpy matches the .py behavior. This is important because: a) It makes it so import tests do the right thing. b) There are directory names in tests/ that match built-in module names.

Furthermore, it always ensures the cwd (for both micropython and cpython) is the test directory (e.g. basics/) rather than being left unset. This also makes it clearer inside the test that e.g. file access is relative to the Python file. Updated tests with file paths to match.

_This work was funded through GitHub Sponsors._