### PR TITLE
WIP: rp2: Enable GPIO wakeup from indefinite lightsleep, document sleep modes.

### DIFF
--- a/docs/library/machine.Pin.rst
+++ b/docs/library/machine.Pin.rst
@@ -196,6 +196,8 @@ Methods
        These values can also be OR'ed together to make a pin generate interrupts in
        more than one power mode.
 
+       .. note:: The ``wake`` parameter is only available on the cc3200 port.
+
      - ``hard`` if true a hardware interrupt is used. This reduces the delay
        between the pin change and the handler being called. Hard interrupt
        handlers may not allocate memory; see :ref:`isr_rules`.

--- a/docs/library/machine.rst
+++ b/docs/library/machine.rst
@@ -145,8 +145,9 @@ Power related functions
    that require processing.  Such events, or wake sources, should be configured before
    sleeping, like `Pin` change or `RTC` timeout.
 
-   The precise behaviour and power-saving capabilities of lightsleep and deepsleep is
-   highly dependent on the underlying hardware, but the general properties are:
+   The precise behaviour and power-saving capabilities of lightsleep and
+   deepsleep, as well as the available wake-up sources, are all highly dependent
+   on the underlying hardware. The general properties are:
 
    * A lightsleep has full RAM and state retention.  Upon wake execution is resumed
      from the point where the sleep was requested, with all subsystems operational.
@@ -156,6 +157,8 @@ Power related functions
      script, similar to a hard or power-on reset. The `reset_cause()` function will
      return `machine.DEEPSLEEP` and this can be used to distinguish a deepsleep wake
      from other resets.
+
+   For more details consult the quick reference for the port you are using.
 
 .. function:: wake_reason()
 

--- a/docs/rp2/quickref.rst
+++ b/docs/rp2/quickref.rst
@@ -119,6 +119,28 @@ Use the :mod:`time <time>` module::
     start = time.ticks_ms() # get millisecond counter
     delta = time.ticks_diff(time.ticks_ms(), start) # compute time difference
 
+Sleep Modes and Power Consumption
+---------------------------------
+
+On the rp2 port:
+
+* `time.sleep()` and `time.sleep_ms()` will suspend the CPU and reduce power
+  consumption compared to actively executing Python code, with no other
+  restrictions on functionality.
+* `machine.lightsleep()` can be used to suspend most internal peripherals and
+  clocks, with an optional timeout. This uses much less power, with some
+  restrictions on resuming execution:
+
+  * The board will be woken up immediately by any `machine.Pin.irq()` trigger
+    which is active when going into light sleep.
+  * If USB is active then `machine.lightsleep()` will wake up almost immediately
+    when the USB host sends the next packet.
+  * Other than `machine.Pin.irq()` and USB, other peripherals cannot wake the
+    board from light sleep.
+
+* `machine.deepsleep()` is implemented as a light sleep followed by a hard reset
+  of the board following wakeup.
+
 Timers
 ------
 

