### PR TITLE
ports/stm32: Make ETH DMA buffer attributes configurable.

### DIFF
--- a/ports/stm32/eth.c
+++ b/ports/stm32/eth.c
@@ -121,7 +121,7 @@ typedef struct _eth_t {
     int16_t (*phy_get_link_status)(uint32_t phy_addr);
 } eth_t;
 
-static eth_dma_t eth_dma __attribute__((aligned(16384)));
+static eth_dma_t eth_dma MICROPY_HW_ETH_DMA_ATTRIBUTE;
 
 eth_t eth_instance;
 

--- a/ports/stm32/mpconfigboard_common.h
+++ b/ports/stm32/mpconfigboard_common.h
@@ -669,3 +669,7 @@
 #endif
 
 #define MICROPY_HW_USES_BOOTLOADER (MICROPY_HW_VTOR != 0x08000000)
+
+#ifndef MICROPY_HW_ETH_DMA_ATTRIBUTE
+#define MICROPY_HW_ETH_DMA_ATTRIBUTE __attribute__((aligned(16384)));
+#endif


### PR DESCRIPTION
This commit allows the attributes for the eth_dma buffer to be overridden by a port.

OpenMV's firmware for the Arduino Portenta stores .data in the DTCM which is inaccessible by the ethernet controller. By overriding the buffer's attributes with alignment and section specifications, we can place the ethernet buffer in the right SRAM location.
