### PR TITLE
ports: Include py/mphal.h instead of mphalport.h.

### DIFF
--- a/ports/esp32/esp32_nvs.c
+++ b/ports/esp32/esp32_nvs.c
@@ -28,7 +28,7 @@
 
 #include "py/runtime.h"
 #include "py/mperrno.h"
-#include "mphalport.h"
+#include "py/mphal.h"
 #include "modesp32.h"
 #include "nvs_flash.h"
 #include "nvs.h"

--- a/ports/esp32/esp32_partition.c
+++ b/ports/esp32/esp32_partition.c
@@ -28,8 +28,8 @@
 
 #include "py/runtime.h"
 #include "py/mperrno.h"
+#include "py/mphal.h"
 #include "extmod/vfs.h"
-#include "mphalport.h"
 #include "modesp32.h"
 #include "esp_ota_ops.h"
 

--- a/ports/esp32/esp32_rmt.c
+++ b/ports/esp32/esp32_rmt.c
@@ -24,9 +24,9 @@
  * THE SOFTWARE.
  */
 
+#include "py/mphal.h"
 #include "py/runtime.h"
 #include "modmachine.h"
-#include "mphalport.h"
 #include "modesp32.h"
 
 #include "esp_task.h"

--- a/ports/esp32/machine_pin.c
+++ b/ports/esp32/machine_pin.c
@@ -37,7 +37,6 @@
 #include "py/mphal.h"
 #include "extmod/modmachine.h"
 #include "extmod/virtpin.h"
-#include "mphalport.h"
 #include "modmachine.h"
 #include "machine_pin.h"
 #include "machine_rtc.h"

--- a/ports/esp32/machine_timer.c
+++ b/ports/esp32/machine_timer.c
@@ -30,10 +30,10 @@
 #include <stdint.h>
 #include <stdio.h>
 
+#include "py/mphal.h"
 #include "py/obj.h"
 #include "py/runtime.h"
 #include "modmachine.h"
-#include "mphalport.h"
 
 #include "hal/timer_hal.h"
 #include "hal/timer_ll.h"

--- a/ports/esp32/modespnow.c
+++ b/ports/esp32/modespnow.c
@@ -50,7 +50,6 @@
 
 #if MICROPY_PY_ESPNOW
 
-#include "mphalport.h"
 #include "modnetwork.h"
 #include "modespnow.h"
 

--- a/ports/esp32/mphalport.c
+++ b/ports/esp32/mphalport.c
@@ -44,7 +44,6 @@
 #include "shared/runtime/pyexec.h"
 #include "shared/tinyusb/mp_usbd.h"
 #include "shared/tinyusb/mp_usbd_cdc.h"
-#include "mphalport.h"
 #include "usb.h"
 #include "usb_serial_jtag.h"
 #include "uart.h"

--- a/ports/mimxrt/tusb_port.c
+++ b/ports/mimxrt/tusb_port.c
@@ -25,7 +25,7 @@
  */
 
 #include "tusb.h"
-#include "mphalport.h"
+#include "py/mphal.h"
 
 #ifndef MICROPY_HW_USB_VID
 #define MICROPY_HW_USB_VID (0xf055)

--- a/ports/nrf/drivers/bluetooth/ble_drv.c
+++ b/ports/nrf/drivers/bluetooth/ble_drv.c
@@ -30,13 +30,13 @@
 #include <string.h>
 #include <stdbool.h>
 
+#include "py/mphal.h"
 #include "py/runtime.h"
 #include "ble_drv.h"
 #include "nrf_sdm.h"
 #include "ble_gap.h"
 #include "ble.h" // sd_ble_uuid_encode
 #include "drivers/flash.h"
-#include "mphalport.h"
 
 
 #if MICROPY_HW_ENABLE_USBDEV && MICROPY_HW_USB_CDC

--- a/ports/nrf/drivers/bluetooth/ble_uart.c
+++ b/ports/nrf/drivers/bluetooth/ble_uart.c
@@ -29,8 +29,8 @@
 #include <string.h>
 #include "ble_uart.h"
 #include "ringbuffer.h"
