### PR TITLE
stm32/boards/ARDUINO_GIGA: Update board config.

### DIFF
--- a/ports/stm32/boards/ARDUINO_GIGA/mpconfigboard.h
+++ b/ports/stm32/boards/ARDUINO_GIGA/mpconfigboard.h
@@ -30,7 +30,7 @@ typedef unsigned int mp_uint_t;     // must be pointer size
 
 // Flash storage config
 #define MICROPY_HW_SPIFLASH_ENABLE_CACHE            (1)
-#define MICROPY_HW_ENABLE_INTERNAL_FLASH_STORAGE    (1)
+#define MICROPY_HW_ENABLE_INTERNAL_FLASH_STORAGE    (0)
 
 #define MICROPY_BOARD_STARTUP       GIGA_board_startup
 void GIGA_board_startup(void);
@@ -38,6 +38,7 @@ void GIGA_board_startup(void);
 #define MICROPY_BOARD_EARLY_INIT    GIGA_board_early_init
 void GIGA_board_early_init(void);
 
+#define MICROPY_HW_ENTER_BOOTLOADER_VIA_RESET   (0)
 #define MICROPY_BOARD_ENTER_BOOTLOADER(nargs, args) GIGA_board_enter_bootloader()
 void GIGA_board_enter_bootloader(void);
 
@@ -45,10 +46,6 @@ void GIGA_board_low_power(int mode);
 #define MICROPY_BOARD_LEAVE_STOP    GIGA_board_low_power(0);
 #define MICROPY_BOARD_ENTER_STOP    GIGA_board_low_power(1);
 #define MICROPY_BOARD_ENTER_STANDBY GIGA_board_low_power(2);
-
-void GIGA_board_osc_enable(int enable);
-#define MICROPY_BOARD_OSC_ENABLE    GIGA_board_osc_enable(1);
-#define MICROPY_BOARD_OSC_DISABLE   GIGA_board_osc_enable(0);
 
 // PLL1 480MHz/48MHz SDMMC and FDCAN
 // USB and RNG are clocked from the HSI48


### PR DESCRIPTION
Just some minor fixes to this board's config.

- Disable internal flash storage and use the external QSPI for storage.
- Disable default bootloader entry mode. The bootloader entry function exists in board_init.c
- Remove OSC enable/disable macros (this board doesn't have an OSC).