### PR TITLE
extmod/modssl_mbedtls: supporting PSA interface and TLSv1.3

### DIFF
--- a/extmod/modssl_mbedtls.c
+++ b/extmod/modssl_mbedtls.c
@@ -168,6 +168,12 @@ STATIC mp_obj_t ssl_context_make_new(const mp_obj_type_t *type_in, size_t n_args
     mbedtls_debug_set_threshold(3);
     #endif
 
+    // Whenever the PSA interface is used (if MBEDTLS_PSA_CRYPTO), psa_crypto_init() needs to be called before any TLS related operations.
+    // TLSv1.3 depends on the PSA interface, TLSv1.2 only uses the PSA stack if MBEDTLS_USE_PSA_CRYPTO is defined.
+    #if defined(MBEDTLS_SSL_PROTO_TLS1_3) || defined(MBEDTLS_USE_PSA_CRYPTO)
+    psa_crypto_init();
+    #endif
+
     const byte seed[] = "upy";
     int ret = mbedtls_ctr_drbg_seed(&self->ctr_drbg, mbedtls_entropy_func, &self->entropy, seed, sizeof(seed));
     if (ret != 0) {

--- a/extmod/modssl_mbedtls.c
+++ b/extmod/modssl_mbedtls.c
@@ -443,6 +443,14 @@ STATIC mp_uint_t socket_read(mp_obj_t o_in, void *buf, mp_uint_t size, int *errc
         // renegotiation.
         ret = MP_EWOULDBLOCK;
         o->poll_mask = MP_STREAM_POLL_WR;
+    #if defined(MBEDTLS_SSL_PROTO_TLS1_3)
+    } else if (ret == MBEDTLS_ERR_SSL_RECEIVED_NEW_SESSION_TICKET) {
+        // It appears a new session ticket being issued by the server right after
+        // completed handshake is not uncommon and shouldn't be treated as fatal.
+        // mbedtls itself states "This error code is experimental and may be
+        // changed or removed without notice."
+        ret = MP_EWOULDBLOCK;
+    #endif
     } else {
         o->last_error = ret;
     }


### PR DESCRIPTION
Add prerequisites for enabling and using support of TLSv1.3 in mbedtls.
TLSv1.3 is supported in mbedtls from version 3.x, but its implementation and API still subject to change.

Please not that there's currently a memory corruption happening to the socket's underlying ssl contexts, causing undefined behaviour and crashes. This is triggered by the garbage collector. PR https://github.com/micropython/micropython/pull/12139 is a addresses that and hence is a prerequisite.