### PR TITLE
Support board level configurations

### DIFF
--- a/ports/esp32/CMakeLists.txt
+++ b/ports/esp32/CMakeLists.txt
@@ -66,4 +66,4 @@ else()
 endif()
 
 # Define the project.
-project(micropython)
+project(micropython_${MICROPY_BOARD})

--- a/ports/esp32/CMakeLists.txt
+++ b/ports/esp32/CMakeLists.txt
@@ -57,7 +57,13 @@ set(SDKCONFIG_DEFAULTS ${CMAKE_BINARY_DIR}/sdkconfig.combined)
 include($ENV{IDF_PATH}/tools/cmake/project.cmake)
 
 # Set the location of the main component for the project (one per target).
-list(APPEND EXTRA_COMPONENT_DIRS main_${IDF_TARGET})
+if(EXISTS ${CMAKE_CURRENT_LIST_DIR}/${MICROPY_BOARD}_main_${IDF_TARGET})
+    message("Including main Dir: ${MICROPY_BOARD}_main_${IDF_TARGET}")
+    list(APPEND EXTRA_COMPONENT_DIRS ${MICROPY_BOARD}_main_${IDF_TARGET})
+else()
+    message("Including main Dir: main_${IDF_TARGET}")
+    list(APPEND EXTRA_COMPONENT_DIRS main_${IDF_TARGET})
+endif()
 
 # Define the project.
 project(micropython)

--- a/py/usermod.cmake
+++ b/py/usermod.cmake
@@ -36,7 +36,15 @@ function(usermod_gather_sources SOURCES_VARNAME INCLUDE_DIRECTORIES_VARNAME INCL
 endfunction()
 
 # Include CMake files for user modules.
-if (USER_C_MODULES)
+if (EXISTS ${USER_C_MODULES}/${MICROPY_BOARD}_micropython.cmake)
+    message("Including User C Module(s) from ${USER_C_MODULE_PATH} for Board ${MICROPY_BOARD}")
+    include(${USER_C_MODULES}/${MICROPY_BOARD}_micropython.cmake)
+
+elseif(EXISTS ${USER_C_MODULES}/micropython.cmake)
+    message("Including User C Module(s) from ${USER_C_MODULE_PATH} from micropython.cnake")
+    include(${USER_C_MODULES}/micropython.cmake)
+
+elseif (USER_C_MODULES)
     foreach(USER_C_MODULE_PATH ${USER_C_MODULES})
         message("Including User C Module(s) from ${USER_C_MODULE_PATH}")
         include(${USER_C_MODULE_PATH})


### PR DESCRIPTION
This PR allows ESP32 board level configuration at both the idf_component.yml file and the USER_C_MODULES.

The idf_component.yml control occurs by looking for a main directory that also incorporates the MICROPY_BOARD variable as part of the name  main_{arch} (i.e. main_esp32) , if a folder does not exist then it falls back to previous behaviour.

For the USER_C_MODULES, the usermod.cmake will look in the USER_C_MODULES directory for ${MICROPY_BOARD}_micropython.cmake, if that does not exist then it will look for a micropython.cmake after that it will fall back to the previous behavior to do a directory scan.  

This will allow boards to specify which USER_C_MODULES will be incorporated and allow unused modules to exist without adding extra code to the build. 