### PR TITLE
py/obj: Add mp_obj_malloc_with_finaliser helper.

### DIFF
--- a/extmod/modlwip.c
+++ b/extmod/modlwip.c
@@ -831,8 +831,7 @@ STATIC void lwip_socket_print(const mp_print_t *print, mp_obj_t self_in, mp_prin
 STATIC mp_obj_t lwip_socket_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *args) {
     mp_arg_check_num(n_args, n_kw, 0, 4, false);
 
-    lwip_socket_obj_t *socket = m_new_obj_with_finaliser(lwip_socket_obj_t);
-    socket->base.type = &lwip_socket_type;
+    lwip_socket_obj_t *socket = mp_obj_malloc_with_finaliser(lwip_socket_obj_t, &lwip_socket_type);
     socket->timeout = -1;
     socket->recv_offset = 0;
     socket->domain = MOD_NETWORK_AF_INET;
@@ -994,8 +993,7 @@ STATIC mp_obj_t lwip_socket_accept(mp_obj_t self_in) {
 
     // Create new socket object, do it here because we must not raise an out-of-memory
     // exception when the LWIP concurrency lock is held
-    lwip_socket_obj_t *socket2 = m_new_obj_with_finaliser(lwip_socket_obj_t);
-    socket2->base.type = &lwip_socket_type;
+    lwip_socket_obj_t *socket2 = mp_obj_malloc_with_finaliser(lwip_socket_obj_t, &lwip_socket_type);
 
     MICROPY_PY_LWIP_ENTER
 

--- a/extmod/modsocket.c
+++ b/extmod/modsocket.c
@@ -54,8 +54,7 @@ STATIC mp_obj_t socket_make_new(const mp_obj_type_t *type, size_t n_args, size_t
     mp_arg_check_num(n_args, n_kw, 0, 3, false);
 
     // create socket object (not bound to any NIC yet)
-    mod_network_socket_obj_t *s = m_new_obj_with_finaliser(mod_network_socket_obj_t);
-    s->base.type = &socket_type;
+    mod_network_socket_obj_t *s = mp_obj_malloc_with_finaliser(mod_network_socket_obj_t, &socket_type);
     s->nic = MP_OBJ_NULL;
     s->nic_protocol = NULL;
     s->domain = MOD_NETWORK_AF_INET;
@@ -163,8 +162,7 @@ STATIC mp_obj_t socket_accept(mp_obj_t self_in) {
 
     // create new socket object
     // starts with empty NIC so that finaliser doesn't run close() method if accept() fails
-    mod_network_socket_obj_t *socket2 = m_new_obj_with_finaliser(mod_network_socket_obj_t);
-    socket2->base.type = &socket_type;
+    mod_network_socket_obj_t *socket2 = mp_obj_malloc_with_finaliser(mod_network_socket_obj_t, &socket_type);
     socket2->nic = MP_OBJ_NULL;
     socket2->nic_protocol = NULL;
 

--- a/extmod/modtls_axtls.c
+++ b/extmod/modtls_axtls.c
@@ -144,12 +144,7 @@ STATIC mp_obj_t ssl_context_make_new(const mp_obj_type_t *type_in, size_t n_args
     // The "protocol" argument is ignored in this implementation.
 
     // Create SSLContext object.
-    #if MICROPY_PY_SSL_FINALISER
-    mp_obj_ssl_context_t *self = m_new_obj_with_finaliser(mp_obj_ssl_context_t);
-    #else
-    mp_obj_ssl_context_t *self = m_new_obj(mp_obj_ssl_context_t);
-    #endif
-    self->base.type = type_in;
+    mp_obj_ssl_context_t *self = mp_obj_malloc_with_finaliser(mp_obj_ssl_context_t, type_in);
     self->key = mp_const_none;
     self->cert = mp_const_none;
 
@@ -209,12 +204,7 @@ STATIC MP_DEFINE_CONST_OBJ_TYPE(
 STATIC mp_obj_t ssl_socket_make_new(mp_obj_ssl_context_t *ssl_context, mp_obj_t sock,
     bool server_side, bool do_handshake_on_connect, mp_obj_t server_hostname) {
 
-    #if MICROPY_PY_SSL_FINALISER
-    mp_obj_ssl_socket_t *o = m_new_obj_with_finaliser(mp_obj_ssl_socket_t);
-    #else
-    mp_obj_ssl_socket_t *o = m_new_obj(mp_obj_ssl_socket_t);
-    #endif
-    o->base.type = &ssl_socket_type;
+    mp_obj_ssl_socket_t *o = mp_obj_malloc_with_finaliser(mp_obj_ssl_socket_t, &ssl_socket_type);
     o->buf = NULL;
     o->bytes_left = 0;
     o->sock = MP_OBJ_NULL;

--- a/extmod/modtls_mbedtls.c
+++ b/extmod/modtls_mbedtls.c
@@ -209,12 +209,7 @@ STATIC mp_obj_t ssl_context_make_new(const mp_obj_type_t *type_in, size_t n_args
     mp_int_t endpoint = mp_obj_get_int(args[0]);
 
     // Create SSLContext object.
-    #if MICROPY_PY_SSL_FINALISER
-    mp_obj_ssl_context_t *self = m_new_obj_with_finaliser(mp_obj_ssl_context_t);
-    #else
-    mp_obj_ssl_context_t *self = m_new_obj(mp_obj_ssl_context_t);
-    #endif
-    self->base.type = type_in;
+    mp_obj_ssl_context_t *self = mp_obj_malloc_with_finaliser(mp_obj_ssl_context_t, type_in);
 
     // Initialise mbedTLS state.
     mbedtls_ssl_config_init(&self->conf);
@@ -487,12 +482,7 @@ STATIC mp_obj_t ssl_socket_make_new(mp_obj_ssl_context_t *ssl_context, mp_obj_t 
     // Verify the socket object has the full stream protocol
     mp_get_stream_raise(sock, MP_STREAM_OP_READ | MP_STREAM_OP_WRITE | MP_STREAM_OP_IOCTL);
 
-    #if MICROPY_PY_SSL_FINALISER
-    mp_obj_ssl_socket_t *o = m_new_obj_with_finaliser(mp_obj_ssl_socket_t);
-    #else
-    mp_obj_ssl_socket_t *o = m_new_obj(mp_obj_ssl_socket_t);
-    #endif
-    o->base.type = &ssl_socket_type;
+    mp_obj_ssl_socket_t *o = mp_obj_malloc_with_finaliser(mp_obj_ssl_socket_t, &ssl_socket_type);
     o->ssl_context = ssl_context;
     o->sock = sock;
     o->poll_mask = 0;

--- a/extmod/vfs_fat.c
+++ b/extmod/vfs_fat.c
@@ -188,8 +188,7 @@ STATIC mp_obj_t fat_vfs_ilistdir_func(size_t n_args, const mp_obj_t *args) {
     }
 
     // Create a new iterator object to list the dir
-    mp_vfs_fat_ilistdir_it_t *iter = m_new_obj_with_finaliser(mp_vfs_fat_ilistdir_it_t);
-    iter->base.type = &mp_type_polymorph_iter_with_finaliser;
+    mp_vfs_fat_ilistdir_it_t *iter = mp_obj_malloc_with_finaliser(mp_vfs_fat_ilistdir_it_t, &mp_type_polymorph_iter_with_finaliser);
     iter->iternext = mp_vfs_fat_ilistdir_it_iternext;
     iter->finaliser = mp_vfs_fat_ilistdir_it_del;
     iter->is_str = is_str_type;

--- a/extmod/vfs_fat_file.c
+++ b/extmod/vfs_fat_file.c
@@ -228,8 +228,7 @@ STATIC mp_obj_t fat_vfs_open(mp_obj_t self_in, mp_obj_t path_in, mp_obj_t mode_i
         }
     }
 
-    pyb_file_obj_t *o = m_new_obj_with_finaliser(pyb_file_obj_t);
-    o->base.type = type;
+    pyb_file_obj_t *o = mp_obj_malloc_with_finaliser(pyb_file_obj_t, type);
 
     const char *fname = mp_obj_str_get_str(path_in);
     FRESULT res = f_open(&self->fatfs, &o->fp, fname, mode);

--- a/extmod/vfs_lfsx.c
+++ b/extmod/vfs_lfsx.c
@@ -224,8 +224,7 @@ STATIC mp_obj_t MP_VFS_LFSx(ilistdir_func)(size_t n_args, const mp_obj_t *args) 
         path = vstr_null_terminated_str(&self->cur_dir);
     }
 
-    MP_VFS_LFSx(ilistdir_it_t) * iter = m_new_obj_with_finaliser(MP_VFS_LFSx(ilistdir_it_t));
-    iter->base.type = &mp_type_polymorph_iter_with_finaliser;
+    MP_VFS_LFSx(ilistdir_it_t) * iter = mp_obj_malloc_with_finaliser(MP_VFS_LFSx(ilistdir_it_t), &mp_type_polymorph_iter_with_finaliser);
 
     iter->iternext = MP_VFS_LFSx(ilistdir_it_iternext);
     iter->finaliser = MP_VFS_LFSx(ilistdir_it_del);

--- a/extmod/vfs_lfsx_file.c
+++ b/extmod/vfs_lfsx_file.c
@@ -90,11 +90,10 @@ mp_obj_t MP_VFS_LFSx(file_open)(mp_obj_t self_in, mp_obj_t path_in, mp_obj_t mod
     }
 
     #if LFS_BUILD_VERSION == 1
-    MP_OBJ_VFS_LFSx_FILE *o = m_new_obj_var_with_finaliser(MP_OBJ_VFS_LFSx_FILE, file_buffer, uint8_t, self->lfs.cfg->prog_size);
+    MP_OBJ_VFS_LFSx_FILE *o = mp_obj_malloc_var_with_finaliser(MP_OBJ_VFS_LFSx_FILE, file_buffer, uint8_t, self->lfs.cfg->prog_size, type);
     #else
-    MP_OBJ_VFS_LFSx_FILE *o = m_new_obj_var_with_finaliser(MP_OBJ_VFS_LFSx_FILE, file_buffer, uint8_t, self->lfs.cfg->cache_size);
+    MP_OBJ_VFS_LFSx_FILE *o = mp_obj_malloc_var_with_finaliser(MP_OBJ_VFS_LFSx_FILE, file_buffer, uint8_t, self->lfs.cfg->cache_size, type);
     #endif
-    o->base.type = type;
     o->vfs = self;
     #if !MICROPY_GC_CONSERVATIVE_CLEAR
     memset(&o->file, 0, sizeof(o->file));

--- a/extmod/vfs_posix.c
+++ b/extmod/vfs_posix.c
@@ -278,8 +278,7 @@ STATIC mp_obj_t vfs_posix_ilistdir_it_del(mp_obj_t self_in) {
 
 STATIC mp_obj_t vfs_posix_ilistdir(mp_obj_t self_in, mp_obj_t path_in) {
     mp_obj_vfs_posix_t *self = MP_OBJ_TO_PTR(self_in);
-    vfs_posix_ilistdir_it_t *iter = m_new_obj_with_finaliser(vfs_posix_ilistdir_it_t);
-    iter->base.type = &mp_type_polymorph_iter_with_finaliser;
+    vfs_posix_ilistdir_it_t *iter = mp_obj_malloc_with_finaliser(vfs_posix_ilistdir_it_t, &mp_type_polymorph_iter_with_finaliser);
     iter->iternext = vfs_posix_ilistdir_it_iternext;
     iter->finaliser = vfs_posix_ilistdir_it_del;
     iter->is_str = mp_obj_get_type(path_in) == &mp_type_str;

--- a/extmod/vfs_posix_file.c
+++ b/extmod/vfs_posix_file.c
@@ -63,7 +63,6 @@ STATIC void vfs_posix_file_print(const mp_print_t *print, mp_obj_t self_in, mp_p
 }
 
 mp_obj_t mp_vfs_posix_file_open(const mp_obj_type_t *type, mp_obj_t file_in, mp_obj_t mode_in) {
-    mp_obj_vfs_posix_file_t *o = m_new_obj_with_finaliser(mp_obj_vfs_posix_file_t);
     const char *mode_s = mp_obj_str_get_str(mode_in);
 
     int mode_rw = 0, mode_x = 0;
@@ -92,8 +91,7 @@ mp_obj_t mp_vfs_posix_file_open(const mp_obj_type_t *type, mp_obj_t file_in, mp_
         }
     }
 
-    o->base.type = type;
-
+    mp_obj_vfs_posix_file_t *o = mp_obj_malloc_with_finaliser(mp_obj_vfs_posix_file_t, type);
     mp_obj_t fid = file_in;
 
     if (mp_obj_is_small_int(fid)) {

--- a/ports/cc3200/mods/modsocket.c
+++ b/ports/cc3200/mods/modsocket.c
@@ -436,8 +436,7 @@ STATIC mp_obj_t socket_make_new(const mp_obj_type_t *type, size_t n_args, size_t
     mp_arg_check_num(n_args, n_kw, 0, 4, false);
 
     // create socket object
-    mod_network_socket_obj_t *s = m_new_obj_with_finaliser(mod_network_socket_obj_t);
-    s->base.type = (mp_obj_t)&socket_type;
+    mod_network_socket_obj_t *s = mp_obj_malloc_with_finaliser(mod_network_socket_obj_t, &socket_type);
     s->sock_base.u_param.domain = SL_AF_INET;
     s->sock_base.u_param.type = SL_SOCK_STREAM;
     s->sock_base.u_param.proto = SL_IPPROTO_TCP;
@@ -509,6 +508,7 @@ STATIC mp_obj_t socket_accept(mp_obj_t self_in) {
 
     // create new socket object
     mod_network_socket_obj_t *socket2 = m_new_obj_with_finaliser(mod_network_socket_obj_t);
+
     // the new socket inherits all properties from its parent
     memcpy (socket2, self, sizeof(mod_network_socket_obj_t));
 

--- a/ports/esp32/esp32_rmt.c
+++ b/ports/esp32/esp32_rmt.c
@@ -131,8 +131,7 @@ STATIC mp_obj_t esp32_rmt_make_new(const mp_obj_type_t *type, size_t n_args, siz
         mp_raise_ValueError(MP_ERROR_TEXT("clock_div must be between 1 and 255"));
     }
 
-    esp32_rmt_obj_t *self = m_new_obj_with_finaliser(esp32_rmt_obj_t);
-    self->base.type = &esp32_rmt_type;
+    esp32_rmt_obj_t *self = mp_obj_malloc_with_finaliser(esp32_rmt_obj_t, &esp32_rmt_type);
     self->channel_id = channel_id;
     self->pin = pin_id;
     self->clock_div = clock_div;

--- a/ports/esp32/machine_i2s.c
+++ b/ports/esp32/machine_i2s.c
@@ -405,8 +405,7 @@ STATIC machine_i2s_obj_t *mp_machine_i2s_make_new_instance(mp_int_t i2s_id) {
 
     machine_i2s_obj_t *self;
     if (MP_STATE_PORT(machine_i2s_obj)[i2s_id] == NULL) {
-        self = m_new_obj_with_finaliser(machine_i2s_obj_t);
-        self->base.type = &machine_i2s_type;
+        self = mp_obj_malloc_with_finaliser(machine_i2s_obj_t, &machine_i2s_type);
         MP_STATE_PORT(machine_i2s_obj)[i2s_id] = self;
         self->i2s_id = i2s_id;
     } else {

--- a/ports/esp32/machine_sdcard.c
+++ b/ports/esp32/machine_sdcard.c
@@ -224,8 +224,7 @@ STATIC mp_obj_t machine_sdcard_make_new(const mp_obj_type_t *type, size_t n_args
 
     DEBUG_printf("  Setting up host configuration");
 
-    sdcard_card_obj_t *self = m_new_obj_with_finaliser(sdcard_card_obj_t);
-    self->base.type = &machine_sdcard_type;
+    sdcard_card_obj_t *self = mp_obj_malloc_with_finaliser(sdcard_card_obj_t, &machine_sdcard_type);
     self->flags = 0;
     // Note that these defaults are macros that expand to structure
     // constants so we can't directly assign them to fields.

--- a/ports/esp32/modsocket.c
+++ b/ports/esp32/modsocket.c
@@ -270,8 +270,7 @@ STATIC void _socket_getaddrinfo(const mp_obj_t addrtuple, struct addrinfo **resp
 STATIC mp_obj_t socket_make_new(const mp_obj_type_t *type_in, size_t n_args, size_t n_kw, const mp_obj_t *args) {
     mp_arg_check_num(n_args, n_kw, 0, 3, false);
 
-    socket_obj_t *sock = m_new_obj_with_finaliser(socket_obj_t);
-    sock->base.type = type_in;
+    socket_obj_t *sock = mp_obj_malloc_with_finaliser(socket_obj_t, type_in);
     sock->domain = AF_INET;
     sock->type = SOCK_STREAM;
     sock->proto = 0;
@@ -364,8 +363,7 @@ STATIC mp_obj_t socket_accept(const mp_obj_t arg0) {
     }
 
     // create new socket object
-    socket_obj_t *sock = m_new_obj_with_finaliser(socket_obj_t);
-    sock->base.type = self->base.type;
+    socket_obj_t *sock = mp_obj_malloc_with_finaliser(socket_obj_t, self->base.type);
     sock->fd = new_fd;
     sock->domain = self->domain;
     sock->type = self->type;

--- a/ports/esp32/network_ppp.c
+++ b/ports/esp32/network_ppp.c
@@ -87,9 +87,8 @@ static void ppp_status_cb(ppp_pcb *pcb, int err_code, void *ctx) {
 STATIC mp_obj_t ppp_make_new(mp_obj_t stream) {
     mp_get_stream_raise(stream, MP_STREAM_OP_READ | MP_STREAM_OP_WRITE);
 
-    ppp_if_obj_t *self = m_new_obj_with_finaliser(ppp_if_obj_t);
+    ppp_if_obj_t *self = mp_obj_malloc_with_finaliser(ppp_if_obj_t, &ppp_if_type);
 
-    self->base.type = &ppp_if_type;
     self->stream = stream;
     self->active = false;
     self->connected = false;

--- a/ports/rp2/machine_timer.c
+++ b/ports/rp2/machine_timer.c
@@ -105,8 +105,7 @@ STATIC mp_obj_t machine_timer_init_helper(machine_timer_obj_t *self, size_t n_ar
 }
 
 STATIC mp_obj_t machine_timer_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *args) {
-    machine_timer_obj_t *self = m_new_obj_with_finaliser(machine_timer_obj_t);
-    self->base.type = &machine_timer_type;
+    machine_timer_obj_t *self = mp_obj_malloc_with_finaliser(machine_timer_obj_t, &machine_timer_type);
     self->pool = alarm_pool_get_default();
     self->alarm_id = ALARM_ID_INVALID;
 

--- a/ports/rp2/rp2_dma.c
+++ b/ports/rp2/rp2_dma.c
@@ -145,8 +145,7 @@ STATIC mp_obj_t rp2_dma_make_new(const mp_obj_type_t *type, size_t n_args, size_
         mp_raise_OSError(MP_EBUSY);
     }
 
-    rp2_dma_obj_t *self = m_new_obj_with_finaliser(rp2_dma_obj_t);
-    self->base.type = &rp2_dma_type;
+    rp2_dma_obj_t *self = mp_obj_malloc_with_finaliser(rp2_dma_obj_t, &rp2_dma_type);
     self->channel = dma_channel;
 
     // Return the DMA object.

--- a/ports/zephyr/modsocket.c
+++ b/ports/zephyr/modsocket.c
@@ -107,8 +107,7 @@ STATIC mp_obj_t format_inet_addr(struct sockaddr *addr, mp_obj_t port) {
 }
 
 socket_obj_t *socket_new(void) {
-    socket_obj_t *socket = m_new_obj_with_finaliser(socket_obj_t);
-    socket->base.type = (mp_obj_t)&socket_type;
+    socket_obj_t *socket = mp_obj_malloc_with_finaliser(socket_obj_t, &socket_type);
     socket->state = STATE_NEW;
     return socket;
 }

--- a/py/misc.h
+++ b/py/misc.h
@@ -82,9 +82,14 @@ typedef unsigned int uint;
 #if MICROPY_ENABLE_FINALISER
 #define m_new_obj_with_finaliser(type) ((type *)(m_malloc_with_finaliser(sizeof(type))))
 #define m_new_obj_var_with_finaliser(type, var_field, var_type, var_num) ((type *)m_malloc_with_finaliser(offsetof(type, var_field) + sizeof(var_type) * (var_num)))
+#define mp_obj_malloc_with_finaliser(struct_type, obj_type) ((struct_type *)mp_obj_malloc_with_finaliser_helper(sizeof(struct_type), obj_type))
+#define mp_obj_malloc_var_with_finaliser(struct_type, var_field, var_type, var_num, obj_type) ((struct_type *)mp_obj_malloc_with_finaliser_helper(sizeof(struct_type) + sizeof(var_type) * (var_num), obj_type))
 #else
 #define m_new_obj_with_finaliser(type) m_new_obj(type)
 #define m_new_obj_var_with_finaliser(type, var_field, var_type, var_num) m_new_obj_var(type, var_field, var_type, var_num)
+#define mp_obj_malloc_with_finaliser(struct_type, obj_type) mp_obj_malloc(struct_type, obj_type)
+#define mp_obj_malloc_var_with_finaliser(struct_type, var_field, var_type, var_num, obj_type) mp_obj_malloc_var(struct_type, var_type, var_num, obj_type)
+
 #endif
 #if MICROPY_MALLOC_USES_ALLOCATED_SIZE
 #define m_renew(type, ptr, old_num, new_num) ((type *)(m_realloc((ptr), sizeof(type) * (old_num), sizeof(type) * (new_num))))

--- a/py/obj.c
+++ b/py/obj.c
@@ -44,6 +44,16 @@ MP_NOINLINE void *mp_obj_malloc_helper(size_t num_bytes, const mp_obj_type_t *ty
     return base;
 }
 
+#if MICROPY_ENABLE_FINALISER
+// Allocates an object and also sets type, for mp_obj_malloc_with_finaliser{,_var} macros.
+MP_NOINLINE void *mp_obj_malloc_with_finaliser_helper(size_t num_bytes, const mp_obj_type_t *type) {
+    mp_obj_base_t *base = (mp_obj_base_t *)m_malloc_with_finaliser(num_bytes);
+    base->type = type;
+    return base;
+}
+#endif
+
+
 const mp_obj_type_t *MICROPY_WRAP_MP_OBJ_GET_TYPE(mp_obj_get_type)(mp_const_obj_t o_in) {
     #if MICROPY_OBJ_IMMEDIATE_OBJS && MICROPY_OBJ_REPR == MICROPY_OBJ_REPR_A
 

--- a/py/obj.h
+++ b/py/obj.h
@@ -916,6 +916,8 @@ extern const struct _mp_obj_exception_t mp_const_GeneratorExit_obj;
 #define mp_obj_malloc_var(struct_type, var_type, var_num, obj_type) ((struct_type *)mp_obj_malloc_helper(sizeof(struct_type) + sizeof(var_type) * (var_num), obj_type))
 void *mp_obj_malloc_helper(size_t num_bytes, const mp_obj_type_t *type);
 
+MP_NOINLINE void *mp_obj_malloc_with_finaliser_helper(size_t num_bytes, const mp_obj_type_t *type);
+
 // These macros are derived from more primitive ones and are used to
 // check for more specific object types.
 // Note: these are kept as macros because inline functions sometimes use much


### PR DESCRIPTION
The macro & helper pair `mp_obj_malloc` & `mp_obj_malloc_var` is already present for use when creating a new object and setting its base.type immediately.

This PR introduces matching `mp_obj_malloc_with_finaliser` & `mp_obj_malloc_var_with_finaliser` helpers to use in the same way for classes that need a finaliser (ie automatic running of `__del__` when the object is garbase collected).