### PR TITLE
py/mkrules.mk: Add MICROPY_PREVIEW_VERSION_2_X.

### DIFF
--- a/.github/workflows/ports_unix.yml
+++ b/.github/workflows/ports_unix.yml
@@ -55,6 +55,18 @@ jobs:
       if: failure()
       run: tests/run-tests.py --print-failures
 
+  standard_v2:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: Build
+      run: source tools/ci.sh && ci_unix_standard_v2_build
+    - name: Run main test suite
+      run: source tools/ci.sh && ci_unix_standard_v2_run_tests
+    - name: Print failures
+      if: failure()
+      run: tests/run-tests.py --print-failures
+
   coverage:
     runs-on: ubuntu-latest
     steps:

--- a/docs/reference/index.rst
+++ b/docs/reference/index.rst
@@ -31,3 +31,4 @@ implementation and the best practices to use them.
    asm_thumb2_index.rst
    filesystem.rst
    pyboard.py.rst
+   micropython2_migration.rst

--- a/docs/reference/micropython2_migration.rst
+++ b/docs/reference/micropython2_migration.rst
@@ -1,0 +1,74 @@
+.. _micropython2_migration:
+
+MicroPython 2.0 Migration Guide
+===============================
+
+MicroPython 2.0 is the (currently in development, not yet available) next major
+release of MicroPython.
+
+After maintaining API compatibility for almost a decade with the ``1.x`` series, in
+order to unblock some project-wide improvements MicroPython 2.0 will introduce a
+small number of breaking API changes that will require some programs to be
+updated. This guide explains how to update your Python code to accommodate these
+changes.
+
+This document is a work-in-progress. As more work is done on MicroPython 2.0,
+more items will be added to the lists below.
+
+**Note:** There are currently no MicroPython 2.0 firmware builds available for
+download. You can build it yourself by enabling the ``MICROPY_PREVIEW_VERSION_2``
+config option. As it gets closer to being ready for release, builds will be
+provided for both ``1.x.y`` and ``2.0.0-preview``.
+
+Hardware and peripherals
+------------------------
+
+Overview
+~~~~~~~~
+
+The goal is to improve consistency in the :mod:`machine` APIs across different
+ports, making it easier to write code, documentation, and tutorials that work on
+any supported microcontroller.
+
+This means that some ports' APIs need to change to match other ports.
+
+Changes
+~~~~~~~
+
+*None yet*
+
+OS & filesystem
+---------------
+
+Overview
+~~~~~~~~
+
+The primary goal is to support the ability to execute :term:`.mpy files <.mpy
+file>` directly from the filesystem without first copying them into RAM. This
+improves code deployment time and reduces memory overhead and fragmentation.
+
+Additionally, a further goal is to support a more flexible way of configuring
+partitions, filesystem types, and options like USB mass storage.
+
+Changes
+~~~~~~~
+
+*None yet*
+
+CPython compatibility
+---------------------
+
+Overview
+~~~~~~~~
+
+The goal is to improve compatibility with CPython by removing MicroPython
+extensions from CPython APIs. In most cases this means moving existing
+MicroPython-specific functions or classes to new modules.
+
+This makes it easier to write code that works on both CPython and MicroPython,
+which is useful for development and testing.
+
+Changes
+~~~~~~~
+
+*None yet*

--- a/ports/esp32/Makefile
+++ b/ports/esp32/Makefile
@@ -52,6 +52,10 @@ ifdef BOARD_VARIANT
 	IDFPY_FLAGS += -D MICROPY_BOARD_VARIANT=$(BOARD_VARIANT)
 endif
 
+ifdef MICROPY_PREVIEW_VERSION_2
+	IDFPY_FLAGS += -D MICROPY_PREVIEW_VERSION_2=1
+endif
+
 HELP_BUILD_ERROR ?= "See \033[1;31mhttps://github.com/micropython/micropython/wiki/Build-Troubleshooting\033[0m"
 
 define RUN_IDF_PY

--- a/ports/rp2/Makefile
+++ b/ports/rp2/Makefile
@@ -48,6 +48,10 @@ ifdef BOARD_VARIANT
 CMAKE_ARGS += -DMICROPY_BOARD_VARIANT=$(BOARD_VARIANT)
 endif
 
+ifdef MICROPY_PREVIEW_VERSION_2
+CMAKE_ARGS += -DMICROPY_PREVIEW_VERSION_2=1
+endif
+
 HELP_BUILD_ERROR ?= "See \033[1;31mhttps://github.com/micropython/micropython/wiki/Build-Troubleshooting\033[0m"
 
 all:

--- a/py/mkrules.cmake
+++ b/py/mkrules.cmake
@@ -15,12 +15,22 @@ set(MICROPY_ROOT_POINTERS_SPLIT "${MICROPY_GENHDR_DIR}/root_pointers.split")
 set(MICROPY_ROOT_POINTERS_COLLECTED "${MICROPY_GENHDR_DIR}/root_pointers.collected")
 set(MICROPY_ROOT_POINTERS "${MICROPY_GENHDR_DIR}/root_pointers.h")
 
