### PR TITLE
ports/rp2: Enable ipv6 per default for rp2.

### DIFF
--- a/ports/rp2/lwip_inc/lwipopts.h
+++ b/ports/rp2/lwip_inc/lwipopts.h
@@ -26,7 +26,10 @@
 #define LWIP_NETIF_EXT_STATUS_CALLBACK  1
 #define LWIP_NETIF_STATUS_CALLBACK      1
 
-#define LWIP_IPV6                       0
+#define LWIP_IPV4                       1
+#define LWIP_IPV6                       1
+#define LWIP_ND6_NUM_DESTINATIONS       4
+#define LWIP_ND6_QUEUEING               0
 #define LWIP_DHCP                       1
 #define LWIP_DHCP_CHECK_LINK_UP         1
 #define DHCP_DOES_ARP_CHECK             0 // to speed DHCP up


### PR DESCRIPTION
### Summary

Having IPv6 support is important, especially for IoT-Devices which might be many, requiring individual IP-addresses. In particular direct access via link-local addresses and having deterministic SLAAC-addresses can be quite convenient. Also in IPv6-only networks or for connecting to IPv6-only services, this is very useful.

I believe that for the Raspberry Pico W, there is enough flash and RAM that enabling IPv6 by default is the right choice.


### Testing

I'm using this change on a Raspberry Pico W for nearly 2 years now and haven't experienced any problems.


### Trade-offs and Alternatives
Should IPv6 support in a network exist (i.e. there are Router Advertisements), but not provide connectivity, connecting by domain name should not be a problem, as DNS will default to return the IPv4-address, if existent, unless reconfigured at runtime to prefer IPv6.

In any case a user can disable obtaining SLAAC-addresses with  `<nic>.ipconfig(autoconf6=False)`.
