### PR TITLE
examples/usercmodule: Include API headers in the C++ example.

### DIFF
--- a/ports/unix/coveragecpp.cpp
+++ b/ports/unix/coveragecpp.cpp
@@ -1,5 +1,20 @@
 extern "C" {
-#include "py/obj.h"
+// Include the complete public API to verify everything compiles as C++.
+#include <py/gc.h>
+#include <py/obj.h>
+#include <py/objarray.h>
+#include <py/objexcept.h>
+#include <py/objfun.h>
+#include <py/objgenerator.h>
+#include <py/objint.h>
+#include <py/objlist.h>
+#include <py/objmodule.h>
+#include <py/objnamedtuple.h>
+#include <py/objstr.h>
+#include <py/objstringio.h>
+#include <py/objtuple.h>
+#include <py/objtype.h>
+#include <py/runtime.h>
 }
 
 #if defined(MICROPY_UNIX_COVERAGE)


### PR DESCRIPTION
Make the CI builds compile the public API as C++ to catch accidental introductions of incompatible code.

See #14323 