### PR TITLE
esp32/usb: Wake main thread when usb receives data.

### DIFF
--- a/ports/esp32/mphalport.c
+++ b/ports/esp32/mphalport.c
@@ -214,7 +214,12 @@ uint64_t mp_hal_time_ns(void) {
     return ns;
 }
 
-// Wake up the main task if it is sleeping
+// Wake up the main task if it is sleeping.
+void mp_hal_wake_main_task(void) {
+    xTaskNotifyGive(mp_main_task_handle);
+}
+
+// Wake up the main task if it is sleeping, to be called from an ISR.
 void mp_hal_wake_main_task_from_isr(void) {
     BaseType_t xHigherPriorityTaskWoken = pdFALSE;
     vTaskNotifyGiveFromISR(mp_main_task_handle, &xHigherPriorityTaskWoken);

--- a/ports/esp32/mphalport.h
+++ b/ports/esp32/mphalport.h
@@ -83,6 +83,7 @@ uint32_t mp_hal_get_cpu_freq(void);
 #define mp_hal_quiet_timing_exit(irq_state) MICROPY_END_ATOMIC_SECTION(irq_state)
 
 // Wake up the main task if it is sleeping
+void mp_hal_wake_main_task(void);
 void mp_hal_wake_main_task_from_isr(void);
 
 // C-level pin HAL


### PR DESCRIPTION
This improves latency on stdin on esp32 parts with built in (tinyusb based) USB like S2 and S3.

The latency is highly visible when importing a module on a `mpremote mount` session, directly slowing down the import process.

With a 14KB python file in mpremote mount it brings the import time from 12.1 sec down to 4.2 sec
When combined with https://github.com/micropython/micropython/pull/12836 the import time drops to ~900ms
```
STEP: ~ $ mpremote mount .
Local directory . is mounted at /remote
Connected to MicroPython at /dev/ttyACM0
Use Ctrl-] or Ctrl-x to exit this shell
>
MicroPython v1.22.0-preview.82.g0bcd3c5734.dirty on 2023-11-01; LOLIN_S2_MINI with ESP32-S2FN4R2
Type "help()" for more information.
>>> import time;s = time.ticks_ms();import big_module; print(time.ticks_diff(time.ticks_ms(), s))
4206
```