### PR TITLE
ports/rp2: Fix minor bug in rp2/machine_uart.c in the ioctl poll handling.

### DIFF
--- a/ports/rp2/machine_uart.c
+++ b/ports/rp2/machine_uart.c
@@ -548,7 +548,7 @@ STATIC mp_uint_t machine_uart_ioctl(mp_obj_t self_in, mp_uint_t request, mp_uint
     if (request == MP_STREAM_POLL) {
         uintptr_t flags = arg;
         ret = 0;
-        if ((flags & MP_STREAM_POLL_RD) && (uart_is_readable(self->uart) || ringbuf_avail(&self->read_buffer) > 0)) {
+        if ((flags & MP_STREAM_POLL_RD) && ((uart_is_readable(self->uart) || ringbuf_avail(&self->read_buffer)) > 0)) {
             ret |= MP_STREAM_POLL_RD;
         }
         if ((flags & MP_STREAM_POLL_WR) && ringbuf_free(&self->write_buffer) > 0) {


### PR DESCRIPTION
There appears to be a minor bug in the RP2 port's UART ioctl for polling. The [lines](https://github.com/micropython/micropython/blob/ed7a3b11d9a6c21a964d55ebfcdefeb392389d10/ports/rp2/machine_uart.c#L551-L553) that checks if the `MP_STREAM_POLL_RD` flag should be set currently say:
```
        if ((flags & MP_STREAM_POLL_RD) && (uart_is_readable(self->uart) || ringbuf_avail(&self->read_buffer) > 0)) {
            ret |= MP_STREAM_POLL_RD;
        }
```
The `&&` operator binds more tightly than the `||` operator. As a result the code is capable setting the read flag even if it was not requested. It seems that there's no straightforward way for a Python user to see an erroneous result, but it's possible that C code could get confused while polling.
