### PR TITLE
ci: Remove macos install step for pkg-config

### DIFF
--- a/tools/ci.sh
+++ b/tools/ci.sh
@@ -651,9 +651,6 @@ function ci_unix_settrace_stackless_run_tests {
 }
 
 function ci_unix_macos_build {
-    # Install pkg-config to configure libffi paths.
-    brew install pkg-config
-
     make ${MAKEOPTS} -C mpy-cross
     make ${MAKEOPTS} -C ports/unix submodules
     #make ${MAKEOPTS} -C ports/unix deplibs


### PR DESCRIPTION
### Summary

* Fix for macos CI failures ([sample job](https://github.com/micropython/micropython/actions/runs/12023820688/job/33518713948))

* Brew renamed this package upstream and looks like it should be a smooth transition, except that the GitHub MacOS Runner also installs pkgconf and trying to install the old pkg-config on top of the new pkgconf causes it to fail.

* See https://github.com/actions/runner-images/pull/11015 for the runner change (and links from there for more detail).

* As pkg-config is already installed on GitHub macOS runners, there's no need to keep this step any more.
