### PR TITLE
esp/network_lan.c: Provide separate arguments for phy_reset and phy_power.

### DIFF
--- a/docs/esp32/quickref.rst
+++ b/docs/esp32/quickref.rst
@@ -128,6 +128,7 @@ The keyword arguments for the constructor defining the PHY type and interface ar
 
 - mdc=pin-object    # set the mdc and mdio pins.
 - mdio=pin-object
+- reset=pin-object  # set the reset pin of the PHY device.
 - power=pin-object  # set the pin which switches the power of the PHY device.
 - phy_type=<type>   # Select the PHY device type. Supported devices are PHY_LAN8710,
   PHY_LAN8720, PH_IP101, PHY_RTL8201, PHY_DP83848 and PHY_KSZ8041


### PR DESCRIPTION
Before, the pin defined for power would be used by the esp_idf driver to reset the PHY. That worked, but sometimes the MDIO configuration started before the power was fully settled, leading to an error. With that change, the power for the PHY is independently enabled in network_lan.c with a 100ms delay to allow the power to settle. A separate define for a reset Pin is provided, even if the PHY reset pin is rarely connected.

It is assumed, that setting the power control pin high enables the power.
Tested with an Olimex ESP32 Ethernet POE board.
Addresses Issue #14013