### PR TITLE
esp32: Workaround native code execution crash on ESP32-S2.

### DIFF
--- a/ports/esp32/main.c
+++ b/ports/esp32/main.c
@@ -39,6 +39,7 @@
 #include "esp_task.h"
 #include "esp_event.h"
 #include "esp_log.h"
+#include "esp_memory_utils.h"
 #include "esp_psram.h"
 
 #include "py/cstack.h"
@@ -237,6 +238,13 @@ void *esp_native_code_commit(void *buf, size_t len, void *reloc) {
     len = (len + 3) & ~3;
     size_t len_node = sizeof(native_code_node_t) + len;
     native_code_node_t *node = heap_caps_malloc(len_node, MALLOC_CAP_EXEC);
+    #if CONFIG_IDF_TARGET_ESP32S2
+    // Workaround for ESP-IDF bug https://github.com/espressif/esp-idf/issues/14835
+    if (node != NULL && !esp_ptr_executable(node)) {
+        free(node);
+        node = NULL;
+    }
+    #endif // CONFIG_IDF_TARGET_ESP32S2
     if (node == NULL) {
         m_malloc_fail(len_node);
     }


### PR DESCRIPTION
### Summary

@dpgeorge found that ESP-IDF V5.2.2 incorrectly returns RTC FAST memory Data Bus addresses as MALLOC_CAP_EXEC on ESP32-S2 when it isn't. This memory is the lowest priority, so it only is returned if D/IRAM is exhausted. Reported upstream at https://github.com/espressif/esp-idf/issues/14835

Apply this workaround to treat the allocation as failed if it gives us non-executable RAM back, rather than crashing.

*This work was funded through GitHub Sponsors.*

### Testing

```
$ cat hello.py
print("Hello world")
$ mpy-cross -X emit=native -march=xtensawin hello.py
$ mpremote cp hello.mpy :
cp hello.mpy :
```

Without connecting Wi-Fi:

```
>>> import hello
Hello world
```

With Wi-Fi connected (i.e. less ESP-IDF heap available) and without this patch:

```
>>> import hello

A fatal error occurred. The crash dump printed below may be used to help
determine what caused it. If you are not already running the most recent
version of MicroPython, consider upgrading. New versions often fix bugs.

To learn more about how to debug and/or report this crash visit the wiki
page at: https://github.com/micropython/micropython/wiki/ESP32-debugging

MPY version : v1.25.0-preview.19.g594670e446 on 2024-11-06
IDF version : v5.2.2
Machine     : Generic ESP32S2 module with ESP32S2

Guru Meditation Error: Core  0 panic'ed (InstructionFetchError). Exception was unhandled.

Core  0 register dump:
PC      : 0x3ff9e49c  PS      : 0x00060b30  A0      : 0x80097890  A1      : 0x3ffe1220  
A2      : 0x3f801b90  A3      : 0x00000000  A4      : 0x00000000  A5      : 0x00000000  
A6      : 0x3f801d90  A7      : 0x00000000  A8      : 0x80090360  A9      : 0x3ffe11f0  
A10     : 0x3f801b90  A11     : 0x00000000  A12     : 0x00000000  A13     : 0x00000000  
A14     : 0x00000001  A15     : 0x00000420  SAR     : 0x0000001c  EXCCAUSE: 0x00000002  
EXCVADDR: 0x3ff9e49c  LBEG    : 0x00000000  LEND    : 0x00000000  LCOUNT  : 0x40028c4c  
```

With Wi-Fi connected and this patch:

```
>>> import hello
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
MemoryError: memory allocation failed, allocating 100 bytes
>>> wlan.disconnect()
>>> import hello
Hello world
```

* Also compiled this patch on IDF V5.0.4. No errors appear there, the heap structure appears to be different (D/IRAM is not used up as quickly, and RTC FAST memory isn't mis-labelled as executable). So this patch has no effect (but still compiles).