### PR TITLE
stm32/mboot: Fix packed final buffer alignment.

### DIFF
--- a/ports/stm32/mboot/pack.c
+++ b/ports/stm32/mboot/pack.c
@@ -59,7 +59,7 @@ static uint8_t uncompressed_buf[MBOOT_PACK_GZIP_BUFFER_SIZE] __attribute__((alig
 // Buffer to hold the start of the firmware, which is only written once the
 // entire firmware is validated.  This is 8 bytes due to STM32WB MCUs requiring
 // that a double-word write to flash can only be done once (due to ECC).
-static uint8_t firmware_head[8];
+static uint8_t firmware_head[8] __attribute__((aligned(8)));
 
 // Flag to indicate that firmware_head contains valid data.
 static bool firmware_head_valid;


### PR DESCRIPTION
When using encrypted/signed bootloader on STM32WB55 there's a good chance mboot will always lock up in the final stage of flashing a dfu.
```
$ python ~/micropython/tools/pydfu.py -u  ~/proj/build-NUCLEO_WB55/firmware.pack.dfu
File: /home/anl/proj/build-NUCLEO_WB55/firmware.pack.dfu
    b'DfuSe' v1, image size: 337685, targets: 1
    b'Target' 0, alt setting: 0, name: "ST...", size: 337400, elements: 31
      0, address: 0x08008000, size: 12944
      1, address: 0x0800c000, size: 12136
      2, address: 0x08010000, size: 11864
      3, address: 0x08014000, size: 12992
      4, address: 0x08018000, size: 12448
      5, address: 0x0801c000, size: 12720
      6, address: 0x08020000, size: 11832
      7, address: 0x08024000, size: 12792
      8, address: 0x08028000, size: 12832
      9, address: 0x0802c000, size: 13336
      10, address: 0x08030000, size: 13168
      11, address: 0x08034000, size: 12256
      12, address: 0x08038000, size: 12464
      13, address: 0x0803c000, size: 12224
      14, address: 0x08040000, size: 12120
      15, address: 0x08044000, size: 11888
      16, address: 0x08048000, size: 11592
      17, address: 0x0804c000, size: 12824
      18, address: 0x08050000, size: 11784
      19, address: 0x08054000, size: 9776
      20, address: 0x08058000, size: 9872
      21, address: 0x0805c000, size: 7688
      22, address: 0x08060000, size: 9616
      23, address: 0x08064000, size: 10952
      24, address: 0x08068000, size: 10400
      25, address: 0x0806c000, size: 10408
      26, address: 0x08070000, size: 10144
      27, address: 0x08074000, size: 11200
      28, address: 0x08078000, size: 7928
      29, address: 0x0807c000, size: 2800
      30, address: 0x08080000, size: 152
    usb: 30c4:0412, device: 0x0000, dfu: 0x011a, b'UFD', 16, 0x0c529f79
Writing memory...
0x08008000   12944 [=========================] 100%
0x0800c000   12136 [=========================] 100%
0x08010000   11864 [=========================] 100%
0x08014000   12992 [=========================] 100%
0x08018000   12448 [=========================] 100%
0x0801c000   12720 [=========================] 100%
0x08020000   11832 [=========================] 100%
0x08024000   12792 [=========================] 100%
0x08028000   12832 [=========================] 100%
0x0802c000   13336 [=========================] 100%
0x08030000   13168 [=========================] 100%
0x08034000   12256 [=========================] 100%
0x08038000   12464 [=========================] 100%
0x0803c000   12224 [=========================] 100%
0x08040000   12120 [=========================] 100%
0x08044000   11888 [=========================] 100%
0x08048000   11592 [=========================] 100%
0x0804c000   12824 [=========================] 100%
0x08050000   11784 [=========================] 100%
0x08054000    9776 [=========================] 100%
0x08058000    9872 [=========================] 100%
0x0805c000    7688 [=========================] 100%
0x08060000    9616 [=========================] 100%
0x08064000   10952 [=========================] 100%
0x08068000   10400 [=========================] 100%
0x0806c000   10408 [=========================] 100%
0x08070000   10144 [=========================] 100%
0x08074000   11200 [=========================] 100%
0x08078000    7928 [=========================] 100%
0x0807c000    2800 [=========================] 100%
0x08080000     152 [                         ]   0%
```

Once all the firmware has been flashed and the final signatures checked, mboot writes the "all good" byte into the header of the application. This step uses the buffer `firmware_head` which, if unaligned in the build, fails when cast to a 64bit pointer in `flash.c`
``` C
    // program the flash uint64 by uint64
    for (int i = 0; i < num_word32 / 2; i++) {
        uint64_t val = *(uint64_t *)src;
```

