### PR TITLE
Move definitions of ATOMIC_SECTION macros to mphal/mphalport.h

### DIFF
--- a/ports/cc3200/application.mk
+++ b/ports/cc3200/application.mk
@@ -18,7 +18,6 @@ APP_INC += -Iutil
 APP_INC += -Ibootmgr
 APP_INC += -I$(BUILD)
 APP_INC += -I$(BUILD)/genhdr
-APP_INC += -I$(TOP)/ports/stm32
 
 APP_CPPDEFINES = -Dgcc -DTARGET_IS_CC3200 -DSL_FULL -DUSE_FREERTOS
 

--- a/ports/cc3200/hal/cc3200_asm.h
+++ b/ports/cc3200/hal/cc3200_asm.h
@@ -32,8 +32,11 @@
 //
 // Note on IRQ state: you should not need to know the specific
 // value of the state variable, but rather just pass the return
-// value from disable_irq back to enable_irq.  If you really need
-// to know the machine-specific values, see irq.h.
+// value from disable_irq back to enable_irq.
+
+// these states correspond to values from query_irq, enable_irq and disable_irq
+#define IRQ_STATE_DISABLED (0x00000001)
+#define IRQ_STATE_ENABLED  (0x00000000)
 
 #ifndef __disable_irq
 #define __disable_irq() __asm__ volatile ("cpsid i");
@@ -77,6 +80,11 @@ static inline uint32_t __get_BASEPRI(void) {
 __attribute__(( always_inline ))
 static inline void __set_BASEPRI(uint32_t value) {
     __asm volatile ("msr basepri, %0" : : "r" (value) : "memory");
+}
+
+__attribute__(( always_inline ))
+static inline uint32_t query_irq(void) {
+    return __get_PRIMASK();
 }
 
 __attribute__(( always_inline ))

--- a/ports/cc3200/hal/cc3200_hal.c
+++ b/ports/cc3200/hal/cc3200_hal.c
@@ -49,7 +49,6 @@
 #include "telnet.h"
 #include "pybuart.h"
 #include "utils.h"
-#include "irq.h"
 
 #ifdef USE_FREERTOS
 #include "FreeRTOS.h"

--- a/ports/cc3200/hal/cc3200_hal.h
+++ b/ports/cc3200/hal/cc3200_hal.h
@@ -30,6 +30,10 @@
 #include "hal/utils.h"
 #include "hal/systick.h"
 
+// assembly functions to handle critical sections, interrupt
+// disabling/enabling and sleep mode enter/exit
+#include "cc3200_asm.h"
+
 /******************************************************************************
  DEFINE CONSTANTS
  ******************************************************************************/
@@ -54,6 +58,9 @@
                                         __asm(" dsb \n"     \
                                               " isb \n");   \
                                      }
+
+#define MICROPY_BEGIN_ATOMIC_SECTION()              disable_irq()
+#define MICROPY_END_ATOMIC_SECTION(state)           enable_irq(state)
 
 /******************************************************************************
  DECLARE PUBLIC FUNCTIONS

--- a/ports/cc3200/mods/pybadc.c
+++ b/ports/cc3200/mods/pybadc.c
@@ -32,7 +32,7 @@
 #include "py/binary.h"
 #include "py/gc.h"
 #include "py/mperrno.h"
-#include "bufhelper.h"
+#include "ports/stm32/bufhelper.h"
 #include "inc/hw_types.h"
 #include "inc/hw_adc.h"
 #include "inc/hw_ints.h"

--- a/ports/cc3200/mods/pybi2c.c
+++ b/ports/cc3200/mods/pybi2c.c
@@ -31,7 +31,7 @@
 #include "py/runtime.h"
 #include "py/mperrno.h"
 #include "py/mphal.h"
-#include "bufhelper.h"
+#include "ports/stm32/bufhelper.h"
 #include "inc/hw_types.h"
 #include "inc/hw_i2c.h"
 #include "inc/hw_ints.h"

--- a/ports/cc3200/mods/pybrtc.c
+++ b/ports/cc3200/mods/pybrtc.c
@@ -25,7 +25,7 @@
  * THE SOFTWARE.
  */
 
-#include "py/mpconfig.h"
+#include "py/mphal.h"
 #include "py/obj.h"
 #include "py/runtime.h"
 #include "py/mperrno.h"

--- a/ports/cc3200/mods/pybspi.c
+++ b/ports/cc3200/mods/pybspi.c
@@ -30,7 +30,7 @@
 
 #include "py/runtime.h"
 #include "py/mperrno.h"
