### PR TITLE
Zero intialize externed mp_state_ctx

### DIFF
--- a/py/mpstate.c
+++ b/py/mpstate.c
@@ -30,4 +30,4 @@
 mp_dynamic_compiler_t mp_dynamic_compiler = {0};
 #endif
 
-mp_state_ctx_t mp_state_ctx;
+mp_state_ctx_t mp_state_ctx = {0};


### PR DESCRIPTION
Added zero initialization of extern mp_state_ctx to satisfy clang on OSX