### PR TITLE
ci: Windows CI fixes for recent MSVC and CPython 3.12.

### DIFF
--- a/.github/workflows/ports_windows.yml
+++ b/.github/workflows/ports_windows.yml
@@ -110,6 +110,11 @@ jobs:
       run:
         shell: msys2 {0}
     steps:
+    - uses: actions/setup-python@v5
+      # note: can go back to installing mingw-w64-${{ matrix.env }}-python after
+      # MSYS2 updates to Python >3.12 (due to settrace compatibility issue)
+      with:
+        python-version: '3.11'
     - uses: msys2/setup-msys2@v2
       with:
         msystem: ${{ matrix.sys }}
@@ -118,9 +123,9 @@ jobs:
           make
           mingw-w64-${{ matrix.env }}-gcc
           pkg-config
-          mingw-w64-${{ matrix.env }}-python3
           git
           diffutils
+        path-type: inherit  # Remove when setup-python is removed
     - uses: actions/checkout@v4
     - name: Build mpy-cross.exe
       run: make -C mpy-cross -j2

--- a/py/objfloat.c
+++ b/py/objfloat.c
@@ -47,6 +47,13 @@
 #define M_PI (3.14159265358979323846)
 #endif
 
+// Workaround a bug in recent MSVC where NAN is no longer constant.
+// (By redefining back to the previous MSVC definition of NAN)
+#if defined(_MSC_VER) && _MSC_VER >= 1942
+#undef NAN
+#define NAN (-(float)(((float)(1e+300 * 1e+300)) * 0.0F))
+#endif
+
 typedef struct _mp_obj_float_t {
     mp_obj_base_t base;
     mp_float_t value;

--- a/tests/extmod/asyncio_new_event_loop.py
+++ b/tests/extmod/asyncio_new_event_loop.py
@@ -12,6 +12,16 @@ if hasattr(asyncio, "set_event_loop"):
     asyncio.set_event_loop(asyncio.new_event_loop())
 
 
+def exception_handler(loop, context):
+    # This is a workaround for a difference between CPython and MicroPython: if
+    # a CPython event loop is closed while there are tasks pending (i.e. not finished)
+    # on it, then the task will log an error. MicroPython does not log this error.
+    if context.get("message", "") == "Task was destroyed but it is pending!":
+        pass
+    else:
+        loop.default_exception_handler(context)
+
+
 async def task():
     for i in range(4):
         print("task", i)
@@ -22,17 +32,21 @@ async def task():
 async def main():
     print("start")
     loop.create_task(task())
-    await asyncio.sleep(0)
+    await asyncio.sleep(0)  # yields, meaning new task will run once
     print("stop")
     loop.stop()
 
 
 # Use default event loop to run some tasks
 loop = asyncio.get_event_loop()
+loop.set_exception_handler(exception_handler)
 loop.create_task(main())
 loop.run_forever()
+loop.close()
 
 # Create new event loop, old one should not keep running
 loop = asyncio.new_event_loop()
+loop.set_exception_handler(exception_handler)
 loop.create_task(main())
 loop.run_forever()
+loop.close()

--- a/tests/misc/sys_settrace_features.py
+++ b/tests/misc/sys_settrace_features.py
@@ -6,6 +6,10 @@ except AttributeError:
     print("SKIP")
     raise SystemExit
 
+if sys.version.startswith("3.12"):
+    # There is a CPython change in settrace that is reverted in 3.13!
+    print("WARNING: this test will fail when compared to CPython 3.12.x behaviour")
+
 
 def print_stacktrace(frame, level=0):
     # Ignore CPython specific helpers.


### PR DESCRIPTION
### Summary

CI has been failing on master for Windows builds recently. These are four commits to make it pass again:

#### 1) MSVC NAN

Recent MSVC versions have introduced a bug where the `NAN` macro is no longer a constant expression in C! Have chosen the workaround approach from here: https://stackoverflow.com/a/79199887 

#### 2) asyncio_new_event_loop test w/ CPython 3.12

~~Added an .exp file for the `asyncio_new_event_loop` test on mingw.  The MSYS2 CPython 3.12.7 package prints some warnings about "Task was destroyed but it is pending!" on interpreter shutdown ([Sample failure](https://github.com/micropython/micropython/actions/runs/11926334558/job/33239930992)).~~ The fix commit updates the test to add `loop.close()` which means the warning appears consistently on other CPython builds, and then filters the warning out via a custom exception handler.

#### 3,4) CPython 3.12 settrace

There is a documented anomaly in CPython 3.12 settrace behaviour: opcode event tracing is missing in this version but has been restored in 3.13. ([Sample failure](https://github.com/micropython/micropython/actions/runs/11926334558/job/33239930992)). MicroPython's behaviour matches all CPython versions except 3.12.

To help clue in anyone running it, the test now prints a warning that it won't pass when run under CPython 3.12 (not possible to SKIP from the CPython run). More context available in CPython issue https://github.com/python/cpython/issues/114480 and the docs PR linked from that issue.

Also changed the mingw CI workflow to install CPython 3.11 from `setup-python` action rather than CPython 3.12.7 from MSYS2. This works around the settrace failure. This commit can be reverted in the future once MSYS2 repository updates to a newer CPython.

### Testing

Ran the failing tests locally with Python 3.12.7 and Python 3.10.

Ran the updated asyncio_new_event_loop test on unix port, rp2 port, and esp32 port.

Otherwise relying on CI to test this.



### Alternatives & Trade-Offs

* We could manually download and install an earlier MSYS2 Python package, there are a number available in their repo archive. However this is unsupported by MSYS2 (due to library dependency compatibility) . Moving over to the setup-python action is less likely to break randomly in the future.