### PR TITLE
py/dynruntime: Add `mp_obj_exception_init` function to define C exception.

### DIFF
--- a/examples/natmod/features4/features4.c
+++ b/examples/natmod/features4/features4.c
@@ -1,5 +1,6 @@
 /*
-  This example extends on features0 but demonstrates how to define a class.
+  This example extends on features0 but demonstrates how to define a class,
+  and a custom exception.
 
   The Factorial class constructor takes an integer, and then the calculate
   method can be called to get the factorial.
@@ -8,6 +9,9 @@
   >>> f = features4.Factorial(4)
   >>> f.calculate()
   24
+
+  If the argument to the Factorial class constructor is less than zero, a
+  FactorialError is raised.
 */
 
 // Include the header file to get access to the MicroPython API
@@ -22,6 +26,8 @@ typedef struct {
     mp_int_t n;
 } mp_obj_factorial_t;
 
+mp_obj_full_type_t mp_type_FactorialError;
+
 // Essentially Factorial.__new__ (but also kind of __init__).
 // Takes a single argument (the number to find the factorial of)
 static mp_obj_t factorial_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *args_in) {
@@ -29,6 +35,10 @@ static mp_obj_t factorial_make_new(const mp_obj_type_t *type, size_t n_args, siz
 
     mp_obj_factorial_t *o = mp_obj_malloc(mp_obj_factorial_t, type);
     o->n = mp_obj_get_int(args_in[0]);
+
+    if (o->n < 0) {
+        mp_raise_msg((mp_obj_type_t *)&mp_type_FactorialError, "argument must be zero or above");
+    }
 
     return MP_OBJ_FROM_PTR(o);
 }
@@ -67,6 +77,12 @@ mp_obj_t mpy_init(mp_obj_fun_bc_t *self, size_t n_args, size_t n_kw, mp_obj_t *a
 
     // Make the Factorial type available on the module.
     mp_store_global(MP_QSTR_Factorial, MP_OBJ_FROM_PTR(&mp_type_factorial));
+
+    // Initialise the exception type.
+    mp_obj_exception_init(&mp_type_FactorialError, MP_QSTR_FactorialError, &mp_type_Exception);
+
+    // Make the FactorialError type available on the module.
+    mp_store_global(MP_QSTR_FactorialError, MP_OBJ_FROM_PTR(&mp_type_FactorialError));
 
     // This must be last, it restores the globals dict
     MP_DYNRUNTIME_INIT_EXIT

--- a/py/dynruntime.h
+++ b/py/dynruntime.h
@@ -90,6 +90,7 @@ static inline void *m_realloc_dyn(void *ptr, size_t new_num_bytes) {
 #define mp_type_bytes                       (*(mp_obj_type_t *)(mp_load_global(MP_QSTR_bytes)))
 #define mp_type_tuple                       (*((mp_obj_base_t *)mp_const_empty_tuple)->type)
 #define mp_type_list                        (*mp_fun_table.type_list)
+#define mp_type_Exception                   (*mp_fun_table.type_Exception)
 #define mp_type_EOFError                    (*(mp_obj_type_t *)(mp_load_global(MP_QSTR_EOFError)))
 #define mp_type_IndexError                  (*(mp_obj_type_t *)(mp_load_global(MP_QSTR_IndexError)))
 #define mp_type_KeyError                    (*(mp_obj_type_t *)(mp_load_global(MP_QSTR_KeyError)))
@@ -236,6 +237,10 @@ static inline void *mp_obj_malloc_helper_dyn(size_t num_bytes, const mp_obj_type
 /******************************************************************************/
 // Exceptions
 
+#define mp_obj_exception_make_new               (MP_OBJ_TYPE_GET_SLOT(&mp_type_Exception, make_new))
+#define mp_obj_exception_print                  (MP_OBJ_TYPE_GET_SLOT(&mp_type_Exception, print))
+#define mp_obj_exception_attr                   (MP_OBJ_TYPE_GET_SLOT(&mp_type_Exception, attr))
+
 #define mp_obj_new_exception(o)                 ((mp_obj_t)(o)) // Assumes returned object will be raised, will create instance then
 #define mp_obj_new_exception_arg1(e_type, arg)  (mp_obj_new_exception_arg1_dyn((e_type), (arg)))
 
@@ -261,6 +266,16 @@ static NORETURN inline void mp_raise_dyn(mp_obj_t o) {
 static inline void mp_raise_OSError_dyn(int er) {
     mp_obj_t args[1] = { MP_OBJ_NEW_SMALL_INT(er) };
     nlr_raise(mp_call_function_n_kw(mp_load_global(MP_QSTR_OSError), 1, 0, &args[0]));
+}
+
+static inline void mp_obj_exception_init(mp_obj_full_type_t *exc, qstr name, const mp_obj_type_t *base) {
+    exc->base.type = &mp_type_type;
+    exc->flags = MP_TYPE_FLAG_NONE;
+    exc->name = name;
+    MP_OBJ_TYPE_SET_SLOT(exc, make_new, mp_obj_exception_make_new, 0);
+    MP_OBJ_TYPE_SET_SLOT(exc, print, mp_obj_exception_print, 1);
+    MP_OBJ_TYPE_SET_SLOT(exc, attr, mp_obj_exception_attr, 2);
+    MP_OBJ_TYPE_SET_SLOT(exc, parent, base, 3);
 }
 
 /******************************************************************************/

--- a/py/nativeglue.c
+++ b/py/nativeglue.c
@@ -344,6 +344,7 @@ const mp_fun_table_t mp_fun_table = {
     &mp_type_fun_builtin_2,
     &mp_type_fun_builtin_3,
     &mp_type_fun_builtin_var,
+    &mp_type_Exception,
     &mp_stream_read_obj,
     &mp_stream_readinto_obj,
     &mp_stream_unbuffered_readline_obj,

--- a/py/nativeglue.h
+++ b/py/nativeglue.h
@@ -171,6 +171,7 @@ typedef struct _mp_fun_table_t {
     const mp_obj_type_t *type_fun_builtin_2;
     const mp_obj_type_t *type_fun_builtin_3;
     const mp_obj_type_t *type_fun_builtin_var;
+    const mp_obj_type_t *type_Exception;
     const mp_obj_fun_builtin_var_t *stream_read_obj;
     const mp_obj_fun_builtin_var_t *stream_readinto_obj;
     const mp_obj_fun_builtin_var_t *stream_unbuffered_readline_obj;

--- a/tools/mpy_ld.py
+++ b/tools/mpy_ld.py
@@ -767,6 +767,7 @@ def link_objects(env, native_qstr_vals_len):
                 "mp_type_fun_builtin_2",
                 "mp_type_fun_builtin_3",
                 "mp_type_fun_builtin_var",
+                "mp_type_Exception",
                 "mp_stream_read_obj",
                 "mp_stream_readinto_obj",
                 "mp_stream_unbuffered_readline_obj",


### PR DESCRIPTION
This allows defining custom exceptions in C in dynamic native modules.  An example of this is added to the existing `features4` example.