### PR TITLE
py/py.mk: Build some core C files as single compilation units.

### DIFF
--- a/py/py.mk
+++ b/py/py.mk
@@ -268,3 +268,21 @@ $(PY_BUILD)/vm.o: CFLAGS += $(CSUPEROPT)
 # http://hg.python.org/cpython/file/b127046831e2/Python/ceval.c#l828
 # http://www.emulators.com/docs/nx25_nostradamus.htm
 #-fno-crossjumping
+
+
+$(PY_BUILD)/bc.o \
+$(PY_BUILD)/gc.o \
+$(PY_BUILD)/malloc.o \
+$(PY_BUILD)/map.o \
+$(PY_BUILD)/nlr%.o \
+$(PY_BUILD)/obj.o \
+$(PY_BUILD)/objclosure.o \
+$(PY_BUILD)/objlist.o \
+$(PY_BUILD)/objmap.o \
+$(PY_BUILD)/objrange.o \
+$(PY_BUILD)/objslice.o \
+$(PY_BUILD)/qstr.o \
+$(PY_BUILD)/smallint.o \
+$(PY_BUILD)/vm.o: \
+	CFLAGS += -fno-function-sections -fno-data-sections
+


### PR DESCRIPTION
(Reviewing #12644 reminded me that I meant to try this experiment.)

## Motivation

Building some source files as single compilation units allows the compiler to do some whole-of-source-file optimizations that aren't possible with `-fgc-sections`, or to emit slightly tighter assembly (even after linker relaxations are applied.)

LTO provides very similar benefits, but is not enabled by default in most builds (and not possible at all for some ports like `esp32`).

## Method

Looking at the "Discarded input sections" of firmware.map for a build with `-fgc-sections` shows a lot of entries like this:

```
 .text          0x00000000        0x0 build-PYBV11/py/emitglue.o
 .data          0x00000000        0x0 build-PYBV11/py/emitglue.o
 .bss           0x00000000        0x0 build-PYBV11/py/emitglue.o
 .text          0x00000000        0x0 build-PYBV11/py/persistentcode.o
 .data          0x00000000        0x0 build-PYBV11/py/persistentcode.o
 .bss           0x00000000        0x0 build-PYBV11/py/persistentcode.o
 .text.mp_raw_code_load_mem
                0x00000000       0x1c build-PYBV11/py/persistentcode.o
 .text          0x00000000        0x0 build-PYBV11/py/runtime.o
 .data          0x00000000        0x0 build-PYBV11/py/runtime.o
 .bss           0x00000000        0x0 build-PYBV11/py/runtime.o
 .rodata.mp_raise_OSError_with_filename.str1.1
                0x00000000        0xe build-PYBV11/py/runtime.o
 .text.mp_raise_OSError_with_filename
                0x00000000       0x40 build-PYBV11/py/runtime.o
```

From the above you can see that all symbols from `emitglue.o` were linked to the final binary, but both `persistentcode.o` and `runtime.o` contained symbols not referenced in the final binary that could be removed by the GC linker pass.

## Code Size

PYBV11 binary size (without cache):

* 390496 on master
* 391196 (+700) if the entire `py/` directory was built without `-ffunction-sections -fdata-sections` 
* 390472 (-24) with only the changes in this PR.

## Performance

Performance of this PR versus master (cache disabled):

```
❯ ./run-perfbench.py -s pyb-run1.txt pyb-run2.txt
diff of scores (higher is better)
N=168 M=100                pyb-run1.txt -> pyb-run2.txt         diff      diff% (error%)
bm_chaos.py                    232.97 ->     237.43 :      +4.46 =  +1.914% (+/-0.02%)
bm_fannkuch.py                  48.76 ->      48.63 :      -0.13 =  -0.267% (+/-0.01%)
bm_fft.py                     1467.10 ->    1514.54 :     +47.44 =  +3.234% (+/-0.00%)
bm_float.py                   3983.10 ->    4065.98 :     +82.88 =  +2.081% (+/-0.02%)
bm_hexiom.py                    30.25 ->      31.29 :      +1.04 =  +3.438% (+/-0.00%)
bm_nqueens.py                 2847.52 ->    2840.84 :      -6.68 =  -0.235% (+/-0.00%)
bm_pidigits.py                 344.66 ->     351.33 :      +6.67 =  +1.935% (+/-0.31%)
core_import_mpy_multi.py       186.48 ->     211.61 :     +25.13 = +13.476% (+/-0.01%)
core_import_mpy_single.py       26.76 ->      30.82 :      +4.06 = +15.172% (+/-0.03%)
core_qstr.py                    19.67 ->      24.29 :      +4.62 = +23.488% (+/-0.01%)
core_yield_from.py             220.02 ->     219.72 :      -0.30 =  -0.136% (+/-0.00%)
misc_aes.py                    265.58 ->     276.24 :     +10.66 =  +4.014% (+/-0.01%)
misc_mandel.py                2073.09 ->    2085.69 :     +12.60 =  +0.608% (+/-0.01%)
misc_pystone.py               1371.56 ->    1426.80 :     +55.24 =  +4.028% (+/-0.00%)
misc_raytrace.py               248.11 ->     251.70 :      +3.59 =  +1.447% (+/-0.01%)
viper_call0.py                 339.03 ->     329.69 :      -9.34 =  -2.755% (+/-0.00%)
viper_call1a.py                330.36 ->     321.47 :      -8.89 =  -2.691% (+/-0.01%)
viper_call1b.py                253.91 ->     251.99 :      -1.92 =  -0.756% (+/-0.01%)
viper_call1c.py                255.86 ->     253.90 :      -1.96 =  -0.766% (+/-0.00%)
viper_call2a.py                325.22 ->     316.61 :      -8.61 =  -2.647% (+/-0.01%)
viper_call2b.py                222.02 ->     221.41 :      -0.61 =  -0.275% (+/-0.01%)
```

## Remaining Work

Currently this is a quick PoC based on PYBV11 only. If the approach seems worthwhile, the next step would be to identify more closely which core files are always 100% linked to the build (or linked depending on make-level options). And/or the cases where some functions can be `#ifdef`-ed out to make this true for a file.

This work was funded through GitHub Sponsors.