### PR TITLE
rp2/boards/W5500_EVB_PICO: Update incorrect url in board.json.

### DIFF
--- a/ports/rp2/boards/W5500_EVB_PICO/board.json
+++ b/ports/rp2/boards/W5500_EVB_PICO/board.json
@@ -15,6 +15,6 @@
     "mcu": "rp2040",
     "product": "Wiznet W5500-EVB-Pico",
     "thumbnail": "",
-    "url": "https://www.wiznet.io/product-item/w5500-evb-pico/",
+    "url": "https://docs.wiznet.io/Product/iEthernet/W5500/w5500-evb-pico",
     "vendor": "Wiznet"
 }


### PR DESCRIPTION
Fix incorrect url as reported in #15122.