### PR TITLE
asyncio: Add support to close the running loop and cancel background tasks

### DIFF
--- a/extmod/asyncio/core.py
+++ b/extmod/asyncio/core.py
@@ -129,6 +129,15 @@ class IOQueue:
             else:
                 self.poller.modify(s, select.POLLIN)
 
+    def all_tasks(self):
+        tasks = set()
+        for q1, q2, _ in self.map.values():
+            if q1 is not None:
+                tasks.add(q1)
+            if q2 is not None:
+                tasks.add(q2)
+
+        return tasks
 
 ################################################################################
 # Main run loop
@@ -285,6 +294,14 @@ class Loop:
     def close():
         pass
 
+    def all_tasks():
+        tasks = set(_task_queue)
+        tasks.update(_io_queue.all_tasks())
+        if cur_task is not None:
+            tasks.add(cur_task)
+
+        return tasks
+
     def set_exception_handler(handler):
         Loop._exc_handler = handler
 
@@ -309,6 +326,13 @@ def current_task():
     if cur_task is None:
         raise RuntimeError("no running event loop")
     return cur_task
+
+
+def all_tasks():
+    if cur_task is None:
+        raise RuntimeError("no running event loop")
+
+    return Loop.all_tasks()
 
 
 def new_event_loop():

--- a/extmod/asyncio/core.py
+++ b/extmod/asyncio/core.py
@@ -254,7 +254,11 @@ def run_until_complete(main_task=None):
 
 # Create a new task from a coroutine and run it until it finishes
 def run(coro):
-    return run_until_complete(create_task(coro))
+    try:
+        return run_until_complete(create_task(coro))
+    finally:
+        Loop.close()
+        run_until_complete()
 
 
 ################################################################################
@@ -292,7 +296,9 @@ class Loop:
             _stop_task = None
 
     def close():
-        pass
+        for t in Loop.all_tasks():
+            if not t.done() and t is not cur_task:
+                t.cancel()
 
     def all_tasks():
         tasks = set(_task_queue)

--- a/extmod/asyncio/task.py
+++ b/extmod/asyncio/task.py
@@ -116,6 +116,12 @@ class TaskQueue:
     def remove(self, v):
         self.heap = ph_delete(self.heap, v)
 
+    def __iter__(self):
+        heap = self.heap
+        while heap:
+            yield heap
+            heap = heap.ph_child
+
 
 # Task class representing a coroutine, can be waited on and cancelled.
 class Task:

--- a/tests/extmod/asyncio_all_tasks.py
+++ b/tests/extmod/asyncio_all_tasks.py
@@ -1,0 +1,50 @@
+try:
+    import asyncio
+except ImportError:
+    print("SKIP")
+    raise SystemExit
+
+import sys
+
+async def waiter():
+    await asyncio.sleep(1)
+
+async def reader():
+    await asyncio.StreamReader().read()
+
+
+async def print_all_tasks():
+    print(list('T' for t in asyncio.all_tasks()))
+
+async def short_wait():
+    await asyncio.sleep(0.01)
+
+async def waiters():
+    t1 = asyncio.create_task(waiter())
+    # NOTE: The singleton generator for ::sleep expects the task to be scheduled
+    # before using it again.
+    await asyncio.sleep(0)
+    t2 = asyncio.create_task(waiter())
+    await asyncio.sleep(0)
+    t3 = asyncio.create_task(short_wait())
+    # Tasks are in the list before they start to run
+    assert t1 in asyncio.all_tasks()
+    assert t2 in asyncio.all_tasks()
+    await print_all_tasks()
+    await t3
+    assert t1 in asyncio.all_tasks()
+    assert t2 in asyncio.all_tasks()
+    assert t3 not in asyncio.all_tasks()
+
+async def readers():
+    t1 = asyncio.create_task(reader())
+    t2 = asyncio.create_task(reader())
+    await print_all_tasks()
+    assert t1 in asyncio.all_tasks()
+    assert t2 in asyncio.all_tasks()
+
+asyncio.run(print_all_tasks())
+asyncio.new_event_loop()
+asyncio.run(readers())
+asyncio.new_event_loop()
+asyncio.run(waiters())

