### PR TITLE
tests: add full, automated, top-level test runner for hardware

### DIFF
--- a/tests/extmod/machine_spi_rate.py
+++ b/tests/extmod/machine_spi_rate.py
@@ -23,6 +23,8 @@ MAX_DELTA_MS = 8
 # Tune test parameters based on the target.
 if "alif" in sys.platform:
     MAX_DELTA_MS = 20
+elif "renesas-ra" in sys.platform:
+    MAX_DELTA_MS = 15
 elif "esp8266" in sys.platform:
     MAX_DELTA_MS = 50  # port requires much looser timing requirements
 

--- a/tests/extmod/machine_spi_rate.py
+++ b/tests/extmod/machine_spi_rate.py
@@ -27,6 +27,8 @@ elif "renesas-ra" in sys.platform:
     MAX_DELTA_MS = 15
 elif "esp8266" in sys.platform:
     MAX_DELTA_MS = 50  # port requires much looser timing requirements
+elif "zephyr" in sys.platform:
+    MAX_DELTA_MS = 10
 
 
 def get_real_baudrate(spi):

--- a/tests/extmod/machine_uart_tx.py
+++ b/tests/extmod/machine_uart_tx.py
@@ -34,6 +34,12 @@ elif "rp2" in sys.platform:
 elif "samd" in sys.platform:
     timing_margin_us = 300
     bit_margin = 1
+elif "zephyr" in sys.platform:
+    bit_margin = 1
+    if "frdm_k64f" in sys.implementation._machine:
+        timing_margin_us = 1200
+    elif "nucleo_wb55rg" in sys.implementation._machine:
+        timing_margin_us = 400
 
 # Test that write+flush takes the expected amount of time to execute.
 for bits_per_s in (2400, 9600, 115200):

--- a/tests/extmod_hardware/machine_adc.py
+++ b/tests/extmod_hardware/machine_adc.py
@@ -1,0 +1,42 @@
+# Test machine.ADC.
+#
+# IMPORTANT: This test requires hardware connections.
+
+try:
+    from machine import ADC, Pin
+except ImportError:
+    print("SKIP")
+    raise SystemExit
+
+import unittest
+from target_wiring import adc_loopback_pins
+
+
+class TestBase:
+    @classmethod
+    def setUpClass(cls):
+        print("set up pins:", cls.pin_adc, cls.pin_out)
+        cls.adc = ADC(cls.pin_adc)
+        cls.pin = Pin(cls.pin_out)
+
+    def setUp(self):
+        self.pin.init(Pin.OUT)
+
+    def test_read_u16(self):
+        self.pin(0)
+        for _ in range(10):
+            self.assertLessEqual(self.adc.read_u16(), 5000)
+        self.pin(1)
+        for _ in range(10):
+            self.assertGreaterEqual(self.adc.read_u16(), 60000)
+
+
+# Generate test classes, one for each set of pins to test.
+for pin_adc, pin_out in adc_loopback_pins:
+    cls_name = "Test_{}_{}".format(pin_adc, pin_out)
+    globals()[cls_name] = type(
+        cls_name, (TestBase, unittest.TestCase), {"pin_adc": pin_adc, "pin_out": pin_out}
+    )
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/extmod_hardware/machine_counter.py
+++ b/tests/extmod_hardware/machine_counter.py
@@ -16,6 +16,10 @@ if "esp32" in sys.platform:
     id = 0
     out_pin = 4
     in_pin = 5
+    if "ESP32S2" in sys.implementation._machine:
+        # FeatherS2
+        out_pin = 5
+        in_pin = 6
 elif sys.platform == "mimxrt":
     if "Teensy" in sys.implementation._machine:
         id = 0

--- a/tests/extmod_hardware/machine_i2c_target.py
+++ b/tests/extmod_hardware/machine_i2c_target.py
@@ -30,11 +30,14 @@ elif sys.platform == "rp2":
     args_target = (1,)
 elif sys.platform == "pyboard":
     if sys.implementation._build == "NUCLEO_WB55":
-        args_controller = {"scl": "B8", "sda": "B9"}
-        args_target = (3,)
+        args_controller = {"scl": "B8", "sda": "B9"}  # Arduino header D15/D14
+        args_target = (3,)  # PC0/PC1, Arduino header A0/A1
     else:
         args_controller = {"scl": "X1", "sda": "X2"}
         args_target = ("X",)
+        if hasattr(Pin.board, "PULL_SCL"):
+            Pin("PULL_SCL", Pin.OUT, value=1)
+            Pin("PULL_SDA", Pin.OUT, value=1)
 elif "zephyr-nucleo_wb55rg" in sys.implementation._machine:
     # PB8=I2C1_SCL, PB9=I2C1_SDA (on Arduino header D15/D14)
     # PC0=I2C3_SCL, PC1=I2C3_SDA (on Arduino header A0/A1)

--- a/tests/extmod_hardware/machine_i2c_target.py
+++ b/tests/extmod_hardware/machine_i2c_target.py
@@ -33,11 +33,8 @@ elif sys.platform == "pyboard":
         args_controller = {"scl": "D13", "sda": "D12"}  # Arduino header D13/D12
         args_target = (1,)  # PB8/PB9, Arduino header D15/D14
     else:
-        args_controller = {"scl": "X1", "sda": "X2"}
+        args_controller = {"scl": "X7", "sda": "X8"}
         args_target = ("X",)
-        if hasattr(Pin.board, "PULL_SCL"):
-            Pin("PULL_SCL", Pin.OUT, value=1)
-            Pin("PULL_SDA", Pin.OUT, value=1)
 elif "zephyr-nucleo_wb55rg" in sys.implementation._machine:
     # PB8=I2C1_SCL, PB9=I2C1_SDA (on Arduino header D15/D14)
     # PC0=I2C3_SCL, PC1=I2C3_SDA (on Arduino header A0/A1)
@@ -55,15 +52,37 @@ elif sys.platform == "mimxrt":
 elif sys.platform == "samd":
     args_controller = {"scl": "D5", "sda": "D1"}
     args_target = ()
-else:
-    print("Please add support for this test on this platform.")
-    raise SystemExit
 
 
 def config_pull_up():
     Pin(args_controller["scl"], Pin.OPEN_DRAIN, Pin.PULL_UP)
     Pin(args_controller["sda"], Pin.OPEN_DRAIN, Pin.PULL_UP)
 
+
+def config_pull_up_disable():
+    pass
+
+
+if hasattr(Pin, "board") and hasattr(Pin.board, "PULL_SCL"):
+
+    def config_pull_up():
+        Pin("PULL_SCL", Pin.OUT, value=1)
+        Pin("PULL_SDA", Pin.OUT, value=1)
+
+    def config_pull_up_disable():
+        Pin("PULL_SCL", Pin.ANALOG)
+        Pin("PULL_SDA", Pin.ANALOG)
+
+try:
+    from target_wiring import i2c_args_controller as args_controller
+    from target_wiring import i2c_args_target as args_target
+    from target_wiring import i2c_kwargs_target as kwargs_target
+except:
+    pass
+
+if "args_controller" not in globals():
+    print("Please add support for this test on this platform.")
+    raise SystemExit
 
 class TestMemory(unittest.TestCase):
     @classmethod
@@ -75,6 +94,7 @@ class TestMemory(unittest.TestCase):
 
     @classmethod
     def tearDownClass(cls):
+        config_pull_up_disable()
         cls.i2c_target.deinit()
 
     def test_scan(self):
@@ -148,6 +168,7 @@ class TestMemoryIRQ(unittest.TestCase):
 
     @classmethod
     def tearDownClass(cls):
+        config_pull_up_disable()
         cls.i2c_target.deinit()
 
     @unittest.skipIf(sys.platform == "esp32", "scan doesn't trigger IRQ_END_WRITE")
@@ -195,6 +216,7 @@ class TestPolling(unittest.TestCase):
 
     @classmethod
     def tearDownClass(cls):
+        config_pull_up_disable()
         cls.i2c_target.deinit()
 
     def test_read(self):
@@ -244,6 +266,7 @@ class TestIRQ(unittest.TestCase):
 
     @classmethod
     def tearDownClass(cls):
+        config_pull_up_disable()
         cls.i2c_target.deinit()
 
     def test_scan(self):

--- a/tests/extmod_hardware/machine_i2c_target.py
+++ b/tests/extmod_hardware/machine_i2c_target.py
@@ -30,8 +30,8 @@ elif sys.platform == "rp2":
     args_target = (1,)
 elif sys.platform == "pyboard":
     if sys.implementation._build == "NUCLEO_WB55":
-        args_controller = {"scl": "B8", "sda": "B9"}  # Arduino header D15/D14
-        args_target = (3,)  # PC0/PC1, Arduino header A0/A1
+        args_controller = {"scl": "D13", "sda": "D12"}  # Arduino header D13/D12
+        args_target = (1,)  # PB8/PB9, Arduino header D15/D14
     else:
         args_controller = {"scl": "X1", "sda": "X2"}
         args_target = ("X",)

--- a/tests/extmod_hardware/machine_pin.py
+++ b/tests/extmod_hardware/machine_pin.py
@@ -1,0 +1,43 @@
+# Test machine.Pin.
+#
+# IMPORTANT: This test requires hardware connections.
+
+try:
+    from machine import Pin
+except ImportError:
+    print("SKIP")
+    raise SystemExit
+
+import unittest
+from target_wiring import pin_loopback_pins
+
+
+class TestBase:
+    @classmethod
+    def setUpClass(cls):
+        print("set up pins:", cls.pin_out, cls.pin_in)
+        cls.p0 = Pin(cls.pin_out)
+        cls.p1 = Pin(cls.pin_in)
+
+    def setUp(self):
+        self.p0.init(Pin.OUT)
+        self.p1.init(Pin.IN)
+
+    def test_connections(self):
+        print(self.pin_out, self.pin_in)
+        print(self.p0, self.p1)
+        self.p0(1)
+        self.assertEqual(1, self.p1())
+        self.p0(0)
+        self.assertEqual(0, self.p1())
+
+
+# Generate test classes, one for each set of pins to test.
+for pin_out, pin_in in pin_loopback_pins:
+    cls_name = "Test_{}_{}".format(pin_out, pin_in)
+    globals()[cls_name] = type(
+        cls_name, (TestBase, unittest.TestCase), {"pin_out": pin_out, "pin_in": pin_in}
+    )
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/extmod_hardware/machine_pin.py
+++ b/tests/extmod_hardware/machine_pin.py
@@ -15,28 +15,101 @@ from target_wiring import pin_loopback_pins
 class TestBase:
     @classmethod
     def setUpClass(cls):
-        print("set up pins:", cls.pin_out, cls.pin_in)
-        cls.p0 = Pin(cls.pin_out)
-        cls.p1 = Pin(cls.pin_in)
+        print("set up pins:", cls.p0_name, cls.p1_name)
+        cls.p0 = Pin(cls.p0_name)
+        cls.p1 = Pin(cls.p1_name)
 
-    def setUp(self):
-        self.p0.init(Pin.OUT)
+    def tearDown(self):
+        self.p0.init(Pin.IN)
         self.p1.init(Pin.IN)
 
-    def test_connections(self):
-        print(self.pin_out, self.pin_in)
-        print(self.p0, self.p1)
-        self.p0(1)
-        self.assertEqual(1, self.p1())
-        self.p0(0)
-        self.assertEqual(0, self.p1())
+    def test_init_with_value(self):
+        self.p1.init(Pin.IN)
+        for _ in range(4):
+            self.p0.init(Pin.OUT, value=0)
+            self.assertEqual(self.p1(), 0)
+            self.p0.init(Pin.OUT, value=1)
+            self.assertEqual(self.p1(), 1)
+
+    def test_call(self):
+        self.p0.init(Pin.OUT)
+        self.p1.init(Pin.IN)
+        for _ in range(4):
+            self.p0(0)
+            self.assertEqual(self.p1(), 0)
+            self.p0(1)
+            self.assertEqual(self.p1(), 1)
+
+    def test_value(self):
+        self.p0.init(Pin.OUT)
+        self.p1.init(Pin.IN)
+        for _ in range(4):
+            self.p0.value(0)
+            self.assertEqual(self.p1.value(), 0)
+            self.p0.value(1)
+            self.assertEqual(self.p1.value(), 1)
+
+    @unittest.skipUnless(hasattr(Pin, "low"), "no low/high methods")
+    def test_low_high(self):
+        self.p0.init(Pin.OUT)
+        self.p1.init(Pin.IN)
+        for _ in range(4):
+            self.p0.low()
+            self.assertEqual(self.p1(), 0)
+            self.p0.high()
+            self.assertEqual(self.p1(), 1)
+
+    def test_off_on(self):
+        self.p0.init(Pin.OUT)
+        self.p1.init(Pin.IN)
+        for _ in range(4):
+            self.p0.off()
+            self.assertEqual(self.p1(), 0)
+            self.p0.on()
+            self.assertEqual(self.p1(), 1)
+
+    def _test_pull(self, pull, value):
+        inv_value = 1 - value
+        self.p1.init(Pin.IN)
+        for _ in range(4):
+            self.p0.init(Pin.OUT, value=inv_value)
+            self.assertEqual(self.p1(), inv_value)
+            self.p0.init(Pin.IN, pull)
+            self.assertEqual(self.p1(), value)
+
+    def test_pull_up(self):
+        self._test_pull(Pin.PULL_UP, 1)
+
+    def test_pull_down(self):
+        self._test_pull(Pin.PULL_DOWN, 0)
+
+    def test_open_drain(self):
+        self.p0.init(Pin.OPEN_DRAIN, Pin.PULL_UP)
+        self.p1.init(Pin.OPEN_DRAIN, Pin.PULL_UP)
+        for _ in range(4):
+            self.p0(1)
+            self.p1(1)
+            self.assertEqual(self.p0(), 1)
+            self.assertEqual(self.p1(), 1)
+            self.p0(0)
+            self.p1(1)
+            self.assertEqual(self.p0(), 0)
+            self.assertEqual(self.p1(), 0)
+            self.p0(1)
+            self.p1(0)
+            self.assertEqual(self.p0(), 0)
+            self.assertEqual(self.p1(), 0)
+            self.p0(0)
+            self.p1(0)
+            self.assertEqual(self.p0(), 0)
+            self.assertEqual(self.p1(), 0)
 
 
 # Generate test classes, one for each set of pins to test.
-for pin_out, pin_in in pin_loopback_pins:
-    cls_name = "Test_{}_{}".format(pin_out, pin_in)
+for p0_name, p1_name in pin_loopback_pins:
+    cls_name = "Test_{}_{}".format(p0_name, p1_name)
     globals()[cls_name] = type(
-        cls_name, (TestBase, unittest.TestCase), {"pin_out": pin_out, "pin_in": pin_in}
+        cls_name, (TestBase, unittest.TestCase), {"p0_name": p0_name, "p1_name": p1_name}
     )
 
 if __name__ == "__main__":

