### PR TITLE
ports/mimxrt: Three bug fixes.

### DIFF
--- a/ports/mimxrt/hal/pwm_backport.h
+++ b/ports/mimxrt/hal/pwm_backport.h
@@ -18,7 +18,7 @@
 typedef struct _pwm_signal_param_u16
 {
     pwm_channels_t pwmChannel; // PWM channel being configured; PWM A or PWM B
-    uint16_t dutyCycle_u16;    // PWM pulse width, value should be between 0 to 65536
+    uint32_t dutyCycle_u16;    // PWM pulse width, value should be between 0 to 65536
     uint16_t Center_u16;       // Center of the pulse, value should be between 0 to 65536
     pwm_level_select_t level;  // PWM output active level select */
     uint16_t deadtimeValue;    // The deadtime value; only used if channel pair is operating in complementary mode
@@ -27,17 +27,17 @@ typedef struct _pwm_signal_param_u16
 #define PWM_FULL_SCALE  (65536UL)
 
 void PWM_UpdatePwmDutycycle_u16(PWM_Type *base, pwm_submodule_t subModule,
-    pwm_channels_t pwmSignal, uint16_t dutyCycle, uint16_t center);
+    pwm_channels_t pwmSignal, uint32_t dutyCycle, uint16_t center);
 
 void PWM_SetupPwm_u16(PWM_Type *base, pwm_submodule_t subModule, pwm_signal_param_u16_t *chnlParams,
     uint32_t pwmFreq_Hz, uint32_t srcClock_Hz, bool output_enable);
 
 void PWM_SetupPwmx_u16(PWM_Type *base, pwm_submodule_t subModule,
-    uint32_t pwmFreq_Hz, uint16_t duty_cycle, uint8_t invert, uint32_t srcClock_Hz);
+    uint32_t pwmFreq_Hz, uint32_t duty_cycle, uint8_t invert, uint32_t srcClock_Hz);
 
 #ifdef FSL_FEATURE_SOC_TMR_COUNT
 status_t QTMR_SetupPwm_u16(TMR_Type *base, qtmr_channel_selection_t channel, uint32_t pwmFreqHz,
-    uint16_t dutyCycleU16, bool outputPolarity, uint32_t srcClock_Hz, bool is_init);
+    uint32_t dutyCycleU16, bool outputPolarity, uint32_t srcClock_Hz, bool is_init);
 #endif // FSL_FEATURE_SOC_TMR_COUNT
 
 #endif // PWM_BACKPORT_H

--- a/ports/mimxrt/machine_uart.c
+++ b/ports/mimxrt/machine_uart.c
@@ -288,6 +288,14 @@ STATIC mp_obj_t machine_uart_init(size_t n_args, const mp_obj_t *args, mp_map_t 
 }
 MP_DEFINE_CONST_FUN_OBJ_KW(machine_uart_init_obj, 1, machine_uart_init);
 
+// uart.deinit()
+STATIC mp_obj_t machine_uart_deinit(mp_obj_t self_in) {
+    machine_uart_obj_t *self = MP_OBJ_TO_PTR(self_in);
+    LPUART_Deinit(self->lpuart);
+    return mp_const_none;
+}
+STATIC MP_DEFINE_CONST_FUN_OBJ_1(machine_uart_deinit_obj, machine_uart_deinit);
+
 STATIC mp_obj_t machine_uart_any(mp_obj_t self_in) {
     machine_uart_obj_t *self = MP_OBJ_TO_PTR(self_in);
     size_t count = LPUART_TransferGetRxRingBufferLength(self->lpuart, &self->handle);
@@ -314,8 +322,18 @@ STATIC mp_obj_t machine_uart_txdone(mp_obj_t self_in) {
 }
 STATIC MP_DEFINE_CONST_FUN_OBJ_1(machine_uart_txdone_obj, machine_uart_txdone);
 
+// Deinitialize all defined UARTs
+void machine_uart_deinit_all(void) {
+    for (int i = 0; i < sizeof(uart_index_table); i++) {
+        if (uart_index_table[i] != 0) {
+            LPUART_Deinit(uart_base_ptr_table[uart_index_table[i]]);
+        }
+    }
+}
+
 STATIC const mp_rom_map_elem_t machine_uart_locals_dict_table[] = {
     { MP_ROM_QSTR(MP_QSTR_init), MP_ROM_PTR(&machine_uart_init_obj) },
+    { MP_ROM_QSTR(MP_QSTR_deinit), MP_ROM_PTR(&machine_uart_deinit_obj) },
 
     { MP_ROM_QSTR(MP_QSTR_any), MP_ROM_PTR(&machine_uart_any_obj) },
 

--- a/ports/mimxrt/main.c
+++ b/ports/mimxrt/main.c
@@ -124,6 +124,7 @@ int main(void) {
         #if MICROPY_PY_NETWORK
         mod_network_deinit();
         #endif
+        machine_uart_deinit_all();
         machine_pwm_deinit_all();
         soft_timer_deinit();
         gc_sweep_all();

--- a/ports/mimxrt/modmachine.h
+++ b/ports/mimxrt/modmachine.h
@@ -43,6 +43,7 @@ extern const mp_obj_type_t machine_wdt_type;
 void machine_adc_init(void);
 void machine_pin_irq_deinit(void);
 void machine_pwm_deinit_all(void);
+void machine_uart_deinit_all(void);
 void machine_timer_init_PIT(void);
 void machine_sdcard_init0(void);
 void mimxrt_sdram_init(void);


### PR DESCRIPTION
- Fix stopping the Pin IRQ by calling Pin.irq() with handler set to None. It worked before, but caused in some cases a crash during soft reset.
- Align the PWM edge cases of duty_u16=0 and duty_u16=65536 for all three internal PWM mechanisms. For duty_u16=0, the output is set to low level, for duty_u16=65536 the output is set to high level.
- Deinitialize all UART instances on soft reset. Otherwise the board will crash, if new data at a previously used UART arrives before it is instantiated again.