### PR TITLE
ports: Various additions and fixes.

### DIFF
--- a/docs/mimxrt/pinout.rst
+++ b/docs/mimxrt/pinout.rst
@@ -14,9 +14,9 @@ The pin assignment of UARTs to pins is fixed.
 The UARTs are numbered 0..8.  The rx/tx pins are assigned according to the
 tables below:
 
-================  ===========  ===========  ===========  ===========
+=================  ===========  ===========  ===========  ===========
 Board / Pin           UART0        UART1        UART2        UART3
-================  ===========  ===========  ===========  ===========
+=================  ===========  ===========  ===========  ===========
 Teensy 4.0             -            0/1          7/8         14/15
 Teensy 4.1             -            0/1          7/8         14/15
 MIMXRT1010-EVK     Debug USB      D0/D1        D7/D6           -
@@ -27,9 +27,10 @@ MIMXRT1050-EVKB    Debug USB      D0/D1        D7/D6        D8/D9
 MIMXRT1060-EVK     Debug USB      D0/D1        D7/D6        D8/D9
 MIMXRT1064-EVK     Debug USB      D0/D1        D7/D6        D8/D9
 MIMXRT1170-EVK     Debug USB      D0/D1       D12/D11      D10/D13
+Adafruit Metro M7     -           D0/D1        D7/D3        A1/A0
 Olimex RT1010Py       -          RxD/TxD       D5/D6           -
-Seeed ARCH MIX        -        J3_19/J3_20  J4_16/J4_17  J4_06/J4_07
-================  ===========  ===========  ===========  ===========
+Seeed ARCH MIX        -         J3_19/J3_20  J4_16/J4_17  J4_06/J4_07
+=================  ===========  ===========  ===========  ===========
 
 |
 
@@ -61,38 +62,38 @@ PWM pin assignment
 Pins are specified in the same way as for the Pin class.  The following tables show
 the assignment of the board Pins to PWM modules:
 
-===========   ==========   ==========   ======    ==============   ======
-Pin/ MIMXRT   1010         1015         1020      1050/1060/1064   1170
-===========   ==========   ==========   ======    ==============   ======
-D0            -            Q1/1         F1/1/B    -                -
-D1            -            Q1/0         F1/1/A    -                -
-D2            F1/3/B       F1/3/A       -         F1/3/B           -
-D3            F1/3/A       F1/0/A       F2/3/B    F4/0/A           F1/2/A
-D4            F1/3/A (*)   Q1/2         Q2/1      F2/3/A           Q4/2
-D5            F1/0/B (*)   F1/0/B       F2/3/A    F1/3/A           F1/2/B
-D6            -            F1/2/B       F2/0/A    Q3/2             F1/0/A
-D7            -            -            F1/0/A    Q3/3             -
-D8            F1/0/A       F1/1/B       F1/0/B    F1/1/X           Q4/3
-D9            F1/1/B (*)   F1/2/A       F2/0/B    F1/0/X           F1/0/B
-D10           F1/3/B       -            F2/2/B    F1/0/B (*)       F2/2/B
-D11           F1/2/A       -            F2/1/A    F1/1/A (*)       -
-D12           F1/2/B       -            F2/1/B    F1/1/B (*)       -
-D13           F1/3/A       -            F2/2/A    F1/0/A (*)       F2/2/A
-D14           F1/0/B       -            -         F2/3/B           -
-D15           F1/0/A       -            -         F2/3/A           -
-A0            -            -            F1/2/A    -                -
-A1            F1/3/X       F1/3/B       F1/2/B    -                -
-A2            F1/2/X       F1/3/A       F1/3/A    -                -
-A3            -            F1/2/A       F1/3/B    -                -
-A4            -            -            -         Q3/1             -
-A5            -            -            -         Q3/0             -
-D31           -            -            -         -                F1/2/B
-D32           -            -            -         -                F1/2/A
-D33           -            -            -         -                F1/1/B
-D34           -            -            -         -                F1/1/A
-D35           -            -            -         -                F1/0/B
-D36           -            -            -         -                F1/0/A
-===========   ==========   ==========   ======    ==============   ======
+===========  ==========  ==========  ======  ==========  ======  ========
+Pin/ MIMXRT  1010        1015        1020    1050/60/64  1170    Metro M7
+===========  ==========  ==========  ======  ==========  ======  ========
+D0           -           Q1/1        F1/1/B  -           -       -
+D1           -           Q1/0        F1/1/A  -           -       -
+D2           F1/3/B      F1/3/A      -       F1/3/B      -       -
+D3           F1/3/A      F1/0/A      F2/3/B  F4/0/A      F1/2/A  -
+D4           F1/3/A (*)  Q1/2        Q2/1    F2/3/A      Q4/2    F1/0/B
+D5           F1/0/B (*)  F1/0/B      F2/3/A  F1/3/A      F1/2/B  F1/0/A
+D6           -           F1/2/B      F2/0/A  Q3/2        F1/0/A  -
+D7           -           -           F1/0/A  Q3/3        -       -
+D8           F1/0/A      F1/1/B      F1/0/B  F1/1/X      Q4/3    F1/3/A
+D9           F1/1/B (*)  F1/2/A      F2/0/B  F1/0/X      F1/0/B  F1/3/B
+D10          F1/3/B      -           F2/2/B  F1/0/B (*)  F2/2/B  F1/2/A
+D11          F1/2/A      -           F2/1/A  F1/1/A (*)  -       F1/2/B
+D12          F1/2/B      -           F2/1/B  F1/1/B (*)  -       F1/1/A
+D13          F1/3/A      -           F2/2/A  F1/0/A (*)  F2/2/A  F1/1/B
+D14          F1/0/B      -           -       F2/3/B      -       F1/0/B
+D15          F1/0/A      -           -       F2/3/A      -       F1/0/A
+A0           -           -           F1/2/A  -           -       -
+A1           F1/3/X      F1/3/B      F1/2/B  -           -       -
+A2           F1/2/X      F1/3/A      F1/3/A  -           -       -
+A3           -           F1/2/A      F1/3/B  -           -       F1/3/B
+A4           -           -           -       Q3/1        -       F1/2/X
+A5           -           -           -       Q3/0        -       -
+D31          -           -           -       -           F1/2/B  -
+D32          -           -           -       -           F1/2/A  -
+D33          -           -           -       -           F1/1/B  -
+D34          -           -           -       -           F1/1/A  -
+D35          -           -           -       -           F1/0/B  -
+D36          -           -           -       -           F1/0/A  -
+===========  ==========  ==========  ======  ==========  ======  ========
 
 Pins denoted with (*) are by default not wired at the board.
 
