### PR TITLE
shared/runtime/gchelper: Add RISC-V RV32I native gchelper.

### DIFF
--- a/shared/runtime/gchelper_generic.c
+++ b/shared/runtime/gchelper_generic.c
@@ -150,6 +150,37 @@ static void gc_helper_get_regs(gc_helper_regs_t arr) {
     arr[10] = x29;
 }
 
+#elif defined(__riscv) && defined(__riscv_xlen) && (__riscv_xlen == 32)
+
+// Fallback implementation for RV32I, prefer gchelper_rv32i.s
+
+static void gc_helper_get_regs(gc_helper_regs_t arr) {
+    register long s0 asm ("x8");
+    register long s1 asm ("x9");
+    register long s2 asm ("x18");
+    register long s3 asm ("x19");
+    register long s4 asm ("x20");
+    register long s5 asm ("x21");
+    register long s6 asm ("x22");
+    register long s7 asm ("x23");
+    register long s8 asm ("x24");
+    register long s9 asm ("x25");
+    register long s10 asm ("x26");
+    register long s11 asm ("x27");
+    arr[0] = s0;
+    arr[1] = s1;
+    arr[2] = s2;
+    arr[3] = s3;
+    arr[4] = s4;
+    arr[5] = s5;
+    arr[6] = s6;
+    arr[7] = s7;
+    arr[8] = s8;
+    arr[9] = s9;
+    arr[10] = s10;
+    arr[11] = s11;
+}
+
 #else
 
 #error "Architecture not supported for gc_helper_get_regs. Set MICROPY_GCREGS_SETJMP to use the fallback implementation."

--- a/shared/runtime/gchelper_rv32i.s
+++ b/shared/runtime/gchelper_rv32i.s
@@ -3,7 +3,7 @@
  *
  * The MIT License (MIT)
  *
- * Copyright (c) 2019 Damien P. George
+ * Copyright (c) 2024 Alessandro Gatti
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -23,30 +23,30 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-#ifndef MICROPY_INCLUDED_LIB_UTILS_GCHELPER_H
-#define MICROPY_INCLUDED_LIB_UTILS_GCHELPER_H
 
-#include <stdint.h>
+    .global gc_helper_get_regs_and_sp
+    .type   gc_helper_get_regs_and_sp, @function
 
-#if MICROPY_GCREGS_SETJMP
-#include <setjmp.h>
-typedef jmp_buf gc_helper_regs_t;
-#else
+gc_helper_get_regs_and_sp:
 
-#if defined(__x86_64__)
-typedef uintptr_t gc_helper_regs_t[6];
-#elif defined(__i386__)
-typedef uintptr_t gc_helper_regs_t[4];
-#elif defined(__thumb2__) || defined(__thumb__) || defined(__arm__)
-typedef uintptr_t gc_helper_regs_t[10];
-#elif defined(__aarch64__)
-typedef uintptr_t gc_helper_regs_t[11]; // x19-x29
-#elif defined(__riscv) && defined(__riscv_xlen) && (__riscv_xlen == 32)
-typedef uintptr_t gc_helper_regs_t[12]; // S0-S11
-#endif
+    /* Store registers into the given array. */
 
-#endif
+    sw    x8,  0(x10)  /* Save S0.  */
+    sw    x9,  4(x10)  /* Save S1.  */
+    sw   x18,  8(x10)  /* Save S2.  */
+    sw   x19, 12(x10)  /* Save S3.  */
+    sw   x20, 16(x10)  /* Save S4.  */
+    sw   x21, 20(x10)  /* Save S5.  */
+    sw   x22, 24(x10)  /* Save S6.  */
+    sw   x23, 28(x10)  /* Save S7.  */
+    sw   x24, 32(x10)  /* Save S8.  */
+    sw   x25, 36(x10)  /* Save S9.  */
+    sw   x26, 40(x10)  /* Save S10. */
+    sw   x27, 44(x10)  /* Save S11. */
 
-void gc_helper_collect_regs_and_stack(void);
+    /* Return the stack pointer. */
 
-#endif // MICROPY_INCLUDED_LIB_UTILS_GCHELPER_H
+    add  x10, x0, x2
+    jalr  x0, x1, 0
+
+    .size gc_helper_get_regs_and_sp, .-gc_helper_get_regs_and_sp


### PR DESCRIPTION
This PR adds native gchelper support for 32 bits RISC-V RV32I targets.

Tests pass on `qemu-riscv` when disabling the setjmp implementation, for both native assembler and C fallback versions.  On an ESP32-C3 board I see no differences in test failures count between the three versions (setjmp, native, and fallback).