### PR TITLE
github: Update issue forms to remove checklist generation.

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -11,19 +11,10 @@ body:
 
         * If you have a question \"How Do I ...?\", please post it on [GitHub Discussions](https://github.com/orgs/micropython/discussions/) or [Discord](https://discord.gg/RB8HZSAExQ) instead of here.
         * For missing or incorrect documentation, or feature requests, then please [choose a different issue type](https://github.com/micropython/micropython/issues/new/choose).
-  - type: checkboxes
-    id: terms
-    attributes:
-      label: Checks
-      description: |
-        Before submitting your bug report, please go over these check points:
-      options:
-      - label: |
-           I agree to follow the MicroPython [Code of Conduct](https://github.com/micropython/micropython/blob/master/CODEOFCONDUCT.md) to ensure a safe and respectful space for everyone.
-        required: true
-      - label: |
-          I've searched for [existing issues](https://github.com/micropython/micropython/issues) matching this bug, and didn't find any.
-        required: true
+
+        #### Existing issue?
+
+        * Please search for [existing issues](https://github.com/micropython/micropython/issues) matching this bug before reporting.
   - type: input
     id: port-board-hw
     attributes:
@@ -33,7 +24,7 @@ body:
       placeholder: |
         esp32 port, ESP32-Fantastic board.
     validations:
-       required: true
+      required: true
   - type: textarea
     id: version
     attributes:
@@ -101,6 +92,17 @@ body:
       description: |
         Is there anything else that might help to resolve this issue?
       value: No, I've provided everything above.
+  - type: dropdown
+    id: code-of-conduct
+    attributes:
+      label: Code of Conduct
+      description: |
+        Do you agree to follow the MicroPython [Code of Conduct](https://github.com/micropython/micropython/blob/master/CODEOFCONDUCT.md) to ensure a safe and respectful space for everyone?
+      options:
+        - "Yes, I agree"
+      multiple: true
+    validations:
+      required: true
   - type: markdown
     attributes:
       value: |

--- a/.github/ISSUE_TEMPLATE/documentation.yml
+++ b/.github/ISSUE_TEMPLATE/documentation.yml
@@ -9,19 +9,10 @@ body:
         This form is for reporting issues with the documentation or examples provided with MicroPython.
 
         If you have a general question \"How Do I ...?\", please post it on [GitHub Discussions](https://github.com/orgs/micropython/discussions/) or [Discord](https://discord.gg/RB8HZSAExQ) instead of here.
-  - type: checkboxes
-    id: terms
-    attributes:
-      label: Checks
-      description: |
-        Before submitting your bug report, please go over these check points:
-      options:
-      - label: |
-           I agree to follow the MicroPython [Code of Conduct](https://github.com/micropython/micropython/blob/master/CODEOFCONDUCT.md) to ensure a safe and respectful space for everyone.
-        required: true
-      - label: |
-          I've searched for [existing issues](https://github.com/micropython/micropython/issues) and didn't find any that matched.
-        required: true
+
+        #### Existing issue?
+
+        * Please search for [existing issues](https://github.com/micropython/micropython/issues) before reporting a new one.
   - type: input
     id: page
     attributes:
@@ -36,6 +27,17 @@ body:
       label: Description
       description: |
         Please describe what was missing from the documentation and/or what was incorrect/incomplete.
+    validations:
+      required: true
+  - type: dropdown
+    id: code-of-conduct
+    attributes:
+      label: Code of Conduct
+      description: |
+        Do you agree to follow the MicroPython [Code of Conduct](https://github.com/micropython/micropython/blob/master/CODEOFCONDUCT.md) to ensure a safe and respectful space for everyone?
+      options:
+        - "Yes, I agree"
+      multiple: true
     validations:
       required: true
   - type: markdown

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -15,19 +15,10 @@ body:
 
         * If you have a question \"How Do I ...?\", please post it on GitHub Discussions or Discord instead of here.
         * Could this feature be implemented as a pure Python library? If so, please open the request on the [micropython-lib repository](https://github.com/micropython/micropython-lib/issues) instead.
-  - type: checkboxes
-    id: terms
-    attributes:
-      label: Checks
-      description: |
-        Before submitting your feature request, please go over these check points:
-      options:
-      - label: |
-           I agree to follow the MicroPython [Code of Conduct](https://github.com/micropython/micropython/blob/master/CODEOFCONDUCT.md) to ensure a safe and respectful space for everyone.
-        required: true
-      - label: |
-          I've searched for [existing issues](https://github.com/micropython/micropython/issues) regarding this feature, and didn't find any.
-        required: true
+
+        #### Existing issue?
+
+        * Please search for [existing issues](https://github.com/micropython/micropython/issues) before opening a new one.
   - type: textarea
     id: feature
     attributes:
@@ -51,14 +42,32 @@ body:
          MicroPython aims to strike a balance between functionality and code size. Can this feature be optionally enabled?
 
          If you believe the usefulness of this feature would outweigh the additional code size, please explain. (It's OK to say you're unsure here, we're happy to discuss this with you.)
-  - type: checkboxes
+  - type: dropdown
     id: implementation
     attributes:
       label: Implementation
+      description: |
+        What is your suggestion for implementing this feature?
+
+        (See also: [How to sponsor](https://github.com/sponsors/micropython#sponsors), [How to submit a Pull Request](https://github.com/micropython/micropython/wiki/ContributorGuidelines).)
       options:
-      - label: I intend to implement this feature and would submit a Pull Request if desirable.
-      - label: I hope the MicroPython maintainers or community will implement this feature.
-      - label: I would like to [Sponsor](https://github.com/sponsors/micropython#sponsors) development of this feature.
+        - I hope the MicroPython maintainers or community will implement this feature
+        - I intend to implement this feature and would submit a Pull Request if desirable
+        - I would like to sponsor development of this feature
+      multiple: true
+    validations:
+      required: true
+  - type: dropdown
+    id: code-of-conduct
+    attributes:
+      label: Code of Conduct
+      description: |
+        Do you agree to follow the MicroPython [Code of Conduct](https://github.com/micropython/micropython/blob/master/CODEOFCONDUCT.md) to ensure a safe and respectful space for everyone?
+      options:
+        - "Yes, I agree"
+      multiple: true
+    validations:
+      required: true
   - type: markdown
     attributes:
       value: |

--- a/.github/ISSUE_TEMPLATE/security.yml
+++ b/.github/ISSUE_TEMPLATE/security.yml
@@ -9,21 +9,11 @@ body:
 
         1. For issues that are readily exploitable or have high impact, please email contact@micropython.org instead.
         1. If this is a question about security, please ask it in [Discussions](https://github.com/orgs/micropython/discussions/) or [Discord](https://discord.gg/RB8HZSAExQ) instead.
-  - type: checkboxes
-    id: terms
-    attributes:
-      label: Checks
-      description: |
-        Before submitting your bug report, please go over these check points:
-      options:
-      - label: |
-           I agree to follow the MicroPython [Code of Conduct](https://github.com/micropython/micropython/blob/master/CODEOFCONDUCT.md) to ensure a safe and respectful space for everyone.
-        required: true
-      - label: I wish to report a specific security issue that is **not readily exploitable and does not have high impact** for MicroPython developers or users.
-        required: true
-      - label: |
-          I've searched for [existing issues](https://github.com/micropython/micropython/issues) and didn't find any that matched.
-        required: true
+
+        #### Existing issue?
+
+        * Please search for [existing issues](https://github.com/micropython/micropython/issues) before reporting a new one.
+
   - type: input
     id: port-board-hw
     attributes:
@@ -55,5 +45,16 @@ body:
 
         * What does this issue allow an attacker to do?
         * How does the attacker exploit this issue?
+    validations:
+      required: true
+  - type: dropdown
+    id: code-of-conduct
+    attributes:
+      label: Code of Conduct
+      description: |
+        Do you agree to follow the MicroPython [Code of Conduct](https://github.com/micropython/micropython/blob/master/CODEOFCONDUCT.md) to ensure a safe and respectful space for everyone?
+      options:
+        - "Yes, I agree"
+      multiple: true
     validations:
       required: true


### PR DESCRIPTION
Update to the issue forms added in #13502, that seem to generally be working well.

These changes were raised by @dpgeorge, and have also been discussed with @jimmo who suggested the dropdowns.

* No longer generates TODO checklists in new issues.
* Issue bodies (and therefore email previews) no longer start with the same fixed checklist text for each new issue.

This branch is the default branch on my fork, can [preview the new forms here](https://github.com/projectgus/micropython/issues) (feel free to open more test issues.)

*This work was funded through GitHub Sponsors.*