### PR TITLE
ports/esp32: Set ESPNow power management with ESPNow.config(pm=).

### DIFF
--- a/docs/library/espnow.rst
+++ b/docs/library/espnow.rst
@@ -170,6 +170,26 @@ Configuration
         <https://docs.espressif.com/projects/esp-idf/en/v4.4.1/esp32/
         api-reference/network/esp_wifi.html#_CPPv415wifi_phy_rate_t>`_.
 
+        *pm*: (ESP32 only) Set the ESPNOW wireless power saving parameters.
+        Usage: ``e.config(pm=(window, interval))``: every ``interval``
+        milliseconds the radio will be turned on for ``window`` milliseconds to
+        listen for incoming messages (``interval`` should be a multiple of
+        100ms). Incoming messages will be lost while the radio is off. Messages
+        may be sent at any time. By default, ESPNOW power saving is disabled and
+        the radio is turned on continuously. Examples::
+
+          e.config(pm=(75, 200))  # equivalent to WLAN.config(pm=WLAN.PM_PERFORMANCE)
+          e.config(pm=(75, 300))  # equivalent to WLAN.config(pm=WLAN.PM_POWERSAVE)
+
+        If the device is also connected to a wifi Access Point, the wifi power
+        saving mode will be used instead
+        (see `WLAN.config(pm=XX)<network.WLAN.config>`).
+
+        See `Config ESP-NOW Power-saving Parameter
+        <https://docs.espressif.com/projects/esp-idf/en/v5.0.2/esp32/
+        api-reference/network/
+        esp_now.html#config-esp-now-power-saving-parameter>`_.
+
     .. data:: Returns:
 
         ``None`` or the value of the parameter being queried.

--- a/ports/esp32/modespnow.c
+++ b/ports/esp32/modespnow.c
@@ -236,12 +236,13 @@ STATIC MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(espnow_active_obj, 1, 2, espnow_activ
 //    timeout: Default read timeout (default=300,000 milliseconds)
 STATIC mp_obj_t espnow_config(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
     esp_espnow_obj_t *self = _get_singleton();
-    enum { ARG_get, ARG_rxbuf, ARG_timeout_ms, ARG_rate };
+    enum { ARG_get, ARG_rxbuf, ARG_timeout_ms, ARG_rate, ARG_pm };
     static const mp_arg_t allowed_args[] = {
         { MP_QSTR_, MP_ARG_OBJ, {.u_obj = MP_OBJ_NULL} },
         { MP_QSTR_rxbuf, MP_ARG_KW_ONLY | MP_ARG_INT, {.u_int = -1} },
         { MP_QSTR_timeout_ms, MP_ARG_KW_ONLY | MP_ARG_INT, {.u_int = INT_MIN} },
         { MP_QSTR_rate, MP_ARG_KW_ONLY | MP_ARG_INT, {.u_int = -1} },
+        { MP_QSTR_pm, MP_ARG_KW_ONLY | MP_ARG_OBJ, {.u_obj = MP_OBJ_NULL} },
     };
     mp_arg_val_t args[MP_ARRAY_SIZE(allowed_args)];
     mp_arg_parse_all(n_args - 1, pos_args + 1, kw_args,
@@ -258,6 +259,17 @@ STATIC mp_obj_t espnow_config(size_t n_args, const mp_obj_t *pos_args, mp_map_t 
         check_esp_err(esp_wifi_config_espnow_rate(ESP_IF_WIFI_STA, args[ARG_rate].u_int));
         check_esp_err(esp_wifi_config_espnow_rate(ESP_IF_WIFI_AP, args[ARG_rate].u_int));
     }
+    if (args[ARG_pm].u_obj != MP_OBJ_NULL) {
+        mp_obj_tuple_t *t = (mp_obj_tuple_t *)MP_OBJ_TO_PTR(args[ARG_pm].u_obj);
+        if (!mp_obj_is_type(t, &mp_type_tuple) || t->len < 1 || t->len > 2) {
+            mp_raise_TypeError(MP_ERROR_TEXT("pm should be set to tuple of length 2"));
+        }
+        check_esp_err(esp_now_set_wake_window(mp_obj_get_int(t->items[0])));
+        if (t->len == 2) {
+            check_esp_err(esp_wifi_connectionless_module_set_wake_interval(mp_obj_get_int(t->items[1])));
+        }
+    }
+
     if (args[ARG_get].u_obj == MP_OBJ_NULL) {
         return mp_const_none;
     }


### PR DESCRIPTION
## Control power management of the wifi radio during ESPNOW operation.

Control the ESPNOW power management parameters with the `ESPNow.config(pm=(window, interval))`. 

These settings are used whenever the module is **disconnected** from a wifi Access Point. While connected to a wifi AP, the wifi power management settings will be used instead (`WLAN.config(pm=WLAN.PM_POWERSAVE)`).

**Usage:**

- `e.config(pm=(75, 200))` sets the wake_window to 75ms and the wake_interval to 200ms, ie: turn on the radio for 75ms every 200ms (equivalent to `WLAN.config(pm=WLAN.PM_PERFORMANCE)`)
- `e.config(pm=(75, 300))` sets the wake_window to 75ms and the wake_interval to 300ms (equivalent to `WLAN.config(pm=WLAN.PM_POWERSAVE)`)

By default, when disconnected from a wifi Access Point the radio is left on continuously which may lead to undesirable power drain of battery operated devices. IDF v5.0 has introduced the `esp_now_set_wake_window()` and `esp_wifi_connectionless_module_set_wake_interval()` to control the duty cycle of the radio for listening to incoming messages while not connected to an AP.

For the results of some power consumption tests, see: https://github.com/glenn20/upy-esp32-experiments/tree/main/ESPNowPowerManagement.

See [Config ESP-NOW Power-saving Parameter](https://docs.espressif.com/projects/esp-idf/en/v5.0.2/esp32/api-reference/network/esp_now.html#config-esp-now-power-saving-parameter).