### PR TITLE
rp2/modmachine: Fix lightsleep returning early.

### DIFF
--- a/ports/rp2/modmachine.c
+++ b/ports/rp2/modmachine.c
@@ -245,8 +245,11 @@ static void mp_machine_lightsleep(size_t n_args, const mp_obj_t *args) {
         #endif
         #endif
 
-        // Go into low-power mode.
-        __wfi();
+        // A timer other than #3 could fire.
+        // Repeatedly go into low-power mode until timer 3 is no longer armed.
+        while (timer_hw->armed & (1u << alarm_num)) {
+            __wfi();
+        }
 
         if (!timer3_enabled) {
             irq_set_enabled(irq_num, false);


### PR DESCRIPTION
fixes #16181

Commit 74fb42a added code using hardware timer 2.
Prior to that only lightsleep used hardware timers specifically timer 3.
It turned off almost all hardware blocks except hardware timers and waits for an interrupt.
It did not check if the interrupt is from hardware timers or if it is from timer 3.

With this change, lightsleep now loops calling __wfi() until timer 3 has fired. Without the loop lightsleep would return very early.

Ideally this pull request should be reviewed by user @projectgus  who made the changes in commit 74fb42a and has also made changes to modmachine.c lightsleep.

### Testing
Tested on PICO W using thonny with code from the issue. Works fine.


