### PR TITLE
renesas-ra/boards/ARDUINO_PORTENTA_C33: Fix incorrect I2C pins.

### DIFF
--- a/ports/renesas-ra/boards/ARDUINO_PORTENTA_C33/mpconfigboard.h
+++ b/ports/renesas-ra/boards/ARDUINO_PORTENTA_C33/mpconfigboard.h
@@ -63,8 +63,8 @@ void PORTENTA_C33_board_enter_bootloader(void);
 #endif
 
 // I2C
-#define MICROPY_HW_I2C2_SCL         (pin_P407)
-#define MICROPY_HW_I2C2_SDA         (pin_P408)
+#define MICROPY_HW_I2C0_SCL         (pin_P408)
+#define MICROPY_HW_I2C0_SDA         (pin_P407)
 
 // SPI
 #define MICROPY_HW_SPI1_SSL         (pin_P104)


### PR DESCRIPTION
This PR fixes the incorrect assignment of the SCL and SDA pins on the Arduino Portenta C33.
![image](https://github.com/micropython/micropython/assets/1326220/bfcaa017-9882-4717-9247-712de5a62327)

Took the opportunity to also change the number of the interface to 0 as it's connected to `IIC0 `

@iabdalkader helped me to test it. Seems to work:

```
>>> print(I2C(0))
I2C(0, freq=400000, scl=P408, sda=P407)
```

Als a bus scan is successful:

```
from machine import I2C
for addr in I2C(0).scan():
        print("🙌 Found device at address 0x%x" %(addr))
```
prints `🙌 Found device at address 0x21`