### PR TITLE
Update pyboard.py fixing get_time() bug

### DIFF
--- a/tools/pyboard.py
+++ b/tools/pyboard.py
@@ -506,7 +506,7 @@ class Pyboard:
         return self.exec_(pyfile)
 
     def get_time(self):
-        t = str(self.eval("pyb.RTC().datetime()"), encoding="utf8")[1:-1].split(", ")
+        t = str(self.eval("machine.RTC().datetime()"), encoding="utf8")[1:-1].split(", ")
         return int(t[4]) * 3600 + int(t[5]) * 60 + int(t[6])
 
     def fs_exists(self, src):


### PR DESCRIPTION
### Summary

The current script evaluates "pyb.RTC().datetime()" resulting in a remote side exception being called as pyb is not defined.

The script should evaluate "machine.RTC().datetime()" and hence return the current time.

This reflects the API in the docs, https://docs.micropython.org/en/latest/library/time.html#module-time

### Testing

Tested with the Raspberry Pi Pico 4MB