### PR TITLE
ports/mimxrt: Add back in cryptolib and hashlib md5.

### DIFF
--- a/ports/mimxrt/mpconfigport.h
+++ b/ports/mimxrt/mpconfigport.h
@@ -130,9 +130,9 @@ uint32_t trng_random_u32(void);
 #define MICROPY_PY_WEBSOCKET                (MICROPY_PY_LWIP)
 #define MICROPY_PY_WEBREPL                  (MICROPY_PY_LWIP)
 #define MICROPY_PY_LWIP_SOCK_RAW            (MICROPY_PY_LWIP)
-// #define MICROPY_PY_HASHLIB_MD5              (MICROPY_PY_SSL)
+#define MICROPY_PY_HASHLIB_MD5              (MICROPY_PY_SSL)
 #define MICROPY_PY_HASHLIB_SHA1             (MICROPY_PY_SSL)
-// #define MICROPY_PY_CRYPTOLIB                (MICROPY_PY_SSL)
+#define MICROPY_PY_CRYPTOLIB                (MICROPY_PY_SSL)
 
 #ifndef MICROPY_PY_BLUETOOTH_ENABLE_CENTRAL_MODE
 #define MICROPY_PY_BLUETOOTH_ENABLE_CENTRAL_MODE (1)


### PR DESCRIPTION
Not sure why these were disabled for the MIMXRT port.

Commit message check seems to be failing with unrelated errors.