### PR TITLE
webassembly: Fix return value of async fun to JS, and promote Python thenable to Promise

### DIFF
--- a/ports/webassembly/objjsproxy.c
+++ b/ports/webassembly/objjsproxy.c
@@ -48,9 +48,17 @@ EM_JS(bool, lookup_attr, (int jsref, const char *str, uint32_t * out), {
     const attr = UTF8ToString(str);
     if (attr in base) {
         let value = base[attr];
-        if (typeof value == "function") {
+        if (typeof value === "function") {
             if (base !== globalThis) {
-                value = value.bind(base);
+                if ("_ref" in value) {
+                    // This is a proxy of a Python function, it doesn't need
+                    // binding.  And not binding it means if it's passed back
+                    // to Python then it can be extracted from the proxy as a
+                    // true Python function.
+                } else {
+                    // A function that is not a Python function.  Bind it.
+                    value = value.bind(base);
+                }
             }
         }
         proxy_convert_js_to_mp_obj_jsside(value, out);

--- a/ports/webassembly/proxy_c.c
+++ b/ports/webassembly/proxy_c.c
@@ -289,10 +289,11 @@ void proxy_c_to_js_get_dict(uint32_t c_ref, uint32_t *out) {
 
 static const mp_obj_fun_builtin_var_t resume_obj;
 
-EM_JS(void, js_then_resolve, (uint32_t * resolve, uint32_t * reject), {
+EM_JS(void, js_then_resolve, (uint32_t * ret_value, uint32_t * resolve, uint32_t * reject), {
+    const ret_value_js = proxy_convert_mp_to_js_obj_jsside(ret_value);
     const resolve_js = proxy_convert_mp_to_js_obj_jsside(resolve);
     const reject_js = proxy_convert_mp_to_js_obj_jsside(reject);
-    resolve_js(null);
+    resolve_js(ret_value_js);
 });
 
 EM_JS(void, js_then_reject, (uint32_t * resolve, uint32_t * reject), {
@@ -321,7 +322,9 @@ static mp_obj_t proxy_resume_execute(mp_obj_t self_in, mp_obj_t value, mp_obj_t 
     proxy_convert_mp_to_js_obj_cside(reject, out_reject);
 
     if (ret_kind == MP_VM_RETURN_NORMAL) {
-        js_then_resolve(out_resolve, out_reject);
+        uint32_t out_ret_value[PVN];
+        proxy_convert_mp_to_js_obj_cside(ret_value, out_ret_value);
+        js_then_resolve(out_ret_value, out_resolve, out_reject);
         return mp_const_none;
     } else if (ret_kind == MP_VM_RETURN_YIELD) {
         // ret_value should be a JS thenable

--- a/tests/ports/webassembly/await_js_async_py.mjs
+++ b/tests/ports/webassembly/await_js_async_py.mjs
@@ -1,0 +1,35 @@
+// Test JavaScript await'ing on Python async functions.
+
+const mp = await (await import(process.argv[2])).loadMicroPython();
+
+globalThis.asyncTimeout = (ms) =>
+    new Promise((resolve) => setTimeout(resolve, ms));
+
+mp.runPython(`
+import js
+
+def f0():
+    print("f0 run")
+    return 1
+
+async def f1():
+    print("f1 run")
+    return 2
+
+async def f2():
+    print("f2 start")
+    await js.asyncTimeout(0)
+    print("f2 end")
+    return 3
+
+async def f3():
+    print("f3 start")
+    ret = await f2()
+    print("f3 end")
+    return ret + 1
+`);
+
+console.log("f0 return:", await mp.globals.get("f0")());
+console.log("f1 return:", await mp.globals.get("f1")());
+console.log("f2 return:", await mp.globals.get("f2")());
+console.log("f3 return:", await mp.globals.get("f3")());

--- a/tests/ports/webassembly/await_js_async_py.mjs.exp
+++ b/tests/ports/webassembly/await_js_async_py.mjs.exp
@@ -1,0 +1,12 @@
+f0 run
+f0 return: 1
+f1 run
+f1 return: 2
+f2 start
+f2 end
+f2 return: 3
+f3 start
+f2 start
+f2 end
+f3 end
+f3 return: 4

--- a/tests/ports/webassembly/fun_proxy.mjs
+++ b/tests/ports/webassembly/fun_proxy.mjs
@@ -1,0 +1,52 @@
+// Test proxying of functions between Python and JavaScript.
+
+const mp = await (await import(process.argv[2])).loadMicroPython();
+
+// Create JS functions living on the JS and Py sides.
+globalThis.jsFunAdd = (x, y) => x + y;
+mp.globals.set("js_fun_sub", (x, y) => x - y);
+
+console.log("== JavaScript side ==");
+
+// JS function living on the JS side, should be a function.
+console.log(globalThis.jsFunAdd);
+console.log(globalThis.jsFunAdd(1, 2));
+
+// JS function living on the Py side, should be a function.
+console.log(mp.globals.get("js_fun_sub"));
+console.log(mp.globals.get("js_fun_sub")(1, 2));
+
+mp.runPython(`
+import js
+
+print("== Python side ==")
+
+py_fun_mul = lambda x, y: x * y
+js.pyFunDiv = lambda x, y: x / y
+
+# JS function living on the JS side, should be a JsProxy.
+print(type(js.jsFunAdd))
+print(js.jsFunAdd(1, 2))
+
+# JS function living on the Py side, should be a JsProxy.
+print(type(js_fun_sub))
+print(js_fun_sub(1, 2))
+
+# Py function living on the Py side, should be a function.
+print(type(py_fun_mul))
+print(py_fun_mul(2, 3))
+
+# Py function living on the JS side, should be a function.
+print(type(js.pyFunDiv))
+print(js.pyFunDiv(6, 2))
+`);
+
+console.log("== JavaScript side ==");
+
+// Py function living on the Py side, should be a proxy function.
+console.log(mp.globals.get("py_fun_mul"));
+console.log(mp.globals.get("py_fun_mul")(2, 3));
+
+// Py function living on the JS side, should be a proxy function.
+console.log(globalThis.pyFunDiv);
+console.log(globalThis.pyFunDiv(6, 2));

--- a/tests/ports/webassembly/fun_proxy.mjs.exp
+++ b/tests/ports/webassembly/fun_proxy.mjs.exp
@@ -1,0 +1,19 @@
+== JavaScript side ==
+[Function (anonymous)]
+3
+[Function (anonymous)]
+-1
+== Python side ==
+<class 'JsProxy'>
+3
+<class 'JsProxy'>
+-1
+<class 'function'>
+6
+<class 'function'>
+3.0
+== JavaScript side ==
+[Function: obj] { _ref: 4 }
+6
+[Function: obj] { _ref: 3 }
+3

--- a/tests/ports/webassembly/fun_py_callback_js.mjs
+++ b/tests/ports/webassembly/fun_py_callback_js.mjs
@@ -1,0 +1,31 @@
+// Test using Python functions as JS callbacks.
+
+const mp = await (await import(process.argv[2])).loadMicroPython();
+
+globalThis.asyncTimeout = (ms) =>
+    new Promise((resolve) => setTimeout(resolve, ms));
+
+mp.runPython(`
+import js
+
+def f0():
+    print("f0 run")
+
+async def f1():
+    print("f1 run")
+
+async def f2():
+    print("f2 start")
+    await js.asyncTimeout(0)
+    print("f2 end")
+
+async def f3():
+    print("f3 start")
+    await f2()
+    print("f3 end")
+
+js.setTimeout(f0, 0)
+js.setTimeout(f1, 50)
+js.setTimeout(f2, 100)
+js.setTimeout(f3, 150)
+`);

--- a/tests/ports/webassembly/fun_py_callback_js.mjs.exp
+++ b/tests/ports/webassembly/fun_py_callback_js.mjs.exp
@@ -1,0 +1,8 @@
+f0 run
+f1 run
+f2 start
+f2 end
+f3 start
+f2 start
+f2 end
+f3 end


### PR DESCRIPTION
This PR improves support for proxying of Python async functions across to JavaScript.