### PR TITLE
extmod/vfs_posix: Fix relative paths on non-root VFS

### DIFF
--- a/extmod/vfs_posix.c
+++ b/extmod/vfs_posix.c
@@ -58,21 +58,23 @@ typedef struct _mp_obj_vfs_posix_t {
 } mp_obj_vfs_posix_t;
 
 STATIC const char *vfs_posix_get_path_str(mp_obj_vfs_posix_t *self, mp_obj_t path) {
-    if (self->root_len == 0) {
-        return mp_obj_str_get_str(path);
+    const char *path_str = mp_obj_str_get_str(path);
+    if (self->root_len == 0 || path_str[0] != '/') {
+        return path_str;
     } else {
-        self->root.len = self->root_len;
-        vstr_add_str(&self->root, mp_obj_str_get_str(path));
+        self->root.len = self->root_len - 1;
+        vstr_add_str(&self->root, path_str);
         return vstr_null_terminated_str(&self->root);
     }
 }
 
 STATIC mp_obj_t vfs_posix_get_path_obj(mp_obj_vfs_posix_t *self, mp_obj_t path) {
-    if (self->root_len == 0) {
+    const char *path_str = mp_obj_str_get_str(path);
+    if (self->root_len == 0 || path_str[0] != '/') {
         return path;
     } else {
-        self->root.len = self->root_len;
-        vstr_add_str(&self->root, mp_obj_str_get_str(path));
+        self->root.len = self->root_len - 1;
+        vstr_add_str(&self->root, path_str);
         return mp_obj_new_str(self->root.buf, self->root.len);
     }
 }

--- a/extmod/vfs_posix.c
+++ b/extmod/vfs_posix.c
@@ -186,7 +186,14 @@ STATIC mp_obj_t vfs_posix_getcwd(mp_obj_t self_in) {
     if (ret == NULL) {
         mp_raise_OSError(errno);
     }
-    ret += self->root_len;
+    if (self->root_len > 0) {
+        ret += self->root_len - 1;
+        #ifdef _WIN32
+        if (*ret == '\\') {
+            *(char *)ret = '/';
+        }
+        #endif
+    }
     return mp_obj_new_str(ret, strlen(ret));
 }
 STATIC MP_DEFINE_CONST_FUN_OBJ_1(vfs_posix_getcwd_obj, vfs_posix_getcwd);

--- a/tests/extmod/vfs_posix.py
+++ b/tests/extmod/vfs_posix.py
@@ -99,6 +99,19 @@ if hasattr(vfs, "statvfs"):
 print(type(list(vfs.ilistdir("."))[0][0]))
 print(type(list(vfs.ilistdir(b"."))[0][0]))
 
+# chdir should not affect absolute paths (regression test)
+vfs.mkdir("/subdir")
+vfs.mkdir("/subdir/micropy_test_dir")
+with vfs.open("/subdir/micropy_test_dir/test2", "w") as f:
+    f.write("wrong")
+vfs.chdir("/subdir")
+with vfs.open("/test2", "r") as f:
+    print(f.read())
+os.chdir(curdir)
+vfs.remove("/subdir/micropy_test_dir/test2")
+vfs.rmdir("/subdir/micropy_test_dir")
+vfs.rmdir("/subdir")
+
 # remove
 os.remove(temp_dir + "/test2")
 print(os.listdir(temp_dir))

--- a/tests/extmod/vfs_posix.py
+++ b/tests/extmod/vfs_posix.py
@@ -88,6 +88,9 @@ print(os.listdir(temp_dir))
 
 # construct new VfsPosix with path argument
 vfs = os.VfsPosix(temp_dir)
+# when VfsPosix is used the intended way via os.mount(), it can only be called
+# with relative paths when the CWD is inside or at its root, so simulate that
+os.chdir(temp_dir)
 print(list(i[0] for i in vfs.ilistdir(".")))
 
 # stat, statvfs (statvfs may not exist)
@@ -111,6 +114,9 @@ os.chdir(curdir)
 vfs.remove("/subdir/micropy_test_dir/test2")
 vfs.rmdir("/subdir/micropy_test_dir")
 vfs.rmdir("/subdir")
+
+# done with vfs, restore CWD
+os.chdir(curdir)
 
 # remove
 os.remove(temp_dir + "/test2")

--- a/tests/extmod/vfs_posix.py.exp
+++ b/tests/extmod/vfs_posix.py.exp
@@ -10,6 +10,7 @@ next_file_no <= base_file_no True
 <class 'tuple'>
 <class 'str'>
 <class 'bytes'>
+hello
 []
 remove OSError
 False

--- a/tests/extmod/vfs_posix_enoent.py
+++ b/tests/extmod/vfs_posix_enoent.py
@@ -1,0 +1,42 @@
+# Test for VfsPosix error conditions
+
+try:
+    import os
+    import sys
+
+    os.VfsPosix
+except (ImportError, AttributeError):
+    print("SKIP")
+    raise SystemExit
+
+if sys.platform == "win32":
+    # Windows doesn't let you delete the current directory, so this cannot be
+    # tested.
+    print("SKIP")
+    raise SystemExit
+
+# We need an empty directory for testing.
+# Skip the test if it already exists.
+temp_dir = "vfs_posix_enoent_test_dir"
+try:
+    os.stat(temp_dir)
+    print("SKIP")
+    raise SystemExit
+except OSError:
+    pass
+
+curdir = os.getcwd()
+os.mkdir(temp_dir)
+os.chdir(temp_dir)
+os.rmdir(curdir + "/" + temp_dir)
+try:
+    print("getcwd():", os.getcwd())
+except OSError as e:
+    # expecting ENOENT = 2
+    print("getcwd():", repr(e))
+
+try:
+    print("VfsPosix():", os.VfsPosix("something"))
+except OSError as e:
+    # expecting ENOENT = 2
+    print("VfsPosix():", repr(e))

--- a/tests/extmod/vfs_posix_enoent.py.exp
+++ b/tests/extmod/vfs_posix_enoent.py.exp
@@ -1,0 +1,2 @@
+getcwd(): OSError(2,)
+VfsPosix(): OSError(2,)

--- a/tests/extmod/vfs_posix_ilistdir_del.py
+++ b/tests/extmod/vfs_posix_ilistdir_del.py
@@ -11,7 +11,13 @@ except (ImportError, AttributeError):
 
 
 def test(testdir):
+    curdir = os.getcwd()
     vfs = os.VfsPosix(testdir)
+    # When VfsPosix is used the intended way via os.mount(), it can only be called
+    # with relative paths when the CWD is inside or at its root, so simulate that.
+    # (Although perhaps calling with a relative path was an oversight in this case
+    # and the respective line below was meant to read `vfs.rmdir("/" + dname)`.)
+    os.chdir(testdir)
     vfs.mkdir("/test_d1")
     vfs.mkdir("/test_d2")
     vfs.mkdir("/test_d3")
@@ -47,6 +53,9 @@ def test(testdir):
         # corruption that may be caused over the loops.
         vfs.open("/test", "w").close()
         vfs.remove("/test")
+
+    # Done with vfs, restore CWD.
+    os.chdir(curdir)
 
 
 # We need an empty directory for testing.

--- a/tests/extmod/vfs_posix_ilistdir_filter.py
+++ b/tests/extmod/vfs_posix_ilistdir_filter.py
@@ -10,7 +10,11 @@ except (ImportError, AttributeError):
 
 
 def test(testdir):
+    curdir = os.getcwd()
     vfs = os.VfsPosix(testdir)
+    # When VfsPosix is used the intended way via os.mount(), it can only be called
+    # with relative paths when the CWD is inside or at its root, so simulate that.
+    os.chdir(testdir)
 
     dirs = [".a", "..a", "...a", "a.b", "a..b"]
 
@@ -23,6 +27,9 @@ def test(testdir):
     dirs.sort()
 
     print(dirs)
+
+    # Done with vfs, restore CWD.
+    os.chdir(curdir)
 
 
 # We need an empty directory for testing.

--- a/tests/extmod/vfs_posix_paths.py
+++ b/tests/extmod/vfs_posix_paths.py
@@ -1,0 +1,73 @@
+# Test for VfsPosix with relative paths
+
+try:
+    import os
+
+    os.VfsPosix
+except (ImportError, AttributeError):
+    print("SKIP")
+    raise SystemExit
+
+# We need a directory for testing that doesn't already exist.
+# Skip the test if it does exist.
+temp_dir = "vfs_posix_paths_test_dir"
+try:
+    import os
+
+    os.stat(temp_dir)
+    print("SKIP")
+    raise SystemExit
+except OSError:
+    pass
+
+curdir = os.getcwd()
+os.mkdir(temp_dir)
+
+# construct new VfsPosix with absolute path argument
+temp_dir_abs = os.getcwd() + os.sep + temp_dir
+vfs = os.VfsPosix(temp_dir_abs)
+# when VfsPosix is used the intended way via os.mount(), it can only be called
+# with relative paths when the CWD is inside or at its root, so simulate that
+os.chdir(temp_dir_abs)
+vfs.mkdir("subdir")
+vfs.mkdir("subdir/one")
+print('listdir("/"):', sorted(i[0] for i in vfs.ilistdir("/")))
+print('listdir("."):', sorted(i[0] for i in vfs.ilistdir(".")))
+print('getcwd() in {"", "/"}:', vfs.getcwd() in {"", "/"})
+print('chdir("subdir"):', vfs.chdir("subdir"))
+print("getcwd():", vfs.getcwd())
+print('mkdir("two"):', vfs.mkdir("two"))
+f = vfs.open("file.py", "w")
+f.write("print('hello')")
+f.close()
+print('listdir("/"):', sorted(i[0] for i in vfs.ilistdir("/")))
+print('listdir("/subdir"):', sorted(i[0] for i in vfs.ilistdir("/subdir")))
+print('listdir("."):', sorted(i[0] for i in vfs.ilistdir(".")))
+try:
+    f = vfs.open("/subdir/file.py", "r")
+    print(f.read())
+    f.close()
+except Exception as e:
+    print(e)
+import sys
+
+sys.path.insert(0, "")
+try:
+    import file
+
+    print(file)
+except Exception as e:
+    print(e)
+del sys.path[0]
+vfs.remove("file.py")
+vfs.rmdir("two")
+vfs.rmdir("/subdir/one")
+vfs.chdir("/")
+vfs.rmdir("/subdir")
+
+# done with vfs, restore CWD
+os.chdir(curdir)
+
+# rmdir
+os.rmdir(temp_dir)
+print(temp_dir in os.listdir())

--- a/tests/extmod/vfs_posix_paths.py
+++ b/tests/extmod/vfs_posix_paths.py
@@ -68,6 +68,25 @@ vfs.rmdir("/subdir")
 # done with vfs, restore CWD
 os.chdir(curdir)
 
+# some integration tests with a mounted VFS
+os.mount(os.VfsPosix(temp_dir_abs), "/mnt")
+os.mkdir("/mnt/dir")
+print('chdir("/mnt/dir"):', os.chdir("/mnt/dir"))
+print("getcwd():", os.getcwd())
+print('chdir("/mnt"):', os.chdir("/mnt"))
+print("getcwd():", os.getcwd())
+print('chdir("/"):', os.chdir("/"))
+print("getcwd():", os.getcwd())
+print('chdir("/mnt/dir"):', os.chdir("/mnt/dir"))
+print("getcwd():", os.getcwd())
+print('chdir(".."):', os.chdir(".."))
+print("getcwd():", os.getcwd())
+os.rmdir("/mnt/dir")
+os.umount("/mnt")
+
+# restore CWD
+os.chdir(curdir)
+
 # rmdir
 os.rmdir(temp_dir)
 print(temp_dir in os.listdir())

--- a/tests/extmod/vfs_posix_paths.py.exp
+++ b/tests/extmod/vfs_posix_paths.py.exp
@@ -1,0 +1,13 @@
+listdir("/"): ['subdir']
+listdir("."): ['subdir']
+getcwd() in {"", "/"}: True
+chdir("subdir"): None
+getcwd(): subdir
+mkdir("two"): None
+listdir("/"): ['subdir']
+listdir("/subdir"): ['file.py', 'one', 'two']
+listdir("."): ['file.py', 'one', 'two']
+print('hello')
+hello
+<module 'file' from 'file.py'>
+False

--- a/tests/extmod/vfs_posix_paths.py.exp
+++ b/tests/extmod/vfs_posix_paths.py.exp
@@ -2,7 +2,7 @@ listdir("/"): ['subdir']
 listdir("."): ['subdir']
 getcwd() in {"", "/"}: True
 chdir("subdir"): None
-getcwd(): subdir
+getcwd(): /subdir
 mkdir("two"): None
 listdir("/"): ['subdir']
 listdir("/subdir"): ['file.py', 'one', 'two']
@@ -10,4 +10,14 @@ listdir("."): ['file.py', 'one', 'two']
 print('hello')
 hello
 <module 'file' from 'file.py'>
+chdir("/mnt/dir"): None
+getcwd(): /mnt/dir
+chdir("/mnt"): None
+getcwd(): /mnt
+chdir("/"): None
+getcwd(): /
+chdir("/mnt/dir"): None
+getcwd(): /mnt/dir
+chdir(".."): None
+getcwd(): /mnt
 False


### PR DESCRIPTION
`VfsPosix` has a couple of bugs regarding handling of relative paths and `chdir()`/`getcwd()` that surface when it is instanced with a non-empty root path (i.e. only a subtree of the outer filesystem is exposed to Python).

They are somewhat entangled, but I tried my best to separate the fixes into individually reviewable commits, each with first a failing test that demonstrates what is going wrong, followed by fixes that makes it pass. (The tricky part of that was to get the fixes in the right order and craft the tests such that they actually pass after the respective fix, rather than continuing to fail due to the remaining bugs.)

1. A `VfsPosix` created with a relative root path gets confused when `chdir()` is called on it and becomes unable to properly resolve absolute paths, because changing directories effectively shifts its root. The simplest fix for that would be to say “don’t do that”, but since the unit tests themselves do it, fix it by making a relative path absolute before storing it.

2. The unwritten API contract expected of a VFS by `mp_vfs_lookup_path()` is that paths passed in are relative to the root of the VFS if they start with `/` and relative to the current directory of the VFS otherwise. This is not correctly implemented in `VfsPosix` for instances with a non-empty root – all paths are interpreted relative to the root. Fix that. Since `VfsPosix` tracks its CWD using the “external” CWD of the Unix process, the correct handling for relative paths is to pass them through unmodified.

3. The unwritten API contract expected of a VFS`.getcwd()` by `mp_vfs_getcwd()` is that its return value should be either `""` or `"/"` when the CWD is at the root of the VFS and otherwise start with a slash and not end with a slash. This is not correctly implemented in `VfsPosix` for instances with a non-empty root – the required leading slash, if any, is cut off because the root length includes a trailing slash. This results in missing slashes in the middle of the return value of `os.getcwd()` or in uninitialized garbage from beyond a string’s null terminator when the CWD is at the VFS root.

The matter is complicated by the fact that there are some faulty existing tests that only pass by accident due to bug 2. Unmodified, they would fail after the fix for bug 2 (5th commit), however that is insignificant because they actually test an unrealistic situation. Fixing them in the 3rd commit to match the realistic situation makes them pass with bug 2 fixed (and also without, when done in this order, because after the 2nd commit, bug 2 has no effect in that case).

The unrealistic situation is that `VfsPosix` methods are called with relative paths while the current working directory is somewhere outside of the root of the VFS. In the intended use of VFS objects via `os.mount()` (as opposed to calling methods directly as the tests do), this never happens, as `mp_vfs_lookup_path()` directs incoming calls to the VFS that contains the CWD. Fix this by explicitly changing the working directory to the root of the VFS before calling methods on it, as the subsequent relative path accesses expect.