### PR TITLE
natmod: Add native modules support for RV32 code.

### DIFF
--- a/docs/develop/natmod.rst
+++ b/docs/develop/natmod.rst
@@ -39,7 +39,8 @@ options for the ``ARCH`` variable, see below):
 * ``armv7emsp`` (ARM Thumb 2, single precision float, eg Cortex-M4F, Cortex-M7)
 * ``armv7emdp`` (ARM Thumb 2, double precision float, eg Cortex-M7)
 * ``xtensa`` (non-windowed, eg ESP8266)
-* ``xtensawin`` (windowed with window size 8, eg ESP32)
+* ``xtensawin`` (windowed with window size 8, eg ESP32, ESP32S3)
+* ``rv32imc`` (RISC-V 32 bits with compressed instructions, eg ESP32C3, ESP32C6)
 
 When compiling and linking the native .mpy file the architecture must be chosen
 and the corresponding file can only be imported on that architecture.  For more
@@ -172,7 +173,7 @@ The file ``Makefile`` contains:
     # Source files (.c or .py)
     SRC = factorial.c
 
-    # Architecture to build for (x86, x64, armv6m, armv7m, xtensa, xtensawin)
+    # Architecture to build for (x86, x64, armv6m, armv7m, xtensa, xtensawin, rv32imc)
     ARCH = x64
 
     # Include to get the rules for compiling and linking the module

--- a/examples/natmod/README.md
+++ b/examples/natmod/README.md
@@ -65,7 +65,7 @@ your system package manager or installed from PyPI in a virtual environment
 with `pip`.
 
 Each example provides a Makefile. You should specify the `ARCH` argument to
