### PR TITLE
rp2: Fix power consumption when sleeping with a timeout.

### DIFF
--- a/ports/rp2/mphalport.c
+++ b/ports/rp2/mphalport.c
@@ -228,6 +228,13 @@ static void soft_timer_hardware_callback(unsigned int alarm_num) {
     // The timer alarm ISR needs to call here and trigger PendSV dispatch via
     // a second ISR, as PendSV may be currently suspended by the other CPU.
     pendsv_schedule_dispatch(PENDSV_DISPATCH_SOFT_TIMER, soft_timer_handler);
+
+    // This ISR only runs on core0, but if core1 is running Python code then it
+    // may be blocked in WFE so wake it up as well. Unfortunately this also sets
+    // the event flag on core0, so a subsequent WFE on this core will not suspend
+    if (core1_entry != NULL) {
+        __sev();
+    }
 }
 
 void soft_timer_init(void) {

--- a/ports/rp2/mpthreadport.c
+++ b/ports/rp2/mpthreadport.c
@@ -39,7 +39,7 @@ extern uint8_t __StackTop, __StackBottom;
 void *core_state[2];
 
 // This will be non-NULL while Python code is executing.
-static void *(*core1_entry)(void *) = NULL;
+core_entry_func_t core1_entry = NULL;
 
 static void *core1_arg = NULL;
 static uint32_t *core1_stack = NULL;

--- a/ports/rp2/mpthreadport.h
+++ b/ports/rp2/mpthreadport.h
@@ -32,6 +32,10 @@ typedef struct mutex mp_thread_mutex_t;
 
 extern void *core_state[2];
 
+typedef void *(*core_entry_func_t)(void *);
+
+extern core_entry_func_t core1_entry;
+
 void mp_thread_init(void);
 void mp_thread_deinit(void);
 void mp_thread_gc_others(void);


### PR DESCRIPTION
### Summary

Fixes a regression introduced in 3af006e (part of #13329), where WFE never blocked in `mp_wfe_or_timeout()` function and would busy-wait instead. This increases power consumption measurably. Originally found when testing https://github.com/micropython/micropython/pull/15345

Root cause is that `mp_wfe_or_timeout()` calls soft timer functions that (after the regression) call `recursive_mutex_enter()` and `recursive_mutex_exit()`. Mutex exit calls `lock_internal_spin_unlock_with_notify()` and the default pico-sdk implementation of this macro issues a SEV which negates the WFE that follows it, meaning the CPU never suspends.

See https://forums.raspberrypi.com/viewtopic.php?p=2233908 for more details.

The fix in this comment adds a custom "nowait" variant mutex that doesn't do WFE/SEV, and uses this one for PendSV. This will use more power when there's contention for the PendSV mutex as the other core will spin, but this shouldn't happen very often.

Additional commit fixes a bug that was masked by this bug, specifically that core1 didn't have any way to resume from WFE (because the soft timer interrupt only triggers on core0).

### Testing

Tested on PICO board while measuring USB power consumption. Prior to this fix, `time.sleep(1)` uses 3-4mA more power than sitting at an idle REPL. After this fix, the power consumption is approximately the same (actually approx 0.3mA higher while sleeping, I assume due to the extra clock or maybe because of USB traffic).

Also ran the full rp2 test suite multiple times. The thread_sleep2 test successfully found the core1 bug mentioned above.

Also connected a PICO-W to a Wi-Fi network.

### Trade-offs and Alternatives

This is the third fix I wrote for this issue(!)

* The first version of this PR replaced the soft timer in `mp_wfe_or_timeout()` with a dedicated hardware timer alarm. This works fine for single core, but in dual core there's potential for both cores to enter this function at the same time meaning this approach is no longer simple.
* I also tried making all the recursive mutexes the "nowait" variety, instead of adding a new variant. This works fine, but it means if there is contention over any mutex then the waiting core will spin. Mostly this probably doesn't matter as there won't be a lot of contention, but there are some pathological cases: For example a program where core1 spends most of its time blocked on a lock or similar.

This approach adds a bit more code size, but it means the low power mutex variant is still used everywhere except for PendSV - and there shouldn't be a lot of lock contention over PendSV.