### PR TITLE
extmod/vfs_semihosting: Add a VFS using semihosting for file I/O.

### DIFF
--- a/extmod/extmod.cmake
+++ b/extmod/extmod.cmake
@@ -66,6 +66,7 @@ set(MICROPY_SOURCE_EXTMOD
     ${MICROPY_EXTMOD_DIR}/vfs_posix.c
     ${MICROPY_EXTMOD_DIR}/vfs_posix_file.c
     ${MICROPY_EXTMOD_DIR}/vfs_reader.c
+    ${MICROPY_EXTMOD_DIR}/vfs_semihosting.c
     ${MICROPY_EXTMOD_DIR}/virtpin.c
     ${MICROPY_EXTMOD_DIR}/nimble/modbluetooth_nimble.c
 )

--- a/extmod/extmod.mk
+++ b/extmod/extmod.mk
@@ -69,6 +69,7 @@ SRC_EXTMOD_C += \
 	extmod/vfs_posix.c \
 	extmod/vfs_posix_file.c \
 	extmod/vfs_reader.c \
+	extmod/vfs_semihosting.c \
 	extmod/virtpin.c \
 	shared/libc/abort_.c \
 	shared/libc/printf.c \

--- a/extmod/modvfs.c
+++ b/extmod/modvfs.c
@@ -33,6 +33,7 @@
 #include "extmod/vfs_lfs.h"
 #include "extmod/vfs_posix.h"
 #include "extmod/vfs_rom.h"
+#include "extmod/vfs_semihosting.h"
 
 #if !MICROPY_VFS
 #error "MICROPY_PY_VFS requires MICROPY_VFS"
@@ -64,6 +65,9 @@ static const mp_rom_map_elem_t vfs_module_globals_table[] = {
     #endif
     #if MICROPY_VFS_POSIX
     { MP_ROM_QSTR(MP_QSTR_VfsPosix), MP_ROM_PTR(&mp_type_vfs_posix) },
+    #endif
+    #if MICROPY_VFS_SEMIHOSTING
+    { MP_ROM_QSTR(MP_QSTR_VfsSemihosting), MP_ROM_PTR(&mp_type_vfs_semihosting) },
     #endif
 };
 static MP_DEFINE_CONST_DICT(vfs_module_globals, vfs_module_globals_table);

