### PR TITLE
esp32: Allow disabling USB CDC.

### DIFF
--- a/ports/esp32/modmachine.c
+++ b/ports/esp32/modmachine.c
@@ -231,7 +231,7 @@ static mp_int_t mp_machine_reset_cause(void) {
 #endif
 
 NORETURN static void machine_bootloader_rtc(void) {
-    #if CONFIG_IDF_TARGET_ESP32S3
+    #if CONFIG_IDF_TARGET_ESP32S3 && MICROPY_HW_USB_CDC
     usb_usj_mode();
     usb_dc_prepare_persist();
     chip_usb_set_persist_flags(USBDC_BOOT_DFU);


### PR DESCRIPTION
### Summary

Some of my ESP32-S3 boards need to have CDC disabled. For details, see https://github.com/micropython/micropython/issues/14217

My board definition includes:
```c
// Disable USB CDC as the same pins are used by I2C0
#define MICROPY_HW_USB_CDC                  (0)
#define MICROPY_HW_ENABLE_USBDEV            (0)
```

After #15108 got merged, my board stopped building.


### Testing

The build works after the proposed fix
