### PR TITLE
ports/rp2: Added init and reset C hooks for RP2040, and increased external pin count

### DIFF
--- a/ports/rp2/CMakeLists.txt
+++ b/ports/rp2/CMakeLists.txt
@@ -425,6 +425,7 @@ endif()
 list(APPEND MICROPY_SOURCE_QSTR
     ${MICROPY_SOURCE_EXTMOD}
     ${MICROPY_SOURCE_USERMOD}
+    ${MICROPY_SOURCE_BOARD}
 )
 
 # Define mpy-cross flags
@@ -443,6 +444,7 @@ target_sources(${MICROPY_TARGET} PRIVATE
     ${MICROPY_SOURCE_LIB}
     ${MICROPY_SOURCE_DRIVERS}
     ${MICROPY_SOURCE_PORT}
+    ${MICROPY_SOURCE_BOARD}
 )
 
 target_link_libraries(${MICROPY_TARGET} micropy_lib_mbedtls)

--- a/ports/rp2/boards/make-pins.py
+++ b/ports/rp2/boards/make-pins.py
@@ -10,8 +10,8 @@ import boardgen
 
 # This is NUM_BANK0_GPIOS. Pin indices are 0 to 29 (inclusive).
 NUM_GPIOS = 30
-# Up to 10 additional extended pins (e.g. via the wifi chip).
-NUM_EXT_GPIOS = 10
+# Up to 32 additional extended pins (e.g. via the wifi chip or io expanders).
+NUM_EXT_GPIOS = 32
 
 
 class Rp2Pin(boardgen.Pin):

--- a/ports/rp2/main.c
+++ b/ports/rp2/main.c
@@ -83,6 +83,9 @@ int main(int argc, char **argv) {
     // Set the MCU frequency and as a side effect the peripheral clock to 48 MHz.
     set_sys_clock_khz(125000, false);
 
+    // Hook for setting up anything that needs to be super early in the bootup process
+    MICROPY_BOARD_STARTUP();
+
     #if MICROPY_HW_ENABLE_UART_REPL
     bi_decl(bi_program_feature("UART REPL"))
     setup_default_uart();
@@ -152,6 +155,9 @@ int main(int argc, char **argv) {
     }
     #endif
 
+    // Hook for setting up anything that can wait until after other hardware features are initialised
+    MICROPY_BOARD_EARLY_INIT();
+
     for (;;) {
 
         // Initialise MicroPython runtime.
@@ -213,6 +219,10 @@ int main(int argc, char **argv) {
 
     soft_reset_exit:
         mp_printf(MP_PYTHON_PRINTER, "MPY: soft reboot\n");
+
+        // Hook for resetting anything immediately following a soft reset command
+        MICROPY_BOARD_START_SOFT_RESET();
+
         #if MICROPY_PY_NETWORK
         mod_network_deinit();
         #endif
@@ -232,6 +242,9 @@ int main(int argc, char **argv) {
         #if MICROPY_HW_ENABLE_USB_RUNTIME_DEVICE
         mp_usbd_deinit();
         #endif
+
+        // Hook for resetting anything right at the end of a soft reset command
+        MICROPY_BOARD_END_SOFT_RESET();
 
         gc_sweep_all();
         mp_deinit();

--- a/ports/rp2/mpconfigport.h
+++ b/ports/rp2/mpconfigport.h
@@ -283,3 +283,19 @@ extern void lwip_lock_release(void);
 #define MICROPY_PY_BLUETOOTH_ENTER uint32_t atomic_state = 0;
 #define MICROPY_PY_BLUETOOTH_EXIT (void)atomic_state;
 #endif
+
+#ifndef MICROPY_BOARD_STARTUP
+#define MICROPY_BOARD_STARTUP()
+#endif
+
+#ifndef MICROPY_BOARD_EARLY_INIT
+#define MICROPY_BOARD_EARLY_INIT()
+#endif
+
+#ifndef MICROPY_BOARD_START_SOFT_RESET
+#define MICROPY_BOARD_START_SOFT_RESET()
+#endif
+
+#ifndef MICROPY_BOARD_END_SOFT_RESET
+#define MICROPY_BOARD_END_SOFT_RESET()
+#endif


### PR DESCRIPTION
Following discussions in https://github.com/orgs/micropython/discussions/12116, this pull request makes changes primarily to support the upcoming Pimoroni Yukon board, but that could also benefit others in the community.

* Adds C hooks for initialising and resetting an RP2040 based board. Yukon currently only uses a few of these, but I included the rest for future product use.
* Increases the number of external IO pins from 10 to the maximum 32 to match the number of pins Yukon's IO expanders expose.

I have tested these successfully with a custom build, that includes the board definitions and pulls in drivers for the IO expanders so the external pins can work. I have left these changes out of this PR, as they are currently quite intrusive.
