### PR TITLE
stm32: Fix pyb.CAN BRS baud rate, make calculation more forgiving.

### DIFF
--- a/docs/library/pyb.CAN.rst
+++ b/docs/library/pyb.CAN.rst
@@ -67,11 +67,17 @@ Methods
        :meth:`~CAN.restart()` can be used to leave the bus-off state
      - *baudrate* if a baudrate other than 0 is provided, this function will try to automatically
        calculate the CAN nominal bit time (overriding *prescaler*, *bs1* and *bs2*) that satisfies
-       both the baudrate and the desired *sample_point*.
-     - *sample_point* given in a percentage of the nominal bit time, the *sample_point* specifies the position
-       of the bit sample with respect to the whole nominal bit time. The default *sample_point* is 75%.
+       both the *baudrate* (within .1%) and the desired *sample_point* (to the nearest 1%). For more precise
+       control over the CAN timing, set the *prescaler*, *bs1* and *bs2* parameters directly.
+     - *sample_point* specifies the position of the bit sample with respect to the whole nominal bit time,
+       expressed as an integer percentage of the nominal bit time. The default *sample_point* is 75%.
+       This parameter is ignored unless *baudrate* is set.
      - *num_filter_banks* for classic CAN, this is the number of banks that will be assigned to CAN(1),
        the rest of the 28 are assigned to CAN(2).
+
+  The remaining parameters are only present on boards with CAN FD support, and configure the optional CAN FD
+  Bit Rate Switch (BRS) feature:
+
      - *brs_prescaler* is the value by which the CAN FD input clock is divided to generate the
        data bit time quanta. The prescaler can be a value between 1 and 32 inclusive.
      - *brs_sjw* is the resynchronisation jump width in units of time quanta for data bits;
@@ -82,10 +88,11 @@ Methods
        it can be a value between 1 and 16 inclusive
      - *brs_baudrate* if a baudrate other than 0 is provided, this function will try to automatically
        calculate the CAN data bit time (overriding *brs_prescaler*, *brs_bs1* and *brs_bs2*) that satisfies
-       both the baudrate and the desired *brs_sample_point*.
-     - *brs_sample_point* given in a percentage of the data bit time, the *brs_sample_point* specifies the position
-       of the bit sample with respect to the whole data bit time. The default *brs_sample_point* is 75%.
-
+       both the *brs_baudrate* (within .1%) and the desired *brs_sample_point* (to the nearest 1%). For more
+       precise control over the BRS timing, set the *brs_prescaler*, *brs_bs1* and *brs_bs2* parameters directly.
+     - *brs_sample_point* specifies the position of the bit sample with respect to the whole nominal bit time,
+       expressed as an integer percentage of the nominal bit time. The default *brs_sample_point* is 75%.
+       This parameter is ignored unless *brs_baudrate* is set.
 
    The time quanta tq is the basic unit of time for the CAN bus.  tq is the CAN
    prescaler value divided by PCLK1 (the frequency of internal peripheral bus 1);

--- a/ports/stm32/pyb_can.c
+++ b/ports/stm32/pyb_can.c
@@ -269,8 +269,8 @@ static mp_obj_t pyb_can_init_helper(pyb_can_obj_t *self, size_t n_args, const mp
     // Set BRS bit timings.
     self->can.Init.DataPrescaler = args[ARG_brs_prescaler].u_int;
     self->can.Init.DataSyncJumpWidth = args[ARG_brs_sjw].u_int;
-    self->can.Init.DataTimeSeg1 = args[ARG_bs1].u_int; // DataTimeSeg1 = Propagation_segment + Phase_segment_1
-    self->can.Init.DataTimeSeg2 = args[ARG_bs2].u_int;
+    self->can.Init.DataTimeSeg1 = args[ARG_brs_bs1].u_int; // DataTimeSeg1 = Propagation_segment + Phase_segment_1
+    self->can.Init.DataTimeSeg2 = args[ARG_brs_bs2].u_int;
     #else
     // Init filter banks for classic CAN.
     can2_start_bank = args[ARG_num_filter_banks].u_int;

--- a/ports/stm32/pyb_can.c
+++ b/ports/stm32/pyb_can.c
@@ -222,7 +222,7 @@ static void pyb_can_get_bit_timing(mp_uint_t baudrate, mp_uint_t sample_point,
         }
     }
 
