### PR TITLE
py/modmicropython: Add micropython.memmove() and micropython.memset().

### DIFF
--- a/py/mpconfig.h
+++ b/py/mpconfig.h
@@ -1256,6 +1256,11 @@ typedef double mp_float_t;
 #define MICROPY_PY_MICROPYTHON_HEAP_LOCKED (MICROPY_CONFIG_ROM_LEVEL_AT_LEAST_EVERYTHING)
 #endif
 
+// Whether to provide "micropython.memmove" and "micropython.memset" functions
+#ifndef MICROPY_ENABLE_MEM_FUNCTIONS
+#define MICROPY_ENABLE_MEM_FUNCTIONS (MICROPY_CONFIG_ROM_LEVEL_AT_LEAST_BASIC_FEATURES)
+#endif
+
 // Whether to provide "array" module. Note that large chunk of the
 // underlying code is shared with "bytearray" builtin type, so to
 // get real savings, it should be disabled too.

--- a/tests/internal_bench/set_bytearray-1-naive.py
+++ b/tests/internal_bench/set_bytearray-1-naive.py
@@ -1,0 +1,14 @@
+import bench
+
+
+def test(num):
+    buf = bytearray(16)
+    c = b"U"[0]
+    i = 0
+    while i < 20000000:
+        for n in range(len(buf)):
+            buf[n] = c
+        i += 1
+
+
+bench.run(test)

--- a/tests/internal_bench/set_bytearray-2-naive-while.py
+++ b/tests/internal_bench/set_bytearray-2-naive-while.py
@@ -1,0 +1,16 @@
+import bench
+
+
+def test(num):
+    buf = bytearray(16)
+    c = b"U"[0]
+    i = 0
+    while i < 20000000:
+        n = 0  # compared to -1-naive.py, eliminate the for loop
+        while n < 16:
+            buf[n] = c
+            n += 1
+        i += 1
+
+
+bench.run(test)

--- a/tests/internal_bench/set_bytearray-3-copy_bytes.py
+++ b/tests/internal_bench/set_bytearray-3-copy_bytes.py
@@ -1,0 +1,12 @@
+import bench
+
+
+def test(num):
+    buf = bytearray(16)
+    i = 0
+    while i < 20000000:
+        buf[:] = b"UUUUUUUUUUUUUUUU"
+        i += 1
+
+
+bench.run(test)

--- a/tests/internal_bench/set_bytearray-4-memset.py
+++ b/tests/internal_bench/set_bytearray-4-memset.py
@@ -1,0 +1,15 @@
+import bench
+
+from micropython import memset
+
+
+def test(num):
+    buf = bytearray(16)
+    c = b"U"[0]
+    i = 0
+    while i < 20000000:
+        memset(buf, 0, c)
+        i += 1
+
+
+bench.run(test)

--- a/tests/internal_bench/slice_copy-1-lvalue_start.py
+++ b/tests/internal_bench/slice_copy-1-lvalue_start.py
@@ -1,0 +1,14 @@
+import bench
+
+
+def test(num):
+    buf = bytearray(16)
+    a = b"\x00\x01\x02\x03\x04\x05\x06\x07"
+    i = 0
+    while i < 20000000:
+        # slice only the starting index of lvalue
+        buf[8:] = a
+        i += 1
+
+
+bench.run(test)

--- a/tests/internal_bench/slice_copy-2-lvalue_start_end.py
+++ b/tests/internal_bench/slice_copy-2-lvalue_start_end.py
@@ -1,0 +1,14 @@
+import bench
+
+
+def test(num):
+    buf = bytearray(16)
+    a = b"\x00\x01\x02\x03\x04\x05\x06\x07"
+    i = 0
+    while i < 20000000:
+        # slice the starting index and length of lvalue
+        buf[8:16] = a
+        i += 1
+
+
+bench.run(test)

--- a/tests/internal_bench/slice_copy-3-lvalue_rvalue_start.py
+++ b/tests/internal_bench/slice_copy-3-lvalue_rvalue_start.py
@@ -1,0 +1,14 @@
+import bench
+
+
+def test(num):
+    buf = bytearray(16)
+    a = b"\x00\x01\x02\x03\x04\x05\x06\x07"
+    i = 0
+    while i < 20000000:
+        # slice the starting index of lvalue and rvalue
+        buf[8:] = a[0:]
+        i += 1
+
+
+bench.run(test)

--- a/tests/internal_bench/slice_copy-4-lvalue_memoryview.py
+++ b/tests/internal_bench/slice_copy-4-lvalue_memoryview.py
@@ -1,0 +1,14 @@
+import bench
+
+
+def test(num):
+    buf = memoryview(bytearray(16))
+    a = b"\x00\x01\x02\x03\x04\x05\x06\x07"
+    i = 0
+    while i < 20000000:
+        # slice the memoryview lvalue
+        buf[8:] = a
+        i += 1
+
+
+bench.run(test)

