### PR TITLE
esp32: Fix heap corruption triggered by bluetooth.active(0).

### DIFF
--- a/ports/esp32/mpnimbleport.c
+++ b/ports/esp32/mpnimbleport.c
@@ -32,7 +32,6 @@
 
 #define DEBUG_printf(...) // printf("nimble (esp32): " __VA_ARGS__)
 
-#include "esp_nimble_hci.h"
 #include "nimble/nimble_port.h"
 #include "nimble/nimble_port_freertos.h"
 
@@ -45,14 +44,13 @@ static void ble_host_task(void *param) {
 }
 
 void mp_bluetooth_nimble_port_hci_init(void) {
-    DEBUG_printf("mp_bluetooth_nimble_port_hci_init\n");
-    esp_nimble_hci_init();
+    // On ESP-IDF the standard nimble_port_init() function calls
+    // esp_nimble_init() which initialises the HCI
 }
 
 void mp_bluetooth_nimble_port_hci_deinit(void) {
-    DEBUG_printf("mp_bluetooth_nimble_port_hci_deinit\n");
-
-    esp_nimble_hci_deinit();
+    // As above, this is handled by ESP-IDF nimble_port_deinit()
+    // (called below)
 }
 
 void mp_bluetooth_nimble_port_start(void) {


### PR DESCRIPTION
### Summary

It seems like at some point Espressif NimBLE team changed nimble_port_init and nimble_port_deinit to manage HCI init internally:
https://github.com/espressif/esp-nimble/commit/f8a79b04c9743543b8959727d7

This change is now included in all the IDF versions that current MicroPython supports.

As a result, existing code that called esp_nimble_hci_deinit() explicitly would trigger a use-after-free bug and heap corruption (specifically this calls through to ble_transport_deinit() which calls os_mempool_free(). The second time this writes out to a bunch of memory pools where the backing buffers have already been freed.)

Symptoms were intermittent random crashes after de-activating Bluetooth. Setting Heap Poisoning to Comprehensive in menuconfig caused the bug to be detected every time.

Found while testing #15523.

### Testing

Ran multi_bluetooth tests on ESP32 and ESP32-S3 with and without Comprehensive heap poisoning, and on IDF v5.0.4 and v5.2.2. Failures (crashes) in ble_gatt_data_transfer.py are present without this fix.