### PR TITLE
tools/pydfu Add option to upload .bin files on specified address.

### DIFF
--- a/tools/pydfu.py
+++ b/tools/pydfu.py
@@ -624,7 +624,7 @@ def main():
     if args.path:
         if str(args.path).endswith(".bin"):
             if not args.address:
-                return
+                raise ValueError("Address must be specified using -a when uploading binary")
             addr = str(args.address)
             if addr.startswith("0x") or addr.startswith("0X"):
                 addr = int(addr, 16)

--- a/tools/pydfu.py
+++ b/tools/pydfu.py
@@ -422,6 +422,20 @@ def read_dfu_file(filename):
     return elements
 
 
+def read_bin_file(filename, address):
+    """Reads binary file(.bin) and stores it as single
+    element in element array just like read_dfu_file() would.
+    """
+    element = {}
+    print("File: {}".format(filename))
+    with open(filename, "rb") as fin:
+        element["data"] = fin.read()
+    element["size"] = len(element["data"])
+    element["num"] = 0
+    element["addr"] = address
+    return [element]
+
+
 class FilterDFU(object):
     """Class for filtering USB devices to identify devices which are in DFU
     mode.
@@ -573,6 +587,13 @@ def main():
     parser.add_argument(
         "-u", "--upload", help="read file from DFU device", dest="path", default=False
     )
+    parser.add_argument(
+        "-a",
+        "--address",
+        help="specify target memory address(hex or dec) when uploading .bin files",
+        dest="address",
+        default=False,
+    )
     parser.add_argument("-x", "--exit", help="Exit DFU", action="store_true", default=False)
     parser.add_argument(
         "-v", "--verbose", help="increase output verbosity", action="store_true", default=False
@@ -601,7 +622,18 @@ def main():
         command_run = True
 
     if args.path:
-        elements = read_dfu_file(args.path)
+        if str(args.path).endswith(".bin"):
+            if not args.address:
+                return
+            addr = str(args.address)
+            if addr.startswith("0x") or addr.startswith("0X"):
+                addr = int(addr, 16)
+            else:
+                addr = int(addr)
+            elements = read_bin_file(args.path, addr)
+        else:
+            elements = read_dfu_file(args.path)
+
         if not elements:
             print("No data in dfu file")
             return

--- a/tools/pydfu.py
+++ b/tools/pydfu.py
@@ -591,8 +591,8 @@ def main():
         "-a",
         "--address",
         help="specify target memory address(hex or dec) when uploading .bin files",
-        dest="address",
-        default=False,
+        type=lambda x: int(x, 0),
+        default=None,
     )
     parser.add_argument("-x", "--exit", help="Exit DFU", action="store_true", default=False)
     parser.add_argument(
@@ -623,14 +623,10 @@ def main():
 
     if args.path:
         if str(args.path).endswith(".bin"):
-            if not args.address:
+            if args.address is None:
                 raise ValueError("Address must be specified using -a when uploading binary")
-            addr = str(args.address)
-            if addr.startswith("0x") or addr.startswith("0X"):
-                addr = int(addr, 16)
-            else:
-                addr = int(addr)
-            elements = read_bin_file(args.path, addr)
+
+            elements = read_bin_file(args.path, args.addr)
         else:
             elements = read_dfu_file(args.path)
 


### PR DESCRIPTION
Adds ability to upload .bin files using DFU.
This feature makes pydfu.py into handy tool usable outside of micropython, since there is no comparable python tool yet.
Doesn't touch original behaviour with .dfu files.
Adds `--address` parameter to specify target memory address for binary file.