### PR TITLE
py/objtype: Allow passing keyword arguments to native base __init__.

### DIFF
--- a/py/obj.h
+++ b/py/obj.h
@@ -516,6 +516,9 @@ typedef mp_obj_t (*mp_fun_3_t)(mp_obj_t, mp_obj_t, mp_obj_t);
 typedef mp_obj_t (*mp_fun_var_t)(size_t n, const mp_obj_t *);
 // mp_fun_kw_t takes mp_map_t* (and not const mp_map_t*) to ease passing
 // this arg to mp_map_lookup().
+// Note that the mp_obj_t* array will contain all arguments, positional and keyword, with the keyword
+// ones starting at offset n, like: arg0 arg1 ... arg<n> key0 value0 key1 value1 ..., and the mp_map_t*
+// gets those same keyword arguments but as a map for convenience; see fun_builtin_var_call.
 typedef mp_obj_t (*mp_fun_kw_t)(size_t n, const mp_obj_t *, mp_map_t *);
 
 // Flags for type behaviour (mp_obj_type_t.flags)

--- a/py/objfun.c
+++ b/py/objfun.c
@@ -107,7 +107,9 @@ static mp_obj_t fun_builtin_var_call(mp_obj_t self_in, size_t n_args, size_t n_k
     if (self->sig & 1) {
         // function allows keywords
 
-        // we create a map directly from the given args array
+        // we create a map directly from the given args array; self->fun.kw does still
+        // expect args to have both positional and keyword arguments, ordered as:
+        // arg0 arg1 ... arg<n_args> key0 value0 key1 value1 ... key<n_kw> value<n_kw>
         mp_map_t kw_args;
         mp_map_init_fixed_table(&kw_args, n_kw, args + n_args);
 

--- a/py/objtype.c
+++ b/py/objtype.c
@@ -85,14 +85,14 @@ static int instance_count_native_bases(const mp_obj_type_t *type, const mp_obj_t
 
 // This wrapper function allows a subclass of a native type to call the
 // __init__() method (corresponding to type->make_new) of the native type.
-static mp_obj_t native_base_init_wrapper(size_t n_args, const mp_obj_t *args) {
+static mp_obj_t native_base_init_wrapper(size_t n_args, const mp_obj_t *args, mp_map_t *kw_args) {
     mp_obj_instance_t *self = MP_OBJ_TO_PTR(args[0]);
     const mp_obj_type_t *native_base = NULL;
     instance_count_native_bases(self->base.type, &native_base);
-    self->subobj[0] = MP_OBJ_TYPE_GET_SLOT(native_base, make_new)(native_base, n_args - 1, 0, args + 1);
+    self->subobj[0] = MP_OBJ_TYPE_GET_SLOT(native_base, make_new)(native_base, n_args - 1, kw_args->used, args + 1);
     return mp_const_none;
 }
-static MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(native_base_init_wrapper_obj, 1, MP_OBJ_FUN_ARGS_MAX, native_base_init_wrapper);
+static MP_DEFINE_CONST_FUN_OBJ_KW(native_base_init_wrapper_obj, 1, native_base_init_wrapper);
 
 #if !MICROPY_CPYTHON_COMPAT
 static

--- a/tests/basics/subclass_native_init.py
+++ b/tests/basics/subclass_native_init.py
@@ -6,6 +6,35 @@ class L(list):
         super().__init__([a, b])
 print(L(2, 3))
 
+# with keyword arguments, with star arguments and without because those use different C calls
+class D(dict):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+print(D())
+print(D([('a', 1)]))
+print(D([('a', 1)], a=2, b=3))
+print(D(a=2, b=3))
+
+class D(dict):
+    def __init__(self):
+        super().__init__()
+print(D())
+
+class D(dict):
+    def __init__(self):
+        super().__init__([])
+print(D())
+
+class D(dict):
+    def __init__(self):
+        super().__init__(a=1)
+print(D())
+
+class D(dict):
+    def __init__(self):
+        super().__init__([], a=1)
+print(D())
+
 # inherits implicitly from object
 class A:
     def __init__(self):


### PR DESCRIPTION
### Summary

Allowing passing keyword arguments to a native base's `__init__` (i.e. `make_new` in the C code); previously only positional arguments allowed. See #15465 and https://github.com/orgs/micropython/discussions/10236 where this came up.

### Testing

Test has been added to the test suite.

### Trade-offs and Alternatives

Every call to the native base's `__init__` going to be result in allocating a `mp_map_t` on the C stack and initialize it with `mp_map_init_fixed_table` (see `fun_builtin_var_call`), even though `make_new` will only use the resulting table to access it's `used` member i.e. to get the number of keyword arguments.

