### PR TITLE
stm32/boards/ARDUINO_GIGA: Add QSPI fix/workaround to early init.

### DIFF
--- a/ports/stm32/boards/ARDUINO_GIGA/board_init.c
+++ b/ports/stm32/boards/ARDUINO_GIGA/board_init.c
@@ -35,6 +35,14 @@ void GIGA_board_startup(void) {
 void GIGA_board_early_init(void) {
     HAL_InitTick(0);
 
+    // The following pins need to be configured at this point to fix an
+    // issue with some boards that have an older QSPI flash part revision.
+    mp_hal_pin_config(pin_PD13, MP_HAL_PIN_MODE_ANALOG, MP_HAL_PIN_PULL_NONE, 0);
+    __HAL_RCC_GPIOD_CLK_DISABLE();
+
+    mp_hal_pin_config(pin_PF7, MP_HAL_PIN_MODE_ANALOG, MP_HAL_PIN_PULL_NONE, 0);
+    __HAL_RCC_GPIOF_CLK_DISABLE();
+
     #if MICROPY_HW_ENABLE_INTERNAL_FLASH_STORAGE == 1
     // The Arduino/mbed bootloader uses the MPU to protect sector 1
     // which is used for the flash filesystem. The following code


### PR DESCRIPTION
This workaround fixes an issue with some production boards that have an older QSPI flash part revision, which can't handle floating pins. Note those pins can be reconfigured and reused later.