### PR TITLE
ports/stm32h5: add sleep modes and RTC alarm wakeup 

### DIFF
--- a/ports/stm32/modmachine.c
+++ b/ports/stm32/modmachine.c
@@ -108,6 +108,12 @@ void machine_init(void) {
         reset_cause = PYB_RESET_DEEPSLEEP;
         PWR->CR1 |= PWR_CR1_CSBF;
     } else
+    #elif defined(STM32H5)
+    if (PWR->PMSR & PWR_PMSR_STOPF || PWR->PMSR & PWR_PMSR_SBF) {
+        // came out of standby or stop mode
+        reset_cause = PYB_RESET_DEEPSLEEP;
+        PWR->PMCR |= PWR_PMCR_CSSF;
+    } else
     #elif defined(STM32H7)
     if (PWR->CPUCR & PWR_CPUCR_SBF || PWR->CPUCR & PWR_CPUCR_STOPF) {
         // came out of standby or stop mode

--- a/ports/stm32/powerctrl.c
+++ b/ports/stm32/powerctrl.c
@@ -48,6 +48,8 @@
 #define POWERCTRL_GET_VOLTAGE_SCALING() PWR_REGULATOR_VOLTAGE_SCALE0
 #elif defined(STM32H723xx)
 #define POWERCTRL_GET_VOLTAGE_SCALING() LL_PWR_GetRegulVoltageScaling()
+#elif defined(STM32H5)
+#define POWERCTRL_GET_VOLTAGE_SCALING() LL_PWR_GetRegulVoltageScaling()
 #else
 #define POWERCTRL_GET_VOLTAGE_SCALING()     \
     (((PWR->CSR1 & PWR_CSR1_ACTVOS) && (SYSCFG->PWRCR & SYSCFG_PWRCR_ODEN)) ? \
@@ -797,6 +799,14 @@ void powerctrl_enter_stop_mode(void) {
     HAL_PWREx_EnableFlashPowerDown();
     #endif
 
+    #if defined(STM32H5)
+    // Save RCC CR to re-enable OSCs and PLLs after wake up from low power mode.
+    uint32_t rcc_cr = RCC->CR;
+
+    // Save the current voltage scaling level to restore after exiting low power mode.
+    uint32_t vscaling = POWERCTRL_GET_VOLTAGE_SCALING();
+    #endif
+
     #if defined(STM32H7)
     // Save RCC CR to re-enable OSCs and PLLs after wake up from low power mode.
     uint32_t rcc_cr = RCC->CR;
@@ -837,9 +847,9 @@ void powerctrl_enter_stop_mode(void) {
     while (__HAL_RCC_GET_SYSCLK_SOURCE() != RCC_CFGR_SWS_HSI48) {
     }
 
-    #else
+    #else // defined(STM32F0)
 
-    #if defined(STM32H7)
+    #if defined(STM32H5) || defined(STM32H7)
     // When exiting from Stop or Standby modes, the Run mode voltage scaling is reset to
     // the default VOS3 value. Restore the voltage scaling to the previous voltage scale.
     if (vscaling != POWERCTRL_GET_VOLTAGE_SCALING()) {
@@ -879,7 +889,7 @@ void powerctrl_enter_stop_mode(void) {
     while (LL_RCC_GetSysClkSource() != LL_RCC_SYS_CLKSOURCE_STATUS_PLL1) {
     }
 
-    #else
+    #else // defined(STM32H5)
 
     // enable PLL
     __HAL_RCC_PLL_ENABLE();
@@ -899,7 +909,7 @@ void powerctrl_enter_stop_mode(void) {
     }
     #endif
 
-    #endif
+    #endif // defined(STM32H5)
 
     powerctrl_disable_hsi_if_unused();
 
@@ -908,6 +918,15 @@ void powerctrl_enter_stop_mode(void) {
         // Enable PLLSAI if it is selected as 48MHz source
         RCC->CR |= RCC_CR_PLL48_ON;
         while (!(RCC->CR & RCC_CR_PLL48_RDY)) {
+        }
+    }
+    #endif
+
+    #if defined(STM32H5)
+    if (rcc_cr & RCC_CR_HSI48ON) {
+        // Enable HSI48.
+        LL_RCC_HSI48_Enable();
+        while (!LL_RCC_HSI48_IsReady()) {
         }
     }
     #endif

--- a/ports/stm32/powerctrlboot.c
+++ b/ports/stm32/powerctrlboot.c
@@ -298,6 +298,10 @@ void SystemClock_Config(void) {
     LL_RCC_SetUSBClockSource(LL_RCC_USB_CLKSOURCE_PLL3Q);
 
     #endif
+
+    #ifdef NDEBUG
+    DBGMCU->CR = 0;
+    #endif
 }
 
 #elif defined(STM32L0)

--- a/ports/stm32/rtc.c
+++ b/ports/stm32/rtc.c
@@ -756,9 +756,11 @@ mp_obj_t pyb_rtc_wakeup(size_t n_args, const mp_obj_t *args) {
         RTC->WPR = 0xff;
 
         // enable external interrupts on line EXTI_RTC_WAKEUP
-        #if defined(STM32G0) || defined(STM32G4) || defined(STM32H5) || defined(STM32L4) || defined(STM32WB) || defined(STM32WL)
+        #if defined(STM32G0) || defined(STM32G4) || defined(STM32L4) || defined(STM32WB) || defined(STM32WL)
         EXTI->IMR1 |= 1 << EXTI_RTC_WAKEUP;
         EXTI->RTSR1 |= 1 << EXTI_RTC_WAKEUP;
+        #elif defined(STM32H5)
+        EXTI->IMR1 |= 1 << EXTI_RTC_WAKEUP;
         #elif defined(STM32H7)
         EXTI_D1->IMR1 |= 1 << EXTI_RTC_WAKEUP;
         EXTI->RTSR1 |= 1 << EXTI_RTC_WAKEUP;
@@ -768,8 +770,10 @@ mp_obj_t pyb_rtc_wakeup(size_t n_args, const mp_obj_t *args) {
         #endif
 
         // clear interrupt flags
-        #if defined(STM32G0) || defined(STM32G4) || defined(STM32H5) || defined(STM32WL)
+        #if defined(STM32G0) || defined(STM32G4) || defined(STM32WL)
         RTC->ICSR &= ~RTC_ICSR_WUTWF;
+        #elif defined(STM32H5)
+        RTC->SCR = RTC_SCR_CWUTF;
         #elif defined(STM32H7A3xx) || defined(STM32H7A3xxQ) || defined(STM32H7B3xx) || defined(STM32H7B3xxQ)
         RTC->SR &= ~RTC_SR_WUTF;
         #else


### PR DESCRIPTION
This PR adds support for machine.lightsleep() and machine.deepsleep() for STM32H5. Wakeup is possible via RTC.alarm(). machine.reset_cause() reports the proper code when waking up from on of those.


```python
r = RTC()
r.wakeup(5_000)
machine.deepsleep()

# System goes to sleep for 5 secs

# Wakes up via reset, all state is lost
MicroPython v1.20.0-288-g3a153d92f-dirty on 2023-10-21; NUCLEO_H563ZI with STM32H563ZI
Type "help()" for more information.

machine.reset_cause()
4
machine.DEEPSLEEP_RESET
4
```

```python
i = 1
r = RTC()
r.wakeup(5_000)
machine.lightsleep()

# System goes to sleep for 5 secs

# Wakes up from Stop mode, state is retained

machine.reset_cause()
4
i
1
```

This PR fixes #12697 
