### PR TITLE
extmod/btstack: Reset pending_value_handle before calling read-done cb.

### DIFF
--- a/extmod/btstack/modbluetooth_btstack.c
+++ b/extmod/btstack/modbluetooth_btstack.c
@@ -462,8 +462,9 @@ STATIC void btstack_packet_handler_read(uint8_t packet_type, uint16_t channel, u
         if (!conn) {
             return;
         }
-        mp_bluetooth_gattc_on_read_write_status(MP_BLUETOOTH_IRQ_GATTC_READ_DONE, conn_handle, conn->pending_value_handle, status);
+        uint16_t value_handle = conn->pending_value_handle;
         conn->pending_value_handle = 0xffff;
+        mp_bluetooth_gattc_on_read_write_status(MP_BLUETOOTH_IRQ_GATTC_READ_DONE, conn_handle, value_handle, status);
     } else if (event_type == GATT_EVENT_CHARACTERISTIC_VALUE_QUERY_RESULT) {
         DEBUG_printf("  --> gatt characteristic value query result\n");
         uint16_t conn_handle = gatt_event_characteristic_value_query_result_get_handle(packet);

--- a/tests/multi_bluetooth/ble_irq_calls.py.exp
+++ b/tests/multi_bluetooth/ble_irq_calls.py.exp
@@ -3,6 +3,7 @@ peripheral start
 _IRQ_CENTRAL_CONNECT
 _IRQ_MTU_EXCHANGED
 _IRQ_GATTS_READ_REQUEST
+_IRQ_GATTS_READ_REQUEST
 _IRQ_CENTRAL_DISCONNECT
 --- instance1 ---
 central start
@@ -24,6 +25,9 @@ CCCD write
 _IRQ_GATTC_WRITE_DONE
 CCCD write result: 0
 issue gattc_read
+_IRQ_GATTC_READ_RESULT
+gattc_read result: b''
+_IRQ_GATTC_READ_DONE
 _IRQ_GATTC_READ_RESULT
 gattc_read result: b''
 _IRQ_GATTC_READ_DONE


### PR DESCRIPTION
Fixes issue #13634.