### PR TITLE
stm32/qspi.c: Allow qspi_write_cmd_data to write cmd with 1 data byte.

### DIFF
--- a/ports/stm32/qspi.c
+++ b/ports/stm32/qspi.c
@@ -232,8 +232,12 @@ STATIC int qspi_write_cmd_data(void *self_in, uint8_t cmd, size_t len, uint32_t 
         while (!(QUADSPI->SR & QUADSPI_SR_FTF)) {
         }
 
-        // This assumes len==2
-        *(uint16_t *)&QUADSPI->DR = data;
+        if (len == 1) {
+            *(uint8_t *)&QUADSPI->DR = data;
+        } else {
+            // This assumes len==2
+            *(uint16_t *)&QUADSPI->DR = data;
+        }
     }
 
     // Wait for write to finish


### PR DESCRIPTION
The existing qspi for stm32 implementation can only send a spi command with exactly 0 or 2 data bytes. Certain spiflash chips (e.g. AT25SF321B) have commands that only take a single data byte, and will ignore the command if more than that is sent. This allows sending a command with a single data byte. Would be nicer to have a general function to send `n` bytes, but there probably aren't many commands that require this.