### PR TITLE
rp2: Fix dropped UART REPL bytes on soft reset.

### DIFF
--- a/ports/rp2/machine_uart.c
+++ b/ports/rp2/machine_uart.c
@@ -458,6 +458,7 @@ static mp_obj_t mp_machine_uart_make_new(const mp_obj_type_t *type, size_t n_arg
 }
 
 static void mp_machine_uart_deinit(machine_uart_obj_t *self) {
+    uart_tx_wait_blocking(self->uart); // Flush TX FIFO if necessary
     uart_deinit(self->uart);
     if (self->uart_id == 0) {
         irq_set_enabled(UART0_IRQ, false);


### PR DESCRIPTION
### Summary

Necessary to fix "mpremote run" over hardware UART (i.e. when `MICROPY_HW_ENABLE_UART_REPL` is set).

Bisect shows bug was introduced by d420b4e4 (#13718), but looks like made more complex by 01c046d2 (#14041). Specifically: resetting and re-initialising the REPL UART during soft reset clears the FIFO before it's done printing the "MPY: soft reboot" line.

Fixed by adding a UART TX flush in the deinit path.

### Testing

1. Build rp2 port with `MICROPY_HW_ENABLE_UART_REPL` set.
2. Open interactive REPL and type Ctrl-D. Note the "MPY: soft reboot" line is not printed, only one invalid character is received.
3. Alternatively, try to use "mpremote run" over the hardware UART. It times out waiting for the "soft reboot" line.

Fails without this PR, works with this PR.

### Trade-offs and Alternatives

* Alternative would be to not reset the REPL UART on soft reset. This may be better from the "principle of least surprise" point of view (i.e. if the user hasn't changed the UART settings then it makes no difference, and if they have changed them then having Soft Reboot change them and lose the REPL seems a bit unexpected.) However doing it that way has less clean layering, as the machine.UART code would need to know about the REPL configuration.