### PR TITLE
shared/tinyusb: Stall the CDC IN endpoint while disconnecting.

### DIFF
--- a/shared/tinyusb/mp_usbd_runtime.c
+++ b/shared/tinyusb/mp_usbd_runtime.c
@@ -472,6 +472,8 @@ static void mp_usbd_disconnect(mp_obj_usb_device_t *usbd) {
     #if MICROPY_HW_USB_CDC
     // Ensure no pending static CDC writes, as these can cause TinyUSB to crash
     tud_cdc_write_clear();
+    // Prevent cdc write flush from initiating any new transfers while disconnecting
+    usbd_edpt_stall(USBD_RHPORT, USBD_CDC_EP_IN);
     #endif
 
     bool was_connected = tud_connected();


### PR DESCRIPTION
Only when dynamic USB devices are enabled.

The issue here is that when the USB reset triggers, the dynamic USB device reset callback is called from inside the TinyUSB task.

If that callback tries to print something then it'll call through to tud_cdc_write_flush(), but TinyUSB hasn't finished updating state yet to know it's no longer configured. Subsequently it may try to queue a transfer and then the low-level DCD layer panics.

By explicitly stalling the endpoint first, usbd_edpt_claim() will fail and tud_cdc_write_flush() returns immediately. The stall remains until the reset finishes processing.

Tested by running the dfu example from #14439 (no longer crashes), and also re-ran high level USB examples on rp2 and samd.

*This work was funded through GitHub Sponsors.*