### PR TITLE
github: Add Pull Request template.

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,33 @@
+<!-- Thanks for submitting a Pull Request! We appreciate you spending the
+     time to improve MicroPython. Please provide enough information so that
+     others can review your Pull Request.
+
+     Before submitting, please read:
+     https://github.com/micropython/micropython/blob/master/CODEOFCONDUCT.md
+     https://github.com/micropython/micropython/wiki/ContributorGuidelines
+
+     Please check any CI failures that appear after your Pull Request is opened.
+-->
+
+### Summary
+
+<!-- Explain the reason for making this change. What problem does the pull request
+     solve, or what improvement does it add? Add links if relevant. -->
+
+
+### Testing
+
+<!-- Explain what testing you did, and on which boards/ports. If there are
+     boards or ports that you couldn't test, please mention this here as well.
+
+     If you leave this empty then your Pull Request may be closed. -->
+
+
+### Trade-offs and Alternatives
+
+<!-- If the Pull Request has some negative impact (i.e. increased code size)
+     then please explain why you think the trade-off improvement is worth it.
+     If you can think of alternative ways to do this, please explain that here too.
+
+     Delete this heading if not relevant (i.e. small fixes) -->
+


### PR DESCRIPTION
### Summary

Provides pull request submitters with contributor documentation, and prompts them to provide relevant information about testing, and trade-offs or alternatives to their change.

Sections are deliberately small so they don't crowd out the space available in the GitHub Pull Request description text field.

### Testing

I've set the template as the default branch on my fork, so clicking through the following link allows testing it out:
https://github.com/projectgus/micropython/compare/master...projectgus:micropython:github/pr_template

### Trade-offs and Alternatives

There's a trade-off between explaining everything in the template, has chance it is "TLDR" ignored or a submitter accidentally submits their text inside one of the long HTML comments (although a maintainer can fix that formatting easily).

Some projects, for [example vscode](https://raw.githubusercontent.com/microsoft/vscode/main/.github/pull_request_template.md), have a really short template that probably helps with that.

I think it is worth keeping some detail in the MicroPython template, though, particularly if it means less back and forth to find out about testing or the reason for making a change.