### PR TITLE
py/mpconfig.h: Enable SSL finalizers if finalizers are enabled.

### DIFF
--- a/extmod/modssl_mbedtls.c
+++ b/extmod/modssl_mbedtls.c
@@ -394,6 +394,7 @@ STATIC mp_obj_t ssl_socket_make_new(mp_obj_ssl_context_t *ssl_context, mp_obj_t 
     return MP_OBJ_FROM_PTR(o);
 
 cleanup:
+    o->sock = MP_OBJ_NULL;
     mbedtls_ssl_free(&o->ssl);
     mbedtls_raise_error(ret);
 }

--- a/ports/esp32/mpconfigport.h
+++ b/ports/esp32/mpconfigport.h
@@ -139,7 +139,6 @@
 #define MICROPY_HW_SOFTSPI_MAX_BAUDRATE     (esp_rom_get_cpu_ticks_per_us() * 1000000 / 200) // roughly
 #define MICROPY_PY_SSL                      (1)
 #define MICROPY_SSL_MBEDTLS                 (1)
-#define MICROPY_PY_SSL_FINALISER            (1)
 #define MICROPY_PY_WEBSOCKET                (1)
 #define MICROPY_PY_WEBREPL                  (1)
 #define MICROPY_PY_ONEWIRE                  (1)

--- a/ports/mimxrt/mpconfigport.h
+++ b/ports/mimxrt/mpconfigport.h
@@ -67,7 +67,6 @@ uint32_t trng_random_u32(void);
 
 // Extended modules
 #define MICROPY_EPOCH_IS_1970               (1)
-#define MICROPY_PY_SSL_FINALISER            (MICROPY_PY_SSL)
 #define MICROPY_PY_TIME_GMTIME_LOCALTIME_MKTIME (1)
 #define MICROPY_PY_TIME_TIME_TIME_NS        (1)
 #define MICROPY_PY_TIME_INCLUDEFILE         "ports/mimxrt/modtime.c"
@@ -110,7 +109,6 @@ uint32_t trng_random_u32(void);
 #define MICROPY_PY_WEBSOCKET                (MICROPY_PY_LWIP)
 #define MICROPY_PY_WEBREPL                  (MICROPY_PY_LWIP)
 #define MICROPY_PY_LWIP_SOCK_RAW            (MICROPY_PY_LWIP)
-#define MICROPY_PY_SSL_FINALISER            (MICROPY_PY_SSL)
 // #define MICROPY_PY_HASHLIB_MD5              (MICROPY_PY_SSL)
 #define MICROPY_PY_HASHLIB_SHA1             (MICROPY_PY_SSL)
 // #define MICROPY_PY_CRYPTOLIB                (MICROPY_PY_SSL)

--- a/ports/stm32/mpconfigport.h
+++ b/ports/stm32/mpconfigport.h
@@ -92,7 +92,6 @@
 #endif
 
 // extended modules
-#define MICROPY_PY_SSL_FINALISER    (MICROPY_PY_SSL)
 #define MICROPY_PY_HASHLIB_MD5      (MICROPY_PY_SSL)
 #define MICROPY_PY_HASHLIB_SHA1     (MICROPY_PY_SSL)
 #define MICROPY_PY_CRYPTOLIB        (MICROPY_PY_SSL)

--- a/py/mpconfig.h
+++ b/py/mpconfig.h
@@ -1718,7 +1718,7 @@ typedef double mp_float_t;
 
 // Whether to add finaliser code to ssl objects
 #ifndef MICROPY_PY_SSL_FINALISER
-#define MICROPY_PY_SSL_FINALISER (0)
+#define MICROPY_PY_SSL_FINALISER (MICROPY_ENABLE_FINALISER)
 #endif
 
 #ifndef MICROPY_PY_WEBSOCKET


### PR DESCRIPTION
The rp2 port was enabling SSL and had finalizers enabled via the "extra features" level, but missed explicitly enabling `MICROPY_PY_SSL_FINALISER` (like esp32, stm32, and mimxrt did).

This commit makes `MICROPY_PY_SSL_FINALISER` default to enabled if finalizers are enabled, and removes the explicit setting of this for esp32, stm32, mimxrt (because they all use the "extra features" level).

This will help with the issue described in https://github.com/micropython/micropython/issues/12278

_This work was funded through GitHub Sponsors._