### PR TITLE
webassembly: run garbage collection when possible at top-level C, and enable C and JS finalizers

### DIFF
--- a/ports/webassembly/Makefile
+++ b/ports/webassembly/Makefile
@@ -54,6 +54,7 @@ EXPORTED_FUNCTIONS_EXTRA += ,\
 	_mp_js_do_exec_async,\
 	_mp_js_do_import,\
 	_mp_js_register_js_module,\
+	_proxy_c_free_obj,\
 	_proxy_c_init,\
 	_proxy_c_to_js_call,\
 	_proxy_c_to_js_delete_attr,\

--- a/ports/webassembly/modjsffi.c
+++ b/ports/webassembly/modjsffi.c
@@ -25,6 +25,7 @@
  */
 
 #include "emscripten.h"
+#include "py/gc.h"
 #include "py/objmodule.h"
 #include "py/runtime.h"
 #include "proxy_c.h"
@@ -75,6 +76,44 @@ static mp_obj_t mp_jsffi_async_timeout_ms(mp_obj_t arg) {
 }
 static MP_DEFINE_CONST_FUN_OBJ_1(mp_jsffi_async_timeout_ms_obj, mp_jsffi_async_timeout_ms);
 
+// *FORMAT-OFF*
+EM_JS(void, js_get_proxy_js_ref_info, (uint32_t * out), {
+    let used = 0;
+    for (const elem of proxy_js_ref) {
+        if (elem !== undefined) {
+            ++used;
+        }
+    }
+    Module.setValue(out, proxy_js_ref.length, "i32");
+    Module.setValue(out + 4, used, "i32");
+});
+// *FORMAT-ON*
+
+static mp_obj_t mp_jsffi_mem_info(void) {
+    mp_obj_list_t *l = (mp_obj_list_t *)MP_OBJ_TO_PTR(MP_STATE_PORT(proxy_c_ref));
+    mp_int_t used = 0;
+    for (size_t i = 0; i < l->len; ++i) {
+        if (l->items[i] != MP_OBJ_NULL) {
+            ++used;
+        }
+    }
+    uint32_t proxy_js_ref_info[2];
+    js_get_proxy_js_ref_info(proxy_js_ref_info);
+    gc_info_t info;
+    gc_info(&info);
+    mp_obj_t elems[] = {
+        MP_OBJ_NEW_SMALL_INT(info.total), // GC heap total bytes
+        MP_OBJ_NEW_SMALL_INT(info.used), // GC heap used bytes
+        MP_OBJ_NEW_SMALL_INT(info.free), // GC heap free bytes
+        MP_OBJ_NEW_SMALL_INT(l->len), // proxy_c_ref allocated size
+        MP_OBJ_NEW_SMALL_INT(used), // proxy_c_ref used
+        MP_OBJ_NEW_SMALL_INT(proxy_js_ref_info[0]), // proxy_js_ref allocated size
+        MP_OBJ_NEW_SMALL_INT(proxy_js_ref_info[1]), // proxy_js_ref used
+    };
+    return mp_obj_new_tuple(MP_ARRAY_SIZE(elems), elems);
+}
+static MP_DEFINE_CONST_FUN_OBJ_0(mp_jsffi_mem_info_obj, mp_jsffi_mem_info);
+
 static const mp_rom_map_elem_t mp_module_jsffi_globals_table[] = {
     { MP_ROM_QSTR(MP_QSTR___name__), MP_ROM_QSTR(MP_QSTR_jsffi) },
 
@@ -83,6 +122,7 @@ static const mp_rom_map_elem_t mp_module_jsffi_globals_table[] = {
     { MP_ROM_QSTR(MP_QSTR_create_proxy), MP_ROM_PTR(&mp_jsffi_create_proxy_obj) },
     { MP_ROM_QSTR(MP_QSTR_to_js), MP_ROM_PTR(&mp_jsffi_to_js_obj) },
     { MP_ROM_QSTR(MP_QSTR_async_timeout_ms), MP_ROM_PTR(&mp_jsffi_async_timeout_ms_obj) },
+    { MP_ROM_QSTR(MP_QSTR_mem_info), MP_ROM_PTR(&mp_jsffi_mem_info_obj) },
 };
 static MP_DEFINE_CONST_DICT(mp_module_jsffi_globals, mp_module_jsffi_globals_table);
 

--- a/ports/webassembly/objjsproxy.c
+++ b/ports/webassembly/objjsproxy.c
@@ -300,7 +300,7 @@ void mp_obj_jsproxy_attr(mp_obj_t self_in, qstr attr, mp_obj_t *dest) {
 typedef struct _jsproxy_it_t {
     mp_obj_base_t base;
     mp_fun_1_t iternext;
-    int ref;
+    mp_obj_jsproxy_t *obj;
     uint16_t cur;
     uint16_t len;
 } jsproxy_it_t;
@@ -309,7 +309,7 @@ static mp_obj_t jsproxy_it_iternext(mp_obj_t self_in) {
     jsproxy_it_t *self = MP_OBJ_TO_PTR(self_in);
     if (self->cur < self->len) {
         uint32_t out[3];
-        js_subscr_int(self->ref, self->cur, out);
+        js_subscr_int(self->obj->ref, self->cur, out);
         self->cur += 1;
         return proxy_convert_js_to_mp_obj_cside(out);
     } else {
@@ -323,7 +323,7 @@ static mp_obj_t jsproxy_new_it(mp_obj_t self_in, mp_obj_iter_buf_t *iter_buf) {
     jsproxy_it_t *o = (jsproxy_it_t *)iter_buf;
     o->base.type = &mp_type_polymorph_iter;
     o->iternext = jsproxy_it_iternext;
-    o->ref = self->ref;
+    o->obj = self;
     o->cur = 0;
     o->len = js_get_len(self->ref);
     return MP_OBJ_FROM_PTR(o);

--- a/ports/webassembly/proxy_c.c
+++ b/ports/webassembly/proxy_c.c
@@ -210,10 +210,10 @@ void proxy_c_to_js_dir(uint32_t c_ref, uint32_t *out) {
             dir = mp_builtin_dir_obj.fun.var(1, args);
         }
         nlr_pop();
-        return proxy_convert_mp_to_js_obj_cside(dir, out);
+        proxy_convert_mp_to_js_obj_cside(dir, out);
     } else {
         // uncaught exception
-        return proxy_convert_mp_to_js_exc_cside(nlr.ret_val, out);
+        proxy_convert_mp_to_js_exc_cside(nlr.ret_val, out);
     }
 }
 
@@ -255,10 +255,10 @@ void proxy_c_to_js_lookup_attr(uint32_t c_ref, const char *attr_in, uint32_t *ou
             member = mp_load_attr(obj, attr);
         }
         nlr_pop();
-        return proxy_convert_mp_to_js_obj_cside(member, out);
+        proxy_convert_mp_to_js_obj_cside(member, out);
     } else {
         // uncaught exception
-        return proxy_convert_mp_to_js_exc_cside(nlr.ret_val, out);
+        proxy_convert_mp_to_js_exc_cside(nlr.ret_val, out);
     }
 }
 
@@ -482,9 +482,9 @@ void proxy_c_to_js_resume(uint32_t c_ref, uint32_t *args) {
         mp_obj_t reject = proxy_convert_js_to_mp_obj_cside(args + 2 * 3);
         mp_obj_t ret = proxy_resume_execute(obj, mp_const_none, mp_const_none, resolve, reject);
         nlr_pop();
-        return proxy_convert_mp_to_js_obj_cside(ret, args);
+        proxy_convert_mp_to_js_obj_cside(ret, args);
     } else {
         // uncaught exception
-        return proxy_convert_mp_to_js_exc_cside(nlr.ret_val, args);
+        proxy_convert_mp_to_js_exc_cside(nlr.ret_val, args);
     }
 }

