### PR TITLE
ports/rp2: Add i2s deinit on soft reset.

### DIFF
--- a/ports/rp2/machine_i2s.c
+++ b/ports/rp2/machine_i2s.c
@@ -171,6 +171,15 @@ void machine_i2s_init0(void) {
     }
 }
 
+void machine_i2s_deinit_all(void) {
+    for (uint8_t i = 0; i < MAX_I2S_RP2; i++) {
+        machine_i2s_obj_t *i2s = MP_STATE_PORT(machine_i2s_obj[i]);
+        if (i2s) {
+            mp_machine_i2s_deinit(i2s);
+        }
+    }
+}
+
 static int8_t get_frame_mapping_index(int8_t bits, format_t format) {
     if (format == MONO) {
         if (bits == 16) {

--- a/ports/rp2/main.c
+++ b/ports/rp2/main.c
@@ -214,6 +214,7 @@ int main(int argc, char **argv) {
         #if MICROPY_PY_NETWORK
         mod_network_deinit();
         #endif
+        machine_i2s_deinit_all();
         rp2_dma_deinit();
         rp2_pio_deinit();
         #if MICROPY_PY_BLUETOOTH

--- a/ports/rp2/modmachine.h
+++ b/ports/rp2/modmachine.h
@@ -6,6 +6,7 @@
 void machine_pin_init(void);
 void machine_pin_deinit(void);
 void machine_i2s_init0(void);
+void machine_i2s_deinit_all(void);
 void machine_pwm_deinit_all(void);
 
 struct _machine_spi_obj_t *spi_from_mp_obj(mp_obj_t o);


### PR DESCRIPTION
### Summary

Code using i2s required a try/finally in order to avoid a hard fault on soft reset.

Add `machine_i2s_deinit_all` to teardown any active i2s instances on reset.

Fixes #14339

Probably replaces #14345

### Testing

I've "fixed" and tested the RP2 port, using our TinyFX/picofx libraries and confirmed that subsequent to this change, forgetting to explicitly `deinit()` your i2s instance will not result in a burst of static and a hardfault.

### Trade-offs and Alternatives

As far as I'm aware, this bring i2s in line with other interfaces such that they're torn down automatically on soft reset.

I don't believe these are any cases where you wouldn't want to do this, but obviously doing so automatically comes at a small code size cost.

It's arguable that this should be done (as mentioned in #14339) with a finalizer, but there are some issues around that topic which would take much longer to work out than simply adding this method.

Even executing all finalizers first does not guarantee they happen in the right order, so since we're using `MP_STATE_PORT` to track active i2s instances, we might as well be nice and clean them up first.

