### PR TITLE
ports/rp2/boards: Added support for YD-RP2040 by VCC-GND studio 4 8 16 MB flash which is a pin compatible PICO clone.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,8 @@
+| :exclamation:  This is not maintained, go upstream |
+|----------------------------------------------------|
+
+
+
 [![CI badge](https://github.com/micropython/micropython/workflows/unix%20port/badge.svg)](https://github.com/micropython/micropython/actions?query=branch%3Amaster+event%3Apush) [![codecov](https://codecov.io/gh/micropython/micropython/branch/master/graph/badge.svg?token=I92PfD05sD)](https://codecov.io/gh/micropython/micropython)
 
 The MicroPython project

--- a/ports/rp2/boards/VCC_GND_YD_RP2040/README.md
+++ b/ports/rp2/boards/VCC_GND_YD_RP2040/README.md
@@ -1,0 +1,45 @@
+# VCC-GND Studio YD-RP2040 
+
+The VCC-GND Studio YD-RP2040 Board is based on the Raspberry Pi RP2040 and can be
+purchased with 4/8/16 MiB of flash.
+
+These boards are available from VCC-GND Studio's [aliexpress page](https://www.aliexpress.com/item/1005004004120604.html). 
+
+## Build notes
+
+Builds can be configured with the `BOARD_VARIANT` parameter. Valid variants
+can be displayed with the `query-variant` target. An example:
+
+```bash
+> cd ports/rp2
+> make BOARD=VCC_GND_YD_RP2040 query-variants
+VARIANTS: flash_4mb flash_8mb flash_16mb
+> make BOARD=VCC_GND_YD_RP2040 BOARD_VARIANT=flash_8mb submodules all  # Build the 8 MiB variant
+```
+
+`flash_8mb` is the default if `BOARD_VARIANT` is not supplied.
+
+## Board-specific modules
+
+The `board` module contains definitions for the onboard LED(GPIO25), WS2812 addressable RGB led (GPIO23) and user button(GPIO24).
+
+Example:
+
+```python
+> import board
+> board.led.toggle()  # Toggles the state of the on-board LED
+> board.key.value()  # Returns 0 or 1 corresponding to the state of the user key
+> 
+> import neopixel
+> from time import sleep
+> n = neopixel.NeoPixel(board.neopixel, 1)
+> n[0] = (255,0,0)
+> n.write()
+> sleep(1)
+> n[0] = (0,255,0)
+> n.write()
+> sleep(1)
+> n[0] = (0,0,255)
+> n.write()
+> sleep(1)
+```

--- a/ports/rp2/boards/VCC_GND_YD_RP2040/board.json
+++ b/ports/rp2/boards/VCC_GND_YD_RP2040/board.json
@@ -1,0 +1,24 @@
+{
+    "deploy": [
+        "deploy.md"
+    ],
+    "docs": "",
+    "features": [
+        "Dual-core",
+        "External Flash",
+        "USB-C",
+        "RGB LED"
+    ],
+    "images": [
+        "VCC_GND_YD_RP2040.png"
+    ],
+    "mcu": "rp2040",
+    "product": "VCC-GND Studio YD-RP2040",
+    "url": "http://vcc-gnd.com/",
+    "variants": {
+        "ydrp2040_flash_4mb": "4 MiB Flash",
+        "ydrp2040_flash_8mb": "8 MiB Flash",
+        "ydrp2040_flash_16mb": "16 MiB Flash"
+    },
+    "vendor": "VCC-GND Studio"
+}

--- a/ports/rp2/boards/VCC_GND_YD_RP2040/deploy.md
+++ b/ports/rp2/boards/VCC_GND_YD_RP2040/deploy.md
@@ -1,0 +1,8 @@
+### Flashing via UF2 bootloader
+
+To get the board in bootloader mode ready for the firmware update, execute
+`machine.bootloader()` at the MicroPython REPL.  Alternatively, hold
+down the BOOT button while pressing reset (RST).  The uf2 file below
+should then be copied to the USB mass storage device that appears.  Once
+programming of the new firmware is complete the device will automatically reset
+and be ready for use.

--- a/ports/rp2/boards/VCC_GND_YD_RP2040/manifest.py
+++ b/ports/rp2/boards/VCC_GND_YD_RP2040/manifest.py
@@ -1,0 +1,2 @@
+include("$(PORT_DIR)/boards/manifest.py")
+freeze("./modules")

--- a/ports/rp2/boards/VCC_GND_YD_RP2040/modules/board.py
+++ b/ports/rp2/boards/VCC_GND_YD_RP2040/modules/board.py
@@ -1,0 +1,5 @@
+from machine import Pin
+
+led = Pin(25, Pin.OUT, value=0)
+key = Pin(24, Pin.IN, Pin.PULL_UP)
+neopixel = Pin(23, Pin.OUT, value=0)

--- a/ports/rp2/boards/VCC_GND_YD_RP2040/mpconfigboard.cmake
+++ b/ports/rp2/boards/VCC_GND_YD_RP2040/mpconfigboard.cmake
@@ -1,0 +1,24 @@
+# CMake file for VCC-GND Studio  RP2040 boards
+
+# VCC-GND Studio boards don't have official pico-sdk support so we define it
+# See also: https://github.com/raspberrypi/pico-sdk/tree/master/src/boards/include/boards
+list(APPEND PICO_BOARD_HEADER_DIRS ${MICROPY_BOARD_DIR})
+
+# Freeze board.py
+set(MICROPY_FROZEN_MANIFEST ${MICROPY_BOARD_DIR}/manifest.py)
+
+# Select the 8MB variant as the default
+set(PICO_BOARD "ydrp2040_flash_8mb")
+
+# Provide different variants for the downloads page
+if(MICROPY_BOARD_VARIANT STREQUAL "flash_4mb")
+    set(PICO_BOARD "ydrp2040_flash_4mb")
+endif()
+
+if(MICROPY_BOARD_VARIANT STREQUAL "flash_8mb")
+    set(PICO_BOARD "ydrp2040_flash_8mb")
+endif()
+
+if(MICROPY_BOARD_VARIANT STREQUAL "flash_16mb")
+    set(PICO_BOARD "ydrp2040_flash_16mb")
+endif()

--- a/ports/rp2/boards/VCC_GND_YD_RP2040/mpconfigboard.h
+++ b/ports/rp2/boards/VCC_GND_YD_RP2040/mpconfigboard.h
@@ -1,0 +1,4 @@
+#define MICROPY_HW_BOARD_NAME "VCC-GND Studio YD-RP2040"
+
+// Allow 1MB for the firmware image itself, allocate the remainder to the filesystem
+#define MICROPY_HW_FLASH_STORAGE_BYTES (PICO_FLASH_SIZE_BYTES - (1 * 1024 * 1024))

--- a/ports/rp2/boards/VCC_GND_YD_RP2040/pins.csv
+++ b/ports/rp2/boards/VCC_GND_YD_RP2040/pins.csv
@@ -1,0 +1,3 @@
+led,GPIO25
+key,GPIO24
+neopixel,GPIO23

--- a/ports/rp2/boards/VCC_GND_YD_RP2040/ydrp2040_common.h
+++ b/ports/rp2/boards/VCC_GND_YD_RP2040/ydrp2040_common.h
@@ -1,0 +1,62 @@
+// Common configuration to all VCC-GND Studio YD-RP2040  boards (only flash size differs)
+
+#ifndef _BOARDS_VCC_GND_YD_RP2040_COMMON_H
+#define _BOARDS_VCC_GND_YD_RP2040_COMMON_H
+
+// --- UART ---
+#ifndef PICO_DEFAULT_UART
+#define PICO_DEFAULT_UART 0
+#endif
+#ifndef PICO_DEFAULT_UART_TX_PIN
+#define PICO_DEFAULT_UART_TX_PIN 0
+#endif
+#ifndef PICO_DEFAULT_UART_RX_PIN
+#define PICO_DEFAULT_UART_RX_PIN 1
+#endif
+
+// --- LED ---
+#ifndef PICO_DEFAULT_LED_PIN
+#define PICO_DEFAULT_LED_PIN 25
+#endif
+
+// --- I2C ---
+#ifndef PICO_DEFAULT_I2C
+#define PICO_DEFAULT_I2C 0
+#endif
+#ifndef PICO_DEFAULT_I2C_SDA_PIN
+#define PICO_DEFAULT_I2C_SDA_PIN 4
+#endif
+#ifndef PICO_DEFAULT_I2C_SCL_PIN
+#define PICO_DEFAULT_I2C_SCL_PIN 5
+#endif
+
+// --- SPI ---
+#ifndef PICO_DEFAULT_SPI
+#define PICO_DEFAULT_SPI 0
+#endif
+#ifndef PICO_DEFAULT_SPI_SCK_PIN
+#define PICO_DEFAULT_SPI_SCK_PIN 18
+#endif
+#ifndef PICO_DEFAULT_SPI_TX_PIN
+#define PICO_DEFAULT_SPI_TX_PIN 19
+#endif
+#ifndef PICO_DEFAULT_SPI_RX_PIN
+#define PICO_DEFAULT_SPI_RX_PIN 16
+#endif
+#ifndef PICO_DEFAULT_SPI_CSN_PIN
+#define PICO_DEFAULT_SPI_CSN_PIN 17
+#endif
+
+// --- FLASH ---
+#define PICO_BOOT_STAGE2_CHOOSE_W25Q080 1
+
+#ifndef PICO_FLASH_SPI_CLKDIV
+#define PICO_FLASH_SPI_CLKDIV 2
+#endif
+
+// All boards have B1 RP2040
+#ifndef PICO_RP2040_B0_SUPPORTED
+#define PICO_RP2040_B0_SUPPORTED 0
+#endif
+
+#endif

--- a/ports/rp2/boards/VCC_GND_YD_RP2040/ydrp2040_flash_16mb.h
+++ b/ports/rp2/boards/VCC_GND_YD_RP2040/ydrp2040_flash_16mb.h
@@ -1,0 +1,18 @@
+// A pico-sdk board definition is required since the boards are
+// not officially supported.
+//
+// Officially supported boards:
+//     https://github.com/raspberrypi/pico-sdk/tree/master/src/boards/include/boards
+
+#ifndef _BOARDS_YDRP2040_FLASH_16MB_H
+#define _BOARDS_YDRP2040_FLASH_16MB_H
+
+#include "ydrp2040_common.h"
+
+#define VCC_GND_YD_RP2040_16MB
+
+#ifndef PICO_FLASH_SIZE_BYTES
+#define PICO_FLASH_SIZE_BYTES (16 * 1024 * 1024)
+#endif
+
+#endif

--- a/ports/rp2/boards/VCC_GND_YD_RP2040/ydrp2040_flash_4mb.h
+++ b/ports/rp2/boards/VCC_GND_YD_RP2040/ydrp2040_flash_4mb.h
@@ -1,0 +1,18 @@
+// A pico-sdk board definition is required since the boards are
+// not officially supported.
+//
+// Officially supported boards:
+//     https://github.com/raspberrypi/pico-sdk/tree/master/src/boards/include/boards
+
+#ifndef _BOARDS_YDRP2040_FLASH_4MB_H
+#define _BOARDS_YDRP2040_FLASH_4MB_H
+
+#include "ydrp2040_common.h"
+
+#define VCC_GND_YD_RP2040_4MB
+
+#ifndef PICO_FLASH_SIZE_BYTES
+#define PICO_FLASH_SIZE_BYTES (4 * 1024 * 1024)
+#endif
+
+#endif

--- a/ports/rp2/boards/VCC_GND_YD_RP2040/ydrp2040_flash_8mb.h
+++ b/ports/rp2/boards/VCC_GND_YD_RP2040/ydrp2040_flash_8mb.h
@@ -1,0 +1,18 @@
+// A pico-sdk board definition is required since the boards are
+// not officially supported.
+//
+// Officially supported boards:
+//     https://github.com/raspberrypi/pico-sdk/tree/master/src/boards/include/boards
+
+#ifndef _BOARDS_YDRP2040_FLASH_8MB_H
+#define _BOARDS_YDRP2040_FLASH_8MB_H
+
+#include "ydrp2040_common.h"
+
+#define VCC_GND_YD_RP2040_8MB
+
+#ifndef PICO_FLASH_SIZE_BYTES
+#define PICO_FLASH_SIZE_BYTES (8 * 1024 * 1024)
+#endif
+
+#endif


### PR DESCRIPTION
ports/rp2/boards: Added support for YD-RP2040 by VCC-GND studio 4 8 16 MB flash which is a pin compatible PICO clone.

VCC-GND studios have pin compatible clones of the Pico with various flash sizes. I needed a uf2 with 8mb flash. These boards also have an addressable RGB led [WS2812 ](http://152.32.187.208:8080/yd-data/YD-RP2040/YD-2040-PIN.png) on GPIO23. 

I mostly copy pasted from the we-act board and replaced strings, the resulting build uf2 seems to work perfectly for me now.  