### PR TITLE
stm32/spi.c: Use non-DMA transfer for STM32F7 MCUs.

### DIFF
--- a/ports/stm32/spi.c
+++ b/ports/stm32/spi.c
@@ -635,7 +635,11 @@ void spi_transfer(const spi_t *self, size_t len, const uint8_t *src, uint8_t *de
         }
     } else {
         // send and receive
-        if (len == 1 || query_irq() == IRQ_STATE_DISABLED) {
+        if (len == 1 || query_irq() == IRQ_STATE_DISABLED
+            #if defined(STM32F7)
+            || src == dest
+            #endif
+            ) {
             status = HAL_SPI_TransmitReceive(self->spi, (uint8_t *)src, dest, len, timeout);
         } else {
             DMA_HandleTypeDef tx_dma, rx_dma;


### PR DESCRIPTION
This is a different patch for issue #13471, changing spi.c. For STM32F7xx MCUs it does not use DMA when source and destination address are identical. 

The reason issue #13471 is yet not found. The code seems to set up DMA properly, and sometimes it even works.