### PR TITLE
tests/thread: Restore gc before test case ends.

### DIFF
--- a/tests/thread/stress_schedule.py
+++ b/tests/thread/stress_schedule.py
@@ -52,6 +52,8 @@ while n < _NUM_TASKS and time.ticks_diff(time.ticks_ms(), t) < _TIMEOUT_MS:
 thread_run = False
 time.sleep_ms(20)
 
+gc.enable()
+
 if n < _NUM_TASKS:
     # Not all the tasks were scheduled, likely the scheduler stopped working.
     print(n)


### PR DESCRIPTION
## Summary

Otherwise GC stays disabled (not re-enabled by soft reset) and later test runs fail with MemoryError.

Note this test case is currently disabled in CI due to "reliability issues" (as of 02b44a0154). Not sure if this is the root cause of the issue in question.

## Testing

* Tested on rp2 port and verified subsequent test failures went away.
* Also re-ran tests on unix port with `run-tests.py -d thread`, but no change expected here as a new micropython process is run for each test file.

## Trade-offs and Alternatives

We could have soft reset re-enable automatic gc, instead? Would be more resilient than this fix, but might have other implications.