### PR TITLE
extmod/nimble: Check for active before setting address mode.

### DIFF
--- a/extmod/nimble/modbluetooth_nimble.c
+++ b/extmod/nimble/modbluetooth_nimble.c
@@ -728,6 +728,9 @@ void mp_bluetooth_get_current_address(uint8_t *addr_type, uint8_t *addr) {
 }
 
 void mp_bluetooth_set_address_mode(uint8_t addr_mode) {
+    if (!mp_bluetooth_is_active()) {
+        mp_raise_OSError(ERRNO_BLUETOOTH_NOT_ACTIVE);
+    }
     switch (addr_mode) {
         case MP_BLUETOOTH_ADDRESS_MODE_PUBLIC:
             if (!has_public_address()) {


### PR DESCRIPTION
`BLE().config(addr_mode=...)` is not safe to call if the NimBLE stack is not yet active (because it tries to acquire mutexes which should be initialized first).