### PR TITLE
pic16bit: Make it build with recent XC16 versions.

### DIFF
--- a/ports/pic16bit/Makefile
+++ b/ports/pic16bit/Makefile
@@ -7,7 +7,7 @@ QSTR_DEFS = qstrdefsport.h
 include $(TOP)/py/py.mk
 include $(TOP)/extmod/extmod.mk
 
-XCVERSION ?= 1.35
+XCVERSION ?= 2.10
 XC16 ?= /opt/microchip/xc16/v$(XCVERSION)
 CROSS_COMPILE ?= $(XC16)/bin/xc16-
 
@@ -31,7 +31,7 @@ CFLAGS += -O1 -DNDEBUG
 endif
 
 LDFLAGS += --heap=0 -nostdlib -T $(XC16)/support/$(PARTFAMILY)/gld/p$(PART).gld -Map=$@.map --cref -p$(PART)
-LIBS += -L$(XC16)/lib -L$(XC16)/lib/$(PARTFAMILY) -lc -lm -lpic30
+LIBS += -L$(XC16)/lib -L$(XC16)/lib/$(PARTFAMILY) -lc99-elf -lm-elf -lc99-pic30-elf
 
 SRC_C = \
 	main.c \

--- a/ports/pic16bit/mpconfigport.h
+++ b/ports/pic16bit/mpconfigport.h
@@ -93,7 +93,3 @@ typedef int mp_off_t;
 #define MICROPY_MPHALPORT_H "pic16bit_mphal.h"
 #define MICROPY_HW_BOARD_NAME "dsPICSK"
 #define MICROPY_HW_MCU_NAME "dsPIC33"
-
-// XC16 toolchain doesn't seem to define these
-typedef int intptr_t;
-typedef unsigned int uintptr_t;

--- a/py/misc.h
+++ b/py/misc.h
@@ -380,6 +380,18 @@ static inline bool mp_check(bool value) {
 
 // mp_int_t can be larger than long, i.e. Windows 64-bit, nan-box variants
 static inline uint32_t mp_clz_mpi(mp_int_t x) {
+    #ifdef __XC16__
+    mp_uint_t mask = MP_OBJ_WORD_MSBIT_HIGH;
+    mp_uint_t zeroes = 0;
+    while (mask != 0) {
+        if (mask & (mp_uint_t)x) {
+            break;
+        }
+        zeroes++;
+        mask >>= 1;
+    }
+    return zeroes;
+    #else
     MP_STATIC_ASSERT(sizeof(mp_int_t) == sizeof(long long)
         || sizeof(mp_int_t) == sizeof(long));
 
@@ -389,6 +401,7 @@ static inline uint32_t mp_clz_mpi(mp_int_t x) {
     } else {
         return mp_clzll((unsigned long long)x);
     }
+    #endif
 }
 
 #endif // MICROPY_INCLUDED_PY_MISC_H


### PR DESCRIPTION
### Summary

The `pic16bit` port was left behind and didn't build anymore on recent compilers.  This PR contains the necessary modifications to make the code build on the currently latest version of xc16 (2.10).

The only code change needed is an implementation of `mp_clz_mpi`, which it requires its own implementation.  The build will fail with a missing reference to `__clzhi2` otherwise, and that symbol doesn't seem to be defined anywhere.

*I've been trying to repurpose a PIC24F board with a new firmware and since MicroPython seems to have a port for it, why not.  I understand that maybe the `pic16bit` port is still lingering around for historical reasons and that this PR is now out of scope for the project, but letting these changes build up dust on my machine isn't much better :)*

### Testing

This PR contains only the platform-generic changes I've made to the port to make it work on a PIC24F.  However, as I don't have a dsPIC33 target board to test this against, I can at least claim it now compiles out of the box without errors.

That said, the code builds and there is at least [one report](https://github.com/micropython/micropython/issues/15868#issuecomment-2358350157) of these changes working on a dsPIC33 in #15868.
