### PR TITLE
ports/stm32: Reserve SPI flash bus.

### DIFF
--- a/ports/stm32/boards/ADAFRUIT_F405_EXPRESS/mpconfigboard.h
+++ b/ports/stm32/boards/ADAFRUIT_F405_EXPRESS/mpconfigboard.h
@@ -28,6 +28,7 @@
 // External SPI Flash config
 #if !MICROPY_HW_ENABLE_INTERNAL_FLASH_STORAGE
 
+#define MICROPY_HW_SPI_IS_RESERVED(id)  (id == 1) // Reserve SPI flash bus.
 #define MICROPY_HW_SPIFLASH_SIZE_BITS (16 * 1024 * 1024) // 16 Mbit (2 MByte)
 
 #define MICROPY_HW_SPIFLASH_CS      (MICROPY_HW_SPI1_NSS)

--- a/ports/stm32/boards/LEGO_HUB_NO6/mpconfigboard.h
+++ b/ports/stm32/boards/LEGO_HUB_NO6/mpconfigboard.h
@@ -65,6 +65,7 @@
 #define MICROPY_HW_SPI2_SCK                      (pyb_pin_FLASH_SCK)
 #define MICROPY_HW_SPI2_MISO                     (pyb_pin_FLASH_MISO)
 #define MICROPY_HW_SPI2_MOSI                     (pyb_pin_FLASH_MOSI)
+#define MICROPY_HW_SPI_IS_RESERVED(id)           (id == 2)  // Reserve SPI flash bus.
 
 // USB config
 #define MICROPY_HW_USB_VBUS_DETECT_PIN           (pyb_pin_USB_VBUS)

--- a/ports/stm32/boards/MIKROE_QUAIL/mpconfigboard.h
+++ b/ports/stm32/boards/MIKROE_QUAIL/mpconfigboard.h
@@ -71,6 +71,7 @@
 // External SPI Flash config (Cypress S25FL164K)
 #if !MICROPY_HW_ENABLE_INTERNAL_FLASH_STORAGE
 
+#define MICROPY_HW_SPI_IS_STATIC(id)  (id == 3) // Shared with SPIFLASH.
 #define MICROPY_HW_SPIFLASH_SIZE_BITS (64 * 1024 * 1024) // 64 Mbit (8 MByte)
 
 #define MICROPY_HW_SPIFLASH_CS (pin_A13)

--- a/ports/stm32/boards/WEACT_F411_BLACKPILL/mpconfigboard.h
+++ b/ports/stm32/boards/WEACT_F411_BLACKPILL/mpconfigboard.h
@@ -86,6 +86,9 @@
 #define MICROPY_HW_ENABLE_INTERNAL_FLASH_STORAGE (1)
 
 #else
+// Reserve SPI flash bus.
+#define MICROPY_HW_SPI_IS_RESERVED(id)  (id == 1)
+
 // Disable internal filesystem to use spiflash.
 #define MICROPY_HW_ENABLE_INTERNAL_FLASH_STORAGE (0)
 

--- a/ports/stm32/mpconfigboard_common.h
+++ b/ports/stm32/mpconfigboard_common.h
@@ -187,6 +187,12 @@
 #define MICROPY_HW_SPI_IS_RESERVED(spi_id) (false)
 #endif
 
+// Function to determine if the given spi_id is static or not.
+// Static SPI instances can be accessed by the user but are not deinit'd on soft reset.
+#ifndef MICROPY_HW_SPI_IS_STATIC
+#define MICROPY_HW_SPI_IS_STATIC(spi_id) (false)
+#endif
+
 // Function to determine if the given tim_id is reserved for system use or not.
 #ifndef MICROPY_HW_TIM_IS_RESERVED
 #define MICROPY_HW_TIM_IS_RESERVED(tim_id) (false)

--- a/ports/stm32/spi.c
+++ b/ports/stm32/spi.c
@@ -548,7 +548,7 @@ void spi_deinit(const spi_t *spi_obj) {
 void spi_deinit_all(void) {
     for (int i = 0; i < MP_ARRAY_SIZE(spi_obj); i++) {
         const spi_t *spi = &spi_obj[i];
-        if (spi->spi != NULL) {
+        if (spi->spi != NULL && !MICROPY_HW_SPI_IS_RESERVED(i + 1) && !MICROPY_HW_SPI_IS_STATIC(i + 1)) {
             spi_deinit(spi);
         }
     }


### PR DESCRIPTION
### Summary

Reserved SPI buses must remain initialized during a soft reboot as they may be used for SPI flash storage or XIP. Fixes an issue introduced in #16346. 