-#include "bufhelper.h"
+#include "ports/stm32/bufhelper.h"
 #include "inc/hw_types.h"
 #include "inc/hw_mcspi.h"
 #include "inc/hw_ints.h"

--- a/ports/cc3200/mpconfigport.h
+++ b/ports/cc3200/mpconfigport.h
@@ -161,13 +161,7 @@ typedef int32_t mp_int_t;                           // must be pointer size
 typedef unsigned int mp_uint_t;                     // must be pointer size
 typedef long mp_off_t;
 
-#define MICROPY_BEGIN_ATOMIC_SECTION()              disable_irq()
-#define MICROPY_END_ATOMIC_SECTION(state)           enable_irq(state)
 #define MICROPY_EVENT_POLL_HOOK                     __WFI();
-
-// assembly functions to handle critical sections, interrupt
-// disabling/enabling and sleep mode enter/exit
-#include "cc3200_asm.h"
 
 // We need to provide a declaration/definition of alloca()
 #include <alloca.h>

--- a/ports/cc3200/mpthreadport.c
+++ b/ports/cc3200/mpthreadport.c
@@ -32,7 +32,6 @@
 #include "py/mphal.h"
 #include "mptask.h"
 #include "task.h"
-#include "irq.h"
 
 #if MICROPY_PY_THREAD
 

--- a/ports/cc3200/telnet/telnet.c
+++ b/ports/cc3200/telnet/telnet.c
@@ -37,7 +37,6 @@
 #include "debug.h"
 #include "serverstask.h"
 #include "genhdr/mpversion.h"
