### PR TITLE
mp_usbd_cdc.c: Skip writing to an uninitialized USB device.

### DIFF
--- a/shared/tinyusb/mp_usbd.h
+++ b/shared/tinyusb/mp_usbd.h
@@ -125,7 +125,6 @@ inline static bool mp_usb_device_builtin_enabled(const mp_obj_usb_device_t *usbd
 
 static inline void mp_usbd_init(void) {
     // Without runtime USB support, this can be a thin wrapper wrapper around tusb_init()
-    extern bool tusb_init(void);
     tusb_init();
 }
 

--- a/shared/tinyusb/mp_usbd_cdc.c
+++ b/shared/tinyusb/mp_usbd_cdc.c
@@ -95,6 +95,9 @@ void tud_cdc_rx_cb(uint8_t itf) {
 }
 
 mp_uint_t mp_usbd_cdc_tx_strn(const char *str, mp_uint_t len) {
+    if (!tusb_inited()) {
+        return 0;
+    }
     size_t i = 0;
     while (i < len) {
         uint32_t n = len - i;


### PR DESCRIPTION
During execution of boot.py the USB device is not yet initialized. Any attempt to write would lock up the device. This change skips writing. Any output from boot.py is lost, but the device does not lock up.

Attempt to fix issue #15471.