### PR TITLE
ports/Makefile: Reinstate -O0 option on demand.

### DIFF
--- a/mpy-cross/Makefile
+++ b/mpy-cross/Makefile
@@ -25,9 +25,9 @@ CFLAGS += -fdata-sections -ffunction-sections -fno-asynchronous-unwind-tables
 # Debugging/Optimization
 ifdef DEBUG
 CFLAGS += -g
-COPT = -O0
+COPT ?= -O0
 else
-COPT = -Os #-DNDEBUG
+COPT ?= -Os #-DNDEBUG
 endif
 
 # On OSX, 'gcc' is a symlink to clang unless a real gcc is installed.

--- a/ports/bare-arm/Makefile
+++ b/ports/bare-arm/Makefile
@@ -16,13 +16,14 @@ PYDFU ?= $(TOP)/tools/pydfu.py
 CFLAGS += -I. -I$(TOP) -I$(BUILD)
 CFLAGS += -Wall -Werror -std=c99 -nostdlib
 CFLAGS += -mthumb -mtune=cortex-m4 -mcpu=cortex-m4 -msoft-float
-CSUPEROPT = -Os # save some code space for performance-critical code
+CFLAGS += $(COPT)
+CSUPEROPT ?= -Os # save some code space for performance-critical code
 
 # Select debugging or optimisation build.
 ifeq ($(DEBUG), 1)
-CFLAGS += -Og
+COPT ?= -Og
 else
-CFLAGS += -Os -DNDEBUG
+COPT ?= -Os -DNDEBUG
 CFLAGS += -fdata-sections -ffunction-sections
 endif
 

--- a/ports/esp8266/Makefile
+++ b/ports/esp8266/Makefile
@@ -89,10 +89,10 @@ LIBS += -L$(dir $(LIBGCC_FILE_NAME)) -lgcc
 # Debugging/Optimization
 CFLAGS += -g  # always include debug info in the ELF
 ifeq ($(DEBUG), 1)
-COPT = -O0
+COPT ?= -O0
 else
 CFLAGS += -fdata-sections -ffunction-sections
-COPT += -Os -DNDEBUG
+COPT ?= -Os -DNDEBUG
 LDFLAGS += --gc-sections
 endif
 

--- a/ports/mimxrt/Makefile
+++ b/ports/mimxrt/Makefile
@@ -309,11 +309,11 @@ SRC_QSTR += $(SRC_C) $(SHARED_SRC_C) $(GEN_PINS_SRC)
 
 CFLAGS += -g  # always include debug info in the ELF
 ifeq ($(DEBUG),1)
-CFLAGS += -Og
+COPT ?= -Og
 # Disable text compression in debug builds
 MICROPY_ROM_TEXT_COMPRESSION = 0
 else
-CFLAGS += -Os -DNDEBUG
+COPT ?= -Os -DNDEBUG
 endif
 
 # Set default values for optional variables
@@ -323,6 +323,7 @@ MICROPY_HW_SDRAM_SIZE ?= 0
 # Configure default compiler flags
 CFLAGS += \
 	$(INC) \
+	$(COPT) \
 	-D__START=main \
 	-D__STARTUP_CLEAR_BSS \
 	-D__STARTUP_INITIALIZE_RAMFUNCTION \

--- a/ports/minimal/Makefile
+++ b/ports/minimal/Makefile
@@ -36,7 +36,7 @@ LDFLAGS += -Wl,-map,$@.map -Wl,-dead_strip
 endif
 endif
 
-CSUPEROPT = -Os # save some code space
+CSUPEROPT ?= -Os # save some code space
 
 # Tune for Debugging or Optimization
 CFLAGS += -g  # always include debug info in the ELF

--- a/ports/pic16bit/Makefile
+++ b/ports/pic16bit/Makefile
@@ -25,9 +25,10 @@ CFLAGS += $(INC) -Wall -Werror -std=gnu99 -nostdlib $(CFLAGS_PIC16BIT) $(COPT)
 
 #Debugging/Optimization
 ifeq ($(DEBUG), 1)
-CFLAGS += -O0 -ggdb
+COPT ?= -O0
+CFLAGS += -ggdb
 else
-CFLAGS += -O1 -DNDEBUG
+COPT ?= -O1 -DNDEBUG
 endif
 
 LDFLAGS += --heap=0 -nostdlib -T $(XC16)/support/$(PARTFAMILY)/gld/p$(PART).gld -Map=$@.map --cref -p$(PART)

--- a/ports/powerpc/Makefile
+++ b/ports/powerpc/Makefile
@@ -24,9 +24,9 @@ INC += -I$(BUILD)
 CFLAGS += $(INC) -g -Wall -Wdouble-promotion -Wfloat-conversion -std=c99 $(COPT)
 CFLAGS += -mno-string -mno-multiple -mno-vsx -mno-altivec -nostdlib
 CFLAGS += -mlittle-endian -mstrict-align -msoft-float
-CFLAGS += -Os
 CFLAGS += -fdata-sections -ffunction-sections -fno-stack-protector -ffreestanding
 CFLAGS += -U_FORTIFY_SOURCE
