### PR TITLE
tests/cpydiff/core_class_name_mangling: New tests for name mangling.

### DIFF
--- a/py/compile.c
+++ b/py/compile.c
@@ -41,8 +41,6 @@
 
 #if MICROPY_ENABLE_COMPILER
 
-// TODO need to mangle __attr names
-
 #define INVALID_LABEL (0xffff)
 
 typedef enum {

--- a/tests/cpydiff/core_class_name_mangling.py
+++ b/tests/cpydiff/core_class_name_mangling.py
@@ -1,0 +1,26 @@
+"""
+categories: Core,Classes
+description: Private Class Members name mangling is not implemented
+cause: The MicroPython compiler does not implement name mangling for private class members.
+workaround: Avoid using or having a collision with global names, by adding a unique prefix to the private class member name manually.
+"""
+
+
+def __print_string(string):
+    print(string)
+
+
+class Foo:
+    def __init__(self, string):
+        self.string = string
+
+    def do_print(self):
+        __print_string(self.string)
+
+
+example_string = "Example String to print."
+
+class_item = Foo(example_string)
+print(class_item.string)
+
+class_item.do_print()


### PR DESCRIPTION
Adding new tests/documentation for missing name mangling for private class members.

Adds testing/documentation for #12150.