### PR TITLE
shared/tinyusb, extmod: Add USB NCM network driver.

### DIFF
--- a/docs/library/network.USBD_NCM.rst
+++ b/docs/library/network.USBD_NCM.rst
@@ -1,0 +1,82 @@
+.. currentmodule:: network
+.. _network.USBD_NCM:
+
+class USBD_NCM -- USB NCM network interface
+===========================================
+
+This class provides a network interface over USB using the NCM (Network
+Control Model) protocol.  The host computer sees this device as a USB
+Ethernet adapter and assigns it an IP address via DHCP (served by the
+MicroPython device).
+
+.. note:: ``network.USBD_NCM`` requires a port with TinyUSB and NCM support,
+          enabled at build time by defining ``MICROPY_PY_NETWORK_USBD_NCM``
+          (off by default).
+
+Example usage::
+
+    import network
+
+    nic = network.USBD_NCM()
+    nic.active(True)
+    # wait for USB host to configure the NCM interface
+    while not nic.isconnected():
+        pass
+
+    print(nic.ipconfig("addr4"))
+
+Constructors
+------------
+
+.. class:: USBD_NCM()
+
+   Create and return a USBD_NCM object.  This initialises the NCM network
+   interface if it has not already been initialised.  Only one instance
+   exists (singleton).
+
+Methods
+-------
+
+.. method:: USBD_NCM.active([is_active])
+
+   Activate or deactivate the network interface.  Without argument returns
+   current state as a bool.
+
+   The interface is brought up automatically before USB enumeration, so this
+   returns ``True`` from boot.
+
+.. method:: USBD_NCM.isconnected()
+
+   Returns ``True`` if the USB host has configured the NCM interface,
+   ``False`` otherwise.
+
+   When USB is disconnected, this returns ``False`` and network traffic
+   stops. The interface remains registered with lwIP and can resume when
+   the host reconnects and re-enumerates the device.
+
+.. method:: USBD_NCM.status()
+
+   Returns the link status as an integer: ``1`` if the interface is up,
+   ``0`` otherwise.
+
+.. method:: USBD_NCM.ipconfig('param')
+            USBD_NCM.ipconfig(param=value, ...)
+
+   See `AbstractNIC.ipconfig`.
+
+.. method:: USBD_NCM.ifconfig([(ip, subnet, gateway, dns)])
+
+   See `AbstractNIC.ifconfig`.
+
+Notes
+-----
+
+**Link-local IP address:** The device IP (169.254.x.1) is derived
+deterministically from the device MAC address. RFC 3927 ARP probe/announce
+(conflict detection) is not implemented, so if two devices happen to derive
+the same address on the same network segment, the conflict will go undetected.
+
+**MAC address uniqueness:** The device and host-side MAC addresses are derived
+from the value returned by ``mp_hal_get_mac()``. If two boards have the same
+hardware MAC (e.g. the port does not use a hardware UID), they will present
+the same network addresses and cause ARP conflicts.

--- a/docs/library/network.USBD_NCM.rst
+++ b/docs/library/network.USBD_NCM.rst
@@ -1,0 +1,81 @@
+.. currentmodule:: network
+.. _network.USBD_NCM:
+
+class USBD_NCM -- USB NCM network interface
+===========================================
+
+This class provides a network interface over USB using the NCM (Network
+Control Model) protocol.  The host computer sees this device as a USB
+Ethernet adapter and assigns it an IP address via DHCP (served by the
+MicroPython device).
+
+.. note:: ``network.USBD_NCM`` requires a port with TinyUSB and NCM support,
+          enabled at build time by defining ``MICROPY_PY_NETWORK_USBD_NCM``
+          (off by default).  The USB NCM class must also be active - either
+          compiled as the default or enabled in ``boot.py`` via
+          ``machine.USBDevice.BUILTIN_NCM``.
+
+Example usage::
+
+    import network
+
+    nic = network.USBD_NCM()
+    nic.active(True)
+    # wait for USB host to configure the NCM interface
+    while not nic.isconnected():
+        pass
+
+    print(nic.ipconfig("addr4"))
+
+Constructors
+------------
+
+.. class:: USBD_NCM()
+
+   Create and return a USBD_NCM object.  This initialises the NCM network
+   interface if it has not already been initialised.  Only one instance
+   exists (singleton).
+
+Methods
+-------
+
+.. method:: USBD_NCM.active([is_active])
+
+   Activate or deactivate the network interface.  Without argument returns
+   current state as a bool.
+
+.. method:: USBD_NCM.isconnected()
+
+   Returns ``True`` if the USB host has configured the NCM interface,
+   ``False`` otherwise.
+
+   When USB is disconnected, this returns ``False`` and network traffic
+   stops. The interface remains registered with lwIP and can resume when
+   the host reconnects and re-enumerates the device.
+
+.. method:: USBD_NCM.status()
+
+   Returns the link status as an integer: ``1`` if the interface is up,
+   ``0`` otherwise.
+
+.. method:: USBD_NCM.ipconfig('param')
+            USBD_NCM.ipconfig(param=value, ...)
+
+   See `AbstractNIC.ipconfig`.
+
+.. method:: USBD_NCM.ifconfig([(ip, subnet, gateway, dns)])
+
+   See `AbstractNIC.ifconfig`.
+
+Notes
+-----
+
+**Link-local IP address:** The device IP (169.254.x.1) is derived
+deterministically from the device MAC address. RFC 3927 ARP probe/announce
+(conflict detection) is not implemented, so if two devices happen to derive
+the same address on the same network segment, the conflict will go undetected.
+
+**MAC address uniqueness:** The device and host-side MAC addresses are derived
+from the value returned by ``mp_hal_get_mac()``. If two boards have the same
+hardware MAC (e.g. the port does not use a hardware UID), they will present
+the same network addresses and cause ARP conflicts.

--- a/docs/library/network.rst
+++ b/docs/library/network.rst
@@ -193,6 +193,7 @@ provide a way to control networking interfaces of various kinds.
    network.WIZNET5K.rst
    network.LAN.rst
    network.PPP.rst
+   network.USBD_NCM.rst
 
 Network functions
 =================

