### PR TITLE
double-precision-float enable

### DIFF
--- a/ports/rp2/mpconfigport.h
+++ b/ports/rp2/mpconfigport.h
@@ -79,7 +79,7 @@
 #define MICROPY_ENABLE_GC                       (1)
 #define MICROPY_ENABLE_EMERGENCY_EXCEPTION_BUF  (1)
 #define MICROPY_LONGINT_IMPL                    (MICROPY_LONGINT_IMPL_MPZ)
-#define MICROPY_FLOAT_IMPL                      (MICROPY_FLOAT_IMPL_FLOAT)
+#define MICROPY_FLOAT_IMPL                      (MICROPY_FLOAT_IMPL_DOUBLE)
 #define MICROPY_SCHEDULER_DEPTH                 (8)
 #define MICROPY_SCHEDULER_STATIC_NODES          (1)
 #ifndef MICROPY_USE_INTERNAL_ERRNO


### PR DESCRIPTION
By default, MicroPython RPI pico port has single precision float support.
Change the same to double precision.
Reason: Typically, the applications that run on high end uC
have the need of higher precision. This also enables your applications
to get same answers on desktop and Pico.
 