### PR TITLE
extmod/machine_signal: Add Signal print function.

### DIFF
--- a/extmod/extmod.cmake
+++ b/extmod/extmod.cmake
@@ -15,6 +15,7 @@ set(MICROPY_SOURCE_EXTMOD
     ${MICROPY_EXTMOD_DIR}/machine_i2c_target.c
     ${MICROPY_EXTMOD_DIR}/machine_i2s.c
     ${MICROPY_EXTMOD_DIR}/machine_mem.c
+    ${MICROPY_EXTMOD_DIR}/machine_pinbase.c
     ${MICROPY_EXTMOD_DIR}/machine_pulse.c
     ${MICROPY_EXTMOD_DIR}/machine_pwm.c
     ${MICROPY_EXTMOD_DIR}/machine_signal.c

--- a/extmod/machine_signal.c
+++ b/extmod/machine_signal.c
@@ -112,6 +112,11 @@ static mp_obj_t signal_make_new(const mp_obj_type_t *type, size_t n_args, size_t
     return MP_OBJ_FROM_PTR(o);
 }
 
+static void signal_print(const mp_print_t *print, mp_obj_t self_in, mp_print_kind_t kind) {
+    machine_signal_t *self = MP_OBJ_TO_PTR(self_in);
+    mp_printf(print, "Signal(%p%s)", self->pin, self->invert ? ", invert=True" : "");
+}
+
 static mp_uint_t signal_ioctl(mp_obj_t self_in, mp_uint_t request, uintptr_t arg, int *errcode) {
     (void)errcode;
     machine_signal_t *self = MP_OBJ_TO_PTR(self_in);
@@ -175,6 +180,7 @@ MP_DEFINE_CONST_OBJ_TYPE(
     MP_QSTR_Signal,
     MP_TYPE_FLAG_NONE,
     make_new, signal_make_new,
+    print, signal_print,
     call, signal_call,
     protocol, &signal_pin_p,
     locals_dict, &signal_locals_dict

--- a/tests/extmod/machine_signal.py
+++ b/tests/extmod/machine_signal.py
@@ -24,6 +24,7 @@ class Pin(machine.PinBase):
 # test non-inverted
 p = Pin()
 s = machine.Signal(p)
+_ = str(s)
 s.value(0)
 print(p.value(), s.value())
 s.value(1)
@@ -32,6 +33,7 @@ print(p.value(), s.value())
 # test inverted, and using on/off methods
 p = Pin()
 s = machine.Signal(p, invert=True)
+_ = str(s)
 s.off()
 print(p.value(), s.value())
 s.on()


### PR DESCRIPTION
Test code is:
```
from machine import Pin, Signal
signal22= Signal(Pin(22, mode=Pin.OUT))
signal22
signal21= Signal(Pin(21, mode=Pin.IN), invert=True)
signal21
```
Ounput is:
```
Signal(Pin(22))
Signal(Pin(21), invert=True)
```
instead of
```
<Signal>
<Signal>
```