### PR TITLE
examples/usercmodule: Add finaliser to cexample.

### DIFF
--- a/tests/misc/cexample_class.py.exp
+++ b/tests/misc/cexample_class.py.exp
@@ -1,3 +1,4 @@
 <Timer>
 True
 True
+de-init cexample resources.

--- a/tests/misc/cexample_class_2.py
+++ b/tests/misc/cexample_class_2.py
@@ -1,0 +1,13 @@
+# test custom native class
+
+try:
+    import cexample
+    import gc
+except ImportError:
+    print("SKIP")
+    raise SystemExit
+
+timer = cexample.Timer()
+timer = None
+gc.collect()
+print("done")

--- a/tests/misc/cexample_class_2.py.exp
+++ b/tests/misc/cexample_class_2.py.exp
@@ -1,0 +1,2 @@
+de-init cexample resources
+done

--- a/tests/misc/cexample_class_3.py
+++ b/tests/misc/cexample_class_3.py
@@ -1,0 +1,19 @@
+# test custom native class
+
+try:
+    import cexample
+    import time
+    import gc
+except ImportError:
+    print("SKIP")
+    raise SystemExit
+
+a = 100
+b = 20
+
+timer = cexample.Timer()
+c = 4
+d = 5
+timer = None
+gc.collect()
+print("done")

--- a/tests/misc/cexample_class_3.py.exp
+++ b/tests/misc/cexample_class_3.py.exp
@@ -1,0 +1,2 @@
+de-init cexample resources
+done


### PR DESCRIPTION
There are a number of situations in user C modules where hardware or static C variables should be reset or de-init when the module is no longer being used, or particularly over a soft-reset.

This PR adds usage of the gc finaliser to the existing cexample module to demonstrate how this can be achieved.

Inspired by discussion in https://github.com/micropython/micropython/pull/12803 and https://ptb.discord.com/channels/574275045187125269/1012726673709469818/1173760875539206225