### PR TITLE
tests/extmod: Support stm32 port in machine.UART TX test.

### DIFF
--- a/tests/extmod/machine_uart_tx.py
+++ b/tests/extmod/machine_uart_tx.py
@@ -9,12 +9,34 @@ except ImportError:
 
 import time, sys
 
+initial_delay_ms = 0
+bit_margin = 0
+timing_margin_us = 100
+
 # Configure pins based on the target.
-if "rp2" in sys.platform:
+if "esp32" in sys.platform:
+    uart_id = 1
+    pins = {}
+    timing_margin_us = 400
+elif "mimxrt" in sys.platform:
+    uart_id = 1
+    pins = {}
+    initial_delay_ms = 20  # UART sends idle frame after init, so wait for that
+    bit_margin = 1
+elif "pyboard" in sys.platform:
+    uart_id = 4
+    pins = {}
+    initial_delay_ms = 50  # UART sends idle frame after init, so wait for that
+    bit_margin = 1  # first start-bit must wait to sync with the UART clock
+elif "rp2" in sys.platform:
     uart_id = 0
-    tx_pin = "GPIO0"
-    rx_pin = "GPIO1"
+    pins = {"tx": "GPIO0", "rx": "GPIO1"}
     timing_margin_us = 180
+elif "samd" in sys.platform:
+    uart_id = 2
+    pins = {"tx": "D1", "rx": "D0"}
+    timing_margin_us = 300
+    bit_margin = 1
 else:
     print("SKIP")
     raise SystemExit
@@ -22,7 +44,8 @@ else:
 # Test that write+flush takes the expected amount of time to execute.
 for bits_per_s in (2400, 9600, 115200):
     text = "Hello World"
-    uart = UART(uart_id, bits_per_s, bits=8, parity=None, stop=1, tx=tx_pin, rx=rx_pin)
+    uart = UART(uart_id, bits_per_s, bits=8, parity=None, stop=1, **pins)
+    time.sleep_ms(initial_delay_ms)
 
     start_us = time.ticks_us()
     uart.write(text)
@@ -33,4 +56,5 @@ for bits_per_s in (2400, 9600, 115200):
     bits_per_char = 10
     expect_us = (len(text)) * bits_per_char * 1_000_000 // bits_per_s
     delta_us = abs(duration_us - expect_us)
-    print(bits_per_s, delta_us <= timing_margin_us or delta_us)
+    margin_us = timing_margin_us + bit_margin * 1_000_000 // bits_per_s
+    print(bits_per_s, delta_us <= margin_us or delta_us)


### PR DESCRIPTION
### Summary

Getting this test running on stm32-based boards requires:
- Adding a small delay after constructing the UART so that the initial idle frame has time to be transmitted before the test starts.
- Adding a timing margin because the time for a UART write is always going to be longer than the exact calculation due to overhead of loading and calling methods (rp2 doesn't have this issue because it doesn't wait for the last byte to go out before returning from `flush()`).

### Testing

This test now passes on PYBv1.0 and PYB-SF2 (and probably all other stm32 boards).  Also retested on Pico and it passes.