### PR TITLE
py/mkrules.mk: Move comment about partial clones outside make rule.

### DIFF
--- a/py/mkrules.mk
+++ b/py/mkrules.mk
@@ -248,13 +248,13 @@ clean-prog:
 .PHONY: clean-prog
 endif
 
+# If available, do blobless partial clones of submodules to save time and space.
+# A blobless partial clone lazily fetches data as needed, but has all the metadata available (tags, etc.).
+# Fallback to standard submodule update if blobless isn't available (earlier than 2.36.0)
 submodules:
 	$(ECHO) "Updating submodules: $(GIT_SUBMODULES)"
 ifneq ($(GIT_SUBMODULES),)
 	$(Q)cd $(TOP) && git submodule sync $(GIT_SUBMODULES)
-	# If available, do blobless partial clones of submodules to save time and space.
-	# A blobless partial clone lazily fetches data as needed, but has all the metadata available (tags, etc.).
-	# Fallback to standard submodule update if blobless isn't available (earlier than 2.36.0)
 	$(Q)cd $(TOP) && git submodule update --init --filter=blob:none $(GIT_SUBMODULES) || \
 	  git submodule update --init $(GIT_SUBMODULES)
 endif


### PR DESCRIPTION
### Summary

Otherwise the comment is printed each time the rule is run.

Follow up to fdd606dd5395d9c474775945fa4458a27199653b.

### Testing

Prior to this commit, running `make submodules` would print the comment, eg:
```

$ make submodules
Use make V=1 or set BUILD_VERBOSE in your environment to increase build verbosity.
Updating submodules: lib/mbedtls lib/berkeley-db-1.xx lib/micropython-lib
Synchronizing submodule url for 'lib/berkeley-db-1.xx'
Synchronizing submodule url for 'lib/mbedtls'
Synchronizing submodule url for 'lib/micropython-lib'
# If available, do blobless partial clones of submodules to save time and space.
# A blobless partial clone lazily fetches data as needed, but has all the metadata available (tags, etc.).
# Fallback to standard submodule update if blobless isn't available (earlier than 2.36.0)
```

After this commit the output is:
```
$ make submodules
Use make V=1 or set BUILD_VERBOSE in your environment to increase build verbosity.
Updating submodules: lib/mbedtls lib/berkeley-db-1.xx lib/micropython-lib
Synchronizing submodule url for 'lib/berkeley-db-1.xx'
Synchronizing submodule url for 'lib/mbedtls'
Synchronizing submodule url for 'lib/micropython-lib'
```