### PR TITLE
py: fix setting globals for compiled native functions

### DIFF
--- a/py/builtinevex.c
+++ b/py/builtinevex.c
@@ -57,9 +57,13 @@ STATIC mp_obj_t code_execute(mp_obj_code_t *self, mp_obj_dict_t *globals, mp_obj
     // set exception handler to restore context if an exception is raised
     nlr_push_jump_callback(&ctx.callback, mp_globals_locals_set_from_nlr_jump_callback);
 
-    // a bit of a hack: fun_bc will re-set globals, so need to make sure it's
-    // the correct one
-    if (mp_obj_is_type(self->module_fun, &mp_type_fun_bc)) {
+    // The call to mp_parse_compile_execute() in mp_builtin_compile() below passes
+    // NULL for the globals, so repopulate that entry now with the correct globals.
+    if (mp_obj_is_type(self->module_fun, &mp_type_fun_bc)
+        #if MICROPY_EMIT_NATIVE
+        || mp_obj_is_type(self->module_fun, &mp_type_fun_native)
+        #endif
+        ) {
         mp_obj_fun_bc_t *fun_bc = MP_OBJ_TO_PTR(self->module_fun);
         ((mp_module_context_t *)fun_bc->context)->module.globals = globals;
     }

--- a/py/emitglue.c
+++ b/py/emitglue.c
@@ -149,7 +149,7 @@ void mp_emit_glue_assign_native(mp_raw_code_t *rc, mp_raw_code_kind_t kind, void
     #endif
 
     #if DEBUG_PRINT
-    DEBUG_printf("assign native: kind=%d fun=%p len=" UINT_FMT " n_pos_args=" UINT_FMT " flags=%x\n", kind, fun_data, fun_len, n_pos_args, (uint)scope_flags);
+    DEBUG_printf("assign native: kind=%d fun=%p len=" UINT_FMT " flags=%x\n", kind, fun_data, fun_len, (uint)scope_flags);
     for (mp_uint_t i = 0; i < fun_len; i++) {
         if (i > 0 && i % 16 == 0) {
             DEBUG_printf("\n");

--- a/py/objfun.c
+++ b/py/objfun.c
@@ -128,15 +128,6 @@ MP_DEFINE_CONST_OBJ_TYPE(
 /******************************************************************************/
 /* byte code functions                                                        */
 
-STATIC qstr mp_obj_code_get_name(const mp_obj_fun_bc_t *fun, const byte *code_info) {
-    MP_BC_PRELUDE_SIZE_DECODE(code_info);
-    mp_uint_t name = mp_decode_uint_value(code_info);
-    #if MICROPY_EMIT_BYTECODE_USES_QSTR_TABLE
-    name = fun->context->constants.qstr_table[name];
-    #endif
-    return name;
-}
-
 qstr mp_obj_fun_get_name(mp_const_obj_t fun_in) {
     const mp_obj_fun_bc_t *fun = MP_OBJ_TO_PTR(fun_in);
     const byte *bc = fun->bytecode;
@@ -148,7 +139,14 @@ qstr mp_obj_fun_get_name(mp_const_obj_t fun_in) {
     #endif
 
     MP_BC_PRELUDE_SIG_DECODE(bc);
-    return mp_obj_code_get_name(fun, bc);
+    MP_BC_PRELUDE_SIZE_DECODE(bc);
+
+    mp_uint_t name = mp_decode_uint_value(bc);
+    #if MICROPY_EMIT_BYTECODE_USES_QSTR_TABLE
+    name = fun->context->constants.qstr_table[name];
+    #endif
+
+    return name;
 }
 
 #if MICROPY_CPYTHON_COMPAT

--- a/tests/basics/builtin_compile.py
+++ b/tests/basics/builtin_compile.py
@@ -29,6 +29,9 @@ def test():
     exec(compile("print(10 + 2)", "file", "single"))
     print(eval(compile("10 + 3", "file", "eval")))
 
+    # test accessing a function's globals from within a compile
+    exec(compile("def func():pass\nprint('x', func.__globals__['x'])", "file", "exec"))
+
     # bad mode
     try:
         compile('1', 'file', '')


### PR DESCRIPTION
And two other minor changes, to fix a DEBUG_printf, and inline a static function.