### PR TITLE
wiznet: Reset mDNS when interface is brought up.

### DIFF
--- a/extmod/network_wiznet5k.c
+++ b/extmod/network_wiznet5k.c
@@ -58,6 +58,7 @@
 #include "shared/netutils/netutils.h"
 #include "lib/wiznet5k/Ethernet/wizchip_conf.h"
 #include "lib/wiznet5k/Ethernet/socket.h"
+#include "lwip/apps/mdns.h"
 #include "lwip/err.h"
 #include "lwip/dns.h"
 #include "lwip/dhcp.h"
@@ -863,6 +864,10 @@ static mp_obj_t wiznet5k_active(size_t n_args, const mp_obj_t *args) {
                 // seems we need a small delay after init
                 mp_hal_delay_ms(250);
 
+                #if LWIP_MDNS_RESPONDER
+                mdns_resp_restart(&self->netif);
+                mdns_resp_add_netif(&self->netif, mod_network_hostname_data, 300);
+                #endif
             }
         } else {
             #if WIZNET5K_WITH_LWIP_STACK


### PR DESCRIPTION
<!-- Thanks for submitting a Pull Request! We appreciate you spending the
     time to improve MicroPython. Please provide enough information so that
     others can review your Pull Request.

     Before submitting, please read:
     https://github.com/micropython/micropython/blob/master/CODEOFCONDUCT.md
     https://github.com/micropython/micropython/wiki/ContributorGuidelines

     Please check any CI failures that appear after your Pull Request is opened.
-->

### Summary
According to [the documentation](https://github.com/lwip-tcpip/lwip/blob/master/doc/mdns.txt#L61), `mdns_resp_restart()` should be called every time the network interface comes up after being down, for example cable connected. Changing the interface active status qualifies for this event since, for WIZnet at least, the PHY is reset when the interface is brought down.

Additionally, this allows to set the hostname from Micropython code prior to bringing the interface up and mDNS responding to the (new) hostname. This allows the hostname to be configured and saved on the flash or be based on dynamic information such as the MAC or unique_id().

<!-- Explain the reason for making this change. What problem does the pull request
     solve, or what improvement does it add? Add links if relevant. -->


### Testing

<!-- Explain what testing you did, and on which boards/ports. If there are
     boards or ports that you couldn't test, please mention this here as well.

     If you leave this empty then your Pull Request may be closed. -->
I've tested this on the W5100S_EVB_PICO with LwIP configured. And then
```python
def bring_up_network(mode=('dhcp',), hostname=None):
    if hostname:
        network.hostname(hostname)

    ...

    nic.active(True)
```

### Trade-offs and Alternatives

<!-- If the Pull Request has some negative impact (i.e. increased code size)
     then please explain why you think the trade-off improvement is worth it.
     If you can think of alternative ways to do this, please explain that here too.

     Delete this heading if not relevant (i.e. small fixes) -->
This is only implemented for the WIZnet interfaces. It may be useful to port it for other NICs as well.
