### PR TITLE
ports/mimxrt: Misc small fixes.

### DIFF
--- a/ports/mimxrt/irq.h
+++ b/ports/mimxrt/irq.h
@@ -69,6 +69,8 @@ static inline void restore_irq_pri(uint32_t basepri) {
 
 #define IRQ_PRI_SYSTICK         NVIC_EncodePriority(NVIC_PRIORITYGROUP_4, 0, 0)
 
+#define IRQ_PRI_CSI             NVIC_EncodePriority(NVIC_PRIORITYGROUP_4, 3, 0)
+
 #define IRQ_PRI_OTG_HS          NVIC_EncodePriority(NVIC_PRIORITYGROUP_4, 6, 0)
 
 #define IRQ_PRI_EXTINT          NVIC_EncodePriority(NVIC_PRIORITYGROUP_4, 14, 0)

--- a/ports/mimxrt/machine_rtc.c
+++ b/ports/mimxrt/machine_rtc.c
@@ -156,8 +156,10 @@ void machine_rtc_start(void) {
     SNVS->HPCOMR |= SNVS_HPCOMR_NPSWA_EN_MASK;
     // Do a basic init.
     SNVS_LP_Init(SNVS);
+    #if FSL_FEATURE_SNVS_HAS_MULTIPLE_TAMPER
     // Disable all external Tamper
     SNVS_LP_DisableAllExternalTamper(SNVS);
+    #endif
 
     SNVS_LP_SRTC_StartTimer(SNVS);
     // If the date is not set, set it to a more recent start date,

--- a/ports/mimxrt/mpconfigport.h
+++ b/ports/mimxrt/mpconfigport.h
@@ -29,7 +29,6 @@
 // Board specific definitions
 #include "mpconfigboard.h"
 #include "fsl_common.h"
-#include "lib/nxp_driver/sdk/CMSIS/Include/core_cm7.h"
 
 uint32_t trng_random_u32(void);
 


### PR DESCRIPTION
### Summary

- Add missing IRQ.
- Ensure feature is available before calling `SNVS_LP_DisableAllExternalTamper`
- Replace hard-coded cm7 header with MCU header.

### Testing

No testing is required, but boards still build.