### PR TITLE
py/malloc: Fix failed memory allocations by more aggressively freeing buffers.

### DIFF
--- a/ports/rp2/mpthreadport.c
+++ b/ports/rp2/mpthreadport.c
@@ -84,10 +84,10 @@ void mp_thread_deinit(void) {
     assert(get_core_num() == 0);
     // Must ensure that core1 is not currently holding the GC lock, otherwise
     // it will be terminated while holding the lock.
-    mp_thread_mutex_lock(&MP_STATE_MEM(gc_mutex), 1);
+    mp_thread_recursive_mutex_lock(&MP_STATE_MEM(gc_mutex), 1);
     multicore_reset_core1();
     core1_entry = NULL;
-    mp_thread_mutex_unlock(&MP_STATE_MEM(gc_mutex));
+    mp_thread_recursive_mutex_unlock(&MP_STATE_MEM(gc_mutex));
 }
 
 void mp_thread_gc_others(void) {

--- a/ports/rp2/mpthreadport.h
+++ b/ports/rp2/mpthreadport.h
@@ -26,9 +26,10 @@
 #ifndef MICROPY_INCLUDED_RP2_MPTHREADPORT_H
 #define MICROPY_INCLUDED_RP2_MPTHREADPORT_H
 
-#include "pico/mutex.h"
+#include "mutex_extra.h"
 
 typedef struct mutex mp_thread_mutex_t;
+typedef recursive_mutex_nowait_t mp_thread_recursive_mutex_t;
 
 extern void *core_state[2];
 
@@ -63,6 +64,23 @@ static inline int mp_thread_mutex_lock(mp_thread_mutex_t *m, int wait) {
 
 static inline void mp_thread_mutex_unlock(mp_thread_mutex_t *m) {
     mutex_exit(m);
+}
+
+static inline void mp_thread_recursive_mutex_init(mp_thread_recursive_mutex_t *m) {
+    recursive_mutex_nowait_init(m);
+}
+
+static inline int mp_thread_recursive_mutex_lock(mp_thread_recursive_mutex_t *m, int wait) {
+    if (wait) {
+        recursive_mutex_nowait_enter_blocking(m);
+        return 1;
+    } else {
+        return recursive_mutex_nowait_try_enter(m, NULL);
+    }
+}
+
+static inline void mp_thread_recursive_mutex_unlock(mp_thread_recursive_mutex_t *m) {
+    recursive_mutex_nowait_exit(m);
 }
 
 #endif // MICROPY_INCLUDED_RP2_MPTHREADPORT_H

--- a/ports/unix/mbedtls/mbedtls_config_port.h
+++ b/ports/unix/mbedtls/mbedtls_config_port.h
@@ -32,7 +32,18 @@
 // Enable mbedtls modules
 #define MBEDTLS_TIMING_C
 
+#if defined(MICROPY_UNIX_COVERAGE)
+// Test the "bare metal" memory management in the coverage build
+#define MICROPY_MBEDTLS_CONFIG_BARE_METAL (1)
+#endif
+
 // Include common mbedtls configuration.
 #include "extmod/mbedtls/mbedtls_config_common.h"
+
+#if defined(MICROPY_UNIX_COVERAGE)
+// See comment above, but fall back to the default platform entropy functions
+#undef MBEDTLS_ENTROPY_HARDWARE_ALT
+#undef MBEDTLS_NO_PLATFORM_ENTROPY
+#endif
 
 #endif /* MICROPY_INCLUDED_MBEDTLS_CONFIG_H */

--- a/ports/unix/mpthreadport.h
+++ b/ports/unix/mpthreadport.h
@@ -28,6 +28,7 @@
 #include <stdbool.h>
 
 typedef pthread_mutex_t mp_thread_mutex_t;
+typedef pthread_mutex_t mp_thread_recursive_mutex_t;
 
 void mp_thread_init(void);
 void mp_thread_deinit(void);

--- a/py/gc.c
+++ b/py/gc.c
@@ -113,9 +113,12 @@
 #endif
 
 #if MICROPY_PY_THREAD && !MICROPY_PY_THREAD_GIL
-#define GC_ENTER() mp_thread_mutex_lock(&MP_STATE_MEM(gc_mutex), 1)
-#define GC_EXIT() mp_thread_mutex_unlock(&MP_STATE_MEM(gc_mutex))
+#define GC_MUTEX_INIT() mp_thread_recursive_mutex_init(&MP_STATE_MEM(gc_mutex))
+#define GC_ENTER() mp_thread_recursive_mutex_lock(&MP_STATE_MEM(gc_mutex), 1)
+#define GC_EXIT() mp_thread_recursive_mutex_unlock(&MP_STATE_MEM(gc_mutex))
 #else
+// Either no threading, or assume callers to gc_collect() hold the GIL
+#define GC_MUTEX_INIT()
 #define GC_ENTER()
 #define GC_EXIT()
 #endif
@@ -210,9 +213,7 @@ void gc_init(void *start, void *end) {
     MP_STATE_MEM(gc_alloc_amount) = 0;
     #endif
 
-    #if MICROPY_PY_THREAD && !MICROPY_PY_THREAD_GIL
-    mp_thread_mutex_init(&MP_STATE_MEM(gc_mutex));
-    #endif
+    GC_MUTEX_INIT();
 }
 
 #if MICROPY_GC_SPLIT_HEAP

--- a/py/modmicropython.c
+++ b/py/modmicropython.c
@@ -132,13 +132,13 @@ static MP_DEFINE_CONST_FUN_OBJ_0(mp_micropython_heap_lock_obj, mp_micropython_he
 
 static mp_obj_t mp_micropython_heap_unlock(void) {
     gc_unlock();
-    return MP_OBJ_NEW_SMALL_INT(MP_STATE_THREAD(gc_lock_depth));
+    return MP_OBJ_NEW_SMALL_INT(MP_STATE_THREAD(gc_lock_depth) >> GC_LOCK_DEPTH_SHIFT);
 }
 static MP_DEFINE_CONST_FUN_OBJ_0(mp_micropython_heap_unlock_obj, mp_micropython_heap_unlock);
 
 #if MICROPY_PY_MICROPYTHON_HEAP_LOCKED
 static mp_obj_t mp_micropython_heap_locked(void) {
-    return MP_OBJ_NEW_SMALL_INT(MP_STATE_THREAD(gc_lock_depth));
+    return MP_OBJ_NEW_SMALL_INT(MP_STATE_THREAD(gc_lock_depth) >> GC_LOCK_DEPTH_SHIFT);
 }
 static MP_DEFINE_CONST_FUN_OBJ_0(mp_micropython_heap_locked_obj, mp_micropython_heap_locked);
 #endif

--- a/py/mpconfig.h
+++ b/py/mpconfig.h
@@ -1629,6 +1629,11 @@ typedef double mp_float_t;
 #define MICROPY_PY_THREAD_GIL_VM_DIVISOR (32)
 #endif
 
+// Is a recursive mutex type in use?
+#ifndef MICROPY_PY_THREAD_RECURSIVE_MUTEX
+#define MICROPY_PY_THREAD_RECURSIVE_MUTEX (MICROPY_PY_THREAD && !MICROPY_PY_THREAD_GIL)
+#endif
+
 // Extended modules
 
 #ifndef MICROPY_PY_ASYNCIO

--- a/py/mpstate.h
+++ b/py/mpstate.h
@@ -77,6 +77,18 @@ typedef struct _mp_sched_item_t {
     mp_obj_t arg;
 } mp_sched_item_t;
 
+// gc_lock_depth field is a combination of the GC_COLLECT_FLAG
+// bit and a lock depth shifted GC_LOCK_DEPTH_SHIFT bits left.
+#if MICROPY_ENABLE_FINALISER
+#define GC_COLLECT_FLAG 1
+#define GC_LOCK_DEPTH_SHIFT 1
+#else
+// If finalisers are disabled then this check doesn't matter, as gc_lock()
+// is called anywhere else that heap can't be changed. So save some code size.
+#define GC_COLLECT_FLAG 0
+#define GC_LOCK_DEPTH_SHIFT 0
+#endif
+
 // This structure holds information about a single contiguous area of
 // memory reserved for the memory manager.
 typedef struct _mp_state_mem_area_t {
@@ -268,6 +280,7 @@ typedef struct _mp_state_thread_t {
     #endif
 
     // Locking of the GC is done per thread.
+    // See GC_LOCK_DEPTH_SHIFT for an explanation of this field.
     uint16_t gc_lock_depth;
 
     ////////////////////////////////////////////////////////////

--- a/py/mpstate.h
+++ b/py/mpstate.h
@@ -145,7 +145,7 @@ typedef struct _mp_state_mem_t {
 
     #if MICROPY_PY_THREAD && !MICROPY_PY_THREAD_GIL
     // This is a global mutex used to make the GC thread-safe.
-    mp_thread_mutex_t gc_mutex;
+    mp_thread_recursive_mutex_t gc_mutex;
     #endif
 } mp_state_mem_t;
 

--- a/py/mpthread.h
+++ b/py/mpthread.h
@@ -48,6 +48,12 @@ void mp_thread_mutex_init(mp_thread_mutex_t *mutex);
 int mp_thread_mutex_lock(mp_thread_mutex_t *mutex, int wait);
 void mp_thread_mutex_unlock(mp_thread_mutex_t *mutex);
 
+#if MICROPY_PY_THREAD_RECURSIVE_MUTEX
+void mp_thread_recursive_mutex_init(mp_thread_recursive_mutex_t *mutex);
+int mp_thread_recursive_mutex_lock(mp_thread_recursive_mutex_t *mutex, int wait);
+void mp_thread_recursive_mutex_unlock(mp_thread_recursive_mutex_t *mutex);
+#endif
+
 #endif // MICROPY_PY_THREAD
 
 #if MICROPY_PY_THREAD && MICROPY_PY_THREAD_GIL

--- a/tests/extmod/ssl_noleak.py
+++ b/tests/extmod/ssl_noleak.py
@@ -1,0 +1,50 @@
+# Ensure that SSLSockets can be allocated sequentially
+# without running out of available memory.
+try:
+    import io
+    import tls
+except ImportError:
+    print("SKIP")
+    raise SystemExit
+
+import unittest
+
+
+class TestSocket(io.IOBase):
+    def write(self, buf):
+        return len(buf)
+
+    def readinto(self, buf):
+        return 0
+
+    def ioctl(self, cmd, arg):
+        return 0
+
+    def setblocking(self, value):
+        pass
+
+
+ITERS = 128
+
+
+class TLSNoLeaks(unittest.TestCase):
+    def test_unique_context(self):
+        for n in range(ITERS):
+            print(n)
+            s = TestSocket()
+            ctx = tls.SSLContext(tls.PROTOCOL_TLS_CLIENT)
+            ctx.verify_mode = tls.CERT_NONE
+            s = ctx.wrap_socket(s, do_handshake_on_connect=False)
+
+    def test_shared_context(self):
+        # Single SSLContext, multiple sockets
+        ctx = tls.SSLContext(tls.PROTOCOL_TLS_CLIENT)
+        ctx.verify_mode = tls.CERT_NONE
+        for n in range(ITERS):
+            print(n)
+            s = TestSocket()
+            s = ctx.wrap_socket(s, do_handshake_on_connect=False)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
### Summary

This issue was originally reported on [Discord by ondrej1024](https://discord.com/channels/574275045187125269/1024252597839859734/1292796291247636553): on RPI_PICO_W a TLS connection via micropython-lib umqtt.simple would fail consistently on reconnect with `OSError(ENOMEM)`. A workaround was to explicitly close the old socket before connecting again. This doesn't seem like it should be necessary.

Was able to generalise into the new test case in this PR: `extmod/ssl_noleak`. This fails when trying to allocate sequential SSL socket objects (one at a time) on rp2 and also other ports.

Different fixes were needed, in separate commits in this PR. First approach was replaced with a new approach at suggestion of @dpgeorge, see inlinecomments below.

Changes:

* For rp2 and other mbedTLS bare metal ports, TLS nodes are "tracked" memory allocations associated with the SSL socket object. If an SSL socket object runs its finaliser during garbage collection then the "tracked" nodes can't be immediately freed (GC is locked) so they were left for the next GC. As a result, allocating a new SSL socket could fail even though enough memory was available (but not yet freed). Fix is to support `gc_free()` during a GC sweep by tracking gc collection separately from "heap is locked".
* This change led to a double-free assertion failure during gc_sweep_all (soft-reset), as the memory buffer might already be free. Fix for this was to split gc_sweep into two phases - one which runs finalisers and then one which frees memory. This works around other potential finaliser issues when memory has already been freed, too. Due to the sparse nature of FTB entries, this could be optimised to more than trade-off adding a second pass, with only a small code size increase.
* Similarly, GC mutex needed to be made recursive on ports which support `MICROPY_PY_THREAD && !MICROPY_PY_THREAD_GIL`. Have added an optional generic recursive mutex interface.
* For esp32 something similar happens where the small SSL socket object in the MicroPython heap holds large buffers outside MicroPython in the ESP-IDF heap. Allocatinga new SSL socket object could fail to allocate new buffers as the ESP-IDF heap is too full, even if there are SSL socket objects eligible for garbage collection that would free up lots of ESP-IDF heap when garbage collected. Fix is to run a gc_collect() and retry if SSL socket setup fails.

### Testing

* New unit test `extmod/ssl_noleak` fails consistently on master (using RPI_NANO_W and ESP32_GENERIC_C3 boards). Probably also fails on other ports using `MICROPY_MBEDTLS_CONFIG_BARE_METAL`, unless they have huge amounts of RAM.
* With fixes in this PR, new test passes (as well as all other unit tests).
* Separate commit enables mbedTLS "bare metal" memory management in the coverage build, to cover these changes and increase the coverage of MicroPython-specific code (the default for unix port being libc calloc and free).

### Performance

Performance benchmark run on PYB_V11 with all cache init commented out:

```
diff of scores (higher is better)
N=168 M=100                ./pybv11_master.txt -> ./pybv11_pr.txt         diff      diff% (error%)
bm_chaos.py                    240.23 ->     242.18 :      +1.95 =  +0.812% (+/-0.00%)
bm_fannkuch.py                  48.62 ->      48.98 :      +0.36 =  +0.740% (+/-0.01%)
bm_fft.py                     1479.57 ->    1492.25 :     +12.68 =  +0.857% (+/-0.00%)
bm_float.py                   4082.97 ->    4080.69 :      -2.28 =  -0.056% (+/-0.00%)
bm_hexiom.py                    31.85 ->      31.80 :      -0.05 =  -0.157% (+/-0.01%)
bm_nqueens.py                 2840.25 ->    2866.36 :     +26.11 =  +0.919% (+/-0.01%)
bm_pidigits.py                 372.74 ->     376.82 :      +4.08 =  +1.095% (+/-0.36%)
bm_wordcount.py                 30.88 ->      30.88 :      +0.00 =  +0.000% (+/-0.01%)
core_import_mpy_multi.py       361.54 ->     363.66 :      +2.12 =  +0.586% (+/-0.01%)
core_import_mpy_single.py       57.34 ->      57.34 :      +0.00 =  +0.000% (+/-0.00%)
core_locals.py                  24.96 ->      24.96 :      +0.00 =  +0.000% (+/-0.00%)
core_qstr.py                    78.47 ->      78.46 :      -0.01 =  -0.013% (+/-0.00%)
core_str.py                     12.56 ->      12.56 :      +0.00 =  +0.000% (+/-0.00%)
core_yield_from.py             220.01 ->     220.00 :      -0.01 =  -0.005% (+/-0.01%)
misc_aes.py                    268.31 ->     268.31 :      +0.00 =  +0.000% (+/-0.01%)
misc_mandel.py                2069.87 ->    2090.56 :     +20.69 =  +1.000% (+/-0.01%)
misc_pystone.py               1366.78 ->    1366.45 :      -0.33 =  -0.024% (+/-0.01%)
misc_raytrace.py               246.10 ->     248.10 :      +2.00 =  +0.813% (+/-0.01%)
viper_call0.py                 332.95 ->     332.96 :      +0.01 =  +0.003% (+/-0.01%)
viper_call1a.py                324.59 ->     324.59 :      +0.00 =  +0.000% (+/-0.00%)
viper_call1b.py                252.76 ->     252.76 :      +0.00 =  +0.000% (+/-0.01%)
viper_call1c.py                254.68 ->     254.67 :      -0.01 =  -0.004% (+/-0.01%)
viper_call2a.py                319.64 ->     319.65 :      +0.01 =  +0.003% (+/-0.01%)
viper_call2b.py                222.30 ->     222.30 :      +0.00 =  +0.000% (+/-0.01%)
```

### Trade-offs and Alternatives

* For future performance gains we could look at adding a similar "fast path" optimisation to the ATB lookups in GC, and/or expanding the ATB and FTB table entries to word size (currently individual bytes).
* For bare metal, @dpgeorge pointed out that it's possible mbedTLS doesn't need "tracked node" allocations (i.e. if mbedTLS structures always contain pointers to the head of each buffer, then they could be tracked as normal GC objects). However the mbedTLS implementation has used "tracked node" allocations for as long as it's been in MicroPython, and seems like good insurance rather than auditing every mbedTLS allocation.
* For ESP32, it's tempting to try and extend the "GC and then retry" behaviour to all ESP-IDF heap allocations. However, this is much more fiddly and has potential thread safety issues for allocations made from non-Python threads. Most of the large ESP-IDF memory allocations happen as part of mbedTLS, at least.