### PR TITLE
Added rp2_flash ioctl to get the flash fs_base_address

### DIFF
--- a/ports/rp2/rp2_flash.c
+++ b/ports/rp2/rp2_flash.c
@@ -177,6 +177,8 @@ STATIC mp_obj_t rp2_flash_ioctl(mp_obj_t self_in, mp_obj_t cmd_in, mp_obj_t arg_
             // TODO check return value
             return MP_OBJ_NEW_SMALL_INT(0);
         }
+        case 0x1000:
+            return MP_OBJ_NEW_SMALL_INT(self->flash_base);
         default:
             return mp_const_none;
     }


### PR DESCRIPTION
There is no way to get the flash file system base address.  I added an ioctl 0x1000 to get that address.

Please feel free to modify the implementation.