### PR TITLE
extmod/vfs_fat: Allow setting label of partition when creating FAT fs

### DIFF
--- a/extmod/vfs_fat.c
+++ b/extmod/vfs_fat.c
@@ -100,7 +100,7 @@ static mp_obj_t fat_vfs_del(mp_obj_t self_in) {
 static MP_DEFINE_CONST_FUN_OBJ_1(fat_vfs_del_obj, fat_vfs_del);
 #endif
 
-static mp_obj_t fat_vfs_mkfs(size_t n_args, const mp_obj_t *args) {
+static mp_obj_t fat_vfs_mkfs(mp_obj_t bdev_in) {
     mp_obj_t bdev_in = args[0];
 
     // create new object
@@ -116,20 +116,13 @@ static mp_obj_t fat_vfs_mkfs(size_t n_args, const mp_obj_t *args) {
         mp_raise_OSError(fresult_to_errno_table[res]);
     }
 
-    // Set the volume label if provided
-    if (n_args > 1 && mp_obj_is_str(args[1])) {
-        const char *label = mp_obj_str_get_str(args[1]);
-        if (strlen(label) <= MICROPY_VFS_FAT_MAX_LABEL_LENGTH) {
-            f_setlabel(&vfs->fatfs, label);
-        } else {
-            mp_raise_OSError(fresult_to_errno_table[FR_INVALID_PARAMETER]);
-        }
-    }
+    // Set the volume
+    f_setlabel(&vfs->fatfs, MICROPY_VFS_FAT_MAX_LABEL_LENGTH);
 
     return mp_const_none;
 }
 
-static MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(fat_vfs_mkfs_fun_obj, 1, 2, fat_vfs_mkfs);
+static MP_DEFINE_CONST_FUN_OBJ_1(fat_vfs_mkfs_fun_obj, fat_vfs_mkfs);
 static MP_DEFINE_CONST_STATICMETHOD_OBJ(fat_vfs_mkfs_obj, MP_ROM_PTR(&fat_vfs_mkfs_fun_obj));
 
 typedef struct _mp_vfs_fat_ilistdir_it_t {

--- a/extmod/vfs_fat.c
+++ b/extmod/vfs_fat.c
@@ -117,7 +117,7 @@ static mp_obj_t fat_vfs_mkfs(mp_obj_t bdev_in) {
     }
 
     // Set the volume
-    f_setlabel(&vfs->fatfs, MICROPY_VFS_FAT_MAX_LABEL_LENGTH);
+    f_setlabel(&vfs->fatfs, MICROPY_HW_FLASH_FS_LABEL);
 
     return mp_const_none;
 }

--- a/extmod/vfs_fat.h
+++ b/extmod/vfs_fat.h
@@ -30,10 +30,6 @@
 #include "lib/oofatfs/ff.h"
 #include "extmod/vfs.h"
 
-#ifndef MICROPY_VFS_FAT_MAX_LABEL_LENGTH
-#define MICROPY_VFS_FAT_MAX_LABEL_LENGTH (8)
-#endif
-
 typedef struct _fs_user_mount_t {
     mp_obj_base_t base;
     mp_vfs_blockdev_t blockdev;

--- a/extmod/vfs_fat.h
+++ b/extmod/vfs_fat.h
@@ -30,6 +30,10 @@
 #include "lib/oofatfs/ff.h"
 #include "extmod/vfs.h"
 
+#ifndef MICROPY_VFS_FAT_MAX_LABEL_LENGTH
+#define MICROPY_VFS_FAT_MAX_LABEL_LENGTH (8)
+#endif
+
 typedef struct _fs_user_mount_t {
     mp_obj_base_t base;
     mp_vfs_blockdev_t blockdev;


### PR DESCRIPTION
### Summary

During a factory reset, a label for the flash drive can be set via `MICROPY_HW_FLASH_FS_LABEL`. However, it would be convenient to be able to set this value when using `vfs.VfsFat.mkfs(p1)`. This PR allows an optional label argument to `vfs.VfsFat.mkfs(p1, "label")`

### Testing
Tested on a PYBV11 for creating a new label for the mounted flash with no label and with a label


### Trade-offs and Alternatives
Slight additional overhead for `mkfs()`. Incompatible function call for littlefsX. 
An alternative, would be to add a `vfs.VfsFat.setlabel("label")`, I decided against this as it would be an additional function call adding more overhead.