### PR TITLE
esp32: Freeze aioespnow module into ESP32 firmware by default.

### DIFF
--- a/ports/esp32/boards/manifest.py
+++ b/ports/esp32/boards/manifest.py
@@ -5,7 +5,7 @@ include("$(MPY_DIR)/extmod/asyncio")
 require("bundle-networking")
 
 # Require some micropython-lib modules.
-# require("aioespnow")
+require("aioespnow")
 require("dht")
 require("ds18x20")
 require("neopixel")

--- a/ports/esp8266/boards/manifest.py
+++ b/ports/esp8266/boards/manifest.py
@@ -1,5 +1,4 @@
 freeze("$(PORT_DIR)/modules")
-# require("aioespnow")
 require("bundle-networking")
 require("dht")
 require("ds18x20")


### PR DESCRIPTION
Uncomment the `# require("aioespnow")` line in `ports/esp32/boards/manifest.py` as proposed in #12580.

This PR can be merged **after** the `lib/micropython-lib` submodule is updated to a revision which includes `micropython/aioespnow/aioespnow.py`. This is expected to occur prior to the release of v1.21.0.

`aioespnow` extends the [`espnow`](https://docs.micropython.org/en/latest/library/espnow.html) module with support for asyncio methods: `arecv()` and `asend()` and is documented in the [espnow documentation](https://docs.micropython.org/en/latest/library/espnow.html).

Fixes #12580 