### PR TITLE
ports/stm32: Add missing header include for debug build.

### DIFF
--- a/ports/stm32/i2c.c
+++ b/ports/stm32/i2c.c
@@ -24,6 +24,7 @@
  * THE SOFTWARE.
  */
 
+#include <string.h>
 #include "py/mperrno.h"
 #include "py/mphal.h"
 #include "py/runtime.h"

--- a/ports/stm32/machine_i2s.c
+++ b/ports/stm32/machine_i2s.c
@@ -29,6 +29,7 @@
 // extmod/machine_i2s.c via MICROPY_PY_MACHINE_I2S_INCLUDEFILE.
 
 #include <stdlib.h>
+#include <string.h>
 #include "py/mphal.h"
 #include "pin.h"
 #include "dma.h"

--- a/ports/stm32/pin_static_af.h
+++ b/ports/stm32/pin_static_af.h
@@ -26,6 +26,9 @@
 #ifndef MICROPY_INCLUDED_STM32_PIN_STATIC_AF_H
 #define MICROPY_INCLUDED_STM32_PIN_STATIC_AF_H
 
+// For debug builds some of the macros expand to use strcmp.
+#include <string.h>
+
 #include "py/mphal.h"
 #include "genhdr/pins.h"
 #include "genhdr/pins_af_defs.h"

--- a/ports/stm32/spi.c
+++ b/ports/stm32/spi.c
@@ -24,6 +24,7 @@
  * THE SOFTWARE.
  */
 
+#include <string.h>
 #include "py/runtime.h"
 #include "py/mperrno.h"
 #include "py/mphal.h"


### PR DESCRIPTION
With newer gcc toolchains (10 or higher) debug build fails if this this header is not included.