### PR TITLE
ports/stm32: Add deinit_all functions for I2C and SPI.

### DIFF
--- a/ports/stm32/i2c.h
+++ b/ports/stm32/i2c.h
@@ -50,6 +50,7 @@ void i2c_init0(void);
 int pyb_i2c_init(I2C_HandleTypeDef *i2c);
 int pyb_i2c_init_freq(const pyb_i2c_obj_t *self, mp_int_t freq);
 uint32_t pyb_i2c_get_baudrate(I2C_HandleTypeDef *i2c);
+void pyb_i2c_deinit_all(void);
 void i2c_ev_irq_handler(mp_uint_t i2c_id);
 void i2c_er_irq_handler(mp_uint_t i2c_id);
 

--- a/ports/stm32/main.c
+++ b/ports/stm32/main.c
@@ -678,6 +678,10 @@ soft_reset_exit:
     soft_timer_deinit();
     timer_deinit();
     uart_deinit_all();
+    spi_deinit_all();
+    #if MICROPY_PY_PYB_LEGACY && MICROPY_HW_ENABLE_HW_I2C
+    pyb_i2c_deinit_all();
+    #endif
     #if MICROPY_HW_ENABLE_CAN
     can_deinit_all();
     #endif

--- a/ports/stm32/pyb_i2c.c
+++ b/ports/stm32/pyb_i2c.c
@@ -428,6 +428,15 @@ int pyb_i2c_init_freq(const pyb_i2c_obj_t *self, mp_int_t freq) {
     return pyb_i2c_init(self->i2c);
 }
 
+void pyb_i2c_deinit_all(void) {
+    for (int i = 0; i < MP_ARRAY_SIZE(pyb_i2c_obj); i++) {
+        const pyb_i2c_obj_t *pyb_i2c = &pyb_i2c_obj[i];
+        if (pyb_i2c->i2c != NULL) {
+            i2c_deinit(pyb_i2c->i2c);
+        }
+    }
+}
+
 static void i2c_reset_after_error(I2C_HandleTypeDef *i2c) {
     // wait for bus-busy flag to be cleared, with a timeout
     for (int timeout = 50; timeout > 0; --timeout) {

--- a/ports/stm32/spi.c
+++ b/ports/stm32/spi.c
@@ -545,6 +545,15 @@ void spi_deinit(const spi_t *spi_obj) {
     }
 }
 
+void spi_deinit_all(void) {
+    for (int i = 0; i < MP_ARRAY_SIZE(spi_obj); i++) {
+        const spi_t *spi = &spi_obj[i];
+        if (spi->spi != NULL) {
+            spi_deinit(spi);
+        }
+    }
+}
+
 static HAL_StatusTypeDef spi_wait_dma_finished(const spi_t *spi, uint32_t t_start, uint32_t timeout) {
     volatile HAL_SPI_StateTypeDef *state = &spi->spi->State;
     for (;;) {

--- a/ports/stm32/spi.h
+++ b/ports/stm32/spi.h
@@ -67,6 +67,7 @@ extern const mp_obj_type_t pyb_spi_type;
 void spi_init0(void);
 int spi_init(const spi_t *spi, bool enable_nss_pin);
 void spi_deinit(const spi_t *spi_obj);
+void spi_deinit_all(void);
 int spi_find_index(mp_obj_t id);
 void spi_set_params(const spi_t *spi_obj, uint32_t prescale, int32_t baudrate,
     int32_t polarity, int32_t phase, int32_t bits, int32_t firstbit);


### PR DESCRIPTION
### Summary

SPI and I2C objects can remain active after a soft-reboot because they are statically allocated and lack a finalizer to collect and deinitialize them. This patch adds `deinit_all` functions for SPI and I2C, similar to other peripherals such as UART, DAC, etc.