### PR TITLE
all/*/board.json: Simplify board feature tags.

### DIFF
--- a/ports/cc3200/boards/WIPY/board.json
+++ b/ports/cc3200/boards/WIPY/board.json
@@ -5,11 +5,10 @@
     "docs": "https://docs.pycom.io/datasheets/development/wipy3/",
     "features": [
         "BLE",
-        "Breadboard Friendly",
-        "MicroSD",
+        "External Flash",
         "RGB LED",
-        "SPI Flash",
-        "WiFi"
+        "WiFi",
+        "microSD"
     ],
     "id": "wipy",
     "images": [

--- a/ports/esp32/boards/ARDUINO_NANO_ESP32/board.json
+++ b/ports/esp32/boards/ARDUINO_NANO_ESP32/board.json
@@ -5,9 +5,10 @@
     "docs": "",
     "features": [
         "BLE",
-        "WiFi",
+        "External Flash",
+        "RGB LED",
         "USB-C",
-        "RGB LED"
+        "WiFi"
     ],
     "images": [
         "ABX00092_01.iso_1000x750.jpg"

--- a/ports/esp32/boards/ESP32_S2_WROVER/board.json
+++ b/ports/esp32/boards/ESP32_S2_WROVER/board.json
@@ -5,7 +5,8 @@
     "docs": "",
     "features": [
         "BLE",
-        "SPIRAM",
+        "External Flash",
+        "External RAM",
         "WiFi"
     ],
     "images": [

--- a/ports/esp32/boards/GENERIC/board.json
+++ b/ports/esp32/boards/GENERIC/board.json
@@ -5,6 +5,7 @@
     "docs": "",
     "features": [
         "BLE",
+        "External Flash",
         "WiFi"
     ],
     "id": "esp32",

--- a/ports/esp32/boards/GENERIC_C3/board.json
+++ b/ports/esp32/boards/GENERIC_C3/board.json
@@ -5,6 +5,7 @@
     "docs": "",
     "features": [
         "BLE",
+        "External Flash",
         "WiFi"
     ],
     "id": "esp32c3",

--- a/ports/esp32/boards/GENERIC_C3_USB/board.json
+++ b/ports/esp32/boards/GENERIC_C3_USB/board.json
@@ -5,6 +5,7 @@
     "docs": "",
     "features": [
         "BLE",
+        "External Flash",
         "WiFi"
     ],
     "id": "esp32c3-usb",

--- a/ports/esp32/boards/GENERIC_D2WD/board.json
+++ b/ports/esp32/boards/GENERIC_D2WD/board.json
@@ -5,6 +5,7 @@
     "docs": "",
     "features": [
         "BLE",
+        "External Flash",
         "WiFi"
     ],
     "id": "esp32-d2wd",

--- a/ports/esp32/boards/GENERIC_OTA/board.json
+++ b/ports/esp32/boards/GENERIC_OTA/board.json
@@ -5,6 +5,7 @@
     "docs": "",
     "features": [
         "BLE",
+        "External Flash",
         "WiFi"
     ],
     "id": "esp32-ota",

--- a/ports/esp32/boards/GENERIC_S2/board.json
+++ b/ports/esp32/boards/GENERIC_S2/board.json
@@ -5,6 +5,7 @@
     "docs": "",
     "features": [
         "BLE",
+        "External Flash",
         "WiFi"
     ],
     "images": [

--- a/ports/esp32/boards/GENERIC_S3/board.json
+++ b/ports/esp32/boards/GENERIC_S3/board.json
@@ -5,6 +5,7 @@
     "docs": "",
     "features": [
         "BLE",
+        "External Flash",
         "WiFi"
     ],
     "images": [

--- a/ports/esp32/boards/GENERIC_S3_SPIRAM/board.json
+++ b/ports/esp32/boards/GENERIC_S3_SPIRAM/board.json
@@ -5,6 +5,7 @@
     "docs": "",
     "features": [
         "BLE",
+        "External Flash",
         "WiFi"
     ],
     "images": [

--- a/ports/esp32/boards/GENERIC_S3_SPIRAM_OCT/board.json
+++ b/ports/esp32/boards/GENERIC_S3_SPIRAM_OCT/board.json
@@ -5,6 +5,7 @@
     "docs": "",
     "features": [
         "BLE",
+        "External Flash",
         "WiFi"
     ],
     "images": [

--- a/ports/esp32/boards/GENERIC_SPIRAM/board.json
+++ b/ports/esp32/boards/GENERIC_SPIRAM/board.json
@@ -5,7 +5,8 @@
     "docs": "",
     "features": [
         "BLE",
-        "SPIRAM",
+        "External Flash",
+        "External RAM",
         "WiFi"
     ],
     "id": "esp32spiram",

--- a/ports/esp32/boards/GENERIC_UNICORE/board.json
+++ b/ports/esp32/boards/GENERIC_UNICORE/board.json
@@ -5,6 +5,7 @@
     "docs": "",
     "features": [
         "BLE",
+        "External Flash",
         "WiFi"
     ],
     "id": "esp32-unicore",

--- a/ports/esp32/boards/LILYGO_TTGO_LORA32/board.json
+++ b/ports/esp32/boards/LILYGO_TTGO_LORA32/board.json
@@ -5,10 +5,11 @@
     "docs": "",
     "features": [
         "BLE",
+        "Display",
+        "External Flash",
         "LoRa",
-        "OLED",
         "SDCard",
-        "USB-MICRO",
+        "USB",
         "WiFi"
     ],
     "images": [

--- a/ports/esp32/boards/LOLIN_C3_MINI/board.json
+++ b/ports/esp32/boards/LOLIN_C3_MINI/board.json
@@ -5,6 +5,7 @@
     "docs": "",
     "features": [
         "BLE",
+        "External Flash",
         "USB-C",
         "WiFi"
     ],

--- a/ports/esp32/boards/LOLIN_S2_MINI/board.json
+++ b/ports/esp32/boards/LOLIN_S2_MINI/board.json
@@ -4,7 +4,8 @@
     ],
     "docs": "",
     "features": [
-        "SPIRAM",
+        "External Flash",
+        "External RAM",
         "USB-C",
         "WiFi"
     ],

--- a/ports/esp32/boards/LOLIN_S2_PICO/board.json
+++ b/ports/esp32/boards/LOLIN_S2_PICO/board.json
@@ -4,10 +4,10 @@
     ],
     "docs": "",
     "features": [
-        "Breadboard Friendly",
-        "OLED",
-        "SPIRAM",
-        "STEMMA QT/QWIIC",
+        "Display",
+        "External Flash",
+        "External RAM",
+        "JST-SH",
         "USB-C",
         "WiFi"
     ],

--- a/ports/esp32/boards/M5STACK_ATOM/board.json
+++ b/ports/esp32/boards/M5STACK_ATOM/board.json
@@ -4,9 +4,9 @@
     ],
     "docs": "",
     "features": [
-        "Grove",
+        "External Flash",
         "IMU",
-        "Infrared",
+        "JST-PH",
         "RGB LED",
         "USB-C",
         "WiFi"

--- a/ports/esp32/boards/OLIMEX_ESP32_POE/board.json
+++ b/ports/esp32/boards/OLIMEX_ESP32_POE/board.json
@@ -5,12 +5,12 @@
     "docs": "",
     "features": [
         "BLE",
-        "WiFi",
-        "MicroSD",
         "Battery Charging",
         "Ethernet",
+        "External Flash",
         "PoE",
-        "Breadboard friendly"
+        "WiFi",
+        "microSD"
     ],
     "images": [
         "ESP32-POE-ISO-1.jpg"

--- a/ports/esp32/boards/SIL_WESP32/board.json
+++ b/ports/esp32/boards/SIL_WESP32/board.json
@@ -6,6 +6,7 @@
     "features": [
         "BLE",
         "Ethernet",
+        "External Flash",
         "PoE",
         "WiFi"
     ],
@@ -18,5 +19,5 @@
     "product": "SIL WESP32",
     "thumbnail": "",
     "url": "https://wesp32.com/",
-    "vendor": "Silicognition LLC"
+    "vendor": "Silicognition"
 }

--- a/ports/esp32/boards/UM_FEATHERS2/board.json
+++ b/ports/esp32/boards/UM_FEATHERS2/board.json
@@ -5,10 +5,11 @@
     "docs": "",
     "features": [
         "Battery Charging",
+        "External Flash",
+        "External RAM",
         "Feather",
+        "JST-SH",
         "RGB LED",
-        "SPIRAM",
-        "STEMMA QT/QWIIC",
         "USB-C",
         "WiFi"
     ],

--- a/ports/esp32/boards/UM_FEATHERS2NEO/board.json
+++ b/ports/esp32/boards/UM_FEATHERS2NEO/board.json
@@ -5,10 +5,11 @@
     "docs": "",
     "features": [
         "Battery Charging",
+        "External Flash",
+        "External RAM",
         "Feather",
+        "JST-SH",
         "RGB LED",
-        "SPIRAM",
-        "STEMMA QT/QWIIC",
         "USB-C",
         "WiFi"
     ],

--- a/ports/esp32/boards/UM_FEATHERS3/board.json
+++ b/ports/esp32/boards/UM_FEATHERS3/board.json
@@ -4,17 +4,17 @@
     ],
     "docs": "",
     "features": [
-        "Battery Charging",
-        "RGB LED",
-        "SPIRAM",
-        "USB-C",
-        "WiFi",
         "BLE",
-        "STEMMA QT/QWIIC",
-        "Feather"
+        "Battery Charging",
+        "External Flash",
+        "External RAM",
+        "Feather",
+        "JST-SH",
+        "RGB LED",
+        "USB-C",
+        "WiFi"
     ],
-    "features_non_filterable": [
-    ],
+    "features_non_filterable": [],
     "id": "feathers3",
     "images": [
         "unexpectedmaker_feathers3.jpg"

--- a/ports/esp32/boards/UM_PROS3/board.json
+++ b/ports/esp32/boards/UM_PROS3/board.json
@@ -4,17 +4,17 @@
     ],
     "docs": "",
     "features": [
-        "Battery Charging",
-        "RGB LED",
-        "SPIRAM",
-        "USB-C",
-        "WiFi",
         "BLE",
-        "STEMMA QT/QWIIC",
-        "Feather"
+        "Battery Charging",
+        "External Flash",
+        "External RAM",
+        "Feather",
+        "JST-SH",
+        "RGB LED",
+        "USB-C",
+        "WiFi"
     ],
-    "features_non_filterable": [
-    ],
+    "features_non_filterable": [],
     "id": "pros3",
     "images": [
         "unexpectedmaker_pros3.jpg"

--- a/ports/esp32/boards/UM_TINYPICO/board.json
+++ b/ports/esp32/boards/UM_TINYPICO/board.json
@@ -4,10 +4,11 @@
     ],
     "docs": "",
     "features": [
-        "Battery Charging",
         "BLE",
+        "Battery Charging",
+        "External Flash",
+        "External RAM",
         "RGB LED",
-        "SPIRAM",
         "USB-C",
         "WiFi"
     ],

--- a/ports/esp32/boards/UM_TINYS2/board.json
+++ b/ports/esp32/boards/UM_TINYS2/board.json
@@ -5,9 +5,10 @@
     "docs": "",
     "features": [
         "Battery Charging",
+        "External Flash",
+        "External RAM",
+        "JST-SH",
         "RGB LED",
-        "SPIRAM",
-        "STEMMA QT/QWIIC",
         "USB-C",
         "WiFi"
     ],

--- a/ports/esp32/boards/UM_TINYS3/board.json
+++ b/ports/esp32/boards/UM_TINYS3/board.json
@@ -4,12 +4,13 @@
     ],
     "docs": "",
     "features": [
+        "BLE",
         "Battery Charging",
+        "External Flash",
+        "External RAM",
         "RGB LED",
-        "SPIRAM",
         "USB-C",
-        "WiFi",
-        "BLE"
+        "WiFi"
     ],
     "features_non_filterable": [
         "TinyPICO Compatible"

--- a/ports/esp8266/boards/GENERIC/board.json
+++ b/ports/esp8266/boards/GENERIC/board.json
@@ -4,6 +4,7 @@
     ],
     "docs": "",
     "features": [
+        "External Flash",
         "WiFi"
     ],
     "id": "esp8266",

--- a/ports/esp8266/boards/GENERIC_1M/board.json
+++ b/ports/esp8266/boards/GENERIC_1M/board.json
@@ -4,6 +4,7 @@
     ],
     "docs": "",
     "features": [
+        "External Flash",
         "WiFi"
     ],
     "id": "esp8266-1m",

--- a/ports/esp8266/boards/GENERIC_512K/board.json
+++ b/ports/esp8266/boards/GENERIC_512K/board.json
@@ -4,6 +4,7 @@
     ],
     "docs": "",
     "features": [
+        "External Flash",
         "WiFi"
     ],
     "id": "esp8266-512k",

--- a/ports/mimxrt/boards/ADAFRUIT_METRO_M7/board.json
+++ b/ports/mimxrt/boards/ADAFRUIT_METRO_M7/board.json
@@ -4,16 +4,12 @@
     ],
     "docs": "",
     "features": [
-        "USB-C",
-        "SPI",
-        "I2C",
-        "UART",
+        "BLE",
+        "External Flash",
+        "JST-SH",
         "RGB LED",
-        "QSPI Flash",
-        "QWIIC",
-        "JLink",
-        "WiFi",
-        "BLE"
+        "USB-C",
+        "WiFi"
     ],
     "images": [
         "Metro_M7.jpg"

--- a/ports/mimxrt/boards/MIMXRT1010_EVK/board.json
+++ b/ports/mimxrt/boards/MIMXRT1010_EVK/board.json
@@ -4,12 +4,10 @@
     ],
     "docs": "",
     "features": [
-        "MicroUSB",
+        "Audio Codec",
+        "External Flash",
         "Microphone",
-        "AudioCodec",
-        "SPDIF",
-        "OpenSDA",
-        "JLink"
+        "USB"
     ],
     "images": [
         "i.MXRT1010-TOP.jpg"

--- a/ports/mimxrt/boards/MIMXRT1015_EVK/board.json
+++ b/ports/mimxrt/boards/MIMXRT1015_EVK/board.json
@@ -4,13 +4,10 @@
     ],
     "docs": "",
     "features": [
-        "MicroSD",
-        "MicroUSB",
+        "Audio Codec",
+        "External Flash",
         "Microphone",
-        "AudioCodec",
-        "CAN",
-        "OpenSDA",
-        "JLink"
+        "USB"
     ],
     "images": [
         "MIMXRT1015-EVK-TOP.jpg"

--- a/ports/mimxrt/boards/MIMXRT1020_EVK/board.json
+++ b/ports/mimxrt/boards/MIMXRT1020_EVK/board.json
@@ -4,15 +4,14 @@
     ],
     "docs": "",
     "features": [
-        "Ethernet",
-        "SDRAM",
-        "MicroSD",
-        "MicroUSB",
-        "Microphone",
-        "AudioCodec",
+        "Audio Codec",
         "CAN",
-        "OpenSDA",
-        "JLink"
+        "Ethernet",
+        "External Flash",
+        "External RAM",
+        "Microphone",
+        "USB",
+        "microSD"
     ],
     "images": [
         "MIMXRT-1020-EVKBD.jpg"

--- a/ports/mimxrt/boards/MIMXRT1050_EVK/board.json
+++ b/ports/mimxrt/boards/MIMXRT1050_EVK/board.json
@@ -4,16 +4,14 @@
     ],
     "docs": "",
     "features": [
-        "Ethernet",
-        "SDRAM",
-        "MicroSD",
-        "MicroUSB",
-        "Microphone",
-        "AudioCodec",
-        "SPDIF",
+        "Audio Codec",
         "CAN",
-        "OpenSDA",
-        "JLink"
+        "Ethernet",
+        "External Flash",
+        "External RAM",
+        "Microphone",
+        "USB",
+        "microSD"
     ],
     "images": [
         "IMX_RT1050-EVKB_TOP-LR.jpg"

--- a/ports/mimxrt/boards/MIMXRT1060_EVK/board.json
+++ b/ports/mimxrt/boards/MIMXRT1060_EVK/board.json
@@ -4,17 +4,15 @@
     ],
     "docs": "",
     "features": [
-        "Ethernet",
-        "SDRAM",
-        "MicroSD",
-        "MicroUSB",
-        "Microphone",
-        "AudioCodec",
-        "SPDIF",
+        "Audio Codec",
         "CAN",
         "Camera",
-        "OpenSDA",
-        "JLink"
+        "Ethernet",
+        "External Flash",
+        "External RAM",
+        "Microphone",
+        "USB",
+        "microSD"
     ],
     "images": [
         "X-MIMXRT1060-EVK-BOARD-BOTTOM.jpg"

--- a/ports/mimxrt/boards/MIMXRT1064_EVK/board.json
+++ b/ports/mimxrt/boards/MIMXRT1064_EVK/board.json
@@ -4,17 +4,15 @@
     ],
     "docs": "",
     "features": [
-        "Ethernet",
-        "SDRAM",
-        "MicroSD",
-        "MicroUSB",
-        "Microphone",
-        "AudioAmp",
-        "SPDIF",
+        "Audio Codec",
         "CAN",
         "Camera",
-        "OpenSDA",
-        "JLink"
+        "Ethernet",
+        "External Flash",
+        "External RAM",
+        "Microphone",
+        "USB",
+        "microSD"
     ],
     "images": [
         "MIMXRT1064EVK-TOP.jpg"

--- a/ports/mimxrt/boards/MIMXRT1170_EVK/board.json
+++ b/ports/mimxrt/boards/MIMXRT1170_EVK/board.json
@@ -4,18 +4,15 @@
     ],
     "docs": "",
     "features": [
-        "Ethernet",
-        "SDRAM",
-        "MicroSD",
-        "MicroUSB",
-        "Microphone",
-        "AudioCodec",
-        "SPDIF",
+        "Audio Codec",
         "CAN",
         "Camera",
-        "SIM Socket",
-        "OpenSDA",
-        "JLink"
+        "Ethernet",
+        "External Flash",
+        "External RAM",
+        "Microphone",
+        "USB",
+        "microSD"
     ],
     "images": [
         "IMX-RT1170-EVK-TOP.jpg"

--- a/ports/mimxrt/boards/OLIMEX_RT1010/board.json
+++ b/ports/mimxrt/boards/OLIMEX_RT1010/board.json
@@ -4,11 +4,9 @@
     ],
     "docs": "",
     "features": [
-        "MicroUSB",
-        "MicroSD",
-        "AudioCodec",
-        "SPDIF",
-        "JLink"
+        "External Flash",
+        "USB",
+        "microSD"
     ],
     "images": [
         "OLIMEX_RT1010Py.jpg"

--- a/ports/mimxrt/boards/SEEED_ARCH_MIX/board.json
+++ b/ports/mimxrt/boards/SEEED_ARCH_MIX/board.json
@@ -4,10 +4,11 @@
     ],
     "docs": "",
     "features": [
-        "MicroSD",
-        "MicroUSB",
-        "SDRAM",
-        "RGB LED"
+        "External Flash",
+        "External RAM",
+        "RGB LED",
+        "USB",
+        "microSD"
     ],
     "images": [
         "main1.jpg"
@@ -16,5 +17,5 @@
     "product": "Arch Mix",
     "thumbnail": "",
     "url": "https://wiki.seeedstudio.com/Arch_Mix/",
-    "vendor": "Seeed Technology Co.,Ltd."
+    "vendor": "Seeed Studio"
 }

--- a/ports/mimxrt/boards/TEENSY40/board.json
+++ b/ports/mimxrt/boards/TEENSY40/board.json
@@ -4,7 +4,8 @@
     ],
     "docs": "",
     "features": [
-        "Breadboard Friendly"
+        "External Flash",
+        "USB"
     ],
     "images": [
         "teensy40_front.jpg"

--- a/ports/mimxrt/boards/TEENSY41/board.json
+++ b/ports/mimxrt/boards/TEENSY41/board.json
@@ -4,9 +4,10 @@
     ],
     "docs": "",
     "features": [
-        "MicroSD",
         "Ethernet",
-        "Breadboard Friendly"
+        "External Flash",
+        "USB",
+        "microSD"
     ],
     "images": [
         "teensy41_4.jpg"

--- a/ports/nrf/boards/arduino_nano_33_ble_sense/board.json
+++ b/ports/nrf/boards/arduino_nano_33_ble_sense/board.json
@@ -4,15 +4,12 @@
     ],
     "docs": "",
     "features": [
-        "Bluetooth 5.0",
-        "IMU LSM9DS1",
-        "Humidity sensor HTS221",
-        "Pressure sensor LPS22H",
-        "Proximity, Light, RGB sensor APDS-9960",
-        "Microphone MPM3610",
-        "Crypto IC ARM CC310",
-        "USB-MICRO",
-        "Breadboard Friendly"
+        "BLE",
+        "Environment Sensor",
+        "IMU",
+        "Microphone",
+        "Secure Element",
+        "USB"
     ],
     "images": [
         "ABX00031_01.iso_998x749.jpg"

--- a/ports/nrf/boards/arduino_primo/board.json
+++ b/ports/nrf/boards/arduino_primo/board.json
@@ -11,5 +11,5 @@
     "product": "arduino_primo",
     "thumbnail": "",
     "url": "",
-    "vendor": ""
+    "vendor": "Arduino"
 }

--- a/ports/nrf/boards/nrf52840-mdk-usb-dongle/board.json
+++ b/ports/nrf/boards/nrf52840-mdk-usb-dongle/board.json
@@ -11,5 +11,5 @@
     "product": "nrf52840-mdk-usb-dongle",
     "thumbnail": "",
     "url": "https://wiki.makerdiary.com/nrf52840-mdk-usb-dongle",
-    "vendor": ""
+    "vendor": "Makerdiary"
 }

--- a/ports/nrf/boards/seeed_xiao_nrf52/board.json
+++ b/ports/nrf/boards/seeed_xiao_nrf52/board.json
@@ -4,14 +4,13 @@
     ],
     "docs": "",
     "features": [
-        "Bluetooth 5.0",
-        "IMU LSM6DS3TR",
-        "Microphone MSM261D3526H1CPM",
-        "USB-C",
-        "Breadboard Friendly",
-        "Battery Management",
+        "BLE",
+        "Battery Charging",
+        "External Flash",
+        "IMU",
+        "Microphone",
         "RGB LED",
-        "QSPI Flash"
+        "USB-C"
     ],
     "images": [
         "XIAO_nrf52840_front.jpg"

--- a/ports/renesas-ra/boards/EK_RA4M1/board.json
+++ b/ports/renesas-ra/boards/EK_RA4M1/board.json
@@ -3,17 +3,12 @@
         "../deploy.md"
     ],
     "docs": "",
-    "features": [
-	"UART",
-	"SPI",
-	"I2C",
-	"ADC"
-    ],
+    "features": [],
     "id": "EK-RA4M1",
     "images": [
         "ek_ra4m1_board.jpg"
     ],
-    "mcu": "RA4M1",
+    "mcu": "ra4m1",
     "product": "EK-RA4M1",
     "thumbnail": "",
     "url": "https://www.renesas.com/products/microcontrollers-microprocessors/ra-cortex-m-mcus/ek-ra4m1-evaluation-kit-ra4m1-mcu-group",

--- a/ports/renesas-ra/boards/EK_RA4W1/board.json
+++ b/ports/renesas-ra/boards/EK_RA4W1/board.json
@@ -3,17 +3,12 @@
         "../deploy.md"
     ],
     "docs": "",
-    "features": [
-	"UART",
-	"SPI",
-	"I2C",
-	"ADC"
-    ],
+    "features": [],
     "id": "EK-RA4W1",
     "images": [
         "ek_ra4w1_board.jpg"
     ],
-    "mcu": "RA4W1",
+    "mcu": "ra4w1",
     "product": "EK-RA4W1",
     "thumbnail": "",
     "url": "https://www.renesas.com/products/microcontrollers-microprocessors/ra-cortex-m-mcus/ek-ra4w1-evaluation-kit-ra4w1-mcu-group",

--- a/ports/renesas-ra/boards/EK_RA6M1/board.json
+++ b/ports/renesas-ra/boards/EK_RA6M1/board.json
@@ -3,17 +3,12 @@
         "../deploy.md"
     ],
     "docs": "",
-    "features": [
-	"UART",
-	"SPI",
-	"I2C",
-	"ADC"
-    ],
+    "features": [],
     "id": "EK-RA6M1",
     "images": [
         "ek_ra6m1_board.jpg"
     ],
-    "mcu": "RA6M1",
+    "mcu": "ra6m1",
     "product": "EK-RA6M1",
     "thumbnail": "",
     "url": "https://www.renesas.com/products/microcontrollers-microprocessors/ra-cortex-m-mcus/ek-ra6m1-evaluation-kit-ra6m1-mcu-group",

--- a/ports/renesas-ra/boards/EK_RA6M2/board.json
+++ b/ports/renesas-ra/boards/EK_RA6M2/board.json
@@ -3,12 +3,7 @@
         "../deploy.md"
     ],
     "docs": "",
-    "features": [
-	"UART",
-	"SPI",
-	"I2C",
-	"ADC"
-    ],
+    "features": [],
     "id": "EK-RA6M2",
     "images": [
         "ek_ra6m2_board.jpg",
@@ -17,7 +12,7 @@
         "ek_ra6m2_j3_pins.jpg",
         "ek_ra6m2_j4_pins.jpg"
     ],
-    "mcu": "RA6M2",
+    "mcu": "ra6m2",
     "product": "EK-RA6M2",
     "thumbnail": "",
     "url": "https://www.renesas.com/products/microcontrollers-microprocessors/ra-cortex-m-mcus/ek-ra6m2-evaluation-kit-ra6m2-mcu-group",

--- a/ports/renesas-ra/boards/RA4M1_CLICKER/board.json
+++ b/ports/renesas-ra/boards/RA4M1_CLICKER/board.json
@@ -3,18 +3,13 @@
         "../deploy.md"
     ],
     "docs": "",
-    "features": [
-	"UART",
-	"SPI",
-	"I2C",
-	"ADC"
-    ],
+    "features": [],
     "id": "RA4M1-CLICKER",
     "images": [
         "ra4m1_clicker_board.jpg",
         "ra4m1_clicker_pins.jpg"
     ],
-    "mcu": "RA4M1",
+    "mcu": "ra4m1",
     "product": "Mikroe RA4M1 Clicker",
     "thumbnail": "",
     "url": "https://www.mikroe.com/ra4m1-clicker",

--- a/ports/renesas-ra/boards/VK_RA6M5/board.json
+++ b/ports/renesas-ra/boards/VK_RA6M5/board.json
@@ -4,18 +4,13 @@
     ],
     "docs": "",
     "features": [
-        "UART",
-        "SPI",
-        "I2C",
-        "ADC",
-        "DAC",
-        "PWM"
+        "DAC"
     ],
     "id": "VK-RA6M5",
     "images": [
         "VK-RA6M5.jpg"
     ],
-    "mcu": "RA6M5",
+    "mcu": "ra6m5",
     "product": "VK-RA6M5",
     "thumbnail": "",
     "url": "https://vekatech.com/VK-RA6M5_docs/brochures/VK-RA6M5%20Flyer%20R2.pdf",

--- a/ports/rp2/boards/ADAFRUIT_FEATHER_RP2040/board.json
+++ b/ports/rp2/boards/ADAFRUIT_FEATHER_RP2040/board.json
@@ -5,11 +5,11 @@
     "docs": "",
     "features": [
         "Battery Charging",
-        "Breadboard Friendly",
+        "Dual-core",
+        "External Flash",
         "Feather",
+        "JST-SH",
         "RGB LED",
-        "SPI Flash",
-        "STEMMA QT/QWIIC",
         "USB-C"
     ],
     "images": [

--- a/ports/rp2/boards/ADAFRUIT_ITSYBITSY_RP2040/board.json
+++ b/ports/rp2/boards/ADAFRUIT_ITSYBITSY_RP2040/board.json
@@ -4,10 +4,10 @@
     ],
     "docs": "",
     "features": [
-        "Breadboard Friendly",
-        "Micro USB",
+        "Dual-core",
+        "External Flash",
         "RGB LED",
-        "SPI Flash"
+        "USB"
     ],
     "images": [
         "4888-05.jpg"

--- a/ports/rp2/boards/ADAFRUIT_QTPY_RP2040/board.json
+++ b/ports/rp2/boards/ADAFRUIT_QTPY_RP2040/board.json
@@ -4,11 +4,10 @@
     ],
     "docs": "",
     "features": [
-        "Breadboard Friendly",
-        "Castellated Pads",
+        "Dual-core",
+        "External Flash",
+        "JST-SH",
         "RGB LED",
-        "SPI Flash",
-        "STEMMA QT/QWIIC",
         "USB-C"
     ],
     "images": [

--- a/ports/rp2/boards/ARDUINO_NANO_RP2040_CONNECT/board.json
+++ b/ports/rp2/boards/ARDUINO_NANO_RP2040_CONNECT/board.json
@@ -4,15 +4,14 @@
     ],
     "docs": "",
     "features": [
-        "Breadboard Friendly",
-        "Castellated Pads",
-        "WiFi Nina-W102",
-        "Bluetooth Nina-W102",
-        "IMU LSM6DSOXTR",
-        "Crypto IC ATECC608A-MAHDA-T",
-        "Microphone MP34DT05",
-        "SPI Flash 16MB",
-        "USB-MICRO"
+        "BLE",
+        "Dual-core",
+        "External Flash",
+        "IMU",
+        "Microphone",
+        "Secure Element",
+        "USB",
+        "WiFi"
     ],
     "images": [
         "ABX00052_01.iso_999x750.jpg"

--- a/ports/rp2/boards/GARATRONIC_PYBSTICK26_RP2040/board.json
+++ b/ports/rp2/boards/GARATRONIC_PYBSTICK26_RP2040/board.json
@@ -4,12 +4,10 @@
     ],
     "docs": "",
     "features": [
-        "USB Stick form factor",
-        "Breadboard Friendly",
-        "Reset/User button",
-        "Red/green/orange/blue leds",
-        "1MB SPI Flash",
-        "USB-A"
+        "Dual-core",
+        "External Flash",
+        "RGB LED",
+        "USB"
     ],
     "images": [
         "pybstick-rp2040-26-broches-micropython-c.jpg"

--- a/ports/rp2/boards/NULLBITS_BIT_C_PRO/board.json
+++ b/ports/rp2/boards/NULLBITS_BIT_C_PRO/board.json
@@ -4,10 +4,10 @@
     ],
     "docs": "",
     "features": [
-        "Breadboard Friendly",
+        "Dual-core",
+        "External Flash",
         "RGB LED",
-        "USB-C",
-        "SPI Flash"
+        "USB-C"
     ],
     "images": [
         "nullbits_bit_c_pro.jpg"

--- a/ports/rp2/boards/PICO/board.json
+++ b/ports/rp2/boards/PICO/board.json
@@ -4,9 +4,9 @@
     ],
     "docs": "",
     "features": [
-        "Breadboard friendly",
-        "Castellated Pads",
-        "Micro USB"
+        "Dual-core",
+        "External Flash",
+        "USB"
     ],
     "id": "rp2-pico",
     "images": [

--- a/ports/rp2/boards/PICO_W/board.json
+++ b/ports/rp2/boards/PICO_W/board.json
@@ -4,11 +4,11 @@
     ],
     "docs": "",
     "features": [
-        "Breadboard friendly",
-        "Castellated Pads",
-        "Micro USB",
-        "WiFi",
-        "Bluetooth"
+        "BLE",
+        "Dual-core",
+        "External Flash",
+        "USB",
+        "WiFi"
     ],
     "id": "rp2-pico-w",
     "images": [

--- a/ports/rp2/boards/PIMORONI_PICOLIPO_16MB/board.json
+++ b/ports/rp2/boards/PIMORONI_PICOLIPO_16MB/board.json
@@ -5,10 +5,9 @@
     "docs": "",
     "features": [
         "Battery Charging",
-        "Breadboard Friendly",
-        "Castellated Pads",
-        "SPI Flash",
-        "STEMMA QT/QWIIC",
+        "Dual-core",
+        "External Flash",
+        "JST-SH",
         "USB-C"
     ],
     "images": [

--- a/ports/rp2/boards/PIMORONI_PICOLIPO_4MB/board.json
+++ b/ports/rp2/boards/PIMORONI_PICOLIPO_4MB/board.json
@@ -5,10 +5,9 @@
     "docs": "",
     "features": [
         "Battery Charging",
-        "Breadboard Friendly",
-        "Castellated Pads",
-        "SPI Flash",
-        "STEMMA QT/QWIIC",
+        "Dual-core",
+        "External Flash",
+        "JST-SH",
         "USB-C"
     ],
     "images": [

--- a/ports/rp2/boards/PIMORONI_TINY2040/board.json
+++ b/ports/rp2/boards/PIMORONI_TINY2040/board.json
@@ -4,8 +4,8 @@
     ],
     "docs": "",
     "features": [
-        "Breadboard Friendly",
-        "Castellated Pads",
+        "Dual-core",
+        "External Flash",
         "RGB LED",
         "USB-C"
     ],

--- a/ports/rp2/boards/SPARKFUN_PROMICRO/board.json
+++ b/ports/rp2/boards/SPARKFUN_PROMICRO/board.json
@@ -4,10 +4,10 @@
     ],
     "docs": "",
     "features": [
-        "Breadboard Friendly",
-        "Castellated Pads",
+        "Dual-core",
+        "External Flash",
+        "JST-SH",
         "RGB LED",
-        "STEMMA QT/QWIIC",
         "USB-C"
     ],
     "images": [

--- a/ports/rp2/boards/SPARKFUN_THINGPLUS/board.json
+++ b/ports/rp2/boards/SPARKFUN_THINGPLUS/board.json
@@ -5,13 +5,13 @@
     "docs": "",
     "features": [
         "Battery Charging",
-        "Breadboard Friendly",
+        "Dual-core",
+        "External Flash",
         "Feather",
-        "MicroSD",
+        "JST-SH",
         "RGB LED",
-        "SPI Flash",
-        "STEMMA QT/QWIIC",
-        "USB-C"
+        "USB-C",
+        "microSD"
     ],
     "images": [
         "17745-SparkFun_Thing_Plus_-_RP2040-01a.jpg"

--- a/ports/rp2/boards/W5100S_EVB_PICO/board.json
+++ b/ports/rp2/boards/W5100S_EVB_PICO/board.json
@@ -4,10 +4,10 @@
     ],
     "docs": "",
     "features": [
-        "Breadboard Friendly",
-        "Castellated Pads",
+        "Dual-core",
         "Ethernet",
-        "Micro USB"
+        "External Flash",
+        "USB"
     ],
     "images": [
         "W5100S-EVB-Pico.jpg"

--- a/ports/rp2/boards/W5500_EVB_PICO/board.json
+++ b/ports/rp2/boards/W5500_EVB_PICO/board.json
@@ -4,10 +4,10 @@
     ],
     "docs": "",
     "features": [
-        "Breadboard Friendly",
-        "Castellated Pads",
+        "Dual-core",
         "Ethernet",
-        "Micro USB"
+        "External Flash",
+        "USB"
     ],
     "images": [
         "W5500-EVB-Pico.jpg"

--- a/ports/rp2/boards/WEACTSTUDIO/board.json
+++ b/ports/rp2/boards/WEACTSTUDIO/board.json
@@ -4,8 +4,8 @@
     ],
     "docs": "",
     "features": [
-        "Breadboard Friendly",
-        "SPI Flash",
+        "Dual-core",
+        "External Flash",
         "USB-C"
     ],
     "images": [

--- a/ports/samd/boards/ADAFRUIT_FEATHER_M0_EXPRESS/board.json
+++ b/ports/samd/boards/ADAFRUIT_FEATHER_M0_EXPRESS/board.json
@@ -5,11 +5,10 @@
     "docs": "",
     "features": [
         "Battery Charging",
-        "Breadboard Friendly",
+        "External Flash",
         "Feather",
-        "Micro USB",
         "RGB LED",
-        "SPI Flash"
+        "USB"
     ],
     "images": [
         "feather_m0_express.jpg"

--- a/ports/samd/boards/ADAFRUIT_FEATHER_M4_EXPRESS/board.json
+++ b/ports/samd/boards/ADAFRUIT_FEATHER_M4_EXPRESS/board.json
@@ -5,11 +5,10 @@
     "docs": "",
     "features": [
         "Battery Charging",
-        "Breadboard Friendly",
+        "External Flash",
         "Feather",
-        "Micro USB",
         "RGB LED",
-        "SPI Flash"
+        "USB"
     ],
     "images": [
         "feather_m4_express.jpg"

--- a/ports/samd/boards/ADAFRUIT_ITSYBITSY_M0_EXPRESS/board.json
+++ b/ports/samd/boards/ADAFRUIT_ITSYBITSY_M0_EXPRESS/board.json
@@ -4,10 +4,9 @@
     ],
     "docs": "",
     "features": [
-        "Breadboard Friendly",
-        "Micro USB",
+        "External Flash",
         "RGB LED",
-        "SPI Flash"
+        "USB"
     ],
     "images": [
         "itsybitsy_m0_express.jpg"

--- a/ports/samd/boards/ADAFRUIT_ITSYBITSY_M4_EXPRESS/board.json
+++ b/ports/samd/boards/ADAFRUIT_ITSYBITSY_M4_EXPRESS/board.json
@@ -4,10 +4,9 @@
     ],
     "docs": "",
     "features": [
-        "Breadboard Friendly",
-        "Micro USB",
+        "External Flash",
         "RGB LED",
-        "SPI Flash"
+        "USB"
     ],
     "images": [
         "itsybitsy_m4_express.jpg"

--- a/ports/samd/boards/ADAFRUIT_METRO_M4_EXPRESS/board.json
+++ b/ports/samd/boards/ADAFRUIT_METRO_M4_EXPRESS/board.json
@@ -4,14 +4,12 @@
     ],
     "docs": "",
     "features": [
-        "Micro USB",
-        "ADC",
-        "DAC",
-        "RGB LED",
-        "QSPI Flash",
-        "WiFi",
         "BLE",
-        "JLink"
+        "DAC",
+        "External Flash",
+        "RGB LED",
+        "USB",
+        "WiFi"
     ],
     "images": [
         "metro_m4_express_airlift.jpg"

--- a/ports/samd/boards/ADAFRUIT_TRINKET_M0/board.json
+++ b/ports/samd/boards/ADAFRUIT_TRINKET_M0/board.json
@@ -4,9 +4,8 @@
     ],
     "docs": "",
     "features": [
-        "Breadboard Friendly",
-        "Micro USB",
-        "RGB LED"
+        "RGB LED",
+        "USB"
     ],
     "images": [
         "trinket_m0.jpg"

--- a/ports/samd/boards/MINISAM_M4/board.json
+++ b/ports/samd/boards/MINISAM_M4/board.json
@@ -4,9 +4,9 @@
     ],
     "docs": "",
     "features": [
-        "Micro USB",
+        "External Flash",
         "RGB LED",
-        "SPI Flash"
+        "USB"
     ],
     "images": [
         "mini_sam_m4.jpg"

--- a/ports/samd/boards/SAMD21_XPLAINED_PRO/board.json
+++ b/ports/samd/boards/SAMD21_XPLAINED_PRO/board.json
@@ -4,10 +4,12 @@
     ],
     "docs": "",
     "features": [
-        "Micro USB",
-        "SPI Flash"
+        "External Flash",
+        "USB"
     ],
-    "images": ["2033-atsamd21-xpro.jpg"],
+    "images": [
+        "2033-atsamd21-xpro.jpg"
+    ],
     "mcu": "samd21",
     "product": "SAMD21 Xplained Pro",
     "thumbnail": "",

--- a/ports/samd/boards/SEEED_WIO_TERMINAL/board.json
+++ b/ports/samd/boards/SEEED_WIO_TERMINAL/board.json
@@ -4,14 +4,17 @@
     ],
     "docs": "",
     "features": [
-        "USB-C",
-        "Display",
-        "Grove",
-        "WiFi",
         "BLE",
-        "SDCard"
+        "Display",
+        "External Flash",
+        "JST-PH",
+        "SDCard",
+        "USB-C",
+        "WiFi"
     ],
-    "images": ["wio-terminal.jpg"],
+    "images": [
+        "wio-terminal.jpg"
+    ],
     "mcu": "samd51",
     "product": "Wio Terminal D51R",
     "thumbnail": "",

--- a/ports/samd/boards/SEEED_XIAO_SAMD21/board.json
+++ b/ports/samd/boards/SEEED_XIAO_SAMD21/board.json
@@ -6,7 +6,9 @@
     "features": [
         "USB-C"
     ],
-    "images": ["seeeduino-xiao.jpg"],
+    "images": [
+        "seeeduino-xiao.jpg"
+    ],
     "mcu": "samd21",
     "product": "Seeeduino XIAO (SAMD21)",
     "thumbnail": "",

--- a/ports/samd/boards/SPARKFUN_SAMD51_THING_PLUS/board.json
+++ b/ports/samd/boards/SPARKFUN_SAMD51_THING_PLUS/board.json
@@ -5,10 +5,9 @@
     "docs": "",
     "features": [
         "Battery Charging",
-        "Breadboard Friendly",
-        "Micro USB",
-        "QWIIC",
-        "SPI Flash"
+        "External Flash",
+        "JST-SH",
+        "USB"
     ],
     "images": [
         "sparkfun_samd51_thing_plus.jpg"

--- a/ports/stm32/boards/ARDUINO_GIGA/board.json
+++ b/ports/stm32/boards/ARDUINO_GIGA/board.json
@@ -4,11 +4,12 @@
     ],
     "docs": "",
     "features": [
-        "8MB SDRAM",
-        "16MB Flash",
-        "Dual-core processor",
-        "USB Full speed",
-        "CYW43 WiFi/BT Module"
+        "BLE",
+        "Dual-core",
+        "External Flash",
+        "External RAM",
+        "USB",
+        "WiFi"
     ],
     "images": [
         "ABX00063_01.front_1000x750.jpg"

--- a/ports/stm32/boards/ARDUINO_NICLA_VISION/board.json
+++ b/ports/stm32/boards/ARDUINO_NICLA_VISION/board.json
@@ -4,11 +4,12 @@
     ],
     "docs": "",
     "features": [
-        "16MB Flash",
-        "Dual-core processor",
-        "USB High Speed Phy",
-        "CYW43 WiFi/BT Module",
-        "NXP SE050 crypto device"
+        "BLE",
+        "Dual-core",
+        "External Flash",
+        "Secure Element",
+        "USB",
+        "WiFi"
     ],
     "images": [
         "ABX00051_01.iso_1000x750.jpg"

--- a/ports/stm32/boards/ARDUINO_PORTENTA_H7/board.json
+++ b/ports/stm32/boards/ARDUINO_PORTENTA_H7/board.json
@@ -4,14 +4,13 @@
     ],
     "docs": "",
     "features": [
-        "8MB SDRAM",
-        "16MB Flash",
-        "Dual-core processor",
-        "USB High Speed Phy",
-        "10/100 Ethernet Phy",
-        "CYW43 WiFi/BT Module",
-        "DisplayPort over USB-C",
-        "2x80 pin HD connectors"
+        "BLE",
+        "Dual-core",
+        "Ethernet",
+        "External Flash",
+        "External RAM",
+        "USB",
+        "WiFi"
     ],
     "images": [
         "ABX00042_01.iso_1000x750.jpg"

--- a/ports/stm32/boards/CERB40/board.json
+++ b/ports/stm32/boards/CERB40/board.json
@@ -8,8 +8,8 @@
         "cerb40.jpg"
     ],
     "mcu": "stm32f4",
-    "product": "CERB40",
+    "product": "Cerb40",
     "thumbnail": "",
     "url": "",
-    "vendor": ""
+    "vendor": "Fez"
 }

--- a/ports/stm32/boards/HYDRABUS/board.json
+++ b/ports/stm32/boards/HYDRABUS/board.json
@@ -8,8 +8,8 @@
         "hydrabus.jpg"
     ],
     "mcu": "stm32f4",
-    "product": "HYDRABUS",
+    "product": "HydraBus v1.0",
     "thumbnail": "",
     "url": "",
-    "vendor": ""
+    "vendor": "HydraBus"
 }

--- a/ports/stm32/boards/LEGO_HUB_NO6/board.json
+++ b/ports/stm32/boards/LEGO_HUB_NO6/board.json
@@ -9,5 +9,5 @@
     "product": "Hub No.6",
     "thumbnail": "",
     "url": "",
-    "vendor": "Lego"
+    "vendor": "LEGO"
 }

--- a/ports/stm32/boards/LIMIFROG/board.json
+++ b/ports/stm32/boards/LIMIFROG/board.json
@@ -8,8 +8,8 @@
         "limifrog.jpg"
     ],
     "mcu": "stm32l4",
-    "product": "LIMIFROG",
+    "product": "LimiFrog",
     "thumbnail": "",
     "url": "",
-    "vendor": ""
+    "vendor": "LimiFrog"
 }

--- a/ports/stm32/boards/MIKROE_QUAIL/board.json
+++ b/ports/stm32/boards/MIKROE_QUAIL/board.json
@@ -8,7 +8,7 @@
     ],
     "id": "MIKROE-QUAIL",
     "images": [
-            "quail_top.jpg"
+        "quail_top.jpg"
     ],
     "mcu": "stm32f4",
     "product": "MikroE Quail",

--- a/ports/stm32/boards/NETDUINO_PLUS_2/board.json
+++ b/ports/stm32/boards/NETDUINO_PLUS_2/board.json
@@ -8,8 +8,8 @@
         "netduino_plus_2.jpg"
     ],
     "mcu": "stm32f4",
-    "product": "NETDUINO_PLUS_2",
+    "product": "Netduino Plus 2",
     "thumbnail": "",
     "url": "",
-    "vendor": ""
+    "vendor": "Netduino"
 }

--- a/ports/stm32/boards/PYBD_SF6/board.json
+++ b/ports/stm32/boards/PYBD_SF6/board.json
@@ -4,8 +4,8 @@
     ],
     "docs": "",
     "features": [
-        "WiFi",
-        "BLE"
+        "BLE",
+        "WiFi"
     ],
     "id": "PYBD-SF6",
     "images": [

--- a/ports/stm32/boards/STM32F439/board.json
+++ b/ports/stm32/boards/STM32F439/board.json
@@ -11,5 +11,5 @@
     "product": "STM32F439",
     "thumbnail": "",
     "url": "",
-    "vendor": ""
+    "vendor": "ST Microelectronics"
 }

--- a/ports/stm32/boards/USBDONGLE_WB55/board.json
+++ b/ports/stm32/boards/USBDONGLE_WB55/board.json
@@ -11,5 +11,5 @@
     "product": "USBDONGLE_WB55",
     "thumbnail": "",
     "url": "",
-    "vendor": ""
+    "vendor": "ST Microelectronics"
 }


### PR DESCRIPTION
- Find a common set of board feature tags and map existing features to that reduced set.
- Remove some less-useful board feature tags.
- Ensure all mcus are specified correctly.
- Ensure all boards have a vendor (and fix some vendor names).

This is to make the downloads page show a less intimidating set of filters.

Work done in conjunction with @mattytrentini .

_This work was funded through GitHub Sponsors._
