### PR TITLE
Remove old board variants

### DIFF
--- a/ports/esp32/boards/ESP32_GENERIC/board.json
+++ b/ports/esp32/boards/ESP32_GENERIC/board.json
@@ -16,7 +16,6 @@
     "thumbnail": "",
     "url": "https://www.espressif.com/en/products/modules",
     "variants": {
-        "IDF3": "Compiled with IDF 3.x",
         "D2WD": "ESP32 D2WD",
         "SPIRAM": "Support for SPIRAM / WROVER",
         "UNICORE": "ESP32 Unicore",

--- a/ports/esp32/boards/UM_TINYPICO/board.json
+++ b/ports/esp32/boards/UM_TINYPICO/board.json
@@ -22,8 +22,5 @@
     "product": "TinyPICO",
     "thumbnail": "",
     "url": "https://www.tinypico.com/",
-    "variants": {
-        "IDF3": "Compiled with IDF 3.x"
-    },
     "vendor": "Unexpected Maker"
 }

--- a/ports/samd/boards/ADAFRUIT_METRO_M4_EXPRESS/board.json
+++ b/ports/samd/boards/ADAFRUIT_METRO_M4_EXPRESS/board.json
@@ -15,9 +15,6 @@
         "metro_m4_express_airlift.jpg"
     ],
     "mcu": "samd51",
-    "variants": {
-        "wlan": "WLAN without SSL support"
-    },
     "product": "Metro M4 Express Airlift",
     "thumbnail": "",
     "url": "https://www.adafruit.com/product/4000",

--- a/tools/autobuild/build-boards.sh
+++ b/tools/autobuild/build-boards.sh
@@ -55,10 +55,8 @@ function build_board {
     $MICROPY_AUTOBUILD_MAKE BOARD=$board BUILD=$build_dir && copy_artefacts $dest_dir $descr $fw_tag $build_dir $@
     rm -rf $build_dir
 
-    # Query variants from board.json and build them. Ignore the special "IDF3"
-    # variant for ESP32 boards (this allows the downloads page to still have
-    # the idf3 files for older releases that used to be explicitly built).
-    for variant in `cat $board_json | python3 -c "import json,sys; print(' '.join(v for v in json.load(sys.stdin).get('variants', {}).keys() if v != 'IDF3'))"`; do
+    # Query variants from board.json and build them.
+    for variant in `cat $board_json | python3 -c "import json,sys; print(' '.join(json.load(sys.stdin).get('variants', {}).keys()))"`; do
         local variant_build_dir=$build_dir-$variant
         echo "building variant $descr $board $variant"
         $MICROPY_AUTOBUILD_MAKE BOARD=$board BOARD_VARIANT=$variant BUILD=$variant_build_dir && copy_artefacts $dest_dir $descr-$variant $fw_tag $variant_build_dir $@


### PR DESCRIPTION
I noticed a few unusual board variants and think they should be removed.

IDF3 builds are _very_ old now (it seems like the last successful builds are from 2021?). Can we remove them? If we want to retain the old builds for [ESP32_GENERIC](https://micropython.org/download/ESP32_GENERIC/) then we'll need to leave `ESP32_GENERIC/board.json` intact but we should at least remove it from `UM_TINYPICO/board.json` since there are [no IDF3 builds for that board](https://micropython.org/download/UM_TINYPICO/). 

If we remove IDF3 entirely we could also slightly simplify [build-boards.sh:61](https://github.com/micropython/micropython/blob/master/tools/autobuild/build-boards.sh#L61). I haven't made that change but can if we decide to remove IDF3.

Finally, I noticed a `wlan` variant for `ADAFRUIT_METRO_M4_EXPRESS`. I believe the samd port doesn't support variants so I think this is a mistake - and appears to be causing an unnecessary build.

