### PR TITLE
struct: Add pack/unpack typecodes (?, c, p)

### DIFF
--- a/py/binary.c
+++ b/py/binary.c
@@ -327,7 +327,7 @@ void mp_binary_set_val(char struct_type, char val_type, mp_obj_t val_in, byte *p
         case 'c': {
             mp_buffer_info_t bufinfo;
             mp_get_buffer_raise(val_in, &bufinfo, MP_BUFFER_READ);
-            val = *(byte*)bufinfo.buf;
+            val = *(byte *)bufinfo.buf;
             break;
         }
         #if MICROPY_PY_BUILTINS_FLOAT
@@ -396,12 +396,12 @@ void mp_binary_set_val_array(char typecode, void *p, size_t index, mp_obj_t val_
             ((mp_obj_t *)p)[index] = val_in;
             break;
         case '?':
-            ((unsigned char*)p)[index] = mp_obj_is_true(val_in) ? 1 : 0;
+            ((unsigned char *)p)[index] = mp_obj_is_true(val_in) ? 1 : 0;
             break;
         case 'c': {
             mp_buffer_info_t bufinfo;
             mp_get_buffer_raise(val_in, &bufinfo, MP_BUFFER_READ);
-            ((byte*)p)[index] = *(byte*)bufinfo.buf;
+            ((byte *)p)[index] = *(byte *)bufinfo.buf;
             break;
         }
         default:

--- a/py/binary.c
+++ b/py/binary.c
@@ -51,8 +51,6 @@ size_t mp_binary_get_size(char struct_type, char val_type, size_t *palign) {
             switch (val_type) {
                 case 'b':
                 case 'B':
-                case '?':
-                case 'c':
                     size = 1;
                     break;
                 case 'h':
@@ -96,8 +94,6 @@ size_t mp_binary_get_size(char struct_type, char val_type, size_t *palign) {
                 case BYTEARRAY_TYPECODE:
                 case 'b':
                 case 'B':
-                case '?':
-                case 'c':
                     align = size = 1;
                     break;
                 case 'h':
@@ -164,10 +160,6 @@ mp_obj_t mp_binary_get_val_array(char typecode, void *p, size_t index) {
         case 'H':
             val = ((unsigned short *)p)[index];
             break;
-        case '?':
-            return ((unsigned char *)p)[index] == 0 ? mp_const_false : mp_const_true;
-        case 'c':
-            return mp_obj_new_bytes(&(((byte *)p)[index]), 1);
         case 'i':
             return mp_obj_new_int(((int *)p)[index]);
         case 'I':
@@ -244,14 +236,9 @@ mp_obj_t mp_binary_get_val(char struct_type, char val_type, byte *p_base, byte *
 
     if (val_type == 'O') {
         return (mp_obj_t)(mp_uint_t)val;
-    } else if (val_type == '?') {
-        return val == 0 ? mp_const_false : mp_const_true;
     } else if (val_type == 'S') {
         const char *s_val = (const char *)(uintptr_t)(mp_uint_t)val;
         return mp_obj_new_str(s_val, strlen(s_val));
-    } else if (val_type == 'c') {
-        byte byteval = (byte)val;
-        return mp_obj_new_bytes(&byteval, 1);
     #if MICROPY_PY_BUILTINS_FLOAT
     } else if (val_type == 'f') {
         union {
@@ -321,15 +308,6 @@ void mp_binary_set_val(char struct_type, char val_type, mp_obj_t val_in, byte *p
         case 'O':
             val = (mp_uint_t)val_in;
             break;
-        case '?':
-            val = mp_obj_is_true(val_in) ? 1 : 0;
-            break;
-        case 'c': {
-            mp_buffer_info_t bufinfo;
-            mp_get_buffer_raise(val_in, &bufinfo, MP_BUFFER_READ);
-            val = *(byte *)bufinfo.buf;
-            break;
-        }
         #if MICROPY_PY_BUILTINS_FLOAT
         case 'f': {
             union {
@@ -395,15 +373,6 @@ void mp_binary_set_val_array(char typecode, void *p, size_t index, mp_obj_t val_
         case 'O':
             ((mp_obj_t *)p)[index] = val_in;
             break;
-        case '?':
-            ((unsigned char *)p)[index] = mp_obj_is_true(val_in) ? 1 : 0;
-            break;
-        case 'c': {
-            mp_buffer_info_t bufinfo;
-            mp_get_buffer_raise(val_in, &bufinfo, MP_BUFFER_READ);
-            ((byte *)p)[index] = *(byte *)bufinfo.buf;
-            break;
-        }
         default:
             #if MICROPY_LONGINT_IMPL != MICROPY_LONGINT_IMPL_NONE
             if (mp_obj_is_exact_type(val_in, &mp_type_int)) {
@@ -424,7 +393,6 @@ void mp_binary_set_val_array_from_int(char typecode, void *p, size_t index, mp_i
             break;
         case BYTEARRAY_TYPECODE:
         case 'B':
-        case '?':
             ((unsigned char *)p)[index] = val;
             break;
         case 'h':

--- a/py/modstruct.c
+++ b/py/modstruct.c
@@ -94,7 +94,7 @@ STATIC size_t calc_size_items(const char *fmt, size_t *total_sz) {
 
         if (*fmt == 'x') {
             size += cnt;
-        } else if (*fmt == 's'|| *fmt == 'p') {
+        } else if (*fmt == 's' || *fmt == 'p') {
             total_cnt += 1;
             size += cnt;
         } else {
@@ -171,8 +171,9 @@ STATIC mp_obj_t struct_unpack_from(size_t n_args, const mp_obj_t *args) {
                 }
                 read_size = *p++;
                 cnt--;
-                if (read_size > cnt)
+                if (read_size > cnt) {
                     read_size = cnt;
+                }
             }
             item = mp_obj_new_bytes(p, read_size);
             p += cnt;
@@ -216,16 +217,16 @@ STATIC void struct_pack_into_internal(mp_obj_t fmt_in, byte *p, size_t n_args, c
                 if (*fmt == 'p') {
                     cnt--;
                 }
-            mp_uint_t to_copy = cnt;
-            if (bufinfo.len < to_copy) {
-                to_copy = bufinfo.len;
-            }
+                mp_uint_t to_copy = cnt;
+                if (bufinfo.len < to_copy) {
+                    to_copy = bufinfo.len;
+                }
                 if (*fmt == 'p') {
                     *p++ = to_copy;
                 }
-            memcpy(p, bufinfo.buf, to_copy);
-            memset(p + to_copy, 0, cnt - to_copy);
-            p += cnt;
+                memcpy(p, bufinfo.buf, to_copy);
+                memset(p + to_copy, 0, cnt - to_copy);
+                p += cnt;
             }
         } else {
             // If we run out of args then we just finish; CPython would raise struct.error

--- a/tests/basics/struct1.py
+++ b/tests/basics/struct1.py
@@ -20,6 +20,10 @@ print(struct.pack("<h", 1))
 print(struct.pack(">h", 1))
 print(struct.pack("<b", 1))
 print(struct.pack(">b", 1))
+print(struct.pack("<?", True))
+print(struct.pack(">?", True))
+print(struct.pack("<c", b"\x01"))
+print(struct.pack(">c", b"\x01"))
 print(struct.pack("<x"))
 print(struct.pack(">x"))
 
@@ -41,6 +45,30 @@ print(struct.unpack(">bxI3xH", b"\x01\0\0\0\0\x02\0\0\0\0\x03"))
 s = struct.pack("BHBI", 10, 100, 200, 300)
 v = struct.unpack("BHBI", s)
 print(v == (10, 100, 200, 300))
+
+# Pascal string behavior
+print(struct.pack("B3pB", 99, b"", 98))
+print(struct.pack("B3pB", 99, b"A", 98))
+print(struct.pack("B3pB", 99, b"AB", 98))
+print(struct.pack("B3pB", 99, b"ABC", 98))
+print(struct.pack("B3pB", 99, b"ABCDEF", 98))
+
+print(struct.pack("B1pB", 99, b"", 98))
+print(struct.pack("B1pB", 99, b"A", 98))
+print(struct.pack("B1pB", 99, b"AB", 98))
+
+print(struct.pack("B0pB", 99, b"", 98))
+print(struct.pack("B0pB", 99, b"A", 98))
+print(struct.pack("B0pB", 99, b"AB", 98))
+
+print(struct.unpack("B3pB", b"c\x00ABb"))
+print(struct.unpack("B3pB", b"c\x01ABb"))
+print(struct.unpack("B3pB", b"c\x02ABb"))
+print(struct.unpack("B3pB", b"c\x03ABb"))
+print(struct.unpack("B3pB", b"c\x04ABb"))
+
+print(struct.unpack("B1pB", b"c\x00ABb"))
+print(struct.unpack("B1pB", b"c\x01ABb"))
 
 # network byte order
 print(struct.pack('!i', 123))

--- a/tests/basics/struct1.py
+++ b/tests/basics/struct1.py
@@ -20,10 +20,6 @@ print(struct.pack("<h", 1))
 print(struct.pack(">h", 1))
 print(struct.pack("<b", 1))
 print(struct.pack(">b", 1))
-print(struct.pack("<?", True))
-print(struct.pack(">?", True))
-print(struct.pack("<c", b"\x01"))
-print(struct.pack(">c", b"\x01"))
 print(struct.pack("<x"))
 print(struct.pack(">x"))
 
@@ -69,6 +65,10 @@ print(struct.unpack("B3pB", b"c\x04ABb"))
 
 print(struct.unpack("B1pB", b"c\x00ABb"))
 print(struct.unpack("B1pB", b"c\x01ABb"))
+
+print(struct.calcsize("B1pB"))
+print(struct.calcsize("B0pB"))
+print(struct.calcsize("B3pB"))
 
 # network byte order
 print(struct.pack('!i', 123))


### PR DESCRIPTION
Based on the discussion at https://github.com/orgs/micropython/discussions/12457, this implements `?` `c` and `p` struct.pack/unpack typecodes

Let me know if you would like some more tests or tests in another location, I wasn't quite sure of that