### PR TITLE
mpremote/transport_serial: Invert flow control settings on windows.

### DIFF
--- a/tools/mpremote/mpremote/transport_serial.py
+++ b/tools/mpremote/mpremote/transport_serial.py
@@ -84,10 +84,12 @@ class SerialTransport(Transport):
                     portinfo = list(serial.tools.list_ports.grep(device))  # type: ignore
                     if portinfo and portinfo[0].manufacturer != "Microsoft":
                         # ESP8266/ESP32 boards use RTS/CTS for flashing and boot mode selection.
-                        # DTR False: to avoid using the reset button will hang the MCU in bootloader mode
-                        # RTS False: to prevent pulses on rts on serial.close() that would POWERON_RESET an ESPxx
-                        self.serial.dtr = False  # DTR False = gpio0 High = Normal boot
-                        self.serial.rts = False  # RTS False = EN High = MCU enabled
+                        # When both lines are the same, no operation is performed on the esp.
+                        # Note: Both of these lines are "active low", so True here results on 0 on the line.
+                        # When DTR=True, RTS=False | DTR:0 / RTS:1 | IO0 is 0 (bootloader mode)
+                        # When DTR=False, RTS=True | DTR:1 / RTS:0 | EN is 0 (reset chip)
+                        self.serial.dtr = True
+                        self.serial.rts = True
                     self.serial.open()
                 else:
                     self.serial = serial.Serial(device, **serial_kwargs)


### PR DESCRIPTION
The RTS/DTR lines are being overrided for windows to stop esp  chips from resetting unexpectedly. 

The settings can conflict with other ports (eg. stm32) if they are not  using the standard "Microsoft" usbser driver by blocking the port due to it handling flow control in the normal way.

More information:
https://docs.espressif.com/projects/esptool/en/latest/esp32/advanced-topics/boot-mode-selection.html#automatic-bootloader

![image](https://github.com/micropython/micropython/assets/3318786/d55c4c17-bf78-4c74-876e-68a44b329e5a)

https://dl.espressif.com/dl/schematics/ESP32-Core-Board-V2_sch.pdf