### PR TITLE
ports: Update board.json files for vendor/product consistency.

### DIFF
--- a/ports/esp32/boards/ARDUINO_NANO_ESP32/board.json
+++ b/ports/esp32/boards/ARDUINO_NANO_ESP32/board.json
@@ -17,8 +17,8 @@
         "ABX00092_01.iso_1000x750.jpg"
     ],
     "mcu": "esp32s3",
-    "product": "Arduino Nano ESP32",
+    "product": "Nano ESP32",
     "thumbnail": "",
-    "url": "https://store.arduino.cc/products/arduino-nano-esp32",
+    "url": "https://docs.arduino.cc/hardware/nano-esp32/",
     "vendor": "Arduino"
 }

--- a/ports/esp32/boards/LILYGO_TTGO_LORA32/board.json
+++ b/ports/esp32/boards/LILYGO_TTGO_LORA32/board.json
@@ -19,8 +19,8 @@
         "lilygo-ttgo-lora-32-v1-6.jpg"
     ],
     "mcu": "esp32",
-    "product": "LILYGO TTGO LoRa32",
+    "product": "TTGO LoRa32",
     "thumbnail": "",
-    "url": "http://www.lilygo.cn/prod_view.aspx?TypeId=50060&Id=1270&FId=t3:50060:3",
+    "url": "https://www.lilygo.cc/products/lora3",
     "vendor": "LILYGO"
 }

--- a/ports/esp32/boards/M5STACK_ATOM/board.json
+++ b/ports/esp32/boards/M5STACK_ATOM/board.json
@@ -18,8 +18,8 @@
         "m5stack_atom.jpg"
     ],
     "mcu": "esp32",
-    "product": "M5 Stack Atom",
+    "product": "Atom",
     "thumbnail": "",
-    "url": "https://m5stack.com/",
-    "vendor": "M5 Stack"
+    "url": "https://shop.m5stack.com/products/atom-matrix-esp32-development-kit",
+    "vendor": "M5Stack"
 }

--- a/ports/esp32/boards/M5STACK_ATOMS3_LITE/board.json
+++ b/ports/esp32/boards/M5STACK_ATOMS3_LITE/board.json
@@ -20,5 +20,5 @@
     "product": "AtomS3 Lite",
     "thumbnail": "",
     "url": "https://shop.m5stack.com/products/atoms3-lite-esp32s3-dev-kit",
-    "vendor": "M5 Stack"
+    "vendor": "M5Stack"
 }

--- a/ports/esp32/boards/M5STACK_NANOC6/board.json
+++ b/ports/esp32/boards/M5STACK_NANOC6/board.json
@@ -18,7 +18,7 @@
         "m5stack_nanoc6.jpg"
     ],
     "mcu": "esp32c6",
-    "product": "M5Stack NanoC6",
+    "product": "NanoC6",
     "url": "https://shop.m5stack.com/products/m5stack-nanoc6-dev-kit",
     "vendor": "M5Stack"
 }

--- a/ports/esp32/boards/OLIMEX_ESP32_EVB/board.json
+++ b/ports/esp32/boards/OLIMEX_ESP32_EVB/board.json
@@ -18,8 +18,8 @@
         "ESP32-EVB_Rev_K1.png"
     ],
     "mcu": "esp32",
-    "product": "Olimex ESP32 EVB",
+    "product": "ESP32 EVB",
     "thumbnail": "",
-    "url": "https://www.olimex.com/Products/IoT/ESP32/ESP32-EVB/open-source-hardware",
-    "vendor": "OLIMEX"
+    "url": "https://www.olimex.com/Products/IoT/ESP32/ESP32-EVB",
+    "vendor": "Olimex"
 }

--- a/ports/esp32/boards/OLIMEX_ESP32_POE/board.json
+++ b/ports/esp32/boards/OLIMEX_ESP32_POE/board.json
@@ -19,8 +19,8 @@
         "ESP32-POE-ISO-1.jpg"
     ],
     "mcu": "esp32",
-    "product": "Olimex ESP32 POE",
+    "product": "ESP32 POE",
     "thumbnail": "",
