### PR TITLE
rp2: Fix USB PLL glitch during wake from light sleep.

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -73,6 +73,7 @@ used during the build process and is not part of the compiled source code.
             /ppp_set_auth.* (Apache-2.0)
         /rp2
             /mutex_extra.c (BSD-3-clause)
+            /clocks_extra.c (BSD-3-clause)
         /stm32
             /usbd*.c (MCD-ST Liberty SW License Agreement V2)
             /stm32_it.* (MIT + BSD-3-clause)

--- a/ports/rp2/CMakeLists.txt
+++ b/ports/rp2/CMakeLists.txt
@@ -117,6 +117,7 @@ set(MICROPY_SOURCE_DRIVERS
 )
 
 set(MICROPY_SOURCE_PORT
+    clocks_extra.c
     fatfs_port.c
     help.c
     machine_bitstream.c
@@ -453,6 +454,7 @@ target_compile_options(${MICROPY_TARGET} PRIVATE
 target_link_options(${MICROPY_TARGET} PRIVATE
     -Wl,--defsym=__micropy_c_heap_size__=${MICROPY_C_HEAP_SIZE}
     -Wl,--wrap=dcd_event_handler
+    -Wl,--wrap=clocks_init
 )
 
 # Apply optimisations to performance-critical source code.

--- a/ports/rp2/clocks_extra.c
+++ b/ports/rp2/clocks_extra.c
@@ -1,0 +1,102 @@
+/*
+ * Copyright (c) 2020 Raspberry Pi (Trading) Ltd.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+#include "pico.h"
+#include "clocks_extra.h"
+#include "hardware/regs/clocks.h"
+#include "hardware/platform_defs.h"
+#include "hardware/clocks.h"
+#include "hardware/watchdog.h"
+#include "hardware/pll.h"
+#include "hardware/xosc.h"
+#include "hardware/irq.h"
+#include "hardware/gpio.h"
+
+#define RTC_CLOCK_FREQ_HZ       (USB_CLK_KHZ * KHZ / 1024)
+
+// Wrap the SDK's clocks_init() function to save code size
+void __wrap_clocks_init(void) {
+    clocks_init_optional_usb(true);
+}
+
+// Copy of clocks_init() from pico-sdk, with USB
+// PLL and clock init made optional (for light sleep wakeup).
+void clocks_init_optional_usb(bool init_usb) {
+    // Start tick in watchdog, the argument is in 'cycles per microsecond' i.e. MHz
+    watchdog_start_tick(XOSC_KHZ / KHZ);
+
+    // Modification: removed FPGA check here
+
+    // Disable resus that may be enabled from previous software
+    clocks_hw->resus.ctrl = 0;
+
+    // Enable the xosc
+    xosc_init();
+
+    // Before we touch PLLs, switch sys and ref cleanly away from their aux sources.
+    hw_clear_bits(&clocks_hw->clk[clk_sys].ctrl, CLOCKS_CLK_SYS_CTRL_SRC_BITS);
+    while (clocks_hw->clk[clk_sys].selected != 0x1) {
+        tight_loop_contents();
+    }
+    hw_clear_bits(&clocks_hw->clk[clk_ref].ctrl, CLOCKS_CLK_REF_CTRL_SRC_BITS);
+    while (clocks_hw->clk[clk_ref].selected != 0x1) {
+        tight_loop_contents();
+    }
+
+    /// \tag::pll_init[]
+    pll_init(pll_sys, PLL_COMMON_REFDIV, PLL_SYS_VCO_FREQ_KHZ * KHZ, PLL_SYS_POSTDIV1, PLL_SYS_POSTDIV2);
+    if (init_usb) {
+        pll_init(pll_usb, PLL_COMMON_REFDIV, PLL_USB_VCO_FREQ_KHZ * KHZ, PLL_USB_POSTDIV1, PLL_USB_POSTDIV2);
+    }
+    /// \end::pll_init[]
+
+    // Configure clocks
+    // CLK_REF = XOSC (usually) 12MHz / 1 = 12MHz
+    clock_configure(clk_ref,
+        CLOCKS_CLK_REF_CTRL_SRC_VALUE_XOSC_CLKSRC,
+        0,             // No aux mux
+        XOSC_KHZ * KHZ,
+        XOSC_KHZ * KHZ);
+
+    /// \tag::configure_clk_sys[]
+    // CLK SYS = PLL SYS (usually) 125MHz / 1 = 125MHz
+    clock_configure(clk_sys,
+        CLOCKS_CLK_SYS_CTRL_SRC_VALUE_CLKSRC_CLK_SYS_AUX,
+        CLOCKS_CLK_SYS_CTRL_AUXSRC_VALUE_CLKSRC_PLL_SYS,
+        SYS_CLK_KHZ * KHZ,
+        SYS_CLK_KHZ * KHZ);
+    /// \end::configure_clk_sys[]
+
+    if (init_usb) {
+        // CLK USB = PLL USB 48MHz / 1 = 48MHz
+        clock_configure(clk_usb,
+            0, // No GLMUX
+            CLOCKS_CLK_USB_CTRL_AUXSRC_VALUE_CLKSRC_PLL_USB,
+            USB_CLK_KHZ * KHZ,
+            USB_CLK_KHZ * KHZ);
+    }
+
+    // CLK ADC = PLL USB 48MHZ / 1 = 48MHz
+    clock_configure(clk_adc,
+        0,             // No GLMUX
+        CLOCKS_CLK_ADC_CTRL_AUXSRC_VALUE_CLKSRC_PLL_USB,
+        USB_CLK_KHZ * KHZ,
+        USB_CLK_KHZ * KHZ);
+
+    // CLK RTC = PLL USB 48MHz / 1024 = 46875Hz
+    clock_configure(clk_rtc,
+        0,             // No GLMUX
+        CLOCKS_CLK_RTC_CTRL_AUXSRC_VALUE_CLKSRC_PLL_USB,
+        USB_CLK_KHZ * KHZ,
+        RTC_CLOCK_FREQ_HZ);
+
+    // CLK PERI = clk_sys. Used as reference clock for Peripherals. No dividers so just select and enable
+    // Normally choose clk_sys or clk_usb
+    clock_configure(clk_peri,
+        0,
+        CLOCKS_CLK_PERI_CTRL_AUXSRC_VALUE_CLK_SYS,
+        SYS_CLK_KHZ * KHZ,
+        SYS_CLK_KHZ * KHZ);
+}

--- a/ports/rp2/clocks_extra.h
+++ b/ports/rp2/clocks_extra.h
@@ -1,0 +1,33 @@
+/*
+ * This file is part of the MicroPython project, http://micropython.org/
+ *
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2024 Angus Gratton
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+#ifndef MICROPY_INCLUDED_RP2_CLOCKS_EXTRA_H
+#define MICROPY_INCLUDED_RP2_CLOCKS_EXTRA_H
+
+#include "hardware/clocks.h"
+
+void clocks_init_optional_usb(bool init_usb);
+
+#endif // MICROPY_INCLUDED_RP2_CLOCKS_EXTRA_H

--- a/ports/rp2/modmachine.c
+++ b/ports/rp2/modmachine.c
@@ -31,7 +31,7 @@
 #include "mp_usbd.h"
 #include "modmachine.h"
 #include "uart.h"
-#include "hardware/clocks.h"
+#include "clocks_extra.h"
 #include "hardware/pll.h"
 #include "hardware/structs/rosc.h"
 #include "hardware/structs/scb.h"
@@ -213,7 +213,7 @@ static void mp_machine_lightsleep(size_t n_args, const mp_obj_t *args) {
     rosc_hw->ctrl = ROSC_CTRL_ENABLE_VALUE_ENABLE << ROSC_CTRL_ENABLE_LSB;
 
     // Bring back all clocks.
-    clocks_init();
+    clocks_init_optional_usb(disable_usb);
     MICROPY_END_ATOMIC_SECTION(my_interrupts);
 }
 

--- a/ports/rp2/modmachine.c
+++ b/ports/rp2/modmachine.c
@@ -138,7 +138,8 @@ static void mp_machine_lightsleep(size_t n_args, const mp_obj_t *args) {
 
     #if MICROPY_HW_ENABLE_USBDEV
     // Only disable the USB clock if a USB host has not configured the device
-    bool disable_usb = !tud_mounted();
+    // or if going to DORMANT mode.
+    bool disable_usb = !(tud_mounted() && n_args > 0);
     #else
     bool disable_usb = true;
     #endif

--- a/tests/ports/rp2/rp2_lightsleep.py
+++ b/tests/ports/rp2/rp2_lightsleep.py
@@ -1,0 +1,31 @@
+# This test is mostly intended for ensuring USB serial stays stable over
+# lightsleep, but can double as a general lightsleep test.
+#
+# In theory this should run on any port, but native USB REPL doesn't currently
+# recover automatically on all ports. On pyboard and ESP32-S3 the host needs to
+# send something to the port before it responds again. Possibly the same for other
+# ports with native USB.
+#
+# A range of sleep periods (1 to 512ms) are tested. The total nominal sleep time
+# is 10.23 seconds, but on most ports this will finish much earlier as interrupts
+# happen before each timeout expires.
+try:
+    from machine import lightsleep, Pin
+except ImportError:
+    print("SKIP")
+    raise SystemExit
+
+from sys import stdout, platform
+
+try:
+    led = Pin(Pin.board.LED, Pin.OUT)
+except AttributeError:
+    led = None
+
+for n in range(100):
+    if led:
+        led.toggle()
+    stdout.write(chr(ord("a") + (n % 26)))
+    lightsleep(2 ** (n % 10))
+
+print("\nDONE")

--- a/tests/ports/rp2/rp2_lightsleep.py.exp
+++ b/tests/ports/rp2/rp2_lightsleep.py.exp
@@ -1,0 +1,2 @@
+abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuv
+DONE


### PR DESCRIPTION
Follow-up to #15111, that change works most of the time but has an intermittent bug where USB doesn't resume as expected after waking from light sleep. Thanks to @GitHubsSilverBullet who reported it here: https://github.com/orgs/micropython/discussions/14401#discussioncomment-9675017

Turns out waking calls `clocks_init()` which will re-initialise the USB PLL. Most of the time this is OK but occasionally it seems like the clock glitches the USB peripheral and it stops working until the next hard reset.

Adds a `machine.lightsleep()` test that consistently hangs in the first two dozen iterations of a single test run on rp2 without this fix. Passed over 100 full test runs in a row with this fix.

The test is currently rp2-only as it seems similar lightsleep USB issues exist on other ports (both pyboard and ESP32-S3 native USB don't send any data to the host after waking, until they receive something from the host first.)

EDIT: Added one more small commit to always disable USB if there is no timeout (i.e. entering DORMANT mode where the external oscillator is disabled.)

*This work was funded through GitHub Sponsors.*