### PR TITLE
tools: Self-hosting of `mpy-tool`.

### DIFF
--- a/py/makeqstrdata.py
+++ b/py/makeqstrdata.py
@@ -9,17 +9,54 @@ from __future__ import print_function
 import re
 import sys
 
-# Python 2/3 compatibility:
+# Python 2/3/MicroPython compatibility:
 #   - iterating through bytes is different
-#   - codepoint2name lives in a different module
-import platform
-
-if platform.python_version_tuple()[0] == "2":
+#   - codepoint2name from html.entities is hard-coded
+if sys.version_info[0] == 2:
     bytes_cons = lambda val, enc=None: bytearray(val)
-    from htmlentitydefs import codepoint2name
-elif platform.python_version_tuple()[0] == "3":
+elif sys.version_info[0] == 3:  # Also handles MicroPython
     bytes_cons = bytes
-    from html.entities import codepoint2name
+
+# fmt: off
+codepoint2name = {
+    198: "AElig", 193: "Aacute", 194: "Acirc", 192: "Agrave", 913: "Alpha", 197: "Aring", 195: "Atilde",
+    196: "Auml", 914: "Beta", 199: "Ccedil", 935: "Chi", 8225: "Dagger", 916: "Delta", 208: "ETH",
+    201: "Eacute", 202: "Ecirc", 200: "Egrave", 917: "Epsilon", 919: "Eta", 203: "Euml", 915: "Gamma",
+    205: "Iacute", 206: "Icirc", 204: "Igrave", 921: "Iota", 207: "Iuml", 922: "Kappa", 923: "Lambda",
+    924: "Mu", 209: "Ntilde", 925: "Nu", 338: "OElig", 211: "Oacute", 212: "Ocirc", 210: "Ograve",
+    937: "Omega", 927: "Omicron", 216: "Oslash", 213: "Otilde", 214: "Ouml", 934: "Phi", 928: "Pi",
+    8243: "Prime", 936: "Psi", 929: "Rho", 352: "Scaron", 931: "Sigma", 222: "THORN", 932: "Tau",
+    920: "Theta", 218: "Uacute", 219: "Ucirc", 217: "Ugrave", 933: "Upsilon", 220: "Uuml", 926: "Xi",
+    221: "Yacute", 376: "Yuml", 918: "Zeta", 225: "aacute", 226: "acirc", 180: "acute", 230: "aelig",
+    224: "agrave", 8501: "alefsym", 945: "alpha", 38: "amp", 8743: "and", 8736: "ang", 229: "aring",
+    8776: "asymp", 227: "atilde", 228: "auml", 8222: "bdquo", 946: "beta", 166: "brvbar", 8226: "bull",
+    8745: "cap", 231: "ccedil", 184: "cedil", 162: "cent", 967: "chi", 710: "circ", 9827: "clubs",
+    8773: "cong", 169: "copy", 8629: "crarr", 8746: "cup", 164: "curren", 8659: "dArr", 8224: "dagger",
+    8595: "darr", 176: "deg", 948: "delta", 9830: "diams", 247: "divide", 233: "eacute", 234: "ecirc",
+    232: "egrave", 8709: "empty", 8195: "emsp", 8194: "ensp", 949: "epsilon", 8801: "equiv", 951: "eta",
+    240: "eth", 235: "euml", 8364: "euro", 8707: "exist", 402: "fnof", 8704: "forall", 189: "frac12",
+    188: "frac14", 190: "frac34", 8260: "frasl", 947: "gamma", 8805: "ge", 62: "gt", 8660: "hArr",
+    8596: "harr", 9829: "hearts", 8230: "hellip", 237: "iacute", 238: "icirc", 161: "iexcl", 236: "igrave",
+    8465: "image", 8734: "infin", 8747: "int", 953: "iota", 191: "iquest", 8712: "isin", 239: "iuml",
+    954: "kappa", 8656: "lArr", 955: "lambda", 9001: "lang", 171: "laquo", 8592: "larr", 8968: "lceil",
+    8220: "ldquo", 8804: "le", 8970: "lfloor", 8727: "lowast", 9674: "loz", 8206: "lrm", 8249: "lsaquo",
+    8216: "lsquo", 60: "lt", 175: "macr", 8212: "mdash", 181: "micro", 183: "middot", 8722: "minus",
+    956: "mu", 8711: "nabla", 160: "nbsp", 8211: "ndash", 8800: "ne", 8715: "ni", 172: "not", 8713: "notin",
+    8836: "nsub", 241: "ntilde", 957: "nu", 243: "oacute", 244: "ocirc", 339: "oelig", 242: "ograve",
+    8254: "oline", 969: "omega", 959: "omicron", 8853: "oplus", 8744: "or", 170: "ordf", 186: "ordm",
+    248: "oslash", 245: "otilde", 8855: "otimes", 246: "ouml", 182: "para", 8706: "part", 8240: "permil",
+    8869: "perp", 966: "phi", 960: "pi", 982: "piv", 177: "plusmn", 163: "pound", 8242: "prime",
+    8719: "prod", 8733: "prop", 968: "psi", 34: "quot", 8658: "rArr", 8730: "radic", 9002: "rang",
+    187: "raquo", 8594: "rarr", 8969: "rceil", 8221: "rdquo", 8476: "real", 174: "reg", 8971: "rfloor",
+    961: "rho", 8207: "rlm", 8250: "rsaquo", 8217: "rsquo", 8218: "sbquo", 353: "scaron", 8901: "sdot",
+    167: "sect", 173: "shy", 963: "sigma", 962: "sigmaf", 8764: "sim", 9824: "spades", 8834: "sub",
+    8838: "sube", 8721: "sum", 8835: "sup", 185: "sup1", 178: "sup2", 179: "sup3", 8839: "supe",
+    223: "szlig", 964: "tau", 8756: "there4", 952: "theta", 977: "thetasym", 8201: "thinsp", 254: "thorn",
+    732: "tilde", 215: "times", 8482: "trade", 8657: "uArr", 250: "uacute", 8593: "uarr", 251: "ucirc",
+    249: "ugrave", 168: "uml", 978: "upsih", 965: "upsilon", 252: "uuml", 8472: "weierp", 958: "xi",
+    253: "yacute", 165: "yen", 255: "yuml", 950: "zeta", 8205: "zwj", 8204: "zwnj"
+}
+# fmt: on
 # end compatibility code
 
 codepoint2name[ord("-")] = "hyphen"