--- a/extmod/extmod.cmake
+++ b/extmod/extmod.cmake
@@ -53,6 +53,7 @@ set(MICROPY_SOURCE_EXTMOD
     ${MICROPY_EXTMOD_DIR}/network_lwip.c
     ${MICROPY_EXTMOD_DIR}/network_ninaw10.c
     ${MICROPY_EXTMOD_DIR}/network_ppp_lwip.c
+    ${MICROPY_EXTMOD_DIR}/network_usbd_ncm.c
     ${MICROPY_EXTMOD_DIR}/network_wiznet5k.c
     ${MICROPY_EXTMOD_DIR}/os_dupterm.c
     ${MICROPY_EXTMOD_DIR}/vfs.c

--- a/extmod/extmod.mk
+++ b/extmod/extmod.mk
@@ -56,6 +56,7 @@ SRC_EXTMOD_C += \
 	extmod/network_lwip.c \
 	extmod/network_ninaw10.c \
 	extmod/network_ppp_lwip.c \
+	extmod/network_usbd_ncm.c \
 	extmod/network_wiznet5k.c \
 	extmod/os_dupterm.c \
 	extmod/vfs.c \

--- a/extmod/modnetwork.c
+++ b/extmod/modnetwork.c
@@ -55,6 +55,11 @@ extern const struct _mp_obj_type_t mod_network_nic_type_nina;
 extern const struct _mp_obj_type_t mod_network_esp_hosted_type;
 #endif
 
+#if MICROPY_PY_NETWORK_USBD_NCM
+extern const struct _mp_obj_type_t mod_network_nic_type_ncm;
+#include "extmod/network_usbd_ncm.h"
+#endif
+
 #ifdef MICROPY_PY_NETWORK_INCLUDEFILE
 #include MICROPY_PY_NETWORK_INCLUDEFILE
 #endif
@@ -75,6 +80,11 @@ char mod_network_hostname_data[MICROPY_PY_NETWORK_HOSTNAME_MAX_LEN + 1] = MICROP
 
 void mod_network_init(void) {
     mp_obj_list_init(&MP_STATE_PORT(mod_network_nic_list), 0);
+    #if MICROPY_PY_NETWORK_USBD_NCM
+    // Initialise the USB NCM netif early so it is ready when TinyUSB starts
+    // receiving packets during USB enumeration (before any Python code runs).
+    ncm_auto_init();
+    #endif
 }
 
 void mod_network_deinit(void) {
@@ -203,6 +213,10 @@ static const mp_rom_map_elem_t mp_module_network_globals_table[] = {
 
     #if MICROPY_PY_NETWORK_ESP_HOSTED
     { MP_ROM_QSTR(MP_QSTR_WLAN), MP_ROM_PTR(&mod_network_esp_hosted_type) },
+    #endif
+
+    #if MICROPY_PY_NETWORK_USBD_NCM
+    { MP_ROM_QSTR(MP_QSTR_USBD_NCM), MP_ROM_PTR(&mod_network_nic_type_ncm) },
     #endif
 
     // Allow a port to take mostly full control of the network module.

--- a/extmod/network_usbd_ncm.c
+++ b/extmod/network_usbd_ncm.c
@@ -1,0 +1,400 @@
+/*
+ * This file is part of the MicroPython project, http://micropython.org/
+ *
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2026 Andrew Leech
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#include "py/runtime.h"
+#include "py/mperrno.h"
+#include "py/mphal.h"
+
+#if MICROPY_PY_NETWORK_USBD_NCM
+
+// Include NCM configuration (MICROPY_PY_NETWORK_USBD_NCM_DHCP_SERVER).
+#include "extmod/network_usbd_ncm.h"
+
+#ifndef NO_QSTR
+#include "tusb.h"
+#endif
+
+#include "lwip/ethip6.h"
+#include "lwip/init.h"
+#include "lwip/timeouts.h"
+#include "lwip/etharp.h"
+#include "lwip/dns.h"
+#include "lwip/dhcp.h"
+#include "netif/ethernet.h"
+#include "lwip/apps/mdns.h"
+
+#include "extmod/modnetwork.h"
+#include "shared/netutils/netutils.h"
+#include "shared/netutils/dhcpserver.h"
+
+#define error_printf(...) mp_printf(&mp_plat_print, "network_usbd_ncm: " __VA_ARGS__)
+
+#if LWIP_IPV6
+#define IP(x) ((x).u_addr.ip4)
+#else
+#define IP(x) (x)
+#endif
+
+const mp_obj_type_t mod_network_nic_type_ncm;
+
+typedef struct _ncm_obj_t {
+    mp_obj_base_t base;
+
+    struct netif netif;
+    bool init;
+
+    ip_addr_t ipaddr;
+    ip_addr_t netmask;
+    ip_addr_t gateway;
+
+    #if MICROPY_PY_NETWORK_USBD_NCM_DHCP_SERVER
+    dhcp_server_t dhcp_server;
+    #endif
+} ncm_obj_t;
+
+// Global object holding the usb net state
+static ncm_obj_t ncm_obj;
+
+static mp_sched_node_t ncm_sched_node;
+
+#define IS_ACTIVE(self) ((self)->netif.flags & NETIF_FLAG_UP)
+
+/* This default mac will be updated during init from hardware unique ID (if available) */
+/* it is suggested that the first byte is 0x02 to indicate a link-local address */
+uint8_t tud_network_mac_address[6] = {0x02, 0x00, 0x00, 0x00, 0x00, 0x00};
+
+// Derive a link-local IPv4 address (169.254.X.1) from a MAC address.
+// Note: no ARP probe/announce is performed (RFC 3927 collision detection is not
+// implemented). The address is deterministic; if two devices share the same MAC,
+// they will get the same link-local IP and ARP conflicts will go undetected.
+// Assumes mp_hal_get_mac() returns a per-device unique value.
+static void generate_linklocal_ip_from_mac(const uint8_t mac_addr[6], uint8_t ip_addr[4]) {
+    ip_addr[0] = 169;
+    ip_addr[1] = 254;
+    ip_addr[3] = 1;
+
+    // Reuse the core string hash (djb2, the same hash() uses on bytes) to
+    // spread the MAC across the third octet, with no extra code compiled in.
+    size_t hash = qstr_compute_hash(mac_addr, 6);
+    uint8_t third_octet = (uint8_t)(hash ^ (hash >> 8));
+
+    // Avoid .0 and .255
+    if (third_octet == 0) {
+        third_octet = 1;
+    }
+    if (third_octet == 255) {
+        third_octet = 254;
+    }
+
+    ip_addr[2] = third_octet;
+}
+
+static err_t linkoutput_fn(struct netif *netif, struct pbuf *p) {
+    (void)netif;
+    if (!tud_ready() || !tud_network_can_xmit(p->tot_len)) {
+        // Drop the frame while the link is down or a previous transmit is
+        // still in flight.  An error return would propagate out of
+        // tcp_output() to the caller of socket.send(), even though tcp_write()
+        // has already queued that data, so the caller would resend bytes that
+        // are already in the stream.  Dropping leaves recovery to TCP
+        // retransmission, as for any other lossy link.
+        return ERR_OK;
+    }
+    tud_network_xmit(p, 0);
+    return ERR_OK;
+}
+
+static err_t netif_init_cb(struct netif *netif) {
+    LWIP_ASSERT("netif != NULL", (netif != NULL));
+    netif->name[0] = 'u'; // lwIP short name "un" for USB Network
+    netif->name[1] = 'n';
+    netif->mtu = CFG_TUD_NET_MTU;
+    netif->flags = NETIF_FLAG_BROADCAST | NETIF_FLAG_ETHARP | NETIF_FLAG_ETHERNET | NETIF_FLAG_IGMP;
+    netif->state = NULL;
+    netif->linkoutput = linkoutput_fn;
+    netif->output = etharp_output;
+    #if LWIP_IPV6
+    netif->output_ip6 = ethip6_output;
+    netif->flags |= NETIF_FLAG_MLD6;
+    #endif
+    return ERR_OK;
+}
+
+static void ncm_init(void) {
+    // Init the NCM object
+    ncm_obj.base.type = (mp_obj_type_t *)&mod_network_nic_type_ncm;
+
+    struct netif *netif = &(ncm_obj.netif);
+
+    MICROPY_PY_LWIP_ENTER
+
+    mp_hal_get_mac(MP_HAL_MAC_ETH0, tud_network_mac_address);
+    tud_network_mac_address[0] = 0x02;
+
+    netif->hwaddr_len = sizeof(tud_network_mac_address);
+    memcpy(netif->hwaddr, tud_network_mac_address, sizeof(tud_network_mac_address));
+
+    // This USB Network essentially creates a link with two interfaces, one for the
+    // host and another for the micropython/lwip end of the connection.
+    // The MAC configured above is use for one end of the link, flip a bit for the
+    // MAC on the other end of the link.
+    netif->hwaddr[5] ^= 0x01;
+
+    // Generate unique link-local IP address from MAC address
+    uint8_t ip_bytes[4];
+    generate_linklocal_ip_from_mac(tud_network_mac_address, ip_bytes);
+
+    // Convert to network byte order and set IP configuration
+    IP(ncm_obj.ipaddr).addr = PP_HTONL(((uint32_t)ip_bytes[0] << 24) | ((uint32_t)ip_bytes[1] << 16) | ((uint32_t)ip_bytes[2] << 8) | ip_bytes[3]);
+    IP(ncm_obj.netmask).addr = PP_HTONL(0xFFFF0000);  // 255.255.0.0 for link-local
+    IP(ncm_obj.gateway).addr = 0;  // No gateway for link-local
+
+    netif = netif_add(
+        netif,
+        ip_2_ip4(&ncm_obj.ipaddr),
+        ip_2_ip4(&ncm_obj.netmask),
+        ip_2_ip4(&ncm_obj.gateway),
+        NULL,
+        netif_init_cb,
+        ethernet_input
+        );
+    if (netif == NULL) {
+        MICROPY_PY_LWIP_EXIT
+        mp_raise_OSError(MP_ENOMEM);
+    }
+    #if LWIP_IPV6
+    netif_create_ip6_linklocal_address(netif, 1);
+    netif_set_ip6_autoconfig_enabled(netif, 1);
+    #endif
+    #if LWIP_NETIF_HOSTNAME
+    netif_set_hostname(netif, mod_network_hostname_data);
+    #endif
+    if (netif_default == NULL) {
+        netif_set_default(netif);
+    }
+
+    #if LWIP_MDNS_RESPONDER
+    mdns_resp_add_netif(netif, mod_network_hostname_data);
+    #endif
+
+    #if MICROPY_PY_NETWORK_USBD_NCM_DHCP_SERVER
+    dhcp_server_init(&ncm_obj.dhcp_server, &ncm_obj.ipaddr, &ncm_obj.netmask);
+    // Don't advertise a default gateway -- this is a point-to-point USB link
+    // and advertising a router causes the host to route all traffic over USB.
+    ncm_obj.dhcp_server.send_router = false;
+    #endif
+
+    // register with network module
+    mod_network_register_nic(&ncm_obj);
+    ncm_obj.init = true;
+
+    MICROPY_PY_LWIP_EXIT
+}
+
+static void _scheduled_tud_network_recv_renew(mp_sched_node_t *node) {
+    (void)node;
+    // Release the TinyUSB receive buffer and pick up the next datagram.
+    tud_network_recv_renew();
+}
+
+bool tud_network_recv_cb(const uint8_t *src, uint16_t size) {
+    if (!ncm_obj.init) {
+        return false;
+    }
+    struct netif *netif = &(ncm_obj.netif);
+    bool ret = true;
+    if (size) {
+        MICROPY_PY_LWIP_ENTER
+
+        struct pbuf *p = pbuf_alloc(PBUF_RAW, size, PBUF_POOL);
+        if (p == NULL) {
+            MICROPY_PY_LWIP_EXIT
+            // Return false without calling recv_renew: TinyUSB holds the buffer.
+            // NCM RX will stall until the host retransmits and memory is available.
+            return false;
+        }
+
+        // Copy buf to pbuf
+        pbuf_take(p, src, size);
+
+        if (netif->input(p, netif) != ERR_OK) {
+            pbuf_free(p);
+            ret = false;
+        }
+
+        MICROPY_PY_LWIP_EXIT
+    }
+    // Defer tud_network_recv_renew(): calling it here would pull the next
+    // datagram, and its full lwIP input path, into this USB interrupt.
+    mp_sched_schedule_node(&ncm_sched_node, _scheduled_tud_network_recv_renew);
+    return ret;
+}
+
+uint16_t tud_network_xmit_cb(uint8_t *dst, void *ref, uint16_t arg) {
+    // copy from network stack packet pointer to dst.
+    (void)arg;
+    MICROPY_PY_LWIP_ENTER
+    struct pbuf *p = (struct pbuf *)ref;
+    uint16_t len = pbuf_copy_partial(p, dst, p->tot_len, 0);
+    MICROPY_PY_LWIP_EXIT
+    return len;
+}
+
+// Set the lwIP link state and tell the host to match, so that a deactivated
+// interface shows up as disconnected rather than silently discarding traffic.
+static void ncm_set_link(bool up) {
+    if (up) {
+        netif_set_link_up(&ncm_obj.netif);
+    } else {
+        netif_set_link_down(&ncm_obj.netif);
+    }
+    tud_network_link_state(TUD_OPT_RHPORT, up);
+}
+
+// Called during netd_init() for the initial link state, which TinyUSB otherwise
+// defaults to up.  netd_init() also runs on every bus reset, so without this the
+// host would see the link come back up after a replug while the netif is down.
+bool tud_network_default_link_state_cb(void) {
+    return !ncm_obj.init || netif_is_link_up(&ncm_obj.netif);
+}
+
+// Called from mod_network_init() to set up the NCM netif before USB starts.
+// TinyUSB's NCM driver begins receiving as soon as the host sends
+// SET_INTERFACE(alt=1), which happens during USB enumeration -- before any
+// Python code runs.  The netif must exist by then so tud_network_recv_cb()
+// can deliver packets to lwIP.
+//
+// The netif is intentionally kept alive across MicroPython soft reset: lwIP
+// is not re-initialised on soft reset, so the netif remains valid and TinyUSB
+// can continue delivering packets. On re-entry we only re-register the singleton
+// with the NIC list (which mod_network_init() cleared) rather than re-running
+// netif_add (which must only be called once per netif).
+void ncm_auto_init(void) {
+    if (!ncm_obj.init) {
+        ncm_init();
+    } else {
+        // On soft-reset mod_network_init() clears the NIC list, so
+        // re-register the (still-live) singleton.
+        mod_network_register_nic(&ncm_obj);
+    }
+    // Bring the interface up here rather than leaving it to active(True): lwIP
+    // drops inbound packets on a down netif, and the host starts DHCP as soon
+    // as it enumerates.  As such active() reads True from boot.
+    netif_set_up(&ncm_obj.netif);
+    ncm_set_link(true);
+}
+
+/*******************************************************************************/
+// MicroPython bindings
+
+// Create and return a USBD_NCM object.
+static mp_obj_t ncm_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *args) {
+    mp_arg_check_num(n_args, n_kw, 0, 0, false);
+    if (!ncm_obj.init) {
+        ncm_init();
+    }
+    // Return NCM object
+    return MP_OBJ_FROM_PTR(&ncm_obj);
+}
+
+static mp_obj_t ncm_status(mp_obj_t self_in) {
+    ncm_obj_t *self = MP_OBJ_TO_PTR(self_in);
+    return MP_OBJ_NEW_SMALL_INT(IS_ACTIVE(self) ? 1 : 0);
+}
+static MP_DEFINE_CONST_FUN_OBJ_1(ncm_status_obj, ncm_status);
+
+static mp_obj_t ncm_isconnected(mp_obj_t self_in) {
+    ncm_obj_t *self = MP_OBJ_TO_PTR(self_in);
+    return mp_obj_new_bool(tud_connected() && netif_is_link_up(&self->netif));
+}
+static MP_DEFINE_CONST_FUN_OBJ_1(ncm_isconnected_obj, ncm_isconnected);
+
+static mp_obj_t ncm_active(size_t n_args, const mp_obj_t *args) {
+    ncm_obj_t *self = MP_OBJ_TO_PTR(args[0]);
+    if (n_args == 1) {
+        return mp_obj_new_bool(IS_ACTIVE(self));
+    } else {
+        if (mp_obj_is_true(args[1])) {
+            if (!IS_ACTIVE(self)) {
+                netif_set_up(&self->netif);
+                ncm_set_link(true);
+            }
+        } else {
+            if (IS_ACTIVE(self)) {
+                ncm_set_link(false);
+                netif_set_down(&self->netif);
+                // Note: We don't call ncm_deinit() here because that would
+                // completely remove the network interface. We just want to
+                // deactivate it so it can be reactivated later.
+            }
+        }
+        return mp_const_none;
+    }
+}
+static MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(ncm_active_obj, 1, 2, ncm_active);
+
+static mp_obj_t ncm_ifconfig(size_t n_args, const mp_obj_t *args) {
+    ncm_obj_t *self = MP_OBJ_TO_PTR(args[0]);
+    return mod_network_nic_ifconfig(&self->netif, n_args - 1, args + 1);
+}
+static MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(ncm_ifconfig_obj, 1, 2, ncm_ifconfig);
+
+static mp_obj_t ncm_ipconfig(size_t n_args, const mp_obj_t *args, mp_map_t *kwargs) {
+    ncm_obj_t *self = MP_OBJ_TO_PTR(args[0]);
+    return mod_network_nic_ipconfig(&self->netif, n_args - 1, args + 1, kwargs);
+}
+static MP_DEFINE_CONST_FUN_OBJ_KW(ncm_ipconfig_obj, 1, ncm_ipconfig);
+
+static mp_obj_t ncm_config(size_t n_args, const mp_obj_t *args, mp_map_t *kwargs) {
+    if (n_args == 2 && kwargs->used == 0) {
+        const char *key = mp_obj_str_get_str(args[1]);
+        if (strcmp(key, "mac") == 0) {
+            return mp_obj_new_bytes(tud_network_mac_address, sizeof(tud_network_mac_address));
+        }
+    }
+    mp_raise_ValueError(MP_ERROR_TEXT("unknown config param"));
+}
+static MP_DEFINE_CONST_FUN_OBJ_KW(ncm_config_obj, 1, ncm_config);
+
+static const mp_rom_map_elem_t ncm_locals_dict_table[] = {
+    { MP_ROM_QSTR(MP_QSTR_status), MP_ROM_PTR(&ncm_status_obj) },
+    { MP_ROM_QSTR(MP_QSTR_isconnected), MP_ROM_PTR(&ncm_isconnected_obj) },
+    { MP_ROM_QSTR(MP_QSTR_active), MP_ROM_PTR(&ncm_active_obj) },
+    { MP_ROM_QSTR(MP_QSTR_ifconfig), MP_ROM_PTR(&ncm_ifconfig_obj) },
+    { MP_ROM_QSTR(MP_QSTR_ipconfig), MP_ROM_PTR(&ncm_ipconfig_obj) },
+    { MP_ROM_QSTR(MP_QSTR_config), MP_ROM_PTR(&ncm_config_obj) },
+};
+static MP_DEFINE_CONST_DICT(ncm_locals_dict, ncm_locals_dict_table);
+
+MP_DEFINE_CONST_OBJ_TYPE(
+    mod_network_nic_type_ncm,
+    MP_QSTR_USBD_NCM,
+    MP_TYPE_FLAG_NONE,
+    make_new, ncm_make_new,
+    locals_dict, &ncm_locals_dict
+    );
+
+#endif

--- a/extmod/network_usbd_ncm.c
+++ b/extmod/network_usbd_ncm.c
@@ -1,0 +1,406 @@
+/*
+ * This file is part of the MicroPython project, http://micropython.org/
+ *
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2026 Andrew Leech
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#include "py/runtime.h"
+#include "py/mperrno.h"
+#include "py/mphal.h"
+
+#if MICROPY_PY_NETWORK_USBD_NCM
+
+// Include NCM configuration (MICROPY_PY_NETWORK_USBD_NCM_DHCP_SERVER, CFG_TUD_NCM_* sizes).
+#include "extmod/network_usbd_ncm.h"
+
+#ifndef NO_QSTR
+#include "tusb.h"
+#endif
+
+#include "lwip/ethip6.h"
+#include "lwip/init.h"
+#include "lwip/timeouts.h"
+#include "lwip/etharp.h"
+#include "lwip/dns.h"
+#include "lwip/dhcp.h"
+#include "netif/ethernet.h"
+#include "lwip/apps/mdns.h"
+
+#include "extmod/modnetwork.h"
+#include "shared/netutils/netutils.h"
+#include "shared/netutils/dhcpserver.h"
+
+#define error_printf(...) mp_printf(&mp_plat_print, "network_usbd_ncm: " __VA_ARGS__)
+
+#if LWIP_IPV6
+#define IP(x) ((x).u_addr.ip4)
+#else
+#define IP(x) (x)
+#endif
+
+const mp_obj_type_t mod_network_nic_type_ncm;
+
+typedef struct _ncm_obj_t {
+    mp_obj_base_t base;
+
+    struct netif netif;
+    bool init;
+
+    ip_addr_t ipaddr;
+    ip_addr_t netmask;
+    ip_addr_t gateway;
+
+    #if MICROPY_PY_NETWORK_USBD_NCM_DHCP_SERVER
+    dhcp_server_t dhcp_server;
+    #endif
+} ncm_obj_t;
+
+// Global object holding the usb net state
+static ncm_obj_t ncm_obj;
+
+static mp_sched_node_t ncm_sched_node;
+// Pending tud_network_recv_renew() flag. mp_sched_schedule_node is a
+// one-slot queue; this flag is consumed once per scheduler drain.
+static volatile bool ncm_recv_renew_pending;
+
+#define IS_ACTIVE(self) ((self)->netif.flags & NETIF_FLAG_UP)
+
+/* This default mac will be updated during init from hardware unique ID (if available) */
+/* it is suggested that the first byte is 0x02 to indicate a link-local address */
+uint8_t tud_network_mac_address[6] = {0x02, 0x00, 0x00, 0x00, 0x00, 0x00};
+
+// Derive a link-local IPv4 address (169.254.X.1) from a MAC address.
+// Note: no ARP probe/announce is performed (RFC 3927 collision detection is not
+// implemented). The address is deterministic; if two devices share the same MAC,
+// they will get the same link-local IP and ARP conflicts will go undetected.
+// Assumes mp_hal_get_mac() returns a per-device unique value.
+static void generate_linklocal_ip_from_mac(const uint8_t mac_addr[6], uint8_t ip_addr[4]) {
+    ip_addr[0] = 169;
+    ip_addr[1] = 254;
+    ip_addr[3] = 1;
+
+    // Reuse the core string hash (djb2, the same hash() uses on bytes) to
+    // spread the MAC across the third octet, with no extra code compiled in.
+    size_t hash = qstr_compute_hash(mac_addr, 6);
+    uint8_t third_octet = (uint8_t)(hash ^ (hash >> 8));
+
+    // Avoid .0 and .255
+    if (third_octet == 0) {
+        third_octet = 1;
+    }
+    if (third_octet == 255) {
+        third_octet = 254;
+    }
+
+    ip_addr[2] = third_octet;
+}
+
+static err_t linkoutput_fn(struct netif *netif, struct pbuf *p) {
+    (void)netif;
+    if (!tud_ready()) {
+        return ERR_USE;
+    }
+    if (!tud_network_can_xmit(p->tot_len)) {
+        // TinyUSB is busy with a previous transmit; let lwIP retry via its
+        // own ARP/TCP retransmit timers rather than busy-waiting here.
+        return ERR_USE;
+    }
+    tud_network_xmit(p, 0);
+    return ERR_OK;
+}
+
+static err_t netif_init_cb(struct netif *netif) {
+    LWIP_ASSERT("netif != NULL", (netif != NULL));
+    netif->name[0] = 'u'; // lwIP short name "un" for USB Network
+    netif->name[1] = 'n';
+    netif->mtu = CFG_TUD_NET_MTU;
+    netif->flags = NETIF_FLAG_BROADCAST | NETIF_FLAG_ETHARP | NETIF_FLAG_ETHERNET | NETIF_FLAG_IGMP;
+    netif->state = NULL;
+    netif->linkoutput = linkoutput_fn;
+    netif->output = etharp_output;
+    #if LWIP_IPV6
+    netif->output_ip6 = ethip6_output;
+    netif->flags |= NETIF_FLAG_MLD6;
+    #endif
+    return ERR_OK;
+}
+
+static void ncm_init(void) {
+    // Init the NCM object
+    ncm_obj.base.type = (mp_obj_type_t *)&mod_network_nic_type_ncm;
+
+    struct netif *netif = &(ncm_obj.netif);
+
+    MICROPY_PY_LWIP_ENTER
+
+    mp_hal_get_mac(MP_HAL_MAC_ETH0, tud_network_mac_address);
+    tud_network_mac_address[0] = 0x02;
+
+    netif->hwaddr_len = sizeof(tud_network_mac_address);
+    memcpy(netif->hwaddr, tud_network_mac_address, sizeof(tud_network_mac_address));
+
+    // This USB Network essentially creates a link with two interfaces, one for the
+    // host and another for the micropython/lwip end of the connection.
+    // The MAC configured above is use for one end of the link, flip a bit for the
+    // MAC on the other end of the link.
+    netif->hwaddr[5] ^= 0x01;
+
+    // Generate unique link-local IP address from MAC address
+    uint8_t ip_bytes[4];
+    generate_linklocal_ip_from_mac(tud_network_mac_address, ip_bytes);
+
+    // Convert to network byte order and set IP configuration
+    IP(ncm_obj.ipaddr).addr = PP_HTONL(((uint32_t)ip_bytes[0] << 24) | ((uint32_t)ip_bytes[1] << 16) | ((uint32_t)ip_bytes[2] << 8) | ip_bytes[3]);
+    IP(ncm_obj.netmask).addr = PP_HTONL(0xFFFF0000);  // 255.255.0.0 for link-local
+    IP(ncm_obj.gateway).addr = 0;  // No gateway for link-local
+
+    netif = netif_add(
+        netif,
+        ip_2_ip4(&ncm_obj.ipaddr),
+        ip_2_ip4(&ncm_obj.netmask),
+        ip_2_ip4(&ncm_obj.gateway),
+        NULL,
+        netif_init_cb,
+        ethernet_input
+        );
+    if (netif == NULL) {
+        MICROPY_PY_LWIP_EXIT
+        mp_raise_OSError(MP_ENOMEM);
+    }
+    #if LWIP_IPV6
+    netif_create_ip6_linklocal_address(netif, 1);
+    netif_set_ip6_autoconfig_enabled(netif, 1);
+    #endif
+    #if LWIP_NETIF_HOSTNAME
+    netif_set_hostname(netif, mod_network_hostname_data);
+    #endif
+    if (netif_default == NULL) {
+        netif_set_default(netif);
+    }
+
+    #if LWIP_MDNS_RESPONDER
+    mdns_resp_add_netif(netif, mod_network_hostname_data);
+    #endif
+
+    #if MICROPY_PY_NETWORK_USBD_NCM_DHCP_SERVER
+    dhcp_server_init(&ncm_obj.dhcp_server, &ncm_obj.ipaddr, &ncm_obj.netmask);
+    // Don't advertise a default gateway -- this is a point-to-point USB link
+    // and advertising a router causes the host to route all traffic over USB.
+    ncm_obj.dhcp_server.send_router = false;
+    #endif
+
+    // register with network module
+    mod_network_register_nic(&ncm_obj);
+    ncm_obj.init = true;
+
+    MICROPY_PY_LWIP_EXIT
+}
+
+static void _scheduled_tud_network_recv_renew(mp_sched_node_t *node) {
+    // Acknowledge the pending receive renew. tud_network_recv_renew() must
+    // be called after each received packet to release the TinyUSB receive
+    // buffer; mp_sched_schedule_node is a single-slot queue so at most one
+    // call is pending at any time.
+    uint32_t atomic_state = MICROPY_BEGIN_ATOMIC_SECTION();
+    if (ncm_recv_renew_pending) {
+        ncm_recv_renew_pending = false;
+        MICROPY_END_ATOMIC_SECTION(atomic_state);
+        tud_network_recv_renew();
+    } else {
+        MICROPY_END_ATOMIC_SECTION(atomic_state);
+    }
+}
+
+bool tud_network_recv_cb(const uint8_t *src, uint16_t size) {
+    if (!ncm_obj.init) {
+        return false;
+    }
+    struct netif *netif = &(ncm_obj.netif);
+    bool ret = true;
+    if (size) {
+        MICROPY_PY_LWIP_ENTER
+
+        struct pbuf *p = pbuf_alloc(PBUF_RAW, size, PBUF_POOL);
+        if (p == NULL) {
+            MICROPY_PY_LWIP_EXIT
+            // Return false without calling recv_renew: TinyUSB holds the buffer.
+            // NCM RX will stall until the host retransmits and memory is available.
+            return false;
+        }
+
+        // Copy buf to pbuf
+        pbuf_take(p, src, size);
+
+        if (netif->input(p, netif) != ERR_OK) {
+            pbuf_free(p);
+            ret = false;
+        }
+
+        MICROPY_PY_LWIP_EXIT
+    }
+    // Schedule tud_network_recv_renew() to run after this callback returns.
+    // recv_renew must not be called from within the recv callback itself.
+    uint32_t atomic_state = MICROPY_BEGIN_ATOMIC_SECTION();
+    ncm_recv_renew_pending = true;
+    MICROPY_END_ATOMIC_SECTION(atomic_state);
+    mp_sched_schedule_node(&ncm_sched_node, _scheduled_tud_network_recv_renew);
+    return ret;
+}
+
+uint16_t tud_network_xmit_cb(uint8_t *dst, void *ref, uint16_t arg) {
+    // copy from network stack packet pointer to dst.
+    (void)arg;
+    MICROPY_PY_LWIP_ENTER
+    struct pbuf *p = (struct pbuf *)ref;
+    uint16_t len = pbuf_copy_partial(p, dst, p->tot_len, 0);
+    MICROPY_PY_LWIP_EXIT
+    return len;
+}
+
+void tud_network_init_cb(void) {
+    // Called by TinyUSB's ECM/RNDIS driver when the host configures the
+    // interface. The NCM driver (TinyUSB >= 0.19) does NOT call this;
+    // instead ncm_auto_init() is called from mod_network_init() before
+    // USB starts. This implementation is kept for ECM/RNDIS compatibility.
+    if (!ncm_obj.init) {
+        ncm_init();
+    }
+    MICROPY_PY_LWIP_ENTER
+    netif_set_link_up(&ncm_obj.netif);
+    MICROPY_PY_LWIP_EXIT
+}
+
+// Called from mod_network_init() to set up the NCM netif before USB starts.
+// TinyUSB's NCM driver begins receiving as soon as the host sends
+// SET_INTERFACE(alt=1), which happens during USB enumeration -- before any
+// Python code runs.  The netif must exist by then so tud_network_recv_cb()
+// can deliver packets to lwIP.
+//
+// The netif is intentionally kept alive across MicroPython soft reset: lwIP
+// is not re-initialised on soft reset, so the netif remains valid and TinyUSB
+// can continue delivering packets. On re-entry we only re-register the singleton
+// with the NIC list (which mod_network_init() cleared) rather than re-running
+// netif_add (which must only be called once per netif).
+void ncm_auto_init(void) {
+    if (!ncm_obj.init) {
+        ncm_init();
+    } else {
+        // On soft-reset mod_network_init() clears the NIC list, so
+        // re-register the (still-live) singleton.
+        mod_network_register_nic(&ncm_obj);
+    }
+    netif_set_up(&ncm_obj.netif);
+    netif_set_link_up(&ncm_obj.netif);
+}
+
+/*******************************************************************************/
+// MicroPython bindings
+
+// Create and return a USBD_NCM object.
+static mp_obj_t ncm_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *args) {
+    mp_arg_check_num(n_args, n_kw, 0, 0, false);
+    if (!ncm_obj.init) {
+        ncm_init();
+    }
+    // Return NCM object
+    return MP_OBJ_FROM_PTR(&ncm_obj);
+}
+
+static mp_obj_t ncm_status(mp_obj_t self_in) {
+    ncm_obj_t *self = MP_OBJ_TO_PTR(self_in);
+    return MP_OBJ_NEW_SMALL_INT(IS_ACTIVE(self) ? 1 : 0);
+}
+static MP_DEFINE_CONST_FUN_OBJ_1(ncm_status_obj, ncm_status);
+
+static mp_obj_t ncm_isconnected(mp_obj_t self_in) {
+    ncm_obj_t *self = MP_OBJ_TO_PTR(self_in);
+    return mp_obj_new_bool(tud_connected() && netif_is_link_up(&self->netif));
+}
+static MP_DEFINE_CONST_FUN_OBJ_1(ncm_isconnected_obj, ncm_isconnected);
+
+static mp_obj_t ncm_active(size_t n_args, const mp_obj_t *args) {
+    ncm_obj_t *self = MP_OBJ_TO_PTR(args[0]);
+    if (n_args == 1) {
+        return mp_obj_new_bool(IS_ACTIVE(self));
+    } else {
+        if (mp_obj_is_true(args[1])) {
+            if (!IS_ACTIVE(self)) {
+                netif_set_up(&self->netif);
+                netif_set_link_up(&self->netif);
+            }
+        } else {
+            if (IS_ACTIVE(self)) {
+                netif_set_link_down(&self->netif);
+                netif_set_down(&self->netif);
+                // Note: We don't call ncm_deinit() here because that would
+                // completely remove the network interface. We just want to
+                // deactivate it so it can be reactivated later.
+            }
+        }
+        return mp_const_none;
+    }
+}
+static MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(ncm_active_obj, 1, 2, ncm_active);
+
+static mp_obj_t ncm_ifconfig(size_t n_args, const mp_obj_t *args) {
+    ncm_obj_t *self = MP_OBJ_TO_PTR(args[0]);
+    return mod_network_nic_ifconfig(&self->netif, n_args - 1, args + 1);
+}
+static MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(ncm_ifconfig_obj, 1, 2, ncm_ifconfig);
+
+static mp_obj_t ncm_ipconfig(size_t n_args, const mp_obj_t *args, mp_map_t *kwargs) {
+    ncm_obj_t *self = MP_OBJ_TO_PTR(args[0]);
+    return mod_network_nic_ipconfig(&self->netif, n_args - 1, args + 1, kwargs);
+}
+static MP_DEFINE_CONST_FUN_OBJ_KW(ncm_ipconfig_obj, 1, ncm_ipconfig);
+
+static mp_obj_t ncm_config(size_t n_args, const mp_obj_t *args, mp_map_t *kwargs) {
+    if (n_args == 2 && kwargs->used == 0) {
+        const char *key = mp_obj_str_get_str(args[1]);
+        if (strcmp(key, "mac") == 0) {
+            return mp_obj_new_bytes(tud_network_mac_address, sizeof(tud_network_mac_address));
+        }
+    }
+    mp_raise_ValueError(MP_ERROR_TEXT("unknown config param"));
+}
+static MP_DEFINE_CONST_FUN_OBJ_KW(ncm_config_obj, 1, ncm_config);
+
+static const mp_rom_map_elem_t ncm_locals_dict_table[] = {
+    { MP_ROM_QSTR(MP_QSTR_status), MP_ROM_PTR(&ncm_status_obj) },
+    { MP_ROM_QSTR(MP_QSTR_isconnected), MP_ROM_PTR(&ncm_isconnected_obj) },
+    { MP_ROM_QSTR(MP_QSTR_active), MP_ROM_PTR(&ncm_active_obj) },
+    { MP_ROM_QSTR(MP_QSTR_ifconfig), MP_ROM_PTR(&ncm_ifconfig_obj) },
+    { MP_ROM_QSTR(MP_QSTR_ipconfig), MP_ROM_PTR(&ncm_ipconfig_obj) },
+    { MP_ROM_QSTR(MP_QSTR_config), MP_ROM_PTR(&ncm_config_obj) },
+};
+static MP_DEFINE_CONST_DICT(ncm_locals_dict, ncm_locals_dict_table);
+
+MP_DEFINE_CONST_OBJ_TYPE(
+    mod_network_nic_type_ncm,
+    MP_QSTR_USBD_NCM,
+    MP_TYPE_FLAG_NONE,
+    make_new, ncm_make_new,
+    locals_dict, &ncm_locals_dict
+    );
+
+#endif

--- a/extmod/network_usbd_ncm.h
+++ b/extmod/network_usbd_ncm.h
@@ -1,0 +1,40 @@
+/*
+ * This file is part of the MicroPython project, http://micropython.org/
+ *
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2026 Andrew Leech
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#ifndef MICROPY_INCLUDED_EXTMOD_NETWORK_USBD_NCM_H
+#define MICROPY_INCLUDED_EXTMOD_NETWORK_USBD_NCM_H
+
+// Start dhcp server on this interface by default as this allows the host computer
+// to be automatically / quickly allocated a suitable ip address to be able to
+// communicate over the usb network link.
+#ifndef MICROPY_PY_NETWORK_USBD_NCM_DHCP_SERVER
+#define MICROPY_PY_NETWORK_USBD_NCM_DHCP_SERVER  (1)
+#endif
+
+// Initialise the NCM netif early (before USB enumeration).
+void ncm_auto_init(void);
+
+#endif // MICROPY_INCLUDED_EXTMOD_NETWORK_USBD_NCM_H

--- a/shared/tinyusb/mp_usbd.h
+++ b/shared/tinyusb/mp_usbd.h
@@ -90,10 +90,11 @@ extern void mp_usbd_port_get_serial_number(char *buf);
 void mp_usbd_hex_str(char *out_str, const uint8_t *bytes, size_t bytes_len);
 
 // Length of built-in configuration descriptor
-#define MP_USBD_BUILTIN_DESC_CFG_LEN (TUD_CONFIG_DESC_LEN +                     \
-    (CFG_TUD_CDC ? (TUD_CDC_DESC_LEN) : 0) +  \
-    (CFG_TUD_MSC ? (TUD_MSC_DESC_LEN) : 0)    \
-    )
+#define MP_USBD_BUILTIN_DESC_CFG_LEN ( \
+    (CFG_TUD_CDC ? (TUD_CDC_DESC_LEN) : 0) + \
+    (CFG_TUD_MSC ? (TUD_MSC_DESC_LEN) : 0) + \
+    (CFG_TUD_NCM ? (TUD_CDC_NCM_DESC_LEN) : 0) + \
+    TUD_CONFIG_DESC_LEN)
 
 // Built-in USB device and configuration descriptor values
 extern const tusb_desc_device_t mp_usbd_builtin_desc_dev;

--- a/shared/tinyusb/mp_usbd_descriptor.c
+++ b/shared/tinyusb/mp_usbd_descriptor.c
@@ -35,6 +35,7 @@
 #define USBD_CDC_CMD_MAX_SIZE (8)
 #define USBD_CDC_IN_OUT_MAX_SIZE ((CFG_TUD_MAX_SPEED == OPT_MODE_HIGH_SPEED) ? 512 : 64)
 #define USBD_MSC_IN_OUT_MAX_SIZE ((CFG_TUD_MAX_SPEED == OPT_MODE_HIGH_SPEED) ? 512 : 64)
+#define USBD_NCM_IN_OUT_MAX_SIZE ((CFG_TUD_MAX_SPEED == OPT_MODE_HIGH_SPEED) ? 512 : 64)
 
 const tusb_desc_device_t mp_usbd_builtin_desc_dev = {
     .bLength = sizeof(tusb_desc_device_t),
@@ -77,7 +78,11 @@ const uint8_t mp_usbd_builtin_desc_cfg[MP_USBD_BUILTIN_DESC_CFG_LEN] = {
         USBD_CDC_CMD_MAX_SIZE, USBD_CDC_EP_OUT, USBD_CDC_EP_IN, USBD_CDC_IN_OUT_MAX_SIZE),
     #endif
     #if CFG_TUD_MSC
-    TUD_MSC_DESCRIPTOR(USBD_ITF_MSC, USBD_STR_MSC, EPNUM_MSC_OUT, EPNUM_MSC_IN, USBD_MSC_IN_OUT_MAX_SIZE),
+    TUD_MSC_DESCRIPTOR(USBD_ITF_MSC, USBD_STR_MSC, USBD_MSC_EP_OUT, USBD_MSC_EP_IN, USBD_MSC_IN_OUT_MAX_SIZE),
+    #endif
+    #if CFG_TUD_NCM
+    // Interface number, description string index, MAC address string index, EP notification address and size, EP data address (out, in), and size, max segment size, notification interval, network capabilities.
+    TUD_CDC_NCM_DESCRIPTOR(USBD_ITF_NCM, USBD_STR_NCM, USBD_STR_NCM_MAC, USBD_NCM_EP_CMD, 64, USBD_NCM_EP_OUT, USBD_NCM_EP_IN, USBD_NCM_IN_OUT_MAX_SIZE, CFG_TUD_NET_MTU, 50, 0),
     #endif
 };
 
@@ -128,6 +133,15 @@ const uint16_t *tud_descriptor_string_cb(uint8_t index, uint16_t langid) {
             #if CFG_TUD_MSC
             case USBD_STR_MSC:
                 desc_str = MICROPY_HW_USB_MSC_INTERFACE_STRING;
+                break;
+            #endif
+            #if CFG_TUD_NCM
+            case USBD_STR_NCM:
+                desc_str = MICROPY_PY_NETWORK_USBD_NCM_INTERFACE_STRING;
+                break;
+            case USBD_STR_NCM_MAC:
+                mp_usbd_hex_str(serial_buf, (uint8_t *)tud_network_mac_address, sizeof(tud_network_mac_address));
+                desc_str = serial_buf;
                 break;
             #endif
             default:

--- a/shared/tinyusb/tusb_config.h
+++ b/shared/tinyusb/tusb_config.h
@@ -94,14 +94,61 @@
 #define CFG_TUD_MSC_BUFSIZE (MICROPY_FATFS_MAX_SS)
 #endif // CFG_TUD_MSC
 
+#if MICROPY_PY_NETWORK_USBD_NCM
+// TinyUSB supports both RNDIS and NCM protocols.
+// NCM is now recommended by Microsoft on Win 11 and above.
+#define CFG_TUD_NCM             (1)
+
+// NCM TinyUSB buffer configuration.
+// These depend on lwIP parameters (TCP_MSS, LWIP_MDNS_RESPONDER); lwipopts.h
+// is safe to include here because MICROPY_PY_NETWORK_USBD_NCM implies LWIP.
+#include "lwipopts.h"
+
+// Must be >> MTU; can be set to 2048 without impact.
+#ifndef CFG_TUD_NCM_IN_NTB_MAX_SIZE
+#define CFG_TUD_NCM_IN_NTB_MAX_SIZE  ((2 + LWIP_MDNS_RESPONDER) * TCP_MSS + 100)
+#endif
+#ifndef CFG_TUD_NCM_OUT_NTB_MAX_SIZE
+#define CFG_TUD_NCM_OUT_NTB_MAX_SIZE ((2 + LWIP_MDNS_RESPONDER) * TCP_MSS + 100)
+#endif
+
+// Number of NCM transfer blocks for reception side.
+#ifndef CFG_TUD_NCM_OUT_NTB_N
+#define CFG_TUD_NCM_OUT_NTB_N 1
+#endif
+// Number of NCM transfer blocks for transmission side.
+#ifndef CFG_TUD_NCM_IN_NTB_N
+#define CFG_TUD_NCM_IN_NTB_N  (2 + LWIP_MDNS_RESPONDER)
+#endif
+
+#ifndef MICROPY_PY_NETWORK_USBD_NCM_INTERFACE_STRING
+#define MICROPY_PY_NETWORK_USBD_NCM_INTERFACE_STRING "Board NET"
+#endif
+#endif // MICROPY_PY_NETWORK_USBD_NCM
+
+#define USBD_RHPORT (0) // Currently only one port is supported
+
 // Define built-in interface, string and endpoint numbering based on the above config
 
-#define USBD_STR_0 (0x00)
-#define USBD_STR_MANUF (0x01)
-#define USBD_STR_PRODUCT (0x02)
-#define USBD_STR_SERIAL (0x03)
-#define USBD_STR_CDC (0x04)
-#define USBD_STR_MSC (0x05)
+enum _USBD_STR {
+    USBD_STR_0 = (0x00),
+    USBD_STR_MANUF = (0x01),
+    USBD_STR_PRODUCT = (0x02),
+    USBD_STR_SERIAL = (0x03),
+    #if CFG_TUD_CDC
+    USBD_STR_CDC,
+    #endif
+    #if CFG_TUD_MSC
+    USBD_STR_MSC,
+    #endif
+    #if CFG_TUD_NCM
+    USBD_STR_NCM,
+    USBD_STR_NCM_MAC,
+    #endif
+    // One more than the highest built-in string index; runtime device string
+    // indexes should start at or above this value to avoid collisions.
+    USBD_STR_BUILTIN_MAX,
+};
 
 #define USBD_MAX_POWER_MA (250)
 
@@ -109,40 +156,60 @@
 #define MICROPY_HW_USB_DESC_STR_MAX (40)
 #endif
 
-#if CFG_TUD_CDC
-#define USBD_ITF_CDC (0) // needs 2 interfaces
-#define USBD_CDC_EP_CMD (0x81)
-#define USBD_CDC_EP_OUT (0x02)
-#define USBD_CDC_EP_IN (0x82)
-#endif // CFG_TUD_CDC
+enum _USBD_ITF {
+    #if CFG_TUD_CDC
+    USBD_ITF_CDC,
+    USBD_ITF_CDC_I2,
+    #endif // CFG_TUD_CDC
+    #if CFG_TUD_MSC
+    USBD_ITF_MSC,
+    #endif // CFG_TUD_MSC
+    #if CFG_TUD_NCM
+    USBD_ITF_NCM,
+    USBD_ITF_NCM_DATA,
+    #endif
+};
 
-#if CFG_TUD_MSC
-// Interface & Endpoint numbers for MSC come after CDC, if it is enabled
+enum _USBD_EP {
+    USBD_EP_BASE = 0x80,
+    #if CFG_TUD_CDC
+    USBD_CDC_EP_CMD,
+    USBD_CDC_EP_IN,
+    #endif // CFG_TUD_CDC
+    #if CFG_TUD_MSC
+    USBD_MSC_EP_IN,
+    #endif // CFG_TUD_MSC
+    #if CFG_TUD_NCM
+    USBD_NCM_EP_CMD,
+    USBD_NCM_EP_IN,
+    #endif // CFG_TUD_NCM
+};
+
+// define the matching in endpoints to each EP_OUT
 #if CFG_TUD_CDC
-#define USBD_ITF_MSC (2)
-#define EPNUM_MSC_OUT (0x03)
-#define EPNUM_MSC_IN (0x83)
-#else
-#define USBD_ITF_MSC (0)
-#define EPNUM_MSC_OUT (0x01)
-#define EPNUM_MSC_IN (0x81)
-#endif // CFG_TUD_CDC
-#endif // CFG_TUD_MSC
+#define USBD_CDC_EP_OUT  ((USBD_CDC_EP_IN)&~TUSB_DIR_IN_MASK)
+#endif
+#if CFG_TUD_MSC
+#define USBD_MSC_EP_OUT  ((USBD_MSC_EP_IN)&~TUSB_DIR_IN_MASK)
+#endif
+#if CFG_TUD_NCM
+#define USBD_NCM_EP_OUT  ((USBD_NCM_EP_IN)&~TUSB_DIR_IN_MASK)
+#endif
+
 
 /* Limits of builtin USB interfaces, endpoints, strings */
-#if CFG_TUD_MSC
-#define USBD_ITF_BUILTIN_MAX (USBD_ITF_MSC + 1)
-#define USBD_STR_BUILTIN_MAX (USBD_STR_MSC + 1)
-#define USBD_EP_BUILTIN_MAX (EPNUM_MSC_OUT + 1)
-#elif CFG_TUD_CDC
-#define USBD_ITF_BUILTIN_MAX (USBD_ITF_CDC + 2)
-#define USBD_STR_BUILTIN_MAX (USBD_STR_CDC + 1)
-#define USBD_EP_BUILTIN_MAX (((USBD_CDC_EP_IN)&~TUSB_DIR_IN_MASK) + 1)
-#else // !CFG_TUD_MSC && !CFG_TUD_CDC
-#define USBD_ITF_BUILTIN_MAX (0)
-#define USBD_STR_BUILTIN_MAX (0)
-#define USBD_EP_BUILTIN_MAX (0)
-#endif
+// Number of interfaces used by all enabled classes
+#define USBD_ITF_BUILTIN_MAX ( \
+    (CFG_TUD_CDC ? 2 : 0) + \
+    (CFG_TUD_MSC ? 1 : 0) + \
+    (CFG_TUD_NCM ? 2 : 0))
+
+// 1 plus the number of interfaces used by all enabled classes
+#define USBD_EP_BUILTIN_MAX ( \
+    (CFG_TUD_CDC ? 2 : 0) + \
+    (CFG_TUD_MSC ? 1 : 0) + \
+    (CFG_TUD_NCM ? 2 : 0) + \
+    1)
 
 #endif // MICROPY_HW_ENABLE_USBDEV
 

