### PR TITLE
stm32: add support for SD cards on H5 MCUs

### DIFF
--- a/ports/stm32/Makefile
+++ b/ports/stm32/Makefile
@@ -408,7 +408,7 @@ HAL_SRC_C += $(addprefix $(STM32LIB_HAL_BASE)/Src/stm32$(MCU_SERIES)xx_,\
 	)
 endif
 
-ifeq ($(MCU_SERIES),$(filter $(MCU_SERIES),f4 f7 h7 l4))
+ifeq ($(MCU_SERIES),$(filter $(MCU_SERIES),f4 f7 h5 h7 l4))
 HAL_SRC_C += $(addprefix $(STM32LIB_HAL_BASE)/Src/stm32$(MCU_SERIES)xx_,\
 	hal_sd.c \
 	ll_sdmmc.c \

--- a/ports/stm32/boards/STM32H573I_DK/mpconfigboard.h
+++ b/ports/stm32/boards/STM32H573I_DK/mpconfigboard.h
@@ -8,6 +8,7 @@
 #define MICROPY_HW_ENABLE_ADC               (1)
 #define MICROPY_HW_ENABLE_DAC               (1)
 #define MICROPY_HW_ENABLE_USB               (1)
+#define MICROPY_HW_ENABLE_SDCARD            (1)
 #define MICROPY_HW_HAS_SWITCH               (1)
 #define MICROPY_HW_HAS_FLASH                (1)
 
@@ -105,6 +106,11 @@
 // USB config
 #define MICROPY_HW_USB_FS                   (1)
 #define MICROPY_HW_USB_MAIN_DEV             (USB_PHY_FS_ID)
+
+// SD card
+#define MICROPY_HW_SDCARD_DETECT_PIN        (pin_H14)
+#define MICROPY_HW_SDCARD_DETECT_PULL       (GPIO_PULLUP)
+#define MICROPY_HW_SDCARD_DETECT_PRESENT    (GPIO_PIN_RESET)
 
 // Ethernet via RMII
 #define MICROPY_HW_ETH_MDC                  (pin_C1)

--- a/ports/stm32/dma.c
+++ b/ports/stm32/dma.c
@@ -156,7 +156,7 @@ static const DMA_InitTypeDef dma_init_struct_i2s = {
 };
 #endif
 
-#if ENABLE_SDIO && !defined(STM32H7)
+#if ENABLE_SDIO && !defined(STM32H5) && !defined(STM32H7)
 // Parameters to dma_init() for SDIO tx and rx.
 static const DMA_InitTypeDef dma_init_struct_sdio = {
     #if defined(STM32F4) || defined(STM32F7)

--- a/ports/stm32/sdcard.c
+++ b/ports/stm32/sdcard.c
@@ -40,7 +40,7 @@
 
 #if MICROPY_HW_ENABLE_SDCARD || MICROPY_HW_ENABLE_MMCARD
 
-#if defined(STM32F7) || defined(STM32H7) || defined(STM32L4)
+#if defined(STM32F7) || defined(STM32H5) || defined(STM32H7) || defined(STM32L4)
 
 // The H7/F7/L4 have 2 SDMMC peripherals, but at the moment this driver only supports
 // using one of them in a given build, selected by MICROPY_HW_SDCARD_SDMMC.
@@ -104,7 +104,7 @@
 #define SDIO_HARDWARE_FLOW_CONTROL_DISABLE  SDMMC_HARDWARE_FLOW_CONTROL_DISABLE
 #define SDIO_HARDWARE_FLOW_CONTROL_ENABLE   SDMMC_HARDWARE_FLOW_CONTROL_ENABLE
 
-#if defined(STM32H7)
+#if defined(STM32H5) || defined(STM32H7)
 #define SDIO_TRANSFER_CLK_DIV               SDMMC_NSpeed_CLK_DIV
 #define SDIO_USE_GPDMA                      0
 #else
@@ -268,7 +268,7 @@ STATIC HAL_StatusTypeDef sdmmc_init_sd(void) {
     // SD device interface configuration
     sdmmc_handle.sd.Instance = SDIO;
     sdmmc_handle.sd.Init.ClockEdge = SDIO_CLOCK_EDGE_RISING;
-    #ifndef STM32H7
+    #if !defined(STM32H5) && !defined(STM32H7)
     sdmmc_handle.sd.Init.ClockBypass = SDIO_CLOCK_BYPASS_DISABLE;
     #endif
     sdmmc_handle.sd.Init.ClockPowerSave = SDIO_CLOCK_POWER_SAVE_ENABLE;


### PR DESCRIPTION
Tested on the STM32H573I_DK.