### PR TITLE
ports/rp2: Skip core1_entry if thread disabled.

### DIFF
--- a/ports/rp2/mphalport.c
+++ b/ports/rp2/mphalport.c
@@ -232,9 +232,11 @@ static void soft_timer_hardware_callback(unsigned int alarm_num) {
     // This ISR only runs on core0, but if core1 is running Python code then it
     // may be blocked in WFE so wake it up as well. Unfortunately this also sets
     // the event flag on core0, so a subsequent WFE on this core will not suspend
+    #if MICROPY_PY_THREAD
     if (core1_entry != NULL) {
         __sev();
     }
+    #endif
 }
 
 void soft_timer_init(void) {


### PR DESCRIPTION
If MICROPY_PY_THREAD is set to 0 (ie: a user C module wishes to use core1 exclusively) then the test of `core1_entry` would fail to compile with an "undeclared identifier" error. Fix it by wrapping in MICROPY_PY_THREAD.

Note: `core1_entry` is defined in `mpthreadport.c` *only* if `MICROPY_PY_THREAD` is enabled.