### PR TITLE
ports/esp32: Allow overriding linker.lf.

### DIFF
--- a/ports/esp32/esp32_common.cmake
+++ b/ports/esp32/esp32_common.cmake
@@ -178,6 +178,13 @@ list(APPEND IDF_COMPONENTS
     vfs
 )
 
+# Provide the default LD fragment if not set
+if (MICROPY_USER_LDFRAGMENTS)
+    set(MICROPY_LDFRAGMENTS ${MICROPY_USER_LDFRAGMENTS})
+else()
+    set(MICROPY_LDFRAGMENTS linker.lf)
+endif()
+
 # Register the main IDF component.
 idf_component_register(
     SRCS
@@ -197,7 +204,7 @@ idf_component_register(
         ${MICROPY_BOARD_DIR}
         ${CMAKE_BINARY_DIR}
     LDFRAGMENTS
-        linker.lf
+        ${MICROPY_LDFRAGMENTS}
     REQUIRES
         ${IDF_COMPONENTS}
 )


### PR DESCRIPTION
Particularly for out of tree builds, we may need to provide alternative/extra linker fragment files.

In the default case, do nothing, provide a plain linker.lf, as before.


### Summary
Updated version of: 
https://github.com/micropython/micropython/pull/16013

Now handled in the shared cmake file.   The external/examples/out-of-tree builds can now choose at their leisure whether to include a local copy of the linker.lf files, provide a custom one, or refer to the existing in-tree one.

### Testing

Build testing for esp32 and esp32-s3 and comparing the sections.ld output, and verifying which files are searched for, by setting / un setting / setting invalid paths for the MICROPY_USER_LDFRAGMENTS


