### PR TITLE
esp32: Makefile, remove submodules sideeffect.

### DIFF
--- a/ports/esp32/Makefile
+++ b/ports/esp32/Makefile
@@ -111,7 +111,12 @@ size-files:
 # "GIT_SUBMODULES", and then abort. This extracts out that line from the idf.py
 # output and passes the list of submodules to py/mkrules.mk which does the
 # `git submodule init` on each.
+#
+# 'idf.py' leaves a directory ports/esp32/managed_components behind (But only the version
+# which is packed into docker.io/espressif/idf:v5.2.2).
+# This directory is a unwanted sideeffect, so we remove it
 submodules:
 	@GIT_SUBMODULES=$$(idf.py $(IDFPY_FLAGS) -B $(BUILD)/submodules -D ECHO_SUBMODULES=1 build 2>&1 | \
 	                  grep '^GIT_SUBMODULES=' | cut -d= -f2); \
+	rm -rf ./managed_components; \
 	$(MAKE) -f ../../py/mkrules.mk GIT_SUBMODULES="$${GIT_SUBMODULES}" submodules

--- a/ports/esp32/esp32_common.cmake
+++ b/ports/esp32/esp32_common.cmake
@@ -61,7 +61,9 @@ list(APPEND MICROPY_SOURCE_DRIVERS
 
 string(CONCAT GIT_SUBMODULES "${GIT_SUBMODULES} " lib/tinyusb)
 if(MICROPY_PY_TINYUSB)
-    set(TINYUSB_SRC "${MICROPY_DIR}/lib/tinyusb/src")
+    if(EXISTS "${MICROPY_DIR}/lib/tinyusb/src")
+        set(TINYUSB_SRC "${MICROPY_DIR}/lib/tinyusb/src")
+    endif()
     string(TOUPPER OPT_MCU_${IDF_TARGET} tusb_mcu)
 
     list(APPEND MICROPY_DEF_TINYUSB


### PR DESCRIPTION
### Summary

This PR removes an unwanted sideffect of
`make -C micropython/ports/esp32 submodules`
versus
`make -C micropython/ports/esp32 submodules BOARD=ESP32_GENERIC_S3`

This sideffect broke the build of ESP32_GENERIC_S3 when running on docker.io/espressif/idf:v5.2.2.

### Testing

This compile ok:
```bash
docker run -t docker.io/espressif/idf:v5.2.2 bash -c "git clone https://github.com/micropython/micropython.git && make -C micropython/mpy-cross && make -C micropython/ports/esp32 submodules && make -C micropython/ports/esp32 BOARD=ESP32_GENERIC_S3"
```

This compile fails (added: BOARD=ESP32_GENERIC_S3):
```bash
docker run -t docker.io/espressif/idf:v5.2.2 bash -c "git clone https://github.com/micropython/micropython.git && make -C micropython/mpy-cross && make -C micropython/ports/esp32 submodules BOARD=ESP32_GENERIC_S3 && make -C micropython/ports/esp32 BOARD=ESP32_GENERIC_S3"
```

Error message
```text
CMake Error at /opt/esp/idf/tools/cmake/build.cmake:544 (message):
  ERROR: Some components (espressif/tinyusb) in the "managed_components"
  directory were modified on the disk since the last run of the CMake.
  Content of this directory is managed automatically.
```

### Subfailure in cmake

In `ports/esp32/Makefile`

```Makefile
submodules:
	@GIT_SUBMODULES=$$(idf.py $(IDFPY_FLAGS) -B $(BUILD)/submodules -D ECHO_SUBMODULES=1 build 2>&1 | \
	                  grep '^GIT_SUBMODULES=' | cut -d= -f2); \
	rm -rf ./managed_components; \
	$(MAKE) -f ../../py/mkrules.mk GIT_SUBMODULES="$${GIT_SUBMODULES}" submodules
```

Here, `idf.py` crashes silently with

```text
CMake Error at /opt/esp/idf/tools/cmake/component.cmake:313 (message):
  Include directory '/home/maerki/2025-01-08b_espressif/ori/lib/tinyusb/src'
  is not a directory.
```

This error occurs using `docker.io/espressif/idf:v5.2.2` and the current version `hmaerki/build-micropython-esp32:v5.2.2`.

The second commit in this MR fixes this.

Sidenote: It is quite dangerous, that `idf.py` may crash silently - and leave `GIT_SUBMODULES` empty. This should be fixed.

### Fix

With this PR applied, both docker commands succeed.