### PR TITLE
rp2: Fix soft timer expiry waking early from lightsleep.

### DIFF
--- a/ports/rp2/mphalport.c
+++ b/ports/rp2/mphalport.c
@@ -250,9 +250,13 @@ static void soft_timer_hardware_callback(unsigned int alarm_num) {
     // a second ISR, as PendSV may be currently suspended by the other CPU.
     pendsv_schedule_dispatch(PENDSV_DISPATCH_SOFT_TIMER, soft_timer_handler);
 
-    // This ISR only runs on core0, but if core1 is running Python code then it
-    // may be blocked in WFE so wake it up as well. Unfortunately this also sets
-    // the event flag on core0, so a subsequent WFE on this core will not suspend
+    // This ISR mostly only runs on core0 but may run on core1 if core1 calls
+    // machine.lightsleep().
+    //
+    // Either way, if the other core is running Python code then it may be
+    // blocked in WFE so wake it up as well. Unfortunately this also sets the
+    // event flag on this core, so a subsequent WFE on this core will not
+    // suspend
     #if MICROPY_PY_THREAD
     if (core1_entry != NULL) {
         __sev();

--- a/tests/ports/rp2/rp2_lightsleep.py
+++ b/tests/ports/rp2/rp2_lightsleep.py
@@ -9,7 +9,7 @@
 # A range of sleep periods (1 to 512ms) are tested. The total nominal sleep time
 # is 10.23 seconds, but on most ports this will finish much earlier as interrupts
 # happen before each timeout expires.
-import sys
+import sys, time
 
 try:
     from machine import lightsleep, Pin
@@ -27,10 +27,28 @@ try:
 except AttributeError:
     led = None
 
+t0 = time.ticks_ms()
+
 for n in range(100):
     if led:
         led.toggle()
     sys.stdout.write(chr(ord("a") + (n % 26)))
     lightsleep(2 ** (n % 10))
 
-print("\nDONE")
+print()  # end of line
+
+delta = time.ticks_diff(time.ticks_ms(), t0)
+
+if delta < 2500:
+    # As per note above, we don't expect the full 10.23 seconds
+    # but a very short total runtime may indicate a bug with
+    # lightsleep
+    print("Unexpected short test time", delta, "ms")
+elif delta > 11000:
+    # Similarly, the test shouldn't take much longer than the max lightsleep
+    # time
+    print("Unexpected long test time", delta, "ms")
+else:
+    print("Test time OK")
+
+print("DONE")

--- a/tests/ports/rp2/rp2_lightsleep.py.exp
+++ b/tests/ports/rp2/rp2_lightsleep.py.exp
@@ -1,2 +1,3 @@
 abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuv
+Test time OK
 DONE

--- a/tests/ports/rp2/rp2_lightsleep_thread.py
+++ b/tests/ports/rp2/rp2_lightsleep_thread.py
@@ -1,0 +1,60 @@
+# Verify that a thread running on CPU1 can go to lightsleep
+# and wake up in the expected timeframe
+import _thread
+import time
+import unittest
+from machine import lightsleep, Pin
+
+try:
+    led = Pin(Pin.board.LED, Pin.OUT)
+except AttributeError:
+    led = None
+
+N_SLEEPS = 5
+SLEEP_MS = 250
+
+IDEAL_RUNTIME = N_SLEEPS * SLEEP_MS
+MAX_RUNTIME = (N_SLEEPS + 1) * SLEEP_MS
+
+
+class LightSleepInThread(unittest.TestCase):
+    def thread_entry(self, is_thread=True):
+        led.toggle()
+        for _ in range(N_SLEEPS):
+            lightsleep(SLEEP_MS)
+            led.toggle()
+        if is_thread:
+            self.thread_done = True
+
+    def elapsed_ms(self):
+        return time.ticks_diff(time.ticks_ms(), self.t0)
+
+    def setUp(self):
+        self.thread_done = False
+        self.t0 = time.ticks_ms()
+
+    def test_cpu0_busy(self):
+        _thread.start_new_thread(self.thread_entry, ())
+        # CPU0 is busy-waiting not asleep itself
+        while not self.thread_done:
+            self.assertLessEqual(self.elapsed_ms(), MAX_RUNTIME)
+        self.assertAlmostEqual(self.elapsed_ms(), IDEAL_RUNTIME, delta=IDEAL_RUNTIME / 2)
+
+    def test_cpu0_sleeping(self):
+        _thread.start_new_thread(self.thread_entry, ())
+        time.sleep_ms(MAX_RUNTIME)
+        self.assertTrue(self.thread_done)
+        self.assertAlmostEqual(self.elapsed_ms(), IDEAL_RUNTIME, delta=IDEAL_RUNTIME / 2)
+
+    def test_cpu0_also_lightsleep(self):
+        _thread.start_new_thread(self.thread_entry, ())
+        time.sleep(0.050)  # account for any delay in starting the thread
+        self.thread_entry(False)  # does the same lightsleep loop, doesn't set the done flag
+        self.assertTrue(self.thread_done)
+        # only one thread can actually be in lightsleep at a time to avoid races, so the total
+        # runtime is doubled by doing it on both CPUs
+        self.assertAlmostEqual(self.elapsed_ms(), IDEAL_RUNTIME * 2, delta=IDEAL_RUNTIME)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
### Summary

Fixes #16181 and partial fix for #16180. Specifically: bug where PICO-W build won't lightsleep() for more than 64ms.

### Details

This is a regression introduced in 74fb42a (#13329) when we switched away from the pico-sdk alarm pool for soft timers and accidentally made soft timer expiry a wakeup source.

Before 74fb42a (including V1.23), both the pico-sdk alarm pool and the lightsleep wakeup timer uses alarm 3. The lightsleep timer would quietly clobber alarm 3's timeout, meaning softtimer events wouldn't wake the chip from lightsleep.

After 74fb42a (including V1.24), soft timer wakeup happens on timer alarm 2 so this interrupt can wake the chip from light sleep. On PICO-W builds this happens every lwIP tick (64ms) which is unexpected.

The change here is to go back to using the same timer alarm for both lightsleep wakeup and soft timer, but now being explicit about lightsleep wakeup clobbering any soft timer wakeup. Also adds a "catch up" call to soft timer handler as it's not currently there.

This also reworks the changes added in 19844b4 to enable the timer IRQ on CPU1. The functionality is basically the same, just being a bit more explicit and by reworking this and the other code there's no more "magic IRQ number 3" in this code.

*Thanks to @cpottle9 for investigating this issue and pinpointing 74fb42a as the regression commit.* :pray:

*This work was funded through GitHub Sponsors.*

### Testing

* [x] Basic test case on PICO-W.
* [x] Unit tests pass on PICO-W.
* [x] Test wakeup from pin IRQ as also reported in #16180 (might need to be fixed separately). (Note: Tested this works provided timeout is provided, issue without timeout is tracked in #7035)
* [ ] Test on RP2350 (help wanted, have ordered hardware but probably won't get until next year).
* [x] Add unit test for light sleep running from thread on core1.
* [x] ~~Add unit test verifying that soft timer callbacks resume after waking from lightsleep.~~ EDIT: Can't do this actually, as `machine.Timer()` uses the alarm pool. However, lightsleep and Wi-Fi are compatible so soft timer is resuming OK.
* [x] Test Wi-Fi stays valid after lightsleep (with a timeout).  

### Trade-offs and Alternatives

* We were hoping to go back to the pico-sdk alarm pool rather than using our own hardware timer alarm now that https://github.com/raspberrypi/pico-sdk/issues/1812 is closed, however @dpgeorge [mentioned here](https://github.com/micropython/micropython/pull/16412#discussion_r1886101759) that the new version of the alarm pool may have another bug - maybe the one fixed in https://github.com/raspberrypi/pico-sdk/pull/2127 ?
* In general, it might be expected that soft timers added by Python code can wake the rp2 from lightsleep. In that case, we could fix this by disabling the 64ms lwIP tick wakeup timer before going to lightsleep. Lightsleep wakeup could then be just another soft timer entry.
* More extreme analysis would be that lwIP tick should wake from lightsleep so that TCP connections can stay up, etc. I'm not sure I buy this one as the rp2 port is already tickless so "idle" is close to this behaviour, but you could make the case. If doing that instead then we should at least disable the lwIP tick while no network interface is up, though.