### PR TITLE
stm32/timer: Fix PWM on Advanced Timer peripherals.

### DIFF
--- a/ports/stm32/timer.c
+++ b/ports/stm32/timer.c
@@ -507,7 +507,7 @@ STATIC mp_int_t compute_ticks_from_dtg(uint32_t dtg) {
 }
 
 STATIC void config_deadtime(pyb_timer_obj_t *self, mp_int_t ticks, mp_int_t brk) {
-    TIM_BreakDeadTimeConfigTypeDef deadTimeConfig;
+    TIM_BreakDeadTimeConfigTypeDef deadTimeConfig = {0};
     deadTimeConfig.OffStateRunMode = TIM_OSSR_DISABLE;
     deadTimeConfig.OffStateIDLEMode = TIM_OSSI_DISABLE;
     deadTimeConfig.LockLevel = TIM_LOCKLEVEL_OFF;


### PR DESCRIPTION
While trying to use Timer1 for PWM output on stm32wb55 I found an issue with C struct initialisation.

I was trying to get PWM output working on PA8 which is matched to Timer1_Channel1, but no matter what I did it would not output on the Pin.

Running the same code for PA3 (Timer2_Channel4) worked fine though, pwm output no worries.

I could see the Timer1.counter() rolling around, and the channel values all looked correct, as did the Pin mode.

``` python
from machine import Pin
from pyb import Timer

Timer1 = Timer(1, freq=1000000)
Timer1Ch1 = Timer1.channel(1, Timer.PWM, pin=Pin.cpu.A8, pulse_width_percent=50)

Timer2 = Timer(2, freq=1000000)
Timer2Ch4 = Timer2.channel(4, Timer.PWM, pin=Pin.cpu.A3, pulse_width_percent=50)
```

Eventually, I dove down into the C debugger and stepped through initialisation. Stumbled upon strangeness in the deadtime/break configuration. For reference... the break stuff is designed to allow using something like a separate pin to cut the PWM output...

![image](https://github.com/micropython/micropython/assets/3318786/17e9c555-622b-4400-8abc-56ca12fe2980)

Ah... gotta love C struct initialisation, if someone adds a new field, or you don't explicitely init to zero, who knows what you might get! (take a look at BreakAF2Mode on the left side).

Note: This code only applies to some (most) chips in the STM range, and only on timers classified as Advanced - WB55 only has one of these out of its 5 timers.

Depending on GCC version and optimisation settings I'm guessing this particular issue won't always affect everyone using these  parts, but the code should be cleaned up regardless to remove the source of the issue. I've tackled it on both fronts here; explicitely adding the missing fields (hoping they exist on all parts?) and also adding an "init the struct to zero" which is a safe catch all.

Nice side effect; adding the `TIM_BreakDeadTimeConfigTypeDef deadTimeConfig = {0};` actually causes this PR to be a net saving of 4 bytes with my compilation settings, as now GCC can optimise out any other fields being set explicitely to zero in the function.

---
This work was funded by Planet Innovation.