### PR TITLE
py/objtype: Add support for __set_name__. (hazard version)

### DIFF
--- a/py/mpconfig.h
+++ b/py/mpconfig.h
@@ -1124,7 +1124,7 @@ typedef time_t mp_timestamp_t;
 #define MICROPY_PY_FUNCTION_ATTRS_CODE (MICROPY_CONFIG_ROM_LEVEL_AT_LEAST_FULL_FEATURES)
 #endif
 
-// Whether to support the descriptors __get__, __set__, __delete__
+// Whether to support the descriptors __get__, __set__, __delete__, __set_name__
 // This costs some code size and makes load/store/delete of instance
 // attributes slower for the classes that use this feature
 #ifndef MICROPY_PY_DESCRIPTORS

--- a/tests/basics/class_descriptor.py
+++ b/tests/basics/class_descriptor.py
@@ -1,21 +1,27 @@
 class Descriptor:
     def __get__(self, obj, cls):
-        print('get')
+        print("get")
         print(type(obj) is Main)
         print(cls is Main)
-        return 'result'
+        return "result"
 
     def __set__(self, obj, val):
-        print('set')
+        print("set")
         print(type(obj) is Main)
         print(val)
 
     def __delete__(self, obj):
-        print('delete')
+        print("delete")
         print(type(obj) is Main)
+
+    def __set_name__(self, owner, name):
+        print("set_name", name)
+        print(owner.__name__ == "Main")
+
 
 class Main:
     Forward = Descriptor()
+
 
 m = Main()
 try:
@@ -26,15 +32,15 @@ except AttributeError:
     raise SystemExit
 
 r = m.Forward
-if 'Descriptor' in repr(r.__class__):
+if "Descriptor" in repr(r.__class__):
     # Target doesn't support descriptors.
-    print('SKIP')
+    print("SKIP")
     raise SystemExit
 
 # Test assignment and deletion.
 
 print(r)
-m.Forward = 'a'
+m.Forward = "a"
 del m.Forward
 
 # Test that lookup of descriptors like __get__ are not passed into __getattr__.

--- a/tests/basics/class_setname_hazard.py
+++ b/tests/basics/class_setname_hazard.py
@@ -1,0 +1,118 @@
+def skip_if_no_descriptors():
+    class Descriptor:
+        def __get__(self, obj, cls):
+            return
+
+    class TestClass:
+        Forward = Descriptor()
+
+    a = TestClass()
+    try:
+        a.__class__
+    except AttributeError:
+        # Target doesn't support __class__.
+        print("SKIP")
+        raise SystemExit
+
+    b = a.Forward
+    if "Descriptor" in repr(b.__class__):
+        # Target doesn't support descriptors.
+        print("SKIP")
+        raise SystemExit
+
+
+skip_if_no_descriptors()
+
+
+# Test basic hazard-free mutations of the enclosing class.
+# See also cpydiff/core_class_setname_hazard.py for broken non-hazard-free cases.
+
+
+class GetSibling:
+    def __set_name__(self, owner, name):
+        print(getattr(owner, name + "_sib"))
+
+
+class GetSiblingTest:
+    desc = GetSibling()
+    desc_sib = 101
+
+
+t101 = GetSiblingTest()
+
+
+class SetSibling:
+    def __set_name__(self, owner, name):
+        setattr(owner, name + "_sib", 102)
+
+
+class SetSiblingTest:
+    desc = SetSibling()
+
+
+t102 = SetSiblingTest()
+
+print(t102.desc_sib)
+
+
+class DelSibling:
+    def __set_name__(self, owner, name):
+        delattr(owner, name + "_sib")
+
+
+class DelSiblingTest:
+    desc = DelSibling()
+    desc_sib = 103
+
+
+t103 = DelSiblingTest()
+
+try:
+    print(t103.desc_sib)
+except AttributeError:
+    print("AttributeError")
+
+
+class GetSelf:
+    x = 201
+
+    def __set_name__(self, owner, name):
+        print(getattr(owner, name).x)
+
+
+class GetSelfTest:
+    desc = GetSelf()
+
+
+t201 = GetSelfTest()
+
+
+class SetSelf:
+    def __set_name__(self, owner, name):
+        setattr(owner, name, 202)
+
+
+class SetSelfTest:
+    desc = SetSelf()
+
+
+t202 = SetSelfTest()
+
+print(t202.desc)
+
+
+class DelSelf:
+    def __set_name__(self, owner, name):
+        delattr(owner, name)
+
+
+class DelSelfTest:
+    desc = DelSelf()
+
+
+t203 = DelSelfTest()
+
+try:
+    print(t203.desc)
+except AttributeError:
+    print("AttributeError")

--- a/tests/cpydiff/core_class_setname_hazard.py
+++ b/tests/cpydiff/core_class_setname_hazard.py
@@ -1,0 +1,87 @@
+"""
+categories: Core,Classes
+description: Descriptor ``__set_name__`` functions may be called twice or missed if members of the parent class are created or removed in ``__set_name__``.
+cause: The ``__set_name__`` procedure is not isolated from the underlying modify-while-iter sequence hazard of the underlying class ``__dict__``.
+workaround: Avoid ``__set_name__`` implementations that add or remove members from the parent class.
+"""
+
+# This bug is EXTREMELY difficult to demonstrate with only a minimal test case
+# due to the unstable iteration order of a class's namespace. This bug more-or-less
+# _requires_ a stochastic test in order to guarantee it occurs or demonstrate its
+# potential impact with any level of clarity.
+
+import random
+import re
+
+letters = "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
+
+junk_re = re.compile(r"[A-Z][A-Z][A-Z][A-Z][A-Z]")
+
+
+def junk_fill(obj, n=10):  # Add randomly-generated attributes to an object.
+    for i in range(n):
+        name = "".join(random.choice(letters) for j in range(5))
+        setattr(obj, name, object())
+
+
+def junk_clear(obj):  # Remove attributes added by junk_fill.
+    to_del = [name for name in dir(obj) if junk_re.match(name)]
+    for name in to_del:
+        delattr(obj, name)
+
+
+def junk_sequencer():
+    global runs
+    try:
+        while True:
+            owner, name = yield
+            runs[name] = runs.get(name, 0) + 1
+            junk_fill(owner)
+    finally:
+        junk_clear(owner)
+
+
+class JunkMaker:
+    def __set_name__(self, owner, name):
+        global seq
+        seq.send((owner, name))
+
+
+runs = {}
+seq = junk_sequencer()
+next(seq)
+
+
+class Main:
+    a = JunkMaker()
+    b = JunkMaker()
+    c = JunkMaker()
+    d = JunkMaker()
+    e = JunkMaker()
+    f = JunkMaker()
+    g = JunkMaker()
+    h = JunkMaker()
+    i = JunkMaker()
+    j = JunkMaker()
+    k = JunkMaker()
+    l = JunkMaker()
+    m = JunkMaker()
+    n = JunkMaker()
+    o = JunkMaker()
+    p = JunkMaker()
+    q = JunkMaker()
+    r = JunkMaker()
+    s = JunkMaker()
+    t = JunkMaker()
+    u = JunkMaker()
+    v = JunkMaker()
+    w = JunkMaker()
+    x = JunkMaker()
+    y = JunkMaker()
+    z = JunkMaker()
+
+
+seq.close()
+
+for k in letters.lower():
+    print(k, runs.get(k, 0))


### PR DESCRIPTION
### Summary

This PR implements the feature described in #15501, adding support for the `__set_name__` data model method.

### Testing

This PR includes and passes the unit test originally submitted in #15500 to verify the feature's absence.

