### PR TITLE
cpydiff: Fix test case for json_nonserializable.

### DIFF
--- a/tests/cpydiff/modules_json_nonserializable.py
+++ b/tests/cpydiff/modules_json_nonserializable.py
@@ -6,10 +6,7 @@ workaround: Unknown
 """
 import json
 
-a = bytes(x for x in range(256))
 try:
-    z = json.dumps(a)
-    x = json.loads(z)
-    print("Should not get here")
+    print(json.dumps(b"shouldn't be able to serialise bytes"))
 except TypeError:
     print("TypeError")


### PR DESCRIPTION
The test case was producing the following error:
```
Traceback (most recent call last):
  File "<stdin>", line 12, in <module>
UnicodeError:
```
which did not demonstrate the intended difference. (this particular non-json-serializable object DID throw an exception! just not TypeError)

The updated version creates the non-conforming json string `"<module 'json'>"` instead, better illustrating the problem.

I tested by manually running the example using a coverage build & in cpython.