--- a/extmod/vfs_semihosting.c
+++ b/extmod/vfs_semihosting.c
@@ -1,0 +1,524 @@
+/*
+ * This file is part of the MicroPython project, https://micropython.org/
+ *
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2024 Alessandro Gatti
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#include "py/builtin.h"
+#include "py/mphal.h"
+#include "py/mpthread.h"
+#include "py/runtime.h"
+#include "py/stream.h"
+#include "shared/runtime/semihosting.h"
+#include "extmod/vfs.h"
+
+#include "vfs_semihosting.h"
+
+#if MICROPY_VFS_SEMIHOSTING
+
+#if !MICROPY_ENABLE_FINALISER
+#error "The semihosting VFS requires MICROPY_ENABLE_FINALISER"
+#endif
+
+#include <unistd.h>
+
+// This VFS is here mostly to support persistent code loading from the host's
+// filesystem.  Most of the limitations here stem from the functions exposed
+// by the semihosting specification, with the most visible being the lack of
+// directory creation and file enumeration function calls.  This code doesn't
+// have security in mind, so path management is cut down to its bare minimum
+// needed to get file I/O working.
+
+typedef struct _mp_obj_vfs_semihosting_t {
+    mp_obj_base_t base;
+    vstr_t root;
+    size_t root_len;
+    bool readonly;
+    vstr_t cwd;
+} mp_obj_vfs_semihosting_t;
+
+static void trim_separators(vstr_t *vstr) {
+    while (vstr_len(vstr) > 0) {
+        if (vstr->buf[vstr_len(vstr) - 1] != '/') {
+            break;
+        }
+        vstr_cut_tail_bytes(vstr, 1);
+    }
+}
+
+static mp_obj_t build_path(mp_obj_t self_in, mp_obj_t path_in) {
+    mp_obj_vfs_semihosting_t *self = MP_OBJ_TO_PTR(self_in);
+    size_t path_length = 0;
+    const char *path = mp_obj_str_get_data(path_in, &path_length);
+    vstr_t *host_path = vstr_new(self->root_len + vstr_len(&self->cwd) + path_length + 2);
+    vstr_add_strn(host_path, self->root.buf, self->root_len);
+    if (path[0] != '/') {
+        vstr_add_str(host_path, self->cwd.buf);
+    }
+    vstr_add_str(host_path, path);
+    trim_separators(host_path);
+    mp_obj_t host_path_in = mp_obj_new_str_from_vstr(host_path);
+    vstr_free(host_path);
+    return host_path_in;
+}
+
+static mp_obj_t vfs_semihosting_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *args) {
+    mp_arg_check_num(n_args, n_kw, 0, 1, false);
+
+    mp_obj_vfs_semihosting_t *vfs = mp_obj_malloc(mp_obj_vfs_semihosting_t, type);
+    vstr_init(&vfs->root, 0);
+    if (n_args == 1) {
+        size_t root_length = 0;
+        const char *root = mp_obj_str_get_data(args[0], &root_length);
+        vstr_add_strn(&vfs->root, root, root_length);
+    }
+    trim_separators(&vfs->root);
+    vfs->root_len = vfs->root.len;
+    vfs->readonly = false;
+    vstr_init(&vfs->cwd, 1);
+    vstr_add_char(&vfs->cwd, '/');
+
+    return MP_OBJ_FROM_PTR(vfs);
+}
+
+static mp_obj_t vfs_semihosting_mount(mp_obj_t self_in, mp_obj_t readonly, mp_obj_t mkfs) {
+    mp_obj_vfs_semihosting_t *self = MP_OBJ_TO_PTR(self_in);
+    if (mp_obj_is_true(readonly)) {
+        self->readonly = true;
+    }
+    if (mp_obj_is_true(mkfs)) {
+        mp_raise_OSError(MP_EPERM);
+    }
+    return mp_const_none;
+}
+static MP_DEFINE_CONST_FUN_OBJ_3(vfs_semihosting_mount_obj, vfs_semihosting_mount);
+
+static mp_obj_t vfs_semihosting_umount(mp_obj_t self_in) {
+    (void)self_in;
+    return mp_const_none;
+}
+static MP_DEFINE_CONST_FUN_OBJ_1(vfs_semihosting_umount_obj, vfs_semihosting_umount);
+
+static mp_obj_t vfs_semihosting_open(mp_obj_t self_in, mp_obj_t path_in, mp_obj_t mode_in) {
+    return mp_vfs_semihosting_file_open(&mp_type_vfs_semihosting_textio, build_path(self_in, path_in), mode_in);
+}
+static MP_DEFINE_CONST_FUN_OBJ_3(vfs_semihosting_open_obj, vfs_semihosting_open);
+
+static mp_obj_t vfs_semihosting_chdir(mp_obj_t self_in, mp_obj_t path_in) {
+    mp_obj_vfs_semihosting_t *self = MP_OBJ_TO_PTR(self_in);
+    size_t path_length = 0;
+    const char *path = mp_obj_str_get_data(path_in, &path_length);
+    if (path[0] != '/') {
+        vstr_add_strn(&self->cwd, path, path_length);
+    } else {
+        vstr_clear(&self->cwd);
+        vstr_init(&self->cwd, path_length + 1);
+        vstr_add_strn(&self->cwd, path, path_length);
+    }
+    trim_separators(&self->cwd);
+    vstr_add_char(&self->cwd, '/');
+    return MP_OBJ_NEW_SMALL_INT(0);
+}
+static MP_DEFINE_CONST_FUN_OBJ_2(vfs_semihosting_chdir_obj, vfs_semihosting_chdir);
+
+static mp_obj_t vfs_semihosting_getcwd(mp_obj_t self_in) {
+    mp_obj_vfs_semihosting_t *self = MP_OBJ_TO_PTR(self_in);
+    return mp_obj_new_str_from_vstr(&self->cwd);
+}
+static MP_DEFINE_CONST_FUN_OBJ_1(vfs_semihosting_getcwd_obj, vfs_semihosting_getcwd);
+
+static mp_obj_t vfs_semihosting_ilistdir(mp_obj_t self_in, mp_obj_t path_in) {
+    (void)self_in;
+    (void)path_in;
+    mp_raise_NotImplementedError(MP_ERROR_TEXT("Semihosting VFS cannot list files."));
+    return mp_const_none;
+}
+static MP_DEFINE_CONST_FUN_OBJ_2(vfs_semihosting_ilistdir_obj, vfs_semihosting_ilistdir);
+
+static mp_obj_t vfs_semihosting_mkdir(mp_obj_t self_in, mp_obj_t path_in) {
+    (void)self_in;
+    (void)path_in;
+    mp_raise_NotImplementedError(MP_ERROR_TEXT("Semihosting VFS cannot create directories."));
+    return mp_const_none;
+}
+static MP_DEFINE_CONST_FUN_OBJ_2(vfs_semihosting_mkdir_obj, vfs_semihosting_mkdir);
+
+static mp_obj_t vfs_semihosting_remove(mp_obj_t self_in, mp_obj_t path_in) {
+    const char *host_path = mp_obj_str_get_str(build_path(self_in, path_in));
+    MP_THREAD_GIL_EXIT();
+    int result = mp_semihosting_remove(host_path);
+    MP_THREAD_GIL_ENTER();
+    if (result != 0) {
+        mp_raise_OSError(result);
+    }
+    return mp_const_none;
+}
+static MP_DEFINE_CONST_FUN_OBJ_2(vfs_semihosting_remove_obj, vfs_semihosting_remove);
+
+static mp_obj_t vfs_semihosting_rename(mp_obj_t self_in, mp_obj_t old_path_in, mp_obj_t new_path_in) {
+    const char *old_host_path = mp_obj_str_get_str(build_path(self_in, old_path_in));
+    const char *new_host_path = mp_obj_str_get_str(build_path(self_in, new_path_in));
+    MP_THREAD_GIL_EXIT();
+    int result = mp_semihosting_rename(old_host_path, new_host_path);
+    MP_THREAD_GIL_ENTER();
+    if (result != 0) {
+        mp_raise_OSError(result);
+    }
+    return mp_const_none;
+}
+static MP_DEFINE_CONST_FUN_OBJ_3(vfs_semihosting_rename_obj, vfs_semihosting_rename);
+
+static mp_obj_t vfs_semihosting_rmdir(mp_obj_t self_in, mp_obj_t path_in) {
+    (void)self_in;
+    (void)path_in;
+    mp_raise_NotImplementedError(MP_ERROR_TEXT("Semihosting VFS cannot remove directories."));
+    return mp_const_none;
+}
+static MP_DEFINE_CONST_FUN_OBJ_2(vfs_semihosting_rmdir_obj, vfs_semihosting_rmdir);
+
+static mp_obj_t vfs_semihosting_stat(mp_obj_t self_in, mp_obj_t path_in) {
+    (void)self_in;
+    (void)path_in;
+    mp_raise_NotImplementedError(MP_ERROR_TEXT("Semihosting VFS cannot obtain information for a file."));
+    return mp_const_none;
+}
+static MP_DEFINE_CONST_FUN_OBJ_2(vfs_semihosting_stat_obj, vfs_semihosting_stat);
+
+#if MICROPY_PY_OS_STATVFS
+static mp_obj_t vfs_semihosting_statvfs(mp_obj_t self_in, mp_obj_t path_in) {
+    (void)self_in;
+    (void)path_in;
+    mp_raise_NotImplementedError(MP_ERROR_TEXT("Semihosting VFS cannot obtain information for a filesystem."));
+    return mp_const_none;
+}
+static MP_DEFINE_CONST_FUN_OBJ_2(vfs_semihosting_statvfs_obj, vfs_semihosting_statvfs);
+#endif
+
+static const mp_rom_map_elem_t vfs_semihosting_locals_dict_table[] = {
+    { MP_ROM_QSTR(MP_QSTR_mount),    MP_ROM_PTR(&vfs_semihosting_mount_obj) },
+    { MP_ROM_QSTR(MP_QSTR_umount),   MP_ROM_PTR(&vfs_semihosting_umount_obj) },
+    { MP_ROM_QSTR(MP_QSTR_open),     MP_ROM_PTR(&vfs_semihosting_open_obj) },
+
+    { MP_ROM_QSTR(MP_QSTR_chdir),    MP_ROM_PTR(&vfs_semihosting_chdir_obj) },
+    { MP_ROM_QSTR(MP_QSTR_getcwd),   MP_ROM_PTR(&vfs_semihosting_getcwd_obj) },
+    { MP_ROM_QSTR(MP_QSTR_ilistdir), MP_ROM_PTR(&vfs_semihosting_ilistdir_obj) },
+    { MP_ROM_QSTR(MP_QSTR_mkdir),    MP_ROM_PTR(&vfs_semihosting_mkdir_obj) },
+    { MP_ROM_QSTR(MP_QSTR_remove),   MP_ROM_PTR(&vfs_semihosting_remove_obj) },
+    { MP_ROM_QSTR(MP_QSTR_rename),   MP_ROM_PTR(&vfs_semihosting_rename_obj) },
+    { MP_ROM_QSTR(MP_QSTR_rmdir),    MP_ROM_PTR(&vfs_semihosting_rmdir_obj) },
+    { MP_ROM_QSTR(MP_QSTR_stat),     MP_ROM_PTR(&vfs_semihosting_stat_obj) },
+    #if MICROPY_PY_OS_STATVFS
+    { MP_ROM_QSTR(MP_QSTR_statvfs),  MP_ROM_PTR(&vfs_semihosting_statvfs_obj) },
+    #endif
+};
+static MP_DEFINE_CONST_DICT(vfs_semihosting_locals_dict, vfs_semihosting_locals_dict_table);
+
+static mp_import_stat_t vfs_semihosting_import_stat(void *self_in, const char *path) {
+    // QEMU's semihosting implementation returns ENOENT when opening a
+    // directory, so it's not really possible to know whether the given path
+    // is a directory or just does not exist.
+
+    (void)self_in;
+    MP_THREAD_GIL_EXIT();
+    int fd = mp_semihosting_open(path, "r");
+    MP_THREAD_GIL_ENTER();
+    int errcode = 0;
+    if (fd < 0) {
+        MP_THREAD_GIL_EXIT();
+        errcode = mp_semihosting_errno();
+        MP_THREAD_GIL_ENTER();
+    } else {
+        MP_THREAD_GIL_EXIT();
+        mp_semihosting_close(fd);
+        MP_THREAD_GIL_ENTER();
+    }
+    switch (errcode) {
+        case ENOENT:
+            return MP_IMPORT_STAT_NO_EXIST;
+        case 0:
+            return MP_IMPORT_STAT_FILE;
+        default:
+            mp_raise_OSError(errcode);
+    }
+}
+
+static const mp_vfs_proto_t vfs_semihosting_proto = {
+    .import_stat = vfs_semihosting_import_stat,
+};
+
+MP_DEFINE_CONST_OBJ_TYPE(
+    mp_type_vfs_semihosting,
+    MP_QSTR_VfsSemihosting,
+    MP_TYPE_FLAG_NONE,
+    make_new, vfs_semihosting_make_new,
+    protocol, &vfs_semihosting_proto,
+    locals_dict, &vfs_semihosting_locals_dict
+    );
+
+typedef struct _mp_obj_vfs_semihosting_file_t {
+    mp_obj_base_t base;
+    mp_int_t fd;
+    mp_int_t pointer;
+} mp_obj_vfs_semihosting_file_t;
+
+static void check_fd_is_open(const mp_obj_vfs_semihosting_file_t *o) {
+    if (o->fd < 0) {
+        mp_raise_ValueError(MP_ERROR_TEXT("I/O operation on closed file"));
+    }
+}
+
+static void vfs_semihosting_file_print(const mp_print_t *print, mp_obj_t self_in, mp_print_kind_t kind) {
+    (void)kind;
+    mp_obj_vfs_semihosting_file_t *self = MP_OBJ_TO_PTR(self_in);
+    mp_printf(print, "<io.%s %d>", mp_obj_get_type_str(self_in), self->fd);
+}
+
+mp_obj_t mp_vfs_semihosting_file_open(const mp_obj_type_t *type, mp_obj_t file_in, mp_obj_t mode_in) {
+    size_t mode_length = 0;
+    const char *mode = mp_obj_str_get_data(mode_in, &mode_length);
+    vstr_t *mode_vstr = vstr_new(mode_length);
+    for (size_t index = 0; index < mode_length; index++) {
+        switch (mode[index]) {
+            case 'r':
+            case 'w':
+            case 'a':
+            case '+':
+                vstr_add_char(mode_vstr, mode[index]);
+                break;
+            case 't':
+                type = &mp_type_vfs_semihosting_textio;
+                break;
+            case 'b':
+                type = &mp_type_vfs_semihosting_fileio;
+                vstr_add_char(mode_vstr, mode[index]);
+                break;
+            default:
+                break;
+        }
+    }
+    mp_obj_vfs_semihosting_file_t *o = mp_obj_malloc_with_finaliser(mp_obj_vfs_semihosting_file_t, type);
+    MP_THREAD_GIL_EXIT();
+    o->fd = mp_semihosting_open(mp_obj_str_get_str(file_in), vstr_null_terminated_str(mode_vstr));
+    MP_THREAD_GIL_ENTER();
+    vstr_free(mode_vstr);
+    if (o->fd < 0) {
+        MP_THREAD_GIL_EXIT();
+        int errcode = mp_semihosting_errno();
+        MP_THREAD_GIL_ENTER();
+        mp_raise_OSError(errcode);
+    }
+    o->pointer = 0;
+    return MP_OBJ_FROM_PTR(o);
+}
+
+static mp_obj_t vfs_semihosting_file_fileno(mp_obj_t self_in) {
+    mp_obj_vfs_semihosting_file_t *self = MP_OBJ_TO_PTR(self_in);
+    check_fd_is_open(self);
+    return MP_OBJ_NEW_SMALL_INT(self->fd);
+}
+static MP_DEFINE_CONST_FUN_OBJ_1(vfs_semihosting_file_fileno_obj, vfs_semihosting_file_fileno);
+
+static mp_obj_t vfs_semihosting_file_tell(mp_obj_t self_in) {
+    mp_obj_vfs_semihosting_file_t *self = MP_OBJ_TO_PTR(self_in);
+    return MP_OBJ_NEW_SMALL_INT(self->pointer);
+}
+static MP_DEFINE_CONST_FUN_OBJ_1(vfs_semihosting_file_tell_obj, vfs_semihosting_file_tell);
+
+static mp_uint_t vfs_semihosting_file_read(mp_obj_t o_in, void *buf, mp_uint_t size, int *errcode) {
+    mp_obj_vfs_semihosting_file_t *o = MP_OBJ_TO_PTR(o_in);
+    check_fd_is_open(o);
+    ssize_t r;
+    MP_THREAD_GIL_EXIT();
+    r = mp_semihosting_read(o->fd, buf, size);
+    MP_THREAD_GIL_ENTER();
+    if (r < 0) {
+        MP_THREAD_GIL_EXIT();
+        *errcode = mp_semihosting_errno();
+        MP_THREAD_GIL_ENTER();
+        return MP_STREAM_ERROR;
+    }
+    assert(r <= size && "Semihosting read more data than requested.");
+    o->pointer += (size - r);
+    return (mp_uint_t)(size - r);
+}
+
+static mp_uint_t vfs_semihosting_file_write(mp_obj_t o_in, const void *buf, mp_uint_t size, int *errcode) {
+    mp_obj_vfs_semihosting_file_t *o = MP_OBJ_TO_PTR(o_in);
+    check_fd_is_open(o);
+    #if MICROPY_PY_OS_DUPTERM
+    if (o->fd <= STDERR_FILENO) {
+        mp_hal_stdout_tx_strn(buf, size);
+        return size;
+    }
+    #endif
+    ssize_t r;
+    MP_THREAD_GIL_EXIT();
+    r = mp_semihosting_write(o->fd, buf, size);
+    MP_THREAD_GIL_ENTER();
+    if (r == 0) {
+        o->pointer += size;
+        return (mp_uint_t)size;
+    }
+    MP_THREAD_GIL_EXIT();
+    *errcode = mp_semihosting_errno();
+    MP_THREAD_GIL_ENTER();
+    return MP_STREAM_ERROR;
+}
+
+static mp_uint_t vfs_semihosting_file_seek(mp_obj_vfs_semihosting_file_t *o, uintptr_t arg, int *errcode) {
+    // The semihosting specifications followed by RISC-V and Arm do not account
+    // for a `whence` parameter, and they only operate on absolute offsets.
+    // `whence` support is emulated by computing the current file size and then
+    // calculate the effective offset accounting from different starting points.
+
+    MP_THREAD_GIL_EXIT();
+    mp_int_t known_size = mp_semihosting_flen(o->fd);
+    MP_THREAD_GIL_ENTER();
+    if (known_size < 0) {
+        MP_THREAD_GIL_EXIT();
+        *errcode = mp_semihosting_errno();
+        MP_THREAD_GIL_ENTER();
+        return MP_STREAM_ERROR;
+    }
+    struct mp_stream_seek_t *s = (struct mp_stream_seek_t *)arg;
+    mp_int_t offset = s->offset;
+    switch (s->whence) {
+        case MP_SEEK_SET:
+            break;
+        case MP_SEEK_CUR:
+            offset = o->pointer + offset;
+            break;
+        case MP_SEEK_END:
+            offset = known_size + offset;
+            break;
+        default:
+            *errcode = MP_EINVAL;
+            return MP_STREAM_ERROR;
+    }
+
+    if (offset >= known_size || offset < 0) {
+        *errcode = MP_EIO;
+        return MP_STREAM_ERROR;
+    }
+
+    MP_THREAD_GIL_EXIT();
+    mp_int_t seek_result = mp_semihosting_seek(o->fd, (mp_uint_t)offset);
+    MP_THREAD_GIL_ENTER();
+    if (seek_result < 0) {
+        MP_THREAD_GIL_EXIT();
+        *errcode = mp_semihosting_errno();
+        MP_THREAD_GIL_ENTER();
+        return MP_STREAM_ERROR;
+    }
+    o->pointer = offset;
+    return 0;
+}
+
+static mp_uint_t vfs_semihosting_file_ioctl(mp_obj_t o_in, mp_uint_t request, uintptr_t arg, int *errcode) {
+    mp_obj_vfs_semihosting_file_t *o = MP_OBJ_TO_PTR(o_in);
+
+    if (request != MP_STREAM_CLOSE) {
+        check_fd_is_open(o);
+    }
+
+    switch (request) {
+        case MP_STREAM_FLUSH:
+            mp_raise_NotImplementedError(MP_ERROR_TEXT("file flushing not available with semihosting"));
+            return 0;
+
+        case MP_STREAM_SEEK:
+            return vfs_semihosting_file_seek(o, arg, errcode);
+
+        case MP_STREAM_CLOSE:
+            if (o->fd >= 0) {
+                MP_THREAD_GIL_EXIT();
+                mp_semihosting_close(o->fd);
+                MP_THREAD_GIL_ENTER();
+            }
+            o->fd = -1;
+            o->pointer = -1;
+            return 0;
+
+        case MP_STREAM_GET_FILENO:
+            return o->fd;
+
+        case MP_STREAM_POLL:
+            mp_raise_NotImplementedError(MP_ERROR_TEXT("poll on file not available with semihosting"));
+            return 0;
+
+        default:
+            *errcode = MP_EINVAL;
+            return MP_STREAM_ERROR;
+    }
+}
+
+static const mp_rom_map_elem_t vfs_semihosting_rawfile_locals_dict_table[] = {
+    { MP_ROM_QSTR(MP_QSTR_fileno),    MP_ROM_PTR(&vfs_semihosting_file_fileno_obj) },
+    { MP_ROM_QSTR(MP_QSTR_read),      MP_ROM_PTR(&mp_stream_read_obj) },
+    { MP_ROM_QSTR(MP_QSTR_readinto),  MP_ROM_PTR(&mp_stream_readinto_obj) },
+    { MP_ROM_QSTR(MP_QSTR_readline),  MP_ROM_PTR(&mp_stream_unbuffered_readline_obj) },
+    { MP_ROM_QSTR(MP_QSTR_readlines), MP_ROM_PTR(&mp_stream_unbuffered_readlines_obj) },
+    { MP_ROM_QSTR(MP_QSTR_write),     MP_ROM_PTR(&mp_stream_write_obj) },
+    { MP_ROM_QSTR(MP_QSTR_seek),      MP_ROM_PTR(&mp_stream_seek_obj) },
+    { MP_ROM_QSTR(MP_QSTR_tell),      MP_ROM_PTR(&vfs_semihosting_file_tell_obj) },
+    { MP_ROM_QSTR(MP_QSTR_flush),     MP_ROM_PTR(&mp_stream_flush_obj) },
+    { MP_ROM_QSTR(MP_QSTR_close),     MP_ROM_PTR(&mp_stream_close_obj) },
+    { MP_ROM_QSTR(MP_QSTR___del__),   MP_ROM_PTR(&mp_stream_close_obj) },
+    { MP_ROM_QSTR(MP_QSTR___enter__), MP_ROM_PTR(&mp_identity_obj) },
+    { MP_ROM_QSTR(MP_QSTR___exit__),  MP_ROM_PTR(&mp_stream___exit___obj) },
+};
+
+static MP_DEFINE_CONST_DICT(vfs_semihosting_rawfile_locals_dict, vfs_semihosting_rawfile_locals_dict_table);
+
+static const mp_stream_p_t vfs_semihosting_fileio_stream_p = {
+    .read = vfs_semihosting_file_read,
+    .write = vfs_semihosting_file_write,
+    .ioctl = vfs_semihosting_file_ioctl,
+};
+
+static const mp_stream_p_t vfs_semihosting_textio_stream_p = {
+    .read = vfs_semihosting_file_read,
+    .write = vfs_semihosting_file_write,
+    .ioctl = vfs_semihosting_file_ioctl,
+    .is_text = true,
+};
+
+MP_DEFINE_CONST_OBJ_TYPE(
+    mp_type_vfs_semihosting_fileio,
+    MP_QSTR_FileIO,
+    MP_TYPE_FLAG_ITER_IS_STREAM,
+    print, vfs_semihosting_file_print,
+    protocol, &vfs_semihosting_fileio_stream_p,
+    locals_dict, &vfs_semihosting_rawfile_locals_dict
+    );
+
+MP_DEFINE_CONST_OBJ_TYPE(
+    mp_type_vfs_semihosting_textio,
+    MP_QSTR_TextIOWrapper,
+    MP_TYPE_FLAG_ITER_IS_STREAM,
+    print, vfs_semihosting_file_print,
+    protocol, &vfs_semihosting_textio_stream_p,
+    locals_dict, &vfs_semihosting_rawfile_locals_dict
+    );
+
+#endif

--- a/extmod/vfs_semihosting.h
+++ b/extmod/vfs_semihosting.h
@@ -1,0 +1,38 @@
+/*
+ * This file is part of the MicroPython project, https://micropython.org/
+ *
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2024 Alessandro Gatti
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#ifndef MICROPY_INCLUDED_EXTMOD_VFS_SEMIHOSTING_H
+#define MICROPY_INCLUDED_EXTMOD_VFS_SEMIHOSTING_H
+
+#include "py/obj.h"
+
+extern const mp_obj_type_t mp_type_vfs_semihosting;
+extern const mp_obj_type_t mp_type_vfs_semihosting_fileio;
+extern const mp_obj_type_t mp_type_vfs_semihosting_textio;
+
+mp_obj_t mp_vfs_semihosting_file_open(const mp_obj_type_t *type, mp_obj_t file_in, mp_obj_t mode_in);
+
+#endif // MICROPY_INCLUDED_EXTMOD_VFS_SEMIHOSTING_H

--- a/ports/qemu/Makefile
+++ b/ports/qemu/Makefile
@@ -90,7 +90,6 @@ SRC_C += \
 	mcu/arm/errorhandler.c \
 	mcu/arm/startup.c \
 	mcu/arm/ticks.c \
-	shared/runtime/semihosting_arm.c \
 
 endif
 
@@ -243,6 +242,7 @@ SRC_C += \
 	shared/readline/readline.c \
 	shared/runtime/interrupt_char.c \
 	shared/runtime/pyexec.c \
+	shared/runtime/semihosting.c \
 	shared/runtime/stdout_helpers.c \
 	shared/runtime/sys_stdio_mphal.c \
 

--- a/ports/qemu/Makefile
+++ b/ports/qemu/Makefile
@@ -273,6 +273,14 @@ SRC_QSTR += $(SRC_C) $(LIBM_SRC_C)
 ################################################################################
 # Main targets
 
+ifneq ($(strip $(QEMU_FS_ROOT)),)
+ifneq ($(wildcard $(QEMU_FS_ROOT)/.),)
+QEMU_ARGS += -semihosting-config arg="-mp $(QEMU_FS_ROOT)"
+else
+$(error "$(QEMU_FS_ROOT)" is not a directory.)
+endif
+endif
+
 all: $(BUILD)/firmware.elf
 
 .PHONY: repl

--- a/ports/qemu/Makefile
+++ b/ports/qemu/Makefile
@@ -277,7 +277,7 @@ all: $(BUILD)/firmware.elf
 
 .PHONY: repl
 repl: $(BUILD)/firmware.elf
-	$(ECHO) "Use machine.reset() to exit"
+	$(ECHO) "Use \"import machine; machine.reset()\" to exit, or press CTRL+A followed by X"
 	$(QEMU_SYSTEM) $(QEMU_ARGS) -serial mon:stdio -kernel $<
 
 .PHONY: run

--- a/ports/qemu/README.md
+++ b/ports/qemu/README.md
@@ -172,3 +172,5 @@ The following options can be specified on the `make` command line:
   example, `make test_natmod TEST_NATMODS="btree heapq re"`).
 - `MICROPY_HEAP_SIZE`: pass in an optional value (in bytes) for overriding the GC
   heap size used by the port.
+- `QEMU_FS_ROOT`: pass in a local directory path to be mounted as the root filesystem
+  base in the emulated environment.

--- a/ports/qemu/main.c
+++ b/ports/qemu/main.c
@@ -32,6 +32,7 @@
 #include "py/mperrno.h"
 #include "shared/runtime/gchelper.h"
 #include "shared/runtime/pyexec.h"
+#include "shared/runtime/semihosting.h"
 
 #if MICROPY_HEAP_SIZE <= 0
 #error MICROPY_HEAP_SIZE must be a positive integer.

--- a/ports/qemu/main.c
+++ b/ports/qemu/main.c
@@ -26,6 +26,8 @@
 
 #include <stdlib.h>
 
+#include "extmod/vfs.h"
+#include "extmod/vfs_semihosting.h"
 #include "py/compile.h"
 #include "py/runtime.h"
 #include "py/gc.h"
@@ -44,8 +46,64 @@ int main(int argc, char **argv) {
     mp_cstack_init_with_sp_here(10240);
     gc_init(gc_heap, (char *)gc_heap + MICROPY_HEAP_SIZE);
 
+    #if MICROPY_VFS_SEMIHOSTING
+    // The fastest way to get something like command line pararameters into a
+    // non-Linux QEMU kernel is to use semihosting's command line argument
+    // string.  If there is no data to be put in the semihosting command
+    // buffer, QEMU puts the file name of the running kernel image in there
+    // instead (probably as an argv[0] emulation mechanism).  Anything coming
+    // in from the outside will be put in the buffer with no checks.
+    //
+    // Semihosting command buffer data can be passed from QEMU via the
+    // `-semihosting-config` command line argument, in the form
+    // '-semihosting-config arg="command line"' (the enclosing quotes will not
+    // be put in the buffer).
+    //
+    // One thing worth mentioning is the horrific lack of security of this
+    // mechanism, as besides MicroPython's honouring an optional `readonly`
+    // mount flag, the emulated interpreter is free to run havoc all through
+    // the host filesystem.
+
+    char command_line[512] = { 0 };
+    if (mp_semihosting_get_cmdline(&command_line, sizeof(command_line) - 1) != 0) {
+        mp_printf(&mp_plat_print, "Semihosting command line too long.\n");
+        exit(1);
+    }
+
+    // Since QEMU cannot have an empty buffer we have to add some command line
+    // parsing to make sure what is in there is actually an intended mountpoint
+    // and not the kernel image path.  For that, the mount point should be
+    // prefixed by the "-mp" commandline argument at position 0.
+
+    char *mountpoint = NULL;
+    if (command_line[0] == '-' && command_line[1] == 'm' &&
+        command_line[2] == 'p' && command_line[3] == ' ') {
+        // Skip any further whitespace.
+        mountpoint = &command_line[4];
+        while (*mountpoint == ' ' || *mountpoint == '\t') {
+            mountpoint++;
+        }
+        // Make sure there's something worthwhile.
+        if (*mountpoint == '\0') {
+            mountpoint = NULL;
+        }
+    }
+    #endif
+
     for (;;) {
         mp_init();
+
+        #if MICROPY_VFS_SEMIHOSTING
+        if (mountpoint) {
+            mp_obj_t mountpoint_obj = mp_obj_new_str_from_cstr(mountpoint);
+            mp_obj_t args[2] = {
+                MP_OBJ_TYPE_GET_SLOT(&mp_type_vfs_semihosting, make_new)(&mp_type_vfs_semihosting, 1, 0, &mountpoint_obj),
+                MP_OBJ_NEW_QSTR(MP_QSTR__slash_),
+            };
+            mp_vfs_mount(2, args, (mp_map_t *)&mp_const_empty_map);
+            MP_STATE_VM(vfs_cur) = MP_STATE_VM(vfs_mount_table);
+        }
+        #endif
 
         for (;;) {
             if (pyexec_mode_kind == PYEXEC_MODE_RAW_REPL) {

--- a/ports/qemu/mcu/arm/startup.c
+++ b/ports/qemu/mcu/arm/startup.c
@@ -30,7 +30,7 @@
 
 #include "py/runtime.h"
 
-#include "shared/runtime/semihosting_arm.h"
+#include "shared/runtime/semihosting.h"
 #include "uart.h"
 
 extern uint32_t _estack, _sidata, _sdata, _edata, _sbss, _ebss;
@@ -134,9 +134,8 @@ void _start(void) {
 
 void exit(int status) {
     // Force qemu to exit using ARM Semihosting
-    mp_semihosting_exit(status);
-    for (;;) {
-    }
+    mp_semihosting_terminate(MP_SEMIHOSTING_EXIT_APPLICATION_EXIT, status);
+    MP_UNREACHABLE;
 }
 
 void abort(void) {

--- a/ports/qemu/mcu/rv64/startup.c
+++ b/ports/qemu/mcu/rv64/startup.c
@@ -29,6 +29,8 @@
 #include <stdlib.h>
 
 #include "uart.h"
+#include "py/mpconfig.h"
+#include "shared/runtime/semihosting.h"
 
 extern void set_interrupt_table(void);
 extern int main(int argc, char **argv);
@@ -36,6 +38,8 @@ extern int main(int argc, char **argv);
 void _entry_point(void) {
     // Set interrupt table
     set_interrupt_table();
+    // Initialise semihosting
+    mp_semihosting_init();
     // Enable UART
     uart_init();
     // Now that we have a basic system up and running we can call main
@@ -45,30 +49,8 @@ void _entry_point(void) {
 }
 
 void exit(int status) {
-    uintptr_t semihosting_arguments[2] = { 0 };
-
-    // Exit via QEMU's RISC-V semihosting support.
-    __asm volatile (
-        ".option push            \n" // Transient options
-        ".option norvc           \n" // Do not emit compressed instructions
-        ".align 4                \n" // 16 bytes alignment
-        "mv     a1, %0           \n" // Load buffer
-        "li     t0, 0x20026      \n" // ADP_Stopped_ApplicationExit
-        "sd     t0, 0(a1)        \n" // ADP_Stopped_ApplicationExit
-        "sd     %1, 8(a1)        \n" // Exit code
-        "addi   a0, zero, 0x20   \n" // TARGET_SYS_EXIT_EXTENDED
-        "slli   zero, zero, 0x1F \n" // Entry NOP
-        "ebreak                  \n" // Give control to the debugger
-        "srai   zero, zero, 7    \n" // Semihosting call
-        ".option pop             \n" // Restore previous options set
-        :
-        : "r" (semihosting_arguments), "r" (status)
-        : "memory"
-        );
-
-    // Should never reach here.
-    for (;;) {
-    }
+    mp_semihosting_terminate(MP_SEMIHOSTING_EXIT_APPLICATION_EXIT, status);
+    MP_UNREACHABLE;
 }
 
 #ifndef NDEBUG

--- a/ports/qemu/mpconfigport.h
+++ b/ports/qemu/mpconfigport.h
@@ -69,6 +69,7 @@
 #define MICROPY_VFS                 (1)
 #define MICROPY_VFS_ROM             (1)
 #define MICROPY_VFS_ROM_IOCTL       (MICROPY_HW_ROMFS_ENABLE_PART0 || MICROPY_HW_ROMFS_ENABLE_PART1)
+#define MICROPY_VFS_SEMIHOSTING     (1)
 
 // type definitions for the specific machine
 

--- a/ports/qemu/mphalport.c
+++ b/ports/qemu/mphalport.c
@@ -27,7 +27,7 @@
 #include "py/mphal.h"
 #include "py/runtime.h"
 #include "py/stream.h"
-#include "shared/runtime/semihosting_arm.h"
+#include "shared/runtime/semihosting.h"
 #include "uart.h"
 
 // UART is better behaved with redirection under qemu-system-arm, so prefer that for stdio.
@@ -56,7 +56,7 @@ int mp_hal_stdin_rx_chr(void) {
         #endif
         #if USE_SEMIHOSTING
         char str[1];
-        int ret = mp_semihosting_rx_chars(str, 1);
+        int ret = mp_semihosting_read(mp_semihosting_stdout, str, 1);
         if (ret == 0) {
             return str[0];
         }
@@ -69,7 +69,7 @@ mp_uint_t mp_hal_stdout_tx_strn(const char *str, size_t len) {
     uart_tx_strn(str, len);
     #endif
     #if USE_SEMIHOSTING
-    mp_semihosting_tx_strn(str, len);
+    mp_semihosting_write(mp_semihosting_stdout, str, len);
     #endif
     return len;
 }

--- a/py/mpconfig.h
+++ b/py/mpconfig.h
@@ -1278,6 +1278,12 @@ typedef time_t mp_timestamp_t;
 #define MICROPY_VFS_ROM (0)
 #endif
 
+// Support for VFS Semihosting, to mount a local directory on an embedded target,
+// either emulated or under a debugger.
+#ifndef MICROPY_VFS_SEMIHOSTING
+#define MICROPY_VFS_SEMIHOSTING (0)
+#endif
+
 /*****************************************************************************/
 /* Fine control over Python builtins, classes, modules, etc                  */
 

