### PR TITLE
py/modsys: Implement sys.intern.

### DIFF
--- a/py/modsys.c
+++ b/py/modsys.c
@@ -147,6 +147,10 @@ STATIC const MP_DEFINE_STR_OBJ(mp_sys_platform_obj, MICROPY_PY_SYS_PLATFORM);
 MP_DEFINE_STR_OBJ(mp_sys_executable_obj, "");
 #endif
 
+#if MICROPY_PY_SYS_INTERN
+MP_DEFINE_CONST_FUN_OBJ_1(mp_sys_intern_obj, mp_obj_str_intern_checked);
+#endif
+
 // exit([retval]): raise SystemExit, with optional argument given to the exception
 STATIC mp_obj_t mp_sys_exit(size_t n_args, const mp_obj_t *args) {
     if (n_args == 0) {
@@ -291,6 +295,10 @@ STATIC const mp_rom_map_elem_t mp_module_sys_globals_table[] = {
     #else
     { MP_ROM_QSTR(MP_QSTR_maxsize), MP_ROM_PTR(&mp_sys_maxsize_obj) },
     #endif
+    #endif
+
+    #if MICROPY_PY_SYS_INTERN
+    { MP_ROM_QSTR(MP_QSTR_intern), MP_ROM_PTR(&mp_sys_intern_obj) },
     #endif
 
     #if MICROPY_PY_SYS_EXIT

--- a/py/mpconfig.h
+++ b/py/mpconfig.h
@@ -1434,6 +1434,11 @@ typedef double mp_float_t;
 #define MICROPY_PY_SYS_EXECUTABLE (0)
 #endif
 
+// Whether to provide "sys.intern"
+#ifndef MICROPY_PY_SYS_INTERN
+#define MICROPY_PY_SYS_INTERN (MICROPY_CONFIG_ROM_LEVEL_AT_LEAST_EVERYTHING)
+#endif
+
 // Whether to provide "sys.exit" function
 #ifndef MICROPY_PY_SYS_EXIT
 #define MICROPY_PY_SYS_EXIT (1)

--- a/tests/basics/sys1.py
+++ b/tests/basics/sys1.py
@@ -23,3 +23,18 @@ if hasattr(sys.implementation, '_mpy'):
 else:
     # Effectively skip subtests
     print(int)
+
+try:
+    print(sys.intern('micropython') == 'micropython')
+    has_intern = True
+except AttributeError:
+    has_intern = False
+    print(True)
+
+if has_intern:
+    try:
+        print(sys.intern(0))
+    except TypeError:
+        print(True)
+else:
+    print(True)

--- a/tests/unix/extra_coverage.py.exp
+++ b/tests/unix/extra_coverage.py.exp
@@ -66,10 +66,10 @@ micropython     machine         math
 
 argv            atexit          byteorder       exc_info
 executable      exit            getsizeof       implementation
-maxsize         modules         path            platform
-print_exception                 ps1             ps2
-stderr          stdin           stdout          tracebacklimit
-version         version_info
+intern          maxsize         modules         path
+platform        print_exception                 ps1
+ps2             stderr          stdin           stdout
+tracebacklimit  version         version_info
 ementation
 # attrtuple
 (start=1, stop=2, step=3)


### PR DESCRIPTION
See https://github.com/micropython/micropython/pull/6164#issuecomment-645932282 for backgroud; with the sys module now not being extensible anymore there's no other option than implementing this in C, as far as I can tell.