### PR TITLE
extmod/network_wiznet5k: Correct MACRAW socket buffer init for W5100S.

### DIFF
--- a/extmod/network_wiznet5k.c
+++ b/extmod/network_wiznet5k.c
@@ -225,7 +225,7 @@ STATIC void wiznet5k_init(void) {
         setSn_IMR(0, Sn_IR_RECV);
         #if _WIZCHIP_ == W5100S
         // Enable interrupt pin
-        setMR(MR2_G_IEN);
+        setMR2(MR2_G_IEN);
         #endif
 
         mp_hal_pin_input(wiznet5k_obj.pin_intn);

--- a/extmod/network_wiznet5k.c
+++ b/extmod/network_wiznet5k.c
@@ -211,7 +211,11 @@ STATIC void wiznet5k_init(void) {
     // Configure wiznet for raw ethernet frame usage.
 
     // Configure 16k buffers for fast MACRAW
+    #if _WIZCHIP_ < W5200
+    uint8_t sn_size[8] = {8, 0, 0, 0, 8, 0, 0, 0}; // 8k buffers on W5100 and W5100S
+    #else
     uint8_t sn_size[16] = {16, 0, 0, 0, 0, 0, 0, 0, 16, 0, 0, 0, 0, 0, 0, 0};
+    #endif
     ctlwizchip(CW_INIT_WIZCHIP, sn_size);
 
     if (wiznet5k_obj.use_interrupt) {


### PR DESCRIPTION
The W5100S only has 8k TX/RX buffers compared to the W5500 16k

`ctlwizchip(CW_INIT_WIZCHIP, sn_size);` was returning -1 on the W5100S and leaving the buffers in the default configuration of 2k per socket, rather than reallocating the full 8k to socket 0 for use in MACRAW
