### PR TITLE
py/mpz: Skip separators when running out of digits to print.

### DIFF
--- a/py/mpz.c
+++ b/py/mpz.c
@@ -1717,7 +1717,7 @@ size_t mpz_as_str_inpl(const mpz_t *i, unsigned int base, const char *prefix, ch
                 break;
             }
         }
-        if (comma && (s - last_comma) == 3) {
+        if (!done && comma && (s - last_comma) == 3) {
             *s++ = comma;
             last_comma = s;
         }

--- a/tests/basics/string_format_intbig.py
+++ b/tests/basics/string_format_intbig.py
@@ -1,0 +1,15 @@
+# basic functionality test for {} format string using large integers
+
+
+def test(fmt, *args):
+    print("{:8s}".format(fmt) + ">" + fmt.format(*args) + "<")
+
+
+# Separator formatter
+
+test("{:,}", 123_456_789_012_345_678_901_234_567)
+test("{:,}", 23_456_789_012_345_678_901_234_567)
+test("{:,}", 3_456_789_012_345_678_901_234_567)
+test("{:,}", -123_456_789_012_345_678_901_234_567)
+test("{:,}", -23_456_789_012_345_678_901_234_567)
+test("{:,}", -3_456_789_012_345_678_901_234_567)


### PR DESCRIPTION
### Summary

As reported in #8984, a stray separator would be printed in front of the number when using `str.format` and an explicit separator when the number of digits to print is a multiple of 3.

### Testing

Tests were run for the Unix port on x64 locally.