### PR TITLE
shared/tinyusb: Add common cdc tx/rx functions.

### DIFF
--- a/ports/esp32/boards/ARDUINO_NANO_ESP32/mpconfigboard.cmake
+++ b/ports/esp32/boards/ARDUINO_NANO_ESP32/mpconfigboard.cmake
@@ -18,7 +18,7 @@ set(SDKCONFIG_DEFAULTS
 set(MICROPY_SOURCE_BOARD
     ${MICROPY_BOARD_DIR}/board_init.c
     ${MICROPY_BOARD_DIR}/double_tap.c
-    ${MICROPY_DIR}/shared/tinyusb/mp_cdc_common.c
+    ${MICROPY_DIR}/shared/tinyusb/mp_usbd_cdc.c
 )
 
 set(MICROPY_FROZEN_MANIFEST ${MICROPY_BOARD_DIR}/manifest.py)

--- a/ports/mimxrt/Makefile
+++ b/ports/mimxrt/Makefile
@@ -232,6 +232,8 @@ SHARED_SRC_C += \
 	shared/runtime/stdout_helpers.c \
 	shared/runtime/sys_stdio_mphal.c \
 	shared/timeutils/timeutils.c \
+	shared/tinyusb/mp_usbd.c \
+	shared/tinyusb/mp_usbd_cdc.c \
 
 # Set flash driver name, base address and internal flash flag, based on the flash type.
 ifeq ($(MICROPY_HW_FLASH_TYPE),$(filter $(MICROPY_HW_FLASH_TYPE),qspi_nor_flash))

--- a/ports/mimxrt/mpconfigport.h
+++ b/ports/mimxrt/mpconfigport.h
@@ -148,6 +148,7 @@ uint32_t trng_random_u32(void);
 #endif
 
 #define MICROPY_HW_ENABLE_USBDEV            (1)
+#define MICROPY_HW_USB_CDC                  (1)
 
 // Hooks to add builtins
 

--- a/ports/mimxrt/mphalport.c
+++ b/ports/mimxrt/mphalport.c
@@ -30,6 +30,7 @@
 #include "py/mphal.h"
 #include "shared/timeutils/timeutils.h"
 #include "shared/runtime/interrupt_char.h"
+#include "shared/tinyusb/mp_usbd_cdc.h"
 #include "extmod/misc.h"
 #include "ticks.h"
 #include "tusb.h"
@@ -44,51 +45,9 @@
 static uint8_t stdin_ringbuf_array[MICROPY_HW_STDIN_BUFFER_LEN];
 ringbuf_t stdin_ringbuf = {stdin_ringbuf_array, sizeof(stdin_ringbuf_array), 0, 0};
 
-uint8_t cdc_itf_pending; // keep track of cdc interfaces which need attention to poll
-
-void poll_cdc_interfaces(void) {
-    // any CDC interfaces left to poll?
-    if (cdc_itf_pending && ringbuf_free(&stdin_ringbuf)) {
-        for (uint8_t itf = 0; itf < 8; ++itf) {
-            if (cdc_itf_pending & (1 << itf)) {
-                tud_cdc_rx_cb(itf);
-                if (!cdc_itf_pending) {
-                    break;
-                }
-            }
-        }
-    }
-}
-
-
-void tud_cdc_rx_cb(uint8_t itf) {
-    // consume pending USB data immediately to free usb buffer and keep the endpoint from stalling.
-    // in case the ringbuffer is full, mark the CDC interface that need attention later on for polling
-    cdc_itf_pending &= ~(1 << itf);
-    for (uint32_t bytes_avail = tud_cdc_n_available(itf); bytes_avail > 0; --bytes_avail) {
-        if (ringbuf_free(&stdin_ringbuf)) {
-            int data_char = tud_cdc_read_char();
-            if (data_char == mp_interrupt_char) {
-                mp_sched_keyboard_interrupt();
-            } else {
-                ringbuf_put(&stdin_ringbuf, data_char);
-            }
-        } else {
-            cdc_itf_pending |= (1 << itf);
-            return;
-        }
-    }
-}
-
 uintptr_t mp_hal_stdio_poll(uintptr_t poll_flags) {
     uintptr_t ret = 0;
-    poll_cdc_interfaces();
-    if ((poll_flags & MP_STREAM_POLL_RD) && ringbuf_peek(&stdin_ringbuf) != -1) {
-        ret |= MP_STREAM_POLL_RD;
-    }
-    if ((poll_flags & MP_STREAM_POLL_WR) && tud_cdc_connected() && tud_cdc_write_available() > 0) {
-        ret |= MP_STREAM_POLL_WR;
-    }
+    ret |= mp_usbd_cdc_poll_interfaces(poll_flags);
     #if MICROPY_PY_OS_DUPTERM
     ret |= mp_os_dupterm_poll(poll_flags);
     #endif
@@ -97,7 +56,7 @@ uintptr_t mp_hal_stdio_poll(uintptr_t poll_flags) {
 
 int mp_hal_stdin_rx_chr(void) {
     for (;;) {
-        poll_cdc_interfaces();
+        mp_usbd_cdc_poll_interfaces(0);
         int c = ringbuf_get(&stdin_ringbuf);
         if (c != -1) {
             return c;
@@ -115,29 +74,10 @@ int mp_hal_stdin_rx_chr(void) {
 mp_uint_t mp_hal_stdout_tx_strn(const char *str, mp_uint_t len) {
     mp_uint_t ret = len;
     bool did_write = false;
-    if (tud_cdc_connected()) {
-        size_t i = 0;
-        while (i < len) {
-            uint32_t n = len - i;
-            if (n > CFG_TUD_CDC_EP_BUFSIZE) {
-                n = CFG_TUD_CDC_EP_BUFSIZE;
-            }
-            uint64_t timeout = ticks_us64() + (uint64_t)(MICROPY_HW_USB_CDC_TX_TIMEOUT * 1000);
-            // Wait with a max of USC_CDC_TIMEOUT ms
-            while (n > tud_cdc_write_available() && ticks_us64() < timeout) {
-                MICROPY_EVENT_POLL_HOOK
-            }
-            if (ticks_us64() >= timeout) {
-                ret = i;
-                break;
-            }
-
-            uint32_t n2 = tud_cdc_write(str + i, n);
-            tud_cdc_write_flush();
-            i += n2;
-        }
+    mp_uint_t cdc_res = mp_usbd_cdc_tx_strn(str, len);
+    if (cdc_res > 0) {
         did_write = true;
-        ret = MIN(i, ret);
+        ret = MIN(cdc_res, ret);
     }
     #if MICROPY_PY_OS_DUPTERM
     int dupterm_res = mp_os_dupterm_tx_strn(str, len);

--- a/ports/mimxrt/mphalport.h
+++ b/ports/mimxrt/mphalport.h
@@ -72,6 +72,7 @@
 #define MP_HAL_PIN_TRIGGER_RISE         kGPIO_IntRisingEdge
 #define MP_HAL_PIN_TRIGGER_RISE_FALL    kGPIO_IntRisingOrFallingEdge
 
+extern int mp_interrupt_char;
 extern ringbuf_t stdin_ringbuf;
 
 // Define an alias for systick_ms, because the shared softtimer.c uses

--- a/ports/nrf/Makefile
+++ b/ports/nrf/Makefile
@@ -185,7 +185,7 @@ SRC_SHARED_C += $(addprefix shared/,\
 	runtime/pyexec.c \
 	runtime/sys_stdio_mphal.c \
 	runtime/interrupt_char.c \
-	tinyusb/mp_cdc_common.c \
+	tinyusb/mp_usbd_cdc.c \
 	timeutils/timeutils.c \
 	)
 

--- a/ports/renesas-ra/Makefile
+++ b/ports/renesas-ra/Makefile
@@ -174,8 +174,8 @@ SHARED_SRC_C += $(addprefix shared/,\
 	runtime/stdout_helpers.c \
 	runtime/sys_stdio_mphal.c \
 	timeutils/timeutils.c \
-	tinyusb/mp_cdc_common.c \
 	tinyusb/mp_usbd.c \
+	tinyusb/mp_usbd_cdc.c \
 	tinyusb/mp_usbd_descriptor.c \
 	)
 

--- a/ports/renesas-ra/mphalport.c
+++ b/ports/renesas-ra/mphalport.c
@@ -34,6 +34,7 @@
 #include "py/ringbuf.h"
 #include "extmod/misc.h"
 #include "shared/runtime/interrupt_char.h"
+#include "shared/tinyusb/mp_usbd_cdc.h"
 #include "tusb.h"
 #include "uart.h"
 
@@ -64,62 +65,16 @@ NORETURN void mp_hal_raise(HAL_StatusTypeDef status) {
     mp_raise_OSError(mp_hal_status_to_errno_table[status]);
 }
 
-#if MICROPY_HW_USB_CDC
-
 uint8_t cdc_itf_pending; // keep track of cdc interfaces which need attention to poll
-
-void poll_cdc_interfaces(void) {
-    // any CDC interfaces left to poll?
-    if (cdc_itf_pending && ringbuf_free(&stdin_ringbuf)) {
-        for (uint8_t itf = 0; itf < 8; ++itf) {
-            if (cdc_itf_pending & (1 << itf)) {
-                tud_cdc_rx_cb(itf);
-                if (!cdc_itf_pending) {
-                    break;
-                }
-            }
-        }
-    }
-}
-
-void tud_cdc_rx_cb(uint8_t itf) {
-    // consume pending USB data immediately to free usb buffer and keep the endpoint from stalling.
-    // in case the ringbuffer is full, mark the CDC interface that need attention later on for polling
-    cdc_itf_pending &= ~(1 << itf);
-    for (uint32_t bytes_avail = tud_cdc_n_available(itf); bytes_avail > 0; --bytes_avail) {
-        if (ringbuf_free(&stdin_ringbuf)) {
-            int data_char = tud_cdc_read_char();
-            if (data_char == mp_interrupt_char) {
-                mp_sched_keyboard_interrupt();
-            } else {
-                ringbuf_put(&stdin_ringbuf, data_char);
-            }
-        } else {
-            cdc_itf_pending |= (1 << itf);
-            return;
-        }
-    }
-}
-
-#endif
 
 uintptr_t mp_hal_stdio_poll(uintptr_t poll_flags) {
     uintptr_t ret = 0;
     #if MICROPY_HW_USB_CDC
-    poll_cdc_interfaces();
+    ret |= mp_usbd_cdc_poll_interfaces(poll_flags);
     #endif
-    #if MICROPY_HW_ENABLE_UART_REPL || MICROPY_HW_USB_CDC
-    if ((poll_flags & MP_STREAM_POLL_RD) && ringbuf_peek(&stdin_ringbuf) != -1) {
-        ret |= MP_STREAM_POLL_RD;
-    }
+    #if MICROPY_HW_ENABLE_UART_REPL
     if (poll_flags & MP_STREAM_POLL_WR) {
-        #if MICROPY_HW_ENABLE_UART_REPL
         ret |= MP_STREAM_POLL_WR;
-        #else
-        if (tud_cdc_connected() && tud_cdc_write_available() > 0) {
-            ret |= MP_STREAM_POLL_WR;
-        }
-        #endif
     }
     #endif
     #if MICROPY_PY_OS_DUPTERM
@@ -132,7 +87,7 @@ uintptr_t mp_hal_stdio_poll(uintptr_t poll_flags) {
 int mp_hal_stdin_rx_chr(void) {
     for (;;) {
         #if MICROPY_HW_USB_CDC
-        poll_cdc_interfaces();
+        mp_usbd_cdc_poll_interfaces(0);
         #endif
 
         #if MICROPY_HW_ENABLE_INTERNAL_FLASH_STORAGE
@@ -165,27 +120,10 @@ mp_uint_t mp_hal_stdout_tx_strn(const char *str, mp_uint_t len) {
     #endif
 
     #if MICROPY_HW_USB_CDC
-    if (tud_cdc_connected()) {
-        size_t i = 0;
-        while (i < len) {
-            uint32_t n = len - i;
-            if (n > CFG_TUD_CDC_EP_BUFSIZE) {
-                n = CFG_TUD_CDC_EP_BUFSIZE;
-            }
-            int timeout = 0;
-            // Wait with a max of USC_CDC_TIMEOUT ms
-            while (n > tud_cdc_write_available() && timeout++ < MICROPY_HW_USB_CDC_TX_TIMEOUT) {
-                MICROPY_EVENT_POLL_HOOK
-            }
-            if (timeout >= MICROPY_HW_USB_CDC_TX_TIMEOUT) {
-                break;
-            }
-            uint32_t n2 = tud_cdc_write(str + i, n);
-            tud_cdc_write_flush();
-            i += n2;
-        }
-        ret = MIN(i, ret);
+    mp_uint_t cdc_res = mp_usbd_cdc_tx_strn(str, len);
+    if (cdc_res > 0) {
         did_write = true;
+        ret = MIN(cdc_res, ret);
     }
     #endif
 

--- a/ports/renesas-ra/mphalport.h
+++ b/ports/renesas-ra/mphalport.h
@@ -42,6 +42,7 @@
 #define MICROPY_HW_USB_CDC_TX_TIMEOUT (500)
 
 extern const unsigned char mp_hal_status_to_errno_table[4];
+extern int mp_interrupt_char;
 extern ringbuf_t stdin_ringbuf;
 
 static inline int mp_hal_status_to_neg_errno(HAL_StatusTypeDef status) {

--- a/ports/rp2/CMakeLists.txt
+++ b/ports/rp2/CMakeLists.txt
@@ -105,8 +105,8 @@ set(MICROPY_SOURCE_LIB
     ${MICROPY_DIR}/shared/runtime/softtimer.c
     ${MICROPY_DIR}/shared/runtime/sys_stdio_mphal.c
     ${MICROPY_DIR}/shared/timeutils/timeutils.c
-    ${MICROPY_DIR}/shared/tinyusb/mp_cdc_common.c
     ${MICROPY_DIR}/shared/tinyusb/mp_usbd.c
+    ${MICROPY_DIR}/shared/tinyusb/mp_usbd_cdc.c
     ${MICROPY_DIR}/shared/tinyusb/mp_usbd_descriptor.c
     ${MICROPY_DIR}/shared/tinyusb/mp_usbd_runtime.c
 )

--- a/ports/rp2/mphalport.c
+++ b/ports/rp2/mphalport.c
@@ -32,6 +32,7 @@
 #include "shared/runtime/softtimer.h"
 #include "shared/timeutils/timeutils.h"
 #include "shared/tinyusb/mp_usbd.h"
+#include "shared/tinyusb/mp_usbd_cdc.h"
 #include "pendsv.h"
 #include "tusb.h"
 #include "uart.h"
@@ -58,68 +59,14 @@ ringbuf_t stdin_ringbuf = { stdin_ringbuf_array, sizeof(stdin_ringbuf_array) };
 
 #endif
 
-#if MICROPY_HW_USB_CDC
-
-uint8_t cdc_itf_pending; // keep track of cdc interfaces which need attention to poll
-
-void poll_cdc_interfaces(void) {
-    if (!cdc_itf_pending) {
-        // Explicitly run the USB stack as the scheduler may be locked (eg we are in
-        // an interrupt handler) while there is data pending.
-        mp_usbd_task();
-    }
-
-    // any CDC interfaces left to poll?
-    if (cdc_itf_pending && ringbuf_free(&stdin_ringbuf)) {
-        for (uint8_t itf = 0; itf < 8; ++itf) {
-            if (cdc_itf_pending & (1 << itf)) {
-                tud_cdc_rx_cb(itf);
-                if (!cdc_itf_pending) {
-                    break;
-                }
-            }
-        }
-    }
-}
-
-void tud_cdc_rx_cb(uint8_t itf) {
-    // consume pending USB data immediately to free usb buffer and keep the endpoint from stalling.
-    // in case the ringbuffer is full, mark the CDC interface that need attention later on for polling
-    cdc_itf_pending &= ~(1 << itf);
-    for (uint32_t bytes_avail = tud_cdc_n_available(itf); bytes_avail > 0; --bytes_avail) {
-        if (ringbuf_free(&stdin_ringbuf)) {
-            int data_char = tud_cdc_read_char();
-            if (data_char == mp_interrupt_char) {
-                mp_sched_keyboard_interrupt();
-            } else {
-                ringbuf_put(&stdin_ringbuf, data_char);
-            }
-        } else {
-            cdc_itf_pending |= (1 << itf);
-            return;
-        }
-    }
-}
-
-#endif
-
 uintptr_t mp_hal_stdio_poll(uintptr_t poll_flags) {
     uintptr_t ret = 0;
     #if MICROPY_HW_USB_CDC
-    poll_cdc_interfaces();
+    ret |= mp_usbd_cdc_poll_interfaces(poll_flags);
     #endif
-    #if MICROPY_HW_ENABLE_UART_REPL || MICROPY_HW_USB_CDC
-    if ((poll_flags & MP_STREAM_POLL_RD) && ringbuf_peek(&stdin_ringbuf) != -1) {
-        ret |= MP_STREAM_POLL_RD;
-    }
+    #if MICROPY_HW_ENABLE_UART_REPL
     if (poll_flags & MP_STREAM_POLL_WR) {
-        #if MICROPY_HW_ENABLE_UART_REPL
         ret |= MP_STREAM_POLL_WR;
-        #else
-        if (tud_cdc_connected() && tud_cdc_write_available() > 0) {
-            ret |= MP_STREAM_POLL_WR;
-        }
-        #endif
     }
     #endif
     #if MICROPY_PY_OS_DUPTERM
@@ -132,7 +79,7 @@ uintptr_t mp_hal_stdio_poll(uintptr_t poll_flags) {
 int mp_hal_stdin_rx_chr(void) {
     for (;;) {
         #if MICROPY_HW_USB_CDC
-        poll_cdc_interfaces();
+        mp_usbd_cdc_poll_interfaces(0);
         #endif
 
         int c = ringbuf_get(&stdin_ringbuf);
@@ -159,32 +106,10 @@ mp_uint_t mp_hal_stdout_tx_strn(const char *str, mp_uint_t len) {
     #endif
 
     #if MICROPY_HW_USB_CDC
-    if (tud_cdc_connected()) {
-        size_t i = 0;
-        while (i < len) {
-            uint32_t n = len - i;
-            if (n > CFG_TUD_CDC_EP_BUFSIZE) {
-                n = CFG_TUD_CDC_EP_BUFSIZE;
-            }
-            int timeout = 0;
-            // Wait with a max of USC_CDC_TIMEOUT ms
-            while (n > tud_cdc_write_available() && timeout++ < MICROPY_HW_USB_CDC_TX_TIMEOUT) {
-                mp_event_wait_ms(1);
-
-                // Explicitly run the USB stack as the scheduler may be locked (eg we
-                // are in an interrupt handler), while there is data pending.
-                mp_usbd_task();
-            }
-            if (timeout >= MICROPY_HW_USB_CDC_TX_TIMEOUT) {
-                ret = i;
-                break;
-            }
-            uint32_t n2 = tud_cdc_write(str + i, n);
-            tud_cdc_write_flush();
-            i += n2;
-        }
-        ret = MIN(i, ret);
+    mp_uint_t cdc_res = mp_usbd_cdc_tx_strn(str, len);
+    if (cdc_res > 0) {
         did_write = true;
+        ret = MIN(cdc_res, ret);
     }
     #endif
 

--- a/ports/samd/Makefile
+++ b/ports/samd/Makefile
@@ -133,8 +133,8 @@ SHARED_SRC_C += \
 	shared/runtime/stdout_helpers.c \
 	shared/runtime/sys_stdio_mphal.c \
 	shared/timeutils/timeutils.c \
-	shared/tinyusb/mp_cdc_common.c \
 	shared/tinyusb/mp_usbd.c \
+	shared/tinyusb/mp_usbd_cdc.c \
 	shared/tinyusb/mp_usbd_descriptor.c \
 	shared/tinyusb/mp_usbd_runtime.c \
 

--- a/ports/samd/mphalport.c
+++ b/ports/samd/mphalport.c
@@ -30,6 +30,7 @@
 #include "py/stream.h"
 #include "shared/runtime/interrupt_char.h"
 #include "shared/tinyusb/mp_usbd.h"
+#include "shared/tinyusb/mp_usbd_cdc.h"
 #include "extmod/misc.h"
 #include "samd_soc.h"
 #include "tusb.h"
@@ -50,48 +51,6 @@ ringbuf_t stdin_ringbuf = { stdin_ringbuf_array, sizeof(stdin_ringbuf_array), 0,
         MICROPY_EVENT_POLL_HOOK; \
         mp_usbd_task(); \
     } while (0)
-
-uint8_t cdc_itf_pending; // keep track of cdc interfaces which need attention to poll
-
-void poll_cdc_interfaces(void) {
-    // any CDC interfaces left to poll?
-    if (cdc_itf_pending && ringbuf_free(&stdin_ringbuf)) {
-        for (uint8_t itf = 0; itf < 8; ++itf) {
-            if (cdc_itf_pending & (1 << itf)) {
-                tud_cdc_rx_cb(itf);
-                if (!cdc_itf_pending) {
-                    break;
-                }
-            }
-        }
-    }
-}
-
-void tud_cdc_rx_cb(uint8_t itf) {
-    // consume pending USB data immediately to free usb buffer and keep the endpoint from stalling.
-    // in case the ringbuffer is full, mark the CDC interface that need attention later on for polling
-    cdc_itf_pending &= ~(1 << itf);
-    for (uint32_t bytes_avail = tud_cdc_n_available(itf); bytes_avail > 0; --bytes_avail) {
-        if (ringbuf_free(&stdin_ringbuf)) {
-            int data_char = tud_cdc_read_char();
-            #if MICROPY_KBD_EXCEPTION
-            if (data_char == mp_interrupt_char) {
-                // Clear the ring buffer
-                stdin_ringbuf.iget = stdin_ringbuf.iput = 0;
-                // and stop
-                mp_sched_keyboard_interrupt();
-            } else {
-                ringbuf_put(&stdin_ringbuf, data_char);
-            }
-            #else
-            ringbuf_put(&stdin_ringbuf, data_char);
-            #endif
-        } else {
-            cdc_itf_pending |= (1 << itf);
-            return;
-        }
-    }
-}
 
 void mp_hal_set_pin_mux(mp_hal_pin_obj_t pin, uint8_t mux) {
     int pin_grp = pin / 32;
@@ -165,16 +124,7 @@ uint64_t mp_hal_ticks_us_64(void) {
 
 uintptr_t mp_hal_stdio_poll(uintptr_t poll_flags) {
     uintptr_t ret = 0;
-
-    poll_cdc_interfaces();
-    if ((poll_flags & MP_STREAM_POLL_RD) && ringbuf_peek(&stdin_ringbuf) != -1) {
-        ret |= MP_STREAM_POLL_RD;
-    }
-
-    if ((poll_flags & MP_STREAM_POLL_WR) && tud_cdc_connected() && tud_cdc_write_available() > 0) {
-        ret |= MP_STREAM_POLL_WR;
-    }
-
+    ret |= mp_usbd_cdc_poll_interfaces(poll_flags);
     #if MICROPY_PY_OS_DUPTERM
     ret |= mp_os_dupterm_poll(poll_flags);
     #endif
@@ -184,7 +134,7 @@ uintptr_t mp_hal_stdio_poll(uintptr_t poll_flags) {
 int mp_hal_stdin_rx_chr(void) {
     for (;;) {
 
-        poll_cdc_interfaces();
+        mp_usbd_cdc_poll_interfaces(0);
         int c = ringbuf_get(&stdin_ringbuf);
         if (c != -1) {
             return c;
@@ -203,28 +153,10 @@ int mp_hal_stdin_rx_chr(void) {
 mp_uint_t mp_hal_stdout_tx_strn(const char *str, mp_uint_t len) {
     mp_uint_t ret = len;
     bool did_write = false;
-    if (tud_cdc_connected()) {
-        size_t i = 0;
-        while (i < len) {
-            uint32_t n = len - i;
-            if (n > CFG_TUD_CDC_EP_BUFSIZE) {
-                n = CFG_TUD_CDC_EP_BUFSIZE;
-            }
-            int timeout = 0;
-            // Wait with a max of USC_CDC_TIMEOUT ms
-            while (n > tud_cdc_write_available() && timeout++ < MICROPY_HW_USB_CDC_TX_TIMEOUT) {
-                MICROPY_EVENT_POLL_HOOK_WITH_USB;
-            }
-            if (timeout >= MICROPY_HW_USB_CDC_TX_TIMEOUT) {
-                ret = i;
-                break;
-            }
-            uint32_t n2 = tud_cdc_write(str + i, n);
-            tud_cdc_write_flush();
-            i += n2;
-        }
-        ret = MIN(i, ret);
+    mp_uint_t cdc_res = mp_usbd_cdc_tx_strn(str, len);
+    if (cdc_res > 0) {
         did_write = true;
+        ret = MIN(cdc_res, ret);
     }
     #if MICROPY_PY_OS_DUPTERM
     int dupterm_res = mp_os_dupterm_tx_strn(str, len);

--- a/ports/samd/mphalport.h
+++ b/ports/samd/mphalport.h
@@ -44,6 +44,7 @@
 #define MICROPY_HW_USB_CDC_TX_TIMEOUT (500)
 
 extern int mp_interrupt_char;
+extern ringbuf_t stdin_ringbuf;
 extern volatile uint32_t systick_ms;
 uint64_t mp_hal_ticks_us_64(void);
 

--- a/shared/tinyusb/mp_usbd_cdc.c
+++ b/shared/tinyusb/mp_usbd_cdc.c
@@ -1,0 +1,153 @@
+/*
+ * This file is part of the MicroPython project, http://micropython.org/
+ *
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2022 Ibrahim Abdelkader <iabdalkader@openmv.io>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#include "py/runtime.h"
+#include "py/mphal.h"
+#include "py/mpconfig.h"
+#include "py/stream.h"
+#include "extmod/modmachine.h"
+
+#if MICROPY_HW_USB_CDC && MICROPY_HW_ENABLE_USBDEV
+#include "tusb.h"
+#include "device/usbd.h"
+
+#include "mp_usbd_cdc.h"
+#include "mp_usbd.h"
+
+static uint8_t cdc_itf_pending; // keep track of cdc interfaces which need attention to poll
+
+uintptr_t mp_usbd_cdc_poll_interfaces(uintptr_t poll_flags) {
+    uintptr_t ret = 0;
+    if (!cdc_itf_pending) {
+        // Explicitly run the USB stack as the scheduler may be locked (eg we are in
+        // an interrupt handler) while there is data pending.
+        mp_usbd_task();
+    }
+
+    // any CDC interfaces left to poll?
+    if (cdc_itf_pending && ringbuf_free(&stdin_ringbuf)) {
+        for (uint8_t itf = 0; itf < 8; ++itf) {
+            if (cdc_itf_pending & (1 << itf)) {
+                tud_cdc_rx_cb(itf);
+                if (!cdc_itf_pending) {
+                    break;
+                }
+            }
+        }
+    }
+    if ((poll_flags & MP_STREAM_POLL_RD) && ringbuf_peek(&stdin_ringbuf) != -1) {
+        ret |= MP_STREAM_POLL_RD;
+    }
+    if ((poll_flags & MP_STREAM_POLL_WR) && tud_cdc_connected() && tud_cdc_write_available() > 0) {
+        // When connected operate as blocking, only allow if space is available.
+        ret |= MP_STREAM_POLL_WR;
+    }
+    return ret;
+}
+
+void tud_cdc_rx_cb(uint8_t itf) {
+    // consume pending USB data immediately to free usb buffer and keep the endpoint from stalling.
+    // in case the ringbuffer is full, mark the CDC interface that need attention later on for polling
+    cdc_itf_pending &= ~(1 << itf);
+    for (uint32_t bytes_avail = tud_cdc_n_available(itf); bytes_avail > 0; --bytes_avail) {
+        if (ringbuf_free(&stdin_ringbuf)) {
+            int data_char = tud_cdc_read_char();
+            #if MICROPY_KBD_EXCEPTION
+            if (data_char == mp_interrupt_char) {
+                // Clear the ring buffer
+                stdin_ringbuf.iget = stdin_ringbuf.iput = 0;
+                // and stop
+                mp_sched_keyboard_interrupt();
+            } else {
+                ringbuf_put(&stdin_ringbuf, data_char);
+            }
+            #else
+            ringbuf_put(&stdin_ringbuf, data_char);
+            #endif
+        } else {
+            cdc_itf_pending |= (1 << itf);
+            return;
+        }
+    }
+}
+
+mp_uint_t mp_usbd_cdc_tx_strn(const char *str, mp_uint_t len) {
+    size_t i = 0;
+    if (tud_cdc_connected()) {
+        while (i < len) {
+            uint32_t n = len - i;
+            if (n > CFG_TUD_CDC_EP_BUFSIZE) {
+                n = CFG_TUD_CDC_EP_BUFSIZE;
+            }
+            int timeout = 0;
+            // Wait with a max of USC_CDC_TIMEOUT ms
+            while (n > tud_cdc_write_available() && timeout++ < MICROPY_HW_USB_CDC_TX_TIMEOUT) {
+                mp_event_wait_ms(1);
+
+                // Explicitly run the USB stack as the scheduler may be locked (eg we
+                // are in an interrupt handler), while there is data pending.
+                mp_usbd_task();
+            }
+            if (timeout >= MICROPY_HW_USB_CDC_TX_TIMEOUT) {
+                break;
+            }
+            uint32_t n2 = tud_cdc_write(str + i, n);
+            tud_cdc_write_flush();
+            i += n2;
+        }
+    }
+    return i;
+}
+
+#if MICROPY_HW_USB_CDC_1200BPS_TOUCH && MICROPY_HW_ENABLE_USBDEV
+
+static mp_sched_node_t mp_bootloader_sched_node;
+
+static void usbd_cdc_run_bootloader_task(mp_sched_node_t *node) {
+    mp_hal_delay_ms(250);
+    machine_bootloader(0, NULL);
+}
+
+void
+#if MICROPY_HW_USB_EXTERNAL_TINYUSB
+mp_usbd_line_state_cb
+#else
+tud_cdc_line_state_cb
+#endif
+    (uint8_t itf, bool dtr, bool rts) {
+    if (dtr == false && rts == false) {
+        // Device is disconnected.
+        cdc_line_coding_t line_coding;
+        tud_cdc_n_get_line_coding(itf, &line_coding);
+        if (line_coding.bit_rate == 1200) {
+            // Delay bootloader jump to allow the USB stack to service endpoints.
+            mp_sched_schedule_node(&mp_bootloader_sched_node, usbd_cdc_run_bootloader_task);
+        }
+    }
+}
+
+#endif
+#endif

--- a/shared/tinyusb/mp_usbd_cdc.h
+++ b/shared/tinyusb/mp_usbd_cdc.h
@@ -3,7 +3,7 @@
  *
  * The MIT License (MIT)
  *
- * Copyright (c) 2022 Ibrahim Abdelkader <iabdalkader@openmv.io>
+ * Copyright (c) 2022 Blake W. Felt & Angus Gratton
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -24,37 +24,16 @@
  * THE SOFTWARE.
  */
 
-#include "py/runtime.h"
-#include "py/mphal.h"
-#include "extmod/modmachine.h"
+#ifndef MICROPY_INCLUDED_SHARED_TINYUSB_MP_USBD_CDC_H
+#define MICROPY_INCLUDED_SHARED_TINYUSB_MP_USBD_CDC_H
 
-#if MICROPY_HW_USB_CDC_1200BPS_TOUCH && MICROPY_HW_ENABLE_USBDEV
-
-#include "tusb.h"
-
-static mp_sched_node_t mp_bootloader_sched_node;
-
-static void usbd_cdc_run_bootloader_task(mp_sched_node_t *node) {
-    mp_hal_delay_ms(250);
-    machine_bootloader(0, NULL);
-}
-
-void
-#if MICROPY_HW_USB_EXTERNAL_TINYUSB
-mp_usbd_line_state_cb
-#else
-tud_cdc_line_state_cb
+#ifndef MICROPY_HW_USB_CDC_TX_TIMEOUT
+#define MICROPY_HW_USB_CDC_TX_TIMEOUT (500)
 #endif
-    (uint8_t itf, bool dtr, bool rts) {
-    if (dtr == false && rts == false) {
-        // Device is disconnected.
-        cdc_line_coding_t line_coding;
-        tud_cdc_n_get_line_coding(itf, &line_coding);
-        if (line_coding.bit_rate == 1200) {
-            // Delay bootloader jump to allow the USB stack to service endpoints.
-            mp_sched_schedule_node(&mp_bootloader_sched_node, usbd_cdc_run_bootloader_task);
-        }
-    }
-}
 
-#endif
+uintptr_t mp_usbd_cdc_poll_interfaces(uintptr_t poll_flags);
+void tud_cdc_rx_cb(uint8_t itf);
+mp_uint_t mp_usbd_cdc_tx_strn(const char *str, mp_uint_t len);
+
+
+#endif // MICROPY_INCLUDED_SHARED_TINYUSB_MP_USBD_CDC_H


### PR DESCRIPTION
There are a few tinyusb CDC functions used for stdio that are currently replicated across a number of ports. 
Not surprisingly in a couple of cases these have started to diverge slightly, with additional features added to one of them.

This PR consolidates a couple of key shared functions used directly by tinyusb based ports. 
