### PR TITLE
esp32/network_wlan: Get and set the WLAN country code.

### DIFF
--- a/docs/library/network.rst
+++ b/docs/library/network.rst
@@ -210,6 +210,12 @@ The following are functions available in the network module.
 
     The default code ``"XX"`` represents the "worldwide" region.
 
+    On ESP32, setting an invalid country code before instantiating the radio
+    interface (ie. calling ``network.WLAN(…)`` the first time) will succeed but
+    then all calls to ``network.WLAN(…)`` will fail until a valid country code is
+    set.  It is best to delay calling ``network.country`` until the radio is
+    initialised first.
+
 .. function:: hostname([name])
 
     Get or set the hostname that will identify this device on the network. It will

--- a/extmod/modnetwork.c
+++ b/extmod/modnetwork.c
@@ -122,6 +122,9 @@ MP_REGISTER_ROOT_POINTER(mp_obj_list_t mod_network_nic_list);
 #endif // MICROPY_PORT_NETWORK_INTERFACES
 
 static mp_obj_t network_country(size_t n_args, const mp_obj_t *args) {
+    #if defined(MICROPY_PY_NETWORK_COUNTRY)
+    return MICROPY_PY_NETWORK_COUNTRY(n_args, args);
+    #else
     if (n_args == 0) {
         return mp_obj_new_str(mod_network_country_code, 2);
     } else {
@@ -134,6 +137,7 @@ static mp_obj_t network_country(size_t n_args, const mp_obj_t *args) {
         mod_network_country_code[1] = str[1];
         return mp_const_none;
     }
+    #endif
 }
 // TODO: Non-static to allow backwards-compatible pyb.country.
 MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(mod_network_country_obj, 0, 1, network_country);

--- a/extmod/modnetwork.h
+++ b/extmod/modnetwork.h
@@ -149,4 +149,6 @@ void mod_network_register_nic(mp_obj_t nic);
 mp_obj_t mod_network_find_nic(const uint8_t *ip);
 #endif
 
+mp_obj_t mp_network_country(size_t n_args, const mp_obj_t *args);
+
 #endif // MICROPY_INCLUDED_MODNETWORK_H

--- a/ports/esp32/mpconfigport.h
+++ b/ports/esp32/mpconfigport.h
@@ -191,6 +191,7 @@
 #define MICROPY_PY_NETWORK_MODULE_GLOBALS_INCLUDEFILE "ports/esp32/modnetwork_globals.h"
 #ifndef MICROPY_PY_NETWORK_WLAN
 #define MICROPY_PY_NETWORK_WLAN             (1)
+#define MICROPY_PY_NETWORK_COUNTRY          mp_network_country
 #endif
 #ifndef MICROPY_HW_ENABLE_SDCARD
 #define MICROPY_HW_ENABLE_SDCARD            (1)

--- a/ports/esp32/network_common.c
+++ b/ports/esp32/network_common.c
@@ -79,6 +79,8 @@ MP_NORETURN void esp_exceptions_helper(esp_err_t e) {
             mp_raise_msg(&mp_type_OSError, MP_ERROR_TEXT("Wifi Not Connected"));
         case ESP_ERR_NO_MEM:
             mp_raise_msg(&mp_type_OSError, MP_ERROR_TEXT("WiFi Out of Memory"));
+        case ESP_ERR_INVALID_ARG:
+            mp_raise_msg(&mp_type_OSError, MP_ERROR_TEXT("WiFi Invalid Argument"));
         default:
             mp_raise_msg_varg(&mp_type_RuntimeError, MP_ERROR_TEXT("Wifi Unknown Error 0x%04x"), e);
     }

--- a/ports/esp32/network_wlan.c
+++ b/ports/esp32/network_wlan.c
@@ -82,6 +82,7 @@ static bool mdns_initialised = false;
 
 static uint8_t conf_wifi_sta_reconnects = 0;
 static uint8_t wifi_sta_reconnects;
+static uint8_t network_country_code_set = 0;
 
 // The rules for this default are defined in the documentation of esp_wifi_set_protocol()
 // rather than in code, so we have to recreate them here.
@@ -262,6 +263,19 @@ static mp_obj_t network_wlan_make_new(const mp_obj_type_t *type, size_t n_args, 
     mp_arg_check_num(n_args, n_kw, 0, 1, false);
 
     esp_initialise_wifi();
+
+    #ifdef MICROPY_PY_NETWORK_COUNTRY
+    char country_code[4] = { '0', '1', ' ', '\0' };
+    if (!(mod_network_country_code[0] == 'X' && mod_network_country_code[1] == 'X')) {
+        country_code[0] = mod_network_country_code[0];
+        country_code[1] = mod_network_country_code[1];
+    }
+    if (network_country_code_set) {
+        // Always follow the AP's country if one is set.
+        esp_exceptions(esp_wifi_set_country_code(country_code, true));
+        network_country_code_set = 0;
+    }
+    #endif
 
     int idx = (n_args > 0) ? mp_obj_get_int(args[0]) : ESP_IF_WIFI_STA;
     if (idx == ESP_IF_WIFI_STA) {
@@ -771,6 +785,58 @@ unknown:
     mp_raise_ValueError(MP_ERROR_TEXT("unknown config param"));
 }
 MP_DEFINE_CONST_FUN_OBJ_KW(network_wlan_config_obj, 1, network_wlan_config);
+
+#ifdef MICROPY_PY_NETWORK_COUNTRY
+mp_obj_t mp_network_country(size_t n_args, const mp_obj_t *pos_args) {
+    // ESP-IDF docs state the country code is three characters long.
+    char country_code[4] = { '0', '1', ' ', '\0' };
+    esp_err_t state;
+
+    // This function can be called at any time once the `network` module is
+    // imported.  Currently the static wifi flags indicate only whether the
+    // radio interface is active or not, whilst we need to know if the
+    // interface is initialised.
+
+    if (n_args == 0) {
+        state = esp_wifi_get_country_code(country_code);
+        if (state != ESP_ERR_WIFI_NOT_INIT) {
+            esp_exceptions(state);
+            if (country_code[0] == '0' && country_code[1] == '1') {
+                mod_network_country_code[0] = 'X';
+                mod_network_country_code[1] = 'X';
+            } else {
+                mod_network_country_code[0] = country_code[0];
+                mod_network_country_code[1] = country_code[1];
+            }
+        }
+
+        return mp_obj_new_str((const char *)mod_network_country_code, 2);
+    }
+
+    if (n_args == 1) {
+        size_t length = 0;
+        const char *code = mp_obj_str_get_data(pos_args[0], &length);
+        if (length < 2) {
+            mp_raise_ValueError(NULL);
+        }
+        mod_network_country_code[0] = code[0];
+        mod_network_country_code[1] = code[1];
+        // Maintain compatibility with the default implementation.
+        if (!(mod_network_country_code[0] == 'X' && mod_network_country_code[1] == 'X')) {
+            country_code[0] = mod_network_country_code[0];
+            country_code[1] = mod_network_country_code[1];
+        }
+        state = esp_wifi_set_country_code(country_code, true);
+        if (state != ESP_ERR_WIFI_NOT_INIT) {
+            esp_exceptions(state);
+        } else {
+            network_country_code_set = 1;
+        }
+    }
+
+    return mp_const_none;
+}
+#endif
 
 static const mp_rom_map_elem_t wlan_if_locals_dict_table[] = {
     { MP_ROM_QSTR(MP_QSTR_active), MP_ROM_PTR(&network_wlan_active_obj) },

--- a/tests/ports/esp32/network_wlan_country.py
+++ b/tests/ports/esp32/network_wlan_country.py
@@ -1,0 +1,40 @@
+# Test WLAN country code get/set - this must be run before any WLAN
+# instantiation, ideally right after a board reboot.
+
+import network
+
+network.country("XX")
+print(network.country())
+
+network.country("QQ")
+try:
+    network.WLAN(network.STA_IF)
+    print("Failed to raise")
+except OSError as e:
+    print(str(e))
+print(network.country())
+
+network.country("AU")
+print(network.country())
+
+wlan = network.WLAN(network.STA_IF)
+print(network.country())
+
+try:
+    network.country("!!")
+    print("Failed to raise")
+except OSError as e:
+    print(str(e))
+print(network.country())
+
+wlan = network.WLAN(network.AP_IF)
+print(network.country())
+network.country("XX")
+print(network.country())
+
+try:
+    network.country("FP")
+    print("Failed to raise")
+except OSError as e:
+    print(str(e))
+print(network.country())

--- a/tests/ports/esp32/network_wlan_country.py.exp
+++ b/tests/ports/esp32/network_wlan_country.py.exp
@@ -1,0 +1,11 @@
+XX
+WiFi Invalid Argument
+XX
+AU
+AU
+WiFi Invalid Argument
+AU
+AU
+XX
+WiFi Invalid Argument
+XX


### PR DESCRIPTION
### Summary

This provides an implementation for #7179, by allowing to set (and get) the country code for the ESP32's WLAN radio interface.

No user-visible API changes have been introduced as this uses `network.country` rather than having its own extra method somewhere else (I initially thought about bolting it onto `network.WLAN` to minimise code changes, but in for a penny, in for a pound).  Ports can now properly set the WLAN country code if they have the APIs for it, rather than just keeping track of the code itself.

There are a couple of minor things one should be aware of when using this on an ESP32, and those have been added as notes to `network.country`'s documentation section:

* ESP-IDF unconditionally stores the chosen country code into the device's non-volatile storage
* setting the country code with no WLAN interface ever being instantiated will raise an exception
* the country code will default to "worldwide" if it was never set in the device or if no WLAN interface was instantiated yet.

### Testing

Testing was done manually on an ESP32C3 using ESP-IDF 5.0.4 and via `tests/ports/esp32/country_wlan.py`.  This is tricky to write a reliable test for because the board's WLAN interface may not be in a known state when the test runs.

Right now the test only passes if it is run when no WLAN has been instantiated before and if the WLAN country code is set to either `XX` (the default when the flash is cleared) or to `AU`.  I was tempted to put `IT` there instead but I managed to resist :)

The provided test cycles between those two known country codes, so it is still independent from the existing device configuration, as long as the first test run was done with an empty NVS.

### Trade-offs and Alternatives

This feature slightly increases the code size so maybe it can be put behind a define of its own, if setting the WLAN country code is not needed.  The existing implementation doesn't do anything interesting for ESP32, so some code space was already lost to begin with, which makes the extra space taken by this feature a bit easier to let go.