### PR TITLE
extmod/modselect: Handle growing the pollfds allocation correctly.

### DIFF
--- a/tests/extmod/select_poll_fd.py
+++ b/tests/extmod/select_poll_fd.py
@@ -34,11 +34,22 @@ poller.register(1, select.POLLIN)
 # Poll for input, should return an empty list.
 print(poller.poll(0))
 
-# Test registering a very large number of file descriptors.
+# Test registering a very large number of file descriptors (will trigger
+# EINVAL due to more than OPEN_MAX fds).
 poller = select.poll()
 for fd in range(6000):
     poller.register(fd)
 try:
     poller.poll()
+    assert False
 except OSError as er:
     print(er.errno == errno.EINVAL)
+
+# Register stdout/stderr, plus many extra ones to trigger the fd vector
+# resizing. Then unregister the excess ones and verify poll still works.
+poller = select.poll()
+for fd in range(1, 1000):
+    poller.register(fd)
+for i in range(3, 1000):
+    poller.unregister(i)
+print(sorted(poller.poll()))

--- a/tests/extmod/select_poll_fd.py
+++ b/tests/extmod/select_poll_fd.py
@@ -35,7 +35,8 @@ poller.register(1, select.POLLIN)
 print(poller.poll(0))
 
 # Test registering a very large number of file descriptors (will trigger
-# EINVAL due to more than OPEN_MAX fds).
+# EINVAL due to more than OPEN_MAX fds). Typically it's 1024 (and on GitHub CI
+# we force this via `ulimit -n 1024`).
 poller = select.poll()
 for fd in range(6000):
     poller.register(fd)

--- a/tools/ci.sh
+++ b/tools/ci.sh
@@ -6,6 +6,9 @@ else
     MAKEOPTS="-j$(sysctl -n hw.ncpu)"
 fi
 
+# Ensure known OPEN_MAX (NO_FILES) limit.
+ulimit -n 1024
+
 ########################################################################################
 # general helper functions
 


### PR DESCRIPTION
Fixes https://github.com/micropython/micropython/issues/12887 -- thanks @junwha0511

---

The poll_obj_t instances have their pollfd field point into this allocation. So if re-allocating results in a move, we need to update the existing poll_obj_t's.

Update the test to cover this case.

Also, because the implementation allows unregistering but allows the pollfds allocation to be sparse (by setting the unregistered entries to fd=-1, in order to make the final poll call succeed, we need to ensure that max_used is below the system limit, even though only three entries are in-use.

_This work was funded through GitHub Sponsors._