### PR TITLE
ports/zephyr: Create options for frozen modules

### DIFF
--- a/ports/zephyr/CMakeLists.txt
+++ b/ports/zephyr/CMakeLists.txt
@@ -34,6 +34,11 @@ set(MICROPY_TARGET      micropython)
 include(${MICROPY_DIR}/py/py.cmake)
 include(${MICROPY_DIR}/extmod/extmod.cmake)
 
+if (CONFIG_MICROPY_FROZEN_MODULES)
+    cmake_path(ABSOLUTE_PATH CONFIG_MICROPY_FROZEN_MANIFEST BASE_DIRECTORY ${CMAKE_CURRENT_LIST_DIR})
+    set(MICROPY_FROZEN_MANIFEST ${CONFIG_MICROPY_FROZEN_MANIFEST})
+endif()
+
 set(MICROPY_SOURCE_PORT
     main.c
     help.c
@@ -115,9 +120,10 @@ zephyr_library_compile_definitions(
 zephyr_library_sources(${MICROPY_SOURCE_QSTR})
 zephyr_library_link_libraries(kernel)
 
-add_dependencies(${MICROPY_TARGET} zephyr_generated_headers)
-
 include(${MICROPY_DIR}/py/mkrules.cmake)
+
+add_dependencies(BUILD_VERSION_HEADER zephyr_generated_headers)
+add_dependencies(${MICROPY_TARGET} zephyr_generated_headers)
 
 target_sources(app PRIVATE
     src/zephyr_start.c

--- a/ports/zephyr/Kconfig
+++ b/ports/zephyr/Kconfig
@@ -41,6 +41,14 @@ config MICROPY_VFS_LFS1
 config MICROPY_VFS_LFS2
 	bool "LittleFs version 2 file system"
 
+config MICROPY_FROZEN_MODULES
+	bool "Enable Frozen Modules"
+
+config MICROPY_FROZEN_MANIFEST
+	string "Path to Frozen Modules manifest.py"
+	depends on MICROPY_FROZEN_MODULES
+	default "boards/manifest.py"
+
 endmenu # MicroPython Options
 
 source "Kconfig.zephyr"

--- a/ports/zephyr/boards/manifest.py
+++ b/ports/zephyr/boards/manifest.py
@@ -1,0 +1,7 @@
+# This is an example frozen module manifest. Enable this by configuring
+# the Zephyr project and enabling the frozen modules config feature.
+
+freeze("$(PORT_DIR)/modules")
+
+# Require a micropython-lib module.
+require("upysh")


### PR DESCRIPTION
Enables the ability to use frozen modules in the zephyr port

### Summary

This enables having frozen modules in zephyr port builds.
Enabled by adding CONFIG_MICROPY_FROZEN_MODULES to the board configuration file.
Manually set manifest path with CONFIG_MICROPY_FROZEN_MANIFEST. 

### Testing

Tested on supermicro nrf52840 (https://github.com/zephyrproject-rtos/zephyr/pull/80168), and the platforms i work on (https://github.com/zephyrproject-rtos/zephyr/pull/78795)
