### PR TITLE
extmod/asyncio: Remove non-working Stream __aenter__/__aexit__ methods.

### DIFF
--- a/extmod/asyncio/stream.py
+++ b/extmod/asyncio/stream.py
@@ -13,12 +13,6 @@ class Stream:
     def get_extra_info(self, v):
         return self.e[v]
 
-    async def __aenter__(self):
-        return self
-
-    async def __aexit__(self, exc_type, exc, tb):
-        await self.close()
-
     def close(self):
         pass
 


### PR DESCRIPTION
It looks like these never worked and there are no tests for this functionality.  Furthermore, CPython doesn't support this.

Fixes #12995.