--- a/tests/extmod/asyncio_shutdown.py
+++ b/tests/extmod/asyncio_shutdown.py
@@ -1,0 +1,135 @@
+try:
+    import asyncio
+except ImportError:
+    print("SKIP")
+    raise SystemExit
+
+import sys
+
+# CPython and Micropython disagree on the sorting of tasks in the ::all_tasks
+# set, so sort the output of the tasks as they shut down rather than expecting
+# them to shut down in the same order.
+class SortedList(list):
+    def print(self):
+        print(*sorted(self))
+
+finished = SortedList()
+
+async def task1():
+    try:
+        await asyncio.sleep(1)
+    finally:
+        finished.append('task1 finished')
+
+async def task2():
+    try:
+        await asyncio.sleep(1)
+    finally:
+        finished.append("task2 finished")
+
+async def reader():
+    try:
+        await asyncio.StreamReader(sys.stdin).read()
+    finally:
+        finished.append("reader finished")
+
+# KeyboardInterrupt in main task should be propagated
+async def ctrlc():
+    asyncio.create_task(task1())
+    await asyncio.sleep(0)
+    asyncio.create_task(task2())
+    await asyncio.sleep(0.01)
+    raise KeyboardInterrupt
+
+
+# If the main task is canceled, the loop should be closed
+async def cancel_main():
+    async def canceler(delay, task):
+        await asyncio.sleep(delay)
+        task.cancel()
+
+    asyncio.create_task(task1())
+    await asyncio.sleep(0)
+    asyncio.create_task(task2())
+    asyncio.create_task(canceler(0.01, asyncio.current_task()))
+    await asyncio.sleep(0.02)
+
+# SystemExit should close the loop
+async def sys_exit():
+    asyncio.create_task(task1())
+    await asyncio.sleep(0)
+    asyncio.create_task(task2())
+    await asyncio.sleep(0.01)
+    raise SystemExit
+
+# Cancelling a background task should have no effect
+async def cancel_bg():
+    t1 = asyncio.create_task(task1())
+    await asyncio.sleep(0)
+    t2 = asyncio.create_task(task2())
+    await asyncio.sleep(0.01)
+    t1.cancel()
+    t2.cancel()
+    await asyncio.sleep(0.01)
+
+# Reader tasks should also be cancelled when the loop is shutdown
+async def cancel_reader():
+    t1 = asyncio.create_task(task1())
+    await asyncio.sleep(0)
+    t2 = asyncio.create_task(reader())
+    await asyncio.sleep(0.01)
+    t1.cancel()
+    t2.cancel()
+    await asyncio.sleep(0.01)
+
+async def close_loop():
+    asyncio.create_task(task1())
+    await asyncio.sleep(0)
+    asyncio.create_task(reader())
+    await asyncio.sleep(0.01)
+
+try:
+    asyncio.new_event_loop()
+    finished.clear()
+    asyncio.run(ctrlc())
+except KeyboardInterrupt:
+    print("KeyboardInterrupt raised")
+finally:
+    finished.print()
+
+try:
+    asyncio.new_event_loop()
+    finished.clear()
+    asyncio.run(cancel_main())
+except asyncio.CancelledError:
+    print("CancelledError raised")
+finally:
+    finished.print()
+
+# Cancel a background waiting task doesn't raise an exception
+print('---')
+asyncio.new_event_loop()
+finished.clear()
+asyncio.run(cancel_bg())
+finished.print()
+
+# Cancel a background IO task doesn't raise an exception
+print('---')
+asyncio.new_event_loop()
+finished.clear()
+asyncio.run(cancel_reader())
+finished.print()
+
+print('---')
+asyncio.new_event_loop()
+finished.clear()
+asyncio.run(cancel_reader())
+finished.print()
+
+try:
+    asyncio.new_event_loop()
+    finished.clear()
+    asyncio.run(sys_exit())
+except SystemExit:
+    print("SystemExit raised")
+


### PR DESCRIPTION
<!-- Thanks for submitting a Pull Request! We appreciate you spending the
     time to improve MicroPython. Please provide enough information so that
     others can review your Pull Request.

     Before submitting, please read:
     https://github.com/micropython/micropython/blob/master/CODEOFCONDUCT.md
     https://github.com/micropython/micropython/wiki/ContributorGuidelines

     Please check any CI failures that appear after your Pull Request is opened.
-->

### Summary

<!-- Explain the reason for making this change. What problem does the pull request
     solve, or what improvement does it add? Add links if relevant. -->

CPython will automatically shutdown the event loop and cancel all background async tasks when the main task exits from `asyncio.run(...)`. This is especially important if the background tasks need to perform some sort of cleanup and/or reset.

This adds support for `asyncio.all_tasks()` which returns a `set` object similar to the way CPython works and allows inspection of all running tasks. This may be used inside a running event loop to forcibly cancel all running tasks.

### Testing

<!-- Explain what testing you did, and on which boards/ports. If there are
     boards or ports that you couldn't test, please mention this here as well.

     If you leave this empty then your Pull Request may be closed. -->

This adds two tests in hopes of measuring compatibility with CPython. The first is `asyncio_all_tasks` which shows the collection of tasks returned from the `asyncio.all_tasks()` function.  The second is `asyncio_shutdown` which shows the compatibility of shutting down background tasks as the main task exits for various reasons.

### Trade-offs and Alternatives

<!-- If the Pull Request has some negative impact (i.e. increased code size)
     then please explain why you think the trade-off improvement is worth it.
     If you can think of alternative ways to do this, please explain that here too.

     Delete this heading if not relevant (i.e. small fixes) -->

The spirit of this feature was originally implemented in #9870; however, it needs this concept to fully work correctly.

Micropython still suffers from the issue where a `try` block in the main task will not have its `finally` executed if it's interrupted from a KeyboardInterrupted (like eg. from `mpremote`); however, at least this will trigger the proper cancel and cleanup of background tasks.

As a caveat the `Loop` in Micropython can be reused after being close()d. In CPython, such is forbidden. CPython uses a `Runner` to manage the shutdown of the loop and tasks after the main task exits.