### PR TITLE
extmod/modssl: Add SSLContext class.

### DIFF
--- a/docs/library/ssl.rst
+++ b/docs/library/ssl.rst
@@ -15,21 +15,11 @@ Functions
 
 .. function:: ssl.wrap_socket(sock, server_side=False, keyfile=None, certfile=None, cert_reqs=CERT_NONE, cadata=None, server_hostname=None, do_handshake=True)
 
-   Takes a `stream` *sock* (usually socket.socket instance of ``SOCK_STREAM`` type),
-   and returns an instance of ssl.SSLSocket, which wraps the underlying stream in
-   an SSL context. Returned object has the usual `stream` interface methods like
-   ``read()``, ``write()``, etc.
-   A server-side SSL socket should be created from a normal socket returned from
-   :meth:`~socket.socket.accept()` on a non-SSL listening server socket.
-
-   - *do_handshake* determines whether the handshake is done as part of the ``wrap_socket``
-     or whether it is deferred to be done as part of the initial reads or writes
-     (there is no ``do_handshake`` method as in CPython).
-     For blocking sockets doing the handshake immediately is standard. For non-blocking
-     sockets (i.e. when the *sock* passed into ``wrap_socket`` is in non-blocking mode)
-     the handshake should generally be deferred because otherwise ``wrap_socket`` blocks
-     until it completes. Note that in AXTLS the handshake can be deferred until the first
-     read or write but it then blocks until completion.
+    Wrap the given *sock* and return a new wrapped-socket object.  The implementation
+    of this function is to first create an `SSLContext` and then call the `SSLContext.wrap_socket`
+    method on that context object.  The arguments *sock*, *server_side* and *server_hostname* are
+    passed through unchanged to the method call.  The argument *do_handshake* is passed through as
+    *do_handshake_on_connect*.  The remaining arguments have the following behaviour:
 
    - *cert_reqs* determines whether the peer (server or client) must present a valid certificate.
      Note that for mbedtls based ports, ``ssl.CERT_NONE`` and ``ssl.CERT_OPTIONAL`` will not
@@ -38,12 +28,39 @@ Functions
    - *cadata* is a bytes object containing the CA certificate chain (in DER format) that will
      validate the peer's certificate.  Currently only a single DER-encoded certificate is supported.
 
+   Depending on the underlying module implementation in a particular
+   :term:`MicroPython port`, some or all keyword arguments above may be not supported.
+
+class SSLContext
+----------------
+
+.. class:: SSLContext(protocol, /)
+
+    Create a new SSLContext instance.  The *protocol* argument must be one of the ``PROTOCOL_*``
+    constants.
+
+.. method:: SSLContext.wrap_socket(sock, *, server_side=False, do_handshake_on_connect=True, server_hostname=None)
+
+   Takes a `stream` *sock* (usually socket.socket instance of ``SOCK_STREAM`` type),
+   and returns an instance of ssl.SSLSocket, wrapping the underlying stream.
+   The returned object has the usual `stream` interface methods like
+   ``read()``, ``write()``, etc.
+
+   - *server_side* selects whether the wrapped socket is on the server or client side.
+     A server-side SSL socket should be created from a normal socket returned from
+     :meth:`~socket.socket.accept()` on a non-SSL listening server socket.
+
+   - *do_handshake_on_connect* determines whether the handshake is done as part of the ``wrap_socket``
+     or whether it is deferred to be done as part of the initial reads or writes
+     For blocking sockets doing the handshake immediately is standard. For non-blocking
+     sockets (i.e. when the *sock* passed into ``wrap_socket`` is in non-blocking mode)
+     the handshake should generally be deferred because otherwise ``wrap_socket`` blocks
+     until it completes. Note that in AXTLS the handshake can be deferred until the first
+     read or write but it then blocks until completion.
+
    - *server_hostname* is for use as a client, and sets the hostname to check against the received
      server certificate.  It also sets the name for Server Name Indication (SNI), allowing the server
      to present the proper certificate.