--- a/tests/extmod_hardware/machine_pin_irq.py
+++ b/tests/extmod_hardware/machine_pin_irq.py
@@ -1,0 +1,117 @@
+# Test machine.Pin.irq() method.
+#
+# IMPORTANT: This test requires hardware connections.
+
+try:
+    from machine import Pin
+
+    Pin.irq
+except (AttributeError, ImportError):
+    print("SKIP")
+    raise SystemExit
+
+import time, unittest
+from target_wiring import pin_loopback_pins
+
+
+class TestBase:
+    @classmethod
+    def setUpClass(cls):
+        print("set up pins:", cls.pin_out, cls.pin_in)
+        cls.p0 = Pin(cls.pin_out)
+        cls.p1 = Pin(cls.pin_in)
+
+    def setUp(self):
+        self.p0.init(Pin.OUT)
+        self.p1.init(Pin.IN)
+        self.events = [0] * 100
+        self.num_events = 0
+
+    def add_event(self, data):
+        self.events[self.num_events] = data
+        self.num_events += 1
+
+    def change_pin(self, value):
+        self.p0(value)
+        time.sleep(0)
+
+    def irq_handler(self, p):
+        if p is self.p1:
+            self.add_event(p())
+        else:
+            print("expecting", self.p1)
+
+    def _test_softirq(self, trigger, events_expected):
+        # Uses time.sleep(0) to run the soft interrupt handler.
+        self.num_events = 0
+
+        self.change_pin(0)
+        self.add_event("a")
+        self.p1.irq(self.irq_handler, trigger)
+        self.add_event("b")
+        self.change_pin(1)
+        self.add_event("c")
+        self.change_pin(0)
+        self.add_event("d")
+        self.change_pin(1)
+        self.add_event("e")
+        self.change_pin(0)
+        self.add_event("f")
+        self.p1.irq(None)
+        self.add_event("g")
+        self.change_pin(1)
+        self.add_event("h")
+        self.change_pin(0)
+        self.add_event("i")
+
+        self.assertEqual(self.events[: self.num_events], events_expected)
+
+    def _test_hardirq(self, trigger, events_expected):
+        self.num_events = 0
+
+        self.p0(0)
+        self.add_event("a")
+        self.p1.irq(self.irq_handler, trigger, hard=True)
+        self.add_event("b")
+        self.p0(1)
+        self.add_event("c")
+        self.p0(0)
+        self.add_event("d")
+        self.p0(1)
+        self.add_event("e")
+        self.p0(0)
+        self.add_event("f")
+        self.p1.irq(None)
+        self.add_event("g")
+        self.p0(1)
+        self.add_event("h")
+        self.p0(0)
+        self.add_event("i")
+
+        self.assertEqual(self.events[: self.num_events], events_expected)
+
+    def test_irq_rising(self):
+        events_expected = ["a", "b", 1, "c", "d", 1, "e", "f", "g", "h", "i"]
+        self._test_softirq(Pin.IRQ_RISING, events_expected)
+        self._test_hardirq(Pin.IRQ_RISING, events_expected)
+
+    def test_irq_falling(self):
+        events_expected = ["a", "b", "c", 0, "d", "e", 0, "f", "g", "h", "i"]
+        self._test_softirq(Pin.IRQ_FALLING, events_expected)
+        self._test_hardirq(Pin.IRQ_FALLING, events_expected)
+
+    def test_irq_rising_falling(self):
+        events_expected = ["a", "b", 1, "c", 0, "d", 1, "e", 0, "f", "g", "h", "i"]
+        self._test_softirq(Pin.IRQ_RISING | Pin.IRQ_FALLING, events_expected)
+        self._test_hardirq(Pin.IRQ_RISING | Pin.IRQ_FALLING, events_expected)
+
+
+# Generate test classes, one for each set of pins to test.
+for pin_out, pin_in in pin_loopback_pins:
+    cls_name = "Test_{}_{}".format(pin_out, pin_in)
+    globals()[cls_name] = type(
+        cls_name, (TestBase, unittest.TestCase), {"pin_out": pin_out, "pin_in": pin_in}
+    )
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/extmod_hardware/machine_pin_irq.py
+++ b/tests/extmod_hardware/machine_pin_irq.py
@@ -10,22 +10,32 @@ except (AttributeError, ImportError):
     print("SKIP")
     raise SystemExit
 
-import time, unittest
+import sys, time, unittest
 from target_wiring import pin_loopback_pins
+
+has_hardirq = sys.platform not in ("esp32",)
+
+events_expected_rising = ["a", "b", 1, "c", "d", 1, "e", "f", "g", "h", "i"]
+events_expected_falling = ["a", "b", "c", 0, "d", "e", 0, "f", "g", "h", "i"]
+events_expected_rising_falling = ["a", "b", 1, "c", 0, "d", 1, "e", 0, "f", "g", "h", "i"]
 
 
 class TestBase:
     @classmethod
     def setUpClass(cls):
-        print("set up pins:", cls.pin_out, cls.pin_in)
-        cls.p0 = Pin(cls.pin_out)
-        cls.p1 = Pin(cls.pin_in)
+        print("set up pins:", cls.p0_name, cls.p1_name)
+        cls.p0 = Pin(cls.p0_name)
+        cls.p1 = Pin(cls.p1_name)
 
     def setUp(self):
         self.p0.init(Pin.OUT)
         self.p1.init(Pin.IN)
         self.events = [0] * 100
         self.num_events = 0
+
+    def tearDown(self):
+        self.p0.init(Pin.IN)
+        self.p1.init(Pin.IN)
 
     def add_event(self, data):
         self.events[self.num_events] = data
@@ -67,6 +77,9 @@ class TestBase:
         self.assertEqual(self.events[: self.num_events], events_expected)
 
     def _test_hardirq(self, trigger, events_expected):
+        if not has_hardirq:
+            self.skipTest("no hard IRQ")
+
         self.num_events = 0
 
         self.p0(0)
@@ -90,27 +103,30 @@ class TestBase:
 
         self.assertEqual(self.events[: self.num_events], events_expected)
 
-    def test_irq_rising(self):
-        events_expected = ["a", "b", 1, "c", "d", 1, "e", "f", "g", "h", "i"]
-        self._test_softirq(Pin.IRQ_RISING, events_expected)
-        self._test_hardirq(Pin.IRQ_RISING, events_expected)
+    def test_rising_softirq(self):
+        self._test_softirq(Pin.IRQ_RISING, events_expected_rising)
 
-    def test_irq_falling(self):
-        events_expected = ["a", "b", "c", 0, "d", "e", 0, "f", "g", "h", "i"]
-        self._test_softirq(Pin.IRQ_FALLING, events_expected)
-        self._test_hardirq(Pin.IRQ_FALLING, events_expected)
+    def test_rising_hardirq(self):
+        self._test_hardirq(Pin.IRQ_RISING, events_expected_rising)
 
-    def test_irq_rising_falling(self):
-        events_expected = ["a", "b", 1, "c", 0, "d", 1, "e", 0, "f", "g", "h", "i"]
-        self._test_softirq(Pin.IRQ_RISING | Pin.IRQ_FALLING, events_expected)
-        self._test_hardirq(Pin.IRQ_RISING | Pin.IRQ_FALLING, events_expected)
+    def test_falling_softirq(self):
+        self._test_softirq(Pin.IRQ_FALLING, events_expected_falling)
+
+    def test_falling_hardirq(self):
+        self._test_hardirq(Pin.IRQ_FALLING, events_expected_falling)
+
+    def test_rising_falling_softirq(self):
+        self._test_softirq(Pin.IRQ_RISING | Pin.IRQ_FALLING, events_expected_rising_falling)
+
+    def test_rising_falling_hardirq(self):
+        self._test_hardirq(Pin.IRQ_RISING | Pin.IRQ_FALLING, events_expected_rising_falling)
 
 
 # Generate test classes, one for each set of pins to test.
-for pin_out, pin_in in pin_loopback_pins:
-    cls_name = "Test_{}_{}".format(pin_out, pin_in)
+for p0_name, p1_name in pin_loopback_pins:
+    cls_name = "Test_{}_{}".format(p0_name, p1_name)
     globals()[cls_name] = type(
-        cls_name, (TestBase, unittest.TestCase), {"pin_out": pin_out, "pin_in": pin_in}
+        cls_name, (TestBase, unittest.TestCase), {"p0_name": p0_name, "p1_name": p1_name}
     )
 
 if __name__ == "__main__":

--- a/tests/extmod_hardware/machine_pin_irq.py
+++ b/tests/extmod_hardware/machine_pin_irq.py
@@ -15,9 +15,9 @@ from target_wiring import pin_loopback_pins
 
 has_hardirq = sys.platform not in ("esp32",)
 
-events_expected_rising = ["a", "b", 1, "c", "d", 1, "e", "f", "g", "h", "i"]
-events_expected_falling = ["a", "b", "c", 0, "d", "e", 0, "f", "g", "h", "i"]
-events_expected_rising_falling = ["a", "b", 1, "c", 0, "d", 1, "e", 0, "f", "g", "h", "i"]
+events_expected_rising = b"ab1cd1efghi"
+events_expected_falling = b"abc0de0fghi"
+events_expected_rising_falling = b"ab1c0d1e0fghi"
 
 
 class TestBase:
@@ -26,11 +26,11 @@ class TestBase:
         print("set up pins:", cls.p0_name, cls.p1_name)
         cls.p0 = Pin(cls.p0_name)
         cls.p1 = Pin(cls.p1_name)
+        cls.events = bytearray(30)
 
     def setUp(self):
         self.p0.init(Pin.OUT)
         self.p1.init(Pin.IN)
-        self.events = [0] * 100
         self.num_events = 0
 
     def tearDown(self):
@@ -38,7 +38,7 @@ class TestBase:
         self.p1.init(Pin.IN)
 
     def add_event(self, data):
-        self.events[self.num_events] = data
+        self.events[self.num_events] = ord(data)
         self.num_events += 1
 
     def change_pin(self, value):
@@ -47,7 +47,7 @@ class TestBase:
 
     def irq_handler(self, p):
         if p is self.p1:
-            self.add_event(p())
+            self.add_event("1" if p() else "0")
         else:
             print("expecting", self.p1)
 

--- a/tests/extmod_hardware/machine_pwm.py
+++ b/tests/extmod_hardware/machine_pwm.py
@@ -100,7 +100,7 @@ def _test_freq(self, freq):
         if sys.platform == "esp32":
             # TODO why is this bit needed to get it working on esp32?
             self.pwm.init(freq=freq, duty_u16=duty_u16)
-            time.sleep(0.1)
+            time.sleep_ms(100)
         self.pwm.duty_u16(duty_u16)
         _test_freq_duty(self, self.pulse_in, self.pwm, freq, duty_u16)
 

--- a/tests/hwtest.py
+++ b/tests/hwtest.py
@@ -69,7 +69,7 @@ NATMOD_LIBS = ("btree", "deflate", "framebuf", "heapq", "random", "re")
 def build_natmods():
     for arch in NATMOD_ARCHS:
         for lib in NATMOD_LIBS:
-            subprocess.run(["make", "-C", f"../examples/natmod/{lib}", "-j", "-B", f"ARCH={arch}"])
+            subprocess.run(["make", "-C", f"../examples/natmod/{lib}", "-j8", "-B", f"ARCH={arch}"])
 
 
 def try_import(target, module):

--- a/tests/hwtest.py
+++ b/tests/hwtest.py
@@ -213,7 +213,7 @@ def main():
         )
         target.port, target.build, target.machine, target.version = sys_info
         target.can_import_mpy = t.eval("hasattr(sys.implementation, '_mpy')")
-        _, target.arch = str(t.exec(target_info_check), "ascii").strip().split()
+        _, target.arch, _ = str(t.exec(target_info_check), "ascii").strip().split()
         if target.arch == "None":
             target.arch = None
         target.has_vfs = try_import(t, "vfs")

--- a/tests/hwtest.py
+++ b/tests/hwtest.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 # MIT license; Copyright (c) 2024 Damien P. George
 
+import argparse
 import sys
 import glob
 import os
@@ -21,6 +22,9 @@ WLAN_PASS = os.getenv("WLAN_PASS")
 if not WLAN_SSID or not WLAN_PASS:
     print("WLAN_SSID and/or WLAN_PASS not provided")
 
+with open("feature_check/target_info.py", "rb") as f:
+    TARGET_INFO_CHECK = f.read()
+
 
 class Target:
     def __init__(self, device, serial_number):
@@ -30,7 +34,13 @@ class Target:
         self.port = None
         self.build = None
         self.machine = None
+        self.can_import_mpy = None
+        self.has_vfs = None
+        self.has_filesystem = None
+        self.has_unittest = None
+        self.has_wlan = None
         self.has_wlan_connected = False
+        self.has_ble = None
 
     def info(self):
         features = ""
@@ -42,6 +52,35 @@ class Target:
             features += " BLE"
         return f"{self.device} {self.port} {self.build} {self.arch}{features} {self.version}"
 
+    def detect_features(self):
+        t = SerialTransport(self.device)
+        t.enter_raw_repl()
+        t.exec("import sys")
+        sys_info = t.eval(
+            "(sys.platform, getattr(sys.implementation, '_build', 'UNKNOWN'), sys.implementation._machine, sys.version)"
+        )
+        self.port, self.build, self.machine, self.version = sys_info
+        self.can_import_mpy = t.eval("hasattr(sys.implementation, '_mpy')")
+        _, self.arch, _ = str(t.exec(TARGET_INFO_CHECK), "ascii").strip().split()
+        if self.arch == "None":
+            self.arch = None
+        self.has_vfs = try_import(t, "vfs")
+        self.has_filesystem = self.has_vfs and t.eval("len(vfs.mount())")
+        self.has_unittest = try_import(t, "unittest")
+        self.has_wlan = try_import(t, "network") and t.eval("hasattr(network, 'WLAN')")
+        self.has_ble = try_import(t, "bluetooth") and t.eval("hasattr(bluetooth, 'BLE')")
+        t.close()
+
+    def setup_wlan(self):
+        t = SerialTransport(self.device)
+        t.enter_raw_repl()
+        rtc_set(self, t)
+        if self.has_filesystem:
+            for file in glob.glob("net_inet/*.der") + glob.glob("multi_net/*.der"):
+                put_file(t, *file.rsplit("/", 1))
+        self.has_wlan_connected = wlan_connect(self, t)
+        t.close()
+
 
 def map_device_name(d):
     if d[0] == "a" and d[1:].isdigit():
@@ -51,29 +90,55 @@ def map_device_name(d):
     return d
 
 
