### PR TITLE
ports/nrf: Add default folders to sys path.

### DIFF
--- a/ports/nrf/main.c
+++ b/ports/nrf/main.c
@@ -191,6 +191,9 @@ soft_reset:
 
     if (ret != 0) {
         printf("MPY: can't mount flash\n");
+    } else {
+        mp_obj_list_append(mp_sys_path, MP_OBJ_NEW_QSTR(MP_QSTR__slash_flash));
+        mp_obj_list_append(mp_sys_path, MP_OBJ_NEW_QSTR(MP_QSTR__slash_flash_slash_lib));
     }
     #endif
 

--- a/ports/nrf/qstrdefsport.h
+++ b/ports/nrf/qstrdefsport.h
@@ -29,6 +29,7 @@
 
 // Entries for sys.path
 Q(/flash)
+Q(/flash/lib)
 
 // For os.sep
 Q(/)


### PR DESCRIPTION
This PR adds `/flash` and `/flash/lib` to the system path. This allows to follow good practice and have libraries live in the `lib` folder which means they will be found by the runtime without adding this path manually at runtime.

Thanks to @iabdalkader for the guidance on how to make those changes.