### PR TITLE
mpremote: do not list bogus devices

### DIFF
--- a/tools/mpremote/mpremote/commands.py
+++ b/tools/mpremote/mpremote/commands.py
@@ -20,16 +20,17 @@ def do_connect(state, args=None):
         if dev == "list":
             # List attached devices.
             for p in sorted(serial.tools.list_ports.comports()):
-                print(
-                    "{} {} {:04x}:{:04x} {} {}".format(
-                        p.device,
-                        p.serial_number,
-                        p.vid if isinstance(p.vid, int) else 0,
-                        p.pid if isinstance(p.pid, int) else 0,
-                        p.manufacturer,
-                        p.product,
+                if p.serial_number is not None:
+                    print(
+                        "{} {} {:04x}:{:04x} {} {}".format(
+                            p.device,
+                            p.serial_number,
+                            p.vid if isinstance(p.vid, int) else 0,
+                            p.pid if isinstance(p.pid, int) else 0,
+                            p.manufacturer,
+                            p.product,
+                        )
                     )
-                )
             # Don't do implicit REPL command.
             state.did_action()
         elif dev == "auto":


### PR DESCRIPTION
On Linux, since kernel 6.7 (and now 6.8) we get the following:
```
$ mpremote connect list
/dev/ttyS0 None 0000:0000 None None
/dev/ttyS1 None 0000:0000 None None
/dev/ttyS2 None 0000:0000 None None
/dev/ttyS3 None 0000:0000 None None
/dev/ttyS4 None 0000:0000 None None
/dev/ttyS5 None 0000:0000 None None
/dev/ttyS6 None 0000:0000 None None
/dev/ttyS7 None 0000:0000 None None
/dev/ttyS8 None 0000:0000 None None
/dev/ttyS9 None 0000:0000 None None
/dev/ttyS10 None 0000:0000 None None
/dev/ttyS11 None 0000:0000 None None
/dev/ttyS12 None 0000:0000 None None
/dev/ttyS13 None 0000:0000 None None
/dev/ttyS14 None 0000:0000 None None
/dev/ttyS15 None 0000:0000 None None
/dev/ttyS16 None 0000:0000 None None
/dev/ttyS17 None 0000:0000 None None
/dev/ttyS18 None 0000:0000 None None
/dev/ttyS19 None 0000:0000 None None
/dev/ttyS20 None 0000:0000 None None
/dev/ttyS21 None 0000:0000 None None
/dev/ttyS22 None 0000:0000 None None
/dev/ttyS23 None 0000:0000 None None
/dev/ttyS24 None 0000:0000 None None
/dev/ttyS25 None 0000:0000 None None
/dev/ttyS26 None 0000:0000 None None
/dev/ttyS27 None 0000:0000 None None
/dev/ttyS28 None 0000:0000 None None
/dev/ttyS29 None 0000:0000 None None
/dev/ttyS30 None 0000:0000 None None
/dev/ttyS31 None 0000:0000 None None
/dev/ttyUSB0 02249F9A 10c4:ea60 Silicon Labs CP2104 USB to UART Bridge Controller
```

With this PR applied:
```
$ mpremote connect list
/dev/ttyUSB0 02249F9A 10c4:ea60 Silicon Labs CP2104 USB to UART Bridge Controller
```