### PR TITLE
py/py.mk: Ignore USER_C_MODULES check when building mpy-cross.

### DIFF
--- a/py/mkrules.cmake
+++ b/py/mkrules.cmake
@@ -211,7 +211,7 @@ if(MICROPY_FROZEN_MANIFEST)
         endif()
         add_custom_command(
             OUTPUT ${MICROPY_MPYCROSS_DEPENDENCY}
-            COMMAND ${MICROPY_MAKE_EXECUTABLE} -C ${MICROPY_DIR}/mpy-cross
+            COMMAND ${MICROPY_MAKE_EXECUTABLE} -C ${MICROPY_DIR}/mpy-cross USER_C_MODULES=
         )
     endif()
 

--- a/py/mkrules.mk
+++ b/py/mkrules.mk
@@ -176,7 +176,7 @@ $(HEADER_BUILD):
 ifneq ($(MICROPY_MPYCROSS_DEPENDENCY),)
 # to automatically build mpy-cross, if needed
 $(MICROPY_MPYCROSS_DEPENDENCY):
-	$(MAKE) -C "$(abspath $(dir $@)..)"
+	$(MAKE) -C "$(abspath $(dir $@)..)" USER_C_MODULES=
 endif
 
 ifneq ($(FROZEN_DIR),)


### PR DESCRIPTION
### Summary

In https://github.com/micropython/micropython/pull/16021 I introduced a new makefile check when setting `USER_C_MODULES` to ensure the provided path exists.

This PR skips the check logic when building mpy-cross as it does not use this variable.

As issue with mpy-cross build failing due to the `USER_C_MODULES` check was first raised by @Gadgetoid in https://github.com/micropython/micropython/pull/16021#issuecomment-2498127602.

I (somewhat unfairly) dismissed this issue at the time, flagging that this variable shouldn't really be set for a mpy-cross build that doesn't use it.

This has come back to bite me however when working on an esp32 project which uses `USER_C_MODULES`.
I didn't realise previously that the esp32 cmake process automatically compiles mpy-cross to ensure that particular xtensa settings are included correctly.
When compiled this way, the variables (like `USER_C_MODULES`) from the target build environment automatically flow down to the `mpy-cross` dependency build. 

When the `USER_C_MODULES` path is provided as a relative path this will be incorrect / broken in the mpy-cross directory so the error is raised.

To avoid this problem entirely this PR skips the check when mpy-cross is being built.

### Testing

I have been building an esp32-s2 project using `USER_C_MODULES` which was failing due to the check raising an error during the automatic dependency build of mpy-cross.

The change from this PR fixed the issue.

An incorrect path still is detected by the check during the target build.

### Trade-offs and Alternatives

Alternatively the mpy-cross Makefile could explicitely test and clear this variable before including `py.mk` however I thought it might be cleaner to keep this related logic located in the one place. Happy to change it if requested however!

