### PR TITLE
rp2: Enable debug symbols in all builds.

### DIFF
--- a/ports/rp2/CMakeLists.txt
+++ b/ports/rp2/CMakeLists.txt
@@ -406,6 +406,7 @@ target_include_directories(${MICROPY_TARGET} PRIVATE
 target_compile_options(${MICROPY_TARGET} PRIVATE
     -Wall
     -Werror
+    -g  # always include debug information in the ELF
 )
 
 target_link_options(${MICROPY_TARGET} PRIVATE


### PR DESCRIPTION
Allows using gdb, addr2line, etc. on a "release" ELF file.

No impact to .bin or .uf2 size, only the .elf will get bigger.

*This work was funded through GitHub Sponsors.*