### PR TITLE
tests: fix thread aes and bytecode limit stress tests

### DIFF
--- a/tests/stress/bytecode_limit.py
+++ b/tests/stress/bytecode_limit.py
@@ -3,14 +3,18 @@
 body = " with f()()() as a:\n  try:\n   f()()()\n  except Exception:\n   pass\n"
 
 # Test overflow of jump offset.
+# Print results at the end in case an intermediate value of n fails with MemoryError.
+results = []
 for n in (433, 432, 431, 430):
     try:
         exec("cond = 0\nif cond:\n" + body * n + "else:\n print('cond false')\n")
+        results.append((n, "ok"))
     except MemoryError:
         print("SKIP")
         raise SystemExit
     except RuntimeError:
-        print("RuntimeError")
+        results.append((n, "RuntimeError"))
+print(results)
 
 # Test changing size of code info (source line/bytecode mapping) due to changing
 # bytecode size in the final passes.  This test is very specific to how the

--- a/tests/stress/bytecode_limit.py.exp
+++ b/tests/stress/bytecode_limit.py.exp
@@ -1,5 +1,4 @@
-RuntimeError
-RuntimeError
 cond false
 cond false
+[(433, 'RuntimeError'), (432, 'RuntimeError'), (431, 'ok'), (430, 'ok')]
 [123]

--- a/tests/thread/stress_aes.py
+++ b/tests/thread/stress_aes.py
@@ -282,6 +282,6 @@ if __name__ == "__main__":
     for i in range(n_thread):
         _thread.start_new_thread(thread_entry, (n_loop,))
     thread_entry(n_loop)
-    while count.value < n_thread:
+    while count.value < n_thread + 1:
         time.sleep(1)
     print("done")


### PR DESCRIPTION
### Summary

On RPI_PICO_W these two tests fail.  This PR fixes both of them so they run correctly on RPI_PICO_W.

### Testing

Tested on RPI_PICO_W and unix port.

