### PR TITLE
py/objdeque.c: correct type flags based on option settings

### DIFF
--- a/py/objdeque.c
+++ b/py/objdeque.c
@@ -263,7 +263,7 @@ static MP_DEFINE_CONST_DICT(deque_locals_dict, deque_locals_dict_table);
 MP_DEFINE_CONST_OBJ_TYPE(
     mp_type_deque,
     MP_QSTR_deque,
-    MP_TYPE_FLAG_ITER_IS_GETITER,
+    DEQUE_TYPE_FLAGS,
     make_new, deque_make_new,
     unary_op, deque_unary_op,
     DEQUE_TYPE_SUBSCR


### PR DESCRIPTION
This fixes a minor issue in the changes made by #10724. The type flags for `deque` were meant to be conditionalized based on `MICROPY_PY_COLLECTIONS_DEQUE_ITER`, but the computed conditionalized value wasn't used.

Discovered by accident while addressing https://github.com/adafruit/circuitpython/issues/9355. @SAK917 recently added #10724 to CircuitPython via https://github.com/adafruit/circuitpython/pull/9065.

@LordFlashmeow can you confirm this is what you wanted?