-
-   Depending on the underlying module implementation in a particular
-   :term:`MicroPython port`, some or all keyword arguments above may be not supported.
 
 .. warning::
 
@@ -55,6 +72,11 @@ Functions
    returns an object more similar to CPython's ``SSLObject`` which does not have
    these socket methods.
 
+.. attribute:: SSLContext.verify_mode
+
+    Set or get the behaviour for verification of peer certificates.  Must be one of the
+    ``CERT_*`` constants.
+
 Exceptions
 ----------
 
@@ -65,8 +87,14 @@ Exceptions
 Constants
 ---------
 
+.. data:: ssl.PROTOCOL_TLS_CLIENT
+          ssl.PROTOCOL_TLS_SERVER
+
+    Supported values for the *protocol* parameter.
+
 .. data:: ssl.CERT_NONE
           ssl.CERT_OPTIONAL
           ssl.CERT_REQUIRED
 
-    Supported values for *cert_reqs* parameter.
+    Supported values for *cert_reqs* parameter, and the :attr:`SSLContext.verify_mode`
+    attribute.

--- a/tests/extmod/ssl_basic.py
+++ b/tests/extmod/ssl_basic.py
@@ -33,7 +33,7 @@ except OSError as er:
 ss = ssl.wrap_socket(TestSocket(), server_side=1, do_handshake=0)
 
 # print
-print(repr(ss)[:12])
+print(ss)
 
 # setblocking() propagates call to the underlying stream object
 ss.setblocking(False)

--- a/tests/extmod/ssl_basic.py.exp
+++ b/tests/extmod/ssl_basic.py.exp
@@ -1,5 +1,5 @@
 OSError: client
-<_SSLSocket 
+<SSLSocket>
 TestSocket.setblocking(False)
 TestSocket.setblocking(True)
 TestSocket.ioctl 4 0

--- a/tests/extmod/ssl_cadata.py
+++ b/tests/extmod/ssl_cadata.py
@@ -1,0 +1,14 @@
+# Test ssl.wrap_socket() with cadata passed in.
+
+try:
+    import io
+    import ssl
+except ImportError:
+    print("SKIP")
+    raise SystemExit
+
+# Invalid cadata.
+try:
+    ssl.wrap_socket(io.BytesIO(), cadata=b"!")
+except ValueError as er:
+    print(repr(er))

--- a/tests/extmod/ssl_cadata.py.exp
+++ b/tests/extmod/ssl_cadata.py.exp
@@ -1,0 +1,1 @@
+ValueError('invalid cert',)

--- a/tests/extmod/ssl_sslcontext.py
+++ b/tests/extmod/ssl_sslcontext.py
@@ -1,0 +1,25 @@
+# Very basic test of ssl.SSLContext class.
+
+try:
+    import socket, ssl
+except ImportError:
+    print("SKIP")
+    raise SystemExit
+
+# Test constructing with arguments.
+ssl.SSLContext(ssl.PROTOCOL_TLS_CLIENT)
+ssl.SSLContext(ssl.PROTOCOL_TLS_SERVER)
+
+# Test printing object.
+ctx = ssl.SSLContext(ssl.PROTOCOL_TLS_CLIENT)
+print("SSLContext" in str(ctx))
+
+# Coverage test for destructor, and calling it twice.
+if hasattr(ctx, "__del__"):
+    ctx.__del__()
+    ctx.__del__()
+
+# Test calling .wrap_socket() method, multiple times.
+ctx = ssl.SSLContext(ssl.PROTOCOL_TLS_SERVER)
+ctx.wrap_socket(socket.socket(), do_handshake_on_connect=False)
+ctx.wrap_socket(socket.socket(), do_handshake_on_connect=False)

