### PR TITLE
py/asmrv32: Do not use binary literals.

### DIFF
--- a/py/asmrv32.h
+++ b/py/asmrv32.h
@@ -122,69 +122,60 @@ void asm_rv32_end_pass(asm_rv32_t *state);
 
 ////////////////////////////////////////////////////////////////////////////////
 
-#define RV32_ENCODE_TYPE_B(op, ft3, rs1, rs2, imm)                                              \
-    ((op & 0b1111111) | ((ft3 & 0b111) << 12) | ((imm & 0b100000000000) >> 4) |  \
-    ((imm & 0b11110) << 7) | ((rs1 & 0b11111) << 15) |                          \
-    ((rs2 & 0b11111) << 20) | ((imm & 0b11111100000) << 20) |                   \
-    ((imm & 0b1000000000000) << 19))
+#define RV32_ENCODE_TYPE_B(op, ft3, rs1, rs2, imm) \
+    ((op & 0x7F) | ((ft3 & 0x07) << 12) | ((imm & 0x800) >> 4) | \
+    ((imm & 0x1E) << 7) | ((rs1 & 0x1F) << 15) | ((rs2 & 0x1F) << 20) | \
+    ((imm & 0x7E0) << 20) | ((imm & 0x1000) << 19))
 
-#define RV32_ENCODE_TYPE_I(op, ft3, rd, rs, imm)                               \
-    ((op & 0b1111111) | ((rd & 0b11111) << 7) | ((ft3 & 0b111) << 12) |          \
-    ((rs & 0b11111) << 15) | ((imm & 0b111111111111) << 20))
+#define RV32_ENCODE_TYPE_I(op, ft3, rd, rs, imm) \
+    ((op & 0x7F) | ((rd & 0x1F) << 7) | ((ft3 & 0x07) << 12) | \
+    ((rs & 0x1F) << 15) | ((imm & 0xFFF) << 20))
 
-#define RV32_ENCODE_TYPE_J(op, rd, imm)                                        \
-    ((op & 0b1111111) | ((rd & 0b11111) << 7) | (imm & 0b11111111000000000000) | \
-    ((imm & 0b100000000000) << 9) | ((imm & 0b11111111110) << 20) |             \
-    ((imm & 0b100000000000000000000) << 11))
+#define RV32_ENCODE_TYPE_J(op, rd, imm) \
+    ((op & 0x7F) | ((rd & 0x1F) << 7) | (imm & 0xFF000) | \
+    ((imm & 0x800) << 9) | ((imm & 0x7FE) << 20) | ((imm & 0x100000) << 11))
 
-#define RV32_ENCODE_TYPE_R(op, ft3, ft7, rd, rs1, rs2)                         \
-    ((op & 0b1111111) | ((rd & 0b11111) << 7) | ((ft3 & 0b111) << 12) |          \
-    ((rs1 & 0b11111) << 15) | ((rs2 & 0b11111) << 20) |                         \
-    ((ft7 & 0b1111111) << 25))
+#define RV32_ENCODE_TYPE_R(op, ft3, ft7, rd, rs1, rs2) \
+    ((op & 0x7F) | ((rd & 0x1F) << 7) | ((ft3 & 0x07) << 12) | \
+    ((rs1 & 0x1F) << 15) | ((rs2 & 0x1F) << 20) | ((ft7 & 0x7F) << 25))
 
-#define RV32_ENCODE_TYPE_S(op, ft3, rs1, rs2, imm)                             \
-    ((op & 0b1111111) | ((imm & 0b11111) << 7) | ((ft3 & 0b111) << 12) |         \
-    ((rs1 & 0b11111) << 15) | ((rs2 & 0b11111) << 20) |                         \
-    ((imm & 0b111111100000) << 20))
+#define RV32_ENCODE_TYPE_S(op, ft3, rs1, rs2, imm) \
+    ((op & 0x7F) | ((imm & 0x1F) << 7) | ((ft3 & 0x07) << 12) | \
+    ((rs1 & 0x1F) << 15) | ((rs2 & 0x1F) << 20) | ((imm & 0xFE0) << 20))
 
