### PR TITLE
docs/framebuf: Add minimal buffer size requirements.

### DIFF
--- a/docs/library/framebuf.rst
+++ b/docs/library/framebuf.rst
@@ -53,6 +53,9 @@ Constructors
     optionally *stride*.  Invalid *buffer* size or dimensions may lead to
     unexpected errors.
 
+    Buffer size depends on the pixel format. See below for additional details.
+    A `ValueError` is thrown if the buffer size is too small.
+
 Drawing primitive shapes
 ------------------------
 
@@ -193,3 +196,27 @@ Constants
 .. data:: framebuf.GS8
 
     Grayscale (8-bit) color format
+
+Buffer size requirements
+------------------------
+
+The following lists the minimal size requirements of the *buffer*
+in bytes, depending on the framebuf pixel mode used. 
+
+- `framebuf.MONO_VLSB`
+    size = *width* * ((*height* + 7) & ~7) / 8 
+
+- `framebuf.MONO_HLSB`, `framebuf.MONO_HMSB`
+    size = ((*width* + 7) & ~7) * *height* / 8
+
+- `framebuf.GS2_HMSB`
+    size = ((*width* + 3) & ~3) * *height* / 4;
+
+- `framebuf.GS4_HMSB`
+    size = ((*width* + 1) & ~1) * *height* / 2;
+
+- `framebuf.RGB565`
+    size = *width* * *height* * 2
+
+- `framebuf.GS8`  
+    size = *width* * *height*


### PR DESCRIPTION
<!-- Thanks for submitting a Pull Request! We appreciate you spending the
     time to improve MicroPython. Please provide enough information so that
     others can review your Pull Request.

     Before submitting, please read:
     https://github.com/micropython/micropython/blob/master/CODEOFCONDUCT.md
     https://github.com/micropython/micropython/wiki/ContributorGuidelines

     Please check any CI failures that appear after your Pull Request is opened.
-->

### Summary

To improve the framebuf documentation regarding buffer size requirements

see https://github.com/micropython/micropython/issues/15571


### Testing

only doc updates

### Trade-offs and Alternatives

none

