### PR TITLE
extmod/modplatform: Distinguish RISC-V 64 from RISC-V 32.

### DIFF
--- a/extmod/modplatform.h
+++ b/extmod/modplatform.h
@@ -48,7 +48,11 @@
 #elif defined(__xtensa__)
 #define MICROPY_PLATFORM_ARCH   "xtensa"
 #elif defined(__riscv)
+#if __riscv_xlen == 64
+#define MICROPY_PLATFORM_ARCH   "riscv64"
+#else
 #define MICROPY_PLATFORM_ARCH   "riscv"
+#endif
 #else
 #define MICROPY_PLATFORM_ARCH   ""
 #endif


### PR DESCRIPTION
### Summary

This PR lets the platform module report a more accurate architecture name when running on a RISC-V 64 bits platform.  Before this PR, any RISC-V platform was simply reported as "riscv".  32-bits RISC-V systems are still reported as "riscv" to maintain compatibility with existing code, following the "arm"/"aarch64" split from a previous PR.

On a RV128 system this will still report "riscv" rather than "riscv128" - but I'd love to be notified of that bug report :)

### Testing

Testing was carried out by building the RV64 Unix port and manually checking the output of `import platform ; platform.platform()` when running the binary under QEMU user mode.

```
[/micropython/ports/unix/build-coverage] $ file micropython
micropython: ELF 64-bit LSB pie executable, UCB RISC-V, RVC, double-float ABI, version 1 (SYSV), dynamically linked, interpreter /lib/ld-linux-riscv64-lp64d.so.1, BuildID[sha1]=491ea180d0ab7b9480a251eaabf046cc7f9b7dbf, for GNU/Linux 4.15.0, with debug_info, not stripped

[/micropython/ports/unix/build-coverage] $ qemu-riscv64 ./micropython
MicroPython v1.24.0-preview.551.g406bccc75.dirty on 2024-12-04; linux [GCC 11.4.0] version
Use Ctrl-D to exit, Ctrl-E for paste mode
>>> import platform ; platform.platform()
'Linux-1.25.0-preview-riscv64--with-glibc2.35'
>>> 
```

### Trade-offs and Alternatives

As in the aarch32/aarch64 split PR, there is a small chance for compatibility issues with code that expects to find a "riscv" system instead of a "riscv64" system.