### PR TITLE
esp32/mbedtls: Disable ALPN support.

### DIFF
--- a/ports/esp32/boards/sdkconfig.base
+++ b/ports/esp32/boards/sdkconfig.base
@@ -51,6 +51,9 @@ CONFIG_LWIP_PPP_CHAP_SUPPORT=y
 # Use 4kiB output buffer instead of default 16kiB
 CONFIG_MBEDTLS_ASYMMETRIC_CONTENT_LEN=y
 
+# Disable ALPN support as it's not implemented in MicroPython
+CONFIG_MBEDTLS_SSL_ALPN=n
+
 # Allow mbedTLS to allocate from PSRAM or internal memory
 #
 # (The ESP-IDF default is internal-only, partly for physical security to prevent


### PR DESCRIPTION
I originally made this commit to work around an obscure issue with ALPN-enabled TLS servers. I sadly don't have the reproduction for that specific issue anymore, but the change still makes sense: It saves ~980 bytes of space by not building ALPN-support in mbedtls, which isn't useful anyway since we expose no methods in MicroPython for setting ALPN parameters.