### PR TITLE
py/objfun: Add function.__code__ attribute

### DIFF
--- a/py/emitbc.c
+++ b/py/emitbc.c
@@ -217,7 +217,7 @@ STATIC void emit_write_bytecode_byte_obj(emit_t *emit, int stack_adj, byte b, mp
 STATIC void emit_write_bytecode_byte_child(emit_t *emit, int stack_adj, byte b, mp_raw_code_t *rc) {
     emit_write_bytecode_byte_const(emit, stack_adj, b,
         mp_emit_common_alloc_const_child(emit->emit_common, rc));
-    #if MICROPY_PY_SYS_SETTRACE
+    #if MICROPY_PY_SYS_SETTRACE || MICROPY_PY_FUNCTION_ATTRS
     rc->line_of_definition = emit->last_source_line;
     #endif
 }

--- a/py/emitglue.c
+++ b/py/emitglue.c
@@ -54,7 +54,7 @@ mp_uint_t mp_verbose_flag = 0;
 mp_raw_code_t *mp_emit_glue_new_raw_code(void) {
     mp_raw_code_t *rc = m_new0(mp_raw_code_t, 1);
     rc->kind = MP_CODE_RESERVED;
-    #if MICROPY_PY_SYS_SETTRACE
+    #if MICROPY_PY_SYS_SETTRACE || MICROPY_PY_FUNCTION_ATTRS
     rc->line_of_definition = 0;
     #endif
     return rc;
@@ -82,7 +82,7 @@ void mp_emit_glue_assign_bytecode(mp_raw_code_t *rc, const byte *code,
     rc->n_children = n_children;
     #endif
 
-    #if MICROPY_PY_SYS_SETTRACE
+    #if MICROPY_PY_SYS_SETTRACE || MICROPY_PY_FUNCTION_ATTRS
     mp_bytecode_prelude_t *prelude = &rc->prelude;
     mp_prof_extract_prelude(code, prelude);
     #endif
@@ -207,7 +207,7 @@ mp_obj_t mp_make_function_from_raw_code(const mp_raw_code_t *rc, const mp_module
                 ((mp_obj_base_t *)MP_OBJ_TO_PTR(fun))->type = &mp_type_gen_wrap;
             }
 
-            #if MICROPY_PY_SYS_SETTRACE
+            #if MICROPY_PY_SYS_SETTRACE || MICROPY_PY_FUNCTION_ATTRS
             mp_obj_fun_bc_t *self_fun = (mp_obj_fun_bc_t *)MP_OBJ_TO_PTR(fun);
             self_fun->rc = rc;
             #endif

--- a/py/emitglue.h
+++ b/py/emitglue.h
@@ -61,16 +61,14 @@ typedef struct _mp_raw_code_t {
     size_t fun_data_len; // so mp_raw_code_save and mp_bytecode_print work
     #endif
     struct _mp_raw_code_t **children;
-    #if MICROPY_PERSISTENT_CODE_SAVE
+    #if MICROPY_PERSISTENT_CODE_SAVE || MICROPY_PY_FUNCTION_ATTRS
     size_t n_children;
-    #if MICROPY_PY_SYS_SETTRACE
     mp_bytecode_prelude_t prelude;
     // line_of_definition is a Python source line where the raw_code was
     // created e.g. MP_BC_MAKE_FUNCTION. This is different from lineno info
     // stored in prelude, which provides line number for first statement of
     // a function. Required to properly implement "call" trace event.
     mp_uint_t line_of_definition;
-    #endif
     #if MICROPY_EMIT_MACHINE_CODE
     uint16_t prelude_offset;
     #endif

--- a/py/objfun.c
+++ b/py/objfun.c
@@ -33,6 +33,7 @@
 #include "py/runtime.h"
 #include "py/bc.h"
 #include "py/stackctrl.h"
+#include "py/profile.h"
 
 #if MICROPY_DEBUG_VERBOSE // print debugging info
 #define DEBUG_PRINT (1)
@@ -343,6 +344,13 @@ void mp_obj_fun_bc_attr(mp_obj_t self_in, qstr attr, mp_obj_t *dest) {
     if (attr == MP_QSTR___globals__) {
         mp_obj_fun_bc_t *self = MP_OBJ_TO_PTR(self_in);
         dest[0] = MP_OBJ_FROM_PTR(self->context->module.globals);
+    }
+    if (attr == MP_QSTR___code__) {
+        mp_obj_fun_bc_t *self = MP_OBJ_TO_PTR(self_in);
+        mp_obj_code_t *code = MP_OBJ_TO_PTR(mp_obj_new_code(self->context, self->rc));
+        if (code != NULL) {
+            dest[0] = MP_OBJ_FROM_PTR(code);
+        }
     }
 }
 #endif

--- a/py/objfun.h
+++ b/py/objfun.h
@@ -34,7 +34,7 @@ typedef struct _mp_obj_fun_bc_t {
     const mp_module_context_t *context;         // context within which this function was defined
     struct _mp_raw_code_t *const *child_table;  // table of children
     const byte *bytecode;                       // bytecode for the function
-    #if MICROPY_PY_SYS_SETTRACE
+    #if MICROPY_PY_SYS_SETTRACE || MICROPY_PY_FUNCTION_ATTRS
     const struct _mp_raw_code_t *rc;
     #endif
     // the following extra_args array is allocated space to take (in order):

--- a/py/profile.h
+++ b/py/profile.h
@@ -29,10 +29,6 @@
 
 #include "py/emitglue.h"
 
-#if MICROPY_PY_SYS_SETTRACE
-
-#define mp_prof_is_executing MP_STATE_THREAD(prof_callback_is_executing)
-
 typedef struct _mp_obj_code_t {
     // TODO this was 4 words
     mp_obj_base_t base;
@@ -41,6 +37,14 @@ typedef struct _mp_obj_code_t {
     mp_obj_dict_t *dict_locals;
     mp_obj_t lnotab;
 } mp_obj_code_t;
+
+void mp_prof_extract_prelude(const byte *bytecode, mp_bytecode_prelude_t *prelude);
+
+mp_obj_t mp_obj_new_code(const mp_module_context_t *mc, const mp_raw_code_t *rc);
+
+#if MICROPY_PY_SYS_SETTRACE
+
+#define mp_prof_is_executing MP_STATE_THREAD(prof_callback_is_executing)
 
 typedef struct _mp_obj_frame_t {
     mp_obj_base_t base;
@@ -53,9 +57,6 @@ typedef struct _mp_obj_frame_t {
     bool trace_opcodes;
 } mp_obj_frame_t;
 
-void mp_prof_extract_prelude(const byte *bytecode, mp_bytecode_prelude_t *prelude);
-
-mp_obj_t mp_obj_new_code(const mp_module_context_t *mc, const mp_raw_code_t *rc);
 mp_obj_t mp_obj_new_frame(const mp_code_state_t *code_state);
 
 // This is the implementation for the sys.settrace


### PR DESCRIPTION
This PR adds support for `__code__` on functions, providing a range of details such as:
* function name (`co_name`)
* file name and line number (`co_filename`, `co_firstlineno`)
* arg count (`co_argcount`)
* arg names (`co_varnames` without locals)

Ths functionality of these generally follow the matching cpython code `co_*` aatributes as described: https://github.com/andrewleech/micropython/pull/new/function.__code__

This is only enabled if MICROPY_PY_SYS_SETTRACE is enabled, which I've included in unix/standard variant as a primary use case of the feature is in unit testing.

Also in support:
* py/profile: Add __code__.co_varnames to query function arguments.
* unix/standard: Enable sys.settrace() by default.

