### PR TITLE
docs/esp8266/tutorial/neopixel.rst: fix wrong index into array in example

### DIFF
--- a/docs/esp8266/tutorial/neopixel.rst
+++ b/docs/esp8266/tutorial/neopixel.rst
@@ -48,7 +48,7 @@ The following demo function makes a fancy show on the LEDs::
         # cycle
         for i in range(4 * n):
             for j in range(n):
-                np[j] = (0, 0, 0)
+                np[j-1] = (0, 0, 0)
             np[i % n] = (255, 255, 255)
             np.write()
             time.sleep_ms(25)
@@ -56,7 +56,7 @@ The following demo function makes a fancy show on the LEDs::
         # bounce
         for i in range(4 * n):
             for j in range(n):
-                np[j] = (0, 0, 128)
+                np[j-1] = (0, 0, 128)
             if (i // n) % 2 == 0:
                 np[i % n] = (0, 0, 0)
             else:
@@ -71,7 +71,7 @@ The following demo function makes a fancy show on the LEDs::
                     val = i & 0xff
                 else:
                     val = 255 - (i & 0xff)
-                np[j] = (val, 0, 0)
+                np[j-1] = (val, 0, 0)
             np.write()
 
         # clear


### PR DESCRIPTION
### Summary

While checking for neopixel support I noticed the example code provided in the docs. When testing the same by copy/paste, I got an array index exception. at line 51. The for loop on the `range(n)` is starting at `1` while the NP pixel array starts at `0`. The provided fix is shifting the index access by -1.

### Testing

The original sample code was throwing an indexing exception in line 51, the new one is running without.
