### PR TITLE
machine.Pin: Implement Pin.toggle() for three ports.

### DIFF
--- a/docs/library/machine.Pin.rst
+++ b/docs/library/machine.Pin.rst
@@ -209,13 +209,13 @@ The following methods are not part of the core Pin API and only implemented on c
 
    Set pin to "0" output level.
 
-   Availability: nrf, rp2, stm32 ports.
+   Availability: mimxrt, nrf, renesas-ra, rp2, samd, stm32 ports.
 
 .. method:: Pin.high()
 
    Set pin to "1" output level.
 
-   Availability: nrf, rp2, stm32 ports.
+   Availability: mimxrt, nrf, renesas-ra, rp2, samd, stm32 ports.
 
 .. method:: Pin.mode([mode])
 
@@ -242,7 +242,7 @@ The following methods are not part of the core Pin API and only implemented on c
 
    Toggle output pin from "0" to "1" or vice-versa.
 
-   Availability: mimxrt, samd, rp2 ports.
+   Availability: cc3200, esp32, esp8266, mimxrt, rp2, samd ports.
 
 Constants
 ---------

--- a/ports/cc3200/mods/pybpin.c
+++ b/ports/cc3200/mods/pybpin.c
@@ -680,6 +680,20 @@ static mp_obj_t pin_value(size_t n_args, const mp_obj_t *args) {
 }
 static MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(pin_value_obj, 1, 2, pin_value);
 