@@ -318,6 +319,7 @@ MIXMXRT1050-EVKB   D10/-/D11/D12/D13 (*)            -                        -
 MIXMXRT1060-EVK    D10/-/D11/D12/D13 (*)            -                        -
 MIXMXRT1064-EVK    D10/-/D11/D12/D13 (*)            -                        -
 MIXMXRT1170-EVK    D10/-/D11/D12/D13          D28/-/D25/D24/D26        -/-/D14/D15/D24
+Adafruit Metro M7  -/-/MOSI/MISO/SCK                -                        -         
 Olimex RT1010Py             -                 CS0/-/SDO/SDI/SCK        SDCARD with CS1
 Seeed ARCH MIX     J4_12/-/J4_14/J4_13/J4_15  J3_09/J3_05/J3_08_J3_11
 =================  =========================  =======================  ===============
@@ -350,6 +352,7 @@ MIXMXRT1050-EVKB   A4/A5        D1/D0         -            -        -
 MIXMXRT1060-EVK    A4/A5        D1/D0         -            -        -
 MIXMXRT1064-EVK    A4/A5        D1/D0         -            -        -
 MIXMXRT1170-EVK    D14/D15      D1/D0        A4/A5        D26/D25  D19/D18
+Adafruit Metro M7  D14/D15      D0/D1
 Olimex RT1010Py      -          SDA1/SCL1    SDA2/SCL2     -        -
 Seeed ARCH MIX     J3_17/J3_16  J4_06/J4_07  J5_05/J5_04   -        -
 =================  ===========  ===========  ===========  =======  =======
@@ -364,18 +367,19 @@ Hardware I2S pin assignment
 
 Pin assignments for a few MIMXRT boards:
 
