### PR TITLE
tools/ci: Fix commit message checking when PR branch HEAD behind master.

### DIFF
--- a/.github/workflows/commit_formatting.yml
+++ b/.github/workflows/commit_formatting.yml
@@ -1,6 +1,6 @@
 name: Check commit message formatting
 
-on: [push, pull_request]
+on: [pull_request]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -12,7 +12,7 @@ jobs:
     steps:
     - uses: actions/checkout@v4
       with:
-        fetch-depth: '100'
+        fetch-depth: 100
     - uses: actions/setup-python@v5
     - name: Check commit message formatting
       run: source tools/ci.sh && ci_commit_formatting_run


### PR DESCRIPTION
### Summary

Fixes the subtle problem [noted here](https://github.com/micropython/micropython/pull/15547#issuecomment-2434479702) - [workflow log here](https://github.com/micropython/micropython/actions/runs/11492562583/job/31986832560?pr=15547). Specifically, default CI HEAD for a PR is a (generated) merge commit into the master branch's current HEAD. If the PR branch isn't fully rebased (i.e. is one or more commits behind latest mater) then the commit check runs against commits from master as well!

Also drops running this check on push, the pull_request event is triggered by default on open and update, so that should cover all cases where this check needs to run.

### Testing

I made this PR branch the default branch in my fork and opened a series of dummy PRs:

1. Up to date with a valid commit message. Passes on master, [still passes](https://github.com/projectgus/micropython/actions/runs/11586370067/job/32256877702?pr=7).
2. Up to date with an invalid commit message. Fails on master, [still fails](https://github.com/projectgus/micropython/actions/runs/11586368061/job/32256874148?pr=8).
3. Old branch (100+ commits out of date) with invalid message. Fails on master but probably tests a lot of unrelated commits. [Tests correct commits and fails with this PR](https://github.com/projectgus/micropython/actions/runs/11587208838/job/32259052443). Note this run needed to do an "unshallow" fetch to find the merge base, due to being more than 100 commits out of date.
4. Old branch (one commit out of date) with valid message. This is the kind of branch which fails on master as it tests unrelated commits. [Checks one commit and passes with this PR](https://github.com/projectgus/micropython/actions/runs/11587538275/job/32259879338?pr=10).

*This work was funded through GitHub Sponsors.*
