### PR TITLE
py/nlrrv64: Add RISC-V RV64I NLR implementation.

### DIFF
--- a/py/nlr.h
+++ b/py/nlr.h
@@ -45,6 +45,7 @@
 #define MICROPY_NLR_NUM_REGS_XTENSA         (10)
 #define MICROPY_NLR_NUM_REGS_XTENSAWIN      (17)
 #define MICROPY_NLR_NUM_REGS_RV32I          (14)
+#define MICROPY_NLR_NUM_REGS_RV64I          (14)
 
 // *FORMAT-OFF*
 
@@ -89,9 +90,16 @@
 #elif defined(__mips__)
     #define MICROPY_NLR_MIPS (1)
     #define MICROPY_NLR_NUM_REGS (MICROPY_NLR_NUM_REGS_MIPS)
-#elif defined(__riscv) && defined(__riscv_xlen) && (__riscv_xlen == 32)
-    #define MICROPY_NLR_RV32I (1)
-    #define MICROPY_NLR_NUM_REGS (MICROPY_NLR_NUM_REGS_RV32I)
+#elif defined(__riscv)
+    #if __riscv_xlen == 32
+        #define MICROPY_NLR_NUM_REGS (MICROPY_NLR_NUM_REGS_RV32I)
+        #define MICROPY_NLR_RV32I (1)
+    #elif __riscv_xlen == 64
+        #define MICROPY_NLR_NUM_REGS (MICROPY_NLR_NUM_REGS_RV64I)
+        #define MICROPY_NLR_RV64I (1)
+    #else
+        #error Unsupported RISC-V variant.
+    #endif
 #else
     #define MICROPY_NLR_SETJMP (1)
     //#warning "No native NLR support for this arch, using setjmp implementation"

--- a/py/nlrrv64.c
+++ b/py/nlrrv64.c
@@ -1,0 +1,81 @@
+/*
+ * This file is part of the MicroPython project, http://micropython.org/
+ *
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2024 Alessandro Gatti
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#include "py/mpstate.h"
+
+#if MICROPY_NLR_RV64I
+
+#undef nlr_push
+
+__attribute__((naked)) unsigned int nlr_push(nlr_buf_t *nlr) {
+    __asm volatile (
+        "sd   x1, 16(x10)       \n" // Store RA.
+        "sd   x8, 24(x10)       \n" // Store S0.
+        "sd   x9, 32(x10)       \n" // Store S1.
+        "sd  x18, 40(x10)       \n" // Store S2.
+        "sd  x19, 48(x10)       \n" // Store S3.
+        "sd  x20, 56(x10)       \n" // Store S4.
+        "sd  x21, 64(x10)       \n" // Store S5.
+        "sd  x22, 72(x10)       \n" // Store S6.
+        "sd  x23, 80(x10)       \n" // Store S7.
+        "sd  x24, 88(x10)       \n" // Store S8.
+        "sd  x25, 96(x10)       \n" // Store S9.
+        "sd  x26, 104(x10)      \n" // Store S10.
+        "sd  x27, 112(x10)      \n" // Store S11.
+        "sd   x2, 120(x10)      \n" // Store SP.
+        "jal  x0, nlr_push_tail \n" // Jump to the C part.
+        );
+}
+
+NORETURN void nlr_jump(void *val) {
+    MP_NLR_JUMP_HEAD(val, top)
+    __asm volatile (
+        "add  x10, x0, %0  \n" // Load nlr_buf address.
+        "ld   x1, 16(x10)  \n" // Retrieve RA.
+        "ld   x8, 24(x10)  \n" // Retrieve S0.
+        "ld   x9, 32(x10)  \n" // Retrieve S1.
+        "ld  x18, 40(x10)  \n" // Retrieve S2.
+        "ld  x19, 48(x10)  \n" // Retrieve S3.
+        "ld  x20, 56(x10)  \n" // Retrieve S4.
+        "ld  x21, 64(x10)  \n" // Retrieve S5.
+        "ld  x22, 72(x10)  \n" // Retrieve S6.
+        "ld  x23, 80(x10)  \n" // Retrieve S7.
+        "ld  x24, 88(x10)  \n" // Retrieve S8.
+        "ld  x25, 96(x10)  \n" // Retrieve S9.
+        "ld  x26, 104(x10) \n" // Retrieve S10.
+        "ld  x27, 112(x10) \n" // Retrieve S11.
+        "ld   x2, 120(x10) \n" // Retrieve SP.
+        "addi x10, x0, 1   \n" // Return 1 for a non-local return.
+        "jalr  x0, x1, 0   \n" // Return.
+        :                      // Outputs.
+        : "r" (top)            // Inputs.
+        : "memory"             // Clobbered.
+        );
+
+    MP_UNREACHABLE
+}
+
+#endif // MICROPY_NLR_RV64I

--- a/py/py.cmake
+++ b/py/py.cmake
@@ -60,6 +60,7 @@ set(MICROPY_SOURCE_PY
     ${MICROPY_PY_DIR}/nlrmips.c
     ${MICROPY_PY_DIR}/nlrpowerpc.c
     ${MICROPY_PY_DIR}/nlrrv32.c
+    ${MICROPY_PY_DIR}/nlrrv64.c
     ${MICROPY_PY_DIR}/nlrsetjmp.c
     ${MICROPY_PY_DIR}/nlrthumb.c
     ${MICROPY_PY_DIR}/nlrx64.c

--- a/py/py.mk
+++ b/py/py.mk
@@ -87,6 +87,7 @@ PY_CORE_O_BASENAME = $(addprefix py/,\
 	nlrpowerpc.o \
 	nlrxtensa.o \
 	nlrrv32.o \
+	nlrrv64.o \
 	nlrsetjmp.o \
 	malloc.o \
 	gc.o \


### PR DESCRIPTION
### Summary

Following the RV32 port, I updated the NLR code for RV64.  It is nothing more than the same code but with doubled byte offsets inside the structure and double-words load/store opcodes.

### Testing

The Qemu RV64 Unix tests pass - I'm also in the process to set up a MicroPython-enabled buildroot for a Milk-V Duo so that RV64 can also be tested locally on my end in the near future (one of my RV64 boards is now free for MicroPython development).