### PR TITLE
py/py.mk: Add check that any specified USER_C_MODULES folder exists.

### DIFF
--- a/py/py.mk
+++ b/py/py.mk
@@ -33,6 +33,9 @@ ifneq ($(USER_C_MODULES),)
 # pre-define USERMOD variables as expanded so that variables are immediate
 # expanded as they're added to them
 
+# Confirm the provided path exists, show abspath if not to make it clearer to fix.
+$(if $(wildcard $(USER_C_MODULES)/.),,$(error USER_C_MODULES doesn't exist: $(abspath $(USER_C_MODULES))))
+
 # C/C++ files that are included in the QSTR/module build
 SRC_USERMOD_C :=
 SRC_USERMOD_CXX :=

--- a/py/usermod.cmake
+++ b/py/usermod.cmake
@@ -42,6 +42,12 @@ endfunction()
 # Include CMake files for user modules.
 if (USER_C_MODULES)
     foreach(USER_C_MODULE_PATH ${USER_C_MODULES})
+        # Confirm the provided path exists, show abspath if not to make it clearer to fix.
+        if (NOT EXISTS ${USER_C_MODULE_PATH})
+            get_filename_component(USER_C_MODULES_ABS "${USER_C_MODULE_PATH}" ABSOLUTE)
+            message(FATAL_ERROR "USER_C_MODULES doesn't exist: ${USER_C_MODULES_ABS}")
+        endif()
+
         message("Including User C Module(s) from ${USER_C_MODULE_PATH}")
         include(${USER_C_MODULE_PATH})
     endforeach()

--- a/py/usermod.cmake
+++ b/py/usermod.cmake
@@ -42,6 +42,10 @@ endfunction()
 # Include CMake files for user modules.
 if (USER_C_MODULES)
     foreach(USER_C_MODULE_PATH ${USER_C_MODULES})
+        # If a directory is given, append the micropython.cmake to it.
+        if (IS_DIRECTORY ${USER_C_MODULE_PATH})
+            set(USER_C_MODULE_PATH "${USER_C_MODULE_PATH}/micropython.cmake")
+        endif()
         # Confirm the provided path exists, show abspath if not to make it clearer to fix.
         if (NOT EXISTS ${USER_C_MODULE_PATH})
             get_filename_component(USER_C_MODULES_ABS "${USER_C_MODULE_PATH}" ABSOLUTE)


### PR DESCRIPTION
### Summary

When compiling with `USER_C_MODULES` set on the command line it's easy to get the path slightly wrong, particularly as it's usually given as a relative path to the port / build root directory.

Currently, if the provided path is incorrect the build proceeds as usual simply without including any of the user c modules which causes confusion for the developer.

This PR adds a basic check in the make rules to ensure that the provided path does indeed exist. 

After also getting confused by the different way this is specifed for make vs cmake I updated cmake script to also accept the folder (same as make) and simply append the `micropython.cmake` file to that if needed. This still works as it did previously if the full path to that file is given.

### Testing
#### With invalid paths:
```
anl@STEP:~/micropython$ make -C ports/unix/ USER_C_MODULES=../../../examples/usercmodule
make: Entering directory '/home/anl/micropython/ports/unix'
Use make V=1 or set BUILD_VERBOSE in your environment to increase build verbosity.
../../py/py.mk:36: *** USER_C_MODULES doesn't exist: /home/anl/examples/usercmodule.  Stop.
make: Leaving directory '/home/anl/micropython/ports/unix'```
```

```
anl@STEP:~/micropython$ make -C ports/rp2/ USER_C_MODULES=../../../examples/usercmodule/micropython.cmake 
make: Entering directory '/home/anl/micropython/ports/rp2'
[ -e build-RPI_PICO/Makefile ] || cmake -S . -B build-RPI_PICO -DPICO_BUILD_DOCS=0 -DMICROPY_BOARD=RPI_PICO -DMICROPY_BOARD_DIR="/home/anl/micropython/ports/rp2/boards/RPI_PICO" -DUSER_C_MODULES=../../../examples/usercmodule/micropython.cmake
PICO_SDK_PATH is /home/anl/micropython/lib/pico-sdk<snip>
<snip>
CMake Error at /home/anl/micropython/py/usermod.cmake:47 (message):
  USER_C_MODULES doesn't exist:
  /home/anl/examples/usercmodule/micropython.cmake
Call Stack (most recent call first):
  CMakeLists.txt:92 (include)

-- Configuring incomplete, errors occurred!
```

#### With corrected path:
```
anl@STEP:~/micropython$ make -C ports/unix/ USER_C_MODULES=../../examples/usercmodule
make: Entering directory '/home/anl/micropython/ports/unix'
Use make V=1 or set BUILD_VERBOSE in your environment to increase build verbosity.
Including User C Module from ../../examples/usercmodule/cexample
Including User C Module from ../../examples/usercmodule/cppexample
Including User C Module from ../../examples/usercmodule/subpackage
GEN build-standard/genhdr/mpversion.h
mkdir -p build-standard/cexample/
mkdir -p build-standard/cppexample/
mkdir -p build-standard/subpackage/
CC ../../examples/usercmodule/cexample/examplemodule.c
...
```

```
anl@STEP:~/micropython$ make -C ports/rp2/ USER_C_MODULES=../../examples/usercmodule/micropython.cmake 
make: Entering directory '/home/anl/micropython/ports/rp2'
[ -e build-RPI_PICO/Makefile ] || cmake -S . -B build-RPI_PICO -DPICO_BUILD_DOCS=0 -DMICROPY_BOARD=RPI_PICO -DMICROPY_BOARD_DIR="/home/anl/micropython/ports/rp2/boards/RPI_PICO" -DUSER_C_MODULES=../../examples/usercmodule/micropython.cmake
PICO_SDK_PATH is /home/anl/micropython/lib/pico-sdk
<snip>
Including User C Module(s) from ../../examples/usercmodule/micropython.cmake
Found User C Module(s): usermod_cexample, usermod_cppexample
...
```