### PR TITLE
Alarm pool sleep changes

### DIFF
--- a/ports/rp2/mpconfigport.h
+++ b/ports/rp2/mpconfigport.h
@@ -198,8 +198,9 @@
 #define MICROPY_PY_LWIP_SOCK_RAW                (MICROPY_PY_LWIP)
 
 // Hardware timer alarm index. Available range 0-3.
-// Number 3 is currently used by pico-sdk (PICO_TIME_DEFAULT_ALARM_POOL_HARDWARE_ALARM_NUM)
+// Number 3 is currently used by pico-sdk alarm pool (PICO_TIME_DEFAULT_ALARM_POOL_HARDWARE_ALARM_NUM)
 #define MICROPY_HW_SOFT_TIMER_ALARM_NUM         (2)
+#define MICROPY_HW_LIGHTSLEEP_ALARM_NUM         (1)
 
 // fatfs configuration
 #define MICROPY_FATFS_ENABLE_LFN                (2)

--- a/ports/rp2/mphalport.c
+++ b/ports/rp2/mphalport.c
@@ -266,17 +266,7 @@ void soft_timer_init(void) {
 }
 
 void mp_wfe_or_timeout(uint32_t timeout_ms) {
-    soft_timer_entry_t timer;
-
-    // Note the timer doesn't have an associated callback, it just exists to create a
-    // hardware interrupt to wake the CPU
-    soft_timer_static_init(&timer, SOFT_TIMER_MODE_ONE_SHOT, 0, NULL);
-    soft_timer_insert(&timer, timeout_ms);
-
-    __wfe();
-
-    // Clean up the timer node if it's not already
-    soft_timer_remove(&timer);
+    best_effort_wfe_or_timeout(delayed_by_ms(get_absolute_time(), timeout_ms));
 }
 
 int mp_hal_is_pin_reserved(int n) {

--- a/tests/ports/rp2/rp2_lightsleep_thread.py
+++ b/tests/ports/rp2/rp2_lightsleep_thread.py
@@ -1,0 +1,54 @@
+# Verify that a thread running on CPU1 can go to lightsleep
+# and wake up in the expected timeframe
+import _thread
+import time
+import unittest
+from machine import lightsleep
+
+N_SLEEPS = 5
+SLEEP_MS = 250
+
+IDEAL_RUNTIME = N_SLEEPS * SLEEP_MS
+MAX_RUNTIME = (N_SLEEPS + 1) * SLEEP_MS
+MAX_DELTA = 20
+
+
+class LightSleepInThread(unittest.TestCase):
+    def thread_entry(self, is_thread=True):
+        for _ in range(N_SLEEPS):
+            lightsleep(SLEEP_MS)
+        if is_thread:
+            self.thread_done = True
+
+    def elapsed_ms(self):
+        return time.ticks_diff(time.ticks_ms(), self.t0)
+
+    def setUp(self):
+        self.thread_done = False
+        self.t0 = time.ticks_ms()
+
+    def test_cpu0_busy(self):
+        _thread.start_new_thread(self.thread_entry, ())
+        # CPU0 is busy-waiting not asleep itself
+        while not self.thread_done:
+            self.assertLessEqual(self.elapsed_ms(), MAX_RUNTIME)
+        self.assertAlmostEqual(self.elapsed_ms(), IDEAL_RUNTIME, delta=MAX_DELTA)
+
+    def test_cpu0_sleeping(self):
+        _thread.start_new_thread(self.thread_entry, ())
+        time.sleep_ms(MAX_RUNTIME)
+        self.assertTrue(self.thread_done)
+        self.assertAlmostEqual(self.elapsed_ms(), MAX_RUNTIME, delta=MAX_DELTA)
+
+    def test_cpu0_also_lightsleep(self):
+        _thread.start_new_thread(self.thread_entry, ())
+        time.sleep(0.050)  # account for any delay in starting the thread
+        self.thread_entry(False)  # does the same lightsleep loop, doesn't set the done flag
+        self.assertTrue(self.thread_done)
+        # only one thread can actually be in lightsleep at a time to avoid races, so the total
+        # runtime is doubled by doing it on both CPUs
+        self.assertAlmostEqual(self.elapsed_ms(), IDEAL_RUNTIME * 2, delta=IDEAL_RUNTIME)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/ports/rp2/rp2_lightsleep_thread.py
+++ b/tests/ports/rp2/rp2_lightsleep_thread.py
@@ -42,12 +42,25 @@ class LightSleepInThread(unittest.TestCase):
 
     def test_cpu0_also_lightsleep(self):
         _thread.start_new_thread(self.thread_entry, ())
-        time.sleep(0.050)  # account for any delay in starting the thread
+        time.sleep_ms(50)  # account for any delay in starting the thread
         self.thread_entry(False)  # does the same lightsleep loop, doesn't set the done flag
-        self.assertTrue(self.thread_done)
-        # only one thread can actually be in lightsleep at a time to avoid races, so the total
-        # runtime is doubled by doing it on both CPUs
-        self.assertAlmostEqual(self.elapsed_ms(), IDEAL_RUNTIME * 2, delta=IDEAL_RUNTIME)
+        while not self.thread_done:
+            time.sleep_ms(10)
+        #
+        # Only one thread can actually be in lightsleep at a time to avoid
+        # races, but otherwise the behaviour when both threads call lightsleep()
+        # is unspecified.
+        #
+        # Currently, the other thread will return immediately if one is already
+        # in lightsleep. Therefore, runtime can be between IDEAL_RUNTIME and
+        # IDEAL_RUNTIME * 2 depending on how many times the calls to lightsleep() race
+        # each other.
+        #
+        # Note this test case is really only here to ensure that the rp2 hasn't
+        # hung or failed to sleep at all - not to verify any correct behaviour
+        # when there's a race to call lightsleep().
+        self.assertGreaterEqual(self.elapsed_ms(), IDEAL_RUNTIME - MAX_DELTA)
+        self.assertLessEqual(self.elapsed_ms(), IDEAL_RUNTIME * 2 + MAX_DELTA)
 
 
 if __name__ == "__main__":

--- a/tests/ports/rp2/rp2_machine_idle.py
+++ b/tests/ports/rp2/rp2_machine_idle.py
@@ -1,4 +1,3 @@
-import sys
 import machine
 import time
 
@@ -17,11 +16,6 @@ import time
 #
 # Verification uses the average idle time, as individual iterations will always
 # have outliers due to interrupts, scheduler, etc.
-
-# RP2350 currently fails this test because machine.idle() resumes immediately.
-if "RP2350" in sys.implementation._machine:
-    print("SKIP")
-    raise SystemExit
 
 ITERATIONS = 500
 total = 0


### PR DESCRIPTION
rp2350 generates a sev when using spin locks, which can prevent the device sleeping, see https://github.com/raspberrypi/pico-sdk/issues/1812 for more background.

The pico-sdk alarm pool handles this.

However Micropython moved away from using the alarm pool due to issues like this...
Fixed in sdk 2.0.0: https://github.com/raspberrypi/pico-sdk/issues/1552
Fixed in sdk 2.1.0: https://github.com/raspberrypi/pico-sdk/issues/1953
Fixed in develop: https://github.com/raspberrypi/pico-sdk/pull/2127

This change puts back the use of the alarm pool in mp_wfe_or_timeout to hopefully fix sleep issues.