### PR TITLE
ports/renesas: Replace MICROPY_EVENT_POLL_HOOK with mp_event_wait.

### DIFF
--- a/drivers/esp-hosted/esp_hosted_bthci_uart.c
+++ b/drivers/esp-hosted/esp_hosted_bthci_uart.c
@@ -72,7 +72,7 @@ int esp_hosted_hci_cmd(int ogf, int ocf, size_t param_len, const uint8_t *param_
     // Receive HCI event packet, initially reading 3 bytes (HCI Event, Event code, Plen).
     for (mp_uint_t start = mp_hal_ticks_ms(), size = 3, i = 0; i < size;) {
         while (!mp_bluetooth_hci_uart_any()) {
-            MICROPY_EVENT_POLL_HOOK
+            mp_event_wait_ms(1);
             // Timeout.
             if ((mp_hal_ticks_ms() - start) > HCI_COMMAND_TIMEOUT) {
                 error_printf("timeout waiting for HCI packet\n");
@@ -126,7 +126,7 @@ int mp_bluetooth_hci_controller_init(void) {
         if (mp_bluetooth_hci_uart_any()) {
             mp_bluetooth_hci_uart_readchar();
         }
-        MICROPY_EVENT_POLL_HOOK
+        mp_event_wait_ms(1);
     }
 
     #ifdef MICROPY_HW_BLE_UART_BAUDRATE_SECONDARY

--- a/drivers/esp-hosted/esp_hosted_wifi.c
+++ b/drivers/esp-hosted/esp_hosted_wifi.c
@@ -243,7 +243,7 @@ static int esp_hosted_request(CtrlMsgId msg_id, void *ctrl_payload) {
 
 static CtrlMsg *esp_hosted_response(CtrlMsgId msg_id, uint32_t timeout) {
     CtrlMsg *ctrl_msg = NULL;
-    for (mp_uint_t start = mp_hal_ticks_ms(); ; mp_hal_delay_ms(10)) {
+    for (mp_uint_t start = mp_hal_ticks_ms(); ; mp_event_wait_ms(10)) {
         if (!esp_hosted_stack_empty(&esp_state.stack)) {
             ctrl_msg = esp_hosted_stack_pop(&esp_state.stack, true);
             if (ctrl_msg->msg_id == msg_id) {
@@ -264,8 +264,6 @@ static CtrlMsg *esp_hosted_response(CtrlMsgId msg_id, uint32_t timeout) {
         if ((mp_hal_ticks_ms() - start) >= timeout) {
             return NULL;
         }
-
-        MICROPY_EVENT_POLL_HOOK
     }
 
     // If message type is a response, check the response struct's return value.

--- a/ports/renesas-ra/machine_uart.c
+++ b/ports/renesas-ra/machine_uart.c
@@ -501,7 +501,7 @@ static mp_uint_t mp_machine_uart_ioctl(mp_obj_t self_in, mp_uint_t request, uint
             if (!uart_tx_busy(self)) {
                 return 0;
             }
-            MICROPY_EVENT_POLL_HOOK
+            mp_event_wait_indefinite();
         } while (mp_hal_ticks_ms() < timeout);
         *errcode = MP_ETIMEDOUT;
         ret = MP_STREAM_ERROR;

--- a/ports/renesas-ra/mpconfigport.h
+++ b/ports/renesas-ra/mpconfigport.h
@@ -243,28 +243,17 @@ typedef unsigned int mp_uint_t; // must be pointer size
 typedef long mp_off_t;
 
 #if MICROPY_PY_THREAD
-#define MICROPY_EVENT_POLL_HOOK \
+#define MICROPY_INTERNAL_EVENT_HOOK \
     do { \
-        extern void mp_handle_pending(bool); \
-        mp_handle_pending(true); \
         if (pyb_thread_enabled) { \
             MP_THREAD_GIL_EXIT(); \
             pyb_thread_yield(); \
             MP_THREAD_GIL_ENTER(); \
-        } else { \
-            __WFI(); \
         } \
     } while (0);
 
 #define MICROPY_THREAD_YIELD() pyb_thread_yield()
 #else
-#define MICROPY_EVENT_POLL_HOOK \
-    do { \
-        extern void mp_handle_pending(bool); \
-        mp_handle_pending(true); \
-        __WFI(); \
-    } while (0);
-
 #define MICROPY_THREAD_YIELD()
 #endif
 

--- a/ports/renesas-ra/mphalport.c
+++ b/ports/renesas-ra/mphalport.c
@@ -104,7 +104,7 @@ int mp_hal_stdin_rx_chr(void) {
             return dupterm_c;
         }
         #endif
-        MICROPY_EVENT_POLL_HOOK
+        mp_event_wait_indefinite();
     }
 }
 

--- a/ports/renesas-ra/mphalport.h
+++ b/ports/renesas-ra/mphalport.h
@@ -35,6 +35,14 @@
 #define MICROPY_PY_PENDSV_ENTER   uint32_t atomic_state = raise_irq_pri(IRQ_PRI_PENDSV)
 #define MICROPY_PY_PENDSV_EXIT    restore_irq_pri(atomic_state)
 
+// Port level Wait-for-Event macro
+//
+// Do not use this macro directly, include py/runtime.h and
+// call mp_event_wait_indefinite() or mp_event_wait_ms(timeout).
+// Uses WFI which will wake up from regular systick interrupt if not
+// before from any other source.
+#define MICROPY_INTERNAL_WFE(TIMEOUT_MS) __WFI()
+
 #define MICROPY_PY_LWIP_ENTER
 #define MICROPY_PY_LWIP_REENTER
 #define MICROPY_PY_LWIP_EXIT

--- a/ports/renesas-ra/uart.c
+++ b/ports/renesas-ra/uart.c
@@ -477,7 +477,7 @@ bool uart_rx_wait(machine_uart_obj_t *self, uint32_t timeout) {
         if (HAL_GetTick() - start >= timeout) {
             return false; // timeout
         }
-        MICROPY_EVENT_POLL_HOOK
+        mp_event_wait_ms(1);
     }
 }
 
@@ -498,7 +498,7 @@ bool uart_tx_wait(machine_uart_obj_t *self, uint32_t timeout) {
         if (HAL_GetTick() - start >= timeout) {
             return false; // timeout
         }
-        MICROPY_EVENT_POLL_HOOK
+        mp_event_wait_ms(1);
     }
 }
 


### PR DESCRIPTION
### Summary

Basic update to the renesas to replace the traditional `MICROPY_EVENT_POLL_HOOK` with the newer `mp_event_wait_indefinite()` / `mp_event_wait_ms()` as appropriate.

### Testing
Renesas imxrt1010 EVK

`python3 test_serial.py` from #15909 has been run on both usb and uart and works without any failures.

`~/micropython/tests$ ./run-tests.py --target renesas-ra --device /dev/ttyACM0` has been run before and after MR with no changes (fails on `builtin_pow3_intbig machine_spi_rate` in both cases).