### PR TITLE
Avoid including system headers when the functionality is disabled

### DIFF
--- a/ports/unix/modsocket.c
+++ b/ports/unix/modsocket.c
@@ -25,6 +25,10 @@
  * THE SOFTWARE.
  */
 
+#include "py/mpconfig.h"
+
+#if MICROPY_PY_SOCKET
+
 #include <stdio.h>
 #include <assert.h>
 #include <string.h>
@@ -48,8 +52,6 @@
 #include "py/mpthread.h"
 #include "extmod/vfs.h"
 #include <poll.h>
-
-#if MICROPY_PY_SOCKET
 
 /*
   The idea of this module is to implement reasonable minimum of

--- a/ports/unix/modtermios.c
+++ b/ports/unix/modtermios.c
@@ -24,6 +24,8 @@
  * THE SOFTWARE.
  */
 
+#if MICROPY_PY_TERMIOS
+
 #include <sys/types.h>
 #include <termios.h>
 #include <unistd.h>
@@ -32,8 +34,6 @@
 #include "py/objlist.h"
 #include "py/runtime.h"
 #include "py/mphal.h"
-
-#if MICROPY_PY_TERMIOS
 
 STATIC mp_obj_t mod_termios_tcgetattr(mp_obj_t fd_in) {
     struct termios term;

--- a/ports/unix/mpbtstackport_h4.c
+++ b/ports/unix/mpbtstackport_h4.c
@@ -24,13 +24,15 @@
  * THE SOFTWARE.
  */
 
+#include "py/mpconfig.h"
+
+#if MICROPY_PY_BLUETOOTH && MICROPY_BLUETOOTH_BTSTACK && MICROPY_BLUETOOTH_BTSTACK_H4
+
 #include <pthread.h>
 
 #include "py/runtime.h"
 #include "py/mperrno.h"
 #include "py/mphal.h"
-
-#if MICROPY_PY_BLUETOOTH && MICROPY_BLUETOOTH_BTSTACK && MICROPY_BLUETOOTH_BTSTACK_H4
 
 #include "lib/btstack/src/hci_transport_h4.h"
 #include "lib/btstack/chipset/zephyr/btstack_chipset_zephyr.h"

--- a/ports/unix/mpbtstackport_usb.c
+++ b/ports/unix/mpbtstackport_usb.c
@@ -24,14 +24,16 @@
  * THE SOFTWARE.
  */
 
+#include "py/mpconfig.h"
+
+#if MICROPY_PY_BLUETOOTH && MICROPY_BLUETOOTH_BTSTACK && MICROPY_BLUETOOTH_BTSTACK_USB
+
 #include <pthread.h>
 #include <unistd.h>
 
 #include "py/runtime.h"
 #include "py/mperrno.h"
 #include "py/mphal.h"
-
-#if MICROPY_PY_BLUETOOTH && MICROPY_BLUETOOTH_BTSTACK && MICROPY_BLUETOOTH_BTSTACK_USB
 
 #include "lib/btstack/src/btstack.h"
 #include "lib/btstack/src/hci_transport_usb.h"


### PR DESCRIPTION
Background:
When I ported ports/unix to WASI, i disabled unrelevant functionalities.
eg. MICROPY_PY_TERMIOS=0 because WASI doen't have termios.
however, it still tries to include the corresponding system headers. (eg. termios.h, which WASI doen't provide.)