-    "url": "https://www.olimex.com/",
-    "vendor": "OLIMEX"
+    "url": "https://www.olimex.com/Products/IoT/ESP32/ESP32-POE",
+    "vendor": "Olimex"
 }

--- a/ports/esp32/boards/SIL_WESP32/board.json
+++ b/ports/esp32/boards/SIL_WESP32/board.json
@@ -18,7 +18,7 @@
         "wesp32-top.jpg"
     ],
     "mcu": "esp32",
-    "product": "SIL WESP32",
+    "product": "wESP32",
     "thumbnail": "",
     "url": "https://wesp32.com/",
     "vendor": "Silicognition"

--- a/ports/mimxrt/boards/ADAFRUIT_METRO_M7/board.json
+++ b/ports/mimxrt/boards/ADAFRUIT_METRO_M7/board.json
@@ -15,7 +15,7 @@
         "Metro_M7.jpg"
     ],
     "mcu": "mimxrt",
-    "product": "Adafruit Metro M7",
+    "product": "Metro M7",
     "thumbnail": "",
     "url": "https://www.adafruit.com/product/4950",
     "vendor": "Adafruit"

--- a/ports/mimxrt/boards/OLIMEX_RT1010/board.json
+++ b/ports/mimxrt/boards/OLIMEX_RT1010/board.json
@@ -12,8 +12,8 @@
         "OLIMEX_RT1010Py.jpg"
     ],
     "mcu": "mimxrt",
-    "product": "Olimex_RT1010Py",
+    "product": "RT1010-Py",
     "thumbnail": "",
-    "url": "https://www.olimex.com/Products/ARM/NXP",
-    "vendor": "OLIMEX"
+    "url": "https://www.olimex.com/Products/MicroPython/RT1010-Py",
+    "vendor": "Olimex"
 }

--- a/ports/nrf/boards/ACTINIUS_ICARUS/board.json
+++ b/ports/nrf/boards/ACTINIUS_ICARUS/board.json
@@ -8,7 +8,7 @@
         "icarus-v1.4-front-shadow-p-800.jpg"
     ],
     "mcu": "nrf91",
-    "product": "actinius_icarus",
+    "product": "Icarus",
     "thumbnail": "",
     "url": "https://www.actinius.com/icarus",
     "vendor": "Actinius"

--- a/ports/nrf/boards/ARDUINO_NANO_33_BLE_SENSE/board.json
+++ b/ports/nrf/boards/ARDUINO_NANO_33_BLE_SENSE/board.json
@@ -15,7 +15,7 @@
         "ABX00031_01.iso_998x749.jpg"
     ],
     "mcu": "nrf52",
-    "product": "Arduino Nano 33 BLE Sense",
+    "product": "Nano 33 BLE Sense",
     "thumbnail": "",
     "url": "https://store.arduino.cc/products/arduino-nano-33-ble-sense",
     "vendor": "Arduino"

--- a/ports/nrf/boards/ARDUINO_PRIMO/board.json
+++ b/ports/nrf/boards/ARDUINO_PRIMO/board.json
@@ -8,8 +8,8 @@
         "arduino_primo.jpg"
     ],
     "mcu": "nrf52",
-    "product": "arduino_primo",
+    "product": "Primo",
     "thumbnail": "",
-    "url": "",
+    "url": "https://docs.arduino.cc/retired/boards/arduino-primo/",
     "vendor": "Arduino"
 }

--- a/ports/nrf/boards/BLUEIO_TAG_EVIM/board.json
+++ b/ports/nrf/boards/BLUEIO_TAG_EVIM/board.json
@@ -8,7 +8,7 @@
         "blyst-nano-mod-4_jpg_project-body.jpg"
     ],
     "mcu": "nrf52",
-    "product": "blueio_tag_evim",
+    "product": "BLUEIO Tag EVIM",
     "thumbnail": "",
     "url": "https://www.i-syst.com/index.php/products/blyst-nano",
     "vendor": "I-SYST"

--- a/ports/nrf/boards/DVK_BL652/board.json
+++ b/ports/nrf/boards/DVK_BL652/board.json
@@ -8,8 +8,8 @@
         "BL652-SA_JPG-500.jpg"
     ],
     "mcu": "nrf52",
