### PR TITLE
tools/metrics.py: Add VIRT_RV32 to the code size metrics.

### DIFF
--- a/tools/ci.sh
+++ b/tools/ci.sh
@@ -55,11 +55,12 @@ function ci_code_size_setup {
     sudo apt-get install gcc-multilib
     gcc --version
     ci_gcc_arm_setup
+    ci_gcc_riscv_setup
 }
 
 function ci_code_size_build {
     # check the following ports for the change in their code size
-    PORTS_TO_CHECK=bmusxpd
+    PORTS_TO_CHECK=bmusxpdv
     SUBMODULES="lib/asf4 lib/berkeley-db-1.xx lib/btstack lib/cyw43-driver lib/lwip lib/mbedtls lib/micropython-lib lib/nxp_driver lib/pico-sdk lib/stm32lib lib/tinyusb"
 
     # starts off at either the ref/pull/N/merge FETCH_HEAD, or the current branch HEAD

--- a/tools/metrics.py
+++ b/tools/metrics.py
@@ -71,6 +71,7 @@ port_data = {
     "r": PortData("nrf", "nrf", "build-PCA10040/firmware.elf"),
     "p": PortData("rp2", "rp2", "build-RPI_PICO_W/firmware.elf", "BOARD=RPI_PICO_W"),
     "d": PortData("samd", "samd", "build-ADAFRUIT_ITSYBITSY_M4_EXPRESS/firmware.elf"),
+    "v": PortData("qemu rv32", "qemu", "build-VIRT_RV32/firmware.elf", "BOARD=VIRT_RV32"),
 }
 
 


### PR DESCRIPTION
### Summary

This commit adds the Qemu-based RISC-V 32 bits `VIRT_RV32` board to the list of ports/boards to be built for measuring code size changes, as per the discussion in https://github.com/micropython/micropython/pull/15743#issuecomment-2328024612.

### Testing

Ran the tool locally on a CI-like environment.

### Trade-offs and Alternatives

In the original discussion it was mentioned the potential for the metrics collection step to take too long.  The RV32 port in question brings in as little third party code as possible and it should be relatively quick to build, all things considered (a single full build takes around a minute on an underclocked i5 laptop).  However, until there are real measurements being taken in the final environment this is all speculation.