### PR TITLE
esp32/network_lan: Check for valid LAN MAC address.

### DIFF
--- a/ports/esp32/network_lan.c
+++ b/ports/esp32/network_lan.c
@@ -36,6 +36,7 @@
 
 #include "esp_eth.h"
 #include "esp_eth_mac.h"
+#include "esp_mac.h"
 #include "esp_event.h"
 #include "esp_log.h"
 #include "esp_netif.h"
@@ -90,6 +91,17 @@ static void eth_event_handler(void *arg, esp_event_base_t event_base,
             break;
         default:
             break;
+    }
+}
+
+static void set_mac_address(lan_if_obj_t *self, uint8_t *mac, size_t len) {
+    if (len != 6) {
+        mp_raise_ValueError(MP_ERROR_TEXT("invalid buffer length"));
+    }
+    if (((mac[0] & 0x01) != 0) ||
+        (esp_eth_ioctl(self->eth_handle, ETH_CMD_S_MAC_ADDR, mac) != ESP_OK) ||
+        (esp_netif_set_mac(self->base.netif, mac) != ESP_OK)) {
+        mp_raise_msg(&mp_type_OSError, MP_ERROR_TEXT("failed setting MAC address"));
     }
 }
 
@@ -302,6 +314,14 @@ static mp_obj_t get_lan(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_ar
         mp_raise_msg(&mp_type_OSError, MP_ERROR_TEXT("esp_netif_attach failed"));
     }
 
+    // If MAC address is unset, set it to the address reserved for the ESP32 ETH interface
+    uint8_t mac_addr[6];
+    esp_eth_ioctl(self->eth_handle, ETH_CMD_G_MAC_ADDR, mac_addr);
+    if ((mac_addr[0] | mac_addr[1] | mac_addr[2] | mac_addr[3] | mac_addr[4] | mac_addr[5]) == 0) {
+        esp_read_mac(mac_addr, ESP_MAC_ETH);  // Get ESP32 MAC address for ETH iface
+        set_mac_address(self, mac_addr, sizeof(mac_addr));
+    }
+
     eth_status = ETH_INITIALIZED;
 
     return MP_OBJ_FROM_PTR(&lan_obj);
@@ -356,15 +376,7 @@ static mp_obj_t lan_config(size_t n_args, const mp_obj_t *args, mp_map_t *kwargs
                     case MP_QSTR_mac: {
                         mp_buffer_info_t bufinfo;
                         mp_get_buffer_raise(kwargs->table[i].value, &bufinfo, MP_BUFFER_READ);
-                        if (bufinfo.len != 6) {
-                            mp_raise_ValueError(MP_ERROR_TEXT("invalid buffer length"));
-                        }
-                        if (
-                            (esp_eth_ioctl(self->eth_handle, ETH_CMD_S_MAC_ADDR, bufinfo.buf) != ESP_OK) ||
-                            (esp_netif_set_mac(self->base.netif, bufinfo.buf) != ESP_OK)
-                            ) {
-                            mp_raise_msg(&mp_type_OSError, MP_ERROR_TEXT("failed setting MAC address"));
-                        }
+                        set_mac_address(self, bufinfo.buf, bufinfo.len);
                         break;
                     }
                     default:


### PR DESCRIPTION
### Summary

`LAN.active()`: Check for a valid MAC address before enabling the LAN interface. 

SPI LAN devices may be initialised with a MAC address of 00:00:00:00:00:00 which will be ignored by DHCP servers and may conflict with other uninitialised devices on the local network.

This PR checks that a valid unicast MAC address has been set (using `LAN.config(mac=...)`) before enabling the LAN interface and will raise OSError("invalid MAC address") if the MAC address is not valid.

Fixes #15425.

### Testing

Tested with LILYGO T-ETH-LITE ESP32S3 board (with initialised and uninitialised MAC addresses). Also tested that devices initialised with a multicast MAC address will raise an OSError("invalid MAC address").

### Trade-offs and Alternatives

Alternatively, guidance could be provided in the LAN network docs to properly initialise the MAC address before calling `LAN.active(True)`.
