### PR TITLE
Updated documentation for cryptolib library

### DIFF
--- a/docs/library/cryptolib.rst
+++ b/docs/library/cryptolib.rst
@@ -4,6 +4,15 @@
 .. module:: cryptolib
    :synopsis: cryptographic ciphers
 
+.. note::
+   The STM32 port requires you to add the following lines to the file 
+   ``micropython/ports/stm32/boards/<board>/mpconfigboard.mk`` before compiling::
+
+      MICROPY_PY_SSL = 1
+      MICROPY_SSL_MBEDTLS = 1
+
+   ``<board>`` should be the same as in ``make BOARD=<board>``.
+
 Classes
 -------
 
@@ -38,3 +47,4 @@ Classes
     .. method:: decrypt(in_buf, [out_buf])
 
         Like `encrypt()`, but for decryption.
+


### PR DESCRIPTION
/docs/library/cryptolib.rst: Add notice to cryptolib docs.
The [cryptolib library](https://docs.micropython.org/en/latest/library/cryptolib.html) is not immediately available for use on the STM32 port. This caused me a lot of personal frustration trying to figure out how to import it and use it.
So I added a note to the documentation notifying users the steps they would need to be able to use it themselves.