### PR TITLE
doc: Document machine.Pin.toggle() method.

### DIFF
--- a/docs/library/machine.Pin.rst
+++ b/docs/library/machine.Pin.rst
@@ -238,6 +238,12 @@ The following methods are not part of the core Pin API and only implemented on c
 
    Availability: cc3200 port.
 
+.. method:: Pin.toggle()
+
+   Toggle output pin from "0" to "1" or vice-versa.
+
+   Availability: mimxrt, samd, rp2 ports.
+
 Constants
 ---------
 


### PR DESCRIPTION
### Summary

Document the `pin.toggle()` method that's available on some ports.

This is an amended version of the commit from #9653. Closes #9652.
