### PR TITLE
examples/embedding: Add -fno-common to the sample compiler flags.

### DIFF
--- a/examples/embedding/Makefile
+++ b/examples/embedding/Makefile
@@ -12,7 +12,7 @@ PROG = embed
 CFLAGS += -I.
 CFLAGS += -I$(EMBED_DIR)
 CFLAGS += -I$(EMBED_DIR)/port
-CFLAGS += -Wall -Og
+CFLAGS += -Wall -Og -fno-common
 
 SRC += main.c
 SRC += $(wildcard $(EMBED_DIR)/*/*.c) $(wildcard $(EMBED_DIR)/*/*/*.c)


### PR DESCRIPTION
This makes no difference when files are linked directly into a target application, but on macOS additional steps are needed to index common symbols in static libraries. See https://stackoverflow.com/a/26581710

By not creating any common symbols, this problem is bypassed.

This will also trigger linker errors if there are cases where the same symbol is defined in the host application.

Alternative to the fix proposed in #13498 and confirmed to work by @Shootfast.

*This work was funded through GitHub sponsors.*