### PR TITLE
py/mkrules: Don't strip binary if STRIP variable is unset.

### DIFF
--- a/ports/unix/Makefile
+++ b/ports/unix/Makefile
@@ -59,8 +59,8 @@ endif
 # Remove unused sections.
 COPT += -fdata-sections -ffunction-sections
 
-# Always enable symbols -- They're occasionally useful, and don't make it into the
-# final .bin/.hex/.dfu so the extra size doesn't matter.
+# Note: Symbols and debug information will still be stripped from the final binary
+# unless "DEBUG=1" or "STRIP=" is passed to make, see README.md for details.
 CFLAGS += -g
 
 ifndef DEBUG

--- a/ports/unix/README.md
+++ b/ports/unix/README.md
@@ -72,3 +72,17 @@ deplibs`. To actually enable/disable use of dependencies, edit the
 `ports/unix/mpconfigport.mk` file, which has inline descriptions of the
 options. For example, to build the SSL module, `MICROPY_PY_SSL` should be
 set to 1.
+
+Debug Symbols
+-------------
+
+By default, builds are stripped of symbols and debug information to save size.
+
+To build a debuggable version of the Unix port, there are two options
+
+1. Run `make [other arguments] DEBUG=1`. Note setting `DEBUG` also reduces the
+   optimisation level, so it's not a good option for builds that also want the
+   best performance.
+2. Run `make [other arguments] STRIP=`. Note that the value of `STRIP` is
+   empty. This will skip the build step that strips symbols and debug
+   information, but changes nothing else in the build configuration.

--- a/py/mkrules.mk
+++ b/py/mkrules.mk
@@ -212,7 +212,9 @@ $(BUILD)/$(PROG): $(OBJ)
 # we may want to compile using Thumb, but link with non-Thumb libc.
 	$(Q)$(CC) -o $@ $^ $(LIB) $(LDFLAGS)
 ifndef DEBUG
+ifdef STRIP
 	$(Q)$(STRIP) $(STRIPFLAGS_EXTRA) $@
+endif
 endif
 	$(Q)$(SIZE) $$(find $(BUILD) -path "$(BUILD)/build/frozen*.o") $@
 


### PR DESCRIPTION
This provides a way to build a non-DEBUG host binary that still has symbols and debug information.

Document this for the unix port, and update a comment in the unix port Makefile.

Stripping the unix binary by default is definitely worthwhile (at least for very small systems) - size 772KB vs 4.4MB.

This work was funded through GitHub Sponsors.