### PR TITLE
nrf/modules/machine: Implement deepsleep()

### DIFF
--- a/docs/library/machine.Pin.rst
+++ b/docs/library/machine.Pin.rst
@@ -42,7 +42,7 @@ Usage Model::
 Constructors
 ------------
 
-.. class:: Pin(id, mode=-1, pull=-1, *, value=None, drive=0, alt=-1)
+.. class:: Pin(id, mode=-1, pull=-1, *, value=None, drive=0, alt=-1, sense=-1)
 
    Access the pin peripheral (GPIO pin) associated with the given ``id``.  If
    additional arguments are given in the constructor then they are used to initialise
@@ -97,6 +97,15 @@ Constructors
        one pin alternate function is supported the this argument is not required.  Not all
        ports implement this argument.
 
+     - ``sense`` specifies whether and on what input value the pin contributes to the
+       *DETECT* signal, which wakes an nRF51/52 system from deep sleep. It can be one of:
+
+       - ``Pin.SENSE_DISABLED`` - Do not wake from this pin.
+       - ``Pin.SENSE_LOW`` - Wake when pin is low.
+       - ``Pin.SENSE_HIGH`` - Wake when pin is high.
+
+       Availability: nrf port.
+
    As specified above, the Pin class allows to set an alternate function for a particular
    pin, but it does not specify any further operations on such a pin.  Pins configured in
    alternate-function mode are usually not used as GPIO but are instead driven by other
@@ -108,7 +117,7 @@ Constructors
 Methods
 -------
 
-.. method:: Pin.init(mode=-1, pull=-1, *, value=None, drive=0, alt=-1)
+.. method:: Pin.init(mode=-1, pull=-1, *, value=None, drive=0, alt=-1, sense=-1)
 
    Re-initialise the pin using the given parameters.  Only those arguments that
    are specified will be set.  The rest of the pin peripheral state will remain
@@ -274,3 +283,13 @@ not all constants are available on all ports.
           Pin.IRQ_HIGH_LEVEL
 
    Selects the IRQ trigger type.
+
+.. data:: Pin.SENSE_DISABLED
+          Pin.SENSE_LOW
+          Pin.SENSE_HIGH
+
+   Selects the *SENSE* configuration of the pin, which determines
+   whether and on what input value it contributes to the *DETECT*
+   signal, which wakes the system from deep sleep.
+
+   Availability: nrf port.

--- a/docs/library/machine.rst
+++ b/docs/library/machine.rst
@@ -160,6 +160,12 @@ Power related functions
      return `machine.DEEPSLEEP` and this can be used to distinguish a deepsleep wake
      from other resets.
 
+   *nrf port:*
+   
+   * The *time_ms* argument to `deepsleep` is ignored, the sleep is always indefinite.
+     nRF microcontrollers are incapable of waking on a timer as all clocks are off in
+     the deep sleep state.
+
 .. function:: wake_reason()
 
    Get the wake reason. See :ref:`constants <machine_constants>` for the possible return values.

--- a/docs/library/machine.rst
+++ b/docs/library/machine.rst
@@ -166,6 +166,9 @@ Power related functions
      nRF microcontrollers are incapable of waking on a timer as all clocks are off in
      the deep sleep state.
 
+   * Pins are configured as wake sources using the ``sense`` argument to the
+     `Pin` constructor.
+
 .. function:: wake_reason()
 
    Get the wake reason. See :ref:`constants <machine_constants>` for the possible return values.


### PR DESCRIPTION
Replace the previous dummy implementation of `machine.deepsleep()` with one that invokes the nRF's deep sleep state _System OFF_. The argument is ignored, nRF microcontrollers are incapable of waking on a timer as all clocks are off in the deep sleep state.

Pins are configured as wake sources using an additional argument `sense` to the `machine.Pin` constructor. This choice is up for debate, it seemed appropriate because it internally _is_ a matter of GPIO configuration. I also considered using the unused `wake` argument to `Pin.irq()`, but rejected that because the configuration has nothing to do with IRQs. Another possibility would be a special function in the `nrf` module, akin to `esp32.wake_on_ext0()`.

`machine.reset_cause()` returns the newly added `DEEPSLEEP_RESET`, like on other ports – the previous mapping to `PWRON_RESET` seemed wrong.

I am unsure where to document this, as there is no port-specific documentation for the nrf port. Should I add a _Quick reference for the nRF51/52_ section just for this?

Tested on nRF52832 (DS-D6) and nRF52840 (ItsyBitsy).