### PR TITLE
esp32,esp8266: Allow Ctrl-C to interrupt the corrupt-fs while loop.

### DIFF
--- a/ports/esp32/modules/inisetup.py
+++ b/ports/esp32/modules/inisetup.py
@@ -17,6 +17,10 @@ def check_bootsec():
 
 def fs_corrupted():
     import time
+    import micropython
+
+    # Allow this loop to be stopped via Ctrl-C.
+    micropython.kbd_intr(3)
 
     while 1:
         print(

--- a/ports/esp8266/modules/inisetup.py
+++ b/ports/esp8266/modules/inisetup.py
@@ -26,6 +26,10 @@ def check_bootsec():
 
 def fs_corrupted():
     import time
+    import micropython
+
+    # Allow this loop to be stopped via Ctrl-C.
+    micropython.kbd_intr(3)
 
     while 1:
         print(


### PR DESCRIPTION
Commit c046b23ea29e0183c899a8dbe1da3bed3440a255 prevented frozen boot code from being interrupted by Ctrl-C, but that means a corrupt filesystem will forever lock up an esp32/esp8266 board.  This commit fixes that by explicitly enabling Ctrl-C before running the forever loop.