### PR TITLE
ports/esp32: Make LAN.active(bool) idempotent.

### DIFF
--- a/ports/esp32/network_lan.c
+++ b/ports/esp32/network_lan.c
@@ -314,13 +314,15 @@ static mp_obj_t lan_active(size_t n_args, const mp_obj_t *args) {
     if (n_args > 1) {
         if (mp_obj_is_true(args[1])) {
             esp_netif_set_hostname(self->base.netif, mod_network_hostname_data);
-            self->base.active = (esp_eth_start(self->eth_handle) == ESP_OK);
-            if (!self->base.active) {
+            esp_err_t res = esp_eth_start(self->eth_handle);
+            self->base.active = (res == ESP_OK);
+            if (!self->base.active && res != ESP_ERR_INVALID_STATE) {
                 mp_raise_msg(&mp_type_OSError, MP_ERROR_TEXT("ethernet enable failed"));
             }
         } else {
-            self->base.active = !(esp_eth_stop(self->eth_handle) == ESP_OK);
-            if (self->base.active) {
+            esp_err_t res = esp_eth_stop(self->eth_handle);
+            self->base.active = !(res == ESP_OK);
+            if (self->base.active && res != ESP_ERR_INVALID_STATE) {
                 mp_raise_msg(&mp_type_OSError, MP_ERROR_TEXT("ethernet disable failed"));
             }
         }


### PR DESCRIPTION
Do not raise an exception when LAN.active(False) is called but LAN is already inactive, or LAN.active(True) is called but LAN is already active.

Aligns this LAN API with with WLAN.active(bool), which is already idempotent.

Within ESP-IDF, it can be seen at [1] and [2] that esp_eth_start() and esp_eth_stop() return ESP_ERR_INVALID_STATE only when the state contradicts the intention, not for any actual error.

[1] https://github.com/espressif/esp-idf/blob/master/components/esp_eth/src/esp_eth.c#L278
[2] https://github.com/espressif/esp-idf/blob/master/components/esp_eth/src/esp_eth.c#L301