### PR TITLE
ports/rp2: Enable mbedtls PEM parser.

### DIFF
--- a/ports/rp2/mbedtls/mbedtls_config_port.h
+++ b/ports/rp2/mbedtls/mbedtls_config_port.h
@@ -29,6 +29,10 @@
 // Set mbedtls configuration
 #define MBEDTLS_ECP_NIST_OPTIM
 
+// Enable mbedtls modules
+#define MBEDTLS_BASE64_C
+#define MBEDTLS_PEM_PARSE_C
+
 // Time hook
 #include <time.h>
 time_t rp2_rtctime_seconds(time_t *timer);


### PR DESCRIPTION

### Summary

Enable `.pem` certificate parser for tls/ssl.

### Testing

Working fine for a few month in Blynk.Edgent.

### Trade-offs and Alternatives

Use `.der` certificates, but DER format does not allow having multiple certificates in a single file
