### PR TITLE
docs/ESP32: Reinitialize watchdog timer with longer timeout.

### DIFF
--- a/docs/esp32/quickref.rst
+++ b/docs/esp32/quickref.rst
@@ -748,7 +748,7 @@ See :ref:`machine.WDT <machine.WDT>`. ::
     from machine import WDT
 
     # enable the WDT with a timeout of 5s (1s is the minimum)
-    wdt = WDT(timeout=5000)
+    wdt = WDT(timeout=5000)  # timeout in milliseconds
     wdt.feed()
 
 .. _Deep_sleep_mode:

--- a/docs/esp32/tutorial/index.rst
+++ b/docs/esp32/tutorial/index.rst
@@ -20,5 +20,6 @@ to `<https://www.python.org>`__.
 
    intro.rst
    pwm.rst
+   wdt.rst
    peripheral_access.rst
    reset.rst

--- a/docs/esp32/tutorial/wdt.rst
+++ b/docs/esp32/tutorial/wdt.rst
@@ -1,0 +1,43 @@
+
+.. _esp32_wdt:
+
+WDT
+===
+
+When the WDT timeout is short, a problem occurs when updating the software:
+you don't have enough time to copy the updates to the device.
+ESP32 allows reinitialise the watchdog with a longer timeout - like an hour.
+
+More comprehansive example usage::
+
+    # Save as 'main.py' and it will run automatically after 'boot.py'
+
+    import sys
+    from time import sleep
+    from machine import WDT, reset
+
+    try:
+        print('Press Ctrl-C to break the program.')
+        sleep(5)
+        print('Enable the WDT with a timeout of 5s.')
+        wdt = WDT(timeout=5000)
+
+        seconds = 1
+        while True:  # infinite work loop
+            print('Do something useful in less than 5 seconds.')
+            print(f'Sleep {seconds} seconds.')
+            if seconds >= 5:
+                print(f'WDT will reboot the board.')
+            sleep(seconds)
+            seconds += 1
+            wdt.feed()
+
+            # 1/0  # uncomment this line to raise an runtime exception, then WDT reboot
+
+            # sys.exit()  # uncomment this line for planned program exit
+
+    except SystemExit:
+        wdt = WDT(timeout=1000 * 60 * 60)  # 1 hour before WDT reboot
+        print('Now you have 1 hour to update program on the board.')
+        print('When ready, type reset() on the REPL/WebREPL command line to reboot.')
+

--- a/docs/library/machine.WDT.rst
+++ b/docs/library/machine.WDT.rst
@@ -5,15 +5,17 @@ class WDT -- watchdog timer
 ===========================
 
 The WDT is used to restart the system when the application crashes and ends
-up into a non recoverable state. Once started it cannot be stopped or
-reconfigured in any way. After enabling, the application must "feed" the
+up into a non recoverable state. Once started it cannot be stopped
+in any way. After enabling, the application must "feed" the
 watchdog periodically to prevent it from expiring and resetting the system.
 
 Example usage::
 
     from machine import WDT
     wdt = WDT(timeout=2000)  # enable it with a timeout of 2s
-    wdt.feed()
+    while True:
+        # do something useful in less than 2 seconds
+        wdt.feed()
 
 Availability of this class: pyboard, WiPy, esp8266, esp32, rp2040, mimxrt.
 


### PR DESCRIPTION
If the WDT timeout is short(several seconds), a problem occurs when updating the software:
you don't have enough time to copy updates to the device.
ESP32 allows reinitializing the watchdog with a longer timeout - like an hour.

Discussion in
ESP32/machine_wdt.c: Add WDT.deinit() method. https://github.com/micropython/micropython/pull/6631

The best explanation at [comment](https://github.com/micropython/micropython/pull/6631#issuecomment-856732972)

This PR is a copy of #10901 which was damaged due to rebase.