### PR TITLE
rp2/modules: Fix FatFS boot script.

### DIFF
--- a/ports/rp2/modules/_boot_fat.py
+++ b/ports/rp2/modules/_boot_fat.py
@@ -5,10 +5,9 @@ import machine, rp2
 # Try to mount the filesystem, and format the flash if it doesn't exist.
 bdev = rp2.Flash()
 try:
-    fs = vfs.VfsFat(bdev)
+    vfs.mount(vfs.VfsFat(bdev), "/")
 except:
     vfs.VfsFat.mkfs(bdev)
-    fs = vfs.VfsFat(bdev)
-vfs.mount(fs, "/")
+    vfs.mount(vfs.VfsFat(bdev), "/")
 
-del vfs, bdev, fs
+del vfs, bdev


### PR DESCRIPTION
This change helps detect if the filesystem is invalid and reformat the FAT if needed.

Fixes #15779