### PR TITLE
ports/rp2: Add a means to set mass-storage filesystem label

### DIFF
--- a/extmod/vfs_fat.c
+++ b/extmod/vfs_fat.c
@@ -39,6 +39,7 @@
 #include <string.h>
 #include "py/runtime.h"
 #include "py/mperrno.h"
+#include "py/objstr.h"
 #include "lib/oofatfs/ff.h"
 #include "extmod/vfs_fat.h"
 #include "shared/timeutils/timeutils.h"
@@ -378,6 +379,22 @@ static mp_obj_t fat_vfs_statvfs(mp_obj_t vfs_in, mp_obj_t path_in) {
 }
 static MP_DEFINE_CONST_FUN_OBJ_2(fat_vfs_statvfs_obj, fat_vfs_statvfs);
 
+static mp_obj_t fat_vfs_label(mp_obj_t vfs_in, mp_obj_t label_in) {
+    #ifdef MICROPY_FATFS_USE_LABEL
+    mp_obj_fat_vfs_t *self = MP_OBJ_TO_PTR(vfs_in);
+    const char *label = mp_obj_str_get_str(label_in);
+
+    FRESULT res = f_setlabel(&self->fatfs, label);
+
+    if (FR_OK != res) {
+        mp_raise_OSError(fresult_to_errno_table[res]);
+    }
+
+    #endif
+    return mp_const_none;
+}
+static MP_DEFINE_CONST_FUN_OBJ_2(fat_vfs_label_obj, fat_vfs_label);
+
 static mp_obj_t vfs_fat_mount(mp_obj_t self_in, mp_obj_t readonly, mp_obj_t mkfs) {
     fs_user_mount_t *self = MP_OBJ_TO_PTR(self_in);
 
@@ -426,6 +443,7 @@ static const mp_rom_map_elem_t fat_vfs_locals_dict_table[] = {
     { MP_ROM_QSTR(MP_QSTR_rename), MP_ROM_PTR(&fat_vfs_rename_obj) },
     { MP_ROM_QSTR(MP_QSTR_stat), MP_ROM_PTR(&fat_vfs_stat_obj) },
     { MP_ROM_QSTR(MP_QSTR_statvfs), MP_ROM_PTR(&fat_vfs_statvfs_obj) },
+    { MP_ROM_QSTR(MP_QSTR_label), MP_ROM_PTR(&fat_vfs_label_obj) },
     { MP_ROM_QSTR(MP_QSTR_mount), MP_ROM_PTR(&vfs_fat_mount_obj) },
     { MP_ROM_QSTR(MP_QSTR_umount), MP_ROM_PTR(&fat_vfs_umount_obj) },
 };

--- a/ports/rp2/modules/_boot_fat.py
+++ b/ports/rp2/modules/_boot_fat.py
@@ -5,9 +5,12 @@ import machine, rp2
 # Try to mount the filesystem, and format the flash if it doesn't exist.
 bdev = rp2.Flash()
 try:
-    vfs.mount(vfs.VfsFat(bdev), "/")
+    fat = vfs.VfsFat(bdev)
+    vfs.mount(fat, "/")
 except:
     vfs.VfsFat.mkfs(bdev)
-    vfs.mount(vfs.VfsFat(bdev), "/")
+    fat = vfs.VfsFat(bdev)
+    fat.label("RP2_MSC")
+    vfs.mount(fat, "/")
 
-del vfs, bdev
+del vfs, bdev, fat


### PR DESCRIPTION
This addresses discussion over at https://github.com/orgs/micropython/discussions/9590

For other boards which more conventionally use MSC, they call `f_setlabel` from the factory reset code paths in C, eg:

https://github.com/micropython/micropython/blob/16c6bc47cf2b9247418bca8c0d1361167d08594e/ports/renesas-ra/factoryreset.c#L88

The C method uses `MICROPY_HW_FLASH_FS_LABEL`,  but I wasn't sure by what means we could incorporate that into RP2's Python filesystem bootstrapping. Perhaps calling `vfs.label()` without an argument could use this as the default value?