### PR TITLE
esp32: Improve machine.SDCard support on newer chips

### DIFF
--- a/docs/esp32/quickref.rst
+++ b/docs/esp32/quickref.rst
@@ -747,7 +747,7 @@ See :ref:`machine.SDCard <machine.SDCard>`. ::
 
     import machine, os, vfs
 
-    # Slot 2 uses pins sck=18, cs=5, miso=19, mosi=23
+    # On original ESP32, slot 2 uses pins sck=18, cs=5, miso=19, mosi=23
     sd = machine.SDCard(slot=2)
     vfs.mount(sd, '/sd') # mount
 

--- a/docs/library/machine.SDCard.rst
+++ b/docs/library/machine.SDCard.rst
@@ -23,7 +23,8 @@ arguments that might need to be set in order to use either a non-standard slot
 or a non-standard pin assignment. The exact subset of arguments supported will
 vary from platform to platform.
 
-.. class:: SDCard(slot=1, width=1, cd=None, wp=None, sck=None, miso=None, mosi=None, cs=None, freq=20000000)
+.. class:: SDCard(slot=1, width=1, cd=None, wp=None, sck=None, miso=None, mosi=None,
+                  cs=None, cmd=None, data=None, freq=20000000)
 
     This class provides access to SD or MMC storage cards using either
     a dedicated SD/MMC interface hardware or through an SPI channel.
@@ -37,7 +38,8 @@ vary from platform to platform.
      - *slot* selects which of the available interfaces to use. Leaving this
        unset will select the default interface.
 
-     - *width* selects the bus width for the SD/MMC interface.
+     - *width* selects the bus width for the SD/MMC interface. This many data
+       pins must be connected to the SD card.
 
      - *cd* can be used to specify a card-detect pin.
 
@@ -51,7 +53,14 @@ vary from platform to platform.
 
      - *cs* can be used to specify an SPI chip select pin.
 
-     - *freq* selects the SD/MMC interface frequency in Hz (only supported on the ESP32).
+    The following additional parameters are only present on ESP32 port:
+
+     - *cmd* can be used to specify the SD CMD pin (ESP32-S3 only).
+
+     - *data* can be used to specify a list or tuple of SD data bus pins
+       (ESP32-S3 only).
+
+     - *freq* selects the SD/MMC interface frequency in Hz.
 
 Implementation-specific details
 -------------------------------