--- a/shared/runtime/semihosting.c
+++ b/shared/runtime/semihosting.c
@@ -1,0 +1,535 @@
+/*
+ * This file is part of the MicroPython project, http://micropython.org/
+ *
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2024 Alessandro Gatti
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#include <stdbool.h>
+
+#include "semihosting.h"
+
+#if !(defined(__ARM_ARCH_ISA_A64) || defined(__ARM_ARCH_ISA_ARM) || defined(__ARM_ARCH_ISA_THUMB)) && !(defined(__riscv) && (__riscv_xlen <= 64))
+#error "Unsupported architecture."
+#endif
+
+// Features file magic header.
+#define MAGIC_SIZE 4
+#define MAGIC_0 0x53 // 'S'
+#define MAGIC_1 0x48 // 'H'
+#define MAGIC_2 0x46 // 'B'
+#define MAGIC_3 0x42 // 'F'
+
+#define CMDLINE_MIN_BUFFER_SIZE 80
+
+#define SYS_OPEN          0x01
+#define SYS_CLOSE         0x02
+#define SYS_WRITEC        0x03
+#define SYS_WRITE0        0x04
+#define SYS_WRITE         0x05
+#define SYS_READ          0x06
+#define SYS_READC         0x07
+#define SYS_ISERROR       0x08
+#define SYS_ISTTY         0x09
+#define SYS_SEEK          0x0A
+#define SYS_FLEN          0x0C
+#define SYS_TMPNAM        0x0D
+#define SYS_REMOVE        0x0E
+#define SYS_RENAME        0x0F
+#define SYS_CLOCK         0x10
+#define SYS_TIME          0x11
+#define SYS_SYSTEM        0x12
+#define SYS_ERRNO         0x13
+#define SYS_GET_CMDLINE   0x15
+#define SYS_HEAPINFO      0x16
+#define SYS_EXIT          0x18
+#define SYS_EXIT_EXTENDED 0x20
+#define SYS_ELAPSED       0x30
+#define SYS_TICKFREQ      0x31
+
+// Extended features availability flags.
+static bool exit_extended_available = false;
+static bool split_stdout_stderr = false;
+
+// Perform a semihosting call with the given call number and using the given
+// parameters block.
+int mp_semihosting_call(unsigned int num, void *arg);
+
+// Convert the given fopen(3) open mode string into the appropriate integer
+// value required by SYS_OPEN.  If the mode is invalid, it will return -1.
+static int mp_lookup_open_mode(const char *mode);
+
+// Computes the length of the given string.  If it gets passed a NULL pointer
+// it will return -1.
+static int mp_strlen(const char *string);
+
+// Check which extended features are advertised by the host system.
+static void mp_check_extended_features_availability(void);
+
+// Write the given string to the host system's debug console.
+static int mp_write_to_debug_console(const char *string, size_t length);
+
+// The host system's STDOUT file handle.
+int mp_semihosting_stdout = -1;
+
+// The host system's STDERR file handle.
+int mp_semihosting_stderr = -1;
+
+int mp_semihosting_open(const char *file_name, const char *file_mode) {
+    if (file_name == NULL || file_mode == NULL) {
+        return -1;
+    }
+
+    int file_name_length = mp_strlen(file_name);
+    if (file_name_length <= 0) {
+        return -1;
+    }
+    int file_open_mode = mp_lookup_open_mode(file_mode);
+    if (file_open_mode < 0) {
+        return -1;
+    }
+
+    uintptr_t arguments[3] = {(uintptr_t)file_name, file_open_mode, file_name_length};
+    return mp_semihosting_call(SYS_OPEN, arguments);
+}
+
+int mp_semihosting_close(int handle) {
+    uintptr_t arguments[] = {handle};
+    return mp_semihosting_call(SYS_CLOSE, arguments);
+}
+
+void mp_semihosting_writec(char character) {
+    uintptr_t arguments[] = {character};
+    mp_semihosting_call(SYS_WRITEC, arguments);
+}
+
+void mp_semihosting_write0(const char *string) {
+    if (string == NULL) {
+        return;
+    }
+    uintptr_t arguments[] = {(uintptr_t)string};
+    mp_semihosting_call(SYS_WRITE0, arguments);
+}
+
+int mp_semihosting_write(int handle, const void *data, size_t length) {
+    if (data == NULL) {
+        return length;
+    }
+    if (length == 0) {
+        return 0;
+    }
+
+    uintptr_t arguments[] = {handle, (uintptr_t)data, length};
+    return mp_semihosting_call(SYS_WRITE, arguments);
+}
+
+int mp_semihosting_read(int handle, void *data, size_t length) {
+    if (data == NULL) {
+        return -1;
+    }
+    if (length == 0) {
+        return 0;
+    }
+
+    uintptr_t arguments[] = {handle, (uintptr_t)data, length};
+    return mp_semihosting_call(SYS_READ, arguments);
+}
+
+inline int mp_semihosting_readc(void) {
+    return mp_semihosting_call(SYS_READC, NULL);
+}
+
+int mp_semihosting_iserror(int code) {
+    uintptr_t arguments[] = {code};
+    return mp_semihosting_call(SYS_ISERROR, arguments);
+}
+
+int mp_semihosting_istty(int handle) {
+    uintptr_t arguments[] = {handle};
+    return mp_semihosting_call(SYS_ISTTY, arguments);
+}
+
+int mp_semihosting_seek(int handle, unsigned int offset) {
+    uintptr_t arguments[] = {handle, offset};
+    return mp_semihosting_call(SYS_SEEK, arguments);
+}
+
+int mp_semihosting_flen(int handle) {
+    uintptr_t arguments[] = {handle};
+    return mp_semihosting_call(SYS_FLEN, arguments);
+}
+
+int mp_semihosting_tmpnam(uint8_t identifier, void *buffer, size_t buffer_length) {
+    if (buffer == NULL || buffer_length == 0) {
+        return -1;
+    }
+
+    uintptr_t arguments[] = {(uintptr_t)buffer, identifier, buffer_length};
+    return mp_semihosting_call(SYS_TMPNAM, arguments);
+}
+
+int mp_semihosting_remove(const char *file_name) {
+    if (file_name == NULL) {
+        return -1;
+    }
+
+    int file_name_length = mp_strlen(file_name);
+    if (file_name_length <= 0) {
+        return -1;
+    }
+
+    uintptr_t arguments[] = {(uintptr_t)file_name, file_name_length};
+    return mp_semihosting_call(SYS_REMOVE, arguments);
+}
+
+int mp_semihosting_rename(const char *old_name, const char *new_name) {
+    if (old_name == NULL || new_name == NULL) {
+        return -1;
+    }
+
+    int old_name_length = mp_strlen(old_name);
+    if (old_name_length <= 0) {
+        return -1;
+    }
+
+    int new_name_length = mp_strlen(new_name);
+    if (new_name_length <= 0) {
+        return -1;
+    }
+
+    uintptr_t arguments[] = {(uintptr_t)old_name, old_name_length, (uintptr_t)new_name, new_name_length};
+    return mp_semihosting_call(SYS_RENAME, arguments);
+}
+
+inline int mp_semihosting_clock(void) {
+    return mp_semihosting_call(SYS_CLOCK, NULL);
+}
+
+inline int mp_semihosting_time(void) {
+    return mp_semihosting_call(SYS_TIME, NULL);
+}
+
+int mp_semihosting_system(const char *command) {
+    if (command == NULL) {
+        return -1;
+    }
+
+    int command_length = mp_strlen(command);
+    if (command_length <= 0) {
+        return -1;
+    }
+
+    uintptr_t arguments[] = {(uintptr_t)command, command_length};
+    return mp_semihosting_call(SYS_SYSTEM, arguments);
+}
+
+inline int mp_semihosting_errno(void) {
+    return mp_semihosting_call(SYS_ERRNO, NULL);
+}
+
+int mp_semihosting_get_cmdline(void *buffer, size_t buffer_length) {
+    if (buffer == NULL || buffer_length < CMDLINE_MIN_BUFFER_SIZE) {
+        return -1;
+    }
+
+    uintptr_t arguments[] = {(uintptr_t)buffer, buffer_length};
+    return mp_semihosting_call(SYS_GET_CMDLINE, arguments);
+}
+
+void mp_semihosting_heapinfo(mp_semihosting_heap_info_t *block) {
+    if (block == NULL) {
+        return;
+    }
+
+    uintptr_t arguments[] = {(uintptr_t)block};
+    mp_semihosting_call(SYS_HEAPINFO, arguments);
+}
+
+void mp_semihosting_exit(unsigned int code, unsigned int subcode) {
+    #if defined(__ARM_ARCH_ISA_A64) || (defined(__riscv) && __riscv_xlen == 64)
+    uintptr_t arguments[] = {code, subcode};
+    mp_semihosting_call(SYS_EXIT, arguments);
+    #else
+    mp_semihosting_call(SYS_EXIT, (void *)code);
+    #endif
+    for (;;) {
+    }
+}
+
+void mp_semihosting_exit_extended(unsigned int code, unsigned int subcode) {
+    uintptr_t arguments[] = {code, subcode};
+    mp_semihosting_call(SYS_EXIT_EXTENDED, arguments);
+    for (;;) {
+    }
+}
+
+int mp_semihosting_elapsed(mp_semihosting_elapsed_ticks_t *ticks) {
+    if (ticks == NULL) {
+        return -1;
+    }
+
+    uintptr_t arguments[] = {(uintptr_t)ticks};
+    return mp_semihosting_call(SYS_ELAPSED, arguments);
+}
+
+inline int mp_semihosting_tickfreq(void) {
+    return mp_semihosting_call(SYS_TICKFREQ, NULL);
+}
+
+void mp_semihosting_init() {
+    mp_check_extended_features_availability();
+    mp_semihosting_stdout = mp_semihosting_open(":tt", "w");
+    if (split_stdout_stderr) {
+        mp_semihosting_stderr = mp_semihosting_open(":tt", "a");
+    } else {
+        mp_semihosting_stderr = mp_semihosting_stdout;
+    }
+}
+
+void mp_check_extended_features_availability(void) {
+    int features_handle = mp_semihosting_open(":semihosting-features", "r");
+    if (features_handle < 0) {
+        return;
+    }
+
+    uint8_t magic_buffer[MAGIC_SIZE];
+    if (mp_semihosting_flen(features_handle) < sizeof(magic_buffer)) {
+        mp_semihosting_close(features_handle);
+        return;
+    }
+
+    if (mp_semihosting_read(features_handle, magic_buffer, sizeof(magic_buffer)) != 0) {
+        mp_semihosting_close(features_handle);
+        return;
+    }
+
+    if (magic_buffer[0] != MAGIC_0 || magic_buffer[1] != MAGIC_1 ||
+        magic_buffer[2] != MAGIC_2 || magic_buffer[3] != MAGIC_3) {
+        mp_semihosting_close(features_handle);
+        return;
+    }
+
+    uint8_t features_byte = 0;
+    if (mp_semihosting_read(features_handle, &features_byte, sizeof(features_byte)) != 0) {
+        mp_semihosting_close(features_handle);
+        return;
+    }
+
+    mp_semihosting_close(features_handle);
+
+    exit_extended_available = (features_byte & 0x01) != 0;
+    split_stdout_stderr = (features_byte & 0x02) != 0;
+}
+
+int mp_strlen(const char *string) {
+    int length = 0;
+    while (*string++ != 0) {
+        length += 1;
+    }
+    return length;
+}
+
+int mp_lookup_open_mode(const char *mode) {
+    if (mode == NULL) {
+        return -1;
+    }
+
+    int mode_found;
+
+    switch (mode[0]) {
+        case 'r':
+            mode_found = 0x00;
+            break;
+        case 'w':
+            mode_found = 0x04;
+            break;
+        case 'a':
+            mode_found = 0x08;
+            break;
+        default:
+            return -1;
+    }
+
+    switch (mode[1]) {
+        case 'b':
+            mode_found |= 0x01;
+            break;
+        case '+':
+            mode_found |= 0x02;
+            break;
+        case '\0':
+            return mode_found;
+        default:
+            return -1;
+    }
+
+    switch (mode[2]) {
+        case 'b':
+            if (mode_found & 0x01) {
+                // 'b' was already seen.
+                return -1;
+            }
+            mode_found |= 1;
+            break;
+        case '+':
+            if (mode_found & 0x02) {
+                // '+' was already seen.
+                return -1;
+            }
+            mode_found |= 2;
+            break;
+        case '\0':
+            return mode_found;
+        default:
+            return -1;
+    }
+
+    return mode[3] == '\0' ? mode_found : -1;
+}
+
+#if defined(__riscv)
+static uintptr_t mp_riscv_call(unsigned int call_number, void *arguments) {
+    register uintptr_t call_number_register asm ("a0") = call_number;
+    register const void *arguments_register asm ("a1") = arguments;
+
+    asm volatile (
+        ".balign 16              \n" // 16 bytes alignment
+        ".option push            \n" // Transient options
+        ".option norvc           \n" // Do not emit compressed instructions
+        "slli   zero, zero, 0x1F \n" // Entry NOP
+        "ebreak                  \n" // Give control to the debugger
+        "srai   zero, zero, 7    \n" // Semihosting call
+        ".option pop             \n" // Restore previous options set
+        : "+r" (call_number_register)
+        : "r" (call_number_register), "r" (arguments_register)
+        : "memory"
+        );
+
+    return call_number_register;
+}
+#endif
+
+#if defined(__ARM_ARCH_ISA_ARM) || defined(__ARM_ARCH_ISA_THUMB)
+static uintptr_t mp_aarch32_call(unsigned int call_number, void *arguments) {
+    register uintptr_t call_number_register asm ("r0") = call_number;
+    register const void *arguments_register asm ("r1") = arguments;
+
+    asm volatile (
+        #if defined(__ARM_ARCH_ISA_ARM)
+        "svc 0x00123456 \n"
+        #elif defined(__ARM_ARCH_ISA_THUMB)
+        "bkpt 0xAB      \n"
+        #endif
+        : "+r" (call_number_register)
+        : "r" (arguments_register)
+        : "memory"
+        );
+
+    return call_number_register;
+}
+#endif
+
+#if defined(__ARM_ARCH_ISA_A64)
+static uintptr_t mp_aarch64_call(unsigned int call_number, void *arguments) {
+    register uintptr_t call_number_register asm ("w0") = call_number;
+    register const void *arguments_register asm ("x1") = arguments;
+    register uintptr_t return_register asm ("x0");
+
+    asm volatile (
+        "hlt  0xF000 \n"
+        "uxtw x0, x0 \n"
+        : "r" (return_register)
+        : "r" (call_number_register), "r" (arguments_register)
+        : "memory"
+        );
+
+    return return_register;
+}
+#endif
+
+inline int mp_semihosting_call(unsigned int num, void *arg) {
+    #if defined(__ARM_ARCH_ISA_A64)
+    return mp_aarch64_call(num, arg);
+    #elif defined(__ARM_ARCH_ISA_ARM) || defined(__ARM_ARCH_ISA_THUMB)
+    return mp_aarch32_call(num, arg);
+    #elif defined(__riscv)
+    return mp_riscv_call(num, arg);
+    #else
+    #error "Unsupported architecture."
+    #endif
+}
+
+inline int mp_semihosting_rx_char() {
+    return mp_semihosting_call(SYS_READC, NULL);
+}
+
+int mp_write_to_debug_console(const char *string, size_t length) {
+    if (length == 0) {
+        return 0;
+    }
+
+    if (length == 1) {
+        mp_semihosting_writec(*string);
+        return 0;
+    }
+
+    return mp_semihosting_write(mp_semihosting_stdout, string, length);
+}
+
+void mp_semihosting_terminate(unsigned int code, unsigned int subcode) {
+    if (exit_extended_available) {
+        mp_semihosting_exit_extended(code, subcode);
+    } else {
+        mp_semihosting_exit(code, subcode);
+    }
+}
+
+int mp_semihosting_tx_strn(const char *string, size_t length) {
+    if (string == NULL) {
+        return -1;
+    }
+
+    return mp_write_to_debug_console(string, length);
+}
+
+int mp_semihosting_tx_strn_cooked(const char *string, size_t length) {
+    if (string == NULL) {
+        return -1;
+    }
+
+    if (length == 0) {
+        return 0;
+    }
+
+    size_t current_offset = 0;
+    for (size_t index = 0; index < length; index++) {
+        if (string[index] != '\n') {
+            continue;
+        }
+
+        mp_write_to_debug_console(string + current_offset, index - current_offset);
+        mp_semihosting_writec('\r');
+        current_offset = index;
+    }
+
+    return mp_write_to_debug_console(string + current_offset, length - current_offset);
+}

--- a/shared/runtime/semihosting.h
+++ b/shared/runtime/semihosting.h
@@ -1,0 +1,255 @@
+/*
+ * This file is part of the MicroPython project, http://micropython.org/
+ *
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2024 Alessandro Gatti
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#ifndef MICROPY_INCLUDED_SHARED_RUNTIME_SEMIHOSTING_H
+#define MICROPY_INCLUDED_SHARED_RUNTIME_SEMIHOSTING_H
+
+/*
+ * This file contains semihosting implementations for Arm AArch32 and AArch64,
+ * and for RISC-V RV32 and RV64.
+ *
+ * RISC-V follows the Arm semihosting specifications, thus making one single
+ * implementation possible.  The specifications followed are:
+ *
+ * - "Semihosting for AArch32 and AArch64", revision 2023Q3
+ *   https://github.com/ARM-software/abi-aa/releases/download/2023Q3/semihosting.pdf
+ * - "RISC-V Semihosting", version 0.6
+ *   https://github.com/riscv-non-isa/riscv-semihosting/releases/download/0.6/riscv-semihosting.pdf
+ *
+ * To integrate semihosting, make sure to call mp_semihosting_init() first.
+ * Then, if the host system's STDOUT should be used instead of a UART, replace
+ * mp_hal_stdin_rx_chr and similar calls in mphalport.c with the semihosting
+ * equivalents.
+ *
+ * At runtime, make sure that the debugger is attached and semihosting is
+ * enabled on its end.  The terminal must be configured in raw mode with local
+ * echo disabled, on Linux this can be done with "stty raw -echo" on the
+ * command line.
+ */
+
+#include <stddef.h>
+#include <stdint.h>
+
+#include "py/mpconfig.h"
+
+// A container for heap and stack pointers as returned by SYS_HEAPINFO.
+typedef struct {
+    void *heap_base;
+    void *heap_limit;
+    void *stack_base;
+    void *stack_limit;
+} mp_semihosting_heap_info_t;
+
+// A 64-bits value indicating how many ticks were counted since the target
+// image's execution started.
+typedef union {
+    struct {
+        uint32_t low;
+        uint32_t high;
+    } split;
+    uint64_t ticks;
+} mp_semihosting_elapsed_ticks_t;
+
+// The host system's STDOUT file handle.
+extern int mp_semihosting_stdout;
+
+// The host system's STDERR file handle.  If the host system does not support
+// explicit STDOUT and STDERR handles, this handle will be aliased to STDOUT
+// instead.
+extern int mp_semihosting_stderr;
+
+/*
+ * All the defined exit codes present in the Arm specification are defined
+ * down below.  Exit codes from 0x20000 to 0x2001F represent specific hardware
+ * event that may or may not occur on a RISC-V CPU.
+ */
+
+enum {
+    MP_SEMIHOSTING_EXIT_BRANCH_THROUGH_ZERO = 0x20000,
+    MP_SEMIHOSTING_EXIT_UNDEFINED_INSTRUCTION,
+    MP_SEMIHOSTING_EXIT_SOFTWARE_INTERRUPT,
+    MP_SEMIHOSTING_EXIT_PREFETCH_ABORT,
+    MP_SEMIHOSTING_EXIT_DATA_ABORT,
+    MP_SEMIHOSTING_EXIT_ADDRESS_EXCEPTION,
+    MP_SEMIHOSTING_EXIT_IRQ,
+    MP_SEMIHOSTING_EXIT_FIQ,
+    MP_SEMIHOSTING_EXIT_BREAKPOINT = 0x20020,
+    MP_SEMIHOSTING_EXIT_WATCHPOINT,
+    MP_SEMIHOSTING_EXIT_STEP_COMPLETE,
+    MP_SEMIHOSTING_EXIT_RUNTIME_ERROR_UNKNOWN,
+    MP_SEMIHOSTING_EXIT_INTERNAL_ERROR,
+    MP_SEMIHOSTING_EXIT_USER_INTERRUPTION,
+    MP_SEMIHOSTING_EXIT_APPLICATION_EXIT,
+    MP_SEMIHOSTING_EXIT_STACK_OVERFLOW,
+    MP_SEMIHOSTING_EXIT_DIVISION_BY_ZERO,
+    MP_SEMIHOSTING_EXIT_OS_SPECIFIC
+};
+
+// Initialises semihosting support.
+void mp_semihosting_init();
+
+// Read a character from the host system's STDIN stream.
+int mp_semihosting_rx_char();
+
+// Write the given string to the host system's STDOUT stream.
+int mp_semihosting_tx_strn(const char *string, size_t length);
+
+// Write the given string to the host system's STDOUT stream, writing a CR byte
+// before each LF byte to be written.
+int mp_semihosting_tx_strn_cooked(const char *string, size_t length);
+
+// Terminates execution with the given code and an optional subcode.  This
+// will choose the appropriate semihosting call (either SYS_EXIT or
+// SYS_EXIT_EXTENDED) depending on the host system's reported capabilities.
+MP_NORETURN void mp_semihosting_terminate(unsigned int code, unsigned int subcode);
+
+// Direct semihosting calls access.
+
+// Open a file on the host system with the given name and file mode.
+// The file mode follows fopen(3)'s syntax.  The function will return -1 if it
+// failed to open the required file, or a file handle number if the operation
+// succeeded.  To see why the operation failed, call mp_semihosting_errno.
+int mp_semihosting_open(const char *file_name, const char *file_mode);
+
+// Close a file previously opened with mp_semihosting_open.  If the file cannot
+// be closed, the function will return -1, otherwise it will return 0.  To see
+// why the operation failed, call mp_semihosting_errno.
+int mp_semihosting_close(int handle);
+
+// Write the given character to the host system's STDOUT file handle.
+void mp_semihosting_writec(char character);
+
+// Write the given NULL-terminated string to the host system's STDOUT file
+// handle.
+void mp_semihosting_write0(const char *string);
+
+// Write the given buffer to the given host system file handle.  The function
+// will return how many characters were left to be written (0 if the operation
+// wrote the whole buffer), or -1 if the input buffer pointer is NULL.
+int mp_semihosting_write(int handle, const void *data, size_t length);
+
+// Read from the given host system file handle into the given buffer. The
+// function will return how many characters were left to be read (0 if the
+// operation read whole buffer), or -1 if the input buffer pointer is NULL.
+int mp_semihosting_read(int handle, void *data, size_t length);
+
+// Read a single character from the host system's STDIN file handle.
+int mp_semihosting_readc(void);
+
+// Check whether the given result code represents an error.  The function will
+// return a non-zero value if the code is indeed an error, or zero otherwise.
+int mp_semihosting_iserror(int code);
+
+// Check whether the given host system file handle is mapped to an interactive
+// device.  The function will return 1 if the handle is mapped to an
+// interactive device, 0 if it is mapped to a regular file, and anything else
+// if an error occurred.
+int mp_semihosting_istty(int handle);
+
+// Move the file pointer on the given host system's file handle to the given
+// absolute offset (in bytes).  The function will return 0 if the file pointer
+// was moved to the requested position, or a negative value if it was not
+// possible to do so.  To see why the operation failed, call
+// mp_semihosting_errno.
+int mp_semihosting_seek(int handle, unsigned int offset);
+
+// Get the length (in bytes) of the host system's file mapped to the given
+// handle.  The function will return a negative value if an error occurred, or
+// the requested file's length (in bytes).
+int mp_semihosting_flen(int handle);
+
+// Create a temporary file on the host system.  The function requires a file
+// identifier between 0 and 255 (inclusive) that will be bound to the requested
+// temporary file.  Subsequent calls to mp_semihosting_tmpnam with the same
+// identifier will always return the same host system file name.  On success,
+// the function will fill the given buffer with the host system's file name,
+// and will return 0.  If the buffer pointer is NULL, the buffer name area is
+// too small, or the operation failed on the host system's end, the function
+// will return -1 instead.  Make sure that the buffer is big enough to contain
+// a host system's full path name.
+int mp_semihosting_tmpnam(uint8_t identifier, void *buffer, size_t buffer_length);
+
+// Delete a file on the host system's matching the given file name.  The
+// function will return 0 if the deletion operation succeeded, or a host system
+// dependent error code instead.
+int mp_semihosting_remove(const char *file_name);
+
+// Rename a file on the host system's name matching the given file name to the
+// new chosen name.  The function will return 0 if the rename operation
+// succeeded, or a host system dependent error code instead.
+int mp_semihosting_rename(const char *old_name, const char *new_name);
+
+// Get how many hundredths of a second passed since execution started.  If an
+// error occurred whilst retrieving clock value, the function will return -1.
+int mp_semihosting_clock(void);
+
+// Get the host system's clock in seconds since midnight of January 1st, 1970
+// at UTC.
+int mp_semihosting_time(void);
+
+// Execute the given command on the host system.  The function will return the
+// command's result code retrieved on the host system.
+int mp_semihosting_system(const char *command);
+
+// Get the last operation's status code.  The function will return the host
+// system's errno variable contents, and can be used to see the exact result
+// code for failed I/O operations.
+int mp_semihosting_errno(void);
+
+// Get the host system's command line that started execution of the target
+// image.  The function will fill the given buffer with the command line
+// arguments passed to the target executable.  The function will return 0 on
+// success, or -1 if it failed.  Make sure that the buffer can contain at
+// least 80 bytes, as it is the minimum supported size defined by the
+// specifications document.
+int mp_semihosting_get_cmdline(void *buffer, size_t buffer_length);
+
+// Fill the given heap info structure with the system's stack and heap
+// start/end addresses.
+void mp_semihosting_heapinfo(mp_semihosting_heap_info_t *block);
+
+// Terminate the execution with the given reason code and optional subcode.
+// This should be preferred over mp_semihosting_exit_extended if the host
+// system does not support the SYS_EXIT_EXTENDED semihosting call.  In doubt
+// use mp_semihosting_terminate instead.
+MP_NORETURN void mp_semihosting_exit(unsigned int code, unsigned int subcode);
+
+// Terminate the execution with the given reason code and optional subcode.
+// This should be preferred over mp_semihosting_exit if the host system
+// supports this semihosting call.  In doubt use mp_semihosting_terminate
+// instead.
+MP_NORETURN void mp_semihosting_exit_extended(unsigned int code, unsigned int subcode);
+
+// Fill the given structure with how many ticks were counted since execution
+// started.  On success, the function will return 0, or -1 if it was not
+// possible to compute the ticks count.
+int mp_semihosting_elapsed(mp_semihosting_elapsed_ticks_t *ticks);
+
+// Get the system's tick frequency.  If this value is not known, the function
+// will return -1 instead.
+int mp_semihosting_tickfreq(void);
+
+#endif // MICROPY_INCLUDED_SHARED_RUNTIME_SEMIHOSTING_H


