### PR TITLE
wiznet5k: w5100s: Properly enable interrupt signal

### DIFF
--- a/extmod/network_wiznet5k.c
+++ b/extmod/network_wiznet5k.c
@@ -221,7 +221,7 @@ static void wiznet5k_init(void) {
         setSn_IMR(0, Sn_IR_RECV);
         #if _WIZCHIP_ == W5100S
         // Enable interrupt pin
-        setMR(MR2_G_IEN);
+        setMR2(getMR2() | MR2_G_IEN);
         #endif
 
         mp_hal_pin_input(wiznet5k_obj.pin_intn);


### PR DESCRIPTION
According to [the datasheet](https://docs.wiznet.io/img/products/w5100s/w5100s_ds_v125e.pdf), page 29, the IEN bit to enable the interrupt is in the MR2 register, not the MR register.

This is just cleanup as the interrupt appears to be enabled by default after resetting the chip.