### PR TITLE
tools: Ensure codeformat.py uses uncrustify 0.72.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,6 @@ user.props
 
 # MacOS desktop metadata files
 .DS_Store
+
+# CI Tools
+tools/uncrustify

--- a/tools/ci.sh
+++ b/tools/ci.sh
@@ -21,8 +21,11 @@ function ci_gcc_arm_setup {
 # c code formatting
 
 function ci_c_code_formatting_setup {
-    sudo apt-get install uncrustify
-    uncrustify --version
+  wget https://github.com/uncrustify/uncrustify/archive/refs/tags/uncrustify-0.72.0.tar.gz
+  tar -xf uncrustify-0.72.0.tar.gz
+  cmake -B tools/uncrustify -S uncrustify-uncrustify-0.72.0
+  cmake --build tools/uncrustify -j
+  ./tools/uncrustify/uncrustify --version
 }
 
 function ci_c_code_formatting_run {

--- a/tools/codeformat.py
+++ b/tools/codeformat.py
@@ -171,7 +171,7 @@ def main():
 
     # Format C files with uncrustify.
     if format_c:
-        command = ["uncrustify", "-c", UNCRUSTIFY_CFG, "-lC", "--no-backup"]
+        command = ["./tools/uncrustify/uncrustify", "-c", UNCRUSTIFY_CFG, "-lC", "--no-backup"]
         if not args.v:
             command.append("-q")
         batch(command)


### PR DESCRIPTION
As identified in https://github.com/micropython/micropython/pull/14046 it's really easy to install a mismatched version of Uncrustify and format source in a way that the CI (which just installs whatever mystery meat Uncrustify apt cares to offer) disagrees with.

Eg: when I develop on macOS, brew installs Uncrustify-0.79.0_f.

This may also vary across Linux distributions, and is also prone to some future break if `runs-on: ubuntu-22.04` is ever changed.

This change is a proposal for installing Uncrustify in a consistent fashion, so that developers and CI get the same version, the same rules and the same output.