### PR TITLE
all: Enable ruff linter check for undefined-name (F821).

### DIFF
--- a/examples/asmled.py
+++ b/examples/asmled.py
@@ -1,5 +1,9 @@
 # flash LED #1 using inline assembler
 # this version is overly verbose and uses word stores
+#
+# ruff: noqa: F821 - @asm_thumb decorator adds names to function scope
+
+
 @micropython.asm_thumb
 def flash_led(r0):
     movw(r1, (stm.GPIOA + stm.GPIO_BSRRL) & 0xFFFF)

--- a/examples/asmsum.py
+++ b/examples/asmsum.py
@@ -1,3 +1,6 @@
+# ruff: noqa: F821 - @asm_thumb decorator adds names to function scope
+
+
 @micropython.asm_thumb
 def asm_sum_words(r0, r1):
     # r0 = len

--- a/examples/bluetooth/ble_uart_repl.py
+++ b/examples/bluetooth/ble_uart_repl.py
@@ -7,6 +7,7 @@ import bluetooth
 import io
 import os
 import micropython
+from micropython import const
 import machine
 
 from ble_uart_peripheral import BLEUART

--- a/examples/hwapi/hwconfig_z_96b_carbon.py
+++ b/examples/hwapi/hwconfig_z_96b_carbon.py
@@ -1,4 +1,4 @@
-from machine import Signal
+from machine import Pin, Signal
 
 # 96Boards Carbon board
 # USR1 - User controlled led, connected to PD2

--- a/examples/natmod/btree/btree_py.py
+++ b/examples/natmod/btree/btree_py.py
@@ -1,3 +1,7 @@
 # Implemented in Python to support keyword arguments
+
+# ruff: noqa: F821 - this file is evaluated with C-defined names in scope
+
+
 def open(stream, *, flags=0, cachesize=0, pagesize=0, minkeypage=0):
     return _open(stream, flags, cachesize, pagesize, minkeypage)

--- a/examples/natmod/features2/test.py
+++ b/examples/natmod/features2/test.py
@@ -1,5 +1,7 @@
 # This Python code will be merged with the C code in main.c
 
+# ruff: noqa: F821 - this file is evaluated with C-defined names in scope
+
 import array
 
 

--- a/examples/rp2/pio_1hz.py
+++ b/examples/rp2/pio_1hz.py
@@ -1,6 +1,8 @@
 # Example using PIO to blink an LED and raise an IRQ at 1Hz.
 # Note: this does not work on Pico W because it uses Pin(25) for LED output.
 
+# ruff: noqa: F821 - @asm_pio decorator adds names to function scope
+
 import time
 from machine import Pin
 import rp2

--- a/examples/rp2/pio_exec.py
+++ b/examples/rp2/pio_exec.py
@@ -5,6 +5,8 @@
 #   - using set_init and set_base
 #   - using StateMachine.exec
 
+# ruff: noqa: F821 - @asm_pio decorator adds names to function scope
+
 import time
 from machine import Pin
 import rp2

--- a/examples/rp2/pio_pinchange.py
+++ b/examples/rp2/pio_pinchange.py
@@ -8,6 +8,8 @@
 #   - setting an irq handler for a StateMachine
 #   - instantiating 2x StateMachine's with the same program and different pins
 
+# ruff: noqa: F821 - @asm_pio decorator adds names to function scope
+
 import time
 from machine import Pin
 import rp2

--- a/examples/rp2/pio_pwm.py
+++ b/examples/rp2/pio_pwm.py
@@ -1,5 +1,7 @@
 # Example of using PIO for PWM, and fading the brightness of an LED
 
+# ruff: noqa: F821 - @asm_pio decorator adds names to function scope
+
 from machine import Pin
 from rp2 import PIO, StateMachine, asm_pio
 from time import sleep

--- a/examples/rp2/pio_uart_rx.py
+++ b/examples/rp2/pio_uart_rx.py
@@ -8,6 +8,8 @@
 #   - PIO irq handler
 #   - using the second core via _thread
 
+# ruff: noqa: F821 - @asm_pio decorator adds names to function scope
+
 import _thread
 from machine import Pin, UART
 from rp2 import PIO, StateMachine, asm_pio

--- a/examples/rp2/pio_uart_tx.py
+++ b/examples/rp2/pio_uart_tx.py
@@ -1,5 +1,7 @@
 # Example using PIO to create a UART TX interface
 
+# ruff: noqa: F821 - @asm_pio decorator adds names to function scope
+
 from machine import Pin
 from rp2 import PIO, StateMachine, asm_pio
 

--- a/examples/rp2/pio_ws2812.py
+++ b/examples/rp2/pio_ws2812.py
@@ -1,5 +1,7 @@
 # Example using PIO to drive a set of WS2812 LEDs.
 
+# ruff: noqa: F821 - @asm_pio decorator adds names to function scope
+
 import array, time
 from machine import Pin
 import rp2

--- a/examples/rp2/pwm_fade.py
+++ b/examples/rp2/pwm_fade.py
@@ -1,6 +1,8 @@
 # Example using PWM to fade an LED.
 # Note: this does not work on Pico W because it uses Pin(25) for LED output.
 
+# ruff: noqa: F821 - @asm_pio decorator adds names to function scope
+
 import time
 from machine import Pin, PWM
 

