### PR TITLE
extmod/modssl_mbedtls: Implement SSLSession support.

### DIFF
--- a/docs/library/ssl.rst
+++ b/docs/library/ssl.rst
@@ -13,7 +13,7 @@ facilities for network sockets, both client-side and server-side.
 Functions
 ---------
 
-.. function:: ssl.wrap_socket(sock, server_side=False, key=None, cert=None, cert_reqs=CERT_NONE, cadata=None, server_hostname=None, do_handshake=True)
+.. function:: ssl.wrap_socket(sock, server_side=False, key=None, cert=None, cert_reqs=CERT_NONE, cadata=None, server_hostname=None, do_handshake=True, session=None)
 
     Wrap the given *sock* and return a new wrapped-socket object.  The implementation
     of this function is to first create an `SSLContext` and then call the `SSLContext.wrap_socket`
@@ -27,6 +27,9 @@ Functions
 
    - *cadata* is a bytes object containing the CA certificate chain (in DER format) that will
      validate the peer's certificate.  Currently only a single DER-encoded certificate is supported.
+
+   - *session* allows a client socket to reuse a session by passing a SSLSession object
+     previously retrieved from the ``session`` property of a wrapped-socket object.
 
    Depending on the underlying module implementation in a particular
    :term:`MicroPython port`, some or all keyword arguments above may be not supported.
@@ -91,7 +94,7 @@ class SSLContext
    be used, so keys can be computed or fetched on demand.  As with the client,
    the context is restricted to PSK cipher suites while this is set.
 
-.. method:: SSLContext.wrap_socket(sock, *, server_side=False, do_handshake_on_connect=True, server_hostname=None, client_id=None)
+.. method:: SSLContext.wrap_socket(sock, *, server_side=False, do_handshake_on_connect=True, server_hostname=None, client_id=None, session=None)
 
    Takes a `stream` *sock* (usually socket.socket instance of ``SOCK_STREAM`` type),
    and returns an instance of ssl.SSLSocket, wrapping the underlying stream.
@@ -117,6 +120,9 @@ class SSLContext
    - *client_id* is a MicroPython-specific extension argument used only when implementing a DTLS
      Server. See :ref:`dtls` for details.
 
+   - *session* allows a client socket to reuse a session by passing a SSLSession object
+     previously retrieved from the ``session`` property of a ssl.SSLSocket object.
+
 .. warning::
 
    Some implementations of ``ssl`` module do NOT validate server certificates,
@@ -137,6 +143,19 @@ class SSLContext
    ``ssl.CERT_REQUIRED`` requires the device's date/time to be properly set, e.g. using
    `mpremote rtc --set <mpremote_command_rtc>` or ``ntptime``, and ``server_hostname``
    must be specified when on the client side.
+
+class SSLSession
+----------------
+
+.. class:: SSLSession(buf)
+
+    This constructor is a MicroPython extension to reconstruct a SSLSession object using
+    a bytes object previously returned by the ``serialize`` method.
+
+.. method:: SSLSession.serialize()
+
+   This function is a MicroPython extension to return a bytes object representing the
+   session, allowing it to be stored and reconstructed at a later time.
 
 Exceptions
 ----------

--- a/docs/library/ssl.rst
+++ b/docs/library/ssl.rst
@@ -13,7 +13,7 @@ facilities for network sockets, both client-side and server-side.
 Functions
 ---------
 
-.. function:: ssl.wrap_socket(sock, server_side=False, key=None, cert=None, cert_reqs=CERT_NONE, cadata=None, server_hostname=None, do_handshake=True)
+.. function:: ssl.wrap_socket(sock, server_side=False, key=None, cert=None, cert_reqs=CERT_NONE, cadata=None, server_hostname=None, do_handshake=True, session=None)
 
     Wrap the given *sock* and return a new wrapped-socket object.  The implementation
     of this function is to first create an `SSLContext` and then call the `SSLContext.wrap_socket`
