### PR TITLE
esp32/network_ppp: Block after deleting task.

### DIFF
--- a/ports/esp32/network_ppp.c
+++ b/ports/esp32/network_ppp.c
@@ -114,6 +114,8 @@ static void pppos_client_task(void *self_in) {
 
     self->client_task_handle = NULL;
     vTaskDelete(NULL);
+    for (;;) {
+    }
 }
 
 STATIC mp_obj_t ppp_active(size_t n_args, const mp_obj_t *args) {


### PR DESCRIPTION
When calling `ppp.active(False)` we could get a crash due to immediately returning after asking FreeRTOS to delete the current task.

This commit adds a simple blocking loop, the same as used in all other places where we call `vTaskDelete(NULL)`.
