### PR TITLE
py/makeqstrdata.py: Ensure that scope names get low qstr values.

### DIFF
--- a/py/makeqstrdata.py
+++ b/py/makeqstrdata.py
@@ -223,11 +223,11 @@ static_qstr_list = [
     "zip",
 ]
 
-# Additional QSTRs that must have index <255 because they are stored in
-# `mp_binary_op_method_name` and `mp_unary_op_method_name` (see py/objtype.c).
+# Additional QSTRs that must have index <255 because they are stored as `byte` values.
 # These are not part of the .mpy compatibility list, but we place them in the
 # fixed unsorted pool (i.e. QDEF0) to ensure their indices are small.
-operator_qstr_list = {
+unsorted_qstr_list = {
+    # From py/objtype.c: used in the `mp_binary_op_method_name` and `mp_unary_op_method_name` tables.
     "__bool__",
     "__pos__",
     "__neg__",
@@ -286,6 +286,13 @@ operator_qstr_list = {
     "__get__",
     "__set__",
     "__delete__",
+    # From py/scope.c: used in `scope_simple_name_table` table.
+    # Note: "<module>" is already in `static_qstr_list`.
+    "<lambda>",
+    "<listcomp>",
+    "<dictcomp>",
+    "<setcomp>",
+    "<genexpr>",
 }
 
 
@@ -404,10 +411,10 @@ def print_qstr_data(qcfgs, qstrs):
         print("QDEF0(MP_QSTR_%s, %s)" % (qstr_escape(qstr), qbytes))
 
     # add remaining qstrs to the sorted (by value) pool (unless they're in
-    # operator_qstr_list, in which case add them to the unsorted pool)
+    # unsorted_qstr_list, in which case add them to the unsorted pool)
     for ident, qstr in sorted(qstrs.values(), key=lambda x: x[1]):
         qbytes = make_bytes(cfg_bytes_len, cfg_bytes_hash, qstr)
-        pool = 0 if qstr in operator_qstr_list else 1
+        pool = 0 if qstr in unsorted_qstr_list else 1
         print("QDEF%d(MP_QSTR_%s, %s)" % (pool, ident, qbytes))
 
 

--- a/py/objtype.c
+++ b/py/objtype.c
@@ -370,6 +370,8 @@ static mp_obj_t mp_obj_instance_make_new(const mp_obj_type_t *self, size_t n_arg
 
 // Qstrs for special methods are guaranteed to have a small value, so we use byte
 // type to represent them.
+// The (unescaped) names appear in `unsorted_str_list` in the QSTR
+// generator script py/makeqstrdata.py to ensure they are assigned low numbers.
 const byte mp_unary_op_method_name[MP_UNARY_OP_NUM_RUNTIME] = {
     [MP_UNARY_OP_BOOL] = MP_QSTR___bool__,
     [MP_UNARY_OP_LEN] = MP_QSTR___len__,
@@ -468,6 +470,8 @@ static mp_obj_t instance_unary_op(mp_unary_op_t op, mp_obj_t self_in) {
 // fail).  They can be added at the expense of code size for the qstr.
 // Qstrs for special methods are guaranteed to have a small value, so we use byte
 // type to represent them.
+// The (unescaped) names appear in `unsorted_str_list` in the QSTR
+// generator script py/makeqstrdata.py to ensure they are assigned low numbers.
 const byte mp_binary_op_method_name[MP_BINARY_OP_NUM_RUNTIME] = {
     [MP_BINARY_OP_LESS] = MP_QSTR___lt__,
     [MP_BINARY_OP_MORE] = MP_QSTR___gt__,

--- a/py/qstr.c
+++ b/py/qstr.c
@@ -79,7 +79,7 @@ size_t qstr_compute_hash(const byte *data, size_t len) {
 // it is part of the .mpy ABI. See the top of py/persistentcode.c and
 // static_qstr_list in makeqstrdata.py. This pool is unsorted (although in a
 // future .mpy version we could re-order them and make it sorted). It also
-// contains additional qstrs that must have IDs <256, see operator_qstr_list
+// contains additional qstrs that must have IDs <256, see unsorted_qstr_list
 // in makeqstrdata.py.
 #if MICROPY_QSTR_BYTES_IN_HASH
 const qstr_hash_t mp_qstr_const_hashes_static[] = {

--- a/py/scope.c
+++ b/py/scope.c
@@ -31,6 +31,8 @@
 #if MICROPY_ENABLE_COMPILER
 
 // These low numbered qstrs should fit in 8 bits.  See assertions below.
+// The (unescaped) names appear in `unsorted_str_list` in the QSTR
+// generator script py/makeqstrdata.py to ensure they are assigned low numbers.
 static const uint8_t scope_simple_name_table[] = {
     [SCOPE_MODULE] = MP_QSTR__lt_module_gt_,
     [SCOPE_LAMBDA] = MP_QSTR__lt_lambda_gt_,


### PR DESCRIPTION
Originally implemented in a patch file provided by @ironss-iotec.

Fixes #14093