-#include "irq.h"
 
 /******************************************************************************
  DEFINE PRIVATE CONSTANTS

--- a/ports/esp32/mpconfigport.h
+++ b/ports/esp32/mpconfigport.h
@@ -187,13 +187,6 @@ void *esp_native_code_commit(void *, size_t, void *);
 #define MP_PLAT_COMMIT_EXEC(buf, len, reloc) esp_native_code_commit(buf, len, reloc)
 #define MP_SSIZE_MAX (0x7fffffff)
 
-// Note: these "critical nested" macros do not ensure cross-CPU exclusion,
-// the only disable interrupts on the current CPU.  To full manage exclusion
-// one should use portENTER_CRITICAL/portEXIT_CRITICAL instead.
-#include "freertos/FreeRTOS.h"
-#define MICROPY_BEGIN_ATOMIC_SECTION() portSET_INTERRUPT_MASK_FROM_ISR()
-#define MICROPY_END_ATOMIC_SECTION(state) portCLEAR_INTERRUPT_MASK_FROM_ISR(state)
-
 #if MICROPY_PY_SOCKET_EVENTS
 #define MICROPY_PY_SOCKET_EVENTS_HANDLER extern void socket_events_handler(void); socket_events_handler();
 #else

--- a/ports/esp32/mphalport.h
+++ b/ports/esp32/mphalport.h
@@ -63,6 +63,13 @@ void check_esp_err_(esp_err_t code);
 void check_esp_err_(esp_err_t code, const char *func, const int line, const char *file);
 #endif
 
+// Note: these "critical nested" macros do not ensure cross-CPU exclusion,
+// the only disable interrupts on the current CPU.  To full manage exclusion
+// one should use portENTER_CRITICAL/portEXIT_CRITICAL instead.
+#include "freertos/FreeRTOS.h"
+#define MICROPY_BEGIN_ATOMIC_SECTION() portSET_INTERRUPT_MASK_FROM_ISR()
+#define MICROPY_END_ATOMIC_SECTION(state) portCLEAR_INTERRUPT_MASK_FROM_ISR(state)
+
 uint32_t mp_hal_ticks_us(void);
 __attribute__((always_inline)) static inline uint32_t mp_hal_ticks_cpu(void) {
     uint32_t ccount;

--- a/ports/esp8266/esp_mphal.h
+++ b/ports/esp8266/esp_mphal.h
@@ -29,6 +29,9 @@
 #include "shared/runtime/interrupt_char.h"
 #include "xtirq.h"
 
+#define MICROPY_BEGIN_ATOMIC_SECTION() esp_disable_irq()
+#define MICROPY_END_ATOMIC_SECTION(state) esp_enable_irq(state)
+
 void mp_sched_keyboard_interrupt(void);
 
 struct _mp_print_t;
@@ -65,6 +68,9 @@ uint32_t mp_hal_get_cpu_freq(void);
 #define DUPTERM_TASK_ID 1
 void uart_task_init();
 void dupterm_task_init();
+
+uint32_t esp_disable_irq(void);
+void esp_enable_irq(uint32_t state);
 
 void ets_event_poll(void);
 #define ETS_POLL_WHILE(cond) { while (cond) ets_event_poll(); }

--- a/ports/esp8266/mpconfigport.h
+++ b/ports/esp8266/mpconfigport.h
@@ -127,9 +127,6 @@
 #define MICROPY_VM_HOOK_LOOP MICROPY_VM_HOOK_POLL
 #define MICROPY_VM_HOOK_RETURN MICROPY_VM_HOOK_POLL
 
-#define MICROPY_BEGIN_ATOMIC_SECTION() esp_disable_irq()
-#define MICROPY_END_ATOMIC_SECTION(state) esp_enable_irq(state)
-
 // type definitions for the specific machine
 
 #define MICROPY_MAKE_POINTER_CALLABLE(p) ((void *)((mp_uint_t)(p)))
@@ -173,6 +170,3 @@ extern const struct _mp_print_t mp_debug_print;
 #define WDEV_HWRNG ((volatile uint32_t *)0x3ff20e44)
 
 #define _assert(expr) ((expr) ? (void)0 : __assert_func(__FILE__, __LINE__, __func__, #expr))
-
-uint32_t esp_disable_irq(void);
-void esp_enable_irq(uint32_t state);

--- a/ports/mimxrt/mpconfigport.h
+++ b/ports/mimxrt/mpconfigport.h
@@ -151,29 +151,7 @@ uint32_t trng_random_u32(void);
 #define MICROPY_PY_NETWORK_HOSTNAME_DEFAULT "mpy-mimxrt"
 #endif
 
-// For regular code that wants to prevent "background tasks" from running.
-// These background tasks (LWIP, Bluetooth) run in PENDSV context.
-// TODO: Check for the settings of the STM32 port in irq.h
-#define NVIC_PRIORITYGROUP_4    ((uint32_t)0x00000003)
-#define IRQ_PRI_PENDSV          NVIC_EncodePriority(NVIC_PRIORITYGROUP_4, 15, 0)
-#define MICROPY_PY_PENDSV_ENTER   uint32_t atomic_state = raise_irq_pri(IRQ_PRI_PENDSV);
-#define MICROPY_PY_PENDSV_REENTER atomic_state = raise_irq_pri(IRQ_PRI_PENDSV);
-#define MICROPY_PY_PENDSV_EXIT    restore_irq_pri(atomic_state);
-
 // Hooks to add builtins
-
-__attribute__((always_inline)) static inline void enable_irq(uint32_t state) {
-    __set_PRIMASK(state);
-}
-
-__attribute__((always_inline)) static inline uint32_t disable_irq(void) {
-    uint32_t state = __get_PRIMASK();
-    __disable_irq();
-    return state;
-}
-
-#define MICROPY_BEGIN_ATOMIC_SECTION()     disable_irq()
-#define MICROPY_END_ATOMIC_SECTION(state)  enable_irq(state)
 
 #if defined(IOMUX_TABLE_ENET)
 extern const struct _mp_obj_type_t network_lan_type;

--- a/ports/renesas-ra/irq.h
+++ b/ports/renesas-ra/irq.h
@@ -54,11 +54,26 @@ extern uint32_t irq_stats[IRQ_STATS_MAX];
 #define IRQ_EXIT(irq)
 #endif
 
+// We have inlined IRQ functions for efficiency (they are generally
+// 1 machine instruction).
+//
+// Note on IRQ state: you should not need to know the specific
+// value of the state variable, but rather just pass the return
+// value from disable_irq back to enable_irq.
+
 static inline uint32_t query_irq(void) {
     return __get_PRIMASK();
 }
 
-// enable_irq and disable_irq are defined inline in mpconfigport.h
+static inline void enable_irq(mp_uint_t state) {
+    __set_PRIMASK(state);
+}
+
+static inline mp_uint_t disable_irq(void) {
+    mp_uint_t state = __get_PRIMASK();
+    __disable_irq();
+    return state;
+}
 
 #if __CORTEX_M >= 0x03
 

--- a/ports/renesas-ra/mpconfigport.h
+++ b/ports/renesas-ra/mpconfigport.h
@@ -250,27 +250,6 @@ typedef unsigned int mp_uint_t; // must be pointer size
 
 typedef long mp_off_t;
 
-// We have inlined IRQ functions for efficiency (they are generally
-// 1 machine instruction).
-//
-// Note on IRQ state: you should not need to know the specific
-// value of the state variable, but rather just pass the return
-// value from disable_irq back to enable_irq.  If you really need
-// to know the machine-specific values, see irq.h.
-
-static inline void enable_irq(mp_uint_t state) {
-    __set_PRIMASK(state);
-}
-
-static inline mp_uint_t disable_irq(void) {
-    mp_uint_t state = __get_PRIMASK();
-    __disable_irq();
-    return state;
-}
-
-#define MICROPY_BEGIN_ATOMIC_SECTION()     disable_irq()
-#define MICROPY_END_ATOMIC_SECTION(state)  enable_irq(state)
-
 #if MICROPY_HW_ENABLE_USBDEV
 #define MICROPY_HW_USBDEV_TASK_HOOK extern void mp_usbd_task(void); mp_usbd_task();
 #define MICROPY_VM_HOOK_COUNT (10)

--- a/ports/renesas-ra/mphalport.h
+++ b/ports/renesas-ra/mphalport.h
@@ -29,6 +29,9 @@
 #include "pin.h"
 #include "py/ringbuf.h"
 
+#define MICROPY_BEGIN_ATOMIC_SECTION()     disable_irq()
+#define MICROPY_END_ATOMIC_SECTION(state)  enable_irq(state)
+
 #define MICROPY_PY_PENDSV_ENTER   uint32_t atomic_state = raise_irq_pri(IRQ_PRI_PENDSV)
 #define MICROPY_PY_PENDSV_EXIT    restore_irq_pri(atomic_state)
 

--- a/ports/rp2/modrp2.c
+++ b/ports/rp2/modrp2.c
@@ -24,6 +24,7 @@
  * THE SOFTWARE.
  */
 
