### PR TITLE
py/runtime: Fix self arg passed to classmethod when accessed via super.

### DIFF
--- a/py/runtime.c
+++ b/py/runtime.c
@@ -1153,6 +1153,10 @@ void mp_convert_member_lookup(mp_obj_t self, const mp_obj_type_t *type, mp_obj_t
             // base type (which is what is passed in the `type` argument to this function).
             if (self != MP_OBJ_NULL) {
                 type = mp_obj_get_type(self);
+                if (type == &mp_type_type) {
+                    // `self` is already a type, so use `self` directly.
+                    type = MP_OBJ_TO_PTR(self);
+                }
             }
             dest[0] = ((mp_obj_static_class_method_t *)MP_OBJ_TO_PTR(member))->fun;
             dest[1] = MP_OBJ_FROM_PTR(type);

--- a/tests/basics/subclass_classmethod.py
+++ b/tests/basics/subclass_classmethod.py
@@ -35,3 +35,34 @@ class B(A):
 B.bar() # class calling classmethod
 B().bar() # instance calling classmethod
 B().baz() # instance calling normal method
+
+# super inside a classmethod
+# ensure the argument of the super method that is called is the child type
+
+
+class C:
+    @classmethod
+    def f(cls):
+        print("C.f", cls.__name__)  # cls should be D
+
+    @classmethod
+    def g(cls):
+        print("C.g", cls.__name__)  # cls should be D
+
+
+class D(C):
+    @classmethod
+    def f(cls):
+        print("D.f", cls.__name__)
+        super().f()
+
+    @classmethod
+    def g(cls):
+        print("D.g", cls.__name__)
+        super(D, cls).g()
+
+
+D.f()
+D.g()
+D().f()
+D().g()


### PR DESCRIPTION

### Summary

MicroPython was not conforming to CPython behaviour when using `super()` within a `classmethod`.  This patch fixes this behaviour.

### Testing

New test added which did not pass before, but now passes.

Thanks to @AJMansfield for the original test case.

### Trade-offs and Alternatives

This increases code size a little bit, but if not fixed it can lead to some very difficult to debug problems, if you even notice there's a problem in the first place.