### PR TITLE
lwip: socket: Use Nagle algorithm and add support for TCP_NODELAY.

### DIFF
--- a/extmod/modlwip.c
+++ b/extmod/modlwip.c
@@ -69,12 +69,20 @@
 #define IP_ADD_MEMBERSHIP 0x400
 #define IP_DROP_MEMBERSHIP 0x401
 
+#define TCP_NODELAY TF_NODELAY
+
 // For compatibilily with older lwIP versions.
 #ifndef ip_set_option
 #define ip_set_option(pcb, opt)   ((pcb)->so_options |= (opt))
 #endif
 #ifndef ip_reset_option
 #define ip_reset_option(pcb, opt) ((pcb)->so_options &= ~(opt))
+#endif
+#ifndef tcp_set_flags
+#define tcp_set_flags(pcb, set_flags) do { (pcb)->flags |= (set_flags); } while (0)
+#endif
+#ifndef tcp_clear_flags
+#define tcp_clear_flags(pcb, clear_flags) do { (pcb)->flags &= ~(clear_flags); } while (0)
 #endif
 
 // A port can define these hooks to provide concurrency protection
@@ -742,9 +750,10 @@ static mp_uint_t lwip_tcp_send(lwip_socket_obj_t *socket, const byte *buf, mp_ui
         MICROPY_PY_LWIP_REENTER
     }
 
-    // If the output buffer is getting full then send the data to the lower layers
-    if (err == ERR_OK && tcp_sndbuf(socket->pcb.tcp) < TCP_SND_BUF / 4) {
-        err = tcp_output(socket->pcb.tcp);
+    // Use nagle algorithm to determine when to send segment buffer (can be
+    // disabled with TCP_NODELAY socket option)
+    if (err == ERR_OK) {
+        err = tcp_output_nagle(socket->pcb.tcp);
     }
 
     MICROPY_PY_LWIP_EXIT
@@ -1440,6 +1449,17 @@ static mp_obj_t lwip_socket_setsockopt(size_t n_args, const mp_obj_t *args) {
             break;
         }
 
+        // level: IPPROTO_TCP
+        case TCP_NODELAY: {
+            mp_int_t val = mp_obj_get_int(args[3]);
+            if (val) {
+                tcp_set_flags(socket->pcb.tcp, opt);
+            } else {
+                tcp_clear_flags(socket->pcb.tcp, opt);
+            }
+            break;
+        }
+
         default:
             printf("Warning: lwip.setsockopt() not implemented\n");
     }
@@ -1829,6 +1849,9 @@ static const mp_rom_map_elem_t mp_module_lwip_globals_table[] = {
     { MP_ROM_QSTR(MP_QSTR_IPPROTO_IP), MP_ROM_INT(0) },
     { MP_ROM_QSTR(MP_QSTR_IP_ADD_MEMBERSHIP), MP_ROM_INT(IP_ADD_MEMBERSHIP) },
     { MP_ROM_QSTR(MP_QSTR_IP_DROP_MEMBERSHIP), MP_ROM_INT(IP_DROP_MEMBERSHIP) },
+
+    { MP_ROM_QSTR(MP_QSTR_IPPROTO_TCP), MP_ROM_INT(IP_PROTO_TCP) },
+    { MP_ROM_QSTR(MP_QSTR_TCP_NODELAY), MP_ROM_INT(TCP_NODELAY) },
 };
 
 static MP_DEFINE_CONST_DICT(mp_module_lwip_globals, mp_module_lwip_globals_table);


### PR DESCRIPTION
This adds support to use the Nagle algorithm implemented already in LwIP to determine when a TCP should be sent.

I was confused as to why there was a constant ~200ms lag when sending small packets from TCP in Micropython. After too much searching, I arrived at the TCP_TMR_INTERVAL which sends packets at its usual timeout interval of 250ms. Changing this to 50ms makes a corresponding difference in the lag but still doesn't offer a solid solution on reducing the latency when small packets are desired.

I looked at adding the TCP_NODELAY socket option for LwIP, but that also didn't work until I found that it isn't used without calling `tcp_output_nagle`. And Micropython currently has a static algorithm to issue packet sends with the send buffer is below 25%. 

It seems to me we should be using the common Nagle algorithm to determine when best to send packets based on best performance / latency? I'm of course open to other ideas and happy to provide some before+after tests based on performance and/or latency if interested.

Maybe not said enough, thanks to all who have put together such an incredible project!