### PR TITLE
esp32: Disable hardware stack protection on ESP32-C6.

### DIFF
--- a/ports/esp32/boards/ESP32_GENERIC_C6/mpconfigboard.cmake
+++ b/ports/esp32/boards/ESP32_GENERIC_C6/mpconfigboard.cmake
@@ -3,5 +3,6 @@ set(IDF_TARGET esp32c6)
 set(SDKCONFIG_DEFAULTS
     boards/sdkconfig.base
     ${SDKCONFIG_IDF_VERSION_SPECIFIC}
+    boards/sdkconfig.c6
     boards/sdkconfig.ble
 )

--- a/ports/esp32/boards/M5STACK_NANOC6/mpconfigboard.cmake
+++ b/ports/esp32/boards/M5STACK_NANOC6/mpconfigboard.cmake
@@ -3,5 +3,6 @@ set(IDF_TARGET esp32c6)
 set(SDKCONFIG_DEFAULTS
     boards/sdkconfig.base
     ${SDKCONFIG_IDF_VERSION_SPECIFIC}
+    boards/sdkconfig.c6
     boards/sdkconfig.ble
 )

--- a/ports/esp32/boards/UM_TINYC6/mpconfigboard.cmake
+++ b/ports/esp32/boards/UM_TINYC6/mpconfigboard.cmake
@@ -3,6 +3,7 @@ set(IDF_TARGET esp32c6)
 set(SDKCONFIG_DEFAULTS
     boards/sdkconfig.base
     ${SDKCONFIG_IDF_VERSION_SPECIFIC}
+    boards/sdkconfig.c6
     boards/sdkconfig.ble
     boards/UM_TINYC6/sdkconfig.board
 )

--- a/ports/esp32/boards/sdkconfig.c6
+++ b/ports/esp32/boards/sdkconfig.c6
@@ -1,0 +1,2 @@
+# Workaround for https://github.com/espressif/esp-idf/issues/14456
+CONFIG_ESP_SYSTEM_HW_STACK_GUARD=n


### PR DESCRIPTION
### Summary

The same as #15771 (see fee9d66e3a7308bd9edffb2624b52f4e04ecc4f3) but for C6.

Fixes issue #15667.

### Testing

Tested with `ESP32_GENERIC_C6` firmware using the method described in #15667.  Without this patch the device resets after a few minutes.  With this patch it ran for 30 minutes without error (at which point I stopped it running).
