### PR TITLE
github/workflows: Update Ubuntu images for code size CI tasks.

### DIFF
--- a/.github/workflows/code_size.yml
+++ b/.github/workflows/code_size.yml
@@ -24,7 +24,7 @@ concurrency:
 
 jobs:
   build:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
     - uses: actions/checkout@v4
       with:

--- a/.github/workflows/code_size_comment.yml
+++ b/.github/workflows/code_size_comment.yml
@@ -11,7 +11,7 @@ concurrency:
 
 jobs:
   comment:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - name: 'Download artifact'
         id: download-artifact


### PR DESCRIPTION
### Summary

The code size calculation CI tasks were still on Ubuntu 20.04, which is a problem for #15843 as Ubuntu 20.04 does not provide the necessary packages for building RISC-V code.

### Testing

The code size CI tasks completed successfully in my branch: https://github.com/agatti/micropython/actions/runs/10957423395.