### PR TITLE
parsenumbase: Favor clarity.

### DIFF
--- a/py/parsenumbase.c
+++ b/py/parsenumbase.c
@@ -41,11 +41,11 @@ size_t mp_parse_num_base(const char *str, size_t len, int *base) {
     if (c == '0') {
         c = *(p++) | 32;
         int b = *base;
-        if (c == 'x' && !(b & ~16)) {
+        if (c == 'x' && (b == 0 || b == 16)) {
             *base = 16;
-        } else if (c == 'o' && !(b & ~8)) {
+        } else if (c == 'o' && (b == 0 || b == 8)) {
             *base = 8;
-        } else if (c == 'b' && !(b & ~2)) {
+        } else if (c == 'b' && (b == 0 || b == 2)) {
             *base = 2;
         } else {
             p -= 2;


### PR DESCRIPTION
### Summary

In #13576 I optimized some code in parsenumbase for code size (using `!(b & ~16)` instead of `(b == 0 || b == 16)` for example. However, based on some testing on godbolt, this seems unnecessary for code size, at least on gcc x86_64 and arm, and it's definitely not good for clarity.

### Testing

Ran the Unix tests.

### Trade-offs and Alternatives

If any ports see code size increased with this change, then it's probably undesirable.