### PR TITLE
extmod: Add new `vfs` module with mount/umount and Vfs classes.

### DIFF
--- a/docs/esp32/quickref.rst
+++ b/docs/esp32/quickref.rst
@@ -650,15 +650,15 @@ SD card
 
 See :ref:`machine.SDCard <machine.SDCard>`. ::
 
-    import machine, os
+    import machine, os, vfs
 
     # Slot 2 uses pins sck=18, cs=5, miso=19, mosi=23
     sd = machine.SDCard(slot=2)
-    os.mount(sd, '/sd')  # mount
+    vfs.mount(sd, '/sd') # mount
 
     os.listdir('/sd')    # list directory contents
 
-    os.umount('/sd')     # eject
+    vfs.umount('/sd')    # eject
 
 RMT
 ---

--- a/docs/library/esp32.rst
+++ b/docs/library/esp32.rst
@@ -114,7 +114,7 @@ methods to enable over-the-air (OTA) updates.
 
     These methods implement the simple and :ref:`extended
     <block-device-interface>` block protocol defined by
-    :class:`os.AbstractBlockDev`.
+    :class:`vfs.AbstractBlockDev`.
 
 .. method:: Partition.set_boot()
 

--- a/docs/library/index.rst
+++ b/docs/library/index.rst
@@ -104,6 +104,7 @@ the following libraries.
    neopixel.rst
    network.rst
    uctypes.rst
+   vfs.rst
 
 The following libraries provide drivers for hardware components.
 

--- a/docs/library/machine.SD.rst
+++ b/docs/library/machine.SD.rst
@@ -20,11 +20,11 @@ more info regarding the pins which can be remapped to be used with a SD card.
 Example usage::
 
     from machine import SD
-    import os
+    import vfs
     # clk cmd and dat0 pins must be passed along with
     # their respective alternate functions
     sd = machine.SD(pins=('GP10', 'GP11', 'GP15'))
-    os.mount(sd, '/sd')
+    vfs.mount(sd, '/sd')
     # do normal file operations
 
 Constructors

--- a/docs/library/machine.SDCard.rst
+++ b/docs/library/machine.SDCard.rst
@@ -27,7 +27,7 @@ vary from platform to platform.
 
     This class provides access to SD or MMC storage cards using either
     a dedicated SD/MMC interface hardware or through an SPI channel.
-    The class implements the block protocol defined by :class:`os.AbstractBlockDev`.
+    The class implements the block protocol defined by :class:`vfs.AbstractBlockDev`.
     This allows the mounting of an SD card to be as simple as::
 
       os.mount(machine.SDCard(), "/sd")

--- a/docs/library/machine.SDCard.rst
+++ b/docs/library/machine.SDCard.rst
@@ -30,7 +30,7 @@ vary from platform to platform.
     The class implements the block protocol defined by :class:`vfs.AbstractBlockDev`.
     This allows the mounting of an SD card to be as simple as::
 
-      os.mount(machine.SDCard(), "/sd")
+      vfs.mount(machine.SDCard(), "/sd")
 
     The constructor takes the following parameters:
 

--- a/docs/library/os.rst
+++ b/docs/library/os.rst
@@ -136,192 +136,30 @@ Terminal redirection and duplication
 Filesystem mounting
 -------------------
 
-Some ports provide a Virtual Filesystem (VFS) and the ability to mount multiple
-"real" filesystems within this VFS.  Filesystem objects can be mounted at either
-the root of the VFS, or at a subdirectory that lives in the root.  This allows
-dynamic and flexible configuration of the filesystem that is seen by Python
-programs.  Ports that have this functionality provide the :func:`mount` and
-:func:`umount` functions, and possibly various filesystem implementations
-represented by VFS classes.
+The following functions and classes have been moved to the :mod:`vfs` module.
+They are provided in this module only for backwards compatibility and will be
+removed in version 2 of MicroPython.
 
 .. function:: mount(fsobj, mount_point, *, readonly)
 
-    Mount the filesystem object *fsobj* at the location in the VFS given by the
-    *mount_point* string.  *fsobj* can be a a VFS object that has a ``mount()``
-    method, or a block device.  If it's a block device then the filesystem type
-    is automatically detected (an exception is raised if no filesystem was
-    recognised).  *mount_point* may be ``'/'`` to mount *fsobj* at the root,
-    or ``'/<name>'`` to mount it at a subdirectory under the root.
-
-    If *readonly* is ``True`` then the filesystem is mounted read-only.
-
-    During the mount process the method ``mount()`` is called on the filesystem
-    object.
-
-    Will raise ``OSError(EPERM)`` if *mount_point* is already mounted.
+    See `vfs.mount`.
 
 .. function:: umount(mount_point)
 
-    Unmount a filesystem. *mount_point* can be a string naming the mount location,
-    or a previously-mounted filesystem object.  During the unmount process the
-    method ``umount()`` is called on the filesystem object.
-
-    Will raise ``OSError(EINVAL)`` if *mount_point* is not found.
+    See `vfs.umount`.
 
 .. class:: VfsFat(block_dev)
 
-    Create a filesystem object that uses the FAT filesystem format.  Storage of
-    the FAT filesystem is provided by *block_dev*.
-    Objects created by this constructor can be mounted using :func:`mount`.
-
-    .. staticmethod:: mkfs(block_dev)
-
-        Build a FAT filesystem on *block_dev*.
+    See `vfs.VfsFat`.
 
 .. class:: VfsLfs1(block_dev, readsize=32, progsize=32, lookahead=32)
 
-    Create a filesystem object that uses the `littlefs v1 filesystem format`_.
-    Storage of the littlefs filesystem is provided by *block_dev*, which must
-    support the :ref:`extended interface <block-device-interface>`.
-    Objects created by this constructor can be mounted using :func:`mount`.
-
-    See :ref:`filesystem` for more information.
-
-    .. staticmethod:: mkfs(block_dev, readsize=32, progsize=32, lookahead=32)
-
-        Build a Lfs1 filesystem on *block_dev*.
-
-    .. note:: There are reports of littlefs v1 failing in certain situations,
-              for details see `littlefs issue 347`_.
+    See `vfs.VfsLfs1`.
 
 .. class:: VfsLfs2(block_dev, readsize=32, progsize=32, lookahead=32, mtime=True)
 
-    Create a filesystem object that uses the `littlefs v2 filesystem format`_.
-    Storage of the littlefs filesystem is provided by *block_dev*, which must
-    support the :ref:`extended interface <block-device-interface>`.
-    Objects created by this constructor can be mounted using :func:`mount`.
+    See `vfs.VfsLfs2`.
 
-    The *mtime* argument enables modification timestamps for files, stored using
-    littlefs attributes.  This option can be disabled or enabled differently each
-    mount time and timestamps will only be added or updated if *mtime* is enabled,
-    otherwise the timestamps will remain untouched.  Littlefs v2 filesystems without
-    timestamps will work without reformatting and timestamps will be added
-    transparently to existing files once they are opened for writing.  When *mtime*
-    is enabled `os.stat` on files without timestamps will return 0 for the timestamp.
+.. class:: VfsPosix(root=None)
 
-    See :ref:`filesystem` for more information.
-
-    .. staticmethod:: mkfs(block_dev, readsize=32, progsize=32, lookahead=32)
-
-        Build a Lfs2 filesystem on *block_dev*.
-
-    .. note:: There are reports of littlefs v2 failing in certain situations,
-              for details see `littlefs issue 295`_.
-
-.. _littlefs v1 filesystem format: https://github.com/ARMmbed/littlefs/tree/v1
-.. _littlefs v2 filesystem format: https://github.com/ARMmbed/littlefs
-.. _littlefs issue 295: https://github.com/ARMmbed/littlefs/issues/295
-.. _littlefs issue 347: https://github.com/ARMmbed/littlefs/issues/347
-
-Block devices
--------------
-
-A block device is an object which implements the block protocol. This enables a
-device to support MicroPython filesystems. The physical hardware is represented
-by a user defined class. The :class:`AbstractBlockDev` class is a template for
-the design of such a class: MicroPython does not actually provide that class,
-but an actual block device class must implement the methods described below.
-
-A concrete implementation of this class will usually allow access to the
-memory-like functionality of a piece of hardware (like flash memory). A block
-device can be formatted to any supported filesystem and mounted using ``os``
-methods.
-
-See :ref:`filesystem` for example implementations of block devices using the
-two variants of the block protocol described below.
-
-.. _block-device-interface:
-
-Simple and extended interface
-.............................
-
-There are two compatible signatures for the ``readblocks`` and ``writeblocks``
-methods (see below), in order to support a variety of use cases.  A given block
-device may implement one form or the other, or both at the same time. The second
-form (with the offset parameter) is referred to as the "extended interface".
-
-Some filesystems (such as littlefs) that require more control over write
-operations, for example writing to sub-block regions without erasing, may require
-that the block device supports the extended interface.
-
-.. class:: AbstractBlockDev(...)
-
-    Construct a block device object.  The parameters to the constructor are
-    dependent on the specific block device.
-
-    .. method:: readblocks(block_num, buf)
-                readblocks(block_num, buf, offset)
-
-        The first form reads aligned, multiples of blocks.
-        Starting at the block given by the index *block_num*, read blocks from
-        the device into *buf* (an array of bytes).
-        The number of blocks to read is given by the length of *buf*,
-        which will be a multiple of the block size.
-
-        The second form allows reading at arbitrary locations within a block,
-        and arbitrary lengths.
-        Starting at block index *block_num*, and byte offset within that block
-        of *offset*, read bytes from the device into *buf* (an array of bytes).
-        The number of bytes to read is given by the length of *buf*.
-
-    .. method:: writeblocks(block_num, buf)
-                writeblocks(block_num, buf, offset)
-
-        The first form writes aligned, multiples of blocks, and requires that the
-        blocks that are written to be first erased (if necessary) by this method.
-        Starting at the block given by the index *block_num*, write blocks from
-        *buf* (an array of bytes) to the device.
-        The number of blocks to write is given by the length of *buf*,
-        which will be a multiple of the block size.
-
-        The second form allows writing at arbitrary locations within a block,
-        and arbitrary lengths.  Only the bytes being written should be changed,
-        and the caller of this method must ensure that the relevant blocks are
-        erased via a prior ``ioctl`` call.
-        Starting at block index *block_num*, and byte offset within that block
-        of *offset*, write bytes from *buf* (an array of bytes) to the device.
-        The number of bytes to write is given by the length of *buf*.
-
-        Note that implementations must never implicitly erase blocks if the offset
-        argument is specified, even if it is zero.
-
-    .. method:: ioctl(op, arg)
-
-        Control the block device and query its parameters.  The operation to
-        perform is given by *op* which is one of the following integers:
-
-          - 1 -- initialise the device (*arg* is unused)
-          - 2 -- shutdown the device (*arg* is unused)
-          - 3 -- sync the device (*arg* is unused)
-          - 4 -- get a count of the number of blocks, should return an integer
-            (*arg* is unused)
-          - 5 -- get the number of bytes in a block, should return an integer,
-            or ``None`` in which case the default value of 512 is used
-            (*arg* is unused)
-          - 6 -- erase a block, *arg* is the block number to erase
-
-       As a minimum ``ioctl(4, ...)`` must be intercepted; for littlefs
-       ``ioctl(6, ...)`` must also be intercepted. The need for others is
-       hardware dependent.
-
-       Prior to any call to ``writeblocks(block, ...)`` littlefs issues
-       ``ioctl(6, block)``. This enables a device driver to erase the block
-       prior to a write if the hardware requires it. Alternatively a driver
-       might intercept ``ioctl(6, block)`` and return 0 (success). In this case
-       the driver assumes responsibility for detecting the need for erasure.
-
-       Unless otherwise stated ``ioctl(op, arg)`` can return ``None``.
-       Consequently an implementation can ignore unused values of ``op``. Where
-       ``op`` is intercepted, the return value for operations 4 and 5 are as
-       detailed above. Other operations should return 0 on success and non-zero
-       for failure, with the value returned being an ``OSError`` errno code.
+    See `vfs.VfsPosix`.

--- a/docs/library/pyb.Flash.rst
+++ b/docs/library/pyb.Flash.rst
@@ -43,7 +43,7 @@ Methods
 
     These methods implement the simple and :ref:`extended
     <block-device-interface>` block protocol defined by
-    :class:`os.AbstractBlockDev`.
+    :class:`vfs.AbstractBlockDev`.
 
 Hardware Note
 -------------

--- a/docs/library/pyb.rst
+++ b/docs/library/pyb.rst
@@ -213,7 +213,7 @@ Miscellaneous functions
 .. function:: mount(device, mountpoint, *, readonly=False, mkfs=False)
 
    .. note:: This function is deprecated. Mounting and unmounting devices should
