### PR TITLE
stm32/boards/make-pins.py: Only support ADC1-3.

### DIFF
--- a/ports/stm32/boards/make-pins.py
+++ b/ports/stm32/boards/make-pins.py
@@ -49,6 +49,11 @@ PinAf = namedtuple(
     ],
 )
 
+# Only support ADC1, ADC2, ADC3 for now (e.g. cannot support ADC4 & ADC5 on
+# STM32G4).
+MIN_ADC_UNIT = 1
+MAX_ADC_UNIT = 3
+
 
 class Stm32Pin(boardgen.Pin):
     def __init__(self, cpu_pin_name):
@@ -134,7 +139,7 @@ class Stm32Pin(boardgen.Pin):
                 raise boardgen.PinGeneratorError(
                     "Invalid adc '{:s}' for pin '{:s}'".format(adc_name, self.name())
                 )
-            adc_units = [int(x) for x in m.group(1)]
+            adc_units = [int(x) for x in m.group(1) if MIN_ADC_UNIT <= int(x) <= MAX_ADC_UNIT]
             adc_mode = m.group(2)
             if adc_mode == "INN":
                 # On H7 we have INN/INP, all other parts use IN only. Only use


### PR DESCRIPTION
e.g. The STM32G4 includes ADC4 & ADC5 which is not currently supported by the stm32 driver.