### PR TITLE
embed: Fix alloca include for FreeBSD and NetBSD.

### DIFF
--- a/ports/embed/port/mpconfigport_common.h
+++ b/ports/embed/port/mpconfigport_common.h
@@ -33,6 +33,10 @@ typedef uintptr_t mp_uint_t; // must be pointer size
 typedef long mp_off_t;
 
 // Need to provide a declaration/definition of alloca()
+#if defined(__FreeBSD__) || defined(__NetBSD__)
+#include <stdlib.h>
+#else
 #include <alloca.h>
+#endif
 
 #define MICROPY_MPHALPORT_H "port/mphalport.h"


### PR DESCRIPTION
When building the embedded port on FreeBSD, I receive the following error:
```
fatal error: alloca.h: No such file or directory
   36 | #include <alloca.h>
      |          ^~~~~~~~~~
```
FreeBSD/NetBSD doesn't include `alloca.h`, but `alloca()` is provided via `stdlib.h` instead. This PR allows it to build properly on those platforms.