### PR TITLE
mpremote: Implement mip install from GitLab.

### DIFF
--- a/docs/reference/mpremote.rst
+++ b/docs/reference/mpremote.rst
@@ -684,6 +684,13 @@ device. See :ref:`packages`.
 
 .. code-block:: bash
 
+  mpremote mip install gitlab:org/repo@branch
+
+Install the package from the specified branch at org/repo on GitLab to the
+device. See :ref:`packages`.
+
+.. code-block:: bash
+
   mpremote mip install --target /flash/third-party functools
 
 Install the ``functools`` package from :term:`micropython-lib` to the

--- a/docs/reference/packages.rst
+++ b/docs/reference/packages.rst
@@ -7,7 +7,7 @@ Installing packages with ``mip``
 --------------------------------
 
 Network-capable boards include the ``mip`` module, which can install packages
-from :term:`micropython-lib` and from third-party sites (including GitHub).
+from :term:`micropython-lib` and from third-party sites (including GitHub, GitLab).
 
 ``mip`` ("mip installs packages") is similar in concept to Python's ``pip`` tool,
 however it does not use the PyPI index, rather it uses :term:`micropython-lib`
@@ -38,24 +38,28 @@ install third-party libraries. The simplest way is to download a file directly::
 When installing a file directly, the ``target`` argument is still supported to set
 the destination path, but ``mpy`` and ``version`` are ignored.
 
-The URL can also start with ``github:`` as a simple way of pointing to content
-hosted on GitHub::
+The URL can also start with ``github:`` or ``gitlab:`` as a simple way of pointing to content
+hosted on GitHub or GitLab::
 
     >>> mip.install("github:org/repo/path/foo.py")  # Uses default branch
     >>> mip.install("github:org/repo/path/foo.py", version="branch-or-tag")  # Optionally specify the branch or tag
+    >>> mip.install("gitlab:org/repo/path/foo.py")  # Uses default branch
+    >>> mip.install("gitlab:org/repo/path/foo.py", version="branch-or-tag")  # Optionally specify the branch or tag
 
 More sophisticated packages (i.e. with more than one file, or with dependencies)
 can be downloaded by specifying the path to their ``package.json``.
 
     >>> mip.install("http://example.com/x/package.json")
     >>> mip.install("github:org/user/path/package.json")
+    >>> mip.install("gitlab:org/user/path/package.json")
 
 If no json file is specified, then "package.json" is implicitly added::
 
     >>> mip.install("http://example.com/x/")
     >>> mip.install("github:org/repo")  # Uses default branch of that repo
     >>> mip.install("github:org/repo", version="branch-or-tag")
-
+    >>> mip.install("gitlab:org/repo")  # Uses default branch of that repo
+    >>> mip.install("gitlab:org/repo", version="branch-or-tag")
 
 Using ``mip`` on the Unix port
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -83,6 +87,8 @@ can be used from a host PC to install packages to a locally connected device
     $ mpremote mip install http://example.com/x/y/foo.py
     $ mpremote mip install github:org/repo
     $ mpremote mip install github:org/repo@branch-or-tag
+    $ mpremote mip install gitlab:org/repo
+    $ mpremote mip install gitlab:org/repo@branch-or-tag
 
 The ``--target=path``, ``--no-mpy``, and ``--index`` arguments can be set::
 
@@ -120,7 +126,8 @@ A typical ``package.json`` for an example ``mlx90640`` library looks like::
       "deps": [
         ["collections-defaultdict", "latest"],
         ["os-path", "latest"],
-        ["github:org/micropython-additions", "main"]
+        ["github:org/micropython-additions", "main"],
+        ["gitlab:org/micropython-otheradditions", "main"]
       ],
       "version": "0.2"
     }

--- a/tools/mpremote/README.md
+++ b/tools/mpremote/README.md
@@ -80,3 +80,4 @@ Examples:
     mpremote cp -r dir/ :
     mpremote mip install aioble
     mpremote mip install github:org/repo@branch
+    mpremote mip install gitlab:org/repo@branch

--- a/tools/mpremote/mpremote/main.py
+++ b/tools/mpremote/mpremote/main.py
@@ -214,7 +214,7 @@ def argparse_mip():
     cmd_parser.add_argument(
         "packages",
         nargs="+",
-        help="list package specifications, e.g. name, name@version, github:org/repo, github:org/repo@branch",
+        help="list package specifications, e.g. name, name@version, github:org/repo, github:org/repo@branch, gitlab:org/repo, gitlab:org/repo@branch",
     )
     return cmd_parser
 

--- a/tools/mpremote/mpremote/mip.py
+++ b/tools/mpremote/mpremote/mip.py
@@ -65,6 +65,18 @@ def _rewrite_url(url, branch=None):
             + "/"
             + "/".join(url[2:])
         )
+    elif url.startswith("gitlab:"):
+        url = url[7:].split("/")
+        url = (
+            "https://gitlab.com/"
+            + url[0]
+            + "/"
+            + url[1]
+            + "/-/raw/"
+            + branch
+            + "/"
+            + "/".join(url[2:])
+        )
     return url
 
 
@@ -116,6 +128,7 @@ def _install_package(transport, package, index, target, version, mpy):
         package.startswith("http://")
         or package.startswith("https://")
         or package.startswith("github:")
+        or package.startswith("gitlab:")
     ):
         if package.endswith(".py") or package.endswith(".mpy"):
             print(f"Downloading {package} to {target}")


### PR DESCRIPTION
mpremote: Implement mip install from GitLab.

tools/mpremote/README.md: Add mip install gitlab:org/repo@branch.
Add example `mpremote mip install gitlab:org/repo@branch`.

tools/mpremote/mpremote/mip.py: Implement install from GitLab.
Modify _rewrite_url() to allow mip install from `gitlab:` repository.

mpremote/mpremote/main.py: Add gitlab:org/repo, gitlab:org/repo@branch.
Modify argparse_mip() for gitlab:org/repo, gitlab:org/repo@branch.

docs/reference/packages.rst: Mip install from GitLab.
Describe how to mip install from GitLab.

docs/reference/mpremote.rst: Install package from GitLab.
Install the package from the specified branch at org/repo on GitLab.

Signed-off-by: Olivier Lenoir <olivier.len02@gmail.com>