### PR TITLE
py/objstr.c: throw exception for invalid encodings

### DIFF
--- a/py/objstr.c
+++ b/py/objstr.c
@@ -1951,6 +1951,12 @@ static mp_obj_t bytes_decode(size_t n_args, const mp_obj_t *args) {
         args = new_args;
         n_args++;
     }
+    else if (n_args == 2) {
+        if (args[1] != MP_OBJ_NEW_QSTR(MP_QSTR_utf_hyphen_8) && args[1] != MP_OBJ_NEW_QSTR(MP_QSTR_ascii)) {
+            mp_raise_ValueError(MP_ERROR_TEXT("only utf-8 and ascii encodings are supported"));
+        }
+    }
+
     return mp_obj_str_make_new(&mp_type_str, n_args, 0, args);
 }
 MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(bytes_decode_obj, 1, 3, bytes_decode);

--- a/py/objstr.c
+++ b/py/objstr.c
@@ -1950,8 +1950,7 @@ static mp_obj_t bytes_decode(size_t n_args, const mp_obj_t *args) {
         new_args[1] = MP_OBJ_NEW_QSTR(MP_QSTR_utf_hyphen_8);
         args = new_args;
         n_args++;
-    }
-    else if (n_args == 2) {
+    } else if (n_args == 2) {
         if (args[1] != MP_OBJ_NEW_QSTR(MP_QSTR_utf_hyphen_8) && args[1] != MP_OBJ_NEW_QSTR(MP_QSTR_ascii)) {
             mp_raise_ValueError(MP_ERROR_TEXT("only utf-8 and ascii encodings are supported"));
         }

--- a/tests/basics/bytearray_decode.py
+++ b/tests/basics/bytearray_decode.py
@@ -4,3 +4,12 @@ try:
 except AttributeError:
     print("SKIP")
     raise SystemExit
+
+print(bytearray(b'').decode('utf-8'))
+print(bytearray(b'abc').decode('ascii'))
+
+try:
+    print(bytearray(b'abc').decode('InvalidEncoding'))
+except ValueError:
+    print("SKIP")
+    raise SystemExit


### PR DESCRIPTION
### Summary

A fix to this issue https://github.com/micropython/micropython/issues/15849
Which throws and exception for invalid encoding types instead of silently ignoring them.


### Testing
Built and run on a pyboard


### Trade-offs and Alternatives
Adds extra code but is more obvious to the user what is incorrect.

