### PR TITLE
py/modthread: Move thread state initialisation to shared function.

### DIFF
--- a/extmod/modbluetooth.c
+++ b/extmod/modbluetooth.c
@@ -34,7 +34,6 @@
 #include "py/objarray.h"
 #include "py/qstr.h"
 #include "py/runtime.h"
-#include "py/stackctrl.h"
 #include "extmod/modbluetooth.h"
 #include <string.h>
 
@@ -1272,14 +1271,7 @@ STATIC mp_obj_t invoke_irq_handler(uint16_t event,
 
     mp_state_thread_t ts;
     if (ts_orig == NULL) {
-        mp_thread_set_state(&ts);
-        mp_stack_set_top(&ts + 1); // need to include ts in root-pointer scan
-        mp_stack_set_limit(MICROPY_PY_BLUETOOTH_SYNC_EVENT_STACK_SIZE);
-        ts.gc_lock_depth = 0;
-        ts.nlr_jump_callback_top = NULL;
-        ts.mp_pending_exception = MP_OBJ_NULL;
-        mp_locals_set(mp_state_ctx.thread.dict_locals); // set from the outer context
-        mp_globals_set(mp_state_ctx.thread.dict_globals); // set from the outer context
+        mp_thread_init_state(&ts, MICROPY_PY_BLUETOOTH_SYNC_EVENT_STACK_SIZE, NULL, NULL);
         MP_THREAD_GIL_ENTER();
     }
 

--- a/py/modthread.c
+++ b/py/modthread.c
@@ -160,26 +160,13 @@ STATIC void *thread_entry(void *args_in) {
     thread_entry_args_t *args = (thread_entry_args_t *)args_in;
 
     mp_state_thread_t ts;
-    mp_thread_set_state(&ts);
-
-    mp_stack_set_top(&ts + 1); // need to include ts in root-pointer scan
-    mp_stack_set_limit(args->stack_size);
+    mp_thread_init_state(&ts, args->stack_size, args->dict_locals, args->dict_globals);
 
     #if MICROPY_ENABLE_PYSTACK
     // TODO threading and pystack is not fully supported, for now just make a small stack
     mp_obj_t mini_pystack[128];
     mp_pystack_init(mini_pystack, &mini_pystack[128]);
     #endif
-
-    // The GC starts off unlocked on this thread.
-    ts.gc_lock_depth = 0;
-
-    ts.nlr_jump_callback_top = NULL;
-    ts.mp_pending_exception = MP_OBJ_NULL;
-
-    // set locals and globals from the calling context
-    mp_locals_set(args->dict_locals);
-    mp_globals_set(args->dict_globals);
 
     MP_THREAD_GIL_ENTER();
 


### PR DESCRIPTION
Follow-up to https://github.com/micropython/micropython/pull/12832#issuecomment-1786202389.

This moves the code for initialising the MicroPython state on a new thread so it can be reused from multiple modules.

I've placed it in `runtime.h` since that was the most straightforward given the other functions this depends upon.