### PR TITLE
nrf/modules/machine: Catch exceptions from pin interrupts

### DIFF
--- a/ports/nrf/modules/machine/adc.c
+++ b/ports/nrf/modules/machine/adc.c
@@ -38,14 +38,14 @@
 
 typedef struct _machine_adc_obj_t {
     mp_obj_base_t base;
-    uint8_t       id;
-#if NRF51
-    uint8_t       ain;
-#endif
+    uint8_t id;
+    #if NRF51
+    uint8_t ain;
+    #endif
 } machine_adc_obj_t;
 
 static const machine_adc_obj_t machine_adc_obj[] = {
-#if NRF51
+    #if NRF51
     {{&machine_adc_type}, .id = 0, .ain = NRF_ADC_CONFIG_INPUT_0},
     {{&machine_adc_type}, .id = 1, .ain = NRF_ADC_CONFIG_INPUT_1},
     {{&machine_adc_type}, .id = 2, .ain = NRF_ADC_CONFIG_INPUT_2},
@@ -54,7 +54,7 @@ static const machine_adc_obj_t machine_adc_obj[] = {
     {{&machine_adc_type}, .id = 5, .ain = NRF_ADC_CONFIG_INPUT_5},
     {{&machine_adc_type}, .id = 6, .ain = NRF_ADC_CONFIG_INPUT_6},
     {{&machine_adc_type}, .id = 7, .ain = NRF_ADC_CONFIG_INPUT_7},
-#else
+    #else
     {{&machine_adc_type}, .id = 0},
     {{&machine_adc_type}, .id = 1},
     {{&machine_adc_type}, .id = 2},
@@ -63,14 +63,14 @@ static const machine_adc_obj_t machine_adc_obj[] = {
     {{&machine_adc_type}, .id = 5},
     {{&machine_adc_type}, .id = 6},
     {{&machine_adc_type}, .id = 7},
-#endif
+    #endif
 };
 
 void adc_init0(void) {
-#if defined(NRF52_SERIES)
+    #if defined(NRF52_SERIES)
     const uint8_t interrupt_priority = 6;
     nrfx_saadc_init(interrupt_priority);
-#endif
+    #endif
 }
 
 static int adc_find(mp_obj_t id) {
@@ -124,49 +124,49 @@ static mp_obj_t mp_machine_adc_make_new(const mp_obj_type_t *type, size_t n_args
     int adc_id = adc_find(args[ARG_id].u_obj);
     const machine_adc_obj_t *self = &machine_adc_obj[adc_id];
 
-#if defined(NRF52_SERIES)
+    #if defined(NRF52_SERIES)
     const nrfx_saadc_channel_t config = {                                                           \
         .channel_config =
         {
             .resistor_p = NRF_SAADC_RESISTOR_DISABLED,
             .resistor_n = NRF_SAADC_RESISTOR_DISABLED,
-            .gain       = NRF_SAADC_GAIN1_4,
-            .reference  = NRF_SAADC_REFERENCE_VDD4,
-            .acq_time   = NRF_SAADC_ACQTIME_3US,
-            .mode       = NRF_SAADC_MODE_SINGLE_ENDED,
-            .burst      = NRF_SAADC_BURST_DISABLED,
+            .gain = NRF_SAADC_GAIN1_4,
+            .reference = NRF_SAADC_REFERENCE_VDD4,
+            .acq_time = NRF_SAADC_ACQTIME_3US,
+            .mode = NRF_SAADC_MODE_SINGLE_ENDED,
+            .burst = NRF_SAADC_BURST_DISABLED,
         },
-        .pin_p          = (nrf_saadc_input_t)(1 + self->id), // pin_p=0 is AIN0, pin_p=8 is AIN7
-        .pin_n          = NRF_SAADC_INPUT_DISABLED,
-        .channel_index  = self->id,
+        .pin_p = (nrf_saadc_input_t)(1 + self->id),          // pin_p=0 is AIN0, pin_p=8 is AIN7
+        .pin_n = NRF_SAADC_INPUT_DISABLED,
+        .channel_index = self->id,
     };
     nrfx_saadc_channels_config(&config, 1);
-#endif
+    #endif
 
     return MP_OBJ_FROM_PTR(self);
 }
 
-int16_t machine_adc_value_read(machine_adc_obj_t * adc_obj) {
+int16_t machine_adc_value_read(machine_adc_obj_t *adc_obj) {
 
-#if NRF51
+    #if NRF51
     nrf_adc_value_t value = 0;
 
     nrfx_adc_channel_t channel_config = {
         .config.resolution = NRF_ADC_CONFIG_RES_8BIT,
-        .config.input      = NRF_ADC_CONFIG_SCALING_INPUT_TWO_THIRDS,
-        .config.reference  = NRF_ADC_CONFIG_REF_VBG,
-        .config.input      = adc_obj->ain,
-        .config.extref     = ADC_CONFIG_EXTREFSEL_None << ADC_CONFIG_EXTREFSEL_Pos // Currently not defined in nrfx/hal.
+        .config.input = NRF_ADC_CONFIG_SCALING_INPUT_TWO_THIRDS,
+        .config.reference = NRF_ADC_CONFIG_REF_VBG,
+        .config.input = adc_obj->ain,
+        .config.extref = ADC_CONFIG_EXTREFSEL_None << ADC_CONFIG_EXTREFSEL_Pos     // Currently not defined in nrfx/hal.
     };
 
     nrfx_adc_sample_convert(&channel_config, &value);
-#else // NRF52
+    #else // NRF52
     nrf_saadc_value_t value = 0;
 
     nrfx_saadc_simple_mode_set((1 << adc_obj->id), NRF_SAADC_RESOLUTION_8BIT, NRF_SAADC_INPUT_DISABLED, NULL);
     nrfx_saadc_buffer_set(&value, 1);
     nrfx_saadc_mode_trigger();
-#endif
+    #endif
     return value;
 }
 
@@ -209,10 +209,9 @@ static MP_DEFINE_CONST_FUN_OBJ_1(mp_machine_adc_value_obj, machine_adc_value);
 #define DIODE_VOLT_DROP_MILLIVOLT    (270)  // Voltage drop over diode.
 
 #define BATTERY_MILLIVOLT(VALUE) \
-        ((((VALUE) * ADC_REF_VOLTAGE_IN_MILLIVOLT) / 255) * ADC_PRE_SCALING_MULTIPLIER)
+    ((((VALUE)*ADC_REF_VOLTAGE_IN_MILLIVOLT) / 255) * ADC_PRE_SCALING_MULTIPLIER)
 
-static uint8_t battery_level_in_percent(const uint16_t mvolts)
-{
+static uint8_t battery_level_in_percent(const uint16_t mvolts) {
     uint8_t battery_level;
 
     if (mvolts >= 3000) {
@@ -236,19 +235,19 @@ static uint8_t battery_level_in_percent(const uint16_t mvolts)
 /// Get battery level in percentage.
 mp_obj_t machine_adc_battery_level(void) {
 
-#if NRF51
+    #if NRF51
     nrf_adc_value_t value = 0;
 
     nrfx_adc_channel_t channel_config = {
         .config.resolution = NRF_ADC_CONFIG_RES_8BIT,
-        .config.input      = NRF_ADC_CONFIG_SCALING_SUPPLY_ONE_THIRD,
-        .config.reference  = NRF_ADC_CONFIG_REF_VBG,
-        .config.input      = NRF_ADC_CONFIG_INPUT_DISABLED,
-        .config.extref     = ADC_CONFIG_EXTREFSEL_None << ADC_CONFIG_EXTREFSEL_Pos // Currently not defined in nrfx/hal.
+        .config.input = NRF_ADC_CONFIG_SCALING_SUPPLY_ONE_THIRD,
+        .config.reference = NRF_ADC_CONFIG_REF_VBG,
+        .config.input = NRF_ADC_CONFIG_INPUT_DISABLED,
+        .config.extref = ADC_CONFIG_EXTREFSEL_None << ADC_CONFIG_EXTREFSEL_Pos     // Currently not defined in nrfx/hal.
     };
 
     nrfx_adc_sample_convert(&channel_config, &value);
-#else // NRF52
+    #else // NRF52
     nrf_saadc_value_t value = 0;
 
     const nrfx_saadc_channel_t config = {                                                           \
@@ -256,22 +255,22 @@ mp_obj_t machine_adc_battery_level(void) {
         {
             .resistor_p = NRF_SAADC_RESISTOR_DISABLED,
             .resistor_n = NRF_SAADC_RESISTOR_DISABLED,
-            .gain       = NRF_SAADC_GAIN1_6,
-            .reference  = NRF_SAADC_REFERENCE_INTERNAL,
-            .acq_time   = NRF_SAADC_ACQTIME_3US,
-            .mode       = NRF_SAADC_MODE_SINGLE_ENDED,
-            .burst      = NRF_SAADC_BURST_DISABLED,
+            .gain = NRF_SAADC_GAIN1_6,
+            .reference = NRF_SAADC_REFERENCE_INTERNAL,
+            .acq_time = NRF_SAADC_ACQTIME_3US,
+            .mode = NRF_SAADC_MODE_SINGLE_ENDED,
+            .burst = NRF_SAADC_BURST_DISABLED,
         },
-        .pin_p          = NRF_SAADC_INPUT_VDD,
-        .pin_n          = NRF_SAADC_INPUT_DISABLED,
-        .channel_index  = 0,
+        .pin_p = NRF_SAADC_INPUT_VDD,
+        .pin_n = NRF_SAADC_INPUT_DISABLED,
+        .channel_index = 0,
     };
     nrfx_saadc_channels_config(&config, 1);
 
     nrfx_saadc_simple_mode_set((1 << 0), NRF_SAADC_RESOLUTION_8BIT, NRF_SAADC_INPUT_DISABLED, NULL);
     nrfx_saadc_buffer_set(&value, 1);
     nrfx_saadc_mode_trigger();
-#endif
+    #endif
 
     uint16_t batt_lvl_in_milli_volts = BATTERY_MILLIVOLT(value) + DIODE_VOLT_DROP_MILLIVOLT;
     uint16_t batt_in_percent = battery_level_in_percent(batt_lvl_in_milli_volts);

--- a/ports/nrf/modules/machine/adc.h
+++ b/ports/nrf/modules/machine/adc.h
@@ -31,6 +31,6 @@ typedef struct _machine_adc_obj_t machine_adc_obj_t;
 
 void adc_init0(void);
 
-int16_t machine_adc_value_read(machine_adc_obj_t * adc_obj);
+int16_t machine_adc_value_read(machine_adc_obj_t *adc_obj);
 
 #endif // ADC_H__

--- a/ports/nrf/modules/machine/i2c.c
+++ b/ports/nrf/modules/machine/i2c.c
@@ -68,7 +68,7 @@
 
 typedef struct _machine_hard_i2c_obj_t {
     mp_obj_base_t base;
-    nrfx_twi_t    p_twi;  // Driver instance
+    nrfx_twi_t p_twi;     // Driver instance
 } machine_hard_i2c_obj_t;
 
 static const machine_hard_i2c_obj_t machine_hard_i2c_obj[] = {
@@ -159,8 +159,7 @@ int machine_hard_i2c_transfer_single(mp_obj_base_t *self_in, uint16_t addr, size
     if (err_code != NRFX_SUCCESS) {
         if (err_code == NRFX_ERROR_DRV_TWI_ERR_ANACK) {
             return -MP_ENODEV;
-        }
-        else if (err_code == NRFX_ERROR_DRV_TWI_ERR_DNACK) {
+        } else if (err_code == NRFX_ERROR_DRV_TWI_ERR_DNACK) {
             return -MP_EIO;
         }
         return -MP_ETIMEDOUT;

--- a/ports/nrf/modules/machine/modmachine.c
+++ b/ports/nrf/modules/machine/modmachine.c
@@ -116,16 +116,16 @@ void machine_init(void) {
         reset_cause = PYB_RESET_LOCKUP;
     } else if (state & POWER_RESETREAS_OFF_Msk) {
         reset_cause = PYB_RESET_POWER_ON;
-#if !defined(NRF9160_XXAA)
+    #if !defined(NRF9160_XXAA)
     } else if (state & POWER_RESETREAS_LPCOMP_Msk) {
         reset_cause = PYB_RESET_LPCOMP;
-#endif
+    #endif
     } else if (state & POWER_RESETREAS_DIF_Msk) {
         reset_cause = PYB_RESET_DIF;
-#if defined(NRF52_SERIES)
+    #if defined(NRF52_SERIES)
     } else if (state & POWER_RESETREAS_NFC_Msk) {
         reset_cause = PYB_RESET_NFC;
-#endif
+    #endif
     }
 
     // clear reset reason
@@ -216,22 +216,22 @@ static void mp_machine_set_freq(size_t n_args, const mp_obj_t *args) {
 }
 
 static mp_obj_t machine_enable_irq(void) {
-#ifndef BLUETOOTH_SD
+    #ifndef BLUETOOTH_SD
     __enable_irq();
-#else
+    #else
 
-#endif
+    #endif
     return mp_const_none;
 }
 MP_DEFINE_CONST_FUN_OBJ_0(machine_enable_irq_obj, machine_enable_irq);
 
 // Resets the board in a manner similar to pushing the external RESET button.
 static mp_obj_t machine_disable_irq(void) {
-#ifndef BLUETOOTH_SD
+    #ifndef BLUETOOTH_SD
     __disable_irq();
-#else
+    #else
 
-#endif
+    #endif
     return mp_const_none;
 }
 MP_DEFINE_CONST_FUN_OBJ_0(machine_disable_irq_obj, machine_disable_irq);

--- a/ports/nrf/modules/machine/pin.c
+++ b/ports/nrf/modules/machine/pin.c
@@ -234,9 +234,9 @@ static void pin_print(const mp_print_t *print, mp_obj_t self_in, mp_print_kind_t
     }
 
     mp_printf(print, "Pin(%d, mode=%s, pull=%s)",
-            self->pin,
-            (nrf_gpio_pin_dir_get(self->pin) == NRF_GPIO_PIN_DIR_OUTPUT) ? "OUT" : "IN",
-            pull);
+        self->pin,
+        (nrf_gpio_pin_dir_get(self->pin) == NRF_GPIO_PIN_DIR_OUTPUT) ? "OUT" : "IN",
+        pull);
 }
 
 static mp_obj_t pin_obj_init_helper(const pin_obj_t *pin, mp_uint_t n_args, const mp_obj_t *args, mp_map_t *kw_args);
@@ -375,11 +375,11 @@ static mp_obj_t pin_obj_init_helper(const pin_obj_t *self, mp_uint_t n_args, con
 
     if (mode == NRF_GPIO_PIN_DIR_OUTPUT || mode == NRF_GPIO_PIN_DIR_INPUT) {
         nrf_gpio_cfg(self->pin,
-                     mode,
-                     input,
-                     pull,
-                     NRF_GPIO_PIN_S0S1,
-                     NRF_GPIO_PIN_NOSENSE);
+            mode,
+            input,
+            pull,
+            NRF_GPIO_PIN_S0S1,
+            NRF_GPIO_PIN_NOSENSE);
     } else {
         mp_raise_msg_varg(&mp_type_ValueError, MP_ERROR_TEXT("invalid pin mode: %d"), mode);
     }
@@ -496,7 +496,7 @@ static MP_DEFINE_CONST_FUN_OBJ_1(pin_af_obj, pin_af);
 static void pin_common_irq_handler(nrfx_gpiote_pin_t pin, nrf_gpiote_polarity_t action) {
     mp_obj_t pin_handler = MP_STATE_PORT(pin_irq_handlers)[pin];
     mp_obj_t pin_number = MP_OBJ_NEW_SMALL_INT(pin);
-    const pin_obj_t *pin_obj  = pin_find(pin_number);
+    const pin_obj_t *pin_obj = pin_find(pin_number);
 
     mp_call_function_1(pin_handler, (mp_obj_t)pin_obj);
 }
@@ -591,7 +591,7 @@ static const mp_rom_map_elem_t pin_locals_dict_table[] = {
     { MP_ROM_QSTR(MP_QSTR_AF_OD),     MP_ROM_INT(GPIO_MODE_AF_OD) },
     { MP_ROM_QSTR(MP_QSTR_PULL_NONE), MP_ROM_INT(GPIO_NOPULL) },
 */
-#include "genhdr/pins_af_const.h"
+    #include "genhdr/pins_af_const.h"
 };
 
 static MP_DEFINE_CONST_DICT(pin_locals_dict, pin_locals_dict_table);

--- a/ports/nrf/modules/machine/pin.h
+++ b/ports/nrf/modules/machine/pin.h
@@ -34,43 +34,43 @@
 #include "py/obj.h"
 
 typedef struct {
-  mp_obj_base_t base;
-  qstr name;
-  uint8_t idx;
-  uint8_t fn;
-  uint8_t unit;
-  uint8_t type;
+    mp_obj_base_t base;
+    qstr name;
+    uint8_t idx;
+    uint8_t fn;
+    uint8_t unit;
+    uint8_t type;
 
-  union {
-    void          *reg;
+    union {
+        void *reg;
 
-    PIN_DEFS_PORT_AF_UNION
-  };
+        PIN_DEFS_PORT_AF_UNION
+    };
 } pin_af_obj_t;
 
 typedef struct {
-  mp_obj_base_t base;
-  qstr name;
-  uint32_t pin : 8;
-  uint32_t num_af : 4;
-  uint32_t adc_channel : 5; // Some ARM processors use 32 bits/PORT
-  uint32_t adc_num  : 3;    // 1 bit per ADC
-  const pin_af_obj_t *af;
-  uint32_t pull;
+    mp_obj_base_t base;
+    qstr name;
+    uint32_t pin : 8;
+    uint32_t num_af : 4;
+    uint32_t adc_channel : 5; // Some ARM processors use 32 bits/PORT
+    uint32_t adc_num  : 3;  // 1 bit per ADC
+    const pin_af_obj_t *af;
+    uint32_t pull;
 } pin_obj_t;
 
 extern const mp_obj_type_t pin_type;
 extern const mp_obj_type_t pin_af_type;
 
 typedef struct {
-  const char *name;
-  const pin_obj_t *pin;
+    const char *name;
+    const pin_obj_t *pin;
 } pin_named_pin_t;
 
 extern const pin_named_pin_t pin_board_pins[];
 extern const pin_named_pin_t pin_cpu_pins[];
 
-//extern pin_map_obj_t pin_map_obj;
+// extern pin_map_obj_t pin_map_obj;
 
 typedef struct {
     mp_obj_base_t base;

--- a/ports/nrf/modules/machine/rtcounter.c
+++ b/ports/nrf/modules/machine/rtcounter.c
@@ -49,18 +49,18 @@ typedef struct {
 
 // Non-volatile part of the RTCounter object.
 typedef struct _machine_rtc_obj_t {
-    mp_obj_base_t          base;
-    const nrfx_rtc_t     * p_rtc;   // Driver instance
-    nrfx_rtc_handler_t     handler; // interrupt callback
-    machine_rtc_config_t * config;  // pointer to volatile part
+    mp_obj_base_t base;
+    const nrfx_rtc_t *p_rtc;        // Driver instance
+    nrfx_rtc_handler_t handler;     // interrupt callback
+    machine_rtc_config_t *config;   // pointer to volatile part
 } machine_rtc_obj_t;
 
 static const nrfx_rtc_t machine_rtc_instances[] = {
     NRFX_RTC_INSTANCE(0),
     NRFX_RTC_INSTANCE(1),
-#if defined(NRF52_SERIES)
+    #if defined(NRF52_SERIES)
     NRFX_RTC_INSTANCE(2),
-#endif
+    #endif
 };
 
 static machine_rtc_config_t configs[MP_ARRAY_SIZE(machine_rtc_instances)];
@@ -72,15 +72,15 @@ static void interrupt_handler2(nrfx_rtc_int_type_t int_type);
 #endif
 
 static const machine_rtc_obj_t machine_rtc_obj[] = {
-    {{&machine_rtcounter_type}, .p_rtc = &machine_rtc_instances[0], .handler=interrupt_handler0, .config=&configs[0]},
-    {{&machine_rtcounter_type}, .p_rtc = &machine_rtc_instances[1], .handler=interrupt_handler1, .config=&configs[1]},
-#if defined(NRF52_SERIES)
-    {{&machine_rtcounter_type}, .p_rtc = &machine_rtc_instances[2], .handler=interrupt_handler2, .config=&configs[2]},
-#endif
+    {{&machine_rtcounter_type}, .p_rtc = &machine_rtc_instances[0], .handler = interrupt_handler0, .config = &configs[0]},
+    {{&machine_rtcounter_type}, .p_rtc = &machine_rtc_instances[1], .handler = interrupt_handler1, .config = &configs[1]},
+    #if defined(NRF52_SERIES)
+    {{&machine_rtcounter_type}, .p_rtc = &machine_rtc_instances[2], .handler = interrupt_handler2, .config = &configs[2]},
+    #endif
 };
 
 static void interrupt_handler(size_t instance_id) {
-    const machine_rtc_obj_t * self = &machine_rtc_obj[instance_id];
+    const machine_rtc_obj_t *self = &machine_rtc_obj[instance_id];
     machine_rtc_config_t *config = self->config;
     if (config->callback != NULL) {
         mp_call_function_1((mp_obj_t)config->callback, (mp_obj_t)self);
@@ -128,8 +128,8 @@ static void rtc_print(const mp_print_t *print, mp_obj_t self_in, mp_print_kind_t
 /* MicroPython bindings for machine API                                       */
 
 const nrfx_rtc_config_t machine_rtc_config = {
-    .prescaler    = RTC_FREQ_TO_PRESCALER(RTC_FREQUENCY),
-    .reliable     = 0,
+    .prescaler = RTC_FREQ_TO_PRESCALER(RTC_FREQUENCY),
+    .reliable = 0,
     .tick_latency = 0, // ignored when reliable == 0
     #ifdef NRF51
     .interrupt_priority = 3,
@@ -161,7 +161,7 @@ static mp_obj_t machine_rtc_make_new(const mp_obj_type_t *type, size_t n_args, s
     #endif
 
     // const and non-const part of the RTC object.
-    const machine_rtc_obj_t * self = &machine_rtc_obj[rtc_id];
+    const machine_rtc_obj_t *self = &machine_rtc_obj[rtc_id];
     machine_rtc_config_t *config = self->config;
 
     if (args[ARG_callback].u_obj == mp_const_none) {
@@ -202,7 +202,7 @@ static mp_obj_t machine_rtc_make_new(const mp_obj_type_t *type, size_t n_args, s
 /// in the configured frequency has been reached.
 ///
 static mp_obj_t machine_rtc_start(mp_obj_t self_in) {
-    machine_rtc_obj_t * self = MP_OBJ_TO_PTR(self_in);
+    machine_rtc_obj_t *self = MP_OBJ_TO_PTR(self_in);
 
     nrfx_rtc_enable(self->p_rtc);
 
@@ -214,7 +214,7 @@ static MP_DEFINE_CONST_FUN_OBJ_1(machine_rtc_start_obj, machine_rtc_start);
 /// Stop the RTCounter.
 ///
 static mp_obj_t machine_rtc_stop(mp_obj_t self_in) {
-    machine_rtc_obj_t * self = MP_OBJ_TO_PTR(self_in);
+    machine_rtc_obj_t *self = MP_OBJ_TO_PTR(self_in);
 
     nrfx_rtc_disable(self->p_rtc);
 
@@ -227,7 +227,7 @@ static MP_DEFINE_CONST_FUN_OBJ_1(machine_rtc_stop_obj, machine_rtc_stop);
 /// with the current prescaler (2^24 / 8 = 2097152 seconds).
 ///
 static mp_obj_t machine_rtc_counter(mp_obj_t self_in) {
-    machine_rtc_obj_t * self = MP_OBJ_TO_PTR(self_in);
+    machine_rtc_obj_t *self = MP_OBJ_TO_PTR(self_in);
 
     uint32_t counter = nrfx_rtc_counter_get(self->p_rtc);
 
@@ -239,7 +239,7 @@ static MP_DEFINE_CONST_FUN_OBJ_1(machine_rtc_counter_obj, machine_rtc_counter);
 /// Free resources associated with this RTC.
 ///
 static mp_obj_t machine_rtc_deinit(mp_obj_t self_in) {
-    machine_rtc_obj_t * self = MP_OBJ_TO_PTR(self_in);
+    machine_rtc_obj_t *self = MP_OBJ_TO_PTR(self_in);
 
     nrfx_rtc_uninit(self->p_rtc);
 

--- a/ports/nrf/modules/machine/soft_pwm.c
+++ b/ports/nrf/modules/machine/soft_pwm.c
@@ -102,7 +102,7 @@ static mp_obj_t mp_machine_pwm_make_new(const mp_obj_type_t *type, size_t n_args
         mp_raise_ValueError(MP_ERROR_TEXT("Pin number >31"));
     }
 
-    machine_pwm_obj_t *self = mp_obj_malloc(machine_pwm_obj_t, &machine_pwm_type);;
+    machine_pwm_obj_t *self = mp_obj_malloc(machine_pwm_obj_t, &machine_pwm_type);
     self->defer_start = false;
     self->pwm_pin = pwm_pin;
     self->duty_mode = DUTY_NOT_SET;
@@ -197,7 +197,7 @@ static void machine_soft_pwm_start(machine_pwm_obj_t *self) {
             duty_width = self->duty * DUTY_FULL_SCALE / 100;
         } else if (self->duty_mode == DUTY_U16) {
             duty_width = self->duty * DUTY_FULL_SCALE / 65536;
-        }if (self->duty_mode == DUTY_NS) {
+        } else if (self->duty_mode == DUTY_NS) {
             duty_width = (uint64_t)self->duty * self->freq * DUTY_FULL_SCALE / 1000000000ULL;
         }
         pwm_set_duty_cycle(self->pwm_pin, duty_width);

--- a/ports/nrf/modules/machine/spi.c
+++ b/ports/nrf/modules/machine/spi.c
@@ -98,20 +98,20 @@
 #endif // NRFX_SPIM_ENABLED
 
 typedef struct _machine_hard_spi_obj_t {
-    mp_obj_base_t       base;
-    const nrfx_spi_t   * p_spi;    // Driver instance
-    nrfx_spi_config_t  * p_config; // pointer to volatile part
+    mp_obj_base_t base;
+    const nrfx_spi_t *p_spi;       // Driver instance
+    nrfx_spi_config_t *p_config;   // pointer to volatile part
 } machine_hard_spi_obj_t;
 
 static const nrfx_spi_t machine_spi_instances[] = {
     NRFX_SPI_INSTANCE(0),
     NRFX_SPI_INSTANCE(1),
-#if defined(NRF52_SERIES)
+    #if defined(NRF52_SERIES)
     NRFX_SPI_INSTANCE(2),
-#if defined(NRF52840_XXAA) && NRFX_SPIM_ENABLED
+    #if defined(NRF52840_XXAA) && NRFX_SPIM_ENABLED
     NRFX_SPI_INSTANCE(3),
-#endif // NRF52840_XXAA && NRFX_SPIM_ENABLED
-#endif // NRF52_SERIES
+    #endif // NRF52840_XXAA && NRFX_SPIM_ENABLED
+    #endif // NRF52_SERIES
 };
 
 static nrfx_spi_config_t configs[MP_ARRAY_SIZE(machine_spi_instances)];
@@ -119,12 +119,12 @@ static nrfx_spi_config_t configs[MP_ARRAY_SIZE(machine_spi_instances)];
 static const machine_hard_spi_obj_t machine_hard_spi_obj[] = {
     {{&machine_spi_type}, .p_spi = &machine_spi_instances[0], .p_config = &configs[0]},
     {{&machine_spi_type}, .p_spi = &machine_spi_instances[1], .p_config = &configs[1]},
-#if defined(NRF52_SERIES)
+    #if defined(NRF52_SERIES)
     {{&machine_spi_type}, .p_spi = &machine_spi_instances[2], .p_config = &configs[2]},
-#if defined(NRF52840_XXAA) && NRFX_SPIM_ENABLED
+    #if defined(NRF52840_XXAA) && NRFX_SPIM_ENABLED
     {{&machine_spi_type}, .p_spi = &machine_spi_instances[3], .p_config = &configs[3]},
-#endif // NRF52840_XXAA && NRFX_SPIM_ENABLED
-#endif // NRF52_SERIES
+    #endif // NRF52840_XXAA && NRFX_SPIM_ENABLED
+    #endif // NRF52_SERIES
 };
 
 void spi_init0(void) {
@@ -151,12 +151,12 @@ static int spi_find(mp_obj_t id) {
     }
 }
 
-void spi_transfer(const machine_hard_spi_obj_t * self, size_t len, const void * src, void * dest) {
+void spi_transfer(const machine_hard_spi_obj_t *self, size_t len, const void *src, void *dest) {
     nrfx_spi_xfer_desc_t xfer_desc = {
         .p_tx_buffer = src,
-        .tx_length   = len,
+        .tx_length = len,
         .p_rx_buffer = dest,
-        .rx_length   = len
+        .rx_length = len
     };
 
     nrfx_spi_xfer(self->p_spi, &xfer_desc, 0);
@@ -220,11 +220,11 @@ static mp_obj_t machine_hard_spi_make_new(const mp_obj_type_t *type, size_t n_ar
         && args[ARG_NEW_mosi].u_obj != MP_OBJ_NULL
         && args[ARG_NEW_miso].u_obj != MP_OBJ_NULL) {
 
-        self->p_config->sck_pin  = mp_hal_get_pin_obj(args[ARG_NEW_sck].u_obj)->pin;
+        self->p_config->sck_pin = mp_hal_get_pin_obj(args[ARG_NEW_sck].u_obj)->pin;
         self->p_config->mosi_pin = mp_hal_get_pin_obj(args[ARG_NEW_mosi].u_obj)->pin;
         self->p_config->miso_pin = mp_hal_get_pin_obj(args[ARG_NEW_miso].u_obj)->pin;
     } else {
-        self->p_config->sck_pin  = MICROPY_HW_SPI0_SCK;
+        self->p_config->sck_pin = MICROPY_HW_SPI0_SCK;
         self->p_config->mosi_pin = MICROPY_HW_SPI0_MOSI;
         self->p_config->miso_pin = MICROPY_HW_SPI0_MISO;
     }
@@ -232,11 +232,11 @@ static mp_obj_t machine_hard_spi_make_new(const mp_obj_type_t *type, size_t n_ar
     // Manually trigger slave select from upper layer.
     self->p_config->ss_pin = NRFX_SPI_PIN_NOT_USED;
 
-#ifdef NRF51
+    #ifdef NRF51
     self->p_config->irq_priority = 3;
-#else
+    #else
     self->p_config->irq_priority = 6;
-#endif
+    #endif
 
     machine_hard_spi_init_helper(self, &args[1]); // Skip instance id param.
 
@@ -260,18 +260,18 @@ static void machine_hard_spi_init_helper(const machine_hard_spi_obj_t *self, mp_
         self->p_config->frequency = NRF_SPI_FREQ_4M;
     } else if (baudrate <= 8000000) {
         self->p_config->frequency = NRF_SPI_FREQ_8M;
-#if defined(NRF52840_XXAA) && NRFX_SPIM_ENABLED
+    #if defined(NRF52840_XXAA) && NRFX_SPIM_ENABLED
     } else if (baudrate <= 16000000) {
         self->p_config->frequency = NRF_SPIM_FREQ_16M;
     } else if (baudrate <= 32000000) {
         self->p_config->frequency = NRF_SPIM_FREQ_32M;
-#endif // NRF52840_XXAA && NRFX_SPIM_ENABLED
+    #endif // NRF52840_XXAA && NRFX_SPIM_ENABLED
     } else { // Default
         self->p_config->frequency = NRF_SPI_FREQ_1M;
     }
 
-    // Active high
     if (args[ARG_INIT_polarity].u_int == 0) {
+        // Active high
         if (args[ARG_INIT_phase].u_int == 0) {
             // First clock edge
             self->p_config->mode = NRF_SPI_MODE_0;
@@ -279,8 +279,8 @@ static void machine_hard_spi_init_helper(const machine_hard_spi_obj_t *self, mp_
             // Second clock edge
             self->p_config->mode = NRF_SPI_MODE_1;
         }
-    // Active low
     } else {
+        // Active low
         if (args[ARG_INIT_phase].u_int == 0) {
             // First clock edge
             self->p_config->mode = NRF_SPI_MODE_2;
@@ -290,7 +290,7 @@ static void machine_hard_spi_init_helper(const machine_hard_spi_obj_t *self, mp_
         }
     }
 
-    self->p_config->orc  = 0xFF; // Overrun character
+    self->p_config->orc = 0xFF;  // Overrun character
     self->p_config->bit_order = (args[ARG_INIT_firstbit].u_int == 0) ? NRF_SPI_BIT_ORDER_MSB_FIRST : NRF_SPI_BIT_ORDER_LSB_FIRST;
 
     // Set context to this instance of SPI
@@ -327,7 +327,7 @@ static void machine_hard_spi_deinit(mp_obj_base_t *self_in) {
 }
 
 static void machine_hard_spi_transfer(mp_obj_base_t *self_in, size_t len, const uint8_t *src, uint8_t *dest) {
-    const machine_hard_spi_obj_t *self = (machine_hard_spi_obj_t*)self_in;
+    const machine_hard_spi_obj_t *self = (machine_hard_spi_obj_t *)self_in;
     spi_transfer(self, len, src, dest);
 }
 

--- a/ports/nrf/modules/machine/spi.h
+++ b/ports/nrf/modules/machine/spi.h
@@ -29,7 +29,7 @@
 typedef struct _machine_hard_spi_obj_t machine_hard_spi_obj_t;
 
 void spi_init0(void);
-void spi_transfer(const machine_hard_spi_obj_t * self,
-                  size_t                         len,
-                  const void *                   src,
-                  void *                         dest);
+void spi_transfer(const machine_hard_spi_obj_t *self,
+    size_t len,
+    const void *src,
+    void *dest);

--- a/ports/nrf/modules/machine/temp.c
+++ b/ports/nrf/modules/machine/temp.c
@@ -91,13 +91,13 @@ int32_t temp_read(void) {
 /// Get temperature.
 static mp_obj_t machine_temp_read(mp_uint_t n_args, const mp_obj_t *args) {
 
-#if BLUETOOTH_SD
+    #if BLUETOOTH_SD
     if (BLUETOOTH_STACK_ENABLED() == 1) {
         int32_t temp;
         (void)sd_temp_get(&temp);
         return MP_OBJ_NEW_SMALL_INT(temp / 4); // resolution of 0.25 degree celsius
     }
-#endif // BLUETOOTH_SD
+    #endif // BLUETOOTH_SD
 
     return MP_OBJ_NEW_SMALL_INT(temp_read());
 }

--- a/ports/nrf/modules/machine/timer.c
+++ b/ports/nrf/modules/machine/timer.c
@@ -37,32 +37,32 @@ enum {
 };
 
 typedef struct _machine_timer_obj_t {
-    mp_obj_base_t  base;
-    nrfx_timer_t   p_instance;
+    mp_obj_base_t base;
+    nrfx_timer_t p_instance;
 } machine_timer_obj_t;
 
 static mp_obj_t machine_timer_callbacks[] = {
     NULL,
     NULL,
     NULL,
-#if defined(NRF52_SERIES)
+    #if defined(NRF52_SERIES)
     NULL,
     NULL,
-#endif
+    #endif
 };
 
 static const machine_timer_obj_t machine_timer_obj[] = {
     {{&machine_timer_type}, NRFX_TIMER_INSTANCE(0)},
-#if MICROPY_PY_MACHINE_SOFT_PWM
+    #if MICROPY_PY_MACHINE_SOFT_PWM
     { },
-#else
+    #else
     {{&machine_timer_type}, NRFX_TIMER_INSTANCE(1)},
-#endif
+    #endif
     {{&machine_timer_type}, NRFX_TIMER_INSTANCE(2)},
-#if defined(NRF52_SERIES)
+    #if defined(NRF52_SERIES)
     {{&machine_timer_type}, NRFX_TIMER_INSTANCE(3)},
     {{&machine_timer_type}, NRFX_TIMER_INSTANCE(4)},
-#endif
+    #endif
 };
 
 void timer_init0(void) {
@@ -112,19 +112,19 @@ static mp_obj_t machine_timer_make_new(const mp_obj_type_t *type, size_t n_args,
     // get static peripheral object
     int timer_id = timer_find(args[ARG_id].u_obj);
 
-#if BLUETOOTH_SD
+    #if BLUETOOTH_SD
     if (timer_id == 0) {
         mp_raise_ValueError(MP_ERROR_TEXT("Timer reserved by Bluetooth LE stack"));
     }
-#endif
+    #endif
 
-#if MICROPY_PY_MACHINE_SOFT_PWM
+    #if MICROPY_PY_MACHINE_SOFT_PWM
     if (timer_id == 1) {
         mp_raise_ValueError(MP_ERROR_TEXT("Timer reserved by ticker driver"));
     }
-#endif
+    #endif
 
-    machine_timer_obj_t *self = (machine_timer_obj_t*)&machine_timer_obj[timer_id];
+    machine_timer_obj_t *self = (machine_timer_obj_t *)&machine_timer_obj[timer_id];
 
     if (mp_obj_is_fun(args[ARG_callback].u_obj)) {
         machine_timer_callbacks[timer_id] = args[ARG_callback].u_obj;
@@ -163,11 +163,11 @@ static mp_obj_t machine_timer_make_new(const mp_obj_type_t *type, size_t n_args,
         ((args[ARG_mode].u_int == TIMER_MODE_ONESHOT) ? NRF_TIMER_SHORT_COMPARE0_STOP_MASK : 0);
     bool enable_interrupts = true;
     nrfx_timer_extended_compare(
-            &self->p_instance,
-            NRF_TIMER_CC_CHANNEL0,
-            args[ARG_period].u_int,
-            short_mask,
-            enable_interrupts);
+        &self->p_instance,
+        NRF_TIMER_CC_CHANNEL0,
+        args[ARG_period].u_int,
+        short_mask,
+        enable_interrupts);
 
     return MP_OBJ_FROM_PTR(self);
 }
@@ -176,7 +176,7 @@ static mp_obj_t machine_timer_make_new(const mp_obj_type_t *type, size_t n_args,
 /// Return counter value, which is currently in us.
 ///
 static mp_obj_t machine_timer_period(mp_obj_t self_in) {
-    machine_timer_obj_t * self = MP_OBJ_TO_PTR(self_in);
+    machine_timer_obj_t *self = MP_OBJ_TO_PTR(self_in);
 
     uint32_t period = nrfx_timer_capture(&self->p_instance, NRF_TIMER_CC_CHANNEL1);
 
@@ -188,7 +188,7 @@ static MP_DEFINE_CONST_FUN_OBJ_1(machine_timer_period_obj, machine_timer_period)
 /// Start the timer.
 ///
 static mp_obj_t machine_timer_start(mp_obj_t self_in) {
-    machine_timer_obj_t * self = MP_OBJ_TO_PTR(self_in);
+    machine_timer_obj_t *self = MP_OBJ_TO_PTR(self_in);
 
     nrfx_timer_enable(&self->p_instance);
 
@@ -200,7 +200,7 @@ static MP_DEFINE_CONST_FUN_OBJ_1(machine_timer_start_obj, machine_timer_start);
 /// Stop the timer.
 ///
 static mp_obj_t machine_timer_stop(mp_obj_t self_in) {
-    machine_timer_obj_t * self = MP_OBJ_TO_PTR(self_in);
+    machine_timer_obj_t *self = MP_OBJ_TO_PTR(self_in);
 
     nrfx_timer_disable(&self->p_instance);
 
@@ -212,7 +212,7 @@ static MP_DEFINE_CONST_FUN_OBJ_1(machine_timer_stop_obj, machine_timer_stop);
 /// Free resources associated with the timer.
 ///
 static mp_obj_t machine_timer_deinit(mp_obj_t self_in) {
-    machine_timer_obj_t * self = MP_OBJ_TO_PTR(self_in);
+    machine_timer_obj_t *self = MP_OBJ_TO_PTR(self_in);
 
     nrfx_timer_uninit(&self->p_instance);
 

--- a/ports/nrf/modules/machine/uart.c
+++ b/ports/nrf/modules/machine/uart.c
@@ -88,8 +88,8 @@ typedef struct _machine_uart_buf_t {
 #endif
 
 typedef struct _machine_uart_obj_t {
-    mp_obj_base_t       base;
-    const nrfx_uart_t * p_uart;      // Driver instance
+    mp_obj_base_t base;
+    const nrfx_uart_t *p_uart;       // Driver instance
     machine_uart_buf_t buf;
     uint16_t timeout;       // timeout waiting for first char (in ms)
     uint16_t timeout_char;  // timeout waiting between chars (in ms)
@@ -206,19 +206,19 @@ static mp_obj_t mp_machine_uart_make_new(const mp_obj_type_t *type, size_t n_arg
     nrfx_uart_config_t config;
 
     // flow control
-#if MICROPY_HW_UART1_HWFC
+    #if MICROPY_HW_UART1_HWFC
     config.hal_cfg.hwfc = NRF_UART_HWFC_ENABLED;
-#else
+    #else
     config.hal_cfg.hwfc = NRF_UART_HWFC_DISABLED;
-#endif
+    #endif
 
     config.hal_cfg.parity = NRF_UART_PARITY_EXCLUDED;
 
-#if (BLUETOOTH_SD == 100)
+    #if (BLUETOOTH_SD == 100)
     config.interrupt_priority = 3;
-#else
+    #else
     config.interrupt_priority = 6;
-#endif
+    #endif
 
     // These baudrates are not supported, it seems.
     if (args[ARG_baudrate].u_int < 1200 || args[ARG_baudrate].u_int > 1000000) {
@@ -239,10 +239,10 @@ static mp_obj_t mp_machine_uart_make_new(const mp_obj_type_t *type, size_t n_arg
     config.pseltxd = MICROPY_HW_UART1_TX;
     config.pselrxd = MICROPY_HW_UART1_RX;
 
-#if MICROPY_HW_UART1_HWFC
+    #if MICROPY_HW_UART1_HWFC
     config.pselrts = MICROPY_HW_UART1_RTS;
     config.pselcts = MICROPY_HW_UART1_CTS;
-#endif
+    #endif
     self->timeout = args[ARG_timeout].u_int;
     self->timeout_char = args[ARG_timeout_char].u_int;
 
@@ -259,9 +259,9 @@ static mp_obj_t mp_machine_uart_make_new(const mp_obj_type_t *type, size_t n_arg
     nrfx_uart_init(self->p_uart, &config, uart_event_handler);
     nrfx_uart_rx(self->p_uart, &self->buf.rx_buf[0], 1);
 
-#if NRFX_UART_ENABLED
+    #if NRFX_UART_ENABLED
     nrfx_uart_rx_enable(self->p_uart);
-#endif
+    #endif
 
     return MP_OBJ_FROM_PTR(self);
 }

--- a/ports/nrf/modules/machine/uart.c
+++ b/ports/nrf/modules/machine/uart.c
@@ -214,11 +214,9 @@ static mp_obj_t mp_machine_uart_make_new(const mp_obj_type_t *type, size_t n_arg
 
     config.hal_cfg.parity = NRF_UART_PARITY_EXCLUDED;
 
-    #if (BLUETOOTH_SD == 100)
-    config.interrupt_priority = 3;
-    #else
-    config.interrupt_priority = 6;
-    #endif
+    // Higher priority than pin interrupts, otherwise printing exceptions from
+    // interrupt handlers gets stuck.
+    config.interrupt_priority = NRFX_GPIOTE_DEFAULT_CONFIG_IRQ_PRIORITY - 1;
 
     // These baudrates are not supported, it seems.
     if (args[ARG_baudrate].u_int < 1200 || args[ARG_baudrate].u_int > 1000000) {

--- a/tools/codeformat.py
+++ b/tools/codeformat.py
@@ -59,11 +59,9 @@ EXCLUSIONS = [
     "ports/nrf/drivers/*.[ch]",
     "ports/nrf/modules/ble/*.[ch]",
     "ports/nrf/modules/board/*.[ch]",
-    "ports/nrf/modules/machine/*.[ch]",
     "ports/nrf/modules/music/*.[ch]",
     "ports/nrf/modules/ubluepy/*.[ch]",
     "ports/nrf/modules/os/*.[ch]",
-    "ports/nrf/modules/time/*.[ch]",
     # STM32 USB dev/host code is mostly 3rd party.
     "ports/stm32/usbdev/**/*.[ch]",
     "ports/stm32/usbhost/**/*.[ch]",


### PR DESCRIPTION
Exceptions in pin interrupt handlers (including the "TypeError: function takes 0 positional arguments but 1 were given" that happens when a function taking the wrong number of arguments was set as an interrupt handler) would end up crashing MicroPython with a "FATAL: uncaught exception". This is particularly annoying on a device such as the DS-D6 where the reset pin is not easily accessible.

In addition, on the nRF52832 (apparently not on the nRF52840, I haven’t checked why), MicroPython would get stuck trying to output this error message, or generally any print output from inside a pin interrupt handler, through the UART after the first character, so that only "F" was visible. The reason was a matching interrupt priority between the running pin interrupt and the UARTE interrupt signaling completion of the output operation. Fix that by increasing the UARTE interrupt priority.

Code taken from the stm32 port and adapted.

(This is just something I happened on and fixed on the side. It’s less important to me than the other nrf PRs. I am also wondering whether the whole thing should be rewritten using _shared/runtime/mpirq.c_, but am not putting in that effort now.)