### PR TITLE
stm32/boards/STM32H7B3I_DK: Enable internal flash.

### DIFF
--- a/ports/stm32/boards/STM32H7B3I_DK/mpconfigboard.h
+++ b/ports/stm32/boards/STM32H7B3I_DK/mpconfigboard.h
@@ -10,7 +10,8 @@
 #define MICROPY_HW_HAS_SWITCH       (1)
 #define MICROPY_HW_HAS_FLASH        (0)
 
-#define MICROPY_HW_ENABLE_INTERNAL_FLASH_STORAGE (0)
+// Disable to use external spiflash.
+#define MICROPY_HW_ENABLE_INTERNAL_FLASH_STORAGE (1)
 
 // The board has a 24MHz HSE, the following gives 280MHz CPU speed
 #define MICROPY_HW_CLK_PLLM         (12)
@@ -40,7 +41,8 @@
 #define MICROPY_HW_PWR_SMPS_CONFIG  (PWR_DIRECT_SMPS_SUPPLY)
 
 #if 0
-// 512MBit external OSPI flash, used for either the filesystem or XIP memory mapped
+// 512MBit external OSPI flash, used for either the filesystem or XIP memory mapped.
+// Currently disabled (need octal-spi flash support).
 #define MICROPY_HW_OSPIFLASH_SIZE_BITS_LOG2 (29)
 #define MICROPY_HW_OSPIFLASH_CS     (pin_G6)
 #define MICROPY_HW_OSPIFLASH_CLK    (pin_B2)

--- a/ports/stm32/boards/STM32H7B3I_DK/mpconfigboard.mk
+++ b/ports/stm32/boards/STM32H7B3I_DK/mpconfigboard.mk
@@ -7,12 +7,11 @@ MICROPY_FLOAT_IMPL = double
 AF_FILE = boards/stm32h7b3_af.csv
 
 ifeq ($(USE_MBOOT),1)
-# When using Mboot all the text goes together after the filesystem
-LD_FILES = boards/stm32h743.ld boards/common_blifs.ld
-TEXT0_ADDR = 0x08040000
+# When using Mboot everything goes after the bootloader
+LD_FILES = boards/stm32h7b3.ld boards/common_bl.ld
+TEXT0_ADDR = 0x08020000
 else
-# When not using Mboot the ISR text goes first, then the rest after the filesystem
-LD_FILES = boards/stm32h7b3.ld boards/common_ifs.ld
+# When not using Mboot everything goes at the start of flash
+LD_FILES = boards/stm32h7b3.ld boards/common_basic.ld
 TEXT0_ADDR = 0x08000000
-TEXT1_ADDR = 0x08040000
 endif

--- a/ports/stm32/boards/stm32h7b3.ld
+++ b/ports/stm32/boards/stm32h7b3.ld
@@ -5,10 +5,9 @@
 /* Specify the memory areas */
 MEMORY
 {
-    FLASH (rx)      : ORIGIN = 0x08000000, LENGTH = 2048K
-    FLASH_ISR (rx)  : ORIGIN = 0x08000000, LENGTH = 128K    /* sector 0, 128K */
-    FLASH_FS (r)    : ORIGIN = 0x08020000, LENGTH = 128K    /* sector 1, 128K */
-    FLASH_TEXT (rx) : ORIGIN = 0x08040000, LENGTH = 1792K   /* sectors 6*128 + 8*128 */
+    FLASH (rx)      : ORIGIN = 0x08000000, LENGTH = 2048K   /* sectors (0-7) + (0-7) */
+    FLASH_APP  (rx) : ORIGIN = 0x08020000, LENGTH = 896K    /* sectors (1-7)         */
+    FLASH_FS (r)    : ORIGIN = 0x08100000, LENGTH = 1024K   /* sectors         (0-7) */
     DTCM (xrw)      : ORIGIN = 0x20000000, LENGTH = 128K    /* Used for storage cache */
     RAM (xrw)       : ORIGIN = 0x24000000, LENGTH = 512K    /* AXI SRAM */    
     RAM_D2 (xrw)    : ORIGIN = 0x30000000, LENGTH = 288K
@@ -28,3 +27,11 @@ _ram_start = ORIGIN(RAM);
 _ram_end = ORIGIN(RAM) + LENGTH(RAM);
 _heap_start = _ebss; /* heap starts just after statically allocated memory */
 _heap_end = _sstack;
+
+/* Location of filesystem RAM cache */
+_micropy_hw_internal_flash_storage_ram_cache_start = ORIGIN(DTCM);
+_micropy_hw_internal_flash_storage_ram_cache_end = ORIGIN(DTCM) + LENGTH(DTCM);
+
+/* Location of filesystem flash storage */
+_micropy_hw_internal_flash_storage_start = ORIGIN(FLASH_FS);
+_micropy_hw_internal_flash_storage_end = ORIGIN(FLASH_FS) + LENGTH(FLASH_FS);


### PR DESCRIPTION
Previously this board had no filesystem. This enables the internal flash and clarifies why the external octal-spiflash is disabled.

Also corrects a typo in mpconfigboard.mk to use the correct linker script.

_This work was funded through GitHub Sponsors._