### PR TITLE
py/runtime: Check for null objects coming from native functions.

### DIFF
--- a/py/mpconfig.h
+++ b/py/mpconfig.h
@@ -500,6 +500,12 @@
 #define MICROPY_COMP_RETURN_IF_EXPR (MICROPY_CONFIG_ROM_LEVEL_AT_LEAST_EXTRA_FEATURES)
 #endif
 
+// Whether to enable extra arguments validation when running native code
+// Requires MICROPY_DYNAMIC_COMPILER and costs 160 bytes (Thumb2)
+#ifndef MICROPY_COMP_EXTRA_VALIDATION
+#define MICROPY_COMP_EXTRA_VALIDATION (0)
+#endif
+
 /*****************************************************************************/
 /* Internal debugging stuff                                                  */
 

--- a/py/objrange.c
+++ b/py/objrange.c
@@ -95,8 +95,20 @@ static mp_obj_t range_make_new(const mp_obj_type_t *type, size_t n_args, size_t 
     o->step = 1;
 
     if (n_args == 1) {
+        #if MICROPY_COMP_EXTRA_VALIDATION
+        if (args[0] == MP_OBJ_NULL) {
+            goto unbounded_local_variable;
+        }
+        #endif
+
         o->stop = mp_obj_get_int(args[0]);
     } else {
+        #if MICROPY_COMP_EXTRA_VALIDATION
+        if (args[0] == MP_OBJ_NULL || args[1] == MP_OBJ_NULL || (n_args == 3 && args[2] == MP_OBJ_NULL)) {
+            goto unbounded_local_variable;
+        }
+        #endif
+
         o->start = mp_obj_get_int(args[0]);
         o->stop = mp_obj_get_int(args[1]);
         if (n_args == 3) {
@@ -108,6 +120,11 @@ static mp_obj_t range_make_new(const mp_obj_type_t *type, size_t n_args, size_t 
     }
 
     return MP_OBJ_FROM_PTR(o);
+
+    #if MICROPY_COMP_EXTRA_VALIDATION
+unbounded_local_variable:
+    mp_raise_msg(&mp_type_NameError, MP_ERROR_TEXT("cannot access local variable"));
+    #endif
 }
 
 static mp_int_t range_len(mp_obj_range_t *self) {


### PR DESCRIPTION
### Summary

When performing inplace binary operations (eg +=, -=, etc) from a native emitted context, the left hand side operand would be NULL if it wasn't defined earlier.  The code assumed the operand would always be non-NULL and hence a crash occurred when accessing the operand object.

This commit turns that crash into an exception being raised, with the same name and message as if the same error occurred in a bytecode context.  Also, the exception is raised at runtime, following the same behaviour as if the function was not decorated as native.

To reproduce the issue just try to execute the following Python code:

```python
@micropython.native
def f():
	a += 10

f()
```

Whilst this is a minor issue, the very fact that it would crash the whole interpreter because of a typo in a native function makes it quite annoying to have...

This fixes issue #15670.

### Testing

This was tested on the Unix port, but the issue would happen on any target that supports native compilation.

### Trade-offs and Alternatives

This patch is only enabled if `MICROPY_ENABLE_COMPILER` is enabled, and should add a hundred bytes or so of code.  Rather than patching the runtime this issue could maybe be fixed when compiling the incorrect statement that emits the binary operation, but I'm quite new to that part of the codebase.  At least it follows the same behaviour as the VM, better than nothing...