### PR TITLE
test/internalbench: Add docs, remove unused code for CPython

### DIFF
--- a/tests/README.md
+++ b/tests/README.md
@@ -147,3 +147,30 @@ the test runs, and the absolute difference value is unreliable. High error
 percentages are particularly common on PC builds, where the host OS may
 influence test run times. Increasing the `N` value may help average this out by
 running each test longer.
+
+## internal_bench
+
+The `internal_bench` directory contains a set of tests for benchmarking
+different internal Python features. By default, tests are run on the (unix or
+Windows) host, but the `--pyboard` option allows them to be run on an attached
+board instead.
+
+Tests are grouped by the first part of the file name, and the test runner compares
+output between each group of tests.
+
+The benchmarks measure the elapsed (wall time) for each test, according
+to MicroPython's own time module.
+
+If run without any arguments, all test groups are run. Otherwise, it's possible
+to manually specify which test cases to run.
+
+Example:
+
+```
+$ ./run-internalbench.py internal_bench/bytebuf-*.py
+internal_bench/bytebuf:
+    0.094s (+00.00%) internal_bench/bytebuf-1-inplace.py
+    0.471s (+399.24%) internal_bench/bytebuf-2-join_map_bytes.py
+    0.177s (+87.78%) internal_bench/bytebuf-3-bytarray_map.py
+1 tests performed (3 individual testcases)
+```

--- a/tests/run-internalbench.py
+++ b/tests/run-internalbench.py
@@ -8,16 +8,11 @@ import re
 from glob import glob
 from collections import defaultdict
 
-# Tests require at least CPython 3.3. If your default python3 executable
-# is of lower version, you can point MICROPY_CPYTHON3 environment var
-# to the correct executable.
 if os.name == "nt":
-    CPYTHON3 = os.getenv("MICROPY_CPYTHON3", "python3.exe")
     MICROPYTHON = os.getenv(
         "MICROPY_MICROPYTHON", "../ports/windows/build-standard/micropython.exe"
     )
 else:
-    CPYTHON3 = os.getenv("MICROPY_CPYTHON3", "python3")
     MICROPYTHON = os.getenv("MICROPY_MICROPYTHON", "../ports/unix/build-standard/micropython")
 
 


### PR DESCRIPTION
These changes came about accidentally as I was trying to find a simple way to have these tests report the CPU time rather than the Wall time on unix port.

That effort failed, at least trying to do it quickly and simply. However, I'd already written a little bit of documentation and cleaned up some unused code so I figure those were worth submitting as a PR. :grin: 

_This work was funded through GitHub Sponsors._