### PR TITLE
zephyr: Link MicroPython with the Zephyr kernel library.

### DIFF
--- a/ports/zephyr/CMakeLists.txt
+++ b/ports/zephyr/CMakeLists.txt
@@ -109,6 +109,7 @@ zephyr_library_compile_definitions(
 )
 
 zephyr_library_sources(${MICROPY_SOURCE_QSTR})
+zephyr_library_link_libraries(kernel)
 
 add_dependencies(${MICROPY_TARGET} zephyr_generated_headers)
 

--- a/ports/zephyr/src/zephyr_start.c
+++ b/ports/zephyr/src/zephyr_start.c
@@ -36,8 +36,4 @@ void main(void) {
     zephyr_getchar_init();
     #endif
     real_main();
-
-    // This is needed so the linker includes k_timer_init, z_impl_k_timer_start
-    // and z_impl_k_timer_stop, as used by libmicropython.a.
-    k_timer_start(NULL, K_MSEC(0), K_MSEC(0));
 }


### PR DESCRIPTION
Unlike most other Zephyr libraries, libkernel.a is not built as a whole-archive.

This change also fixes a linker error observed on nucleo_wb55rg while preparing an upgrade to Zephyr v3.5.0, caused by an undefined reference to `z_impl_k_busy_wait'.

Fixes the CI failure in #9335 
https://github.com/micropython/micropython/actions/runs/6671185807/job/18132599350?pr=9335