### PR TITLE
stm32: Remove preemptive keyboard interrupt via PendSV

### DIFF
--- a/ports/renesas-ra/pendsv.h
+++ b/ports/renesas-ra/pendsv.h
@@ -48,7 +48,6 @@ enum {
 typedef void (*pendsv_dispatch_t)(void);
 
 void pendsv_init(void);
-void pendsv_kbd_intr(void);
 void pendsv_schedule_dispatch(size_t slot, pendsv_dispatch_t f);
 
 #endif // MICROPY_INCLUDED_RENESAS_RA_PENDSV_H

--- a/ports/renesas-ra/uart.c
+++ b/ports/renesas-ra/uart.c
@@ -49,7 +49,7 @@ static KEYEX_CB keyex_cb[MICROPY_HW_MAX_UART] = {(KEYEX_CB)NULL};
 
 static int chk_kbd_interrupt(int d) {
     if (d == mp_interrupt_char) {
-        pendsv_kbd_intr();
+        mp_sched_keyboard_interrupt();
         return 1;
     } else {
         return 0;

--- a/ports/stm32/boards/common_isr_ram/common_isr.ld
+++ b/ports/stm32/boards/common_isr_ram/common_isr.ld
@@ -14,7 +14,7 @@
        flash (in main.c) along with the isr_vector above.
     */
     . = ALIGN(4);
-    *(.text.pendsv_kbd_intr)
+    *(.text.mp_sched_keyboard_interrupt)
     *(.text.pendsv_schedule_dispatch)
     *(.text.storage_systick_callback)
     *(.text.SysTick_Handler)

--- a/ports/stm32/pendsv.h
+++ b/ports/stm32/pendsv.h
@@ -51,7 +51,6 @@ enum {
 typedef void (*pendsv_dispatch_t)(void);
 
 void pendsv_init(void);
-void pendsv_kbd_intr(void);
 void pendsv_schedule_dispatch(size_t slot, pendsv_dispatch_t f);
 
 #endif // MICROPY_INCLUDED_STM32_PENDSV_H

--- a/ports/stm32/uart.c
+++ b/ports/stm32/uart.c
@@ -1229,7 +1229,7 @@ void uart_irq_handler(mp_uint_t uart_id) {
                 data &= self->char_mask;
                 if (self->attached_to_repl && data == mp_interrupt_char) {
                     // Handle interrupt coming in on a UART REPL
-                    pendsv_kbd_intr();
+                    mp_sched_keyboard_interrupt();
                 } else {
                     if (self->char_width == CHAR_WIDTH_9BIT) {
                         ((uint16_t *)self->read_buf)[self->read_buf_head] = data;

--- a/ports/stm32/usbd_cdc_interface.c
+++ b/ports/stm32/usbd_cdc_interface.c
@@ -315,7 +315,7 @@ int8_t usbd_cdc_receive(usbd_cdc_state_t *cdc_in, size_t len) {
     // copy the incoming data into the circular buffer
     for (const uint8_t *src = cdc->rx_packet_buf, *top = cdc->rx_packet_buf + len; src < top; ++src) {
         if (cdc->attached_to_repl && *src == mp_interrupt_char) {
-            pendsv_kbd_intr();
+            mp_sched_keyboard_interrupt();
         } else {
             uint16_t next_put = (cdc->rx_buf_put + 1) & (MICROPY_HW_USB_CDC_RX_DATA_SIZE - 1);
             if (next_put == cdc->rx_buf_get) {


### PR DESCRIPTION
### Summary

Since the very beginning, the `stm32` port (first called `stm`, then `stmhal` now `stm32`) has had a special keyboard interrupt feature which works by using PendSV to break out of any running code.

This preemptive ctrl-C was added long ago in commit 01156d510c728408be4fd3100bcee18e8985ac00

The `stm32` port still uses that ancient code, and current does this:
- If ctrl-C is received on UART or USB then `mp_sched_keyboard_interrupt()` is called (like all other ports) to set a flag for the VM to see, and then the VM (or any loop calling `mp_handle_pending(true)`) will eventually handle the `KeyboardInterrupt` exception, raising it via NLR.
- If another ctrl-C is received while the existing scheduled keyboard interrupt is still pending (ie the VM has not yet processed it) then a special hard NLR jump will activate, that preempts the calling code.  Within the PendSV interrupt the stack is adjusted and an NLR jump is made to the most recent `nlr_push()` location.  This is like a normal NLR except *it is called from an interrupt context and completely annihilates the code that was interrupted by the IRQ*.

The reason for the preemptive interrupt was to handle ctrl-C properly before the VM was able to handle it.  Then when the esp8266 port came along, it needed a more port-agnostic way to handle ctrl-C, and so the mechanism was added to the VM and runtime to be able to check for pending interrupts.  Then the `stm32` port was updated to use this mechanism, with a fallback to the old preemptive way if a second ctrl-C was received (without the first one being processed).

This preemptive NLR jump is problematic because it can interrupt long-running instructions (eg store multiple, usually used at the end of a function to restore registers and return).  If such an instruction is interrupted the CPU remembers that with some flags, and can resume the long-running instruction when the interrupt finishes.  But the preemptive NLR does a long jump to different code at thread level and so the long-running interrupt is never resumed.  This leads to a CPU fault.

This fault has been previously reported in #3807 and #3842 (see also #294).  I was never able to reproduce the issues reported there, but finally (after 6 years!) I can reproduce it.

The bad behaviour of preemptive NLR jump has become apparent since #15486.  If you run the test suite over and over again on any stm32 board, it will eventually crash the board (see testing section below).

The point is, a skipped test now soft resets the board and so the board must run `boot.py` again.  The test runner may then interrupt the execution of `boot.py` with the double-ctrl-C that it sends (in `tools/pyboard.py:enter_raw_repl()`) in order to get the board into a known good state for the next test.  If the timing is right, this can trigger the preemptive PendSV in an unfortunate location and hard fault the board.

The fix in this PR is to just remove the preemptive NLR jump feature.  No other port has this feature and it's not needed, ctrl-C works very well on those ports.  Preemptive NLR jump is a very dangerous thing and is obviously buggy.

See this comment here which suggests what's done in this PR: https://github.com/micropython/micropython/issues/3842#issuecomment-396935908

### Testing

I have been using this to trigger the fault:
```
while true; do ./run-tests.py --target pyboard -d extmod stress float micropython basics misc --exclude extreme_exc --exclude mtime --exclude pow3_intbig --exclude recursive_iternext  --exclude float_parse --exclude math_constants --exclude vfs_blockdev_invalid || break; done
```
That can trigger the error on PYBv1.x, but it happens more regularly on PYBD-SF2/6.

With this PR, the board no longer hard faults.  (But it does show a new issue, it can still interrupt `boot.py` with a single ctrl-C, and that will be fixed in a follow-up PR.)

### Trade-offs and Alternatives

Could clear the CPU state for the long-running instruction as suggested in #3842.  But it's much simpler to just remove this code, which can have other issues as per #294.