### PR TITLE
tools/mpremote: Add ws:// and wss:// endpoints.

### DIFF
--- a/tools/mpremote/mpremote/commands.py
+++ b/tools/mpremote/mpremote/commands.py
@@ -56,7 +56,11 @@ def do_connect(state, args=None):
             # Connect to the given device.
             if dev.startswith("port:"):
                 dev = dev[len("port:") :]
-            state.transport = SerialTransport(dev, baudrate=115200)
+            opts = {}
+            if args and args.insecure_certificate:
+                import ssl
+                opts = {"sslopt": {"cert_reqs": ssl.CERT_NONE}}
+            state.transport = SerialTransport(dev, baudrate=115200, **opts)
             return
     except TransportError as er:
         msg = er.args[0]

--- a/tools/mpremote/mpremote/main.py
+++ b/tools/mpremote/mpremote/main.py
@@ -97,6 +97,7 @@ def _bool_flag(cmd_parser, name, short_name, default, description):
 
 def argparse_connect():
     cmd_parser = argparse.ArgumentParser(description="connect to given device")
+    _bool_flag(cmd_parser, "insecure-certificate", "k", False, "Don't check certificate validity.")
     cmd_parser.add_argument(
         "device", nargs=1, help="Either list, auto, id:x, port:x, or any valid device name/path"
     )

--- a/tools/mpremote/requirements.txt
+++ b/tools/mpremote/requirements.txt
@@ -1,2 +1,3 @@
 pyserial >= 3.3
 importlib_metadata >= 1.4; python_version < "3.8"
+websocket-client >= 1.7.0


### PR DESCRIPTION
This PR depends on the PR, changing the webrepl functionality: https://github.com/micropython/micropython-lib/pull/814

One extension might be, to allow users to specify their own ca certificate instead of just allowing to skip verification.