### PR TITLE
extmod/network: Implement IPv6 API to set and retrieve nic configuration.

### DIFF
--- a/extmod/modnetwork.c
+++ b/extmod/modnetwork.c
@@ -141,10 +141,17 @@ mp_obj_t mod_network_hostname(size_t n_args, const mp_obj_t *args) {
 }
 static MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(mod_network_hostname_obj, 0, 1, mod_network_hostname);
 
+#if LWIP_VERSION_MAJOR >= 2
+MP_DEFINE_CONST_FUN_OBJ_KW(mod_network_ipconfig_obj, 0, mod_network_ipconfig);
+#endif
+
 static const mp_rom_map_elem_t mp_module_network_globals_table[] = {
     { MP_ROM_QSTR(MP_QSTR___name__), MP_ROM_QSTR(MP_QSTR_network) },
     { MP_ROM_QSTR(MP_QSTR_country), MP_ROM_PTR(&mod_network_country_obj) },
     { MP_ROM_QSTR(MP_QSTR_hostname), MP_ROM_PTR(&mod_network_hostname_obj) },
+    #if LWIP_VERSION_MAJOR >= 2
+    { MP_ROM_QSTR(MP_QSTR_ipconfig), MP_ROM_PTR(&mod_network_ipconfig_obj) },
+    #endif
 
     // Defined per port in mpconfigport.h
     #ifdef MICROPY_PORT_NETWORK_INTERFACES

--- a/extmod/modnetwork.h
+++ b/extmod/modnetwork.h
@@ -69,10 +69,18 @@ extern char mod_network_hostname_data[MICROPY_PY_NETWORK_HOSTNAME_MAX_LEN + 1];
 mp_obj_t mod_network_hostname(size_t n_args, const mp_obj_t *args);
 
 #if MICROPY_PY_LWIP
+
+#include "lwip/init.h"
+
 struct netif;
 void mod_network_lwip_init(void);
 void mod_network_lwip_poll_wrapper(uint32_t ticks_ms);
 mp_obj_t mod_network_nic_ifconfig(struct netif *netif, size_t n_args, const mp_obj_t *args);
+#if LWIP_VERSION_MAJOR >= 2
+mp_obj_t mod_network_ipconfig(size_t n_args, const mp_obj_t *args, mp_map_t *kwargs);
+mp_obj_t mod_network_nic_ipconfig(struct netif *netif, size_t n_args, const mp_obj_t *args, mp_map_t *kwargs);
+extern int mp_mod_network_prefer_dns_use_ip_version;
+#endif
 #elif defined(MICROPY_PORT_NETWORK_INTERFACES)
 
 struct _mod_network_socket_obj_t;

--- a/extmod/network_cyw43.c
+++ b/extmod/network_cyw43.c
@@ -321,6 +321,12 @@ static mp_obj_t network_cyw43_ifconfig(size_t n_args, const mp_obj_t *args) {
 }
 MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(network_cyw43_ifconfig_obj, 1, 2, network_cyw43_ifconfig);
 
+static mp_obj_t network_cyw43_ipconfig(size_t n_args, const mp_obj_t *args, mp_map_t *kwargs) {
+    network_cyw43_obj_t *self = MP_OBJ_TO_PTR(args[0]);
+    return mod_network_nic_ipconfig(&self->cyw->netif[self->itf], n_args - 1, args + 1, kwargs);
+}
+static MP_DEFINE_CONST_FUN_OBJ_KW(network_cyw43_ipconfig_obj, 1, network_cyw43_ipconfig);
+
 static mp_obj_t network_cyw43_status(size_t n_args, const mp_obj_t *args) {
     network_cyw43_obj_t *self = MP_OBJ_TO_PTR(args[0]);
     (void)self;
@@ -532,6 +538,7 @@ static const mp_rom_map_elem_t network_cyw43_locals_dict_table[] = {
     { MP_ROM_QSTR(MP_QSTR_disconnect), MP_ROM_PTR(&network_cyw43_disconnect_obj) },
     { MP_ROM_QSTR(MP_QSTR_isconnected), MP_ROM_PTR(&network_cyw43_isconnected_obj) },
     { MP_ROM_QSTR(MP_QSTR_ifconfig), MP_ROM_PTR(&network_cyw43_ifconfig_obj) },
+    { MP_ROM_QSTR(MP_QSTR_ipconfig), MP_ROM_PTR(&network_cyw43_ipconfig_obj) },
     { MP_ROM_QSTR(MP_QSTR_status), MP_ROM_PTR(&network_cyw43_status_obj) },
     { MP_ROM_QSTR(MP_QSTR_config), MP_ROM_PTR(&network_cyw43_config_obj) },
 

--- a/extmod/network_esp_hosted.c
+++ b/extmod/network_esp_hosted.c
@@ -204,6 +204,13 @@ static mp_obj_t network_esp_hosted_ifconfig(size_t n_args, const mp_obj_t *args)
 }
 static MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(network_esp_hosted_ifconfig_obj, 1, 2, network_esp_hosted_ifconfig);
 
+static mp_obj_t network_esp_hosted_ipconfig(size_t n_args, const mp_obj_t *args, mp_map_t *kwargs) {
+    esp_hosted_obj_t *self = MP_OBJ_TO_PTR(args[0]);
+    void *netif = esp_hosted_wifi_get_netif(self->itf);
+    return mod_network_nic_ipconfig(netif, n_args - 1, args + 1, kwargs);
+}
+static MP_DEFINE_CONST_FUN_OBJ_KW(network_esp_hosted_ipconfig_obj, 1, network_esp_hosted_ipconfig);
+
 static mp_obj_t network_esp_hosted_config(size_t n_args, const mp_obj_t *args, mp_map_t *kwargs) {
     esp_hosted_obj_t *self = MP_OBJ_TO_PTR(args[0]);
 
@@ -299,6 +306,7 @@ static const mp_rom_map_elem_t network_esp_hosted_locals_dict_table[] = {
     { MP_ROM_QSTR(MP_QSTR_disconnect),          MP_ROM_PTR(&network_esp_hosted_disconnect_obj) },
     { MP_ROM_QSTR(MP_QSTR_isconnected),         MP_ROM_PTR(&network_esp_hosted_isconnected_obj) },
     { MP_ROM_QSTR(MP_QSTR_ifconfig),            MP_ROM_PTR(&network_esp_hosted_ifconfig_obj) },
+    { MP_ROM_QSTR(MP_QSTR_ipconfig),            MP_ROM_PTR(&network_esp_hosted_ipconfig_obj) },
     { MP_ROM_QSTR(MP_QSTR_config),              MP_ROM_PTR(&network_esp_hosted_config_obj) },
     { MP_ROM_QSTR(MP_QSTR_status),              MP_ROM_PTR(&network_esp_hosted_status_obj) },
     { MP_ROM_QSTR(MP_QSTR_OPEN),                MP_ROM_INT(ESP_HOSTED_SEC_OPEN) },

--- a/extmod/network_lwip.c
+++ b/extmod/network_lwip.c
@@ -26,6 +26,7 @@
 
 #include "py/runtime.h"
 #include "py/mphal.h"
+#include "py/parsenum.h"
 
 #if MICROPY_PY_NETWORK && MICROPY_PY_LWIP
 
@@ -40,9 +41,19 @@
 #include "lwip/timeouts.h"
 #include "lwip/dns.h"
 #include "lwip/dhcp.h"
+#include "lwip/nd6.h"
+#include "lwip/dhcp6.h"
+#include "lwip/prot/dhcp.h"
+#include "lwip/prot/dhcp6.h"
+#include <string.h>
+#include <stdlib.h>
+
+int mp_mod_network_prefer_dns_use_ip_version = 4;
 
 // Implementations of network methods that can be used by any interface.
 
+// This function provides the implementation of nic.ifconfig, is deprecated and will be removed.
+// Use network.ipconfig and nic.ipconfig instead.
 mp_obj_t mod_network_nic_ifconfig(struct netif *netif, size_t n_args, const mp_obj_t *args) {
     if (n_args == 0) {
         // Get IP addresses
@@ -88,6 +99,291 @@ mp_obj_t mod_network_nic_ifconfig(struct netif *netif, size_t n_args, const mp_o
         dns_setserver(0, &dns);
         return mp_const_none;
     }
+}
+
+// This function provides the common implementation of network.ipconfig
+mp_obj_t mod_network_ipconfig(size_t n_args, const mp_obj_t *args, mp_map_t *kwargs) {
+    if (kwargs->used == 0) {
+        // Get config value
+        if (n_args != 1) {
+            mp_raise_TypeError(MP_ERROR_TEXT("must query one param"));
+        }
+
+        switch (mp_obj_str_get_qstr(args[0])) {
+            case MP_QSTR_dns: {
+                char addr_str[IPADDR_STRLEN_MAX];
+                ipaddr_ntoa_r(dns_getserver(0), addr_str, sizeof(addr_str));
+                return mp_obj_new_str(addr_str, strlen(addr_str));
+            }
+            case MP_QSTR_prefer: {
+                return MP_OBJ_NEW_SMALL_INT(mp_mod_network_prefer_dns_use_ip_version);
+            }
+            default: {
+                mp_raise_ValueError(MP_ERROR_TEXT("unexpected key"));
+                break;
+            }
+        }
+    } else {
+        // Set config value(s)
+        if (n_args != 0) {
+            mp_raise_TypeError(MP_ERROR_TEXT("can't specify pos and kw args"));
+        }
+
+        for (size_t i = 0; i < kwargs->alloc; ++i) {
+            if (MP_MAP_SLOT_IS_FILLED(kwargs, i)) {
+                mp_map_elem_t *e = &kwargs->table[i];
+                switch (mp_obj_str_get_qstr(e->key)) {
+                    case MP_QSTR_dns: {
+                        ip_addr_t dns;
+                        size_t addr_len;
+                        const char *addr_str = mp_obj_str_get_data(e->value, &addr_len);
+                        if (!ipaddr_aton(addr_str, &dns)) {
+                            mp_raise_ValueError(MP_ERROR_TEXT("invalid arguments as dns server"));
+                        }
+                        dns_setserver(0, &dns);
+                        break;
+                    }
+                    case MP_QSTR_prefer: {
+                        int value = mp_obj_get_int(e->value);
+                        if (value != 4 && value != 6) {
+                            mp_raise_ValueError(MP_ERROR_TEXT("invalid prefer argument"));
+                        }
+                        mp_mod_network_prefer_dns_use_ip_version = value;
+                        break;
+                    }
+                    default: {
+                        mp_raise_ValueError(MP_ERROR_TEXT("unexpected key"));
+                        break;
+                    }
+                }
+            }
+        }
+    }
+    return mp_const_none;
+}
+
+mp_obj_t mod_network_nic_ipconfig(struct netif *netif, size_t n_args, const mp_obj_t *args, mp_map_t *kwargs) {
+
+    if (kwargs->used == 0) {
+        // Get config value
+        if (n_args != 1) {
+            mp_raise_TypeError(MP_ERROR_TEXT("must query one param"));
+        }
+
+        switch (mp_obj_str_get_qstr(args[0])) {
+            case MP_QSTR_dhcp4: {
+                struct dhcp *dhcp = netif_dhcp_data(netif);
+                return mp_obj_new_bool(dhcp != NULL && dhcp->state != DHCP_STATE_OFF);
+            }
+            case MP_QSTR_has_dhcp4: {
+                return mp_obj_new_bool(dhcp_supplied_address(netif));
+            }
+            #if LWIP_IPV6_DHCP6
+            case MP_QSTR_dhcp6: {
+                struct dhcp6 *dhcp = netif_dhcp6_data(netif);
+                return mp_obj_new_bool(dhcp != NULL && dhcp->state != DHCP6_STATE_OFF);
+            }
+            #endif
+            #if LWIP_IPV6_AUTOCONFIG
+            case MP_QSTR_autoconf6: {
+                return netif->ip6_autoconfig_enabled ?  mp_const_true : mp_const_false;
+            }
+            case MP_QSTR_has_autoconf6: {
+                int found = 0;
+                for (int i = 1; i < LWIP_IPV6_NUM_ADDRESSES; i++) {
+                    if (ip6_addr_isvalid(netif_ip6_addr_state(netif, i)) &&
+                        !netif_ip6_addr_isstatic(netif, i)) {
+                        found = 1;
+                        break;
+                    }
+                }
+                if (found) {
+                    break;
+                }
+                return mp_obj_new_bool(found);
+            }
+            #endif
+            case MP_QSTR_addr4: {
+                mp_obj_t tuple[2] = {
+                    netutils_format_ipv4_addr((uint8_t *)&netif->ip_addr, NETUTILS_BIG),
+                    netutils_format_ipv4_addr((uint8_t *)&netif->netmask, NETUTILS_BIG),
+                };
+                return mp_obj_new_tuple(2, tuple);
+            }
+            #if LWIP_IPV6
+            case MP_QSTR_addr6: {
+                mp_obj_t addrs[LWIP_IPV6_NUM_ADDRESSES];
+                size_t n_addrs = 0;
+                for (int i = 0; i < LWIP_IPV6_NUM_ADDRESSES; i++) {
+                    if (ip6_addr_isvalid(netif_ip6_addr_state(netif, i))) {
+                        char addr_str[IPADDR_STRLEN_MAX];
+                        ipaddr_ntoa_r(netif_ip_addr6(netif, i), addr_str, sizeof(addr_str));
+                        mp_obj_t tuple[4] = {
+                            mp_obj_new_str(addr_str, strlen(addr_str)),
+                            MP_OBJ_NEW_SMALL_INT(netif_ip6_addr_state(netif, i)),
+                            MP_OBJ_NEW_SMALL_INT(netif_ip6_addr_pref_life(netif, i)), // preferred
+                            MP_OBJ_NEW_SMALL_INT(netif_ip6_addr_valid_life(netif, i))
+                        };
+                        addrs[n_addrs++] = mp_obj_new_tuple(4, tuple);
+                    }
+                }
+                return mp_obj_new_list(n_addrs, addrs);
+            }
+            #endif
+            case MP_QSTR_gw4: {
+                return netutils_format_ipv4_addr((uint8_t *)&netif->gw, NETUTILS_BIG);
+            }
+            default: {
+                mp_raise_ValueError(MP_ERROR_TEXT("unexpected key"));
+                break;
+            }
+        }
+        return mp_const_none;
+    } else {
+        // Set config value(s)
+        if (n_args != 0) {
+            mp_raise_TypeError(MP_ERROR_TEXT("can't specify pos and kw args"));
+        }
+
+        for (size_t i = 0; i < kwargs->alloc; ++i) {
+            if (MP_MAP_SLOT_IS_FILLED(kwargs, i)) {
+                mp_map_elem_t *e = &kwargs->table[i];
+                switch (mp_obj_str_get_qstr(e->key)) {
+                    case MP_QSTR_dhcp4: {
+                        if (mp_obj_is_true(e->value)) {
+                            if (dhcp_supplied_address(netif)) {
+                                dhcp_renew(netif);
+                            } else {
+                                dhcp_release_and_stop(netif);
+                                dhcp_start(netif);
+                            }
+                        } else {
+                            dhcp_release_and_stop(netif);
+                        }
+                        break;
+                    }
+                    #if LWIP_IPV6_DHCP6
+                    case MP_QSTR_dhcp6: {
+                        dhcp6_disable(netif);
+                        dhcp6_enable_stateless(netif);
+                        break;
+                    }
+                    #endif
+                    #if LWIP_IPV6_AUTOCONFIG
+                    case MP_QSTR_autoconf6: {
+                        netif_set_ip6_autoconfig_enabled(netif, mp_obj_is_true(e->value));
+                        if (mp_obj_is_true(e->value)) {
+                            nd6_restart_netif(netif);
+                        } else {
+                            // Clear out any non-static addresses, skip link-local address in slot 0
+                            for (i = 1; i < LWIP_IPV6_NUM_ADDRESSES; i++) {
+                                if (ip6_addr_isvalid(netif_ip6_addr_state(netif, i)) &&
+                                    !netif_ip6_addr_isstatic(netif, i)) {
+                                    netif_ip6_addr_set_state(netif, i, IP6_ADDR_INVALID);
+                                }
+                            }
+                        }
+                        break;
+                    }
+                    #endif
+                    case MP_QSTR_addr4:
+                    case MP_QSTR_addr6: {
+                        ip_addr_t ip_addr;
+                        ip_addr_t netmask;
+                        int prefix_bits = 32;
+                        if (e->value != mp_const_none && mp_obj_is_str(e->value)) {
+                            size_t addr_len;
+                            const char *input_str = mp_obj_str_get_data(e->value, &addr_len);
+                            char plain_ip[IPADDR_STRLEN_MAX];
+                            char *split = strchr(input_str, '/');
+                            const char *addr_str = input_str;
+                            if (split) {
+                                int to_copy = sizeof(plain_ip) - 1;
+                                if (split - addr_str < to_copy) {
+                                    to_copy = split - addr_str;
+                                }
+                                memcpy(plain_ip, addr_str, to_copy);
+                                mp_obj_t prefix_obj = mp_parse_num_integer(split + 1, strlen(split + 1), 10, NULL);
+                                prefix_bits = mp_obj_get_int(prefix_obj);
+                            }
+                            if (mp_obj_str_get_qstr(args[0]) == MP_QSTR_addr4) {
+                                uint32_t mask = -(1u << (32 - prefix_bits));
+                                ip_addr_set_ip4_u32_val(netmask, ((mask & 0xFF) << 24) | ((mask & 0xFF00) << 8) | ((mask >> 8) & 0xFF00) | ((mask >> 24) & 0xFF));
+                            }
+                            if (!ipaddr_aton(addr_str, &ip_addr)) {
+                                mp_raise_ValueError(MP_ERROR_TEXT("invalid arguments"));
+                            }
+                            if ((mp_obj_str_get_qstr(args[0]) == MP_QSTR_addr6) != IP_IS_V6(&ip_addr)
+                                || (mp_obj_str_get_qstr(args[0]) == MP_QSTR_addr4) != IP_IS_V4(&ip_addr)) {
+                                mp_raise_ValueError(MP_ERROR_TEXT("invalid address type"));
+                            }
+                        } else if (e->value != mp_const_none) {
+                            mp_obj_t *items;
+                            mp_obj_get_array_fixed_n(e->value, 2, &items);
+                            size_t addr_len;
+                            const char *ip_addr_str = mp_obj_str_get_data(items[0], &addr_len);
+                            const char *netmask_str = mp_obj_str_get_data(items[1], &addr_len);
+                            if (!ipaddr_aton(ip_addr_str, &ip_addr)) {
+                                mp_raise_ValueError(MP_ERROR_TEXT("invalid arguments"));
+                            }
+                            if (!ipaddr_aton(netmask_str, &netmask)) {
+                                mp_raise_ValueError(MP_ERROR_TEXT("invalid arguments"));
+                            }
+                            if (!IP_IS_V4(&ip_addr) || !IP_IS_V4(&netmask)) {
+                                mp_raise_ValueError(MP_ERROR_TEXT("invalid address type"));
+                            }
+                        }
+                        if (mp_obj_str_get_qstr(args[0]) == MP_QSTR_addr4) {
+                            if (e->value != mp_const_none) {
+                                netif->ip_addr = ip_addr;
+                                netif->netmask = netmask;
+                            } else {
+                                ip4_addr_set_any(ip_2_ip4(&netif->ip_addr));
+                                ip4_addr_set_any(ip_2_ip4(&netif->netmask));
+                            }
+                        #if LWIP_IPV6
+                        } else if (mp_obj_str_get_qstr(args[0]) == MP_QSTR_addr6) {
+                            // Clear out any existing static addresses. Address 0 comes from autoconf.
+                            for (i = 1; i < LWIP_IPV6_NUM_ADDRESSES; i++) {
+                                if (ip6_addr_isvalid(netif_ip6_addr_state(netif, i)) &&
+                                    netif_ip6_addr_isstatic(netif, i)) {
+                                    netif_ip6_addr_set_state(netif, i, IP6_ADDR_INVALID);
+                                }
+                            }
+                            if (e->value != mp_const_none) {
+                                s8_t free_idx;
+                                netif_add_ip6_address(netif, ip_2_ip6(&ip_addr), &free_idx);
+                                netif_ip6_addr_set_valid_life(netif, free_idx, IP6_ADDR_LIFE_STATIC);
+                                netif_ip6_addr_set_pref_life(netif, free_idx, IP6_ADDR_LIFE_STATIC);
+                                netif_ip6_addr_set_state(netif, free_idx, IP6_ADDR_PREFERRED);
+                            }
+                        #endif
+                        }
+                        break;
+                    }
+                    case MP_QSTR_gw4: {
+                        ip_addr_t ip_addr;
+                        size_t addr_len;
+                        const char *addr_str = mp_obj_str_get_data(e->value, &addr_len);
+                        if (!ipaddr_aton(addr_str, &ip_addr)) {
+                            mp_raise_ValueError(MP_ERROR_TEXT("invalid arguments"));
+                        }
+                        if (IP_IS_V4(&ip_addr)) {
+                            netif->gw = ip_addr;
+                        } else {
+                            mp_raise_ValueError(MP_ERROR_TEXT("invalid address type"));
+                        }
+                        break;
+                    }
+                    default: {
+                        mp_raise_ValueError(MP_ERROR_TEXT("unexpected key"));
+                        break;
+                    }
+                }
+            }
+        }
+    }
+    return mp_const_none;
 }
 
 #endif // LWIP_VERSION_MAJOR >= 2

--- a/extmod/network_wiznet5k.c
+++ b/extmod/network_wiznet5k.c
@@ -915,6 +915,12 @@ static mp_obj_t wiznet5k_ifconfig(size_t n_args, const mp_obj_t *args) {
 }
 static MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(wiznet5k_ifconfig_obj, 1, 2, wiznet5k_ifconfig);
 
+static mp_obj_t network_wiznet5k_ipconfig(size_t n_args, const mp_obj_t *args, mp_map_t *kwargs) {
+    wiznet5k_obj_t *self = MP_OBJ_TO_PTR(args[0]);
+    return mod_network_nic_ipconfig(&self->netif, n_args - 1, args + 1, kwargs);
+}
+static MP_DEFINE_CONST_FUN_OBJ_KW(wiznet5k_ipconfig_obj, 1, network_wiznet5k_ipconfig);
+
 static mp_obj_t send_ethernet_wrapper(mp_obj_t self_in, mp_obj_t buf_in) {
     wiznet5k_obj_t *self = MP_OBJ_TO_PTR(self_in);
     mp_buffer_info_t buf;
@@ -1008,6 +1014,9 @@ static const mp_rom_map_elem_t wiznet5k_locals_dict_table[] = {
     { MP_ROM_QSTR(MP_QSTR_isconnected), MP_ROM_PTR(&wiznet5k_isconnected_obj) },
     { MP_ROM_QSTR(MP_QSTR_active), MP_ROM_PTR(&wiznet5k_active_obj) },
     { MP_ROM_QSTR(MP_QSTR_ifconfig), MP_ROM_PTR(&wiznet5k_ifconfig_obj) },
+    #if WIZNET5K_WITH_LWIP_STACK
+    { MP_ROM_QSTR(MP_QSTR_ipconfig), MP_ROM_PTR(&wiznet5k_ipconfig_obj) },
+    #endif
     { MP_ROM_QSTR(MP_QSTR_status), MP_ROM_PTR(&wiznet5k_status_obj) },
     { MP_ROM_QSTR(MP_QSTR_config), MP_ROM_PTR(&wiznet5k_config_obj) },
     #if WIZNET5K_WITH_LWIP_STACK


### PR DESCRIPTION
fixes #12600

This change implements a new `<AbstractNIC>.ipconfig` function for the CYW43 NIC class, to set and retrieve network configuration for a NIC. Currently this change supports:

- `ipconfig("addr4")` obtain a tuple `(addr, netmask)` of the currently configured ipv4 address
- `ipconfig("addr6")` obtain a list of tuples `(addr, state, prefered_lifetime, valid_lifetime)` of all currently active ipv6 addresses. This includes static, slaac and link-local addresses
- `ipconfig(addr4="1.2.3.4/24")` to set the ipv4 address and netmask
- `ipconfig(addr6="2a01::2")` to set a static ipv6 address. Note that this does not configure an interface route, as this does not seem supported by lwip
- `ipconfig(autoconf6=True)` to enable ipv6 network configuration with slaac (and wait up to 10s for an address to be received)
- `ipconfig(gw4="1.2.3.1")` to set the ipv4 gatewas
- `network.ipconfig(dns="2a01::2")` set the primary dns server (can be a ipv4 or ipv6 address).
- `ipconfig(dhcp4=True)` enable, and wait for (up to 10s), ipv4 dhcp. This sets ipv4 address, netmask, gateway and a dns server. `ipconfig(dhcp4=False)` stops dhcp, releases the ip, and clears the configured ipv4 address.
- `ipconfig(dhcp6=True)` enable stateless dhcpv6 to obtain a dns server
- `netwok.ipconfig(prefer=6)` to prefer ipv6 addresses to be returned as dns responses (falling back to ipv4 if the host does not have an ipv6 address). Note that this does not flush the dns cache, so if a host is already in the dns cache with its v4 address, subsequent lookups will return that address even if `prefer=6` is set.

This interface replaces `network.ifconfig` completely, and  `ifconfig` should be marked as deprecated and removed in a future version.