### PR TITLE
extmod/modframebuf.c: handle read-only storage types.

### DIFF
--- a/examples/natmod/framebuf/framebuf.c
+++ b/examples/natmod/framebuf/framebuf.c
@@ -10,6 +10,7 @@ void *memset(void *s, int c, size_t n) {
 #endif
 
 mp_obj_full_type_t mp_type_framebuf;
+mp_obj_full_type_t mp_type_staticbuf;
 
 #include "extmod/modframebuf.c"
 

--- a/extmod/modframebuf.c
+++ b/extmod/modframebuf.c
@@ -44,6 +44,7 @@ typedef struct _mp_obj_framebuf_t {
 
 #if !MICROPY_ENABLE_DYNRUNTIME
 static const mp_obj_type_t mp_type_framebuf;
+static const mp_obj_type_t mp_type_staticbuf;
 #endif
 
 typedef void (*setpixel_t)(const mp_obj_framebuf_t *, unsigned int, unsigned int, uint32_t);
@@ -231,6 +232,18 @@ static void gs8_fill_rect(const mp_obj_framebuf_t *fb, unsigned int x, unsigned 
     }
 }
 
+static mp_obj_t get_framebuf_or_staticbuf(mp_obj_t buf_in) {
+    mp_obj_t buf_out;
+    buf_out = mp_obj_cast_to_native_base(buf_in, MP_OBJ_FROM_PTR(&mp_type_framebuf));
+    if (buf_out == MP_OBJ_NULL) {
+        buf_out = mp_obj_cast_to_native_base(buf_in, MP_OBJ_FROM_PTR(&mp_type_staticbuf));
+    }
+    if (buf_out == MP_OBJ_NULL) {
+        mp_raise_TypeError(NULL);
+    }
+    return buf_out;
+}
+
 static mp_framebuf_p_t formats[] = {
     [FRAMEBUF_MVLSB] = {mvlsb_setpixel, mvlsb_getpixel, mvlsb_fill_rect},
     [FRAMEBUF_RGB565] = {rgb565_setpixel, rgb565_getpixel, rgb565_fill_rect},
@@ -318,7 +331,13 @@ static mp_obj_t framebuf_make_new(const mp_obj_type_t *type, size_t n_args, size
     }
 
     mp_buffer_info_t bufinfo;
-    mp_get_buffer_raise(args_in[0], &bufinfo, MP_BUFFER_WRITE);
+    bool status = mp_get_buffer(args_in[0], &bufinfo, MP_BUFFER_WRITE);
+    if (!status) {
+        mp_get_buffer_raise(args_in[0], &bufinfo, MP_BUFFER_READ);
+        if (type != (mp_obj_type_t *)&mp_type_staticbuf) {
+            mp_raise_ValueError(MP_ERROR_TEXT("buffer must be writable"));
+        }
+    }
 
     if ((strides_required * stride + (height_required - strides_required) * width_required) * bpp / 8 > bufinfo.len) {
         mp_raise_ValueError(NULL);
@@ -709,10 +728,7 @@ static MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(framebuf_poly_obj, 5, 6, framebuf_pol
 
 static mp_obj_t framebuf_blit(size_t n_args, const mp_obj_t *args_in) {
     mp_obj_framebuf_t *self = MP_OBJ_TO_PTR(args_in[0]);
-    mp_obj_t source_in = mp_obj_cast_to_native_base(args_in[1], MP_OBJ_FROM_PTR(&mp_type_framebuf));
-    if (source_in == MP_OBJ_NULL) {
-        mp_raise_TypeError(NULL);
-    }
+    mp_obj_t source_in = get_framebuf_or_staticbuf(args_in[1]);
     mp_obj_framebuf_t *source = MP_OBJ_TO_PTR(source_in);
 
     mp_int_t x = mp_obj_get_int(args_in[2]);
@@ -723,7 +739,8 @@ static mp_obj_t framebuf_blit(size_t n_args, const mp_obj_t *args_in) {
     }
     mp_obj_framebuf_t *palette = NULL;
     if (n_args > 5 && args_in[5] != mp_const_none) {
-        palette = MP_OBJ_TO_PTR(mp_obj_cast_to_native_base(args_in[5], MP_OBJ_FROM_PTR(&mp_type_framebuf)));
+        mp_obj_t palette_in = get_framebuf_or_staticbuf(args_in[5]);
+        palette = MP_OBJ_TO_PTR(palette_in);
     }
 
     if (
@@ -871,6 +888,14 @@ static MP_DEFINE_CONST_OBJ_TYPE(
     buffer, framebuf_get_buffer,
     locals_dict, &framebuf_locals_dict
     );
+
+static MP_DEFINE_CONST_OBJ_TYPE(
+    mp_type_staticbuf,
+    MP_QSTR_StaticBuffer,
+    MP_TYPE_FLAG_NONE,
+    make_new, framebuf_make_new,
+    buffer, framebuf_get_buffer
+    );
 #endif
 
 #if !MICROPY_ENABLE_DYNRUNTIME
@@ -886,6 +911,7 @@ static const mp_rom_map_elem_t framebuf_module_globals_table[] = {
     { MP_ROM_QSTR(MP_QSTR___name__), MP_ROM_QSTR(MP_QSTR_framebuf) },
     { MP_ROM_QSTR(MP_QSTR_FrameBuffer), MP_ROM_PTR(&mp_type_framebuf) },
     { MP_ROM_QSTR(MP_QSTR_FrameBuffer1), MP_ROM_PTR(&legacy_framebuffer1_obj) },
+    { MP_ROM_QSTR(MP_QSTR_StaticBuffer), MP_ROM_PTR(&mp_type_staticbuf) },
     { MP_ROM_QSTR(MP_QSTR_MVLSB), MP_ROM_INT(FRAMEBUF_MVLSB) },
     { MP_ROM_QSTR(MP_QSTR_MONO_VLSB), MP_ROM_INT(FRAMEBUF_MVLSB) },
     { MP_ROM_QSTR(MP_QSTR_RGB565), MP_ROM_INT(FRAMEBUF_RGB565) },

--- a/tests/extmod/framebuf_buffer.py
+++ b/tests/extmod/framebuf_buffer.py
@@ -1,0 +1,20 @@
+try:
+    import framebuf
+except ImportError:
+    print("SKIP")
+    raise SystemExit
+
+
+def test_constructor(*args):
+    try:
+        framebuf.FrameBuffer(*args)
+        print("Valid")
+    except ValueError:
+        print("ValueError")
+
+
+print("bytearray")
+test_constructor(bytearray(64), 8, 8, framebuf.GS8)
+
+print("bytes")
+test_constructor(bytes(64), 8, 8, framebuf.GS8)

--- a/tests/extmod/framebuf_buffer.py.exp
+++ b/tests/extmod/framebuf_buffer.py.exp
@@ -1,0 +1,4 @@
+bytearray
+Valid
+bytes
+ValueError


### PR DESCRIPTION
Edit: ignore this, skip to https://github.com/micropython/micropython/pull/15285#issuecomment-2171119725

Handle a FrameBuffer wrapper around a read-only type, such as bytes() frozen as bytecode.

This is an extremely crude attempt at supporting the use-case described in #15275 without having every single method on FrameBuffer have to check the writability of the underlying storage buffer.

I don't particularly like this solution, but I'm raising it as a PR to hopefully promote discussion about how this kind of (very valid in my opinion) use case can be solved.

Between 32blit, PicoSystem and PicoGraphics I have some not-trivial experience dealing with graphics and asset conversion on embedded platforms, but most of these are rather more complex and wider in scope than MicroPython's FrameBuffer.

Some tests:

```python
from framebuf import FrameBuffer, GS8

buf = FrameBuffer(bytes(25), 5, 5, GS8)

print(dir(buf))

buf2 = FrameBuffer(bytearray(bytes(25)), 5, 5, GS8)

print(dir(buf2))

buf2.blit(buf, 0, 0)
buf.blit(buf2, 0, 0)
```

Outputs:

```
./build-standard/micropython test.py 
['__class__', 'blit', 'ellipse', 'fill', 'fill_rect', 'hline', 'line', 'pixel', 'poly', 'rect', 'scroll', 'text', 'vline']
['__class__', 'blit', 'ellipse', 'fill', 'fill_rect', 'hline', 'line', 'pixel', 'poly', 'rect', 'scroll', 'text', 'vline']
Traceback (most recent call last):
  File "test.py", line 12, in <module>
TypeError: read-only
```

Other potential solutions:

* Expand `blit` to accept raw bytes
* Add a `raw_blit` to do what blit does, using faster scanline copies, from raw bytes