### PR TITLE
unix/mpthreadport: Work around lack of thread cancellation on Android.

### DIFF
--- a/ports/unix/mpthreadport.c
+++ b/ports/unix/mpthreadport.c
@@ -45,8 +45,14 @@
 // potential conflict with other uses of the more commonly used SIGUSR1.
 #ifdef SIGRTMIN
 #define MP_THREAD_GC_SIGNAL (SIGRTMIN + 5)
+#ifdef __ANDROID__
+#define MP_THREAD_TERMINATE_SIGNAL (SIGRTMIN + 6)
+#endif
 #else
 #define MP_THREAD_GC_SIGNAL (SIGUSR1)
+#ifdef __ANDROID__
+#define MP_THREAD_TERMINATE_SIGNAL (SIGUSR2)
+#endif
 #endif
 
 // This value seems to be about right for both 32-bit and 64-bit builds.
@@ -107,6 +113,18 @@ static void mp_thread_gc(int signo, siginfo_t *info, void *context) {
     }
 }
 
+// On Android, pthread_cancel and pthread_setcanceltype are not implemented.
+// To achieve that result a new signal handler responding on either
+// (SIGRTMIN + 6) or SIGUSR2 is installed on every child thread.  The sole
+// purpose of this new signal handler is to terminate the thread in a safe
+// asynchronous manner.
+
+#ifdef __ANDROID__
+static void mp_thread_terminate(int signo, siginfo_t *info, void *context) {
+    pthread_exit(NULL);
+}
+#endif
+
 void mp_thread_init(void) {
     pthread_key_create(&tls_key, NULL);
     pthread_setspecific(tls_key, &mp_state_ctx.thread);
@@ -135,6 +153,14 @@ void mp_thread_init(void) {
     sa.sa_sigaction = mp_thread_gc;
     sigemptyset(&sa.sa_mask);
     sigaction(MP_THREAD_GC_SIGNAL, &sa, NULL);
+
+    // Install a signal handler for asynchronous termination if needed.
+    #if defined(__ANDROID__)
+    sa.sa_flags = SA_SIGINFO;
+    sa.sa_sigaction = mp_thread_terminate;
+    sigemptyset(&sa.sa_mask);
+    sigaction(MP_THREAD_TERMINATE_SIGNAL, &sa, NULL);
+    #endif
 }
 
 void mp_thread_deinit(void) {
@@ -142,7 +168,11 @@ void mp_thread_deinit(void) {
     while (thread->next != NULL) {
         mp_thread_t *th = thread;
         thread = thread->next;
+        #if defined(__ANDROID__)
+        pthread_kill(th->id, MP_THREAD_TERMINATE_SIGNAL);
+        #else
         pthread_cancel(th->id);
+        #endif
         free(th);
     }
     mp_thread_unix_end_atomic_section();
@@ -200,7 +230,9 @@ void mp_thread_start(void) {
     }
     #endif
 
+    #if !defined(__ANDROID__)
     pthread_setcanceltype(PTHREAD_CANCEL_ASYNCHRONOUS, NULL);
+    #endif
     mp_thread_unix_begin_atomic_section();
     for (mp_thread_t *th = thread; th != NULL; th = th->next) {
         if (th->id == pthread_self()) {


### PR DESCRIPTION
### Summary

This commit fixes thread-related compilation issues under Android using [Termux](https://termux.dev/en/) as its runtime environment.

On Android's libc (Bionic) thread cancellation is not implemented, but the Unix port uses that mechanism to provide asynchronous thread termination.  In this commit there is a workaround for that, by adding a new signal handler to each newly created thread, whose callback simply exits the thread.  Threads are then sent the new signal rather than being explicitly cancelled, which in turn trigger the signal handler to stop the thread execution at the next possible occasion.

This makes the cancellation behaviour differ slightly on Android, as threads are probably going to linger a little bit more since the method introduced in this commit is equivalent to setting PTHREAD_CANCEL_DEFERRED as the thread cancellation type.  On the other hand there are no guarantees of immediate cancellation using PTHREAD_CANCEL_ASYNCHRONOUS either.

This fixes the pthread-related issues reported in #16259.

### Testing

This has been tested on a no-name Android tablet running Android 11 on AArch64.  On AArch64 these changes make MicroPython build and run, and make the standard tests suite pass, along with running all the extra tests in `tests/thread/` via `run-tests.py` multiple times in a row.

### Trade-offs and Alternatives

This fixes compilation issues for a niche environment and eventual binary size increases are limited to the Android platform, not impacting neither the Unix port nor MicroPython as a whole otherwise.
