### PR TITLE
tools/mpremote: Support trailing slash on dest for non-recursive copy.

### DIFF
--- a/tools/mpremote/mpremote/commands.py
+++ b/tools/mpremote/mpremote/commands.py
@@ -129,8 +129,15 @@ def _remote_path_basename(a):
 
 def do_filesystem_cp(state, src, dest, multiple, check_hash=False):
     if dest.startswith(":"):
-        dest_exists = state.transport.fs_exists(dest[1:])
-        dest_isdir = dest_exists and state.transport.fs_isdir(dest[1:])
+        dest_no_slash = dest.rstrip("/" + os.path.sep + (os.path.altsep or ""))
+        dest_exists = state.transport.fs_exists(dest_no_slash[1:])
+        dest_isdir = dest_exists and state.transport.fs_isdir(dest_no_slash[1:])
+
+        # A trailing / on dest forces it to be a directory.
+        if dest != dest_no_slash:
+            if not dest_isdir:
+                raise CommandError("cp: destination is not a directory")
+            dest = dest_no_slash
     else:
         dest_exists = os.path.exists(dest)
         dest_isdir = dest_exists and os.path.isdir(dest)

--- a/tools/mpremote/mpremote/main.py
+++ b/tools/mpremote/mpremote/main.py
@@ -547,7 +547,10 @@ def main():
 
         return 0
     except CommandError as e:
+        # Make sure existing stdout appears before the error message on stderr.
+        sys.stdout.flush()
         print(f"{_PROG}: {e}", file=sys.stderr)
+        sys.stderr.flush()
         return 1
     finally:
         do_disconnect(state)

--- a/tools/mpremote/tests/run-mpremote-tests.sh
+++ b/tools/mpremote/tests/run-mpremote-tests.sh
@@ -16,7 +16,7 @@ for t in $TESTS; do
     TMP=$(mktemp -d)
     echo -n "${t}: "
     # Strip CR and replace the random temp dir with a token.
-    if env MPREMOTE=${MPREMOTE} TMP="${TMP}" "${t}" | tr -d '\r' | sed "s,${TMP},"'${TMP},g' > "${t}.out"; then
+    if env MPREMOTE=${MPREMOTE} TMP="${TMP}" "${t}" 2>&1 | tr -d '\r' | sed "s,${TMP},"'${TMP},g' > "${t}.out"; then
         if diff "${t}.out" "${t}.exp" > /dev/null; then
             echo "OK"
         else

--- a/tools/mpremote/tests/test_filesystem.sh
+++ b/tools/mpremote/tests/test_filesystem.sh
@@ -66,6 +66,11 @@ $MPREMOTE resume cp "${TMP}/a.py" :aaa
 $MPREMOTE resume cp "${TMP}/a.py" :bbb/b.py
 $MPREMOTE resume cat :aaa/a.py bbb/b.py
 
+# Test cp -f (force copy).
+echo -----
+$MPREMOTE resume cp -f "${TMP}/a.py" :aaa
+$MPREMOTE resume cat :aaa/a.py
+
 echo -----
 $MPREMOTE resume rm :b.py c.py
 $MPREMOTE resume ls

--- a/tools/mpremote/tests/test_filesystem.sh
+++ b/tools/mpremote/tests/test_filesystem.sh
@@ -71,6 +71,11 @@ echo -----
 $MPREMOTE resume cp -f "${TMP}/a.py" :aaa
 $MPREMOTE resume cat :aaa/a.py
 
+# Test cp where the destination has a trailing /.
+echo -----
+$MPREMOTE resume cp "${TMP}/a.py" :aaa/
+$MPREMOTE resume cp "${TMP}/a.py" :aaa/a.py/ || echo "expect error"
+
 echo -----
 $MPREMOTE resume rm :b.py c.py
 $MPREMOTE resume ls

--- a/tools/mpremote/tests/test_filesystem.sh.exp
+++ b/tools/mpremote/tests/test_filesystem.sh.exp
@@ -42,6 +42,12 @@ cp ${TMP}/a.py :aaa
 print("Hello")
 print("World")
 -----
+cp ${TMP}/a.py :aaa/
+Up to date: aaa/a.py
+cp ${TMP}/a.py :aaa/a.py/
+mpremote: cp: destination is not a directory
+expect error
+-----
 rm :b.py
 rm :c.py
 ls :

--- a/tools/mpremote/tests/test_filesystem.sh.exp
+++ b/tools/mpremote/tests/test_filesystem.sh.exp
@@ -38,6 +38,10 @@ print("World")
 print("Hello")
 print("World")
 -----
+cp ${TMP}/a.py :aaa
+print("Hello")
+print("World")
+-----
 rm :b.py
 rm :c.py
 ls :


### PR DESCRIPTION
### Summary

This fixes a regression in db59e55fe7a0b67d3af868990468e7b8056afe42: prior to that commit `mpremote` supported trailing slashes on the destination of a normal (non-recursive) copy.

Add back support for that, with the semantics that a trailing slash requires the destination to be an existing directory.

### Testing

A test has been added to the `mpremote` tests (also a test for force copy, in a separate commit).  As part of getting the test working, needed to flush stdout before printing error messages to stderr.

The `mpremote` tests were then run on a PYBD_SF2.  They passed.