### PR TITLE
Fix/mip documentation

### DIFF
--- a/docs/reference/packages.rst
+++ b/docs/reference/packages.rst
@@ -69,9 +69,9 @@ On the Unix port, ``mip`` can be used at the REPL as above, and also by using ``
     $ ./micropython -m mip install pkgname-or-url
     $ ./micropython -m mip install pkgname-or-url@version
 
-The ``--target=path``, ``--no-mpy``, and ``--index`` arguments can be set::
+The ``--target path``, ``--no-mpy``, and ``--index`` arguments can be set::
 
-    $ ./micropython -m mip install --target=third-party pkgname
+    $ ./micropython -m mip install --target third-party pkgname
     $ ./micropython -m mip install --no-mpy pkgname
     $ ./micropython -m mip install --index https://host/pi pkgname
 


### PR DESCRIPTION
### Summary
There is small mistake in [Package management](https://docs.micropython.org/en/latest/reference/packages.html) documentation. It is stating that it can be used on Unix port like this:
` mpremote mip install --target=/flash/third-party pkgname`
But it has to be used like this:
` mpremote mip install --target /flash/third-party pkgname`
This error is probably caused by mip usage directly in python code (`mip.install("pkgname", target="third-party")`)

