### PR TITLE
docs: socket: Note that socket.getaddrinfo() doesn't take kwargs.

### DIFF
--- a/docs/library/socket.rst
+++ b/docs/library/socket.rst
@@ -106,6 +106,12 @@ Functions
       from an exception object). The use of negative values is a provisional
       detail which may change in the future.
 
+   .. admonition:: Difference to CPython
+      :class: attention
+
+      The optional arguments to this function are not keyword arguments and must
+      be passed as positional arguments.
+
 .. function:: inet_ntop(af, bin_addr)
 
    Convert a binary network address *bin_addr* of the given address family *af*


### PR DESCRIPTION
Closes #8039.

I'm not sure if it's viable to note this for every MP function where CPython takes kwargs and MP doesn't, but this is one where a lot of existing sample code is likely to pass kwargs.

This work was funded through GitHub Sponsors.