### PR TITLE
tests/README: Update instructions for elliptic curve key/cert pair.

### DIFF
--- a/tests/README.md
+++ b/tests/README.md
@@ -195,6 +195,7 @@ $ openssl x509 -in rsa_cert.pem -out rsa_cert.der -outform DER
 
 To test elliptic curve key/cert pairs, create a key then a certificate using:
 ```
-$ openssl ecparam -name prime256v1 -genkey -noout -out ec_key.der -outform DER
-$ openssl req -new -x509 -key ec_key.der -out ec_cert.der -outform DER -days 365 -nodes -subj '/CN=micropython.local/O=MicroPython/C=AU'
+$ openssl ecparam -name prime256v1 -genkey -noout -out ec_key.pem
+$ openssl x509 -in ec_key.pem -out ec_key.der -outform DER
+$ openssl req -new -x509 -key ec_key.pem -out ec_cert.der -outform DER -days 365 -nodes -subj '/CN=micropython.local/O=MicroPython/C=AU'
 ```


### PR DESCRIPTION
### Summary

When following the instructions in the tests/readme to create certs:
```
anl@STEP: ~/micropython/tests $ openssl ecparam -name prime256v1 -genkey -noout -out ec_key.der -outform DER
anl@STEP: ~/micropython/tests $ openssl req -new -x509 -key ec_key.der -out ec_cert.der -outform DER -days 365 -nodes -subj '/CN=micropython.local/O=MicroPython/C=AU'
```

I got the error:
```
unable to load Private Key
139897947084096:error:0909006C:PEM routines:get_name:no start line:../crypto/pem/pem_lib.c:745:Expecting: ANY PRIVATE KEY
```

This is on an WSL / Ubuntu based system:
```
OpenSSL 1.1.1f  31 Mar 2020
```

This updates the instructions to first create the key as a pem then convert to der, as per earlier cert generation commands.
