### PR TITLE
esp32/boards/LOLIN_C3_MINI/mpconfigboard.h: Enabled i2s.

### DIFF
--- a/ports/esp32/boards/ESP32_GENERIC_C3/mpconfigboard.h
+++ b/ports/esp32/boards/ESP32_GENERIC_C3/mpconfigboard.h
@@ -4,7 +4,7 @@
 #define MICROPY_HW_MCU_NAME                 "ESP32C3"
 
 #define MICROPY_HW_ENABLE_SDCARD            (0)
-#define MICROPY_PY_MACHINE_I2S              (0)
+#define MICROPY_PY_MACHINE_I2S              (1)
 
 // Enable UART REPL for modules that have an external USB-UART and don't use native USB.
 #define MICROPY_HW_ENABLE_UART_REPL         (1)

--- a/ports/esp32/boards/ESP32_GENERIC_C3/mpconfigboard.h
+++ b/ports/esp32/boards/ESP32_GENERIC_C3/mpconfigboard.h
@@ -4,7 +4,6 @@
 #define MICROPY_HW_MCU_NAME                 "ESP32C3"
 
 #define MICROPY_HW_ENABLE_SDCARD            (0)
-#define MICROPY_PY_MACHINE_I2S              (1)
 
 // Enable UART REPL for modules that have an external USB-UART and don't use native USB.
 #define MICROPY_HW_ENABLE_UART_REPL         (1)

--- a/ports/esp32/boards/LOLIN_C3_MINI/mpconfigboard.h
+++ b/ports/esp32/boards/LOLIN_C3_MINI/mpconfigboard.h
@@ -3,7 +3,6 @@
 #define MICROPY_PY_NETWORK_HOSTNAME_DEFAULT "mpy-c3-mini"
 
 #define MICROPY_HW_ENABLE_SDCARD            (0)
-#define MICROPY_PY_MACHINE_I2S              (1)
 
 #define MICROPY_HW_I2C0_SCL                 (10)
 #define MICROPY_HW_I2C0_SDA                 (8)

--- a/ports/esp32/boards/LOLIN_C3_MINI/mpconfigboard.h
+++ b/ports/esp32/boards/LOLIN_C3_MINI/mpconfigboard.h
@@ -3,7 +3,7 @@
 #define MICROPY_PY_NETWORK_HOSTNAME_DEFAULT "mpy-c3-mini"
 
 #define MICROPY_HW_ENABLE_SDCARD            (0)
-#define MICROPY_PY_MACHINE_I2S              (0)
+#define MICROPY_PY_MACHINE_I2S              (1)
 
 #define MICROPY_HW_I2C0_SCL                 (10)
 #define MICROPY_HW_I2C0_SDA                 (8)


### PR DESCRIPTION

### Summary

Enabled i2s for lolin_c3_mini as it works fine now.


### Testing

Tested on esp32_c3_SuperMini and it works great!