+if(NOT MICROPY_PREVIEW_VERSION_2)
+    set(MICROPY_PREVIEW_VERSION_2 0)
+endif()
+
 # Need to do this before extracting MICROPY_CPP_DEF below. Rest of frozen
 # manifest handling is at the end of this file.
 if(MICROPY_FROZEN_MANIFEST)
     target_compile_definitions(${MICROPY_TARGET} PUBLIC
         MICROPY_QSTR_EXTRA_POOL=mp_qstr_frozen_const_pool
         MICROPY_MODULE_FROZEN_MPY=\(1\)
+    )
+endif()
+
+if(MICROPY_PREVIEW_VERSION_2)
+    target_compile_definitions(${MICROPY_TARGET} PUBLIC
+        MICROPY_PREVIEW_VERSION_2=\(1\)
     )
 endif()
 

--- a/py/mkrules.mk
+++ b/py/mkrules.mk
@@ -4,6 +4,13 @@ THIS_MAKEFILE = $(lastword $(MAKEFILE_LIST))
 include $(dir $(THIS_MAKEFILE))mkenv.mk
 endif
 
+# Enable in-progress/breaking changes that are slated for MicroPython 2.x.
+MICROPY_PREVIEW_VERSION_2 ?= 0
+
+ifeq ($(MICROPY_PREVIEW_VERSION_2),1)
+CFLAGS += -DMICROPY_PREVIEW_VERSION_2=1
+endif
+
 HELP_BUILD_ERROR ?= "See \033[1;31mhttps://github.com/micropython/micropython/wiki/Build-Troubleshooting\033[0m"
 HELP_MPY_LIB_SUBMODULE ?= "\033[1;31mError: micropython-lib submodule is not initialized.\033[0m Run 'make submodules'"
 

--- a/py/modsys.c
+++ b/py/modsys.c
@@ -79,19 +79,26 @@ STATIC const mp_rom_obj_tuple_t mp_sys_implementation_version_info_obj = {
     }
 };
 STATIC const MP_DEFINE_STR_OBJ(mp_sys_implementation_machine_obj, MICROPY_BANNER_MACHINE);
-#if MICROPY_PERSISTENT_CODE_LOAD
-#define SYS_IMPLEMENTATION_ELEMS \
-    MP_ROM_QSTR(MP_QSTR_micropython), \
-    MP_ROM_PTR(&mp_sys_implementation_version_info_obj), \
-    MP_ROM_PTR(&mp_sys_implementation_machine_obj), \
-    MP_ROM_INT(MPY_FILE_HEADER_INT)
-#else
-#define SYS_IMPLEMENTATION_ELEMS \
+#define SYS_IMPLEMENTATION_ELEMS_BASE \
     MP_ROM_QSTR(MP_QSTR_micropython), \
     MP_ROM_PTR(&mp_sys_implementation_version_info_obj), \
     MP_ROM_PTR(&mp_sys_implementation_machine_obj)
+
+#if MICROPY_PERSISTENT_CODE_LOAD
+#define SYS_IMPLEMENTATION_ELEMS__MPY \
+    , MP_ROM_INT(MPY_FILE_HEADER_INT)
+#else
+#define SYS_IMPLEMENTATION_ELEMS__MPY
 #endif
+
 #if MICROPY_PY_ATTRTUPLE
