### PR TITLE
esp32,esp8266: Fix ESP32 log levels, esp.osdebug() documentation

### DIFF
--- a/docs/library/esp.rst
+++ b/docs/library/esp.rst
@@ -62,12 +62,35 @@ Functions
 
 .. function:: flash_erase(sector_no)
 
-.. function:: osdebug(level)
+.. function:: osdebug(uart_no)
 
-    Turn esp os debugging messages on or off.
+    .. note:: This is the ESP8266 form of this function.
 
-    The *level* parameter sets the threshold for the log messages for all esp components.
-    The log levels are defined as constants:
+    Change the level of OS serial debug log messages. On boot,
+    OS serial debug log messages are disabled.
+
+    ``uart_no`` is the number of the UART peripheral which should receive
+    OS-level output, or ``None`` to disable OS serial debug log messages.
+
+.. function:: osdebug(uart_no, [level])
+    :no-index:
+
+    .. note:: This is the ESP32 form of this function.
+
+    Change the level of OS serial debug log messages. On boot, OS
+    serial debug log messages are limited to Error output only.
+
+    The behaviour of this function depends on the arguments passed to it. The
+    following combinations are supported:
+
+    ``osdebug(None)`` restores the default OS debug log message level
+    (``LOG_ERROR``).
+
+    ``osdebug(0)`` enables all available OS debug log messages (in the
+    default build configuration this is ``LOG_INFO``).
+
+    ``osdebug(0, level)`` sets the OS debug log message level to the
+     specified value. The log levels are defined as constants:
 
         * ``LOG_NONE`` -- No log output
         * ``LOG_ERROR`` -- Critical errors, software module can not recover on its own
@@ -76,6 +99,15 @@ Functions
         * ``LOG_DEBUG`` -- Extra information which is not necessary for normal use (values, pointers, sizes, etc)
         * ``LOG_VERBOSE`` -- Bigger chunks of debugging information, or frequent messages
           which can potentially flood the output
+
+    .. note:: ``LOG_DEBUG`` and ``LOG_VERBOSE`` are not compiled into the
+              MicroPython binary by default, to save size. A custom build with a
+              modified "``sdkconfig``" source file is needed to see any output
+              at these log levels.
+
+    .. note:: Log output on ESP32 is automatically suspended in "Raw REPL" mode,
+              to prevent communications issues. This means OS level logging is never
+              seen when using ``mpremote run`` and similar tools.
 
 .. function:: set_native_code_location(start, length)
 

--- a/ports/esp32/boards/sdkconfig.base
+++ b/ports/esp32/boards/sdkconfig.base
@@ -17,9 +17,18 @@ CONFIG_BOOTLOADER_SKIP_VALIDATE_IN_DEEP_SLEEP=y
 CONFIG_BOOTLOADER_APP_ROLLBACK_ENABLE=y
 
 # Change default log level to "ERROR" (instead of "INFO")
-CONFIG_LOG_DEFAULT_LEVEL_INFO=n
 CONFIG_LOG_DEFAULT_LEVEL_ERROR=y
-CONFIG_LOG_DEFAULT_LEVEL=1
+
+# Set the maximum included log level higher than the default,
+# so esp.osdebug() can enable more logging at runtime.
+#
+# To increase the max log verbosity to Debug or Verbose instead, comment
+# CONFIG_LOG_MAXIMUM_LEVEL_INFO=y and uncomment one of the other settings.
+#
+# If not needed, the next line can be commented entirely to save binary size.
+CONFIG_LOG_MAXIMUM_LEVEL_INFO=y
+#CONFIG_LOG_MAXIMUM_LEVEL_DEBUG=y
+#CONFIG_LOG_MAXIMUM_LEVEL_VERBOSE=y
 
 # Main XTAL Config
 # Only on: ESP32

--- a/ports/esp32/modesp.c
+++ b/ports/esp32/modesp.c
@@ -37,12 +37,12 @@
 #include "py/mphal.h"
 
 STATIC mp_obj_t esp_osdebug(size_t n_args, const mp_obj_t *args) {
-    esp_log_level_t level = LOG_LOCAL_LEVEL;
+    esp_log_level_t level = LOG_LOCAL_LEVEL; // Maximum available level
     if (n_args == 2) {
         level = mp_obj_get_int(args[1]);
     }
     if (args[0] == mp_const_none) {
-        // Disable logging
+        // Set logging back to boot default of ESP_LOG_ERROR
         esp_log_level_set("*", ESP_LOG_ERROR);
     } else {
         // Enable logging at the given level


### PR DESCRIPTION
* Fix regression in `esp.osdebug()` functionality, closes #12815
* Correct the documentation for this function.

As part of the first fix, the ESP32 binary file unfortunately gets 20KB larger as it was being built without INFO level logging functions. The DEBUG and VERBOSE levels still aren't compiled in by default, enabling these requires a custom build with different `sdkconfig` (have added documentation for this).

Binary sizes, ESP32_GENERIC board:

| Max log level | Size | Compared to "Error" |
| --------------- | ---- | ---- |
| Error | 1642112 | |
| Info | 1662208 | +20,096 (101.2%) |
| Debug | 1697808 | +55,696 (103.4%) |
| Verbose | 1706336 | +64,224 (103.9%) |

This work was funded through GitHub Sponsors.