### PR TITLE
fix websocket clean shutdown

### DIFF
--- a/tests/extmod/websocket_basic.py.exp
+++ b/tests/extmod/websocket_basic.py.exp
@@ -5,7 +5,7 @@ b'pingpingpingpingpingpingpingpingpingpingpingpingpingpingpingpingpingpingpingpi
 b'\x81~\x00\x80pongpongpongpongpongpongpongpongpongpongpongpongpongpongpongpongpongpongpongpongpongpongpongpongpongpongpongpongpongpongpongpong'
 b'\x00\x00\x00\x00'
 b''
-b'\x81\x02\x88\x00'
+b'\x88\x00'
 b'ping'
 b'pong'
 0


### PR DESCRIPTION
When the websocket closes currently, it does not send a proper "close"-frame but encodes the `0x8800`-sequence inside a binary packet, which is wrong. The close packet is a different kind of websocket frame. This change resolves the error I get in Firefox when the websocket closes (and the change also seems logical to me, according to the websocket standard)