### PR TITLE
renesas-ra/modrenesas: Expose the Flash block device in a renesas module.

### DIFF
--- a/ports/renesas-ra/Makefile
+++ b/ports/renesas-ra/Makefile
@@ -250,6 +250,7 @@ SRC_C += \
 	machine_pin.c \
 	machine_rtc.c \
 	machine_sdcard.c \
+	modrenesas.c \
 	extint.c \
 	usrsw.c \
 	flash.c \

--- a/ports/renesas-ra/modrenesas.c
+++ b/ports/renesas-ra/modrenesas.c
@@ -1,0 +1,41 @@
+/*
+ * This file is part of the MicroPython project, http://micropython.org/
+ *
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2019 Damien P. George
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#include "py/runtime.h"
+#include "storage.h"
+
+static const mp_rom_map_elem_t renesas_module_globals_table[] = {
+    { MP_ROM_QSTR(MP_QSTR___name__), MP_ROM_QSTR(MP_QSTR_renesas) },
+    { MP_ROM_QSTR(MP_QSTR_Flash),    MP_ROM_PTR(&pyb_flash_type) },
+};
+static MP_DEFINE_CONST_DICT(renesas_module_globals, renesas_module_globals_table);
+
+const mp_obj_module_t mp_module_renesas = {
+    .base = { &mp_type_module },
+    .globals = (mp_obj_dict_t *)&renesas_module_globals,
+};
+
+MP_REGISTER_MODULE(MP_QSTR_renesas, mp_module_renesas);


### PR DESCRIPTION
### Summary

Allowing to use Python methods for creating and modifying the file system. The Flash block device for the file system can be accessed with:

    from renesas import Flash
    bdev = Flash(start=0)

With the block device accessible for Python, the startup code for mounting and eventually creating the file system can be implemented e.g. as `_boot.py` script, replacing the existing C code and allowing to use for instance LFS1 as file system. That saves >12k of flash space and increases the available file system size from 19k to 34k at a RA4M1 device. Deactivating the C startup code can be configured in mpconfigboard.h with the settings:
```
// Disable the C startup code for mounting the file system
#define MICROPY_HW_FLASH_MOUNT_AT_BOOT (0)
// Disable the boot mode select. If needed, use Python code
#define MICROPY_BOARD_BEFORE_SOFT_RESET_LOOP(x)
// Use _boot.py to mount flash at boot and to handle boot mode selection.
#define MICROPY_BOARD_FROZEN_BOOT_FILE "_boot.py"
```
### Testing

Tested with a RA4M1 board (Weact RA4M1 core module) and a RA6M2 board.
