### PR TITLE
esp8266/boards: Remove urllib from the 2MiB manifest.

### DIFF
--- a/ports/esp8266/boards/ESP8266_GENERIC/manifest_2MiB.py
+++ b/ports/esp8266/boards/ESP8266_GENERIC/manifest_2MiB.py
@@ -10,10 +10,6 @@ require("ssd1306")
 # micropython-lib: file utilities
 require("upysh")
 
-# micropython-lib: requests
-require("urequests")
-require("urllib.urequest")
-
 # micropython-lib: umqtt
 require("umqtt.simple")
 require("umqtt.robust")


### PR DESCRIPTION
No other network-enabled board has urllib.urequest frozen in to the firmware, and esp8266 is relatively low on flash, so remove this module.

And (u)requests is already included by bundle-networking.