### PR TITLE
stm32/ethernet: A few improvements.

### DIFF
--- a/ports/stm32/Makefile
+++ b/ports/stm32/Makefile
@@ -251,6 +251,7 @@ SRC_C += \
 	pyb_can.c \
 	usb.c \
 	eth.c \
+	eth_phy.c \
 	gccollect.c \
 	help.c \
 	machine_bitstream.c \

--- a/ports/stm32/boards/ARDUINO_PORTENTA_H7/board_init.c
+++ b/ports/stm32/boards/ARDUINO_PORTENTA_H7/board_init.c
@@ -115,7 +115,7 @@ void PORTENTA_board_early_init(void) {
     mp_hal_pin_write(pyb_pin_ETH_RST, 1);
 
     // Put Eth in low-power mode
-    eth_init(&eth_instance, MP_HAL_MAC_ETH0);
+    eth_init(&eth_instance, MP_HAL_MAC_ETH0, 0);
     eth_low_power_mode(&eth_instance, true);
 
     #if MICROPY_HW_USB_HS_ULPI3320

--- a/ports/stm32/boards/ARDUINO_PORTENTA_H7/board_init.c
+++ b/ports/stm32/boards/ARDUINO_PORTENTA_H7/board_init.c
@@ -115,7 +115,7 @@ void PORTENTA_board_early_init(void) {
     mp_hal_pin_write(pyb_pin_ETH_RST, 1);
 
     // Put Eth in low-power mode
-    eth_init(&eth_instance, MP_HAL_MAC_ETH0, 0);
+    eth_init(&eth_instance, MP_HAL_MAC_ETH0, 0, ETH_PHY_LAN8742);
     eth_low_power_mode(&eth_instance, true);
 
     #if MICROPY_HW_USB_HS_ULPI3320

--- a/ports/stm32/eth.c
+++ b/ports/stm32/eth.c
@@ -246,19 +246,12 @@ static int eth_mac_init(eth_t *self) {
     #endif
     mpu_config_end(irq_state);
 
-    // Enable peripheral clock
+    // Set MAC to reset state
     #if defined(STM32H5)
-    __HAL_RCC_ETH_CLK_ENABLE();
-    __HAL_RCC_ETHTX_CLK_ENABLE();
-    __HAL_RCC_ETHRX_CLK_ENABLE();
     __HAL_RCC_ETH_FORCE_RESET();
     #elif defined(STM32H7)
-    __HAL_RCC_ETH1MAC_CLK_ENABLE();
-    __HAL_RCC_ETH1TX_CLK_ENABLE();
-    __HAL_RCC_ETH1RX_CLK_ENABLE();
     __HAL_RCC_ETH1MAC_FORCE_RESET();
     #else
-    __HAL_RCC_ETH_CLK_ENABLE();
     __HAL_RCC_ETHMAC_FORCE_RESET();
     #endif
 

--- a/ports/stm32/eth.h
+++ b/ports/stm32/eth.h
@@ -29,7 +29,7 @@
 typedef struct _eth_t eth_t;
 extern eth_t eth_instance;
 
-void eth_init(eth_t *self, int mac_idx);
+void eth_init(eth_t *self, int mac_idx, uint32_t phy_addr);
 void eth_set_trace(eth_t *self, uint32_t value);
 struct netif *eth_netif(eth_t *self);
 int eth_link_status(eth_t *self);

--- a/ports/stm32/eth_phy.c
+++ b/ports/stm32/eth_phy.c
@@ -4,6 +4,7 @@
  * The MIT License (MIT)
  *
  * Copyright (c) 2019 Damien P. George
+ * Copyright (c) 2024 Robert Hammelrath
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -23,25 +24,36 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-#ifndef MICROPY_INCLUDED_STM32_ETH_H
-#define MICROPY_INCLUDED_STM32_ETH_H
 
-enum {
-    ETH_PHY_LAN8742 = 0,
-    ETH_PHY_LAN8720,
-    ETH_PHY_DP83848,
-    ETH_PHY_DP83825
-};
+#include "py/mphal.h"
+#include "eth_phy.h"
 
-typedef struct _eth_t eth_t;
-extern eth_t eth_instance;
+#if defined(MICROPY_HW_ETH_MDC)
 
-int eth_init(eth_t *self, int mac_idx, uint32_t phy_addr, int phy_type);
-void eth_set_trace(eth_t *self, uint32_t value);
-struct netif *eth_netif(eth_t *self);
-int eth_link_status(eth_t *self);
-int eth_start(eth_t *self);
-int eth_stop(eth_t *self);
-void eth_low_power_mode(eth_t *self, bool enable);
+#define PHY_SCSR_LAN87XX                (0x001f)
+#define PHY_SCSR_LAN87XX_SPEED_Pos      (2)
+#define PHY_SCSR_LAN87XX_SPEED_Msk      (7)
 
-#endif // MICROPY_INCLUDED_STM32_ETH_H
+#define PHY_SCSR_DP838XX                (0x0010)
+#define PHY_RECR_DP838XX                (0x0015)
+#define PHY_SCSR_DP838XX_DUPLEX_Msk     (4)
+#define PHY_SCSR_DP838XX_10M_Msk        (2)
+
+int16_t eth_phy_lan87xx_get_link_status(uint32_t phy_addr) {
+    // Get the link mode & speed
+    int16_t scsr = eth_phy_read(phy_addr, PHY_SCSR_LAN87XX);
+    return (scsr >> PHY_SCSR_LAN87XX_SPEED_Pos) & PHY_SCSR_LAN87XX_SPEED_Msk;
+}
+
+int16_t eth_phy_dp838xx_get_link_status(uint32_t phy_addr) {
+    int16_t scsr = 0;
+    // Get the link mode & speed
+    uint16_t temp = eth_phy_read(phy_addr, PHY_SCSR_DP838XX);
+    scsr = (temp & PHY_SCSR_DP838XX_10M_Msk) ? PHY_SPEED_10HALF : PHY_SPEED_100HALF;
+    if (temp & PHY_SCSR_DP838XX_DUPLEX_Msk) {
+        scsr |= PHY_DUPLEX;
+    }
+    return scsr;
+}
+
+#endif

--- a/ports/stm32/eth_phy.h
+++ b/ports/stm32/eth_phy.h
@@ -4,6 +4,7 @@
  * The MIT License (MIT)
  *
  * Copyright (c) 2019 Damien P. George
+ * Copyright (c) 2024 Robert Hammelrath
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -23,25 +24,44 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-#ifndef MICROPY_INCLUDED_STM32_ETH_H
-#define MICROPY_INCLUDED_STM32_ETH_H
 
-enum {
-    ETH_PHY_LAN8742 = 0,
-    ETH_PHY_LAN8720,
-    ETH_PHY_DP83848,
-    ETH_PHY_DP83825
-};
+#ifndef MICROPY_INCLUDED_STM32_PHY_H
+#define MICROPY_INCLUDED_STM32_PYH_H
 
-typedef struct _eth_t eth_t;
-extern eth_t eth_instance;
+#if defined(MICROPY_HW_ETH_MDC)
 
-int eth_init(eth_t *self, int mac_idx, uint32_t phy_addr, int phy_type);
-void eth_set_trace(eth_t *self, uint32_t value);
-struct netif *eth_netif(eth_t *self);
-int eth_link_status(eth_t *self);
-int eth_start(eth_t *self);
-int eth_stop(eth_t *self);
-void eth_low_power_mode(eth_t *self, bool enable);
+// Common ETH PHY register definitions
+#undef PHY_BCR
+#define PHY_BCR                 (0x0000)
+#define PHY_BCR_SOFT_RESET      (0x8000)
+#define PHY_BCR_AUTONEG_EN      (0x1000)
+#define PHY_BCR_POWER_DOWN      (0x0800U)
 
-#endif // MICROPY_INCLUDED_STM32_ETH_H
+#undef PHY_BSR
+#define PHY_BSR                 (0x0001)
+#define PHY_BSR_LINK_STATUS     (0x0004)
+#define PHY_BSR_AUTONEG_DONE    (0x0020)
+
+#undef PHY_ANAR
+#define PHY_ANAR                (0x0004)
+#define PHY_ANAR_SPEED_10HALF   (0x0020)
+#define PHY_ANAR_SPEED_10FULL   (0x0040)
+#define PHY_ANAR_SPEED_100HALF  (0x0080)
+#define PHY_ANAR_SPEED_100FULL  (0x0100)
+#define PHY_ANAR_IEEE802_3      (0x0001)
+
+#define PHY_SPEED_10HALF   (1)
+#define PHY_SPEED_10FULL   (5)
+#define PHY_SPEED_100HALF  (2)
+#define PHY_SPEED_100FULL  (6)
+#define PHY_DUPLEX         (4)
+
+uint32_t eth_phy_read(uint32_t phy_addr, uint32_t reg);
+void eth_phy_write(uint32_t phy_addr, uint32_t reg, uint32_t val);
+
+int16_t eth_phy_lan87xx_get_link_status(uint32_t phy_addr);
+int16_t eth_phy_dp838xx_get_link_status(uint32_t phy_addr);
+
+#endif
+
+#endif  // MICROPY_INCLUDED_STM32_PHY_H

--- a/ports/stm32/network_lan.c
+++ b/ports/stm32/network_lan.c
@@ -53,10 +53,17 @@ static void network_lan_print(const mp_print_t *print, mp_obj_t self_in, mp_prin
         );
 }
 
-static mp_obj_t network_lan_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *args) {
-    mp_arg_check_num(n_args, n_kw, 0, 0, false);
+static mp_obj_t network_lan_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *all_args) {
+    enum { ARG_phy_addr};
+    static const mp_arg_t allowed_args[] = {
+        { MP_QSTR_phy_addr, MP_ARG_KW_ONLY | MP_ARG_INT, {.u_int = 0} },
+    };
+    // Parse args.
+    mp_arg_val_t args[MP_ARRAY_SIZE(allowed_args)];
+    mp_arg_parse_all_kw_array(n_args, n_kw, all_args, MP_ARRAY_SIZE(allowed_args), allowed_args, args);
+
     const network_lan_obj_t *self = &network_lan_eth0;
-    eth_init(self->eth, MP_HAL_MAC_ETH0);
+    eth_init(self->eth, MP_HAL_MAC_ETH0, args[ARG_phy_addr].u_int);
     return MP_OBJ_FROM_PTR(self);
 }
 

--- a/ports/stm32/network_lan.c
+++ b/ports/stm32/network_lan.c
@@ -54,16 +54,19 @@ static void network_lan_print(const mp_print_t *print, mp_obj_t self_in, mp_prin
 }
 
 static mp_obj_t network_lan_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *all_args) {
-    enum { ARG_phy_addr};
+    enum { ARG_phy_addr, ARG_phy_type};
     static const mp_arg_t allowed_args[] = {
         { MP_QSTR_phy_addr, MP_ARG_KW_ONLY | MP_ARG_INT, {.u_int = 0} },
+        { MP_QSTR_phy_type, MP_ARG_KW_ONLY | MP_ARG_INT, {.u_int = ETH_PHY_LAN8742} },
     };
     // Parse args.
     mp_arg_val_t args[MP_ARRAY_SIZE(allowed_args)];
     mp_arg_parse_all_kw_array(n_args, n_kw, all_args, MP_ARRAY_SIZE(allowed_args), allowed_args, args);
 
     const network_lan_obj_t *self = &network_lan_eth0;
-    eth_init(self->eth, MP_HAL_MAC_ETH0, args[ARG_phy_addr].u_int);
+    if (eth_init(self->eth, MP_HAL_MAC_ETH0, args[ARG_phy_addr].u_int, args[ARG_phy_type].u_int) != 0) {
+        mp_raise_ValueError(MP_ERROR_TEXT("invalid phy_type"));
+    }
     return MP_OBJ_FROM_PTR(self);
 }
 
