### PR TITLE
extmod/modplatform: Add picolibc to the recognised libcs list.

### DIFF
--- a/extmod/modplatform.h
+++ b/extmod/modplatform.h
@@ -83,6 +83,9 @@
 #elif defined(__NEWLIB__)
 #define MICROPY_PLATFORM_LIBC_LIB       "newlib"
 #define MICROPY_PLATFORM_LIBC_VER       _NEWLIB_VERSION
+#elif defined(_PICOLIBC__)
+#define MICROPY_PLATFORM_LIBC_LIB       "picolibc"
+#define MICROPY_PLATFORM_LIBC_VER       _PICOLIBC_VERSION
 #else
 #define MICROPY_PLATFORM_LIBC_LIB       ""
 #define MICROPY_PLATFORM_LIBC_VER       ""


### PR DESCRIPTION
Picolibc was not yet recognised by the `platform` module, this PR adds it to the known libc implementations MicroPython knows about.