### PR TITLE
extmod/vfs_posix_file.c: Unix port stdio buffer enhancement

### DIFF
--- a/extmod/vfs_posix_file.c
+++ b/extmod/vfs_posix_file.c
@@ -274,12 +274,58 @@ STATIC const mp_stream_p_t vfs_posix_textio_stream_p = {
     .is_text = true,
 };
 
+#if MICROPY_PY_SYS_STDIO_BUFFER
+
+const mp_obj_vfs_posix_file_t mp_sys_stdin_buffer_obj = {{&mp_type_vfs_posix_fileio}, STDIN_FILENO};
+const mp_obj_vfs_posix_file_t mp_sys_stdout_buffer_obj = {{&mp_type_vfs_posix_fileio}, STDOUT_FILENO};
+const mp_obj_vfs_posix_file_t mp_sys_stderr_buffer_obj = {{&mp_type_vfs_posix_fileio}, STDERR_FILENO};
+
+// Forward declarations.
+const mp_obj_vfs_posix_file_t mp_sys_stdin_obj;
+const mp_obj_vfs_posix_file_t mp_sys_stdout_obj;
+const mp_obj_vfs_posix_file_t mp_sys_stderr_obj;
+
+STATIC void vfs_posix_textio_attr(mp_obj_t self_in, qstr attr, mp_obj_t *dest) {
+    if (dest[0] != MP_OBJ_NULL) {
+        // These objects are read-only.
+        return;
+    }
+
+    if (attr == MP_QSTR_buffer) {
+        // Implement the `buffer` attribute only on std{in,out,err} instances.
+        if (MP_OBJ_TO_PTR(self_in) == &mp_sys_stdin_obj) {
+            dest[0] = MP_OBJ_FROM_PTR(&mp_sys_stdin_buffer_obj);
+            return;
+        }
+        if (MP_OBJ_TO_PTR(self_in) == &mp_sys_stdout_obj) {
+            dest[0] = MP_OBJ_FROM_PTR(&mp_sys_stdout_buffer_obj);
+            return;
+        }
+        if (MP_OBJ_TO_PTR(self_in) == &mp_sys_stderr_obj) {
+            dest[0] = MP_OBJ_FROM_PTR(&mp_sys_stderr_buffer_obj);
+            return;
+        }
+    }
+
+    // Any other attribute - forward to locals dict.
+    dest[1] = MP_OBJ_SENTINEL;
+};
+
+#define VFS_POSIX_TEXTIO_TYPE_ATTR attr, vfs_posix_textio_attr,
+
+#else
+
+#define VFS_POSIX_TEXTIO_TYPE_ATTR
+
+#endif // MICROPY_PY_SYS_STDIO_BUFFER
+
 MP_DEFINE_CONST_OBJ_TYPE(
     mp_type_vfs_posix_textio,
     MP_QSTR_TextIOWrapper,
     MP_TYPE_FLAG_ITER_IS_STREAM,
     print, vfs_posix_file_print,
     protocol, &vfs_posix_textio_stream_p,
+    VFS_POSIX_TEXTIO_TYPE_ATTR
     locals_dict, &vfs_posix_rawfile_locals_dict
     );
 

--- a/tests/io/file_stdio.py
+++ b/tests/io/file_stdio.py
@@ -2,3 +2,4 @@ import sys
 
 print(sys.stdin.fileno())
 print(sys.stdout.fileno())
+print(sys.stderr.fileno())

