### PR TITLE
ports/rp2: Fix SparkFun Pro Micro RP2040 image

### DIFF
--- a/ports/rp2/boards/SPARKFUN_PROMICRO/board.json
+++ b/ports/rp2/boards/SPARKFUN_PROMICRO/board.json
@@ -11,7 +11,7 @@
         "USB-C"
     ],
     "images": [
-        "17745-SparkFun_Thing_Plus_-_RP2040-01a.jpg"
+        "18288-SparkFun_Pro_Micro_-_RP2040-01.jpg"
     ],
     "mcu": "rp2040",
     "product": "Pro Micro RP2040",


### PR DESCRIPTION
### Summary

Fix to use correct image: https://github.com/micropython/micropython-media/pull/73

### Testing

N/A
