### PR TITLE
tests/multi_net: Fix skipping of SSLContext tests when .der don't exist.

### DIFF
--- a/tests/multi_net/sslcontext_server_client.py
+++ b/tests/multi_net/sslcontext_server_client.py
@@ -15,17 +15,13 @@ certfile = "ec_cert.der"
 keyfile = "ec_key.der"
 
 try:
-    os.stat(certfile)
-    os.stat(keyfile)
+    with open(certfile, "rb") as cf:
+        cert = cadata = cf.read()
+    with open(keyfile, "rb") as kf:
+        key = kf.read()
 except OSError:
     print("SKIP")
     raise SystemExit
-
-with open(certfile, "rb") as cf:
-    cert = cadata = cf.read()
-
-with open(keyfile, "rb") as kf:
-    key = kf.read()
 
 
 # Server

--- a/tests/multi_net/sslcontext_server_client_ciphers.py
+++ b/tests/multi_net/sslcontext_server_client_ciphers.py
@@ -13,14 +13,12 @@ PORT = 8000
 # These are test certificates. See tests/README.md for details.
 cert = cafile = "ec_cert.der"
 key = "ec_key.der"
-with open(cafile, "rb") as f:
-    cadata = f.read()
-with open(key, "rb") as f:
-    keydata = f.read()
 
 try:
-    os.stat(cafile)
-    os.stat(key)
+    with open(cafile, "rb") as f:
+        cadata = f.read()
+    with open(key, "rb") as f:
+        keydata = f.read()
 except OSError:
     print("SKIP")
     raise SystemExit


### PR DESCRIPTION
The `sslcontext_server_client_ciphers.py` test was using stat to test for the .der files after it already tried to open them for reading.  That is now fixed.  And `sslcontext_server_client.py` is adjusted to use the same pattern for skipping the test.