+#include "py/mphal.h"
 #include "py/runtime.h"
 #include "drivers/dht/dht.h"
 #include "modrp2.h"

--- a/ports/rp2/mpconfigport.h
+++ b/ports/rp2/mpconfigport.h
@@ -244,12 +244,6 @@ extern const struct _mp_obj_type_t mod_network_nic_type_wiznet5k;
 #define MICROPY_HW_BOOTSEL_DELAY_US 8
 #endif
 
-// Entering a critical section.
-extern uint32_t mp_thread_begin_atomic_section(void);
-extern void mp_thread_end_atomic_section(uint32_t);
-#define MICROPY_BEGIN_ATOMIC_SECTION()     mp_thread_begin_atomic_section()
-#define MICROPY_END_ATOMIC_SECTION(state)  mp_thread_end_atomic_section(state)
-
 // Prevent the "lwIP task" from running when unsafe to do so.
 #define MICROPY_PY_LWIP_ENTER   lwip_lock_acquire();
 #define MICROPY_PY_LWIP_REENTER lwip_lock_acquire();

--- a/ports/rp2/mphalport.h
+++ b/ports/rp2/mphalport.h
@@ -36,11 +36,18 @@
 #define SYSTICK_MAX (0xffffff)
 #define MICROPY_HW_USB_CDC_TX_TIMEOUT (500)
 
+// Entering a critical section.
+#define MICROPY_BEGIN_ATOMIC_SECTION()     mp_thread_begin_atomic_section()
+#define MICROPY_END_ATOMIC_SECTION(state)  mp_thread_end_atomic_section(state)
+
 #define MICROPY_PY_PENDSV_ENTER   pendsv_suspend()
 #define MICROPY_PY_PENDSV_EXIT    pendsv_resume()
 
 extern int mp_interrupt_char;
 extern ringbuf_t stdin_ringbuf;
+
+uint32_t mp_thread_begin_atomic_section(void);
+void mp_thread_end_atomic_section(uint32_t);
 
 void mp_hal_set_interrupt_char(int c);
 void mp_hal_time_ns_set_from_rtc(void);

--- a/ports/rp2/mpthreadport.c
+++ b/ports/rp2/mpthreadport.c
@@ -26,6 +26,7 @@
 
 #include "py/runtime.h"
 #include "py/gc.h"
+#include "py/mphal.h"
 #include "py/mpthread.h"
 #include "pico/stdlib.h"
 #include "pico/multicore.h"

--- a/ports/rp2/rp2_flash.c
+++ b/ports/rp2/rp2_flash.c
@@ -26,6 +26,7 @@
 
 #include <string.h>
 
