### PR TITLE
uasyncio/core.py: Make current_task raise when there is no task.

### DIFF
--- a/extmod/uasyncio/core.py
+++ b/extmod/uasyncio/core.py
@@ -222,6 +222,8 @@ def run_until_complete(main_task=None):
                 _exc_context["exception"] = exc
                 _exc_context["future"] = t
                 Loop.call_exception_handler(_exc_context)
+        finally:
+            del cur_task
 
 
 # Create a new task from a coroutine and run it until it finishes
@@ -286,7 +288,10 @@ def get_event_loop(runq_len=0, waitq_len=0):
 
 
 def current_task():
-    return cur_task
+    try:
+        return cur_task
+    except NameError:
+        raise RuntimeError("no running event loop")
 
 
 def new_event_loop():

--- a/tests/extmod/uasyncio_current_task.py
+++ b/tests/extmod/uasyncio_current_task.py
@@ -10,6 +10,12 @@ except ImportError:
         raise SystemExit
 
 
+try:
+    print(asyncio.current_task())
+except RuntimeError:
+    print("RuntimeError")
+
+
 async def task(result):
     result[0] = asyncio.current_task()
 
@@ -23,3 +29,9 @@ async def main():
 
 
 asyncio.run(main())
+
+
+try:
+    print(asyncio.current_task())
+except RuntimeError:
+    print("RuntimeError")

--- a/tests/extmod/uasyncio_current_task.py.exp
+++ b/tests/extmod/uasyncio_current_task.py.exp
@@ -1,1 +1,3 @@
+RuntimeError
 True
+RuntimeError


### PR DESCRIPTION
To match CPython it should raise RuntimeError if no loop is currently active. Previously it returned the most recent task that ran.

I compared doing it this way versus setting it to None, but then we need to add the extra line to declare `cur_task`.

It's +60 bytes, but only +24 bytes if you don't include the error message for the `RuntimeError`.

Fixes #11530  CC @peterhinch 
