### PR TITLE
esp32/modesp32.c: Add mcu_temperature() function for C3/S2/S3 devices.

### DIFF
--- a/docs/esp32/quickref.rst
+++ b/docs/esp32/quickref.rst
@@ -18,6 +18,9 @@ working with this board it may be useful to get an overview of the microcontroll
    general.rst
    tutorial/index.rst
 
+Note that there are several varieties of ESP32 -- ESP32, ESP32C3, ESP32S2, ESP32S3 --
+supported by MicroPython, with some differences in functionality between them.
+
 Installing MicroPython
 ----------------------
 
@@ -58,7 +61,7 @@ The :mod:`esp32` module::
     import esp32
 
     esp32.raw_temperature() # read the internal temperature of the MCU, in Fahrenheit
-    esp32.ULP()             # access to the Ultra-Low-Power Co-processor
+    esp32.ULP()             # access to the Ultra-Low-Power Co-processor, not on ESP32C3
 
 Note that the temperature sensor in the ESP32 will typically read higher than
 ambient due to the IC getting warm while it runs.  This effect can be minimised

--- a/docs/esp32/quickref.rst
+++ b/docs/esp32/quickref.rst
@@ -67,6 +67,12 @@ Note that the temperature sensor in the ESP32 will typically read higher than
 ambient due to the IC getting warm while it runs.  This effect can be minimised
 by reading the temperature sensor immediately after waking up from sleep.
 
+ESP32C3, ESP32S2, and ESP32S3 also have an internal temperature sensor available.
+It is implemented a bit differently to the ESP32 and returns the temperature in
+Celsius::
+
+    esp32.mcu_temperature() # read the internal temperature of the MCU, in Celsius
+
 Networking
 ----------
 


### PR DESCRIPTION
For ESP32C3/S2/S3 IDFv5 exposes new internal temperature API which is different than base ESP32, IDFv4.

Thanks to @robert-hh for cleaner code and testing sensor capability in these devices.

See discussion #10443