### PR TITLE
py/qstr: Special case qstr_find_strn for empty string. 

### DIFF
--- a/ports/bare-arm/lib.c
+++ b/ports/bare-arm/lib.c
@@ -110,8 +110,9 @@ char *strchr(const char *s, int c) {
 }
 
 int strncmp(const char *s1, const char *s2, size_t n) {
-    while (*s1 && *s2 && n-- > 0) {
+    while (n > 0 && *s1 && *s2) {
         int c = *s1++ - *s2++;
+        --n;
         if (c) {
             return c;
         }

--- a/py/qstr.c
+++ b/py/qstr.c
@@ -233,6 +233,11 @@ STATIC qstr qstr_add(mp_uint_t hash, mp_uint_t len, const char *q_ptr) {
 }
 
 qstr qstr_find_strn(const char *str, size_t str_len) {
+    if (str_len == 0) {
+        // strncmp behaviour is undefined for str==NULL.
+        return MP_QSTR_;
+    }
+
     // work out hash of str
     size_t str_hash = qstr_compute_hash((const byte *)str, str_len);
 

--- a/shared/libc/string0.c
+++ b/shared/libc/string0.c
@@ -154,7 +154,7 @@ int strcmp(const char *s1, const char *s2) {
 }
 
 int strncmp(const char *s1, const char *s2, size_t n) {
-    while (*s1 && *s2 && n > 0) {
+    while (n > 0 && *s1 && *s2) {
         char c1 = *s1++; // XXX UTF8 get char, next char
         char c2 = *s2++; // XXX UTF8 get char, next char
         n--;


### PR DESCRIPTION
Reported here: https://github.com/micropython/micropython/pull/12853#issuecomment-1793951315