### PR TITLE
esp32/mpnimbleport: Release the GIL while doing NimBLE port deinit.

### DIFF
--- a/ports/esp32/mpnimbleport.c
+++ b/ports/esp32/mpnimbleport.c
@@ -63,12 +63,21 @@ void mp_bluetooth_nimble_port_start(void) {
 void mp_bluetooth_nimble_port_shutdown(void) {
     DEBUG_printf("mp_bluetooth_nimble_port_shutdown\n");
 
+    #if MICROPY_PY_BLUETOOTH_USE_SYNC_EVENTS_WITH_INTERLOCK
+    // Release the GIL so any callbacks can run during the shutdown calls below.
+    MP_THREAD_GIL_EXIT();
+    #endif
+
     // Despite the name, these is an ESP32-specific (no other NimBLE ports have these functions).
     // Calls ble_hs_stop() and waits for stack shutdown.
     nimble_port_stop();
 
     // Shuts down the event queue.
     nimble_port_deinit();
+
+    #if MICROPY_PY_BLUETOOTH_USE_SYNC_EVENTS_WITH_INTERLOCK
+    MP_THREAD_GIL_ENTER();
+    #endif
 
     // Mark stack as shutdown.
     mp_bluetooth_nimble_ble_state = MP_BLUETOOTH_NIMBLE_BLE_STATE_OFF;


### PR DESCRIPTION
In case callbacks must run (eg a disconnect event happens during the deinit) and the GIL must be obtained to run the callback.

Fixes issue #12349.

TODO:
- [ ] maybe write a multitest for this case (soft reset while connected with IRQ handler active)