### PR TITLE
ci: Fix reference commit for code size comparison.

### DIFF
--- a/.github/workflows/code_size.yml
+++ b/.github/workflows/code_size.yml
@@ -1,7 +1,6 @@
 name: Check code size
 
 on:
-  push:
   pull_request:
     paths:
       - '.github/workflows/*.yml'

--- a/tools/ci.sh
+++ b/tools/ci.sh
@@ -69,25 +69,37 @@ function ci_code_size_build {
     PORTS_TO_CHECK=bmusxpdv
     SUBMODULES="lib/asf4 lib/berkeley-db-1.xx lib/btstack lib/cyw43-driver lib/lwip lib/mbedtls lib/micropython-lib lib/nxp_driver lib/pico-sdk lib/stm32lib lib/tinyusb"
 
-    # starts off at either the ref/pull/N/merge FETCH_HEAD, or the current branch HEAD
-    git checkout -b pull_request # save the current location
-    git remote add upstream https://github.com/micropython/micropython.git
-    git fetch --depth=100 upstream master
-    # If the common ancestor commit hasn't been found, fetch more.
-    git merge-base upstream/master HEAD || git fetch --unshallow upstream master
+    # Default GitHub pull request sets HEAD to a generated merge commit
+    # between PR branch (HEAD^2) and base branch (i.e. master) (HEAD^1).
+    #
+    # We want to compare this generated commit with the base branch, to see what
+    # the code size impact would be if we merged this PR.
+    REFERENCE=$(git rev-parse --short HEAD^1)
+    COMPARISON=$(git rev-parse --short HEAD)
+
+    echo "Comparing sizes of reference ${REFERENCE} to ${COMPARISON}..."
+    git log --oneline $REFERENCE..$COMPARISON
+
+    function code_size_build_step {
+        COMMIT=$1
+        OUTFILE=$2
+        IGNORE_ERRORS=$3
+
+        echo "Building ${COMMIT}..."
+        git checkout --detach $COMMIT
+        git submodule update --init $SUBMODULES
+        git show -s
+        tools/metrics.py clean $PORTS_TO_CHECK
+        tools/metrics.py build $PORTS_TO_CHECK | tee $OUTFILE || $IGNORE_ERRORS
+    }
+
     # build reference, save to size0
     # ignore any errors with this build, in case master is failing
-    git checkout `git merge-base --fork-point upstream/master pull_request`
-    git submodule update --init $SUBMODULES
-    git show -s
-    tools/metrics.py clean $PORTS_TO_CHECK
-    tools/metrics.py build $PORTS_TO_CHECK | tee ~/size0 || true
+    code_size_build_step $REFERENCE ~/size0 true
     # build PR/branch, save to size1
-    git checkout pull_request
-    git submodule update --init $SUBMODULES
-    git log upstream/master..HEAD
-    tools/metrics.py clean $PORTS_TO_CHECK
-    tools/metrics.py build $PORTS_TO_CHECK | tee ~/size1
+    code_size_build_step $COMPARISON ~/size1 false
+
+    unset -f code_size_build_step
 }
 
 ########################################################################################


### PR DESCRIPTION
### Summary

Follow-up to #16114 after looking into the details of which commits GitHub checks out in PR actions.

Currently the code size comparison is between the merge base (i.e. where the PR branched), and the generated merge commit into master. If the PR branch is older than current master, this means the size comparison could incorrectly include changes already merged on master but missing from the PR branch.

This PR changes it to compare the generated merge commit against current master, i.e. the size impact if this PR was to be merged.

This commit also disables running the code size check on "push", it now only runs on pull_request events.

*This work was funded through GitHub Sponsors.*

### Testing

Similar to #16114, I set this branch as the default branch on my fork and opened some PRs:

1. One commit which increases rp2 code size. [Reports +96 bytes.](https://github.com/projectgus/micropython/pull/11#issuecomment-2448705751)
2. Same commit which increases rp2 code size, on top of an old branch (v1.22). The current size check misreports the increase as [0 bytes](https://github.com/projectgus/micropython/pull/13), but with this PR it reports [reports +96 bytes](https://github.com/projectgus/micropython/pull/12#issuecomment-2448725241).

### Trade-offs and Alternatives

* Instead of comparing the "generated merge commit" and master, we could compare the actual PR branch head against its merge base. Then any results should be the same as what the PR author would have seen if comparing sizes locally. However, it's fiddly to find the merge base and it's potentially less useful as an out of date PR branch might not include (for example) an optimisation change which will effect the code size after merging.
* Could leave the "push" event on and modify it to compare incremental changes in size on a branch as it evolves. A lot more work to store the artifacts and generate a report or a graph, though.