### PR TITLE
extmod/extmod.mk: Fix libmetal build prefix.

### DIFF
--- a/extmod/extmod.mk
+++ b/extmod/extmod.mk
@@ -616,6 +616,6 @@ $(BUILD)/$(OPENAMP_DIR)/lib/virtio_mmio/virtio_mmio_drv.o: CFLAGS += -Wno-unused
 # We need to have generated libmetal before compiling OpenAMP.
 $(addprefix $(BUILD)/, $(SRC_OPENAMP_C:.c=.o)): $(BUILD)/openamp/metal/config.h
 
-SRC_THIRDPARTY_C += $(SRC_LIBMETAL_C) $(SRC_OPENAMP_C)
+SRC_THIRDPARTY_C += $(SRC_OPENAMP_C) $(SRC_LIBMETAL_C:$(BUILD)/%=%)
 
 endif # MICROPY_PY_OPENAMP


### PR DESCRIPTION
libmetal source files already have the build directory prefix, because they're auto-generated inside the build directory. When they're added to `SRC_THIRDPARTY_C`, another build directory prefix is added resulting
in the object files being generated in a nested build directory. This patch strips the build directory prefix before adding libmetal's source files.

This has no effect on functionality, it's just to avoid nested build directories which can be confusing.