### PR TITLE
examples/usb: Add README that points out the alternative usb modules.

### DIFF
--- a/examples/usb/README.md
+++ b/examples/usb/README.md
@@ -1,0 +1,16 @@
+## USBDevice Examples
+
+These are examples of how to use the low-level `machine.USBDevice` class to create custom
+USB device functionality.
+
+Alternatively, there are [usb driver modules in
+micropython-lib](https://github.com/micropython/micropython-lib/tree/master/micropython/usb#readme)
+which provide a simpler interface and more built-in functionality.
+
+In this directory:
+
+* `usb_dfu_device.py` implements the USB Device Firmware Update protocol.
+* `usb_simple_device.py` implements a custom USB protocol, with a matching host
+  program to run on a PC.
+
+See comments at the top of each Python file for more details.


### PR DESCRIPTION
I didn't get a chance to review #14439, but one thing I think is important is to provide a link to the micropython-lib usb modules from here.

Otherwise if someone starts by looking in this directory then they won't know that the alternative exists.

(In general there are probably also opportunities to mention this example in the docs or micropython-lib, but I feel like this is the most important link as it's the most likely to turn a new user away if they're looking for something more high-level.)