### PR TITLE
ports/unix/modtermios.c: add baudrate options.

### DIFF
--- a/ports/unix/modtermios.c
+++ b/ports/unix/modtermios.c
@@ -141,6 +141,27 @@ static const mp_rom_map_elem_t mp_module_termios_globals_table[] = {
     #ifdef B115200
     C(B115200),
     #endif
+    #ifdef B230400
+    C(B230400),
+    #endif
+    #ifdef B460800
+    C(B460800),
+    #endif
+    #ifdef B500000
+    C(B500000),
+    #endif
+    #ifdef B576000
+    C(B576000),
+    #endif
+    #ifdef B921600
+    C(B921600),
+    #endif
+    #ifdef B1000000
+    C(B1000000),
+    #endif
+    #ifdef B1152000
+    C(B1152000)
+    #endif
 #undef C
 };
 


### PR DESCRIPTION
### Summary

This adds some more baudrate option as they are available in the linux kernel - up to a certain point that seams reasonable in an embedded context. 

### Testing

Compiled on linux 6.9.7 and opened a connection to a USB-to-Serial adapter with one of the higher baudrates (via patched [pycopy-serial/](https://github.com/pfalcon/pycopy))


### Trade-offs and Alternatives

The number of possible options could probably be reduced to reduce code size since such high speeds might not be very common. Obviously just having a maximum of 115200 seemed to be good enough until now.

