### PR TITLE
renesas-ra: Support changing baudrate for UART.

### DIFF
--- a/ports/renesas-ra/Makefile
+++ b/ports/renesas-ra/Makefile
@@ -359,7 +359,11 @@ HAL_SRC_C += $(addprefix $(HAL_DIR)/ra/fsp/src/bsp/mcu/all/,\
 
 HAL_SRC_C += $(addprefix $(HAL_DIR)/ra/fsp/src/,\
 	r_ioport/r_ioport.c \
+	r_sci_uart/r_sci_uart.c \
 	)
+
+CFLAGS_FSP = -Wno-unused-variable -Wno-unused-function
+$(BUILD)/lib/fsp/ra/fsp/src/r_sci_uart/r_sci_uart.o: CFLAGS += $(CFLAGS_FSP)
 
 ifeq ($(USE_FSP_LPM), 1)
 CFLAGS += -DUSE_FSP_LPM

--- a/ports/renesas-ra/fsp_cfg/r_sci_uart_cfg.h
+++ b/ports/renesas-ra/fsp_cfg/r_sci_uart_cfg.h
@@ -1,0 +1,25 @@
+#ifndef R_SCI_UART_CFG_H_
+#define R_SCI_UART_CFG_H_
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#define SCI_UART_CFG_PARAM_CHECKING_ENABLE (BSP_CFG_PARAM_CHECKING_ENABLE)
+#define SCI_UART_CFG_FIFO_SUPPORT (0)
+#define SCI_UART_CFG_DTC_SUPPORTED (0)
+#define SCI_UART_CFG_FLOW_CONTROL_SUPPORT (0)
+#define SCI_UART_CFG_RS485_SUPPORT (0)
+
+/*
+ * Disable r_sci_uart.c's interrupt handlers by defining followings
+ * because the renesas-ra has own interrupt handlers for SCI and
+ * symbol conflict happens.
+ */
+
+#define SCI_UART_CFG_TX_ENABLE (0)
+#define SCI_UART_CFG_RX_ENABLE (0)
+
+#ifdef __cplusplus
+}
+#endif
+#endif /* R_SCI_UART_CFG_H_ */


### PR DESCRIPTION
This PR enables changing baudrate for UART such as UART.init(baudrate) and available other than 115200 baudrate.
* Link fsp/src/r_sci_uart/r_sci_uart.c and call R_SCI_UART_BaudCalculate() from ra/ra_sci.c to change baudrate.
* Make UART.init(baudrate) work.
* Tested on EK boards with baudrate 4800/9600/19200/38400/115200/230400/460800/576000/921600/1152000/2000000.
　(except EK-RA4M1 & EK-RA4W1 does not work with 2000000)

This request and issue was reported by @iabdalkader -san and @mbedNoobNinja -san  in #10943. 
This change affects #10943 and #11405.
