### PR TITLE
esp32/i2c: Use idf function for calculating main timeout.

### DIFF
--- a/ports/esp32/machine_i2c.c
+++ b/ports/esp32/machine_i2c.c
@@ -257,7 +257,7 @@ static void machine_hw_i2c_init(machine_hw_i2c_obj_t *self, bool first_init) {
         .master.clk_speed = self->freq,
     };
     i2c_param_config(self->port, &conf);
-    int timeout = I2C_SCLK_FREQ / 1000000 * self->timeout_us;
+    int timeout = i2c_ll_calculate_timeout_us_to_reg_val(I2C_SCLK_FREQ, self->timeout_us);
     i2c_set_timeout(self->port, (timeout > I2C_LL_MAX_TIMEOUT) ? I2C_LL_MAX_TIMEOUT : timeout);
     i2c_driver_install(self->port, I2C_MODE_MASTER, 0, 0, 0);
 }


### PR DESCRIPTION
<!-- Thanks for submitting a Pull Request! We appreciate you spending the
     time to improve MicroPython. Please provide enough information so that
     others can review your Pull Request.

     Before submitting, please read:
     https://github.com/micropython/micropython/blob/master/CODEOFCONDUCT.md
     https://github.com/micropython/micropython/wiki/ContributorGuidelines

     Please check any CI failures that appear after your Pull Request is opened.
-->

### Summary

The esp32 I2C driver sets a global timeout during init. The functionality for this is currently only correct for original esp32 and esp32-s2, newer parts have a slightly different argument.

When searching through the IDF code for this driver I found this function that handles the chip-specific differences.

ESP32-S2
![image](https://github.com/user-attachments/assets/a3d3d5eb-11dd-4b52-8f89-8dc91a8285a9)

ESP32-S3
![image](https://github.com/user-attachments/assets/ee8eb445-5ce5-40b0-950e-edfdfdd7eaf1)


### Testing

This has been implemented from the reference manual & inspecting the IDF codebase, I haven't pysically tested it so far.