@@ -28,6 +28,9 @@ Functions
    - *cadata* is a str or bytes object containing the CA certificate chain that will validate the
      peer's certificate.  It can be one or more certificates in PEM format, or single DER-encoded
      certificate.
+
+   - *session* allows a client socket to reuse a session by passing a SSLSession object
+     previously retrieved from the ``session`` property of a wrapped-socket object.
 
    Depending on the underlying module implementation in a particular
    :term:`MicroPython port`, some or all keyword arguments above may be not supported.
@@ -92,7 +95,7 @@ class SSLContext
    be used, so keys can be computed or fetched on demand.  As with the client,
    the context is restricted to PSK cipher suites while this is set.
 
-.. method:: SSLContext.wrap_socket(sock, *, server_side=False, do_handshake_on_connect=True, server_hostname=None, client_id=None)
+.. method:: SSLContext.wrap_socket(sock, *, server_side=False, do_handshake_on_connect=True, server_hostname=None, client_id=None, session=None)
 
    Takes a `stream` *sock* (usually socket.socket instance of ``SOCK_STREAM`` type),
    and returns an instance of ssl.SSLSocket, wrapping the underlying stream.
@@ -118,6 +121,9 @@ class SSLContext
    - *client_id* is a MicroPython-specific extension argument used only when implementing a DTLS
      Server. See :ref:`dtls` for details.
 
+   - *session* allows a client socket to reuse a session by passing a SSLSession object
+     previously retrieved from the ``session`` property of a ssl.SSLSocket object.
+
 .. warning::
 
    Some implementations of ``ssl`` module do NOT validate server certificates,
@@ -138,6 +144,19 @@ class SSLContext
    ``ssl.CERT_REQUIRED`` requires the device's date/time to be properly set, e.g. using
    `mpremote rtc --set <mpremote_command_rtc>` or ``ntptime``, and ``server_hostname``
    must be specified when on the client side.
+
+class SSLSession
+----------------
+
+.. class:: SSLSession(buf)
+
+    This constructor is a MicroPython extension to reconstruct a SSLSession object using
+    a bytes object previously returned by the ``serialize`` method.
+
+.. method:: SSLSession.serialize()
+
+   This function is a MicroPython extension to return a bytes object representing the
+   session, allowing it to be stored and reconstructed at a later time.
 
 Exceptions
 ----------

--- a/extmod/modtls_mbedtls.c
+++ b/extmod/modtls_mbedtls.c
@@ -67,6 +67,14 @@
 #include "mbedtls/ssl_cookie.h"
 #endif
 
+#if defined(MBEDTLS_CONFIG_FILE)
+#include MBEDTLS_CONFIG_FILE
+#endif
+
+#if defined(MBEDTLS_SSL_SESSION_TICKETS) && defined(MBEDTLS_SSL_TICKET_C)
+#include "mbedtls/ssl_ticket.h"
+#endif
+
 #ifndef MICROPY_MBEDTLS_CONFIG_BARE_METAL
 #define MICROPY_MBEDTLS_CONFIG_BARE_METAL (0)
 #endif
