### PR TITLE
mimxrt: Change the UART pin assignment of the OLIMEX RT1010 board.

### DIFF
--- a/docs/mimxrt/pinout.rst
+++ b/docs/mimxrt/pinout.rst
@@ -28,7 +28,7 @@ MIMXRT1060-EVK     Debug USB      D0/D1        D7/D6        D8/D9
 MIMXRT1064-EVK     Debug USB      D0/D1        D7/D6        D8/D9
 MIMXRT1170-EVK     Debug USB      D0/D1       D12/D11      D10/D13
 Adafruit Metro M7     -           D0/D1        D7/D3        A1/A0
-Olimex RT1010Py       -          RxD/TxD       D5/D6           -
+Olimex RT1010Py       -          RxD/TxD       D7/D8        D5/D6
 Seeed ARCH MIX        -         J3_19/J3_20  J4_16/J4_17  J4_06/J4_07
 =================  ===========  ===========  ===========  ===========
 

--- a/ports/mimxrt/boards/OLIMEX_RT1010/mpconfigboard.h
+++ b/ports/mimxrt/boards/OLIMEX_RT1010/mpconfigboard.h
@@ -18,18 +18,18 @@
 // LPUART4 on D5/D6    -> 2
 
 #define MICROPY_HW_UART_NUM     (sizeof(uart_index_table) / sizeof(uart_index_table)[0])
-#define MICROPY_HW_UART_INDEX   { 0, 1, 4 }
+#define MICROPY_HW_UART_INDEX   { 0, 1, 3, 4 }
 
 #define IOMUX_TABLE_UART \
     { IOMUXC_GPIO_10_LPUART1_TXD }, { IOMUXC_GPIO_09_LPUART1_RXD }, \
     { 0 }, { 0 }, \
-    { 0 }, { 0 }, \
+    { IOMUXC_GPIO_08_LPUART3_TXD }, { IOMUXC_GPIO_07_LPUART3_RXD }, \
     { IOMUXC_GPIO_06_LPUART4_TXD }, { IOMUXC_GPIO_05_LPUART4_RXD },
 
 #define IOMUX_TABLE_UART_CTS_RTS \
     { IOMUXC_GPIO_08_LPUART1_CTS_B }, { IOMUXC_GPIO_07_LPUART1_RTS_B }, \
     { 0 }, { 0 }, \
-    { 0 }, { 0 }, \
+    { IOMUXC_GPIO_AD_14_LPUART3_CTS_B }, { IOMUXC_GPIO_AD_13_LPUART3_RTS_B }, \
     { IOMUXC_GPIO_AD_14_LPUART4_CTS_B }, { IOMUXC_GPIO_AD_13_LPUART4_RTS_B },
 
 #define MICROPY_HW_SPI_INDEX { 0, 1, 2 }


### PR DESCRIPTION
Enabling UART at the UEXT1 connector of the base board and adding another UART.
