### PR TITLE
stm32/mboot/Makefile: Revert change to BOARD_DIR that removed abspath.

### DIFF
--- a/ports/stm32/mboot/Makefile
+++ b/ports/stm32/mboot/Makefile
@@ -6,7 +6,7 @@ BOARD ?= $(notdir $(BOARD_DIR:/=))
 else
 # If not given on the command line, then default to PYBV10.
 BOARD ?= PYBV10
-BOARD_DIR ?= ../boards/$(BOARD)
+BOARD_DIR ?= $(abspath ../boards/$(BOARD))
 endif
 
 # If the build directory is not given, make it reflect the board name.


### PR DESCRIPTION
This reverts the change from ce2058685b9ca2278849b3117c2461f6b6fc727f.

Without abspath, the build artefacts (object files) for boards with source files are placed outside the build directory, because the BOARD_DIR variable starts with "..".  For the list of source files added to SRC_C, none of them can start with "..".  The usual fix for that would be to make the files relative to the top of the MicroPython repo (because of the vpath rule), eg ports/stm32/boards/$(BOARD).  But then the $(wildcard ...) pattern won't find files in this directory.

So abspath is necessary, although it will prevent building when there is a space in the path.  A better solution for spaces needs to be found.