### PR TITLE
Correcting SAMD QSPI baud calculation.

### DIFF
--- a/ports/samd/samd_qspiflash.c
+++ b/ports/samd/samd_qspiflash.c
@@ -238,7 +238,7 @@ static void wait_for_flash_ready(void) {
 }
 
 static uint8_t get_baud(int32_t freq_mhz) {
-    int baud = get_peripheral_freq() / (freq_mhz * 1000000) - 1;
+    int baud = get_cpu_freq() / (freq_mhz * 1000000) - 1;
     if (baud < 1) {
         baud = 1;
     }


### PR DESCRIPTION
The QSPI baud is derived from AHB clock, not from APB clock.
Datasheet: The QSPI Baud rate clock is generated by dividing the module clock (CLK_QSPI_AHB) by a value between 1 and 255.

As previously implemented, all baud rates are 2.5 times (120/48) greater than set.