### PR TITLE
ports/esp32: Print support information on panic.

### DIFF
--- a/ports/esp32/CMakeLists.txt
+++ b/ports/esp32/CMakeLists.txt
@@ -59,5 +59,8 @@ include($ENV{IDF_PATH}/tools/cmake/project.cmake)
 # Set the location of the main component for the project (one per target).
 list(APPEND EXTRA_COMPONENT_DIRS main_${IDF_TARGET})
 
+# Enable the panic handler wrapper
+idf_build_set_property(LINK_OPTIONS "-Wl,--wrap=esp_panic_handler" APPEND)
+
 # Define the project.
 project(micropython)

--- a/ports/esp32/esp32_common.cmake
+++ b/ports/esp32/esp32_common.cmake
@@ -53,6 +53,7 @@ list(APPEND MICROPY_SOURCE_DRIVERS
 )
 
 list(APPEND MICROPY_SOURCE_PORT
+    panichandler.c
     adc.c
     main.c
     ppp_set_auth.c

--- a/ports/esp32/panichandler.c
+++ b/ports/esp32/panichandler.c
@@ -1,0 +1,68 @@
+/*
+ * This file is part of the MicroPython project, http://micropython.org/
+ *
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2024 Mindhash B.V.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#include "genhdr/mpversion.h"
+#include "py/mpconfig.h"
+
+#ifdef MICROPY_BUILD_TYPE
+#define MICROPY_BUILD_TYPE_PAREN " (" MICROPY_BUILD_TYPE ")"
+#else
+#define MICROPY_BUILD_TYPE_PAREN
+#endif
+
+#ifdef CONFIG_ESP_PANIC_HANDLER_IRAM
+#define MICROPY_WRAP_PANICHANDLER_FUN(f) IRAM_ATTR f
+#define MICROPY_WRAP_PANICHANDLER_STR(s) DRAM_STR(s)
+#else
+#define MICROPY_WRAP_PANICHANDLER_FUN(f) f
+#define MICROPY_WRAP_PANICHANDLER_STR(s) (s)
+#endif
+
+void __real_esp_panic_handler(void *);
+void esp_panic_handler_reconfigure_wdts(uint32_t timeout_ms);
+void panic_print_str(const char *str);
+
+void MICROPY_WRAP_PANICHANDLER_FUN(__wrap_esp_panic_handler)(void *info) {
+    esp_panic_handler_reconfigure_wdts(1000);
+
+    const static char *msg = MICROPY_WRAP_PANICHANDLER_STR(
+        "\r\n"
+        "A fatal error occurred. The crash dump printed below may be used to help\r\n"
+        "determine what caused it. If you are not already running the most recent\r\n"
+        "version of MicroPython, consider upgrading. New versions often fix bugs.\r\n"
+        "\r\n"
+        "To learn more about how to debug and/or report this crash visit the wiki\r\n"
+        "page at: https://github.com/micropython/micropython/wiki/ESP32-debugging\r\n"
+        "\r\n"
+        "MPY version : " MICROPY_GIT_TAG " on " MICROPY_BUILD_DATE MICROPY_BUILD_TYPE_PAREN "\r\n"
+        "IDF version : " IDF_VER "\r\n"
+        "Machine     : " MICROPY_HW_BOARD_NAME " with " MICROPY_HW_MCU_NAME "\r\n"
+        "\r\n"
+        );
+    panic_print_str(msg);
+
+    __real_esp_panic_handler(info);
+}


### PR DESCRIPTION
When a fatal error occurs it's important to know which precise version it occurred on in order to be able to decode the crash dump information such as the backtrace.

I noticed it today in https://github.com/micropython/micropython/issues/14005#issuecomment-1979962621, and quickly prototyped a small improvement.

By wrapping around the built-in IDF panic handler we can print some extra information whenever a fatal error occurs. The message link to [a new wiki page](https://github.com/micropython/micropython/wiki/ESP32-debugging) which contains additional information on how to debug ESP32 issues links to the bug reporting issue template.

Example of current output:

```
A fatal error occurred. The crash dump printed below may be used to help
determine what caused it. If you are not already running the most recent
version of MicroPython, consider upgrading. New versions often fix bugs.

To learn more about how to debug and/or report this crash visit the wiki
page at: https://github.com/micropython/micropython/wiki/ESP32-debugging

MPY version : v1.23.0-preview.213.gfbf668cf3d.dirty on 2024-03-13
IDF version : v5.2.1
Machine     : GlobalLink 520 Bx with ESP32S3

Guru Meditation Error: Core  1 panic'ed (LoadProhibited). Exception was unhandled.

... (snip)
```

(Another suggestion is we could perhaps mention the SHA256 hash of each ESP32 image ELF file on the website. The IDF prints the "ELF file SHA256" at the end of each fatal error message, making it easy to look up the corresponding ELF file.)