### PR TITLE
esp32: Add support for named pins.

### DIFF
--- a/ports/esp32/boards/make-pins.py
+++ b/ports/esp32/boards/make-pins.py
@@ -1,0 +1,185 @@
+#!/usr/bin/env python
+
+import argparse
+import sys
+import csv
+import re
+
+MAX_CPU_PINS = 49
+
+
+def parse_pin(name_str):
+    """Parses a string and returns a pin number."""
+    if len(name_str) < 2:
+        raise ValueError("Expecting pin name to be at least 2 characters.")
+    if not name_str.startswith("GPIO"):
+        raise ValueError("Expecting pin name to start with GPIO")
+    return int(re.findall(r"\d+$", name_str)[0])
+
+
+class Pin:
+    def __init__(self, pin):
+        self.pin = pin
+        self.is_board = False
+
+    def cpu_pin_name(self):
+        return "GPIO{:d}".format(self.pin)
+
+    def is_board_pin(self):
+        return self.is_board
+
+    def set_is_board_pin(self):
+        self.is_board = True
+
+
+class NamedPin:
+    def __init__(self, name, pin):
+        self._name = name
+        self._pin = pin
+
+    def pin(self):
+        return self._pin
+
+    def name(self):
+        return self._name
+
+
+class Pins:
+    def __init__(self):
+        self.cpu_pins = []  # list of NamedPin objects
+        self.board_pins = []  # list of NamedPin objects
+
+    def find_pin(self, pin_name):
+        for pin in self.cpu_pins:
+            if pin.name() == pin_name:
+                return pin.pin()
+
+    def create_pins(self):
+        for pin_num in range(MAX_CPU_PINS):
+            pin = Pin(pin_num)
+            self.cpu_pins.append(NamedPin(pin.cpu_pin_name(), pin))
+
+    def parse_board_file(self, filename):
+        with open(filename, "r") as csvfile:
+            rows = csv.reader(csvfile)
+            for row in rows:
+                if len(row) == 0 or row[0].startswith("#"):
+                    # Skip empty lines, and lines starting with "#"
+                    continue
+                if len(row) != 2:
+                    raise ValueError("Expecting two entries in a row")
+
+                cpu_pin_name = row[1]
+                parse_pin(cpu_pin_name)
+                pin = self.find_pin(cpu_pin_name)
+                if not pin:
+                    raise ValueError("Unknown pin {}".format(cpu_pin_name))
+                pin.set_is_board_pin()
+                if row[0]:  # Only add board pins that have a name
+                    self.board_pins.append(NamedPin(row[0], pin))
+
+    def print_table(self, label, named_pins, out_source):
+        print("", file=out_source)
+        print(
+            "const machine_{}_obj_t machine_{}_obj_table[GPIO_NUM_MAX] = {{".format(label, label),
+            file=out_source,
+        )
+        for pin in named_pins:
+            print("    #if MICROPY_HW_ENABLE_{}".format(pin.name()), file=out_source)
+            print(
+                "    [GPIO_NUM_{}] = {{ .base = {{ .type = &machine_{}_type }} }},".format(
+                    pin.pin().pin, label
+                ),
+                file=out_source,
+            )
+            print("    #endif", file=out_source)
+        print("};", file=out_source)
+
+    def print_named(self, label, named_pins, out_source):
+        print("", file=out_source)
+        print(
+            "STATIC const mp_rom_map_elem_t machine_pin_{:s}_pins_locals_dict_table[] = {{".format(
+                label
+            ),
+            file=out_source,
+        )
+        for named_pin in named_pins:
+            pin = named_pin.pin()
+            print(
+                "  {{ MP_ROM_QSTR(MP_QSTR_{:s}), MP_ROM_PTR(&pin_{:s}) }},".format(
+                    named_pin.name(), pin.cpu_pin_name()
+                ),
+                file=out_source,
+            )
+
+        print("};", file=out_source)
+        print(
+            "MP_DEFINE_CONST_DICT(machine_pin_{:s}_pins_locals_dict, machine_pin_{:s}_pins_locals_dict_table);".format(
+                label, label
+            ),
+            file=out_source,
+        )
+
+    def print_tables(self, out_source):
+        self.print_table("pin", self.cpu_pins, out_source)
+        self.print_table("pin_irq", self.cpu_pins, out_source)
+        self.print_named("board", self.board_pins, out_source)
+
+    def print_header(self, out_header):
+        # Provide #defines for each cpu pin.
+        for named_pin in self.cpu_pins:
+            pin = named_pin.pin()
+            n = pin.cpu_pin_name()
+            print("#if MICROPY_HW_ENABLE_{}".format(n), file=out_header)
+            print(
+                "#define pin_{:s} (machine_pin_obj_table[{}])".format(n, pin.pin),
+                file=out_header,
+            )
+            print("#endif", file=out_header)
+
+        # Provide #define's mapping board to cpu name.
+        for named_pin in self.board_pins:
+            if named_pin.pin().is_board_pin():
+                print(
+                    "#define pin_{:s} pin_{:s}".format(
+                        named_pin.name(), named_pin.pin().cpu_pin_name()
+                    ),
+                    file=out_header,
+                )
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Generate board specific pin file")
+    parser.add_argument("--board-csv")
+    parser.add_argument("--prefix")
+    parser.add_argument("--output-source")
+    parser.add_argument("--output-header")
+    args = parser.parse_args(sys.argv[1:])
+
+    pins = Pins()
+    pins.create_pins()
+
+    if args.board_csv:
+        pins.parse_board_file(args.board_csv)
+
+    with open(args.output_source, "w") as out_source:
+        print("// This file was automatically generated by make-pins.py", file=out_source)
+        print("//", file=out_source)
+
+        if args.board_csv:
+            print("// --board-csv {:s}".format(args.board_csv), file=out_source)
+
+        if args.prefix:
+            print("// --prefix {:s}".format(args.prefix), file=out_source)
+            print("", file=out_source)
+            with open(args.prefix, "r") as prefix_file:
+                print(prefix_file.read(), end="", file=out_source)
+
+        pins.print_tables(out_source)
+
+    with open(args.output_header, "w") as out_header:
+        pins.print_header(out_header)
+
+
+if __name__ == "__main__":
+    main()

--- a/ports/esp32/boards/pins_prefix.c
+++ b/ports/esp32/boards/pins_prefix.c
@@ -1,0 +1,4 @@
+#include "py/obj.h"
+#include "machine_pin.h"
+#include "modmachine.h"
+#include "genhdr/pins.h"

