### PR TITLE
tools/mpremote: Reduce dependencies.

### DIFF
--- a/tools/mpremote/requirements.txt
+++ b/tools/mpremote/requirements.txt
@@ -1,2 +1,2 @@
 pyserial >= 3.3
-importlib_metadata >= 1.4
+importlib_metadata >= 1.4; python_version < "3.8"


### PR DESCRIPTION
No longer require importlib_metadata on new Python versions as it is
included in the standard distribution.