### PR TITLE
io: Remove FileIO and TextIOWrapper

### DIFF
--- a/docs/library/io.rst
+++ b/docs/library/io.rst
@@ -86,16 +86,6 @@ Functions
 Classes
 -------
 
-.. class:: FileIO(...)
-
-    This is type of a file open in binary mode, e.g. using ``open(name, "rb")``.
-    You should not instantiate this class directly.
-
-.. class:: TextIOWrapper(...)
-
-    This is type of a file open in text mode, e.g. using ``open(name, "rt")``.
-    You should not instantiate this class directly.
-
 .. class:: StringIO([string])
 .. class:: BytesIO([string])
 


### PR DESCRIPTION
FileIO and TextIOWrapper were removed in https://github.com/micropython/micropython/commit/e65d1e69e88268145ff0e7e73240f028885915be. Remove them also from the docs.
