### PR TITLE
pydfu: Add support for USB serial number argument to handle multiple DFU devices

### DIFF
--- a/tools/pydfu.py
+++ b/tools/pydfu.py
@@ -107,15 +107,23 @@ def find_dfu_cfg_descr(descr):
     return None
 
 
-def init(**kwargs):
+def init(serial_number, **kwargs):
     """Initializes the found DFU device so that we can program it."""
     global __dev, __cfg_descr
     devices = get_dfu_devices(**kwargs)
     if not devices:
         raise ValueError("No DFU device found")
-    if len(devices) > 1:
-        raise ValueError("Multiple DFU devices found")
-    __dev = devices[0]
+    elif serial_number is not None:
+        for dev in devices:
+            if dev.serial_number == serial_number:
+                __dev = dev
+                break
+        else:
+            raise ValueError(f"DFU device with serial number: {serial_number} was not found")
+    elif len(devices) > 1:
+        raise ValueError("Multiple DFU devices found, use --serial to select device")
+    else:
+        __dev = devices[0]
     __dev.set_configuration()
 
     # Claim DFU interface
@@ -570,6 +578,7 @@ def main():
     parser.add_argument(
         "-m", "--mass-erase", help="mass erase device", action="store_true", default=False
     )
+    parser.add_argument("--serial", help="Serial number of required DFU", default=None)
     parser.add_argument(
         "-u", "--upload", help="read file from DFU device", dest="path", default=False
     )
@@ -592,7 +601,7 @@ def main():
         list_dfu_devices(**kwargs)
         return
 
-    init(**kwargs)
+    init(args.serial, **kwargs)
 
     command_run = False
     if args.mass_erase:


### PR DESCRIPTION
In automated testing platforms that use multiple Micropython devices and run within CI/CD pipelines, there can be cases where two or more devices are left in DFU mode, causing the `pydfu` flashing process to fail with the following error:

```
pydfu.py", line 117, in init
    raise ValueError("Multiple DFU devices found")
ValueError: Multiple DFU devices found
```

To allow distinguishing between DFU devices a serial number argument was added. It can be retrieved using the dmesg:

```
usb 1-7.3: Product: STM32  BOOTLOADER
usb 1-7.3: Manufacturer: STMicroelectronics
usb 1-7.3: SerialNumber: 315C34853133
```

The serial number should be passed as is, for example:

```
./pydfu.py -u firmware.dfu --serial 315C34853133
```

With the serial number argument, users and CI/CD pipelines can now flash specific devices, even when multiple DFU devices are present.