-#define RV32_ENCODE_TYPE_U(op, rd, imm)                                        \
-    ((op & 0b1111111) | ((rd & 0b11111) << 7) |                                  \
-    (imm & 0b11111111111111111111000000000000))
+#define RV32_ENCODE_TYPE_U(op, rd, imm) \
+    ((op & 0x7F) | ((rd & 0x1F) << 7) | (imm & 0xFFFFF000))
 
 #define RV32_ENCODE_TYPE_CB(op, ft3, rs, imm) \
-    ((op & 0b11) | ((ft3 & 0b111) << 13) | ((rs & 0b111) << 7) | \
-    (((imm) & 0b100000000) << 4) | (((imm) & 0b11000000) >> 1) | \
-    (((imm) & 0b100000) >> 3) | (((imm) & 0b11000) << 7) | \
-    (((imm) & 0b110) << 2))
+    ((op & 0x03) | ((ft3 & 0x07) << 13) | ((rs & 0x07) << 7) | \
+    (((imm) & 0x100) << 4) | (((imm) & 0xC0) >> 1) | (((imm) & 0x20) >> 3) | \
+    (((imm) & 0x18) << 7) | (((imm) & 0x06) << 2))
 
 #define RV32_ENCODE_TYPE_CI(op, ft3, rd, imm) \
-    ((op & 0b11) | ((ft3 & 0b111) << 13) | ((rd & 0b11111) << 7) | \
-    (((imm) & 0b100000) << 7) | (((imm) & 0b11111) << 2))
+    ((op & 0x03) | ((ft3 & 0x07) << 13) | ((rd & 0x1F) << 7) | \
+    (((imm) & 0x20) << 7) | (((imm) & 0x1F) << 2))
 
 #define RV32_ENCODE_TYPE_CIW(op, ft3, rd, imm) \
-    ((op & 0b11) | ((ft3 & 0b111) << 13) | ((rd & 0b111) << 2) | \
-    ((imm & 0b1111000000) << 1) | ((imm & 0b110000) << 7) | \
-    ((imm & 0b1000) << 2) | ((imm & 0b100) << 4))
+    ((op & 0x03) | ((ft3 & 0x07) << 13) | ((rd & 0x07) << 2) | \
+    ((imm & 0x3C0) << 1) | ((imm & 0x30) << 7) | \
+    ((imm & 0x08) << 2) | ((imm & 0x04) << 4))
 
 #define RV32_ENCODE_TYPE_CJ(op, ft3, imm) \
-    ((op & 0b11) | ((ft3 & 0b111) << 13) | \
-    ((imm & 0b1110) << 2) | ((imm & 0b1100000000) << 1) | \
-    ((imm & 0b100000000000) << 1) | ((imm & 0b10000000000) >> 2) | \
-    ((imm & 0b10000000) >> 1) | ((imm & 0b1000000) << 1) | \
-    ((imm & 0b100000) >> 3) | ((imm & 0b10000) << 7))
+    ((op & 0x03) | ((ft3 & 0x07) << 13) | ((imm & 0x0E) << 2) | \
+    ((imm & 0x300) << 1) | ((imm & 0x800) << 1) | ((imm & 0x400) >> 2) | \
+    ((imm & 0x80) >> 1) | ((imm & 0x40) << 1) | ((imm & 0x20) >> 3) | \
+    ((imm & 0x10) << 7))
 
 #define RV32_ENCODE_TYPE_CL(op, ft3, rd, rs, imm) \
