### PR TITLE
esp32 : fix for #7158 - machine.deepsleep() not behaving as expected

### DIFF
--- a/ports/esp32/modmachine.c
+++ b/ports/esp32/modmachine.c
@@ -115,6 +115,9 @@ STATIC mp_obj_t machine_sleep_helper(wake_type_t wake_type, size_t n_args, const
 
     mp_int_t expiry = args[ARG_sleep_ms].u_int;
 
+    // First, disable any previously set wake-up source
+    esp_sleep_disable_wakeup_source(ESP_SLEEP_WAKEUP_ALL);
+
     if (expiry != 0) {
         esp_sleep_enable_timer_wakeup(((uint64_t)expiry) * 1000);
     }


### PR DESCRIPTION
This PR fixes machine.deepsleep() waking up the board after a delay d, for example when a machine.lightsleep(d) call was issued previously. This is because previous wake-sources remain active, whereas machine.deepsleep() shall put the board to sleep forever as per the
[machine.deepsleep documentation](https://docs.micropython.org/en/latest/esp32/quickref.html#general-board-control)

See #7158 for more details on : issue description, reproduction steps and fix implementation.