### PR TITLE
extmod/vfs_posix_file: Initialize fd to -1.

### DIFF
--- a/extmod/vfs_posix_file.c
+++ b/extmod/vfs_posix_file.c
@@ -64,6 +64,8 @@ STATIC void vfs_posix_file_print(const mp_print_t *print, mp_obj_t self_in, mp_p
 
 mp_obj_t mp_vfs_posix_file_open(const mp_obj_type_t *type, mp_obj_t file_in, mp_obj_t mode_in) {
     mp_obj_vfs_posix_file_t *o = m_new_obj_with_finaliser(mp_obj_vfs_posix_file_t);
+    o->fd = -1;  // required! Zero is a valid file descriptor.
+
     const char *mode_s = mp_obj_str_get_str(mode_in);
 
     int mode_rw = 0, mode_x = 0;


### PR DESCRIPTION
Otherwise the file descriptor is zero, which will close standard input when the garbage collector cleans up the FileIO object.

Closes #12709.