### PR TITLE
stm32/adc: Add STM32H5 support to pyb.ADC

### DIFF
--- a/ports/stm32/adc.c
+++ b/ports/stm32/adc.c
@@ -352,7 +352,7 @@ STATIC void adcx_init_periph(ADC_HandleTypeDef *adch, uint32_t resolution) {
     adch->Init.DataAlign = ADC_DATAALIGN_RIGHT;
     adch->Init.DMAContinuousRequests = DISABLE;
     #elif defined(STM32G0) || defined(STM32G4) || defined(STM32H5) || defined(STM32L4) || defined(STM32WB)
-    #if defined(STM32G4)
+    #if defined(STM32G4) || defined(STM32H5)
     adch->Init.ClockPrescaler = ADC_CLOCK_ASYNC_DIV16;
     #else
     adch->Init.ClockPrescaler = ADC_CLOCK_ASYNC_DIV1;
@@ -395,7 +395,7 @@ STATIC void adc_init_single(pyb_obj_adc_t *adc_obj) {
 STATIC void adc_config_channel(ADC_HandleTypeDef *adc_handle, uint32_t channel) {
     ADC_ChannelConfTypeDef sConfig;
 
-    #if defined(STM32G0) || defined(STM32G4) || defined(STM32H7) || defined(STM32L4) || defined(STM32WB)
+    #if defined(STM32G0) || defined(STM32G4) || defined(STM32H5) || defined(STM32H7) || defined(STM32L4) || defined(STM32WB)
     sConfig.Rank = ADC_REGULAR_RANK_1;
     if (__HAL_ADC_IS_CHANNEL_INTERNAL(channel) == 0) {
         channel = __HAL_ADC_DECIMAL_NB_TO_CHANNEL(channel);
@@ -896,6 +896,9 @@ float adc_read_core_temp_float(ADC_HandleTypeDef *adcHandle) {
     } else {
         return 0;
     }
+    float core_temp_avg_slope = (*ADC_CAL2 - *ADC_CAL1) / 100.0f;
+    #elif defined(STM32H5)
+    int32_t raw_value = adc_config_and_read_ref(adcHandle, ADC_CHANNEL_TEMPSENSOR);
     float core_temp_avg_slope = (*ADC_CAL2 - *ADC_CAL1) / 100.0f;
     #else
     int32_t raw_value = adc_config_and_read_ref(adcHandle, ADC_CHANNEL_TEMPSENSOR);


### PR DESCRIPTION
# Description

Add STM32H5 ADC support to pyb.ADC by correcting existing code.

Changes are:
* Run ADC on PCLK/16
* Use STM32 ADC library channel literals (__HAL_ADC_DECIMAL_NB_TO_CHANNEL)
* Use correct temperature conversion for H5 (30°C, 130°C calibration points)

Thanks to @yn386 for discussions.


# Enviroment

* NUCLEO-H563ZI
* Using STM32H573I-DK board with minor modifications (input clock, on-chip flash)
* First ADC Input (PF12) connected externally to GPIO PF14

```
MicroPython v1.20.0-283-g7d66ae603-dirty on 2023-07-29; STM32H573I-DK with STM32H573IIK3Q
```

# Tests

``` Python
from pyb import Pin, ADC, ADCAll

io = Pin('F14', Pin.OUT_PP)
io.high()

adc=ADC(Pin('F12'))
adc.read()
# Result: 4095 -> Ok, 3.30 V

io.low()
adc.read()
# Result: 4 --> Ok, ~2 mV
adc.read()
# Result: 2 --> Ok, ~1 mV

all=ADCAll(12,0x70000)
all.read_core_temp()
#Result: 28.2205 -> Ok 

all.read_core_vref()
# Result: 1.207985 -> Ok, nominal 1.21 V
```