--- a/mpy-cross/mpy_cross/__init__.py
+++ b/mpy-cross/mpy_cross/__init__.py
@@ -100,7 +100,7 @@ def compile(src, dest=None, src_path=None, opt=None, march=None, mpy_cross=None,
     if not src:
         raise ValueError("src is required")
     if not os.path.exists(src):
-        raise CrossCompileError("Input .py file not found: {}.".format(src_py))
+        raise CrossCompileError("Input .py file not found: {}.".format(src))
 
     args = []
 

--- a/ports/cc3200/tools/uniflash.py
+++ b/ports/cc3200/tools/uniflash.py
@@ -41,7 +41,7 @@ def execute(command):
     if exitCode == 0:
         return cmd_log
     else:
-        raise ProcessException(command, exitCode, output)
+        raise subprocess.CalledProcessError(exitCode, command, output)
 
 
 def main():

--- a/ports/nrf/examples/ssd1306_mod.py
+++ b/ports/nrf/examples/ssd1306_mod.py
@@ -19,6 +19,7 @@
 # disp = SSD1306_I2C_Mod(128, 64, i2c)
 
 from ssd1306 import SSD1306_I2C
+from micropython import const
 
 SET_COL_ADDR = const(0x21)
 SET_PAGE_ADDR = const(0x22)

--- a/ports/nrf/examples/ubluepy_eddystone.py
+++ b/ports/nrf/examples/ubluepy_eddystone.py
@@ -1,3 +1,4 @@
+from micropython import const
 from ubluepy import Peripheral, constants
 
 BLE_GAP_ADV_FLAG_LE_GENERAL_DISC_MODE = const(0x02)

--- a/ports/qemu-arm/test-frzmpy/frozen_asm.py
+++ b/ports/qemu-arm/test-frzmpy/frozen_asm.py
@@ -1,5 +1,7 @@
 # Test freezing inline-asm code.
 
+# ruff: noqa: F821 - @asm_thumb decorator adds names to function scope
+
 import micropython
 
 

--- a/ports/renesas-ra/boards/make-pins.py
+++ b/ports/renesas-ra/boards/make-pins.py
@@ -220,13 +220,7 @@ class Pins(object):
             for named_pin in self.board_pins:
                 qstr_set |= set([named_pin.name()])
             for qstr in sorted(qstr_set):
-                cond_var = None
-                if qstr.startswith("AF"):
-                    af_words = qstr.split("_")
-                    cond_var = conditional_var(af_words[1])
-                    print_conditional_if(cond_var, file=qstr_file)
                 print("Q({})".format(qstr), file=qstr_file)
-                # print_conditional_endif(cond_var, file=qstr_file)
 
     def print_ad_hdr(self, ad_const_filename):
         with open(ad_const_filename, "wt") as ad_const_file:

--- a/ports/stm32/boards/NUCLEO_WB55/rfcore_debug.py
+++ b/ports/stm32/boards/NUCLEO_WB55/rfcore_debug.py
@@ -35,6 +35,7 @@
 # See rfcore_firmware.py for more information.
 
 from machine import mem8, mem16, mem32
+from micropython import const
 import stm
 
 SRAM2A_BASE = const(0x2003_0000)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,6 @@ ignore = [
   "F401",
   "F403",
   "F405",
-  "F821",
   "PLC1901",
 ]
 line-length = 337
@@ -46,3 +45,7 @@ max-complexity = 40
 
 [tool.ruff.per-file-ignores]
 "ports/cc3200/tools/uniflash.py" = ["E711"]
+
+# manifest.py files are evaluated with some global names pre-defined
+"**/manifest.py" = ["F821"]
+"ports/**/boards/manifest*.py" = ["F821"]

--- a/tools/mpy-tool.py
+++ b/tools/mpy-tool.py
@@ -35,7 +35,7 @@ if platform.python_version_tuple()[0] == "2":
     bytes_cons = lambda val, enc=None: bytearray(val)
     is_str_type = lambda o: isinstance(o, str)
     is_bytes_type = lambda o: type(o) is bytearray
-    is_int_type = lambda o: isinstance(o, int) or isinstance(o, long)
+    is_int_type = lambda o: isinstance(o, int) or isinstance(o, long)  # noqa: F821
 
     def hexlify_to_str(b):
         x = hexlify_py2(b)

--- a/tools/mpy_ld.py
+++ b/tools/mpy_ld.py
@@ -966,6 +966,9 @@ def build_mpy(env, entry_offset, fmpy, native_qstr_vals, native_qstr_objs):
 
     # MPY: relocation information
     prev_kind = None
+    prev_base = None
+    prev_offset = None
+    prev_n = None
     for base, addr, kind in env.mpy_relocs:
         if isinstance(kind, str) and kind.startswith(".text"):
             kind = 0


### PR DESCRIPTION
If you run a linter in your editor or other part of your workflow then [F821 undefined-name](https://beta.ruff.rs/docs/rules/undefined-name/) is excellent for quickly catching typos, missing imports, etc.

This is the sibling PR to https://github.com/micropython/micropython-lib/pull/714

The commits in this branch are code changes to enable that check. Changes include:

* Several minor bug fixes found by this check. I don't think anything serious, but bugs all the same!
* A couple of minor code changes (pre-setting variables) were needed for code which would have worked anyhow, but tripped the linter.
* Added inline `# ruff: noqa: F821` to files which have implicit imports (pio, asm, native module support code, etc.) Most of these are examples, so I think it's good practice to add the ignore in the file rather than globally as they may be copied and used elsewhere.
* Globally ignore F821 in manifest files, which also have implicit imports but are generally tiny.

~~This PR doesn't include the other Ruff fix from #12196, so it will keep failing until rebased on that PR.~~ (EDIT: Merged and rebased.)

---

This work was funded by GitHub Sponsors.