### PR TITLE
esp32: Fix stuck TouchPad readings on ESP32-S3, use version specifiers in code.

### DIFF
--- a/docs/esp32/quickref.rst
+++ b/docs/esp32/quickref.rst
@@ -751,20 +751,33 @@ APA102 (DotStar) uses a different driver as it has an additional clock pin.
 Capacitive touch
 ----------------
 
-Use the ``TouchPad`` class in the ``machine`` module::
+ESP32, ESP32-S2 and ESP32-S3 support capacitive touch via the ``TouchPad`` class
+in the ``machine`` module::
 
     from machine import TouchPad, Pin
 
     t = TouchPad(Pin(14))
     t.read()              # Returns a smaller number when touched
 
-``TouchPad.read`` returns a value relative to the capacitive variation. Small numbers (typically in
-the *tens*) are common when a pin is touched, larger numbers (above *one thousand*) when
-no touch is present. However the values are *relative* and can vary depending on the board
-and surrounding composition so some calibration may be required.
+``TouchPad.read`` returns a value proportional to the capacitance between the
+pin and the board's Ground connection. On ESP32 the number becomes smaller when
+the pin (or connected touch pad) is touched, on ESP32-S2 and ESP32-S3 the number
+becomes larger when the pin is touched.
 
-There are ten capacitive touch-enabled pins that can be used on the ESP32: 0, 2, 4, 12, 13
-14, 15, 27, 32, 33. Trying to assign to any other pins will result in a ``ValueError``.
+In all cases, a touch causes a significant change in the return value. Note the
+returned values are *relative* and can vary depending on the board and
+surrounding environment so some calibration (i.e. comparison to a baseline or
+rolling average) may be required.
+
+========= ==============================================
+Chip      Touch-enabled pins
+--------- ----------------------------------------------
+ESP32     0, 2, 4, 12, 13, 14, 15, 27, 32, 33
+ESP32-S2  1 to 14 inclusive
+ESP32-S3  1 to 14 inclusive
+========= ==============================================
+
+Trying to assign to any other pins will result in a ``ValueError``.
 
 Note that TouchPads can be used to wake an ESP32 from sleep::
 

--- a/ports/esp32/machine_touchpad.c
+++ b/ports/esp32/machine_touchpad.c
@@ -29,12 +29,14 @@
 #include "modmachine.h"
 #include "driver/gpio.h"
 
-#if CONFIG_IDF_TARGET_ESP32 || CONFIG_IDF_TARGET_ESP32S2 || CONFIG_IDF_TARGET_ESP32S3
+#if SOC_TOUCH_SENSOR_SUPPORTED
 
-#if CONFIG_IDF_TARGET_ESP32
+#if SOC_TOUCH_VERSION_1 // ESP32 only
 #include "driver/touch_pad.h"
-#elif CONFIG_IDF_TARGET_ESP32S2 || CONFIG_IDF_TARGET_ESP32S3
+#elif SOC_TOUCH_VERSION_2 // All other SoCs with touch, to date
 #include "driver/touch_sensor.h"
