### PR TITLE
.github/workflows/ruff.yml: Pin to 0.1.0.

### DIFF
--- a/.github/workflows/ruff.yml
+++ b/.github/workflows/ruff.yml
@@ -6,5 +6,5 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
-    - run: pip install --user ruff
-    - run: ruff --format=github .
+    - run: pip install --user ruff==0.1.0
+    - run: ruff check --output-format=github .

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,6 +12,6 @@ repos:
         verbose: true
         stages: [commit-msg]
   - repo: https://github.com/charliermarsh/ruff-pre-commit
-    rev: v0.0.265
+    rev: v0.1.0
     hooks:
       - id: ruff


### PR DESCRIPTION
The `--format` flag was changed to `--output-format` in the recent update.

Pin to this version to prevent further updates from breaking (e.g. through new rules or other changes).

_This work was funded through GitHub Sponsors._