### PR TITLE
global: Run uncrustify on all .c source files. 

### DIFF
--- a/drivers/bus/softqspi.c
+++ b/drivers/bus/softqspi.c
@@ -57,7 +57,7 @@ static void nibble_write(mp_soft_qspi_obj_t *self, uint8_t v) {
 }
 
 static int mp_soft_qspi_ioctl(void *self_in, uint32_t cmd, uintptr_t arg) {
-    mp_soft_qspi_obj_t *self = (mp_soft_qspi_obj_t*)self_in;
+    mp_soft_qspi_obj_t *self = (mp_soft_qspi_obj_t *)self_in;
     (void)arg;
 
     switch (cmd) {
@@ -68,7 +68,7 @@ static int mp_soft_qspi_ioctl(void *self_in, uint32_t cmd, uintptr_t arg) {
             // Configure pins
             mp_hal_pin_write(self->clk, 0);
             mp_hal_pin_output(self->clk);
-            //mp_hal_pin_write(self->clk, 1);
+            // mp_hal_pin_write(self->clk, 1);
             mp_hal_pin_output(self->io0);
             mp_hal_pin_input(self->io1);
             mp_hal_pin_write(self->io2, 1);
@@ -156,20 +156,20 @@ static void mp_soft_qspi_qwrite(mp_soft_qspi_obj_t *self, size_t len, const uint
         SCK_LOW(self);
     }
 
-    //mp_hal_pin_input(self->io1);
+    // mp_hal_pin_input(self->io1);
 }
 
 static int mp_soft_qspi_write_cmd_data(void *self_in, uint8_t cmd, size_t len, uint32_t data) {
-    mp_soft_qspi_obj_t *self = (mp_soft_qspi_obj_t*)self_in;
+    mp_soft_qspi_obj_t *self = (mp_soft_qspi_obj_t *)self_in;
     uint32_t cmd_buf = cmd | data << 8;
     CS_LOW(self);
-    mp_soft_qspi_transfer(self, 1 + len, (uint8_t*)&cmd_buf, NULL);
+    mp_soft_qspi_transfer(self, 1 + len, (uint8_t *)&cmd_buf, NULL);
     CS_HIGH(self);
     return 0;
 }
 
 static int mp_soft_qspi_write_cmd_addr_data(void *self_in, uint8_t cmd, uint32_t addr, size_t len, const uint8_t *src) {
-    mp_soft_qspi_obj_t *self = (mp_soft_qspi_obj_t*)self_in;
+    mp_soft_qspi_obj_t *self = (mp_soft_qspi_obj_t *)self_in;
     uint8_t cmd_buf[5] = {cmd};
     uint8_t addr_len = mp_spi_set_addr_buff(&cmd_buf[1], addr);
     CS_LOW(self);
@@ -180,17 +180,17 @@ static int mp_soft_qspi_write_cmd_addr_data(void *self_in, uint8_t cmd, uint32_t
 }
 
 static int mp_soft_qspi_read_cmd(void *self_in, uint8_t cmd, size_t len, uint32_t *dest) {
-    mp_soft_qspi_obj_t *self = (mp_soft_qspi_obj_t*)self_in;
+    mp_soft_qspi_obj_t *self = (mp_soft_qspi_obj_t *)self_in;
     uint32_t cmd_buf = cmd;
     CS_LOW(self);
-    mp_soft_qspi_transfer(self, 1 + len, (uint8_t*)&cmd_buf, (uint8_t*)&cmd_buf);
+    mp_soft_qspi_transfer(self, 1 + len, (uint8_t *)&cmd_buf, (uint8_t *)&cmd_buf);
     CS_HIGH(self);
     *dest = cmd_buf >> 8;
     return 0;
 }
 
 static int mp_soft_qspi_read_cmd_qaddr_qdata(void *self_in, uint8_t cmd, uint32_t addr, uint8_t num_dummy, size_t len, uint8_t *dest) {
-    mp_soft_qspi_obj_t *self = (mp_soft_qspi_obj_t*)self_in;
+    mp_soft_qspi_obj_t *self = (mp_soft_qspi_obj_t *)self_in;
     uint8_t cmd_buf[16] = {cmd};
     uint8_t addr_len = mp_spi_set_addr_buff(&cmd_buf[1], addr);
     CS_LOW(self);

--- a/drivers/bus/softspi.c
+++ b/drivers/bus/softspi.c
@@ -27,7 +27,7 @@
 #include "drivers/bus/spi.h"
 
 int mp_soft_spi_ioctl(void *self_in, uint32_t cmd) {
-    mp_soft_spi_obj_t *self = (mp_soft_spi_obj_t*)self_in;
+    mp_soft_spi_obj_t *self = (mp_soft_spi_obj_t *)self_in;
 
     switch (cmd) {
         case MP_SPI_IOCTL_INIT:
@@ -49,11 +49,11 @@ static uint8_t swap_bits(uint8_t byte) {
         0x00, 0x08, 0x04, 0x0c, 0x02, 0x0a, 0x06, 0x0e,
         0x01, 0x09, 0x05, 0x0d, 0x03, 0x0b, 0x07, 0x0f
     };
-    return ((swap_table[byte & 0x0f] << 4) | swap_table[byte >> 4]);
+    return (swap_table[byte & 0x0f] << 4) | swap_table[byte >> 4];
 }
 
 void mp_soft_spi_transfer(void *self_in, size_t len, const uint8_t *src, uint8_t *dest) {
-    mp_soft_spi_obj_t *self = (mp_soft_spi_obj_t*)self_in;
+    mp_soft_spi_obj_t *self = (mp_soft_spi_obj_t *)self_in;
     uint32_t delay_half = self->delay_half;
 
     // If a port defines MICROPY_HW_SOFTSPI_MIN_DELAY, and the configured

--- a/drivers/esp-hosted/esp_hosted_bthci_uart.c
+++ b/drivers/esp-hosted/esp_hosted_bthci_uart.c
@@ -139,12 +139,12 @@ int mp_bluetooth_hci_controller_init(void) {
     mp_hal_pin_output(MICROPY_HW_BLE_UART_RTS);
     mp_hal_pin_write(MICROPY_HW_BLE_UART_RTS, 0);
 
-    for (size_t i=0; i<3; i++ ){
+    for (size_t i = 0; i < 3; i++) {
         // Send reset command
         if (!esp_hosted_hci_cmd(OGF_HOST_CTL, OCF_RESET, 0, NULL)) {
             return 0;
         }
-    
+
         mp_bluetooth_hci_controller_drain_rx(100);
         debug_printf("HCI reset failed, retry...\n");
     }

--- a/drivers/esp-hosted/esp_hosted_hal.h
+++ b/drivers/esp-hosted/esp_hosted_hal.h
@@ -53,11 +53,11 @@
 #endif
 
 // Logging macros.
-#define debug_printf(fmt, ...)   do { do_printf(ANSI_C_BLUE "%s() " fmt ANSI_C_DEFAULT, __func__, ##__VA_ARGS__); } while (0)
-#define info_printf(fmt, ...)    do { do_printf(ANSI_C_GREEN "%s() " fmt ANSI_C_DEFAULT, __func__, ##__VA_ARGS__); } while (0)
-#define warn_printf(fmt, ...)    do { do_printf(ANSI_C_YELLOW "%s() " fmt ANSI_C_DEFAULT, __func__, ##__VA_ARGS__); } while (0)
-#define error_printf(fmt, ...)   do { do_printf(ANSI_C_RED "%s() " fmt ANSI_C_DEFAULT, __func__, ##__VA_ARGS__); } while (0)
-#define crit_printf(fmt, ...)    do { do_printf(ANSI_C_MAGENTA "%s() " fmt ANSI_C_DEFAULT, __func__, ##__VA_ARGS__); } while (0)
+#define debug_printf(fmt, ...)   do { do_printf(ANSI_C_BLUE "%s() " fmt ANSI_C_DEFAULT, __func__,##__VA_ARGS__); } while (0)
+#define info_printf(fmt, ...)    do { do_printf(ANSI_C_GREEN "%s() " fmt ANSI_C_DEFAULT, __func__,##__VA_ARGS__); } while (0)
+#define warn_printf(fmt, ...)    do { do_printf(ANSI_C_YELLOW "%s() " fmt ANSI_C_DEFAULT, __func__,##__VA_ARGS__); } while (0)
+#define error_printf(fmt, ...)   do { do_printf(ANSI_C_RED "%s() " fmt ANSI_C_DEFAULT, __func__,##__VA_ARGS__); } while (0)
+#define crit_printf(fmt, ...)    do { do_printf(ANSI_C_MAGENTA "%s() " fmt ANSI_C_DEFAULT, __func__,##__VA_ARGS__); } while (0)
 
 typedef enum {
     ESP_HOSTED_MODE_BT,

--- a/drivers/esp-hosted/esp_hosted_wifi.c
+++ b/drivers/esp-hosted/esp_hosted_wifi.c
@@ -80,51 +80,49 @@ static void esp_hosted_macstr_to_bytes(const uint8_t *mac_str, size_t mac_len, u
 // to avoid bleeding the protocol buffer API into the public interface, convert esp_hosted_security_t
 // to/from CtrlWifiSecProt here.
 
-static esp_hosted_security_t sec_prot_to_hosted_security(CtrlWifiSecProt sec_prot)
-{
+static esp_hosted_security_t sec_prot_to_hosted_security(CtrlWifiSecProt sec_prot) {
     switch (sec_prot) {
-    case CTRL__WIFI_SEC_PROT__Open:
-        return ESP_HOSTED_SEC_OPEN;
-    case CTRL__WIFI_SEC_PROT__WEP:
-        return ESP_HOSTED_SEC_WEP;
-    case CTRL__WIFI_SEC_PROT__WPA_PSK:
-        return ESP_HOSTED_SEC_WPA_PSK;
-    case CTRL__WIFI_SEC_PROT__WPA2_PSK:
-        return ESP_HOSTED_SEC_WPA2_PSK;
-    case CTRL__WIFI_SEC_PROT__WPA_WPA2_PSK:
-        return ESP_HOSTED_SEC_WPA_WPA2_PSK;
-    case CTRL__WIFI_SEC_PROT__WPA2_ENTERPRISE:
-        return ESP_HOSTED_SEC_WPA2_ENTERPRISE;
-    case CTRL__WIFI_SEC_PROT__WPA3_PSK:
-        return ESP_HOSTED_SEC_WPA3_PSK;
-    case CTRL__WIFI_SEC_PROT__WPA2_WPA3_PSK:
-        return ESP_HOSTED_SEC_WPA2_WPA3_PSK;
-    default:
-        return ESP_HOSTED_SEC_INVALID;
+        case CTRL__WIFI_SEC_PROT__Open:
+            return ESP_HOSTED_SEC_OPEN;
+        case CTRL__WIFI_SEC_PROT__WEP:
+            return ESP_HOSTED_SEC_WEP;
+        case CTRL__WIFI_SEC_PROT__WPA_PSK:
+            return ESP_HOSTED_SEC_WPA_PSK;
+        case CTRL__WIFI_SEC_PROT__WPA2_PSK:
+            return ESP_HOSTED_SEC_WPA2_PSK;
+        case CTRL__WIFI_SEC_PROT__WPA_WPA2_PSK:
+            return ESP_HOSTED_SEC_WPA_WPA2_PSK;
+        case CTRL__WIFI_SEC_PROT__WPA2_ENTERPRISE:
+            return ESP_HOSTED_SEC_WPA2_ENTERPRISE;
+        case CTRL__WIFI_SEC_PROT__WPA3_PSK:
+            return ESP_HOSTED_SEC_WPA3_PSK;
+        case CTRL__WIFI_SEC_PROT__WPA2_WPA3_PSK:
+            return ESP_HOSTED_SEC_WPA2_WPA3_PSK;
+        default:
+            return ESP_HOSTED_SEC_INVALID;
     }
 }
 
-static CtrlWifiSecProt hosted_security_to_sec_prot(esp_hosted_security_t hosted_security)
-{
+static CtrlWifiSecProt hosted_security_to_sec_prot(esp_hosted_security_t hosted_security) {
     switch (hosted_security) {
-    case ESP_HOSTED_SEC_OPEN:
-        return CTRL__WIFI_SEC_PROT__Open;
-    case ESP_HOSTED_SEC_WEP:
-        return CTRL__WIFI_SEC_PROT__WEP;
-    case ESP_HOSTED_SEC_WPA_PSK:
-        return CTRL__WIFI_SEC_PROT__WPA_PSK;
-    case ESP_HOSTED_SEC_WPA2_PSK:
-        return CTRL__WIFI_SEC_PROT__WPA2_PSK;
-    case ESP_HOSTED_SEC_WPA_WPA2_PSK:
-        return CTRL__WIFI_SEC_PROT__WPA_WPA2_PSK;
-    case ESP_HOSTED_SEC_WPA2_ENTERPRISE:
-        return CTRL__WIFI_SEC_PROT__WPA2_ENTERPRISE;
-    case ESP_HOSTED_SEC_WPA3_PSK:
-        return CTRL__WIFI_SEC_PROT__WPA3_PSK;
-    case ESP_HOSTED_SEC_WPA2_WPA3_PSK:
-        return CTRL__WIFI_SEC_PROT__WPA2_WPA3_PSK;
-    default:
-        abort(); // Range should be checked by the caller, making this unreachable
+        case ESP_HOSTED_SEC_OPEN:
+            return CTRL__WIFI_SEC_PROT__Open;
+        case ESP_HOSTED_SEC_WEP:
+            return CTRL__WIFI_SEC_PROT__WEP;
+        case ESP_HOSTED_SEC_WPA_PSK:
+            return CTRL__WIFI_SEC_PROT__WPA_PSK;
+        case ESP_HOSTED_SEC_WPA2_PSK:
+            return CTRL__WIFI_SEC_PROT__WPA2_PSK;
+        case ESP_HOSTED_SEC_WPA_WPA2_PSK:
+            return CTRL__WIFI_SEC_PROT__WPA_WPA2_PSK;
+        case ESP_HOSTED_SEC_WPA2_ENTERPRISE:
+            return CTRL__WIFI_SEC_PROT__WPA2_ENTERPRISE;
+        case ESP_HOSTED_SEC_WPA3_PSK:
+            return CTRL__WIFI_SEC_PROT__WPA3_PSK;
+        case ESP_HOSTED_SEC_WPA2_WPA3_PSK:
+            return CTRL__WIFI_SEC_PROT__WPA2_WPA3_PSK;
+        default:
+            abort(); // Range should be checked by the caller, making this unreachable
     }
 }
 

--- a/drivers/memory/spiflash.c
+++ b/drivers/memory/spiflash.c
@@ -137,7 +137,7 @@ static int mp_spiflash_read_cmd(mp_spiflash_t *self, uint8_t cmd, size_t len, ui
     if (c->bus_kind == MP_SPIFLASH_BUS_SPI) {
         mp_hal_pin_write(c->bus.u_spi.cs, 0);
         c->bus.u_spi.proto->transfer(c->bus.u_spi.data, 1, &cmd, NULL);
-        c->bus.u_spi.proto->transfer(c->bus.u_spi.data, len, (void*)dest, (void*)dest);
+        c->bus.u_spi.proto->transfer(c->bus.u_spi.data, len, (void *)dest, (void *)dest);
         mp_hal_pin_write(c->bus.u_spi.cs, 1);
         return 0;
     } else {

--- a/examples/embedding/main.c
+++ b/examples/embedding/main.c
@@ -24,7 +24,7 @@ static const char *example_2 =
     "gc.collect()\n"
     "\n"
     "print('finish')\n"
-    ;
+;
 
 // This array is the MicroPython GC heap.
 static char heap[8 * 1024];

--- a/examples/natmod/btree/btree_c.c
+++ b/examples/natmod/btree/btree_c.c
@@ -45,16 +45,16 @@ int puts(const char *s) {
 
 int native_errno;
 #if defined(__linux__)
-int *__errno_location (void)
+int *__errno_location(void)
 #else
-int *__errno (void)
+int *__errno(void)
 #endif
 {
     return &native_errno;
 }
 
 ssize_t mp_stream_posix_write(void *stream, const void *buf, size_t len) {
-    mp_obj_base_t* o = stream;
+    mp_obj_base_t *o = stream;
     const mp_stream_p_t *stream_p = MP_OBJ_TYPE_GET_SLOT(o->type, protocol);
     mp_uint_t out_sz = stream_p->write(MP_OBJ_FROM_PTR(stream), buf, len, &native_errno);
     if (out_sz == MP_STREAM_ERROR) {
@@ -65,7 +65,7 @@ ssize_t mp_stream_posix_write(void *stream, const void *buf, size_t len) {
 }
 
 ssize_t mp_stream_posix_read(void *stream, void *buf, size_t len) {
-    mp_obj_base_t* o = stream;
+    mp_obj_base_t *o = stream;
     const mp_stream_p_t *stream_p = MP_OBJ_TYPE_GET_SLOT(o->type, protocol);
     mp_uint_t out_sz = stream_p->read(MP_OBJ_FROM_PTR(stream), buf, len, &native_errno);
     if (out_sz == MP_STREAM_ERROR) {
@@ -76,7 +76,7 @@ ssize_t mp_stream_posix_read(void *stream, void *buf, size_t len) {
 }
 
 off_t mp_stream_posix_lseek(void *stream, off_t offset, int whence) {
-    const mp_obj_base_t* o = stream;
+    const mp_obj_base_t *o = stream;
     const mp_stream_p_t *stream_p = MP_OBJ_TYPE_GET_SLOT(o->type, protocol);
     struct mp_stream_seek_t seek_s;
     seek_s.offset = offset;
@@ -89,7 +89,7 @@ off_t mp_stream_posix_lseek(void *stream, off_t offset, int whence) {
 }
 
 int mp_stream_posix_fsync(void *stream) {
-    mp_obj_base_t* o = stream;
+    mp_obj_base_t *o = stream;
     const mp_stream_p_t *stream_p = MP_OBJ_TYPE_GET_SLOT(o->type, protocol);
     mp_uint_t res = stream_p->ioctl(MP_OBJ_FROM_PTR(stream), MP_STREAM_FLUSH, 0, &native_errno);
     if (res == MP_STREAM_ERROR) {
@@ -146,22 +146,22 @@ mp_obj_t mpy_init(mp_obj_fun_bc_t *self, size_t n_args, size_t n_kw, mp_obj_t *a
     btree_getiter_iternext.getiter = btree_getiter;
     btree_getiter_iternext.iternext = btree_iternext;
 
-    btree_type.base.type = (void*)&mp_fun_table.type_type;
+    btree_type.base.type = (void *)&mp_fun_table.type_type;
     btree_type.flags = MP_TYPE_FLAG_ITER_IS_CUSTOM;
     btree_type.name = MP_QSTR_btree;
     MP_OBJ_TYPE_SET_SLOT(&btree_type, print, btree_print, 0);
     MP_OBJ_TYPE_SET_SLOT(&btree_type, iter, &btree_getiter_iternext, 1);
     MP_OBJ_TYPE_SET_SLOT(&btree_type, binary_op, btree_binary_op, 2);
     MP_OBJ_TYPE_SET_SLOT(&btree_type, subscr, btree_subscr, 3);
-    btree_locals_dict_table[0] = (mp_map_elem_t){ MP_OBJ_NEW_QSTR(MP_QSTR_close), MP_OBJ_FROM_PTR(&btree_close_obj) };
-    btree_locals_dict_table[1] = (mp_map_elem_t){ MP_OBJ_NEW_QSTR(MP_QSTR_flush), MP_OBJ_FROM_PTR(&btree_flush_obj) };
-    btree_locals_dict_table[2] = (mp_map_elem_t){ MP_OBJ_NEW_QSTR(MP_QSTR_get), MP_OBJ_FROM_PTR(&btree_get_obj) };
-    btree_locals_dict_table[3] = (mp_map_elem_t){ MP_OBJ_NEW_QSTR(MP_QSTR_put), MP_OBJ_FROM_PTR(&btree_put_obj) };
-    btree_locals_dict_table[4] = (mp_map_elem_t){ MP_OBJ_NEW_QSTR(MP_QSTR_seq), MP_OBJ_FROM_PTR(&btree_seq_obj) };
-    btree_locals_dict_table[5] = (mp_map_elem_t){ MP_OBJ_NEW_QSTR(MP_QSTR_keys), MP_OBJ_FROM_PTR(&btree_keys_obj) };
-    btree_locals_dict_table[6] = (mp_map_elem_t){ MP_OBJ_NEW_QSTR(MP_QSTR_values), MP_OBJ_FROM_PTR(&btree_values_obj) };
-    btree_locals_dict_table[7] = (mp_map_elem_t){ MP_OBJ_NEW_QSTR(MP_QSTR_items), MP_OBJ_FROM_PTR(&btree_items_obj) };
-    MP_OBJ_TYPE_SET_SLOT(&btree_type, locals_dict, (void*)&btree_locals_dict, 4);
+    btree_locals_dict_table[0] = (mp_map_elem_t) { MP_OBJ_NEW_QSTR(MP_QSTR_close), MP_OBJ_FROM_PTR(&btree_close_obj) };
+    btree_locals_dict_table[1] = (mp_map_elem_t) { MP_OBJ_NEW_QSTR(MP_QSTR_flush), MP_OBJ_FROM_PTR(&btree_flush_obj) };
+    btree_locals_dict_table[2] = (mp_map_elem_t) { MP_OBJ_NEW_QSTR(MP_QSTR_get), MP_OBJ_FROM_PTR(&btree_get_obj) };
+    btree_locals_dict_table[3] = (mp_map_elem_t) { MP_OBJ_NEW_QSTR(MP_QSTR_put), MP_OBJ_FROM_PTR(&btree_put_obj) };
+    btree_locals_dict_table[4] = (mp_map_elem_t) { MP_OBJ_NEW_QSTR(MP_QSTR_seq), MP_OBJ_FROM_PTR(&btree_seq_obj) };
+    btree_locals_dict_table[5] = (mp_map_elem_t) { MP_OBJ_NEW_QSTR(MP_QSTR_keys), MP_OBJ_FROM_PTR(&btree_keys_obj) };
+    btree_locals_dict_table[6] = (mp_map_elem_t) { MP_OBJ_NEW_QSTR(MP_QSTR_values), MP_OBJ_FROM_PTR(&btree_values_obj) };
+    btree_locals_dict_table[7] = (mp_map_elem_t) { MP_OBJ_NEW_QSTR(MP_QSTR_items), MP_OBJ_FROM_PTR(&btree_items_obj) };
+    MP_OBJ_TYPE_SET_SLOT(&btree_type, locals_dict, (void *)&btree_locals_dict, 4);
 
     mp_store_global(MP_QSTR_open, MP_OBJ_FROM_PTR(&btree_open_obj));
     mp_store_global(MP_QSTR_INCL, MP_OBJ_NEW_SMALL_INT(FLAG_END_KEY_INCL));

--- a/examples/natmod/deflate/deflate.c
+++ b/examples/natmod/deflate/deflate.c
@@ -51,14 +51,14 @@ mp_obj_t mpy_init(mp_obj_fun_bc_t *self, size_t n_args, size_t n_kw, mp_obj_t *a
     deflateio_type.name = MP_QSTR_DeflateIO;
     MP_OBJ_TYPE_SET_SLOT(&deflateio_type, make_new, &deflateio_make_new, 0);
     MP_OBJ_TYPE_SET_SLOT(&deflateio_type, protocol, &deflateio_stream_p, 1);
-    deflateio_locals_dict_table[0] = (mp_map_elem_t){ MP_OBJ_NEW_QSTR(MP_QSTR_read), MP_OBJ_FROM_PTR(&mp_stream_read_obj) };
-    deflateio_locals_dict_table[1] = (mp_map_elem_t){ MP_OBJ_NEW_QSTR(MP_QSTR_readinto), MP_OBJ_FROM_PTR(&mp_stream_readinto_obj) };
-    deflateio_locals_dict_table[2] = (mp_map_elem_t){ MP_OBJ_NEW_QSTR(MP_QSTR_readline), MP_OBJ_FROM_PTR(&mp_stream_unbuffered_readline_obj) };
-    deflateio_locals_dict_table[3] = (mp_map_elem_t){ MP_OBJ_NEW_QSTR(MP_QSTR_write), MP_OBJ_FROM_PTR(&mp_stream_write_obj) };
-    deflateio_locals_dict_table[4] = (mp_map_elem_t){ MP_OBJ_NEW_QSTR(MP_QSTR_close), MP_OBJ_FROM_PTR(&mp_stream_close_obj) };
-    deflateio_locals_dict_table[5] = (mp_map_elem_t){ MP_OBJ_NEW_QSTR(MP_QSTR___enter__), MP_OBJ_FROM_PTR(&mp_identity_obj) };
-    deflateio_locals_dict_table[6] = (mp_map_elem_t){ MP_OBJ_NEW_QSTR(MP_QSTR___exit__), MP_OBJ_FROM_PTR(&mp_stream___exit___obj) };
-    MP_OBJ_TYPE_SET_SLOT(&deflateio_type, locals_dict, (void*)&deflateio_locals_dict, 2);
+    deflateio_locals_dict_table[0] = (mp_map_elem_t) { MP_OBJ_NEW_QSTR(MP_QSTR_read), MP_OBJ_FROM_PTR(&mp_stream_read_obj) };
+    deflateio_locals_dict_table[1] = (mp_map_elem_t) { MP_OBJ_NEW_QSTR(MP_QSTR_readinto), MP_OBJ_FROM_PTR(&mp_stream_readinto_obj) };
+    deflateio_locals_dict_table[2] = (mp_map_elem_t) { MP_OBJ_NEW_QSTR(MP_QSTR_readline), MP_OBJ_FROM_PTR(&mp_stream_unbuffered_readline_obj) };
+    deflateio_locals_dict_table[3] = (mp_map_elem_t) { MP_OBJ_NEW_QSTR(MP_QSTR_write), MP_OBJ_FROM_PTR(&mp_stream_write_obj) };
+    deflateio_locals_dict_table[4] = (mp_map_elem_t) { MP_OBJ_NEW_QSTR(MP_QSTR_close), MP_OBJ_FROM_PTR(&mp_stream_close_obj) };
+    deflateio_locals_dict_table[5] = (mp_map_elem_t) { MP_OBJ_NEW_QSTR(MP_QSTR___enter__), MP_OBJ_FROM_PTR(&mp_identity_obj) };
+    deflateio_locals_dict_table[6] = (mp_map_elem_t) { MP_OBJ_NEW_QSTR(MP_QSTR___exit__), MP_OBJ_FROM_PTR(&mp_stream___exit___obj) };
+    MP_OBJ_TYPE_SET_SLOT(&deflateio_type, locals_dict, (void *)&deflateio_locals_dict, 2);
 
     mp_store_global(MP_QSTR___name__, MP_OBJ_NEW_QSTR(MP_QSTR_deflate));
     mp_store_global(MP_QSTR_DeflateIO, MP_OBJ_FROM_PTR(&deflateio_type));

--- a/examples/natmod/features4/features4.c
+++ b/examples/natmod/features4/features4.c
@@ -68,12 +68,12 @@ mp_obj_t mpy_init(mp_obj_fun_bc_t *self, size_t n_args, size_t n_kw, mp_obj_t *a
     MP_DYNRUNTIME_INIT_ENTRY
 
     // Initialise the type.
-    mp_type_factorial.base.type = (void*)&mp_type_type;
+    mp_type_factorial.base.type = (void *)&mp_type_type;
     mp_type_factorial.flags = MP_TYPE_FLAG_NONE;
     mp_type_factorial.name = MP_QSTR_Factorial;
     MP_OBJ_TYPE_SET_SLOT(&mp_type_factorial, make_new, factorial_make_new, 0);
-    factorial_locals_dict_table[0] = (mp_map_elem_t){ MP_OBJ_NEW_QSTR(MP_QSTR_calculate), MP_OBJ_FROM_PTR(&factorial_calculate_obj) };
-    MP_OBJ_TYPE_SET_SLOT(&mp_type_factorial, locals_dict, (void*)&factorial_locals_dict, 1);
+    factorial_locals_dict_table[0] = (mp_map_elem_t) { MP_OBJ_NEW_QSTR(MP_QSTR_calculate), MP_OBJ_FROM_PTR(&factorial_calculate_obj) };
+    MP_OBJ_TYPE_SET_SLOT(&mp_type_factorial, locals_dict, (void *)&factorial_locals_dict, 1);
 
     // Make the Factorial type available on the module.
     mp_store_global(MP_QSTR_Factorial, MP_OBJ_FROM_PTR(&mp_type_factorial));

--- a/examples/natmod/framebuf/framebuf.c
+++ b/examples/natmod/framebuf/framebuf.c
@@ -22,23 +22,23 @@ static MP_DEFINE_CONST_DICT(framebuf_locals_dict, framebuf_locals_dict_table);
 mp_obj_t mpy_init(mp_obj_fun_bc_t *self, size_t n_args, size_t n_kw, mp_obj_t *args) {
     MP_DYNRUNTIME_INIT_ENTRY
 
-    mp_type_framebuf.base.type = (void*)&mp_type_type;
+    mp_type_framebuf.base.type = (void *)&mp_type_type;
     mp_type_framebuf.name = MP_QSTR_FrameBuffer;
     MP_OBJ_TYPE_SET_SLOT(&mp_type_framebuf, make_new, framebuf_make_new, 0);
     MP_OBJ_TYPE_SET_SLOT(&mp_type_framebuf, buffer, framebuf_get_buffer, 1);
-    framebuf_locals_dict_table[0] = (mp_map_elem_t){ MP_OBJ_NEW_QSTR(MP_QSTR_fill), MP_OBJ_FROM_PTR(&framebuf_fill_obj) };
-    framebuf_locals_dict_table[1] = (mp_map_elem_t){ MP_OBJ_NEW_QSTR(MP_QSTR_fill_rect), MP_OBJ_FROM_PTR(&framebuf_fill_rect_obj) };
-    framebuf_locals_dict_table[2] = (mp_map_elem_t){ MP_OBJ_NEW_QSTR(MP_QSTR_pixel), MP_OBJ_FROM_PTR(&framebuf_pixel_obj) };
-    framebuf_locals_dict_table[3] = (mp_map_elem_t){ MP_OBJ_NEW_QSTR(MP_QSTR_hline), MP_OBJ_FROM_PTR(&framebuf_hline_obj) };
-    framebuf_locals_dict_table[4] = (mp_map_elem_t){ MP_OBJ_NEW_QSTR(MP_QSTR_vline), MP_OBJ_FROM_PTR(&framebuf_vline_obj) };
-    framebuf_locals_dict_table[5] = (mp_map_elem_t){ MP_OBJ_NEW_QSTR(MP_QSTR_rect), MP_OBJ_FROM_PTR(&framebuf_rect_obj) };
-    framebuf_locals_dict_table[6] = (mp_map_elem_t){ MP_OBJ_NEW_QSTR(MP_QSTR_line), MP_OBJ_FROM_PTR(&framebuf_line_obj) };
-    framebuf_locals_dict_table[7] = (mp_map_elem_t){ MP_OBJ_NEW_QSTR(MP_QSTR_ellipse), MP_OBJ_FROM_PTR(&framebuf_ellipse_obj) };
-    framebuf_locals_dict_table[8] = (mp_map_elem_t){ MP_OBJ_NEW_QSTR(MP_QSTR_poly), MP_OBJ_FROM_PTR(&framebuf_poly_obj) };
-    framebuf_locals_dict_table[9] = (mp_map_elem_t){ MP_OBJ_NEW_QSTR(MP_QSTR_blit), MP_OBJ_FROM_PTR(&framebuf_blit_obj) };
-    framebuf_locals_dict_table[10] = (mp_map_elem_t){ MP_OBJ_NEW_QSTR(MP_QSTR_scroll), MP_OBJ_FROM_PTR(&framebuf_scroll_obj) };
-    framebuf_locals_dict_table[11] = (mp_map_elem_t){ MP_OBJ_NEW_QSTR(MP_QSTR_text), MP_OBJ_FROM_PTR(&framebuf_text_obj) };
-    MP_OBJ_TYPE_SET_SLOT(&mp_type_framebuf, locals_dict, (void*)&framebuf_locals_dict, 2);
+    framebuf_locals_dict_table[0] = (mp_map_elem_t) { MP_OBJ_NEW_QSTR(MP_QSTR_fill), MP_OBJ_FROM_PTR(&framebuf_fill_obj) };
+    framebuf_locals_dict_table[1] = (mp_map_elem_t) { MP_OBJ_NEW_QSTR(MP_QSTR_fill_rect), MP_OBJ_FROM_PTR(&framebuf_fill_rect_obj) };
+    framebuf_locals_dict_table[2] = (mp_map_elem_t) { MP_OBJ_NEW_QSTR(MP_QSTR_pixel), MP_OBJ_FROM_PTR(&framebuf_pixel_obj) };
+    framebuf_locals_dict_table[3] = (mp_map_elem_t) { MP_OBJ_NEW_QSTR(MP_QSTR_hline), MP_OBJ_FROM_PTR(&framebuf_hline_obj) };
+    framebuf_locals_dict_table[4] = (mp_map_elem_t) { MP_OBJ_NEW_QSTR(MP_QSTR_vline), MP_OBJ_FROM_PTR(&framebuf_vline_obj) };
+    framebuf_locals_dict_table[5] = (mp_map_elem_t) { MP_OBJ_NEW_QSTR(MP_QSTR_rect), MP_OBJ_FROM_PTR(&framebuf_rect_obj) };
+    framebuf_locals_dict_table[6] = (mp_map_elem_t) { MP_OBJ_NEW_QSTR(MP_QSTR_line), MP_OBJ_FROM_PTR(&framebuf_line_obj) };
+    framebuf_locals_dict_table[7] = (mp_map_elem_t) { MP_OBJ_NEW_QSTR(MP_QSTR_ellipse), MP_OBJ_FROM_PTR(&framebuf_ellipse_obj) };
+    framebuf_locals_dict_table[8] = (mp_map_elem_t) { MP_OBJ_NEW_QSTR(MP_QSTR_poly), MP_OBJ_FROM_PTR(&framebuf_poly_obj) };
+    framebuf_locals_dict_table[9] = (mp_map_elem_t) { MP_OBJ_NEW_QSTR(MP_QSTR_blit), MP_OBJ_FROM_PTR(&framebuf_blit_obj) };
+    framebuf_locals_dict_table[10] = (mp_map_elem_t) { MP_OBJ_NEW_QSTR(MP_QSTR_scroll), MP_OBJ_FROM_PTR(&framebuf_scroll_obj) };
+    framebuf_locals_dict_table[11] = (mp_map_elem_t) { MP_OBJ_NEW_QSTR(MP_QSTR_text), MP_OBJ_FROM_PTR(&framebuf_text_obj) };
+    MP_OBJ_TYPE_SET_SLOT(&mp_type_framebuf, locals_dict, (void *)&framebuf_locals_dict, 2);
 
     mp_store_global(MP_QSTR_FrameBuffer, MP_OBJ_FROM_PTR(&mp_type_framebuf));
     mp_store_global(MP_QSTR_MVLSB, MP_OBJ_NEW_SMALL_INT(FRAMEBUF_MVLSB));

--- a/examples/natmod/random/random.c
+++ b/examples/natmod/random/random.c
@@ -12,7 +12,7 @@ uint8_t yasmarang_dat;
 mp_obj_t mpy_init(mp_obj_fun_bc_t *self, size_t n_args, size_t n_kw, mp_obj_t *args) {
     MP_DYNRUNTIME_INIT_ENTRY
 
-    yasmarang_pad = 0xeda4baba;
+        yasmarang_pad = 0xeda4baba;
     yasmarang_n = 69;
     yasmarang_d = 233;
 

--- a/examples/natmod/re/re.c
+++ b/examples/natmod/re/re.c
@@ -65,23 +65,23 @@ mp_obj_t mpy_init(mp_obj_fun_bc_t *self, size_t n_args, size_t n_kw, mp_obj_t *a
     // Because MP_QSTR_start/end/split are static, xtensa and xtensawin will make a small data section
     // to copy in this key/value pair if they are specified as a struct, so assign them separately.
 
-    match_type.base.type = (void*)&mp_fun_table.type_type;
+    match_type.base.type = (void *)&mp_fun_table.type_type;
     match_type.name = MP_QSTR_match;
     MP_OBJ_TYPE_SET_SLOT(&match_type, print, match_print, 0);
-    match_locals_dict_table[0] = (mp_map_elem_t){ MP_OBJ_NEW_QSTR(MP_QSTR_group), MP_OBJ_FROM_PTR(&match_group_obj) };
-    match_locals_dict_table[1] = (mp_map_elem_t){ MP_OBJ_NEW_QSTR(MP_QSTR_groups), MP_OBJ_FROM_PTR(&match_groups_obj) };
-    match_locals_dict_table[2] = (mp_map_elem_t){ MP_OBJ_NEW_QSTR(MP_QSTR_span), MP_OBJ_FROM_PTR(&match_span_obj) };
-    match_locals_dict_table[3] = (mp_map_elem_t){ MP_OBJ_NEW_QSTR(MP_QSTR_start), MP_OBJ_FROM_PTR(&match_start_obj) };
-    match_locals_dict_table[4] = (mp_map_elem_t){ MP_OBJ_NEW_QSTR(MP_QSTR_end), MP_OBJ_FROM_PTR(&match_end_obj) };
-    MP_OBJ_TYPE_SET_SLOT(&match_type, locals_dict, (void*)&match_locals_dict, 1);
+    match_locals_dict_table[0] = (mp_map_elem_t) { MP_OBJ_NEW_QSTR(MP_QSTR_group), MP_OBJ_FROM_PTR(&match_group_obj) };
+    match_locals_dict_table[1] = (mp_map_elem_t) { MP_OBJ_NEW_QSTR(MP_QSTR_groups), MP_OBJ_FROM_PTR(&match_groups_obj) };
+    match_locals_dict_table[2] = (mp_map_elem_t) { MP_OBJ_NEW_QSTR(MP_QSTR_span), MP_OBJ_FROM_PTR(&match_span_obj) };
+    match_locals_dict_table[3] = (mp_map_elem_t) { MP_OBJ_NEW_QSTR(MP_QSTR_start), MP_OBJ_FROM_PTR(&match_start_obj) };
+    match_locals_dict_table[4] = (mp_map_elem_t) { MP_OBJ_NEW_QSTR(MP_QSTR_end), MP_OBJ_FROM_PTR(&match_end_obj) };
+    MP_OBJ_TYPE_SET_SLOT(&match_type, locals_dict, (void *)&match_locals_dict, 1);
 
-    re_type.base.type = (void*)&mp_fun_table.type_type;
+    re_type.base.type = (void *)&mp_fun_table.type_type;
     re_type.name = MP_QSTR_re;
     MP_OBJ_TYPE_SET_SLOT(&re_type, print, re_print, 0);
-    re_locals_dict_table[0] = (mp_map_elem_t){ MP_OBJ_NEW_QSTR(MP_QSTR_match), MP_OBJ_FROM_PTR(&re_match_obj) };
-    re_locals_dict_table[1] = (mp_map_elem_t){ MP_OBJ_NEW_QSTR(MP_QSTR_search), MP_OBJ_FROM_PTR(&re_search_obj) };
-    re_locals_dict_table[2] = (mp_map_elem_t){ MP_OBJ_NEW_QSTR(MP_QSTR_split), MP_OBJ_FROM_PTR(&re_split_obj) };
-    MP_OBJ_TYPE_SET_SLOT(&re_type, locals_dict, (void*)&re_locals_dict, 1);
+    re_locals_dict_table[0] = (mp_map_elem_t) { MP_OBJ_NEW_QSTR(MP_QSTR_match), MP_OBJ_FROM_PTR(&re_match_obj) };
+    re_locals_dict_table[1] = (mp_map_elem_t) { MP_OBJ_NEW_QSTR(MP_QSTR_search), MP_OBJ_FROM_PTR(&re_search_obj) };
+    re_locals_dict_table[2] = (mp_map_elem_t) { MP_OBJ_NEW_QSTR(MP_QSTR_split), MP_OBJ_FROM_PTR(&re_split_obj) };
+    MP_OBJ_TYPE_SET_SLOT(&re_type, locals_dict, (void *)&re_locals_dict, 1);
 
     mp_store_global(MP_QSTR_compile, MP_OBJ_FROM_PTR(&mod_re_compile_obj));
     mp_store_global(MP_QSTR_match, MP_OBJ_FROM_PTR(&re_match_obj));

--- a/extmod/nimble/nimble/nimble_npl_os.c
+++ b/extmod/nimble/nimble/nimble_npl_os.c
@@ -79,8 +79,8 @@ static void *m_malloc_bluetooth(size_t size) {
     return alloc->data;
 }
 
-static mp_bluetooth_nimble_malloc_t* get_nimble_malloc(void *ptr) {
-    return (mp_bluetooth_nimble_malloc_t*)((uintptr_t)ptr - sizeof(mp_bluetooth_nimble_malloc_t));
+static mp_bluetooth_nimble_malloc_t *get_nimble_malloc(void *ptr) {
+    return (mp_bluetooth_nimble_malloc_t *)((uintptr_t)ptr - sizeof(mp_bluetooth_nimble_malloc_t));
 }
 
 static void m_free_bluetooth(void *ptr) {
@@ -117,7 +117,7 @@ static bool is_valid_nimble_malloc(void *ptr) {
 
 void *nimble_malloc(size_t size) {
     DEBUG_MALLOC_printf("NIMBLE malloc(%u)\n", (uint)size);
-    void* ptr = m_malloc_bluetooth(size);
+    void *ptr = m_malloc_bluetooth(size);
     DEBUG_MALLOC_printf("  --> %p\n", ptr);
     return ptr;
 }

--- a/extmod/nimble/nimble/nimble_npl_os.c
+++ b/extmod/nimble/nimble/nimble_npl_os.c
@@ -93,11 +93,11 @@ static void m_free_bluetooth(void *ptr) {
     } else {
         MP_STATE_PORT(bluetooth_nimble_memory) = NULL;
     }
-    m_free(alloc
     #if MICROPY_MALLOC_USES_ALLOCATED_SIZE
-           , alloc->size
+    m_free(alloc, alloc->size);
+    #else
+    m_free(alloc);
     #endif
-    );
 }
 
 // Check if a nimble ptr is tracked.

--- a/extmod/nimble/syscfg/syscfg.h
+++ b/extmod/nimble/syscfg/syscfg.h
@@ -17,7 +17,7 @@ void *nimble_realloc(void *ptr, size_t size);
 int nimble_sprintf(char *str, const char *fmt, ...);
 #define sprintf(str, fmt, ...) nimble_sprintf(str, fmt, __VA_ARGS__)
 
-#define MYNEWT_VAL(x) MYNEWT_VAL_ ## x
+#define MYNEWT_VAL(x) MYNEWT_VAL_##x
 
 #define MYNEWT_VAL_LOG_LEVEL (255)
 

--- a/shared/libc/string0.c
+++ b/shared/libc/string0.c
@@ -42,14 +42,14 @@ void *memcpy(void *dst, const void *src, size_t n) {
 
         if (n & 2) {
             // copy half-word
-            *(uint16_t*)d = *(const uint16_t*)s;
-            d = (uint32_t*)((uint16_t*)d + 1);
-            s = (const uint32_t*)((const uint16_t*)s + 1);
+            *(uint16_t *)d = *(const uint16_t *)s;
+            d = (uint32_t *)((uint16_t *)d + 1);
+            s = (const uint32_t *)((const uint16_t *)s + 1);
         }
 
         if (n & 1) {
             // copy byte
-            *((uint8_t*)d) = *((const uint8_t*)s);
+            *((uint8_t *)d) = *((const uint8_t *)s);
         }
     } else {
         // unaligned access, copy bytes
@@ -72,10 +72,10 @@ void *__memcpy_chk(void *dest, const void *src, size_t len, size_t slen) {
 }
 
 void *memmove(void *dest, const void *src, size_t n) {
-    if (src < dest && (uint8_t*)dest < (const uint8_t*)src + n) {
+    if (src < dest && (uint8_t *)dest < (const uint8_t *)src + n) {
         // need to copy backwards
-        uint8_t *d = (uint8_t*)dest + n - 1;
-        const uint8_t *s = (const uint8_t*)src + n - 1;
+        uint8_t *d = (uint8_t *)dest + n - 1;
+        const uint8_t *s = (const uint8_t *)src + n - 1;
         for (; n > 0; n--) {
             *d-- = *s--;
         }
@@ -94,11 +94,11 @@ void *memset(void *s, int c, size_t n) {
             *s32++ = 0;
         }
         if (n & 2) {
-            *((uint16_t*)s32) = 0;
-            s32 = (uint32_t*)((uint16_t*)s32 + 1);
+            *((uint16_t *)s32) = 0;
+            s32 = (uint32_t *)((uint16_t *)s32 + 1);
         }
         if (n & 1) {
-            *((uint8_t*)s32) = 0;
+            *((uint8_t *)s32) = 0;
         }
     } else {
         uint8_t *s2 = s;
@@ -115,8 +115,11 @@ int memcmp(const void *s1, const void *s2, size_t n) {
     while (n--) {
         char c1 = *s1_8++;
         char c2 = *s2_8++;
-        if (c1 < c2) return -1;
-        else if (c1 > c2) return 1;
+        if (c1 < c2) {
+            return -1;
+        } else if (c1 > c2) {
+            return 1;
+        }
     }
     return 0;
 }
@@ -126,8 +129,9 @@ void *memchr(const void *s, int c, size_t n) {
         const unsigned char *p = s;
 
         do {
-            if (*p++ == c)
-                return ((void *)(p - 1));
+            if (*p++ == c) {
+                return (void *)(p - 1);
+            }
         } while (--n != 0);
     }
     return 0;
@@ -145,12 +149,19 @@ int strcmp(const char *s1, const char *s2) {
     while (*s1 && *s2) {
         char c1 = *s1++; // XXX UTF8 get char, next char
         char c2 = *s2++; // XXX UTF8 get char, next char
-        if (c1 < c2) return -1;
-        else if (c1 > c2) return 1;
+        if (c1 < c2) {
+            return -1;
+        } else if (c1 > c2) {
+            return 1;
+        }
     }
-    if (*s2) return -1;
-    else if (*s1) return 1;
-    else return 0;
+    if (*s2) {
+        return -1;
+    } else if (*s1) {
+        return 1;
+    } else {
+        return 0;
+    }
 }
 
 int strncmp(const char *s1, const char *s2, size_t n) {
@@ -158,13 +169,21 @@ int strncmp(const char *s1, const char *s2, size_t n) {
         char c1 = *s1++; // XXX UTF8 get char, next char
         char c2 = *s2++; // XXX UTF8 get char, next char
         n--;
-        if (c1 < c2) return -1;
-        else if (c1 > c2) return 1;
+        if (c1 < c2) {
+            return -1;
+        } else if (c1 > c2) {
+            return 1;
+        }
     }
-    if (n == 0) return 0;
-    else if (*s2) return -1;
-    else if (*s1) return 1;
-    else return 0;
+    if (n == 0) {
+        return 0;
+    } else if (*s2) {
+        return -1;
+    } else if (*s1) {
+        return 1;
+    } else {
+        return 0;
+    }
 }
 
 char *strcpy(char *dest, const char *src) {
@@ -179,21 +198,21 @@ char *strcpy(char *dest, const char *src) {
 // Public Domain implementation of strncpy from:
 // http://en.wikibooks.org/wiki/C_Programming/Strings#The_strncpy_function
 char *strncpy(char *s1, const char *s2, size_t n) {
-     char *dst = s1;
-     const char *src = s2;
-     /* Copy bytes, one at a time.  */
-     while (n > 0) {
-         n--;
-         if ((*dst++ = *src++) == '\0') {
-             /* If we get here, we found a null character at the end
-                of s2, so use memset to put null bytes at the end of
-                s1.  */
-             memset(dst, '\0', n);
-             break;
-         }
-     }
-     return s1;
- }
+    char *dst = s1;
+    const char *src = s2;
+    /* Copy bytes, one at a time.  */
+    while (n > 0) {
+        n--;
+        if ((*dst++ = *src++) == '\0') {
+            /* If we get here, we found a null character at the end
+               of s2, so use memset to put null bytes at the end of
+               s1.  */
+            memset(dst, '\0', n);
+            break;
+        }
+    }
+    return s1;
+}
 
 // needed because gcc optimises strcpy + strcat to this
 char *stpcpy(char *dest, const char *src) {
@@ -218,29 +237,31 @@ char *strcat(char *dest, const char *src) {
 
 // Public Domain implementation of strchr from:
 // http://en.wikibooks.org/wiki/C_Programming/Strings#The_strchr_function
-char *strchr(const char *s, int c)
-{
+char *strchr(const char *s, int c) {
     /* Scan s for the character.  When this loop is finished,
        s will either point to the end of the string or the
        character we were looking for.  */
-    while (*s != '\0' && *s != (char)c)
+    while (*s != '\0' && *s != (char)c) {
         s++;
-    return ((*s == c) ? (char *) s : 0);
+    }
+    return (*s == c) ? (char *)s : 0;
 }
 
 
 // Public Domain implementation of strstr from:
 // http://en.wikibooks.org/wiki/C_Programming/Strings#The_strstr_function
-char *strstr(const char *haystack, const char *needle)
-{
+char *strstr(const char *haystack, const char *needle) {
     size_t needlelen;
     /* Check for the null needle case.  */
-    if (*needle == '\0')
-        return (char *) haystack;
+    if (*needle == '\0') {
+        return (char *)haystack;
+    }
     needlelen = strlen(needle);
-    for (; (haystack = strchr(haystack, *needle)) != 0; haystack++)
-        if (strncmp(haystack, needle, needlelen) == 0)
-            return (char *) haystack;
+    for (; (haystack = strchr(haystack, *needle)) != 0; haystack++) {
+        if (strncmp(haystack, needle, needlelen) == 0) {
+            return (char *)haystack;
+        }
+    }
     return 0;
 }
 

--- a/tools/codeformat.py
+++ b/tools/codeformat.py
@@ -34,11 +34,13 @@ import subprocess
 
 # Relative to top-level repo dir.
 PATHS = [
-    "drivers/ninaw10/*.[ch]",
+    "drivers/**/*.[ch]",
+    "examples/**/*.[ch]",
     "extmod/*.[ch]",
     "extmod/btstack/*.[ch]",
-    "extmod/nimble/*.[ch]",
+    "extmod/nimble/**/*.[ch]",
     "lib/mbedtls_errors/tester.c",
+    "shared/libc/*.[ch]",
     "shared/netutils/*.[ch]",
     "shared/timeutils/*.[ch]",
     "shared/runtime/*.[ch]",
@@ -49,7 +51,10 @@ PATHS = [
 ]
 
 EXCLUSIONS = [
+    # Fixups broken by preprocessor macro
+    "shared/readline/*.[ch]",
     # The cc3200 port is not fully formatted yet.
+    "drivers/cc3100/*/*.[ch]",
     "ports/cc3200/*/*.[ch]",
     # ESP-IDF downloads 3rd party code.
     "ports/esp32/managed_components/*",


### PR DESCRIPTION
Enforce .c code consistency by running uncrustify -c tools/uncrustify.cfg across the whole* codebase, with:

```
find . -name *.c | xargs uncrustify -c tools/uncrustify.cfg --replace --no-backup
```

Followed by tools/codeformat.py to fix all the erroneous ifdef indents.

* Skip third-party code in lib/ and drivers/cc3100/
* Skip third-party code in ports/cc3200/FreeRTOS/
* Skip all exclusions listed in tools/codeformat.py

As mentioned in https://github.com/micropython/micropython/pull/13777 it looks like there are files that are not covered either by the `PATHS` or `EXCLUSIONS` in `tools/codeformat.py`, resulting in some files that have not been considered for code consistency reformatting.

I think there are some valid changes here, but also a few left that raise an eyebrow.

Should some of these paths be added to the code formatting tool? Eg:

* `drivers/bus/*.[ch]`
* `drivers/memory/*.[ch]`
* `examples/**/*.[ch]`

Also it looks like `extmod/nimble/nimble/nimble_npl_os.c` is missed, since the glob is `extmod/nimble/*.[ch]` and, as such, does not include that subdirectory.

Other files should either be formatted, or explicitly excluded.

The nrf port has been ignored because it's not fully formatted, but if it's ignored will it ever be fully formatted?
