### PR TITLE
tests/net_inet: Add simpler tls sites test, and skip existing on axtls.

### DIFF
--- a/tests/net_inet/test_tls_sites.py
+++ b/tests/net_inet/test_tls_sites.py
@@ -1,7 +1,14 @@
+# Test making HTTPS requests to sites that may require advanced ciphers.
+
 import sys
 import select
 import socket
 import ssl
+
+# Don't run if ssl doesn't support required certificates (eg axtls).
+if not hasattr(ssl, "CERT_REQUIRED"):
+    print("SKIP")
+    raise SystemExit
 
 
 def test_one(site, opts):

--- a/tests/net_inet/test_tls_sites_simple.py
+++ b/tests/net_inet/test_tls_sites_simple.py
@@ -1,0 +1,43 @@
+# Test making HTTPS requests to sites that allow simple ciphers.
+
+import sys
+import socket
+import ssl
+
+SITES = (
+    ("micropython.org", "/ks/test.html"),
+    ("pypi.org", "/"),
+)
+
+
+def test_one(site, path):
+    ai = socket.getaddrinfo(site, 443, socket.AF_INET)
+    addr = ai[0][-1]
+
+    # Create SSLContext.
+    ssl_context = ssl.SSLContext(ssl.PROTOCOL_TLS_CLIENT)
+    if sys.implementation.name != "micropython":
+        # CPython compatibility: disable check_hostname
+        ssl_context.check_hostname = False
+    ssl_context.verify_mode = ssl.CERT_NONE
+
+    s = socket.socket(socket.AF_INET)
+    s.connect(addr)
+    s = ssl_context.wrap_socket(s)
+
+    s.write(b"GET %s HTTP/1.0\r\nHost: %s\r\n\r\n" % (bytes(path, "ascii"), bytes(site, "ascii")))
+    resp = s.read(4096)
+    s.close()
+
+    if resp.startswith(b"HTTP/1."):
+        print(site, "ok")
+    else:
+        print(site, "response doesn't start with HTTP/1.")
+
+
+def main():
+    for site, path in SITES:
+        test_one(site, path)
+
+
+main()


### PR DESCRIPTION
Ports that use axtls cannot run the `test_tls_sites.py` test because the sites it connects to use advanced ciphers.  So skip this test on such ports, and add a new, simpler test that doesn't require certificate verification and works with axtls.