### PR TITLE
build: Fix build errors on Clang for AArch32.

### DIFF
--- a/py/emitglue.c
+++ b/py/emitglue.c
@@ -115,7 +115,7 @@ void mp_emit_glue_assign_native(mp_raw_code_t *rc, mp_raw_code_kind_t kind, cons
     #endif
     #elif MICROPY_EMIT_ARM
     #if (defined(__linux__) && defined(__GNUC__)) || __ARM_ARCH == 7
-    __builtin___clear_cache((void *)fun_data, (uint8_t *)fun_data + fun_len);
+    __builtin___clear_cache((void *)fun_data, (char *)fun_data + fun_len);
     #elif defined(__arm__)
     // Flush I-cache and D-cache.
     asm volatile (

--- a/shared/runtime/gchelper_generic.c
+++ b/shared/runtime/gchelper_generic.c
@@ -101,6 +101,10 @@ static void gc_helper_get_regs(gc_helper_regs_t arr) {
 // Fallback implementation, prefer gchelper_thumb1.s or gchelper_thumb2.s
 
 static void gc_helper_get_regs(gc_helper_regs_t arr) {
+    #ifdef __clang__
+    #pragma clang diagnostic push
+    #pragma clang diagnostic ignored "-Wuninitialized"
+    #endif
     register long r4 asm ("r4");
     register long r5 asm ("r5");
     register long r6 asm ("r6");
@@ -121,6 +125,9 @@ static void gc_helper_get_regs(gc_helper_regs_t arr) {
     arr[7] = r11;
     arr[8] = r12;
     arr[9] = r13;
+    #ifdef __clang__
+    #pragma clang diagnostic pop
+    #endif
 }
 
 #elif defined(__aarch64__)


### PR DESCRIPTION
### Summary

This PR contains minor changes that allow the code to build with Clang for AArch32.  There are test failures on Android, (`select_poll_fd`, `vfs_posix` on both 32 and 64 bits, `float_parse`, `float_parse_doubleprec` on 64 bits only), however the latter two are due to minor floating point rounding errors, whilst `select_poll_fd` cannot be tested due to Python crashing when generating the expected output, and `vfs_posix` failing when calling `os.listdir("/")`, as on Android the device root directory cannot be enumerated unless the process runs as root.

This PR fixes the remaining issues reported in #16259.

### Testing

GCC compatibility was tested by building and running tests for the Arm Unix target, using the `tools/ci.sh` script.

Android compatibility was tested by building and running tests inside Termux on both 32-bit and 64-bit Android instances.