### PR TITLE
samd: A few minor improvements.

### DIFF
--- a/docs/samd/quickref.rst
+++ b/docs/samd/quickref.rst
@@ -65,6 +65,8 @@ Use the :mod:`time <time>` module::
     start = time.ticks_ms() # get millisecond counter
     delta = time.ticks_diff(time.ticks_ms(), start) # compute time difference
 
+Note that :func:`time.sleep_us()` delays by busy waiting. During that time, other tasks are
+not scheduled.
 
 Clock and time
 --------------

--- a/ports/samd/mphalport.c
+++ b/ports/samd/mphalport.c
@@ -69,13 +69,9 @@ void mp_hal_clr_pin_mux(mp_hal_pin_obj_t pin) {
 }
 
 void mp_hal_delay_ms(mp_uint_t ms) {
-    if (ms > 10) {
-        uint32_t t0 = systick_ms;
-        while (systick_ms - t0 < ms) {
-            MICROPY_EVENT_POLL_HOOK
-        }
-    } else {
-        mp_hal_delay_us(ms * 1000);
+    uint32_t t0 = systick_ms;
+    while (systick_ms - t0 < ms) {
+        MICROPY_EVENT_POLL_HOOK
     }
 }
 

--- a/ports/samd/mphalport.c
+++ b/ports/samd/mphalport.c
@@ -94,10 +94,10 @@ void mp_hal_delay_us(mp_uint_t us) {
 }
 
 uint64_t mp_hal_ticks_us_64(void) {
-    uint32_t us64_upper = ticks_us64_upper;
     uint32_t us64_lower;
     uint8_t intflag;
     __disable_irq();
+    uint32_t us64_upper = ticks_us64_upper;
     #if defined(MCU_SAMD21)
     us64_lower = REG_TC4_COUNT32_COUNT;
     intflag = TC4->COUNT32.INTFLAG.reg;

--- a/tests/extmod/machine_uart_irq_txidle.py
+++ b/tests/extmod/machine_uart_irq_txidle.py
@@ -16,27 +16,20 @@ if "rp2" in sys.platform:
     uart_id = 0
     tx_pin = "GPIO0"
     rx_pin = "GPIO1"
-    min_window = 1
 elif "samd" in sys.platform and "ItsyBitsy M0" in sys.implementation._machine:
     uart_id = 0
     tx_pin = "D1"
     rx_pin = "D0"
-    # For SAMD delay_ms has to be used for the trailing window, and the
-    # mininmal time is 11 ms to allow for scheduling.
-    min_window = 11
 elif "samd" in sys.platform and "ItsyBitsy M4" in sys.implementation._machine:
     uart_id = 3
     tx_pin = "D1"
     rx_pin = "D0"
-    min_window = 11
 elif "mimxrt" in sys.platform:
     uart_id = 1
     tx_pin = None
-    min_window = 0
 elif "nrf" in sys.platform:
     uart_id = 0
     tx_pin = None
-    min_window = 0
 else:
     print("Please add support for this test on this platform.")
     raise SystemExit
@@ -61,12 +54,11 @@ for bits_per_s in (2400, 9600, 115200):
     # the test marks a time window close to the expected of the sending
     # and the time at which the IRQ should have been fired.
     # It is just a rough estimation of 10 characters before and
-    # 20 characters after the data's end, unless there is a need to
-    # wait a minimal time, like for SAMD devices.
+    # 20 characters after the data's end.
 
     bits_per_char = 10  # 1(startbit) + 8(bits) + 1(stopbit) + 0(parity)
     start_time_us = (len(text) - 10) * bits_per_char * 1_000_000 // bits_per_s
-    window_ms = max(min_window, 20 * bits_per_char * 1_000 // bits_per_s + 1)
+    window_ms = 20 * bits_per_char * 1_000 // bits_per_s + 1
 
     print("write", bits_per_s)
     uart.write(text)


### PR DESCRIPTION
- Fix a execution order bug in mp_hal_ticks_us_64().
     The upper 32 bit of the 64 bit ticks register was taken before  disabling the interrupts. That may have caused a wrong return value. 
- Simplify mp_hal_delay_ms().
    Do NOT use mp_hal_delay_us() for short delays. This was initially done to make short delays precise, but mp_hal_delay_us() does not allow for scheduling. Leave using mp_hal_delay_us() to user code if needed.

Both changes do not affect the API of the calls.