### PR TITLE
Make raising `SystemExit` do a soft reset on bare-metal targets

### DIFF
--- a/extmod/modmachine.c
+++ b/extmod/modmachine.c
@@ -62,7 +62,6 @@ NORETURN static void mp_machine_deepsleep(size_t n_args, const mp_obj_t *args);
 #endif
 
 static mp_obj_t machine_soft_reset(void) {
-    pyexec_system_exit = PYEXEC_FORCED_EXIT;
     mp_raise_type(&mp_type_SystemExit);
 }
 static MP_DEFINE_CONST_FUN_OBJ_0(machine_soft_reset_obj, machine_soft_reset);

--- a/extmod/modmachine.c
+++ b/extmod/modmachine.c
@@ -24,6 +24,7 @@
  * THE SOFTWARE.
  */
 
+#include "py/builtin.h"
 #include "py/runtime.h"
 
 #if MICROPY_PY_MACHINE
@@ -33,6 +34,10 @@
 
 #if MICROPY_PY_MACHINE_DHT_READINTO
 #include "drivers/dht/dht.h"
+#endif
+
+#if !MICROPY_PY_SYS_EXIT
+#error MICROPY_PY_MACHINE requires MICROPY_PY_SYS_EXIT
 #endif
 
 // The port must provide implementations of these low-level machine functions.
@@ -60,11 +65,6 @@ NORETURN static void mp_machine_deepsleep(size_t n_args, const mp_obj_t *args);
 #ifdef MICROPY_PY_MACHINE_INCLUDEFILE
 #include MICROPY_PY_MACHINE_INCLUDEFILE
 #endif
