### PR TITLE
ports/stm32: Allow HSE to be a wakeup source for BLE for the WB55.

### DIFF
--- a/ports/stm32/rfcore.c
+++ b/ports/stm32/rfcore.c
@@ -539,8 +539,12 @@ void rfcore_init(void) {
     while (LL_HSEM_1StepLock(HSEM, CFG_HW_PWR_STANDBY_SEMID)) {
     }
 
-    // Select LSE as RF wakeup source
+    // Set the wakeup source to LSE or fall back to use HSE
+    #if MICROPY_HW_RTC_USE_LSE
     RCC->CSR = (RCC->CSR & ~RCC_CSR_RFWKPSEL) | 1 << RCC_CSR_RFWKPSEL_Pos;
+    #else
+    RCC->CSR = (RCC->CSR & ~RCC_CSR_RFWKPSEL) | 3 << RCC_CSR_RFWKPSEL_Pos;
+    #endif
 
     // Initialise IPCC and shared memory structures
     ipcc_init(IRQ_PRI_SDIO);


### PR DESCRIPTION
### Summary

On an internal project using the stm32wb55 a cost-down exercise trialled removing the 32KHz oscillator, known as LSE (Low-Speed External clock). 

The affects bring-up of the BLE core which expects to receive a clock signal from LSE.

However, it is possible to use HSE (High-Speed External clock) with appropriate configuration.
This change falls back to using HSE if MICROPY_HW_RTC_USE_LSE is set to 0.

### Testing

Tested on project hardware without the 32khz crystal, built with `#define MICROPY_HW_RTC_USE_LSE 0` in mpconfigboard.h

Feature originally developed by @mattytrentini 

---
This work was funded by Planet Innovation.