### PR TITLE
github/workflows: Run rp2 and stm32 CI with space in repository path.

### DIFF
--- a/.github/workflows/ports_mimxrt.yml
+++ b/.github/workflows/ports_mimxrt.yml
@@ -20,8 +20,13 @@ concurrency:
 jobs:
   build:
     runs-on: ubuntu-20.04
+    defaults:
+      run:
+        working-directory: 'micropython repo'  # test build with space in path
     steps:
     - uses: actions/checkout@v4
+      with:
+        path: 'micropython repo'
     - name: Install packages
       run: source tools/ci.sh && ci_mimxrt_setup
     - name: Build

--- a/.github/workflows/ports_rp2.yml
+++ b/.github/workflows/ports_rp2.yml
@@ -20,8 +20,13 @@ concurrency:
 jobs:
   build:
     runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: 'micropython repo'  # test build with space in path
     steps:
     - uses: actions/checkout@v4
+      with:
+        path: 'micropython repo'
     - name: Install packages
       run: source tools/ci.sh && ci_rp2_setup
     - name: Build


### PR DESCRIPTION
To test building with make and cmake when there is a space in the path.