### PR TITLE
esp32/machine_timer: Add find free timer id.

### DIFF
--- a/docs/library/machine.Timer.rst
+++ b/docs/library/machine.Timer.rst
@@ -31,6 +31,7 @@ Constructors
 
    Construct a new timer object of the given ``id``. ``id`` of -1 constructs a
    virtual timer (if supported by a board).
+   ``id`` of -2 selects the ``id`` of a free timer (Supported at ESP32 port).
    ``id`` shall not be passed as a keyword argument.
 
    See ``init`` for parameters of initialisation.


### PR DESCRIPTION
`atimer = Timer(-2)`
The constructor `id` of -2 selects the `id` of a free timer.
Check the timer `id` range.
Check if the timer is already in use.

This allows you to write **separated library modules** without worrying about the timer id. For example:
```
class DoSomethingByTymer():
    def init(self):
        self.timer = Timer(-2, mode=Timer.PERIODIC, period=5000, callback=self.cb)
    def cb(self):
        print('DoSomethingByTymer()')
        # etc
```

EDITED: Maybe `id` value `None` is a better arg?
`atimer = Timer(None)`
