### PR TITLE
renesas-ra/usb: Use interrupt rather than polling for usb task.

### DIFF
--- a/ports/renesas-ra/Makefile
+++ b/ports/renesas-ra/Makefile
@@ -157,6 +157,9 @@ LIBSTDCPP_FILE_NAME = "$(shell $(CXX) $(CXXFLAGS) -print-file-name=libstdc++.a)"
 LDFLAGS += -L"$(shell dirname $(LIBSTDCPP_FILE_NAME))"
 endif
 
+# Hook tinyusb USB interrupt if used to service usb task.
+LDFLAGS += --wrap=dcd_event_handler
+
 # Options for mpy-cross
 MPY_CROSS_FLAGS += -march=armv7m
 

--- a/ports/renesas-ra/mpconfigport.h
+++ b/ports/renesas-ra/mpconfigport.h
@@ -250,25 +250,10 @@ typedef unsigned int mp_uint_t; // must be pointer size
 
 typedef long mp_off_t;
 
-#if MICROPY_HW_ENABLE_USBDEV
-#define MICROPY_HW_USBDEV_TASK_HOOK extern void mp_usbd_task(void); mp_usbd_task();
-#define MICROPY_VM_HOOK_COUNT (10)
-#define MICROPY_VM_HOOK_INIT static uint vm_hook_divisor = MICROPY_VM_HOOK_COUNT;
-#define MICROPY_VM_HOOK_POLL if (--vm_hook_divisor == 0) { \
-        vm_hook_divisor = MICROPY_VM_HOOK_COUNT; \
-        MICROPY_HW_USBDEV_TASK_HOOK \
-}
-#define MICROPY_VM_HOOK_LOOP MICROPY_VM_HOOK_POLL
-#define MICROPY_VM_HOOK_RETURN MICROPY_VM_HOOK_POLL
-#else
-#define MICROPY_HW_USBDEV_TASK_HOOK
-#endif
-
 #if MICROPY_PY_THREAD
 #define MICROPY_EVENT_POLL_HOOK \
     do { \
         extern void mp_handle_pending(bool); \
-        MICROPY_HW_USBDEV_TASK_HOOK \
         mp_handle_pending(true); \
         if (pyb_thread_enabled) { \
             MP_THREAD_GIL_EXIT(); \
@@ -284,7 +269,6 @@ typedef long mp_off_t;
 #define MICROPY_EVENT_POLL_HOOK \
     do { \
         extern void mp_handle_pending(bool); \
-        MICROPY_HW_USBDEV_TASK_HOOK \
         mp_handle_pending(true); \
         __WFI(); \
     } while (0);


### PR DESCRIPTION
### Summary

Most ports using TinyUSB now service the usb tasks from the usb interrupt. Based on issues reported in https://github.com/micropython/micropython/pull/14462#issuecomment-2251555449 I noticed the renesas port was still using the older polling pattern for this.

A quick test on a  "EK-RA4W1 with usb cable patched on" I've got showed that the interrupt wrap approach appears to work correctly here, so submitted this change.

### Testing

So far just flashing this change to "EK-RA4W1 with usb cable patched on" and tested that repl is still available in mpremote 

The board I have uses the renesas full-speed peripheral, this change has not been tested on renesas board with high-speed usb.
