### PR TITLE
tools/ci.sh: Clean up Arm, MIPS, and RV64 Unix port build steps.

### DIFF
--- a/tools/ci.sh
+++ b/tools/ci.sh
@@ -704,6 +704,7 @@ function ci_unix_qemu_riscv64_setup {
 
 function ci_unix_qemu_riscv64_build {
     ci_unix_build_helper "${CI_UNIX_OPTS_QEMU_RISCV64[@]}"
+    ci_unix_build_ffi_lib_helper riscv64-linux-gnu-gcc
 }
 
 function ci_unix_qemu_riscv64_run_tests {

--- a/tools/ci.sh
+++ b/tools/ci.sh
@@ -674,6 +674,8 @@ function ci_unix_qemu_arm_setup {
     sudo apt-get install gcc-arm-linux-gnueabi g++-arm-linux-gnueabi
     sudo apt-get install qemu-user
     qemu-arm --version
+    sudo mkdir /etc/qemu-binfmt
+    sudo ln -s /usr/arm-linux-gnueabi/ /etc/qemu-binfmt/arm
 }
 
 function ci_unix_qemu_arm_build {
@@ -684,7 +686,6 @@ function ci_unix_qemu_arm_build {
 function ci_unix_qemu_arm_run_tests {
     # Issues with ARM tests:
     # - (i)listdir does not work, it always returns the empty list (it's an issue with the underlying C call)
-    export QEMU_LD_PREFIX=/usr/arm-linux-gnueabi
     file ./ports/unix/build-coverage/micropython
     (cd tests && MICROPY_MICROPYTHON=../ports/unix/build-coverage/micropython ./run-tests.py --exclude 'vfs_posix.*\.py')
 }


### PR DESCRIPTION
### Summary

These are some minor patches I've made on my tree when I added the Unix RV64 target to the CI scripts.  I forgot to submit them back then, so here they are, rebased onto the latest master and all.  In short, the MIPS target now doesn't require any workarounds to run under CI and passes FFI tests, the RV64 target now has an FFI helper, and the Arm build doesn't require an environment variable to run anymore (now shares the same post-installation setup commands as MIPS).

### Testing

When building and running the Arm and MIPS targets locally in a VM environment equivalent to the CI image (same OS, packages, and run commands), the VFS tests pass.  No idea on why they must be disabled in the CI environment - the RV64 build passes them anyway.