### PR TITLE
pyboard.py: Default to the last available serial port on the system

### DIFF
--- a/tools/pyboard.py
+++ b/tools/pyboard.py
@@ -766,12 +766,19 @@ del _injected_buf, _FS
 
 def main():
     import argparse
+    import serial.tools.list_ports
+
+    default_device = "/dev/ttyACM0"
+    available_devices = serial.tools.list_ports.comports()
+    if available_devices:
+        default_device = available_devices[-1].name
+    default_device = os.environ.get("PYBOARD_DEVICE", default_device)
 
     cmd_parser = argparse.ArgumentParser(description="Run scripts on the pyboard.")
     cmd_parser.add_argument(
         "-d",
         "--device",
-        default=os.environ.get("PYBOARD_DEVICE", "/dev/ttyACM0"),
+        default=default_device,
         help="the serial device or the IP address of the pyboard",
     )
     cmd_parser.add_argument(


### PR DESCRIPTION
A small addition to the pyboard.py upload tool. This makes it default to the last serial port available on the system instead of `/dev/ttyACM0`.

My main reason for adding this is that port numbers on windows are not very predictable, and looking up the port each time is quite annoying.
The reason for picking the last port in the list, is that physical RS232 ports (even if they are rare) are first in the list before USB ports. So the last thing in the list is the thing you most recently plugged in. So very likely your target.

End result of this change is that not specifying a port on Windows works. And not specifying a port on Linux will act slightly different if you have multiple boards connected.