### PR TITLE
ports/modmachine: Set a minimum delay time for lightsleep/deepsleep.

### DIFF
--- a/ports/rp2/modmachine.c
+++ b/ports/rp2/modmachine.c
@@ -46,6 +46,7 @@
 
 #define RP2_RESET_PWRON (1)
 #define RP2_RESET_WDT (3)
+#define RP2_LIGHTSLEEP_MIN (1)
 
 #define MICROPY_PY_MACHINE_EXTRA_GLOBALS \
     { MP_ROM_QSTR(MP_QSTR_Pin),                 MP_ROM_PTR(&machine_pin_type) }, \
@@ -111,9 +112,9 @@ static void mp_machine_lightsleep(size_t n_args, const mp_obj_t *args) {
 
     if (n_args == 1) {
         delay_ms = mp_obj_get_int(args[0]);
-        if (delay_ms <= 1) {
-            // Sleep is too small, just use standard delay.
-            mp_hal_delay_ms(delay_ms);
+        if (delay_ms <= RP2_LIGHTSLEEP_MIN) {
+            // Sleep time is too small, just use standard delay.
+            mp_hal_delay_ms(RP2_LIGHTSLEEP_MIN);
             return;
         }
         use_timer_alarm = delay_ms < (1ULL << 32) / 1000;

--- a/ports/samd/modmachine.c
+++ b/ports/samd/modmachine.c
@@ -117,6 +117,9 @@ static void mp_machine_lightsleep(size_t n_args, const mp_obj_t *args) {
     uint32_t freq = get_cpu_freq();
     if (n_args > 0) {
         duration = mp_obj_get_int(args[0]);
+        if (duration <= 0) {
+            return;
+        }
     }
     EIC_occured = false;
     // Slow down
@@ -130,7 +133,7 @@ static void mp_machine_lightsleep(size_t n_args, const mp_obj_t *args) {
     GCLK->CLKCTRL.reg = GCLK_CLKCTRL_CLKEN | GCLK_CLKCTRL_GEN_GCLK3 | EIC_GCLK_ID;
     if (duration > 0) {
         uint32_t t0 = systick_ms;
-        while ((systick_ms - t0 < duration) && (EIC_occured == false)) {
+        while (((systick_ms - t0) < duration) && (EIC_occured == false)) {
             __WFI();
         }
     } else {


### PR DESCRIPTION
rp2: enforce a minimal delay time of 1 ms, if supplied.
samd: return immediately if the delay value is <= 0.
mimxrt: set the delay to 1000 if a smaller value is supplied.

This behaviour matches the other ports, which return fast for a too small or negative delay value.