### PR TITLE
esp32/mpconfigport: Use the appropriate wait-for-interrupt opcode.

### DIFF
--- a/ports/esp32/mpconfigport.h
+++ b/ports/esp32/mpconfigport.h
@@ -292,12 +292,17 @@ void *esp_native_code_commit(void *, size_t, void *);
         MP_THREAD_GIL_ENTER(); \
     } while (0);
 #else
+#if CONFIG_IDF_TARGET_ARCH_RISCV
+#define MICROPY_PY_WAIT_FOR_INTERRUPT asm volatile ("wfi\n")
+#else
+#define MICROPY_PY_WAIT_FOR_INTERRUPT asm volatile ("waiti 0\n")
+#endif
 #define MICROPY_EVENT_POLL_HOOK \
     do { \
         extern void mp_handle_pending(bool); \
         mp_handle_pending(true); \
         MICROPY_PY_SOCKET_EVENTS_HANDLER \
-        asm ("waiti 0"); \
+            MICROPY_PY_WAIT_FOR_INTERRUPT; \
     } while (0);
 #endif
 


### PR DESCRIPTION
### Summary

Compiling a version of MicroPython for ESP32 with threading disabled was not possible due to a bit of Xtensa-specific assembly code in `MICROPY_EVENT_POLL_HOOK`.  This PR contains the RISC-V equivalent for that bit of code.

### Testing

Testing was done on an ESP32-C3 with threading disabled (it required a few more changes to even compile and link, e.g. fully disabling bluetooth and its module enumeration, adding stubs for `vTaskPreDeletionHook` and `vPortCleanUpTCB` in `mpthreadport.c`, include `mpthreadport.h` in `esp32_rmt.c`, etc.).  

On a test run, there are no failures outside `thread/`, and that's expected.