### PR TITLE
ports/webassembly: Add support for browser WebWorkers

### DIFF
--- a/ports/webassembly/README.md
+++ b/ports/webassembly/README.md
@@ -88,6 +88,20 @@ MicroPython code execution will suspend the browser so be sure to atomize usage
 within this environment. Unfortunately interrupts have not been implemented for the
 browser.
 
+Running with WebWorkers on browsers
+-----------------
+To enable WebWorker support and receive messages outside of DOM, set `Module.webWorkerEventCallback` to a function that'll receive the events.
+
+```
+importScripts('micropython.js');
+// ...
+Module.webWorkerEventCallback = (event) => {
+  console.log(`Received an event from MicroPython!`);
+};
+```
+
+WebWorkers on the web gives more flexibility to developers when consuming the WASM module. Example cases where this is useful are: not blocking main thread, creating and disposing multiple instances on a single session, using multiple instances for different purposes separate from each other...
+
 Testing
 -------
 

--- a/ports/webassembly/library.js
+++ b/ports/webassembly/library.js
@@ -27,7 +27,9 @@
 mergeInto(LibraryManager.library, {
     mp_js_write: function(ptr, len) {
         const buffer = HEAPU8.subarray(ptr, ptr + len)
-        if (ENVIRONMENT_IS_NODE) {
+        if (ENVIRONMENT_IS_WORKER && typeof Module.webWorkerEventCallback === 'function') {
+            Module.webWorkerEventCallback({detail: buffer});
+        } else if (ENVIRONMENT_IS_NODE) {
             process.stdout.write(buffer);
         } else {
             const printEvent = new CustomEvent('micropython-print', { detail: buffer });

--- a/ports/webassembly/wrapper.js
+++ b/ports/webassembly/wrapper.js
@@ -35,7 +35,7 @@ var mainProgram = function()
 
   MP_JS_EPOCH = Date.now();
 
-  if (typeof window === 'undefined' && require.main === module) {
+  if (ENVIRONMENT_IS_NODE && require.main === module) {
       var fs = require('fs');
       var heap_size = 128 * 1024;
       var contents = '';


### PR DESCRIPTION
This PR adds MicroPython WebAssembly support to WebWorkers on browsers. Changes are similar and adhere to existing code style. A small section is added to README.md file about the new support.

WASM port works great so far but it is always tied to main thread on browsers. This blocks us from loading/disposing multiple instances of the module or put the work outside of main thread to not block it. It looks like WASM side has no problems with running on a WebWorker, being loaded to a worker, and disposal when worker is disposed. This opens a door for having clean instances of the module whenever needed in a WebWorker. Getting it up and running on WebWorker's without modifying source code meant emulating global `window` and `document` objects, adding `addEventListener` and `removeEventListener` functionality to each webWorker file. Having this change merged removes all this hack and boilterplate code and allows a very simple single API for receiving messages from WASM module.

As WebWorkers don't have direct access to DOM, using a callback that has been previously set to the Module works. This means WASM module can have a dedicated communication line to push buffers to webWorker. When `webWorkerEventCallback` is not set on Module, webWorker environment is ignored. 

'myWebWorkerFile.js':
```
importScripts('micropython.js');
// ...
Module.webWorkerEventCallback = (event) => {
  console.log(`Received an event from MicroPython!`);
  const buffer = event.detail;
};
```

Please let me know if I need to take further action, I'd like to contribute this change to the repository. Thanks