### PR TITLE
unix: Fix support for Bluetooth via libusb, add HCI dump feature

### DIFF
--- a/ports/unix/Makefile
+++ b/ports/unix/Makefile
@@ -33,6 +33,25 @@ QSTR_GLOBAL_DEPENDENCIES += $(VARIANT_DIR)/mpconfigvariant.h
 # OS name, for simple autoconfig
 UNAME_S := $(shell uname -s)
 
+# If the variant enables it, enable modbluetooth.
+ifeq ($(MICROPY_PY_BLUETOOTH),1)
+ifeq ($(MICROPY_BLUETOOTH_BTSTACK),1)
+HAVE_LIBUSB := $(shell (which pkg-config > /dev/null && pkg-config --exists libusb-1.0) 2>/dev/null && echo '1')
+
+# Figure out which BTstack transport to use.
+ifeq ($(HAVE_LIBUSB),1)
+# Default to btstack-over-usb.
+MICROPY_BLUETOOTH_BTSTACK_USB ?= 1
+MICROPY_BLUETOOTH_BTSTACK_H4 ?= 0
+else
+# Fallback to HCI controller via a H4 UART (e.g. Zephyr on nRF) over a /dev/tty serial port.
+MICROPY_BLUETOOTH_BTSTACK_USB ?= 0
+MICROPY_BLUETOOTH_BTSTACK_H4 ?= 1
+endif
+
+endif
+endif
+
 # include py core make definitions
 include $(TOP)/py/py.mk
 include $(TOP)/extmod/extmod.mk
@@ -144,20 +163,8 @@ ifeq ($(MICROPY_SSL_AXTLS),1)
 endif
 endif
 
-# If the variant enables it, enable modbluetooth.
 ifeq ($(MICROPY_PY_BLUETOOTH),1)
 ifeq ($(MICROPY_BLUETOOTH_BTSTACK),1)
-HAVE_LIBUSB := $(shell (which pkg-config > /dev/null && pkg-config --exists libusb-1.0) 2>/dev/null && echo '1')
-
-# Figure out which BTstack transport to use.
-ifeq ($(HAVE_LIBUSB),1)
-# Default to btstack-over-usb.
-MICROPY_BLUETOOTH_BTSTACK_USB ?= 1
-else
-# Fallback to HCI controller via a H4 UART (e.g. Zephyr on nRF) over a /dev/tty serial port.
-MICROPY_BLUETOOTH_BTSTACK_H4 ?= 1
-endif
-
 SRC_BTSTACK_C += lib/btstack/platform/embedded/btstack_run_loop_embedded.c
 endif
 endif

--- a/ports/unix/Makefile
+++ b/ports/unix/Makefile
@@ -49,6 +49,12 @@ MICROPY_BLUETOOTH_BTSTACK_USB ?= 0
 MICROPY_BLUETOOTH_BTSTACK_H4 ?= 1
 endif
 
+# MICROPY_BLUETOOTH_BTSTACK_HCI_DUMP could be set to 1 to activate logging
+# to file "/tmp/hci_dump.pklg" for btstack-over-usb.
+ifndef MICROPY_BLUETOOTH_BTSTACK_HCI_DUMP
+MICROPY_BLUETOOTH_BTSTACK_HCI_DUMP ?= 0
+endif
+
 # Set the file that will be included by "extmod/btstack/btstack_config.h"
 # 
 # The original file "extmod/btstack/btstack_config_common.h"
@@ -171,7 +177,21 @@ endif
 
 ifeq ($(MICROPY_PY_BLUETOOTH),1)
 ifeq ($(MICROPY_BLUETOOTH_BTSTACK),1)
+
+ifeq ($(MICROPY_BLUETOOTH_BTSTACK_USB),0)
 SRC_BTSTACK_C += lib/btstack/platform/embedded/btstack_run_loop_embedded.c
+endif
+
+ifeq ($(MICROPY_BLUETOOTH_BTSTACK_USB),1)
+SRC_BTSTACK_C += lib/btstack/platform/posix/btstack_run_loop_posix.c
+
+ifeq ($(MICROPY_BLUETOOTH_BTSTACK_HCI_DUMP),1)
+CFLAGS += -DMICROPY_BLUETOOTH_BTSTACK_HCI_DUMP=1
+SRC_BTSTACK_C += lib/btstack/platform/posix/hci_dump_posix_fs.c
+endif
+
+endif
+
 endif
 endif
 

--- a/ports/unix/Makefile
+++ b/ports/unix/Makefile
@@ -49,8 +49,14 @@ MICROPY_BLUETOOTH_BTSTACK_USB ?= 0
 MICROPY_BLUETOOTH_BTSTACK_H4 ?= 1
 endif
 
