### PR TITLE
samd: Specify UF2 family.

### DIFF
--- a/ports/samd/Makefile
+++ b/ports/samd/Makefile
@@ -183,7 +183,7 @@ $(BUILD)/firmware.bin: $(BUILD)/firmware.elf
 	$(Q)$(OBJCOPY) -O binary -j .isr_vector -j .text -j .data $^ $(BUILD)/firmware.bin
 
 $(BUILD)/firmware.uf2: $(BUILD)/firmware.bin
-	$(Q)$(PYTHON) $(UF2CONV) -b $(TEXT0) -c -o $@ $<
+	$(Q)$(PYTHON) $(UF2CONV) $(UF2CONV_FLAGS) -b $(TEXT0) -c -o $@ $<
 
 # pin_af.c: $(BUILD)/$(GEN_PIN_AF) | $(HEADER_BUILD)
 

--- a/ports/samd/mcu/samd21/mpconfigmcu.mk
+++ b/ports/samd/mcu/samd21/mpconfigmcu.mk
@@ -13,3 +13,5 @@ endif
 MICROPY_VFS_LFS1 ?= 1
 
 SRC_S += shared/runtime/gchelper_thumb1.s
+
+UF2CONV_FLAGS += -f 0x68ed2b88

--- a/ports/samd/mcu/samd51/mpconfigmcu.mk
+++ b/ports/samd/mcu/samd51/mpconfigmcu.mk
@@ -14,3 +14,5 @@ SRC_S += shared/runtime/gchelper_thumb2.s
 
 SRC_C += \
 	fatfs_port.c \
+
+UF2CONV_FLAGS += -f 0x55114460


### PR DESCRIPTION
### Summary

Set the UF2 firmware images family to Microchip SAMD21 or SAMD51. This helps tools such as file to identify built firmware.

### Testing

Before:
```
$ file ports/samd/build-ADAFRUIT_ITSYBITSY_M*_EXPRESS/firmware.uf2
ports/samd/build-ADAFRUIT_ITSYBITSY_M0_EXPRESS/firmware.uf2: UF2 firmware image, file size 00000000, base address 0x002000, 910 total blocks
ports/samd/build-ADAFRUIT_ITSYBITSY_M4_EXPRESS/firmware.uf2: UF2 firmware image, file size 00000000, base address 0x004000, 1034 total blocks
```

After:
```
$ file ports/samd/build-ADAFRUIT_ITSYBITSY_M*_EXPRESS/firmware.uf2
ports/samd/build-ADAFRUIT_ITSYBITSY_M0_EXPRESS/firmware.uf2: UF2 firmware image, family Microchip (Atmel) SAMD21, base address 0x002000, 910 total blocks
ports/samd/build-ADAFRUIT_ITSYBITSY_M4_EXPRESS/firmware.uf2: UF2 firmware image, family Microchip (Atmel) SAMD51, base address 0x004000, 1034 total blocks
```

Other ports such as nrf52, ESP32, and RP2 are already setting the UF2 family correctly. SAMD is the only micropython port missing the UF2 family.

### Trade-offs and Alternatives

I've put `UF2CONV_FLAGS` in MCU makefile definitions, maybe there is a better way to do this?
