### PR TITLE
stm32/usb: Fix USB support on STM32G4.

### DIFF
--- a/ports/stm32/boards/NUCLEO_G474RE/mpconfigboard.h
+++ b/ports/stm32/boards/NUCLEO_G474RE/mpconfigboard.h
@@ -5,7 +5,7 @@
 #define MICROPY_HW_ENABLE_RNG       (1)
 #define MICROPY_HW_ENABLE_ADC       (1)
 #define MICROPY_HW_ENABLE_DAC       (1) // A4, A5
-#define MICROPY_HW_ENABLE_USB       (0) // A12 (dp), A11 (dm)
+#define MICROPY_HW_ENABLE_USB       (0) // can be enabled if USB cable connected to PA11/PA12 (D-/D+)
 #define MICROPY_HW_HAS_SWITCH       (1)
 #define MICROPY_HW_HAS_FLASH        (0) // QSPI extflash not mounted
 
@@ -84,7 +84,7 @@
 #define MICROPY_HW_LED_OFF(pin)     (mp_hal_pin_low(pin))
 
 // USB config pin A12 (dp), A11 (dm) not mounted on Nucleo
-// #define MICROPY_HW_USB_FS              (1)
+#define MICROPY_HW_USB_FS              (1)
 // #define MICROPY_HW_USB_VBUS_DETECT_PIN (pin_A9)
 // #define MICROPY_HW_USB_OTG_ID_PIN      (pin_A10)
 

--- a/ports/stm32/mpconfigboard_common.h
+++ b/ports/stm32/mpconfigboard_common.h
@@ -559,7 +559,7 @@
 #endif
 
 // Whether the USB peripheral is device-only, or multiple OTG
-#if defined(STM32L0) || defined(STM32L432xx) || defined(STM32WB)
+#if defined(STM32G4) || defined(STM32L0) || defined(STM32L432xx) || defined(STM32WB)
 #define MICROPY_HW_USB_IS_MULTI_OTG (0)
 #else
 #define MICROPY_HW_USB_IS_MULTI_OTG (1)

--- a/ports/stm32/stm32_it.c
+++ b/ports/stm32/stm32_it.c
@@ -312,7 +312,7 @@ void USB_IRQHandler(void) {
 }
 #endif
 
-#elif defined(STM32WB)
+#elif defined(STM32G4) || defined(STM32WB)
 
 #if MICROPY_HW_USB_FS
 void USB_LP_IRQHandler(void) {

--- a/ports/stm32/usb.c
+++ b/ports/stm32/usb.c
@@ -59,7 +59,7 @@
 #endif
 
 // Maximum number of endpoints (excluding EP0)
-#if defined(STM32L0) || defined(STM32WB)
+#if defined(STM32G0) || defined(STM32G4) || defined(STM32L0) || defined(STM32WB)
 #define MAX_ENDPOINT(dev_id) (7)
 #elif defined(STM32L4)
 #define MAX_ENDPOINT(dev_id) (5)
@@ -67,7 +67,7 @@
 #define MAX_ENDPOINT(dev_id) ((dev_id) == USB_PHY_FS_ID ? 3 : 5)
 #elif defined(STM32F7)
 #define MAX_ENDPOINT(dev_id) ((dev_id) == USB_PHY_FS_ID ? 5 : 8)
-#elif defined(STM32G0) || defined(STM32H7)
+#elif defined(STM32H7)
 #define MAX_ENDPOINT(dev_id) (8)
 #endif
 

--- a/ports/stm32/usbd_conf.c
+++ b/ports/stm32/usbd_conf.c
@@ -67,7 +67,7 @@ void HAL_PCD_MspInit(PCD_HandleTypeDef *hpcd) {
     if (hpcd->Instance == USB_OTG_FS) {
         // Configure USB GPIO's.
 
-        #if defined(STM32G0)
+        #if defined(STM32G0) || defined(STM32G4)
 
         // These MCUs don't have an alternate function for USB but rather require
         // the pins to be disconnected from all peripherals, ie put in analog mode.
@@ -146,7 +146,7 @@ void HAL_PCD_MspInit(PCD_HandleTypeDef *hpcd) {
         #elif defined(STM32L432xx)
         NVIC_SetPriority(USB_FS_IRQn, IRQ_PRI_OTG_FS);
         HAL_NVIC_EnableIRQ(USB_FS_IRQn);
-        #elif defined(STM32WB)
+        #elif defined(STM32G4) || defined(STM32WB)
         NVIC_SetPriority(USB_LP_IRQn, IRQ_PRI_OTG_FS);
         HAL_NVIC_EnableIRQ(USB_LP_IRQn);
         #else


### PR DESCRIPTION
(WIP - I do not have a G4 board to test on).

Raised here: https://github.com/orgs/micropython/discussions/11547
But according to https://github.com/micropython/micropython/pull/6911 it's supposed to work (but I'm not sure how?)

Also see note about MAX_ENDPOINTS. The reference manual for WB, G0, G4 all say "Configurable number of endpoints from 1 to 8", but we have 7 for WB and 8 for G0. Didn't check H7. (Assuming 7 is correct?).

_This work was funded through GitHub Sponsors._