### PR TITLE
tools/mpremote: Fix exec_ -> exec in commands.py.

### DIFF
--- a/tools/mpremote/mpremote/commands.py
+++ b/tools/mpremote/mpremote/commands.py
@@ -137,13 +137,13 @@ def do_filesystem(state, args):
                 raise CommandError("'cp -r' source files must be local")
             _list_recursive(src_files, path)
         known_dirs = {""}
-        state.transport.exec_("import os")
+        state.transport.exec("import os")
         for dir, file in src_files:
             dir_parts = dir.split("/")
             for i in range(len(dir_parts)):
                 d = "/".join(dir_parts[: i + 1])
                 if d not in known_dirs:
-                    state.transport.exec_(
+                    state.transport.exec(
                         "try:\n os.mkdir('%s')\nexcept OSError as e:\n print(e)" % d
                     )
                     known_dirs.add(d)


### PR DESCRIPTION
This was missed in the pyboard refactor and is preventing `cp -r` from working.