### PR TITLE
tools/autobuild: Add support for application .bin files for esp32.

### DIFF
--- a/tools/autobuild/build-boards.sh
+++ b/tools/autobuild/build-boards.sh
@@ -33,6 +33,9 @@ function build_board {
             elif [ -r $build_dir/micropython.$ext ]; then
                 # esp32 has micropython.elf, etc
                 mv $build_dir/micropython.$ext $dest
+            elif [ $ext = app-bin -a -r $build_dir/micropython.bin ]; then
+                # esp32 has micropython.bin which is just the application
+                mv $build_dir/micropython.bin $dest
             fi
         done
     )
@@ -62,7 +65,7 @@ function build_boards {
 }
 
 function build_esp32_boards {
-    build_boards modesp32.c $1 $2 bin elf map uf2
+    build_boards modesp32.c $1 $2 bin elf map uf2 app-bin
 }
 
 function build_mimxrt_boards {


### PR DESCRIPTION
On esp32, the build output consists of:
- micropython.elf
- micropython.map
- micropython.bin -- application only
- micropython.uf2 -- application only
- firmware.bin -- bootloader, partition table and application

Currently everything is available at the download page except `micropython.bin`.  This commit adds that file but with the extension changed to `.app_bin`, to distinguish it from `.bin` (the full thing).

Eg for the generic esp32 port the file would be `esp32-20230426-v1.20.0.app_bin`.  For a nightly build it would be `esp32-20230724-unstable-v1.20.0-312-g8ef5622b9.app_bin`.