### PR TITLE
esp32: fix SPI construction

### DIFF
--- a/ports/esp32/machine_hw_spi.c
+++ b/ports/esp32/machine_hw_spi.c
@@ -73,13 +73,6 @@
 #define MP_HW_SPI_MAX_XFER_BYTES (4092)
 #define MP_HW_SPI_MAX_XFER_BITS (MP_HW_SPI_MAX_XFER_BYTES * 8) // Has to be an even multiple of 8
 
-#if CONFIG_IDF_TARGET_ESP32C3
-#define SPI2_HOST SPI2_HOST
-#elif CONFIG_IDF_TARGET_ESP32S3
-#define SPI2_HOST SPI3_HOST
-#define FSPI_HOST SPI2_HOST
-#endif
-
 typedef struct _machine_hw_spi_default_pins_t {
     int8_t sck;
     int8_t mosi;
@@ -218,9 +211,6 @@ STATIC void machine_hw_spi_init_internal(
     }
 
     if (self->host != SPI2_HOST
-        #ifdef FSPI_HOST
-        && self->host != FSPI_HOST
-        #endif
         #if SOC_SPI_PERIPH_NUM > 2
         && self->host != SPI3_HOST
         #endif

--- a/ports/esp32/machine_hw_spi.c
+++ b/ports/esp32/machine_hw_spi.c
@@ -232,7 +232,7 @@ STATIC void machine_hw_spi_init_internal(
         #ifdef FSPI_HOST
         && self->host != FSPI_HOST
         #endif
-        #ifdef SPI3_HOST
+        #if SOC_SPI_PERIPH_NUM > 2
         && self->host != SPI3_HOST
         #endif
         ) {

--- a/ports/esp32/machine_hw_spi.c
+++ b/ports/esp32/machine_hw_spi.c
@@ -46,23 +46,12 @@
 
 // Default pins for SPI(id=1) aka IDF SPI2, can be overridden by a board
 #ifndef MICROPY_HW_SPI1_SCK
-#ifdef SPI2_IOMUX_PIN_NUM_CLK
 // Use IO_MUX pins by default.
 // If SPI lines are routed to other pins through GPIO matrix
 // routing adds some delay and lower limit applies to SPI clk freq
-#define MICROPY_HW_SPI1_SCK SPI2_IOMUX_PIN_NUM_CLK      // pin 14 on ESP32
-#define MICROPY_HW_SPI1_MOSI SPI2_IOMUX_PIN_NUM_MOSI    // pin 13 on ESP32
-#define MICROPY_HW_SPI1_MISO SPI2_IOMUX_PIN_NUM_MISO    // pin 12 on ESP32
-// Only for compatibility with IDF 4.2 and older
-#elif CONFIG_IDF_TARGET_ESP32S2
-#define MICROPY_HW_SPI1_SCK FSPI_IOMUX_PIN_NUM_CLK
-#define MICROPY_HW_SPI1_MOSI FSPI_IOMUX_PIN_NUM_MOSI
-#define MICROPY_HW_SPI1_MISO FSPI_IOMUX_PIN_NUM_MISO
-#else
 #define MICROPY_HW_SPI1_SCK SPI2_IOMUX_PIN_NUM_CLK
 #define MICROPY_HW_SPI1_MOSI SPI2_IOMUX_PIN_NUM_MOSI
 #define MICROPY_HW_SPI1_MISO SPI2_IOMUX_PIN_NUM_MISO
-#endif
 #endif
 
 // Default pins for SPI(id=2) aka IDF SPI3, can be overridden by a board


### PR DESCRIPTION
This fixes the construction of `machine.SPI` objects on esp32 so that:
- SPI(1) and SPI(2) work on esp32, esp32s2, esp32s3
- SPI(1) works on esp32c3
- SPI(1) consistently maps to SPI2_HOST and SPI(2) consistently maps to SPI3_HOST (for all SoC variants)

Fixes issue #11919.