### PR TITLE
stm32: Fix extraction of hse/hsi/pllm values from preprocessed source.

### DIFF
--- a/ports/stm32/boards/plli2svalues.py
+++ b/ports/stm32/boards/plli2svalues.py
@@ -132,12 +132,9 @@ def search_header(filename, re_define, lookup):
             m = regex_define.match(line)
             if m:
                 # found lookup value
-                found = m.group(3)
-                if "*" in found or "/" in found:
-                    # process define using multiply or divide to calculate value
-                    found = eval(found)
+                found = m.group(2)
                 if m.group(1) == lookup:
-                    val = int(found)
+                    val = eval(found)
     return val
 
 
@@ -179,7 +176,7 @@ def main():
             # extract hse value from processed header files
             hse = search_header(
                 argv[0][len("file:") :],
-                r"static.* (micropy_hw_hse_value) = +\(*(\(uint32_t\))?([0-9 +-/\*]+)\)*;",
+                r"static.* (micropy_hw_hse_value) = +([0-9 +-/\*()]+);",
                 "micropy_hw_hse_value",
             )
             if hse is None:
@@ -190,7 +187,7 @@ def main():
             # extract pllm value from processed header files
             pllm = search_header(
                 argv[0][len("file:") :],
-                r"static.* (micropy_hw_clk_pllm) = +\(*(\(uint32_t\))?([0-9 +-/\*]+)\)*;",
+                r"static.* (micropy_hw_clk_pllm) = +([0-9 +-/\*()]+);",
                 "micropy_hw_clk_pllm",
             )
             if pllm is None:

--- a/ports/stm32/boards/pllvalues.py
+++ b/ports/stm32/boards/pllvalues.py
@@ -231,7 +231,7 @@ def print_table(hse, valid_plls):
 def search_header_for_hsx_values(filename):
     hse = hsi = None
     regex_def = re.compile(
-        r"static.* +(micropy_hw_hs[ei]_value) = +\(*(\(uint32_t\))?([0-9 +-/\*]+)\)*;",
+        r"static.* +(micropy_hw_hs[ei]_value) = +([0-9 +-/\*()]+);",
     )
     with open(filename) as f:
         for line in f:
@@ -239,10 +239,8 @@ def search_header_for_hsx_values(filename):
             m = regex_def.match(line)
             if m:
                 # Found HSE_VALUE or HSI_VALUE
-                found = m.group(3)
-                if "*" in found or "/" in found:
-                    found = eval(found)
-                val = int(found) // 1000000
+                found = m.group(2)
+                val = eval(found) // 1000000
                 if m.group(1) == "micropy_hw_hse_value":
                     hse = val
                 else:


### PR DESCRIPTION
### Summary

Follow up to #15646.

The expressions for the `micropy_hw_hse_value` etc variables may contain parenthesis, eg `micropy_hw_hse_value = ((25) * 1000000)`.  To handle such a case, simplify the regex and always use `eval(found)` to evaluate the expression.

### Testing

The `WEACT_F411_BLACKPILL` board now builds.  Tested all 6 variants, they all build.