### PR TITLE
extmod/moductypes: Validate the descriptor tuple.

### DIFF
--- a/tests/extmod/uctypes_sizeof.py
+++ b/tests/extmod/uctypes_sizeof.py
@@ -43,8 +43,47 @@ assert uctypes.sizeof(S.arr4) == 6
 print(uctypes.sizeof(S.sub))
 assert uctypes.sizeof(S.sub) == 1
 
-# invalid descriptor
+# invalid descriptors
 try:
     print(uctypes.sizeof([]))
 except TypeError:
     print("TypeError")
+
+try:
+    print(uctypes.sizeof(()))
+except TypeError:
+    print("TypeError")
+
+try:
+    print(uctypes.sizeof(("garbage",)))
+except TypeError:
+    print("TypeError")
+
+try:
+    # PTR * 3 is intended to be an invalid agg_type (STRUCT, PTR, ARRAY are valid ones).
+    print(uctypes.sizeof((uctypes.PTR * 3,)))
+except TypeError:
+    print("TypeError")
+
+try:
+    print(uctypes.sizeof((0, {}, "garbage")))
+except TypeError:
+    print("TypeError")
+
+try:
+    print(uctypes.sizeof((uctypes.PTR | 0,)))
+except TypeError:
+    print("TypeError")
+
+try:
+    print(uctypes.sizeof((uctypes.ARRAY | 0,)))
+except TypeError:
+    print("TypeError")
+
+try:
+    print(uctypes.sizeof((uctypes.ARRAY | 0, 1, {}, "garbage")))
+except TypeError:
+    print("TypeError")
+
+# empty descriptor
+print(uctypes.sizeof({}))

--- a/tests/extmod/uctypes_sizeof.py.exp
+++ b/tests/extmod/uctypes_sizeof.py.exp
@@ -5,3 +5,11 @@ TypeError
 6
 1
 TypeError
+TypeError
+TypeError
+TypeError
+TypeError
+TypeError
+TypeError
+TypeError
+0

--- a/tests/extmod/uctypes_sizeof_od.py
+++ b/tests/extmod/uctypes_sizeof_od.py
@@ -45,9 +45,3 @@ assert uctypes.sizeof(S.arr4) == 6
 
 print(uctypes.sizeof(S.sub))
 assert uctypes.sizeof(S.sub) == 1
-
-# invalid descriptor
-try:
-    print(uctypes.sizeof([]))
-except TypeError:
-    print("TypeError")

--- a/tests/extmod/uctypes_sizeof_od.py.exp
+++ b/tests/extmod/uctypes_sizeof_od.py.exp
@@ -4,4 +4,3 @@
 TypeError
 6
 1
-TypeError


### PR DESCRIPTION
Fixes issue #12702 i.e. various null dereferencing, out of bounds access and assert(0) failures.

Tried to get code size down but there doesn't seem to be another way. As to whether it's worth it: by design uctypes can crash because it accesses arbitrary memory, but I'd still argue that at least the usage of describing what one is trying to do should be forced to be correct.