### PR TITLE
rp2: Fix the ADC pin initialisation.

### DIFF
--- a/docs/rp2/quickref.rst
+++ b/docs/rp2/quickref.rst
@@ -187,6 +187,14 @@ Use the :ref:`machine.ADC <machine.ADC>` class::
     adc = ADC(Pin(26))     # create ADC object on ADC pin
     adc.read_u16()         # read value, 0-65535 across voltage range 0.0v - 3.3v
 
+The argument of the constructor ADC specifies either a Pin by number, name of as
+Pin object, or a channel number in the range 0 - 3 or ADC.CORE_TEMP for the
+internal temperature sensor. If a pin is specified,
+the pin is initialized in high-Z mode. If a channel number is used, the pin
+is not initialized and configuring is left to the user code. After hard reset,
+RP2040 pins operate in current sink mode at about 60µA. If the pin is not
+otherwise configured, that may lead to wrong ADC readings.
+
 Software SPI bus
 ----------------
 

--- a/ports/rp2/machine_adc.c
+++ b/ports/rp2/machine_adc.c
@@ -74,14 +74,14 @@ static mp_obj_t mp_machine_adc_make_new(const mp_obj_type_t *type, size_t n_args
     const machine_pin_obj_t *pin = NULL;
 
     if (mp_obj_is_int(source)) {
-        // Get and validate channel number.
         channel = mp_obj_get_int(source);
-        if (ADC_IS_VALID_GPIO(channel)) {
-            channel = ADC_CHANNEL_FROM_GPIO(channel);
-        } else if (!(channel >= 0 && channel <= ADC_CHANNEL_TEMPSENSOR)) {
-            mp_raise_ValueError(MP_ERROR_TEXT("invalid channel"));
+        if (!(channel >= 0 && channel <= ADC_CHANNEL_TEMPSENSOR)) {
+            // Not a valid ADC channel, fallback to searching for a pin.
+            channel = -1;
         }
-    } else {
+    }
+
+    if (channel == -1) {
         // Get GPIO and check it has ADC capabilities.
         pin = machine_pin_find(source);
         bool valid_adc_pin = false;


### PR DESCRIPTION
- Fix the ADC pin initialization:  the change closes the gap when an integer was used as Pin reference. With that change, e.g. ADC(26), ADC(Pin(26)) and ADC("GP26") behave identical and the GPIO is initialized in high-Z mode. Only when using ADC channel numbers 0 - 4 the ADC pin is not initialized and that step is left to the user code.
