### PR TITLE
tinyusb: Don't disconnect on soft reset unless runtime USB was active.

### DIFF
--- a/shared/tinyusb/mp_usbd_runtime.c
+++ b/shared/tinyusb/mp_usbd_runtime.c
@@ -431,11 +431,12 @@ void mp_usbd_init(void) {
 // Top-level USB device deinit.
 //
 // This variant is called from soft reset, NULLs out the USB device
-// singleton instance from MP_STATE_VM, and disconnects the port.
+// singleton instance from MP_STATE_VM, and disconnects the port if a
+// runtime device was active.
 void mp_usbd_deinit(void) {
     mp_obj_usb_device_t *usbd = MP_OBJ_TO_PTR(MP_STATE_VM(usbd));
     MP_STATE_VM(usbd) = MP_OBJ_NULL;
-    if (usbd) {
+    if (usbd && usbd->active) {
         // Disconnect if a runtime USB device was active
         mp_usbd_disconnect(usbd);
     }

--- a/shared/tinyusb/mp_usbd_runtime.c
+++ b/shared/tinyusb/mp_usbd_runtime.c
@@ -44,7 +44,7 @@
 #include "device/usbd_pvt.h"
 #endif
 
-static bool in_usbd_task; // Flags if mp_usbd_task() is processing already
+static bool in_usbd_task; // Flags if mp_usbd_task() is currently running
 
 // Some top-level functions that manage global TinyUSB USBD state, not the
 // singleton object visible to Python
@@ -250,8 +250,8 @@ static uint16_t _runtime_dev_claim_itfs(tusb_desc_interface_t const *itf_desc, u
 // configuration. Returns number of bytes to claim from descriptors pointed to
 // by itf_desc.
 //
-// This is a little fiddly as it's called before any compiled-in "static"
-// TinyUSB drivers, but we don't want to override those.
+// This is a little fiddly as it's called before any built-in TinyUSB drivers,
+// but we don't want to override those.
 //
 // Also, TinyUSB expects us to know how many interfaces to claim for each time
 // this function is called, and will behave unexpectedly if we claim the wrong
@@ -266,7 +266,7 @@ static uint16_t runtime_dev_open(uint8_t rhport, tusb_desc_interface_t const *it
         return 0;
     }
 
-    // If TinyUSB built-in drivers are enabled, don't claim any interface in the static range
+    // If TinyUSB built-in drivers are enabled, don't claim any interface in the built-in range
     if (mp_usb_device_builtin_enabled(usbd) && itf_desc->bInterfaceNumber < USBD_ITF_BUILTIN_MAX) {
         return 0;
     }
@@ -400,7 +400,7 @@ usbd_class_driver_t const *usbd_app_driver_get_cb(uint8_t *driver_count) {
 
 // Top-level USB device subsystem init.
 //
-// Makes an on-demand call to mp_usbd_activate(), if USB is needed.
+// Initialises TinyUSB and/or re-activates it, provided USB is needed.
 //
 // This is called on any soft reset after boot.py runs, or on demand if the
 // user activates USB and it hasn't activated yet.
@@ -414,7 +414,7 @@ void mp_usbd_init(void) {
         // Builtin  drivers are available, so initialise as defaults
         need_usb = true;
         #else
-        // No static drivers, nothing to initialise
+        // No builtin drivers, nothing to initialise
         need_usb = false;
         #endif
     } else {
@@ -472,7 +472,10 @@ static void mp_usbd_disconnect(mp_obj_usb_device_t *usbd) {
     bool was_connected = tud_connected();
     tud_disconnect();
     if (was_connected) {
-        mp_hal_delay_ms(50); // TODO: Always???
+        // Need to ensure a long enough delay before TinyUSB re-connects that
+        // the host triggers a bus reset. This may happen anyway, but delaying here
+        // lets us be "belt and braces" sure.
+        mp_hal_delay_ms(50);
     }
 }
 


### PR DESCRIPTION
Previously, constructing the singleton USBDevice object was enough to trigger a USB disconnect on soft reset. Now it also has to be active.

The only case where this changes the behaviour is if the USBDevice object has been constructed but never set to active (no more disconnect in this case). Otherwise, behaviour is the same.

This change was [requested by hippy on the raspberrypi forums](https://forums.raspberrypi.com/viewtopic.php?p=2205682#p2205682).

This PR also includes a second commit that updates some comments related to runtime USB, but doesn't change any code.