### PR TITLE
esp32,esp8266: Use new mp_obj_new_str_from_cstr() function.

### DIFF
--- a/ports/esp32/network_common.c
+++ b/ports/esp32/network_common.c
@@ -166,7 +166,7 @@ static mp_obj_t esp_network_ipconfig(size_t n_args, const mp_obj_t *args, mp_map
             case MP_QSTR_dns: {
                 char addr_str[IPADDR_STRLEN_MAX];
                 ipaddr_ntoa_r(dns_getserver(0), addr_str, sizeof(addr_str));
-                return mp_obj_new_str(addr_str, strlen(addr_str));
+                return mp_obj_new_str_from_cstr(addr_str);
             }
             default: {
                 mp_raise_ValueError(MP_ERROR_TEXT("unexpected key"));

--- a/ports/esp8266/network_wlan.c
+++ b/ports/esp8266/network_wlan.c
@@ -345,7 +345,7 @@ static mp_obj_t esp_network_ipconfig(size_t n_args, const mp_obj_t *args, mp_map
                 char addr_str[IPADDR_STRLEN_MAX];
                 ip_addr_t dns_addr = dns_getserver(0);
                 ipaddr_ntoa_r(&dns_addr, addr_str, sizeof(addr_str));
-                return mp_obj_new_str(addr_str, strlen(addr_str));
+                return mp_obj_new_str_from_cstr(addr_str);
             }
             default: {
                 mp_raise_ValueError(MP_ERROR_TEXT("unexpected key"));


### PR DESCRIPTION
These were missed in the previous commit.
