### PR TITLE
esp32/machine_i2c.c: Fix warnings when I2C is disabled.

### DIFF
--- a/ports/esp32/machine_i2c.c
+++ b/ports/esp32/machine_i2c.c
@@ -32,6 +32,8 @@
 #include "driver/i2c.h"
 #include "hal/i2c_ll.h"
 
+#if MICROPY_PY_MACHINE_I2C || MICROPY_PY_MACHINE_SOFTI2C
+
 #ifndef MICROPY_HW_I2C0_SCL
 #define MICROPY_HW_I2C0_SCL (GPIO_NUM_18)
 #define MICROPY_HW_I2C0_SDA (GPIO_NUM_19)
@@ -210,3 +212,5 @@ MP_DEFINE_CONST_OBJ_TYPE(
     protocol, &machine_hw_i2c_p,
     locals_dict, &mp_machine_i2c_locals_dict
     );
+
+#endif


### PR DESCRIPTION
Fix warning when all I2C define`s is 0.
https://github.com/micropython/micropython/blob/d19371cb23b58151f27695a445f33505af6bdb1e/ports/esp32/mpconfigport.h#L135
https://github.com/micropython/micropython/blob/d19371cb23b58151f27695a445f33505af6bdb1e/ports/esp32/mpconfigport.h#L137