### PR TITLE
py/emitglue: Add explicit cast of proto_fun to uint8_t pointer.

### DIFF
--- a/ports/webassembly/Makefile
+++ b/ports/webassembly/Makefile
@@ -38,7 +38,6 @@ OBJ += $(addprefix $(BUILD)/, $(SRC_C:.c=.o))
 JSFLAGS += -s ASYNCIFY
 JSFLAGS += -s EXPORTED_FUNCTIONS="['_mp_js_init', '_mp_js_init_repl', '_mp_js_do_str', '_mp_js_process_char', '_mp_hal_get_interrupt_char', '_mp_sched_keyboard_interrupt']"
 JSFLAGS += -s EXPORTED_RUNTIME_METHODS="['ccall', 'cwrap', 'FS']"
-JSFLAGS += -s --memory-init-file 0
 JSFLAGS += --js-library library.js
 
 all: $(BUILD)/micropython.js

--- a/py/emitglue.h
+++ b/py/emitglue.h
@@ -63,7 +63,7 @@ typedef const void *mp_proto_fun_t;
 // is guaranteed to have either its first or second byte non-zero.  So if both bytes are
 // zero then the mp_proto_fun_t pointer must be an mp_raw_code_t.
 static inline bool mp_proto_fun_is_bytecode(mp_proto_fun_t proto_fun) {
-    const uint8_t *header = proto_fun;
+    const uint8_t *header = (const uint8_t *)proto_fun;
     return (header[0] | (header[1] << 8)) != (MP_PROTO_FUN_INDICATOR_RAW_CODE_0 | (MP_PROTO_FUN_INDICATOR_RAW_CODE_1 << 8));
 }
 


### PR DESCRIPTION
Otherwise C++ compilers may complain when this header is included in an extern "C" block.