### PR TITLE
ports/*: increase LWIP timers for ports with mDNS support

### DIFF
--- a/extmod/lwip-include/lwipopts_common.h
+++ b/extmod/lwip-include/lwipopts_common.h
@@ -65,7 +65,9 @@
 
 #define LWIP_NUM_NETIF_CLIENT_DATA      LWIP_MDNS_RESPONDER
 #define MEMP_NUM_UDP_PCB                (4 + LWIP_MDNS_RESPONDER)
-#define MEMP_NUM_SYS_TIMEOUT            (LWIP_NUM_SYS_TIMEOUT_INTERNAL + LWIP_MDNS_RESPONDER)
+
+// The mDNS responder requires 5 timers per IP version plus 2 others. Not having enough silently breaks it.
+#define MEMP_NUM_SYS_TIMEOUT            (LWIP_NUM_SYS_TIMEOUT_INTERNAL + (LWIP_MDNS_RESPONDER * (2 + (5 * (LWIP_IPV4 + LWIP_IPV6)))))
 
 #define SO_REUSE                        1
 #define TCP_LISTEN_BACKLOG              1


### PR DESCRIPTION
<!-- Thanks for submitting a Pull Request! We appreciate you spending the
     time to improve MicroPython. Please provide enough information so that
     others can review your Pull Request.

     Before submitting, please read:
     https://github.com/micropython/micropython/blob/master/CODEOFCONDUCT.md
     https://github.com/micropython/micropython/wiki/ContributorGuidelines

     Please check any CI failures that appear after your Pull Request is opened.
-->

### Summary

Despite the code comments claiming one is sufficient, the mDNS application is capable of using up to twelve timers. Three per IP protocol are started at once in `mdns_start_multicast_timeouts_ipvX`, then another two per protocol can be started in `mdns_handle_question`. Further timers can be started for two additional callbacks.


Having certain timers, such as `MDNS_MULTICAST_TIMEOUT`, fail to start due to none being free will break mDNS forever as the app will never realize it's safe to transmit a packet.
<!-- Explain the reason for making this change. What problem does the pull request
     solve, or what improvement does it add? Add links if relevant. -->


### Testing

This fixes mDNS on W5500_EVB_PICO. Before, mDNS would work for a bit after connection until the host's cache expired a minute or two later. Then the board would never respond to further queries. With this patch, all works well.

<!-- Explain what testing you did, and on which boards/ports. If there are
     boards or ports that you couldn't test, please mention this here as well.

     If you leave this empty then your Pull Request may be closed. -->


### Trade-offs and Alternatives

This PR goes somewhat overkill and allocates the maximal amount of timers; it's uncertain if all can run simultaneously, or how many callback timers are needed.

Each timer struct is 16 bytes on standard 32 bit builds. Plus 8 bytes of allocater overhead, that's 288 more bytes of RAM used which shouldn't be too horrible. Users who don't need mDNS can manually disable it to recover the RAM if necessary.
