### PR TITLE
rp2/mphalport: Run TinyUSB stack while waiting for CDC input/output.

### DIFF
--- a/ports/renesas-ra/mpconfigport.h
+++ b/ports/renesas-ra/mpconfigport.h
@@ -272,7 +272,7 @@ static inline mp_uint_t disable_irq(void) {
 #define MICROPY_END_ATOMIC_SECTION(state)  enable_irq(state)
 
 #if MICROPY_HW_ENABLE_USBDEV
-#define MICROPY_HW_USBDEV_TASK_HOOK extern void usbd_task(void); usbd_task();
+#define MICROPY_HW_USBDEV_TASK_HOOK extern void mp_usbd_task(void); mp_usbd_task();
 #define MICROPY_VM_HOOK_COUNT (10)
 #define MICROPY_VM_HOOK_INIT static uint vm_hook_divisor = MICROPY_VM_HOOK_COUNT;
 #define MICROPY_VM_HOOK_POLL if (--vm_hook_divisor == 0) { \

--- a/shared/tinyusb/mp_usbd.h
+++ b/shared/tinyusb/mp_usbd.h
@@ -29,6 +29,9 @@
 
 #include "py/obj.h"
 
+// Call this to explicitly run the TinyUSB device task.
+void mp_usbd_task(void);
+
 // Function to be implemented in port code.
 // Can write a string up to MICROPY_HW_USB_DESC_STR_MAX characters long, plus terminating byte.
 extern void mp_usbd_port_get_serial_number(char *buf);


### PR DESCRIPTION
The recent change in bcbdee235719d459a4cd60d51021454fba54cd0f meant that TinyUSB can no longer be run from within a soft (or hard) IRQ handler, ie when the scheduler is locked.  That means that Python code that calls `print(...)` from within a scheduled function may block indefinitely if the USB CDC buffers are full.
 
This commit fixes that problem by explicitly running the TinyUSB stack when waiting within stdio tx/rx functions.
