### PR TITLE
mpremote: Fix UnboundLocalError in Transport.fs_writefile().

### DIFF
--- a/tools/mpremote/mpremote/transport.py
+++ b/tools/mpremote/mpremote/transport.py
@@ -151,9 +151,9 @@ class Transport:
             while data:
                 chunk = data[:chunk_size]
                 self.exec("w(" + repr(chunk) + ")")
-                written += len(chunk)
                 data = data[len(chunk) :]
                 if progress_callback:
+                    written += len(chunk)
                     progress_callback(written, src_size)
             self.exec("f.close()")
         except TransportExecError as e:


### PR DESCRIPTION
### Summary

The variable `written` was being used before it was defined in the `fs_writefile()` method of the `Transport` class. This was causing an `UnboundLocalError` to be raised when `progress_callback` was not provided.

fixes: #16084


### Testing

The following code executes as expected after the fix is applied (See #16084):

```py
from mpremote.transport_serial import SerialTransport

board = SerialTransport("/dev/ttyUSB0", 115200)
board.enter_raw_repl()
board.fs_writefile("/test.data", b"hello")
board.exit_raw_repl()
board.close()
```
