### PR TITLE
extmod/extmod.mk: Suppress deprecated-non-prototype warning.

### DIFF
--- a/extmod/extmod.mk
+++ b/extmod/extmod.mk
@@ -294,7 +294,7 @@ SRC_THIRDPARTY_C += $(addprefix $(BTREE_DIR)/,\
 CFLAGS_EXTMOD += -DMICROPY_PY_BTREE=1
 # we need to suppress certain warnings to get berkeley-db to compile cleanly
 # and we have separate BTREE_DEFS so the definitions don't interfere with other source code
-$(BUILD)/$(BTREE_DIR)/%.o: CFLAGS += -Wno-old-style-definition -Wno-sign-compare -Wno-unused-parameter $(BTREE_DEFS)
+$(BUILD)/$(BTREE_DIR)/%.o: CFLAGS += -Wno-old-style-definition -Wno-sign-compare -Wno-unused-parameter -Wno-deprecated-non-prototype -Wno-unknown-warning-option $(BTREE_DEFS)
 $(BUILD)/extmod/modbtree.o: CFLAGS += $(BTREE_DEFS)
 endif
 


### PR DESCRIPTION
This PR was suggested by @jimmo in https://github.com/orgs/micropython/discussions/11492#discussioncomment-5897122 to suppress warnings like the following when compiling the unix port on macOS:

```
CC ../../lib/berkeley-db-1.xx/btree/bt_close.c
../../lib/berkeley-db-1.xx/btree/bt_close.c:63:1: error: a function declaration without a prototype is deprecated in all versions of C and is not supported in C2x [-Werror,-Wdeprecated-non-prototype]
__bt_close(dbp)
^
../../lib/berkeley-db-1.xx/btree/bt_close.c:116:1: error: a function declaration without a prototype is deprecated in all versions of C and is not supported in C2x [-Werror,-Wdeprecated-non-prototype]
__bt_sync(dbp, flags)
^
../../lib/berkeley-db-1.xx/btree/bt_close.c:159:1: error: a function declaration without a prototype is deprecated in all versions of C and is not supported in C2x [-Werror,-Wdeprecated-non-prototype]
bt_meta(t)
^
../../lib/berkeley-db-1.xx/btree/bt_close.c:159:1: error: a function declaration without a prototype is deprecated in all versions of C and is not supported in C2x [-Werror,-Wdeprecated-non-prototype]
4 errors generated.
-e See https://github.com/micropython/micropython/wiki/Build-Troubleshooting
make: *** [build-standard/lib/berkeley-db-1.xx/btree/bt_close.o] Error 1
```