@@ -67,52 +76,106 @@ The standard PyBoard has just one slot. No arguments are necessary or supported.
 ESP32
 `````
 
-The ESP32 provides two channels of SD/MMC hardware and also supports
-access to SD Cards through either of the two SPI ports that are
-generally available to the user. As a result the *slot* argument can
-take a value between 0 and 3, inclusive. Slots 0 and 1 use the
-built-in SD/MMC hardware while slots 2 and 3 use the SPI ports. Slot 0
-supports 1, 4 or 8-bit wide access while slot 1 supports 1 or 4-bit
-access; the SPI slots only support 1-bit access.
+SD cards support access in both SD/MMC mode and the simpler (but slower) SPI
+mode. ESP32 and ESP32-S3 chips can access SD cards using either mode. SPI mode
+makes use of a `SPI` host peripheral, which cannot concurrently be used for
+something else.
 
-  .. note:: Slot 0 is used to communicate with on-board flash memory
-            on most ESP32 modules and so will be unavailable to the
-            user.
+The ``slot`` argument determines which mode is used. Different values are
+available on different chips:
 
-  .. note:: Most ESP32 modules that provide an SD card slot using the
-            dedicated hardware only wire up 1 data pin, so the default
-            value for *width* is 1.
+====== ================= ============ ========================
+Slot   Supported chips   Mode         Supported data width
+====== ================= ============ ========================
+0      ESP32-S3          SD/MMC       1, 4, or 8 bits.
+1      ESP32, ESP32-S3   SD/MMC       1 or 4 bits.
+2      ESP32, ESP32-S3   `SPI` (id=1) 1 bit.
+3      ESP32, ESP32-S3   `SPI` (id=0) 1 bit.
+====== ================= ============ ========================
 
-The pins used by the dedicated SD/MMC hardware are fixed. The pins
-used by the SPI hardware can be reassigned.
+.. note:: On the original ESP32, SDMMC slot 0 is unavailable as its pins are
+          used to communicate with on-board flash memory.
 
-  .. note:: If any of the SPI signals are remapped then all of the SPI
-            signals will pass through a GPIO multiplexer unit which
-            can limit the performance of high frequency signals. Since
-            the normal operating speed for SD cards is 40MHz this can
-            cause problems on some cards.
+.. note:: Most ESP32 modules that provide an SD card slot using the
+          dedicated hardware only wire up 1 data pin, so the default
+          value for ``width`` is 1.
 
-The default (and preferred) pin assignment are as follows:
+Additional details depend on which ESP32 family chip is in use:
 
-    ====== ====== ====== ====== ======
-    Slot   0      1      2      3
-    ------ ------ ------ ------ ------
-    Signal   Pin    Pin    Pin    Pin
-    ====== ====== ====== ====== ======
-    sck       6     14     18     14
-    cmd      11     15
-    cs                      5     15
-    miso                   19     12
-    mosi                   23     13
-    D0        7      2
-    D1        8      4
-    D2        9     12
-    D3       10     13
-    D4       16
-    D5       17
-    D6        5
-    D7       18
-    ====== ====== ====== ====== ======
+Original ESP32
+~~~~~~~~~~~~~~
+
+Pin assignments in SD/MMC mode are fixed on the original ESP32. When accessing a
+card in SPI mode, pins can be set to different values in the constructor.
+
+The default pin assignments are as follows:
+
+    ====== ====== ====== ====== ============
+    Slot   1      2      3      Can be set
+    ------ ------ ------ ------ ------------
+    Signal   Pin    Pin    Pin
+    ====== ====== ====== ====== ============
+    CLK      14                 No
+    CMD      15                 No
+    D0        2                 No
+    D1        4                 No
+    D2       12                 No
+    D3       13                 No
+    sck             18     14   Yes
+    cs               5     15   Yes
+    miso            19     12   Yes
+    mosi            23     13   Yes
+    ====== ====== ====== ====== ============
+
+The ``cd`` and ``wp`` pins are not fixed in either mode and default to disabled, unless set.
+
+ESP32-S3
+~~~~~~~~
+
+The ESP32-S3 chip allows pins to be set to different values for both SD/MMC and
+SPI mode access.
+
+If not set, default pin assignments are as follows:
+
+    ======== ====== ====== ====== ======
+    Slot     0      1      2      3
+    -------- ------ ------ ------ ------
+    Signal     Pin    Pin    Pin    Pin
+    ======== ====== ====== ====== ======
+    CLK      14     14
+    CMD      15     15
+    D0        2      2
+    D1        4      4
+    D2       12     12
+    D3       13     13
+    D4       33*
+    D5       34*
+    D6       35*
+    D7       36*
+    sck                    37*     14
+    cs                     34*     13
+    miso                   37*      2
+    mosi                   35*     15
+    ======== ====== ====== ====== ======
+
+.. note:: Slots 0 and 1 cannot both be in use at the same time.
+
+.. note:: Pins marked with an asterisk * in the table must be changed from the
+          default if the ESP32-S3 board is configured for Octal SPI Flash or
+          PSRAM.
+
+To access a card in SD/MMC mode, set ``slot`` parameter value 0 or 1 and
+parameters ``sck`` (for CLK), ``cmd`` and ``data`` as needed to assign pins. If
+the ``data`` argument is passed then it should be a list or tuple of data pins
+or pin numbers with length equal to the ``width`` argument. For example::
+
+    sd = SDCard(slot=0, width=4, sck=8, cmd=9, data=(10, 11, 12, 13))
+
+To access a card in SPI mode, set ``slot`` parameter value 2 or 3 and pass
+parameters ``sck``, ``cs``, ``miso``, ``mosi`` as needed to assign pins.
+
+In either mode the ``cd`` and ``wp`` pins default to disabled, unless set in the
+constructor.
 
 cc3200
 ``````

--- a/docs/library/machine.SDCard.rst
+++ b/docs/library/machine.SDCard.rst
@@ -77,24 +77,34 @@ ESP32
 `````
 
 SD cards support access in both SD/MMC mode and the simpler (but slower) SPI
-mode. ESP32 and ESP32-S3 chips can access SD cards using either mode. SPI mode
-makes use of a `SPI` host peripheral, which cannot concurrently be used for
-something else.
+mode.
+
+SPI mode makes use of a `SPI` host peripheral, which cannot concurrently be used
+for other SPI interactions.
 
 The ``slot`` argument determines which mode is used. Different values are
-available on different chips:
+supported on different chips:
 
