### PR TITLE
extmod/os_dumpterm: Handle exception correctly when it happens on read and on write.

### DIFF
--- a/extmod/os_dupterm.c
+++ b/extmod/os_dupterm.c
@@ -45,6 +45,10 @@ void mp_os_deactivate(size_t dupterm_idx, const char *msg, mp_obj_t exc) {
     if (exc != MP_OBJ_NULL) {
         mp_obj_print_exception(&mp_plat_print, exc);
     }
+    if (term == MP_OBJ_NULL) {
+        // Dupterm was already closed.
+        return;
+    }
     nlr_buf_t nlr;
     if (nlr_push(&nlr) == 0) {
         mp_stream_close(term);


### PR DESCRIPTION
When disconnecting from the webrepl abruptly, micropython crashes. Inspection with the debugger reveals, that `dupterm_objs` is already `NULL` and so deactivation/closing segfaults. This happens because the `dupterm_obj` is already removed from the exception that was handled when trying to read from the socket.