### PR TITLE
py/nlr: Add "memory" to asm clobbers list in nlr_jump.

### DIFF
--- a/py/nlraarch64.c
+++ b/py/nlraarch64.c
@@ -75,7 +75,7 @@ NORETURN void nlr_jump(void *val) {
         "ret                     \n"
         :
         : "r" (top)
-        :
+        : "memory"
         );
 
     MP_UNREACHABLE

--- a/py/nlrmips.c
+++ b/py/nlrmips.c
@@ -78,7 +78,7 @@ NORETURN void nlr_jump(void *val) {
         "nop            \n"
         :
         : "r" (top)
-        :
+        : "memory"
         );
     MP_UNREACHABLE
 }

--- a/py/nlrpowerpc.c
+++ b/py/nlrpowerpc.c
@@ -114,7 +114,7 @@ NORETURN void nlr_jump(void *val) {
         "blr ;"
         :
         : "r" (&top->regs)
-        :
+        : "memory"
         );
 
     MP_UNREACHABLE;
@@ -203,7 +203,7 @@ NORETURN void nlr_jump(void *val) {
         "blr ;"
         :
         : "r" (&top->regs)
-        :
+        : "memory"
         );
 
     MP_UNREACHABLE;

--- a/py/nlrthumb.c
+++ b/py/nlrthumb.c
@@ -132,7 +132,7 @@ NORETURN void nlr_jump(void *val) {
         "bx     lr                  \n" // return
         :                           // output operands
         : "r" (top)                 // input operands
-        :                           // clobbered registers
+        : "memory"                  // clobbered registers
         );
 
     MP_UNREACHABLE

--- a/py/nlrx64.c
+++ b/py/nlrx64.c
@@ -123,7 +123,7 @@ NORETURN void nlr_jump(void *val) {
         "ret                        \n" // return
         :                           // output operands
         : "r" (top)                 // input operands
-        :                           // clobbered registers
+        : "memory"                  // clobbered registers
         );
 
     MP_UNREACHABLE

--- a/py/nlrx86.c
+++ b/py/nlrx86.c
@@ -95,7 +95,7 @@ NORETURN void nlr_jump(void *val) {
         "ret                        \n" // return
         :                           // output operands
         : "r" (top)                 // input operands
-        :                           // clobbered registers
+        : "memory"                  // clobbered registers
         );
 
     MP_UNREACHABLE

--- a/py/nlrxtensa.c
+++ b/py/nlrxtensa.c
@@ -74,7 +74,7 @@ NORETURN void nlr_jump(void *val) {
         "ret.n                      \n" // return
         :                           // output operands
         : "r" (top)                 // input operands
-        :                           // clobbered registers
+        : "memory"                  // clobbered registers
         );
 
     MP_UNREACHABLE


### PR DESCRIPTION
Newer versions of gcc (14 and up) have more sophisticated dead-code detection, and the asm clobbers list needs to contain "memory" to inform the compiler that the asm code actually does something.

Tested that adding this "memory" line does not change the generated code on ARM Thumb2, x86-64 and Xtensa targets (using gcc 13.2).

Fixes issue #14115.