### PR TITLE
examples/natmod: Fix links in README.md.

### DIFF
--- a/examples/natmod/README.md
+++ b/examples/natmod/README.md
@@ -1,12 +1,12 @@
 # Dynamic Native Modules
 
 Dynamic Native Modules are .mpy files that contain native machine code from a
-language other than Python. For more info see [the documentation]
-(https://docs.micropython.org/en/latest/develop/natmod.html).
+language other than Python. For more info see [the
+documentation](https://docs.micropython.org/en/latest/develop/natmod.html).
 
-This should not be confused with [User C Modules]
-(https://docs.micropython.org/en/latest/develop/cmodules.html) which are a
-mechanism to add additional out-of-tree modules into the firmware build.
+This should not be confused with [User C
+Modules](https://docs.micropython.org/en/latest/develop/cmodules.html) which are
+a mechanism to add additional out-of-tree modules into the firmware build.
 
 ## Examples
 


### PR DESCRIPTION
I noticed that the links in the examples/natmod/README.md file were incorrectly formatted (can't split lines between the square brackets and parentheses) and weren't rendering correctly when viewed in Github. The first commit resolves those links.

I used [mdl](https://github.com/markdownlint/markdownlint) to lint the README and tidied up a couple of other suggestions too (specifically [MD014](https://github.com/markdownlint/markdownlint/blob/main/docs/RULES.md#md014---dollar-signs-used-before-commands-without-showing-output), and [MD007](https://github.com/markdownlint/markdownlint/blob/main/docs/RULES.md#md007---unordered-list-indentation)). These issues are tidied up in the second commit.