### PR TITLE
mpremote: Add rfc2217, serial over tcp.

### DIFF
--- a/docs/reference/mpremote.rst
+++ b/docs/reference/mpremote.rst
@@ -100,6 +100,8 @@ The full list of supported commands are:
     command output)
   - ``port:<path>``: connect to the device with the given path (the first column
     from the ``connect list`` command output
+  - ``rfc2217://<host>:<port>``: connect to the device using serial over TCP
+    (e.g. a networked serial port based on RFC2217)
   - any valid device name/path, to connect to that device
 
   **Note:** Instead of using the ``connect`` command, there are several
@@ -109,7 +111,7 @@ The full list of supported commands are:
 
   **Note:** The ``auto`` option will only detect USB serial ports, i.e. a serial
   port that has an associated USB VID/PID (i.e. CDC/ACM or FTDI-style
-  devices). Other types of serial ports
+  devices). Other types of serial ports will not be auto-detected.
 
 .. _mpremote_command_disconnect:
 

--- a/tools/mpremote/mpremote/transport_serial.py
+++ b/tools/mpremote/mpremote/transport_serial.py
@@ -76,7 +76,9 @@ class SerialTransport(Transport):
         delayed = False
         for attempt in range(wait + 1):
             try:
-                if os.name == "nt":
+                if device.startswith("rfc2217://"):
+                    self.serial = serial.serial_for_url(device, **serial_kwargs)
+                elif os.name == "nt":
                     self.serial = serial.Serial(**serial_kwargs)
                     self.serial.port = device
                     portinfo = list(serial.tools.list_ports.grep(device))  # type: ignore


### PR DESCRIPTION
This PR adds the capability fror mpremote to connect to (simulated) boards that are accessible via remote serial ports, or serial over TCP based on [rfc2217](https://www.rfc-editor.org/rfc/rfc2217.html)

To connect to a device use the following 
`mpremote connect rfc2217://localhost:4000`

**Implementation:** 
pyserial already has built-in support for [rfc2217](https://pyserial.readthedocs.io/en/latest/url_handlers.html#rfc2217) so I have implemented it as a minor addition to the serial protocol.

It would be simple to add support for a straight tcp pipe ( using `socket://host:port` ) if there is use for that as well. 


Some rfc2217 servers that can be used on a (remote) machine to connect to:
- [ser2net](https://www.systutorials.com/docs/linux/man/8-ser2net/)
 - WokWi simulator of esp32 and rp2 boards 
   https://docs.wokwi.com/vscode/project-config#serial-port-forwarding
- [Pyserial example servers](https://docs.espressif.com/projects/esptool/en/latest/esp8266/esptool/remote-serial-ports.html#pyserial-example-servers)
- `com2tcp-rfc2217.bat` from hub4com ](https://sourceforge.net/projects/com0com/files/)

 