### PR TITLE
nrf/main: Fix build of microbit when SD is used.

### DIFF
--- a/ports/nrf/main.c
+++ b/ports/nrf/main.c
@@ -262,7 +262,7 @@ soft_reset:
     led_state(1, 0);
 
     #if MICROPY_VFS || MICROPY_MBFS || MICROPY_MODULE_FROZEN
-    ret = pyexec_file_if_exists("boot.py");
+    ret_code = pyexec_file_if_exists("boot.py");
     #endif
 
     #if MICROPY_HW_USB_CDC
@@ -270,7 +270,7 @@ soft_reset:
     #endif
 
     #if MICROPY_VFS || MICROPY_MBFS || MICROPY_MODULE_FROZEN
-    if (pyexec_mode_kind == PYEXEC_MODE_FRIENDLY_REPL && ret != 0) {
+    if (pyexec_mode_kind == PYEXEC_MODE_FRIENDLY_REPL && ret_code != 0) {
         pyexec_file_if_exists("main.py");
     }
     #endif


### PR DESCRIPTION
Building microbit with SD enabled currently fails:
```
 make -C ports/nrf BOARD=MICROBIT SD=s110

main.c: In function '_start':
main.c:265:5: error: 'ret' undeclared (first use in this function)
  265 |     ret = pyexec_file_if_exists("boot.py");
      |     ^~~
```

ret is only defined `#if MICROPY_HW_ENABLE_INTERNAL_FLASH_STORAGE` which is disabled by:
```
#if defined(NRF51822)
#if defined(BLUETOOTH_SD)
// If SoftDevice is used there is less flash/ram available for application
#define MICROPY_CONFIG_ROM_LEVEL (MICROPY_CONFIG_ROM_LEVEL_MINIMUM)
```

This PR switches the call to capture return value in a more closely defined variable that's always available and appropriate for this use.