### PR TITLE
rp2/machine_uart: Make it so TX is done only when no longer busy.

### DIFF
--- a/docs/library/machine.UART.rst
+++ b/docs/library/machine.UART.rst
@@ -160,7 +160,7 @@ Methods
 
    .. note::
 
-       For the rp2, esp8266 and nrf ports the call returns while the last byte is sent.
+       For the esp8266 and nrf ports the call returns while the last byte is sent.
        If required, a one character wait time has to be added in the calling script.
 
    Availability: rp2, esp32, esp8266, mimxrt, cc3200, stm32, nrf ports, renesas-ra
@@ -172,7 +172,7 @@ Methods
 
    .. note::
 
-       For the rp2, esp8266 and nrf ports the call may return ``True`` even if the last byte
+       For the esp8266 and nrf ports the call may return ``True`` even if the last byte
        of a transfer is still being sent. If required, a one character wait time has to be
        added in the calling script.
 

--- a/ports/rp2/machine_uart.c
+++ b/ports/rp2/machine_uart.c
@@ -491,8 +491,9 @@ static mp_int_t mp_machine_uart_any(machine_uart_obj_t *self) {
 }
 
 static bool mp_machine_uart_txdone(machine_uart_obj_t *self) {
+    // TX is done when: nothing in the ringbuf, TX FIFO is empty, TX output is not busy.
     return ringbuf_avail(&self->write_buffer) == 0
-           && (uart_get_hw(self->uart)->fr & UART_UARTFR_TXFE_BITS);
+           && (uart_get_hw(self->uart)->fr & (UART_UARTFR_TXFE_BITS | UART_UARTFR_BUSY_BITS)) == UART_UARTFR_TXFE_BITS;
 }
 
 static void mp_machine_uart_sendbreak(machine_uart_obj_t *self) {

--- a/tests/extmod/machine_uart_tx.py
+++ b/tests/extmod/machine_uart_tx.py
@@ -14,6 +14,7 @@ if "rp2" in sys.platform:
     uart_id = 0
     tx_pin = "GPIO0"
     rx_pin = "GPIO1"
+    timing_margin_us = 180
 else:
     print("SKIP")
     raise SystemExit
@@ -31,4 +32,5 @@ for bits_per_s in (2400, 9600, 115200):
     # 1(startbit) + 8(bits) + 1(stopbit) + 0(parity)
     bits_per_char = 10
     expect_us = (len(text)) * bits_per_char * 1_000_000 // bits_per_s
-    print(bits_per_s, duration_us <= expect_us)
+    delta_us = abs(duration_us - expect_us)
+    print(bits_per_s, delta_us <= timing_margin_us or delta_us)


### PR DESCRIPTION
### Summary

When flushing a UART on the rp2 port, it returns just before the last character is sent out the wire.

Fix this by waiting until the BUSY flag is cleared.

### Testing

TODO: the `tests/extmod/machine_uart_tx.py` test needs updating to cover this case.  Currently that test checks that transmit time is less than the expected time, and on rp2 the transmit+flush time is quite a bit less than expected (because it returns while there's still a byte left to transmit).  Rather it should be changed so transmit time is very close to the expected time.

Edit: that's now done.  Also docs updated.

