### PR TITLE
machine: Add nchanges param to time_pulse_us func.

### DIFF
--- a/docs/library/machine.rst
+++ b/docs/library/machine.rst
@@ -316,6 +316,15 @@ Miscellaneous functions
    microseconds.  The *pulse_level* argument should be 0 to time a low pulse
    or 1 to time a high pulse.
 
+   If the current input value of the pin is different to *pulse_level*,
+   the function first (*) waits until the pin input becomes equal to *pulse_level*,
+   then (**) times the duration that the pin is equal to *pulse_level*.
+
+   The above behaviour is for when nchanges=2. That behaviour can be generalised by
+   passing in a larger value for nchanges which is the number of times the function
+   waits for the pin to change. On error the return value can be down to -nchanges and
+   indicates how many edges were missed.
+
    If *nchanges* is 3, if the pin is initially equal to *pulse_level* then first
    waits until the pin input becomes different from *pulse_level* (***).
    Then if the current input value of the pin is different to *pulse_level*,

--- a/docs/library/machine.rst
+++ b/docs/library/machine.rst
@@ -310,19 +310,23 @@ Miscellaneous functions
    varies by hardware (so use substring of a full value if you expect a short
    ID). In some MicroPython ports, ID corresponds to the network MAC address.
 
-.. function:: time_pulse_us(pin, pulse_level, timeout_us=1000000, /)
+.. function:: time_pulse_us(pin, pulse_level, timeout_us=1000000, nchanges=2, /)
 
    Time a pulse on the given *pin*, and return the duration of the pulse in
    microseconds.  The *pulse_level* argument should be 0 to time a low pulse
    or 1 to time a high pulse.
 
-   If the current input value of the pin is different to *pulse_level*,
-   the function first (*) waits until the pin input becomes equal to *pulse_level*,
-   then (**) times the duration that the pin is equal to *pulse_level*.
+   If *nchanges* is 3, if the pin is initially equal to *pulse_level* then first
+   waits until the pin input becomes different from *pulse_level* (***).
+   Then if the current input value of the pin is different to *pulse_level*,
+   the function first (**)(*nchanges* is 2) waits until the pin input becomes equal to *pulse_level*,
+   then (*)(*nchanges* is 1) times the duration that the pin is equal to *pulse_level*.
    If the pin is already equal to *pulse_level* then timing starts straight away.
+   Higher values of *nchanges* are possible, which allow more synchronisation.
 
+   The function returns -3 if there was timeout waiting for condition marked (***) above.
    The function will return -2 if there was timeout waiting for condition marked
-   (*) above, and -1 if there was timeout during the main measurement, marked (**)
+   (**) above, and -1 if there was timeout during the main measurement, marked (*)
    above. The timeout is the same for both cases and given by *timeout_us* (which
    is in microseconds).
 

--- a/drivers/dht/dht.c
+++ b/drivers/dht/dht.c
@@ -72,7 +72,7 @@ static mp_obj_t dht_readinto(mp_obj_t pin_in, mp_obj_t buf_in) {
     }
 
     // time pulse, should be 80us
-    ticks = machine_time_pulse_us(pin, 1, 150);
+    ticks = machine_time_pulse_us(pin, 1, 150, 2);
     if ((mp_int_t)ticks < 0) {
         goto timeout;
     }