@@ -90,6 +98,9 @@ typedef struct _mp_obj_ssl_context_t {
     mbedtls_x509_crt cacert;
     mbedtls_x509_crt cert;
     mbedtls_pk_context pkey;
+    #if defined(MBEDTLS_SSL_SESSION_TICKETS) && defined(MBEDTLS_SSL_TICKET_C)
+    mbedtls_ssl_ticket_context ticket;
+    #endif
     int authmode;
     int *ciphersuites;
     mp_obj_t handler;
@@ -354,6 +365,9 @@ static mp_obj_t ssl_context_make_new(const mp_obj_type_t *type_in, size_t n_args
     mbedtls_x509_crt_init(&self->cacert);
     mbedtls_x509_crt_init(&self->cert);
     mbedtls_pk_init(&self->pkey);
+    #if defined(MBEDTLS_SSL_SESSION_TICKETS) && defined(MBEDTLS_SSL_TICKET_C)
+    mbedtls_ssl_ticket_init(&self->ticket);
+    #endif
     self->ciphersuites = NULL;
     self->handler = mp_const_none;
     #if MICROPY_PY_SSL_ECDSA_SIGN_ALT
@@ -412,6 +426,14 @@ static mp_obj_t ssl_context_make_new(const mp_obj_type_t *type_in, size_t n_args
             &self->cookie_ctx);
     }
     #endif // MBEDTLS_SSL_DTLS_HELLO_VERIFY
+
+    #if defined(MBEDTLS_SSL_SESSION_TICKETS) && defined(MBEDTLS_SSL_TICKET_C)
+    ret = mbedtls_ssl_ticket_setup(&self->ticket, mbedtls_ctr_drbg_random, &self->ctr_drbg, MBEDTLS_CIPHER_AES_256_GCM, 86400);
+    if (ret != 0) {
+        mbedtls_raise_error(ret);
+    }
+    mbedtls_ssl_conf_session_tickets_cb(&self->conf, mbedtls_ssl_ticket_write, mbedtls_ssl_ticket_parse, &self->ticket);
+    #endif
 
     return MP_OBJ_FROM_PTR(self);
 }
