### PR TITLE
ci: Improve esp32 port build times

### DIFF
--- a/.github/workflows/ports_esp32.yml
+++ b/.github/workflows/ports_esp32.yml
@@ -22,7 +22,15 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  build_idf50:
+  build_idf:
+    strategy:
+      fail-fast: false
+      matrix:
+        board:
+          - ""  # builds CI-only test configuration
+          - ESP32_GENERIC_C3
+          - ESP32_GENERIC_S2
+          - ESP32_GENERIC_S3
     runs-on: ubuntu-20.04
     steps:
     - uses: actions/checkout@v4
@@ -43,4 +51,4 @@ jobs:
       run: source tools/ci.sh && ci_esp32_idf50_setup
 
     - name: Build
-      run: source tools/ci.sh && ci_esp32_build
+      run: source tools/ci.sh && ci_esp32_build "${{ matrix.board }}"

--- a/.github/workflows/ports_esp32.yml
+++ b/.github/workflows/ports_esp32.yml
@@ -1,5 +1,9 @@
 name: esp32 port
 
+env:
+  # GitHub tag of ESP-IDF to use for CI (note: must be a tag or a branch)
+  IDF_VER: v5.0.2
+
 on:
   push:
   pull_request:
@@ -22,7 +26,21 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
     - uses: actions/checkout@v4
-    - name: Install packages
+
+    - name: Cached ESP-IDF install
+      id: cache-esp-idf
+      uses: actions/cache@v3
+      with:
+        path: |
+          ./esp-idf/
+          ~/.espressif/
+          !~/.espressif/dist/
+          ~/.cache/pip/
+        key: esp-idf-${{ env.IDF_VER }}
+
+    - name: Install ESP-IDF packages
+      if: steps.cache-esp-idf.outputs.cache-hit != 'true'
       run: source tools/ci.sh && ci_esp32_idf50_setup
+
     - name: Build
       run: source tools/ci.sh && ci_esp32_build

--- a/tools/ci.sh
+++ b/tools/ci.sh
@@ -127,19 +127,24 @@ function ci_esp32_idf50_setup {
     ./esp-idf/install.sh
 }
 
-function ci_esp32_build {
+function ci_esp32_build {  # arg: board name or ""
     source esp-idf/export.sh
     make ${MAKEOPTS} -C mpy-cross
     make ${MAKEOPTS} -C ports/esp32 submodules
-    make ${MAKEOPTS} -C ports/esp32 \
-        USER_C_MODULES=../../../examples/usercmodule/micropython.cmake \
-        FROZEN_MANIFEST=$(pwd)/ports/esp32/boards/manifest_test.py
-    make ${MAKEOPTS} -C ports/esp32 BOARD=ESP32_GENERIC_C3
-    make ${MAKEOPTS} -C ports/esp32 BOARD=ESP32_GENERIC_S2
-    make ${MAKEOPTS} -C ports/esp32 BOARD=ESP32_GENERIC_S3
+    if [ -z "$1" ]; then
+        echo "Building test configuration..."
+        make ${MAKEOPTS} -C ports/esp32 \
+             USER_C_MODULES=../../../examples/usercmodule/micropython.cmake \
+             FROZEN_MANIFEST=$(pwd)/ports/esp32/boards/manifest_test.py
 
-    # Test building native .mpy with xtensawin architecture.
-    ci_native_mpy_modules_build xtensawin
+        # Test building native .mpy with xtensawin architecture.
+        echo "Testing native .mpy with xtensawin..."
+        ci_native_mpy_modules_build xtensawin
+    else
+        export BOARD="$1"
+        echo "Building for board ${BOARD}..."
+        make ${MAKEOPTS} -C ports/esp32
+    fi
 }
 
 ########################################################################################

--- a/tools/ci.sh
+++ b/tools/ci.sh
@@ -120,8 +120,10 @@ function ci_cc3200_build {
 
 function ci_esp32_idf50_setup {
     pip3 install pyelftools
-    git clone https://github.com/espressif/esp-idf.git
-    git -C esp-idf checkout v5.0.2
+    git clone --depth 1 --branch $IDF_VER https://github.com/espressif/esp-idf.git
+    # doing a treeless clone isn't quite as good as --shallow-submodules, but it
+    # is smaller than full clones and works when the submodule commit isn't a head.
+    git -C esp-idf submodule update --init --recursive --filter=tree:0
     ./esp-idf/install.sh
 }
 


### PR DESCRIPTION
Currently `port_esp32` build job is taking 7-8 minutes in most CI runs, the slowest part of CI.

This PR makes two changes to improve performance:

1. Cache the ESP-IDF checkout (including all submodules) and the ESP-IDF tools install. Cache is keyed per ESP-IDF version, and the cache action also scopes to each branch (although the default branch cache is available to other branches.) These steps take a little over 1 minute to run on cache miss, but restoring from a cache hit takes approx 15 seconds.
2. Use GitHub Actions build matrix to build each board separately. With a warm cache each build now takes 2-3 minutes.

Best case, with a warm cache and if all the per-board jobs run in parallel, entire `port_esp32` build job should take less than 3 minutes.

With a cold cache a fully parallel build is about 4m30s.

The worst-case for both of these will be slower if not all jobs can run in parallel.