+#include "py/mphal.h"
 #include "py/runtime.h"
 #include "extmod/vfs.h"
 #include "modrp2.h"

--- a/ports/samd/mpconfigport.h
+++ b/ports/samd/mpconfigport.h
@@ -177,18 +177,6 @@
 #endif  // !defined(MICROPY_HW_MCUFLASH) ....
 
 // Miscellaneous settings
-__attribute__((always_inline)) static inline void enable_irq(uint32_t state) {
-    __set_PRIMASK(state);
-}
-
-__attribute__((always_inline)) static inline uint32_t disable_irq(void) {
-    uint32_t state = __get_PRIMASK();
-    __disable_irq();
-    return state;
-}
-
-#define MICROPY_BEGIN_ATOMIC_SECTION()     disable_irq()
-#define MICROPY_END_ATOMIC_SECTION(state)  enable_irq(state)
 
 #define MICROPY_EVENT_POLL_HOOK \
     do { \

--- a/ports/samd/mphalport.h
+++ b/ports/samd/mphalport.h
@@ -35,6 +35,9 @@
 #include "hpl_time_measure.h"
 #include "sam.h"
 
+#define MICROPY_BEGIN_ATOMIC_SECTION()     disable_irq()
+#define MICROPY_END_ATOMIC_SECTION(state)  enable_irq(state)
+
 #define MICROPY_PY_PENDSV_ENTER   uint32_t atomic_state = raise_irq_pri(IRQ_PRI_PENDSV)
 #define MICROPY_PY_PENDSV_EXIT    restore_irq_pri(atomic_state)
 
@@ -45,6 +48,16 @@ extern volatile uint32_t systick_ms;
 uint64_t mp_hal_ticks_us_64(void);
 
 void mp_hal_set_interrupt_char(int c);
+
+__attribute__((always_inline)) static inline void enable_irq(uint32_t state) {
+    __set_PRIMASK(state);
+}
+
+__attribute__((always_inline)) static inline uint32_t disable_irq(void) {
+    uint32_t state = __get_PRIMASK();
+    __disable_irq();
+    return state;
+}
 
 #define mp_hal_delay_us_fast  mp_hal_delay_us
 

--- a/ports/stm32/irq.h
+++ b/ports/stm32/irq.h
@@ -52,11 +52,26 @@ extern uint32_t irq_stats[IRQ_STATS_MAX];
 #define IRQ_EXIT(irq)
 #endif
 
+// We have inlined IRQ functions for efficiency (they are generally
+// 1 machine instruction).
+//
+// Note on IRQ state: you should not need to know the specific
+// value of the state variable, but rather just pass the return
+// value from disable_irq back to enable_irq.
+
 static inline uint32_t query_irq(void) {
     return __get_PRIMASK();
 }
 
-// enable_irq and disable_irq are defined inline in mpconfigport.h
+static inline void enable_irq(mp_uint_t state) {
+    __set_PRIMASK(state);
+}
+
+static inline mp_uint_t disable_irq(void) {
+    mp_uint_t state = __get_PRIMASK();
+    __disable_irq();
+    return state;
+}
 
 #if __CORTEX_M >= 0x03
 

--- a/ports/stm32/mpu.h
+++ b/ports/stm32/mpu.h
@@ -26,6 +26,8 @@
 #ifndef MICROPY_INCLUDED_STM32_MPU_H
 #define MICROPY_INCLUDED_STM32_MPU_H
 
+#include "irq.h"
+
 #if (defined(STM32F4) && defined(MICROPY_HW_ETH_MDC)) || defined(STM32F7) || defined(STM32H7) || defined(STM32WB)
 
 #define MPU_REGION_ETH      (MPU_REGION_NUMBER0)

--- a/ports/unix/mpconfigport.h
+++ b/ports/unix/mpconfigport.h
@@ -221,12 +221,6 @@ static inline unsigned long mp_random_seed_init(void) {
 #include <stdio.h>
 #endif
 
-// If threading is enabled, configure the atomic section.
-#if MICROPY_PY_THREAD
-#define MICROPY_BEGIN_ATOMIC_SECTION() (mp_thread_unix_begin_atomic_section(), 0xffffffff)
-#define MICROPY_END_ATOMIC_SECTION(x) (void)x; mp_thread_unix_end_atomic_section()
-#endif
-
 // In lieu of a WFI(), slow down polling from being a tight loop.
 #ifndef MICROPY_EVENT_POLL_HOOK
 #define MICROPY_EVENT_POLL_HOOK \

--- a/ports/unix/mphalport.h
+++ b/ports/unix/mphalport.h
@@ -30,6 +30,12 @@
 #define CHAR_CTRL_C (3)
 #endif
 
+// If threading is enabled, configure the atomic section.
+#if MICROPY_PY_THREAD
+#define MICROPY_BEGIN_ATOMIC_SECTION() (mp_thread_unix_begin_atomic_section(), 0xffffffff)
+#define MICROPY_END_ATOMIC_SECTION(x) (void)x; mp_thread_unix_end_atomic_section()
+#endif
+
 void mp_hal_set_interrupt_char(char c);
 
 #define mp_hal_stdio_poll unused // this is not implemented, nor needed

--- a/ports/zephyr/mpconfigport.h
+++ b/ports/zephyr/mpconfigport.h
@@ -139,6 +139,3 @@ typedef long mp_off_t;
 // extra built in names to add to the global namespace
 #define MICROPY_PORT_BUILTINS \
     { MP_ROM_QSTR(MP_QSTR_open), MP_ROM_PTR(&mp_builtin_open_obj) },
-
-#define MICROPY_BEGIN_ATOMIC_SECTION irq_lock
-#define MICROPY_END_ATOMIC_SECTION irq_unlock

--- a/ports/zephyr/mphalport.h
+++ b/ports/zephyr/mphalport.h
@@ -1,6 +1,9 @@
 #include <zephyr/zephyr.h>
 #include "shared/runtime/interrupt_char.h"
 
+#define MICROPY_BEGIN_ATOMIC_SECTION irq_lock
+#define MICROPY_END_ATOMIC_SECTION irq_unlock
+
 void mp_hal_init(void);
 void mp_hal_wait_sem(struct k_sem *sem, uint32_t timeout_ms);
 

--- a/py/mpconfig.h
+++ b/py/mpconfig.h
@@ -1850,14 +1850,6 @@ typedef double mp_float_t;
 #endif
 #endif
 
-// On embedded platforms, these will typically enable/disable irqs.
-#ifndef MICROPY_BEGIN_ATOMIC_SECTION
-#define MICROPY_BEGIN_ATOMIC_SECTION() (0)
-#endif
-#ifndef MICROPY_END_ATOMIC_SECTION
-#define MICROPY_END_ATOMIC_SECTION(state) (void)(state)
-#endif
-
 // Allow to override static modifier for global objects, e.g. to use with
 // object code analysis tools which don't support static symbols.
 #ifndef STATIC

--- a/py/mphal.h
+++ b/py/mphal.h
@@ -35,6 +35,14 @@
 #include <mphalport.h>
 #endif
 
+// On embedded platforms, these will typically enable/disable irqs.
+#ifndef MICROPY_BEGIN_ATOMIC_SECTION
+#define MICROPY_BEGIN_ATOMIC_SECTION() (0)
+#endif
+#ifndef MICROPY_END_ATOMIC_SECTION
+#define MICROPY_END_ATOMIC_SECTION(state) (void)(state)
+#endif
+
 #ifndef mp_hal_stdio_poll
 uintptr_t mp_hal_stdio_poll(uintptr_t poll_flags);
 #endif

--- a/py/objexcept.c
+++ b/py/objexcept.c
@@ -81,6 +81,8 @@ void mp_init_emergency_exception_buf(void) {
 #else
 #define mp_emergency_exception_buf_size MP_STATE_VM(mp_emergency_exception_buf_size)
 
+#include "py/mphal.h" // for MICROPY_BEGIN_ATOMIC_SECTION/MICROPY_END_ATOMIC_SECTION
+
 void mp_init_emergency_exception_buf(void) {
     mp_emergency_exception_buf_size = 0;
     MP_STATE_VM(mp_emergency_exception_buf) = NULL;

--- a/py/scheduler.c
+++ b/py/scheduler.c
@@ -26,6 +26,7 @@
 
 #include <stdio.h>
 
+#include "py/mphal.h"
 #include "py/runtime.h"
 
 // Schedules an exception on the main thread (for exceptions "thrown" by async


### PR DESCRIPTION
MICROPY_BEGIN_ATOMIC_SECTION/MICROPY_END_ATOMIC_SECTION belong more to the MicroPython HAL rather than build configuration settings, so move their default configuration to py/mphal.h, and require all users of these macros to include py/mphal.h (here, py/objexcept.c and py/scheduler.c).

This helps ports separate configuration from their HAL implementations, and can improve build times (because mpconfig.h is included everywhere, whereas mphal.h is not).
