### PR TITLE
pyproject.toml: Move python build dependencies to one location.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,54 @@
+[project]
+name = "MicroPython_tools"
+description = 'MicroPython build tools'
+version = "1.0.0"
+# dynamic = ["version"]
+readme = "README.md"
+requires-python = ">=3.7"
+license = "MIT"
+keywords = []
+authors = [
+    { name = "Damien P. George", email = "dpg@nowhere.xyz" },
+    { name = "Jos Verlinde", email = "jos_verlinde@hotmail.com" },
+]
+classifiers = [
+    "Programming Language :: Python",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3 :: Only",
+    "Programming Language :: Python :: Implementation :: MicroPython",
+]
+
+[build-system]
+requires = ["hatchling", "hatch-vcs"]
+build-backend = "hatchling.build"
+
+[tool.hatch.version]
+# source = "vcs"
+# tag-pattern = "(?P<version>v(\\d+).(\\d+).(\\d+))"
+# raw-options = { version_scheme = "python-simplified-semver" } # 1.22.1.dev1+g551360320.d20231010
+
+[project.optional-dependencies]
+docs = ["sphinx~=7.2.6", "sphinxcontrib.jquery==4.1"]
+githooks = ["pre-commit>=3.4.0"]
+# Linters
+black = ["black>=23.1.0"]
+codespell = ["codespell[toml]>=2.0.0"]
+ruff = ["ruff>=0.0.243"]
+mypy = ["mypy>=1.0.0"]
+pyright = ["pyright"]
+# nested extras requires pip >= 21.2
+lint = [
+    "MicroPython_tools[black,codespell,ruff]",
+]
+# port build requirements
+port_stm32 = ["pyhy"]                     # only for encrypted mboot support
+port_esp32 = ["esptool>=3.0.0"]
+port_esp8266 = ["esptool>=3.0.0"]
+port_nrf = ["nrfutil>=6.0.0", "intelhex"]
+# native modules
+# https://github.com/micropython/micropython/blob/9f835df35e1628974437cdf87334667a9e2ce3c5/docs/develop/natmod.rst#L187
+native = ["pyelftools>=0.25"]
+
 [tool.black]
 line-length = 99
 


### PR DESCRIPTION
Allows the maintenance of Python dependencies in a central location, the `pyproject.toml` file.

This is a draft based on the conversation in : https://github.com/micropython/micropython/pull/12503

This allows :
- Simple pinning of specific version of python tools used in the development and build process.
- Easy installation using standard package management tools 
  - `pip install .[docs,lint]`
  - `pip install .[port_nrf]`
  Tthe CI builds to use the precise same versions (if specified) 
- Depedendency management tools such as Dependabot to generate security alerts and/or propose periodic updates.
- Avoids the need to repetedly update the build instructions for the ports that need these dependencies 
- Uses the same package manager and build backend as used by mpremote, (hatch/hatchling)

todo:
 - [ ] Validate / complete added project metadata
 - [ ] Validate version scheme selected
       the current scheme uses pre-release versions, but slightly difrenet from  
 - [ ] Update port's readme.md files 
 - [ ] Update CI scripts 

Signed-off-by: Jos Verlinde <jos_verlinde@hotmail.com>

Signed-off-by: Jos Verlinde <jos_verlinde@hotmail.com>