### PR TITLE
esp32/boards/LILYGO_TTGO_LORA32: Add necessary reset sequence for OLED display

### DIFF
--- a/ports/esp32/boards/LILYGO_TTGO_LORA32/modules/lilygo_oled.py
+++ b/ports/esp32/boards/LILYGO_TTGO_LORA32/modules/lilygo_oled.py
@@ -4,7 +4,12 @@ import network
 
 
 class OLED(SSD1306_I2C):
-    def __init__(self, i2c):
+    def __init__(self, i2c, rstpin):
+        # Initialize the OLED display
+        if rstpin is not None:
+            rstpin.value(0)
+            sleep_ms(50)
+            rstpin.value(1)  # must be held high after initialization
         super().__init__(128, 32, i2c)
 
     def test(self):

--- a/ports/esp32/boards/LILYGO_TTGO_LORA32/modules/lora32.py
+++ b/ports/esp32/boards/LILYGO_TTGO_LORA32/modules/lora32.py
@@ -28,6 +28,7 @@ class Lora32Base:
         # OLED
         self.OLED_SDA = const(21)
         self.OLED_SCL = const(22)
+        self.OLED_RST = None
 
         if define_helpers:
             self.create_helpers()
@@ -35,7 +36,8 @@ class Lora32Base:
     def create_helpers(self):
         self.led = Pin(self.LED, Pin.OUT)
         self.i2c = SoftI2C(scl=Pin(self.OLED_SCL), sda=Pin(self.OLED_SDA))
-        self.oled = OLED(self.i2c)
+        rstpin = self.OLED_RST is not None and Pin(self.OLED_RST, Pin.OUT) or None
+        self.oled = OLED(self.i2c, rstpin)
 
 
 class Lora32v1_0(Lora32Base):


### PR DESCRIPTION
Fix for board v1.0 based on https://rntlab.com/question/heltec-lora-32-micropython-oled-not-working/ and old Arduino code samples for this hardware e.g. https://github.com/elvis-epx/LoRaMaDoR/blob/master/src/Display.cpp.