--- a/shared/tinyusb/tusb_config.h
+++ b/shared/tinyusb/tusb_config.h
@@ -94,14 +94,59 @@
 #define CFG_TUD_MSC_BUFSIZE (MICROPY_FATFS_MAX_SS)
 #endif // CFG_TUD_MSC
 
+#if MICROPY_PY_NETWORK_USBD_NCM
+// TinyUSB supports both RNDIS and NCM protocols.
+// NCM is now recommended by Microsoft on Win 11 and above.
+#define CFG_TUD_NCM             (1)
+
+// NCM TinyUSB buffer configuration.
+// These depend on lwIP parameters (TCP_MSS, LWIP_MDNS_RESPONDER); lwipopts.h
+// is safe to include here because MICROPY_PY_NETWORK_USBD_NCM implies LWIP.
+#include "lwipopts.h"
+
+// Must be >> MTU; can be set to 2048 without impact.
+#ifndef CFG_TUD_NCM_IN_NTB_MAX_SIZE
+#define CFG_TUD_NCM_IN_NTB_MAX_SIZE  ((2 + LWIP_MDNS_RESPONDER) * TCP_MSS + 100)
+#endif
+#ifndef CFG_TUD_NCM_OUT_NTB_MAX_SIZE
+#define CFG_TUD_NCM_OUT_NTB_MAX_SIZE ((2 + LWIP_MDNS_RESPONDER) * TCP_MSS + 100)
+#endif
+
+// Number of NCM transfer blocks for reception side.
+#ifndef CFG_TUD_NCM_OUT_NTB_N
+#define CFG_TUD_NCM_OUT_NTB_N 1
+#endif
+// Number of NCM transfer blocks for transmission side.
+#ifndef CFG_TUD_NCM_IN_NTB_N
+#define CFG_TUD_NCM_IN_NTB_N  (2 + LWIP_MDNS_RESPONDER)
+#endif
+
+#ifndef MICROPY_PY_NETWORK_USBD_NCM_INTERFACE_STRING
+#define MICROPY_PY_NETWORK_USBD_NCM_INTERFACE_STRING "Board NET"
+#endif
+#endif // MICROPY_PY_NETWORK_USBD_NCM
+
 // Define built-in interface, string and endpoint numbering based on the above config
 
