### PR TITLE
py/gc: Return max_free size in bytes.

### DIFF
--- a/py/gc.c
+++ b/py/gc.c
@@ -715,6 +715,7 @@ void gc_info(gc_info_t *info) {
 
     info->used *= BYTES_PER_BLOCK;
     info->free *= BYTES_PER_BLOCK;
+    info->max_free *= BYTES_PER_BLOCK;
 
     #if MICROPY_GC_SPLIT_HEAP_AUTO
     info->max_new_split = gc_get_max_new_split();


### PR DESCRIPTION
I think this was an oversight, but regardless of that, for consistency, max_free should be in bytes, not block count. This matches the info's total, used, and free sizes. Also, while it's currently possible to use `MICROPY_BYTES_PER_GC_BLOCK` in outside code to get the maximum free size in bytes, in the future, different areas could have different block sizes, which would make `max_free` useless.