-def list_ports(args):
-    ports = []
-    for p in sorted(serial.tools.list_ports.comports()):
-        if p.device.startswith("/dev/ttyS"):
-            # Skip invalid ttySx ports.
-            continue
-        if not args or p.device in args:
-            t = SerialTransport(p.device)
-            t.enter_raw_repl()
-            t.exec("import os")
-            is_octoprobe_infra = "OCTOPROBE" in t.eval("os.listdir()")
-            t.close()
-            if is_octoprobe_infra:
-                if not args:
-                    # If no devices specified, skip Octoprobe infrastructure.
-                    print(f"{p.device} Octoprobe infrastructure device, skipping")
-                    continue
-                print(f"{p.device} Octoprobe infrastructure device")
-            ports.append(Target(p.device, p.serial_number))
-    return ports
+def detect_octoprobe(device):
+    t = SerialTransport(device)
+    t.enter_raw_repl()
+    t.exec("import os")
+    is_octoprobe_infra = "OCTOPROBE" in t.eval("os.listdir()")
+    t.close()
+    return is_octoprobe_infra
 
 
-NATMOD_ARCHS = ("x86", "x64", "armv6m", "armv7m", "armv7emsp", "armv7emdp", "xtensa", "xtensawin", "rv32imc")
+def list_targets(args, exclude_devices):
+    targets = []
+    valid_serial_ports = sorted(serial.tools.list_ports.comports())
+    if args:
+        for device in args:
+            for p in valid_serial_ports:
+                if device == p.device:
+                    if detect_octoprobe(device):
+                        print(f"{device} Octoprobe infrastructure device")
+                    targets.append(Target(device, p.serial_number))
+                    break
+            else:
+                print(f"{device} not found")
+                sys.exit(1)
+    else:
+        for p in valid_serial_ports:
+            if p.device.startswith("/dev/ttyS"):
+                # Skip invalid ttySx ports.
+                continue
+            if p.device in exclude_devices:
+                continue
+            if detect_octoprobe(p.device):
+                # If no devices specified, skip Octoprobe infrastructure.
+                print(f"{p.device} Octoprobe infrastructure device, skipping")
+                continue
+            targets.append(Target(p.device, p.serial_number))
+    return targets
+
+
+NATMOD_ARCHS = (
+    "x86",
+    "x64",
+    "armv6m",
+    "armv7m",
+    "armv7emsp",
+    "armv7emdp",
+    "xtensa",
+    "xtensawin",
+    "rv32imc",
+)
 NATMOD_LIBS = ("btree", "deflate", "framebuf", "heapq", "random", "re")
 
 
@@ -82,7 +147,9 @@ def build_natmods(archs):
         archs = NATMOD_ARCHS
     for arch in archs:
         for lib in NATMOD_LIBS:
-            subprocess.run(["make", "-C", f"../examples/natmod/{lib}", "-j8", "-B", f"ARCH={arch}"])
+            subprocess.run(
+                ["make", "-C", f"../examples/natmod/{lib}", "-j8", "-B", f"ARCH={arch}"]
+            )
 
 
 def try_import(target, module):
@@ -170,9 +237,11 @@ def do_test(cmd):
         time.sleep(2)
 
 
-def run_multitests_on_one_target(targets, tests):
-    for target in targets:
-        do_test(["./run-multitests.py", "-i", f"pyb:{target.device}", "-p2"] + tests)
+def run_multitests_p2(instances, tests):
+    cmd = ["./run-multitests.py", "-p2"]
+    for instance in instances:
+        cmd.extend(["-i", f"pyb:{instance}"])
+    do_test(cmd + tests)
 
 
 def run_multitests_on_two_targets(targets, tests):
@@ -187,26 +256,41 @@ def run_multitests_on_two_targets(targets, tests):
         )
 
 
-def main():
-    args = sys.argv[1:]
+ALL_TEST_CODES = "vphmnwb"
 
-    if len(args) > 0 and args[0] == "build-natmod":
-        build_natmods(args[1:])
+
+def main():
+    cmd_parser = argparse.ArgumentParser(description="Run all tests on hardware targets")
+    cmd_parser.add_argument(
+        "--build-natmods", action="store_true", help="build all/selected natmods"
+    )
+    cmd_parser.add_argument("-s", "--tests", default=ALL_TEST_CODES, help="tests to run")
+    cmd_parser.add_argument(
+        "-r", "--reference", default=None, help="reference device for WLAN and BLE tests"
+    )
+    cmd_parser.add_argument("test_instances", nargs="*", help="target devices to test")
+    args = cmd_parser.parse_args()
+
+    if args.build_natmods:
+        build_natmods(args.test_instances)
         return
 
-    selected_tests = "vphmnwb"
-    if len(args) > 0:
-        # Select certain tests.
-        if (a := args.pop(0)) != "all":
-            selected_tests = a
+    selected_tests = args.tests
+    for test_code in selected_tests:
+        if test_code not in ALL_TEST_CODES:
+            print(f"{test_code} is not a valid test code")
+            sys.exit(1)
 
-    with open("feature_check/target_info.py", "rb") as f:
-        target_info_check = f.read()
+    ref_target = None
+    if args.reference:
+        ref_device = map_device_name(args.reference)
+        ref_target = Target(ref_device, "")
+        ref_target.detect_features()
 
     print("Selected tests:", selected_tests)
 
-    selected_devices = [map_device_name(d) for d in args]
-    targets = list_ports(selected_devices)
+    selected_devices = [map_device_name(d) for d in args.test_instances]
+    targets = list_targets(selected_devices, [ref_target.device] if ref_target else [])
 
     select_vcprate = "v" in selected_tests
     select_python = "p" in selected_tests
@@ -216,28 +300,18 @@ def main():
     select_wlan = "w" in selected_tests
     select_ble = "b" in selected_tests
 
-    targets_ble = []
     for target in targets:
-        t = SerialTransport(target.device)
-        t.enter_raw_repl()
-        t.exec("import sys")
-        sys_info = t.eval(
-            "(sys.platform, getattr(sys.implementation, '_build', 'UNKNOWN'), sys.implementation._machine, sys.version)"
-        )
-        target.port, target.build, target.machine, target.version = sys_info
-        target.can_import_mpy = t.eval("hasattr(sys.implementation, '_mpy')")
-        _, target.arch, _ = str(t.exec(target_info_check), "ascii").strip().split()
-        if target.arch == "None":
-            target.arch = None
-        target.has_vfs = try_import(t, "vfs")
-        target.has_filesystem = target.has_vfs and t.eval("len(vfs.mount())")
-        target.has_unittest = try_import(t, "unittest")
-        target.has_wlan = try_import(t, "network") and t.eval("hasattr(network, 'WLAN')")
-        target.has_ble = try_import(t, "bluetooth") and t.eval("hasattr(bluetooth, 'BLE')")
-        t.close()
+        target.detect_features()
 
     for target in targets:
         print(target.info())
+
+    if ref_target:
+        print("=" * 64)
+        print("REFERENCE")
+        print(ref_target.info())
+        if select_wlan and ref_target.has_wlan:
+            ref_target.setup_wlan()
 
     print("=" * 64)
     print("=" * 64)
@@ -287,7 +361,8 @@ def main():
             if select_via_mpy and target.can_import_mpy:
                 port_specific = []
                 if target.port == "esp8266":
-                    port_specific.extend(("-d", "basics", "extmod", "float"))
+                    # extreme_exc has a stack overflow and crashes the device
+                    port_specific.extend(("--exclude", "extreme_exc"))
                 do_test(run_tests_cmd + ["--via-mpy"] + port_specific)
 
             if select_native and target.arch is not None:
@@ -304,21 +379,21 @@ def main():
                         do_test(run_cmd + ["-d", "ports/stm32_hardware"])
 
             if select_wlan and target.has_wlan:
-                t = SerialTransport(target.device)
-                t.enter_raw_repl()
-                rtc_set(target, t)
-                if target.has_filesystem:
-                    for file in glob.glob("net_inet/*.der") + glob.glob("multi_net/*.der"):
-                        put_file(t, *file.rsplit("/", 1))
-                target.has_wlan_connected = wlan_connect(target, t)
-                t.close()
+                target.setup_wlan()
                 if target.has_wlan_connected:
                     do_test(run_tests_cmd + ["-d", "net_hosted", "net_inet"])
+                    run_multitests_p2([target.device], tests_multi_net)
+                    if ref_target and ref_target.has_wlan_connected:
+                        run_multitests_p2([target.device, ref_target.device], tests_multi_net)
+                        run_multitests_p2([target.device, ref_target.device], tests_multi_wlan)
+
+            if select_ble and target.has_ble:
+                if ref_target and ref_target.has_ble:
+                    run_multitests_p2([target.device, ref_target.device], tests_multi_bluetooth)
 
         targets_wlan = [t for t in targets if t.has_wlan_connected]
         if select_wlan and targets_wlan:
             print("=" * 64)
-            run_multitests_on_one_target(targets_wlan, tests_multi_net)
             run_multitests_on_two_targets(targets_wlan, tests_multi_net)
             run_multitests_on_two_targets(targets_wlan, tests_multi_wlan)
 

--- a/tests/hwtest.py
+++ b/tests/hwtest.py
@@ -62,7 +62,7 @@ def list_ports(args):
     return ports
 
 
-NATMOD_ARCHS = ("x86", "x64", "armv6", "armv6m", "armv7m", "armv7em", "armv7emsp", "armv7emdp", "xtensa", "xtensawin", "rv32imc")
+NATMOD_ARCHS = ("x86", "x64", "armv6m", "armv7m", "armv7emsp", "armv7emdp", "xtensa", "xtensawin", "rv32imc")
 NATMOD_LIBS = ("btree", "deflate", "framebuf", "heapq", "random", "re")
 
 

--- a/tests/hwtest.py
+++ b/tests/hwtest.py
@@ -1,0 +1,272 @@
+#!/usr/bin/env python3
+# MIT license; Copyright (c) 2024 Damien P. George
+
+import sys
+import glob
+import os
+import subprocess
+import serial.tools.list_ports
+import datetime
+import time
+import vcprate
+
+sys.path.append("../tools/mpremote")
+from mpremote.transport_serial import SerialTransport
+import mpremote.commands
+
+WLAN_SSID = os.getenv("WLAN_SSID")
+WLAN_PASS = os.getenv("WLAN_PASS")
+
+if not WLAN_SSID or not WLAN_PASS:
+    print("WLAN_SSID and/or WLAN_PASS not provided")
+
+
+class Target:
+    def __init__(self, device, serial_number):
+        self.device = device
+        self.device_suffix = device.split("/")[-1]
+        self.serial_number = serial_number
+        self.port = None
+        self.machine = None
+        self.has_wlan_connected = False
+
+    def info(self):
+        features = ""
+        if self.can_import_mpy:
+            features += " import-mpy"
+        if self.has_wlan:
+            features += " WLAN"
+        if self.has_ble:
+            features += " BLE"
+        return f"{self.device} {self.port} {self.arch}{features} {self.version}"
+
+
+def map_device_name(d):
+    if d[0] == "a" and d[1:].isdigit():
+        return "/dev/ttyACM" + d[1:]
+    if d[0] == "u" and d[1:].isdigit():
+        return "/dev/ttyUSB" + d[1:]
+    return d
+
+
+def list_ports(args):
+    ports = []
+    for p in sorted(serial.tools.list_ports.comports()):
+        if p.device.startswith("/dev/ttyS"):
+            # Skip invalid ttySx ports.
+            continue
+        if not args or p.device in args:
+            ports.append(Target(p.device, p.serial_number))
+    return ports
+
+
+NATMOD_LIBS = ("btree", "deflate", "framebuf", "heapq", "random", "re")
+
+
+def build_natmods():
+    for arch in ("armv6m", "armv7emsp", "armv7emdp", "xtensawin"):
+        for lib in NATMOD_LIBS:
+            subprocess.run(["make", "-C", f"examples/natmod/{lib}", "-B", f"ARCH={arch}"])
+
+
+def try_import(target, module):
+    return (
+        target.exec(f"try:\n import {module}\n print(True)\nexcept:\n print(False)").strip()
+        == b"True"
+    )
+
+
+def rtc_set(target, serial):
+    now = datetime.datetime.now()
+    time.sleep(1 - now.microsecond * 1e-6)
+    now = datetime.datetime.now()
+    print(target.device, "set time to", now)
+    timetuple = "({}, {}, {}, {}, {}, {}, {}, {})".format(
+        now.year,
+        now.month,
+        now.day,
+        now.weekday(),
+        now.hour,
+        now.minute,
+        now.second,
+        now.microsecond,
+    )
+    serial.exec("import machine;machine.RTC().datetime({})".format(timetuple))
+
+
+def put_file(target_serial, path, file):
+    class state:
+        transport = target_serial
+
+    mpremote.commands.do_filesystem_cp(state, os.path.join(path, file), ":" + file, False, True)
+
+
+def wlan_connect(target, target_serial):
+    print(f"{target.device} connecting to {WLAN_SSID}... ", end="")
+    sys.stdout.flush()
+    out = target_serial.exec(f"""
+import sys, machine, network, time
+wl = network.WLAN()
+wl.active(1)
+if not wl.isconnected():
+    wl.connect('{WLAN_SSID}', '{WLAN_PASS}')
+    t0 = time.ticks_ms()
+    print('connect')
+    while not wl.isconnected() and time.ticks_diff(time.ticks_ms(), t0) < 10_000:
+        machine.idle()
+""")
+    isconnected, ifconfig = target_serial.eval("(wl.isconnected(), wl.ifconfig())")
+    if isconnected:
+        print(ifconfig[0])
+    else:
+        print("FAIL")
+    return isconnected
+
+
+def do_test(cmd):
+    print("-" * 32)
+    print("RUN", " ".join(cmd))
+    try:
+        subprocess.run(cmd, check=True)
+        print("PASS")
+    except subprocess.CalledProcessError as er:
+        print("ERROR", er)
+        time.sleep(1)
+    except KeyboardInterrupt:
+        print("INTERRUPT")
+        time.sleep(1)
+
+
+def run_multitests_on_one_target(targets, tests):
+    for target in targets:
+        do_test(["./run-multitests.py", "-i", f"pyb:{target.device}", "-p2"] + tests)
+
+
+def run_multitests_on_two_targets(targets, tests):
+    if len(targets) == 1:
+        return
+    for i in range(len(targets)):
+        target0 = targets[i]
+        target1 = targets[(i + 1) % len(targets)]
+        do_test(
+            ["./run-multitests.py", "-i", f"pyb:{target0.device}", "-i", f"pyb:{target1.device}"]
+            + tests
+        )
+
+
+def main():
+    # build_natmods()
+
+    with open("feature_check/target_info.py", "rb") as f:
+        target_info_check = f.read()
+
+    selected_devices = [map_device_name(d) for d in sys.argv[1:]]
+    targets = list_ports(selected_devices)
+
+    select_vcprate = True
+    select_python = True
+    select_hardware = True
+    select_via_mpy = True
+    select_via_mpy_native = True
+    select_wlan = True
+    select_ble = True
+
+    targets_ble = []
+    for target in targets:
+        t = SerialTransport(target.device)
+        t.enter_raw_repl()
+        t.exec("import sys")
+        sys_info = t.eval("(sys.platform, sys.implementation._machine, sys.version)")
+        target.port, target.machine, target.version = sys_info
+        target.can_import_mpy = t.eval("hasattr(sys.implementation, '_mpy')")
+        _, target.arch = str(t.exec(target_info_check), "ascii").strip().split()
+        if target.arch == "None":
+            target.arch = None
+        target.has_vfs = try_import(t, "vfs")
+        target.has_wlan = try_import(t, "network") and t.eval("hasattr(network, 'WLAN')")
+        target.has_ble = try_import(t, "bluetooth") and t.eval("hasattr(bluetooth, 'BLE')")
+        t.close()
+
+    for target in targets:
+        print(target.info())
+
+    print("=" * 64)
+    print("=" * 64)
+
+    tests_natmod = [
+        file for file in glob.iglob("extmod/*.py") if file.split("/")[1].startswith(NATMOD_LIBS)
+    ]
+    tests_multi_net = [file for file in glob.iglob("multi_net/*.py")]
+    tests_multi_bluetooth = [
+        file for file in glob.iglob("multi_bluetooth/*.py") if "/ble_" in file
+    ]
+
+    if True:
+        for target in targets:
+            print("=" * 64)
+            print(target.info())
+            print(target.machine)
+            print(target.version)
+            run_tests_cmd = [
+                "./run-tests.py",
+                "--test-instance",
+                target.device,
+                "--result-dir",
+                f"results_{target.device_suffix}",
+            ]
+            do_test(run_tests_cmd + ["--clean-failures"])
+
+            if select_vcprate:
+                try:
+                    vcprate.do_test(target.device)
+                except KeyboardInterrupt:
+                    print("INTERRUPT")
+                    time.sleep(1)
+
+            if select_python:
+                do_test(run_tests_cmd)
+
+            if select_hardware:
+                do_test(run_tests_cmd + ["-d", "extmod_hardware"])
+                if target.port == "pyboard":
+                    do_test(run_tests_cmd + ["-d", "ports/stm32_hardware"])
+
+            if select_via_mpy and target.can_import_mpy:
+                port_specific = []
+                if target.port == "esp8266":
+                    port_specific.extend(("-d", "basics", "extmod", "float"))
+                do_test(run_tests_cmd + ["--via-mpy"] + port_specific)
+
+            if select_via_mpy_native and target.arch is not None:
+                do_test(run_tests_cmd + ["--via-mpy", "--emit", "native"])
+                do_test(
+                    ["./run-natmodtests.py", "-p", "-d", target.device]
+                    + tests_natmod
+                )
+
+            if select_wlan and target.has_wlan:
+                t = SerialTransport(target.device)
+                t.enter_raw_repl()
+                rtc_set(target, t)
+                if target.has_vfs:
+                    for file in glob.glob("net_inet/*.der") + glob.glob("multi_net/*.der"):
+                        put_file(t, *file.rsplit("/", 1))
+                target.has_wlan_connected = wlan_connect(target, t)
+                t.close()
+                if target.has_wlan_connected:
+                    do_test(run_tests_cmd + ["-d", "net_hosted", "net_inet"])
+
+    targets_wlan = [t for t in targets if t.has_wlan_connected]
+    if select_wlan and targets_wlan:
+        print("=" * 64)
+        run_multitests_on_one_target(targets_wlan, tests_multi_net)
+        run_multitests_on_two_targets(targets_wlan, tests_multi_net)
+
+    targets_ble = [t for t in targets if t.has_ble]
+    if select_ble and targets_ble:
+        print("=" * 64)
+        run_multitests_on_two_targets(targets_ble, tests_multi_bluetooth)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/hwtest.py
+++ b/tests/hwtest.py
@@ -77,8 +77,10 @@ NATMOD_ARCHS = ("x86", "x64", "armv6m", "armv7m", "armv7emsp", "armv7emdp", "xte
 NATMOD_LIBS = ("btree", "deflate", "framebuf", "heapq", "random", "re")
 
 
-def build_natmods():
-    for arch in NATMOD_ARCHS:
+def build_natmods(archs):
+    if not archs:
+        archs = NATMOD_ARCHS
+    for arch in archs:
         for lib in NATMOD_LIBS:
             subprocess.run(["make", "-C", f"../examples/natmod/{lib}", "-j8", "-B", f"ARCH={arch}"])
 
@@ -189,7 +191,7 @@ def main():
     args = sys.argv[1:]
 
     if len(args) > 0 and args[0] == "build-natmod":
-        build_natmods()
+        build_natmods(args[1:])
         return
 
     selected_tests = "vphmnwb"

--- a/tests/hwtest.py
+++ b/tests/hwtest.py
@@ -146,10 +146,11 @@ def do_test(cmd):
     print("-" * 32)
     print("RUN", " ".join(cmd))
     try:
-        subprocess.run(cmd, check=True)
-        print("PASS")
-    except subprocess.CalledProcessError as er:
-        print("ERROR", er)
+        result = subprocess.run(cmd)
+        if result.returncode == 0:
+            print("PASS")
+        else:
+            print(f"ERROR returncode={result.returncode}")
         time.sleep(1)
     except KeyboardInterrupt:
         print("INTERRUPT")

--- a/tests/hwtest.py
+++ b/tests/hwtest.py
@@ -61,7 +61,7 @@ class Target:
         )
         self.port, self.build, self.machine, self.version = sys_info
         self.can_import_mpy = t.eval("hasattr(sys.implementation, '_mpy')")
