### PR TITLE
Make `micropython` display `--version`.

### DIFF
--- a/ports/unix/main.c
+++ b/ports/unix/main.c
@@ -318,6 +318,7 @@ static void print_help(char **argv) {
     printf(
         "usage: %s [<opts>] [-X <implopt>] [-c <command> | -m <module> | <filename>]\n"
         "Options:\n"
+        "--version : show version information\n"
         "-h : print this help message\n"
         "-i : enable inspection via REPL after running command/module/file\n"
         #if MICROPY_DEBUG_PRINTERS
@@ -367,6 +368,10 @@ static void pre_process_options(int argc, char **argv) {
             }
             if (strcmp(argv[a], "-h") == 0) {
                 print_help(argv);
+                exit(0);
+            }
+            if (strcmp(argv[a], "--version") == 0) {
+                printf("MicroPython " MICROPY_GIT_TAG " on " MICROPY_BUILD_DATE "\n");
                 exit(0);
             }
             if (strcmp(argv[a], "-X") == 0) {


### PR DESCRIPTION
<!-- Thanks for submitting a Pull Request! We appreciate you spending the
     time to improve MicroPython. Please provide enough information so that
     others can review your Pull Request.

     Before submitting, please read:
     https://github.com/micropython/micropython/blob/master/CODEOFCONDUCT.md
     https://github.com/micropython/micropython/wiki/ContributorGuidelines

     Please check any CI failures that appear after your Pull Request is opened.
-->

### Summary

<!-- Explain the reason for making this change. What problem does the pull request
     solve, or what improvement does it add? Add links if relevant. -->

Just adds `--version` to `micropython` so `mpy-cross` and `micropython` have matching help and version flags.

### Testing

<!-- Explain what testing you did, and on which boards/ports. If there are
     boards or ports that you couldn't test, please mention this here as well.

     If you leave this empty then your Pull Request may be closed. -->

Ran it on windows and unix and it works.


