### PR TITLE
esp32/machine_uart: Apply timeout_char default.

### DIFF
--- a/ports/esp32/machine_uart.c
+++ b/ports/esp32/machine_uart.c
@@ -277,17 +277,17 @@ static void mp_machine_uart_init_helper(machine_uart_obj_t *self, size_t n_args,
     }
 
     // set timeout_char
-    // make sure it is at least as long as a whole character (12 bits here)
     if (args[ARG_timeout_char].u_int != -1) {
         self->timeout_char = args[ARG_timeout_char].u_int;
-        uint32_t char_time_ms = 12000 / baudrate + 1;
-        uint32_t rx_timeout = self->timeout_char / char_time_ms;
-        if (rx_timeout < 1) {
-            check_esp_err(uart_set_rx_full_threshold(self->uart_num, 1));
-            check_esp_err(uart_set_rx_timeout(self->uart_num, 1));
-        } else {
-            check_esp_err(uart_set_rx_timeout(self->uart_num, rx_timeout));
-        }
+    }
+    // make sure it is at least as long as a whole character (12 bits here)
+    uint32_t char_time_ms = 12000 / baudrate + 1;
+    uint32_t rx_timeout = self->timeout_char / char_time_ms;
+    if (rx_timeout < 1) {
+        check_esp_err(uart_set_rx_full_threshold(self->uart_num, 1));
+        check_esp_err(uart_set_rx_timeout(self->uart_num, 1));
+    } else {
+        check_esp_err(uart_set_rx_timeout(self->uart_num, rx_timeout));
     }
 
     // set line inversion


### PR DESCRIPTION
If the `timeout_char` parameter is not given, we should still configure the UART to ensure the UART is always initialized consistently. So the default of `0`get applied correctly, or if for example the baud rate was changed the char timeout isn't still based on the old baud rate causing weird behaviour, etc.