### PR TITLE
all: Replace MP_STATE_PORT with MP_STATE_ROOT.

### DIFF
--- a/docs/develop/porting.rst
+++ b/docs/develop/porting.rst
@@ -173,8 +173,6 @@ The following is an example of an ``mpconfigport.h`` file:
    #define MICROPY_HW_BOARD_NAME "example-board"
    #define MICROPY_HW_MCU_NAME   "unknown-cpu"
 
-   #define MP_STATE_PORT MP_STATE_VM
-
 This configuration file contains machine-specific configurations including aspects like if different
 MicroPython features should be enabled e.g. ``#define MICROPY_ENABLE_GC (1)``. Making this Setting
 ``(0)`` disables the feature.

--- a/drivers/ninaw10/nina_wifi_bsp.c
+++ b/drivers/ninaw10/nina_wifi_bsp.c
@@ -73,7 +73,7 @@ int nina_bsp_init(void) {
         MP_OBJ_NEW_SMALL_INT(MICROPY_HW_WIFI_SPI_BAUDRATE),
     };
 
-    MP_STATE_PORT(mp_wifi_spi) = MP_OBJ_TYPE_GET_SLOT(&machine_spi_type, make_new)((mp_obj_t)&machine_spi_type, 2, 0, args);
+    MP_ROOT_POINTER(mp_wifi_spi) = MP_OBJ_TYPE_GET_SLOT(&machine_spi_type, make_new)((mp_obj_t)&machine_spi_type, 2, 0, args);
     return 0;
 }
 
