### PR TITLE
tools/mpremote: Fix absolute path usage in remote mounted VFS.

### DIFF
--- a/tools/mpremote/mpremote/transport_serial.py
+++ b/tools/mpremote/mpremote/transport_serial.py
@@ -838,6 +838,9 @@ class RemoteFS:
     def __init__(self, cmd):
         self.cmd = cmd
 
+    def _abspath(self, path):
+        return path if path.startswith("/") else self.path + path
+
     def mount(self, readonly, mkfs):
         pass
 
@@ -859,7 +862,7 @@ class RemoteFS:
     def remove(self, path):
         c = self.cmd
         c.begin(CMD_REMOVE)
-        c.wr_str(self.path + path)
+        c.wr_str(self._abspath(path))
         res = c.rd_s32()
         c.end()
         if res < 0:
@@ -868,8 +871,8 @@ class RemoteFS:
     def rename(self, old, new):
         c = self.cmd
         c.begin(CMD_RENAME)
-        c.wr_str(self.path + old)
-        c.wr_str(self.path + new)
+        c.wr_str(self._abspath(old))
+        c.wr_str(self._abspath(new))
         res = c.rd_s32()
         c.end()
         if res < 0:
@@ -878,7 +881,7 @@ class RemoteFS:
     def mkdir(self, path):
         c = self.cmd
         c.begin(CMD_MKDIR)
-        c.wr_str(self.path + path)
+        c.wr_str(self._abspath(path))
         res = c.rd_s32()
         c.end()
         if res < 0:
@@ -887,7 +890,7 @@ class RemoteFS:
     def rmdir(self, path):
         c = self.cmd
         c.begin(CMD_RMDIR)
-        c.wr_str(self.path + path)
+        c.wr_str(self._abspath(path))
         res = c.rd_s32()
         c.end()
         if res < 0:
@@ -896,7 +899,7 @@ class RemoteFS:
     def stat(self, path):
         c = self.cmd
         c.begin(CMD_STAT)
-        c.wr_str(self.path + path)
+        c.wr_str(self._abspath(path))
         res = c.rd_s8()
         if res < 0:
             c.end()
@@ -912,7 +915,7 @@ class RemoteFS:
     def ilistdir(self, path):
         c = self.cmd
         c.begin(CMD_ILISTDIR_START)
-        c.wr_str(self.path + path)
+        c.wr_str(self._abspath(path))
         res = c.rd_s8()
         c.end()
         if res < 0:
@@ -933,7 +936,7 @@ class RemoteFS:
     def open(self, path, mode):
         c = self.cmd
         c.begin(CMD_OPEN)
-        c.wr_str(self.path + path)
+        c.wr_str(self._abspath(path))
         c.wr_str(mode)
         fd = c.rd_s8()
         c.end()


### PR DESCRIPTION
Prior to this fix the current working path in the remote VFS would always be prepended to the requested path to get the full path, even if the requested path was already absolute, ie starting with "/".

So `os.chdir("/remote/dir1")` would set the working path to "/dir1/", and a subsequent call with an absolute path like `os.listdir("/remote/dir2")` would try to list the directory "/dir1/dir2/".

Fixes issue #15308.