### PR TITLE
feature/optional_i2c_bus_id

### DIFF
--- a/ports/esp32/machine_i2c.c
+++ b/ports/esp32/machine_i2c.c
@@ -146,12 +146,11 @@ static void machine_hw_i2c_print(const mp_print_t *print, mp_obj_t self_in, mp_p
 }
 
 mp_obj_t machine_hw_i2c_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *all_args) {
-    MP_MACHINE_I2C_CHECK_FOR_LEGACY_SOFTI2C_CONSTRUCTION(n_args, n_kw, all_args);
 
     // Parse args
     enum { ARG_id, ARG_scl, ARG_sda, ARG_freq, ARG_timeout };
     static const mp_arg_t allowed_args[] = {
-        { MP_QSTR_id, MP_ARG_REQUIRED | MP_ARG_OBJ, {.u_obj = MP_OBJ_NULL} },
+        { MP_QSTR_id, MP_ARG_OBJ, {.u_obj = MP_OBJ_NULL} },
         { MP_QSTR_scl, MP_ARG_KW_ONLY | MP_ARG_OBJ, {.u_obj = MP_OBJ_NULL} },
         { MP_QSTR_sda, MP_ARG_KW_ONLY | MP_ARG_OBJ, {.u_obj = MP_OBJ_NULL} },
         { MP_QSTR_freq, MP_ARG_KW_ONLY | MP_ARG_INT, {.u_int = 400000} },
@@ -161,7 +160,15 @@ mp_obj_t machine_hw_i2c_make_new(const mp_obj_type_t *type, size_t n_args, size_
     mp_arg_parse_all_kw_array(n_args, n_kw, all_args, MP_ARRAY_SIZE(allowed_args), allowed_args, args);
 
     // Get I2C bus
-    mp_int_t i2c_id = mp_obj_get_int(args[ARG_id].u_obj);
+    // Bus ID - use I2C bus 0 as default
+    mp_int_t i2c_id = I2C_NUM_0;
+
+    // User provided a value?
+    if (args[ARG_id].u_obj != MP_OBJ_NULL) {
+        i2c_id = mp_obj_get_int(args[ARG_id].u_obj);
+    }
+
+    // Check if the I2C bus is valid
     if (!(I2C_NUM_0 <= i2c_id && i2c_id < I2C_NUM_MAX)) {
         mp_raise_msg_varg(&mp_type_ValueError, MP_ERROR_TEXT("I2C(%d) doesn't exist"), i2c_id);
     }

--- a/ports/rp2/machine_i2c.c
+++ b/ports/rp2/machine_i2c.c
@@ -97,7 +97,7 @@ static void machine_i2c_print(const mp_print_t *print, mp_obj_t self_in, mp_prin
 mp_obj_t machine_i2c_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *all_args) {
     enum { ARG_id, ARG_freq, ARG_scl, ARG_sda, ARG_timeout };
     static const mp_arg_t allowed_args[] = {
-        { MP_QSTR_id, MP_ARG_REQUIRED | MP_ARG_OBJ },
+        { MP_QSTR_id,  MP_ARG_OBJ, {.u_rom_obj = MP_ROM_NONE} },
         { MP_QSTR_freq, MP_ARG_INT, {.u_int = DEFAULT_I2C_FREQ} },
         { MP_QSTR_scl, MICROPY_I2C_PINS_ARG_OPTS | MP_ARG_KW_ONLY | MP_ARG_OBJ, {.u_rom_obj = MP_ROM_NONE} },
         { MP_QSTR_sda, MICROPY_I2C_PINS_ARG_OPTS | MP_ARG_KW_ONLY | MP_ARG_OBJ, {.u_rom_obj = MP_ROM_NONE} },
@@ -108,8 +108,20 @@ mp_obj_t machine_i2c_make_new(const mp_obj_type_t *type, size_t n_args, size_t n
     mp_arg_val_t args[MP_ARRAY_SIZE(allowed_args)];
     mp_arg_parse_all_kw_array(n_args, n_kw, all_args, MP_ARRAY_SIZE(allowed_args), allowed_args, args);
 
-    // Get I2C bus.
-    int i2c_id = mp_obj_get_int(args[ARG_id].u_obj);
+    // Bus ID - use the default I2C bus as default
+    #ifdef PICO_DEFAULT_I2C
+    int i2c_id = PICO_DEFAULT_I2C;
+    #else
+    // invalid value
+    int i2c_id = -1;
+    #endif
+
+    // User provide a value?
+    if (args[ARG_id].u_obj != mp_const_none){
+        i2c_id = mp_obj_get_int(args[ARG_id].u_obj);
+    }
+    
+    // Check if the I2C bus is valid
     if (i2c_id < 0 || i2c_id >= MP_ARRAY_SIZE(machine_i2c_obj)) {
         mp_raise_msg_varg(&mp_type_ValueError, MP_ERROR_TEXT("I2C(%d) doesn't exist"), i2c_id);
     }


### PR DESCRIPTION
### Summary

This pull request gives the option to not pass an I2C Bus ID when creating a machine I2C object on RP2 and ESP32. If the ID is not provided on RP2, the default bus ID (PICO_DEFAULT_I2C) is used. For ESP32, I2C_NUM_0  is used.  This would allow users on both platforms to simply declare an I2C object with machine.I2C() without passing any arguments, thus creating an object with the default I2C ID, SCL, and SDA. 

Our use case is a higher-level python driver that creates machine.I2C objects. We would like the driver to be portable to many different RP2 and ESP32 boards without having to explicitly specify these arguments. 

### Testing
Tested on RP2 with Raspberry Pi Pico W:

- Created machine.I2C object by passing no arguments to I2C(). Verified that it successfully could use the scan() method to detect a connected sensor.
- Exercised I2C object by using it with an example program performing reads and writes to a sensor.

Tested on ESP32 with [Sparkfun Thing Plus - ESP32 WROOM (Micro-B)](https://www.sparkfun.com/sparkfun-thing-plus-esp32-wroom-micro-b.html):

- Created machine.I2C object by passing no arguments to I2C(). Verified that it successfully could use the scan() method to detect a connected sensor.
- Exercised I2C object by using it with an example program performing reads and writes to a sensor.

### Trade-offs and Alternatives

- For ESP32, this required removal of the MP_MACHINE_I2C_CHECK_FOR_LEGACY_SOFTI2C_CONSTRUCTION() macro in machine_hw_i2c_make_new(). This macro would cause the I2C object to be created with an ID of -1 if not explicitly specified. This would cause a SoftwareI2C object to be created. Thus, this could break backwards compatibility for ESP32 if users have code where they don't specify the ID (or specify it as -1) and expect that to lead to creation of a SoftwareI2C object. However, this is a legacy construction and likely should be removed anyways. It is a more intuitive behavior for creation of an I2C object with no ID argument to get an I2C object with default ID rather than an entirely different SoftwareI2C object. 
- As with any default argument that is optionally supplied by a user, making it optional means that it may be more frequently overlooked. The default may sometimes be used when the user actually should look into it deeply enough to decide which ID/Bus they want to use.

