### PR TITLE
ports/renesas-ra/Makefile: Fix binary file generation.

### DIFF
--- a/ports/renesas-ra/Makefile
+++ b/ports/renesas-ra/Makefile
@@ -442,7 +442,8 @@ endef
 
 define GENERATE_BIN
 	$(ECHO) "GEN $(1)"
-	$(Q)$(OBJCOPY) -I ihex -O binary $(2) $(1)
+	$(Q)$(OBJCOPY) -O binary -j .id_code $(2) $(BUILD)/id_code.bin
+	$(Q)$(OBJCOPY) -O binary --remove-section=.id_code $(2) $(1)
 endef
 
 define GENERATE_HEX
@@ -452,7 +453,7 @@ endef
 
 .PHONY:
 
-$(BUILD)/firmware.bin: $(BUILD)/firmware.hex
+$(BUILD)/firmware.bin: $(BUILD)/firmware.elf
 	$(call GENERATE_BIN,$@,$^)
 
 $(BUILD)/firmware.hex: $(BUILD)/firmware.elf


### PR DESCRIPTION
The linker scripts for most of these microcontrollers contain non-contiguous flash sections that result in big binary files, that exceed the flash size. This fixes the binary files by copying only the text and data sections.

For example, every `.bin` hosted here is 16 Mbytes https://micropython.org/download/EK_RA4M1/

### Testing

Tested uploading binaries to two RA boards, before it was impossible to upload the binary due to its size.