### PR TITLE
rp2/modmachine: Use atomic section macros

### DIFF
--- a/ports/rp2/modmachine.c
+++ b/ports/rp2/modmachine.c
@@ -127,10 +127,10 @@ static void mp_machine_lightsleep(size_t n_args, const mp_obj_t *args) {
 
     const uint32_t xosc_hz = XOSC_MHZ * 1000000;
 
-    uint32_t my_interrupts = mp_thread_begin_atomic_section();
+    uint32_t my_interrupts = MICROPY_BEGIN_ATOMIC_SECTION();
     #if MICROPY_PY_NETWORK_CYW43
     if (cyw43_has_pending && cyw43_poll != NULL) {
-        mp_thread_end_atomic_section(my_interrupts);
+        MICROPY_END_ATOMIC_SECTION(my_interrupts);
         return;
     }
     #endif
@@ -196,7 +196,7 @@ static void mp_machine_lightsleep(size_t n_args, const mp_obj_t *args) {
 
     // Bring back all clocks.
     clocks_init();
-    mp_thread_end_atomic_section(my_interrupts);
+    MICROPY_END_ATOMIC_SECTION(my_interrupts);
 }
 
 NORETURN static void mp_machine_deepsleep(size_t n_args, const mp_obj_t *args) {


### PR DESCRIPTION
To avoid undefined references to
mp_thread_begin_atomic_section/mp_thread_end_atomic_section, replace them with the MICROPY_BEGIN_ATOMIC_SECTION / MICROPY_END_ATOMIC_SECTION macros. That way, the support for building with MICROPY_PY_THREAD disabled introduced by commit efa54c27b9ea ("rp2/mpconfigport: Allow MICROPY_PY_THREAD to be disabled by a board.") is useable again.

Fixes commit 19844b498306 ("rp2/modmachine: Prevent lock-up when lightsleep() called within thread.").