### PR TITLE
ci/ci_commit_formatting_run: Problem with checking older MR branch.

### DIFF
--- a/tools/ci.sh
+++ b/tools/ci.sh
@@ -44,7 +44,9 @@ function ci_code_spell_run {
 
 function ci_commit_formatting_run {
     git remote add upstream https://github.com/micropython/micropython.git
-    git fetch --depth=100 upstream  master
+    git fetch --depth=100 upstream master
+    # If the common ancestor commit hasn't been found, fetch more.
+    git merge-base upstream/master HEAD || git fetch --unshallow upstream master
     # For a PR, upstream/master..HEAD ends with a merge commit into master, exclude that one.
     tools/verifygitlog.py -v upstream/master..HEAD --no-merges
 }
@@ -68,6 +70,8 @@ function ci_code_size_build {
     git checkout -b pull_request # save the current location
     git remote add upstream https://github.com/micropython/micropython.git
     git fetch --depth=100 upstream master
+    # If the common ancestor commit hasn't been found, fetch more.
+    git merge-base upstream/master HEAD || git fetch --unshallow upstream master
     # build reference, save to size0
     # ignore any errors with this build, in case master is failing
     git checkout `git merge-base --fork-point upstream/master pull_request`


### PR DESCRIPTION
I've noticed on a couple of MR's lately that the CI commit message check is failing, even when the MR commit looks fine.

One example of this is https://github.com/micropython/micropython/actions/runs/6059530353/job/16442749613?pr=12126
This an MR with 4 commits, however the CI check is looking at a _long_ list of different commits:
![image](https://github.com/micropython/micropython/assets/3318786/753be445-3f6c-4946-8b1a-061ef9698f65)

I made this dummy MR branched from the same point as #12126  to test / examine the issue, though in testing locally I'm pretty sure I've found the problem. Assuming this initial push fails the same way, I'll push a follow up commit to check the solution.

This MR, like many other active MR's, is branched from an old enough point in master that when `ci_commit_formatting_run` runs `git fetch --depth=100 upstream master` it doesn't actually grab enough commits from upstream to find the common ancestor between the MR branch and master. 

It ends up checking _only_ master... which includes some older commits that did not pass the check.