-    "product": "dvk_bl652",
+    "product": "DVK-BL652",
     "thumbnail": "",
-    "url": "https://www.lairdconnect.com/wireless-modules/bluetooth-modules/bluetooth-5-modules/bl652-series-bluetooth-v5-nfc-module",
-    "vendor": "Laird Connectivity"
+    "url": "https://www.ezurio.com/wireless-modules/bluetooth-modules/bluetooth-5-modules/bl652-series-bluetooth-v5-nfc-module",
+    "vendor": "Ezurio"
 }

--- a/ports/nrf/boards/EVK_NINA_B1/board.json
+++ b/ports/nrf/boards/EVK_NINA_B1/board.json
@@ -8,7 +8,7 @@
         "EVK-NINA-B1_.jpg"
     ],
     "mcu": "nrf52",
-    "product": "evk_nina_b1",
+    "product": "EVK-NINA-B1",
     "thumbnail": "",
     "url": "https://www.u-blox.com/en/product/evk-nina-b1",
     "vendor": "u-blox"

--- a/ports/nrf/boards/EVK_NINA_B3/board.json
+++ b/ports/nrf/boards/EVK_NINA_B3/board.json
@@ -8,7 +8,7 @@
         "EVK-NINA-B3-top.jpg"
     ],
     "mcu": "nrf52",
-    "product": "evk_nina_b3",
+    "product": "EVK-NINA-B3",
     "thumbnail": "",
     "url": "https://www.u-blox.com/en/product/evk-nina-b3",
     "vendor": "u-blox"

--- a/ports/nrf/boards/IBK_BLYST_NANO/board.json
+++ b/ports/nrf/boards/IBK_BLYST_NANO/board.json
@@ -8,7 +8,7 @@
         "blyst-nano-fingertip-close_jpg_content-body-gallery.jpg"
     ],
     "mcu": "nrf52",
-    "product": "ibk_blyst_nano",
+    "product": "IBK BLYST Nano",
     "thumbnail": "",
     "url": "https://www.i-syst.com/products/blyst-nano",
     "vendor": "I-SYST"

--- a/ports/nrf/boards/IDK_BLYST_NANO/board.json
+++ b/ports/nrf/boards/IDK_BLYST_NANO/board.json
@@ -8,7 +8,7 @@
         "blyst-nano-fingertip-close_jpg_content-body-gallery.jpg"
     ],
     "mcu": "nrf52",
-    "product": "idk_blyst_nano",
+    "product": "IDK BLYST Nano",
     "thumbnail": "",
     "url": "https://www.i-syst.com/products/blyst-nano",
     "vendor": "I-SYST"

--- a/ports/nrf/boards/NRF52840_MDK_USB_DONGLE/board.json
+++ b/ports/nrf/boards/NRF52840_MDK_USB_DONGLE/board.json
@@ -8,7 +8,7 @@
         "dongle_pcba_case.jpg"
     ],
     "mcu": "nrf52",
-    "product": "nrf52840-mdk-usb-dongle",
+    "product": "nrf52840 MDK USB Dongle",
     "thumbnail": "",
     "url": "https://wiki.makerdiary.com/nrf52840-mdk-usb-dongle",
     "vendor": "Makerdiary"

--- a/ports/nrf/boards/SEEED_XIAO_NRF52/board.json
+++ b/ports/nrf/boards/SEEED_XIAO_NRF52/board.json
@@ -16,8 +16,8 @@
         "XIAO_nrf52840_front.jpg"
     ],
     "mcu": "nrf52",
-    "product": "SEEED XIAO nRF52840 Sense",
+    "product": "XIAO nRF52840 Sense",
     "thumbnail": "",
-    "url": "https://www.seeedstudio.com",
+    "url": "https://www.seeedstudio.com/Seeed-XIAO-BLE-Sense-nRF52840-p-5253.html",
     "vendor": "Seeed Studio"
 }

--- a/ports/nrf/boards/WT51822_S4AT/board.json
+++ b/ports/nrf/boards/WT51822_S4AT/board.json
@@ -8,8 +8,8 @@
         "WT51822-S4AT.jpg"
     ],
     "mcu": "nrf51",
