### PR TITLE
docs/rp2: Add wlan information to the quickref.

### DIFF
--- a/docs/esp32/quickref.rst
+++ b/docs/esp32/quickref.rst
@@ -83,30 +83,30 @@ The :class:`network.WLAN` class in the :mod:`network` module::
 
     import network
 
-    wlan = network.WLAN(network.WLAN.IF_STA) # create station interface
-    wlan.active(True)       # activate the interface
-    wlan.scan()             # scan for access points
-    wlan.isconnected()      # check if the station is connected to an AP
+    wlan = network.WLAN()       # create station interface (the default, see below for an access point interface)
+    wlan.active(True)           # activate the interface
+    wlan.scan()                 # scan for access points
+    wlan.isconnected()          # check if the station is connected to an AP
     wlan.connect('ssid', 'key') # connect to an AP
-    wlan.config('mac')      # get the interface's MAC address
-    wlan.ipconfig('addr4')  # get the interface's IPv4 addresses
+    wlan.config('mac')          # get the interface's MAC address
+    wlan.ipconfig('addr4')      # get the interface's IPv4 addresses
 
     ap = network.WLAN(network.WLAN.IF_AP) # create access-point interface
-    ap.config(ssid='ESP-AP') # set the SSID of the access point
-    ap.config(max_clients=10) # set how many clients can connect to the network
-    ap.active(True)         # activate the interface
+    ap.config(ssid='ESP-AP')              # set the SSID of the access point
+    ap.config(max_clients=10)             # set how many clients can connect to the network
+    ap.active(True)                       # activate the interface
 
 A useful function for connecting to your local WiFi network is::
 
     def do_connect():
-        import network
-        wlan = network.WLAN(network.WLAN.IF_STA)
+        import machine, network
+        wlan = network.WLAN()
         wlan.active(True)
         if not wlan.isconnected():
             print('connecting to network...')
             wlan.connect('ssid', 'key')
             while not wlan.isconnected():
-                pass
+                machine.idle()
         print('network config:', wlan.ipconfig('addr4'))
 
 Once the network is established the :mod:`socket <socket>` module can be used

--- a/docs/rp2/quickref.rst
+++ b/docs/rp2/quickref.rst
@@ -55,6 +55,57 @@ The :mod:`rp2` module::
 
     import rp2
 
+Networking
+----------
+
+WLAN
+^^^^
+
+.. note::
+   This section applies only to devices that include WiFi support, such as the `Pico W`_ and `Pico 2 W`_.
+
+The :class:`network.WLAN` class in the :mod:`network` module::
+
+    import network
+
+    wlan = network.WLAN()       # create station interface (the default, see below for an access point interface)
+    wlan.active(True)           # activate the interface
+    wlan.scan()                 # scan for access points
+    wlan.isconnected()          # check if the station is connected to an AP
+    wlan.connect('ssid', 'key') # connect to an AP
+    wlan.config('mac')          # get the interface's MAC address
+    wlan.ipconfig('addr4')      # get the interface's IPv4 addresses
+
+    ap = network.WLAN(network.WLAN.IF_AP) # create access-point interface
+    ap.config(ssid='RP2-AP')              # set the SSID of the access point
+    ap.config(max_clients=10)             # set how many clients can connect to the network
+    ap.active(True)                       # activate the interface
+
+A useful function for connecting to your local WiFi network is::
+
+    def do_connect():
+        import machine, network
+        wlan = network.WLAN()
+        wlan.active(True)
+        if not wlan.isconnected():
+            print('connecting to network...')
+            wlan.connect('ssid', 'key')
+            while not wlan.isconnected():
+                machine.idle()
+        print('network config:', wlan.ipconfig('addr4'))
+
+Once the network is established the :mod:`socket <socket>` module can be used
+to create and use TCP/UDP sockets as usual, and the ``requests`` module for
+convenient HTTP requests.
+
+After a call to ``wlan.connect()``, the device will by default retry to connect
+**forever**, even when the authentication failed or no AP is in range.
+``wlan.status()`` will return ``network.STAT_CONNECTING`` in this state until a
+connection succeeds or the interface gets disabled.
+
+.. _Pico W: https://www.raspberrypi.com/documentation/microcontrollers/pico-series.html#picow-technical-specification
+.. _Pico 2 W: https://www.raspberrypi.com/documentation/microcontrollers/pico-series.html#pico2w-technical-specification
+
 Delay and timing
 ----------------
 


### PR DESCRIPTION
### Summary

Some rp2 boards include wifi at least with the very popular Pico W and Pico 2 W. 
New users frequently ask how to set up wifi and are confused because it's not covered in the quickref; this PR adds the wlan section (copied and modified with notes from the ESP32 quickref).

### Testing

I built the docs locally with:

```bash
docker run --rm -v `pwd`:/mp -w /mp/docs -p 8000:8000 minidocks/sphinx-doc sphinx-autobuild --host 0.0.0.0 . _build/
```

And the changes look correct.

### Trade-offs and Alternatives

It would be better if the quickrefs were consolidated (for all ports) rather than duplicated, and I think the `machine` module is  close enough to parity between ports that this would be possible. However, in the meantime, adding wlan to the rp2 port seems reasonable. 

### Todo

~~This still needs work, particularly the LAN section, as I'm not familiar enough with rp2 LAN boards (particularly the Wiznet range) to know what's supported or how it works. I'm happy to make changes if other folks can provide appropriate information.~~

> [!NOTE]
> I've removed the LAN section in order to get moving with the (more important) wlan section.
