### PR TITLE
esp32/mpconfigport: Enable the RV32 emitter for ESP32C3 targets.

### DIFF
--- a/ports/esp32/mpconfigport.h
+++ b/ports/esp32/mpconfigport.h
@@ -18,9 +18,8 @@
 
 // object representation and NLR handling
 #define MICROPY_OBJ_REPR                    (MICROPY_OBJ_REPR_A)
+#if !CONFIG_IDF_TARGET_ESP32C3
 #define MICROPY_NLR_SETJMP                  (1)
-#if CONFIG_IDF_TARGET_ESP32C3
-#define MICROPY_GCREGS_SETJMP               (1)
 #endif
 
 // memory allocation policies
@@ -44,6 +43,8 @@
 #define MICROPY_PERSISTENT_CODE_LOAD        (1)
 #if !CONFIG_IDF_TARGET_ESP32C3
 #define MICROPY_EMIT_XTENSAWIN              (1)
+#else
+#define MICROPY_EMIT_RV32                   (1)
 #endif
 
 // workaround for xtensa-esp32-elf-gcc esp-2020r3, which can generate wrong code for loops


### PR DESCRIPTION
### Summary

The RV32 code emitter assumed that the arch-specific NLR was used instead of the setjmp/longjmp based NLR code.  If the latter NLR provider was chosen, the emitter would allocate space on the stack for the NLR buffer but would not fill it in.

This change makes the emitter backend aware of the setjmp-based NLR being enabled and makes sure the native calls to setjmp() are added to the generated code.

### Testing

This was tested on the QEMU RISC-V port using the default configuration and `MICROPY_NLR_SETJMP` enabled, and on an ESP32C3 with the ESP32 port using the default configuration and `MICROPY_EMIT_RV32` enabled.

### Trade-offs and Alternatives

This adds up to 16 bytes to each generated RV32 function that requires setjmp-based NLR (adds two native calls to MP_F_SETJMP in the function setup code).  The main alternative would be to stop compilation if both the setjmp-based NLR and the RV32 emitter are requested at the same time, but that would add a bit more complexity on the port configuration/documentation side.  As an aside, the RV32-specific NLR should probably be used anyway as it takes up 64 bytes on the stack as opposed to newlib's/picolibc's 304 bytes, but that's more of an issue on RV32 MCUs with smaller RAM space than what an ESP32C3 has.

I have limited code changes to the RV32 emitter, even though the Xtensa windowed emitter unconditionally brings in setjmp support in `py/emitnxtensawin.c`.  I wasn't sure on whether said emitter would ever work without a setjmp NLR so I left it alone.