-====== ================= ============ ========================
-Slot   Supported chips   Mode         Supported data width
-====== ================= ============ ========================
-0      ESP32-S3          SD/MMC       1, 4, or 8 bits.
-1      ESP32, ESP32-S3   SD/MMC       1 or 4 bits.
-2      ESP32, ESP32-S3   `SPI` (id=1) 1 bit.
-3      ESP32, ESP32-S3   `SPI` (id=0) 1 bit.
-====== ================= ============ ========================
+========== ======== ======== ============ ============
+Chip       Slot 0   Slot 1   Slot 2       Slot 3
+========== ======== ======== ============ ============
+ESP32               SD/MMC   SPI (id=1)   SPI (id=0)
+ESP32-C3                     SPI (id=0)
+ESP32-C6                     SPI (id=0)
+ESP32-S2                     SPI (id=1)   SPI (id=0)
+ESP32-S3   SD/MMC   SD/MMC   SPI (id=1)   SPI (id=0)
+========== ======== ======== ============ ============
 
-.. note:: On the original ESP32, SDMMC slot 0 is unavailable as its pins are
-          used to communicate with on-board flash memory.
+Different slots support different data bus widths (number of data pins):
+
+========== ========== =====================
+Slot       Type       Supported data widths
+========== ========== =====================
+0          SD/MMC     1, 4, 8
+1          SD/MMC     1, 4
+2          SPI        1
+3          SPI        1
+========== ========== =====================
 
 .. note:: Most ESP32 modules that provide an SD card slot using the
           dedicated hardware only wire up 1 data pin, so the default
@@ -105,8 +115,9 @@ Additional details depend on which ESP32 family chip is in use:
 Original ESP32
 ~~~~~~~~~~~~~~
 
-Pin assignments in SD/MMC mode are fixed on the original ESP32. When accessing a
-card in SPI mode, pins can be set to different values in the constructor.
+In SD/MMC mode (slot 1), pin assignments in SD/MMC mode are fixed on the
+original ESP32. The SPI mode slots (2 & 3) allow pins to be set to different
+values in the constructor.
 
 The default pin assignments are as follows:
 
@@ -176,6 +187,19 @@ parameters ``sck``, ``cs``, ``miso``, ``mosi`` as needed to assign pins.
 
 In either mode the ``cd`` and ``wp`` pins default to disabled, unless set in the
 constructor.
+
+Other ESP32 chips
+~~~~~~~~~~~~~~~~~
+
+Other ESP32 family chips do not have hardware SD/MMC host controllers and can
+only access SD cards in SPI mode.
+
+To access a card in SPI mode, set ``slot`` parameter value 2 or 3 and pass
+parameters ``sck``, ``cs``, ``miso``, ``mosi`` to assign pins.
+
+.. note:: ESP32-C3 and ESP32-C6 only have one available `SPI` bus, so the only
+          valid ``slot`` parameter value is 2. Using this bus for the SD card
+          will prevent also using it for :class:`machine.SPI`.
 
 cc3200
 ``````

--- a/ports/esp32/boards/ESP32_GENERIC_C3/mpconfigboard.h
+++ b/ports/esp32/boards/ESP32_GENERIC_C3/mpconfigboard.h
@@ -3,7 +3,5 @@
 #define MICROPY_HW_BOARD_NAME               "ESP32C3 module"
 #define MICROPY_HW_MCU_NAME                 "ESP32C3"
 
-#define MICROPY_HW_ENABLE_SDCARD            (0)
-
 // Enable UART REPL for modules that have an external USB-UART and don't use native USB.
 #define MICROPY_HW_ENABLE_UART_REPL         (1)

--- a/ports/esp32/boards/ESP32_GENERIC_C6/mpconfigboard.h
+++ b/ports/esp32/boards/ESP32_GENERIC_C6/mpconfigboard.h
@@ -3,7 +3,6 @@
 #define MICROPY_HW_BOARD_NAME               "ESP32C6 module"
 #define MICROPY_HW_MCU_NAME                 "ESP32C6"
 
-#define MICROPY_HW_ENABLE_SDCARD            (0)
 #define MICROPY_PY_MACHINE_I2S              (0)
 
 // Enable UART REPL for modules that have an external USB-UART and don't use native USB.

--- a/ports/esp32/boards/ESP32_GENERIC_S2/mpconfigboard.h
+++ b/ports/esp32/boards/ESP32_GENERIC_S2/mpconfigboard.h
@@ -2,7 +2,6 @@
 #define MICROPY_HW_MCU_NAME "ESP32S2"
 
 #define MICROPY_PY_BLUETOOTH (0)
-#define MICROPY_HW_ENABLE_SDCARD (0)
 
 // Enable UART REPL for modules that have an external USB-UART and don't use native USB.
 #define MICROPY_HW_ENABLE_UART_REPL         (1)

