### PR TITLE
Add nic.ipconfig for other ports (like esp32, stm32 and others)

### DIFF
--- a/extmod/modnetwork.c
+++ b/extmod/modnetwork.c
@@ -144,12 +144,15 @@ static MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(mod_network_hostname_obj, 0, 1, mod_n
 #if LWIP_VERSION_MAJOR >= 2
 MP_DEFINE_CONST_FUN_OBJ_KW(mod_network_ipconfig_obj, 0, mod_network_ipconfig);
 #endif
+#if MICROPY_PY_NETWORK_NINAW10
+MP_DEFINE_CONST_FUN_OBJ_KW(mod_network_ipconfig_obj, 0, network_ninaw10_ipconfig);
+#endif
 
 static const mp_rom_map_elem_t mp_module_network_globals_table[] = {
     { MP_ROM_QSTR(MP_QSTR___name__), MP_ROM_QSTR(MP_QSTR_network) },
     { MP_ROM_QSTR(MP_QSTR_country), MP_ROM_PTR(&mod_network_country_obj) },
     { MP_ROM_QSTR(MP_QSTR_hostname), MP_ROM_PTR(&mod_network_hostname_obj) },
-    #if LWIP_VERSION_MAJOR >= 2
+    #if LWIP_VERSION_MAJOR >= 2 || MICROPY_PY_NETWORK_NINAW10
     { MP_ROM_QSTR(MP_QSTR_ipconfig), MP_ROM_PTR(&mod_network_ipconfig_obj) },
     #endif
 

--- a/extmod/modnetwork.h
+++ b/extmod/modnetwork.h
@@ -83,6 +83,10 @@ extern int mp_mod_network_prefer_dns_use_ip_version;
 #endif
 #elif defined(MICROPY_PORT_NETWORK_INTERFACES)
 
+#if MICROPY_PY_NETWORK_NINAW10
+mp_obj_t network_ninaw10_ipconfig(size_t n_args, const mp_obj_t *args, mp_map_t *kwargs);
+#endif
+
 struct _mod_network_socket_obj_t;
 
 typedef struct _mod_network_nic_protocol_t {

--- a/ports/esp32/modnetwork.h
+++ b/ports/esp32/modnetwork.h
@@ -54,6 +54,8 @@ MP_DECLARE_CONST_FUN_OBJ_VAR_BETWEEN(esp_network_get_wlan_obj);
 MP_DECLARE_CONST_FUN_OBJ_KW(esp_network_get_lan_obj);
 MP_DECLARE_CONST_FUN_OBJ_1(esp_network_ppp_make_new_obj);
 MP_DECLARE_CONST_FUN_OBJ_VAR_BETWEEN(esp_network_ifconfig_obj);
+MP_DECLARE_CONST_FUN_OBJ_KW(esp_network_ipconfig_obj);
+MP_DECLARE_CONST_FUN_OBJ_KW(esp_nic_ipconfig_obj);
 MP_DECLARE_CONST_FUN_OBJ_KW(esp_network_config_obj);
 MP_DECLARE_CONST_FUN_OBJ_VAR_BETWEEN(esp_network_phy_mode_obj);
 

--- a/ports/esp32/modnetwork_globals.h
+++ b/ports/esp32/modnetwork_globals.h
@@ -11,6 +11,7 @@
 { MP_ROM_QSTR(MP_QSTR_PPP), MP_ROM_PTR(&esp_network_ppp_make_new_obj) },
 #endif
 { MP_ROM_QSTR(MP_QSTR_phy_mode), MP_ROM_PTR(&esp_network_phy_mode_obj) },
+{ MP_ROM_QSTR(MP_QSTR_ipconfig), MP_ROM_PTR(&esp_network_ipconfig_obj) },
 
 #if MICROPY_PY_NETWORK_WLAN
 { MP_ROM_QSTR(MP_QSTR_STA_IF), MP_ROM_INT(WIFI_IF_STA)},

--- a/ports/esp32/network_lan.c
+++ b/ports/esp32/network_lan.c
@@ -404,6 +404,7 @@ static const mp_rom_map_elem_t lan_if_locals_dict_table[] = {
     { MP_ROM_QSTR(MP_QSTR_status), MP_ROM_PTR(&lan_status_obj) },
     { MP_ROM_QSTR(MP_QSTR_config), MP_ROM_PTR(&lan_config_obj) },
     { MP_ROM_QSTR(MP_QSTR_ifconfig), MP_ROM_PTR(&esp_network_ifconfig_obj) },
+    { MP_ROM_QSTR(MP_QSTR_ipconfig), MP_ROM_PTR(&esp_nic_ipconfig_obj) },
 };
 
 static MP_DEFINE_CONST_DICT(lan_if_locals_dict, lan_if_locals_dict_table);

--- a/ports/esp32/network_wlan.c
+++ b/ports/esp32/network_wlan.c
@@ -728,6 +728,7 @@ static const mp_rom_map_elem_t wlan_if_locals_dict_table[] = {
     { MP_ROM_QSTR(MP_QSTR_isconnected), MP_ROM_PTR(&network_wlan_isconnected_obj) },
     { MP_ROM_QSTR(MP_QSTR_config), MP_ROM_PTR(&network_wlan_config_obj) },
     { MP_ROM_QSTR(MP_QSTR_ifconfig), MP_ROM_PTR(&esp_network_ifconfig_obj) },
+    { MP_ROM_QSTR(MP_QSTR_ipconfig), MP_ROM_PTR(&esp_nic_ipconfig_obj) },
 
     // Constants
     { MP_ROM_QSTR(MP_QSTR_IF_STA), MP_ROM_INT(WIFI_IF_STA)},

--- a/ports/esp8266/modnetwork.h
+++ b/ports/esp8266/modnetwork.h
@@ -1,3 +1,4 @@
 extern const mp_obj_type_t esp_network_wlan_type;
 
 MP_DECLARE_CONST_FUN_OBJ_VAR_BETWEEN(esp_network_phy_mode_obj);
+MP_DECLARE_CONST_FUN_OBJ_KW(esp_network_ipconfig_obj);

--- a/ports/esp8266/modnetwork_globals.h
+++ b/ports/esp8266/modnetwork_globals.h
@@ -1,5 +1,6 @@
 { MP_ROM_QSTR(MP_QSTR_WLAN), MP_ROM_PTR(&esp_network_wlan_type) },
 { MP_ROM_QSTR(MP_QSTR_phy_mode), MP_ROM_PTR(&esp_network_phy_mode_obj) },
+{ MP_ROM_QSTR(MP_QSTR_ipconfig), MP_ROM_PTR(&esp_network_ipconfig_obj) },
 
 { MP_ROM_QSTR(MP_QSTR_STA_IF), MP_ROM_INT(STATION_IF)},
 { MP_ROM_QSTR(MP_QSTR_AP_IF), MP_ROM_INT(SOFTAP_IF)},

--- a/ports/mimxrt/network_lan.c
+++ b/ports/mimxrt/network_lan.c
@@ -179,6 +179,12 @@ static mp_obj_t network_lan_ifconfig(size_t n_args, const mp_obj_t *args) {
 }
 MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(network_lan_ifconfig_obj, 1, 2, network_lan_ifconfig);
 
+static mp_obj_t network_lan_ipconfig(size_t n_args, const mp_obj_t *args, mp_map_t *kwargs) {
+    network_lan_obj_t *self = MP_OBJ_TO_PTR(args[0]);
+    return mod_network_nic_ipconfig(eth_netif(self->eth), n_args - 1, args + 1, kwargs);
+}
+static MP_DEFINE_CONST_FUN_OBJ_KW(network_lan_ipconfig_obj, 1, network_lan_ipconfig);
+
 static mp_obj_t network_lan_status(size_t n_args, const mp_obj_t *args) {
     network_lan_obj_t *self = MP_OBJ_TO_PTR(args[0]);
     (void)self;
@@ -241,6 +247,7 @@ static const mp_rom_map_elem_t network_lan_locals_dict_table[] = {
     { MP_ROM_QSTR(MP_QSTR_active), MP_ROM_PTR(&network_lan_active_obj) },
     { MP_ROM_QSTR(MP_QSTR_isconnected), MP_ROM_PTR(&network_lan_isconnected_obj) },
     { MP_ROM_QSTR(MP_QSTR_ifconfig), MP_ROM_PTR(&network_lan_ifconfig_obj) },
+    { MP_ROM_QSTR(MP_QSTR_ipconfig), MP_ROM_PTR(&network_lan_ipconfig_obj) },
     { MP_ROM_QSTR(MP_QSTR_status), MP_ROM_PTR(&network_lan_status_obj) },
     { MP_ROM_QSTR(MP_QSTR_config), MP_ROM_PTR(&network_lan_config_obj) },
 

--- a/ports/stm32/network_lan.c
+++ b/ports/stm32/network_lan.c
@@ -101,6 +101,12 @@ static mp_obj_t network_lan_ifconfig(size_t n_args, const mp_obj_t *args) {
 }
 MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(network_lan_ifconfig_obj, 1, 2, network_lan_ifconfig);
 
+static mp_obj_t network_lan_ipconfig(size_t n_args, const mp_obj_t *args, mp_map_t *kwargs) {
+    network_lan_obj_t *self = MP_OBJ_TO_PTR(args[0]);
+    return mod_network_nic_ipconfig(eth_netif(self->eth), n_args - 1, args + 1, kwargs);
+}
+static MP_DEFINE_CONST_FUN_OBJ_KW(network_lan_ipconfig_obj, 1, network_lan_ipconfig);
+
 static mp_obj_t network_lan_status(size_t n_args, const mp_obj_t *args) {
     network_lan_obj_t *self = MP_OBJ_TO_PTR(args[0]);
     (void)self;
@@ -163,6 +169,7 @@ static const mp_rom_map_elem_t network_lan_locals_dict_table[] = {
     { MP_ROM_QSTR(MP_QSTR_active), MP_ROM_PTR(&network_lan_active_obj) },
     { MP_ROM_QSTR(MP_QSTR_isconnected), MP_ROM_PTR(&network_lan_isconnected_obj) },
     { MP_ROM_QSTR(MP_QSTR_ifconfig), MP_ROM_PTR(&network_lan_ifconfig_obj) },
+    { MP_ROM_QSTR(MP_QSTR_ipconfig), MP_ROM_PTR(&network_lan_ipconfig_obj) },
     { MP_ROM_QSTR(MP_QSTR_status), MP_ROM_PTR(&network_lan_status_obj) },
     { MP_ROM_QSTR(MP_QSTR_config), MP_ROM_PTR(&network_lan_config_obj) },
 

--- a/shared/netutils/netutils.c
+++ b/shared/netutils/netutils.c
@@ -63,7 +63,13 @@ void netutils_parse_ipv4_addr(mp_obj_t addr_in, uint8_t *out_ip, netutils_endian
         return;
     }
     const char *s = addr_str;
-    const char *s_top = addr_str + addr_len;
+    const char *s_top;
+    // Scan for the end of valid address characters
+    for (s_top = addr_str; s_top < addr_str + addr_len; s_top++) {
+        if (!(*s_top == '.' || (*s_top >= '0' && *s_top <= '9'))) {
+            break;
+        }
+    }
     for (mp_uint_t i = 3; ; i--) {
         mp_uint_t val = 0;
         for (; s < s_top && *s != '.'; s++) {


### PR DESCRIPTION
In order to make network configuration extensible and consistent across ports, we implemented `ipconfig` for the other implemented nics:

   - [x] extmod/network_ninaw10.c -> nina_ifconfig
   - [x] ports/cc3200/mods/modwlan.c -> sl_NetCfgSet
   - [x] ports/esp32/network_lan.c --> esp-netif
   - [x] ports/esp32/network_ppp.c --> (old?) lwip, can only be used to set dns.
   - [x] ports/esp32/network_wlan.c --> esp-netif (setting the IP in CIDR notation requries more work)
   - [x] ports/esp8266/network_wlan.c -> esp-netif, copy of the esp32 code(?)
   - [x] ports/mimxrt/network_lan.c -> lwip
   - [x] ports/stm32/network_lan.c -> lwip
