### PR TITLE
py: Add support for function doc strings.

### DIFF
--- a/py/compile.c
+++ b/py/compile.c
@@ -797,6 +797,32 @@ static qstr compile_funcdef_helper(compiler_t *comp, mp_parse_node_struct_t *pns
     // compile the function definition
     compile_funcdef_lambdef(comp, fscope, pns->nodes[1], PN_typedargslist);
 
+    #if MICROPY_ENABLE_DOC_STRING
+    // look for the first statement
+    mp_parse_node_t pn = pns->nodes[3]; // the function body/suite
+    if (MP_PARSE_NODE_IS_STRUCT_KIND(pn, PN_suite_block_stmts)) {
+        // a list of statements; get the first one
+        pn = ((mp_parse_node_struct_t *)pn)->nodes[0];
+    }
+
+    // check the first statement for a doc string
+    if (MP_PARSE_NODE_IS_STRUCT_KIND(pn, PN_expr_stmt)) {
+        mp_parse_node_struct_t *pns2 = (mp_parse_node_struct_t *)pn;
+        if ((MP_PARSE_NODE_IS_LEAF(pns2->nodes[0])
+             && MP_PARSE_NODE_LEAF_KIND(pns2->nodes[0]) == MP_PARSE_NODE_STRING)
+            || (MP_PARSE_NODE_IS_STRUCT_KIND(pns2->nodes[0], PN_const_object)
+                && mp_obj_is_str(mp_parse_node_extract_const_object((mp_parse_node_struct_t *)pns2->nodes[0])))) {
+            // duplicate the function on the stack
+            EMIT(dup_top);
+            // compile the doc string
+            compile_node(comp, pns2->nodes[0]);
+            // store the doc string into the function
+            EMIT(rot_two);
+            EMIT_ARG(attr, MP_QSTR___doc__, MP_EMIT_ATTR_STORE);
+        }
+    }
+    #endif
+
     // return its name (the 'f' in "def f(...):")
     return fscope->simple_name;
 }

