### PR TITLE
esp32: fix Partition.writeblocks partial write corruption

### DIFF
--- a/ports/esp32/esp32_partition.c
+++ b/ports/esp32/esp32_partition.c
@@ -200,7 +200,7 @@ STATIC mp_obj_t esp32_partition_writeblocks(size_t n_args, const mp_obj_t *args)
                     check_esp_err(esp_partition_write(self->part, addr, self->cache, o));
                 }
                 if (top_addr < addr + NATIVE_BLOCK_SIZE_BYTES) {
-                    check_esp_err(esp_partition_write(self->part, top_addr, self->cache, addr + NATIVE_BLOCK_SIZE_BYTES - top_addr));
+                    check_esp_err(esp_partition_write(self->part, top_addr, self->cache + (top_addr - addr), addr + NATIVE_BLOCK_SIZE_BYTES - top_addr));
                 }
                 o = 0;
                 addr += NATIVE_BLOCK_SIZE_BYTES;


### PR DESCRIPTION
To simulate a partial erase, the code reads a native block, erases it, and writes back the data before and after the erased area. However, the current logic was filling the area after the erased block with data from the beginning of the native block-aligned data, instead of applying the proper offset.

Fixes #12474.