### PR TITLE
Use pyproject.toml in tools/codeformat.py black config.

### DIFF
--- a/tools/codeformat.py
+++ b/tools/codeformat.py
@@ -90,6 +90,7 @@ EXCLUSIONS = [
 TOP = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
 
 UNCRUSTIFY_CFG = os.path.join(TOP, "tools/uncrustify.cfg")
+PYPROJECT_TOML = os.path.join(TOP, "pyproject.toml")
 
 C_EXTS = (
     ".c",
@@ -208,7 +209,7 @@ def main():
 
     # Format Python files with black.
     if format_py:
-        command = ["black", "--fast", "--line-length=99"]
+        command = ["black", "--fast", "--config={}".format(PYPROJECT_TOML)]
         if args.v:
             command.append("-v")
         else:


### PR DESCRIPTION
Replace the hardcoded line-length for `black` with a reference to the project-root pyproject.toml file to have one source for all relevant configuration.

Signed-off-by: Jos Verlinde <jos_verlinde@hotmail.com>