### PR TITLE
rp2: fix atomic section

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -69,6 +69,8 @@ used during the build process and is not part of the compiled source code.
             /FreeRTOS (GPL-2.0 with FreeRTOS exception)
         /esp32
             /ppp_set_auth.* (Apache-2.0)
+        /rp2
+            /mutex_extra.c (BSD-3-clause)
         /stm32
             /usbd*.c (MCD-ST Liberty SW License Agreement V2)
             /stm32_it.* (MIT + BSD-3-clause)

--- a/ports/rp2/CMakeLists.txt
+++ b/ports/rp2/CMakeLists.txt
@@ -129,6 +129,7 @@ set(MICROPY_SOURCE_PORT
     mphalport.c
     mpnetworkport.c
     mpthreadport.c
+    mutex_extra.c
     pendsv.c
     rp2_flash.c
     rp2_pio.c

--- a/ports/rp2/mpthreadport.c
+++ b/ports/rp2/mpthreadport.c
@@ -52,9 +52,6 @@ uint32_t mp_thread_begin_atomic_section(void) {
         // When both cores are executing, we also need to provide
         // full mutual exclusion.
         mp_thread_mutex_lock(&atomic_mutex, 1);
-        // In case this atomic section is for flash access, then
-        // suspend the other core.
-        multicore_lockout_start_blocking();
     }
 
     return save_and_disable_interrupts();
@@ -64,7 +61,6 @@ void mp_thread_end_atomic_section(uint32_t state) {
     restore_interrupts(state);
 
     if (core1_entry) {
-        multicore_lockout_end_blocking();
         mp_thread_mutex_unlock(&atomic_mutex);
     }
 }

--- a/ports/rp2/mutex_extra.c
+++ b/ports/rp2/mutex_extra.c
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2020 Raspberry Pi (Trading) Ltd.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#include "mutex_extra.h"
+
+// These functions are taken from lib/pico-sdk/src/common/pico_sync/mutex.c and modified
+// so that they atomically obtain the mutex and disable interrupts.
+
+uint32_t __time_critical_func(mutex_enter_blocking_and_disable_interrupts)(mutex_t * mtx) {
+    lock_owner_id_t caller = lock_get_caller_owner_id();
+    do {
+        uint32_t save = spin_lock_blocking(mtx->core.spin_lock);
+        if (!lock_is_owner_id_valid(mtx->owner)) {
+            mtx->owner = caller;
+            spin_unlock_unsafe(mtx->core.spin_lock);
+            return save;
+        }
+        lock_internal_spin_unlock_with_wait(&mtx->core, save);
+    } while (true);
+}
+
+void __time_critical_func(mutex_exit_and_restore_interrupts)(mutex_t * mtx, uint32_t save) {
+    spin_lock_unsafe_blocking(mtx->core.spin_lock);
+    assert(lock_is_owner_id_valid(mtx->owner));
+    mtx->owner = LOCK_INVALID_OWNER_ID;
+    lock_internal_spin_unlock_with_notify(&mtx->core, save);
+}

--- a/ports/rp2/mutex_extra.h
+++ b/ports/rp2/mutex_extra.h
@@ -1,0 +1,34 @@
+/*
+ * This file is part of the MicroPython project, http://micropython.org/
+ *
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2023 Damien P. George
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+#ifndef MICROPY_INCLUDED_RP2_MUTEX_EXTRA_H
+#define MICROPY_INCLUDED_RP2_MUTEX_EXTRA_H
+
+#include "pico/mutex.h"
+
+uint32_t mutex_enter_blocking_and_disable_interrupts(mutex_t *mtx);
+void mutex_exit_and_restore_interrupts(mutex_t *mtx, uint32_t save);
+
+#endif // MICROPY_INCLUDED_RP2_MUTEX_EXTRA_H


### PR DESCRIPTION
This is an attempt to fix #12980 and #13288.

~~There are two fixes to the `MICROPY_BEGIN_ATOMIC_SECTION`/`
MICROPY_END_ATOMIC_SECTION` on the rp2 port:~~
- ~~Use a recursive mutex to prevent deadlocks on the same thread, in the case an IRQ races against the thread level (on the same core) when acquiring the atomic section (mutex may be taken but IRQs not yet disabled, then the IRQ waits forever trying to acquire the mutux).~~
- ~~Unlock the mutex if it was locked, not if `core1_entry` is still non-null, to fix the case where the second core finishes (and sets `core1_entry` to `NULL`) while the first core is in the middle of an atomic operation.~~

Edit: the two changes are now:
1. split out multicore lockout handling so it's only done when doing a flash erase/write
2. change the ATOMIC_SECTION macros so they use new mutex enter/exit functions that also disable/restore interrupts (atomically).