### PR TITLE
esp32: Workaround math.gamma(-inf) result.

### DIFF
--- a/ports/esp32/mpconfigport.h
+++ b/ports/esp32/mpconfigport.h
@@ -282,6 +282,10 @@ typedef long mp_off_t;
 #define MICROPY_PY_MACHINE_BOOTLOADER       (0)
 #endif
 
+// Workaround for upstream bug https://github.com/espressif/esp-idf/issues/14273
+// Can be removed if a fix is available in supported ESP-IDF versions.
+#define MICROPY_PY_MATH_GAMMA_FIX_NEGINF (1)
+
 #ifndef MICROPY_BOARD_STARTUP
 #define MICROPY_BOARD_STARTUP boardctrl_startup
 #endif

--- a/py/modmath.c
+++ b/py/modmath.c
@@ -196,7 +196,17 @@ MATH_FUN_1(erf, erf)
 // erfc(x): return the complementary error function of x
 MATH_FUN_1(erfc, erfc)
 // gamma(x): return the gamma function of x
+#if MICROPY_PY_MATH_GAMMA_FIX_NEGINF
+static mp_float_t MICROPY_FLOAT_C_FUN(tgamma_func)(mp_float_t x) {
+    if (isinf(x) && x < 0) {
+        math_error();
+    }
+    return MICROPY_FLOAT_C_FUN(tgamma)(x);
+}
+MATH_FUN_1(gamma, tgamma_func)
+#else
 MATH_FUN_1(gamma, tgamma)
+#endif
 // lgamma(x): return the natural logarithm of the gamma function of x
 MATH_FUN_1(lgamma, lgamma)
 #endif

--- a/py/mpconfig.h
+++ b/py/mpconfig.h
@@ -1393,6 +1393,11 @@ typedef double mp_float_t;
 #define MICROPY_PY_MATH_POW_FIX_NAN (0)
 #endif
 
+// Whether to provide fix for gamma(-inf) to raise ValueError
+#ifndef MICROPY_PY_MATH_GAMMA_FIX_NEGINF
+#define MICROPY_PY_MATH_GAMMA_FIX_NEGINF (0)
+#endif
+
 // Whether to provide "cmath" module
 #ifndef MICROPY_PY_CMATH
 #define MICROPY_PY_CMATH (MICROPY_CONFIG_ROM_LEVEL_AT_LEAST_EXTRA_FEATURES)


### PR DESCRIPTION
### Summary

Without this workaround, `math.gamma(-float("inf"))` returns inf instead of raising a math domain ValueError.
 
Found while testing #15523.

Upstream issue reported as https://github.com/espressif/esp-idf/issues/14273

### Testing

tests/float/math_domain_special.py fails on esp32 without this fix.

*This work was funded through GitHub Sponsors.*