--- a/tests/extmod/ssl_sslcontext_micropython.py
+++ b/tests/extmod/ssl_sslcontext_micropython.py
@@ -1,0 +1,29 @@
+# Test MicroPython-specific behaviour of ssl.SSLContext.
+
+try:
+    import ssl
+except ImportError:
+    print("SKIP")
+    raise SystemExit
+
+# Test constructing without any arguments (in CPython it's a DeprecationWarning).
+try:
+    ssl.SSLContext()
+except TypeError:
+    print("TypeError")
+
+# Test attributes that don't exist (in CPython new attributes can be added).
+# This test is needed for coverage because SSLContext implements a custom attr handler.
+ctx = ssl.SSLContext(ssl.PROTOCOL_TLS_CLIENT)
+try:
+    ctx.does_not_exist
+except AttributeError:
+    print("AttributeError on load")
+try:
+    ctx.does_not_exist = None
+except AttributeError:
+    print("AttributeError on store")
+try:
+    del ctx.does_not_exist
+except AttributeError:
+    print("AttributeError on delete")

--- a/tests/extmod/ssl_sslcontext_micropython.py.exp
+++ b/tests/extmod/ssl_sslcontext_micropython.py.exp
@@ -1,0 +1,4 @@
+TypeError
+AttributeError on load
+AttributeError on store
+AttributeError on delete

--- a/tests/extmod/ssl_sslcontext_verify_mode.py
+++ b/tests/extmod/ssl_sslcontext_verify_mode.py
@@ -1,0 +1,24 @@
+# Test ssl.SSLContext.verify_mode attribute.
+# It's not available in the axtls implementation, so has an independent test.
+
+try:
+    import ssl
+except ImportError:
+    print("SKIP")
+    raise SystemExit
+
+if not hasattr(ssl.SSLContext(ssl.PROTOCOL_TLS_CLIENT), "verify_mode"):
+    print("SKIP")
+    raise SystemExit
+
+# Test default verify_mode for server (client default is different in MicroPython).
+ctx = ssl.SSLContext(ssl.PROTOCOL_TLS_SERVER)
+print(ctx.verify_mode == ssl.CERT_NONE)
+
+# Test setting and getting verify_mode.
+ctx.verify_mode = ssl.CERT_NONE
+print(ctx.verify_mode == ssl.CERT_NONE)
+ctx.verify_mode = ssl.CERT_OPTIONAL
+print(ctx.verify_mode == ssl.CERT_OPTIONAL)
+ctx.verify_mode = ssl.CERT_REQUIRED
+print(ctx.verify_mode == ssl.CERT_REQUIRED)

--- a/tests/net_inet/test_tls_sites.py
+++ b/tests/net_inet/test_tls_sites.py
@@ -3,7 +3,7 @@ import ssl
 
 # CPython only supports server_hostname with SSLContext
 if hasattr(ssl, "SSLContext"):
-    ssl = ssl.SSLContext()
+    ssl = ssl.SSLContext(ssl.PROTOCOL_TLS_CLIENT)
 
 
 def test_one(site, opts):


### PR DESCRIPTION
This PR adds the SSLContext class to the ssl module, and retains the existing ssl.wrap_socket() function to maintain backwards compatibility.

CPython deprecated the ssl.wrap_socket() function since CPython 3.7 and instead one should use ssl.SSLContext().wrap_socket().  This PR makes that possible.

For the axtls implementation:
- ssl.SSLContext is added, although it doesn't hold much state because axtls requires calling ssl_ctx_new() for each new socket
- ssl.SSLContext.wrap_socket() is added
- ssl.PROTOCOL_TLS_CLIENT and ssl.PROTOCOL_TLS_SERVER are added

For the mbedtls implementation:
- ssl.SSLContext is added, and holds most of the mbedtls state
- ssl.verify_mode is added (getter and setter)
- ssl.SSLContext.wrap_socket() is added
- ssl.PROTOCOL_TLS_CLIENT and ssl.PROTOCOL_TLS_SERVER are added

The signatures match CPython:
- SSLContext(protocol)
- SSLContext.wrap_socket(sock, *, server_side=False, do_handshake_on_connect=True, server_hostname=None)

The existing ssl.wrap_socket() functions retain their existing signature.