### PR TITLE
py/emitinlinerv32: Reduce footprint and fix build on ESP32.

### DIFF
--- a/py/emitinlinerv32.c
+++ b/py/emitinlinerv32.c
@@ -709,9 +709,11 @@ static bool handle_load_store_opcode_with_offset(emit_inline_asm_t *emit, qstr o
         return false;
     }
 
-    mp_uint_t rd;
-    mp_uint_t rs1;
-    parse_register_node(nodes[0], &rd, opcode_data->argument1_kind & C);
+    mp_uint_t rd = 0;
+    mp_uint_t rs1 = 0;
+    if (!parse_register_node(nodes[0], &rd, opcode_data->argument1_kind & C)) {
+        return false;
+    }
     if (!parse_register_node(nodes[1], &rs1, opcode_data->argument3_kind & C)) {
         return false;
     }


### PR DESCRIPTION
### Summary

This PR fixes a warning occurring on the compiler version shipped with ESP-IDF v5.2.0 and later, and incorporates the suggestions made in #15714 to reduce the overall footprint.

The size reduction for QEMU/VIRT_RV32 is 975 bytes, on ESP32 should probably be close to that.

This PR can wait for v1.25.0 to get out first, there's no improvement in functionality or any critical bugfixes compared to #15714 (ESP32 has this feature turned off by default anyway).

### Testing

The inlineasm tests passed successfully on both QEMU and an ESP32C3 using ESP-IDF v5.2.0.