@@ -162,6 +165,11 @@ static const mp_rom_map_elem_t network_lan_locals_dict_table[] = {
     { MP_ROM_QSTR(MP_QSTR_ifconfig), MP_ROM_PTR(&network_lan_ifconfig_obj) },
     { MP_ROM_QSTR(MP_QSTR_status), MP_ROM_PTR(&network_lan_status_obj) },
     { MP_ROM_QSTR(MP_QSTR_config), MP_ROM_PTR(&network_lan_config_obj) },
+
+    { MP_ROM_QSTR(MP_QSTR_PHY_LAN8742), MP_ROM_INT(ETH_PHY_LAN8742) },
+    { MP_ROM_QSTR(MP_QSTR_PHY_LAN8720), MP_ROM_INT(ETH_PHY_LAN8720) },
+    { MP_ROM_QSTR(MP_QSTR_PHY_DP83848), MP_ROM_INT(ETH_PHY_DP83848) },
+    { MP_ROM_QSTR(MP_QSTR_PHY_DP83825), MP_ROM_INT(ETH_PHY_DP83825) },
 };
 static MP_DEFINE_CONST_DICT(network_lan_locals_dict, network_lan_locals_dict_table);
 


### PR DESCRIPTION
- Set the output speed of RMII_TXD0 and RMII_TXD1 to medium. That matches better the frequency of the signals that may occur at these pins. For configurations with a high capacitive load at these pins medium driving speed may still be too low.
- Allow to set the address of the PHY in the LAN object constructor with the keyword argument  `phy_addr=x`, e.g. `lan = network.LAN(phy_addr=1`. The default value is 0, matching the current behavior.
- Remove some code duplication.
- Allow setting the type of the PHY with the keyword option `phy_type=<model>`. Supported model names are PHY_LAN8742, PHY_LAN8720 and PHY_DP83848. The default is PHY_LAN8742. Tested with a LAN8720 (=LAN8742) and DP83848 device.