### PR TITLE
esp32/network_ppp: Make PPP support optional.

### DIFF
--- a/ports/esp32/modnetwork_globals.h
+++ b/ports/esp32/modnetwork_globals.h
@@ -7,7 +7,9 @@
 #if MICROPY_PY_NETWORK_LAN
 { MP_ROM_QSTR(MP_QSTR_LAN), MP_ROM_PTR(&esp_network_get_lan_obj) },
 #endif
+#if defined(CONFIG_ESP_NETIF_TCPIP_LWIP) && defined(CONFIG_LWIP_PPP_SUPPORT)
 { MP_ROM_QSTR(MP_QSTR_PPP), MP_ROM_PTR(&esp_network_ppp_make_new_obj) },
+#endif
 { MP_ROM_QSTR(MP_QSTR_phy_mode), MP_ROM_PTR(&esp_network_phy_mode_obj) },
 
 #if MICROPY_PY_NETWORK_WLAN

--- a/ports/esp32/network_ppp.c
+++ b/ports/esp32/network_ppp.c
@@ -43,6 +43,8 @@
 #include "lwip/dns.h"
 #include "netif/ppp/pppapi.h"
 
+#if defined(CONFIG_ESP_NETIF_TCPIP_LWIP) && defined(CONFIG_LWIP_PPP_SUPPORT)
+
 #define PPP_CLOSE_TIMEOUT_MS (4000)
 
 typedef struct _ppp_if_obj_t {
@@ -341,3 +343,5 @@ MP_DEFINE_CONST_OBJ_TYPE(
     MP_TYPE_FLAG_NONE,
     locals_dict, &ppp_if_locals_dict
     );
+
+#endif

--- a/ports/esp32/ppp_set_auth.c
+++ b/ports/esp32/ppp_set_auth.c
@@ -9,7 +9,7 @@
 
 #include "ppp_set_auth.h"
 
-#ifdef CONFIG_ESP_NETIF_TCPIP_LWIP
+#if defined(CONFIG_ESP_NETIF_TCPIP_LWIP) && defined(CONFIG_LWIP_PPP_SUPPORT)
 
 #include "netif/ppp/pppapi.h"
 


### PR DESCRIPTION
PPP is not that commonly used, let it be turned off in the board config to save space.  It is still on by default.

On an basic ESP32-S3 build, turning off PPP with LWIP still on saves ~35 kB of codend 4 kB of data.

 ```
  text    data     bss     dec     hex filename
1321257  304296 2941433 4566986  45afca before-ppp-off.elf
1285101  299920 2810305 4395326  43113e after-ppp-off.elf
-------------------------------
-36156    -4376     -56
```

Note that the BSS segment size includes all NOBITS sections in ELF file. Some of these are aligned to 64kB chunk sized dummy blocks, I think for alignment to MMU boundaries, and these went down by 1 block each, so 128 kiB of BSS is not really part of the binary size reduction.