### PR TITLE
Add one more skip for codespell -- mis

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ line-length = 99
 [tool.codespell]
 count = ""
 ignore-regex = '\b[A-Z]{3}\b'
-ignore-words-list = "ans,asend,deques,dout,extint,hsi,iput,numer,technic,ure"
+ignore-words-list = "ans,asend,deques,dout,extint,hsi,iput,mis,numer,technic,ure"
 quiet-level = 3
 skip = """
 */build*,\


### PR DESCRIPTION
Observed with codespell 2.2.5.dev57+gdc7e98d9

    ❯ codespell
    ./ports/rp2/machine_uart.c:163: mis ==> miss, mist
    ./ports/rp2/machine_uart.c:168: mis ==> miss, mist
    2