### PR TITLE
extmod/asyncio: Make current_task raise exception when there is no task.

### DIFF
--- a/extmod/asyncio/core.py
+++ b/extmod/asyncio/core.py
@@ -164,6 +164,7 @@ def run_until_complete(main_task=None):
                 dt = max(0, ticks_diff(t.ph_key, ticks()))
             elif not _io_queue.map:
                 # No tasks can be woken so finished running
+                cur_task = None
                 return
             # print('(poll {})'.format(dt), len(_io_queue.map))
             _io_queue.wait_io_event(dt)
@@ -188,6 +189,7 @@ def run_until_complete(main_task=None):
             assert t.data is None
             # This task is done, check if it's the main task and then loop should stop
             if t is main_task:
+                cur_task = None
                 if isinstance(er, StopIteration):
                     return er.value
                 raise er
@@ -242,6 +244,7 @@ async def _stopper():
     pass
 
 
+cur_task = None
 _stop_task = None
 
 
@@ -291,6 +294,8 @@ def get_event_loop(runq_len=0, waitq_len=0):
 
 
 def current_task():
+    if cur_task is None:
+        raise RuntimeError("no running event loop")
     return cur_task
 
 

--- a/tests/extmod/asyncio_current_task.py
+++ b/tests/extmod/asyncio_current_task.py
@@ -19,4 +19,15 @@ async def main():
     print(t is result[0])
 
 
+try:
+    print(asyncio.current_task())
+except RuntimeError:
+    print("RuntimeError")
+
+
 asyncio.run(main())
+
+try:
+    print(asyncio.current_task())
+except RuntimeError:
+    print("RuntimeError")


### PR DESCRIPTION
Matches CPython behaviour.

Fixes issue #11530.