### PR TITLE
extmod/moductypes: Validate that uctypes.struct addr argument is an int.

### DIFF
--- a/extmod/moductypes.c
+++ b/extmod/moductypes.c
@@ -96,7 +96,7 @@ STATIC NORETURN void syntax_error(void) {
 STATIC mp_obj_t uctypes_struct_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *args) {
     mp_arg_check_num(n_args, n_kw, 2, 3, false);
     mp_obj_uctypes_struct_t *o = mp_obj_malloc(mp_obj_uctypes_struct_t, type);
-    o->addr = (void *)(uintptr_t)mp_obj_int_get_truncated(args[0]);
+    o->addr = (void *)(uintptr_t)mp_obj_get_int_truncated(args[0]);
     o->desc = args[1];
     o->flags = LAYOUT_NATIVE;
     if (n_args == 3) {

--- a/tests/extmod/uctypes_error.py
+++ b/tests/extmod/uctypes_error.py
@@ -8,6 +8,12 @@ except ImportError:
 
 data = bytearray(b"01234567")
 
+# first argument isn't an integer
+try:
+    uctypes.struct(data, {})
+except TypeError:
+    print("TypeError")
+
 # del subscr not supported
 S = uctypes.struct(uctypes.addressof(data), {})
 try:

--- a/tests/extmod/uctypes_error.py.exp
+++ b/tests/extmod/uctypes_error.py.exp
@@ -3,3 +3,4 @@ TypeError
 TypeError
 TypeError
 TypeError
+TypeError


### PR DESCRIPTION
Fixes issue #12660.