### PR TITLE
rp2: Make result of thread.get_ident() a non-zero integer.

### DIFF
--- a/ports/rp2/mpthreadport.c
+++ b/ports/rp2/mpthreadport.c
@@ -115,9 +115,9 @@ STATIC void core1_entry_wrapper(void) {
 }
 
 mp_uint_t mp_thread_get_id(void) {
-    // On RP2, there are only two threads, one for each core, so the thread id
-    // is the core number.
-    return get_core_num();
+    // On RP2, there are only two threads, one for each core.
+    // _thread.get_ident() must be non-zero.
+    return get_core_num() + 1;
 }
 
 mp_uint_t mp_thread_create(void *(*entry)(void *), void *arg, size_t *stack_size) {
@@ -149,7 +149,7 @@ mp_uint_t mp_thread_create(void *(*entry)(void *), void *arg, size_t *stack_size
     // Adjust stack_size to provide room to recover from hitting the limit.
     *stack_size -= 512;
 
-    return 1;
+    return 2; // mp_thread_get_id() result for core 1
 }
 
 void mp_thread_start(void) {


### PR DESCRIPTION
- [CPython says thread identifier is a "nonzero integer"](https://docs.python.org/3.5/library/_thread.html#_thread.get_ident), so rp2 should use a 1-indexed core number rather than 0-indexed.

- Fixes the thread/thread_ident1 test failure on rp2 port. Follow-up to #13351.

Unfortunately this may be a breaking change for any existing rp2 MP code which makes a hard-coded comparison of thread identifier to 0 or 1.

*This work was funded through GitHub Sponsors.*