### PR TITLE
esp32: Use configured stack-limit-margin when creating threads.

### DIFF
--- a/ports/esp32/main.c
+++ b/ports/esp32/main.c
@@ -71,13 +71,6 @@
 // MicroPython runs as a task under FreeRTOS
 #define MP_TASK_PRIORITY        (ESP_TASK_PRIO_MIN + 1)
 
-// Set the margin for detecting stack overflow, depending on the CPU architecture.
-#if CONFIG_IDF_TARGET_ESP32C3
-#define MP_TASK_STACK_LIMIT_MARGIN (2048)
-#else
-#define MP_TASK_STACK_LIMIT_MARGIN (1024)
-#endif
-
 int vprintf_null(const char *format, va_list ap) {
     // do nothing: this is used as a log target during raw repl mode
     return 0;

--- a/ports/esp32/mphalport.h
+++ b/ports/esp32/mphalport.h
@@ -50,6 +50,13 @@
 #define MP_TASK_COREID (1)
 #endif
 
+// Set the margin for detecting stack overflow, depending on the CPU architecture.
+#if CONFIG_IDF_TARGET_ESP32C3
+#define MP_TASK_STACK_LIMIT_MARGIN (2048)
+#else
+#define MP_TASK_STACK_LIMIT_MARGIN (1024)
+#endif
+
 extern TaskHandle_t mp_main_task_handle;
 
 extern ringbuf_t stdin_ringbuf;

--- a/ports/esp32/mpthreadport.c
+++ b/ports/esp32/mpthreadport.c
@@ -38,7 +38,7 @@
 #if MICROPY_PY_THREAD
 
 #define MP_THREAD_MIN_STACK_SIZE                        (4 * 1024)
-#define MP_THREAD_DEFAULT_STACK_SIZE                    (MP_THREAD_MIN_STACK_SIZE + 1024)
+#define MP_THREAD_DEFAULT_STACK_SIZE                    (MP_THREAD_MIN_STACK_SIZE + MP_TASK_STACK_LIMIT_MARGIN)
 #define MP_THREAD_PRIORITY                              (ESP_TASK_PRIO_MIN + 1)
 
 #if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(5, 2, 0) && !CONFIG_FREERTOS_ENABLE_STATIC_TASK_CLEAN_UP
@@ -161,7 +161,7 @@ mp_uint_t mp_thread_create_ex(void *(*entry)(void *), void *arg, size_t *stack_s
     thread = th;
 
     // adjust the stack_size to provide room to recover from hitting the limit
-    *stack_size -= 1024;
+    *stack_size -= MP_TASK_STACK_LIMIT_MARGIN;
 
     mp_thread_mutex_unlock(&thread_mutex);
 


### PR DESCRIPTION
### Summary

This gives more stack margin for threads on ESP32C3 (it should have been done this way from the beginning).  That's important for IDF v5.2, see https://github.com/micropython/micropython/pull/15523#issuecomment-2264356843

### Testing

Ran the main test suite on an ESP32C3 using IDF v5.0.5.  All tests pass (sans known failure `math_domain_special.py`).