### PR TITLE
ESP32 UART - XonXoff flow control

### DIFF
--- a/docs/library/machine.UART.rst
+++ b/docs/library/machine.UART.rst
@@ -76,7 +76,7 @@ Methods
          - ``0`` means no flow control.
          - ``UART.RTS`` will enable hardware receive flow control by using the RTS output pin to
            signal if the receive FIFO has sufficient space to accept more data.
-         - ``UART.CTS`` will enable hardward transmit flow control by pausing transmission when the
+         - ``UART.CTS`` will enable hardware transmit flow control by pausing transmission when the
            CTS input pin signals that the receiver is running low on buffer space.
          - ``UART.RTS | UART.CTS`` will enable both, for full hardware flow control.
          - ``UART.XONOFF`` will enable XON/XOFF flow control in both the transmit

--- a/docs/library/machine.UART.rst
+++ b/docs/library/machine.UART.rst
@@ -69,15 +69,25 @@ Methods
          - ``UART.INV_RX`` will invert RX line (idle state of RX line now logic low).
          - ``UART.INV_TX | UART.INV_RX`` will invert both lines (idle state at logic low).
 
-     - *flow* specifies which hardware flow control signals to use. The value
-       is a bitmask.
+     - *flow* specifies the type of flow control to use. The value
+       is one of the following.  The set of supported flow control types
+       depends on the port.
 
-         - ``0`` will ignore hardware flow control signals.
-         - ``UART.RTS`` will enable receive flow control by using the RTS output pin to
+         - ``0`` means no flow control.
+         - ``UART.RTS`` will enable hardware receive flow control by using the RTS output pin to
            signal if the receive FIFO has sufficient space to accept more data.
-         - ``UART.CTS`` will enable transmit flow control by pausing transmission when the
+         - ``UART.CTS`` will enable hardward transmit flow control by pausing transmission when the
            CTS input pin signals that the receiver is running low on buffer space.
          - ``UART.RTS | UART.CTS`` will enable both, for full hardware flow control.
+         - ``UART.XONOFF`` will enable XON/XOFF flow control in both the transmit
+           and receive directions.  When the receiver's internal buffer is almost
+           full, an XOFF character (CTRL-S) will be transmitted to tell the other
+           end to pause sending.  When the buffer has drained so there is more space
+           available, an XON character (CTRL-Q) will be transmitted to tell the
+           other end to resume sending.  Similarly, when the receiver receives XOFF,
+           the transmitter will pause sending until XON is received.  XONXOFF flow
+           control cannot be used at the same time as RTC/CTS flow control.
+
 
    On the WiPy only the following keyword-only parameter is supported:
 

