### PR TITLE
zephyr: Fix mp_int_t and mp_uint_t on 64bit

### DIFF
--- a/ports/zephyr/mpconfigport.h
+++ b/ports/zephyr/mpconfigport.h
@@ -133,8 +133,8 @@ void mp_hal_signal_event(void);
 #define MICROPY_HW_MCU_NAME "unknown-cpu"
 #endif
 
-typedef int mp_int_t; // must be pointer size
-typedef unsigned mp_uint_t; // must be pointer size
+typedef intptr_t mp_int_t; // must be pointer size
+typedef uintptr_t mp_uint_t; // must be pointer size
 typedef long mp_off_t;
 
 #define MP_STATE_PORT MP_STATE_VM


### PR DESCRIPTION
### Summary

These both need to fit a pointer, so make them intptr_t and mp_uint_t, similar to other ports. Micropython on zephyr fails to build without this fix.

### Testing

This was tested with zephyr built for a 64 bit RISC-V board.