### PR TITLE
RFC: make source code generation better at picking up source changes

### DIFF
--- a/docs/develop/qstr.rst
+++ b/docs/develop/qstr.rst
@@ -60,8 +60,8 @@ Processing happens in the following stages:
    means that ``qstr.i.last`` will only contain data from files that have
    changed since the last compile.
 
-2. ``qstr.split`` is an empty file created after running ``makeqstrdefs.py split``
-   on qstr.i.last. It's just used as a dependency to indicate that the step ran.
+2. ``qstr.split`` is a file created after running ``makeqstrdefs.py split``
+   on qstr.i.last. It's used as a dependency to indicate that the step ran.
    This script outputs one file per input C file,  ``genhdr/qstr/...file.c.qstr``,
    which contains only the matched QSTRs. Each QSTR is printed as ``Q(Foo)``.
    This step is necessary to combine the existing files with the new data

--- a/ports/windows/msvc/genhdr.targets
+++ b/ports/windows/msvc/genhdr.targets
@@ -14,9 +14,14 @@
     <PyQstrDefs>$(PySrcDir)qstrdefs.h</PyQstrDefs>
     <QstrDefsCollected>$(DestDir)qstrdefscollected.h</QstrDefsCollected>
     <QstrGen>$(DestDir)qstrdefs.generated.h</QstrGen>
-    <ModuleDefsCollected>$(DestDir)/moduledefs.collected</ModuleDefsCollected>
-    <RootPointersCollected>$(DestDir)/root_pointers.collected</RootPointersCollected>
-    <CompressedCollected>$(DestDir)/compressed.collected</CompressedCollected>
+    <ModuleDefsCollected>$(DestDir)moduledefs.collected</ModuleDefsCollected>
+    <ModuleDefs>$(DestDir)moduledefs.h</ModuleDefs>
+    <RootPointersCollected>$(DestDir)root_pointers.collected</RootPointersCollected>
+    <RootPointers>$(DestDir)root_pointers.h</RootPointers>
+    <CompressedCollected>$(DestDir)compressed.collected</CompressedCollected>
+    <CompressedData>$(DestDir)compressed.data.h</CompressedData>
+    <FrozenContent>$(DestDir)frozen_content.c</FrozenContent>
+    <VersionHeader>$(DestDir)mpversion.h</VersionHeader>
     <PyPython Condition="'$(PyPython)' == ''">$(MICROPY_CPYTHON3)</PyPython>
     <PyPython Condition="'$(PyPython)' == ''">python</PyPython>
     <CLToolExe Condition="'$(CLToolExe)' == ''">cl.exe</CLToolExe>