-#define USBD_STR_0 (0x00)
-#define USBD_STR_MANUF (0x01)
-#define USBD_STR_PRODUCT (0x02)
-#define USBD_STR_SERIAL (0x03)
-#define USBD_STR_CDC (0x04)
-#define USBD_STR_MSC (0x05)
+enum _USBD_STR {
+    USBD_STR_0 = (0x00),
+    USBD_STR_MANUF = (0x01),
+    USBD_STR_PRODUCT = (0x02),
+    USBD_STR_SERIAL = (0x03),
+    #if CFG_TUD_CDC
+    USBD_STR_CDC,
+    #endif
+    #if CFG_TUD_MSC
+    USBD_STR_MSC,
+    #endif
+    #if CFG_TUD_NCM
+    USBD_STR_NCM,
+    USBD_STR_NCM_MAC,
+    #endif
+    // One more than the highest built-in string index; runtime device string
+    // indexes should start at or above this value to avoid collisions.
+    USBD_STR_BUILTIN_MAX,
+};
 
 #define USBD_MAX_POWER_MA (250)
 
@@ -109,40 +154,60 @@
 #define MICROPY_HW_USB_DESC_STR_MAX (40)
 #endif
 
-#if CFG_TUD_CDC
-#define USBD_ITF_CDC (0) // needs 2 interfaces
-#define USBD_CDC_EP_CMD (0x81)
-#define USBD_CDC_EP_OUT (0x02)
-#define USBD_CDC_EP_IN (0x82)
-#endif // CFG_TUD_CDC
+enum _USBD_ITF {
+    #if CFG_TUD_CDC
+    USBD_ITF_CDC,
+    USBD_ITF_CDC_I2,
+    #endif // CFG_TUD_CDC
+    #if CFG_TUD_MSC
+    USBD_ITF_MSC,
+    #endif // CFG_TUD_MSC
+    #if CFG_TUD_NCM
+    USBD_ITF_NCM,
+    USBD_ITF_NCM_DATA,
+    #endif
+};
 
