### PR TITLE
ports/rp2: Include check for CYW43_GPIO in machine_pin_cyw43.c

### DIFF
--- a/ports/rp2/machine_pin_cyw43.c
+++ b/ports/rp2/machine_pin_cyw43.c
@@ -30,7 +30,7 @@
 #include "py/runtime.h"
 #include "py/mphal.h"
 
-#if defined(MICROPY_PY_NETWORK_CYW43) && defined(MICROPY_HW_PIN_EXT_COUNT)
+#if defined(MICROPY_PY_NETWORK_CYW43) && defined(MICROPY_HW_PIN_EXT_COUNT) && defined(CYW43_GPIO) && CYW43_GPIO == 1
 
 #include "modmachine.h"
 #include "machine_pin.h"
@@ -83,4 +83,4 @@ void machine_pin_ext_config(machine_pin_obj_t *self, int mode, int value) {
     }
 }
 
-#endif // defined(MICROPY_PY_NETWORK_CYW43) && defined(MICROPY_HW_PIN_EXT_COUNT)
+#endif // defined(MICROPY_PY_NETWORK_CYW43) && defined(MICROPY_HW_PIN_EXT_COUNT) && defined(CYW43_GPIO) && CYW43_GPIO == 1


### PR DESCRIPTION
When doing some experiments with IO expander support for the Pimoroni Yukon, I discovered that the `#if` check in `machine_pin_cyw43.c` only checks that `MICROPY_PY_NETWORK_CYW43` and `MICROPY_HW_PIN_EXT_COUNT` are defined.

This is a reasonable assumption for the Pico W, but causes conflicts if someone (such as myself) wants to attach an external IO expander to their Pico W and have its pins appear as `Pin` objects.

This PR addresses this by adding the additional checks for `defined(CYW43_GPIO) && CYW43_GPIO == 1` to `machine_pin_cyw43.c` letting board builds include wireless but separately choose whether the external IO pins come from the cyw43 or not.

The long term solution of course would be to allow for multiple external pin types, but that feels like a bigger discussion, and is more than I currently require anyway.