### PR TITLE
ci: Enable caching for esp32 port builds, split into multiple jobs

### DIFF
--- a/.github/workflows/ports_esp32.yml
+++ b/.github/workflows/ports_esp32.yml
@@ -22,7 +22,25 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
     - uses: actions/checkout@v4
-    - name: Install packages
-      run: source tools/ci.sh && ci_esp32_idf50_setup
+
+    - id: idf_ver
+      name: Read the ESP-IDF version
+      run: source tools/ci.sh && echo "IDF_VER=$IDF_VER" | tee "$GITHUB_OUTPUT"
+
+    - name: Cached ESP-IDF install
+      id: cache_esp_idf
+      uses: actions/cache@v3
+      with:
+        path: |
+          ./esp-idf/
+          ~/.espressif/
+          !~/.espressif/dist/
+          ~/.cache/pip/
+        key: esp-idf-${{ steps.idf_ver.outputs.IDF_VER }}
+
+    - name: Install ESP-IDF packages
+      if: steps.cache_esp_idf.outputs.cache-hit != 'true'
+      run: source tools/ci.sh && ci_esp32_idf_setup
+
     - name: Build
       run: source tools/ci.sh && ci_esp32_build

--- a/.github/workflows/ports_esp32.yml
+++ b/.github/workflows/ports_esp32.yml
@@ -18,7 +18,13 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  build_idf50:
+  build_idf:
+    strategy:
+      fail-fast: false
+      matrix:
+        ci_func:  # names are functions in ci.sh
+          - esp32_build_cmod_s2
+          - esp32_build_s3_c3
     runs-on: ubuntu-20.04
     steps:
     - uses: actions/checkout@v4
@@ -42,5 +48,5 @@ jobs:
       if: steps.cache_esp_idf.outputs.cache-hit != 'true'
       run: source tools/ci.sh && ci_esp32_idf_setup
 
-    - name: Build
-      run: source tools/ci.sh && ci_esp32_build
+    - name: Build ci_${{matrix.ci_func }}
+      run: source tools/ci.sh && ci_${{ matrix.ci_func }}

--- a/.github/workflows/ports_esp32.yml
+++ b/.github/workflows/ports_esp32.yml
@@ -48,5 +48,10 @@ jobs:
       if: steps.cache_esp_idf.outputs.cache-hit != 'true'
       run: source tools/ci.sh && ci_esp32_idf_setup
 
+    - name: ccache
+      uses: hendrikmuhs/ccache-action@v1.2
+      with:
+        key: esp32-${{ matrix.ci_func }}
+
     - name: Build ci_${{matrix.ci_func }}
       run: source tools/ci.sh && ci_${{ matrix.ci_func }}

--- a/.github/workflows/ports_stm32.yml
+++ b/.github/workflows/ports_stm32.yml
@@ -18,20 +18,18 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  build_pyb:
+  build_stm32:
+    strategy:
+      fail-fast: false
+      matrix:
+        ci_func:  # names are functions in ci.sh
+          - stm32_pyb_build
+          - stm32_nucleo_build
     runs-on: ubuntu-20.04
     steps:
     - uses: actions/checkout@v4
     - name: Install packages
       run: source tools/ci.sh && ci_stm32_setup
-    - name: Build
-      run: source tools/ci.sh && ci_stm32_pyb_build
+    - name: Build ci_${{matrix.ci_func }}
+      run: source tools/ci.sh && ci_${{ matrix.ci_func }}
 
-  build_nucleo:
-    runs-on: ubuntu-20.04
-    steps:
-    - uses: actions/checkout@v4
-    - name: Install packages
-      run: source tools/ci.sh && ci_stm32_setup
-    - name: Build
-      run: source tools/ci.sh && ci_stm32_nucleo_build

