### PR TITLE
ports: Fix ports missing the vfs module.

### DIFF
--- a/py/mpconfig.h
+++ b/py/mpconfig.h
@@ -1746,7 +1746,7 @@ typedef double mp_float_t;
 
 // Whether to provide the "vfs" module
 #ifndef MICROPY_PY_VFS
-#define MICROPY_PY_VFS (MICROPY_CONFIG_ROM_LEVEL_AT_LEAST_EXTRA_FEATURES && MICROPY_VFS)
+#define MICROPY_PY_VFS (MICROPY_CONFIG_ROM_LEVEL_AT_LEAST_CORE_FEATURES && MICROPY_VFS)
 #endif
 
 #ifndef MICROPY_PY_WEBSOCKET


### PR DESCRIPTION
In PR #13584 the VFS module was not enabled for the SAMD21 port. This  is done now. For some reasons, the builds on the download page have VFS provided.

Note: The same should apply to all boards with the NRF52832 MCU. So it might be better to change the default rule in py/mpconfig.py to set the level limit for VFS to MICROPY_CONFIG_ROM_LEVEL_AT_LEAST_BASIC_FEATURES.
