### PR TITLE
py/profile.c: Remove the requirement to disable the const optimisation when using sys.settrace.

### DIFF
--- a/ports/unix/mpconfigport.h
+++ b/ports/unix/mpconfigport.h
@@ -134,12 +134,6 @@ typedef long mp_off_t;
 #define MICROPY_STACKLESS_STRICT    (0)
 #endif
 
-// If settrace is enabled then we need code saving.
-#if MICROPY_PY_SYS_SETTRACE
-#define MICROPY_PERSISTENT_CODE_SAVE (1)
-#define MICROPY_COMP_CONST (0)
-#endif
-
 // Unix-specific configuration of machine.mem*.
 #define MICROPY_MACHINE_MEM_GET_READ_ADDR   mod_machine_mem_get_addr
 #define MICROPY_MACHINE_MEM_GET_WRITE_ADDR  mod_machine_mem_get_addr

--- a/py/mpconfig.h
+++ b/py/mpconfig.h
@@ -312,9 +312,11 @@
 #define MICROPY_PERSISTENT_CODE_LOAD (0)
 #endif
 
-// Whether to support saving of persistent code
+// Whether to support saving of persistent code, i.e. for mpy-cross to
+// generate .mpy files. Enabling this enables additional metadata on raw code
+// objects which is also required for sys.settrace.
 #ifndef MICROPY_PERSISTENT_CODE_SAVE
-#define MICROPY_PERSISTENT_CODE_SAVE (0)
+#define MICROPY_PERSISTENT_CODE_SAVE (MICROPY_PY_SYS_SETTRACE)
 #endif
 
 // Whether to support saving persistent code to a file via mp_raw_code_save_file
@@ -2011,16 +2013,6 @@ typedef double mp_float_t;
 #else
 #undef MP_WARN_CAT
 #define MP_WARN_CAT(x) (NULL)
-#endif
-
-// Feature dependency check.
-#if MICROPY_PY_SYS_SETTRACE
-#if !MICROPY_PERSISTENT_CODE_SAVE
-#error "MICROPY_PY_SYS_SETTRACE requires MICROPY_PERSISTENT_CODE_SAVE to be enabled"
-#endif
-#if MICROPY_COMP_CONST
-#error "MICROPY_PY_SYS_SETTRACE requires MICROPY_COMP_CONST to be disabled"
-#endif
 #endif
 
 #endif // MICROPY_INCLUDED_PY_MPCONFIG_H

--- a/py/profile.c
+++ b/py/profile.c
@@ -31,6 +31,12 @@
 
 #if MICROPY_PY_SYS_SETTRACE
 
+#if !MICROPY_PERSISTENT_CODE_SAVE
+// The settrace feature requires that we maintain additional metadata on the raw
+// code object which is normally only done when writing .mpy files.
+#error "MICROPY_PY_SYS_SETTRACE requires MICROPY_PERSISTENT_CODE_SAVE to be enabled"
+#endif
+
 #define prof_trace_cb MP_STATE_THREAD(prof_trace_callback)
 #define QSTR_MAP(context, idx) (context->constants.qstr_table[idx])
 

--- a/tests/misc/sys_settrace_features.py
+++ b/tests/misc/sys_settrace_features.py
@@ -22,7 +22,9 @@ def print_stacktrace(frame, level=0):
             frame.f_code.co_name,
             # Keep just the filename.
             "sys_settrace_" + frame.f_code.co_filename.split("sys_settrace_")[-1],
-            frame.f_lineno,
+            max(
+                1, frame.f_lineno
+            ),  # CPython 3.11 emits `0` where CPython 3.6 emits `1` for the "call" event corresponding to import.
         )
     )
 

--- a/tests/misc/sys_settrace_features.py
+++ b/tests/misc/sys_settrace_features.py
@@ -67,6 +67,11 @@ def trace_tick_handler(frame, event, arg):
     if any(name in frame_name for name in to_ignore):
         return
 
+    # Lines 4,5,7 create the `const` lambda, and line `15` is a `_X = const()` which
+    # MicroPython will not see as it's optimised out.
+    if "sys_settrace_importme" in frame.f_code.co_filename and frame.f_lineno in (4, 5, 7, 15):
+        return trace_tick_handler
+
     print("### trace_handler::main event:", event)
     __prof__.trace_tick(frame, event, arg)
 

--- a/tests/misc/sys_settrace_subdir/sys_settrace_importme.py
+++ b/tests/misc/sys_settrace_subdir/sys_settrace_importme.py
@@ -3,12 +3,18 @@ print("Yep, I got imported.")
 try:
     x = const(1)
 except NameError:
-    print("const not defined")
+    # Either running on CPython or MICROPY_COMP_CONST disabled.
+    const = lambda x: x
 
-const = lambda x: x
 
+# No const optimisation.
 _CNT01 = "CONST01"
+
+# Const assigned to an underscore name. Invisible to MicroPython with
+# MICROPY_COMP_CONST enabled.
 _CNT02 = const(123)
+
+# Consts assigned to regular name, executed normally.
 A123 = const(123)
 a123 = const(123)
 


### PR DESCRIPTION
The only reason that const had to be disabled was to make the test
output match CPython when const was involved. Instead, this commit
fixes the test to handle the lines where const is used.

Also:
 - make the sys_settrace_features.py test work against newer CPython versions
 - remove the special handling for MICROPY_PERSISTENT_CODE_SAVE in
   unix/mpconfigport.h, and make this automatic.
 - move the check for MICROPY_PERSISTENT_CODE_SAVE to where it's used
   (like we do for other similar checks) and add a comment explaining
   it.

cc @andrewleech -- this is to support maybe making it possible to enable sys.settrace by default (see #[12280](https://github.com/micropython/micropython/pull/12280)).

_This work was funded through GitHub Sponsors._