### PR TITLE
f-string thousands separator for float

### DIFF
--- a/ports/unix/coverage.c
+++ b/ports/unix/coverage.c
@@ -520,17 +520,17 @@ static mp_obj_t extra_coverage(void) {
 
         // format with inadequate buffer size
         char buf[5];
-        mp_format_float(1, buf, sizeof(buf), 'g', 0, '+');
+        mp_format_float(1, buf, sizeof(buf), 'g', 0, '+', '\0');
         mp_printf(&mp_plat_print, "%s\n", buf);
 
         // format with just enough buffer so that precision must be
         // set from 0 to 1 twice
         char buf2[8];
-        mp_format_float(1, buf2, sizeof(buf2), 'g', 0, '+');
+        mp_format_float(1, buf2, sizeof(buf2), 'g', 0, '+', '\0');
         mp_printf(&mp_plat_print, "%s\n", buf2);
 
         // format where precision is trimmed to avoid buffer overflow
-        mp_format_float(1, buf2, sizeof(buf2), 'e', 0, '+');
+        mp_format_float(1, buf2, sizeof(buf2), 'e', 0, '+', '\0');
         mp_printf(&mp_plat_print, "%s\n", buf2);
     }
 

--- a/py/formatfloat.h
+++ b/py/formatfloat.h
@@ -29,7 +29,7 @@
 #include "py/mpconfig.h"
 
 #if MICROPY_PY_BUILTINS_FLOAT
-int mp_format_float(mp_float_t f, char *buf, size_t bufSize, char fmt, int prec, char sign);
+int mp_format_float(mp_float_t f, char *buf, size_t bufSize, char fmt, int prec, char sign, char tsep);
 #endif
 
 #endif // MICROPY_INCLUDED_PY_FORMATFLOAT_H

--- a/py/mpprint.c
+++ b/py/mpprint.c
@@ -344,6 +344,7 @@ int mp_print_float(const mp_print_t *print, mp_float_t f, char fmt, int flags, c
     char buf[32];
     char sign = '\0';
     int chrs = 0;
+    char tsep = 0;
 
     if (flags & PF_FLAG_SHOW_SIGN) {
         sign = '+';
@@ -352,7 +353,11 @@ int mp_print_float(const mp_print_t *print, mp_float_t f, char fmt, int flags, c
         sign = ' ';
     }
 
-    int len = mp_format_float(f, buf, sizeof(buf), fmt, prec, sign);
+    if (flags & PF_FLAG_SHOW_COMMA) {
+        tsep = ',';
+    }
+
+    int len = mp_format_float(f, buf, sizeof(buf), fmt, prec, sign, tsep);
 
     char *s = buf;
 

--- a/py/objcomplex.c
+++ b/py/objcomplex.c
@@ -57,15 +57,15 @@ static void complex_print(const mp_print_t *print, mp_obj_t o_in, mp_print_kind_
     const int precision = 16;
     #endif
     if (o->real == 0) {
-        mp_format_float(o->imag, buf, sizeof(buf), 'g', precision, '\0');
+        mp_format_float(o->imag, buf, sizeof(buf), 'g', precision, '\0', '\0');
         mp_printf(print, "%sj", buf);
     } else {
-        mp_format_float(o->real, buf, sizeof(buf), 'g', precision, '\0');
+        mp_format_float(o->real, buf, sizeof(buf), 'g', precision, '\0', '\0');
         mp_printf(print, "(%s", buf);
         if (o->imag >= 0 || isnan(o->imag)) {
             mp_print_str(print, "+");
         }
-        mp_format_float(o->imag, buf, sizeof(buf), 'g', precision, '\0');
+        mp_format_float(o->imag, buf, sizeof(buf), 'g', precision, '\0', '\0');
         mp_printf(print, "%sj)", buf);
     }
 }

--- a/py/objfloat.c
+++ b/py/objfloat.c
@@ -47,13 +47,6 @@
 #define M_PI (3.14159265358979323846)
 #endif
 
-// Workaround a bug in recent MSVC where NAN is no longer constant.
-// (By redefining back to the previous MSVC definition of NAN)
-#if defined(_MSC_VER) && _MSC_VER >= 1942
-#undef NAN
-#define NAN (-(float)(((float)(1e+300 * 1e+300)) * 0.0F))
-#endif
-
 typedef struct _mp_obj_float_t {
     mp_obj_base_t base;
     mp_float_t value;
@@ -123,7 +116,7 @@ static void float_print(const mp_print_t *print, mp_obj_t o_in, mp_print_kind_t 
     char buf[32];
     const int precision = 16;
     #endif
-    mp_format_float(o_val, buf, sizeof(buf), 'g', precision, '\0');
+    mp_format_float(o_val, buf, sizeof(buf), 'g', precision, '\0', '\0');
     mp_print_str(print, buf);
     if (strchr(buf, '.') == NULL && strchr(buf, 'e') == NULL && strchr(buf, 'n') == NULL) {
         // Python floats always have decimal point (unless inf or nan)

--- a/tests/float/float_format.py
+++ b/tests/float/float_format.py
@@ -25,3 +25,14 @@ for r in range(38):
     # But formatting as 0.999...e-r is NOT ok.
     if s[0] == "0":
         print("FAIL:", s)
+
+# check the thousand separator
+for val in (
+    123.4,
+    5678.9,
+    987654321.1,
+):
+    print("{:,.1f}".format(val))
+
+# check that the rounding up is done properly even with the thousand separator
+print("{:,.1f}".format(9999.999))


### PR DESCRIPTION
### Summary

Closes #11284 
thousand separator was not implemented for floating point number

### Testing

test the thousand separator for different float
test that the rounding up with the thousand separator (esp :  9,999.99 rounded to 10,000.0)

couldn't test that no buffer overflow occurs when using the thousand separator
