### PR TITLE
shared/runtime/sys_stdio_mphal: fix docstring for stdio

### DIFF
--- a/shared/runtime/sys_stdio_mphal.c
+++ b/shared/runtime/sys_stdio_mphal.c
@@ -54,7 +54,7 @@ static const sys_stdio_obj_t stdio_buffer_obj;
 
 static void stdio_obj_print(const mp_print_t *print, mp_obj_t self_in, mp_print_kind_t kind) {
     sys_stdio_obj_t *self = MP_OBJ_TO_PTR(self_in);
-    mp_printf(print, "<io.FileIO %d>", self->fd);
+    mp_printf(print, "<io.StringIO %d>", self->fd);
 }
 
 static mp_uint_t stdio_read(mp_obj_t self_in, void *buf, mp_uint_t size, int *errcode) {
@@ -122,7 +122,7 @@ static const mp_stream_p_t stdio_obj_stream_p = {
 
 MP_DEFINE_CONST_OBJ_TYPE(
     stdio_obj_type,
-    MP_QSTR_FileIO,
+    MP_QSTR_StringIO,
     MP_TYPE_FLAG_ITER_IS_STREAM,
     print, stdio_obj_print,
     protocol, &stdio_obj_stream_p,
@@ -154,7 +154,7 @@ static const mp_stream_p_t stdio_buffer_obj_stream_p = {
 
 static MP_DEFINE_CONST_OBJ_TYPE(
     stdio_buffer_obj_type,
-    MP_QSTR_FileIO,
+    MP_QSTR_StringIO,
     MP_TYPE_FLAG_ITER_IS_STREAM,
     print, stdio_obj_print,
     protocol, &stdio_buffer_obj_stream_p,


### PR DESCRIPTION
### Summary

Docstring for stdio indicates "FileIO", which is a binary IO stream.
As detailed in adafruit#553, stdio is not binary by design;
its docstring should indicate "StringIO".
More detail in issue adafruit#9543

### Testing

Tested Pico build on Waveshare RP2040-Zero.

### Trade-offs and Alternatives

Applies generally. Could break some tests which expect FileIO type, but that would be unusual.

Intent is unclear for unused stdio_buffer_obj; if this was intended to implement (e.g.) stdout.buffer, then maybe it should stay FileIO.