### PR TITLE
extmod/lwip-include: Factor common lwIP config into lwipopts_common.h.

### DIFF
--- a/extmod/lwip-include/lwipopts_common.h
+++ b/extmod/lwip-include/lwipopts_common.h
@@ -1,0 +1,109 @@
+/*
+ * This file is part of the MicroPython project, http://micropython.org/
+ *
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2025 Damien P. George
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+#ifndef MICROPY_INCLUDED_LWIPOPTS_COMMON_H
+#define MICROPY_INCLUDED_LWIPOPTS_COMMON_H
+
+#include "py/mpconfig.h"
+
+// This sys-arch protection is not needed.
+// Ports either protect lwIP code with flags, or run it at PendSV priority.
+#define SYS_ARCH_DECL_PROTECT(lev) do { } while (0)
+#define SYS_ARCH_PROTECT(lev) do { } while (0)
+#define SYS_ARCH_UNPROTECT(lev) do { } while (0)
+
+#define NO_SYS                          1
+#define SYS_LIGHTWEIGHT_PROT            1
+#define MEM_ALIGNMENT                   4
+
+#define LWIP_CHKSUM_ALGORITHM           3
+#define LWIP_CHECKSUM_CTRL_PER_NETIF    1
+
+#define LWIP_ARP                        1
+#define LWIP_ETHERNET                   1
+#define LWIP_RAW                        1
+#define LWIP_NETCONN                    0
+#define LWIP_SOCKET                     0
+#define LWIP_STATS                      0
+#define LWIP_NETIF_HOSTNAME             1
+
+#define LWIP_DHCP                       1
+#define LWIP_DHCP_CHECK_LINK_UP         1
+#define LWIP_DHCP_DOES_ACD_CHECK        0 // to speed DHCP up
+#define LWIP_DNS                        1
+#define LWIP_DNS_SUPPORT_MDNS_QUERIES   1
+#define LWIP_MDNS_RESPONDER             1
+#define LWIP_IGMP                       1
+
+#if MICROPY_PY_LWIP_PPP
+#define PPP_SUPPORT                     1
+#define PAP_SUPPORT                     1
+#define CHAP_SUPPORT                    1
+#endif
+
+#define LWIP_NUM_NETIF_CLIENT_DATA      LWIP_MDNS_RESPONDER
+#define MEMP_NUM_UDP_PCB                (4 + LWIP_MDNS_RESPONDER)
+#define MEMP_NUM_SYS_TIMEOUT            (LWIP_NUM_SYS_TIMEOUT_INTERNAL + LWIP_MDNS_RESPONDER)
+
+#define SO_REUSE                        1
+#define TCP_LISTEN_BACKLOG              1
+
+// TCP memory settings.
+// Default lwIP settings takes 15800 bytes; TCP d/l: 380k/s local, 7.2k/s remote; TCP u/l is very slow.
+#ifndef MEM_SIZE
+
+#if 0
+// lwIP takes 19159 bytes; TCP d/l and u/l are around 320k/s on local network.
+#define MEM_SIZE (5000)
+#define TCP_WND (4 * TCP_MSS)
+#define TCP_SND_BUF (4 * TCP_MSS)
+#endif
+
+#if 1
+// lwIP takes 26700 bytes; TCP dl/ul are around 750/600 k/s on local network.
+#define MEM_SIZE (8000)
+#define TCP_MSS (800)
+#define TCP_WND (8 * TCP_MSS)
+#define TCP_SND_BUF (8 * TCP_MSS)
+#define MEMP_NUM_TCP_SEG (32)
+#endif
+
+#if 0
+// lwIP takes 45600 bytes; TCP dl/ul are around 1200/1000 k/s on local network.
+#define MEM_SIZE (16000)
+#define TCP_MSS (1460)
+#define TCP_WND (8 * TCP_MSS)
+#define TCP_SND_BUF (8 * TCP_MSS)
+#define MEMP_NUM_TCP_SEG (32)
+#endif
+
+#endif // MEM_SIZE
+
+// Needed for PPP.
+#define sys_jiffies sys_now
+
+typedef uint32_t sys_prot_t;
+
+#endif // MICROPY_INCLUDED_LWIPOPTS_COMMON_H

--- a/ports/mimxrt/lwip_inc/lwipopts.h
+++ b/ports/mimxrt/lwip_inc/lwipopts.h
@@ -1,56 +1,15 @@
 #ifndef MICROPY_INCLUDED_MIMXRT_LWIP_LWIPOPTS_H
 #define MICROPY_INCLUDED_MIMXRT_LWIP_LWIPOPTS_H
 
-#include <stdint.h>
-
-// This protection is not needed, instead we execute all lwIP code at PendSV priority
-#define SYS_ARCH_DECL_PROTECT(lev) do { } while (0)
-#define SYS_ARCH_PROTECT(lev) do { } while (0)
-#define SYS_ARCH_UNPROTECT(lev) do { } while (0)
-
-#define NO_SYS                          1
-#define SYS_LIGHTWEIGHT_PROT            1
-#define MEM_ALIGNMENT                   4
-
-#define LWIP_CHKSUM_ALGORITHM           3
-// The checksum flags are set in eth.c
-#define LWIP_CHECKSUM_CTRL_PER_NETIF    1
-
-#define LWIP_ARP                        1
-#define LWIP_ETHERNET                   1
-#define LWIP_RAW                        1
-#define LWIP_NETCONN                    0
-#define LWIP_SOCKET                     0
-#define LWIP_STATS                      0
-#define LWIP_NETIF_HOSTNAME             1
 #define LWIP_NETIF_EXT_STATUS_CALLBACK  1
 
 #define LWIP_IPV6                       0
-#define LWIP_DHCP                       1
-#define LWIP_DHCP_CHECK_LINK_UP         1
-#define LWIP_DHCP_DOES_ACD_CHECK        0 // to speed DHCP up
-#define LWIP_DNS                        1
-#define LWIP_DNS_SUPPORT_MDNS_QUERIES   1
-#define LWIP_MDNS_RESPONDER             1
-#define LWIP_IGMP                       1
 
-#define LWIP_NUM_NETIF_CLIENT_DATA      LWIP_MDNS_RESPONDER
-#define MEMP_NUM_UDP_PCB                (4 + LWIP_MDNS_RESPONDER)
-#define MEMP_NUM_SYS_TIMEOUT            (LWIP_NUM_SYS_TIMEOUT_INTERNAL + LWIP_MDNS_RESPONDER)
-
-#define SO_REUSE                        1
-#define TCP_LISTEN_BACKLOG              1
-
-extern uint32_t trng_random_u32(void);
 #define LWIP_RAND() trng_random_u32()
 
-// lwip takes 26700 bytes
-#define MEM_SIZE (8000)
-#define TCP_MSS (800)
-#define TCP_WND (8 * TCP_MSS)
-#define TCP_SND_BUF (8 * TCP_MSS)
-#define MEMP_NUM_TCP_SEG (32)
+// Include common lwIP configuration.
+#include "extmod/lwip-include/lwipopts_common.h"
 
-typedef uint32_t sys_prot_t;
+extern uint32_t trng_random_u32(void);
 
 #endif // MICROPY_INCLUDED_MIMXRT_LWIP_LWIPOPTS_H

--- a/ports/renesas-ra/lwip_inc/lwipopts.h
+++ b/ports/renesas-ra/lwip_inc/lwipopts.h
@@ -1,45 +1,8 @@
 #ifndef MICROPY_INCLUDED_RA_LWIP_LWIPOPTS_H
 #define MICROPY_INCLUDED_RA_LWIP_LWIPOPTS_H
 
-#include <stdint.h>
-
-// This protection is not needed, instead protect lwIP code with flags
-#define SYS_ARCH_DECL_PROTECT(lev) do { } while (0)
-#define SYS_ARCH_PROTECT(lev) do { } while (0)
-#define SYS_ARCH_UNPROTECT(lev) do { } while (0)
-
-#define NO_SYS                          1
-#define SYS_LIGHTWEIGHT_PROT            1
-#define MEM_ALIGNMENT                   4
-
-#define LWIP_CHKSUM_ALGORITHM           3
-#define LWIP_CHECKSUM_CTRL_PER_NETIF    1
-
-#define LWIP_ARP                        1
-#define LWIP_ETHERNET                   1
-#define LWIP_RAW                        1
-#define LWIP_NETCONN                    0
-#define LWIP_SOCKET                     0
-#define LWIP_STATS                      0
-#define LWIP_NETIF_HOSTNAME             1
-
 #define LWIP_IPV6                       0
-#define LWIP_DHCP                       1
-#define LWIP_DHCP_CHECK_LINK_UP         1
-#define LWIP_DHCP_DOES_ACD_CHECK        0 // to speed DHCP up
-#define LWIP_DNS                        1
-#define LWIP_DNS_SUPPORT_MDNS_QUERIES   1
-#define LWIP_MDNS_RESPONDER             1
-#define LWIP_IGMP                       1
 
-#define LWIP_NUM_NETIF_CLIENT_DATA      LWIP_MDNS_RESPONDER
-#define MEMP_NUM_UDP_PCB                (4 + LWIP_MDNS_RESPONDER)
-#define MEMP_NUM_SYS_TIMEOUT            (LWIP_NUM_SYS_TIMEOUT_INTERNAL + LWIP_MDNS_RESPONDER)
-
-#define SO_REUSE                        1
-#define TCP_LISTEN_BACKLOG              1
-
-extern uint32_t rng_read(void);
 #define LWIP_RAND() rng_read()
 
 #define MEM_SIZE                        (16 * 1024)
@@ -51,6 +14,9 @@ extern uint32_t rng_read(void);
 #define TCP_QUEUE_OOSEQ                 (1)
 #define MEMP_NUM_TCP_SEG                (2 * TCP_SND_QUEUELEN)
 
-typedef uint32_t sys_prot_t;
+// Include common lwIP configuration.
+#include "extmod/lwip-include/lwipopts_common.h"
+
+extern uint32_t rng_read(void);
 
 #endif // MICROPY_INCLUDED_RA_LWIP_LWIPOPTS_H

--- a/ports/rp2/lwip_inc/lwipopts.h
+++ b/ports/rp2/lwip_inc/lwipopts.h
@@ -1,28 +1,6 @@
 #ifndef MICROPY_INCLUDED_RP2_LWIP_LWIPOPTS_H
 #define MICROPY_INCLUDED_RP2_LWIP_LWIPOPTS_H
 
-#include "py/mpconfig.h"
-
-// This protection is not needed, instead protect lwIP code with flags
-#define SYS_ARCH_DECL_PROTECT(lev) do { } while (0)
-#define SYS_ARCH_PROTECT(lev) do { } while (0)
-#define SYS_ARCH_UNPROTECT(lev) do { } while (0)
-
-#define NO_SYS                          1
-#define SYS_LIGHTWEIGHT_PROT            1
-#define MEM_ALIGNMENT                   4
-
-#define LWIP_CHKSUM_ALGORITHM           3
-// The checksum flags are set in eth.c
-#define LWIP_CHECKSUM_CTRL_PER_NETIF    1
-
-#define LWIP_ARP                        1
-#define LWIP_ETHERNET                   1
-#define LWIP_RAW                        1
-#define LWIP_NETCONN                    0
-#define LWIP_SOCKET                     0
-#define LWIP_STATS                      0
-#define LWIP_NETIF_HOSTNAME             1
 #define LWIP_NETIF_EXT_STATUS_CALLBACK  1
 #define LWIP_NETIF_STATUS_CALLBACK      1
 
@@ -30,40 +8,12 @@
 #define LWIP_IPV6                       1
 #define LWIP_ND6_NUM_DESTINATIONS       4
 #define LWIP_ND6_QUEUEING               0
-#define LWIP_DHCP                       1
-#define LWIP_DHCP_CHECK_LINK_UP         1
-#define LWIP_DHCP_DOES_ACD_CHECK        0 // to speed DHCP up
-#define LWIP_DNS                        1
-#define LWIP_DNS_SUPPORT_MDNS_QUERIES   1
-#define LWIP_MDNS_RESPONDER             1
-#define LWIP_IGMP                       1
 
-#if MICROPY_PY_LWIP_PPP
-#define PPP_SUPPORT                     1
-#define PAP_SUPPORT                     1
-#define CHAP_SUPPORT                    1
-#endif
-
-#define LWIP_NUM_NETIF_CLIENT_DATA      LWIP_MDNS_RESPONDER
-#define MEMP_NUM_UDP_PCB                (4 + LWIP_MDNS_RESPONDER)
-#define MEMP_NUM_SYS_TIMEOUT            (LWIP_NUM_SYS_TIMEOUT_INTERNAL + LWIP_MDNS_RESPONDER)
-
-#define SO_REUSE                        1
-#define TCP_LISTEN_BACKLOG              1
-
-extern uint32_t rosc_random_u32(void);
 #define LWIP_RAND() rosc_random_u32()
 
-// lwip takes 26700 bytes
-#define MEM_SIZE (8000)
-#define TCP_MSS (800)
-#define TCP_WND (8 * TCP_MSS)
-#define TCP_SND_BUF (8 * TCP_MSS)
-#define MEMP_NUM_TCP_SEG (32)
+// Include common lwIP configuration.
+#include "extmod/lwip-include/lwipopts_common.h"
 
-typedef uint32_t sys_prot_t;
-
-// Needed for PPP.
-#define sys_jiffies sys_now
+extern uint32_t rosc_random_u32(void);
 
 #endif // MICROPY_INCLUDED_RP2_LWIP_LWIPOPTS_H

--- a/ports/stm32/lwip_inc/lwipopts.h
+++ b/ports/stm32/lwip_inc/lwipopts.h
@@ -1,89 +1,18 @@
 #ifndef MICROPY_INCLUDED_STM32_LWIP_LWIPOPTS_H
 #define MICROPY_INCLUDED_STM32_LWIP_LWIPOPTS_H
 
-#include "py/mpconfig.h"
-
-// This protection is not needed, instead we execute all lwIP code at PendSV priority
-#define SYS_ARCH_DECL_PROTECT(lev) do { } while (0)
-#define SYS_ARCH_PROTECT(lev) do { } while (0)
-#define SYS_ARCH_UNPROTECT(lev) do { } while (0)
-
-#define NO_SYS                          1
-#define SYS_LIGHTWEIGHT_PROT            1
-#define MEM_ALIGNMENT                   4
-
-#define LWIP_CHKSUM_ALGORITHM           3
-#define LWIP_CHECKSUM_CTRL_PER_NETIF    1
-
-#define LWIP_ARP                        1
-#define LWIP_ETHERNET                   1
-#define LWIP_RAW                        1
-#define LWIP_NETCONN                    0
-#define LWIP_SOCKET                     0
-#define LWIP_STATS                      0
-#define LWIP_NETIF_HOSTNAME             1
 #define LWIP_NETIF_EXT_STATUS_CALLBACK  1
 
 #define LWIP_LOOPIF_MULTICAST           1
 #define LWIP_LOOPBACK_MAX_PBUFS         8
 
 #define LWIP_IPV6                       0
-#define LWIP_DHCP                       1
-#define LWIP_DHCP_CHECK_LINK_UP         1
-#define LWIP_DHCP_DOES_ACD_CHECK        0 // to speed DHCP up
-#define LWIP_DNS                        1
-#define LWIP_DNS_SUPPORT_MDNS_QUERIES   1
-#define LWIP_MDNS_RESPONDER             1
-#define LWIP_IGMP                       1
 
-#if MICROPY_PY_LWIP_PPP
-#define PPP_SUPPORT                     1
-#define PAP_SUPPORT                     1
-#define CHAP_SUPPORT                    1
-#endif
-
-#define LWIP_NUM_NETIF_CLIENT_DATA      LWIP_MDNS_RESPONDER
-#define MEMP_NUM_UDP_PCB                (4 + LWIP_MDNS_RESPONDER)
-#define MEMP_NUM_SYS_TIMEOUT            (LWIP_NUM_SYS_TIMEOUT_INTERNAL + LWIP_MDNS_RESPONDER)
-
-#define SO_REUSE                        1
-#define TCP_LISTEN_BACKLOG              1
-
-extern uint32_t rng_get(void);
 #define LWIP_RAND() rng_get()
 
-// default
-// lwip takes 15800 bytes; TCP d/l: 380k/s local, 7.2k/s remote
-// TCP u/l is very slow
+// Include common lwIP configuration.
+#include "extmod/lwip-include/lwipopts_common.h"
 
-#if 0
-// lwip takes 19159 bytes; TCP d/l and u/l are around 320k/s on local network
-#define MEM_SIZE (5000)
-#define TCP_WND (4 * TCP_MSS)
-#define TCP_SND_BUF (4 * TCP_MSS)
-#endif
-
-#if 1
-// lwip takes 26700 bytes; TCP dl/ul are around 750/600 k/s on local network
-#define MEM_SIZE (8000)
-#define TCP_MSS (800)
-#define TCP_WND (8 * TCP_MSS)
-#define TCP_SND_BUF (8 * TCP_MSS)
-#define MEMP_NUM_TCP_SEG (32)
-#endif
-
-#if 0
-// lwip takes 45600 bytes; TCP dl/ul are around 1200/1000 k/s on local network
-#define MEM_SIZE (16000)
-#define TCP_MSS (1460)
-#define TCP_WND (8 * TCP_MSS)
-#define TCP_SND_BUF (8 * TCP_MSS)
-#define MEMP_NUM_TCP_SEG (32)
-#endif
-
-typedef uint32_t sys_prot_t;
-
-// Needed for PPP.
-#define sys_jiffies sys_now
+extern uint32_t rng_get(void);
 
 #endif // MICROPY_INCLUDED_STM32_LWIP_LWIPOPTS_H


### PR DESCRIPTION
### Summary

This lwIP configuration file has options that are common to all ports, and the ports are updated to use this file.  This change is a no-op, the lwIP configuration remains the same for the four ports using this common file.

This reduces code duplication, keeps the ports in sync, and makes it easier to update the configuration for all ports at once.

### Testing

For each port built a board with lwIP enabled: `RPI_PICO_W`, `PYBD_SF6`, `TEENSY41`, `ARDUINO_PORTENTA_C33`.  Built both before and after the commit in this PR.  Then compared the binary firmware.  The only things that changed in the binary were (1) the git commit hash in the version string; (2) the ordering of some of the pins in the `machine.Pin.board` dict (for some reason the order of these are not deterministic).  So I could conclude that the lwIP config changes are a no-op.

Edit: also built an stm32 board with PPP enabled and it builds.