### PR TITLE
samd: A set of small changes.

### DIFF
--- a/ports/samd/Makefile
+++ b/ports/samd/Makefile
@@ -78,7 +78,7 @@ ifeq ($(DEBUG),1)
 CFLAGS += -O0
 else
 CFLAGS += -Os -DNDEBUG
-LDFLAGS += --gc-sections
+LDFLAGS += --gc-sections --print-memory-usage
 CFLAGS += -fdata-sections -ffunction-sections
 endif
 
@@ -198,7 +198,6 @@ all: $(BUILD)/firmware.uf2
 $(BUILD)/firmware.elf: $(OBJ)
 	$(ECHO) "LINK $@"
 	$(Q)$(LD) $(LDFLAGS) -o $@ $^ $(LIBS)
-	$(Q)$(SIZE) $@
 
 $(BUILD)/firmware.bin: $(BUILD)/firmware.elf
 	$(Q)$(OBJCOPY) -O binary -j .isr_vector -j .text -j .data $^ $(BUILD)/firmware.bin

--- a/ports/samd/Makefile
+++ b/ports/samd/Makefile
@@ -119,6 +119,7 @@ SRC_C += \
 	tusb_port.c \
 
 SHARED_SRC_C += \
+	drivers/dht/dht.c \
 	shared/runtime/mpirq.c \
 	shared/libc/printf.c \
 	shared/libc/string0.c \