--- a/ports/webassembly/proxy_c.h
+++ b/ports/webassembly/proxy_c.h
@@ -39,6 +39,9 @@ typedef struct _mp_obj_jsproxy_t {
 extern const mp_obj_type_t mp_type_jsproxy;
 extern const mp_obj_type_t mp_type_JsException;
 
+void external_call_depth_inc(void);
+void external_call_depth_dec(void);
+
 void proxy_c_init(void);
 mp_obj_t proxy_convert_js_to_mp_obj_cside(uint32_t *value);
 void proxy_convert_mp_to_js_obj_cside(mp_obj_t obj, uint32_t *out);

--- a/ports/webassembly/proxy_js.js
+++ b/ports/webassembly/proxy_js.js
@@ -24,6 +24,9 @@
  * THE SOFTWARE.
  */
 
+// Number of static entries at the start of proxy_js_ref.
+const PROXY_JS_REF_NUM_STATIC = 2;
+
 // These constants should match the constants in proxy_c.c.
 
 const PROXY_KIND_MP_EXCEPTION = -1;
@@ -57,6 +60,28 @@ class PythonError extends Error {
 
 function proxy_js_init() {
     globalThis.proxy_js_ref = [globalThis, undefined];
+    globalThis.proxy_js_ref_next = PROXY_JS_REF_NUM_STATIC;
+}
+
+// js_obj cannot be undefined
+function proxy_js_add_obj(js_obj) {
+    // Search for the first free slot in proxy_js_ref.
+    while (proxy_js_ref_next < proxy_js_ref.length) {
+        if (proxy_js_ref[proxy_js_ref_next] === undefined) {
+            // Free slot found, reuse it.
+            const id = proxy_js_ref_next;
+            ++proxy_js_ref_next;
+            proxy_js_ref[id] = js_obj;
+            return id;
+        }
+        ++proxy_js_ref_next;
+    }
+
+    // No free slots, so grow proxy_js_ref by one (append at the end of the array).
+    const id = proxy_js_ref.length;
+    proxy_js_ref[id] = js_obj;
+    proxy_js_ref_next = proxy_js_ref.length;
+    return id;
 }
 
 function proxy_call_python(target, argumentsList) {
@@ -147,8 +172,7 @@ function proxy_convert_js_to_mp_obj_jsside(js_obj, out) {
         Module.setValue(out + 4, js_obj._ref, "i32");
     } else {
         kind = PROXY_KIND_JS_OBJECT;
-        const id = proxy_js_ref.length;
-        proxy_js_ref[id] = js_obj;
+        const id = proxy_js_add_obj(js_obj);
         Module.setValue(out + 4, id, "i32");
     }
     Module.setValue(out + 0, kind, "i32");
@@ -161,8 +185,7 @@ function proxy_convert_js_to_mp_obj_jsside_force_double_proxy(js_obj, out) {
         js_obj instanceof PyProxyThenable
     ) {
         const kind = PROXY_KIND_JS_OBJECT;
-        const id = proxy_js_ref.length;
-        proxy_js_ref[id] = js_obj;
+        const id = proxy_js_add_obj(js_obj);
         Module.setValue(out + 4, id, "i32");
         Module.setValue(out + 0, kind, "i32");
     } else {

--- a/ports/webassembly/proxy_js.js
+++ b/ports/webassembly/proxy_js.js
@@ -61,6 +61,11 @@ class PythonError extends Error {
 function proxy_js_init() {
     globalThis.proxy_js_ref = [globalThis, undefined];
     globalThis.proxy_js_ref_next = PROXY_JS_REF_NUM_STATIC;
+    globalThis.pyProxyFinalizationRegistry = new FinalizationRegistry(
+        (cRef) => {
+            Module.ccall("proxy_c_free_obj", "null", ["number"], [cRef]);
+        },
+    );
 }
 
 // js_obj cannot be undefined
@@ -251,6 +256,7 @@ function proxy_convert_mp_to_js_obj_jsside(value) {
             const target = new PyProxy(id);
             obj = new Proxy(target, py_proxy_handler);
         }
+        globalThis.pyProxyFinalizationRegistry.register(obj, id);
     }
     return obj;
 }


### PR DESCRIPTION
This PR makes three improvements to memory management on the webassembly port:
- run the GC in more places at top-level C code, eg so that memory can be freed when running a pure asyncio-based application (collection can now happen when a promise/coroutine is resumed)
- enable `__del__` finaliser on `JsProxy` objects, to free JavaScript-side memory when Python no longer needs the object
- enable finalization registry on `PyProxy` objects, to free Python-side memory when JavaScript no longer needs the object