### PR TITLE
py/emitnative: Simplify how the prelude is found for native functions, and support `__name__' on them

### DIFF
--- a/py/bc.c
+++ b/py/bc.c
@@ -336,9 +336,9 @@ void mp_setup_code_state(mp_code_state_t *code_state, size_t n_args, size_t n_kw
 // On entry code_state should be allocated somewhere (stack/heap) and
 // contain the following valid entries:
 //    - code_state->fun_bc should contain a pointer to the function object
-//    - code_state->ip should contain a pointer to the beginning of the prelude
 //    - code_state->n_state should be the number of objects in the local state
 void mp_setup_code_state_native(mp_code_state_native_t *code_state, size_t n_args, size_t n_kw, const mp_obj_t *args) {
+    code_state->ip = mp_obj_fun_native_get_prelude_ptr(code_state->fun_bc);
     code_state->sp = &code_state->state[0] - 1;
     mp_setup_code_state_helper((mp_code_state_t *)code_state, n_args, n_kw, args);
 }

--- a/py/emitglue.c
+++ b/py/emitglue.c
@@ -199,12 +199,14 @@ mp_obj_t mp_make_function_from_proto_fun(mp_proto_fun_t proto_fun, const mp_modu
     switch (rc->kind) {
         #if MICROPY_EMIT_NATIVE
         case MP_CODE_NATIVE_PY:
-        case MP_CODE_NATIVE_VIPER:
             fun = mp_obj_new_fun_native(def_args, rc->fun_data, context, rc->children);
             // Check for a generator function, and if so change the type of the object
             if (rc->is_generator) {
                 ((mp_obj_base_t *)MP_OBJ_TO_PTR(fun))->type = &mp_type_native_gen_wrap;
             }
+            break;
+        case MP_CODE_NATIVE_VIPER:
+            fun = mp_obj_new_fun_viper(rc->fun_data, context, rc->children);
             break;
         #endif
         #if MICROPY_EMIT_INLINE_ASM

--- a/py/obj.h
+++ b/py/obj.h
@@ -833,6 +833,8 @@ extern const mp_obj_type_t mp_type_fun_builtin_2;
 extern const mp_obj_type_t mp_type_fun_builtin_3;
 extern const mp_obj_type_t mp_type_fun_builtin_var;
 extern const mp_obj_type_t mp_type_fun_bc;
+extern const mp_obj_type_t mp_type_fun_native;
+extern const mp_obj_type_t mp_type_fun_asm;
 extern const mp_obj_type_t mp_type_module;
 extern const mp_obj_type_t mp_type_staticmethod;
 extern const mp_obj_type_t mp_type_classmethod;

--- a/py/obj.h
+++ b/py/obj.h
@@ -834,6 +834,7 @@ extern const mp_obj_type_t mp_type_fun_builtin_3;
 extern const mp_obj_type_t mp_type_fun_builtin_var;
 extern const mp_obj_type_t mp_type_fun_bc;
 extern const mp_obj_type_t mp_type_fun_native;
+extern const mp_obj_type_t mp_type_fun_viper;
 extern const mp_obj_type_t mp_type_fun_asm;
 extern const mp_obj_type_t mp_type_module;
 extern const mp_obj_type_t mp_type_staticmethod;

--- a/py/objfun.c
+++ b/py/objfun.c
@@ -137,10 +137,6 @@ STATIC qstr mp_obj_code_get_name(const mp_obj_fun_bc_t *fun, const byte *code_in
     return name;
 }
 
-#if MICROPY_EMIT_NATIVE
-STATIC const mp_obj_type_t mp_type_fun_native;
-#endif
-
 qstr mp_obj_fun_get_name(mp_const_obj_t fun_in) {
     const mp_obj_fun_bc_t *fun = MP_OBJ_TO_PTR(fun_in);
     #if MICROPY_EMIT_NATIVE
@@ -420,7 +416,7 @@ STATIC mp_obj_t fun_native_call(mp_obj_t self_in, size_t n_args, size_t n_kw, co
 #define FUN_BC_TYPE_ATTR
 #endif
 
-STATIC MP_DEFINE_CONST_OBJ_TYPE(
+MP_DEFINE_CONST_OBJ_TYPE(
     mp_type_fun_native,
     MP_QSTR_function,
     MP_TYPE_FLAG_BINDS_SELF,
@@ -429,25 +425,12 @@ STATIC MP_DEFINE_CONST_OBJ_TYPE(
     call, fun_native_call
     );
 
-mp_obj_t mp_obj_new_fun_native(const mp_obj_t *def_args, const void *fun_data, const mp_module_context_t *mc, struct _mp_raw_code_t *const *child_table) {
-    mp_obj_fun_bc_t *o = MP_OBJ_TO_PTR(mp_obj_new_fun_bc(def_args, (const byte *)fun_data, mc, child_table));
-    o->base.type = &mp_type_fun_native;
-    return MP_OBJ_FROM_PTR(o);
-}
-
 #endif // MICROPY_EMIT_NATIVE
 
 /******************************************************************************/
 /* inline assembler functions                                                 */
 
 #if MICROPY_EMIT_INLINE_ASM
-
-typedef struct _mp_obj_fun_asm_t {
-    mp_obj_base_t base;
-    size_t n_args;
-    const void *fun_data; // GC must be able to trace this pointer
-    mp_uint_t type_sig;
-} mp_obj_fun_asm_t;
 
 typedef mp_uint_t (*inline_asm_fun_0_t)(void);
 typedef mp_uint_t (*inline_asm_fun_1_t)(mp_uint_t);
@@ -529,19 +512,11 @@ STATIC mp_obj_t fun_asm_call(mp_obj_t self_in, size_t n_args, size_t n_kw, const
     return mp_native_to_obj(ret, self->type_sig);
 }
 
-STATIC MP_DEFINE_CONST_OBJ_TYPE(
+MP_DEFINE_CONST_OBJ_TYPE(
     mp_type_fun_asm,
     MP_QSTR_function,
     MP_TYPE_FLAG_BINDS_SELF,
     call, fun_asm_call
     );
-
-mp_obj_t mp_obj_new_fun_asm(size_t n_args, const void *fun_data, mp_uint_t type_sig) {
-    mp_obj_fun_asm_t *o = mp_obj_malloc(mp_obj_fun_asm_t, &mp_type_fun_asm);
-    o->n_args = n_args;
-    o->fun_data = fun_data;
-    o->type_sig = type_sig;
-    return MP_OBJ_FROM_PTR(o);
-}
 
 #endif // MICROPY_EMIT_INLINE_ASM

--- a/py/objfun.c
+++ b/py/objfun.c
@@ -139,14 +139,14 @@ STATIC qstr mp_obj_code_get_name(const mp_obj_fun_bc_t *fun, const byte *code_in
 
 qstr mp_obj_fun_get_name(mp_const_obj_t fun_in) {
     const mp_obj_fun_bc_t *fun = MP_OBJ_TO_PTR(fun_in);
+    const byte *bc = fun->bytecode;
+
     #if MICROPY_EMIT_NATIVE
     if (fun->base.type == &mp_type_fun_native || fun->base.type == &mp_type_native_gen_wrap) {
-        // TODO native functions don't have name stored
-        return MP_QSTR_;
+        bc = mp_obj_fun_native_get_prelude_ptr(fun);
     }
     #endif
 
-    const byte *bc = fun->bytecode;
     MP_BC_PRELUDE_SIG_DECODE(bc);
     return mp_obj_code_get_name(fun, bc);
 }

--- a/py/objfun.c
+++ b/py/objfun.c
@@ -401,7 +401,7 @@ mp_obj_t mp_obj_new_fun_bc(const mp_obj_t *def_args, const byte *code, const mp_
 STATIC mp_obj_t fun_native_call(mp_obj_t self_in, size_t n_args, size_t n_kw, const mp_obj_t *args) {
     MP_STACK_CHECK();
     mp_obj_fun_bc_t *self = MP_OBJ_TO_PTR(self_in);
-    mp_call_fun_t fun = MICROPY_MAKE_POINTER_CALLABLE((void *)self->bytecode);
+    mp_call_fun_t fun = mp_obj_fun_native_get_function_start(self);
     return fun(self_in, n_args, n_kw, args);
 }
 

--- a/py/objfun.c
+++ b/py/objfun.c
@@ -428,6 +428,27 @@ MP_DEFINE_CONST_OBJ_TYPE(
 #endif // MICROPY_EMIT_NATIVE
 
 /******************************************************************************/
+/* viper functions                                                           */
+
+#if MICROPY_EMIT_NATIVE
+
+STATIC mp_obj_t fun_viper_call(mp_obj_t self_in, size_t n_args, size_t n_kw, const mp_obj_t *args) {
+    MP_STACK_CHECK();
+    mp_obj_fun_bc_t *self = MP_OBJ_TO_PTR(self_in);
+    mp_call_fun_t fun = MICROPY_MAKE_POINTER_CALLABLE((void *)self->bytecode);
+    return fun(self_in, n_args, n_kw, args);
+}
+
+MP_DEFINE_CONST_OBJ_TYPE(
+    mp_type_fun_viper,
+    MP_QSTR_function,
+    MP_TYPE_FLAG_BINDS_SELF,
+    call, fun_viper_call
+    );
+
+#endif // MICROPY_EMIT_NATIVE
+
+/******************************************************************************/
 /* inline assembler functions                                                 */
 
 #if MICROPY_EMIT_INLINE_ASM

--- a/py/objfun.h
+++ b/py/objfun.h
@@ -54,11 +54,21 @@ mp_obj_t mp_obj_new_fun_bc(const mp_obj_t *def_args, const byte *code, const mp_
 void mp_obj_fun_bc_attr(mp_obj_t self_in, qstr attr, mp_obj_t *dest);
 
 #if MICROPY_EMIT_NATIVE
+
 static inline mp_obj_t mp_obj_new_fun_native(const mp_obj_t *def_args, const void *fun_data, const mp_module_context_t *mc, struct _mp_raw_code_t *const *child_table) {
     mp_obj_fun_bc_t *o = MP_OBJ_TO_PTR(mp_obj_new_fun_bc(def_args, (const byte *)fun_data, mc, child_table));
     o->base.type = &mp_type_fun_native;
     return MP_OBJ_FROM_PTR(o);
 }
+
+static inline mp_obj_t mp_obj_new_fun_viper(const void *fun_data, const mp_module_context_t *mc, struct _mp_raw_code_t *const *child_table) {
+    mp_obj_fun_bc_t *o = mp_obj_malloc(mp_obj_fun_bc_t, &mp_type_fun_viper);
+    o->bytecode = fun_data;
+    o->context = mc;
+    o->child_table = child_table;
+    return MP_OBJ_FROM_PTR(o);
+}
+
 #endif
 
 #if MICROPY_EMIT_INLINE_ASM

--- a/py/objfun.h
+++ b/py/objfun.h
@@ -43,9 +43,32 @@ typedef struct _mp_obj_fun_bc_t {
     mp_obj_t extra_args[];
 } mp_obj_fun_bc_t;
 
+typedef struct _mp_obj_fun_asm_t {
+    mp_obj_base_t base;
+    size_t n_args;
+    const void *fun_data; // GC must be able to trace this pointer
+    mp_uint_t type_sig;
+} mp_obj_fun_asm_t;
+
 mp_obj_t mp_obj_new_fun_bc(const mp_obj_t *def_args, const byte *code, const mp_module_context_t *cm, struct _mp_raw_code_t *const *raw_code_table);
-mp_obj_t mp_obj_new_fun_native(const mp_obj_t *def_args, const void *fun_data, const mp_module_context_t *cm, struct _mp_raw_code_t *const *raw_code_table);
-mp_obj_t mp_obj_new_fun_asm(size_t n_args, const void *fun_data, mp_uint_t type_sig);
 void mp_obj_fun_bc_attr(mp_obj_t self_in, qstr attr, mp_obj_t *dest);
+
+#if MICROPY_EMIT_NATIVE
+static inline mp_obj_t mp_obj_new_fun_native(const mp_obj_t *def_args, const void *fun_data, const mp_module_context_t *mc, struct _mp_raw_code_t *const *child_table) {
+    mp_obj_fun_bc_t *o = MP_OBJ_TO_PTR(mp_obj_new_fun_bc(def_args, (const byte *)fun_data, mc, child_table));
+    o->base.type = &mp_type_fun_native;
+    return MP_OBJ_FROM_PTR(o);
+}
+#endif
+
+#if MICROPY_EMIT_INLINE_ASM
+static inline mp_obj_t mp_obj_new_fun_asm(size_t n_args, const void *fun_data, mp_uint_t type_sig) {
+    mp_obj_fun_asm_t *o = mp_obj_malloc(mp_obj_fun_asm_t, &mp_type_fun_asm);
+    o->n_args = n_args;
+    o->fun_data = fun_data;
+    o->type_sig = type_sig;
+    return MP_OBJ_FROM_PTR(o);
+}
+#endif
 
 #endif // MICROPY_INCLUDED_PY_OBJFUN_H

--- a/py/objfun.h
+++ b/py/objfun.h
@@ -69,6 +69,34 @@ static inline mp_obj_t mp_obj_new_fun_viper(const void *fun_data, const mp_modul
     return MP_OBJ_FROM_PTR(o);
 }
 
+static inline const uint8_t *mp_obj_fun_native_get_prelude_ptr(const mp_obj_fun_bc_t *fun_native) {
+    // Obtain a pointer to the start of the function prelude, based on prelude_ptr_index.
+    uintptr_t prelude_ptr_index = ((uintptr_t *)fun_native->bytecode)[0];
+    const uint8_t *prelude_ptr;
+    if (prelude_ptr_index == 0) {
+        prelude_ptr = (const uint8_t *)fun_native->child_table;
+    } else {
+        prelude_ptr = (const uint8_t *)fun_native->child_table[prelude_ptr_index];
+    }
+    return prelude_ptr;
+}
+
+static inline void *mp_obj_fun_native_get_function_start(const mp_obj_fun_bc_t *fun_native) {
+    // Obtain a pointer to the start of the function executable machine code.
+    return MICROPY_MAKE_POINTER_CALLABLE((void *)(fun_native->bytecode + sizeof(uintptr_t)));
+}
+
+static inline void *mp_obj_fun_native_get_generator_start(const mp_obj_fun_bc_t *fun_native) {
+    // Obtain a pointer to the start of the generator executable machine code.
+    uintptr_t start_offset = ((uintptr_t *)fun_native->bytecode)[1];
+    return MICROPY_MAKE_POINTER_CALLABLE((void *)(fun_native->bytecode + start_offset));
+}
+
+static inline void *mp_obj_fun_native_get_generator_resume(const mp_obj_fun_bc_t *fun_native) {
+    // Obtain a pointer to the resume location of the generator executable machine code.
+    return MICROPY_MAKE_POINTER_CALLABLE((void *)&((uintptr_t *)fun_native->bytecode)[2]);
+}
+
 #endif
 
 #if MICROPY_EMIT_INLINE_ASM

--- a/py/objgenerator.c
+++ b/py/objgenerator.c
@@ -101,13 +101,7 @@ STATIC mp_obj_t native_gen_wrap_call(mp_obj_t self_in, size_t n_args, size_t n_k
     mp_obj_fun_bc_t *self_fun = MP_OBJ_TO_PTR(self_in);
 
     // Determine start of prelude.
-    uintptr_t prelude_ptr_index = ((uintptr_t *)self_fun->bytecode)[0];
-    const uint8_t *prelude_ptr;
-    if (prelude_ptr_index == 0) {
-        prelude_ptr = (void *)self_fun->child_table;
-    } else {
-        prelude_ptr = (void *)self_fun->child_table[prelude_ptr_index];
-    }
+    const uint8_t *prelude_ptr = mp_obj_fun_native_get_prelude_ptr(self_fun);
 
     // Extract n_state from the prelude.
     const uint8_t *ip = prelude_ptr;
@@ -119,17 +113,14 @@ STATIC mp_obj_t native_gen_wrap_call(mp_obj_t self_in, size_t n_args, size_t n_k
     // Parse the input arguments and set up the code state
     o->pend_exc = mp_const_none;
     o->code_state.fun_bc = self_fun;
-    o->code_state.ip = prelude_ptr;
     o->code_state.n_state = n_state;
-    o->code_state.sp = &o->code_state.state[0] - 1;
     mp_setup_code_state_native(&o->code_state, n_args, n_kw, args);
 
     // Indicate we are a native function, which doesn't use this variable
     o->code_state.exc_sp_idx = MP_CODE_STATE_EXC_SP_IDX_SENTINEL;
 
     // Prepare the generator instance for execution
-    uintptr_t start_offset = ((uintptr_t *)self_fun->bytecode)[1];
-    o->code_state.ip = MICROPY_MAKE_POINTER_CALLABLE((void *)(self_fun->bytecode + start_offset));
+    o->code_state.ip = mp_obj_fun_native_get_generator_start(self_fun);
 
     return MP_OBJ_FROM_PTR(o);
 }
@@ -208,9 +199,9 @@ mp_vm_return_kind_t mp_obj_gen_resume(mp_obj_t self_in, mp_obj_t send_value, mp_
 
     #if MICROPY_EMIT_NATIVE
     if (self->code_state.exc_sp_idx == MP_CODE_STATE_EXC_SP_IDX_SENTINEL) {
-        // A native generator, with entry point 2 words into the "bytecode" pointer
+        // A native generator.
         typedef uintptr_t (*mp_fun_native_gen_t)(void *, mp_obj_t);
-        mp_fun_native_gen_t fun = MICROPY_MAKE_POINTER_CALLABLE((const void *)(self->code_state.fun_bc->bytecode + 2 * sizeof(uintptr_t)));
+        mp_fun_native_gen_t fun = mp_obj_fun_native_get_generator_resume(self->code_state.fun_bc);
         ret_kind = fun((void *)&self->code_state, throw_value);
     } else
     #endif

--- a/tests/run-tests.py
+++ b/tests/run-tests.py
@@ -643,9 +643,7 @@ def run_tests(pyb, tests, args, result_dir, num_threads=1):
     # Some tests are known to fail with native emitter
     # Remove them from the below when they work
     if args.emit == "native":
-        skip_tests.update(
-            {"basics/%s.py" % t for t in "gen_yield_from_close generator_name".split()}
-        )  # require raise_varargs, generator name
+        skip_tests.add("basics/gen_yield_from_close.py")  # require raise_varargs
         skip_tests.update(
             {"basics/async_%s.py" % t for t in "with with2 with_break with_return".split()}
         )  # require async_with
@@ -656,7 +654,6 @@ def run_tests(pyb, tests, args, result_dir, num_threads=1):
         skip_tests.add("basics/del_deref.py")  # requires checking for unbound local
         skip_tests.add("basics/del_local.py")  # requires checking for unbound local
         skip_tests.add("basics/exception_chain.py")  # raise from is not supported
-        skip_tests.add("basics/fun_name.py")  # requires proper names for native functions
         skip_tests.add("basics/scope_implicit.py")  # requires checking for unbound local
         skip_tests.add("basics/sys_tracebacklimit.py")  # requires traceback info
         skip_tests.add("basics/try_finally_return2.py")  # requires raise_varargs


### PR DESCRIPTION
With this PR, native functions (via `@micropython.native`) are now a little smaller because they don't have to load their prelude pointer, that's handled instead by the runtime.

And, native functions now support `__name__` to get their function name.