### PR TITLE
ports/stm32: Added STM32H5 Ethernet support.

### DIFF
--- a/ports/stm32/mpu.h
+++ b/ports/stm32/mpu.h
@@ -26,7 +26,7 @@
 #ifndef MICROPY_INCLUDED_STM32_MPU_H
 #define MICROPY_INCLUDED_STM32_MPU_H
 
-#if defined(STM32F7) || defined(STM32H7) || defined(MICROPY_HW_ETH_MDC)
+#if (defined(STM32F4) && defined(MICROPY_HW_ETH_MDC)) || defined(STM32F7) || defined(STM32H7)
 
 #define MPU_REGION_ETH      (MPU_REGION_NUMBER0)
 #define MPU_REGION_QSPI1    (MPU_REGION_NUMBER1)
@@ -97,8 +97,15 @@ static inline void mpu_config_end(uint32_t irq_state) {
 
 #elif defined(STM32H5)
 
+#define MPU_REGION_SIG      (MPU_REGION_NUMBER0)
+#define MPU_REGION_ETH      (MPU_REGION_NUMBER1)
+
 #define ST_DEVICE_SIGNATURE_BASE (0x08fff800)
 #define ST_DEVICE_SIGNATURE_LIMIT (0x08ffffff)
+
+// STM32H5 Cortex-M33 MPU works differently from older cores.
+// Macro only takes region size in bytes, Attributes are coded in mpu_config_region().
+#define MPU_CONFIG_ETH(size) (size)
 
 static inline void mpu_init(void) {
     // Configure attribute 0, inner-outer non-cacheable (=0x44).
@@ -123,6 +130,49 @@ static inline void mpu_init(void) {
     SCB->SHCSR |= SCB_SHCSR_MEMFAULTENA_Msk;
     __DMB();
     __ISB();
+}
+
+static inline uint32_t mpu_config_start(void) {
+    return disable_irq();
+}
+
+static inline void mpu_config_region(uint32_t region, uint32_t base_addr, uint32_t size) {
+    if (region == MPU_REGION_ETH) {
+        // Configure region 1 to make DMA memory non-cacheable.
+
+        __DMB();
+        // Configure attribute 1, inner-outer non-cacheable (=0x44).
+        MPU->MAIR0 = (MPU->MAIR0 & ~MPU_MAIR0_Attr1_Msk)
+            | 0x44 << MPU_MAIR0_Attr1_Pos;
+        __DMB();
+
+        // RBAR
+        //  BASE          Bits [31:5] of base address
+        //  SH[4:3]  00 = Non-shareable
+        //  AP[2:1]  01 = Read/write by any privilege level
+        //  XN[0]:    1 = No execution
+
+        // RLAR
+        //  LIMIT         Limit address. Contains bits[31:5] of the upper inclusive limit of the selected MPU memory region
+        //  AT[3:1] 001 = Attribute 1
+        //  EN[0]     1 = Enabled
+        MPU->RNR = region;
+        MPU->RBAR = (base_addr & MPU_RBAR_BASE_Msk)
+            | MPU_ACCESS_NOT_SHAREABLE << MPU_RBAR_SH_Pos
+            | MPU_REGION_ALL_RW << MPU_RBAR_AP_Pos
+            | MPU_INSTRUCTION_ACCESS_DISABLE << MPU_RBAR_XN_Pos;
+        MPU->RLAR = ((base_addr + size - 1) & MPU_RLAR_LIMIT_Msk)
+            | MPU_ATTRIBUTES_NUMBER1 << MPU_RLAR_AttrIndx_Pos
+            | MPU_REGION_ENABLE << MPU_RLAR_EN_Pos;
+    }
+    __DMB();
+}
+
+static inline void mpu_config_end(uint32_t irq_state) {
+    __ISB();
+    __DSB();
+    __DMB();
+    enable_irq(irq_state);
 }
 
 #else


### PR DESCRIPTION
This PR implements Ethernet support for STM32H5 when used with PR #12176 for NUCLEO-H563ZI board.

# Description

Add STM32H5 Ethernet support.

Changes are:
* Add Cortex-M33 MPU code. Ethernet driver requires MPU to define cache strategy for DMA buffers (descriptors and frames).
* Add support for STM32H5 Ethernet controller. The controller is mostly compatible with the STM32H7. However the descriptor layout is different.
* Adapt clocking and reset for STM32H5.


Source code can be condensed where STM32H7 and STM32H5 code is identical. Currently code is separated by compiler defines for easier testing. Feedback on this topic is very welcome.


# Environment

* NUCLEO-H563ZI
* Using STM32H573I-DK board with minor modifications (input clock, on-chip flash)
* 100 BaseT Ethernet connected at CN14

```
MicroPython v1.20.0-287-ga006721d7-dirty on 2023-08-26; NUCLEO_H563ZI with STM32H563ZI
```

# Tests

## Link/Network Setup

``` Python
# Precondition: Ethernet connection established, cable connected

import network

nic=network.LAN()
nic.status()  # link state
>>> 3

mac = nic.config("mac")  # MCUs MAC address
formatted_mac = ':'.join('{:02x}'.format(byte) for byte in mac)
print(formatted_mac)
>>> 02:30:93:xx:xx:xx

# nic.config(trace=8)

nic.active(1)   # Activate IP layer, gets DHCP address if possible

nic.status()
>>> 3
nic.isconnected()
>>> True
nic.ifconfig()  # IP config, should display DHCP provided address
('10.0.0.xxx', '255.255.255.0', '10.0.0.yyy', '10.0.0.zzz')
```


## Performance

Running iperf3 versus server in LAN.

``` Python
import iperf3   # install with mpremote
iperf3.client('10.0.0.xxx')

CLIENT MODE: TCP sending
Connecting to ('10.0.0.103', 5201)
Interval           Transfer     Bitrate
  0.00-1.00   sec  9.81 MBytes  82.3 Mbits/sec
  1.00-2.00   sec  9.85 MBytes  82.6 Mbits/sec
  2.00-3.00   sec  9.80 MBytes  82.2 Mbits/sec
  3.00-4.00   sec  9.85 MBytes  82.6 Mbits/sec
  4.00-5.00   sec  9.80 MBytes  82.2 Mbits/sec
  5.00-6.00   sec  9.84 MBytes  82.2 Mbits/sec
  6.00-7.00   sec  9.85 MBytes  82.6 Mbits/sec
  7.00-8.00   sec  9.80 MBytes  82.2 Mbits/sec
  8.00-9.00   sec  9.85 MBytes  82.6 Mbits/sec
  9.00-10.00  sec  9.76 MBytes  82.2 Mbits/sec
- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 
  0.00-10.00  sec  98.2 MBytes  82.4 Mbits/sec  sender
  0.00-10.24  sec  98.2 MBytes  80.5 Mbits/sec  receiver
```


## Stability

Ping from host with maximum frame size at ca. 100 frames per second to device for > 3 days.

```
10.0.0.125 : xmt/rcv/%loss = 12414865/12413858/0%, min/avg/max = 0.220/0.452/1.00
```
