### PR TITLE
py/stream.c: Fixed stream write unicode count.

### DIFF
--- a/tests/unicode/unicode_write_count.py
+++ b/tests/unicode/unicode_write_count.py
@@ -1,0 +1,7 @@
+import sys
+
+n_text = sys.stdout.write("🚀\n")
+sys.stdout.write("{}\n".format(n_text))
+
+n_text = sys.stdout.write("1🚀2a3α4b5β6c7γ8d9δ0ぁ1🙐\n")
+sys.stdout.write("{}\n".format(n_text))


### PR DESCRIPTION
Per request, this PR was split from a fix originally in this PR (addition of buffer attribute for unix stdio streams):
https://github.com/micropython/micropython/pull/12091/commits/efbe8c959578139a328f1f1b787dbfc14dafe10c

Brief, when using the write method of a stream of unicode characters, cpython returns the character count while micropython is returning the bytes count.

`test/unicode/unicode_write_count.py` adds the following test:

```
import sys

n_text = sys.stdout.write("🚀\n")
sys.stdout.write("{}\n".format(n_text))

n_text = sys.stdout.write("1🚀2a3α4b5β6c7γ8d9δ0ぁ1🙐\n")
sys.stdout.write("{}\n".format(n_text))
```

Today the output is:
```
🚀
5
1🚀2a3α4b5β6c7γ8d9δ0ぁ1🙐
35
```

The cpython matching output should be:
```
🚀
2
1🚀2a3α4b5β6c7γ8d9δ0ぁ1🙐
23
```

If we are able to merge the other PR first (buffer attr), I would like to also enable unicode writes as part of the unix port stdio tests.  Both that PR one and this one are required for bytes/unicode coverage for unix stdio.


