### PR TITLE
all tinyusb ports: On cold boot, enable USB after boot.py completes.

### DIFF
--- a/ports/mimxrt/main.c
+++ b/ports/mimxrt/main.c
@@ -34,8 +34,8 @@
 #include "shared/runtime/gchelper.h"
 #include "shared/runtime/pyexec.h"
 #include "shared/runtime/softtimer.h"
+#include "shared/tinyusb/mp_usbd.h"
 #include "ticks.h"
-#include "tusb.h"
 #include "led.h"
 #include "pendsv.h"
 #include "modmachine.h"
@@ -63,7 +63,6 @@ void board_init(void);
 int main(void) {
     board_init();
     ticks_init();
-    tusb_init();
     pendsv_init();
 
     #if MICROPY_PY_LWIP
@@ -115,6 +114,9 @@ int main(void) {
 
         // Execute user scripts.
         int ret = pyexec_file_if_exists("boot.py");
+
+        mp_usbd_init();
+
         if (ret & PYEXEC_FORCED_EXIT) {
             goto soft_reset_exit;
         }

--- a/ports/nrf/drivers/usb/usb_cdc.c
+++ b/ports/nrf/drivers/usb/usb_cdc.c
@@ -29,7 +29,6 @@
 
 #if MICROPY_HW_USB_CDC
 
-#include "tusb.h"
 #include "nrfx.h"
 #include "nrfx_power.h"
 #include "nrfx_uart.h"
@@ -37,6 +36,7 @@
 #include "py/stream.h"
 #include "py/runtime.h"
 #include "shared/runtime/interrupt_char.h"
+#include "shared/tinyusb/mp_usbd.h"
 
 #ifdef BLUETOOTH_SD
 #include "nrf_sdm.h"
@@ -186,7 +186,7 @@ int usb_cdc_init(void)
     tx_ringbuf.iget = 0;
     tx_ringbuf.iput = 0;
 
-    tusb_init();
+    mp_usbd_init();
 
     return 0;
 }

--- a/ports/nrf/main.c
+++ b/ports/nrf/main.c
@@ -261,13 +261,15 @@ soft_reset:
 
     led_state(1, 0);
 
+    #if MICROPY_VFS || MICROPY_MBFS || MICROPY_MODULE_FROZEN
+    ret = pyexec_file_if_exists("boot.py");
+    #endif
+
     #if MICROPY_HW_USB_CDC
     usb_cdc_init();
     #endif
 
     #if MICROPY_VFS || MICROPY_MBFS || MICROPY_MODULE_FROZEN
-    // run boot.py and main.py if they exist.
-    ret = pyexec_file_if_exists("boot.py");
     if (pyexec_mode_kind == PYEXEC_MODE_FRIENDLY_REPL && ret != 0) {
         pyexec_file_if_exists("main.py");
     }

--- a/ports/rp2/main.c
+++ b/ports/rp2/main.c
@@ -38,7 +38,7 @@
 #include "shared/runtime/gchelper.h"
 #include "shared/runtime/pyexec.h"
 #include "shared/runtime/softtimer.h"
-#include "tusb.h"
+#include "shared/tinyusb/mp_usbd.h"
 #include "uart.h"
 #include "modmachine.h"
 #include "modrp2.h"
@@ -86,11 +86,8 @@ int main(int argc, char **argv) {
     #endif
     #endif
 
-    #if MICROPY_HW_ENABLE_USBDEV
-    #if MICROPY_HW_USB_CDC
+    #if MICROPY_HW_ENABLE_USBDEV && MICROPY_HW_USB_CDC
     bi_decl(bi_program_feature("USB REPL"))
-    #endif
-    tusb_init();
     #endif
 
     #if MICROPY_PY_THREAD
@@ -181,6 +178,11 @@ int main(int argc, char **argv) {
 
         // Execute user scripts.
         int ret = pyexec_file_if_exists("boot.py");
+
+        #if MICROPY_HW_ENABLE_USBDEV
+        mp_usbd_init();
+        #endif
+
         if (ret & PYEXEC_FORCED_EXIT) {
             goto soft_reset_exit;
         }

--- a/ports/samd/main.c
+++ b/ports/samd/main.c
@@ -33,6 +33,7 @@
 #include "shared/runtime/gchelper.h"
 #include "shared/runtime/pyexec.h"
 #include "shared/runtime/softtimer.h"
+#include "shared/tinyusb/mp_usbd.h"
 
 extern uint8_t _sstack, _estack, _sheap, _eheap;
 extern void adc_deinit_all(void);
@@ -56,6 +57,9 @@ void samd_main(void) {
 
         // Execute user scripts.
         int ret = pyexec_file_if_exists("boot.py");
+
+        mp_usbd_init();
+
         if (ret & PYEXEC_FORCED_EXIT) {
             goto soft_reset_exit;
         }

--- a/ports/samd/samd_soc.c
+++ b/ports/samd/samd_soc.c
@@ -62,8 +62,6 @@ static void usb_init(void) {
     PORT->Group[0].PMUX[12].reg = alt << 4 | alt;
     PORT->Group[0].PINCFG[24].reg = PORT_PINCFG_PMUXEN;
     PORT->Group[0].PINCFG[25].reg = PORT_PINCFG_PMUXEN;
-
-    tusb_init();
 }
 
 // Initialize the µs counter on TC 0/1 or TC4/5

--- a/shared/tinyusb/mp_usbd.h
+++ b/shared/tinyusb/mp_usbd.h
@@ -28,6 +28,13 @@
 #define MICROPY_INCLUDED_SHARED_TINYUSB_MP_USBD_H
 
 #include "py/obj.h"
+#include "tusb.h"
+
+static inline void mp_usbd_init(void) {
+    // Currently this is a thin wrapper around tusb_init(), however
+    // runtime USB support will require this to be extended.
+    tusb_init();
+}
 
 // Call this to explicitly run the TinyUSB device task.
 void mp_usbd_task(void);


### PR DESCRIPTION
This implements similar behaviour to the stm32 port.

Currently this doesn't add any useful functionality (and may break workflows that depend on USB-CDC being live in boot.py), however it's a precondition for more usable workflows with USB devices defined in Python (allows setting up USB interfaces in boot.py before the device enumerates for the first time).

#9497 is the PR for the eventual dynamic USB support on TinyUSB. Currently this is only implemented for samd & rp2, but changing it for all TinyUSB ports here maintains consistency and makes it easier to expand dynamic USB support to the other ports in the future.

## Breaking Changes

The documented advice for MicroPython is to put only early initialisation code into `boot.py` and the main application into `main.py`. For these cases it's unlikely this change will break anything. (Specifically: USB-CDC is not initialised and open during an early cold boot, so any output from a short-running `boot.py` after hard reset won't ever have been available on the USB-CDC port.)

However, the *de facto* situation for most of these ports is that `boot.py` and `main.py` were interchangeable until now. Any application that put all of its functionality into `boot.py` may find that it no longer works as expected.

## Testing

I only have hardware to test this on `rp2` and `samd`, so I haven't tested this on mimxrt, nrf or renesas-ra.

This work was funded through GitHub Sponsors.