### PR TITLE
stm32: Add analog switches configuration.

### DIFF
--- a/ports/stm32/boards/ARDUINO_GIGA/mpconfigboard.h
+++ b/ports/stm32/boards/ARDUINO_GIGA/mpconfigboard.h
@@ -104,6 +104,12 @@ void GIGA_board_low_power(int mode);
 // SMPS configuration
 #define MICROPY_HW_PWR_SMPS_CONFIG      (PWR_LDO_SUPPLY)
 
+// Configure the analog switches for dual-pad pins.
+#define MICROPY_HW_ANALOG_SWITCH_PA0    (SYSCFG_SWITCH_PA0_OPEN)
+#define MICROPY_HW_ANALOG_SWITCH_PA1    (SYSCFG_SWITCH_PA1_OPEN)
+#define MICROPY_HW_ANALOG_SWITCH_PC2    (SYSCFG_SWITCH_PC2_OPEN)
+#define MICROPY_HW_ANALOG_SWITCH_PC3    (SYSCFG_SWITCH_PC3_OPEN)
+
 // There is an external 32kHz oscillator
 #define RTC_ASYNCH_PREDIV           (0)
 #define RTC_SYNCH_PREDIV            (0x7fff)

--- a/ports/stm32/boards/ARDUINO_NICLA_VISION/board_init.c
+++ b/ports/stm32/boards/ARDUINO_NICLA_VISION/board_init.c
@@ -65,11 +65,6 @@ void NICLAV_board_early_init(void) {
     }
     #endif
 
-    // Make sure PC2 and PC3 and PC2_C and PC3_C pads are connected
-    // through the analog switch for ULPI NXT and DIR pins.
-    HAL_SYSCFG_AnalogSwitchConfig(SYSCFG_SWITCH_PC2, SYSCFG_SWITCH_PC2_CLOSE);
-    HAL_SYSCFG_AnalogSwitchConfig(SYSCFG_SWITCH_PC3, SYSCFG_SWITCH_PC3_CLOSE);
-
     #if MICROPY_HW_USB_HS_ULPI3320
     // Make sure UPLI is Not in low-power mode.
     ulpi_leave_low_power();

--- a/ports/stm32/boards/ARDUINO_NICLA_VISION/mpconfigboard.h
+++ b/ports/stm32/boards/ARDUINO_NICLA_VISION/mpconfigboard.h
@@ -107,6 +107,13 @@ void NICLAV_board_osc_enable(int enable);
 // SMPS configuration
 #define MICROPY_HW_PWR_SMPS_CONFIG      (PWR_LDO_SUPPLY)
 
+// Configure the analog switches for dual-pad pins.
+#define MICROPY_HW_ANALOG_SWITCH_PA0    (SYSCFG_SWITCH_PA0_OPEN)
+#define MICROPY_HW_ANALOG_SWITCH_PA1    (SYSCFG_SWITCH_PA1_OPEN)
+// PC2_C and PC3_C, which are connected to ULPI NXT and DIR pins.
+#define MICROPY_HW_ANALOG_SWITCH_PC2    (SYSCFG_SWITCH_PC2_CLOSE)
+#define MICROPY_HW_ANALOG_SWITCH_PC3    (SYSCFG_SWITCH_PC3_CLOSE)
+
 // There is an external 32kHz oscillator
 #define RTC_ASYNCH_PREDIV           (0)
 #define RTC_SYNCH_PREDIV            (0x7fff)

--- a/ports/stm32/boards/ARDUINO_PORTENTA_H7/mpconfigboard.h
+++ b/ports/stm32/boards/ARDUINO_PORTENTA_H7/mpconfigboard.h
@@ -109,6 +109,12 @@ void PORTENTA_board_osc_enable(int enable);
 // SMPS configuration
 #define MICROPY_HW_PWR_SMPS_CONFIG      (PWR_SMPS_1V8_SUPPLIES_LDO)
 
+// Configure the analog switches for dual-pad pins.
+#define MICROPY_HW_ANALOG_SWITCH_PA0    (SYSCFG_SWITCH_PA0_OPEN)
+#define MICROPY_HW_ANALOG_SWITCH_PA1    (SYSCFG_SWITCH_PA1_OPEN)
+#define MICROPY_HW_ANALOG_SWITCH_PC2    (SYSCFG_SWITCH_PC2_OPEN)
+#define MICROPY_HW_ANALOG_SWITCH_PC3    (SYSCFG_SWITCH_PC3_OPEN)
+
 // There is an external 32kHz oscillator
 #define RTC_ASYNCH_PREDIV           (0)
 #define RTC_SYNCH_PREDIV            (0x7fff)

--- a/ports/stm32/system_stm32.c
+++ b/ports/stm32/system_stm32.c
@@ -587,6 +587,20 @@ MP_WEAK void SystemClock_Config(void) {
     // Enable the Debug Module in low-power modes.
     DBGMCU->CR |= (DBGMCU_CR_DBG_SLEEPD1 | DBGMCU_CR_DBG_STOPD1 | DBGMCU_CR_DBG_STANDBYD1);
     #endif
+
+    // Configure the analog switches
+    #ifdef MICROPY_HW_ANALOG_SWITCH_PA0
+    HAL_SYSCFG_AnalogSwitchConfig(SYSCFG_SWITCH_PA0, MICROPY_HW_ANALOG_SWITCH_PA0);
+    #endif
+    #ifdef MICROPY_HW_ANALOG_SWITCH_PA1
+    HAL_SYSCFG_AnalogSwitchConfig(SYSCFG_SWITCH_PA1, MICROPY_HW_ANALOG_SWITCH_PA1);
+    #endif
+    #ifdef MICROPY_HW_ANALOG_SWITCH_PC2
+    HAL_SYSCFG_AnalogSwitchConfig(SYSCFG_SWITCH_PC2, MICROPY_HW_ANALOG_SWITCH_PC2);
+    #endif
+    #ifdef MICROPY_HW_ANALOG_SWITCH_PC3
+    HAL_SYSCFG_AnalogSwitchConfig(SYSCFG_SWITCH_PC3, MICROPY_HW_ANALOG_SWITCH_PC3);
+    #endif
 }
 
 #endif


### PR DESCRIPTION
This PR adds support for dual-pad pins, allowing access to the extra ADC channels on the second pads (when the analog switch is open). Additionally the second commit adds new config options to configure the analog switches, this is not strictly necessary I can move them back to `board_init.c` files, but figured that eventually more boards will need to configure them.