### PR TITLE
py/objdeque.c: Fix buffer overflow in deque_subscr().

### DIFF
--- a/py/objdeque.c
+++ b/py/objdeque.c
@@ -208,7 +208,7 @@ static mp_obj_t deque_subscr(mp_obj_t self_in, mp_obj_t index, mp_obj_t value) {
 
     size_t offset = mp_get_index(self->base.type, deque_len(self), index, false);
     size_t index_val = self->i_get + offset;
-    if (index_val > self->alloc) {
+    if (index_val >= self->alloc) {
         index_val -= self->alloc;
     }
 

--- a/tests/basics/deque2.py
+++ b/tests/basics/deque2.py
@@ -31,6 +31,16 @@ print(d[0], d[1], d[-1])
 d[3] = 5
 print(d[3])
 
+# Access the last element via index, when the last element is at various locations
+d = deque((), 2)
+for i in range(4):
+    d.append(i)
+    print(i, d[-1])
+
+# Write the last element then access all elements from the end
+d[-1] = 4
+print(d[-2], d[-1])
+
 # Accessing indices out of bounds raises IndexError
 try:
     d[4]


### PR DESCRIPTION
### Summary
This PR resolves an off-by-one buffer overflow in py/objdeque.c when using deque with indexing. The error occurs when appending data beyond the size of the allocated buffer (discarding items from the opposite end) without overflow checking.
### Reproduction
The following code demonstrates the issue on all boards/ports:
```python
from collections import deque

d = deque((), 2)

for i in range(4):
    d.append(i)
    print(f"{i=} {d[-1]=}")
```
##### Expected Output
```
i=0 d[-1]=0
i=1 d[-1]=1
i=2 d[-1]=2
i=3 d[-1]=3
```
##### Actual Output
```
i=0 d[-1]=0
i=1 d[-1]=1
i=2 d[-1]=2
Traceback (most recent call last):
  File "/tmp/deque_fail.py", line 7, in <module>
TypeError: 'deque' object isn't subscriptable
```

#### Root Cause
The issue arises from an off-by-one error in `deque_subscr()`. If `index_val` equals `self->alloc`, the necessary index correction `index_val -= self->alloc` is skipped, leading to an out-of-bounds access when `self->items[index_val]` is called. Since `self->items` has a length of `self->alloc`, this results in a buffer overflow.

This fix ensures that the index correction is applied whenever `index_val >= self->alloc`, preventing access beyond the allocated buffer size.
### Testing
Tested on unix and esp32 port.