-        _, self.arch, _ = str(t.exec(TARGET_INFO_CHECK), "ascii").strip().split()
+        _, self.arch, *_ = str(t.exec(TARGET_INFO_CHECK), "ascii").strip().split()
         if self.arch == "None":
             self.arch = None
         self.has_vfs = try_import(t, "vfs")

--- a/tests/hwtest.py
+++ b/tests/hwtest.py
@@ -61,13 +61,14 @@ def list_ports(args):
     return ports
 
 
+NATMOD_ARCHS = ("x86", "x64", "armv6", "armv6m", "armv7m", "armv7em", "armv7emsp", "armv7emdp", "xtensa", "xtensawin", "rv32imc")
 NATMOD_LIBS = ("btree", "deflate", "framebuf", "heapq", "random", "re")
 
 
 def build_natmods():
-    for arch in ("armv6m", "armv7emsp", "armv7emdp", "xtensawin"):
+    for arch in NATMOD_ARCHS:
         for lib in NATMOD_LIBS:
-            subprocess.run(["make", "-C", f"examples/natmod/{lib}", "-B", f"ARCH={arch}"])
+            subprocess.run(["make", "-C", f"../examples/natmod/{lib}", "-j", "-B", f"ARCH={arch}"])
 
 
 def try_import(target, module):
@@ -172,7 +173,9 @@ def run_multitests_on_two_targets(targets, tests):
 
 
 def main():
-    # build_natmods()
+    if len(sys.argv) > 1 and sys.argv[1] == "build-natmod":
+        build_natmods()
+        return
 
     with open("feature_check/target_info.py", "rb") as f:
         target_info_check = f.read()

--- a/tests/hwtest.py
+++ b/tests/hwtest.py
@@ -277,7 +277,12 @@ def main():
                 do_test(run_tests_cmd + ["--via-mpy"] + port_specific)
 
             if select_native and target.arch is not None:
-                do_test(run_tests_cmd + ["--via-mpy", "--emit", "native"])
+                run_native = ["--via-mpy", "--emit", "native"]
+                do_test(run_tests_cmd + run_native)
+                if select_hardware:
+                    do_test(run_tests_cmd + run_native + ["-d", "extmod_hardware"])
+                    if target.port == "pyboard":
+                        do_test(run_tests_cmd + run_native + ["-d", "ports/stm32_hardware"])
                 do_test(["./run-natmodtests.py", "-p", "-d", target.device] + tests_natmod)
 
             if select_wlan and target.has_wlan:

--- a/tests/hwtest.py
+++ b/tests/hwtest.py
@@ -181,12 +181,11 @@ def main():
         build_natmods()
         return
 
-    if len(args) > 0 and args[0] == "-s":
+    selected_tests = "vphmnwb"
+    if len(args) > 0:
         # Select certain tests.
-        args.pop(0)
-        selected_tests = args.pop(0)
-    else:
-        selected_tests = "vphmnwb"
+        if (a := args.pop(0)) != "all":
+            selected_tests = a
 
     with open("feature_check/target_info.py", "rb") as f:
         target_info_check = f.read()

--- a/tests/hwtest.py
+++ b/tests/hwtest.py
@@ -233,11 +233,12 @@ def main():
         file for file in glob.iglob("extmod/*.py") if file.split("/")[1].startswith(NATMOD_LIBS)
     ]
     tests_multi_net = [file for file in glob.iglob("multi_net/*.py")]
+    tests_multi_wlan = [file for file in glob.iglob("multi_wlan/*.py")]
     tests_multi_bluetooth = [
         file for file in glob.iglob("multi_bluetooth/*.py") if "/ble_" in file
     ]
 
-    if True:
+    try:
         for target in targets:
             print("=" * 64)
             print(target.info())
@@ -301,16 +302,20 @@ def main():
                 if target.has_wlan_connected:
                     do_test(run_tests_cmd + ["-d", "net_hosted", "net_inet"])
 
-    targets_wlan = [t for t in targets if t.has_wlan_connected]
-    if select_wlan and targets_wlan:
-        print("=" * 64)
-        run_multitests_on_one_target(targets_wlan, tests_multi_net)
-        run_multitests_on_two_targets(targets_wlan, tests_multi_net)
+        targets_wlan = [t for t in targets if t.has_wlan_connected]
+        if select_wlan and targets_wlan:
+            print("=" * 64)
+            run_multitests_on_one_target(targets_wlan, tests_multi_net)
+            run_multitests_on_two_targets(targets_wlan, tests_multi_net)
+            run_multitests_on_two_targets(targets_wlan, tests_multi_wlan)
 
-    targets_ble = [t for t in targets if t.has_ble]
-    if select_ble and targets_ble:
-        print("=" * 64)
-        run_multitests_on_two_targets(targets_ble, tests_multi_bluetooth)
+        targets_ble = [t for t in targets if t.has_ble]
+        if select_ble and targets_ble:
+            print("=" * 64)
+            run_multitests_on_two_targets(targets_ble, tests_multi_bluetooth)
+
+    except KeyboardInterrupt:
+        print("INTERRUPT")
 
 
 if __name__ == "__main__":

--- a/tests/hwtest.py
+++ b/tests/hwtest.py
@@ -58,6 +58,17 @@ def list_ports(args):
             # Skip invalid ttySx ports.
             continue
         if not args or p.device in args:
+            t = SerialTransport(p.device)
+            t.enter_raw_repl()
+            t.exec("import os")
+            is_octoprobe_infra = "OCTOPROBE" in t.eval("os.listdir()")
+            t.close()
+            if is_octoprobe_infra:
+                if not args:
+                    # If no devices specified, skip Octoprobe infrastructure.
+                    print(f"{p.device} Octoprobe infrastructure device, skipping")
+                    continue
+                print(f"{p.device} Octoprobe infrastructure device")
             ports.append(Target(p.device, p.serial_number))
     return ports
 

--- a/tests/hwtest.py
+++ b/tests/hwtest.py
@@ -151,10 +151,10 @@ def do_test(cmd):
             print("PASS")
         else:
             print(f"ERROR returncode={result.returncode}")
-        time.sleep(1)
+        time.sleep(2)
     except KeyboardInterrupt:
         print("INTERRUPT")
-        time.sleep(1)
+        time.sleep(2)
 
 
 def run_multitests_on_one_target(targets, tests):
@@ -265,7 +265,7 @@ def main():
                     vcprate.do_test(target.device)
                 except KeyboardInterrupt:
                     print("INTERRUPT")
-                    time.sleep(1)
+                    time.sleep(2)
 
             if select_python:
                 do_test(run_tests_cmd)
@@ -283,7 +283,7 @@ def main():
             if select_hardware:
                 run_cmds = [run_tests_cmd]
                 if select_native and target.arch is not None:
-                    run_cmds += run_tests_native_cmd
+                    run_cmds.append(run_tests_native_cmd)
                 for run_cmd in run_cmds:
                     do_test(run_cmd + ["-d", "extmod_hardware"])
                     if target.port == "pyboard":

--- a/tests/hwtest.py
+++ b/tests/hwtest.py
@@ -240,7 +240,7 @@ def do_test(cmd):
 def run_multitests_p2(instances, tests):
     cmd = ["./run-multitests.py", "-p2"]
     for instance in instances:
-        cmd.extend(["-i", f"pyb:{instance}"])
+        cmd.extend(["--test-instance", f"{instance}"])
     do_test(cmd + tests)
 
 
@@ -251,7 +251,7 @@ def run_multitests_on_two_targets(targets, tests):
         target0 = targets[i]
         target1 = targets[(i + 1) % len(targets)]
         do_test(
-            ["./run-multitests.py", "-i", f"pyb:{target0.device}", "-i", f"pyb:{target1.device}"]
+            ["./run-multitests.py", "--test-instance", f"{target0.device}", "--test-instance", f"{target1.device}"]
             + tests
         )
 
@@ -367,7 +367,7 @@ def main():
 
             if select_native and target.arch is not None:
                 do_test(run_tests_native_cmd)
-                do_test(["./run-natmodtests.py", "-p", "-d", target.device] + tests_natmod)
+                do_test(["./run-natmodtests.py", "--test-instance", target.device] + tests_natmod)
 
             if select_hardware:
                 run_cmds = [run_tests_cmd]

--- a/tests/hwtest.py
+++ b/tests/hwtest.py
@@ -9,7 +9,7 @@ import subprocess
 import serial.tools.list_ports
 import datetime
 import time
-import vcprate
+import serial_test
 
 sys.path.append("../tools/mpremote")
 from mpremote.transport_serial import SerialTransport
@@ -256,7 +256,7 @@ def run_multitests_on_two_targets(targets, tests):
         )
 
 
-ALL_TEST_CODES = "vphmnwb"
+ALL_TEST_CODES = "sphmnwb"
 
 
 def main():
@@ -292,7 +292,7 @@ def main():
     selected_devices = [map_device_name(d) for d in args.test_instances]
     targets = list_targets(selected_devices, [ref_target.device] if ref_target else [])
 
-    select_vcprate = "v" in selected_tests
+    select_serial = "s" in selected_tests
     select_python = "p" in selected_tests
     select_hardware = "h" in selected_tests
     select_via_mpy = "m" in selected_tests
@@ -348,9 +348,11 @@ def main():
 
             do_test(run_tests_cmd + ["--clean-failures"])
 
-            if select_vcprate:
+            if select_serial:
                 try:
-                    vcprate.do_test(target.device)
+                    serial_test.do_test(target.device)
+                except serial_test.TestError:
+                    pass
                 except KeyboardInterrupt:
                     print("INTERRUPT")
                     time.sleep(2)

--- a/tests/hwtest.py
+++ b/tests/hwtest.py
@@ -251,7 +251,13 @@ def run_multitests_on_two_targets(targets, tests):
         target0 = targets[i]
         target1 = targets[(i + 1) % len(targets)]
         do_test(
-            ["./run-multitests.py", "--test-instance", f"{target0.device}", "--test-instance", f"{target1.device}"]
+            [
+                "./run-multitests.py",
+                "--test-instance",
+                f"{target0.device}",
+                "--test-instance",
+                f"{target1.device}",
+            ]
             + tests
         )
 
@@ -322,7 +328,12 @@ def main():
     tests_multi_net = [file for file in glob.iglob("multi_net/*.py")]
     tests_multi_wlan = [file for file in glob.iglob("multi_wlan/*.py")]
     tests_multi_bluetooth = [
-        file for file in glob.iglob("multi_bluetooth/*.py") if "/ble_" in file
+        file for file in glob.iglob("multi_bluetooth/*.py") if "/stress_" not in file
+    ]
+    tests_multi_net_no_tls = [
+        file
+        for file in tests_multi_net
+        if file.startswith(("multi_net/asyncio_tcp_", "multi_net/tcp_", "multi_net/udp_"))
     ]
 
     try:
@@ -384,10 +395,13 @@ def main():
             if select_wlan and target.has_wlan:
                 target.setup_wlan()
                 if target.has_wlan_connected:
+                    tests_net = tests_multi_net
+                    if target.port == "esp8266":
+                        tests_net = tests_multi_net_no_tls
                     do_test(run_tests_cmd + ["-d", "net_hosted", "net_inet"])
