### PR TITLE
Fix 'make submodules' when building out-of-tree

### DIFF
--- a/py/mkrules.mk
+++ b/py/mkrules.mk
@@ -251,8 +251,8 @@ endif
 submodules:
 	$(ECHO) "Updating submodules: $(GIT_SUBMODULES)"
 ifneq ($(GIT_SUBMODULES),)
-	$(Q)git submodule sync $(addprefix $(TOP)/,$(GIT_SUBMODULES))
-	$(Q)git submodule update --init $(addprefix $(TOP)/,$(GIT_SUBMODULES))
+	$(Q)cd $(TOP) && git submodule sync $(GIT_SUBMODULES)
+	$(Q)cd $(TOP) && git submodule update --init $(GIT_SUBMODULES)
 endif
 .PHONY: submodules
 


### PR DESCRIPTION
When MicroPython is used as a submodule and built using `make` from the containing project, e.g. following the [instructions](https://github.com/micropython/micropython/blob/master/examples/embedding/README.md#out-of-tree-build) for the _embed_ port, `make submodules` fails because it goes looking for the sub-sub-module paths in the outer repository instead of in the micropython repository.

This is fixed by the attached commit: invoke `git` inside the micropython submodule instead of at the outer project level.

(I initially thought that this would affect not just the embed port but also [external board definitions](https://github.com/micropython/micropython-example-boards), but it turns out it does not, because in the external-board-definition process MicroPython is build by a sub-`make` that operates inside the MicroPython submodule.)

**Steps to reproduce**

```sh
git init mpembedder
cd mpembedder
git submodule add https://github.com/micropython/micropython.git micropython
cp micropython/examples/embedding/* .
perl -pi -e 's|MICROPYTHON_TOP = ../..|MICROPYTHON_TOP = micropython|' micropython_embed.mk
echo 'require("time")' > manifest.py
make -f micropython_embed.mk FROZEN_MANIFEST=manifest.py submodules
```

**Actual result**

```
Use make V=1 or set BUILD_VERBOSE in your environment to increase build verbosity.
Updating submodules: lib/micropython-lib
error: pathspec 'micropython/lib/micropython-lib' did not match any file(s) known to git
make: *** [submodules] Error 1
```

**Expected result**

```
Use make V=1 or set BUILD_VERBOSE in your environment to increase build verbosity.
Updating submodules: lib/micropython-lib
Submodule 'lib/micropython-lib' (https://github.com/micropython/micropython-lib.git) registered for path 'lib/micropython-lib'
Cloning into '/Users/cwalther/mpembedder/micropython/lib/micropython-lib'...
Submodule path 'lib/micropython-lib': checked out 'ddb1a279578bfff8c1b18aff3baa668620684f64'
```
