### PR TITLE
tests/extmod: Fix access of RTC class in machine.RTC test.

### DIFF
--- a/tests/extmod/machine_rtc.py
+++ b/tests/extmod/machine_rtc.py
@@ -6,7 +6,7 @@ except ImportError:
     print("SKIP")
     raise SystemExit
 
-rtc = machine.RTC()
+rtc = RTC()
 
 # Save datetime.
 orig_datetime = rtc.datetime()


### PR DESCRIPTION
This previously passed on some targets that automatically import the `machine` module in `boot.py`.

Tested using `./run-tests.py --target pyboard --via-mpy` which forces a clean namespace, and fails without this patch.