### PR TITLE
unix/alloc: Remove unused MICROPY_FORCE_PLAT_ALLOC_EXEC option.

### DIFF
--- a/ports/unix/alloc.c
+++ b/ports/unix/alloc.c
@@ -32,7 +32,7 @@
 
 #include "py/mpstate.h"
 
-#if MICROPY_EMIT_NATIVE || (MICROPY_PY_FFI && MICROPY_FORCE_PLAT_ALLOC_EXEC)
+#if MICROPY_EMIT_NATIVE
 
 #if defined(__OpenBSD__) || defined(__MACH__)
 #define MAP_ANONYMOUS MAP_ANON
@@ -80,4 +80,4 @@ void mp_unix_free_exec(void *ptr, size_t size) {
 
 MP_REGISTER_ROOT_POINTER(void *mmap_region_head);
 
-#endif // MICROPY_EMIT_NATIVE || (MICROPY_PY_FFI && MICROPY_FORCE_PLAT_ALLOC_EXEC)
+#endif // MICROPY_EMIT_NATIVE

--- a/ports/unix/mpconfigport.h
+++ b/ports/unix/mpconfigport.h
@@ -170,11 +170,6 @@ void mp_unix_alloc_exec(size_t min_size, void **ptr, size_t *size);
 void mp_unix_free_exec(void *ptr, size_t size);
 #define MP_PLAT_ALLOC_EXEC(min_size, ptr, size) mp_unix_alloc_exec(min_size, ptr, size)
 #define MP_PLAT_FREE_EXEC(ptr, size) mp_unix_free_exec(ptr, size)
-#ifndef MICROPY_FORCE_PLAT_ALLOC_EXEC
-// Use MP_PLAT_ALLOC_EXEC for any executable memory allocation, including for FFI
-// (overriding libffi own implementation)
-#define MICROPY_FORCE_PLAT_ALLOC_EXEC (1)
-#endif
 
 // If enabled, configure how to seed random on init.
 #ifdef MICROPY_PY_RANDOM_SEED_INIT_FUNC


### PR DESCRIPTION
The `MICROPY_FORCE_PLAT_ALLOC_EXEC` config option was made obsolete by commit 97966254577167f4c50200af1af89109a275da1c, so remove it.