-#if CFG_TUD_MSC
-// Interface & Endpoint numbers for MSC come after CDC, if it is enabled
+enum _USBD_EP {
+    USBD_EP_BASE = 0x80,
+    #if CFG_TUD_CDC
+    USBD_CDC_EP_CMD,
+    USBD_CDC_EP_IN,
+    #endif // CFG_TUD_CDC
+    #if CFG_TUD_MSC
+    USBD_MSC_EP_IN,
+    #endif // CFG_TUD_MSC
+    #if CFG_TUD_NCM
+    USBD_NCM_EP_CMD,
+    USBD_NCM_EP_IN,
+    #endif // CFG_TUD_NCM
+};
+
+// define the matching in endpoints to each EP_OUT
 #if CFG_TUD_CDC
-#define USBD_ITF_MSC (2)
-#define EPNUM_MSC_OUT (0x03)
-#define EPNUM_MSC_IN (0x83)
-#else
-#define USBD_ITF_MSC (0)
-#define EPNUM_MSC_OUT (0x01)
-#define EPNUM_MSC_IN (0x81)
-#endif // CFG_TUD_CDC
-#endif // CFG_TUD_MSC
+#define USBD_CDC_EP_OUT  (USBD_CDC_EP_IN & ~TUSB_DIR_IN_MASK)
+#endif
+#if CFG_TUD_MSC
+#define USBD_MSC_EP_OUT  (USBD_MSC_EP_IN & ~TUSB_DIR_IN_MASK)
+#endif
+#if CFG_TUD_NCM
+#define USBD_NCM_EP_OUT  (USBD_NCM_EP_IN & ~TUSB_DIR_IN_MASK)
+#endif
+
 
 /* Limits of builtin USB interfaces, endpoints, strings */
