### PR TITLE
ports/unix: Freeze `asyncio`.

### DIFF
--- a/ports/unix/variants/manifest.py
+++ b/ports/unix/variants/manifest.py
@@ -1,3 +1,4 @@
+include("$(MPY_DIR)/extmod/asyncio")
 add_library("unix-ffi", "$(MPY_LIB_DIR)/unix-ffi")
 require("mip-cmdline")
 require("ssl")


### PR DESCRIPTION
### Summary

`asyncio` is available for most ports out of the box, this adds it to the unix binaries.

### Testing

This now works without referencing any libraries on the filesystem:

```py
import asyncio
```

### Trade-offs and Alternatives

Alternatively, one needs to put `asyncio` somewhere on the filesystem and maybe configure `MICROPYPATH` to use it.