### PR TITLE
py/lexer: Allow conversion specifiers in f-strings (e.g. !r).

### DIFF
--- a/tests/basics/string_fstring.py
+++ b/tests/basics/string_fstring.py
@@ -61,3 +61,22 @@ except (ValueError, SyntaxError):
 print(f"a {1,} b")
 print(f"a {x,y,} b")
 print(f"a {x,1} b")
+
+# f-strings with conversion specifiers (only support !r and !s).
+a = "123"
+print(f"{a!r}")
+print(f"{a!s}")
+try:
+    eval('print(f"{a!x}")')
+except (ValueError, SyntaxError):
+    # CPython detects this at compile time, MicroPython fails with ValueError
+    # when the str.format is executed.
+    print("ValueError")
+
+# Mixing conversion specifiers with formatting.
+print(f"{a!r:8s}")
+print(f"{a!s:8s}")
+
+# Still allow ! in expressions.
+print(f"{'1' if a != '456' else '0'!r:8s}")
+print(f"{'1' if a != '456' else '0'!s:8s}")

--- a/tests/cpydiff/core_fstring_repr.py
+++ b/tests/cpydiff/core_fstring_repr.py
@@ -1,18 +1,8 @@
 """
 categories: Core
-description: f-strings don't support the !r, !s, and !a conversions
-cause: MicroPython is optimised for code space.
-workaround: Use repr(), str(), and ascii() explicitly.
+description: f-strings don't support !a conversions
+cause: MicropPython does not implement ascii()
+workaround: None
 """
 
-
-class X:
-    def __repr__(self):
-        return "repr"
-
-    def __str__(self):
-        return "str"
-
-
-print(f"{X()!r}")
-print(f"{X()!s}")
+f"{'unicode text'!a}"


### PR DESCRIPTION
This was done by @greezybacon in https://github.com/micropython/micropython/pull/8711

I've just done some minor fixups to the comments and commit messages and added more tests.

Fixes #11737

---

PEP-498 allows for conversion specifiers like !r and !s to convert the expression declared in braces to be passed through repr() and str() respectively.

This updates the logic that detects the end of the expression to also stop when it sees "![rs]" that is either at the end of the f-string or before the ":" indicating the start of the format specifier. The "![rs]" is now retained in the format string, whereas previously it stayed on the end of the expression leading to a syntax error.

Previously: `f"{x!y:z}"` --> `"{:z}".format(x!y)`
Now: `f"{x!y:z}"` --> `"{!y:z}".format(x)`

Note that "!a" is not supported by `str.format` as MicroPython has no `ascii()`, but now this will raise the correct error.

Updated cpydiff and added tests.