### PR TITLE
stm32/boards/make-pins.py: Fix H7 ADC generation.

### DIFF
--- a/ports/stm32/boards/make-pins.py
+++ b/ports/stm32/boards/make-pins.py
@@ -135,7 +135,11 @@ class Stm32Pin(boardgen.Pin):
                     "Invalid adc '{:s}' for pin '{:s}'".format(adc_name, self.name())
                 )
             adc_units = [int(x) for x in m.group(1)]
-            _adc_mode = m.group(2)
+            adc_mode = m.group(2)
+            if adc_mode == "INN":
+                # On H7 we have INN/INP, all other parts use IN only. Only use
+                # IN or INP channels.
+                continue
             adc_channel = int(m.group(3))
 
             # Pick the entry with the most ADC units, e.g. "ADC1_INP16/ADC12_INN1/ADC12_INP0" --> "ADC12_INN1".
@@ -247,6 +251,8 @@ class Stm32PinGenerator(boardgen.PinGenerator):
             )
             # Don't include pins that weren't in pins.csv.
             for pin in self.available_pins():
+                if pin._hidden:
+                    continue
                 if adc_unit in pin._adc_units:
                     print(
                         "    [{:d}] = {:s},".format(pin._adc_channel, self._cpu_pin_pointer(pin)),


### PR DESCRIPTION
* Only emit ADC table entries for pins that aren't cpu-hidden (i.e. ignore `X,-Y` rows).
* Only use the P channels on H7.


cc @iabdalkader 

---

This now emits (on ARDUINO_PORTENTA_H7):

```
const machine_pin_obj_t pin_A0_obj = PIN(A, 0, pin_A0_af, PIN_ADC1, 16);
const machine_pin_obj_t pin_A1_obj = PIN(A, 1, pin_A1_af, PIN_ADC1, 17);

...

const machine_pin_obj_t * const pin_adc1[20] = {
    [16] = &pin_A0_obj,
    [17] = &pin_A1_obj,
    [18] = &pin_A4_obj,
    [12] = &pin_C2_obj,
    [13] = &pin_C3_obj,
    [6] = &pin_F12_obj,
};

const machine_pin_obj_t * const pin_adc2[20] = {
    [18] = &pin_A4_obj,
    [12] = &pin_C2_obj,
    [13] = &pin_C3_obj,
    [2] = &pin_F13_obj,
};

const machine_pin_obj_t * const pin_adc3[17] = {
    [12] = &pin_C2_obj,
};
```
