### PR TITLE
mimxrt/mpbthciport.c: Change the method of setting the baud rate.

### DIFF
--- a/ports/mimxrt/modmachine.h
+++ b/ports/mimxrt/modmachine.h
@@ -51,4 +51,6 @@ void machine_i2s_init0();
 void machine_i2s_deinit_all(void);
 void machine_rtc_start(void);
 
+void machine_uart_set_baudrate(mp_obj_t uart, uint32_t baudrate);
+
 #endif // MICROPY_INCLUDED_MIMXRT_MODMACHINE_H

--- a/ports/mimxrt/mpbthciport.c
+++ b/ports/mimxrt/mpbthciport.c
@@ -34,9 +34,6 @@
 #include "modmachine.h"
 #include "mpbthciport.h"
 
-#include "fsl_lpuart.h"
-#include CLOCK_CONFIG_H
-
 #if MICROPY_PY_BLUETOOTH
 
 #define DEBUG_printf(...) // mp_printf(&mp_plat_print, "mpbthciport.c: " __VA_ARGS__)
@@ -111,9 +108,7 @@ int mp_bluetooth_hci_uart_deinit(void) {
 int mp_bluetooth_hci_uart_set_baudrate(uint32_t baudrate) {
     DEBUG_printf("mp_bluetooth_hci_uart_set_baudrate(%lu)\n", baudrate);
     if (mp_bthci_uart != MP_OBJ_NULL) {
-        // This struct is not public, so we use the base defined in board config files.
-        // machine_uart_obj_t uart = (machine_uart_obj_t *) MP_PTR_FROM_OBJ(mp_bthci_uart);
-        LPUART_SetBaudRate(MICROPY_HW_BLE_UART_BASE, baudrate, BOARD_BOOTCLOCKRUN_UART_CLK_ROOT);
+        machine_uart_set_baudrate(mp_bthci_uart, baudrate);
     }
     return 0;
 }


### PR DESCRIPTION
By calling uart.init() instead of setting the baud rate by a call to the NXP lib.

Fixes machine_uart.c to work with a baud rate of 921600.

Note: Should by tested with a CYW43 capable HW first. I had used that code with the esp_hosted hardware.