### PR TITLE
ports/unix: Add embedded mode.

### DIFF
--- a/docs/unix/quickref.rst
+++ b/docs/unix/quickref.rst
@@ -8,7 +8,7 @@ Command line options
 
 Usage::
 
-    micropython [ -h ] [ -i ] [ -O<level> ] [ -v ] [ -X <option> ] [ -c <command> | -m <module> | <script> ] [ <args> ]
+    micropython [ -h ] [ -i ] [ -e ] [ -O<level> ] [ -v ] [ -X <option> ] [ -c <command> | -m <module> | <script> ] [ <args> ]
 
 
 Invocation options:
@@ -16,6 +16,20 @@ Invocation options:
 .. option:: -c <command>
 
    Runs the code in ``<command>``. The code can be one or more Python statements.
+
+.. option:: -e
+
+   Runs MicroPython in "embedded mode":
+
+   * ``boot.py`` and ``main.py`` are executed; boot.py unconditionally,
+     ``main.py`` only if no script argument is used.
+
+   * Instead of the ``readline`` library, MicroPython uses the same REPL as
+     on embedded systems.
+
+   This mode is mainly useful for running MicroPython as a subprocess, e.g.
+   for testing. For interactive use, a ``stty raw; micropython -e …; stty
+   -raw`` wrapper is required.
 
 .. option:: -m <module>
 

--- a/ports/unix/Makefile
+++ b/ports/unix/Makefile
@@ -217,6 +217,7 @@ SRC_C += \
 SHARED_SRC_C += $(addprefix shared/,\
 	runtime/gchelper_generic.c \
 	timeutils/timeutils.c \
+	runtime/pyexec.c \
 	$(SHARED_SRC_C_EXTRA) \
 	)
 

