### PR TITLE
extmod/uasyncio: Provide asyncio.iscoroutine function.

### DIFF
--- a/docs/library/uasyncio.rst
+++ b/docs/library/uasyncio.rst
@@ -62,6 +62,10 @@ Core functions
 
     This is a coroutine, and a MicroPython extension.
 
+.. function:: iscoroutine(obj)
+
+    Return True if obj is a coroutine object.
+
 Additional functions
 --------------------
 

--- a/extmod/uasyncio/core.py
+++ b/extmod/uasyncio/core.py
@@ -139,9 +139,14 @@ def _promote_to_task(aw):
     return aw if isinstance(aw, Task) else create_task(aw)
 
 
+# Return True if obj is a coroutine object
+def iscoroutine(obj):
+    return hasattr(obj, "send")
+
+
 # Create and schedule a new task from a coroutine
 def create_task(coro):
-    if not hasattr(coro, "send"):
+    if not iscoroutine(coro):
         raise TypeError("coroutine expected")
     t = Task(coro, globals())
     _task_queue.push(t)


### PR DESCRIPTION
Matches https://docs.python.org/3/library/asyncio-task.html#asyncio.iscoroutine

I've run into needing this function a number of times when using cpython compatible asyncio code, particularly with code that passes (async) functions around like "function pointers" and/or wrapper functions. 

When a non-async function is used instead of an async one, the `await function()` fails with errors like `TypeError: 'NoneType' object isn't iterable` (assuming function returns None) which can be tricky to track and debug. In these cases I'd like to do an `asyncio.iscoroutine(function)` earlier to ensure the right function type has been passed in, preferably in a manner that's compatible with cpython.

