### PR TITLE
qemu: Enable more via-mpy and via-mpy with native emitter tests

### DIFF
--- a/ports/qemu/Makefile
+++ b/ports/qemu/Makefile
@@ -128,6 +128,8 @@ CFLAGS += $(SPECS_FRAGMENT)
 LDFLAGS += $(SPECS_FRAGMENT)
 endif
 
+RUN_TESTS_FULL_ARGS = -t execpty:"$(QEMU_SYSTEM) $(QEMU_ARGS) -serial pty -kernel ../ports/qemu/$<" $(RUN_TESTS_ARGS)
+
 ################################################################################
 # Source files and libraries
 
@@ -169,8 +171,13 @@ run: $(BUILD)/firmware.elf
 
 .PHONY: test
 test: $(BUILD)/firmware.elf
-	$(eval DIRNAME=ports/$(notdir $(CURDIR)))
-	cd $(TOP)/tests && ./run-tests.py -t execpty:"$(QEMU_SYSTEM) $(QEMU_ARGS) -serial pty -kernel ../$(DIRNAME)/$<" $(RUN_TESTS_ARGS) $(RUN_TESTS_EXTRA)
+	cd $(TOP)/tests && ./run-tests.py $(RUN_TESTS_FULL_ARGS) $(RUN_TESTS_EXTRA)
+
+.PHONY: test_full
+test_full: $(BUILD)/firmware.elf
+	cd $(TOP)/tests && ./run-tests.py $(RUN_TESTS_FULL_ARGS)
+	cd $(TOP)/tests && ./run-tests.py $(RUN_TESTS_FULL_ARGS) --via-mpy
+	cd $(TOP)/tests && ./run-tests.py $(RUN_TESTS_FULL_ARGS) --via-mpy --emit native
 
 .PHONY: test_natmod
 test_natmod: $(BUILD)/firmware.elf

--- a/ports/qemu/boards/SABRELITE.mk
+++ b/ports/qemu/boards/SABRELITE.mk
@@ -16,4 +16,7 @@ SRC_BOARD_O = shared/runtime/gchelper_generic.o
 MPY_CROSS_FLAGS += -march=armv6
 
 # These tests don't work on Cortex-A9, so exclude them.
-RUN_TESTS_ARGS = --exclude 'inlineasm/thumb/(asmdiv|asmspecialregs).py'
+RUN_TESTS_ARGS += --exclude 'inlineasm/thumb/(asmbcc|asmbitops|asmconst|asmdiv|asmit|asmspecialregs).py'
+
+# These tests fail with via-mpy and the native (armv6) emitter, so exclude them.
+RUN_TESTS_ARGS += --exclude 'extmod/vfs_rom.py|float/math_domain.py'

--- a/py/asmarm.c
+++ b/py/asmarm.c
@@ -328,7 +328,7 @@ void asm_arm_ldrh_reg_reg(asm_arm_t *as, uint rd, uint rn) {
 
 void asm_arm_ldrh_reg_reg_offset(asm_arm_t *as, uint rd, uint rn, uint byte_offset) {
     // ldrh rd, [rn, #off]
-    emit_al(as, 0x1f000b0 | (rn << 16) | (rd << 12) | ((byte_offset & 0xf0) << 4) | (byte_offset & 0xf));
+    emit_al(as, 0x1d000b0 | (rn << 16) | (rd << 12) | ((byte_offset & 0xf0) << 4) | (byte_offset & 0xf));
 }
 
 void asm_arm_ldrb_reg_reg(asm_arm_t *as, uint rd, uint rn) {

--- a/tests/extmod/vfs_rom.py
+++ b/tests/extmod/vfs_rom.py
@@ -1,7 +1,7 @@
 # Test VfsRom filesystem.
 
 try:
-    import sys, struct, os, uctypes, vfs
+    import errno, sys, struct, os, uctypes, vfs
 
     vfs.VfsRom
 except (ImportError, AttributeError):

--- a/tests/run-tests.py
+++ b/tests/run-tests.py
@@ -84,6 +84,8 @@ class __FS:
     pass
   def chdir(self, path):
     pass
+  def getcwd(self):
+    return ""
   def stat(self, path):
     if path == '__injected_test.mpy':
       return tuple(0 for _ in range(10))

--- a/tests/run-tests.py
+++ b/tests/run-tests.py
@@ -65,7 +65,9 @@ injected_import_hook_code = """\
 import sys, os, io, vfs
 class __File(io.IOBase):
   def __init__(self):
-    sys.modules['__injected_test'].__name__ = '__main__'
+    module = sys.modules['__injected_test']
+    module.__name__ = '__main__'
+    sys.modules['__main__'] = module
     self.off = 0
   def ioctl(self, request, arg):
     if request == 4: # MP_STREAM_CLOSE

--- a/tools/ci.sh
+++ b/tools/ci.sh
@@ -285,14 +285,14 @@ function ci_qemu_build_arm {
     make ${MAKEOPTS} -C ports/qemu submodules
     make ${MAKEOPTS} -C ports/qemu CFLAGS_EXTRA=-DMP_ENDIANNESS_BIG=1
     make ${MAKEOPTS} -C ports/qemu clean
-    make ${MAKEOPTS} -C ports/qemu test
-    make ${MAKEOPTS} -C ports/qemu BOARD=SABRELITE test
+    make ${MAKEOPTS} -C ports/qemu test_full
+    make ${MAKEOPTS} -C ports/qemu BOARD=SABRELITE test_full
 }
 
 function ci_qemu_build_rv32 {
     make ${MAKEOPTS} -C mpy-cross
     make ${MAKEOPTS} -C ports/qemu BOARD=VIRT_RV32 submodules
-    make ${MAKEOPTS} -C ports/qemu BOARD=VIRT_RV32 test
+    make ${MAKEOPTS} -C ports/qemu BOARD=VIRT_RV32 test_full
 
     # Test building and running native .mpy with rv32imc architecture.
     ci_native_mpy_modules_build rv32imc


### PR DESCRIPTION
### Summary

The qemu port has recently undergone a lot of improvement, including adding of RISC-V support and improved test running to use the standard bare-metal test approach.

One of the reasons to improve the test runner was to be able to enable more native emitter tests on the qemu port, by leveraging the `--via-mpy` and `--emit native` arguments to `run-tests.py`.

That can now be done, and is now done in this PR.

### Testing

Tested locally with `make test_full`.  Updated CI to use this new `test_full` make target.

### Trade-offs and Alternatives

This will make CI a bit slower but not by much, and the benefit is well worth it (better test coverage of the ARM and RISC-V native emitters).