-#include "mphalport.h"
 #include "shared/runtime/interrupt_char.h"
+#include "py/mphal.h"
 #include "py/runtime.h"
 
 #if MICROPY_PY_SYS_STDFILES

--- a/ports/nrf/main.c
+++ b/ports/nrf/main.c
@@ -31,6 +31,7 @@
 
 #include "py/nlr.h"
 #include "py/mperrno.h"
+#include "py/mphal.h"
 #include "py/lexer.h"
 #include "py/parse.h"
 #include "py/obj.h"
@@ -53,7 +54,6 @@
 #include "i2c.h"
 #include "adc.h"
 #include "rtcounter.h"
-#include "mphalport.h"
 
 #if MICROPY_PY_MACHINE_HW_PWM
 #include "pwm.h"

--- a/ports/nrf/modules/board/led.c
+++ b/ports/nrf/modules/board/led.c
@@ -25,9 +25,9 @@
  * THE SOFTWARE.
  */
 
+#include "py/mphal.h"
 #include "py/runtime.h"
 
-#include "mphalport.h"
 #include "led.h"
 #include "mpconfigboard.h"
 

--- a/ports/nrf/modules/machine/rtcounter.c
+++ b/ports/nrf/modules/machine/rtcounter.c
@@ -25,9 +25,8 @@
  * THE SOFTWARE.
  */
 
-#include "py/nlr.h"
+#include "py/mphal.h"
 #include "py/runtime.h"
-#include "mphalport.h"
 #include "rtcounter.h"
 #include "nrfx_rtc.h"
 #include "nrf_clock.h"

--- a/ports/nrf/modules/ubluepy/ubluepy_scanner.c
+++ b/ports/nrf/modules/ubluepy/ubluepy_scanner.c
@@ -25,7 +25,7 @@
  */
 
 #include <string.h>
-#include "py/obj.h"
+#include "py/mphal.h"
 #include "py/runtime.h"
 #include "py/objstr.h"
 #include "py/objlist.h"
@@ -33,7 +33,6 @@
 #if MICROPY_PY_UBLUEPY_CENTRAL
 
 #include "ble_drv.h"
-#include "mphalport.h"
 
 static void adv_event_handler(mp_obj_t self_in, uint16_t event_id, ble_drv_adv_data_t * data) {
     ubluepy_scanner_obj_t *self = MP_OBJ_TO_PTR(self_in);

--- a/ports/nrf/nrfx_log.h
+++ b/ports/nrf/nrfx_log.h
@@ -28,7 +28,7 @@
 #define NRFX_LOG_H
 
 #include <stdio.h>
-#include "mphalport.h"
+#include "py/mphal.h"
 #include "nrfx_config.h"
 
 #define LOG_TEST_UART 1

--- a/ports/samd/fatfs_port.c
+++ b/ports/samd/fatfs_port.c
@@ -25,7 +25,7 @@
  * THE SOFTWARE.
  */
 
-#include "mphalport.h"
+#include "py/mphal.h"
 #include "py/runtime.h"
 #include "shared/timeutils/timeutils.h"
 #include "lib/oofatfs/ff.h"

--- a/ports/samd/samd_soc.c
+++ b/ports/samd/samd_soc.c
@@ -31,12 +31,12 @@
  * THE SOFTWARE.
  */
 
+#include "py/mphal.h"
 #include "py/runtime.h"
 #include "modmachine.h"
 #include "samd_soc.h"
 #include "sam.h"
 #include "tusb.h"
-#include "mphalport.h"
 
 extern void machine_rtc_start(bool force);
 

--- a/ports/webassembly/mphalport.c
+++ b/ports/webassembly/mphalport.c
@@ -25,8 +25,8 @@
  */
 
 #include <unistd.h>
+#include "py/mphal.h"
 #include "library.h"
-#include "mphalport.h"
 
 static void stderr_print_strn(void *env, const char *str, size_t len) {
     (void)env;


### PR DESCRIPTION
The `mphalport.h` header should not be included directly, rather `py/mphal.h` should be used.
