### PR TITLE
shared/runtime/sys_stdio_mphal: Fix docstring for stdio.

### DIFF
--- a/shared/runtime/sys_stdio_mphal.c
+++ b/shared/runtime/sys_stdio_mphal.c
@@ -54,7 +54,7 @@ static const sys_stdio_obj_t stdio_buffer_obj;
 
 static void stdio_obj_print(const mp_print_t *print, mp_obj_t self_in, mp_print_kind_t kind) {
     sys_stdio_obj_t *self = MP_OBJ_TO_PTR(self_in);
-    mp_printf(print, "<io.FileIO %d>", self->fd);
+    mp_printf(print, "<io.%s %d>", mp_obj_get_type_str(self_in), self->fd);
 }
 
 static mp_uint_t stdio_read(mp_obj_t self_in, void *buf, mp_uint_t size, int *errcode) {
@@ -122,7 +122,7 @@ static const mp_stream_p_t stdio_obj_stream_p = {
 
 MP_DEFINE_CONST_OBJ_TYPE(
     stdio_obj_type,
-    MP_QSTR_FileIO,
+    MP_QSTR_TextIOWrapper,
     MP_TYPE_FLAG_ITER_IS_STREAM,
     print, stdio_obj_print,
     protocol, &stdio_obj_stream_p,

--- a/tests/basics/sys_stdio.py
+++ b/tests/basics/sys_stdio.py
@@ -2,6 +2,14 @@
 
 import sys
 
+try:
+    sys.stdout
+    sys.stdin
+    sys.stderr
+except AttributeError:
+    print("SKIP")
+    raise SystemExit
+
 # CPython is more verbose; no need to match exactly
 
 print('TextIOWrapper' in str(sys.stdout))

--- a/tests/basics/sys_stdio.py
+++ b/tests/basics/sys_stdio.py
@@ -1,0 +1,25 @@
+# Test sys.std* objects.
+
+import sys
+
+# CPython is more verbose; no need to match exactly
+
+print('TextIOWrapper' in str(sys.stdout))
+print('TextIOWrapper' in str(sys.stderr))
+print('TextIOWrapper' in str(sys.stdin))
+
+print('TextIOWrapper' in str(type(sys.stdout)))
+print('TextIOWrapper' in str(type(sys.stderr)))
+print('TextIOWrapper' in str(type(sys.stdin)))
+
+# # .buffer member is optional
+# try:
+#     print('FileIO' in str(sys.stdout.buffer))
+#     print('FileIO' in str(sys.stderr.buffer))
+#     print('FileIO' in str(sys.stdin.buffer))
+#
+#     print('FileIO' in str(type(sys.stdout.buffer)))
+#     print('FileIO' in str(type(sys.stderr.buffer)))
+#     print('FileIO' in str(type(sys.stdin.buffer)))
+# except AttributeError:
+#     print("SKIP")

--- a/tests/basics/sys_stdio_buffer.py
+++ b/tests/basics/sys_stdio_buffer.py
@@ -1,33 +1,21 @@
-# Test sys.std* objects.
+# Test sys.std*.buffer objects.
 
 import sys
 
 try:
-    sys.stdout
-    sys.stdin
-    sys.stderr
+    sys.stdout.buffer
+    sys.stdin.buffer
+    sys.stderr.buffer
 except AttributeError:
     print("SKIP")
     raise SystemExit
 
 # CPython is more verbose; no need to match exactly
 
-print('TextIOWrapper' in str(sys.stdout))
-print('TextIOWrapper' in str(sys.stderr))
-print('TextIOWrapper' in str(sys.stdin))
+print('FileIO' in str(sys.stdout.buffer))
+print('FileIO' in str(sys.stderr.buffer))
+print('FileIO' in str(sys.stdin.buffer))
 
-print('TextIOWrapper' in str(type(sys.stdout)))
-print('TextIOWrapper' in str(type(sys.stderr)))
-print('TextIOWrapper' in str(type(sys.stdin)))
-
-# # .buffer member is optional
-# try:
-#     print('FileIO' in str(sys.stdout.buffer))
-#     print('FileIO' in str(sys.stderr.buffer))
-#     print('FileIO' in str(sys.stdin.buffer))
-#
-#     print('FileIO' in str(type(sys.stdout.buffer)))
-#     print('FileIO' in str(type(sys.stderr.buffer)))
-#     print('FileIO' in str(type(sys.stdin.buffer)))
-# except AttributeError:
-#     print("SKIP")
+print('FileIO' in str(type(sys.stdout.buffer)))
+print('FileIO' in str(type(sys.stderr.buffer)))
+print('FileIO' in str(type(sys.stdin.buffer)))

--- a/tests/basics/sys_stdio_buffer.py
+++ b/tests/basics/sys_stdio_buffer.py
@@ -19,3 +19,15 @@ print('TextIOWrapper' in str(sys.stdin))
 print('TextIOWrapper' in str(type(sys.stdout)))
 print('TextIOWrapper' in str(type(sys.stderr)))
 print('TextIOWrapper' in str(type(sys.stdin)))
+
+# # .buffer member is optional
+# try:
+#     print('FileIO' in str(sys.stdout.buffer))
+#     print('FileIO' in str(sys.stderr.buffer))
+#     print('FileIO' in str(sys.stdin.buffer))
+#
+#     print('FileIO' in str(type(sys.stdout.buffer)))
+#     print('FileIO' in str(type(sys.stderr.buffer)))
+#     print('FileIO' in str(type(sys.stdin.buffer)))
+# except AttributeError:
+#     print("SKIP")

--- a/tests/basics/sys_stdio_buffer.py.exp
+++ b/tests/basics/sys_stdio_buffer.py.exp
@@ -1,0 +1,6 @@
+True
+True
+True
+True
+True
+True


### PR DESCRIPTION
### Summary
Docstring for stdio indicates "FileIO", which is a binary IO stream.
As detailed in adafruit#553, stdio is not binary by design;
its docstring should indicate "StringIO".
More detail in issue adafruit#9543.

### Testing
Pico build on Waveshare RP2040-Zero.