### PR TITLE
extmod/vfs_lfs: Fix lfs cache_size calculation.

### DIFF
--- a/extmod/vfs_lfsx.c
+++ b/extmod/vfs_lfsx.c
@@ -99,7 +99,7 @@ STATIC void MP_VFS_LFSx(init_config)(MP_OBJ_VFS_LFSx * self, mp_obj_t bdev, size
     config->lookahead_buffer = m_new(uint8_t, config->lookahead / 8);
     #else
     config->block_cycles = 100;
-    config->cache_size = 4 * MAX(read_size, prog_size);
+    config->cache_size = MIN(config->block_size, (4 * MAX(read_size, prog_size)));
     config->lookahead_size = lookahead;
     config->read_buffer = m_new(uint8_t, config->cache_size);
     config->prog_buffer = m_new(uint8_t, config->cache_size);


### PR DESCRIPTION
The calculation of the lfs2 `cache_size` was incorrect, the maximum allowed size is block_size.

The cache size must be:  
> a multiple of the read and program sizes, and a factor of the block size.


This was discovered when re-writing https://github.com/peterzuger/extended-block-device-micropython from a previous implementation in python.

The python implementation used a cache to allow read/writeblocks with offsets, the new C-implementation only allows `offset=0` and this requires `os.VfsLfs2(readsize=blocksize, progsize=blocksize)`. This caused missing blockdevice writes (and other filesystem errors) from littlefs because of the incorrect `cache_size` calculation.

This is also checked and detected when enabling asserts in littlefs.