### PR TITLE
extmod/asyncio: Make SingletonGenerator create_task()-aware.

### DIFF
--- a/extmod/asyncio/core.py
+++ b/extmod/asyncio/core.py
@@ -49,6 +49,9 @@ class SingletonGenerator:
             self.exc.__traceback__ = None
             raise self.exc
 
+    def send(self, x):
+        self.__next__()
+
 
 # Pause task execution for the given time (integer in milliseconds, uPy extension)
 # Use a SingletonGenerator to do it without allocating on the heap


### PR DESCRIPTION
### Summary

This commit allows the awaitable returned by `asyncio.sleep/sleep_ms()` to be passed directly to `asyncio.create_task()`.

Although the documentation says that `sleep/sleep_ms()` are coroutines and `create_task()` accepts coroutines, this is not the case; `sleep/sleep_ms()` actually return a `SingletonGenerator()`, which is missing a `send()` method.

```
=== import asyncio
=== asyncio.run(asyncio.sleep_ms(2000))
===
Traceback (most recent call last):
  File "<stdin>", line 3, in <module>
  File "asyncio/core.py", line 1, in run
  File "asyncio/core.py", line 1, in create_task
TypeError: coroutine expected
```

This is easily solved by implementing the missing `send()` method.

### Testing

The principle is as follows:

```
=== import asyncio
=== from time import ticks_ms as ticks, ticks_add
===
=== class SingletonGenerator2(asyncio.SingletonGenerator):
===   def send(self, x):
===     self.__next__()
===
=== def sleep_ms(t, sgen=SingletonGenerator2()):
===   sgen.state = ticks_add(ticks(), max(0, t))
===   return sgen
===
=== asyncio.run(sleep_ms(2000))
===
>>>
```

### Trade-offs and Alternatives

In exchange for adding just two lines of source code and one method definition, we no longer have to manually `async def` wrap awaitables that wait for a specified time; the benefits are obvious.