### PR TITLE
esp32 M5STACK_ATOM: Add set_pixel_color_x_y and get_pixel_color_x_y.

### DIFF
--- a/ports/esp32/boards/M5STACK_ATOM/modules/atom.py
+++ b/ports/esp32/boards/M5STACK_ATOM/modules/atom.py
@@ -73,3 +73,13 @@ class Matrix(ATOM):
     # WS2812 number: 25
     def __init__(self):
         super(Matrix, self).__init__(np_n=25)
+
+    def set_pixel_color_x_y(self, x, y, r, g, b):
+        if (0 <= x < 5) and (0 <= y < 5):
+            n = (y * 5) + x
+            self.set_pixel_color(n, r, g, b)
+
+    def get_pixel_color_x_y(self, x, y):
+        if (0 <= x < 5) and (0 <= y < 5):
+            n = (y * 5) + x
+            return self.get_pixel_color(n)


### PR DESCRIPTION
This pull request adds utility functions to set and get pixel colors on an M5Stack Atom Matrix device by `x`, `y` position.

Valid values of `x` and `y` are 0-4 inclusive.

Tested on an M5Stack Atom Matrix as follows:

```
>>> import atom
>>> a = atom.Matrix()
>>> a.set_pixel_color_x_y(0, 0, 16, 0, 0)
>>> a.set_pixel_color_x_y(4, 4, 0, 16, 0)
>>> a.get_pixel_color_x_y(0, 0)
(16, 0, 0)
>>> a.set_pixel_color_x_y(5, 0, 16, 0, 0)
>>> a.set_pixel_color_x_y(0, 5, 16, 0, 0)
>>> a.get_pixel_color_x_y(6, 6)
>>> a.get_pixel_color_x_y(-1, -1)
```

Follows convention established in `atom.py` that invalid values for `x` and `y` do nothing.

Image showing the code above running on a device...

![IMG_8333](https://github.com/micropython/micropython/assets/94062/44fec758-83e0-4aa3-85be-352e2429c8fe)
