### PR TITLE
webassembly: Add very simple asyncio module with create_task.

### DIFF
--- a/ports/webassembly/asyncio.py
+++ b/ports/webassembly/asyncio.py
@@ -1,0 +1,24 @@
+# Minimal asyncio interface that uses JavaScript for scheduling.
+# Only implements a very small subset of the asyncio API.
+
+import jsffi
+
+
+class Task:
+    def __init__(self, coro):
+        self._coro = coro
+
+    def done(self):
+        return self._coro is None
+
+
+async def sleep(s):
+    await jsffi.async_timeout(s)
+
+
+def create_task(coro):
+    if not hasattr(coro, "send"):
+        raise TypeError("coroutine expected")
+    t = Task(coro)
+    jsffi.create_task(t)
+    return t

--- a/ports/webassembly/asyncio.py
+++ b/ports/webassembly/asyncio.py
@@ -1,7 +1,32 @@
 # Minimal asyncio interface that uses JavaScript for scheduling.
 # Only implements a very small subset of the asyncio API.
 
-import jsffi
+import js, jsffi
+
+
+class Event:
+    def __init__(self):
+        self.clear()
+
+    def _set_callbacks(self, resolve, reject):
+        self._resolve = resolve
+        self._reject = reject
+
+    def is_set(self):
+        return self._promise is None
+
+    def set(self):
+        if self._promise is not None:
+            self._resolve()
+            self._promise = None
+
+    def clear(self):
+        self._promise = js.Promise.new(self._set_callbacks)
+
+    async def wait(self):
+        if self._promise is not None:
+            await self._promise
+        return True
 
 
 class Task:

--- a/ports/webassembly/variants/pyscript/manifest.py
+++ b/ports/webassembly/variants/pyscript/manifest.py
@@ -1,3 +1,5 @@
+module("asyncio.py", base_path="$(PORT_DIR)")
+
 require("abc")
 require("base64")
 require("collections")

--- a/tests/ports/webassembly/asyncio_create_task.mjs
+++ b/tests/ports/webassembly/asyncio_create_task.mjs
@@ -1,0 +1,41 @@
+// Test asyncio.create_task().
+
+const mp = await (await import(process.argv[2])).loadMicroPython();
+
+globalThis.p0 = new Promise((resolve, reject) => {
+    resolve(123);
+});
+
+globalThis.p1 = new Promise((resolve, reject) => {
+    setTimeout(() => {
+        console.log("setTimeout resolved");
+        resolve(456);
+    }, 500);
+});
+
+mp.runPython(`
+import js
+import asyncio
+
+async def task(id, pp):
+    print("task start", id)
+    print("task await", id, await pp)
+    print("task await", id, await pp)
+    print("task end", id)
+
+print("start")
+t1 = asyncio.create_task(task(1, js.p0))
+t2 = asyncio.create_task(task(2, js.p1))
+print("t1", t1.done(), t2.done())
+print("end")
+`);
+
+await globalThis.p1;
+await globalThis.p1;
+await globalThis.p1;
+await globalThis.p1;
+
+mp.runPython(`
+print("restart")
+print("t1", t1.done(), t2.done())
+`);

--- a/tests/ports/webassembly/asyncio_create_task.mjs.exp
+++ b/tests/ports/webassembly/asyncio_create_task.mjs.exp
@@ -1,0 +1,14 @@
+start
+t1 False False
+end
+task start 1
+task start 2
+task await 1 123
+task await 1 123
+task end 1
+setTimeout resolved
+task await 2 456
+task await 2 456
+task end 2
+restart
+t1 True True

--- a/tests/ports/webassembly/asyncio_event.mjs
+++ b/tests/ports/webassembly/asyncio_event.mjs
@@ -1,0 +1,57 @@
+// Test asyncio.Event.
+//
+// This test is taken from tests/extmod/asyncio_event.py and adapted:
+// - changed asyncio.run(main()) to await main()
+// - removed cancel and wait_for parts of the test
+
+const mp = await (await import(process.argv[2])).loadMicroPython();
+
+await mp.runPythonAsync(`
+import asyncio
+
+async def task(id, ev):
+    print("start", id)
+    print(await ev.wait())
+    print("end", id)
+
+
+async def main():
+    ev = asyncio.Event()
+
+    # Set and clear without anything waiting, and test is_set()
+    print(ev.is_set())
+    ev.set()
+    print(ev.is_set())
+    ev.clear()
+    print(ev.is_set())
+
+    # Create 2 tasks waiting on the event
+    print("----")
+    asyncio.create_task(task(1, ev))
+    asyncio.create_task(task(2, ev))
+    print("yield")
+    await asyncio.sleep(0)
+    print("set event")
+    ev.set()
+    print("yield")
+    await asyncio.sleep(0)
+
+    # Create a task waiting on the already-set event
+    print("----")
+    asyncio.create_task(task(3, ev))
+    print("yield")
+    await asyncio.sleep(0)
+
+    # Clear event, start a task, then set event again
+    print("----")
+    print("clear event")
+    ev.clear()
+    asyncio.create_task(task(4, ev))
+    await asyncio.sleep(0)
+    print("set event")
+    ev.set()
+    await asyncio.sleep(0)
+
+
+await main()
+`);

--- a/tests/ports/webassembly/asyncio_event.mjs.exp
+++ b/tests/ports/webassembly/asyncio_event.mjs.exp
@@ -1,0 +1,24 @@
+False
+True
+False
+----
+yield
+start 1
+start 2
+set event
+yield
+True
+end 1
+True
+end 2
+----
+yield
+start 3
+True
+end 3
+----
+clear event
+start 4
+set event
+True
+end 4

--- a/tests/ports/webassembly/asyncio_sleep.mjs
+++ b/tests/ports/webassembly/asyncio_sleep.mjs
@@ -1,0 +1,25 @@
+// Test asyncio.sleep().
+
+const mp = await (await import(process.argv[2])).loadMicroPython();
+
+await mp.runPythonAsync(`
+import time
+import asyncio
+
+print("main start")
+t0 = time.time()
+await asyncio.sleep(0.25)
+dt = time.time() - t0
+print(0.2 <= dt <= 0.3)
+
+async def task():
+    print("task start")
+    t0 = time.time()
+    await asyncio.sleep(0.25)
+    dt = time.time() - t0
+    print(0.2 <= dt <= 0.3)
+    print("task end")
+
+asyncio.create_task(task())
+print("main end")
+`);

--- a/tests/ports/webassembly/asyncio_sleep.mjs.exp
+++ b/tests/ports/webassembly/asyncio_sleep.mjs.exp
@@ -1,0 +1,6 @@
+main start
+True
+main end
+task start
+True
+task end

--- a/tests/run-tests.py
+++ b/tests/run-tests.py
@@ -681,6 +681,7 @@ def run_tests(pyb, tests, args, result_dir, num_threads=1):
         elif args.target == "webassembly":
             skip_tests.add("basics/string_format_modulo.py")  # can't print nulls to stdout
             skip_tests.add("basics/string_strip.py")  # can't print nulls to stdout
+            skip_tests.update(t for t in tests if t.startswith("extmod/asyncio_"))
             skip_tests.add("extmod/binascii_a2b_base64.py")
             skip_tests.add("extmod/re_stack_overflow.py")
             skip_tests.add("extmod/time_res.py")


### PR DESCRIPTION
This allows Python code to run `asyncio.create_task(...)` to schedule a cooperative task from within Python.  The actual running of the task is handled by the JavaScript runtime.