### PR TITLE
unix/main: Fix build on RISC-V 64 bits.

### DIFF
--- a/ports/unix/main.c
+++ b/ports/unix/main.c
@@ -562,7 +562,12 @@ MP_NOINLINE int main_(int argc, char **argv) {
             // First entry is empty. We've already added an empty entry to sys.path, so skip it.
             ++path;
         }
-        bool path_remaining = *path;
+        // GCC targeting RISC-V 64 reports a warning about `path_remaining` being clobbered by
+        // either setjmp or vfork if that variable it is allocated on the stack.  This may
+        // probably be a compiler error as it occurs on a few recent GCC releases (up to 14.1.0)
+        // but LLVM doesn't report any warnings.
+        static bool path_remaining;
+        path_remaining = *path;
         while (path_remaining) {
             char *path_entry_end = strchr(path, PATHLIST_SEP_CHAR);
             if (path_entry_end == NULL) {


### PR DESCRIPTION
A variable needed to be marked as static to make gcc on RISC-V build the Unix port.

Fixes bug #12838.