### PR TITLE
ports/esp32: Poll serial/JTAG for unread data to prevent blocking.

### DIFF
--- a/ports/esp32/mphalport.c
+++ b/ports/esp32/mphalport.c
@@ -100,6 +100,9 @@ void check_esp_err_(esp_err_t code, const char *func, const int line, const char
 
 uintptr_t mp_hal_stdio_poll(uintptr_t poll_flags) {
     uintptr_t ret = 0;
+    #if CONFIG_ESP_CONSOLE_USB_SERIAL_JTAG
+    usb_serial_jtag_poll_rx();
+    #endif
     if ((poll_flags & MP_STREAM_POLL_RD) && stdin_ringbuf.iget != stdin_ringbuf.iput) {
         ret |= MP_STREAM_POLL_RD;
     }
@@ -111,6 +114,9 @@ uintptr_t mp_hal_stdio_poll(uintptr_t poll_flags) {
 
 int mp_hal_stdin_rx_chr(void) {
     for (;;) {
+        #if CONFIG_ESP_CONSOLE_USB_SERIAL_JTAG
+        usb_serial_jtag_poll_rx();
+        #endif
         int c = ringbuf_get(&stdin_ringbuf);
         if (c != -1) {
             return c;

--- a/ports/esp32/usb_serial_jtag.c
+++ b/ports/esp32/usb_serial_jtag.c
@@ -33,11 +33,38 @@
 #include "hal/usb_serial_jtag_ll.h"
 #include "esp_intr_alloc.h"
 #include "soc/periph_defs.h"
+#include "freertos/portmacro.h"
 
 #define USB_SERIAL_JTAG_BUF_SIZE (64)
 
+static DRAM_ATTR portMUX_TYPE rx_mux = portMUX_INITIALIZER_UNLOCKED;
 static uint8_t rx_buf[USB_SERIAL_JTAG_BUF_SIZE];
 static volatile bool terminal_connected = false;
+
+static void usb_serial_jtag_handle_rx(void) {
+    if (xPortInIsrContext()) {
+        portENTER_CRITICAL_ISR(&rx_mux);
+    } else {
+        portENTER_CRITICAL(&rx_mux);
+    }
+    size_t req_len = ringbuf_free(&stdin_ringbuf);
+    if (req_len > USB_SERIAL_JTAG_BUF_SIZE) {
+        req_len = USB_SERIAL_JTAG_BUF_SIZE;
+    }
+    size_t len = usb_serial_jtag_ll_read_rxfifo(rx_buf, req_len);
+    for (size_t i = 0; i < len; ++i) {
+        if (rx_buf[i] == mp_interrupt_char) {
+            mp_sched_keyboard_interrupt();
+        } else {
+            ringbuf_put(&stdin_ringbuf, rx_buf[i]);
+        }
+    }
+    if (xPortInIsrContext()) {
+        portEXIT_CRITICAL_ISR(&rx_mux);
+    } else {
+        portEXIT_CRITICAL(&rx_mux);
+    }
+}
 
 static void usb_serial_jtag_isr_handler(void *arg) {
     uint32_t flags = usb_serial_jtag_ll_get_intsts_mask();
@@ -48,18 +75,7 @@ static void usb_serial_jtag_isr_handler(void *arg) {
 
     if (flags & USB_SERIAL_JTAG_INTR_SERIAL_OUT_RECV_PKT) {
         usb_serial_jtag_ll_clr_intsts_mask(USB_SERIAL_JTAG_INTR_SERIAL_OUT_RECV_PKT);
-        size_t req_len = ringbuf_free(&stdin_ringbuf);
-        if (req_len > USB_SERIAL_JTAG_BUF_SIZE) {
-            req_len = USB_SERIAL_JTAG_BUF_SIZE;
-        }
-        size_t len = usb_serial_jtag_ll_read_rxfifo(rx_buf, req_len);
-        for (size_t i = 0; i < len; ++i) {
-            if (rx_buf[i] == mp_interrupt_char) {
-                mp_sched_keyboard_interrupt();
-            } else {
-                ringbuf_put(&stdin_ringbuf, rx_buf[i]);
-            }
-        }
+        usb_serial_jtag_handle_rx();
         mp_hal_wake_main_task_from_isr();
     }
 }
@@ -71,6 +87,12 @@ void usb_serial_jtag_init(void) {
         USB_SERIAL_JTAG_INTR_SOF);
     ESP_ERROR_CHECK(esp_intr_alloc(ETS_USB_SERIAL_JTAG_INTR_SOURCE, ESP_INTR_FLAG_LEVEL1,
         usb_serial_jtag_isr_handler, NULL, NULL));
+}
+
+void usb_serial_jtag_poll_rx(void) {
+    if (usb_serial_jtag_ll_rxfifo_data_available() && ringbuf_free(&stdin_ringbuf)) {
+        usb_serial_jtag_handle_rx();
+    }
 }
 
 void usb_serial_jtag_tx_strn(const char *str, size_t len) {

--- a/ports/esp32/usb_serial_jtag.h
+++ b/ports/esp32/usb_serial_jtag.h
@@ -27,6 +27,7 @@
 #define MICROPY_INCLUDED_ESP32_USB_SERIAL_JTAG_H
 
 void usb_serial_jtag_init(void);
+void usb_serial_jtag_poll_rx(void);
 void usb_serial_jtag_tx_strn(const char *str, size_t len);
 
 #endif // MICROPY_INCLUDED_ESP32_USB_SERIAL_JTAG_H


### PR DESCRIPTION
If data is pushed over serial/JTAG too fast we may fill up stdin_ringbuf and not be able to read all the data out of the serial/JTAG buffer. Thus we need to explicitly poll and read the serial/JTAG RX buffer to prevent blocking (since if the serial/JTAG buffer is already filled, we will not get another interrupt to transfer it to the stdin ringbuffer).

This fixed pasting large amounts of text over the serial/JTAG console for me.

EDIT: Reworked based on feedback; previous iteration is [here](https://github.com/micropython/micropython/commit/79521ca5c0b28b2fa5fba581c6efc24c9e08f087).