### PR TITLE
extmod/vfs_rom: Remove ability to create VfsRom from an address.

### DIFF
--- a/extmod/vfs_rom.c
+++ b/extmod/vfs_rom.c
@@ -198,15 +198,13 @@ static mp_obj_t vfs_rom_make_new(const mp_obj_type_t *type, size_t n_args, size_
     self->base.type = type;
     self->memory = args[0];
 
+    // Get the ROMFS memory region.
     mp_buffer_info_t bufinfo;
-    if (mp_get_buffer(self->memory, &bufinfo, MP_BUFFER_READ)) {
-        if (bufinfo.len < ROMFS_SIZE_MIN) {
-            mp_raise_OSError(MP_ENODEV);
-        }
-        self->filesystem = bufinfo.buf;
-    } else {
-        self->filesystem = (const uint8_t *)(uintptr_t)mp_obj_get_int_truncated(self->memory);
+    mp_get_buffer_raise(self->memory, &bufinfo, MP_BUFFER_READ);
+    if (bufinfo.len < ROMFS_SIZE_MIN) {
+        mp_raise_OSError(MP_ENODEV);
     }
+    self->filesystem = bufinfo.buf;
 
     // Verify it is a ROMFS.
     if (!(self->filesystem[0] == ROMFS_HEADER_BYTE0

--- a/tests/extmod/vfs_rom.py
+++ b/tests/extmod/vfs_rom.py
@@ -226,7 +226,8 @@ class TestEdgeCases(unittest.TestCase):
 class TestStandalone(TestBase):
     def test_constructor(self):
         self.assertIsInstance(vfs.VfsRom(self.romfs), vfs.VfsRom)
-        self.assertIsInstance(vfs.VfsRom(self.romfs_addr), vfs.VfsRom)
+        with self.assertRaises(TypeError):
+            vfs.VfsRom(self.romfs_addr)
 
     def test_mount(self):
         vfs.VfsRom(self.romfs).mount(True, False)


### PR DESCRIPTION
### Summary

`VfsRom` objects can currently be constructed from an address (a pointer to memory containing a ROMFS).  It's not necessary to support this mode of construction, which allows an arbitrary memory address to be specified and potentially allows invalid memory accesses.

Requiring an object with the buffer protocol is safer, and also means that the length of the region is always specified.  It also doesn't lose any generality because you can always create a buffer from an arbitrary memory region using `uctypes.bytearray_at`.

### Testing

Corresponding test updated, will run under CI.
