### PR TITLE
ports/rp2: Disable correct IRQ for PIO1.

### DIFF
--- a/ports/rp2/rp2_pio.c
+++ b/ports/rp2/rp2_pio.c
@@ -149,7 +149,7 @@ void rp2_pio_init(void) {
 
 void rp2_pio_deinit(void) {
     // Disable and clear interrupts.
-    irq_set_mask_enabled((1u << PIO0_IRQ_0) | (1u << PIO0_IRQ_1), false);
+    irq_set_mask_enabled((1u << PIO0_IRQ_0) | (1u << PIO1_IRQ_0), false);
     irq_remove_handler(PIO0_IRQ_0, pio0_irq0);
     irq_remove_handler(PIO1_IRQ_0, pio1_irq0);
 


### PR DESCRIPTION
Caught this while monkeying around trying to get some whacky custom C++ module to not hardlock on soft reset.