### PR TITLE
drivers/memory/spiflash: Add an option to soft-reset SPI flash. 

### DIFF
--- a/drivers/memory/spiflash.c
+++ b/drivers/memory/spiflash.c
@@ -44,6 +44,8 @@
 #define CMD_RD_DEVID    (0x9f)
 #define CMD_CHIP_ERASE  (0xc7)
 #define CMD_C4READ      (0xeb)
+#define CMD_RSTEN       (0x66)
+#define CMD_RESET       (0x99)
 
 // 32 bit addressing commands
 #define CMD_WRITE_32    (0x12)
@@ -179,6 +181,14 @@ void mp_spiflash_init(mp_spiflash_t *self) {
 
     // Ensure SPI flash is out of sleep mode
     mp_spiflash_deepsleep_internal(self, 0);
+
+    // Software reset.
+    #if MICROPY_HW_SPIFLASH_SOFT_RESET
+    mp_spiflash_write_cmd(self, CMD_RSTEN);
+    mp_spiflash_write_cmd(self, CMD_RESET);
+    mp_spiflash_wait_wip0(self);
+    mp_hal_delay_ms(1);
+    #endif
 
     #if defined(CHECK_DEVID)
     // Validate device id

--- a/ports/stm32/boards/ARDUINO_GIGA/mpconfigboard.h
+++ b/ports/stm32/boards/ARDUINO_GIGA/mpconfigboard.h
@@ -29,9 +29,11 @@ typedef unsigned int mp_uint_t;     // must be pointer size
 #define MICROPY_HW_ENABLE_TIMER     (1)
 #define MICROPY_HW_ENABLE_SDCARD    (0)
 #define MICROPY_HW_ENABLE_MMCARD    (0)
+#define MICROPY_HW_ENTER_BOOTLOADER_VIA_RESET   (0)
 
 // Flash storage config
 #define MICROPY_HW_SPIFLASH_ENABLE_CACHE            (1)
+#define MICROPY_HW_SPIFLASH_SOFT_RESET              (1)
 #define MICROPY_HW_ENABLE_INTERNAL_FLASH_STORAGE    (0)
 
 #define MICROPY_BOARD_STARTUP       GIGA_board_startup

--- a/ports/stm32/boards/ARDUINO_NICLA_VISION/mpconfigboard.h
+++ b/ports/stm32/boards/ARDUINO_NICLA_VISION/mpconfigboard.h
@@ -29,9 +29,11 @@ typedef unsigned int mp_uint_t;     // must be pointer size
 #define MICROPY_HW_ENABLE_TIMER     (1)
 #define MICROPY_HW_ENABLE_SDCARD    (0)
 #define MICROPY_HW_ENABLE_MMCARD    (0)
+#define MICROPY_HW_ENTER_BOOTLOADER_VIA_RESET   (0)
 
 // Flash storage config
 #define MICROPY_HW_SPIFLASH_ENABLE_CACHE            (1)
+#define MICROPY_HW_SPIFLASH_SOFT_RESET              (1)
 #define MICROPY_HW_ENABLE_INTERNAL_FLASH_STORAGE    (0)
 
 #define MICROPY_BOARD_STARTUP       NICLAV_board_startup

--- a/ports/stm32/boards/ARDUINO_OPTA/mpconfigboard.h
+++ b/ports/stm32/boards/ARDUINO_OPTA/mpconfigboard.h
@@ -25,9 +25,11 @@ typedef unsigned int mp_uint_t;     // must be pointer size
 #define MICROPY_HW_HAS_SWITCH       (1)
 #define MICROPY_HW_HAS_FLASH        (1)
 #define MICROPY_HW_ENABLE_TIMER     (1)
+#define MICROPY_HW_ENTER_BOOTLOADER_VIA_RESET   (0)
 
 // Flash storage config
 #define MICROPY_HW_SPIFLASH_ENABLE_CACHE            (1)
+#define MICROPY_HW_SPIFLASH_SOFT_RESET              (1)
 #define MICROPY_HW_ENABLE_INTERNAL_FLASH_STORAGE    (0)
 
 #define MICROPY_BOARD_STARTUP       OPTA_board_startup

--- a/ports/stm32/boards/ARDUINO_PORTENTA_H7/mpconfigboard.h
+++ b/ports/stm32/boards/ARDUINO_PORTENTA_H7/mpconfigboard.h
@@ -29,9 +29,11 @@ typedef unsigned int mp_uint_t;     // must be pointer size
 #define MICROPY_HW_ENABLE_TIMER     (1)
 #define MICROPY_HW_ENABLE_SDCARD    (1)
 #define MICROPY_HW_ENABLE_MMCARD    (0)
+#define MICROPY_HW_ENTER_BOOTLOADER_VIA_RESET   (0)
 
 // Flash storage config
 #define MICROPY_HW_SPIFLASH_ENABLE_CACHE            (1)
+#define MICROPY_HW_SPIFLASH_SOFT_RESET              (1)
 #define MICROPY_HW_ENABLE_INTERNAL_FLASH_STORAGE    (0)
 
 #define MICROPY_BOARD_STARTUP       PORTENTA_board_startup


### PR DESCRIPTION
Add an option to soft-reset SPI flash. This puts the flash in a known state on reset/init. Note this option is disabled by default, so it shouldn't affect any other board using this driver.