### PR TITLE
stm32: Refactor pyb.CAN implementation, add tests.

### DIFF
--- a/ports/stm32/main.c
+++ b/ports/stm32/main.c
@@ -86,7 +86,7 @@
 #include "accel.h"
 #include "servo.h"
 #include "dac.h"
-#include "can.h"
+#include "pyb_can.h"
 #include "subghz.h"
 
 #if MICROPY_PY_THREAD
@@ -536,7 +536,7 @@ soft_reset:
     timer_init0();
 
     #if MICROPY_HW_ENABLE_CAN
-    can_init0();
+    pyb_can_init0();
     #endif
 
     #if MICROPY_HW_ENABLE_USB
@@ -683,7 +683,7 @@ soft_reset_exit:
     pyb_i2c_deinit_all();
     #endif
     #if MICROPY_HW_ENABLE_CAN
-    can_deinit_all();
+    pyb_can_deinit_all();
     #endif
     #if MICROPY_HW_ENABLE_DAC
     dac_deinit_all();

--- a/ports/stm32/modpyb.c
+++ b/ports/stm32/modpyb.c
@@ -41,7 +41,7 @@
 #include "i2c.h"
 #include "spi.h"
 #include "uart.h"
-#include "can.h"
+#include "pyb_can.h"
 #include "adc.h"
 #include "storage.h"
 #include "sdcard.h"