-
-static mp_obj_t machine_soft_reset(void) {
-    mp_raise_type(&mp_type_SystemExit);
-}
-static MP_DEFINE_CONST_FUN_OBJ_0(machine_soft_reset_obj, machine_soft_reset);
 
 #if MICROPY_PY_MACHINE_BOOTLOADER
 NORETURN mp_obj_t machine_bootloader(size_t n_args, const mp_obj_t *args) {
@@ -156,7 +156,7 @@ static const mp_rom_map_elem_t machine_module_globals_table[] = {
     #endif
 
     // Reset related functions.
-    { MP_ROM_QSTR(MP_QSTR_soft_reset), MP_ROM_PTR(&machine_soft_reset_obj) },
+    { MP_ROM_QSTR(MP_QSTR_soft_reset), MP_ROM_PTR(&mp_sys_exit_obj) },
     #if MICROPY_PY_MACHINE_BOOTLOADER
     { MP_ROM_QSTR(MP_QSTR_bootloader), MP_ROM_PTR(&machine_bootloader_obj) },
     #endif

--- a/ports/qemu-arm/modmachine.c
+++ b/ports/qemu-arm/modmachine.c
@@ -27,9 +27,6 @@
 // This file is never compiled standalone, it's included directly from
 // extmod/modmachine.c via MICROPY_PY_MACHINE_INCLUDEFILE.
 
-// This variable is needed for machine.soft_reset(), but the variable is otherwise unused.
-int pyexec_system_exit = 0;
-
 static void mp_machine_idle(void) {
     // Do nothing.
 }

--- a/ports/unix/modmachine.c
+++ b/ports/unix/modmachine.c
@@ -36,9 +36,6 @@
 #define MICROPY_PAGE_MASK (MICROPY_PAGE_SIZE - 1)
 #endif
 
-// This variable is needed for machine.soft_reset(), but the variable is otherwise unused.
-int pyexec_system_exit = 0;
-
 uintptr_t mod_machine_mem_get_addr(mp_obj_t addr_o, uint align) {
     uintptr_t addr = mp_obj_get_int_truncated(addr_o);
     if ((addr & (align - 1)) != 0) {

--- a/py/builtin.h
+++ b/py/builtin.h
@@ -126,6 +126,8 @@ MP_DECLARE_CONST_FUN_OBJ_2(mp_op_getitem_obj);
 MP_DECLARE_CONST_FUN_OBJ_3(mp_op_setitem_obj);
 MP_DECLARE_CONST_FUN_OBJ_2(mp_op_delitem_obj);
 
+MP_DECLARE_CONST_FUN_OBJ_VAR_BETWEEN(mp_sys_exit_obj);
+
 // Modules needed by the runtime.
 extern const mp_obj_dict_t mp_module_builtins_globals;
 extern const mp_obj_module_t mp_module___main__;

--- a/shared/runtime/pyexec.c
+++ b/shared/runtime/pyexec.c
@@ -44,7 +44,6 @@
 #include "genhdr/mpversion.h"
 
 pyexec_mode_kind_t pyexec_mode_kind = PYEXEC_MODE_FRIENDLY_REPL;
-int pyexec_system_exit = 0;
 
 #if MICROPY_REPL_INFO
 static bool repl_display_debugging_info = 0;
@@ -73,9 +72,6 @@ static int parse_compile_execute(const void *source, mp_parse_input_kind_t input
     #ifdef MICROPY_BOARD_BEFORE_PYTHON_EXEC
     MICROPY_BOARD_BEFORE_PYTHON_EXEC(input_kind, exec_flags);
     #endif
-
-    // by default a SystemExit exception returns 0
-    pyexec_system_exit = 0;
 
     nlr_buf_t nlr;
     nlr.ret_val = NULL;
@@ -146,7 +142,7 @@ static int parse_compile_execute(const void *source, mp_parse_input_kind_t input
         // check for SystemExit
         if (mp_obj_is_subclass_fast(MP_OBJ_FROM_PTR(((mp_obj_base_t *)nlr.ret_val)->type), MP_OBJ_FROM_PTR(&mp_type_SystemExit))) {
             // at the moment, the value of SystemExit is unused
-            ret = pyexec_system_exit;
+            ret = PYEXEC_FORCED_EXIT;
         } else {
             mp_obj_print_exception(&mp_plat_print, MP_OBJ_FROM_PTR(nlr.ret_val));
             ret = 0;

--- a/shared/runtime/pyexec.h
+++ b/shared/runtime/pyexec.h
@@ -35,11 +35,6 @@ typedef enum {
 
 extern pyexec_mode_kind_t pyexec_mode_kind;
 
-// Set this to the value (eg PYEXEC_FORCED_EXIT) that will be propagated through
-// the pyexec functions if a SystemExit exception is raised by the running code.
-// It will reset to 0 at the start of each execution (eg each REPL entry).
-extern int pyexec_system_exit;
-
 #define PYEXEC_FORCED_EXIT (0x100)
 
 int pyexec_raw_repl(void);


### PR DESCRIPTION
### Summary

The current situation with `SystemExit` and soft reset is the following:
- `sys.exit()` follows CPython and just raises `SystemExit`
- on the unix port, raising `SystemExit` quits the application / MicroPython, whether at the REPL or in code (this follows CPython behaviour)
- on bare-metal ports, raising `SystemExit` at the REPL does nothing, raising it in code will stop the code and drop into the REPL
- `machine.soft_reset()` raises `SystemExit` but with a special flag set, and bare-metal targets check this flag when it propagates to the top-level and do a soft reset when they receive it

The original idea here was that a bare-metal target can't "quit" like the unix port can, and so dropping to the REPL was considered the same as "quit".  But this bare-metal behaviour is arguably inconsistent with unix.

This PR proposes to change the behaviour to the following, which is more consistent:
- raising `SystemExit` on a bare-metal port will do a soft reset (unless the exception is caught by the application)
- `machine.soft_reset()` is now equivalent to `sys.exit()`
- unix port behaviour remains unchanged

### Testing

Tested running the test suite on PYBD-SF6 and everything still passes (in particular tests that skip by raising `SystemExit` still correctly skip).

### Trade-offs and Alternatives

This decreases code size, simplifies behaviour and makes unix and bare-metal behaviour match (and match CPython).

It is a breaking change though, if users are expecting `SystemExit` to just drop to the REPL.  The alternative would be to not make this change.

