### PR TITLE
unix/modffi: Let RV64 pass FFI tests again.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,8 +11,9 @@ build/
 build-*/
 docs/genrst/
 
-# Test failure outputs
+# Test failure outputs and intermediate artefacts
 tests/results/*
+tests/ports/unix/ffi_lib.so
 
 # Python cache files
 __pycache__/

--- a/.gitmodules
+++ b/.gitmodules
@@ -3,7 +3,7 @@
 	url = https://github.com/micropython/axtls.git
 [submodule "lib/libffi"]
 	path = lib/libffi
-	url = https://github.com/atgreen/libffi
+	url = https://github.com/libffi/libffi
 [submodule "lib/lwip"]
 	path = lib/lwip
 	url = https://github.com/lwip-tcpip/lwip.git

--- a/ports/unix/Makefile
+++ b/ports/unix/Makefile
@@ -168,7 +168,7 @@ ifeq ($(MICROPY_STANDALONE),1)
 # Build libffi from source.
 GIT_SUBMODULES += lib/libffi
 DEPLIBS += libffi
-LIBFFI_CFLAGS := -I$(shell ls -1d $(BUILD)/lib/libffi/out/lib/libffi-*/include)
+LIBFFI_CFLAGS := -I$(shell ls -1d $(BUILD)/lib/libffi/include)
  ifeq ($(MICROPY_FORCE_32BIT),1)
   LIBFFI_LDFLAGS = $(BUILD)/lib/libffi/out/lib32/libffi.a
  else

--- a/ports/unix/alloc.c
+++ b/ports/unix/alloc.c
@@ -85,25 +85,6 @@ void mp_unix_mark_exec(void) {
     }
 }
 
-#if MICROPY_FORCE_PLAT_ALLOC_EXEC
-// Provide implementation of libffi ffi_closure_* functions in terms
-// of the functions above. On a normal Linux system, this save a lot
-// of code size.
-void *ffi_closure_alloc(size_t size, void **code);
-void ffi_closure_free(void *ptr);
-
-void *ffi_closure_alloc(size_t size, void **code) {
-    size_t dummy;
-    mp_unix_alloc_exec(size, code, &dummy);
-    return *code;
-}
-
-void ffi_closure_free(void *ptr) {
-    (void)ptr;
-    // TODO
-}
-#endif
-
 MP_REGISTER_ROOT_POINTER(void *mmap_region_head);
 
 #endif // MICROPY_EMIT_NATIVE || (MICROPY_PY_FFI && MICROPY_FORCE_PLAT_ALLOC_EXEC)