-    mp_raise_msg(&mp_type_ValueError, MP_ERROR_TEXT("couldn't match baudrate and sample point"));
+    mp_raise_msg_varg(&mp_type_ValueError, MP_ERROR_TEXT("couldn't match baudrate %u and sample point %u"), baudrate, sample_point / 10);
 }
 
 // init(mode, prescaler=100, *, sjw=1, bs1=6, bs2=8)

--- a/ports/stm32/pyb_can.c
+++ b/ports/stm32/pyb_can.c
@@ -25,6 +25,7 @@
  */
 
 #include <string.h>
+#include <stdlib.h>
 
 #include "py/objarray.h"
 #include "py/runtime.h"
@@ -199,12 +200,19 @@ static void pyb_can_get_bit_timing(mp_uint_t baudrate, mp_uint_t sample_point,
     uint32_t max_brp, uint32_t max_bs1, uint32_t max_bs2, uint32_t min_tseg,
     mp_int_t *bs1_out, mp_int_t *bs2_out, mp_int_t *prescaler_out) {
     uint32_t can_kern_clk = pyb_can_get_source_freq();
+    mp_uint_t max_baud_error = baudrate / 1000; // Allow .1% deviation
+    const mp_uint_t MAX_SAMPLE_ERROR = 5; // round to nearest 1%, which is the param resolution
+    sample_point *= 10;
     // Calculate CAN bit timing.
     for (uint32_t brp = 1; brp < max_brp; brp++) {
         for (uint32_t bs1 = min_tseg; bs1 < max_bs1; bs1++) {
             for (uint32_t bs2 = min_tseg; bs2 < max_bs2; bs2++) {
-                if ((baudrate == (can_kern_clk / (brp * (1 + bs1 + bs2)))) &&
-                    ((sample_point * 10) == (((1 + bs1) * 1000) / (1 + bs1 + bs2)))) {
+                mp_int_t calc_baud = can_kern_clk / (brp * (1 + bs1 + bs2));
+                mp_int_t calc_sample = ((1 + bs1) * 1000) / (1 + bs1 + bs2);
+                mp_int_t baud_err = baudrate - calc_baud;
+                mp_int_t sample_err = sample_point - calc_sample;
+                if (abs(baud_err) < max_baud_error &&
+                    abs(sample_err) < MAX_SAMPLE_ERROR) {
                     *bs1_out = bs1;
                     *bs2_out = bs2;
                     *prescaler_out = brp;


### PR DESCRIPTION
### Summary

* Fixes #16330. Thanks @albertstoewer for the very comprehensive bug report.
* As part of verifying the fix, I realised the baud rate calculations are very unforgiving. Have added a small amount of error tolerance, which allowed me to set desired baud rates on STM32H723G.
* Similarly, the error when a baudrate couldn't be achieved was hard to debug on CAN-FD as the calculation is repeated twice (once for the Classic baud rate and once for BRS). Added the failing rate to the error message.

### Testing

* Tested using a NUCLEO STM32H723G baud using the test code submitted in #16330 with sample points both changed to 75 in order to be accepted. For the device on the other side I modified the [embassy stm32g4 can example](https://github.com/embassy-rs/embassy/blob/main/examples/stm32g4/src/bin/can.rs) to use the same baud rates and flashed on the NUCLEO STM32G474RE. Confirmed no frames received by the STM32G4 without the patch, and received successfully with the patch.
* For the STM32H723 to work successfully I needed to cherry-pick the fix from #16543 first.
