### PR TITLE
extmod/modnetwork.c: Increase max hostname length to 32.

### DIFF
--- a/docs/library/network.rst
+++ b/docs/library/network.rst
@@ -188,6 +188,11 @@ The following are functions available in the network module.
     during connection. For this reason, you must set the hostname before
     activating/connecting your network interfaces.
 
+    The length of the hostname is limited to 32 characters.
+    :term:`MicroPython ports <MicroPython port>` may choose to set a lower
+    limit for memory reasons. If the given name does not fit, a `ValueError`
+    is raised.
+
     The default hostname is typically the name of the board.
 
 .. function:: phy_mode([mode])

--- a/extmod/modnetwork.c
+++ b/extmod/modnetwork.c
@@ -56,7 +56,7 @@ char mod_network_country_code[2] = "XX";
 #error "MICROPY_PY_NETWORK_HOSTNAME_DEFAULT must be set in mpconfigport.h or mpconfigboard.h"
 #endif
 
-char mod_network_hostname[MICROPY_PY_NETWORK_HOSTNAME_MAX_LEN + 1] = MICROPY_PY_NETWORK_HOSTNAME_DEFAULT;
+char mod_network_hostname_data[MICROPY_PY_NETWORK_HOSTNAME_MAX_LEN + 1] = MICROPY_PY_NETWORK_HOSTNAME_DEFAULT;
 
 #ifdef MICROPY_PORT_NETWORK_INTERFACES
 
