### PR TITLE
shared/runtime/gchelper: Add RISC-V RV64I native gchelper.

### DIFF
--- a/ports/unix/mpconfigport.h
+++ b/ports/unix/mpconfigport.h
@@ -105,7 +105,7 @@ typedef long mp_off_t;
 // Always enable GC.
 #define MICROPY_ENABLE_GC           (1)
 
-#if !(defined(MICROPY_GCREGS_SETJMP) || defined(__x86_64__) || defined(__i386__) || defined(__thumb2__) || defined(__thumb__) || defined(__arm__))
+#if !(defined(MICROPY_GCREGS_SETJMP) || defined(__x86_64__) || defined(__i386__) || defined(__thumb2__) || defined(__thumb__) || defined(__arm__) || (defined(__riscv) && (__riscv_xlen == 64)))
 // Fall back to setjmp() implementation for discovery of GC pointers in registers.
 #define MICROPY_GCREGS_SETJMP (1)
 #endif

--- a/shared/runtime/gchelper_generic.c
+++ b/shared/runtime/gchelper_generic.c
@@ -150,23 +150,24 @@ static void gc_helper_get_regs(gc_helper_regs_t arr) {
     arr[10] = x29;
 }
 
-#elif defined(__riscv) && defined(__riscv_xlen) && (__riscv_xlen == 32)
+#elif defined(__riscv) && (__riscv_xlen <= 64)
 
-// Fallback implementation for RV32I, prefer gchelper_rv32i.s
+// Fallback implementation for RV32I and RV64I, prefer gchelper_rv32i.s
+// for RV32I targets or gchelper_rv64i.s for RV64I targets.
 
 static void gc_helper_get_regs(gc_helper_regs_t arr) {
-    register long s0 asm ("x8");
-    register long s1 asm ("x9");
-    register long s2 asm ("x18");
-    register long s3 asm ("x19");
-    register long s4 asm ("x20");
-    register long s5 asm ("x21");
-    register long s6 asm ("x22");
-    register long s7 asm ("x23");
-    register long s8 asm ("x24");
-    register long s9 asm ("x25");
-    register long s10 asm ("x26");
-    register long s11 asm ("x27");
+    register uintptr_t s0 asm ("x8");
+    register uintptr_t s1 asm ("x9");
+    register uintptr_t s2 asm ("x18");
+    register uintptr_t s3 asm ("x19");
+    register uintptr_t s4 asm ("x20");
+    register uintptr_t s5 asm ("x21");
+    register uintptr_t s6 asm ("x22");
+    register uintptr_t s7 asm ("x23");
+    register uintptr_t s8 asm ("x24");
+    register uintptr_t s9 asm ("x25");
+    register uintptr_t s10 asm ("x26");
+    register uintptr_t s11 asm ("x27");
     arr[0] = s0;
     arr[1] = s1;
     arr[2] = s2;

--- a/shared/runtime/gchelper_rv64i.s
+++ b/shared/runtime/gchelper_rv64i.s
@@ -3,7 +3,7 @@
  *
  * The MIT License (MIT)
  *
- * Copyright (c) 2019 Damien P. George
+ * Copyright (c) 2024 Alessandro Gatti
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -23,30 +23,30 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-#ifndef MICROPY_INCLUDED_LIB_UTILS_GCHELPER_H
-#define MICROPY_INCLUDED_LIB_UTILS_GCHELPER_H
 
-#include <stdint.h>
+    .global gc_helper_get_regs_and_sp
+    .type   gc_helper_get_regs_and_sp, @function
 
-#if MICROPY_GCREGS_SETJMP
-#include <setjmp.h>
-typedef jmp_buf gc_helper_regs_t;
-#else
+gc_helper_get_regs_and_sp:
 
-#if defined(__x86_64__)
-typedef uintptr_t gc_helper_regs_t[6];
-#elif defined(__i386__)
-typedef uintptr_t gc_helper_regs_t[4];
-#elif defined(__thumb2__) || defined(__thumb__) || defined(__arm__)
-typedef uintptr_t gc_helper_regs_t[10];
-#elif defined(__aarch64__)
-typedef uintptr_t gc_helper_regs_t[11]; // x19-x29
-#elif defined(__riscv) && (__riscv_xlen <= 64)
-typedef uintptr_t gc_helper_regs_t[12]; // S0-S11
-#endif
+    /* Store registers into the given array. */
 
-#endif
+    sw    x8,  0(x10)  /* Save S0.  */
+    sw    x9,  8(x10)  /* Save S1.  */
+    sw   x18, 16(x10)  /* Save S2.  */
+    sw   x19, 24(x10)  /* Save S3.  */
+    sw   x20, 32(x10)  /* Save S4.  */
+    sw   x21, 40(x10)  /* Save S5.  */
+    sw   x22, 48(x10)  /* Save S6.  */
+    sw   x23, 56(x10)  /* Save S7.  */
+    sw   x24, 64(x10)  /* Save S8.  */
+    sw   x25, 72(x10)  /* Save S9.  */
+    sw   x26, 80(x10)  /* Save S10. */
+    sw   x27, 88(x10)  /* Save S11. */
 
-void gc_helper_collect_regs_and_stack(void);
+    /* Return the stack pointer. */
 
-#endif // MICROPY_INCLUDED_LIB_UTILS_GCHELPER_H
+    add  x10, x0, x2
+    jalr  x0, x1, 0
+
+    .size gc_helper_get_regs_and_sp, .-gc_helper_get_regs_and_sp


### PR DESCRIPTION
### Summary

This adds native gchelper support to RV64, given that said platform is now under CI and the code changes required are minimal.  The Unix port already enables platform-specific gchelper code (albeit the generic version), so the RV64 platform deserved its own entry in there.

### Testing

This has been tested on the CI environment both using the generic gchelper code and using the assembler version with this change in the Unix port makefile:

```diff
diff --git a/ports/unix/Makefile b/ports/unix/Makefile
index d5bd6d409..2fab170bf 100644
--- a/ports/unix/Makefile
+++ b/ports/unix/Makefile
@@ -214,16 +214,19 @@ SRC_C += \
        $(wildcard $(VARIANT_DIR)/*.c)
 
 SHARED_SRC_C += $(addprefix shared/,\
-       runtime/gchelper_generic.c \
+       runtime/gchelper_native.c \
        timeutils/timeutils.c \
        $(SHARED_SRC_C_EXTRA) \
        )
 
+SRC_O += shared/runtime/gchelper_rv64i.o
 SRC_CXX += \
 
 OBJ = $(PY_O)
 OBJ += $(addprefix $(BUILD)/, $(SRC_C:.c=.o))
 OBJ += $(addprefix $(BUILD)/, $(SRC_CXX:.cpp=.o))
+OBJ += $(addprefix $(BUILD)/, $(SRC_O:.s=.o))
 OBJ += $(addprefix $(BUILD)/, $(SHARED_SRC_C:.c=.o))
```

### Trade-offs and Alternatives

On RV64, a setjmp frame consumes close to half a kilobyte, so having an alternative implementation for gchelper on that platform would give some interesting memory savings.  The proposed implementation takes around 128 bytes of memory, which is far less than the setjmp version.