--- a/tests/internal_bench/slice_copy-5-lvalue_rvalue_memoryview.py
+++ b/tests/internal_bench/slice_copy-5-lvalue_rvalue_memoryview.py
@@ -1,0 +1,14 @@
+import bench
+
+
+def test(num):
+    buf = memoryview(bytearray(16))
+    a = memoryview(b"\x00\x01\x02\x03\x04\x05\x06\x07")
+    i = 0
+    while i < 20000000:
+        # slice both the lvalue & rvalue memoryviews
+        buf[8:] = a[0:]
+        i += 1
+
+
+bench.run(test)

--- a/tests/internal_bench/slice_copy-6-memmove.py
+++ b/tests/internal_bench/slice_copy-6-memmove.py
@@ -1,0 +1,15 @@
+import bench
+
+from micropython import memmove
+
+
+def test(num):
+    buf = bytearray(16)
+    a = b"\x00\x01\x02\x03\x04\x05\x06\x07"
+    i = 0
+    while i < 20000000:
+        memmove(buf, 8, a, 0)  # implicit 'len'
+        i += 1
+
+
+bench.run(test)


### PR DESCRIPTION
This was based on a discussion about providing a more optimal way to copy data between buffers, however based on  benchmarks so far it seems like it might not be worth it compared to optimising "copy to/from slice" code paths written in idiomatic Python.

## Summary

Adds two functions to `micropython` module, gated behind a new config option:

* `micropython.memmove(dest, dest_idx, src, src_idx, [len])` - an optimised equivalent of `dest[dest_idx:dest_idx+len] = src[src_idx:src_idx+len]`. Copies memory contents with semantics of C `memmove`, hence the name. `len` argument is optional, length defaults to the minimum of the length of the source and destination regions.
* `micropython.memset(dest, dest_idx=0, c=0, len=len(dest)-dest_idx)` - an optimised equivalent of `dest[dest_idx:] = bytes([c]*len)`. Modelled on C's `memset`.

Unlike assigning to a slice, the destination buffer size never changes as a result of calling either of these functions. Out of bounds assignment raises an exception.

## Benchmarks - memmove

Comparing memmove to current MicroPython "best practices" (unix port, i5-1248P CPU):

```
❯ ./run-internalbench.py --user-time internal_bench/slice_copy*.py
internal_bench/slice_copy:
    1.143s (+00.00%) internal_bench/slice_copy-1-lvalue_start.py
    1.248s (+09.19%) internal_bench/slice_copy-2-lvalue_start_end.py
    2.607s (+128.08%) internal_bench/slice_copy-3-lvalue_rvalue_start.py
    1.144s (+00.09%) internal_bench/slice_copy-4-lvalue_memoryview.py
    2.047s (+79.09%) internal_bench/slice_copy-5-lvalue_rvalue_memoryview.py
    1.072s (-06.21%) internal_bench/slice_copy-6-memmove.py
1 tests performed (6 individual testcases)
```

Honestly I found this a little underwhelming! Admittedly, `slice_copy-6-memmove.py` can do the equivalent of `slice_copy-5-lvalue_rvalue_memoryview.py` (slices on both sides of the assignment) and it's almost twice as fast, but it's *only* twice as fast (in a tight loop that does nothing else, working with pretty short buffers.)

Maybe the C implementation of memmove() needs some tweaks to streamline the error checking :shrug: .

When rebased against PR #10160 things get even closer:

```
❯ ./run-internalbench.py --user-time internal_bench/slice_copy*.py
internal_bench/slice_copy:
    0.969s (+00.00%) internal_bench/slice_copy-1-lvalue_start.py
    1.062s (+09.60%) internal_bench/slice_copy-2-lvalue_start_end.py
    2.218s (+128.90%) internal_bench/slice_copy-3-lvalue_rvalue_start.py
    0.968s (-00.10%) internal_bench/slice_copy-4-lvalue_memoryview.py
    1.743s (+79.88%) internal_bench/slice_copy-5-lvalue_rvalue_memoryview.py
    1.092s (+12.69%) internal_bench/slice_copy-6-memmove.py
1 tests performed (6 individual testcases)
```

Now `slice_copy-6-memmove.py` is only 1.6x faster than `slice_copy-5-lvalue_rvalue_memoryview.py`, and no faster than assigning a buffer to an lvalue slice...

## Benchmarks - memset

```
❯ ./run-internalbench.py internal_bench/set_bytearray*
internal_bench/set_bytearray:
    10.591s (+00.00%) internal_bench/set_bytearray-1-naive.py
    9.405s (-11.20%) internal_bench/set_bytearray-2-naive-while.py
    1.110s (-89.52%) internal_bench/set_bytearray-3-copy_bytes.py
    0.935s (-91.17%) internal_bench/set_bytearray-4-memset.py
1 tests performed (4 individual testcases)
```

Kind of the same story with memset, writing out a bytes array (which can be frozen to flash) is basically as fast as using the `memset()` function. The naive versions of this are a lot slower, though!

*Disclaimer: The new test file names take some liberties with the meaning of `lvalue` and `rvalue`, happy to take suggestions for more accurate term to use.*

_This work was funded through GitHub Sponsors._