### PR TITLE
qemu-arm: Fix tinytest test profile when updating set of dirs/files.

### DIFF
--- a/ports/qemu-arm/tests_profile.txt
+++ b/ports/qemu-arm/tests_profile.txt
@@ -1,10 +1,10 @@
 # Port-specific test directories.
 
-test_dirs.add(("inlineasm", "qemu-arm"))
+test_dirs.update(("inlineasm", "ports/qemu-arm"))
 
 # Port-specific tests exclusion list.
 
-exclude_tests.add(
+exclude_tests.update(
     (
         # inline asm FP tests (require Cortex-M4)
         "inlineasm/asmfpaddsub.py",

--- a/ports/qemu-riscv/tests_profile.txt
+++ b/ports/qemu-riscv/tests_profile.txt
@@ -1,3 +1,7 @@
+# Port-specific test directories.
+
+test_dirs.update(())
+
 # Port-specific tests exclusion list.
 
-exclude_tests = exclude_tests.union(())
+exclude_tests.update(())


### PR DESCRIPTION
### Summary

Updating a set must use `.update()` rather than `.add()`.

Also apply the same pattern to qemu-riscv to prevent the same issue when directories/files are added to that port's `tests_profile.txt` file.

### Testing

Prior to this change, the qemu-arm port was not running any of the `inlineasm` or `ports/qemu-arm` tests.  Now it does (verified by inspecting the `build/genhdr/test.h` and `build/console.out` files).