### PR TITLE
rp2/mpconfigport: Leave callable pointers alone on RV32.

### DIFF
--- a/ports/rp2/mpconfigport.h
+++ b/ports/rp2/mpconfigport.h
@@ -275,7 +275,9 @@ extern const struct _mp_obj_type_t mod_network_nic_type_wiznet5k;
 #define MICROPY_HW_BOOTSEL_DELAY_US 8
 #endif
 
+#if PICO_ARM
 #define MICROPY_MAKE_POINTER_CALLABLE(p) ((void *)((mp_uint_t)(p) | 1))
+#endif
 
 #define MP_SSIZE_MAX (0x7fffffff)
 typedef intptr_t mp_int_t; // must be pointer size


### PR DESCRIPTION
### Summary

The port configuration file tagged callable pointers' LSB on both Arm and RISC-V variants.  This is needed on Arm due to Thumb/Thumb2 code addresses having their LSB set, but on RISC-V this is not required.

### Testing

My RPI2 is still being shipped, but I've rebuilt the port with both board variants making sure the define in question is enabled only for the Arm port.  All the other Arm-based ports have that defined, as it is needed to properly handle Thumb/Thumb2 code, but non-Arm ports in fact do not have that define.