### PR TITLE
esp32: Apply the LWIP active TCP socket limit.

### DIFF
--- a/ports/esp32/CMakeLists.txt
+++ b/ports/esp32/CMakeLists.txt
@@ -74,5 +74,9 @@ list(APPEND EXTRA_COMPONENT_DIRS main_${IDF_TARGET})
 # Enable the panic handler wrapper
 idf_build_set_property(LINK_OPTIONS "-Wl,--wrap=esp_panic_handler" APPEND)
 
+# Patch LWIP memory pool allocators (see lwip_patch.c)
+idf_build_set_property(LINK_OPTIONS "-Wl,--wrap=memp_malloc" APPEND)
+idf_build_set_property(LINK_OPTIONS "-Wl,--wrap=memp_free" APPEND)
+
 # Define the project.
 project(micropython)

--- a/ports/esp32/boards/sdkconfig.base
+++ b/ports/esp32/boards/sdkconfig.base
@@ -133,3 +133,7 @@ CONFIG_NEWLIB_NANO_FORMAT=y
 # Due to limitations in the PMP system this feature breaks native emitters
 # so is disabled by default.
 CONFIG_ESP_SYSTEM_PMP_IDRAM_SPLIT=n
+
+# Further limit total sockets in TIME-WAIT when there are many short-lived
+# connections.
+CONFIG_LWIP_MAX_ACTIVE_TCP=12

--- a/ports/esp32/esp32_common.cmake
+++ b/ports/esp32/esp32_common.cmake
@@ -108,6 +108,7 @@ list(APPEND MICROPY_SOURCE_PORT
     network_wlan.c
     mpnimbleport.c
     modsocket.c
+    lwip_patch.c
     modesp.c
     esp32_nvs.c
     esp32_partition.c

--- a/ports/esp32/lwip_patch.c
+++ b/ports/esp32/lwip_patch.c
@@ -1,0 +1,64 @@
+/*
+ * This file is part of the MicroPython project, http://micropython.org/
+ *
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2024 Angus Gratton
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+#include "lwip/memp.h"
+
+// This is a link-time patch to enforce the limit of max active TCP PCBs. A
+// workaround for upstream issue https://github.com/espressif/esp-idf/issues/9670
+//
+// Without this limit the number of TCP PCBs in TIME-WAIT is unbounded, which can
+// have two problems on systems with a lot of short-lived TCP connections:
+//
+// - Higher memory usage.
+// - Increased chance of stalled TCP connections due to port reuse.
+
+static unsigned active_tcp_pcbs;
+
+void *__real_memp_malloc(memp_t type);
+void __real_memp_free(memp_t type, void *mem);
+
+void *__wrap_memp_malloc(memp_t type) {
+    if (type != MEMP_TCP_PCB) {
+        return __real_memp_malloc(type);
+    }
+
+    if (active_tcp_pcbs >= MEMP_NUM_TCP_PCB) {
+        return NULL;
+    }
+
+    void *res = __real_memp_malloc(MEMP_TCP_PCB);
+    if (res != NULL) {
+        ++active_tcp_pcbs;
+    }
+    return res;
+}
+
+void __wrap_memp_free(memp_t type, void *mem) {
+    __real_memp_free(type, mem);
+    if (type == MEMP_TCP_PCB && mem != NULL) {
+        assert(active_tcp_pcbs);
+        --active_tcp_pcbs;
+    }
+}


### PR DESCRIPTION
### Summary

This is a workaround for a bug in ESP-IDF where the configuration setting for LWIP maximum active TCP sockets (PCBs) is not applied. See https://github.com/espressif/esp-idf/issues/9670

Fixes cases where a lot of short-lived TCP connections can cause:

- Excessive memory usage (unbounded number of sockets in TIME-WAIT).
- Much higher risk of stalled connections due to repeated port numbers. The maximum number of active TCP PCBs is reduced from 16 to 12 to further reduce this risk.

This is not a 100% fix for the second point: a peer can still reuse a port number while a previous socket is in TIME-WAIT, and LWIP will reject that connection (in an RFC compliant way) causing the peer to stall.

* Closes #15844
* Closes #12819

(Note that this may not be a complete fix for every failure reported in those issues, but it should fix most of them. Will need additional info to reproduce any remaining problems, so probably worth opening a new issue.)

### Testing

Using the test program supplied in the issue report for #15844, and this test client:

```py
#!/usr/bin/env python
import time
import requests

IP = '192.168.66.125:80'

start = time.time()

for i in range(1000_000):
    r = requests.get(f'http://{IP}/*JOY;{i};0;0;0;0;0', timeout=20)
    r.close()
    print(i, time.time() - start)
    time.sleep(0.15)
```

* On master branch this test fails reliably, often in the first 500 iterations and always before 1000 iterations. Packet captures show a local port is reused by the client and that connection stalls (until either the client times out or the server socket ages out of TIME-WAIT).
* With the fix in this PR applied but the default max number of TCP PCBs (16), failures were seen between 1000 and 2000 iterations.
* With all changes in the PR applied, including reducing the max TCP PCBs to 12, a failure happened after 28,000 iterations and 1h40m (unclear if this was due to port reuse or another transient network issue). A follow up test has run over 7,000 iterations without failing. EDIT: This test stopped after 16,579 iterations due to reused port.

The frequency of TCP local port reuse depends on the client system (in this case desktop Linux), so may vary depending on the host OS and other network usage.

### Trade-offs and Alternatives

* The trade-off to sockets being cleaned up out of TIME-WAIT early is the possibility of delayed packets sent to the old socket being received by a new socket on the same port (see RFC1337). This patch compromises by only cleaning up sockets early when a lot of short-lived sockets are created, otherwise the full TIME-WAIT period should apply.
* As discussed in the linked issues it is possible to lower the MSL instead, so TIME-WAIT always ends more rapidly (say reduced from 120 seconds to 10 seconds). On quality network links this is probably fine, but may lead to problems on poor network links.
* LWIP could implement the behaviour of many other TCP/IP stacks: accept an out-of-window SYN on a TIME-WAIT socket so the reused port can be opened. Then port reuse would (mostly) not trigger stalled connections. See the [last heading in this comment](https://github.com/micropython/micropython/issues/15844#issuecomment-2384979336) for some discussion. However, out of scope for MicroPython to be able to change this - would need to be discussed with the LWIP maintainers, then wait for the change to be adopted by esp-lwip.

*This work was funded through GitHub Sponsors.*