### PR TITLE
esp32/esp32_rmt: Fix RMT looping

### DIFF
--- a/ports/esp32/esp32_rmt.c
+++ b/ports/esp32/esp32_rmt.c
@@ -323,12 +323,18 @@ STATIC mp_obj_t esp32_rmt_write_pulses(size_t n_args, const mp_obj_t *args) {
         check_esp_err(rmt_wait_tx_done(self->channel_id, portMAX_DELAY));
     }
 
+    #if !CONFIG_IDF_TARGET_ESP32S3
+    check_esp_err(rmt_write_items(self->channel_id, self->items, num_items, false));
+    #endif
+
     if (self->loop_en) {
         check_esp_err(rmt_set_tx_intr_en(self->channel_id, false));
         check_esp_err(rmt_set_tx_loop_mode(self->channel_id, true));
     }
 
+    #if CONFIG_IDF_TARGET_ESP32S3
     check_esp_err(rmt_write_items(self->channel_id, self->items, num_items, false));
+    #endif
 
     return mp_const_none;
 }


### PR DESCRIPTION
Commit 7ea06a3e2638e0fb82240c0b88c9cd1ecaf942f5 moved the `rmt_write_items()` call to fix RMT looping for ESP32-S3, but broke it for the other ESP32s (i.e. issue #6167 has been re-introduced). This commit conditionally compiles the location of that call.

I have tested this and confirmed the bug, and the fix, on generic ESP32 and ESP32-S3.