### PR TITLE
py/emitnative: Code generation improvements for Xtensa and RV32.

### DIFF
--- a/py/asmrv32.h
+++ b/py/asmrv32.h
@@ -694,6 +694,7 @@ static inline void asm_rv32_opcode_xori(asm_rv32_t *state, mp_uint_t rd, mp_uint
 #define REG_LOCAL_1 ASM_RV32_REG_S3
 #define REG_LOCAL_2 ASM_RV32_REG_S4
 #define REG_LOCAL_3 ASM_RV32_REG_S5
+#define REG_ZERO ASM_RV32_REG_ZERO
 
 void asm_rv32_meta_comparison_eq(asm_rv32_t *state, mp_uint_t rs1, mp_uint_t rs2, mp_uint_t rd);
 void asm_rv32_meta_comparison_ne(asm_rv32_t *state, mp_uint_t rs1, mp_uint_t rs2, mp_uint_t rd);
@@ -756,6 +757,7 @@ void asm_rv32_emit_store_reg_reg_offset(asm_rv32_t *state, mp_uint_t source, mp_
 #define ASM_STORE_REG_REG(state, rs1, rs2) ASM_STORE32_REG_REG(state, rs1, rs2)
 #define ASM_SUB_REG_REG(state, rd, rs) asm_rv32_opcode_sub(state, rd, rd, rs)
 #define ASM_XOR_REG_REG(state, rd, rs) asm_rv32_emit_optimised_xor(state, rd, rs)
+#define ASM_CLR_REG(state, rd)
 
 #endif
 

--- a/py/asmxtensa.h
+++ b/py/asmxtensa.h
@@ -143,6 +143,14 @@ static inline void asm_xtensa_op_addi(asm_xtensa_t *as, uint reg_dest, uint reg_
     asm_xtensa_op24(as, ASM_XTENSA_ENCODE_RRI8(2, 12, reg_src, reg_dest, imm8 & 0xff));
 }
 
+static inline void asm_xtensa_op_addx2(asm_xtensa_t *as, uint reg_dest, uint reg_src_a, uint reg_src_b) {
+    asm_xtensa_op24(as, ASM_XTENSA_ENCODE_RRR(0, 0, 9, reg_dest, reg_src_a, reg_src_b));
+}
+
+static inline void asm_xtensa_op_addx4(asm_xtensa_t *as, uint reg_dest, uint reg_src_a, uint reg_src_b) {
+    asm_xtensa_op24(as, ASM_XTENSA_ENCODE_RRR(0, 0, 10, reg_dest, reg_src_a, reg_src_b));
+}
+
 static inline void asm_xtensa_op_and(asm_xtensa_t *as, uint reg_dest, uint reg_src_a, uint reg_src_b) {
     asm_xtensa_op24(as, ASM_XTENSA_ENCODE_RRR(0, 0, 1, reg_dest, reg_src_a, reg_src_b));
 }

--- a/py/emitnative.c
+++ b/py/emitnative.c
@@ -1550,6 +1550,11 @@ static void emit_native_load_subscr(emit_t *emit) {
                             asm_rv32_opcode_lbu(emit->as, REG_RET, reg_base, index_value);
                             break;
                         }
+                        #elif N_XTENSA || N_XTENSAWIN
+                        if (index_value > 0 && index_value < 256) {
+                            asm_xtensa_op_l8ui(emit->as, REG_RET, reg_base, index_value);
+                            break;
+                        }
                         #endif
                         need_reg_single(emit, reg_index, 0);
                         ASM_MOV_REG_IMM(emit->as, reg_index, index_value);
@@ -1571,6 +1576,11 @@ static void emit_native_load_subscr(emit_t *emit) {
                         #elif N_RV32
                         if (FIT_SIGNED(index_value, 11)) {
                             asm_rv32_opcode_lhu(emit->as, REG_RET, reg_base, index_value << 1);
+                            break;
+                        }
+                        #elif N_XTENSA || N_XTENSAWIN
+                        if (index_value > 0 && index_value < 256) {
+                            asm_xtensa_op_l16ui(emit->as, REG_RET, reg_base, index_value);
                             break;
                         }
                         #endif
@@ -1595,6 +1605,10 @@ static void emit_native_load_subscr(emit_t *emit) {
                         if (FIT_SIGNED(index_value, 10)) {
                             asm_rv32_opcode_lw(emit->as, REG_RET, reg_base, index_value << 2);
                             break;
+                        }
+                        #elif N_XTENSA || N_XTENSAWIN
+                        if (index_value > 0 && index_value < 256) {
+                            asm_xtensa_l32i_optimised(emit->as, REG_RET, reg_base, index_value);
                         }
                         #endif
                         need_reg_single(emit, reg_index, 0);
@@ -1812,6 +1826,11 @@ static void emit_native_store_subscr(emit_t *emit) {
                             asm_rv32_opcode_sb(emit->as, reg_value, reg_base, index_value);
                             break;
                         }
+                        #elif N_XTENSA || N_XTENSAWIN
+                        if (index_value > 0 && index_value < 256) {
+                            asm_xtensa_op_s8i(emit->as, REG_RET, reg_base, index_value);
+                            break;
+                        }
                         #endif
                         ASM_MOV_REG_IMM(emit->as, reg_index, index_value);
                         #if N_ARM
@@ -1838,6 +1857,11 @@ static void emit_native_store_subscr(emit_t *emit) {
                             asm_rv32_opcode_sh(emit->as, reg_value, reg_base, index_value << 1);
                             break;
                         }
+                        #elif N_XTENSA || N_XTENSAWIN
+                        if (index_value > 0 && index_value < 256) {
+                            asm_xtensa_op_s16i(emit->as, REG_RET, reg_base, index_value);
+                            break;
+                        }
                         #endif
                         ASM_MOV_REG_IMM(emit->as, reg_index, index_value << 1);
                         ASM_ADD_REG_REG(emit->as, reg_index, reg_base); // add 2*index to base
@@ -1859,6 +1883,10 @@ static void emit_native_store_subscr(emit_t *emit) {
                         if (FIT_SIGNED(index_value, 10)) {
                             asm_rv32_opcode_sw(emit->as, reg_value, reg_base, index_value << 2);
                             break;
+                        }
+                        #elif N_XTENSA || N_XTENSAWIN
+                        if (index_value > 0 && index_value < 256) {
+                            asm_xtensa_s32i_optimised(emit->as, REG_RET, reg_base, index_value);
                         }
                         #elif N_ARM
                         ASM_MOV_REG_IMM(emit->as, reg_index, index_value);

--- a/py/emitnative.c
+++ b/py/emitnative.c
@@ -1625,6 +1625,11 @@ static void emit_native_load_subscr(emit_t *emit) {
                 }
                 case VTYPE_PTR16: {
                     // pointer to 16-bit memory
+                    #if N_XTENSA || N_XTENSAWIN
+                    asm_xtensa_op_addx2(emit->as, REG_ARG_1, reg_index, REG_ARG_1);
+                    asm_xtensa_op_l16ui(emit->as, REG_RET, REG_ARG_1, 0);
+                    break;
+                    #endif
                     ASM_ADD_REG_REG(emit->as, REG_ARG_1, reg_index); // add index to base
                     ASM_ADD_REG_REG(emit->as, REG_ARG_1, reg_index); // add index to base
                     ASM_LOAD16_REG_REG(emit->as, REG_RET, REG_ARG_1); // load from (base+2*index)
@@ -1636,6 +1641,10 @@ static void emit_native_load_subscr(emit_t *emit) {
                     asm_rv32_opcode_slli(emit->as, REG_TEMP2, reg_index, 2);
                     asm_rv32_opcode_cadd(emit->as, REG_ARG_1, REG_TEMP2);
                     asm_rv32_opcode_lw(emit->as, REG_RET, REG_ARG_1, 0);
+                    break;
+                    #elif N_XTENSA || N_XTENSAWIN
+                    asm_xtensa_op_addx4(emit->as, REG_ARG_1, reg_index, REG_ARG_1);
+                    asm_xtensa_op_l32i_n(emit->as, REG_RET, REG_ARG_1, 0);
                     break;
                     #endif
                     ASM_ADD_REG_REG(emit->as, REG_ARG_1, reg_index); // add index to base
@@ -1900,6 +1909,10 @@ static void emit_native_store_subscr(emit_t *emit) {
                     #if N_ARM
                     asm_arm_strh_reg_reg_reg(emit->as, reg_value, REG_ARG_1, reg_index);
                     break;
+                    #elif N_XTENSA || N_XTENSAWIN
+                    asm_xtensa_op_addx2(emit->as, REG_ARG_1, reg_index, REG_ARG_1);
+                    asm_xtensa_op_s16i(emit->as, reg_value, REG_ARG_1, 0);
+                    break;
                     #endif
                     ASM_ADD_REG_REG(emit->as, REG_ARG_1, reg_index); // add index to base
                     ASM_ADD_REG_REG(emit->as, REG_ARG_1, reg_index); // add index to base
@@ -1915,6 +1928,10 @@ static void emit_native_store_subscr(emit_t *emit) {
                     asm_rv32_opcode_slli(emit->as, REG_TEMP2, reg_index, 2);
                     asm_rv32_opcode_cadd(emit->as, REG_ARG_1, REG_TEMP2);
                     asm_rv32_opcode_sw(emit->as, reg_value, REG_ARG_1, 0);
+                    break;
+                    #elif N_XTENSA || N_XTENSAWIN
+                    asm_xtensa_op_addx4(emit->as, REG_ARG_1, reg_index, REG_ARG_1);
+                    asm_xtensa_op_s32i_n(emit->as, reg_value, REG_ARG_1, 0);
                     break;
                     #endif
                     ASM_ADD_REG_REG(emit->as, REG_ARG_1, reg_index); // add index to base


### PR DESCRIPTION
### Summary

This PR contains ~two~ three improvements to the emitter for native and viper code.

In the first one, address generation for Xtensa and Xtensawin (eg. calculating a byte offset in an array of words/halfwords) was done by calculating the final byte offset by hand without even using shifts, which would mean three opcodes for halfwords (add + add + load/store) and five opcodes for words (add + add + add + add + load/store).  Said platform offers the `ADDX2` and `ADDX4` opcodes that perform an addition between two registers but with one of them being pre-shifted by either 2 or 4 bits, making them ideal to replace the addition sequences in the examples described earlier.

The second one exploits the fact that RV32 has a register (X0/ZERO) that is hardwired to ignore writes and to always return zero when read.  For native functions that require an exception handler, the code sequence emitted when setting up the exception stack would zero a temporary register and then use that to clear some memory locations needed to be zeroed.  On RV32 the temporary register clearing is skipped and memory is written with the contents of X0/ZERO, obtaining the same result without an extra XOR operation.

Finally, the third one lets Xtensa and Xtensawin Viper load and stores that go through an immediate offset to emit a single opcode if the offset is small enough to be embedded in the opcode itself.  The regular code sequence is emitted otherwise.

### Testing

`micropython/viper*` and `micropython/native*` tests pass on an ESP8266, on a plain ESP32 with ESP-IDF 5.2.0, on QEMU/VIRT_RV32, and on QEMU/MPS2_AN385.

### Trade-offs and Alternatives

There are more places where a temporary register is zeroed and then used to clear memory, but rather than using an explicit 0 value they use `MP_OBJ_NULL` which is defined to 0 as well.  To keep things safe I left those bits alone, but if needed I can expand that by perform an `#if` check on the value of `MP_OBJ_NULL` and use X0/ZERO on RV32 in those cases.