-make (one of x86, x64, armv6m, armv7m, xtensa, xtensawin):
+make (one of x86, x64, armv6m, armv7m, xtensa, xtensawin, rv32imc):
 
 ```
 $ cd features0

--- a/examples/natmod/btree/Makefile
+++ b/examples/natmod/btree/Makefile
@@ -7,7 +7,7 @@ MOD = btree_$(ARCH)
 # Source files (.c or .py)
 SRC = btree_c.c
 
-# Architecture to build for (x86, x64, armv7m, xtensa, xtensawin)
+# Architecture to build for (x86, x64, armv7m, xtensa, xtensawin, rv32imc)
 ARCH = x64
 
 BTREE_DIR = $(MPY_DIR)/lib/berkeley-db-1.xx

--- a/examples/natmod/deflate/Makefile
+++ b/examples/natmod/deflate/Makefile
@@ -7,7 +7,7 @@ MOD = deflate_$(ARCH)
 # Source files (.c or .py)
 SRC = deflate.c
 
-# Architecture to build for (x86, x64, armv7m, xtensa, xtensawin)
+# Architecture to build for (x86, x64, armv7m, xtensa, xtensawin, rv32imc)
 ARCH = x64
 
 include $(MPY_DIR)/py/dynruntime.mk

--- a/examples/natmod/features0/Makefile
+++ b/examples/natmod/features0/Makefile
@@ -7,8 +7,9 @@ MOD = features0
 # Source files (.c or .py)
 SRC = features0.c
 
-# Architecture to build for (x86, x64, armv7m, xtensa, xtensawin)
+# Architecture to build for (x86, x64, armv7m, xtensa, xtensawin, rv32imc)
 ARCH = x64
 
 # Include to get the rules for compiling and linking the module
 include $(MPY_DIR)/py/dynruntime.mk
+

--- a/examples/natmod/features1/Makefile
+++ b/examples/natmod/features1/Makefile
@@ -7,7 +7,7 @@ MOD = features1
 # Source files (.c or .py)
 SRC = features1.c
 
-# Architecture to build for (x86, x64, armv7m, xtensa, xtensawin)
+# Architecture to build for (x86, x64, armv7m, xtensa, xtensawin, rv32imc)
 ARCH = x64
 
 # Include to get the rules for compiling and linking the module

--- a/examples/natmod/features3/Makefile
+++ b/examples/natmod/features3/Makefile
@@ -7,7 +7,7 @@ MOD = features3
 # Source files (.c or .py)
 SRC = features3.c
 
-# Architecture to build for (x86, x64, armv7m, xtensa, xtensawin)
+# Architecture to build for (x86, x64, armv7m, xtensa, xtensawin, rv32imc)
 ARCH = x64
 
 # Include to get the rules for compiling and linking the module

--- a/examples/natmod/features4/Makefile
+++ b/examples/natmod/features4/Makefile
@@ -7,7 +7,7 @@ MOD = features4
 # Source files (.c or .py)
 SRC = features4.c
 
-# Architecture to build for (x86, x64, armv7m, xtensa, xtensawin)
+# Architecture to build for (x86, x64, armv7m, xtensa, xtensawin, rv32imc)
 ARCH = x64
 
 # Include to get the rules for compiling and linking the module

--- a/examples/natmod/heapq/Makefile
+++ b/examples/natmod/heapq/Makefile
@@ -7,7 +7,7 @@ MOD = heapq_$(ARCH)
 # Source files (.c or .py)
 SRC = heapq.c
 
-# Architecture to build for (x86, x64, armv7m, xtensa, xtensawin)
+# Architecture to build for (x86, x64, armv7m, xtensa, xtensawin, rv32imc)
 ARCH = x64
 
 include $(MPY_DIR)/py/dynruntime.mk

--- a/examples/natmod/random/Makefile
+++ b/examples/natmod/random/Makefile
@@ -7,7 +7,7 @@ MOD = random_$(ARCH)
 # Source files (.c or .py)
 SRC = random.c
 
-# Architecture to build for (x86, x64, armv7m, xtensa, xtensawin)
+# Architecture to build for (x86, x64, armv7m, xtensa, xtensawin, rv32imc)
 ARCH = x64
 
 include $(MPY_DIR)/py/dynruntime.mk

--- a/examples/natmod/re/Makefile
+++ b/examples/natmod/re/Makefile
@@ -7,7 +7,7 @@ MOD = re_$(ARCH)
 # Source files (.c or .py)
 SRC = re.c
 
-# Architecture to build for (x86, x64, armv7m, xtensa, xtensawin)
+# Architecture to build for (x86, x64, armv7m, xtensa, xtensawin, rv32imc)
 ARCH = x64
 
 include $(MPY_DIR)/py/dynruntime.mk

--- a/examples/natmod/re/re.c
+++ b/examples/natmod/re/re.c
@@ -4,7 +4,20 @@
 #define MICROPY_PY_RE_MATCH_SPAN_START_END (1)
 #define MICROPY_PY_RE_SUB (0) // requires vstr interface
 
+#if defined __has_builtin
+#if __has_builtin(__builtin_alloca)
+#define alloca __builtin_alloca
+#endif
+#endif
+
+#if !defined(alloca)
+#if defined(_PICOLIBC__) && !defined(HAVE_BUILTIN_ALLOCA)
+#define alloca(n) m_malloc(n)
+#else
 #include <alloca.h>
+#endif
+#endif
+
 #include "py/dynruntime.h"
 
 #define STACK_LIMIT (2048)

--- a/ports/qemu/Makefile
+++ b/ports/qemu/Makefile
@@ -168,6 +168,12 @@ test: $(BUILD)/firmware.elf
 	$(eval DIRNAME=ports/$(notdir $(CURDIR)))
 	cd $(TOP)/tests && ./run-tests.py -t execpty:"$(QEMU_SYSTEM) $(QEMU_ARGS) -serial pty -kernel ../$(DIRNAME)/$<" $(RUN_TESTS_ARGS) $(RUN_TESTS_EXTRA)
 
+.PHONY: test_natmod
+test_natmod: $(BUILD)/firmware.elf
+	$(eval DIRNAME=ports/$(notdir $(CURDIR)))
+	# "btree" cannot build against Picolibc right now.
+	cd $(TOP)/tests && ./run-natmodtests.py -p -d execpty:"$(QEMU_SYSTEM) $(QEMU_ARGS) -serial pty -kernel ../$(DIRNAME)/$<" $(RUN_NATMODTESTS_ARGS) extmod/{deflate,framebuf,heapq,random_basic,re}*.py
+
 $(BUILD)/firmware.elf: $(LDSCRIPT) $(OBJ)
 	$(Q)$(CC) $(LDFLAGS) -o $@ $(OBJ) $(LIBS)
 	$(Q)$(SIZE) $@

--- a/ports/qemu/README.md
+++ b/ports/qemu/README.md
@@ -71,8 +71,9 @@ To access the REPL directly use:
 
     $ make repl
 
-This will start `qemu-system-arm` with the UART redirected to stdio.  It's also
-possible to redirect the UART to a pty device using:
+This will start `qemu-system-arm` (or `qemu-system-riscv32`) with the UART
+redirected to stdio.  It's also possible to redirect the UART to a pty device
+using:
 
     $ make run
 
@@ -84,7 +85,7 @@ for example `mpremote`:
 
 You can disconnect and reconnect to the serial device multiple times.  Once you
 are finished, stop the `make run` command by pressing Ctrl-C where that command
-was started (or execute `machine.reset()` at the REPL).
+was started (or execute `import machine; machine.reset()` at the REPL).
 
 The test suite can be run against the firmware by using the UART redirection.
 You can either do this automatically using the single command:
@@ -96,6 +97,17 @@ tests against the serial device, for example:
 
     $ cd ../../tests
     $ ./run-tests.py -t /dev/pts/1
+
+Selected native modules that come as examples with the MicroPython source tree
+can also be tested with this command (this is currently supported only for the
+`VIRT_RV32` board):
+
+    $ make test_natmod
+
+The same remarks about manually running the tests apply for native modules, but
+`run-natmodtests.py` should be run instead of `run-tests.py`.  In this case you
+also have to explicitly pass the architecture you are running native modules to
+`run-natmodtests.py` ("--arch rv32imc" for the `VIRT_RV32` board).
 
 Extra make options
 ------------------

--- a/ports/qemu/boards/VIRT_RV32.mk
+++ b/ports/qemu/boards/VIRT_RV32.mk
@@ -12,3 +12,5 @@ MPY_CROSS_FLAGS += -march=rv32imc
 
 # These Thumb tests don't run on RV32, so exclude them.
 RUN_TESTS_ARGS = --exclude 'inlineasm|qemu/asm_test'
+
+RUN_NATMODTESTS_ARGS = --arch rv32imc

--- a/py/dynruntime.mk
+++ b/py/dynruntime.mk
@@ -99,6 +99,22 @@ CROSS = xtensa-esp32-elf-
 CFLAGS +=
 MICROPY_FLOAT_IMPL ?= float
 
+else ifeq ($(ARCH),rv32imc)
+
+# rv32imc
+CROSS = riscv64-unknown-elf-
+CFLAGS += -march=rv32imac -mabi=ilp32 -mno-relax
+# If Picolibc is available then select it explicitly.  Ubuntu 22.04 ships its
+# bare metal RISC-V toolchain with Picolibc rather than Newlib, and the default
+# is "nosys" so a value must be provided.  To avoid having per-distro
+# workarounds, always select Picolibc if available.
+PICOLIBC_SPECS = $(shell $(CROSS)gcc --print-file-name=picolibc.specs)
+ifneq ($(PICOLIBC_SPECS),picolibc.specs)
+CFLAGS += --specs=$(PICOLIBC_SPECS)
+endif
+
+MICROPY_FLOAT_IMPL ?= none
+
 else
 $(error architecture '$(ARCH)' not supported)
 endif

--- a/py/dynruntime.mk
+++ b/py/dynruntime.mk
@@ -38,6 +38,8 @@ MPY_CROSS_FLAGS += -march=$(ARCH)
 SRC_O += $(addprefix $(BUILD)/, $(patsubst %.c,%.o,$(filter %.c,$(SRC))) $(patsubst %.S,%.o,$(filter %.S,$(SRC))))
 SRC_MPY += $(addprefix $(BUILD)/, $(patsubst %.py,%.mpy,$(filter %.py,$(SRC))))
 
+CLEAN_EXTRA += $(MOD).mpy
+
 ################################################################################
 # Architecture configuration
 

--- a/tools/ci.sh
+++ b/tools/ci.sh
@@ -273,6 +273,7 @@ function ci_qemu_setup_arm {
 }
 
 function ci_qemu_setup_rv32 {
+    ci_mpy_format_setup
     ci_gcc_riscv_setup
     sudo apt-get update
     sudo apt-get install qemu-system
@@ -292,6 +293,10 @@ function ci_qemu_build_rv32 {
     make ${MAKEOPTS} -C mpy-cross
     make ${MAKEOPTS} -C ports/qemu BOARD=VIRT_RV32 submodules
     make ${MAKEOPTS} -C ports/qemu BOARD=VIRT_RV32 test
+
+    # Test building and running native .mpy with rv32imc architecture.
+    ci_native_mpy_modules_build rv32imc
+    make ${MAKEOPTS} -C ports/qemu BOARD=VIRT_RV32 test_natmod
 }
 
 ########################################################################################
@@ -476,10 +481,14 @@ function ci_native_mpy_modules_build {
         arch=$1
     fi
     make -C examples/natmod/features1 ARCH=$arch
-    make -C examples/natmod/features2 ARCH=$arch
+    if [ $arch != rv32imc ]; then
+        # This requires soft-float support on rv32imc.
+        make -C examples/natmod/features2 ARCH=$arch
+        # This requires thread local storage support on rv32imc.
+        make -C examples/natmod/btree ARCH=$arch
+    fi
     make -C examples/natmod/features3 ARCH=$arch
     make -C examples/natmod/features4 ARCH=$arch
-    make -C examples/natmod/btree ARCH=$arch
     make -C examples/natmod/deflate ARCH=$arch
     make -C examples/natmod/framebuf ARCH=$arch
     make -C examples/natmod/heapq ARCH=$arch


### PR DESCRIPTION
### Summary

This commit adds support for RV32IMC native modules, which is one of the few remaining bits left to bring RV32 support to parity with Thumb or x86 (the other is inline assembler). 

### Testing

All tests were performed on an ESP32C3 board, with cross-compilation done in an environment similar to the CI machine used to build the ESP32 and Qemu-RISCV ports.  The natmods being built are the ones from the `examples/natmod/` directory, using the tests in `tests/extmod/` to exercise the code in a known way whenever possible.

### Trade-offs and Alternatives

There isn't any alternative to this in order to get natmod support on RV32, and there are no real trade-offs in execution speed or in code size.  A full-fledged linker would be able to convert some two-opcodes relocations into a single opcode or perform similar optimisations (the infamous R_RISCV_RELAX relocation marker), but this isn't it.  The RV32-specific relocations handling code had to be moved to its own function to please the linter when it measures function complexity.

One thing worth mentioning is the insane amount of [possible static relocation types](https://github.com/riscv-non-isa/riscv-elf-psabi-doc/blob/master/riscv-elf.adoc#reloc-table) that must be handled (around 35 in total).  Right now I've implemented all the ones I've seen from building the sample natmods, for the ones I didn't see yet, I'll have to add them in blindly and hope the documentation is accurate.

The makefile changes to add native compilation are pretty much the same as what was originally written for the Qemu-RISCV port.  It's quite convoluted but I couldn't find any better way to simplify that and get the same out-of-the-box compilation output under various Linux environments.