### PR TITLE
stm32/mpu: Enable STM32WB mpu use to support qspi flash.

### DIFF
--- a/ports/stm32/mpu.h
+++ b/ports/stm32/mpu.h
@@ -26,7 +26,7 @@
 #ifndef MICROPY_INCLUDED_STM32_MPU_H
 #define MICROPY_INCLUDED_STM32_MPU_H
 
-#if (defined(STM32F4) && defined(MICROPY_HW_ETH_MDC)) || defined(STM32F7) || defined(STM32H7)
+#if (defined(STM32F4) && defined(MICROPY_HW_ETH_MDC)) || defined(STM32F7) || defined(STM32H7) || defined(STM32WB)
 
 #define MPU_REGION_ETH      (MPU_REGION_NUMBER0)
 #define MPU_REGION_QSPI1    (MPU_REGION_NUMBER1)


### PR DESCRIPTION
This MR has been tested on custom hardware that includes a stm32WB55 and a qspi flash chip. Tested on both:
* Renesas AT25SF641B
* Macronix MX25L25673G

The Renesas QSPI Flash chip also required a change to the spiflash driver which is included in this MR:
* drivers/spiflash: Add support for specific CR write command.

The Macronix, and winbond chips I've used on previous projects, all seem to support writing to both status and config registers with the one command, sending two bytes of data.
The Renesas chip on the other hand only supports writing one byte of data on the WRSR command, instead opting for a separate command to write the the CR register.