### PR TITLE
tools/manifestfile.py: Fix freeze() when script is an empty iterable.

### DIFF
--- a/tools/manifestfile.py
+++ b/tools/manifestfile.py
@@ -291,7 +291,7 @@ class ManifestFile:
     def _search(self, base_path, package_path, files, exts, kind, opt=None, strict=False):
         base_path = self._resolve_path(base_path)
 
-        if files:
+        if files is not None:
             # Use explicit list of files (relative to package_path).
             for file in files:
                 if package_path:


### PR DESCRIPTION
The documentation for `freeze()` says that:
- If `script` is `None`, all files in `path` will be frozen.
- If `script` is an iterable then `freeze()` is called on all items of the iterable.

This commit makes sure this behaviour is followed when an empty tuple/list is passed in for `script` (previously an empty tuple/list froze all files).

Fixes issue #14125.