### PR TITLE
ports/stm32: implement TX/RX inversion parameter for UART on STM32H7

### DIFF
--- a/ports/stm32/machine_uart.c
+++ b/ports/stm32/machine_uart.c
@@ -37,11 +37,20 @@
 #include "irq.h"
 #include "pendsv.h"
 
+#if defined(STM32H7)
+#define MICROPY_PY_MACHINE_UART_INV_ENTRY \
+    { MP_ROM_QSTR(MP_QSTR_INV_TX), MP_ROM_INT(UART_ADVFEATURE_TXINVERT_INIT) }, \
+    { MP_ROM_QSTR(MP_QSTR_INV_RX), MP_ROM_INT(UART_ADVFEATURE_RXINVERT_INIT) },
+#else
+#define MICROPY_PY_MACHINE_UART_INV_ENTRY
+#endif
+
 #define MICROPY_PY_MACHINE_UART_CLASS_CONSTANTS \
     { MP_ROM_QSTR(MP_QSTR_RTS), MP_ROM_INT(UART_HWCONTROL_RTS) }, \
     { MP_ROM_QSTR(MP_QSTR_CTS), MP_ROM_INT(UART_HWCONTROL_CTS) }, \
     { MP_ROM_QSTR(MP_QSTR_IRQ_RXIDLE), MP_ROM_INT(UART_FLAG_IDLE) }, \
     { MP_ROM_QSTR(MP_QSTR_IRQ_RX), MP_ROM_INT(UART_FLAG_RXNE) }, \
+    MICROPY_PY_MACHINE_UART_INV_ENTRY \
 
 static void mp_machine_uart_print(const mp_print_t *print, mp_obj_t self_in, mp_print_kind_t kind) {
     machine_uart_obj_t *self = MP_OBJ_TO_PTR(self_in);
@@ -125,11 +134,27 @@ static void mp_machine_uart_print(const mp_print_t *print, mp_obj_t self_in, mp_
         if (self->mp_irq_trigger != 0) {
             mp_printf(print, "; irq=0x%x", self->mp_irq_trigger);
         }
+        #if defined(STM32H7)
+        mp_print_str(print, ", invert=");
+        if (!(cr2 & (USART_CR2_TXINV | USART_CR2_RXINV))) {
+            mp_print_str(print, "0");
+        } else {
+            if (cr2 & USART_CR2_TXINV) {
+                mp_print_str(print, "INV_TX");
+                if (cr2 & USART_CR2_RXINV) {
+                    mp_print_str(print, "|");
+                }
+            }
+            if (cr2 & USART_CR2_RXINV) {
+                mp_print_str(print, "INV_RX");
+            }
+        }
+        #endif
         mp_print_str(print, ")");
     }
 }
 
-/// \method init(baudrate, bits=8, parity=None, stop=1, *, timeout=1000, timeout_char=0, flow=0, read_buf_len=64)
+/// \method init(baudrate, bits=8, parity=None, stop=1, *, timeout=1000, timeout_char=0, flow=0, read_buf_len=64, invert=0)
 ///
 /// Initialise the UART bus with the given parameters:
 ///