-#if CFG_TUD_MSC
-#define USBD_ITF_BUILTIN_MAX (USBD_ITF_MSC + 1)
-#define USBD_STR_BUILTIN_MAX (USBD_STR_MSC + 1)
-#define USBD_EP_BUILTIN_MAX (EPNUM_MSC_OUT + 1)
-#elif CFG_TUD_CDC
-#define USBD_ITF_BUILTIN_MAX (USBD_ITF_CDC + 2)
-#define USBD_STR_BUILTIN_MAX (USBD_STR_CDC + 1)
-#define USBD_EP_BUILTIN_MAX (((USBD_CDC_EP_IN)&~TUSB_DIR_IN_MASK) + 1)
-#else // !CFG_TUD_MSC && !CFG_TUD_CDC
-#define USBD_ITF_BUILTIN_MAX (0)
-#define USBD_STR_BUILTIN_MAX (0)
-#define USBD_EP_BUILTIN_MAX (0)
-#endif
+// Number of interfaces used by all enabled classes
+#define USBD_ITF_BUILTIN_MAX ( \
+    (CFG_TUD_CDC ? 2 : 0) + \
+    (CFG_TUD_MSC ? 1 : 0) + \
+    (CFG_TUD_NCM ? 2 : 0))
+
+// 1 plus the number of interfaces used by all enabled classes
+#define USBD_EP_BUILTIN_MAX ( \
+    (CFG_TUD_CDC ? 2 : 0) + \
+    (CFG_TUD_MSC ? 1 : 0) + \
+    (CFG_TUD_NCM ? 2 : 0) + \
+    1)
 
 #endif // MICROPY_HW_ENABLE_USBDEV
 


