### PR TITLE
Improve MSYS2-based CI builds.

### DIFF
--- a/.github/workflows/ports_windows.yml
+++ b/.github/workflows/ports_windows.yml
@@ -42,6 +42,8 @@ jobs:
           configuration: Debug
         - visualstudio: '2019'
           configuration: Debug
+    env:
+      CI_BUILD_CONFIGURATION: ${{ matrix.configuration }}
     runs-on: ${{ matrix.runner }}
     steps:
     - name: Install Visual Studio 2017

--- a/.github/workflows/ports_windows.yml
+++ b/.github/workflows/ports_windows.yml
@@ -108,16 +108,6 @@ jobs:
       run:
         shell: msys2 {0}
     steps:
-    - name: Get Python path
-      id: python_path
-      shell: python
-      run: |
-        import os
-        import sys
-        output = f"python={os.fspath(sys.executable)}"
-        print(output)
-        with open(os.environ["GITHUB_OUTPUT"], "w") as f:
-            f.write(output)
     - uses: msys2/setup-msys2@v2
       with:
         msystem: ${{ matrix.sys }}
@@ -126,7 +116,7 @@ jobs:
           make
           mingw-w64-${{ matrix.env }}-gcc
           pkg-config
-          python3
+          mingw-w64-${{ matrix.env }}-python3
           git
           diffutils
     - uses: actions/checkout@v4
@@ -138,8 +128,7 @@ jobs:
       run: make -C ports/windows -j2 VARIANT=${{ matrix.variant }}
     - name: Run tests
       id: test
-      # msys python breaks tests so we need to use "real" windows python
-      run: MICROPY_CPYTHON3=$(cygpath "${{ steps.python_path.outputs.python }}") make -C ports/windows test_full VARIANT=${{ matrix.variant }}
+      run: make -C ports/windows test_full VARIANT=${{ matrix.variant }}
     - name: Print failures
       if: failure() && steps.test.conclusion == 'failure'
       working-directory: tests

--- a/ports/windows/Makefile
+++ b/ports/windows/Makefile
@@ -101,6 +101,9 @@ include $(TOP)/py/mkrules.mk
 
 .PHONY: test test_full
 
+# Note for recent gcc versions like 13.2:
+# - mingw64-x86_64 gcc builds will pass the math_domain_special test
+# - mingw64-ucrt64 gcc builds will pass all of the below tests
 RUN_TESTS_SKIP += -e math_fun -e float2int_double -e float_parse -e math_domain_special
 
 test: $(BUILD)/$(PROG) $(TOP)/tests/run-tests.py

--- a/ports/windows/README.md
+++ b/ports/windows/README.md
@@ -45,7 +45,7 @@ Install MSYS2 from http://repo.msys2.org/distrib, start the msys2.exe shell and
 install the build tools:
 
     pacman -Syuu
-    pacman -S make mingw-w64-x86_64-gcc pkg-config python3
+    pacman -S make mingw-w64-x86_64-gcc pkg-config mingw-w64-x86_64-python3
 
 Start the mingw64.exe shell and build:
 

--- a/tests/run-tests.py
+++ b/tests/run-tests.py
@@ -580,7 +580,7 @@ def run_tests(pyb, tests, args, result_dir, num_threads=1):
     if os.getenv("GITHUB_ACTIONS") == "true":
         skip_tests.add("thread/stress_schedule.py")  # has reliability issues
 
-        if os.getenv("RUNNER_OS") == "Windows":
+        if os.getenv("RUNNER_OS") == "Windows" and os.getenv("CI_BUILD_CONFIGURATION") == "Debug":
             # fails with stack overflow on Debug builds
             skip_tests.add("misc/sys_settrace_features.py")
 

--- a/tests/run-tests.py
+++ b/tests/run-tests.py
@@ -3,6 +3,7 @@
 import os
 import subprocess
 import sys
+import sysconfig
 import platform
 import argparse
 import inspect
@@ -583,10 +584,6 @@ def run_tests(pyb, tests, args, result_dir, num_threads=1):
             # fails with stack overflow on Debug builds
             skip_tests.add("misc/sys_settrace_features.py")
 
-            if os.getenv("MSYSTEM") is not None:
-                # fails due to wrong path separator
-                skip_tests.add("import/import_file.py")
-
     if upy_float_precision == 0:
         skip_tests.add("extmod/uctypes_le_float.py")
         skip_tests.add("extmod/uctypes_native_float.py")
@@ -711,7 +708,9 @@ def run_tests(pyb, tests, args, result_dir, num_threads=1):
 
     # Some tests use unsupported features on Windows
     if os.name == "nt":
-        skip_tests.add("import/import_file.py")  # works but CPython prints forward slashes
+        if not sysconfig.get_platform().startswith("mingw"):
+            # Works but CPython uses '\' path separator
+            skip_tests.add("import/import_file.py")
 
     # Some tests are known to fail with native emitter
     # Remove them from the below when they work


### PR DESCRIPTION
This builds on #10263, fixing a mistake I once made when writing the MSYS2 installation instructions: the correct  (well, for what we need) package to install for Python on MSYS2 is `<mingwprefix>-python3` not plain `python3`. This way one single Python version can be used both for running run-tests.py and getting the expected test output.

Note these days MSYS2 also has an 'ucrt64' [environment ](https://www.msys2.org/docs/environments/) which apparently has a bunch of floating point related fixes we've sort of long been waiting for, but it's unclear to me if `mingw64` is going to be deprecated so I only added a comment about that.

@dlech FYI

Now, I only figured this out after RDP-ing into the action runner because I didn't notice at first that the way I setup my local MSYS2 environment used different instructions from the one in windows/README.md. However the process to RDP into a github action runner mentioned in #10263 does not work anymore since that repository has been disabled due to a violation of GitHub's terms of service. I skimmed over those terms but really have no idea which terms exactly.. @dpgeorge these instructions can be pretty useful imo, and the basic principle is simple enough and there are multiple solutions to implement it, but I have no idea if I can post them here and/or include them in the docs somewhere - what do you think?