### PR TITLE
nrf/mpconfigport: Enable MICROPY_NLR_THUMB_USE_LONG_JUMP on nRF51xx.

### DIFF
--- a/ports/nrf/mpconfigport.h
+++ b/ports/nrf/mpconfigport.h
@@ -59,6 +59,12 @@
 
 // options to control how MicroPython is built
 
+// Due to the use of LTO and the unknown distance between nlr.o and nlrthumb.o code,
+// MCUs using the Thumb 1 instruction set must enable this NLR long jump feature.
+#if defined(NRF51822)
+#define MICROPY_NLR_THUMB_USE_LONG_JUMP    (1)
+#endif
+
 #ifndef MICROPY_VFS
 #define MICROPY_VFS                        (CORE_FEAT)
 #endif


### PR DESCRIPTION
Follow up to #11353.