### PR TITLE
py/builtinevex: Handle invalid filenames for execfile.

### DIFF
--- a/extmod/vfs_reader.c
+++ b/extmod/vfs_reader.c
@@ -69,10 +69,10 @@ STATIC void mp_reader_vfs_close(void *data) {
     m_del_obj(mp_reader_vfs_t, reader);
 }
 
-void mp_reader_new_file(mp_reader_t *reader, const char *filename) {
+void mp_reader_new_file(mp_reader_t *reader, qstr filename) {
     mp_reader_vfs_t *rf = m_new_obj(mp_reader_vfs_t);
     mp_obj_t args[2] = {
-        mp_obj_new_str(filename, strlen(filename)),
+        MP_OBJ_NEW_QSTR(filename),
         MP_OBJ_NEW_QSTR(MP_QSTR_rb),
     };
     rf->file = mp_vfs_open(MP_ARRAY_SIZE(args), &args[0], (mp_map_t *)&mp_const_empty_map);

--- a/mpy-cross/main.c
+++ b/mpy-cross/main.c
@@ -71,7 +71,7 @@ STATIC int compile_and_save(const char *file, const char *output_file, const cha
         if (strcmp(file, "-") == 0) {
             lex = mp_lexer_new_from_fd(MP_QSTR__lt_stdin_gt_, STDIN_FILENO, false);
         } else {
-            lex = mp_lexer_new_from_file(file);
+            lex = mp_lexer_new_from_file(qstr_from_str(file));
         }
 
         qstr source_name;
@@ -104,7 +104,7 @@ STATIC int compile_and_save(const char *file, const char *output_file, const cha
                 vstr_add_str(&vstr, output_file);
             }
 
-            mp_raw_code_save_file(&cm, vstr_null_terminated_str(&vstr));
+            mp_raw_code_save_file(&cm, qstr_from_strn(vstr.buf, vstr.len));
             vstr_clear(&vstr);
         }
 

--- a/ports/esp8266/main.c
+++ b/ports/esp8266/main.c
@@ -141,7 +141,7 @@ void user_init(void) {
 }
 
 #if !MICROPY_VFS
-mp_lexer_t *mp_lexer_new_from_file(const char *filename) {
+mp_lexer_t *mp_lexer_new_from_file(qstr filename) {
     mp_raise_OSError(MP_ENOENT);
 }
 

--- a/ports/minimal/main.c
+++ b/ports/minimal/main.c
@@ -73,7 +73,7 @@ void gc_collect(void) {
 }
 #endif
 
-mp_lexer_t *mp_lexer_new_from_file(const char *filename) {
+mp_lexer_t *mp_lexer_new_from_file(qstr filename) {
     mp_raise_OSError(MP_ENOENT);
 }
 

--- a/ports/nrf/main.c
+++ b/ports/nrf/main.c
@@ -302,8 +302,8 @@ soft_reset:
 #if !MICROPY_VFS
 #if MICROPY_MBFS
 // Use micro:bit filesystem
-mp_lexer_t *mp_lexer_new_from_file(const char *filename) {
-    return os_mbfs_new_reader(filename);
+mp_lexer_t *mp_lexer_new_from_file(qstr filename) {
+    return os_mbfs_new_reader(qstr_str(filename));
 }
 
 mp_import_stat_t mp_import_stat(const char *path) {
@@ -317,7 +317,7 @@ MP_DEFINE_CONST_FUN_OBJ_KW(mp_builtin_open_obj, 1, mp_builtin_open);
 
 #else
 // use dummy functions - no filesystem available
-mp_lexer_t *mp_lexer_new_from_file(const char *filename) {
+mp_lexer_t *mp_lexer_new_from_file(qstr filename) {
     mp_raise_OSError(MP_ENOENT);
 }
 

--- a/ports/pic16bit/main.c
+++ b/ports/pic16bit/main.c
@@ -102,7 +102,7 @@ void gc_collect(void) {
     gc_collect_end();
 }
 
-mp_lexer_t *mp_lexer_new_from_file(const char *filename) {
+mp_lexer_t *mp_lexer_new_from_file(qstr filename) {
     mp_raise_OSError(MP_ENOENT);
 }
 

--- a/ports/powerpc/main.c
+++ b/ports/powerpc/main.c
@@ -111,7 +111,7 @@ void gc_collect(void) {
     gc_dump_info(&mp_plat_print);
 }
 
-mp_lexer_t *mp_lexer_new_from_file(const char *filename) {
+mp_lexer_t *mp_lexer_new_from_file(qstr filename) {
     mp_raise_OSError(MP_ENOENT);
 }
 

--- a/ports/qemu-arm/main.c
+++ b/ports/qemu-arm/main.c
@@ -41,7 +41,7 @@ int main(int argc, char **argv) {
 void gc_collect(void) {
 }
 
-mp_lexer_t *mp_lexer_new_from_file(const char *filename) {
+mp_lexer_t *mp_lexer_new_from_file(qstr filename) {
     mp_raise_OSError(MP_ENOENT);
 }
 

--- a/ports/qemu-arm/test_main.c
+++ b/ports/qemu-arm/test_main.c
@@ -34,7 +34,7 @@ void gc_collect(void) {
     gc_collect_end();
 }
 
-mp_lexer_t *mp_lexer_new_from_file(const char *filename) {
+mp_lexer_t *mp_lexer_new_from_file(qstr filename) {
     mp_raise_OSError(MP_ENOENT);
 }
 

--- a/ports/teensy/lexerfrozen.c
+++ b/ports/teensy/lexerfrozen.c
@@ -9,6 +9,6 @@ mp_import_stat_t mp_import_stat(const char *path) {
     return MP_IMPORT_STAT_NO_EXIST;
 }
 
-mp_lexer_t *mp_lexer_new_from_file(const char *filename) {
+mp_lexer_t *mp_lexer_new_from_file(qstr filename) {
     mp_raise_OSError(MP_ENOENT);
 }

--- a/ports/unix/main.c
+++ b/ports/unix/main.c
@@ -129,7 +129,8 @@ STATIC int execute_from_lexer(int source_kind, const void *source, mp_parse_inpu
             const vstr_t *vstr = source;
             lex = mp_lexer_new_from_str_len(MP_QSTR__lt_stdin_gt_, vstr->buf, vstr->len, false);
         } else if (source_kind == LEX_SRC_FILENAME) {
-            lex = mp_lexer_new_from_file((const char *)source);
+            const char *filename = (const char *)source;
+            lex = mp_lexer_new_from_file(qstr_from_str(filename));
         } else { // LEX_SRC_STDIN
             lex = mp_lexer_new_from_fd(MP_QSTR__lt_stdin_gt_, 0, false);
         }

--- a/ports/webassembly/main.c
+++ b/ports/webassembly/main.c
@@ -124,7 +124,7 @@ void gc_collect(void) {
 }
 
 #if !MICROPY_VFS
-mp_lexer_t *mp_lexer_new_from_file(const char *filename) {
+mp_lexer_t *mp_lexer_new_from_file(qstr filename) {
     mp_raise_OSError(MP_ENOENT);
 }
 

--- a/ports/zephyr/main.c
+++ b/ports/zephyr/main.c
@@ -189,7 +189,7 @@ void gc_collect(void) {
 }
 
 #if !MICROPY_READER_VFS
-mp_lexer_t *mp_lexer_new_from_file(const char *filename) {
+mp_lexer_t *mp_lexer_new_from_file(qstr filename) {
     mp_raise_OSError(ENOENT);
 }
 #endif

--- a/py/builtinevex.c
+++ b/py/builtinevex.c
@@ -136,17 +136,18 @@ STATIC mp_obj_t eval_exec_helper(size_t n_args, const mp_obj_t *args, mp_parse_i
     }
     #endif
 
-    // Extract the source code.
-    mp_buffer_info_t bufinfo;
-    mp_get_buffer_raise(args[0], &bufinfo, MP_BUFFER_READ);
 
     // create the lexer
     // MP_PARSE_SINGLE_INPUT is used to indicate a file input
     mp_lexer_t *lex;
     if (MICROPY_PY_BUILTINS_EXECFILE && parse_input_kind == MP_PARSE_SINGLE_INPUT) {
-        lex = mp_lexer_new_from_file(bufinfo.buf);
+        lex = mp_lexer_new_from_file(mp_obj_str_get_qstr(args[0]));
         parse_input_kind = MP_PARSE_FILE_INPUT;
     } else {
+        // Extract the source code.
+        mp_buffer_info_t bufinfo;
+        mp_get_buffer_raise(args[0], &bufinfo, MP_BUFFER_READ);
+
         lex = mp_lexer_new_from_str_len(MP_QSTR__lt_string_gt_, bufinfo.buf, bufinfo.len, 0);
     }
 

--- a/py/builtinimport.c
+++ b/py/builtinimport.c
@@ -164,11 +164,11 @@ STATIC void do_load_from_lexer(mp_module_context_t *context, mp_lexer_t *lex) {
 #endif
 
 #if (MICROPY_HAS_FILE_READER && MICROPY_PERSISTENT_CODE_LOAD) || MICROPY_MODULE_FROZEN_MPY
-STATIC void do_execute_raw_code(const mp_module_context_t *context, const mp_raw_code_t *rc, const char *source_name) {
-    (void)source_name;
-
+STATIC void do_execute_raw_code(const mp_module_context_t *context, const mp_raw_code_t *rc, qstr source_name) {
     #if MICROPY_PY___FILE__
-    mp_store_attr(MP_OBJ_FROM_PTR(&context->module), MP_QSTR___file__, MP_OBJ_NEW_QSTR(qstr_from_str(source_name)));
+    mp_store_attr(MP_OBJ_FROM_PTR(&context->module), MP_QSTR___file__, MP_OBJ_NEW_QSTR(source_name));
+    #else
+    (void)source_name;
     #endif
 
     // execute the module in its context
@@ -224,7 +224,12 @@ STATIC void do_load(mp_module_context_t *module_obj, vstr_t *file) {
         if (frozen_type == MP_FROZEN_MPY) {
             const mp_frozen_module_t *frozen = modref;
             module_obj->constants = frozen->constants;
-            do_execute_raw_code(module_obj, frozen->rc, file_str + frozen_path_prefix_len);
+            #if MICROPY_PY___FILE__
+            qstr frozen_file_qstr = qstr_from_str(file_str + frozen_path_prefix_len);
+            #else
+            qstr frozen_file_qstr = MP_QSTRnull;
+            #endif
+            do_execute_raw_code(module_obj, frozen->rc, frozen_file_qstr);
             return;
         }
         #endif
@@ -232,14 +237,16 @@ STATIC void do_load(mp_module_context_t *module_obj, vstr_t *file) {
 
     #endif // MICROPY_MODULE_FROZEN
 
+    qstr file_qstr = qstr_from_str(file_str);
+
     // If we support loading .mpy files then check if the file extension is of
     // the correct format and, if so, load and execute the file.
     #if MICROPY_HAS_FILE_READER && MICROPY_PERSISTENT_CODE_LOAD
     if (file_str[file->len - 3] == 'm') {
         mp_compiled_module_t cm;
         cm.context = module_obj;
-        mp_raw_code_load_file(file_str, &cm);
-        do_execute_raw_code(cm.context, cm.rc, file_str);
+        mp_raw_code_load_file(file_qstr, &cm);
+        do_execute_raw_code(cm.context, cm.rc, file_qstr);
         return;
     }
     #endif
@@ -247,7 +254,7 @@ STATIC void do_load(mp_module_context_t *module_obj, vstr_t *file) {
     // If we can compile scripts then load the file and compile and execute it.
     #if MICROPY_ENABLE_COMPILER
     {
-        mp_lexer_t *lex = mp_lexer_new_from_file(file_str);
+        mp_lexer_t *lex = mp_lexer_new_from_file(file_qstr);
         do_load_from_lexer(module_obj, lex);
         return;
     }

--- a/py/lexer.c
+++ b/py/lexer.c
@@ -879,10 +879,10 @@ mp_lexer_t *mp_lexer_new_from_str_len(qstr src_name, const char *str, size_t len
 
 #if MICROPY_READER_POSIX || MICROPY_READER_VFS
 
-mp_lexer_t *mp_lexer_new_from_file(const char *filename) {
+mp_lexer_t *mp_lexer_new_from_file(qstr filename) {
     mp_reader_t reader;
     mp_reader_new_file(&reader, filename);
-    return mp_lexer_new(qstr_from_str(filename), reader);
+    return mp_lexer_new(filename, reader);
 }
 
 #if MICROPY_HELPER_LEXER_UNIX

--- a/py/lexer.h
+++ b/py/lexer.h
@@ -191,7 +191,7 @@ mp_lexer_t *mp_lexer_new_from_str_len(qstr src_name, const char *str, size_t len
 
 // If MICROPY_READER_POSIX or MICROPY_READER_VFS aren't enabled then
 // this function must be implemented by the port.
-mp_lexer_t *mp_lexer_new_from_file(const char *filename);
+mp_lexer_t *mp_lexer_new_from_file(qstr filename);
 
 #if MICROPY_HELPER_LEXER_UNIX
 mp_lexer_t *mp_lexer_new_from_fd(qstr filename, int fd, bool close_fd);

--- a/py/persistentcode.c
+++ b/py/persistentcode.c
@@ -451,7 +451,7 @@ void mp_raw_code_load_mem(const byte *buf, size_t len, mp_compiled_module_t *con
 
 #if MICROPY_HAS_FILE_READER
 
-void mp_raw_code_load_file(const char *filename, mp_compiled_module_t *context) {
+void mp_raw_code_load_file(qstr filename, mp_compiled_module_t *context) {
     mp_reader_t reader;
     mp_reader_new_file(&reader, filename);
     mp_raw_code_load(&reader, context);
@@ -638,12 +638,12 @@ STATIC void fd_print_strn(void *env, const char *str, size_t len) {
     (void)ret;
 }
 
-void mp_raw_code_save_file(mp_compiled_module_t *cm, const char *filename) {
+void mp_raw_code_save_file(mp_compiled_module_t *cm, qstr filename) {
     MP_THREAD_GIL_EXIT();
-    int fd = open(filename, O_WRONLY | O_CREAT | O_TRUNC, 0644);
+    int fd = open(qstr_str(filename), O_WRONLY | O_CREAT | O_TRUNC, 0644);
     MP_THREAD_GIL_ENTER();
     if (fd < 0) {
-        mp_raise_OSError_with_filename(errno, filename);
+        mp_raise_OSError_with_filename(errno, qstr_str(filename));
     }
     mp_print_t fd_print = {(void *)(intptr_t)fd, fd_print_strn};
     mp_raw_code_save(cm, &fd_print);

--- a/py/persistentcode.h
+++ b/py/persistentcode.h
@@ -113,10 +113,10 @@ enum {
 
 void mp_raw_code_load(mp_reader_t *reader, mp_compiled_module_t *ctx);
 void mp_raw_code_load_mem(const byte *buf, size_t len, mp_compiled_module_t *ctx);
-void mp_raw_code_load_file(const char *filename, mp_compiled_module_t *ctx);
+void mp_raw_code_load_file(qstr filename, mp_compiled_module_t *ctx);
 
 void mp_raw_code_save(mp_compiled_module_t *cm, mp_print_t *print);
-void mp_raw_code_save_file(mp_compiled_module_t *cm, const char *filename);
+void mp_raw_code_save_file(mp_compiled_module_t *cm, qstr filename);
 
 void mp_native_relocate(void *reloc, uint8_t *text, uintptr_t reloc_text);
 

--- a/py/reader.c
+++ b/py/reader.c
@@ -134,12 +134,12 @@ void mp_reader_new_file_from_fd(mp_reader_t *reader, int fd, bool close_fd) {
 
 #if !MICROPY_VFS_POSIX
 // If MICROPY_VFS_POSIX is defined then this function is provided by the VFS layer
-void mp_reader_new_file(mp_reader_t *reader, const char *filename) {
+void mp_reader_new_file(mp_reader_t *reader, qstr filename) {
     MP_THREAD_GIL_EXIT();
-    int fd = open(filename, O_RDONLY, 0644);
+    int fd = open(qstr_str(filename), O_RDONLY, 0644);
     MP_THREAD_GIL_ENTER();
     if (fd < 0) {
-        mp_raise_OSError_with_filename(errno, filename);
+        mp_raise_OSError_with_filename(errno, qstr_str(filename));
     }
     mp_reader_new_file_from_fd(reader, fd, true);
 }

--- a/py/reader.h
+++ b/py/reader.h
@@ -40,7 +40,7 @@ typedef struct _mp_reader_t {
 } mp_reader_t;
 
 void mp_reader_new_mem(mp_reader_t *reader, const byte *buf, size_t len, size_t free_len);
-void mp_reader_new_file(mp_reader_t *reader, const char *filename);
+void mp_reader_new_file(mp_reader_t *reader, qstr filename);
 void mp_reader_new_file_from_fd(mp_reader_t *reader, int fd, bool close_fd);
 
 #endif // MICROPY_INCLUDED_PY_READER_H

--- a/shared/memzip/lexermemzip.c
+++ b/shared/memzip/lexermemzip.c
@@ -5,15 +5,15 @@
 #include "py/mperrno.h"
 #include "memzip.h"
 
-mp_lexer_t *mp_lexer_new_from_file(const char *filename)
+mp_lexer_t *mp_lexer_new_from_file(qstr filename)
 {
     void *data;
     size_t len;
 
-    if (memzip_locate(filename, &data, &len) != MZ_OK) {
+    if (memzip_locate(qstr_str(filename), &data, &len) != MZ_OK) {
         mp_raise_OSError(MP_ENOENT);
     }
 
-    return mp_lexer_new_from_str_len(qstr_from_str(filename), (const char *)data, (mp_uint_t)len, 0);
+    return mp_lexer_new_from_str_len(filename, (const char *)data, (mp_uint_t)len, 0);
 }
 

--- a/shared/runtime/pyexec.c
+++ b/shared/runtime/pyexec.c
@@ -100,7 +100,7 @@ STATIC int parse_compile_execute(const void *source, mp_parse_input_kind_t input
             } else if (exec_flags & EXEC_FLAG_SOURCE_IS_READER) {
                 lex = mp_lexer_new(MP_QSTR__lt_stdin_gt_, *(mp_reader_t *)source);
             } else if (exec_flags & EXEC_FLAG_SOURCE_IS_FILENAME) {
-                lex = mp_lexer_new_from_file(source);
+                lex = mp_lexer_new_from_file(qstr_from_str(source));
             } else {
                 lex = (mp_lexer_t *)source;
             }

--- a/tests/micropython/builtin_execfile.py
+++ b/tests/micropython/builtin_execfile.py
@@ -70,5 +70,11 @@ except OSError:
 # Test execfile with a file that does exist.
 execfile("/test_mnt/test.py")
 
+# Test that it only works with string arguments.
+try:
+    execfile(b"aaa")
+except TypeError:
+    print("TypeError")
+
 # Unmount the VFS object.
 os.umount(fs)

--- a/tests/micropython/builtin_execfile.py.exp
+++ b/tests/micropython/builtin_execfile.py.exp
@@ -3,4 +3,5 @@ open /noexist.py rb
 OSError
 open /test.py rb
 123
+TypeError
 umount


### PR DESCRIPTION
Fixes #12522.

If a non-string buffer was passed to execfile, then it would be passed as a non-null-terminated char* to mp_lexer_new_from_file.

This changes mp_lexer_new_from_file to take a qstr instead (as in almost all cases a qstr will be created from this input anyway).

This now makes execfile require a string (not generic buffer) argument, which is probably a good fix to make anyway.

_This work was funded through GitHub Sponsors._