### PR TITLE
fix: Compare length before memcmp

### DIFF
--- a/extmod/vfs.c
+++ b/extmod/vfs.c
@@ -273,7 +273,7 @@ mp_obj_t mp_vfs_umount(mp_obj_t mnt_in) {
         mnt_str = mp_obj_str_get_data(mnt_in, &mnt_len);
     }
     for (mp_vfs_mount_t **vfsp = &MP_STATE_VM(vfs_mount_table); *vfsp != NULL; vfsp = &(*vfsp)->next) {
-        if ((mnt_str != NULL && !memcmp(mnt_str, (*vfsp)->str, mnt_len + 1)) || (*vfsp)->obj == mnt_in) {
+        if ((mnt_str != NULL && mnt_len == (*vfsp)->len && !memcmp(mnt_str, (*vfsp)->str, mnt_len)) || (*vfsp)->obj == mnt_in) {
             vfs = *vfsp;
             *vfsp = (*vfsp)->next;
             break;


### PR DESCRIPTION
Hi,
I patched the buffer overflow discussed at #13006
The comparison between the given unmount string and existing mount strings were made by the given string,
which leads to buffer overflow. 

```
# Test for VfsLittle using a RAM device, with mount/umount

try:
    import os

    os.VfsLfs1
except (ImportError, AttributeError):
    print("SKIP")
    raise SystemExit

class RAMBlockDevice:
    ERASE_BLOCK_SIZE = 1024

    def __init__(self, blocks):
        self.data = bytearray(blocks * self.ERASE_BLOCK_SIZE)

    def readblocks(self, block, buf, off=0):
        addr = block * self.ERASE_BLOCK_SIZE + off
        for i in range(len(buf)):
            buf[i] = self.data[addr + i]

    def writeblocks(self, block, buf, off=0):
        addr = block * self.ERASE_BLOCK_SIZE + off
        for i in range(len(buf)):
            self.data[addr + i] = buf[i]

    def ioctl(self, op, arg):
        if op == 4:  # block count
            return len(self.data) // self.ERASE_BLOCK_SIZE
        if op == 5:  # block size
            return self.ERASE_BLOCK_SIZE
        if op == 6:  # erase block
            return 0

def test(vfs_class):
    bdev = RAMBlockDevice(10)
    vfs_class.mkfs(bdev)  # construction
    vfs = vfs_class(bdev)

# mount
    os.mount(vfs, "/lfs")
# umount
    os.umount("/lffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffs")

import sys

sys.path.clear()
sys.path.append("/lfs")
sys.path.append("")

# run tests
test(os.VfsLfs1)
```