### PR TITLE
extmod/modssl_mbedtls: Reference SSLContext from SSLSocket.

### DIFF
--- a/extmod/modssl_mbedtls.c
+++ b/extmod/modssl_mbedtls.c
@@ -357,6 +357,7 @@ STATIC mp_obj_t ssl_socket_make_new(mp_obj_ssl_context_t *ssl_context, mp_obj_t 
     mp_obj_ssl_socket_t *o = m_new_obj(mp_obj_ssl_socket_t);
     #endif
     o->base.type = &ssl_socket_type;
+    o->ssl_context = ssl_context;
     o->sock = sock;
     o->poll_mask = 0;
     o->last_error = 0;


### PR DESCRIPTION
Prevent the GC cleaning up (and finalising) the SSLContext while the socket is still live.

Reported by @mirko -- calling gc.collect() between two reads of the same ssl socket causes a crash.