### PR TITLE
renesas-ra/boards/ARDUINO_PORTENTA_C33: Fix the RTC clock source.

### DIFF
--- a/ports/renesas-ra/boards/ARDUINO_PORTENTA_C33/mpconfigboard.h
+++ b/ports/renesas-ra/boards/ARDUINO_PORTENTA_C33/mpconfigboard.h
@@ -28,7 +28,7 @@
 // peripheral config
 #define MICROPY_HW_ENABLE_RNG       (1)
 #define MICROPY_HW_ENABLE_RTC       (1)
-#define MICROPY_HW_RTC_SOURCE       (1)
+#define MICROPY_HW_RTC_SOURCE       (0)
 #define MICROPY_HW_ENABLE_ADC       (1)
 #define MICROPY_HW_HAS_FLASH        (1)
 #define MICROPY_HW_ENABLE_USBDEV    (1)


### PR DESCRIPTION
Switch the RTC clock source to Sub-clock (XCIN). This board has an accurate LSE crystal, and it should be used for the RTC clock source.