### PR TITLE
examples/network: Improve HTTP client examples to work with IPv4 and IPv6, and add more comments

### DIFF
--- a/examples/network/http_client.py
+++ b/examples/network/http_client.py
@@ -1,16 +1,35 @@
+# Very simple HTTP client example:
+# - Connects to a server.
+# - Sends a HTTP request.
+# - Reads the result.
+#
+# This example works in both MicroPython and CPython.
+#
+# To implement an HTTP client using less code, use mip to install the requests package:
+# https://github.com/micropython/micropython-lib/tree/master/python-ecosys/requests
+
 import socket
 
 
-def main(use_stream=False):
-    s = socket.socket()
-
-    ai = socket.getaddrinfo("google.com", 80)
+# `addr_family` selects IPv4 vs IPv6: 0 means either, or use
+# socket.AF_INET or socket.AF_INET6 to select a particular one.
+def main(domain, addr_family=0, use_stream=False):
+    # Lookup the server address, for the given family and socket type.
+    ai = socket.getaddrinfo(domain, 80, addr_family, socket.SOCK_STREAM)
     print("Address infos:", ai)
-    addr = ai[0][-1]
 
+    # Select the first address.
+    ai = ai[0]
+
+    # Create a socket with the server's family, type and proto.
+    s = socket.socket(ai[0], ai[1], ai[2])
+
+    # Connect to the server.
+    addr = ai[-1]
     print("Connect address:", addr)
     s.connect(addr)
 
+    # Send request and read response.
     if use_stream:
         # MicroPython socket objects support stream (aka file) interface
         # directly, but the line below is needed for CPython.
@@ -21,7 +40,8 @@ def main(use_stream=False):
         s.send(b"GET / HTTP/1.0\r\n\r\n")
         print(s.recv(4096))
 
+    # Close the socket.
     s.close()
 
 
-main()
+main("google.com")

--- a/examples/network/http_client.py
+++ b/examples/network/http_client.py
@@ -13,9 +13,13 @@ import socket
 
 # `addr_family` selects IPv4 vs IPv6: 0 means either, or use
 # socket.AF_INET or socket.AF_INET6 to select a particular one.
-def main(domain, addr_family=0, use_stream=False):
+def main(url, addr_family=0, use_stream=False):
+    # Split the given URL into components.
+    proto, _, host, path = url.split(b"/", 3)
+    assert proto == b"http:"
+
     # Lookup the server address, for the given family and socket type.
-    ai = socket.getaddrinfo(domain, 80, addr_family, socket.SOCK_STREAM)
+    ai = socket.getaddrinfo(host, 80, addr_family, socket.SOCK_STREAM)
     print("Address infos:", ai)
 
     # Select the first address.
@@ -30,18 +34,19 @@ def main(domain, addr_family=0, use_stream=False):
     s.connect(addr)
 
     # Send request and read response.
+    request = b"GET /%s HTTP/1.0\r\nHost: %s\r\n\r\n" % (path, host)
     if use_stream:
         # MicroPython socket objects support stream (aka file) interface
         # directly, but the line below is needed for CPython.
         s = s.makefile("rwb", 0)
-        s.write(b"GET / HTTP/1.0\r\n\r\n")
+        s.write(request)
         print(s.read())
     else:
-        s.send(b"GET / HTTP/1.0\r\n\r\n")
+        s.send(request)
         print(s.recv(4096))
 
     # Close the socket.
     s.close()
 
 
-main("google.com")
+main(b"http://www.google.com/")

--- a/examples/network/https_client.py
+++ b/examples/network/https_client.py
@@ -32,7 +32,10 @@ def main(domain, addr_family=0, use_stream=True):
     s.connect(addr)
 
     # Upgrade the socket to a TLS connection.
-    s = ssl.wrap_socket(s)
+    ctx = ssl.SSLContext(ssl.PROTOCOL_TLS_CLIENT)
+    ctx.check_hostname = False
+    ctx.verify_mode = ssl.CERT_NONE
+    s = ctx.wrap_socket(s)
     print(s)
 
     # Send request and read response.

--- a/examples/network/https_client.py
+++ b/examples/network/https_client.py
@@ -1,20 +1,41 @@
+# Very simple HTTPS client example:
+# - Connects to a server.
+# - Upgrades the connection to a TLS connection.
+# - Sends a HTTP request.
+# - Reads the result.
+#
+# This example works in both MicroPython and CPython.
+#
+# To implement an HTTPS client using less code, use mip to install the requests package:
+# https://github.com/micropython/micropython-lib/tree/master/python-ecosys/requests
+
 import socket
 import ssl
 
 
-def main(use_stream=True):
-    s = socket.socket()
-
-    ai = socket.getaddrinfo("google.com", 443)
+# `addr_family` selects IPv4 vs IPv6: 0 means either, or use
+# socket.AF_INET or socket.AF_INET6 to select a particular one.
+def main(domain, addr_family=0, use_stream=True):
+    # Lookup the server address, for the given family and socket type.
+    ai = socket.getaddrinfo(domain, 443, addr_family, socket.SOCK_STREAM)
     print("Address infos:", ai)
-    addr = ai[0][-1]
 
+    # Select the first address.
+    ai = ai[0]
+
+    # Create a socket with the server's family, type and proto.
+    s = socket.socket(ai[0], ai[1], ai[2])
+
+    # Connect to the server.
+    addr = ai[-1]
     print("Connect address:", addr)
     s.connect(addr)
 
+    # Upgrade the socket to a TLS connection.
     s = ssl.wrap_socket(s)
     print(s)
 
+    # Send request and read response.
     if use_stream:
         # Both CPython and MicroPython SSLSocket objects support read() and
         # write() methods.
@@ -26,7 +47,8 @@ def main(use_stream=True):
         s.send(b"GET / HTTP/1.0\r\n\r\n")
         print(s.recv(4096))
 
+    # Close the socket.
     s.close()
 
 
-main()
+main("google.com")

--- a/examples/network/https_client_nonblocking.py
+++ b/examples/network/https_client_nonblocking.py
@@ -37,13 +37,13 @@ def read_nonblocking(poller, sock, n):
     return data
 
 
-def main(url):
+def main(url, addr_family=0):
     # Split the given URL into components.
     proto, _, host, path = url.split(b"/", 3)
     assert proto == b"https:"
 
     # Note: this getaddrinfo() call is blocking!
-    ai = socket.getaddrinfo(host, 443)[0]
+    ai = socket.getaddrinfo(host, 443, addr_family, socket.SOCK_STREAM)[0]
     addr = ai[-1]
     print("Connect address:", addr)
 


### PR DESCRIPTION
### Summary

The main changes here are to pass the address family and socket type to `getaddrinfo()`, and then use the result of the address lookup when creating the socket, so it has the correct address family.
    
This allows both IPv4 and IPv6 to work, because the socket is created with the correct AF_INETx type for the address.
    
Also add some more comments to the examples to explain what's going on.

And use `SSLContext` instead of `ssl.wrap_socket()` because the latter is deprecated (in CPython at least).
    
Fixes issue #15580.

### Testing

Tested on CPython (only `http_client.py` and `https_client.py`), MicroPython unix and Pico W.