### PR TITLE
mimxrt/LED: Fix the the machine.LED class.

### DIFF
--- a/ports/mimxrt/led.c
+++ b/ports/mimxrt/led.c
@@ -52,19 +52,7 @@ void led_init(void) {
     // Turn off LEDs and initialize
     for (mp_int_t led = 0; led < NUM_LEDS; led++) {
         const machine_pin_obj_t *led_pin = machine_led_obj[led].led_pin;
-
-        gpio_pin_config_t pin_config = {
-            .outputLogic = 1U,
-            .direction = kGPIO_DigitalOutput,
-            .interruptMode = kGPIO_NoIntmode,
-        };
-
-        GPIO_PinInit(led_pin->gpio, led_pin->pin, &pin_config);
-
-        // ALT mode for GPIO is always 5
-        IOMUXC_SetPinMux(led_pin->muxRegister, 5U, 0, 0, led_pin->configRegister,
-            1U);                 // Software Input On Field: Input Path is determined by functionality
-        IOMUXC_SetPinConfig(led_pin->muxRegister, 5U, 0, 0, led_pin->configRegister, 0x10B0U);
+        mp_hal_pin_output(led_pin);
         MICROPY_HW_LED_OFF(led_pin);
     }
 }

--- a/ports/mimxrt/main.c
+++ b/ports/mimxrt/main.c
@@ -93,7 +93,7 @@ int main(void) {
     #endif
 
     for (;;) {
-        #if defined(MICROPY_HW_LED1)
+        #if defined(MICROPY_HW_LED1_PIN)
         led_init();
         #endif
 


### PR DESCRIPTION
led_init() was not called, and therefore the machine.LED class seemed not to work. led_init() now uses mp_hal_pin_output() to configure the pin.