### PR TITLE
Fix the issue on linux/wsl of pyboard and mpremote "locking up" some ESP32 and ESP8266 boards

### DIFF
--- a/tools/mpremote/mpremote/transport_serial.py
+++ b/tools/mpremote/mpremote/transport_serial.py
@@ -59,7 +59,7 @@ def reraise_filesystem_error(e, info):
 
 
 class SerialTransport(Transport):
-    def __init__(self, device, baudrate=115200, wait=0, exclusive=True):
+    def __init__(self, device, baudrate=115200, wait=0, exclusive=True, hard_reset=False,):
         self.in_raw_repl = False
         self.use_raw_paste = True
         self.device_name = device
@@ -90,7 +90,27 @@ class SerialTransport(Transport):
                         self.serial.rts = False  # RTS False = EN High = MCU enabled
                     self.serial.open()
                 else:
-                    self.serial = serial.Serial(device, **serial_kwargs)
+                    self.serial = serial.Serial()  # Must not put a device in here, else rts locks up ESP8266/ESP32
+                    self.serial.dtr = False  # DTR False = gpio0 High = Normal boot
+                    self.serial.rts = False  # RTS False = EN High = MCU enabled
+                    self.serial.port = device
+                    self.serial.baudrate = serial_kwargs["baudrate"]
+                    self.serial.rtscts = 0  # Do not use hardware flow control (rts used for MCU reset)
+                    self.serial.dsrdtr = 0  # Do not use hardware flow control (dtr used for gpio0)
+                    self.serial.inter_byte_timeout = serial_kwargs["interCharTimeout"]
+                    if "exclusive" in serial_kwargs:
+                        self.serial.exclusive = serial_kwargs["exclusive"]
+                    self.serial.open()
+
+                    if hard_reset:
+                        # pause ( the above open() only just pulled the line low )
+                        time.sleep(0.2)
+                        # this is reset (setting this "high" resets MCU boards that use RTS/CTS for flashing)
+                        self.serial.rts = True
+                        time.sleep(0.2)
+                        self.serial.rts = False
+                        # must wait for the reset, otherwise subsequent commands (the ctrl-A) get lost
+                        time.sleep(2.0)
                 break
             except OSError:
                 if wait == 0:

--- a/tools/mpremote/mpremote/transport_serial.py
+++ b/tools/mpremote/mpremote/transport_serial.py
@@ -59,7 +59,14 @@ def reraise_filesystem_error(e, info):
 
 
 class SerialTransport(Transport):
-    def __init__(self, device, baudrate=115200, wait=0, exclusive=True, hard_reset=False,):
+    def __init__(
+        self,
+        device,
+        baudrate=115200,
+        wait=0,
+        exclusive=True,
+        hard_reset=False,
+    ):
         self.in_raw_repl = False
         self.use_raw_paste = True
         self.device_name = device
@@ -90,13 +97,16 @@ class SerialTransport(Transport):
                         self.serial.rts = False  # RTS False = EN High = MCU enabled
                     self.serial.open()
                 else:
-                    self.serial = serial.Serial()  # Must not put a device in here, else rts locks up ESP8266/ESP32
+                    # Must not put device in .Serial(), else rts locks up ESP8266/ESP32
+                    self.serial = serial.Serial()
                     self.serial.dtr = False  # DTR False = gpio0 High = Normal boot
                     self.serial.rts = False  # RTS False = EN High = MCU enabled
                     self.serial.port = device
                     self.serial.baudrate = serial_kwargs["baudrate"]
-                    self.serial.rtscts = 0  # Do not use hardware flow control (rts used for MCU reset)
-                    self.serial.dsrdtr = 0  # Do not use hardware flow control (dtr used for gpio0)
+                    # Do not use hardware flow control (rts used for MCU reset)
+                    self.serial.rtscts = 0
+                    # Do not use hardware flow control (dtr used for gpio0)
+                    self.serial.dsrdtr = 0
                     self.serial.inter_byte_timeout = serial_kwargs["interCharTimeout"]
                     if "exclusive" in serial_kwargs:
                         self.serial.exclusive = serial_kwargs["exclusive"]

--- a/tools/pyboard.py
+++ b/tools/pyboard.py
@@ -265,7 +265,7 @@ class ProcessPtyToTerminal:
 
 class Pyboard:
     def __init__(
-        self, device, baudrate=115200, user="micro", password="python", wait=0, exclusive=True
+        self, device, baudrate=115200, user="micro", password="python", wait=0, exclusive=True, hard_reset=False,
     ):
         self.in_raw_repl = False
         self.use_raw_paste = True
