### PR TITLE
py/mpz: Ignore calls to to_bytes with zero length.

### DIFF
--- a/py/mpz.c
+++ b/py/mpz.c
@@ -1590,6 +1590,11 @@ bool mpz_as_uint_checked(const mpz_t *i, mp_uint_t *value) {
 }
 
 void mpz_as_bytes(const mpz_t *z, bool big_endian, size_t len, byte *buf) {
+    if (len == 0) {
+        // No output is necessary.
+        return;
+    }
+
     byte *b = buf;
     if (big_endian) {
         b += len;


### PR DESCRIPTION
Requesting a zero-sized bytes representation of large integers (using mpz rather than `long long`) would attempt to sign-extend a zero-bytes buffer with no bounds checking.  This PR sidesteps the whole issue by not performing any operation if the requested length is zero, with the same runtime behaviour as smaller integers in the same situation.

For the record, code like `int.from_bytes(bytes(range(20)), "big").to_bytes(0, "big")` would crash MicroPython with:

```
#0  __memset_avx2_unaligned_erms ()
    at ../sysdeps/x86_64/multiarch/memset-vec-unaligned-erms.S:330
#1  0x000055555557a9c9 in mpz_as_bytes (z=<optimized out>, 
    big_endian=big_endian@entry=true, len=<optimized out>, len@entry=0, 
    buf=<optimized out>, buf@entry=0x7ffff7a06fe0 "") at ../../py/mpz.c:1631
#2  0x0000555555598eec in mp_obj_int_to_bytes_impl (self_in=<optimized out>, 
    big_endian=big_endian@entry=true, len=len@entry=0, 
    buf=buf@entry=0x7ffff7a06fe0 "") at ../../py/objint_mpz.c:118
#3  0x0000555555598525 in int_to_bytes (n_args=<optimized out>, 
    args=0x7fffffffab78) at ../../py/objint.c:440
[...]
```