### PR TITLE
py/gc: When heap autosplit is enabled, limit new heap size.

### DIFF
--- a/docs/library/esp32.rst
+++ b/docs/library/esp32.rst
@@ -76,6 +76,7 @@ Functions
        The "max new split" value in :func:`micropython.mem_info()` output
        corresponds to the largest free block of ESP-IDF heap that could be
        automatically added on demand to the MicroPython heap.
+       See also :func:`micropython.heap_sys_reserve`.
 
        The result of :func:`gc.mem_free()` is the total of the current "free"
        and "max new split" values printed by :func:`micropython.mem_info()`.

--- a/docs/library/micropython.rst
+++ b/docs/library/micropython.rst
@@ -102,6 +102,28 @@ Functions
    Note: `heap_locked()` is not enabled on most ports by default,
    requires ``MICROPY_PY_MICROPYTHON_HEAP_LOCKED``.
 
+.. function:: heap_sys_reserve([new_value])
+
+   .. note:: This function is only present on ports using the "auto split heap"
+      feature.
+
+   Get or set the number of bytes of free heap RAM that MicroPython *tries* to
+   reserve for the system.
+
+   When called with no arguments, returns the currently set value. When called
+   with an argument, updates the currently set value.
+
+   This is a soft limit that prevents "greedily" growing the MicroPython heap
+   too large. If MicroPython has no choice but to grow the heap or fail then
+   it will still grow the MicroPython heap beyond this limit.
+
+   Setting a higher value may help if the system is failing to allocate memory
+   outside MicroPython. Setting a lower value or even zero may help if
+   MicroPython memory is becoming unnecessarily fragmented.
+
+   Changing this limit cannot resolve memory issues that are caused by requiring
+   more memory than is physically available in the system.
+
 .. function:: kbd_intr(chr)
 
    Set the character that will raise a `KeyboardInterrupt` exception.  By

--- a/ports/esp32/gccollect.c
+++ b/ports/esp32/gccollect.c
@@ -84,4 +84,8 @@ size_t gc_get_max_new_split(void) {
     return heap_caps_get_largest_free_block(MALLOC_CAP_DEFAULT);
 }
 
+size_t gc_get_total_free(void) {
+    return heap_caps_get_free_size(MALLOC_CAP_DEFAULT);
+}
+
 #endif

--- a/ports/esp32/mpconfigport.h
+++ b/ports/esp32/mpconfigport.h
@@ -187,6 +187,15 @@ void *esp_native_code_commit(void *, size_t, void *);
 #define MP_PLAT_COMMIT_EXEC(buf, len, reloc) esp_native_code_commit(buf, len, reloc)
 #define MP_SSIZE_MAX (0x7fffffff)
 
+#ifndef MP_PLAT_DEFAULT_HEAP_SYS_RESERVE
+// Try to keep some heap free for ESP-IDF system, unless Python is completely out of memory
+//
+// The default here is particularly high, because it's enough memory to initialise Wi-Fi and
+// create a TLS connection. If the program is not using these things, or if the heap doesn't
+// grow until after those things are created, then this will fragment memory more than needed.
+#define MP_PLAT_DEFAULT_HEAP_SYS_RESERVE (80 * 1024)
+#endif
+
 #if MICROPY_PY_SOCKET_EVENTS
 #define MICROPY_PY_SOCKET_EVENTS_HANDLER extern void socket_events_handler(void); socket_events_handler();
 #else

--- a/py/gc.h
+++ b/py/gc.h
@@ -40,6 +40,10 @@ void gc_add(void *start, void *end);
 // Port must implement this function to return the maximum available block of
 // RAM to allocate a new heap area into using MP_PLAT_ALLOC_HEAP.
 size_t gc_get_max_new_split(void);
+// This function returns the total amount of free RAM available for heap.
+size_t gc_get_total_free(void);
+// Runtime tuneable "soft" limit for free system heap
+extern size_t gc_heap_sys_reserve;
 #endif // MICROPY_GC_SPLIT_HEAP_AUTO
 #endif // MICROPY_GC_SPLIT_HEAP
 