@@ -80,7 +80,7 @@ static mp_obj_t dht_readinto(mp_obj_t pin_in, mp_obj_t buf_in) {
     // time 40 pulses for data (either 26us or 70us)
     uint8_t *buf = bufinfo.buf;
     for (int i = 0; i < 40; ++i) {
-        ticks = machine_time_pulse_us(pin, 1, 100);
+        ticks = machine_time_pulse_us(pin, 1, 100, 2);
         if ((mp_int_t)ticks < 0) {
             goto timeout;
         }

--- a/extmod/machine_pulse.c
+++ b/extmod/machine_pulse.c
@@ -30,8 +30,7 @@
 
 #if MICROPY_PY_MACHINE_PULSE
 
-mp_uint_t machine_time_pulse_us(mp_hal_pin_obj_t pin, int pulse_level, mp_uint_t timeout_us) {
-    mp_uint_t nchanges = 2;
+mp_uint_t machine_time_pulse_us(mp_hal_pin_obj_t pin, int pulse_level, mp_uint_t timeout_us, mp_uint_t nchanges) {
     mp_uint_t start = mp_hal_ticks_us();
     for (;;) {
         // Sample ticks and pin as close together as possible, and always in the same
@@ -71,10 +70,14 @@ static mp_obj_t machine_time_pulse_us_(size_t n_args, const mp_obj_t *args) {
     if (n_args > 2) {
         timeout_us = mp_obj_get_int(args[2]);
     }
-    mp_uint_t us = machine_time_pulse_us(pin, level, timeout_us);
-    // May return -1 or -2 in case of timeout
+    mp_uint_t nchanges = 2;
+    if (n_args > 3) {
+        nchanges = mp_obj_get_int(args[3]);
+    }
+    mp_uint_t us = machine_time_pulse_us(pin, level, timeout_us, nchanges);
+    // May return -1 or -2 or -3 in case of timeout
     return mp_obj_new_int(us);
 }
-MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(machine_time_pulse_us_obj, 2, 3, machine_time_pulse_us_);
+MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(machine_time_pulse_us_obj, 2, 4, machine_time_pulse_us_);
 
 #endif

--- a/extmod/machine_pulse.c
+++ b/extmod/machine_pulse.c
@@ -75,7 +75,7 @@ static mp_obj_t machine_time_pulse_us_(size_t n_args, const mp_obj_t *args) {
         nchanges = mp_obj_get_int(args[3]);
     }
     mp_uint_t us = machine_time_pulse_us(pin, level, timeout_us, nchanges);
-    // May return -1 or -2 or -3 in case of timeout
+    // May return from -1 to -nchanges in case of timeout
     return mp_obj_new_int(us);
 }
 MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(machine_time_pulse_us_obj, 2, 4, machine_time_pulse_us_);

--- a/extmod/modmachine.h
+++ b/extmod/modmachine.h
@@ -261,7 +261,7 @@ uintptr_t MICROPY_MACHINE_MEM_GET_WRITE_ADDR(mp_obj_t addr_o, uint align);
 
 MP_NORETURN mp_obj_t machine_bootloader(size_t n_args, const mp_obj_t *args);
 void machine_bitstream_high_low(mp_hal_pin_obj_t pin, uint32_t *timing_ns, const uint8_t *buf, size_t len);
-mp_uint_t machine_time_pulse_us(mp_hal_pin_obj_t pin, int pulse_level, mp_uint_t timeout_us);
+mp_uint_t machine_time_pulse_us(mp_hal_pin_obj_t pin, int pulse_level, mp_uint_t timeout_us, mp_uint_t nchanges);
 
 MP_DECLARE_CONST_FUN_OBJ_0(machine_unique_id_obj);
 MP_DECLARE_CONST_FUN_OBJ_0(machine_reset_obj);

--- a/tests/extmod/machine_pulse.py
+++ b/tests/extmod/machine_pulse.py
@@ -40,3 +40,5 @@ print(type(t))
 p = ConstPin(0)
 print(machine.time_pulse_us(p, 1, 10))
 print(machine.time_pulse_us(p, 0, 10))
+
+machine.time_pulse_us(p, 0, 10, 3)

--- a/tests/extmod_hardware/machine_pwm.py
+++ b/tests/extmod_hardware/machine_pwm.py
@@ -59,14 +59,11 @@ def _test_freq_duty(self, pulse_in, pwm, freq, duty_u16):
     expected_us = (expected_low_us, expected_high_us)
     timeout = 2 * expected_total_us
 
-    # Wait for output to settle.
-    time_pulse_us(pulse_in, 0, timeout)
-    time_pulse_us(pulse_in, 1, timeout)
-
     if duty_u16 == 0 or duty_u16 == 65535:
         # Expect a constant output level.
         no_pulse = (
-            time_pulse_us(pulse_in, 0, timeout) < 0 and time_pulse_us(pulse_in, 1, timeout) < 0
+            time_pulse_us(pulse_in, 0, timeout, 3) < 0
+            and time_pulse_us(pulse_in, 1, timeout, 3) < 0
         )
         self.assertTrue(no_pulse)
         if expected_high_us == 0:
@@ -80,9 +77,8 @@ def _test_freq_duty(self, pulse_in, pwm, freq, duty_u16):
         n_averaging = 10
         for level in (0, 1):
             t = 0
-            time_pulse_us(pulse_in, level, timeout)
             for _ in range(n_averaging):
-                t += time_pulse_us(pulse_in, level, timeout)
+                t += time_pulse_us(pulse_in, level, timeout, 3)
             t //= n_averaging
             expected = expected_us[level]
             print(" level={} timing_er={}".format(level, abs(t - expected)), end="")

--- a/tests/extmod_hardware/machine_pwm.py
+++ b/tests/extmod_hardware/machine_pwm.py
@@ -78,10 +78,10 @@ def _test_freq_duty(self, pulse_in, pwm, freq, duty_u16):
         for level in (0, 1):
             t = 0
             for _ in range(n_averaging):
-                t += time_pulse_us(pulse_in, level, timeout, 3)
+                t += time_pulse_us(pulse_in, level, timeout, 4)
             t //= n_averaging
             expected = expected_us[level]
-            print(" level={} timing_er={}".format(level, abs(t - expected)), end="")
+            print(" level={} timing_er={}".format(level, abs(t - expected)), end=" :")
             self.assertLessEqual(abs(t - expected), timing_margin_us)
 
     print()

--- a/tests/extmod_hardware/machine_pwm.py
+++ b/tests/extmod_hardware/machine_pwm.py
@@ -62,8 +62,7 @@ def _test_freq_duty(self, pulse_in, pwm, freq, duty_u16):
     if duty_u16 == 0 or duty_u16 == 65535:
         # Expect a constant output level.
         no_pulse = (
-            time_pulse_us(pulse_in, 0, timeout, 3) < 0
-            and time_pulse_us(pulse_in, 1, timeout, 3) < 0
+            time_pulse_us(pulse_in, 0, timeout) < 0 and time_pulse_us(pulse_in, 1, timeout) < 0
         )
         self.assertTrue(no_pulse)
         if expected_high_us == 0:


### PR DESCRIPTION
time_pulse_us(pin, pulse_level, timeout_us=1000000, **nchanges=2**, /)

If `nchanges` is 3, if the pin is initially equal to *pulse_level* then first
waits until the pin input becomes different from *pulse_level*.
Then if the current input value of the pin is different to *pulse_level*,
the function first waits until the pin input becomes equal to *pulse_level*,
then times the duration that the pin is equal to *pulse_level*.

**The advantage is that there is no need for additional synchronization before measuring the pulse duration.**
A little bit longer, but with higher accuracy.

The jitter of the pulse measurement process is about 5-15 μs on the ESP32 board.

Idia from @robert-hh https://github.com/micropython/micropython/pull/16147#issuecomment-2454287302

This function is used in DRAFT PR for tests
**PWM from 10845 and time_hardware_pulse_us() and test from 16147.** #16161
The tests results show the functionality of the function over the entire ESP32 PWM frequency range from 1Hz to 40MHz.
