### PR TITLE
esp8266/Makefile: Fix local toolchain builds on recent Linux systems.

### DIFF
--- a/ports/esp8266/Makefile
+++ b/ports/esp8266/Makefile
@@ -185,6 +185,11 @@ else ifneq ($(shell cat $(CONFVARS_FILE)), $(FROZEN_MANIFEST) $(UART_OS))
 $(shell echo $(FROZEN_MANIFEST) $(UART_OS) > $(CONFVARS_FILE))
 endif
 
+ESPTOOL := $(shell command -v esptool 2> /dev/null)
+ifndef ESPTOOL
+ESPTOOL = esptool.py
+endif
+
 $(BUILD)/uart.o: $(CONFVARS_FILE)
 
 FROZEN_EXTRA_DEPS = $(CONFVARS_FILE)
@@ -193,11 +198,11 @@ FROZEN_EXTRA_DEPS = $(CONFVARS_FILE)
 
 deploy: $(FWBIN)
 	$(ECHO) "Writing $< to the board"
-	$(Q)esptool.py --port $(PORT) --baud $(BAUD) write_flash --verify --flash_size=$(FLASH_SIZE) --flash_mode=$(FLASH_MODE) 0 $<
+	$(Q)$(ESPTOOL) --port $(PORT) --baud $(BAUD) write_flash --verify --flash_size=$(FLASH_SIZE) --flash_mode=$(FLASH_MODE) 0 $<
 
 erase:
 	$(ECHO) "Erase flash"
-	$(Q)esptool.py --port $(PORT) --baud $(BAUD) erase_flash
+	$(Q)$(ESPTOOL) --port $(PORT) --baud $(BAUD) erase_flash
 
 reset:
 	echo -e "\r\nimport machine; machine.reset()\r\n" >$(PORT)
@@ -205,7 +210,7 @@ reset:
 ifeq ($(BOARD_VARIANT),OTA)
 $(FWBIN): $(BUILD)/firmware.elf
 	$(ECHO) "Create $@"
-	$(Q)esptool.py elf2image $^
+	$(Q)$(ESPTOOL) elf2image $^
 	$(Q)$(PYTHON) makeimg.py $(BUILD)/firmware.elf-0x00000.bin $(BUILD)/firmware.elf-0x[0-5][1-f]000.bin $(BUILD)/firmware-ota.bin
 
 	$(Q)cat $(YAOTA8266)/yaota8266.bin $(BUILD)/firmware-ota.bin > $@
@@ -213,7 +218,7 @@ $(FWBIN): $(BUILD)/firmware.elf
 else
 $(FWBIN): $(BUILD)/firmware.elf
 	$(ECHO) "Create $@"
-	$(Q)esptool.py elf2image $^
+	$(Q)$(ESPTOOL) elf2image $^
 	$(Q)$(PYTHON) makeimg.py $(BUILD)/firmware.elf-0x00000.bin $(BUILD)/firmware.elf-0x[0-5][1-f]000.bin $@
 endif
 


### PR DESCRIPTION
### Summary

This commit fixes compilation for the ESP8266 port when using a local toolchain on relatively recent Linux systems.

The documentation asks the user to delete the esptool instance that comes with the toolchain, in favour of using the one provided by the system.  On Linux systems that are at least two years old (looking at the CI Ubuntu image as an example), the version of esptool installed with the package manager isn't called `esptool.py` but just `esptool`. The Makefile didn't take that into account and used `esptool.py` without checking if such a command exists, making builds fail.

Now preference is given to the `esptool` command, falling back to `esptool.py` only if the former command does not exist or it is not available to the current user, to maintain compatibility with old setups.

### Testing

The 8266 port was successfully built twice on Ubuntu 22.04 using a local toolchain with its provided `esptool` instance deleted.  Once with `esptool` provided by `apt-get`, and once with `esptool` provided by `pip` (using the CI scripts).  