### PR TITLE
extmod/modplatform: Add Android-specific platform definitions.

### DIFF
--- a/extmod/modplatform.h
+++ b/extmod/modplatform.h
@@ -53,7 +53,13 @@
 #define MICROPY_PLATFORM_ARCH   ""
 #endif
 
-#if defined(__GNUC__)
+#if defined(__clang__)
+#define MICROPY_PLATFORM_COMPILER \
+    "Clang " \
+    MP_STRINGIFY(__clang_major__) "." \
+    MP_STRINGIFY(__clang_minor__) "." \
+    MP_STRINGIFY(__clang_patchlevel__)
+#elif defined(__GNUC__)
 #define MICROPY_PLATFORM_COMPILER \
     "GCC " \
     MP_STRINGIFY(__GNUC__) "." \

--- a/extmod/modplatform.h
+++ b/extmod/modplatform.h
@@ -96,12 +96,17 @@
 #elif defined(_PICOLIBC__)
 #define MICROPY_PLATFORM_LIBC_LIB       "picolibc"
 #define MICROPY_PLATFORM_LIBC_VER       _PICOLIBC_VERSION
+#elif defined(__ANDROID__)
+#define MICROPY_PLATFORM_LIBC_LIB       "bionic"
+#define MICROPY_PLATFORM_LIBC_VER       MP_STRINGIFY(__ANDROID_API__)
 #else
 #define MICROPY_PLATFORM_LIBC_LIB       ""
 #define MICROPY_PLATFORM_LIBC_VER       ""
 #endif
 
-#if defined(__linux)
+#if defined(__ANDROID__)
+#define MICROPY_PLATFORM_SYSTEM         "Android"
+#elif defined(__linux)
 #define MICROPY_PLATFORM_SYSTEM         "Linux"
 #elif defined(__unix__)
 #define MICROPY_PLATFORM_SYSTEM         "Unix"

--- a/extmod/modplatform.h
+++ b/extmod/modplatform.h
@@ -36,7 +36,11 @@
 // See: https://sourceforge.net/p/predef/wiki/Home/
 
 #if defined(__ARM_ARCH)
+#if defined(__ARM_ARCH_ISA_A64)
+#define MICROPY_PLATFORM_ARCH   "aarch64"
+#else
 #define MICROPY_PLATFORM_ARCH   "arm"
+#endif
 #elif defined(__x86_64__) || defined(_M_X64)
 #define MICROPY_PLATFORM_ARCH   "x86_64"
 #elif defined(__i386__) || defined(_M_IX86)


### PR DESCRIPTION
### Summary

With #16261 and #16264 now MicroPython can run as a standalone application on Android under a host environment like Termux.  This also means the `platform` module assumed that an Android system is plain Linux (which is technically true, actually!).

These commits add code to the `platform` module to be able to report more accurately some entries that are common on an Android system (CPU platform, libc, platform name, and compiler name/version).

The `sys` module is unaffected to maintain wider compatibility with existing Python code.

### Testing

Testing was done on a no-name Android 11 AArch64 tablet running MicroPython under a Termux host environment.

This is a session transcript of a manual test run:

```
MicroPython v1.25.0-preview.35.g9e3133a62.dirty on 2024-11-20; linux [Clang 19.1.3] version
Use Ctrl-D to exit, Ctrl-E for paste mode
>>> import platform
>>> platform.platform()
'Android-1.25.0-preview-aarch64--with-bionic24'
>>> platform.libc_ver()
('bionic', '24')
>>> platform.python_compiler()
'Clang 19.1.3'
>>> import sys
>>> sys.platform
'linux'
```

### Trade-offs and Alternatives

There are two commits that may trigger compatibility issues.

The first one is about reporting "aarch64" instead of "arm" when running on 64-bit Arm systems.  Some code may check for "arm" without caring whether it is a 32 or 64 bits system and thus fail on an AArch64 system.  The x86 platform however reports separate entries for 32 and 64 bit systems.  If that's OK I can also add another PR that separates RV32 from RV64.

The second one is for being able to pick Clang apart from GCC.  Unlike the first one compatibility issues are much less prominent, but they're still theoretically there.

I split the commits into three separate entities to make it easier to eventually remove either or both above mentioned entries.