### PR TITLE
tools/manifestfile: Add --unix-ffi option.

### DIFF
--- a/tools/manifestfile.py
+++ b/tools/manifestfile.py
@@ -603,6 +603,9 @@ def main():
         default=os.path.join(os.path.dirname(__file__), "../lib/micropython-lib"),
         help="path to micropython-lib repo",
     )
+    cmd_parser.add_argument(
+        "--unix-ffi", action="store_true", help="prepend unix-ffi to the library path"
+    )
     cmd_parser.add_argument("--port", default=None, help="path to port dir")
     cmd_parser.add_argument("--board", default=None, help="path to board dir")
     cmd_parser.add_argument(
@@ -632,6 +635,8 @@ def main():
         exit(1)
 
     m = ManifestFile(mode, path_vars)
+    if args.unix_ffi:
+        m.add_library("unix-ffi", os.path.join("$(MPY_LIB_DIR)", "unix-ffi"), prepend=True)
     for manifest_file in args.files:
         try:
             m.execute(manifest_file)


### PR DESCRIPTION
Allows adding unix-ffi library from the command line, to fix micropython-lib builds.

Follow up to 35dd959133fb233d75e9b3cddbf98b2ed01c6594 from https://github.com/micropython/micropython/pull/13620

This doesn't expose the full `add_library()` function to the command line, as currently the only use case is unix-ffi libraries. The only "external" user of this tool is currently micropython-lib.

Before:

```
 python ../../tools/manifestfile.py --lib . --compile unix-ffi/email.message/manifest.py
Error in manifest file: /home/gus/ry/george/micropython/lib/micropython-lib/unix-ffi/email.message/manifest.py: Package 're' not found in any known library.
```

After:

```
❯ python ../../tools/manifestfile.py --unix-ffi --lib . --compile unix-ffi/email.message/manifest.py
version=0.5.3 description=None license=None author=None pypi=None pypi_publish=None
ManifestOutput(file_type=1, full_path='/home/gus/ry/george/micropython/lib/micropython-lib/unix-ffi/ffilib/ffilib.py', target_path='ffilib.py', timestamp=1676863157.6312485, kind=6, metadata=<__main__.ManifestPackageMetadata object at 0x7a8cd86d3a10>, opt=None)
ManifestOutput(file_type=1, full_path='/home/gus/ry/george/micropython/lib/micropython-lib/unix-ffi/re/re.py', target_path='re.py', timestamp=1707800376.548602, kind=6, metadata=<__main__.ManifestPackageMetadata object at 0x7a8cd86d3190>, opt=None)
ManifestOutput(file_type=1, full_path='/home/gus/ry/george/micropython/lib/micropython-lib/python-stdlib/binascii/binascii.py', target_path='binascii.py', timestamp=1676863157.6112483, kind=6, metadata=<__main__.ManifestPackageMetadata object at 0x7a8cd86dcc90>, opt=None)
ManifestOutput(file_type=1, full_path='/home/gus/ry/george/micropython/lib/micropython-lib/python-stdlib/os/os/__init__.py', target_path='os/__init__.py', timestamp=1677138094.1277487, kind=6, metadata=<__main__.ManifestPackageMetadata object at 0x7a8cd86de150>, opt=None)
ManifestOutput(file_type=1, full_path='/home/gus/ry/george/micropython/lib/micropython-lib/python-stdlib/os-path/os/path.py', target_path='os/path.py', timestamp=1707800376.548602, kind=6, metadata=<__main__.ManifestPackageMetadata object at 0x7a8cd86dc9d0>, opt=None)
ManifestOutput(file_type=1, full_path='/home/gus/ry/george/micropython/lib/micropython-lib/python-stdlib/uu/uu.py', target_path='uu.py', timestamp=1676863157.6245818, kind=6, metadata=<__main__.ManifestPackageMetadata object at 0x7a8cd86d3610>, opt=None)
ManifestOutput(file_type=1, full_path='/home/gus/ry/george/micropython/lib/micropython-lib/python-stdlib/struct/struct.py', target_path='struct.py', timestamp=1676863157.617915, kind=6, metadata=<__main__.ManifestPackageMetadata object at 0x7a8cd86dc910>, opt=None)
ManifestOutput(file_type=1, full_path='/home/gus/ry/george/micropython/lib/micropython-lib/python-stdlib/base64/base64.py', target_path='base64.py', timestamp=1707800376.545269, kind=6, metadata=<__main__.ManifestPackageMetadata object at 0x7a8cd86d3490>, opt=None)
ManifestOutput(file_type=1, full_path='/home/gus/ry/george/micropython/lib/micropython-lib/python-stdlib/random/random.py', target_path='random.py', timestamp=1676863157.617915, kind=6, metadata=<__main__.ManifestPackageMetadata object at 0x7a8cd86dc510>, opt=None)
ManifestOutput(file_type=1, full_path='/home/gus/ry/george/micropython/lib/micropython-lib/python-stdlib/datetime/datetime.py', target_path='datetime.py', timestamp=1700610061.7551172, kind=6, metadata=<__main__.ManifestPackageMetadata object at 0x7a8cd86dcbd0>, opt=None)
ManifestOutput(file_type=1, full_path='/home/gus/ry/george/micropython/lib/micropython-lib/python-stdlib/collections/collections/__init__.py', target_path='collections/__init__.py', timestamp=1677138094.1244152, kind=6, metadata=<__main__.ManifestPackageMetadata object at 0x7a8cd86dd7d0>, opt=None)
ManifestOutput(file_type=1, full_path='/home/gus/ry/george/micropython/lib/micropython-lib/python-stdlib/collections-defaultdict/collections/defaultdict.py', target_path='collections/defaultdict.py', timestamp=1677138094.1244152, kind=6, metadata=<__main__.ManifestPackageMetadata object at 0x7a8cd86dda50>, opt=None)
ManifestOutput(file_type=1, full_path='/home/gus/ry/george/micropython/lib/micropython-lib/unix-ffi/urllib.parse/urllib/parse.py', target_path='urllib/parse.py', timestamp=1680739294.753335, kind=6, metadata=<__main__.ManifestPackageMetadata object at 0x7a8cd86dc090>, opt=None)
ManifestOutput(file_type=1, full_path='/home/gus/ry/george/micropython/lib/micropython-lib/python-stdlib/warnings/warnings.py', target_path='warnings.py', timestamp=1676863157.6245818, kind=6, metadata=<__main__.ManifestPackageMetadata object at 0x7a8cd86dc950>, opt=None)
ManifestOutput(file_type=1, full_path='/home/gus/ry/george/micropython/lib/micropython-lib/python-stdlib/quopri/quopri.py', target_path='quopri.py', timestamp=1676863157.617915, kind=6, metadata=<__main__.ManifestPackageMetadata object at 0x7a8cd86dd290>, opt=None)
ManifestOutput(file_type=1, full_path='/home/gus/ry/george/micropython/lib/micropython-lib/python-stdlib/functools/functools.py', target_path='functools.py', timestamp=1676863157.6112483, kind=6, metadata=<__main__.ManifestPackageMetadata object at 0x7a8cd86dd590>, opt=None)
ManifestOutput(file_type=1, full_path='/home/gus/ry/george/micropython/lib/micropython-lib/python-stdlib/string/string.py', target_path='string.py', timestamp=1676863157.617915, kind=6, metadata=<__main__.ManifestPackageMetadata object at 0x7a8cd86df0d0>, opt=None)
ManifestOutput(file_type=1, full_path='/home/gus/ry/george/micropython/lib/micropython-lib/unix-ffi/email.encoders/email/quoprimime.py', target_path='email/quoprimime.py', timestamp=1677138094.1344154, kind=6, metadata=<__main__.ManifestPackageMetadata object at 0x7a8cd86dd150>, opt=None)
ManifestOutput(file_type=1, full_path='/home/gus/ry/george/micropython/lib/micropython-lib/unix-ffi/email.encoders/email/base64mime.py', target_path='email/base64mime.py', timestamp=1677138094.1344154, kind=6, metadata=<__main__.ManifestPackageMetadata object at 0x7a8cd86dd150>, opt=None)
ManifestOutput(file_type=1, full_path='/home/gus/ry/george/micropython/lib/micropython-lib/unix-ffi/email.encoders/email/encoders.py', target_path='email/encoders.py', timestamp=1677138094.1344154, kind=6, metadata=<__main__.ManifestPackageMetadata object at 0x7a8cd86dd150>, opt=None)
ManifestOutput(file_type=1, full_path='/home/gus/ry/george/micropython/lib/micropython-lib/unix-ffi/email.errors/email/errors.py', target_path='email/errors.py', timestamp=1677138094.1344154, kind=6, metadata=<__main__.ManifestPackageMetadata object at 0x7a8cd86dc3d0>, opt=None)
ManifestOutput(file_type=1, full_path='/home/gus/ry/george/micropython/lib/micropython-lib/unix-ffi/email.charset/email/charset.py', target_path='email/charset.py', timestamp=1677138094.1344154, kind=6, metadata=<__main__.ManifestPackageMetadata object at 0x7a8cd86dd8d0>, opt=None)
ManifestOutput(file_type=1, full_path='/home/gus/ry/george/micropython/lib/micropython-lib/unix-ffi/email.utils/email/utils.py', target_path='email/utils.py', timestamp=1680739294.753335, kind=6, metadata=<__main__.ManifestPackageMetadata object at 0x7a8cd86d28d0>, opt=None)
ManifestOutput(file_type=1, full_path='/home/gus/ry/george/micropython/lib/micropython-lib/unix-ffi/email.message/email/message.py', target_path='email/message.py', timestamp=1677138094.1377487, kind=6, metadata=<__main__.ManifestPackageMetadata object at 0x7a8cd86d1bd0>, opt=None)
ManifestOutput(file_type=1, full_path='/home/gus/ry/george/micropython/lib/micropython-lib/unix-ffi/email.message/email/iterators.py', target_path='email/iterators.py', timestamp=1677138094.1377487, kind=6, metadata=<__main__.ManifestPackageMetadata object at 0x7a8cd86d1bd0>, opt=None)
```

*This work was funded through GitHub Sponsors.*