--- a/py/compile.c
+++ b/py/compile.c
@@ -280,6 +280,7 @@ static void compile_trailer_paren_helper(compiler_t *comp, mp_parse_node_t pn_ar
 static void compile_comprehension(compiler_t *comp, mp_parse_node_struct_t *pns, scope_kind_t kind);
 static void compile_atom_brace_helper(compiler_t *comp, mp_parse_node_struct_t *pns, bool create_map);
 static void compile_node(compiler_t *comp, mp_parse_node_t pn);
+static void check_for_doc_string(compiler_t *comp, mp_parse_node_t pn, bool store_to_func_attr);
 
 static uint comp_next_label(compiler_t *comp) {
     return comp->next_label++;
@@ -797,31 +798,8 @@ static qstr compile_funcdef_helper(compiler_t *comp, mp_parse_node_struct_t *pns
     // compile the function definition
     compile_funcdef_lambdef(comp, fscope, pns->nodes[1], PN_typedargslist);
 
-    #if MICROPY_ENABLE_DOC_STRING
-    // look for the first statement
-    mp_parse_node_t pn = pns->nodes[3]; // the function body/suite
-    if (MP_PARSE_NODE_IS_STRUCT_KIND(pn, PN_suite_block_stmts)) {
-        // a list of statements; get the first one
-        pn = ((mp_parse_node_struct_t *)pn)->nodes[0];
-    }
-
-    // check the first statement for a doc string
-    if (MP_PARSE_NODE_IS_STRUCT_KIND(pn, PN_expr_stmt)) {
-        mp_parse_node_struct_t *pns2 = (mp_parse_node_struct_t *)pn;
-        if ((MP_PARSE_NODE_IS_LEAF(pns2->nodes[0])
-             && MP_PARSE_NODE_LEAF_KIND(pns2->nodes[0]) == MP_PARSE_NODE_STRING)
-            || (MP_PARSE_NODE_IS_STRUCT_KIND(pns2->nodes[0], PN_const_object)
-                && mp_obj_is_str(mp_parse_node_extract_const_object((mp_parse_node_struct_t *)pns2->nodes[0])))) {
-            // duplicate the function on the stack
-            EMIT(dup_top);
-            // compile the doc string
-            compile_node(comp, pns2->nodes[0]);
-            // store the doc string into the function
-            EMIT(rot_two);
-            EMIT_ARG(attr, MP_QSTR___doc__, MP_EMIT_ATTR_STORE);
-        }
-    }
-    #endif
+    // check the function body/suite for a docstring
+    check_for_doc_string(comp, pns->nodes[3], true);
 
     // return its name (the 'f' in "def f(...):")
     return fscope->simple_name;
@@ -3024,7 +3002,7 @@ tail_recursion:
     EMIT(for_iter_end);
 }
 
-static void check_for_doc_string(compiler_t *comp, mp_parse_node_t pn) {
+static void check_for_doc_string(compiler_t *comp, mp_parse_node_t pn, bool store_to_func_attr) {
     #if MICROPY_ENABLE_DOC_STRING
     // see http://www.python.org/dev/peps/pep-0257/
 
@@ -3057,10 +3035,20 @@ static void check_for_doc_string(compiler_t *comp, mp_parse_node_t pn) {
              && MP_PARSE_NODE_LEAF_KIND(pns->nodes[0]) == MP_PARSE_NODE_STRING)
             || (MP_PARSE_NODE_IS_STRUCT_KIND(pns->nodes[0], PN_const_object)
                 && mp_obj_is_str(get_const_object((mp_parse_node_struct_t *)pns->nodes[0])))) {
+            if (store_to_func_attr) {
+                // duplicate the function on the stack
+                EMIT(dup_top);
+            }
             // compile the doc string
             compile_node(comp, pns->nodes[0]);
-            // store the doc string
-            compile_store_id(comp, MP_QSTR___doc__);
+            if (store_to_func_attr) {
+                // store the doc string into the function
+                EMIT(rot_two);
+                EMIT_ARG(attr, MP_QSTR___doc__, MP_EMIT_ATTR_STORE);
+            } else {
+                // store the doc string to the module/class dict
+                compile_store_id(comp, MP_QSTR___doc__);
+            }
         }
     }
     #else
@@ -3092,7 +3080,7 @@ static bool compile_scope(compiler_t *comp, scope_t *scope, pass_kind_t pass) {
         EMIT(return_value);
     } else if (scope->kind == SCOPE_MODULE) {
         if (!comp->is_repl) {
-            check_for_doc_string(comp, scope->pn);
+            check_for_doc_string(comp, scope->pn, false);
         }
         compile_node(comp, scope->pn);
         EMIT_ARG(load_const_tok, MP_TOKEN_KW_NONE);
@@ -3211,7 +3199,7 @@ static bool compile_scope(compiler_t *comp, scope_t *scope, pass_kind_t pass) {
         EMIT_ARG(load_const_str, MP_PARSE_NODE_LEAF_ARG(pns->nodes[0])); // 0 is class name
         compile_store_id(comp, MP_QSTR___qualname__);
 
-        check_for_doc_string(comp, pns->nodes[2]);
+        check_for_doc_string(comp, pns->nodes[2], false);
         compile_node(comp, pns->nodes[2]); // 2 is class body
 
         id_info_t *id = scope_find(scope, MP_QSTR___class__);
@@ -3228,6 +3216,7 @@ static bool compile_scope(compiler_t *comp, scope_t *scope, pass_kind_t pass) {
 
     // make sure we match all the exception levels
     assert(comp->cur_except_level == 0);
+
 
     return pass_complete;
 }

--- a/py/mpconfig.h
+++ b/py/mpconfig.h
@@ -917,7 +917,7 @@ typedef long long mp_longint_impl_t;
 #define MICROPY_ENABLE_SOURCE_LINE (MICROPY_CONFIG_ROM_LEVEL_AT_LEAST_EXTRA_FEATURES)
 #endif
 
-// Whether to include doc strings (increases RAM usage)
+// Whether to include doc strings for functions, classes and modules (increases RAM usage)
 #ifndef MICROPY_ENABLE_DOC_STRING
 #define MICROPY_ENABLE_DOC_STRING (MICROPY_CONFIG_ROM_LEVEL_AT_LEAST_EVERYTHING)
 #endif

--- a/py/mpconfig.h
+++ b/py/mpconfig.h
@@ -919,7 +919,7 @@ typedef long long mp_longint_impl_t;
 
 // Whether to include doc strings (increases RAM usage)
 #ifndef MICROPY_ENABLE_DOC_STRING
-#define MICROPY_ENABLE_DOC_STRING (0)
+#define MICROPY_ENABLE_DOC_STRING (MICROPY_CONFIG_ROM_LEVEL_AT_LEAST_EVERYTHING)
 #endif
 
 // Exception messages are removed (requires disabling MICROPY_ROM_TEXT_COMPRESSION)

--- a/py/objfun.c
+++ b/py/objfun.c
@@ -356,6 +356,17 @@ static mp_obj_t fun_bc_call(mp_obj_t self_in, size_t n_args, size_t n_kw, const 
 void mp_obj_fun_bc_attr(mp_obj_t self_in, qstr attr, mp_obj_t *dest) {
     if (dest[0] != MP_OBJ_NULL) {
         // not load attribute
+        #if MICROPY_ENABLE_DOC_STRING
+        mp_obj_fun_bc_t *self = MP_OBJ_TO_PTR(self_in);
+        if (attr == MP_QSTR___doc__) {
+            if (dest[1] == MP_OBJ_NULL) {
+                self->doc_string = mp_const_none;
+            } else {
+                self->doc_string = dest[1];
+            }
+            dest[0] = MP_OBJ_NULL; // success with store/delete
+        }
+        #endif
         return;
     }
     const mp_obj_fun_bc_t *self = MP_OBJ_TO_PTR(self_in);
@@ -389,6 +400,11 @@ void mp_obj_fun_bc_attr(mp_obj_t self_in, qstr attr, mp_obj_t *dest) {
             dest[0] = mp_obj_new_code(self->context, self->rc, true);
             #endif
         }
+    }
+    #endif
+    #if MICROPY_ENABLE_DOC_STRING
+    if (attr == MP_QSTR___doc__) {
+        dest[0] = self->doc_string;
     }
     #endif
 }
@@ -442,6 +458,9 @@ mp_obj_t mp_obj_new_fun_bc(const mp_obj_t *def_args, const byte *code, const mp_
     o->bytecode = code;
     o->context = context;
     o->child_table = child_table;
+    #if MICROPY_ENABLE_DOC_STRING
+    o->doc_string = mp_const_none;
+    #endif
     if (def_pos_args != NULL) {
         memcpy(o->extra_args, def_pos_args->items, n_def_args * sizeof(mp_obj_t));
     }

--- a/py/objfun.h
+++ b/py/objfun.h
@@ -34,6 +34,9 @@ typedef struct _mp_obj_fun_bc_t {
     const mp_module_context_t *context;         // context within which this function was defined
     struct _mp_raw_code_t *const *child_table;  // table of children
     const byte *bytecode;                       // bytecode for the function
+    #if MICROPY_ENABLE_DOC_STRING
+    mp_obj_t doc_string;
+    #endif
     #if MICROPY_PY_SYS_SETTRACE
     const struct _mp_raw_code_t *rc;
     #endif

--- a/tests/basics/docstring.py
+++ b/tests/basics/docstring.py
@@ -4,15 +4,31 @@
 """Module docstring"""
 
 
+def func_no_docstring():
+    pass
+
+
+def func_with_docstring():
+    """Function docstring"""
+
+
 class A:
     """Class docstring"""
+
+    def method(self):
+        """Method docstring"""
 
 
 if not hasattr(A, "__doc__"):
     print("SKIP")
     raise SystemExit
 
+print(func_no_docstring.__doc__)
+print(func_with_docstring.__doc__)
+
 print(A.__doc__)
 print(A().__doc__)
+print(A.method.__doc__)
+print(A().method.__doc__)
 
 print(globals()["__doc__"])

--- a/tests/basics/docstring.py
+++ b/tests/basics/docstring.py
@@ -1,7 +1,7 @@
 # Test docstrings with the __doc__ special attribute.
 
 # This is the module's docstring.
-"""Module docstring"""
+"""module docstring"""
 
 
 def func_no_docstring():
@@ -9,14 +9,19 @@ def func_no_docstring():
 
 
 def func_with_docstring():
-    """Function docstring"""
+    """func_with_docstring docstring"""
+
+
+def func_with_docstring_and_statement():
+    """func_with_docstring_and_statement docstring"""
+    return 1
 
 
 class A:
-    """Class docstring"""
+    """A docstring"""
 
     def method(self):
-        """Method docstring"""
+        """A.method docstring"""
 
 
 if not hasattr(A, "__doc__"):
@@ -25,6 +30,7 @@ if not hasattr(A, "__doc__"):
 
 print(func_no_docstring.__doc__)
 print(func_with_docstring.__doc__)
+print(func_with_docstring_and_statement.__doc__)
 
 print(A.__doc__)
 print(A().__doc__)

--- a/tests/basics/docstring.py
+++ b/tests/basics/docstring.py
@@ -1,0 +1,18 @@
+# Test docstrings with the __doc__ special attribute.
+
+# This is the module's docstring.
+"""Module docstring"""
+
+
+class A:
+    """Class docstring"""
+
+
+if not hasattr(A, "__doc__"):
+    print("SKIP")
+    raise SystemExit
+
+print(A.__doc__)
+print(A().__doc__)
+
+print(globals()["__doc__"])


### PR DESCRIPTION
This PR adds support for function doc strings.  It's disabled by default.

```py
def f():
    "doc string"
    pass

print(f.__doc__)
```

TODO:
- [x] add tests
- [x] ~~maybe have a separate compile-time option for this~~ no, let's keep it under the existing MICROPY_ENABLE_DOC_STRING option
- [ ] check that the native .mpy ABI is unchanged