### PR TITLE
tools/metrics.py: Change rp2 board selection to RPI_PICO_W.

### DIFF
--- a/tools/ci.sh
+++ b/tools/ci.sh
@@ -55,7 +55,7 @@ function ci_code_size_setup {
 function ci_code_size_build {
     # check the following ports for the change in their code size
     PORTS_TO_CHECK=bmusxpd
-    SUBMODULES="lib/asf4 lib/berkeley-db-1.xx lib/mbedtls lib/micropython-lib lib/nxp_driver lib/pico-sdk lib/stm32lib lib/tinyusb"
+    SUBMODULES="lib/asf4 lib/berkeley-db-1.xx lib/btstack lib/cyw43-driver lib/lwip lib/mbedtls lib/micropython-lib lib/nxp_driver lib/pico-sdk lib/stm32lib lib/tinyusb"
 
     # starts off at either the ref/pull/N/merge FETCH_HEAD, or the current branch HEAD
     git checkout -b pull_request # save the current location

--- a/tools/metrics.py
+++ b/tools/metrics.py
@@ -69,7 +69,7 @@ port_data = {
     "x": PortData("mimxrt", "mimxrt", "build-TEENSY40/firmware.elf"),
     "e": PortData("renesas-ra", "renesas-ra", "build-EK_RA6M2/firmware.elf"),
     "r": PortData("nrf", "nrf", "build-PCA10040/firmware.elf"),
-    "p": PortData("rp2", "rp2", "build-RPI_PICO/firmware.elf"),
+    "p": PortData("rp2", "rp2", "build-RPI_PICO_W/firmware.elf", "BOARD=RPI_PICO_W"),
     "d": PortData("samd", "samd", "build-ADAFRUIT_ITSYBITSY_M4_EXPRESS/firmware.elf"),
 }
 


### PR DESCRIPTION
This tool is used to compute size differences in the firmware (eg as part of CI), but it doesn't currently check any firmware that has bare-metal lwIP/networking, making it hard to see how firmware size changes when networking related changes are made.

So, change the board selection for the rp2 port to RPI_PICO_W.  Changes in size to standard RPI_PICO firmware will be very similar to other bare-metal boards like PYBV10.