### PR TITLE
esp32/modsocket.c: Explicitly send AI_CANONNAME hint. 

### DIFF
--- a/ports/esp32/modsocket.c
+++ b/ports/esp32/modsocket.c
@@ -942,6 +942,8 @@ static mp_obj_t esp_socket_getaddrinfo(size_t n_args, const mp_obj_t *args) {
     if (n_args > 5) {
         hints.ai_flags = mp_obj_get_int(args[5]);
     }
+    // Since we rely on ai_canonname after this call (in _getaddrinfo_inner), we explicitly ask for it
+    hints.ai_flags = hints.ai_flags | AI_CANONNAME;
 
     _getaddrinfo_inner(args[0], args[1], &hints, &res);
     mp_obj_t ret_list = mp_obj_new_list(0, NULL);


### PR DESCRIPTION
### Summary

I am using Micropython on a newer ESP-IDF (5.4) than is currently supported. Everything works fine, but network calls were failing with a reboot. I tracked it down the a newer LWIP implementation in ESP-IDF that requires the `AI_CANONNAME` hint to be set for `getaddrinfo`. If you do not set this hint, the later call to `_getaddrinfo_inner` will crash when it tries to read `res[0]->ai_canonname`. 

I do not believe this change to have any negative effect on earlier ESP-IDF versions, but it's apparently required for newer ones .

### Testing

Tested on an ESP32-S3 (Tulip board). 
