### PR TITLE
extmod/modnetwork: Make hostname dynamically allocated.

### DIFF
--- a/docs/library/network.rst
+++ b/docs/library/network.rst
@@ -188,7 +188,17 @@ The following are functions available in the network module.
     during connection. For this reason, you must set the hostname before
     activating/connecting your network interfaces.
 
+    The length of the hostname is limited to 63 characters [#f1]_, unless
+    further limited by the port (e.g. ESP32 and ESP8266 limit to 32 characters).
+    If the given name does not fit, a `ValueError` is raised.
+
     The default hostname is typically the name of the board.
+
+.. [#f1] `DHCP <https://datatracker.ietf.org/doc/html/rfc2131#page-10>`_ has a
+    64-byte limit on the ``sname`` field which includes the terminating null
+    byte, while `mDNS <https://datatracker.ietf.org/doc/html/rfc6762#appendix-C>`_
+    references `DNS's <https://datatracker.ietf.org/doc/html/rfc1035#section-2.3.4>`_
+    63-character limit
 
 .. function:: phy_mode([mode])
 

--- a/extmod/modnetwork.h
+++ b/extmod/modnetwork.h
@@ -56,10 +56,13 @@
 extern char mod_network_country_code[2];
 
 #ifndef MICROPY_PY_NETWORK_HOSTNAME_MAX_LEN
-#define MICROPY_PY_NETWORK_HOSTNAME_MAX_LEN (16)
+// DHCP has a 64-byte limit on the `sname` field which includes the
+// terminating null byte, while mDNS references DNS's 63-character limit.
+// DHCP: https://datatracker.ietf.org/doc/html/rfc2131#page-10
+// mDNS: https://datatracker.ietf.org/doc/html/rfc6762#appendix-C
+// DNS: https://datatracker.ietf.org/doc/html/rfc1035#section-2.3.4
+#define MICROPY_PY_NETWORK_HOSTNAME_MAX_LEN (63)
 #endif
-
-extern char mod_network_hostname[MICROPY_PY_NETWORK_HOSTNAME_MAX_LEN];
 
 #if MICROPY_PY_LWIP
 struct netif;
@@ -110,9 +113,14 @@ typedef struct _mod_network_socket_obj_t {
 
 #endif // MICROPY_PY_LWIP / MICROPY_PORT_NETWORK_INTERFACES
 
-#ifdef MICROPY_PORT_NETWORK_INTERFACES
 void mod_network_init(void);
 void mod_network_deinit(void);
+
+const char *mod_network_get_hostname(void);
+mp_obj_t mod_network_get_hostname_obj(void);
+void mod_network_set_hostname_obj(mp_obj_t value);
+
+#ifdef MICROPY_PORT_NETWORK_INTERFACES
 void mod_network_register_nic(mp_obj_t nic);
 mp_obj_t mod_network_find_nic(const uint8_t *ip);
 #endif

--- a/extmod/network_cyw43.c
+++ b/extmod/network_cyw43.c
@@ -422,7 +422,7 @@ STATIC mp_obj_t network_cyw43_config(size_t n_args, const mp_obj_t *args, mp_map
             }
             case MP_QSTR_hostname: {
                 // TODO: Deprecated. Use network.hostname() instead.
-                return mp_obj_new_str(mod_network_hostname, strlen(mod_network_hostname));
+                return mod_network_get_hostname_obj();
             }
             default:
                 mp_raise_ValueError(MP_ERROR_TEXT("unknown config param"));
@@ -498,12 +498,7 @@ STATIC mp_obj_t network_cyw43_config(size_t n_args, const mp_obj_t *args, mp_map
                     }
                     case MP_QSTR_hostname: {
                         // TODO: Deprecated. Use network.hostname(name) instead.
-                        size_t len;
-                        const char *str = mp_obj_str_get_data(e->value, &len);
-                        if (len >= MICROPY_PY_NETWORK_HOSTNAME_MAX_LEN) {
-                            mp_raise_ValueError(NULL);
-                        }
-                        strcpy(mod_network_hostname, str);
+                        mod_network_set_hostname_obj(e->value);
                         break;
                     }
                     default:

--- a/ports/esp32/main.c
+++ b/ports/esp32/main.c
@@ -53,6 +53,7 @@
 #include "usb.h"
 #include "usb_serial_jtag.h"
 #include "modmachine.h"
+#include "extmod/modnetwork.h"
 #include "modnetwork.h"
 #include "mpthreadport.h"
 
@@ -97,6 +98,9 @@ void mp_task(void *pvParameter) {
     uart_stdout_init();
     #endif
     machine_init();
+    #if MICROPY_PY_NETWORK
+    mod_network_init();
+    #endif
 
     esp_err_t err = esp_event_loop_create_default();
     if (err != ESP_OK) {
@@ -184,6 +188,9 @@ soft_reset_exit:
     machine_deinit();
     #if MICROPY_PY_SOCKET_EVENTS
     socket_events_deinit();
+    #endif
+    #if MICROPY_PY_NETWORK
+    mod_network_deinit();
     #endif
 
     mp_deinit();

--- a/ports/esp32/mpconfigport.h
+++ b/ports/esp32/mpconfigport.h
@@ -129,6 +129,7 @@
 #endif
 #define MICROPY_PY_NETWORK_INCLUDEFILE      "ports/esp32/modnetwork.h"
 #define MICROPY_PY_NETWORK_MODULE_GLOBALS_INCLUDEFILE "ports/esp32/modnetwork_globals.h"
+#define MICROPY_PY_NETWORK_HOSTNAME_MAX_LEN (32)
 #ifndef MICROPY_PY_NETWORK_WLAN
 #define MICROPY_PY_NETWORK_WLAN             (1)
 #endif

--- a/ports/esp32/network_wlan.c
+++ b/ports/esp32/network_wlan.c
@@ -169,8 +169,8 @@ static void network_wlan_ip_event_handler(void *event_handler_arg, esp_event_bas
             if (!mdns_initialised) {
                 mdns_init();
                 #if MICROPY_HW_ENABLE_MDNS_RESPONDER
-                mdns_hostname_set(mod_network_hostname);
-                mdns_instance_name_set(mod_network_hostname);
+                mdns_hostname_set(mod_network_get_hostname());
+                mdns_instance_name_set(mod_network_get_hostname());
                 #endif
                 mdns_initialised = true;
             }
@@ -305,7 +305,7 @@ STATIC mp_obj_t network_wlan_connect(size_t n_args, const mp_obj_t *pos_args, mp
         esp_exceptions(esp_wifi_set_config(ESP_IF_WIFI_STA, &wifi_sta_config));
     }
 
-    esp_exceptions(esp_netif_set_hostname(wlan_sta_obj.netif, mod_network_hostname));
+    esp_exceptions(esp_netif_set_hostname(wlan_sta_obj.netif, mod_network_get_hostname()));
 
     wifi_sta_reconnects = 0;
     // connect to the WiFi AP
@@ -522,12 +522,7 @@ STATIC mp_obj_t network_wlan_config(size_t n_args, const mp_obj_t *args, mp_map_
                     case MP_QSTR_hostname:
                     case MP_QSTR_dhcp_hostname: {
                         // TODO: Deprecated. Use network.hostname(name) instead.
-                        size_t len;
-                        const char *str = mp_obj_str_get_data(kwargs->table[i].value, &len);
-                        if (len >= MICROPY_PY_NETWORK_HOSTNAME_MAX_LEN) {
-                            mp_raise_ValueError(NULL);
-                        }
-                        strcpy(mod_network_hostname, str);
+                        mod_network_set_hostname_obj(kwargs->table[i].value);
                         break;
                     }
                     case MP_QSTR_max_clients: {
@@ -630,7 +625,7 @@ STATIC mp_obj_t network_wlan_config(size_t n_args, const mp_obj_t *args, mp_map_
         case MP_QSTR_dhcp_hostname: {
             // TODO: Deprecated. Use network.hostname() instead.
             req_if = ESP_IF_WIFI_STA;
-            val = mp_obj_new_str(mod_network_hostname, strlen(mod_network_hostname));
+            val = mod_network_get_hostname_obj();
             break;
         }
         case MP_QSTR_max_clients: {

--- a/ports/esp8266/main.c
+++ b/ports/esp8266/main.c
@@ -40,6 +40,7 @@
 #define USE_US_TIMER 1
 
 #include "extmod/misc.h"
+#include "extmod/modnetwork.h"
 #include "shared/readline/readline.h"
 #include "shared/runtime/pyexec.h"
 #include "gccollect.h"
@@ -66,6 +67,9 @@ STATIC void mp_reset(void) {
     pin_init0();
     readline_init0();
     dupterm_task_init();
+    #if MICROPY_PY_NETWORK
+    mod_network_init();
+    #endif
 
     // Activate UART(0) on dupterm slot 1 for the REPL
     {
@@ -93,6 +97,11 @@ STATIC void mp_reset(void) {
 void soft_reset(void) {
     gc_sweep_all();
     mp_hal_stdout_tx_str("MPY: soft reboot\r\n");
+
+    #if MICROPY_PY_NETWORK
+    mod_network_deinit();
+    #endif
+
     mp_hal_delay_us(10000); // allow UART to flush output
     mp_reset();
     #if MICROPY_REPL_EVENT_DRIVEN

--- a/ports/esp8266/mpconfigport.h
+++ b/ports/esp8266/mpconfigport.h
@@ -77,6 +77,7 @@
 #endif
 #define MICROPY_PY_NETWORK_INCLUDEFILE "ports/esp8266/modnetwork.h"
 #define MICROPY_PY_NETWORK_MODULE_GLOBALS_INCLUDEFILE "ports/esp8266/modnetwork_globals.h"
+#define MICROPY_PY_NETWORK_HOSTNAME_MAX_LEN (32)
 #define MICROPY_PY_WEBSOCKET        (1)
 #define MICROPY_PY_ONEWIRE          (1)
 #define MICROPY_PY_WEBREPL          (1)

--- a/ports/esp8266/network_wlan.c
+++ b/ports/esp8266/network_wlan.c
@@ -152,7 +152,7 @@ STATIC mp_obj_t esp_connect(size_t n_args, const mp_obj_t *pos_args, mp_map_t *k
         error_check(wifi_station_set_config(&config), "Cannot set STA config");
     }
 
-    wifi_station_set_hostname(mod_network_hostname);
+    wifi_station_set_hostname((char *)mod_network_get_hostname());
 
     error_check(wifi_station_connect(), "Cannot connect to AP");
 
@@ -402,12 +402,7 @@ STATIC mp_obj_t esp_config(size_t n_args, const mp_obj_t *args, mp_map_t *kwargs
                     case MP_QSTR_hostname:
                     case MP_QSTR_dhcp_hostname: {
                         // TODO: Deprecated. Use network.hostname(name) instead.
-                        size_t len;
-                        const char *str = mp_obj_str_get_data(kwargs->table[i].value, &len);
-                        if (len >= MICROPY_PY_NETWORK_HOSTNAME_MAX_LEN) {
-                            mp_raise_ValueError(NULL);
-                        }
-                        strcpy(mod_network_hostname, str);
+                        mod_network_set_hostname_obj(kwargs->table[i].value);
                         break;
                     }
                     case MP_QSTR_protocol: {
@@ -483,7 +478,7 @@ STATIC mp_obj_t esp_config(size_t n_args, const mp_obj_t *args, mp_map_t *kwargs
         case MP_QSTR_dhcp_hostname: {
             req_if = STATION_IF;
             // TODO: Deprecated. Use network.hostname() instead.
-            val = mp_obj_new_str(mod_network_hostname, strlen(mod_network_hostname));
+            val = mod_network_get_hostname_obj();
             break;
         }
         case MP_QSTR_protocol: {

--- a/ports/mimxrt/cyw43_configport.h
+++ b/ports/mimxrt/cyw43_configport.h
@@ -61,7 +61,7 @@
 #define CYW43_THREAD_EXIT               MICROPY_PY_LWIP_EXIT
 #define CYW43_THREAD_LOCK_CHECK
 
-#define CYW43_HOST_NAME                 mod_network_hostname
+#define CYW43_HOST_NAME                 mod_network_get_hostname()
 
 #define CYW43_SDPCM_SEND_COMMON_WAIT    __WFI();
 #define CYW43_DO_IOCTL_WAIT             __WFI();

--- a/ports/mimxrt/eth.c
+++ b/ports/mimxrt/eth.c
@@ -559,7 +559,7 @@ STATIC void eth_lwip_init(eth_t *self) {
     n->name[0] = 'e';
     n->name[1] = (self == &eth_instance0 ? '0' : '1');
     netif_add(n, &ipconfig[0], &ipconfig[1], &ipconfig[2], self, eth_netif_init, ethernet_input);
-    netif_set_hostname(n, mod_network_hostname);
+    netif_set_hostname(n, mod_network_get_hostname());
     netif_set_default(n);
     netif_set_up(n);
 

--- a/ports/rp2/cyw43_configport.h
+++ b/ports/rp2/cyw43_configport.h
@@ -48,7 +48,7 @@
 #define CYW43_THREAD_EXIT               MICROPY_PY_LWIP_EXIT
 #define CYW43_THREAD_LOCK_CHECK
 
-#define CYW43_HOST_NAME                 mod_network_hostname
+#define CYW43_HOST_NAME                 mod_network_get_hostname()
 
 #define CYW43_SDPCM_SEND_COMMON_WAIT \
     if (get_core_num() == 0) { \

--- a/ports/stm32/cyw43_configport.h
+++ b/ports/stm32/cyw43_configport.h
@@ -62,7 +62,7 @@
 #define CYW43_THREAD_EXIT               MICROPY_PY_LWIP_EXIT
 #define CYW43_THREAD_LOCK_CHECK
 
-#define CYW43_HOST_NAME                 mod_network_hostname
+#define CYW43_HOST_NAME                 mod_network_get_hostname()
 
 #define CYW43_SDPCM_SEND_COMMON_WAIT    __WFI();
 #define CYW43_DO_IOCTL_WAIT             __WFI();

--- a/ports/stm32/eth.c
+++ b/ports/stm32/eth.c
@@ -737,7 +737,7 @@ STATIC void eth_lwip_init(eth_t *self) {
     n->name[0] = 'e';
     n->name[1] = '0';
     netif_add(n, &ipconfig[0], &ipconfig[1], &ipconfig[2], self, eth_netif_init, ethernet_input);
-    netif_set_hostname(n, mod_network_hostname);
+    netif_set_hostname(n, mod_network_get_hostname());
     netif_set_default(n);
     netif_set_up(n);
 


### PR DESCRIPTION
Alternative to #12403 by @M3t0r that reduces the need for 64 bytes of `.data`. The default will now be entirely in ROM, and the override can be a qstr or const value.

---

This increases the limit from 15 to 63 characters for the host name, and additioanlly allows e.g. a frozen or qstr value to be used.

Docs change by Simon Lutz Brüggen <micropython@m3t0r.de>

_This work was funded through GitHub Sponsors._