### PR TITLE
tools/mpremote/mpremote/mip: Allow target dir in package deps

### DIFF
--- a/docs/reference/packages.rst
+++ b/docs/reference/packages.rst
@@ -120,7 +120,12 @@ A typical ``package.json`` for an example ``mlx90640`` library looks like::
       "deps": [
         ["collections-defaultdict", "latest"],
         ["os-path", "latest"],
-        ["github:org/micropython-additions", "main"]
+        ["github:org/micropython-additions", "main"],
+        [
+          "folder/file.py",
+          "github:other_org/repo/src/some_file.py",
+          "1.7.4"
+        ]
       ],
       "version": "0.2"
     }
@@ -130,7 +135,10 @@ This includes two files, hosted at a GitHub repo named
 the device. It depends on ``collections-defaultdict`` and ``os-path`` which will
 be installed automatically from the :term:`micropython-lib`. The third
 dependency installs the content as defined by the ``package.json`` file of the
-``main`` branch of the GitHub repo ``org/micropython-additions``.
+``main`` branch of the GitHub repo ``org/micropython-additions``. The last
+dependency installs the single file ``some_file.py`` of the GitHub repo
+``other_org/repo`` located in the subfolder ``src`` as ``folder/file.py`` based on
+the ``1.7.4`` tag.
 
 Freezing packages
 -----------------

--- a/tools/mpremote/mpremote/mip.py
+++ b/tools/mpremote/mpremote/mip.py
@@ -107,7 +107,11 @@ def _install_json(transport, package_json_url, index, target, version, mpy):
     for target_path, url in package_json.get("urls", ()):
         fs_target_path = target + "/" + target_path
         _download_file(transport, _rewrite_url(url, version), fs_target_path)
-    for dep, dep_version in package_json.get("deps", ()):
+    for sublist in package_json.get("deps", ()):
+        if len(sublist) == 2:
+            dep, dep_version = sublist[0], sublist[1]
+        else:
+            target, dep, dep_version = sublist[0], sublist[1], sublist[2]
         _install_package(transport, dep, index, target, dep_version, mpy)
 
 


### PR DESCRIPTION
This PR allows to specify custom target directories in the `package.json` dependencies list. 

As of now other micropython packages or repos with a `package.json` file could be specified. Both would have definition files for the list of files and their individual target path. 

For a single file, which is not part of this "active" package definition file this was not possible. An example for this is the [Microdot framework](https://github.com/miguelgrinberg/microdot), which has already been discussed in https://github.com/miguelgrinberg/microdot/issues/67

With this change single files, a URL **and** a specific version can be used in the list of dependencies. The change is fully backwards compatible. The documentation is expanded as well with an example