### PR TITLE
tools/makemanifest.py: Provide access to MICROPY_MANIFEST_xxx symbols.

### DIFF
--- a/py/mkrules.mk
+++ b/py/mkrules.mk
@@ -206,6 +206,9 @@ MICROPY_MANIFEST_MPY_LIB_DIR = $(MPY_LIB_DIR)
 MICROPY_MANIFEST_PORT_DIR = $(shell pwd)
 MICROPY_MANIFEST_BOARD_DIR = $(BOARD_DIR)
 MICROPY_MANIFEST_MPY_DIR = $(TOP)
+# Set variables for BOARD and BOARD_VARIANT by default
+MICROPY_MANIFEST_BOARD = $(BOARD)
+MICROPY_MANIFEST_BOARD_VARIANT = $(BOARD_VARIANT)
 
 # Find all MICROPY_MANIFEST_* variables and turn them into command line arguments.
 MANIFEST_VARIABLES = $(foreach var,$(filter MICROPY_MANIFEST_%, $(.VARIABLES)),-v "$(subst MICROPY_MANIFEST_,,$(var))=$($(var))")

--- a/tools/makemanifest.py
+++ b/tools/makemanifest.py
@@ -143,7 +143,7 @@ def main():
     # Extract variables for substitution.
     for var in args.var:
         name, value = var.split("=", 1)
-        if os.path.exists(value):
+        if name in ("MPY_DIR", "MPY_LIB_DIR", "BOARD_DIR", "PORT_DIR") and os.path.exists(value):
             value = os.path.abspath(value)
         VARS[name] = value
 

--- a/tools/manifestfile.py
+++ b/tools/manifestfile.py
@@ -222,6 +222,7 @@ class ManifestFile:
             "add_library": self.add_library,
             "package": self.package,
             "module": self.module,
+            "resolve": self.resolve,
             "options": IncludeOptions(**kwargs),
         }
 
@@ -571,6 +572,12 @@ class ManifestFile:
         frozen directly.
         """
         self._freeze_internal(path, script, exts=(".mpy",), kind=KIND_FREEZE_MPY, opt=opt)
+
+    def resolve(self, name):
+        if name[0] == "$" and name[1:] in self._path_vars.keys():
+            return self._path_vars[name[1:]]
+        else:
+            return None
 
 
 # Generate a temporary file with a line appended to the end that adds __version__.


### PR DESCRIPTION
The new function resolve(name) returns the value of a Makefile symbol defined as MICROPY_MANIFEST_<name>.

Example:

Makefile:

MICROPY_MANIFEST_FROZEN_SET = "default"

manifest.py:

frozen_set = resolve("$FROZEN_SET")

If name is not defined, resolve() returns `None`.

Notes:
- Instead of "resolve" the function may have any other appropriate name.
- The "$XYZ" notation was kept for consistency with the other functions.

P.S.: In case that this feature existed already, just give me a hint and sorry for the wasting your time.