### PR TITLE
tests/extmod/machine_timer: Fix tests.

### DIFF
--- a/tests/extmod/machine_timer.py
+++ b/tests/extmod/machine_timer.py
@@ -9,30 +9,30 @@ except:
     raise SystemExit
 
 # create and deinit
-t = machine.Timer(freq=1)
+t = machine.Timer(0, freq=1)
 t.deinit()
 
 # deinit again
 t.deinit()
 
 # create 2 and deinit
-t = machine.Timer(freq=1)
-t2 = machine.Timer(freq=1)
+t = machine.Timer(0, freq=1)
+t2 = machine.Timer(1, freq=1)
 t.deinit()
 t2.deinit()
 
 # create 2 and deinit in different order
-t = machine.Timer(freq=1)
-t2 = machine.Timer(freq=1)
+t = machine.Timer(0, freq=1)
+t2 = machine.Timer(1, freq=1)
 t2.deinit()
 t.deinit()
 
 # create one-shot timer with callback and wait for it to print (should be just once)
-t = machine.Timer(period=1, mode=machine.Timer.ONE_SHOT, callback=lambda t: print("one-shot"))
+t = machine.Timer(0, period=1, mode=machine.Timer.ONE_SHOT, callback=lambda t: print("one-shot"))
 time.sleep_ms(5)
 t.deinit()
 
 # create periodic timer with callback and wait for it to print
-t = machine.Timer(period=4, mode=machine.Timer.PERIODIC, callback=lambda t: print("periodic"))
+t = machine.Timer(0, period=4, mode=machine.Timer.PERIODIC, callback=lambda t: print("periodic"))
 time.sleep_ms(14)
 t.deinit()


### PR DESCRIPTION
`machine.Timer` requires a timer id in its constructor, which was not passed when building objects.

This PR makes the test pass on an ESP32C3 at least, as it would consistently fail before.