### PR TITLE
Add method to convert NUL-terminated C strings to MicroPython strings.

### DIFF
--- a/extmod/modlwip.c
+++ b/extmod/modlwip.c
@@ -373,7 +373,7 @@ mp_obj_t lwip_format_inet_addr(const ip_addr_t *ip, mp_uint_t port) {
     char ipstr[IPADDR_STRLEN_MAX];
     ipaddr_ntoa_r(ip, ipstr, sizeof(ipstr));
     mp_obj_t tuple[2] = {
-        tuple[0] = mp_obj_new_str(ipstr, strlen(ipstr)),
+        tuple[0] = mp_obj_new_str_from_cstr(ipstr),
         tuple[1] = mp_obj_new_int(port),
     };
     return mp_obj_new_tuple(2, tuple);

--- a/extmod/modnetwork.c
+++ b/extmod/modnetwork.c
@@ -127,7 +127,7 @@ MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(mod_network_country_obj, 0, 1, network_count
 
 mp_obj_t mod_network_hostname(size_t n_args, const mp_obj_t *args) {
     if (n_args == 0) {
-        return mp_obj_new_str(mod_network_hostname_data, strlen(mod_network_hostname_data));
+        return mp_obj_new_str_from_cstr(mod_network_hostname_data);
     } else {
         size_t len;
         const char *str = mp_obj_str_get_data(args[0], &len);

--- a/extmod/modopenamp.c
+++ b/extmod/modopenamp.c
@@ -263,7 +263,7 @@ static void openamp_ns_callback(struct rpmsg_device *rdev, const char *name, uin
     // the Name Service (NS) announcement containing the name of the channel.
     virtio_dev_obj_t *virtio_device = metal_container_of(rdev, virtio_dev_obj_t, rvdev);
     if (virtio_device->ns_callback != mp_const_none) {
-        mp_call_function_2(virtio_device->ns_callback, mp_obj_new_int(dest), mp_obj_new_str(name, strlen(name)));
+        mp_call_function_2(virtio_device->ns_callback, mp_obj_new_int(dest), mp_obj_new_str_from_cstr(name));
     }
 }
 

--- a/extmod/modopenamp_remoteproc_store.c
+++ b/extmod/modopenamp_remoteproc_store.c
@@ -70,7 +70,7 @@ void *mp_openamp_remoteproc_store_alloc(void) {
 static int openamp_remoteproc_store_open(void *store, const char *path, const void **image_data) {
     metal_log(METAL_LOG_DEBUG, "store_open(): %s\n", path);
     mp_obj_t args[2] = {
-        mp_obj_new_str(path, strlen(path)),
+        mp_obj_new_str_from_cstr(path),
         MP_OBJ_NEW_QSTR(MP_QSTR_rb),
     };
 

--- a/extmod/modtls_mbedtls.c
+++ b/extmod/modtls_mbedtls.c
@@ -307,7 +307,7 @@ static mp_obj_t ssl_context_get_ciphers(mp_obj_t self_in) {
     mp_obj_t list = mp_obj_new_list(0, NULL);
     for (const int *cipher_list = mbedtls_ssl_list_ciphersuites(); *cipher_list; ++cipher_list) {
         const char *cipher_name = mbedtls_ssl_get_ciphersuite_name(*cipher_list);
-        mp_obj_list_append(list, MP_OBJ_FROM_PTR(mp_obj_new_str(cipher_name, strlen(cipher_name))));
+        mp_obj_list_append(list, MP_OBJ_FROM_PTR(mp_obj_new_str_from_cstr(cipher_name)));
     }
     return list;
 }
@@ -572,8 +572,8 @@ static mp_obj_t mod_ssl_cipher(mp_obj_t o_in) {
     mp_obj_ssl_socket_t *o = MP_OBJ_TO_PTR(o_in);
     const char *cipher_suite = mbedtls_ssl_get_ciphersuite(&o->ssl);
     const char *tls_version = mbedtls_ssl_get_version(&o->ssl);
-    mp_obj_t tuple[2] = {mp_obj_new_str(cipher_suite, strlen(cipher_suite)),
-                         mp_obj_new_str(tls_version, strlen(tls_version))};
+    mp_obj_t tuple[2] = {mp_obj_new_str_from_cstr(cipher_suite),
+                         mp_obj_new_str_from_cstr(tls_version)};
 
     return mp_obj_new_tuple(2, tuple);
 }

--- a/extmod/modwebrepl.c
+++ b/extmod/modwebrepl.c
@@ -146,7 +146,7 @@ static void handle_op(mp_obj_webrepl_t *self) {
     // Handle operations requiring opened file
 
     mp_obj_t open_args[2] = {
-        mp_obj_new_str(self->hdr.fname, strlen(self->hdr.fname)),
+        mp_obj_new_str_from_cstr(self->hdr.fname),
         MP_OBJ_NEW_QSTR(MP_QSTR_rb)
     };
 

--- a/extmod/network_esp_hosted.c
+++ b/extmod/network_esp_hosted.c
@@ -230,7 +230,7 @@ static mp_obj_t network_esp_hosted_config(size_t n_args, const mp_obj_t *args, m
             case MP_QSTR_essid: {
                 esp_hosted_netinfo_t netinfo;
                 esp_hosted_wifi_netinfo(&netinfo);
-                return mp_obj_new_str(netinfo.ssid, strlen(netinfo.ssid));
+                return mp_obj_new_str_from_cstr(netinfo.ssid);
             }
             case MP_QSTR_security: {
                 esp_hosted_netinfo_t netinfo;

--- a/extmod/network_lwip.c
+++ b/extmod/network_lwip.c
@@ -113,7 +113,7 @@ mp_obj_t mod_network_ipconfig(size_t n_args, const mp_obj_t *args, mp_map_t *kwa
             case MP_QSTR_dns: {
                 char addr_str[IPADDR_STRLEN_MAX];
                 ipaddr_ntoa_r(dns_getserver(0), addr_str, sizeof(addr_str));
-                return mp_obj_new_str(addr_str, strlen(addr_str));
+                return mp_obj_new_str_from_cstr(addr_str);
             }
             case MP_QSTR_prefer: {
                 return MP_OBJ_NEW_SMALL_INT(mp_mod_network_prefer_dns_use_ip_version);
@@ -219,7 +219,7 @@ mp_obj_t mod_network_nic_ipconfig(struct netif *netif, size_t n_args, const mp_o
                         char addr_str[IPADDR_STRLEN_MAX];
                         ipaddr_ntoa_r(netif_ip_addr6(netif, i), addr_str, sizeof(addr_str));
                         mp_obj_t tuple[4] = {
-                            mp_obj_new_str(addr_str, strlen(addr_str)),
+                            mp_obj_new_str_from_cstr(addr_str),
                             MP_OBJ_NEW_SMALL_INT(netif_ip6_addr_state(netif, i)),
                             MP_OBJ_NEW_SMALL_INT(netif_ip6_addr_pref_life(netif, i)), // preferred
                             MP_OBJ_NEW_SMALL_INT(netif_ip6_addr_valid_life(netif, i))

--- a/extmod/network_ninaw10.c
+++ b/extmod/network_ninaw10.c
@@ -536,7 +536,7 @@ static mp_obj_t network_ninaw10_config(size_t n_args, const mp_obj_t *args, mp_m
             case MP_QSTR_ssid: {
                 nina_netinfo_t netinfo;
                 nina_netinfo(&netinfo);
-                return mp_obj_new_str(netinfo.ssid, strlen(netinfo.ssid));
+                return mp_obj_new_str_from_cstr(netinfo.ssid);
             }
             case MP_QSTR_security: {
                 nina_netinfo_t netinfo;

--- a/extmod/vfs.c
+++ b/extmod/vfs.c
@@ -139,7 +139,7 @@ mp_import_stat_t mp_vfs_import_stat(const char *path) {
     }
 
     // delegate to vfs.stat() method
-    mp_obj_t path_o = mp_obj_new_str(path_out, strlen(path_out));
+    mp_obj_t path_o = mp_obj_new_str_from_cstr(path_out);
     mp_obj_t stat;
     nlr_buf_t nlr;
     if (nlr_push(&nlr) == 0) {

--- a/extmod/vfs_fat.c
+++ b/extmod/vfs_fat.c
@@ -144,7 +144,7 @@ static mp_obj_t mp_vfs_fat_ilistdir_it_iternext(mp_obj_t self_in) {
         // make 4-tuple with info about this entry
         mp_obj_tuple_t *t = MP_OBJ_TO_PTR(mp_obj_new_tuple(4, NULL));
         if (self->is_str) {
-            t->items[0] = mp_obj_new_str(fn, strlen(fn));
+            t->items[0] = mp_obj_new_str_from_cstr(fn);
         } else {
             t->items[0] = mp_obj_new_bytes((const byte *)fn, strlen(fn));
         }
@@ -291,7 +291,7 @@ static mp_obj_t fat_vfs_getcwd(mp_obj_t vfs_in) {
     if (res != FR_OK) {
         mp_raise_OSError(fresult_to_errno_table[res]);
     }
-    return mp_obj_new_str(buf, strlen(buf));
+    return mp_obj_new_str_from_cstr(buf);
 }
 static MP_DEFINE_CONST_FUN_OBJ_1(fat_vfs_getcwd_obj, fat_vfs_getcwd);
 

--- a/extmod/vfs_lfsx.c
+++ b/extmod/vfs_lfsx.c
@@ -192,7 +192,7 @@ static mp_obj_t MP_VFS_LFSx(ilistdir_it_iternext)(mp_obj_t self_in) {
     // make 4-tuple with info about this entry
     mp_obj_tuple_t *t = MP_OBJ_TO_PTR(mp_obj_new_tuple(4, NULL));
     if (self->is_str) {
-        t->items[0] = mp_obj_new_str(info.name, strlen(info.name));
+        t->items[0] = mp_obj_new_str_from_cstr(info.name);
     } else {
         t->items[0] = mp_obj_new_bytes((const byte *)info.name, strlen(info.name));
     }

--- a/extmod/vfs_posix.c
+++ b/extmod/vfs_posix.c
@@ -194,7 +194,7 @@ static mp_obj_t vfs_posix_getcwd(mp_obj_t self_in) {
         }
         #endif
     }
-    return mp_obj_new_str(ret, strlen(ret));
+    return mp_obj_new_str_from_cstr(ret);
 }
 static MP_DEFINE_CONST_FUN_OBJ_1(vfs_posix_getcwd_obj, vfs_posix_getcwd);
 
@@ -234,7 +234,7 @@ static mp_obj_t vfs_posix_ilistdir_it_iternext(mp_obj_t self_in) {
         mp_obj_tuple_t *t = MP_OBJ_TO_PTR(mp_obj_new_tuple(3, NULL));
 
         if (self->is_str) {
-            t->items[0] = mp_obj_new_str(fn, strlen(fn));
+            t->items[0] = mp_obj_new_str_from_cstr(fn);
         } else {
             t->items[0] = mp_obj_new_bytes((const byte *)fn, strlen(fn));
         }

--- a/ports/cc3200/mods/modwlan.c
+++ b/ports/cc3200/mods/modwlan.c
@@ -1185,7 +1185,7 @@ static MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(wlan_mode_obj, 1, 2, wlan_mode);
 static mp_obj_t wlan_ssid(size_t n_args, const mp_obj_t *args) {
     wlan_obj_t *self = args[0];
     if (n_args == 1) {
-        return mp_obj_new_str((const char *)self->ssid, strlen((const char *)self->ssid));
+        return mp_obj_new_str_from_cstr((const char *)self->ssid);
     } else {
         size_t len;
         const char *ssid = mp_obj_str_get_data(args[1], &len);
@@ -1205,7 +1205,7 @@ static mp_obj_t wlan_auth(size_t n_args, const mp_obj_t *args) {
         } else {
             mp_obj_t security[2];
             security[0] = mp_obj_new_int(self->auth);
-            security[1] = mp_obj_new_str((const char *)self->key, strlen((const char *)self->key));
+            security[1] = mp_obj_new_str_from_cstr((const char *)self->key);
             return mp_obj_new_tuple(2, security);
         }
     } else {
@@ -1309,7 +1309,7 @@ static MP_DEFINE_CONST_FUN_OBJ_KW(wlan_irq_obj, 1, wlan_irq);
 //    mp_obj_t connections = mp_obj_new_list(0, NULL);
 //
 //    if (wlan_is_connected()) {
-//        device[0] = mp_obj_new_str((const char *)wlan_obj.ssid_o, strlen((const char *)wlan_obj.ssid_o));
+//        device[0] = mp_obj_new_str_from_cstr((const char *)wlan_obj.ssid_o);
 //        device[1] = mp_obj_new_bytes((const byte *)wlan_obj.bssid, SL_BSSID_LENGTH);
 //        // add the device to the list
 //        mp_obj_list_append(connections, mp_obj_new_tuple(MP_ARRAY_SIZE(device), device));

--- a/ports/esp32/esp32_partition.c
+++ b/ports/esp32/esp32_partition.c
@@ -156,7 +156,7 @@ static mp_obj_t esp32_partition_info(mp_obj_t self_in) {
         MP_OBJ_NEW_SMALL_INT(self->part->subtype),
         mp_obj_new_int_from_uint(self->part->address),
         mp_obj_new_int_from_uint(self->part->size),
-        mp_obj_new_str(&self->part->label[0], strlen(&self->part->label[0])),
+        mp_obj_new_str_from_cstr(&self->part->label[0]),
         mp_obj_new_bool(self->part->encrypted),
     };
     return mp_obj_new_tuple(6, tuple);

--- a/ports/esp32/modsocket.c
+++ b/ports/esp32/modsocket.c
@@ -951,7 +951,7 @@ static mp_obj_t esp_socket_getaddrinfo(size_t n_args, const mp_obj_t *args) {
             mp_obj_new_int(resi->ai_family),
             mp_obj_new_int(resi->ai_socktype),
             mp_obj_new_int(resi->ai_protocol),
-            mp_obj_new_str(resi->ai_canonname, strlen(resi->ai_canonname)),
+            mp_obj_new_str_from_cstr(resi->ai_canonname),
             mp_const_none
         };
 
@@ -962,7 +962,7 @@ static mp_obj_t esp_socket_getaddrinfo(size_t n_args, const mp_obj_t *args) {
             char buf[16];
             ip4addr_ntoa_r(&ip4_addr, buf, sizeof(buf));
             mp_obj_t inaddr_objs[2] = {
-                mp_obj_new_str(buf, strlen(buf)),
+                mp_obj_new_str_from_cstr(buf),
                 mp_obj_new_int(ntohs(addr->sin_port))
             };
             addrinfo_objs[4] = mp_obj_new_tuple(2, inaddr_objs);

--- a/ports/esp32/network_common.c
+++ b/ports/esp32/network_common.c
@@ -328,7 +328,7 @@ mp_obj_t esp_ifname(esp_netif_t *netif) {
     char ifname[NETIF_NAMESIZE + 1] = {0};
     mp_obj_t ret = mp_const_none;
     if (esp_netif_get_netif_impl_name(netif, ifname) == ESP_OK && ifname[0] != 0) {
-        ret = mp_obj_new_str((char *)ifname, strlen(ifname));
+        ret = mp_obj_new_str_from_cstr((char *)ifname);
     }
     return ret;
 }

--- a/ports/esp32/network_ppp.c
+++ b/ports/esp32/network_ppp.c
@@ -344,7 +344,7 @@ static mp_obj_t ppp_config(size_t n_args, const mp_obj_t *args, mp_map_t *kwargs
                 char ifname[NETIF_NAMESIZE + 1] = {0};
                 netif_index_to_name(netif_get_index(pppif), ifname);
                 if (ifname[0] != 0) {
-                    val = mp_obj_new_str((char *)ifname, strlen(ifname));
+                    val = mp_obj_new_str_from_cstr((char *)ifname);
                 }
             }
             break;

--- a/ports/esp32/network_wlan.c
+++ b/ports/esp32/network_wlan.c
@@ -640,7 +640,7 @@ static mp_obj_t network_wlan_config(size_t n_args, const mp_obj_t *args, mp_map_
         case MP_QSTR_essid:
             switch (self->if_id) {
                 case ESP_IF_WIFI_STA:
-                    val = mp_obj_new_str((char *)cfg.sta.ssid, strlen((char *)cfg.sta.ssid));
+                    val = mp_obj_new_str_from_cstr((char *)cfg.sta.ssid);
                     break;
                 case ESP_IF_WIFI_AP:
                     val = mp_obj_new_str((char *)cfg.ap.ssid, cfg.ap.ssid_len);

--- a/ports/esp8266/network_wlan.c
+++ b/ports/esp8266/network_wlan.c
@@ -626,7 +626,7 @@ static mp_obj_t esp_config(size_t n_args, const mp_obj_t *args, mp_map_t *kwargs
         case MP_QSTR_ssid:
         case MP_QSTR_essid:
             if (self->if_id == STATION_IF) {
-                val = mp_obj_new_str((char *)cfg.sta.ssid, strlen((char *)cfg.sta.ssid));
+                val = mp_obj_new_str_from_cstr((char *)cfg.sta.ssid);
             } else {
                 val = mp_obj_new_str((char *)cfg.ap.ssid, cfg.ap.ssid_len);
             }

--- a/ports/unix/coverage.c
+++ b/ports/unix/coverage.c
@@ -388,7 +388,7 @@ static mp_obj_t extra_coverage(void) {
         mp_printf(&mp_plat_print, "# str\n");
 
         // intern string
-        mp_printf(&mp_plat_print, "%d\n", mp_obj_is_qstr(mp_obj_str_intern(mp_obj_new_str("intern me", 9))));
+        mp_printf(&mp_plat_print, "%d\n", mp_obj_is_qstr(mp_obj_str_intern(mp_obj_new_str_from_cstr("intern me"))));
     }
 
     // bytearray
@@ -471,12 +471,12 @@ static mp_obj_t extra_coverage(void) {
         // call mp_call_function_1_protected
         mp_call_function_1_protected(MP_OBJ_FROM_PTR(&mp_builtin_abs_obj), MP_OBJ_NEW_SMALL_INT(1));
         // call mp_call_function_1_protected with invalid args
-        mp_call_function_1_protected(MP_OBJ_FROM_PTR(&mp_builtin_abs_obj), mp_obj_new_str("abc", 3));
+        mp_call_function_1_protected(MP_OBJ_FROM_PTR(&mp_builtin_abs_obj), mp_obj_new_str_from_cstr("abc"));
 
         // call mp_call_function_2_protected
         mp_call_function_2_protected(MP_OBJ_FROM_PTR(&mp_builtin_divmod_obj), MP_OBJ_NEW_SMALL_INT(1), MP_OBJ_NEW_SMALL_INT(1));
         // call mp_call_function_2_protected with invalid args
-        mp_call_function_2_protected(MP_OBJ_FROM_PTR(&mp_builtin_divmod_obj), mp_obj_new_str("abc", 3), mp_obj_new_str("abc", 3));
+        mp_call_function_2_protected(MP_OBJ_FROM_PTR(&mp_builtin_divmod_obj), mp_obj_new_str_from_cstr("abc"), mp_obj_new_str_from_cstr("abc"));
 
         // mp_obj_int_get_checked with mp_obj_int_t that has a value that is a small integer
         mp_printf(&mp_plat_print, "%d\n", mp_obj_int_get_checked(mp_obj_int_new_mpz()));
@@ -733,7 +733,7 @@ static mp_obj_t extra_coverage(void) {
         // mp_obj_is_integer accepts ints and booleans
         mp_printf(&mp_plat_print, "%d %d\n", mp_obj_is_integer(MP_OBJ_NEW_SMALL_INT(1)), mp_obj_is_integer(mp_obj_new_int_from_ll(1)));
         mp_printf(&mp_plat_print, "%d %d\n", mp_obj_is_integer(mp_const_true), mp_obj_is_integer(mp_const_false));
-        mp_printf(&mp_plat_print, "%d %d\n", mp_obj_is_integer(mp_obj_new_str("1", 1)), mp_obj_is_integer(mp_const_none));
+        mp_printf(&mp_plat_print, "%d %d\n", mp_obj_is_integer(mp_obj_new_str_from_cstr("1")), mp_obj_is_integer(mp_const_none));
 
         // mp_obj_is_int accepts small int and object ints
         mp_printf(&mp_plat_print, "%d %d\n", mp_obj_is_int(MP_OBJ_NEW_SMALL_INT(1)), mp_obj_is_int(mp_obj_new_int_from_ll(1)));

--- a/ports/unix/main.c
+++ b/ports/unix/main.c
@@ -639,7 +639,7 @@ MP_NOINLINE int main_(int argc, char **argv) {
                     return invalid_args();
                 }
                 mp_obj_t import_args[4];
-                import_args[0] = mp_obj_new_str(argv[a + 1], strlen(argv[a + 1]));
+                import_args[0] = mp_obj_new_str_from_cstr(argv[a + 1]);
                 import_args[1] = import_args[2] = mp_const_none;
                 // Ask __import__ to handle imported module specially - set its __name__
                 // to __main__, and also return this leaf module, not top-level package

--- a/ports/unix/modffi.c
+++ b/ports/unix/modffi.c
@@ -174,7 +174,7 @@ static mp_obj_t return_ffi_value(ffi_union_t *val, char type) {
             if (!s) {
                 return mp_const_none;
             }
-            return mp_obj_new_str(s, strlen(s));
+            return mp_obj_new_str_from_cstr(s);
         }
         case 'v':
             return mp_const_none;

--- a/ports/unix/modjni.c
+++ b/ports/unix/modjni.c
@@ -337,7 +337,7 @@ static mp_obj_t new_jobject(jobject jo) {
         return mp_const_none;
     } else if (JJ(IsInstanceOf, jo, String_class)) {
         const char *s = JJ(GetStringUTFChars, jo, NULL);
-        mp_obj_t ret = mp_obj_new_str(s, strlen(s));
+        mp_obj_t ret = mp_obj_new_str_from_cstr(s);
         JJ(ReleaseStringUTFChars, jo, s);
         return ret;
     } else if (JJ(IsInstanceOf, jo, Class_class)) {

--- a/ports/unix/modos.c
+++ b/ports/unix/modos.c
@@ -40,7 +40,7 @@ static mp_obj_t mp_os_getenv(size_t n_args, const mp_obj_t *args) {
         }
         return mp_const_none;
     }
-    return mp_obj_new_str(s, strlen(s));
+    return mp_obj_new_str_from_cstr(s);
 }
 static MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(mp_os_getenv_obj, 1, 2, mp_os_getenv);
 

--- a/ports/zephyr/main.c
+++ b/ports/zephyr/main.c
@@ -103,7 +103,7 @@ static void vfs_init(void) {
     int ret = 0;
 
     #ifdef CONFIG_DISK_DRIVER_SDMMC
-    mp_obj_t args[] = { mp_obj_new_str(CONFIG_SDMMC_VOLUME_NAME, strlen(CONFIG_SDMMC_VOLUME_NAME)) };
+    mp_obj_t args[] = { mp_obj_new_str_from_cstr(CONFIG_SDMMC_VOLUME_NAME) };
     bdev = MP_OBJ_TYPE_GET_SLOT(&zephyr_disk_access_type, make_new)(&zephyr_disk_access_type, ARRAY_SIZE(args), 0, args);
     mount_point_str = "/sd";
     #elif defined(CONFIG_FLASH_MAP) && FLASH_AREA_LABEL_EXISTS(storage)
@@ -113,7 +113,7 @@ static void vfs_init(void) {
     #endif
 
     if ((bdev != NULL)) {
-        mount_point = mp_obj_new_str(mount_point_str, strlen(mount_point_str));
+        mount_point = mp_obj_new_str_from_cstr(mount_point_str);
         ret = mp_vfs_mount_and_chdir_protected(bdev, mount_point);
         // TODO: if this failed, make a new file system and try to mount again
     }

--- a/ports/zephyr/modsocket.c
+++ b/ports/zephyr/modsocket.c
@@ -92,7 +92,7 @@ static mp_obj_t format_inet_addr(struct sockaddr *addr, mp_obj_t port) {
     net_addr_ntop(addr->sa_family, &sockaddr_in6->sin6_addr, buf, sizeof(buf));
     mp_obj_tuple_t *tuple = mp_obj_new_tuple(addr->sa_family == AF_INET ? 2 : 4, NULL);
 
-    tuple->items[0] = mp_obj_new_str(buf, strlen(buf));
+    tuple->items[0] = mp_obj_new_str_from_cstr(buf);
     // We employ the fact that port offset is the same for IPv4 & IPv6
     // not filled in
     // tuple->items[1] = mp_obj_new_int(ntohs(((struct sockaddr_in*)addr)->sin_port));

--- a/py/binary.c
+++ b/py/binary.c
@@ -338,7 +338,7 @@ mp_obj_t mp_binary_get_val(char struct_type, char val_type, byte *p_base, byte *
         return (mp_obj_t)(mp_uint_t)val;
     } else if (val_type == 'S') {
         const char *s_val = (const char *)(uintptr_t)(mp_uint_t)val;
-        return mp_obj_new_str(s_val, strlen(s_val));
+        return mp_obj_new_str_from_cstr(s_val);
     #if MICROPY_PY_BUILTINS_FLOAT
     } else if (val_type == 'e') {
         return mp_obj_new_float_from_f(mp_decode_half_float(val));

--- a/py/obj.h
+++ b/py/obj.h
@@ -971,6 +971,7 @@ mp_obj_t mp_obj_new_int_from_str_len(const char **str, size_t len, bool neg, uns
 mp_obj_t mp_obj_new_int_from_ll(long long val); // this must return a multi-precision integer object (or raise an overflow exception)
 mp_obj_t mp_obj_new_int_from_ull(unsigned long long val); // this must return a multi-precision integer object (or raise an overflow exception)
 mp_obj_t mp_obj_new_str(const char *data, size_t len); // will check utf-8 (raises UnicodeError)
+mp_obj_t mp_obj_new_str_from_cstr(const char *str); // // accepts null-terminated string, will check utf-8 (raises UnicodeError)
 mp_obj_t mp_obj_new_str_via_qstr(const char *data, size_t len); // input data must be valid utf-8
 mp_obj_t mp_obj_new_str_from_vstr(vstr_t *vstr); // will check utf-8 (raises UnicodeError)
 #if MICROPY_PY_BUILTINS_STR_UNICODE && MICROPY_PY_BUILTINS_STR_UNICODE_CHECK

--- a/py/objstr.c
+++ b/py/objstr.c
@@ -2308,6 +2308,10 @@ mp_obj_t mp_obj_new_str(const char *data, size_t len) {
     }
 }
 
+mp_obj_t mp_obj_new_str_from_cstr(const char *str) {
+    return mp_obj_new_str(str, strlen(str));
+}
+
 mp_obj_t mp_obj_str_intern(mp_obj_t str) {
     GET_STR_DATA_LEN(str, data, len);
     return mp_obj_new_str_via_qstr((const char *)data, len);


### PR DESCRIPTION
py/objstr.c: Add new mp_obj_new_str_0() method.
There were lots of places where this pattern was duplicated, to convert a standard C string to a MicroPython string:

```
x = mp_obj_new_str(s, strlen(s));
```

This PR provides a simpler method that removes this code duplication:

```
x = mp_obj_new_str_0(s);
```

The `_0` suffix is because it accepts a NUL-terminated string as a parameter.

This gives clearer, and probably smaller, code.

All users in-tree are updated.  (All the ones I could find, anyway).