### PR TITLE
stm32: Support 'FDCAN' in board pin CSVs.

### DIFF
--- a/ports/stm32/boards/make-pins.py
+++ b/ports/stm32/boards/make-pins.py
@@ -122,6 +122,9 @@ class Stm32Pin(boardgen.Pin):
                 if af_ext:
                     af_pin = "EXT" + af_pin
 
+                # Special case: FDCAN peripheral is named CAN in MicroPython, same as bxCAN
+                af_fn = af_fn.replace("FDCAN", "CAN")
+
                 af_supported = af_fn in SUPPORTED_AF and af_pin in SUPPORTED_AF[af_fn]
 
                 self._afs.append(PinAf(af_idx, af_fn, af_unit, af_pin, af_supported, af_name))


### PR DESCRIPTION
## Summary

This PR has been split out from #15989.

Previously micros with the 'FDCAN' peripheral (as opposed to the older 'CAN' peripheral) needed to rename these pins in the CSVs for the CAN driver to work.

The following CSVs in MicroPython still had FDCAN in them:

❯ rg -t csv -l FDCAN boards
boards/stm32h7b3_af.csv
boards/stm32h743_af.csv
boards/stm32h573_af.csv
boards/stm32h723_af.csv
boards/stm32g0b1_af.csv

Confirmed that this allows CAN to work on NUCLEO_H723ZG board, and that at least one board based on each of the other chips can still compile. Some of these boards could possibly have MICROPY_HW_ENABLE_CAN set and work, now.

### Testing

* Tested CAN peripheral 1 now works on the NUCLEO_H723ZG board. Additional testing was also done as part of #15989.

### Trade-offs and Alternatives
 
* Could manually rename FDCAN in the mentioned CSV files, but given it's been missed in the past it seems safer for future SoCs if we apply the fix during processing.