--- a/ports/esp32/machine_uart.c
+++ b/ports/esp32/machine_uart.c
@@ -212,15 +212,19 @@ static void mp_machine_uart_print(const mp_print_t *print, mp_obj_t self_in, mp_
     if (self->flowcontrol) {
         mp_printf(print, ", flow=");
         uint32_t flow_mask = self->flowcontrol;
-        if (flow_mask & UART_HW_FLOWCTRL_RTS) {
-            mp_printf(print, "RTS");
-            flow_mask &= ~UART_HW_FLOWCTRL_RTS;
-            if (flow_mask) {
-                mp_printf(print, "|");
+        if (flow_mask == UART_HW_FLOWCTRL_MAX) {
+            mp_printf(print, "XONXOFF");
+        } else {
+            if (flow_mask & UART_HW_FLOWCTRL_RTS) {
+                mp_printf(print, "RTS");
+                flow_mask &= ~UART_HW_FLOWCTRL_RTS;
+                if (flow_mask) {
+                    mp_printf(print, "|");
+                }
             }
-        }
-        if (flow_mask & UART_HW_FLOWCTRL_CTS) {
-            mp_printf(print, "CTS");
+            if (flow_mask & UART_HW_FLOWCTRL_CTS) {
+                mp_printf(print, "CTS");
+            }
         }
     }
     mp_printf(print, ")");
@@ -392,9 +396,9 @@ static void mp_machine_uart_init_helper(machine_uart_obj_t *self, size_t n_args,
     }
     check_esp_err(uart_set_line_inverse(self->uart_num, self->invert));
 
-    // set hardware flow control
+    // set flow control
     if (args[ARG_flow].u_int != -1) {
-        if (args[ARG_flow].u_int & ~UART_HW_FLOWCTRL_CTS_RTS) {
+        if (args[ARG_flow].u_int != UART_HW_FLOWCTRL_MAX && args[ARG_flow].u_int & ~UART_HW_FLOWCTRL_CTS_RTS) {
             mp_raise_ValueError(MP_ERROR_TEXT("invalid flow control mask"));
         }
         self->flowcontrol = args[ARG_flow].u_int;
@@ -404,7 +408,18 @@ static void mp_machine_uart_init_helper(machine_uart_obj_t *self, size_t n_args,
     #else
     uint8_t uart_fifo_len = UART_FIFO_LEN;
     #endif
-    check_esp_err(uart_set_hw_flow_ctrl(self->uart_num, self->flowcontrol, uart_fifo_len - uart_fifo_len / 4));
+    
+    if (args[ARG_flow].u_int == UART_HW_FLOWCTRL_MAX) {
+        // Enable XON/XOFF flow control
+        check_esp_err(uart_set_sw_flow_ctrl(self->uart_num, 1, uart_fifo_len/2, uart_fifo_len - 8));
+        // Disable hardware RTS/CTS flow control
+        check_esp_err(uart_set_hw_flow_ctrl(self->uart_num, 0, 0));
+    } else {
+        // Disable CON/XOFF flow control
+        check_esp_err(uart_set_sw_flow_ctrl(self->uart_num, 0, 0, 0));
+        // Enable RTS and/or CTS hardware flow control according to self->flowcontrol
+        check_esp_err(uart_set_hw_flow_ctrl(self->uart_num, self->flowcontrol, uart_fifo_len - uart_fifo_len / 4));
+    }
 }
 
 static mp_obj_t mp_machine_uart_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *args) {

--- a/ports/esp32/machine_uart.c
+++ b/ports/esp32/machine_uart.c
@@ -408,10 +408,10 @@ static void mp_machine_uart_init_helper(machine_uart_obj_t *self, size_t n_args,
     #else
     uint8_t uart_fifo_len = UART_FIFO_LEN;
     #endif
-    
+
     if (args[ARG_flow].u_int == UART_HW_FLOWCTRL_MAX) {
         // Enable XON/XOFF flow control
-        check_esp_err(uart_set_sw_flow_ctrl(self->uart_num, 1, uart_fifo_len/2, uart_fifo_len - 8));
+        check_esp_err(uart_set_sw_flow_ctrl(self->uart_num, 1, uart_fifo_len / 2, uart_fifo_len - 8));
         // Disable hardware RTS/CTS flow control
         check_esp_err(uart_set_hw_flow_ctrl(self->uart_num, 0, 0));
     } else {


### PR DESCRIPTION
<!-- Thanks for submitting a Pull Request! We appreciate you spending the
     time to improve MicroPython. Please provide enough information so that
     others can review your Pull Request.

     Before submitting, please read:
     https://github.com/micropython/micropython/blob/master/CODEOFCONDUCT.md
     https://github.com/micropython/micropython/wiki/ContributorGuidelines

     Please check any CI failures that appear after your Pull Request is opened.
-->

### Summary

I have an existing ESP32 application that is written in C++ that consists of a display panel with embedded ESP32, plus a realtime CNC controller that also runs on another ESP32.  The two ends communicate over a UART link a high speed - between 1 Mbps and 5 Mbps.  I am porting to another ESP32-S3 display, replacing the C++ display code with MicroPython and LVGL.   To prevent overrun, the communication link uses XON/XOFF software flow control.  Due to hardware pinout and cabling limitations, it is not feasible to use RTS/CTS flow control. The low-level UART driver in ESP-IDF supports XON/XOFF flow control, so it quite easy to expose that capability via the MicroPython UART class.  The API change simply adds a UART.XONXOFF option to the "flow" parameter.

XON/XOFF, of course, is a is a well-known flow control method with long history.  It is supported by many serial drivers and terminal emulators.

This PR implements the feature only for the ESP32 port, although it is probably possible to do a similar thing for many other ports.  The API change - namely the addition of the UART.XONXOFF value - should not conflict with any existing usage on other ports.

### Testing

I tested it on an ESP32-S3 system, namely an Elecrow 7" HMI panel.  With the UART configured as follows:
```
from machine import UART
u = UART(1, 1000000, rx=44, tx=43, flow=UART.XONXOFF)
```
I connected to the device using TeraTermPro on a PC, setting the speed to 1000000 and enabling XonXoff flow control in TeraTerm.  The test application sends characters periodically and receives anything that is sent.  I verified that, when I sent CTRL-S via TeraTerm, the application paused its transmission, resuming it on receipt of CTRL-Q.  In the other direction, I pasted large blocks of text into TeraTerm and verified that there were periodic pauses as flow control occurred, and that no data was lost during the transmission of those large blocks of data at high speed.

I also tested with my existing C++ application running on the other end, which depends on flow control to avoid overrunning the receiver.  The system works correctly, without data loss, when XONXOFF flow control is enabled.

The ESP32 API for enabling XON/XOFF flow control is the same on all ESP32 variants, so there is no reason to expect differences across the ESP32 family.

### Trade-offs and Alternatives

The code size increase is 384 bytes of FLASH.

The only alternative that would work in my application (short of going back to C++) would be to revamp the serial line protocol to wrap all of the messages in limited-length packets and apply some form of request/acknowledge flow control at the packet level.  That would require a lot of design and implementation on an existing stable product at the other end.

Trying to do the XON/XOFF at the Python level is unlikely to work, considering the high speed of the communication link, the limited size of the ESP32's hardware FIFO, and hard-to-control latencies introduced by the display driver and the LVGL stack.

As previously mentioned, RTS/CTS hardware flow control is not feasible because of severe pin limitations at both ends of the communications channel, as well as existing cabling techniques that are deployed in existing variants of this new device.