--- a/ports/samd/Makefile
+++ b/ports/samd/Makefile
@@ -139,10 +139,33 @@ ASF4_SRC_C += $(addprefix lib/asf4/$(MCU_SERIES_LOWER)/,\
 	)
 
 LIBM_SRC_C += $(addprefix lib/libm/,\
+	acoshf.c \
+	asinfacosf.c \
+	asinhf.c \
+	atan2f.c \
+	atanf.c \
+	atanhf.c \
+	ef_rem_pio2.c \
 	ef_sqrt.c \
+	erf_lgamma.c \
 	fmodf.c \
+	kf_cos.c \
+	kf_rem_pio2.c \
+	kf_sin.c \
+	kf_tan.c \
+	log1pf.c \
 	math.c \
 	nearbyintf.c \
+	roundf.c \
+	sf_cos.c \
+	sf_erf.c \
+	sf_frexp.c \
+	sf_ldexp.c \
+	sf_modf.c \
+	sf_sin.c \
+	sf_tan.c \
+	wf_lgamma.c \
+	wf_tgamma.c \
 	)
 
 TINYUSB_SRC_C += $(addprefix lib/tinyusb/src/,\

--- a/ports/samd/boards/ADAFRUIT_FEATHER_M0_EXPRESS/mpconfigboard.mk
+++ b/ports/samd/boards/ADAFRUIT_FEATHER_M0_EXPRESS/mpconfigboard.mk
@@ -5,5 +5,4 @@ TEXT0 = 0x2000
 
 # The ?='s allow overriding in mpconfigboard.mk.
 # MicroPython settings
-MICROPY_VFS_LFS1 ?= 1
 MICROPY_HW_CODESIZE ?= 248K

--- a/ports/samd/boards/ADAFRUIT_FEATHER_M4_EXPRESS/mpconfigboard.mk
+++ b/ports/samd/boards/ADAFRUIT_FEATHER_M4_EXPRESS/mpconfigboard.mk
@@ -5,5 +5,4 @@ TEXT0 = 0x4000
 
 # The ?='s allow overriding in mpconfigboard.mk.
 # MicroPython settings
-MICROPY_VFS_LFS1 ?= 1
 MICROPY_HW_CODESIZE ?= 496K

--- a/ports/samd/boards/ADAFRUIT_ITSYBITSY_M0_EXPRESS/mpconfigboard.mk
+++ b/ports/samd/boards/ADAFRUIT_ITSYBITSY_M0_EXPRESS/mpconfigboard.mk
@@ -5,5 +5,4 @@ TEXT0 = 0x2000
 
 # The ?='s allow overriding in mpconfigboard.mk.
 # MicroPython settings
-MICROPY_VFS_LFS1 ?= 1
 MICROPY_HW_CODESIZE ?= 248K

--- a/ports/samd/boards/ADAFRUIT_ITSYBITSY_M4_EXPRESS/mpconfigboard.mk
+++ b/ports/samd/boards/ADAFRUIT_ITSYBITSY_M4_EXPRESS/mpconfigboard.mk
@@ -5,5 +5,4 @@ TEXT0 = 0x4000
 
 # The ?='s allow overriding in mpconfigboard.mk.
 # MicroPython settings
-MICROPY_VFS_LFS1 ?= 1
 MICROPY_HW_CODESIZE ?= 496K

--- a/ports/samd/boards/ADAFRUIT_METRO_M4_EXPRESS/mpconfigboard.mk
+++ b/ports/samd/boards/ADAFRUIT_METRO_M4_EXPRESS/mpconfigboard.mk
@@ -4,8 +4,6 @@ LD_FILES = boards/samd51x19a.ld sections.ld
 TEXT0 = 0x4000
 
 # MicroPython settings
-MICROPY_VFS_LFS1 ?= 1
-
 MICROPY_PY_NETWORK ?= 1
 MICROPY_PY_NETWORK_NINAW10 ?= 1
 

--- a/ports/samd/boards/ADAFRUIT_TRINKET_M0/mpconfigboard.mk
+++ b/ports/samd/boards/ADAFRUIT_TRINKET_M0/mpconfigboard.mk
@@ -2,7 +2,3 @@ MCU_SERIES = SAMD21
 CMSIS_MCU = SAMD21E18A
 LD_FILES = boards/samd21x18a.ld sections.ld
 TEXT0 = 0x2000
-
-# The ?='s allow overriding in mpconfigboard.mk.
-# MicroPython settings
-MICROPY_VFS_LFS1 ?= 1

--- a/ports/samd/boards/MINISAM_M4/mpconfigboard.mk
+++ b/ports/samd/boards/MINISAM_M4/mpconfigboard.mk
@@ -6,5 +6,4 @@ TEXT0 = 0x4000
 
 # The ?='s allow overriding in mpconfigboard.mk.
 # MicroPython settings
-MICROPY_VFS_LFS1 ?= 1
 MICROPY_HW_CODESIZE ?= 496K

--- a/ports/samd/boards/SAMD21_XPLAINED_PRO/mpconfigboard.mk
+++ b/ports/samd/boards/SAMD21_XPLAINED_PRO/mpconfigboard.mk
@@ -2,7 +2,3 @@ MCU_SERIES = SAMD21
 CMSIS_MCU = SAMD21J18A
 LD_FILES = boards/samd21x18a.ld sections.ld
 TEXT0 = 0x2000
-
-# The ?='s allow overriding in mpconfigboard.mk.
-# MicroPython settings
-MICROPY_VFS_LFS1 ?= 1

--- a/ports/samd/boards/SEEED_WIO_TERMINAL/mpconfigboard.mk
+++ b/ports/samd/boards/SEEED_WIO_TERMINAL/mpconfigboard.mk
@@ -5,5 +5,4 @@ TEXT0 = 0x4000
 
 # The ?='s allow overriding in mpconfigboard.mk.
 # MicroPython settings
-MICROPY_VFS_LFS1 ?= 1
 MICROPY_HW_CODESIZE ?= 496K

--- a/ports/samd/boards/SEEED_XIAO_SAMD21/mpconfigboard.mk
+++ b/ports/samd/boards/SEEED_XIAO_SAMD21/mpconfigboard.mk
@@ -2,8 +2,3 @@ MCU_SERIES = SAMD21
 CMSIS_MCU = SAMD21G18A
 LD_FILES = boards/samd21x18a.ld sections.ld
 TEXT0 = 0x2000
-
-# The ?='s allow overriding in mpconfigboard.mk.
-# MicroPython settings
-MICROPY_VFS_LFS1 ?= 1
-

--- a/ports/samd/boards/SPARKFUN_SAMD51_THING_PLUS/mpconfigboard.mk
+++ b/ports/samd/boards/SPARKFUN_SAMD51_THING_PLUS/mpconfigboard.mk
@@ -5,5 +5,4 @@ TEXT0 = 0x4000
 
 # The ?='s allow overriding in mpconfigboard.mk.
 # MicroPython settings
-MICROPY_VFS_LFS1 ?= 1
 MICROPY_HW_CODESIZE ?= 1008K

--- a/ports/samd/mcu/samd21/mpconfigmcu.mk
+++ b/ports/samd/mcu/samd21/mpconfigmcu.mk
@@ -7,32 +7,3 @@ MICROPY_HW_CODESIZE ?= 184K
 MICROPY_VFS_LFS1 ?= 1
 
 SRC_S += shared/runtime/gchelper_thumb1.s
-
-LIBM_SRC_C +=  $(addprefix lib/libm/,\
-	acoshf.c \
-	asinfacosf.c \
-	asinhf.c \
-	atan2f.c \
-	atanf.c \
-	atanhf.c \
-	ef_rem_pio2.c \
-	erf_lgamma.c \
-	fmodf.c \
-	kf_cos.c \
-	kf_rem_pio2.c \
-	kf_sin.c \
-	kf_tan.c \
-	log1pf.c \
-	math.c \
-	nearbyintf.c \
-	roundf.c \
-	sf_cos.c \
-	sf_erf.c \
-	sf_frexp.c \
-	sf_ldexp.c \
-	sf_modf.c \
-	sf_sin.c \
-	sf_tan.c \
-	wf_lgamma.c \
-	wf_tgamma.c \
-	)

--- a/ports/samd/mcu/samd21/mpconfigmcu.mk
+++ b/ports/samd/mcu/samd21/mpconfigmcu.mk
@@ -4,6 +4,8 @@ MPY_CROSS_MCU_ARCH = armv6m
 
 MICROPY_HW_CODESIZE ?= 184K
 
+MICROPY_VFS_LFS1 ?= 1
+
 SRC_S += shared/runtime/gchelper_thumb1.s
 
 LIBM_SRC_C +=  $(addprefix lib/libm/,\

--- a/ports/samd/mcu/samd51/mpconfigmcu.h
+++ b/ports/samd/mcu/samd51/mpconfigmcu.h
@@ -25,8 +25,6 @@
 #define MICROPY_PY_CMATH                (0)
 #endif
 
-#define MICROPY_PY_MACHINE_DHT_READINTO (1)
-#define MICROPY_PY_ONEWIRE              (1)
 #define MICROPY_PY_OS_SYNC              (1)
 #define MICROPY_PY_OS_URANDOM           (1)
 #define MICROPY_PY_RANDOM_SEED_INIT_FUNC (trng_random_u32())

--- a/ports/samd/mcu/samd51/mpconfigmcu.mk
+++ b/ports/samd/mcu/samd51/mpconfigmcu.mk
@@ -13,32 +13,3 @@ SRC_S += shared/runtime/gchelper_thumb2.s
 SRC_C += \
 	fatfs_port.c \
 	drivers/dht/dht.c \
-
-LIBM_SRC_C +=  $(addprefix lib/libm/,\
-	acoshf.c \
-	asinfacosf.c \
-	asinhf.c \
-	atan2f.c \
-	atanf.c \
-	atanhf.c \
-	ef_rem_pio2.c \
-	erf_lgamma.c \
-	fmodf.c \
-	kf_cos.c \
-	kf_rem_pio2.c \
-	kf_sin.c \
-	kf_tan.c \
-	log1pf.c \
-	math.c \
-	nearbyintf.c \
-	roundf.c \
-	sf_cos.c \
-	sf_erf.c \
-	sf_frexp.c \
-	sf_ldexp.c \
-	sf_modf.c \
-	sf_sin.c \
-	sf_tan.c \
-	wf_lgamma.c \
-	wf_tgamma.c \
-	)

--- a/ports/samd/mcu/samd51/mpconfigmcu.mk
+++ b/ports/samd/mcu/samd51/mpconfigmcu.mk
@@ -12,4 +12,3 @@ SRC_S += shared/runtime/gchelper_thumb2.s
 
 SRC_C += \
 	fatfs_port.c \
-	drivers/dht/dht.c \

--- a/ports/samd/mpconfigport.h
+++ b/ports/samd/mpconfigport.h
@@ -129,6 +129,8 @@
 #define MICROPY_PY_MACHINE_PIN_MAKE_NEW     mp_pin_make_new
 #define MICROPY_PY_MACHINE_DHT_READINTO     (1)
 #define MICROPY_PY_ONEWIRE                  (1)
+#define MICROPY_PY_PLATFORM                 (1)
+#define MICROPY_PLATFORM_VERSION            "ASF4"
 
 #define MP_STATE_PORT MP_STATE_VM
 

--- a/ports/samd/mpconfigport.h
+++ b/ports/samd/mpconfigport.h
@@ -127,6 +127,8 @@
 #define MICROPY_PY_MACHINE_PWM_INCLUDEFILE  "ports/samd/machine_pwm.c"
 #endif
 #define MICROPY_PY_MACHINE_PIN_MAKE_NEW     mp_pin_make_new
+#define MICROPY_PY_MACHINE_DHT_READINTO     (1)
+#define MICROPY_PY_ONEWIRE                  (1)
 
 #define MP_STATE_PORT MP_STATE_VM
 


### PR DESCRIPTION
Mostly port file reorganization and compatibility improvement. No new features.

- samd: Set the LFS type in mpconfigmcu.mk instead of mpconfigboard.mk. The default is either LFS1 for SAMD21 or LFS2 for SAMD51.
- samd: Move the math lib files from mpconfigmcu.mk to Makefile. They are used by both SAMD21 and SAMD51.
- samd: Print memory region usage instead of totals. It is more informative.
- samd21: Include the DHT and Onewire low level drivers. People missed them, and these sensors are pretty popular.
- samd: Provide the platform module. 
