### PR TITLE
extmod/network_nina: Fix the AP security mode constants.

### DIFF
--- a/drivers/ninaw10/nina_wifi_drv.c
+++ b/drivers/ninaw10/nina_wifi_drv.c
@@ -95,7 +95,7 @@ typedef enum {
 
     // AP mode commands.
     NINA_CMD_START_AP_OPEN          = 0x18,
-    NINA_CMD_START_AP_WEP           = 0x19,
+    NINA_CMD_START_AP_WPA           = 0x19,
 
     // AP mode scan commands.
     NINA_CMD_AP_START_SCAN          = 0x36,
@@ -395,7 +395,7 @@ int nina_start_ap(const char *ssid, uint8_t security, const char *key, uint16_t 
     uint8_t status = NINA_STATUS_AP_FAILED;
 
     if ((key == NULL && security != NINA_SEC_OPEN) ||
-        (security != NINA_SEC_OPEN && security != NINA_SEC_WEP)) {
+        (security != NINA_SEC_OPEN && security != NINA_SEC_WPA_PSK)) {
         return -1;
     }
 
@@ -406,8 +406,8 @@ int nina_start_ap(const char *ssid, uint8_t security, const char *key, uint16_t 
                 return -1;
             }
             break;
-        case NINA_SEC_WEP:
-            if (nina_send_command_read_ack(NINA_CMD_START_AP_WEP,
+        case NINA_SEC_WPA_PSK:
+            if (nina_send_command_read_ack(NINA_CMD_START_AP_WPA,
                 3, ARG_8BITS, NINA_ARGS(ARG_STR(ssid), ARG_STR(key), ARG_BYTE(channel))) != SPI_ACK) {
                 return -1;
             }

--- a/extmod/network_ninaw10.c
+++ b/extmod/network_ninaw10.c
@@ -266,7 +266,7 @@ static mp_obj_t network_ninaw10_connect(mp_uint_t n_args, const mp_obj_t *pos_ar
     static const mp_arg_t allowed_args[] = {
         { MP_QSTR_ssid,     MP_ARG_REQUIRED | MP_ARG_OBJ, {.u_obj = MP_OBJ_NULL} },
         { MP_QSTR_key,      MP_ARG_OBJ, {.u_obj = mp_const_none} },
-        { MP_QSTR_security, MP_ARG_KW_ONLY | MP_ARG_INT, {.u_int = -1} },
+        { MP_QSTR_security, MP_ARG_KW_ONLY | MP_ARG_INT, {.u_int = NINA_SEC_WPA_PSK} },
         { MP_QSTR_channel,  MP_ARG_KW_ONLY | MP_ARG_INT, {.u_int = 1} },
     };
 
@@ -277,7 +277,6 @@ static mp_obj_t network_ninaw10_connect(mp_uint_t n_args, const mp_obj_t *pos_ar
 
     // get ssid
     const char *ssid = mp_obj_str_get_str(args[ARG_ssid].u_obj);
-
     if (strlen(ssid) == 0) {
         mp_raise_ValueError(MP_ERROR_TEXT("SSID can't be empty"));
     }
@@ -290,12 +289,6 @@ static mp_obj_t network_ninaw10_connect(mp_uint_t n_args, const mp_obj_t *pos_ar
 
     // get security mode
     mp_uint_t security = args[ARG_security].u_int;
-    if (security == -1 && self->itf == MOD_NETWORK_STA_IF) {
-        security = NINA_SEC_WPA_PSK;
-    } else if (security == -1 && self->itf == MOD_NETWORK_AP_IF) {
-        security = NINA_SEC_WEP;
-    }
-
     // Ensure that the key is not empty if a security mode is used.
     if (security != NINA_SEC_OPEN && strlen(key) == 0) {
         mp_raise_ValueError(MP_ERROR_TEXT("key can't be empty"));
@@ -326,11 +319,6 @@ static mp_obj_t network_ninaw10_connect(mp_uint_t n_args, const mp_obj_t *pos_ar
         soft_timer_reinsert(&mp_wifi_poll_timer, NINAW10_POLL_INTERVAL);
     } else {
         mp_uint_t channel = args[ARG_channel].u_int;
-
-        if (security != NINA_SEC_OPEN && security != NINA_SEC_WEP) {
-            mp_raise_msg(&mp_type_OSError, MP_ERROR_TEXT("AP mode only supports WEP or OPEN security modes"));
-        }
-
         // Initialize WiFi in AP mode.
         if (nina_start_ap(ssid, security, key, channel) != 0) {
             mp_raise_msg(&mp_type_OSError, MP_ERROR_TEXT("failed to start in AP mode"));


### PR DESCRIPTION
I was looking at the Nina firmware recently when I noticed that the command opcode `0x19` actually starts the AP in WPA/WPA2 mode. This has been long misunderstood because its handler was called `setApPassPhrase` implying that it's WEP. Even though a function exists in the firmware that attempts to set up an AP with WEP, it seems that this mode is not supported for AP.

I've verified this and the AP is using WPA/WPA2:
```bash
> nmcli dev wifi
BSSID              SSID  MODE   CHAN  RATE        SIGNAL  BARS  SECURITY  
84:CC:A8:30:4C:51  NINA  Infra  1     135 Mbit/s  100     ▂▄▆█  WPA1 WPA2 
```

There are no functional changes in this PR, it just fixes the constants names and removes the useless sanity checks for `WEP`.