--- a/tools/ci.sh
+++ b/tools/ci.sh
@@ -121,6 +121,8 @@ function ci_cc3200_build {
 # GitHub tag of ESP-IDF to use for CI (note: must be a tag or a branch)
 IDF_VER=v5.0.2
 
+export IDF_CCACHE_ENABLE=1
+
 function ci_esp32_idf_setup {
     pip3 install pyelftools
     git clone --depth 1 --branch $IDF_VER https://github.com/espressif/esp-idf.git

--- a/tools/ci.sh
+++ b/tools/ci.sh
@@ -130,19 +130,30 @@ function ci_esp32_idf_setup {
     ./esp-idf/install.sh
 }
 
-function ci_esp32_build {
+function ci_esp32_build_common {
     source esp-idf/export.sh
     make ${MAKEOPTS} -C mpy-cross
     make ${MAKEOPTS} -C ports/esp32 submodules
+}
+
+function ci_esp32_build_cmod_s2 {
+    ci_esp32_build_common
+
     make ${MAKEOPTS} -C ports/esp32 \
         USER_C_MODULES=../../../examples/usercmodule/micropython.cmake \
         FROZEN_MANIFEST=$(pwd)/ports/esp32/boards/manifest_test.py
-    make ${MAKEOPTS} -C ports/esp32 BOARD=ESP32_GENERIC_C3
-    make ${MAKEOPTS} -C ports/esp32 BOARD=ESP32_GENERIC_S2
-    make ${MAKEOPTS} -C ports/esp32 BOARD=ESP32_GENERIC_S3
 
     # Test building native .mpy with xtensawin architecture.
     ci_native_mpy_modules_build xtensawin
+
+    make ${MAKEOPTS} -C ports/esp32 BOARD=ESP32_GENERIC_S2
+}
+
+function ci_esp32_build_s3_c3 {
+    ci_esp32_build_common
+
+    make ${MAKEOPTS} -C ports/esp32 BOARD=ESP32_GENERIC_S3
+    make ${MAKEOPTS} -C ports/esp32 BOARD=ESP32_GENERIC_C3
 }
 
 ########################################################################################

--- a/tools/ci.sh
+++ b/tools/ci.sh
@@ -118,10 +118,15 @@ function ci_cc3200_build {
 ########################################################################################
 # ports/esp32
 
-function ci_esp32_idf50_setup {
+# GitHub tag of ESP-IDF to use for CI (note: must be a tag or a branch)
+IDF_VER=v5.0.2
+
+function ci_esp32_idf_setup {
     pip3 install pyelftools
-    git clone https://github.com/espressif/esp-idf.git
-    git -C esp-idf checkout v5.0.2
+    git clone --depth 1 --branch $IDF_VER https://github.com/espressif/esp-idf.git
+    # doing a treeless clone isn't quite as good as --shallow-submodules, but it
+    # is smaller than full clones and works when the submodule commit isn't a head.
+    git -C esp-idf submodule update --init --recursive --filter=tree:0
     ./esp-idf/install.sh
 }
 


### PR DESCRIPTION
Changes to improve performance of esp32 build (previously sitting at 7-8 minutes per run, slowest CI step along with Zephyr.)

1. Cache the ESP-IDF checkout (including all submodules) and the ESP-IDF tools install. Cache is keyed per ESP-IDF version, and the cache action also scopes to each branch (although the default branch cache is available to other branches.) These steps take a little over 1 minute to run on cache miss, but restoring from a cache hit takes approx 15 seconds.
2. Use GitHub Actions build matrix to parameterise which function in ci.sh should be run. This allows splitting up the build steps with minimum copy-paste of boilerplate. With a warm IDF cache the current build jobs each takes around 3 minutes, and will usually run in parallel.
3. Enable [ccache](https://ccache.dev/) for ESP-IDF builds, using hendrikmuhs' [ccache action](https://github.com/hendrikmuhs/ccache-action/) because the cache should be refreshed after each build, the built-in cache action isn't quite enough. A warm ccache, this saves an extra ~40-60 seconds per MicroPython build (i.e. 80-120 seconds per job.) For example see [this job](https://github.com/micropython/micropython/actions/runs/7094430432/job/19309688449?pr=13090), finished in 1m30s.

There is also a commit here to change stm32 build to use the build matrix, for consistency with esp32 rather than because it significantly reduces reduces copy/paste.