### PR TITLE
esp8266: Add support for C++ user c modules.

### DIFF
--- a/ports/esp8266/Makefile
+++ b/ports/esp8266/Makefile
@@ -96,6 +96,9 @@ COPT += -Os -DNDEBUG
 LDFLAGS += --gc-sections
 endif
 
+# Flags for optional C++ source code
+CXXFLAGS += $(filter-out -Wmissing-prototypes -Wold-style-definition -std=gnu99,$(CFLAGS))
+
 # Options for mpy-cross
 MPY_CROSS_FLAGS += -march=xtensa
 


### PR DESCRIPTION
See https://github.com/orgs/micropython/discussions/14172

_This work was funded through GitHub Sponsors._