--- a/ports/unix/modffi.c
+++ b/ports/unix/modffi.c
@@ -191,9 +191,12 @@ static mp_obj_t return_ffi_value(ffi_union_t *val, char type) {
         case 'i':
         case 'l':
             return mp_obj_new_int((ffi_sarg)val->ffi);
+        case 'I':
+            // On RV64, 32-bit values are stored as signed integers inside the
+            // holding register.
+            return mp_obj_new_int_from_uint(val->ffi & 0xFFFFFFFF);
         case 'B':
         case 'H':
-        case 'I':
         case 'L':
             return mp_obj_new_int_from_uint(val->ffi);
         case 'q':

--- a/ports/unix/modffi.c
+++ b/ports/unix/modffi.c
@@ -334,7 +334,8 @@ static mp_obj_t mod_ffi_callback(size_t n_args, const mp_obj_t *pos_args, mp_map
     const char *rettype = mp_obj_str_get_str(rettype_in);
 
     mp_int_t nparams = MP_OBJ_SMALL_INT_VALUE(mp_obj_len_maybe(paramtypes_in));
-    mp_obj_fficallback_t *o = mp_obj_malloc_var(mp_obj_fficallback_t, params, ffi_type *, nparams, &fficallback_type);
+    mp_obj_fficallback_t *o = (mp_obj_fficallback_t *)m_tracked_calloc(offsetof(mp_obj_fficallback_t, params) + sizeof(ffi_type *) * nparams, sizeof(uint8_t));
+    o->base.type = &fficallback_type;
 
     o->clo = ffi_closure_alloc(sizeof(ffi_closure), &o->func);
 

--- a/ports/unix/mpconfigport.h
+++ b/ports/unix/mpconfigport.h
@@ -117,8 +117,8 @@ typedef long mp_off_t;
 #define MICROPY_HELPER_LEXER_UNIX   (1)
 #define MICROPY_VFS_POSIX           (1)
 #define MICROPY_READER_POSIX        (1)
-#ifndef MICROPY_TRACKED_ALLOC
-#define MICROPY_TRACKED_ALLOC       (MICROPY_BLUETOOTH_BTSTACK)
+#if MICROPY_PY_FFI || MICROPY_BLUETOOTH_BTSTACK
+#define MICROPY_TRACKED_ALLOC       (1)
 #endif
 
 // VFS stat functions should return time values relative to 1970/1/1

--- a/tools/ci.sh
+++ b/tools/ci.sh
@@ -421,6 +421,7 @@ CI_UNIX_OPTS_QEMU_ARM=(
 CI_UNIX_OPTS_QEMU_RISCV64=(
     CROSS_COMPILE=riscv64-linux-gnu-
     VARIANT=coverage
+    MICROPY_STANDALONE=1
 )
 
 function ci_unix_build_helper {
@@ -691,16 +692,12 @@ function ci_unix_qemu_arm_run_tests {
 }
 
 function ci_unix_qemu_riscv64_setup {
-    . /etc/os-release
-    for repository in "${VERSION_CODENAME}" "${VERSION_CODENAME}-updates" "${VERSION_CODENAME}-security"
-    do
-        sudo add-apt-repository -y -n "deb [arch=riscv64] http://ports.ubuntu.com/ubuntu-ports ${repository} main"
-    done
     sudo apt-get update
-    sudo dpkg --add-architecture riscv64
-    sudo apt-get install gcc-riscv64-linux-gnu g++-riscv64-linux-gnu libffi-dev:riscv64
+    sudo apt-get install gcc-riscv64-linux-gnu g++-riscv64-linux-gnu
     sudo apt-get install qemu-user
     qemu-riscv64 --version
+    sudo mkdir /etc/qemu-binfmt
+    sudo ln -s /usr/riscv64-linux-gnu/ /etc/qemu-binfmt/riscv64
 }
 
 function ci_unix_qemu_riscv64_build {


### PR DESCRIPTION
### Summary

PR #15800 combined with #15767 would trigger an incompatibility in the libffi version used by the CI environment for testing the RISC-V 64 Unix port.  Using a source-built libffi library would also bring up a RISC-V 64 specific issue when handling unsigned 32 bit values in certain cases.

The first problem is solved by updating the vendored libffi version to v3.6.4 (the latest stable at this point), and pointing the libffi submodule to the official libffi repository.  This, along with some FFI callback memory management changes, closes #15528.

The second problem stems from how RISC-V 64 holds 32-bit integers inside a 64 bits wide register.  Quoting from the "RISC-V Instruction Set Manual Volume 1", section 4.2:

> The compiler and calling convention maintain an invariant that all 32-bit values are held in a sign-extended format in 64-bit registers. Even 32-bit unsigned integers extend bit 31 into bits 63 through 32. Consequently, conversion between unsigned and signed 32-bit integers is a no-op, as is conversion from a signed 32-bit integer to a signed 64-bit integer.

The compiler can handle this since it knows what is going to happen to values whose lifetime it manages, and can generate code that takes this situation into account.  However, for FFI functions the compiler has no idea on what's in store for the value and so it just leaves it alone.  The modffi code wasn't aware of this and would happily return 64-bit signed values if the `uint32_t` value returned by the function had its most significant bit set.

### Testing

Testing occurred in a CI-like environment using the same commands used in `ci.sh` to build both the Qemu Unix RISC-V 64, Arm, and MIPS ports.