### PR TITLE
stm32/stm32_it: Enable PVD_PVM_IRQHandler for stm32wb and stm32wl.

### DIFF
--- a/ports/stm32/stm32_it.c
+++ b/ports/stm32/stm32_it.c
@@ -514,7 +514,7 @@ void PVD_IRQHandler(void) {
     IRQ_EXIT(PVD_IRQn);
 }
 
-#if defined(STM32L4)
+#if defined(STM32L4) || defined(STM32WB) || defined(STM32WL)
 void PVD_PVM_IRQHandler(void) {
     IRQ_ENTER(PVD_PVM_IRQn);
     Handle_EXTI_Irq(EXTI_PVD_OUTPUT);


### PR DESCRIPTION
### Summary

As found in https://github.com/micropython/micropython/issues/15548 there is a gap in support for the sw interrupt on STM32WBxx and STM32WLxx.

### Testing

This has been tested on NUCLEO_WB55 with the example code:
```
from pyb import Pin, ExtInt

def callback(line):
    print(line)

EXTI_PVD_NUM = 16
exti = ExtInt(EXTI_PVD_NUM, ExtInt.IRQ_RISING_FALLING, Pin.PULL_DOWN, callback)

exti.swint()
```

Before the change, the cpu is locked up as soon as the final line is run. After the change:
```
MicroPython v1.24.0-preview.187.g8b8b730d2c.dirty on 2024-08-14; NUCLEO-WB55 with STM32WB55RGV6
Type "help()" for more information.
>>>
>>>
paste mode; Ctrl-C to cancel, Ctrl-D to finish
=== from pyb import Pin, ExtInt
===
=== def callback(line):
===     print(line)
===
=== EXTI_PVD_NUM = 16
=== exti = ExtInt(EXTI_PVD_NUM, ExtInt.IRQ_RISING_FALLING, Pin.PULL_DOWN, callback)
===
=== exti.swint()
===
16
>>>
```

It was tested on WL in https://github.com/micropython/micropython/issues/15548
