### PR TITLE
Add (CPython-compatible) bound method comparison and hashing

### DIFF
--- a/py/obj.h
+++ b/py/obj.h
@@ -828,6 +828,7 @@ extern const mp_obj_type_t mp_type_fun_bc;
 extern const mp_obj_type_t mp_type_module;
 extern const mp_obj_type_t mp_type_staticmethod;
 extern const mp_obj_type_t mp_type_classmethod;
+extern const mp_obj_type_t mp_type_bound_meth;
 extern const mp_obj_type_t mp_type_property;
 extern const mp_obj_type_t mp_type_stringio;
 extern const mp_obj_type_t mp_type_bytesio;

--- a/py/objboundmeth.c
+++ b/py/objboundmeth.c
@@ -83,6 +83,25 @@ STATIC mp_obj_t bound_meth_call(mp_obj_t self_in, size_t n_args, size_t n_kw, co
     return mp_call_method_self_n_kw(self->meth, self->self, n_args, n_kw, args);
 }
 
+STATIC mp_obj_t bound_meth_unary_op(mp_unary_op_t op, mp_obj_t self_in) {
+    mp_obj_bound_meth_t *self = MP_OBJ_TO_PTR(self_in);
+    switch (op) {
+        case MP_UNARY_OP_HASH:
+            return MP_OBJ_NEW_SMALL_INT((mp_uint_t)self->self ^ (mp_uint_t)self->meth);
+        default:
+            return MP_OBJ_NULL; // op not supported
+    }
+}
+
+STATIC mp_obj_t bound_meth_binary_op(mp_binary_op_t op, mp_obj_t lhs_in, mp_obj_t rhs_in) {
+    if (!mp_obj_is_type(rhs_in, &mp_type_bound_meth) || op != MP_BINARY_OP_EQUAL) {
+        return MP_OBJ_NULL; // op not supported
+    }
+    mp_obj_bound_meth_t *lhs = MP_OBJ_TO_PTR(lhs_in);
+    mp_obj_bound_meth_t *rhs = MP_OBJ_TO_PTR(rhs_in);
+    return mp_obj_new_bool(lhs->self == rhs->self && lhs->meth == rhs->meth);
+}
+
 #if MICROPY_PY_FUNCTION_ATTRS
 STATIC void bound_meth_attr(mp_obj_t self_in, qstr attr, mp_obj_t *dest) {
     if (dest[0] != MP_OBJ_NULL) {
@@ -107,13 +126,15 @@ STATIC void bound_meth_attr(mp_obj_t self_in, qstr attr, mp_obj_t *dest) {
 #define BOUND_METH_TYPE_ATTR
 #endif
 
-STATIC MP_DEFINE_CONST_OBJ_TYPE(
+MP_DEFINE_CONST_OBJ_TYPE(
     mp_type_bound_meth,
     MP_QSTR_bound_method,
     MP_TYPE_FLAG_NONE,
     BOUND_METH_TYPE_PRINT
     BOUND_METH_TYPE_ATTR
-    call, bound_meth_call
+    call, bound_meth_call,
+    unary_op, bound_meth_unary_op,
+    binary_op, bound_meth_binary_op
     );
 
 mp_obj_t mp_obj_new_bound_meth(mp_obj_t meth, mp_obj_t self) {

--- a/tests/basics/boundmeth1.py
+++ b/tests/basics/boundmeth1.py
@@ -3,13 +3,17 @@
 # uPy and CPython differ when printing a bound method, so just print the type
 print(type(repr([].append)))
 
+
 class A:
     def f(self):
         return 0
+
     def g(self, a):
         return a
+
     def h(self, a, b, c, d, e, f):
         return a + b + c + d + e + f
+
 
 # bound method with no extra args
 m = A().f
@@ -27,4 +31,36 @@ print(m(1, 2, 3, 4, 5, 6))
 try:
     A().f.x = 1
 except AttributeError:
-    print('AttributeError')
+    print("AttributeError")
+
+# bound method comparison with same object
+a = A()
+m1 = a.f
+m2 = a.f
+print(m1 == a.f)  # should result in True
+print(m2 == a.f)  # should result in True
+print(m1 == m2)  # should result in True
+print(m1 != a.f)  # should result in False
+
+# bound method comparison with different objects
+a1 = A()
+a2 = A()
+m1 = a1.f
+m2 = a2.f
+print(m1 == a2.f)  # should result in False
+print(m2 == a1.f)  # should result in False
+print(m1 != a2.f)  # should result in True
+
+# bound method hashing
+a = A()
+m1 = a.f
+m2 = a.f
+print(hash(m1) == hash(a.f))  # should result in True
+print(hash(m2) == hash(a.f))  # should result in True
+print(hash(m1) == hash(m2))  # should result in True
+print(hash(m1) != hash(a.g))  # should result in True
+
+# bound method hashing with different objects
+a2 = A()
+m2 = a2.f
+print(hash(m1) == hash(a2.f))  # should result in False

--- a/tests/basics/boundmeth1.py
+++ b/tests/basics/boundmeth1.py
@@ -3,17 +3,13 @@
 # uPy and CPython differ when printing a bound method, so just print the type
 print(type(repr([].append)))
 
-
 class A:
     def f(self):
         return 0
-
     def g(self, a):
         return a
-
     def h(self, a, b, c, d, e, f):
         return a + b + c + d + e + f
-
 
 # bound method with no extra args
 m = A().f


### PR DESCRIPTION
This PR adds support for comparing and hashing bound method references.

It incorporates code changes from @DvdGiessen along with some added tests.

This resolves issues #5233 and #12627.
```
Code size report:

   bare-arm:   +88 +0.155% 
minimal x86:  +232 +0.124% [incl +32(data)]
   unix x64:  +232 +0.029% standard[incl +32(data)]
      stm32:   +88 +0.022% PYBV10
     mimxrt:   +88 +0.024% TEENSY40
        rp2:   +88 +0.027% RPI_PICO
       samd:   +88 +0.034% ADAFRUIT_ITSYBITSY_M4_EXPRESS
```
