### PR TITLE
Draft: Implement native NLR on Windows under MSVC

### DIFF
--- a/mpy-cross/.gitignore
+++ b/mpy-cross/.gitignore
@@ -1,0 +1,7 @@
+*.user
+*.*sdf
+*.suo
+*.sln
+*.filters
+.vs/*
+*.VC.*db

--- a/mpy-cross/mpconfigport.h
+++ b/mpy-cross/mpconfigport.h
@@ -148,6 +148,7 @@ typedef long mp_off_t;
 #define restrict
 #define inline                      __inline
 #define alignof(t)                  __alignof(t)
+#define __attribute__(a)
 #undef MICROPY_ALLOC_PATH_MAX
 #define MICROPY_ALLOC_PATH_MAX      260
 #define PATH_MAX                    MICROPY_ALLOC_PATH_MAX

--- a/mpy-cross/mpy-cross.vcxproj
+++ b/mpy-cross/mpy-cross.vcxproj
@@ -45,6 +45,7 @@
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <ImportGroup Label="ExtensionSettings">
+    <Import Project="$(VCTargetsPath)\BuildCustomizations\masm.props" />
   </ImportGroup>
   <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
@@ -95,11 +96,18 @@
     <ClCompile Include="$(PyBaseDir)mpy-cross\main.c"/>
     <ClCompile Include="$(PyBaseDir)ports\windows\fmode.c" />
   </ItemGroup>
+  <ItemGroup>
+    <MASM Include="@(PyCoreAsmSource)">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">true</ExcludedFromBuild>
+    </MASM>
+  </ItemGroup>
   <Import Project="$(PyMsvcDir)genhdr.targets" />
   <Import Project="$(CustomPropsFile)" Condition="exists('$(CustomPropsFile)')" />
   <Target Name="GenHeaders" BeforeTargets="BuildGenerateSources" DependsOnTargets="GenerateHeaders">
   </Target>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">
+    <Import Project="$(VCTargetsPath)\BuildCustomizations\masm.targets" />
   </ImportGroup>
 </Project>

--- a/ports/windows/micropython.vcxproj
+++ b/ports/windows/micropython.vcxproj
@@ -42,6 +42,7 @@
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <ImportGroup Label="ExtensionSettings">
+    <Import Project="$(VCTargetsPath)\BuildCustomizations\masm.props" />
   </ImportGroup>
   <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
@@ -103,11 +104,18 @@
     <ClInclude Include="$(PyBaseDir)ports\windows\*.h" />
     <ClInclude Include="$(PyBaseDir)ports\windows\msvc\*.h" />
   </ItemGroup>
+  <ItemGroup>
+    <MASM Include="@(PyCoreAsmSource)">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">true</ExcludedFromBuild>
+    </MASM>
+  </ItemGroup>
   <Import Project="msvc/genhdr.targets" />
   <Import Project="$(CustomPropsFile)" Condition="exists('$(CustomPropsFile)')" />
   <Target Name="GenerateMicroPythonSources" BeforeTargets="BuildGenerateSources" DependsOnTargets="GenerateHeaders;FreezeModules">
   </Target>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">
+    <Import Project="$(VCTargetsPath)\BuildCustomizations\masm.targets" />
   </ImportGroup>
 </Project>

--- a/ports/windows/mpconfigport.h
+++ b/ports/windows/mpconfigport.h
@@ -281,6 +281,7 @@ typedef long mp_off_t;
 #define inline                      __inline
 #define alignof(t)                  __alignof(t)
 #endif
+#define __attribute__(a)
 #define PATH_MAX                    MICROPY_ALLOC_PATH_MAX
 #define S_ISREG(m)                  (((m) & S_IFMT) == S_IFREG)
 #define S_ISDIR(m)                  (((m) & S_IFMT) == S_IFDIR)

--- a/ports/windows/msvc/sources.props
+++ b/ports/windows/msvc/sources.props
@@ -29,4 +29,7 @@
     <PyCoreInclude Include="$(PyBaseDir)py\*.h" />
     <PyExtModInclude Include="$(PyBaseDir)extmod\*.h" />
   </ItemGroup>
+  <ItemGroup>
+    <PyCoreAsmSource Include="$(PyBaseDir)py\nlrx64_msvc.asm" />
+  </ItemGroup>
 </Project>

--- a/py/nlr.c
+++ b/py/nlr.c
@@ -28,7 +28,9 @@
 
 #if !MICROPY_NLR_SETJMP
 // When not using setjmp, nlr_push_tail is called from inline asm so needs special care
-#if MICROPY_NLR_X86 && MICROPY_NLR_OS_WINDOWS
+#if MICROPY_NLR_X86 && MICROPY_NLR_OS_WINDOWS && defined(_MSC_VER)
+unsigned int nlr_push_tail(nlr_buf_t *nlr);
+#elif MICROPY_NLR_X86 && MICROPY_NLR_OS_WINDOWS
 // On these 32-bit platforms make sure nlr_push_tail doesn't have a leading underscore
 unsigned int nlr_push_tail(nlr_buf_t *nlr) asm ("nlr_push_tail");
 #else

--- a/py/nlr.h
+++ b/py/nlr.h
@@ -55,10 +55,10 @@
 #else
 #define MICROPY_NLR_OS_WINDOWS 0
 #endif
-#if defined(__i386__)
+#if defined(__i386__) || defined(_M_IX86)
     #define MICROPY_NLR_X86 (1)
     #define MICROPY_NLR_NUM_REGS (MICROPY_NLR_NUM_REGS_X86)
-#elif defined(__x86_64__)
+#elif defined(__x86_64__) || defined(_M_AMD64)
     #define MICROPY_NLR_X64 (1)
     #if MICROPY_NLR_OS_WINDOWS
         #define MICROPY_NLR_NUM_REGS (MICROPY_NLR_NUM_REGS_X64_WIN)

--- a/py/nlrx64.c
+++ b/py/nlrx64.c
@@ -26,7 +26,20 @@
 
 #include "py/mpstate.h"
 
-#if MICROPY_NLR_X64
+#if MICROPY_NLR_X64 && defined(_MSC_VER)
+
+#undef nlr_push
+
+// MSVC doesn't support inline x64 asm. Code from nlrx64_msvc.asm is used.
+
+extern void nlr_jump_tail(void *);
+
+void nlr_jump(void *val) {
+    MP_NLR_JUMP_HEAD(val, top)
+    nlr_jump_tail(top); // do the rest in assembly
+}
+
+#elif MICROPY_NLR_X64
 
 #undef nlr_push
 

--- a/py/nlrx64_msvc.asm
+++ b/py/nlrx64_msvc.asm
@@ -1,0 +1,71 @@
+;*
+;* This file is part of the MicroPython project, http://micropython.org/
+;*
+;* The MIT License (MIT)
+;*
+;* Copyright (c) 2013-2017 Damien P. George
+;*
+;* Permission is hereby granted, free of charge, to any person obtaining a copy
+;* of this software and associated documentation files (the "Software"), to deal
+;* in the Software without restriction, including without limitation the rights
+;* to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+;* copies of the Software, and to permit persons to whom the Software is
+;* furnished to do so, subject to the following conditions:
+;*
+;* The above copyright notice and this permission notice shall be included in
+;* all copies or substantial portions of the Software.
+;*
+;* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+;* IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+;* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+;* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+;* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+;* OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+;* THE SOFTWARE.
+;*
+
+; unsigned int nlr_push_tail(nlr_buf_t *nlr);
+nlr_push_tail	proto
+
+.code
+
+;// x86-64 callee-save registers are:
+;//  rbx, rbp, rsp, r12, r13, r14, r15
+
+;unsigned int nlr_push(nlr_buf_t *nlr)
+nlr_push	PROC EXPORT
+	mov   rax, [rsp]         ; load return rip
+	mov   16[rcx], rax       ; store rip into nlr_buf
+	mov   24[rcx], rbp       ; store rbp into nlr_buf
+	mov   32[rcx], rsp       ; store rsp into nlr_buf
+	mov   40[rcx], rbx       ; store rbx into nlr_buf
+	mov   48[rcx], r12       ; store r12 into nlr_buf
+	mov   56[rcx], r13       ; store r13 into nlr_buf
+	mov   64[rcx], r14       ; store r14 into nlr_buf
+	mov   72[rcx], r15       ; store r15 into nlr_buf
+	mov   80[rcx], rdi       ; store rdr into nlr_buf
+	mov   88[rcx], rsi       ; store rsi into nlr_buf
+	jmp   nlr_push_tail      ; do the rest in C
+nlr_push	ENDP
+
+
+; void nlr_jump_tail(void *val)
+nlr_jump_tail	PROC EXPORT
+                             ; rcx points to nlr_buf
+	mov   rsi, 88[rcx]       ; load saved rsi
+	mov   rdi, 80[rcx]       ; load saved rdi
+	mov   r15, 72[rcx]       ; load saved r15
+	mov   r14, 64[rcx]       ; load saved r14
+	mov   r13, 56[rcx]       ; load saved r13
+	mov   r12, 48[rcx]       ; load saved r12
+	mov   rbx, 40[rcx]       ; load saved rbx
+	mov   rsp, 32[rcx]       ; load saved rsp
+	mov   rbp, 24[rcx]       ; load saved rbp
+	mov   rax, 16[rcx]       ; load saved rip
+	mov   [rsp], rax         ; store saved rip to stack
+	xor   rax, rax           ; clear return register
+	inc   al                 ; increase to make 1, non-local return
+	ret
+nlr_jump_tail	ENDP
+
+				END

--- a/py/objgenerator.c
+++ b/py/objgenerator.c
@@ -210,7 +210,7 @@ mp_vm_return_kind_t mp_obj_gen_resume(mp_obj_t self_in, mp_obj_t send_value, mp_
     if (self->code_state.exc_sp_idx == MP_CODE_STATE_EXC_SP_IDX_SENTINEL) {
         // A native generator, with entry point 2 words into the "bytecode" pointer
         typedef uintptr_t (*mp_fun_native_gen_t)(void *, mp_obj_t);
-        mp_fun_native_gen_t fun = MICROPY_MAKE_POINTER_CALLABLE((const void *)(self->code_state.fun_bc->bytecode + 2 * sizeof(uintptr_t)));
+        mp_fun_native_gen_t fun = MICROPY_MAKE_POINTER_CALLABLE((void *)(self->code_state.fun_bc->bytecode + 2 * sizeof(uintptr_t)));
         ret_kind = fun((void *)&self->code_state, throw_value);
     } else
     #endif


### PR DESCRIPTION
Native NLR now works when building with MSVC for both x86 and x64.

This is one step on the way to getting feature parity between MINGW/gcc Windows builds and MSVC.