### PR TITLE
ports/stm32/mpnetworkport.c: Add lwip loopback support

### DIFF
--- a/extmod/extmod.mk
+++ b/extmod/extmod.mk
@@ -267,6 +267,9 @@ SRC_THIRDPARTY_C += $(addprefix $(LWIP_DIR)/,\
 	core/ipv6/nd6.c \
 	netif/ethernet.c \
 	)
+ifeq ($(MICROPY_PY_LWIP_LOOPBACK),1)
+CFLAGS_EXTMOD += -DLWIP_NETIF_LOOPBACK=1
+endif
 ifeq ($(MICROPY_PY_LWIP_SLIP),1)
 CFLAGS_EXTMOD += -DMICROPY_PY_LWIP_SLIP=1
 SRC_THIRDPARTY_C += $(LWIP_DIR)/netif/slipif.c

--- a/ports/stm32/lwip_inc/lwipopts.h
+++ b/ports/stm32/lwip_inc/lwipopts.h
@@ -24,6 +24,9 @@
 #define LWIP_NETIF_HOSTNAME             1
 #define LWIP_NETIF_EXT_STATUS_CALLBACK  1
 
+#define LWIP_LOOPIF_MULTICAST           1
+#define LWIP_LOOPBACK_MAX_PBUFS         8
+
 #define LWIP_IPV6                       0
 #define LWIP_DHCP                       1
 #define LWIP_DHCP_CHECK_LINK_UP         1

--- a/ports/stm32/mpnetworkport.c
+++ b/ports/stm32/mpnetworkport.c
@@ -72,6 +72,10 @@ STATIC void pyb_lwip_poll(void) {
 
     // Run the lwIP internal updates
     sys_check_timeouts();
+
+    #if LWIP_NETIF_LOOPBACK
+    netif_poll_all();
+    #endif
 }
 
 void mod_network_lwip_poll_wrapper(uint32_t ticks_ms) {

--- a/tests/net_hosted/asyncio_loopback.py
+++ b/tests/net_hosted/asyncio_loopback.py
@@ -1,0 +1,64 @@
+# Test network loopback behaviour
+
+try:
+    import asyncio
+except ImportError:
+    print("SKIP")
+    raise SystemExit
+
+
+async def client(host, port):
+    print(f"client open_connection to {host}:{port}")
+    reader, writer = await asyncio.open_connection(host, port)
+
+    data_in = b"A" * 100
+
+    print("client writing")
+    writer.write(data_in)
+    await writer.drain()
+
+    await asyncio.sleep(0.1)
+
+    print("client reading")
+    data = await reader.readexactly(100)
+    print(f"client got {len(data)} bytes")
+
+    assert data_in == data
+
+    print("client closing")
+
+    writer.close()
+    await writer.wait_closed()
+
+    print("client closed")
+
+
+async def echo_handler(reader, writer):
+    print("handler reading")
+    await asyncio.sleep(0.1)
+    data = await reader.readexactly(100)
+    print(f"handler got {len(data)} bytes")
+
+    print("handler writing")
+    writer.write(data)
+    await writer.drain()
+
+    print("handler closing")
+
+    writer.close()
+    await writer.wait_closed()
+
+    print("handler closed")
+
+
+async def test(host, port):
+    print(f"create server on {host}:{port}")
+    server = await asyncio.start_server(echo_handler, host, port)
+
+    async with server:
+        print("server started")
+        await client("127.0.0.1", 8080)
+    print("server closed")
+
+
+asyncio.run(test("0.0.0.0", 8080))

--- a/tests/net_hosted/asyncio_loopback.py.exp
+++ b/tests/net_hosted/asyncio_loopback.py.exp
@@ -1,0 +1,14 @@
+create server on 0.0.0.0:8080
+server started
+client open_connection to 127.0.0.1:8080
+client writing
+handler reading
+client reading
+handler got 100 bytes
+handler writing
+handler closing
+handler closed
+client got 100 bytes
+client closing
+client closed
+server closed


### PR DESCRIPTION
This implements support for loopback(localhost/127.0.0.1) traffic in the stm32 port.

In our application users may provide scripts that need to access the REST API on the local server (See Feller-AG/wiser-api#9).

For the added test, I am unsure how much and where to print, but I though more is better.
Currently the test only attempts "127.0.0.1" because "localhost" does not work on the unix port(but now does on the stm32 port).


Since this adds code size and is probably not used by most applications, I have not enabled anything by default.

This could probably be expanded to the mimxrt and rp2 port but I have no boards to test.