### PR TITLE
tools\mpremote\mpremote\transport_serial.py: Fix encoding error in PyboardCommand class.

### DIFF
--- a/tools/mpremote/mpremote/transport_serial.py
+++ b/tools/mpremote/mpremote/transport_serial.py
@@ -795,7 +795,7 @@ class PyboardCommand:
         if n == 0:
             return ""
         else:
-            return str(self.fin.read(n), "utf8")
+            return str(self.fin.read(n), "utf8", errors="backslashreplace")
 
     def wr_s8(self, i):
         self.fout.write(struct.pack("<b", i))
@@ -925,7 +925,7 @@ class PyboardCommand:
         fd = self.rd_s8()
         buf = self.rd_bytes()
         if self.data_files[fd][1]:
-            buf = str(buf, "utf8")
+            buf = str(buf, "utf8", errors="backslashreplace")
         n = self.data_files[fd][0].write(buf)
         self.wr_s32(n)
         # self.log_cmd(f"write {fd} {len(buf)} -> {n}")


### PR DESCRIPTION
This is a fix for utf-8 decoding errors that are thrown when non-utf8 content is received. For instance during a reboot of an ESP8266 module.

The fix is to handle conversion errors by replacing illegal characters.
Note that these illegal characters most often occur during an MCU reboot sequence when the MCU is using baudrates different from115200

<details>
<summary>Error Details</summary>

