### PR TITLE
extmod/vfs_blockdev: Support bool return from Python read/write blocks.

### DIFF
--- a/extmod/vfs_blockdev.c
+++ b/extmod/vfs_blockdev.c
@@ -58,6 +58,13 @@ static int mp_vfs_blockdev_call_rw(mp_obj_t *args, size_t block_num, size_t bloc
     if (ret == mp_const_none) {
         return 0;
     } else {
+        // Some block devices return a bool indicating success, so
+        // convert those to an errno integer code.
+        if (ret == mp_const_true) {
+            return 0;
+        } else if (ret == mp_const_false) {
+            return -MP_EIO;
+        }
         // Block device functions are expected to return 0 on success
         // and negative integer on errors. Check for positive integer
         // results as some callers (i.e. littlefs) will produce corrupt


### PR DESCRIPTION
### Summary

Commit f4ab9d924790581989f2398fe30bbac5d680577f inadvertently broke some Python block devices, for example esp32 and stm32 SDCard classes.  Those classes return a bool from their `readblocks` and `writeblocks` methods instead of an integer errno code.  With that change, both `False` and `True` return values are now be interpreted as non-zero and hence the block device call fails.

The fix in this commit is to allow a bool and explicitly convert `True` to 0 and `False` to `-MP_EIO`.

Fixes issues #16171 and #16214.

### Testing

Tested on PYBV11 using:
```py
import pyb, vfs
sdcard = pyb.SDCard()
vfs.VfsFat(sdcard)
```
That would previously fail, but with this patch passes.

Tested also on ESP32 (a Lolin 32 Pro).  Wit this patch mounting an SD card passes.

### Trade-offs and Alternatives

This is a simple fix and a candidate for a patch release (1.24.1).  An alternative is to make the Python blockdev functions return integers instead of bools, but that's an API change.

Edit: see #16223 for the alternative.
