### PR TITLE
ports/rp2: Lower minimum GC heap.

### DIFF
--- a/ports/rp2/memmap_mp.ld
+++ b/ports/rp2/memmap_mp.ld
@@ -256,9 +256,13 @@ SECTIONS
     __StackBottom = __StackTop - SIZEOF(.stack_dummy);
     PROVIDE(__stack = __StackTop);
 
-    /* Check GC heap is at least 128 KB */
-    /* On a RP2040 using all SRAM this should always be the case. */
-    ASSERT((__GcHeapEnd - __GcHeapStart) > 128*1024, "GcHeap is too small")
+    /* Check GC heap is at least 64 KB */
+    /* This is half the minimum RAM suggested for full-featured MicroPython.
+     * This value accounts for large static buffers included in user C or C++
+     * modules, which might significantly reduce the available heap but also
+     * lower demand for memory at runtime.
+     */
+    ASSERT((__GcHeapEnd - __GcHeapStart) > 64*1024, "GcHeap is too small")
 
     ASSERT( __binary_info_header_end - __logical_binary_start <= 256, "Binary info must be in first 256 bytes of the binary")
     /* todo assert on extra code */


### PR DESCRIPTION
Reduce mimimum heap requirement to half documented minimum MCU RAM for full-featured MicroPython (assuming actual heap + overheads means 128K RAM in real terms offers about 64K heap).

This value allows more room for large, static buffers in user C modules (such as graphics buffers or otherwise) which might be allocated outside of MicroPython's heap to guarantee alignment or avoid fragmentation.

Since the minimum MCU RAM suggested for MicroPython is 128K, and a portion of that must necessarily be MicroPython overheads and the GC's bitmap I believe 64K represents a reasonable hard minimum beyond which MicroPython (on a Pico at least) becomes unpleasant to use.

From allocating large graphics buffers across many Pimoroni products, and doing unspeakable things to make MicroPython ports for PicoSystem, PicoVision and others we've hit ~32K remaining heap often enough to know it's not a bag of laughs, but *mostly* fine.

This limit was set in https://github.com/micropython/micropython/commit/c80e7c14e6305e50e3b39f97172d4d8fe1214d3b so I'm tagging @cpottle9 for comment!

The alternative would be to remove this lower bounds check altogether, or set it to a minimum sensible value such as 16K. The only time this check is ever reasonably going to trigger is when someone is building their own custom MicroPython (with C/C++ modules) and wants a static buffer >~64k (Pico port has 192k heap normally, IIRC) and we can safely assume that someone is making a well-intentioned choice and does not want to maintain a downstream hack of the linker script.... It's me. That someone is me.

