### PR TITLE
tests/run-tests.py: Set name of injected test module to '__main__'.

### DIFF
--- a/tests/run-tests.py
+++ b/tests/run-tests.py
@@ -59,10 +59,13 @@ DIFF = os.getenv("MICROPY_DIFF", "diff -u")
 os.environ["PYTHONIOENCODING"] = "utf-8"
 
 # Code to allow a target MicroPython to import an .mpy from RAM
+# Note: the module is named `__injected_test` but it needs to have `__name__` set to
+# `__main__` so that the test sees itself as the main module, eg so unittest works.
 injected_import_hook_code = """\
 import sys, os, io, vfs
 class __File(io.IOBase):
   def __init__(self):
+    sys.modules['__injected_test'].__name__ = '__main__'
     self.off = 0
   def ioctl(self, request, arg):
     return 0


### PR DESCRIPTION
### Summary

Running unittest-based tests with `--via-mpy` is currently broken, because the unittest test needs the module to be named `__main__`, whereas it's actually called `__injected_test`.

Fix this by changing the name when the file is opened.

### Testing

The following now works:
```
$ ./run-tests.py -t a0 --via-mpy extmod/machine1.py
```

### Trade-offs and Alternatives

This fix is a little hacky.

An alternative would be to just make unittest-based tests do this at the end of the file:
```py
unittest.main(__name__)
```
(Instead of `if __name__ == '__main__': unittest.main()`).

