### PR TITLE
rp2/cyw43_configport: Define CYW43_PRINTF to mp_printf to get messages.

### DIFF
--- a/ports/rp2/cyw43_configport.h
+++ b/ports/rp2/cyw43_configport.h
@@ -27,6 +27,7 @@
 #define MICROPY_INCLUDED_RP2_CYW43_CONFIGPORT_H
 
 // The board-level config will be included here, so it can set some CYW43 values.
+#include <stdio.h>
 #include "py/mpconfig.h"
 #include "py/mperrno.h"
 #include "py/mphal.h"
@@ -39,6 +40,7 @@
 #define CYW43_SLEEP_MAX                 (10)
 #define CYW43_NETUTILS                  (1)
 #define CYW43_USE_OTP_MAC               (1)
+#define CYW43_PRINTF(...)               mp_printf(MP_PYTHON_PRINTER, __VA_ARGS__)
 
 #define CYW43_EPERM                     MP_EPERM // Operation not permitted
 #define CYW43_EIO                       MP_EIO // I/O error


### PR DESCRIPTION
### Summary

The cyw43-driver uses `printf` by default for `CYW43_PRINTF`, but on the rp2 port `printf` only goes to a UART output and not to USB CDC.

By defining `CYW43_PRINTF` to `mp_printf`, all the messages from the cyw43-driver are seen on USB CDC.

For example this allows `network.WLAN().config(trace=1)` to show async WALN events.

### Testing

Tested on Pico W doing `network.WLAN().config(trace=1)` and connecting to an AP, it shows messages like:
```
[   30101] ASYNC(0000,ASSOC_REQ_IE,0,0,0)
[   30102] ASYNC(0000,AUTH,0,0,0)
[   30106] ASYNC(0000,ASSOC_RESP_IE,0,0,0)
[   30106] ASYNC(0000,ASSOC,0,0,0)
[   30106] ASYNC(0001,LINK,0,0,0)
[   30120] ASYNC(0000,JOIN,0,0,0)
[   30120] ASYNC(0000,SET_SSID,0,0,0)
[   30140] ASYNC(0000,PSK_SUP,6,0,0)
```