### PR TITLE
LICENSE,docs: Update copyright year range to include 2025.

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2013-2024 Damien P. George
+Copyright (c) 2013-2025 Damien P. George
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -71,7 +71,7 @@ master_doc = "index"
 
 # General information about the project.
 project = "MicroPython"
-copyright = "- The MicroPython Documentation is Copyright © 2014-2024, " + micropy_authors
+copyright = "- The MicroPython Documentation is Copyright © 2014-2025, " + micropy_authors
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the


### PR DESCRIPTION
### Summary

Update year from 2024 to 2025.  It's a new year!

### Testing

Should be self evident, follows previous commits such as 5f6e6891245c5c766801bb6c0a62395fefae132c
