### PR TITLE
Change esp32.RMT.source_freq() to class method

### DIFF
--- a/docs/library/esp32.rst
+++ b/docs/library/esp32.rst
@@ -226,7 +226,7 @@ For more details see Espressif's `ESP-IDF RMT documentation.
     ``100``) and the output level to apply the carrier to (a boolean as per
     *idle_level*).
 
-.. method:: RMT.source_freq()
+.. classmethod:: RMT.source_freq()
 
     Returns the source clock frequency. Currently the source clock is not
     configurable so this will always return 80MHz.

--- a/docs/library/esp32.rst
+++ b/docs/library/esp32.rst
@@ -193,7 +193,7 @@ numbers specified in ``write_pulses`` are multiplied by the resolution to
 define the pulses.
 
 ``clock_div`` is an 8-bit divider (0-255) and each pulse can be defined by
-multiplying the resolution by a 15-bit (0-32,768) number. There are eight
+multiplying the resolution by a 15-bit (1-``PULSE_MAX``) number. There are eight
 channels (0-7) and each can have a different clock divider.
 
 So, in the example above, the 80MHz clock is divided by 8. Thus the
@@ -264,10 +264,10 @@ For more details see Espressif's `ESP-IDF RMT documentation.
     **Mode 3:** *duration* and *data* are lists or tuples of equal length,
     specifying individual durations and the output level for each.
 
-    Durations are in integer units of the channel resolution (as described
-    above), between 1 and 32767 units. Output levels are any value that can
-    be converted to a boolean, with ``True`` representing high voltage and
-    ``False`` representing low.
+    Durations are in integer units of the channel resolution (as
+    described above), between 1 and ``PULSE_MAX`` units. Output levels
+    are any value that can be converted to a boolean, with ``True``
+    representing high voltage and ``False`` representing low.
 
     If transmission of an earlier sequence is in progress then this method will
     block until that transmission is complete before beginning the new sequence.
@@ -289,6 +289,13 @@ For more details see Espressif's `ESP-IDF RMT documentation.
 
     Passing in no argument will not change the channel.  This function returns
     the current channel number.
+
+Constants
+---------
+
+.. data:: RMT.PULSE_MAX
+
+   Maximum integer that can be set for a pulse duration.
 
 Ultra-Low-Power co-processor
 ----------------------------

--- a/ports/esp32/esp32_rmt.c
+++ b/ports/esp32/esp32_rmt.c
@@ -368,6 +368,9 @@ STATIC const mp_rom_map_elem_t esp32_rmt_locals_dict_table[] = {
 
     // Class methods
     { MP_ROM_QSTR(MP_QSTR_source_freq), MP_ROM_PTR(&esp32_rmt_source_obj) },
+
+    // Constants
+    { MP_ROM_QSTR(MP_QSTR_PULSE_MAX), MP_ROM_INT(32767) },
 };
 STATIC MP_DEFINE_CONST_DICT(esp32_rmt_locals_dict, esp32_rmt_locals_dict_table);
 

--- a/ports/esp32/esp32_rmt.c
+++ b/ports/esp32/esp32_rmt.c
@@ -206,10 +206,11 @@ STATIC MP_DEFINE_CONST_FUN_OBJ_1(esp32_rmt_deinit_obj, esp32_rmt_deinit);
 // Return the source frequency.
 // Currently only the APB clock (80MHz) can be used but it is possible other
 // clock sources will added in the future.
-STATIC mp_obj_t esp32_rmt_source_freq(mp_obj_t self_in) {
+STATIC mp_obj_t esp32_rmt_source_freq() {
     return mp_obj_new_int(APB_CLK_FREQ);
 }
-STATIC MP_DEFINE_CONST_FUN_OBJ_1(esp32_rmt_source_freq_obj, esp32_rmt_source_freq);
+STATIC MP_DEFINE_CONST_FUN_OBJ_0(esp32_rmt_source_freq_obj, esp32_rmt_source_freq);
+STATIC MP_DEFINE_CONST_STATICMETHOD_OBJ(esp32_rmt_source_obj, MP_ROM_PTR(&esp32_rmt_source_freq_obj));
 
 // Return the clock divider.
 STATIC mp_obj_t esp32_rmt_clock_div(mp_obj_t self_in) {
@@ -357,7 +358,6 @@ STATIC MP_DEFINE_CONST_STATICMETHOD_OBJ(esp32_rmt_bitstream_channel_obj, MP_ROM_
 STATIC const mp_rom_map_elem_t esp32_rmt_locals_dict_table[] = {
     { MP_ROM_QSTR(MP_QSTR___del__), MP_ROM_PTR(&esp32_rmt_deinit_obj) },
     { MP_ROM_QSTR(MP_QSTR_deinit), MP_ROM_PTR(&esp32_rmt_deinit_obj) },
-    { MP_ROM_QSTR(MP_QSTR_source_freq), MP_ROM_PTR(&esp32_rmt_source_freq_obj) },
     { MP_ROM_QSTR(MP_QSTR_clock_div), MP_ROM_PTR(&esp32_rmt_clock_div_obj) },
     { MP_ROM_QSTR(MP_QSTR_wait_done), MP_ROM_PTR(&esp32_rmt_wait_done_obj) },
     { MP_ROM_QSTR(MP_QSTR_loop), MP_ROM_PTR(&esp32_rmt_loop_obj) },
@@ -365,6 +365,9 @@ STATIC const mp_rom_map_elem_t esp32_rmt_locals_dict_table[] = {
 
     // Static methods
     { MP_ROM_QSTR(MP_QSTR_bitstream_channel), MP_ROM_PTR(&esp32_rmt_bitstream_channel_obj) },
+
+    // Class methods
+    { MP_ROM_QSTR(MP_QSTR_source_freq), MP_ROM_PTR(&esp32_rmt_source_obj) },
 };
 STATIC MP_DEFINE_CONST_DICT(esp32_rmt_locals_dict, esp32_rmt_locals_dict_table);
 


### PR DESCRIPTION
To create a `esp32.RMT()` instance with an optimum (i.e. highest resolution) `clock_div` is currently awkward because you need to know the source clock frequency to calculate the best `clock_div` but unfortunately that is only currently available as an `source_freq()` method on the instance **after** you have already created it, i.e. we have a chicken and egg problem. So `RMT.source_freq()` should really be a class method, not an instance method and this PR changes that in the code and documentation. Of course this change is backwards compatible for existing code because you can still reference that function from an instance, or now also, from the class, i.e.

```python
from esp32 import RMT
rmt = RMT(0, pin)

assert rmt.source_freq() == RMT.source_freq()
````