### PR TITLE
esp32: Provide a specific path to linker.lf.

### DIFF
--- a/ports/esp32/esp32_common.cmake
+++ b/ports/esp32/esp32_common.cmake
@@ -190,7 +190,7 @@ idf_component_register(
         ${MICROPY_BOARD_DIR}
         ${CMAKE_BINARY_DIR}
     LDFRAGMENTS
-        linker.lf
+        ${MICROPY_PORT_DIR}/main_${IDF_TARGET}/linker.lf
     REQUIRES
         ${IDF_COMPONENTS}
 )


### PR DESCRIPTION
Providing a simple name relies on the right paths being searched at the right time.  However, external boards, such as demonstrated in https://github.com/micropython/micropython-example-boards will fail to find the linker.lf file, and fail to build without providing a more explicit path.  (Note that micropython-example-boards currently uses v1.21 of micropython, which predates the introduction of the linker.lf dependency, so it still works, this issue was uncovered while updating that repository to micropython v1.23)

Tested with builds for esp32 and builds and run tests for esp32-s3 with esp-idf 5.0.4, 5.1.2 and 5.2.2

### Trade-offs and Alternatives

There may be other ways altogether of doing this?