### PR TITLE
esp32/boards: Fixed um_rgbtouch_mini compile error.

### DIFF
--- a/ports/esp32/boards/UM_RGBTOUCH_MINI/manifest.py
+++ b/ports/esp32/boards/UM_RGBTOUCH_MINI/manifest.py
@@ -1,2 +1,2 @@
 include("$(PORT_DIR)/boards/manifest.py")
-freeze("modules")
+# freeze("modules") - to re-enable at a later stage when there are modules


### PR DESCRIPTION
Fixed the missing modules folder compile issue reported by @dpgeorge 