### PR TITLE
rp2/cyw43_configport: Make cyw43_delay_ms() a busy loop.

### DIFF
--- a/ports/rp2/cyw43_configport.h
+++ b/ports/rp2/cyw43_configport.h
@@ -117,7 +117,12 @@ static inline void cyw43_delay_us(uint32_t us) {
 }
 
 static inline void cyw43_delay_ms(uint32_t ms) {
-    mp_hal_delay_ms(ms);
+    // PendSV may be disabled via CYW43_THREAD_ENTER, so this delay is a busy loop.
+    uint32_t us = ms * 1000;
+    uint32_t start = mp_hal_ticks_us();
+    while (mp_hal_ticks_us() - start < us) {
+        mp_event_handle_nowait();
+    }
 }
 
 #define CYW43_EVENT_POLL_HOOK mp_event_handle_nowait()


### PR DESCRIPTION
Currently, `cyw43_delay_ms()` calls `mp_hal_delay_ms()` which uses PendSV to set up a timer and wait for an interrupt, using wfe.  But in the cyw43 initialisation stage PendSV is disabled and so this delay suspends on the wfe instruction for an indefinite amount of time.

Work around this by changing the implementation of `cyw43_delay_ms()` to a busy loop.

Fixes issue #15220.