### PR TITLE
tests: Fix all file ioctl's to support only MP_STREAM_CLOSE.

### DIFF
--- a/tests/micropython/builtin_execfile.py
+++ b/tests/micropython/builtin_execfile.py
@@ -16,7 +16,9 @@ class File(io.IOBase):
         self.off = 0
 
     def ioctl(self, request, arg):
-        return 0
+        if request == 4:  # MP_STREAM_CLOSE
+            return 0
+        return -1
 
     def readinto(self, buf):
         buf[:] = memoryview(self.data)[self.off : self.off + len(buf)]

--- a/tests/micropython/import_mpy_invalid.py
+++ b/tests/micropython/import_mpy_invalid.py
@@ -22,7 +22,9 @@ class UserFile(io.IOBase):
         return n
 
     def ioctl(self, req, arg):
-        return 0
+        if req == 4:  # MP_STREAM_CLOSE
+            return 0
+        return -1
 
 
 class UserFS:

--- a/tests/micropython/import_mpy_native.py
+++ b/tests/micropython/import_mpy_native.py
@@ -28,7 +28,9 @@ class UserFile(io.IOBase):
         return n
 
     def ioctl(self, req, arg):
-        return 0
+        if req == 4:  # MP_STREAM_CLOSE
+            return 0
+        return -1
 
 
 class UserFS:

--- a/tests/micropython/import_mpy_native_gc.py
+++ b/tests/micropython/import_mpy_native_gc.py
@@ -22,7 +22,9 @@ class UserFile(io.IOBase):
         return n
 
     def ioctl(self, req, arg):
-        return 0
+        if req == 4:  # MP_STREAM_CLOSE
+            return 0
+        return -1
 
 
 class UserFS:

--- a/tests/perf_bench/core_import_mpy_multi.py
+++ b/tests/perf_bench/core_import_mpy_multi.py
@@ -31,7 +31,9 @@ class File(io.IOBase):
         self.off = 0
 
     def ioctl(self, request, arg):
-        return 0
+        if request == 4:  # MP_STREAM_CLOSE
+            return 0
+        return -1
 
     def readinto(self, buf):
         buf[:] = memoryview(file_data)[self.off : self.off + len(buf)]

--- a/tests/perf_bench/core_import_mpy_single.py
+++ b/tests/perf_bench/core_import_mpy_single.py
@@ -86,7 +86,9 @@ class File(io.IOBase):
         self.off = 0
 
     def ioctl(self, request, arg):
-        return 0
+        if request == 4:  # MP_STREAM_CLOSE
+            return 0
+        return -1
 
     def readinto(self, buf):
         buf[:] = memoryview(file_data)[self.off : self.off + len(buf)]

--- a/tests/run-natmodtests.py
+++ b/tests/run-natmodtests.py
@@ -35,7 +35,9 @@ class __File(io.IOBase):
   def __init__(self):
     self.off = 0
   def ioctl(self, request, arg):
-    return 0
+    if request == 4: # MP_STREAM_CLOSE
+      return 0
+    return -1
   def readinto(self, buf):
     buf[:] = memoryview(__buf)[self.off:self.off + len(buf)]
     self.off += len(buf)

--- a/tests/run-tests.py
+++ b/tests/run-tests.py
@@ -68,7 +68,9 @@ class __File(io.IOBase):
     sys.modules['__injected_test'].__name__ = '__main__'
     self.off = 0
   def ioctl(self, request, arg):
-    return 0
+    if request == 4: # MP_STREAM_CLOSE
+      return 0
+    return -1
   def readinto(self, buf):
     buf[:] = memoryview(__buf)[self.off:self.off + len(buf)]
     self.off += len(buf)


### PR DESCRIPTION
### Summary

A return value of 0 from Python-level `ioctl()` means success, but if that's returned unconditionally it means that the method supports all ioctl calls, which is not true.  Returning 0 without doing anything can potentially lead to a crash, eg for MP_STREAM_SEEK which requires returning a value in the passed-in struct pointer.

This commit makes it so that all `ioctl()` methods respond only to MP_STREAM_CLOSE, ie they return -1 (indicating error) for all other ioctl calls.

(This change was originally made as part of #8381.  It's no longer needed for that PR but still worth fixing.)

### Testing

This is not technically needed to pass tests -- the CI should continue to pass with this change -- but in the future it may be necessary if new ioctl's are added.
