### PR TITLE
py/emitnative: Fix case of clobbered REG_TEMP0 when loading const obj.

### DIFF
--- a/py/emitnative.c
+++ b/py/emitnative.c
@@ -357,6 +357,7 @@ static void emit_native_mov_reg_qstr(emit_t *emit, int arg_reg, qstr qst) {
     #endif
 }
 
+// This function may clobber REG_TEMP0 (and `reg_dest` can be REG_TEMP0).
 static void emit_native_mov_reg_qstr_obj(emit_t *emit, int reg_dest, qstr qst) {
     #if MICROPY_PERSISTENT_CODE_SAVE
     emit_load_reg_with_object(emit, reg_dest, MP_OBJ_NEW_QSTR(qst));
@@ -1117,6 +1118,7 @@ static exc_stack_entry_t *emit_native_pop_exc_stack(emit_t *emit) {
     return e;
 }
 
+// This function will clobber REG_TEMP0 (and `reg` can be REG_TEMP0).
 static void emit_load_reg_with_object(emit_t *emit, int reg, mp_obj_t obj) {
     emit->scope->scope_flags |= MP_SCOPE_FLAG_HASCONSTS;
     size_t table_off = mp_emit_common_use_const_obj(emit->emit_common, obj);
@@ -1391,9 +1393,9 @@ static void emit_native_load_const_str(emit_t *emit, qstr qst) {
 
 static void emit_native_load_const_obj(emit_t *emit, mp_obj_t obj) {
     emit_native_pre(emit);
-    need_reg_single(emit, REG_RET, 0);
-    emit_load_reg_with_object(emit, REG_RET, obj);
-    emit_post_push_reg(emit, VTYPE_PYOBJ, REG_RET);
+    need_reg_single(emit, REG_TEMP0, 0);
+    emit_load_reg_with_object(emit, REG_TEMP0, obj);
+    emit_post_push_reg(emit, VTYPE_PYOBJ, REG_TEMP0);
 }
 
 static void emit_native_load_null(emit_t *emit) {


### PR DESCRIPTION
### Summary

The `emit_load_reg_with_object()` helper function will clobber `REG_TEMP0`. This is currently OK on architectures where `REG_RET` and `REG_TEMP0` are the same (all architectures except RV32), because all callers of `emit_load_reg_with_object()` use either `REG_RET` or `REG_TEMP0` as the destination register.  But on RV32 these registers are different and so when `REG_RET` is the destination, `REG_TEMP0` is clobbered, leading to incorrectly generated machine code.

This commit fixes the issue simply by using `REG_TEMP0` as the destination register for all uses of `emit_load_reg_with_object()`, and adds a comment to make sure the caller of this function is careful.

### Testing

This is currently tested only by inspecting output of `mpy-cross -march=debug` for the following code:
```py
import array

@micropython.native
def a():
        array.array('B', b'12')

a()
```
See https://github.com/micropython/micropython/issues/15551#issuecomment-2259068640 for background.

TODO: would be good to improve the qemu-riscv (and qemu-arm) ports so they can test this case by generating .mpy files using mpy-cross with a native emitter for all their tests, and running the .mpy.  But that requires a bit of upfront leg work.