### PR TITLE
py/py.mk: Remove extra build dir created for frozen_content.

### DIFF
--- a/py/py.mk
+++ b/py/py.mk
@@ -203,7 +203,7 @@ PY_O += $(PY_CORE_O)
 
 # object file for frozen code specified via a manifest
 ifneq ($(FROZEN_MANIFEST),)
-PY_O += $(BUILD)/$(BUILD)/frozen_content.o
+PY_O += $(BUILD)/frozen_content.o
 endif
 
 # Sources that may contain qstrings


### PR DESCRIPTION
The current rule creates a extra dir nested in the build dir, and frozen_content ends up in `build-BOARD/build-BOARD/frozen_content.o`. I don't think this is intentional, is there a reason for this ?