### PR TITLE
mimxrt/rtc: Improve the RTC initialisation during start-up.

### DIFF
--- a/ports/mimxrt/Makefile
+++ b/ports/mimxrt/Makefile
@@ -137,6 +137,7 @@ SRC_HAL_IMX_C += \
 	$(MCU_DIR)/drivers/fsl_pit.c \
 	$(MCU_DIR)/drivers/fsl_pwm.c \
 	$(MCU_DIR)/drivers/fsl_sai.c \
+	$(MCU_DIR)/drivers/fsl_snvs_hp.c \
 	$(MCU_DIR)/drivers/fsl_snvs_lp.c \
 	$(MCU_DIR)/drivers/fsl_wdog.c \
 	$(MCU_DIR)/system_$(MCU_SERIES)$(MCU_CORE).c \

--- a/ports/mimxrt/machine_rtc.c
+++ b/ports/mimxrt/machine_rtc.c
@@ -30,6 +30,7 @@
 #include "modmachine.h"
 #include "ticks.h"
 #include "fsl_snvs_lp.h"
+#include "fsl_snvs_hp.h"
 
 typedef struct _machine_rtc_obj_t {
     mp_obj_base_t base;
@@ -41,6 +42,12 @@ STATIC const machine_rtc_obj_t machine_rtc_obj = {{&machine_rtc_type}};
 
 // Start the RTC Timer.
 void machine_rtc_start(void) {
+    // Enable Non-Privileged Software Access
+    SNVS->HPCOMR |= SNVS_HPCOMR_NPSWA_EN_MASK;
+    // Do a basic init.
+    SNVS_LP_Init(SNVS);
+    // Disable all external Tamper
+    SNVS_LP_DisableAllExternalTamper(SNVS);
 
     SNVS_LP_SRTC_StartTimer(SNVS);
     // If the date is not set, set it to a more recent start date,


### PR DESCRIPTION
It solves a problem, that the RTC may stop running on battery power after the battery was low and the board not powered.
Following PR 7463 from the CircuitPyhton repository.