### PR TITLE
rp2/CYW43: Use m_tracked_calloc and m_tracked_free for CYW43 malloc.

### DIFF
--- a/ports/rp2/boards/RPI_PICO_W/mpconfigboard.cmake
+++ b/ports/rp2/boards/RPI_PICO_W/mpconfigboard.cmake
@@ -2,9 +2,6 @@
 
 set(PICO_BOARD "pico_w")
 
-# The C malloc is needed by cyw43-driver Bluetooth
-set(MICROPY_C_HEAP_SIZE 4096)
-
 set(MICROPY_PY_LWIP ON)
 set(MICROPY_PY_NETWORK_CYW43 ON)
 

--- a/ports/rp2/cyw43_configport.h
+++ b/ports/rp2/cyw43_configport.h
@@ -90,13 +90,14 @@
 
 #define cyw43_schedule_internal_poll_dispatch(func) pendsv_schedule_dispatch(PENDSV_DISPATCH_CYW43, func)
 
-// Bluetooth uses the C heap to load its firmware (provided by pico-sdk).
-// Space is reserved for this, see MICROPY_C_HEAP_SIZE.
+// Bluetooth requires dynamic memory allocation to load its firmware (the allocation
+// call is made from pico-sdk).  This allocation is always done at thread-level, not
+// from an IRQ, so is safe to delegate to the MicroPython GC heap.
 #ifndef cyw43_malloc
-#define cyw43_malloc malloc
+#define cyw43_malloc(nmemb) m_tracked_calloc(nmemb, 1)
 #endif
 #ifndef cyw43_free
-#define cyw43_free free
+#define cyw43_free m_tracked_free
 #endif
 
 void cyw43_post_poll_hook(void);


### PR DESCRIPTION
When using malloc and free, there were stack overflow situations depending on the arm-none-eabi package version.