### PR TITLE
py/nlrx64: Always compile with omit-frame-pointer for "unix" gcc

### DIFF
--- a/py/nlrx64.c
+++ b/py/nlrx64.c
@@ -35,6 +35,11 @@
 
 __attribute__((used)) unsigned int nlr_push_tail(nlr_buf_t *nlr);
 
+#if !MICROPY_NLR_OS_WINDOWS && defined(__GNUC__) && !defined(__clang__)
+// nlr_push prelude should never push ebp onto the stack (gcc-only attribute)
+__attribute__((optimize("omit-frame-pointer")))
+#endif
+
 unsigned int nlr_push(nlr_buf_t *nlr) {
     (void)nlr;
 


### PR DESCRIPTION
Fixes situation where building embedded MicroPython with -O0 and MICROPY_NLR_X64 crashes at runtime. Closes https://github.com/micropython/micropython/issues/12421.

macOS still needs the tweak found further down in this file which pops EBP back off the stack after the generated function prelude pushes it. This is because the `__attribute__((optimize("")))` syntax is gcc-only, and the unix port builds with Clang for macOS.