### PR TITLE
ports/rp2/machine_uart: fix race condition in interrupt handling

### DIFF
--- a/ports/rp2/machine_uart.c
+++ b/ports/rp2/machine_uart.c
@@ -194,7 +194,7 @@ STATIC inline void uart_service_interrupt(machine_uart_obj_t *self) {
     }
     if (uart_get_hw(self->uart)->mis & UART_UARTMIS_TXMIS_BITS) { // tx interrupt?
         // clear all interrupt bits but rx
-        uart_get_hw(self->uart)->icr = UART_UARTICR_BITS & (~UART_UARTICR_RXIC_BITS);
+        uart_get_hw(self->uart)->icr = UART_UARTICR_BITS & ~(UART_UARTICR_RXIC_BITS | UART_UARTICR_RTIC_BITS);
         uart_fill_tx_fifo(self);
     }
 }


### PR DESCRIPTION
The irq service routine cleared the RT interrupt bit on TX interrupt. This opens the possibility that an RT interrupt is missed.