### PR TITLE
rp2/rp2_pio: Add sideset_pindirs support for PIO.

### DIFF
--- a/docs/library/rp2.rst
+++ b/docs/library/rp2.rst
@@ -23,7 +23,7 @@ The ``rp2`` module includes functions for assembling PIO programs.
 
 For running PIO programs, see :class:`rp2.StateMachine`.
 
-.. function:: asm_pio(*, out_init=None, set_init=None, sideset_init=None, in_shiftdir=0, out_shiftdir=0, autopush=False, autopull=False, push_thresh=32, pull_thresh=32, fifo_join=PIO.JOIN_NONE)
+.. function:: asm_pio(*, out_init=None, set_init=None, sideset_init=None, side_pindir=False, in_shiftdir=PIO.SHIFT_LEFT, out_shiftdir=PIO.SHIFT_LEFT, autopush=False, autopull=False, push_thresh=32, pull_thresh=32, fifo_join=PIO.JOIN_NONE)
 
     Assemble a PIO program.
 
@@ -35,8 +35,10 @@ For running PIO programs, see :class:`rp2.StateMachine`.
     - *out_init* configures the pins used for ``out()`` instructions.
     - *set_init* configures the pins used for ``set()`` instructions. There can
       be at most 5.
-    - *sideset_init* configures the pins used side-setting. There can be at
-      most 5.
+    - *sideset_init* configures the pins used for ``.side()`` modifiers. There
+      can be at most 5.
+    - *side_pindir* when set to ``True`` configures ``.side()`` modifiers to be
+      used for pin directions, instead of pin values (the default, when ``False``).
 
     The following parameters are used by default, but can be overridden in
     `StateMachine.init()`:

--- a/ports/rp2/modules/rp2.py
+++ b/ports/rp2/modules/rp2.py
@@ -26,20 +26,21 @@ class PIOASMEmit:
         out_init=None,
         set_init=None,
         sideset_init=None,
-        in_shiftdir=0,
-        out_shiftdir=0,
+        side_pindir=False,
+        in_shiftdir=PIO.SHIFT_LEFT,
+        out_shiftdir=PIO.SHIFT_LEFT,
         autopush=False,
         autopull=False,
         push_thresh=32,
         pull_thresh=32,
-        fifo_join=0,
+        fifo_join=PIO.JOIN_NONE,
     ):
         # array is a built-in module so importing it here won't require
         # scanning the filesystem.
         from array import array
 
         self.labels = {}
-        execctrl = 0
+        execctrl = side_pindir << 29
         shiftctrl = (
             fifo_join << 30
             | (pull_thresh & 0x1F) << 25


### PR DESCRIPTION
PIO side-setting can also be used to change pin directions instead of pin values.
This adds a parameter `sideset_pindirs` to decorator `asm_pio()` to configure it.

While C SDK 2.1.0 uses the singular for naming (`SIDE_PINDIR`), its `pioasm` directive
actually uses the plural (`.side_set <count> (opt) (pindirs)`), so it would look like:

```
.program test
    .side_set 1 opt pindirs
    .lang_opt python sideset_init = rp2.PIO.IN_LOW
    .lang_opt python sideset_opt = True
    .lang_opt python sideset_pindirs = True
...
```

Also replaces a few close-by 0s with corresponding `PIO.*` constants.

Addresses #10027.
