### PR TITLE
ci: Add GitHub Actions caching for Zephyr

### DIFF
--- a/.github/workflows/ports_zephyr.yml
+++ b/.github/workflows/ports_zephyr.yml
@@ -42,6 +42,10 @@ jobs:
         # cache the "workspace"
         path: ./zephyrproject
         key: zephyr-workspace-${{ steps.versions.outputs.ZEPHYR }}
+    - name: ccache
+      uses: hendrikmuhs/ccache-action@v1.2
+      with:
+        key: zephyr
     - name: Install packages
       run: source tools/ci.sh && ci_zephyr_setup
     - name: Install Zephyr

--- a/.github/workflows/ports_zephyr.yml
+++ b/.github/workflows/ports_zephyr.yml
@@ -30,9 +30,22 @@ jobs:
         docker-images: false
         swap-storage: false
     - uses: actions/checkout@v4
+    - id: versions
+      name: Read Zephyr version
+      run: source tools/ci.sh && echo "ZEPHYR=$ZEPHYR_VERSION" | tee "$GITHUB_OUTPUT"
+    - name: Cached Zephyr Workspace
+      id: cache_workspace
+      uses: actions/cache@v4
+      with:
+        # note that the Zephyr CI docker image is 15GB. At time of writing
+        # GitHub caches are limited to 10GB total for a project. So we only
+        # cache the "workspace"
+        path: ./zephyrproject
+        key: zephyr-workspace-${{ steps.versions.outputs.ZEPHYR }}
     - name: Install packages
       run: source tools/ci.sh && ci_zephyr_setup
     - name: Install Zephyr
+      if: steps.cache_workspace.outputs.cache-hit != 'true'
       run: source tools/ci.sh && ci_zephyr_install
     - name: Build
       run: source tools/ci.sh && ci_zephyr_build

--- a/tools/ci.sh
+++ b/tools/ci.sh
@@ -754,12 +754,15 @@ function ci_zephyr_setup {
     # Directories cached by GitHub Actions, mounted
     # into the container
     ZEPHYRPROJECT_DIR="$(pwd)/zephyrproject"
+    CCACHE_DIR="$(pwd)/.ccache"
 
     mkdir -p "${ZEPHYRPROJECT_DIR}"
+    mkdir -p "${CCACHE_DIR}"
 
     docker run --name zephyr-ci -d -it \
       -v "$(pwd)":/micropython \
       -v "${ZEPHYRPROJECT_DIR}":/zephyrproject \
+      -v "${CCACHE_DIR}":/root/.cache/ccache \
       -e ZEPHYR_SDK_INSTALL_DIR=/opt/toolchains/zephyr-sdk-${ZEPHYR_SDK_VERSION} \
       -e ZEPHYR_TOOLCHAIN_VARIANT=zephyr \
       -e ZEPHYR_BASE=/zephyrproject/zephyr \

--- a/tools/ci.sh
+++ b/tools/ci.sh
@@ -747,7 +747,7 @@ ZEPHYR_SDK_VERSION=0.16.8
 ZEPHYR_VERSION=v3.7.0
 
 function ci_zephyr_setup {
-    IMAGE=zephyrprojectrtos/ci:${ZEPHYR_DOCKER_VERSION}
+    IMAGE=ghcr.io/zephyrproject-rtos/ci:${ZEPHYR_DOCKER_VERSION}
 
     docker pull ${IMAGE}
 

--- a/tools/ci.sh
+++ b/tools/ci.sh
@@ -747,14 +747,24 @@ ZEPHYR_SDK_VERSION=0.16.8
 ZEPHYR_VERSION=v3.7.0
 
 function ci_zephyr_setup {
-    docker pull zephyrprojectrtos/ci:${ZEPHYR_DOCKER_VERSION}
+    IMAGE=zephyrprojectrtos/ci:${ZEPHYR_DOCKER_VERSION}
+
+    docker pull ${IMAGE}
+
+    # Directories cached by GitHub Actions, mounted
+    # into the container
+    ZEPHYRPROJECT_DIR="$(pwd)/zephyrproject"
+
+    mkdir -p "${ZEPHYRPROJECT_DIR}"
+
     docker run --name zephyr-ci -d -it \
       -v "$(pwd)":/micropython \
+      -v "${ZEPHYRPROJECT_DIR}":/zephyrproject \
       -e ZEPHYR_SDK_INSTALL_DIR=/opt/toolchains/zephyr-sdk-${ZEPHYR_SDK_VERSION} \
       -e ZEPHYR_TOOLCHAIN_VARIANT=zephyr \
       -e ZEPHYR_BASE=/zephyrproject/zephyr \
       -w /micropython/ports/zephyr \
-      zephyrprojectrtos/ci:${ZEPHYR_DOCKER_VERSION}
+      ${IMAGE}
     docker ps -a
 
     # qemu-system-arm is needed to run the test suite.


### PR DESCRIPTION
### Summary

Reduces Zephyr CI build times by approx 50%.

### Details

Zephyr is one of the slower-running CI jobs, partially as it has to pull a docker image and then clone the Zephyr repository (including submodules). This PR tackles this in a few places:

1. Cache the Zephyr Workspace (similar to ESP-IDF caching in #13090). The Zephyr workspace is about 2.5GB!!
2. ~~Cache the Docker image.~~ Turns out not feasible as the image is 15GB(!), and each repository only gets 10GB of cache in total. Have removed from this PR.
3. Switch the Docker image source to the GitHub Container Registry rather than Docker Hub. Benefit seems marginal, the "Install Packages" step that pulls the image takes between 2 and 3 minutes each time with a lot of variation. However I did see the fastest time yet (1m52s) pulling from the GitHub Registry so there might be some benefit there. :shrug: 
4. Added ccache persistence, similar to the ESP32 CI workflow (but a little more complex as the ccache directory needs to be mounted into the container).

*This work was funded through GitHub Sponsors.*

### Testing

All up, the total Zephyr build job is down from (for example) [11m4s on master](https://github.com/micropython/micropython/actions/runs/12343941960/job/34445781228) to [5m17s on this branch with a warm cache](https://github.com/micropython/micropython/actions/runs/12366470093/job/34514261104).

A cold cache run takes about 40s longer than before (due to creating the workspace cache), but this should happen very infrequently (for example: the ESP-IDF v5.2.2 cache object is now 4 months old and gets reused many times every day.)

There is a lot of variation between runs (as much as 2-3 minutes), but there are consistently speedups resulting from changes 1 and 4 and a possible small speedup from change 3.

### Trade-Offs and Alternatives

* I don't see other easy performance improvements, as 50% of the build time is now pulling the Zephyr CI image. We could probably get rid of this step entirely by downloading just the Zephyr SDK tarball (and caching it), as we don't need most of [what's in the CI image](https://github.com/zephyrproject-rtos/docker-image/blob/main/Dockerfile.ci#L135). However then we have the maintenance task of keeping it working through updates, instead of using the supported image.