### PR TITLE
py/asmarm: Make all SABRELITE tests pass.

### DIFF
--- a/ports/qemu/Makefile
+++ b/ports/qemu/Makefile
@@ -19,7 +19,7 @@ QSTR_DEFS = qstrdefsport.h
 MICROPY_ROM_TEXT_COMPRESSION ?= 1
 
 ifeq ($(QEMU_ARCH),arm)
-MICROPY_HEAP_SIZE ?= 122880
+MICROPY_HEAP_SIZE ?= 143360
 ifeq ($(BOARD),MICROBIT)
 FROZEN_MANIFEST ?= "require('unittest'); freeze('test-frzmpy', ('frozen_const.py'))"
 else
@@ -27,7 +27,7 @@ FROZEN_MANIFEST ?= "require('unittest'); freeze('test-frzmpy', ('frozen_asm_thum
 endif
 endif
 ifeq ($(QEMU_ARCH),riscv32)
-MICROPY_HEAP_SIZE ?= 122880
+MICROPY_HEAP_SIZE ?= 143360
 FROZEN_MANIFEST ?= "require('unittest'); freeze('test-frzmpy', ('frozen_asm_rv32.py', 'frozen_const.py', 'frozen_viper.py', 'native_frozen_align.py'))"
 endif
 

--- a/ports/qemu/boards/SABRELITE.mk
+++ b/ports/qemu/boards/SABRELITE.mk
@@ -17,6 +17,3 @@ MPY_CROSS_FLAGS += -march=armv6
 
 # These tests don't work on Cortex-A9, so exclude them.
 RUN_TESTS_ARGS += --exclude 'inlineasm/thumb/(asmbcc|asmbitops|asmconst|asmdiv|asmit|asmspecialregs).py'
-
-# These tests fail with via-mpy and the native (armv6) emitter, so exclude them.
-RUN_TESTS_ARGS += --exclude 'extmod/vfs_rom.py|float/math_domain.py'

--- a/py/asmarm.c
+++ b/py/asmarm.c
@@ -292,8 +292,15 @@ void asm_arm_orr_reg_reg_reg(asm_arm_t *as, uint rd, uint rn, uint rm) {
 }
 
 void asm_arm_mov_reg_local_addr(asm_arm_t *as, uint rd, int local_num) {
-    // add rd, sp, #local_num*4
-    emit_al(as, asm_arm_op_add_imm(rd, ASM_ARM_REG_SP, local_num << 2));
+    if (local_num >= 0x40) {
+        // mov r8, #local_num*4
+        // add rd, sp, r8
+        asm_arm_mov_reg_i32_optimised(as, ASM_ARM_REG_R8, local_num << 2);
+        emit_al(as, asm_arm_op_add_reg(rd, ASM_ARM_REG_SP, ASM_ARM_REG_R8));
+    } else {
+        // add rd, sp, #local_num*4
+        emit_al(as, asm_arm_op_add_imm(rd, ASM_ARM_REG_SP, local_num << 2));
+    }
 }
 
 void asm_arm_mov_reg_pcrel(asm_arm_t *as, uint reg_dest, uint label) {

--- a/py/asmarm.c
+++ b/py/asmarm.c
@@ -344,8 +344,15 @@ void asm_arm_ldrh_reg_reg(asm_arm_t *as, uint rd, uint rn) {
 }
 
 void asm_arm_ldrh_reg_reg_offset(asm_arm_t *as, uint rd, uint rn, uint byte_offset) {
-    // ldrh rd, [rn, #off]
-    emit_al(as, 0x1d000b0 | (rn << 16) | (rd << 12) | ((byte_offset & 0xf0) << 4) | (byte_offset & 0xf));
+    if (byte_offset < 0x100) {
+        // ldrh rd, [rn, #off]
+        emit_al(as, 0x1d000b0 | (rn << 16) | (rd << 12) | ((byte_offset & 0xf0) << 4) | (byte_offset & 0xf));
+    } else {
+        // mov r8, #off
+        // ldrh rd, [rn, r8]
+        asm_arm_mov_reg_i32_optimised(as, ASM_ARM_REG_R8, byte_offset);
+        emit_al(as, 0x19000b0 | (rn << 16) | (rd << 12) | ASM_ARM_REG_R8);
+    }
 }
 
 void asm_arm_ldrb_reg_reg(asm_arm_t *as, uint rd, uint rn) {


### PR DESCRIPTION
### Summary

This PR adds fixes for native code generation issues that made `tests/extmod/vfs_rom.py` and `tests/float/math_domain.py` fail when ran through the native emitter.

The commits in this PR address the same issue encountered in #15937 with regard to the Arm code generator, namely not checking for immediates' range when embedding them into opcodes.

The heap size for the Qemu port was also increased from 120KiB to 140KiB, as code generated for `tests/extmod/vfs_rom.py` would not fit into the available heap during a full test run.  This is due to the fact that no compressed opcodes are generated and thus a much larger block is needed.

### Testing

The full test suite passes when ran under Qemu with `make -C mpy-cross ; make -C ports/qemu BOARD=SABRELITE RUN_TESTS_EXTRA='--via-mpy --emit native --mpy-cross-flags="-march=armv6"' test`.