### PR TITLE
docs: Add dependencies for sphinx to 'Build docs' action.

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -17,6 +17,6 @@ jobs:
     - uses: actions/checkout@v4
     - uses: actions/setup-python@v4
     - name: Install Python packages
-      run: pip install Sphinx
+      run: pip install -r docs/requirements.txt
     - name: Build docs
       run: make -C docs/ html

--- a/docs/develop/gettingstarted.rst
+++ b/docs/develop/gettingstarted.rst
@@ -245,7 +245,7 @@ that you use a virtual environment:
 
    $ python3 -m venv env
    $ source env/bin/activate
-   $ pip install sphinx
+   $ pip install -r docs/requirements.txt
 
 Navigate to the ``docs`` directory:
 

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,0 +1,2 @@
+sphinx~=7.2.6
+sphinxcontrib.jquery==4.1


### PR DESCRIPTION
Fixes broken documentation build due to missing module.

The modules needed to build the documentation are listed in `docs/requirements-docs.txt` to have a single file for these.
(alternatively this could be a 'docs' section in a common pyproject.toml file) 

Fixes: https://github.com/micropython/micropython/issues/12498
See : https://github.com/orgs/micropython/discussions/12456