### PR TITLE
ports/webassembly: Make mp_js_do_str and mp_js_process_char asynchronous.

### DIFF
--- a/ports/webassembly/README.md
+++ b/ports/webassembly/README.md
@@ -121,7 +121,7 @@ Initialize MicroPython repl. Must be called before entering characters into
 the repl.
 
 ```
-mp_js_process_char(char)
+await mp_js_process_char(char)
 ```
 
 Input character into MicroPython repl. `char` must be of type `number`. This

--- a/ports/webassembly/README.md
+++ b/ports/webassembly/README.md
@@ -49,7 +49,7 @@ using the require command and the general API outlined below. For example:
 var mp_js = require('./build/micropython.js');
 
 mp_js_init(64 * 1024);
-mp_js_do_str("print('hello world')\n");
+await mp_js_do_str("print('hello world')\n");
 ```
 
 Running with HTML
@@ -77,7 +77,7 @@ something to stdout.  The following code demonstrates basic functionality:
       Module["onRuntimeInitialized"] = async function() {
         mp_js_startup();
         mp_js_init(64 * 1024);
-        mp_js_do_str("print('hello world')");
+        await mp_js_do_str("print('hello world')");
       };
     </script>
   </body>
@@ -108,7 +108,7 @@ Initialize MicroPython with the given stack size in bytes. This must be
 called before attempting to interact with MicroPython.
 
 ```
-mp_js_do_str(code)
+await mp_js_do_str(code)
 ```
 
 Execute the input code. `code` must be a `string`.

--- a/ports/webassembly/wrapper.js
+++ b/ports/webassembly/wrapper.js
@@ -29,7 +29,7 @@ var Module = {};
 var mainProgram = function()
 {
   mp_js_init = Module.cwrap('mp_js_init', 'null', ['number']);
-  mp_js_do_str = Module.cwrap('mp_js_do_str', 'number', ['string']);
+  mp_js_do_str = Module.cwrap('mp_js_do_str', 'number', ['string'], {async: true});
   mp_js_init_repl = Module.cwrap('mp_js_init_repl', 'null', ['null']);
   mp_js_process_char = Module.cwrap('mp_js_process_char', 'number', ['number']);
 
@@ -75,7 +75,9 @@ var mainProgram = function()
               }
           });
       } else {
-          process.exitCode = mp_js_do_str(contents);
+          mp_js_do_str(contents).then(exitCode => {
+              process.exitCode = exitCode
+          })
       }
   }
 }

--- a/ports/webassembly/wrapper.js
+++ b/ports/webassembly/wrapper.js
@@ -31,7 +31,7 @@ var mainProgram = function()
   mp_js_init = Module.cwrap('mp_js_init', 'null', ['number']);
   mp_js_do_str = Module.cwrap('mp_js_do_str', 'number', ['string'], {async: true});
   mp_js_init_repl = Module.cwrap('mp_js_init_repl', 'null', ['null']);
-  mp_js_process_char = Module.cwrap('mp_js_process_char', 'number', ['number']);
+  mp_js_process_char = Module.cwrap('mp_js_process_char', 'number', ['number'], {async: true});
 
   MP_JS_EPOCH = Date.now();
 
@@ -69,9 +69,11 @@ var mainProgram = function()
           process.stdin.setRawMode(true);
           process.stdin.on('data', function (data) {
               for (var i = 0; i < data.length; i++) {
-                  if (mp_js_process_char(data[i])) {
-                      process.exit()
-                  }
+                  mp_js_process_char(data[i]).then(result => {
+                      if (result) {
+                          process.exit()
+                      }
+                  })
               }
           });
       } else {


### PR DESCRIPTION
This fixes a bug tracked by #10692 where `gc.collect()` would crash due to `emscripten_scan_stack` being called synchronously within `mp_js_do_str` and `mp_js_process_char`. 

The fix was to make `mp_js_do_str` and `mp_js_process_char` asynchronous by marking them as `{async: true}` in the `Module.cwrap()` call, and then to call the function asynchronously in `wrapper.js`.

GC test results before this patch:

```
$ (cd tests && MICROPY_MICROPYTHON=../ports/webassembly/node_run.sh ./run-tests.py -j1 stress/gc_trace.py)
FAIL  stress/gc_trace.py
1 tests performed (2 individual testcases)
0 tests passed
1 tests failed: gc_trace

$ cat tests/results/stress_gc_trace.py.out 
Aborted(Assertion failed: The call to mp_js_do_str is running asynchronously. If this was intended, add the async option to the ccall/cwrap call.)
/Users/eli/projects/micropython/ports/webassembly/build/micropython.js:213
      throw ex;
      ^

RuntimeError: Aborted(Assertion failed: The call to mp_js_do_str is running asynchronously. If this was intended, add the async option to the ccall/cwrap call.)
    at abort (/Users/eli/projects/micropython/ports/webassembly/build/micropython.js:754:11)
    at assert (/Users/eli/projects/micropython/ports/webassembly/build/micropython.js:455:5)
    at ccall (/Users/eli/projects/micropython/ports/webassembly/build/micropython.js:4460:9)
    at /Users/eli/projects/micropython/ports/webassembly/build/micropython.js:4479:16
    at Object.mainProgram [as onRuntimeInitialized] (/Users/eli/projects/micropython/ports/webassembly/build/micropython.js:78:30)
    at doRun (/Users/eli/projects/micropython/ports/webassembly/build/micropython.js:5238:71)
    at run (/Users/eli/projects/micropython/ports/webassembly/build/micropython.js:5255:5)
    at runCaller (/Users/eli/projects/micropython/ports/webassembly/build/micropython.js:5199:19)
    at removeRunDependency (/Users/eli/projects/micropython/ports/webassembly/build/micropython.js:717:7)
    at receiveInstance (/Users/eli/projects/micropython/ports/webassembly/build/micropython.js:935:5)

Node.js v18.12.1
CRASH%
```

GC test results after this patch:

```
$ (cd tests && MICROPY_MICROPYTHON=../ports/webassembly/node_run.sh ./run-tests.py -j1 stress/gc_trace.py)

pass  stress/gc_trace.py
1 tests performed (2 individual testcases)
1 tests passed
```

I also updated the PR to indicate that `mp_js_do_str` and `mp_js_process_char` need to be called asynchronously.