--- a/py/modmicropython.c
+++ b/py/modmicropython.c
@@ -144,6 +144,20 @@ STATIC MP_DEFINE_CONST_FUN_OBJ_0(mp_micropython_heap_locked_obj, mp_micropython_
 #endif
 #endif
 
+#if MICROPY_GC_SPLIT_HEAP_AUTO
+STATIC mp_obj_t mp_micropython_heap_sys_reserve(size_t n_args, const mp_obj_t *args) {
+    if (n_args > 0) {
+        mp_int_t new = mp_obj_get_int(args[0]);
+        if (new < 0) {
+            mp_raise_ValueError(NULL);
+        }
+        gc_heap_sys_reserve = new;
+    }
+    return mp_obj_new_int(gc_heap_sys_reserve);
+}
+STATIC MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(mp_micropython_heap_sys_reserve_obj, 0, 1, mp_micropython_heap_sys_reserve);
+#endif
+
 #if MICROPY_ENABLE_EMERGENCY_EXCEPTION_BUF && (MICROPY_EMERGENCY_EXCEPTION_BUF_SIZE == 0)
 STATIC MP_DEFINE_CONST_FUN_OBJ_1(mp_alloc_emergency_exception_buf_obj, mp_alloc_emergency_exception_buf);
 #endif
@@ -195,6 +209,9 @@ STATIC const mp_rom_map_elem_t mp_module_micropython_globals_table[] = {
     { MP_ROM_QSTR(MP_QSTR_heap_unlock), MP_ROM_PTR(&mp_micropython_heap_unlock_obj) },
     #if MICROPY_PY_MICROPYTHON_HEAP_LOCKED
     { MP_ROM_QSTR(MP_QSTR_heap_locked), MP_ROM_PTR(&mp_micropython_heap_locked_obj) },
+    #endif
+    #if MICROPY_GC_SPLIT_HEAP_AUTO
+    { MP_ROM_QSTR(MP_QSTR_heap_sys_reserve), MP_ROM_PTR(&mp_micropython_heap_sys_reserve_obj) },
     #endif
     #endif
     #if MICROPY_KBD_EXCEPTION


### PR DESCRIPTION
Previously the "auto split" function (added in #12141) would try to "greedily" double the heap size each time, and only tries to grow by a smaller increment if it would be not possible to allocate the memory.

Greedily growing the heap like this reduces the chance of Python fragmentation, but increases the chance of prematurely running out of system heap (even when there's quite a lot of Python heap free.)

This adds a new function `micropython.heap_sys_reserve()` and a port-specific macro, `MP_PLAT_DEFAULT_HEAP_SYS_RESERVE`. This is the amount of total system heap to *try* and keep free, and a function `gc_get_total_free()` to get the total free system heap. These are added on esp32, as this is the only port that enables "auto split" by default.

---

On original ESP32 without PSRAM, I've been [running this test program](https://gist.github.com/projectgus/51b35be90c87a849ae467e5476db5bf7) that first allocates around 60,000 bytes of Python data (in small chunks), then initializes ESP32 Wi-Fi STA mode, and then creates as many concurrent TLS connections as it can.

* MicroPython commit d325ee45 (last commit before auto-split), the Python total heap size is 108032 (constant) and one TLS socket can be created before ESP-IDF system heap runs out.
* Current master branch, the Python total heap size grows from 64000 to 128000 bytes. Zero TLS sockets can be created after the heap size grows.
* Previous version of this PR ("don't greedily take more than 75% of free system heap"), the pattern is actually the same as current master: heap size grows to 128000 bytes, zero TLS sockets can be created after this.
* Current version of this PR, with default 80KB `heap_sys_reserve` for the system heap, the Python total heap size grows from 64000 to 111168 bytes. One TLS socket can be created.
* Calling `micropython.heap_sys_reserve(100000)` at the beginning allows two TLS sockets to be created. The Python total heap size grows from 64000 to 75712 bytes. Setting the value higher doesn't improve this further (limited by actual RAM requirements.)

So , this seems promising but the side effects may be a little unpredictable, still:

* The Python heap will still grow into the "reserved" space if it has to, but that memory may be more fragmented than before due to the new "conservative" growing strategy that's only adding the minimum necessary each time.
* If Wi-Fi is enabled or large system memory allocations like TLS happen *before* the Python heap grows (including over a soft reset) then it will unnecessarily grow the Python heap conservatively, as the heaviest memory use has already happened but it doesn't "know" this. However it seems like most often the heap growth happens the other way around.

---

I've experimented with this version a little bit and it seems to perform well, but I'm not 100% sure. Anyone who is experiencing issues running out of system heap and wants to test it, please report back if it helps you.

*This work was funded through GitHub Sponsors.*