### PR TITLE
esp32/modules/inisetup.py: Allows to format the partition as FAT.

### DIFF
--- a/ports/esp32/modules/inisetup.py
+++ b/ports/esp32/modules/inisetup.py
@@ -37,8 +37,12 @@ by firmware programming).
 def setup():
     check_bootsec()
     print("Performing initial setup")
-    os.VfsLfs2.mkfs(bdev)
-    vfs = os.VfsLfs2(bdev)
+    if bdev.info()[4] == "vfs":
+        os.VfsLfs2.mkfs(bdev)
+        vfs = os.VfsLfs2(bdev)
+    elif bdev.info()[4] == "ffat":
+        os.VfsFat.mkfs(bdev)
+        vfs = os.VfsFat(bdev)
     os.mount(vfs, "/")
     with open("boot.py", "w") as f:
         f.write(


### PR DESCRIPTION
 To fix this https://github.com/micropython/micropython/pull/11528#issuecomment-1602684192 .

Now the compiled `micropython.uf2` can be directly used in UF2 bootloader.