-===============  ==  =====  ======== ======= ======= ======== ======= =======
-Board            ID  MCK    SCK_TX   WS_TX   SD_TX   SCK_RX   WS_RX   SD_RX
-===============  ==  =====  ======== ======= ======= ======== ======= =======
-Teensy 4.0       1   23     26       27      7       21       20      8
-Teensy 4.0       2   33     4        3       2       -        -       5
-Teensy 4.1       1   23     26       27      7       21       20      8
-Teensy 4.1       2   33     4        3       2       -        -       5
-Seeed Arch MIX   1   J4_09  J4_14    J4_15   J14_13  J4_11    J4_10   J4_10
-Olimex RT1010Py  1   D8     D6       D7      D4      D1       D2      D3
-Olimex RT1010Py  3   -      D10      D9      D11     -        -       -
-MIMXRT_DEV       1   "MCK"  "SCK_TX" "WS_TX" "SD_TX" "SCK_RX" "WS_RX" "SD_RX"
-===============  ==  =====  ======== ======= ======= ======== ======= =======
+=================  ==  =====  ======== ======= ======= ======== ======= =======
+Board              ID  MCK    SCK_TX   WS_TX   SD_TX   SCK_RX   WS_RX   SD_RX
+=================  ==  =====  ======== ======= ======= ======== ======= =======
+Teensy 4.0         1   23     26       27      7       21       20      8
+Teensy 4.0         2   33     4        3       2       -        -       5
+Teensy 4.1         1   23     26       27      7       21       20      8
+Teensy 4.1         2   33     4        3       2       -        -       5
+Seeed Arch MIX     1   J4_09  J4_14    J4_15   J14_13  J4_11    J4_10   J4_10
+Adafruit Metro M7  1   D8     D10      D9      D12     D14      D15     D13     
+Olimex RT1010Py    1   D8     D6       D7      D4      D1       D2      D3
+Olimex RT1010Py    3   -      D10      D9      D11     -        -       -
+MIMXRT_DEV         1   "MCK"  "SCK_TX" "WS_TX" "SD_TX" "SCK_RX" "WS_RX" "SD_RX"
+=================  ==  =====  ======== ======= ======= ======== ======= =======
 
 Symbolic pin names are provided for the MIMXRT_10xx_DEV boards.
 These are provided for the other boards as well.

--- a/docs/samd/pinout.rst
+++ b/docs/samd/pinout.rst
@@ -334,6 +334,75 @@ The default devices at the board are:
 - SPI 1 at pins PA23/PA22/PA17, labelled MOSI, MISO and SCK
 - DAC output on pins PA02 and PA05, labelled A0 and A1
 
