### PR TITLE
stm32/fdcan: Fix extended CAN ID filtering for stm32g4.

### DIFF
--- a/ports/stm32/fdcan.c
+++ b/ports/stm32/fdcan.c
@@ -86,8 +86,8 @@ bool can_init(pyb_can_obj_t *can_obj, uint32_t mode, uint32_t prescaler, uint32_
     init->DataSyncJumpWidth = 1;
     init->DataTimeSeg1 = 1;
     init->DataTimeSeg2 = 1;
-    init->StdFiltersNbr = 28; // /2  ? if FDCAN2 is used !!?
-    init->ExtFiltersNbr = 0; // Not used
+    init->StdFiltersNbr = 28;
+    init->ExtFiltersNbr = 8;
     init->TxFifoQueueMode = FDCAN_TX_FIFO_OPERATION;
     #elif defined(STM32H7)
     // The dedicated FDCAN RAM is 2560 32-bit words and shared between the FDCAN instances.


### PR DESCRIPTION
### Summary

This fix was split out from #15989.

Without this fix, extended CAN ID filtering doesn't work on STM32G4. The memory bank addresses used for these are independent, can (and must) enable both.

Also looks like no need to halve these if FDCAN2 is added (as per comment). The Reference Manual is a bit unclear but looks like the peripheral's RAM multiplies out for each additional controller.

### Testing

* Tested on NUCLEO_STM32G474 board as part of #15989.
