### PR TITLE
ports/rp2/boards/W5100S_EVB_PICO/mpconfigboard.cmake: Set default mode to HardWired

### DIFF
--- a/ports/rp2/boards/W5100S_EVB_PICO/mpconfigboard.cmake
+++ b/ports/rp2/boards/W5100S_EVB_PICO/mpconfigboard.cmake
@@ -1,5 +1,5 @@
 # cmake file for Wiznet W5100S-EVB-Pico.
 set(PICO_BOARD wiznet_w5100s_evb_pico)
 set(MICROPY_PY_NETWORK_WIZNET5K W5100S)
-set(MICROPY_PY_LWIP 1)
+set(MICROPY_PY_LWIP 0)
 set(MICROPY_FROZEN_MANIFEST ${MICROPY_BOARD_DIR}/manifest.py)

--- a/ports/rp2/boards/W5500_EVB_PICO/mpconfigboard.cmake
+++ b/ports/rp2/boards/W5500_EVB_PICO/mpconfigboard.cmake
@@ -1,5 +1,5 @@
 # cmake file for Wiznet W5500-EVB-Pico.
 set(PICO_BOARD wiznet_w5100s_evb_pico)
 set(MICROPY_PY_NETWORK_WIZNET5K W5500)
-set(MICROPY_PY_LWIP 1)
+set(MICROPY_PY_LWIP 0)
 set(MICROPY_FROZEN_MANIFEST ${MICROPY_BOARD_DIR}/manifest.py)


### PR DESCRIPTION
The W5100S and W5500 modules are optimized for hard-wired settings.

So, I suggest to set the default mode to Hard wired (='LwIP 0')
Based on performance tests conducted with iperf3,
it was found that the bitrate of the device in hard-wired mode is 74% higher than the LwIP. 
(LWIP: 747 kbits/sec, Hardwired: 1.34Mbits/sec)

Therefore, to enhance the default network speed and performance for users. 
Please refer to the following post for speed measurement using iperf3: https://vo.la/nFDNF

Signed-off-by: scarlet lee <scarlet@wiznet.io>
