### PR TITLE
ports/unix: Add raw REPL support.

### DIFF
--- a/ports/unix/Makefile
+++ b/ports/unix/Makefile
@@ -130,6 +130,7 @@ ifeq ($(MICROPY_USE_READLINE),1)
 INC += -I$(TOP)/shared/readline
 CFLAGS += -DMICROPY_USE_READLINE=1
 SHARED_SRC_C_EXTRA += readline/readline.c
+SHARED_SRC_C_EXTRA += runtime/pyexec.c
 endif
 ifeq ($(MICROPY_PY_TERMIOS),1)
 CFLAGS += -DMICROPY_PY_TERMIOS=1

--- a/ports/unix/main.c
+++ b/ports/unix/main.c
@@ -177,6 +177,9 @@ static int execute_from_lexer(int source_kind, const void *source, mp_parse_inpu
 
 #if MICROPY_USE_READLINE == 1
 #include "shared/readline/readline.h"
+#ifdef __linux__
+#include "shared/runtime/pyexec.h"
+#endif
 #else
 static char *strjoin(const char *s1, int sep_char, const char *s2) {
     int l1 = strlen(s1);
@@ -216,6 +219,19 @@ static int do_repl(void) {
             // cancel input
             mp_hal_stdout_tx_str("\r\n");
             goto input_restart;
+        #ifdef __linux__
+        } else if (ret == CHAR_CTRL_A) {
+            // Enter raw REPL
+            pyexec_mode_kind = PYEXEC_MODE_RAW_REPL;
+            mp_hal_stdout_tx_str("\r\n");
+            int status = pyexec_raw_repl();
+            if (status != 0) {
+                mp_hal_stdio_mode_orig();
+                vstr_clear(&line);
+                return status;
+            }
+            goto input_restart;
+        #endif
         } else if (ret == CHAR_CTRL_D) {
             // EOF
             printf("\n");

--- a/shared/runtime/pyexec.c
+++ b/shared/runtime/pyexec.c
@@ -39,6 +39,7 @@
 #include "irq.h"
 #include "usb.h"
 #endif
+#include "extmod/modplatform.h"
 #include "shared/readline/readline.h"
 #include "shared/runtime/pyexec.h"
 #include "genhdr/mpversion.h"


### PR DESCRIPTION
### Summary

Add raw REPL support to the unix port. This make it possible to connect to a unix micropython instance using mpremote and utilise the functionality of the raw REPL. This is useful for debugging and CI tests of mpremote and related tools.

For example, one can run micropython behind a PTY with `socat` and connect to the slave pty (as if it were a serial port) with `mpremote`:

```bash
socat PTY,link=$HOME/.upy-pty,rawer EXEC:./build-standard/micropython,pty,stderr,onlcr=0 &
mpremote resume connect ~/.upy-pty ls
```
(The `resume` argument is required since micropython v1.24 as a soft reset terminates the micropython process).

or, using the micropython docker image (thanks to @mattytrentini ):

```bash
socat PTY,link=$HOME/.upy-pty,rawer EXEC:"docker run -ti --rm micropython/unix\:v1.23.0",pty,stderr,onlcr=0
```

### Testing

This has been tested using private CI workflows adapted from those in the [`mpremote-path`](https://github.com/glenn20/mpremote-path) tool (which uses `mpremote` as a library).

### Trade-offs and Alternatives

The changes impact only the unix port (adding `pyexec.c` to the build) and present a user-visible change through behaviour when a ctrl-A character is entered at the repl. However, this reflects expected behaviour on other ports and should not impact on expected or supported usage.
