### PR TITLE
py: Improve support for inplace operators

### DIFF
--- a/py/objarray.c
+++ b/py/objarray.c
@@ -292,6 +292,12 @@ STATIC mp_obj_t array_binary_op(mp_binary_op_t op, mp_obj_t lhs_in, mp_obj_t rhs
     mp_obj_array_t *lhs = MP_OBJ_TO_PTR(lhs_in);
     switch (op) {
         case MP_BINARY_OP_ADD: {
+            #if MICROPY_PY_BUILTINS_MEMORYVIEW
+            if (lhs->base.type == &mp_type_memoryview) {
+                return MP_OBJ_NULL; // op not supported
+            }
+            #endif
+
             // allow to add anything that has the buffer protocol (extension to CPython)
             mp_buffer_info_t lhs_bufinfo;
             mp_buffer_info_t rhs_bufinfo;

--- a/py/objstr.c
+++ b/py/objstr.c
@@ -403,7 +403,16 @@ mp_obj_t mp_obj_str_binary_op(mp_binary_op_t op, mp_obj_t lhs_in, mp_obj_t rhs_i
     } else {
         // LHS is str and RHS has an incompatible type
         // (except if operation is EQUAL, but that's handled by mp_obj_equal)
-        bad_implicit_conversion(rhs_in);
+
+        // CONTAINS must fail with a bad-implicit-conversion exception, because
+        // otherwise mp_binary_op() will fallback to `list(lhs).__contains__(rhs)`.
+        if (op == MP_BINARY_OP_CONTAINS) {
+            bad_implicit_conversion(rhs_in);
+        }
+
+        // All other operations are not supported, and may be handled by another
+        // type, eg for reverse operations.
+        return MP_OBJ_NULL;
     }
 
     switch (op) {

--- a/py/objtype.c
+++ b/py/objtype.c
@@ -534,7 +534,6 @@ STATIC mp_obj_t instance_binary_op(mp_binary_op_t op, mp_obj_t lhs_in, mp_obj_t 
     // Note: For ducktyping, CPython does not look in the instance members or use
     // __getattr__ or __getattribute__.  It only looks in the class dictionary.
     mp_obj_instance_t *lhs = MP_OBJ_TO_PTR(lhs_in);
-retry:;
     qstr op_name = mp_binary_op_method_name[op];
     /* Still try to lookup native slot
     if (op_name == 0) {
@@ -559,22 +558,12 @@ retry:;
         res = mp_call_method_n_kw(1, 0, dest);
         res = op == MP_BINARY_OP_CONTAINS ? mp_obj_new_bool(mp_obj_is_true(res)) : res;
     } else {
-        // If this was an inplace method, fallback to normal method
-        // https://docs.python.org/3/reference/datamodel.html#object.__iadd__ :
-        // "If a specific method is not defined, the augmented assignment
-        // falls back to the normal methods."
-        if (op >= MP_BINARY_OP_INPLACE_OR && op <= MP_BINARY_OP_INPLACE_POWER) {
-            op -= MP_BINARY_OP_INPLACE_OR - MP_BINARY_OP_OR;
-            goto retry;
-        }
         return MP_OBJ_NULL; // op not supported
     }
 
     #if MICROPY_PY_BUILTINS_NOTIMPLEMENTED
     // NotImplemented means "try other fallbacks (like calling __rop__
-    // instead of __op__) and if nothing works, raise TypeError". As
-    // MicroPython doesn't implement any fallbacks, signal to raise
-    // TypeError right away.
+    // instead of __op__) and if nothing works, raise TypeError".
     if (res == mp_const_notimplemented) {
         return MP_OBJ_NULL; // op not supported
     }

--- a/py/runtime.c
+++ b/py/runtime.c
@@ -625,6 +625,15 @@ generic_binary_op:
         }
     }
 
+    // If this was an inplace method, fallback to the corresponding normal method.
+    // https://docs.python.org/3/reference/datamodel.html#object.__iadd__ :
+    // "If a specific method is not defined, the augmented assignment falls back
+    // to the normal methods."
+    if (op >= MP_BINARY_OP_INPLACE_OR && op <= MP_BINARY_OP_INPLACE_POWER) {
+        op += MP_BINARY_OP_OR - MP_BINARY_OP_INPLACE_OR;
+        goto generic_binary_op;
+    }
+
     #if MICROPY_PY_REVERSE_SPECIAL_METHODS
     if (op >= MP_BINARY_OP_OR && op <= MP_BINARY_OP_POWER) {
         mp_obj_t t = rhs;

--- a/tests/basics/class_reverse_op.py
+++ b/tests/basics/class_reverse_op.py
@@ -1,5 +1,7 @@
-class A:
+# Test reverse operators.
 
+# Test user type with integers.
+class A:
     def __init__(self, v):
         self.v = v
 
@@ -14,5 +16,33 @@ class A:
     def __repr__(self):
         return "A({})".format(self.v)
 
+
 print(A(3) + 1)
 print(2 + A(5))
+
+
+# Test user type with strings.
+class B:
+    def __init__(self, v):
+        self.v = v
+
+    def __repr__(self):
+        return "B({})".format(self.v)
+
+    def __ror__(self, o):
+        return B(o + "|" + self.v)
+
+    def __radd__(self, o):
+        return B(o + "+" + self.v)
+
+    def __rmul__(self, o):
+        return B(o + "*" + self.v)
+
+    def __rtruediv__(self, o):
+        return B(o + "/" + self.v)
+
+
+print("a" | B("b"))
+print("a" + B("b"))
+print("a" * B("b"))
+print("a" / B("b"))

--- a/tests/basics/class_reverse_op.py
+++ b/tests/basics/class_reverse_op.py
@@ -46,3 +46,8 @@ print("a" | B("b"))
 print("a" + B("b"))
 print("a" * B("b"))
 print("a" / B("b"))
+
+x = "a"; x |= B("b"); print(x)
+x = "a"; x += B("b"); print(x)
+x = "a"; x *= B("b"); print(x)
+x = "a"; x /= B("b"); print(x)

--- a/tests/basics/list_mult.py
+++ b/tests/basics/list_mult.py
@@ -11,6 +11,16 @@ a = [1, 2, 3]
 c = a * 3
 print(a, c)
 
+# check inplace multiplication
+a = [4, 5, 6]
+a *= 3
+print(a)
+
+# check reverse inplace multiplication
+a = 3
+a *= [7, 8, 9]
+print(a)
+
 # unsupported type on RHS
 try:
     [] * None

--- a/tests/basics/op_error_memoryview.py
+++ b/tests/basics/op_error_memoryview.py
@@ -7,7 +7,17 @@ except:
 
 # unsupported binary operators
 try:
+    memoryview(b"") + b""
+except TypeError:
+    print("TypeError")
+
+try:
+    memoryview(b"") + memoryview(b"")
+except TypeError:
+    print("TypeError")
+
+try:
     m = memoryview(bytearray())
     m += bytearray()
 except TypeError:
-    print('TypeError')
+    print("TypeError")

--- a/tests/basics/string_mult.py
+++ b/tests/basics/string_mult.py
@@ -10,3 +10,13 @@ for i in (-4, -2, 0, 2, 4):
 a = '123'
 c = a * 3
 print(a, c)
+
+# check inplace multiplication
+a = '456'
+a *= 3
+print(a)
+
+# check reverse inplace multiplication
+a = 3
+a *= '789'
+print(a)


### PR DESCRIPTION
This improves core support for inplace operators, both on built-in types and user classes.

It's an alternative to #10844 that is more comprehensive.  The Python snippets in that PR (in particular reverse inplace division) will now work, with the patches in this PR.

There are three distinct changes/improvements here:
1. disallow addition of memoryview objects; this is compatible with CPython, and is needed to keep the existing test suit passing with the other two changes
2. make it so str objects don't prematurely raise TypeError if the arguments to a binary operation (eg +) are not both str
3. the code that handles inplace -> normal binary operator fallback, move it from `py/objtype.c` to `py/runtime.c`, making it apply to all types, not just user classes