### PR TITLE
ports/esp32/UM_TINYPICO: fix typo in deploy.md installation instructions

### DIFF
--- a/ports/esp32/boards/UM_TINYPICO/deploy.md
+++ b/ports/esp32/boards/UM_TINYPICO/deploy.md
@@ -31,16 +31,16 @@ From then on program the firmware starting at address 0x1000:
 
 ### Linux
 ```bash
-esptool.py --chip esp32 --port /dev/ttyUSB0 --baud 912600 write_flash -z 0x1000 tinypico-micropython-firmware-version.bin
+esptool.py --chip esp32 --port /dev/ttyUSB0 --baud 921600 write_flash -z 0x1000 tinypico-micropython-firmware-version.bin
 ```
 
 ### Mac
 ```bash
-esptool.py --chip esp32 --port /dev/tty.SLAB_USBtoUART --baud 912600 write_flash -z 0x1000 tinypico-micropython-firmware-version.bin
+esptool.py --chip esp32 --port /dev/tty.SLAB_USBtoUART --baud 921600 write_flash -z 0x1000 tinypico-micropython-firmware-version.bin
 ```
 
 ### Windows
 Change (X) to whatever COM port is being used by the board
 ```bash
-esptool --chip esp32 --port COM(X) --baud 912600 write_flash -z 0x1000 tinypico-micropython-firmware-version.bin
+esptool --chip esp32 --port COM(X) --baud 921600 write_flash -z 0x1000 tinypico-micropython-firmware-version.bin
 ```


### PR DESCRIPTION
The installation instructions for ESP32 TinyPICO board contain a typo that uses a non-standard baud rate 9**12**600 instead of 9**21**600. This makes the upload command fail on some Windows computers.