### PR TITLE
tools,unix: Enable Undefined Behavior Sanitizer (UBSan) for unix port and in CI.

### DIFF
--- a/ports/unix/Makefile
+++ b/ports/unix/Makefile
@@ -91,6 +91,17 @@ ifndef DEBUG
 CFLAGS += -U _FORTIFY_SOURCE
 endif
 
+# Optional Undefined Behavior Sanitizer
+#
+# Note that if running MicroPython with UBSan outside of the Makefile,
+# the environment variable UBSAN_OPTIONS should be set as shown below.
+UBSAN ?= 0
+ifeq ($(UBSAN),1)
+CFLAGS += -fsanitize=undefined
+LDFLAGS += -lubsan
+export UBSAN_OPTIONS=suppressions=$(TOP)/tools/ubsan-suppressions.txt
+endif
+
 # On OSX, 'gcc' is a symlink to clang unless a real gcc is installed.
 # The unix port of MicroPython on OSX must be compiled with clang,
 # while cross-compile ports require gcc, so we test here for OSX and

--- a/ports/unix/README.md
+++ b/ports/unix/README.md
@@ -73,6 +73,21 @@ deplibs`. To actually enable/disable use of dependencies, edit the
 options. For example, to build the SSL module, `MICROPY_PY_SSL` should be
 set to 1.
 
+Build Variants
+--------------
+
+The default `standard` variant is suitable for most uses. Additional build
+variants can be found in the `variants` subdirectory and built by setting
+`VARIANT=name` environment variable (i.e. `make test VARIANT=coverage`).
+
+Note that each variant is built in its own build directory.
+
+Additional variants include:
+
+* `minimal` variant has minimum code size and reduced features.
+* `coverage` variant enables almost all possible features and is suitable for
+  code coverage testing.
+
 Debug Symbols
 -------------
 
@@ -86,3 +101,24 @@ To build a debuggable version of the Unix port, there are two options
 2. Run `make [other arguments] STRIP=`. Note that the value of `STRIP` is
    empty. This will skip the build step that strips symbols and debug
    information, but changes nothing else in the build configuration.
+
+Undefined Behavior Sanitizer
+----------------------------
+
+The Unix port supports being built with the Undefined Behavior Sanitizer (aka
+UBSan) (see [gcc
+docs](https://gcc.gnu.org/onlinedocs/gcc/Instrumentation-Options.html#index-fsanitize_003dundefined),
+the Clang docs linked from that page have more details.)
+
+Only the `coverage` variant is built with UBSan enabled by default. Set the
+environment variable `UBSAN=1` to enable UBSan for a different variant, or set
+`VARIANT=coverage UBSAN=0` to build `coverage` without UBSan.
+
+UBSan will print an error to stderr if Undefined Behaviour is triggered, but
+continues execution. This means any unit test that triggers UB fails due to the
+additional output.
+
+The `make test` target should be used to run tests if possible, because it sets
+the `UBSAN_OPTIONS` environment variable to compensate for UB in some third party
+code. See the `Makefile` in this directory for details.
+

--- a/ports/unix/variants/coverage/mpconfigvariant.mk
+++ b/ports/unix/variants/coverage/mpconfigvariant.mk
@@ -1,6 +1,8 @@
 # Disable optimisations and enable assert() on coverage builds.
 DEBUG ?= 1
 
+UBSAN ?= 1
+
 CFLAGS += \
 	-fprofile-arcs -ftest-coverage \
 	-Wformat -Wmissing-declarations -Wmissing-prototypes \

--- a/py/binary.c
+++ b/py/binary.c
@@ -196,7 +196,7 @@ static float mp_decode_half_float(uint16_t hf) {
         ++e;
     }
 
-    fpu.i = ((hf & 0x8000) << 16) | (e << 23) | (m << 13);
+    fpu.i = ((hf & 0x8000U) << 16) | (e << 23) | (m << 13);
     return fpu.f;
 }
 

--- a/py/mpz.c
+++ b/py/mpz.c
@@ -708,7 +708,9 @@ void mpz_set(mpz_t *dest, const mpz_t *src) {
     mpz_need_dig(dest, src->len);
     dest->neg = src->neg;
     dest->len = src->len;
-    memcpy(dest->dig, src->dig, src->len * sizeof(mpz_dig_t));
+    if (src->len) {
+        memcpy(dest->dig, src->dig, src->len * sizeof(mpz_dig_t));
+    }
 }
 
 void mpz_set_from_int(mpz_t *z, mp_int_t val) {

--- a/py/objarray.c
+++ b/py/objarray.c
@@ -128,7 +128,9 @@ static mp_obj_t array_construct(char typecode, mp_obj_t initializer) {
         size_t sz = mp_binary_get_size('@', typecode, NULL);
         size_t len = bufinfo.len / sz;
         mp_obj_array_t *o = array_new(typecode, len);
-        memcpy(o->items, bufinfo.buf, len * sz);
+        if (len) {
+            memcpy(o->items, bufinfo.buf, len * sz);
+        }
         return MP_OBJ_FROM_PTR(o);
     }
 
@@ -189,7 +191,9 @@ static mp_obj_t bytearray_make_new(const mp_obj_type_t *type_in, size_t n_args, 
         // 1 arg, an integer: construct a blank bytearray of that length
         mp_uint_t len = mp_obj_get_int(args[0]);
         mp_obj_array_t *o = array_new(BYTEARRAY_TYPECODE, len);
-        memset(o->items, 0, len);
+        if (len) {
+            memset(o->items, 0, len);
+        }
         return MP_OBJ_FROM_PTR(o);
     } else {
         // 1 arg: construct the bytearray from that
@@ -413,6 +417,10 @@ static mp_obj_t array_extend(mp_obj_t self_in, mp_obj_t arg_in) {
     // allow to extend by anything that has the buffer protocol (extension to CPython)
     mp_buffer_info_t arg_bufinfo;
     mp_get_buffer_raise(arg_in, &arg_bufinfo, MP_BUFFER_READ);
+
+    if (!arg_bufinfo.len) {
+        return mp_const_none; // Empty sequence, nothing to extend
+    }
 
     size_t sz = mp_binary_get_size('@', self->typecode, NULL);
 
@@ -669,7 +677,9 @@ size_t mp_obj_array_len(mp_obj_t self_in) {
 #if MICROPY_PY_BUILTINS_BYTEARRAY
 mp_obj_t mp_obj_new_bytearray(size_t n, const void *items) {
     mp_obj_array_t *o = array_new(BYTEARRAY_TYPECODE, n);
-    memcpy(o->items, items, n);
+    if (n) {
+        memcpy(o->items, items, n);
+    }
     return MP_OBJ_FROM_PTR(o);
 }
 

--- a/py/objdict.c
+++ b/py/objdict.c
@@ -269,7 +269,9 @@ mp_obj_t mp_obj_dict_copy(mp_obj_t self_in) {
     other->map.all_keys_are_qstrs = self->map.all_keys_are_qstrs;
     other->map.is_fixed = 0;
     other->map.is_ordered = self->map.is_ordered;
-    memcpy(other->map.table, self->map.table, self->map.alloc * sizeof(mp_map_elem_t));
+    if (self->map.alloc) {
+        memcpy(other->map.table, self->map.table, self->map.alloc * sizeof(mp_map_elem_t));
+    }
     return other_out;
 }
 static MP_DEFINE_CONST_FUN_OBJ_1(dict_copy_obj, mp_obj_dict_copy);

--- a/py/objset.c
+++ b/py/objset.c
@@ -177,7 +177,9 @@ static mp_obj_t set_copy(mp_obj_t self_in) {
     mp_obj_set_t *other = mp_obj_malloc(mp_obj_set_t, self->base.type);
     mp_set_init(&other->set, self->set.alloc);
     other->set.used = self->set.used;
-    memcpy(other->set.table, self->set.table, self->set.alloc * sizeof(mp_obj_t));
+    if (self->set.alloc) {
+        memcpy(other->set.table, self->set.table, self->set.alloc * sizeof(mp_obj_t));
+    }
     return MP_OBJ_FROM_PTR(other);
 }
 static MP_DEFINE_CONST_FUN_OBJ_1(set_copy_obj, set_copy);

--- a/py/sequence.c
+++ b/py/sequence.c
@@ -105,7 +105,7 @@ bool mp_seq_cmp_bytes(mp_uint_t op, const byte *data1, size_t len1, const byte *
         }
     }
     size_t min_len = len1 < len2 ? len1 : len2;
-    int res = memcmp(data1, data2, min_len);
+    int res = min_len ? memcmp(data1, data2, min_len) : 0;
     if (op == MP_BINARY_OP_EQUAL) {
         // If we are checking for equality, here's the answer
         return res == 0;

--- a/tools/ubsan-suppressions.txt
+++ b/tools/ubsan-suppressions.txt
@@ -1,0 +1,5 @@
+# UBSan runtime suppressions, for third party code only
+# See https://clang.llvm.org/docs/UndefinedBehaviorSanitizer.html#issue-suppression
+
+# Default lfs2 file_max config is documented to overflow to negative value if seeking too far
+signed-integer-overflow:lfs2.c


### PR DESCRIPTION
This PR enables [UBSan](https://gcc.gnu.org/onlinedocs/gcc/Instrumentation-Options.html#index-fsanitize_003dundefined) on the coverage build by default, so it will be checked in CI.

Includes two supporting commits to fix UB that appeared in test runs. Kudos to @jepler who did a ton of previous work with UBSan in #7237, #7370, #3799, probably others - hence why this PR is pretty small.

## Null argument checks

The biggest commit in this PR is to fix cases where UBSan detects a null pointer being passed to a function argument decorated as non-null. In every case this was a libc function (memset, memcpy, etc) where the length argument was zero, so a no-op in principle.

@jepler did a good job of explaining the potential risk in #3799 so I'll quote that here:

> Traditionally, `memset(NULL, value, 0)` has been accepted without causing problems.  However, it is not standards-compliant behavior; and for instance Ted Unangst of the OpenBSD project notes that "A smart C compiler may observe a call to memcpy, flag both pointers as valid, and then delete any null checks. Forwards and backwards."
>    https://www.tedunangst.com/flak/post/zero-size-objects
>
> Since micropython is using -fdelete-null-pointer-checks ("enabled by default on most targets") and it is probably giving good code size improvements, we have to pay a modest price and add a few checks.

There are multiple ways we could handle this:

1. Current approach in this PR is to add the checks in the code, and incur a code size increase. It's relatively small, as most of the checks can be optimised out again by the compiler, but it's still there and may be an unacceptably high cost.
2. The approach @jepler chose in #7369 was to have a compile time flag that adds these checks via macros, disabled in production builds to save code size. I think this is an OK approach, but worry that it adds similar source code complexity as 1 without adding protection against the optimisation issue described above - i.e. UBSan builds won't see the UB due to the conditional check, so if it does happen then we'll find it the old fashioned way.
3. Disable all non-null argument checks in UBSan. In practice MicroPython really only encounters these when calling libc functions, so there's a similar benefit and risk as approach 2 but the code stays simpler. This was actually my first choice, there's a branch at https://github.com/projectgus/micropython/tree/feature/ubsan_unix_skip_nonnull that implements it. Then I got nervous about the risk of not checking for it...

@jepler I'd be very interested in your thoughts on this, if you're around. I can see benefits for each approach.

