### PR TITLE
ports/qemu: Fix inline-if in `lookup_cause`.

### DIFF
--- a/ports/qemu/mcu/rv32/interrupts.c
+++ b/ports/qemu/mcu/rv32/interrupts.c
@@ -144,7 +144,7 @@ const char *lookup_cause(uint32_t mcause) {
             case 11:
                 return exception_causes[6];
             default:
-                return (mcause >= 16) ?
+                return ((mcause & 0x7FFFFFFF) >= 16) ?
                        exception_causes[7] :
                        exception_causes[0];
         }


### PR DESCRIPTION
This patch isn't optimal, yet it makes it consistent to work with the same 31 bits of mcause inside this switch-block.