--- a/ports/esp32/boards/LOLIN_C3_MINI/mpconfigboard.h
+++ b/ports/esp32/boards/LOLIN_C3_MINI/mpconfigboard.h
@@ -2,8 +2,6 @@
 #define MICROPY_HW_MCU_NAME                 "ESP32-C3FH4"
 #define MICROPY_PY_NETWORK_HOSTNAME_DEFAULT "mpy-c3-mini"
 
-#define MICROPY_HW_ENABLE_SDCARD            (0)
-
 #define MICROPY_HW_I2C0_SCL                 (10)
 #define MICROPY_HW_I2C0_SDA                 (8)
 

--- a/ports/esp32/boards/LOLIN_S2_MINI/mpconfigboard.h
+++ b/ports/esp32/boards/LOLIN_S2_MINI/mpconfigboard.h
@@ -3,7 +3,6 @@
 #define MICROPY_PY_NETWORK_HOSTNAME_DEFAULT "mpy-s2-mini"
 
 #define MICROPY_PY_BLUETOOTH                (0)
-#define MICROPY_HW_ENABLE_SDCARD            (0)
 
 #define MICROPY_HW_I2C0_SCL                 (35)
 #define MICROPY_HW_I2C0_SDA                 (33)

--- a/ports/esp32/boards/LOLIN_S2_PICO/mpconfigboard.h
+++ b/ports/esp32/boards/LOLIN_S2_PICO/mpconfigboard.h
@@ -3,7 +3,6 @@
 #define MICROPY_PY_NETWORK_HOSTNAME_DEFAULT "mpy-s2-pico"
 
 #define MICROPY_PY_BLUETOOTH     (0)
-#define MICROPY_HW_ENABLE_SDCARD (0)
 
 #define MICROPY_HW_I2C0_SCL      (9)
 #define MICROPY_HW_I2C0_SDA      (8)

--- a/ports/esp32/boards/M5STACK_NANOC6/mpconfigboard.h
+++ b/ports/esp32/boards/M5STACK_NANOC6/mpconfigboard.h
@@ -1,7 +1,6 @@
 #define MICROPY_HW_BOARD_NAME    "M5Stack NanoC6"
 #define MICROPY_HW_MCU_NAME      "ESP32C6"
 
-#define MICROPY_HW_ENABLE_SDCARD (0)
 #define MICROPY_PY_MACHINE_I2S   (0)
 
 #define MICROPY_HW_I2C0_SCL      (1)

--- a/ports/esp32/boards/UM_FEATHERS2/mpconfigboard.h
+++ b/ports/esp32/boards/UM_FEATHERS2/mpconfigboard.h
@@ -3,7 +3,6 @@
 #define MICROPY_PY_NETWORK_HOSTNAME_DEFAULT "FeatherS2"
 
 #define MICROPY_PY_BLUETOOTH                (0)
-#define MICROPY_HW_ENABLE_SDCARD            (0)
 
 #define MICROPY_HW_I2C0_SCL (9)
 #define MICROPY_HW_I2C0_SDA (8)

--- a/ports/esp32/boards/UM_FEATHERS2NEO/mpconfigboard.h
+++ b/ports/esp32/boards/UM_FEATHERS2NEO/mpconfigboard.h
@@ -3,7 +3,6 @@
 #define MICROPY_PY_NETWORK_HOSTNAME_DEFAULT "FeatherS2-Neo"
 
 #define MICROPY_PY_BLUETOOTH                (0)
-#define MICROPY_HW_ENABLE_SDCARD            (0)
 
 #define MICROPY_HW_I2C0_SCL (9)
 #define MICROPY_HW_I2C0_SDA (8)

--- a/ports/esp32/boards/UM_TINYC6/mpconfigboard.h
+++ b/ports/esp32/boards/UM_TINYC6/mpconfigboard.h
@@ -1,7 +1,6 @@
 #define MICROPY_HW_BOARD_NAME    "Unexpected Maker TinyC6"
 #define MICROPY_HW_MCU_NAME      "ESP32C6"
 
-#define MICROPY_HW_ENABLE_SDCARD (0)
 #define MICROPY_PY_MACHINE_I2S   (0)
 
 #define MICROPY_HW_I2C0_SCL      (7)

--- a/ports/esp32/boards/UM_TINYS2/mpconfigboard.h
+++ b/ports/esp32/boards/UM_TINYS2/mpconfigboard.h
@@ -3,7 +3,6 @@
 #define MICROPY_PY_NETWORK_HOSTNAME_DEFAULT "TinyS2"
 
 #define MICROPY_PY_BLUETOOTH                (0)
-#define MICROPY_HW_ENABLE_SDCARD            (0)
 
 #define MICROPY_HW_I2C0_SCL (9)
 #define MICROPY_HW_I2C0_SDA (8)