-                    run_multitests_p2([target.device], tests_multi_net)
+                    run_multitests_p2([target.device], tests_net)
                     if ref_target and ref_target.has_wlan_connected:
-                        run_multitests_p2([target.device, ref_target.device], tests_multi_net)
+                        run_multitests_p2([target.device, ref_target.device], tests_net)
                         run_multitests_p2([target.device, ref_target.device], tests_multi_wlan)
 
             if select_ble and target.has_ble:

--- a/tests/hwtest.py
+++ b/tests/hwtest.py
@@ -207,7 +207,8 @@ def wlan_connect(target, target_serial):
 import sys, machine, network, time
 wl = network.WLAN()
 wl.active(1)
-if not wl.isconnected():
+if not wl.isconnected() or wl.config('essid') != '{WLAN_SSID}':
+    wl.disconnect()
     wl.connect('{WLAN_SSID}', '{WLAN_PASS}')
     t0 = time.ticks_ms()
     print('connect')
@@ -222,9 +223,22 @@ if not wl.isconnected():
     return isconnected
 
 
-def do_test(cmd):
-    print("-" * 32)
+def do_test(test_group_name, cmd, targets=None):
+    # Add test instance(s) and result dir arguments.
+    if targets:
+        cmd_extra = []
+        result_dir = f"results_{test_group_name}"
+        for target in targets:
+            cmd_extra.extend(["-t", f"{target.device}"])
+            result_dir += f"_{target.device_suffix}"
+        cmd_extra.extend(["--result-dir", result_dir])
+        cmd = cmd[0:1] + cmd_extra + cmd[1:]
+
+    # Print command that will be run.
+    print("-" * 16, test_group_name, "-" * 16)
     print("RUN", " ".join(cmd))
+
+    # Run test.
     try:
         result = subprocess.run(cmd)
         if result.returncode == 0:
@@ -237,32 +251,34 @@ def do_test(cmd):
         time.sleep(2)
 
 
-def run_multitests_p2(instances, tests):
+def run_multitests_p2(targets, tests):
+    test_group_name = tests[0].split("/", 1)[0]
     cmd = ["./run-multitests.py", "-p2"]
-    for instance in instances:
-        cmd.extend(["--test-instance", f"{instance}"])
-    do_test(cmd + tests)
+    do_test(test_group_name, cmd + tests, targets)
 
 
 def run_multitests_on_two_targets(targets, tests):
     if len(targets) == 1:
         return
+    test_group_name = tests[0].split("/", 1)[0]
+    cmd = ["./run-multitests.py"]
     for i in range(len(targets)):
         target0 = targets[i]
         target1 = targets[(i + 1) % len(targets)]
-        do_test(
-            [
-                "./run-multitests.py",
-                "--test-instance",
-                f"{target0.device}",
-                "--test-instance",
-                f"{target1.device}",
-            ]
-            + tests
-        )
+        do_test(test_group_name, cmd + tests, [target0, target1])
 
 
-ALL_TEST_CODES = "sphmnwb"
+ALL_TEST_CODES = "syhmnwb"
+
+TEST_CODE_NAME = {
+    "s": "serial",
+    "y": "bytecode",
+    "h": "hardware",
+    "m": "via-mpy",
+    "n": "native",
+    "w": "wlan",
+    "b": "ble",
+}
 
 
 def main():
@@ -270,7 +286,7 @@ def main():
     cmd_parser.add_argument(
         "--build-natmods", action="store_true", help="build all/selected natmods"
     )
-    cmd_parser.add_argument("-s", "--tests", default=ALL_TEST_CODES, help="tests to run")
+    cmd_parser.add_argument("-s", "--tests", default=ALL_TEST_CODES, help="tests to run: " + ALL_TEST_CODES)
     cmd_parser.add_argument(
         "-r", "--reference", default=None, help="reference device for WLAN and BLE tests"
     )
@@ -287,24 +303,34 @@ def main():
             print(f"{test_code} is not a valid test code")
             sys.exit(1)
 
-    ref_target = None
-    if args.reference:
-        ref_device = map_device_name(args.reference)
-        ref_target = Target(ref_device, "")
-        ref_target.detect_features()
-
-    print("Selected tests:", selected_tests)
-
-    selected_devices = [map_device_name(d) for d in args.test_instances]
-    targets = list_targets(selected_devices, [ref_target.device] if ref_target else [])
-
     select_serial = "s" in selected_tests
-    select_python = "p" in selected_tests
+    select_bytecode = "y" in selected_tests
     select_hardware = "h" in selected_tests
     select_via_mpy = "m" in selected_tests
     select_native = "n" in selected_tests
     select_wlan = "w" in selected_tests
     select_ble = "b" in selected_tests
+
+    print("Selected tests:", ", ".join(TEST_CODE_NAME[t] for t in selected_tests))
+
+    ref_target = None
+    if args.reference:
+        ref_device = map_device_name(args.reference)
+        ref_target = Target(ref_device, "")
+        ref_target.detect_features()
+        print()
+        print("=" * 64)
+        print("REFERENCE")
+        print(ref_target.info())
+        if select_wlan and ref_target.has_wlan:
+            ref_target.setup_wlan()
+
+    print()
+    print("=" * 64)
+    print("TARGETS TO BE TESTED")
+
+    selected_devices = [map_device_name(d) for d in args.test_instances]
+    targets = list_targets(selected_devices, [ref_target.device] if ref_target else [])
 
     for target in targets:
         target.detect_features()
@@ -312,15 +338,7 @@ def main():
     for target in targets:
         print(target.info())
 
-    if ref_target:
-        print("=" * 64)
-        print("REFERENCE")
-        print(ref_target.info())
-        if select_wlan and ref_target.has_wlan:
-            ref_target.setup_wlan()
-
-    print("=" * 64)
-    print("=" * 64)
+    print()
 
     tests_natmod = [
         file for file in glob.iglob("extmod/*.py") if file.split("/")[1].startswith(NATMOD_LIBS)
@@ -336,9 +354,16 @@ def main():
         if file.startswith(("multi_net/asyncio_tcp_", "multi_net/tcp_", "multi_net/udp_"))
     ]
 
+    # Remove existing results for all given targets.
+    for target in targets:
+        for result_dir in glob.iglob(f"results_*{target.device_suffix}*"):
+            for f in glob.iglob(os.path.join(result_dir, "*")):
+                os.remove(f)
+
     try:
         for target in targets:
             print("=" * 64)
+            print("TEST")
             print(target.info())
             print(target.machine, "--", target.version)
 
@@ -348,18 +373,12 @@ def main():
                 mip_install(target, t, "unittest")
                 t.close()
 
-            run_tests_cmd = [
-                "./run-tests.py",
-                "--test-instance",
-                target.device,
-                "--result-dir",
-                f"results_{target.device_suffix}",
-            ]
+            run_tests_cmd = ["./run-tests.py"]
             run_tests_native_cmd = run_tests_cmd + ["--via-mpy", "--emit", "native"]
-
-            do_test(run_tests_cmd + ["--clean-failures"])
+            run_tests_target = [target]
 
             if select_serial:
+                print("-" * 16, "serial", "-" * 16)
                 serial_test.test_passed = True
                 try:
                     serial_test.do_test(target.device)
@@ -369,28 +388,28 @@ def main():
                     print("INTERRUPT")
                     time.sleep(2)
 
-            if select_python:
-                do_test(run_tests_cmd)
+            if select_bytecode:
+                do_test("bytecode", run_tests_cmd, run_tests_target)
 
             if select_via_mpy and target.can_import_mpy:
                 port_specific = []
                 if target.port == "esp8266":
                     # extreme_exc has a stack overflow and crashes the device
                     port_specific.extend(("--exclude", "extreme_exc"))
-                do_test(run_tests_cmd + ["--via-mpy"] + port_specific)
+                do_test("mpy", run_tests_cmd + ["--via-mpy"] + port_specific, run_tests_target)
 
             if select_native and target.arch is not None:
-                do_test(run_tests_native_cmd)
-                do_test(["./run-natmodtests.py", "--test-instance", target.device] + tests_natmod)
+                do_test("native", run_tests_native_cmd, run_tests_target)
+                do_test("natmod", ["./run-natmodtests.py"] + tests_natmod, run_tests_target)
 
             if select_hardware:
-                run_cmds = [run_tests_cmd]
+                run_cmds = [("", run_tests_cmd)]
                 if select_native and target.arch is not None:
-                    run_cmds.append(run_tests_native_cmd)
-                for run_cmd in run_cmds:
-                    do_test(run_cmd + ["-d", "extmod_hardware"])
+                    run_cmds.append(("_native", run_tests_native_cmd))
+                for run_name, run_cmd in run_cmds:
+                    do_test("extmod_hardware" + run_name, run_cmd + ["-d", "extmod_hardware"], run_tests_target)
                     if target.port == "pyboard":
-                        do_test(run_cmd + ["-d", "ports/stm32_hardware"])
+                        do_test("stm32_hardware" + run_name, run_cmd + ["-d", "ports/stm32_hardware"], run_tests_target)
 
             if select_wlan and target.has_wlan:
                 target.setup_wlan()
@@ -398,15 +417,15 @@ def main():
                     tests_net = tests_multi_net
                     if target.port == "esp8266":
                         tests_net = tests_multi_net_no_tls
-                    do_test(run_tests_cmd + ["-d", "net_hosted", "net_inet"])
-                    run_multitests_p2([target.device], tests_net)
+                    do_test("net", run_tests_cmd + ["-d", "net_hosted", "net_inet"], run_tests_target)
+                    run_multitests_p2([target], tests_net)
                     if ref_target and ref_target.has_wlan_connected:
-                        run_multitests_p2([target.device, ref_target.device], tests_net)
-                        run_multitests_p2([target.device, ref_target.device], tests_multi_wlan)
+                        run_multitests_p2([target, ref_target], tests_net)
+                        run_multitests_p2([target, ref_target], tests_multi_wlan)
 
             if select_ble and target.has_ble:
                 if ref_target and ref_target.has_ble:
-                    run_multitests_p2([target.device, ref_target.device], tests_multi_bluetooth)
+                    run_multitests_p2([target, ref_target], tests_multi_bluetooth)
 
         targets_wlan = [t for t in targets if t.has_wlan_connected]
         if select_wlan and targets_wlan:

--- a/tests/hwtest.py
+++ b/tests/hwtest.py
@@ -349,6 +349,7 @@ def main():
             do_test(run_tests_cmd + ["--clean-failures"])
 
             if select_serial:
+                serial_test.test_passed = True
                 try:
                     serial_test.do_test(target.device)
                 except serial_test.TestError:

--- a/tests/micropython/extreme_exc.py
+++ b/tests/micropython/extreme_exc.py
@@ -20,6 +20,12 @@ except RuntimeError:
     print("SKIP")
     raise SystemExit
 
+# ESP32 boards with PSRAM can't run this test, too difficult to use up all heap.
+import sys, gc
+if sys.platform == "esp32" and gc.mem_free() > 1024 * 1024:
+    print("SKIP")
+    raise SystemExit
+
 # some ports need to allocate heap for the emergency exception
 try:
     micropython.alloc_emergency_exception_buf(256)

--- a/tests/micropython/schedule_sleep.py
+++ b/tests/micropython/schedule_sleep.py
@@ -12,6 +12,10 @@ except (ImportError, AttributeError):
     print("SKIP")
     raise SystemExit
 
+import sys
+if sys.platform in ("nrf", "samd"):
+    print("this port needs a better mp_hal_delay_ms")
+    FAIL
 
 # Basic test of scheduling a function.
 

--- a/tests/multi_extmod/machine_i2c_target_irq.py
+++ b/tests/multi_extmod/machine_i2c_target_irq.py
@@ -27,8 +27,14 @@ elif sys.platform == "mimxrt":
     i2c_kwargs = {}
     clock_stretch_us = 50  # mimxrt cannot delay too long in the IRQ handler
 elif sys.platform == "rp2":
-    i2c_args = (0,)
-    i2c_kwargs = {"scl": 9, "sda": 8}
+    import os
+
+    if "OCTOPROBE" in os.listdir():
+        i2c_args = (1,)
+        i2c_kwargs = {"scl": 11, "sda": 10}
+    else:
+        i2c_args = (1,)
+        i2c_kwargs = {"scl": 7, "sda": 6}
 elif sys.platform == "pyboard":
     i2c_args = ("Y",)
     i2c_kwargs = {}

--- a/tests/multi_extmod/machine_i2c_target_memory.py
+++ b/tests/multi_extmod/machine_i2c_target_memory.py
@@ -17,14 +17,20 @@ if sys.platform == "alif":
     i2c_args = (1,)  # pins P3_7/P3_6
     i2c_kwargs = {}
 elif sys.platform == "esp32":
-    i2c_args = (1,)  # on pins 9/8
-    i2c_kwargs = {}
+    i2c_args = (0,)  # on pins 9/8
+    i2c_kwargs = {"scl": 9, "sda": 8}
 elif sys.platform == "mimxrt":
     i2c_args = (0,)  # pins 19/18 on Teensy 4.x
     i2c_kwargs = {}
 elif sys.platform == "rp2":
-    i2c_args = (0,)
-    i2c_kwargs = {"scl": 9, "sda": 8}
+    import os
+
+    if "OCTOPROBE" in os.listdir():
+        i2c_args = (1,)
+        i2c_kwargs = {"scl": 11, "sda": 10}
+    else:
+        i2c_args = (1,)
+        i2c_kwargs = {"scl": 7, "sda": 6}
 elif sys.platform == "pyboard":
     i2c_args = ("Y",)
     i2c_kwargs = {}

--- a/tests/multi_wlan/01_ap_sta.py
+++ b/tests/multi_wlan/01_ap_sta.py
@@ -64,9 +64,9 @@ def instance0():
         raise RuntimeError("Timed out waiting for station, status ", ap.status())
 
     print("AP got station")
-    time.sleep(
-        3
-    )  # depending on port, may still need to negotiate DHCP lease for STA to see connection
+
+    # depending on port, may still need to negotiate DHCP lease for STA to see connection
+    multitest.wait("STA waiting disconnect")
 
     print("AP disabling...")
     ap.active(False)
@@ -99,6 +99,8 @@ def instance1():
     print("channel", sta.config("channel"))
 
     print("STA waiting for disconnect...")
+
+    multitest.broadcast("STA waiting disconnect")
 
     # Expect the AP to disconnect us immediately
     if not wait_for(lambda: not sta.isconnected()):

--- a/tests/multi_wlan/getaddrinfo.py
+++ b/tests/multi_wlan/getaddrinfo.py
@@ -12,6 +12,8 @@ except (ImportError, NameError):
 
 import socket
 
+print("SKIP")
+raise SystemExit
 
 def instance0():
     WLAN(WLAN.IF_AP).active(0)

--- a/tests/ports/renesas-ra/spi.py
+++ b/tests/ports/renesas-ra/spi.py
@@ -20,7 +20,7 @@ for bus in spis:
     except ValueError:
         print("ValueError", bus)
 
-spi = SPI(0)
+spi = SPI(0, baudrate=500000, polarity=0, phase=0, bits=8)
 print(spi)
 
 spi = SPI(0)

--- a/tests/ports/renesas-ra/uart1.py
+++ b/tests/ports/renesas-ra/uart1.py
@@ -3,8 +3,10 @@ from machine import UART
 
 machine = os.uname().machine
 if "EK-RA6M2" in machine:
