### PR TITLE
docs/library/math: Document math.log with two arguments.

### DIFF
--- a/docs/library/math.rst
+++ b/docs/library/math.rst
@@ -125,8 +125,11 @@ Functions
    Return the natural logarithm of the gamma function of ``x``.
 
 .. function:: log(x)
+              log(x, base)
 
-   Return the natural logarithm of ``x``.
+   With one argument, return the natural logarithm of *x*.
+
+   With two arguments, return the logarithm of *x* to the given *base*.
 
 .. function:: log10(x)
 


### PR DESCRIPTION
The functionality is there but it's not documented.