### PR TITLE
renesas-ra/boards/make-pins.py: Fix PA/PB pins support.

### DIFF
--- a/ports/renesas-ra/boards/make-pins.py
+++ b/ports/renesas-ra/boards/make-pins.py
@@ -140,7 +140,7 @@ class Pins(object):
             for row in rows:
                 try:
                     cpu_pin_name = row[0]
-                    cpu_pin_port = int(row[1])
+                    cpu_pin_port = int(row[1], 16)
                     cpu_pin_bit = int(row[2])
                 except:
                     continue


### PR DESCRIPTION
Fix an issue that PA/PB pins are not genereted.

This change affects #10943 and #11405.
Tested on VK-RA6M5 with RA6M5 using #10943 code as below:
```
>>> dir(machine.Pin.cpu)
['__class__', '__name__', '__bases__', '__dict__', 'P000', 'P001', 'P002', 'P003', 'P004', 'P005', 'P006', 'P007', 'P008', 'P009', 'P010', 'P014', 'P015', 'P100', 'P101', 'P102', 'P103', 'P104', 'P105', 'P106', 'P107', 'P108', 'P109', 'P110', 'P111', 'P112', 'P113', 'P114', 'P115', 'P200', 'P201', 'P202', 'P203', 'P204', 'P205', 'P206', 'P207', 'P208', 'P209', 'P210', 'P211', 'P212', 'P213', 'P214', 'P300', 'P301', 'P302', 'P303', 'P304', 'P305', 'P306', 'P307', 'P308', 'P309', 'P310', 'P311', 'P312', 'P313', 'P314', 'P315', 'P400', 'P401', 'P402', 'P403', 'P404', 'P405', 'P406', 'P407', 'P408', 'P409', 'P410', 'P411', 'P412', 'P413', 'P414', 'P415', 'P500', 'P501', 'P502', 'P503', 'P504', 'P505', 'P506', 'P507', 'P508', 'P511', 'P512', 'P513', 'P600', 'P601', 'P602', 'P603', 'P604', 'P605', 'P606', 'P607', 'P608', 'P609', 'P610', 'P611', 'P612', 'P613', 'P614', 'P615', 'P700', 'P701', 'P702', 'P703', 'P704', 'P705', 'P706', 'P707', 'P708', 'P800', 'P801', 'P802', 'P803', 'P804', 'P805', 'P806', 'P900', 'P901', 'P905', 'P906', 'P907', 'P908', 'PA00', 'PA01', 'PA08', 'PA09', 'PA10', 'PB00', 'PB01']
```

This issue was reported by @iabdalkader -san in #11590. 

