### PR TITLE
tests: get `connect_nonblock_xfer.py` test working again and simplify it

### DIFF
--- a/tests/net_hosted/connect_nonblock_xfer.py.exp
+++ b/tests/net_hosted/connect_nonblock_xfer.py.exp
@@ -1,0 +1,44 @@
+--- Plain sockets to nowhere ---
+connect: EINPROGRESS
+poll:    []
+send er: EAGAIN
+connect: EINPROGRESS
+poll:    []
+write:   None
+connect: EINPROGRESS
+poll:    []
+recv er: EAGAIN
+connect: EINPROGRESS
+poll:    []
+read:    None
+--- SSL sockets to nowhere ---
+connect: EINPROGRESS
+wrap ok: True
+poll:    []
+write:   None
+connect: EINPROGRESS
+wrap ok: True
+poll:    []
+read:    None
+--- Plain sockets ---
+connect: EINPROGRESS
+poll:    []
+send er: EAGAIN
+connect: EINPROGRESS
+poll:    []
+write:   None
+connect: EINPROGRESS
+poll:    []
+recv er: EAGAIN
+connect: EINPROGRESS
+poll:    []
+read:    None
+--- SSL sockets ---
+connect: EINPROGRESS
+wrap ok: True
+poll:    [(<SSLSocket>, 4)]
+write:   4
+connect: EINPROGRESS
+wrap ok: True
+poll:    [(<SSLSocket>, 4)]
+read:    None


### PR DESCRIPTION
### Summary

CPython changed its non-blocking socket behaviour recently and this test would not run under CPython anymore.  So the following steps were taken to get the test working again and then simplify it:
- Run the test against CPython 3.10.10 and capture the output into the .exp file for the test.
- Run this test on unix port of MicroPython and verify that the output matches the CPython 3.10.10 output in the new .exp file (it did).  From now on take unix MicroPython as the source of truth for this test when modifying it.
- Remove all code that was there for CPython compatibility.
- Make it print out more useful information during the test run, including names of the OSError errno values.
- Add polling of the socket before the send/write/recv/read to verify that the poll gives the correct result in non-blocking mode.

As part of this, it was found that bare-metal lwIP boards (eg PYBD_SF2, RPI_PICO_W) failed the test due to non-conforming behaviour of send/write on a non-blocking socket that's not yet connected.  That issue is also fixed in this PR.

### Testing
    
Tested on unix MicroPython, ESP32_GENERIC, PYBD_SF2 and RPI_PICO_W boards.  This test and all existing network tests pass.  Multinet tests pass.

### Trade-offs and Alternatives

Matching CPython behaviour here would be a lot of work and changes to socket code, which now uses `BlockingIOError`.  I don't think we need to do that, not a good use of time, is a big churn of functionality, 
and many things need to be retested and fixed (eg `asyncio`).

esp8266 can't pass this test because axtls doesn't fully support non-blocking mode, so the test is skipped on this platform.  It does actually pass the normal socket (not TLS) bits of this test, but separating those out into a separate test is not worth it, IMO.