### PR TITLE
Make sys.stdout.buffer.write() return the number of bytes written.

### DIFF
--- a/extmod/misc.h
+++ b/extmod/misc.h
@@ -39,10 +39,12 @@ bool mp_os_dupterm_is_builtin_stream(mp_const_obj_t stream);
 void mp_os_dupterm_stream_detached_attached(mp_obj_t stream_detached, mp_obj_t stream_attached);
 uintptr_t mp_os_dupterm_poll(uintptr_t poll_flags);
 int mp_os_dupterm_rx_chr(void);
-void mp_os_dupterm_tx_strn(const char *str, size_t len);
+int mp_os_dupterm_tx_strn(const char *str, size_t len);
 void mp_os_deactivate(size_t dupterm_idx, const char *msg, mp_obj_t exc);
 #else
-#define mp_os_dupterm_tx_strn(s, l)
+static inline int mp_os_dupterm_tx_strn(const char *s, size_t l) {
+    return -1;
+}
 #endif
 
 #endif // MICROPY_INCLUDED_EXTMOD_MISC_H

--- a/ports/cc3200/hal/cc3200_hal.c
+++ b/ports/cc3200/hal/cc3200_hal.c
@@ -140,10 +140,15 @@ void mp_hal_delay_ms(mp_uint_t delay) {
     }
 }
 
