### PR TITLE
extmod/modnetwork.h: Increase hostname limit to 64 bytes

### DIFF
--- a/docs/library/network.rst
+++ b/docs/library/network.rst
@@ -188,7 +188,19 @@ The following are functions available in the network module.
     during connection. For this reason, you must set the hostname before
     activating/connecting your network interfaces.
 
+    The length of the hostname is limited to 63 characters [#f1]_.
+    :term:`MicroPython ports <MicroPython port>` may choose to set a lower
+    limit for memory reasons. If the given name does not fit, a `ValueError`
+    is raised.
+
     The default hostname is typically the name of the board.
+
+.. [#f1] `DHCP <https://datatracker.ietf.org/doc/html/rfc2131#page-10>`_ has a
+    64-byte limit on the ``sname`` field which includes the terminating null
+    byte, while `mDNS
+    <https://datatracker.ietf.org/doc/html/rfc6762#appendix-C>`_ references
+    `DNS's <https://datatracker.ietf.org/doc/html/rfc1035#section-2.3.4>`_
+    63-character limit
 
 .. function:: phy_mode([mode])
 

--- a/extmod/modnetwork.h
+++ b/extmod/modnetwork.h
@@ -56,7 +56,7 @@
 extern char mod_network_country_code[2];
 
 #ifndef MICROPY_PY_NETWORK_HOSTNAME_MAX_LEN
-#define MICROPY_PY_NETWORK_HOSTNAME_MAX_LEN (16)
+#define MICROPY_PY_NETWORK_HOSTNAME_MAX_LEN (64)
 #endif
 
 extern char mod_network_hostname[MICROPY_PY_NETWORK_HOSTNAME_MAX_LEN];


### PR DESCRIPTION
PR #10635 introduced this limit which seems rather arbirtrary and wildly insufficient to me.

A 16 bytes length limits means a 15 character string limit, which even `ubinascii.hexlify(machine.unique_id())` on most ports will break. And then assuming you just supply a random 15 byte hex string, most people won't be able to identify the hosts function in a list on their wifi routers.

I wanted to set my hostname to `rpi-fan-controller-{hex_uid}` and just got a ValueError without explanation. It took me 2 hours to figure what went wrong. Because of this I added a note about the exception and limitation to the documentation.

Since I didn't really understand the reason for 16 bytes I set the new limit to the size used in all involved protocols: DHCP 64 bytes, DNS 63 "octets" (characters) plus length byte, and mDNS which points to the DNS RFC. I can imagine that some ports for small boards might want to decrease the size of this statically allocated buffer, and from what I gathered from the C code it would be a simple as defining `MICROPY_PY_NETWORK_HOSTNAME_MAX_LEN`, so I mentioned this possibility for end users in the documentation as well.