### PR TITLE
extmod/modplatform: Expose CPU features/extensions.

### DIFF
--- a/docs/library/platform.rst
+++ b/docs/library/platform.rst
@@ -36,3 +36,11 @@ Functions
    Returns a tuple of strings *(lib, version)*, where *lib* is the name of the
    libc that MicroPython is linked to, and *version* the corresponding version
    of this libc.
+
+.. function:: processor()
+
+   Returns a string with a detailed name of the processor, if one is available.
+   If no name for the processor is known, it will return an empty string
+   instead.
+
+   This is currently available only on RISC-V targets (both 32 and 64 bits).


### PR DESCRIPTION
This PR adds the ability to expose CPU-specific features/extensions to scripts when the `platform` module is compiled in.

Right now this is only available on RISC-V RV32, but I looked into extending it for other architectures.  Some Cortex CPUs have a pair of registers called `ID_PFR` but no flags are defined in CMSIS.  For x86/x64 accessing those flags would be OS-dependent, but still doable if you limit yourself to Linux and Windows.  Finally, for Aarch64 the `ID_AA64PFR` registers have documented flags, but I have no Armv8 to test an eventual implementation on.

The function name is still somewhat tentative as different architectures may have different names for the same thing after all.

For RISC-V, it is not implemented as a singleton with precomputed values like other functions in the `platform` module because it is technically possible to disable extensions by clearing the bits in the MISA special register rather than reading them.