--- a/ports/rp2/machine_pin.c
+++ b/ports/rp2/machine_pin.c
@@ -94,6 +94,13 @@ static inline bool is_ext_pin(__unused const machine_pin_obj_t *self) {
 #define is_ext_pin(x) false
 #endif
 
+static void mp_gpio_irq_enable(uint gpio, uint32_t events, bool enabled) {
+    // Setting IRQ enabled both allows handler to run and makes this pin wakeup from WFI/WFE
+    gpio_set_irq_enabled(gpio, events, enabled);
+    // ... also make an IRQ pin into a DORMANT mode wake source
+    gpio_set_dormant_irq_enabled(gpio, events, enabled);
+}
+
 static void gpio_irq(void) {
     for (int i = 0; i < num_intr_regs; ++i) {
         uint32_t intr = iobank0_hw->intr[i];
@@ -128,7 +135,7 @@ void machine_pin_deinit(void) {
         if (MICROPY_HW_PIN_RESERVED(i)) {
             continue;
         }
-        gpio_set_irq_enabled(i, GPIO_IRQ_ALL, false);
+        mp_gpio_irq_enable(i, GPIO_IRQ_ALL, false);
     }
     irq_remove_handler(IO_IRQ_BANK0, gpio_irq);
 }
@@ -439,7 +446,7 @@ void mp_hal_pin_interrupt(mp_hal_pin_obj_t pin, mp_obj_t handler, mp_uint_t trig
     machine_pin_irq_obj_t *irq = machine_pin_get_irq(pin);
 
     // Disable all IRQs while data is updated.
-    gpio_set_irq_enabled(pin, GPIO_IRQ_ALL, false);
+    mp_gpio_irq_enable(pin, GPIO_IRQ_ALL, false);
 
     // Update IRQ data.
     irq->base.handler = handler;
@@ -447,9 +454,9 @@ void mp_hal_pin_interrupt(mp_hal_pin_obj_t pin, mp_obj_t handler, mp_uint_t trig
     irq->flags = 0;
     irq->trigger = trigger;
 
-    // Enable IRQ if a handler is given.
-    if (handler != mp_const_none && trigger != MP_HAL_PIN_TRIGGER_NONE) {
-        gpio_set_irq_enabled(pin, trigger, true);
+    if (trigger != MP_HAL_PIN_TRIGGER_NONE) {
+        // Enable IRQ even if no handler is set, so pin can wake CPU from WFI/WFE/dormant
+        mp_gpio_irq_enable(pin, trigger, true);
     }
 }
 
@@ -575,10 +582,10 @@ MP_DEFINE_CONST_OBJ_TYPE(
 static mp_uint_t machine_pin_irq_trigger(mp_obj_t self_in, mp_uint_t new_trigger) {
     machine_pin_obj_t *self = MP_OBJ_TO_PTR(self_in);
     machine_pin_irq_obj_t *irq = MP_STATE_PORT(machine_pin_irq_obj[self->id]);
-    gpio_set_irq_enabled(self->id, GPIO_IRQ_ALL, false);
+    mp_gpio_irq_enable(self->id, GPIO_IRQ_ALL, false);
     irq->flags = 0;
     irq->trigger = new_trigger;
-    gpio_set_irq_enabled(self->id, new_trigger, true);
+    mp_gpio_irq_enable(self->id, new_trigger, true);
     return 0;
 }
 

--- a/ports/rp2/modmachine.c
+++ b/ports/rp2/modmachine.c
@@ -148,8 +148,9 @@ static void alarm_sleep_callback(uint alarm_id) {
 #define DEBUG_LIGHTSLEEP 0
 
 static void mp_machine_lightsleep(size_t n_args, const mp_obj_t *args) {
+    const mp_int_t MAX_TIMER_DELAY_MS = (1ULL << 32) / 1000;
     mp_int_t delay_ms = 0;
-    bool use_timer_alarm = false;
+    bool dormant_mode = (n_args == 0);
 
     if (n_args == 1) {
         delay_ms = mp_obj_get_int(args[0]);
@@ -158,11 +159,8 @@ static void mp_machine_lightsleep(size_t n_args, const mp_obj_t *args) {
             mp_hal_delay_ms(delay_ms);
             return;
         }
-        use_timer_alarm = delay_ms < (1ULL << 32) / 1000;
-        if (use_timer_alarm) {
-            // Use timer alarm to wake.
-        } else {
-            // TODO: Use RTC alarm to wake.
+        if (delay_ms >= MAX_TIMER_DELAY_MS) {
+            // Note: Support could be added in future by using RTC alarm for this wakeup
             mp_raise_ValueError(MP_ERROR_TEXT("sleep too long"));
         }
     }
@@ -185,12 +183,14 @@ static void mp_machine_lightsleep(size_t n_args, const mp_obj_t *args) {
     in_lightsleep = true;
     #endif
 
-    #if MICROPY_HW_ENABLE_USBDEV
-    // Only disable the USB clock if a USB host has not configured the device
-    // or if going to DORMANT mode.
-    bool disable_usb = !(tud_mounted() && n_args > 0);
-    #else
     bool disable_usb = true;
+    #if MICROPY_HW_ENABLE_USBDEV
+    // Don't disable USB if a host has configured the device. Also, don't go to DORMANT
+    // mode as this messes up the USB device state
+    if (tud_mounted()) {
+        disable_usb = false;
+        dormant_mode = false;
+    }
     #endif
     if (disable_usb) {
         clock_stop(clk_usb);
@@ -241,7 +241,7 @@ static void mp_machine_lightsleep(size_t n_args, const mp_obj_t *args) {
     #endif
 
     bool alarm_armed = false;
-    if (n_args == 0) {
+    if (dormant_mode) {
         #if MICROPY_PY_NETWORK_CYW43
         gpio_set_dormant_irq_enabled(CYW43_PIN_WL_HOST_WAKE, GPIO_IRQ_LEVEL_HIGH, true);
         #endif
@@ -249,30 +249,27 @@ static void mp_machine_lightsleep(size_t n_args, const mp_obj_t *args) {
     } else {
         uint32_t save_sleep_en0 = clocks_hw->sleep_en0;
         uint32_t save_sleep_en1 = clocks_hw->sleep_en1;
-        if (use_timer_alarm) {
-            // Use timer alarm to wake.
-            clocks_hw->sleep_en0 = 0x0;
-            #if PICO_RP2040
-            clocks_hw->sleep_en1 = CLOCKS_SLEEP_EN1_CLK_SYS_TIMER_BITS;
-            #elif PICO_RP2350
-            if (watchdog_active) {
-                // clk_sys watchdog and clk_ref ticks must be enabled for the watchdog counter to decrement on RP2350.
-                clocks_hw->sleep_en1 = CLOCKS_SLEEP_EN1_CLK_REF_TICKS_BITS | CLOCKS_SLEEP_EN1_CLK_SYS_TIMER0_BITS | CLOCKS_SLEEP_EN1_CLK_SYS_WATCHDOG_BITS;
-            } else {
-                clocks_hw->sleep_en1 = CLOCKS_SLEEP_EN1_CLK_REF_TICKS_BITS | CLOCKS_SLEEP_EN1_CLK_SYS_TIMER0_BITS;
-            }
-            #else
-            #error Unknown processor
-            #endif
+
+        // Configure timer alarm to wake.
+        clocks_hw->sleep_en0 = 0x0;
+        #if PICO_RP2040
+        clocks_hw->sleep_en1 = CLOCKS_SLEEP_EN1_CLK_SYS_TIMER_BITS;
+        #elif PICO_RP2350
+        if (watchdog_active) {
+            // clk_sys watchdog and clk_ref ticks must be enabled for the watchdog counter to decrement on RP2350.
+            clocks_hw->sleep_en1 = CLOCKS_SLEEP_EN1_CLK_REF_TICKS_BITS | CLOCKS_SLEEP_EN1_CLK_SYS_TIMER0_BITS | CLOCKS_SLEEP_EN1_CLK_SYS_WATCHDOG_BITS;
+        } else {
+            clocks_hw->sleep_en1 = CLOCKS_SLEEP_EN1_CLK_REF_TICKS_BITS | CLOCKS_SLEEP_EN1_CLK_SYS_TIMER0_BITS;
+        }
+        #else
+        #error Unknown processor
+        #endif
+        if (delay_ms > 0) {
             hardware_alarm_claim(MICROPY_HW_LIGHTSLEEP_ALARM_NUM);
             hardware_alarm_set_callback(MICROPY_HW_LIGHTSLEEP_ALARM_NUM, alarm_sleep_callback);
             if (hardware_alarm_set_target(MICROPY_HW_LIGHTSLEEP_ALARM_NUM, make_timeout_time_ms(delay_ms)) == PICO_OK) {
                 alarm_armed = true;
             }
-        } else {
-            // TODO: Use RTC alarm to wake.
-            clocks_hw->sleep_en0 = 0x0;
-            clocks_hw->sleep_en1 = 0x0;
         }
 
         if (!disable_usb) {
@@ -331,26 +328,24 @@ static void mp_machine_lightsleep(size_t n_args, const mp_obj_t *args) {
     mp_hal_time_ns_set_from_rtc();
 
     // Note: This must be done after MICROPY_END_ATOMIC_SECTION
-    if (use_timer_alarm) {
-        if (alarm_armed) {
-            hardware_alarm_cancel(MICROPY_HW_LIGHTSLEEP_ALARM_NUM);
-        }
-        hardware_alarm_set_callback(MICROPY_HW_LIGHTSLEEP_ALARM_NUM, NULL);
-        hardware_alarm_unclaim(MICROPY_HW_LIGHTSLEEP_ALARM_NUM);
-
-        #if DEBUG_LIGHTSLEEP
-        // Check irq.h for the list of IRQ's
-        // for rp2040 00000042: TIMER_IRQ_1 woke the device as expected
-        //            00000020: USBCTRL_IRQ woke the device (probably early)
-        // For rp2350 00000000:00000002: TIMER0_IRQ_1 woke the device as expected
-        //            00000000:00004000: USBCTRL_IRQ woke the device (probably early)
-        #if PICO_RP2040
-        mp_printf(MP_PYTHON_PRINTER, "lightsleep: pending_intr=%08lx\n", pending_intr);
-        #else
-        mp_printf(MP_PYTHON_PRINTER, "lightsleep: pending_intr=%08lx:%08lx\n", pending_intr[1], pending_intr[0]);
-        #endif
-        #endif
+    if (alarm_armed) {
+        hardware_alarm_cancel(MICROPY_HW_LIGHTSLEEP_ALARM_NUM);
     }
+    hardware_alarm_set_callback(MICROPY_HW_LIGHTSLEEP_ALARM_NUM, NULL);
+    hardware_alarm_unclaim(MICROPY_HW_LIGHTSLEEP_ALARM_NUM);
+
+    #if DEBUG_LIGHTSLEEP
+    // Check irq.h for the list of IRQ's
+    // for rp2040 00000042: TIMER_IRQ_1 woke the device as expected
+    //            00000020: USBCTRL_IRQ woke the device (probably early)
+    // For rp2350 00000000:00000002: TIMER0_IRQ_1 woke the device as expected
+    //            00000000:00004000: USBCTRL_IRQ woke the device (probably early)
+    #if PICO_RP2040
+    mp_printf(MP_PYTHON_PRINTER, "lightsleep: pending_intr=%08lx\n", pending_intr);
+    #else
+    mp_printf(MP_PYTHON_PRINTER, "lightsleep: pending_intr=%08lx:%08lx\n", pending_intr[1], pending_intr[0]);
+    #endif
+    #endif // DEBUG_LIGHTSLEEP
 
     #if MICROPY_PY_THREAD
     // Clearing the flag here is atomic, and we know we're the ones who set it


### PR DESCRIPTION
### Summary

Make the `Pin.irq()` wakeup behaviour more consistent on rp2. Closes https://github.com/micropython/micropython/issues/7035 and Closes https://github.com/micropython/micropython/issues/16180 (the last part of that issue to need fixing.)

* Make it so any pin which has a `Pin.irq()` trigger set will wake rp2 port from any `machine.lightsleep()` call. (Previously this only worked if lightsleep had a timeout *and* the IRQ had a handler set.)
* Don't use the lowest power DORMANT mode if USB is active. Similar to #15301 it seems like disabling the USB clock while a device is enumerated leads to intermittent failures on wakeup. If USB is active then rp2 will now enter the higher level sleep mode only, the same one which is used if a timeout is set (in addition, the board is usually woken almost immediately by the USB host so this configuration doesn't save much power.)
* Document the rp2 sleep and low power modes and their capabilities/limitations.
* Add some notes in the machine documentation about sleep mode differences between ports.

### TODOs

* [ ] Waking from lightsleep appears to clobber the UART settings
* [ ] Full testing

*This work was funded through GitHub Sponsors.*

### Testing

* TBD

### Trade-offs and Alternatives

* Instead of not allowing DORMANT mode when USB is active, we could first disable the USB device entirely (so the host sees it disconnect) and then go to DORMANT mode. Unclear if there's any use case that this would be useful for, though...?