-      be performed by :meth:`os.mount` and :meth:`os.umount` instead.
+      be performed by :meth:`vfs.mount` and :meth:`vfs.umount` instead.
 
    Mount a block device and make it available as part of the filesystem.
    ``device`` must be an object that provides the block protocol. (The

--- a/docs/library/pyb.rst
+++ b/docs/library/pyb.rst
@@ -217,7 +217,7 @@ Miscellaneous functions
 
    Mount a block device and make it available as part of the filesystem.
    ``device`` must be an object that provides the block protocol. (The
-   following is also deprecated. See :class:`os.AbstractBlockDev` for the
+   following is also deprecated. See :class:`vfs.AbstractBlockDev` for the
    correct way to create a block device.)
 
     - ``readblocks(self, blocknum, buf)``

--- a/docs/library/rp2.Flash.rst
+++ b/docs/library/rp2.Flash.rst
@@ -32,5 +32,5 @@ Methods
 
     These methods implement the simple and extended
     :ref:`block protocol <block-device-interface>` defined by
-    :class:`os.AbstractBlockDev`.
+    :class:`vfs.AbstractBlockDev`.
 

--- a/docs/library/vfs.rst
+++ b/docs/library/vfs.rst
@@ -1,0 +1,208 @@
+:mod:`vfs` -- virtual filesystem control
+========================================
+
+.. module:: vfs
+   :synopsis: virtual filesystem control
+
+The ``vfs`` module contains functions for creating filesystem objects and
+mounting/unmounting them in the Virtual Filesystem.
+
+Filesystem mounting
+-------------------
+
+Some ports provide a Virtual Filesystem (VFS) and the ability to mount multiple
+"real" filesystems within this VFS.  Filesystem objects can be mounted at either
+the root of the VFS, or at a subdirectory that lives in the root.  This allows
+dynamic and flexible configuration of the filesystem that is seen by Python
+programs.  Ports that have this functionality provide the :func:`mount` and
+:func:`umount` functions, and possibly various filesystem implementations
+represented by VFS classes.
+
+.. function:: mount(fsobj, mount_point, *, readonly)
+
+    Mount the filesystem object *fsobj* at the location in the VFS given by the
+    *mount_point* string.  *fsobj* can be a a VFS object that has a ``mount()``
+    method, or a block device.  If it's a block device then the filesystem type
+    is automatically detected (an exception is raised if no filesystem was
+    recognised).  *mount_point* may be ``'/'`` to mount *fsobj* at the root,
+    or ``'/<name>'`` to mount it at a subdirectory under the root.
+
+    If *readonly* is ``True`` then the filesystem is mounted read-only.
+
+    During the mount process the method ``mount()`` is called on the filesystem
+    object.
+
+    Will raise ``OSError(EPERM)`` if *mount_point* is already mounted.
+
+.. function:: umount(mount_point)
+
+    Unmount a filesystem. *mount_point* can be a string naming the mount location,
+    or a previously-mounted filesystem object.  During the unmount process the
+    method ``umount()`` is called on the filesystem object.
+
+    Will raise ``OSError(EINVAL)`` if *mount_point* is not found.
+
+.. class:: VfsFat(block_dev)
+
+    Create a filesystem object that uses the FAT filesystem format.  Storage of
+    the FAT filesystem is provided by *block_dev*.
+    Objects created by this constructor can be mounted using :func:`mount`.
+
+    .. staticmethod:: mkfs(block_dev)
+
+        Build a FAT filesystem on *block_dev*.
+
+.. class:: VfsLfs1(block_dev, readsize=32, progsize=32, lookahead=32)
+
+    Create a filesystem object that uses the `littlefs v1 filesystem format`_.
+    Storage of the littlefs filesystem is provided by *block_dev*, which must
+    support the :ref:`extended interface <block-device-interface>`.
+    Objects created by this constructor can be mounted using :func:`mount`.
+
+    See :ref:`filesystem` for more information.
+
+    .. staticmethod:: mkfs(block_dev, readsize=32, progsize=32, lookahead=32)
+
+        Build a Lfs1 filesystem on *block_dev*.
+
+    .. note:: There are reports of littlefs v1 failing in certain situations,
+              for details see `littlefs issue 347`_.
+
+.. class:: VfsLfs2(block_dev, readsize=32, progsize=32, lookahead=32, mtime=True)
+
+    Create a filesystem object that uses the `littlefs v2 filesystem format`_.
+    Storage of the littlefs filesystem is provided by *block_dev*, which must
+    support the :ref:`extended interface <block-device-interface>`.
+    Objects created by this constructor can be mounted using :func:`mount`.
+
+    The *mtime* argument enables modification timestamps for files, stored using
+    littlefs attributes.  This option can be disabled or enabled differently each
+    mount time and timestamps will only be added or updated if *mtime* is enabled,
+    otherwise the timestamps will remain untouched.  Littlefs v2 filesystems without
+    timestamps will work without reformatting and timestamps will be added
+    transparently to existing files once they are opened for writing.  When *mtime*
+    is enabled `os.stat` on files without timestamps will return 0 for the timestamp.
+
+    See :ref:`filesystem` for more information.
+
+    .. staticmethod:: mkfs(block_dev, readsize=32, progsize=32, lookahead=32)
+
+        Build a Lfs2 filesystem on *block_dev*.
+
+    .. note:: There are reports of littlefs v2 failing in certain situations,
+              for details see `littlefs issue 295`_.
+
+.. class:: VfsPosix(root=None)
+
+    Create a filesystem object that accesses the host POSIX filesystem.
+    If *root* is specified then it should be a path in the host filesystem to use
+    as the root of the ``VfsPosix`` object.  Otherwise the current directory of
+    the host filesystem is used.
+
+.. _littlefs v1 filesystem format: https://github.com/ARMmbed/littlefs/tree/v1
+.. _littlefs v2 filesystem format: https://github.com/ARMmbed/littlefs
+.. _littlefs issue 295: https://github.com/ARMmbed/littlefs/issues/295
+.. _littlefs issue 347: https://github.com/ARMmbed/littlefs/issues/347
+
+Block devices
+-------------
+
+A block device is an object which implements the block protocol. This enables a
+device to support MicroPython filesystems. The physical hardware is represented
+by a user defined class. The :class:`AbstractBlockDev` class is a template for
+the design of such a class: MicroPython does not actually provide that class,
+but an actual block device class must implement the methods described below.
+
+A concrete implementation of this class will usually allow access to the
+memory-like functionality of a piece of hardware (like flash memory). A block
+device can be formatted to any supported filesystem and mounted using ``os``
+methods.
+
+See :ref:`filesystem` for example implementations of block devices using the
+two variants of the block protocol described below.
+
+.. _block-device-interface:
+
+Simple and extended interface
+.............................
+
+There are two compatible signatures for the ``readblocks`` and ``writeblocks``
+methods (see below), in order to support a variety of use cases.  A given block
+device may implement one form or the other, or both at the same time. The second
+form (with the offset parameter) is referred to as the "extended interface".
+
+Some filesystems (such as littlefs) that require more control over write
+operations, for example writing to sub-block regions without erasing, may require
+that the block device supports the extended interface.
+
+.. class:: AbstractBlockDev(...)
+
+    Construct a block device object.  The parameters to the constructor are
+    dependent on the specific block device.
+
+    .. method:: readblocks(block_num, buf)
+                readblocks(block_num, buf, offset)
+
+        The first form reads aligned, multiples of blocks.
+        Starting at the block given by the index *block_num*, read blocks from
+        the device into *buf* (an array of bytes).
+        The number of blocks to read is given by the length of *buf*,
+        which will be a multiple of the block size.
+
+        The second form allows reading at arbitrary locations within a block,
+        and arbitrary lengths.
+        Starting at block index *block_num*, and byte offset within that block
+        of *offset*, read bytes from the device into *buf* (an array of bytes).
+        The number of bytes to read is given by the length of *buf*.
+
+    .. method:: writeblocks(block_num, buf)
+                writeblocks(block_num, buf, offset)
+
+        The first form writes aligned, multiples of blocks, and requires that the
+        blocks that are written to be first erased (if necessary) by this method.
+        Starting at the block given by the index *block_num*, write blocks from
+        *buf* (an array of bytes) to the device.
+        The number of blocks to write is given by the length of *buf*,
+        which will be a multiple of the block size.
+
+        The second form allows writing at arbitrary locations within a block,
+        and arbitrary lengths.  Only the bytes being written should be changed,
+        and the caller of this method must ensure that the relevant blocks are
+        erased via a prior ``ioctl`` call.
+        Starting at block index *block_num*, and byte offset within that block
+        of *offset*, write bytes from *buf* (an array of bytes) to the device.
+        The number of bytes to write is given by the length of *buf*.
+
+        Note that implementations must never implicitly erase blocks if the offset
+        argument is specified, even if it is zero.
+
+    .. method:: ioctl(op, arg)
+
+        Control the block device and query its parameters.  The operation to
+        perform is given by *op* which is one of the following integers:
+
+          - 1 -- initialise the device (*arg* is unused)
+          - 2 -- shutdown the device (*arg* is unused)
+          - 3 -- sync the device (*arg* is unused)
+          - 4 -- get a count of the number of blocks, should return an integer
+            (*arg* is unused)
+          - 5 -- get the number of bytes in a block, should return an integer,
+            or ``None`` in which case the default value of 512 is used
+            (*arg* is unused)
+          - 6 -- erase a block, *arg* is the block number to erase
+
+       As a minimum ``ioctl(4, ...)`` must be intercepted; for littlefs
+       ``ioctl(6, ...)`` must also be intercepted. The need for others is
+       hardware dependent.
+
+       Prior to any call to ``writeblocks(block, ...)`` littlefs issues
+       ``ioctl(6, block)``. This enables a device driver to erase the block
+       prior to a write if the hardware requires it. Alternatively a driver
+       might intercept ``ioctl(6, block)`` and return 0 (success). In this case
+       the driver assumes responsibility for detecting the need for erasure.
+
+       Unless otherwise stated ``ioctl(op, arg)`` can return ``None``.
+       Consequently an implementation can ignore unused values of ``op``. Where
+       ``op`` is intercepted, the return value for operations 4 and 5 are as
+       detailed above. Other operations should return 0 on success and non-zero
+       for failure, with the value returned being an ``OSError`` errno code.

--- a/docs/library/zephyr.DiskAccess.rst
+++ b/docs/library/zephyr.DiskAccess.rst
@@ -34,5 +34,5 @@ Methods
 
     These methods implement the simple and extended
     :ref:`block protocol <block-device-interface>` defined by
-    :class:`os.AbstractBlockDev`.
+    :class:`vfs.AbstractBlockDev`.
 

--- a/docs/library/zephyr.FlashArea.rst
+++ b/docs/library/zephyr.FlashArea.rst
@@ -37,4 +37,4 @@ Methods
 
     These methods implement the simple and extended
     :ref:`block protocol <block-device-interface>` defined by
-    :class:`os.AbstractBlockDev`.
+    :class:`vfs.AbstractBlockDev`.

--- a/docs/mimxrt/quickref.rst
+++ b/docs/mimxrt/quickref.rst
@@ -443,27 +443,27 @@ SD card
 
 See :ref:`machine.SDCard <machine.SDCard>`::
 
-    import machine, os
+    import machine, os, vfs
 
     sd = machine.SDCard()
-    fs = os.VfsFat(sd)
-    os.mount(fs, "/sd")  # mount
+    fs = vfs.VfsFat(sd)
+    vfs.mount(fs, "/sd") # mount
     os.listdir('/sd')    # list directory contents
-    os.umount('/sd')     # eject
+    vfs.umount('/sd')    # eject
 
 Note: The i.mx-rt 1011 and 1015 based boards do not support the ``machine.SDCard``
 class.  For these, the SPI based driver ``sdcard.py`` from the MicroPython drivers
 can be used.  When using it, you have to overdrive the CS pin of the SPI hardware
 module.  Example::
 
-    import os, sdcard, machine
+    import vfs, sdcard, machine
 
     cs_pin = "D10"
     spi = machine.SPI(0) # SPI0 with cs at Pin "D10" used for SDCARD
     cs = machine.Pin(cs_pin, machine.Pin.OUT, value=1)
     sd = sdcard.SDCard(spi, cs)
-    vfs = os.VfsFat(sd)
-    os.mount(vfs, "/sdcard")
+    fs = vfs.VfsFat(sd)
+    vfs.mount(fs, "/sdcard")
 
 OneWire driver
 --------------

--- a/docs/pyboard/general.rst
+++ b/docs/pyboard/general.rst
@@ -21,7 +21,7 @@ If needed, you can prevent the use of the SD card by creating an empty file
 called ``/flash/SKIPSD``.  If this file exists when the pyboard boots
 up then the SD card will be skipped and the pyboard will always boot from the
 internal filesystem (in this case the SD card won't be mounted but you can still
-mount and use it later in your program using ``os.mount``).
+mount and use it later in your program using ``vfs.mount``).
 
 (Note that on older versions of the board, ``/flash`` is called ``0:/`` and ``/sd``
 is called ``1:/``).

--- a/docs/reference/filesystem.rst
+++ b/docs/reference/filesystem.rst
@@ -40,7 +40,7 @@ Block devices
 -------------
 
 A block device is an instance of a class that implements the
-:class:`os.AbstractBlockDev` protocol.
+:class:`vfs.AbstractBlockDev` protocol.
 
 Built-in block devices
 ~~~~~~~~~~~~~~~~~~~~~~
@@ -116,8 +116,8 @@ It can be used as follows::
 
 An example of a block device that supports both the simple and extended
 interface (i.e. both signatures and behaviours of the
-:meth:`os.AbstractBlockDev.readblocks` and
-:meth:`os.AbstractBlockDev.writeblocks` methods) is::
+:meth:`vfs.AbstractBlockDev.readblocks` and
+:meth:`vfs.AbstractBlockDev.writeblocks` methods) is::
 
     class RAMBlockDev:
         def __init__(self, block_size, num_blocks):
