### PR TITLE
rp2/boards/WEACTSTUDIO: Fix variant names in board.json.

### DIFF
--- a/ports/rp2/boards/WEACTSTUDIO/board.json
+++ b/ports/rp2/boards/WEACTSTUDIO/board.json
@@ -15,9 +15,9 @@
     "product": "WeAct Studio RP2040",
     "url": "https://github.com/WeActTC/WeActStudio.RP2040CoreBoard",
     "variants": {
-        "FLASH_2MB": "2 MiB Flash",
-        "FLASH_4MB": "4 MiB Flash",
-        "FLASH_8MB": "8 MiB Flash"
+        "FLASH_2M": "2 MiB Flash",
+        "FLASH_4M": "4 MiB Flash",
+        "FLASH_8M": "8 MiB Flash"
     },
     "vendor": "WeAct"
 }


### PR DESCRIPTION
### Summary

It looks like the variants for this board were never being built properly, because the auto-build system used the variant name from `board.json` which did not match the variant names in the original `mpconfigboard.mk`.  Eg `FLASH_2MB` in `board.json` but `FLASH_2M` in `mpconfigboard.mk`.

This mistake is apparent since 5dff78f38edc0354e854e6c73af61c5064afe9d3, which made it a build error to specify an invalid variant.

Fix this by using the correct variant names in `board.json`.