### PR TITLE
tests/stress/bytecode_limit.py: Reverse order of cases.

### DIFF
--- a/tests/stress/bytecode_limit.py
+++ b/tests/stress/bytecode_limit.py
@@ -3,7 +3,7 @@
 body = " with f()()() as a:\n  try:\n   f()()()\n  except Exception:\n   pass\n"
 
 # Test overflow of jump offset.
-for n in (430, 431, 432, 433):
+for n in (433, 432, 431, 430):
     try:
         exec("cond = 0\nif cond:\n" + body * n + "else:\n print('cond false')\n")
     except MemoryError:

--- a/tests/stress/bytecode_limit.py.exp
+++ b/tests/stress/bytecode_limit.py.exp
@@ -1,5 +1,5 @@
-cond false
-cond false
 RuntimeError
 RuntimeError
+cond false
+cond false
 [123]


### PR DESCRIPTION
The PYBD_SF2 is right on the limit of being able to run this test and so it succeeds the first two cases and fails the next two with MemoryError.

This causes it to SKIP, but that only works if it's the first thing printed. So reverse the order of the tests so it fails on the biggest one first.

_This work was funded through GitHub Sponsors._