### PR TITLE
tools/codeformat: Skip ESP-IDF managed components.

### DIFF
--- a/tools/codeformat.py
+++ b/tools/codeformat.py
@@ -60,6 +60,8 @@ PATHS = [
 EXCLUSIONS = [
     # The cc3200 port is not fully formatted yet.
     "ports/cc3200/*/*.[ch]",
+    # ESP-IDF downloads 3rd party code.
+    "ports/esp32/managed_components/*",
     # The nrf port is not fully formatted yet.
     "ports/nrf/boards/*.[ch]",
     "ports/nrf/device/*.[ch]",


### PR DESCRIPTION
During a build the ESP-IDF downloads managed components in the `ports/esp32/managed_components` directory, which shouldn't be checked/formatted by us.