### PR TITLE
extmod/machine_i2c: Do a fast poll during I2C.scan().

### DIFF
--- a/extmod/machine_i2c.c
+++ b/extmod/machine_i2c.c
@@ -328,7 +328,12 @@ STATIC mp_obj_t machine_i2c_scan(mp_obj_t self_in) {
         if (ret == 0) {
             mp_obj_list_append(list, MP_OBJ_NEW_SMALL_INT(addr));
         }
-        #ifdef MICROPY_EVENT_POLL_HOOK
+        // This scan loop may run for some time, so process any pending events/exceptions,
+        // or allow the port to run any necessary background tasks.  But do it as fast as
+        // possible, in particular we are not waiting on any events.
+        #if defined(MICROPY_EVENT_POLL_HOOK_FAST)
+        MICROPY_EVENT_POLL_HOOK_FAST;
+        #elif defined(MICROPY_EVENT_POLL_HOOK)
         MICROPY_EVENT_POLL_HOOK
         #endif
     }


### PR DESCRIPTION
Fixes issue #12912.

This is needed to get scan working again on rp2 after the change made in 8c432ea2d437255eefb4aff18764936ad11b70c7