### PR TITLE
ESP32_S3: Fix build ESP32_GENERIC_S3.

### DIFF
--- a/ports/esp32/esp32_common.cmake
+++ b/ports/esp32/esp32_common.cmake
@@ -61,7 +61,9 @@ list(APPEND MICROPY_SOURCE_DRIVERS
 
 string(CONCAT GIT_SUBMODULES "${GIT_SUBMODULES} " lib/tinyusb)
 if(MICROPY_PY_TINYUSB)
-    set(TINYUSB_SRC "${MICROPY_DIR}/lib/tinyusb/src")
+    if(EXISTS "${MICROPY_DIR}/lib/tinyusb/src")
+        set(TINYUSB_SRC "${MICROPY_DIR}/lib/tinyusb/src")
+    endif()
     string(TOUPPER OPT_MCU_${IDF_TARGET} tusb_mcu)
 
     list(APPEND MICROPY_DEF_TINYUSB


### PR DESCRIPTION
### Summary

Building `ESP32_GENERIC_S3` and `ESP32_GENERIC_S2` fails.

### Testing

`mpbuild build --idf v5.3.1 ESP32_GENERIC_S3` fails:
```
CMake Error at /opt/esp/idf/tools/cmake/build.cmake:544 (message):
  ERROR: Some components (espressif/tinyusb) in the "managed_components"
```

Tracking down the error leads to this command:
```
cd ports/esp32
GIT_SUBMODULES=$(idf.py -D MICROPY_BOARD=ESP32_GENERIC_S3 -D MICROPY_BOARD_DIR=".../ports/esp32/boards/ESP32_GENERIC_S3"  -B build-ESP32_GENERIC_S3/submodules -D ECHO_SUBMODULES=1 build
```
This commands errors with `Include directory '.../lib/tinyusb/src' is not a directory`.

### Fix

With this PR applied, these ports built successfully, eg. with return code 0:
```
set -euox pipefail

git clean -fxd; mpbuild build --idf v5.3.1 ARDUINO_NANO_ESP32 
git clean -fxd; mpbuild build --idf v5.3.1 ESP32_GENERIC 
git clean -fxd; mpbuild build --idf v5.3.1 ESP32_GENERIC D2WD
git clean -fxd; mpbuild build --idf v5.3.1 ESP32_GENERIC OTA
git clean -fxd; mpbuild build --idf v5.3.1 ESP32_GENERIC SPIRAM
git clean -fxd; mpbuild build --idf v5.3.1 ESP32_GENERIC UNICORE
git clean -fxd; mpbuild build --idf v5.3.1 ESP32_GENERIC_C3 
git clean -fxd; mpbuild build --idf v5.3.1 ESP32_GENERIC_C6 
git clean -fxd; mpbuild build --idf v5.3.1 ESP32_GENERIC_S2 
git clean -fxd; mpbuild build --idf v5.3.1 ESP32_GENERIC_S3 
git clean -fxd; mpbuild build --idf v5.3.1 ESP32_GENERIC FLASH_4M
git clean -fxd; mpbuild build --idf v5.3.1 ESP32_GENERIC SPIRAM_OCT
git clean -fxd; mpbuild build --idf v5.3.1 OLIMEX_ESP32_EVB 
git clean -fxd; mpbuild build --idf v5.3.1 OLIMEX_ESP32_POE 
```

## Notes

* How do your builds work?
* Builds using `--idf v5.2.2` failed as `pip list ... idf-component-manager 2.1.1` seems to be too old.
* Builds using `--idf v5.4` failed with
```
py/persistentcode.c:439:38: error: 'prelude_ptr' may be used uninitialized [-Werror=maybe-uninitialized]
```

