### PR TITLE
core,rp2,esp8266,windows, unix: Add new cross-port functions for event waiting and handling.

### DIFF
--- a/drivers/cyw43/cywbt.c
+++ b/drivers/cyw43/cywbt.c
@@ -68,7 +68,7 @@ STATIC int cywbt_hci_cmd_raw(size_t len, uint8_t *buf) {
     mp_bluetooth_hci_uart_write((void *)buf, len);
     for (int c, i = 0; i < 6; ++i) {
         while ((c = mp_bluetooth_hci_uart_readchar()) == -1) {
-            MICROPY_EVENT_POLL_HOOK
+            mp_event_wait_indefinite();
         }
         buf[i] = c;
     }
@@ -88,7 +88,7 @@ STATIC int cywbt_hci_cmd_raw(size_t len, uint8_t *buf) {
     int sz = buf[2] - 3;
     for (int c, i = 0; i < sz; ++i) {
         while ((c = mp_bluetooth_hci_uart_readchar()) == -1) {
-            MICROPY_EVENT_POLL_HOOK
+            mp_event_wait_indefinite();
         }
         buf[i] = c;
     }

--- a/drivers/ninaw10/nina_bt_hci.c
+++ b/drivers/ninaw10/nina_bt_hci.c
@@ -75,12 +75,13 @@ static int nina_hci_cmd(int ogf, int ocf, size_t param_len, const uint8_t *param
     // Receive HCI event packet, initially reading 3 bytes (HCI Event, Event code, Plen).
     for (mp_uint_t start = mp_hal_ticks_ms(), size = 3, i = 0; i < size;) {
         while (!mp_bluetooth_hci_uart_any()) {
-            MICROPY_EVENT_POLL_HOOK
+            mp_uint_t elapsed = mp_hal_ticks_ms() - start;
             // Timeout.
-            if ((mp_hal_ticks_ms() - start) > HCI_COMMAND_TIMEOUT) {
+            if (elapsed > HCI_COMMAND_TIMEOUT) {
                 error_printf("timeout waiting for HCI packet\n");
                 return -1;
             }
+            mp_event_wait_ms(HCI_COMMAND_TIMEOUT - elapsed);
         }
 
         buf[i] = mp_bluetooth_hci_uart_readchar();

--- a/extmod/btstack/modbluetooth_btstack.c
+++ b/extmod/btstack/modbluetooth_btstack.c
@@ -552,7 +552,7 @@ STATIC void set_random_address(void) {
         volatile bool ready = false;
         btstack_crypto_random_generate(&sm_crypto_random_request, static_addr, 6, &btstack_static_address_ready, (void *)&ready);
         while (!ready) {
-            MICROPY_EVENT_POLL_HOOK
+            mp_event_wait_indefinite();
         }
 
         #endif // MICROPY_BLUETOOTH_USE_MP_HAL_GET_MAC_STATIC_ADDRESS
@@ -574,7 +574,7 @@ STATIC void set_random_address(void) {
             break;
         }
 
-        MICROPY_EVENT_POLL_HOOK
+        mp_event_wait_indefinite();
     }
     DEBUG_printf("set_random_address: Address loaded by controller\n");
 }
@@ -654,7 +654,7 @@ int mp_bluetooth_init(void) {
     // Either the HCI event will set state to ACTIVE, or the timeout will set it to TIMEOUT.
     mp_bluetooth_btstack_port_start();
     while (mp_bluetooth_btstack_state == MP_BLUETOOTH_BTSTACK_STATE_STARTING) {
-        MICROPY_EVENT_POLL_HOOK
+        mp_event_wait_indefinite();
     }
     btstack_run_loop_remove_timer(&btstack_init_deinit_timeout);
 
@@ -727,7 +727,7 @@ void mp_bluetooth_deinit(void) {
     // either timeout or clean shutdown.
     mp_bluetooth_btstack_port_deinit();
     while (mp_bluetooth_btstack_state == MP_BLUETOOTH_BTSTACK_STATE_ACTIVE) {
-        MICROPY_EVENT_POLL_HOOK
+        mp_event_wait_indefinite();
     }
     btstack_run_loop_remove_timer(&btstack_init_deinit_timeout);
 

--- a/extmod/machine_i2c.c
+++ b/extmod/machine_i2c.c
@@ -331,11 +331,7 @@ STATIC mp_obj_t machine_i2c_scan(mp_obj_t self_in) {
         // This scan loop may run for some time, so process any pending events/exceptions,
         // or allow the port to run any necessary background tasks.  But do it as fast as
         // possible, in particular we are not waiting on any events.
-        #if defined(MICROPY_EVENT_POLL_HOOK_FAST)
-        MICROPY_EVENT_POLL_HOOK_FAST;
-        #elif defined(MICROPY_EVENT_POLL_HOOK)
-        MICROPY_EVENT_POLL_HOOK
-        #endif
+        mp_event_handle_nowait();
     }
     return list;
 }

--- a/extmod/modlwip.c
+++ b/extmod/modlwip.c
@@ -318,11 +318,7 @@ typedef struct _lwip_socket_obj_t {
 } lwip_socket_obj_t;
 
 static inline void poll_sockets(void) {
-    #ifdef MICROPY_EVENT_POLL_HOOK
-    MICROPY_EVENT_POLL_HOOK;
-    #else
-    mp_hal_delay_ms(1);
-    #endif
+    mp_event_wait_ms(1);
 }
 
 STATIC struct tcp_pcb *volatile *lwip_socket_incoming_array(lwip_socket_obj_t *socket) {

--- a/extmod/modssl_mbedtls.c
+++ b/extmod/modssl_mbedtls.c
@@ -391,9 +391,7 @@ STATIC mp_obj_t ssl_socket_make_new(mp_obj_ssl_context_t *ssl_context, mp_obj_t 
             if (ret != MBEDTLS_ERR_SSL_WANT_READ && ret != MBEDTLS_ERR_SSL_WANT_WRITE) {
                 goto cleanup;
             }
-            #ifdef MICROPY_EVENT_POLL_HOOK
-            MICROPY_EVENT_POLL_HOOK
-            #endif
+            mp_event_wait_ms(1);
         }
     }
 

--- a/extmod/network_cyw43.c
+++ b/extmod/network_cyw43.c
@@ -222,8 +222,13 @@ STATIC mp_obj_t network_cyw43_scan(size_t n_args, const mp_obj_t *pos_args, mp_m
 
     // Wait for scan to finish, with a 10s timeout
     uint32_t start = mp_hal_ticks_ms();
-    while (cyw43_wifi_scan_active(self->cyw) && mp_hal_ticks_ms() - start < 10000) {
-        MICROPY_EVENT_POLL_HOOK
+    const uint32_t TIMEOUT = 10000;
+    while (cyw43_wifi_scan_active(self->cyw)) {
+        uint32_t elapsed = mp_hal_ticks_ms() - start;
+        if (elapsed >= TIMEOUT) {
+            break;
+        }
+        mp_event_wait_ms(TIMEOUT - elapsed);
     }
 
     return res;

--- a/extmod/nimble/modbluetooth_nimble.c
+++ b/extmod/nimble/modbluetooth_nimble.c
@@ -570,7 +570,7 @@ void mp_bluetooth_nimble_port_shutdown(void) {
     ble_hs_stop(&ble_hs_shutdown_stop_listener, ble_hs_shutdown_stop_cb, NULL);
 
     while (mp_bluetooth_nimble_ble_state != MP_BLUETOOTH_NIMBLE_BLE_STATE_OFF) {
-        MICROPY_EVENT_POLL_HOOK
+        mp_event_wait_indefinite();
     }
 }
 
@@ -636,10 +636,11 @@ int mp_bluetooth_init(void) {
     // On non-ringbuffer builds (NimBLE on STM32/Unix) this will also poll the UART and run the event queue.
     mp_uint_t timeout_start_ticks_ms = mp_hal_ticks_ms();
     while (mp_bluetooth_nimble_ble_state != MP_BLUETOOTH_NIMBLE_BLE_STATE_ACTIVE) {
-        if (mp_hal_ticks_ms() - timeout_start_ticks_ms > NIMBLE_STARTUP_TIMEOUT) {
+        uint32_t elapsed = mp_hal_ticks_ms() - timeout_start_ticks_ms;
+        if (elapsed > NIMBLE_STARTUP_TIMEOUT) {
             break;
         }
-        MICROPY_EVENT_POLL_HOOK
+        mp_event_wait_ms(NIMBLE_STARTUP_TIMEOUT - elapsed);
     }
 
     if (mp_bluetooth_nimble_ble_state != MP_BLUETOOTH_NIMBLE_BLE_STATE_ACTIVE) {

--- a/ports/esp8266/esp_mphal.c
+++ b/ports/esp8266/esp_mphal.c
@@ -53,7 +53,7 @@ void mp_hal_init(void) {
 void MP_FASTCODE(mp_hal_delay_us)(uint32_t us) {
     uint32_t start = system_get_time();
     while (system_get_time() - start < us) {
-        ets_event_poll();
+        mp_event_handle_nowait();
     }
 }
 
@@ -120,11 +120,6 @@ void MP_FASTCODE(mp_hal_delay_ms)(uint32_t delay) {
 
 uint64_t mp_hal_time_ns(void) {
     return pyb_rtc_get_us_since_epoch() * 1000ULL;
-}
-
-void ets_event_poll(void) {
-    ets_loop_iter();
-    mp_handle_pending(true);
 }
 
 void __assert_func(const char *file, int line, const char *func, const char *expr) {

--- a/ports/esp8266/esp_mphal.h
+++ b/ports/esp8266/esp_mphal.h
@@ -72,9 +72,6 @@ void dupterm_task_init();
 uint32_t esp_disable_irq(void);
 void esp_enable_irq(uint32_t state);
 
-void ets_event_poll(void);
-#define ETS_POLL_WHILE(cond) { while (cond) ets_event_poll(); }
-
 // needed for machine.I2C
 #include "osapi.h"
 #define mp_hal_delay_us_fast(us) os_delay_us(us)

--- a/ports/esp8266/machine_uart.c
+++ b/ports/esp8266/machine_uart.c
@@ -300,7 +300,7 @@ STATIC mp_uint_t mp_machine_uart_ioctl(mp_obj_t self_in, mp_uint_t request, uint
             if (mp_machine_uart_txdone(self)) {
                 return 0;
             }
-            MICROPY_EVENT_POLL_HOOK
+            mp_event_wait_ms(1);
         } while (system_get_time() < timeout);
 
         *errcode = MP_ETIMEDOUT;

--- a/ports/esp8266/modespnow.c
+++ b/ports/esp8266/modespnow.c
@@ -285,7 +285,7 @@ static int ringbuf_get_bytes_wait(ringbuf_t *r, uint8_t *data, size_t len, mp_in
     int status = 0;
     while (((status = ringbuf_get_bytes(r, data, len)) == -1)
            && (timeout_ms < 0 || (mp_uint_t)(mp_hal_ticks_ms() - start) < (mp_uint_t)timeout_ms)) {
-        MICROPY_EVENT_POLL_HOOK;
+        mp_event_wait_ms(1);
     }
     return status;
 }

--- a/ports/esp8266/modmachine.c
+++ b/ports/esp8266/modmachine.c
@@ -91,7 +91,7 @@ STATIC mp_obj_t mp_machine_unique_id(void) {
 
 STATIC void mp_machine_idle(void) {
     asm ("waiti 0");
-    ets_event_poll(); // handle any events after possibly a long wait (eg feed WDT)
+    mp_event_handle_nowait(); // handle any events after possibly a long wait (eg feed WDT)
 }
 
 STATIC void mp_machine_lightsleep(size_t n_args, const mp_obj_t *args) {
@@ -106,7 +106,7 @@ STATIC void mp_machine_lightsleep(size_t n_args, const mp_obj_t *args) {
     uint32_t wifi_mode = wifi_get_opmode();
     uint32_t start = system_get_time();
     while (system_get_time() - start <= max_us) {
-        ets_event_poll();
+        mp_event_handle_nowait();
         if (wifi_mode == NULL_MODE) {
             // Can only idle if the wifi is off
             asm ("waiti 0");

--- a/ports/esp8266/uart.c
+++ b/ports/esp8266/uart.c
@@ -18,6 +18,7 @@
 #include "c_types.h"
 #include "user_interface.h"
 #include "py/mphal.h"
+#include "py/runtime.h"
 
 // seems that this is missing in the Espressif SDK
 #define FUNC_U0RXD 0
@@ -218,7 +219,7 @@ bool ICACHE_FLASH_ATTR uart_rx_wait(uint32_t timeout_us) {
         if (system_get_time() - start >= timeout_us) {
             return false; // timeout
         }
-        ets_event_poll();
+        mp_event_handle_nowait();
     }
 }
 

--- a/ports/rp2/cyw43_configport.h
+++ b/ports/rp2/cyw43_configport.h
@@ -30,6 +30,7 @@
 #include "py/mpconfig.h"
 #include "py/mperrno.h"
 #include "py/mphal.h"
+#include "py/runtime.h"
 #include "extmod/modnetwork.h"
 #include "pendsv.h"
 
@@ -119,6 +120,6 @@ static inline void cyw43_delay_ms(uint32_t ms) {
     mp_hal_delay_ms(ms);
 }
 
-#define CYW43_EVENT_POLL_HOOK MICROPY_EVENT_POLL_HOOK_FAST
+#define CYW43_EVENT_POLL_HOOK mp_event_handle_nowait()
 
 #endif // MICROPY_INCLUDED_RP2_CYW43_CONFIGPORT_H

--- a/ports/rp2/main.c
+++ b/ports/rp2/main.c
@@ -73,6 +73,9 @@ bi_decl(bi_program_feature_group_with_flags(BINARY_INFO_TAG_MICROPYTHON,
     BI_NAMED_GROUP_SEPARATE_COMMAS | BI_NAMED_GROUP_SORT_ALPHA));
 
 int main(int argc, char **argv) {
+    // This is a tickless port, interrupts should always trigger SEV.
+    SCB->SCR |= SCB_SCR_SEVONPEND_Msk;
+
     #if MICROPY_HW_ENABLE_UART_REPL
     bi_decl(bi_program_feature("UART REPL"))
     setup_default_uart();

--- a/ports/rp2/mpconfigport.h
+++ b/ports/rp2/mpconfigport.h
@@ -249,17 +249,18 @@ extern const struct _mp_obj_type_t mod_network_nic_type_wiznet5k;
 #define MICROPY_PY_LWIP_REENTER lwip_lock_acquire();
 #define MICROPY_PY_LWIP_EXIT    lwip_lock_release();
 
-#define MICROPY_EVENT_POLL_HOOK_FAST \
-    do { \
-        extern void mp_handle_pending(bool); \
-        mp_handle_pending(true); \
+// Port level Wait-for-Event macro
+//
+// Do not use this macro directly, include py/runtime.h and
+// call mp_event_wait_indefinite() or mp_event_wait_ms(timeout)
+#define MICROPY_INTERNAL_WFE(TIMEOUT_MS) \
+    do {                                 \
+        if ((TIMEOUT_MS) < 0) { \
+            __wfe(); \
+        } else { \
+            best_effort_wfe_or_timeout(make_timeout_time_ms(TIMEOUT_MS)); \
+        } \
     } while (0)
-
-#define MICROPY_EVENT_POLL_HOOK \
-    do { \
-        MICROPY_EVENT_POLL_HOOK_FAST; \
-        __wfe(); \
-    } while (0);
 
 #define MICROPY_MAKE_POINTER_CALLABLE(p) ((void *)((mp_uint_t)(p) | 1))
 

--- a/ports/rp2/rp2_flash.c
+++ b/ports/rp2/rp2_flash.c
@@ -121,11 +121,10 @@ STATIC mp_obj_t rp2_flash_readblocks(size_t n_args, const mp_obj_t *args) {
         offset += mp_obj_get_int(args[3]);
     }
     memcpy(bufinfo.buf, (void *)(XIP_BASE + self->flash_base + offset), bufinfo.len);
-    // MICROPY_EVENT_POLL_HOOK_FAST is called here to avoid a fail in registering
+    // mp_event_handle_nowait() is called here to avoid a fail in registering
     // USB at boot time, if the board is busy loading files or scanning the file
-    // system. MICROPY_EVENT_POLL_HOOK_FAST calls tud_task(). As the alternative
-    // tud_task() should be called in the USB IRQ. See discussion in PR #10423.
-    MICROPY_EVENT_POLL_HOOK_FAST;
+    // system. mp_event_handle_nowait() will call the TinyUSB task if needed.
+    mp_event_handle_nowait();
     return mp_const_none;
 }
 STATIC MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(rp2_flash_readblocks_obj, 3, 4, rp2_flash_readblocks);
@@ -140,7 +139,7 @@ STATIC mp_obj_t rp2_flash_writeblocks(size_t n_args, const mp_obj_t *args) {
         mp_uint_t atomic_state = MICROPY_BEGIN_ATOMIC_SECTION();
         flash_range_erase(self->flash_base + offset, bufinfo.len);
         MICROPY_END_ATOMIC_SECTION(atomic_state);
-        MICROPY_EVENT_POLL_HOOK_FAST;
+        mp_event_handle_nowait();
         // TODO check return value
     } else {
         offset += mp_obj_get_int(args[3]);
@@ -149,7 +148,7 @@ STATIC mp_obj_t rp2_flash_writeblocks(size_t n_args, const mp_obj_t *args) {
     mp_uint_t atomic_state = MICROPY_BEGIN_ATOMIC_SECTION();
     flash_range_program(self->flash_base + offset, bufinfo.buf, bufinfo.len);
     MICROPY_END_ATOMIC_SECTION(atomic_state);
-    MICROPY_EVENT_POLL_HOOK_FAST;
+    mp_event_handle_nowait();
     // TODO check return value
     return mp_const_none;
 }

--- a/ports/rp2/rp2_pio.c
+++ b/ports/rp2/rp2_pio.c
@@ -729,7 +729,7 @@ STATIC mp_obj_t rp2_state_machine_get(size_t n_args, const mp_obj_t *args) {
     for (;;) {
         while (pio_sm_is_rx_fifo_empty(self->pio, self->sm)) {
             // This delay must be fast.
-            MICROPY_EVENT_POLL_HOOK_FAST;
+            mp_event_handle_nowait();
         }
         uint32_t value = pio_sm_get(self->pio, self->sm) >> shift;
         if (dest == NULL) {
@@ -787,7 +787,7 @@ STATIC mp_obj_t rp2_state_machine_put(size_t n_args, const mp_obj_t *args) {
         }
         while (pio_sm_is_tx_fifo_full(self->pio, self->sm)) {
             // This delay must be fast.
-            MICROPY_EVENT_POLL_HOOK_FAST;
+            mp_event_handle_nowait();
         }
         pio_sm_put(self->pio, self->sm, value << shift);
     }

--- a/ports/unix/coverage.c
+++ b/ports/unix/coverage.c
@@ -578,9 +578,10 @@ STATIC mp_obj_t extra_coverage(void) {
         mp_sched_unlock();
         mp_printf(&mp_plat_print, "unlocked\n");
 
-        // drain pending callbacks
+        // drain pending callbacks, and test mp_event_wait_indefinite(), mp_event_wait_ms()
+        mp_event_wait_indefinite(); // the unix port only waits 500us in this call
         while (mp_sched_num_pending()) {
-            mp_handle_pending(true);
+            mp_event_wait_ms(1);
         }
 
         // setting the keyboard interrupt and raising it during mp_handle_pending

--- a/ports/unix/mpconfigport.h
+++ b/ports/unix/mpconfigport.h
@@ -222,14 +222,10 @@ static inline unsigned long mp_random_seed_init(void) {
 #endif
 
 // In lieu of a WFI(), slow down polling from being a tight loop.
-#ifndef MICROPY_EVENT_POLL_HOOK
-#define MICROPY_EVENT_POLL_HOOK \
-    do { \
-        extern void mp_handle_pending(bool); \
-        mp_handle_pending(true); \
-        usleep(500); /* equivalent to mp_hal_delay_us(500) */ \
-    } while (0);
-#endif
+//
+// Note that we don't delay for the full TIMEOUT_MS, as execution
+// can't be woken from the delay.
+#define MICROPY_INTERNAL_WFE(TIMEOUT_MS) mp_hal_delay_us(500)
 
 // Configure the implementation of machine.idle().
 #include <sched.h>

--- a/ports/unix/unix_mphal.c
+++ b/ports/unix/unix_mphal.c
@@ -237,17 +237,10 @@ uint64_t mp_hal_time_ns(void) {
 
 #ifndef mp_hal_delay_ms
 void mp_hal_delay_ms(mp_uint_t ms) {
-    #ifdef MICROPY_EVENT_POLL_HOOK
     mp_uint_t start = mp_hal_ticks_ms();
     while (mp_hal_ticks_ms() - start < ms) {
-        // MICROPY_EVENT_POLL_HOOK does usleep(500).
-        MICROPY_EVENT_POLL_HOOK
+        mp_event_wait_ms(1);
     }
-    #else
-    // TODO: POSIX et al. define usleep() as guaranteedly capable only of 1s sleep:
-    // "The useconds argument shall be less than one million."
-    usleep(ms * 1000);
-    #endif
 }
 #endif
 

--- a/ports/windows/mpconfigport.h
+++ b/ports/windows/mpconfigport.h
@@ -227,14 +227,11 @@ typedef long mp_off_t;
 #include "sleep.h"
 
 #if MICROPY_ENABLE_SCHEDULER
-// Use 1mSec sleep to make sure there is effectively a wait period:
+// Use minimum 1mSec sleep to make sure there is effectively a wait period:
 // something like usleep(500) truncates and ends up calling Sleep(0).
-#define MICROPY_EVENT_POLL_HOOK \
-    do { \
-        extern void mp_handle_pending(bool); \
-        mp_handle_pending(true); \
-        msec_sleep(1.0); \
-    } while (0);
+#define MICROPY_INTERNAL_WFE(TIMEOUT_MS) msec_sleep(MAX(1.0, (double)(TIMEOUT_MS)))
+#else
+#define MICROPY_INTERNAL_WFE(TIMEOUT_MS) /* No-op */
 #endif
 
 #ifdef __GNUC__

--- a/py/mphal.h
+++ b/py/mphal.h
@@ -98,4 +98,17 @@ uint64_t mp_hal_time_ns(void);
 #include "extmod/virtpin.h"
 #endif
 
+// Event handling and wait-for-event functions.
+
+#ifndef MICROPY_INTERNAL_WFE
+// Fallback definition for ports that don't need to suspend the CPU.
+#define MICROPY_INTERNAL_WFE(TIMEOUT_MS) (void)0
+#endif
+
+#ifndef MICROPY_INTERNAL_EVENT_HOOK
+// Fallback definition for ports that don't need any port-specific
+// non-blocking event processing.
+#define MICROPY_INTERNAL_EVENT_HOOK (void)0
+#endif
+
 #endif // MICROPY_INCLUDED_PY_MPHAL_H

--- a/py/runtime.h
+++ b/py/runtime.h
@@ -109,6 +109,23 @@ bool mp_sched_schedule(mp_obj_t function, mp_obj_t arg);
 bool mp_sched_schedule_node(mp_sched_node_t *node, mp_sched_callback_t callback);
 #endif
 
+// Handles any pending MicroPython events without waiting for an interrupt or event.
+void mp_event_handle_nowait(void);
+
+// Handles any pending MicroPython events and then suspends execution until the
+// next interrupt or event.
+//
+// Note: on "tickless" ports this can suspend execution for a long time,
+// don't call unless you know an interrupt is coming to continue execution.
+// On "ticked" ports it may return early due to the tick interrupt.
+void mp_event_wait_indefinite(void);
+
+// Handle any pending MicroPython events and then suspends execution until the
+// next interrupt or event, or until timeout_ms milliseconds have elapsed.
+//
+// On "ticked" ports it may return early due to the tick interrupt.
+void mp_event_wait_ms(mp_uint_t timeout_ms);
+
 // extra printing method specifically for mp_obj_t's which are integral type
 int mp_print_mp_int(const mp_print_t *print, mp_obj_t x, int base, int base_char, int flags, char fill, int width, int prec);
 

--- a/py/scheduler.c
+++ b/py/scheduler.c
@@ -241,3 +241,39 @@ void mp_handle_pending(bool raise_exc) {
     }
     #endif
 }
+
+// Handles any pending MicroPython events without waiting for an interrupt or event.
+void mp_event_handle_nowait(void) {
+    #if defined(MICROPY_EVENT_POLL_HOOK_FAST) && !MICROPY_PREVIEW_VERSION_2
+    // For ports still using the old macros.
+    MICROPY_EVENT_POLL_HOOK_FAST
+    #else
+    // Process any port layer (non-blocking) events.
+    MICROPY_INTERNAL_EVENT_HOOK;
+    mp_handle_pending(true);
+    #endif
+}
+
+// Handles any pending MicroPython events and then suspends execution until the
+// next interrupt or event.
+void mp_event_wait_indefinite(void) {
+    #if defined(MICROPY_EVENT_POLL_HOOK) && !MICROPY_PREVIEW_VERSION_2
+    // For ports still using the old macros.
+    MICROPY_EVENT_POLL_HOOK
+    #else
+    mp_event_handle_nowait();
+    MICROPY_INTERNAL_WFE(-1);
+    #endif
+}
+
+// Handle any pending MicroPython events and then suspends execution until the
+// next interrupt or event, or until timeout_ms milliseconds have elapsed.
+void mp_event_wait_ms(mp_uint_t timeout_ms) {
+    #if defined(MICROPY_EVENT_POLL_HOOK) && !MICROPY_PREVIEW_VERSION_2
+    // For ports still using the old macros.
+    MICROPY_EVENT_POLL_HOOK
+    #else
+    mp_event_handle_nowait();
+    MICROPY_INTERNAL_WFE(timeout_ms);
+    #endif
+}


### PR DESCRIPTION
This PR fixes #12925, which is a regression on rp2 introduced when rp2 became "tickless" in #12837.

It implements one of the [suggestions from the linked Issue](https://github.com/micropython/micropython/issues/12925#issuecomment-1803038430): to add new functions for "wait for event" and "handle events". The new functions are port-agnostic:

* `mp_event_handle_nowait()` - Handle any pending MicroPython events without waiting for an interrupt or event.
* `mp_event_wait_indefinite()` - Handle any pending MicroPython events and then suspend execution until the next interrupt or event. This function is deliberately named to attract attention when developers use it, as on tickless ports it will cause issues if the developer expects it to return without a corresponding interrupt having occurred.
* `mp_event_wait_ms(mp_uint_t timeout_ms)` - Handle any pending MicroPython events and then suspend execution until the next interrupt or event, or until timeout_ms milliseconds have elapsed.

Each port only needs to provide a `MICROPY_INTERNAL_WFE(OPTIONAL_TIMEOUT)` macro to implement the "wait for event" logic. More port-specific macros may be needed when adding other ports.

These functions are intended to eventually replace `MICROPY_EVENT_POLL_HOOK` and `MICROPY_EVENT_POLL_HOOK_FAST`, although on all ports except rp2 they are currently implemented using these macros.

This PR switches over `extmod`, `rp2` port and the built-in drivers supported by `rp2` to use the new functions, fixing the issue of indefinite sleep under some conditions.

It also switches over `esp8266`, to avoid problems where `i2c.scan()` doesn't call `ets_event_poll()` and can trigger a WDT.

Finally it switches over Windows, as this was necessary to get the same sleep behaviour with the new functions, and unix  so that the coverage tests pass on the new functions.

`rp2` port also enables [SEVONPEND](https://developer.arm.com/documentation/dui0497/a/cortex-m0-peripherals/system-control-block/system-control-register) to ensure `SEV` bit is set on each interrupt, removing potential race conditions between the interrupt and the main thread checking a hardware condition. It may be possible to make this more fine-grained in future by manually calling `SEV` from individual ISRs, but this approach ensures the firmware can't become stuck if a `SEV` is missing.

*This work was funded through GitHub Sponsors.*