### PR TITLE
mpremote: Make soft-reset count as an action.

### DIFF
--- a/tools/mpremote/mpremote/commands.py
+++ b/tools/mpremote/mpremote/commands.py
@@ -238,6 +238,7 @@ def do_resume(state, _args=None):
 
 def do_soft_reset(state, _args=None):
     state.ensure_raw_repl(soft_reset=True)
+    state.did_action()
 
 
 def do_rtc(state, args):


### PR DESCRIPTION
Otherwise `mpremote soft-reset` will implicitly run the repl command.

Fixes #10871 cc @bulletmark

_This work was funded through GitHub Sponsors._