### PR TITLE
esp32/machine_hw_spi: Reject invalid number of bits in constructor.

### DIFF
--- a/ports/esp32/machine_hw_spi.c
+++ b/ports/esp32/machine_hw_spi.c
@@ -196,6 +196,10 @@ static void machine_hw_spi_init_internal(machine_hw_spi_obj_t *self, mp_arg_val_
         changed = true;
     }
 
+    if (args[ARG_bits].u_int != -1 && args[ARG_bits].u_int <= 0) {
+        mp_raise_ValueError(MP_ERROR_TEXT("invalid bits"));
+    }
+
     if (args[ARG_bits].u_int != -1 && args[ARG_bits].u_int != self->bits) {
         self->bits = args[ARG_bits].u_int;
         changed = true;


### PR DESCRIPTION
### Summary

This commit adds an extra bit of parameters validation to the SPI bus constructor on ESP32.  Passing 0 as the number of bits would trigger a division by zero error when performing read/write operations on an SPI bus created in such a fashion.

This fixes #5910.

### Testing

This was tested locally on an ESP32-D0WD:

```
MicroPython v1.24.0-preview.363.g17d823445.dirty on 2024-10-01; Generic ESP32 module with ESP32
Type "help()" for more information.
>>> import machine
>>> machine.SPI(2, 10000000, sck=10, mosi=20, phase=0, bits=0, firstbit=0)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
ValueError: Invalid number of bits (0)
>>> machine.SPI(2, 10000000, sck=10, mosi=20, phase=0, bits=-2, firstbit=0)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
ValueError: Invalid number of bits (-2)
>>> machine.SPI(2, 10000000, sck=10, mosi=20, phase=0, bits=-1, firstbit=0)
SPI(id=2, baudrate=10000000, polarity=0, phase=0, bits=8, firstbit=0, sck=10, mosi=20, miso=19)
>>> 
```

### Trade-offs and Alternatives

This PR fixes the issue on ESP32, but maybe this is still a problems on other ports.  I do not have many non-ESP32 boards that are currently supported around here so I can only claim this fixes the ESP32 version of the bug.  Given that the bus instances are constructed in platform-specific code then I'd have to fix all of them if they have this specific issue.  I've got no problem in doing the fix on other platforms but I may not be able to perform code validation.