### PR TITLE
windows/msvc/paths.props: Dont add variant path for mpy-cross build.

### DIFF
--- a/ports/windows/msvc/common.props
+++ b/ports/windows/msvc/common.props
@@ -19,6 +19,9 @@
     <PyFileCopyCookie>$(PyBuildDir)copycookie$(Configuration)$(Platform)</PyFileCopyCookie>
     <CharacterSet>MultiByte</CharacterSet>
   </PropertyGroup>
+  <PropertyGroup Condition="'$(PyBuildingMpyCross)' != 'True'">
+    <PyIncDirs>$(PyIncDirs);$(PyVariantDir)</PyIncDirs>
+  </PropertyGroup>
   <ItemDefinitionGroup>
     <ClCompile>
       <AdditionalIncludeDirectories>$(PyIncDirs);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>

--- a/ports/windows/msvc/paths.props
+++ b/ports/windows/msvc/paths.props
@@ -31,8 +31,8 @@
     <PyVariantDir Condition="'$(PyVariantDir)' == ''">$(PyWinDir)variants\$(PyVariant)\</PyVariantDir>
     <PyTargetDir Condition="'$(PyTargetDir)' == ''">$(PyBuildDir)</PyTargetDir>
 
-    <!-- All include directories needed for MicroPython -->
-    <PyIncDirs>$(PyIncDirs);$(PyBaseDir);$(PyWinDir);$(PyBuildDir);$(PyWinDir)msvc;$(PyVariantDir)</PyIncDirs>
+    <!-- Common include directories needed for MicroPython -->
+    <PyIncDirs>$(PyIncDirs);$(PyBaseDir);$(PyWinDir);$(PyBuildDir);$(PyWinDir)msvc</PyIncDirs>
 
     <!-- Within PyBuildDir different subdirectories are used based on configuration and platform.
          By default these are chosen based on the Configuration and Platform properties, but


### PR DESCRIPTION
If you try and build mpy-cross.vcxproj from Visual Studio (tested both 2017 and 2022), it expected the PyVariant property to be set, and without it ends up with an invalid include path, which results in a double-backslash in the cl.exe command line.

Same goes for using `msbuild`. It's easy to add `/p:PyVariant=standard` there but it should not be necessary.

paths.props is shared by mpy-cross.vcxproj, but in the mpy-cross build, PyVariant will be not set (because common.props explicitly doesn't set it when building mpy-cross).

However, paths.props will attempt to default PyVariantDir to `variants\$(PyVariant)\` which will end up as `variants\\` and the double backslash breaks the cl.exe command line.

This appears to work, but I wonder if all uses of PyVariantDir should also now have a `Condition` added?

cc @stinos 
