### PR TITLE
py/lexer: Add missing initialisation for fstring_args_idx.

### DIFF
--- a/py/lexer.c
+++ b/py/lexer.c
@@ -846,6 +846,7 @@ mp_lexer_t *mp_lexer_new(qstr src_name, mp_reader_t reader) {
     vstr_init(&lex->vstr, 32);
     #if MICROPY_PY_FSTRINGS
     vstr_init(&lex->fstring_args, 0);
+    lex->fstring_args_idx = 0;
     #endif
 
     // store sentinel for first indentation level


### PR DESCRIPTION
Fixes #12531 - see discussion there.

---

This was missed in 692d36d779192f32371f7f9daa845b566f26968d. Probably never noticed because everything enables `MICROPY_GC_CONSERVATIVE_CLEAR`, but found via ASAN thanks to @gwangmu & @chibinz.

_This work was funded through GitHub Sponsors._