### PR TITLE
py: remove five TODOs and implement two other minor ones

### DIFF
--- a/py/emitbc.c
+++ b/py/emitbc.c
@@ -794,10 +794,10 @@ static void emit_bc_call_function_method_helper(emit_t *emit, int stack_adj, mp_
         // each positional arg is one object, each kwarg is two objects, the key
         // and the value and one extra object for the star args bitmap.
         stack_adj -= (int)n_positional + 2 * (int)n_keyword + 1;
-        emit_write_bytecode_byte_uint(emit, stack_adj, bytecode_base + 1, (n_keyword << 8) | n_positional); // TODO make it 2 separate uints?
+        emit_write_bytecode_byte_uint(emit, stack_adj, bytecode_base + 1, (n_keyword << 8) | n_positional);
     } else {
         stack_adj -= (int)n_positional + 2 * (int)n_keyword;
-        emit_write_bytecode_byte_uint(emit, stack_adj, bytecode_base, (n_keyword << 8) | n_positional); // TODO make it 2 separate uints?
+        emit_write_bytecode_byte_uint(emit, stack_adj, bytecode_base, (n_keyword << 8) | n_positional);
     }
 }
 

--- a/py/lexer.c
+++ b/py/lexer.c
@@ -228,7 +228,6 @@ static const char *const tok_enc =
     "=e="         // = ==
     "!.";         // start of special cases: != . ...
 
-// TODO static assert that number of tokens is less than 256 so we can safely make this table with byte sized entries
 static const uint8_t tok_enc_kind[] = {
     MP_TOKEN_DEL_PAREN_OPEN, MP_TOKEN_DEL_PAREN_CLOSE,
     MP_TOKEN_DEL_BRACKET_OPEN, MP_TOKEN_DEL_BRACKET_CLOSE,
@@ -773,6 +772,9 @@ void mp_lexer_to_next(mp_lexer_t *lex) {
 
     } else {
         // search for encoded delimiter or operator
+
+        // assert that the token enum value fits in a byte, so they all fit in tok_enc_kind
+        MP_STATIC_ASSERT(MP_TOKEN_NUMBER_OF <= 256);
 
         const char *t = tok_enc;
         size_t tok_enc_index = 0;

--- a/py/lexer.h
+++ b/py/lexer.h
@@ -152,6 +152,8 @@ typedef enum _mp_token_kind_t {
     MP_TOKEN_DEL_SEMICOLON,
     MP_TOKEN_DEL_EQUAL,
     MP_TOKEN_DEL_MINUS_MORE,
+
+    MP_TOKEN_NUMBER_OF,
 } mp_token_kind_t;
 
 // this data structure is exposed for efficiency

--- a/py/obj.h
+++ b/py/obj.h
@@ -1258,7 +1258,7 @@ bool mp_seq_cmp_bytes(mp_uint_t op, const byte *data1, size_t len1, const byte *
 bool mp_seq_cmp_objs(mp_uint_t op, const mp_obj_t *items1, size_t len1, const mp_obj_t *items2, size_t len2);
 mp_obj_t mp_seq_index_obj(const mp_obj_t *items, size_t len, size_t n_args, const mp_obj_t *args);
 mp_obj_t mp_seq_count_obj(const mp_obj_t *items, size_t len, mp_obj_t value);
-mp_obj_t mp_seq_extract_slice(size_t len, const mp_obj_t *seq, mp_bound_slice_t *indexes);
+mp_obj_t mp_seq_extract_slice(const mp_obj_t *seq, mp_bound_slice_t *indexes);
 
 // Helper to clear stale pointers from allocated, but unused memory, to preclude GC problems
 #define mp_seq_clear(start, len, alloc_len, item_sz) memset((byte *)(start) + (len) * (item_sz), 0, ((alloc_len) - (len)) * (item_sz))

--- a/py/objlist.c
+++ b/py/objlist.c
@@ -188,7 +188,7 @@ static mp_obj_t list_subscr(mp_obj_t self_in, mp_obj_t index, mp_obj_t value) {
         if (mp_obj_is_type(index, &mp_type_slice)) {
             mp_bound_slice_t slice;
             if (!mp_seq_get_fast_slice_indexes(self->len, index, &slice)) {
-                return mp_seq_extract_slice(self->len, self->items, &slice);
+                return mp_seq_extract_slice(self->items, &slice);
             }
             mp_obj_list_t *res = list_new(slice.stop - slice.start);
             mp_seq_copy(res->items, self->items + slice.start, res->len, mp_obj_t);

--- a/py/objrange.c
+++ b/py/objrange.c
@@ -33,7 +33,6 @@
 
 typedef struct _mp_obj_range_it_t {
     mp_obj_base_t base;
-    // TODO make these values generic objects or something
     mp_int_t cur;
     mp_int_t stop;
     mp_int_t step;
@@ -72,7 +71,6 @@ static mp_obj_t mp_obj_new_range_iterator(mp_int_t cur, mp_int_t stop, mp_int_t 
 
 typedef struct _mp_obj_range_t {
     mp_obj_base_t base;
-    // TODO make these values generic objects or something
     mp_int_t start;
     mp_int_t stop;
     mp_int_t step;

--- a/py/repl.c
+++ b/py/repl.c
@@ -225,7 +225,6 @@ static void print_completions(const mp_print_t *print,
                     gap += WORD_SLOT_LEN;
                 }
                 if (line_len + gap + d_len <= MAX_LINE_LEN) {
-                    // TODO optimise printing of gap?
                     for (int j = 0; j < gap; ++j) {
                         mp_print_str(print, " ");
                     }

--- a/py/sequence.c
+++ b/py/sequence.c
@@ -63,11 +63,7 @@ bool mp_seq_get_fast_slice_indexes(mp_uint_t len, mp_obj_t slice, mp_bound_slice
     return indexes->step == 1;
 }
 
-#endif
-
-mp_obj_t mp_seq_extract_slice(size_t len, const mp_obj_t *seq, mp_bound_slice_t *indexes) {
-    (void)len; // TODO can we remove len from the arg list?
-
+mp_obj_t mp_seq_extract_slice(const mp_obj_t *seq, mp_bound_slice_t *indexes) {
     mp_int_t start = indexes->start, stop = indexes->stop;
     mp_int_t step = indexes->step;
 
@@ -86,6 +82,8 @@ mp_obj_t mp_seq_extract_slice(size_t len, const mp_obj_t *seq, mp_bound_slice_t 
     }
     return res;
 }
+
+#endif
 
 // Special-case comparison function for sequences of bytes
 // Don't pass MP_BINARY_OP_NOT_EQUAL here


### PR DESCRIPTION
This cleans up a bit of the code by removing/implementing some very minor TODOs.
