### PR TITLE
webassembly: Revert conversion of Python None to JavaScript null, and make dict proxy return undefined when key doesn't exist

### DIFF
--- a/ports/webassembly/README.md
+++ b/ports/webassembly/README.md
@@ -182,4 +182,6 @@ A Python `dict` instance is proxied such that:
     }
 
 works as expected on the JavaScript side and iterates through the keys of the
-Python `dict`.
+Python `dict`.  Furthermore, when JavaScript accesses a key that does not exist
+in the Python dict, the JavaScript code receives `undefined` instead of a
+`KeyError` exception being raised.

--- a/ports/webassembly/README.md
+++ b/ports/webassembly/README.md
@@ -160,6 +160,18 @@ context, created and returned by `loadMicroPython()`.
 - `replProcessCharWithAsyncify(chr)`: process an incoming character at the REPL,
   for use when ASYNCIFY is enabled.
 
+Type conversions
+----------------
+
+Read-only objects (booleanns, numbers, strings, etc) are converted when passed between
+Python and JavaScript.  The conversions are:
+
+- JavaScript `null` converts to/from Python `None`.
+- JavaScript `undefined` converts to/from Python `js.undefined`.
+
+The conversion between `null` and `None` matches the behaviour of the Python `json`
+module.
+
 Proxying
 --------
 

--- a/ports/webassembly/proxy_c.c
+++ b/ports/webassembly/proxy_c.c
@@ -59,6 +59,16 @@ enum {
     PROXY_KIND_JS_PYPROXY = 7,
 };
 
