### PR TITLE
esp32: Fix machine.PWM on IDF <5.2.

### DIFF
--- a/ports/esp32/machine_pwm.c
+++ b/ports/esp32/machine_pwm.c
@@ -34,8 +34,11 @@
 #include "py/mphal.h"
 #include "driver/ledc.h"
 #include "esp_err.h"
-#include "esp_clk_tree.h"
 #include "soc/gpio_sig_map.h"
+
+#if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(5, 1, 0)
+#include "esp_clk_tree.h"
+#endif
 
 #define PWM_DBG(...)
 // #define PWM_DBG(...) mp_printf(&mp_plat_print, __VA_ARGS__); mp_printf(&mp_plat_print, "\n");
@@ -208,7 +211,41 @@ static void configure_channel(machine_pwm_obj_t *self) {
     }
 }
 
+// Temporary workaround for ledc_find_suitable_duty_resolution function only being added in IDF V5.2
+#if ESP_IDF_VERSION < ESP_IDF_VERSION_VAL(5, 2, 0)
+static uint32_t ledc_find_suitable_duty_resolution(uint32_t src_clk_freq, uint32_t timer_freq) {
+    // This implementation is based on the one used in Micropython v1.23
+
+    // Find the highest bit resolution for the requested frequency
+    unsigned int freq = src_clk_freq;
+
+    int divider = (freq + timer_freq / 2) / timer_freq; // rounded
+    if (divider == 0) {
+        divider = 1;
+    }
+    float f = (float)freq / divider; // actual frequency
+    if (f <= 1.0) {
+        f = 1.0;
+    }
+    freq = (unsigned int)roundf((float)freq / f);
+
+    unsigned int res = 0;
+    for (; freq > 1; freq >>= 1) {
+        ++res;
+    }
+    if (res == 0) {
+        res = 1;
+    } else if (res > HIGHEST_PWM_RES) {
+        // Limit resolution to HIGHEST_PWM_RES to match units of our duty
+        res = HIGHEST_PWM_RES;
+    }
+
+    return res;
+}
+#endif
+
 static void set_freq(machine_pwm_obj_t *self, unsigned int freq, ledc_timer_config_t *timer) {
+    esp_err_t err;
     if (freq != timer->freq_hz) {
         // Configure the new frequency and resolution
         timer->freq_hz = freq;
@@ -228,10 +265,21 @@ static void set_freq(machine_pwm_obj_t *self, unsigned int freq, ledc_timer_conf
         }
         #endif
         uint32_t src_clk_freq = 0;
-        esp_err_t err = esp_clk_tree_src_get_freq_hz(timer->clk_cfg, ESP_CLK_TREE_SRC_FREQ_PRECISION_CACHED, &src_clk_freq);
+        #if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(5, 1, 0)
+        err = esp_clk_tree_src_get_freq_hz(timer->clk_cfg, ESP_CLK_TREE_SRC_FREQ_PRECISION_CACHED, &src_clk_freq);
         if (err != ESP_OK) {
             mp_raise_msg_varg(&mp_type_ValueError, MP_ERROR_TEXT("unable to query source clock frequency %d"), (int)timer->clk_cfg);
         }
+        #else
+        // Simplified fallback logic for IDF V5.0.x, for targets with APB only.
+        src_clk_freq = APB_CLK_FREQ; // 80 MHz
+        #if SOC_LEDC_SUPPORT_REF_TICK
+        if (timer->clk_cfg == LEDC_USE_REF_TICK) {
+            src_clk_freq = REF_CLK_FREQ; // 1 MHz
+        }
+        #endif // SOC_LEDC_SUPPORT_REF_TICK
+        #endif // ESP_IDF_VERSION
+
         timer->duty_resolution = ledc_find_suitable_duty_resolution(src_clk_freq, timer->freq_hz);
 
         // Set frequency


### PR DESCRIPTION
### Summary

Restore PWM support for ESP-IDF v5.0.x and v5.1.x. The cleanup in #16090 relies on some functions not available in older ESP-IDF. Temporarily restore support for a possible V1.24.1 bugfix release, before we actually drop support for ESP-IDF <5.2.

(Edit: Dropped the other commit which was in this PR as it wasn't necessary.)

### Testing

* Tried briefly to make a unit test with `machine.time_pulse_us()` as suggested by @dpgeorge [here](https://github.com/micropython/micropython/pull/16090#issuecomment-2445811920). Unfortunately it looks like readback of the same pin that's outputting PWM doesn't currently work - need to either fix that or require a jumper between two pins to run the test.
* Instead, wired up the logic analyser and measured frequencies between 50Hz and 16.667Mhz with some different duty cycles on ESP32, ESP32-C3 and ESP32-S3 and ESP-IDF versions 5.2.2, 5.1 and 5.0.4.

### Trade-offs and Alternatives

* We could drop support for ESP-IDF <5.2 immediately instead of reinstating support here, but that's not very reasonable if there's going to be a V1.24.1 bugfix release.