### PR TITLE
tools/mpremote: Fix mpremote mip install with multiple lib folders in sys.path.

### DIFF
--- a/tools/mpremote/mpremote/mip.py
+++ b/tools/mpremote/mpremote/mip.py
@@ -179,9 +179,9 @@ def do_mip(state, args):
             if args.target is None:
                 state.transport.exec("import sys")
                 lib_paths = (
-                    state.transport.eval("'\\n'.join(p for p in sys.path if p.endswith('/lib'))")
+                    state.transport.eval("'|'.join(p for p in sys.path if p.endswith('/lib'))")
                     .decode()
-                    .split("\n")
+                    .split("|")
                 )
                 if lib_paths and lib_paths[0]:
                     args.target = lib_paths[0]


### PR DESCRIPTION
This is a fix for an algorithmic error in mpremote mip, 
that throws an error  due to a `\n` used in the concatenation and split.

The issue is is discussed in https://github.com/orgs/micropython/discussions/14078 

Repro & manual test: 
- connect a pybv11 with an SD card 
  on start the pybv11 will mount the SD card and add a 2nd `../lib`-path to sys.path, which will trigger the error.
  `sys.path` : `['', '.frozen', '/sd', '/sd/lib', '/flash', '/flash/lib']`
- `mpremote mip install requests`

  - Expected result:
     ```
     Install requests
     Installing requests (latest) from https://micropython.org/pi/v2 to /sd/lib
     Installing: /sd/lib/requests/__init__.mpy
     Done
     ```

<details><summary>Sample error without this fix</summary>
<p>


Install requests
Installing requests (latest) from https://micropython.org/pi/v2 to /sd/lib
/requests/__init__.mpy
Traceback (most recent call last):
  File "<frozen runpy>", line 198, in _run_module_as_main
  File "<frozen runpy>", line 88, in _run_code
  File "C:\Users\josverl\pipx\.cache\493badebc2c62e8\Scripts\mpremote.exe\__main__.py", line 7, in <module>
  File "C:\Users\josverl\pipx\.cache\493badebc2c62e8\Lib\site-packages\mpremote\main.py", line 528, in main
    handler_func(state, args)
  File "C:\Users\josverl\pipx\.cache\493badebc2c62e8\Lib\site-packages\mpremote\mip.py", line 197, in do_mip
    _install_package(
  File "C:\Users\josverl\pipx\.cache\493badebc2c62e8\Lib\site-packages\mpremote\mip.py", line 160, in _install_package
    _install_json(transport, package, index, target, version, mpy)
  File "C:\Users\josverl\pipx\.cache\493badebc2c62e8\Lib\site-packages\mpremote\mip.py", line 118, in _install_json
    _download_file(transport, file_url, fs_target_path)
  File "C:\Users\josverl\pipx\.cache\493badebc2c62e8\Lib\site-packages\mpremote\mip.py", line 91, in _download_file
    _ensure_path_exists(transport, dest)
  File "C:\Users\josverl\pipx\.cache\493badebc2c62e8\Lib\site-packages\mpremote\mip.py", line 33, in _ensure_path_exists
    transport.fs_mkdir(prefix)
  File "C:\Users\josverl\pipx\.cache\493badebc2c62e8\Lib\site-packages\mpremote\transport_serial.py", line 427, in fs_mkdir
    self.exec("import os\nos.mkdir('%s')" % dir)
  File "C:\Users\josverl\pipx\.cache\493badebc2c62e8\Lib\site-packages\mpremote\transport_serial.py", line 287, in exec
    raise TransportError("exception", ret, ret_err)
mpremote.transport.TransportError: ('exception', b'', b'Traceback (most recent call last):\r\n  File "<stdin>", line 2\r\nSyntaxError: invalid syntax\r\n')

</p>
</details> 
