### PR TITLE
esp32: Move linker wrap directives to common cmake file.

### DIFF
--- a/ports/esp32/CMakeLists.txt
+++ b/ports/esp32/CMakeLists.txt
@@ -71,12 +71,5 @@ include($ENV{IDF_PATH}/tools/cmake/project.cmake)
 # Set the location of the main component for the project (one per target).
 list(APPEND EXTRA_COMPONENT_DIRS main_${IDF_TARGET})
 
-# Enable the panic handler wrapper
-idf_build_set_property(LINK_OPTIONS "-Wl,--wrap=esp_panic_handler" APPEND)
-
-# Patch LWIP memory pool allocators (see lwip_patch.c)
-idf_build_set_property(LINK_OPTIONS "-Wl,--wrap=memp_malloc" APPEND)
-idf_build_set_property(LINK_OPTIONS "-Wl,--wrap=memp_free" APPEND)
-
 # Define the project.
 project(micropython)

--- a/ports/esp32/CMakeLists.txt
+++ b/ports/esp32/CMakeLists.txt
@@ -1,5 +1,8 @@
 # Top-level cmake file for building MicroPython on ESP32.
-
+#
+# Note for maintainers: Where possible, functionality should be put into
+# esp32_common.cmake not this file. This is because this CMakeLists.txt file
+# needs to be duplicated for out-of-tree builds, and can easily get out of date.
 cmake_minimum_required(VERSION 3.12)
 
 # Retrieve IDF version

--- a/ports/esp32/esp32_common.cmake
+++ b/ports/esp32/esp32_common.cmake
@@ -236,6 +236,13 @@ target_include_directories(${MICROPY_TARGET} PUBLIC
 target_link_libraries(${MICROPY_TARGET} micropy_extmod_btree)
 target_link_libraries(${MICROPY_TARGET} usermod)
 
+# Enable the panic handler wrapper
+idf_build_set_property(LINK_OPTIONS "-Wl,--wrap=esp_panic_handler" APPEND)
+
+# Patch LWIP memory pool allocators (see lwip_patch.c)
+idf_build_set_property(LINK_OPTIONS "-Wl,--wrap=memp_malloc" APPEND)
+idf_build_set_property(LINK_OPTIONS "-Wl,--wrap=memp_free" APPEND)
+
 # Collect all of the include directories and compile definitions for the IDF components,
 # including those added by the IDF Component Manager via idf_components.yaml.
 foreach(comp ${__COMPONENT_NAMES_RESOLVED})

--- a/ports/esp32/esp32_common.cmake
+++ b/ports/esp32/esp32_common.cmake
@@ -1,3 +1,9 @@
+# This is the common ESP-IDF "main component" CMakeLists.txt contents for MicroPython.
+#
+# This file is included directly from a main_${IDF_TARGET}/CMakeLists.txt file
+# (or included from an out-of-tree main component CMakeLists.txt for out-of-tree
+# builds.)
+
 # Set location of base MicroPython directory.
 if(NOT MICROPY_DIR)
     get_filename_component(MICROPY_DIR ${CMAKE_CURRENT_LIST_DIR}/../.. ABSOLUTE)


### PR DESCRIPTION
### Summary

For in-tree builds, these are effectively equivalent. However for out-of-tree builds it's preferable to have as little as possible
in the top-level CMakeLists.txt file (as the out-of-tree build needs its own copy).

### Testing

Built the ESP32 port and used the linker map file to verify the `__wrap_`-prefixed symbols were still linked into the ELF file.
