### PR TITLE
ports/rp2: Replace CMSIS with Pico SDK equivalents.

### DIFF
--- a/ports/rp2/machine_uart.c
+++ b/ports/rp2/machine_uart.c
@@ -369,9 +369,9 @@ static void mp_machine_uart_init_helper(machine_uart_obj_t *self, size_t n_args,
 
         uart_init(self->uart, self->baudrate);
         uart_set_format(self->uart, self->bits, self->stop, self->parity);
-        __DSB(); // make sure UARTLCR_H register is written to
+        __dsb(); // make sure UARTLCR_H register is written to
         uart_set_fifo_enabled(self->uart, true);
-        __DSB(); // make sure UARTLCR_H register is written to
+        __dsb(); // make sure UARTLCR_H register is written to
         gpio_set_function(self->tx, GPIO_FUNC_UART);
         gpio_set_function(self->rx, GPIO_FUNC_UART);
         if (self->invert & UART_INVERT_RX) {

--- a/ports/rp2/main.c
+++ b/ports/rp2/main.c
@@ -47,6 +47,7 @@
 #include "genhdr/mpversion.h"
 #include "mp_usbd.h"
 
+#include "RP2040.h" // cmsis, for PendSV_IRQn and SCB/SCB_SCR_SEVONPEND_Msk
 #include "pico/stdlib.h"
 #include "pico/binary_info.h"
 #include "pico/unique_id.h"

--- a/ports/rp2/mphalport.h
+++ b/ports/rp2/mphalport.h
@@ -30,7 +30,6 @@
 #include "pico/time.h"
 #include "hardware/clocks.h"
 #include "hardware/structs/systick.h"
-#include "RP2040.h" // cmsis, for NVIC_SetPriority, PendSV_IRQn and SCB/SCB_SCR_SEVONPEND_Msk
 #include "pendsv.h"
 
 #define SYSTICK_MAX (0xffffff)

--- a/ports/rp2/mphalport.h
+++ b/ports/rp2/mphalport.h
@@ -30,7 +30,7 @@
 #include "pico/time.h"
 #include "hardware/clocks.h"
 #include "hardware/structs/systick.h"
-#include "RP2040.h" // cmsis, for __WFI
+#include "RP2040.h" // cmsis, for NVIC_SetPriority, PendSV_IRQn and SCB/SCB_SCR_SEVONPEND_Msk
 #include "pendsv.h"
 
 #define SYSTICK_MAX (0xffffff)

--- a/ports/rp2/mpnetworkport.c
+++ b/ports/rp2/mpnetworkport.c
@@ -57,7 +57,7 @@ static void gpio_irq_handler(void) {
         // CYW43_POST_POLL_HOOK which is called at the end of cyw43_poll_func.
         gpio_set_irq_enabled(CYW43_PIN_WL_HOST_WAKE, CYW43_IRQ_LEVEL, false);
         cyw43_has_pending = 1;
-        __SEV();
+        __sev();
         pendsv_schedule_dispatch(PENDSV_DISPATCH_CYW43, cyw43_poll);
         CYW43_STAT_INC(IRQ_COUNT);
     }

--- a/ports/rp2/mpnetworkport.c
+++ b/ports/rp2/mpnetworkport.c
@@ -43,6 +43,7 @@ static soft_timer_entry_t mp_network_soft_timer;
 #include "lib/cyw43-driver/src/cyw43.h"
 #include "lib/cyw43-driver/src/cyw43_stats.h"
 #include "hardware/irq.h"
+#include "RP2040.h" // cmsis, for NVIC_SetPriority and PendSV_IRQn
 
 #define CYW43_IRQ_LEVEL GPIO_IRQ_LEVEL_HIGH
 #define CYW43_SHARED_IRQ_HANDLER_PRIORITY PICO_SHARED_IRQ_HANDLER_HIGHEST_ORDER_PRIORITY


### PR DESCRIPTION
This change replaces a couple of CMSIS holdouts with their Pico SDK equivalents. AFAICT these are functionally identical, fancy decorators around their ASM counterparts.

I have updated the comment in `mphalport.h` to clarify what's still coming from CMSIS. I believe `__WFI` has long since been replaced with `__wfi()` so `__DSB()` and `__SEV()` should probably follow suit.

Let me know if there's a reason things are as they are (obviously wrong stale comment notwithstanding.)

It might be worth evaluating what bumping the priority of `PendSV_IRQn` and https://github.com/micropython/micropython/blob/b4213c9c920afb8da5d3d123b26527e26dceb877/ports/rp2/main.c#L77C8-L77C39 are intended to accomplish, and whether this is generalisable and could make a good case for a Pico SDK function. 

I'm a little over my head, and probably fighting a losing battle, but the CMSIS inclusion feels like an ugly wart.