### PR TITLE
tests/extmod/re_sub.py: Fix test execution on Python 3.13.1.

### DIFF
--- a/tests/extmod/re_sub.py
+++ b/tests/extmod/re_sub.py
@@ -10,6 +10,8 @@ except AttributeError:
     print("SKIP")
     raise SystemExit
 
+import sys
+
 
 def multiply(m):
     return str(int(m.group(0)) * 2)
@@ -47,7 +49,11 @@ print(re.sub("(abc)", r"\g<1>\g<1>", "abc"))
 print(re.sub("a", "b", "c"))
 
 # with maximum substitution count specified
-print(re.sub("a", "b", "1a2a3a", 2))
+if sys.implementation.name != "micropython":
+    # On CPython 3.13 and later the substitution count must be a keyword argument.
+    print(re.sub("a", "b", "1a2a3a", count=2))
+else:
+    print(re.sub("a", "b", "1a2a3a", 2))
 
 # invalid group
 try:


### PR DESCRIPTION
### Summary

This PR fixes a test failure for `extmod/re_sub.py` where the code, whilst being correct, would not make the test pass due to a newer Python version than expected.

On Python 3.13.1, running `tests/extmod/re_sub.py` would yield a deprecation warning about `re.sub` not providing the match count as a keyword parameter:

```bash
/micropython/tests/extmod/re_sub.py:50: DeprecationWarning: 'count' is passed as positional argument
  print(re.sub("a", "b", "1a2a3a", 2))
```

This warning would be embedded in the expected test result and thus the test would always fail.

The expected ouput file was generated by running `python tests/extmod/re_sub.py > tests/extmod/re_sub.py.exp`, with stderr output not ending up in the file.  The output is identical to older Python versions than 3.13.1.

### Testing

`extmod/re_sub.py` passes on an ESP32-C3 with ESP-IDF 5.2.0 with no code changes, using Python 3.13.1 to generate the expected test output.

### Trade-offs and Alternatives

I can see two alternatives to this.  The first one is to change the expected test output collector to ignore what comes out of `stderr` (and eventually print something alerting the user of that fact).  The second one is to make `re.sub`'s `count` parameter available also as a keyword argument and change the parsing code involved.

The first option isn't a long-term fix as the test will fail on newer Python versions anyway.  The second one may make the code size larger, although it has the potential to streamline argument parsing (by using `mp_arg_parse_all` instead of manual checking).