### PR TITLE
stm32/main: Catch and report corrupted lfs filesystem at startup.

### DIFF
--- a/ports/stm32/main.c
+++ b/ports/stm32/main.c
@@ -185,8 +185,15 @@ MP_NOINLINE static bool init_flash_fs(uint reset_mode) {
 
     if (len != -1) {
         // Detected a littlefs filesystem so create correct block device for it
-        mp_obj_t args[] = { MP_OBJ_NEW_QSTR(MP_QSTR_len), MP_OBJ_NEW_SMALL_INT(len) };
-        bdev = MP_OBJ_TYPE_GET_SLOT(&pyb_flash_type, make_new)(&pyb_flash_type, 0, 1, args);
+        mp_obj_t lfs_bdev = pyb_flash_new_obj(0, len);
+        if (lfs_bdev == mp_const_none) {
+            // Invalid len detected, filesystem header block likely corrupted.
+            // Create bdev with default size to attempt to mount the whole flash or
+            // let user attempt recovery if desired.
+            bdev = pyb_flash_new_obj(0, -1);
+        } else {
+            bdev = lfs_bdev;
+        }
     }
 
     #endif

--- a/ports/stm32/storage.h
+++ b/ports/stm32/storage.h
@@ -77,4 +77,8 @@ extern const struct _pyb_flash_obj_t pyb_flash_obj;
 struct _fs_user_mount_t;
 void pyb_flash_init_vfs(struct _fs_user_mount_t *vfs);
 
+#if !BUILDING_MBOOT
+mp_obj_t pyb_flash_new_obj(mp_int_t start, mp_int_t len);
+#endif
+
 #endif // MICROPY_INCLUDED_STM32_STORAGE_H


### PR DESCRIPTION
On stm platform the startup code attempts to mount the configured filesystem.

If there is an existing littlefs filesystem that's suitable corrupted it's possible for the reported blocksize to be incorrect here: https://github.com/micropython/micropython/blob/813d559bc098eeaa1c6e0fa1deff92e666c0b458/ports/stm32/main.c#L176

This `block_size` (which is read from the filesystem iteself) is used to create the `len` argument passed to `pyb_flash_make_new()` here: https://github.com/micropython/micropython/blob/813d559bc098eeaa1c6e0fa1deff92e666c0b458/ports/stm32/main.c#L187

In `pyb_flash_make_new()` the len arg is validated to be a mutliple of the underlying hardware block size: https://github.com/micropython/micropython/blob/813d559bc098eeaa1c6e0fa1deff92e666c0b458/ports/stm32/storage.c#L315

Any failure is raised as a `ValueError`. This exception is not caught currently in main, it flows up to the high level assert / startup failure.

As this occurs before `boot.py` is run, the users (potentially frozen) application code doesn't have any opportunity to detect and handle the issue.

This MR adds a try/except around `pyb_flash_make_new()`, resulting the corrupt filesystem not being mounted so application code can handle the issue safely without needing external tools to wipe the flash.