--- a/ports/esp32/machine_pin.c
+++ b/ports/esp32/machine_pin.c
@@ -5,7 +5,7 @@
  *
  * The MIT License (MIT)
  *
- * Copyright (c) 2016 Damien P. George
+ * Copyright (c) 2016-2023 Damien P. George
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -38,8 +38,10 @@
 #include "mphalport.h"
 #include "modmachine.h"
 #include "extmod/virtpin.h"
+#include "machine_pin.h"
 #include "machine_rtc.h"
 #include "modesp32.h"
+#include "genhdr/pins.h"
 
 #if CONFIG_IDF_TARGET_ESP32C3
 #include "soc/usb_serial_jtag_reg.h"
@@ -55,174 +57,18 @@
 #define GPIO_FIRST_NON_OUTPUT (46)
 #endif
 
-typedef struct _machine_pin_obj_t {
-    mp_obj_base_t base;
-    gpio_num_t id;
-} machine_pin_obj_t;
+// Return the gpio_num_t index for a given pin or pin-irq object.
+#define PIN_OBJ_INDEX(self) ((self) - &machine_pin_obj_table[0])
+#define PIN_IRQ_OBJ_INDEX(self) ((self) - &machine_pin_irq_obj_table[0])
 
-typedef struct _machine_pin_irq_obj_t {
-    mp_obj_base_t base;
-    gpio_num_t id;
-} machine_pin_irq_obj_t;
-
-STATIC const machine_pin_obj_t machine_pin_obj[GPIO_NUM_MAX] = {
-    #if CONFIG_IDF_TARGET_ESP32
-
-    {{&machine_pin_type}, GPIO_NUM_0},
-    {{&machine_pin_type}, GPIO_NUM_1},
-    {{&machine_pin_type}, GPIO_NUM_2},
-    {{&machine_pin_type}, GPIO_NUM_3},
-    {{&machine_pin_type}, GPIO_NUM_4},
-    {{&machine_pin_type}, GPIO_NUM_5},
-    {{&machine_pin_type}, GPIO_NUM_6},
-    {{&machine_pin_type}, GPIO_NUM_7},
-    {{&machine_pin_type}, GPIO_NUM_8},
-    {{&machine_pin_type}, GPIO_NUM_9},
-    {{&machine_pin_type}, GPIO_NUM_10},
-    {{&machine_pin_type}, GPIO_NUM_11},
-    {{&machine_pin_type}, GPIO_NUM_12},
-    {{&machine_pin_type}, GPIO_NUM_13},
-    {{&machine_pin_type}, GPIO_NUM_14},
-    {{&machine_pin_type}, GPIO_NUM_15},
-    #if CONFIG_ESP32_SPIRAM_SUPPORT
-    {{NULL}, -1},
-    {{NULL}, -1},
-    #else
-    {{&machine_pin_type}, GPIO_NUM_16},
-    {{&machine_pin_type}, GPIO_NUM_17},
-    #endif
-    {{&machine_pin_type}, GPIO_NUM_18},
-    {{&machine_pin_type}, GPIO_NUM_19},
-    {{&machine_pin_type}, GPIO_NUM_20},
-    {{&machine_pin_type}, GPIO_NUM_21},
-    {{&machine_pin_type}, GPIO_NUM_22},
-    {{&machine_pin_type}, GPIO_NUM_23},
-    {{NULL}, -1},
-    {{&machine_pin_type}, GPIO_NUM_25},
-    {{&machine_pin_type}, GPIO_NUM_26},
-    {{&machine_pin_type}, GPIO_NUM_27},
-    {{NULL}, -1},
-    {{NULL}, -1},
-    {{NULL}, -1},
-    {{NULL}, -1},
-    {{&machine_pin_type}, GPIO_NUM_32},
-    {{&machine_pin_type}, GPIO_NUM_33},
-    {{&machine_pin_type}, GPIO_NUM_34},
-    {{&machine_pin_type}, GPIO_NUM_35},
-    {{&machine_pin_type}, GPIO_NUM_36},
-    {{&machine_pin_type}, GPIO_NUM_37},
-    {{&machine_pin_type}, GPIO_NUM_38},
-    {{&machine_pin_type}, GPIO_NUM_39},
-
-    #elif CONFIG_IDF_TARGET_ESP32C3
-
-    {{&machine_pin_type}, GPIO_NUM_0},
-    {{&machine_pin_type}, GPIO_NUM_1},
-    {{&machine_pin_type}, GPIO_NUM_2},
-    {{&machine_pin_type}, GPIO_NUM_3},
-    {{&machine_pin_type}, GPIO_NUM_4},
-    {{&machine_pin_type}, GPIO_NUM_5},
-    {{&machine_pin_type}, GPIO_NUM_6},
-    {{&machine_pin_type}, GPIO_NUM_7},
-    {{&machine_pin_type}, GPIO_NUM_8},
-    {{&machine_pin_type}, GPIO_NUM_9},
-    {{&machine_pin_type}, GPIO_NUM_10},
-    {{&machine_pin_type}, GPIO_NUM_11},
-    {{&machine_pin_type}, GPIO_NUM_12},
-    {{&machine_pin_type}, GPIO_NUM_13},
-    {{NULL}, -1}, // 14 FLASH
-    {{NULL}, -1}, // 15 FLASH
-    {{NULL}, -1}, // 16 FLASH
-    {{NULL}, -1}, // 17 FLASH
-    #if CONFIG_ESP_CONSOLE_USB_SERIAL_JTAG
-    {{NULL}, -1}, // 18 is for native USB D-
-    {{NULL}, -1}, // 19 is for native USB D+
-    #else
-    {{&machine_pin_type}, GPIO_NUM_18},
-    {{&machine_pin_type}, GPIO_NUM_19},
-    #endif
-    {{&machine_pin_type}, GPIO_NUM_20},
-    {{&machine_pin_type}, GPIO_NUM_21},
-
-    #elif CONFIG_IDF_TARGET_ESP32S2 || CONFIG_IDF_TARGET_ESP32S3
-
-    {{&machine_pin_type}, GPIO_NUM_0},
-    {{&machine_pin_type}, GPIO_NUM_1},
-    {{&machine_pin_type}, GPIO_NUM_2},
-    {{&machine_pin_type}, GPIO_NUM_3},
-    {{&machine_pin_type}, GPIO_NUM_4},
-    {{&machine_pin_type}, GPIO_NUM_5},
-    {{&machine_pin_type}, GPIO_NUM_6},
-    {{&machine_pin_type}, GPIO_NUM_7},
-    {{&machine_pin_type}, GPIO_NUM_8},
-    {{&machine_pin_type}, GPIO_NUM_9},
-    {{&machine_pin_type}, GPIO_NUM_10},
-    {{&machine_pin_type}, GPIO_NUM_11},
-    {{&machine_pin_type}, GPIO_NUM_12},
-    {{&machine_pin_type}, GPIO_NUM_13},
-    {{&machine_pin_type}, GPIO_NUM_14},
-    {{&machine_pin_type}, GPIO_NUM_15},
-    {{&machine_pin_type}, GPIO_NUM_16},
-    {{&machine_pin_type}, GPIO_NUM_17},
-    {{&machine_pin_type}, GPIO_NUM_18},
-    #if CONFIG_USB_CDC_ENABLED
-    {{NULL}, -1}, // 19 is for native USB D-
-    {{NULL}, -1}, // 20 is for native USB D-
-    #else
-    {{&machine_pin_type}, GPIO_NUM_19},
-    {{&machine_pin_type}, GPIO_NUM_20},
-    #endif
-    {{&machine_pin_type}, GPIO_NUM_21},
-    {{NULL}, -1}, // 22 not a pin
-    {{NULL}, -1}, // 23 not a pin
-    {{NULL}, -1}, // 24 not a pin
-    {{NULL}, -1}, // 25 not a pin
-    #if CONFIG_SPIRAM
-    {{NULL}, -1}, // 26 PSRAM
-    #else
-    {{&machine_pin_type}, GPIO_NUM_26},
-    #endif
-    {{NULL}, -1}, // 27 FLASH/PSRAM
-    {{NULL}, -1}, // 28 FLASH/PSRAM
-    {{NULL}, -1}, // 29 FLASH/PSRAM
-    {{NULL}, -1}, // 30 FLASH/PSRAM
-    {{NULL}, -1}, // 31 FLASH/PSRAM
-    {{NULL}, -1}, // 32 FLASH/PSRAM
-    #if CONFIG_SPIRAM_MODE_OCT
-    {{NULL}, -1}, // 33 FLASH/PSRAM
-    {{NULL}, -1}, // 34 FLASH/PSRAM
-    {{NULL}, -1}, // 35 FLASH/PSRAM
-    {{NULL}, -1}, // 36 FLASH/PSRAM
-    {{NULL}, -1}, // 37 FLASH/PSRAM
-    #else
-    {{&machine_pin_type}, GPIO_NUM_33},
-    {{&machine_pin_type}, GPIO_NUM_34},
-    {{&machine_pin_type}, GPIO_NUM_35},
-    {{&machine_pin_type}, GPIO_NUM_36},
-    {{&machine_pin_type}, GPIO_NUM_37},
-    #endif
-    {{&machine_pin_type}, GPIO_NUM_38},
-    {{&machine_pin_type}, GPIO_NUM_39}, // MTCLK
-    {{&machine_pin_type}, GPIO_NUM_40}, // MTDO
-    {{&machine_pin_type}, GPIO_NUM_41}, // MTDI
-    {{&machine_pin_type}, GPIO_NUM_42}, // MTMS
-    {{&machine_pin_type}, GPIO_NUM_43}, // U0TXD
-    {{&machine_pin_type}, GPIO_NUM_44}, // U0RXD
-    {{&machine_pin_type}, GPIO_NUM_45},
-    {{&machine_pin_type}, GPIO_NUM_46},
-
-    #endif
-
-    #if CONFIG_IDF_TARGET_ESP32S3 && MICROPY_HW_ESP32S3_EXTENDED_IO
-
-    {{&machine_pin_type}, GPIO_NUM_47},
-    {{&machine_pin_type}, GPIO_NUM_48},
-
-    #endif
-};
-
-// forward declaration
-STATIC const machine_pin_irq_obj_t machine_pin_irq_object[GPIO_NUM_MAX];
+STATIC const machine_pin_obj_t *machine_pin_find_named(const mp_obj_dict_t *named_pins, mp_obj_t name) {
+    const mp_map_t *named_map = &named_pins->map;
+    mp_map_elem_t *named_elem = mp_map_lookup((mp_map_t *)named_map, name, MP_MAP_LOOKUP);
+    if (named_elem != NULL && named_elem->value != NULL) {
+        return MP_OBJ_TO_PTR(named_elem->value);
+    }
+    return NULL;
+}
 
 void machine_pins_init(void) {
     static bool did_install = false;
@@ -234,16 +80,16 @@ void machine_pins_init(void) {
 }
 
 void machine_pins_deinit(void) {
-    for (int i = 0; i < MP_ARRAY_SIZE(machine_pin_obj); ++i) {
-        if (machine_pin_obj[i].id != (gpio_num_t)-1) {
-            gpio_isr_handler_remove(machine_pin_obj[i].id);
+    for (int i = 0; i < MP_ARRAY_SIZE(machine_pin_obj_table); ++i) {
+        if (machine_pin_obj_table[i].base.type != NULL) {
+            gpio_isr_handler_remove(i);
         }
     }
 }
 
 STATIC void machine_pin_isr_handler(void *arg) {
     machine_pin_obj_t *self = arg;
-    mp_obj_t handler = MP_STATE_PORT(machine_pin_irq_handler)[self->id];
+    mp_obj_t handler = MP_STATE_PORT(machine_pin_irq_handler)[PIN_OBJ_INDEX(self)];
     mp_sched_schedule(handler, MP_OBJ_FROM_PTR(self));
     mp_hal_wake_main_task_from_isr();
 }
@@ -252,28 +98,37 @@ STATIC const machine_pin_obj_t *machine_pin_find(mp_obj_t pin_in) {
     if (mp_obj_is_type(pin_in, &machine_pin_type)) {
         return pin_in;
     }
-    // get the wanted pin object
-    if (mp_obj_is_small_int(pin_in)) {
+
+    // Try to find the pin via integer index into the array of all pins.
+    if (mp_obj_is_int(pin_in)) {
         int wanted_pin = mp_obj_get_int(pin_in);
-        if (0 <= wanted_pin && wanted_pin < MP_ARRAY_SIZE(machine_pin_obj)) {
-            machine_pin_obj_t *self = (machine_pin_obj_t *)&machine_pin_obj[wanted_pin];
+        if (0 <= wanted_pin && wanted_pin < MP_ARRAY_SIZE(machine_pin_obj_table)) {
+            const machine_pin_obj_t *self = (machine_pin_obj_t *)&machine_pin_obj_table[wanted_pin];
             if (self->base.type != NULL) {
                 return self;
             }
         }
     }
-    // At this place a check for named pins may be added
-    //
-    mp_raise_ValueError(MP_ERROR_TEXT("expecting a pin"));
+
+    // Try to find the pin in the board pins dict.
+    if (mp_obj_is_str(pin_in)) {
+        const machine_pin_obj_t *self = machine_pin_find_named(&machine_pin_board_pins_locals_dict, pin_in);
+        if (self->base.type != NULL) {
+            return self;
+        }
+    }
+
+    mp_raise_ValueError(MP_ERROR_TEXT("invalid pin"));
 }
 
 gpio_num_t machine_pin_get_id(mp_obj_t pin_in) {
-    return machine_pin_find(pin_in)->id;
+    const machine_pin_obj_t *self = machine_pin_find(pin_in);
+    return PIN_OBJ_INDEX(self);
 }
 
 STATIC void machine_pin_print(const mp_print_t *print, mp_obj_t self_in, mp_print_kind_t kind) {
     machine_pin_obj_t *self = self_in;
-    mp_printf(print, "Pin(%u)", self->id);
+    mp_printf(print, "Pin(%u)", PIN_OBJ_INDEX(self));
 }
 
 // pin.init(mode=None, pull=-1, *, value, drive, hold)
@@ -293,32 +148,32 @@ STATIC mp_obj_t machine_pin_obj_init_helper(const machine_pin_obj_t *self, size_
 
     // reset the pin to digital if this is a mode-setting init (grab it back from ADC)
     if (args[ARG_mode].u_obj != mp_const_none) {
-        if (rtc_gpio_is_valid_gpio(self->id)) {
+        if (rtc_gpio_is_valid_gpio(PIN_OBJ_INDEX(self))) {
             #if !CONFIG_IDF_TARGET_ESP32C3
-            rtc_gpio_deinit(self->id);
+            rtc_gpio_deinit(PIN_OBJ_INDEX(self));
             #endif
         }
     }
 
     #if CONFIG_IDF_TARGET_ESP32C3
-    if (self->id == 18 || self->id == 19) {
+    if (PIN_OBJ_INDEX(self) == 18 || PIN_OBJ_INDEX(self) == 19) {
         CLEAR_PERI_REG_MASK(USB_SERIAL_JTAG_CONF0_REG, USB_SERIAL_JTAG_USB_PAD_ENABLE);
     }
     #endif
 
     // configure the pin for gpio
-    esp_rom_gpio_pad_select_gpio(self->id);
+    esp_rom_gpio_pad_select_gpio(PIN_OBJ_INDEX(self));
 
     // set initial value (do this before configuring mode/pull)
     if (args[ARG_value].u_obj != MP_OBJ_NULL) {
-        gpio_set_level(self->id, mp_obj_is_true(args[ARG_value].u_obj));
+        gpio_set_level(PIN_OBJ_INDEX(self), mp_obj_is_true(args[ARG_value].u_obj));
     }
 
     // set drive capability (do this before configuring mode)
-    if (args[ARG_drive].u_obj != MP_OBJ_NULL && GPIO_IS_VALID_OUTPUT_GPIO(self->id)) {
+    if (args[ARG_drive].u_obj != MP_OBJ_NULL && GPIO_IS_VALID_OUTPUT_GPIO(PIN_OBJ_INDEX(self))) {
         mp_int_t strength = mp_obj_get_int(args[ARG_drive].u_obj);
         if (0 <= strength && strength < GPIO_DRIVE_CAP_MAX) {
-            gpio_set_drive_capability(self->id, strength);
+            gpio_set_drive_capability(PIN_OBJ_INDEX(self), strength);
         }
     }
 
@@ -326,11 +181,11 @@ STATIC mp_obj_t machine_pin_obj_init_helper(const machine_pin_obj_t *self, size_
     if (args[ARG_mode].u_obj != mp_const_none) {
         mp_int_t pin_io_mode = mp_obj_get_int(args[ARG_mode].u_obj);
         #ifdef GPIO_FIRST_NON_OUTPUT
-        if (self->id >= GPIO_FIRST_NON_OUTPUT && (pin_io_mode & GPIO_MODE_DEF_OUTPUT)) {
+        if (PIN_OBJ_INDEX(self) >= GPIO_FIRST_NON_OUTPUT && (pin_io_mode & GPIO_MODE_DEF_OUTPUT)) {
             mp_raise_ValueError(MP_ERROR_TEXT("pin can only be input"));
         }
         #endif
-        gpio_set_direction(self->id, pin_io_mode);
+        gpio_set_direction(PIN_OBJ_INDEX(self), pin_io_mode);
     }
 
     // configure pull
@@ -340,24 +195,24 @@ STATIC mp_obj_t machine_pin_obj_init_helper(const machine_pin_obj_t *self, size_
             mode = mp_obj_get_int(args[ARG_pull].u_obj);
         }
         if (mode & GPIO_PULL_DOWN) {
-            gpio_pulldown_en(self->id);
+            gpio_pulldown_en(PIN_OBJ_INDEX(self));
         } else {
-            gpio_pulldown_dis(self->id);
+            gpio_pulldown_dis(PIN_OBJ_INDEX(self));
         }
         if (mode & GPIO_PULL_UP) {
-            gpio_pullup_en(self->id);
+            gpio_pullup_en(PIN_OBJ_INDEX(self));
         } else {
-            gpio_pullup_dis(self->id);
+            gpio_pullup_dis(PIN_OBJ_INDEX(self));
         }
     }
 
     // configure pad hold
-    if (args[ARG_hold].u_obj != MP_OBJ_NULL && GPIO_IS_VALID_OUTPUT_GPIO(self->id)) {
+    if (args[ARG_hold].u_obj != MP_OBJ_NULL && GPIO_IS_VALID_OUTPUT_GPIO(PIN_OBJ_INDEX(self))) {
         // always disable pad hold to apply outstanding config changes
-        gpio_hold_dis(self->id);
+        gpio_hold_dis(PIN_OBJ_INDEX(self));
         // (re-)enable pad hold if requested
         if (mp_obj_is_true(args[ARG_hold].u_obj)) {
-            gpio_hold_en(self->id);
+            gpio_hold_en(PIN_OBJ_INDEX(self));
         }
     }
 
@@ -387,10 +242,10 @@ STATIC mp_obj_t machine_pin_call(mp_obj_t self_in, size_t n_args, size_t n_kw, c
     machine_pin_obj_t *self = self_in;
     if (n_args == 0) {
         // get pin
-        return MP_OBJ_NEW_SMALL_INT(gpio_get_level(self->id));
+        return MP_OBJ_NEW_SMALL_INT(gpio_get_level(PIN_OBJ_INDEX(self)));
     } else {
         // set pin
-        gpio_set_level(self->id, mp_obj_is_true(args[0]));
+        gpio_set_level(PIN_OBJ_INDEX(self), mp_obj_is_true(args[0]));
         return mp_const_none;
     }
 }
@@ -410,7 +265,7 @@ STATIC MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(machine_pin_value_obj, 1, 2, machine_
 // pin.off()
 STATIC mp_obj_t machine_pin_off(mp_obj_t self_in) {
     machine_pin_obj_t *self = MP_OBJ_TO_PTR(self_in);
-    gpio_set_level(self->id, 0);
+    gpio_set_level(PIN_OBJ_INDEX(self), 0);
     return mp_const_none;
 }
 STATIC MP_DEFINE_CONST_FUN_OBJ_1(machine_pin_off_obj, machine_pin_off);
@@ -418,7 +273,7 @@ STATIC MP_DEFINE_CONST_FUN_OBJ_1(machine_pin_off_obj, machine_pin_off);
 // pin.on()
 STATIC mp_obj_t machine_pin_on(mp_obj_t self_in) {
     machine_pin_obj_t *self = MP_OBJ_TO_PTR(self_in);
-    gpio_set_level(self->id, 1);
+    gpio_set_level(PIN_OBJ_INDEX(self), 1);
     return mp_const_none;
 }
 STATIC MP_DEFINE_CONST_FUN_OBJ_1(machine_pin_on_obj, machine_pin_on);
@@ -455,20 +310,20 @@ STATIC mp_obj_t machine_pin_irq(size_t n_args, const mp_obj_t *pos_args, mp_map_
                 mp_raise_ValueError(MP_ERROR_TEXT("no resources"));
             }
 
-            if (!RTC_IS_VALID_EXT_PIN(self->id)) {
+            if (!RTC_IS_VALID_EXT_PIN(PIN_OBJ_INDEX(self))) {
                 mp_raise_ValueError(MP_ERROR_TEXT("invalid pin for wake"));
             }
 
             if (machine_rtc_config.ext0_pin == -1) {
-                machine_rtc_config.ext0_pin = self->id;
-            } else if (machine_rtc_config.ext0_pin != self->id) {
+                machine_rtc_config.ext0_pin = PIN_OBJ_INDEX(self);
+            } else if (machine_rtc_config.ext0_pin != PIN_OBJ_INDEX(self)) {
                 mp_raise_ValueError(MP_ERROR_TEXT("no resources"));
             }
 
             machine_rtc_config.ext0_level = trigger == GPIO_INTR_LOW_LEVEL ? 0 : 1;
             machine_rtc_config.ext0_wake_types = wake;
         } else {
-            if (machine_rtc_config.ext0_pin == self->id) {
+            if (machine_rtc_config.ext0_pin == PIN_OBJ_INDEX(self)) {
                 machine_rtc_config.ext0_pin = -1;
             }
 
@@ -476,17 +331,24 @@ STATIC mp_obj_t machine_pin_irq(size_t n_args, const mp_obj_t *pos_args, mp_map_
                 handler = MP_OBJ_NULL;
                 trigger = 0;
             }
-            gpio_isr_handler_remove(self->id);
-            MP_STATE_PORT(machine_pin_irq_handler)[self->id] = handler;
-            gpio_set_intr_type(self->id, trigger);
-            gpio_isr_handler_add(self->id, machine_pin_isr_handler, (void *)self);
+            gpio_isr_handler_remove(PIN_OBJ_INDEX(self));
+            MP_STATE_PORT(machine_pin_irq_handler)[PIN_OBJ_INDEX(self)] = handler;
+            gpio_set_intr_type(PIN_OBJ_INDEX(self), trigger);
+            gpio_isr_handler_add(PIN_OBJ_INDEX(self), machine_pin_isr_handler, (void *)self);
         }
     }
 
     // return the irq object
-    return MP_OBJ_FROM_PTR(&machine_pin_irq_object[self->id]);
+    return MP_OBJ_FROM_PTR(&machine_pin_irq_obj_table[PIN_OBJ_INDEX(self)]);
 }
 STATIC MP_DEFINE_CONST_FUN_OBJ_KW(machine_pin_irq_obj, 1, machine_pin_irq);
+
+MP_DEFINE_CONST_OBJ_TYPE(
+    machine_pin_board_pins_obj_type,
+    MP_QSTR_board,
+    MP_TYPE_FLAG_NONE,
+    locals_dict, &machine_pin_board_pins_locals_dict
+    );
 
 STATIC const mp_rom_map_elem_t machine_pin_locals_dict_table[] = {
     // instance methods
@@ -495,6 +357,9 @@ STATIC const mp_rom_map_elem_t machine_pin_locals_dict_table[] = {
     { MP_ROM_QSTR(MP_QSTR_off), MP_ROM_PTR(&machine_pin_off_obj) },
     { MP_ROM_QSTR(MP_QSTR_on), MP_ROM_PTR(&machine_pin_on_obj) },
     { MP_ROM_QSTR(MP_QSTR_irq), MP_ROM_PTR(&machine_pin_irq_obj) },
+
+    // class attributes
+    { MP_ROM_QSTR(MP_QSTR_board), MP_ROM_PTR(&machine_pin_board_pins_obj_type) },
 
     // class constants
     { MP_ROM_QSTR(MP_QSTR_IN), MP_ROM_INT(GPIO_MODE_INPUT) },
@@ -518,10 +383,10 @@ STATIC mp_uint_t pin_ioctl(mp_obj_t self_in, mp_uint_t request, uintptr_t arg, i
 
     switch (request) {
         case MP_PIN_READ: {
-            return gpio_get_level(self->id);
+            return gpio_get_level(PIN_OBJ_INDEX(self));
         }
         case MP_PIN_WRITE: {
-            gpio_set_level(self->id, arg);
+            gpio_set_level(PIN_OBJ_INDEX(self), arg);
             return 0;
         }
     }
@@ -548,172 +413,19 @@ MP_DEFINE_CONST_OBJ_TYPE(
 /******************************************************************************/
 // Pin IRQ object
 
-STATIC const mp_obj_type_t machine_pin_irq_type;
-
-STATIC const machine_pin_irq_obj_t machine_pin_irq_object[GPIO_NUM_MAX] = {
-    #if CONFIG_IDF_TARGET_ESP32
-
-    {{&machine_pin_irq_type}, GPIO_NUM_0},
-    {{&machine_pin_irq_type}, GPIO_NUM_1},
-    {{&machine_pin_irq_type}, GPIO_NUM_2},
-    {{&machine_pin_irq_type}, GPIO_NUM_3},
-    {{&machine_pin_irq_type}, GPIO_NUM_4},
-    {{&machine_pin_irq_type}, GPIO_NUM_5},
-    {{&machine_pin_irq_type}, GPIO_NUM_6},
-    {{&machine_pin_irq_type}, GPIO_NUM_7},
-    {{&machine_pin_irq_type}, GPIO_NUM_8},
-    {{&machine_pin_irq_type}, GPIO_NUM_9},
-    {{&machine_pin_irq_type}, GPIO_NUM_10},
-    {{&machine_pin_irq_type}, GPIO_NUM_11},
-    {{&machine_pin_irq_type}, GPIO_NUM_12},
-    {{&machine_pin_irq_type}, GPIO_NUM_13},
-    {{&machine_pin_irq_type}, GPIO_NUM_14},
-    {{&machine_pin_irq_type}, GPIO_NUM_15},
-    #if CONFIG_ESP32_SPIRAM_SUPPORT
-    {{NULL}, -1},
-    {{NULL}, -1},
-    #else
-    {{&machine_pin_irq_type}, GPIO_NUM_16},
-    {{&machine_pin_irq_type}, GPIO_NUM_17},
-    #endif
-    {{&machine_pin_irq_type}, GPIO_NUM_18},
-    {{&machine_pin_irq_type}, GPIO_NUM_19},
-    {{&machine_pin_irq_type}, GPIO_NUM_20},
-    {{&machine_pin_irq_type}, GPIO_NUM_21},
-    {{&machine_pin_irq_type}, GPIO_NUM_22},
-    {{&machine_pin_irq_type}, GPIO_NUM_23},
-    {{NULL}, -1},
-    {{&machine_pin_irq_type}, GPIO_NUM_25},
-    {{&machine_pin_irq_type}, GPIO_NUM_26},
-    {{&machine_pin_irq_type}, GPIO_NUM_27},
-    {{NULL}, -1},
-    {{NULL}, -1},
-    {{NULL}, -1},
-    {{NULL}, -1},
-    {{&machine_pin_irq_type}, GPIO_NUM_32},
-    {{&machine_pin_irq_type}, GPIO_NUM_33},
-    {{&machine_pin_irq_type}, GPIO_NUM_34},
-    {{&machine_pin_irq_type}, GPIO_NUM_35},
-    {{&machine_pin_irq_type}, GPIO_NUM_36},
-    {{&machine_pin_irq_type}, GPIO_NUM_37},
-    {{&machine_pin_irq_type}, GPIO_NUM_38},
-    {{&machine_pin_irq_type}, GPIO_NUM_39},
-
-    #elif CONFIG_IDF_TARGET_ESP32C3
-
-    {{&machine_pin_irq_type}, GPIO_NUM_0},
-    {{&machine_pin_irq_type}, GPIO_NUM_1},
-    {{&machine_pin_irq_type}, GPIO_NUM_2},
-    {{&machine_pin_irq_type}, GPIO_NUM_3},
-    {{&machine_pin_irq_type}, GPIO_NUM_4},
-    {{&machine_pin_irq_type}, GPIO_NUM_5},
-    {{&machine_pin_irq_type}, GPIO_NUM_6},
-    {{&machine_pin_irq_type}, GPIO_NUM_7},
-    {{&machine_pin_irq_type}, GPIO_NUM_8},
-    {{&machine_pin_irq_type}, GPIO_NUM_9},
-    {{&machine_pin_irq_type}, GPIO_NUM_10},
-    {{&machine_pin_irq_type}, GPIO_NUM_11},
-    {{&machine_pin_irq_type}, GPIO_NUM_12},
-    {{&machine_pin_irq_type}, GPIO_NUM_13},
-    {{&machine_pin_irq_type}, GPIO_NUM_14},
-    {{&machine_pin_irq_type}, GPIO_NUM_15},
-    {{&machine_pin_irq_type}, GPIO_NUM_16},
-    {{&machine_pin_irq_type}, GPIO_NUM_17},
-    {{&machine_pin_irq_type}, GPIO_NUM_18},
-    {{&machine_pin_irq_type}, GPIO_NUM_19},
-    {{&machine_pin_irq_type}, GPIO_NUM_20},
-    {{&machine_pin_irq_type}, GPIO_NUM_21},
-
-    #elif CONFIG_IDF_TARGET_ESP32S2 || CONFIG_IDF_TARGET_ESP32S3
-
-    {{&machine_pin_irq_type}, GPIO_NUM_0},
-    {{&machine_pin_irq_type}, GPIO_NUM_1},
-    {{&machine_pin_irq_type}, GPIO_NUM_2},
-    {{&machine_pin_irq_type}, GPIO_NUM_3},
-    {{&machine_pin_irq_type}, GPIO_NUM_4},
-    {{&machine_pin_irq_type}, GPIO_NUM_5},
-    {{&machine_pin_irq_type}, GPIO_NUM_6},
-    {{&machine_pin_irq_type}, GPIO_NUM_7},
-    {{&machine_pin_irq_type}, GPIO_NUM_8},
-    {{&machine_pin_irq_type}, GPIO_NUM_9},
-    {{&machine_pin_irq_type}, GPIO_NUM_10},
-    {{&machine_pin_irq_type}, GPIO_NUM_11},
-    {{&machine_pin_irq_type}, GPIO_NUM_12},
-    {{&machine_pin_irq_type}, GPIO_NUM_13},
-    {{&machine_pin_irq_type}, GPIO_NUM_14},
-    {{&machine_pin_irq_type}, GPIO_NUM_15},
-    {{&machine_pin_irq_type}, GPIO_NUM_16},
-    {{&machine_pin_irq_type}, GPIO_NUM_17},
-    {{&machine_pin_irq_type}, GPIO_NUM_18},
-    #if CONFIG_USB_CDC_ENABLED
-    {{NULL}, -1}, // 19 is for native USB D-
-    {{NULL}, -1}, // 20 is for native USB D-
-    #else
-    {{&machine_pin_irq_type}, GPIO_NUM_19},
-    {{&machine_pin_irq_type}, GPIO_NUM_20},
-    #endif
-    {{&machine_pin_irq_type}, GPIO_NUM_21},
-    {{NULL}, -1}, // 22 not a pin
-    {{NULL}, -1}, // 23 not a pin
-    {{NULL}, -1}, // 24 not a pin
-    {{NULL}, -1}, // 25 not a pin
-    #if CONFIG_SPIRAM
-    {{NULL}, -1}, // 26 PSRAM
-    #else
-    {{&machine_pin_irq_type}, GPIO_NUM_26},
-    #endif
-    {{NULL}, -1}, // 27 FLASH/PSRAM
-    {{NULL}, -1}, // 28 FLASH/PSRAM
-    {{NULL}, -1}, // 29 FLASH/PSRAM
-    {{NULL}, -1}, // 30 FLASH/PSRAM
-    {{NULL}, -1}, // 31 FLASH/PSRAM
-    {{NULL}, -1}, // 32 FLASH/PSRAM
-    #if CONFIG_SPIRAM_MODE_OCT
-    {{NULL}, -1}, // 33 FLASH/PSRAM
-    {{NULL}, -1}, // 34 FLASH/PSRAM
-    {{NULL}, -1}, // 35 FLASH/PSRAM
-    {{NULL}, -1}, // 36 FLASH/PSRAM
-    {{NULL}, -1}, // 37 FLASH/PSRAM
-    #else
-    {{&machine_pin_irq_type}, GPIO_NUM_33},
-    {{&machine_pin_irq_type}, GPIO_NUM_34},
-    {{&machine_pin_irq_type}, GPIO_NUM_35},
-    {{&machine_pin_irq_type}, GPIO_NUM_36},
-    {{&machine_pin_irq_type}, GPIO_NUM_37},
-    #endif
-    {{&machine_pin_irq_type}, GPIO_NUM_38},
-    {{&machine_pin_irq_type}, GPIO_NUM_39},
-    {{&machine_pin_irq_type}, GPIO_NUM_40},
-    {{&machine_pin_irq_type}, GPIO_NUM_41},
-    {{&machine_pin_irq_type}, GPIO_NUM_42},
-    {{&machine_pin_irq_type}, GPIO_NUM_43},
-    {{&machine_pin_irq_type}, GPIO_NUM_44},
-    {{&machine_pin_irq_type}, GPIO_NUM_45},
-    {{&machine_pin_irq_type}, GPIO_NUM_46},
-
-    #endif
-
-    #if CONFIG_IDF_TARGET_ESP32S3 && MICROPY_HW_ESP32S3_EXTENDED_IO
-
-    {{&machine_pin_irq_type}, GPIO_NUM_47},
-    {{&machine_pin_irq_type}, GPIO_NUM_48},
-
-    #endif
-};
-
 STATIC mp_obj_t machine_pin_irq_call(mp_obj_t self_in, size_t n_args, size_t n_kw, const mp_obj_t *args) {
     machine_pin_irq_obj_t *self = self_in;
     mp_arg_check_num(n_args, n_kw, 0, 0, false);
-    machine_pin_isr_handler((void *)&machine_pin_obj[self->id]);
+    machine_pin_isr_handler((void *)&machine_pin_obj_table[PIN_IRQ_OBJ_INDEX(self)]);
     return mp_const_none;
 }
 
 STATIC mp_obj_t machine_pin_irq_trigger(size_t n_args, const mp_obj_t *args) {
     machine_pin_irq_obj_t *self = args[0];
-    uint32_t orig_trig = GPIO.pin[self->id].int_type;
+    uint32_t orig_trig = GPIO.pin[PIN_IRQ_OBJ_INDEX(self)].int_type;
     if (n_args == 2) {
         // set trigger
-        gpio_set_intr_type(self->id, mp_obj_get_int(args[1]));
+        gpio_set_intr_type(PIN_IRQ_OBJ_INDEX(self), mp_obj_get_int(args[1]));
     }
     // return original trigger value
     return MP_OBJ_NEW_SMALL_INT(orig_trig);
@@ -725,7 +437,7 @@ STATIC const mp_rom_map_elem_t machine_pin_irq_locals_dict_table[] = {
 };
 STATIC MP_DEFINE_CONST_DICT(machine_pin_irq_locals_dict, machine_pin_irq_locals_dict_table);
 
-STATIC MP_DEFINE_CONST_OBJ_TYPE(
+MP_DEFINE_CONST_OBJ_TYPE(
     machine_pin_irq_type,
     MP_QSTR_IRQ,
     MP_TYPE_FLAG_NONE,

--- a/ports/esp32/machine_pin.h
+++ b/ports/esp32/machine_pin.h
@@ -1,0 +1,164 @@
+/*
+ * This file is part of the MicroPython project, http://micropython.org/
+ *
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2023 Damien P. George
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+#ifndef MICROPY_INCLUDED_ESP32_MACHINE_PIN_H
+#define MICROPY_INCLUDED_ESP32_MACHINE_PIN_H
+
+#include "py/obj.h"
+#include "hal/gpio_types.h"
+
+// Define which pins are enabled for a given SoC and configuration.
+
+#if CONFIG_IDF_TARGET_ESP32
+
+#define MICROPY_HW_ENABLE_GPIO0 (1)
+#define MICROPY_HW_ENABLE_GPIO1 (1)
+#define MICROPY_HW_ENABLE_GPIO2 (1)
+#define MICROPY_HW_ENABLE_GPIO3 (1)
+#define MICROPY_HW_ENABLE_GPIO4 (1)
+#define MICROPY_HW_ENABLE_GPIO5 (1)
+#define MICROPY_HW_ENABLE_GPIO6 (1)
+#define MICROPY_HW_ENABLE_GPIO7 (1)
+#define MICROPY_HW_ENABLE_GPIO8 (1)
+#define MICROPY_HW_ENABLE_GPIO9 (1)
+#define MICROPY_HW_ENABLE_GPIO10 (1)
+#define MICROPY_HW_ENABLE_GPIO11 (1)
+#define MICROPY_HW_ENABLE_GPIO12 (1)
+#define MICROPY_HW_ENABLE_GPIO13 (1)
+#define MICROPY_HW_ENABLE_GPIO14 (1)
+#define MICROPY_HW_ENABLE_GPIO15 (1)
+#if !CONFIG_ESP32_SPIRAM_SUPPORT
+#define MICROPY_HW_ENABLE_GPIO16 (1)
+#define MICROPY_HW_ENABLE_GPIO17 (1)
+#endif
+#define MICROPY_HW_ENABLE_GPIO18 (1)
+#define MICROPY_HW_ENABLE_GPIO19 (1)
+#define MICROPY_HW_ENABLE_GPIO20 (1)
+#define MICROPY_HW_ENABLE_GPIO21 (1)
+#define MICROPY_HW_ENABLE_GPIO22 (1)
+#define MICROPY_HW_ENABLE_GPIO23 (1)
+#define MICROPY_HW_ENABLE_GPIO25 (1)
+#define MICROPY_HW_ENABLE_GPIO26 (1)
+#define MICROPY_HW_ENABLE_GPIO27 (1)
+#define MICROPY_HW_ENABLE_GPIO32 (1)
+#define MICROPY_HW_ENABLE_GPIO33 (1)
+#define MICROPY_HW_ENABLE_GPIO34 (1)
+#define MICROPY_HW_ENABLE_GPIO35 (1)
+#define MICROPY_HW_ENABLE_GPIO36 (1)
+#define MICROPY_HW_ENABLE_GPIO37 (1)
+#define MICROPY_HW_ENABLE_GPIO38 (1)
+#define MICROPY_HW_ENABLE_GPIO39 (1)
+
+#elif CONFIG_IDF_TARGET_ESP32C3
+
+#define MICROPY_HW_ENABLE_GPIO0 (1)
+#define MICROPY_HW_ENABLE_GPIO1 (1)
+#define MICROPY_HW_ENABLE_GPIO2 (1)
+#define MICROPY_HW_ENABLE_GPIO3 (1)
+#define MICROPY_HW_ENABLE_GPIO4 (1)
+#define MICROPY_HW_ENABLE_GPIO5 (1)
+#define MICROPY_HW_ENABLE_GPIO6 (1)
+#define MICROPY_HW_ENABLE_GPIO7 (1)
+#define MICROPY_HW_ENABLE_GPIO8 (1)
+#define MICROPY_HW_ENABLE_GPIO9 (1)
+#define MICROPY_HW_ENABLE_GPIO10 (1)
+#define MICROPY_HW_ENABLE_GPIO11 (1)
+#define MICROPY_HW_ENABLE_GPIO12 (1)
+#define MICROPY_HW_ENABLE_GPIO13 (1)
+#if !CONFIG_ESP_CONSOLE_USB_SERIAL_JTAG
+#define MICROPY_HW_ENABLE_GPIO18 (1)
+#define MICROPY_HW_ENABLE_GPIO19 (1)
+#endif
+#define MICROPY_HW_ENABLE_GPIO20 (1)
+#define MICROPY_HW_ENABLE_GPIO21 (1)
+
+#elif CONFIG_IDF_TARGET_ESP32S2 || CONFIG_IDF_TARGET_ESP32S3
+
+#define MICROPY_HW_ENABLE_GPIO0 (1)
+#define MICROPY_HW_ENABLE_GPIO1 (1)
+#define MICROPY_HW_ENABLE_GPIO2 (1)
+#define MICROPY_HW_ENABLE_GPIO3 (1)
+#define MICROPY_HW_ENABLE_GPIO4 (1)
+#define MICROPY_HW_ENABLE_GPIO5 (1)
+#define MICROPY_HW_ENABLE_GPIO6 (1)
+#define MICROPY_HW_ENABLE_GPIO7 (1)
+#define MICROPY_HW_ENABLE_GPIO8 (1)
+#define MICROPY_HW_ENABLE_GPIO9 (1)
+#define MICROPY_HW_ENABLE_GPIO10 (1)
+#define MICROPY_HW_ENABLE_GPIO11 (1)
+#define MICROPY_HW_ENABLE_GPIO12 (1)
+#define MICROPY_HW_ENABLE_GPIO13 (1)
+#define MICROPY_HW_ENABLE_GPIO14 (1)
+#define MICROPY_HW_ENABLE_GPIO15 (1)
+#define MICROPY_HW_ENABLE_GPIO16 (1)
+#define MICROPY_HW_ENABLE_GPIO17 (1)
+#define MICROPY_HW_ENABLE_GPIO18 (1)
+#if !CONFIG_USB_CDC_ENABLED
+#define MICROPY_HW_ENABLE_GPIO19 (1)
+#define MICROPY_HW_ENABLE_GPIO20 (1)
+#endif
+#define MICROPY_HW_ENABLE_GPIO21 (1)
+#if !CONFIG_SPIRAM
+#define MICROPY_HW_ENABLE_GPIO26 (1)
+#endif
+#if !CONFIG_SPIRAM_MODE_OCT
+#define MICROPY_HW_ENABLE_GPIO33 (1)
+#define MICROPY_HW_ENABLE_GPIO34 (1)
+#define MICROPY_HW_ENABLE_GPIO35 (1)
+#define MICROPY_HW_ENABLE_GPIO36 (1)
+#define MICROPY_HW_ENABLE_GPIO37 (1)
+#endif
+#define MICROPY_HW_ENABLE_GPIO38 (1)
+#define MICROPY_HW_ENABLE_GPIO39 (1)
+#define MICROPY_HW_ENABLE_GPIO40 (1)
+#define MICROPY_HW_ENABLE_GPIO41 (1)
+#define MICROPY_HW_ENABLE_GPIO42 (1)
+#define MICROPY_HW_ENABLE_GPIO43 (1)
+#define MICROPY_HW_ENABLE_GPIO44 (1)
+#define MICROPY_HW_ENABLE_GPIO45 (1)
+#define MICROPY_HW_ENABLE_GPIO46 (1)
+#if CONFIG_IDF_TARGET_ESP32S3 && MICROPY_HW_ESP32S3_EXTENDED_IO
+#define MICROPY_HW_ENABLE_GPIO47 (1)
+#define MICROPY_HW_ENABLE_GPIO48 (1)
+#endif
+
+#endif
+
+typedef struct _machine_pin_obj_t {
+    mp_obj_base_t base;
+} machine_pin_obj_t;
+
+typedef struct _machine_pin_irq_obj_t {
+    mp_obj_base_t base;
+} machine_pin_irq_obj_t;
+
+extern const mp_obj_type_t machine_pin_irq_type;
+
+extern const machine_pin_obj_t machine_pin_obj_table[GPIO_NUM_MAX];
+extern const machine_pin_irq_obj_t machine_pin_irq_obj_table[GPIO_NUM_MAX];
+
+extern const mp_obj_dict_t machine_pin_board_pins_locals_dict;
+
+#endif // MICROPY_INCLUDED_ESP32_MACHINE_PIN_H


### PR DESCRIPTION
This adds named-pins support to the esp32 port, following other ports.

It adds:
- ~~`machine.Pin.cpu.GPIOn` for all available CPU pins~~ Edit: this is now removed
- `machine.Pin.board.xxx` for any board-specific named pins, specified by a board's `pins.csv`
- ability to construct a pin by name, `machine.Pin("<name>")`, ~~eg the name can be `"GPIO1"` for a cpu pin~~

TODO:
- [x] reduce firmware size by combining pin and pin_irq objects