### PR TITLE
docs: Note which ports have default or optional network.PPP support.

### DIFF
--- a/docs/library/network.PPP.rst
+++ b/docs/library/network.PPP.rst
@@ -5,7 +5,12 @@ class PPP -- create network connections over serial PPP
 =======================================================
 
 This class allows you to create a network connection over a serial port using
-the PPP protocol.  It is only available on selected ports and boards.
+the PPP protocol.
+
+.. note:: Currently only the esp32 port has PPP support enabled in the default
+          firmware build. PPP support can be enabled in custom builds of the
+          stm32 and rp2 ports by enabling networking support and setting
+          ``MICROPY_PY_NETWORK_PPP_LWIP`` to 1.
 
 Example usage::
 

--- a/ports/rp2/mpconfigport.h
+++ b/ports/rp2/mpconfigport.h
@@ -212,6 +212,10 @@
 #ifndef MICROPY_PY_WEBREPL
 #define MICROPY_PY_WEBREPL              (1)
 #endif
+
+#ifndef MICROPY_PY_NETWORK_PPP_LWIP
+#define MICROPY_PY_NETWORK_PPP_LWIP     (0)
+#endif
 #endif
 
 #if MICROPY_PY_NETWORK_CYW43

--- a/ports/stm32/mpconfigport.h
+++ b/ports/stm32/mpconfigport.h
@@ -146,14 +146,22 @@
 #define MICROPY_HW_SOFTSPI_MAX_BAUDRATE (HAL_RCC_GetSysClockFreq() / 48)
 #define MICROPY_PY_WEBSOCKET        (MICROPY_PY_LWIP)
 #define MICROPY_PY_WEBREPL          (MICROPY_PY_LWIP)
-#ifndef MICROPY_PY_SOCKET
-#define MICROPY_PY_SOCKET           (1)
-#endif
 #ifndef MICROPY_PY_NETWORK
 #define MICROPY_PY_NETWORK          (1)
 #endif
 #ifndef MICROPY_PY_ONEWIRE
 #define MICROPY_PY_ONEWIRE          (1)
+#endif
+
+// optional network features
+#if MICROPY_PY_NETWORK
+#ifndef MICROPY_PY_SOCKET
+#define MICROPY_PY_SOCKET           (1)
+#endif
+
+#ifndef MICROPY_PY_NETWORK_PPP_LWIP
+#define MICROPY_PY_NETWORK_PPP_LWIP     (0)
+#endif
 #endif
 
 // fatfs configuration used in ffconf.h


### PR DESCRIPTION
### Summary

Someone was asking on Discord why only esp32 had network.PPP support. This PR adds a note in the docs about availability on custom builds of stm32 and rp2 ports. It also adds the default values of these macros to the respective mpconfigport.h files, to improve discoverability.

### Testing

* Built stm32 port `PYBD_SF2` board with the new macro line changed to 1, verified build succeeded. It was also necessary to disable VFAT to save binary size.
* Built rp2 port `RPI_PICO_W` board with the new macro line changed to 1, verified build succeeded and it was possible to instantiate a `network.PPP` object.

### Trade-offs and Alternatives

* It's a bit fiddly to have these notes in the docs about piecemeal support, but it gives a better user experience than following the documentation and finding the support is missing.