### PR TITLE
stm32: Fix ARDUINO_NICLA_VISION CAN pins.

### DIFF
--- a/ports/stm32/boards/ARDUINO_NICLA_VISION/mpconfigboard.h
+++ b/ports/stm32/boards/ARDUINO_NICLA_VISION/mpconfigboard.h
@@ -186,8 +186,8 @@ extern struct _spi_bdev_t spi_bdev;
 
 // FDCAN bus
 #define MICROPY_HW_CAN1_NAME        "FDCAN1"
-#define MICROPY_HW_CAN1_TX          (pin_A10)
-#define MICROPY_HW_CAN1_RX          (pin_A9)
+#define MICROPY_HW_CAN1_TX          (pin_B9)
+#define MICROPY_HW_CAN1_RX          (pin_B8)
 #define MICROPY_HW_CAN_IS_RESERVED(id) (id != PYB_CAN_1)
 
 // LEDs


### PR DESCRIPTION
### Summary

This fix was split out from #15989. The CAN pin assignments for ARDUINO_NICLA_VISION were incorrect. The only STM32G474 pins with CAN function that are also broken out on the board are PB8 and PB9

### Testing

* Tested as part of #15989.
