### PR TITLE
py: Change ifdef DEBUG_PRINT to if DEBUG_PRINT.

### DIFF
--- a/py/emitglue.c
+++ b/py/emitglue.c
@@ -87,7 +87,7 @@ void mp_emit_glue_assign_bytecode(mp_raw_code_t *rc, const byte *code,
     mp_prof_extract_prelude(code, prelude);
     #endif
 
-    #ifdef DEBUG_PRINT
+    #if DEBUG_PRINT
     #if !(MICROPY_PERSISTENT_CODE_SAVE || MICROPY_DEBUG_PRINTERS)
     const size_t len = 0;
     #endif
@@ -149,7 +149,7 @@ void mp_emit_glue_assign_native(mp_raw_code_t *rc, mp_raw_code_kind_t kind, void
     rc->n_pos_args = n_pos_args;
     rc->type_sig = type_sig;
 
-    #ifdef DEBUG_PRINT
+    #if DEBUG_PRINT
     DEBUG_printf("assign native: kind=%d fun=%p len=" UINT_FMT " n_pos_args=" UINT_FMT " flags=%x\n", kind, fun_data, fun_len, n_pos_args, (uint)scope_flags);
     for (mp_uint_t i = 0; i < fun_len; i++) {
         if (i > 0 && i % 16 == 0) {

--- a/py/emitnative.c
+++ b/py/emitnative.c
@@ -745,7 +745,7 @@ STATIC void adjust_stack(emit_t *emit, mp_int_t stack_size_delta) {
     if (emit->pass > MP_PASS_SCOPE && emit->stack_size > emit->scope->stack_size) {
         emit->scope->stack_size = emit->stack_size;
     }
-    #ifdef DEBUG_PRINT
+    #if DEBUG_PRINT
     DEBUG_printf("  adjust_stack; stack_size=%d+%d; stack now:", emit->stack_size - stack_size_delta, stack_size_delta);
     for (int i = 0; i < emit->stack_size; i++) {
         stack_info_t *si = &emit->stack_info[i];


### PR DESCRIPTION
`#if DEBUG_PRINT` is used 7 times

![image](https://github.com/micropython/micropython/assets/70886343/abf792a7-0bdb-4211-9431-e6bc1742a827)

`#ifdef DEBUG_PRINT` is used 3 times.

![image](https://github.com/micropython/micropython/assets/70886343/c7755402-6534-4d69-8756-f6f3e804c498)

Make them the same `#if DEBUG_PRINT`.