+// pin.toggle()
+static mp_obj_t pin_toggle(mp_obj_t self_in) {
+    pin_obj_t *self = self_in;
+    if (self->value) {
+        self->value = 0;
+        MAP_GPIOPinWrite(self->port, self->bit, 0);
+    } else {
+        self->value = 1;
+        MAP_GPIOPinWrite(self->port, self->bit, self->bit);
+    }
+    return mp_const_none;
+}
+static MP_DEFINE_CONST_FUN_OBJ_1(pin_toggle_obj, pin_toggle);
+
 static mp_obj_t pin_id(mp_obj_t self_in) {
     pin_obj_t *self = self_in;
     return MP_OBJ_NEW_QSTR(self->name);
@@ -902,6 +916,7 @@ static const mp_rom_map_elem_t pin_locals_dict_table[] = {
     // instance methods
     { MP_ROM_QSTR(MP_QSTR_init),                    MP_ROM_PTR(&pin_init_obj) },
     { MP_ROM_QSTR(MP_QSTR_value),                   MP_ROM_PTR(&pin_value_obj) },
+    { MP_ROM_QSTR(MP_QSTR_toggle),                  MP_ROM_PTR(&pin_toggle_obj) },
     { MP_ROM_QSTR(MP_QSTR_id),                      MP_ROM_PTR(&pin_id_obj) },
     { MP_ROM_QSTR(MP_QSTR_mode),                    MP_ROM_PTR(&pin_mode_obj) },
     { MP_ROM_QSTR(MP_QSTR_pull),                    MP_ROM_PTR(&pin_pull_obj) },

--- a/ports/esp32/machine_pin.c
+++ b/ports/esp32/machine_pin.c
@@ -287,6 +287,15 @@ static mp_obj_t machine_pin_on(mp_obj_t self_in) {
 }
 static MP_DEFINE_CONST_FUN_OBJ_1(machine_pin_on_obj, machine_pin_on);
 
+// pin.toggle()
+static mp_obj_t machine_pin_toggle(mp_obj_t self_in) {
+    machine_pin_obj_t *self = MP_OBJ_TO_PTR(self_in);
+    gpio_num_t index = PIN_OBJ_PTR_INDEX(self);
+    gpio_set_level(index, 1 - mp_hal_pin_read_output(index));
+    return mp_const_none;
+}
+static MP_DEFINE_CONST_FUN_OBJ_1(machine_pin_toggle_obj, machine_pin_toggle);
+
 // pin.irq(handler=None, trigger=IRQ_FALLING|IRQ_RISING)
 static mp_obj_t machine_pin_irq(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
     enum { ARG_handler, ARG_trigger, ARG_wake };
@@ -366,6 +375,7 @@ static const mp_rom_map_elem_t machine_pin_locals_dict_table[] = {
     { MP_ROM_QSTR(MP_QSTR_value), MP_ROM_PTR(&machine_pin_value_obj) },
     { MP_ROM_QSTR(MP_QSTR_off), MP_ROM_PTR(&machine_pin_off_obj) },
     { MP_ROM_QSTR(MP_QSTR_on), MP_ROM_PTR(&machine_pin_on_obj) },
+    { MP_ROM_QSTR(MP_QSTR_toggle), MP_ROM_PTR(&machine_pin_toggle_obj) },
     { MP_ROM_QSTR(MP_QSTR_irq), MP_ROM_PTR(&machine_pin_irq_obj) },
 
     // class attributes

--- a/ports/esp32/mphalport.h
+++ b/ports/esp32/mphalport.h
@@ -36,6 +36,7 @@
 #include "freertos/task.h"
 
 #include "driver/spi_master.h"
+#include "soc/gpio_reg.h"
 
 #define MICROPY_PLATFORM_VERSION "IDF" IDF_VER
 
@@ -132,6 +133,15 @@ static inline void mp_hal_pin_od_high(mp_hal_pin_obj_t pin) {
 }
 static inline int mp_hal_pin_read(mp_hal_pin_obj_t pin) {
     return gpio_get_level(pin);
+}
+static inline int mp_hal_pin_read_output(mp_hal_pin_obj_t pin) {
+    #if defined(GPIO_OUT1_REG)
+    return pin < 32
+        ? (*(uint32_t *)GPIO_OUT_REG >> pin) & 1
+        : (*(uint32_t *)GPIO_OUT1_REG >> (pin - 32)) & 1;
+    #else
+    return (*(uint32_t *)GPIO_OUT_REG >> pin) & 1;
+    #endif
 }
 static inline void mp_hal_pin_write(mp_hal_pin_obj_t pin, int v) {
     gpio_set_level(pin, v);

--- a/ports/esp8266/esp_mphal.h
+++ b/ports/esp8266/esp_mphal.h
@@ -100,6 +100,13 @@ void mp_hal_pin_open_drain(mp_hal_pin_obj_t pin);
         else { gpio_output_set(1 << (p), 0, 1 << (p), 0); } \
 } while (0)
 #define mp_hal_pin_read(p) pin_get(p)
+static inline int mp_hal_pin_read_output(mp_hal_pin_obj_t pin) {
+    if (pin >= 16) {
+        return READ_PERI_REG(RTC_GPIO_OUT) & 1;
+    } else {
+        return (GPIO_REG_READ(GPIO_OUT_ADDRESS) >> pin) & 1;
+    }
+}
 #define mp_hal_pin_write(p, v) pin_set((p), (v))
 
 void *ets_get_esf_buf_ctlblk(void);

--- a/ports/esp8266/machine_pin.c
+++ b/ports/esp8266/machine_pin.c
@@ -373,6 +373,14 @@ static mp_obj_t pyb_pin_on(mp_obj_t self_in) {
 }
 static MP_DEFINE_CONST_FUN_OBJ_1(pyb_pin_on_obj, pyb_pin_on);
 
+// pin.toggle()
+static mp_obj_t machine_pin_toggle(mp_obj_t self_in) {
+    pyb_pin_obj_t *self = self_in;
+    pin_set(self->phys_port, 1 - mp_hal_pin_read_output(self->phys_port));
+    return mp_const_none;
+}
+static MP_DEFINE_CONST_FUN_OBJ_1(machine_pin_toggle_obj, machine_pin_toggle);
+
 // pin.irq(handler=None, trigger=IRQ_FALLING|IRQ_RISING, hard=False)
 static mp_obj_t pyb_pin_irq(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
     enum { ARG_handler, ARG_trigger, ARG_hard };
@@ -435,6 +443,7 @@ static const mp_rom_map_elem_t pyb_pin_locals_dict_table[] = {
     { MP_ROM_QSTR(MP_QSTR_value),   MP_ROM_PTR(&pyb_pin_value_obj) },
     { MP_ROM_QSTR(MP_QSTR_off),     MP_ROM_PTR(&pyb_pin_off_obj) },
     { MP_ROM_QSTR(MP_QSTR_on),      MP_ROM_PTR(&pyb_pin_on_obj) },
+    { MP_ROM_QSTR(MP_QSTR_toggle), MP_ROM_PTR(&machine_pin_toggle_obj) },
     { MP_ROM_QSTR(MP_QSTR_irq),     MP_ROM_PTR(&pyb_pin_irq_obj) },
 
     // class constants


### PR DESCRIPTION
### Summary

The ESP32, ESP8266 and CC3200 ports did not provide the method Pin.toggle(). This PR adds it. 

### Testing

Tested with:

- ESP32
- ESP32C3
- ESP32C6
- ESP32S2
- ESP32S3
- ESP8266
- WiPY 1 (CC3200)