### PR TITLE
shared/tinyusb: Allow ports to use 1200bps-touch without other CDC code.

### DIFF
--- a/ports/esp32/boards/ARDUINO_NANO_ESP32/board_init.c
+++ b/ports/esp32/boards/ARDUINO_NANO_ESP32/board_init.c
@@ -26,6 +26,7 @@
 
 #include <string.h>
 #include "py/mphal.h"
+#include "shared/tinyusb/mp_usbd_cdc.h"
 
 #include <esp_system.h>
 #include <esp_ota_ops.h>
@@ -87,7 +88,6 @@ void NANO_ESP32_enter_bootloader(void) {
 }
 
 void NANO_ESP32_usb_callback_line_state_changed(int itf, void *event_in) {
-    extern void mp_usbd_line_state_cb(uint8_t itf, bool dtr, bool rts);
     cdcacm_event_t *event = event_in;
     mp_usbd_line_state_cb(itf, event->line_state_changed_data.dtr, event->line_state_changed_data.rts);
 }

--- a/ports/esp32/usb.c
+++ b/ports/esp32/usb.c
@@ -79,7 +79,7 @@ void usb_init(void) {
         .callback_rx_wanted_char = &MICROPY_HW_USB_CUSTOM_RX_WANTED_CHAR_CB,
         #endif
         #ifdef MICROPY_HW_USB_CUSTOM_LINE_STATE_CB
-        .callback_line_state_changed = &MICROPY_HW_USB_CUSTOM_LINE_STATE_CB,
+        .callback_line_state_changed = (tusb_cdcacm_callback_t)&MICROPY_HW_USB_CUSTOM_LINE_STATE_CB,
         #endif
         #ifdef MICROPY_HW_USB_CUSTOM_LINE_CODING_CB
         .callback_line_coding_changed = &MICROPY_HW_USB_CUSTOM_LINE_CODING_CB,

--- a/ports/nrf/mpconfigport.h
+++ b/ports/nrf/mpconfigport.h
@@ -335,6 +335,7 @@ long unsigned int rng_generate_random_word(void);
 #if MICROPY_HW_USB_CDC
 #include "device/usbd.h"
 #define MICROPY_HW_USBDEV_TASK_HOOK extern void tud_task(void); tud_task();
+#define MICROPY_EXCLUDE_SHARED_TINYUSB_USBD_CDC (1)
 #else
 #define MICROPY_HW_USBDEV_TASK_HOOK ;
 #endif

--- a/shared/tinyusb/mp_usbd_cdc.c
+++ b/shared/tinyusb/mp_usbd_cdc.c
@@ -26,16 +26,13 @@
 
 #include "py/runtime.h"
 #include "py/mphal.h"
-#include "py/mpconfig.h"
 #include "py/stream.h"
 #include "extmod/modmachine.h"
 
-#if MICROPY_HW_USB_CDC && MICROPY_HW_ENABLE_USBDEV
-#include "tusb.h"
-#include "device/usbd.h"
-
-#include "mp_usbd_cdc.h"
 #include "mp_usbd.h"
+#include "mp_usbd_cdc.h"
+
+#if MICROPY_HW_USB_CDC && MICROPY_HW_ENABLE_USBDEV && !MICROPY_EXCLUDE_SHARED_TINYUSB_USBD_CDC
 
 static uint8_t cdc_itf_pending; // keep track of cdc interfaces which need attention to poll
 
@@ -122,6 +119,8 @@ mp_uint_t mp_usbd_cdc_tx_strn(const char *str, mp_uint_t len) {
     return i;
 }
 
+#endif
+
 #if MICROPY_HW_USB_CDC_1200BPS_TOUCH && MICROPY_HW_ENABLE_USBDEV
 
 static mp_sched_node_t mp_bootloader_sched_node;
@@ -149,5 +148,4 @@ tud_cdc_line_state_cb
     }
 }
 
-#endif
 #endif

--- a/shared/tinyusb/mp_usbd_cdc.h
+++ b/shared/tinyusb/mp_usbd_cdc.h
@@ -35,5 +35,8 @@ uintptr_t mp_usbd_cdc_poll_interfaces(uintptr_t poll_flags);
 void tud_cdc_rx_cb(uint8_t itf);
 mp_uint_t mp_usbd_cdc_tx_strn(const char *str, mp_uint_t len);
 
+#if MICROPY_HW_USB_EXTERNAL_TINYUSB
+void mp_usbd_line_state_cb(uint8_t itf, bool dtr, bool rts);
+#endif
 
 #endif // MICROPY_INCLUDED_SHARED_TINYUSB_MP_USBD_CDC_H


### PR DESCRIPTION
This fixes the build for some esp32 and nrf boards (for example `ARDUINO_NANO_33_BLE_SENSE` and `ARDUINO_NANO_ESP32`) due to commit c98789a6d8e05acb608afe4b30cf3ca563419b2d.  Changes are:

- Allow the CDC TX/RX functions in `mp_usbd_cdc.c` to be enabled separately to those needed for `MICROPY_HW_USB_CDC_1200BPS_TOUCH`.

- Add `MICROPY_EXCLUDE_SHARED_TINYUSB_USBD_CDC` option as a temporary workaround for the nrf port to use.

- Declare `mp_usbd_line_state_cb()` in a header as a public function.

- Fix warning with type cast of `.callback_line_state_changed`.