### PR TITLE
extmod/machine_spi.c: Support firstbit=machine.LSB for machine.SoftSPI.

### DIFF
--- a/drivers/bus/softspi.c
+++ b/drivers/bus/softspi.c
@@ -44,11 +44,17 @@ int mp_soft_spi_ioctl(void *self_in, uint32_t cmd) {
     return 0;
 }
 
+static uint8_t swap_bits(uint8_t byte) {
+    const static uint8_t swap_table[16] = {
+        0x00, 0x08, 0x04, 0x0c, 0x02, 0x0a, 0x06, 0x0e,
+        0x01, 0x09, 0x05, 0x0d, 0x03, 0x0b, 0x07, 0x0f
+    };
+    return ((swap_table[byte & 0x0f] << 4) | swap_table[byte >> 4]);
+}
+
 void mp_soft_spi_transfer(void *self_in, size_t len, const uint8_t *src, uint8_t *dest) {
     mp_soft_spi_obj_t *self = (mp_soft_spi_obj_t*)self_in;
     uint32_t delay_half = self->delay_half;
-
-    // only MSB transfer is implemented
 
     // If a port defines MICROPY_HW_SOFTSPI_MIN_DELAY, and the configured
     // delay_half is equal to this value, then the software SPI implementation
@@ -56,75 +62,49 @@ void mp_soft_spi_transfer(void *self_in, size_t len, const uint8_t *src, uint8_t
     #ifdef MICROPY_HW_SOFTSPI_MIN_DELAY
     if (delay_half == MICROPY_HW_SOFTSPI_MIN_DELAY) {
         for (size_t i = 0; i < len; ++i) {
-            uint8_t data_out = src[i];
+            uint8_t data_out = self->firstbit != MICROPY_PY_MACHINE_SPI_MSB ?
+                src[i] : swap_bits(src[i]);
             uint8_t data_in = 0;
-        if (self->firstbit == MICROPY_PY_MACHINE_SPI_MSB) {
-                for (int j = 0; j < 8; ++j, data_out <<= 1) {
-                    mp_hal_pin_write(self->mosi, (data_out >> 7) & 1);
-                    mp_hal_pin_write(self->sck, 1 - self->polarity);
-                    data_in = (data_in << 1) | mp_hal_pin_read(self->miso);
-                    mp_hal_pin_write(self->sck, self->polarity);
-                }
-        } else {  // MICROPY_PY_MACHINE_SPI_LSB
-                for (int j = 0; j < 8; ++j, data_out >>= 1) {
-                    mp_hal_pin_write(self->mosi, data_out & 1);
-                    mp_hal_pin_write(self->sck, 1 - self->polarity);
-                    data_in = (data_in >> 1) | (mp_hal_pin_read(self->miso) << 7);
-                    mp_hal_pin_write(self->sck, self->polarity);
-                }
-        } 
-        if (dest != NULL) {
-            dest[i] = data_in;
-        }
+            for (int j = 0; j < 8; ++j, data_out >>= 1) {
+                mp_hal_pin_write(self->mosi, data_out & 1);
+                mp_hal_pin_write(self->sck, 1 - self->polarity);
+                data_in = (data_in << 1) | mp_hal_pin_read(self->miso);
+                mp_hal_pin_write(self->sck, self->polarity);
+            }
+            if (dest != NULL) {
+                dest[i] = self->firstbit == MICROPY_PY_MACHINE_SPI_MSB ?
+                    data_in : swap_bits(data_in);
+            }
         }
         return;
     }
     #endif
 
     for (size_t i = 0; i < len; ++i) {
-        uint8_t data_out = src[i];
+        uint8_t data_out = self->firstbit != MICROPY_PY_MACHINE_SPI_MSB ?
+            src[i] : swap_bits(src[i]);
         uint8_t data_in = 0;
-        if (self->firstbit == MICROPY_PY_MACHINE_SPI_MSB) {
-            for (int j = 0; j < 8; ++j, data_out <<= 1) {
-                mp_hal_pin_write(self->mosi, (data_out >> 7) & 1);
-                if (self->phase == 0) {
-                    mp_hal_delay_us_fast(delay_half);
-                    mp_hal_pin_write(self->sck, 1 - self->polarity);
-                } else {
-                    mp_hal_pin_write(self->sck, 1 - self->polarity);
-                    mp_hal_delay_us_fast(delay_half);
-                }
-                data_in = (data_in << 1) | mp_hal_pin_read(self->miso);
-                if (self->phase == 0) {
-                    mp_hal_delay_us_fast(delay_half);
-                    mp_hal_pin_write(self->sck, self->polarity);
-                } else {
-                    mp_hal_pin_write(self->sck, self->polarity);
-                    mp_hal_delay_us_fast(delay_half);
-                }
+        for (int j = 0; j < 8; ++j, data_out >>= 1) {
+            mp_hal_pin_write(self->mosi, data_out & 1);
+            if (self->phase == 0) {
+                mp_hal_delay_us_fast(delay_half);
+                mp_hal_pin_write(self->sck, 1 - self->polarity);
+            } else {
+                mp_hal_pin_write(self->sck, 1 - self->polarity);
+                mp_hal_delay_us_fast(delay_half);
             }
-        } else {  // MICROPY_PY_MACHINE_SPI_LSB
-            for (int j = 0; j < 8; ++j, data_out >>= 1) {
-                mp_hal_pin_write(self->mosi, data_out & 1);
-                if (self->phase == 0) {
-                    mp_hal_delay_us_fast(delay_half);
-                    mp_hal_pin_write(self->sck, 1 - self->polarity);
-                } else {
-                    mp_hal_pin_write(self->sck, 1 - self->polarity);
-                    mp_hal_delay_us_fast(delay_half);
-                }
-                data_in = (data_in >> 1) | (mp_hal_pin_read(self->miso) << 7);
-                if (self->phase == 0) {
-                    mp_hal_delay_us_fast(delay_half);
-                    mp_hal_pin_write(self->sck, self->polarity);
-                } else {
-                    mp_hal_pin_write(self->sck, self->polarity);
-                    mp_hal_delay_us_fast(delay_half);
-                }
+            data_in = (data_in << 1) | mp_hal_pin_read(self->miso);
+            if (self->phase == 0) {
+                mp_hal_delay_us_fast(delay_half);
+                mp_hal_pin_write(self->sck, self->polarity);
+            } else {
+                mp_hal_pin_write(self->sck, self->polarity);
+                mp_hal_delay_us_fast(delay_half);
             }
         }
         if (dest != NULL) {
-            dest[i] = data_in;
+            dest[i] = self->firstbit == MICROPY_PY_MACHINE_SPI_MSB ?
+                data_in : swap_bits(data_in);
         }
     }
 }

--- a/drivers/bus/spi.h
+++ b/drivers/bus/spi.h
@@ -42,6 +42,7 @@ typedef struct _mp_soft_spi_obj_t {
     uint32_t delay_half; // microsecond delay for half SCK period
     uint8_t polarity;
     uint8_t phase;
+    uint8_t firstbit;
     mp_hal_pin_obj_t sck;
     mp_hal_pin_obj_t mosi;
     mp_hal_pin_obj_t miso;

--- a/extmod/machine_spi.c
+++ b/extmod/machine_spi.c
@@ -33,12 +33,6 @@
 
 #include "extmod/modmachine.h"
 
-// if a port didn't define MSB/LSB constants then provide them
-#ifndef MICROPY_PY_MACHINE_SPI_MSB
-#define MICROPY_PY_MACHINE_SPI_MSB (0)
-#define MICROPY_PY_MACHINE_SPI_LSB (1)
-#endif
-
 /******************************************************************************/
 // MicroPython bindings for generic machine.SPI
 
@@ -185,9 +179,8 @@ STATIC mp_obj_t mp_machine_soft_spi_make_new(const mp_obj_type_t *type, size_t n
     if (args[ARG_bits].u_int != 8) {
         mp_raise_ValueError(MP_ERROR_TEXT("bits must be 8"));
     }
-    if (args[ARG_firstbit].u_int != MICROPY_PY_MACHINE_SPI_MSB) {
-        mp_raise_ValueError(MP_ERROR_TEXT("firstbit must be MSB"));
-    }
+    self->spi.firstbit = args[ARG_firstbit].u_int == MICROPY_PY_MACHINE_SPI_MSB ?
+        MICROPY_PY_MACHINE_SPI_MSB : MICROPY_PY_MACHINE_SPI_LSB;
     if (args[ARG_sck].u_obj == MP_OBJ_NULL
         || args[ARG_mosi].u_obj == MP_OBJ_NULL
         || args[ARG_miso].u_obj == MP_OBJ_NULL) {
@@ -206,11 +199,12 @@ STATIC mp_obj_t mp_machine_soft_spi_make_new(const mp_obj_type_t *type, size_t n
 STATIC void mp_machine_soft_spi_init(mp_obj_base_t *self_in, size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
     mp_machine_soft_spi_obj_t *self = (mp_machine_soft_spi_obj_t *)self_in;
 
-    enum { ARG_baudrate, ARG_polarity, ARG_phase, ARG_sck, ARG_mosi, ARG_miso };
+    enum { ARG_baudrate, ARG_polarity, ARG_phase, ARG_firstbit, ARG_sck, ARG_mosi, ARG_miso };
     static const mp_arg_t allowed_args[] = {
         { MP_QSTR_baudrate, MP_ARG_INT, {.u_int = -1} },
         { MP_QSTR_polarity, MP_ARG_INT, {.u_int = -1} },
         { MP_QSTR_phase, MP_ARG_INT, {.u_int = -1} },
+        { MP_QSTR_firstbit, MP_ARG_KW_ONLY | MP_ARG_INT, {.u_int = -1} },
         { MP_QSTR_sck, MP_ARG_KW_ONLY | MP_ARG_OBJ, {.u_obj = MP_OBJ_NULL} },
         { MP_QSTR_mosi, MP_ARG_KW_ONLY | MP_ARG_OBJ, {.u_obj = MP_OBJ_NULL} },
         { MP_QSTR_miso, MP_ARG_KW_ONLY | MP_ARG_OBJ, {.u_obj = MP_OBJ_NULL} },
@@ -226,6 +220,10 @@ STATIC void mp_machine_soft_spi_init(mp_obj_base_t *self_in, size_t n_args, cons
     }
     if (args[ARG_phase].u_int != -1) {
         self->spi.phase = args[ARG_phase].u_int;
+    }
+    if (args[ARG_firstbit].u_int != -1) {
+        self->spi.firstbit = args[ARG_firstbit].u_int == MICROPY_PY_MACHINE_SPI_MSB ?
+            MICROPY_PY_MACHINE_SPI_MSB : MICROPY_PY_MACHINE_SPI_LSB;
     }
     if (args[ARG_sck].u_obj != MP_OBJ_NULL) {
         self->spi.sck = mp_hal_get_pin_obj(args[ARG_sck].u_obj);

--- a/ports/esp32/mpconfigport.h
+++ b/ports/esp32/mpconfigport.h
@@ -119,8 +119,6 @@
 #define MICROPY_PY_MACHINE_I2C_TRANSFER_WRITE1 (1)
 #define MICROPY_PY_MACHINE_SOFTI2C          (1)
 #define MICROPY_PY_MACHINE_SPI              (1)
-#define MICROPY_PY_MACHINE_SPI_MSB          (0)
-#define MICROPY_PY_MACHINE_SPI_LSB          (1)
 #define MICROPY_PY_MACHINE_SOFTSPI          (1)
 #ifndef MICROPY_PY_MACHINE_DAC
 #define MICROPY_PY_MACHINE_DAC              (1)

--- a/py/mpconfig.h
+++ b/py/mpconfig.h
@@ -1718,6 +1718,12 @@ typedef double mp_float_t;
 #define MICROPY_PY_MACHINE_SOFTSPI (0)
 #endif
 
+// if a port didn't define MSB/LSB constants then provide them
+#ifndef MICROPY_PY_MACHINE_SPI_MSB
+#define MICROPY_PY_MACHINE_SPI_MSB (0)
+#define MICROPY_PY_MACHINE_SPI_LSB (1)
+#endif
+
 // Whether to provide the "machine.Timer" class
 #ifndef MICROPY_PY_MACHINE_TIMER
 #define MICROPY_PY_MACHINE_TIMER (0)


### PR DESCRIPTION
Sometimes needed and sought for.

For the change the definition of MICROPY_PY_MACHINE_SPI_MSB/ -LSB was moved to py/mpconfig.h, making them available to all ports. The identical defines in esp32/mpconfigport.h were deleted.