### PR TITLE
ports: Switch FATFS LFN to type 2.

### DIFF
--- a/ports/mimxrt/mpconfigport.h
+++ b/ports/mimxrt/mpconfigport.h
@@ -118,10 +118,12 @@ uint32_t trng_random_u32(void);
 #define MICROPY_PY_ONEWIRE                  (1)
 
 // fatfs configuration used in ffconf.h
-#define MICROPY_FATFS_ENABLE_LFN            (1)
-#define MICROPY_FATFS_RPATH                 (2)
-#define MICROPY_FATFS_MAX_SS                (4096)
+#define MICROPY_FATFS_ENABLE_LFN            (2)
 #define MICROPY_FATFS_LFN_CODE_PAGE         437 /* 1=SFN/ANSI 437=LFN/U.S.(OEM) */
+#define MICROPY_FATFS_USE_LABEL             (1)
+#define MICROPY_FATFS_RPATH                 (2)
+#define MICROPY_FATFS_MULTI_PARTITION       (1)
+#define MICROPY_FATFS_MAX_SS                (4096)
 
 #ifndef MICROPY_PY_NETWORK
 #define MICROPY_PY_NETWORK                  (1)

--- a/ports/renesas-ra/mpconfigport.h
+++ b/ports/renesas-ra/mpconfigport.h
@@ -167,7 +167,7 @@
 #endif
 
 // fatfs configuration used in ffconf.h
-#define MICROPY_FATFS_ENABLE_LFN       (1)
+#define MICROPY_FATFS_ENABLE_LFN       (2)
 #define MICROPY_FATFS_LFN_CODE_PAGE    437 /* 1=SFN/ANSI 437=LFN/U.S.(OEM) */
 #define MICROPY_FATFS_USE_LABEL        (1)
 #define MICROPY_FATFS_RPATH            (2)

--- a/ports/rp2/mpconfigport.h
+++ b/ports/rp2/mpconfigport.h
@@ -178,7 +178,7 @@
 #define MICROPY_HW_SOFT_TIMER_ALARM_NUM         (2)
 
 // fatfs configuration
-#define MICROPY_FATFS_ENABLE_LFN                (1)
+#define MICROPY_FATFS_ENABLE_LFN                (2)
 #define MICROPY_FATFS_LFN_CODE_PAGE             437 /* 1=SFN/ANSI 437=LFN/U.S.(OEM) */
 #define MICROPY_FATFS_RPATH                     (2)
 #if MICROPY_HW_USB_MSC

--- a/ports/stm32/mpconfigport.h
+++ b/ports/stm32/mpconfigport.h
@@ -157,7 +157,7 @@
 #endif
 
 // fatfs configuration used in ffconf.h
-#define MICROPY_FATFS_ENABLE_LFN       (1)
+#define MICROPY_FATFS_ENABLE_LFN       (2)
 #define MICROPY_FATFS_LFN_CODE_PAGE    437 /* 1=SFN/ANSI 437=LFN/U.S.(OEM) */
 #define MICROPY_FATFS_USE_LABEL        (1)
 #define MICROPY_FATFS_RPATH            (2)


### PR DESCRIPTION
### Summary

FatFS LFN type 2 uses the stack to allocate the internal working buffer for LFN, which is thread-safe and saves about 300bytes of BSS memory. The mimxrt port is also changed to use LFN2 and the configuration is aligned with the rest of the ports (enable multi-partition, use label etc..).

Note I only changed the major ports that actually use FatFs (for storage for example).

```
      stm32:  -436 -0.111% PYBV10[incl -512(bss)]
     mimxrt:  +312 +0.085% TEENSY40
      rp2:  -384 -0.042% RPI_PICO_W[incl -512(bss)]
```

### Testing

This config has been tested on rp2, mimxrt, stm32 ports.