### PR TITLE
tests/run-tests.py: Wait for soft reset if a target skips a test.

### DIFF
--- a/tests/run-tests.py
+++ b/tests/run-tests.py
@@ -824,6 +824,12 @@ def run_tests(pyb, tests, args, result_dir, num_threads=1):
         output_mupy = run_micropython(pyb, args, test_file, test_file_abspath)
 
         if output_mupy == b"SKIP\n":
+            if pyb is not None and hasattr(pyb, "read_until"):
+                # Running on a target over a serial connection, and the target requested
+                # to skip the test.  It does this via a SystemExit which triggers a soft
+                # reset.  Wait for the soft reset to finish, so we don't interrupt the
+                # start-up code (eg boot.py) when preparing to run the next test.
+                pyb.read_until(1, b"raw REPL; CTRL-B to exit\r\n")
             print("skip ", test_file)
             skipped_tests.append(test_name)
             return


### PR DESCRIPTION
### Summary

Commit 69c25ea8653566ec97690b5121bd10b753c89426 made raising `SystemExit` do a soft reset (on bare-metal targets).  This means that any test which is skipped by a target (by raising `SystemExit`) will trigger a soft reset on that target, and then it must execute its startup code, such as `boot.py`.

If the timing is right, this startup code can be unintentionally interrupted by the test runner when preparing the next test, because the test runner enters the raw REPL again via a Ctrl-C Ctrl-A ctrl-D sequence (in `Pyboard.enter_raw_repl()`).

When this happens (`boot.py` is interrupted) the target may not be set up correctly, and it may (in the case of stm32 boards) flash LEDs and take extra time, slowing down the test run.

Fix this by explicitly waiting (with a short 1 second timeout) for the target to finish its soft reset when it skips a test.

### Testing

Run the test suite many times over and stm32 boards will occasionally have their boot.py interrupted and flash their LEDs to indicate that.  With this patch applied you don't ever see that behaviour.