### PR TITLE
ports/esp32/usb.c: Allow serial/jtag to be enabled.

### DIFF
--- a/ports/esp32/usb.c
+++ b/ports/esp32/usb.c
@@ -30,13 +30,12 @@
 
 #include "esp_rom_gpio.h"
 #include "esp_mac.h"
-#include "esp_private/usb_phy.h"
 
-static usb_phy_handle_t phy_hdl;
 
 #if MICROPY_HW_USB_CDC
-
 #include "shared/tinyusb/mp_usbd.h"
+#include "esp_private/usb_phy.h"
+static usb_phy_handle_t phy_hdl;
 
 
 
@@ -67,10 +66,13 @@ void mp_usbd_port_get_serial_number(char *serial_buf) {
     mp_usbd_hex_str(serial_buf, mac, sizeof(mac));
 }
 
-#endif // MICROPY_HW_USB_CDC
-
+#else // !MICROPY_HW_USB_CDC
 
 #if CONFIG_IDF_TARGET_ESP32S3
+
+#include "esp_private/usb_phy.h"
+static usb_phy_handle_t phy_hdl;
+
 void usb_usj_mode(void) {
     // Switch the USB PHY back to Serial/Jtag mode, disabling OTG support
     // This should be run before jumping to bootloader.
@@ -81,3 +83,5 @@ void usb_usj_mode(void) {
     usb_new_phy(&phy_conf, &phy_hdl);
 }
 #endif
+
+#endif // MICROPY_HW_USB_CDC

--- a/ports/esp32/usb.c
+++ b/ports/esp32/usb.c
@@ -66,12 +66,14 @@ void mp_usbd_port_get_serial_number(char *serial_buf) {
     mp_usbd_hex_str(serial_buf, mac, sizeof(mac));
 }
 
-#else // !MICROPY_HW_USB_CDC
+#endif
 
 #if CONFIG_IDF_TARGET_ESP32S3
 
+#if !MICROPY_HW_USB_CDC
 #include "esp_private/usb_phy.h"
 static usb_phy_handle_t phy_hdl;
+#endif
 
 void usb_usj_mode(void) {
     // Switch the USB PHY back to Serial/Jtag mode, disabling OTG support
@@ -84,4 +86,3 @@ void usb_usj_mode(void) {
 }
 #endif
 
-#endif // MICROPY_HW_USB_CDC


### PR DESCRIPTION
### Summary

I was having an issue getting USB serial going on an ESP32S3 LilyGO T-Deck, the flavor that is called "Serial/JTAG mode" in Micropython (not the one where there's an explicit serial -> USB chip onboard.) 

The REPL appears fine on the UART chip models. But on the T-Deck (and presumably other boards with no explicit UART chip) I cannot see or type into the REPL from the serial monitor. 

If i set in mpconfigport.h: 
```c
#define MICROPY_HW_USB_CDC (1)
#define MICROPY_HW_ESP_USB_SERIAL_JTAG (1)
```

I get a compiler error:  `#error "Invalid build config: Can't enable both native USB and USB Serial/JTAG peripheral"`. OK, so for the T-Deck I turn off HW_USB_CDC: 

```c
#ifdef TDECK
#define MICROPY_HW_USB_CDC (0)
#else
#define MICROPY_HW_USB_CDC (1)
#endif
```

But then ports/esp32/usb.c has a #ifdef for `MICROPY_HW_USB_CDC` bracketed around the entire code, including `usb_usj_mode` which is required in the bootloader. So, if i'm understanding it right -- we can't have both `USB_CDC` and `USB_SERIAL_JTAG` on at once. Makes sense. But `usb_usj_mode` requires `USB_CDC` to be enabled to switch the PHY back to Serial/JTAG mode. That doesn't make sense to me. So this PR moves the `#ifdef` out of the way of `usb_usj_mode`. 

### Testing

With this, everything compiles fine and I'm able to use `mpremote` etc to control the T-Deck over Serial/JTAG. 