--- a/tests/io/file_stdio2.py
+++ b/tests/io/file_stdio2.py
@@ -1,0 +1,65 @@
+# Test sys.std*.buffer objects.
+
+import sys
+
+try:
+    sys.stdout.buffer
+    sys.stdin.buffer
+    sys.stderr.buffer
+except AttributeError:
+    print("SKIP")
+    raise SystemExit
+
+
+# force cpython to flush after every print
+# this is to sequence stdout and stderr
+def print_flush(*args, **kwargs):
+    try:
+        print(*args, **kwargs, flush=True)
+    except TypeError:
+        print(*args, **kwargs)
+
+
+print_flush("==stdin==")
+print_flush(sys.stdin.buffer.fileno())
+
+
+print_flush("==stdout==")
+print_flush(sys.stdout.buffer.fileno())
+n_text = sys.stdout.write("The quick brown fox jumps over the lazy dog\n")
+sys.stdout.flush()
+n_binary = sys.stdout.buffer.write("The quick brown fox jumps over the lazy dog\n".encode("utf-8"))
+sys.stdout.buffer.flush()
+print_flush("n_text:{} n_binary:{}".format(n_text, n_binary))
+
+# temporarily disabling unicode tests until future PR which fixes unicode write character count
+# n_text = sys.stdout.write("🚀")
+# sys.stdout.flush()
+# n_binary = sys.stdout.buffer.write("🚀".encode("utf-8"))
+# sys.stdout.buffer.flush()
+# print_flush("")
+# print_flush("n_text:{} n_binary:{}".format(n_text, n_binary))
+# n_text = sys.stdout.write("1🚀2a3α4b5β6c7γ8d9δ0ぁ1🙐")
+# sys.stdout.flush()
+# n_binary = sys.stdout.buffer.write("1🚀2a3α4b5β6c7γ8d9δ0ぁ1🙐".encode("utf-8"))
+# sys.stdout.buffer.flush()
+# print_flush("")
+# print_flush("n_text:{} n_binary:{}".format(n_text, n_binary))
+
+
+print_flush("==stderr==")
+print_flush(sys.stderr.buffer.fileno())
+n_text = sys.stderr.write("The quick brown fox jumps over the lazy dog\n")
+sys.stderr.flush()
+n_binary = sys.stderr.buffer.write("The quick brown fox jumps over the lazy dog\n".encode("utf-8"))
+sys.stderr.buffer.flush()
+print_flush("n_text:{} n_binary:{}".format(n_text, n_binary))
+
+# temporarily disabling unicode tests until future PR which fixes unicode write character count
+# n_text = sys.stderr.write("🚀")
+# sys.stderr.flush()
+# n_binary = sys.stderr.buffer.write("🚀".encode("utf-8"))
+# sys.stderr.buffer.flush()
+# print_flush("")
+# print_flush("n_text:{} n_binary:{}".format(n_text, n_binary))
+# print_flush("")

--- a/tests/run-tests.py
+++ b/tests/run-tests.py
@@ -709,7 +709,9 @@ def run_tests(pyb, tests, args, result_dir, num_threads=1):
             # run CPython to work out expected output
             try:
                 output_expected = subprocess.check_output(
-                    CPYTHON3_CMD + [os.path.abspath(test_file)], cwd=os.path.dirname(test_file)
+                    CPYTHON3_CMD + [os.path.abspath(test_file)],
+                    cwd=os.path.dirname(test_file),
+                    stderr=subprocess.STDOUT,
                 )
                 if args.write_exp:
                     with open(test_file_expected, "wb") as f:


### PR DESCRIPTION
This PR enhances port/unix by adding the buffer attribute to stdio.

Currently, the unix port stdio does not have the buffer attribute as does cpython and other ports, making reading bytes over stdio not possible.  The enhancement will make CLI tools easier to implement, improve porting python tools to micropython, and improved interoperablity between ports, especially when piping raw data samples (IQ, audio, etc...)

Related discussions:
https://github.com/orgs/micropython/discussions/12070
https://github.com/orgs/micropython/discussions/11889

**shared/runtime/sys_stdio_mphal.c** was used as a model for the implementation.  Instead of using **mp_hal_stdin_rx_chr** and **mp_hal_stdout_tx_strn** (which works for raw input but not pipes), I instead created two mp_stream with is_text = false using STDIN_FILE and STDOUT_FILE.  A new stdio buffer stream may then read/write from these streams respectively.

One question I have: I'm unsure of the utilitzation of **MICROPY_PY_SYS_STDIO_BUFFER** as it is used in **sys_stdio_mphal.c**.  I went ahead and made my implementation match though I'm not fully clear of it's intended usage.

I've done some tests, a simple one here piping bytes 0-255 using micropython as well as python.

```
./micropython buffertest.py write | ./micropython buffertest.py read
python buffertest.py write | ./micropython buffertest.py read
./micropython buffertest.py write | python buffertest.py read
```


**buffertest.py**
```
import sys
import asyncio

async def write():
    for x in range(256):
        sys.stdout.buffer.write(x.to_bytes(1,'little'))

async def read():
    while True:
        # r = sys.stdin.read(1)      # today we only have stdin.read which crashes with unicode error at 128
        r = sys.stdin.buffer.read(1) # thumbs up!
        if r != None and len(r)==0:
            break
        print('{:<10} {}'.format(int.from_bytes(r,'big'),r))

async def main():
    if 'read' in sys.argv:
        await read()
    elif 'write' in sys.argv:
        await write()

asyncio.run(main())
```