### PR TITLE
rp2/CMakeLists: Apply O2 optimisation to vm and mpz source code.

### DIFF
--- a/ports/rp2/CMakeLists.txt
+++ b/ports/rp2/CMakeLists.txt
@@ -455,6 +455,15 @@ target_link_options(${MICROPY_TARGET} PRIVATE
     -Wl,--wrap=dcd_event_handler
 )
 
+# Apply optimisations to performance-critical source code.
+set_source_files_properties(
+    ${MICROPY_PY_DIR}/map.c
+    ${MICROPY_PY_DIR}/mpz.c
+    ${MICROPY_PY_DIR}/vm.c
+    PROPERTIES
+    COMPILE_OPTIONS "-O2"
+)
+
 set_source_files_properties(
     ${PICO_SDK_PATH}/src/rp2_common/pico_double/double_math.c
     ${PICO_SDK_PATH}/src/rp2_common/pico_float/float_math.c


### PR DESCRIPTION
Enabling this optimisation increases the RPI_PICO firmware by +3200 bytes.

Performace change is:
```
diff of scores (higher is better)
N=100 M=100               rpi-base ->  rpi-opt       diff      diff% (error%)
bm_chaos.py                 196.56 ->   218.64 :   +22.08 = +11.233% (+/-0.05%)
bm_fannkuch.py               52.47 ->    53.75 :    +1.28 =  +2.439% (+/-0.03%)
bm_fft.py                  1476.74 ->  1524.90 :   +48.16 =  +3.261% (+/-0.01%)
bm_float.py                2305.65 ->  2497.01 :  +191.36 =  +8.300% (+/-0.08%)
bm_hexiom.py                 32.83 ->    36.02 :    +3.19 =  +9.717% (+/-0.04%)
bm_nqueens.py              2335.85 ->  2252.63 :   -83.22 =  -3.563% (+/-0.06%)
bm_pidigits.py              366.23 ->   474.88 :  +108.65 = +29.667% (+/-0.04%)
bm_wordcount.py              41.20 ->    39.99 :    -1.21 =  -2.937% (+/-0.01%)
core_import_mpy_multi.py    327.44 ->   331.06 :    +3.62 =  +1.106% (+/-0.09%)
core_import_mpy_single.py    63.41 ->    62.73 :    -0.68 =  -1.072% (+/-0.22%)
core_locals.py               27.24 ->    28.87 :    +1.63 =  +5.984% (+/-0.01%)
core_qstr.py                137.31 ->   139.92 :    +2.61 =  +1.901% (+/-0.03%)
core_str.py                  18.44 ->    17.91 :    -0.53 =  -2.874% (+/-0.02%)
core_yield_from.py          221.69 ->   213.00 :    -8.69 =  -3.920% (+/-0.01%)
misc_aes.py                 303.38 ->   312.49 :    +9.11 =  +3.003% (+/-0.01%)
misc_mandel.py             1501.00 ->  1729.17 :  +228.17 = +15.201% (+/-0.04%)
misc_pystone.py            1348.22 ->  1445.67 :   +97.45 =  +7.228% (+/-0.07%)
misc_raytrace.py            223.81 ->   249.64 :   +25.83 = +11.541% (+/-0.07%)
viper_call0.py              331.05 ->   331.11 :    +0.06 =  +0.018% (+/-0.00%)
viper_call1a.py             323.34 ->   323.41 :    +0.07 =  +0.022% (+/-0.00%)
viper_call1b.py             241.01 ->   241.05 :    +0.04 =  +0.017% (+/-0.00%)
viper_call1c.py             242.88 ->   242.92 :    +0.04 =  +0.016% (+/-0.00%)
viper_call2a.py             318.41 ->   318.47 :    +0.06 =  +0.019% (+/-0.00%)
viper_call2b.py             211.27 ->   211.30 :    +0.03 =  +0.014% (+/-0.00%)
```
And the test `tests/basics/builtin_pow3_intbig.py` now passes (it uses a lot of mpz code).

I tried -O3 and optimising `gc.c`, but the PR here is the best combination of optimisation level and files that I could find.