@@ -66,7 +71,7 @@ using(var outFile = System.IO.File.CreateText(OutputFile)) {
     <ItemGroup>
       <PyIncDirs Include="$(PyIncDirs)"/>
       <PreProcDefs Include="%(ClCompile.PreProcessorDefinitions);NO_QSTR"/>
-      <PyQstrSourceFiles Include="@(ClCompile)" Exclude="$(PyBuildDir)\frozen_content.c">
+      <PyQstrSourceFiles Include="@(ClCompile)" Exclude="$(FrozenContent)">
         <Changed>False</Changed>
         <OutFile>$([System.String]::new('%(FullPath)').Replace('$(PyBaseDir)', '$(DestDir)qstr\'))</OutFile>
       </PyQstrSourceFiles>
@@ -113,13 +118,9 @@ using(var outFile = System.IO.File.CreateText(OutputFile)) {
     <Exec Command="$(PyPython) $(PySrcDir)makeqstrdefs.py cat module _ $(DestDir)module $(ModuleDefsCollected)"/>
   </Target>
 
-  <Target Name="MakeModuleDefs" DependsOnTargets="CollectModuleDefs" Inputs="$(ModuleDefsCollected)" Outputs="$(DestDir)moduledefs.h">
-    <PropertyGroup>
-      <DestFile>$(DestDir)moduledefs.h</DestFile>
-      <TmpFile>$(DestFile).tmp</TmpFile>
-    </PropertyGroup>
-    <Exec Command="$(PyPython) $(PySrcDir)makemoduledefs.py $(ModuleDefsCollected) > $(TmpFile)"/>
-    <MSBuild Projects="$(MSBuildThisFileFullPath)" Targets="CopyFileIfDifferent" Properties="SourceFile=$(TmpFile);DestFile=$(DestFile)"/>
+  <Target Name="MakeModuleDefs" DependsOnTargets="CollectModuleDefs" Inputs="$(ModuleDefsCollected)" Outputs="$(ModuleDefs)">
+    <Exec Command="$(PyPython) $(PySrcDir)makemoduledefs.py $(ModuleDefsCollected) > $(ModuleDefs).tmp"/>
+    <MSBuild Projects="$(MSBuildThisFileFullPath)" Targets="CopyFileIfDifferent" Properties="SourceFile=$(ModuleDefs).tmp;DestFile=$(ModuleDefs)"/>
   </Target>
 
   <Target Name="CollectRootPointers" DependsOnTargets="MakeQstrDefs" Inputs="$(DestDir)qstr.i.last" Outputs="$(RootPointersCollected)">
@@ -127,57 +128,42 @@ using(var outFile = System.IO.File.CreateText(OutputFile)) {
     <Exec Command="$(PyPython) $(PySrcDir)makeqstrdefs.py cat root_pointer _ $(DestDir)root_pointer $(RootPointersCollected)"/>
   </Target>
 
-  <Target Name="MakeRootPointers" DependsOnTargets="CollectRootPointers" Inputs="$(PySrcDir)make_root_pointers.py;$(RootPointersCollected)" Outputs="$(DestDir)root_pointers.h">
-    <PropertyGroup>
-      <DestFile>$(DestDir)root_pointers.h</DestFile>
-      <TmpFile>$(DestFile).tmp</TmpFile>
-    </PropertyGroup>
-    <Exec Command="$(PyPython) $(PySrcDir)make_root_pointers.py $(RootPointersCollected) > $(TmpFile)"/>
-    <MSBuild Projects="$(MSBuildThisFileFullPath)" Targets="CopyFileIfDifferent" Properties="SourceFile=$(TmpFile);DestFile=$(DestFile)"/>
+  <Target Name="MakeRootPointers" DependsOnTargets="CollectRootPointers" Inputs="$(PySrcDir)make_root_pointers.py;$(RootPointersCollected)" Outputs="$(RootPointers)">
+    <Exec Command="$(PyPython) $(PySrcDir)make_root_pointers.py $(RootPointersCollected) > $(RootPointers).tmp"/>
+    <MSBuild Projects="$(MSBuildThisFileFullPath)" Targets="CopyFileIfDifferent" Properties="SourceFile=$(RootPointers).tmp;DestFile=$(RootPointers)"/>
   </Target>
 
-  <Target Name="MakeCompressedData" DependsOnTargets="CollectCompressedData" Inputs="$(CompressedCollected)" Outputs="$(DestDir)compressed.data.h">
-    <PropertyGroup>
-      <DestFile>$(DestDir)compressed.data.h</DestFile>
-      <TmpFile>$(DestFile).tmp</TmpFile>
-    </PropertyGroup>
-    <Exec Command="$(PyPython) $(PySrcDir)makecompresseddata.py $(CompressedCollected) > $(TmpFile)"/>
-    <MSBuild Projects="$(MSBuildThisFileFullPath)" Targets="CopyFileIfDifferent" Properties="SourceFile=$(TmpFile);DestFile=$(DestFile)"/>
+  <Target Name="MakeCompressedData" DependsOnTargets="CollectCompressedData" Inputs="$(CompressedCollected)" Outputs="$(CompressedData)">
+    <Exec Command="$(PyPython) $(PySrcDir)makecompresseddata.py $(CompressedCollected) > $(CompressedData).tmp"/>
+    <MSBuild Projects="$(MSBuildThisFileFullPath)" Targets="CopyFileIfDifferent" Properties="SourceFile=$(CompressedData).tmp;DestFile=$(CompressedData)"/>
   </Target>
 
   <Target Name="MakeQstrData" DependsOnTargets="MakeQstrDefs" Inputs="$(QstrDefsCollected);$(PyQstrDefs);$(QstrDefs)" Outputs="$(QstrGen)">
-    <PropertyGroup>
-      <TmpFile>$(QstrGen).tmp</TmpFile>
-    </PropertyGroup>
     <Exec Command="$(PyClTool) /nologo /I@(PyIncDirs, ' /I') /D@(PreProcDefs, ' /D') /E $(PyQstrDefs) $(QstrDefs) > $(DestDir)qstrdefs.preprocessed.h"/>
     <!--Because makemanifest.py relies on this file to have all Q() and QCFG() entries.-->
     <Exec Command="type $(QstrDefsCollected) >> $(DestDir)qstrdefs.preprocessed.h"/>
-    <Exec Command="$(PyPython) $(PySrcDir)makeqstrdata.py $(DestDir)qstrdefs.preprocessed.h > $(TmpFile)"/>
-    <MSBuild Projects="$(MSBuildThisFileFullPath)" Targets="CopyFileIfDifferent" Properties="SourceFile=$(TmpFile);DestFile=$(QstrGen)"/>
+    <Exec Command="$(PyPython) $(PySrcDir)makeqstrdata.py $(DestDir)qstrdefs.preprocessed.h > $(QstrGen).tmp"/>
+    <MSBuild Projects="$(MSBuildThisFileFullPath)" Targets="CopyFileIfDifferent" Properties="SourceFile=$(QstrGen).tmp;DestFile=$(QstrGen)"/>
   </Target>
 
-  <Target Name="MakeVersionHdr" DependsOnTargets="MakeDestDir">
-    <PropertyGroup>
-      <DestFile>$(DestDir)mpversion.h</DestFile>
-      <TmpFile>$(DestFile).tmp</TmpFile>
-    </PropertyGroup>
-    <Exec Command="$(PyPython) $(PySrcDir)makeversionhdr.py $(TmpFile)"/>
-    <MSBuild Projects="$(MSBuildThisFileFullPath)" Targets="CopyFileIfDifferent" Properties="SourceFile=$(TmpFile);DestFile=$(DestFile)"/>
+  <Target Name="MakeVersionHdr" DependsOnTargets="MakeDestDir" Outputs="$(VersionHeader)">
+    <Exec Command="$(PyPython) $(PySrcDir)makeversionhdr.py $(VersionHeader).tmp"/>
+    <MSBuild Projects="$(MSBuildThisFileFullPath)" Targets="CopyFileIfDifferent" Properties="SourceFile=$(VersionHeader).tmp;DestFile=$(VersionHeader)"/>
   </Target>
 
-  <Target Name="FreezeModules" Condition="'$(FrozenManifest)' != ''" DependsOnTargets="MakeQstrData;MakeRootPointers" Inputs="$(FrozenManifest)" Outputs="$(PyBuildDir)frozen_content.c">
+  <Target Name="FreezeModules" Condition="'$(FrozenManifest)' != ''" DependsOnTargets="MakeQstrData;MakeRootPointers" Inputs="$(FrozenManifest)" Outputs="$(FrozenContent)">
     <ItemGroup>
-      <ClCompile Include="$(PyBuildDir)frozen_content.c"/>
+      <ClCompile Include="$(FrozenContent)"/>
       <ClCompile>
         <PreprocessorDefinitions>MICROPY_MODULE_FROZEN_MPY=1;MICROPY_QSTR_EXTRA_POOL=mp_qstr_frozen_const_pool;MPZ_DIG_SIZE=16;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       </ClCompile>
     </ItemGroup>
-    <Exec Command="$(PyPython) $(PyBaseDir)tools\makemanifest.py -v MPY_DIR=$(PyBaseDir) -v MPY_LIB_DIR=$(PyBaseDir)/lib/micropython-lib -v PORT_DIR=$(PyWinDir) -o $(PyBuildDir)frozen_content.c -b $(PyBuildDir) $(FrozenManifest)"/>
+    <Exec Command="$(PyPython) $(PyBaseDir)tools\makemanifest.py -v MPY_DIR=$(PyBaseDir) -v MPY_LIB_DIR=$(PyBaseDir)/lib/micropython-lib -v PORT_DIR=$(PyWinDir) -o $(FrozenContent) -b $(PyBuildDir) $(FrozenManifest)"/>
     <WriteLinesToFile File="$(TLogLocation)frozen.read.1.tlog" Lines="$(FrozenManifest)" Overwrite="True"/>
   </Target>
 
   <Target Name="RemoveGeneratedFiles" AfterTargets="Clean">
-    <RemoveDir Directories="$(DestDir)"/>
+    <RemoveDir Directories="$(DestDir);$(PyBuildDir)frozen_mpy"/>
   </Target>
 
   <!--Copies SourceFile to DestFile only if SourceFile's content differs from DestFile's.

--- a/py/makeqstrdefs.py
+++ b/py/makeqstrdefs.py
@@ -225,10 +225,11 @@ if __name__ == "__main__":
         sys.exit(0)
 
     args.mode = sys.argv[2]
-    args.input_filename = sys.argv[3]  # Unused for command=cat
+    args.input_filename = sys.argv[3]  # Possibly unused for command=cat
     args.output_dir = sys.argv[4]
-    args.output_file = None if len(sys.argv) == 5 else sys.argv[5]  # Unused for command=split
-
+    args.output_file = (
+        None if len(sys.argv) == 5 else sys.argv[5]
+    )  # Possibly unused for command=split
     if args.mode not in (_MODE_QSTR, _MODE_COMPRESS, _MODE_MODULE, _MODE_ROOT_POINTER):
         print("error: mode %s unrecognised" % sys.argv[2])
         sys.exit(2)
@@ -238,12 +239,23 @@ if __name__ == "__main__":
     except OSError:
         pass
 
-    if args.command in ("split", "cat"):
-        args.split_file = args.output_dir + "/" + args.mode + ".split"
+    # _ has been used historically to indicate 'not an actual argument'
+    def is_actual_file(arg):
+        return args is not None and arg != "_"
 
     if args.command == "split":
+        args.split_file = (
+            args.output_file
+            if is_actual_file(args.output_file)
+            else args.output_dir + "/" + args.mode + ".split"
+        )
         with io.open(args.input_filename, encoding="utf-8") as infile:
             process_file(infile)
 
     if args.command == "cat":
+        args.split_file = (
+            args.input_filename
+            if is_actual_file(args.input_filename)
+            else args.output_dir + "/" + args.mode + ".split"
+        )
         cat_together()

--- a/py/mkrules.cmake
+++ b/py/mkrules.cmake
@@ -89,8 +89,7 @@ add_custom_command(
 
 add_custom_command(
     OUTPUT ${MICROPY_QSTRDEFS_SPLIT}
-    COMMAND ${Python3_EXECUTABLE} ${MICROPY_PY_DIR}/makeqstrdefs.py split qstr ${MICROPY_GENHDR_DIR}/qstr.i.last ${MICROPY_GENHDR_DIR}/qstr _
-    COMMAND touch ${MICROPY_QSTRDEFS_SPLIT}
+    COMMAND ${Python3_EXECUTABLE} ${MICROPY_PY_DIR}/makeqstrdefs.py split qstr ${MICROPY_GENHDR_DIR}/qstr.i.last ${MICROPY_GENHDR_DIR}/qstr ${MICROPY_QSTRDEFS_SPLIT}
     DEPENDS ${MICROPY_QSTRDEFS_LAST}
     VERBATIM
     COMMAND_EXPAND_LISTS
@@ -98,7 +97,7 @@ add_custom_command(
 
 add_custom_command(
     OUTPUT ${MICROPY_QSTRDEFS_COLLECTED}
-    COMMAND ${Python3_EXECUTABLE} ${MICROPY_PY_DIR}/makeqstrdefs.py cat qstr _ ${MICROPY_GENHDR_DIR}/qstr ${MICROPY_QSTRDEFS_COLLECTED}
+    COMMAND ${Python3_EXECUTABLE} ${MICROPY_PY_DIR}/makeqstrdefs.py cat qstr ${MICROPY_QSTRDEFS_SPLIT} ${MICROPY_GENHDR_DIR}/qstr ${MICROPY_QSTRDEFS_COLLECTED}
     BYPRODUCTS "${MICROPY_QSTRDEFS_COLLECTED}.hash"
     DEPENDS ${MICROPY_QSTRDEFS_SPLIT}
     VERBATIM
@@ -127,8 +126,7 @@ add_custom_command(
 
 add_custom_command(
     OUTPUT ${MICROPY_MODULEDEFS_SPLIT}
-    COMMAND ${Python3_EXECUTABLE} ${MICROPY_PY_DIR}/makeqstrdefs.py split module ${MICROPY_GENHDR_DIR}/qstr.i.last ${MICROPY_GENHDR_DIR}/module _
-    COMMAND touch ${MICROPY_MODULEDEFS_SPLIT}
+    COMMAND ${Python3_EXECUTABLE} ${MICROPY_PY_DIR}/makeqstrdefs.py split module ${MICROPY_GENHDR_DIR}/qstr.i.last ${MICROPY_GENHDR_DIR}/module ${MICROPY_MODULEDEFS_SPLIT}
     DEPENDS ${MICROPY_QSTRDEFS_LAST}
     VERBATIM
     COMMAND_EXPAND_LISTS
@@ -136,7 +134,7 @@ add_custom_command(
 
 add_custom_command(
     OUTPUT ${MICROPY_MODULEDEFS_COLLECTED}
-    COMMAND ${Python3_EXECUTABLE} ${MICROPY_PY_DIR}/makeqstrdefs.py cat module _ ${MICROPY_GENHDR_DIR}/module ${MICROPY_MODULEDEFS_COLLECTED}
+    COMMAND ${Python3_EXECUTABLE} ${MICROPY_PY_DIR}/makeqstrdefs.py cat module ${MICROPY_MODULEDEFS_SPLIT} ${MICROPY_GENHDR_DIR}/module ${MICROPY_MODULEDEFS_COLLECTED}
     BYPRODUCTS "${MICROPY_MODULEDEFS_COLLECTED}.hash"
     DEPENDS ${MICROPY_MODULEDEFS_SPLIT}
     VERBATIM
@@ -153,8 +151,7 @@ add_custom_command(
 
 add_custom_command(
     OUTPUT ${MICROPY_ROOT_POINTERS_SPLIT}
-    COMMAND ${Python3_EXECUTABLE} ${MICROPY_PY_DIR}/makeqstrdefs.py split root_pointer ${MICROPY_GENHDR_DIR}/qstr.i.last ${MICROPY_GENHDR_DIR}/root_pointer _
-    COMMAND touch ${MICROPY_ROOT_POINTERS_SPLIT}
+    COMMAND ${Python3_EXECUTABLE} ${MICROPY_PY_DIR}/makeqstrdefs.py split root_pointer ${MICROPY_GENHDR_DIR}/qstr.i.last ${MICROPY_GENHDR_DIR}/root_pointer ${MICROPY_ROOT_POINTERS_SPLIT}
     DEPENDS ${MICROPY_QSTRDEFS_LAST}
     VERBATIM
     COMMAND_EXPAND_LISTS
@@ -162,7 +159,7 @@ add_custom_command(
 
 add_custom_command(
     OUTPUT ${MICROPY_ROOT_POINTERS_COLLECTED}
-    COMMAND ${Python3_EXECUTABLE} ${MICROPY_PY_DIR}/makeqstrdefs.py cat root_pointer _ ${MICROPY_GENHDR_DIR}/root_pointer ${MICROPY_ROOT_POINTERS_COLLECTED}
+    COMMAND ${Python3_EXECUTABLE} ${MICROPY_PY_DIR}/makeqstrdefs.py cat root_pointer ${MICROPY_ROOT_POINTERS_SPLIT} ${MICROPY_GENHDR_DIR}/root_pointer ${MICROPY_ROOT_POINTERS_COLLECTED}
     BYPRODUCTS "${MICROPY_ROOT_POINTERS_COLLECTED}.hash"
     DEPENDS ${MICROPY_ROOT_POINTERS_SPLIT}
     VERBATIM

--- a/py/mkrules.mk
+++ b/py/mkrules.mk
@@ -123,42 +123,38 @@ $(HEADER_BUILD)/qstr.i.last: $(SRC_QSTR) $(QSTR_GLOBAL_DEPENDENCIES) | $(QSTR_GL
 
 $(HEADER_BUILD)/qstr.split: $(HEADER_BUILD)/qstr.i.last
 	$(ECHO) "GEN $@"
-	$(Q)$(PYTHON) $(PY_SRC)/makeqstrdefs.py split qstr $< $(HEADER_BUILD)/qstr _
-	$(Q)$(TOUCH) $@
+	$(Q)$(PYTHON) $(PY_SRC)/makeqstrdefs.py split qstr $< $(HEADER_BUILD)/qstr $(HEADER_BUILD)/qstr.split
 
 $(QSTR_DEFS_COLLECTED): $(HEADER_BUILD)/qstr.split
 	$(ECHO) "GEN $@"
-	$(Q)$(PYTHON) $(PY_SRC)/makeqstrdefs.py cat qstr _ $(HEADER_BUILD)/qstr $@
+	$(Q)$(PYTHON) $(PY_SRC)/makeqstrdefs.py cat qstr $(HEADER_BUILD)/qstr.split $(HEADER_BUILD)/qstr $@
 
 # Module definitions via MP_REGISTER_MODULE.
 $(HEADER_BUILD)/moduledefs.split: $(HEADER_BUILD)/qstr.i.last
 	$(ECHO) "GEN $@"
-	$(Q)$(PYTHON) $(PY_SRC)/makeqstrdefs.py split module $< $(HEADER_BUILD)/module _
-	$(Q)$(TOUCH) $@
+	$(Q)$(PYTHON) $(PY_SRC)/makeqstrdefs.py split module $< $(HEADER_BUILD)/module $(HEADER_BUILD)/moduledefs.split
 
 $(HEADER_BUILD)/moduledefs.collected: $(HEADER_BUILD)/moduledefs.split
 	$(ECHO) "GEN $@"
-	$(Q)$(PYTHON) $(PY_SRC)/makeqstrdefs.py cat module _ $(HEADER_BUILD)/module $@
+	$(Q)$(PYTHON) $(PY_SRC)/makeqstrdefs.py cat module $(HEADER_BUILD)/moduledefs.split $(HEADER_BUILD)/module $@
 
 # Module definitions via MP_REGISTER_ROOT_POINTER.
 $(HEADER_BUILD)/root_pointers.split: $(HEADER_BUILD)/qstr.i.last
 	$(ECHO) "GEN $@"
-	$(Q)$(PYTHON) $(PY_SRC)/makeqstrdefs.py split root_pointer $< $(HEADER_BUILD)/root_pointer _
-	$(Q)$(TOUCH) $@
+	$(Q)$(PYTHON) $(PY_SRC)/makeqstrdefs.py split root_pointer $< $(HEADER_BUILD)/root_pointer $(HEADER_BUILD)/root_pointers.split
 
 $(HEADER_BUILD)/root_pointers.collected: $(HEADER_BUILD)/root_pointers.split
 	$(ECHO) "GEN $@"
-	$(Q)$(PYTHON) $(PY_SRC)/makeqstrdefs.py cat root_pointer _ $(HEADER_BUILD)/root_pointer $@
+	$(Q)$(PYTHON) $(PY_SRC)/makeqstrdefs.py cat root_pointer $(HEADER_BUILD)/root_pointers.split $(HEADER_BUILD)/root_pointer $@
 
 # Compressed error strings.
 $(HEADER_BUILD)/compressed.split: $(HEADER_BUILD)/qstr.i.last
 	$(ECHO) "GEN $@"
-	$(Q)$(PYTHON) $(PY_SRC)/makeqstrdefs.py split compress $< $(HEADER_BUILD)/compress _
-	$(Q)$(TOUCH) $@
+	$(Q)$(PYTHON) $(PY_SRC)/makeqstrdefs.py split compress $< $(HEADER_BUILD)/compress $(HEADER_BUILD)/compressed.split
 
 $(HEADER_BUILD)/compressed.collected: $(HEADER_BUILD)/compressed.split
 	$(ECHO) "GEN $@"
-	$(Q)$(PYTHON) $(PY_SRC)/makeqstrdefs.py cat compress _ $(HEADER_BUILD)/compress $@
+	$(Q)$(PYTHON) $(PY_SRC)/makeqstrdefs.py cat compress $(HEADER_BUILD)/compressed.split $(HEADER_BUILD)/compress $@
 
 # $(sort $(var)) removes duplicates
 #

--- a/tools/makemanifest.py
+++ b/tools/makemanifest.py
@@ -164,11 +164,14 @@ def main():
         sys.exit(1)
 
     manifest = manifestfile.ManifestFile(manifestfile.MODE_FREEZE, VARS)
+    ts_newest = 0
 
     # Include top-level inputs, to generate the manifest
     for input_manifest in args.files:
         try:
             manifest.execute(input_manifest)
+            if input_manifest.endswith(".py"):
+                ts_newest = max(ts_newest, get_timestamp(input_manifest))
         except manifestfile.ManifestFileError as er:
             print('freeze error executing "{}": {}'.format(input_manifest, er.args[0]))
             sys.exit(1)
@@ -176,7 +179,6 @@ def main():
     # Process the manifest
     str_paths = []
     mpy_files = []
-    ts_newest = 0
     for result in manifest.files():
         if result.kind == manifestfile.KIND_FREEZE_AS_STR:
             str_paths.append(


### PR DESCRIPTION
### Summary

This is a first attempt to reduce the number of build failures which originate from the build system not properly picking up certain changes, typcially while developing and switching between branches (also see https://github.com/orgs/micropython/discussions/15693 where it's mentioned this is not uncommon). It's RFC currently because:
- I'm not sure this fixes all possible problems, so if someone else knows of a case not covered here and easy to reproduce then I can look into that and hopefully come up with a fix
- the main fix is pretty drastic and changes behavior

About that last part: makeqstrdefs.py seems to have been designed such that one can run `makeqstrdefs split ...` multiple times followed by a single `makeqstrdefs cat ...`. As far as I'm aware this isn't used as such in the micropython source itself. But it is also not possible anymore now., because basically my change is that `split` now creates a file which serves as input to tell `cat` what to do, and that file is overwritten each time. I can make it such that `split` appends to that file instead so multiple calls are possible again, but that would require an extra build step because at one point the file obviously has to be deleted again else we'd just keep appending to it, and the original problem only worsens. Thoughts?


### Testing

I verified changing between branches where one has more moduleds/frozen content than the other now works as expected.


### Trade-offs and Alternatives

The only alternative is seeing a build error, doing `make clean` and seeing if that fixes it :)