-void mp_hal_stdout_tx_strn(const char *str, size_t len) {
-    mp_os_dupterm_tx_strn(str, len);
+mp_uint_t mp_hal_stdout_tx_strn(const char *str, size_t len) {
+    mp_uint_t ret = len;
+    int dupterm_res = mp_os_dupterm_tx_strn(str, len);
+    if (dupterm_res >= 0) {
+        ret = dupterm_res;
+    }
     // and also to telnet
     telnet_tx_strn(str, len);
+    return ret;
 }
 
 int mp_hal_stdin_rx_chr(void) {

--- a/ports/esp8266/esp_mphal.c
+++ b/ports/esp8266/esp_mphal.c
@@ -94,8 +94,14 @@ void mp_hal_debug_str(const char *str) {
 }
 #endif
 
-void mp_hal_stdout_tx_strn(const char *str, uint32_t len) {
-    mp_os_dupterm_tx_strn(str, len);
+mp_uint_t mp_hal_stdout_tx_strn(const char *str, uint32_t len) {
+    int dupterm_res = mp_os_dupterm_tx_strn(str, len);
+    if (dupterm_res < 0) {
+        // no outputs, nothing was written
+        return 0;
+    } else {
+        return dupterm_res;
+    }
 }
 
 void mp_hal_debug_tx_strn_cooked(void *env, const char *str, uint32_t len) {

--- a/ports/mimxrt/mphalport.c
+++ b/ports/mimxrt/mphalport.c
@@ -112,9 +112,12 @@ int mp_hal_stdin_rx_chr(void) {
     }
 }
 
-void mp_hal_stdout_tx_strn(const char *str, mp_uint_t len) {
+mp_uint_t mp_hal_stdout_tx_strn(const char *str, mp_uint_t len) {
+    mp_uint_t ret = len;
+    bool did_write = false;
     if (tud_cdc_connected()) {
-        for (size_t i = 0; i < len;) {
+        size_t i = 0;
+        while (i < len) {
             uint32_t n = len - i;
             if (n > CFG_TUD_CDC_EP_BUFSIZE) {
                 n = CFG_TUD_CDC_EP_BUFSIZE;
@@ -125,6 +128,7 @@ void mp_hal_stdout_tx_strn(const char *str, mp_uint_t len) {
                 MICROPY_EVENT_POLL_HOOK
             }
             if (ticks_us64() >= timeout) {
+                ret = i;
                 break;
             }
 
@@ -132,10 +136,17 @@ void mp_hal_stdout_tx_strn(const char *str, mp_uint_t len) {
             tud_cdc_write_flush();
             i += n2;
         }
+        did_write = true;
+        ret = MIN(i, ret);
     }
     #if MICROPY_PY_OS_DUPTERM
-    mp_os_dupterm_tx_strn(str, len);
+    int dupterm_res = mp_os_dupterm_tx_strn(str, len);
+    if (dupterm_res >= 0) {
+        did_write = true;
+        ret = MIN((mp_uint_t)dupterm_res, ret);
+    }
     #endif
+    return did_write ? ret : 0;
 }
 
 uint64_t mp_hal_time_ns(void) {

--- a/ports/minimal/uart_core.c
+++ b/ports/minimal/uart_core.c
@@ -29,10 +29,14 @@ int mp_hal_stdin_rx_chr(void) {
 }
 
 // Send string of given length
-void mp_hal_stdout_tx_strn(const char *str, mp_uint_t len) {
+mp_uint_t mp_hal_stdout_tx_strn(const char *str, mp_uint_t len) {
+    mp_uint_t ret = len;
     #if MICROPY_MIN_USE_STDOUT
     int r = write(STDOUT_FILENO, str, len);
-    (void)r;
+    if (r >= 0) {
+        // in case of an error in the syscall, report no bytes written
+        ret = 0;
+    }
     #elif MICROPY_MIN_USE_STM32_MCU
     while (len--) {
         // wait for TXE
@@ -41,4 +45,5 @@ void mp_hal_stdout_tx_strn(const char *str, mp_uint_t len) {
         USART1->DR = *str++;
     }
     #endif
+    return ret;
 }

--- a/ports/nrf/drivers/bluetooth/ble_uart.c
+++ b/ports/nrf/drivers/bluetooth/ble_uart.c
@@ -110,10 +110,11 @@ int mp_hal_stdin_rx_chr(void) {
     return (int)byte;
 }
 
-void mp_hal_stdout_tx_strn(const char *str, size_t len) {
+mp_uint_t mp_hal_stdout_tx_strn(const char *str, size_t len) {
     // Not connected: drop output
-    if (!ble_uart_enabled()) return;
+    if (!ble_uart_enabled()) return 0;
 
+    mp_uint_t ret = len;
     uint8_t *buf = (uint8_t *)str;
     size_t send_len;
 
@@ -134,6 +135,7 @@ void mp_hal_stdout_tx_strn(const char *str, size_t len) {
         len -= send_len;
         buf += send_len;
     }
+    return ret;
 }
 
 void ble_uart_tx_char(char c) {

--- a/ports/nrf/drivers/usb/usb_cdc.c
+++ b/ports/nrf/drivers/usb/usb_cdc.c
@@ -231,12 +231,12 @@ int mp_hal_stdin_rx_chr(void) {
     return 0;
 }
 
-void mp_hal_stdout_tx_strn(const char *str, mp_uint_t len) {
-
+mp_uint_t mp_hal_stdout_tx_strn(const char *str, mp_uint_t len) {
     for (const char *top = str + len; str < top; str++) {
         ringbuf_put((ringbuf_t*)&tx_ringbuf, *str);
         usb_cdc_loop();
     }
+    return len;
 }
 
 void mp_hal_stdout_tx_strn_cooked(const char *str, mp_uint_t len) {

--- a/ports/nrf/mphalport.c
+++ b/ports/nrf/mphalport.c
@@ -196,10 +196,12 @@ int mp_hal_stdin_rx_chr(void) {
     return 0;
 }
 
-void mp_hal_stdout_tx_strn(const char *str, mp_uint_t len) {
+mp_uint_t mp_hal_stdout_tx_strn(const char *str, mp_uint_t len) {
     if (MP_STATE_VM(dupterm_objs[0]) != MP_OBJ_NULL) {
         uart_tx_strn(MP_STATE_VM(dupterm_objs[0]), str, len);
+        return len;
     }
+    return 0;
 }
 
 void mp_hal_stdout_tx_strn_cooked(const char *str, mp_uint_t len) {

--- a/ports/pic16bit/pic16bit_mphal.c
+++ b/ports/pic16bit/pic16bit_mphal.c
@@ -75,10 +75,12 @@ void mp_hal_stdout_tx_str(const char *str) {
     mp_hal_stdout_tx_strn(str, strlen(str));
 }
 
-void mp_hal_stdout_tx_strn(const char *str, size_t len) {
+mp_uint_t mp_hal_stdout_tx_strn(const char *str, size_t len) {
+    mp_uint_t ret = len;
     for (; len > 0; --len) {
         uart_tx_char(*str++);
     }
+    return ret;
 }
 
 void mp_hal_stdout_tx_strn_cooked(const char *str, size_t len) {

--- a/ports/powerpc/uart_lpc_serial.c
+++ b/ports/powerpc/uart_lpc_serial.c
@@ -108,7 +108,7 @@ int mp_hal_stdin_rx_chr(void) {
 }
 
 
-void mp_hal_stdout_tx_strn(const char *str, mp_uint_t len) {
+mp_uint_t mp_hal_stdout_tx_strn(const char *str, mp_uint_t len) {
     int i;
     for (i = 0; i < len; i++) {
         while (lpc_uart_tx_full()) {
@@ -116,4 +116,5 @@ void mp_hal_stdout_tx_strn(const char *str, mp_uint_t len) {
         }
         lpc_uart_reg_write(REG_RBR, str[i]);
     }
+    return len;
 }

--- a/ports/powerpc/uart_potato.c
+++ b/ports/powerpc/uart_potato.c
@@ -118,7 +118,7 @@ int mp_hal_stdin_rx_chr(void) {
     return (char)(val & 0x000000ff);
 }
 
-void mp_hal_stdout_tx_strn(const char *str, mp_uint_t len) {
+mp_uint_t mp_hal_stdout_tx_strn(const char *str, mp_uint_t len) {
     int i;
 
     for (i = 0; i < len; i++) {
@@ -129,4 +129,5 @@ void mp_hal_stdout_tx_strn(const char *str, mp_uint_t len) {
         }
         potato_uart_reg_write(POTATO_CONSOLE_TX, val);
     }
+    return len;
 }

--- a/ports/rp2/mphalport.c
+++ b/ports/rp2/mphalport.c
@@ -151,14 +151,18 @@ int mp_hal_stdin_rx_chr(void) {
 }
 
 // Send string of given length
-void mp_hal_stdout_tx_strn(const char *str, mp_uint_t len) {
+mp_uint_t mp_hal_stdout_tx_strn(const char *str, mp_uint_t len) {
+    mp_uint_t ret = len;
+    bool did_write = false;
     #if MICROPY_HW_ENABLE_UART_REPL
     mp_uart_write_strn(str, len);
+    did_write = true;
     #endif
 
     #if MICROPY_HW_USB_CDC
     if (tud_cdc_connected()) {
-        for (size_t i = 0; i < len;) {
+        size_t i = 0;
+        while (i < len) {
             uint32_t n = len - i;
             if (n > CFG_TUD_CDC_EP_BUFSIZE) {
                 n = CFG_TUD_CDC_EP_BUFSIZE;
@@ -173,18 +177,26 @@ void mp_hal_stdout_tx_strn(const char *str, mp_uint_t len) {
                 mp_usbd_task();
             }
             if (timeout >= MICROPY_HW_USB_CDC_TX_TIMEOUT) {
+                ret = i;
                 break;
             }
             uint32_t n2 = tud_cdc_write(str + i, n);
             tud_cdc_write_flush();
             i += n2;
         }
+        ret = MIN(i, ret);
+        did_write = true;
     }
     #endif
 
     #if MICROPY_PY_OS_DUPTERM
-    mp_os_dupterm_tx_strn(str, len);
+    int dupterm_res = mp_os_dupterm_tx_strn(str, len);
+    if (dupterm_res >= 0) {
+        did_write = true;
+        ret = MIN((mp_uint_t)dupterm_res, ret);
+    }
     #endif
+    return did_write ? ret : 0;
 }
 
 void mp_hal_delay_ms(mp_uint_t ms) {

--- a/ports/samd/mphalport.c
+++ b/ports/samd/mphalport.c
@@ -200,9 +200,12 @@ int mp_hal_stdin_rx_chr(void) {
     }
 }
 
-void mp_hal_stdout_tx_strn(const char *str, mp_uint_t len) {
+mp_uint_t mp_hal_stdout_tx_strn(const char *str, mp_uint_t len) {
+    mp_uint_t ret = len;
+    bool did_write = false;
     if (tud_cdc_connected()) {
-        for (size_t i = 0; i < len;) {
+        size_t i = 0;
+        while (i < len) {
             uint32_t n = len - i;
             if (n > CFG_TUD_CDC_EP_BUFSIZE) {
                 n = CFG_TUD_CDC_EP_BUFSIZE;
@@ -213,14 +216,22 @@ void mp_hal_stdout_tx_strn(const char *str, mp_uint_t len) {
                 MICROPY_EVENT_POLL_HOOK_WITH_USB;
             }
             if (timeout >= MICROPY_HW_USB_CDC_TX_TIMEOUT) {
+                ret = i;
                 break;
             }
             uint32_t n2 = tud_cdc_write(str + i, n);
             tud_cdc_write_flush();
             i += n2;
         }
+        ret = MIN(i, ret);
+        did_write = true;
     }
     #if MICROPY_PY_OS_DUPTERM
-    mp_os_dupterm_tx_strn(str, len);
+    int dupterm_res = mp_os_dupterm_tx_strn(str, len);
+    if (dupterm_res >= 0) {
+        did_write = true;
+        ret = MIN((mp_uint_t)dupterm_res, ret);
+    }
     #endif
+    return did_write ? ret : 0;
 }

--- a/ports/stm32/mphalport.c
+++ b/ports/stm32/mphalport.c
@@ -57,14 +57,22 @@ MP_WEAK int mp_hal_stdin_rx_chr(void) {
     }
 }
 
-MP_WEAK void mp_hal_stdout_tx_strn(const char *str, size_t len) {
+MP_WEAK mp_uint_t mp_hal_stdout_tx_strn(const char *str, size_t len) {
+    mp_uint_t ret = len;
+    bool did_write = false;
     if (MP_STATE_PORT(pyb_stdio_uart) != NULL) {
         uart_tx_strn(MP_STATE_PORT(pyb_stdio_uart), str, len);
+        did_write = true;
     }
     #if 0 && defined(USE_HOST_MODE) && MICROPY_HW_HAS_LCD
     lcd_print_strn(str, len);
     #endif
-    mp_os_dupterm_tx_strn(str, len);
+    int dupterm_res = mp_os_dupterm_tx_strn(str, len);
+    if (dupterm_res >= 0) {
+        did_write = true;
+        ret = MIN((mp_uint_t)dupterm_res, ret);
+    }
+    return did_write ? ret : 0;
 }
 
 #if __CORTEX_M >= 0x03

--- a/ports/unix/unix_mphal.c
+++ b/ports/unix/unix_mphal.c
@@ -184,10 +184,15 @@ main_term:;
     return c;
 }
 
-void mp_hal_stdout_tx_strn(const char *str, size_t len) {
+mp_uint_t mp_hal_stdout_tx_strn(const char *str, size_t len) {
     ssize_t ret;
     MP_HAL_RETRY_SYSCALL(ret, write(STDOUT_FILENO, str, len), {});
-    mp_os_dupterm_tx_strn(str, len);
+    mp_uint_t written = ret < 0 ? 0 : ret;
+    int dupterm_res = mp_os_dupterm_tx_strn(str, len);
+    if (dupterm_res >= 0) {
+        written = MIN((mp_uint_t)dupterm_res, written);
+    }
+    return written;
 }
 
 // cooked is same as uncooked because the terminal does some postprocessing

--- a/ports/webassembly/mphalport.c
+++ b/ports/webassembly/mphalport.c
@@ -27,8 +27,9 @@
 #include "library.h"
 #include "mphalport.h"
 
-void mp_hal_stdout_tx_strn(const char *str, size_t len) {
+mp_uint_t mp_hal_stdout_tx_strn(const char *str, size_t len) {
     mp_js_write(str, len);
+    return len;
 }
 
 void mp_hal_delay_ms(mp_uint_t ms) {

--- a/ports/webassembly/mphalport.h
+++ b/ports/webassembly/mphalport.h
@@ -28,7 +28,7 @@
 #include "shared/runtime/interrupt_char.h"
 
 #define mp_hal_stdin_rx_chr() (0)
-void mp_hal_stdout_tx_strn(const char *str, size_t len);
+mp_uint_t mp_hal_stdout_tx_strn(const char *str, size_t len);
 
 void mp_hal_delay_ms(mp_uint_t ms);
 void mp_hal_delay_us(mp_uint_t us);

--- a/ports/windows/windows_mphal.c
+++ b/ports/windows/windows_mphal.c
@@ -221,10 +221,11 @@ int mp_hal_stdin_rx_chr(void) {
     }
 }
 
-void mp_hal_stdout_tx_strn(const char *str, size_t len) {
+mp_uint_t mp_hal_stdout_tx_strn(const char *str, size_t len) {
     MP_THREAD_GIL_EXIT();
-    write(STDOUT_FILENO, str, len);
+    int ret = write(STDOUT_FILENO, str, len);
     MP_THREAD_GIL_ENTER();
+    return ret < 0 ? 0 : ret; // return the number of bytes written, so in case of an error in the syscall, return 0
 }
 
 void mp_hal_stdout_tx_strn_cooked(const char *str, size_t len) {

--- a/ports/zephyr/uart_core.c
+++ b/ports/zephyr/uart_core.c
@@ -44,7 +44,8 @@ int mp_hal_stdin_rx_chr(void) {
 }
 
 // Send string of given length
-void mp_hal_stdout_tx_strn(const char *str, mp_uint_t len) {
+mp_uint_t mp_hal_stdout_tx_strn(const char *str, mp_uint_t len) {
+    mp_uint_t ret = len;
     #ifdef CONFIG_CONSOLE_SUBSYS
     while (len--) {
         char c = *str++;
@@ -60,4 +61,5 @@ void mp_hal_stdout_tx_strn(const char *str, mp_uint_t len) {
         uart_poll_out(uart_console_dev, *str++);
     }
     #endif
+    return ret;
 }

--- a/py/mphal.h
+++ b/py/mphal.h
@@ -56,7 +56,7 @@ void mp_hal_stdout_tx_str(const char *str);
 #endif
 
 #ifndef mp_hal_stdout_tx_strn
-void mp_hal_stdout_tx_strn(const char *str, size_t len);
+mp_uint_t mp_hal_stdout_tx_strn(const char *str, size_t len);
 #endif
 
 #ifndef mp_hal_stdout_tx_strn_cooked

--- a/shared/runtime/sys_stdio_mphal.c
+++ b/shared/runtime/sys_stdio_mphal.c
@@ -142,8 +142,7 @@ STATIC mp_uint_t stdio_buffer_read(mp_obj_t self_in, void *buf, mp_uint_t size, 
 }
 
 STATIC mp_uint_t stdio_buffer_write(mp_obj_t self_in, const void *buf, mp_uint_t size, int *errcode) {
-    mp_hal_stdout_tx_strn(buf, size);
-    return size;
+    return mp_hal_stdout_tx_strn(buf, size);
 }
 
 STATIC const mp_stream_p_t stdio_buffer_obj_stream_p = {


### PR DESCRIPTION
For a bit of background see https://github.com/orgs/micropython/discussions/11807

MicroPython code may depend on the return value of sys.stdout.buffer.write() to reflect the number of bytes actually written. In most cases a write() succeeds, but in case it doesn't, data gets lost without any way to know it, if write() simply returns the number of bytes that should have been written.

One reason why a write may fail, is where USB is used and the receiving end doesn't read fast enough to clear out the receive buffer. In that case, write on the MicroPython side will timeout, and without this patch, part of the data is lost. This behavior was observed between a Pi Pico as client and a Linux host using the ACM driver.

This patch addresses this issue by at least moving the responsibility of supplying a return value from the core code in sys_stdio_mphal.c to the respective mp_hal_stdout_tx_strn() functions in each port. The next step is to make each port return the number of bytes actually written. For some ports, this is already implemented by this patch: where the write() system call is used, or tud_cdc_write() is used to write to USB.

A tricky problem is where mp_hal_stdout_tx_strn() has multiple outputs, e.g. USB combined with dupterm and/or hardware UART. In such cases, only successfully written bytes should probably be sent to dupterm, or else a second attempt to submit the same data will show on dupterm as duplicated data, and/or dupterm shows data that is not visible on USB.

sys.stdout.write() is a bit more difficult (but not impossible) to fix as it performs data modification (aka "cooked" output). It is kept as-is in this patch. The tradeoff made here is that developers that really care about the return value of write(), should probably use sys.stdout.buffer.write() anyway.

This patch may break some existing code, but the expectation is that it fixes existing code as well, given the fact that the return value oddness of sys.stdout.buffer.write() is not documented and probably not well known, so it is not likely that code depends on the prior (broken) behavior.