### PR TITLE
ports/esp32/uart.c: UART clock source on S3 C3

### DIFF
--- a/ports/esp32/machine_uart.c
+++ b/ports/esp32/machine_uart.c
@@ -319,6 +319,10 @@ STATIC mp_obj_t machine_uart_make_new(const mp_obj_type_t *type, size_t n_args, 
         .flow_ctrl = UART_HW_FLOWCTRL_DISABLE,
         .rx_flow_ctrl_thresh = 0
     };
+    #if SOC_UART_SUPPORT_XTAL_CLK
+    // works independently of APB frequency
+    uartcfg.source_clk = UART_SCLK_XTAL; // ESP32C3, ESP32S3
+    #endif
 
     // create instance
     machine_uart_obj_t *self = mp_obj_malloc(machine_uart_obj_t, &machine_uart_type);

--- a/ports/esp32/uart.c
+++ b/ports/esp32/uart.c
@@ -46,6 +46,10 @@ void uart_stdout_init(void) {
         .flow_ctrl = UART_HW_FLOWCTRL_DISABLE,
         .rx_flow_ctrl_thresh = 0
     };
+    #if SOC_UART_SUPPORT_XTAL_CLK
+    // works independently of APB frequency
+    uartcfg.source_clk = UART_SCLK_XTAL; // ESP32C3, ESP32S3
+    #endif
     uart_param_config(MICROPY_HW_UART_REPL, &uartcfg);
 
     const uint32_t rxbuf = 129; // IDF requires > 128 min


### PR DESCRIPTION
Change UART clock source on S3/C3 so UART can operate when CPU frequency is below 80MHz.

This change allows the UART to remain operational when using DFS (Dynamic Frequency Scaling).

See also:
https://github.com/espressif/arduino-esp32/pull/7496/files