### PR TITLE
lib/libm/wf_[lt]gamma: Define _IEEE_LIBM only if not set.

### DIFF
--- a/lib/libm/wf_lgamma.c
+++ b/lib/libm/wf_lgamma.c
@@ -24,7 +24,9 @@
  */
 
 #include "fdlibm.h"
+#ifndef _IEEE_LIBM
 #define _IEEE_LIBM 1
+#endif
 
 #ifdef __STDC__
 	float lgammaf(float x)

--- a/lib/libm/wf_tgamma.c
+++ b/lib/libm/wf_tgamma.c
@@ -24,7 +24,9 @@
 
 #include "math.h"
 #include "fdlibm.h"
+#ifndef _IEEE_LIBM
 #define _IEEE_LIBM 1
+#endif
 
 #ifdef __STDC__
 	float tgammaf(float x)


### PR DESCRIPTION
fdilibm was originally meant to see _IEEE_LIBM defined from outside the libm code, not it being hardcoded in (see section 4 in https://netlib.org/fdlibm/readme).  Picolibc assumes this assumption holds true and attempts to define it itself, conflicting with the existing definition.

Although Picolibc provides its own libm support, on RISC-V the version of Picolibc installed on the CI machine currently crashes when running the math tests.  This is a stop-gap solution that would make things work until either a fix for the test crashes is found or a newer version of Picolibc is provided by the CI machine's package repository.

**Edit: Picolibc crashes due to its lgammaf implementation requiring TLS support enabled.**