### PR TITLE
webassembly/api: Resolve thenables returned from runPythonAsync.

### DIFF
--- a/ports/webassembly/api.js
+++ b/ports/webassembly/api.js
@@ -152,7 +152,11 @@ export async function loadMicroPython(options) {
                 [buf, len, value],
             );
             Module._free(buf);
-            return proxy_convert_mp_to_js_obj_jsside_with_free(value);
+            const ret = proxy_convert_mp_to_js_obj_jsside_with_free(value);
+            if (ret instanceof PyProxyThenable) {
+                return Promise.resolve(ret);
+            }
+            return ret;
         },
         replInit() {
             Module.ccall("mp_js_repl_init", "null", ["null"]);

--- a/tests/ports/webassembly/run_python_async_no_await.mjs
+++ b/tests/ports/webassembly/run_python_async_no_await.mjs
@@ -1,0 +1,24 @@
+// Test runPythonAsync() without await'ing it.
+
+const mp = await (await import(process.argv[2])).loadMicroPython();
+
+globalThis.p = new Promise((resolve, reject) => {
+    setTimeout(() => {
+        resolve(123);
+        console.log("setTimeout resolved");
+    }, 100);
+});
+
+console.log(1);
+
+const ret = mp.runPythonAsync(`
+import js
+print("py 1")
+print("resolved value:", await js.p)
+print("py 2")
+`);
+
+// `ret` should be a Promise.
+console.log(2, ret);
+
+// Here, the Python async code should continue to run until completed.

--- a/tests/ports/webassembly/run_python_async_no_await.mjs.exp
+++ b/tests/ports/webassembly/run_python_async_no_await.mjs.exp
@@ -1,0 +1,6 @@
+1
+2 Promise { <pending> }
+py 1
+setTimeout resolved
+resolved value: 123
+py 2


### PR DESCRIPTION
JavaScript semantics are such that the caller of an async function does not need to await that function for it to run to completion.  This commit makes that behaviour also apply to top-level async Python code run via `runPythonAsync()`.