### PR TITLE
stm32: clean up flash sector erase code, and fix bank issues with H5/H7 MCUs

### DIFF
--- a/ports/stm32/boards/LEGO_HUB_NO6/mboot_memory.ld
+++ b/ports/stm32/boards/LEGO_HUB_NO6/mboot_memory.ld
@@ -8,6 +8,6 @@ MEMORY
     RAM (xrw)       : ORIGIN = 0x20000000, LENGTH = 120K
 }
 
-/* Location from which mboot is allowed to write to flash.
-   Must be the start of a flash erase sector. */
-_mboot_writable_flash_start = ORIGIN(FLASH_BL) + LENGTH(FLASH_BL);
+/* Location of protected flash area which must not be modified, because mboot lives there. */
+_mboot_protected_flash_start = ORIGIN(FLASH_BL);
+_mboot_protected_flash_end_exclusive = ORIGIN(FLASH_BL) + LENGTH(FLASH_BL);

--- a/ports/stm32/flash.c
+++ b/ports/stm32/flash.c
@@ -355,35 +355,6 @@ int flash_erase(uint32_t flash_dest, uint32_t num_word32) {
     return mp_hal_status_to_neg_errno(status);
 }
 
-/*
-// erase the sector using an interrupt
-void flash_erase_it(uint32_t flash_dest, uint32_t num_word32) {
-    // check there is something to write
-    if (num_word32 == 0) {
-        return;
-    }
-
-    // unlock
-    HAL_FLASH_Unlock();
-
-    // Clear pending flags (if any)
-    __HAL_FLASH_CLEAR_FLAG(FLASH_FLAG_EOP | FLASH_FLAG_OPERR | FLASH_FLAG_WRPERR |
-                           FLASH_FLAG_PGAERR | FLASH_FLAG_PGPERR|FLASH_FLAG_PGSERR);
-
-    // erase the sector(s)
-    FLASH_EraseInitTypeDef EraseInitStruct;
-    EraseInitStruct.TypeErase = TYPEERASE_SECTORS;
-    EraseInitStruct.VoltageRange = VOLTAGE_RANGE_3; // voltage range needs to be 2.7V to 3.6V
-    EraseInitStruct.Sector = flash_get_sector_info(flash_dest, NULL, NULL);
-    EraseInitStruct.NbSectors = flash_get_sector_info(flash_dest + 4 * num_word32 - 1, NULL, NULL) - EraseInitStruct.Sector + 1;
-    if (HAL_FLASHEx_Erase_IT(&EraseInitStruct) != HAL_OK) {
-        // error occurred during sector erase
-        HAL_FLASH_Lock(); // lock the flash
-        return;
-    }
-}
-*/
-
 int flash_write(uint32_t flash_dest, const uint32_t *src, uint32_t num_word32) {
     #if MICROPY_HW_STM32WB_FLASH_SYNCRONISATION
     // Acquire lock on the flash peripheral.
@@ -498,47 +469,3 @@ int flash_write(uint32_t flash_dest, const uint32_t *src, uint32_t num_word32) {
 
     return mp_hal_status_to_neg_errno(status);
 }
-
-/*
- use erase, then write
-void flash_erase_and_write(uint32_t flash_dest, const uint32_t *src, uint32_t num_word32) {
-    // check there is something to write
-    if (num_word32 == 0) {
-        return;
-    }
-
-    // unlock
-    HAL_FLASH_Unlock();
-
-    // Clear pending flags (if any)
-    __HAL_FLASH_CLEAR_FLAG(FLASH_FLAG_EOP | FLASH_FLAG_OPERR | FLASH_FLAG_WRPERR |
-                           FLASH_FLAG_PGAERR | FLASH_FLAG_PGPERR|FLASH_FLAG_PGSERR);
-
-    // erase the sector(s)
-    FLASH_EraseInitTypeDef EraseInitStruct;
-    EraseInitStruct.TypeErase = TYPEERASE_SECTORS;
-    EraseInitStruct.VoltageRange = VOLTAGE_RANGE_3; // voltage range needs to be 2.7V to 3.6V
-    EraseInitStruct.Sector = flash_get_sector_info(flash_dest, NULL, NULL);
-    EraseInitStruct.NbSectors = flash_get_sector_info(flash_dest + 4 * num_word32 - 1, NULL, NULL) - EraseInitStruct.Sector + 1;
-    uint32_t SectorError = 0;
-    if (HAL_FLASHEx_Erase(&EraseInitStruct, &SectorError) != HAL_OK) {
-        // error occurred during sector erase
-        HAL_FLASH_Lock(); // lock the flash
-        return;
-    }
-
-    // program the flash word by word
-    for (int i = 0; i < num_word32; i++) {
-        if (HAL_FLASH_Program(TYPEPROGRAM_WORD, flash_dest, *src) != HAL_OK) {
-            // error occurred during flash write
-            HAL_FLASH_Lock(); // lock the flash
-            return;
-        }
-        flash_dest += 4;
-        src += 1;
-    }
-
-    // lock the flash
-    HAL_FLASH_Lock();
-}
-*/

--- a/ports/stm32/flash.h
+++ b/ports/stm32/flash.h
@@ -28,7 +28,7 @@
 
 bool flash_is_valid_addr(uint32_t addr);
 int32_t flash_get_sector_info(uint32_t addr, uint32_t *start_addr, uint32_t *size);
-int flash_erase(uint32_t flash_dest, uint32_t num_word32);
+int flash_erase(uint32_t flash_dest);
 int flash_write(uint32_t flash_dest, const uint32_t *src, uint32_t num_word32);
 
 #endif // MICROPY_INCLUDED_STM32_FLASH_H

--- a/ports/stm32/flashbdev.c
+++ b/ports/stm32/flashbdev.c
@@ -68,7 +68,6 @@ extern uint8_t _micropy_hw_internal_flash_storage_ram_cache_end[];
 #define FLASH_FLAG_FORCE_WRITE  (2)
 #define FLASH_FLAG_ERASED       (4)
 static __IO uint8_t flash_flags = 0;
-static uint32_t flash_cache_sector_id;
 static uint32_t flash_cache_sector_start;
 static uint32_t flash_cache_sector_size;
 static uint32_t flash_tick_counter_last_write;
@@ -80,7 +79,7 @@ int32_t flash_bdev_ioctl(uint32_t op, uint32_t arg) {
     switch (op) {
         case BDEV_IOCTL_INIT:
             flash_flags = 0;
-            flash_cache_sector_id = 0;
+            flash_cache_sector_start = (uint32_t)-1;
             flash_tick_counter_last_write = 0;
             return 0;
 
@@ -110,14 +109,13 @@ int32_t flash_bdev_ioctl(uint32_t op, uint32_t arg) {
 static uint8_t *flash_cache_get_addr_for_write(uint32_t flash_addr) {
     uint32_t flash_sector_start;
     uint32_t flash_sector_size;
-    int32_t flash_sector_id = flash_get_sector_info(flash_addr, &flash_sector_start, &flash_sector_size);
+    flash_get_sector_info(flash_addr, &flash_sector_start, &flash_sector_size);
     if (flash_sector_size > FLASH_SECTOR_SIZE_MAX) {
         flash_sector_size = FLASH_SECTOR_SIZE_MAX;
     }
-    if (flash_cache_sector_id != flash_sector_id) {
+    if (flash_cache_sector_start != flash_sector_start) {
         flash_bdev_ioctl(BDEV_IOCTL_SYNC, 0);
         memcpy((void *)CACHE_MEM_START_ADDR, (const void *)flash_sector_start, flash_sector_size);
-        flash_cache_sector_id = flash_sector_id;
         flash_cache_sector_start = flash_sector_start;
         flash_cache_sector_size = flash_sector_size;
     }
@@ -130,8 +128,8 @@ static uint8_t *flash_cache_get_addr_for_write(uint32_t flash_addr) {
 static uint8_t *flash_cache_get_addr_for_read(uint32_t flash_addr) {
     uint32_t flash_sector_start;
     uint32_t flash_sector_size;
-    int32_t flash_sector_id = flash_get_sector_info(flash_addr, &flash_sector_start, &flash_sector_size);
-    if (flash_cache_sector_id == flash_sector_id) {
+    flash_get_sector_info(flash_addr, &flash_sector_start, &flash_sector_size);
+    if (flash_cache_sector_start == flash_sector_start) {
         // in cache, copy from there
         return (uint8_t *)CACHE_MEM_START_ADDR + flash_addr - flash_sector_start;
     }

--- a/ports/stm32/flashbdev.c
+++ b/ports/stm32/flashbdev.c
@@ -159,25 +159,6 @@ static void flash_bdev_irq_handler(void) {
         return;
     }
 
-    // This code uses interrupts to erase the flash
-    /*
-    if (flash_erase_state == 0) {
-        flash_erase_it(flash_cache_sector_start, flash_cache_sector_size / 4);
-        flash_erase_state = 1;
-        return;
-    }
-
-    if (flash_erase_state == 1) {
-        // wait for erase
-        // TODO add timeout
-        #define flash_erase_done() (__HAL_FLASH_GET_FLAG(FLASH_FLAG_BSY) == RESET)
-        if (!flash_erase_done()) {
-            return;
-        }
-        flash_erase_state = 2;
-    }
-    */
-
     // This code erases the flash directly, waiting for it to finish
     if (!(flash_flags & FLASH_FLAG_ERASED)) {
         flash_erase(flash_cache_sector_start, flash_cache_sector_size / 4);

--- a/ports/stm32/flashbdev.c
+++ b/ports/stm32/flashbdev.c
@@ -161,7 +161,7 @@ static void flash_bdev_irq_handler(void) {
 
     // This code erases the flash directly, waiting for it to finish
     if (!(flash_flags & FLASH_FLAG_ERASED)) {
-        flash_erase(flash_cache_sector_start, flash_cache_sector_size / 4);
+        flash_erase(flash_cache_sector_start);
         flash_flags |= FLASH_FLAG_ERASED;
         return;
     }

--- a/ports/stm32/mboot/main.c
+++ b/ports/stm32/mboot/main.c
@@ -465,7 +465,7 @@ static int mboot_flash_page_erase(uint32_t addr, uint32_t *next_addr) {
     }
 
     // Erase the flash page.
-    ret = flash_erase(sector_start, sector_size / sizeof(uint32_t));
+    ret = flash_erase(sector_start);
     if (ret != 0) {
         return ret;
     }

--- a/ports/stm32/mboot/main.c
+++ b/ports/stm32/mboot/main.c
@@ -109,14 +109,12 @@
 // These bits are used to detect valid application firmware at APPLICATION_ADDR
 #define APP_VALIDITY_BITS (0x00000003)
 
-// Symbol provided by the linker, at the address in flash where mboot can start erasing/writing.
-extern uint8_t _mboot_writable_flash_start;
+// Symbols provided by the linker, the protected flash address range where mboot lives.
+extern uint8_t _mboot_protected_flash_start;
+extern uint8_t _mboot_protected_flash_end_exclusive;
 
 // For 1ms system ticker.
 volatile uint32_t systick_ms;
-
-// The sector number of the first sector that can be erased/written.
-int32_t first_writable_flash_sector;
 
 // Global dfu state
 dfu_context_t dfu_context SECTION_NOZERO_BSS;
@@ -410,10 +408,10 @@ void mp_hal_pin_config_speed(uint32_t port_pin, uint32_t speed) {
 /******************************************************************************/
 // FLASH
 
-#if defined(STM32G0)
+#define FLASH_START (FLASH_BASE)
+
+#if defined(STM32G0) || defined(STM32H5)
 #define FLASH_END (FLASH_BASE + FLASH_SIZE - 1)
-#elif defined(STM32H5)
-#define FLASH_END (0x08000000 + 2 * 1024 * 1024)
 #elif defined(STM32WB)
 #define FLASH_END FLASH_END_ADDR
 #endif
@@ -446,30 +444,36 @@ void mp_hal_pin_config_speed(uint32_t port_pin, uint32_t speed) {
 #define FLASH_LAYOUT_STR "@Internal Flash  /0x08000000/256*04Kg" MBOOT_SPIFLASH_LAYOUT MBOOT_SPIFLASH2_LAYOUT
 #endif
 
+static bool flash_is_modifiable_addr_range(uint32_t addr, uint32_t len) {
+    return addr + len < (uint32_t)&_mboot_protected_flash_start
+           || addr >= (uint32_t)&_mboot_protected_flash_end_exclusive;
+}
+
 static int mboot_flash_mass_erase(void) {
     // Erase all flash pages after mboot.
-    uint32_t start_addr = (uint32_t)&_mboot_writable_flash_start;
+    uint32_t start_addr = (uint32_t)&_mboot_protected_flash_end_exclusive;
     uint32_t num_words = (FLASH_END + 1 - start_addr) / sizeof(uint32_t);
     int ret = flash_erase(start_addr, num_words);
     return ret;
 }
 
 static int mboot_flash_page_erase(uint32_t addr, uint32_t *next_addr) {
+    // Compute start and end address of the sector being erased.
     uint32_t sector_size = 0;
     uint32_t sector_start = 0;
-    int32_t sector = flash_get_sector_info(addr, &sector_start, &sector_size);
-    if (sector < first_writable_flash_sector) {
+    int ret = flash_get_sector_info(addr, &sector_start, &sector_size);
+    *next_addr = sector_start + sector_size;
+
+    if (ret < 0 || !flash_is_modifiable_addr_range(addr, *next_addr - addr)) {
         // Don't allow to erase the sector with this bootloader in it, or invalid sectors
         dfu_context.status = DFU_STATUS_ERROR_ADDRESS;
-        dfu_context.error = (sector == 0) ? MBOOT_ERROR_STR_OVERWRITE_BOOTLOADER_IDX
-                                          : MBOOT_ERROR_STR_INVALID_ADDRESS_IDX;
+        dfu_context.error = (ret < 0) ? MBOOT_ERROR_STR_INVALID_ADDRESS_IDX
+                                      : MBOOT_ERROR_STR_OVERWRITE_BOOTLOADER_IDX;
         return -MBOOT_ERRNO_FLASH_ERASE_DISALLOWED;
     }
 
-    *next_addr = sector_start + sector_size;
-
     // Erase the flash page.
-    int ret = flash_erase(sector_start, sector_size / sizeof(uint32_t));
+    ret = flash_erase(sector_start, sector_size / sizeof(uint32_t));
     if (ret != 0) {
         return ret;
     }
@@ -485,12 +489,12 @@ static int mboot_flash_page_erase(uint32_t addr, uint32_t *next_addr) {
 }
 
 static int mboot_flash_write(uint32_t addr, const uint8_t *src8, size_t len) {
-    int32_t sector = flash_get_sector_info(addr, NULL, NULL);
-    if (sector < first_writable_flash_sector) {
+    bool valid = flash_is_valid_addr(addr);
+    if (!valid || !flash_is_modifiable_addr_range(addr, len)) {
         // Don't allow to write the sector with this bootloader in it, or invalid sectors.
         dfu_context.status = DFU_STATUS_ERROR_ADDRESS;
-        dfu_context.error = (sector == 0) ? MBOOT_ERROR_STR_OVERWRITE_BOOTLOADER_IDX
-                                          : MBOOT_ERROR_STR_INVALID_ADDRESS_IDX;
+        dfu_context.error = (!valid) ? MBOOT_ERROR_STR_INVALID_ADDRESS_IDX
+                                     : MBOOT_ERROR_STR_OVERWRITE_BOOTLOADER_IDX;
         return -MBOOT_ERRNO_FLASH_WRITE_DISALLOWED;
     }
 
@@ -1495,12 +1499,6 @@ enter_bootloader:
     pri <<= (8 - __NVIC_PRIO_BITS);
     __ASM volatile ("msr basepri_max, %0" : : "r" (pri) : "memory");
     #endif
-
-    // Compute the first erasable/writable internal flash sector.
-    first_writable_flash_sector = flash_get_sector_info((uint32_t)&_mboot_writable_flash_start, NULL, NULL);
-    if (first_writable_flash_sector < 0) {
-        first_writable_flash_sector = INT32_MAX;
-    }
 
     #if defined(MBOOT_SPIFLASH_ADDR)
     MBOOT_SPIFLASH_SPIFLASH->config = MBOOT_SPIFLASH_CONFIG;

--- a/ports/stm32/mboot/stm32_memory.ld
+++ b/ports/stm32/mboot/stm32_memory.ld
@@ -9,6 +9,6 @@ MEMORY
     RAM (xrw)       : ORIGIN = 0x20000000, LENGTH = 120K
 }
 
-/* Location from which mboot is allowed to write to flash.
-   Must be the start of a flash erase sector. */
-_mboot_writable_flash_start = ORIGIN(FLASH_BL) + LENGTH(FLASH_BL);
+/* Location of protected flash area which must not be modified, because mboot lives there. */
+_mboot_protected_flash_start = ORIGIN(FLASH_BL);
+_mboot_protected_flash_end_exclusive = ORIGIN(FLASH_BL) + LENGTH(FLASH_BL);


### PR DESCRIPTION
This PR:
- cleans up the flash sector erase code
- fixes flash sector erase bugs with H5/H7 MCUs, so that the sector number is correctly calculated for the second bank
- improves mass erase in mboot so that it works with MCUs that have multiple banks

TODO:
- [x] test internal flash filesystem access on various boards
- [x] test mboot mass erase
- [x] test mboot erase/write