### PR TITLE
Esp32 bootloader fixes

### DIFF
--- a/ports/esp32/modmachine.c
+++ b/ports/esp32/modmachine.c
@@ -220,11 +220,13 @@ static mp_int_t mp_machine_reset_cause(void) {
     }
 }
 
+#ifdef MICROPY_BOARD_ENTER_BOOTLOADER
 NORETURN void mp_machine_bootloader(size_t n_args, const mp_obj_t *args) {
     MICROPY_BOARD_ENTER_BOOTLOADER(n_args, args);
     for (;;) {
     }
 }
+#endif
 
 void machine_init(void) {
     is_soft_reset = 0;

--- a/ports/esp32/modmachine.c
+++ b/ports/esp32/modmachine.c
@@ -220,6 +220,14 @@ static mp_int_t mp_machine_reset_cause(void) {
     }
 }
 
+#if MICROPY_ESP32_USE_BOOTLOADER_RTC
+#include "soc/rtc_cntl_reg.h"
+NORETURN static void machine_bootloader_rtc(void) {
+    REG_WRITE(RTC_CNTL_OPTION1_REG, RTC_CNTL_FORCE_DOWNLOAD_BOOT);
+    esp_restart();
+}
+#endif
+
 #ifdef MICROPY_BOARD_ENTER_BOOTLOADER
 NORETURN void mp_machine_bootloader(size_t n_args, const mp_obj_t *args) {
     MICROPY_BOARD_ENTER_BOOTLOADER(n_args, args);

--- a/ports/esp32/mpconfigport.h
+++ b/ports/esp32/mpconfigport.h
@@ -268,6 +268,14 @@ typedef long mp_off_t;
 #define MICROPY_HW_ENABLE_MDNS_RESPONDER    (1)
 #endif
 
+#ifndef MICROPY_BOARD_ENTER_BOOTLOADER
+// RTC has a register to trigger bootloader on these targets
+#if CONFIG_IDF_TARGET_ESP32S2 || CONFIG_IDF_TARGET_ESP32S3 || CONFIG_IDF_TARGET_ESP32C2 || CONFIG_IDF_TARGET_ESP32C3
+#define MICROPY_ESP32_USE_BOOTLOADER_RTC    (1)
+#define MICROPY_BOARD_ENTER_BOOTLOADER(nargs, args) machine_bootloader_rtc()
+#endif
+#endif
+
 #ifdef MICROPY_BOARD_ENTER_BOOTLOADER
 #define MICROPY_PY_MACHINE_BOOTLOADER       (1)
 #else

--- a/ports/esp32/mpconfigport.h
+++ b/ports/esp32/mpconfigport.h
@@ -115,7 +115,6 @@
 #define MICROPY_PY_MACHINE                  (1)
 #define MICROPY_PY_MACHINE_INCLUDEFILE      "ports/esp32/modmachine.c"
 #define MICROPY_PY_MACHINE_BARE_METAL_FUNCS (1)
-#define MICROPY_PY_MACHINE_BOOTLOADER       (1)
 #define MICROPY_PY_MACHINE_DISABLE_IRQ_ENABLE_IRQ (1)
 #define MICROPY_PY_MACHINE_ADC              (1)
 #define MICROPY_PY_MACHINE_ADC_INCLUDEFILE  "ports/esp32/machine_adc.c"
@@ -269,8 +268,10 @@ typedef long mp_off_t;
 #define MICROPY_HW_ENABLE_MDNS_RESPONDER    (1)
 #endif
 
-#ifndef MICROPY_BOARD_ENTER_BOOTLOADER
-#define MICROPY_BOARD_ENTER_BOOTLOADER(nargs, args)
+#ifdef MICROPY_BOARD_ENTER_BOOTLOADER
+#define MICROPY_PY_MACHINE_BOOTLOADER       (1)
+#else
+#define MICROPY_PY_MACHINE_BOOTLOADER       (0)
 #endif
 
 #ifndef MICROPY_BOARD_STARTUP


### PR DESCRIPTION
Currently only the Arduino Nano ESP32 defines a machine.bootloader handler for ESP32.  All other boards will intentionally hang.

There is no error message, nor is a NotImplementedError raised.  There's no indication if Micropython has crashed, or if the bootloader was entered but USB is not working, which is a real problem the ESP32 bootloader has.  It's not possible escape from this hang with ^C or any other means besides physical access to the reset pin or the ability to cycle power.

Change this to only define an implementation of machine.bootloader() when there is a handler for it.

Support bootloader on ESP32-S2/S3/C2/C3.

On these targets it's possible to enter the bootloader by setting a bit in an RTC register before resetting.

Structure it in a way that a board can still provide a custom bootloader handler.  The handler here will be the default if none is provided, for any board based on the supported targets.
