### PR TITLE
esp32|rp2: PROJECT_DIR -> CMAKE_CURRENT_LIST_DIR.

### DIFF
--- a/ports/esp32/CMakeLists.txt
+++ b/ports/esp32/CMakeLists.txt
@@ -2,9 +2,6 @@
 
 cmake_minimum_required(VERSION 3.12)
 
-# Set the location of this port's directory.
-set(MICROPY_PORT_DIR ${CMAKE_SOURCE_DIR})
-
 # Set the board if it's not already set.
 if(NOT MICROPY_BOARD)
     set(MICROPY_BOARD GENERIC)
@@ -12,7 +9,7 @@ endif()
 
 # Set the board directory and check that it exists.
 if(NOT MICROPY_BOARD_DIR)
-    set(MICROPY_BOARD_DIR ${MICROPY_PORT_DIR}/boards/${MICROPY_BOARD})
+    set(MICROPY_BOARD_DIR ${CMAKE_CURRENT_LIST_DIR}/boards/${MICROPY_BOARD})
 endif()
 if(NOT EXISTS ${MICROPY_BOARD_DIR}/mpconfigboard.cmake)
     message(FATAL_ERROR "Invalid MICROPY_BOARD specified: ${MICROPY_BOARD}")
@@ -35,7 +32,7 @@ include(${MICROPY_BOARD_DIR}/mpconfigboard.cmake)
 if (MICROPY_USER_FROZEN_MANIFEST)
     set(MICROPY_FROZEN_MANIFEST ${MICROPY_USER_FROZEN_MANIFEST})
 elseif (NOT MICROPY_FROZEN_MANIFEST)
-    set(MICROPY_FROZEN_MANIFEST ${MICROPY_PORT_DIR}/boards/manifest.py)
+    set(MICROPY_FROZEN_MANIFEST ${CMAKE_CURRENT_LIST_DIR}/boards/manifest.py)
 endif()
 
 # Add sdkconfig fragments that depend on the IDF version.

--- a/ports/esp32/main/CMakeLists.txt
+++ b/ports/esp32/main/CMakeLists.txt
@@ -1,6 +1,10 @@
 # Set location of base MicroPython directory.
 if(NOT MICROPY_DIR)
-    get_filename_component(MICROPY_DIR ${PROJECT_DIR}/../.. ABSOLUTE)
+    get_filename_component(MICROPY_DIR ${CMAKE_CURRENT_LIST_DIR}/../../.. ABSOLUTE)
+endif()
+
+if(NOT MICROPY_PORT_DIR)
+    get_filename_component(MICROPY_PORT_DIR ${MICROPY_DIR}/ports/esp32 ABSOLUTE)
 endif()
 
 # Include core source components.