-    "product": "wt51822_s4at",
+    "product": "WT51822-S4AT",
     "thumbnail": "",
-    "url": "http://www.wireless-tag.com/portfolio/wt51822-s4at-2/",
+    "url": "https://shop.wireless-tag.com/products/esp32-c3-mini-1-10pcs-espressif-esp32-c3-mini-1-4mb-flash-pcb-antenna-15-gpios-wifi-ble-5-module-esp32-c3-module-on-esp32-c3-chip",
     "vendor": "Wireless-Tag"
 }

--- a/ports/renesas-ra/boards/ARDUINO_PORTENTA_C33/board.json
+++ b/ports/renesas-ra/boards/ARDUINO_PORTENTA_C33/board.json
@@ -15,7 +15,7 @@
         "ABX00074_01.iso_1000x750.jpg"
     ],
     "mcu": "RA6M5",
-    "product": "Arduino Portenta C33",
+    "product": "Portenta C33",
     "thumbnail": "",
     "url": "https://store.arduino.cc/pages/portenta-c33",
     "vendor": "Arduino"

--- a/ports/rp2/boards/ARDUINO_NANO_RP2040_CONNECT/board.json
+++ b/ports/rp2/boards/ARDUINO_NANO_RP2040_CONNECT/board.json
@@ -17,7 +17,7 @@
         "ABX00052_01.iso_999x750.jpg"
     ],
     "mcu": "rp2040",
-    "product": "Arduino Nano RP2040 Connect",
+    "product": "Nano RP2040 Connect",
     "thumbnail": "",
     "url": "https://store-usa.arduino.cc/products/arduino-nano-rp2040-connect",
     "vendor": "Arduino"

--- a/ports/rp2/boards/GARATRONIC_PYBSTICK26_RP2040/board.json
+++ b/ports/rp2/boards/GARATRONIC_PYBSTICK26_RP2040/board.json
@@ -13,7 +13,7 @@
         "pybstick-rp2040-26-broches-micropython-c.jpg"
     ],
     "mcu": "rp2040",
-    "product": "PYBSTICK26 RP2040",
+    "product": "RP2040 PYBStick",
     "thumbnail": "",
     "url": "https://shop.mchobby.be/product.php?id_product=2331",
     "vendor": "McHobby"

--- a/ports/rp2/boards/POLOLU_3PI_2040_ROBOT/board.json
+++ b/ports/rp2/boards/POLOLU_3PI_2040_ROBOT/board.json
@@ -15,7 +15,7 @@
         "pololu_3pi_2040_robot.jpg"
     ],
     "mcu": "rp2040",
-    "product": "Pololu 3pi+ 2040 Robot",
+    "product": "3pi+ 2040 Robot",
     "thumbnail": "",
     "url": "https://www.pololu.com/3pi",
     "vendor": "Pololu"

--- a/ports/rp2/boards/POLOLU_ZUMO_2040_ROBOT/board.json
+++ b/ports/rp2/boards/POLOLU_ZUMO_2040_ROBOT/board.json
@@ -16,7 +16,7 @@
         "pololu_zumo_2040_robot.jpg"
     ],
     "mcu": "rp2040",
-    "product": "Pololu Zumo 2040 Robot",
+    "product": "Zumo 2040 Robot",
     "thumbnail": "",
     "url": "https://www.pololu.com/zumo",
     "vendor": "Pololu"

--- a/ports/rp2/boards/SPARKFUN_PROMICRO/board.json
+++ b/ports/rp2/boards/SPARKFUN_PROMICRO/board.json
@@ -14,7 +14,7 @@
         "18288-SparkFun_Pro_Micro_-_RP2040-01.jpg"
     ],
     "mcu": "rp2040",
-    "product": "Pro Micro RP2040",
+    "product": "Pro Micro - RP2040",
     "thumbnail": "",
     "url": "https://www.sparkfun.com/products/18288",
     "vendor": "SparkFun"

--- a/ports/rp2/boards/SPARKFUN_THINGPLUS/board.json
+++ b/ports/rp2/boards/SPARKFUN_THINGPLUS/board.json
@@ -17,7 +17,7 @@
         "17745-SparkFun_Thing_Plus_-_RP2040-01a.jpg"
     ],
     "mcu": "rp2040",
