### PR TITLE
ports/stm32: Support remapping FMC memory banks.

### DIFF
--- a/ports/stm32/sdram.c
+++ b/ports/stm32/sdram.c
@@ -34,11 +34,19 @@
 #if defined(MICROPY_HW_FMC_SDCKE0) && defined(MICROPY_HW_FMC_SDNE0)
 #define FMC_SDRAM_BANK FMC_SDRAM_BANK1
 #define FMC_SDRAM_CMD_TARGET_BANK FMC_SDRAM_CMD_TARGET_BANK1
+#if MICROPY_HW_FMC_SWAP_BANKS
+#define SDRAM_START_ADDRESS 0x60000000
+#else
 #define SDRAM_START_ADDRESS 0xC0000000
+#endif
 #elif defined(MICROPY_HW_FMC_SDCKE1) && defined(MICROPY_HW_FMC_SDNE1)
 #define FMC_SDRAM_BANK FMC_SDRAM_BANK2
 #define FMC_SDRAM_CMD_TARGET_BANK FMC_SDRAM_CMD_TARGET_BANK2
+#if MICROPY_HW_FMC_SWAP_BANKS
+#define SDRAM_START_ADDRESS 0x70000000
+#else
 #define SDRAM_START_ADDRESS 0xD0000000
+#endif
 #endif
 
 // Provides the MPU_REGION_SIZE_X value when passed the size of region in bytes
@@ -58,6 +66,10 @@ bool sdram_init(void) {
     FMC_SDRAM_CommandTypeDef command;
 
     __HAL_RCC_FMC_CLK_ENABLE();
+
+    #if MICROPY_HW_FMC_SWAP_BANKS
+    HAL_SetFMCMemorySwappingConfig(FMC_SWAPBMAP_SDRAM_SRAM);
+    #endif
 
     #if defined(MICROPY_HW_FMC_SDCKE0)
     mp_hal_pin_config_alt_static_speed(MICROPY_HW_FMC_SDCKE0, MP_HAL_PIN_MODE_ALT, MP_HAL_PIN_PULL_NONE, MP_HAL_PIN_SPEED_VERY_HIGH, STATIC_AF_FMC_SDCKE0);


### PR DESCRIPTION
The patch enables SDRAM banks 1 and 2 to be accessible at 0xC0000000 and 0xD0000000 respectively (default mapping) or remapped to addresses 0x60000000 and 0x70000000.