### PR TITLE
py/parsenum.c: reduce code footprint of mp_parse_num_float.

### DIFF
--- a/tests/float/float_parse.py
+++ b/tests/float/float_parse.py
@@ -31,6 +31,9 @@ print(float("1e-4294967301"))
 print(float("1e18446744073709551621"))
 print(float("1e-18446744073709551621"))
 
+# mantissa overflow while processing deferred trailing zeros
+print(float("10000000000000000000001"))
+
 # check small decimals are as close to their true value as possible
 for n in range(1, 10):
     print(float("0.%u" % n) == n / 10)


### PR DESCRIPTION
<!-- Thanks for submitting a Pull Request! We appreciate you spending the
     time to improve MicroPython. Please provide enough information so that
     others can review your Pull Request.

     Before submitting, please read:
     https://github.com/micropython/micropython/blob/master/CODEOFCONDUCT.md
     https://github.com/micropython/micropython/wiki/ContributorGuidelines

     Please check any CI failures that appear after your Pull Request is opened.
-->

### Summary

The existing mantissa parsing code uses a floating point variable to accumulate digits. 

Using an mp_float_uint_t variable instead, and casting to mp_float_t at the very end is more efficient and reduces code size. In some cases, it also improves the rounding behaviour as extra digits are taken into account by the int-to-float conversion code.

### Testing

<!-- Explain what testing you did, and on which boards/ports. If there are
     boards or ports that you couldn't test, please mention this here as well. -->

The new code was unit-tested using a small program generating 100'000 random mantissa and exponents, parsing the resulting number as a float and comparing the result to the value obtained via bigint arithmetic.
- when using `MICROPY_FLOAT_IMPL_DOUBLE`, with exponents between -200 and 200
  - the max relative error of the old code is around 5.7e-16
  - the max relative error of the new code is around 4.3e-16
  - CPython max relative error is around 3.6e-16
- when using `MICROPY_FLOAT_IMPL_FLOAT`, with exponents between -20 and 50
  - the max relative error of the old code is around 4.3e-7
  - the max relative error of the new code is around 2.4e-7

The code size reduction was observed on binaries built using gcc-arm-none-eabi-9-2019-q4-major

### Trade-offs and Alternatives

<!-- If the Pull Request has some negative impact (i.e. increased code size)
     then please explain why you think the trade-off improvement is worth it.
     If you can think of alternative ways to do this, please explain that here too.

     Delete this heading if not relevant (i.e. small fixes) -->

A further improvement in precision for positive exponents could be obtained by leveraging bigint arithmetic up to the computation of the final value:
```
        #if MICROPY_FLOAT_IMPL == MICROPY_FLOAT_IMPL_FLOAT
        mp_obj_t mant_obj = mp_obj_new_int_from_uint(mantissa);
        #else
        mp_obj_t mant_obj = mp_obj_new_int_from_ulonglong(mantissa);
        #endif
        mp_binary_op_t combine_op = MP_BINARY_OP_MULTIPLY;
        if (exp_val < 0) {
            combine_op = MP_BINARY_OP_TRUE_DIVIDE;
            exp_val = -exp_val;
        }
        mp_obj_t exp_obj = MP_OBJ_NEW_SMALL_INT(exp_val);
        mp_obj_t pow_obj = mp_binary_op(MP_BINARY_OP_POWER, MP_OBJ_NEW_SMALL_INT(10), exp_obj);
        mp_obj_t res_obj = mp_binary_op(combine_op, mant_obj, pow_obj);
        dec_val = mp_obj_get_float(res_obj);
```
This would however increase the code size, and cause dynamic object allocation in case the mantissa is larger then 9 digits or the absolute value of the exponent is bigger than 9, so this idea was dropped.