### PR TITLE
Update board.json files to resolve missing images in MicroPython Downloads

### DIFF
--- a/ports/stm32/boards/B_L475E_IOT01A/board.json
+++ b/ports/stm32/boards/B_L475E_IOT01A/board.json
@@ -4,10 +4,12 @@
     ],
     "docs": "",
     "features": [],
-    "images": [],
+    "images": [
+        "b-l475e-iot01a-discovery.jpg"
+    ],
     "mcu": "stm32l4",
     "product": "B_L475E_IOT01A",
     "thumbnail": "",
-    "url": "",
+    "url": "https://www.st.com/en/evaluation-tools/b-l475e-iot01a.html",
     "vendor": "ST Microelectronics"
 }

--- a/ports/stm32/boards/GARATRONIC_PYBSTICK26_F411/board.json
+++ b/ports/stm32/boards/GARATRONIC_PYBSTICK26_F411/board.json
@@ -4,7 +4,9 @@
     ],
     "docs": "",
     "features": [],
-    "images": [],
+    "images": [
+        "pybstick26_f411.jpg"
+    ],
     "mcu": "stm32f4",
     "product": "GARATRONIC_PYBSTICK26_F411",
     "thumbnail": "",

--- a/ports/stm32/boards/LEGO_HUB_NO6/board.json
+++ b/ports/stm32/boards/LEGO_HUB_NO6/board.json
@@ -4,7 +4,9 @@
     ],
     "docs": "",
     "features": [],
-    "images": [],
+    "images": [
+        "lego_hub_6.jpg"
+    ],
     "mcu": "stm32f4",
     "product": "Hub No.6",
     "thumbnail": "",

--- a/ports/stm32/boards/LEGO_HUB_NO7/board.json
+++ b/ports/stm32/boards/LEGO_HUB_NO7/board.json
@@ -4,7 +4,9 @@
     ],
     "docs": "",
     "features": [],
-    "images": [],
+    "images": [
+        "lego_hub_7.jpg"
+    ],
     "mcu": "stm32f4",
     "product": "Hub No.7",
     "thumbnail": "",

--- a/ports/stm32/boards/NUCLEO_F756ZG/board.json
+++ b/ports/stm32/boards/NUCLEO_F756ZG/board.json
@@ -10,6 +10,6 @@
     "mcu": "stm32f7",
     "product": "Nucleo F756ZG",
     "thumbnail": "",
-    "url": "",
+    "url": "https://www.st.com/en/evaluation-tools/nucleo-f756zg.html",
     "vendor": "ST Microelectronics"
 }

--- a/ports/stm32/boards/NUCLEO_G0B1RE/board.json
+++ b/ports/stm32/boards/NUCLEO_G0B1RE/board.json
@@ -10,6 +10,6 @@
     "mcu": "stm32g0",
     "product": "Nucleo G0B1RE",
     "thumbnail": "",
-    "url": "",
+    "url": "https://www.st.com/en/evaluation-tools/nucleo-g0b1re.html",
     "vendor": "ST Microelectronics"
 }

--- a/ports/stm32/boards/NUCLEO_G474RE/board.json
+++ b/ports/stm32/boards/NUCLEO_G474RE/board.json
@@ -10,6 +10,6 @@
     "mcu": "stm32g4",
     "product": "Nucleo G474RE",
     "thumbnail": "",
-    "url": "",
+    "url": "https://www.st.com/en/evaluation-tools/nucleo-g474re.html",
     "vendor": "ST Microelectronics"
 }

--- a/ports/stm32/boards/NUCLEO_H723ZG/board.json
+++ b/ports/stm32/boards/NUCLEO_H723ZG/board.json
@@ -10,6 +10,6 @@
     "mcu": "stm32h7",
     "product": "Nucleo H723ZG",
     "thumbnail": "",
-    "url": "",
+    "url": "https://www.st.com/en/evaluation-tools/nucleo-h723zg.html",
     "vendor": "ST Microelectronics"
 }

--- a/ports/stm32/boards/NUCLEO_H743ZI2/board.json
+++ b/ports/stm32/boards/NUCLEO_H743ZI2/board.json
@@ -4,7 +4,9 @@
     ],
     "docs": "",
     "features": [],
-    "images": [],
+    "images": [
+        "nucleo_h743zi2.jpg"
+    ],
     "mcu": "stm32h7",
     "product": "Nucleo H743ZI2",
     "thumbnail": "",

--- a/ports/stm32/boards/NUCLEO_L152RE/board.json
+++ b/ports/stm32/boards/NUCLEO_L152RE/board.json
@@ -10,6 +10,6 @@
     "mcu": "stm32l1",
     "product": "Nucleo L152RE",
     "thumbnail": "",
-    "url": "",
+    "url": "https://www.st.com/en/evaluation-tools/nucleo-l152re.html",
     "vendor": "ST Microelectronics"
 }

--- a/ports/stm32/boards/NUCLEO_L4A6ZG/board.json
+++ b/ports/stm32/boards/NUCLEO_L4A6ZG/board.json
@@ -10,6 +10,6 @@
     "mcu": "stm32l4",
     "product": "Nucleo L4A6ZG",
     "thumbnail": "",
-    "url": "",
+    "url": "https://www.st.com/en/evaluation-tools/nucleo-l4a6zg.html",
     "vendor": "ST Microelectronics"
 }

--- a/ports/stm32/boards/NUCLEO_WL55/board.json
+++ b/ports/stm32/boards/NUCLEO_WL55/board.json
@@ -10,6 +10,6 @@
     "mcu": "stm32wl",
     "product": "Nucleo WL55",
     "thumbnail": "",
-    "url": "",
+    "url": "https://www.st.com/en/evaluation-tools/nucleo-wl55jc.html",
     "vendor": "ST Microelectronics"
 }

--- a/ports/stm32/boards/STM32L496GDISC/board.json
+++ b/ports/stm32/boards/STM32L496GDISC/board.json
@@ -4,10 +4,12 @@
     ],
     "docs": "",
     "features": [],
-    "images": [],
+    "images": [
+        "stm32l496discovery.jpg"
+    ],
     "mcu": "stm32l4",
     "product": "Discovery L496G",
     "thumbnail": "",
-    "url": "",
+    "url": "https://www.st.com/en/evaluation-tools/32l496gdiscovery.html",
     "vendor": "ST Microelectronics"
 }


### PR DESCRIPTION
There are some missing images at [MicroPython Downloads](https://micropython.org/download/); this PR attempts to resolve all the current issues in this repository. Most of the additions are actually in https://github.com/micropython/micropython-media/pull/67 - see that PR for more details.
