### PR TITLE
ports/unix: extmod/modre.c Fix regression on FreeBSD build.

### DIFF
--- a/extmod/modre.c
+++ b/extmod/modre.c
@@ -194,7 +194,8 @@ static void re_print(const mp_print_t *print, mp_obj_t self_in, mp_print_kind_t 
     mp_printf(print, "<re %p>", self);
 }
 
-static mp_obj_t re_exec(bool is_anchored, uint n_args, const mp_obj_t *args) {
+// Note: this function can't be named re_exec because it may clash with system headers, eg on FreeBSD
+static mp_obj_t re_exec_helper(bool is_anchored, uint n_args, const mp_obj_t *args) {
     (void)n_args;
     mp_obj_re_t *self;
     if (mp_obj_is_type(args[0], (mp_obj_type_t *)&re_type)) {
@@ -223,12 +224,12 @@ static mp_obj_t re_exec(bool is_anchored, uint n_args, const mp_obj_t *args) {
 }
 
 static mp_obj_t re_match(size_t n_args, const mp_obj_t *args) {
-    return re_exec(true, n_args, args);
+    return re_exec_helper(true, n_args, args);
 }
 MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(re_match_obj, 2, 4, re_match);
 
 static mp_obj_t re_search(size_t n_args, const mp_obj_t *args) {
-    return re_exec(false, n_args, args);
+    return re_exec_helper(false, n_args, args);
 }
 MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(re_search_obj, 2, 4, re_search);
 


### PR DESCRIPTION
### Summary

Fix for issue I reported earlier #15430

### Testing

Verified build now completes on FreeBSD14.1 and runs properly

```console
[owen@calvin ~/micropython/micropython]$ uname -a
FreeBSD calvin.easytarget.org 14.1-RELEASE-p2 FreeBSD 14.1-RELEASE-p2 #12 releng/14.1-n267684-1eba659e2f68-dirty: Tue Jul  2 02:05:23 CEST 2024     root@calvin.easytarget.org:/usr/obj/usr/src/amd64.amd64/sys/CALVINKERNEL amd64

[owen@calvin ~/micropython/micropython]$ ./ports/unix/build-standard/micropython 
MicroPython 358e501e7-dirty on 2024-07-08; linux [GCC 13.2.0] version
Use Ctrl-D to exit, Ctrl-E for paste mode
>>> 
```


