### PR TITLE
py/vm.c: don't complain about "raise … from None".

### DIFF
--- a/py/vm.c
+++ b/py/vm.c
@@ -1171,8 +1171,10 @@ unwind_return:
 
                 ENTRY(MP_BC_RAISE_FROM): {
                     MARK_EXC_IP_SELECTIVE();
-                    mp_warning(NULL, "exception chaining not supported");
-                    sp--; // ignore (pop) "from" argument
+                    mp_obj_t from_value = POP();
+                    if (from_value != mp_const_none) {
+                        mp_warning(NULL, "exception chaining not supported");
+                    }
                     mp_obj_t obj = mp_make_raise_obj(TOP());
                     RAISE(obj);
                 }

--- a/tests/basics/exception_chain.py
+++ b/tests/basics/exception_chain.py
@@ -1,6 +1,15 @@
 # Exception chaining is not supported, but check that basic
 # exception works as expected.
+
 try:
     raise Exception from None
 except Exception:
     print("Caught Exception")
+
+try:
+    try:
+        raise ValueError("Value")
+    except Exception as exc:
+        raise RuntimeError("Runtime") from exc
+except Exception as ex2:
+    print("Caught Exception:", ex2)

--- a/tests/basics/exception_chain.py.exp
+++ b/tests/basics/exception_chain.py.exp
@@ -1,2 +1,3 @@
-Warning: exception chaining not supported
 Caught Exception
+Warning: exception chaining not supported
+Caught Exception: Runtime


### PR DESCRIPTION
`raise SomeException() from None` is a common Python idiom to suppress chained exceptions and thus shouldn't trigger a warning on a version of Python that doesn't support them in the first place.