### PR TITLE
*/board.json: Restrict to standard features.

### DIFF
--- a/ports/esp32/boards/UM_NANOS3/board.json
+++ b/ports/esp32/boards/UM_NANOS3/board.json
@@ -6,7 +6,7 @@
     "features": [
         "Battery Charging",
         "RGB LED",
-        "SPIRAM",
+        "External RAM",
         "WiFi",
         "BLE"
     ],

--- a/ports/renesas-ra/boards/ARDUINO_PORTENTA_C33/board.json
+++ b/ports/renesas-ra/boards/ARDUINO_PORTENTA_C33/board.json
@@ -4,13 +4,12 @@
     ],
     "docs": "",
     "features": [
-        "512KB SRAM",
-        "2MB Flash",
-        "16MB QSPI Flash",
-        "USB High Speed Phy",
-        "10/100 Ethernet Phy",
-        "ESP32 WiFi/BT Module",
-        "NXP SE050 crypto device"
+        "BLE",
+        "Ethernet",
+        "External Flash",
+        "Secure Element",
+        "USB-C",
+        "WiFi"
     ],
     "images": [
         "ABX00074_01.iso_1000x750.jpg"


### PR DESCRIPTION
Applies to newly-added ARDUINO_PORTENTA_C33 and UM_NANOS3.

Makes the list match the standard features defined in 24a6e951ec7696b8d18d95fe5da36f7e489913d0.

_This work was funded through GitHub Sponsors._