### PR TITLE
extmod/moddeflate: Change default window size.

### DIFF
--- a/lib/uzlib/header.c
+++ b/lib/uzlib/header.c
@@ -108,6 +108,10 @@ int uzlib_parse_zlib_gzip_header(uzlib_uncomp_t *d, int *wbits)
         d->checksum_type = UZLIB_CHKSUM_CRC;
         d->checksum = ~0;
 
+        /* gzip does not include the window size in the header, as it is expected that a
+           compressor will use wbits=15 (32kiB).*/
+        *wbits = 15;
+
         return UZLIB_HEADER_GZIP;
     } else {
        /* check checksum */


### PR DESCRIPTION
The primary purpose of this commit is to make decompress default to wbits=15 when the format is gzip (or auto format with gzip detected). The idea is that someone decompressing a gzip stream should be able to use the default `deflate.DeflateIO(f)` and it will "just work" for any input stream, even though it uses a lot of memory.

This is done by making uzlib report gzip files as having wbits set to 15 in their header (where it previously only set the wbits out parameter for zlib files), and then fixing up the logic in `deflateio_init_read`.

Updates the documentation to match.

_This work was funded through GitHub Sponsors._