### PR TITLE
esp32: Enable support for machine.USBDevice.

### DIFF
--- a/ports/esp32/esp32_common.cmake
+++ b/ports/esp32/esp32_common.cmake
@@ -78,6 +78,7 @@ if(MICROPY_PY_TINYUSB)
         ${MICROPY_DIR}/shared/tinyusb/mp_usbd.c
         ${MICROPY_DIR}/shared/tinyusb/mp_usbd_cdc.c
         ${MICROPY_DIR}/shared/tinyusb/mp_usbd_descriptor.c
+        ${MICROPY_DIR}/shared/tinyusb/mp_usbd_runtime.c
     )
 
     list(APPEND MICROPY_INC_TINYUSB

--- a/ports/esp32/main.c
+++ b/ports/esp32/main.c
@@ -183,6 +183,10 @@ soft_reset_exit:
     mp_thread_deinit();
     #endif
 
+    #if MICROPY_HW_ENABLE_USB_RUNTIME_DEVICE
+    mp_usbd_deinit();
+    #endif
+
     gc_sweep_all();
 
     // Free any native code pointers that point to iRAM.

--- a/ports/esp32/mpconfigport.h
+++ b/ports/esp32/mpconfigport.h
@@ -215,6 +215,10 @@
 #else
 #define MICROPY_HW_USB_VID  (CONFIG_TINYUSB_DESC_CUSTOM_VID)
 #endif
+
+#ifndef MICROPY_HW_ENABLE_USB_RUNTIME_DEVICE
+#define MICROPY_HW_ENABLE_USB_RUNTIME_DEVICE    (1) // Support machine.USBDevice
+#endif
 #endif
 
 #ifndef MICROPY_HW_USB_PID


### PR DESCRIPTION
### Summary

Recently support for machine.USBDevice was kindly added to the ESP32 port. However it's not currently enabled in the runtime yet by default.
After discussing it (#15564) I followed the recipe of @TomFahey and the suggestions of @andrewleech to enable the USB runtime support support the same way it's been added e.g. to the RP2 port.

### Testing

I tested it on an Arduino Nano ESP32 board by emulating a HID keyboard. In fact I had a whole class of students testing it and it worked beautifully.

### Trade-offs and Alternatives

I'm not sure how this affects the binary size but I would expect a minimal increase.