### PR DESCRIPTION
> Depends on #19101 (network init) and #19102 (TinyUSB Makefile consolidation). The first 5 commits in this branch are from those PRs and will drop out once they merge.

### Summary

This PR provides a network interface over the USB connection which is connected to the existing LWIP network stack.

`dmesg` after plugging in a Pico with NCM enabled:
![image](https://github.com/user-attachments/assets/1ef13deb-cf77-424f-bb48-48888e122d45)

The regular USB serial port is still provided for mpremote. Use that to enable the network interface:
![image](https://github.com/user-attachments/assets/864e0104-2a0f-454b-9e25-88fc3abbb0d7)

DHCP server is provided by the board, so the host gets an IP address automatically:
![image](https://github.com/user-attachments/assets/c117bb8c-08b2-4acf-b28a-533ef0457cc5)

After that, sockets and services can be used as per any normal network connection:

![image](https://github.com/user-attachments/assets/6f98aaa0-e8f2-4fe3-ac9c-95a728164496)
![image](https://github.com/user-attachments/assets/df37b074-b847-44af-8567-1f5623942f68)

Any port based on TinyUSB can use this with minimal effort, provided LWIP is also enabled. The board/chip needs to be large enough to support the ~20KB RAM needs of LWIP.

The feature is disabled by default. Enable it by setting `MICROPY_PY_NETWORK_NCM=1` at build time.

#### Building

On stm32 (also requires enabling the TinyUSB stack and LWIP):
```bash
make -j -C ports/stm32 BOARD=NUCLEO_WB55 \
  MICROPY_PY_LWIP=1 \
  CFLAGS_EXTRA="-DMICROPY_HW_TINYUSB_STACK=1 -DMICROPY_PY_NETWORK_NCM=1"
```

On a cmake-based port (rp2):
```bash
make -j -C ports/rp2 BOARD=RPI_PICO2_W \
  MICROPY_PY_LWIP=1 \
  CFLAGS_EXTRA="-DMICROPY_PY_NETWORK_NCM=1"
```

On mimxrt:
```bash
make -j -C ports/mimxrt BOARD=SEEED_ARCH_MIX \
  MICROPY_PY_LWIP=1 \
  CFLAGS_EXTRA="-DMICROPY_PY_NETWORK_NCM=1 -DLWIP_IPV6=1"
```

### Testing
- Pico (minimal connectivity testing)
- STM32F765 running microdot (with stm32 TinyUSB PR merged)
- NUCLEO_WB55 (stm32, CDC+NCM, ping verified)
- mimxrt/SEEED_ARCH_MIX (NCM device appears but both CDC and NCM were locked up - needs further investigation)

### Trade-offs and Alternatives

LWIP adds ~20KB RAM overhead, so for smaller parts a custom USB protocol may be more appropriate. A network connection over USB opens up use of existing servers and services (HTTP, MQTT, WebREPL, etc.) without requiring Ethernet hardware.

### Generative AI

I used generative AI tools when creating this PR, but a human has checked the
code and is responsible for the code and the description above.

---
This work was funded by Planet Innovation.