### PR TITLE
arduino-boards: Fix incorrect board identifiers.

### DIFF
--- a/ports/esp32/boards/ARDUINO_NANO_ESP32/mpconfigboard.h
+++ b/ports/esp32/boards/ARDUINO_NANO_ESP32/mpconfigboard.h
@@ -1,6 +1,9 @@
 #define MICROPY_HW_BOARD_NAME               "Arduino Nano ESP32"
 #define MICROPY_HW_MCU_NAME                 "ESP32S3"
 
+// Network config
+#define MICROPY_PY_NETWORK_HOSTNAME_DEFAULT "mpy-nano-esp32"
+
 #define MICROPY_PY_MACHINE_DAC              (0)
 
 #define MICROPY_HW_I2C0_SCL                 (12)

--- a/ports/renesas-ra/boards/ARDUINO_PORTENTA_C33/mpconfigboard.h
+++ b/ports/renesas-ra/boards/ARDUINO_PORTENTA_C33/mpconfigboard.h
@@ -5,10 +5,14 @@
  */
 
 // MCU config
-#define MICROPY_HW_BOARD_NAME       "PORTENTA C33"
+#define MICROPY_HW_BOARD_NAME       "Arduino Portenta C33"
 #define MICROPY_HW_MCU_NAME         "RA6M5"
 #define MICROPY_HW_MCU_SYSCLK       200000000
 #define MICROPY_HW_MCU_PCLK         100000000
+#define MICROPY_HW_FLASH_FS_LABEL   "Portenta C33"
+
+// Network config
+#define MICROPY_PY_NETWORK_HOSTNAME_DEFAULT "mpy-portenta-c33"
 
 // module config
 #define MICROPY_EMIT_THUMB          (1)

--- a/ports/rp2/boards/ARDUINO_NANO_RP2040_CONNECT/mpconfigboard.h
+++ b/ports/rp2/boards/ARDUINO_NANO_RP2040_CONNECT/mpconfigboard.h
@@ -4,6 +4,9 @@
 #define MICROPY_HW_BOARD_NAME           "Arduino Nano RP2040 Connect"
 #define MICROPY_HW_FLASH_STORAGE_BYTES  (8 * 1024 * 1024)
 
+// Network config
+#define MICROPY_PY_NETWORK_HOSTNAME_DEFAULT "mpy-nano-rp2040-connect"
+
 // Enable networking.
 #define MICROPY_PY_NETWORK              (1)
 

--- a/ports/stm32/boards/ARDUINO_GIGA/mpconfigboard.h
+++ b/ports/stm32/boards/ARDUINO_GIGA/mpconfigboard.h
@@ -4,10 +4,12 @@
  * Copyright (c) 2023 Arduino SA
  */
 
-#define MICROPY_HW_BOARD_NAME       "GIGA"
+#define MICROPY_HW_BOARD_NAME       "Arduino GIGA R1 WiFi"
 #define MICROPY_HW_MCU_NAME         "STM32H747"
-#define MICROPY_PY_SYS_PLATFORM     "Giga"
-#define MICROPY_HW_FLASH_FS_LABEL   "Giga"
+#define MICROPY_HW_FLASH_FS_LABEL   "GIGA R1 WiFi"
+
+// Network config
+#define MICROPY_PY_NETWORK_HOSTNAME_DEFAULT "mpy-giga-r1-wifi"
 
 #define MICROPY_OBJ_REPR            (MICROPY_OBJ_REPR_C)
 #define UINT_FMT                    "%u"

--- a/ports/stm32/boards/ARDUINO_NICLA_VISION/mpconfigboard.h
+++ b/ports/stm32/boards/ARDUINO_NICLA_VISION/mpconfigboard.h
@@ -4,10 +4,12 @@
  * Copyright (c) 2023 Arduino SA
  */
 
-#define MICROPY_HW_BOARD_NAME       "NICLAVISION"
+#define MICROPY_HW_BOARD_NAME       "Arduino Nicla Vision"
 #define MICROPY_HW_MCU_NAME         "STM32H747"
-#define MICROPY_PY_SYS_PLATFORM     "Nicla Vision"
-#define MICROPY_HW_FLASH_FS_LABEL   "niclavision"
+#define MICROPY_HW_FLASH_FS_LABEL   "Nicla Vision"
+
+// Network config
+#define MICROPY_PY_NETWORK_HOSTNAME_DEFAULT "mpy-nicla-vision"
 
 #define MICROPY_OBJ_REPR            (MICROPY_OBJ_REPR_C)
 #define UINT_FMT                    "%u"

--- a/ports/stm32/boards/ARDUINO_PORTENTA_H7/mpconfigboard.h
+++ b/ports/stm32/boards/ARDUINO_PORTENTA_H7/mpconfigboard.h
@@ -4,12 +4,12 @@
  * Copyright (c) 2022 Arduino SA
  */
 
-#define MICROPY_HW_BOARD_NAME       "PORTENTA"
+#define MICROPY_HW_BOARD_NAME       "Arduino Portenta H7"
 #define MICROPY_HW_MCU_NAME         "STM32H747"
-#define MICROPY_PY_SYS_PLATFORM     "Portenta"
-#define MICROPY_HW_FLASH_FS_LABEL   "portenta"
+#define MICROPY_HW_FLASH_FS_LABEL   "Portenta H7"
 
-#define MICROPY_PY_NETWORK_HOSTNAME_DEFAULT "Portenta"
+// Network config
+#define MICROPY_PY_NETWORK_HOSTNAME_DEFAULT "mpy-portenta-h7"
 
 #define MICROPY_OBJ_REPR            (MICROPY_OBJ_REPR_C)
 #define UINT_FMT                    "%u"


### PR DESCRIPTION
- This PR changes the Arduino board identifiers to correspond to their official names. This helps to identify boards at runtime. At the moment the Arduino Portenta H7 is reported as `PORTENTA` which is unfortunate as now there is another Portenta board (Portenta C33) supported in MicroPython. 
- I also took the opportunity to make the other identifiers for flash and network name consistent.
- And I removed the incorrectly used `MICROPY_PY_SYS_PLATFORM` identifiers
- Added missing `MICROPY_PY_NETWORK_HOSTNAME_DEFAULT` identifiers