### PR TITLE
ports/rp2: Use MICROPY_BOARD_DIR to find pins.csv.

### DIFF
--- a/ports/rp2/CMakeLists.txt
+++ b/ports/rp2/CMakeLists.txt
@@ -519,15 +519,14 @@ endforeach()
 # Include the main MicroPython cmake rules.
 include(${MICROPY_DIR}/py/mkrules.cmake)
 
-set(MICROPY_BOARDS_DIR "${MICROPY_PORT_DIR}/boards")
-set(GEN_PINS_AF_CSV "${MICROPY_BOARDS_DIR}/rp2_af.csv")
-set(GEN_PINS_PREFIX "${MICROPY_BOARDS_DIR}/rp2_prefix.c")
-set(GEN_PINS_MKPINS "${MICROPY_BOARDS_DIR}/make-pins.py")
+set(GEN_PINS_AF_CSV "${MICROPY_PORT_DIR}/boards/rp2_af.csv")
+set(GEN_PINS_PREFIX "${MICROPY_PORT_DIR}/boards/rp2_prefix.c")
+set(GEN_PINS_MKPINS "${MICROPY_PORT_DIR}/boards/make-pins.py")
 set(GEN_PINS_SRC "${CMAKE_BINARY_DIR}/pins_${MICROPY_BOARD}.c")
 set(GEN_PINS_HDR "${MICROPY_GENHDR_DIR}/pins.h")
 
-if(EXISTS "${MICROPY_BOARDS_DIR}/${MICROPY_BOARD}/pins.csv")
-    set(GEN_PINS_BOARD_CSV "${MICROPY_BOARDS_DIR}/${MICROPY_BOARD}/pins.csv")
+if(EXISTS "${MICROPY_BOARD_DIR}/pins.csv")
+    set(GEN_PINS_BOARD_CSV "${MICROPY_BOARD_DIR}/pins.csv")
     set(GEN_PINS_CSV_ARG --board-csv "${GEN_PINS_BOARD_CSV}")
 endif()
 


### PR DESCRIPTION
It's not valid to assume that `${MICROPY_PORT_DIR}/boards/${MICROPY_BOARD}` is equal to `${MICROPY_BOARD_DIR}`, because the latter could be *outside* of `${MICROPY_PORT_DIR}`, eg: https://github.com/pimoroni/badger2040/tree/main/firmware/PIMORONI_BADGER2040W

This PR replaces this path with the canonical `${MICROPY_BOARD_DIR}` so that `pins.csv` is correctly located when building against out-of-tree board definitions.

Additionally I've removed `MICROPY_BOARDS_DIR` to discourage similar mistakes.

This bug caused `pins.csv` in our out-of-tree board definitions for Badger 2040W to not be detected- https://github.com/pimoroni/badger2040/issues/60