### PR TITLE
lib/libm/kf_rem_pio: Fix uninitialized issued when compiling with gcc13.2.

### DIFF
--- a/extmod/extmod.mk
+++ b/extmod/extmod.mk
@@ -159,6 +159,7 @@ SRC_LIB_LIBM_DBL_SQRT_HW_C += lib/libm_dbl/thumb_vfp_sqrt.c
 
 # Too many warnings in libm_dbl, disable for now.
 $(BUILD)/lib/libm_dbl/%.o: CFLAGS += -Wno-double-promotion -Wno-float-conversion
+$(BUILD)/lib/libm/kf_rem_pio2.o: CFLAGS += -Wno-maybe-uninitialized
 
 ################################################################################
 # VFS FAT FS


### PR DESCRIPTION
You will get a compile error with GCC 13.2, thinking fq is uninitialized.