### PR TITLE
docs/reference/pyboard.py: Fix filesystem cp example with three files.

### DIFF
--- a/docs/reference/pyboard.py.rst
+++ b/docs/reference/pyboard.py.rst
@@ -120,9 +120,8 @@ Some more examples::
     # Same, but using . instead.
     $ pyboard.py --device /dev/ttyACM0 -f cp :main.py .
 
-    # Copy three files to the device, keeping their names
-    # and paths (note: `lib` must exist on the device)
-    $ pyboard.py --device /dev/ttyACM0 -f cp main.py app.py lib/foo.py :
+    # Copy three files to the device, keeping their names.
+    $ pyboard.py --device /dev/ttyACM0 -f cp main.py app.py foo.py :
 
     # Remove a file from the device.
     $ pyboard.py --device /dev/ttyACM0 -f rm util.py


### PR DESCRIPTION
Fix documentation to match behaviour (directories are not preserved).

Fixes issue #11101.
