### PR TITLE
examples/bluetooth/ble_advertising.py: Error when advertising payload is too large instead of silently failing

### DIFF
--- a/examples/bluetooth/ble_advertising.py
+++ b/examples/bluetooth/ble_advertising.py
@@ -1,8 +1,11 @@
 # Helpers for generating BLE advertising payloads.
 
-from micropython import const
+
 import struct
+
 import bluetooth
+
+from micropython import const
 
 # Advertising payloads are repeated packets of the following form:
 #   1 byte data length (N + 1)
@@ -18,6 +21,8 @@ _ADV_TYPE_UUID16_MORE = const(0x2)
 _ADV_TYPE_UUID32_MORE = const(0x4)
 _ADV_TYPE_UUID128_MORE = const(0x6)
 _ADV_TYPE_APPEARANCE = const(0x19)
+
+_ADV_MAX_PAYLOAD = const(31)
 
 
 # Generate a payload to be passed to gap_advertise(adv_data=...).
@@ -50,6 +55,8 @@ def advertising_payload(limited_disc=False, br_edr=False, name=None, services=No
     if appearance:
         _append(_ADV_TYPE_APPEARANCE, struct.pack("<h", appearance))
 
+    if len(payload) > _ADV_MAX_PAYLOAD:
+        raise ValueError(f"ADV payload too large. Max {_ADV_MAX_PAYLOAD} got {len(payload)}")
     return payload
 
 

--- a/examples/bluetooth/ble_bonding_peripheral.py
+++ b/examples/bluetooth/ble_bonding_peripheral.py
@@ -5,12 +5,13 @@
 #
 # Work-in-progress demo of implementing bonding and passkey auth.
 
-import bluetooth
+import binascii
+import json
 import random
 import struct
 import time
-import json
-import binascii
+
+import bluetooth
 from ble_advertising import advertising_payload
 
 from micropython import const
@@ -70,8 +71,12 @@ class BLETemperature:
         self._ble.config(addr_mode=2)
         ((self._handle,),) = self._ble.gatts_register_services((_ENV_SENSE_SERVICE,))
         self._connections = set()
-        self._payload = advertising_payload(
-            name=name, services=[_ENV_SENSE_UUID], appearance=_ADV_APPEARANCE_GENERIC_THERMOMETER
+        self._adv_data = advertising_payload(
+            services=[_ENV_SENSE_UUID],
+            appearance=_ADV_APPEARANCE_GENERIC_THERMOMETER,
+        )
+        self._resp_data = advertising_payload(
+            name=name,
         )
         self._advertise()
 
@@ -150,7 +155,7 @@ class BLETemperature:
 
     def _advertise(self, interval_us=500000):
         self._ble.config(addr_mode=2)
-        self._ble.gap_advertise(interval_us, adv_data=self._payload)
+        self._ble.gap_advertise(interval_us, adv_data=self._adv_data, resp_data=self._resp_data)
 
     def _load_secrets(self):
         self._secrets = {}

--- a/examples/bluetooth/ble_simple_peripheral.py
+++ b/examples/bluetooth/ble_simple_peripheral.py
@@ -1,9 +1,8 @@
 # This example demonstrates a UART periperhal.
 
-import bluetooth
-import random
-import struct
 import time
+
+import bluetooth
 from ble_advertising import advertising_payload
 
 from micropython import const
@@ -40,7 +39,8 @@ class BLESimplePeripheral:
         ((self._handle_tx, self._handle_rx),) = self._ble.gatts_register_services((_UART_SERVICE,))
         self._connections = set()
         self._write_callback = None
-        self._payload = advertising_payload(name=name, services=[_UART_UUID])
+        self._adv_data = advertising_payload(services=[_UART_UUID])
+        self._resp_data = advertising_payload(name=name)
         self._advertise()
 
     def _irq(self, event, data):
@@ -70,7 +70,7 @@ class BLESimplePeripheral:
 
     def _advertise(self, interval_us=500000):
         print("Starting advertising")
-        self._ble.gap_advertise(interval_us, adv_data=self._payload)
+        self._ble.gap_advertise(interval_us, adv_data=self._adv_data, resp_data=self._resp_data)
 
     def on_write(self, callback):
         self._write_callback = callback

--- a/examples/bluetooth/ble_uart_peripheral.py
+++ b/examples/bluetooth/ble_uart_peripheral.py
@@ -42,7 +42,8 @@ class BLEUART:
         self._rx_buffer = bytearray()
         self._handler = None
         # Optionally add services=[_UART_UUID], but this is likely to make the payload too large.
-        self._payload = advertising_payload(name=name, appearance=_ADV_APPEARANCE_GENERIC_COMPUTER)
+        self._adv_data = advertising_payload(appearance=_ADV_APPEARANCE_GENERIC_COMPUTER)
+        self._resp_data = advertising_payload(name=name)
         self._advertise()
 
     def irq(self, handler):
@@ -86,7 +87,7 @@ class BLEUART:
         self._connections.clear()
 
     def _advertise(self, interval_us=500000):
-        self._ble.gap_advertise(interval_us, adv_data=self._payload)
+        self._ble.gap_advertise(interval_us, adv_data=self._adv_data, resp_data=self._resp_data)
 
 
 def demo():


### PR DESCRIPTION
When adverting a name + _UART_SERVICE using the bluetooth module, I ran into an issue where a name longer than 8 characters would not be advertising the data I set, It would instead be advertising as if no other data was set. After debugging and looking into the BLE docs I finally figured out that the maximum size of the advertising payload is 31 bytes and I was exceeding it.

To prevent others from running into this issue I've modified the examples to warn when the payload is too large and show that you can send any other data using `resp_data`.