### PR TITLE
stm32 / spiflash: Support defining exact flash chip(s) connected. 

### DIFF
--- a/drivers/bus/qspi.h
+++ b/drivers/bus/qspi.h
@@ -39,12 +39,17 @@ enum {
     MP_QSPI_IOCTL_BUS_RELEASE,
 };
 
+enum qspi_tranfer_mode {
+    MP_QSPI_TRANSFER_CMD_ADDR_DATA,
+    MP_QSPI_TRANSFER_CMD_QADDR_QDATA,
+};
+
 typedef struct _mp_qspi_proto_t {
     int (*ioctl)(void *self, uint32_t cmd);
     int (*write_cmd_data)(void *self, uint8_t cmd, size_t len, uint32_t data);
     int (*write_cmd_addr_data)(void *self, uint8_t cmd, uint32_t addr, size_t len, const uint8_t *src);
     int (*read_cmd)(void *self, uint8_t cmd, size_t len, uint32_t *dest);
-    int (*read_cmd_qaddr_qdata)(void *self, uint8_t cmd, uint32_t addr, size_t len, uint8_t *dest);
+    int (*read_cmd_addr_data)(void *self, uint8_t cmd, uint32_t addr, size_t len, uint8_t *dest, uint8_t mode);
 } mp_qspi_proto_t;
 
 typedef struct _mp_soft_qspi_obj_t {

--- a/drivers/bus/qspi.h
+++ b/drivers/bus/qspi.h
@@ -37,6 +37,7 @@ enum {
     MP_QSPI_IOCTL_DEINIT,
     MP_QSPI_IOCTL_BUS_ACQUIRE,
     MP_QSPI_IOCTL_BUS_RELEASE,
+    MP_QSPI_IOCTL_FLASH_SIZE,
 };
 
 enum qspi_tranfer_mode {
@@ -45,7 +46,7 @@ enum qspi_tranfer_mode {
 };
 
 typedef struct _mp_qspi_proto_t {
-    int (*ioctl)(void *self, uint32_t cmd);
+    int (*ioctl)(void *self, uint32_t cmd, uint32_t arg);
     int (*write_cmd_data)(void *self, uint8_t cmd, size_t len, uint32_t data);
     int (*write_cmd_addr_data)(void *self, uint8_t cmd, uint32_t addr, size_t len, const uint8_t *src);
     int (*read_cmd)(void *self, uint8_t cmd, size_t len, uint32_t *dest);

--- a/drivers/bus/softqspi.c
+++ b/drivers/bus/softqspi.c
@@ -188,16 +188,28 @@ static int mp_soft_qspi_read_cmd(void *self_in, uint8_t cmd, size_t len, uint32_
     return 0;
 }
 
-static int mp_soft_qspi_read_cmd_qaddr_qdata(void *self_in, uint8_t cmd, uint32_t addr, size_t len, uint8_t *dest) {
+static int mp_soft_qspi_read_cmd_addr_data(void *self_in, uint8_t cmd, uint32_t addr, size_t len, uint8_t *dest, uint8_t mode) {
+    int ret = 0;
     mp_soft_qspi_obj_t *self = (mp_soft_qspi_obj_t*)self_in;
     uint8_t cmd_buf[7] = {cmd};
     uint8_t addr_len = mp_spi_set_addr_buff(&cmd_buf[1], addr);
     CS_LOW(self);
     mp_soft_qspi_transfer(self, 1, cmd_buf, NULL);
-    mp_soft_qspi_qwrite(self, addr_len + 3, &cmd_buf[1]); // 3/4 addr bytes, 1 extra byte (0), 2 dummy bytes (4 dummy cycles)
-    mp_soft_qspi_qread(self, len, dest);
+    if (mode == MP_QSPI_TRANSFER_CMD_ADDR_DATA) {
+        // cmd, address and data on 1 line.
+        // 3 addr bytes, 1 dummy byte (8 dummy cycles x 1 line)
+        mp_soft_qspi_transfer(self, addr_len + 1, &cmd_buf[1], NULL);
+        mp_soft_qspi_transfer(self, len, NULL, dest);
+    } else if (mode == MP_QSPI_TRANSFER_CMD_QADDR_QDATA) {
+        // cmd 1 line, address and data on 4 lines.
+        // 3/4 addr bytes, 1 extra byte (mode: 0), 2 dummy bytes (4 dummy cycles x 4 lines)
+        mp_soft_qspi_qwrite(self, addr_len + 3, &cmd_buf[1]);
+        mp_soft_qspi_qread(self, len, dest);
+    } else {
+        ret = -1;
+    }
     CS_HIGH(self);
-    return 0;
+    return ret;
 }
 
 const mp_qspi_proto_t mp_soft_qspi_proto = {
@@ -205,5 +217,5 @@ const mp_qspi_proto_t mp_soft_qspi_proto = {
     .write_cmd_data = mp_soft_qspi_write_cmd_data,
     .write_cmd_addr_data = mp_soft_qspi_write_cmd_addr_data,
     .read_cmd = mp_soft_qspi_read_cmd,
-    .read_cmd_qaddr_qdata = mp_soft_qspi_read_cmd_qaddr_qdata,
+    .read_cmd_addr_data = mp_soft_qspi_read_cmd_addr_data,
 };

--- a/drivers/bus/softqspi.c
+++ b/drivers/bus/softqspi.c
@@ -56,7 +56,7 @@ static void nibble_write(mp_soft_qspi_obj_t *self, uint8_t v) {
     mp_hal_pin_write(self->io3, (v >> 3) & 1);
 }
 
-static int mp_soft_qspi_ioctl(void *self_in, uint32_t cmd) {
+static int mp_soft_qspi_ioctl(void *self_in, uint32_t cmd, uint32_t arg) {
     mp_soft_qspi_obj_t *self = (mp_soft_qspi_obj_t*)self_in;
 
     switch (cmd) {

--- a/drivers/memory/external_flash_device.h
+++ b/drivers/memory/external_flash_device.h
@@ -29,11 +29,16 @@
 #include <stdbool.h>
 #include <stdint.h>
 
-typedef struct {
+typedef struct _external_flash_device {
+    // Flash size in bytes.
     uint32_t total_size;
+
     uint16_t start_up_time_us;
 
     // Three response bytes to 0x9f JEDEC ID command.
+    // The first field is always a manufacturer_id, however the other two are used
+    // differently be each manufacturer.
+    // All three together will always uniquely identify a chip model.
     uint8_t manufacturer_id;
     uint8_t memory_type;
     uint8_t capacity;
@@ -66,9 +71,12 @@ typedef struct {
     bool single_status_byte : 1;
 } external_flash_device;
 
-// Settings for the Adesto Tech AT25DF081A 1MiB SPI flash. Its on the SAMD21
-// Xplained board.
+// typedef struct _external_flash_device ;
+
+// Settings for the Adesto Tech / Renesas AT25DF081A 1MiB SPI flash.
+// Its on the SAMD21 Xplained board.
 // Datasheet: https://www.adestotech.com/wp-content/uploads/doc8715.pdf
+//            https://www.renesas.com/eu/en/document/dst/at25df081a-datasheet
 #define AT25DF081A { \
         .total_size = (1 << 20), /* 1 MiB */ \
         .start_up_time_us = 10000, \
@@ -82,6 +90,42 @@ typedef struct {
         .supports_qspi = false, \
         .supports_qspi_writes = false, \
         .write_status_register_split = false, \
+        .single_status_byte = false, \
+}
+
+// Settings for the Renesas AT25SF161B 2MiB SPI flash.
+// Datasheet: https://www.renesas.com/us/en/document/dst/at25sf161b-datasheet?r=1608796
+#define AT25SF161B { \
+        .total_size = (1 << 21), /* 2 MiB */ \
+        .start_up_time_us = 5000, \
+        .manufacturer_id = 0x1f, \
+        .memory_type = 0x86, \
+        .capacity = 0x01, \
+        .max_clock_speed_mhz = 133, \
+        .quad_enable_bit_mask = 0x02, \
+        .has_sector_protection = true, \
+        .supports_fast_read = true, \
+        .supports_qspi = true, \
+        .supports_qspi_writes = true, \
+        .write_status_register_split = true, \
+        .single_status_byte = false, \
+}
+
+// Settings for the Renesas AT25SF641B 8MiB SPI flash.
+// Datasheet: https://www.renesas.com/us/en/document/dst/at25sf641b-datasheet?r=1608816
+#define AT25SF641B { \
+        .total_size = (1 << 23), /* 8 MiB */ \
+        .start_up_time_us = 5000, \
+        .manufacturer_id = 0x1f, \
+        .memory_type = 0x88, \
+        .capacity = 0x01, \
+        .max_clock_speed_mhz = 133, \
+        .quad_enable_bit_mask = 0x02, \
+        .has_sector_protection = true, \
+        .supports_fast_read = true, \
+        .supports_qspi = true, \
+        .supports_qspi_writes = true, \
+        .write_status_register_split = true, \
         .single_status_byte = false, \
 }
 
@@ -378,6 +422,24 @@ typedef struct {
         .manufacturer_id = 0xc2, \
         .memory_type = 0x20, \
         .capacity = 0x16, \
+        .max_clock_speed_mhz = 133, \
+        .quad_enable_bit_mask = 0x40, \
+        .has_sector_protection = false, \
+        .supports_fast_read = true, \
+        .supports_qspi = true, \
+        .supports_qspi_writes = true, \
+        .write_status_register_split = false, \
+        .single_status_byte = true, \
+}
+
+// Settings for the Macronix MX25L25673G 32MiB SPI flash.
+// Datasheet: https://www.macronix.com/Lists/Datasheet/Attachments/8761/MX25L25673G,%203V,%20256Mb,%20v1.7.pdf
+#define MX25L25673G  { \
+        .total_size = (1 << 25), /* 32 MiB */ \
+        .start_up_time_us = 5000, \
+        .manufacturer_id = 0xc2, \
+        .memory_type = 0x20, \
+        .capacity = 0x19, \
         .max_clock_speed_mhz = 133, \
         .quad_enable_bit_mask = 0x40, \
         .has_sector_protection = false, \

--- a/drivers/memory/spiflash.c
+++ b/drivers/memory/spiflash.c
@@ -80,14 +80,14 @@ static external_flash_device generic_config = GENERIC;
 static void mp_spiflash_acquire_bus(mp_spiflash_t *self) {
     const mp_spiflash_config_t *c = self->config;
     if (c->bus_kind == MP_SPIFLASH_BUS_QSPI) {
-        c->bus.u_qspi.proto->ioctl(c->bus.u_qspi.data, MP_QSPI_IOCTL_BUS_ACQUIRE);
+        c->bus.u_qspi.proto->ioctl(c->bus.u_qspi.data, MP_QSPI_IOCTL_BUS_ACQUIRE, 0);
     }
 }
 
 static void mp_spiflash_release_bus(mp_spiflash_t *self) {
     const mp_spiflash_config_t *c = self->config;
     if (c->bus_kind == MP_SPIFLASH_BUS_QSPI) {
-        c->bus.u_qspi.proto->ioctl(c->bus.u_qspi.data, MP_QSPI_IOCTL_BUS_RELEASE);
+        c->bus.u_qspi.proto->ioctl(c->bus.u_qspi.data, MP_QSPI_IOCTL_BUS_RELEASE, 0);
     }
 }
 
@@ -198,7 +198,7 @@ int mp_spiflash_init(mp_spiflash_t *self) {
         mp_hal_pin_output(self->config->bus.u_spi.cs);
         self->config->bus.u_spi.proto->ioctl(self->config->bus.u_spi.data, MP_SPI_IOCTL_INIT);
     } else {
-        self->config->bus.u_qspi.proto->ioctl(self->config->bus.u_qspi.data, MP_QSPI_IOCTL_INIT);
+        self->config->bus.u_qspi.proto->ioctl(self->config->bus.u_qspi.data, MP_QSPI_IOCTL_INIT, 0);
     }
 
     mp_spiflash_acquire_bus(self);
@@ -325,6 +325,10 @@ int mp_spiflash_init(mp_spiflash_t *self) {
                 ret = -1;
             }
         }
+    }
+
+    if (self->config->bus_kind == MP_SPIFLASH_BUS_QSPI) {
+        self->config->bus.u_qspi.proto->ioctl(self->config->bus.u_qspi.data, MP_QSPI_IOCTL_FLASH_SIZE, self->device->total_size);
     }
 
     mp_spiflash_release_bus(self);

--- a/drivers/memory/spiflash.h
+++ b/drivers/memory/spiflash.h
@@ -37,6 +37,7 @@ enum {
 };
 
 struct _mp_spiflash_t;
+struct _external_flash_device;
 
 #if MICROPY_HW_SPIFLASH_ENABLE_CACHE
 // A cache must be provided by the user in the config struct.  The same cache
@@ -69,9 +70,10 @@ typedef struct _mp_spiflash_config_t {
 typedef struct _mp_spiflash_t {
     const mp_spiflash_config_t *config;
     volatile uint32_t flags;
+    const struct _external_flash_device *device;
 } mp_spiflash_t;
 
-void mp_spiflash_init(mp_spiflash_t *self);
+int mp_spiflash_init(mp_spiflash_t *self);
 void mp_spiflash_deepsleep(mp_spiflash_t *self, int value);
 
 // These functions go direct to the SPI flash device

--- a/ports/stm32/Makefile
+++ b/ports/stm32/Makefile
@@ -278,6 +278,7 @@ SRC_C += \
 	adc.c \
 	sdio.c \
 	subghz.c \
+	mpu.c \
 	$(wildcard $(BOARD_DIR)/*.c)
 
 SRC_O += \

--- a/ports/stm32/boards/PYBD_SF2/mpconfigboard.h
+++ b/ports/stm32/boards/PYBD_SF2/mpconfigboard.h
@@ -65,10 +65,10 @@ void board_sleep(int value);
 #define MICROPY_HW_RTC_USE_CALOUT   (1)
 
 // SPI flash #1, for R/W storage
+#define MICROPY_HW_SPIFLASH_DEVICES AT25SF161B
 #define MICROPY_HW_SOFTQSPI_SCK_LOW(self) (GPIOE->BSRR = (0x10000 << 11))
 #define MICROPY_HW_SOFTQSPI_SCK_HIGH(self) (GPIOE->BSRR = (1 << 11))
 #define MICROPY_HW_SOFTQSPI_NIBBLE_READ(self) ((GPIOE->IDR >> 7) & 0xf)
-#define MICROPY_HW_SPIFLASH_SIZE_BITS (16 * 1024 * 1024)
 #define MICROPY_HW_SPIFLASH_CS      (pyb_pin_QSPI1_CS)
 #define MICROPY_HW_SPIFLASH_SCK     (pyb_pin_QSPI1_CLK)
 #define MICROPY_HW_SPIFLASH_IO0     (pyb_pin_QSPI1_D0)
@@ -84,7 +84,6 @@ extern struct _spi_bdev_t spi_bdev;
 #endif
 #define MICROPY_HW_BDEV_SPIFLASH    (&spi_bdev)
 #define MICROPY_HW_BDEV_SPIFLASH_CONFIG (&spiflash_config)
-#define MICROPY_HW_BDEV_SPIFLASH_SIZE_BYTES (MICROPY_HW_SPIFLASH_SIZE_BITS / 8)
 #define MICROPY_HW_BDEV_SPIFLASH_EXTENDED (&spi_bdev) // for extended block protocol
 
 // SPI flash #2, to be memory mapped

--- a/ports/stm32/boards/STM32F769DISC/board_init.c
+++ b/ports/stm32/boards/STM32F769DISC/board_init.c
@@ -1,5 +1,6 @@
 #include "storage.h"
 #include "qspi.h"
+#include "mpconfigboard.h"
 
 // This configuration is needed for mboot to be able to write to the external QSPI flash
 
@@ -21,6 +22,6 @@ spi_bdev_t spi_bdev;
 // This init function is needed to memory map the QSPI flash early in the boot process
 
 void board_early_init(void) {
-    qspi_init();
+    qspi_init(MICROPY_HW_BDEV_SPIFLASH_SIZE_BYTES);
     qspi_memory_map();
 }

--- a/ports/stm32/main.c
+++ b/ports/stm32/main.c
@@ -185,10 +185,14 @@ MP_NOINLINE static bool init_flash_fs(uint reset_mode) {
 
     if (len != -1) {
         // Detected a littlefs filesystem so create correct block device for it
-        mp_obj_t args[] = { MP_OBJ_NEW_QSTR(MP_QSTR_len), MP_OBJ_NEW_SMALL_INT(len) };
-        bdev = MP_OBJ_TYPE_GET_SLOT(&pyb_flash_type, make_new)(&pyb_flash_type, 0, 1, args);
+        mp_obj_t lfs_bdev = pyb_flash_new_obj(0, len);
+        if (lfs_bdev == mp_const_none) {
+            // Uncaught exception; len must be an invalid length.
+            mp_printf(&mp_plat_print, "MPY: corrupted filesystem\n");
+        } else {
+            bdev = lfs_bdev;
+        }
     }
-
     #endif
 
     // Try to mount the flash on "/flash" and chdir to it for the boot-up directory.

--- a/ports/stm32/mpconfigboard_common.h
+++ b/ports/stm32/mpconfigboard_common.h
@@ -548,11 +548,9 @@
 //  - MICROPY_HW_BDEV_SPIFLASH - pointer to a spi_bdev_t
 //  - MICROPY_HW_BDEV_SPIFLASH_CONFIG - pointer to an mp_spiflash_config_t
 //  - MICROPY_HW_BDEV_SPIFLASH_SIZE_BYTES - size in bytes of the SPI flash
-#define MICROPY_HW_BDEV_IOCTL(op, arg) ( \
-    (op) == BDEV_IOCTL_NUM_BLOCKS ? (MICROPY_HW_BDEV_SPIFLASH_SIZE_BYTES / FLASH_BLOCK_SIZE) : \
-    (op) == BDEV_IOCTL_INIT ? spi_bdev_ioctl(MICROPY_HW_BDEV_SPIFLASH, (op), (uint32_t)MICROPY_HW_BDEV_SPIFLASH_CONFIG) : \
-    spi_bdev_ioctl(MICROPY_HW_BDEV_SPIFLASH, (op), (arg)) \
-    )
+// The board can specify the SPI flash chip(s) being used as comma separated list in:
+//  - MICROPY_HW_SPIFLASH_DEVICES
+#define MICROPY_HW_BDEV_IOCTL(op, arg) (spi_bdev_ioctl(MICROPY_HW_BDEV_SPIFLASH, (op), (arg)))
 #define MICROPY_HW_BDEV_READBLOCKS(dest, bl, n) spi_bdev_readblocks(MICROPY_HW_BDEV_SPIFLASH, (dest), (bl), (n))
 #define MICROPY_HW_BDEV_WRITEBLOCKS(src, bl, n) spi_bdev_writeblocks(MICROPY_HW_BDEV_SPIFLASH, (src), (bl), (n))
 #endif

--- a/ports/stm32/mpu.c
+++ b/ports/stm32/mpu.c
@@ -1,0 +1,73 @@
+/*
+ * This file is part of the MicroPython project, http://micropython.org/
+ *
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2019 Damien P. George
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#include <stdint.h>
+#include "py/mphal.h"
+#include "mpu.h"
+
+#if (defined(STM32F4) && defined(MICROPY_HW_ETH_MDC)) || defined(STM32F7) || defined(STM32H7) || defined(STM32WB)
+
+void mpu_config_region(uint32_t region, uint32_t base_addr, uint32_t attr_size) {
+    MPU->RNR = region;
+    MPU->RBAR = base_addr;
+    MPU->RASR = attr_size;
+}
+
+#elif defined(STM32H5)
+
+void mpu_config_region(uint32_t region, uint32_t base_addr, uint32_t size) {
+    if (region == MPU_REGION_ETH) {
+        // Configure region 1 to make DMA memory non-cacheable.
+
+        __DMB();
+        // Configure attribute 1, inner-outer non-cacheable (=0x44).
+        MPU->MAIR0 = (MPU->MAIR0 & ~MPU_MAIR0_Attr1_Msk)
+            | 0x44 << MPU_MAIR0_Attr1_Pos;
+        __DMB();
+
+        // RBAR
+        //  BASE          Bits [31:5] of base address
+        //  SH[4:3]  00 = Non-shareable
+        //  AP[2:1]  01 = Read/write by any privilege level
+        //  XN[0]:    1 = No execution
+
+        // RLAR
+        //  LIMIT         Limit address. Contains bits[31:5] of the upper inclusive limit of the selected MPU memory region
+        //  AT[3:1] 001 = Attribute 1
+        //  EN[0]     1 = Enabled
+        MPU->RNR = region;
+        MPU->RBAR = (base_addr & MPU_RBAR_BASE_Msk)
+            | MPU_ACCESS_NOT_SHAREABLE << MPU_RBAR_SH_Pos
+            | MPU_REGION_ALL_RW << MPU_RBAR_AP_Pos
+            | MPU_INSTRUCTION_ACCESS_DISABLE << MPU_RBAR_XN_Pos;
+        MPU->RLAR = ((base_addr + size - 1) & MPU_RLAR_LIMIT_Msk)
+            | MPU_ATTRIBUTES_NUMBER1 << MPU_RLAR_AttrIndx_Pos
+            | MPU_REGION_ENABLE << MPU_RLAR_EN_Pos;
+    }
+    __DMB();
+}
+
+#endif

--- a/ports/stm32/octospi.c
+++ b/ports/stm32/octospi.c
@@ -269,37 +269,59 @@ static int octospi_read_cmd(void *self_in, uint8_t cmd, size_t len, uint32_t *de
     return 0;
 }
 
-static int octospi_read_cmd_qaddr_qdata(void *self_in, uint8_t cmd, uint32_t addr, size_t len, uint8_t *dest) {
+static int octospi_read_cmd_addr_data(void *self_in, uint8_t cmd, uint32_t addr, size_t len, uint8_t *dest, uint8_t mode) {
+    // Note this only support use with 1 or 4 line commands.
+    // Full 8-line mode support is not included.
+    // Some commands will auto-downgrade to support 2-line mode if needed by hardware.
     (void)self_in;
 
-    #if defined(MICROPY_HW_OSPIFLASH_IO1) && !defined(MICROPY_HW_OSPIFLASH_IO2) && !defined(MICROPY_HW_OSPIFLASH_IO4)
+    uint32_t adsize = MICROPY_HW_SPI_ADDR_IS_32BIT(addr) ? 3 : 2;
+
+    uint32_t dmode = 0;
+    uint32_t admode = 0;
+    uint32_t dcyc = 0;
+    uint32_t abmode = 0;
+
+    if (mode == MP_QSPI_TRANSFER_CMD_QADDR_QDATA) {
+        dmode = 3; // 4 data lines used
+        admode = 3; // 4 address lines used
+        dcyc = 4; // 4 dummy cycles (2  bytes)
+        abmode = 3; // alternate-byte bytes sent on 4 lines
+    } else if (mode == MP_QSPI_TRANSFER_CMD_ADDR_DATA) {
+        dmode = 1; // 1 data lines used
+        admode = 1; // 1 address lines used
+        dcyc = 8; // 8 dummy cycles (1 byte)
+        abmode = 0; // No alternate-byte bytes sent
+    } else {
+        return -1;
+    }
+
+    #if !defined(MICROPY_HW_OSPIFLASH_IO2) && !defined(MICROPY_HW_OSPIFLASH_IO4)
 
     // Use 2-line address, 2-line data.
 
-    uint32_t adsize = MICROPY_HW_SPI_ADDR_IS_32BIT(addr) ? 3 : 2;
-    uint32_t dmode = 2; // data on 2-lines
-    uint32_t admode = 2; // address on 2-lines
-    uint32_t dcyc = 4; // 4 dummy cycles
+    dmode = 2; // data on 2-lines
+    admode = 2; // address on 2-lines
+    dcyc = 4; // 4 dummy cycles
 
     if (cmd == 0xeb || cmd == 0xec) {
         // Convert to 2-line command.
         cmd = MICROPY_HW_SPI_ADDR_IS_32BIT(addr) ? 0xbc : 0xbb;
     }
+    #endif
 
-    #else
+    #if !defined(MICROPY_HW_OSPIFLASH_IO1)
 
     // Fallback to use 1-line address, 1-line data.
 
-    uint32_t adsize = MICROPY_HW_SPI_ADDR_IS_32BIT(addr) ? 3 : 2;
-    uint32_t dmode = 1; // data on 1-line
-    uint32_t admode = 1; // address on 1-line
-    uint32_t dcyc = 0; // 0 dummy cycles
+    dmode = 1; // data on 1-line
+    admode = 1; // address on 1-line
+    dcyc = 0; // 0 dummy cycles
 
     if (cmd == 0xeb || cmd == 0xec) {
         // Convert to 1-line command.
         cmd = MICROPY_HW_SPI_ADDR_IS_32BIT(addr) ? 0x13 : 0x03;
     }
-
     #endif
 
     OCTOSPI1->FCR = OCTOSPI_FCR_CTCF; // clear TC flag
@@ -311,7 +333,7 @@ static int octospi_read_cmd_qaddr_qdata(void *self_in, uint8_t cmd, uint32_t add
             | 0 << OCTOSPI_CCR_SIOO_Pos // send instruction every transaction
             | dmode << OCTOSPI_CCR_DMODE_Pos // data on n lines
             | 0 << OCTOSPI_CCR_ABSIZE_Pos // 8-bit alternate byte
-            | 0 << OCTOSPI_CCR_ABMODE_Pos // no alternate byte
+            | abmode << OCTOSPI_CCR_ABMODE_Pos // alternate byte
             | adsize << OCTOSPI_CCR_ADSIZE_Pos // 32 or 24-bit address size
             | admode << OCTOSPI_CCR_ADMODE_Pos // address on n lines
             | 1 << OCTOSPI_CCR_IMODE_Pos // instruction on 1 line
@@ -357,7 +379,7 @@ const mp_qspi_proto_t octospi_proto = {
     .write_cmd_data = octospi_write_cmd_data,
     .write_cmd_addr_data = octospi_write_cmd_addr_data,
     .read_cmd = octospi_read_cmd,
-    .read_cmd_qaddr_qdata = octospi_read_cmd_qaddr_qdata,
+    .read_cmd_addr_data = octospi_read_cmd_addr_data,
 };
 
 #endif // defined(MICROPY_HW_OSPIFLASH_SIZE_BITS_LOG2)

--- a/ports/stm32/octospi.c
+++ b/ports/stm32/octospi.c
@@ -92,7 +92,7 @@ void octospi_init(void) {
     OCTOSPI1->CR |= OCTOSPI_CR_EN;
 }
 
-static int octospi_ioctl(void *self_in, uint32_t cmd) {
+static int octospi_ioctl(void *self_in, uint32_t cmd, uint32_t arg) {
     (void)self_in;
     switch (cmd) {
         case MP_QSPI_IOCTL_INIT:

--- a/ports/stm32/qspi.c
+++ b/ports/stm32/qspi.c
@@ -32,7 +32,7 @@
 #include "qspi.h"
 #include "pin_static_af.h"
 
-#if defined(MICROPY_HW_QSPIFLASH_SIZE_BITS_LOG2)
+#if MICROPY_HW_ENABLE_QSPI || defined(MICROPY_HW_QSPIFLASH_SIZE_BITS_LOG2)
 
 #define QSPI_MAP_ADDR (0x90000000)
 
@@ -52,17 +52,18 @@
 #define MICROPY_HW_QSPI_CS_HIGH_CYCLES  2  // nCS stays high for 2 cycles
 #endif
 
-#ifndef MICROPY_HW_QSPI_MPU_REGION_SIZE
-#define MICROPY_HW_QSPI_MPU_REGION_SIZE ((1 << (MICROPY_HW_QSPIFLASH_SIZE_BITS_LOG2 - 3)) >> 20)
+#ifndef MICROPY_HW_QSPIFLASH_SIZE_BITS_LOG2
 #endif
 
-#if (MICROPY_HW_QSPIFLASH_SIZE_BITS_LOG2 - 3 - 1) >= 24
-#define QSPI_CMD 0xec
-#define QSPI_ADSIZE 3
-#else
-#define QSPI_CMD 0xeb
-#define QSPI_ADSIZE 2
-#endif
+// Fast Read command in 32bit and 24bit addressing.
+#define QSPI_FAST_READ_A4_CMD 0xec
+#define QSPI_FAST_READ_A3_CMD 0xeb
+
+// this formula computes the log2 of "m"
+#define BITS_TO_LOG2(m) ((m) - 1) / (((m) - 1) % 255 + 1) / 255 % 255 * 8 + 7 - 86 / (((m) - 1) % 255 + 12)
+
+#define MBytes (1024 * 1024)
+static size_t qspi_memory_size_bytes = 0;
 
 static inline void qspi_mpu_disable_all(void) {
     // Configure MPU to disable access to entire QSPI region, to prevent CPU
@@ -71,6 +72,8 @@ static inline void qspi_mpu_disable_all(void) {
     mpu_config_region(MPU_REGION_QSPI1, QSPI_MAP_ADDR, MPU_CONFIG_NOACCESS(0x00, MPU_REGION_SIZE_256MB));
     mpu_config_end(irq_state);
 }
+
+#if 1
 
 static inline void qspi_mpu_enable_mapped(void) {
     // Configure MPU to allow access to only the valid part of external SPI flash.
@@ -83,36 +86,106 @@ static inline void qspi_mpu_enable_mapped(void) {
     // other enabled region overlaps the disabled subregion, and the access is
     // unprivileged or the background region is disabled, the MPU issues a fault.
     uint32_t irq_state = mpu_config_start();
-    #if MICROPY_HW_QSPI_MPU_REGION_SIZE > 128
-    mpu_config_region(MPU_REGION_QSPI1, QSPI_MAP_ADDR, MPU_CONFIG_NOACCESS(0xFF, MPU_REGION_SIZE_256MB));
-    #elif MICROPY_HW_QSPI_MPU_REGION_SIZE > 64
-    mpu_config_region(MPU_REGION_QSPI1, QSPI_MAP_ADDR, MPU_CONFIG_NOACCESS(0x0F, MPU_REGION_SIZE_256MB));
-    #elif MICROPY_HW_QSPI_MPU_REGION_SIZE > 32
-    mpu_config_region(MPU_REGION_QSPI1, QSPI_MAP_ADDR, MPU_CONFIG_NOACCESS(0x03, MPU_REGION_SIZE_256MB));
-    #elif MICROPY_HW_QSPI_MPU_REGION_SIZE > 16
-    mpu_config_region(MPU_REGION_QSPI1, QSPI_MAP_ADDR, MPU_CONFIG_NOACCESS(0x01, MPU_REGION_SIZE_256MB));
-    #elif MICROPY_HW_QSPI_MPU_REGION_SIZE > 8
-    mpu_config_region(MPU_REGION_QSPI1, QSPI_MAP_ADDR, MPU_CONFIG_NOACCESS(0x01, MPU_REGION_SIZE_256MB));
-    mpu_config_region(MPU_REGION_QSPI2, QSPI_MAP_ADDR, MPU_CONFIG_NOACCESS(0x0F, MPU_REGION_SIZE_32MB));
-    #elif MICROPY_HW_QSPI_MPU_REGION_SIZE > 4
-    mpu_config_region(MPU_REGION_QSPI1, QSPI_MAP_ADDR, MPU_CONFIG_NOACCESS(0x01, MPU_REGION_SIZE_256MB));
-    mpu_config_region(MPU_REGION_QSPI2, QSPI_MAP_ADDR, MPU_CONFIG_NOACCESS(0x03, MPU_REGION_SIZE_32MB));
-    #elif MICROPY_HW_QSPI_MPU_REGION_SIZE > 2
-    mpu_config_region(MPU_REGION_QSPI1, QSPI_MAP_ADDR, MPU_CONFIG_NOACCESS(0x01, MPU_REGION_SIZE_256MB));
-    mpu_config_region(MPU_REGION_QSPI2, QSPI_MAP_ADDR, MPU_CONFIG_NOACCESS(0x01, MPU_REGION_SIZE_32MB));
-    #elif MICROPY_HW_QSPI_MPU_REGION_SIZE > 1
-    mpu_config_region(MPU_REGION_QSPI1, QSPI_MAP_ADDR, MPU_CONFIG_NOACCESS(0x01, MPU_REGION_SIZE_256MB));
-    mpu_config_region(MPU_REGION_QSPI2, QSPI_MAP_ADDR, MPU_CONFIG_NOACCESS(0x0F, MPU_REGION_SIZE_32MB));
-    mpu_config_region(MPU_REGION_QSPI3, QSPI_MAP_ADDR, MPU_CONFIG_NOACCESS(0x01, MPU_REGION_SIZE_16MB));
-    #else
-    mpu_config_region(MPU_REGION_QSPI1, QSPI_MAP_ADDR, MPU_CONFIG_NOACCESS(0x01, MPU_REGION_SIZE_256MB));
-    mpu_config_region(MPU_REGION_QSPI2, QSPI_MAP_ADDR, MPU_CONFIG_NOACCESS(0x01, MPU_REGION_SIZE_32MB));
-    mpu_config_region(MPU_REGION_QSPI3, QSPI_MAP_ADDR, MPU_CONFIG_NOACCESS(0x03, MPU_REGION_SIZE_4MB));
-    #endif
+
+    if (qspi_memory_size_bytes > (128 * MBytes)) {
+        mpu_config_region(MPU_REGION_QSPI1, QSPI_MAP_ADDR, MPU_CONFIG_NOACCESS(0xFF, MPU_REGION_SIZE_256MB));
+    } else if (qspi_memory_size_bytes > (64 * MBytes)) {
+        mpu_config_region(MPU_REGION_QSPI1, QSPI_MAP_ADDR, MPU_CONFIG_NOACCESS(0x0F, MPU_REGION_SIZE_256MB));
+    } else if (qspi_memory_size_bytes > (32 * MBytes)) {
+        mpu_config_region(MPU_REGION_QSPI1, QSPI_MAP_ADDR, MPU_CONFIG_NOACCESS(0x03, MPU_REGION_SIZE_256MB));
+    } else if (qspi_memory_size_bytes > (16 * MBytes)) {
+        mpu_config_region(MPU_REGION_QSPI1, QSPI_MAP_ADDR, MPU_CONFIG_NOACCESS(0x01, MPU_REGION_SIZE_256MB));
+    } else if (qspi_memory_size_bytes > (8 * MBytes)) {
+        mpu_config_region(MPU_REGION_QSPI1, QSPI_MAP_ADDR, MPU_CONFIG_NOACCESS(0x01, MPU_REGION_SIZE_256MB));
+        mpu_config_region(MPU_REGION_QSPI2, QSPI_MAP_ADDR, MPU_CONFIG_NOACCESS(0x0F, MPU_REGION_SIZE_32MB));
+    } else if (qspi_memory_size_bytes > (4 * MBytes)) {
+        mpu_config_region(MPU_REGION_QSPI1, QSPI_MAP_ADDR, MPU_CONFIG_NOACCESS(0x01, MPU_REGION_SIZE_256MB));
+        mpu_config_region(MPU_REGION_QSPI2, QSPI_MAP_ADDR, MPU_CONFIG_NOACCESS(0x03, MPU_REGION_SIZE_32MB));
+    } else if (qspi_memory_size_bytes > (2 * MBytes)) {
+        mpu_config_region(MPU_REGION_QSPI1, QSPI_MAP_ADDR, MPU_CONFIG_NOACCESS(0x01, MPU_REGION_SIZE_256MB));
+        mpu_config_region(MPU_REGION_QSPI2, QSPI_MAP_ADDR, MPU_CONFIG_NOACCESS(0x01, MPU_REGION_SIZE_32MB));
+    } else if (qspi_memory_size_bytes > (1 * MBytes)) {
+        mpu_config_region(MPU_REGION_QSPI1, QSPI_MAP_ADDR, MPU_CONFIG_NOACCESS(0x01, MPU_REGION_SIZE_256MB));
+        mpu_config_region(MPU_REGION_QSPI2, QSPI_MAP_ADDR, MPU_CONFIG_NOACCESS(0x0F, MPU_REGION_SIZE_32MB));
+        mpu_config_region(MPU_REGION_QSPI3, QSPI_MAP_ADDR, MPU_CONFIG_NOACCESS(0x01, MPU_REGION_SIZE_16MB));
+    } else {
+        mpu_config_region(MPU_REGION_QSPI1, QSPI_MAP_ADDR, MPU_CONFIG_NOACCESS(0x01, MPU_REGION_SIZE_256MB));
+        mpu_config_region(MPU_REGION_QSPI2, QSPI_MAP_ADDR, MPU_CONFIG_NOACCESS(0x01, MPU_REGION_SIZE_32MB));
+        mpu_config_region(MPU_REGION_QSPI3, QSPI_MAP_ADDR, MPU_CONFIG_NOACCESS(0x03, MPU_REGION_SIZE_4MB));
+    }
     mpu_config_end(irq_state);
 }
 
-void qspi_init(void) {
+#else
+
+// This variant of the function is harder to read, but 76 bytes smaller.
+
+static inline void qspi_mpu_enable_mapped(void) {
+    // Configure MPU to allow access to only the valid part of external SPI flash.
+    // The memory accesses to the mapped QSPI are faster if the MPU is not used
+    // for the memory-mapped region, so 3 MPU regions are used to disable access
+    // to everything except the valid address space, using holes in the bottom
+    // of the regions and nesting them.
+    // Note: Disabling a subregion (by setting its corresponding SRD bit to 1)
+    // means another region overlapping the disabled range matches instead.  If no
+    // other enabled region overlaps the disabled subregion, and the access is
+    // unprivileged or the background region is disabled, the MPU issues a fault.
+    uint32_t irq_state = mpu_config_start();
+
+    static const uint8_t region_definitions[][7] = {
+        // Each row per MB region total size, specifying region srd and size for MPU_REGION_QSPI1, 2 and 3.
+        {128, 0xFF, MPU_REGION_SIZE_256MB, 0, 0, 0, 0},
+        { 64, 0x0F, MPU_REGION_SIZE_256MB, 0, 0, 0, 0},
+        { 32, 0x03, MPU_REGION_SIZE_256MB, 0, 0, 0, 0},
+        { 16, 0x01, MPU_REGION_SIZE_256MB, 0, 0, 0, 0},
+        {  8, 0x01, MPU_REGION_SIZE_256MB,
+           0x0F, MPU_REGION_SIZE_32MB, 0, 0},
+        {  4, 0x01, MPU_REGION_SIZE_256MB,
+           0x03, MPU_REGION_SIZE_32MB, 0, 0},
+        {  2, 0x01, MPU_REGION_SIZE_256MB,
+           0x01, MPU_REGION_SIZE_32MB, 0, 0},
+        {  1, 0x01, MPU_REGION_SIZE_256MB,
+           0x0F, MPU_REGION_SIZE_32MB,
+           0x01, MPU_REGION_SIZE_16MB},
+        {  0, 0x01, MPU_REGION_SIZE_256MB,
+           0x01, MPU_REGION_SIZE_32MB,
+           0x03, MPU_REGION_SIZE_4MB},
+    };
+    size_t qspi_memory_size_mbytes = qspi_memory_size_bytes / 1024 / 1024;
+
+    for (uint8_t i = 0; i < 9; ++i) {
+        if (qspi_memory_size_mbytes > region_definitions[i][0]) {
+            uint32_t attr_size_1 = MPU_CONFIG_NOACCESS(region_definitions[i][1], region_definitions[i][2]);
+            mpu_config_region(MPU_REGION_QSPI1, QSPI_MAP_ADDR, attr_size_1);
+            if (region_definitions[i][3] > 0) {
+                uint32_t attr_size_2 = MPU_CONFIG_NOACCESS(region_definitions[i][3], region_definitions[i][4]);
+                mpu_config_region(MPU_REGION_QSPI2, QSPI_MAP_ADDR, attr_size_2);
+            }
+            if (region_definitions[i][5] > 0) {
+                uint32_t attr_size_3 = MPU_CONFIG_NOACCESS(region_definitions[i][5], region_definitions[i][6]);
+                mpu_config_region(MPU_REGION_QSPI3, QSPI_MAP_ADDR, attr_size_3);
+            }
+            break;
+        }
+    }
+    mpu_config_end(irq_state);
+}
+
+#endif
+
+void qspi_set_memory_size(size_t memory_size_bytes) {
+    qspi_memory_size_bytes = memory_size_bytes;
+    size_t QSPIFLASH_SIZE_BITS_LOG2 = BITS_TO_LOG2(qspi_memory_size_bytes * 8);
+    QUADSPI->DCR =
+        (QSPIFLASH_SIZE_BITS_LOG2 - 3 - 1) << QUADSPI_DCR_FSIZE_Pos
+            | (MICROPY_HW_QSPI_CS_HIGH_CYCLES - 1) << QUADSPI_DCR_CSHT_Pos
+            | 0 << QUADSPI_DCR_CKMODE_Pos // CLK idles at low state
+    ;
+}
+
+void qspi_init(size_t memory_size_bytes) {
+    qspi_memory_size_bytes = memory_size_bytes;
+
     qspi_mpu_disable_all();
 
     // Configure pins
@@ -143,15 +216,20 @@ void qspi_init(void) {
             | 1 << QUADSPI_CR_EN_Pos // enable the peripheral
     ;
 
-    QUADSPI->DCR =
-        (MICROPY_HW_QSPIFLASH_SIZE_BITS_LOG2 - 3 - 1) << QUADSPI_DCR_FSIZE_Pos
-            | (MICROPY_HW_QSPI_CS_HIGH_CYCLES - 1) << QUADSPI_DCR_CSHT_Pos
-            | 0 << QUADSPI_DCR_CKMODE_Pos // CLK idles at low state
-    ;
+    if (qspi_memory_size_bytes) {
+        qspi_set_memory_size(qspi_memory_size_bytes);
+    }
 }
 
-void qspi_memory_map(void) {
+void qspi_memory_map() {
     // Enable memory-mapped mode
+    uint8_t cmd = QSPI_FAST_READ_A3_CMD;
+    uint8_t adsize = 2;
+    if (qspi_memory_size_bytes > (16 * MBytes)) {
+        // Flash chips over 16MB require 32bit addressing.
+        cmd = QSPI_FAST_READ_A4_CMD;
+        adsize = 3;
+    }
 
     QUADSPI->ABR = 0; // disable continuous read mode
 
@@ -163,20 +241,20 @@ void qspi_memory_map(void) {
             | 4 << QUADSPI_CCR_DCYC_Pos // 4 dummy cycles
             | 0 << QUADSPI_CCR_ABSIZE_Pos // 8-bit alternate byte
             | 3 << QUADSPI_CCR_ABMODE_Pos // alternate byte on 4 lines
-            | QSPI_ADSIZE << QUADSPI_CCR_ADSIZE_Pos
+            | adsize << QUADSPI_CCR_ADSIZE_Pos
             | 3 << QUADSPI_CCR_ADMODE_Pos // address on 4 lines
             | 1 << QUADSPI_CCR_IMODE_Pos // instruction on 1 line
-            | QSPI_CMD << QUADSPI_CCR_INSTRUCTION_Pos
+            | cmd << QUADSPI_CCR_INSTRUCTION_Pos
     ;
 
     qspi_mpu_enable_mapped();
 }
 
-static int qspi_ioctl(void *self_in, uint32_t cmd) {
+static int qspi_ioctl(void *self_in, uint32_t cmd, uint32_t arg) {
     (void)self_in;
     switch (cmd) {
         case MP_QSPI_IOCTL_INIT:
-            qspi_init();
+            qspi_init(0);
             break;
         case MP_QSPI_IOCTL_BUS_ACQUIRE:
             // Disable memory-mapped region during bus access
@@ -192,6 +270,11 @@ static int qspi_ioctl(void *self_in, uint32_t cmd) {
             // Switch to memory-map mode when bus is idle
             qspi_memory_map();
             break;
+        case MP_QSPI_IOCTL_FLASH_SIZE:
+            if (arg > 0) {
+                qspi_set_memory_size(arg);
+            }
+            return qspi_memory_size_bytes;
     }
     return 0; // success
 }

--- a/ports/stm32/qspi.h
+++ b/ports/stm32/qspi.h
@@ -30,7 +30,7 @@
 
 extern const mp_qspi_proto_t qspi_proto;
 
-void qspi_init(void);
+void qspi_init(size_t memory_size_bytes);
 void qspi_memory_map(void);
 
 #endif // MICROPY_INCLUDED_STM32_QSPI_H

--- a/ports/stm32/storage.c
+++ b/ports/stm32/storage.c
@@ -48,11 +48,11 @@ static void storage_systick_callback(uint32_t ticks_ms);
 
 void storage_init(void) {
     if (!storage_is_initialised) {
-        storage_is_initialised = true;
-
         systick_enable_dispatch(SYSTICK_DISPATCH_STORAGE, storage_systick_callback);
 
-        MICROPY_HW_BDEV_IOCTL(BDEV_IOCTL_INIT, 0);
+        if (MICROPY_HW_BDEV_IOCTL(BDEV_IOCTL_INIT, 0) == 0) {
+            storage_is_initialised = true;
+        }
 
         #if defined(MICROPY_HW_BDEV2_IOCTL)
         MICROPY_HW_BDEV2_IOCTL(BDEV_IOCTL_INIT, 0);

--- a/ports/stm32/storage.c
+++ b/ports/stm32/storage.c
@@ -273,6 +273,30 @@ const pyb_flash_obj_t pyb_flash_obj = {
     0, // actual size handled in ioctl, MP_BLOCKDEV_IOCTL_BLOCK_COUNT case
 };
 
+mp_obj_t pyb_flash_new_obj(mp_int_t start, mp_int_t len) {
+
+    uint32_t bl_len = (storage_get_block_count() - FLASH_PART1_START_BLOCK) * FLASH_BLOCK_SIZE;
+
+    if (start == -1) {
+        start = 0;
+    } else if (!(0 <= start && start < bl_len && start % MICROPY_HW_BDEV_BLOCKSIZE_EXT == 0)) {
+        return mp_const_none;
+    }
+
+    if (len == -1) {
+        len = bl_len - start;
+    } else if (!(0 < len && start + len <= bl_len && len % MICROPY_HW_BDEV_BLOCKSIZE_EXT == 0)) {
+        return mp_const_none;
+    }
+
+    pyb_flash_obj_t *self = mp_obj_malloc(pyb_flash_obj_t, &pyb_flash_type);
+    self->use_native_block_size = false;
+    self->start = start;
+    self->len = len;
+
+    return MP_OBJ_FROM_PTR(self);
+}
+
 static void pyb_flash_print(const mp_print_t *print, mp_obj_t self_in, mp_print_kind_t kind) {
     pyb_flash_obj_t *self = MP_OBJ_TO_PTR(self_in);
     if (self == &pyb_flash_obj) {
@@ -296,30 +320,15 @@ static mp_obj_t pyb_flash_make_new(const mp_obj_type_t *type, size_t n_args, siz
         // Default singleton object that accesses entire flash, including virtual partition table
         return MP_OBJ_FROM_PTR(&pyb_flash_obj);
     }
-
-    pyb_flash_obj_t *self = mp_obj_malloc(pyb_flash_obj_t, &pyb_flash_type);
-    self->use_native_block_size = false;
-
-    uint32_t bl_len = (storage_get_block_count() - FLASH_PART1_START_BLOCK) * FLASH_BLOCK_SIZE;
-
     mp_int_t start = args[ARG_start].u_int;
-    if (start == -1) {
-        start = 0;
-    } else if (!(0 <= start && start < bl_len && start % MICROPY_HW_BDEV_BLOCKSIZE_EXT == 0)) {
-        mp_raise_ValueError(NULL);
-    }
-
     mp_int_t len = args[ARG_len].u_int;
-    if (len == -1) {
-        len = bl_len - start;
-    } else if (!(0 < len && start + len <= bl_len && len % MICROPY_HW_BDEV_BLOCKSIZE_EXT == 0)) {
+
+    mp_obj_t self = pyb_flash_new_obj(start, len);
+    if (self == mp_const_none) {
+        // Invalid start or end arg
         mp_raise_ValueError(NULL);
     }
-
-    self->start = start;
-    self->len = len;
-
-    return MP_OBJ_FROM_PTR(self);
+    return self;
 }
 
 static mp_obj_t pyb_flash_readblocks(size_t n_args, const mp_obj_t *args) {

--- a/ports/stm32/storage.h
+++ b/ports/stm32/storage.h
@@ -77,4 +77,8 @@ extern const struct _pyb_flash_obj_t pyb_flash_obj;
 struct _fs_user_mount_t;
 void pyb_flash_init_vfs(struct _fs_user_mount_t *vfs);
 
+#if !BUILDING_MBOOT
+mp_obj_t pyb_flash_new_obj(mp_int_t start, mp_int_t len);
+#endif
+
 #endif // MICROPY_INCLUDED_STM32_STORAGE_H


### PR DESCRIPTION
Different spiflash brands / models can require slightly different settings to use. 
This PR allows a board profile to declare the model spiflash being used directly.

It's re-using a header of spiflash definitions already available in `drivers/memory/external_flash_device.h`, however new ones could be added inline in mpconfigboard.h if needed.

This started as an additional commit in https://github.com/micropython/micropython/pull/12512 and also provides functionality first presented in https://github.com/micropython/micropython/pull/11932