### PR TITLE
nrf/boards: Enable MICROPY_HW_ENABLE_USBDEV on boards with USB CDC.

### DIFF
--- a/ports/nrf/boards/NRF52840_MDK_USB_DONGLE/mpconfigboard.h
+++ b/ports/nrf/boards/NRF52840_MDK_USB_DONGLE/mpconfigboard.h
@@ -37,6 +37,7 @@
 
 #define MICROPY_HW_ENABLE_RNG        (1)
 
+#define MICROPY_HW_ENABLE_USBDEV     (1)
 #define MICROPY_HW_USB_CDC           (1)
 
 #define MICROPY_HW_HAS_LED           (1)

--- a/ports/nrf/boards/PARTICLE_XENON/mpconfigboard.h
+++ b/ports/nrf/boards/PARTICLE_XENON/mpconfigboard.h
@@ -37,6 +37,7 @@
 
 #define MICROPY_HW_ENABLE_RNG       (1)
 
+#define MICROPY_HW_ENABLE_USBDEV    (1)
 #define MICROPY_HW_USB_CDC          (1)
 
 #define MICROPY_HW_HAS_LED          (1)

--- a/ports/nrf/boards/PCA10059/mpconfigboard.h
+++ b/ports/nrf/boards/PCA10059/mpconfigboard.h
@@ -37,6 +37,7 @@
 
 #define MICROPY_HW_ENABLE_RNG       (1)
 
+#define MICROPY_HW_ENABLE_USBDEV    (1)
 #define MICROPY_HW_USB_CDC          (1)
 
 #define MICROPY_HW_HAS_LED          (1)


### PR DESCRIPTION
These boards were broken by 9d0d262be069089f01da6b40d2cd78f1da14de0f.