### PR TITLE
Nano ESP32: allow `machine.bootloader` to run either hardware or DFU bootloader 

### DIFF
--- a/ports/esp32/boards/ARDUINO_NANO_ESP32/board_init.c
+++ b/ports/esp32/boards/ARDUINO_NANO_ESP32/board_init.c
@@ -27,6 +27,7 @@
 #include <string.h>
 #include "py/mphal.h"
 #include "shared/tinyusb/mp_usbd_cdc.h"
+#include "modmachine.h"
 
 #include <esp_system.h>
 #include <esp_ota_ops.h>
@@ -66,7 +67,13 @@ static void rgb_pulse_delay() {
     mp_hal_pin_write(LED_BLUE, 1);
 }
 
-void NANO_ESP32_enter_bootloader(void) {
+NORETURN void NANO_ESP32_enter_bootloader(size_t n_args, const void *args) {
+    mp_int_t mode;
+    if (n_args == 1 && mp_obj_get_int_maybe(*(const mp_obj_t *)args, &mode) && mode == 1) {
+        // jump to hardware bootloader (does not return)
+        machine_bootloader_rtc();
+    }
+
     if (!_recovery_active) {
         // check for valid partition scheme
         const esp_partition_t *ota_part = esp_ota_get_next_update_partition(NULL);
@@ -104,7 +111,7 @@ void NANO_ESP32_board_startup(void) {
     _recovery_marker_found = double_tap_check_match();
     if (_recovery_marker_found && !_recovery_active) {
         // double tap detected in user application, reboot to factory
-        NANO_ESP32_enter_bootloader();
+        NANO_ESP32_enter_bootloader(0, NULL);
     }
 
     // delay with mark set then proceed

--- a/ports/esp32/boards/ARDUINO_NANO_ESP32/mpconfigboard.h
+++ b/ports/esp32/boards/ARDUINO_NANO_ESP32/mpconfigboard.h
@@ -1,3 +1,5 @@
+#include <stddef.h> // for size_t
+
 #define MICROPY_HW_BOARD_NAME               "Arduino Nano ESP32"
 #define MICROPY_HW_MCU_NAME                 "ESP32-S3"
 
@@ -27,8 +29,12 @@
 #define MICROPY_HW_USB_MANUFACTURER_STRING "Arduino"
 #define MICROPY_HW_USB_PRODUCT_FS_STRING "Nano ESP32"
 
+// Custom bootloader function may fall back to the default one
+#define MICROPY_ESP32_USE_BOOTLOADER_RTC    (1)
+
 #define MICROPY_BOARD_STARTUP                           NANO_ESP32_board_startup
 void NANO_ESP32_board_startup(void);
 
-#define MICROPY_BOARD_ENTER_BOOTLOADER(nargs, args)     NANO_ESP32_enter_bootloader()
-void NANO_ESP32_enter_bootloader(void);
+// args is an array of mp_obj_t, but that type isn't yet defined when this file is parsed
+#define MICROPY_BOARD_ENTER_BOOTLOADER(nargs, args)     NANO_ESP32_enter_bootloader(nargs, args)
+void NANO_ESP32_enter_bootloader(size_t n_args, const void *args);

--- a/ports/esp32/modmachine.c
+++ b/ports/esp32/modmachine.c
@@ -272,7 +272,7 @@ static mp_int_t mp_machine_reset_cause(void) {
 #include "esp32s3/rom/usb/chip_usb_dw_wrapper.h"
 #endif
 
-MP_NORETURN static void machine_bootloader_rtc(void) {
+MP_NORETURN void machine_bootloader_rtc(void) {
     #if CONFIG_IDF_TARGET_ESP32S3 && MICROPY_HW_USB_CDC
     usb_usj_mode();
     usb_dc_prepare_persist();

--- a/ports/esp32/modmachine.h
+++ b/ports/esp32/modmachine.h
@@ -21,4 +21,8 @@ void machine_pwm_deinit_all(void);
 void machine_uart_deinit_all(void);
 void machine_i2s_init0();
 
+#ifdef MICROPY_ESP32_USE_BOOTLOADER_RTC
+void machine_bootloader_rtc(void);
+#endif
+
 #endif // MICROPY_INCLUDED_ESP32_MODMACHINE_H


### PR DESCRIPTION
### Summary

The `machine.bootloder`implementation on the Arduino Nano ESP32 is different from other Espressif-based boards in that it calls a custom "bootloader" (actually, a different application) which allows DFU uploads. This allows users to easily switch between Micropython and Arduino C environments. 

However in some cases the hardware bootloader is still useful - for example when a full flash is required. This PR introduces argument parsing of the `machine.bootloader()` implementation so that when it is called with `1` as argument, the hardware bootloader is started - in all other cases, as before, the Arduino bootloader will run.

### Testing

Tested on Arduino Nano ESP32:
- `machine.bootloader()` starts the Arduino bootloader (for use with `dfu-tool`)
- `machine.bootloader(1)` starts the ESP32-S3 hardware bootloader (for use with `esptool`)