### PR TITLE
stm32/dma: Reset all dma channels during soft-reset.

### DIFF
--- a/ports/stm32/dma.c
+++ b/ports/stm32/dma.c
@@ -1520,6 +1520,19 @@ void dma_deinit(const dma_descr_t *dma_descr) {
     }
 }
 
+void dma_deinit_all() {
+    for (size_t i = 0; i < NSTREAM; i++) {
+        DMA_HandleTypeDef *handle = dma_handle[i];
+        if (handle != NULL) {
+            #if !defined(STM32F0)
+            HAL_NVIC_DisableIRQ(dma_irqn[i]);
+            #endif
+            dma_handle[i] = NULL;
+            dma_disable_clock(i);
+        }
+    }
+}
+
 void dma_invalidate_channel(const dma_descr_t *dma_descr) {
     if (dma_descr != NULL) {
         dma_id_t dma_id = dma_descr->id;

--- a/ports/stm32/dma.h
+++ b/ports/stm32/dma.h
@@ -152,6 +152,7 @@ void dma_init(DMA_HandleTypeDef *dma, const dma_descr_t *dma_descr, uint32_t dir
 void dma_init_handle(DMA_HandleTypeDef *dma, const dma_descr_t *dma_descr, uint32_t dir, void *data);
 void dma_deinit(const dma_descr_t *dma_descr);
 void dma_invalidate_channel(const dma_descr_t *dma_descr);
+void dma_deinit_all();
 
 // API that configures the DMA directly and does not use the HAL.
 void dma_nohal_init(const dma_descr_t *descr, uint32_t config);

--- a/ports/stm32/main.c
+++ b/ports/stm32/main.c
@@ -670,6 +670,7 @@ soft_reset_exit:
     dac_deinit_all();
     #endif
     machine_deinit();
+    dma_deinit_all();
 
     #if MICROPY_PY_THREAD
     pyb_thread_deinit();


### PR DESCRIPTION
On a work project I'm using a C module to configure and use DMA for timer interactions. The same thing can be done with https://github.com/andrewleech/micropython-stm32-pwm-sine-wave

Once DMA interrupts have been enabled with any channels not used by internal micropython usage, these don't get turned off on soft-reset which leaves them still enabled. If they get triggered, a hard fault occurs as the HAL interrupt tries to access the original definition struct which has now disappeared.

This MR adds an explicit reset of all DMA channels during soft reset to ensure this hard fault cannot occur.