-    ((op & 0b11) | ((ft3 & 0b111) << 13) | ((rd & 0b111) << 2) | \
-    ((rs & 0b111) << 7) | ((imm & 0b1000000) >> 1) | \
-    ((imm & 0b111000) << 7) | ((imm & 0b100) << 4))
+    ((op & 0x03) | ((ft3 & 0x07) << 13) | ((rd & 0x07) << 2) | \
+    ((rs & 0x07) << 7) | ((imm & 0x40) >> 1) | ((imm & 0x38) << 7) | \
+    ((imm & 0x04) << 4))
 
 #define RV32_ENCODE_TYPE_CR(op, ft4, rs1, rs2) \
-    ((op & 0b11) | ((rs2 & 0b11111) << 2) | ((rs1 & 0b11111) << 7) | \
-    ((ft4 & 0b1111) << 12))
+    ((op & 0x03) | ((rs2 & 0x1F) << 2) | ((rs1 & 0x1F) << 7) | ((ft4 & 0x0F) << 12))
 
 #define RV32_ENCODE_TYPE_CSS(op, ft3, rs, imm) \
-    ((op & 0b11) | ((ft3 & 0b111) << 13) | ((rs & 0b11111) << 2) | \
-    ((imm) & 0b111111) << 7)
+    ((op & 0x03) | ((ft3 & 0x07) << 13) | ((rs & 0x1F) << 2) | ((imm) & 0x3F) << 7)
 
 void asm_rv32_emit_word_opcode(asm_rv32_t *state, mp_uint_t opcode);
 void asm_rv32_emit_halfword_opcode(asm_rv32_t *state, mp_uint_t opcode);
