### PR TITLE
esp32/network_ppp: Build with no IPv6 support.

### DIFF
--- a/ports/esp32/network_ppp.c
+++ b/ports/esp32/network_ppp.c
@@ -65,7 +65,11 @@ static void ppp_status_cb(ppp_pcb *pcb, int err_code, void *ctx) {
 
     switch (err_code) {
         case PPPERR_NONE:
+            #if CONFIG_LWIP_IPV6
             self->connected = (pppif->ip_addr.u_addr.ip4.addr != 0);
+            #else
+            self->connected = (pppif->ip_addr.addr != 0);
+            #endif // CONFIG_LWIP_IPV6
             break;
         case PPPERR_USER:
             self->clean_close = true;
@@ -250,7 +254,11 @@ STATIC mp_obj_t ppp_ifconfig(size_t n_args, const mp_obj_t *args) {
         ip_addr_t dns;
         mp_obj_t *items;
         mp_obj_get_array_fixed_n(args[1], 4, &items);
+        #if CONFIG_LWIP_IPV6
         netutils_parse_ipv4_addr(items[3], (uint8_t *)&dns.u_addr.ip4, NETUTILS_BIG);
+        #else
+        netutils_parse_ipv4_addr(items[3], (uint8_t *)&dns, NETUTILS_BIG);
+        #endif // CONFIG_LWIP_IPV6
         dns_setserver(0, &dns);
         return mp_const_none;
     }


### PR DESCRIPTION
PPP code assumes that IPv6 support is enabled.  Whilst this is the default, certain applications may want to disable IPv6 support if not needed (or to reduce code size).

This makes the code build with CONFIG_LWIP_IPV6 disabled, reducing code by about 30k in that case.

In my particular case I do not need WiFi/IP support and I'm a bit short of flash space.  Since there is no easy way to remove LwIP altogether all I can do is removing bits and pieces via configuration options.  As a reference, ESP32_GENERIC shrunk by 29152 bytes with no IPv6 support.