@@ -148,7 +148,7 @@ interface (i.e. both signatures and behaviours of the
                 return 0
 
 As it supports the extended interface, it can be used with :class:`littlefs
-<os.VfsLfs2>`::
+<vfs.VfsLfs2>`::
 
     import os
 
@@ -166,8 +166,8 @@ normally would be used from Python code, for example::
 Filesystems
 -----------
 
-MicroPython ports can provide implementations of :class:`FAT <os.VfsFat>`,
-:class:`littlefs v1 <os.VfsLfs1>` and :class:`littlefs v2 <os.VfsLfs2>`.
+MicroPython ports can provide implementations of :class:`FAT <vfs.VfsFat>`,
+:class:`littlefs v1 <vfs.VfsLfs1>` and :class:`littlefs v2 <vfs.VfsLfs2>`.
 
 The following table shows which filesystems are included in the firmware by
 default for given port/board combinations, however they can be optionally

--- a/docs/reference/filesystem.rst
+++ b/docs/reference/filesystem.rst
@@ -108,11 +108,11 @@ RAM using a ``bytearray``::
 
 It can be used as follows::
 
-    import os
+    import vfs
 
     bdev = RAMBlockDev(512, 50)
-    os.VfsFat.mkfs(bdev)
-    os.mount(bdev, '/ramdisk')
+    vfs.VfsFat.mkfs(bdev)
+    vfs.mount(bdev, '/ramdisk')
 
 An example of a block device that supports both the simple and extended
 interface (i.e. both signatures and behaviours of the
@@ -150,11 +150,11 @@ interface (i.e. both signatures and behaviours of the
 As it supports the extended interface, it can be used with :class:`littlefs
 <vfs.VfsLfs2>`::
 
-    import os
+    import vfs
 
     bdev = RAMBlockDev(512, 50)
-    os.VfsLfs2.mkfs(bdev)
-    os.mount(bdev, '/ramdisk')
+    vfs.VfsLfs2.mkfs(bdev)
+    vfs.mount(bdev, '/ramdisk')
 
 Once mounted, the filesystem (regardless of its type) can be used as it
 normally would be used from Python code, for example::
@@ -197,16 +197,16 @@ recommended to use littlefs instead.
 To format the entire flash using FAT::
 
     # ESP8266 and ESP32
-    import os
-    os.umount('/')
-    os.VfsFat.mkfs(bdev)
-    os.mount(bdev, '/')
+    import vfs
+    vfs.umount('/')
+    vfs.VfsFat.mkfs(bdev)
+    vfs.mount(bdev, '/')
 
     # STM32
-    import os, pyb
-    os.umount('/flash')
-    os.VfsFat.mkfs(pyb.Flash(start=0))
-    os.mount(pyb.Flash(start=0), '/flash')
+    import os, vfs, pyb
+    vfs.umount('/flash')
+    vfs.VfsFat.mkfs(pyb.Flash(start=0))
+    vfs.mount(pyb.Flash(start=0), '/flash')
     os.chdir('/flash')
 
 Littlefs
@@ -222,16 +222,16 @@ resistant to filesystem corruption.
 To format the entire flash using littlefs v2::
 
     # ESP8266 and ESP32
-    import os
-    os.umount('/')
-    os.VfsLfs2.mkfs(bdev)
-    os.mount(bdev, '/')
+    import vfs
+    vfs.umount('/')
+    vfs.VfsLfs2.mkfs(bdev)
+    vfs.mount(bdev, '/')
 
     # STM32
-    import os, pyb
-    os.umount('/flash')
-    os.VfsLfs2.mkfs(pyb.Flash(start=0))
-    os.mount(pyb.Flash(start=0), '/flash')
+    import os, vfs, pyb
+    vfs.umount('/flash')
+    vfs.VfsLfs2.mkfs(pyb.Flash(start=0))
+    vfs.mount(pyb.Flash(start=0), '/flash')
     os.chdir('/flash')
 
 A littlefs filesystem can be still be accessed on a PC over USB MSC using the
@@ -264,14 +264,14 @@ block devices spanning a subset of the flash device.
 For example, to configure the first 256kiB as FAT (and available over USB MSC),
 and the remainder as littlefs::
 
-    import os, pyb
-    os.umount('/flash')
+    import os, vfs, pyb
+    vfs.umount('/flash')
     p1 = pyb.Flash(start=0, len=256*1024)
     p2 = pyb.Flash(start=256*1024)
-    os.VfsFat.mkfs(p1)
-    os.VfsLfs2.mkfs(p2)
-    os.mount(p1, '/flash')
-    os.mount(p2, '/data')
+    vfs.VfsFat.mkfs(p1)
+    vfs.VfsLfs2.mkfs(p2)
+    vfs.mount(p1, '/flash')
+    vfs.mount(p2, '/data')
     os.chdir('/flash')
 
 This might be useful to make your Python files, configuration and other
@@ -282,9 +282,9 @@ failure, etc.
 The partition at offset ``0`` will be mounted automatically (and the filesystem
 type automatically detected), but you can add::
 
-    import os, pyb
+    import vfs, pyb
     p2 = pyb.Flash(start=256*1024)
-    os.mount(p2, '/data')
+    vfs.mount(p2, '/data')
 
 to ``boot.py`` to mount the data partition.
 
@@ -297,7 +297,7 @@ define an arbitrary partition layout.
 At boot, the partition named "vfs" will be mounted at ``/`` by default, but any
 additional partitions can be mounted in your ``boot.py`` using::
 
-    import esp32, os
+    import esp32, vfs
     p = esp32.Partition.find(esp32.Partition.TYPE_DATA, label='foo')
-    os.mount(p, '/foo')
+    vfs.mount(p, '/foo')
 

--- a/docs/reference/micropython2_migration.rst
+++ b/docs/reference/micropython2_migration.rst
@@ -71,4 +71,11 @@ which is useful for development and testing.
 Changes
 ~~~~~~~
 
-*None yet*
+Introduction of a new module :mod:`vfs`.  The following functions and
+classes have moved out of :mod:`os` to :mod:`vfs`:
+- `os.mount`
+- `os.umount`
+- `os.VfsFat`
+- `os.VfsLfs1`
+- `os.VfsLfs2`
+- `os.VfsPosix`

--- a/docs/renesas-ra/quickref.rst
+++ b/docs/renesas-ra/quickref.rst
@@ -387,15 +387,15 @@ SDCard
 The frozen sdcard driver (drivers/sdcard/sdcard.py) is available by connecting microSD card device to hardware SPI0 pins.::
 
     from machine import Pin, SPI
-    import os, sdcard
+    import os, vfs, sdcard
 
     spi = SPI(0, baudrate=500000)
     cs = Pin.cpu.P103
     sd = sdcard.SDCard(spi, cs)
-    os.mount(sd, '/sd')
+    vfs.mount(sd, '/sd')
     os.listdir('/')
     os.chdir('/sd')
-    os.umount('/sd')
+    vfs.umount('/sd')
 
 OneWire driver
 --------------

--- a/docs/wipy/general.rst
+++ b/docs/wipy/general.rst
@@ -373,7 +373,7 @@ functions are defined in ``os`` module:
    Mounts a block device (like an ``SD`` object) in the specified mount
    point. Example::
 
-      os.mount(sd, '/sd')
+      vfs.mount(sd, '/sd')
 
 .. function:: unmount(path)
 

--- a/docs/wipy/quickref.rst
+++ b/docs/wipy/quickref.rst
@@ -171,13 +171,13 @@ SD card
 See :ref:`machine.SD <machine.SD>`. ::
 
     from machine import SD
-    import os
+    import vfs
 
     # clock pin, cmd pin, data0 pin
     sd = SD(pins=('GP10', 'GP11', 'GP15'))
     # or use default ones for the expansion board
     sd = SD()
-    os.mount(sd, '/sd')
+    vfs.mount(sd, '/sd')
 
 WLAN (WiFi)
 -----------

--- a/docs/zephyr/quickref.rst
+++ b/docs/zephyr/quickref.rst
@@ -109,12 +109,12 @@ Disk Access
 
 Use the :ref:`zephyr.DiskAccess <zephyr.DiskAccess>` class to support filesystem::
 
-    import os
+    import vfs
     from zephyr import DiskAccess
 
     block_dev = DiskAccess('SDHC')      # create a block device object for an SD card
-    os.VfsFat.mkfs(block_dev)           # create FAT filesystem object using the disk storage block
-    os.mount(block_dev, '/sd')          # mount the filesystem at the SD card subdirectory
+    vfs.VfsFat.mkfs(block_dev)          # create FAT filesystem object using the disk storage block
+    vfs.mount(block_dev, '/sd')         # mount the filesystem at the SD card subdirectory
 
     # with the filesystem mounted, files can be manipulated as normal
     with open('/sd/hello.txt','w') as f:     # open a new file in the directory
@@ -126,12 +126,12 @@ Flash Area
 
 Use the :ref:`zephyr.FlashArea <zephyr.FlashArea>` class to support filesystem::
 
-    import os
+    import vfs
     from zephyr import FlashArea
 
     block_dev = FlashArea(4, 4096)      # creates a block device object in the frdm-k64f flash scratch partition
-    os.VfsLfs2.mkfs(block_dev)          # create filesystem in lfs2 format using the flash block device
-    os.mount(block_dev, '/flash')       # mount the filesystem at the flash subdirectory
+    vfs.VfsLfs2.mkfs(block_dev)         # create filesystem in lfs2 format using the flash block device
+    vfs.mount(block_dev, '/flash')      # mount the filesystem at the flash subdirectory
 
     # with the filesystem mounted, files can be manipulated as normal
     with open('/flash/hello.txt','w') as f:     # open a new file in the directory

--- a/docs/zephyr/tutorial/storage.rst
+++ b/docs/zephyr/tutorial/storage.rst
@@ -6,14 +6,14 @@ Filesystems and Storage
 Storage modules support virtual filesystem with FAT and littlefs formats, backed by either
 Zephyr DiskAccess or FlashArea (flash map) APIs depending on which the board supports.
 
-See `os Filesystem Mounting <https://docs.micropython.org/en/latest/library/os.html?highlight=os#filesystem-mounting>`_.
+See `vfs Filesystem Mounting <https://docs.micropython.org/en/latest/library/vfs.html?highlight=vfs#filesystem-mounting>`_.
 
 Disk Access
 -----------
 
 The :ref:`zephyr.DiskAccess <zephyr.DiskAccess>` class can be used to access storage devices, such as SD cards.
 This class uses `Zephyr Disk Access API <https://docs.zephyrproject.org/latest/reference/storage/disk/access.html>`_ and
-implements the `os.AbstractBlockDev` protocol.
+implements the `vfs.AbstractBlockDev` protocol.
 
 For use with SD card controllers, SD cards must be present at boot & not removed; they will
 be auto detected and initialized by filesystem at boot. Use the disk driver interface and a
@@ -39,7 +39,7 @@ customize filesystem configurations. To store persistent data on the device, usi
 API is recommended (see below).
 
 This class uses `Zephyr Flash map API <https://docs.zephyrproject.org/latest/reference/storage/flash_map/flash_map.html#>`_ and
-implements the `os.AbstractBlockDev` protocol.
+implements the `vfs.AbstractBlockDev` protocol.
 
 Example usage with the internal flash on the reel_board or the rv32m1_vega_ri5cy board::
 

--- a/docs/zephyr/tutorial/storage.rst
+++ b/docs/zephyr/tutorial/storage.rst
@@ -21,11 +21,11 @@ file system to access SD cards via disk access (see below).
 
 Example usage of FatFS with an SD card on the mimxrt1050_evk board::
 
-    import os
+    import vfs
     from zephyr import DiskAccess
     bdev = zephyr.DiskAccess('SDHC')        # create block device object using DiskAccess
-    os.VfsFat.mkfs(bdev)                    # create FAT filesystem object using the disk storage block
-    os.mount(bdev, '/sd')                   # mount the filesystem at the SD card subdirectory
+    vfs.VfsFat.mkfs(bdev)                   # create FAT filesystem object using the disk storage block
+    vfs.mount(bdev, '/sd')                  # mount the filesystem at the SD card subdirectory
     with open('/sd/hello.txt','w') as f:    # open a new file in the directory
         f.write('Hello world')              # write to the file
     print(open('/sd/hello.txt').read())     # print contents of the file
@@ -43,11 +43,11 @@ implements the `vfs.AbstractBlockDev` protocol.
 
 Example usage with the internal flash on the reel_board or the rv32m1_vega_ri5cy board::
 
-    import os
+    import vfs
     from zephyr import FlashArea
     bdev = FlashArea(FlashArea.STORAGE, 4096)   # create block device object using FlashArea
-    os.VfsLfs2.mkfs(bdev)                       # create Little filesystem object using the flash area block
-    os.mount(bdev, '/flash')                    # mount the filesystem at the flash storage subdirectory
+    vfs.VfsLfs2.mkfs(bdev)                      # create Little filesystem object using the flash area block
+    vfs.mount(bdev, '/flash')                   # mount the filesystem at the flash storage subdirectory
     with open('/flash/hello.txt','w') as f:     # open a new file in the directory
         f.write('Hello world')                  # write to the file
     print(open('/flash/hello.txt').read())      # print contents of the file

--- a/extmod/extmod.cmake
+++ b/extmod/extmod.cmake
@@ -42,6 +42,7 @@ set(MICROPY_SOURCE_EXTMOD
     ${MICROPY_EXTMOD_DIR}/modtls_axtls.c
     ${MICROPY_EXTMOD_DIR}/modtls_mbedtls.c
     ${MICROPY_EXTMOD_DIR}/modtime.c
+    ${MICROPY_EXTMOD_DIR}/modvfs.c
     ${MICROPY_EXTMOD_DIR}/modwebsocket.c
     ${MICROPY_EXTMOD_DIR}/modwebrepl.c
     ${MICROPY_EXTMOD_DIR}/network_cyw43.c

--- a/extmod/extmod.mk
+++ b/extmod/extmod.mk
@@ -40,6 +40,7 @@ SRC_EXTMOD_C += \
 	extmod/modtls_mbedtls.c \
 	extmod/modtime.c \
 	extmod/moductypes.c \
+	extmod/modvfs.c \
 	extmod/modwebrepl.c \
 	extmod/modwebsocket.c \
 	extmod/network_cyw43.c \

--- a/extmod/modos.c
+++ b/extmod/modos.c
@@ -195,6 +195,10 @@ STATIC const mp_rom_map_elem_t os_module_globals_table[] = {
 
     #if MICROPY_VFS
     { MP_ROM_QSTR(MP_QSTR_ilistdir), MP_ROM_PTR(&mp_vfs_ilistdir_obj) },
+    #endif
+
+    // The following MicroPython extensions are deprecated.  Use the `vfs` module instead.
+    #if !MICROPY_PREVIEW_VERSION_2 && MICROPY_VFS
     { MP_ROM_QSTR(MP_QSTR_mount), MP_ROM_PTR(&mp_vfs_mount_obj) },
     { MP_ROM_QSTR(MP_QSTR_umount), MP_ROM_PTR(&mp_vfs_umount_obj) },
     #if MICROPY_VFS_FAT

--- a/extmod/modvfs.c
+++ b/extmod/modvfs.c
@@ -1,0 +1,67 @@
+/*
+ * This file is part of the MicroPython project, http://micropython.org/
+ *
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2023 Damien P. George
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#include "py/runtime.h"
+
+#if MICROPY_PY_VFS
+
+#include "extmod/vfs.h"
+#include "extmod/vfs_fat.h"
+#include "extmod/vfs_lfs.h"
+#include "extmod/vfs_posix.h"
+
+#if !MICROPY_VFS
+#error "MICROPY_PY_VFS requires MICROPY_VFS"
+#endif
+
+STATIC const mp_rom_map_elem_t vfs_module_globals_table[] = {
+    { MP_ROM_QSTR(MP_QSTR___name__), MP_ROM_QSTR(MP_QSTR_vfs) },
+
+    { MP_ROM_QSTR(MP_QSTR_mount), MP_ROM_PTR(&mp_vfs_mount_obj) },
+    { MP_ROM_QSTR(MP_QSTR_umount), MP_ROM_PTR(&mp_vfs_umount_obj) },
+    #if MICROPY_VFS_FAT
+    { MP_ROM_QSTR(MP_QSTR_VfsFat), MP_ROM_PTR(&mp_fat_vfs_type) },
+    #endif
+    #if MICROPY_VFS_LFS1
+    { MP_ROM_QSTR(MP_QSTR_VfsLfs1), MP_ROM_PTR(&mp_type_vfs_lfs1) },
+    #endif
+    #if MICROPY_VFS_LFS2
+    { MP_ROM_QSTR(MP_QSTR_VfsLfs2), MP_ROM_PTR(&mp_type_vfs_lfs2) },
+    #endif
+    #if MICROPY_VFS_POSIX
+    { MP_ROM_QSTR(MP_QSTR_VfsPosix), MP_ROM_PTR(&mp_type_vfs_posix) },
+    #endif
+};
+STATIC MP_DEFINE_CONST_DICT(vfs_module_globals, vfs_module_globals_table);
+
+const mp_obj_module_t mp_module_vfs = {
+    .base = { &mp_type_module },
+    .globals = (mp_obj_dict_t *)&vfs_module_globals,
+};
+
+MP_REGISTER_MODULE(MP_QSTR_vfs, mp_module_vfs);
+
+#endif // MICROPY_PY_VFS

--- a/ports/cc3200/mpconfigport.h
+++ b/ports/cc3200/mpconfigport.h
@@ -124,6 +124,7 @@
 #define MICROPY_PY_TIME_GMTIME_LOCALTIME_MKTIME     (1)
 #define MICROPY_PY_TIME_TIME_TIME_NS                (1)
 #define MICROPY_PY_TIME_INCLUDEFILE                 "ports/cc3200/mods/modtime.c"
+#define MICROPY_PY_VFS                              (1)
 #define MICROPY_PY_MACHINE                          (1)
 #define MICROPY_PY_MACHINE_INCLUDEFILE              "ports/cc3200/mods/modmachine.c"
 #define MICROPY_PY_MACHINE_BARE_METAL_FUNCS         (1)

--- a/ports/esp32/modules/_boot.py
+++ b/ports/esp32/modules/_boot.py
@@ -1,13 +1,13 @@
 import gc
-import os
+import vfs
 from flashbdev import bdev
 
 try:
     if bdev:
-        os.mount(bdev, "/")
+        vfs.mount(bdev, "/")
 except OSError:
     import inisetup
 
-    vfs = inisetup.setup()
+    inisetup.setup()
 
 gc.collect()

--- a/ports/esp32/modules/inisetup.py
+++ b/ports/esp32/modules/inisetup.py
@@ -1,4 +1,4 @@
-import os
+import vfs
 from flashbdev import bdev
 
 
@@ -38,12 +38,12 @@ def setup():
     check_bootsec()
     print("Performing initial setup")
     if bdev.info()[4] == "vfs":
-        os.VfsLfs2.mkfs(bdev)
-        vfs = os.VfsLfs2(bdev)
+        vfs.VfsLfs2.mkfs(bdev)
+        fs = vfs.VfsLfs2(bdev)
     elif bdev.info()[4] == "ffat":
-        os.VfsFat.mkfs(bdev)
-        vfs = os.VfsFat(bdev)
-    os.mount(vfs, "/")
+        vfs.VfsFat.mkfs(bdev)
+        fs = vfs.VfsFat(bdev)
+    vfs.mount(fs, "/")
     with open("boot.py", "w") as f:
         f.write(
             """\
@@ -54,4 +54,4 @@ def setup():
 #webrepl.start()
 """
         )
-    return vfs
+    return fs

--- a/ports/esp8266/boards/ESP8266_GENERIC/board.md
+++ b/ports/esp8266/boards/ESP8266_GENERIC/board.md
@@ -13,7 +13,7 @@ Note: v1.12-334 and newer (including v1.13) require an ESP8266 module with
 2MiB of flash or more, and use littlefs as the filesystem by default.  When
 upgrading from older firmware please backup your files first, and either
 erase all flash before upgrading, or after upgrading execute
-`os.VfsLfs2.mkfs(bdev)`.
+`vfs.VfsLfs2.mkfs(bdev)`.
 
 ### OTA builds
 Over-The-Air (OTA) builds of the ESP8266 firmware are also provided.

--- a/ports/esp8266/modules/_boot.py
+++ b/ports/esp8266/modules/_boot.py
@@ -1,12 +1,12 @@
 import gc
 
 gc.threshold((gc.mem_free() + gc.mem_alloc()) // 4)
-import os
+import vfs
 from flashbdev import bdev
 
 if bdev:
     try:
-        os.mount(bdev, "/")
+        vfs.mount(bdev, "/")
     except:
         import inisetup
 

--- a/ports/esp8266/modules/inisetup.py
+++ b/ports/esp8266/modules/inisetup.py
@@ -1,4 +1,4 @@
-import os
+import vfs
 import network
 from flashbdev import bdev
 
@@ -36,7 +36,7 @@ def fs_corrupted():
             """\
 The filesystem starting at sector %d with size %d sectors looks corrupt.
 You may want to make a flash snapshot and try to recover it. Otherwise,
-format it with os.VfsLfs2.mkfs(bdev), or completely erase the flash and
+format it with vfs.VfsLfs2.mkfs(bdev), or completely erase the flash and
 reprogram MicroPython.
 """
             % (bdev.start_sec, bdev.blocks)
@@ -48,9 +48,9 @@ def setup():
     check_bootsec()
     print("Performing initial setup")
     wifi()
-    os.VfsLfs2.mkfs(bdev)
-    vfs = os.VfsLfs2(bdev)
-    os.mount(vfs, "/")
+    vfs.VfsLfs2.mkfs(bdev)
+    fs = vfs.VfsLfs2(bdev)
+    vfs.mount(fs, "/")
     with open("boot.py", "w") as f:
         f.write(
             """\

--- a/ports/mimxrt/boards/TEENSY40/format.py
+++ b/ports/mimxrt/boards/TEENSY40/format.py
@@ -1,11 +1,11 @@
 # format.py
 # Re-create the file system
 
-import os
+import vfs
 import mimxrt
 
 bdev = mimxrt.Flash()
 
-os.VfsLfs2.mkfs(bdev, progsize=256)
-vfs = os.VfsLfs2(bdev, progsize=256)
-os.mount(vfs, "/")
+vfs.VfsLfs2.mkfs(bdev, progsize=256)
+fs = vfs.VfsLfs2(bdev, progsize=256)
+vfs.mount(fs, "/")

--- a/ports/mimxrt/modules/_boot.py
+++ b/ports/mimxrt/modules/_boot.py
@@ -3,17 +3,18 @@
 # Note: the flash requires the programming size to be aligned to 256 bytes.
 
 import os
+import vfs
 import sys
 import mimxrt
 from machine import Pin
 
 bdev = mimxrt.Flash()
 try:
-    vfs = os.VfsLfs2(bdev, progsize=256)
+    fs = vfs.VfsLfs2(bdev, progsize=256)
 except:
-    os.VfsLfs2.mkfs(bdev, progsize=256)
-    vfs = os.VfsLfs2(bdev, progsize=256)
-os.mount(vfs, "/flash")
+    vfs.VfsLfs2.mkfs(bdev, progsize=256)
+    fs = vfs.VfsLfs2(bdev, progsize=256)
+vfs.mount(fs, "/flash")
 os.chdir("/flash")
 sys.path.append("/flash")
 sys.path.append("/flash/lib")
@@ -27,8 +28,8 @@ except:
 
         sdcard = SDCard(1)
 
-        fat = os.VfsFat(sdcard)
-        os.mount(fat, "/sdcard")
+        fat = vfs.VfsFat(sdcard)
+        vfs.mount(fat, "/sdcard")
         os.chdir("/sdcard")
         sys.path.append("/sdcard")
     except:

--- a/ports/nrf/examples/mountsd.py
+++ b/ports/nrf/examples/mountsd.py
@@ -20,7 +20,7 @@ Direct wiring on SD card (SPI):
   ---------------------------------
 """
 
-import os
+import os, vfs
 from machine import SPI, Pin
 from sdcard import SDCard
 
@@ -28,7 +28,7 @@ from sdcard import SDCard
 def mnt():
     cs = Pin("P22", mode=Pin.OUT)
     sd = SDCard(SPI(0), cs)
-    os.mount(sd, "/")
+    vfs.mount(sd, "/")
 
 
 def list():

--- a/ports/nrf/examples/seeed_tft.py
+++ b/ports/nrf/examples/seeed_tft.py
@@ -44,7 +44,7 @@ Example usage of SD card reader:
     tf = mount_tf()
     os.listdir()
 """
-import os
+import vfs
 import time
 import framebuf
 
@@ -54,7 +54,7 @@ from sdcard import SDCard
 
 def mount_tf(self, mount_point="/"):
     sd = SDCard(SPI(0), Pin("P15", mode=Pin.OUT))
-    os.mount(sd, mount_point)
+    vfs.mount(sd, mount_point)
 
 
 class ILI9341:

--- a/ports/nrf/modules/scripts/_mkfs.py
+++ b/ports/nrf/modules/scripts/_mkfs.py
@@ -1,19 +1,19 @@
-import os, nrf
+import vfs, nrf
 
 try:
-    from os import VfsLfs1
+    from vfs import VfsLfs1
 
-    os.VfsLfs1.mkfs(nrf.Flash())
+    vfs.VfsLfs1.mkfs(nrf.Flash())
 except ImportError:
     try:
-        from os import VfsLfs2
+        from vfs import VfsLfs2
 
-        os.VfsLfs2.mkfs(nrf.Flash())
+        vfs.VfsLfs2.mkfs(nrf.Flash())
     except ImportError:
         try:
-            from os import VfsFat
+            from vfs import VfsFat
 
-            os.VfsFat.mkfs(nrf.Flash())
+            vfs.VfsFat.mkfs(nrf.Flash())
         except ImportError:
             pass
         except OSError as e:

--- a/ports/rp2/modules/_boot.py
+++ b/ports/rp2/modules/_boot.py
@@ -1,4 +1,4 @@
-import os
+import vfs
 import machine, rp2
 
 
@@ -6,10 +6,10 @@ import machine, rp2
 # Note: the flash requires the programming size to be aligned to 256 bytes.
 bdev = rp2.Flash()
 try:
-    vfs = os.VfsLfs2(bdev, progsize=256)
+    fs = vfs.VfsLfs2(bdev, progsize=256)
 except:
-    os.VfsLfs2.mkfs(bdev, progsize=256)
-    vfs = os.VfsLfs2(bdev, progsize=256)
-os.mount(vfs, "/")
+    vfs.VfsLfs2.mkfs(bdev, progsize=256)
+    fs = vfs.VfsLfs2(bdev, progsize=256)
+vfs.mount(fs, "/")
 
-del os, bdev, vfs
+del vfs, bdev, fs

--- a/ports/rp2/modules/_boot_fat.py
+++ b/ports/rp2/modules/_boot_fat.py
@@ -1,15 +1,14 @@
-import os
+import vfs
 import machine, rp2
 
 
 # Try to mount the filesystem, and format the flash if it doesn't exist.
 bdev = rp2.Flash()
 try:
-    vfs = os.VfsFat(bdev)
-    os.mount(vfs, "/")
+    fs = vfs.VfsFat(bdev)
 except:
-    os.VfsFat.mkfs(bdev)
-    vfs = os.VfsFat(bdev)
-os.mount(vfs, "/")
+    vfs.VfsFat.mkfs(bdev)
+    fs = vfs.VfsFat(bdev)
+vfs.mount(fs, "/")
 
-del os, bdev, vfs
+del vfs, bdev, fs

--- a/ports/samd/modules/_boot.py
+++ b/ports/samd/modules/_boot.py
@@ -1,21 +1,21 @@
 import gc
-import os
+import vfs
 import samd
 import sys
 
 bdev = samd.Flash()
 
 # Try to mount the filesystem, and format the flash if it doesn't exist.
-fs_type = os.VfsLfs2 if hasattr(os, "VfsLfs2") else os.VfsLfs1
+fs_type = vfs.VfsLfs2 if hasattr(vfs, "VfsLfs2") else vfs.VfsLfs1
 
 try:
-    vfs = fs_type(bdev, progsize=256)
+    fs = fs_type(bdev, progsize=256)
 except:
     fs_type.mkfs(bdev, progsize=256)
-    vfs = fs_type(bdev, progsize=256)
-os.mount(vfs, "/")
+    fs = fs_type(bdev, progsize=256)
+vfs.mount(fs, "/")
 sys.path.append("/lib")
 
-del vfs, fs_type, bdev, os, samd, sys
+del fs, fs_type, bdev, vfs, samd, sys
 gc.collect()
 del gc

--- a/py/mpconfig.h
+++ b/py/mpconfig.h
@@ -1744,6 +1744,11 @@ typedef double mp_float_t;
 #define MICROPY_PY_SSL_FINALISER (MICROPY_ENABLE_FINALISER)
 #endif
 
+// Whether to provide the "vfs" module
+#ifndef MICROPY_PY_VFS
+#define MICROPY_PY_VFS (MICROPY_CONFIG_ROM_LEVEL_AT_LEAST_EXTRA_FEATURES && MICROPY_VFS)
+#endif
+
 #ifndef MICROPY_PY_WEBSOCKET
 #define MICROPY_PY_WEBSOCKET (0)
 #endif

--- a/tests/extmod/vfs_basic.py
+++ b/tests/extmod/vfs_basic.py
@@ -1,10 +1,8 @@
 # test VFS functionality without any particular filesystem type
 
 try:
-    import os
-
-    os.mount
-except (ImportError, AttributeError):
+    import os, vfs
+except ImportError:
     print("SKIP")
     raise SystemExit
 
@@ -59,11 +57,11 @@ class Filesystem:
 
 # first we umount any existing mount points the target may have
 try:
-    os.umount("/")
+    vfs.umount("/")
 except OSError:
     pass
 for path in os.listdir("/"):
-    os.umount("/" + path)
+    vfs.umount("/" + path)
 
 # stat root dir
 print(os.stat("/"))
@@ -83,7 +81,7 @@ for func in ("chdir", "listdir", "mkdir", "remove", "rmdir", "stat"):
             print(func, arg, "OSError")
 
 # basic mounting and listdir
-os.mount(Filesystem(1), "/test_mnt")
+vfs.mount(Filesystem(1), "/test_mnt")
 print(os.listdir())
 
 # ilistdir
@@ -103,13 +101,13 @@ print(os.listdir("test_mnt"))
 print(os.listdir("/test_mnt"))
 
 # mounting another filesystem
-os.mount(Filesystem(2), "/test_mnt2", readonly=True)
+vfs.mount(Filesystem(2), "/test_mnt2", readonly=True)
 print(os.listdir())
 print(os.listdir("/test_mnt2"))
 
 # mounting over an existing mount point
 try:
-    os.mount(Filesystem(3), "/test_mnt2")
+    vfs.mount(Filesystem(3), "/test_mnt2")
 except OSError:
     print("OSError")
 
@@ -139,23 +137,23 @@ open("test_file")
 open("test_file", "wb")
 
 # umount
-os.umount("/test_mnt")
-os.umount("/test_mnt2")
+vfs.umount("/test_mnt")
+vfs.umount("/test_mnt2")
 
 # umount a non-existent mount point
 try:
-    os.umount("/test_mnt")
+    vfs.umount("/test_mnt")
 except OSError:
     print("OSError")
 
 # root dir
-os.mount(Filesystem(3), "/")
+vfs.mount(Filesystem(3), "/")
 print(os.stat("/"))
 print(os.statvfs("/"))
 print(os.listdir())
 open("test")
 
-os.mount(Filesystem(4), "/mnt")
+vfs.mount(Filesystem(4), "/mnt")
 print(os.listdir())
 print(os.listdir("/mnt"))
 os.chdir("/mnt")
@@ -166,9 +164,9 @@ os.chdir("/subdir")
 print(os.listdir())
 os.chdir("/")
 
-os.umount("/")
+vfs.umount("/")
 print(os.listdir("/"))
-os.umount("/mnt")
+vfs.umount("/mnt")
 
 # chdir to a non-existent mount point (current directory should remain unchanged)
 try:
@@ -178,7 +176,7 @@ except OSError:
 print(os.getcwd())
 
 # chdir to a non-existent subdirectory in a mounted filesystem
-os.mount(Filesystem(5, 1), "/mnt")
+vfs.mount(Filesystem(5, 1), "/mnt")
 try:
     os.chdir("/mnt/subdir")
 except OSError:

--- a/tests/extmod/vfs_blockdev.py
+++ b/tests/extmod/vfs_blockdev.py
@@ -1,10 +1,10 @@
 # Test for behaviour of combined standard and extended block device
 
 try:
-    import os
+    import vfs
 
-    os.VfsFat
-    os.VfsLfs2
+    vfs.VfsFat
+    vfs.VfsLfs2
 except (ImportError, AttributeError):
     print("SKIP")
     raise SystemExit
@@ -65,12 +65,10 @@ def test(bdev, vfs_class):
 
 
 try:
-    import os
-
     bdev = RAMBlockDevice(50)
 except MemoryError:
     print("SKIP")
     raise SystemExit
 
-test(bdev, os.VfsFat)
-test(bdev, os.VfsLfs2)
+test(bdev, vfs.VfsFat)
+test(bdev, vfs.VfsLfs2)

--- a/tests/extmod/vfs_fat_fileio1.py
+++ b/tests/extmod/vfs_fat_fileio1.py
@@ -1,13 +1,8 @@
 try:
-    import errno
-    import os
-except ImportError:
-    print("SKIP")
-    raise SystemExit
+    import errno, os, vfs
 
-try:
-    os.VfsFat
-except AttributeError:
+    vfs.VfsFat
+except (ImportError, AttributeError):
     print("SKIP")
     raise SystemExit
 
@@ -38,13 +33,13 @@ class RAMFS:
 
 try:
     bdev = RAMFS(50)
-    os.VfsFat.mkfs(bdev)
+    vfs.VfsFat.mkfs(bdev)
 except MemoryError:
     print("SKIP")
     raise SystemExit
 
-vfs = os.VfsFat(bdev)
-os.mount(vfs, "/ramdisk")
+fs = vfs.VfsFat(bdev)
+vfs.mount(fs, "/ramdisk")
 os.chdir("/ramdisk")
 
 # file IO
@@ -99,12 +94,12 @@ with open("foo_file.txt") as f2:
 #    print(f.read())
 
 # dirs
-vfs.mkdir("foo_dir")
+fs.mkdir("foo_dir")
 
 try:
-    vfs.rmdir("foo_file.txt")
+    fs.rmdir("foo_file.txt")
 except OSError as e:
     print(e.errno == 20)  # errno.ENOTDIR
 
-vfs.remove("foo_file.txt")
-print(list(vfs.ilistdir()))
+fs.remove("foo_file.txt")
+print(list(fs.ilistdir()))

--- a/tests/extmod/vfs_fat_finaliser.py
+++ b/tests/extmod/vfs_fat_finaliser.py
@@ -1,9 +1,9 @@
 # Test VfsFat class and its finaliser
 
 try:
-    import errno, os
+    import errno, os, vfs
 
-    os.VfsFat
+    vfs.VfsFat
 except (ImportError, AttributeError):
     print("SKIP")
     raise SystemExit
@@ -39,8 +39,8 @@ except MemoryError:
     raise SystemExit
 
 # Format block device and create VFS object
-os.VfsFat.mkfs(bdev)
-vfs = os.VfsFat(bdev)
+vfs.VfsFat.mkfs(bdev)
+fs = vfs.VfsFat(bdev)
 
 # Here we test that opening a file with the heap locked fails correctly.  This
 # is a special case because file objects use a finaliser and allocating with a
@@ -52,7 +52,7 @@ micropython.heap_lock()
 try:
     import errno, os
 
-    vfs.open("x", "r")
+    fs.open("x", "r")
 except MemoryError:
     print("MemoryError")
 micropython.heap_unlock()
@@ -77,10 +77,10 @@ for i in range(1024):
 # Only read back N-1 files because the last one may not be finalised due to
 # references to it being left on the C stack.
 for n in names:
-    f = vfs.open(n, "w")
+    f = fs.open(n, "w")
     f.write(n)
     f = None  # release f without closing
 gc.collect()  # should finalise at least the first N-1 files by closing them
 for n in names[:-1]:
-    with vfs.open(n, "r") as f:
+    with fs.open(n, "r") as f:
         print(f.read())

--- a/tests/extmod/vfs_fat_ilistdir_del.py
+++ b/tests/extmod/vfs_fat_ilistdir_del.py
@@ -2,9 +2,9 @@
 import gc
 
 try:
-    import os
+    import os, vfs
 
-    os.VfsFat
+    vfs.VfsFat
 except (ImportError, AttributeError):
     print("SKIP")
     raise SystemExit
@@ -37,29 +37,29 @@ class RAMBlockDevice:
 
 def test(bdev, vfs_class):
     vfs_class.mkfs(bdev)
-    vfs = vfs_class(bdev)
-    vfs.mkdir("/test_d1")
-    vfs.mkdir("/test_d2")
-    vfs.mkdir("/test_d3")
+    fs = vfs_class(bdev)
+    fs.mkdir("/test_d1")
+    fs.mkdir("/test_d2")
+    fs.mkdir("/test_d3")
 
     for i in range(10):
         print(i)
 
         # We want to partially iterate the ilistdir iterator to leave it in an
         # open state, which will then test the finaliser when it's garbage collected.
-        idir = vfs.ilistdir("/")
+        idir = fs.ilistdir("/")
         print(any(idir))
 
         # Alternate way of partially iterating the ilistdir object, modifying the
         # filesystem while it's open.
-        for dname, *_ in vfs.ilistdir("/"):
-            vfs.rmdir(dname)
+        for dname, *_ in fs.ilistdir("/"):
+            fs.rmdir(dname)
             break
-        vfs.mkdir(dname)
+        fs.mkdir(dname)
 
         # Also create a fully drained iterator and ensure trying to reuse it
         # throws the correct exception.
-        idir_emptied = vfs.ilistdir("/")
+        idir_emptied = fs.ilistdir("/")
         l = list(idir_emptied)
         print(len(l))
         try:
@@ -68,7 +68,7 @@ def test(bdev, vfs_class):
             pass
 
         gc.collect()
-        vfs.open("/test", "w").close()
+        fs.open("/test", "w").close()
 
 
 try:
@@ -77,4 +77,4 @@ except MemoryError:
     print("SKIP")
     raise SystemExit
 
-test(bdev, os.VfsFat)
+test(bdev, vfs.VfsFat)

--- a/tests/extmod/vfs_fat_more.py
+++ b/tests/extmod/vfs_fat_more.py
@@ -1,12 +1,8 @@
 try:
-    import os
-except ImportError:
-    print("SKIP")
-    raise SystemExit
+    import os, vfs
 
-try:
-    os.VfsFat
-except AttributeError:
+    vfs.VfsFat
+except (ImportError, AttributeError):
     print("SKIP")
     raise SystemExit
 
@@ -44,14 +40,14 @@ except MemoryError:
 
 # first we umount any existing mount points the target may have
 try:
-    os.umount("/")
+    vfs.umount("/")
 except OSError:
     pass
 for path in os.listdir("/"):
-    os.umount("/" + path)
+    vfs.umount("/" + path)
 
-os.VfsFat.mkfs(bdev)
-os.mount(bdev, "/")
+vfs.VfsFat.mkfs(bdev)
+vfs.mount(bdev, "/")
 
 print(os.getcwd())
 
@@ -94,8 +90,8 @@ for exist in ("", "/", "dir", "/dir", "dir/subdir"):
 os.chdir("/")
 print(os.stat("test5.txt")[:-3])
 
-os.VfsFat.mkfs(bdev2)
-os.mount(bdev2, "/sys")
+vfs.VfsFat.mkfs(bdev2)
+vfs.mount(bdev2, "/sys")
 print(os.listdir())
 print(os.listdir("sys"))
 print(os.listdir("/sys"))
@@ -104,7 +100,7 @@ os.rmdir("dir2")
 os.remove("test5.txt")
 print(os.listdir())
 
-os.umount("/")
+vfs.umount("/")
 print(os.getcwd())
 print(os.listdir())
 print(os.listdir("sys"))

--- a/tests/extmod/vfs_fat_mtime.py
+++ b/tests/extmod/vfs_fat_mtime.py
@@ -1,11 +1,11 @@
 # Test for VfsFat using a RAM device, mtime feature
 
 try:
-    import time, os
+    import time, os, vfs
 
     time.time
     time.sleep
-    os.VfsFat
+    vfs.VfsFat
 except (ImportError, AttributeError):
     print("SKIP")
     raise SystemExit
@@ -41,21 +41,21 @@ def test(bdev, vfs_class):
     vfs_class.mkfs(bdev)
 
     # construction
-    vfs = vfs_class(bdev)
+    fs = vfs_class(bdev)
 
     # Create an empty file, should have a timestamp.
     current_time = int(time.time())
-    vfs.open("test1", "wt").close()
+    fs.open("test1", "wt").close()
 
     # Wait 2 seconds so mtime will increase (FAT has 2 second resolution).
     time.sleep(2)
 
     # Create another empty file, should have a timestamp.
-    vfs.open("test2", "wt").close()
+    fs.open("test2", "wt").close()
 
     # Stat the files and check mtime is non-zero.
-    stat1 = vfs.stat("test1")
-    stat2 = vfs.stat("test2")
+    stat1 = fs.stat("test1")
+    stat2 = fs.stat("test2")
     print(stat1[8] != 0, stat2[8] != 0)
 
     # Check that test1 has mtime which matches time.time() at point of creation.
@@ -67,8 +67,8 @@ def test(bdev, vfs_class):
     print(stat1[8] < stat2[8])
 
     # Unmount.
-    vfs.umount()
+    fs.umount()
 
 
 bdev = RAMBlockDevice(50)
-test(bdev, os.VfsFat)
+test(bdev, vfs.VfsFat)

--- a/tests/extmod/vfs_fat_oldproto.py
+++ b/tests/extmod/vfs_fat_oldproto.py
@@ -1,13 +1,8 @@
 try:
-    import errno
-    import os
-except ImportError:
-    print("SKIP")
-    raise SystemExit
+    import errno, os, vfs
 
-try:
-    os.VfsFat
-except AttributeError:
+    vfs.VfsFat
+except (ImportError, AttributeError):
     print("SKIP")
     raise SystemExit
 
@@ -41,18 +36,18 @@ except MemoryError:
     print("SKIP")
     raise SystemExit
 
-os.VfsFat.mkfs(bdev)
-vfs = os.VfsFat(bdev)
-os.mount(vfs, "/ramdisk")
+vfs.VfsFat.mkfs(bdev)
+fs = vfs.VfsFat(bdev)
+vfs.mount(fs, "/ramdisk")
 
 # file io
-with vfs.open("file.txt", "w") as f:
+with fs.open("file.txt", "w") as f:
     f.write("hello!")
 
-print(list(vfs.ilistdir()))
+print(list(fs.ilistdir()))
 
-with vfs.open("file.txt", "r") as f:
+with fs.open("file.txt", "r") as f:
     print(f.read())
 
-vfs.remove("file.txt")
-print(list(vfs.ilistdir()))
+fs.remove("file.txt")
+print(list(fs.ilistdir()))

--- a/tests/extmod/vfs_fat_ramdisklarge.py
+++ b/tests/extmod/vfs_fat_ramdisklarge.py
@@ -1,14 +1,10 @@
 # test making a FAT filesystem on a very large block device
 
 try:
-    import os
-except ImportError:
-    print("SKIP")
-    raise SystemExit
+    import os, vfs
 
-try:
-    os.VfsFat
-except AttributeError:
+    vfs.VfsFat
+except (ImportError, AttributeError):
     print("SKIP")
     raise SystemExit
 
@@ -46,24 +42,24 @@ class RAMBDevSparse:
 
 try:
     bdev = RAMBDevSparse(4 * 1024 * 1024 * 1024 // RAMBDevSparse.SEC_SIZE)
-    os.VfsFat.mkfs(bdev)
+    vfs.VfsFat.mkfs(bdev)
 except MemoryError:
     print("SKIP")
     raise SystemExit
 
-vfs = os.VfsFat(bdev)
-os.mount(vfs, "/ramdisk")
+fs = vfs.VfsFat(bdev)
+vfs.mount(fs, "/ramdisk")
 
-print("statvfs:", vfs.statvfs("/ramdisk"))
+print("statvfs:", fs.statvfs("/ramdisk"))
 
 f = open("/ramdisk/test.txt", "w")
 f.write("test file")
 f.close()
 
-print("statvfs:", vfs.statvfs("/ramdisk"))
+print("statvfs:", fs.statvfs("/ramdisk"))
 
 f = open("/ramdisk/test.txt")
 print(f.read())
 f.close()
 
-os.umount(vfs)
+vfs.umount(fs)

--- a/tests/extmod/vfs_lfs.py
+++ b/tests/extmod/vfs_lfs.py
@@ -1,10 +1,10 @@
 # Test for VfsLittle using a RAM device
 
 try:
-    import os
+    import os, vfs
 
-    os.VfsLfs1
-    os.VfsLfs2
+    vfs.VfsLfs1
+    vfs.VfsLfs2
 except (ImportError, AttributeError):
     print("SKIP")
     raise SystemExit
@@ -47,44 +47,44 @@ def test(bdev, vfs_class):
     vfs_class.mkfs(bdev)
 
     # construction
-    vfs = vfs_class(bdev)
+    fs = vfs_class(bdev)
 
     # statvfs
-    print(vfs.statvfs("/"))
+    print(fs.statvfs("/"))
 
     # open, write close
-    f = vfs.open("test", "w")
+    f = fs.open("test", "w")
     f.write("littlefs")
     f.close()
 
     # statvfs after creating a file
-    print(vfs.statvfs("/"))
+    print(fs.statvfs("/"))
 
     # ilistdir
-    print(list(vfs.ilistdir()))
-    print(list(vfs.ilistdir("/")))
-    print(list(vfs.ilistdir(b"/")))
+    print(list(fs.ilistdir()))
+    print(list(fs.ilistdir("/")))
+    print(list(fs.ilistdir(b"/")))
 
     # mkdir, rmdir
-    vfs.mkdir("testdir")
-    print(list(vfs.ilistdir()))
-    print(sorted(list(vfs.ilistdir("testdir"))))
-    vfs.rmdir("testdir")
-    print(list(vfs.ilistdir()))
-    vfs.mkdir("testdir")
+    fs.mkdir("testdir")
+    print(list(fs.ilistdir()))
+    print(sorted(list(fs.ilistdir("testdir"))))
+    fs.rmdir("testdir")
+    print(list(fs.ilistdir()))
+    fs.mkdir("testdir")
 
     # stat a file
-    print_stat(vfs.stat("test"))
+    print_stat(fs.stat("test"))
 
     # stat a dir (size seems to vary on LFS2 so don't print that)
-    print_stat(vfs.stat("testdir"), False)
+    print_stat(fs.stat("testdir"), False)
 
     # read
-    with vfs.open("test", "r") as f:
+    with fs.open("test", "r") as f:
         print(f.read())
 
     # create large file
-    with vfs.open("testbig", "w") as f:
+    with fs.open("testbig", "w") as f:
         data = "large012" * 32 * 16
         print("data length:", len(data))
         for i in range(4):
@@ -92,63 +92,63 @@ def test(bdev, vfs_class):
             f.write(data)
 
     # stat after creating large file
-    print(vfs.statvfs("/"))
+    print(fs.statvfs("/"))
 
     # rename
-    vfs.rename("testbig", "testbig2")
-    print(sorted(list(vfs.ilistdir())))
-    vfs.chdir("testdir")
-    vfs.rename("/testbig2", "testbig2")
-    print(sorted(list(vfs.ilistdir())))
-    vfs.rename("testbig2", "/testbig2")
-    vfs.chdir("/")
-    print(sorted(list(vfs.ilistdir())))
+    fs.rename("testbig", "testbig2")
+    print(sorted(list(fs.ilistdir())))
+    fs.chdir("testdir")
+    fs.rename("/testbig2", "testbig2")
+    print(sorted(list(fs.ilistdir())))
+    fs.rename("testbig2", "/testbig2")
+    fs.chdir("/")
+    print(sorted(list(fs.ilistdir())))
 
     # remove
-    vfs.remove("testbig2")
-    print(sorted(list(vfs.ilistdir())))
+    fs.remove("testbig2")
+    print(sorted(list(fs.ilistdir())))
 
     # getcwd, chdir
-    vfs.mkdir("/testdir2")
-    vfs.mkdir("/testdir/subdir")
-    print(vfs.getcwd())
-    vfs.chdir("/testdir")
-    print(vfs.getcwd())
+    fs.mkdir("/testdir2")
+    fs.mkdir("/testdir/subdir")
+    print(fs.getcwd())
+    fs.chdir("/testdir")
+    print(fs.getcwd())
 
     # create file in directory to make sure paths are relative
-    vfs.open("test2", "w").close()
-    print_stat(vfs.stat("test2"))
-    print_stat(vfs.stat("/testdir/test2"))
-    vfs.remove("test2")
+    fs.open("test2", "w").close()
+    print_stat(fs.stat("test2"))
+    print_stat(fs.stat("/testdir/test2"))
+    fs.remove("test2")
 
     # chdir back to root and remove testdir
-    vfs.chdir("/")
-    print(vfs.getcwd())
-    vfs.chdir("testdir")
-    print(vfs.getcwd())
-    vfs.chdir("..")
-    print(vfs.getcwd())
-    vfs.chdir("testdir/subdir")
-    print(vfs.getcwd())
-    vfs.chdir("../..")
-    print(vfs.getcwd())
-    vfs.chdir("/./testdir2")
-    print(vfs.getcwd())
-    vfs.chdir("../testdir")
-    print(vfs.getcwd())
-    vfs.chdir("../..")
-    print(vfs.getcwd())
-    vfs.chdir(".//testdir")
-    print(vfs.getcwd())
-    vfs.chdir("subdir/./")
-    print(vfs.getcwd())
-    vfs.chdir("/")
-    print(vfs.getcwd())
-    vfs.rmdir("testdir/subdir")
-    vfs.rmdir("testdir")
-    vfs.rmdir("testdir2")
+    fs.chdir("/")
+    print(fs.getcwd())
+    fs.chdir("testdir")
+    print(fs.getcwd())
+    fs.chdir("..")
+    print(fs.getcwd())
+    fs.chdir("testdir/subdir")
+    print(fs.getcwd())
+    fs.chdir("../..")
+    print(fs.getcwd())
+    fs.chdir("/./testdir2")
+    print(fs.getcwd())
+    fs.chdir("../testdir")
+    print(fs.getcwd())
+    fs.chdir("../..")
+    print(fs.getcwd())
+    fs.chdir(".//testdir")
+    print(fs.getcwd())
+    fs.chdir("subdir/./")
+    print(fs.getcwd())
+    fs.chdir("/")
+    print(fs.getcwd())
+    fs.rmdir("testdir/subdir")
+    fs.rmdir("testdir")
+    fs.rmdir("testdir2")
 
 
 bdev = RAMBlockDevice(30)
-test(bdev, os.VfsLfs1)
-test(bdev, os.VfsLfs2)
+test(bdev, vfs.VfsLfs1)
+test(bdev, vfs.VfsLfs2)

--- a/tests/extmod/vfs_lfs_corrupt.py
+++ b/tests/extmod/vfs_lfs_corrupt.py
@@ -1,10 +1,10 @@
 # Test for VfsLittle using a RAM device, testing error handling from corrupt block device
 
 try:
-    import os
+    import vfs
 
-    os.VfsLfs1
-    os.VfsLfs2
+    vfs.VfsLfs1
+    vfs.VfsLfs2
 except (ImportError, AttributeError):
     print("SKIP")
     raise SystemExit
@@ -47,28 +47,28 @@ def corrupt(bdev, block):
 def create_vfs(bdev, vfs_class):
     bdev.ret = 0
     vfs_class.mkfs(bdev)
-    vfs = vfs_class(bdev)
-    with vfs.open("f", "w") as f:
+    fs = vfs_class(bdev)
+    with fs.open("f", "w") as f:
         for i in range(100):
             f.write("test")
-    return vfs
+    return fs
 
 
 def test(bdev, vfs_class):
     print("test", vfs_class)
 
     # statvfs
-    vfs = create_vfs(bdev, vfs_class)
+    fs = create_vfs(bdev, vfs_class)
     corrupt(bdev, 0)
     corrupt(bdev, 1)
     try:
-        print(vfs.statvfs(""))
+        print(fs.statvfs(""))
     except OSError:
         print("statvfs OSError")
 
     # error during read
-    vfs = create_vfs(bdev, vfs_class)
-    f = vfs.open("f", "r")
+    fs = create_vfs(bdev, vfs_class)
+    f = fs.open("f", "r")
     bdev.ret = -5  # EIO
     try:
         f.read(10)
@@ -76,8 +76,8 @@ def test(bdev, vfs_class):
         print("read OSError")
 
     # error during write
-    vfs = create_vfs(bdev, vfs_class)
-    f = vfs.open("f", "a")
+    fs = create_vfs(bdev, vfs_class)
+    f = fs.open("f", "a")
     bdev.ret = -5  # EIO
     try:
         f.write("test")
@@ -85,8 +85,8 @@ def test(bdev, vfs_class):
         print("write OSError")
 
     # error during close
-    vfs = create_vfs(bdev, vfs_class)
-    f = vfs.open("f", "w")
+    fs = create_vfs(bdev, vfs_class)
+    f = fs.open("f", "w")
     f.write("test")
     bdev.ret = -5  # EIO
     try:
@@ -95,8 +95,8 @@ def test(bdev, vfs_class):
         print("close OSError")
 
     # error during flush
-    vfs = create_vfs(bdev, vfs_class)
-    f = vfs.open("f", "w")
+    fs = create_vfs(bdev, vfs_class)
+    f = fs.open("f", "w")
     f.write("test")
     bdev.ret = -5  # EIO
     try:
@@ -108,5 +108,5 @@ def test(bdev, vfs_class):
 
 
 bdev = RAMBlockDevice(30)
-test(bdev, os.VfsLfs1)
-test(bdev, os.VfsLfs2)
+test(bdev, vfs.VfsLfs1)
+test(bdev, vfs.VfsLfs2)

--- a/tests/extmod/vfs_lfs_error.py
+++ b/tests/extmod/vfs_lfs_error.py
@@ -1,10 +1,10 @@
 # Test for VfsLittle using a RAM device, testing error handling
 
 try:
-    import os
+    import vfs
 
-    os.VfsLfs1
-    os.VfsLfs2
+    vfs.VfsLfs1
+    vfs.VfsLfs2
 except (ImportError, AttributeError):
     print("SKIP")
     raise SystemExit
@@ -52,63 +52,63 @@ def test(bdev, vfs_class):
 
     # set up for following tests
     vfs_class.mkfs(bdev)
-    vfs = vfs_class(bdev)
-    with vfs.open("testfile", "w") as f:
+    fs = vfs_class(bdev)
+    with fs.open("testfile", "w") as f:
         f.write("test")
-    vfs.mkdir("testdir")
+    fs.mkdir("testdir")
 
     # ilistdir
     try:
-        vfs.ilistdir("noexist")
+        fs.ilistdir("noexist")
     except OSError:
         print("ilistdir OSError")
 
     # remove
     try:
-        vfs.remove("noexist")
+        fs.remove("noexist")
     except OSError:
         print("remove OSError")
 
     # rmdir
     try:
-        vfs.rmdir("noexist")
+        fs.rmdir("noexist")
     except OSError:
         print("rmdir OSError")
 
     # rename
     try:
-        vfs.rename("noexist", "somethingelse")
+        fs.rename("noexist", "somethingelse")
     except OSError:
         print("rename OSError")
 
     # mkdir
     try:
-        vfs.mkdir("testdir")
+        fs.mkdir("testdir")
     except OSError:
         print("mkdir OSError")
 
     # chdir to nonexistent
     try:
-        vfs.chdir("noexist")
+        fs.chdir("noexist")
     except OSError:
         print("chdir OSError")
-    print(vfs.getcwd())  # check still at root
+    print(fs.getcwd())  # check still at root
 
     # chdir to file
     try:
-        vfs.chdir("testfile")
+        fs.chdir("testfile")
     except OSError:
         print("chdir OSError")
-    print(vfs.getcwd())  # check still at root
+    print(fs.getcwd())  # check still at root
 
     # stat
     try:
-        vfs.stat("noexist")
+        fs.stat("noexist")
     except OSError:
         print("stat OSError")
 
     # error during seek
-    with vfs.open("testfile", "r") as f:
+    with fs.open("testfile", "r") as f:
         f.seek(1 << 30)  # SEEK_SET
         try:
             f.seek(1 << 30, 1)  # SEEK_CUR
@@ -117,5 +117,5 @@ def test(bdev, vfs_class):
 
 
 bdev = RAMBlockDevice(30)
-test(bdev, os.VfsLfs1)
-test(bdev, os.VfsLfs2)
+test(bdev, vfs.VfsLfs1)
+test(bdev, vfs.VfsLfs2)

--- a/tests/extmod/vfs_lfs_file.py
+++ b/tests/extmod/vfs_lfs_file.py
@@ -1,10 +1,10 @@
 # Test for VfsLittle using a RAM device, file IO
 
 try:
-    import os
+    import vfs
 
-    os.VfsLfs1
-    os.VfsLfs2
+    vfs.VfsLfs1
+    vfs.VfsLfs2
 except (ImportError, AttributeError):
     print("SKIP")
     raise SystemExit
@@ -42,10 +42,10 @@ def test(bdev, vfs_class):
     vfs_class.mkfs(bdev)
 
     # construction
-    vfs = vfs_class(bdev)
+    fs = vfs_class(bdev)
 
     # create text, print, write, close
-    f = vfs.open("test.txt", "wt")
+    f = fs.open("test.txt", "wt")
     print(f)
     f.write("littlefs")
     f.close()
@@ -54,48 +54,48 @@ def test(bdev, vfs_class):
     f.close()
 
     # create binary, print, write, flush, close
-    f = vfs.open("test.bin", "wb")
+    f = fs.open("test.bin", "wb")
     print(f)
     f.write("littlefs")
     f.flush()
     f.close()
 
     # create for append
-    f = vfs.open("test.bin", "ab")
+    f = fs.open("test.bin", "ab")
     f.write("more")
     f.close()
 
     # create exclusive
-    f = vfs.open("test2.bin", "xb")
+    f = fs.open("test2.bin", "xb")
     f.close()
 
     # create exclusive with error
     try:
-        vfs.open("test2.bin", "x")
+        fs.open("test2.bin", "x")
     except OSError:
         print("open OSError")
 
     # read default
-    with vfs.open("test.txt", "") as f:
+    with fs.open("test.txt", "") as f:
         print(f.read())
 
     # read text
-    with vfs.open("test.txt", "rt") as f:
+    with fs.open("test.txt", "rt") as f:
         print(f.read())
 
     # read binary
-    with vfs.open("test.bin", "rb") as f:
+    with fs.open("test.bin", "rb") as f:
         print(f.read())
 
     # create read and write
-    with vfs.open("test.bin", "r+b") as f:
+    with fs.open("test.bin", "r+b") as f:
         print(f.read(8))
         f.write("MORE")
-    with vfs.open("test.bin", "rb") as f:
+    with fs.open("test.bin", "rb") as f:
         print(f.read())
 
     # seek and tell
-    f = vfs.open("test.txt", "r")
+    f = fs.open("test.txt", "r")
     print(f.tell())
     f.seek(3, 0)
     print(f.tell())
@@ -103,13 +103,13 @@ def test(bdev, vfs_class):
 
     # open nonexistent
     try:
-        vfs.open("noexist", "r")
+        fs.open("noexist", "r")
     except OSError:
         print("open OSError")
 
     # open multiple files at the same time
-    f1 = vfs.open("test.txt", "")
-    f2 = vfs.open("test.bin", "b")
+    f1 = fs.open("test.txt", "")
+    f2 = fs.open("test.bin", "b")
     print(f1.read())
     print(f2.read())
     f1.close()
@@ -117,5 +117,5 @@ def test(bdev, vfs_class):
 
 
 bdev = RAMBlockDevice(30)
-test(bdev, os.VfsLfs1)
-test(bdev, os.VfsLfs2)
+test(bdev, vfs.VfsLfs1)
+test(bdev, vfs.VfsLfs2)

--- a/tests/extmod/vfs_lfs_ilistdir_del.py
+++ b/tests/extmod/vfs_lfs_ilistdir_del.py
@@ -2,9 +2,9 @@
 import gc
 
 try:
-    import os
+    import vfs
 
-    os.VfsLfs2
+    vfs.VfsLfs2
 except (ImportError, AttributeError):
     print("SKIP")
     raise SystemExit
@@ -37,29 +37,29 @@ class RAMBlockDevice:
 
 def test(bdev, vfs_class):
     vfs_class.mkfs(bdev)
-    vfs = vfs_class(bdev)
-    vfs.mkdir("/test_d1")
-    vfs.mkdir("/test_d2")
-    vfs.mkdir("/test_d3")
+    fs = vfs_class(bdev)
+    fs.mkdir("/test_d1")
+    fs.mkdir("/test_d2")
+    fs.mkdir("/test_d3")
 
     for i in range(10):
         print(i)
 
         # We want to partially iterate the ilistdir iterator to leave it in an
         # open state, which will then test the finaliser when it's garbage collected.
-        idir = vfs.ilistdir("/")
+        idir = fs.ilistdir("/")
         print(any(idir))
 
         # Alternate way of partially iterating the ilistdir object, modifying the
         # filesystem while it's open.
-        for dname, *_ in vfs.ilistdir("/"):
-            vfs.rmdir(dname)
+        for dname, *_ in fs.ilistdir("/"):
+            fs.rmdir(dname)
             break
-        vfs.mkdir(dname)
+        fs.mkdir(dname)
 
         # Also create a fully drained iterator and ensure trying to reuse it
         # throws the correct exception.
-        idir_emptied = vfs.ilistdir("/")
+        idir_emptied = fs.ilistdir("/")
         l = list(idir_emptied)
         print(len(l))
         try:
@@ -68,8 +68,8 @@ def test(bdev, vfs_class):
             pass
 
         gc.collect()
-        vfs.open("/test", "w").close()
+        fs.open("/test", "w").close()
 
 
 bdev = RAMBlockDevice(30)
-test(bdev, os.VfsLfs2)
+test(bdev, vfs.VfsLfs2)

--- a/tests/extmod/vfs_lfs_mount.py
+++ b/tests/extmod/vfs_lfs_mount.py
@@ -1,10 +1,10 @@
 # Test for VfsLittle using a RAM device, with mount/umount
 
 try:
-    import os
+    import os, vfs
 
-    os.VfsLfs1
-    os.VfsLfs2
+    vfs.VfsLfs1
+    vfs.VfsLfs2
 except (ImportError, AttributeError):
     print("SKIP")
     raise SystemExit
@@ -42,7 +42,7 @@ def test(vfs_class):
 
     # mount bdev unformatted
     try:
-        os.mount(bdev, "/lfs")
+        vfs.mount(bdev, "/lfs")
     except Exception as er:
         print(repr(er))
 
@@ -50,10 +50,10 @@ def test(vfs_class):
     vfs_class.mkfs(bdev)
 
     # construction
-    vfs = vfs_class(bdev)
+    fs = vfs_class(bdev)
 
     # mount
-    os.mount(vfs, "/lfs")
+    vfs.mount(fs, "/lfs")
 
     # import
     with open("/lfs/lfsmod.py", "w") as f:
@@ -73,11 +73,11 @@ def test(vfs_class):
     import lfsmod2
 
     # umount
-    os.umount("/lfs")
+    vfs.umount("/lfs")
 
     # mount read-only
-    vfs = vfs_class(bdev)
-    os.mount(vfs, "/lfs", readonly=True)
+    fs = vfs_class(bdev)
+    vfs.mount(fs, "/lfs", readonly=True)
 
     # test reading works
     with open("/lfs/subdir/lfsmod2.py") as f:
@@ -90,13 +90,13 @@ def test(vfs_class):
         print(repr(er))
 
     # umount
-    os.umount("/lfs")
+    vfs.umount("/lfs")
 
     # mount bdev again
-    os.mount(bdev, "/lfs")
+    vfs.mount(bdev, "/lfs")
 
     # umount
-    os.umount("/lfs")
+    vfs.umount("/lfs")
 
     # clear imported modules
     sys.modules.clear()
@@ -110,5 +110,5 @@ sys.path.append("/lfs")
 sys.path.append("")
 
 # run tests
-test(os.VfsLfs1)
-test(os.VfsLfs2)
+test(vfs.VfsLfs1)
+test(vfs.VfsLfs2)

--- a/tests/extmod/vfs_lfs_mtime.py
+++ b/tests/extmod/vfs_lfs_mtime.py
@@ -1,11 +1,11 @@
 # Test for VfsLfs using a RAM device, mtime feature
 
 try:
-    import time, os
+    import time, vfs
 
     time.time
     time.sleep
-    os.VfsLfs2
+    vfs.VfsLfs2
 except (ImportError, AttributeError):
     print("SKIP")
     raise SystemExit
@@ -44,21 +44,21 @@ def test(bdev, vfs_class):
 
     # construction
     print("mtime=True")
-    vfs = vfs_class(bdev, mtime=True)
+    fs = vfs_class(bdev, mtime=True)
 
     # Create an empty file, should have a timestamp.
     current_time = int(time.time())
-    vfs.open("test1", "wt").close()
+    fs.open("test1", "wt").close()
 
     # Wait 1 second so mtime will increase by at least 1.
     time.sleep(1)
 
     # Create another empty file, should have a timestamp.
-    vfs.open("test2", "wt").close()
+    fs.open("test2", "wt").close()
 
     # Stat the files and check mtime is non-zero.
-    stat1 = vfs.stat("test1")
-    stat2 = vfs.stat("test2")
+    stat1 = fs.stat("test1")
+    stat2 = fs.stat("test2")
     print(stat1[8] != 0, stat2[8] != 0)
 
     # Check that test1 has mtime which matches time.time() at point of creation.
@@ -71,34 +71,34 @@ def test(bdev, vfs_class):
     time.sleep(1)
 
     # Open test1 for reading and ensure mtime did not change.
-    vfs.open("test1", "rt").close()
-    print(vfs.stat("test1") == stat1)
+    fs.open("test1", "rt").close()
+    print(fs.stat("test1") == stat1)
 
     # Open test1 for writing and ensure mtime increased from the previous value.
-    vfs.open("test1", "wt").close()
+    fs.open("test1", "wt").close()
     stat1_old = stat1
-    stat1 = vfs.stat("test1")
+    stat1 = fs.stat("test1")
     print(stat1_old[8] < stat1[8])
 
     # Unmount.
-    vfs.umount()
+    fs.umount()
 
     # Check that remounting with mtime=False can read the timestamps.
     print("mtime=False")
-    vfs = vfs_class(bdev, mtime=False)
-    print(vfs.stat("test1") == stat1)
-    print(vfs.stat("test2") == stat2)
-    f = vfs.open("test1", "wt")
+    fs = vfs_class(bdev, mtime=False)
+    print(fs.stat("test1") == stat1)
+    print(fs.stat("test2") == stat2)
+    f = fs.open("test1", "wt")
     f.close()
-    print(vfs.stat("test1") == stat1)
-    vfs.umount()
+    print(fs.stat("test1") == stat1)
+    fs.umount()
 
     # Check that remounting with mtime=True still has the timestamps.
     print("mtime=True")
-    vfs = vfs_class(bdev, mtime=True)
-    print(vfs.stat("test1") == stat1)
-    print(vfs.stat("test2") == stat2)
-    vfs.umount()
+    fs = vfs_class(bdev, mtime=True)
+    print(fs.stat("test1") == stat1)
+    print(fs.stat("test2") == stat2)
+    fs.umount()
 
 
 try:
@@ -107,4 +107,4 @@ except MemoryError:
     print("SKIP")
     raise SystemExit
 
-test(bdev, os.VfsLfs2)
+test(bdev, vfs.VfsLfs2)

--- a/tests/extmod/vfs_lfs_superblock.py
+++ b/tests/extmod/vfs_lfs_superblock.py
@@ -1,9 +1,9 @@
 # Test for VfsLfs using a RAM device, when the first superblock does not exist
 
 try:
-    import os
+    import os, vfs
 
-    os.VfsLfs2
+    vfs.VfsLfs2
 except (ImportError, AttributeError):
     print("SKIP")
     raise SystemExit
@@ -36,12 +36,12 @@ lfs2_data = b"\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\x
 bdev = RAMBlockDevice(64, lfs2_data)
 
 # Create the VFS explicitly, no auto-detection is needed for this.
-vfs = os.VfsLfs2(bdev)
-print(list(vfs.ilistdir()))
+fs = vfs.VfsLfs2(bdev)
+print(list(fs.ilistdir()))
 
 # Mount the block device directly; this relies on auto-detection.
-os.mount(bdev, "/userfs")
+vfs.mount(bdev, "/userfs")
 print(os.listdir("/userfs"))
 
 # Clean up.
-os.umount("/userfs")
+vfs.umount("/userfs")

--- a/tests/extmod/vfs_posix.py
+++ b/tests/extmod/vfs_posix.py
@@ -1,10 +1,9 @@
 # Test for VfsPosix
 
 try:
-    import gc
-    import os
+    import gc, os, vfs
 
-    os.VfsPosix
+    vfs.VfsPosix
 except (ImportError, AttributeError):
     print("SKIP")
     raise SystemExit
@@ -13,8 +12,6 @@ except (ImportError, AttributeError):
 # Skip the test if it does exist.
 temp_dir = "micropy_test_dir"
 try:
-    import os
-
     os.stat(temp_dir)
     print("SKIP")
     raise SystemExit
@@ -87,35 +84,35 @@ os.rename(temp_dir + "/test", temp_dir + "/test2")
 print(os.listdir(temp_dir))
 
 # construct new VfsPosix with path argument
-vfs = os.VfsPosix(temp_dir)
-# when VfsPosix is used the intended way via os.mount(), it can only be called
+fs = vfs.VfsPosix(temp_dir)
+# when VfsPosix is used the intended way via vfs.mount(), it can only be called
 # with relative paths when the CWD is inside or at its root, so simulate that
 os.chdir(temp_dir)
-print(list(i[0] for i in vfs.ilistdir(".")))
+print(list(i[0] for i in fs.ilistdir(".")))
 
 # stat, statvfs (statvfs may not exist)
-print(type(vfs.stat(".")))
-if hasattr(vfs, "statvfs"):
-    assert type(vfs.statvfs(".")) is tuple
+print(type(fs.stat(".")))
+if hasattr(fs, "statvfs"):
+    assert type(fs.statvfs(".")) is tuple
 
 # check types of ilistdir with str/bytes arguments
-print(type(list(vfs.ilistdir("."))[0][0]))
-print(type(list(vfs.ilistdir(b"."))[0][0]))
+print(type(list(fs.ilistdir("."))[0][0]))
+print(type(list(fs.ilistdir(b"."))[0][0]))
 
 # chdir should not affect absolute paths (regression test)
-vfs.mkdir("/subdir")
-vfs.mkdir("/subdir/micropy_test_dir")
-with vfs.open("/subdir/micropy_test_dir/test2", "w") as f:
+fs.mkdir("/subdir")
+fs.mkdir("/subdir/micropy_test_dir")
+with fs.open("/subdir/micropy_test_dir/test2", "w") as f:
     f.write("wrong")
-vfs.chdir("/subdir")
-with vfs.open("/test2", "r") as f:
+fs.chdir("/subdir")
+with fs.open("/test2", "r") as f:
     print(f.read())
 os.chdir(curdir)
-vfs.remove("/subdir/micropy_test_dir/test2")
-vfs.rmdir("/subdir/micropy_test_dir")
-vfs.rmdir("/subdir")
+fs.remove("/subdir/micropy_test_dir/test2")
+fs.rmdir("/subdir/micropy_test_dir")
+fs.rmdir("/subdir")
 
-# done with vfs, restore CWD
+# done with fs, restore CWD
 os.chdir(curdir)
 
 # remove

--- a/tests/extmod/vfs_posix_enoent.py
+++ b/tests/extmod/vfs_posix_enoent.py
@@ -1,10 +1,9 @@
 # Test for VfsPosix error conditions
 
 try:
-    import os
-    import sys
+    import os, sys, vfs
 
-    os.VfsPosix
+    vfs.VfsPosix
 except (ImportError, AttributeError):
     print("SKIP")
     raise SystemExit
@@ -36,7 +35,7 @@ except OSError as e:
     print("getcwd():", repr(e))
 
 try:
-    print("VfsPosix():", os.VfsPosix("something"))
+    print("VfsPosix():", vfs.VfsPosix("something"))
 except OSError as e:
     # expecting ENOENT = 2
     print("VfsPosix():", repr(e))

--- a/tests/extmod/vfs_posix_ilistdir_del.py
+++ b/tests/extmod/vfs_posix_ilistdir_del.py
@@ -2,9 +2,9 @@
 import gc
 
 try:
-    import os
+    import os, vfs
 
-    os.VfsPosix
+    vfs.VfsPosix
 except (ImportError, AttributeError):
     print("SKIP")
     raise SystemExit
@@ -12,34 +12,34 @@ except (ImportError, AttributeError):
 
 def test(testdir):
     curdir = os.getcwd()
-    vfs = os.VfsPosix(testdir)
-    # When VfsPosix is used the intended way via os.mount(), it can only be called
+    fs = vfs.VfsPosix(testdir)
+    # When VfsPosix is used the intended way via vfs.mount(), it can only be called
     # with relative paths when the CWD is inside or at its root, so simulate that.
     # (Although perhaps calling with a relative path was an oversight in this case
-    # and the respective line below was meant to read `vfs.rmdir("/" + dname)`.)
+    # and the respective line below was meant to read `fs.rmdir("/" + dname)`.)
     os.chdir(testdir)
-    vfs.mkdir("/test_d1")
-    vfs.mkdir("/test_d2")
-    vfs.mkdir("/test_d3")
+    fs.mkdir("/test_d1")
+    fs.mkdir("/test_d2")
+    fs.mkdir("/test_d3")
 
     for i in range(10):
         print(i)
 
         # We want to partially iterate the ilistdir iterator to leave it in an
         # open state, which will then test the finaliser when it's garbage collected.
-        idir = vfs.ilistdir("/")
+        idir = fs.ilistdir("/")
         print(any(idir))
 
         # Alternate way of partially iterating the ilistdir object, modifying the
         # filesystem while it's open.
-        for dname, *_ in vfs.ilistdir("/"):
-            vfs.rmdir(dname)
+        for dname, *_ in fs.ilistdir("/"):
+            fs.rmdir(dname)
             break
-        vfs.mkdir(dname)
+        fs.mkdir(dname)
 
         # Also create a fully drained iterator and ensure trying to reuse it
         # throws the correct exception.
-        idir_emptied = vfs.ilistdir("/")
+        idir_emptied = fs.ilistdir("/")
         l = list(idir_emptied)
         print(len(l))
         try:
@@ -51,10 +51,10 @@ def test(testdir):
 
         # Create and delete a file, try to flush out any filesystem
         # corruption that may be caused over the loops.
-        vfs.open("/test", "w").close()
-        vfs.remove("/test")
+        fs.open("/test", "w").close()
+        fs.remove("/test")
 
-    # Done with vfs, restore CWD.
+    # Done with fs, restore CWD.
     os.chdir(curdir)
 
 

--- a/tests/extmod/vfs_posix_ilistdir_filter.py
+++ b/tests/extmod/vfs_posix_ilistdir_filter.py
@@ -1,9 +1,9 @@
 # Test ilistdir filter of . and .. for VfsPosix.
 
 try:
-    import os
+    import os, vfs
 
-    os.VfsPosix
+    vfs.VfsPosix
 except (ImportError, AttributeError):
     print("SKIP")
     raise SystemExit
@@ -11,24 +11,24 @@ except (ImportError, AttributeError):
 
 def test(testdir):
     curdir = os.getcwd()
-    vfs = os.VfsPosix(testdir)
-    # When VfsPosix is used the intended way via os.mount(), it can only be called
+    fs = vfs.VfsPosix(testdir)
+    # When VfsPosix is used the intended way via vfs.mount(), it can only be called
     # with relative paths when the CWD is inside or at its root, so simulate that.
     os.chdir(testdir)
 
     dirs = [".a", "..a", "...a", "a.b", "a..b"]
 
     for dir in dirs:
-        vfs.mkdir(dir)
+        fs.mkdir(dir)
 
     dirs = []
-    for entry in vfs.ilistdir("/"):
+    for entry in fs.ilistdir("/"):
         dirs.append(entry[0])
     dirs.sort()
 
     print(dirs)
 
-    # Done with vfs, restore CWD.
+    # Done with fs, restore CWD.
     os.chdir(curdir)
 
 

--- a/tests/extmod/vfs_posix_paths.py
+++ b/tests/extmod/vfs_posix_paths.py
@@ -1,9 +1,9 @@
 # Test for VfsPosix with relative paths
 
 try:
-    import os
+    import os, vfs
 
-    os.VfsPosix
+    vfs.VfsPosix
 except (ImportError, AttributeError):
     print("SKIP")
     raise SystemExit
@@ -12,8 +12,6 @@ except (ImportError, AttributeError):
 # Skip the test if it does exist.
 temp_dir = "vfs_posix_paths_test_dir"
 try:
-    import os
-
     os.stat(temp_dir)
     print("SKIP")
     raise SystemExit
@@ -25,26 +23,26 @@ os.mkdir(temp_dir)
 
 # construct new VfsPosix with absolute path argument
 temp_dir_abs = os.getcwd() + os.sep + temp_dir
-vfs = os.VfsPosix(temp_dir_abs)
-# when VfsPosix is used the intended way via os.mount(), it can only be called
+fs = vfs.VfsPosix(temp_dir_abs)
+# when VfsPosix is used the intended way via vfs.mount(), it can only be called
 # with relative paths when the CWD is inside or at its root, so simulate that
 os.chdir(temp_dir_abs)
-vfs.mkdir("subdir")
-vfs.mkdir("subdir/one")
-print('listdir("/"):', sorted(i[0] for i in vfs.ilistdir("/")))
-print('listdir("."):', sorted(i[0] for i in vfs.ilistdir(".")))
-print('getcwd() in {"", "/"}:', vfs.getcwd() in {"", "/"})
-print('chdir("subdir"):', vfs.chdir("subdir"))
-print("getcwd():", vfs.getcwd())
-print('mkdir("two"):', vfs.mkdir("two"))
-f = vfs.open("file.py", "w")
+fs.mkdir("subdir")
+fs.mkdir("subdir/one")
+print('listdir("/"):', sorted(i[0] for i in fs.ilistdir("/")))
+print('listdir("."):', sorted(i[0] for i in fs.ilistdir(".")))
+print('getcwd() in {"", "/"}:', fs.getcwd() in {"", "/"})
+print('chdir("subdir"):', fs.chdir("subdir"))
+print("getcwd():", fs.getcwd())
+print('mkdir("two"):', fs.mkdir("two"))
+f = fs.open("file.py", "w")
 f.write("print('hello')")
 f.close()
-print('listdir("/"):', sorted(i[0] for i in vfs.ilistdir("/")))
-print('listdir("/subdir"):', sorted(i[0] for i in vfs.ilistdir("/subdir")))
-print('listdir("."):', sorted(i[0] for i in vfs.ilistdir(".")))
+print('listdir("/"):', sorted(i[0] for i in fs.ilistdir("/")))
+print('listdir("/subdir"):', sorted(i[0] for i in fs.ilistdir("/subdir")))
+print('listdir("."):', sorted(i[0] for i in fs.ilistdir(".")))
 try:
-    f = vfs.open("/subdir/file.py", "r")
+    f = fs.open("/subdir/file.py", "r")
     print(f.read())
     f.close()
 except Exception as e:
@@ -59,17 +57,17 @@ try:
 except Exception as e:
     print(e)
 del sys.path[0]
-vfs.remove("file.py")
-vfs.rmdir("two")
-vfs.rmdir("/subdir/one")
-vfs.chdir("/")
-vfs.rmdir("/subdir")
+fs.remove("file.py")
+fs.rmdir("two")
+fs.rmdir("/subdir/one")
+fs.chdir("/")
+fs.rmdir("/subdir")
 
-# done with vfs, restore CWD
+# done with fs, restore CWD
 os.chdir(curdir)
 
 # some integration tests with a mounted VFS
-os.mount(os.VfsPosix(temp_dir_abs), "/mnt")
+vfs.mount(vfs.VfsPosix(temp_dir_abs), "/mnt")
 os.mkdir("/mnt/dir")
 print('chdir("/mnt/dir"):', os.chdir("/mnt/dir"))
 print("getcwd():", os.getcwd())
@@ -82,7 +80,7 @@ print("getcwd():", os.getcwd())
 print('chdir(".."):', os.chdir(".."))
 print("getcwd():", os.getcwd())
 os.rmdir("/mnt/dir")
-os.umount("/mnt")
+vfs.umount("/mnt")
 
 # restore CWD
 os.chdir(curdir)

--- a/tests/extmod/vfs_userfs.py
+++ b/tests/extmod/vfs_userfs.py
@@ -4,12 +4,9 @@
 import sys
 
 try:
-    import io
+    import io, vfs
 
     io.IOBase
-    import os
-
-    os.mount
 except (ImportError, AttributeError):
     print("SKIP")
     raise SystemExit
@@ -79,7 +76,7 @@ user_files = {
     "/usermod5.py": b"print('in usermod5')",
     "/usermod6.py": b"print('in usermod6')",
 }
-os.mount(UserFS(user_files), "/userfs")
+vfs.mount(UserFS(user_files), "/userfs")
 
 # open and read a file
 f = open("/userfs/data.txt")
@@ -110,5 +107,5 @@ UserFile.buffer_size = 1024
 import usermod6
 
 # unmount and undo path addition
-os.umount("/userfs")
+vfs.umount("/userfs")
 sys.path.pop()

--- a/tests/micropython/builtin_execfile.py
+++ b/tests/micropython/builtin_execfile.py
@@ -1,11 +1,10 @@
 # Test builtin execfile function using VFS.
 
 try:
-    import io, os
+    import io, os, vfs
 
     execfile
     io.IOBase
-    os.mount
 except (ImportError, NameError, AttributeError):
     print("SKIP")
     raise SystemExit
@@ -44,25 +43,21 @@ class Filesystem:
 
 # First umount any existing mount points the target may have.
 try:
-    import io, os
-
-    os.umount("/")
+    vfs.umount("/")
 except OSError:
     pass
 for path in os.listdir("/"):
-    os.umount("/" + path)
+    vfs.umount("/" + path)
 
 # Create and mount the VFS object.
 files = {
     "/test.py": "print(123)",
 }
 fs = Filesystem(files)
-os.mount(fs, "/test_mnt")
+vfs.mount(fs, "/test_mnt")
 
 # Test execfile with a file that doesn't exist.
 try:
-    import io, os
-
     execfile("/test_mnt/noexist.py")
 except OSError:
     print("OSError")
@@ -77,4 +72,4 @@ except TypeError:
     print("TypeError")
 
 # Unmount the VFS object.
-os.umount(fs)
+vfs.umount(fs)

--- a/tests/micropython/import_mpy_invalid.py
+++ b/tests/micropython/import_mpy_invalid.py
@@ -1,10 +1,9 @@
 # test importing of invalid .mpy files
 
 try:
-    import sys, io, os
+    import sys, io, vfs
 
     io.IOBase
-    os.mount
 except (ImportError, AttributeError):
     print("SKIP")
     raise SystemExit
@@ -52,7 +51,7 @@ user_files = {
 }
 
 # create and mount a user filesystem
-os.mount(UserFS(user_files), "/userfs")
+vfs.mount(UserFS(user_files), "/userfs")
 sys.path.append("/userfs")
 
 # import .mpy files from the user filesystem
@@ -64,5 +63,5 @@ for i in range(len(user_files)):
         print(mod, "ValueError", er)
 
 # unmount and undo path addition
-os.umount("/userfs")
+vfs.umount("/userfs")
 sys.path.pop()

--- a/tests/micropython/import_mpy_native.py
+++ b/tests/micropython/import_mpy_native.py
@@ -1,11 +1,10 @@
 # test importing of .mpy files with native code
 
 try:
-    import sys, io, os
+    import sys, io, vfs
 
     sys.implementation._mpy
     io.IOBase
-    os.mount
 except (ImportError, AttributeError):
     print("SKIP")
     raise SystemExit
@@ -110,7 +109,7 @@ user_files = {
 # fmt: on
 
 # create and mount a user filesystem
-os.mount(UserFS(user_files), "/userfs")
+vfs.mount(UserFS(user_files), "/userfs")
 sys.path.append("/userfs")
 
 # import .mpy files from the user filesystem
@@ -123,5 +122,5 @@ for i in range(len(user_files)):
         print(mod, "ValueError", er)
 
 # unmount and undo path addition
-os.umount("/userfs")
+vfs.umount("/userfs")
 sys.path.pop()

--- a/tests/micropython/import_mpy_native_gc.py
+++ b/tests/micropython/import_mpy_native_gc.py
@@ -1,11 +1,10 @@
 # Test that native code loaded from a .mpy file is retained after a GC.
 
 try:
-    import gc, sys, io, os
+    import gc, sys, io, vfs
 
     sys.implementation._mpy
     io.IOBase
-    os.mount
 except (ImportError, AttributeError):
     print("SKIP")
     raise SystemExit
@@ -72,7 +71,7 @@ if sys_implementation_mpy not in features0_file_contents:
 user_files = {"/features0.mpy": features0_file_contents[sys_implementation_mpy]}
 
 # Create and mount a user filesystem.
-os.mount(UserFS(user_files), "/userfs")
+vfs.mount(UserFS(user_files), "/userfs")
 sys.path.append("/userfs")
 
 # Import the native function.
@@ -93,5 +92,5 @@ for i in range(1000):
 print(factorial(10))
 
 # Unmount and undo path addition.
-os.umount("/userfs")
+vfs.umount("/userfs")
 sys.path.pop()

--- a/tests/perf_bench/core_import_mpy_multi.py
+++ b/tests/perf_bench/core_import_mpy_multi.py
@@ -1,8 +1,8 @@
 # Test performance of importing an .mpy file many times.
 
-import sys, io, os
+import sys, io, vfs
 
-if not (hasattr(io, "IOBase") and hasattr(os, "mount")):
+if not hasattr(io, "IOBase"):
     print("SKIP")
     raise SystemExit
 
@@ -57,7 +57,7 @@ class FS:
 
 
 def mount():
-    os.mount(FS(), "/__remote")
+    vfs.mount(FS(), "/__remote")
     sys.path.insert(0, "/__remote")
 
 

--- a/tests/perf_bench/core_import_mpy_single.py
+++ b/tests/perf_bench/core_import_mpy_single.py
@@ -2,9 +2,9 @@
 # The first import of a module will intern strings that don't already exist, and
 # this test should be representative of what happens in a real application.
 
-import io, os, sys
+import sys, io, vfs
 
-if not (hasattr(io, "IOBase") and hasattr(os, "mount")):
+if not hasattr(io, "IOBase"):
     print("SKIP")
     raise SystemExit
 
@@ -112,7 +112,7 @@ class FS:
 
 
 def mount():
-    os.mount(FS(), "/__remote")
+    vfs.mount(FS(), "/__remote")
     sys.path.insert(0, "/__remote")
 
 

--- a/tests/ports/cc3200/os.py
+++ b/tests/ports/cc3200/os.py
@@ -3,7 +3,7 @@ os module test for the CC3200 based boards
 """
 
 from machine import SD
-import os
+import os, vfs
 
 mch = os.uname().machine
 if "LaunchPad" in mch:
@@ -15,7 +15,7 @@ else:
 
 sd = SD(pins=sd_pins)
 
-os.mount(sd, "/sd")
+vfs.mount(sd, "/sd")
 os.mkfs("/sd")
 os.chdir("/flash")
 print(os.listdir())
@@ -88,7 +88,7 @@ print(os.listdir("/"))
 os.unmount("/sd")
 print(os.listdir("/"))
 os.mkfs(sd)
-os.mount(sd, "/sd")
+vfs.mount(sd, "/sd")
 print(os.listdir("/"))
 os.chdir("/flash")
 
@@ -104,12 +104,12 @@ sd.init()
 print(os.listdir("/sd"))
 
 try:
-    os.mount(sd, "/sd")
+    vfs.mount(sd, "/sd")
 except:
     print("Exception")
 
 try:
-    os.mount(sd, "/sd2")
+    vfs.mount(sd, "/sd2")
 except:
     print("Exception")
 
@@ -159,6 +159,6 @@ try:
 except:
     print("Exception")
 
-os.mount(sd, "/sd")
+vfs.mount(sd, "/sd")
 print(os.listdir("/"))
 os.unmount("/sd")

--- a/tests/ports/unix/extra_coverage.py.exp
+++ b/tests/ports/unix/extra_coverage.py.exp
@@ -59,7 +59,7 @@ heapq           io              json            machine
 math            os              platform        random
 re              select          socket          struct
 sys             termios         time            tls
-uctypes         websocket
+uctypes         vfs             websocket
 me
 
 micropython     machine         math

--- a/tests/run-natmodtests.py
+++ b/tests/run-natmodtests.py
@@ -30,7 +30,7 @@ TEST_MAPPINGS = {
 
 # Code to allow a target MicroPython to import an .mpy from RAM
 injected_import_hook_code = """\
-import sys, os, io
+import sys, io, vfs
 class __File(io.IOBase):
   def __init__(self):
     self.off = 0
@@ -52,7 +52,7 @@ class __FS:
       raise OSError(-2) # ENOENT
   def open(self, path, mode):
     return __File()
-os.mount(__FS(), '/__remote')
+vfs.mount(__FS(), '/__remote')
 sys.path.insert(0, '/__remote')
 sys.modules['{}'] = __import__('__injected')
 """

--- a/tests/run-tests.py
+++ b/tests/run-tests.py
@@ -59,7 +59,7 @@ os.environ["PYTHONIOENCODING"] = "utf-8"
 
 # Code to allow a target MicroPython to import an .mpy from RAM
 injected_import_hook_code = """\
-import sys, os, io
+import sys, os, io, vfs
 class __File(io.IOBase):
   def __init__(self):
     self.off = 0
@@ -83,7 +83,7 @@ class __FS:
       raise OSError(-2) # ENOENT
   def open(self, path, mode):
     return __File()
-os.mount(__FS(), '/__vfstest')
+vfs.mount(__FS(), '/__vfstest')
 os.chdir('/__vfstest')
 __import__('__injected_test')
 """


### PR DESCRIPTION
This PR adds a new `vfs` module.  The following functions and classes have been placed in this new module:
- `vfs.mount()`
- `vfs.umount()`
- `vfs.VfsFat`
- `vfs.VfsLfs1`
- `vfs.VfsLfs2`
- `vfs.VfsPosix`

These are from the `os` module.  They are still available in the `os` module for now, but the intention is to deprecate the `os.mount` etc use and favour `vfs.mount` instead.  Then eventually these functions/classes will be removed from the `os` module.  This is to make the `os` module (eventually) strictly a subset of the CPython `os` module.

Docs, test and ports have all been updated to use `vfs` instead of `os` in the appropriate places.

TODO:
- [x] Decide whether/when to update `pyboard.py` and `mpremote` to use `vfs` instead of `os`.  That will make these tools not work with older versions of MicroPython firmware (one will need to use older versions of `mpremote`, which is easy to do with `pip`).