@@ -300,7 +300,27 @@ class Pyboard:
                             self.serial.rts = False  # RTS False = EN High = MCU enabled
                         self.serial.open()
                     else:
-                        self.serial = serial.Serial(device, **serial_kwargs)
+                        self.serial = serial.Serial()  # Must not put device in here, else rts locks up ESP8266/ESP32
+                        self.serial.dtr = False  # DTR False = gpio0 High = Normal boot
+                        self.serial.rts = False  # RTS False = EN High = MCU enabled
+                        self.serial.port = device
+                        self.serial.baudrate = serial_kwargs["baudrate"]
+                        self.serial.rtscts = 0  # Do not use hardware flow control (rts used for MCU reset)
+                        self.serial.dsrdtr = 0  # Do not use hardware flow control (dtr used for gpio0)
+                        self.serial.inter_byte_timeout = serial_kwargs["interCharTimeout"]
+                        if "exclusive" in serial_kwargs:
+                            self.serial.exclusive = serial_kwargs["exclusive"]
+                        self.serial.open()
+
+                        if hard_reset:
+                            # pause ( the above open() only just pulled the line low )
+                            time.sleep(0.2)
+                            # this is reset (setting this "high" resets MCU boards that use RTS/CTS for flashing)
+                            self.serial.rts = True
+                            time.sleep(0.2)
+                            self.serial.rts = False
+                            # must wait for the reset, otherwise subsequent commands (the ctrl-A) get lost
+                            time.sleep(2.0)
                     break
                 except (OSError, IOError):  # Py2 and Py3 have different errors
                     if wait == 0:

--- a/tools/pyboard.py
+++ b/tools/pyboard.py
@@ -307,7 +307,7 @@ class Pyboard:
                             self.serial.rts = False  # RTS False = EN High = MCU enabled
                         self.serial.open()
                     else:
-                        # Must not put device in .Serial(), else rts locks up ESP8266/ESP32
+                        # Must not put device in .Serial(), else RTS line locks up ESP8266/ESP32 
                         self.serial = serial.Serial()
                         self.serial.dtr = False  # DTR False = gpio0 High = Normal boot
                         self.serial.rts = False  # RTS False = EN High = MCU enabled

--- a/tools/pyboard.py
+++ b/tools/pyboard.py
@@ -265,7 +265,14 @@ class ProcessPtyToTerminal:
 
 class Pyboard:
     def __init__(
-        self, device, baudrate=115200, user="micro", password="python", wait=0, exclusive=True, hard_reset=False,
+        self,
+        device,
+        baudrate=115200,
+        user="micro",
+        password="python",
+        wait=0,
+        exclusive=True,
+        hard_reset=False,
     ):
         self.in_raw_repl = False
         self.use_raw_paste = True
@@ -300,13 +307,16 @@ class Pyboard:
                             self.serial.rts = False  # RTS False = EN High = MCU enabled
                         self.serial.open()
                     else:
-                        self.serial = serial.Serial()  # Must not put device in here, else rts locks up ESP8266/ESP32
+                        # Must not put device in .Serial(), else rts locks up ESP8266/ESP32
+                        self.serial = serial.Serial()
                         self.serial.dtr = False  # DTR False = gpio0 High = Normal boot
                         self.serial.rts = False  # RTS False = EN High = MCU enabled
                         self.serial.port = device
                         self.serial.baudrate = serial_kwargs["baudrate"]
-                        self.serial.rtscts = 0  # Do not use hardware flow control (rts used for MCU reset)
-                        self.serial.dsrdtr = 0  # Do not use hardware flow control (dtr used for gpio0)
+                        # Do not use hardware flow control (rts used for MCU reset)
+                        self.serial.rtscts = 0
+                        # Do not use hardware flow control (dtr used for gpio0)
+                        self.serial.dsrdtr = 0
                         self.serial.inter_byte_timeout = serial_kwargs["interCharTimeout"]
                         if "exclusive" in serial_kwargs:
                             self.serial.exclusive = serial_kwargs["exclusive"]


### PR DESCRIPTION
This modification prevents DTR and RTS line pulses occurring when the port is (re-) opened.

The cause is a python bug, but delaying the open until after resetting the dtr successfully works around it.