### PR TITLE
py/mkrules.mk: Use partial clone for submodules if available.

### DIFF
--- a/py/mkrules.mk
+++ b/py/mkrules.mk
@@ -252,7 +252,11 @@ submodules:
 	$(ECHO) "Updating submodules: $(GIT_SUBMODULES)"
 ifneq ($(GIT_SUBMODULES),)
 	$(Q)cd $(TOP) && git submodule sync $(GIT_SUBMODULES)
-	$(Q)cd $(TOP) && git submodule update --init $(GIT_SUBMODULES)
+	# If available, do blobless partial clones of submodules to save time and space.
+	# A blobless partial clone lazily fetches data as needed, but has all the metadata available (tags, etc.).
+	# Fallback to standard submodule update if blobless isn't available (earlier than 2.36.0)
+	$(Q)cd $(TOP) && git submodule update --init --filter=blob:none $(GIT_SUBMODULES) || \
+	  git submodule update --init $(GIT_SUBMODULES)
 endif
 .PHONY: submodules
 


### PR DESCRIPTION
### Summary

Micropython relies on a number of submodules for third party and chip vendor libraries. Users need to check these out before building their desired ports and Github Actions CI here needs to clone them all multiple times for every build.

Many of these are getting significantly larger over time, slowing down usage and consuming more disk space.  There can also be resistance to adding larger libraries / sdk's here as submodules to avoid these sort of issues.

As suggested in https://github.com/micropython/micropython/pull/11349#issuecomment-1524305575 by @dhalbert newer version of git have features to avoid pulling all historic / blob data which can have a significant impact of total data use.

The change here has been directly inspired by https://github.com/adafruit/circuitpython/issues/7225 and https://github.com/adafruit/circuitpython/pull/7788

### Testing

Very little so far, it's been pushed here to trigger CI to ensure it still passes and hopefully get an idea of any speed improvements gained.

This is using a standard feature of git with automatic fallback to previous behavior on error.

### Trade-offs and Alternatives

Shallow clone is the more common way of achieving this but that often results in issues due to the lack of history metadata, particularly around versions derived from tags etc. While that's less often an issue in submodules this filter method is generally considered a safer means of gaining similar size improvements.
