### PR TITLE
Stm32g4 timer20 interrupt

### DIFF
--- a/ports/stm32/stm32_it.c
+++ b/ports/stm32/stm32_it.c
@@ -775,6 +775,14 @@ void TIM17_FDCAN_IT1_IRQHandler(void) {
 }
 #endif
 
+#if defined(STM32G4)
+void TIM20_UP_IRQHandler(void) {
+    IRQ_ENTER(TIM20_UP_IRQn);
+    timer_irq_handler(20);
+    IRQ_EXIT(TIM20_UP_IRQn);
+}
+#endif
+
 #if defined(STM32H7)
 void TIM15_IRQHandler(void) {
     IRQ_ENTER(TIM15_IRQn);

--- a/ports/stm32/timer.c
+++ b/ports/stm32/timer.c
@@ -264,8 +264,8 @@ uint32_t timer_get_source_freq(uint32_t tim_id) {
     #else
 
     uint32_t source, clk_div;
-    if (tim_id == 1 || (8 <= tim_id && tim_id <= 11)) {
-        // TIM{1,8,9,10,11} are on APB2
+    if (tim_id == 1 || (8 <= tim_id && tim_id <= 11) || tim_id == 20) {
+        // TIM{1,8,9,10,11,20} are on APB2
         #if defined(STM32F0) || defined(STM32G0)
         source = HAL_RCC_GetPCLK1Freq();
         clk_div = RCC->CFGR & RCC_CFGR_PPRE;


### PR DESCRIPTION
### Summary

Attaching an callback to timer 20 on a STM32 G4 will cause the repl to lock up until reset. After fixing the callback issue, a base frequency issue showed up. Both should be solved with this PR.

### Testing
board: NUCLEO_G474RE
``` py
def timer20_cb(_):
   print('Hello!')

import pyb
timer20 = pyb.Timer(20)
timer20.init(freq=1,callback=timer20_cb)
```
Before: lockup.
After: Hello!...
