### PR TITLE
py: fix native emitter to work with `async with` statements

### DIFF
--- a/mpy-cross/main.c
+++ b/mpy-cross/main.c
@@ -54,7 +54,7 @@ static void stdout_print_strn(void *env, const char *str, size_t len) {
     (void)dummy;
 }
 
-static const mp_print_t mp_stdout_print = {NULL, stdout_print_strn};
+const mp_print_t mp_stdout_print = {NULL, stdout_print_strn};
 
 static void stderr_print_strn(void *env, const char *str, size_t len) {
     (void)env;
@@ -130,7 +130,7 @@ static int usage(char **argv) {
         "Target specific options:\n"
         "-msmall-int-bits=number : set the maximum bits used to encode a small-int\n"
         "-march=<arch> : set architecture for native emitter;\n"
-        "                x86, x64, armv6, armv6m, armv7m, armv7em, armv7emsp, armv7emdp, xtensa, xtensawin, rv32imc\n"
+        "                x86, x64, armv6, armv6m, armv7m, armv7em, armv7emsp, armv7emdp, xtensa, xtensawin, rv32imc, debug\n"
         "\n"
         "Implementation specific options:\n", argv[0]
         );
@@ -316,6 +316,9 @@ MP_NOINLINE int main_(int argc, char **argv) {
                 } else if (strcmp(arch, "rv32imc") == 0) {
                     mp_dynamic_compiler.native_arch = MP_NATIVE_ARCH_RV32IMC;
                     mp_dynamic_compiler.nlr_buf_num_regs = MICROPY_NLR_NUM_REGS_RV32I;
+                } else if (strcmp(arch, "debug") == 0) {
+                    mp_dynamic_compiler.native_arch = MP_NATIVE_ARCH_DEBUG;
+                    mp_dynamic_compiler.nlr_buf_num_regs = 0;
                 } else if (strcmp(arch, "host") == 0) {
                     #if defined(__i386__) || defined(_M_IX86)
                     mp_dynamic_compiler.native_arch = MP_NATIVE_ARCH_X86;

--- a/mpy-cross/mpconfigport.h
+++ b/mpy-cross/mpconfigport.h
@@ -47,6 +47,8 @@
 #define MICROPY_EMIT_INLINE_XTENSA  (1)
 #define MICROPY_EMIT_XTENSAWIN      (1)
 #define MICROPY_EMIT_RV32           (1)
+#define MICROPY_EMIT_NATIVE_DEBUG   (1)
+#define MICROPY_EMIT_NATIVE_DEBUG_PRINTER (&mp_stdout_print)
 
 #define MICROPY_DYNAMIC_COMPILER    (1)
 #define MICROPY_COMP_CONST_FOLDING  (1)
@@ -164,3 +166,5 @@ typedef int ssize_t;
 typedef mp_off_t off_t;
 
 #endif
+
+extern const struct _mp_print_t mp_stdout_print;

--- a/py/asmbase.c
+++ b/py/asmbase.c
@@ -30,6 +30,7 @@
 #include "py/obj.h"
 #include "py/misc.h"
 #include "py/asmbase.h"
+#include "py/persistentcode.h"
 
 #if MICROPY_EMIT_MACHINE_CODE
 
@@ -91,6 +92,11 @@ void mp_asm_base_label_assign(mp_asm_base_t *as, size_t label) {
     } else {
         // ensure label offset has not changed from PASS_COMPUTE to PASS_EMIT
         assert(as->label_offsets[label] == as->code_offset);
+        #if MICROPY_DYNAMIC_COMPILER && MICROPY_EMIT_NATIVE_DEBUG
+        if (mp_dynamic_compiler.native_arch == MP_NATIVE_ARCH_DEBUG) {
+            mp_printf(MICROPY_EMIT_NATIVE_DEBUG_PRINTER, "label(label_%u)\n", (unsigned int)label);
+        }
+        #endif
     }
 }
 

--- a/py/compile.c
+++ b/py/compile.c
@@ -103,6 +103,7 @@ static const emit_method_table_t *emit_native_table[] = {
     &emit_native_xtensa_method_table,
     &emit_native_xtensawin_method_table,
     &emit_native_rv32_method_table,
+    &emit_native_debug_method_table,
 };
 
 #elif MICROPY_EMIT_NATIVE
@@ -121,6 +122,8 @@ static const emit_method_table_t *emit_native_table[] = {
 #define NATIVE_EMITTER(f) emit_native_xtensawin_##f
 #elif MICROPY_EMIT_RV32
 #define NATIVE_EMITTER(f) emit_native_rv32_##f
+#elif MICROPY_EMIT_NATIVE_DEBUG
+#define NATIVE_EMITTER(f) emit_native_debug_##f
 #else
 #error "unknown native emitter"
 #endif

--- a/py/compile.c
+++ b/py/compile.c
@@ -1899,19 +1899,7 @@ static void compile_async_with_stmt_helper(compiler_t *comp, size_t n, mp_parse_
 
         // Handle case 1: call __aexit__
         // Stack: (..., ctx_mgr)
-        EMIT_ARG(load_const_tok, MP_TOKEN_KW_NONE); // to tell end_finally there's no exception
-        EMIT(rot_two);
-        EMIT_ARG(jump, l_aexit_no_exc); // jump to code below to call __aexit__
-
-        // Start of "finally" block
-        // At this point we have case 2 or 3, we detect which one by the TOS being an exception or not
-        EMIT_ARG(label_assign, l_finally_block);
-
-        // Detect if TOS an exception or not
-        EMIT(dup_top);
-        EMIT_LOAD_GLOBAL(MP_QSTR_BaseException);
-        EMIT_ARG(binary_op, MP_BINARY_OP_EXCEPTION_MATCH);
-        EMIT_ARG(pop_jump_if, false, l_ret_unwind_jump); // if not an exception then we have case 3
+        EMIT_ARG(async_with_setup_finally, l_aexit_no_exc, l_finally_block, l_ret_unwind_jump);
 
         // Handle case 2: call __aexit__ and either swallow or re-raise the exception
         // Stack: (..., ctx_mgr, exc)
@@ -1937,6 +1925,7 @@ static void compile_async_with_stmt_helper(compiler_t *comp, size_t n, mp_parse_
         EMIT_ARG(pop_jump_if, false, l_end);
         EMIT(pop_top); // pop exception
         EMIT_ARG(load_const_tok, MP_TOKEN_KW_NONE); // replace with None to swallow exception
+        // Stack: (..., None)
         EMIT_ARG(jump, l_end);
         EMIT_ARG(adjust_stack_size, 2);
 
@@ -1946,6 +1935,8 @@ static void compile_async_with_stmt_helper(compiler_t *comp, size_t n, mp_parse_
         EMIT(rot_three);
         EMIT(rot_three);
         EMIT_ARG(label_assign, l_aexit_no_exc);
+        // We arrive here from either case 1 (a jump) or case 3 (fall through)
+        // Stack: case 1: (..., None, ctx_mgr) or case 3: (..., X, INT, ctx_mgr)
         EMIT_ARG(load_method, MP_QSTR___aexit__, false);
         EMIT_ARG(load_const_tok, MP_TOKEN_KW_NONE);
         EMIT(dup_top);
@@ -1953,6 +1944,7 @@ static void compile_async_with_stmt_helper(compiler_t *comp, size_t n, mp_parse_
         EMIT_ARG(call_method, 3, 0, 0);
         compile_yield_from(comp);
         EMIT(pop_top);
+        // Stack: case 1: (..., None) or case 3: (..., X, INT)
         EMIT_ARG(adjust_stack_size, -1);
 
         // End of "finally" block

--- a/py/emit.h
+++ b/py/emit.h
@@ -144,6 +144,9 @@ typedef struct _emit_method_table_t {
     void (*unwind_jump)(emit_t *emit, mp_uint_t label, mp_uint_t except_depth);
     void (*setup_block)(emit_t *emit, mp_uint_t label, int kind);
     void (*with_cleanup)(emit_t *emit, mp_uint_t label);
+    #if MICROPY_PY_ASYNC_AWAIT
+    void (*async_with_setup_finally)(emit_t *emit, mp_uint_t label_aexit_no_exc, mp_uint_t label_finally_block, mp_uint_t label_ret_unwind_jump);
+    #endif
     void (*end_finally)(emit_t *emit);
     void (*get_iter)(emit_t *emit, bool use_stack);
     void (*for_iter)(emit_t *emit, mp_uint_t label);
@@ -264,6 +267,9 @@ void mp_emit_bc_jump_if_or_pop(emit_t *emit, bool cond, mp_uint_t label);
 void mp_emit_bc_unwind_jump(emit_t *emit, mp_uint_t label, mp_uint_t except_depth);
 void mp_emit_bc_setup_block(emit_t *emit, mp_uint_t label, int kind);
 void mp_emit_bc_with_cleanup(emit_t *emit, mp_uint_t label);
+#if MICROPY_PY_ASYNC_AWAIT
+void mp_emit_bc_async_with_setup_finally(emit_t *emit, mp_uint_t label_aexit_no_exc, mp_uint_t label_finally_block, mp_uint_t label_ret_unwind_jump);
+#endif
 void mp_emit_bc_end_finally(emit_t *emit);
 void mp_emit_bc_get_iter(emit_t *emit, bool use_stack);
 void mp_emit_bc_for_iter(emit_t *emit, mp_uint_t label);

--- a/py/emit.h
+++ b/py/emit.h
@@ -202,6 +202,7 @@ extern const emit_method_table_t emit_native_arm_method_table;
 extern const emit_method_table_t emit_native_xtensa_method_table;
 extern const emit_method_table_t emit_native_xtensawin_method_table;
 extern const emit_method_table_t emit_native_rv32_method_table;
+extern const emit_method_table_t emit_native_debug_method_table;
 
 extern const mp_emit_method_table_id_ops_t mp_emit_bc_method_table_load_id_ops;
 extern const mp_emit_method_table_id_ops_t mp_emit_bc_method_table_store_id_ops;
@@ -215,6 +216,7 @@ emit_t *emit_native_arm_new(mp_emit_common_t *emit_common, mp_obj_t *error_slot,
 emit_t *emit_native_xtensa_new(mp_emit_common_t *emit_common, mp_obj_t *error_slot, uint *label_slot, mp_uint_t max_num_labels);
 emit_t *emit_native_xtensawin_new(mp_emit_common_t *emit_common, mp_obj_t *error_slot, uint *label_slot, mp_uint_t max_num_labels);
 emit_t *emit_native_rv32_new(mp_emit_common_t *emit_common, mp_obj_t *error_slot, uint *label_slot, mp_uint_t max_num_labels);
+emit_t *emit_native_debug_new(mp_emit_common_t *emit_common, mp_obj_t *error_slot, uint *label_slot, mp_uint_t max_num_labels);
 
 void emit_bc_set_max_num_labels(emit_t *emit, mp_uint_t max_num_labels);
 
@@ -226,6 +228,7 @@ void emit_native_arm_free(emit_t *emit);
 void emit_native_xtensa_free(emit_t *emit);
 void emit_native_xtensawin_free(emit_t *emit);
 void emit_native_rv32_free(emit_t *emit);
+void emit_native_debug_free(emit_t *emit);
 
 void mp_emit_bc_start_pass(emit_t *emit, pass_kind_t pass, scope_t *scope);
 bool mp_emit_bc_end_pass(emit_t *emit);

--- a/py/emitbc.c
+++ b/py/emitbc.c
@@ -666,6 +666,27 @@ void mp_emit_bc_with_cleanup(emit_t *emit, mp_uint_t label) {
     mp_emit_bc_adjust_stack_size(emit, -4);
 }
 
+#if MICROPY_PY_ASYNC_AWAIT
+void mp_emit_bc_async_with_setup_finally(emit_t *emit, mp_uint_t label_aexit_no_exc, mp_uint_t label_finally_block, mp_uint_t label_ret_unwind_jump) {
+    // The async-with body has executed and no exception was raised, the execution fell through to this point.
+    // Stack: (..., ctx_mgr)
+
+    // Finish async-with body and prepare to enter "finally" block.
+    mp_emit_bc_load_const_tok(emit, MP_TOKEN_KW_NONE); // to tell end_finally there's no exception
+    mp_emit_bc_rot_two(emit);
+    mp_emit_bc_jump(emit, label_aexit_no_exc); // jump to code to call __aexit__
+
+    // Start of "finally" block which is entered via one of: an exception propagating out, a return, an unwind jump.
+    mp_emit_bc_label_assign(emit, label_finally_block);
+
+    // Detect which case we have by the TOS being an exception or not.
+    mp_emit_bc_dup_top(emit);
+    mp_emit_bc_load_global(emit, MP_QSTR_BaseException, MP_EMIT_IDOP_GLOBAL_GLOBAL);
+    mp_emit_bc_binary_op(emit, MP_BINARY_OP_EXCEPTION_MATCH);
+    mp_emit_bc_pop_jump_if(emit, false, label_ret_unwind_jump); // if not an exception then we have return or unwind jump.
+}
+#endif
+
 void mp_emit_bc_end_finally(emit_t *emit) {
     emit_write_bytecode_byte(emit, -1, MP_BC_END_FINALLY);
 }
@@ -862,6 +883,9 @@ const emit_method_table_t emit_bc_method_table = {
     mp_emit_bc_unwind_jump,
     mp_emit_bc_setup_block,
     mp_emit_bc_with_cleanup,
+    #if MICROPY_PY_ASYNC_AWAIT
+    mp_emit_bc_async_with_setup_finally,
+    #endif
     mp_emit_bc_end_finally,
     mp_emit_bc_get_iter,
     mp_emit_bc_for_iter,

--- a/py/emitnative.c
+++ b/py/emitnative.c
@@ -1459,6 +1459,7 @@ static void emit_native_load_attr(emit_t *emit, qstr qst) {
 }
 
 static void emit_native_load_method(emit_t *emit, qstr qst, bool is_super) {
+    DEBUG_printf("load_method(%s, %d)\n", qstr_str(qst), is_super);
     if (is_super) {
         emit_get_stack_pointer_to_reg_for_pop(emit, REG_ARG_2, 3); // arg2 = dest ptr
         emit_get_stack_pointer_to_reg_for_push(emit, REG_ARG_2, 2); // arg2 = dest ptr
@@ -2149,6 +2150,7 @@ static void emit_native_setup_with(emit_t *emit, mp_uint_t label) {
 }
 
 static void emit_native_setup_block(emit_t *emit, mp_uint_t label, int kind) {
+    DEBUG_printf("setup_block(%d, %d)\n", (int)label, kind);
     if (kind == MP_EMIT_SETUP_BLOCK_WITH) {
         emit_native_setup_with(emit, label);
     } else {
@@ -2233,6 +2235,8 @@ static void emit_native_end_finally(emit_t *emit) {
     //   if exc == None: pass
     //   else: raise exc
     // the check if exc is None is done in the MP_F_NATIVE_RAISE stub
+    DEBUG_printf("end_finally\n");
+
     emit_native_pre(emit);
     ASM_MOV_REG_LOCAL(emit->as, REG_ARG_1, LOCAL_IDX_EXC_VAL(emit));
     emit_call(emit, MP_F_NATIVE_RAISE);
@@ -2256,6 +2260,8 @@ static void emit_native_end_finally(emit_t *emit) {
 static void emit_native_get_iter(emit_t *emit, bool use_stack) {
     // perhaps the difficult one, as we want to rewrite for loops using native code
     // in cases where we iterate over a Python object, can we use normal runtime calls?
+
+    DEBUG_printf("get_iter(%d)\n", use_stack);
 
     vtype_kind_t vtype;
     emit_pre_pop_reg(emit, &vtype, REG_ARG_1);
@@ -2838,6 +2844,7 @@ static void emit_native_call_function(emit_t *emit, mp_uint_t n_positional, mp_u
 }
 
 static void emit_native_call_method(emit_t *emit, mp_uint_t n_positional, mp_uint_t n_keyword, mp_uint_t star_flags) {
+    DEBUG_printf("call_method(%d, %d, %d)\n", n_positional, n_keyword, star_flags);
     if (star_flags) {
         emit_get_stack_pointer_to_reg_for_pop(emit, REG_ARG_3, n_positional + 2 * n_keyword + 3); // pointer to args
         emit_call_with_2_imm_args(emit, MP_F_CALL_METHOD_N_KW_VAR, 1, REG_ARG_1, n_positional | (n_keyword << 8), REG_ARG_2);
@@ -2904,6 +2911,7 @@ static void emit_native_return_value(emit_t *emit) {
 }
 
 static void emit_native_raise_varargs(emit_t *emit, mp_uint_t n_args) {
+    DEBUG_printf("raise_varargs(%d)\n", n_args);
     (void)n_args;
     assert(n_args == 1);
     vtype_kind_t vtype_exc;
@@ -2918,6 +2926,8 @@ static void emit_native_raise_varargs(emit_t *emit, mp_uint_t n_args) {
 
 static void emit_native_yield(emit_t *emit, int kind) {
     // Note: 1 (yield) or 3 (yield from) labels are reserved for this function, starting at *emit->label_slot
+
+    DEBUG_printf("yield(%d)\n", kind);
 
     if (emit->do_viper_types) {
         mp_raise_NotImplementedError(MP_ERROR_TEXT("native yield"));

--- a/py/emitnative.c
+++ b/py/emitnative.c
@@ -59,7 +59,7 @@
 #endif
 
 // wrapper around everything in this file
-#if N_X64 || N_X86 || N_THUMB || N_ARM || N_XTENSA || N_XTENSAWIN || N_RV32
+#if N_X64 || N_X86 || N_THUMB || N_ARM || N_XTENSA || N_XTENSAWIN || N_RV32 || N_DEBUG
 
 // C stack layout for native functions:
 //  0:                          nlr_buf_t [optional]
@@ -348,6 +348,8 @@ static void emit_native_mov_reg_state_addr(emit_t *emit, int reg_dest, int local
 static void emit_native_mov_reg_qstr(emit_t *emit, int arg_reg, qstr qst) {
     #if MICROPY_PERSISTENT_CODE_SAVE
     ASM_LOAD16_REG_REG_OFFSET(emit->as, arg_reg, REG_QSTR_TABLE, mp_emit_common_use_qstr(emit->emit_common, qst));
+    #elif defined(ASM_MOV_REG_QSTR)
+    ASM_MOV_REG_QSTR(emit->as, arg_reg, qst);
     #else
     ASM_MOV_REG_IMM(emit->as, arg_reg, qst);
     #endif
@@ -2604,6 +2606,8 @@ static void emit_native_binary_op(emit_t *emit, mp_binary_op_t op) {
                 default:
                     break;
             }
+            #elif N_DEBUG
+            asm_debug_setcc_reg_reg_reg(emit->as, op_idx, REG_RET, REG_ARG_2, reg_rhs);
             #else
             #error not implemented
             #endif

--- a/py/emitndebug.c
+++ b/py/emitndebug.c
@@ -1,0 +1,285 @@
+// native-debug specific stuff
+
+#include "py/mpconfig.h"
+
+#if MICROPY_EMIT_NATIVE_DEBUG
+
+#include "py/asmbase.h"
+#include "py/nativeglue.h"
+
+#define asm_debug_printf(as, fmt, ...) \
+    do { \
+        if (as->base.pass == MP_ASM_PASS_EMIT) { \
+            if (fmt[0] != 'E') { \
+                mp_printf(MICROPY_EMIT_NATIVE_DEBUG_PRINTER, "    "); \
+            } \
+            if (as->base.suppress) { \
+                mp_printf(MICROPY_EMIT_NATIVE_DEBUG_PRINTER, "dead_code "); \
+            } \
+            mp_printf(MICROPY_EMIT_NATIVE_DEBUG_PRINTER, fmt, __VA_ARGS__); \
+        } \
+    } while (0)
+
+enum {
+    ASM_DEBUG_REG_R00,
+    ASM_DEBUG_REG_R01,
+    ASM_DEBUG_REG_R02,
+    ASM_DEBUG_REG_R03,
+    ASM_DEBUG_REG_R04,
+    ASM_DEBUG_REG_R05,
+    ASM_DEBUG_REG_R06,
+    ASM_DEBUG_REG_R07,
+    ASM_DEBUG_REG_R08,
+    ASM_DEBUG_REG_R09,
+    ASM_DEBUG_REG_R10,
+    ASM_DEBUG_REG_R11,
+};
+
+typedef struct _asm_debug_t {
+    mp_asm_base_t base;
+} asm_debug_t;
+
+static const char *const reg_name_table[] = {
+    "r_ret",
+    "r_arg1",
+    "r_arg2",
+    "r_arg3",
+    "r_arg4",
+    "r_temp0",
+    "r_temp1",
+    "r_temp2",
+    "r_local1",
+    "r_local2",
+    "r_local3",
+    "r_fun_table",
+};
+
+static const char *const fun_name_table[MP_F_NUMBER_OF] = {
+    [MP_F_CONVERT_OBJ_TO_NATIVE] = "convert_obj_to_native",
+    [MP_F_CONVERT_NATIVE_TO_OBJ] = "convert_native_to_obj",
+    [MP_F_NATIVE_SWAP_GLOBALS] = "native_swap_globals",
+    [MP_F_LOAD_NAME] = "load_name",
+    [MP_F_LOAD_GLOBAL] = "load_global",
+    [MP_F_LOAD_BUILD_CLASS] = "load_build_class",
+    [MP_F_LOAD_ATTR] = "load_attr",
+    [MP_F_LOAD_METHOD] = "load_method",
+    [MP_F_LOAD_SUPER_METHOD] = "load_super_method",
+    [MP_F_STORE_NAME] = "store_name",
+    [MP_F_STORE_GLOBAL] = "store_global",
+    [MP_F_STORE_ATTR] = "store_attr",
+    [MP_F_OBJ_SUBSCR] = "obj_subscr",
+    [MP_F_OBJ_IS_TRUE] = "obj_is_true",
+    [MP_F_UNARY_OP] = "unary_op",
+    [MP_F_BINARY_OP] = "binary_op",
+    [MP_F_BUILD_TUPLE] = "build_tuple",
+    [MP_F_BUILD_LIST] = "build_list",
+    [MP_F_BUILD_MAP] = "build_map",
+    [MP_F_BUILD_SET] = "build_set",
+    [MP_F_STORE_SET] = "store_set",
+    [MP_F_LIST_APPEND] = "list_append",
+    [MP_F_STORE_MAP] = "store_map",
+    [MP_F_MAKE_FUNCTION_FROM_PROTO_FUN] = "make_function_from_proto_fun",
+    [MP_F_NATIVE_CALL_FUNCTION_N_KW] = "native_call_function_n_kw",
+    [MP_F_CALL_METHOD_N_KW] = "call_method_n_kw",
+    [MP_F_CALL_METHOD_N_KW_VAR] = "call_method_n_kw_var",
+    [MP_F_NATIVE_GETITER] = "native_getiter",
+    [MP_F_NATIVE_ITERNEXT] = "native_iternext",
+    [MP_F_NLR_PUSH] = "nlr_push",
+    [MP_F_NLR_POP] = "nlr_pop",
+    [MP_F_NATIVE_RAISE] = "native_raise",
+    [MP_F_IMPORT_NAME] = "import_name",
+    [MP_F_IMPORT_FROM] = "import_from",
+    [MP_F_IMPORT_ALL] = "import_all",
+    [MP_F_NEW_SLICE] = "new_slice",
+    [MP_F_UNPACK_SEQUENCE] = "unpack_sequence",
+    [MP_F_UNPACK_EX] = "unpack_ex",
+    [MP_F_DELETE_NAME] = "delete_name",
+    [MP_F_DELETE_GLOBAL] = "delete_global",
+    [MP_F_NEW_CLOSURE] = "new_closure",
+    [MP_F_ARG_CHECK_NUM_SIG] = "arg_check_num_sig",
+    [MP_F_SETUP_CODE_STATE] = "setup_code_state",
+    [MP_F_SMALL_INT_FLOOR_DIVIDE] = "small_int_floor_divide",
+    [MP_F_SMALL_INT_MODULO] = "small_int_modulo",
+    [MP_F_NATIVE_YIELD_FROM] = "native_yield_from",
+    [MP_F_SETJMP] = "setjmp",
+};
+
+static void asm_debug_end_pass(asm_debug_t *as) {
+    (void)as;
+}
+
+static void asm_debug_entry(asm_debug_t *as, int num_locals) {
+    asm_debug_printf(as, "ENTRY(num_locals=%d)\n", num_locals);
+}
+
+static void asm_debug_exit(asm_debug_t *as) {
+    asm_debug_printf(as, "EXIT(%u)\n", 0);
+}
+
+static void asm_debug_fun(asm_debug_t *as, const char *op, int fun_idx) {
+    asm_debug_printf(as, "%s(%s)\n", op, fun_name_table[fun_idx]);
+}
+
+static void asm_debug_reg(asm_debug_t *as, const char *op, int reg) {
+    asm_debug_printf(as, "%s(%s)\n", op, reg_name_table[reg]);
+}
+
+static void asm_debug_label(asm_debug_t *as, const char *op, unsigned int label) {
+    asm_debug_printf(as, "%s(label_%u)\n", op, label);
+}
+
+static void asm_debug_reg_imm(asm_debug_t *as, const char *op, int reg, int imm) {
+    asm_debug_printf(as, "%s(%s, %d=0x%x)\n", op, reg_name_table[reg], imm, imm);
+}
+
+#if !MICROPY_PERSISTENT_CODE_SAVE
+static void asm_debug_reg_qstr(asm_debug_t *as, const char *op, int reg, int qst) {
+    asm_debug_printf(as, "%s(%s, %s)\n", op, reg_name_table[reg], qstr_str(qst));
+}
+#endif
+
+static void asm_debug_reg_reg(asm_debug_t *as, const char *op, int reg1, int reg2) {
+    asm_debug_printf(as, "%s(%s, %s)\n", op, reg_name_table[reg1], reg_name_table[reg2]);
+}
+
+static void asm_debug_reg_local(asm_debug_t *as, const char *op, int reg, unsigned int local) {
+    asm_debug_printf(as, "%s(%s, local_%u)\n", op, reg_name_table[reg], local);
+}
+
+static void asm_debug_reg_label(asm_debug_t *as, const char *op, int reg, unsigned int label) {
+    asm_debug_printf(as, "%s(%s, label_%u)\n", op, reg_name_table[reg], label);
+}
+
+static void asm_debug_local_reg(asm_debug_t *as, const char *op, int local, int reg) {
+    asm_debug_printf(as, "%s(local_%d, %s)\n", op, local, reg_name_table[reg]);
+}
+
+static void asm_debug_reg_label_bool(asm_debug_t *as, const char *op, int reg, unsigned int label, bool b) {
+    asm_debug_printf(as, "%s(%s, label_%u, %s)\n", op, reg_name_table[reg], label, b ? "true" : "false");
+}
+
+static void asm_debug_reg_reg_offset(asm_debug_t *as, const char *op, int reg1, int reg2, int offset) {
+    asm_debug_printf(as, "%s(%s, %s, %d)\n", op, reg_name_table[reg1], reg_name_table[reg2], offset);
+}
+
+static void asm_debug_reg_reg_label(asm_debug_t *as, const char *op, int reg1, int reg2, unsigned int label) {
+    asm_debug_printf(as, "%s(%s, %s, label_%u)\n", op, reg_name_table[reg1], reg_name_table[reg2], label);
+}
+
+static void asm_debug_setcc_reg_reg_reg(asm_debug_t *as, int op, int reg1, int reg2, int reg3) {
+    asm_debug_printf(as, "setcc(%d, %s, %s, %s)\n", op, reg_name_table[reg1], reg_name_table[reg2], reg_name_table[reg3]);
+}
+
+// The following macros provide a (mostly) arch-independent API to
+// generate native code, and are used by the native emitter.
+
+#define ASM_WORD_SIZE (8)
+
+#define REG_RET ASM_DEBUG_REG_R00
+#define REG_ARG_1 ASM_DEBUG_REG_R01
+#define REG_ARG_2 ASM_DEBUG_REG_R02
+#define REG_ARG_3 ASM_DEBUG_REG_R03
+#define REG_ARG_4 ASM_DEBUG_REG_R04
+
+#define REG_TEMP0 ASM_DEBUG_REG_R05
+#define REG_TEMP1 ASM_DEBUG_REG_R06
+#define REG_TEMP2 ASM_DEBUG_REG_R07
+
+#define REG_LOCAL_1 ASM_DEBUG_REG_R08
+#define REG_LOCAL_2 ASM_DEBUG_REG_R09
+#define REG_LOCAL_3 ASM_DEBUG_REG_R10
+#define REG_LOCAL_NUM (3)
+
+// Holds a pointer to mp_fun_table
+#define REG_FUN_TABLE ASM_DEBUG_REG_R11
+
+#define ASM_T               asm_debug_t
+#define ASM_END_PASS        asm_debug_end_pass
+#define ASM_ENTRY(as, num_locals) \
+    asm_debug_entry(as, num_locals)
+#define ASM_EXIT(as) \
+    asm_debug_exit(as)
+
+#define ASM_JUMP(as, label) \
+    asm_debug_label(as, "jump", label)
+#define ASM_JUMP_IF_REG_ZERO(as, reg, label, bool_test) \
+    asm_debug_reg_label_bool(as, "jump_if_reg_zero", reg, label, bool_test)
+#define ASM_JUMP_IF_REG_NONZERO(as, reg, label, bool_test) \
+    asm_debug_reg_label_bool(as, "jump_if_reg_nonzero", reg, label, bool_test)
+#define ASM_JUMP_IF_REG_EQ(as, reg1, reg2, label) \
+    asm_debug_reg_reg_label(as, "jump_if_reg_eq", reg1, reg2, label)
+#define ASM_JUMP_REG(as, reg) \
+    asm_debug_reg(as, "jump_reg", reg)
+#define ASM_CALL_IND(as, idx) \
+    asm_debug_fun(as, "call_ind", idx)
+
+#define ASM_MOV_LOCAL_REG(as, local_num, reg_src) \
+    asm_debug_local_reg(as, "mov_local_reg", local_num, reg_src)
+#define ASM_MOV_REG_IMM(as, reg_dest, imm) \
+    asm_debug_reg_imm(as, "mov_reg_imm", reg_dest, imm)
+#define ASM_MOV_REG_QSTR(as, reg_dest, qst) \
+    asm_debug_reg_qstr(as, "mov_reg_qstr", reg_dest, qst)
+#define ASM_MOV_REG_LOCAL(as, reg_dest, local_num) \
+    asm_debug_reg_local(as, "mov_reg_local", reg_dest, local_num)
+#define ASM_MOV_REG_REG(as, reg_dest, reg_src) \
+    asm_debug_reg_reg(as, "mov_reg_reg", reg_dest, reg_src)
+#define ASM_MOV_REG_LOCAL_ADDR(as, reg_dest, local_num) \
+    asm_debug_reg_local(as, "mov_reg_local_addr", reg_dest, local_num)
+#define ASM_MOV_REG_PCREL(as, reg_dest, label) \
+    asm_debug_reg_label(as, "mov_reg_pcrel", reg_dest, label)
+
+#define ASM_NOT_REG(as, reg_dest) \
+    asm_debug_reg(as, "not", reg_dest)
+#define ASM_NEG_REG(as, reg_dest) \
+    asm_debug_reg(as, "neg", reg_dest)
+#define ASM_LSL_REG_REG(as, reg_dest, reg_src) \
+    asm_debug_reg_reg(as, "lsl", reg_dest, reg_src)
+#define ASM_LSR_REG_REG(as, reg_dest, reg_src) \
+    asm_debug_reg_reg(as, "lsr", reg_dest, reg_src)
+#define ASM_ASR_REG_REG(as, reg_dest, reg_src) \
+    asm_debug_reg_reg(as, "asr", reg_dest, reg_src)
+#define ASM_OR_REG_REG(as, reg_dest, reg_src) \
+    asm_debug_reg_reg(as, "or", reg_dest, reg_src)
+#define ASM_XOR_REG_REG(as, reg_dest, reg_src) \
+    asm_debug_reg_reg(as, "xor", reg_dest, reg_src)
+#define ASM_AND_REG_REG(as, reg_dest, reg_src) \
+    asm_debug_reg_reg(as, "and", reg_dest, reg_src)
+#define ASM_ADD_REG_REG(as, reg_dest, reg_src) \
+    asm_debug_reg_reg(as, "add", reg_dest, reg_src)
+#define ASM_SUB_REG_REG(as, reg_dest, reg_src) \
+    asm_debug_reg_reg(as, "sub", reg_dest, reg_src)
+#define ASM_MUL_REG_REG(as, reg_dest, reg_src) \
+    asm_debug_reg_reg(as, "mul", reg_dest, reg_src)
+
+#define ASM_LOAD_REG_REG(as, reg_dest, reg_base) \
+    asm_debug_reg_reg(as, "load", reg_dest, reg_base)
+#define ASM_LOAD_REG_REG_OFFSET(as, reg_dest, reg_base, word_offset) \
+    asm_debug_reg_reg_offset(as, "load", reg_dest, reg_base, word_offset)
+#define ASM_LOAD8_REG_REG(as, reg_dest, reg_base) \
+    asm_debug_reg_reg(as, "load8", reg_dest, reg_base)
+#define ASM_LOAD16_REG_REG(as, reg_dest, reg_base) \
+    asm_debug_reg_reg(as, "load16", reg_dest, reg_base)
+#define ASM_LOAD16_REG_REG_OFFSET(as, reg_dest, reg_base, uint16_offset) \
+    asm_debug_reg_reg_offset(as, "load16", reg_dest, reg_base, uint16_offset)
+#define ASM_LOAD32_REG_REG(as, reg_dest, reg_base) \
+    asm_debug_reg_reg(as, "load32", reg_dest, reg_base)
+
+#define ASM_STORE_REG_REG(as, reg_src, reg_base) \
+    asm_debug_reg_reg(as, "store", reg_src, reg_base)
+#define ASM_STORE_REG_REG_OFFSET(as, reg_src, reg_base, word_offset) \
+    asm_debug_reg_reg_offset(as, "store", reg_src, reg_base, word_offset)
+#define ASM_STORE8_REG_REG(as, reg_src, reg_base) \
+    asm_debug_reg_reg(as, "store8", reg_src, reg_base)
+#define ASM_STORE16_REG_REG(as, reg_src, reg_base) \
+    asm_debug_reg_reg(as, "store16", reg_src, reg_base)
+#define ASM_STORE32_REG_REG(as, reg_src, reg_base) \
+    asm_debug_reg_reg(as, "store32", reg_src, reg_base)
+
+// Word indices of REG_LOCAL_x in nlr_buf_t
+#define NLR_BUF_IDX_LOCAL_1 (5) // rbx
+
+#define N_DEBUG (1)
+#define EXPORT_FUN(name) emit_native_debug_##name
+#include "py/emitnative.c"
+
+#endif

--- a/py/mpconfig.h
+++ b/py/mpconfig.h
@@ -412,7 +412,7 @@
 #endif
 
 // Convenience definition for whether any native emitter is enabled
-#define MICROPY_EMIT_NATIVE (MICROPY_EMIT_X64 || MICROPY_EMIT_X86 || MICROPY_EMIT_THUMB || MICROPY_EMIT_ARM || MICROPY_EMIT_XTENSA || MICROPY_EMIT_XTENSAWIN || MICROPY_EMIT_RV32)
+#define MICROPY_EMIT_NATIVE (MICROPY_EMIT_X64 || MICROPY_EMIT_X86 || MICROPY_EMIT_THUMB || MICROPY_EMIT_ARM || MICROPY_EMIT_XTENSA || MICROPY_EMIT_XTENSAWIN || MICROPY_EMIT_RV32 || MICROPY_EMIT_NATIVE_DEBUG)
 
 // Some architectures cannot read byte-wise from executable memory.  In this case
 // the prelude for a native function (which usually sits after the machine code)

--- a/py/persistentcode.h
+++ b/py/persistentcode.h
@@ -98,6 +98,7 @@ enum {
     MP_NATIVE_ARCH_XTENSA,
     MP_NATIVE_ARCH_XTENSAWIN,
     MP_NATIVE_ARCH_RV32IMC,
+    MP_NATIVE_ARCH_DEBUG, // this entry should always be last
 };
 
 enum {

--- a/py/py.cmake
+++ b/py/py.cmake
@@ -26,6 +26,7 @@ set(MICROPY_SOURCE_PY
     ${MICROPY_PY_DIR}/emitinlinethumb.c
     ${MICROPY_PY_DIR}/emitinlinextensa.c
     ${MICROPY_PY_DIR}/emitnarm.c
+    ${MICROPY_PY_DIR}/emitndebug.c
     ${MICROPY_PY_DIR}/emitnrv32.c
     ${MICROPY_PY_DIR}/emitnthumb.c
     ${MICROPY_PY_DIR}/emitnx64.c

--- a/py/py.mk
+++ b/py/py.mk
@@ -116,6 +116,7 @@ PY_CORE_O_BASENAME = $(addprefix py/,\
 	emitnxtensawin.o \
 	asmrv32.o \
 	emitnrv32.o \
+	emitndebug.o \
 	formatfloat.o \
 	parsenumbase.o \
 	parsenum.o \

--- a/tests/basics/gen_yield_from_throw_repeat.py
+++ b/tests/basics/gen_yield_from_throw_repeat.py
@@ -1,0 +1,22 @@
+# Test throwing repeatedly into the same generator, where that generator
+# is yielding from another generator.
+
+
+def yielder():
+    yield 4
+    yield 5
+
+
+def gen():
+    while True:
+        try:
+            print("gen received:", (yield from yielder()))
+        except ValueError as exc:
+            print(repr(exc))
+
+
+g = gen()
+for i in range(2):
+    print("send, got:", g.send(None))
+    print("throw, got:", g.throw(ValueError("a", i)))
+    print("throw, got:", g.throw(ValueError("b", i)))

--- a/tests/basics/generator_throw_repeat.py
+++ b/tests/basics/generator_throw_repeat.py
@@ -1,0 +1,16 @@
+# Test throwing repeatedly into the same generator.
+
+
+def gen():
+    while True:
+        try:
+            print("gen received:", (yield "value"))
+        except ValueError as exc:
+            print(repr(exc))
+
+
+g = gen()
+for i in range(2):
+    print("send, got:", g.send(None))
+    print("throw, got:", g.throw(ValueError("a", i)))
+    print("throw, got:", g.throw(ValueError("b", i)))

--- a/tests/run-tests.py
+++ b/tests/run-tests.py
@@ -731,10 +731,7 @@ def run_tests(pyb, tests, args, result_dir, num_threads=1):
         skip_tests.add("basics/sys_tracebacklimit.py")  # requires traceback info
         skip_tests.add("basics/try_finally_return2.py")  # requires raise_varargs
         skip_tests.add("basics/unboundlocal.py")  # requires checking for unbound local
-        skip_tests.add("extmod/asyncio_event.py")  # unknown issue
         skip_tests.add("extmod/asyncio_lock.py")  # requires async with
-        skip_tests.add("extmod/asyncio_micropython.py")  # unknown issue
-        skip_tests.add("extmod/asyncio_wait_for.py")  # unknown issue
         skip_tests.add("misc/features.py")  # requires raise_varargs
         skip_tests.add(
             "misc/print_exception.py"

--- a/tests/run-tests.py
+++ b/tests/run-tests.py
@@ -718,9 +718,6 @@ def run_tests(pyb, tests, args, result_dir, num_threads=1):
     if args.emit == "native":
         skip_tests.add("basics/gen_yield_from_close.py")  # require raise_varargs
         skip_tests.update(
-            {"basics/async_%s.py" % t for t in "with with2 with_break with_return".split()}
-        )  # require async_with
-        skip_tests.update(
             {"basics/%s.py" % t for t in "try_reraise try_reraise2".split()}
         )  # require raise_varargs
         skip_tests.add("basics/annotate_var.py")  # requires checking for unbound local
@@ -731,7 +728,6 @@ def run_tests(pyb, tests, args, result_dir, num_threads=1):
         skip_tests.add("basics/sys_tracebacklimit.py")  # requires traceback info
         skip_tests.add("basics/try_finally_return2.py")  # requires raise_varargs
         skip_tests.add("basics/unboundlocal.py")  # requires checking for unbound local
-        skip_tests.add("extmod/asyncio_lock.py")  # requires async with
         skip_tests.add("misc/features.py")  # requires raise_varargs
         skip_tests.add(
             "misc/print_exception.py"


### PR DESCRIPTION
This fixes the native emitter so that `async with` statements now work with it.

----

This PR also includes a new "debug native emitter" that can be used to print out pseudo instructions generated by the native emitter, to help debug issues with it.  Eg with the following `test.py` file:
```py
@micropython.native
def f():
    return 1
```
`mpy-cross` can be used as follows to get debug output from the native emitter:
```
$ ./build/mpy-cross -march=debug test.py
ENTRY(num_locals=6)
    load(r_fun_table, r_arg1, 1)
    load(r_local3, r_fun_table, 2)
    load(r_fun_table, r_fun_table, 3)
    load(r_fun_table, r_fun_table, 0)
    mov_local_reg(local_0, r_arg1)
    mov_reg_imm(r_arg1, 1=0x1)
    mov_local_reg(local_3, r_arg1)
    mov_reg_local_addr(r_arg1, local_0)
    call_ind(setup_code_state)
    mov_reg_imm(r_ret, 3=0x3)
    jump(label_0)
    dead_code load(r_ret, r_fun_table, 0)
    dead_code jump(label_0)
label(label_0)
EXIT(0)
```