+#else
+#error "Unknown touch hardware version"
 #endif
 
 typedef struct _mtp_obj_t {
@@ -70,6 +72,8 @@ static const mtp_obj_t touchpad_obj[] = {
     {{&machine_touchpad_type}, GPIO_NUM_12, TOUCH_PAD_NUM12},
     {{&machine_touchpad_type}, GPIO_NUM_13, TOUCH_PAD_NUM13},
     {{&machine_touchpad_type}, GPIO_NUM_14, TOUCH_PAD_NUM14},
+    #else
+    #error "Please add GPIO mapping for this SoC"
     #endif
 };
 
@@ -92,14 +96,14 @@ static mp_obj_t mtp_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_
     if (!initialized) {
         touch_pad_init();
         touch_pad_set_fsm_mode(TOUCH_FSM_MODE_TIMER);
-        #if CONFIG_IDF_TARGET_ESP32S2 || CONFIG_IDF_TARGET_ESP32S3
+        #if TOUCH_HW_VER == 2
         touch_pad_fsm_start();
         #endif
         initialized = 1;
     }
-    #if CONFIG_IDF_TARGET_ESP32
+    #if SOC_TOUCH_VERSION_1
     esp_err_t err = touch_pad_config(self->touchpad_id, 0);
-    #elif CONFIG_IDF_TARGET_ESP32S2 || CONFIG_IDF_TARGET_ESP32S3
+    #elif SOC_TOUCH_VERSION_2
     esp_err_t err = touch_pad_config(self->touchpad_id);
     #endif
     if (err == ESP_OK) {
@@ -110,10 +114,10 @@ static mp_obj_t mtp_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_
 
 static mp_obj_t mtp_config(mp_obj_t self_in, mp_obj_t value_in) {
     mtp_obj_t *self = self_in;
-    #if CONFIG_IDF_TARGET_ESP32
+    #if SOC_TOUCH_VERSION_1
     uint16_t value = mp_obj_get_int(value_in);
     esp_err_t err = touch_pad_config(self->touchpad_id, value);
-    #elif CONFIG_IDF_TARGET_ESP32S2 || CONFIG_IDF_TARGET_ESP32S3
+    #elif SOC_TOUCH_VERSION_2
     esp_err_t err = touch_pad_config(self->touchpad_id);
     #endif
     if (err == ESP_OK) {
@@ -125,10 +129,10 @@ MP_DEFINE_CONST_FUN_OBJ_2(mtp_config_obj, mtp_config);
 
 static mp_obj_t mtp_read(mp_obj_t self_in) {
     mtp_obj_t *self = self_in;
-    #if CONFIG_IDF_TARGET_ESP32
+    #if SOC_TOUCH_VERSION_1
     uint16_t value;
     esp_err_t err = touch_pad_read(self->touchpad_id, &value);
-    #elif CONFIG_IDF_TARGET_ESP32S2 || CONFIG_IDF_TARGET_ESP32S3
+    #elif SOC_TOUCH_VERSION_2
     uint32_t value;
     esp_err_t err = touch_pad_read_raw_data(self->touchpad_id, &value);
     #endif
@@ -155,4 +159,4 @@ MP_DEFINE_CONST_OBJ_TYPE(
     locals_dict, &mtp_locals_dict
     );
 
-#endif
+#endif // SOC_TOUCH_SENSOR_SUPPORTED

--- a/ports/esp32/machine_touchpad.c
+++ b/ports/esp32/machine_touchpad.c
@@ -96,9 +96,6 @@ static mp_obj_t mtp_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_
     if (!initialized) {
         touch_pad_init();
         touch_pad_set_fsm_mode(TOUCH_FSM_MODE_TIMER);
-        #if TOUCH_HW_VER == 2
-        touch_pad_fsm_start();
-        #endif
         initialized = 1;
     }
     #if SOC_TOUCH_VERSION_1
@@ -107,6 +104,10 @@ static mp_obj_t mtp_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_
     esp_err_t err = touch_pad_config(self->touchpad_id);
     #endif
     if (err == ESP_OK) {
+        #if SOC_TOUCH_VERSION_2
+        touch_pad_fsm_start();
+        #endif
+
         return MP_OBJ_FROM_PTR(self);
     }
     mp_raise_ValueError(MP_ERROR_TEXT("Touch pad error"));


### PR DESCRIPTION
### Summary

* Updates the `machine.TouchPad` driver to use hardware version specifiers instead of chip names. This should make adding future SoCs easier.
* Fixes #13178, by updating the fix applied in #8955.
* Update the docs for ESP32-S3 and ESP32-S3 TouchPad differences.

The new order of initialisation matches more closely the order in Espressif's example code, i.e.
https://github.com/espressif/esp-idf/blob/v5.2.2/examples/peripherals/touch_sensor/touch_sensor_v2/touch_pad_read/main/tp_read_main.c#L86

*This work was funded through GitHub Sponsors.*

### Testing

* Tested on ESP32, ESP32-S2 and ESP32-S3 using the example code from the linked issue. Plus a similar example which initialised multiple channels.
* Unfortunately I had no working boards with PCB touch pads, so used dupont wires hanging off dev board connections... Works well enough.
 
The only buggy case of stuck max readings that I was able to reproduce was on ESP32-S3, and never reproduced once the fix was applied.

The hardware FSM did seem to get stuck once on ESP32-S3 in a different way (was reading correctly and then stopped updating and didn't start again). However I think this was due to my poor quality touch pad inputs (had moved the wires a lot and it would have changed capacitance by a huge factor).

### Trade-offs and Alternatives

* The Espressif touch sensor V2 hardware in S2 and S3 has a lot of features (denoise, background averaging, etc) which MicroPython is not using. It'd be good to support this, although it'd be a lot of work for someone and also may break code that relies on the current "raw" readings.