### PR TITLE
py/modthread.c: Initialise nlr_jump_callback_top on threads.

### DIFF
--- a/py/modthread.c
+++ b/py/modthread.c
@@ -174,6 +174,7 @@ STATIC void *thread_entry(void *args_in) {
     // The GC starts off unlocked on this thread.
     ts.gc_lock_depth = 0;
 
+    ts.nlr_jump_callback_top = NULL;
     ts.mp_pending_exception = MP_OBJ_NULL;
 
     // set locals and globals from the calling context

--- a/py/mpstate.h
+++ b/py/mpstate.h
@@ -249,8 +249,10 @@ typedef struct _mp_state_vm_t {
     #endif
 } mp_state_vm_t;
 
-// This structure holds state that is specific to a given thread.
-// Everything in this structure is scanned for root pointers.
+// This structure holds state that is specific to a given thread. Everything
+// in this structure is scanned for root pointers.  Anything added to this
+// structure must have corresponding initialisation added to thread_entry (in
+// py/modthread.c).
 typedef struct _mp_state_thread_t {
     // Stack top at the start of program
     char *stack_top;


### PR DESCRIPTION
This should fix #12695 -- @bhcuong2008 could you please test and see if it solves your problem?

---

The main thread gets this because the thread state is in bss, but subsequent threads need this field to be initialised.

Also added a note to mpstate.h to help avoid missing this in the future.

_This work was funded through GitHub Sponsors._