### PR TITLE
enabled i2s for lolin_c3_mini as it works fine now

### DIFF
--- a/ports/esp32/boards/LOLIN_C3_MINI/mpconfigboard.h
+++ b/ports/esp32/boards/LOLIN_C3_MINI/mpconfigboard.h
@@ -3,7 +3,7 @@
 #define MICROPY_PY_NETWORK_HOSTNAME_DEFAULT "mpy-c3-mini"
 
 #define MICROPY_HW_ENABLE_SDCARD            (0)
-#define MICROPY_PY_MACHINE_I2S              (0)
+#define MICROPY_PY_MACHINE_I2S              (1)
 
 #define MICROPY_HW_I2C0_SCL                 (10)
 #define MICROPY_HW_I2C0_SDA                 (8)


### PR DESCRIPTION
### Summary

enabled i2s for lolin_c3_mini


### Testing

tested on esp32_c3_supermini and i2s works great