### PR TITLE
rp2/modmachine: Re-sync time_ns offset when coming out of lightsleep.

### DIFF
--- a/ports/rp2/modmachine.c
+++ b/ports/rp2/modmachine.c
@@ -261,6 +261,9 @@ static void mp_machine_lightsleep(size_t n_args, const mp_obj_t *args) {
     // Bring back all clocks.
     runtime_init_clocks_optional_usb(disable_usb);
     MICROPY_END_ATOMIC_SECTION(my_interrupts);
+
+    // Re-sync mp_hal_time_ns() counter with aon timer.
+    mp_hal_time_ns_set_from_rtc();
 }
 
 NORETURN static void mp_machine_deepsleep(size_t n_args, const mp_obj_t *args) {

--- a/tests/extmod/time_time_ns.py
+++ b/tests/extmod/time_time_ns.py
@@ -22,3 +22,10 @@ if 2000000 < t1 - t0 < 50000000:
     print(True)
 else:
     print(t0, t1, t1 - t0)
+
+# Check that time.time() and time.time_ns() are within a second of each other.
+# Note that time.time() may return an int or float.
+for _ in range(10):
+    t_s, t_ns = time.time(), time.time_ns()
+    print(abs(t_s * 1_000 - t_ns // 1_000_000) <= 1_000)
+    time.sleep_us(100_000)

--- a/tests/extmod/time_time_ns.py.exp
+++ b/tests/extmod/time_time_ns.py.exp
@@ -1,2 +1,12 @@
 True
 True
+True
+True
+True
+True
+True
+True
+True
+True
+True
+True

--- a/tests/extmod/vfs_lfs_mtime.py
+++ b/tests/extmod/vfs_lfs_mtime.py
@@ -3,7 +3,7 @@
 try:
     import time, vfs
 
-    time.time
+    time.time_ns
     time.sleep
     vfs.VfsLfs2
 except (ImportError, AttributeError):
@@ -47,7 +47,8 @@ def test(bdev, vfs_class):
     fs = vfs_class(bdev, mtime=True)
 
     # Create an empty file, should have a timestamp.
-    current_time = int(time.time())
+    # Use time_ns() for current time because that's what's used for VfsLfs2 time.
+    current_time = time.time_ns() // 1_000_000_000
     fs.open("test1", "wt").close()
 
     # Wait 1 second so mtime will increase by at least 1.
@@ -61,7 +62,7 @@ def test(bdev, vfs_class):
     stat2 = fs.stat("test2")
     print(stat1[8] != 0, stat2[8] != 0)
 
-    # Check that test1 has mtime which matches time.time() at point of creation.
+    # Check that test1 has mtime which matches time.time_ns() at point of creation.
     print(current_time <= stat1[8] <= current_time + 1)
 
     # Check that test1 is older than test2.


### PR DESCRIPTION
### Summary

Prior to this fix, `tests/extmod/vfs_lfs_mtime.py` would fail when run after the `tests/ports/rp2/rp2_lightsleep.py` test, because `time.time_ns()` would have a large and constant offset from `time.time()`.

Fix this by re-syncing the time-ns offset when coming out of lightsleep.

### Testing

Running the test suite multiple times on a Pico, it now passes the `vfs_lfs_mtime.py` test.  Prior to this fix, it would fail it on the second (and later) test run.