@@ -192,235 +183,235 @@ void asm_rv32_emit_halfword_opcode(asm_rv32_t *state, mp_uint_t opcode);
 // ADD RD, RS1, RS2
 static inline void asm_rv32_opcode_add(asm_rv32_t *state, mp_uint_t rd, mp_uint_t rs1, mp_uint_t rs2) {
     // R: 0000000 ..... ..... 000 ..... 0110011
-    asm_rv32_emit_word_opcode(state, RV32_ENCODE_TYPE_R(0b0110011, 0b000, 0b0000000, rd, rs1, rs2));
+    asm_rv32_emit_word_opcode(state, RV32_ENCODE_TYPE_R(0x33, 0x00, 0x00, rd, rs1, rs2));
 }
 
 // ADDI RD, RS, IMMEDIATE
 static inline void asm_rv32_opcode_addi(asm_rv32_t *state, mp_uint_t rd, mp_uint_t rs, mp_int_t immediate) {
     // I: ............ ..... 000 ..... 0010011
-    asm_rv32_emit_word_opcode(state, RV32_ENCODE_TYPE_I(0b0010011, 0b000, rd, rs, immediate));
+    asm_rv32_emit_word_opcode(state, RV32_ENCODE_TYPE_I(0x13, 0x00, rd, rs, immediate));
 }
 
 // AND RD, RS1, RS2
 static inline void asm_rv32_opcode_and(asm_rv32_t *state, mp_uint_t rd, mp_uint_t rs1, mp_uint_t rs2) {
     // R: 0000000 ..... ..... 111 ..... 0110011
-    asm_rv32_emit_word_opcode(state, RV32_ENCODE_TYPE_R(0b0110011, 0b111, 0b0000000, rd, rs1, rs2));
+    asm_rv32_emit_word_opcode(state, RV32_ENCODE_TYPE_R(0x33, 0x07, 0x00, rd, rs1, rs2));
 }
 
 // AUIPC RD, offset
 static inline void asm_rv32_opcode_auipc(asm_rv32_t *state, mp_uint_t rd, mp_int_t offset) {
     // U: .................... ..... 0010111
-    asm_rv32_emit_word_opcode(state, RV32_ENCODE_TYPE_U(0b0010111, rd, offset));
+    asm_rv32_emit_word_opcode(state, RV32_ENCODE_TYPE_U(0x17, rd, offset));
 }
 
 // BEQ RS1, RS2, OFFSET
 static inline void asm_rv32_opcode_beq(asm_rv32_t *state, mp_uint_t rs1, mp_uint_t rs2, mp_int_t offset) {
     // B: . ...... ..... ..... 000 .... . 1100011
-    asm_rv32_emit_word_opcode(state, RV32_ENCODE_TYPE_B(0b1100011, 0b000, rs1, rs2, offset));
+    asm_rv32_emit_word_opcode(state, RV32_ENCODE_TYPE_B(0x63, 0x00, rs1, rs2, offset));
 }
 
 // BNE RS1, RS2, OFFSET
 static inline void asm_rv32_opcode_bne(asm_rv32_t *state, mp_uint_t rs1, mp_uint_t rs2, mp_int_t offset) {
     // B: . ...... ..... ..... 001 .... . 1100011
-    asm_rv32_emit_word_opcode(state, RV32_ENCODE_TYPE_B(0b1100011, 0b001, rs1, rs2, offset));
+    asm_rv32_emit_word_opcode(state, RV32_ENCODE_TYPE_B(0x63, 0x01, rs1, rs2, offset));
 }
 
 // C.ADD RD, RS
 static inline void asm_rv32_opcode_cadd(asm_rv32_t *state, mp_uint_t rd, mp_uint_t rs) {
     // CR: 1001 ..... ..... 10
-    asm_rv32_emit_halfword_opcode(state, RV32_ENCODE_TYPE_CR(0b10, 0b1001, rd, rs));
+    asm_rv32_emit_halfword_opcode(state, RV32_ENCODE_TYPE_CR(0x02, 0x09, rd, rs));
 }
 
 // C.ADDI RD, IMMEDIATE
 static inline void asm_rv32_opcode_caddi(asm_rv32_t *state, mp_uint_t rd, mp_int_t immediate) {
     // CI: 000 . ..... ..... 01
-    asm_rv32_emit_halfword_opcode(state, RV32_ENCODE_TYPE_CI(0b01, 0b000, rd, immediate));
+    asm_rv32_emit_halfword_opcode(state, RV32_ENCODE_TYPE_CI(0x01, 0x00, rd, immediate));
 }
 
 // C.ADDI4SPN RD', IMMEDIATE
 static inline void asm_rv32_opcode_caddi4spn(asm_rv32_t *state, mp_uint_t rd, mp_uint_t immediate) {
     // CIW: 000 ........ ... 00
-    asm_rv32_emit_halfword_opcode(state, RV32_ENCODE_TYPE_CIW(0b00, 0b000, rd, immediate));
+    asm_rv32_emit_halfword_opcode(state, RV32_ENCODE_TYPE_CIW(0x00, 0x00, rd, immediate));
 }
 
 // C.BEQZ RS', IMMEDIATE
 static inline void asm_rv32_opcode_cbeqz(asm_rv32_t *state, mp_uint_t rs, mp_int_t offset) {
     // CB: 110 ... ... ..... 01
-    asm_rv32_emit_halfword_opcode(state, RV32_ENCODE_TYPE_CB(0b01, 0b110, rs, offset));
+    asm_rv32_emit_halfword_opcode(state, RV32_ENCODE_TYPE_CB(0x01, 0x06, rs, offset));
 }
 
 // C.BNEZ RS', IMMEDIATE
 static inline void asm_rv32_opcode_cbnez(asm_rv32_t *state, mp_uint_t rs, mp_int_t offset) {
     // CB: 111 ... ... ..... 01
-    asm_rv32_emit_halfword_opcode(state, RV32_ENCODE_TYPE_CB(0b01, 0b111, rs, offset));
+    asm_rv32_emit_halfword_opcode(state, RV32_ENCODE_TYPE_CB(0x01, 0x07, rs, offset));
 }
 
 // C.J OFFSET
 static inline void asm_rv32_opcode_cj(asm_rv32_t *state, mp_int_t offset) {
     // CJ: 101 ........... 01
-    asm_rv32_emit_halfword_opcode(state, RV32_ENCODE_TYPE_CJ(0b01, 0b101, offset));
+    asm_rv32_emit_halfword_opcode(state, RV32_ENCODE_TYPE_CJ(0x01, 0x05, offset));
 }
 
 // C.JALR RS
 static inline void asm_rv32_opcode_cjalr(asm_rv32_t *state, mp_uint_t rs) {
     // CR: 1001 ..... 00000 10
-    asm_rv32_emit_halfword_opcode(state, RV32_ENCODE_TYPE_CR(0b10, 0b1001, rs, 0));
+    asm_rv32_emit_halfword_opcode(state, RV32_ENCODE_TYPE_CR(0x02, 0x09, rs, 0));
 }
 
 // C.JR RS
 static inline void asm_rv32_opcode_cjr(asm_rv32_t *state, mp_uint_t rs) {
     // CR: 1000 ..... 00000 10
-    asm_rv32_emit_halfword_opcode(state, RV32_ENCODE_TYPE_CR(0b10, 0b1000, rs, 0));
+    asm_rv32_emit_halfword_opcode(state, RV32_ENCODE_TYPE_CR(0x02, 0x08, rs, 0));
 }
 
 // C.LI RD, IMMEDIATE
 static inline void asm_rv32_opcode_cli(asm_rv32_t *state, mp_uint_t rd, mp_int_t immediate) {
     // CI: 010 . ..... ..... 01
-    asm_rv32_emit_halfword_opcode(state, RV32_ENCODE_TYPE_CI(0b01, 0b010, rd, immediate));
+    asm_rv32_emit_halfword_opcode(state, RV32_ENCODE_TYPE_CI(0x01, 0x02, rd, immediate));
 }
 
 // C.LUI RD, IMMEDIATE
 static inline void asm_rv32_opcode_clui(asm_rv32_t *state, mp_uint_t rd, mp_int_t immediate) {
     // CI: 011 . ..... ..... 01
-    asm_rv32_emit_halfword_opcode(state, RV32_ENCODE_TYPE_CI(0b01, 0b011, rd, immediate >> 12));
+    asm_rv32_emit_halfword_opcode(state, RV32_ENCODE_TYPE_CI(0x01, 0x03, rd, immediate >> 12));
 }
 
 // C.LW RD', OFFSET(RS')
 static inline void asm_rv32_opcode_clw(asm_rv32_t *state, mp_uint_t rd, mp_uint_t rs, mp_int_t offset) {
     // CL: 010 ... ... .. ... 00
-    asm_rv32_emit_halfword_opcode(state, RV32_ENCODE_TYPE_CL(0b00, 0b010, rd, rs, offset));
+    asm_rv32_emit_halfword_opcode(state, RV32_ENCODE_TYPE_CL(0x00, 0x02, rd, rs, offset));
 }
 
 // C.LWSP RD, OFFSET
 static inline void asm_rv32_opcode_clwsp(asm_rv32_t *state, mp_uint_t rd, mp_uint_t offset) {
     // CI: 010 . ..... ..... 10
-    asm_rv32_emit_halfword_opcode(state, RV32_ENCODE_TYPE_CI(0b10, 0b010, rd, ((offset & 0b11000000) >> 6) | (offset & 0b111100)));
+    asm_rv32_emit_halfword_opcode(state, RV32_ENCODE_TYPE_CI(0x02, 0x02, rd, ((offset & 0xC0) >> 6) | (offset & 0x3C)));
 }
 
 // C.MV RD, RS
 static inline void asm_rv32_opcode_cmv(asm_rv32_t *state, mp_uint_t rd, mp_uint_t rs) {
     // CR: 1000 ..... ..... 10
-    asm_rv32_emit_halfword_opcode(state, RV32_ENCODE_TYPE_CR(0b10, 0b1000, rd, rs));
+    asm_rv32_emit_halfword_opcode(state, RV32_ENCODE_TYPE_CR(0x02, 0x08, rd, rs));
 }
 
 // C.SWSP RS, OFFSET
 static inline void asm_rv32_opcode_cswsp(asm_rv32_t *state, mp_uint_t rs, mp_uint_t offset) {
     // CSS: 010 ...... ..... 10
-    asm_rv32_emit_halfword_opcode(state, RV32_ENCODE_TYPE_CSS(0b10, 0b110, rs, ((offset & 0b11000000) >> 6) | (offset & 0b111100)));
+    asm_rv32_emit_halfword_opcode(state, RV32_ENCODE_TYPE_CSS(0x02, 0x06, rs, ((offset & 0xC0) >> 6) | (offset & 0x3C)));
 }
 
 // JALR RD, RS, offset
 static inline void asm_rv32_opcode_jalr(asm_rv32_t *state, mp_uint_t rd, mp_uint_t rs, mp_int_t offset) {
     // I: ............ ..... 000 ..... 1100111
-    asm_rv32_emit_word_opcode(state, RV32_ENCODE_TYPE_I(0b1100111, 0b000, rd, rs, offset));
+    asm_rv32_emit_word_opcode(state, RV32_ENCODE_TYPE_I(0x67, 0x00, rd, rs, offset));
 }
 
 // LBU RD, OFFSET(RS)
 static inline void asm_rv32_opcode_lbu(asm_rv32_t *state, mp_uint_t rd, mp_uint_t rs, mp_int_t offset) {
     // I: ............ ..... 100 ..... 0000011
-    asm_rv32_emit_word_opcode(state, RV32_ENCODE_TYPE_I(0b0000011, 0b100, rd, rs, offset));
+    asm_rv32_emit_word_opcode(state, RV32_ENCODE_TYPE_I(0x03, 0x04, rd, rs, offset));
 }
 
 // LHU RD, OFFSET(RS)
 static inline void asm_rv32_opcode_lhu(asm_rv32_t *state, mp_uint_t rd, mp_uint_t rs, mp_int_t offset) {
     // I: ............ ..... 101 ..... 0000011
-    asm_rv32_emit_word_opcode(state, RV32_ENCODE_TYPE_I(0b0000011, 0b101, rd, rs, offset));
+    asm_rv32_emit_word_opcode(state, RV32_ENCODE_TYPE_I(0x03, 0x05, rd, rs, offset));
 }
 
 // LUI RD, immediate
 static inline void asm_rv32_opcode_lui(asm_rv32_t *state, mp_uint_t rd, mp_int_t immediate) {
     // U: .................... ..... 0110111
-    asm_rv32_emit_word_opcode(state, RV32_ENCODE_TYPE_U(0b0110111, rd, immediate));
+    asm_rv32_emit_word_opcode(state, RV32_ENCODE_TYPE_U(0x37, rd, immediate));
 }
 
 // LW RD, OFFSET(RS)
 static inline void asm_rv32_opcode_lw(asm_rv32_t *state, mp_uint_t rd, mp_uint_t rs, mp_int_t offset) {
     // I: ............ ..... 010 ..... 0000011
-    asm_rv32_emit_word_opcode(state, RV32_ENCODE_TYPE_I(0b0000011, 0b010, rd, rs, offset));
+    asm_rv32_emit_word_opcode(state, RV32_ENCODE_TYPE_I(0x03, 0x02, rd, rs, offset));
 }
 
 // MUL RD, RS1, RS2
 static inline void asm_rv32m_opcode_mul(asm_rv32_t *state, mp_uint_t rd, mp_uint_t rs1, mp_uint_t rs2) {
     // R: 0000001 ..... ..... 000 ..... 0110011
-    asm_rv32_emit_word_opcode(state, RV32_ENCODE_TYPE_R(0b0110011, 0b000, 0b0000001, rd, rs1, rs2));
+    asm_rv32_emit_word_opcode(state, RV32_ENCODE_TYPE_R(0x33, 0x00, 0x01, rd, rs1, rs2));
 }
 
 // OR RD, RS1, RS2
 static inline void asm_rv32_opcode_or(asm_rv32_t *state, mp_uint_t rd, mp_uint_t rs1, mp_uint_t rs2) {
     // R: 0000000 ..... ..... 110 ..... 0110011
-    asm_rv32_emit_word_opcode(state, RV32_ENCODE_TYPE_R(0b0110011, 0b110, 0b0000000, rd, rs1, rs2));
+    asm_rv32_emit_word_opcode(state, RV32_ENCODE_TYPE_R(0x33, 0x06, 0x00, rd, rs1, rs2));
 }
 
 // SLL RD, RS1, RS2
 static inline void asm_rv32_opcode_sll(asm_rv32_t *state, mp_uint_t rd, mp_uint_t rs1, mp_uint_t rs2) {
     // R: 0000000 ..... ..... 001 ..... 0110011
-    asm_rv32_emit_word_opcode(state, RV32_ENCODE_TYPE_R(0b0110011, 0b001, 0b0000000, rd, rs1, rs2));
+    asm_rv32_emit_word_opcode(state, RV32_ENCODE_TYPE_R(0x33, 0x01, 0x00, rd, rs1, rs2));
 }
 
 // SLLI RD, RS, IMMEDIATE
 static inline void asm_rv32_opcode_slli(asm_rv32_t *state, mp_uint_t rd, mp_uint_t rs, mp_uint_t immediate) {
     // I: 0000000..... ..... 001 ..... 0010011
-    asm_rv32_emit_word_opcode(state, RV32_ENCODE_TYPE_I(0b0010011, 0b001, rd, rs, immediate & 0x1F));
+    asm_rv32_emit_word_opcode(state, RV32_ENCODE_TYPE_I(0x13, 0x01, rd, rs, immediate & 0x1F));
 }
 
 // SRL RD, RS1, RS2
 static inline void asm_rv32_opcode_srl(asm_rv32_t *state, mp_uint_t rd, mp_uint_t rs1, mp_uint_t rs2) {
     // R: 0000000 ..... ..... 101 ..... 0110011
-    asm_rv32_emit_word_opcode(state, RV32_ENCODE_TYPE_R(0b0110011, 0b101, 0b0000000, rd, rs1, rs2));
+    asm_rv32_emit_word_opcode(state, RV32_ENCODE_TYPE_R(0x33, 0x05, 0x00, rd, rs1, rs2));
 }
 
 // SLT RD, RS1, RS2
 static inline void asm_rv32_opcode_slt(asm_rv32_t *state, mp_uint_t rd, mp_uint_t rs1, mp_uint_t rs2) {
     // R: 0000000 ..... ..... 010 ..... 0110011
-    asm_rv32_emit_word_opcode(state, RV32_ENCODE_TYPE_R(0b0110011, 0b010, 0b0000000, rd, rs1, rs2));
+    asm_rv32_emit_word_opcode(state, RV32_ENCODE_TYPE_R(0x33, 0x02, 0x00, rd, rs1, rs2));
 }
 
 // SLTU RD, RS1, RS2
 static inline void asm_rv32_opcode_sltu(asm_rv32_t *state, mp_uint_t rd, mp_uint_t rs1, mp_uint_t rs2) {
     // R: 0000000 ..... ..... 011 ..... 0110011
-    asm_rv32_emit_word_opcode(state, RV32_ENCODE_TYPE_R(0b0110011, 0b011, 0b0000000, rd, rs1, rs2));
+    asm_rv32_emit_word_opcode(state, RV32_ENCODE_TYPE_R(0x33, 0x03, 0x00, rd, rs1, rs2));
 }
 
 // SRA RD, RS1, RS2
 static inline void asm_rv32_opcode_sra(asm_rv32_t *state, mp_uint_t rd, mp_uint_t rs1, mp_uint_t rs2) {
     // R: 0100000 ..... ..... 101 ..... 0110011
-    asm_rv32_emit_word_opcode(state, RV32_ENCODE_TYPE_R(0b0110011, 0b101, 0b0100000, rd, rs1, rs2));
+    asm_rv32_emit_word_opcode(state, RV32_ENCODE_TYPE_R(0x33, 0x05, 0x20, rd, rs1, rs2));
 }
 
 // SUB RD, RS1, RS2
 static inline void asm_rv32_opcode_sub(asm_rv32_t *state, mp_uint_t rd, mp_uint_t rs1, mp_uint_t rs2) {
     // R: 0100000 ..... ..... 000 ..... 0110011
-    asm_rv32_emit_word_opcode(state, RV32_ENCODE_TYPE_R(0b0110011, 0b000, 0b0100000, rd, rs1, rs2));
+    asm_rv32_emit_word_opcode(state, RV32_ENCODE_TYPE_R(0x33, 0x00, 0x20, rd, rs1, rs2));
 }
 
 // SB RS2, OFFSET(RS1)
 static inline void asm_rv32_opcode_sb(asm_rv32_t *state, mp_uint_t rs2, mp_uint_t rs1, mp_int_t offset) {
     // S: ....... ..... ..... 000 ..... 0100011
-    asm_rv32_emit_word_opcode(state, RV32_ENCODE_TYPE_S(0b0100011, 0b000, rs1, rs2, offset));
+    asm_rv32_emit_word_opcode(state, RV32_ENCODE_TYPE_S(0x23, 0x00, rs1, rs2, offset));
 }
 
 // SH RS2, OFFSET(RS1)
 static inline void asm_rv32_opcode_sh(asm_rv32_t *state, mp_uint_t rs2, mp_uint_t rs1, mp_int_t offset) {
     // S: ....... ..... ..... 001 ..... 0100011
-    asm_rv32_emit_word_opcode(state, RV32_ENCODE_TYPE_S(0b0100011, 0b001, rs1, rs2, offset));
+    asm_rv32_emit_word_opcode(state, RV32_ENCODE_TYPE_S(0x23, 0x01, rs1, rs2, offset));
 }
 
 // SW RS2, OFFSET(RS1)
 static inline void asm_rv32_opcode_sw(asm_rv32_t *state, mp_uint_t rs2, mp_uint_t rs1, mp_int_t offset) {
     // S: ....... ..... ..... 010 ..... 0100011
-    asm_rv32_emit_word_opcode(state, RV32_ENCODE_TYPE_S(0b0100011, 0b010, rs1, rs2, offset));
+    asm_rv32_emit_word_opcode(state, RV32_ENCODE_TYPE_S(0x23, 0x02, rs1, rs2, offset));
 }
 
 // XOR RD, RS1, RS2
 static inline void asm_rv32_opcode_xor(asm_rv32_t *state, mp_uint_t rd, mp_uint_t rs1, mp_uint_t rs2) {
     // R: 0000000 ..... ..... 100 ..... 0110011
-    asm_rv32_emit_word_opcode(state, RV32_ENCODE_TYPE_R(0b0110011, 0b100, 0b0000000, rd, rs1, rs2));
+    asm_rv32_emit_word_opcode(state, RV32_ENCODE_TYPE_R(0x33, 0x04, 0x00, rd, rs1, rs2));
 }
 
 // XORI RD, RS, IMMEDIATE
 static inline void asm_rv32_opcode_xori(asm_rv32_t *state, mp_uint_t rd, mp_uint_t rs, mp_int_t immediate) {
     // I: ............ ..... 100 ..... 0010011
-    asm_rv32_emit_word_opcode(state, RV32_ENCODE_TYPE_I(0b0010011, 0b100, rd, rs, immediate));
+    asm_rv32_emit_word_opcode(state, RV32_ENCODE_TYPE_I(0x13, 0x04, rd, rs, immediate));
 }
 
 #define ASM_WORD_SIZE (4)


### PR DESCRIPTION
### Summary

As per discussion in https://github.com/micropython/micropython/pull/15347#discussion_r1658693954, non-standard binary literals have been removed in favour of their hexadecimal counterparts.

### Testing

This was tested with the Qemu RISC-V port.