### PR TITLE
ports: Fix lwIP config setting to disable DHCP ARP check.

### DIFF
--- a/ports/mimxrt/lwip_inc/lwipopts.h
+++ b/ports/mimxrt/lwip_inc/lwipopts.h
@@ -28,7 +28,7 @@
 #define LWIP_IPV6                       0
 #define LWIP_DHCP                       1
 #define LWIP_DHCP_CHECK_LINK_UP         1
-#define DHCP_DOES_ARP_CHECK             0 // to speed DHCP up
+#define LWIP_DHCP_DOES_ACD_CHECK        0 // to speed DHCP up
 #define LWIP_DNS                        1
 #define LWIP_DNS_SUPPORT_MDNS_QUERIES   1
 #define LWIP_MDNS_RESPONDER             1

--- a/ports/renesas-ra/lwip_inc/lwipopts.h
+++ b/ports/renesas-ra/lwip_inc/lwipopts.h
@@ -26,7 +26,7 @@
 #define LWIP_IPV6                       0
 #define LWIP_DHCP                       1
 #define LWIP_DHCP_CHECK_LINK_UP         1
-#define DHCP_DOES_ARP_CHECK             0 // to speed DHCP up
+#define LWIP_DHCP_DOES_ACD_CHECK        0 // to speed DHCP up
 #define LWIP_DNS                        1
 #define LWIP_DNS_SUPPORT_MDNS_QUERIES   1
 #define LWIP_MDNS_RESPONDER             1

--- a/ports/rp2/lwip_inc/lwipopts.h
+++ b/ports/rp2/lwip_inc/lwipopts.h
@@ -32,7 +32,7 @@
 #define LWIP_ND6_QUEUEING               0
 #define LWIP_DHCP                       1
 #define LWIP_DHCP_CHECK_LINK_UP         1
-#define DHCP_DOES_ARP_CHECK             0 // to speed DHCP up
+#define LWIP_DHCP_DOES_ACD_CHECK        0 // to speed DHCP up
 #define LWIP_DNS                        1
 #define LWIP_DNS_SUPPORT_MDNS_QUERIES   1
 #define LWIP_MDNS_RESPONDER             1

--- a/ports/stm32/lwip_inc/lwipopts.h
+++ b/ports/stm32/lwip_inc/lwipopts.h
@@ -30,7 +30,7 @@
 #define LWIP_IPV6                       0
 #define LWIP_DHCP                       1
 #define LWIP_DHCP_CHECK_LINK_UP         1
-#define DHCP_DOES_ARP_CHECK             0 // to speed DHCP up
+#define LWIP_DHCP_DOES_ACD_CHECK        0 // to speed DHCP up
 #define LWIP_DNS                        1
 #define LWIP_DNS_SUPPORT_MDNS_QUERIES   1
 #define LWIP_MDNS_RESPONDER             1


### PR DESCRIPTION
### Summary

lwIP was recently updated in a89ac9e24a566e45bd3ffa7ef9e61e1d994616ea to STABLE-2_2_0_RELEASE, and this introduced a change in the configuration variable `DHCP_DOES_ARP_CHECK`, renaming it to `LWIP_DHCP_DOES_ACD_CHECK`.

This commit fixes the ports lwIP settings to use the new configuration option.

Without this option, connecting to a WiFi access-point takes about 12.5 seconds.  With this option (ie disabling DHCP ARP checks) connecting takes about 4 seconds.

### Testing

Tested on an RPI_PICO_W and PYBD_SF2.