### PR TITLE
stm32/pin: add config options to exclude legacy items, alt function support, and cpu/board objects

### DIFF
--- a/ports/stm32/mpconfigboard_common.h
+++ b/ports/stm32/mpconfigboard_common.h
@@ -52,6 +52,11 @@
 #define MICROPY_PY_PYB_LEGACY (1)
 #endif
 
+// Whether to include legacy methods and constants in machine.Pin (which is also pyb.Pin).
+#ifndef MICROPY_PY_MACHINE_PIN_LEGACY
+#define MICROPY_PY_MACHINE_PIN_LEGACY (!MICROPY_PREVIEW_VERSION_2)
+#endif
+
 // Whether machine.bootloader() will enter the bootloader via reset, or direct jump.
 #ifndef MICROPY_HW_ENTER_BOOTLOADER_VIA_RESET
 #define MICROPY_HW_ENTER_BOOTLOADER_VIA_RESET (1)

--- a/ports/stm32/mpconfigboard_common.h
+++ b/ports/stm32/mpconfigboard_common.h
@@ -57,6 +57,11 @@
 #define MICROPY_PY_MACHINE_PIN_LEGACY (!MICROPY_PREVIEW_VERSION_2)
 #endif
 
+// Whether to include support for alternate function selection in machine.Pin (and pyb.Pin).
+#ifndef MICROPY_PY_MACHINE_PIN_ALT_SUPPORT
+#define MICROPY_PY_MACHINE_PIN_ALT_SUPPORT (1)
+#endif
+
 // Whether machine.bootloader() will enter the bootloader via reset, or direct jump.
 #ifndef MICROPY_HW_ENTER_BOOTLOADER_VIA_RESET
 #define MICROPY_HW_ENTER_BOOTLOADER_VIA_RESET (1)

--- a/ports/stm32/pin.c
+++ b/ports/stm32/pin.c
@@ -280,6 +280,8 @@ static mp_obj_t pin_call(mp_obj_t self_in, size_t n_args, size_t n_kw, const mp_
     }
 }
 
