### PR TITLE
py/mkrules.mk: Fix dependency file generation for compiler wrappers.

### DIFF
--- a/py/mkrules.mk
+++ b/py/mkrules.mk
@@ -63,7 +63,7 @@ $(BUILD)/%.o: %.s
 
 define compile_c
 $(ECHO) "CC $<"
-$(Q)$(CC) $(CFLAGS) -c -MD -o $@ $< || (echo -e $(HELP_BUILD_ERROR); false)
+$(Q)$(CC) $(CFLAGS) -c -MD -MF $(@:.o=.d) -o $@ $< || (echo -e $(HELP_BUILD_ERROR); false)
 @# The following fixes the dependency file.
 @# See http://make.paulandlesley.org/autodep.html for details.
 @# Regex adjusted from the above to play better with Windows paths, etc.
@@ -75,7 +75,7 @@ endef
 
 define compile_cxx
 $(ECHO) "CXX $<"
-$(Q)$(CXX) $(CXXFLAGS) -c -MD -o $@ $< || (echo -e $(HELP_BUILD_ERROR); false)
+$(Q)$(CXX) $(CXXFLAGS) -c -MD -MF $(@:.o=.d) -o $@ $< || (echo -e $(HELP_BUILD_ERROR); false)
 @# The following fixes the dependency file.
 @# See http://make.paulandlesley.org/autodep.html for details.
 @# Regex adjusted from the above to play better with Windows paths, etc.


### PR DESCRIPTION
When compiling micropython with [distcc](https://www.distcc.org/), it does not understand the [`-MD`](https://gcc.gnu.org/onlinedocs/gcc/Preprocessor-Options.html#index-MD) flag on its own, this fixes the interaction by explicitly adding the [`-MF`](https://gcc.gnu.org/onlinedocs/gcc/Preprocessor-Options.html#index-MF) option.

The error in distcc is described here under "Problems with gcc -MD":
https://www.distcc.org/faq.html