### PR TITLE
py/usermod.cmake: Don't recurse into private/link-only dependencies.

### DIFF
--- a/py/usermod.cmake
+++ b/py/usermod.cmake
@@ -2,7 +2,7 @@
 add_library(usermod INTERFACE)
 
 function(usermod_gather_sources SOURCES_VARNAME INCLUDE_DIRECTORIES_VARNAME INCLUDED_VARNAME LIB)
-    if (NOT ${LIB} IN_LIST ${INCLUDED_VARNAME})
+    if (NOT ${LIB} IN_LIST ${INCLUDED_VARNAME} AND TARGET ${LIB})
         list(APPEND ${INCLUDED_VARNAME} ${LIB})
 
         if (NOT TARGET ${LIB})


### PR DESCRIPTION
This addresses an issue with building User C Modules that need to link non-INTERFACE libraries and shield dependencies from QSTR generation by marking them PRIVATE.

In particular, this makes it possible to build a usermod that includes RP2 PIO code. PioAsm converts the input `.pio` file into a `.pio.h` header, and this header is then `#include`d into the C code that makes use of it.

However, these headers are only generated _after_ the QSTR generation step; if qstr generation attempts to process one of these files, it fails, as in:

```
make[4]: Leaving directory '/home/user/project/micropython/ports/rp2/build-CUSTOM'
make[4]: Entering directory '/home/user/project/micropython/ports/rp2/build-CUSTOM'
[  1%] Generating genhdr/pins.h, pins_CUSTOM.c
[  1%] Generating genhdr/qstr.i.last
'/home/user/project/modules/i2c_multi/i2c_multi.c:14:10: fatal error: i2c_multi.pio.h: No such file or directory
   14 | #include "i2c_multi.pio.h"
      |          ^~~~~~~~~~~~~~~~~
compilation terminated.
```

(In this case, `i2c_multi` is a micropython module I'm writing in order to bind https://github.com/dgatf/I2C-slave-multi-address-RP2040.)

This is the ideal use-case for a PRIVATE source file; however, INTERFACE libraries can only declare INTERFACE sources -- so it's necessary to move the pio code into a separate STATIC library and have it declare its own link dependencies as well.

However, when doing this, as in:

```cmake
add_library(i2c_multi STATIC)
target_sources(i2c_multi
  PRIVATE
    ${CMAKE_CURRENT_LIST_DIR}/i2c_multi.c
)
target_include_directories(i2c_multi
  PUBLIC
    ${CMAKE_CURRENT_LIST_DIR}
)
pico_generate_pio_header(i2c_multi ${CMAKE_CURRENT_LIST_DIR}/i2c_multi.pio)
target_link_libraries(i2c_multi
  PRIVATE
    pico_stdlib
    hardware_irq
    hardware_pio
    hardware_i2c
)

add_library(usermod_i2c_multi INTERFACE)
target_sources(usermod_i2c_multi
  INTERFACE
    ${CMAKE_CURRENT_LIST_DIR}/mpy_api.c
)
target_include_directories(usermod_i2c_multi
  INTERFACE
    ${CMAKE_CURRENT_LIST_DIR}
)
target_link_libraries(usermod_i2c_multi
  INTERFACE
    i2c_multi
)

target_link_libraries(usermod
  INTERFACE
    usermod_i2c_multi
)
```

Currently, `usermod.cmake` doesn't correctly handle these private dependencies, and errors out with errors like this one when it recurses:

```
CMake Error at /home/user/project/micropython/py/usermod.cmake:9 (get_target_property):
  get_target_property() called with non-existent target
  "$<LINK_ONLY:hardware_i2c>".
Call Stack (most recent call first):
  /home/user/project/micropython/py/usermod.cmake:24 (usermod_gather_sources)
  /home/user/project/micropython/py/usermod.cmake:24 (usermod_gather_sources)
  /home/user/project/micropython/py/usermod.cmake:24 (usermod_gather_sources)
  /home/user/project/micropython/py/usermod.cmake:24 (usermod_gather_sources)
  /home/user/project/micropython/py/usermod.cmake:24 (usermod_gather_sources)
  /home/user/project/micropython/py/usermod.cmake:24 (usermod_gather_sources)
  /home/user/project/micropython/py/usermod.cmake:47 (usermod_gather_sources)
  CMakeLists.txt:80 (include)
```

Adding the check for whether a given string is a valid target ensures that these recursively-acquired private dependencies are appropriately ignored.

### Testing

I've tested builds of all of the example usermodules; None of them are impacted by this change.

### Trade-offs and Alternatives

This change would also make the process of recursively gathering qstr sources from usermods silently ignore misspelled dependencies; but all this amounts to is a missed opportunity to fail early, and the error message that a misspelled dependency will cause later is arguably more useful anyway:

```
CMake Error at /home/user/project/micropython/py/usermod.cmake:9 (get_target_property):
  get_target_property() called with non-existent target
  "library_that_does_not_exist".
Call Stack (most recent call first):
  /home/user/project/micropython/py/usermod.cmake:24 (usermod_gather_sources)
  /home/user/project/micropython/py/usermod.cmake:24 (usermod_gather_sources)
  /home/user/project/micropython/py/usermod.cmake:24 (usermod_gather_sources)
  /home/user/project/micropython/py/usermod.cmake:24 (usermod_gather_sources)
  /home/user/project/micropython/py/usermod.cmake:47 (usermod_gather_sources)
  CMakeLists.txt:80 (include)
```
vs
```
/usr/lib/gcc/arm-none-eabi/9.2.1/../../../arm-none-eabi/bin/ld: cannot find -llibrary_that_does_not_exist
collect2: error: ld returned 1 exit status
```






