### PR TITLE
tests,esp32: Skip soft timer test on esp32 port, rename.

### DIFF
--- a/tests/extmod/machine_soft_timer.py
+++ b/tests/extmod/machine_soft_timer.py
@@ -1,4 +1,11 @@
-# test machine.Timer
+# test "soft" machine.Timer (no hardware ID)
+import sys
+
+
+if sys.platform == "esp32":
+    print("SKIP")  # TODO: Implement soft timers for esp32 port
+    raise SystemExit
+
 
 try:
     import time, machine as machine


### PR DESCRIPTION
### Summary

Rename the extmod/machine_timer.py test to machine_soft_timer.py (as this is what it tests). Skip it on esp32, which has no soft timer support.

Found while testing #15523.

### Testing

Allows this test to not fail on esp32.