### PR TITLE
ports/esp32: Check if main heap allocation failed.

### DIFF
--- a/ports/esp32/main.c
+++ b/ports/esp32/main.c
@@ -116,6 +116,10 @@ void mp_task(void *pvParameter) {
     }
 
     void *mp_task_heap = MP_PLAT_ALLOC_HEAP(MICROPY_GC_INITIAL_HEAP_SIZE);
+    if (mp_task_heap == NULL) {
+        printf("mp_task_heap allocation failed!\n");
+        esp_restart();
+    }
 
 soft_reset:
     // initialise the stack pointer for the main thread


### PR DESCRIPTION
If the heap allocation fails we will crash if we continue, so at least we can show a clear error message so one can figure out memory allocation was the problem (instead of just seeing some arbitrary null pointer error later).