### PR TITLE
tools/ci.sh: Add mimxrt and samd ports to code size build.

### DIFF
--- a/tools/ci.sh
+++ b/tools/ci.sh
@@ -61,8 +61,8 @@ function ci_code_size_setup {
 
 function ci_code_size_build {
     # check the following ports for the change in their code size
-    PORTS_TO_CHECK=bmusp
-    SUBMODULES="lib/berkeley-db-1.xx lib/mbedtls lib/micropython-lib lib/pico-sdk lib/stm32lib lib/tinyusb"
+    PORTS_TO_CHECK=bmusxpd
+    SUBMODULES="lib/asf4 lib/berkeley-db-1.xx lib/mbedtls lib/micropython-lib lib/nxp_driver lib/pico-sdk lib/stm32lib lib/tinyusb"
 
     # starts off at either the ref/pull/N/merge FETCH_HEAD, or the current branch HEAD
     git checkout -b pull_request # save the current location


### PR DESCRIPTION
The automatic code size build and GitHub comment is a really great feature (thanks @dlech!) and we are relying on it more to make decisions about what to merge.  So this adds a few more builds to it (mimxrt and samd).  They should be pretty quick to build (current CI takes about 6 minutes for the code size check).