### PR TITLE
ports/esp32: Skip codespell for IDF managed components.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,7 @@ skip = """
 ./ports/cc3200/hal,\
 ./ports/cc3200/simplelink,\
 ./ports/cc3200/telnet,\
+./ports/esp32/managed_components,\
 ./ports/nrf/drivers/bluetooth/s1*,\
 ./ports/stm32/usbhost,\
 ./tests,\


### PR DESCRIPTION
During a build the ESP-IDF downloads managed components in the `ports/esp32/managed_components` directory, which shouldn't be spellchecked by us.