### PR TITLE
py/mkrules.mk: Add support for custom manifest variables.

### DIFF
--- a/py/mkrules.mk
+++ b/py/mkrules.mk
@@ -199,10 +199,21 @@ CFLAGS += -DMICROPY_QSTR_EXTRA_POOL=mp_qstr_frozen_const_pool
 CFLAGS += -DMICROPY_MODULE_FROZEN_MPY
 CFLAGS += -DMICROPY_MODULE_FROZEN_STR
 
+# Set default path variables to be passed to makemanifest.py. These will be
+# available in path substitutions. Additional variables can be set per-board
+# in mpconfigboard.mk or on the make command line.
+MICROPY_MANIFEST_MPY_LIB_DIR = $(MPY_LIB_DIR)
+MICROPY_MANIFEST_PORT_DIR = $(shell pwd)
+MICROPY_MANIFEST_BOARD_DIR = $(BOARD_DIR)
+MICROPY_MANIFEST_MPY_DIR = $(TOP)
+
+# Find all MICROPY_MANIFEST_* variables and turn them into command line arguments.
+MANIFEST_VARIABLES = $(foreach var,$(filter MICROPY_MANIFEST_%, $(.VARIABLES)),-v "$(subst MICROPY_MANIFEST_,,$(var))=$($(var))")
+
 # to build frozen_content.c from a manifest
 $(BUILD)/frozen_content.c: FORCE $(BUILD)/genhdr/qstrdefs.generated.h $(BUILD)/genhdr/root_pointers.h | $(MICROPY_MPYCROSS_DEPENDENCY)
 	$(Q)test -e "$(MPY_LIB_DIR)/README.md" || (echo -e $(HELP_MPY_LIB_SUBMODULE); false)
-	$(Q)$(MAKE_MANIFEST) -o $@ -v "MPY_DIR=$(TOP)" -v "MPY_LIB_DIR=$(MPY_LIB_DIR)" -v "PORT_DIR=$(shell pwd)" -v "BOARD_DIR=$(BOARD_DIR)" -b "$(BUILD)" $(if $(MPY_CROSS_FLAGS),-f"$(MPY_CROSS_FLAGS)",) --mpy-tool-flags="$(MPY_TOOL_FLAGS)" $(FROZEN_MANIFEST)
+	$(Q)$(MAKE_MANIFEST) -o $@ $(MANIFEST_VARIABLES) -b "$(BUILD)" $(if $(MPY_CROSS_FLAGS),-f"$(MPY_CROSS_FLAGS)",) --mpy-tool-flags="$(MPY_TOOL_FLAGS)" $(FROZEN_MANIFEST)
 endif
 
 ifneq ($(PROG),)


### PR DESCRIPTION
Sketch of an idea to support passing more state e.g. from the board or make command line into the manifest file.

At the moment manifest.py expects these to be paths (and it will try to make them absolute). We also should consider making them accessible e.g. so you can do conditionals (i.e. not just in path substitutions).

Also... need to confirm we can do this or something like it in cmake.

---

This allows e.g. a board (or make command line) to set

`MICROPY_MANIFEST_MY_VARIABLE = foo`

and then in the manifest.py they can query this, e.g. via

`include("$(MY_VARIABLE)/path/manifest.py")`