### PR TITLE
webassembly: Support top-level await of asyncio Task and Event.

### DIFF
--- a/ports/webassembly/modjsffi.c
+++ b/ports/webassembly/modjsffi.c
@@ -63,20 +63,6 @@ static mp_obj_t mp_jsffi_to_js(mp_obj_t arg) {
 static MP_DEFINE_CONST_FUN_OBJ_1(mp_jsffi_to_js_obj, mp_jsffi_to_js);
 
 // *FORMAT-OFF*
-EM_JS(void, promise_with_timeout_ms, (double ms, uint32_t * out), {
-    const ret = new Promise((resolve) => setTimeout(resolve, ms));
-    proxy_convert_js_to_mp_obj_jsside(ret, out);
-});
-// *FORMAT-ON*
-
-static mp_obj_t mp_jsffi_async_timeout_ms(mp_obj_t arg) {
-    uint32_t out[PVN];
-    promise_with_timeout_ms(mp_obj_get_float_to_d(arg), out);
-    return proxy_convert_js_to_mp_obj_cside(out);
-}
-static MP_DEFINE_CONST_FUN_OBJ_1(mp_jsffi_async_timeout_ms_obj, mp_jsffi_async_timeout_ms);
-
-// *FORMAT-OFF*
 EM_JS(void, js_get_proxy_js_ref_info, (uint32_t * out), {
     let used = 0;
     for (const elem of proxy_js_ref) {
@@ -121,7 +107,6 @@ static const mp_rom_map_elem_t mp_module_jsffi_globals_table[] = {
     { MP_ROM_QSTR(MP_QSTR_JsException), MP_ROM_PTR(&mp_type_JsException) },
     { MP_ROM_QSTR(MP_QSTR_create_proxy), MP_ROM_PTR(&mp_jsffi_create_proxy_obj) },
     { MP_ROM_QSTR(MP_QSTR_to_js), MP_ROM_PTR(&mp_jsffi_to_js_obj) },
-    { MP_ROM_QSTR(MP_QSTR_async_timeout_ms), MP_ROM_PTR(&mp_jsffi_async_timeout_ms_obj) },
     { MP_ROM_QSTR(MP_QSTR_mem_info), MP_ROM_PTR(&mp_jsffi_mem_info_obj) },
 };
 static MP_DEFINE_CONST_DICT(mp_module_jsffi_globals, mp_module_jsffi_globals_table);

--- a/ports/webassembly/qstrdefsport.h
+++ b/ports/webassembly/qstrdefsport.h
@@ -1,3 +1,4 @@
 // qstrs specific to this port
 // *FORMAT-OFF*
 Q(/lib)
+Q(asyncio.core)

--- a/tests/ports/webassembly/asyncio_top_level_await.mjs
+++ b/tests/ports/webassembly/asyncio_top_level_await.mjs
@@ -1,0 +1,25 @@
+// Test top-level await on asyncio primitives: Task, Event.
+
+const mp = await (await import(process.argv[2])).loadMicroPython();
+
+await mp.runPythonAsync(`
+import asyncio
+
+async def task(event):
+    print("task set event")
+    event.set()
+    print("task sleep")
+    await asyncio.sleep(0.1)
+    print("task end")
+
+event = asyncio.Event()
+t = asyncio.create_task(task(event))
+
+print("top-level wait event")
+await event.wait()
+print("top-level wait task")
+await t
+print("top-level end")
+`);
+
+console.log("finished");

--- a/tests/ports/webassembly/asyncio_top_level_await.mjs.exp
+++ b/tests/ports/webassembly/asyncio_top_level_await.mjs.exp
@@ -1,0 +1,7 @@
+top-level wait event
+task set event
+task sleep
+top-level wait task
+task end
+top-level end
+finished


### PR DESCRIPTION
This change allows doing a top-level await on an asyncio primitive like Task and Event.

This feature enables a better interaction and synchronisation between JavaScript and Python, because `api.runPythonAsync` can now be used (called from JavaScript) to await on the completion of asyncio primitives.