### PR TITLE
ports/esp32: Remove unused mbedtls debug function.

### DIFF
--- a/ports/esp32/main.c
+++ b/ports/esp32/main.c
@@ -216,11 +216,6 @@ void nlr_jump_fail(void *val) {
     esp_restart();
 }
 
-// modussl_mbedtls uses this function but it's not enabled in ESP IDF
-void mbedtls_debug_set_threshold(int threshold) {
-    (void)threshold;
-}
-
 void *esp_native_code_commit(void *buf, size_t len, void *reloc) {
     len = (len + 3) & ~3;
     uint32_t *p = heap_caps_malloc(len, MALLOC_CAP_EXEC);


### PR DESCRIPTION
Since commit beeb7483d889f5880895ecdd8e7a354f16956037 we already check in `modussl_mbedtls` whether this function is provided by the ESP-IDF before calling it, thus we no longer need to define it here in order to compile.

Removing it so that if `CONFIG_MBEDTLS_DEBUG` is defined we do not cause any 'multiple definition' compile errors.