### PR TITLE
esp32: Enable multiple extra component directories in build

### DIFF
--- a/ports/esp32/CMakeLists.txt
+++ b/ports/esp32/CMakeLists.txt
@@ -47,7 +47,7 @@ set(SDKCONFIG_DEFAULTS ${CMAKE_BINARY_DIR}/sdkconfig.combined)
 include($ENV{IDF_PATH}/tools/cmake/project.cmake)
 
 # Set the location of the main component for the project (one per target).
-set(EXTRA_COMPONENT_DIRS main_${IDF_TARGET})
+list(APPEND EXTRA_COMPONENT_DIRS main_${IDF_TARGET})
 
 # Define the project.
 project(micropython)


### PR DESCRIPTION
The EXTRA_COMPONENT_DIRS variable is a list so adding a directory so should be done via append, not set. This enables boards to use other components in the build. See:
https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-guides/build-system.html#optional-project-variables