### PR TITLE
py/scheduler,rp2: Avoid scheduler race conditions when GIL disabled, fix "TinyUSB callback can't recurse" error

### DIFF
--- a/docs/library/micropython.rst
+++ b/docs/library/micropython.rst
@@ -136,6 +136,14 @@ Functions
    the heap may be locked) and scheduling a function to call later will lift
    those restrictions.
 
+   On multi-threaded ports, the scheduled function's behaviour depends on
+   whether the Global Interpreter Lock (GIL) is enabled for the specific port:
+
+   - If GIL is enabled, the function can preempt any thread and run in its
+     context.
+   - If GIL is disabled, the function will only preempt the main thread and run
+     in its context.
+
    Note: If `schedule()` is called from a preempting IRQ, when memory
    allocation is not allowed and the callback to be passed to `schedule()` is
    a bound method, passing this directly will fail. This is because creating a

--- a/shared/tinyusb/mp_usbd_runtime.c
+++ b/shared/tinyusb/mp_usbd_runtime.c
@@ -501,6 +501,15 @@ void mp_usbd_task_callback(mp_sched_node_t *node) {
 // Task function can be called manually to force processing of USB events
 // (mostly from USB-CDC serial port when blocking.)
 void mp_usbd_task(void) {
+    #if MICROPY_PY_THREAD && !MICROPY_PY_THREAD_GIL
+    if (!mp_thread_is_main_thread()) {
+        // Avoid race with the scheduler callback by scheduling TinyUSB to run
+        // on the main thread.
+        mp_usbd_schedule_task();
+        return;
+    }
+    #endif
+
     if (in_usbd_task) {
         // If this exception triggers, it means a USB callback tried to do
         // something that itself became blocked on TinyUSB (most likely: read or

--- a/tests/thread/thread_stdin.py
+++ b/tests/thread/thread_stdin.py
@@ -1,0 +1,44 @@
+# Test that having multiple threads block on stdin doesn't cause any issues.
+#
+# The test doesn't expect any input on stdin.
+#
+# This is a regression test for https://github.com/micropython/micropython/issues/15230
+# on rp2, but doubles as a general property to test across all ports.
+import sys
+import _thread
+
+try:
+    import select
+except ImportError:
+    print("SKIP")
+    raise SystemExit
+
+
+class StdinWaiter:
+    def __init__(self):
+        self._done = False
+
+    def wait_stdin(self, timeout_ms):
+        poller = select.poll()
+        poller.register(sys.stdin, select.POLLIN)
+        poller.poll(timeout_ms)
+        # Ignoring the poll result as we don't expect any input
+        self._done = True
+
+    def is_done(self):
+        return self._done
+
+
+thread_waiter = StdinWaiter()
+_thread.start_new_thread(thread_waiter.wait_stdin, (1000,))
+StdinWaiter().wait_stdin(1000)
+
+# Spinning here is mostly not necessary but there is some inconsistency waking
+# the two threads, especially on CPython CI runners where the thread may not
+# have run yet. The actual delay is <20ms but spinning here instead of
+# sleep(0.1) means the test can run on MP builds without float support.
+while not thread_waiter.is_done():
+    pass
+
+# The background thread should have completed its wait by now.
+print(thread_waiter.is_done())


### PR DESCRIPTION
### Summary

Looks like there was a bug since v1.22 when using rp2 threads, where either CPU may poll CDC input and trigger the TinyUSB task. TinyUSB could run on both CPUs concurrently, which may have lead to some incorrect behaviour.

The race started triggering an exception when runtime USB support was added, and a check was added for the USB task recursing on itself from a Python handler function. This check can be incorrectly triggered by the race (as the flag that indicates the TinyUSB task is running is set by the other CPU).

The race is most commonly triggered when working from the interactive REPL, even a minimal running thread can trigger it. This commit adds a test case that triggers it in a different way (polling stdin from a thread).

The root cause is that the scheduler on threaded ports without GIL can run on any thread, and creates potential for race conditions that are hard to avoid. So the first fix is to run all scheduler callbacks on the main thread if GIL disabled.

The secondary fix is not to run the TinyUSB task when polled from another task, if the GIL is disabled. Instead we schedule the TinyUSB task to run on the main thread.

Closes #15390.

### Trade-offs and Alternatives

Could make the scheduler always only run on the main thread, but with the GIL this has quite an impact on scheduler latency - and isn't necessary for correct behaviour. There is a branch linked from a comment below that mostly works around this, but it's a more complex change (and will still have higher latency than running the callback immediately in whatever thread is currently holding the GIL).

### Testing

* Ran all thread tests, including the new test case, on rp2 port with and without `MICROPY_HW_ENABLE_USB_RUNTIME_DEVICE` set, verified no longer raises an exception.
* Ran all thread tests on esp32 port, verified no regression when GIL enabled.

*This work was funded through GitHub Sponsors.*
