### PR TITLE
ports/ra: Fix SysTick clock source.

### DIFF
--- a/ports/renesas-ra/ra/ra_config.h
+++ b/ports/renesas-ra/ra/ra_config.h
@@ -26,6 +26,7 @@
 #define RA_RA_CONFIG_H_
 
 #include <stdint.h>
+#include "py/mpconfig.h"
 
 #if defined(RA4M1) | defined(RA4W1)
 #define SCI_CH_MAX      10

--- a/ports/renesas-ra/ra/ra_init.c
+++ b/ports/renesas-ra/ra/ra_init.c
@@ -30,7 +30,7 @@
 
 void ra_init(void) {
     ra_int_init();
-    SysTick_Config(PCLK / 1000);
+    SysTick_Config(MICROPY_HW_MCU_SYSCLK / 1000);
     internal_flash_init();
 }
 

--- a/ports/renesas-ra/ra/ra_timer.h
+++ b/ports/renesas-ra/ra/ra_timer.h
@@ -34,8 +34,6 @@ uint32_t HAL_GetTick(void);
 #define TENUSEC_COUNT (PCLK / DEF_CLKDEV / 100000)
 #define MSEC_COUNT    (PCLK / DEF_CLKDEV / 100)
 
-__attribute__((naked)) void min_delay(__attribute__((unused)) uint32_t loop_cnt);
-
 typedef void (*AGT_TIMER_CB)(void *);
 
 void ra_agt_timer_set_callback(uint32_t ch, AGT_TIMER_CB cb, void *param);


### PR DESCRIPTION
The SysTick_Config function is using PCLK instead of the system clock, to configure the ticks.