### PR TITLE
stm32: added STM32H7 series octospi storage support, fixed STM32H7B3I_DK's octospi-pins implementation

### DIFF
--- a/ports/stm32/boards/STM32H7B3I_DK/mpconfigboard.h
+++ b/ports/stm32/boards/STM32H7B3I_DK/mpconfigboard.h
@@ -39,20 +39,20 @@
 // SMPS configuration
 #define MICROPY_HW_PWR_SMPS_CONFIG  (PWR_DIRECT_SMPS_SUPPLY)
 
-#if 0
+#if 1
 // 512MBit external OSPI flash, used for either the filesystem or XIP memory mapped
 #define MICROPY_HW_OSPIFLASH_SIZE_BITS_LOG2 (29)
 #define MICROPY_HW_OSPIFLASH_CS     (pin_G6)
-#define MICROPY_HW_OSPIFLASH_CLK    (pin_B2)
+#define MICROPY_HW_OSPIFLASH_SCK    (pin_B2)
 #define MICROPY_HW_OSPIFLASH_DQS    (pin_C5)
-#define MICROPY_HW_OSPIFLASH_IO0    (pin_P8)
+#define MICROPY_HW_OSPIFLASH_IO0    (pin_D11) // changed from pin_P8
 #define MICROPY_HW_OSPIFLASH_IO1    (pin_F9)
 #define MICROPY_HW_OSPIFLASH_IO2    (pin_F7)
 #define MICROPY_HW_OSPIFLASH_IO3    (pin_F6)
 #define MICROPY_HW_OSPIFLASH_IO4    (pin_C1)
 #define MICROPY_HW_OSPIFLASH_IO5    (pin_H3)
-#define MICROPY_HW_OSPIFLASH_IO6    (pin_D6)
-#define MICROPY_HW_OSPIFLASH_IO7    (pin_G14)
+#define MICROPY_HW_OSPIFLASH_IO6    (pin_G9) // changed from pin_D6
+#define MICROPY_HW_OSPIFLASH_IO7    (pin_D7) // changed from pin_G14
 #endif
 
 // UART buses

