### PR TITLE
doc: Note that machine.USBDevice is now available on esp32 port.

### DIFF
--- a/docs/library/machine.USBDevice.rst
+++ b/docs/library/machine.USBDevice.rst
@@ -4,8 +4,9 @@
 class USBDevice -- USB Device driver
 ====================================
 
-.. note:: ``machine.USBDevice`` is currently only supported on the rp2 and samd
-          ports.
+.. note:: ``machine.USBDevice`` is currently only supported for esp32, rp2 and
+          samd ports. Native USB support is also required, and not every board
+          supports native USB.
 
 USBDevice provides a low-level Python API for implementing USB device functions using
 Python code.


### PR DESCRIPTION
Support was added in PR #16356, this updates the docs to match.

*This work was funded through GitHub Sponsors.*