-    # 0, 7, 9
-    uart_ids = (0, 7, 9)
+    # 7, 9
+    # skip 0 because that's the UART REPL
+    # TODO really should work out why the REPL breaks when just constructing UART(0)
+    uart_ids = (7, 9)
     try_id = 7
     try_s = "UART(7, baudrate=115200, bits=8, parity=None, stop=1, tx=P401, rx=P402, flow=0, rxbuf=259, timeout=0, timeout_char=2)"
 elif "RA4M1 CLICKER" in machine:
@@ -26,8 +28,8 @@ elif "EK-RA4W1" in machine:
     try_s = "UART(9, baudrate=115200, bits=8, parity=None, stop=1, tx=P109, rx=P110, flow=0, rxbuf=259, timeout=0, timeout_char=2)"
 elif "EK-RA6M1" in machine:
     # 0, 1, 2, 3, 4, 8, 9
-    # 1/3/4/9 are disabled
-    uart_ids = (0, 2, 8)
+    # 1/3/4/9 are disabled, and skip 0 because that's the UART REPL
+    uart_ids = (2, 8)
     try_id = 8
     try_s = "UART(8, baudrate=115200, bits=8, parity=None, stop=1, tx=P105, rx=P104, flow=0, rxbuf=259, timeout=0, timeout_char=2)"
 else:

--- a/tests/ports/stm32/uart.py
+++ b/tests/ports/stm32/uart.py
@@ -1,7 +1,7 @@
 import sys
 from pyb import UART
 
-if "STM32WB" in sys.implementation._machine:
+if "STM32WB" in sys.implementation._machine or "STM32U5" in sys.implementation._machine:
     # UART(1) is usually connected to the REPL on these MCUs.
     print("SKIP")
     raise SystemExit

--- a/tests/ports/stm32_hardware/spi_dma_align.py
+++ b/tests/ports/stm32_hardware/spi_dma_align.py
@@ -6,7 +6,9 @@
 import unittest
 from machine import SPI
 
-SPI_NUM = 2
+from target_wiring import spi_standalone_args_list
+
+SPI_NUM = spi_standalone_args_list[0][0]
 BAUDRATE = 5_000_000
 
 

--- a/tests/run-multitests.py
+++ b/tests/run-multitests.py
@@ -538,7 +538,7 @@ def run_tests(test_files, instances_truth, instances_test):
         else:
             print("FAIL")
             test_results.append((test_file, "fail", ""))
-            if not cmd_args.show_output:
+            if False and not cmd_args.show_output:
                 print("### TEST ###")
                 print(output_test, end="")
                 print("### TRUTH ###")

--- a/tests/run-multitests.py
+++ b/tests/run-multitests.py
@@ -118,6 +118,7 @@ IGNORE_OUTPUT_MATCHES = (
     "hci_number_completed_packet",  # Warning from unix btstack.
     "lld_pdu_get_tx_flush_nb HCI packet count mismatch (",  # From ESP-IDF, see https://github.com/espressif/esp-idf/issues/5105
     " ets_task(",  # ESP8266 port debug output
+    "DHCPS: client connected: MAC=",  # cyw43 AP
 )
 
 

--- a/tests/run-multitests.py
+++ b/tests/run-multitests.py
@@ -547,6 +547,14 @@ def run_tests(test_files, instances_truth, instances_test):
                 print("### DIFF ###")
                 print_diff(output_truth, output_test)
 
+            # Save results to file.
+            test_basename = instances_str.replace("|", "_") + "_" + test_file.replace("..", "_").replace("./", "").replace("/", "_")
+            result_filename = os.path.join(cmd_args.result_dir, test_basename)
+            with open(result_filename + ".exp", "w") as f:
+                f.write(output_truth)
+            with open(result_filename + ".out", "w") as f:
+                f.write(output_test)
+
         # Print test output metrics, if there are any.
         if output_metrics:
             for metric in output_metrics:

--- a/tests/run-natmodtests.py
+++ b/tests/run-natmodtests.py
@@ -62,6 +62,8 @@ class __File(io.IOBase):
   def ioctl(self, request, arg):
     if request == 4: # MP_STREAM_CLOSE
       return 0
+    if request == 11: # MP_STREAM_GET_BUFFER_SIZE
+      return 249
     return -1
   def readinto(self, buf):
     buf[:] = memoryview(__buf)[self.off:self.off + len(buf)]

--- a/tests/run-tests.py
+++ b/tests/run-tests.py
@@ -1481,4 +1481,8 @@ if __name__ == "__main__":
     except KeyboardInterrupt:
         print()
         print("INTERRUPT")
-        sys.exit(1)
+        sys.exit(2)
+    except Exception as er:
+        print("ERROR:")
+        print(er)
+        sys.exit(2)

