### PR TITLE
extmod/asyncio/event.py: Fix ThreadSafeFlag.ioctl return.

### DIFF
--- a/extmod/asyncio/event.py
+++ b/extmod/asyncio/event.py
@@ -49,7 +49,7 @@ try:
         def ioctl(self, req, flags):
             if req == 3:  # MP_STREAM_POLL
                 return self.state * flags
-            return None
+            return -1  # Other requests are unsupported
 
         def set(self):
             self.state = 1

--- a/tests/extmod/asyncio_threadsafeflag.py
+++ b/tests/extmod/asyncio_threadsafeflag.py
@@ -16,17 +16,6 @@ except AttributeError:
     raise SystemExit
 
 
-try:
-    # Unix port can't select/poll on user-defined types.
-    import select
-
-    poller = select.poll()
-    poller.register(asyncio.ThreadSafeFlag())
-except TypeError:
-    print("SKIP")
-    raise SystemExit
-
-
 async def task(id, flag):
     print("task", id)
     await flag.wait()
@@ -34,9 +23,7 @@ async def task(id, flag):
 
 
 def set_from_schedule(flag):
-    print("schedule")
     flag.set()
-    print("schedule done")
 
 
 async def main():

--- a/tests/extmod/asyncio_threadsafeflag.py.exp
+++ b/tests/extmod/asyncio_threadsafeflag.py.exp
@@ -9,8 +9,6 @@ yield
 task 2
 set event
 yield
-schedule
-schedule done
 wait task
 task 2 done
 ----


### PR DESCRIPTION
iobase_ioctl expects that an ioctl method must return an integer, and will raise otherwise.

This was tripping up aioble on Unix, where the new hybrid modselect.c implementation will attempt to extract a file descriptor from the pollable via ioctl(MP_STREAM_GET_FILENO).

However, ThreadSafeFlag's ioctl only supported MP_STREAM_POLL, and returned None otherwise.

This makes it return `-1` (to match tests/extmod/select_poll_custom.py). It should probably be `-22` (corresponding to MP_EINVAL), but the value is never checked, and MP_EINVAL can be a different value on different ports.

_This work was funded through GitHub Sponsors._