-endif
-endif
+# Set the file that will be included by "extmod/btstack/btstack_config.h"
+# 
+# The original file "extmod/btstack/btstack_config_common.h"
+# will be included by it. 
+MICROPY_BLUETOOTH_BTSTACK_CONFIG_FILE ?= '"ports/unix/btstack_config.h"'
+
+endif # MICROPY_BLUETOOTH_BTSTACK
+endif # MICROPY_PY_BLUETOOTH
 
 # include py core make definitions
 include $(TOP)/py/py.mk

--- a/ports/unix/btstack_config.h
+++ b/ports/unix/btstack_config.h
@@ -1,0 +1,23 @@
+#ifndef MICROPY_INCLUDED_PORTS_UNIX_BTSTACK_CONFIG_H
+#define MICROPY_INCLUDED_PORTS_UNIX_BTSTACK_CONFIG_H
+
+
+#include "extmod/btstack/btstack_config_common.h"
+
+#ifdef MICROPY_BLUETOOTH_BTSTACK_USB
+#if MICROPY_BLUETOOTH_BTSTACK_USB
+
+// Workaround:
+//
+// If ENABLE_SCO_OVER_HCI is not defined there is a compiler error:
+//
+// ../../lib/btstack/platform/libusb/hci_transport_h2_libusb.c:1354:13:
+// error: ‘signal_sco_can_send_now’ defined but not used
+//
+// Because the problem is in an external code this workaround is done.
+#define ENABLE_SCO_OVER_HCI
+
+#endif
+#endif
+
+#endif // MICROPY_INCLUDED_PORTS_UNIX_BTSTACK_CONFIG_H

--- a/ports/unix/mpbtstackport_common.c
+++ b/ports/unix/mpbtstackport_common.c
@@ -41,7 +41,7 @@
 
 #include "mpbtstackport.h"
 
-// Called by the UART polling thread in mpbthciport.c, or by the USB polling thread in mpbtstackport_usb.c.
+// Called by the UART polling thread in mpbthciport.c
 bool mp_bluetooth_hci_poll(void) {
     if (mp_bluetooth_btstack_state == MP_BLUETOOTH_BTSTACK_STATE_STARTING || mp_bluetooth_btstack_state == MP_BLUETOOTH_BTSTACK_STATE_ACTIVE || mp_bluetooth_btstack_state == MP_BLUETOOTH_BTSTACK_STATE_HALTING) {
         // Pretend like we're running in IRQ context (i.e. other things can't be running at the same time).
@@ -80,9 +80,11 @@ uint32_t hal_time_ms(void) {
 }
 
 void mp_bluetooth_btstack_port_init(void) {
+    #if !MICROPY_BLUETOOTH_BTSTACK_USB
     btstack_run_loop_init(btstack_run_loop_embedded_get_instance());
 
     // hci_dump_init(hci_dump_embedded_stdout_get_instance());
+    #endif
 
     #if MICROPY_BLUETOOTH_BTSTACK_H4
     mp_bluetooth_btstack_port_init_h4();

--- a/ports/unix/mpbtstackport_usb.c
+++ b/ports/unix/mpbtstackport_usb.c
@@ -147,7 +147,7 @@ void mp_bluetooth_btstack_port_deinit(void) {
 // stack_limit:
 // Value that will be used for mp_stack_set_limit().
 //
-STATIC void init_mp_state_thread(mp_state_thread_t *ts, mp_uint_t stack_limit) {
+static void init_mp_state_thread(mp_state_thread_t *ts, mp_uint_t stack_limit) {
 
     mp_thread_set_state(ts);
     mp_stack_set_top(ts + 1); // need to include ts in root-pointer scan
@@ -167,7 +167,7 @@ STATIC void init_mp_state_thread(mp_state_thread_t *ts, mp_uint_t stack_limit) {
 //
 // The function was extracted from invoke_irq_handler() in extmod/modbluetooth.c.
 //
-STATIC void deinit_mp_state_thread() {
+static void deinit_mp_state_thread() {
 
     MP_THREAD_GIL_EXIT();
     mp_thread_set_state(NULL);


### PR DESCRIPTION
ports/unix did not build with
"make MICROPY_PY_BLUETOOTH=1 MICROPY_BLUETOOTH_BTSTACK=1".

This PR fixes it. If libusb-1.0 exists on the machine "MICROPY_BLUETOOTH_BTSTACK_USB=1" is
automatically set and Bluetooth over USB should work.

Now also a log file "/tmp/hci_dump.pklg" could be activated by setting
"MICROPY_BLUETOOTH_BTSTACK_HCI_DUMP=1".
