### PR TITLE
tools/dfu.py: Add option to specify firmware version to DFU file suffix.

### DIFF
--- a/ports/stm32/Makefile
+++ b/ports/stm32/Makefile
@@ -71,6 +71,7 @@ PYDFU ?= $(TOP)/tools/pydfu.py
 DFU_UTIL ?= dfu-util
 BOOTLOADER_DFU_USB_VID ?= 0x0483
 BOOTLOADER_DFU_USB_PID ?= 0xDF11
+DFU_FW_VER ?= 0
 STFLASH ?= st-flash
 OPENOCD ?= openocd
 OPENOCD_CONFIG ?= boards/openocd_stm32f4.cfg
@@ -534,6 +535,7 @@ define GENERATE_DFU
 	$(ECHO) "GEN $(1)"
 	$(Q)$(PYTHON) $(DFU) \
 	-D $(BOOTLOADER_DFU_USB_VID):$(BOOTLOADER_DFU_USB_PID) \
+	-V $(DFU_FW_VER) \
 	$(if $(2),$(addprefix -b ,$(3):$(2))) \
 	$(if $(4),$(addprefix -b ,$(5):$(4))) \
 	$(1)

--- a/ports/stm32/mboot/Makefile
+++ b/ports/stm32/mboot/Makefile
@@ -41,6 +41,7 @@ DFU=$(TOP)/tools/dfu.py
 PYDFU ?= $(TOP)/tools/pydfu.py
 BOOTLOADER_DFU_USB_VID ?= 0x0483
 BOOTLOADER_DFU_USB_PID ?= 0xDF11
+DFU_FW_VER ?= 0
 STFLASH ?= st-flash
 OPENOCD ?= openocd
 OPENOCD_CONFIG ?= boards/openocd_stm32f4.cfg
@@ -207,7 +208,10 @@ deploy-stlink: $(BUILD)/firmware.dfu
 $(BUILD)/firmware.dfu: $(BUILD)/firmware.elf
 	$(ECHO) "Create $@"
 	$(Q)$(OBJCOPY) -O binary -j .isr_vector -j .text -j .data $^ $(BUILD)/firmware.bin
-	$(Q)$(PYTHON) $(DFU) -b $(MBOOT_TEXT0_ADDR):$(BUILD)/firmware.bin $@
+	$(Q)$(PYTHON) $(DFU) \
+		-D $(BOOTLOADER_DFU_USB_VID):$(BOOTLOADER_DFU_USB_PID) \
+		-V $(DFU_FW_VER) \
+		-b $(MBOOT_TEXT0_ADDR):$(BUILD)/firmware.bin $@
 
 $(BUILD)/firmware.hex: $(BUILD)/firmware.elf
 	$(ECHO) "Create $@"


### PR DESCRIPTION
### Summary

The suffix section of the DFU file format contains a bcdDevice field for the firmware version containted in the file. The existing dfu.py used to build DFU files always sets this to 0; this change allows setting this to any 16 bit number, and allows defining this in Make using DFU_FW_VER. This field can be used in an OTA to ensure compatibility of the incoming firmware file.

### Testing

Tested on PYBD_SF6. 
* Built `build-PYBD_SF6/firmware.dfu` without any changed options
* inspected generated dfu file to verify suffix field contains 0x0000 as first 2 bytes of suffix
* Flashed above firmware using dfu-util 
* Flashed above firmware using pydfu.py
* Flashed above firmware (gzipped) by copying to pyboard and using `fwupdate.py` to get pyboard to update itself from filesystem

* Built `build-PYBD_SF6/firmware.dfu` using `make BOARD=PYBD_SF6 DFU_FW_VER=0x1337`
* inspected generated dfu file to verify suffix field contains 0x1337 as first 2 bytes of suffix
* Flashed above firmware using dfu-util 
* Flashed above firmware using pydfu.py
* Flashed above firmware by copying to pyboard and using `fwupdate.py` to get pyboard to update itself from filesystem

* ` Built `mboot/build-PYBD_SF6/firmware.dfu` without any changed options
* inspected generated dfu file to verify suffix field contains 0x0000 as first 2 bytes of suffix
* Flashed above firmware by copying to pyboard and using `fwupdate.py` to get pyboard to update mboot from filesystem

* Built `mboot/build-PYBD_SF6/firmware.dfu` using `make BOARD=PYBD_SF6 DFU_FW_VER=0x1337 -C mboot`
* inspected generated dfu file to verify suffix field contains 0x1337 as first 2 bytes of suffix
* Flashed above firmware by copying to pyboard and using `fwupdate.py` to get pyboard to update itself from filesystem