### PR TITLE
esp32: support SD card on ESP32C6

### DIFF
--- a/ports/esp32/boards/ESP32_GENERIC_C6/mpconfigboard.h
+++ b/ports/esp32/boards/ESP32_GENERIC_C6/mpconfigboard.h
@@ -3,7 +3,7 @@
 #define MICROPY_HW_BOARD_NAME               "ESP32C6 module"
 #define MICROPY_HW_MCU_NAME                 "ESP32C6"
 
-#define MICROPY_HW_ENABLE_SDCARD            (0)
+#define MICROPY_HW_ENABLE_SDCARD            (1)
 #define MICROPY_PY_MACHINE_I2S              (0)
 
 // Enable UART REPL for modules that have an external USB-UART and don't use native USB.


### PR DESCRIPTION
### Summary

I wanted to use an SD card with my ESP32C6! This required making SDMMC support optional, since the ESP32C6 only has SPI.

I'm not sure about all of this code, especially the slot defaults and the condition combinations that I've implemented here, feedback is very welcome!

### Testing

I've tested initialising an SD card and reading and writing data to and from it directly using `readblock` and `writeblock`. This seems to behave correctly, but formatting it using `vfs.VfsFat.mkfs` fails with EIO (and I don't understand why, as all the calls into machine_sdcard.c that I've traced so far have been successful). Maybe someone else can shed some light on this problem?

### Trade-offs and Alternatives
This increases size a bit.
before:
```
bootloader  @0x000000    18064  (   14704 remaining)
partitions  @0x008000     3072  (    1024 remaining)
application @0x010000  1926480  (  105136 remaining)
total                  1992016
```
after:
```
bootloader  @0x000000    18064  (   14704 remaining)
partitions  @0x008000     3072  (    1024 remaining)
application @0x010000  1953376  (   78240 remaining)
total                  2018912
```
I don't think there are any very relevant alternatives besides not implementing SD support.