### PR TITLE
ports/esp32: Add basic espressif IDF v5.3 compatibility.

### DIFF
--- a/ports/esp32/README.md
+++ b/ports/esp32/README.md
@@ -28,7 +28,7 @@ manage the ESP32 microcontroller, as well as a way to manage the required
 build environment and toolchains needed to build the firmware.
 
 The ESP-IDF changes quickly and MicroPython only supports certain versions.
-Currently MicroPython supports v5.0.4, v5.0.5, v5.1.2, v5.2.0, v5.2.2.
+Currently MicroPython supports v5.0.4, v5.0.5, v5.1.2, v5.2.0, v5.2.2, v5.3.
 
 To install the ESP-IDF the full instructions can be found at the
 [Espressif Getting Started guide](https://docs.espressif.com/projects/esp-idf/en/latest/esp32/get-started/index.html#installation-step-by-step).

--- a/ports/esp32/machine_touchpad.c
+++ b/ports/esp32/machine_touchpad.c
@@ -31,9 +31,17 @@
 
 #if SOC_TOUCH_SENSOR_SUPPORTED
 
-#if SOC_TOUCH_VERSION_1 // ESP32 only
+#if ESP_IDF_VERSION < ESP_IDF_VERSION_VAL(5, 3, 0)
+#if SOC_TOUCH_VERSION_1
+#define SOC_TOUCH_SENSOR_VERSION (1)
+#elif SOC_TOUCH_VERSION_2
+#define SOC_TOUCH_SENSOR_VERSION (2)
+#endif
+#endif
+
+#if SOC_TOUCH_SENSOR_VERSION == 1 // ESP32 only
 #include "driver/touch_pad.h"
-#elif SOC_TOUCH_VERSION_2 // All other SoCs with touch, to date
+#elif SOC_TOUCH_SENSOR_VERSION == 2 // All other SoCs with touch, to date
 #include "driver/touch_sensor.h"
 #else
 #error "Unknown touch hardware version"
@@ -98,13 +106,13 @@ static mp_obj_t mtp_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_
         touch_pad_set_fsm_mode(TOUCH_FSM_MODE_TIMER);
         initialized = 1;
     }
-    #if SOC_TOUCH_VERSION_1
+    #if SOC_TOUCH_SENSOR_VERSION == 1
     esp_err_t err = touch_pad_config(self->touchpad_id, 0);
