### PR TITLE
py/mpconfig: Add MICROPY_PY_PLATFORM.

### DIFF
--- a/ports/esp32/mpconfigport.h
+++ b/ports/esp32/mpconfigport.h
@@ -140,7 +140,6 @@
 #define MICROPY_PY_WEBSOCKET                (1)
 #define MICROPY_PY_WEBREPL                  (1)
 #define MICROPY_PY_ONEWIRE                  (1)
-#define MICROPY_PY_PLATFORM                 (1)
 #define MICROPY_PY_SOCKET_EVENTS            (MICROPY_PY_WEBREPL)
 #define MICROPY_PY_BLUETOOTH_RANDOM_ADDR    (1)
 #define MICROPY_PY_BLUETOOTH_DEFAULT_GAP_NAME ("ESP32")

--- a/ports/mimxrt/mpconfigport.h
+++ b/ports/mimxrt/mpconfigport.h
@@ -94,7 +94,6 @@ uint32_t trng_random_u32(void);
 #define MICROPY_PY_MACHINE_TIMER            (1)
 #define MICROPY_SOFT_TIMER_TICKS_MS         systick_ms
 #define MICROPY_PY_ONEWIRE                  (1)
-#define MICROPY_PY_PLATFORM                 (1)
 
 // fatfs configuration used in ffconf.h
 #define MICROPY_FATFS_ENABLE_LFN            (1)

--- a/ports/renesas-ra/mpconfigport.h
+++ b/ports/renesas-ra/mpconfigport.h
@@ -132,9 +132,6 @@
 #ifndef MICROPY_PY_ONEWIRE
 #define MICROPY_PY_ONEWIRE          (1)
 #endif
-#ifndef MICROPY_PY_PLATFORM
-#define MICROPY_PY_PLATFORM         (1)
-#endif
 
 // fatfs configuration used in ffconf.h
 #define MICROPY_FATFS_ENABLE_LFN       (1)

--- a/ports/stm32/mpconfigport.h
+++ b/ports/stm32/mpconfigport.h
@@ -137,9 +137,6 @@
 #ifndef MICROPY_PY_ONEWIRE
 #define MICROPY_PY_ONEWIRE          (1)
 #endif
-#ifndef MICROPY_PY_PLATFORM
-#define MICROPY_PY_PLATFORM         (1)
-#endif
 
 // fatfs configuration used in ffconf.h
 #define MICROPY_FATFS_ENABLE_LFN       (1)

--- a/py/mpconfig.h
+++ b/py/mpconfig.h
@@ -1726,6 +1726,11 @@ typedef double mp_float_t;
 #define MICROPY_PY_ONEWIRE (0)
 #endif
 
+// Whether to provide the "platform" module
+#ifndef MICROPY_PY_PLATFORM
+#define MICROPY_PY_PLATFORM (MICROPY_CONFIG_ROM_LEVEL_AT_LEAST_EXTRA_FEATURES)
+#endif
+
 /*****************************************************************************/
 /* Hooks for a port to add builtins                                          */
 

--- a/tests/unix/extra_coverage.py.exp
+++ b/tests/unix/extra_coverage.py.exp
@@ -56,10 +56,10 @@ cmath           collections     cppexample      cryptolib
 deflate         errno           example_package
 ffi             framebuf        gc              hashlib
 heapq           io              json            machine
-math            os              random          re
-select          socket          ssl             struct
-sys             termios         time            uctypes
-websocket
+math            os              platform        random
+re              select          socket          ssl
+struct          sys             termios         time
+uctypes         websocket
 me
 
 micropython     machine         math


### PR DESCRIPTION
Previously this was explicitly enabled on esp32/stm32/renesas/mimxrt/samd, but didn't get a default feature level because it wasn't in py/mpconfig.h.

Now enabled at the "extra features" level, which adds rp2, unix-standard, windows, esp8266, webassembly, and some nrf boards.

Related to #12049 (which is actually about `os.uname()`, but `platform.platform()` provides the same)

This work was funded through GitHub Sponsors.