### PR TITLE
py/obj: Fix type mismatch when printing object.

### DIFF
--- a/py/obj.c
+++ b/py/obj.c
@@ -128,7 +128,7 @@ void mp_obj_print_helper(const mp_print_t *print, mp_obj_t o_in, mp_print_kind_t
     if (MP_OBJ_TYPE_HAS_SLOT(type, print)) {
         MP_OBJ_TYPE_GET_SLOT(type, print)((mp_print_t *)print, o_in, kind);
     } else {
-        mp_printf(print, "<%q>", type->name);
+        mp_printf(print, "<%q>", (qstr)type->name);
     }
 }
 


### PR DESCRIPTION
<!-- Thanks for submitting a Pull Request! We appreciate you spending the
     time to improve MicroPython. Please provide enough information so that
     others can review your Pull Request.

     Before submitting, please read:
     https://github.com/micropython/micropython/blob/master/CODEOFCONDUCT.md
     https://github.com/micropython/micropython/wiki/ContributorGuidelines

     Please check any CI failures that appear after your Pull Request is opened.
-->

### Summary

<!-- Explain the reason for making this change. What problem does the pull request
     solve, or what improvement does it add? Add links if relevant. -->

The `type` member of `mp_obj_type_t` is `uint16_t` while `mp_vprintf` expects `qstr` which is a typedef of `size_t`. This can lead to undefined behaviour. In my case, for qstr 0xaf4 the `va_arg` invocation returned 0x100000af4 which later lead to assertion failure when looking up the qstring.

### Testing

<!-- Explain what testing you did, and on which boards/ports. If there are
     boards or ports that you couldn't test, please mention this here as well.

     If you leave this empty then your Pull Request may be closed. -->

The bug manifests on arm64 Darwin with GCC 12 & GCC 13 on micropython-1.19 unix port when running something like `print("%s" % object)`. The commit fixes it on this configuration, and likely on git master as well.

