### PR TITLE
ports/stm32: Correct STM32G4 FDCAN clock frequency.

### DIFF
--- a/ports/stm32/pyb_can.c
+++ b/ports/stm32/pyb_can.c
@@ -182,7 +182,10 @@ static uint32_t pyb_can_get_source_freq() {
             break;
         }
     }
-    #else // F4 and F7 and assume other MCUs too.
+    #elif defined(STM32G4)
+    // STM32G4 CAN clock from reset is HSE, unchanged by MicroPython
+    can_kern_clk = HSE_VALUE;
+    #else // G0, F4, F7 and assume other MCUs too.
     // CAN1/CAN2/CAN3 on APB1 use GetPCLK1Freq, alternatively use the following:
     // can_kern_clk = ((HSE_VALUE / osc_config.PLL.PLLM ) * osc_config.PLL.PLLN) /
     //  (osc_config.PLL.PLLQ * clk_init.AHBCLKDivider * clk_init.APB1CLKDivider);


### PR DESCRIPTION
Fixes automatic baudrate calculation results.

Default clock source on this SoC is HSE not PCLK1. We could fix this by switching to PCLK1 instead, but two extra complications:

* PCLK1 on this board is a 42.5MHz and the Pyboard CAN sample_point calculation requires an exact match, which is harder to hit with this source frequency.
* Would be a breaking change for any existing Python code on this board, i.e. specifying brp, bs1, bs2 to initialise CAN.

In the future it might be worth looking switching to the PLL source on this SoC instead, as this is a much higher frequency that would give higher quality BRS bitrate matches (probably too high without using the second divider going into the CAN peripheral though, so more code changes needed also.)

*This work was funded through GitHub Sponsors.*