### PR TITLE
mimxrt: A few small changes for the MIMXRT port.

### DIFF
--- a/ports/mimxrt/boards/MIMXRT1176.ld
+++ b/ports/mimxrt/boards/MIMXRT1176.ld
@@ -39,7 +39,7 @@ dtcm_size           = 0x00020000;
 ocrm_start          = 0x20240000;
 ocrm_size           = 0x00100000;
 
-#ifdef MICROPY_HW_SDRAM_AVAIL
+#if MICROPY_HW_SDRAM_AVAIL
 sdram_start         = 0x80000000;
 sdram_size          = MICROPY_HW_SDRAM_SIZE;
 #endif
@@ -49,7 +49,7 @@ __stack_size__ = 0x8000;
 _estack = __StackTop;
 _sstack = __StackLimit;
 
-#ifdef MICROPY_HW_SDRAM_AVAIL
+#if MICROPY_HW_SDRAM_AVAIL
 _gc_heap_start = ORIGIN(m_sdram);
 _gc_heap_end = ORIGIN(m_sdram) + LENGTH(m_sdram);
 #else


### PR DESCRIPTION
- Fix and complete UART.deinit() and uart_deinit_all().
  The code did not check at deinit whether a UART was initialized. That did not matter for all MCU's except  MIMXRT1176, which crashes at the second soft reset in a row. But since it is a general problem to use UART methods of a UART which has been deinitialized, checks were added to all applicable methods for a clear response instead of e.g. a crash.
- Change a conditional in the MIMXRT1176 loader script, which always assumed that external RAM is present.
- Support a baud rate of 300. That one is still used, and before the lowest baud rate that could be set was 324. The change causes a slight drop in the baud rate resolution above 1 MBaud.