@@ -295,6 +332,9 @@ unsorted_qstr_list = {
     "<genexpr>",
 }
 
+# Matches any string that needs no escaping (alphanum + _ only)
+RE_NO_ESCAPE = re.compile(r"^[a-zA-Z0-9_]$")
+
 
 # this must match the equivalent function in qstr.c
 def compute_hash(qstr, bytes_hash):
@@ -307,15 +347,17 @@ def compute_hash(qstr, bytes_hash):
 
 
 def qstr_escape(qst):
-    def esc_char(m):
-        c = ord(m.group(0))
+    def esc_char(c):
+        if RE_NO_ESCAPE.match(c):
+            return c
+        c = ord(c)
         try:
             name = codepoint2name[c]
         except KeyError:
             name = "0x%02x" % c
         return "_" + name + "_"
 
-    return re.sub(r"[^A-Za-z0-9_]", esc_char, qst)
+    return "".join(map(esc_char, qst))
 
 
 static_qstr_list_ident = list(map(qstr_escape, static_qstr_list))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.codespell]
 count = ""
 ignore-regex = '\b[A-Z]{3}\b'
-ignore-words-list = "ans,asend,deques,dout,emac,extint,hsi,iput,mis,numer,shft,synopsys,technic,ure"
+ignore-words-list = "ans,asend,deques,dout,emac,extint,hsi,iput,mis,notin,numer,shft,synopsys,technic,ure,curren"
 quiet-level = 3
 skip = """
 */build*,\

--- a/tools/ci.sh
+++ b/tools/ci.sh
@@ -118,9 +118,19 @@ function ci_mpy_format_test {
     python2.7 ./tools/mpy-tool.py -xd tests/frozen/frozentest.mpy
     python3 ./tools/mpy-tool.py -xd tests/frozen/frozentest.mpy
 
+    # Build MicroPython
+    ci_unix_standard_build
+    micropython=./ports/unix/build-standard/micropython
+    $micropython -m mip install --target . argparse __future__
+    export MICROPYPATH=.
+
+    # Test mpy-tool.py running under MicroPython
+    $micropython ./tools/mpy-tool.py -x -d tests/frozen/frozentest.mpy
+
     # Test mpy-tool.py dump feature on native code
     make -C examples/natmod/features1
     ./tools/mpy-tool.py -xd examples/natmod/features1/features1.mpy
+    $micropython ./tools/mpy-tool.py -x -d examples/natmod/features1/features1.mpy
 }
 
 ########################################################################################

--- a/tools/mpy-tool.py
+++ b/tools/mpy-tool.py
@@ -1765,7 +1765,7 @@ def merge_mpy(compiled_modules, output_file):
             f.write(merged_mpy)
 
 
-def main():
+def main(args=None):
     global global_qstrs
 
     import argparse
@@ -1797,7 +1797,7 @@ def main():
     )
     cmd_parser.add_argument("-o", "--output", default=None, help="output file")
     cmd_parser.add_argument("files", nargs="+", help="input .mpy files")
-    args = cmd_parser.parse_args()
+    args = cmd_parser.parse_args(args)
 
     # set config values relevant to target machine
     config.MICROPY_LONGINT_IMPL = {

--- a/tools/mpy-tool.py
+++ b/tools/mpy-tool.py
@@ -24,11 +24,11 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
 
-# Python 2/3 compatibility code
+# Python 2/3/MicroPython compatibility code
 from __future__ import print_function
-import platform
+import sys
 
-if platform.python_version_tuple()[0] == "2":
+if sys.version_info[0] == 2:
     from binascii import hexlify as hexlify_py2
 
     str_cons = lambda val, enc=None: str(val)
@@ -41,7 +41,7 @@ if platform.python_version_tuple()[0] == "2":
         x = hexlify_py2(b)
         return ":".join(x[i : i + 2] for i in range(0, len(x), 2))
 
-else:
+elif sys.version_info[0] == 3:  # Also handles MicroPython
     from binascii import hexlify
 
     str_cons = str


### PR DESCRIPTION
### Summary

This allows running `mpy-tool` using MicroPython itself.

### Testing

Currently it is used in `ViperIDE` to disassemble `.mpy` files:
- MicroPython VM runs in-browser using WebAssembly
- The filesystem is [populated with the required libraries](https://github.com/vshymanskyy/ViperIDE/tree/main/src/tools_vfs)
- `.mpy` file is copied to the VM as well
- The `mpy-tool` is [used to dissect](https://github.com/vshymanskyy/ViperIDE/blob/7e42f28da5394c273b34d8f04835961676a43d8d/src/python_utils.js#L218-L233) the `.mpy`

Also, a test is added to `ci.sh`

### Trade-offs and Alternatives

None that I'm aware of