### PR TITLE
ports/mimxrt: Fix deepsleep wakeup pin ifdef.

### DIFF
--- a/ports/mimxrt/modmachine.c
+++ b/ports/mimxrt/modmachine.c
@@ -142,7 +142,7 @@ NORETURN STATIC void mp_machine_deepsleep(size_t n_args, const mp_obj_t *args) {
     #ifdef MIMXRT117x_SERIES
     machine_pin_config(pin_WAKEUP_DIG, PIN_MODE_IT_RISING, PIN_PULL_DISABLED, PIN_DRIVE_OFF, 0, PIN_AF_MODE_ALT5);
     GPC_CM_EnableIrqWakeup(GPC_CPU_MODE_CTRL_0, GPIO13_Combined_0_31_IRQn, true);
-    #elif defined IOMUXC_SNVS_WAKEUP_GPIO5_IO00
+    #elif defined pin_WAKEUP
     machine_pin_config(pin_WAKEUP, PIN_MODE_IT_RISING, PIN_PULL_DISABLED, PIN_DRIVE_OFF, 0, PIN_AF_MODE_ALT5);
     GPC_EnableIRQ(GPC, GPIO5_Combined_0_15_IRQn);
     #endif


### PR DESCRIPTION
The ifdef for the wakeup pin was not being defined. https://github.com/openmv/micropython/blob/f13c0bc8a9b922ef856a454592366d5b428f532f/ports/mimxrt/modmachine.c#L145

Note, waking up via deepsleep on the mimxrt is broken without this.