### PR TITLE
esp32/network_ppp: Reduce PPP thread CPU usage.

### DIFF
--- a/ports/esp32/network_ppp.c
+++ b/ports/esp32/network_ppp.c
@@ -108,9 +108,10 @@ static void pppos_client_task(void *self_in) {
     ppp_if_obj_t *self = (ppp_if_obj_t *)self_in;
     uint8_t buf[256];
 
-    while (ulTaskNotifyTake(pdTRUE, 0) == 0) {
+    int len = 0;
+    while (ulTaskNotifyTake(pdTRUE, len <= 0) == 0) {
         int err;
-        int len = mp_stream_rw(self->stream, buf, sizeof(buf), &err, 0);
+        len = mp_stream_rw(self->stream, buf, sizeof(buf), &err, 0);
         if (len > 0) {
             pppos_input_tcpip(self->pcb, (u8_t *)buf, len);
         }


### PR DESCRIPTION
Reduces the CPU usage by the PPP thread by sleeping for one tick if there was nothing to read; preventing the loop using 100% CPU when the read operation has a zero timeout and immediately returns.