### PR TITLE
wiznet: Use a pull-up on the interrupt line.

### DIFF
--- a/extmod/network_wiznet5k.c
+++ b/extmod/network_wiznet5k.c
@@ -234,6 +234,7 @@ static void wiznet5k_init(void) {
         #endif
 
         mp_hal_pin_input(wiznet5k_obj.pin_intn);
+        mp_hal_pin_config(wiznet5k_obj.pin_intn, GPIO_IN, MP_HAL_PIN_PULL_UP, 0);
         wiznet5k_config_interrupt(true);
     }
 


### PR DESCRIPTION
<!-- Thanks for submitting a Pull Request! We appreciate you spending the
     time to improve MicroPython. Please provide enough information so that
     others can review your Pull Request.

     Before submitting, please read:
     https://github.com/micropython/micropython/blob/master/CODEOFCONDUCT.md
     https://github.com/micropython/micropython/wiki/ContributorGuidelines

     Please check any CI failures that appear after your Pull Request is opened.
-->

### Summary

<!-- Explain the reason for making this change. What problem does the pull request
     solve, or what improvement does it add? Add links if relevant. -->
Without one, if there isn't an external pull-up on the board, the non-asserted state of the line is completed undefined. Since the interrupt condition is falling edge triggered, if the voltage of the INTn line is not considered above digital 0 when an interrupt occurs, then the interrupt is not triggered. But worse, the floating pin may be leading to over-servicing the interrupt when there is in fact no interrupt condition.

According to the schematics of the eval boards, there may not be a pull-up on the INTn line, so there should be one enabled on the MCU. If there is one additionally on the board, it's harmless to add an additional pull-up in the MCU.

- [W5100S-EVB-Pico](https://docs.wiznet.io/assets/images/w5100s-evb-pico_sch_v110-50b55eac13c594678a5c536a6d371111.jpg) does not have one
- [W5100S-EVB-Pico2](https://docs.wiznet.io/Product/iEthernet/W5100S/w5100s-evb-pico2#schematic-v10) does not have one
- [W5500-EVB-Pico](https://docs.wiznet.io/Product/iEthernet/W5500/w5500-evb-pico#schematic) has one
- [W5500-EVB-Pico2](https://docs.wiznet.io/Product/iEthernet/W5100S/w5100s-evb-pico2#schematic-v10) has one

Additionally, the [W5100S Datasheet](https://docs.wiznet.io/img/products/w5100s/w5100s-ds-v128e.pdf), page 14 indicates there is no internal pull-up on the INTn pin.


### Testing

<!-- Explain what testing you did, and on which boards/ports. If there are
     boards or ports that you couldn't test, please mention this here as well.

     If you leave this empty then your Pull Request may be closed. -->

I've been battling intermittent delays or what appears to be dropped packets with the W5100S for some time. This seems to finally resolve the issue.

### Trade-offs and Alternatives

<!-- If the Pull Request has some negative impact (i.e. increased code size)
     then please explain why you think the trade-off improvement is worth it.
     If you can think of alternative ways to do this, please explain that here too.

     Delete this heading if not relevant (i.e. small fixes) -->

Oddly, I don't see a HAL method to configure an input with a pull-up, so it looks like both function calls are needed?
