### PR TITLE
py/py.mk: Add USERMOD_LIB_ASM to include assembly files.

### DIFF
--- a/docs/develop/cmodules.rst
+++ b/docs/develop/cmodules.rst
@@ -59,7 +59,7 @@ A MicroPython user C module is a directory with the following files:
     SRC_USERMOD_LIB_C += $(EXAMPLE_MOD_DIR)/utils/algorithm.c
 
   Similarly, use ``SRC_USERMOD_CXX`` and ``SRC_USERMOD_LIB_CXX`` for C++
-  source files.
+  source files. If you want to include assembly files use ``SRC_USERMOD_LIB_ASM``.
 
   If you have custom compiler options (like ``-I`` to add directories to search
   for header files), these should be added to ``CFLAGS_USERMOD`` for C code

--- a/py/py.mk
+++ b/py/py.mk
@@ -36,9 +36,10 @@ ifneq ($(USER_C_MODULES),)
 # C/C++ files that are included in the QSTR/module build
 SRC_USERMOD_C :=
 SRC_USERMOD_CXX :=
-# Other C/C++ files (e.g. libraries or helpers)
+# Other C/C++/Assembly files (e.g. libraries or helpers)
 SRC_USERMOD_LIB_C :=
 SRC_USERMOD_LIB_CXX :=
+SRC_USERMOD_LIB_ASM :=
 # Optionally set flags
 CFLAGS_USERMOD :=
 CXXFLAGS_USERMOD :=
@@ -60,6 +61,7 @@ SRC_USERMOD_PATHFIX_C += $(patsubst $(USER_C_MODULES)/%.c,%.c,$(SRC_USERMOD_C))
 SRC_USERMOD_PATHFIX_CXX += $(patsubst $(USER_C_MODULES)/%.cpp,%.cpp,$(SRC_USERMOD_CXX))
 SRC_USERMOD_PATHFIX_LIB_C += $(patsubst $(USER_C_MODULES)/%.c,%.c,$(SRC_USERMOD_LIB_C))
 SRC_USERMOD_PATHFIX_LIB_CXX += $(patsubst $(USER_C_MODULES)/%.cpp,%.cpp,$(SRC_USERMOD_LIB_CXX))
+SRC_USERMOD_PATHFIX_LIB_ASM += $(patsubst $(USER_C_MODULES)/%.S,%.S,$(SRC_USERMOD_LIB_ASM))
 
 CFLAGS += $(CFLAGS_USERMOD)
 CXXFLAGS += $(CXXFLAGS_USERMOD)
@@ -70,6 +72,7 @@ PY_O += $(addprefix $(BUILD)/, $(SRC_USERMOD_PATHFIX_C:.c=.o))
 PY_O += $(addprefix $(BUILD)/, $(SRC_USERMOD_PATHFIX_CXX:.cpp=.o))
 PY_O += $(addprefix $(BUILD)/, $(SRC_USERMOD_PATHFIX_LIB_C:.c=.o))
 PY_O += $(addprefix $(BUILD)/, $(SRC_USERMOD_PATHFIX_LIB_CXX:.cpp=.o))
+PY_O += $(addprefix $(BUILD)/, $(SRC_USERMOD_PATHFIX_LIB_ASM:.S=.o))
 endif
 
 # py object files


### PR DESCRIPTION
### Summary

Introduce `USERMOD_LIB_ASM` to allow users to include assembly files as part of their user modules. It could be used to include optimized functions or outputs of other programming languages.

### Testing

Tested on `unix`.

### Trade-offs and Alternatives

* Assemble files yourself and use `LDFLAGS_USERMOD` to include the compiled functions as a library.