-    "product": "Thing Plus RP2040",
+    "product": "Thing Plus - RP2040",
     "thumbnail": "",
     "url": "https://www.sparkfun.com/products/17745",
     "vendor": "SparkFun"

--- a/ports/rp2/boards/W5100S_EVB_PICO/board.json
+++ b/ports/rp2/boards/W5100S_EVB_PICO/board.json
@@ -13,8 +13,8 @@
         "W5100S-EVB-Pico.jpg"
     ],
     "mcu": "rp2040",
-    "product": "Wiznet W5100S-EVB-Pico",
+    "product": "W5100S-EVB-Pico",
     "thumbnail": "",
-    "url": "https://www.wiznet.io/product-item/w5100s-evb-pico/",
-    "vendor": "Wiznet"
+    "url": "https://docs.wiznet.io/Product/iEthernet/W5100S/w5100s-evb-pico",
+    "vendor": "WIZnet"
 }

--- a/ports/rp2/boards/W5500_EVB_PICO/board.json
+++ b/ports/rp2/boards/W5500_EVB_PICO/board.json
@@ -13,8 +13,8 @@
         "W5500-EVB-Pico.jpg"
     ],
     "mcu": "rp2040",
-    "product": "Wiznet W5500-EVB-Pico",
+    "product": "W5500-EVB-Pico",
     "thumbnail": "",
     "url": "https://docs.wiznet.io/Product/iEthernet/W5500/w5500-evb-pico",
-    "vendor": "Wiznet"
+    "vendor": "WIZnet"
 }

--- a/ports/rp2/boards/WEACTSTUDIO/board.json
+++ b/ports/rp2/boards/WEACTSTUDIO/board.json
@@ -12,7 +12,7 @@
         "weact_rp2040.jpg"
     ],
     "mcu": "rp2040",
-    "product": "WeAct Studio RP2040",
+    "product": "Studio RP2040",
     "url": "https://github.com/WeActTC/WeActStudio.RP2040CoreBoard",
     "variants": {
         "FLASH_2M": "2 MiB Flash",

--- a/ports/samd/boards/SEEED_XIAO_SAMD21/board.json
+++ b/ports/samd/boards/SEEED_XIAO_SAMD21/board.json
@@ -10,7 +10,7 @@
         "seeeduino-xiao.jpg"
     ],
     "mcu": "samd21",
-    "product": "Seeeduino XIAO (SAMD21)",
+    "product": "XIAO SAMD21",
     "thumbnail": "",
     "url": "https://www.seeedstudio.com/Seeeduino-XIAO-Arduino-Microcontroller-SAMD21-Cortex-M0+-p-4426.html",
     "vendor": "Seeed Studio"

--- a/ports/samd/boards/SPARKFUN_SAMD51_THING_PLUS/board.json
+++ b/ports/samd/boards/SPARKFUN_SAMD51_THING_PLUS/board.json
@@ -13,7 +13,7 @@
         "sparkfun_samd51_thing_plus.jpg"
     ],
     "mcu": "samd51",
-    "product": "SparkFun SAMD51 Thing Plus",
+    "product": "SAMD51 Thing Plus",
     "thumbnail": "",
     "url": "https://www.sparkfun.com/products/14713",
     "vendor": "SparkFun"

--- a/ports/stm32/boards/ARDUINO_GIGA/board.json
+++ b/ports/stm32/boards/ARDUINO_GIGA/board.json
@@ -15,7 +15,7 @@
         "ABX00063_01.front_1000x750.jpg"
     ],
     "mcu": "stm32h7",
-    "product": "Arduino Giga",
+    "product": "Giga",
     "thumbnail": "",
     "url": "https://store.arduino.cc/products/giga-r1-wifi",
     "vendor": "Arduino"

--- a/ports/stm32/boards/ARDUINO_NICLA_VISION/board.json
+++ b/ports/stm32/boards/ARDUINO_NICLA_VISION/board.json
@@ -15,7 +15,7 @@
         "ABX00051_01.iso_1000x750.jpg"
     ],
     "mcu": "stm32h7",
