### PR TITLE
tools: Only issue a single Ctrl-C when entering raw REPL.

### DIFF
--- a/tools/mpremote/mpremote/transport_serial.py
+++ b/tools/mpremote/mpremote/transport_serial.py
@@ -121,7 +121,7 @@ class SerialTransport(Transport):
         return data
 
     def enter_raw_repl(self, soft_reset=True):
-        self.serial.write(b"\r\x03\x03")  # ctrl-C twice: interrupt any running program
+        self.serial.write(b"\r\x03")  # ctrl-C: interrupt any running program
 
         # flush input (without relying on serial.flushInput())
         n = self.serial.inWaiting()

--- a/tools/pyboard.py
+++ b/tools/pyboard.py
@@ -348,7 +348,7 @@ class Pyboard:
         return data
 
     def enter_raw_repl(self, soft_reset=True):
-        self.serial.write(b"\r\x03\x03")  # ctrl-C twice: interrupt any running program
+        self.serial.write(b"\r\x03")  # ctrl-C: interrupt any running program
 
         # flush input (without relying on serial.flushInput())
         n = self.serial.inWaiting()


### PR DESCRIPTION
### Summary

A long time ago when there was only the `stm` port, Ctrl-C would trigger a preemptive NLR jump to break out of running code.  Then in commit 124df6f8d07b53542b6960dbeea9b63bff469a67 a more general approach to asynchronous `KeyboardInterrupt` exceptions was implemented, and `stmhal` supported both approaches, with the general (soft) interrupt taking priority.

Then in commit bc1488a05f509cd5be8bfab9574babfcb993806f `pyboard.py` was updated with a corresponding change to make it issue a double Ctrl-C to break out of any existing code when entering the raw REPL (two Ctrl-C characters were sent in order to more reliably trigger the preemptive NLR jump).

No other port has preemptive NLR jumps and so a double Ctrl-C doesn't really behave any differently to a single Ctrl-C: with USB CDC the double Ctrl-C would most likely be in the same USB packet and so processed in the same low-level USB callback, so it's just setting the keyboard interrupt flag twice in a row.  The VM/runtime then just sees one keyboard interrupt and acts as though only one Ctrl-C was sent.

This commit changes the double Ctrl-C to a single Ctrl-C in `pyboard.py` and `mpremote`.  That keeps things as simple as they need to be.

### Testing

Ran the test suite on a PYBD-SF2 and ESP32_GENERIC board.  It passes.

Also ran the `mpremote` tests on the same hardware.  They also pass.

### Trade-offs and Alternatives

There's a slight risk this may change behaviour of some code which expects two Ctrl-C's, but that's unlikely because in the vast majority of cases two back-to-back Ctrl-C's will just end up being one `KeyboardInterrupt`, ie equivalent to a single Ctrl-C (especially due to #15988 that preemptive NLR jump is removed).