### PR TITLE
esp32: Remove old compiler workaround.

### DIFF
--- a/ports/esp32/mpconfigport.h
+++ b/ports/esp32/mpconfigport.h
@@ -47,13 +47,6 @@
 #define MICROPY_EMIT_RV32                   (1)
 #endif
 
-// workaround for xtensa-esp32-elf-gcc esp-2020r3, which can generate wrong code for loops
-// see https://github.com/espressif/esp-idf/issues/9130
-// this was fixed in newer versions of the compiler by:
-//   "gas: use literals/const16 for xtensa loop relaxation"
-//   https://github.com/jcmvbkbc/binutils-gdb-xtensa/commit/403b0b61f6d4358aee8493cb1d11814e368942c9
-#define MICROPY_COMP_CONST_FOLDING_COMPILER_WORKAROUND (1)
-
 // optimisations
 #ifndef MICROPY_OPT_COMPUTED_GOTO
 #define MICROPY_OPT_COMPUTED_GOTO           (1)

--- a/py/parse.c
+++ b/py/parse.c
@@ -648,11 +648,6 @@ static const mp_rom_map_elem_t mp_constants_table[] = {
 static MP_DEFINE_CONST_MAP(mp_constants_map, mp_constants_table);
 #endif
 
-#if MICROPY_COMP_CONST_FOLDING_COMPILER_WORKAROUND
-// Some versions of the xtensa-esp32-elf-gcc compiler generate wrong code if this
-// function is static, so provide a hook for them to work around this problem.
-MP_NOINLINE
-#endif
 static bool fold_logical_constants(parser_t *parser, uint8_t rule_id, size_t *num_args) {
     if (rule_id == RULE_or_test
         || rule_id == RULE_and_test) {


### PR DESCRIPTION
### Summary

The ESP32 port contains a workaround to avoid having a certain function in `py/parse.c` being generated incorrectly.  The compiler in question is not part of any currently supported version of ESP-IDF anymore, and the problem inside the compiler (well, assembler in this case) has been corrected a few years ago.

### Testing

The default test suite (as in `run-tests.py --target esp32`) was executed successfully on an ESP32-D0WD and on an ESP32C3 - using a firmware image built with both ESP-IDF 5.0.4 and 5.2.2.