### PR TITLE
unix/README: Fix typo in build dependencies.

### DIFF
--- a/ports/unix/README.md
+++ b/ports/unix/README.md
@@ -32,7 +32,7 @@ On Debian/Ubuntu/Mint and related Linux distros, you can install all these
 dependencies with a command like:
 
 ```
-# apt install build-essential git python3 pkg-config libbfi-dev
+# apt install build-essential git python3 pkg-config libffi-dev
 ```
 
 (See below for steps to build either a standalone or minimal MicroPython


### PR DESCRIPTION
`libffi-dev` is written as `libbfi-dev` by mistake.