--- a/ports/unix/main.c
+++ b/ports/unix/main.c
@@ -320,7 +320,9 @@ STATIC void print_help(char **argv) {
         "usage: %s [<opts>] [-X <implopt>] [-c <command> | -m <module> | <filename>]\n"
         "Options:\n"
         "-h : print this help message\n"
+#if MICROPY_USE_READLINE == 1
         "-e : embedded mode: run 'boot.py', enable raw input\n"
+#endif
         "-i : enable inspection via REPL after running command/module/file\n"
         #if MICROPY_DEBUG_PRINTERS
         "-v : verbose (trace various operations); can be multiple\n"
@@ -624,7 +626,9 @@ MP_NOINLINE int main_(int argc, char **argv) {
     const int NOTHING_EXECUTED = -2;
     int ret = NOTHING_EXECUTED;
     bool inspect = false;
+#if MICROPY_USE_READLINE == 1
     bool embed = false;
+#endif
     for (int a = 1; a < argc; a++) {
         if (argv[a][0] == '-') {
             if (strcmp(argv[a], "-i") == 0) {
@@ -637,9 +641,11 @@ MP_NOINLINE int main_(int argc, char **argv) {
                 set_sys_argv(argv, argc, a + 2); // Then what comes after the command
                 ret = do_str(argv[a + 1]);
                 break;
+#if MICROPY_USE_READLINE == 1
             } else if (strcmp(argv[a], "-e") == 0) {
                 embed = true;
                 pyexec_file_if_exists("boot.py");
+#endif
             } else if (strcmp(argv[a], "-m") == 0) {
                 if (a + 1 >= argc) {
                     return invalid_args();
@@ -735,6 +741,7 @@ MP_NOINLINE int main_(int argc, char **argv) {
         inspect = true;
     }
     if (ret == NOTHING_EXECUTED || inspect) {
+#if MICROPY_USE_READLINE == 1
         if (embed) {
             // Run main.py if not told otherwise
             if (ret == NOTHING_EXECUTED) {
@@ -755,7 +762,9 @@ MP_NOINLINE int main_(int argc, char **argv) {
                     }
                 }
             }
-        } else if (isatty(0) || inspect) {
+        } else
+#endif
+        if (isatty(0) || inspect) {
             prompt_read_history();
             ret = do_repl();
             prompt_write_history();

--- a/ports/unix/main.c
+++ b/ports/unix/main.c
@@ -53,6 +53,7 @@
 #include "extmod/vfs_posix.h"
 #include "genhdr/mpversion.h"
 #include "input.h"
+#include "shared/runtime/pyexec.h"
 
 // Command line options, with their defaults
 STATIC bool compile_only = false;
@@ -319,6 +320,7 @@ STATIC void print_help(char **argv) {
         "usage: %s [<opts>] [-X <implopt>] [-c <command> | -m <module> | <filename>]\n"
         "Options:\n"
         "-h : print this help message\n"
+        "-e : embedded mode: run 'boot.py', enable raw input\n"
         "-i : enable inspection via REPL after running command/module/file\n"
         #if MICROPY_DEBUG_PRINTERS
         "-v : verbose (trace various operations); can be multiple\n"
@@ -622,6 +624,7 @@ MP_NOINLINE int main_(int argc, char **argv) {
     const int NOTHING_EXECUTED = -2;
     int ret = NOTHING_EXECUTED;
     bool inspect = false;
+    bool embed = false;
     for (int a = 1; a < argc; a++) {
         if (argv[a][0] == '-') {
             if (strcmp(argv[a], "-i") == 0) {
@@ -634,6 +637,9 @@ MP_NOINLINE int main_(int argc, char **argv) {
                 set_sys_argv(argv, argc, a + 2); // Then what comes after the command
                 ret = do_str(argv[a + 1]);
                 break;
+            } else if (strcmp(argv[a], "-e") == 0) {
+                embed = true;
+                pyexec_file_if_exists("boot.py");
             } else if (strcmp(argv[a], "-m") == 0) {
                 if (a + 1 >= argc) {
                     return invalid_args();
@@ -729,7 +735,27 @@ MP_NOINLINE int main_(int argc, char **argv) {
         inspect = true;
     }
     if (ret == NOTHING_EXECUTED || inspect) {
-        if (isatty(0) || inspect) {
+        if (embed) {
+            // Run main.py if not told otherwise
+            if (ret == NOTHING_EXECUTED) {
+                ret = pyexec_file_if_exists("main.py");
+                if (ret & PYEXEC_FORCED_EXIT) {
+                    goto soft_reset_exit;
+                }
+            }
+            ret = 0;
+            for (;;) {
+                if (pyexec_mode_kind == PYEXEC_MODE_RAW_REPL) {
+                    if (pyexec_raw_repl() != 0) {
+                        break;
+                    }
+                } else {
+                    if (pyexec_friendly_repl() != 0) {
+                        break;
+                    }
+                }
+            }
+        } else if (isatty(0) || inspect) {
             prompt_read_history();
             ret = do_repl();
             prompt_write_history();
@@ -737,6 +763,8 @@ MP_NOINLINE int main_(int argc, char **argv) {
             ret = execute_from_lexer(LEX_SRC_STDIN, NULL, MP_PARSE_FILE_INPUT, false);
         }
     }
+
+soft_reset_exit:
 
     #if MICROPY_PY_SYS_SETTRACE
     MP_STATE_THREAD(prof_trace_callback) = MP_OBJ_NULL;

--- a/shared/runtime/pyexec.c
+++ b/shared/runtime/pyexec.c
@@ -42,6 +42,7 @@
 #include "shared/readline/readline.h"
 #include "shared/runtime/pyexec.h"
 #include "genhdr/mpversion.h"
+#include "extmod/modplatform.h"
 
 pyexec_mode_kind_t pyexec_mode_kind = PYEXEC_MODE_FRIENDLY_REPL;
 int pyexec_system_exit = 0;


### PR DESCRIPTION
Embedded mode means that

* boot.py is executed, if present
* the same REPL as on embedded systems is used that is, ^A switches to raw mode.

This change does not yet(?)

* modify the terminal mode Workaround: wrap with `stty raw; micropython -e …; stty -raw`
* support a restart via `machine.reset()`