### PR TITLE
ports/boot: Skip execution of main.py if boot.py fails.

### DIFF
--- a/ports/esp32/main.c
+++ b/ports/esp32/main.c
@@ -124,8 +124,11 @@ soft_reset:
 
     // run boot-up scripts
     pyexec_frozen_module("_boot.py", false);
-    pyexec_file_if_exists("boot.py");
-    if (pyexec_mode_kind == PYEXEC_MODE_FRIENDLY_REPL) {
+    int ret = pyexec_file_if_exists("boot.py");
+    if (ret & PYEXEC_FORCED_EXIT) {
+        goto soft_reset_exit;
+    }
+    if (pyexec_mode_kind == PYEXEC_MODE_FRIENDLY_REPL && ret != 0) {
         int ret = pyexec_file_if_exists("main.py");
         if (ret & PYEXEC_FORCED_EXIT) {
             goto soft_reset_exit;

--- a/ports/esp8266/main.c
+++ b/ports/esp8266/main.c
@@ -83,8 +83,8 @@ STATIC void mp_reset(void) {
 
     #if MICROPY_MODULE_FROZEN
     pyexec_frozen_module("_boot.py", false);
-    pyexec_file_if_exists("boot.py");
-    if (pyexec_mode_kind == PYEXEC_MODE_FRIENDLY_REPL) {
+    int ret = pyexec_file_if_exists("boot.py");
+    if (pyexec_mode_kind == PYEXEC_MODE_FRIENDLY_REPL && ret != 0) {
         pyexec_file_if_exists("main.py");
     }
     #endif

--- a/ports/nrf/main.c
+++ b/ports/nrf/main.c
@@ -263,8 +263,10 @@ soft_reset:
 
     #if MICROPY_VFS || MICROPY_MBFS || MICROPY_MODULE_FROZEN
     // run boot.py and main.py if they exist.
-    pyexec_file_if_exists("boot.py");
-    pyexec_file_if_exists("main.py");
+    ret = pyexec_file_if_exists("boot.py");
+    if (pyexec_mode_kind == PYEXEC_MODE_FRIENDLY_REPL && ret != 0) {
+        pyexec_file_if_exists("main.py");
+    }
     #endif
 
     for (;;) {

--- a/ports/rp2/main.c
+++ b/ports/rp2/main.c
@@ -179,7 +179,7 @@ int main(int argc, char **argv) {
         if (ret & PYEXEC_FORCED_EXIT) {
             goto soft_reset_exit;
         }
-        if (pyexec_mode_kind == PYEXEC_MODE_FRIENDLY_REPL) {
+        if (pyexec_mode_kind == PYEXEC_MODE_FRIENDLY_REPL && ret != 0) {
             ret = pyexec_file_if_exists("main.py");
             if (ret & PYEXEC_FORCED_EXIT) {
                 goto soft_reset_exit;


### PR DESCRIPTION
That can be caused e.g. by an exception. The feature is implemented in some way already for the STM32, Renesas, MIMXRT and SAMD. This PR adds it for the ports RP2, ESP8266, ESP32 and NRF. No change for the CC3200 and Teensy ports.