### PR TITLE
extmod: Fix compile error for LWIP with SLIP support.

### DIFF
--- a/extmod/modlwip.c
+++ b/extmod/modlwip.c
@@ -127,15 +127,15 @@ sio_fd_t sio_open(u8_t dvnum) {
 }
 
 void sio_send(u8_t c, sio_fd_t fd) {
-    mp_obj_type_t *type = mp_obj_get_type(MP_STATE_VM(lwip_slip_stream));
+    const mp_stream_p_t *stream_p = mp_get_stream(MP_STATE_VM(lwip_slip_stream));
     int error;
-    type->stream_p->write(MP_STATE_VM(lwip_slip_stream), &c, 1, &error);
+    stream_p->write(MP_STATE_VM(lwip_slip_stream), &c, 1, &error);
 }
 
 u32_t sio_tryread(sio_fd_t fd, u8_t *data, u32_t len) {
-    mp_obj_type_t *type = mp_obj_get_type(MP_STATE_VM(lwip_slip_stream));
+    const mp_stream_p_t *stream_p = mp_get_stream(MP_STATE_VM(lwip_slip_stream));
     int error;
-    mp_uint_t out_sz = type->stream_p->read(MP_STATE_VM(lwip_slip_stream), data, len, &error);
+    mp_uint_t out_sz = stream_p->read(MP_STATE_VM(lwip_slip_stream), data, len, &error);
     if (out_sz == MP_STREAM_ERROR) {
         if (mp_is_nonblocking_error(error)) {
             return 0;


### PR DESCRIPTION
### Summary

Fixes a compile error if STM32 port is compiled with:

`make BOARD=(..) MICROPY_PY_LWIP=1  MICROPY_PY_LWIP_SLIP=1 `

### Testing

Tested with STM32F4DISC target in hardware, with SLIP link over UART. Ping from Linux host got a proper response. 

On STM32F4DISC:
```
import pyb
import lwip
import network
tim = pyb.Timer(7)
tim.init(freq=20)
tim.callback(lambda t: lwip.callback())
u = pyb.UART(3, 500000, read_buf_len=1550)
sl = lwip.slip(u, "192.168.5.2", "192.168.5.1")
```

On Host (Linux):
``` stty -F /dev/ttyUSB0 500000
sudo slattach -L -p slip  /dev/ttyUSB0 &
sudo ifconfig sl0 192.168.5.1 pointopoint 192.168.5.2 mtu 1500
ping 192.168.5.2
```