### PR TITLE
ports/pin: Specify machine module pins consistently across ports.

### DIFF
--- a/ports/esp32/machine_i2c.c
+++ b/ports/esp32/machine_i2c.c
@@ -185,10 +185,10 @@ mp_obj_t machine_hw_i2c_make_new(const mp_obj_type_t *type, size_t n_args, size_
 
     // Set SCL/SDA pins if given
     if (args[ARG_scl].u_obj != MP_OBJ_NULL) {
-        self->scl = mp_hal_get_pin_obj(args[ARG_scl].u_obj);
+        self->scl = machine_pin_get_id(args[ARG_scl].u_obj);
     }
     if (args[ARG_sda].u_obj != MP_OBJ_NULL) {
-        self->sda = mp_hal_get_pin_obj(args[ARG_sda].u_obj);
+        self->sda = machine_pin_get_id(args[ARG_sda].u_obj);
     }
 
     // Initialise the I2C peripheral

--- a/ports/esp32/machine_i2s.c
+++ b/ports/esp32/machine_i2s.c
@@ -392,9 +392,9 @@ STATIC void machine_i2s_init_helper(machine_i2s_obj_t *self, size_t n_pos_args, 
     //
 
     // are Pins valid?
-    int8_t sck = args[ARG_sck].u_obj == MP_OBJ_NULL ? -1 : mp_hal_get_pin_obj(args[ARG_sck].u_obj);
-    int8_t ws = args[ARG_ws].u_obj == MP_OBJ_NULL ? -1 : mp_hal_get_pin_obj(args[ARG_ws].u_obj);
-    int8_t sd = args[ARG_sd].u_obj == MP_OBJ_NULL ? -1 : mp_hal_get_pin_obj(args[ARG_sd].u_obj);
+    int8_t sck = args[ARG_sck].u_obj == MP_OBJ_NULL ? -1 : machine_pin_get_id(args[ARG_sck].u_obj);
+    int8_t ws = args[ARG_ws].u_obj == MP_OBJ_NULL ? -1 : machine_pin_get_id(args[ARG_ws].u_obj);
+    int8_t sd = args[ARG_sd].u_obj == MP_OBJ_NULL ? -1 : machine_pin_get_id(args[ARG_sd].u_obj);
 
     // is Mode valid?
     i2s_mode_t mode = args[ARG_mode].u_int;

--- a/ports/esp32/machine_sdcard.c
+++ b/ports/esp32/machine_sdcard.c
@@ -131,18 +131,9 @@ static const sdspi_device_config_t spi_dev_defaults[2] = {
     SDSPI_DEVICE_CONFIG_DEFAULT(), // HSPI (ESP32) / SPI2 (ESP32S3)
 };
 
-STATIC gpio_num_t pin_or_int(const mp_obj_t arg) {
-    if (mp_obj_is_small_int(arg)) {
-        return MP_OBJ_SMALL_INT_VALUE(arg);
-    } else {
-        // This raises a value error if the argument is not a Pin.
-        return machine_pin_get_id(arg);
-    }
-}
-
 #define SET_CONFIG_PIN(config, pin_var, arg_id) \
     if (arg_vals[arg_id].u_obj != mp_const_none) \
-    config.pin_var = pin_or_int(arg_vals[arg_id].u_obj)
+    config.pin_var = machine_pin_get_id(arg_vals[arg_id].u_obj)
 
 STATIC esp_err_t sdcard_ensure_card_init(sdcard_card_obj_t *self, bool force) {
     if (force || !(self->flags & SDCARD_CARD_FLAGS_CARD_INIT_DONE)) {

--- a/ports/esp32/mphalport.h
+++ b/ports/esp32/mphalport.h
@@ -86,7 +86,6 @@ void mp_hal_wake_main_task_from_isr(void);
 #define mp_hal_pin_obj_t gpio_num_t
 mp_hal_pin_obj_t machine_pin_get_id(mp_obj_t pin_in);
 #define mp_hal_get_pin_obj(o) machine_pin_get_id(o)
-#define mp_obj_get_pin(o) machine_pin_get_id(o) // legacy name; only to support esp8266/modonewire
 #define mp_hal_pin_name(p) (p)
 static inline void mp_hal_pin_input(mp_hal_pin_obj_t pin) {
     esp_rom_gpio_pad_select_gpio(pin);

--- a/ports/esp8266/modesp.c
+++ b/ports/esp8266/modesp.c
@@ -201,8 +201,8 @@ STATIC MP_DEFINE_CONST_FUN_OBJ_0(esp_check_fw_obj, esp_check_fw);
 STATIC mp_obj_t esp_apa102_write_(mp_obj_t clockPin, mp_obj_t dataPin, mp_obj_t buf) {
     mp_buffer_info_t bufinfo;
     mp_get_buffer_raise(buf, &bufinfo, MP_BUFFER_READ);
-    esp_apa102_write(mp_obj_get_pin_obj(clockPin)->phys_port,
-        mp_obj_get_pin_obj(dataPin)->phys_port,
+    esp_apa102_write(mp_obj_get_pin(clockPin),
+        mp_obj_get_pin(dataPin),
         (uint8_t *)bufinfo.buf, bufinfo.len);
     return mp_const_none;
 }

--- a/ports/renesas-ra/machine_spi.c
+++ b/ports/renesas-ra/machine_spi.c
@@ -205,7 +205,7 @@ mp_obj_t machine_hard_spi_make_new(const mp_obj_type_t *type, size_t n_args, siz
     if (args[ARG_sck].u_obj == MP_OBJ_NULL) {
         sck = self->sck->pin;
     } else {
-        const machine_pin_obj_t *arg_sck = mp_hal_get_pin_obj(args[ARG_sck].u_obj);
+        const machine_pin_obj_t *arg_sck = machine_pin_find(args[ARG_sck].u_obj);
         sck = arg_sck->pin;
         if (!IS_VALID_SCK(self->sck->pin, sck)) {
             mp_raise_ValueError(MP_ERROR_TEXT("bad SCK pin"));
@@ -214,7 +214,7 @@ mp_obj_t machine_hard_spi_make_new(const mp_obj_type_t *type, size_t n_args, siz
     if (args[ARG_mosi].u_obj == MP_OBJ_NULL) {
         mosi = self->mosi->pin;
     } else {
-        const machine_pin_obj_t *arg_mosi = mp_hal_get_pin_obj(args[ARG_mosi].u_obj);
+        const machine_pin_obj_t *arg_mosi = machine_pin_find(args[ARG_mosi].u_obj);
         mosi = arg_mosi->pin;
         if (!IS_VALID_MOSI(self->mosi->pin, mosi)) {
             mp_raise_ValueError(MP_ERROR_TEXT("bad MOSI pin"));
@@ -223,7 +223,7 @@ mp_obj_t machine_hard_spi_make_new(const mp_obj_type_t *type, size_t n_args, siz
     if (args[ARG_miso].u_obj == MP_OBJ_NULL) {
         miso = self->miso->pin;
     } else {
-        const machine_pin_obj_t *arg_miso = mp_hal_get_pin_obj(args[ARG_miso].u_obj);
+        const machine_pin_obj_t *arg_miso = machine_pin_find(args[ARG_miso].u_obj);
         miso = arg_miso->pin;
         if (!IS_VALID_MISO(self->miso->pin, miso)) {
             mp_raise_ValueError(MP_ERROR_TEXT("bad MISO pin"));
@@ -287,21 +287,21 @@ STATIC void machine_hard_spi_init(mp_obj_base_t *self_in, size_t n_args, const m
         }
     }
     if (args[ARG_sck].u_obj != MP_OBJ_NULL) {
-        const machine_pin_obj_t *arg_sck = mp_hal_get_pin_obj(args[ARG_sck].u_obj);
+        const machine_pin_obj_t *arg_sck = machine_pin_find(args[ARG_sck].u_obj);
         sck = arg_sck->pin;
         if (!IS_VALID_SCK(self->sck->pin, sck)) {
             mp_raise_ValueError(MP_ERROR_TEXT("bad SCK pin"));
         }
     }
     if (args[ARG_mosi].u_obj != MP_OBJ_NULL) {
-        const machine_pin_obj_t *arg_mosi = mp_hal_get_pin_obj(args[ARG_mosi].u_obj);
+        const machine_pin_obj_t *arg_mosi = machine_pin_find(args[ARG_mosi].u_obj);
         mosi = arg_mosi->pin;
         if (!IS_VALID_MOSI(self->mosi->pin, mosi)) {
             mp_raise_ValueError(MP_ERROR_TEXT("bad MOSI pin"));
         }
     }
     if (args[ARG_miso].u_obj != MP_OBJ_NULL) {
-        const machine_pin_obj_t *arg_miso = mp_hal_get_pin_obj(args[ARG_miso].u_obj);
+        const machine_pin_obj_t *arg_miso = machine_pin_find(args[ARG_miso].u_obj);
         miso = arg_miso->pin;
         if (!IS_VALID_MISO(self->miso->pin, miso)) {
             mp_raise_ValueError(MP_ERROR_TEXT("bad MISO pin"));


### PR DESCRIPTION
This function is called pin_find() and take an object of pin type, int type or optional string type as argument and returns a matching pin object. This approach was already implemented in the STM32, Renesas-RA, CC3200, MIMXRT and SAMD port. The actual PR add or extends it for the RP2, ESP32 and ESP8266 port. A minor update is included for the Renesas-RA port, but just for internal consistency.

As a side effect, Pin objects can be specified for the machine modules either as Pin(x), a number, where pins are numbered, or a string, if board pins are named. With an ESP32 board, one could write:
`p = PWM(Pin(4), ....)` instead of `p = PWM(4, ....)`, with a RP2 board on can write e.g.:
`u = UART(1, rx=4, tx=5)` instead of `u = UART(1, rx=Pin(4), tx=Pin(5))`.