### PR TITLE
ports/rp2: Make lightsleep preserve SLEEP_EN0 and SLEEP_EN1.

### DIFF
--- a/ports/rp2/modmachine.c
+++ b/ports/rp2/modmachine.c
@@ -196,6 +196,8 @@ static void mp_machine_lightsleep(size_t n_args, const mp_obj_t *args) {
         #endif
         xosc_dormant();
     } else {
+        uint32_t save_sleep_en0 = clocks_hw->sleep_en0;
+        uint32_t save_sleep_en1 = clocks_hw->sleep_en1;
         bool timer3_enabled = irq_is_enabled(3);
 
         const uint32_t alarm_num = 3;
@@ -251,8 +253,8 @@ static void mp_machine_lightsleep(size_t n_args, const mp_obj_t *args) {
         if (!timer3_enabled) {
             irq_set_enabled(irq_num, false);
         }
-        clocks_hw->sleep_en0 |= ~(0u);
-        clocks_hw->sleep_en1 |= ~(0u);
+        clocks_hw->sleep_en0 = save_sleep_en0;
+        clocks_hw->sleep_en1 = save_sleep_en1;
     }
 
     // Enable ROSC.

--- a/tests/ports/rp2/rp2_lightsleep_regs.py
+++ b/tests/ports/rp2/rp2_lightsleep_regs.py
@@ -1,0 +1,58 @@
+# Test that SLEEP_ENx registers are preserved over a call to machine.lightsleep().
+
+import sys
+from machine import mem32, lightsleep
+import unittest
+
+is_rp2350 = "RP2350" in sys.implementation._machine
+
+if is_rp2350:
+    CLOCK_BASE = 0x40010000
+    SLEEP_EN0 = CLOCK_BASE + 0xB4
+    SLEEP_EN1 = CLOCK_BASE + 0xB8
+    TO_DISABLE_EN0 = 1 << 30  # SHA256
+    TO_DISABLE_EN1 = 1 << 4  # SRAM0
+else:
+    CLOCK_BASE = 0x40008000
+    SLEEP_EN0 = CLOCK_BASE + 0xA8
+    SLEEP_EN1 = CLOCK_BASE + 0xAC
+    TO_DISABLE_EN0 = 1 << 28  # SRAM0
+    TO_DISABLE_EN1 = 1 << 0  # SRAM4
+
+
+class Test(unittest.TestCase):
+    def setUp(self):
+        self.orig_sleep_en0 = mem32[SLEEP_EN0]
+        self.orig_sleep_en1 = mem32[SLEEP_EN1]
+
+    def tearDown(self):
+        mem32[SLEEP_EN0] = self.orig_sleep_en0
+        mem32[SLEEP_EN1] = self.orig_sleep_en1
+
+    def test_sleep_en_regs(self):
+        print()
+
+        # Disable some bits so the registers aren't just 0xffff.
+        mem32[SLEEP_EN0] &= ~TO_DISABLE_EN0
+        mem32[SLEEP_EN1] &= ~TO_DISABLE_EN1
+
+        # Get the registers before the lightsleep.
+        sleep_en0_before = mem32[SLEEP_EN0] & 0xFFFFFFFF
+        sleep_en1_before = mem32[SLEEP_EN1] & 0xFFFFFFFF
+        print(hex(sleep_en0_before), hex(sleep_en1_before))
+
+        # Do a lightsleep.
+        lightsleep(100)
+
+        # Get the registers after a lightsleep.
+        sleep_en0_after = mem32[SLEEP_EN0] & 0xFFFFFFFF
+        sleep_en1_after = mem32[SLEEP_EN1] & 0xFFFFFFFF
+        print(hex(sleep_en0_after), hex(sleep_en1_after))
+
+        # Check the registers have not changed.
+        self.assertEqual(sleep_en0_before, sleep_en0_after)
+        self.assertEqual(sleep_en1_before, sleep_en1_after)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
<!-- Thanks for submitting a Pull Request! We appreciate you spending the
     time to improve MicroPython. Please provide enough information so that
     others can review your Pull Request.

     Before submitting, please read:
     https://github.com/micropython/micropython/blob/master/CODEOFCONDUCT.md
     https://github.com/micropython/micropython/wiki/ContributorGuidelines

     Please check any CI failures that appear after your Pull Request is opened.
-->

### Summary
Fixes #16502

The problem was introduced in commit d1423ef.
Calling machine.lightsleep() overwrites RP2 registers SLEEP_EN0 and SLEEP_EN1 with their power on default values.

Prior to that commit the register values were saved on entry to lightsleep and restored before returning.

My change restores the earlier behavior.

See the issue (opened by me) for more details.

Suggest it would good for @projectgus and/or @peterharperuk to review these changes.

<!-- Explain the reason for making this change. What problem does the pull request
     solve, or what improvement does it add? Add links if relevant. -->


### Testing

Testing information captured in issue #16502.

<!-- Explain what testing you did, and on which boards/ports. If there are
     boards or ports that you couldn't test, please mention this here as well.

     If you leave this empty then your Pull Request may be closed. -->


### Trade-offs and Alternatives

There are not trade-offs. 
Code size increase for RP2 is small, just a few bytes.

<!-- If the Pull Request has some negative impact (i.e. increased code size)
     then please explain why you think the trade-off improvement is worth it.
     If you can think of alternative ways to do this, please explain that here too.

     Delete this heading if not relevant (i.e. small fixes) -->

