### PR TITLE
ports/ESP32: Fixed VBAT voltage calc for UM S3 boards.

### DIFF
--- a/ports/esp32/boards/UM_FEATHERS3/modules/feathers3.py
+++ b/ports/esp32/boards/UM_FEATHERS3/modules/feathers3.py
@@ -65,8 +65,9 @@ def get_battery_voltage():
     This is an approximation only, but useful to detect if the charge state of the battery is getting low.
     """
     adc = ADC(Pin(VBAT_SENSE))  # Assign the ADC pin to read
+    adc.atten(ADC.ATTN_2_5DB)  # Needs 2.5DB attenuation for max voltage of 1.116V w/batt of 4.2V
     measuredvbat = adc.read()
-    measuredvbat /= 4095  # divide by 4095 as we are using the default ADC attenuation of 0dB
+    measuredvbat /= 3657  # Divide by 3657 as we are using 2.5dB attenuation, which is max input of 1.25V = 4095 counts
     measuredvbat *= 4.2  # Multiply by 4.2V, our max charge voltage for a 1S LiPo
     return round(measuredvbat, 2)
 

--- a/ports/esp32/boards/UM_PROS3/modules/pros3.py
+++ b/ports/esp32/boards/UM_PROS3/modules/pros3.py
@@ -41,8 +41,9 @@ def get_battery_voltage():
     This is an approximation only, but useful to detect if the charge state of the battery is getting low.
     """
     adc = ADC(Pin(VBAT_SENSE))  # Assign the ADC pin to read
+    adc.atten(ADC.ATTN_2_5DB)  # Needs 2.5DB attenuation for max voltage of 1.116V w/batt of 4.2V
     measuredvbat = adc.read()
-    measuredvbat /= 4095  # divide by 4095 as we are using the default ADC attenuation of 0dB
+    measuredvbat /= 3657  # Divide by 3657 as we are using 2.5dB attenuation, which is max input of 1.25V = 4095 counts
     measuredvbat *= 4.2  # Multiply by 4.2V, our max charge voltage for a 1S LiPo
     return round(measuredvbat, 2)
 

--- a/ports/esp32/boards/UM_TINYS3/modules/tinys3.py
+++ b/ports/esp32/boards/UM_TINYS3/modules/tinys3.py
@@ -41,8 +41,9 @@ def get_battery_voltage():
     This is an approximation only, but useful to detect if the charge state of the battery is getting low.
     """
     adc = ADC(Pin(VBAT_SENSE))  # Assign the ADC pin to read
+    adc.atten(ADC.ATTN_2_5DB)  # Needs 2.5DB attenuation for max voltage of 1.116V w/batt of 4.2V
     measuredvbat = adc.read()
-    measuredvbat /= 4095  # divide by 4095 as we are using the default ADC attenuation of 0dB
+    measuredvbat /= 3657  # Divide by 3657 as we are using 2.5dB attenuation, which is max input of 1.25V = 4095 counts
     measuredvbat *= 4.2  # Multiply by 4.2V, our max charge voltage for a 1S LiPo
     return round(measuredvbat, 2)
 


### PR DESCRIPTION
Fixed VBAT calculation - changed the ADC attenuation and divider.
Thanks @joey232 for finding the issue and working out the fix.