### PR TITLE
port/rp2: Make tickless, remove 1ms timeout when idle.

### DIFF
--- a/ports/rp2/modmachine.c
+++ b/ports/rp2/modmachine.c
@@ -111,7 +111,7 @@ STATIC mp_obj_t machine_freq(size_t n_args, const mp_obj_t *args) {
 STATIC MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(machine_freq_obj, 0, 1, machine_freq);
 
 STATIC mp_obj_t machine_idle(void) {
-    best_effort_wfe_or_timeout(make_timeout_time_ms(1));
+    __wfe();
     return mp_const_none;
 }
 STATIC MP_DEFINE_CONST_FUN_OBJ_0(machine_idle_obj, machine_idle);

--- a/ports/rp2/mpconfigport.h
+++ b/ports/rp2/mpconfigport.h
@@ -274,7 +274,7 @@ extern void mp_thread_end_atomic_section(uint32_t);
 #define MICROPY_EVENT_POLL_HOOK \
     do { \
         MICROPY_EVENT_POLL_HOOK_FAST; \
-        best_effort_wfe_or_timeout(make_timeout_time_ms(1)); \
+        __wfe(); \
     } while (0);
 
 #define MICROPY_MAKE_POINTER_CALLABLE(p) ((void *)((mp_uint_t)(p) | 1))


### PR DESCRIPTION
The main motivation for doing this was to reduce the latency when the system is woken by a USB interrupt. The `best_effort_wfe_or_timeout()` function calls into the pico-sdk dynamic timer framework which sets up a new dynamic timer instance each time, and then has to tear it down before continuing after a WFE.

Testing Python interrupt latency it seems to improved by about 12us (from average of 46us to 34us running a Pin IRQ). C-based "scheduled nodes" should see even lower latency.

Test code was:

```python
import machine
from machine import Pin

i = Pin(2, Pin.IN, Pin.PULL_UP)
o = Pin(3, Pin.OUT)

def handler(_):
    o(1)
    print('!')
    o(0)

i.irq(handler, Pin.IRQ_FALLING)

while True:
    machine.idle()
```

With latency measured using logic analyzer:

![LA Capture of the above in pulseview](https://github.com/micropython/micropython/assets/205573/c37fa994-8949-4836-a45c-b9b54cac4d30)

(Channel 0 is "i", Channel is "o". Please excuse noisy CH0, was triggering with a button. Time 0 is the first falling edge of channel 0.)

The risk with this change is that it exposes cases where a driver expects execution to continue without an interrupt. Alternative is to enable the standard ARM SysTick interrupt to wake the CPU at tick intervals. (There is a [branch with SysTick enabled and working](https://github.com/micropython/micropython/compare/master...projectgus:feature/rp2_systick), but testing shows tickless is just as functional.)

This work was funded through GitHub Sponsors.