### PR TITLE
py: clean up lexer and reader if an import fails

### DIFF
--- a/py/persistentcode.c
+++ b/py/persistentcode.c
@@ -391,6 +391,10 @@ STATIC mp_raw_code_t *load_raw_code(mp_reader_t *reader, mp_module_context_t *co
 }
 
 void mp_raw_code_load(mp_reader_t *reader, mp_compiled_module_t *cm) {
+    // Set exception handler to close the reader if an exception is raised.
+    MP_DEFINE_NLR_JUMP_CALLBACK_FUNCTION_1(ctx, reader->close, reader->data);
+    nlr_push_jump_callback(&ctx.callback, mp_call_function_1_from_nlr_jump_callback);
+
     byte header[4];
     read_bytes(reader, header, sizeof(header));
     byte arch = MPY_FEATURE_DECODE_ARCH(header[2]);
@@ -435,7 +439,8 @@ void mp_raw_code_load(mp_reader_t *reader, mp_compiled_module_t *cm) {
     cm->n_obj = n_obj;
     #endif
 
-    reader->close(reader->data);
+    // Deregister exception handler and close the reader.
+    nlr_pop_jump_callback(true);
 }
 
 void mp_raw_code_load_mem(const byte *buf, size_t len, mp_compiled_module_t *context) {

--- a/py/runtime.c
+++ b/py/runtime.c
@@ -197,6 +197,11 @@ void mp_globals_locals_set_from_nlr_jump_callback(void *ctx_in) {
     mp_locals_set(ctx->locals);
 }
 
+void mp_call_function_1_from_nlr_jump_callback(void *ctx_in) {
+    nlr_jump_callback_node_call_function_1_t *ctx = ctx_in;
+    ctx->func(ctx->arg);
+}
+
 mp_obj_t MICROPY_WRAP_MP_LOAD_NAME(mp_load_name)(qstr qst) {
     // logic: search locals, globals, builtins
     DEBUG_OP_printf("load name %s\n", qstr_str(qst));

--- a/py/runtime.h
+++ b/py/runtime.h
@@ -29,6 +29,13 @@
 #include "py/mpstate.h"
 #include "py/pystack.h"
 
+// For use with mp_call_function_1_from_nlr_jump_callback.
+#define MP_DEFINE_NLR_JUMP_CALLBACK_FUNCTION_1(ctx, f, a) \
+    nlr_jump_callback_node_call_function_1_t ctx = { \
+        .func = (void (*)(void *))(f), \
+        .arg = (a), \
+    }
+
 typedef enum {
     MP_VM_RETURN_NORMAL,
     MP_VM_RETURN_YIELD,
@@ -72,6 +79,13 @@ typedef struct _nlr_jump_callback_node_globals_locals_t {
     mp_obj_dict_t *globals;
     mp_obj_dict_t *locals;
 } nlr_jump_callback_node_globals_locals_t;
+
+// For use with mp_call_function_1_from_nlr_jump_callback.
+typedef struct _nlr_jump_callback_node_call_function_1_t {
+    nlr_jump_callback_node_t callback;
+    void (*func)(void *);
+    void *arg;
+} nlr_jump_callback_node_call_function_1_t;
 
 // Tables mapping operator enums to qstrs, defined in objtype.c
 extern const byte mp_unary_op_method_name[];
@@ -121,6 +135,7 @@ static inline void mp_globals_set(mp_obj_dict_t *d) {
 }
 
 void mp_globals_locals_set_from_nlr_jump_callback(void *ctx_in);
+void mp_call_function_1_from_nlr_jump_callback(void *ctx_in);
 
 mp_obj_t mp_load_name(qstr qst);
 mp_obj_t mp_load_global(qstr qst);

--- a/tests/extmod/vfs_userfs.py
+++ b/tests/extmod/vfs_userfs.py
@@ -69,6 +69,7 @@ user_files = {
     "/usermod1.py": b"print('in usermod1')\nimport usermod2",
     "/usermod2.py": b"print('in usermod2')",
     "/usermod3.py": b"syntax error",
+    "/usermod4.mpy": b"syntax error",
 }
 os.mount(UserFS(user_files), "/userfs")
 
@@ -85,6 +86,12 @@ try:
     import usermod3
 except SyntaxError:
     print("SyntaxError in usermod3")
+
+# import a .mpy file with a syntax error (file should be closed on error)
+try:
+    import usermod4
+except ValueError:
+    print("ValueError in usermod4")
 
 # unmount and undo path addition
 os.umount("/userfs")

--- a/tests/extmod/vfs_userfs.py
+++ b/tests/extmod/vfs_userfs.py
@@ -68,6 +68,7 @@ user_files = {
     "/data.txt": b"some data in a text file",
     "/usermod1.py": b"print('in usermod1')\nimport usermod2",
     "/usermod2.py": b"print('in usermod2')",
+    "/usermod3.py": b"syntax error",
 }
 os.mount(UserFS(user_files), "/userfs")
 
@@ -78,6 +79,12 @@ print(f.read())
 # import files from the user filesystem
 sys.path.append("/userfs")
 import usermod1
+
+# import a .py file with a syntax error (file should be closed on error)
+try:
+    import usermod3
+except SyntaxError:
+    print("SyntaxError in usermod3")
 
 # unmount and undo path addition
 os.umount("/userfs")

--- a/tests/extmod/vfs_userfs.py.exp
+++ b/tests/extmod/vfs_userfs.py.exp
@@ -10,3 +10,8 @@ stat /usermod2.py
 open /usermod2.py rb
 ioctl 4 0
 in usermod2
+stat /usermod3
+stat /usermod3.py
+open /usermod3.py rb
+ioctl 4 0
+SyntaxError in usermod3

--- a/tests/extmod/vfs_userfs.py.exp
+++ b/tests/extmod/vfs_userfs.py.exp
@@ -15,3 +15,9 @@ stat /usermod3.py
 open /usermod3.py rb
 ioctl 4 0
 SyntaxError in usermod3
+stat /usermod4
+stat /usermod4.py
+stat /usermod4.mpy
+open /usermod4.mpy rb
+ioctl 4 0
+ValueError in usermod4


### PR DESCRIPTION
This is an alternative to #3874 that uses the new nlr-jump-callback feature to make sure lexers are freed, and readers closed, if an exception is raised during the loading of a file.