### PR TITLE
py: makemoduledefs: fix multiple declarations, and auto-declare attr functions

### DIFF
--- a/py/builtin.h
+++ b/py/builtin.h
@@ -132,8 +132,6 @@ extern const mp_obj_module_t mp_module___main__;
 extern const mp_obj_module_t mp_module_builtins;
 extern const mp_obj_module_t mp_module_sys;
 
-void mp_module_sys_attr(mp_obj_t self_in, qstr attr, mp_obj_t *dest);
-
 // Modules needed by the parser when MICROPY_COMP_MODULE_CONST is enabled.
 extern const mp_obj_module_t mp_module_errno;
 extern const mp_obj_module_t mp_module_uctypes;

--- a/py/makemoduledefs.py
+++ b/py/makemoduledefs.py
@@ -106,7 +106,10 @@ def generate_module_delegations(delegations):
     if not delegations:
         return
 
-    print("\n#define MICROPY_MODULE_DELEGATIONS \\")
+    print()
+    for obj_module, fun_name in delegations:
+        print("extern void {}(mp_obj_t self_in, qstr attr, mp_obj_t *dest);".format(fun_name))
+    print("#define MICROPY_MODULE_DELEGATIONS \\")
     for obj_module, fun_name in delegations:
         print(
             "    {{ MP_ROM_PTR(&{obj_module}), {fun_name} }}, \\".format(

--- a/py/makemoduledefs.py
+++ b/py/makemoduledefs.py
@@ -109,7 +109,7 @@ def generate_module_delegations(delegations):
     print("\n#define MICROPY_MODULE_DELEGATIONS \\")
     for obj_module, fun_name in delegations:
         print(
-            "    {{ MP_ROM_PTR(&{obj_module}), {fun_name} }},".format(
+            "    {{ MP_ROM_PTR(&{obj_module}), {fun_name} }}, \\".format(
                 obj_module=obj_module, fun_name=fun_name
             )
         )

--- a/py/modsys.c
+++ b/py/modsys.c
@@ -336,7 +336,7 @@ MP_REGISTER_ROOT_POINTER(mp_obj_t sys_exitfunc);
 #if MICROPY_PY_SYS_ATTR_DELEGATION
 // Contains mutable sys attributes.
 MP_REGISTER_ROOT_POINTER(mp_obj_t sys_mutable[MP_SYS_MUTABLE_NUM]);
-MP_REGISTER_MODULE_DELEGATION(mp_module_sys, &mp_module_sys_attr);
+MP_REGISTER_MODULE_DELEGATION(mp_module_sys, mp_module_sys_attr);
 #endif
 
 #endif // MICROPY_PY_SYS

--- a/py/objmodule.c
+++ b/py/objmodule.c
@@ -34,12 +34,6 @@
 #include "py/runtime.h"
 #include "py/builtin.h"
 
-#ifndef NO_QSTR
-// Only include module definitions when not doing qstr extraction, because the
-// qstr extraction stage also generates this module definition header file.
-#include "genhdr/moduledefs.h"
-#endif
-
 STATIC void module_print(const mp_print_t *print, mp_obj_t self_in, mp_print_kind_t kind) {
     (void)kind;
     mp_obj_module_t *self = MP_OBJ_TO_PTR(self_in);

--- a/py/objmodule.h
+++ b/py/objmodule.h
@@ -28,6 +28,12 @@
 
 #include "py/obj.h"
 
+#ifndef NO_QSTR
+// Only include module definitions when not doing qstr extraction, because the
+// qstr extraction stage also generates this module definition header file.
+#include "genhdr/moduledefs.h"
+#endif
+
 extern const mp_map_t mp_builtin_module_map;
 extern const mp_map_t mp_builtin_extensible_module_map;
 


### PR DESCRIPTION
There are two commits here:
- Fix declaring multiple module delegations, by adding `\` at end of each line
- Automatically declare delegation attr functions.

The latter makes it so that the delegation function declarations don't need to be put somewhere global, like in mpconfigport.h.  That would otherwise make it hard for extension modules to use delegation.