### PR TITLE
CODECONVENTIONS: Update for change from black to ruff format.

### DIFF
--- a/CODECONVENTIONS.md
+++ b/CODECONVENTIONS.md
@@ -53,13 +53,17 @@ are then certifying and signing off against the following:
 Code auto-formatting
 ====================
 
-Both C and Python code are auto-formatted using the `tools/codeformat.py`
-script.  This uses [uncrustify](https://github.com/uncrustify/uncrustify) to
-format C code and [black](https://github.com/psf/black) to format Python code.
-After making changes, and before committing, run this tool to reformat your
-changes to the correct style.  Without arguments this tool will reformat all
-source code (and may take some time to run).  Otherwise pass as arguments to
-the tool the files that changed and it will only reformat those.
+Both C and Python code formatting is controlled for consistency across the 
+micropython codebase.  
+Any C code contributed is formatted using the `tools/codeformat.py` script
+which uses [uncrustify](https://github.com/uncrustify/uncrustify).  
+Python code is linted and formatted using 
+[ruff & ruff format](https://github.com/astral-sh/ruff).
+After making changes, and before committing, run  `tools/codeformat.py` to 
+reformat your C code and `ruff format` for any python code to the correct style.  
+Without arguments this tool will reformat all source code (and may take some time 
+to run).  Otherwise pass as arguments to the tool the files that changed and it 
+will only reformat those.
 
 uncrustify
 ==========
@@ -151,11 +155,19 @@ Tips:
 * To ignore the pre-commit message format check temporarily, start the commit
   message subject line with "WIP" (for "Work In Progress").
 
+Running pre-commit manually
+===========================
+Once pre-commit is installed as per the previous section it can be manually run against 
+the micropython python codebase to update file formatting on demand, with either:
+* `pre-commit run --all-files` to fix all files in the micropython codebase
+* `pre-commit run --file ./path/to/my/file` to fix just one file
+* `pre-commit run --file ./path/to/my/folder/*` to fix just one folder
+
 Python code conventions
 =======================
 
 Python code follows [PEP 8](https://legacy.python.org/dev/peps/pep-0008/) and
-is auto-formatted using [black](https://github.com/psf/black) with a line-length
+is auto-formatted using [ruff format](https://docs.astral.sh/ruff/formatter) with a line-length
 of 99 characters.
 
 Naming conventions:


### PR DESCRIPTION
Also add notes on running pre-commit manually.

This should match the changes made in https://github.com/micropython/micropython/pull/12805