--- a/tests/run-tests.py
+++ b/tests/run-tests.py
@@ -315,6 +315,7 @@ tests_requiring_target_wiring = (
     "extmod_hardware/machine_can_timings.py",
     "extmod_hardware/machine_encoder.py",
     "extmod_hardware/machine_i2c_target.py",
+    "extmod_hardware/machine_adc.py",
     "extmod_hardware/machine_pin.py",
     "extmod_hardware/machine_pwm.py",
     "extmod_hardware/machine_uart_irq_break.py",

--- a/tests/run-tests.py
+++ b/tests/run-tests.py
@@ -317,6 +317,7 @@ tests_requiring_target_wiring = (
     "extmod_hardware/machine_i2c_target.py",
     "extmod_hardware/machine_adc.py",
     "extmod_hardware/machine_pin.py",
+    "extmod_hardware/machine_pin_irq.py",
     "extmod_hardware/machine_pwm.py",
     "extmod_hardware/machine_uart_irq_break.py",
     "extmod_hardware/machine_uart_irq_rx.py",

--- a/tests/run-tests.py
+++ b/tests/run-tests.py
@@ -1474,4 +1474,9 @@ the last matching regex is used:
 
 
 if __name__ == "__main__":
-    main()
+    try:
+        main()
+    except KeyboardInterrupt:
+        print()
+        print("INTERRUPT")
+        sys.exit(1)

--- a/tests/run-tests.py
+++ b/tests/run-tests.py
@@ -39,6 +39,8 @@ RV32_ARCH_FLAGS = {
     "zcmp": 1 << 1,
 }
 
+VERBOSE = False
+
 # Tests require at least CPython 3.3. If your default python3 executable
 # is of lower version, you can point MICROPY_CPYTHON3 environment var
 # to the correct executable.
@@ -1464,7 +1466,7 @@ the last matching regex is used:
     try:
         os.makedirs(args.result_dir, exist_ok=True)
         test_results, testcase_count = run_tests(pyb, tests, args, args.result_dir, args.jobs)
-        res = create_test_report(args, test_results, testcase_count)
+        res = create_test_report(args, test_results, testcase_count, verbose=VERBOSE)
     finally:
         if pyb:
             pyb.close()

--- a/tests/run-tests.py
+++ b/tests/run-tests.py
@@ -1346,6 +1346,9 @@ the last matching regex is used:
         action="store_true",
         help="print the result for each test",
     )
+    cmd_parser.add_argument(
+        "-c", "--trace-output", action="store_true", help="trace test output while running"
+    )
     args = cmd_parser.parse_args()
 
     global verbose_each_test

--- a/tests/run-tests.py
+++ b/tests/run-tests.py
@@ -1373,6 +1373,22 @@ the last matching regex is used:
     # Automatically detect the platform.
     detect_test_platform(pyb, args)
 
+    if False and args.platform == "esp8266":
+        print(pyb.exec_("import os; u=os.dupterm(None,1);os.dupterm(u,1)"))
+        print("A", pyb.exec_("print(u)"))
+        pyb.exec_raw_no_follow("u.init(baudrate=2*115200)")
+        pyb.serial.baudrate = 2 * 115200
+        import time
+
+        time.sleep(0.2)
+        while pyb.serial.inWaiting() > 0:
+            print("-", pyb.serial.read(pyb.serial.inWaiting()))
+        time.sleep(0.2)
+        print("next")
+        pyb.enter_raw_repl(soft_reset=0)
+        print("B", pyb.exec_("print(u)"))
+        # unfortunately the baudrate is reset back to 115200 upon soft reset
+
     if args.run_failures and (any(args.files) or args.test_dirs is not None):
         raise ValueError(
             "--run-failures cannot be used together with files or --test-dirs arguments"

--- a/tests/run-tests.py
+++ b/tests/run-tests.py
@@ -744,6 +744,42 @@ class ThreadSafeCounter:
         return self._value
 
 
+stdout_isatty = sys.stdout.isatty()
+end_erase = "                                 \r"
+
+
+def print_output_skip(test):
+    if stdout_isatty:
+        print("skip ", test, end=end_erase)
+    else:
+        print("skip ", test)
+
+
+def print_output_start(test):
+    if stdout_isatty:
+        print(".... ", test, end=end_erase)
+
+
+def print_output_end_skip(test, reason):
+    if stdout_isatty:
+        return
+        print(reason, test, end=end_erase)
+    else:
+        print(reason, test)
+
+
+def print_output_end_pass(test, extra_info):
+    if stdout_isatty:
+        return
+        print("pass ", test, extra_info, end=end_erase)
+    else:
+        print("pass ", test, extra_info)
+
+
+def print_output_end_fail(test, extra_info):
+    print("FAIL ", test, extra_info)
+
+
 def run_tests(pyb, tests, args, result_dir, num_threads=1):
     testcase_count = ThreadSafeCounter()
     raw_repl_failure_count = ThreadSafeCounter()
@@ -1004,13 +1040,15 @@ def run_tests(pyb, tests, args, result_dir, num_threads=1):
         skip_it |= skip_inlineasm and is_inlineasm
 
         if skip_it:
-            print("skip ", test_file)
+            print_output_skip(test_file)
             test_results.append((test_file, "skip", ""))
             return
         elif args.dry_run:
             print("found", test_file)
             test_results.append((test_file, "found", ""))
             return
+
+        print_output_start(test_file)
 
         # Run the test on the MicroPython target.
         output_mupy = run_micropython(pyb, args, test_file, test_file_abspath)
@@ -1023,11 +1061,11 @@ def run_tests(pyb, tests, args, result_dir, num_threads=1):
                 # reset.  Wait for the soft reset to finish, so we don't interrupt the
                 # start-up code (eg boot.py) when preparing to run the next test.
                 pyb.read_until(1, b"raw REPL; CTRL-B to exit\r\n")
-            print("skip ", test_file)
+            print_output_end_skip(test_file, "skip")
             test_results.append((test_file, "skip", ""))
             return
         elif output_mupy == b"SKIP-TOO-LARGE\n":
-            print("lrge ", test_file)
+            print_output_end_skip(test_file, "lrge")
             test_results.append((test_file, "skip", "too large"))
             return
 
@@ -1114,7 +1152,7 @@ def run_tests(pyb, tests, args, result_dir, num_threads=1):
 
         # Print test summary, update counters, and save .exp/.out files if needed.
         if test_passed:
-            print("pass ", test_file, extra_info)
+            print_output_end_pass(test_file, extra_info)
             test_results.append((test_file, "pass", ""))
             rm_f(filename_expected)
             rm_f(filename_mupy)
@@ -1122,7 +1160,7 @@ def run_tests(pyb, tests, args, result_dir, num_threads=1):
             if output_mupy.startswith(b"could not enter raw repl"):
                 extra_info = "raw REPL failed"
                 raw_repl_failure_count.increment()
-            print("FAIL ", test_file, extra_info)
+            print_output_end_fail(test_file, extra_info)
             if output_expected is not None:
                 with open(filename_expected, "wb") as f:
                     f.write(output_expected)

--- a/tests/run-tests.py
+++ b/tests/run-tests.py
@@ -314,6 +314,7 @@ tests_requiring_target_wiring = (
     "extmod/machine_uart_tx.py",
     "extmod_hardware/machine_can_timings.py",
     "extmod_hardware/machine_encoder.py",
+    "extmod_hardware/machine_i2c_target.py",
     "extmod_hardware/machine_pin.py",
     "extmod_hardware/machine_pwm.py",
     "extmod_hardware/machine_uart_irq_break.py",
@@ -748,32 +749,34 @@ class ThreadSafeCounter:
         return self._value
 
 
-stdout_isatty = sys.stdout.isatty()
+verbose_each_test = not sys.stdout.isatty()
 end_erase = "                                 \r"
 
 
 def print_output_skip(test):
-    if stdout_isatty:
+    if not verbose_each_test:
         print("skip ", test, end=end_erase)
     else:
         print("skip ", test)
 
 
 def print_output_start(test):
-    if stdout_isatty:
+    if not verbose_each_test:
+        print(".... ", test, end=end_erase)
+    else:
         print(".... ", test, end=end_erase)
 
 
 def print_output_end_skip(test, reason):
-    if stdout_isatty:
+    if not verbose_each_test:
         return
         print(reason, test, end=end_erase)
     else:
-        print(reason, test)
+        print(reason + " ", test)
 
 
 def print_output_end_pass(test, extra_info):
-    if stdout_isatty:
+    if not verbose_each_test:
         return
         print("pass ", test, extra_info, end=end_erase)
     else:
@@ -1336,7 +1339,15 @@ the last matching regex is used:
         default=None,
         help="force the given script to be used as target_wiring.py",
     )
+    cmd_parser.add_argument(
+        "--verbose-each-test",
+        action="store_true",
+        help="print the result for each test",
+    )
     args = cmd_parser.parse_args()
+
+    global verbose_each_test
+    verbose_each_test = args.verbose_each_test
 
     prologue = ""
     if args.begin:

--- a/tests/run-tests.py
+++ b/tests/run-tests.py
@@ -314,6 +314,7 @@ tests_requiring_target_wiring = (
     "extmod/machine_uart_tx.py",
     "extmod_hardware/machine_can_timings.py",
     "extmod_hardware/machine_encoder.py",
+    "extmod_hardware/machine_pin.py",
     "extmod_hardware/machine_pwm.py",
     "extmod_hardware/machine_uart_irq_break.py",
     "extmod_hardware/machine_uart_irq_rx.py",

--- a/tests/run-tests.py
+++ b/tests/run-tests.py
@@ -318,6 +318,7 @@ tests_requiring_target_wiring = (
     "extmod_hardware/machine_uart_irq_break.py",
     "extmod_hardware/machine_uart_irq_rx.py",
     "extmod_hardware/machine_uart_irq_rxidle.py",
+    "ports/stm32_hardware/spi_dma_align.py",
 )
 
 

--- a/tests/target_wiring/EK_RA6M2.py
+++ b/tests/target_wiring/EK_RA6M2.py
@@ -3,6 +3,10 @@
 # Connect:
 # - P601 to P602
 
+pin_loopback_pins = [("P601", "P602")]
+
 # UART(9) is on P602/P601.
 uart_loopback_args = (9,)
 uart_loopback_kwargs = {}
+
+spi_standalone_args_list = [(0,)]

--- a/tests/target_wiring/NUCLEO_G0B1RE.py
+++ b/tests/target_wiring/NUCLEO_G0B1RE.py
@@ -1,0 +1,14 @@
+# Target wiring for NUCLEO_G0B1RE.
+#
+# Connect:
+# - PC4 to PC5 (D0 to D1 on Arduino header)
+
+pin_loopback_pins = [("D0", "D1")]
+
+pwm_loopback_pins = [("D0", "D1")]
+
+# UART(3) is on PC4/PC5.
+uart_loopback_args = (3,)
+uart_loopback_kwargs = {}
+
+spi_standalone_args_list = [(1,), (2,)]

--- a/tests/target_wiring/NUCLEO_H723ZG.py
+++ b/tests/target_wiring/NUCLEO_H723ZG.py
@@ -1,0 +1,28 @@
+# Target wiring for NUCLEO_H723ZG.
+#
+# TODO: need to work out why D12/13/14/15 don't work properly,
+# because it would be good to use those for I2C tests.
+#
+# Connect:
+# - D0 to D1 (Arduino labels)
+# - D52 to D53 (Arduino labels)
+
+# UART(2) is on PD5/PD6 = D53/D52.
+uart_loopback_args = (2,)
+uart_loopback_kwargs = {}
+
+spi_standalone_args_list = [(3,)]
+
+# CAN args assume no connection for single device tests
+can_args = (1,)
+can_kwargs = {}
+
+pwm_loopback_pins = [("D0", "D1")]
+pin_loopback_pins = [("D0", "D1")]
+#pwm_loopback_pins = [("D14", "D12"), ("D15", "D13")]
+#pwm_loopback_pins = [("D12", "D14"), ("D13", "D15")]
+
+#i2c_args_controller = {"scl": "D13", "sda": "D12"}  # Arduino header D13/D12
+#i2c_args_target = (1,)  # PB8/PB9, Arduino header D15/D14
+i2c_args_controller = {"scl": "fail", "sda": "fail"}
+i2c_args_target = ("fail",)

--- a/tests/target_wiring/NUCLEO_L152RE.py
+++ b/tests/target_wiring/NUCLEO_L152RE.py
@@ -1,0 +1,16 @@
+# Target wiring for NUCLEO_L152RE.
+#
+# Connect:
+# - PA9 to PA10 (D8 to D2 on Arduino header)
+# - PB3 to PB5 (D3 to D4 on Arduino header)
+
+pin_loopback_pins = [("D2", "D8"), ("D3", "D4")]
+
+# D3=PB3 has TIM2_CH2, D4=PB5 has TIM3_CH2.
+pwm_loopback_pins = [("D3", "D4"), ("D4", "D3")]
+
+# UART(1) is on PA9/PA10.
+uart_loopback_args = (1,)
+uart_loopback_kwargs = {}
+
+spi_standalone_args_list = [(1,), (2,), (3,)]

--- a/tests/target_wiring/NUCLEO_U575ZI_Q.py
+++ b/tests/target_wiring/NUCLEO_U575ZI_Q.py
@@ -1,0 +1,22 @@
+# Target wiring for NUCLEO_U575ZI_Q.
+#
+# Connect:
+# - D12 to D14 (Arduino labels)
+# - D13 to D15 (Arduino labels)
+# - D52 to D53 (Arduino labels)
+
+pin_loopback_pins = [("D12", "D14"), ("D13", "D15"), ("D52", "D53")]
+pwm_loopback_pins = [("D12", "D14"), ("D13", "D15")]
+
+# UART(2) is on PD5/PD6 = Arduino D53/D52.
+uart_loopback_args = (2,)
+uart_loopback_kwargs = {}
+
+spi_standalone_args_list = [(1,), (3,)]
+
+# CAN args assume no connection for single device tests.
+can_args = (1,)
+can_kwargs = {}
+
+i2c_args_controller = {"scl": "D13", "sda": "D12"}  # Arduino D13/D12
+i2c_args_target = (1,)  # PB8/PB9 = Arduino D15/D14

--- a/tests/target_wiring/NUCLEO_U575ZI_Q.py
+++ b/tests/target_wiring/NUCLEO_U575ZI_Q.py
@@ -12,7 +12,8 @@ pwm_loopback_pins = [("D12", "D14"), ("D13", "D15")]
 uart_loopback_args = (2,)
 uart_loopback_kwargs = {}
 
-spi_standalone_args_list = [(1,), (3,)]
+# TODO get SPI(3) working, it fails for transfers above 1023 bytes
+spi_standalone_args_list = [(1,), (2,)]
 
 # CAN args assume no connection for single device tests.
 can_args = (1,)

--- a/tests/target_wiring/NUCLEO_WB55.py
+++ b/tests/target_wiring/NUCLEO_WB55.py
@@ -1,7 +1,9 @@
 # Target wiring for NUCLEO_WB55.
 #
 # Connect:
-# - PA2 to PA3
+# - PA2 to PA3 (D0 to D1 on Arduino header)
+# - PA5 to PB8=I2C1_SCL (D13 to D15 on Arduino header)
+# - PA6 to PB9=I2C1_SDA (D12 to D14 on Arduino header)
 
 # LPUART(1) is on PA2/PA3.
 uart_loopback_args = ("LP1",)
@@ -9,4 +11,7 @@ uart_loopback_kwargs = {}
 
 spi_standalone_args_list = [(1,), (2,)]
 
-pwm_loopback_pins = [("D1", "D0")]
+pwm_loopback_pins = [("D1", "D0"), ("D12", "D14"), ("D13", "D15")]
+
+i2c_args_controller = {"scl": "D13", "sda": "D12"}  # Arduino header D13/D12
+i2c_args_target = (1,)  # PB8/PB9, Arduino header D15/D14

--- a/tests/target_wiring/NUCLEO_WB55.py
+++ b/tests/target_wiring/NUCLEO_WB55.py
@@ -5,13 +5,14 @@
 # - PA5 to PB8=I2C1_SCL (D13 to D15 on Arduino header)
 # - PA6 to PB9=I2C1_SDA (D12 to D14 on Arduino header)
 
+pin_loopback_pins = [("D0", "D1"), ("D12", "D14"), ("D13", "D15")]
+pwm_loopback_pins = pin_loopback_pins
+
 # LPUART(1) is on PA2/PA3.
 uart_loopback_args = ("LP1",)
 uart_loopback_kwargs = {}
 
 spi_standalone_args_list = [(1,), (2,)]
-
-pwm_loopback_pins = [("D1", "D0"), ("D12", "D14"), ("D13", "D15")]
 
 i2c_args_controller = {"scl": "D13", "sda": "D12"}  # Arduino header D13/D12
 i2c_args_target = (1,)  # PB8/PB9, Arduino header D15/D14

--- a/tests/target_wiring/OPENMV_AE3.py
+++ b/tests/target_wiring/OPENMV_AE3.py
@@ -1,0 +1,25 @@
+# Target wiring for OPENMV_AE3 board.
+#
+# Break out board V4 left pins mapping (it's wired incorrectly):
+# - p3 = p5_2
+# - p2 = p5_3
+# - p1 = p5_0
+# - p0 = p5_1
+# - p4 = p0_5
+# - p5 = p0_4
+#
+# Connect:
+# - P4 and P5 (P0_5/P0_4, for UART1 TX and RX)
+# - P0 and P2
+# - P1 and P3
+
+uart_loopback_args = (1,)
+uart_loopback_kwargs = {}
+
+spi_standalone_args_list = [(0,)]
+
+pwm_loopback_pins = [("P4", "P5")]
+pwm_loopback_pins += [("P0", "P2"), ("P1", "P3")]
+
+i2c_args_controller = {"scl": "P2", "sda": "P3"}
+i2c_args_target = (2,)  # on pins P0/P1

--- a/tests/target_wiring/OPENMV_AE3.py
+++ b/tests/target_wiring/OPENMV_AE3.py
@@ -13,13 +13,17 @@
 # - P0 and P2
 # - P1 and P3
 
+pin_loopback_pins = [("P4", "P5"), ("P0", "P2"), ("P1", "P3")]
+
+pwm_loopback_pins = pin_loopback_pins
+
+# Test ADC on P4, P5.
+adc_loopback_pins = [("P4", "P5"), ("P5", "P4")]
+
 uart_loopback_args = (1,)
 uart_loopback_kwargs = {}
 
 spi_standalone_args_list = [(0,)]
-
-pwm_loopback_pins = [("P4", "P5")]
-pwm_loopback_pins += [("P0", "P2"), ("P1", "P3")]
 
 i2c_args_controller = {"scl": "P2", "sda": "P3"}
 i2c_args_target = (2,)  # on pins P0/P1

--- a/tests/target_wiring/OPENMV_N6.py
+++ b/tests/target_wiring/OPENMV_N6.py
@@ -1,0 +1,15 @@
+# Target wiring for OPENMV_N6.
+#
+# Connect:
+# - P4 to P5 (PB10 to PB11)
+# - P7 to P8 (PG13 to PD13)
+
+# UART(3) is on P4/P5.
+uart_loopback_args = (3,)
+uart_loopback_kwargs = {}
+
+# Test SPI(2) and SPI(4).
+spi_standalone_args_list = [(2,), (4,)]
+
+# Test TIM2 and TIM4.
+pwm_loopback_pins = [("P4", "P5"), ("P7", "P8")]

--- a/tests/target_wiring/OPENMV_N6.py
+++ b/tests/target_wiring/OPENMV_N6.py
@@ -1,8 +1,17 @@
 # Target wiring for OPENMV_N6.
 #
 # Connect:
+# - P2 to P3 (for ADC test)
 # - P4 to P5 (PB10 to PB11)
 # - P7 to P8 (PG13 to PD13)
+
+pin_loopback_pins = [("P4", "P5"), ("P7", "P8")]
+
+# Test ADC on P2, P3.
+adc_loopback_pins = [("P2", "P3"), ("P3", "P2")]
+
+# Test TIM2 and TIM4.
+pwm_loopback_pins = pin_loopback_pins
 
 # UART(3) is on P4/P5.
 uart_loopback_args = (3,)
@@ -11,5 +20,6 @@ uart_loopback_kwargs = {}
 # Test SPI(2) and SPI(4).
 spi_standalone_args_list = [(2,), (4,)]
 
-# Test TIM2 and TIM4.
-pwm_loopback_pins = [("P4", "P5"), ("P7", "P8")]
+# CAN args assume no connection for single device tests.
+can_args = (1,)
+can_kwargs = {}

--- a/tests/target_wiring/PYBx.py
+++ b/tests/target_wiring/PYBx.py
@@ -2,6 +2,14 @@
 #
 # Connect:
 # - X1 to X2
+# - X7 to X9
+# - X8 to X10
+
+# Test all connected pin pairs.
+pin_loopback_pins = [("X1", "X2"), ("X7", "X9"), ("X8", "X10")]
+
+# Test all connected pin pairs to test multiple different TIMs.
+pwm_loopback_pins = pin_loopback_pins
 
 # UART("XA") is on X1/X2  (usually UART(4) on PA0/PA1).
 uart_loopback_args = ("XA",)
@@ -9,8 +17,6 @@ uart_loopback_kwargs = {}
 
 spi_standalone_args_list = [(1,), (2,)]
 
-# CAN args assume no connection for single device tests
+# CAN args assume no connection for single device tests.
 can_args = (1,)
 can_kwargs = {}
-
-pwm_loopback_pins = [("X1", "X2")]

--- a/tests/target_wiring/PYBx.py
+++ b/tests/target_wiring/PYBx.py
@@ -2,11 +2,13 @@
 #
 # Connect:
 # - X1 to X2
-# - X7 to X9
-# - X8 to X10
+# - X3 to X9
+# - X4 to X10
+#
+# May need to tweak pins to avoid CAN test failures (CAN is on X9/X10).
 
 # Test all connected pin pairs.
-pin_loopback_pins = [("X1", "X2"), ("X7", "X9"), ("X8", "X10")]
+pin_loopback_pins = [("X1", "X2"), ("X3", "X9"), ("X4", "X10")]
 
 # Test all connected pin pairs to test multiple different TIMs.
 pwm_loopback_pins = pin_loopback_pins
@@ -20,3 +22,6 @@ spi_standalone_args_list = [(1,), (2,)]
 # CAN args assume no connection for single device tests.
 can_args = (1,)
 can_kwargs = {}
+
+i2c_args_controller = {"scl": "X3", "sda": "X4"}
+i2c_args_target = ("X",)

--- a/tests/target_wiring/README.md
+++ b/tests/target_wiring/README.md
@@ -24,6 +24,19 @@ There are three ways to provide the target wiring configuration:
 A target wiring script should define the following variables if the corresponding test
 is to be supported.
 
+### Pin tests
+
+Pin tests require two GPIO pins to be connected in loopback mode.
+The variables are:
+
+    pin_loopback_pins: list[tuple[Any, Any]]
+
+The two Pin instances will be created using:
+
+    for p0, p1 in pin_loopback_pins:
+        machine.Pin(p0)
+        machine.Pin(p1)
+
 ### UART tests
 
 UART tests require one UART to be connected in loopback mode, ie TX connected physically

--- a/tests/target_wiring/UM_FEATHERS2.py
+++ b/tests/target_wiring/UM_FEATHERS2.py
@@ -1,0 +1,7 @@
+# Target wiring for UM_FEATHERS2.
+#
+# Connect:
+# - GPIO5 to GPIO6
+
+uart_loopback_args = (1,)
+uart_loopback_kwargs = {"tx": 6, "rx": 5}

--- a/tests/target_wiring/ZEPHYR_FRDM_K64F.py
+++ b/tests/target_wiring/ZEPHYR_FRDM_K64F.py
@@ -1,0 +1,7 @@
+# Target wiring for zephyr frdm_k64f.
+#
+# Connect:
+# - TX=PTC17 to RX=PTC16
+
+uart_loopback_args = ("uart3",)
+uart_loopback_kwargs = {}  # TX/RX=PTC17/PTC16

--- a/tests/target_wiring/ZEPHYR_FRDM_K64F.py
+++ b/tests/target_wiring/ZEPHYR_FRDM_K64F.py
@@ -5,3 +5,6 @@
 
 uart_loopback_args = ("uart3",)
 uart_loopback_kwargs = {}  # TX/RX=PTC17/PTC16
+
+# for machine.Pin
+pwm_loopback_pins = [(("gpioc", 16), ("gpioc", 17))]

--- a/tests/target_wiring/ZEPHYR_FRDM_K64F.py
+++ b/tests/target_wiring/ZEPHYR_FRDM_K64F.py
@@ -3,8 +3,8 @@
 # Connect:
 # - TX=PTC17 to RX=PTC16
 
+pin_loopback_pins = [(("gpioc", 16), ("gpioc", 17))]
+adc_loopback_pins = []  # TODO work out how to refer to ADC pins
+
 uart_loopback_args = ("uart3",)
 uart_loopback_kwargs = {}  # TX/RX=PTC17/PTC16
-
-# for machine.Pin
-pwm_loopback_pins = [(("gpioc", 16), ("gpioc", 17))]

--- a/tests/target_wiring/ZEPHYR_NUCLEO_WB55RG.py
+++ b/tests/target_wiring/ZEPHYR_NUCLEO_WB55RG.py
@@ -1,7 +1,19 @@
 # Target wiring for zephyr nucleo_wb55rg.
 #
 # Connect:
-# - TX=PC0 to RX=PC1
+# - PC0=TX to PC1=RX (A0 to A1 on Arduino header)
+# - PA5 to PB8=I2C1_SCL (D13 to D15 on Arduino header)
+# - PA6 to PB9=I2C1_SDA (D12 to D14 on Arduino header)
+
+from machine import Pin
 
 uart_loopback_args = ("lpuart1",)
 uart_loopback_kwargs = {}
+
+spi_standalone_args_list = [("spi1",)]
+
+# for machine.Pin
+pwm_loopback_pins = [(("gpioc", 0), ("gpioc", 1))]
+
+i2c_args_controller = {"scl": Pin(("gpioa", 5)), "sda": Pin(("gpioa", 6))}
+i2c_args_target = ("i2c1",)

--- a/tests/target_wiring/ZEPHYR_NUCLEO_WB55RG.py
+++ b/tests/target_wiring/ZEPHYR_NUCLEO_WB55RG.py
@@ -7,13 +7,13 @@
 
 from machine import Pin
 
+pin_loopback_pins = [(("gpioc", 0), ("gpioc", 1)), (("gpioa", 5), ("gpiob", 8)), (("gpioa", 6), ("gpiob", 9))]
+adc_loopback_pins = []  # TODO, currently only configured on PA0 and PC2
+
 uart_loopback_args = ("lpuart1",)
 uart_loopback_kwargs = {}
 
 spi_standalone_args_list = [("spi1",)]
-
-# for machine.Pin
-pwm_loopback_pins = [(("gpioc", 0), ("gpioc", 1))]
 
 i2c_args_controller = {"scl": Pin(("gpioa", 5)), "sda": Pin(("gpioa", 6))}
 i2c_args_target = ("i2c1",)

--- a/tests/target_wiring/ZEPHYR_RPI_PICO.py
+++ b/tests/target_wiring/ZEPHYR_RPI_PICO.py
@@ -1,0 +1,18 @@
+# Target wiring for zephyr rpi_pico board.
+#
+# Connect:
+# - GPIO0 to GPIO1
+# - GPIO4 to GPIO6 and GPIO5 to GPIO7
+
+from machine import Pin
+
+uart_loopback_args = ("uart0",)
+uart_loopback_kwargs = {}
+
+spi_standalone_args_list = [("spi0",)]
+
+# for machine.Pin
+pwm_loopback_pins = [(("gpio0", 0), ("gpio0", 1))]
+
+i2c_args_controller = {"scl": Pin(("gpio0", 5)), "sda": Pin(("gpio0", 4))}
+i2c_args_target = ("i2c1",)  # on gpio7/gpio6

--- a/tests/target_wiring/alif.py
+++ b/tests/target_wiring/alif.py
@@ -9,3 +9,6 @@ uart_loopback_kwargs = {}
 spi_standalone_args_list = [(0,)]
 
 pwm_loopback_pins = [("P0_4", "P0_5")]
+
+i2c_args_controller = {"scl": "P1_1", "sda": "P1_0"}
+i2c_args_target = (0,)  # on pins P0_3/P0_2

--- a/tests/target_wiring/alif.py
+++ b/tests/target_wiring/alif.py
@@ -2,13 +2,16 @@
 #
 # Connect:
 # - UART1 TX and RX, usually P0_5 and P0_4
+# - P0_2 to P1_0 and P0_3 to P1_1
+
+pin_loopback_pins = [("P0_4", "P0_5"), ("P0_2", "P1_0"), ("P0_3", "P1_1")]
+pwm_loopback_pins = pin_loopback_pins
+adc_loopback_pins = pin_loopback_pins
 
 uart_loopback_args = (1,)
 uart_loopback_kwargs = {}
 
 spi_standalone_args_list = [(0,)]
-
-pwm_loopback_pins = [("P0_4", "P0_5")]
 
 i2c_args_controller = {"scl": "P1_1", "sda": "P1_0"}
 i2c_args_target = (0,)  # on pins P0_3/P0_2

--- a/tests/target_wiring/esp32.py
+++ b/tests/target_wiring/esp32.py
@@ -19,3 +19,21 @@ pwm_loopback_pins = [(4, 5)]
 encoder_loopback_id = 0
 encoder_loopback_out_pins = (4, 12)
 encoder_loopback_in_pins = (5, 13)
+
+import sys
+if "C6" in sys.implementation._machine:
+    # 01Space C6 board
+    # also ESP32-C6-DevKitC-1 doesn't seem to like 12/13 connected together
+    encoder_loopback_out_pins = (4, 6)
+    encoder_loopback_in_pins = (5, 7)
+
+if "P4" in sys.implementation._machine:
+    # FireBeetle 2 board
+    encoder_loopback_out_pins = (4, 7)
+    encoder_loopback_in_pins = (5, 8)
+
+if "S2" in sys.implementation._machine:
+    # FeatherS2 board
+    uart_loopback_kwargs = {"tx": 5, "rx": 6}
+    encoder_loopback_out_pins = (5, 10)
+    encoder_loopback_in_pins = (6, 11)

--- a/tests/target_wiring/esp32.py
+++ b/tests/target_wiring/esp32.py
@@ -22,18 +22,31 @@ encoder_loopback_in_pins = (5, 13)
 
 import sys
 if "C6" in sys.implementation._machine:
-    # 01Space C6 board
-    # also ESP32-C6-DevKitC-1 doesn't seem to like 12/13 connected together
+    # ESP32-C6-DevKitC-1 (doesn't seem to like 12/13 connected together)
+    # connect 4 to 5 and 6 to 7
+    pin_loopback_pins = [(4, 5), (6, 7)]
     encoder_loopback_out_pins = (4, 6)
     encoder_loopback_in_pins = (5, 7)
+    i2c_args_controller = {"scl": 4, "sda": 6}
+    i2c_args_target = (0,)
+    i2c_kwargs_target = {"scl": 5, "sda": 7}
 
 if "P4" in sys.implementation._machine:
-    # FireBeetle 2 board
+    # FireBeetle 2 board; connect 4/5 and 7/8
+    pwm_loopback_pins += [(7, 8)]
     encoder_loopback_out_pins = (4, 7)
     encoder_loopback_in_pins = (5, 8)
+    i2c_args_controller = {"scl": 4, "sda": 7}
+    i2c_args_target = (0,)
+    i2c_kwargs_target = {"scl": 5, "sda": 8}
 
 if "S2" in sys.implementation._machine:
-    # FeatherS2 board
+    # FeatherS2 board, connect 5/6 and 10/11
+    pin_loopback_pins = [(5, 6), (10, 11)]
+    pwm_loopback_pins = [(5, 6)]
     uart_loopback_kwargs = {"tx": 5, "rx": 6}
     encoder_loopback_out_pins = (5, 10)
     encoder_loopback_in_pins = (6, 11)
+    i2c_args_controller = {"scl": 5, "sda": 10}
+    i2c_args_target = (0,)
+    i2c_kwargs_target = {"scl": 6, "sda": 11}

--- a/tests/target_wiring/esp32.py
+++ b/tests/target_wiring/esp32.py
@@ -6,6 +6,10 @@
 
 import sys
 
+pin_loopback_pins = [(4, 5)]
+pwm_loopback_pins = pin_loopback_pins
+adc_loopback_pins = pin_loopback_pins
+
 uart_loopback_args = (1,)
 uart_loopback_kwargs = {"tx": 4, "rx": 5}
 
@@ -13,8 +17,6 @@ if "ESP32-C" in sys.implementation._machine:
     spi_standalone_args_list = [(1,)]
 else:
     spi_standalone_args_list = [(1,), (2,)]
-
-pwm_loopback_pins = [(4, 5)]
 
 encoder_loopback_id = 0
 encoder_loopback_out_pins = (4, 12)

--- a/tests/target_wiring/nrf.py
+++ b/tests/target_wiring/nrf.py
@@ -3,6 +3,8 @@
 # Connect:
 # - UART0 TX and RX
 
+pin_loopback_pins = []
+
 uart_loopback_args = (0,)
 uart_loopback_kwargs = {}
 

--- a/tests/target_wiring/rp2.py
+++ b/tests/target_wiring/rp2.py
@@ -2,6 +2,7 @@
 #
 # Connect:
 # - GPIO0 to GPIO1
+# - GPIO4 to GPIO6 and GPIO5 to GPIO7
 
 uart_loopback_args = (0,)
 uart_loopback_kwargs = {"tx": "GPIO0", "rx": "GPIO1"}
@@ -9,3 +10,6 @@ uart_loopback_kwargs = {"tx": "GPIO0", "rx": "GPIO1"}
 spi_standalone_args_list = [(0,), (1,)]
 
 pwm_loopback_pins = [("GPIO0", "GPIO1")]
+
+i2c_args_controller = {"scl": 5, "sda": 4}
+i2c_args_target = (1,)  # on pins 7/6

--- a/tests/target_wiring/rp2.py
+++ b/tests/target_wiring/rp2.py
@@ -4,12 +4,13 @@
 # - GPIO0 to GPIO1
 # - GPIO4 to GPIO6 and GPIO5 to GPIO7
 
+pin_loopback_pins = [("GPIO0", "GPIO1"), ("GPIO4", "GPIO6"), ("GPIO5", "GPIO7")]
+pwm_loopback_pins = [("GPIO0", "GPIO1")]
+
 uart_loopback_args = (0,)
 uart_loopback_kwargs = {"tx": "GPIO0", "rx": "GPIO1"}
 
 spi_standalone_args_list = [(0,), (1,)]
-
-pwm_loopback_pins = [("GPIO0", "GPIO1")]
 
 i2c_args_controller = {"scl": 5, "sda": 4}
 i2c_args_target = (1,)  # on pins 7/6

--- a/tests/target_wiring/samd.py
+++ b/tests/target_wiring/samd.py
@@ -3,9 +3,10 @@
 # Connect:
 # - D0 to D1
 
+pin_loopback_pins = [("D0", "D1")]
+pwm_loopback_pins = [("D0", "D1")]
+
 uart_loopback_args = ()
 uart_loopback_kwargs = {"tx": "D1", "rx": "D0"}
 
 spi_standalone_args_list = [()]
-
-pwm_loopback_pins = [("D0", "D1")]

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -76,6 +76,8 @@ builtin tests suitable for the target platform are ran.
 # Code to allow a target MicroPython to import an .mpy from RAM
 # Note: the module is named `__injected_test` but it needs to have `__name__` set to
 # `__main__` so that the test sees itself as the main module, eg so unittest works.
+# Use `sys.path.append()` to make it visible, so things in existing current dir (eg
+# target_wiring.py) can still be imported.
 _injected_import_hook_code = """\
 import sys, os, io, vfs
 class __File(io.IOBase):
@@ -104,7 +106,7 @@ class __FS:
   def getcwd(self):
     return ""
   def stat(self, path):
-    if path == '__injected_test.mpy':
+    if path == '/__injected_test.mpy':
       return (0,0,0,0,0,0,0,0,0,0)
     else:
       raise OSError(2) # ENOENT
@@ -112,7 +114,8 @@ class __FS:
     self.stat(path)
     return __File()
 vfs.mount(__FS(), '/__vfstest')
-os.chdir('/__vfstest')
+#os.chdir('/__vfstest')
+sys.path.append('/__vfstest')
 {import_prologue}
 __import__('__injected_test')
 """

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -88,7 +88,7 @@ class __File(io.IOBase):
     if request == 4: # MP_STREAM_CLOSE
       return 0
     if request == 11: # MP_STREAM_GET_BUFFER_SIZE
-      return 249
+      return 32 - 7
     return -1
   def readinto(self, buf):
     buf[:] = memoryview(__buf)[self.off:self.off + len(buf)]

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -87,6 +87,8 @@ class __File(io.IOBase):
   def ioctl(self, request, arg):
     if request == 4: # MP_STREAM_CLOSE
       return 0
+    if request == 11: # MP_STREAM_GET_BUFFER_SIZE
+      return 249
     return -1
   def readinto(self, buf):
     buf[:] = memoryview(__buf)[self.off:self.off + len(buf)]

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -309,7 +309,7 @@ def run_script_on_remote_target(pyb, args, test_file, is_special, requires_targe
 
 # Print a summary of the results and save them to a JSON file.
 # Returns True if everything succeeded, False otherwise.
-def create_test_report(args, test_results, testcase_count=None):
+def create_test_report(args, test_results, testcase_count=None, *, verbose=True):
     passed_tests = list(r for r in test_results if r[1] == "pass")
     skipped_tests = list(r for r in test_results if r[1] == "skip" and r[2] != "too large")
     skipped_tests_too_large = list(
@@ -342,17 +342,14 @@ def create_test_report(args, test_results, testcase_count=None):
         )
 
     if len(skipped_tests) > 0:
-        print(
-            "{} tests skipped: {}".format(
-                len(skipped_tests), " ".join(test[0] for test in skipped_tests)
-            )
-        )
+        details = ": " + " ".join(test[0] for test in skipped_tests) if verbose else ""
+        print("{} tests skipped".format(len(skipped_tests)) + details)
 
     if len(skipped_tests_too_large) > 0:
+        details = ": " + " ".join(test[0] for test in skipped_tests_too_large) if verbose else ""
         print(
-            "{} tests skipped because they are too large: {}".format(
-                len(skipped_tests_too_large), " ".join(test[0] for test in skipped_tests_too_large)
-            )
+            "{} tests skipped because they are too large".format(len(skipped_tests_too_large))
+            + details
         )
 
     if len(failed_tests) > 0:

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -292,7 +292,23 @@ def run_script_on_remote_target(pyb, args, test_file, is_special, requires_targe
                 + repr(pyb.target_wiring_script)
                 + "),'target_wiring')"
             )
-        output_mupy = pyb.exec_(script, timeout=TEST_TIMEOUT)
+        trace_output = args.trace_output and "feature_check" not in test_file
+        if trace_output:
+            print(f"**** running {test_file}")
+        accum = []
+
+        def foo(x):
+            if x == b"\x04":
+                return
+            if trace_output:
+                sys.stdout.buffer.write(x)
+                sys.stdout.buffer.flush()
+            accum.append(x)
+
+        pyb.exec_(script, timeout=TEST_TIMEOUT, data_consumer=foo)
+        if trace_output:
+            print("**** done")
+        output_mupy = b"".join(accum)
     except pyboard.PyboardError as e:
         had_crash = True
         if not is_special and e.args[0] == "exception":


### PR DESCRIPTION
### Summary

With the aim to speed up testing for a release, I put together a script to automatically run tests on devices running MicroPython.  We have a lot of different tests these days, with different ways to run them.  The idea with this top-level test runner is:
- detect all serial devices connected
- detect what platform is running on each device and what its capabilities are (eg WLAN, BLE, ability to import .mpy files)
- run as many tests as possible given the connected devices (eg if there are two WLAN boards connected, then run the network multitests against them, among other things)

Basically all you need to do is connect boards to your PC via USB and run:
```
$ cd tests
$ ./hwtest.py
```
Then it does the rest.  It takes between 10 and 15 minutes per board, so if you have many connected it can take a few hours.  You can also restrict to given devices by specifying them on the command line, eg:
```
$ ./hwtest.py a0 a1 u0
```
(Probably the name of the script `hwtest.py` can change to something better.)

### Testing

This was used to test 16 distinct boards for the recent v1.24.0 release.

### Trade-offs and Alternatives

This is a bit of a hacky script at the moment but can be improved over time.

Currently there are no boards that pass all tests (!!) and so over time we need to fix things and improve the tests so more of them can pass.

