### PR TITLE
Fix memory leak and logic bug with handling of _pio_funcs.

### DIFF
--- a/ports/rp2/modules/rp2.py
+++ b/ports/rp2/modules/rp2.py
@@ -215,22 +215,29 @@ _pio_funcs = {
     # "block": see above
     "clear": 0x40,
     "rel": lambda x: x | 0x10,
-    # functions
-    "wrap_target": None,
-    "wrap": None,
-    "label": None,
-    "word": None,
-    "nop": None,
-    "jmp": None,
-    "wait": None,
-    "in_": None,
-    "out": None,
-    "push": None,
-    "pull": None,
-    "mov": None,
-    "irq": None,
-    "set": None,
 }
+
+
+_pio_directives = (
+    "wrap_target",
+    "wrap",
+    "label",
+)
+
+
+_pio_instructions = (
+    "word",
+    "nop",
+    "jmp",
+    "wait",
+    "in_",
+    "out",
+    "push",
+    "pull",
+    "mov",
+    "irq",
+    "set",
+)
 
 
 def asm_pio(**kw):
@@ -239,25 +246,15 @@ def asm_pio(**kw):
     def dec(f):
         nonlocal emit
 
-        gl = _pio_funcs
-        gl["wrap_target"] = emit.wrap_target
-        gl["wrap"] = emit.wrap
-        gl["label"] = emit.label
-        gl["word"] = emit.word
-        gl["nop"] = emit.nop
-        gl["jmp"] = emit.jmp
-        gl["wait"] = emit.wait
-        gl["in_"] = emit.in_
-        gl["out"] = emit.out
-        gl["push"] = emit.push
-        gl["pull"] = emit.pull
-        gl["mov"] = emit.mov
-        gl["irq"] = emit.irq
-        gl["set"] = emit.set
+        gl = f.__globals__
+        old_gl = gl.copy()
+        gl.clear()
 
-        old_gl = f.__globals__.copy()
-        f.__globals__.clear()
-        f.__globals__.update(gl)
+        gl.update(_pio_funcs)
+        for name in _pio_directives:
+            gl[name] = getattr(emit, name)
+        for name in _pio_instructions:
+            gl[name] = getattr(emit, name)
 
         emit.start_pass(0)
         f()
@@ -265,8 +262,8 @@ def asm_pio(**kw):
         emit.start_pass(1)
         f()
 
-        f.__globals__.clear()
-        f.__globals__.update(old_gl)
+        gl.clear()
+        gl.update(old_gl)
 
         return emit.prog
 
@@ -284,19 +281,15 @@ def asm_pio_encode(instr, sideset_count, sideset_opt=False):
     emit.num_sideset = 0
 
     gl = _pio_funcs
-    gl["word"] = emit.word
-    gl["nop"] = emit.nop
-    # gl["jmp"] = emit.jmp currently not supported
-    gl["wait"] = emit.wait
-    gl["in_"] = emit.in_
-    gl["out"] = emit.out
-    gl["push"] = emit.push
-    gl["pull"] = emit.pull
-    gl["mov"] = emit.mov
-    gl["irq"] = emit.irq
-    gl["set"] = emit.set
+    for name in _pio_instructions:
+        gl[name] = getattr(emit, name)
+    gl["jmp"] = None  # emit.jmp currently not supported
 
-    exec(instr, gl)
+    try:
+        exec(instr, gl)
+    finally:
+        for name in _pio_instructions:
+            del gl[name]
 
     if len(emit.prog[_PROG_DATA]) != 1:
         raise PIOASMError("expecting exactly 1 instruction")


### PR DESCRIPTION
<!-- Thanks for submitting a Pull Request! We appreciate you spending the
     time to improve MicroPython. Please provide enough information so that
     others can review your Pull Request.

     Before submitting, please read:
     https://github.com/micropython/micropython/blob/master/CODEOFCONDUCT.md
     https://github.com/micropython/micropython/wiki/ContributorGuidelines

     Please check any CI failures that appear after your Pull Request is opened.
-->

### Summary

The rp2 port and package of the same name use a global dict (`_pio_funcs`) to populate a namespace for `@asm_pio` functions to be executed in.  That dict is not cleaned up after use, keeping references to bound methods of a `PIOASMEmit`.  By not setting/clearing all the functions, `asm_pio_encode` unintentionally allows the use of the old directives (harmless) as well as `jmp` (in general, produces the wrong output).

Note this PR is extracted from #16593 .

### Testing

Run any PIO example, eg https://github.com/micropython/micropython/blob/master/examples/rp2/pio_1hz.py, and then inspect `_pio_funcs`.  The bound methods can be seen before the fix:
```
>>> rp2._pio_funcs
{'in_': <bound_method>, 'y_dec': 4, 'pin': 6, 'iffull': 64, 'gpio': 0,
 'not_osre': 7, 'clear': 64, 'rel': <function <lambda> at 0x200043c0>,
 'wrap': <bound_method>, 'x_not_y': 5, 'word': <bound_method>,
 'out': <bound_method>, 'push': <bound_method>, 'noblock': 1,
 'pull': <bound_method>, 'wrap_target': <bound_method>, 'x_dec': 2,
 'mov': <bound_method>, 'irq': <bound_method>, 'set': <bound_method>,
 'y': 2, 'x': 1, 'null': 3, 'pc': 5,
 'invert': <function <lambda> at 0x200043a0>, 'pins': 0, 'not_x': 1,
 'not_y': 3, 'ifempty': 64, 'isr': 6, 'pindirs': 4, 'exec': 8,
 'label': <bound_method>, 'status': 5, 'nop': <bound_method>, 'osr': 7,
 'block': 33, 'reverse': <function <lambda> at 0x200043b0>,
 'jmp': <bound_method>, 'wait': <bound_method>}
```

Repeat with the fix, verifying the PIO program actually runs, inspect again:
```
>>> rp2._pio_funcs
{'in_': None, 'y_dec': 4, 'pin': 6, 'iffull': 64, 'gpio': 0, 'not_osre': 7,
 'clear': 64, 'rel': <function <lambda> at 0x200043c0>, 'wrap': None,
 'x_not_y': 5, 'word': None, 'out': None, 'push': None, 'noblock': 1,
 'pull': None, 'wrap_target': None, 'x_dec': 2, 'mov': None, 'irq': None,
 'set': None, 'y': 2, 'x': 1, 'null': 3, 'pc': 5,
 'invert': <function <lambda> at 0x200043a0>, 'pins': 0, 'not_x': 1,
 'not_y': 3, 'ifempty': 64, 'isr': 6, 'pindirs': 4, 'exec': 8, 'label': None,
 'status': 5, 'nop': None, 'osr': 7, 'block': 33,
 'reverse': <function <lambda> at 0x200043b0>, 'jmp': None, 'wait': None}
```


### Trade-offs and Alternatives

It's not clear why the `_pio_funcs` had these bound methods to start, maybe to save some RAM in `asm_pio_encode`?  `asm_pio` only uses `_pio_funcs` as a temporary to update another dict, the bound methods could easily be set there instead.
