### PR TITLE
rp2/CMakeLists.txt: Enable pins.csv usage for out-of-tree boards

### DIFF
--- a/ports/rp2/CMakeLists.txt
+++ b/ports/rp2/CMakeLists.txt
@@ -537,8 +537,8 @@ set(GEN_PINS_MKPINS "${MICROPY_BOARDS_DIR}/make-pins.py")
 set(GEN_PINS_SRC "${CMAKE_BINARY_DIR}/pins_${MICROPY_BOARD}.c")
 set(GEN_PINS_HDR "${MICROPY_GENHDR_DIR}/pins.h")
 
-if(EXISTS "${MICROPY_BOARDS_DIR}/${MICROPY_BOARD}/pins.csv")
-    set(GEN_PINS_BOARD_CSV "${MICROPY_BOARDS_DIR}/${MICROPY_BOARD}/pins.csv")
+if(EXISTS "${MICROPY_BOARD_DIR}/pins.csv")
+    set(GEN_PINS_BOARD_CSV "${MICROPY_BOARD_DIR}/pins.csv")
     set(GEN_PINS_CSV_ARG --board-csv "${GEN_PINS_BOARD_CSV}")
 endif()
 


### PR DESCRIPTION
The current generation of pins.h hard-codes rp2/boards as the directory for the board being built. Change this to use the value of MICROPY_BOARD_DIR to find pins.csv for both in-tree and out-of-tree boards.