### PR TITLE
examples/bluetooth: Link to aioble in BLE examples.

### DIFF
--- a/examples/bluetooth/ble_advertising.py
+++ b/examples/bluetooth/ble_advertising.py
@@ -1,5 +1,9 @@
 # Helpers for generating BLE advertising payloads.
 
+# A more fully-featured (and easier to use) version of this is implemented in
+# aioble. This code is provided just as a basic example. See
+# https://github.com/micropython/micropython-lib/tree/master/micropython/bluetooth/aioble
+
 from micropython import const
 import struct
 import bluetooth

--- a/examples/bluetooth/ble_bonding_peripheral.py
+++ b/examples/bluetooth/ble_bonding_peripheral.py
@@ -4,6 +4,11 @@
 # any connected central every 10 seconds.
 #
 # Work-in-progress demo of implementing bonding and passkey auth.
+#
+# This example demonstrates the low-level bluetooth module. For most
+# applications, we recommend using the higher-level aioble library, which
+# includes an implementation of the secret store. See
+# https://github.com/micropython/micropython-lib/tree/master/micropython/bluetooth/aioble
 
 import bluetooth
 import random

--- a/examples/bluetooth/ble_simple_central.py
+++ b/examples/bluetooth/ble_simple_central.py
@@ -1,6 +1,11 @@
 # This example finds and connects to a peripheral running the
 # UART service (e.g. ble_simple_peripheral.py).
 
+# This example demonstrates the low-level bluetooth module. For most
+# applications, we recommend using the higher-level aioble library which takes
+# care of all IRQ handling and connection management. See
+# https://github.com/micropython/micropython-lib/tree/master/micropython/bluetooth/aioble
+
 import bluetooth
 import random
 import struct

--- a/examples/bluetooth/ble_simple_peripheral.py
+++ b/examples/bluetooth/ble_simple_peripheral.py
@@ -1,5 +1,10 @@
 # This example demonstrates a UART periperhal.
 
+# This example demonstrates the low-level bluetooth module. For most
+# applications, we recommend using the higher-level aioble library which takes
+# care of all IRQ handling and connection management. See
+# https://github.com/micropython/micropython-lib/tree/master/micropython/bluetooth/aioble
+
 import bluetooth
 import random
 import struct

--- a/examples/bluetooth/ble_temperature.py
+++ b/examples/bluetooth/ble_temperature.py
@@ -3,6 +3,12 @@
 # The sensor's local value updates every second, and it will notify
 # any connected central every 10 seconds.
 
+# This example demonstrates the low-level bluetooth module. For most
+# applications, we recommend using the higher-level aioble library which takes
+# care of all IRQ handling and connection management. See
+# https://github.com/micropython/micropython-lib/tree/master/micropython/bluetooth/aioble
+# and in particular the temp_sensor.py example included with aioble.
+
 import bluetooth
 import random
 import struct

--- a/examples/bluetooth/ble_temperature_central.py
+++ b/examples/bluetooth/ble_temperature_central.py
@@ -1,5 +1,11 @@
 # This example finds and connects to a BLE temperature sensor (e.g. the one in ble_temperature.py).
 
+# This example demonstrates the low-level bluetooth module. For most
+# applications, we recommend using the higher-level aioble library which takes
+# care of all IRQ handling and connection management. See
+# https://github.com/micropython/micropython-lib/tree/master/micropython/bluetooth/aioble
+# and in particular the temp_client.py example included with aioble.
+
 import bluetooth
 import random
 import struct

--- a/examples/bluetooth/ble_uart_peripheral.py
+++ b/examples/bluetooth/ble_uart_peripheral.py
@@ -1,5 +1,10 @@
 # This example demonstrates a peripheral implementing the Nordic UART Service (NUS).
 
+# This example demonstrates the low-level bluetooth module. For most
+# applications, we recommend using the higher-level aioble library which takes
+# care of all IRQ handling and connection management. See
+# https://github.com/micropython/micropython-lib/tree/master/micropython/bluetooth/aioble
+
 import bluetooth
 from ble_advertising import advertising_payload
 


### PR DESCRIPTION
I've seen a few articles and tutorials written that are using `bluetooth` but would be much simpler and clearer if they used `aioble`.

We already link to `aioble` from bluetooth.rst, but also add a note to the top of the examples.