### PR TITLE
esp32/network_lan: LAN.active(True) should succeed if already active.

### DIFF
--- a/ports/esp32/network_lan.c
+++ b/ports/esp32/network_lan.c
@@ -312,13 +312,14 @@ static mp_obj_t lan_active(size_t n_args, const mp_obj_t *args) {
     lan_if_obj_t *self = MP_OBJ_TO_PTR(args[0]);
 
     if (n_args > 1) {
-        if (mp_obj_is_true(args[1])) {
+        bool make_active = mp_obj_is_true(args[1]);
+        if (make_active && !self->base.active) {
             esp_netif_set_hostname(self->base.netif, mod_network_hostname_data);
             self->base.active = (esp_eth_start(self->eth_handle) == ESP_OK);
             if (!self->base.active) {
                 mp_raise_msg(&mp_type_OSError, MP_ERROR_TEXT("ethernet enable failed"));
             }
-        } else {
+        } else if (!make_active && self->base.active) {
             self->base.active = !(esp_eth_stop(self->eth_handle) == ESP_OK);
             if (self->base.active) {
                 mp_raise_msg(&mp_type_OSError, MP_ERROR_TEXT("ethernet disable failed"));


### PR DESCRIPTION
This PR ensures that `network.LAN.active(True/False)` will not raise an exception if the LAN is already in the desired state.


### Summary

<!-- Explain the reason for making this change. What problem does the pull request
     solve, or what improvement does it add? Add links if relevant. -->

Currently, `lan.active(True)` will raise an `OSError` exception if the LAN is already in the desired state. 

This is inconsistent with `network.WLAN.active(True/False)` and causes `lan.active(True)` to raise an exception after a soft reset (causing commonly used network startup scripts to fail for LAN interfaces after a soft reset).


### Testing

I have tested this on a [LILYGO-T-ETH-LITE ESP32S3](https://www.lilygo.cc/products/t-eth-lite) board using the W5500 LAN driver.

### Trade-offs and Alternatives

The PR checks the return status of esp_eth_start/stop() and does not raise exception on ESP_ERR_INVALID_STATE as this is [documented as indicating the device is already in the desired state](https://docs.espressif.com/projects/esp-idf/en/v4.2/esp32/api-reference/network/esp_eth.html#_CPPv413esp_eth_start16esp_eth_handle_t).

While an exception is no longer raised the espressif drivers still print a warning message:

- `E (677173) esp_eth: esp_eth_start(286): driver started already`.
