### PR TITLE
extmod/btstack/btstack_hci_uart: Trigger a poll after UART data is sent.

### DIFF
--- a/extmod/btstack/btstack_hci_uart.c
+++ b/extmod/btstack/btstack_hci_uart.c
@@ -36,6 +36,7 @@
 #include "extmod/mpbthci.h"
 #include "extmod/btstack/btstack_hci_uart.h"
 
+#include "mpbthciport.h"
 #include "mpbtstackport.h"
 
 #define HCI_TRACE (0)
@@ -129,6 +130,10 @@ STATIC void btstack_uart_send_block(const uint8_t *buf, uint16_t len) {
 
     mp_bluetooth_hci_uart_write(buf, len);
     send_done = true;
+
+    // Data has been written out synchronously on the UART, so trigger a poll which will
+    // then notify btstack (don't call send_handler here or it may call us recursively).
+    mp_bluetooth_hci_poll_now();
 }
 
 STATIC int btstack_uart_get_supported_sleep_modes(void) {


### PR DESCRIPTION
Prior to this commit, BTstack would only be notified of sent UART data when the mp_bluetooth_hci_poll() function was called for some other reason, eg because of incoming data over UART.  This is highly suboptimal.

With this commit, BTstack is now notified immediately after UART data has been sent out.  This improves the multi_bluetooth/perf_gatt_char_write.py performance test by about a factor of 10x for write-without-response, and about 4x for write-with-response (tested on LEGO_HUB_NO6 as instance1).