### PR TITLE
extmod/nimble: Support pairing/bonding on the ESP32.

### DIFF
--- a/docs/library/bluetooth.rst
+++ b/docs/library/bluetooth.rst
@@ -722,7 +722,7 @@ Pairing and bonding
     and ``_IRQ_SET_SECRET`` events.
 
     **Note:** This is currently only supported when using the NimBLE stack on
-    STM32 and Unix (not ESP32).
+    ESP32, STM32 and Unix.
 
 .. method:: BLE.gap_pair(conn_handle, /)
 

--- a/extmod/nimble/modbluetooth_nimble.c
+++ b/extmod/nimble/modbluetooth_nimble.c
@@ -592,17 +592,6 @@ int mp_bluetooth_init(void) {
 
     mp_bluetooth_nimble_ble_state = MP_BLUETOOTH_NIMBLE_BLE_STATE_STARTING;
 
-    ble_hs_cfg.reset_cb = reset_cb;
-    ble_hs_cfg.sync_cb = sync_cb;
-    ble_hs_cfg.gatts_register_cb = gatts_register_cb;
-    ble_hs_cfg.store_status_cb = ble_store_util_status_rr;
-
-    #if MICROPY_PY_BLUETOOTH_ENABLE_PAIRING_BONDING
-    ble_hs_cfg.store_read_cb = ble_secret_store_read;
-    ble_hs_cfg.store_write_cb = ble_secret_store_write;
-    ble_hs_cfg.store_delete_cb = ble_secret_store_delete;
-    #endif // MICROPY_PY_BLUETOOTH_ENABLE_PAIRING_BONDING
-
     MP_STATE_PORT(bluetooth_nimble_root_pointers) = m_new0(mp_bluetooth_nimble_root_pointers_t, 1);
     mp_bluetooth_gatts_db_create(&MP_STATE_PORT(bluetooth_nimble_root_pointers)->gatts_db);
 
@@ -621,6 +610,17 @@ int mp_bluetooth_init(void) {
     // Initialise NimBLE memory and data structures.
     DEBUG_printf("mp_bluetooth_init: nimble_port_init\n");
     nimble_port_init();
+
+    ble_hs_cfg.reset_cb = reset_cb;
+    ble_hs_cfg.sync_cb = sync_cb;
+    ble_hs_cfg.gatts_register_cb = gatts_register_cb;
+    ble_hs_cfg.store_status_cb = ble_store_util_status_rr;
+
+    #if MICROPY_PY_BLUETOOTH_ENABLE_PAIRING_BONDING
+    ble_hs_cfg.store_read_cb = ble_secret_store_read;
+    ble_hs_cfg.store_write_cb = ble_secret_store_write;
+    ble_hs_cfg.store_delete_cb = ble_secret_store_delete;
+    #endif // MICROPY_PY_BLUETOOTH_ENABLE_PAIRING_BONDING
 
     // Make sure that the HCI UART and event handling task is running.
     mp_bluetooth_nimble_port_start();

--- a/extmod/nimble/modbluetooth_nimble.c
+++ b/extmod/nimble/modbluetooth_nimble.c
@@ -617,6 +617,8 @@ int mp_bluetooth_init(void) {
     ble_hs_cfg.store_status_cb = ble_store_util_status_rr;
 
     #if MICROPY_PY_BLUETOOTH_ENABLE_PAIRING_BONDING
+    ble_hs_cfg.sm_our_key_dist = BLE_SM_PAIR_KEY_DIST_ENC | BLE_SM_PAIR_KEY_DIST_ID | BLE_SM_PAIR_KEY_DIST_SIGN;
+    ble_hs_cfg.sm_their_key_dist = BLE_SM_PAIR_KEY_DIST_ENC | BLE_SM_PAIR_KEY_DIST_ID | BLE_SM_PAIR_KEY_DIST_SIGN;
     ble_hs_cfg.store_read_cb = ble_secret_store_read;
     ble_hs_cfg.store_write_cb = ble_secret_store_write;
     ble_hs_cfg.store_delete_cb = ble_secret_store_delete;


### PR DESCRIPTION
Two fixes to NimBLE to fix compatibility with the ESP-IDF.

The first commit moves the runtime initialisation of `ble_hs_cfg` to happen after `nimble_port_init()`. That is consistent with the order used in NimBLE examples. On the ESP32 port this is needed because the ESP-IDF sets up the default RAM secret store callbacks in its implementation of `nimble_port_init()` (specifically, it calls `esp_nimble_init()` which in turn calls `ble_store_ram_init()`). We want to override those callbacks with our own so used to implement the `IRQ_[GS]ET_SECRET` events in Python.

The second commit sets the BLE key distribution parameters at runtime. This isn't needed in most ports since we already set the default values in `extmod/nimble/syscfg/syscfg.h`; however in the ESP32 port that headerfile is not used, and the default values in the ESP-IDF don't enable key distribution nor can we change those defaults via `sdkconfig`. Setting the values explicitly at runtime seems like a reasonable solution.

These two commits together make persistent pairing/bonding work on the ESP32 in my own local tests.

Third commit updates the documentation to mention that the ESP32 now also supports pairing/bonding.

Fixes #12958.