### PR TITLE
tests/unix/mod_os: Make os.system() test work on windows.

### DIFF
--- a/tests/unix/mod_os.py
+++ b/tests/unix/mod_os.py
@@ -12,7 +12,7 @@ os.unsetenv("TEST_VARIABLE")
 print(os.getenv("TEST_VARIABLE"))
 print(os.getenv("TEST_VARIABLE", "TEST_DEFAULT_VALUE"))
 
-print(os.system("true"))
+print(os.system("exit 0"))
 
 rand = os.urandom(4)
 print(type(rand) is bytes, len(rand))


### PR DESCRIPTION
The "true" command by default is unavailable on windows so use an equivalent which works on both unix and windows.

I'm not sure how I missed this, perhaps I had a true.exe in my PATH (as seems to be the case for Appveyor).