@@ -141,6 +166,7 @@ static void mp_machine_uart_print(const mp_print_t *print, mp_obj_t self_in, mp_
 ///   - `timeout_char` is the timeout in milliseconds to wait between characters.
 ///   - `flow` is RTS | CTS where RTS == 256, CTS == 512
 ///   - `read_buf_len` is the character length of the read buffer (0 to disable).
+///   - `invert` specifies which lines to invert. INV_TX | INV_RX (0 to disable). --> Only for STM32H7
 static void mp_machine_uart_init_helper(machine_uart_obj_t *self, size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
     static const mp_arg_t allowed_args[] = {
         { MP_QSTR_baudrate, MP_ARG_REQUIRED | MP_ARG_INT, {.u_int = 9600} },
@@ -152,11 +178,17 @@ static void mp_machine_uart_init_helper(machine_uart_obj_t *self, size_t n_args,
         { MP_QSTR_timeout_char, MP_ARG_KW_ONLY | MP_ARG_INT, {.u_int = 0} },
         { MP_QSTR_rxbuf, MP_ARG_KW_ONLY | MP_ARG_INT, {.u_int = -1} },
         { MP_QSTR_read_buf_len, MP_ARG_KW_ONLY | MP_ARG_INT, {.u_int = 64} }, // legacy
+        #if defined(STM32H7)
+        { MP_QSTR_invert, MP_ARG_KW_ONLY | MP_ARG_INT, {.u_int = 0} },
+        #endif
     };
 
     // parse args
     struct {
         mp_arg_val_t baudrate, bits, parity, stop, flow, timeout, timeout_char, rxbuf, read_buf_len;
+        #if defined(STM32H7)
+        mp_arg_val_t invert;
+        #endif
     } args;
     mp_arg_parse_all(n_args, pos_args, kw_args,
         MP_ARRAY_SIZE(allowed_args), allowed_args, (mp_arg_val_t *)&args);
@@ -202,11 +234,18 @@ static void mp_machine_uart_init_helper(machine_uart_obj_t *self, size_t n_args,
     // flow control
     uint32_t flow = args.flow.u_int;
 
+    // inverted
+    #if defined(STM32H7)
+    uint32_t invert = args.invert.u_int;
+    #else
+    uint32_t invert = 0;
+    #endif
+
     // Save attach_to_repl setting because uart_init will disable it.
     bool attach_to_repl = self->attached_to_repl;
 
     // init UART (if it fails, it's because the port doesn't exist)
-    if (!uart_init(self, baudrate, bits, parity, stop, flow)) {
+    if (!uart_init(self, baudrate, bits, parity, stop, flow, invert)) {
         mp_raise_msg_varg(&mp_type_ValueError, MP_ERROR_TEXT("UART(%d) doesn't exist"), self->uart_id);
     }
 

--- a/ports/stm32/main.c
+++ b/ports/stm32/main.c
@@ -502,7 +502,7 @@ void stm32_main(uint32_t reset_mode) {
     pyb_uart_repl_obj.is_static = true;
     pyb_uart_repl_obj.timeout = 0;
     pyb_uart_repl_obj.timeout_char = 2;
-    uart_init(&pyb_uart_repl_obj, MICROPY_HW_UART_REPL_BAUD, UART_WORDLENGTH_8B, UART_PARITY_NONE, UART_STOPBITS_1, 0);
+    uart_init(&pyb_uart_repl_obj, MICROPY_HW_UART_REPL_BAUD, UART_WORDLENGTH_8B, UART_PARITY_NONE, UART_STOPBITS_1, 0, 0);
     uart_set_rxbuf(&pyb_uart_repl_obj, sizeof(pyb_uart_repl_rxbuf), pyb_uart_repl_rxbuf);
     uart_attach_to_repl(&pyb_uart_repl_obj, true);
     MP_STATE_PORT(machine_uart_obj_all)[MICROPY_HW_UART_REPL - 1] = &pyb_uart_repl_obj;

--- a/ports/stm32/mpbthciport.c
+++ b/ports/stm32/mpbthciport.c
@@ -184,7 +184,7 @@ int mp_bluetooth_hci_uart_init(uint32_t port, uint32_t baudrate) {
     MP_STATE_PORT(machine_uart_obj_all)[mp_bluetooth_hci_uart_obj.uart_id - 1] = &mp_bluetooth_hci_uart_obj;
 
     // Initialise the UART.
-    uart_init(&mp_bluetooth_hci_uart_obj, baudrate, UART_WORDLENGTH_8B, UART_PARITY_NONE, UART_STOPBITS_1, UART_HWCONTROL_RTS | UART_HWCONTROL_CTS);
+    uart_init(&mp_bluetooth_hci_uart_obj, baudrate, UART_WORDLENGTH_8B, UART_PARITY_NONE, UART_STOPBITS_1, UART_HWCONTROL_RTS | UART_HWCONTROL_CTS, 0);
     uart_set_rxbuf(&mp_bluetooth_hci_uart_obj, sizeof(hci_uart_rxbuf), hci_uart_rxbuf);
 
     // Add IRQ handler for IDLE (i.e. packet finished).

--- a/ports/stm32/uart.c
+++ b/ports/stm32/uart.c
@@ -265,7 +265,7 @@ bool uart_exists(int uart_id) {
 
 // assumes Init parameters have been set up correctly
 bool uart_init(machine_uart_obj_t *uart_obj,
-    uint32_t baudrate, uint32_t bits, uint32_t parity, uint32_t stop, uint32_t flow) {
+    uint32_t baudrate, uint32_t bits, uint32_t parity, uint32_t stop, uint32_t flow, uint32_t invert) {
     USART_TypeDef *UARTx;
     IRQn_Type irqn;
     uint8_t uart_fn = AF_FN_UART;
@@ -675,6 +675,20 @@ bool uart_init(machine_uart_obj_t *uart_obj,
     huart.Init.OverSampling = UART_OVERSAMPLING_16;
     #if defined(STM32U5)
     huart.Init.ClockPrescaler = UART_PRESCALER_DIV16;
+    #endif
+
+    #if defined(STM32H7)
+    huart.AdvancedInit.AdvFeatureInit = (UART_ADVFEATURE_TXINVERT_INIT | UART_ADVFEATURE_RXINVERT_INIT);
+    if (invert & UART_ADVFEATURE_RXINVERT_INIT) {
+        huart.AdvancedInit.RxPinLevelInvert = UART_ADVFEATURE_RXINV_ENABLE;
+    } else {
+        huart.AdvancedInit.RxPinLevelInvert = UART_ADVFEATURE_RXINV_DISABLE;
+    }
+    if (invert & UART_ADVFEATURE_TXINVERT_INIT) {
+        huart.AdvancedInit.TxPinLevelInvert = UART_ADVFEATURE_TXINV_ENABLE;
+    } else {
+        huart.AdvancedInit.TxPinLevelInvert = UART_ADVFEATURE_TXINV_DISABLE;
+    }
     #endif
 
     #if defined(STM32G4) || defined(STM32H7) || defined(STM32N6) // WB also has a fifo..

--- a/ports/stm32/uart.h
+++ b/ports/stm32/uart.h
@@ -87,7 +87,7 @@ void uart_init0(void);
 void uart_deinit_all(void);
 bool uart_exists(int uart_id);
 bool uart_init(machine_uart_obj_t *uart_obj,
-    uint32_t baudrate, uint32_t bits, uint32_t parity, uint32_t stop, uint32_t flow);
+    uint32_t baudrate, uint32_t bits, uint32_t parity, uint32_t stop, uint32_t flow, uint32_t invert);
 void uart_irq_config(machine_uart_obj_t *self, bool enable);
 void uart_set_rxbuf(machine_uart_obj_t *self, size_t len, void *buf);
 void uart_deinit(machine_uart_obj_t *uart_obj);


### PR DESCRIPTION
On my board I am using a STM32H753 controller and needed the inversion feature for the UART which is not yet implemented in the STM32 port.
So I have implemented the missing keyword-only parameter `invert` for the `UART.init` function in accordance to the [docs](https://docs.micropython.org/en/latest/library/machine.UART.html#machine.UART).

- added constants `UART.INV_TX` and `UART.INV_RX` 
- added the new `invert` keyword parameter to the `uart_init` function.
- adapted the `uart_init` call in the main.c for the STM32H7 to the new function definition
- added `invert` setting to `uart_print` output

All changes apply for STM32H7 only. Due to define statements they have no effect for all other STM32 controllers.

I have tested the new Implementation on my STM32H753 succesfully.