### PR TITLE
docs/library/machine.UART: Fix UART.irq docs to match current code.

### DIFF
--- a/docs/library/machine.UART.rst
+++ b/docs/library/machine.UART.rst
@@ -152,31 +152,6 @@ Methods
    Send a break condition on the bus. This drives the bus low for a duration
    longer than required for a normal transmission of a character.
 
-.. method:: UART.irq(trigger, priority=1, handler=None, wake=machine.IDLE)
-
-   Create a callback to be triggered when data is received on the UART.
-
-       - *trigger* can only be ``UART.RX_ANY``
-       - *priority* level of the interrupt. Can take values in the range 1-7.
-         Higher values represent higher priorities.
-       - *handler* an optional function to be called when new characters arrive.
-       - *wake* can only be ``machine.IDLE``.
-
-   .. note::
-
-      The handler will be called whenever any of the following two conditions are met:
-
-          - 8 new characters have been received.
-          - At least 1 new character is waiting in the Rx buffer and the Rx line has been
-            silent for the duration of 1 complete frame.
-
-      This means that when the handler function is called there will be between 1 to 8
-      characters waiting.
-
-   Returns an irq object.
-
-   Availability: WiPy.
-
 .. method:: UART.flush()
 
    Waits until all data has been sent. In case of a timeout, an exception is raised. The timeout
@@ -203,11 +178,42 @@ Methods
 
    Availability: rp2, esp32, esp8266, mimxrt, cc3200, stm32, nrf ports, renesas-ra
 
+.. method:: UART.irq(handler=None, trigger=0, hard=False)
+
+   Configure an interrupt handler to be called when a UART event occurs.
+
+   The arguments are:
+
+     - *handler* is an optional function to be called when the interrupt event
+       triggers.  The handler must take exactly one argument which is the
+       ``UART`` instance.
+
+     - *trigger* configures the event which can generate an interrupt.
+       Possible values are:
+
+       - ``UART.IRQ_RXIDLE`` interrupt after receiving at least one character
+         and then the RX line goes idle.
+
+     - *hard* if true a hardware interrupt is used.  This reduces the delay
+       between the pin change and the handler being called.  Hard interrupt
+       handlers may not allocate memory; see :ref:`isr_rules`.
+
+   Returns an irq object.
+
+   Availability: renesas-ra, stm32.
+
 Constants
 ---------
 
-.. data:: UART.RX_ANY
+.. data:: UART.RTS
+          UART.CTS
 
-    IRQ trigger sources
+    Flow control options.
 
-    Availability: WiPy.
+    Availability: esp32, mimxrt, renesas-ra, rp2, stm32.
+
+.. data:: UART.IRQ_RXIDLE
+
+    IRQ trigger sources.
+
+    Availability: stm32.


### PR DESCRIPTION
These docs now match the code in `extmod/machine_uart.c`.