### PR TITLE
tools/verifygitlog.py: Show invalid commit subjects in quotes.

### DIFF
--- a/tools/verifygitlog.py
+++ b/tools/verifygitlog.py
@@ -47,7 +47,7 @@ def git_log(pretty_format, *args):
 
 
 def diagnose_subject_line(subject_line, subject_line_format, err):
-    err.error("Subject line: " + subject_line)
+    err.error('Subject line: "' + subject_line + '"')
     if not subject_line.endswith("."):
         err.error('* must end with "."')
     if not re.match(r"^[^!]+: ", subject_line):


### PR DESCRIPTION
### Summary

If a commit subject line has any trailing whitespace it won't match the repository validation rules, and the line will show up as part of the relevant error message.  However, since there's no quotation marks around the offending text, the trailing whitespace may go unnoticed, and given that the commit message is then discarded when the commit operation is retried this can get fairly annoying.

This commit simply modifies the error output for invalid subject lines to add quotation marks around the offending text, so trailing whitespace is much easier to see.

### Testing

I accidentally triggered the trailing whitespace issue when attempting to commit some code (the subject line has a trailing space character past the period):

```
[...]
MicroPython git commit message format checker............................Failed
- hook id: verifygitlog
- duration: 0.15s
- exit code: 1

error: Subject line: py/emitnative: Use RV32 Zba opcodes for shorter sequences if enabled. 
error: * must end with "."
error: * must match: '^[^!]+: [A-Z]+.+ .+\\.$'
error: * Example: "py/runtime: Add support for foo to bar."
[...]
```

But after this change it looks like this:

```
[...]
MicroPython git commit message format checker............................Failed
- hook id: verifygitlog
- duration: 0.15s
- exit code: 1

error: Subject line: "py/emitnative: Use RV32 Zba opcodes for shorter sequences if enabled. "
error: * must end with "."
error: * must match: '^[^!]+: [A-Z]+.+ .+\\.$'
error: * Example: "py/runtime: Add support for foo to bar."
[...]
```

With the trailing space slightly more visible.

### Trade-offs and Alternatives

I could have used the backtick (`) character instead of normal quotation mark character but then that may yield "interesting" side-effects if the output is accidentally copied and pasted in an Unix-like shell.