### PR TITLE
extmod/modlwip: Fix IGMP address type when IPv6 is enabled.

### DIFF
--- a/extmod/modlwip.c
+++ b/extmod/modlwip.c
@@ -1432,7 +1432,7 @@ static mp_obj_t lwip_socket_setsockopt(size_t n_args, const mp_obj_t *args) {
         case IP_DROP_MEMBERSHIP: {
             mp_buffer_info_t bufinfo;
             mp_get_buffer_raise(args[3], &bufinfo, MP_BUFFER_READ);
-            if (bufinfo.len != sizeof(ip_addr_t) * 2) {
+            if (bufinfo.len != sizeof(MP_IGMP_IP_ADDR_TYPE) * 2) {
                 mp_raise_ValueError(NULL);
             }
 


### PR DESCRIPTION
### Summary

This was missed in 628abf8f25a7705a2810fffe2ca6ae652c532896

Fixes issue #16100.

### Testing

Tested with PYBD-SF2 and Pico W.  Multicast join works on v1.23.0 but not v1.24.0, but works again with this patch.
