### PR TITLE
qemu-arm/mpconfigport: Use MICROPY_CONFIG_ROM_LEVEL_EXTRA_FEATURES.

### DIFF
--- a/ports/qemu-arm/mpconfigport.h
+++ b/ports/qemu-arm/mpconfigport.h
@@ -2,7 +2,7 @@
 
 // options to control how MicroPython is built
 
-#define MICROPY_ALLOC_PATH_MAX      (512)
+#define MICROPY_CONFIG_ROM_LEVEL    (MICROPY_CONFIG_ROM_LEVEL_EXTRA_FEATURES)
 
 #if defined(__ARM_ARCH_ISA_ARM)
 #define MICROPY_EMIT_ARM            (1)
@@ -15,42 +15,24 @@
 
 #define MICROPY_MALLOC_USES_ALLOCATED_SIZE (1)
 #define MICROPY_MEM_STATS           (1)
-#define MICROPY_DEBUG_PRINTERS      (0)
 #define MICROPY_ENABLE_GC           (1)
-#define MICROPY_STACK_CHECK         (1)
+#define MICROPY_KBD_EXCEPTION       (0)
 #define MICROPY_HELPER_REPL         (0)
-#define MICROPY_HELPER_LEXER_UNIX   (0)
-#define MICROPY_ENABLE_SOURCE_LINE  (1)
 #define MICROPY_LONGINT_IMPL        (MICROPY_LONGINT_IMPL_MPZ)
 #define MICROPY_FLOAT_IMPL          (MICROPY_FLOAT_IMPL_FLOAT)
-#define MICROPY_CAN_OVERRIDE_BUILTINS (1)
 #define MICROPY_WARNINGS            (1)
-#define MICROPY_PY_ALL_SPECIAL_METHODS (1)
-#define MICROPY_PY_REVERSE_SPECIAL_METHODS (1)
-#define MICROPY_PY_ARRAY_SLICE_ASSIGN (1)
-#define MICROPY_PY_BUILTINS_BYTES_HEX (1)
-#define MICROPY_PY_BUILTINS_FROZENSET (1)
-#define MICROPY_PY_BUILTINS_MEMORYVIEW (1)
-#define MICROPY_PY_BUILTINS_POW3    (1)
-#define MICROPY_PY_IO               (1)
-#define MICROPY_PY_SYS_EXIT         (1)
-#define MICROPY_PY_SYS_MAXSIZE      (1)
+#define MICROPY_PY_BUILTINS_INPUT   (0)
+#define MICROPY_PY_BUILTINS_HELP    (0)
+#define MICROPY_PY_IO_IOBASE        (0)
 #define MICROPY_PY_SYS_PLATFORM     "qemu-arm"
-#define MICROPY_PY_ERRNO            (1)
-#define MICROPY_PY_BINASCII         (1)
-#define MICROPY_PY_RANDOM           (1)
-#define MICROPY_PY_UCTYPES          (1)
-#define MICROPY_PY_DEFLATE          (1)
-#define MICROPY_PY_JSON             (1)
-#define MICROPY_PY_OS               (1)
-#define MICROPY_PY_RE               (1)
-#define MICROPY_PY_HEAPQ            (1)
-#define MICROPY_PY_HASHLIB          (1)
+#define MICROPY_PY_SYS_STDFILES     (0)
+#define MICROPY_PY_SYS_STDIO_BUFFER (0)
+#define MICROPY_PY_SELECT           (0)
+#define MICROPY_PY_TIME             (0)
+#define MICROPY_PY_ASYNCIO          (0)
 #define MICROPY_PY_MACHINE          (1)
 #define MICROPY_PY_MACHINE_INCLUDEFILE "ports/qemu-arm/modmachine.c"
 #define MICROPY_PY_MACHINE_PIN_BASE (1)
-#define MICROPY_PY_MICROPYTHON_MEM_INFO (1)
-#define MICROPY_USE_INTERNAL_PRINTF (1)
 #define MICROPY_VFS                 (1)
 
 // type definitions for the specific machine
@@ -66,6 +48,9 @@ typedef long mp_off_t;
 
 // We need to provide a declaration/definition of alloca()
 #include <alloca.h>
+
+// We need an implementation of the log2 function which is not a macro.
+#define MP_NEED_LOG2 (1)
 
 #ifdef TEST
 #include "shared/upytesthelper/upytesthelper.h"

--- a/tests/extmod/framebuf_polygon.py
+++ b/tests/extmod/framebuf_polygon.py
@@ -1,5 +1,3 @@
-import sys
-
 try:
     import framebuf
     from array import array
@@ -18,8 +16,8 @@ def print_buffer(buffer, width, height):
     for row in range(height):
         for col in range(width):
             val = buffer[(row * width) + col]
-            sys.stdout.write(" {:02x}".format(val) if val else " ··")
-        sys.stdout.write("\n")
+            print(" {:02x}".format(val) if val else " ··", end="")
+        print()
 
 
 buf = bytearray(70 * 70)


### PR DESCRIPTION
This simplifes the port configuration.  It enables quite a few new features, including the `math` and `cmath` modules, adding about 20k to the firmware size.
