### PR TITLE
tests/run-tests.py: Automatically detect native arch and mpy-cross flag.

### DIFF
--- a/tests/feature_check/target_info.py
+++ b/tests/feature_check/target_info.py
@@ -1,0 +1,22 @@
+# Retrieve the native architecture of the target.
+# See https://docs.micropython.org/en/latest/reference/mpyfiles.html#versioning-and-compatibility-of-mpy-files
+# for more details.
+
+import sys
+
+sys_mpy = getattr(sys.implementation, "_mpy", 0)
+arch = [
+    None,
+    "x86",
+    "x64",
+    "armv6",
+    "armv6m",
+    "armv7m",
+    "armv7em",
+    "armv7emsp",
+    "armv7emdp",
+    "xtensa",
+    "xtensawin",
+    "rv32imc",
+][sys_mpy >> 10]
+print(arch)


### PR DESCRIPTION
### Summary

Now that some ports support multiple architectures (eg esp32 has both Xtensa and RISC-V CPUs) it's no longer possible to set mpy-cross flags based on the target, eg `./run-tests.py --target esp32`.  Instead this commit makes it so the `-march=xxx` argument to mpy-cross is detected automatically via evaluation of `sys.implementation._mpy`.

### Testing

Ran tests on the unix port, PYBv1.0 and Pico, using `--via-mpy --emit native`.  The mpy-cross flags were correctly determined.

### Trade-offs and Alternatives

Alternatives would be:
- specify the MCU in the target, eg `--target esp32c3`, but that adds more complexity to `run-tests.py`
- have a new argument, eg `--arch risc-v`, but again that adds extra complexity and a burden to the user

IMO automatic detection of the mpy-cross flags makes it easier all round to maintain and run the tests.