### PR TITLE
extmod/modbluetooth: Initialise nlr_jump_callback_top for IRQ handlers.

### DIFF
--- a/extmod/modbluetooth.c
+++ b/extmod/modbluetooth.c
@@ -1276,6 +1276,7 @@ STATIC mp_obj_t invoke_irq_handler(uint16_t event,
         mp_stack_set_top(&ts + 1); // need to include ts in root-pointer scan
         mp_stack_set_limit(MICROPY_PY_BLUETOOTH_SYNC_EVENT_STACK_SIZE - 1024);
         ts.gc_lock_depth = 0;
+        ts.nlr_jump_callback_top = NULL;
         ts.mp_pending_exception = MP_OBJ_NULL;
         mp_locals_set(mp_state_ctx.thread.dict_locals); // set from the outer context
         mp_globals_set(mp_state_ctx.thread.dict_globals); // set from the outer context


### PR DESCRIPTION
Similar to #12711 where this change was implemented for threads: When the Bluetooth IRQ handler is called the thread state is not not zero-initialized and thus we need to manually set this to NULL.

Fixes #12239.

My original issue noted that the issue was introduced when we switched to IDFv5; I suppose that before it just happened to be zero already without the explicit initialisation but due to changes elsewhere in the stack / compiler that changed.