### PR TITLE
esp32: Disable hardware stack protection on ESP32-C3.

### DIFF
--- a/ports/esp32/boards/ESP32_GENERIC_C3/sdkconfig.c3usb
+++ b/ports/esp32/boards/ESP32_GENERIC_C3/sdkconfig.c3usb
@@ -1,1 +1,4 @@
 CONFIG_ESP32C3_REV_MIN_3=y
+
+# Workaround for https://github.com/espressif/esp-idf/issues/14456
+CONFIG_ESP_SYSTEM_HW_STACK_GUARD=n

--- a/ports/esp32/boards/LOLIN_C3_MINI/sdkconfig.board
+++ b/ports/esp32/boards/LOLIN_C3_MINI/sdkconfig.board
@@ -1,1 +1,4 @@
 CONFIG_ESP32C3_REV_MIN_3=y
+
+# Workaround for https://github.com/espressif/esp-idf/issues/14456
+CONFIG_ESP_SYSTEM_HW_STACK_GUARD=n


### PR DESCRIPTION
### Summary

Closes #15667. Really a workaround for what appears to be an upstream issue: https://github.com/espressif/esp-idf/issues/14456 - if we find the root cause then we can revert this.

### Testing

* Ran the reproducer code from the linked issue, verified no longer crashes. Issue reporter has also reported that disabling hardware stack protector avoids the crash.
* Verified MicroPython still builds on v5.0.4 even with the non-existent new config item.

### Trade-offs and Alternatives

* Could wait for a fix, but even if this turns out to be an MP issue the hardware stack protector feature was only recently enabled in ESP-IDF so we're otherwise no worse off.