-    "product": "Arduino Nicla Vision",
+    "product": "Nicla Vision",
     "thumbnail": "",
     "url": "https://store.arduino.cc/products/nicla-vision",
     "vendor": "Arduino"

--- a/ports/stm32/boards/ARDUINO_OPTA/board.json
+++ b/ports/stm32/boards/ARDUINO_OPTA/board.json
@@ -14,7 +14,7 @@
         "AFX00002_01.iso_1000x750.jpg"
     ],
     "mcu": "stm32h7",
-    "product": "Arduino Opta WiFi",
+    "product": "Opta WiFi",
     "thumbnail": "",
     "url": "https://store.arduino.cc/products/opta-wifi",
     "vendor": "Arduino"

--- a/ports/stm32/boards/ARDUINO_PORTENTA_H7/board.json
+++ b/ports/stm32/boards/ARDUINO_PORTENTA_H7/board.json
@@ -16,7 +16,7 @@
         "ABX00042_01.iso_1000x750.jpg"
     ],
     "mcu": "stm32h7",
-    "product": "Arduino Portenta H7",
+    "product": "Portenta H7",
     "thumbnail": "",
     "url": "https://store.arduino.cc/products/portenta-h7",
     "vendor": "Arduino"

--- a/ports/stm32/boards/HYDRABUS/board.json
+++ b/ports/stm32/boards/HYDRABUS/board.json
@@ -10,6 +10,6 @@
     "mcu": "stm32f4",
     "product": "HydraBus v1.0",
     "thumbnail": "",
-    "url": "",
+    "url": "https://github.com/hydrabus/hydrabus",
     "vendor": "HydraBus"
 }

--- a/ports/stm32/boards/LIMIFROG/board.json
+++ b/ports/stm32/boards/LIMIFROG/board.json
@@ -10,6 +10,6 @@
     "mcu": "stm32l4",
     "product": "LimiFrog",
     "thumbnail": "",
-    "url": "",
+    "url": "https://github.com/LimiFrog",
     "vendor": "LimiFrog"
 }

--- a/ports/stm32/boards/OLIMEX_E407/board.json
+++ b/ports/stm32/boards/OLIMEX_E407/board.json
@@ -8,8 +8,8 @@
         "olimex_e407.jpg"
     ],
     "mcu": "stm32f4",
-    "product": "E407",
+    "product": "STM32-E407",
     "thumbnail": "",
-    "url": "",
-    "vendor": "OLIMEX"
+    "url": "https://www.olimex.com/Products/ARM/ST/STM32-E407",
+    "vendor": "Olimex"
 }

--- a/ports/stm32/boards/OLIMEX_H407/board.json
+++ b/ports/stm32/boards/OLIMEX_H407/board.json
@@ -8,8 +8,8 @@
         "olimex_h407.jpg"
     ],
     "mcu": "stm32f4",
-    "product": "H407",
+    "product": "STM32-H407",
     "thumbnail": "",
-    "url": "",
-    "vendor": "OLIMEX"
+    "url": "https://www.olimex.com/Products/ARM/ST/STM32-H407",
+    "vendor": "Olimex"
 }

--- a/ports/stm32/boards/SPARKFUN_MICROMOD_STM32/board.json
+++ b/ports/stm32/boards/SPARKFUN_MICROMOD_STM32/board.json
@@ -8,8 +8,8 @@
         "sparkfun_micromod_stm32.jpg"
     ],
     "mcu": "stm32f4",
-    "product": "Micromod STM32",
+    "product": "MicroMod STM32",
     "thumbnail": "",
-    "url": "",
+    "url": "https://www.sparkfun.com/products/17713",
     "vendor": "SparkFun"
 }


### PR DESCRIPTION
The `vendor` and `product` fields in the `board.json` files were somewhat inconsistent. In particular, I wanted to remove any duplication of the vendor name in the product field so that `f"{vendor} {product}"` reads well.

In addition to that I checked - and updated - most of the url's for `board.json`'s that I modified. I also tried to match case and spacing used by the manufacturers for the vendor and product names. 

In short, it was a general tidy-up of a lot of the `board.json` files. 

(I was going to add `features` to boards that didn't specify them, but that will have to come in a later PR...)