-    #elif SOC_TOUCH_VERSION_2
+    #elif SOC_TOUCH_SENSOR_VERSION == 2
     esp_err_t err = touch_pad_config(self->touchpad_id);
     #endif
     if (err == ESP_OK) {
-        #if SOC_TOUCH_VERSION_2
+        #if SOC_TOUCH_SENSOR_VERSION == 2
         touch_pad_fsm_start();
         #endif
 
@@ -115,10 +123,10 @@ static mp_obj_t mtp_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_
 
 static mp_obj_t mtp_config(mp_obj_t self_in, mp_obj_t value_in) {
     mtp_obj_t *self = self_in;
-    #if SOC_TOUCH_VERSION_1
+    #if SOC_TOUCH_SENSOR_VERSION == 1
     uint16_t value = mp_obj_get_int(value_in);
     esp_err_t err = touch_pad_config(self->touchpad_id, value);
-    #elif SOC_TOUCH_VERSION_2
+    #elif SOC_TOUCH_SENSOR_VERSION == 2
     esp_err_t err = touch_pad_config(self->touchpad_id);
     #endif
     if (err == ESP_OK) {
@@ -130,10 +138,10 @@ MP_DEFINE_CONST_FUN_OBJ_2(mtp_config_obj, mtp_config);
 
 static mp_obj_t mtp_read(mp_obj_t self_in) {
     mtp_obj_t *self = self_in;
-    #if SOC_TOUCH_VERSION_1
+    #if SOC_TOUCH_SENSOR_VERSION == 1
     uint16_t value;
     esp_err_t err = touch_pad_read(self->touchpad_id, &value);
-    #elif SOC_TOUCH_VERSION_2
+    #elif SOC_TOUCH_SENSOR_VERSION == 2
     uint32_t value;
     esp_err_t err = touch_pad_read_raw_data(self->touchpad_id, &value);
     #endif

--- a/ports/esp32/network_wlan.c
+++ b/ports/esp32/network_wlan.c
@@ -768,6 +768,9 @@ static const mp_rom_map_elem_t wlan_if_locals_dict_table[] = {
     { MP_ROM_QSTR(MP_QSTR_SEC_WPA3_EXT_PSK), MP_ROM_INT(WIFI_AUTH_WPA3_EXT_PSK) },
     { MP_ROM_QSTR(MP_QSTR_SEC_WPA3_EXT_PSK_MIXED_MODE), MP_ROM_INT(WIFI_AUTH_WPA3_EXT_PSK_MIXED_MODE) },
     #endif
+    #if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(5, 3, 0)
+    { MP_ROM_QSTR(MP_QSTR_SEC_DPP), MP_ROM_INT(WIFI_AUTH_DPP) },
+    #endif
 
     { MP_ROM_QSTR(MP_QSTR_PM_NONE), MP_ROM_INT(WIFI_PS_NONE) },
     { MP_ROM_QSTR(MP_QSTR_PM_PERFORMANCE), MP_ROM_INT(WIFI_PS_MIN_MODEM) },
@@ -775,7 +778,9 @@ static const mp_rom_map_elem_t wlan_if_locals_dict_table[] = {
 };
 static MP_DEFINE_CONST_DICT(wlan_if_locals_dict, wlan_if_locals_dict_table);
 
-#if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(5, 2, 0)
+#if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(5, 3, 0)
+_Static_assert(WIFI_AUTH_MAX == 14, "Synchronize WIFI_AUTH_XXX constants with the ESP-IDF. Look at esp-idf/components/esp_wifi/include/esp_wifi_types_generic.h");
+#elif ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(5, 2, 0)
 _Static_assert(WIFI_AUTH_MAX == 13, "Synchronize WIFI_AUTH_XXX constants with the ESP-IDF. Look at esp-idf/components/esp_wifi/include/esp_wifi_types.h");
 #elif ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(5, 0, 5) && ESP_IDF_VERSION < ESP_IDF_VERSION_VAL(5, 1, 0) || ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(5, 1, 2)
 _Static_assert(WIFI_AUTH_MAX == 11, "Synchronize WIFI_AUTH_XXX constants with the ESP-IDF. Look at esp-idf/components/esp_wifi/include/esp_wifi_types.h");

--- a/ports/esp32/usb_serial_jtag.c
+++ b/ports/esp32/usb_serial_jtag.c
@@ -35,10 +35,13 @@
 #include "soc/periph_defs.h"
 #include "freertos/portmacro.h"
 
-#define USB_SERIAL_JTAG_BUF_SIZE (64)
+// Number of bytes in the input buffer, and number of bytes for output chunking.
+#if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(5, 3, 0)
+#define USB_SERIAL_JTAG_PACKET_SZ_BYTES (64)
+#endif
 
 static DRAM_ATTR portMUX_TYPE rx_mux = portMUX_INITIALIZER_UNLOCKED;
-static uint8_t rx_buf[USB_SERIAL_JTAG_BUF_SIZE];
+static uint8_t rx_buf[USB_SERIAL_JTAG_PACKET_SZ_BYTES];
 static volatile bool terminal_connected = false;
 
 static void usb_serial_jtag_handle_rx(void) {
@@ -48,8 +51,8 @@ static void usb_serial_jtag_handle_rx(void) {
         portENTER_CRITICAL(&rx_mux);
     }
     size_t req_len = ringbuf_free(&stdin_ringbuf);
-    if (req_len > USB_SERIAL_JTAG_BUF_SIZE) {
-        req_len = USB_SERIAL_JTAG_BUF_SIZE;
+    if (req_len > USB_SERIAL_JTAG_PACKET_SZ_BYTES) {
+        req_len = USB_SERIAL_JTAG_PACKET_SZ_BYTES;
     }
     size_t len = usb_serial_jtag_ll_read_rxfifo(rx_buf, req_len);
     for (size_t i = 0; i < len; ++i) {


### PR DESCRIPTION
### Summary

Espressif have recently release IDF v5.3, this PR is working towards basic compatibility with it.

### Testing

I've initially tried running this on a C3 device which only has the builtin USB exposed (no uart->usb).
I _do not_ get repl on the USB connection however, nothing is seen over the USB port after the initial reboot / startup text: 

```
--- esp-idf-monitor 1.4.0 on /dev/ttyUSB0 460800 ---
--- Quit: Ctrl+] | Menu: Ctrl+T | Help: Ctrl+T followed by Ctrl+H ---
ESP-ROM:esp32c3-api1-20210207
Build:Feb  7 2021
rst:0x15 (USB_UART_CHIP_RESET),boot:0xf (SPI_FAST_FLASH_BOOT)
Saved PC:0x4200832c
0x4200832c: usb_serial_jtag_ll_txfifo_writable at /opt/esp/idf/components/hal/esp32c3/include/hal/usb_serial_jtag_ll.h:160
 (inlined by) usb_serial_jtag_tx_strn at /home/anl/micropython/ports/esp32/usb_serial_jtag.c:109

SPIWP:0xee
mode:DIO, clock div:1
load:0x3fcd5820,len:0xf28
load:0x403cc710,len:0x93c
load:0x403ce710,len:0x2ac8
entry 0x403cc710
```

### Trade-offs and Alternatives

Unknown at this point.
