### PR TITLE
shared/readline: Implement CTRL-L (clear screen, redraw prompt)

### DIFF
--- a/shared/readline/readline.c
+++ b/shared/readline/readline.c
@@ -188,6 +188,11 @@ int readline_process_char(int c) {
             redraw_step_back = rl.cursor_pos - rl.orig_line_len;
             redraw_from_cursor = true;
         #endif
+        } else if (c == CHAR_CTRL_L) {
+            mp_hal_stdout_tx_str("\x1b[2J\x1b[H");
+            mp_hal_stdout_tx_str(rl.prompt);
+            mp_hal_stdout_tx_strn(rl.line->buf + rl.orig_line_len, rl.cursor_pos - rl.orig_line_len);
+            redraw_from_cursor = true;
         #if MICROPY_REPL_EMACS_EXTRA_WORDS_MOVE
         } else if (c == CHAR_CTRL_W) {
             goto backward_kill_word;

--- a/shared/readline/readline.h
+++ b/shared/readline/readline.h
@@ -33,6 +33,7 @@
 #define CHAR_CTRL_E (5)
 #define CHAR_CTRL_F (6)
 #define CHAR_CTRL_K (11)
+#define CHAR_CTRL_L (12)
 #define CHAR_CTRL_N (14)
 #define CHAR_CTRL_P (16)
 #define CHAR_CTRL_U (21)


### PR DESCRIPTION
This commit implements CTRL-L, a somewhat common key to clear the the screen and move the prompt and command line to the top of the screen. At least zsh, fish, ruby, and GNU readline support it.

Fixes: https://github.com/micropython/micropython/issues/11354