### PR TITLE
ports/stm32: Enable FIFO for H7 controller.

### DIFF
--- a/ports/stm32/Makefile
+++ b/ports/stm32/Makefile
@@ -417,6 +417,12 @@ HAL_SRC_C += $(addprefix $(STM32LIB_HAL_BASE)/Src/stm32$(MCU_SERIES)xx_,\
 	)
 endif
 
+ifeq ($(MCU_SERIES),$(filter $(MCU_SERIES),h7))
+HAL_SRC_C += $(addprefix $(STM32LIB_HAL_BASE)/Src/stm32$(MCU_SERIES)xx_,\
+    hal_uart_ex.c \
+    )
+endif
+
 USBDEV_SRC_C += $(addprefix $(USBDEV_DIR)/,\
 	core/src/usbd_core.c \
 	core/src/usbd_ctlreq.c \

--- a/ports/stm32/boards/stm32h7xx_hal_conf_base.h
+++ b/ports/stm32/boards/stm32h7xx_hal_conf_base.h
@@ -90,6 +90,7 @@
 #include "stm32h7xx_hal_spi.h"
 #include "stm32h7xx_hal_tim.h"
 #include "stm32h7xx_hal_uart.h"
+#include "stm32h7xx_hal_uart_ex.h"
 #include "stm32h7xx_hal_usart.h"
 #include "stm32h7xx_hal_wwdg.h"
 #include "stm32h7xx_ll_adc.h"


### PR DESCRIPTION
On my board I sometimes have the problem that single bytes get lost during UART communication at 115200 baud. I use the `UART.read()` method and see that sometimes single bytes are missing in the middle of the data.
The reason is that sometimes the receive interrupt of the UART is not called fast enough before the next byte is received.
Fortunately, the H7 controller has a hardware FIFO. This was not used in the existing implementation.
I enabled the FIFO in the code for the H7 controller and have never had a problem with missing bytes since.

As far as I know, using the FIFO has no negative effect on communication behaviour. Therefore, I do not think a configuration option is necessary at this point, and it can always be enabled.

I have tested the new implementation on a STM32H753 succesfully.