@@ -483,6 +505,9 @@ static void ssl_context_attr(mp_obj_t self_in, qstr attr, mp_obj_t *dest) {
 #if MICROPY_PY_SSL_FINALISER
 static mp_obj_t ssl_context___del__(mp_obj_t self_in) {
     mp_obj_ssl_context_t *self = MP_OBJ_TO_PTR(self_in);
+    #if defined(MBEDTLS_SSL_SESSION_TICKETS) && defined(MBEDTLS_SSL_TICKET_C)
+    mbedtls_ssl_ticket_free(&self->ticket);
+    #endif
     mbedtls_pk_free(&self->pkey);
     mbedtls_x509_crt_free(&self->cert);
     mbedtls_x509_crt_free(&self->cacert);

--- a/extmod/modtls_mbedtls.c
+++ b/extmod/modtls_mbedtls.c
@@ -107,6 +107,12 @@ typedef struct _mp_obj_ssl_context_t {
     #endif
 } mp_obj_ssl_context_t;
 
+// This corresponds to an SSLSession object.
+typedef struct _mp_obj_ssl_session_t {
+    mp_obj_base_t base;
+    mbedtls_ssl_session session;
+} mp_obj_ssl_session_t;
+
 // This corresponds to an SSLSocket object.
 typedef struct _mp_obj_ssl_socket_t {
     mp_obj_base_t base;
@@ -124,6 +130,7 @@ typedef struct _mp_obj_ssl_socket_t {
     #endif
 } mp_obj_ssl_socket_t;
 
+static const mp_obj_type_t ssl_session_type;
 static const mp_obj_type_t ssl_context_type;
 static const mp_obj_type_t ssl_socket_type;
 
@@ -131,7 +138,7 @@ static const MP_DEFINE_STR_OBJ(mbedtls_version_obj, MBEDTLS_VERSION_STRING_FULL)
 
 static mp_obj_t ssl_socket_make_new(mp_obj_ssl_context_t *ssl_context, mp_obj_t sock,
     bool server_side, bool do_handshake_on_connect, mp_obj_t server_hostname,
-    mp_obj_t client_id);
+    mp_obj_t client_id, mp_obj_t ssl_session);
 
 /******************************************************************************/
 // Helper functions.
@@ -266,6 +273,60 @@ static int ssl_sock_cert_verify(void *ptr, mbedtls_x509_crt *crt, int depth, uin
     mp_obj_memoryview_init(&cert, 'B', 0, crt->raw.len, crt->raw.p);
     return mp_obj_get_int(mp_call_function_2(o->handler, MP_OBJ_FROM_PTR(&cert), MP_OBJ_NEW_SMALL_INT(depth)));
 }
+
+/******************************************************************************/
+// SSLSession type.
+
+static mp_obj_t ssl_session_make_new(const mp_obj_type_t *type_in, size_t n_args, size_t n_kw, const mp_obj_t *args) {
+    mp_arg_check_num(n_args, n_kw, 1, 1, false);
+
+    mp_buffer_info_t bufinfo;
+    mp_get_buffer_raise(args[0], &bufinfo, MP_BUFFER_READ);
+
+    mp_obj_ssl_session_t *self = m_new_obj(mp_obj_ssl_session_t);
+    self->base.type = type_in;
+
+    mbedtls_ssl_session_init(&self->session);
+    int ret = mbedtls_ssl_session_load(&self->session, bufinfo.buf, bufinfo.len);
+    if (ret != 0) {
+        mbedtls_raise_error(ret);
+    }
+
+    return MP_OBJ_FROM_PTR(self);
+}
+
+static mp_obj_t ssl_session_serialize(mp_obj_t self_in) {
+    mp_obj_ssl_session_t *self = MP_OBJ_TO_PTR(self_in);
+    size_t len;
+    vstr_t vstr;
+    mbedtls_ssl_session_save(&self->session, NULL, 0, &len);
+    vstr_init_len(&vstr, len);
+    mbedtls_ssl_session_save(&self->session, (unsigned char *)vstr.buf, len, &len);
+    return mp_obj_new_bytes_from_vstr(&vstr);
+}
+static MP_DEFINE_CONST_FUN_OBJ_1(ssl_session_serialize_obj, ssl_session_serialize);
+
+static mp_int_t ssl_session_get_buffer(mp_obj_t self_in, mp_buffer_info_t *bufinfo, mp_uint_t flags) {
+    if (flags != MP_BUFFER_READ) {
+        return 1;
+    }
+    mp_get_buffer_raise(ssl_session_serialize(self_in), bufinfo, flags);
+    return 0;
+}
+
+static const mp_rom_map_elem_t ssl_session_locals_dict_table[] = {
+    { MP_ROM_QSTR(MP_QSTR_serialize), MP_ROM_PTR(&ssl_session_serialize_obj) },
+};
+static MP_DEFINE_CONST_DICT(ssl_session_locals_dict, ssl_session_locals_dict_table);
+
+static MP_DEFINE_CONST_OBJ_TYPE(
+    ssl_session_type,
+    MP_QSTR_SSLSession,
+    MP_TYPE_FLAG_NONE,
+    make_new, ssl_session_make_new,
+    buffer, ssl_session_get_buffer,
+    locals_dict, &ssl_session_locals_dict
+    );
 
 /******************************************************************************/
 // SSLContext type.
@@ -624,7 +685,7 @@ static int ssl_context_psk_server_callback(void *p_ctx, mbedtls_ssl_context *ssl
 #endif
 
 static mp_obj_t ssl_context_wrap_socket(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
-    enum { ARG_server_side, ARG_do_handshake_on_connect, ARG_server_hostname, ARG_client_id };
+    enum { ARG_server_side, ARG_do_handshake_on_connect, ARG_server_hostname, ARG_client_id, ARG_session };
     static const mp_arg_t allowed_args[] = {
         { MP_QSTR_server_side, MP_ARG_KW_ONLY | MP_ARG_BOOL, {.u_bool = false} },
         { MP_QSTR_do_handshake_on_connect, MP_ARG_KW_ONLY | MP_ARG_BOOL, {.u_bool = true} },
@@ -632,6 +693,7 @@ static mp_obj_t ssl_context_wrap_socket(size_t n_args, const mp_obj_t *pos_args,
         #ifdef MBEDTLS_SSL_DTLS_HELLO_VERIFY
         { MP_QSTR_client_id, MP_ARG_KW_ONLY | MP_ARG_OBJ, {.u_rom_obj = MP_ROM_NONE} },
         #endif
+        { MP_QSTR_session, MP_ARG_KW_ONLY | MP_ARG_OBJ, {.u_rom_obj = MP_ROM_NONE} },
     };
 
     // Parse arguments.
@@ -647,7 +709,7 @@ static mp_obj_t ssl_context_wrap_socket(size_t n_args, const mp_obj_t *pos_args,
 
     // Create and return the new SSLSocket object.
     return ssl_socket_make_new(self, sock, args[ARG_server_side].u_bool,
-        args[ARG_do_handshake_on_connect].u_bool, args[ARG_server_hostname].u_obj, client_id);
+        args[ARG_do_handshake_on_connect].u_bool, args[ARG_server_hostname].u_obj, client_id, args[ARG_session].u_obj);
 }
 static MP_DEFINE_CONST_FUN_OBJ_KW(ssl_context_wrap_socket_obj, 2, ssl_context_wrap_socket);
 
@@ -744,7 +806,7 @@ static int _mbedtls_timing_get_delay(void *ctx) {
 #endif
 
 static mp_obj_t ssl_socket_make_new(mp_obj_ssl_context_t *ssl_context, mp_obj_t sock,
-    bool server_side, bool do_handshake_on_connect, mp_obj_t server_hostname, mp_obj_t client_id) {
+    bool server_side, bool do_handshake_on_connect, mp_obj_t server_hostname, mp_obj_t client_id, mp_obj_t ssl_session) {
 
     // Store the current SSL context.
     store_active_context(ssl_context);
@@ -793,6 +855,14 @@ static mp_obj_t ssl_socket_make_new(mp_obj_ssl_context_t *ssl_context, mp_obj_t 
         o->sock = MP_OBJ_NULL;
         mbedtls_ssl_free(&o->ssl);
         mp_raise_ValueError(MP_ERROR_TEXT("CERT_REQUIRED requires server_hostname"));
+    }
+
+    if (ssl_session != mp_const_none) {
+        mp_obj_ssl_session_t *session = MP_OBJ_TO_PTR(ssl_session);
+        ret = mbedtls_ssl_set_session(&o->ssl, &session->session);
+        if (ret != 0) {
+            goto cleanup;
+        }
     }
 
     #ifdef MBEDTLS_SSL_PROTO_DTLS
@@ -1026,6 +1096,36 @@ static mp_uint_t socket_ioctl(mp_obj_t o_in, mp_uint_t request, uintptr_t arg, i
     return ret;
 }
 
+static void ssl_socket_attr(mp_obj_t self_in, qstr attr, mp_obj_t *dest) {
+    mp_obj_ssl_socket_t *self = MP_OBJ_TO_PTR(self_in);
+    if (dest[0] == MP_OBJ_NULL) {
+        // Load attribute.
+        if (attr == MP_QSTR_session) {
+            mp_obj_ssl_session_t *o = m_new_obj(mp_obj_ssl_session_t);
+            o->base.type = &ssl_session_type;
+            mbedtls_ssl_session_init(&o->session);
+            int ret = mbedtls_ssl_get_session(&self->ssl, &o->session);
+            if (ret != 0) {
+                mbedtls_raise_error(ret);
+            }
+            dest[0] = MP_OBJ_FROM_PTR(o);
+        } else {
+            // Continue lookup in locals_dict.
+            dest[1] = MP_OBJ_SENTINEL;
+        }
+    } else if (dest[1] != MP_OBJ_NULL) {
+        // Store attribute.
+        if (attr == MP_QSTR_session) {
+            mp_obj_ssl_session_t *ssl_session = MP_OBJ_TO_PTR(dest[1]);
+            dest[0] = MP_OBJ_NULL;
+            int ret = mbedtls_ssl_set_session(&self->ssl, &ssl_session->session);
+            if (ret != 0) {
+                mbedtls_raise_error(ret);
+            }
+        }
+    }
+}
+
 static const mp_rom_map_elem_t ssl_socket_locals_dict_table[] = {
     { MP_ROM_QSTR(MP_QSTR_read), MP_ROM_PTR(&mp_stream_read_obj) },
     { MP_ROM_QSTR(MP_QSTR_readinto), MP_ROM_PTR(&mp_stream_readinto_obj) },
@@ -1063,6 +1163,7 @@ static MP_DEFINE_CONST_OBJ_TYPE(
     MP_QSTR_SSLSocket,
     MP_TYPE_FLAG_NONE,
     protocol, &ssl_socket_stream_p,
+    attr, ssl_socket_attr,
     locals_dict, &ssl_socket_locals_dict
     );
 
@@ -1125,6 +1226,7 @@ static const mp_rom_map_elem_t mp_module_tls_globals_table[] = {
 
     // Classes.
     { MP_ROM_QSTR(MP_QSTR_SSLContext), MP_ROM_PTR(&ssl_context_type) },
+    { MP_ROM_QSTR(MP_QSTR_SSLSession), MP_ROM_PTR(&ssl_session_type) },
 
     // Constants.
     { MP_ROM_QSTR(MP_QSTR_MBEDTLS_VERSION), MP_ROM_PTR(&mbedtls_version_obj)},

--- a/ports/unix/mbedtls/mbedtls_config_port.h
+++ b/ports/unix/mbedtls/mbedtls_config_port.h
@@ -28,8 +28,11 @@
 
 // Set mbedtls configuration
 #define MBEDTLS_CIPHER_MODE_CTR // needed for MICROPY_PY_CRYPTOLIB_CTR
+#define MBEDTLS_SSL_SESSION_TICKETS
 
 // Enable mbedtls modules
+#define MBEDTLS_GCM_C
+#define MBEDTLS_SSL_TICKET_C
 #define MBEDTLS_TIMING_C
 
 #if defined(MICROPY_UNIX_COVERAGE)

--- a/tests/multi_net/sslcontext_server_client_session.py
+++ b/tests/multi_net/sslcontext_server_client_session.py
@@ -1,0 +1,131 @@
+# Test creating an SSL connection with certificates as bytes objects.
+
+try:
+    from io import IOBase
+    import os
+    import socket
+    import ssl
+except ImportError:
+    print("SKIP")
+    raise SystemExit
+
+if not hasattr(ssl, "SSLSession"):
+    print("SKIP")
+    raise SystemExit
+
+PORT = 8000
+
+# These are test certificates. See tests/README.md for details.
+certfile = "ec_cert.der"
+keyfile = "ec_key.der"
+
+try:
+    os.stat(certfile)
+    os.stat(keyfile)
+except OSError:
+    print("SKIP")
+    raise SystemExit
+
+with open(certfile, "rb") as cf:
+    cert = cadata = cf.read()
+
+with open(keyfile, "rb") as kf:
+    key = kf.read()
+
+
+# Helper class to count number of bytes going over a TCP socket
+class CountingStream(IOBase):
+    def __init__(self, stream):
+        self.stream = stream
+        self.count = 0
+
+    def readinto(self, buf, nbytes=None):
+        result = self.stream.readinto(buf) if nbytes is None else self.stream.readinto(buf, nbytes)
+        self.count += result
+        return result
+
+    def write(self, buf):
+        self.count += len(buf)
+        return self.stream.write(buf)
+
+    def ioctl(self, req, arg):
+        if hasattr(self.stream, "ioctl"):
+            return self.stream.ioctl(req, arg)
+        return 0
+
+
+# Server
+def instance0():
+    multitest.globals(IP=multitest.get_network_ip())
+    s = socket.socket()
+    s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+    s.bind(socket.getaddrinfo("0.0.0.0", PORT)[0][-1])
+    s.listen(1)
+    multitest.next()
+    server_ctx = ssl.SSLContext(ssl.PROTOCOL_TLS_SERVER)
+    server_ctx.load_cert_chain(cert, key)
+    for i in range(7):
+        s2, _ = s.accept()
+        s2 = server_ctx.wrap_socket(s2, server_side=True)
+        print(s2.read(18))
+        s2.write(b"server to client {}".format(i))
+        s2.close()
+    s.close()
+
+
+# Client
+def instance1():
+    multitest.next()
+
+    def connect_and_count(i, session, set_method="wrap_socket"):
+        s = socket.socket()
+        s.connect(socket.getaddrinfo(IP, PORT)[0][-1])
+        s = CountingStream(s)
+        client_ctx = ssl.SSLContext(ssl.PROTOCOL_TLS_CLIENT)
+        client_ctx.verify_mode = ssl.CERT_REQUIRED
+        client_ctx.load_verify_locations(cadata=cadata)
+        wrap_socket_kwargs = {}
+        if set_method == "wrap_socket":
+            wrap_socket_kwargs = {"session": session}
+        elif set_method == "socket_attr":
+            wrap_socket_kwargs = {"do_handshake_on_connect": False}
+        s2 = client_ctx.wrap_socket(s, server_hostname="micropython.local", **wrap_socket_kwargs)
+        if set_method == "socket_attr" and session is not None:
+            s2.session = session
+        s2.write(b"client to server {}".format(i))
+        print(s2.read(18))
+        session = s2.session
+        print(type(session))
+        s2.close()
+        return session, s.count
+
+    # No session reuse
+    session, count_without_reuse = connect_and_count(0, None)
+
+    # Direct session reuse
+    session, count = connect_and_count(1, session, "wrap_socket")
+    print(count < count_without_reuse)
+
+    # Serialized session reuse
+    session = ssl.SSLSession(session.serialize())
+    session, count = connect_and_count(2, session, "wrap_socket")
+    print(count < count_without_reuse)
+
+    # Serialized session reuse (using buffer protocol)
+    session = ssl.SSLSession(bytes(session))
+    session, count = connect_and_count(3, session, "wrap_socket")
+    print(count < count_without_reuse)
+
+    # Direct session reuse
+    session, count = connect_and_count(4, session, "socket_attr")
+    print(count < count_without_reuse)
+
+    # Serialized session reuse
+    session = ssl.SSLSession(session.serialize())
+    session, count = connect_and_count(5, session, "socket_attr")
+    print(count < count_without_reuse)
+
+    # Serialized session reuse (using buffer protocol)
+    session = ssl.SSLSession(bytes(session))
+    session, count = connect_and_count(6, session, "socket_attr")
+    print(count < count_without_reuse)

--- a/tests/multi_net/sslcontext_server_client_session.py.exp
+++ b/tests/multi_net/sslcontext_server_client_session.py.exp
@@ -1,0 +1,29 @@
+--- instance0 ---
+b'client to server 0'
+b'client to server 1'
+b'client to server 2'
+b'client to server 3'
+b'client to server 4'
+b'client to server 5'
+b'client to server 6'
+--- instance1 ---
+b'server to client 0'
+<class 'SSLSession'>
+b'server to client 1'
+<class 'SSLSession'>
+True
+b'server to client 2'
+<class 'SSLSession'>
+True
+b'server to client 3'
+<class 'SSLSession'>
+True
+b'server to client 4'
+<class 'SSLSession'>
+True
+b'server to client 5'
+<class 'SSLSession'>
+True
+b'server to client 6'
+<class 'SSLSession'>
+True


### PR DESCRIPTION
## Summary

This implements support for the `SSLSession` class, introduced in CPython in 3.6 (see https://github.com/micropython/micropython/issues/2415). It allows saving session data from an active TLS client-side connection and then creating a new connection re-using this session data. Benefits include a faster handshake and reduced data usage for short connections.

## Implementation details

This PR adds the `SSLSession` class, the `session=` parameter for the `SSLContext.wrap_socket()` method, and the `session` attribute for an `SSLSocket` object.

Additionally, I've added a non-standard part: The `SSLSession.serialize()` function that converts the session to a bytes object (also available via the buffer protocol, so perhaps exposing this function is redundant); so that it can be stored by the user, and a constructor for the SSLSession object that accepts a bytes-like object to reconstruct the session object (CPython doesn't allow direct construction). This allows storing the session somewhere and use it after a deep sleep or reboot.

The second commit adds server-side support for TLS tickets in the Unix port, so that we can meaningfully test the session resumption in tests. The third commit adds a test which tests session resumption using the `SSLSession` object, checking that the resumption worked by checking that a resuming consumes less data.

https://github.com/micropython/micropython-lib/pull/829 is a companion MR that implements support in the `ssl` module wrapper. It is required for the tests to pass.

## Usage example

A small example test, using a wrapper class around the TCP socket so we can count how many bytes of data we're sending/receiving:

```python
from io import IOBase
import socket
import ssl
import time

import network
wlan = network.WLAN(network.STA_IF)
wlan.active(True)
wlan.connect('my-ssid', 'my-password')
while wlan.ifconfig()[0] == '0.0.0.0':
    time.sleep(0.1)

class AccountingStream(IOBase):
    def __init__(self, stream):
        self.stream = stream
        self.bytes_read = 0
        self.bytes_written = 0
        for attr in dir(stream):
            if not hasattr(self, attr):
                value = getattr(stream, attr)
                if callable(value):
                    setattr(self, attr, value)
    def read(self, size=None):
        result = self.stream.read() if size is None else self.stream.read(size)
        self.bytes_read += len(result)
        return result
    def readinto(self, buf, nbytes=None):
        result = self.stream.readinto(buf) if nbytes is None else self.stream.readinto(buf, nbytes)
        self.bytes_read += result
        return result
    def write(self, buf):
        self.bytes_written += len(buf)
        return self.stream.write(buf)

def connect_and_count(host, port, session=None):
    addr = socket.getaddrinfo(host, port)[0][-1]
    sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
    sock.settimeout(10)
    sock.connect(addr)
    sock_accounting = AccountingStream(sock)
    sock_tls = ssl.wrap_socket(sock_accounting, cert_reqs=ssl.CERT_NONE, server_hostname=host, session=session)
    sock_tls.write('HEAD / HTTP/1.1\r\nHost: {}\r\n\r\n'.format(host).encode())
    print('Response:', sock_tls.readline())
    print('Bytes read and written:', sock_accounting.bytes_read, sock_accounting.bytes_written)
    session = sock_tls.session
    sock.close()
    return session

host, port = 'tls-v1-2.badssl.com', 1012
socket.getaddrinfo(host, port)

print('Clean start:')
t = time.ticks_ms()
session = connect_and_count(host, port, None)
print('Time (ms):', time.ticks_diff(time.ticks_ms(), t))

print('\nReusing SSLSession:')
t = time.ticks_ms()
session = connect_and_count(host, port, session)
print('Time (ms):', time.ticks_diff(time.ticks_ms(), t))

print('\nUsing serialized and parsed SSLSession:')
t = time.ticks_ms()
session = connect_and_count(host, port, ssl.SSLSession(bytes(session)))
print('Time (ms):', time.ticks_diff(time.ticks_ms(), t))
```
```
Clean start:
Response: b'HTTP/1.1 200 OK\r\n'
Bytes read and written: 4947 453
Time (ms): 1829

Reusing SSLSession:
Response: b'HTTP/1.1 200 OK\r\n'
Bytes read and written: 438 602
Time (ms): 919

Using serialized and parsed SSLSession:
Response: b'HTTP/1.1 200 OK\r\n'
Bytes read and written: 438 602
Time (ms): 926
```

## Testing

I've deployed this in production and been running it for a number of years on a large number of devices.