### PR TITLE
doc: Add documentation for SPI Ethernet devices on esp32 port.

### DIFF
--- a/docs/library/network.LAN.rst
+++ b/docs/library/network.LAN.rst
@@ -6,7 +6,7 @@ class LAN -- control an Ethernet module
 
 This class allows you to control the Ethernet interface. The PHY hardware type is board-specific.
 
-Example usage::
+Example usage, for a board with built-in LAN support::
 
     import network
     nic = network.LAN(0)
@@ -32,7 +32,7 @@ Constructors
      - *phy_addr* specifies the address of the PHY interface. As with *phy_type*, the hardwired value has
        to be used for most boards and that value is the default.
      - *ref_clk_mode* specifies, whether the data clock is provided by the Ethernet controller or
-       the PYH interface.
+       the PHY interface.
        The default value is the one that matches the board. If set to ``LAN.OUT`` or ``Pin.OUT``
        or ``True``, the clock is driven by the Ethernet controller, if set to ``LAN.IN``
        or ``Pin.IN`` or ``False``, the clock is driven by the PHY interface.
@@ -40,6 +40,9 @@ Constructors
    For example, with the Seeed Arch Mix board you can  use::
 
      nic = LAN(0, phy_type=LAN.PHY_LAN8720, phy_addr=1, ref_clk_mode=Pin.IN)
+
+   .. note:: On esp32 port the constructor requires different arguments. See
+             :ref:`esp32 port reference <esp32_network_lan>`.
 
 Methods
 -------

--- a/docs/library/network.WIZNET5K.rst
+++ b/docs/library/network.WIZNET5K.rst
@@ -9,6 +9,9 @@ the W5200 and W5500 chipsets.  The particular chipset that is supported
 by the firmware is selected at compile-time via the MICROPY_PY_NETWORK_WIZNET5K
 option.
 
+.. note:: The esp32 port also supports WIZnet W5500 chipsets, but this port
+          uses the :ref:`network.LAN interface <esp32_spi_ethernet>`.
+
 Example usage::
 
     import network


### PR DESCRIPTION
### Summary

This was inspired by some confusion on Discord about how to use WIZnet5K on ESP32.

As well as adding documentation for the SPI Ethernet "mode" of `network.LAN` on ESP32, this PR adds some cross-reference links between related network documentation pages.

*This work was funded through GitHub Sponsors.*

### Testing

* I set up an ESP32-S3 with a W5500 breakout and ran the sample code which has been added as part of the new doc section.

### Trade-offs and Alternatives

* We could try to move this documentation out of esp32 quickref and into the `network.LAN` doc, but I think it'll be even messier to do it that way.
