### PR TITLE
tests/run-multitests.py: Change to dir of test script when running it.

### DIFF
--- a/tests/multi_net/asyncio_tls_server_client.py
+++ b/tests/multi_net/asyncio_tls_server_client.py
@@ -11,8 +11,8 @@ except ImportError:
 PORT = 8000
 
 # These are test certificates. See tests/README.md for details.
-cert = cafile = "multi_net/rsa_cert.der"
-key = "multi_net/rsa_key.der"
+cert = cafile = "rsa_cert.der"
+key = "rsa_key.der"
 
 try:
     os.stat(cafile)

--- a/tests/multi_net/asyncio_tls_server_client_cert_required_error.py
+++ b/tests/multi_net/asyncio_tls_server_client_cert_required_error.py
@@ -11,8 +11,8 @@ except ImportError:
 PORT = 8000
 
 # These are test certificates. See tests/README.md for details.
-cert = cafile = "multi_net/rsa_cert.der"
-key = "multi_net/rsa_key.der"
+cert = cafile = "rsa_cert.der"
+key = "rsa_key.der"
 
 try:
     os.stat(cafile)

--- a/tests/multi_net/asyncio_tls_server_client_readline.py
+++ b/tests/multi_net/asyncio_tls_server_client_readline.py
@@ -11,8 +11,8 @@ except ImportError:
 PORT = 8000
 
 # These are test certificates. See tests/README.md for details.
-cert = cafile = "multi_net/rsa_cert.der"
-key = "multi_net/rsa_key.der"
+cert = cafile = "rsa_cert.der"
+key = "rsa_key.der"
 
 try:
     os.stat(cafile)

--- a/tests/multi_net/asyncio_tls_server_client_verify_error.py
+++ b/tests/multi_net/asyncio_tls_server_client_verify_error.py
@@ -11,8 +11,8 @@ except ImportError:
 PORT = 8000
 
 # These are test certificates. See tests/README.md for details.
-cert = cafile = "multi_net/rsa_cert.der"
-key = "multi_net/rsa_key.der"
+cert = cafile = "rsa_cert.der"
+key = "rsa_key.der"
 
 try:
     os.stat(cafile)

--- a/tests/multi_net/ssl_cert_rsa.py
+++ b/tests/multi_net/ssl_cert_rsa.py
@@ -10,8 +10,8 @@ except ImportError:
 PORT = 8000
 
 # These are test certificates. See tests/README.md for details.
-certfile = "multi_net/rsa_cert.der"
-keyfile = "multi_net/rsa_key.der"
+certfile = "rsa_cert.der"
+keyfile = "rsa_key.der"
 
 try:
     os.stat(certfile)

--- a/tests/multi_net/sslcontext_check_hostname_error.py
+++ b/tests/multi_net/sslcontext_check_hostname_error.py
@@ -11,8 +11,8 @@ except ImportError:
 PORT = 8000
 
 # These are test certificates. See tests/README.md for details.
-cert = cafile = "multi_net/rsa_cert.der"
-key = "multi_net/rsa_key.der"
+cert = cafile = "rsa_cert.der"
+key = "rsa_key.der"
 
 try:
     os.stat(cafile)

--- a/tests/multi_net/sslcontext_getpeercert.py
+++ b/tests/multi_net/sslcontext_getpeercert.py
@@ -12,8 +12,8 @@ except ImportError:
 PORT = 8000
 
 # These are test certificates. See tests/README.md for details.
-cert = cafile = "multi_net/rsa_cert.der"
-key = "multi_net/rsa_key.der"
+cert = cafile = "rsa_cert.der"
+key = "rsa_key.der"
 
 try:
     os.stat(cafile)

--- a/tests/multi_net/sslcontext_server_client.py
+++ b/tests/multi_net/sslcontext_server_client.py
@@ -11,8 +11,8 @@ except ImportError:
 PORT = 8000
 
 # These are test certificates. See tests/README.md for details.
-certfile = "multi_net/rsa_cert.der"
-keyfile = "multi_net/rsa_key.der"
+certfile = "rsa_cert.der"
+keyfile = "rsa_key.der"
 
 try:
     os.stat(certfile)

--- a/tests/multi_net/sslcontext_server_client_ciphers.py
+++ b/tests/multi_net/sslcontext_server_client_ciphers.py
@@ -11,8 +11,8 @@ except ImportError:
 PORT = 8000
 
 # These are test certificates. See tests/README.md for details.
-cert = cafile = "multi_net/rsa_cert.der"
-key = "multi_net/rsa_key.der"
+cert = cafile = "rsa_cert.der"
+key = "rsa_key.der"
 
 try:
     os.stat(cafile)

--- a/tests/multi_net/sslcontext_server_client_files.py
+++ b/tests/multi_net/sslcontext_server_client_files.py
@@ -11,8 +11,8 @@ except ImportError:
 PORT = 8000
 
 # These are test certificates. See tests/README.md for details.
-cert = cafile = "multi_net/rsa_cert.der"
-key = "multi_net/rsa_key.der"
+cert = cafile = "rsa_cert.der"
+key = "rsa_key.der"
 
 try:
     os.stat(cafile)

--- a/tests/multi_net/sslcontext_verify_error.py
+++ b/tests/multi_net/sslcontext_verify_error.py
@@ -11,8 +11,8 @@ except ImportError:
 PORT = 8000
 
 # These are test certificates. See tests/README.md for details.
-cert = cafile = "multi_net/rsa_cert.der"
-key = "multi_net/rsa_key.der"
+cert = cafile = "rsa_cert.der"
+key = "rsa_key.der"
 
 try:
     os.stat(cafile)

--- a/tests/multi_net/sslcontext_verify_time_error.py
+++ b/tests/multi_net/sslcontext_verify_time_error.py
@@ -11,8 +11,8 @@ except ImportError:
 PORT = 8000
 
 # These are test certificates. See tests/README.md for details.
-cert = cafile = "multi_net/expired_cert.der"
-key = "multi_net/rsa_key.der"
+cert = cafile = "expired_cert.der"
+key = "rsa_key.der"
 
 try:
     os.stat(cafile)


### PR DESCRIPTION
This matches the behaviour of run-tests.py, which sets cwd to the directory containing the test script, which helps to isolate the filesystem.

It means that the SSL tests no longer need to know the name of their containing directory to find the certificate files, and helps to run these tests on bare-metal.