### PR TITLE
py/runtime: Always initialise sched_state in mp_init.

### DIFF
--- a/py/runtime.c
+++ b/py/runtime.c
@@ -69,11 +69,10 @@ void mp_init(void) {
     // no pending exceptions to start with
     MP_STATE_THREAD(mp_pending_exception) = MP_OBJ_NULL;
     #if MICROPY_ENABLE_SCHEDULER
+    // no pending callbacks to start with
+    MP_STATE_VM(sched_state) = MP_SCHED_IDLE;
     #if MICROPY_SCHEDULER_STATIC_NODES
-    if (MP_STATE_VM(sched_head) == NULL) {
-        // no pending callbacks to start with
-        MP_STATE_VM(sched_state) = MP_SCHED_IDLE;
-    } else {
+    if (MP_STATE_VM(sched_head) != NULL) {
         // pending callbacks are on the list, eg from before a soft reset
         MP_STATE_VM(sched_state) = MP_SCHED_PENDING;
     }


### PR DESCRIPTION
When MICROPY_SCHEDULER_STATIC_NODES is enabled, the logic is unchanged.

When MICROPY_SCHEDULER_STATIC_NODES is disable, sched_state is now always initialised to MP_SCHED_IDLE when calling mp_init().  For example, the use of mp_sched_vm_abort(), if it aborts a running scheduled function, can lead to the scheduler starting off in a locked state when the runtime is restarted, and then it stays locked.  This commit fixes that case by resetting sched_state.