### PR TITLE
esp32: Fix RTC initialization from datetime.

### DIFF
--- a/ports/esp32/machine_rtc.c
+++ b/ports/esp32/machine_rtc.c
@@ -126,15 +126,20 @@ static mp_obj_t machine_rtc_datetime_helper(mp_uint_t n_args, const mp_obj_t *ar
         return mp_obj_new_tuple(8, tuple);
     } else {
         // Set time
-
         mp_obj_t *items;
-        mp_obj_get_array_fixed_n(args[1], 8, &items);
 
         struct timeval tv = {0};
         if (use_init_format) {
-            tv.tv_sec = timeutils_seconds_since_epoch(mp_obj_get_int(items[0]), mp_obj_get_int(items[1]), mp_obj_get_int(items[2]), mp_obj_get_int(items[3]), mp_obj_get_int(items[4]), mp_obj_get_int(items[5]));
-            tv.tv_usec = mp_obj_get_int(items[6]);
+            size_t seq_len;
+            mp_ob_get_array_min_max(args[1], 3, 8, &seq_len, &items);
+            mp_int_t hour = seq_len > 3 ? mp_obj_get_int(items[3]) : 0;
+            mp_int_t minute = seq_len > 4 ? mp_obj_get_int(items[4]) : 0;
+            mp_int_t second = seq_len > 5 ? mp_obj_get_int(items[5]) : 0;
+            mp_int_t subsecond = seq_len > 6 ? mp_obj_get_int(items[6]) : 0;
+            tv.tv_sec = timeutils_seconds_since_epoch(mp_obj_get_int(items[0]), mp_obj_get_int(items[1]), mp_obj_get_int(items[2]), hour, minute, second);
+            tv.tv_usec = subsecond;
         } else {
+            mp_obj_get_array_fixed_n(args[1], 8, &items);
             tv.tv_sec = timeutils_seconds_since_epoch(mp_obj_get_int(items[0]), mp_obj_get_int(items[1]), mp_obj_get_int(items[2]), mp_obj_get_int(items[4]), mp_obj_get_int(items[5]), mp_obj_get_int(items[6]));
             tv.tv_usec = mp_obj_get_int(items[7]);
         }

--- a/ports/esp32/machine_rtc.c
+++ b/ports/esp32/machine_rtc.c
@@ -101,7 +101,7 @@ static mp_obj_t machine_rtc_make_new(const mp_obj_type_t *type, size_t n_args, s
     return (mp_obj_t)&machine_rtc_obj;
 }
 
-static mp_obj_t machine_rtc_datetime_helper(mp_uint_t n_args, const mp_obj_t *args) {
+static mp_obj_t machine_rtc_datetime_helper(mp_uint_t n_args, const mp_obj_t *args, bool use_init_format) {
     if (n_args == 1) {
         // Get time
 
@@ -131,21 +131,26 @@ static mp_obj_t machine_rtc_datetime_helper(mp_uint_t n_args, const mp_obj_t *ar
         mp_obj_get_array_fixed_n(args[1], 8, &items);
 
         struct timeval tv = {0};
-        tv.tv_sec = timeutils_seconds_since_epoch(mp_obj_get_int(items[0]), mp_obj_get_int(items[1]), mp_obj_get_int(items[2]), mp_obj_get_int(items[4]), mp_obj_get_int(items[5]), mp_obj_get_int(items[6]));
-        tv.tv_usec = mp_obj_get_int(items[7]);
+        if (use_init_format) {
+            tv.tv_sec = timeutils_seconds_since_epoch(mp_obj_get_int(items[0]), mp_obj_get_int(items[1]), mp_obj_get_int(items[2]), mp_obj_get_int(items[3]), mp_obj_get_int(items[4]), mp_obj_get_int(items[5]));
+            tv.tv_usec = mp_obj_get_int(items[6]);
+        } else {
+            tv.tv_sec = timeutils_seconds_since_epoch(mp_obj_get_int(items[0]), mp_obj_get_int(items[1]), mp_obj_get_int(items[2]), mp_obj_get_int(items[4]), mp_obj_get_int(items[5]), mp_obj_get_int(items[6]));
+            tv.tv_usec = mp_obj_get_int(items[7]);
+        }
         settimeofday(&tv, NULL);
 
         return mp_const_none;
     }
 }
 static mp_obj_t machine_rtc_datetime(size_t n_args, const mp_obj_t *args) {
-    return machine_rtc_datetime_helper(n_args, args);
+    return machine_rtc_datetime_helper(n_args, args, false);
 }
 static MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(machine_rtc_datetime_obj, 1, 2, machine_rtc_datetime);
 
 static mp_obj_t machine_rtc_init(mp_obj_t self_in, mp_obj_t date) {
     mp_obj_t args[2] = {self_in, date};
-    machine_rtc_datetime_helper(2, args);
+    machine_rtc_datetime_helper(2, args, true);
 
     return mp_const_none;
 }

--- a/py/obj.c
+++ b/py/obj.c
@@ -448,6 +448,25 @@ void mp_obj_get_array_fixed_n(mp_obj_t o, size_t len, mp_obj_t **items) {
     }
 }
 
+void mp_ob_get_array_min_max(mp_obj_t o, size_t min_len, size_t max_len, size_t *len, mp_obj_t **items) {
+    mp_obj_get_array(o, len, items);
+    if (*len < min_len) {
+        #if MICROPY_ERROR_REPORTING <= MICROPY_ERROR_REPORTING_TERSE
+        mp_raise_ValueError(MP_ERROR_TEXT("tuple/list length too short"));
+        #else
+        mp_raise_msg_varg(&mp_type_ValueError,
+            MP_ERROR_TEXT("requested minimum length %d but object has length %d"), (int)min_len, (int)*len);
+        #endif
+    } else if (*len > max_len) {
+        #if MICROPY_ERROR_REPORTING <= MICROPY_ERROR_REPORTING_TERSE
+        mp_raise_ValueError(MP_ERROR_TEXT("tuple/list length too long"));
+        #else
+        mp_raise_msg_varg(&mp_type_ValueError,
+            MP_ERROR_TEXT("requested maximum length %d but object has length %d"), (int)max_len, (int)*len);
+        #endif
+    }
+}
+
 // is_slice determines whether the index is a slice index
 size_t mp_get_index(const mp_obj_type_t *type, size_t len, mp_obj_t index, bool is_slice) {
     mp_int_t i;

--- a/py/obj.h
+++ b/py/obj.h
@@ -1045,6 +1045,7 @@ bool mp_obj_get_complex_maybe(mp_obj_t self_in, mp_float_t *real, mp_float_t *im
 #endif
 void mp_obj_get_array(mp_obj_t o, size_t *len, mp_obj_t **items); // *items may point inside a GC block
 void mp_obj_get_array_fixed_n(mp_obj_t o, size_t len, mp_obj_t **items); // *items may point inside a GC block
+void mp_ob_get_array_min_max(mp_obj_t o, size_t min_len, size_t max_len, size_t *len, mp_obj_t **items); // *items may point inside a GC block
 size_t mp_get_index(const mp_obj_type_t *type, size_t len, mp_obj_t index, bool is_slice);
 mp_obj_t mp_obj_id(mp_obj_t o_in);
 mp_obj_t mp_obj_len(mp_obj_t o_in);

--- a/tests/ports/esp32/machine_rtc_init.exp
+++ b/tests/ports/esp32/machine_rtc_init.exp
@@ -1,0 +1,4 @@
+2024 12 26 3 6 30 20
+2024 12 26 3
+requested maximum length 8 but object has length 9
+requested minimum length 3 but object has length 2

--- a/tests/ports/esp32/machine_rtc_init.py
+++ b/tests/ports/esp32/machine_rtc_init.py
@@ -1,0 +1,46 @@
+# Test init behaviour of machine.RTC.
+
+try:
+    from machine import RTC
+except ImportError:
+    print("SKIP")
+    raise SystemExit
+
+rtc = RTC()
+
+year = 2024
+month = 12
+day = 26
+# weekday is 3 (Thursday)
+hour = 6
+minute = 30
+second = 20
+microsecond = 0
+tzinfo = 0
+
+# Save datetime.
+orig_datetime = rtc.datetime()
+
+# Set datetime to a known value using init.
+rtc.init((year, month, day, hour, minute, second, microsecond, tzinfo))
+now = rtc.datetime()
+print(now[0], now[1], now[2], now[3], now[4], now[5], now[6])
+
+# Test with date only.
+rtc.init((year, month, day))
+print(now[0], now[1], now[2], now[3])
+
+# Test with too many arguments.
+try:
+    rtc.init((year, month, day, hour, minute, second, microsecond, tzinfo, 1234))
+except ValueError as e:
+    print(e)
+
+# Test with too few arguments.
+try:
+    rtc.init((year, month))
+except ValueError as e:
+    print(e)
+
+# Restore datetime.
+rtc.datetime(orig_datetime)


### PR DESCRIPTION
### Summary

I was pulling my hair out trying to initialize the RTC though its `init` function as follows:
```py
rtc = RTC()

year = 2024
month = 12
day = 26
weekday = 3
hour = 6
minute = 30
second = 20
microsecond = 0
tzinfo = 0

rtc.init((year, month, day, hour, minute, second, microsecond, tzinfo))
```
However it kept being initialized with a wrong date / time. The documentation states:

> Initialise the RTC. Datetime is a tuple of the form:
> (year, month, day[, hour[, minute[, second[, microsecond[, tzinfo]]]]]

The problem lies in the fact that both the `datetime` setter and init use the same helper function. The 8-tuple for that one is different though according to the docs:

> The 8-tuple has the following format:
> (year, month, day, weekday, hours, minutes, seconds, subseconds)

It uses `weekday` which makes sense as the getter should deliver this information and both setter and getter shall use the same format. Now we can see that using the same helper function for both formats cannot work and the two need to be distinguished. This is what this PR does. It fixes the issue by treating the two differently.

### Testing

I tested the fix on an Arduino Nano ESP32. I wasn't sure where to add a unit test, but here is what I wrote in MicroPython:

```py
from machine import RTC

rtc = RTC()

year = 2024
month = 12
day = 26
weekday = 3
hour = 6
minute = 30
second = 20
microsecond = 0
tzinfo = 0

def test(source, should_fail=False):
    print(f"\nTesting {source}")
    # Read time
    t = rtc.datetime()
    print(t)
    try:
        assert t[0] == 2024, f"Year should be 2024 but was {t[0]}"
        assert t[1] == 12, f"Month should be 12 but was {t[1]}"
        assert t[2] == 26, f"Day should be 26 but was {t[2]}"
        assert t[3] == 3, f"Weekday should be 3 but was {t[3]}"
        assert t[4] == 6, f"Hour should be 6 but was {t[4]}"
        assert t[5] == 30, f"Minute should be 30 but was {t[5]}"
        assert t[6] == 20, f"Second should be 20 but was {t[6]}"
        if should_fail:
            print("❌ Test should have failed but didn't")
        else:
            print("✅ Test passed")
    except AssertionError:
        if should_fail:
            print("✅ Test failed as expected")
        else:
            print("❌ Test passed but should have failed")


# Initialise the RTC. Datetime is a tuple of the form:
# (year, month, day[, hour[, minute[, second[, microsecond[, tzinfo]]]]]
rtc.init((year, month, day, hour, minute, second, microsecond, tzinfo))
test("init in order")

rtc.init((year, month, day, tzinfo, hour, minute, second, microsecond))
test("init out of order", should_fail=True)

# The 8-tuple has the following format:
# (year, month, day, weekday, hours, minutes, seconds, subseconds)
rtc.datetime((year, month, day, weekday, hour, minute, second, microsecond))
test("datetime in order")
```

The output before applying the fix:

```
Testing init in order
(2024, 12, 27, 4, 6, 20, 0, 373)
❌ Test passed but should have failed

Testing init out of order
(2024, 12, 26, 3, 6, 30, 20, 245)
❌ Test should have failed but didn't

Testing datetime in order
(2024, 12, 26, 3, 6, 30, 20, 256)
✅ Test passed
```

The output after applying the fix:

```
Testing init in order
(2024, 12, 26, 3, 6, 30, 20, 389)
✅ Test passed

Testing init out of order
(2024, 12, 26, 3, 0, 6, 30, 365)
✅ Test failed as expected

Testing datetime in order
(2024, 12, 26, 3, 6, 30, 20, 235)
✅ Test passed
```

### Trade-offs and Alternatives

An alternative could be to change the documentation so that the `init` and the `datetime` function use the same format. `tzinfo` doesn't seem to be used anyway. At least not in this port.