### PR TITLE
py/emitbc: Remove call to adjust Python stack by 0 entries.

### DIFF
--- a/py/emitbc.c
+++ b/py/emitbc.c
@@ -448,7 +448,6 @@ void mp_emit_bc_label_assign(emit_t *emit, mp_uint_t l) {
     // should be emitted (until another unconditional flow control).
     emit->suppress = false;
 
-    mp_emit_bc_adjust_stack_size(emit, 0);
     if (emit->pass == MP_PASS_SCOPE) {
         return;
     }


### PR DESCRIPTION
This call used to be needed when there was an `emit_bc_pre()` function that needed to be called at the start of each emitted bytecode.  But in 8e7745eb315cdaf7dec033891f88e091ab4e016e that function was removed and now the call to `mp_emit_bc_adjust_stack_size()` does nothing when adjusting by 0 entries, so it can be removed.