### PR TITLE
lib/tinyusb: Update TinyUSB to release 0.17.0

### DIFF
--- a/shared/tinyusb/mp_usbd.h
+++ b/shared/tinyusb/mp_usbd.h
@@ -40,6 +40,13 @@
 #include "device/dcd.h"
 #endif
 
+// Initialise TinyUSB device.
+static inline void mp_usbd_init_tud(void) {
+    tusb_init();
+    tud_cdc_configure_fifo_t cfg = { .rx_persistent = 0, .tx_persistent = 1 };
+    tud_cdc_configure_fifo(&cfg);
+}
+
 // Run the TinyUSB device task
 void mp_usbd_task(void);
 
@@ -125,7 +132,8 @@ inline static bool mp_usb_device_builtin_enabled(const mp_obj_usb_device_t *usbd
 
 static inline void mp_usbd_init(void) {
     // Without runtime USB support, this can be a thin wrapper wrapper around tusb_init()
-    tusb_init();
+    // which is called in the below helper function.
+    mp_usbd_init_tud();
 }
 
 #endif

--- a/shared/tinyusb/mp_usbd_runtime.c
+++ b/shared/tinyusb/mp_usbd_runtime.c
@@ -428,8 +428,10 @@ void mp_usbd_init(void) {
     }
 
     if (need_usb) {
-        tusb_init(); // Safe to call redundantly
-        tud_connect(); // Reconnect if mp_usbd_deinit() has disconnected
+        // The following will call tusb_init(), which is safe to call redundantly.
+        mp_usbd_init_tud();
+        // Reconnect if mp_usbd_deinit() has disconnected.
+        tud_connect();
     }
 }
 

--- a/shared/tinyusb/tusb_config.h
+++ b/shared/tinyusb/tusb_config.h
@@ -83,7 +83,6 @@
 #ifndef CFG_TUD_CDC_TX_BUFSIZE
 #define CFG_TUD_CDC_TX_BUFSIZE  ((CFG_TUD_MAX_SPEED == OPT_MODE_HIGH_SPEED) ? 512 : 256)
 #endif
-#define CFG_TUD_CDC_PERSISTENT_TX_BUFF (1)
 #endif
 
 // MSC Configuration


### PR DESCRIPTION
### Summary

TinyUSB (finally!) has a new release, 0.17.0.  Usually we track latest master but now there's a release it would be good to update to that.

More importantly, an updated TinyUSB is needed for both RP2350 support #15619 and ESP32 shared TinyUSB integration #15108.  Both those PRs update TinyUSB to a commit prior to the 0.17.0 release, and it would be good to consolidate those updates into a single update of TinyUSB, hence this PR.

### Testing

Testing is needed for all existing TinyUSB ports:
- [x] mimxrt
- [x] nrf
- [x] renesas-ra FS
- [x] renesas-ra HS
- [x] rp2
- [x] samd