### PR TITLE
esp8266: WLAN.config('channel') to use wifi_get/set_channel().

### DIFF
--- a/ports/esp8266/network_wlan.c
+++ b/ports/esp8266/network_wlan.c
@@ -641,8 +641,7 @@ static mp_obj_t esp_config(size_t n_args, const mp_obj_t *args, mp_map_t *kwargs
             val = MP_OBJ_NEW_SMALL_INT(cfg.ap.authmode);
             break;
         case MP_QSTR_channel:
-            req_if = SOFTAP_IF;
-            val = MP_OBJ_NEW_SMALL_INT(cfg.ap.channel);
+            val = MP_OBJ_NEW_SMALL_INT(wifi_get_channel());
             break;
         case MP_QSTR_hostname:
         case MP_QSTR_dhcp_hostname: {

--- a/ports/esp8266/network_wlan.c
+++ b/ports/esp8266/network_wlan.c
@@ -565,8 +565,8 @@ static mp_obj_t esp_config(size_t n_args, const mp_obj_t *args, mp_map_t *kwargs
                         break;
                     }
                     case MP_QSTR_channel: {
-                        req_if = SOFTAP_IF;
                         cfg.ap.channel = mp_obj_get_int(kwargs->table[i].value);
+                        error_check(wifi_set_channel(cfg.ap.channel), "can't set channel");
                         break;
                     }
                     case MP_QSTR_hostname:

--- a/tests/multi_wlan/01_ap_sta.py
+++ b/tests/multi_wlan/01_ap_sta.py
@@ -96,15 +96,7 @@ def instance1():
 
     print("STA connected")
 
-    # Print the current channel, if the port support this
-    try:
-        print("channel", sta.config("channel"))
-    except OSError as e:
-        if "AP" in str(e):
-            # ESP8266 only supports reading channel on the AP interface, so fake this result
-            print("channel", CHANNEL)
-        else:
-            raise
+    print("channel", sta.config("channel"))
 
     print("STA waiting for disconnect...")
 


### PR DESCRIPTION
## ESP8266: `WLAN.config("channel")` to use `wifi_get_channel()`.

- `WLAN.config('channel')` now uses `wifi_get_channel()` to return current wifi channel, rather than the "configured" channel.
- Fixes #11463 : WLAN.config('channel') returns incorrect channel for AP_IF if STA has connected to an external AP running on a different channel.
- This provides the same behaviour as ESP32 from PR #8991 (Does not trigger bug in Issue #11491).
- May also be used on the STA_IF interface.

## ESP8266: `WLAN.config(channel=X)` to use `wifi_set_channel()`.

- May also be used on the STA_IF interface.

This also significantly simplifies setting the channel for `espnow` users on the ESP8266 and allows channel setting code to be portable across ESP32 and ESP8266 platforms, eg. if using the `STA_IF` interface portable code to set the channel required:
```py
    if sys.platform == "esp8266":
        # On ESP8266, use the AP interface to set the channel
        ap_save = ap.active()
        ap.active(True)
        ap.config(channel=6)
        ap.active(ap_save)
    else:
        sta.config(channel=6)  # On ESP32 use STA interface
```
With this PR the equivalent code is:
```py
  sta.config(channel=6)
```

