### PR TITLE
docs/reference/speed_python.rst: Remove 4-arg limit for viper.

### DIFF
--- a/docs/reference/speed_python.rst
+++ b/docs/reference/speed_python.rst
@@ -247,7 +247,6 @@ Python will interpret the result as 2**32 -1 rather than as -1.
 
 In addition to the restrictions imposed by the native emitter the following constraints apply:
 
-* Functions may have up to four arguments.
 * Default argument values are not permitted.
 * Floating point may be used but is not optimised.
 


### PR DESCRIPTION
This limit was removed in a676b5acf6ee9c17926cf9786370d30a077d99c0.

Fixes #11553