### PR TITLE
wiznet5k: Properly enable socket buffers for W5100(S).

### DIFF
--- a/extmod/network_wiznet5k.c
+++ b/extmod/network_wiznet5k.c
@@ -211,7 +211,11 @@ static void wiznet5k_init(void) {
     // Configure wiznet for raw ethernet frame usage.
 
     // Configure 16k buffers for fast MACRAW
+    #if _WIZCHIP_ < W5200
+    uint8_t sn_size[8] = {8, 0, 0, 0, 8, 0, 0, 0};
+    #else
     uint8_t sn_size[16] = {16, 0, 0, 0, 0, 0, 0, 0, 16, 0, 0, 0, 0, 0, 0, 0};
+    #endif
     ctlwizchip(CW_INIT_WIZCHIP, sn_size);
 
     if (wiznet5k_obj.use_interrupt) {


### PR DESCRIPTION
The W5100 and W5100S only have 4 available sockets and 16kB of socket buffer. Allocating 16kB to either the receive or transmit buffer of a single socket is not allowed, so the current setup does not change the allocation for socket 0 from the reset default. `ctlwizchip` is returning `-1` to indicate the error, but the response isn't being inspected and probably doesn't need to be.