### PR TITLE
py/misc: Fix msvc and C++ compatibility.

### DIFF
--- a/py/misc.h
+++ b/py/misc.h
@@ -357,7 +357,7 @@ static inline uint32_t mp_clzll(unsigned long long x) {
 // Microsoft don't ship _BitScanReverse64 on Win32, so emulate it
 static inline uint32_t mp_clzll(unsigned long long x) {
     unsigned long h = x >> 32;
-    return h ? mp_clzl(h) : (mp_clzl(x) + 32);
+    return h ? mp_clzl(h) : (mp_clzl((unsigned long)x) + 32);
 }
 #endif
 


### PR DESCRIPTION
### Summary

Use an explicit cast to suppress the implicit conversion which started popping up in recent compiler versions (and wasn't there yet in 07bf3179).

### Testing

Standard CI tests all run