### PR TITLE
ports/rp2: Replace PIO_NUM with pio_get_index.

### DIFF
--- a/ports/rp2/rp2_pio.c
+++ b/ports/rp2/rp2_pio.c
@@ -37,8 +37,6 @@
 #include "hardware/irq.h"
 #include "hardware/pio.h"
 
-#define PIO_NUM(pio) ((pio) == pio0 ? 0 : 1)
-
 typedef struct _rp2_pio_obj_t {
     mp_obj_base_t base;
     PIO pio;
@@ -82,7 +80,7 @@ static void pio_irq0(PIO pio) {
     pio->irq = ints >> 8;
 
     // Call handler if it is registered, for PIO irqs.
-    rp2_pio_irq_obj_t *irq = MP_STATE_PORT(rp2_pio_irq_obj[PIO_NUM(pio)]);
+    rp2_pio_irq_obj_t *irq = MP_STATE_PORT(rp2_pio_irq_obj[pio_get_index(pio)]);
     if (irq != NULL && (ints & irq->trigger)) {
         irq->flags = ints & irq->trigger;
         mp_irq_handler(&irq->base);
@@ -90,7 +88,7 @@ static void pio_irq0(PIO pio) {
 
     // Call handler if it is registered, for StateMachine irqs.
     for (size_t i = 0; i < 4; ++i) {
-        rp2_state_machine_irq_obj_t *irq = MP_STATE_PORT(rp2_state_machine_irq_obj[PIO_NUM(pio) * 4 + i]);
+        rp2_state_machine_irq_obj_t *irq = MP_STATE_PORT(rp2_state_machine_irq_obj[pio_get_index(pio) * 4 + i]);
         if (irq != NULL && ((ints >> (8 + i)) & irq->trigger)) {
             irq->flags = 1;
             mp_irq_handler(&irq->base);
@@ -280,7 +278,7 @@ static mp_obj_t rp2_pio_add_program(mp_obj_t self_in, mp_obj_t prog_in) {
     uint offset = rp2_pio_add_managed_program(self->pio, &pio_program);
 
     // Store the program offset in the program object.
-    prog[PROG_OFFSET_PIO0 + PIO_NUM(self->pio)] = MP_OBJ_NEW_SMALL_INT(offset);
+    prog[PROG_OFFSET_PIO0 + pio_get_index(self->pio)] = MP_OBJ_NEW_SMALL_INT(offset);
 
     return mp_const_none;
 }
@@ -301,12 +299,12 @@ static mp_obj_t rp2_pio_remove_program(size_t n_args, const mp_obj_t *args) {
         mp_buffer_info_t bufinfo;
         mp_get_buffer_raise(prog[PROG_DATA], &bufinfo, MP_BUFFER_READ);
         length = bufinfo.len / 2;
-        offset = mp_obj_get_int(prog[PROG_OFFSET_PIO0 + PIO_NUM(self->pio)]);
+        offset = mp_obj_get_int(prog[PROG_OFFSET_PIO0 + pio_get_index(self->pio)]);
         if (offset < 0) {
             mp_raise_ValueError("prog not in instruction memory");
         }
         // Invalidate the program offset in the program object.
-        prog[PROG_OFFSET_PIO0 + PIO_NUM(self->pio)] = MP_OBJ_NEW_SMALL_INT(-1);
+        prog[PROG_OFFSET_PIO0 + pio_get_index(self->pio)] = MP_OBJ_NEW_SMALL_INT(-1);
     }
 
     // Remove the program from the instruction memory.
@@ -354,7 +352,7 @@ static mp_obj_t rp2_pio_irq(size_t n_args, const mp_obj_t *pos_args, mp_map_t *k
     mp_arg_parse_all(n_args - 1, pos_args + 1, kw_args, MP_ARRAY_SIZE(allowed_args), allowed_args, args);
 
     // Get the IRQ object.
-    rp2_pio_irq_obj_t *irq = MP_STATE_PORT(rp2_pio_irq_obj[PIO_NUM(self->pio)]);
+    rp2_pio_irq_obj_t *irq = MP_STATE_PORT(rp2_pio_irq_obj[pio_get_index(self->pio)]);
 
     // Allocate the IRQ object if it doesn't already exist.
     if (irq == NULL) {
@@ -364,7 +362,7 @@ static mp_obj_t rp2_pio_irq(size_t n_args, const mp_obj_t *pos_args, mp_map_t *k
         irq->base.parent = MP_OBJ_FROM_PTR(self);
         irq->base.handler = mp_const_none;
         irq->base.ishard = false;
-        MP_STATE_PORT(rp2_pio_irq_obj[PIO_NUM(self->pio)]) = irq;
+        MP_STATE_PORT(rp2_pio_irq_obj[pio_get_index(self->pio)]) = irq;
     }
 
     if (n_args > 1 || kw_args->used != 0) {
@@ -426,7 +424,7 @@ MP_DEFINE_CONST_OBJ_TYPE(
 
 static mp_uint_t rp2_pio_irq_trigger(mp_obj_t self_in, mp_uint_t new_trigger) {
     rp2_pio_obj_t *self = MP_OBJ_TO_PTR(self_in);
-    rp2_pio_irq_obj_t *irq = MP_STATE_PORT(rp2_pio_irq_obj[PIO_NUM(self->pio)]);
+    rp2_pio_irq_obj_t *irq = MP_STATE_PORT(rp2_pio_irq_obj[pio_get_index(self->pio)]);
     irq_set_enabled(self->irq, false);
     irq->flags = 0;
     irq->trigger = new_trigger;
@@ -436,7 +434,7 @@ static mp_uint_t rp2_pio_irq_trigger(mp_obj_t self_in, mp_uint_t new_trigger) {
 
 static mp_uint_t rp2_pio_irq_info(mp_obj_t self_in, mp_uint_t info_type) {
     rp2_pio_obj_t *self = MP_OBJ_TO_PTR(self_in);
-    rp2_pio_irq_obj_t *irq = MP_STATE_PORT(rp2_pio_irq_obj[PIO_NUM(self->pio)]);
+    rp2_pio_irq_obj_t *irq = MP_STATE_PORT(rp2_pio_irq_obj[pio_get_index(self->pio)]);
     if (info_type == MP_IRQ_INFO_FLAGS) {
         return irq->flags;
     } else if (info_type == MP_IRQ_INFO_TRIGGERS) {
@@ -537,10 +535,10 @@ static mp_obj_t rp2_state_machine_init_helper(const rp2_state_machine_obj_t *sel
     mp_obj_get_array_fixed_n(args[ARG_prog].u_obj, PROG_MAX_FIELDS, &prog);
 
     // Get and the program offset, and load it into memory if it's not already there.
-    mp_int_t offset = mp_obj_get_int(prog[PROG_OFFSET_PIO0 + PIO_NUM(self->pio)]);
+    mp_int_t offset = mp_obj_get_int(prog[PROG_OFFSET_PIO0 + pio_get_index(self->pio)]);
     if (offset < 0) {
-        rp2_pio_add_program(&rp2_pio_obj[PIO_NUM(self->pio)], args[ARG_prog].u_obj);
-        offset = mp_obj_get_int(prog[PROG_OFFSET_PIO0 + PIO_NUM(self->pio)]);
+        rp2_pio_add_program(&rp2_pio_obj[pio_get_index(self->pio)], args[ARG_prog].u_obj);
+        offset = mp_obj_get_int(prog[PROG_OFFSET_PIO0 + pio_get_index(self->pio)]);
     }
     rp2_state_machine_initial_pc[self->id] = offset;
 
@@ -907,7 +905,7 @@ MP_DEFINE_CONST_OBJ_TYPE(
 
 static mp_uint_t rp2_state_machine_irq_trigger(mp_obj_t self_in, mp_uint_t new_trigger) {
     rp2_state_machine_obj_t *self = MP_OBJ_TO_PTR(self_in);
-    rp2_state_machine_irq_obj_t *irq = MP_STATE_PORT(rp2_state_machine_irq_obj[PIO_NUM(self->pio)]);
+    rp2_state_machine_irq_obj_t *irq = MP_STATE_PORT(rp2_state_machine_irq_obj[pio_get_index(self->pio)]);
     irq_set_enabled(self->irq, false);
     irq->flags = 0;
     irq->trigger = new_trigger;
@@ -917,7 +915,7 @@ static mp_uint_t rp2_state_machine_irq_trigger(mp_obj_t self_in, mp_uint_t new_t
 
 static mp_uint_t rp2_state_machine_irq_info(mp_obj_t self_in, mp_uint_t info_type) {
     rp2_state_machine_obj_t *self = MP_OBJ_TO_PTR(self_in);
-    rp2_state_machine_irq_obj_t *irq = MP_STATE_PORT(rp2_state_machine_irq_obj[PIO_NUM(self->pio)]);
+    rp2_state_machine_irq_obj_t *irq = MP_STATE_PORT(rp2_state_machine_irq_obj[pio_get_index(self->pio)]);
     if (info_type == MP_IRQ_INFO_FLAGS) {
         return irq->flags;
     } else if (info_type == MP_IRQ_INFO_TRIGGERS) {

--- a/ports/rp2/rp2_pio.c
+++ b/ports/rp2/rp2_pio.c
@@ -226,7 +226,7 @@ static void asm_pio_init_gpio(PIO pio, uint32_t sm, asm_pio_config_t *config) {
     pio_sm_set_pins_with_mask(pio, sm, config->pinvals << config->base, pinmask);
     pio_sm_set_pindirs_with_mask(pio, sm, config->pindirs << config->base, pinmask);
     for (size_t i = 0; i < config->count; ++i) {
-        gpio_set_function(config->base + i, pio == pio0 ? GPIO_FUNC_PIO0 : GPIO_FUNC_PIO1);
+        gpio_set_function(config->base + i, GPIO_FUNC_PIO0 + pio_get_index(pio));
     }
 }
 

--- a/ports/rp2/rp2_pio.c
+++ b/ports/rp2/rp2_pio.c
@@ -326,7 +326,7 @@ static mp_obj_t rp2_pio_state_machine(size_t n_args, const mp_obj_t *pos_args, m
     }
 
     // Return the correct StateMachine object.
-    const rp2_state_machine_obj_t *sm = rp2_state_machine_get_object((self->pio == pio0 ? 0 : 4) + sm_id);
+    const rp2_state_machine_obj_t *sm = rp2_state_machine_get_object(pio_get_index(self->pio) * 4 + sm_id);
 
     if (n_args > 2 || kw_args->used > 0) {
         // Configuration arguments given so init this StateMachine.

--- a/ports/rp2/rp2_pio.c
+++ b/ports/rp2/rp2_pio.c
@@ -242,7 +242,7 @@ static rp2_pio_obj_t rp2_pio_obj[] = {
 
 static void rp2_pio_print(const mp_print_t *print, mp_obj_t self_in, mp_print_kind_t kind) {
     rp2_pio_obj_t *self = MP_OBJ_TO_PTR(self_in);
-    mp_printf(print, "PIO(%u)", self->pio == pio0 ? 0 : 1);
+    mp_printf(print, "PIO(%u)", pio_get_index(self->pio));
 }
 
 // constructor(id)


### PR DESCRIPTION
The `PIO_NUM` macro had been defined ~3 years ago when `rp2_pio.c` was first conceived.

There's now a Pico SDK function for this `pio_get_index()`, which is already used in some parts of `rpi_pio.c`.

This change:

* removes `PIO_NUM` in favour of using `pio_get_index()` everywhere.
* fixes `rp2_pio_print` to use `pio_get_index()` too, since it had its own copy of the ternary expression
* remove a ternary from `rp2_pio_state_machine` and calculate it from `pio_get_index`. If it's good enough for `pio_irq0` it's good enough for here.
*  Remove a ternary on `GPIO_FUNC_PIO0` vs `GPIO_FUNC_PIO1` these are, helpfully, sequentially ordered so we can calculate them too.