### PR TITLE
esp32/boards: Remove references to the IDF version in board.md files.

### DIFF
--- a/ports/esp32/README.md
+++ b/ports/esp32/README.md
@@ -28,8 +28,7 @@ manage the ESP32 microcontroller, as well as a way to manage the required
 build environment and toolchains needed to build the firmware.
 
 The ESP-IDF changes quickly and MicroPython only supports certain versions.
-Currently MicroPython supports v5.0.2,
-although other IDF v4 versions may also work.
+Currently MicroPython supports only v5.0.2.
 
 To install the ESP-IDF the full instructions can be found at the
 [Espressif Getting Started guide](https://docs.espressif.com/projects/esp-idf/en/latest/esp32/get-started/index.html#installation-step-by-step).

--- a/ports/esp32/boards/GENERIC/board.md
+++ b/ports/esp32/boards/GENERIC/board.md
@@ -1,3 +1,1 @@
-The following files are daily firmware for ESP32-based boards without external SPIRAM.
-
-This firmware is compiled using ESP-IDF v4.x. Some older releases are also provided that are compiled with ESP-IDF v3.x.
+The following files are firmware for ESP32-based boards without external SPIRAM.

--- a/ports/esp32/boards/GENERIC_SPIRAM/board.md
+++ b/ports/esp32/boards/GENERIC_SPIRAM/board.md
@@ -1,3 +1,1 @@
-The following files are daily firmware for ESP32-based boards with external SPIRAM (also known as PSRAM).
-
-This firmware is compiled using ESP-IDF v4.x. Some older releases are also provided that are compiled with ESP-IDF v3.x.
+The following files are firmware for ESP32-based boards with external SPIRAM (also known as PSRAM).

--- a/ports/esp32/boards/OLIMEX_ESP32_POE/board.md
+++ b/ports/esp32/boards/OLIMEX_ESP32_POE/board.md
@@ -1,4 +1,2 @@
-The following files are daily firmware for Olimex ESP32 boards with Ethernet.
+The following files are firmware for Olimex ESP32 boards with Ethernet.
 They match the boards ESP32 ETH-PoE, ESP32 ETH-PoE-ISO and ESP32 Gateway.
-
-This firmware is compiled using ESP-IDF v4.x.

--- a/ports/esp32/boards/UM_FEATHERS2/board.md
+++ b/ports/esp32/boards/UM_FEATHERS2/board.md
@@ -1,2 +1,1 @@
-The following files are daily firmware for the FeatherS2. This firmware is
-compiled using ESP-IDF v4.3 or later.
+The following files are firmware for the FeatherS2.

--- a/ports/esp32/boards/UM_FEATHERS2NEO/board.md
+++ b/ports/esp32/boards/UM_FEATHERS2NEO/board.md
@@ -1,2 +1,1 @@
-The following files are daily firmware for the FeatherS2 Neo. This firmware is
-compiled using ESP-IDF v4.3 or later.
+The following files are firmware for the FeatherS2 Neo.

--- a/ports/esp32/boards/UM_FEATHERS3/board.md
+++ b/ports/esp32/boards/UM_FEATHERS3/board.md
@@ -1,2 +1,1 @@
-The following files are daily firmware for the FeatherS3. This firmware is
-compiled using ESP-IDF v4.4 or later.
+The following files are firmware for the FeatherS3.

--- a/ports/esp32/boards/UM_PROS3/board.md
+++ b/ports/esp32/boards/UM_PROS3/board.md
@@ -1,2 +1,1 @@
-The following files are daily firmware for the ProS3. This firmware is
-compiled using ESP-IDF v4.4 or later.
+The following files are firmware for the ProS3.

--- a/ports/esp32/boards/UM_TINYPICO/board.md
+++ b/ports/esp32/boards/UM_TINYPICO/board.md
@@ -1,3 +1,1 @@
-The following files are daily firmware for the TinyPICO. This firmware is compiled
-using ESP-IDF v4.2 or later.  Some older releases are also provided that are
-compiled with ESP-IDF v3.x.
+The following files are firmware for the TinyPICO.

--- a/ports/esp32/boards/UM_TINYS2/board.md
+++ b/ports/esp32/boards/UM_TINYS2/board.md
@@ -1,2 +1,1 @@
-The following files are daily firmware for the TinyS2. This firmware is compiled
-using ESP-IDF v4.3 or later.
+The following files are firmware for the TinyS2.

--- a/ports/esp32/boards/UM_TINYS3/board.md
+++ b/ports/esp32/boards/UM_TINYS3/board.md
@@ -1,2 +1,1 @@
-The following files are daily firmware for the TinyS3. This firmware is
-compiled using ESP-IDF v4.4 or later.
+The following files are firmware for the TinyS3.


### PR DESCRIPTION
Listing the IDF version number in the board description is not as important as it once was, when the IDF was still undergoing a lot of changes.  Now, all builds use IDF 5.x and it's possible to query the exact version with platform.platform().