### PR TITLE
esp8266/boards/ESP8266_GENERIC: Disable MICROPY_DEBUG_PRINTERS.

### DIFF
--- a/ports/esp8266/boards/ESP8266_GENERIC/mpconfigboard.h
+++ b/ports/esp8266/boards/ESP8266_GENERIC/mpconfigboard.h
@@ -7,7 +7,6 @@
 #define MICROPY_EMIT_XTENSA             (1)
 #define MICROPY_EMIT_INLINE_XTENSA      (1)
 
-#define MICROPY_DEBUG_PRINTERS          (1)
 #define MICROPY_ERROR_REPORTING         (MICROPY_ERROR_REPORTING_NORMAL)
 
 #define MICROPY_READER_VFS              (MICROPY_VFS)
@@ -24,7 +23,6 @@
 #define MICROPY_EMIT_XTENSA             (1)
 #define MICROPY_EMIT_INLINE_XTENSA      (1)
 
-#define MICROPY_DEBUG_PRINTERS          (1)
 #define MICROPY_ERROR_REPORTING         (MICROPY_ERROR_REPORTING_NORMAL)
 
 #define MICROPY_READER_VFS              (MICROPY_VFS)


### PR DESCRIPTION
This is not enabled on any other MCU port, and is essentially unused on esp8266 because mp_verbose_flag is always 0.  Disabling saves ~7k of flash.