### PR TITLE
tests/extmod: Make get_event_loop tests compatible with CPython 3.12.

### DIFF
--- a/tests/extmod/asyncio_get_event_loop.py
+++ b/tests/extmod/asyncio_get_event_loop.py
@@ -1,11 +1,15 @@
 # Test get_event_loop()
-# Note: CPython deprecated get_event_loop() so this test needs a .exp
 
 try:
     import asyncio
 except ImportError:
     print("SKIP")
     raise SystemExit
+
+# CPython 3.12 deprecated calling get_event_loop() when there is no current event
+# loop, so to make this test run on CPython requires setting the event loop.
+if hasattr(asyncio, "set_event_loop"):
+    asyncio.set_event_loop(asyncio.new_event_loop())
 
 
 async def main():

--- a/tests/extmod/asyncio_get_event_loop.py.exp
+++ b/tests/extmod/asyncio_get_event_loop.py.exp
@@ -1,2 +1,0 @@
-start
-end

--- a/tests/extmod/asyncio_new_event_loop.py
+++ b/tests/extmod/asyncio_new_event_loop.py
@@ -1,11 +1,15 @@
 # Test Loop.new_event_loop()
-# Note: CPython deprecated get_event_loop() so this test needs a .exp
 
 try:
     import asyncio
 except ImportError:
     print("SKIP")
     raise SystemExit
+
+# CPython 3.12 deprecated calling get_event_loop() when there is no current event
+# loop, so to make this test run on CPython requires setting the event loop.
+if hasattr(asyncio, "set_event_loop"):
+    asyncio.set_event_loop(asyncio.new_event_loop())
 
 
 async def task():

--- a/tests/extmod/asyncio_new_event_loop.py.exp
+++ b/tests/extmod/asyncio_new_event_loop.py.exp
@@ -1,6 +1,0 @@
-start
-task 0
-stop
-start
-task 0
-stop


### PR DESCRIPTION
Follow up to 2e852522b178e6e9b2f0cdb954ba44aa9e7d7c0d: instead of having .exp files for the get_event_loop tests, tweak them so they are compatible with CPython 3.12.  This requires calling `asyncio.set_event_loop()` so there is an active event loop and `asyncio.get_event_loop()` succeeds without a warning.