+#if MICROPY_PREVIEW_VERSION_2
+#define SYS_IMPLEMENTATION_ELEMS__V2 \
+    , MP_ROM_TRUE
+#else
+#define SYS_IMPLEMENTATION_ELEMS__V2
+#endif
+
 STATIC const qstr impl_fields[] = {
     MP_QSTR_name,
     MP_QSTR_version,
@@ -99,19 +106,30 @@ STATIC const qstr impl_fields[] = {
     #if MICROPY_PERSISTENT_CODE_LOAD
     MP_QSTR__mpy,
     #endif
+    #if MICROPY_PREVIEW_VERSION_2
+    MP_QSTR__v2,
+    #endif
 };
 STATIC MP_DEFINE_ATTRTUPLE(
     mp_sys_implementation_obj,
     impl_fields,
-    3 + MICROPY_PERSISTENT_CODE_LOAD,
-    SYS_IMPLEMENTATION_ELEMS
+    3 + MICROPY_PERSISTENT_CODE_LOAD + MICROPY_PREVIEW_VERSION_2,
+    SYS_IMPLEMENTATION_ELEMS_BASE
+    SYS_IMPLEMENTATION_ELEMS__MPY
+    SYS_IMPLEMENTATION_ELEMS__V2
     );
 #else
 STATIC const mp_rom_obj_tuple_t mp_sys_implementation_obj = {
     {&mp_type_tuple},
     3 + MICROPY_PERSISTENT_CODE_LOAD,
+    // Do not include SYS_IMPLEMENTATION_ELEMS__V2 because
+    // SYS_IMPLEMENTATION_ELEMS__MPY may be empty if
+    // MICROPY_PERSISTENT_CODE_LOAD is disabled, which means they'll share
+    // the same index. Cannot query _v2 if MICROPY_PY_ATTRTUPLE is
+    // disabled.
     {
-        SYS_IMPLEMENTATION_ELEMS
+        SYS_IMPLEMENTATION_ELEMS_BASE
+                                SYS_IMPLEMENTATION_ELEMS__MPY
     }
 };
 #endif

--- a/py/mpconfig.h
+++ b/py/mpconfig.h
@@ -53,6 +53,12 @@
 #define MICROPY_VERSION_STRING MICROPY_VERSION_STRING_BASE
 #endif
 
+// If this is enabled, then in-progress/breaking changes slated for the 2.x
+// release will be enabled.
+#ifndef MICROPY_PREVIEW_VERSION_2
+#define MICROPY_PREVIEW_VERSION_2 (0)
+#endif
+
 // This file contains default configuration settings for MicroPython.
 // You can override any of the options below using mpconfigport.h file
 // located in a directory of your port.
@@ -1828,7 +1834,11 @@ typedef double mp_float_t;
 
 // String used for the banner, and sys.version additional information
 #ifndef MICROPY_BANNER_NAME_AND_VERSION
+#if MICROPY_PREVIEW_VERSION_2
+#define MICROPY_BANNER_NAME_AND_VERSION "MicroPython (with v2.0 preview) " MICROPY_GIT_TAG " on " MICROPY_BUILD_DATE
+#else
 #define MICROPY_BANNER_NAME_AND_VERSION "MicroPython " MICROPY_GIT_TAG " on " MICROPY_BUILD_DATE
+#endif
 #endif
 
 // String used for the second part of the banner, and sys.implementation._machine

--- a/tools/ci.sh
+++ b/tools/ci.sh
@@ -462,6 +462,15 @@ function ci_unix_standard_run_tests {
     ci_unix_run_tests_full_helper standard
 }
 
+function ci_unix_standard_v2_build {
+    ci_unix_build_helper VARIANT=standard MICROPY_PREVIEW_VERSION_2=1
+    ci_unix_build_ffi_lib_helper gcc
+}
+
+function ci_unix_standard_v2_run_tests {
+    ci_unix_run_tests_full_helper standard
+}
+
 function ci_unix_coverage_setup {
     sudo pip3 install setuptools
     sudo pip3 install pyelftools


### PR DESCRIPTION
This is a first step towards planning a "MicroPython 2.0" release.

It wasn't our goal that eventually we'd get tired of doing 1.x releases and at some point the next release would just be 2.0. Rather 2.0 should be an opportunity to re-visit some core things in MicroPython and take a once-a-decade opportunity to learn from previous decisions and change a few things to improve the usability, performance, and functionality.

A very simple example is something like the inconsistency of classes/methods/constants in the machine API (see e.g. #10607 for one that comes up a lot). At some point to fix the inconsistencies, we will need to break some ports to make them match. But this doesn't seem like something we can do in a 1.x release as we strive to ensure that existing code continues to work across minor releases.

Another simple example is changes around improving CPython compatibility, in particular removing/rehoming MicroPython-specific extensions.

A more complicated example is something like mapfs (#8381), which requires a bit of a re-think of how board initialisation and boot works, and for example might mean that we need to adjust flash offsets, which means that updating would require a full flash erase. This might be a good opportunity to also improve consistency across ports too.

Similarly something like the proposed `uevent` (#6125) which might allow us to change a few ideas about how events and IRQs work.

Anyway, the goal is not big sweeping changes that will require programs to be completely rewritten (we do not want this!), rather to identify the changes we can make that are blocking bigger improvements to the project and bundle them up into one major release. And to do this while providing an easy way to test out or work on these changes alongside the main 1.x development work.

At some point there would be a final 1.x release and the 2.x features would be considered ready, in which case this new flag gets removed and v2.0.0 gets released, along with a list of instructions for how to migrate existing code.

Branches would be simpler in (very) many ways, but also adds a lot of other complexity and overhead for the maintainers to keep them in sync. It is of course possible to raise PRs against the non-default branch. But for example, its nice to just be able to run the CI for 1.x and 2.x in the same branch (as this PR does). Also, it's not too difficult to switch to a branch model if we discover it becomes necessary.

When building with `MICROPY_PREVIEW_VERSION_2_X` enabled, the versioning (see https://github.com/orgs/micropython/discussions/12603) is unchanged, except the banner gets "(with 2.x preview)" appended before the semver. i.e. think of it as being a 1.X build, some number of commits past the tag, but with extra features enabled, rather than having a different version. This can also be access programmatically via `sys.implementation._2x` (set to `True`, or unset).

None of this is set in stone, so feedback welcome!

---

This provides a way to enable features and changes slated for MicroPython 2.x, by running `make MICROPY_PREVIEW_VERSION_2_X=1`. Also supported for the cmake ports (except Zephyr).

This is an alternative to having a 2.x development branch (or equivalently, keeping a 1.x release branch). Any feature or change that needs to be "hidden" until 2.x can use this flag (either in the Makefile or the preprocessor).

A good example is changing function arguments or other public API features, in particular to aid in improving consistency between ports.

_This work was funded through GitHub Sponsors._