### PR TITLE
extmod/machine_usb_device: Add remote_wakeup.

### DIFF
--- a/docs/library/machine.USBDevice.rst
+++ b/docs/library/machine.USBDevice.rst
@@ -215,6 +215,13 @@ Methods
      drivers. Placing a different string at any of these indexes overrides that
      string in the built-in driver.
 
+.. method:: USBDevice.remote_wakeup(self)
+
+    Wake up host if we are in suspend mode and the REMOTE_WAKEUP feature
+    is enabled by the host. This has to be enabled in the USB attributes,
+    and on the host. Returns ``True`` if remote wakeup was enabled and
+    active and the host was woken up.
+
 .. method:: USBDevice.submit_xfer(self, ep, buffer /)
 
             Submit a USB transfer on endpoint number ``ep``. ``buffer`` must be

--- a/extmod/machine_usb_device.c
+++ b/extmod/machine_usb_device.c
@@ -157,6 +157,11 @@ static mp_obj_t usb_device_active(size_t n_args, const mp_obj_t *args) {
 }
 static MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(usb_device_active_obj, 1, 2, usb_device_active);
 
+static mp_obj_t usb_remote_wakeup(mp_obj_t self) {
+    return mp_obj_new_bool(tud_remote_wakeup());
+}
+static MP_DEFINE_CONST_FUN_OBJ_1(usb_remote_wakeup_obj, usb_remote_wakeup);
+
 static mp_obj_t usb_device_stall(size_t n_args, const mp_obj_t *args) {
     mp_obj_usb_device_t *self = (mp_obj_usb_device_t *)MP_OBJ_TO_PTR(args[0]);
     int epnum = mp_obj_get_int(args[1]);
@@ -272,6 +277,7 @@ static const mp_rom_map_elem_t usb_device_locals_dict_table[] = {
     { MP_ROM_QSTR(MP_QSTR_submit_xfer), MP_ROM_PTR(&usb_device_submit_xfer_obj) },
     { MP_ROM_QSTR(MP_QSTR_active), MP_ROM_PTR(&usb_device_active_obj) },
     { MP_ROM_QSTR(MP_QSTR_stall), MP_ROM_PTR(&usb_device_stall_obj) },
+    { MP_ROM_QSTR(MP_QSTR_remote_wakeup), MP_ROM_PTR(&usb_remote_wakeup_obj) },
 
     // Built-in driver constants
     { MP_ROM_QSTR(MP_QSTR_BUILTIN_NONE), MP_ROM_PTR(&mp_type_usb_device_builtin_none) },


### PR DESCRIPTION
I'm using usb-"remote_wakeup" on one of my projects and adding it to the existing usb_device implementation was just a matter of exposing the tusb-funcion and a tiny addition to micropython lib to allow setting the attribute indicating support, here:

https://github.com/micropython/micropython-lib/blob/50ed36fbeb919753bcc26ce13a8cffd7691d06ef/micropython/usb/usb-device/usb/device/core.py#L192

@projectgus, maybe you're interested.