### PR TITLE
mpy-cross: allow using stdin and stdout instead of files

### DIFF
--- a/mpy-cross/main.c
+++ b/mpy-cross/main.c
@@ -90,7 +90,8 @@ STATIC int compile_and_save(const char *file, const char *output_file, const cha
         cm.context = m_new_obj(mp_module_context_t);
         mp_compile_to_raw_code(&parse_tree, source_name, false, &cm);
 
-        if (output_file != NULL && strcmp(output_file, "-") == 0) {
+        if ((output_file != NULL && strcmp(output_file, "-") == 0) ||
+            (output_file == NULL && strcmp(file, "-") == 0)) {
             mp_raw_code_save(&cm, (mp_print_t *)&mp_stdout_print);
         } else {
             vstr_t vstr;
@@ -121,7 +122,7 @@ STATIC int usage(char **argv) {
         "usage: %s [<opts>] [-X <implopt>] [--] <input filename>\n"
         "Options:\n"
         "--version : show version information\n"
-        "-o : output file for compiled bytecode (defaults to input with .mpy extension)\n"
+        "-o : output file for compiled bytecode (defaults to input filename with .mpy extension, or stdout if input is stdin)\n"
         "-s : source filename to embed in the compiled bytecode (defaults to input file)\n"
         "-v : verbose (trace various operations); can be multiple\n"
         "-O[N] : apply bytecode optimizations of level N\n"

--- a/mpy-cross/main.c
+++ b/mpy-cross/main.c
@@ -243,7 +243,7 @@ MP_NOINLINE int main_(int argc, char **argv) {
 
     // parse main options
     for (int a = 1; a < argc; a++) {
-        if (option_parsing_active && argv[a][0] == '-') {
+        if (option_parsing_active && argv[a][0] == '-' && argv[a][1] != '\0') {
             if (strcmp(argv[a], "-X") == 0) {
                 a += 1;
             } else if (strcmp(argv[a], "--version") == 0) {

--- a/mpy-cross/main.c
+++ b/mpy-cross/main.c
@@ -100,7 +100,7 @@ STATIC int compile_and_save(const char *file, const char *output_file, const cha
 
 STATIC int usage(char **argv) {
     printf(
-        "usage: %s [<opts>] [-X <implopt>] <input filename>\n"
+        "usage: %s [<opts>] [-X <implopt>] [--] <input filename>\n"
         "Options:\n"
         "--version : show version information\n"
         "-o : output file for compiled bytecode (defaults to input with .mpy extension)\n"
@@ -220,10 +220,11 @@ MP_NOINLINE int main_(int argc, char **argv) {
     const char *input_file = NULL;
     const char *output_file = NULL;
     const char *source_file = NULL;
+    bool option_parsing_active = true;
 
     // parse main options
     for (int a = 1; a < argc; a++) {
-        if (argv[a][0] == '-') {
+        if (option_parsing_active && argv[a][0] == '-') {
             if (strcmp(argv[a], "-X") == 0) {
                 a += 1;
             } else if (strcmp(argv[a], "--version") == 0) {
@@ -309,6 +310,8 @@ MP_NOINLINE int main_(int argc, char **argv) {
                 } else {
                     return usage(argv);
                 }
+            } else if (strcmp(argv[a], "--") == 0) {
+                option_parsing_active = false;
             } else {
                 return usage(argv);
             }


### PR DESCRIPTION
Specifying `-` for the input or output file name uses stdin and stdout instead.