### PR TITLE
ports/stm32: Updated STM32L452XX Multi OTG handling

### DIFF
--- a/ports/stm32/mpconfigboard_common.h
+++ b/ports/stm32/mpconfigboard_common.h
@@ -619,7 +619,7 @@
 // Whether the USB peripheral is device-only, or multiple OTG
 // For STM32G0 and STM32H5 the USB peripheral supports device and host mode,
 // but otherwise acts like a non-multi-OTG peripheral.
-#if defined(STM32G0) || defined(STM32G4) || defined(STM32H5) || defined(STM32L0) || defined(STM32L1) || defined(STM32L432xx) || defined(STM32WB)
+#if defined(STM32G0) || defined(STM32G4) || defined(STM32H5) || defined(STM32L0) || defined(STM32L1) || defined(STM32L432xx) || defined(STM32L452xx) || defined(STM32WB)
 #define MICROPY_HW_USB_IS_MULTI_OTG (0)
 #else
 #define MICROPY_HW_USB_IS_MULTI_OTG (1)

--- a/ports/stm32/stm32_it.c
+++ b/ports/stm32/stm32_it.c
@@ -312,7 +312,7 @@ void USB_DRD_FS_IRQHandler(void) {
 }
 #endif
 
-#elif defined(STM32L0) || defined(STM32L432xx)
+#elif defined(STM32L0) || defined(STM32L432xx) || defined(STM32L452xx)
 
 #if MICROPY_HW_USB_FS
 void USB_IRQHandler(void) {

--- a/ports/stm32/usbd_conf.c
+++ b/ports/stm32/usbd_conf.c
@@ -93,7 +93,7 @@ void HAL_PCD_MspInit(PCD_HandleTypeDef *hpcd) {
         const uint32_t otg_alt = GPIO_AF10_OTG1_FS;
         #elif defined(STM32L0)
         const uint32_t otg_alt = GPIO_AF0_USB;
-        #elif defined(STM32L432xx)
+        #elif defined(STM32L432xx) || defined(STM32L452xx)
         const uint32_t otg_alt = GPIO_AF10_USB_FS;
         #elif defined(STM32H5) || defined(STM32WB)
         const uint32_t otg_alt = GPIO_AF10_USB;
@@ -156,7 +156,7 @@ void HAL_PCD_MspInit(PCD_HandleTypeDef *hpcd) {
         #elif defined(STM32L0)
         NVIC_SetPriority(USB_IRQn, IRQ_PRI_OTG_FS);
         HAL_NVIC_EnableIRQ(USB_IRQn);
-        #elif defined(STM32L432xx)
+        #elif defined(STM32L432xx) || defined(STM32L452xx)
         NVIC_SetPriority(USB_FS_IRQn, IRQ_PRI_OTG_FS);
         HAL_NVIC_EnableIRQ(USB_FS_IRQn);
         #elif defined(STM32G4) || defined(STM32L1) || defined(STM32WB)


### PR DESCRIPTION
Added custom Multi OTG handling for STM32L452XX
based on STM32L432XX handling.
https://github.com/micropython/micropython/issues/15795

### Summary

To enable USB when using an L4 which is not based on the L432, Multi OTG handling seems to fall through the cracks, and results in the build not completing.

### Testing

I do not yet have HW, so have not been able to test on a L452 target.

### Trade-offs and Alternatives

Ideally the multi OTG handling would not involve piecemeal handling for specific targets, which then needs springling around various files.