### PR TITLE
esp32/boards: Remove BLE from list of features for ESP32-S2.

### DIFF
--- a/ports/esp32/boards/ESP32_GENERIC_S2/board.json
+++ b/ports/esp32/boards/ESP32_GENERIC_S2/board.json
@@ -4,7 +4,6 @@
     ],
     "docs": "",
     "features": [
-        "BLE",
         "External Flash",
         "External RAM",
         "WiFi"


### PR DESCRIPTION
The ESP32-S2 doesn't support BLE, but `ESP32_GENERIC_S2/board.json` listed it as a feature. This PR just removes that feature from that `board.json`.

This resolves #15618. 