### PR TITLE
mimxrt: Fixes for previous commits.

### DIFF
--- a/ports/mimxrt/boards/ADAFRUIT_METRO_M7/mpconfigboard.h
+++ b/ports/mimxrt/boards/ADAFRUIT_METRO_M7/mpconfigboard.h
@@ -7,7 +7,7 @@
 #define MICROPY_HW_LED_OFF(pin) (mp_hal_pin_low(pin))
 
 #define MICROPY_HW_NUM_PIN_IRQS (2 * 32)
-#define MICROPY_HW_ENABLE_SDCARD    (0)
+#define MICROPY_PY_MACHINE_SDCARD    (0)
 
 // Define mapping logical UART # to hardware UART #
 // LPUART1 on USB_DBG  -> 0

--- a/ports/mimxrt/boards/MIMXRT1010_EVK/mpconfigboard.h
+++ b/ports/mimxrt/boards/MIMXRT1010_EVK/mpconfigboard.h
@@ -7,7 +7,7 @@
 #define MICROPY_HW_LED_OFF(pin) (mp_hal_pin_low(pin))
 
 #define MICROPY_HW_NUM_PIN_IRQS (2 * 32)
-#define MICROPY_HW_ENABLE_SDCARD    (0)
+#define MICROPY_PY_MACHINE_SDCARD    (0)
 
 // Define mapping logical UART # to hardware UART #
 // LPUART1 on USB_DBG  -> 0

--- a/ports/mimxrt/mpbthciport.c
+++ b/ports/mimxrt/mpbthciport.c
@@ -36,6 +36,10 @@
 
 #if MICROPY_PY_BLUETOOTH
 
+#ifndef MICROPY_HW_BLE_UART_FLOW_CONTROL
+#define MICROPY_HW_BLE_UART_FLOW_CONTROL (3)
+#endif
+
 #define DEBUG_printf(...) // mp_printf(&mp_plat_print, "mpbthciport.c: " __VA_ARGS__)
 #define ERROR_printf(...) mp_printf(&mp_plat_print, "mpbthciport.c: " __VA_ARGS__)
 
@@ -85,7 +89,7 @@ int mp_bluetooth_hci_uart_init(uint32_t port, uint32_t baudrate) {
     mp_obj_t args[] = {
         MP_OBJ_NEW_SMALL_INT(port),
         MP_OBJ_NEW_QSTR(MP_QSTR_baudrate), MP_OBJ_NEW_SMALL_INT(baudrate),
-        MP_OBJ_NEW_QSTR(MP_QSTR_flow), MP_OBJ_NEW_SMALL_INT(3),
+        MP_OBJ_NEW_QSTR(MP_QSTR_flow), MP_OBJ_NEW_SMALL_INT(MICROPY_HW_BLE_UART_FLOW_CONTROL),
         MP_OBJ_NEW_QSTR(MP_QSTR_timeout), MP_OBJ_NEW_SMALL_INT(200),
         MP_OBJ_NEW_QSTR(MP_QSTR_timeout_char), MP_OBJ_NEW_SMALL_INT(200),
         MP_OBJ_NEW_QSTR(MP_QSTR_txbuf), MP_OBJ_NEW_SMALL_INT(768),


### PR DESCRIPTION
- mimxrt/sdcard: Fix an omission of commit 552b0bbe1 for SDCARD which prevents building of the firmware for MIMXRT1010_EVK and Adafruit Metro M7. It did not define MICROPY_PY_MACHINE_SDCARD properly for these boards.
- mimxrt/mpbthciport.c: Allow to configure UART flow control for BLE.  Not all boards or BLE extensions have the flow control signals for BLE available at suitable pins. Actually none of the Adafruit extensions match for flow control. This change can be made later as well, since at the moment not MIMXRT board support BLE. It's WIP.
