### PR TITLE
extmod/vfs_fat.c: Add default volume label to mkfs if it exists

### DIFF
--- a/extmod/vfs_fat.c
+++ b/extmod/vfs_fat.c
@@ -114,6 +114,11 @@ static mp_obj_t fat_vfs_mkfs(mp_obj_t bdev_in) {
         mp_raise_OSError(fresult_to_errno_table[res]);
     }
 
+    // set the filesystem label if it's configured
+    #ifdef MICROPY_HW_FLASH_FS_LABEL
+    f_setlabel(&vfs->fatfs, MICROPY_HW_FLASH_FS_LABEL);
+    #endif
+
     return mp_const_none;
 }
 static MP_DEFINE_CONST_FUN_OBJ_1(fat_vfs_mkfs_fun_obj, fat_vfs_mkfs);


### PR DESCRIPTION
### Summary

Using mkfs doesn't set a volume label for FAT filesystems, this PR will set the default volume label if it exists.


### Testing
Tested on a PYBV11

### Trade-offs and Alternatives
Alternatives would be to add a new function for setting/getting the label or adding a second optional argument to mfks for setting the volume label. Both of which would add more code for little gain.