@@ -136,7 +136,7 @@ int nina_bsp_spi_slave_deselect(void) {
 }
 
 int nina_bsp_spi_transfer(const uint8_t *tx_buf, uint8_t *rx_buf, uint32_t size) {
-    mp_obj_t mp_wifi_spi = MP_STATE_PORT(mp_wifi_spi);
+    mp_obj_t mp_wifi_spi = MP_ROOT_POINTER(mp_wifi_spi);
     ((mp_machine_spi_p_t *)MP_OBJ_TYPE_GET_SLOT(&machine_spi_type, protocol))->transfer(mp_wifi_spi, size, tx_buf, rx_buf);
     #if NINA_DEBUG
     for (int i = 0; i < size; i++) {

--- a/examples/usercmodule/subpackage/modexamplepackage.c
+++ b/examples/usercmodule/subpackage/modexamplepackage.c
@@ -50,10 +50,10 @@ STATIC mp_obj_t example_package_f(void) {
 STATIC MP_DEFINE_CONST_FUN_OBJ_0(example_package_f_obj, example_package_f);
 
 STATIC mp_obj_t example_package___init__(void) {
-    if (!MP_STATE_VM(example_package_initialised)) {
+    if (!MP_ROOT_POINTER(example_package_initialised)) {
         // __init__ for builtins is called each time the module is imported,
         //   so ensure that initialisation only happens once.
-        MP_STATE_VM(example_package_initialised) = true;
+        MP_ROOT_POINTER(example_package_initialised) = true;
         mp_printf(&mp_plat_print, "example_package.__init__\n");
     }
     return mp_const_none;

--- a/extmod/modlwip.c
+++ b/extmod/modlwip.c
@@ -118,15 +118,15 @@ sio_fd_t sio_open(u8_t dvnum) {
 }
 
 void sio_send(u8_t c, sio_fd_t fd) {
-    mp_obj_type_t *type = mp_obj_get_type(MP_STATE_VM(lwip_slip_stream));
+    mp_obj_type_t *type = mp_obj_get_type(MP_ROOT_POINTER(lwip_slip_stream));
     int error;
-    type->stream_p->write(MP_STATE_VM(lwip_slip_stream), &c, 1, &error);
+    type->stream_p->write(MP_ROOT_POINTER(lwip_slip_stream), &c, 1, &error);
 }
 
 u32_t sio_tryread(sio_fd_t fd, u8_t *data, u32_t len) {
-    mp_obj_type_t *type = mp_obj_get_type(MP_STATE_VM(lwip_slip_stream));
+    mp_obj_type_t *type = mp_obj_get_type(MP_ROOT_POINTER(lwip_slip_stream));
     int error;
-    mp_uint_t out_sz = type->stream_p->read(MP_STATE_VM(lwip_slip_stream), data, len, &error);
+    mp_uint_t out_sz = type->stream_p->read(MP_ROOT_POINTER(lwip_slip_stream), data, len, &error);
     if (out_sz == MP_STREAM_ERROR) {
         if (mp_is_nonblocking_error(error)) {
             return 0;
@@ -143,7 +143,7 @@ STATIC mp_obj_t lwip_slip_make_new(mp_obj_t type_in, size_t n_args, size_t n_kw,
 
     lwip_slip_obj.base.type = &lwip_slip_type;
 
-    MP_STATE_VM(lwip_slip_stream) = args[0];
+    MP_ROOT_POINTER(lwip_slip_stream) = args[0];
 
     ip_addr_t iplocal, ipremote;
     if (!ipaddr_aton(mp_obj_str_get_str(args[1]), &iplocal)) {

--- a/extmod/modnetwork.c
+++ b/extmod/modnetwork.c
@@ -61,27 +61,27 @@ char mod_network_hostname[MICROPY_PY_NETWORK_HOSTNAME_MAX_LEN] = MICROPY_PY_NETW
 #ifdef MICROPY_PORT_NETWORK_INTERFACES
 
 void mod_network_init(void) {
-    mp_obj_list_init(&MP_STATE_PORT(mod_network_nic_list), 0);
+    mp_obj_list_init(&MP_ROOT_POINTER(mod_network_nic_list), 0);
 }
 
 void mod_network_deinit(void) {
 }
 
 void mod_network_register_nic(mp_obj_t nic) {
-    for (mp_uint_t i = 0; i < MP_STATE_PORT(mod_network_nic_list).len; i++) {
-        if (MP_STATE_PORT(mod_network_nic_list).items[i] == nic) {
+    for (mp_uint_t i = 0; i < MP_ROOT_POINTER(mod_network_nic_list).len; i++) {
+        if (MP_ROOT_POINTER(mod_network_nic_list).items[i] == nic) {
             // nic already registered
             return;
         }
     }
     // nic not registered so add to list
-    mp_obj_list_append(MP_OBJ_FROM_PTR(&MP_STATE_PORT(mod_network_nic_list)), nic);
+    mp_obj_list_append(MP_OBJ_FROM_PTR(&MP_ROOT_POINTER(mod_network_nic_list)), nic);
 }
 
 mp_obj_t mod_network_find_nic(const uint8_t *ip) {
     // find a NIC that is suited to given IP address
-    for (mp_uint_t i = 0; i < MP_STATE_PORT(mod_network_nic_list).len; i++) {
-        mp_obj_t nic = MP_STATE_PORT(mod_network_nic_list).items[i];
+    for (mp_uint_t i = 0; i < MP_ROOT_POINTER(mod_network_nic_list).len; i++) {
+        mp_obj_t nic = MP_ROOT_POINTER(mod_network_nic_list).items[i];
         // TODO check IP suitability here
         // mod_network_nic_protocol_t *nic_protocol = (mod_network_nic_protocol_t *)MP_OBJ_TYPE_GET_SLOT(mp_obj_get_type(nic), protocol);
         return nic;
@@ -91,7 +91,7 @@ mp_obj_t mod_network_find_nic(const uint8_t *ip) {
 }
 
 STATIC mp_obj_t network_route(void) {
-    return MP_OBJ_FROM_PTR(&MP_STATE_PORT(mod_network_nic_list));
+    return MP_OBJ_FROM_PTR(&MP_ROOT_POINTER(mod_network_nic_list));
 }
 STATIC MP_DEFINE_CONST_FUN_OBJ_0(network_route_obj, network_route);
 

--- a/extmod/modos.c
+++ b/extmod/modos.c
@@ -67,7 +67,7 @@
 // Sync all filesystems.
 STATIC mp_obj_t mp_os_sync(void) {
     #if MICROPY_VFS_FAT
-    for (mp_vfs_mount_t *vfs = MP_STATE_VM(vfs_mount_table); vfs != NULL; vfs = vfs->next) {
+    for (mp_vfs_mount_t *vfs = MP_ROOT_POINTER(vfs_mount_table); vfs != NULL; vfs = vfs->next) {
         // this assumes that vfs->obj is fs_user_mount_t with block device functions
         disk_ioctl(MP_OBJ_TO_PTR(vfs->obj), CTRL_SYNC, NULL);
     }

--- a/extmod/modsocket.c
+++ b/extmod/modsocket.c
@@ -587,8 +587,8 @@ STATIC mp_obj_t mod_socket_getaddrinfo(size_t n_args, const mp_obj_t *args) {
 
     if (!have_ip) {
         // find a NIC that can do a name lookup
-        for (mp_uint_t i = 0; i < MP_STATE_PORT(mod_network_nic_list).len; i++) {
-            mp_obj_t nic = MP_STATE_PORT(mod_network_nic_list).items[i];
+        for (mp_uint_t i = 0; i < MP_ROOT_POINTER(mod_network_nic_list).len; i++) {
+            mp_obj_t nic = MP_ROOT_POINTER(mod_network_nic_list).items[i];
             mod_network_nic_protocol_t *nic_protocol = (mod_network_nic_protocol_t *)MP_OBJ_TYPE_GET_SLOT(mp_obj_get_type(nic), protocol);
             if (nic_protocol->gethostbyname != NULL) {
                 int ret = nic_protocol->gethostbyname(nic, host, hlen, out_ip);

--- a/extmod/nimble/nimble/nimble_npl_os.c
+++ b/extmod/nimble/nimble/nimble_npl_os.c
@@ -71,11 +71,11 @@ STATIC void *m_malloc_bluetooth(size_t size) {
     size += sizeof(mp_bluetooth_nimble_malloc_t);
     mp_bluetooth_nimble_malloc_t *alloc = m_malloc0(size);
     alloc->size = size;
-    alloc->next = MP_STATE_PORT(bluetooth_nimble_memory);
+    alloc->next = MP_ROOT_POINTER(bluetooth_nimble_memory);
     if (alloc->next) {
         alloc->next->prev = alloc;
     }
-    MP_STATE_PORT(bluetooth_nimble_memory) = alloc;
+    MP_ROOT_POINTER(bluetooth_nimble_memory) = alloc;
     return alloc->data;
 }
 
@@ -91,7 +91,7 @@ STATIC void m_free_bluetooth(void *ptr) {
     if (alloc->prev) {
         alloc->prev->next = alloc->next;
     } else {
-        MP_STATE_PORT(bluetooth_nimble_memory) = NULL;
+        MP_ROOT_POINTER(bluetooth_nimble_memory) = NULL;
     }
     m_free(alloc
     #if MICROPY_MALLOC_USES_ALLOCATED_SIZE
@@ -104,7 +104,7 @@ STATIC void m_free_bluetooth(void *ptr) {
 // If it isn't, that means that it's from a previous soft-reset cycle.
 STATIC bool is_valid_nimble_malloc(void *ptr) {
     DEBUG_MALLOC_printf("NIMBLE is_valid_nimble_malloc(%p)\n", ptr);
-    mp_bluetooth_nimble_malloc_t *alloc = MP_STATE_PORT(bluetooth_nimble_memory);
+    mp_bluetooth_nimble_malloc_t *alloc = MP_ROOT_POINTER(bluetooth_nimble_memory);
     while (alloc) {
         DEBUG_MALLOC_printf("NIMBLE   checking: %p\n", alloc->data);
         if (alloc->data == ptr) {

--- a/extmod/os_dupterm.c
+++ b/extmod/os_dupterm.c
@@ -39,8 +39,8 @@
 #include "shared/runtime/interrupt_char.h"
 
 void mp_os_deactivate(size_t dupterm_idx, const char *msg, mp_obj_t exc) {
-    mp_obj_t term = MP_STATE_VM(dupterm_objs[dupterm_idx]);
-    MP_STATE_VM(dupterm_objs[dupterm_idx]) = MP_OBJ_NULL;
+    mp_obj_t term = MP_ROOT_POINTER(dupterm_objs[dupterm_idx]);
+    MP_ROOT_POINTER(dupterm_objs[dupterm_idx]) = MP_OBJ_NULL;
     mp_printf(&mp_plat_print, msg);
     if (exc != MP_OBJ_NULL) {
         mp_obj_print_exception(&mp_plat_print, exc);
@@ -58,7 +58,7 @@ uintptr_t mp_os_dupterm_poll(uintptr_t poll_flags) {
     uintptr_t poll_flags_out = 0;
 
     for (size_t idx = 0; idx < MICROPY_PY_OS_DUPTERM; ++idx) {
-        mp_obj_t s = MP_STATE_VM(dupterm_objs[idx]);
+        mp_obj_t s = MP_ROOT_POINTER(dupterm_objs[idx]);
         if (s == MP_OBJ_NULL) {
             continue;
         }
@@ -95,16 +95,16 @@ uintptr_t mp_os_dupterm_poll(uintptr_t poll_flags) {
 
 int mp_os_dupterm_rx_chr(void) {
     for (size_t idx = 0; idx < MICROPY_PY_OS_DUPTERM; ++idx) {
-        if (MP_STATE_VM(dupterm_objs[idx]) == MP_OBJ_NULL) {
+        if (MP_ROOT_POINTER(dupterm_objs[idx]) == MP_OBJ_NULL) {
             continue;
         }
 
         #if MICROPY_PY_OS_DUPTERM_BUILTIN_STREAM
-        if (mp_os_dupterm_is_builtin_stream(MP_STATE_VM(dupterm_objs[idx]))) {
+        if (mp_os_dupterm_is_builtin_stream(MP_ROOT_POINTER(dupterm_objs[idx]))) {
             byte buf[1];
             int errcode = 0;
-            const mp_stream_p_t *stream_p = mp_get_stream(MP_STATE_VM(dupterm_objs[idx]));
-            mp_uint_t out_sz = stream_p->read(MP_STATE_VM(dupterm_objs[idx]), buf, 1, &errcode);
+            const mp_stream_p_t *stream_p = mp_get_stream(MP_ROOT_POINTER(dupterm_objs[idx]));
+            mp_uint_t out_sz = stream_p->read(MP_ROOT_POINTER(dupterm_objs[idx]), buf, 1, &errcode);
             if (errcode == 0 && out_sz != 0) {
                 return buf[0];
             } else {
@@ -117,8 +117,8 @@ int mp_os_dupterm_rx_chr(void) {
         if (nlr_push(&nlr) == 0) {
             byte buf[1];
             int errcode;
-            const mp_stream_p_t *stream_p = mp_get_stream(MP_STATE_VM(dupterm_objs[idx]));
-            mp_uint_t out_sz = stream_p->read(MP_STATE_VM(dupterm_objs[idx]), buf, 1, &errcode);
+            const mp_stream_p_t *stream_p = mp_get_stream(MP_ROOT_POINTER(dupterm_objs[idx]));
+            mp_uint_t out_sz = stream_p->read(MP_ROOT_POINTER(dupterm_objs[idx]), buf, 1, &errcode);
             if (out_sz == 0) {
                 nlr_pop();
                 mp_os_deactivate(idx, "dupterm: EOF received, deactivating\n", MP_OBJ_NULL);
@@ -150,22 +150,22 @@ int mp_os_dupterm_rx_chr(void) {
 
 void mp_os_dupterm_tx_strn(const char *str, size_t len) {
     for (size_t idx = 0; idx < MICROPY_PY_OS_DUPTERM; ++idx) {
-        if (MP_STATE_VM(dupterm_objs[idx]) == MP_OBJ_NULL) {
+        if (MP_ROOT_POINTER(dupterm_objs[idx]) == MP_OBJ_NULL) {
             continue;
         }
 
         #if MICROPY_PY_OS_DUPTERM_BUILTIN_STREAM
-        if (mp_os_dupterm_is_builtin_stream(MP_STATE_VM(dupterm_objs[idx]))) {
+        if (mp_os_dupterm_is_builtin_stream(MP_ROOT_POINTER(dupterm_objs[idx]))) {
             int errcode = 0;
-            const mp_stream_p_t *stream_p = mp_get_stream(MP_STATE_VM(dupterm_objs[idx]));
-            stream_p->write(MP_STATE_VM(dupterm_objs[idx]), str, len, &errcode);
+            const mp_stream_p_t *stream_p = mp_get_stream(MP_ROOT_POINTER(dupterm_objs[idx]));
+            stream_p->write(MP_ROOT_POINTER(dupterm_objs[idx]), str, len, &errcode);
             continue;
         }
         #endif
 
         nlr_buf_t nlr;
         if (nlr_push(&nlr) == 0) {
-            mp_stream_write(MP_STATE_VM(dupterm_objs[idx]), str, len, MP_STREAM_RW_WRITE);
+            mp_stream_write(MP_ROOT_POINTER(dupterm_objs[idx]), str, len, MP_STREAM_RW_WRITE);
             nlr_pop();
         } else {
             mp_os_deactivate(idx, "dupterm: Exception in write() method, deactivating: ", MP_OBJ_FROM_PTR(nlr.ret_val));
@@ -183,15 +183,15 @@ STATIC mp_obj_t mp_os_dupterm(size_t n_args, const mp_obj_t *args) {
         mp_raise_ValueError(MP_ERROR_TEXT("invalid dupterm index"));
     }
 
-    mp_obj_t previous_obj = MP_STATE_VM(dupterm_objs[idx]);
+    mp_obj_t previous_obj = MP_ROOT_POINTER(dupterm_objs[idx]);
     if (previous_obj == MP_OBJ_NULL) {
         previous_obj = mp_const_none;
     }
     if (args[0] == mp_const_none) {
-        MP_STATE_VM(dupterm_objs[idx]) = MP_OBJ_NULL;
+        MP_ROOT_POINTER(dupterm_objs[idx]) = MP_OBJ_NULL;
     } else {
         mp_get_stream_raise(args[0], MP_STREAM_OP_READ | MP_STREAM_OP_WRITE | MP_STREAM_OP_IOCTL);
-        MP_STATE_VM(dupterm_objs[idx]) = args[0];
+        MP_ROOT_POINTER(dupterm_objs[idx]) = args[0];
     }
 
     #if MICROPY_PY_OS_DUPTERM_STREAM_DETACHED_ATTACHED

--- a/extmod/os_dupterm.c
+++ b/extmod/os_dupterm.c
@@ -39,8 +39,8 @@
 #include "shared/runtime/interrupt_char.h"
 
 void mp_os_deactivate(size_t dupterm_idx, const char *msg, mp_obj_t exc) {
-    mp_obj_t term = MP_ROOT_POINTER(dupterm_objs[dupterm_idx]);
-    MP_ROOT_POINTER(dupterm_objs[dupterm_idx]) = MP_OBJ_NULL;
+    mp_obj_t term = MP_ROOT_POINTER(dupterm_objs)[dupterm_idx];
+    MP_ROOT_POINTER(dupterm_objs)[dupterm_idx] = MP_OBJ_NULL;
     mp_printf(&mp_plat_print, msg);
     if (exc != MP_OBJ_NULL) {
         mp_obj_print_exception(&mp_plat_print, exc);
@@ -58,7 +58,7 @@ uintptr_t mp_os_dupterm_poll(uintptr_t poll_flags) {
     uintptr_t poll_flags_out = 0;
 
     for (size_t idx = 0; idx < MICROPY_PY_OS_DUPTERM; ++idx) {
-        mp_obj_t s = MP_ROOT_POINTER(dupterm_objs[idx]);
+        mp_obj_t s = MP_ROOT_POINTER(dupterm_objs)[idx];
         if (s == MP_OBJ_NULL) {
             continue;
         }
@@ -95,16 +95,16 @@ uintptr_t mp_os_dupterm_poll(uintptr_t poll_flags) {
 
 int mp_os_dupterm_rx_chr(void) {
     for (size_t idx = 0; idx < MICROPY_PY_OS_DUPTERM; ++idx) {
-        if (MP_ROOT_POINTER(dupterm_objs[idx]) == MP_OBJ_NULL) {
+        if (MP_ROOT_POINTER(dupterm_objs)[idx] == MP_OBJ_NULL) {
             continue;
         }
 
         #if MICROPY_PY_OS_DUPTERM_BUILTIN_STREAM
-        if (mp_os_dupterm_is_builtin_stream(MP_ROOT_POINTER(dupterm_objs[idx]))) {
+        if (mp_os_dupterm_is_builtin_stream(MP_ROOT_POINTER(dupterm_objs)[idx])) {
             byte buf[1];
             int errcode = 0;
-            const mp_stream_p_t *stream_p = mp_get_stream(MP_ROOT_POINTER(dupterm_objs[idx]));
-            mp_uint_t out_sz = stream_p->read(MP_ROOT_POINTER(dupterm_objs[idx]), buf, 1, &errcode);
+            const mp_stream_p_t *stream_p = mp_get_stream(MP_ROOT_POINTER(dupterm_objs)[idx]);
+            mp_uint_t out_sz = stream_p->read(MP_ROOT_POINTER(dupterm_objs)[idx], buf, 1, &errcode);
             if (errcode == 0 && out_sz != 0) {
                 return buf[0];
             } else {
@@ -117,8 +117,8 @@ int mp_os_dupterm_rx_chr(void) {
         if (nlr_push(&nlr) == 0) {
             byte buf[1];
             int errcode;
-            const mp_stream_p_t *stream_p = mp_get_stream(MP_ROOT_POINTER(dupterm_objs[idx]));
-            mp_uint_t out_sz = stream_p->read(MP_ROOT_POINTER(dupterm_objs[idx]), buf, 1, &errcode);
+            const mp_stream_p_t *stream_p = mp_get_stream(MP_ROOT_POINTER(dupterm_objs)[idx]);
+            mp_uint_t out_sz = stream_p->read(MP_ROOT_POINTER(dupterm_objs)[idx], buf, 1, &errcode);
             if (out_sz == 0) {
                 nlr_pop();
                 mp_os_deactivate(idx, "dupterm: EOF received, deactivating\n", MP_OBJ_NULL);
@@ -150,22 +150,22 @@ int mp_os_dupterm_rx_chr(void) {
 
 void mp_os_dupterm_tx_strn(const char *str, size_t len) {
     for (size_t idx = 0; idx < MICROPY_PY_OS_DUPTERM; ++idx) {
-        if (MP_ROOT_POINTER(dupterm_objs[idx]) == MP_OBJ_NULL) {
+        if (MP_ROOT_POINTER(dupterm_objs)[idx] == MP_OBJ_NULL) {
             continue;
         }
 
         #if MICROPY_PY_OS_DUPTERM_BUILTIN_STREAM
-        if (mp_os_dupterm_is_builtin_stream(MP_ROOT_POINTER(dupterm_objs[idx]))) {
+        if (mp_os_dupterm_is_builtin_stream(MP_ROOT_POINTER(dupterm_objs)[idx])) {
             int errcode = 0;
-            const mp_stream_p_t *stream_p = mp_get_stream(MP_ROOT_POINTER(dupterm_objs[idx]));
-            stream_p->write(MP_ROOT_POINTER(dupterm_objs[idx]), str, len, &errcode);
+            const mp_stream_p_t *stream_p = mp_get_stream(MP_ROOT_POINTER(dupterm_objs)[idx]);
+            stream_p->write(MP_ROOT_POINTER(dupterm_objs)[idx], str, len, &errcode);
             continue;
         }
         #endif
 
         nlr_buf_t nlr;
         if (nlr_push(&nlr) == 0) {
-            mp_stream_write(MP_ROOT_POINTER(dupterm_objs[idx]), str, len, MP_STREAM_RW_WRITE);
+            mp_stream_write(MP_ROOT_POINTER(dupterm_objs)[idx], str, len, MP_STREAM_RW_WRITE);
             nlr_pop();
         } else {
             mp_os_deactivate(idx, "dupterm: Exception in write() method, deactivating: ", MP_OBJ_FROM_PTR(nlr.ret_val));
@@ -183,15 +183,15 @@ STATIC mp_obj_t mp_os_dupterm(size_t n_args, const mp_obj_t *args) {
         mp_raise_ValueError(MP_ERROR_TEXT("invalid dupterm index"));
     }
 
-    mp_obj_t previous_obj = MP_ROOT_POINTER(dupterm_objs[idx]);
+    mp_obj_t previous_obj = MP_ROOT_POINTER(dupterm_objs)[idx];
     if (previous_obj == MP_OBJ_NULL) {
         previous_obj = mp_const_none;
     }
     if (args[0] == mp_const_none) {
-        MP_ROOT_POINTER(dupterm_objs[idx]) = MP_OBJ_NULL;
+        MP_ROOT_POINTER(dupterm_objs)[idx] = MP_OBJ_NULL;
     } else {
         mp_get_stream_raise(args[0], MP_STREAM_OP_READ | MP_STREAM_OP_WRITE | MP_STREAM_OP_IOCTL);
-        MP_ROOT_POINTER(dupterm_objs[idx]) = args[0];
+        MP_ROOT_POINTER(dupterm_objs)[idx] = args[0];
     }
 
     #if MICROPY_PY_OS_DUPTERM_STREAM_DETACHED_ATTACHED

--- a/ports/cc3200/ftp/ftp.c
+++ b/ports/cc3200/ftp/ftp.c
@@ -1071,7 +1071,7 @@ static ftp_result_t ftp_list_dir (char *list, uint32_t maxlistsize, uint32_t *li
 #endif
         if (ftp_data.listroot) {
             // root directory "hack"
-            mp_vfs_mount_t *vfs = MP_STATE_VM(vfs_mount_table);
+            mp_vfs_mount_t *vfs = MP_ROOT_POINTER(vfs_mount_table);
             int i = ftp_data.volcount;
             while (vfs != NULL && i != 0) {
                 vfs = vfs->next;

--- a/ports/cc3200/hal/cc3200_hal.c
+++ b/ports/cc3200/hal/cc3200_hal.c
@@ -142,12 +142,12 @@ void mp_hal_delay_ms(mp_uint_t delay) {
 }
 
 void mp_hal_stdout_tx_strn(const char *str, size_t len) {
-    if (MP_STATE_PORT(os_term_dup_obj)) {
-        if (mp_obj_is_type(MP_STATE_PORT(os_term_dup_obj)->stream_o, &pyb_uart_type)) {
-            uart_tx_strn(MP_STATE_PORT(os_term_dup_obj)->stream_o, str, len);
+    if (MP_ROOT_POINTER(os_term_dup_obj)) {
+        if (mp_obj_is_type(MP_ROOT_POINTER(os_term_dup_obj)->stream_o, &pyb_uart_type)) {
+            uart_tx_strn(MP_ROOT_POINTER(os_term_dup_obj)->stream_o, str, len);
         } else {
-            MP_STATE_PORT(os_term_dup_obj)->write[2] = mp_obj_new_str_of_type(&mp_type_str, (const byte *)str, len);
-            mp_call_method_n_kw(1, 0, MP_STATE_PORT(os_term_dup_obj)->write);
+            MP_ROOT_POINTER(os_term_dup_obj)->write[2] = mp_obj_new_str_of_type(&mp_type_str, (const byte *)str, len);
+            mp_call_method_n_kw(1, 0, MP_ROOT_POINTER(os_term_dup_obj)->write);
         }
     }
     // and also to telnet
@@ -159,14 +159,14 @@ int mp_hal_stdin_rx_chr(void) {
         // read telnet first
         if (telnet_rx_any()) {
             return telnet_rx_char();
-        } else if (MP_STATE_PORT(os_term_dup_obj)) { // then the stdio_dup
-            if (mp_obj_is_type(MP_STATE_PORT(os_term_dup_obj)->stream_o, &pyb_uart_type)) {
-                if (uart_rx_any(MP_STATE_PORT(os_term_dup_obj)->stream_o)) {
-                    return uart_rx_char(MP_STATE_PORT(os_term_dup_obj)->stream_o);
+        } else if (MP_ROOT_POINTER(os_term_dup_obj)) { // then the stdio_dup
+            if (mp_obj_is_type(MP_ROOT_POINTER(os_term_dup_obj)->stream_o, &pyb_uart_type)) {
+                if (uart_rx_any(MP_ROOT_POINTER(os_term_dup_obj)->stream_o)) {
+                    return uart_rx_char(MP_ROOT_POINTER(os_term_dup_obj)->stream_o);
                 }
             } else {
-                MP_STATE_PORT(os_term_dup_obj)->read[2] = mp_obj_new_int(1);
-                mp_obj_t data = mp_call_method_n_kw(1, 0, MP_STATE_PORT(os_term_dup_obj)->read);
+                MP_ROOT_POINTER(os_term_dup_obj)->read[2] = mp_obj_new_int(1);
+                mp_obj_t data = mp_call_method_n_kw(1, 0, MP_ROOT_POINTER(os_term_dup_obj)->read);
                 // data len is > 0
                 if (mp_obj_is_true(data)) {
                     mp_buffer_info_t bufinfo;

--- a/ports/cc3200/misc/mpirq.c
+++ b/ports/cc3200/misc/mpirq.c
@@ -58,7 +58,7 @@ STATIC uint8_t mp_irq_priorities[] = { INT_PRIORITY_LVL_7, INT_PRIORITY_LVL_6, I
  ******************************************************************************/
 void mp_irq_init0 (void) {
     // initialize the callback objects list
-    mp_obj_list_init(&MP_STATE_PORT(mp_irq_obj_list), 0);
+    mp_obj_list_init(&MP_ROOT_POINTER(mp_irq_obj_list), 0);
 }
 
 mp_obj_t mp_irq_new (mp_obj_t parent, mp_obj_t handler, const mp_irq_methods_t *methods) {
@@ -69,13 +69,13 @@ mp_obj_t mp_irq_new (mp_obj_t parent, mp_obj_t handler, const mp_irq_methods_t *
     self->isenabled = true;
     // remove it in case it was already registered
     mp_irq_remove(parent);
-    mp_obj_list_append(&MP_STATE_PORT(mp_irq_obj_list), self);
+    mp_obj_list_append(&MP_ROOT_POINTER(mp_irq_obj_list), self);
     return self;
 }
 
 mp_irq_obj_t *mp_irq_find (mp_obj_t parent) {
-    for (mp_uint_t i = 0; i < MP_STATE_PORT(mp_irq_obj_list).len; i++) {
-        mp_irq_obj_t *callback_obj = ((mp_irq_obj_t *)(MP_STATE_PORT(mp_irq_obj_list).items[i]));
+    for (mp_uint_t i = 0; i < MP_ROOT_POINTER(mp_irq_obj_list).len; i++) {
+        mp_irq_obj_t *callback_obj = ((mp_irq_obj_t *)(MP_ROOT_POINTER(mp_irq_obj_list).items[i]));
         if (callback_obj->parent == parent) {
             return callback_obj;
         }
@@ -85,8 +85,8 @@ mp_irq_obj_t *mp_irq_find (mp_obj_t parent) {
 
 void mp_irq_wake_all (void) {
     // re-enable all active callback objects one by one
-    for (mp_uint_t i = 0; i < MP_STATE_PORT(mp_irq_obj_list).len; i++) {
-        mp_irq_obj_t *callback_obj = ((mp_irq_obj_t *)(MP_STATE_PORT(mp_irq_obj_list).items[i]));
+    for (mp_uint_t i = 0; i < MP_ROOT_POINTER(mp_irq_obj_list).len; i++) {
+        mp_irq_obj_t *callback_obj = ((mp_irq_obj_t *)(MP_ROOT_POINTER(mp_irq_obj_list).items[i]));
         if (callback_obj->isenabled) {
             callback_obj->methods->enable(callback_obj->parent);
         }
@@ -95,8 +95,8 @@ void mp_irq_wake_all (void) {
 
 void mp_irq_disable_all (void) {
     // re-enable all active callback objects one by one
-    for (mp_uint_t i = 0; i < MP_STATE_PORT(mp_irq_obj_list).len; i++) {
-        mp_irq_obj_t *callback_obj = ((mp_irq_obj_t *)(MP_STATE_PORT(mp_irq_obj_list).items[i]));
+    for (mp_uint_t i = 0; i < MP_ROOT_POINTER(mp_irq_obj_list).len; i++) {
+        mp_irq_obj_t *callback_obj = ((mp_irq_obj_t *)(MP_ROOT_POINTER(mp_irq_obj_list).items[i]));
         callback_obj->methods->disable(callback_obj->parent);
     }
 }
@@ -104,7 +104,7 @@ void mp_irq_disable_all (void) {
 void mp_irq_remove (const mp_obj_t parent) {
     mp_irq_obj_t *callback_obj;
     if ((callback_obj = mp_irq_find(parent))) {
-        mp_obj_list_remove(&MP_STATE_PORT(mp_irq_obj_list), callback_obj);
+        mp_obj_list_remove(&MP_ROOT_POINTER(mp_irq_obj_list), callback_obj);
     }
 }
 

--- a/ports/cc3200/mods/modmachine.c
+++ b/ports/cc3200/mods/modmachine.c
@@ -125,7 +125,7 @@ STATIC MP_DEFINE_CONST_FUN_OBJ_0(machine_unique_id_obj, machine_unique_id);
 
 STATIC mp_obj_t machine_main(mp_obj_t main) {
     if (mp_obj_is_str(main)) {
-        MP_STATE_PORT(machine_config_main) = main;
+        MP_ROOT_POINTER(machine_config_main) = main;
     } else {
         mp_raise_ValueError(MP_ERROR_TEXT("invalid argument(s) value"));
     }

--- a/ports/cc3200/mods/modos.c
+++ b/ports/cc3200/mods/modos.c
@@ -67,8 +67,8 @@ STATIC os_term_dup_obj_t os_term_dup_obj;
 void osmount_unmount_all (void) {
     //TODO
     /*
-    for (mp_uint_t i = 0; i < MP_STATE_PORT(mount_obj_list).len; i++) {
-        os_fs_mount_t *mount_obj = ((os_fs_mount_t *)(MP_STATE_PORT(mount_obj_list).items[i]));
+    for (mp_uint_t i = 0; i < MP_ROOT_POINTER(mount_obj_list).len; i++) {
+        os_fs_mount_t *mount_obj = ((os_fs_mount_t *)(MP_ROOT_POINTER(mount_obj_list).items[i]));
         unmount(mount_obj);
     }
     */
@@ -122,15 +122,15 @@ STATIC MP_DEFINE_CONST_FUN_OBJ_1(os_urandom_obj, os_urandom);
 
 STATIC mp_obj_t os_dupterm(uint n_args, const mp_obj_t *args) {
     if (n_args == 0) {
-        if (MP_STATE_PORT(os_term_dup_obj) == MP_OBJ_NULL) {
+        if (MP_ROOT_POINTER(os_term_dup_obj) == MP_OBJ_NULL) {
             return mp_const_none;
         } else {
-            return MP_STATE_PORT(os_term_dup_obj)->stream_o;
+            return MP_ROOT_POINTER(os_term_dup_obj)->stream_o;
         }
     } else {
         mp_obj_t stream_o = args[0];
         if (stream_o == mp_const_none) {
-            MP_STATE_PORT(os_term_dup_obj) = MP_OBJ_NULL;
+            MP_ROOT_POINTER(os_term_dup_obj) = MP_OBJ_NULL;
         } else {
             if (!mp_obj_is_type(stream_o, &pyb_uart_type)) {
                 // must be a stream-like object providing at least read and write methods
@@ -138,7 +138,7 @@ STATIC mp_obj_t os_dupterm(uint n_args, const mp_obj_t *args) {
                 mp_load_method(stream_o, MP_QSTR_write, os_term_dup_obj.write);
             }
             os_term_dup_obj.stream_o = stream_o;
-            MP_STATE_PORT(os_term_dup_obj) = &os_term_dup_obj;
+            MP_ROOT_POINTER(os_term_dup_obj) = &os_term_dup_obj;
         }
         return mp_const_none;
     }

--- a/ports/cc3200/mods/pybsleep.c
+++ b/ports/cc3200/mods/pybsleep.c
@@ -155,7 +155,7 @@ void pyb_sleep_pre_init (void) {
 
 void pyb_sleep_init0 (void) {
     // initialize the sleep objects list
-    mp_obj_list_init(&MP_STATE_PORT(pyb_sleep_obj_list), 0);
+    mp_obj_list_init(&MP_ROOT_POINTER(pyb_sleep_obj_list), 0);
 
     // register and enable the PRCM interrupt
     osi_InterruptRegister(INT_PRCM, (P_OSI_INTR_ENTRY)PRCMInterruptHandler, INT_PRIORITY_LVL_1);
@@ -216,13 +216,13 @@ void pyb_sleep_add (const mp_obj_t obj, WakeUpCB_t wakeup) {
     sleep_obj->wakeup = wakeup;
     // remove it in case it was already registered
     pyb_sleep_remove (obj);
-    mp_obj_list_append(&MP_STATE_PORT(pyb_sleep_obj_list), sleep_obj);
+    mp_obj_list_append(&MP_ROOT_POINTER(pyb_sleep_obj_list), sleep_obj);
 }
 
 void pyb_sleep_remove (const mp_obj_t obj) {
     pyb_sleep_obj_t *sleep_obj;
     if ((sleep_obj = pyb_sleep_find(obj))) {
-        mp_obj_list_remove(&MP_STATE_PORT(pyb_sleep_obj_list), sleep_obj);
+        mp_obj_list_remove(&MP_ROOT_POINTER(pyb_sleep_obj_list), sleep_obj);
     }
 }
 
@@ -305,9 +305,9 @@ pybsleep_wake_reason_t pyb_sleep_get_wake_reason (void) {
  DEFINE PRIVATE FUNCTIONS
  ******************************************************************************/
 STATIC pyb_sleep_obj_t *pyb_sleep_find (mp_obj_t obj) {
-    for (mp_uint_t i = 0; i < MP_STATE_PORT(pyb_sleep_obj_list).len; i++) {
+    for (mp_uint_t i = 0; i < MP_ROOT_POINTER(pyb_sleep_obj_list).len; i++) {
         // search for the object and then remove it
-        pyb_sleep_obj_t *sleep_obj = ((pyb_sleep_obj_t *)(MP_STATE_PORT(pyb_sleep_obj_list).items[i]));
+        pyb_sleep_obj_t *sleep_obj = ((pyb_sleep_obj_t *)(MP_ROOT_POINTER(pyb_sleep_obj_list).items[i]));
         if (sleep_obj->obj == obj) {
             return sleep_obj;
         }
@@ -520,8 +520,8 @@ STATIC void PRCMInterruptHandler (void) {
 }
 
 STATIC void pyb_sleep_obj_wakeup (void) {
-    for (mp_uint_t i = 0; i < MP_STATE_PORT(pyb_sleep_obj_list).len; i++) {
-        pyb_sleep_obj_t *sleep_obj = ((pyb_sleep_obj_t *)MP_STATE_PORT(pyb_sleep_obj_list).items[i]);
+    for (mp_uint_t i = 0; i < MP_ROOT_POINTER(pyb_sleep_obj_list).len; i++) {
+        pyb_sleep_obj_t *sleep_obj = ((pyb_sleep_obj_t *)MP_ROOT_POINTER(pyb_sleep_obj_list).items[i]);
         sleep_obj->wakeup(sleep_obj->obj);
     }
 }

--- a/ports/cc3200/mods/pybtimer.c
+++ b/ports/cc3200/mods/pybtimer.c
@@ -123,7 +123,7 @@ STATIC void TIMER3BIntHandler(void);
  DEFINE PUBLIC FUNCTIONS
  ******************************************************************************/
 void timer_init0 (void) {
-    mp_obj_list_init(&MP_STATE_PORT(pyb_timer_channel_obj_list), 0);
+    mp_obj_list_init(&MP_ROOT_POINTER(pyb_timer_channel_obj_list), 0);
 }
 
 /******************************************************************************
@@ -146,8 +146,8 @@ STATIC int pyb_timer_channel_irq_flags (mp_obj_t self_in) {
 }
 
 STATIC pyb_timer_channel_obj_t *pyb_timer_channel_find (uint32_t timer, uint16_t channel_n) {
-    for (mp_uint_t i = 0; i < MP_STATE_PORT(pyb_timer_channel_obj_list).len; i++) {
-        pyb_timer_channel_obj_t *ch = ((pyb_timer_channel_obj_t *)(MP_STATE_PORT(pyb_timer_channel_obj_list).items[i]));
+    for (mp_uint_t i = 0; i < MP_ROOT_POINTER(pyb_timer_channel_obj_list).len; i++) {
+        pyb_timer_channel_obj_t *ch = ((pyb_timer_channel_obj_t *)(MP_ROOT_POINTER(pyb_timer_channel_obj_list).items[i]));
         // any 32-bit timer must be matched by any of its 16-bit versions
         if (ch->timer->timer == timer && ((ch->channel & TIMER_A) == channel_n || (ch->channel & TIMER_B) == channel_n)) {
             return ch;
@@ -159,7 +159,7 @@ STATIC pyb_timer_channel_obj_t *pyb_timer_channel_find (uint32_t timer, uint16_t
 STATIC void pyb_timer_channel_remove (pyb_timer_channel_obj_t *ch) {
     pyb_timer_channel_obj_t *channel;
     if ((channel = pyb_timer_channel_find(ch->timer->timer, ch->channel))) {
-        mp_obj_list_remove(&MP_STATE_PORT(pyb_timer_channel_obj_list), channel);
+        mp_obj_list_remove(&MP_ROOT_POINTER(pyb_timer_channel_obj_list), channel);
         // unregister it with the sleep module
         pyb_sleep_remove((const mp_obj_t)channel);
     }
@@ -168,7 +168,7 @@ STATIC void pyb_timer_channel_remove (pyb_timer_channel_obj_t *ch) {
 STATIC void pyb_timer_channel_add (pyb_timer_channel_obj_t *ch) {
     // remove it in case it already exists
     pyb_timer_channel_remove(ch);
-    mp_obj_list_append(&MP_STATE_PORT(pyb_timer_channel_obj_list), ch);
+    mp_obj_list_append(&MP_ROOT_POINTER(pyb_timer_channel_obj_list), ch);
     // register it with the sleep module
     pyb_sleep_add((const mp_obj_t)ch, (WakeUpCB_t)timer_channel_init);
 }

--- a/ports/cc3200/mods/pybuart.c
+++ b/ports/cc3200/mods/pybuart.c
@@ -120,8 +120,8 @@ STATIC const mp_obj_t pyb_uart_def_pin[PYB_NUM_UARTS][2] = { {&pin_GP1, &pin_GP2
  ******************************************************************************/
 void uart_init0 (void) {
     // save references of the UART objects, to prevent the read buffers from being trashed by the gc
-    MP_STATE_PORT(pyb_uart_objs)[0] = &pyb_uart_obj[0];
-    MP_STATE_PORT(pyb_uart_objs)[1] = &pyb_uart_obj[1];
+    MP_ROOT_POINTER(pyb_uart_objs)[0] = &pyb_uart_obj[0];
+    MP_ROOT_POINTER(pyb_uart_objs)[1] = &pyb_uart_obj[1];
 }
 
 uint32_t uart_rx_any(pyb_uart_obj_t *self) {
@@ -249,7 +249,7 @@ STATIC void UARTGenericIntHandler(uint32_t uart_id) {
         MAP_UARTIntClear(self->reg, UART_INT_RX | UART_INT_RT);
         while (UARTCharsAvail(self->reg)) {
             int data = MAP_UARTCharGetNonBlocking(self->reg);
-            if (MP_STATE_PORT(os_term_dup_obj) && MP_STATE_PORT(os_term_dup_obj)->stream_o == self && data == mp_interrupt_char) {
+            if (MP_ROOT_POINTER(os_term_dup_obj) && MP_ROOT_POINTER(os_term_dup_obj)->stream_o == self && data == mp_interrupt_char) {
                 // raise an exception when interrupts are finished
                 mp_sched_keyboard_interrupt();
             } else { // there's always a read buffer available

--- a/ports/cc3200/mpconfigport.h
+++ b/ports/cc3200/mpconfigport.h
@@ -137,8 +137,6 @@
 #define MICROPY_PORT_CONSTANTS \
     { MP_ROM_QSTR(MP_QSTR_machine),     MP_ROM_PTR(&mp_module_machine) },  \
 
-#define MP_STATE_PORT MP_STATE_VM
-
 // type definitions for the specific machine
 #define MICROPY_MAKE_POINTER_CALLABLE(p)            ((void *)((mp_uint_t)(p) | 1))
 #define MP_SSIZE_MAX                                (0x7FFFFFFF)

--- a/ports/cc3200/mptask.c
+++ b/ports/cc3200/mptask.c
@@ -174,7 +174,7 @@ soft_reset:
     mp_obj_list_append(mp_sys_path, MP_OBJ_NEW_QSTR(MP_QSTR__slash_flash_slash_lib));
 
     // reset config variables; they should be set by boot.py
-    MP_STATE_PORT(machine_config_main) = MP_OBJ_NULL;
+    MP_ROOT_POINTER(machine_config_main) = MP_OBJ_NULL;
 
     if (!safeboot) {
         // run boot.py
@@ -198,10 +198,10 @@ soft_reset:
         // run the main script from the current directory.
         if (pyexec_mode_kind == PYEXEC_MODE_FRIENDLY_REPL) {
             const char *main_py;
-            if (MP_STATE_PORT(machine_config_main) == MP_OBJ_NULL) {
+            if (MP_ROOT_POINTER(machine_config_main) == MP_OBJ_NULL) {
                 main_py = "main.py";
             } else {
-                main_py = mp_obj_str_get_str(MP_STATE_PORT(machine_config_main));
+                main_py = mp_obj_str_get_str(MP_ROOT_POINTER(machine_config_main));
             }
             int ret = pyexec_file_if_exists(main_py);
             if (ret & PYEXEC_FORCED_EXIT) {
@@ -335,11 +335,11 @@ STATIC void mptask_init_sflash_filesystem(void) {
     vfs->len = 6;
     vfs->obj = MP_OBJ_FROM_PTR(vfs_fat);
     vfs->next = NULL;
-    MP_STATE_VM(vfs_mount_table) = vfs;
+    MP_ROOT_POINTER(vfs_mount_table) = vfs;
 
     // The current directory is used as the boot up directory.
     // It is set to the internal flash filesystem by default.
-    MP_STATE_PORT(vfs_cur) = vfs;
+    MP_ROOT_POINTER(vfs_cur) = vfs;
 
     // create /flash/sys, /flash/lib and /flash/cert if they don't exist
     if (FR_OK != f_chdir(&vfs_fat->fatfs, "/sys")) {

--- a/ports/esp32/machine_i2s.c
+++ b/ports/esp32/machine_i2s.c
@@ -149,7 +149,7 @@ STATIC const int8_t i2s_frame_map[NUM_I2S_USER_FORMATS][I2S_RX_FRAME_SIZE_IN_BYT
 
 void machine_i2s_init0() {
     for (i2s_port_t p = 0; p < I2S_NUM_AUTO; p++) {
-        MP_STATE_PORT(machine_i2s_obj)[p] = NULL;
+        MP_ROOT_POINTER(machine_i2s_obj)[p] = NULL;
     }
 }
 
@@ -510,13 +510,13 @@ STATIC mp_obj_t machine_i2s_make_new(const mp_obj_type_t *type, size_t n_pos_arg
     }
 
     machine_i2s_obj_t *self;
-    if (MP_STATE_PORT(machine_i2s_obj)[port] == NULL) {
+    if (MP_ROOT_POINTER(machine_i2s_obj)[port] == NULL) {
         self = m_new_obj_with_finaliser(machine_i2s_obj_t);
         self->base.type = &machine_i2s_type;
-        MP_STATE_PORT(machine_i2s_obj)[port] = self;
+        MP_ROOT_POINTER(machine_i2s_obj)[port] = self;
         self->port = port;
     } else {
-        self = MP_STATE_PORT(machine_i2s_obj)[port];
+        self = MP_ROOT_POINTER(machine_i2s_obj)[port];
         machine_i2s_deinit(self);
     }
 

--- a/ports/esp32/machine_pin.c
+++ b/ports/esp32/machine_pin.c
@@ -76,7 +76,7 @@ void machine_pins_init(void) {
         gpio_install_isr_service(0);
         did_install = true;
     }
-    memset(&MP_ROOT_POINTER(machine_pin_irq_handler[0]), 0, sizeof(MP_ROOT_POINTER(machine_pin_irq_handler)));
+    memset(&MP_ROOT_POINTER(machine_pin_irq_handler)[0], 0, sizeof(MP_ROOT_POINTER(machine_pin_irq_handler)));
 }
 
 void machine_pins_deinit(void) {

--- a/ports/esp32/machine_pin.c
+++ b/ports/esp32/machine_pin.c
@@ -76,7 +76,7 @@ void machine_pins_init(void) {
         gpio_install_isr_service(0);
         did_install = true;
     }
-    memset(&MP_STATE_PORT(machine_pin_irq_handler[0]), 0, sizeof(MP_STATE_PORT(machine_pin_irq_handler)));
+    memset(&MP_ROOT_POINTER(machine_pin_irq_handler[0]), 0, sizeof(MP_ROOT_POINTER(machine_pin_irq_handler)));
 }
 
 void machine_pins_deinit(void) {
@@ -89,7 +89,7 @@ void machine_pins_deinit(void) {
 
 STATIC void machine_pin_isr_handler(void *arg) {
     machine_pin_obj_t *self = arg;
-    mp_obj_t handler = MP_STATE_PORT(machine_pin_irq_handler)[PIN_OBJ_INDEX(self)];
+    mp_obj_t handler = MP_ROOT_POINTER(machine_pin_irq_handler)[PIN_OBJ_INDEX(self)];
     mp_sched_schedule(handler, MP_OBJ_FROM_PTR(self));
     mp_hal_wake_main_task_from_isr();
 }
@@ -332,7 +332,7 @@ STATIC mp_obj_t machine_pin_irq(size_t n_args, const mp_obj_t *pos_args, mp_map_
                 trigger = 0;
             }
             gpio_isr_handler_remove(PIN_OBJ_INDEX(self));
-            MP_STATE_PORT(machine_pin_irq_handler)[PIN_OBJ_INDEX(self)] = handler;
+            MP_ROOT_POINTER(machine_pin_irq_handler)[PIN_OBJ_INDEX(self)] = handler;
             gpio_set_intr_type(PIN_OBJ_INDEX(self), trigger);
             gpio_isr_handler_add(PIN_OBJ_INDEX(self), machine_pin_isr_handler, (void *)self);
         }

--- a/ports/esp32/machine_timer.c
+++ b/ports/esp32/machine_timer.c
@@ -71,7 +71,7 @@ STATIC mp_obj_t machine_timer_init_helper(machine_timer_obj_t *self, mp_uint_t n
 
 void machine_timer_deinit_all(void) {
     // Disable, deallocate and remove all timers from list
-    machine_timer_obj_t **t = &MP_STATE_PORT(machine_timer_obj_head);
+    machine_timer_obj_t **t = &MP_ROOT_POINTER(machine_timer_obj_head);
     while (*t != NULL) {
         machine_timer_disable(*t);
         machine_timer_obj_t *next = (*t)->next;
@@ -95,7 +95,7 @@ STATIC mp_obj_t machine_timer_make_new(const mp_obj_type_t *type, size_t n_args,
     machine_timer_obj_t *self = NULL;
 
     // Check whether the timer is already initialized, if so use it
-    for (machine_timer_obj_t *t = MP_STATE_PORT(machine_timer_obj_head); t; t = t->next) {
+    for (machine_timer_obj_t *t = MP_ROOT_POINTER(machine_timer_obj_head); t; t = t->next) {
         if (t->group == group && t->index == index) {
             self = t;
             break;
@@ -108,8 +108,8 @@ STATIC mp_obj_t machine_timer_make_new(const mp_obj_type_t *type, size_t n_args,
         self->index = index;
 
         // Add the timer to the linked-list of timers
-        self->next = MP_STATE_PORT(machine_timer_obj_head);
-        MP_STATE_PORT(machine_timer_obj_head) = self;
+        self->next = MP_ROOT_POINTER(machine_timer_obj_head);
+        MP_ROOT_POINTER(machine_timer_obj_head) = self;
     }
 
     if (n_args > 1 || n_kw > 0) {

--- a/ports/esp32/main.c
+++ b/ports/esp32/main.c
@@ -115,7 +115,7 @@ soft_reset:
     mp_obj_list_append(mp_sys_path, MP_OBJ_NEW_QSTR(MP_QSTR__slash_lib));
     readline_init0();
 
-    MP_STATE_PORT(native_code_pointers) = MP_OBJ_NULL;
+    MP_ROOT_POINTER(native_code_pointers) = MP_OBJ_NULL;
 
     // initialise peripherals
     machine_pins_init();
@@ -155,7 +155,7 @@ soft_reset_exit:
 
     #if MICROPY_ESPNOW
     espnow_deinit(mp_const_none);
-    MP_STATE_PORT(espnow_singleton) = NULL;
+    MP_ROOT_POINTER(espnow_singleton) = NULL;
     #endif
 
     machine_timer_deinit_all();
@@ -165,10 +165,10 @@ soft_reset_exit:
     #endif
 
     // Free any native code pointers that point to iRAM.
-    if (MP_STATE_PORT(native_code_pointers) != MP_OBJ_NULL) {
+    if (MP_ROOT_POINTER(native_code_pointers) != MP_OBJ_NULL) {
         size_t len;
         mp_obj_t *items;
-        mp_obj_list_get(MP_STATE_PORT(native_code_pointers), &len, &items);
+        mp_obj_list_get(MP_ROOT_POINTER(native_code_pointers), &len, &items);
         for (size_t i = 0; i < len; ++i) {
             heap_caps_free(MP_OBJ_TO_PTR(items[i]));
         }
@@ -220,10 +220,10 @@ void *esp_native_code_commit(void *buf, size_t len, void *reloc) {
     if (p == NULL) {
         m_malloc_fail(len);
     }
-    if (MP_STATE_PORT(native_code_pointers) == MP_OBJ_NULL) {
-        MP_STATE_PORT(native_code_pointers) = mp_obj_new_list(0, NULL);
+    if (MP_ROOT_POINTER(native_code_pointers) == MP_OBJ_NULL) {
+        MP_ROOT_POINTER(native_code_pointers) = mp_obj_new_list(0, NULL);
     }
-    mp_obj_list_append(MP_STATE_PORT(native_code_pointers), MP_OBJ_TO_PTR(p));
+    mp_obj_list_append(MP_ROOT_POINTER(native_code_pointers), MP_OBJ_TO_PTR(p));
     if (reloc) {
         mp_native_relocate(reloc, buf, (uintptr_t)p);
     }

--- a/ports/esp32/modespnow.c
+++ b/ports/esp32/modespnow.c
@@ -131,7 +131,7 @@ const mp_obj_type_t esp_espnow_type;
 // If state == INITIALISED check the device has been initialised.
 // Raises OSError if not initialised and state == INITIALISED.
 static esp_espnow_obj_t *_get_singleton() {
-    return MP_STATE_PORT(espnow_singleton);
+    return MP_ROOT_POINTER(espnow_singleton);
 }
 
 static esp_espnow_obj_t *_get_singleton_initialised() {
@@ -154,7 +154,7 @@ STATIC mp_obj_t espnow_make_new(const mp_obj_type_t *type, size_t n_args,
     // garbage collected.
     // NOTE: on soft reset the espnow_singleton MUST be set to NULL and the
     // ESP-NOW functions de-initialised (see main.c).
-    esp_espnow_obj_t *self = MP_STATE_PORT(espnow_singleton);
+    esp_espnow_obj_t *self = MP_ROOT_POINTER(espnow_singleton);
     if (self != NULL) {
         return self;
     }
@@ -171,7 +171,7 @@ STATIC mp_obj_t espnow_make_new(const mp_obj_type_t *type, size_t n_args,
     #endif // MICROPY_ESPNOW_RSSI
 
     // Set the global singleton pointer for the espnow protocol.
-    MP_STATE_PORT(espnow_singleton) = self;
+    MP_ROOT_POINTER(espnow_singleton) = self;
 
     return self;
 }

--- a/ports/esp32/mpconfigport.h
+++ b/ports/esp32/mpconfigport.h
@@ -152,8 +152,6 @@
 #define MICROPY_FATFS_MAX_SS                (4096)
 #define MICROPY_FATFS_LFN_CODE_PAGE         437 /* 1=SFN/ANSI 437=LFN/U.S.(OEM) */
 
-#define MP_STATE_PORT MP_STATE_VM
-
 // type definitions for the specific machine
 
 #define MICROPY_MAKE_POINTER_CALLABLE(p) ((void *)((mp_uint_t)(p)))

--- a/ports/esp8266/machine_pin.c
+++ b/ports/esp8266/machine_pin.c
@@ -95,7 +95,7 @@ void pin_init0(void) {
     ETS_GPIO_INTR_DISABLE();
     ETS_GPIO_INTR_ATTACH(pin_intr_handler_part1, NULL);
     // disable all interrupts
-    memset(&MP_STATE_PORT(pin_irq_handler)[0], 0, 16 * sizeof(mp_obj_t));
+    memset(&MP_ROOT_POINTER(pin_irq_handler)[0], 0, 16 * sizeof(mp_obj_t));
     for (int p = 0; p < 16; ++p) {
         GPIO_REG_WRITE(GPIO_STATUS_W1TC_ADDRESS, 1 << p);
         SET_TRIGGER(p, 0);
@@ -113,7 +113,7 @@ void MP_FASTCODE(pin_intr_handler_part2)(uint32_t status) {
     status &= 0xffff;
     for (int p = 0; status; ++p, status >>= 1) {
         if (status & 1) {
-            mp_obj_t handler = MP_STATE_PORT(pin_irq_handler)[p];
+            mp_obj_t handler = MP_ROOT_POINTER(pin_irq_handler)[p];
             if (handler != MP_OBJ_NULL) {
                 mp_sched_schedule(handler, MP_OBJ_FROM_PTR(&pyb_pin_obj[p]));
             }
@@ -401,7 +401,7 @@ STATIC mp_obj_t pyb_pin_irq(size_t n_args, const mp_obj_t *pos_args, mp_map_t *k
             trigger = 0;
         }
         ETS_GPIO_INTR_DISABLE();
-        MP_STATE_PORT(pin_irq_handler)[self->phys_port] = handler;
+        MP_ROOT_POINTER(pin_irq_handler)[self->phys_port] = handler;
         SET_TRIGGER(self->phys_port, trigger);
         GPIO_REG_WRITE(GPIO_STATUS_W1TC_ADDRESS, 1 << self->phys_port);
         ETS_GPIO_INTR_ENABLE();

--- a/ports/esp8266/machine_uart.c
+++ b/ports/esp8266/machine_uart.c
@@ -169,10 +169,10 @@ STATIC void pyb_uart_init_helper(pyb_uart_obj_t *self, size_t n_args, const mp_o
         byte *buf;
         if (len <= UART0_STATIC_RXBUF_LEN) {
             buf = uart_ringbuf_array;
-            MP_STATE_PORT(uart0_rxbuf) = NULL; // clear any old pointer
+            MP_ROOT_POINTER(uart0_rxbuf) = NULL; // clear any old pointer
         } else {
             buf = m_new(byte, len);
-            MP_STATE_PORT(uart0_rxbuf) = buf; // retain root pointer
+            MP_ROOT_POINTER(uart0_rxbuf) = buf; // retain root pointer
         }
         uart0_set_rxbuf(buf, len);
     }

--- a/ports/esp8266/modespnow.c
+++ b/ports/esp8266/modespnow.c
@@ -166,7 +166,7 @@ mp_obj_t espnow_deinit(mp_obj_t _) {
         self->recv_buffer = NULL;
         self->tx_packets = self->tx_responses;
     }
-    MP_STATE_PORT(espnow_buffer) = NULL;
+    MP_ROOT_POINTER(espnow_buffer) = NULL;
     return mp_const_none;
 }
 
@@ -181,7 +181,7 @@ STATIC mp_obj_t espnow_active(size_t n_args, const mp_obj_t *args) {
             if (self->recv_buffer == NULL) {    // Already initialised
                 self->recv_buffer = m_new_obj(ringbuf_t);
                 ringbuf_alloc(self->recv_buffer, self->recv_buffer_size);
-                MP_STATE_PORT(espnow_buffer) = self->recv_buffer;
+                MP_ROOT_POINTER(espnow_buffer) = self->recv_buffer;
                 esp_now_init();
                 esp_now_set_self_role(ESP_NOW_ROLE_COMBO);
                 esp_now_register_recv_cb(recv_cb);

--- a/ports/esp8266/mpconfigport.h
+++ b/ports/esp8266/mpconfigport.h
@@ -140,8 +140,6 @@ void *esp_native_code_commit(void *, size_t, void *);
 // printer for debugging output, goes to UART only
 extern const struct _mp_print_t mp_debug_print;
 
-#define MP_STATE_PORT MP_STATE_VM
-
 // We need an implementation of the log2 function which is not a macro
 #define MP_NEED_LOG2 (1)
 

--- a/ports/mimxrt/machine_i2s.c
+++ b/ports/mimxrt/machine_i2s.c
@@ -278,17 +278,17 @@ AT_NONCACHEABLE_SECTION_ALIGN(STATIC edma_tcd_t edmaTcd[MICROPY_HW_I2S_NUM], 32)
 // called on processor reset
 void machine_i2s_init0() {
     for (uint8_t i = 0; i < MICROPY_HW_I2S_NUM; i++) {
-        MP_STATE_PORT(machine_i2s_obj)[i] = NULL;
+        MP_ROOT_POINTER(machine_i2s_obj)[i] = NULL;
     }
 }
 
 // called on soft reboot
 void machine_i2s_deinit_all(void) {
     for (uint8_t i = 0; i < MICROPY_HW_I2S_NUM; i++) {
-        machine_i2s_obj_t *i2s_obj = MP_STATE_PORT(machine_i2s_obj)[i];
+        machine_i2s_obj_t *i2s_obj = MP_ROOT_POINTER(machine_i2s_obj)[i];
         if (i2s_obj != NULL) {
             machine_i2s_deinit(i2s_obj);
-            MP_STATE_PORT(machine_i2s_obj)[i] = NULL;
+            MP_ROOT_POINTER(machine_i2s_obj)[i] = NULL;
         }
     }
 }
@@ -1005,13 +1005,13 @@ STATIC mp_obj_t machine_i2s_make_new(const mp_obj_type_t *type, size_t n_pos_arg
     uint8_t i2s_id_zero_base = i2s_id - 1;
 
     machine_i2s_obj_t *self;
-    if (MP_STATE_PORT(machine_i2s_obj)[i2s_id_zero_base] == NULL) {
+    if (MP_ROOT_POINTER(machine_i2s_obj)[i2s_id_zero_base] == NULL) {
         self = mp_obj_malloc(machine_i2s_obj_t, &machine_i2s_type);
-        MP_STATE_PORT(machine_i2s_obj)[i2s_id_zero_base] = self;
+        MP_ROOT_POINTER(machine_i2s_obj)[i2s_id_zero_base] = self;
         self->i2s_id = i2s_id;
         self->edmaTcd = &edmaTcd[i2s_id_zero_base];
     } else {
-        self = MP_STATE_PORT(machine_i2s_obj)[i2s_id_zero_base];
+        self = MP_ROOT_POINTER(machine_i2s_obj)[i2s_id_zero_base];
         machine_i2s_deinit(MP_OBJ_FROM_PTR(self));
     }
 

--- a/ports/mimxrt/machine_pin.c
+++ b/ports/mimxrt/machine_pin.c
@@ -111,7 +111,7 @@ void call_handler(GPIO_Type *gpio, int gpio_nr, int pin) {
                 return;
             }
             #endif
-            machine_pin_irq_obj_t *irq = MP_ROOT_POINTER(machine_pin_irq_objects[index]);
+            machine_pin_irq_obj_t *irq = MP_ROOT_POINTER(machine_pin_irq_objects)[index];
             if (irq != NULL) {
                 irq->flags = irq->trigger;
                 mp_irq_handler(&irq->base);
@@ -175,11 +175,11 @@ void GPIO6_Combined_16_31_IRQHandler(void) {
 // Deinit all pin IRQ handlers.
 void machine_pin_irq_deinit(void) {
     for (int i = 0; i < ARRAY_SIZE(MP_ROOT_POINTER(machine_pin_irq_objects)); ++i) {
-        machine_pin_irq_obj_t *irq = MP_ROOT_POINTER(machine_pin_irq_objects[i]);
+        machine_pin_irq_obj_t *irq = MP_ROOT_POINTER(machine_pin_irq_objects)[i];
         if (irq != NULL) {
             machine_pin_obj_t *self = MP_OBJ_TO_PTR(irq->base.parent);
             GPIO_PortDisableInterrupts(self->gpio, 1U << self->pin);
-            MP_ROOT_POINTER(machine_pin_irq_objects[i]) = NULL;
+            MP_ROOT_POINTER(machine_pin_irq_objects)[i] = NULL;
         }
     }
 }
@@ -402,12 +402,12 @@ STATIC mp_obj_t machine_pin_irq(size_t n_args, const mp_obj_t *pos_args, mp_map_
     if (index >= ARRAY_SIZE(MP_ROOT_POINTER(machine_pin_irq_objects))) {
         mp_raise_ValueError(MP_ERROR_TEXT("IRQ not supported on given Pin"));
     }
-    machine_pin_irq_obj_t *irq = MP_ROOT_POINTER(machine_pin_irq_objects[index]);
+    machine_pin_irq_obj_t *irq = MP_ROOT_POINTER(machine_pin_irq_objects)[index];
 
     if (args[ARG_handler].u_obj == mp_const_none) {
         // remove the IRQ from the table, leave it to gc to free it.
         GPIO_PortDisableInterrupts(self->gpio, 1U << self->pin);
-        MP_ROOT_POINTER(machine_pin_irq_objects[index]) = NULL;
+        MP_ROOT_POINTER(machine_pin_irq_objects)[index] = NULL;
         return mp_const_none;
     }
 
@@ -419,7 +419,7 @@ STATIC mp_obj_t machine_pin_irq(size_t n_args, const mp_obj_t *pos_args, mp_map_
         irq->base.parent = MP_OBJ_FROM_PTR(self);
         irq->base.handler = mp_const_none;
         irq->base.ishard = false;
-        MP_ROOT_POINTER(machine_pin_irq_objects[index]) = irq;
+        MP_ROOT_POINTER(machine_pin_irq_objects)[index] = irq;
     }
 
     if (n_args > 1 || kw_args->used != 0) {
@@ -537,7 +537,7 @@ MP_DEFINE_CONST_OBJ_TYPE(
 STATIC mp_uint_t machine_pin_irq_trigger(mp_obj_t self_in, mp_uint_t new_trigger) {
     machine_pin_obj_t *self = MP_OBJ_TO_PTR(self_in);
     uint32_t gpio_nr = GPIO_get_instance(self->gpio);
-    machine_pin_irq_obj_t *irq = MP_ROOT_POINTER(machine_pin_irq_objects[GET_PIN_IRQ_INDEX(gpio_nr, self->pin)]);
+    machine_pin_irq_obj_t *irq = MP_ROOT_POINTER(machine_pin_irq_objects)[GET_PIN_IRQ_INDEX(gpio_nr, self->pin)];
     uint32_t irq_num = self->pin < 16 ? GPIO_combined_low_irqs[gpio_nr] : GPIO_combined_high_irqs[gpio_nr];
     DisableIRQ(irq_num);
     irq->flags = 0;
@@ -554,7 +554,7 @@ STATIC mp_uint_t machine_pin_irq_trigger(mp_obj_t self_in, mp_uint_t new_trigger
 STATIC mp_uint_t machine_pin_irq_info(mp_obj_t self_in, mp_uint_t info_type) {
     machine_pin_obj_t *self = MP_OBJ_TO_PTR(self_in);
     uint32_t gpio_nr = GPIO_get_instance(self->gpio);
-    machine_pin_irq_obj_t *irq = MP_ROOT_POINTER(machine_pin_irq_objects[GET_PIN_IRQ_INDEX(gpio_nr, self->pin)]);
+    machine_pin_irq_obj_t *irq = MP_ROOT_POINTER(machine_pin_irq_objects)[GET_PIN_IRQ_INDEX(gpio_nr, self->pin)];
     if (info_type == MP_IRQ_INFO_FLAGS) {
         return irq->flags;
     } else if (info_type == MP_IRQ_INFO_TRIGGERS) {

--- a/ports/mimxrt/mpbthciport.c
+++ b/ports/mimxrt/mpbthciport.c
@@ -92,7 +92,7 @@ int mp_bluetooth_hci_uart_init(uint32_t port, uint32_t baudrate) {
     };
 
     mp_bthci_uart = MP_OBJ_TYPE_GET_SLOT(&machine_uart_type, make_new)((mp_obj_t)&machine_uart_type, 1, 5, args);
-    MP_STATE_PORT(mp_bthci_uart) = mp_bthci_uart;
+    MP_ROOT_POINTER(mp_bthci_uart) = mp_bthci_uart;
 
     // Start the HCI polling to process any initial events/packets.
     mp_bluetooth_hci_start_polling();

--- a/ports/mimxrt/mpconfigport.h
+++ b/ports/mimxrt/mpconfigport.h
@@ -187,8 +187,6 @@ extern const struct _mp_obj_type_t mp_network_cyw43_type;
 #define MICROPY_BOARD_PENDSV_ENTRIES
 #endif
 
-#define MP_STATE_PORT MP_STATE_VM
-
 // Miscellaneous settings
 #ifndef  MICROPY_EVENT_POLL_HOOK
 #define MICROPY_EVENT_POLL_HOOK \

--- a/ports/minimal/mpconfigport.h
+++ b/ports/minimal/mpconfigport.h
@@ -41,5 +41,3 @@ typedef long mp_off_t;
 #define MICROPY_MIN_USE_STM32_MCU (1)
 #define MICROPY_HEAP_SIZE      (2048) // heap size 2 kilobytes
 #endif
-
-#define MP_STATE_PORT MP_STATE_VM

--- a/ports/nrf/boards/MICROBIT/modules/microbitdisplay.c
+++ b/ports/nrf/boards/MICROBIT/modules/microbitdisplay.c
@@ -66,8 +66,8 @@ void microbit_display_show(microbit_display_obj_t *display, microbit_image_obj_t
 mp_obj_t microbit_display_show_func(mp_uint_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
 
     // Cancel any animations.
-    MP_STATE_PORT(async_data)[0] = NULL;
-    MP_STATE_PORT(async_data)[1] = NULL;
+    MP_ROOT_POINTER(async_data)[0] = NULL;
+    MP_ROOT_POINTER(async_data)[1] = NULL;
 
     static const mp_arg_t show_allowed_args[] = {
         { MP_QSTR_image,    MP_ARG_REQUIRED | MP_ARG_OBJ, {.u_obj = MP_OBJ_NULL} },
@@ -141,8 +141,8 @@ STATIC void async_stop(void) {
     async_tick = 0;
     async_delay = 1000;
     async_clear = false;
-    MP_STATE_PORT(async_data)[0] = NULL;
-    MP_STATE_PORT(async_data)[1] = NULL;
+    MP_ROOT_POINTER(async_data)[0] = NULL;
+    MP_ROOT_POINTER(async_data)[1] = NULL;
     wakeup_event = true;
 }
 
@@ -286,7 +286,7 @@ static int32_t callback(void) {
 }
 
 static void draw_object(mp_obj_t obj) {
-    microbit_display_obj_t *display = (microbit_display_obj_t*)MP_STATE_PORT(async_data)[0];
+    microbit_display_obj_t *display = (microbit_display_obj_t*)MP_ROOT_POINTER(async_data)[0];
     if (obj == MP_OBJ_STOP_ITERATION) {
         if (async_clear) {
             microbit_display_show(&microbit_display_obj, BLANK_IMAGE);
@@ -319,7 +319,7 @@ static void microbit_display_update(void) {
     switch (async_mode) {
         case ASYNC_MODE_ANIMATION:
         {
-            if (MP_STATE_PORT(async_data)[0] == NULL || MP_STATE_PORT(async_data)[1] == NULL) {
+            if (MP_ROOT_POINTER(async_data)[0] == NULL || MP_ROOT_POINTER(async_data)[1] == NULL) {
                 async_stop();
                 break;
             }
@@ -376,13 +376,13 @@ void microbit_display_tick(void) {
 
 void microbit_display_animate(microbit_display_obj_t *self, mp_obj_t iterable, mp_int_t delay, bool clear, bool wait) {
     // Reset the repeat state.
-    MP_STATE_PORT(async_data)[0] = NULL;
-    MP_STATE_PORT(async_data)[1] = NULL;
+    MP_ROOT_POINTER(async_data)[0] = NULL;
+    MP_ROOT_POINTER(async_data)[1] = NULL;
     async_iterator = mp_getiter(iterable, NULL);
     async_delay = delay;
     async_clear = clear;
-    MP_STATE_PORT(async_data)[0] = self; // so it doesn't get GC'd
-    MP_STATE_PORT(async_data)[1] = async_iterator;
+    MP_ROOT_POINTER(async_data)[0] = self; // so it doesn't get GC'd
+    MP_ROOT_POINTER(async_data)[1] = async_iterator;
     wakeup_event = false;
     mp_obj_t obj = mp_iternext_allow_raise(async_iterator);
     draw_object(obj);

--- a/ports/nrf/drivers/softpwm.c
+++ b/ports/nrf/drivers/softpwm.c
@@ -76,8 +76,8 @@ static const pwm_events OFF_EVENTS = {
     }
 };
 
-#define active_events MP_STATE_PORT(pwm_active_events)
-#define pending_events MP_STATE_PORT(pwm_pending_events)
+#define active_events MP_ROOT_POINTER(pwm_active_events)
+#define pending_events MP_ROOT_POINTER(pwm_pending_events)
 
 void softpwm_init0(void) {
     active_events = &OFF_EVENTS;

--- a/ports/nrf/main.c
+++ b/ports/nrf/main.c
@@ -170,7 +170,7 @@ soft_reset:
             MP_OBJ_NEW_SMALL_INT(0),
             MP_OBJ_NEW_SMALL_INT(115200),
         };
-        MP_STATE_PORT(board_stdio_uart) = MP_OBJ_TYPE_GET_SLOT(&machine_uart_type, make_new)((mp_obj_t)&machine_uart_type, MP_ARRAY_SIZE(args), 0, args);
+        MP_ROOT_POINTER(board_stdio_uart) = MP_OBJ_TYPE_GET_SLOT(&machine_uart_type, make_new)((mp_obj_t)&machine_uart_type, MP_ARRAY_SIZE(args), 0, args);
     }
     #endif
 
@@ -211,12 +211,12 @@ soft_reset:
         sdcard_init_vfs(vfs);
 
         // put the sd device in slot 1 (it will be unused at this point)
-        MP_STATE_PORT(fs_user_mount)[1] = vfs;
+        MP_ROOT_POINTER(fs_user_mount)[1] = vfs;
 
         FRESULT res = f_mount(&vfs->fatfs, vfs->str, 1);
         if (res != FR_OK) {
             printf("MPY: can't mount SD card\n");
-            MP_STATE_PORT(fs_user_mount)[1] = NULL;
+            MP_ROOT_POINTER(fs_user_mount)[1] = NULL;
             m_del_obj(fs_user_mount_t, vfs);
         } else {
             // TODO these should go before the /flash entries in the path

--- a/ports/nrf/modules/machine/pin.c
+++ b/ports/nrf/modules/machine/pin.c
@@ -113,10 +113,10 @@ STATIC bool pin_class_debug;
 #endif
 
 void pin_init0(void) {
-    MP_STATE_PORT(pin_class_mapper) = mp_const_none;
-    MP_STATE_PORT(pin_class_map_dict) = mp_const_none;
+    MP_ROOT_POINTER(pin_class_mapper) = mp_const_none;
+    MP_ROOT_POINTER(pin_class_map_dict) = mp_const_none;
     for (int i = 0; i < NUM_OF_PINS; i++) {
-        MP_STATE_PORT(pin_irq_handlers)[i] = mp_const_none;
+        MP_ROOT_POINTER(pin_irq_handlers)[i] = mp_const_none;
     }
     // Initialize GPIOTE if not done yet.
     if (!nrfx_gpiote_is_init()) {
@@ -152,8 +152,8 @@ const pin_obj_t *pin_find(mp_obj_t user_obj) {
         return pin_obj;
     }
 
-    if (MP_STATE_PORT(pin_class_mapper) != mp_const_none) {
-        pin_obj = mp_call_function_1(MP_STATE_PORT(pin_class_mapper), user_obj);
+    if (MP_ROOT_POINTER(pin_class_mapper) != mp_const_none) {
+        pin_obj = mp_call_function_1(MP_ROOT_POINTER(pin_class_mapper), user_obj);
         if (pin_obj != mp_const_none) {
             if (!mp_obj_is_type(pin_obj, &pin_type)) {
                 mp_raise_ValueError(MP_ERROR_TEXT("Pin.mapper didn't return a Pin object"));
@@ -171,8 +171,8 @@ const pin_obj_t *pin_find(mp_obj_t user_obj) {
         // other lookup methods.
     }
 
-    if (MP_STATE_PORT(pin_class_map_dict) != mp_const_none) {
-        mp_map_t *pin_map_map = mp_obj_dict_get_map(MP_STATE_PORT(pin_class_map_dict));
+    if (MP_ROOT_POINTER(pin_class_map_dict) != mp_const_none) {
+        mp_map_t *pin_map_map = mp_obj_dict_get_map(MP_ROOT_POINTER(pin_class_map_dict));
         mp_map_elem_t *elem = mp_map_lookup(pin_map_map, user_obj, MP_MAP_LOOKUP);
         if (elem != NULL && elem->value != NULL) {
             pin_obj = elem->value;
@@ -292,10 +292,10 @@ STATIC MP_DEFINE_CONST_FUN_OBJ_1(pin_on_obj, pin_on);
 /// Get or set the pin mapper function.
 STATIC mp_obj_t pin_mapper(mp_uint_t n_args, const mp_obj_t *args) {
     if (n_args > 1) {
-        MP_STATE_PORT(pin_class_mapper) = args[1];
+        MP_ROOT_POINTER(pin_class_mapper) = args[1];
         return mp_const_none;
     }
-    return MP_STATE_PORT(pin_class_mapper);
+    return MP_ROOT_POINTER(pin_class_mapper);
 }
 STATIC MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(pin_mapper_fun_obj, 1, 2, pin_mapper);
 STATIC MP_DEFINE_CONST_CLASSMETHOD_OBJ(pin_mapper_obj, (mp_obj_t)&pin_mapper_fun_obj);
@@ -304,10 +304,10 @@ STATIC MP_DEFINE_CONST_CLASSMETHOD_OBJ(pin_mapper_obj, (mp_obj_t)&pin_mapper_fun
 /// Get or set the pin mapper dictionary.
 STATIC mp_obj_t pin_map_dict(mp_uint_t n_args, const mp_obj_t *args) {
     if (n_args > 1) {
-        MP_STATE_PORT(pin_class_map_dict) = args[1];
+        MP_ROOT_POINTER(pin_class_map_dict) = args[1];
         return mp_const_none;
     }
-    return MP_STATE_PORT(pin_class_map_dict);
+    return MP_ROOT_POINTER(pin_class_map_dict);
 }
 STATIC MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(pin_map_dict_fun_obj, 1, 2, pin_map_dict);
 STATIC MP_DEFINE_CONST_CLASSMETHOD_OBJ(pin_map_dict_obj, (mp_obj_t)&pin_map_dict_fun_obj);
@@ -494,7 +494,7 @@ STATIC MP_DEFINE_CONST_FUN_OBJ_1(pin_af_obj, pin_af);
 
 
 STATIC void pin_common_irq_handler(nrfx_gpiote_pin_t pin, nrf_gpiote_polarity_t action) {
-    mp_obj_t pin_handler = MP_STATE_PORT(pin_irq_handlers)[pin];
+    mp_obj_t pin_handler = MP_ROOT_POINTER(pin_irq_handlers)[pin];
     mp_obj_t pin_number = MP_OBJ_NEW_SMALL_INT(pin);
     const pin_obj_t *pin_obj  = pin_find(pin_number);
 
@@ -529,7 +529,7 @@ STATIC mp_obj_t pin_irq(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_ar
         nrfx_gpiote_in_init(pin, &config, pin_common_irq_handler);
     }
 
-    MP_STATE_PORT(pin_irq_handlers)[pin] = args[ARG_handler].u_obj;
+    MP_ROOT_POINTER(pin_irq_handlers)[pin] = args[ARG_handler].u_obj;
 
     nrfx_gpiote_in_event_enable(pin, true);
 

--- a/ports/nrf/modules/music/modmusic.c
+++ b/ports/nrf/modules/music/modmusic.c
@@ -70,7 +70,7 @@ enum {
     ASYNC_MUSIC_STATE_ARTICULATE,
 };
 
-#define music_data MP_STATE_PORT(modmusic_music_data)
+#define music_data MP_ROOT_POINTER(modmusic_music_data)
 
 extern volatile uint32_t ticks;
 

--- a/ports/nrf/modules/os/modos.c
+++ b/ports/nrf/modules/os/modos.c
@@ -87,7 +87,7 @@ STATIC MP_DEFINE_CONST_FUN_OBJ_0(os_uname_obj, os_uname);
 /// Sync all filesystems.
 STATIC mp_obj_t os_sync(void) {
     #if MICROPY_VFS_FAT
-    for (mp_vfs_mount_t *vfs = MP_STATE_VM(vfs_mount_table); vfs != NULL; vfs = vfs->next) {
+    for (mp_vfs_mount_t *vfs = MP_ROOT_POINTER(vfs_mount_table); vfs != NULL; vfs = vfs->next) {
         // this assumes that vfs->obj is fs_user_mount_t with block device functions
         disk_ioctl(MP_OBJ_TO_PTR(vfs->obj), CTRL_SYNC, NULL);
     }
@@ -118,16 +118,16 @@ STATIC MP_DEFINE_CONST_FUN_OBJ_1(os_urandom_obj, os_urandom);
 // TODO should accept any object with read/write methods.
 STATIC mp_obj_t os_dupterm(mp_uint_t n_args, const mp_obj_t *args) {
     if (n_args == 0) {
-        if (MP_STATE_PORT(board_stdio_uart) == NULL) {
+        if (MP_ROOT_POINTER(board_stdio_uart) == NULL) {
             return mp_const_none;
         } else {
-            return MP_STATE_PORT(board_stdio_uart);
+            return MP_ROOT_POINTER(board_stdio_uart);
         }
     } else {
         if (args[0] == mp_const_none) {
-            MP_STATE_PORT(board_stdio_uart) = NULL;
+            MP_ROOT_POINTER(board_stdio_uart) = NULL;
         } else if (mp_obj_get_type(args[0]) == &machine_uart_type) {
-            MP_STATE_PORT(board_stdio_uart) = args[0];
+            MP_ROOT_POINTER(board_stdio_uart) = args[0];
         } else {
             mp_raise_ValueError(MP_ERROR_TEXT("need a UART object"));
         }

--- a/ports/nrf/mpconfigport.h
+++ b/ports/nrf/mpconfigport.h
@@ -303,8 +303,6 @@ long unsigned int rng_generate_random_word(void);
 #define MICROPY_PORT_CONSTANTS \
     { MP_ROM_QSTR(MP_QSTR_machine), MP_ROM_PTR(&mp_module_machine) }, \
 
-#define MP_STATE_PORT MP_STATE_VM
-
 #if MICROPY_HW_USB_CDC
 #include "device/usbd.h"
 #define MICROPY_HW_USBDEV_TASK_HOOK extern void tud_task(void); tud_task();

--- a/ports/nrf/mphalport.c
+++ b/ports/nrf/mphalport.c
@@ -175,11 +175,11 @@ void mp_hal_set_interrupt_char(int c) {
 #if !MICROPY_PY_BLE_NUS && !MICROPY_HW_USB_CDC
 uintptr_t mp_hal_stdio_poll(uintptr_t poll_flags) {
     uintptr_t ret = 0;
-    if ((poll_flags & MP_STREAM_POLL_RD) && MP_STATE_PORT(board_stdio_uart) != NULL
-        && uart_rx_any(MP_STATE_PORT(board_stdio_uart))) {
+    if ((poll_flags & MP_STREAM_POLL_RD) && MP_ROOT_POINTER(board_stdio_uart) != NULL
+        && uart_rx_any(MP_ROOT_POINTER(board_stdio_uart))) {
         ret |= MP_STREAM_POLL_RD;
     }
-    if ((poll_flags & MP_STREAM_POLL_WR) && MP_STATE_PORT(board_stdio_uart) != NULL) {
+    if ((poll_flags & MP_STREAM_POLL_WR) && MP_ROOT_POINTER(board_stdio_uart) != NULL) {
         ret |= MP_STREAM_POLL_WR;
     }
     return ret;
@@ -187,8 +187,8 @@ uintptr_t mp_hal_stdio_poll(uintptr_t poll_flags) {
 
 int mp_hal_stdin_rx_chr(void) {
     for (;;) {
-        if (MP_STATE_PORT(board_stdio_uart) != NULL && uart_rx_any(MP_STATE_PORT(board_stdio_uart))) {
-            return uart_rx_char(MP_STATE_PORT(board_stdio_uart));
+        if (MP_ROOT_POINTER(board_stdio_uart) != NULL && uart_rx_any(MP_ROOT_POINTER(board_stdio_uart))) {
+            return uart_rx_char(MP_ROOT_POINTER(board_stdio_uart));
         }
         MICROPY_EVENT_POLL_HOOK
     }
@@ -197,14 +197,14 @@ int mp_hal_stdin_rx_chr(void) {
 }
 
 void mp_hal_stdout_tx_strn(const char *str, mp_uint_t len) {
-    if (MP_STATE_PORT(board_stdio_uart) != NULL) {
-        uart_tx_strn(MP_STATE_PORT(board_stdio_uart), str, len);
+    if (MP_ROOT_POINTER(board_stdio_uart) != NULL) {
+        uart_tx_strn(MP_ROOT_POINTER(board_stdio_uart), str, len);
     }
 }
 
 void mp_hal_stdout_tx_strn_cooked(const char *str, mp_uint_t len) {
-    if (MP_STATE_PORT(board_stdio_uart) != NULL) {
-        uart_tx_strn_cooked(MP_STATE_PORT(board_stdio_uart), str, len);
+    if (MP_ROOT_POINTER(board_stdio_uart) != NULL) {
+        uart_tx_strn_cooked(MP_ROOT_POINTER(board_stdio_uart), str, len);
     }
 }
 #endif

--- a/ports/pic16bit/board.c
+++ b/ports/pic16bit/board.c
@@ -140,7 +140,7 @@ int switch_get(int sw) {
 // TODO need an irq
 void uart_rx_irq(void) {
     if (c == interrupt_char) {
-        MP_STATE_MAIN_THREAD(mp_pending_exception) = MP_STATE_PORT(keyboard_interrupt_obj);
+        MP_STATE_MAIN_THREAD(mp_pending_exception) = MP_ROOT_POINTER(keyboard_interrupt_obj);
     }
 }
 */

--- a/ports/pic16bit/mpconfigport.h
+++ b/ports/pic16bit/mpconfigport.h
@@ -89,8 +89,6 @@ typedef int mp_off_t;
 #define MICROPY_PORT_BUILTINS \
     { MP_ROM_QSTR(MP_QSTR_open), MP_ROM_PTR(&mp_builtin_open_obj) },
 
-#define MP_STATE_PORT MP_STATE_VM
-
 #define MICROPY_MPHALPORT_H "pic16bit_mphal.h"
 #define MICROPY_HW_BOARD_NAME "dsPICSK"
 #define MICROPY_HW_MCU_NAME "dsPIC33"

--- a/ports/pic16bit/pic16bit_mphal.c
+++ b/ports/pic16bit/pic16bit_mphal.c
@@ -32,7 +32,7 @@
 static int interrupt_char;
 
 void mp_hal_init(void) {
-    MP_STATE_PORT(keyboard_interrupt_obj) = mp_obj_new_exception(&mp_type_KeyboardInterrupt);
+    MP_ROOT_POINTER(keyboard_interrupt_obj) = mp_obj_new_exception(&mp_type_KeyboardInterrupt);
 }
 
 mp_uint_t mp_hal_ticks_ms(void) {

--- a/ports/powerpc/mpconfigport.h
+++ b/ports/powerpc/mpconfigport.h
@@ -110,8 +110,6 @@ typedef long mp_off_t;
 #define MICROPY_HW_BOARD_NAME "bare-metal"
 #define MICROPY_HW_MCU_NAME "POWERPC"
 
-#define MP_STATE_PORT MP_STATE_VM
-
 // powerpc64 gcc doesn't seem to define these
 // These are pointers, so make them 64 bit types
 typedef long intptr_t;

--- a/ports/renesas-ra/boardctrl.c
+++ b/ports/renesas-ra/boardctrl.c
@@ -142,10 +142,10 @@ int boardctrl_run_main_py(boardctrl_state_t *state) {
     if (run_main_py) {
         // Run main.py (or what it was configured to be), if it exists.
         const char *main_py;
-        if (MP_STATE_PORT(pyb_config_main) == MP_OBJ_NULL) {
+        if (MP_ROOT_POINTER(pyb_config_main) == MP_OBJ_NULL) {
             main_py = "main.py";
         } else {
-            main_py = mp_obj_str_get_str(MP_STATE_PORT(pyb_config_main));
+            main_py = mp_obj_str_get_str(MP_ROOT_POINTER(pyb_config_main));
         }
         int ret = pyexec_file_if_exists(main_py);
 

--- a/ports/renesas-ra/extint.c
+++ b/ports/renesas-ra/extint.c
@@ -100,7 +100,7 @@ uint extint_irq_no[EXTI_NUM_VECTORS];
 
 void extint_callback(void *param) {
     uint irq_no = *((uint *)param);
-    mp_obj_t *cb = &MP_STATE_PORT(pyb_extint_callback)[irq_no];
+    mp_obj_t *cb = &MP_ROOT_POINTER(pyb_extint_callback)[irq_no];
     if (*cb != mp_const_none) {
         mp_sched_lock();
         // When executing code within a handler we must lock the GC to prevent
@@ -142,7 +142,7 @@ uint extint_register(mp_obj_t pin_obj, uint32_t mode, uint32_t pull, mp_obj_t ca
         (pull != MP_HAL_PIN_PULL_UP)) {
         mp_raise_msg_varg(&mp_type_ValueError, MP_ERROR_TEXT("invalid ExtInt Pull: %d"), pull);
     }
-    mp_obj_t *cb = &MP_STATE_PORT(pyb_extint_callback)[v_line];
+    mp_obj_t *cb = &MP_ROOT_POINTER(pyb_extint_callback)[v_line];
     if (!override_callback_obj && *cb != mp_const_none && callback_obj != mp_const_none) {
         mp_raise_msg_varg(&mp_type_ValueError, MP_ERROR_TEXT("ExtInt vector %d is already in use"), v_line);
     }
@@ -185,7 +185,7 @@ void extint_register_pin(const machine_pin_obj_t *pin, uint32_t mode, bool hard_
     }
 
     // Check if the ExtInt line is already in use by another Pin/ExtInt
-    mp_obj_t *cb = &MP_STATE_PORT(pyb_extint_callback)[line];
+    mp_obj_t *cb = &MP_ROOT_POINTER(pyb_extint_callback)[line];
     if (*cb != mp_const_none && MP_OBJ_FROM_PTR(pin) != pyb_extint_callback_arg[line]) {
         if (mp_obj_is_small_int(pyb_extint_callback_arg[line])) {
             mp_raise_msg_varg(&mp_type_OSError, MP_ERROR_TEXT("ExtInt vector %d is already in use"), line);
@@ -387,7 +387,7 @@ void extint_init0(void) {
     ra_icu_init();
     ra_icu_deinit();
     for (int i = 0; i < PYB_EXTI_NUM_VECTORS; i++) {
-        MP_STATE_PORT(pyb_extint_callback)[i] = mp_const_none;
+        MP_ROOT_POINTER(pyb_extint_callback)[i] = mp_const_none;
     }
 }
 

--- a/ports/renesas-ra/machine_rtc.c
+++ b/ports/renesas-ra/machine_rtc.c
@@ -291,7 +291,7 @@ mp_obj_t machine_rtc_wakeup(size_t n_args, const mp_obj_t *args) {
         callback = args[2];
     }
     // set the callback
-    MP_STATE_PORT(pyb_extint_callback)[EXTI_RTC_WAKEUP] = callback;
+    MP_ROOT_POINTER(pyb_extint_callback)[EXTI_RTC_WAKEUP] = callback;
     pyb_extint_callback_arg[EXTI_RTC_WAKEUP] = MP_OBJ_NEW_SMALL_INT(EXTI_RTC_WAKEUP);
     rtc_wakeup_param = EXTI_RTC_WAKEUP;
     if (enable) {

--- a/ports/renesas-ra/machine_uart.c
+++ b/ports/renesas-ra/machine_uart.c
@@ -321,15 +321,15 @@ STATIC mp_obj_t machine_uart_make_new(const mp_obj_type_t *type, size_t n_args, 
     }
 
     machine_uart_obj_t *self;
-    if (MP_STATE_PORT(machine_uart_obj_all)[uart_id] == NULL) {
+    if (MP_ROOT_POINTER(machine_uart_obj_all)[uart_id] == NULL) {
         // create new UART object
         self = m_new0(machine_uart_obj_t, 1);
         self->base.type = &machine_uart_type;
         self->uart_id = uart_id;
-        MP_STATE_PORT(machine_uart_obj_all)[uart_id] = self;
+        MP_ROOT_POINTER(machine_uart_obj_all)[uart_id] = self;
     } else {
         // reference existing UART object
-        self = MP_STATE_PORT(machine_uart_obj_all)[uart_id];
+        self = MP_ROOT_POINTER(machine_uart_obj_all)[uart_id];
     }
 
     // start the peripheral

--- a/ports/renesas-ra/main.c
+++ b/ports/renesas-ra/main.c
@@ -121,7 +121,7 @@ STATIC mp_obj_t pyb_main(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_a
     };
 
     if (mp_obj_is_str(pos_args[0])) {
-        MP_STATE_PORT(pyb_config_main) = pos_args[0];
+        MP_ROOT_POINTER(pyb_config_main) = pos_args[0];
 
         // parse args
         mp_arg_val_t args[MP_ARRAY_SIZE(allowed_args)];
@@ -249,9 +249,9 @@ int main(void) {
     uart_init(&machine_uart_repl_obj, MICROPY_HW_UART_REPL_BAUD, UART_WORDLENGTH_8B, UART_PARITY_NONE, UART_STOPBITS_1, 0);
     uart_set_rxbuf(&machine_uart_repl_obj, sizeof(machine_uart_repl_rxbuf), machine_uart_repl_rxbuf);
     uart_attach_to_repl(&machine_uart_repl_obj, true);
-    MP_STATE_PORT(machine_uart_obj_all)[MICROPY_HW_UART_REPL] = &machine_uart_repl_obj;
+    MP_ROOT_POINTER(machine_uart_obj_all)[MICROPY_HW_UART_REPL] = &machine_uart_repl_obj;
     #if RA_EARLY_PRINT
-    MP_STATE_PORT(pyb_stdio_uart) = &machine_uart_repl_obj;
+    MP_ROOT_POINTER(pyb_stdio_uart) = &machine_uart_repl_obj;
     #endif
     #endif
 
@@ -293,9 +293,9 @@ soft_reset:
     // by boot.py must be set after boot.py is run.
 
     #if defined(MICROPY_HW_UART_REPL)
-    MP_STATE_PORT(pyb_stdio_uart) = &machine_uart_repl_obj;
+    MP_ROOT_POINTER(pyb_stdio_uart) = &machine_uart_repl_obj;
     #else
-    MP_STATE_PORT(pyb_stdio_uart) = NULL;
+    MP_ROOT_POINTER(pyb_stdio_uart) = NULL;
     #endif
 
     readline_init0();
@@ -321,7 +321,7 @@ soft_reset:
     }
 
     // reset config variables; they should be set by boot.py
-    MP_STATE_PORT(pyb_config_main) = MP_OBJ_NULL;
+    MP_ROOT_POINTER(pyb_config_main) = MP_OBJ_NULL;
 
     // Run optional frozen boot code.
     #ifdef MICROPY_BOARD_FROZEN_BOOT_FILE

--- a/ports/renesas-ra/modmachine.c
+++ b/ports/renesas-ra/modmachine.c
@@ -137,7 +137,7 @@ STATIC mp_obj_t machine_info(size_t n_args, const mp_obj_t *args) {
     // free space on flash
     {
         #if MICROPY_VFS_FAT
-        for (mp_vfs_mount_t *vfs = MP_STATE_VM(vfs_mount_table); vfs != NULL; vfs = vfs->next) {
+        for (mp_vfs_mount_t *vfs = MP_ROOT_POINTER(vfs_mount_table); vfs != NULL; vfs = vfs->next) {
             if (strncmp("/flash", vfs->str, vfs->len) == 0) {
                 // assumes that it's a FatFs filesystem
                 fs_user_mount_t *vfs_fat = MP_OBJ_TO_PTR(vfs->obj);

--- a/ports/renesas-ra/mpconfigport.h
+++ b/ports/renesas-ra/mpconfigport.h
@@ -151,8 +151,6 @@
 #define MICROPY_PORT_CONSTANTS \
     MACHINE_BUILTIN_MODULE_CONSTANTS \
 
-#define MP_STATE_PORT MP_STATE_VM
-
 // type definitions for the specific machine
 
 #define MICROPY_MAKE_POINTER_CALLABLE(p) ((void *)((uint32_t)(p) | 1))

--- a/ports/renesas-ra/mphalport.c
+++ b/ports/renesas-ra/mphalport.c
@@ -48,8 +48,8 @@ NORETURN void mp_hal_raise(HAL_StatusTypeDef status) {
 
 MP_WEAK uintptr_t mp_hal_stdio_poll(uintptr_t poll_flags) {
     uintptr_t ret = 0;
-    if (MP_STATE_PORT(pyb_stdio_uart) != NULL) {
-        mp_obj_t pyb_stdio_uart = MP_OBJ_FROM_PTR(MP_STATE_PORT(pyb_stdio_uart));
+    if (MP_ROOT_POINTER(pyb_stdio_uart) != NULL) {
+        mp_obj_t pyb_stdio_uart = MP_OBJ_FROM_PTR(MP_ROOT_POINTER(pyb_stdio_uart));
         int errcode;
         const mp_stream_p_t *stream_p = mp_get_stream(pyb_stdio_uart);
         ret = stream_p->ioctl(pyb_stdio_uart, MP_STREAM_POLL, poll_flags, &errcode);
@@ -66,8 +66,8 @@ MP_WEAK int mp_hal_stdin_rx_chr(void) {
         #if MICROPY_HW_ENABLE_INTERNAL_FLASH_STORAGE
         flash_cache_commit();
         #endif
-        if (MP_STATE_PORT(pyb_stdio_uart) != NULL && uart_rx_any(MP_STATE_PORT(pyb_stdio_uart))) {
-            return uart_rx_char(MP_STATE_PORT(pyb_stdio_uart));
+        if (MP_ROOT_POINTER(pyb_stdio_uart) != NULL && uart_rx_any(MP_ROOT_POINTER(pyb_stdio_uart))) {
+            return uart_rx_char(MP_ROOT_POINTER(pyb_stdio_uart));
         }
         int dupterm_c = mp_os_dupterm_rx_chr();
         if (dupterm_c >= 0) {
@@ -78,8 +78,8 @@ MP_WEAK int mp_hal_stdin_rx_chr(void) {
 }
 
 MP_WEAK void mp_hal_stdout_tx_strn(const char *str, size_t len) {
-    if (MP_STATE_PORT(pyb_stdio_uart) != NULL) {
-        uart_tx_strn(MP_STATE_PORT(pyb_stdio_uart), str, len);
+    if (MP_ROOT_POINTER(pyb_stdio_uart) != NULL) {
+        uart_tx_strn(MP_ROOT_POINTER(pyb_stdio_uart), str, len);
     }
     mp_os_dupterm_tx_strn(str, len);
 }

--- a/ports/renesas-ra/timer.c
+++ b/ports/renesas-ra/timer.c
@@ -57,7 +57,7 @@ typedef struct _pyb_timer_obj_t {
     pyb_timer_channel_obj_t *channel;
     #endif
 } pyb_timer_obj_t;
-#define PYB_TIMER_OBJ_ALL_NUM MP_ARRAY_SIZE(MP_STATE_PORT(pyb_timer_obj_all))
+#define PYB_TIMER_OBJ_ALL_NUM MP_ARRAY_SIZE(MP_ROOT_POINTER(pyb_timer_obj_all))
 
 STATIC mp_obj_t pyb_timer_deinit(mp_obj_t self_in);
 STATIC mp_obj_t pyb_timer_callback(mp_obj_t self_in, mp_obj_t callback);
@@ -68,14 +68,14 @@ static const int ra_agt_timer_ch[TIMER_SIZE] = {1, 2};
 
 void timer_init0(void) {
     for (uint i = 0; i < PYB_TIMER_OBJ_ALL_NUM; i++) {
-        MP_STATE_PORT(pyb_timer_obj_all)[i] = NULL;
+        MP_ROOT_POINTER(pyb_timer_obj_all)[i] = NULL;
     }
 }
 
 // unregister all interrupt sources
 void timer_deinit(void) {
     for (uint i = 0; i < PYB_TIMER_OBJ_ALL_NUM; i++) {
-        pyb_timer_obj_t *tim = MP_STATE_PORT(pyb_timer_obj_all)[i];
+        pyb_timer_obj_t *tim = MP_ROOT_POINTER(pyb_timer_obj_all)[i];
         if (tim != NULL) {
             pyb_timer_deinit(MP_OBJ_FROM_PTR(tim));
         }
@@ -153,17 +153,17 @@ STATIC mp_obj_t pyb_timer_make_new(const mp_obj_type_t *type, size_t n_args, siz
     mp_int_t tim_id = mp_obj_get_int(args[0]);
     // create new Timer object
     pyb_timer_obj_t *tim;
-    if (MP_STATE_PORT(pyb_timer_obj_all)[tim_id - 1] == NULL) {
+    if (MP_ROOT_POINTER(pyb_timer_obj_all)[tim_id - 1] == NULL) {
         // create new Timer object
         tim = m_new_obj(pyb_timer_obj_t);
         memset(tim, 0, sizeof(*tim));
         tim->base.type = &pyb_timer_type;
         tim->tim_id = tim_id;
         tim->callback = mp_const_none;
-        MP_STATE_PORT(pyb_timer_obj_all)[tim_id - 1] = tim;
+        MP_ROOT_POINTER(pyb_timer_obj_all)[tim_id - 1] = tim;
     } else {
         // reference existing Timer object
-        tim = MP_STATE_PORT(pyb_timer_obj_all)[tim_id - 1];
+        tim = MP_ROOT_POINTER(pyb_timer_obj_all)[tim_id - 1];
     }
     if (n_args > 1 || n_kw > 0) {
         // start the peripheral
@@ -544,7 +544,7 @@ void timer_irq_handler(void *param) {
     uint tim_id = *(uint *)param;
     if ((tim_id != 0) && (tim_id - 1 < PYB_TIMER_OBJ_ALL_NUM)) {
         // get the timer object
-        pyb_timer_obj_t *tim = MP_STATE_PORT(pyb_timer_obj_all)[tim_id - 1];
+        pyb_timer_obj_t *tim = MP_ROOT_POINTER(pyb_timer_obj_all)[tim_id - 1];
 
         if (tim == NULL) {
             // do nohting

--- a/ports/renesas-ra/uart.c
+++ b/ports/renesas-ra/uart.c
@@ -64,7 +64,7 @@ static void set_kbd_interrupt(uint32_t ch, void *keyex) {
 #endif
 
 static void uart_rx_cb(uint32_t ch, int d) {
-    machine_uart_obj_t *self = MP_STATE_PORT(machine_uart_obj_all)[ch];
+    machine_uart_obj_t *self = MP_ROOT_POINTER(machine_uart_obj_all)[ch];
     if (self == NULL) {
         // UART object has not been set, so we can't do anything, not
         // even disable the IRQ.  This should never happen.
@@ -86,17 +86,17 @@ void uart_init0(void) {
 
 // unregister all interrupt sources
 void uart_deinit_all(void) {
-    for (int i = 0; i < MP_ARRAY_SIZE(MP_STATE_PORT(machine_uart_obj_all)); i++) {
-        machine_uart_obj_t *uart_obj = MP_STATE_PORT(machine_uart_obj_all)[i];
+    for (int i = 0; i < MP_ARRAY_SIZE(MP_ROOT_POINTER(machine_uart_obj_all)); i++) {
+        machine_uart_obj_t *uart_obj = MP_ROOT_POINTER(machine_uart_obj_all)[i];
         if (uart_obj != NULL && !uart_obj->is_static) {
             uart_deinit(uart_obj);
-            MP_STATE_PORT(machine_uart_obj_all)[i] = NULL;
+            MP_ROOT_POINTER(machine_uart_obj_all)[i] = NULL;
         }
     }
 }
 
 bool uart_exists(int uart_id) {
-    if (uart_id > MP_ARRAY_SIZE(MP_STATE_PORT(machine_uart_obj_all))) {
+    if (uart_id > MP_ARRAY_SIZE(MP_ROOT_POINTER(machine_uart_obj_all))) {
         // safeguard against machine_uart_obj_all array being configured too small
         return false;
     }

--- a/ports/renesas-ra/usrsw.c
+++ b/ports/renesas-ra/usrsw.c
@@ -104,8 +104,8 @@ mp_obj_t pyb_switch_value(mp_obj_t self_in) {
 STATIC MP_DEFINE_CONST_FUN_OBJ_1(pyb_switch_value_obj, pyb_switch_value);
 
 STATIC mp_obj_t switch_callback(mp_obj_t line) {
-    if (MP_STATE_PORT(pyb_switch_callback) != mp_const_none) {
-        mp_call_function_0(MP_STATE_PORT(pyb_switch_callback));
+    if (MP_ROOT_POINTER(pyb_switch_callback) != mp_const_none) {
+        mp_call_function_0(MP_ROOT_POINTER(pyb_switch_callback));
     }
     return mp_const_none;
 }
@@ -115,7 +115,7 @@ STATIC MP_DEFINE_CONST_FUN_OBJ_1(switch_callback_obj, switch_callback);
 /// Register the given function to be called when the switch is pressed down.
 /// If `fun` is `None`, then it disables the callback.
 mp_obj_t pyb_switch_callback(mp_obj_t self_in, mp_obj_t callback) {
-    MP_STATE_PORT(pyb_switch_callback) = callback;
+    MP_ROOT_POINTER(pyb_switch_callback) = callback;
     // Init the EXTI each time this function is called, since the EXTI
     // may have been disabled by an exception in the interrupt, or the
     // user disabling the line explicitly.

--- a/ports/rp2/machine_i2s.c
+++ b/ports/rp2/machine_i2s.c
@@ -230,7 +230,7 @@ STATIC mp_obj_t machine_i2s_deinit(mp_obj_t self_in);
 
 void machine_i2s_init0(void) {
     for (uint8_t i = 0; i < MAX_I2S_RP2; i++) {
-        MP_ROOT_POINTER(machine_i2s_obj[i]) = NULL;
+        MP_ROOT_POINTER(machine_i2s_obj)[i] = NULL;
     }
 }
 
@@ -730,7 +730,7 @@ STATIC void dma_irq_handler(uint8_t irq_index) {
         return;
     }
 
-    machine_i2s_obj_t *self = MP_ROOT_POINTER(machine_i2s_obj[irq_index]);
+    machine_i2s_obj_t *self = MP_ROOT_POINTER(machine_i2s_obj)[irq_index];
     if (self == NULL) {
         // This should never happen
         return;
@@ -896,12 +896,12 @@ STATIC mp_obj_t machine_i2s_make_new(const mp_obj_type_t *type, size_t n_pos_arg
     }
 
     machine_i2s_obj_t *self;
-    if (MP_ROOT_POINTER(machine_i2s_obj[i2s_id]) == NULL) {
+    if (MP_ROOT_POINTER(machine_i2s_obj)[i2s_id] == NULL) {
         self = mp_obj_malloc(machine_i2s_obj_t, &machine_i2s_type);
-        MP_ROOT_POINTER(machine_i2s_obj[i2s_id]) = self;
+        MP_ROOT_POINTER(machine_i2s_obj)[i2s_id] = self;
         self->i2s_id = i2s_id;
     } else {
-        self = MP_ROOT_POINTER(machine_i2s_obj[i2s_id]);
+        self = MP_ROOT_POINTER(machine_i2s_obj)[i2s_id];
         machine_i2s_deinit(MP_OBJ_FROM_PTR(self));
     }
 

--- a/ports/rp2/machine_i2s.c
+++ b/ports/rp2/machine_i2s.c
@@ -230,7 +230,7 @@ STATIC mp_obj_t machine_i2s_deinit(mp_obj_t self_in);
 
 void machine_i2s_init0(void) {
     for (uint8_t i = 0; i < MAX_I2S_RP2; i++) {
-        MP_STATE_PORT(machine_i2s_obj[i]) = NULL;
+        MP_ROOT_POINTER(machine_i2s_obj[i]) = NULL;
     }
 }
 
@@ -730,7 +730,7 @@ STATIC void dma_irq_handler(uint8_t irq_index) {
         return;
     }
 
-    machine_i2s_obj_t *self = MP_STATE_PORT(machine_i2s_obj[irq_index]);
+    machine_i2s_obj_t *self = MP_ROOT_POINTER(machine_i2s_obj[irq_index]);
     if (self == NULL) {
         // This should never happen
         return;
@@ -896,12 +896,12 @@ STATIC mp_obj_t machine_i2s_make_new(const mp_obj_type_t *type, size_t n_pos_arg
     }
 
     machine_i2s_obj_t *self;
-    if (MP_STATE_PORT(machine_i2s_obj[i2s_id]) == NULL) {
+    if (MP_ROOT_POINTER(machine_i2s_obj[i2s_id]) == NULL) {
         self = mp_obj_malloc(machine_i2s_obj_t, &machine_i2s_type);
-        MP_STATE_PORT(machine_i2s_obj[i2s_id]) = self;
+        MP_ROOT_POINTER(machine_i2s_obj[i2s_id]) = self;
         self->i2s_id = i2s_id;
     } else {
-        self = MP_STATE_PORT(machine_i2s_obj[i2s_id]);
+        self = MP_ROOT_POINTER(machine_i2s_obj[i2s_id]);
         machine_i2s_deinit(MP_OBJ_FROM_PTR(self));
     }
 

--- a/ports/rp2/machine_pin.c
+++ b/ports/rp2/machine_pin.c
@@ -106,7 +106,7 @@ STATIC void gpio_irq(void) {
                 if (intr & 0xf) {
                     uint32_t gpio = 8 * i + j;
                     gpio_acknowledge_irq(gpio, intr & 0xf);
-                    machine_pin_irq_obj_t *irq = MP_STATE_PORT(machine_pin_irq_obj[gpio]);
+                    machine_pin_irq_obj_t *irq = MP_ROOT_POINTER(machine_pin_irq_obj[gpio]);
                     if (irq != NULL && (intr & irq->trigger)) {
                         irq->flags = intr & irq->trigger;
                         mp_irq_handler(&irq->base);
@@ -119,7 +119,7 @@ STATIC void gpio_irq(void) {
 }
 
 void machine_pin_init(void) {
-    memset(MP_STATE_PORT(machine_pin_irq_obj), 0, sizeof(MP_STATE_PORT(machine_pin_irq_obj)));
+    memset(MP_ROOT_POINTER(machine_pin_irq_obj), 0, sizeof(MP_ROOT_POINTER(machine_pin_irq_obj)));
     irq_add_shared_handler(IO_IRQ_BANK0, gpio_irq, PICO_SHARED_IRQ_HANDLER_DEFAULT_ORDER_PRIORITY);
     irq_set_enabled(IO_IRQ_BANK0, true);
     #if MICROPY_HW_PIN_EXT_COUNT
@@ -424,7 +424,7 @@ STATIC MP_DEFINE_CONST_FUN_OBJ_1(machine_pin_toggle_obj, machine_pin_toggle);
 
 STATIC machine_pin_irq_obj_t *machine_pin_get_irq(mp_hal_pin_obj_t pin) {
     // Get the IRQ object.
-    machine_pin_irq_obj_t *irq = MP_STATE_PORT(machine_pin_irq_obj[pin]);
+    machine_pin_irq_obj_t *irq = MP_ROOT_POINTER(machine_pin_irq_obj[pin]);
 
     // Allocate the IRQ object if it doesn't already exist.
     if (irq == NULL) {
@@ -434,7 +434,7 @@ STATIC machine_pin_irq_obj_t *machine_pin_get_irq(mp_hal_pin_obj_t pin) {
         irq->base.parent = MP_OBJ_FROM_PTR(machine_pin_cpu_pins[pin]);
         irq->base.handler = mp_const_none;
         irq->base.ishard = false;
-        MP_STATE_PORT(machine_pin_irq_obj[pin]) = irq;
+        MP_ROOT_POINTER(machine_pin_irq_obj[pin]) = irq;
     }
     return irq;
 }
@@ -569,7 +569,7 @@ MP_DEFINE_CONST_OBJ_TYPE(
 
 STATIC mp_uint_t machine_pin_irq_trigger(mp_obj_t self_in, mp_uint_t new_trigger) {
     machine_pin_obj_t *self = MP_OBJ_TO_PTR(self_in);
-    machine_pin_irq_obj_t *irq = MP_STATE_PORT(machine_pin_irq_obj[self->id]);
+    machine_pin_irq_obj_t *irq = MP_ROOT_POINTER(machine_pin_irq_obj[self->id]);
     gpio_set_irq_enabled(self->id, GPIO_IRQ_ALL, false);
     irq->flags = 0;
     irq->trigger = new_trigger;
@@ -579,7 +579,7 @@ STATIC mp_uint_t machine_pin_irq_trigger(mp_obj_t self_in, mp_uint_t new_trigger
 
 STATIC mp_uint_t machine_pin_irq_info(mp_obj_t self_in, mp_uint_t info_type) {
     machine_pin_obj_t *self = MP_OBJ_TO_PTR(self_in);
-    machine_pin_irq_obj_t *irq = MP_STATE_PORT(machine_pin_irq_obj[self->id]);
+    machine_pin_irq_obj_t *irq = MP_ROOT_POINTER(machine_pin_irq_obj[self->id]);
     if (info_type == MP_IRQ_INFO_FLAGS) {
         return irq->flags;
     } else if (info_type == MP_IRQ_INFO_TRIGGERS) {

--- a/ports/rp2/machine_pin.c
+++ b/ports/rp2/machine_pin.c
@@ -106,7 +106,7 @@ STATIC void gpio_irq(void) {
                 if (intr & 0xf) {
                     uint32_t gpio = 8 * i + j;
                     gpio_acknowledge_irq(gpio, intr & 0xf);
-                    machine_pin_irq_obj_t *irq = MP_ROOT_POINTER(machine_pin_irq_obj[gpio]);
+                    machine_pin_irq_obj_t *irq = MP_ROOT_POINTER(machine_pin_irq_obj)[gpio];
                     if (irq != NULL && (intr & irq->trigger)) {
                         irq->flags = intr & irq->trigger;
                         mp_irq_handler(&irq->base);
@@ -424,7 +424,7 @@ STATIC MP_DEFINE_CONST_FUN_OBJ_1(machine_pin_toggle_obj, machine_pin_toggle);
 
 STATIC machine_pin_irq_obj_t *machine_pin_get_irq(mp_hal_pin_obj_t pin) {
     // Get the IRQ object.
-    machine_pin_irq_obj_t *irq = MP_ROOT_POINTER(machine_pin_irq_obj[pin]);
+    machine_pin_irq_obj_t *irq = MP_ROOT_POINTER(machine_pin_irq_obj)[pin];
 
     // Allocate the IRQ object if it doesn't already exist.
     if (irq == NULL) {
@@ -434,7 +434,7 @@ STATIC machine_pin_irq_obj_t *machine_pin_get_irq(mp_hal_pin_obj_t pin) {
         irq->base.parent = MP_OBJ_FROM_PTR(machine_pin_cpu_pins[pin]);
         irq->base.handler = mp_const_none;
         irq->base.ishard = false;
-        MP_ROOT_POINTER(machine_pin_irq_obj[pin]) = irq;
+        MP_ROOT_POINTER(machine_pin_irq_obj)[pin] = irq;
     }
     return irq;
 }
@@ -569,7 +569,7 @@ MP_DEFINE_CONST_OBJ_TYPE(
 
 STATIC mp_uint_t machine_pin_irq_trigger(mp_obj_t self_in, mp_uint_t new_trigger) {
     machine_pin_obj_t *self = MP_OBJ_TO_PTR(self_in);
-    machine_pin_irq_obj_t *irq = MP_ROOT_POINTER(machine_pin_irq_obj[self->id]);
+    machine_pin_irq_obj_t *irq = MP_ROOT_POINTER(machine_pin_irq_obj)[self->id];
     gpio_set_irq_enabled(self->id, GPIO_IRQ_ALL, false);
     irq->flags = 0;
     irq->trigger = new_trigger;
@@ -579,7 +579,7 @@ STATIC mp_uint_t machine_pin_irq_trigger(mp_obj_t self_in, mp_uint_t new_trigger
 
 STATIC mp_uint_t machine_pin_irq_info(mp_obj_t self_in, mp_uint_t info_type) {
     machine_pin_obj_t *self = MP_OBJ_TO_PTR(self_in);
-    machine_pin_irq_obj_t *irq = MP_ROOT_POINTER(machine_pin_irq_obj[self->id]);
+    machine_pin_irq_obj_t *irq = MP_ROOT_POINTER(machine_pin_irq_obj)[self->id];
     if (info_type == MP_IRQ_INFO_FLAGS) {
         return irq->flags;
     } else if (info_type == MP_IRQ_INFO_TRIGGERS) {

--- a/ports/rp2/machine_uart.c
+++ b/ports/rp2/machine_uart.c
@@ -359,10 +359,10 @@ STATIC void machine_uart_init_helper(machine_uart_obj_t *self, size_t n_args, co
 
         // Allocate the RX/TX buffers.
         ringbuf_alloc(&(self->read_buffer), rxbuf_len + 1);
-        MP_STATE_PORT(rp2_uart_rx_buffer[self->uart_id]) = self->read_buffer.buf;
+        MP_ROOT_POINTER(rp2_uart_rx_buffer[self->uart_id]) = self->read_buffer.buf;
 
         ringbuf_alloc(&(self->write_buffer), txbuf_len + 1);
-        MP_STATE_PORT(rp2_uart_tx_buffer[self->uart_id]) = self->write_buffer.buf;
+        MP_ROOT_POINTER(rp2_uart_tx_buffer[self->uart_id]) = self->write_buffer.buf;
 
         // Set the irq handler.
         if (self->uart_id == 0) {
@@ -414,8 +414,8 @@ STATIC mp_obj_t machine_uart_deinit(mp_obj_t self_in) {
         irq_set_enabled(UART1_IRQ, false);
     }
     self->baudrate = 0;
-    MP_STATE_PORT(rp2_uart_rx_buffer[self->uart_id]) = NULL;
-    MP_STATE_PORT(rp2_uart_tx_buffer[self->uart_id]) = NULL;
+    MP_ROOT_POINTER(rp2_uart_rx_buffer[self->uart_id]) = NULL;
+    MP_ROOT_POINTER(rp2_uart_tx_buffer[self->uart_id]) = NULL;
     return mp_const_none;
 }
 STATIC MP_DEFINE_CONST_FUN_OBJ_1(machine_uart_deinit_obj, machine_uart_deinit);

--- a/ports/rp2/machine_uart.c
+++ b/ports/rp2/machine_uart.c
@@ -359,10 +359,10 @@ STATIC void machine_uart_init_helper(machine_uart_obj_t *self, size_t n_args, co
 
         // Allocate the RX/TX buffers.
         ringbuf_alloc(&(self->read_buffer), rxbuf_len + 1);
-        MP_ROOT_POINTER(rp2_uart_rx_buffer[self->uart_id]) = self->read_buffer.buf;
+        MP_ROOT_POINTER(rp2_uart_rx_buffer)[self->uart_id] = self->read_buffer.buf;
 
         ringbuf_alloc(&(self->write_buffer), txbuf_len + 1);
-        MP_ROOT_POINTER(rp2_uart_tx_buffer[self->uart_id]) = self->write_buffer.buf;
+        MP_ROOT_POINTER(rp2_uart_tx_buffer)[self->uart_id] = self->write_buffer.buf;
 
         // Set the irq handler.
         if (self->uart_id == 0) {
@@ -414,8 +414,8 @@ STATIC mp_obj_t machine_uart_deinit(mp_obj_t self_in) {
         irq_set_enabled(UART1_IRQ, false);
     }
     self->baudrate = 0;
-    MP_ROOT_POINTER(rp2_uart_rx_buffer[self->uart_id]) = NULL;
-    MP_ROOT_POINTER(rp2_uart_tx_buffer[self->uart_id]) = NULL;
+    MP_ROOT_POINTER(rp2_uart_rx_buffer)[self->uart_id] = NULL;
+    MP_ROOT_POINTER(rp2_uart_tx_buffer)[self->uart_id] = NULL;
     return mp_const_none;
 }
 STATIC MP_DEFINE_CONST_FUN_OBJ_1(machine_uart_deinit_obj, machine_uart_deinit);

--- a/ports/rp2/mpconfigport.h
+++ b/ports/rp2/mpconfigport.h
@@ -212,8 +212,6 @@ extern const struct _mp_obj_type_t mod_network_nic_type_wiznet5k;
 #define MICROPY_BOARD_PENDSV_ENTRIES
 #endif
 
-#define MP_STATE_PORT MP_STATE_VM
-
 // Miscellaneous settings
 
 #ifndef MICROPY_HW_USB_VID

--- a/ports/rp2/rp2_pio.c
+++ b/ports/rp2/rp2_pio.c
@@ -82,7 +82,7 @@ STATIC void pio_irq0(PIO pio) {
     pio->irq = ints >> 8;
 
     // Call handler if it is registered, for PIO irqs.
-    rp2_pio_irq_obj_t *irq = MP_STATE_PORT(rp2_pio_irq_obj[PIO_NUM(pio)]);
+    rp2_pio_irq_obj_t *irq = MP_ROOT_POINTER(rp2_pio_irq_obj[PIO_NUM(pio)]);
     if (irq != NULL && (ints & irq->trigger)) {
         irq->flags = ints & irq->trigger;
         mp_irq_handler(&irq->base);
@@ -90,7 +90,7 @@ STATIC void pio_irq0(PIO pio) {
 
     // Call handler if it is registered, for StateMachine irqs.
     for (size_t i = 0; i < 4; ++i) {
-        rp2_state_machine_irq_obj_t *irq = MP_STATE_PORT(rp2_state_machine_irq_obj[PIO_NUM(pio) * 4 + i]);
+        rp2_state_machine_irq_obj_t *irq = MP_ROOT_POINTER(rp2_state_machine_irq_obj[PIO_NUM(pio) * 4 + i]);
         if (irq != NULL && ((ints >> (8 + i)) & irq->trigger)) {
             irq->flags = 1;
             mp_irq_handler(&irq->base);
@@ -143,8 +143,8 @@ STATIC void rp2_pio_remove_all_managed_programs(PIO pio) {
 
 void rp2_pio_init(void) {
     // Set up interrupts.
-    memset(MP_STATE_PORT(rp2_pio_irq_obj), 0, sizeof(MP_STATE_PORT(rp2_pio_irq_obj)));
-    memset(MP_STATE_PORT(rp2_state_machine_irq_obj), 0, sizeof(MP_STATE_PORT(rp2_state_machine_irq_obj)));
+    memset(MP_ROOT_POINTER(rp2_pio_irq_obj), 0, sizeof(MP_ROOT_POINTER(rp2_pio_irq_obj)));
+    memset(MP_ROOT_POINTER(rp2_state_machine_irq_obj), 0, sizeof(MP_ROOT_POINTER(rp2_state_machine_irq_obj)));
     irq_set_exclusive_handler(PIO0_IRQ_0, pio0_irq0);
     irq_set_exclusive_handler(PIO1_IRQ_0, pio1_irq0);
 }
@@ -354,7 +354,7 @@ STATIC mp_obj_t rp2_pio_irq(size_t n_args, const mp_obj_t *pos_args, mp_map_t *k
     mp_arg_parse_all(n_args - 1, pos_args + 1, kw_args, MP_ARRAY_SIZE(allowed_args), allowed_args, args);
 
     // Get the IRQ object.
-    rp2_pio_irq_obj_t *irq = MP_STATE_PORT(rp2_pio_irq_obj[PIO_NUM(self->pio)]);
+    rp2_pio_irq_obj_t *irq = MP_ROOT_POINTER(rp2_pio_irq_obj[PIO_NUM(self->pio)]);
 
     // Allocate the IRQ object if it doesn't already exist.
     if (irq == NULL) {
@@ -364,7 +364,7 @@ STATIC mp_obj_t rp2_pio_irq(size_t n_args, const mp_obj_t *pos_args, mp_map_t *k
         irq->base.parent = MP_OBJ_FROM_PTR(self);
         irq->base.handler = mp_const_none;
         irq->base.ishard = false;
-        MP_STATE_PORT(rp2_pio_irq_obj[PIO_NUM(self->pio)]) = irq;
+        MP_ROOT_POINTER(rp2_pio_irq_obj[PIO_NUM(self->pio)]) = irq;
     }
 
     if (n_args > 1 || kw_args->used != 0) {
@@ -426,7 +426,7 @@ MP_DEFINE_CONST_OBJ_TYPE(
 
 STATIC mp_uint_t rp2_pio_irq_trigger(mp_obj_t self_in, mp_uint_t new_trigger) {
     rp2_pio_obj_t *self = MP_OBJ_TO_PTR(self_in);
-    rp2_pio_irq_obj_t *irq = MP_STATE_PORT(rp2_pio_irq_obj[PIO_NUM(self->pio)]);
+    rp2_pio_irq_obj_t *irq = MP_ROOT_POINTER(rp2_pio_irq_obj[PIO_NUM(self->pio)]);
     irq_set_enabled(self->irq, false);
     irq->flags = 0;
     irq->trigger = new_trigger;
@@ -436,7 +436,7 @@ STATIC mp_uint_t rp2_pio_irq_trigger(mp_obj_t self_in, mp_uint_t new_trigger) {
 
 STATIC mp_uint_t rp2_pio_irq_info(mp_obj_t self_in, mp_uint_t info_type) {
     rp2_pio_obj_t *self = MP_OBJ_TO_PTR(self_in);
-    rp2_pio_irq_obj_t *irq = MP_STATE_PORT(rp2_pio_irq_obj[PIO_NUM(self->pio)]);
+    rp2_pio_irq_obj_t *irq = MP_ROOT_POINTER(rp2_pio_irq_obj[PIO_NUM(self->pio)]);
     if (info_type == MP_IRQ_INFO_FLAGS) {
         return irq->flags;
     } else if (info_type == MP_IRQ_INFO_TRIGGERS) {
@@ -824,7 +824,7 @@ STATIC mp_obj_t rp2_state_machine_irq(size_t n_args, const mp_obj_t *pos_args, m
     mp_arg_parse_all(n_args - 1, pos_args + 1, kw_args, MP_ARRAY_SIZE(allowed_args), allowed_args, args);
 
     // Get the IRQ object.
-    rp2_state_machine_irq_obj_t *irq = MP_STATE_PORT(rp2_state_machine_irq_obj[self->id]);
+    rp2_state_machine_irq_obj_t *irq = MP_ROOT_POINTER(rp2_state_machine_irq_obj[self->id]);
 
     // Allocate the IRQ object if it doesn't already exist.
     if (irq == NULL) {
@@ -834,7 +834,7 @@ STATIC mp_obj_t rp2_state_machine_irq(size_t n_args, const mp_obj_t *pos_args, m
         irq->base.parent = MP_OBJ_FROM_PTR(self);
         irq->base.handler = mp_const_none;
         irq->base.ishard = false;
-        MP_STATE_PORT(rp2_state_machine_irq_obj[self->id]) = irq;
+        MP_ROOT_POINTER(rp2_state_machine_irq_obj[self->id]) = irq;
     }
 
     if (n_args > 1 || kw_args->used != 0) {
@@ -889,7 +889,7 @@ MP_DEFINE_CONST_OBJ_TYPE(
 
 STATIC mp_uint_t rp2_state_machine_irq_trigger(mp_obj_t self_in, mp_uint_t new_trigger) {
     rp2_state_machine_obj_t *self = MP_OBJ_TO_PTR(self_in);
-    rp2_state_machine_irq_obj_t *irq = MP_STATE_PORT(rp2_state_machine_irq_obj[PIO_NUM(self->pio)]);
+    rp2_state_machine_irq_obj_t *irq = MP_ROOT_POINTER(rp2_state_machine_irq_obj[PIO_NUM(self->pio)]);
     irq_set_enabled(self->irq, false);
     irq->flags = 0;
     irq->trigger = new_trigger;
@@ -899,7 +899,7 @@ STATIC mp_uint_t rp2_state_machine_irq_trigger(mp_obj_t self_in, mp_uint_t new_t
 
 STATIC mp_uint_t rp2_state_machine_irq_info(mp_obj_t self_in, mp_uint_t info_type) {
     rp2_state_machine_obj_t *self = MP_OBJ_TO_PTR(self_in);
-    rp2_state_machine_irq_obj_t *irq = MP_STATE_PORT(rp2_state_machine_irq_obj[PIO_NUM(self->pio)]);
+    rp2_state_machine_irq_obj_t *irq = MP_ROOT_POINTER(rp2_state_machine_irq_obj[PIO_NUM(self->pio)]);
     if (info_type == MP_IRQ_INFO_FLAGS) {
         return irq->flags;
     } else if (info_type == MP_IRQ_INFO_TRIGGERS) {

--- a/ports/rp2/rp2_pio.c
+++ b/ports/rp2/rp2_pio.c
@@ -82,7 +82,7 @@ STATIC void pio_irq0(PIO pio) {
     pio->irq = ints >> 8;
 
     // Call handler if it is registered, for PIO irqs.
-    rp2_pio_irq_obj_t *irq = MP_ROOT_POINTER(rp2_pio_irq_obj[PIO_NUM(pio)]);
+    rp2_pio_irq_obj_t *irq = MP_ROOT_POINTER(rp2_pio_irq_obj)[PIO_NUM(pio)];
     if (irq != NULL && (ints & irq->trigger)) {
         irq->flags = ints & irq->trigger;
         mp_irq_handler(&irq->base);
@@ -90,7 +90,7 @@ STATIC void pio_irq0(PIO pio) {
 
     // Call handler if it is registered, for StateMachine irqs.
     for (size_t i = 0; i < 4; ++i) {
-        rp2_state_machine_irq_obj_t *irq = MP_ROOT_POINTER(rp2_state_machine_irq_obj[PIO_NUM(pio) * 4 + i]);
+        rp2_state_machine_irq_obj_t *irq = MP_ROOT_POINTER(rp2_state_machine_irq_obj)[PIO_NUM(pio) * 4 + i];
         if (irq != NULL && ((ints >> (8 + i)) & irq->trigger)) {
             irq->flags = 1;
             mp_irq_handler(&irq->base);
@@ -354,7 +354,7 @@ STATIC mp_obj_t rp2_pio_irq(size_t n_args, const mp_obj_t *pos_args, mp_map_t *k
     mp_arg_parse_all(n_args - 1, pos_args + 1, kw_args, MP_ARRAY_SIZE(allowed_args), allowed_args, args);
 
     // Get the IRQ object.
-    rp2_pio_irq_obj_t *irq = MP_ROOT_POINTER(rp2_pio_irq_obj[PIO_NUM(self->pio)]);
+    rp2_pio_irq_obj_t *irq = MP_ROOT_POINTER(rp2_pio_irq_obj)[PIO_NUM(self->pio)];
 
     // Allocate the IRQ object if it doesn't already exist.
     if (irq == NULL) {
@@ -364,7 +364,7 @@ STATIC mp_obj_t rp2_pio_irq(size_t n_args, const mp_obj_t *pos_args, mp_map_t *k
         irq->base.parent = MP_OBJ_FROM_PTR(self);
         irq->base.handler = mp_const_none;
         irq->base.ishard = false;
-        MP_ROOT_POINTER(rp2_pio_irq_obj[PIO_NUM(self->pio)]) = irq;
+        MP_ROOT_POINTER(rp2_pio_irq_obj)[PIO_NUM(self->pio)] = irq;
     }
 
     if (n_args > 1 || kw_args->used != 0) {
@@ -426,7 +426,7 @@ MP_DEFINE_CONST_OBJ_TYPE(
 
 STATIC mp_uint_t rp2_pio_irq_trigger(mp_obj_t self_in, mp_uint_t new_trigger) {
     rp2_pio_obj_t *self = MP_OBJ_TO_PTR(self_in);
-    rp2_pio_irq_obj_t *irq = MP_ROOT_POINTER(rp2_pio_irq_obj[PIO_NUM(self->pio)]);
+    rp2_pio_irq_obj_t *irq = MP_ROOT_POINTER(rp2_pio_irq_obj)[PIO_NUM(self->pio)];
     irq_set_enabled(self->irq, false);
     irq->flags = 0;
     irq->trigger = new_trigger;
@@ -436,7 +436,7 @@ STATIC mp_uint_t rp2_pio_irq_trigger(mp_obj_t self_in, mp_uint_t new_trigger) {
 
 STATIC mp_uint_t rp2_pio_irq_info(mp_obj_t self_in, mp_uint_t info_type) {
     rp2_pio_obj_t *self = MP_OBJ_TO_PTR(self_in);
-    rp2_pio_irq_obj_t *irq = MP_ROOT_POINTER(rp2_pio_irq_obj[PIO_NUM(self->pio)]);
+    rp2_pio_irq_obj_t *irq = MP_ROOT_POINTER(rp2_pio_irq_obj)[PIO_NUM(self->pio)];
     if (info_type == MP_IRQ_INFO_FLAGS) {
         return irq->flags;
     } else if (info_type == MP_IRQ_INFO_TRIGGERS) {
@@ -824,7 +824,7 @@ STATIC mp_obj_t rp2_state_machine_irq(size_t n_args, const mp_obj_t *pos_args, m
     mp_arg_parse_all(n_args - 1, pos_args + 1, kw_args, MP_ARRAY_SIZE(allowed_args), allowed_args, args);
 
     // Get the IRQ object.
-    rp2_state_machine_irq_obj_t *irq = MP_ROOT_POINTER(rp2_state_machine_irq_obj[self->id]);
+    rp2_state_machine_irq_obj_t *irq = MP_ROOT_POINTER(rp2_state_machine_irq_obj)[self->id];
 
     // Allocate the IRQ object if it doesn't already exist.
     if (irq == NULL) {
@@ -834,7 +834,7 @@ STATIC mp_obj_t rp2_state_machine_irq(size_t n_args, const mp_obj_t *pos_args, m
         irq->base.parent = MP_OBJ_FROM_PTR(self);
         irq->base.handler = mp_const_none;
         irq->base.ishard = false;
-        MP_ROOT_POINTER(rp2_state_machine_irq_obj[self->id]) = irq;
+        MP_ROOT_POINTER(rp2_state_machine_irq_obj)[self->id] = irq;
     }
 
     if (n_args > 1 || kw_args->used != 0) {
@@ -889,7 +889,7 @@ MP_DEFINE_CONST_OBJ_TYPE(
 
 STATIC mp_uint_t rp2_state_machine_irq_trigger(mp_obj_t self_in, mp_uint_t new_trigger) {
     rp2_state_machine_obj_t *self = MP_OBJ_TO_PTR(self_in);
-    rp2_state_machine_irq_obj_t *irq = MP_ROOT_POINTER(rp2_state_machine_irq_obj[PIO_NUM(self->pio)]);
+    rp2_state_machine_irq_obj_t *irq = MP_ROOT_POINTER(rp2_state_machine_irq_obj)[PIO_NUM(self->pio)];
     irq_set_enabled(self->irq, false);
     irq->flags = 0;
     irq->trigger = new_trigger;
@@ -899,7 +899,7 @@ STATIC mp_uint_t rp2_state_machine_irq_trigger(mp_obj_t self_in, mp_uint_t new_t
 
 STATIC mp_uint_t rp2_state_machine_irq_info(mp_obj_t self_in, mp_uint_t info_type) {
     rp2_state_machine_obj_t *self = MP_OBJ_TO_PTR(self_in);
-    rp2_state_machine_irq_obj_t *irq = MP_ROOT_POINTER(rp2_state_machine_irq_obj[PIO_NUM(self->pio)]);
+    rp2_state_machine_irq_obj_t *irq = MP_ROOT_POINTER(rp2_state_machine_irq_obj)[PIO_NUM(self->pio)];
     if (info_type == MP_IRQ_INFO_FLAGS) {
         return irq->flags;
     } else if (info_type == MP_IRQ_INFO_TRIGGERS) {

--- a/ports/samd/machine_i2c.c
+++ b/ports/samd/machine_i2c.c
@@ -81,7 +81,7 @@ STATIC void i2c_send_command(Sercom *i2c, uint8_t command) {
 
 void common_i2c_irq_handler(int i2c_id) {
     // handle Sercom I2C IRQ
-    machine_i2c_obj_t *self = MP_ROOT_POINTER(sercom_table[i2c_id]);
+    machine_i2c_obj_t *self = MP_ROOT_POINTER(sercom_table)[i2c_id];
     // Handle IRQ
     if (self != NULL) {
         Sercom *i2c = self->instance;
@@ -161,7 +161,7 @@ mp_obj_t machine_i2c_make_new(const mp_obj_type_t *type, size_t n_args, size_t n
     if (sda_pad_config.pad_nr != 0 || scl_pad_config.pad_nr != 1) {
         mp_raise_ValueError(MP_ERROR_TEXT("invalid pin for sda or scl"));
     }
-    MP_ROOT_POINTER(sercom_table[self->id]) = self;
+    MP_ROOT_POINTER(sercom_table)[self->id] = self;
     self->freq = args[ARG_freq].u_int;
 
     // Configure the Pin mux.

--- a/ports/samd/machine_i2c.c
+++ b/ports/samd/machine_i2c.c
@@ -81,7 +81,7 @@ STATIC void i2c_send_command(Sercom *i2c, uint8_t command) {
 
 void common_i2c_irq_handler(int i2c_id) {
     // handle Sercom I2C IRQ
-    machine_i2c_obj_t *self = MP_STATE_PORT(sercom_table[i2c_id]);
+    machine_i2c_obj_t *self = MP_ROOT_POINTER(sercom_table[i2c_id]);
     // Handle IRQ
     if (self != NULL) {
         Sercom *i2c = self->instance;
@@ -161,7 +161,7 @@ mp_obj_t machine_i2c_make_new(const mp_obj_type_t *type, size_t n_args, size_t n
     if (sda_pad_config.pad_nr != 0 || scl_pad_config.pad_nr != 1) {
         mp_raise_ValueError(MP_ERROR_TEXT("invalid pin for sda or scl"));
     }
-    MP_STATE_PORT(sercom_table[self->id]) = self;
+    MP_ROOT_POINTER(sercom_table[self->id]) = self;
     self->freq = args[ARG_freq].u_int;
 
     // Configure the Pin mux.

--- a/ports/samd/machine_pin.c
+++ b/ports/samd/machine_pin.c
@@ -293,7 +293,7 @@ STATIC mp_obj_t machine_pin_irq(size_t n_args, const mp_obj_t *pos_args, mp_map_
 
     // Get the IRQ object.
     uint8_t eic_id = get_pin_obj_ptr(self->pin_id)->eic;
-    machine_pin_irq_obj_t *irq = MP_STATE_PORT(machine_pin_irq_objects[eic_id]);
+    machine_pin_irq_obj_t *irq = MP_ROOT_POINTER(machine_pin_irq_objects[eic_id]);
     if (irq != NULL && irq->pin_id != self->pin_id) {
         mp_raise_ValueError(MP_ERROR_TEXT("IRQ already used"));
     }
@@ -307,7 +307,7 @@ STATIC mp_obj_t machine_pin_irq(size_t n_args, const mp_obj_t *pos_args, mp_map_
         irq->base.handler = mp_const_none;
         irq->base.ishard = false;
         irq->pin_id = 0xff;
-        MP_STATE_PORT(machine_pin_irq_objects[eic_id]) = irq;
+        MP_ROOT_POINTER(machine_pin_irq_objects[eic_id]) = irq;
     }
     // (Re-)configure the irq.
     if (n_args > 1 || kw_args->used != 0) {
@@ -384,7 +384,7 @@ void pin_irq_deinit_all(void) {
 
     EIC->INTENCLR.reg = 0xffff;  // Disable all interrupts from the EIC.
     for (int i = 0; i < 16; i++) { // Clear all irq object pointers
-        MP_STATE_PORT(machine_pin_irq_objects[i]) = NULL;
+        MP_ROOT_POINTER(machine_pin_irq_objects[i]) = NULL;
     }
     // Disable all irq's at the NVIC controller
     #if defined(MCU_SAMD21)
@@ -405,7 +405,7 @@ void EIC_Handler() {
         if (isr & mask) {
             EIC_occured = true;
             EIC->INTFLAG.reg |= mask; // clear the ISR flag
-            machine_pin_irq_obj_t *irq = MP_STATE_PORT(machine_pin_irq_objects[eic_id]);
+            machine_pin_irq_obj_t *irq = MP_ROOT_POINTER(machine_pin_irq_objects[eic_id]);
             if (irq != NULL) {
                 irq->flags = irq->trigger;
                 mp_irq_handler(&irq->base);
@@ -481,7 +481,7 @@ MP_DEFINE_CONST_OBJ_TYPE(
 
 static uint8_t find_eic_id(int pin) {
     for (int eic_id = 0; eic_id < 16; eic_id++) {
-        machine_pin_irq_obj_t *irq = MP_STATE_PORT(machine_pin_irq_objects[eic_id]);
+        machine_pin_irq_obj_t *irq = MP_ROOT_POINTER(machine_pin_irq_objects[eic_id]);
         if (irq != NULL && irq->pin_id == pin) {
             return eic_id;
         }
@@ -493,7 +493,7 @@ STATIC mp_uint_t machine_pin_irq_trigger(mp_obj_t self_in, mp_uint_t new_trigger
     machine_pin_obj_t *self = MP_OBJ_TO_PTR(self_in);
     uint8_t eic_id = find_eic_id(self->pin_id);
     if (eic_id != 0xff) {
-        machine_pin_irq_obj_t *irq = MP_STATE_PORT(machine_pin_irq_objects[eic_id]);
+        machine_pin_irq_obj_t *irq = MP_ROOT_POINTER(machine_pin_irq_objects[eic_id]);
         EIC->INTENCLR.reg |= (1 << eic_id);
         irq->flags = 0;
         irq->trigger = new_trigger;
@@ -506,7 +506,7 @@ STATIC mp_uint_t machine_pin_irq_info(mp_obj_t self_in, mp_uint_t info_type) {
     machine_pin_obj_t *self = MP_OBJ_TO_PTR(self_in);
     uint8_t eic_id = find_eic_id(self->pin_id);
     if (eic_id != 0xff) {
-        machine_pin_irq_obj_t *irq = MP_STATE_PORT(machine_pin_irq_objects[eic_id]);
+        machine_pin_irq_obj_t *irq = MP_ROOT_POINTER(machine_pin_irq_objects[eic_id]);
         if (info_type == MP_IRQ_INFO_FLAGS) {
             return irq->flags;
         } else if (info_type == MP_IRQ_INFO_TRIGGERS) {

--- a/ports/samd/machine_spi.c
+++ b/ports/samd/machine_spi.c
@@ -64,7 +64,7 @@ extern Sercom *sercom_instance[];
 
 void common_spi_irq_handler(int spi_id) {
     // handle Sercom IRQ RXC
-    machine_spi_obj_t *self = MP_ROOT_POINTER(sercom_table[spi_id]);
+    machine_spi_obj_t *self = MP_ROOT_POINTER(sercom_table)[spi_id];
     // Handle IRQ
     if (self != NULL) {
         Sercom *spi = sercom_instance[self->id];
@@ -255,7 +255,7 @@ STATIC mp_obj_t machine_spi_make_new(const mp_obj_type_t *type, size_t n_args, s
     self->sck = 0xff;
 
     self->new = true;
-    MP_ROOT_POINTER(sercom_table[spi_id]) = self;
+    MP_ROOT_POINTER(sercom_table)[spi_id] = self;
 
     mp_map_t kw_args;
     mp_map_init_fixed_table(&kw_args, n_kw, args + n_args);
@@ -270,7 +270,7 @@ STATIC void machine_sercom_deinit(mp_obj_base_t *self_in) {
     spi->SPI.INTENCLR.reg = 0xff;
     sercom_enable(spi, 0);
     // clear table entry of spi
-    MP_ROOT_POINTER(sercom_table[self->id]) = NULL;
+    MP_ROOT_POINTER(sercom_table)[self->id] = NULL;
 }
 
 STATIC void machine_spi_transfer(mp_obj_base_t *self_in, size_t len, const uint8_t *src, uint8_t *dest) {

--- a/ports/samd/machine_spi.c
+++ b/ports/samd/machine_spi.c
@@ -64,7 +64,7 @@ extern Sercom *sercom_instance[];
 
 void common_spi_irq_handler(int spi_id) {
     // handle Sercom IRQ RXC
-    machine_spi_obj_t *self = MP_STATE_PORT(sercom_table[spi_id]);
+    machine_spi_obj_t *self = MP_ROOT_POINTER(sercom_table[spi_id]);
     // Handle IRQ
     if (self != NULL) {
         Sercom *spi = sercom_instance[self->id];
@@ -255,7 +255,7 @@ STATIC mp_obj_t machine_spi_make_new(const mp_obj_type_t *type, size_t n_args, s
     self->sck = 0xff;
 
     self->new = true;
-    MP_STATE_PORT(sercom_table[spi_id]) = self;
+    MP_ROOT_POINTER(sercom_table[spi_id]) = self;
 
     mp_map_t kw_args;
     mp_map_init_fixed_table(&kw_args, n_kw, args + n_args);
@@ -270,7 +270,7 @@ STATIC void machine_sercom_deinit(mp_obj_base_t *self_in) {
     spi->SPI.INTENCLR.reg = 0xff;
     sercom_enable(spi, 0);
     // clear table entry of spi
-    MP_STATE_PORT(sercom_table[self->id]) = NULL;
+    MP_ROOT_POINTER(sercom_table[self->id]) = NULL;
 }
 
 STATIC void machine_spi_transfer(mp_obj_base_t *self_in, size_t len, const uint8_t *src, uint8_t *dest) {

--- a/ports/samd/machine_uart.c
+++ b/ports/samd/machine_uart.c
@@ -86,7 +86,7 @@ void sercom_deinit_all(void) {
         uart->USART.INTENCLR.reg = 0xff;
         sercom_register_irq(i, NULL);
         sercom_enable(uart, 0);
-        MP_ROOT_POINTER(sercom_table[i]) = NULL;
+        MP_ROOT_POINTER(sercom_table)[i] = NULL;
     }
 }
 #endif
@@ -113,7 +113,7 @@ STATIC void uart_drain_rx_fifo(machine_uart_obj_t *self, Sercom *uart) {
 }
 
 void common_uart_irq_handler(int uart_id) {
-    machine_uart_obj_t *self = MP_ROOT_POINTER(sercom_table[uart_id]);
+    machine_uart_obj_t *self = MP_ROOT_POINTER(sercom_table)[uart_id];
     // Handle IRQ
     if (self != NULL) {
         Sercom *uart = sercom_instance[self->id];
@@ -401,7 +401,7 @@ STATIC mp_obj_t machine_uart_make_new(const mp_obj_type_t *type, size_t n_args, 
     self->cts = 0xff;
     #endif
     self->new = true;
-    MP_ROOT_POINTER(sercom_table[uart_id]) = self;
+    MP_ROOT_POINTER(sercom_table)[uart_id] = self;
 
     mp_map_t kw_args;
     mp_map_init_fixed_table(&kw_args, n_kw, args + n_args);

--- a/ports/samd/machine_uart.c
+++ b/ports/samd/machine_uart.c
@@ -86,7 +86,7 @@ void sercom_deinit_all(void) {
         uart->USART.INTENCLR.reg = 0xff;
         sercom_register_irq(i, NULL);
         sercom_enable(uart, 0);
-        MP_STATE_PORT(sercom_table[i]) = NULL;
+        MP_ROOT_POINTER(sercom_table[i]) = NULL;
     }
 }
 #endif
@@ -113,7 +113,7 @@ STATIC void uart_drain_rx_fifo(machine_uart_obj_t *self, Sercom *uart) {
 }
 
 void common_uart_irq_handler(int uart_id) {
-    machine_uart_obj_t *self = MP_STATE_PORT(sercom_table[uart_id]);
+    machine_uart_obj_t *self = MP_ROOT_POINTER(sercom_table[uart_id]);
     // Handle IRQ
     if (self != NULL) {
         Sercom *uart = sercom_instance[self->id];
@@ -401,7 +401,7 @@ STATIC mp_obj_t machine_uart_make_new(const mp_obj_type_t *type, size_t n_args, 
     self->cts = 0xff;
     #endif
     self->new = true;
-    MP_STATE_PORT(sercom_table[uart_id]) = self;
+    MP_ROOT_POINTER(sercom_table[uart_id]) = self;
 
     mp_map_t kw_args;
     mp_map_init_fixed_table(&kw_args, n_kw, args + n_args);
@@ -417,7 +417,7 @@ MP_DEFINE_CONST_FUN_OBJ_KW(machine_uart_init_obj, 1, machine_uart_init);
 STATIC mp_obj_t machine_uart_deinit(mp_obj_t self_in) {
     machine_uart_obj_t *self = MP_OBJ_TO_PTR(self_in);
     // Check if it is the active object.
-    if (MP_STATE_PORT(sercom_table)[self->id] == self) {
+    if (MP_ROOT_POINTER(sercom_table)[self->id] == self) {
         Sercom *uart = sercom_instance[self->id];
         // Disable interrupts and de-register the IRQ
         if (uart) {

--- a/ports/samd/mpconfigport.h
+++ b/ports/samd/mpconfigport.h
@@ -132,8 +132,6 @@
 #define MICROPY_PY_PLATFORM                 (1)
 #define MICROPY_PLATFORM_VERSION            "ASF4"
 
-#define MP_STATE_PORT MP_STATE_VM
-
 // Additional entries for use with pendsv_schedule_dispatch.
 #ifndef MICROPY_BOARD_PENDSV_ENTRIES
 #define MICROPY_BOARD_PENDSV_ENTRIES

--- a/ports/stm32/boardctrl.c
+++ b/ports/stm32/boardctrl.c
@@ -230,10 +230,10 @@ int boardctrl_run_main_py(boardctrl_state_t *state) {
     if (run_main_py) {
         // Run main.py (or what it was configured to be), if it exists.
         const char *main_py;
-        if (MP_STATE_PORT(pyb_config_main) == MP_OBJ_NULL) {
+        if (MP_ROOT_POINTER(pyb_config_main) == MP_OBJ_NULL) {
             main_py = "main.py";
         } else {
-            main_py = mp_obj_str_get_str(MP_STATE_PORT(pyb_config_main));
+            main_py = mp_obj_str_get_str(MP_ROOT_POINTER(pyb_config_main));
         }
         int ret = pyexec_file_if_exists(main_py);
 

--- a/ports/stm32/can.c
+++ b/ports/stm32/can.c
@@ -33,14 +33,14 @@
 #if MICROPY_HW_ENABLE_CAN
 
 void can_init0(void) {
-    for (uint i = 0; i < MP_ARRAY_SIZE(MP_STATE_PORT(pyb_can_obj_all)); i++) {
-        MP_STATE_PORT(pyb_can_obj_all)[i] = NULL;
+    for (uint i = 0; i < MP_ARRAY_SIZE(MP_ROOT_POINTER(pyb_can_obj_all)); i++) {
+        MP_ROOT_POINTER(pyb_can_obj_all)[i] = NULL;
     }
 }
 
 void can_deinit_all(void) {
-    for (int i = 0; i < MP_ARRAY_SIZE(MP_STATE_PORT(pyb_can_obj_all)); i++) {
-        pyb_can_obj_t *can_obj = MP_STATE_PORT(pyb_can_obj_all)[i];
+    for (int i = 0; i < MP_ARRAY_SIZE(MP_ROOT_POINTER(pyb_can_obj_all)); i++) {
+        pyb_can_obj_t *can_obj = MP_ROOT_POINTER(pyb_can_obj_all)[i];
         if (can_obj != NULL) {
             can_deinit(can_obj);
         }
@@ -318,7 +318,7 @@ STATIC void can_rx_irq_handler(uint can_id, uint fifo_id) {
     mp_obj_t irq_reason = MP_OBJ_NEW_SMALL_INT(0);
     byte *state;
 
-    self = MP_STATE_PORT(pyb_can_obj_all)[can_id - 1];
+    self = MP_ROOT_POINTER(pyb_can_obj_all)[can_id - 1];
 
     if (fifo_id == CAN_FIFO0) {
         callback = self->rxcallback0;
@@ -355,7 +355,7 @@ STATIC void can_rx_irq_handler(uint can_id, uint fifo_id) {
 }
 
 STATIC void can_sce_irq_handler(uint can_id) {
-    pyb_can_obj_t *self = MP_STATE_PORT(pyb_can_obj_all)[can_id - 1];
+    pyb_can_obj_t *self = MP_ROOT_POINTER(pyb_can_obj_all)[can_id - 1];
     if (self) {
         self->can.Instance->MSR = CAN_MSR_ERRI;
         uint32_t esr = self->can.Instance->ESR;

--- a/ports/stm32/extint.c
+++ b/ports/stm32/extint.c
@@ -276,7 +276,7 @@ uint extint_register(mp_obj_t pin_obj, uint32_t mode, uint32_t pull, mp_obj_t ca
         mp_raise_msg_varg(&mp_type_ValueError, MP_ERROR_TEXT("invalid ExtInt Pull: %d"), pull);
     }
 
-    mp_obj_t *cb = &MP_STATE_PORT(pyb_extint_callback)[v_line];
+    mp_obj_t *cb = &MP_ROOT_POINTER(pyb_extint_callback)[v_line];
     if (!override_callback_obj && *cb != mp_const_none && callback_obj != mp_const_none) {
         mp_raise_msg_varg(&mp_type_ValueError, MP_ERROR_TEXT("ExtInt vector %d is already in use"), v_line);
     }
@@ -322,7 +322,7 @@ void extint_register_pin(const pin_obj_t *pin, uint32_t mode, bool hard_irq, mp_
     uint32_t line = pin->pin;
 
     // Check if the ExtInt line is already in use by another Pin/ExtInt
-    mp_obj_t *cb = &MP_STATE_PORT(pyb_extint_callback)[line];
+    mp_obj_t *cb = &MP_ROOT_POINTER(pyb_extint_callback)[line];
     if (*cb != mp_const_none && MP_OBJ_FROM_PTR(pin) != pyb_extint_callback_arg[line]) {
         if (mp_obj_is_small_int(pyb_extint_callback_arg[line])) {
             mp_raise_msg_varg(&mp_type_OSError, MP_ERROR_TEXT("ExtInt vector %d is already in use"), line);
@@ -373,7 +373,7 @@ void extint_register_pin(const pin_obj_t *pin, uint32_t mode, bool hard_irq, mp_
 void extint_set(const pin_obj_t *pin, uint32_t mode) {
     uint32_t line = pin->pin;
 
-    mp_obj_t *cb = &MP_STATE_PORT(pyb_extint_callback)[line];
+    mp_obj_t *cb = &MP_ROOT_POINTER(pyb_extint_callback)[line];
 
     extint_disable(line);
 
@@ -697,10 +697,10 @@ MP_DEFINE_CONST_OBJ_TYPE(
 
 void extint_init0(void) {
     for (int i = 0; i < PYB_EXTI_NUM_VECTORS; i++) {
-        if (MP_STATE_PORT(pyb_extint_callback)[i] == MP_OBJ_SENTINEL) {
+        if (MP_ROOT_POINTER(pyb_extint_callback)[i] == MP_OBJ_SENTINEL) {
             continue;
         }
-        MP_STATE_PORT(pyb_extint_callback)[i] = mp_const_none;
+        MP_ROOT_POINTER(pyb_extint_callback)[i] = mp_const_none;
         pyb_extint_mode[i] = EXTI_Mode_Interrupt;
     }
 }
@@ -710,7 +710,7 @@ void Handle_EXTI_Irq(uint32_t line) {
     if (__HAL_GPIO_EXTI_GET_FLAG(1 << line)) {
         __HAL_GPIO_EXTI_CLEAR_FLAG(1 << line);
         if (line < EXTI_NUM_VECTORS) {
-            mp_obj_t *cb = &MP_STATE_PORT(pyb_extint_callback)[line];
+            mp_obj_t *cb = &MP_ROOT_POINTER(pyb_extint_callback)[line];
             #if MICROPY_PY_NETWORK_CYW43 && defined(pyb_pin_WL_HOST_WAKE)
             if (pyb_extint_callback_arg[line] == MP_OBJ_FROM_PTR(pyb_pin_WL_HOST_WAKE)) {
                 if (cyw43_poll) {

--- a/ports/stm32/fdcan.c
+++ b/ports/stm32/fdcan.c
@@ -346,7 +346,7 @@ STATIC void can_rx_irq_handler(uint can_id, uint fifo_id) {
     mp_obj_t irq_reason = MP_OBJ_NEW_SMALL_INT(0);
     byte *state;
 
-    self = MP_STATE_PORT(pyb_can_obj_all)[can_id - 1];
+    self = MP_ROOT_POINTER(pyb_can_obj_all)[can_id - 1];
 
     CAN_TypeDef *can = self->can.Instance;
 

--- a/ports/stm32/machine_i2s.c
+++ b/ports/stm32/machine_i2s.c
@@ -164,7 +164,7 @@ STATIC const int8_t i2s_frame_map[NUM_I2S_USER_FORMATS][I2S_RX_FRAME_SIZE_IN_BYT
 
 void machine_i2s_init0() {
     for (uint8_t i = 0; i < MICROPY_HW_MAX_I2S; i++) {
-        MP_STATE_PORT(machine_i2s_obj)[i] = NULL;
+        MP_ROOT_POINTER(machine_i2s_obj)[i] = NULL;
     }
 }
 
@@ -597,9 +597,9 @@ void HAL_I2S_ErrorCallback(I2S_HandleTypeDef *hi2s) {
 void HAL_I2S_RxCpltCallback(I2S_HandleTypeDef *hi2s) {
     machine_i2s_obj_t *self;
     if (hi2s->Instance == I2S1) {
-        self = MP_STATE_PORT(machine_i2s_obj)[0];
+        self = MP_ROOT_POINTER(machine_i2s_obj)[0];
     } else {
-        self = MP_STATE_PORT(machine_i2s_obj)[1];
+        self = MP_ROOT_POINTER(machine_i2s_obj)[1];
     }
 
     // bottom half of buffer now filled,
@@ -616,9 +616,9 @@ void HAL_I2S_RxCpltCallback(I2S_HandleTypeDef *hi2s) {
 void HAL_I2S_RxHalfCpltCallback(I2S_HandleTypeDef *hi2s) {
     machine_i2s_obj_t *self;
     if (hi2s->Instance == I2S1) {
-        self = MP_STATE_PORT(machine_i2s_obj)[0];
+        self = MP_ROOT_POINTER(machine_i2s_obj)[0];
     } else {
-        self = MP_STATE_PORT(machine_i2s_obj)[1];
+        self = MP_ROOT_POINTER(machine_i2s_obj)[1];
     }
 
     // top half of buffer now filled,
@@ -636,9 +636,9 @@ void HAL_I2S_TxCpltCallback(I2S_HandleTypeDef *hi2s) {
     machine_i2s_obj_t *self;
 
     if (hi2s->Instance == I2S1) {
-        self = MP_STATE_PORT(machine_i2s_obj)[0];
+        self = MP_ROOT_POINTER(machine_i2s_obj)[0];
     } else {
-        self = MP_STATE_PORT(machine_i2s_obj)[1];
+        self = MP_ROOT_POINTER(machine_i2s_obj)[1];
     }
 
     // for non-blocking operation, this IRQ-based callback handles
@@ -655,9 +655,9 @@ void HAL_I2S_TxCpltCallback(I2S_HandleTypeDef *hi2s) {
 void HAL_I2S_TxHalfCpltCallback(I2S_HandleTypeDef *hi2s) {
     machine_i2s_obj_t *self;
     if (hi2s->Instance == I2S1) {
-        self = MP_STATE_PORT(machine_i2s_obj)[0];
+        self = MP_ROOT_POINTER(machine_i2s_obj)[0];
     } else {
-        self = MP_STATE_PORT(machine_i2s_obj)[1];
+        self = MP_ROOT_POINTER(machine_i2s_obj)[1];
     }
 
     // for non-blocking operation, this IRQ-based callback handles
@@ -858,12 +858,12 @@ STATIC mp_obj_t machine_i2s_make_new(const mp_obj_type_t *type, size_t n_pos_arg
     }
 
     machine_i2s_obj_t *self;
-    if (MP_STATE_PORT(machine_i2s_obj)[i2s_id_zero_base] == NULL) {
+    if (MP_ROOT_POINTER(machine_i2s_obj)[i2s_id_zero_base] == NULL) {
         self = mp_obj_malloc(machine_i2s_obj_t, &machine_i2s_type);
-        MP_STATE_PORT(machine_i2s_obj)[i2s_id_zero_base] = self;
+        MP_ROOT_POINTER(machine_i2s_obj)[i2s_id_zero_base] = self;
         self->i2s_id = i2s_id;
     } else {
-        self = MP_STATE_PORT(machine_i2s_obj)[i2s_id_zero_base];
+        self = MP_ROOT_POINTER(machine_i2s_obj)[i2s_id_zero_base];
         machine_i2s_deinit(MP_OBJ_FROM_PTR(self));
     }
 

--- a/ports/stm32/machine_uart.c
+++ b/ports/stm32/machine_uart.c
@@ -392,15 +392,15 @@ STATIC mp_obj_t pyb_uart_make_new(const mp_obj_type_t *type, size_t n_args, size
     }
 
     pyb_uart_obj_t *self;
-    if (MP_STATE_PORT(pyb_uart_obj_all)[uart_id - 1] == NULL) {
+    if (MP_ROOT_POINTER(pyb_uart_obj_all)[uart_id - 1] == NULL) {
         // create new UART object
         self = m_new0(pyb_uart_obj_t, 1);
         self->base.type = &pyb_uart_type;
         self->uart_id = uart_id;
-        MP_STATE_PORT(pyb_uart_obj_all)[uart_id - 1] = self;
+        MP_ROOT_POINTER(pyb_uart_obj_all)[uart_id - 1] = self;
     } else {
         // reference existing UART object
-        self = MP_STATE_PORT(pyb_uart_obj_all)[uart_id - 1];
+        self = MP_ROOT_POINTER(pyb_uart_obj_all)[uart_id - 1];
     }
 
     if (n_args > 1 || n_kw > 0) {

--- a/ports/stm32/main.c
+++ b/ports/stm32/main.c
@@ -124,7 +124,7 @@ STATIC mp_obj_t pyb_main(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_a
     };
 
     if (mp_obj_is_str(pos_args[0])) {
-        MP_STATE_PORT(pyb_config_main) = pos_args[0];
+        MP_ROOT_POINTER(pyb_config_main) = pos_args[0];
 
         // parse args
         mp_arg_val_t args[MP_ARRAY_SIZE(allowed_args)];
@@ -261,7 +261,7 @@ STATIC bool init_sdcard_fs(void) {
             }
             vfs->obj = MP_OBJ_FROM_PTR(vfs_fat);
             vfs->next = NULL;
-            for (mp_vfs_mount_t **m = &MP_STATE_VM(vfs_mount_table);; m = &(*m)->next) {
+            for (mp_vfs_mount_t **m = &MP_ROOT_POINTER(vfs_mount_table);; m = &(*m)->next) {
                 if (*m == NULL) {
                     *m = vfs;
                     break;
@@ -282,7 +282,7 @@ STATIC bool init_sdcard_fs(void) {
             {
                 if (first_part) {
                     // use SD card as current directory
-                    MP_STATE_PORT(vfs_cur) = vfs;
+                    MP_ROOT_POINTER(vfs_cur) = vfs;
                 }
             }
             first_part = false;
@@ -439,8 +439,8 @@ void stm32_main(uint32_t reset_mode) {
     uart_init(&pyb_uart_repl_obj, MICROPY_HW_UART_REPL_BAUD, UART_WORDLENGTH_8B, UART_PARITY_NONE, UART_STOPBITS_1, 0);
     uart_set_rxbuf(&pyb_uart_repl_obj, sizeof(pyb_uart_repl_rxbuf), pyb_uart_repl_rxbuf);
     uart_attach_to_repl(&pyb_uart_repl_obj, true);
-    MP_STATE_PORT(pyb_uart_obj_all)[MICROPY_HW_UART_REPL - 1] = &pyb_uart_repl_obj;
-    MP_STATE_PORT(pyb_stdio_uart) = &pyb_uart_repl_obj;
+    MP_ROOT_POINTER(pyb_uart_obj_all)[MICROPY_HW_UART_REPL - 1] = &pyb_uart_repl_obj;
+    MP_ROOT_POINTER(pyb_stdio_uart) = &pyb_uart_repl_obj;
     #endif
 
     spi_init0();
@@ -568,7 +568,7 @@ soft_reset:
     }
 
     // reset config variables; they should be set by boot.py
-    MP_STATE_PORT(pyb_config_main) = MP_OBJ_NULL;
+    MP_ROOT_POINTER(pyb_config_main) = MP_OBJ_NULL;
 
     // Run optional frozen boot code.
     #ifdef MICROPY_BOARD_FROZEN_BOOT_FILE
@@ -676,9 +676,9 @@ soft_reset_exit:
     #endif
 
     #if defined(MICROPY_HW_UART_REPL)
-    MP_STATE_PORT(pyb_stdio_uart) = &pyb_uart_repl_obj;
+    MP_ROOT_POINTER(pyb_stdio_uart) = &pyb_uart_repl_obj;
     #else
-    MP_STATE_PORT(pyb_stdio_uart) = NULL;
+    MP_ROOT_POINTER(pyb_stdio_uart) = NULL;
     #endif
 
     MICROPY_BOARD_END_SOFT_RESET(&state);

--- a/ports/stm32/modmachine.c
+++ b/ports/stm32/modmachine.c
@@ -229,7 +229,7 @@ STATIC mp_obj_t machine_info(size_t n_args, const mp_obj_t *args) {
     // free space on flash
     {
         #if MICROPY_VFS_FAT
-        for (mp_vfs_mount_t *vfs = MP_STATE_VM(vfs_mount_table); vfs != NULL; vfs = vfs->next) {
+        for (mp_vfs_mount_t *vfs = MP_ROOT_POINTER(vfs_mount_table); vfs != NULL; vfs = vfs->next) {
             if (strncmp("/flash", vfs->str, vfs->len) == 0) {
                 // assumes that it's a FatFs filesystem
                 fs_user_mount_t *vfs_fat = MP_OBJ_TO_PTR(vfs->obj);

--- a/ports/stm32/modpyb.c
+++ b/ports/stm32/modpyb.c
@@ -92,20 +92,20 @@ MP_DECLARE_CONST_FUN_OBJ_KW(pyb_main_obj); // defined in main.c
 // This is a legacy function, use of os.dupterm is preferred.
 STATIC mp_obj_t pyb_repl_uart(size_t n_args, const mp_obj_t *args) {
     if (n_args == 0) {
-        if (MP_STATE_PORT(pyb_stdio_uart) == NULL) {
+        if (MP_ROOT_POINTER(pyb_stdio_uart) == NULL) {
             return mp_const_none;
         } else {
-            return MP_OBJ_FROM_PTR(MP_STATE_PORT(pyb_stdio_uart));
+            return MP_OBJ_FROM_PTR(MP_ROOT_POINTER(pyb_stdio_uart));
         }
     } else {
         if (args[0] == mp_const_none) {
-            if (MP_STATE_PORT(pyb_stdio_uart) != NULL) {
-                uart_attach_to_repl(MP_STATE_PORT(pyb_stdio_uart), false);
-                MP_STATE_PORT(pyb_stdio_uart) = NULL;
+            if (MP_ROOT_POINTER(pyb_stdio_uart) != NULL) {
+                uart_attach_to_repl(MP_ROOT_POINTER(pyb_stdio_uart), false);
+                MP_ROOT_POINTER(pyb_stdio_uart) = NULL;
             }
         } else if (mp_obj_get_type(args[0]) == &pyb_uart_type) {
-            MP_STATE_PORT(pyb_stdio_uart) = MP_OBJ_TO_PTR(args[0]);
-            uart_attach_to_repl(MP_STATE_PORT(pyb_stdio_uart), true);
+            MP_ROOT_POINTER(pyb_stdio_uart) = MP_OBJ_TO_PTR(args[0]);
+            uart_attach_to_repl(MP_ROOT_POINTER(pyb_stdio_uart), true);
         } else {
             mp_raise_ValueError(MP_ERROR_TEXT("need a UART object"));
         }

--- a/ports/stm32/mpbthciport.c
+++ b/ports/stm32/mpbthciport.c
@@ -175,7 +175,7 @@ int mp_bluetooth_hci_uart_init(uint32_t port, uint32_t baudrate) {
     // We don't want to block indefinitely, but expect flow control is doing its job.
     mp_bluetooth_hci_uart_obj.timeout = 200;
     mp_bluetooth_hci_uart_obj.timeout_char = 200;
-    MP_STATE_PORT(pyb_uart_obj_all)[mp_bluetooth_hci_uart_obj.uart_id - 1] = &mp_bluetooth_hci_uart_obj;
+    MP_ROOT_POINTER(pyb_uart_obj_all)[mp_bluetooth_hci_uart_obj.uart_id - 1] = &mp_bluetooth_hci_uart_obj;
 
     // Initialise the UART.
     uart_init(&mp_bluetooth_hci_uart_obj, baudrate, UART_WORDLENGTH_8B, UART_PARITY_NONE, UART_STOPBITS_1, UART_HWCONTROL_RTS | UART_HWCONTROL_CTS);

--- a/ports/stm32/mpconfigport.h
+++ b/ports/stm32/mpconfigport.h
@@ -204,8 +204,6 @@ extern const struct _mp_obj_type_t mod_network_nic_type_wiznet5k;
     MICROPY_HW_NIC_WIZNET5K \
     MICROPY_BOARD_NETWORK_INTERFACES \
 
-#define MP_STATE_PORT MP_STATE_VM
-
 // type definitions for the specific machine
 
 #define MICROPY_MAKE_POINTER_CALLABLE(p) ((void *)((uint32_t)(p) | 1))

--- a/ports/stm32/mphalport.c
+++ b/ports/stm32/mphalport.c
@@ -26,8 +26,8 @@ NORETURN void mp_hal_raise(HAL_StatusTypeDef status) {
 
 MP_WEAK uintptr_t mp_hal_stdio_poll(uintptr_t poll_flags) {
     uintptr_t ret = 0;
-    if (MP_STATE_PORT(pyb_stdio_uart) != NULL) {
-        mp_obj_t pyb_stdio_uart = MP_OBJ_FROM_PTR(MP_STATE_PORT(pyb_stdio_uart));
+    if (MP_ROOT_POINTER(pyb_stdio_uart) != NULL) {
+        mp_obj_t pyb_stdio_uart = MP_OBJ_FROM_PTR(MP_ROOT_POINTER(pyb_stdio_uart));
         int errcode;
         const mp_stream_p_t *stream_p = mp_get_stream(pyb_stdio_uart);
         ret = stream_p->ioctl(pyb_stdio_uart, MP_STREAM_POLL, poll_flags, &errcode);
@@ -46,8 +46,8 @@ MP_WEAK int mp_hal_stdin_rx_chr(void) {
         }
         #endif
         #endif
-        if (MP_STATE_PORT(pyb_stdio_uart) != NULL && uart_rx_any(MP_STATE_PORT(pyb_stdio_uart))) {
-            return uart_rx_char(MP_STATE_PORT(pyb_stdio_uart));
+        if (MP_ROOT_POINTER(pyb_stdio_uart) != NULL && uart_rx_any(MP_ROOT_POINTER(pyb_stdio_uart))) {
+            return uart_rx_char(MP_ROOT_POINTER(pyb_stdio_uart));
         }
         int dupterm_c = mp_os_dupterm_rx_chr();
         if (dupterm_c >= 0) {
@@ -58,8 +58,8 @@ MP_WEAK int mp_hal_stdin_rx_chr(void) {
 }
 
 MP_WEAK void mp_hal_stdout_tx_strn(const char *str, size_t len) {
-    if (MP_STATE_PORT(pyb_stdio_uart) != NULL) {
-        uart_tx_strn(MP_STATE_PORT(pyb_stdio_uart), str, len);
+    if (MP_ROOT_POINTER(pyb_stdio_uart) != NULL) {
+        uart_tx_strn(MP_ROOT_POINTER(pyb_stdio_uart), str, len);
     }
     #if 0 && defined(USE_HOST_MODE) && MICROPY_HW_HAS_LCD
     lcd_print_strn(str, len);

--- a/ports/stm32/pin.c
+++ b/ports/stm32/pin.c
@@ -91,8 +91,8 @@
 STATIC bool pin_class_debug;
 
 void pin_init0(void) {
-    MP_STATE_PORT(pin_class_mapper) = mp_const_none;
-    MP_STATE_PORT(pin_class_map_dict) = mp_const_none;
+    MP_ROOT_POINTER(pin_class_mapper) = mp_const_none;
+    MP_ROOT_POINTER(pin_class_map_dict) = mp_const_none;
     pin_class_debug = false;
 }
 
@@ -113,8 +113,8 @@ const pin_obj_t *pin_find(mp_obj_t user_obj) {
         return pin_obj;
     }
 
-    if (MP_STATE_PORT(pin_class_mapper) != mp_const_none) {
-        mp_obj_t o = mp_call_function_1(MP_STATE_PORT(pin_class_mapper), user_obj);
+    if (MP_ROOT_POINTER(pin_class_mapper) != mp_const_none) {
+        mp_obj_t o = mp_call_function_1(MP_ROOT_POINTER(pin_class_mapper), user_obj);
         if (o != mp_const_none) {
             if (!mp_obj_is_type(o, &pin_type)) {
                 mp_raise_ValueError(MP_ERROR_TEXT("Pin.mapper didn't return a Pin object"));
@@ -132,8 +132,8 @@ const pin_obj_t *pin_find(mp_obj_t user_obj) {
         // other lookup methods.
     }
 
-    if (MP_STATE_PORT(pin_class_map_dict) != mp_const_none) {
-        mp_map_t *pin_map_map = mp_obj_dict_get_map(MP_STATE_PORT(pin_class_map_dict));
+    if (MP_ROOT_POINTER(pin_class_map_dict) != mp_const_none) {
+        mp_map_t *pin_map_map = mp_obj_dict_get_map(MP_ROOT_POINTER(pin_class_map_dict));
         mp_map_elem_t *elem = mp_map_lookup(pin_map_map, user_obj, MP_MAP_LOOKUP);
         if (elem != NULL && elem->value != MP_OBJ_NULL) {
             mp_obj_t o = elem->value;
@@ -280,10 +280,10 @@ STATIC mp_obj_t pin_call(mp_obj_t self_in, size_t n_args, size_t n_kw, const mp_
 /// Get or set the pin mapper function.
 STATIC mp_obj_t pin_mapper(size_t n_args, const mp_obj_t *args) {
     if (n_args > 1) {
-        MP_STATE_PORT(pin_class_mapper) = args[1];
+        MP_ROOT_POINTER(pin_class_mapper) = args[1];
         return mp_const_none;
     }
-    return MP_STATE_PORT(pin_class_mapper);
+    return MP_ROOT_POINTER(pin_class_mapper);
 }
 STATIC MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(pin_mapper_fun_obj, 1, 2, pin_mapper);
 STATIC MP_DEFINE_CONST_CLASSMETHOD_OBJ(pin_mapper_obj, MP_ROM_PTR(&pin_mapper_fun_obj));
@@ -292,10 +292,10 @@ STATIC MP_DEFINE_CONST_CLASSMETHOD_OBJ(pin_mapper_obj, MP_ROM_PTR(&pin_mapper_fu
 /// Get or set the pin mapper dictionary.
 STATIC mp_obj_t pin_map_dict(size_t n_args, const mp_obj_t *args) {
     if (n_args > 1) {
-        MP_STATE_PORT(pin_class_map_dict) = args[1];
+        MP_ROOT_POINTER(pin_class_map_dict) = args[1];
         return mp_const_none;
     }
-    return MP_STATE_PORT(pin_class_map_dict);
+    return MP_ROOT_POINTER(pin_class_map_dict);
 }
 STATIC MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(pin_map_dict_fun_obj, 1, 2, pin_map_dict);
 STATIC MP_DEFINE_CONST_CLASSMETHOD_OBJ(pin_map_dict_obj, MP_ROM_PTR(&pin_map_dict_fun_obj));

--- a/ports/stm32/pyb_can.c
+++ b/ports/stm32/pyb_can.c
@@ -312,7 +312,7 @@ STATIC mp_obj_t pyb_can_make_new(const mp_obj_type_t *type, size_t n_args, size_
     } else {
         can_idx = mp_obj_get_int(args[0]);
     }
-    if (can_idx < 1 || can_idx > MP_ARRAY_SIZE(MP_STATE_PORT(pyb_can_obj_all))) {
+    if (can_idx < 1 || can_idx > MP_ARRAY_SIZE(MP_ROOT_POINTER(pyb_can_obj_all))) {
         mp_raise_msg_varg(&mp_type_ValueError, MP_ERROR_TEXT("CAN(%d) doesn't exist"), can_idx);
     }
 
@@ -322,13 +322,13 @@ STATIC mp_obj_t pyb_can_make_new(const mp_obj_type_t *type, size_t n_args, size_
     }
 
     pyb_can_obj_t *self;
-    if (MP_STATE_PORT(pyb_can_obj_all)[can_idx - 1] == NULL) {
+    if (MP_ROOT_POINTER(pyb_can_obj_all)[can_idx - 1] == NULL) {
         self = mp_obj_malloc(pyb_can_obj_t, &pyb_can_type);
         self->can_id = can_idx;
         self->is_enabled = false;
-        MP_STATE_PORT(pyb_can_obj_all)[can_idx - 1] = self;
+        MP_ROOT_POINTER(pyb_can_obj_all)[can_idx - 1] = self;
     } else {
-        self = MP_STATE_PORT(pyb_can_obj_all)[can_idx - 1];
+        self = MP_ROOT_POINTER(pyb_can_obj_all)[can_idx - 1];
     }
 
     if (!self->is_enabled || n_args > 1) {

--- a/ports/stm32/rtc.c
+++ b/ports/stm32/rtc.c
@@ -730,7 +730,7 @@ mp_obj_t pyb_rtc_wakeup(size_t n_args, const mp_obj_t *args) {
     }
 
     // set the callback
-    MP_STATE_PORT(pyb_extint_callback)[EXTI_RTC_WAKEUP] = callback;
+    MP_ROOT_POINTER(pyb_extint_callback)[EXTI_RTC_WAKEUP] = callback;
 
     // disable register write protection
     RTC->WPR = 0xca;

--- a/ports/stm32/subghz.c
+++ b/ports/stm32/subghz.c
@@ -43,7 +43,7 @@ STATIC void handle_radio_irq() {
     // subghz_irq(handler) to re-enable when needed.
     HAL_NVIC_DisableIRQ(SUBGHZ_Radio_IRQn);
 
-    mp_obj_t callback = MP_STATE_PORT(subghz_callback);
+    mp_obj_t callback = MP_ROOT_POINTER(subghz_callback);
     if (callback != mp_const_none) {
         mp_sched_lock();
         gc_lock();
@@ -80,11 +80,11 @@ void subghz_init(void) {
     while (__HAL_RCC_GET_FLAG(RCC_FLAG_RFRST) != 0) {
     }
 
-    MP_STATE_PORT(subghz_callback) = mp_const_none;
+    MP_ROOT_POINTER(subghz_callback) = mp_const_none;
 }
 
 void subghz_deinit(void) {
-    MP_STATE_PORT(subghz_callback) = mp_const_none;
+    MP_ROOT_POINTER(subghz_callback) = mp_const_none;
     NVIC_DisableIRQ(SUBGHZ_Radio_IRQn);
     __HAL_RCC_SUBGHZ_RADIO_FORCE_RESET();
     __HAL_RCC_SUBGHZ_RADIO_RELEASE_RESET();
@@ -104,7 +104,7 @@ STATIC mp_obj_t subghz_cs(mp_obj_t value) {
 MP_DEFINE_CONST_FUN_OBJ_1(subghz_cs_obj, subghz_cs);
 
 STATIC mp_obj_t subghz_irq(mp_obj_t handler) {
-    MP_STATE_PORT(subghz_callback) = handler;
+    MP_ROOT_POINTER(subghz_callback) = handler;
 
     if (mp_obj_is_true(handler)) {
         HAL_NVIC_ClearPendingIRQ(SUBGHZ_Radio_IRQn);

--- a/ports/stm32/timer.c
+++ b/ports/stm32/timer.c
@@ -145,7 +145,7 @@ typedef struct _pyb_timer_obj_t {
 TIM_HandleTypeDef TIM5_Handle;
 TIM_HandleTypeDef TIM6_Handle;
 
-#define PYB_TIMER_OBJ_ALL_NUM MP_ARRAY_SIZE(MP_STATE_PORT(pyb_timer_obj_all))
+#define PYB_TIMER_OBJ_ALL_NUM MP_ARRAY_SIZE(MP_ROOT_POINTER(pyb_timer_obj_all))
 
 STATIC mp_obj_t pyb_timer_deinit(mp_obj_t self_in);
 STATIC mp_obj_t pyb_timer_callback(mp_obj_t self_in, mp_obj_t callback);
@@ -153,14 +153,14 @@ STATIC mp_obj_t pyb_timer_channel_callback(mp_obj_t self_in, mp_obj_t callback);
 
 void timer_init0(void) {
     for (uint i = 0; i < PYB_TIMER_OBJ_ALL_NUM; i++) {
-        MP_STATE_PORT(pyb_timer_obj_all)[i] = NULL;
+        MP_ROOT_POINTER(pyb_timer_obj_all)[i] = NULL;
     }
 }
 
 // unregister all interrupt sources
 void timer_deinit(void) {
     for (uint i = 0; i < PYB_TIMER_OBJ_ALL_NUM; i++) {
-        pyb_timer_obj_t *tim = MP_STATE_PORT(pyb_timer_obj_all)[i];
+        pyb_timer_obj_t *tim = MP_ROOT_POINTER(pyb_timer_obj_all)[i];
         if (tim != NULL) {
             pyb_timer_deinit(MP_OBJ_FROM_PTR(tim));
         }
@@ -995,7 +995,7 @@ STATIC mp_obj_t pyb_timer_make_new(const mp_obj_type_t *type, size_t n_args, siz
     }
 
     pyb_timer_obj_t *tim;
-    if (MP_STATE_PORT(pyb_timer_obj_all)[tim_id - 1] == NULL) {
+    if (MP_ROOT_POINTER(pyb_timer_obj_all)[tim_id - 1] == NULL) {
         // create new Timer object
         tim = m_new_obj(pyb_timer_obj_t);
         memset(tim, 0, sizeof(*tim));
@@ -1010,10 +1010,10 @@ STATIC mp_obj_t pyb_timer_make_new(const mp_obj_type_t *type, size_t n_args, siz
         uint32_t ti = tim_instance_table[tim_id - 1];
         tim->tim.Instance = (TIM_TypeDef *)(ti & 0xffffff00);
         tim->irqn = ti & 0xff;
-        MP_STATE_PORT(pyb_timer_obj_all)[tim_id - 1] = tim;
+        MP_ROOT_POINTER(pyb_timer_obj_all)[tim_id - 1] = tim;
     } else {
         // reference existing Timer object
-        tim = MP_STATE_PORT(pyb_timer_obj_all)[tim_id - 1];
+        tim = MP_ROOT_POINTER(pyb_timer_obj_all)[tim_id - 1];
     }
 
     if (n_args > 1 || n_kw > 0) {
@@ -1727,7 +1727,7 @@ STATIC void timer_handle_irq_channel(pyb_timer_obj_t *tim, uint8_t channel, mp_o
 void timer_irq_handler(uint tim_id) {
     if (tim_id - 1 < PYB_TIMER_OBJ_ALL_NUM) {
         // get the timer object
-        pyb_timer_obj_t *tim = MP_STATE_PORT(pyb_timer_obj_all)[tim_id - 1];
+        pyb_timer_obj_t *tim = MP_ROOT_POINTER(pyb_timer_obj_all)[tim_id - 1];
 
         if (tim == NULL) {
             // Timer object has not been set, so we can't do anything.

--- a/ports/stm32/uart.c
+++ b/ports/stm32/uart.c
@@ -162,17 +162,17 @@ void uart_init0(void) {
 
 // unregister all interrupt sources
 void uart_deinit_all(void) {
-    for (int i = 0; i < MP_ARRAY_SIZE(MP_STATE_PORT(pyb_uart_obj_all)); i++) {
-        pyb_uart_obj_t *uart_obj = MP_STATE_PORT(pyb_uart_obj_all)[i];
+    for (int i = 0; i < MP_ARRAY_SIZE(MP_ROOT_POINTER(pyb_uart_obj_all)); i++) {
+        pyb_uart_obj_t *uart_obj = MP_ROOT_POINTER(pyb_uart_obj_all)[i];
         if (uart_obj != NULL && !uart_obj->is_static) {
             uart_deinit(uart_obj);
-            MP_STATE_PORT(pyb_uart_obj_all)[i] = NULL;
+            MP_ROOT_POINTER(pyb_uart_obj_all)[i] = NULL;
         }
     }
 }
 
 bool uart_exists(int uart_id) {
-    if (uart_id > MP_ARRAY_SIZE(MP_STATE_PORT(pyb_uart_obj_all))) {
+    if (uart_id > MP_ARRAY_SIZE(MP_ROOT_POINTER(pyb_uart_obj_all))) {
         // safeguard against pyb_uart_obj_all array being configured too small
         return false;
     }
@@ -1126,7 +1126,7 @@ void uart_tx_strn(pyb_uart_obj_t *uart_obj, const char *str, uint len) {
 // - On STM32F4 the IRQ flags are cleared by reading SR then DR.
 void uart_irq_handler(mp_uint_t uart_id) {
     // get the uart object
-    pyb_uart_obj_t *self = MP_STATE_PORT(pyb_uart_obj_all)[uart_id - 1];
+    pyb_uart_obj_t *self = MP_ROOT_POINTER(pyb_uart_obj_all)[uart_id - 1];
 
     if (self == NULL) {
         // UART object has not been set, so we can't do anything, not

--- a/ports/stm32/usb.c
+++ b/ports/stm32/usb.c
@@ -227,7 +227,7 @@ void pyb_usb_init0(void) {
         usb_device.usbd_cdc_itf[i].attached_to_repl = false;
     }
     #if MICROPY_HW_USB_HID
-    MP_STATE_PORT(pyb_hid_report_desc) = MP_OBJ_NULL;
+    MP_ROOT_POINTER(pyb_hid_report_desc) = MP_OBJ_NULL;
     #endif
 
     pyb_usb_vcp_init0();
@@ -583,7 +583,7 @@ STATIC mp_obj_t pyb_usb_mode(size_t n_args, const mp_obj_t *pos_args, mp_map_t *
         hid_info.report_desc_len = bufinfo.len;
 
         // need to keep a copy of this so report_desc does not get GC'd
-        MP_STATE_PORT(pyb_hid_report_desc) = items[4];
+        MP_ROOT_POINTER(pyb_hid_report_desc) = items[4];
     }
     #endif
 
@@ -642,19 +642,19 @@ STATIC bool pyb_usb_vcp_irq_scheduled[MICROPY_HW_USB_CDC_NUM];
 
 STATIC void pyb_usb_vcp_init0(void) {
     for (size_t i = 0; i < MICROPY_HW_USB_CDC_NUM; ++i) {
-        MP_STATE_PORT(pyb_usb_vcp_irq)[i] = mp_const_none;
+        MP_ROOT_POINTER(pyb_usb_vcp_irq)[i] = mp_const_none;
         pyb_usb_vcp_irq_scheduled[i] = false;
     }
 
     // Activate USB_VCP(0) on dupterm slot 1 for the REPL
-    MP_STATE_VM(dupterm_objs[1]) = MP_OBJ_FROM_PTR(&pyb_usb_vcp_obj[0]);
+    MP_ROOT_POINTER(dupterm_objs[1]) = MP_OBJ_FROM_PTR(&pyb_usb_vcp_obj[0]);
     usb_vcp_attach_to_repl(&pyb_usb_vcp_obj[0], true);
 }
 
 STATIC mp_obj_t pyb_usb_vcp_irq_run(mp_obj_t self_in) {
     pyb_usb_vcp_obj_t *self = MP_OBJ_TO_PTR(self_in);
     uint8_t idx = self->cdc_itf->cdc_idx;
-    mp_obj_t callback = MP_STATE_PORT(pyb_usb_vcp_irq)[idx];
+    mp_obj_t callback = MP_ROOT_POINTER(pyb_usb_vcp_irq)[idx];
     pyb_usb_vcp_irq_scheduled[idx] = false;
     if (callback != mp_const_none && usbd_cdc_rx_num(self->cdc_itf)) {
         mp_call_function_1(callback, self_in);
@@ -666,7 +666,7 @@ STATIC MP_DEFINE_CONST_FUN_OBJ_1(pyb_usb_vcp_irq_run_obj, pyb_usb_vcp_irq_run);
 void usbd_cdc_rx_event_callback(usbd_cdc_itf_t *cdc) {
     uint8_t idx = cdc->cdc_idx;
     mp_obj_t self = MP_OBJ_FROM_PTR(&pyb_usb_vcp_obj[idx]);
-    mp_obj_t callback = MP_STATE_PORT(pyb_usb_vcp_irq)[idx];
+    mp_obj_t callback = MP_ROOT_POINTER(pyb_usb_vcp_irq)[idx];
     if (callback != mp_const_none && !pyb_usb_vcp_irq_scheduled[idx]) {
         pyb_usb_vcp_irq_scheduled[idx] = mp_sched_schedule(MP_OBJ_FROM_PTR(&pyb_usb_vcp_irq_run_obj), self);
     }
@@ -851,7 +851,7 @@ STATIC mp_obj_t pyb_usb_vcp_irq(size_t n_args, const mp_obj_t *pos_args, mp_map_
         }
 
         // Reconfigure the IRQ.
-        MP_STATE_PORT(pyb_usb_vcp_irq)[self->cdc_itf->cdc_idx] = handler;
+        MP_ROOT_POINTER(pyb_usb_vcp_irq)[self->cdc_itf->cdc_idx] = handler;
     }
 
     return mp_const_none;

--- a/ports/stm32/usb.c
+++ b/ports/stm32/usb.c
@@ -647,7 +647,7 @@ STATIC void pyb_usb_vcp_init0(void) {
     }
 
     // Activate USB_VCP(0) on dupterm slot 1 for the REPL
-    MP_ROOT_POINTER(dupterm_objs[1]) = MP_OBJ_FROM_PTR(&pyb_usb_vcp_obj[0]);
+    MP_ROOT_POINTER(dupterm_objs)[1] = MP_OBJ_FROM_PTR(&pyb_usb_vcp_obj[0]);
     usb_vcp_attach_to_repl(&pyb_usb_vcp_obj[0], true);
 }
 

--- a/ports/stm32/usrsw.c
+++ b/ports/stm32/usrsw.c
@@ -103,8 +103,8 @@ mp_obj_t pyb_switch_value(mp_obj_t self_in) {
 STATIC MP_DEFINE_CONST_FUN_OBJ_1(pyb_switch_value_obj, pyb_switch_value);
 
 STATIC mp_obj_t switch_callback(mp_obj_t line) {
-    if (MP_STATE_PORT(pyb_switch_callback) != mp_const_none) {
-        mp_call_function_0(MP_STATE_PORT(pyb_switch_callback));
+    if (MP_ROOT_POINTER(pyb_switch_callback) != mp_const_none) {
+        mp_call_function_0(MP_ROOT_POINTER(pyb_switch_callback));
     }
     return mp_const_none;
 }
@@ -114,7 +114,7 @@ STATIC MP_DEFINE_CONST_FUN_OBJ_1(switch_callback_obj, switch_callback);
 /// Register the given function to be called when the switch is pressed down.
 /// If `fun` is `None`, then it disables the callback.
 mp_obj_t pyb_switch_callback(mp_obj_t self_in, mp_obj_t callback) {
-    MP_STATE_PORT(pyb_switch_callback) = callback;
+    MP_ROOT_POINTER(pyb_switch_callback) = callback;
     // Init the EXTI each time this function is called, since the EXTI
     // may have been disabled by an exception in the interrupt, or the
     // user disabling the line explicitly.

--- a/ports/teensy/mpconfigport.h
+++ b/ports/teensy/mpconfigport.h
@@ -39,8 +39,6 @@ extern const struct _mp_obj_module_t pyb_module;
 #define MICROPY_PORT_CONSTANTS \
     { MP_ROM_QSTR(MP_QSTR_pyb), MP_ROM_PTR(&pyb_module) }, \
 
-#define MP_STATE_PORT MP_STATE_VM
-
 // type definitions for the specific machine
 
 #define UINT_FMT "%u"

--- a/ports/teensy/teensy_hal.c
+++ b/ports/teensy/teensy_hal.c
@@ -28,12 +28,12 @@ uintptr_t mp_hal_stdio_poll(uintptr_t poll_flags) {
         if (usb_vcp_rx_num()) {
             ret |= MP_STREAM_POLL_RD;
         }
-        if (MP_STATE_PORT(pyb_stdio_uart) != NULL && uart_rx_any(MP_STATE_PORT(pyb_stdio_uart))) {
+        if (MP_ROOT_POINTER(pyb_stdio_uart) != NULL && uart_rx_any(MP_ROOT_POINTER(pyb_stdio_uart))) {
             ret |= MP_STREAM_POLL_RD;
         }
     }
     if (poll_flags & MP_STREAM_POLL_WR) {
-        if (MP_STATE_PORT(pyb_stdio_uart) != NULL || usb_vcp_is_enabled()) {
+        if (MP_ROOT_POINTER(pyb_stdio_uart) != NULL || usb_vcp_is_enabled()) {
             ret |= MP_STREAM_POLL_WR;
         }
     }
@@ -45,8 +45,8 @@ int mp_hal_stdin_rx_chr(void) {
         byte c;
         if (usb_vcp_recv_byte(&c) != 0) {
             return c;
-        } else if (MP_STATE_PORT(pyb_stdio_uart) != NULL && uart_rx_any(MP_STATE_PORT(pyb_stdio_uart))) {
-            return uart_rx_char(MP_STATE_PORT(pyb_stdio_uart));
+        } else if (MP_ROOT_POINTER(pyb_stdio_uart) != NULL && uart_rx_any(MP_ROOT_POINTER(pyb_stdio_uart))) {
+            return uart_rx_char(MP_ROOT_POINTER(pyb_stdio_uart));
         }
         __WFI();
     }
@@ -57,8 +57,8 @@ void mp_hal_stdout_tx_str(const char *str) {
 }
 
 void mp_hal_stdout_tx_strn(const char *str, size_t len) {
-    if (MP_STATE_PORT(pyb_stdio_uart) != NULL) {
-        uart_tx_strn(MP_STATE_PORT(pyb_stdio_uart), str, len);
+    if (MP_ROOT_POINTER(pyb_stdio_uart) != NULL) {
+        uart_tx_strn(MP_ROOT_POINTER(pyb_stdio_uart), str, len);
     }
     if (usb_vcp_is_enabled()) {
         usb_vcp_send_strn(str, len);
@@ -67,9 +67,9 @@ void mp_hal_stdout_tx_strn(const char *str, size_t len) {
 
 void mp_hal_stdout_tx_strn_cooked(const char *str, size_t len) {
     // send stdout to UART and USB CDC VCP
-    if (MP_STATE_PORT(pyb_stdio_uart) != NULL) {
+    if (MP_ROOT_POINTER(pyb_stdio_uart) != NULL) {
         void uart_tx_strn_cooked(pyb_uart_obj_t *uart_obj, const char *str, uint len);
-        uart_tx_strn_cooked(MP_STATE_PORT(pyb_stdio_uart), str, len);
+        uart_tx_strn_cooked(MP_ROOT_POINTER(pyb_stdio_uart), str, len);
     }
     if (usb_vcp_is_enabled()) {
         usb_vcp_send_strn_cooked(str, len);

--- a/ports/unix/alloc.c
+++ b/ports/unix/alloc.c
@@ -61,15 +61,15 @@ void mp_unix_alloc_exec(size_t min_size, void **ptr, size_t *size) {
     mmap_region_t *rg = m_new_obj(mmap_region_t);
     rg->ptr = *ptr;
     rg->len = min_size;
-    rg->next = MP_STATE_VM(mmap_region_head);
-    MP_STATE_VM(mmap_region_head) = rg;
+    rg->next = MP_ROOT_POINTER(mmap_region_head);
+    MP_ROOT_POINTER(mmap_region_head) = rg;
 }
 
 void mp_unix_free_exec(void *ptr, size_t size) {
     munmap(ptr, size);
 
     // unlink the mmap'd region from the list
-    for (mmap_region_t **rg = (mmap_region_t **)&MP_STATE_VM(mmap_region_head); *rg != NULL; *rg = (*rg)->next) {
+    for (mmap_region_t **rg = (mmap_region_t **)&MP_ROOT_POINTER(mmap_region_head); *rg != NULL; *rg = (*rg)->next) {
         if ((*rg)->ptr == ptr) {
             mmap_region_t *next = (*rg)->next;
             m_del_obj(mmap_region_t, *rg);
@@ -80,7 +80,7 @@ void mp_unix_free_exec(void *ptr, size_t size) {
 }
 
 void mp_unix_mark_exec(void) {
-    for (mmap_region_t *rg = MP_STATE_VM(mmap_region_head); rg != NULL; rg = rg->next) {
+    for (mmap_region_t *rg = MP_ROOT_POINTER(mmap_region_head); rg != NULL; rg = rg->next) {
         gc_collect_root(rg->ptr, rg->len / sizeof(mp_uint_t));
     }
 }

--- a/ports/unix/input.c
+++ b/ports/unix/input.c
@@ -108,8 +108,8 @@ void prompt_write_history(void) {
         vstr_printf(&vstr, "%s/.micropython.history", home);
         int fd = open(vstr_null_terminated_str(&vstr), O_CREAT | O_TRUNC | O_WRONLY, 0644);
         if (fd != -1) {
-            for (int i = MP_ARRAY_SIZE(MP_STATE_PORT(readline_hist)) - 1; i >= 0; i--) {
-                const char *line = MP_STATE_PORT(readline_hist)[i];
+            for (int i = MP_ARRAY_SIZE(MP_ROOT_POINTER(readline_hist)) - 1; i >= 0; i--) {
+                const char *line = MP_ROOT_POINTER(readline_hist)[i];
                 if (line != NULL) {
                     while (write(fd, line, strlen(line)) == -1 && errno == EINTR) {
                     }

--- a/ports/unix/main.c
+++ b/ports/unix/main.c
@@ -542,7 +542,7 @@ MP_NOINLINE int main_(int argc, char **argv) {
             MP_OBJ_NEW_QSTR(MP_QSTR__slash_),
         };
         mp_vfs_mount(2, args, (mp_map_t *)&mp_const_empty_map);
-        MP_STATE_VM(vfs_cur) = MP_STATE_VM(vfs_mount_table);
+        MP_ROOT_POINTER(vfs_cur) = MP_ROOT_POINTER(vfs_mount_table);
     }
     #endif
 
@@ -743,8 +743,8 @@ MP_NOINLINE int main_(int argc, char **argv) {
 
     #if MICROPY_PY_SYS_ATEXIT
     // Beware, the sys.settrace callback should be disabled before running sys.atexit.
-    if (mp_obj_is_callable(MP_STATE_VM(sys_exitfunc))) {
-        mp_call_function_0(MP_STATE_VM(sys_exitfunc));
+    if (mp_obj_is_callable(MP_ROOT_POINTER(sys_exitfunc))) {
+        mp_call_function_0(MP_ROOT_POINTER(sys_exitfunc));
     }
     #endif
 

--- a/ports/unix/mpconfigport.h
+++ b/ports/unix/mpconfigport.h
@@ -51,8 +51,6 @@
 #define MICROPY_PY_SYS_PATH_DEFAULT ".frozen:~/.micropython/lib:/usr/lib/micropython"
 #endif
 
-#define MP_STATE_PORT MP_STATE_VM
-
 // Configure which emitter to use for this target.
 #if !defined(MICROPY_EMIT_X64) && defined(__x86_64__)
     #define MICROPY_EMIT_X64        (1)

--- a/ports/webassembly/main.c
+++ b/ports/webassembly/main.c
@@ -103,7 +103,7 @@ void mp_js_init(int heap_size) {
             MP_OBJ_NEW_QSTR(qstr_from_str("/")),
         };
         mp_vfs_mount(2, args, (mp_map_t *)&mp_const_empty_map);
-        MP_STATE_VM(vfs_cur) = MP_STATE_VM(vfs_mount_table);
+        MP_ROOT_POINTER(vfs_cur) = MP_ROOT_POINTER(vfs_mount_table);
     }
     #endif
 }

--- a/ports/webassembly/mpconfigport.h
+++ b/ports/webassembly/mpconfigport.h
@@ -89,8 +89,6 @@ typedef long mp_off_t;
 #define MICROPY_HW_BOARD_NAME "JS"
 #define MICROPY_HW_MCU_NAME "Emscripten"
 
-#define MP_STATE_PORT MP_STATE_VM
-
 #if MICROPY_VFS
 // _GNU_SOURCE must be defined to get definitions of DT_xxx symbols from dirent.h.
 #define _GNU_SOURCE

--- a/ports/windows/mpconfigport.h
+++ b/ports/windows/mpconfigport.h
@@ -213,8 +213,6 @@ typedef long long mp_off_t;
 typedef long mp_off_t;
 #endif
 
-#define MP_STATE_PORT               MP_STATE_VM
-
 #define MICROPY_MPHALPORT_H         "windows_mphal.h"
 
 // We need to provide a declaration/definition of alloca()

--- a/ports/zephyr/modbluetooth_zephyr.c
+++ b/ports/zephyr/modbluetooth_zephyr.c
@@ -125,8 +125,8 @@ int mp_bluetooth_init(void) {
     mp_bluetooth_deinit();
 
     // Allocate memory for state.
-    MP_STATE_PORT(bluetooth_zephyr_root_pointers) = m_new0(mp_bluetooth_zephyr_root_pointers_t, 1);
-    mp_bluetooth_gatts_db_create(&MP_STATE_PORT(bluetooth_zephyr_root_pointers)->gatts_db);
+    MP_ROOT_POINTER(bluetooth_zephyr_root_pointers) = m_new0(mp_bluetooth_zephyr_root_pointers_t, 1);
+    mp_bluetooth_gatts_db_create(&MP_ROOT_POINTER(bluetooth_zephyr_root_pointers)->gatts_db);
 
     #if MICROPY_PY_BLUETOOTH_ENABLE_CENTRAL_MODE
     mp_bluetooth_zephyr_gap_scan_state = MP_BLUETOOTH_ZEPHYR_GAP_SCAN_STATE_INACTIVE;
@@ -169,7 +169,7 @@ void mp_bluetooth_deinit(void) {
     // state as suspended so it can be correctly reactivated later.
     mp_bluetooth_zephyr_ble_state = MP_BLUETOOTH_ZEPHYR_BLE_STATE_SUSPENDED;
 
-    MP_STATE_PORT(bluetooth_zephyr_root_pointers) = NULL;
+    MP_ROOT_POINTER(bluetooth_zephyr_root_pointers) = NULL;
 }
 
 bool mp_bluetooth_is_active(void) {
@@ -281,7 +281,7 @@ int mp_bluetooth_gatts_register_service_begin(bool append) {
     }
 
     // Reset the gatt characteristic value db.
-    mp_bluetooth_gatts_db_reset(MP_STATE_PORT(bluetooth_zephyr_root_pointers)->gatts_db);
+    mp_bluetooth_gatts_db_reset(MP_ROOT_POINTER(bluetooth_zephyr_root_pointers)->gatts_db);
 
     return MP_EOPNOTSUPP;
 }
@@ -305,7 +305,7 @@ int mp_bluetooth_gatts_read(uint16_t value_handle, const uint8_t **value, size_t
     if (!mp_bluetooth_is_active()) {
         return ERRNO_BLUETOOTH_NOT_ACTIVE;
     }
-    return mp_bluetooth_gatts_db_read(MP_STATE_PORT(bluetooth_zephyr_root_pointers)->gatts_db, value_handle, value, value_len);
+    return mp_bluetooth_gatts_db_read(MP_ROOT_POINTER(bluetooth_zephyr_root_pointers)->gatts_db, value_handle, value, value_len);
 }
 
 int mp_bluetooth_gatts_write(uint16_t value_handle, const uint8_t *value, size_t value_len, bool send_update) {
@@ -315,7 +315,7 @@ int mp_bluetooth_gatts_write(uint16_t value_handle, const uint8_t *value, size_t
     if (send_update) {
         return MP_EOPNOTSUPP;
     }
-    return mp_bluetooth_gatts_db_write(MP_STATE_PORT(bluetooth_zephyr_root_pointers)->gatts_db, value_handle, value, value_len);
+    return mp_bluetooth_gatts_db_write(MP_ROOT_POINTER(bluetooth_zephyr_root_pointers)->gatts_db, value_handle, value, value_len);
 }
 
 int mp_bluetooth_gatts_notify_indicate(uint16_t conn_handle, uint16_t value_handle, int gatts_op, const uint8_t *value, size_t value_len) {

--- a/ports/zephyr/mpconfigport.h
+++ b/ports/zephyr/mpconfigport.h
@@ -131,8 +131,6 @@ typedef int mp_int_t; // must be pointer size
 typedef unsigned mp_uint_t; // must be pointer size
 typedef long mp_off_t;
 
-#define MP_STATE_PORT MP_STATE_VM
-
 // extra built in names to add to the global namespace
 #define MICROPY_PORT_BUILTINS \
     { MP_ROM_QSTR(MP_QSTR_open), MP_ROM_PTR(&mp_builtin_open_obj) },

--- a/ports/zephyr/mpconfigport_minimal.h
+++ b/ports/zephyr/mpconfigport_minimal.h
@@ -81,5 +81,3 @@
 typedef int mp_int_t; // must be pointer size
 typedef unsigned mp_uint_t; // must be pointer size
 typedef long mp_off_t;
-
-#define MP_STATE_PORT MP_STATE_VM

--- a/py/modsys.c
+++ b/py/modsys.c
@@ -152,7 +152,7 @@ MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(mp_sys_print_exception_obj, 1, 2, mp_sys_pri
 
 #if MICROPY_PY_SYS_EXC_INFO
 STATIC mp_obj_t mp_sys_exc_info(void) {
-    mp_obj_t cur_exc = MP_OBJ_FROM_PTR(MP_STATE_VM(cur_exception));
+    mp_obj_t cur_exc = MP_OBJ_FROM_PTR(MP_ROOT_POINTER(cur_exception));
     mp_obj_tuple_t *t = MP_OBJ_TO_PTR(mp_obj_new_tuple(3, NULL));
 
     if (cur_exc == MP_OBJ_NULL) {
@@ -180,8 +180,8 @@ STATIC MP_DEFINE_CONST_FUN_OBJ_1(mp_sys_getsizeof_obj, mp_sys_getsizeof);
 #if MICROPY_PY_SYS_ATEXIT
 // atexit(callback): Callback is called when sys.exit is called.
 STATIC mp_obj_t mp_sys_atexit(mp_obj_t obj) {
-    mp_obj_t old = MP_STATE_VM(sys_exitfunc);
-    MP_STATE_VM(sys_exitfunc) = obj;
+    mp_obj_t old = MP_ROOT_POINTER(sys_exitfunc);
+    MP_ROOT_POINTER(sys_exitfunc) = obj;
     return old;
 }
 STATIC MP_DEFINE_CONST_FUN_OBJ_1(mp_sys_atexit_obj, mp_sys_atexit);
@@ -231,8 +231,8 @@ STATIC const uint16_t sys_mutable_keys[] = {
 
 void mp_module_sys_attr(mp_obj_t self_in, qstr attr, mp_obj_t *dest) {
     MP_STATIC_ASSERT(MP_ARRAY_SIZE(sys_mutable_keys) == MP_SYS_MUTABLE_NUM + 1);
-    MP_STATIC_ASSERT(MP_ARRAY_SIZE(MP_STATE_VM(sys_mutable)) == MP_SYS_MUTABLE_NUM);
-    mp_module_generic_attr(attr, dest, sys_mutable_keys, MP_STATE_VM(sys_mutable));
+    MP_STATIC_ASSERT(MP_ARRAY_SIZE(MP_ROOT_POINTER(sys_mutable)) == MP_SYS_MUTABLE_NUM);
+    mp_module_generic_attr(attr, dest, sys_mutable_keys, MP_ROOT_POINTER(sys_mutable));
 }
 #endif
 
@@ -240,7 +240,7 @@ STATIC const mp_rom_map_elem_t mp_module_sys_globals_table[] = {
     { MP_ROM_QSTR(MP_QSTR___name__), MP_ROM_QSTR(MP_QSTR_sys) },
 
     #if MICROPY_PY_SYS_ARGV
-    { MP_ROM_QSTR(MP_QSTR_argv), MP_ROM_PTR(&MP_STATE_VM(mp_sys_argv_obj)) },
+    { MP_ROM_QSTR(MP_QSTR_argv), MP_ROM_PTR(&MP_ROOT_POINTER(mp_sys_argv_obj)) },
     #endif
     { MP_ROM_QSTR(MP_QSTR_version), MP_ROM_PTR(&mp_sys_version_obj) },
     { MP_ROM_QSTR(MP_QSTR_version_info), MP_ROM_PTR(&mp_sys_version_info_obj) },

--- a/py/objexcept.c
+++ b/py/objexcept.c
@@ -581,7 +581,7 @@ void mp_obj_exception_add_traceback(mp_obj_t self_in, qstr file, size_t line, qs
     // if memory allocation fails (eg because gc is locked), just return
 
     #if MICROPY_PY_SYS_TRACEBACKLIMIT
-    mp_int_t max_traceback = MP_OBJ_SMALL_INT_VALUE(MP_STATE_VM(sys_mutable[MP_SYS_MUTABLE_TRACEBACKLIMIT]));
+    mp_int_t max_traceback = MP_OBJ_SMALL_INT_VALUE(MP_ROOT_POINTER(sys_mutable[MP_SYS_MUTABLE_TRACEBACKLIMIT]));
     if (max_traceback <= 0) {
         return;
     } else if (self->traceback_data != NULL && self->traceback_len >= max_traceback * TRACEBACK_ENTRY_LEN) {

--- a/py/objexcept.c
+++ b/py/objexcept.c
@@ -581,7 +581,7 @@ void mp_obj_exception_add_traceback(mp_obj_t self_in, qstr file, size_t line, qs
     // if memory allocation fails (eg because gc is locked), just return
 
     #if MICROPY_PY_SYS_TRACEBACKLIMIT
-    mp_int_t max_traceback = MP_OBJ_SMALL_INT_VALUE(MP_ROOT_POINTER(sys_mutable[MP_SYS_MUTABLE_TRACEBACKLIMIT]));
+    mp_int_t max_traceback = MP_OBJ_SMALL_INT_VALUE(MP_ROOT_POINTER(sys_mutable)[MP_SYS_MUTABLE_TRACEBACKLIMIT]);
     if (max_traceback <= 0) {
         return;
     } else if (self->traceback_data != NULL && self->traceback_len >= max_traceback * TRACEBACK_ENTRY_LEN) {

--- a/py/persistentcode.c
+++ b/py/persistentcode.c
@@ -354,10 +354,10 @@ STATIC mp_raw_code_t *load_raw_code(mp_reader_t *reader, mp_module_context_t *co
             // to trace.  This is because native functions can start inside `buf` and so
             // it's possible that the only GC-reachable pointers are pointers inside `buf`.
             // So put this `buf` on a list of reachable root pointers.
-            if (MP_STATE_PORT(track_reloc_code_list) == MP_OBJ_NULL) {
-                MP_STATE_PORT(track_reloc_code_list) = mp_obj_new_list(0, NULL);
+            if (MP_ROOT_POINTER(track_reloc_code_list) == MP_OBJ_NULL) {
+                MP_ROOT_POINTER(track_reloc_code_list) = mp_obj_new_list(0, NULL);
             }
-            mp_obj_list_append(MP_STATE_PORT(track_reloc_code_list), MP_OBJ_FROM_PTR(fun_data));
+            mp_obj_list_append(MP_ROOT_POINTER(track_reloc_code_list), MP_OBJ_FROM_PTR(fun_data));
             #endif
             // Do the relocations.
             mp_native_relocate(&ri, fun_data, (uintptr_t)fun_data);

--- a/py/repl.c
+++ b/py/repl.c
@@ -35,8 +35,8 @@
 
 #if MICROPY_PY_SYS_PS1_PS2
 const char *mp_repl_get_psx(unsigned int entry) {
-    if (mp_obj_is_str(MP_STATE_VM(sys_mutable)[entry])) {
-        return mp_obj_str_get_str(MP_STATE_VM(sys_mutable)[entry]);
+    if (mp_obj_is_str(MP_ROOT_POINTER(sys_mutable)[entry])) {
+        return mp_obj_str_get_str(MP_ROOT_POINTER(sys_mutable)[entry]);
     } else {
         return "";
     }

--- a/py/runtime.c
+++ b/py/runtime.c
@@ -119,19 +119,19 @@ void mp_init(void) {
     #endif
 
     #if MICROPY_PERSISTENT_CODE_TRACK_RELOC_CODE
-    MP_STATE_VM(track_reloc_code_list) = MP_OBJ_NULL;
+    MP_ROOT_POINTER(track_reloc_code_list) = MP_OBJ_NULL;
     #endif
 
     #if MICROPY_PY_OS_DUPTERM
     for (size_t i = 0; i < MICROPY_PY_OS_DUPTERM; ++i) {
-        MP_STATE_VM(dupterm_objs[i]) = MP_OBJ_NULL;
+        MP_ROOT_POINTER(dupterm_objs[i]) = MP_OBJ_NULL;
     }
     #endif
 
     #if MICROPY_VFS
     // initialise the VFS sub-system
-    MP_STATE_VM(vfs_cur) = NULL;
-    MP_STATE_VM(vfs_mount_table) = NULL;
+    MP_ROOT_POINTER(vfs_cur) = NULL;
+    MP_ROOT_POINTER(vfs_mount_table) = NULL;
     #endif
 
     #if MICROPY_PY_SYS_PATH_ARGV_DEFAULTS
@@ -148,12 +148,12 @@ void mp_init(void) {
     #endif // MICROPY_PY_SYS_PATH_ARGV_DEFAULTS
 
     #if MICROPY_PY_SYS_ATEXIT
-    MP_STATE_VM(sys_exitfunc) = mp_const_none;
+    MP_ROOT_POINTER(sys_exitfunc) = mp_const_none;
     #endif
 
     #if MICROPY_PY_SYS_PS1_PS2
-    MP_STATE_VM(sys_mutable[MP_SYS_MUTABLE_PS1]) = MP_OBJ_NEW_QSTR(MP_QSTR__gt__gt__gt__space_);
-    MP_STATE_VM(sys_mutable[MP_SYS_MUTABLE_PS2]) = MP_OBJ_NEW_QSTR(MP_QSTR__dot__dot__dot__space_);
+    MP_ROOT_POINTER(sys_mutable[MP_SYS_MUTABLE_PS1]) = MP_OBJ_NEW_QSTR(MP_QSTR__gt__gt__gt__space_);
+    MP_ROOT_POINTER(sys_mutable[MP_SYS_MUTABLE_PS2]) = MP_OBJ_NEW_QSTR(MP_QSTR__dot__dot__dot__space_);
     #endif
 
     #if MICROPY_PY_SYS_SETTRACE
@@ -163,11 +163,11 @@ void mp_init(void) {
     #endif
 
     #if MICROPY_PY_SYS_TRACEBACKLIMIT
-    MP_STATE_VM(sys_mutable[MP_SYS_MUTABLE_TRACEBACKLIMIT]) = MP_OBJ_NEW_SMALL_INT(1000);
+    MP_ROOT_POINTER(sys_mutable[MP_SYS_MUTABLE_TRACEBACKLIMIT]) = MP_OBJ_NEW_SMALL_INT(1000);
     #endif
 
     #if MICROPY_PY_BLUETOOTH
-    MP_STATE_VM(bluetooth) = MP_OBJ_NULL;
+    MP_ROOT_POINTER(bluetooth) = MP_OBJ_NULL;
     #endif
 
     #if MICROPY_PY_THREAD_GIL

--- a/py/runtime.c
+++ b/py/runtime.c
@@ -124,7 +124,7 @@ void mp_init(void) {
 
     #if MICROPY_PY_OS_DUPTERM
     for (size_t i = 0; i < MICROPY_PY_OS_DUPTERM; ++i) {
-        MP_ROOT_POINTER(dupterm_objs[i]) = MP_OBJ_NULL;
+        MP_ROOT_POINTER(dupterm_objs)[i] = MP_OBJ_NULL;
     }
     #endif
 
@@ -152,8 +152,8 @@ void mp_init(void) {
     #endif
 
     #if MICROPY_PY_SYS_PS1_PS2
-    MP_ROOT_POINTER(sys_mutable[MP_SYS_MUTABLE_PS1]) = MP_OBJ_NEW_QSTR(MP_QSTR__gt__gt__gt__space_);
-    MP_ROOT_POINTER(sys_mutable[MP_SYS_MUTABLE_PS2]) = MP_OBJ_NEW_QSTR(MP_QSTR__dot__dot__dot__space_);
+    MP_ROOT_POINTER(sys_mutable)[MP_SYS_MUTABLE_PS1] = MP_OBJ_NEW_QSTR(MP_QSTR__gt__gt__gt__space_);
+    MP_ROOT_POINTER(sys_mutable)[MP_SYS_MUTABLE_PS2] = MP_OBJ_NEW_QSTR(MP_QSTR__dot__dot__dot__space_);
     #endif
 
     #if MICROPY_PY_SYS_SETTRACE
@@ -163,7 +163,7 @@ void mp_init(void) {
     #endif
 
     #if MICROPY_PY_SYS_TRACEBACKLIMIT
-    MP_ROOT_POINTER(sys_mutable[MP_SYS_MUTABLE_TRACEBACKLIMIT]) = MP_OBJ_NEW_SMALL_INT(1000);
+    MP_ROOT_POINTER(sys_mutable)[MP_SYS_MUTABLE_TRACEBACKLIMIT] = MP_OBJ_NEW_SMALL_INT(1000);
     #endif
 
     #if MICROPY_PY_BLUETOOTH

--- a/py/runtime.h
+++ b/py/runtime.h
@@ -228,7 +228,7 @@ mp_uint_t mp_native_from_obj(mp_obj_t obj, mp_uint_t type);
 mp_obj_t mp_native_to_obj(mp_uint_t val, mp_uint_t type);
 
 #if MICROPY_PY_SYS_PATH
-#define mp_sys_path (MP_ROOT_POINTER(sys_mutable[MP_SYS_MUTABLE_PATH]))
+#define mp_sys_path (MP_ROOT_POINTER(sys_mutable)[MP_SYS_MUTABLE_PATH])
 #endif
 
 #if MICROPY_PY_SYS_ARGV

--- a/py/runtime.h
+++ b/py/runtime.h
@@ -228,11 +228,11 @@ mp_uint_t mp_native_from_obj(mp_obj_t obj, mp_uint_t type);
 mp_obj_t mp_native_to_obj(mp_uint_t val, mp_uint_t type);
 
 #if MICROPY_PY_SYS_PATH
-#define mp_sys_path (MP_STATE_VM(sys_mutable[MP_SYS_MUTABLE_PATH]))
+#define mp_sys_path (MP_ROOT_POINTER(sys_mutable[MP_SYS_MUTABLE_PATH]))
 #endif
 
 #if MICROPY_PY_SYS_ARGV
-#define mp_sys_argv (MP_OBJ_FROM_PTR(&MP_STATE_VM(mp_sys_argv_obj)))
+#define mp_sys_argv (MP_OBJ_FROM_PTR(&MP_ROOT_POINTER(mp_sys_argv_obj)))
 #endif
 
 #if MICROPY_WARNINGS

--- a/py/scheduler.c
+++ b/py/scheduler.c
@@ -103,7 +103,7 @@ static inline void mp_sched_run_pending(void) {
 
     // Run at most one pending Python callback.
     if (!mp_sched_empty()) {
-        mp_sched_item_t item = MP_STATE_VM(sched_queue)[MP_STATE_VM(sched_idx)];
+        mp_sched_item_t item = MP_ROOT_POINTER(sched_queue)[MP_STATE_VM(sched_idx)];
         MP_STATE_VM(sched_idx) = IDX_MASK(MP_STATE_VM(sched_idx) + 1);
         --MP_STATE_VM(sched_len);
         MICROPY_END_ATOMIC_SECTION(atomic_state);
@@ -163,8 +163,8 @@ bool MICROPY_WRAP_MP_SCHED_SCHEDULE(mp_sched_schedule)(mp_obj_t function, mp_obj
             MP_STATE_VM(sched_state) = MP_SCHED_PENDING;
         }
         uint8_t iput = IDX_MASK(MP_STATE_VM(sched_idx) + MP_STATE_VM(sched_len)++);
-        MP_STATE_VM(sched_queue)[iput].func = function;
-        MP_STATE_VM(sched_queue)[iput].arg = arg;
+        MP_ROOT_POINTER(sched_queue)[iput].func = function;
+        MP_ROOT_POINTER(sched_queue)[iput].arg = arg;
         MICROPY_SCHED_HOOK_SCHEDULED;
         ret = true;
     } else {

--- a/py/vm.c
+++ b/py/vm.c
@@ -114,7 +114,7 @@
 #define SET_TOP(val) *sp = (val)
 
 #if MICROPY_PY_SYS_EXC_INFO
-#define CLEAR_SYS_EXC_INFO() MP_STATE_VM(cur_exception) = NULL;
+#define CLEAR_SYS_EXC_INFO() MP_ROOT_POINTER(cur_exception) = NULL;
 #else
 #define CLEAR_SYS_EXC_INFO()
 #endif
@@ -1369,7 +1369,7 @@ exception_handler:
             // exception occurred
 
             #if MICROPY_PY_SYS_EXC_INFO
-            MP_STATE_VM(cur_exception) = nlr.ret_val;
+            MP_ROOT_POINTER(cur_exception) = nlr.ret_val;
             #endif
 
             #if SELECTIVE_EXC_IP

--- a/shared/readline/readline.c
+++ b/shared/readline/readline.c
@@ -52,7 +52,7 @@ enum { ESEQ_NONE, ESEQ_ESC, ESEQ_ESC_BRACKET, ESEQ_ESC_BRACKET_DIGIT, ESEQ_ESC_O
 #endif
 
 void readline_init0(void) {
-    memset(MP_STATE_PORT(readline_hist), 0, MICROPY_READLINE_HISTORY_SIZE * sizeof(const char*));
+    memset(MP_ROOT_POINTER(readline_hist), 0, MICROPY_READLINE_HISTORY_SIZE * sizeof(const char*));
 }
 
 STATIC char *str_dup_maybe(const char *str) {
@@ -337,12 +337,12 @@ backward_kill_word:
 up_arrow_key:
 #endif
                 // up arrow
-                if (rl.hist_cur + 1 < MICROPY_READLINE_HISTORY_SIZE && MP_STATE_PORT(readline_hist)[rl.hist_cur + 1] != NULL) {
+                if (rl.hist_cur + 1 < MICROPY_READLINE_HISTORY_SIZE && MP_ROOT_POINTER(readline_hist)[rl.hist_cur + 1] != NULL) {
                     // increase hist num
                     rl.hist_cur += 1;
                     // set line to history
                     rl.line->len = rl.orig_line_len;
-                    vstr_add_str(rl.line, MP_STATE_PORT(readline_hist)[rl.hist_cur]);
+                    vstr_add_str(rl.line, MP_ROOT_POINTER(readline_hist)[rl.hist_cur]);
                     // set redraw parameters
                     redraw_step_back = rl.cursor_pos - rl.orig_line_len;
                     redraw_from_cursor = true;
@@ -359,7 +359,7 @@ down_arrow_key:
                     // set line to history
                     vstr_cut_tail_bytes(rl.line, rl.line->len - rl.orig_line_len);
                     if (rl.hist_cur >= 0) {
-                        vstr_add_str(rl.line, MP_STATE_PORT(readline_hist)[rl.hist_cur]);
+                        vstr_add_str(rl.line, MP_ROOT_POINTER(readline_hist)[rl.hist_cur]);
                     }
                     // set redraw parameters
                     redraw_step_back = rl.cursor_pos - rl.orig_line_len;
@@ -567,16 +567,16 @@ int readline(vstr_t *line, const char *prompt) {
 
 void readline_push_history(const char *line) {
     if (line[0] != '\0'
-        && (MP_STATE_PORT(readline_hist)[0] == NULL
-            || strcmp(MP_STATE_PORT(readline_hist)[0], line) != 0)) {
+        && (MP_ROOT_POINTER(readline_hist)[0] == NULL
+            || strcmp(MP_ROOT_POINTER(readline_hist)[0], line) != 0)) {
         // a line which is not empty and different from the last one
         // so update the history
         char *most_recent_hist = str_dup_maybe(line);
         if (most_recent_hist != NULL) {
             for (int i = MICROPY_READLINE_HISTORY_SIZE - 1; i > 0; i--) {
-                MP_STATE_PORT(readline_hist)[i] = MP_STATE_PORT(readline_hist)[i - 1];
+                MP_ROOT_POINTER(readline_hist)[i] = MP_ROOT_POINTER(readline_hist)[i - 1];
             }
-            MP_STATE_PORT(readline_hist)[0] = most_recent_hist;
+            MP_ROOT_POINTER(readline_hist)[0] = most_recent_hist;
         }
     }
 }


### PR DESCRIPTION
Implements option (3) from #12228. cc @robert-hh @dlech 

---

Before MP_REGISTER_ROOT_POINTER was added, a port could define additional
root pointers in its mpconfigport.h. It made sense to refer to them via a
distinct macro, hence MP_STATE_PORT, even though all ports alias that to
MP_STATE_VM.

Now the MP_REGISTER_ROOT_POINTER feature can be used to implement root
pointers for modules that mpstate.h does not know about, such as modules in
extmod, or user c module. We could also consider moving some
config-optional stuff that's currently in mpstate.h to use
MP_REGISTER_ROOT_POINTER. But things defined with MP_REGISTER_ROOT_POINTER
are no longer "port". So for example, in modbluetooth_nimble.c we use
MP_STATE_PORT(bluetooth_nimble_root_pointers), but the only thing that's
"port" about them is that bluetooth can be enabled by the port/board.

This renames all previous uses of MP_STATE_PORT to the new MP_STATE_ROOT.

Furthermore, it moves the generated entries out of the mp_state_vm_t
structure and into an new mp_state_root_t structure that sits between
thread and vm (so it's still part of root pointer searching).

Also fixes several cases where MP_STATE_VM was incorrectly used for what
should be now MP_STATE_ROOT.

Other than the logical improvement, it also means that ports no longer
have to define MP_STATE_PORT (one less thing to duplicate in
mpconfigport.h).

_This work was funded through GitHub Sponsors._