### PR TITLE
nrf/ticker: Fix the soft reboot lock-up of the micro:bit board.

### DIFF
--- a/ports/nrf/drivers/ticker.c
+++ b/ports/nrf/drivers/ticker.c
@@ -62,6 +62,7 @@ void ticker_init0(void) {
 #else
     NRFX_IRQ_PRIORITY_SET(FastTicker_IRQn, 2);
 #endif
+    m_num_of_slow_tickers = 0;
 
     NRFX_IRQ_PRIORITY_SET(SlowTicker_IRQn, 3);
 


### PR DESCRIPTION
### Summary

The micro:bit board and probably other boards using the music or display module locked up on soft reboot. Reason was an buffer overflow caused by an index counter, which was not reset on soft_reboot.

### Testing

Tested with a micro:bit board, performing a series of soft reboots.
