### PR TITLE
stm32/uart: Fix UART timeout issue with low baudrate.

### DIFF
--- a/ports/stm32/uart.c
+++ b/ports/stm32/uart.c
@@ -1052,12 +1052,20 @@ size_t uart_tx_data(pyb_uart_obj_t *self, const void *src_in, size_t num_chars, 
         // the overall timeout rather than the character timeout.
         timeout = self->timeout;
     } else {
+        #if defined(STM32G4)
+        // With using UART FIFO, the timeout should be long enough that FIFO becomes empty.
+        // Since previous data transfer may be ongoing, the timeout must be multiplied
+        // timeout_char by FIFO size + 1.
+        // STM32G4 has 8 words FIFO.
+        timeout = (8 + 1) * self->timeout_char;
+        #else
         // The timeout specified here is for waiting for the TX data register to
         // become empty (ie between chars), as well as for the final char to be
         // completely transferred.  The default value for timeout_char is long
         // enough for 1 char, but we need to double it to wait for the last char
         // to be transferred to the data register, and then to be transmitted.
         timeout = 2 * self->timeout_char;
+        #endif
     }
 
     const uint8_t *src = (const uint8_t *)src_in;


### PR DESCRIPTION
### MicroPython Version
v1.20.0-261-g813d559bc

### Environment
NUCLEO-G474RE

### How to reproduce
Execute this code:
```python
from pyb import UART
uart = UART(1, 4800, bits=8, parity=None, stop=1)
print(uart)

print(uart.any())
print(uart.write("123"))
print(uart.write(b"abcd"))
print(uart.writechar(1))
```

Got result:
```
UART(1, baudrate=4800, bits=8, parity=None, stop=1, flow=0, timeout=0, timeout_char=4, rxbuf=64)
0
3
Traceback (most recent call last):
  File "<stdin>", line 7, in <module>
OSError: [Errno 110] ETIMEDOUT
```

### Detail of changes
`timeout_char` is calculated at
https://github.com/micropython/micropython/blob/813d559bc098eeaa1c6e0fa1deff92e666c0b458/ports/stm32/machine_uart.c#L253
However, if `13000 / baudrate` is not divisible by baudrate (such as 4800, 9600, ...), calculated timeout will be less than actual timeout required.
To solve this issue, this PR rounds up timeout_char if `13000 / baudrate` is not divisible by baudrate.

Since this PR affects test results using tests/pyb/uart.py, I also modified expected test result.

### Effect of changes
Be able to write values with low baudlate.
```
UART(1, baudrate=4800, bits=8, parity=None, stop=1, flow=0, timeout=0, timeout_char=5, rxbuf=64)
0
3
4
None
```