@@ -116,20 +116,21 @@ STATIC mp_obj_t network_country(size_t n_args, const mp_obj_t *args) {
 // TODO: Non-static to allow backwards-compatible pyb.country.
 MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(mod_network_country_obj, 0, 1, network_country);
 
-STATIC mp_obj_t network_hostname(size_t n_args, const mp_obj_t *args) {
+mp_obj_t mod_network_hostname(size_t n_args, const mp_obj_t *args) {
     if (n_args == 0) {
-        return mp_obj_new_str(mod_network_hostname, strlen(mod_network_hostname));
+        return mp_obj_new_str(mod_network_hostname_data, strlen(mod_network_hostname_data));
     } else {
         size_t len;
         const char *str = mp_obj_str_get_data(args[0], &len);
         if (len > MICROPY_PY_NETWORK_HOSTNAME_MAX_LEN) {
             mp_raise_ValueError(NULL);
         }
-        strcpy(mod_network_hostname, str);
+        memcpy(mod_network_hostname_data, str, len);
+        mod_network_hostname_data[len] = 0;
         return mp_const_none;
     }
 }
-STATIC MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(mod_network_hostname_obj, 0, 1, network_hostname);
+STATIC MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(mod_network_hostname_obj, 0, 1, mod_network_hostname);
 
 STATIC const mp_rom_map_elem_t mp_module_network_globals_table[] = {
     { MP_ROM_QSTR(MP_QSTR___name__), MP_ROM_QSTR(MP_QSTR_network) },

--- a/extmod/modnetwork.c
+++ b/extmod/modnetwork.c
@@ -35,7 +35,7 @@
 #if MICROPY_PY_NETWORK
 
 #include "shared/netutils/netutils.h"
-#include "modnetwork.h"
+#include "extmod/modnetwork.h"
 
 #if MICROPY_PY_NETWORK_CYW43
 // So that CYW43_LINK_xxx constants are available to MICROPY_PORT_NETWORK_INTERFACES.
@@ -56,7 +56,7 @@ char mod_network_country_code[2] = "XX";
 #error "MICROPY_PY_NETWORK_HOSTNAME_DEFAULT must be set in mpconfigport.h or mpconfigboard.h"
 #endif
 
-char mod_network_hostname[MICROPY_PY_NETWORK_HOSTNAME_MAX_LEN] = MICROPY_PY_NETWORK_HOSTNAME_DEFAULT;
+char mod_network_hostname[MICROPY_PY_NETWORK_HOSTNAME_MAX_LEN + 1] = MICROPY_PY_NETWORK_HOSTNAME_DEFAULT;
 
 #ifdef MICROPY_PORT_NETWORK_INTERFACES
 
@@ -122,7 +122,7 @@ STATIC mp_obj_t network_hostname(size_t n_args, const mp_obj_t *args) {
     } else {
         size_t len;
         const char *str = mp_obj_str_get_data(args[0], &len);
-        if (len >= MICROPY_PY_NETWORK_HOSTNAME_MAX_LEN) {
+        if (len > MICROPY_PY_NETWORK_HOSTNAME_MAX_LEN) {
             mp_raise_ValueError(NULL);
         }
         strcpy(mod_network_hostname, str);

--- a/extmod/modnetwork.h
+++ b/extmod/modnetwork.h
@@ -61,7 +61,12 @@ extern char mod_network_country_code[2];
 #endif
 
 // This is a null-terminated string.
-extern char mod_network_hostname[MICROPY_PY_NETWORK_HOSTNAME_MAX_LEN + 1];
+extern char mod_network_hostname_data[MICROPY_PY_NETWORK_HOSTNAME_MAX_LEN + 1];
+
+// To support backwards-compatible (esp32, esp8266, cyw43)
+// `if.config(hostname=...)` to forward directly to the implementation of
+// `network.hostname(...)`.
+mp_obj_t mod_network_hostname(size_t n_args, const mp_obj_t *args);
 
 #if MICROPY_PY_LWIP
 struct netif;

--- a/extmod/modnetwork.h
+++ b/extmod/modnetwork.h
@@ -56,10 +56,12 @@
 extern char mod_network_country_code[2];
 
 #ifndef MICROPY_PY_NETWORK_HOSTNAME_MAX_LEN
-#define MICROPY_PY_NETWORK_HOSTNAME_MAX_LEN (16)
+// Doesn't include the null terminator.
+#define MICROPY_PY_NETWORK_HOSTNAME_MAX_LEN (32)
 #endif
 
-extern char mod_network_hostname[MICROPY_PY_NETWORK_HOSTNAME_MAX_LEN];
+// This is a null-terminated string.
+extern char mod_network_hostname[MICROPY_PY_NETWORK_HOSTNAME_MAX_LEN + 1];
 
 #if MICROPY_PY_LWIP
 struct netif;

--- a/extmod/network_cyw43.c
+++ b/extmod/network_cyw43.c
@@ -422,7 +422,7 @@ STATIC mp_obj_t network_cyw43_config(size_t n_args, const mp_obj_t *args, mp_map
             }
             case MP_QSTR_hostname: {
                 // TODO: Deprecated. Use network.hostname() instead.
-                return mp_obj_new_str(mod_network_hostname, strlen(mod_network_hostname));
+                return mod_network_hostname(0, NULL);
             }
             default:
                 mp_raise_ValueError(MP_ERROR_TEXT("unknown config param"));
@@ -498,12 +498,7 @@ STATIC mp_obj_t network_cyw43_config(size_t n_args, const mp_obj_t *args, mp_map
                     }
                     case MP_QSTR_hostname: {
                         // TODO: Deprecated. Use network.hostname(name) instead.
-                        size_t len;
-                        const char *str = mp_obj_str_get_data(e->value, &len);
-                        if (len > MICROPY_PY_NETWORK_HOSTNAME_MAX_LEN) {
-                            mp_raise_ValueError(NULL);
-                        }
-                        strcpy(mod_network_hostname, str);
+                        mod_network_hostname(1, &e->value);
                         break;
                     }
                     default:

--- a/extmod/network_cyw43.c
+++ b/extmod/network_cyw43.c
@@ -500,7 +500,7 @@ STATIC mp_obj_t network_cyw43_config(size_t n_args, const mp_obj_t *args, mp_map
                         // TODO: Deprecated. Use network.hostname(name) instead.
                         size_t len;
                         const char *str = mp_obj_str_get_data(e->value, &len);
-                        if (len >= MICROPY_PY_NETWORK_HOSTNAME_MAX_LEN) {
+                        if (len > MICROPY_PY_NETWORK_HOSTNAME_MAX_LEN) {
                             mp_raise_ValueError(NULL);
                         }
                         strcpy(mod_network_hostname, str);

--- a/ports/esp32/network_wlan.c
+++ b/ports/esp32/network_wlan.c
@@ -524,7 +524,7 @@ STATIC mp_obj_t network_wlan_config(size_t n_args, const mp_obj_t *args, mp_map_
                         // TODO: Deprecated. Use network.hostname(name) instead.
                         size_t len;
                         const char *str = mp_obj_str_get_data(kwargs->table[i].value, &len);
-                        if (len >= MICROPY_PY_NETWORK_HOSTNAME_MAX_LEN) {
+                        if (len > MICROPY_PY_NETWORK_HOSTNAME_MAX_LEN) {
                             mp_raise_ValueError(NULL);
                         }
                         strcpy(mod_network_hostname, str);

--- a/ports/esp32/network_wlan.c
+++ b/ports/esp32/network_wlan.c
@@ -169,8 +169,8 @@ static void network_wlan_ip_event_handler(void *event_handler_arg, esp_event_bas
             if (!mdns_initialised) {
                 mdns_init();
                 #if MICROPY_HW_ENABLE_MDNS_RESPONDER
-                mdns_hostname_set(mod_network_hostname);
-                mdns_instance_name_set(mod_network_hostname);
+                mdns_hostname_set(mod_network_hostname_data);
+                mdns_instance_name_set(mod_network_hostname_data);
                 #endif
                 mdns_initialised = true;
             }
@@ -305,7 +305,7 @@ STATIC mp_obj_t network_wlan_connect(size_t n_args, const mp_obj_t *pos_args, mp
         esp_exceptions(esp_wifi_set_config(ESP_IF_WIFI_STA, &wifi_sta_config));
     }
 
-    esp_exceptions(esp_netif_set_hostname(wlan_sta_obj.netif, mod_network_hostname));
+    esp_exceptions(esp_netif_set_hostname(wlan_sta_obj.netif, mod_network_hostname_data));
 
     wifi_sta_reconnects = 0;
     // connect to the WiFi AP
@@ -522,12 +522,7 @@ STATIC mp_obj_t network_wlan_config(size_t n_args, const mp_obj_t *args, mp_map_
                     case MP_QSTR_hostname:
                     case MP_QSTR_dhcp_hostname: {
                         // TODO: Deprecated. Use network.hostname(name) instead.
-                        size_t len;
-                        const char *str = mp_obj_str_get_data(kwargs->table[i].value, &len);
-                        if (len > MICROPY_PY_NETWORK_HOSTNAME_MAX_LEN) {
-                            mp_raise_ValueError(NULL);
-                        }
-                        strcpy(mod_network_hostname, str);
+                        mod_network_hostname(1, &kwargs->table[i].value);
                         break;
                     }
                     case MP_QSTR_max_clients: {
@@ -630,7 +625,7 @@ STATIC mp_obj_t network_wlan_config(size_t n_args, const mp_obj_t *args, mp_map_
         case MP_QSTR_dhcp_hostname: {
             // TODO: Deprecated. Use network.hostname() instead.
             req_if = ESP_IF_WIFI_STA;
-            val = mp_obj_new_str(mod_network_hostname, strlen(mod_network_hostname));
+            val = mod_network_hostname(0, NULL);
             break;
         }
         case MP_QSTR_max_clients: {

--- a/ports/esp8266/network_wlan.c
+++ b/ports/esp8266/network_wlan.c
@@ -404,7 +404,7 @@ STATIC mp_obj_t esp_config(size_t n_args, const mp_obj_t *args, mp_map_t *kwargs
                         // TODO: Deprecated. Use network.hostname(name) instead.
                         size_t len;
                         const char *str = mp_obj_str_get_data(kwargs->table[i].value, &len);
-                        if (len >= MICROPY_PY_NETWORK_HOSTNAME_MAX_LEN) {
+                        if (len > MICROPY_PY_NETWORK_HOSTNAME_MAX_LEN) {
                             mp_raise_ValueError(NULL);
                         }
                         strcpy(mod_network_hostname, str);

--- a/ports/esp8266/network_wlan.c
+++ b/ports/esp8266/network_wlan.c
@@ -152,7 +152,7 @@ STATIC mp_obj_t esp_connect(size_t n_args, const mp_obj_t *pos_args, mp_map_t *k
         error_check(wifi_station_set_config(&config), "Cannot set STA config");
     }
 
-    wifi_station_set_hostname(mod_network_hostname);
+    wifi_station_set_hostname(mod_network_hostname_data);
 
     error_check(wifi_station_connect(), "Cannot connect to AP");
 
@@ -402,12 +402,7 @@ STATIC mp_obj_t esp_config(size_t n_args, const mp_obj_t *args, mp_map_t *kwargs
                     case MP_QSTR_hostname:
                     case MP_QSTR_dhcp_hostname: {
                         // TODO: Deprecated. Use network.hostname(name) instead.
-                        size_t len;
-                        const char *str = mp_obj_str_get_data(kwargs->table[i].value, &len);
-                        if (len > MICROPY_PY_NETWORK_HOSTNAME_MAX_LEN) {
-                            mp_raise_ValueError(NULL);
-                        }
-                        strcpy(mod_network_hostname, str);
+                        mod_network_hostname(1, &kwargs->table[i].value);
                         break;
                     }
                     case MP_QSTR_protocol: {
@@ -481,9 +476,9 @@ STATIC mp_obj_t esp_config(size_t n_args, const mp_obj_t *args, mp_map_t *kwargs
             break;
         case MP_QSTR_hostname:
         case MP_QSTR_dhcp_hostname: {
-            req_if = STATION_IF;
             // TODO: Deprecated. Use network.hostname() instead.
-            val = mp_obj_new_str(mod_network_hostname, strlen(mod_network_hostname));
+            req_if = STATION_IF;
+            val = mod_network_hostname(0, NULL);
             break;
         }
         case MP_QSTR_protocol: {

--- a/ports/mimxrt/cyw43_configport.h
+++ b/ports/mimxrt/cyw43_configport.h
@@ -61,7 +61,7 @@
 #define CYW43_THREAD_EXIT               MICROPY_PY_LWIP_EXIT
 #define CYW43_THREAD_LOCK_CHECK
 
-#define CYW43_HOST_NAME                 mod_network_hostname
+#define CYW43_HOST_NAME                 mod_network_hostname_data
 
 #define CYW43_SDPCM_SEND_COMMON_WAIT    __WFI();
 #define CYW43_DO_IOCTL_WAIT             __WFI();

--- a/ports/mimxrt/eth.c
+++ b/ports/mimxrt/eth.c
@@ -559,7 +559,7 @@ STATIC void eth_lwip_init(eth_t *self) {
     n->name[0] = 'e';
     n->name[1] = (self == &eth_instance0 ? '0' : '1');
     netif_add(n, &ipconfig[0], &ipconfig[1], &ipconfig[2], self, eth_netif_init, ethernet_input);
-    netif_set_hostname(n, mod_network_hostname);
+    netif_set_hostname(n, mod_network_hostname_data);
     netif_set_default(n);
     netif_set_up(n);
 

--- a/ports/rp2/cyw43_configport.h
+++ b/ports/rp2/cyw43_configport.h
@@ -48,7 +48,7 @@
 #define CYW43_THREAD_EXIT               MICROPY_PY_LWIP_EXIT
 #define CYW43_THREAD_LOCK_CHECK
 
-#define CYW43_HOST_NAME                 mod_network_hostname
+#define CYW43_HOST_NAME                 mod_network_hostname_data
 
 #define CYW43_SDPCM_SEND_COMMON_WAIT \
     if (get_core_num() == 0) { \

--- a/ports/stm32/cyw43_configport.h
+++ b/ports/stm32/cyw43_configport.h
@@ -62,7 +62,7 @@
 #define CYW43_THREAD_EXIT               MICROPY_PY_LWIP_EXIT
 #define CYW43_THREAD_LOCK_CHECK
 
-#define CYW43_HOST_NAME                 mod_network_hostname
+#define CYW43_HOST_NAME                 mod_network_hostname_data
 
 #define CYW43_SDPCM_SEND_COMMON_WAIT    __WFI();
 #define CYW43_DO_IOCTL_WAIT             __WFI();

--- a/ports/stm32/eth.c
+++ b/ports/stm32/eth.c
@@ -737,7 +737,7 @@ STATIC void eth_lwip_init(eth_t *self) {
     n->name[0] = 'e';
     n->name[1] = '0';
     netif_add(n, &ipconfig[0], &ipconfig[1], &ipconfig[2], self, eth_netif_init, ethernet_input);
-    netif_set_hostname(n, mod_network_hostname);
+    netif_set_hostname(n, mod_network_hostname_data);
     netif_set_default(n);
     netif_set_up(n);
 


### PR DESCRIPTION
See also earlier PRs #12403 and #12404.

This changes from the previous limit of 15 characters. Although DHCP and mDNS allow for up to 63, ESP32 and ESP8266 only allow 32, so this seems like a reasonable limit to enforce across all ports (and avoids wasting the additional memory).

Also clarifies that `MICROPY_PY_NETWORK_HOSTNAME_MAX_LEN` does not include the null terminator (which was unclear before).

_This work was funded through GitHub Sponsors._