### PR TITLE
extmod/modonewire.c reliable timings for onewire.

### DIFF
--- a/extmod/modonewire.c
+++ b/extmod/modonewire.c
@@ -41,8 +41,8 @@
 #define TIMING_READ1  (6)
 #define TIMING_READ2  (9)
 #define TIMING_READ3  (55)
-#define TIMING_WRITE1 (10)
-#define TIMING_WRITE2 (50)
+#define TIMING_WRITE1 (6)
+#define TIMING_WRITE2 (54)
 #define TIMING_WRITE3 (10)
 
 STATIC int onewire_bus_reset(mp_hal_pin_obj_t pin) {


### PR DESCRIPTION
When using long cables for sensors on onewire e.g. ds18b20,
the current default timings might be to optimistic. 
Thus leading to bus failures and CRC errors.

Timings given by https://www.analog.com/en/technical-articles/1wire-communication-through-software.html give stable results.