### PR TITLE
ports/esp32/machine_sdcard.c: CLK, CMD and D0 custom pins in SD/MMC.

### DIFF
--- a/ports/esp32/machine_sdcard.c
+++ b/ports/esp32/machine_sdcard.c
@@ -298,9 +298,11 @@ STATIC mp_obj_t machine_sdcard_make_new(const mp_obj_type_t *type, size_t n_args
         // it is a good idea to set the internal pull-ups anyway.
         // slot_config.flags = SDMMC_SLOT_FLAG_INTERNAL_PULLUP;
 
+        #if CONFIG_IDF_TARGET_ESP32
         SET_CONFIG_PIN(slot_config, clk, ARG_sck);
         SET_CONFIG_PIN(slot_config, cmd, ARG_mosi);
         SET_CONFIG_PIN(slot_config, d0, ARG_miso);
+        #endif
 
         SET_CONFIG_PIN(slot_config, gpio_cd, ARG_cd);
         SET_CONFIG_PIN(slot_config, gpio_wp, ARG_wp);

--- a/ports/esp32/machine_sdcard.c
+++ b/ports/esp32/machine_sdcard.c
@@ -298,6 +298,10 @@ STATIC mp_obj_t machine_sdcard_make_new(const mp_obj_type_t *type, size_t n_args
         // it is a good idea to set the internal pull-ups anyway.
         // slot_config.flags = SDMMC_SLOT_FLAG_INTERNAL_PULLUP;
 
+        SET_CONFIG_PIN(slot_config, clk, ARG_sck);
+        SET_CONFIG_PIN(slot_config, cmd, ARG_mosi);
+        SET_CONFIG_PIN(slot_config, d0, ARG_miso);
+
         SET_CONFIG_PIN(slot_config, gpio_cd, ARG_cd);
         SET_CONFIG_PIN(slot_config, gpio_wp, ARG_wp);
 

--- a/ports/esp32/machine_sdcard.c
+++ b/ports/esp32/machine_sdcard.c
@@ -298,7 +298,7 @@ STATIC mp_obj_t machine_sdcard_make_new(const mp_obj_type_t *type, size_t n_args
         // it is a good idea to set the internal pull-ups anyway.
         // slot_config.flags = SDMMC_SLOT_FLAG_INTERNAL_PULLUP;
 
-        #if CONFIG_IDF_TARGET_ESP32
+        #if CONFIG_IDF_TARGET_ESP32S3
         SET_CONFIG_PIN(slot_config, clk, ARG_sck);
         SET_CONFIG_PIN(slot_config, cmd, ARG_mosi);
         SET_CONFIG_PIN(slot_config, d0, ARG_miso);


### PR DESCRIPTION
```
# Example to use TF Shield Expansion Module with LilyGo T-Display-S3
#
# Execute: exec(open('t_display_s3_shield.py').read())
# Format card as FAT32
# Requires my modifications to support sck, mosi and miso custom pins
# (micropython/ports/esp32/machine_sdcard.c)
#
# (c) 2023 Josep Comas

# Import libraries
import machine, os
from machine import Pin, SDCard

# Pin assignments
SD_SCLK = Pin(11)
SD_CMD  = Pin(13)
SD_D0   = Pin(12)

# Open SDCard
sd = SDCard(slot=1, width=1, cd=None, wp=None, sck=SD_SCLK, mosi=SD_CMD, miso=SD_D0)

# Get SDCard size
sd.info()

# Mount SDCard
os.mount(sd, '/sd')

# List files
os.listdir('/sd')

```