### PR TITLE
unix/main: Add --version command-line option.

### DIFF
--- a/ports/unix/main.c
+++ b/ports/unix/main.c
@@ -318,6 +318,7 @@ static void print_help(char **argv) {
     printf(
         "usage: %s [<opts>] [-X <implopt>] [-c <command> | -m <module> | <filename>]\n"
         "Options:\n"
+        "--version : show version information\n"
         "-h : print this help message\n"
         "-i : enable inspection via REPL after running command/module/file\n"
         #if MICROPY_DEBUG_PRINTERS
@@ -367,6 +368,10 @@ static void pre_process_options(int argc, char **argv) {
             }
             if (strcmp(argv[a], "-h") == 0) {
                 print_help(argv);
+                exit(0);
+            }
+            if (strcmp(argv[a], "--version") == 0) {
+                printf(MICROPY_BANNER_NAME_AND_VERSION "; " MICROPY_BANNER_MACHINE "\n");
                 exit(0);
             }
             if (strcmp(argv[a], "-X") == 0) {


### PR DESCRIPTION
### Summary

As a replacement for #15518 (which seems abandoned by the author).

Adds `--version` to the unix port.

CPython also has `--version`, and so does our `mpy-cross`.

Example output:
```
$ micropython --version
MicroPython v1.24.0-preview.354.g584e41183 on 2024-09-26; linux [GCC 14.1.1] version
```

### Testing

Ran `micropython --version`.

### Trade-offs and Alternatives

This adds a bit of code size to the executable, but IMO it's worth it to have the version available like this.

An alternative would be to run something like:
```
$ micropython -c "import sys; print(sys.version)" 
3.4.0; MicroPython v1.24.0-preview.354.g584e41183 on 2024-09-26
```
but that's not as easy to do (or know to do that).