### PR TITLE
ports/rp2: Provide direct memory access to UART FIFOs.

### DIFF
--- a/extmod/machine_uart.c
+++ b/extmod/machine_uart.c
@@ -54,6 +54,10 @@ STATIC void mp_machine_uart_writechar(machine_uart_obj_t *self, uint16_t data);
 STATIC mp_irq_obj_t *mp_machine_uart_irq(machine_uart_obj_t *self, bool any_args, mp_arg_val_t *args);
 #endif
 
+#if MICROPY_PY_MACHINE_UART_FIFO_BUFFER
+STATIC mp_int_t mp_machine_uart_fifo_buffer(mp_obj_t o_in, mp_buffer_info_t *bufinfo, mp_uint_t flags);
+#endif
+
 STATIC mp_uint_t mp_machine_uart_read(mp_obj_t self_in, void *buf_in, mp_uint_t size, int *errcode);
 STATIC mp_uint_t mp_machine_uart_write(mp_obj_t self_in, const void *buf_in, mp_uint_t size, int *errcode);
 STATIC mp_uint_t mp_machine_uart_ioctl(mp_obj_t self_in, mp_uint_t request, uintptr_t arg, int *errcode);
@@ -181,6 +185,9 @@ MP_DEFINE_CONST_OBJ_TYPE(
     make_new, mp_machine_uart_make_new,
     print, mp_machine_uart_print,
     protocol, &uart_stream_p,
+    #if MICROPY_PY_MACHINE_UART_FIFO_BUFFER
+    buffer, mp_machine_uart_fifo_buffer,
+    #endif
     locals_dict, &machine_uart_locals_dict
     );
 

--- a/extmod/modmachine.h
+++ b/extmod/modmachine.h
@@ -88,6 +88,12 @@
 #define MICROPY_PY_MACHINE_UART_IRQ (0)
 #endif
 
+// Whether to enable the direct access to the UART FIFO through the buffer interface.
+// Requires a port to implement mp_machine_uart_fifo_buffer().
+#ifndef MICROPY_PY_MACHINE_UART_FIFO_BUFFER
+#define MICROPY_PY_MACHINE_UART_FIFO_BUFFER (0)
+#endif
+
 // Temporary support for legacy construction of SoftI2C via I2C type.
 #define MP_MACHINE_I2C_CHECK_FOR_LEGACY_SOFTI2C_CONSTRUCTION(n_args, n_kw, all_args) \
     do { \

--- a/ports/rp2/machine_uart.c
+++ b/ports/rp2/machine_uart.c
@@ -570,5 +570,15 @@ STATIC mp_uint_t mp_machine_uart_ioctl(mp_obj_t self_in, mp_uint_t request, uint
     return ret;
 }
 
+STATIC mp_int_t mp_machine_uart_fifo_buffer(mp_obj_t o_in, mp_buffer_info_t *bufinfo, mp_uint_t flags) {
+    machine_uart_obj_t *self = o_in;
+
+    bufinfo->len = 4;
+    bufinfo->typecode = 'I';
+    bufinfo->buf = (void *)&uart_get_hw(self->uart)->dr;
+
+    return 0;
+}
+
 MP_REGISTER_ROOT_POINTER(void *rp2_uart_rx_buffer[2]);
 MP_REGISTER_ROOT_POINTER(void *rp2_uart_tx_buffer[2]);

--- a/ports/rp2/mpconfigport.h
+++ b/ports/rp2/mpconfigport.h
@@ -138,6 +138,7 @@
 #define MICROPY_PY_MACHINE_UART                 (1)
 #define MICROPY_PY_MACHINE_UART_INCLUDEFILE     "ports/rp2/machine_uart.c"
 #define MICROPY_PY_MACHINE_UART_SENDBREAK       (1)
+#define MICROPY_PY_MACHINE_UART_FIFO_BUFFER     (1)
 #define MICROPY_PY_MACHINE_WDT                  (1)
 #define MICROPY_PY_MACHINE_WDT_INCLUDEFILE      "ports/rp2/machine_wdt.c"
 #define MICROPY_PY_ONEWIRE                      (1)


### PR DESCRIPTION
This PR is similar in intent to #7650 but for UARTs, providing a way to easily get direct access to the FIFO register of a given UART so that the UART object can be passed directly to the `read` or `write` argument on a DMA controller.

The change introduces a new `MICROPY_PY_MACHINE_UART_FIFO_BUFFER` configuration in `mpconfigport.h` because parts of the `machine.UART` code are implemented in the `extmod` directory rather than the port directory.

Below is a simple example of how this can be used. (For the purpose of the example, pins 16 and 17 are connected together.)

```
>>> from machine import UART
>>> from rp2 import DMA
>>> u = UART(0, baudrate=1_000_000, tx=16, rx=17)
>>> recv_buf = bytearray(256)
>>> send_dma = DMA()
>>> send_conf = send_dma.pack_ctrl(size=0, inc_write=False, treq_sel=20)
>>> recv_dma = DMA()
>>> recv_conf = recv_dma.pack_ctrl(size=0, inc_read=False, treq_sel=21)
>>> recv_dma.config(read=u, write=recv_buf, ctrl=recv_conf, count=len(recv_buf), trigger=True)
>>> send_dma.config(read=b"Hello there!", write=u, ctrl=send_conf, count=12)
>>> recv_buf[:12]
bytearray(b'\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00')
>>> send_dma.active(1)
False
>>> recv_buf[:12]
bytearray(b'Hello there!')
```