### PR TITLE
github/workflows: Add RISC-V 64 bits Unix port to CI.

### DIFF
--- a/.github/workflows/ports_unix.yml
+++ b/.github/workflows/ports_unix.yml
@@ -235,3 +235,17 @@ jobs:
     - name: Print failures
       if: failure()
       run: tests/run-tests.py --print-failures
+
+  qemu_riscv64:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: Install packages
+      run: source tools/ci.sh && ci_unix_qemu_riscv64_setup
+    - name: Build
+      run: source tools/ci.sh && ci_unix_qemu_riscv64_build
+    - name: Run main test suite
+      run: source tools/ci.sh && ci_unix_qemu_riscv64_run_tests
+    - name: Print failures
+      if: failure()
+      run: tests/run-tests.py --print-failures

--- a/tools/ci.sh
+++ b/tools/ci.sh
@@ -427,6 +427,11 @@ CI_UNIX_OPTS_QEMU_ARM=(
     MICROPY_STANDALONE=1
 )
 
+CI_UNIX_OPTS_QEMU_RISCV64=(
+    CROSS_COMPILE=riscv64-linux-gnu-
+    VARIANT=coverage
+)
+
 function ci_unix_build_helper {
     make ${MAKEOPTS} -C mpy-cross
     make ${MAKEOPTS} -C ports/unix "$@" submodules
@@ -690,6 +695,28 @@ function ci_unix_qemu_arm_run_tests {
     export QEMU_LD_PREFIX=/usr/arm-linux-gnueabi
     file ./ports/unix/build-coverage/micropython
     (cd tests && MICROPY_MICROPYTHON=../ports/unix/build-coverage/micropython ./run-tests.py --exclude 'vfs_posix.*\.py')
+}
+
+function ci_unix_qemu_riscv64_setup {
+    . /etc/os-release
+    for repository in "${VERSION_CODENAME}" "${VERSION_CODENAME}-updates" "${VERSION_CODENAME}-security"
+    do
+        sudo add-apt-repository -y -n "deb [arch=riscv64] http://ports.ubuntu.com/ubuntu-ports ${repository} main"
+    done
+    sudo apt-get update
+    sudo dpkg --add-architecture riscv64
+    sudo apt-get install gcc-riscv64-linux-gnu g++-riscv64-linux-gnu libffi-dev:riscv64
+    sudo apt-get install qemu-user
+    qemu-riscv64 --version
+}
+
+function ci_unix_qemu_riscv64_build {
+    ci_unix_build_helper "${CI_UNIX_OPTS_QEMU_RISCV64[@]}"
+}
+
+function ci_unix_qemu_riscv64_run_tests {
+    file ./ports/unix/build-coverage/micropython
+    (cd tests && MICROPY_MICROPYTHON=../ports/unix/build-coverage/micropython ./run-tests.py)
 }
 
 ########################################################################################


### PR DESCRIPTION
### Summary

The Unix port can be built for RISC-V 64 bits but it is not under CI. There are documented usages of the Unix port for RISC-V 64 bits, and until recently it required some external workarounds to build successfully.  Now that it can build out of the box it's not a bad idea to have it under CI.

See the discussion in #15528, and issue #12838 that started it all.

Regarding adding repositories to the CI instances to fetch the RV64 `libffi-dev` binary package from (along with its dependencies), I'm not entirely satisfied with the way it's currently done - it doesn't look safe enough to me.  `add-apt-repository` is able to add repositories using separate command line arguments for each apt source line field, but I haven't found anything that allows to set a specific architecture for the source (or I might have just missed it...).

### Testing

The CI jobs completed successfully when pushing to a local branch in my fork: https://github.com/agatti/micropython/actions/runs/10068525047/job/27834049532

Something worth mentioning is that the test run passes without the explicit listdir/ilistdir and ffi test exceptions, so maybe those exceptions for the other ports should be revised?