### PR TITLE
stm32/boards/NUCLEO_WL55: Freeze LoRa driver.

### DIFF
--- a/ports/stm32/boards/NUCLEO_WL55/manifest.py
+++ b/ports/stm32/boards/NUCLEO_WL55/manifest.py
@@ -1,0 +1,6 @@
+# Don't include default frozen modules because MCU is tight on flash space.
+
+# Only install the sync version of the LoRa driver because this board doesn't
+# have asyncio by default.
+require("lora-sync")
+require("lora-stm32wl5")

--- a/ports/stm32/boards/NUCLEO_WL55/mpconfigboard.mk
+++ b/ports/stm32/boards/NUCLEO_WL55/mpconfigboard.mk
@@ -9,5 +9,5 @@ TEXT0_ADDR = 0x08000000
 MICROPY_VFS_FAT = 0
 MICROPY_VFS_LFS2 = 1
 
-# Don't include default frozen modules because MCU is tight on flash space
-FROZEN_MANIFEST ?=
+# Board-specific manifest (doesn't include default modules, adds LoRa driver).
+FROZEN_MANIFEST ?= $(BOARD_DIR)/manifest.py


### PR DESCRIPTION
This adds the sync version of the LoRa driver (and the base WL55 driver). cc @projectgus 

Adds +13.6kiB (212.6 -> 226.2). Limit for this board is 232kiB.

_This work was funded through GitHub Sponsors._