### PR TITLE
py/builtinimport: Fix for external-import disabled.

### DIFF
--- a/py/builtinimport.c
+++ b/py/builtinimport.c
@@ -632,9 +632,14 @@ mp_obj_t mp_builtin___import___default(size_t n_args, const mp_obj_t *args) {
         return elem->value;
     }
 
-    // Try the name directly as a built-in.
+    // Try the name directly as a non-extensible built-in (e.g. `micropython`).
     qstr module_name_qstr = mp_obj_str_get_qstr(args[0]);
     mp_obj_t module_obj = mp_module_get_builtin(module_name_qstr, false);
+    if (module_obj != MP_OBJ_NULL) {
+        return module_obj;
+    }
+    // Now try as an extensible built-in (e.g. `time`).
+    module_obj = mp_module_get_builtin(module_name_qstr, true);
     if (module_obj != MP_OBJ_NULL) {
         return module_obj;
     }


### PR DESCRIPTION
Follow-up to 24c02c4eb5f11200f876bb57cd63a9d0bae91fd3 for when `MICROPY_ENABLE_EXTERNAL_IMPORT=0`. It now needs to try both extensible and non-extensible modules.

This maybe could be optimised further by removing the second argument from `mp_module_get_builtin`, or possibly even disabling the distinction between extensible and non-extensible builtins when `MICROPY_ENABLE_EXTERNAL_IMPORT=0` (i.e. all modules just go in `mp_builtin_module_table` and `MP_REGISTER_EXTENSIBLE_MODULE` just behaves like `MP_REGISTER_MODULE`). Not sure if that's worth it though?