--- a/ports/esp32/machine_sdcard.c
+++ b/ports/esp32/machine_sdcard.c
@@ -177,6 +177,10 @@ static mp_obj_t machine_sdcard_make_new(const mp_obj_type_t *type, size_t n_args
         ARG_mosi,
         ARG_sck,
         ARG_cs,
+        #if SOC_SDMMC_USE_GPIO_MATRIX
+        ARG_cmd,
+        ARG_data,
+        #endif
         ARG_freq,
     };
     static const mp_arg_t allowed_args[] = {
@@ -189,6 +193,11 @@ static mp_obj_t machine_sdcard_make_new(const mp_obj_type_t *type, size_t n_args
         { MP_QSTR_mosi,     MP_ARG_KW_ONLY | MP_ARG_OBJ, {.u_obj = mp_const_none} },
         { MP_QSTR_sck,      MP_ARG_KW_ONLY | MP_ARG_OBJ, {.u_obj = mp_const_none} },
         { MP_QSTR_cs,       MP_ARG_KW_ONLY | MP_ARG_OBJ, {.u_obj = mp_const_none} },
+        // Optional assignment of SDMMC interface pins, if host supports this
+        #if SOC_SDMMC_USE_GPIO_MATRIX
+        { MP_QSTR_cmd,      MP_ARG_KW_ONLY | MP_ARG_OBJ, {.u_obj = mp_const_none} },
+        { MP_QSTR_data,     MP_ARG_KW_ONLY | MP_ARG_OBJ, {.u_obj = mp_const_none} },
+        #endif
         // freq is valid for both SPI and SDMMC interfaces
         { MP_QSTR_freq,     MP_ARG_KW_ONLY | MP_ARG_INT, {.u_int = 20000000} },
     };
@@ -211,6 +220,11 @@ static mp_obj_t machine_sdcard_make_new(const mp_obj_type_t *type, size_t n_args
         arg_vals[ARG_miso].u_obj, arg_vals[ARG_mosi].u_obj,
         arg_vals[ARG_sck].u_obj, arg_vals[ARG_cs].u_obj);
 
+    #if SOC_SDMMC_USE_GPIO_MATRIX
+    DEBUG_printf("  cmd=%p, data=%p",
+        arg_vals[ARG_cmd].u_obj, arg_vals[ARG_data].u_obj);
+    #endif
+
     int slot_num = arg_vals[ARG_slot].u_int;
     if (slot_num < 0 || slot_num > 3) {
         mp_raise_ValueError(MP_ERROR_TEXT("slot number must be between 0 and 3 inclusive"));
@@ -221,6 +235,13 @@ static mp_obj_t machine_sdcard_make_new(const mp_obj_type_t *type, size_t n_args
     if (is_spi) {
         slot_num -= 2;
     }
+    // Verify valid argument combinations
+    #if SOC_SDMMC_USE_GPIO_MATRIX
+    if (is_spi && (arg_vals[ARG_cmd].u_obj != mp_const_none
+                   || arg_vals[ARG_data].u_obj != mp_const_none)) {
+        mp_raise_ValueError(MP_ERROR_TEXT("invalid config: SPI slot with SDMMC pin arguments"));
+    }
+    #endif
 
     DEBUG_printf("  Setting up host configuration");
 
@@ -306,6 +327,32 @@ static mp_obj_t machine_sdcard_make_new(const mp_obj_type_t *type, size_t n_args
         } else {
             mp_raise_ValueError(MP_ERROR_TEXT("width must be 1 or 4 (or 8 on slot 0)"));
         }
+
+        #if SOC_SDMMC_USE_GPIO_MATRIX
+        // Optionally configure all the SDMMC pins, if chip supports this
+        SET_CONFIG_PIN(slot_config, clk, ARG_sck); // reuse SPI SCK for CLK
+        SET_CONFIG_PIN(slot_config, cmd, ARG_cmd);
+        if (arg_vals[ARG_data].u_obj != mp_const_none) {
+            mp_obj_t *data_vals;
+            size_t data_len;
+            mp_obj_get_array(arg_vals[ARG_data].u_obj, &data_len, &data_vals);
+            if (data_len != width) {
+                mp_raise_msg_varg(&mp_type_ValueError, MP_ERROR_TEXT("data argument length must match width %d"), width);
+            }
+            slot_config.d0 = machine_pin_get_id(data_vals[0]);
+            if (width > 1) {
+                slot_config.d1 = machine_pin_get_id(data_vals[1]);
+                slot_config.d2 = machine_pin_get_id(data_vals[2]);
+                slot_config.d3 = machine_pin_get_id(data_vals[3]);
+            }
+            if (width == 8) {
+                slot_config.d4 = machine_pin_get_id(data_vals[4]);
+                slot_config.d5 = machine_pin_get_id(data_vals[5]);
+                slot_config.d6 = machine_pin_get_id(data_vals[6]);
+                slot_config.d7 = machine_pin_get_id(data_vals[7]);
+            }
+        }
+        #endif
 
         DEBUG_printf("  Calling init_slot()");
         check_esp_err(sdmmc_host_init_slot(self->host.slot, &slot_config));

--- a/ports/esp32/machine_sdcard.c
+++ b/ports/esp32/machine_sdcard.c
@@ -33,7 +33,9 @@
 
 #if MICROPY_HW_ENABLE_SDCARD
 
+#if SOC_SDMMC_HOST_SUPPORTED
 #include "driver/sdmmc_host.h"
+#endif
 #include "driver/sdspi_host.h"
 #include "sdmmc_cmd.h"
 #include "esp_log.h"
@@ -69,18 +71,34 @@ typedef struct _sdcard_obj_t {
 
 #define _SECTOR_SIZE(self) (self->card.csd.sector_size)
 
+// Number SPI buses available for firmware app (including for SD)
+#define NUM_SD_SPI_BUS (SOC_SPI_PERIPH_NUM - 1)
+
+#if CONFIG_IDF_TARGET_ESP32
+#define SD_SLOT_MIN 1
+#elif SOC_SDMMC_HOST_SUPPORTED
+#define SD_SLOT_MIN 0
+#else
+#define SD_SLOT_MIN 2
+#endif
+#define SD_SLOT_MAX (NUM_SD_SPI_BUS + 1) // Inclusive
+
 // SPI bus default bus and device configuration.
 
-static const spi_bus_config_t spi_bus_defaults[2] = {
+static const spi_bus_config_t spi_bus_defaults[NUM_SD_SPI_BUS] = {
     {
         #if CONFIG_IDF_TARGET_ESP32
         .miso_io_num = GPIO_NUM_19,
         .mosi_io_num = GPIO_NUM_23,
         .sclk_io_num = GPIO_NUM_18,
-        #else
+        #elif CONFIG_IDF_TARGET_ESP32S3
         .miso_io_num = GPIO_NUM_36,
         .mosi_io_num = GPIO_NUM_35,
         .sclk_io_num = GPIO_NUM_37,
+        #else
+        .miso_io_num = GPIO_NUM_NC,
+        .mosi_io_num = GPIO_NUM_NC,
+        .sclk_io_num = GPIO_NUM_NC,
         #endif
         .data2_io_num = GPIO_NUM_NC,
         .data3_io_num = GPIO_NUM_NC,
@@ -92,6 +110,7 @@ static const spi_bus_config_t spi_bus_defaults[2] = {
         .flags = SPICOMMON_BUSFLAG_MASTER | SPICOMMON_BUSFLAG_SCLK | SPICOMMON_BUSFLAG_MISO | SPICOMMON_BUSFLAG_MOSI,
         .intr_flags = 0,
     },
+    #if NUM_SD_SPI_BUS > 1
     {
         .miso_io_num = GPIO_NUM_2,
         .mosi_io_num = GPIO_NUM_15,
@@ -106,28 +125,34 @@ static const spi_bus_config_t spi_bus_defaults[2] = {
         .flags = SPICOMMON_BUSFLAG_MASTER | SPICOMMON_BUSFLAG_SCLK | SPICOMMON_BUSFLAG_MISO | SPICOMMON_BUSFLAG_MOSI,
         .intr_flags = 0,
     },
+    #endif
 };
 
 #if CONFIG_IDF_TARGET_ESP32
-static const uint8_t spi_dma_channel_defaults[2] = {
+static const uint8_t spi_dma_channel_defaults[NUM_SD_SPI_BUS] = {
     2,
     1,
 };
 #endif
 
-static const sdspi_device_config_t spi_dev_defaults[2] = {
+static const sdspi_device_config_t spi_dev_defaults[NUM_SD_SPI_BUS] = {
+    #if NUM_SD_SPI_BUS > 1
     {
         #if CONFIG_IDF_TARGET_ESP32
         .host_id = VSPI_HOST,
         .gpio_cs = GPIO_NUM_5,
-        #else
+        #elif CONFIG_IDF_TARGET_ESP32S3
         .host_id = SPI3_HOST,
         .gpio_cs = GPIO_NUM_34,
+        #else
+        .host_id = SPI3_HOST,
+        .gpio_cs = GPIO_NUM_NC,
         #endif
         .gpio_cd = SDSPI_SLOT_NO_CD,
         .gpio_wp = SDSPI_SLOT_NO_WP,
         .gpio_int = SDSPI_SLOT_NO_INT,
     },
+    #endif
     SDSPI_DEVICE_CONFIG_DEFAULT(), // HSPI (ESP32) / SPI2 (ESP32S3)
 };
 
@@ -159,12 +184,15 @@ static esp_err_t sdcard_ensure_card_init(sdcard_card_obj_t *self, bool force) {
 // Expose the SD card or MMC as an object with the block protocol.
 
 // Create a new SDCard object
-// The driver supports either the host SD/MMC controller (default) or SPI mode
-// In both cases there are two "slots". Slot 0 on the SD/MMC controller is
-// typically tied up with the flash interface in most ESP32 modules but in
-// theory supports 1, 4 or 8-bit transfers. Slot 1 supports only 1 and 4-bit
-// transfers. Only 1-bit is supported on the SPI interfaces.
-// card = SDCard(slot=1, width=None, present_pin=None, wp_pin=None)
+//
+// SD/MMC or SPI mode is determined by the slot argument
+// 0,1 is SD/MMC mode where supported.
+// 2,3 is SPI mode where supported (1-bit only)
+//
+// Original ESP32 can't use 0
+// ESP32-C3/C6/etc can only use 2 (only one SPI bus, no SD/MMC controller)
+//
+// Consult machine.SDCard docs for more details.
 
 static mp_obj_t machine_sdcard_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *args) {
     // check arguments
@@ -183,8 +211,13 @@ static mp_obj_t machine_sdcard_make_new(const mp_obj_type_t *type, size_t n_args
         #endif
         ARG_freq,
     };
+    #if SOC_SDMMC_HOST_SUPPORTED
+    static const int DEFAULT_SLOT = 1;
+    #else
+    static const int DEFAULT_SLOT = SD_SLOT_MAX;
+    #endif
     static const mp_arg_t allowed_args[] = {
-        { MP_QSTR_slot,     MP_ARG_KW_ONLY | MP_ARG_INT, {.u_int = 1} },
+        { MP_QSTR_slot,     MP_ARG_KW_ONLY | MP_ARG_INT, {.u_int = DEFAULT_SLOT} },
         { MP_QSTR_width,    MP_ARG_KW_ONLY | MP_ARG_INT, {.u_int = 1} },
         { MP_QSTR_cd,       MP_ARG_KW_ONLY | MP_ARG_OBJ, {.u_obj = mp_const_none} },
         { MP_QSTR_wp,       MP_ARG_KW_ONLY | MP_ARG_OBJ, {.u_obj = mp_const_none} },
@@ -226,20 +259,33 @@ static mp_obj_t machine_sdcard_make_new(const mp_obj_type_t *type, size_t n_args
     #endif
 
     int slot_num = arg_vals[ARG_slot].u_int;
-    if (slot_num < 0 || slot_num > 3) {
-        mp_raise_ValueError(MP_ERROR_TEXT("slot number must be between 0 and 3 inclusive"));
+    if (slot_num < SD_SLOT_MIN || slot_num > SD_SLOT_MAX) {
+        mp_raise_ValueError(MP_ERROR_TEXT("invalid slot number"));
     }
 
+    #if SOC_SDMMC_HOST_SUPPORTED
     // Slots 0 and 1 are native SD/MMC, slots 2 and 3 are SPI
     bool is_spi = (slot_num >= 2);
+    #else
+    bool is_spi = true;
+    #endif
     if (is_spi) {
         slot_num -= 2;
+        assert(slot_num < NUM_SD_SPI_BUS);
     }
+
     // Verify valid argument combinations
     #if SOC_SDMMC_USE_GPIO_MATRIX
     if (is_spi && (arg_vals[ARG_cmd].u_obj != mp_const_none
                    || arg_vals[ARG_data].u_obj != mp_const_none)) {
         mp_raise_ValueError(MP_ERROR_TEXT("invalid config: SPI slot with SDMMC pin arguments"));
+    }
+    #endif
+    #if SOC_SDMMC_HOST_SUPPORTED
+    if (!is_spi && (arg_vals[ARG_miso].u_obj != mp_const_none
+                    || arg_vals[ARG_mosi].u_obj != mp_const_none
+                    || arg_vals[ARG_cs].u_obj != mp_const_none)) {
+        mp_raise_ValueError(MP_ERROR_TEXT("invalid config: SDMMC slot with SPI pin arguments"));
     }
     #endif
 
@@ -253,21 +299,17 @@ static mp_obj_t machine_sdcard_make_new(const mp_obj_type_t *type, size_t n_args
     if (is_spi) {
         sdmmc_host_t _temp_host = SDSPI_HOST_DEFAULT();
         _temp_host.max_freq_khz = freq / 1000;
+        // SPI SDMMC sets the slot to the SPI host ID
+        _temp_host.slot = spi_dev_defaults[slot_num].host_id;
         self->host = _temp_host;
-    } else {
+    }
+    #if SOC_SDMMC_HOST_SUPPORTED
+    else {
         sdmmc_host_t _temp_host = SDMMC_HOST_DEFAULT();
         _temp_host.max_freq_khz = freq / 1000;
         self->host = _temp_host;
     }
-
-    if (is_spi) {
-        // Needs to match spi_dev_defaults above.
-        #if CONFIG_IDF_TARGET_ESP32
-        self->host.slot = slot_num ? HSPI_HOST : VSPI_HOST;
-        #else
-        self->host.slot = slot_num ? SPI2_HOST : SPI3_HOST;
-        #endif
-    }
+    #endif
 
     DEBUG_printf("  Calling host.init()");
 
@@ -294,6 +336,15 @@ static mp_obj_t machine_sdcard_make_new(const mp_obj_type_t *type, size_t n_args
         SET_CONFIG_PIN(dev_config, gpio_cd, ARG_cd);
         SET_CONFIG_PIN(dev_config, gpio_wp, ARG_wp);
 
+        // On chips other than original ESP32 and S3, there are not
+        // always default SPI pins assigned
+        if (dev_config.gpio_cs == GPIO_NUM_NC
+            || bus_config.miso_io_num == GPIO_NUM_NC
+            || bus_config.mosi_io_num == GPIO_NUM_NC
+            || bus_config.sclk_io_num == GPIO_NUM_NC) {
+            mp_raise_ValueError(MP_ERROR_TEXT("SPI pin values required"));
+        }
+
         DEBUG_printf("  Calling spi_bus_initialize()");
         check_esp_err(spi_bus_initialize(spi_host_id, &bus_config, dma_channel));
 
@@ -309,7 +360,9 @@ static mp_obj_t machine_sdcard_make_new(const mp_obj_type_t *type, size_t n_args
             spi_bus_free(spi_host_id);
             mp_raise_ValueError(MP_ERROR_TEXT("SPI bus already in use"));
         }
-    } else {
+    }
+    #if SOC_SDMMC_HOST_SUPPORTED
+    else {
         // SD/MMC interface
         DEBUG_printf("  Setting up SDMMC slot configuration");
         sdmmc_slot_config_t slot_config = SDMMC_SLOT_CONFIG_DEFAULT();
@@ -357,6 +410,7 @@ static mp_obj_t machine_sdcard_make_new(const mp_obj_type_t *type, size_t n_args
         DEBUG_printf("  Calling init_slot()");
         check_esp_err(sdmmc_host_init_slot(self->host.slot, &slot_config));
     }
+    #endif // SOC_SDMMC_HOST_SUPPORTED
 
     DEBUG_printf("  Returning new card object: %p", self);
     return MP_OBJ_FROM_PTR(self);


### PR DESCRIPTION
### Summary

Updating the esp32 port `machine.SDCard` support for other chips:

* Added support for configuring pins in SD/MMC mode on ESP32-S3. Closes #8514. Closes #16526.
* Added support for SDCard in SPI mode on ESP32-S2, C3 and C6. This is a little restrictive on C3 and C6 as they only have one available SPI bus, so can't use this and `machine.SPI` together. Have enabled on all boards by default (the code size impact is about 4KB).
* Explicitly disable slot 0 on original ESP32 (and document this). There are effectively zero ESP32 boards in the world that can use slot 0 for SDMMC.

*This work was funded through GitHub sponsors*

### TODO

* [x] Final docs pass
* ~~[ ] ESP32-S3 SDCard object should print the additonal pin config~~ *EDIT: Actually SDCard has no print support on esp32, so leaving this off.*

### Testing

Manual testing with SD card breakout module:

* [x] ESP32-S3 in SDMMC mode with custom pins.
* [x] ESP32-S3 in SPI mode on both hosts.
* [x] ESP32-C3 in SPI mode.
* [x] ESP32-C6 in SPI mode. 
* [x] ESP32-S2 in SPI mode on both hosts.
* [x] ESP32 in SDMMC and SPI modes.

~~Note that testing is easier if cherry-picking #16700 fix into the branch.~~

### Trade-offs and Alternatives

* Could drop the commit that enables SDCard on SPI-only chips if preferable, and update docs to suit. Although on balance I think it's still potentially useful.