+Adafruit Metro M4 Airlift pin assignment table
+----------------------------------------------
+
+=== ==== ============ ==== ==== ==== ====== ====== ===== ===== =====
+Pin GPIO Pin name     IRQ  ADC  ADC  Serial Serial  TC    PWM   PWM
+=== ==== ============ ==== ==== ==== ====== ====== ===== ===== =====
+  2 PA02           A0  2     0    -     -      -     -     -     - 
+  5 PA05           A1  5     5    -     -     0/1   0/1    -     - 
+  6 PA06           A2  6     6    -     -     0/2   1/0    -     - 
+ 32 PB00           A3  9    12    -     -     5/2   7/0    -     - 
+ 40 PB08           A4  8     2    0     -     4/0   4/0    -     - 
+ 41 PB09           A5  9     3    1     -     4/1   4/1    -     - 
+ 23 PA23           D0  7     -    -    3/1    5/0   4/1   1/7   0/3
+ 22 PA22           D1  6     -    -    3/0    5/1   4/0   1/6   0/2
+ 49 PB17           D2  1     -    -    5/1     -    6/1   3/1   0/5
+ 48 PB16           D3  0     -    -    5/0     -    6/0   3/0   0/4
+ 45 PB13           D4 13     -    -    4/1     -    4/1   3/1   0/1
+ 46 PB14           D5 14     -    -    4/2     -    5/0   4/0   0/2
+ 47 PB15           D6 15     -    -    4/3     -    5/1   4/1   0/3
+ 44 PB12           D7 12     -    -    4/0     -    4/0   3/0   0/0
+ 21 PA21           D8  5     -    -    5/3    3/3   7/1   1/5   0/1
+ 20 PA20           D9  4     -    -    5/2    3/2   7/0   1/4   0/0
+  3 PA03         AREF  3    10    -     -      -     -     -     - 
+ 18 PA18          D10  2     -    -    1/2    3/2   3/0   1/2   0/6
+ 19 PA19          D11  3     -    -    1/3    3/3   3/1   1/3   0/7
+ 16 PA16          D13  0     -    -    1/0    3/1   2/0   1/0   0/4
+ 36 PB04     ESP_BUSY  4     -    6     -      -     -     -     - 
+ 15 PA15       ESP_CS 15     -    -    2/3    4/3   3/1   2/1   1/3
+ 33 PB01    ESP_GPIO0  1    13    -     -     5/3   7/1    -     - 
+ 37 PB05    ESP_RESET  5     -    7     -      -     -     -     - 
+ 55 PB23      ESP_RTS  7     -    -    1/3    5/3   7/1    -     - 
+  7 PA07       ESP_RX  7     7    -     -     0/3   1/1    -     - 
+  4 PA04       ESP_TX  4     4    -     -     0/0   0/0    -     - 
+ 43 PB11     FLASH_CS 12     -    -     -     4/3   5/1   0/5   1/1
+ 11 PA11   FLASH_HOLD 11    11    -    0/3    2/3   1/1   0/3   1/7
+  9 PA09   FLASH_MISO  9     9    3    0/1    2/0   0/1   0/1   1/5
+  8 PA08   FLASH_MOSI  -     8    2    0/0    2/1   0/0   0/0   1/4
+ 42 PB10    FLASH_SCK 10     -    -     -     4/2   5/0   0/4   1/0
+ 10 PA10     FLASH_WP 10    10    -    0/2    2/2   1/0   0/2   1/6
+ 14 PA14         MISO 14     -    -    2/2    4/2   3/0   2/0   1/2
+ 12 PA12         MOSI 12     -    -    2/0    4/1   2/0   0/6   1/2
+ 54 PB22     NEOPIXEL 22     -    -    1/2    5/2   7/0    -     - 
+ 38 PB06        RXLED  6     -    8     -      -     -     -     - 
+ 13 PA13          SCK 13     -    -    2/1    4/0   2/1   0/7   1/3
+ 35 PB03          SCL  9    15    -     -     5/1   6/1    -     - 
+ 34 PB02          SDA  2    14    -     -     5/0   6/0   2/2    - 
+ 30 PA30        SWCLK 14     -    -    7/2    1/2   6/0   2/0    - 
+ 31 PA31        SWDIO 15     -    -    7/3    1/3   6/1   2/1    - 
+ 62 PB30          SWO 14     -    -    7/0    5/1   0/0   4/0   0/6
+ 39 PB07        TXLED  7     -    9     -      -     -     -     - 
+ 24 PA24       USB_DM  8     -    -    3/2    5/2   5/0   2/2    - 
+ 25 PA25       USB_DP  9     -    -    3/3    5/3   5/1    -     - 
+ 17 PA17   USB_HOSTEN  1     -    -    1/1    3/0   2/1   1/1   0/5
+  0 PA00            -  0     -    -     -     1/0   2/0    -     - 
+  1 PA01            -  1     -    -     -     1/1   2/1    -     - 
+ 27 PA27            - 11     -    -     -      -     -     -     - 
+ 63 PB31            - 15     -    -    7/1    5/0   0/1   4/1   0/7
+=== ==== ============ ==== ==== ==== ====== ====== ===== ===== =====
+
+For the definition of the table columns see the explanation at the table
+for Adafruit ItsyBitsy M4 Express :ref:`samd51_pinout_table`.
+
+The default devices at the board are:
+
+- UART 3 at pins PA23/PA22, labelled D0/D1 resp. RX/TX
+- I2C 5 at pins PB02/PB03, labelled SDA/SCL
+- SPI 4 at pins PA12/PA14/PA13, labelled MOSI, MISO and SCK
+- DAC output on pins PA02 and PA05, labelled A0 and A1
+
 SEEED XIAO pin assignment table
 -------------------------------
 

--- a/ports/mimxrt/Makefile
+++ b/ports/mimxrt/Makefile
@@ -140,7 +140,13 @@ SRC_HAL_IMX_C += \
 	$(MCU_DIR)/drivers/fsl_snvs_lp.c \
 	$(MCU_DIR)/drivers/fsl_wdog.c \
 	$(MCU_DIR)/system_$(MCU_SERIES)$(MCU_CORE).c \
-	$(MCU_DIR)/xip/fsl_flexspi_nor_boot.c \
+
+# Use a specific boot header for 1062 so the Teensy loader doesn't erase the filesystem.
+ifeq ($(MCU_SERIES), MIMXRT1062)
+SRC_HAL_IMX_C += hal/fsl_flexspi_nor_boot.c
+else
+SRC_HAL_IMX_C += $(MCU_DIR)/xip/fsl_flexspi_nor_boot.c
+endif
 
 ifeq ($(MICROPY_HW_SDRAM_AVAIL),1)
 SRC_HAL_IMX_C += $(MCU_DIR)/drivers/fsl_semc.c


### PR DESCRIPTION
- Fix a regression for MIMXRT PWM, which caused setting duty_u16() behave like duty_ns() when the frequency was changed: the positive pulse duration did not change. That came up during testing for PR #11516. Fix an inconsistency when displaying a PWM pin's properties and improve the check for a pin to support PWM.
- Add the pinout information for the Adafruit Metro M7 board.
- Add the pinout information for the Adafruit Metro M4 board.