### PR TITLE
rp2: switch math library routines to use MicroPython-provided ones

### DIFF
--- a/extmod/machine_timer.c
+++ b/extmod/machine_timer.c
@@ -26,6 +26,7 @@
 
 #include "py/runtime.h"
 #include "py/mphal.h"
+#include "py/mpmath.h"
 
 #if MICROPY_PY_MACHINE_TIMER
 

--- a/extmod/modsocket.c
+++ b/extmod/modsocket.c
@@ -32,6 +32,7 @@
 #include "py/runtime.h"
 #include "py/stream.h"
 #include "py/mperrno.h"
+#include "py/mpmath.h"
 
 #if MICROPY_PY_NETWORK && MICROPY_PY_SOCKET && !MICROPY_PY_LWIP
 

--- a/lib/libm/acoshf.c
+++ b/lib/libm/acoshf.c
@@ -14,6 +14,11 @@
 #define sqrtf sqrt
 #endif
 
+#define acoshf LIBM_FUNC_WRAP(acoshf)
+#define logf LIBM_FUNC_WRAP(logf)
+#define log1pf LIBM_FUNC_WRAP(log1pf)
+#define sqrtf LIBM_FUNC_WRAP(sqrtf)
+
 /* acosh(x) = log(x + sqrt(x*x-1)) */
 float acoshf(float x)
 {

--- a/lib/libm/asinfacosf.c
+++ b/lib/libm/asinfacosf.c
@@ -21,6 +21,10 @@
 
 #include "libm.h"
 
+#define acosf LIBM_FUNC_WRAP(acosf)
+#define asinf LIBM_FUNC_WRAP(asinf)
+#define sqrtf LIBM_FUNC_WRAP(sqrtf)
+
 // dpgeorge: pio2 was double in original implementation of asinf
 static const float
 pio2_hi = 1.5707962513e+00f, /* 0x3fc90fda */

--- a/lib/libm/asinhf.c
+++ b/lib/libm/asinhf.c
@@ -6,6 +6,11 @@
 
 #include "libm.h"
 
+#define logf LIBM_FUNC_WRAP(logf)
+#define sqrtf LIBM_FUNC_WRAP(sqrtf)
+#define asinhf LIBM_FUNC_WRAP(asinhf)
+#define log1pf LIBM_FUNC_WRAP(log1pf)
+
 /* asinh(x) = sign(x)*log(|x|+sqrt(x*x+1)) ~= x - x^3/6 + o(x^5) */
 float asinhf(float x)
 {

--- a/lib/libm/atan2f.c
+++ b/lib/libm/atan2f.c
@@ -21,6 +21,10 @@
 
 #include "libm.h"
 
+#define atan2f LIBM_FUNC_WRAP(atan2f)
+#define atanf LIBM_FUNC_WRAP(atanf)
+#define fabsf LIBM_FUNC_WRAP(fabsf)
+
 static const float
 pi     = 3.1415927410e+00f, /* 0x40490fdb */
 pi_lo  = -8.7422776573e-08f; /* 0xb3bbbd2e */

--- a/lib/libm/atanf.c
+++ b/lib/libm/atanf.c
@@ -22,6 +22,8 @@
 
 #include "libm.h"
 
+#define atanf LIBM_FUNC_WRAP(atanf)
+
 static const float atanhi[] = {
   4.6364760399e-01f, /* atan(0.5)hi 0x3eed6338 */
   7.8539812565e-01f, /* atan(1.0)hi 0x3f490fda */

--- a/lib/libm/atanhf.c
+++ b/lib/libm/atanhf.c
@@ -6,6 +6,9 @@
 
 #include "libm.h"
 
+#define log1pf LIBM_FUNC_WRAP(log1pf)
+#define atanhf LIBM_FUNC_WRAP(atanhf)
+
 /* atanh(x) = log((1+x)/(1-x))/2 = log1p(2x/(1-x))/2 ~= x + x^3/3 + o(x^5) */
 float atanhf(float x)
 {

--- a/lib/libm/ef_sqrt.c
+++ b/lib/libm/ef_sqrt.c
@@ -24,6 +24,8 @@
 
 #include "fdlibm.h"
 
+#define sqrtf LIBM_FUNC_WRAP(sqrtf)
+
 #ifdef __STDC__
 static	const float	one	= 1.0f, tiny=1.0e-30f;
 #else

--- a/lib/libm/erf_lgamma.c
+++ b/lib/libm/erf_lgamma.c
@@ -25,7 +25,8 @@
 
 #include "fdlibm.h"
 
-#define __ieee754_logf logf
+#define __ieee754_logf LIBM_FUNC_WRAP(logf)
+#define floorf LIBM_FUNC_WRAP(floorf)
 
 #ifdef __STDC__
 static const float 

--- a/lib/libm/fdlibm.h
+++ b/lib/libm/fdlibm.h
@@ -22,6 +22,13 @@
 
 #include <math.h>
 
+// Include libm.h to get definition of LIBM_FUNC_WRAP.
+#include "libm.h"
+#undef FLT_EVAL_METHOD
+#undef FORCE_EVAL
+#undef GET_FLOAT_WORD
+#undef SET_FLOAT_WORD
+
 /* Default to XOPEN_MODE.  */
 #define _XOPEN_MODE
 

--- a/lib/libm/fmodf.c
+++ b/lib/libm/fmodf.c
@@ -6,6 +6,8 @@
 
 #include "libm.h"
 
+#define fmodf LIBM_FUNC_WRAP(fmodf)
+
 float fmodf(float x, float y)
 {
 	union {float f; uint32_t i;} ux = {x}, uy = {y};

--- a/lib/libm/kf_rem_pio2.c
+++ b/lib/libm/kf_rem_pio2.c
@@ -24,6 +24,8 @@
 
 #include "fdlibm.h"
 
+#define floorf LIBM_FUNC_WRAP(floorf)
+
 /* In the float version, the input parameter x contains 8 bit
    integers, not 24 bit integers.  113 bit precision is not supported.  */
 

--- a/lib/libm/libm.h
+++ b/lib/libm/libm.h
@@ -19,6 +19,8 @@
 #include <stdint.h>
 #include <math.h>
 
+#define LIBM_FUNC_WRAP(fun) mp_libm_##fun
+
 #define FLT_EVAL_METHOD 0
 
 #define FORCE_EVAL(x) do {                        \
@@ -52,3 +54,54 @@ do {                                              \
       __u.i = (w);                                \
       (d) = __u.f;                                \
 } while (0)
+
+float LIBM_FUNC_WRAP(acosf)(float x);
+float LIBM_FUNC_WRAP(acoshf)(float x);
+float LIBM_FUNC_WRAP(asinf)(float x);
+float LIBM_FUNC_WRAP(asinhf)(float x);
+float LIBM_FUNC_WRAP(atan2f)(float y, float x);
+float LIBM_FUNC_WRAP(atanf)(float x);
+float LIBM_FUNC_WRAP(atanhf)(float x);
+float LIBM_FUNC_WRAP(ceilf)(float x);
+float LIBM_FUNC_WRAP(cosf)(float x);
+float LIBM_FUNC_WRAP(coshf)(float x);
+float LIBM_FUNC_WRAP(erfcf)(float x);
+float LIBM_FUNC_WRAP(erff)(float x);
+float LIBM_FUNC_WRAP(expf)(float x);
+float LIBM_FUNC_WRAP(expm1f)(float x);
+float LIBM_FUNC_WRAP(floorf)(float x);
+float LIBM_FUNC_WRAP(fmodf)(float x, float y);
+float LIBM_FUNC_WRAP(frexpf)(float x, int *exp);
+float LIBM_FUNC_WRAP(ldexpf)(float x, int exp);
+float LIBM_FUNC_WRAP(lgammaf)(float x);
+float LIBM_FUNC_WRAP(lgammaf)(float x);
+float LIBM_FUNC_WRAP(log10f)(float x);
+float LIBM_FUNC_WRAP(log1pf)(float x);
+float LIBM_FUNC_WRAP(log2f)(float x);
+float LIBM_FUNC_WRAP(logf)(float x);
+float LIBM_FUNC_WRAP(modff)(float x, float *iptr);
+float LIBM_FUNC_WRAP(nearbyintf)(float x);
+float LIBM_FUNC_WRAP(powf)(float x, float y);
+float LIBM_FUNC_WRAP(sinf)(float x);
+float LIBM_FUNC_WRAP(sinhf)(float x);
+float LIBM_FUNC_WRAP(sqrtf)(float x);
+float LIBM_FUNC_WRAP(tanf)(float x);
+float LIBM_FUNC_WRAP(tanhf)(float x);
+float LIBM_FUNC_WRAP(tgammaf)(float x);
+float LIBM_FUNC_WRAP(truncf)(float x);
+
+#ifndef NDEBUG
+float LIBM_FUNC_WRAP(copysignf)(float x, float y);
+#else
+static inline float LIBM_FUNC_WRAP(copysignf)(float x, float y) {
+    return copysignf(x, y);
+}
+#endif
+
+static inline float LIBM_FUNC_WRAP(fabsf)(float x) {
+    return fabsf(x);
+}
+
+static inline float LIBM_FUNC_WRAP(nanf)(const char *tagp) {
+    return nanf(tagp);
+}

--- a/lib/libm/log1pf.c
+++ b/lib/libm/log1pf.c
@@ -18,6 +18,8 @@
 
 #include "libm.h"
 
+#define log1pf LIBM_FUNC_WRAP(log1pf)
+
 static const float
 ln2_hi = 6.9313812256e-01f, /* 0x3f317180 */
 ln2_lo = 9.0580006145e-06f, /* 0x3717f7d1 */

--- a/lib/libm/math.c
+++ b/lib/libm/math.c
@@ -26,6 +26,21 @@
 
 #include "libm.h"
 
+#define ceilf LIBM_FUNC_WRAP(ceilf)
+#define copysignf LIBM_FUNC_WRAP(copysignf)
+#define coshf LIBM_FUNC_WRAP(coshf)
+#define expf LIBM_FUNC_WRAP(expf)
+#define expm1f LIBM_FUNC_WRAP(expm1f)
+#define floorf LIBM_FUNC_WRAP(floorf)
+#define log10f LIBM_FUNC_WRAP(log10f)
+#define logf LIBM_FUNC_WRAP(logf)
+#define logf LIBM_FUNC_WRAP(logf)
+#define powf LIBM_FUNC_WRAP(powf)
+#define sinhf LIBM_FUNC_WRAP(sinhf)
+#define sqrtf LIBM_FUNC_WRAP(sqrtf)
+#define tanhf LIBM_FUNC_WRAP(tanhf)
+#define truncf LIBM_FUNC_WRAP(truncf)
+
 typedef float float_t;
 typedef union {
     float f;

--- a/lib/libm/nearbyintf.c
+++ b/lib/libm/nearbyintf.c
@@ -2,6 +2,8 @@
 
 #include "libm.h"
 
+#define nearbyintf LIBM_FUNC_WRAP(nearbyintf)
+
 float nearbyintf(float x)
 {
 	union {float f; uint32_t i;} u = {x};

--- a/lib/libm/roundf.c
+++ b/lib/libm/roundf.c
@@ -6,6 +6,8 @@
 
 #include "libm.h"
 
+#define roundf LIBM_FUNC_WRAP(roundf)
+
 float roundf(float x)
 {
 	union {float f; uint32_t i;} u = {x};

--- a/lib/libm/sf_cos.c
+++ b/lib/libm/sf_cos.c
@@ -24,6 +24,8 @@
 
 #include "fdlibm.h"
 
+#define cosf LIBM_FUNC_WRAP(cosf)
+
 #ifdef __STDC__
 	float cosf(float x)
 #else

--- a/lib/libm/sf_erf.c
+++ b/lib/libm/sf_erf.c
@@ -24,7 +24,9 @@
 
 #include "fdlibm.h"
 
-#define __ieee754_expf expf
+#define __ieee754_expf LIBM_FUNC_WRAP(expf)
+#define erfcf LIBM_FUNC_WRAP(erfcf)
+#define erff LIBM_FUNC_WRAP(erff)
 
 #ifdef __v810__
 #define const

--- a/lib/libm/sf_frexp.c
+++ b/lib/libm/sf_frexp.c
@@ -24,6 +24,8 @@
 
 #include "fdlibm.h"
 
+#define frexpf LIBM_FUNC_WRAP(frexpf)
+
 #ifdef __STDC__
 static const float
 #else

--- a/lib/libm/sf_ldexp.c
+++ b/lib/libm/sf_ldexp.c
@@ -24,6 +24,8 @@
 
 #include "fdlibm.h"
 
+#define ldexpf LIBM_FUNC_WRAP(ldexpf)
+
 #ifdef __STDC__
 	float ldexpf(float value, int exp)
 #else

--- a/lib/libm/sf_modf.c
+++ b/lib/libm/sf_modf.c
@@ -24,6 +24,8 @@
 
 #include "fdlibm.h"
 
+#define modff LIBM_FUNC_WRAP(modff)
+
 #ifdef __STDC__
 static const float one = 1.0f;
 #else

--- a/lib/libm/sf_sin.c
+++ b/lib/libm/sf_sin.c
@@ -24,6 +24,8 @@
 
 #include "fdlibm.h"
 
+#define sinf LIBM_FUNC_WRAP(sinf)
+
 #ifdef __STDC__
 	float sinf(float x)
 #else

--- a/lib/libm/sf_tan.c
+++ b/lib/libm/sf_tan.c
@@ -24,6 +24,8 @@
 
 #include "fdlibm.h"
 
+#define tanf LIBM_FUNC_WRAP(tanf)
+
 #ifdef __STDC__
 	float tanf(float x)
 #else

--- a/lib/libm/thumb_vfp_sqrtf.c
+++ b/lib/libm/thumb_vfp_sqrtf.c
@@ -1,6 +1,8 @@
 // an implementation of sqrtf for Thumb using hardware VFP instructions
 
-#include <math.h>
+#include "libm.h"
+
+#define sqrtf LIBM_FUNC_WRAP(sqrtf)
 
 float sqrtf(float x) {
     __asm__ volatile (

--- a/lib/libm/wf_lgamma.c
+++ b/lib/libm/wf_lgamma.c
@@ -24,6 +24,9 @@
  */
 
 #include "fdlibm.h"
+
+#define lgammaf LIBM_FUNC_WRAP(lgammaf)
+
 #define _IEEE_LIBM 1
 
 #ifdef __STDC__

--- a/lib/libm/wf_tgamma.c
+++ b/lib/libm/wf_tgamma.c
@@ -24,6 +24,10 @@
 
 #include "math.h"
 #include "fdlibm.h"
+
+#define expf LIBM_FUNC_WRAP(expf)
+#define tgammaf LIBM_FUNC_WRAP(tgammaf)
+
 #define _IEEE_LIBM 1
 
 #ifdef __STDC__

--- a/ports/rp2/CMakeLists.txt
+++ b/ports/rp2/CMakeLists.txt
@@ -86,6 +86,27 @@ set(MICROPY_QSTRDEFS_PORT
 )
 
 set(MICROPY_SOURCE_LIB
+    ${MICROPY_DIR}/lib/libm/acoshf.c
+    ${MICROPY_DIR}/lib/libm/asinfacosf.c
+    ${MICROPY_DIR}/lib/libm/asinhf.c
+    ${MICROPY_DIR}/lib/libm/atan2f.c
+    ${MICROPY_DIR}/lib/libm/atanf.c
+    ${MICROPY_DIR}/lib/libm/atanhf.c
+    ${MICROPY_DIR}/lib/libm/ef_sqrt.c
+    ${MICROPY_DIR}/lib/libm/fmodf.c
+    ${MICROPY_DIR}/lib/libm/log1pf.c
+    ${MICROPY_DIR}/lib/libm/math.c
+    ${MICROPY_DIR}/lib/libm/nearbyintf.c
+    ${MICROPY_DIR}/lib/libm/sf_cos.c
+    ${MICROPY_DIR}/lib/libm/sf_erf.c
+    ${MICROPY_DIR}/lib/libm/sf_frexp.c
+    ${MICROPY_DIR}/lib/libm/sf_ldexp.c
+    ${MICROPY_DIR}/lib/libm/sf_modf.c
+    ${MICROPY_DIR}/lib/libm/sf_sin.c
+    ${MICROPY_DIR}/lib/libm/sf_tan.c
+    ${MICROPY_DIR}/lib/libm/wf_lgamma.c
+    ${MICROPY_DIR}/lib/libm/wf_tgamma.c
+
     ${MICROPY_DIR}/lib/littlefs/lfs1.c
     ${MICROPY_DIR}/lib/littlefs/lfs1_util.c
     ${MICROPY_DIR}/lib/littlefs/lfs2.c

--- a/ports/rp2/machine_timer.c
+++ b/ports/rp2/machine_timer.c
@@ -27,6 +27,7 @@
 #include "py/runtime.h"
 #include "py/mperrno.h"
 #include "py/mphal.h"
+#include "py/mpmath.h"
 #include "pico/time.h"
 
 #define ALARM_ID_INVALID (-1)

--- a/ports/rp2/mpconfigport.h
+++ b/ports/rp2/mpconfigport.h
@@ -85,6 +85,7 @@
 #ifndef MICROPY_USE_INTERNAL_ERRNO
 #define MICROPY_USE_INTERNAL_ERRNO              (1)
 #endif
+#define MICROPY_USE_INTERNAL_LIBM               (1)
 
 // Fine control over Python builtins, classes, modules, etc
 #define MICROPY_PY_BUILTINS_HELP_TEXT           rp2_help_text
@@ -267,6 +268,9 @@ extern const struct _mp_obj_type_t mod_network_nic_type_wiznet5k;
 typedef intptr_t mp_int_t; // must be pointer size
 typedef uintptr_t mp_uint_t; // must be pointer size
 typedef intptr_t mp_off_t;
+
+// We need an implementation of the log2 function which is not a macro.
+#define MP_NEED_LOG2 (1)
 
 // We need to provide a declaration/definition of alloca()
 #include <alloca.h>

--- a/ports/stm32/servo.c
+++ b/ports/stm32/servo.c
@@ -28,6 +28,7 @@
 
 #include "py/runtime.h"
 #include "py/mphal.h"
+#include "py/mpmath.h"
 #include "pin.h"
 #include "timer.h"
 #include "servo.h"

--- a/ports/stm32/timer.c
+++ b/ports/stm32/timer.c
@@ -29,6 +29,7 @@
 
 #include "py/runtime.h"
 #include "py/gc.h"
+#include "py/mpmath.h"
 #include "timer.h"
 #include "servo.h"
 #include "pin.h"

--- a/py/formatfloat.c
+++ b/py/formatfloat.c
@@ -31,7 +31,7 @@
 #include <assert.h>
 #include <stdlib.h>
 #include <stdint.h>
-#include <math.h>
+#include "py/mpmath.h"
 #include "py/formatfloat.h"
 
 /***********************************************************************

--- a/py/modbuiltins.c
+++ b/py/modbuiltins.c
@@ -34,10 +34,7 @@
 #include "py/runtime.h"
 #include "py/builtin.h"
 #include "py/stream.h"
-
-#if MICROPY_PY_BUILTINS_FLOAT
-#include <math.h>
-#endif
+#include "py/mpmath.h"
 
 #if MICROPY_PY_IO
 extern struct _mp_dummy_t mp_sys_stdout_obj; // type is irrelevant, just need pointer

--- a/py/modcmath.c
+++ b/py/modcmath.c
@@ -28,7 +28,7 @@
 
 #if MICROPY_PY_BUILTINS_FLOAT && MICROPY_PY_BUILTINS_COMPLEX && MICROPY_PY_CMATH
 
-#include <math.h>
+#include "py/mpmath.h"
 
 // phase(z): returns the phase of the number z in the range (-pi, +pi]
 STATIC mp_obj_t mp_cmath_phase(mp_obj_t z_obj) {

--- a/py/modmath.c
+++ b/py/modmath.c
@@ -29,7 +29,7 @@
 
 #if MICROPY_PY_BUILTINS_FLOAT && MICROPY_PY_MATH
 
-#include <math.h>
+#include "py/mpmath.h"
 
 // M_PI is not part of the math.h standard and may not be defined
 // And by defining our own we can ensure it uses the correct const format.

--- a/py/mpconfig.h
+++ b/py/mpconfig.h
@@ -812,13 +812,9 @@ typedef long long mp_longint_impl_t;
 
 #if MICROPY_FLOAT_IMPL == MICROPY_FLOAT_IMPL_FLOAT
 #define MICROPY_PY_BUILTINS_FLOAT (1)
-#define MICROPY_FLOAT_CONST(x) x##F
-#define MICROPY_FLOAT_C_FUN(fun) fun##f
 typedef float mp_float_t;
 #elif MICROPY_FLOAT_IMPL == MICROPY_FLOAT_IMPL_DOUBLE
 #define MICROPY_PY_BUILTINS_FLOAT (1)
-#define MICROPY_FLOAT_CONST(x) x
-#define MICROPY_FLOAT_C_FUN(fun) fun
 typedef double mp_float_t;
 #else
 #define MICROPY_PY_BUILTINS_FLOAT (0)
@@ -937,6 +933,11 @@ typedef double mp_float_t;
 // Whether to use internally defined *printf() functions (otherwise external ones)
 #ifndef MICROPY_USE_INTERNAL_PRINTF
 #define MICROPY_USE_INTERNAL_PRINTF (1)
+#endif
+
+// Whether to use internal math library functions (otherwise external ones)
+#ifndef MICROPY_USE_INTERNAL_LIBM
+#define MICROPY_USE_INTERNAL_LIBM (0)
 #endif
 
 // The mp_print_t printer used for printf output when MICROPY_USE_INTERNAL_PRINTF is enabled

--- a/py/mpmath.h
+++ b/py/mpmath.h
@@ -1,0 +1,69 @@
+/*
+ * This file is part of the MicroPython project, http://micropython.org/
+ *
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2023 Damien P. George
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#include "py/mpconfig.h"
+
+#if MICROPY_PY_BUILTINS_FLOAT && MICROPY_FLOAT_IMPL == MICROPY_FLOAT_IMPL_FLOAT
+
+// MicroPython is configured to use single precision float.
+
+#define MICROPY_FLOAT_CONST(x) x##F
+
+#if MICROPY_USE_INTERNAL_LIBM
+
+// Use local libm, single precision.
+#include "lib/libm/libm.h"
+#define MICROPY_FLOAT_C_FUN(fun) mp_libm_##fun##f
+
+#else
+
+// Use system math library.
+#include <math.h>
+#define MICROPY_FLOAT_C_FUN(fun) fun##f
+
+#endif
+
+#elif MICROPY_PY_BUILTINS_FLOAT && MICROPY_FLOAT_IMPL == MICROPY_FLOAT_IMPL_DOUBLE
+
+// MicroPython is configured to use double precision float.
+
+#define MICROPY_FLOAT_CONST(x) x
+
+#if MICROPY_USE_INTERNAL_LIBM
+
+// Local libm, double precision.
+#include "lib/libm_dbl/libm.h"
+#define MICROPY_FLOAT_C_FUN(fun) mp_libm_##fun
+
+#else
+
+// Use system math library.
+#include <math.h>
+#define MICROPY_FLOAT_C_FUN(fun) fun
+
+#endif
+
+#endif

--- a/py/objcomplex.c
+++ b/py/objcomplex.c
@@ -33,7 +33,7 @@
 
 #if MICROPY_PY_BUILTINS_COMPLEX
 
-#include <math.h>
+#include "py/mpmath.h"
 #include "py/formatfloat.h"
 
 typedef struct _mp_obj_complex_t {

--- a/py/objfloat.c
+++ b/py/objfloat.c
@@ -34,7 +34,7 @@
 
 #if MICROPY_PY_BUILTINS_FLOAT
 
-#include <math.h>
+#include "py/mpmath.h"
 #include "py/formatfloat.h"
 
 #if MICROPY_OBJ_REPR != MICROPY_OBJ_REPR_C && MICROPY_OBJ_REPR != MICROPY_OBJ_REPR_D

--- a/py/parsenum.c
+++ b/py/parsenum.c
@@ -31,10 +31,7 @@
 #include "py/parsenumbase.h"
 #include "py/parsenum.h"
 #include "py/smallint.h"
-
-#if MICROPY_PY_BUILTINS_FLOAT
-#include <math.h>
-#endif
+#include "py/mpmath.h"
 
 STATIC NORETURN void raise_exc(mp_obj_t exc, mp_lexer_t *lex) {
     // if lex!=NULL then the parser called us and we need to convert the


### PR DESCRIPTION
The `pico-sdk` has a few bugs in its math functions (like sqrt, log, pow).  This PR switches the rp2 port to use the math functions in `lib/libm`, to match other bare-metal ports.

This fixes most issues with floating point calculations on rp2.  But there's still one bug with `-inf+inf` in the `pico-sdk` which can't be easily fixed by us.

Note: this is WIP because it needs a bit of cleaning up so existing ports build.