```
11:52:31|INFO    |board_stubber        - Local directory C:\Users\josverl\AppData\Local\Temp\board_stubberagrvu06k is mounted at /remote
11:52:31|INFO    |board_stubber        - b' \r\npaste mode; Ctrl-C to cancel, Ctrl-D to finish\r\n=== A\x01'
11:52:31|WARNING |board_stubber        - Traceback (most recent call last):

11:52:31|WARNING |board_stubber        -   File "C:\develop\MyPython\micropython-stubber\.venv\Lib\site-packages\mpremote\main.py", line 502, in main

11:52:31|WARNING |board_stubber        -     handler_func(state, args)

11:52:31|WARNING |board_stubber        -   File "C:\develop\MyPython\micropython-stubber\.venv\Lib\site-packages\mpremote\commands.py", line 203, in do_exec

11:52:31|WARNING |board_stubber        -     _do_execbuffer(state, args.expr[0], args.follow)

11:52:31|WARNING |board_stubber        -   File "C:\develop\MyPython\micropython-stubber\.venv\Lib\site-packages\mpremote\commands.py", line 191, in _do_execbuffer

11:52:31|WARNING |board_stubber        -     ret, ret_err = state.pyb.follow(timeout=None, data_consumer=pyboard.stdout_write_bytes)

11:52:31|WARNING |board_stubber        -                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

11:52:31|WARNING |board_stubber        -   File "C:\develop\MyPython\micropython-stubber\.venv\Lib\site-packages\mpremote\pyboard.py", line 388, in follow

11:52:31|WARNING |board_stubber        -     data = self.read_until(1, b"\x04", timeout=timeout, data_consumer=data_consumer)

11:52:31|WARNING |board_stubber        -            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

11:52:31|WARNING |board_stubber        -   File "C:\develop\MyPython\micropython-stubber\.venv\Lib\site-packages\mpremote\pyboard.py", line 333, in read_until

11:52:31|WARNING |board_stubber        -     elif self.serial.inWaiting() > 0:

11:52:31|WARNING |board_stubber        -          ^^^^^^^^^^^^^^^^^^^^^^^

11:52:31|WARNING |board_stubber        -   File "C:\develop\MyPython\micropython-stubber\.venv\Lib\site-packages\mpremote\pyboardextended.py", line 608, in inWaiting

11:52:31|WARNING |board_stubber        -     self._check_input(False)

11:52:31|WARNING |board_stubber        -   File "C:\develop\MyPython\micropython-stubber\.venv\Lib\site-packages\mpremote\pyboardextended.py", line 589, in _check_input

11:52:31|WARNING |board_stubber        -     PyboardCommand.cmd_table[c](self.cmd)

11:52:31|WARNING |board_stubber        -   File "C:\develop\MyPython\micropython-stubber\.venv\Lib\site-packages\mpremote\pyboardextended.py", line 420, in do_stat

11:52:31|WARNING |board_stubber        -     path = self.root + self.rd_str()

11:52:31|WARNING |board_stubber        -                        ^^^^^^^^^^^^^

11:52:31|WARNING |board_stubber        -   File "C:\develop\MyPython\micropython-stubber\.venv\Lib\site-packages\mpremote\pyboardextended.py", line 386, in rd_str

11:52:31|WARNING |board_stubber        -     return str(self.fin.read(n), "utf8")

11:52:31|WARNING |board_stubber        -            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

11:52:31|WARNING |board_stubber        - UnicodeDecodeError: 'utf-8' codec can't decode byte 0xff in position 9: invalid start byte

11:52:31|WARNING |board_stubber        -

11:52:31|WARNING |board_stubber        - During handling of the above exception, another exception occurred:

11:52:31|WARNING |board_stubber        -

11:52:31|WARNING |board_stubber        - Traceback (most recent call last):

11:52:31|WARNING |board_stubber        -   File "<frozen runpy>", line 198, in _run_module_as_main

11:52:31|WARNING |board_stubber        -   File "<frozen runpy>", line 88, in _run_code

11:52:31|WARNING |board_stubber        -   File "C:\develop\MyPython\micropython-stubber\.venv\Lib\site-packages\mpremote\__main__.py", line 6, in <module>

11:52:31|WARNING |board_stubber        -     sys.exit(main.main())

11:52:31|WARNING |board_stubber        -              ^^^^^^^^^^^

11:52:31|WARNING |board_stubber        -   File "C:\develop\MyPython\micropython-stubber\.venv\Lib\site-packages\mpremote\main.py", line 517, in main

11:52:31|WARNING |board_stubber        -     do_disconnect(state)

11:52:31|WARNING |board_stubber        -   File "C:\develop\MyPython\micropython-stubber\.venv\Lib\site-packages\mpremote\commands.py", line 76, in do_disconnect

11:52:31|WARNING |board_stubber        -     state.pyb.umount_local()

11:52:31|WARNING |board_stubber        -   File "C:\develop\MyPython\micropython-stubber\.venv\Lib\site-packages\mpremote\pyboardextended.py", line 724, in umount_local

11:52:31|WARNING |board_stubber        -     self.exec_('uos.umount("/remote")')

11:52:31|WARNING |board_stubber        -   File "C:\develop\MyPython\micropython-stubber\.venv\Lib\site-packages\mpremote\pyboard.py", line 494, in exec_

11:52:31|WARNING |board_stubber        -     ret, ret_err = self.exec_raw(command, data_consumer=data_consumer)

11:52:31|WARNING |board_stubber        -                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

11:52:31|WARNING |board_stubber        -   File "C:\develop\MyPython\micropython-stubber\.venv\Lib\site-packages\mpremote\pyboard.py", line 479, in exec_raw

11:52:31|WARNING |board_stubber        -     self.exec_raw_no_follow(command)

11:52:31|WARNING |board_stubber        -   File "C:\develop\MyPython\micropython-stubber\.venv\Lib\site-packages\mpremote\pyboard.py", line 463, in exec_raw_no_follow

11:52:31|WARNING |board_stubber        -     raise PyboardError("could not enter raw repl")

11:52:31|WARNING |board_stubber        - mpremote.pyboard.PyboardError: could not enter raw repl

11:52:46|INFO    |board_stubber        - Resetting COM19 ESP module with ESP8266
11:52:48|INFO    |board_stubber        - Running createstubs db on COM19 ESP module with ESP8266 using temp path: C:\Users\josverl\AppData\Local\Temp\board_stubberagrvu06k
`

</details>




Signed-off-by: Jos Verlinde <jos_verlinde@hotmail.com>