+MP_DEFINE_CONST_OBJ_TYPE(
+    mp_type_undefined,
+    MP_QSTR_undefined,
+    MP_TYPE_FLAG_NONE
+    );
+
+static const mp_obj_base_t mp_const_undefined_obj = {&mp_type_undefined};
+
+#define mp_const_undefined (MP_OBJ_FROM_PTR(&mp_const_undefined_obj))
+
 MP_DEFINE_EXCEPTION(JsException, Exception)
 
 void proxy_c_init(void) {
@@ -80,7 +90,7 @@ static inline mp_obj_t proxy_c_get_obj(uint32_t c_ref) {
 
 mp_obj_t proxy_convert_js_to_mp_obj_cside(uint32_t *value) {
     if (value[0] == PROXY_KIND_JS_UNDEFINED) {
-        return mp_const_none;
+        return mp_const_undefined;
     } else if (value[0] == PROXY_KIND_JS_NULL) {
         return mp_const_none;
     } else if (value[0] == PROXY_KIND_JS_BOOLEAN) {
@@ -122,6 +132,9 @@ void proxy_convert_mp_to_js_obj_cside(mp_obj_t obj, uint32_t *out) {
         const char *str = mp_obj_str_get_data(obj, &len);
         out[1] = len;
         out[2] = (uintptr_t)str;
+    } else if (obj == mp_const_undefined) {
+        kind = PROXY_KIND_MP_JSPROXY;
+        out[1] = 1;
     } else if (mp_obj_is_jsproxy(obj)) {
         kind = PROXY_KIND_MP_JSPROXY;
         out[1] = mp_obj_jsproxy_get_ref(obj);

--- a/ports/webassembly/proxy_js.js
+++ b/ports/webassembly/proxy_js.js
@@ -188,7 +188,7 @@ function proxy_convert_mp_to_js_obj_jsside(value) {
     }
     if (kind === PROXY_KIND_MP_NONE) {
         // None
-        obj = undefined;
+        obj = null;
     } else if (kind === PROXY_KIND_MP_BOOL) {
         // bool
         obj = Module.getValue(value + 4, "i32") ? true : false;

--- a/ports/webassembly/proxy_js.js
+++ b/ports/webassembly/proxy_js.js
@@ -56,7 +56,7 @@ class PythonError extends Error {
 }
 
 function proxy_js_init() {
-    globalThis.proxy_js_ref = [globalThis];
+    globalThis.proxy_js_ref = [globalThis, undefined];
 }
 
 function proxy_call_python(target, argumentsList) {

--- a/tests/ports/webassembly/await_error_handling.mjs.exp
+++ b/tests/ports/webassembly/await_error_handling.mjs.exp
@@ -1,5 +1,5 @@
 1
 2
-(<JsProxy 6>, 'Error', 'test')
+(<JsProxy 7>, 'Error', 'test')
 3
 true Error test

--- a/tests/ports/webassembly/jsffi_create_proxy.mjs.exp
+++ b/tests/ports/webassembly/jsffi_create_proxy.mjs.exp
@@ -1,5 +1,5 @@
 1
-<JsProxy 1>
+<JsProxy 2>
 1
 1
 PyProxy { _ref: 3 }

--- a/tests/ports/webassembly/jsffi_to_js.mjs.exp
+++ b/tests/ports/webassembly/jsffi_to_js.mjs.exp
@@ -1,6 +1,6 @@
 1
-<JsProxy 1>
 <JsProxy 2>
+<JsProxy 3>
 false
 1
 true

--- a/tests/ports/webassembly/py_proxy_dict_undefined.mjs
+++ b/tests/ports/webassembly/py_proxy_dict_undefined.mjs
@@ -1,0 +1,34 @@
+// Test passing a Python dict into JavaScript, how it behaves with undefined keys.
+// If JavaScript accesses a key that does not exist, `undefined` should be returned.
+// This is different to Python-side behaviour, where `KeyError` is raised.
+
+const mp = await (await import(process.argv[2])).loadMicroPython();
+
+// Create a JavaScript function with default arguments.
+// When `value` is `undefined` it will receive its default.
+function withDefault({ value = "OK" } = {}) {
+    console.log(value);
+}
+
+globalThis.withDefault = withDefault;
+
+// Call the function from JavaScript with various arguments.
+withDefault();
+withDefault({});
+withDefault({ value: null });
+withDefault({ value: undefined });
+withDefault({ value: () => {} });
+
+console.log("====");
+
+// Call the function from Python with the same arguments as above.
+// The results should be the same.
+mp.runPython(`
+import js
+
+js.withDefault()
+js.withDefault({})
+js.withDefault({"value": None})
+js.withDefault({"value": js.undefined})
+js.withDefault({"value": (lambda: {})})
+`);

--- a/tests/ports/webassembly/py_proxy_dict_undefined.mjs.exp
+++ b/tests/ports/webassembly/py_proxy_dict_undefined.mjs.exp
@@ -1,0 +1,11 @@
+OK
+OK
+null
+OK
+[Function: value]
+====
+OK
+OK
+null
+OK
+[Function: obj] { _ref: 7 }

--- a/tests/ports/webassembly/py_proxy_to_js.mjs.exp
+++ b/tests/ports/webassembly/py_proxy_to_js.mjs.exp
@@ -1,4 +1,4 @@
 false 1
 true [ 1, 2, 3 ]
-true [ undefined, true, 1.2 ]
-true { tuple: [ 1, 2, 3 ], one: 1, list: [ undefined, true, 1.2 ] }
+true [ null, true, 1.2 ]
+true { tuple: [ 1, 2, 3 ], one: 1, list: [ null, true, 1.2 ] }

--- a/tests/ports/webassembly/register_js_module.js.exp
+++ b/tests/ports/webassembly/register_js_module.js.exp
@@ -1,2 +1,2 @@
-<JsProxy 1>
+<JsProxy 2>
 2

--- a/tests/ports/webassembly/run_python_async.mjs.exp
+++ b/tests/ports/webassembly/run_python_async.mjs.exp
@@ -1,17 +1,17 @@
 = TEST 1 ==========
 1
-<JsProxy 1>
+<JsProxy 2>
 py 1
-<JsProxy 4>
+<JsProxy 5>
 py 2
 2
 resolved 123
 3
 = TEST 2 ==========
 1
-<JsProxy 5>
+<JsProxy 6>
 py 1
-<JsProxy 8>
+<JsProxy 9>
 py 2
 2
 setTimeout resolved

--- a/tests/ports/webassembly/run_python_async.mjs.exp
+++ b/tests/ports/webassembly/run_python_async.mjs.exp
@@ -23,7 +23,7 @@ py 1
 setTimeout resolved
 resolved value: 123
 py 2
-2 undefined
+2 null
 = TEST 4 ==========
 1
 py 1
@@ -35,4 +35,4 @@ py 3
 setTimeout B resolved
 resolved value: 456
 py 4
-2 undefined
+2 null


### PR DESCRIPTION
There are 3 related commits in this PR:
- Revert back to converting Python None to JavaScript null.  This essentially reverts fa23e4b093f81f03a24187c7ea0c928a9b4a661b which made `None` convert to `undefined`.  So now it's back to how it was before that commit, and Py `None` converts to JS `null`.  That's consistent with how the `json` module converts these values.
- Create a special "undefined" type/instance for Python visibility.  This corresponds exactly to JS `undefined`.  It's accessible via `js.undefined`.  Passing this from Py to JS, JS will receive `undefined`.  And when JS passes `undefined` to Py, Py will see the proxy `js.undefined` value.
- Make proxy Py dicts return `undefined` to JS when JS looks up a key that doesn't exist (instead of raising `KeyError`).  These semantics match better the JS behaviour of `{}` objects.

The first two changes mean the following:
- There's a one-to-one correspondence between Py `None` and JS `null`.
- There's a one-to-one correspondence between Py `js.undefined` and JS `undefined`.
- Conversion of these values matches the `json` module.

All three changes together mean that, given the following JavaScript function with an optional argument:
```js
function withDefault({ value = 'OK' } = {}) {
  console.log(value);
}
```
the JavaScript and Python code to call this function have equivalent behaviour, namely, in JavaScript:
```js
withDefault();
withDefault({});
withDefault({ value: null });
withDefault({ value: undefined });
```
and in Python:
```py
js.withDefault()
js.withDefault({})
js.withDefault({"value": None})
js.withDefault({"value": js.undefined})
```