+COPT ?= -Os
 
 LDFLAGS += -N -T powerpc.lds -nostdlib
 

--- a/ports/qemu-arm/Makefile
+++ b/ports/qemu-arm/Makefile
@@ -61,9 +61,9 @@ CFLAGS += $(CFLAGS_EXTRA)
 # Debugging/Optimization
 ifeq ($(DEBUG), 1)
 CFLAGS += -g
-COPT = -O0
+COPT ?= -O0
 else
-COPT += -Os -DNDEBUG
+COPT ?= -Os -DNDEBUG
 endif
 
 ## With CoudeSourcery it's actually a little different, you just need `-T generic-m-hosted.ld`.

--- a/ports/renesas-ra/Makefile
+++ b/ports/renesas-ra/Makefile
@@ -140,12 +140,11 @@ LDFLAGS += --gc-sections
 CFLAGS += -g  # always include debug info in the ELF
 ifeq ($(DEBUG), 1)
 CFLAGS += -DPENDSV_DEBUG
-#COPT = -Og
-COPT = -Os
+COPT ?= -Os
 # Disable text compression in debug builds
 MICROPY_ROM_TEXT_COMPRESSION = 0
 else
-COPT += -Os -DNDEBUG
+COPT ?= -Os -DNDEBUG
 endif
 
 # Flags for optional C++ source code

--- a/ports/stm32/Makefile
+++ b/ports/stm32/Makefile
@@ -285,7 +285,7 @@ SRC_O += \
 	$(SYSTEM_FILE)
 
 ifeq ($(MCU_SERIES),$(filter $(MCU_SERIES),f0 g0 l0))
-CSUPEROPT = -Os # save some code space
+CSUPEROPT ?= -Os # save some code space
 SRC_O += \
 	resethandler_m0.o \
 	shared/runtime/gchelper_thumb1.o

--- a/ports/stm32/mboot/Makefile
+++ b/ports/stm32/mboot/Makefile
@@ -90,9 +90,9 @@ LDFLAGS += --gc-sections
 # Debugging/Optimization
 ifeq ($(DEBUG), 1)
 CFLAGS += -g -DPENDSV_DEBUG
-COPT = -Og
+COPT ?= -Og
 else
-COPT += -Os -DNDEBUG
+COPT ?= -Os -DNDEBUG
 endif
 
 $(BUILD)/shared/libc/string0.o: CFLAGS += $(CFLAGS_BUILTIN)

--- a/ports/unix/README.md
+++ b/ports/unix/README.md
@@ -82,7 +82,8 @@ To build a debuggable version of the Unix port, there are two options
 
 1. Run `make [other arguments] DEBUG=1`. Note setting `DEBUG` also reduces the
    optimisation level, so it's not a good option for builds that also want the
-   best performance.
+   best performance. When using gdb and facing 'optimized out' values or stepping
+   through the source not halting at the correct location, also pass `COPT=-O0`.
 2. Run `make [other arguments] STRIP=`. Note that the value of `STRIP` is
    empty. This will skip the build step that strips symbols and debug
    information, but changes nothing else in the build configuration.

--- a/ports/windows/Makefile
+++ b/ports/windows/Makefile
@@ -45,9 +45,9 @@ LDFLAGS += -lm -lbcrypt $(LDFLAGS_EXTRA)
 # Debugging/Optimization
 ifdef DEBUG
 CFLAGS += -g
-COPT = -O0
+COPT ?= -O0
 else
-COPT = -Os #-DNDEBUG
+COPT ?= -Os #-DNDEBUG
 endif
 
 # source files

--- a/py/py.mk
+++ b/py/py.mk
@@ -19,7 +19,7 @@ QSTR_GLOBAL_DEPENDENCIES += $(PY_SRC)/mpconfig.h mpconfigport.h
 QSTR_GLOBAL_REQUIREMENTS += $(HEADER_BUILD)/mpversion.h
 
 # some code is performance bottleneck and compiled with other optimization options
-CSUPEROPT = -O3
+CSUPEROPT ?= -O3
 
 # Enable building 32-bit code on 64-bit host.
 ifeq ($(MICROPY_FORCE_32BIT),1)


### PR DESCRIPTION
-Og introduced in for example 9ffb1ad and c5dbbf7 results in a binary with debug symbols, but essentially breaks debugging with gdb since it still allows the compiler to optimize temporaries for instance, so gdb will report 'optimized out' for a lot of variables and breakpoints will often halt at the wrong line.
-O0 has none of these problems so allow it by specifying DEBUG=2, leaving the original DEBUG=1 functionality as-is.

See for instance https://stackoverflow.com/questions/63386189/whats-the-difference-between-a-compilers-o0-option-and-og-option for some more information.

I'm not sure if DEBUG=2 is a common way of doing this, but it's definitely pretty simple. Likewise: don't know if all ports I changed this for even work with gdb?

In theory `-g3` is also better than `-g` but at least with `-O0 -g` stepping through the source and looking at variables and memory all just seems to work fine enough, whereas `-Og` is just not usable for getting detailed information on a problem quickly.