### PR TITLE
esp32/mphalport: Print debug strings even before the GIL is ready.

### DIFF
--- a/ports/esp32/mpconfigport.h
+++ b/ports/esp32/mpconfigport.h
@@ -314,3 +314,8 @@ void boardctrl_startup(void);
 #endif
 #endif
 #endif
+
+// The minimum string length threshold for string printing to stdout operations to be GIL-aware.
+#ifndef MICROPY_PY_STRING_TX_GIL_THRESHOLD
+#define MICROPY_PY_STRING_TX_GIL_THRESHOLD  (20)
+#endif


### PR DESCRIPTION
### Summary

If verbose debugging is enabled there is some stdout output happening before the GIL is ready, and the code assumed that no string printing occurred before the interpreter was fully initialised.  Printing long strings would operate without holding the GIL, which would crash if string output would happen too early in the startup process.

This commit addresses that issue, making sure verbose debugging output will work even before the interpreter is fully initialised (as if it is not yet ready there's no GIL to take care of).

Also, the threshold that would indicate whether a string is "long" (and thus requiring a GIL release/lock operation) or not was hardcoded to 20 bytes.  This commit makes that configurable, maintaining 20 bytes as a default.

This fixes bug #15408.

### Testing

Testing was done with an ESP32C3 board, with both `MICROPY_DEBUG_PRINTERS` and `MICROPY_DEBUG_VERBOSE` enabled.

### Trade-offs and Alternatives

This patch adds around 32 bytes of code, but only when `MICROPY_DEBUG_PRINTERS`, `MICROPY_DEBUG_VERBOSE`, and `MICROPY_PY_THREAD_GIL` are enabled.  Given that the first two flags are off by default, and enabling them means printing extra debugging information, a minor code size increase and even minor slowdown when printing strings is not only tolerated but expected.
