### PR TITLE
stm32/Makefile: Ignore uninitialised variable warning in H5 HAL SD code.

### DIFF
--- a/ports/stm32/Makefile
+++ b/ports/stm32/Makefile
@@ -338,6 +338,10 @@ HAL_SRC_C += $(addprefix $(STM32LIB_HAL_BASE)/Src/stm32$(MCU_SERIES)xx_,\
 	ll_sdmmc.c \
 	ll_fmc.c \
 	)
+ifeq ($(MCU_SERIES),$(filter $(MCU_SERIES),h5))
+# HAL H5-1.0.0 has a bug with uninitialised variable in HAL_SD_ConfigWideBusOperation.
+$(BUILD)/$(STM32LIB_HAL_BASE)/Src/stm32$(MCU_SERIES)xx_hal_sd.o: CFLAGS += -Wno-error=maybe-uninitialized
+endif
 endif
 
 ifeq ($(MCU_SERIES),$(filter $(MCU_SERIES),f4 f7 h7))


### PR DESCRIPTION
This warning appears when using an MCU like H562 that only has one SDMMC.