@@ -16,7 +20,7 @@ if(NOT CMAKE_BUILD_EARLY_EXPANSION)
 endif()
 
 set(MICROPY_QSTRDEFS_PORT
-    ${PROJECT_DIR}/qstrdefsport.h
+    ${MICROPY_PORT_DIR}/qstrdefsport.h
 )
 
 set(MICROPY_SOURCE_SHARED
@@ -48,44 +52,45 @@ set(MICROPY_SOURCE_DRIVERS
 )
 
 set(MICROPY_SOURCE_PORT
-    ${PROJECT_DIR}/main.c
-    ${PROJECT_DIR}/uart.c
-    ${PROJECT_DIR}/usb.c
-    ${PROJECT_DIR}/usb_serial_jtag.c
-    ${PROJECT_DIR}/gccollect.c
-    ${PROJECT_DIR}/mphalport.c
-    ${PROJECT_DIR}/fatfs_port.c
-    ${PROJECT_DIR}/help.c
-    ${PROJECT_DIR}/machine_bitstream.c
-    ${PROJECT_DIR}/machine_timer.c
-    ${PROJECT_DIR}/machine_pin.c
-    ${PROJECT_DIR}/machine_touchpad.c
-    ${PROJECT_DIR}/machine_adc.c
-    ${PROJECT_DIR}/machine_adcblock.c
-    ${PROJECT_DIR}/machine_dac.c
-    ${PROJECT_DIR}/machine_i2c.c
-    ${PROJECT_DIR}/machine_i2s.c
-    ${PROJECT_DIR}/machine_uart.c
-    ${PROJECT_DIR}/modmachine.c
-    ${PROJECT_DIR}/network_common.c
-    ${PROJECT_DIR}/network_lan.c
-    ${PROJECT_DIR}/network_ppp.c
-    ${PROJECT_DIR}/network_wlan.c
-    ${PROJECT_DIR}/mpnimbleport.c
-    ${PROJECT_DIR}/modsocket.c
-    ${PROJECT_DIR}/modesp.c
-    ${PROJECT_DIR}/esp32_nvs.c
-    ${PROJECT_DIR}/esp32_partition.c
-    ${PROJECT_DIR}/esp32_rmt.c
-    ${PROJECT_DIR}/esp32_ulp.c
-    ${PROJECT_DIR}/modesp32.c
-    ${PROJECT_DIR}/machine_hw_spi.c
-    ${PROJECT_DIR}/machine_wdt.c
-    ${PROJECT_DIR}/mpthreadport.c
-    ${PROJECT_DIR}/machine_rtc.c
-    ${PROJECT_DIR}/machine_sdcard.c
-    ${PROJECT_DIR}/modespnow.c
+    main.c
+    uart.c
+    usb.c
+    usb_serial_jtag.c
+    gccollect.c
+    mphalport.c
+    fatfs_port.c
+    help.c
+    machine_bitstream.c
+    machine_timer.c
+    machine_pin.c
+    machine_touchpad.c
+    machine_adc.c
+    machine_adcblock.c
+    machine_dac.c
+    machine_i2c.c
+    machine_i2s.c
+    machine_uart.c
+    modmachine.c
+    network_common.c
+    network_lan.c
+    network_ppp.c
+    network_wlan.c
+    mpnimbleport.c
+    modsocket.c
+    modesp.c
+    esp32_nvs.c
+    esp32_partition.c
+    esp32_rmt.c
+    esp32_ulp.c
+    modesp32.c
+    machine_hw_spi.c
+    machine_wdt.c
+    mpthreadport.c
+    machine_rtc.c
+    machine_sdcard.c
+    modespnow.c
 )
+list(TRANSFORM MICROPY_SOURCE_PORT PREPEND ${MICROPY_PORT_DIR}/)
 
 set(MICROPY_SOURCE_QSTR
     ${MICROPY_SOURCE_PY}

--- a/ports/rp2/CMakeLists.txt
+++ b/ports/rp2/CMakeLists.txt
@@ -20,7 +20,7 @@ set(PICO_TINYUSB_PATH ${MICROPY_DIR}/lib/tinyusb)
 set(PICO_LWIP_PATH ${MICROPY_DIR}/lib/lwip)
 
 # Set the location of this port's directory.
-set(MICROPY_PORT_DIR ${CMAKE_SOURCE_DIR})
+set(MICROPY_PORT_DIR ${CMAKE_CURRENT_LIST_DIR})
 
 # Set the board if it's not already set.
 if(NOT MICROPY_BOARD)
@@ -80,7 +80,7 @@ include(${MICROPY_DIR}/py/usermod.cmake)
 add_executable(${MICROPY_TARGET})
 
 set(MICROPY_QSTRDEFS_PORT
-    ${PROJECT_SOURCE_DIR}/qstrdefsport.h
+    ${MICROPY_PORT_DIR}/qstrdefsport.h
 )
 
 set(MICROPY_SOURCE_LIB
@@ -146,20 +146,20 @@ set(MICROPY_SOURCE_QSTR
     ${MICROPY_DIR}/shared/readline/readline.c
     ${MICROPY_DIR}/shared/runtime/mpirq.c
     ${MICROPY_DIR}/shared/runtime/sys_stdio_mphal.c
-    ${PROJECT_SOURCE_DIR}/machine_adc.c
-    ${PROJECT_SOURCE_DIR}/machine_i2c.c
-    ${PROJECT_SOURCE_DIR}/machine_i2s.c
-    ${PROJECT_SOURCE_DIR}/machine_pin.c
-    ${PROJECT_SOURCE_DIR}/machine_rtc.c
-    ${PROJECT_SOURCE_DIR}/machine_spi.c
-    ${PROJECT_SOURCE_DIR}/machine_timer.c
-    ${PROJECT_SOURCE_DIR}/machine_uart.c
-    ${PROJECT_SOURCE_DIR}/machine_wdt.c
-    ${PROJECT_SOURCE_DIR}/modmachine.c
-    ${PROJECT_SOURCE_DIR}/modrp2.c
-    ${PROJECT_SOURCE_DIR}/modos.c
-    ${PROJECT_SOURCE_DIR}/rp2_flash.c
-    ${PROJECT_SOURCE_DIR}/rp2_pio.c
+    ${MICROPY_PORT_DIR}/machine_adc.c
+    ${MICROPY_PORT_DIR}/machine_i2c.c
+    ${MICROPY_PORT_DIR}/machine_i2s.c
+    ${MICROPY_PORT_DIR}/machine_pin.c
+    ${MICROPY_PORT_DIR}/machine_rtc.c
+    ${MICROPY_PORT_DIR}/machine_spi.c
+    ${MICROPY_PORT_DIR}/machine_timer.c
+    ${MICROPY_PORT_DIR}/machine_uart.c
+    ${MICROPY_PORT_DIR}/machine_wdt.c
+    ${MICROPY_PORT_DIR}/modmachine.c
+    ${MICROPY_PORT_DIR}/modrp2.c
+    ${MICROPY_PORT_DIR}/modos.c
+    ${MICROPY_PORT_DIR}/rp2_flash.c
+    ${MICROPY_PORT_DIR}/rp2_pio.c
     ${CMAKE_BINARY_DIR}/pins_${MICROPY_BOARD}.c
 )
 
@@ -343,7 +343,7 @@ set(MICROPY_CROSS_FLAGS -march=armv6m)
 if (MICROPY_USER_FROZEN_MANIFEST)
     set(MICROPY_FROZEN_MANIFEST ${MICROPY_USER_FROZEN_MANIFEST})
 elseif (NOT MICROPY_FROZEN_MANIFEST)
-    set(MICROPY_FROZEN_MANIFEST ${PROJECT_SOURCE_DIR}/boards/manifest.py)
+    set(MICROPY_FROZEN_MANIFEST ${MICROPY_PORT_DIR}/boards/manifest.py)
 endif()
 
 target_sources(${MICROPY_TARGET} PRIVATE
@@ -362,7 +362,7 @@ target_include_directories(${MICROPY_TARGET} PRIVATE
     ${MICROPY_INC_CORE}
     ${MICROPY_INC_USERMOD}
     ${MICROPY_BOARD_DIR}
-    "${PROJECT_SOURCE_DIR}"
+    "${MICROPY_PORT_DIR}"
     "${CMAKE_BINARY_DIR}"
 )
 


### PR DESCRIPTION
In commit 9b90882146, initial support was added for building with the newly introduced CMake support provided by the ESP-IDF.

Specifically, the commit message states:

> This commit adds support for building the esp32 port with CMake, and
in particular, it builds MicroPython as a component within the ESP-IDF. Using CMake and the ESP-IDF build infrastructure makes it much easier to maintain the port, especially with the various new ESP32 MCUs and their required toolchains.

`PROJECT_DIR` is a variable populated by the ESP-IDF specifically and is not stable when used with "[Pure CMake components][1]" as documented in the ESP-IDF. It is intended to be used in the scope of the parent of the current file (the "project") as opposed to the current file ("the component"). Crossing into the parent scope like this works solely when the "project" is MicroPython, but not when used as a component by other ESP-IDF projects.

Analyzing this file, the intention is to reference the "Project" which in the example is the parent directory. Within the [CMake variables][2] documentation, there is one specifically defined for referencing the directory for the CMake listfile currently being processed: `CMAKE_CURRENT_LIST_DIR`.

After making the change from `PROJECT_DIR` to `CMAKE_CURRENT_LIST_DIR`, the reach into the parent scope defined by the ESP-IDF and the resulting CMake interface violation is removed.

Similar to the component definition, the project `CMakeLists.txt` uses the variable `CMAKE_SOURCE_DIR` which CMake defines as "The path to the top level of the source tree."  This commit changes the variable to `CMAKE_CURRENT_LIST_DIR` for the reasons cited above.

Additionally, it was discovered that similar changes could be used to improve the build process for the RP2.  These changes are also included in this commit.

[1]: https://docs.espressif.com/projects/esp-idf/en/latest/esp32s2/api-guides/build-system.html#writing-pure-cmake-components
[2]: https://cmake.org/cmake/help/latest/manual/cmake-variables.7.html
[3]: https://cmake.org/cmake/help/latest/variable/CMAKE_CURRENT_LIST_DIR.html