### PR TITLE
stm32/can: Fix clearing filters on CAN3 (bxCAN).

### DIFF
--- a/ports/stm32/can.c
+++ b/ports/stm32/can.c
@@ -174,7 +174,7 @@ void can_clearfilter(pyb_can_obj_t *self, uint32_t f, uint8_t bank) {
     filter.FilterActivation = DISABLE;
     filter.BankNumber = bank;
 
-    HAL_CAN_ConfigFilter(NULL, &filter);
+    HAL_CAN_ConfigFilter(&self->can, &filter);
 }
 
 int can_receive(CAN_HandleTypeDef *can, int fifo, CanRxMsgTypeDef *msg, uint8_t *data, uint32_t timeout_ms) {


### PR DESCRIPTION
### Summary

This fix was split out from #15989.

The instance argument to `HAL_CAN_ConfigFilter()` is ignored for CAN1, CAN2 but needed for CAN3.

### Testing

* Tested as part of #15989.