### PR TITLE
unix/mpbthciport: Remove thread detached attribute

### DIFF
--- a/ports/unix/mpbthciport.c
+++ b/ports/unix/mpbthciport.c
@@ -196,10 +196,7 @@ int mp_bluetooth_hci_uart_init(uint32_t port, uint32_t baudrate) {
     }
 
     // Create a thread to run the polling loop.
-    pthread_attr_t attr;
-    pthread_attr_init(&attr);
-    pthread_attr_setdetachstate(&attr, PTHREAD_CREATE_DETACHED);
-    pthread_create(&hci_poll_thread_id, &attr, &hci_poll_thread, NULL);
+    pthread_create(&hci_poll_thread_id, NULL, &hci_poll_thread, NULL);
 
     return 0;
 }

--- a/ports/unix/mpbtstackport_usb.c
+++ b/ports/unix/mpbtstackport_usb.c
@@ -110,10 +110,7 @@ static void *btstack_thread(void *arg) {
 
 void mp_bluetooth_btstack_port_start(void) {
     // Create a thread to run the btstack loop.
-    pthread_attr_t attr;
-    pthread_attr_init(&attr);
-    pthread_attr_setdetachstate(&attr, PTHREAD_CREATE_DETACHED);
-    pthread_create(&bstack_thread_id, &attr, &btstack_thread, NULL);
+    pthread_create(&bstack_thread_id, NULL, &btstack_thread, NULL);
 }
 
 #endif // MICROPY_PY_BLUETOOTH && MICROPY_BLUETOOTH_BTSTACK && MICROPY_BLUETOOTH_BTSTACK_USB


### PR DESCRIPTION
Hi 

I'm using micropython unix port with bluetooth nimble enabled. When i'm run bluetooth example ble_simple_central.py, it exit with illegal instruction crash fault.

I found the bug is case by pthread_join in mp_bluetooth_hci_uart_deinit function.

The [pthread_join](http://pubs.opengroup.org/onlinepubs/9699919799/functions/pthread_join.html) says:

    The behavior is undefined if the value specified by the thread argument to pthread_join() does not refer to a joinable thread.

If the thread is set detached attribute, and the thread is not joinable. 

So i remove the thread detached attribute and fix the crash fault.

