### PR TITLE
ci: Move codespell into GitHub action workflow, apply codespell version.

### DIFF
--- a/.github/workflows/code_formatting.yml
+++ b/.github/workflows/code_formatting.yml
@@ -18,13 +18,3 @@ jobs:
       run: source tools/ci.sh && ci_c_code_formatting_run
     - name: Check code formatting
       run: git diff --exit-code
-
-  code-spelling:
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v4
-    - uses: actions/setup-python@v5
-    - name: Install packages
-      run: source tools/ci.sh && ci_code_spell_setup
-    - name: Run spell checker
-      run: source tools/ci.sh && ci_code_spell_run

--- a/.github/workflows/codespell.yml
+++ b/.github/workflows/codespell.yml
@@ -1,0 +1,12 @@
+name: Check spelling with codespell
+
+on: [push, pull_request]
+
+jobs:
+  codespell:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - run: pip install --user codespell==2.2.6 tomli
+    - run: codespell
+

--- a/.github/workflows/codespell.yml
+++ b/.github/workflows/codespell.yml
@@ -7,6 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
+    # codespell version should be kept in sync with .pre-commit-config.yml
     - run: pip install --user codespell==2.2.6 tomli
     - run: codespell
 

--- a/.github/workflows/ruff.yml
+++ b/.github/workflows/ruff.yml
@@ -1,6 +1,7 @@
-# https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-python
 name: Python code lint and formatting with ruff
+
 on: [push, pull_request]
+
 jobs:
   ruff:
     runs-on: ubuntu-latest

--- a/.github/workflows/ruff.yml
+++ b/.github/workflows/ruff.yml
@@ -6,6 +6,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
+    # ruff version should be kept in sync with .pre-commit-config.yaml
     - run: pip install --user ruff==0.1.3
     - run: ruff check --output-format=github .
     - run: ruff format --diff .

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,11 +12,13 @@ repos:
         verbose: true
         stages: [commit-msg]
   - repo: https://github.com/charliermarsh/ruff-pre-commit
+    # Version should be kept in sync with .github/workflows/ruff.yml
     rev: v0.1.3
     hooks:
       - id: ruff
       - id: ruff-format
   - repo: https://github.com/codespell-project/codespell
+    # Version should be kept in sync with .github/workflows/codespell.yml
     rev: v2.2.6
     hooks:
       - id: codespell

--- a/tools/ci.sh
+++ b/tools/ci.sh
@@ -31,17 +31,6 @@ function ci_c_code_formatting_run {
 }
 
 ########################################################################################
-# code spelling
-
-function ci_code_spell_setup {
-    pip3 install codespell tomli
-}
-
-function ci_code_spell_run {
-    codespell
-}
-
-########################################################################################
 # commit formatting
 
 function ci_commit_formatting_run {


### PR DESCRIPTION
* Similar to ruff.yaml, it's simpler to run the `codespell` command directly from a workflow file.
* Applies a specific version to codespell, same as pre-commit (introduced in #12157)

~~Additional, optional commit in this branch:~~

EDIT: Dropped this commit as `yq` is only packaged in Ubuntu starting from "lunar", 23.04.

* ~~Read the CI tool versions (ruff, codespell) from `.pre-commit-config.yaml`. This means there is now a single canonical source for these versions, at the cost of some ugly "yq" YAML parsing in the workflow steps.~~

~~Can drop the second commit if it's too fiddly, and~~ will add comments instead to remind anyone updating that the version is copied in two places.

*This work was funded through GitHub Sponsors.*