### PR DESCRIPTION
### Summary

This contains a VFS implementation that uses semihosting as a file I/O call interface, allowing the code to access files located either in the host machine (if using QEMU), or in the machine where the debugger is running on (if using SWD/JTAG).  The implementation is meant to be only used to aid in debugging in very specific cases, and it is rather limited due to what the Arm/RISC-V semihosting specification offers.  The following features are not available: flush, poll, stat (both file and vfs), ilistdir, mkdir, and rmdir.

The Arm and RISC-V semihosting implementations have been merged into one single file with the same interface, with the only difference being the semihosting call entry point.  I've added the Arm semihosting call code to the RISC-V implementation because all the file I/O functions were already implemented there.  Semihosting support was also extended to AArch64 and RV64 targets.  The old platform-specific files have been left alone, not sure if they have any further use, but I can always update the PR to remove them.

This feature was originally written for a situation where it made sense to be available on real hardware, but then I realised it could help with ~~natmod testing, so I migrated this to run on QEMU.  For that, the import machinery may require some changes to accommodate for semihosting limitations.  The reason being that it seems there is no way to know if a path points to a file, to a directory, or to some other special entity.  With QEMU's semihosting implementation, opening a directory as if it was a file returns ENOENT (instead of EISDIR), the same as if the file wasn't there, but maybe it is enough for MPY files?~~ a subset of generic filesystem operations.

### Testing

VFS testing has been done manually on QEMU (VIRT_RV32, MPS2_AN385, and SABRELITE boards), as I'm not sure what is the proper way to add this to the CI pipeline though.  Regarding the rest of the semihosting calls, most of them were tested on RV32 when debugging the native RV32 emitter back then, the code is virtually the same.

### Trade-offs and Alternatives

On real boards, using `mpremote mount` can be an option, but it requires allocating a serial port to let it talk with the device's REPL - if a REPL is actually present to begin with.  With semihosting all serial ports are available for the board to use as the SWD/JTAG communication channel will be used for file I/O instead.

This has potential security implications if used incorrectly.  Since the usage of this feature is restricted to very specific cases, there may be issues regarding unexpected path traversals and I/O on files outside the local root.  It is disabled by default except for the QEMU port (and must be explicitly activated on the command line), as it can be helpful when testing.