### PR TITLE
test,esp32: Fix machine_spi_rate test on ESP32-C3.

### DIFF
--- a/tests/extmod/machine_spi_rate.py
+++ b/tests/extmod/machine_spi_rate.py
@@ -21,11 +21,10 @@ if "pyboard" in sys.platform:
 elif "rp2" in sys.platform:
     spi_instances = ((0, Pin(18), Pin(19), Pin(16)),)
 elif "esp32" in sys.platform:
-    spi_instances = [
-        (1, Pin(18), Pin(19), Pin(21)),
-    ]
-    if "ESP32C3" not in str(sys.implementation):
-        spi_instances.append((2, Pin(18), Pin(19), Pin(21)))
+    if "ESP32C3" in str(sys.implementation):
+        spi_instances = ((1, Pin(4), Pin(5), Pin(6)),)
+    else:
+        spi_instances = ((1, Pin(18), Pin(19), Pin(21)), (2, Pin(18), Pin(19), Pin(21)))
 else:
     print("Please add support for this test on this platform.")
     raise SystemExit


### PR DESCRIPTION
### Summary

Update to the test added in #15543, changes the SPI pins for ESP32-C3. Found while testing #15523, not sure if it's a regression there or if I missed it when testing the first time (IO 18 and 19 are the native USB pins).

### Testing

Test passes on ESP32, ESP32-C3 and ESP32-S3.
