### PR TITLE
esp32/boards: Remove remaining "id" entries from board.json.

### DIFF
--- a/ports/esp32/boards/ESP32_GENERIC_C6/board.json
+++ b/ports/esp32/boards/ESP32_GENERIC_C6/board.json
@@ -7,7 +7,6 @@
         "BLE",
         "WiFi"
     ],
-    "id": "esp32c6",
     "images": [
         "esp32c6_devkitmini.jpg"
     ],

--- a/ports/esp32/boards/UM_NANOS3/board.json
+++ b/ports/esp32/boards/UM_NANOS3/board.json
@@ -13,7 +13,6 @@
     "features_non_filterable": [
         "TinyPICO Nano Compatible"
     ],
-    "id": "nanos3",
     "images": [
         "unexpectedmaker_nanos3.jpg"
     ],

--- a/ports/esp32/boards/UM_OMGS3/board.json
+++ b/ports/esp32/boards/UM_OMGS3/board.json
@@ -13,7 +13,6 @@
     "features_non_filterable": [
         "I2C BAT Fuel Gauge"
     ],
-    "id": "omgs3",
     "images": [
         "unexpectedmaker_omgs3.jpg"
     ],

--- a/tools/autobuild/build-downloads.py
+++ b/tools/autobuild/build-downloads.py
@@ -65,9 +65,8 @@ def main(repo_path, output_path):
                 )
                 sys.exit(1)
 
-            # Use "id" if specified, otherwise default to board dir (e.g. "PYBV11").
-            # We allow boards to override ID for the historical build names.
-            blob["id"] = blob.get("id", os.path.basename(board_dir))
+            # The ID of a board is the board directory (e.g. "PYBV11").
+            blob["id"] = os.path.basename(board_dir)
 
             # Check for duplicate board IDs.
             if blob["id"] in board_ids:


### PR DESCRIPTION
### Summary

This entry was originally used to override the firmware filenames generated by the build server, but these days all filenames should match the board directory name.  So, remove the "id" entry and let the default be used.

This is a follow-up to 1a99f74063569df0927e1ada0256059fcdef128c (these three boards were added after that change).

### Testing

No testing has been done.  The change is hopefully self evident.
