### PR TITLE
Pre-commit for codespell

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -16,3 +16,10 @@ repos:
     hooks:
       - id: ruff
       - id: ruff-format
+  - repo: https://github.com/codespell-project/codespell
+    rev: v2.2.6
+    hooks:
+      - id: codespell
+        name: Spellcheck for changed files (codespell)
+        additional_dependencies:
+          - tomli

--- a/CODECONVENTIONS.md
+++ b/CODECONVENTIONS.md
@@ -104,6 +104,22 @@ This command may work, please raise a new Issue if it doesn't:
 curl -L https://github.com/Homebrew/homebrew-core/raw/2b07d8192623365078a8b855a164ebcdf81494a6/Formula/uncrustify.rb > uncrustify.rb && brew install uncrustify.rb && rm uncrustify.rb
 ```
 
+Code spell checking
+===================
+
+Code spell checking is done using [codespell](https://github.com/codespell-project/codespell#codespell)
+and runs in a GitHub action in CI.  Codespell is configured via `pyproject.toml`
+to avoid false positives.  It is recommended run codespell before submitting a
+PR.  To simplify this, codespell is configured as a pre-commit hook and will be
+installed if you run `pre-commit install` (see below).
+
+If you want to install and run codespell manually, you can do so by running:
+
+```
+$ pip install codespell tomli
+$ codespell
+```
+
 Automatic Pre-Commit Hooks
 ==========================
 


### PR DESCRIPTION
Add a pre-commit hook for codespell and updates the documentation accordingly.

To minimize complexity when using the pre-commit hook, codespell and tomli are installed automatically from the codespell-repo, and configuration is read from the pyproject.toml file.

to test: 
```
$> pip install pre-commit

$> pre-commit install --hook-type pre-commit --hook-type commit-msg

$> pre-commit run codespell               
Spellcheck for changed files (codespell).................................Passed
```

Signed-off-by: Jos Verlinde <jos_verlinde@hotmail.com>