+#if MICROPY_PY_MACHINE_PIN_LEGACY
+
 /// \classmethod mapper([fun])
 /// Get or set the pin mapper function.
 static mp_obj_t pin_mapper(size_t n_args, const mp_obj_t *args) {
@@ -304,20 +306,6 @@ static mp_obj_t pin_map_dict(size_t n_args, const mp_obj_t *args) {
 static MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(pin_map_dict_fun_obj, 1, 2, pin_map_dict);
 static MP_DEFINE_CONST_CLASSMETHOD_OBJ(pin_map_dict_obj, MP_ROM_PTR(&pin_map_dict_fun_obj));
 
-/// \classmethod af_list()
-/// Returns an array of alternate functions available for this pin.
-static mp_obj_t pin_af_list(mp_obj_t self_in) {
-    machine_pin_obj_t *self = MP_OBJ_TO_PTR(self_in);
-    mp_obj_t result = mp_obj_new_list(0, NULL);
-
-    const pin_af_obj_t *af = self->af;
-    for (mp_uint_t i = 0; i < self->num_af; i++, af++) {
-        mp_obj_list_append(result, MP_OBJ_FROM_PTR(af));
-    }
-    return result;
-}
-static MP_DEFINE_CONST_FUN_OBJ_1(pin_af_list_obj, pin_af_list);
-
 /// \classmethod debug([state])
 /// Get or set the debugging state (`True` or `False` for on or off).
 static mp_obj_t pin_debug(size_t n_args, const mp_obj_t *args) {
@@ -329,6 +317,8 @@ static mp_obj_t pin_debug(size_t n_args, const mp_obj_t *args) {
 }
 static MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(pin_debug_fun_obj, 1, 2, pin_debug);
 static MP_DEFINE_CONST_CLASSMETHOD_OBJ(pin_debug_obj, MP_ROM_PTR(&pin_debug_fun_obj));
+
+#endif // MICROPY_PY_MACHINE_PIN_LEGACY
 
 // init(mode, pull=None, alt=-1, *, value, alt)
 static mp_obj_t pin_obj_init_helper(const machine_pin_obj_t *self, size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
@@ -442,6 +432,8 @@ static mp_obj_t pin_irq(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_ar
 }
 static MP_DEFINE_CONST_FUN_OBJ_KW(pin_irq_obj, 1, pin_irq);
 
+#if MICROPY_PY_MACHINE_PIN_LEGACY
+
 /// \method name()
 /// Get the pin name.
 static mp_obj_t pin_name(mp_obj_t self_in) {
@@ -468,6 +460,20 @@ static mp_obj_t pin_names(mp_obj_t self_in) {
     return result;
 }
 static MP_DEFINE_CONST_FUN_OBJ_1(pin_names_obj, pin_names);
+
+/// \classmethod af_list()
+/// Returns an array of alternate functions available for this pin.
+static mp_obj_t pin_af_list(mp_obj_t self_in) {
+    machine_pin_obj_t *self = MP_OBJ_TO_PTR(self_in);
+    mp_obj_t result = mp_obj_new_list(0, NULL);
+
+    const pin_af_obj_t *af = self->af;
+    for (mp_uint_t i = 0; i < self->num_af; i++, af++) {
+        mp_obj_list_append(result, MP_OBJ_FROM_PTR(af));
+    }
+    return result;
+}
+static MP_DEFINE_CONST_FUN_OBJ_1(pin_af_list_obj, pin_af_list);
 
 /// \method port()
 /// Get the pin port.
@@ -520,6 +526,8 @@ static mp_obj_t pin_af(mp_obj_t self_in) {
 }
 static MP_DEFINE_CONST_FUN_OBJ_1(pin_af_obj, pin_af);
 
+#endif // MICROPY_PY_MACHINE_PIN_LEGACY
+
 static const mp_rom_map_elem_t pin_locals_dict_table[] = {
     // instance methods
     { MP_ROM_QSTR(MP_QSTR_init),    MP_ROM_PTR(&pin_init_obj) },
@@ -531,6 +539,7 @@ static const mp_rom_map_elem_t pin_locals_dict_table[] = {
     // Legacy names as used by pyb.Pin
     { MP_ROM_QSTR(MP_QSTR_low),     MP_ROM_PTR(&pin_off_obj) },
     { MP_ROM_QSTR(MP_QSTR_high),    MP_ROM_PTR(&pin_on_obj) },
+    #if MICROPY_PY_MACHINE_PIN_LEGACY
     { MP_ROM_QSTR(MP_QSTR_name),    MP_ROM_PTR(&pin_name_obj) },
     { MP_ROM_QSTR(MP_QSTR_names),   MP_ROM_PTR(&pin_names_obj) },
     { MP_ROM_QSTR(MP_QSTR_af_list), MP_ROM_PTR(&pin_af_list_obj) },
@@ -540,11 +549,14 @@ static const mp_rom_map_elem_t pin_locals_dict_table[] = {
     { MP_ROM_QSTR(MP_QSTR_mode),    MP_ROM_PTR(&pin_mode_obj) },
     { MP_ROM_QSTR(MP_QSTR_pull),    MP_ROM_PTR(&pin_pull_obj) },
     { MP_ROM_QSTR(MP_QSTR_af),      MP_ROM_PTR(&pin_af_obj) },
+    #endif
 
+    #if MICROPY_PY_MACHINE_PIN_LEGACY
     // class methods
     { MP_ROM_QSTR(MP_QSTR_mapper),  MP_ROM_PTR(&pin_mapper_obj) },
     { MP_ROM_QSTR(MP_QSTR_dict),    MP_ROM_PTR(&pin_map_dict_obj) },
     { MP_ROM_QSTR(MP_QSTR_debug),   MP_ROM_PTR(&pin_debug_obj) },
+    #endif
 
     // class attributes
     { MP_ROM_QSTR(MP_QSTR_board),   MP_ROM_PTR(&pin_board_pins_obj_type) },
@@ -562,12 +574,14 @@ static const mp_rom_map_elem_t pin_locals_dict_table[] = {
     { MP_ROM_QSTR(MP_QSTR_IRQ_RISING), MP_ROM_INT(GPIO_MODE_IT_RISING) },
     { MP_ROM_QSTR(MP_QSTR_IRQ_FALLING), MP_ROM_INT(GPIO_MODE_IT_FALLING) },
 
+    #if MICROPY_PY_MACHINE_PIN_LEGACY
     // legacy class constants
     { MP_ROM_QSTR(MP_QSTR_OUT_PP),    MP_ROM_INT(GPIO_MODE_OUTPUT_PP) },
     { MP_ROM_QSTR(MP_QSTR_OUT_OD),    MP_ROM_INT(GPIO_MODE_OUTPUT_OD) },
     { MP_ROM_QSTR(MP_QSTR_AF_PP),     MP_ROM_INT(GPIO_MODE_AF_PP) },
     { MP_ROM_QSTR(MP_QSTR_AF_OD),     MP_ROM_INT(GPIO_MODE_AF_OD) },
     { MP_ROM_QSTR(MP_QSTR_PULL_NONE), MP_ROM_INT(GPIO_NOPULL) },
+    #endif
 
     #include "genhdr/pins_af_const.h"
 };

--- a/ports/stm32/pin.c
+++ b/ports/stm32/pin.c
@@ -577,8 +577,12 @@ static const mp_rom_map_elem_t pin_locals_dict_table[] = {
     #endif
 
     // class attributes
+    #if MICROPY_PY_MACHINE_PIN_BOARD_NUM_ENTRIES > 0
     { MP_ROM_QSTR(MP_QSTR_board),   MP_ROM_PTR(&pin_board_pins_obj_type) },
+    #endif
+    #if MICROPY_PY_MACHINE_PIN_CPU_NUM_ENTRIES > 0
     { MP_ROM_QSTR(MP_QSTR_cpu),     MP_ROM_PTR(&pin_cpu_pins_obj_type) },
+    #endif
 
     // class constants
     { MP_ROM_QSTR(MP_QSTR_IN),        MP_ROM_INT(GPIO_MODE_INPUT) },

--- a/tools/boardgen.py
+++ b/tools/boardgen.py
@@ -172,6 +172,8 @@ class PinGenerator:
         self._pins = []
         self._pin_type = pin_type
         self._enable_af = enable_af
+        self._pin_cpu_num_entries = 0
+        self._pin_board_num_entries = 0
 
     # Allows a port to define a known cpu pin (without relying on it being in the
     # csv file).
@@ -298,6 +300,9 @@ class PinGenerator:
                     # Don't include hidden pins in Pins.board.
                     continue
 
+                # Keep track of the total number of Pin.board entries.
+                self._pin_board_num_entries += 1
+
                 # We don't use the enable macro for board pins, because they
                 # shouldn't be referenced in pins.csv unless they're
                 # available.
@@ -322,6 +327,9 @@ class PinGenerator:
             file=out_source,
         )
         for pin in self.available_pins(exclude_hidden=True):
+            # Keep track of the total number of Pin.cpu entries.
+            self._pin_cpu_num_entries += 1
+
             m = pin.enable_macro()
             if m:
                 print("    #if {}".format(m), file=out_source)
@@ -351,6 +359,20 @@ class PinGenerator:
 
     # Print the pin_CPUNAME and pin_BOARDNAME macros.
     def print_defines(self, out_header, cpu=True, board=True):
+        # Provide #defines for the number of cpu and board pins.
+        print(
+            "#define MICROPY_PY_MACHINE_PIN_CPU_NUM_ENTRIES ({})".format(
+                self._pin_cpu_num_entries
+            ),
+            file=out_header,
+        )
+        print(
+            "#define MICROPY_PY_MACHINE_PIN_BOARD_NUM_ENTRIES ({})".format(
+                self._pin_board_num_entries
+            ),
+            file=out_header,
+        )
+
         # Provide #defines for each cpu pin.
         for pin in self.available_pins():
             print(file=out_header)


### PR DESCRIPTION
### Summary

stm32's `Pin` class has a lot of legacy entries in it.  This PR adds config options to exclude them if desired by a board.  Also adds some other related options to exclude other pin entries:
- `MICROPY_PY_MACHINE_PIN_LEGACY` can be disabled to exclude all the methods and constants that are not part of the standard `machine.Pin` set
- `MICROPY_PY_MACHINE_PIN_ALT_SUPPORT` can be disabled to exclude support for alternate functions
- `machine.Pin.cpu` and `machine.Pin.board` are excluded automatically if they contain no entries

These are all enabled by default so nothing should change on existing board configurations.

### Testing

Tested on PYBV10, by disabling the options, and by removing all `Pin.board` names in `pins.csv`.

### Trade-offs and Alternatives

This is useful for a board to have fine control over what's available in `machine.Pin`.  Without these config options a board would need to copy all the `Pin` code in order to customise/exclude these legacy items.