--- a/ports/stm32/pyb_can.h
+++ b/ports/stm32/pyb_can.h
@@ -1,0 +1,58 @@
+/*
+ * This file is part of the MicroPython project, http://micropython.org/
+ *
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2014 Damien P. George
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+#ifndef MICROPY_INCLUDED_STM32_PYB_CAN_H
+#define MICROPY_INCLUDED_STM32_PYB_CAN_H
+
+#include "py/mphal.h"
+
+#if MICROPY_HW_ENABLE_CAN
+
+#include "py/obj.h"
+#include "can.h"
+
+typedef struct _pyb_can_obj_t {
+    mp_obj_base_t base;
+    mp_obj_t rxcallback0;
+    mp_obj_t rxcallback1;
+    mp_uint_t can_id : 8;
+    bool is_enabled : 1;
+    byte rx_state0;
+    byte rx_state1;
+    uint16_t num_error_warning;
+    uint16_t num_error_passive;
+    uint16_t num_bus_off;
+    CAN_HandleTypeDef can;
+} pyb_can_obj_t;
+
+extern const mp_obj_type_t pyb_can_type;
+
+void pyb_can_deinit_all(void);
+void pyb_can_init0(void);
+
+void pyb_can_irq_handler(uint can_id, can_rx_fifo_t fifo, can_int_t interrupt);
+
+#endif
+#endif

--- a/tests/multi_pyb_can/rx_callback.py
+++ b/tests/multi_pyb_can/rx_callback.py
@@ -1,0 +1,98 @@
+from pyb import CAN
+import time
+import errno
+
+# Test the various receive IRQs, including overflow
+
+rx_overflow = False
+
+REASONS = ["received", "full", "overflow"]
+
+# CAN IDs
+ID_SPAM = 0x345  # messages spammed into the receive FIFO
+ID_ACK_OFLOW = 0x055  # message the receiver sends after it's seen an overflow
+ID_AFTER = 0x100  # message the sender sends after the ACK
+
+
+def cb0(bus, reason):
+    global rx_overflow
+    if reason != 0 and not rx_overflow:
+        # exact timing of 'received' callbacks depends on controller type,
+        # so only log the other two
+        print("rx0 reason", REASONS[reason])
+    if reason == 2:
+        rx_overflow = True
+
+
+# Accept all standard IDs on FIFO 0
+def _enable_accept_all():
+    if hasattr(CAN, "MASK"):  # FD-CAN controller
+        can.setfilter(0, CAN.RANGE, 0, (0x0, 0x7FF), extframe=False)
+    else:
+        can.setfilter(0, CAN.MASK16, 0, (0, 0, 0, 0), extframe=False)
+
+
+# Receiver
+def instance0():
+    _enable_accept_all()
+    can.rxcallback(0, cb0)
+
+    multitest.next()
+    multitest.wait("sender ready")
+    multitest.broadcast("receiver ready")
+
+    while not rx_overflow:
+        pass  # Resume ASAP after FIFO0 overflows
+
+    can.send(b"overflow", ID_ACK_OFLOW)
+
+    # drain the receive FIFO, making sure we read at least on ID_SPAM message
+    rxed_spam = False
+    while can.any(0):
+        msg = can.recv(0, timeout=0)
+        assert msg[0] == ID_SPAM
+        rxed_spam = True
+    print("rxed_spam", rxed_spam)
+
+    # This should be the one message with ID_AFTER, there may be one or two spam messages as well
+    for _ in range(10):
+        msg = can.recv(0, timeout=500)
+        if msg[0] == ID_AFTER:
+            print(msg)
+            break
+
+    # RX FIFO should be empty now
+    print("any", can.any(0))
+
+
+# Sender
+def instance1():
+    _enable_accept_all()
+    multitest.next()
+    multitest.broadcast("sender ready")
+    multitest.wait("receiver ready")
+
+    # Spam out messages until the receiver tells us its RX FIFO is full.
+    #
+    # The RX FIFO on the receiver can vary from 3 deep (BXCAN) to 25 deep (STM32H7),
+    # so we keep sending to it until we see a CAN message on ID_ACK_OFLOW indicating
+    # the receiver's FIFO has overflowed
+    for i in range(255):
+        can.send(bytes([i] * 8), ID_SPAM, timeout=25)
+        if can.any(0):
+            print(can.recv(0))  # should be ID_ACK_OFLOW
+            break
+        # on boards like STM32H7 the TX FIFO is really deep, so don't fill it too quickly...
+        time.sleep_ms(1)
+
+    # give the receiver some time to make space in the FIFO
+    time.sleep_ms(200)
+
+    # send the final message, the receiver should get this one
+    can.send(b"aaaaa", ID_AFTER)
+
+    # Sender's RX FIFO should also be empty at this point
+    print("any", can.any(0))
+
+
+can = CAN(1, CAN.NORMAL, baudrate=500_000, sample_point=75)

--- a/tests/multi_pyb_can/rx_callback.py.exp
+++ b/tests/multi_pyb_can/rx_callback.py.exp
@@ -1,0 +1,9 @@
+--- instance0 ---
+rx0 reason full
+rx0 reason overflow
+rxed_spam True
+(256, False, False, 0, b'aaaaa')
+any False
+--- instance1 ---
+(85, False, False, 0, b'overflow')
+any False

--- a/tests/multi_pyb_can/rx_filters.py
+++ b/tests/multi_pyb_can/rx_filters.py
@@ -1,0 +1,50 @@
+from pyb import CAN
+import time
+import errno
+
+# Test for the filtering capabilities for RX FIFO 0 and 1.
+
+
+# Receiver
+def instance0():
+    # Configure to receive standard frames (in a range) on FIFO 0
+    # and extended frames (in a range) on FIFO 1.
+    if hasattr(CAN, "MASK"):
+        # FD-CAN has independent filter banks for standard and extended IDs
+        can.setfilter(0, CAN.MASK, 0, (0x300, 0x700), extframe=False)
+        can.setfilter(0, CAN.MASK, 1, (0x3000, 0x7000), extframe=True)
+    else:
+        # pyb.CAN only supports MASK32 for extended ids
+        can.setfilter(0, CAN.MASK16, 0, (0x300, 0x700, 0x300, 0x700), extframe=False)
+        can.setfilter(1, CAN.MASK32, 1, (0x3000, 0x7000), extframe=True)
+
+    multitest.next()
+    multitest.wait("sender ready")
+    multitest.broadcast("receiver ready")
+    for i in range(3):
+        print(i)
+        print("fifo0", can.recv(0, timeout=200))
+        print("fifo1", can.recv(1, timeout=200))
+
+    try:
+        can.recv(0, timeout=100)  # should time out
+    except OSError as e:
+        assert e.errno == errno.ETIMEDOUT
+        print("Timed out as expected")
+
+
+# Sender
+def instance1():
+    multitest.next()
+    multitest.broadcast("sender ready")
+    multitest.wait("receiver ready")
+
+    for i in range(3):
+        print(i)
+        can.send(bytes([i, 3] * i), 0x345)
+        can.send(bytes([0xEE] * i), 0x3700 + i, extframe=True)
+        can.send(b"abcdef", 0x123)  # matches no filter, expect ACKed but not received
+        time.sleep_ms(5)  # avoid flooding either our or the receiver's FIFO
+
+
+can = CAN(1, CAN.NORMAL, baudrate=500_000, sample_point=75)

--- a/tests/multi_pyb_can/rx_filters.py.exp
+++ b/tests/multi_pyb_can/rx_filters.py.exp
@@ -1,0 +1,15 @@
+--- instance0 ---
+0
+fifo0 (837, False, False, 0, b'')
+fifo1 (14080, True, False, 0, b'')
+1
+fifo0 (837, False, False, 0, b'\x01\x03')
+fifo1 (14081, True, False, 0, b'\xee')
+2
+fifo0 (837, False, False, 0, b'\x02\x03\x02\x03')
+fifo1 (14082, True, False, 0, b'\xee\xee')
+Timed out as expected
+--- instance1 ---
+0
+1
+2


### PR DESCRIPTION
### Summary

I've been gradually working on stm32 as the first implementation of the new CAN API (#12337), and first step was to refactor the low-level part of the `pyb.CAN` driver to be reusable from `machine.CAN` as well. In the course of doing this I also wrote some simple automated tests for `pyb.CAN`.

~~After doing the refactors and adding the tests I discovered some small bugs in various STM32 boards. This PR contains bugfix commits also submitted in #16543, #16545, #16546, #16547. Only the top two commits in this branch are unique to this PR (but it's difficult to run the tests without the other fixes).~~

can.h API changes (only relevant for anyone writing C code against this API):

* Peripheral argument is now `CAN_HandleTypeDef *` instead of `pyb_can_obj_t *`, to decouple the two layers.
* Adds a new `can_rx_fifo_t` enum for the RX FIFO selection. The numeric value of this enum is the same as the previous values used by bxCAN (0, 1), but they are different to the enums previously used by FDCAN. The FDCAN ST HAL enums are buffer offset values but these are now moved into the implementation and are no longer exposed in the API.
* Responsibility for re-enabling RX interrupts has been moved up to the caller of `can_receive()`. See pyb_can.c for the necessary code.

As part of the refactoring some `pyb.CAN` behaviour changed on FDCAN, to make it the same as bxCAN:

* FDCAN peripherals no longer send rx callbacks with ids 3,4,5 when the bus error state changes (this behaviour wasn't documented).
* FDCAN peripherals now increment the error counters the same as bxCAN-based peripherals. 

### Testing

Ran the new multi-tests via command line:

```
./run-multitests.py -i pyb:/dev/ttyACM0 -i pyb:/dev/ttyACM1 -p2 multi_pyb_can/*.py
```

Tests pass on various pairings of the following boards:

* PyBoard V1.1 (bxCAN).
* NUCLEO_H723ZG board (FDCAN).
* ARDUINO_NICLA_VISION (STM32H747, FDCAN)
* NUCLEO_G474RE board (FDCAN, but G series has different peripheral design to H5+H7).

### Trade-offs and Alternatives

* I think the only real alternative would have been to ignore the existing `pyb.CAN` driver and make the STM32 `machine.CAN` driver from scratch. Given how much refactoring was needed here then that does look like a somewhat appealing alternative in hindsight, especially as I'm not done yet! However, this way the code size will be smaller for as long as both `pyb.CAN` and the future `machine.CAN` drivers are included in MicroPython.

### Follow-up work (not in this PR)

* Add multi-tests around CAN-FD mode.
* Finish the stm32 machine.CAN implementation based on this lower layer.