--- a/ports/stm32/octospi.c
+++ b/ports/stm32/octospi.c
@@ -45,6 +45,24 @@
 
 void octospi_init(void) {
     // Configure OCTOSPI pins (allows 1, 2, 4 or 8 line configuration).
+    #if defined(STM32H7)
+    mp_hal_pin_config_alt_static_speed(MICROPY_HW_OSPIFLASH_CS, MP_HAL_PIN_MODE_ALT, MP_HAL_PIN_PULL_NONE, MP_HAL_PIN_SPEED_VERY_HIGH, STATIC_AF_OCTOSPIM_P1_NCS);
+    mp_hal_pin_config_alt_static_speed(MICROPY_HW_OSPIFLASH_SCK, MP_HAL_PIN_MODE_ALT, MP_HAL_PIN_PULL_NONE, MP_HAL_PIN_SPEED_VERY_HIGH, STATIC_AF_OCTOSPIM_P1_CLK);
+    mp_hal_pin_config_alt_static_speed(MICROPY_HW_OSPIFLASH_IO0, MP_HAL_PIN_MODE_ALT, MP_HAL_PIN_PULL_NONE, MP_HAL_PIN_SPEED_VERY_HIGH, STATIC_AF_OCTOSPIM_P1_IO0);
+    #if defined(MICROPY_HW_OSPIFLASH_IO1)
+    mp_hal_pin_config_alt_static_speed(MICROPY_HW_OSPIFLASH_IO1, MP_HAL_PIN_MODE_ALT, MP_HAL_PIN_PULL_NONE, MP_HAL_PIN_SPEED_VERY_HIGH, STATIC_AF_OCTOSPIM_P1_IO1);
+    #if defined(MICROPY_HW_OSPIFLASH_IO2)
+    mp_hal_pin_config_alt_static_speed(MICROPY_HW_OSPIFLASH_IO2, MP_HAL_PIN_MODE_ALT, MP_HAL_PIN_PULL_NONE, MP_HAL_PIN_SPEED_VERY_HIGH, STATIC_AF_OCTOSPIM_P1_IO2);
+    mp_hal_pin_config_alt_static_speed(MICROPY_HW_OSPIFLASH_IO3, MP_HAL_PIN_MODE_ALT, MP_HAL_PIN_PULL_NONE, MP_HAL_PIN_SPEED_VERY_HIGH, STATIC_AF_OCTOSPIM_P1_IO3);
+    #if defined(MICROPY_HW_OSPIFLASH_IO4)
+    mp_hal_pin_config_alt_static_speed(MICROPY_HW_OSPIFLASH_IO4, MP_HAL_PIN_MODE_ALT, MP_HAL_PIN_PULL_NONE, MP_HAL_PIN_SPEED_VERY_HIGH, STATIC_AF_OCTOSPIM_P1_IO4);
+    mp_hal_pin_config_alt_static_speed(MICROPY_HW_OSPIFLASH_IO5, MP_HAL_PIN_MODE_ALT, MP_HAL_PIN_PULL_NONE, MP_HAL_PIN_SPEED_VERY_HIGH, STATIC_AF_OCTOSPIM_P1_IO5);
+    mp_hal_pin_config_alt_static_speed(MICROPY_HW_OSPIFLASH_IO6, MP_HAL_PIN_MODE_ALT, MP_HAL_PIN_PULL_NONE, MP_HAL_PIN_SPEED_VERY_HIGH, STATIC_AF_OCTOSPIM_P1_IO6);
+    mp_hal_pin_config_alt_static_speed(MICROPY_HW_OSPIFLASH_IO7, MP_HAL_PIN_MODE_ALT, MP_HAL_PIN_PULL_NONE, MP_HAL_PIN_SPEED_VERY_HIGH, STATIC_AF_OCTOSPIM_P1_IO7);
+    #endif
+    #endif
+    #endif
+    #else
     mp_hal_pin_config_alt_static_speed(MICROPY_HW_OSPIFLASH_CS, MP_HAL_PIN_MODE_ALT, MP_HAL_PIN_PULL_NONE, MP_HAL_PIN_SPEED_VERY_HIGH, STATIC_AF_OCTOSPI1_NCS);
     mp_hal_pin_config_alt_static_speed(MICROPY_HW_OSPIFLASH_SCK, MP_HAL_PIN_MODE_ALT, MP_HAL_PIN_PULL_NONE, MP_HAL_PIN_SPEED_VERY_HIGH, STATIC_AF_OCTOSPI1_CLK);
     mp_hal_pin_config_alt_static_speed(MICROPY_HW_OSPIFLASH_IO0, MP_HAL_PIN_MODE_ALT, MP_HAL_PIN_PULL_NONE, MP_HAL_PIN_SPEED_VERY_HIGH, STATIC_AF_OCTOSPI1_IO0);
@@ -61,6 +79,7 @@ void octospi_init(void) {
     #endif
     #endif
     #endif
+    #endif
 
     // Reset and turn on the OCTOSPI peripheral.
     __HAL_RCC_OSPI1_CLK_ENABLE();
@@ -68,12 +87,19 @@ void octospi_init(void) {
     __HAL_RCC_OSPI1_RELEASE_RESET();
 
     // Configure the OCTOSPI peripheral.
-
+    #if defined(STM32H7)
+    OCTOSPI1->CR =
+        3 << OCTOSPI_CR_FTHRES_Pos // 4 bytes must be available to read/write
+            | 0 << OCTOSPI_CR_FSEL_Pos // FLASH 0 selected
+            | 0 << OCTOSPI_CR_DQM_Pos // dual-memory mode disabled
+    ;
+    #else
     OCTOSPI1->CR =
         3 << OCTOSPI_CR_FTHRES_Pos // 4 bytes must be available to read/write
             | 0 << OCTOSPI_CR_MSEL_Pos // FLASH 0 selected
             | 0 << OCTOSPI_CR_DMM_Pos // dual-memory mode disabled
     ;
+    #endif
 
     OCTOSPI1->DCR1 =
         (MICROPY_HW_OSPIFLASH_SIZE_BITS_LOG2 - 3 - 1) << OCTOSPI_DCR1_DEVSIZE_Pos


### PR DESCRIPTION
ports/stm32/octospi.c: Add STM32H7 series octospi storage support.
ports/stm32/boards/STM32H7B3I_DK/mpconfigboard.h: Fix STM32H7B3I_DK's octospi-pins implementation.
Signed-off-by: nspsck