### PR TITLE
libm/libm: Do not force floating point type size evaluation.

### DIFF
--- a/lib/libm/libm.h
+++ b/lib/libm/libm.h
@@ -19,7 +19,10 @@
 #include <stdint.h>
 #include <math.h>
 
-#define FLT_EVAL_METHOD 0
+// These lines verify that FLT_EVAL_METHOD==0, MicroPython's libm requires this.
+// If compilation fails here then check the host compiler's FLT_EVAL_METHOD.
+typedef float float_t;
+typedef double double_t;
 
 #define FORCE_EVAL(x) do {                        \
 	if (sizeof(x) == sizeof(float)) {         \

--- a/lib/libm_dbl/libm.h
+++ b/lib/libm_dbl/libm.h
@@ -15,7 +15,10 @@
 #include <stdint.h>
 #include <math.h>
 
-#define FLT_EVAL_METHOD 0
+// These lines verify that FLT_EVAL_METHOD==0, MicroPython's libm requires this.
+// If compilation fails here then check the host compiler's FLT_EVAL_METHOD.
+typedef float float_t;
+typedef double double_t;
 
 #define FORCE_EVAL(x) do {                        \
 	if (sizeof(x) == sizeof(float)) {         \


### PR DESCRIPTION
MicroPython's vendored `libm` and `libm_dbl` definition of `FLT_EVAL_METHOD` break compilation on embedded targets that use picolibc as their libc provider (see discussion: https://github.com/micropython/micropython/pull/12853#discussion_r1591815622).

One case where this is needed is the RISC-V toolchain available on the CI image.  Going forward, other toolchains may prefer to use picolibc instead of newlib, and users may want to be able to use said library with MicroPython.

Starting from C99 `FLT_EVAL_METHOD` should be left to the compiler/libc to define, according to the appropriate floating point types' representation for the platform.  Choosing floating point types representations should be done via compiler options rather than with `#define`s.

Tests pass on both `qemu-arm` and `qemu-riscv` with this change applied.  Though I saw no build breakages for ports/boards that used either `libm` or `libm_dbl`, I cannot tell whether this PR breaks code on hardware platforms I have no access to.