### PR TITLE
tests/extmod: Make invalid-blockdev test work consistently on all ports.

### DIFF
--- a/tests/extmod/vfs_blockdev_invalid.py
+++ b/tests/extmod/vfs_blockdev_invalid.py
@@ -19,7 +19,7 @@ class RAMBlockDevice:
         self.write_res = 0
 
     def readblocks(self, block, buf, off=0):
-        print("readblocks")
+        # print("readblocks", block, len(buf), off)
         addr = block * self.ERASE_BLOCK_SIZE + off
         for i in range(len(buf)):
             buf[i] = self.data[addr + i]

--- a/tests/extmod/vfs_blockdev_invalid.py.exp
+++ b/tests/extmod/vfs_blockdev_invalid.py.exp
@@ -1,126 +1,28 @@
 <class 'VfsLfs2'>
-readblocks
-readblocks
-readblocks
-readblocks
-readblocks
-readblocks
-readblocks
-readblocks
-readblocks
-readblocks
-readblocks
-readblocks
-readblocks
-readblocks
-readblocks
-readblocks
-readblocks
-readblocks
-readblocks
-readblocks
-readblocks
-readblocks
-readblocks
-readblocks
-readblocks
-readblocks
-readblocks
-readblocks
-readblocks
-readblocks
 opened
-readblocks
-readblocks
-readblocks
-readblocks
-readblocks
-readblocks
-readblocks
-readblocks
-readblocks
-readblocks
 read 1 a
 read rest aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-readblocks
 OSError [Errno 5] EIO
-readblocks
-readblocks
-readblocks
-readblocks
-readblocks
-readblocks
-readblocks
-readblocks
-readblocks
 read 1 a
 read rest aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-readblocks
 OSError [Errno 22] EINVAL
-readblocks
-readblocks
-readblocks
-readblocks
-readblocks
-readblocks
-readblocks
-readblocks
-readblocks
 read 1 a
 read rest aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-readblocks
 OSError [Errno 22] EINVAL
-readblocks
-readblocks
-readblocks
-readblocks
-readblocks
-readblocks
-readblocks
-readblocks
-readblocks
 read 1 a
 read rest aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-readblocks
 OSError [Errno 22] EINVAL
-readblocks
-readblocks
-readblocks
-readblocks
-readblocks
-readblocks
-readblocks
-readblocks
-readblocks
 read 1 a
 read rest aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
 <class 'VfsFat'>
-readblocks
-readblocks
-readblocks
-readblocks
-readblocks
 opened
-readblocks
 read 1 a
 read rest aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-readblocks
 OSError [Errno 5] EIO
-readblocks
-readblocks
 OSError [Errno 5] EIO
-readblocks
 OSError [Errno 5] EIO
-readblocks
-readblocks
 OSError [Errno 5] EIO
-readblocks
 OSError [Errno 5] EIO
-readblocks
-readblocks
 OSError [Errno 5] EIO
-readblocks
 OSError [Errno 5] EIO
-readblocks
-readblocks
 OSError [Errno 5] EIO


### PR DESCRIPTION
### Summary

Some ports (eg stm32) configure the FAT driver differently (eg with multi-partition support) and that leads to a slightly different sequence of block reads, compared to other configurations (eg rp2).  Adjust the test so it passes for the different configurations.

Also print out more information about the arguments passed to `readblocks` for easier debugging.  They should be deterministic for a given filesystem implementation.

### Testing

This test tested to now work on PYBD-SF2, Pico and ESP32 (generic).

