### PR TITLE
webassembly/proxy_c: Reject promises with a PythonError instance.

### DIFF
--- a/tests/ports/webassembly/run_python_async_error.mjs
+++ b/tests/ports/webassembly/run_python_async_error.mjs
@@ -1,0 +1,11 @@
+// Test raising an exception in async Python code running in runPythonAsync,
+// that the JavaScript-level promise is rejected with a PythonError.
+
+const mp = await (await import(process.argv[2])).loadMicroPython();
+
+try {
+    await mp.runPythonAsync("await fail");
+} catch (error) {
+    console.log(error.name, error.type);
+    console.log(error.message);
+}

--- a/tests/ports/webassembly/run_python_async_error.mjs.exp
+++ b/tests/ports/webassembly/run_python_async_error.mjs.exp
@@ -1,0 +1,5 @@
+PythonError NameError
+Traceback (most recent call last):
+  File "<stdin>", line 1, in <module>
+NameError: name 'fail' isn't defined
+


### PR DESCRIPTION
The `reason` in a rejected promise should be an instance of `Error`.  That leads to better error messages on the JavaScript side.