### PR TITLE
tests/cpydiff/core_class: Document issue with super in classmethod.

### DIFF
--- a/tests/cpydiff/core_class_superclassmethod.py
+++ b/tests/cpydiff/core_class_superclassmethod.py
@@ -1,0 +1,45 @@
+"""
+categories: Core,Classes
+description: super inside a classmethod defers to type rather than parent class.
+cause: Unknown
+workaround: Unknown
+"""
+
+
+class A:
+    @classmethod
+    def f(cls):
+        print("Af", cls.__name__)
+
+    @classmethod
+    def g(cls):
+        print("Ag", cls.__name__)
+
+
+class B(A):
+    @classmethod
+    def f(cls):
+        print("Bf", cls.__name__)
+        super().f()
+
+    @classmethod
+    def g(cls):
+        print("Bg", cls.__name__)
+        super(B, cls).g()
+
+
+class C(B):
+    @classmethod
+    def f(cls):
+        print("Cf", cls.__name__)
+        super().f()
+
+    @classmethod
+    def g(cls):
+        print("Cg", cls.__name__)
+        super(C, cls).g()
+
+
+c = C()
+c.f()
+c.g()


### PR DESCRIPTION
### Summary

This documents an existing problem with the way `super()` is implemented that became evident while I was implementing `__init_subclass__`, where when used inside a classmethod it defers to the ancestor of the class object itself (i.e. `type`), rather than parent classes it inherits from.

This is probably an issue with super itself not treating the second argument differently when its a type in the way that CPython does.

### Testing

I've verified this against CPython versions 3.8, 3.10, and 3.12.

