### PR TITLE
ports/mimxrt/mpbthciport: Add missing extmod/modmachine.h header.

### DIFF
--- a/ports/mimxrt/mpbthciport.c
+++ b/ports/mimxrt/mpbthciport.c
@@ -29,6 +29,7 @@
 #include "py/stream.h"
 #include "py/mphal.h"
 #include "extmod/modbluetooth.h"
+#include "extmod/modmachine.h"
 #include "extmod/mpbthci.h"
 #include "shared/runtime/softtimer.h"
 #include "modmachine.h"


### PR DESCRIPTION
Include extmod/modmachine.h for machine_uart_type declaration.