### PR TITLE
Factor dupterm-notify implmentation, enable on rp2, and fix recursive execution of `mp_os_dupterm_rx_chr`

### DIFF
--- a/extmod/modos.c
+++ b/extmod/modos.c
@@ -24,6 +24,7 @@
  * THE SOFTWARE.
  */
 
+#include "py/mphal.h"
 #include "py/objstr.h"
 #include "py/runtime.h"
 
@@ -126,6 +127,21 @@ STATIC mp_obj_t mp_os_uname(void) {
 }
 STATIC MP_DEFINE_CONST_FUN_OBJ_0(mp_os_uname_obj, mp_os_uname);
 
+#endif
+
+#if MICROPY_PY_OS_DUPTERM_NOTIFY
+STATIC mp_obj_t mp_os_dupterm_notify(mp_obj_t obj_in) {
+    (void)obj_in;
+    for (;;) {
+        int c = mp_os_dupterm_rx_chr();
+        if (c < 0) {
+            break;
+        }
+        ringbuf_put(&stdin_ringbuf, c);
+    }
+    return mp_const_none;
+}
+STATIC MP_DEFINE_CONST_FUN_OBJ_1(mp_os_dupterm_notify_obj, mp_os_dupterm_notify);
 #endif
 
 STATIC const mp_rom_map_elem_t os_module_globals_table[] = {

--- a/ports/esp32/modos.c
+++ b/ports/esp32/modos.c
@@ -27,6 +27,9 @@
  * THE SOFTWARE.
  */
 
+// This file is never compiled standalone, it's included directly from
+// extmod/modos.c via MICROPY_PY_OS_INCLUDEFILE.
+
 #include "esp_system.h"
 
 #include "py/runtime.h"
@@ -48,18 +51,3 @@ STATIC mp_obj_t mp_os_urandom(mp_obj_t num) {
     return mp_obj_new_bytes_from_vstr(&vstr);
 }
 STATIC MP_DEFINE_CONST_FUN_OBJ_1(mp_os_urandom_obj, mp_os_urandom);
-
-#if MICROPY_PY_OS_DUPTERM_NOTIFY
-STATIC mp_obj_t mp_os_dupterm_notify(mp_obj_t obj_in) {
-    (void)obj_in;
-    for (;;) {
-        int c = mp_os_dupterm_rx_chr();
-        if (c < 0) {
-            break;
-        }
-        ringbuf_put(&stdin_ringbuf, c);
-    }
-    return mp_const_none;
-}
-STATIC MP_DEFINE_CONST_FUN_OBJ_1(mp_os_dupterm_notify_obj, mp_os_dupterm_notify);
-#endif

--- a/ports/esp8266/esp_mphal.c
+++ b/ports/esp8266/esp_mphal.c
@@ -134,33 +134,6 @@ void MP_FASTCODE(mp_hal_signal_input)(void) {
     #endif
 }
 
-STATIC void dupterm_task_handler(os_event_t *evt) {
-    static byte lock;
-    if (lock) {
-        return;
-    }
-    lock = 1;
-    while (1) {
-        int c = mp_os_dupterm_rx_chr();
-        if (c < 0) {
-            break;
-        }
-        ringbuf_put(&stdin_ringbuf, c);
-    }
-    mp_hal_signal_input();
-    lock = 0;
-}
-
-STATIC os_event_t dupterm_evt_queue[4];
-
-void dupterm_task_init() {
-    system_os_task(dupterm_task_handler, DUPTERM_TASK_ID, dupterm_evt_queue, MP_ARRAY_SIZE(dupterm_evt_queue));
-}
-
-void mp_hal_signal_dupterm_input(void) {
-    system_os_post(DUPTERM_TASK_ID, 0, 0);
-}
-
 // this bit is unused in the Xtensa PS register
 #define ETS_LOOP_ITER_BIT (12)
 

--- a/ports/esp8266/esp_mphal.h
+++ b/ports/esp8266/esp_mphal.h
@@ -41,8 +41,6 @@ extern const struct _mp_print_t mp_debug_print;
 extern ringbuf_t stdin_ringbuf;
 // Call this after putting data to stdin_ringbuf
 void mp_hal_signal_input(void);
-// Call this when data is available in dupterm object
-void mp_hal_signal_dupterm_input(void);
 
 // This variable counts how many times the UART is attached to dupterm
 extern int uart_attached_to_dupterm;
@@ -65,9 +63,7 @@ void mp_hal_set_interrupt_char(int c);
 uint32_t mp_hal_get_cpu_freq(void);
 
 #define UART_TASK_ID 0
-#define DUPTERM_TASK_ID 1
 void uart_task_init();
-void dupterm_task_init();
 
 uint32_t esp_disable_irq(void);
 void esp_enable_irq(uint32_t state);

--- a/ports/esp8266/main.c
+++ b/ports/esp8266/main.c
@@ -63,7 +63,6 @@ STATIC void mp_reset(void) {
     #endif
     pin_init0();
     readline_init0();
-    dupterm_task_init();
 
     // Activate UART(0) on dupterm slot 1 for the REPL
     {

--- a/ports/esp8266/modos.c
+++ b/ports/esp8266/modos.c
@@ -25,16 +25,10 @@
  * THE SOFTWARE.
  */
 
-#include <string.h>
+// This file is never compiled standalone, it's included directly from
+// extmod/modos.c via MICROPY_PY_OS_INCLUDEFILE.
 
-#include "py/objtuple.h"
-#include "py/objstr.h"
-#include "extmod/misc.h"
 #include "extmod/modmachine.h"
-#include "extmod/vfs.h"
-#include "extmod/vfs_fat.h"
-#include "extmod/vfs_lfs.h"
-#include "genhdr/mpversion.h"
 #include "user_interface.h"
 
 STATIC const char *mp_os_uname_release(void) {
@@ -60,10 +54,3 @@ void mp_os_dupterm_stream_detached_attached(mp_obj_t stream_detached, mp_obj_t s
         --uart_attached_to_dupterm;
     }
 }
-
-STATIC mp_obj_t mp_os_dupterm_notify(mp_obj_t obj_in) {
-    (void)obj_in;
-    mp_hal_signal_dupterm_input();
-    return mp_const_none;
-}
-STATIC MP_DEFINE_CONST_FUN_OBJ_1(mp_os_dupterm_notify_obj, mp_os_dupterm_notify);

--- a/ports/mimxrt/modos.c
+++ b/ports/mimxrt/modos.c
@@ -28,6 +28,9 @@
  * THE SOFTWARE.
  */
 
+// This file is never compiled standalone, it's included directly from
+// extmod/modos.c via MICROPY_PY_OS_INCLUDEFILE.
+
 #include "py/runtime.h"
 #include "py/mphal.h"
 
@@ -107,19 +110,4 @@ STATIC mp_obj_t mp_os_urandom(mp_obj_t num) {
     return mp_obj_new_bytes_from_vstr(&vstr);
 }
 STATIC MP_DEFINE_CONST_FUN_OBJ_1(mp_os_urandom_obj, mp_os_urandom);
-#endif
-
-#if MICROPY_PY_OS_DUPTERM_NOTIFY
-STATIC mp_obj_t mp_os_dupterm_notify(mp_obj_t obj_in) {
-    (void)obj_in;
-    for (;;) {
-        int c = mp_os_dupterm_rx_chr();
-        if (c < 0) {
-            break;
-        }
-        ringbuf_put(&stdin_ringbuf, c);
-    }
-    return mp_const_none;
-}
-STATIC MP_DEFINE_CONST_FUN_OBJ_1(mp_os_dupterm_notify_obj, mp_os_dupterm_notify);
 #endif

--- a/ports/rp2/mpconfigport.h
+++ b/ports/rp2/mpconfigport.h
@@ -98,6 +98,7 @@
 #define MICROPY_PY_OS_INCLUDEFILE               "ports/rp2/modos.c"
 #ifndef MICROPY_PY_OS_DUPTERM
 #define MICROPY_PY_OS_DUPTERM                   (1)
+#define MICROPY_PY_OS_DUPTERM_NOTIFY            (1)
 #endif
 #define MICROPY_PY_OS_SYNC                      (1)
 #define MICROPY_PY_OS_UNAME                     (1)

--- a/ports/samd/modos.c
+++ b/ports/samd/modos.c
@@ -29,6 +29,9 @@
  * THE SOFTWARE.
  */
 
+// This file is never compiled standalone, it's included directly from
+// extmod/modos.c via MICROPY_PY_OS_INCLUDEFILE.
+
 #include "py/runtime.h"
 #include "py/mphal.h"
 #include "modmachine.h"
@@ -95,19 +98,4 @@ bool mp_os_dupterm_is_builtin_stream(mp_const_obj_t stream) {
     const mp_obj_type_t *type = mp_obj_get_type(stream);
     return type == &machine_uart_type;
 }
-#endif
-
-#if MICROPY_PY_OS_DUPTERM_NOTIFY
-STATIC mp_obj_t mp_os_dupterm_notify(mp_obj_t obj_in) {
-    (void)obj_in;
-    for (;;) {
-        int c = mp_os_dupterm_rx_chr();
-        if (c < 0) {
-            break;
-        }
-        ringbuf_put(&stdin_ringbuf, c);
-    }
-    return mp_const_none;
-}
-STATIC MP_DEFINE_CONST_FUN_OBJ_1(mp_os_dupterm_notify_obj, mp_os_dupterm_notify);
 #endif


### PR DESCRIPTION
This is an alternative to #9297, to implement `os.dupterm_notify()` on rp2.  As part of the implementation it factors all existing ports' implementations of this function into `extmod/modos.c`.  Then it can simply be enabled via `MICROPY_PY_OS_DUPTERM_NOTIFY`.

The PR also attempts to fix problems with recursively calling dupterm RX, which were apparent on rp2.