### PR TITLE
docs\library\sys.rst: Document  implementation.version.releaselevel.

### DIFF
--- a/docs/library/sys.rst
+++ b/docs/library/sys.rst
@@ -69,13 +69,15 @@ Constants
    MicroPython, it has following attributes:
 
    * *name* - string "micropython"
-   * *version* - tuple (major, minor, micro), e.g. (1, 7, 0)
+   * *version* - tuple (major, minor, micro, releaselevel), e.g. (1, 22, 0, '')
    * *_machine* - string describing the underlying machine
    * *_mpy* - supported mpy file-format version (optional attribute)
 
    This object is the recommended way to distinguish MicroPython from other
    Python implementations (note that it still may not exist in the very
    minimal ports).
+
+   Starting with version 1.22.0-preview, the 4th node *releaselevel* in *implementation.version* is either an empty string or *'preview'*
 
    .. admonition:: Difference to CPython
       :class: attention


### PR DESCRIPTION
This documents the 4th node of the sys.implementation.version, as discussed in: 

- https://github.com/micropython/micropython/issues/13317
- https://github.com/orgs/micropython/discussions/12603


Signed-off-by: Jos Verlinde <jos_verlinde@hotmail.com>