### PR TITLE
docs/library/espnow.rst: Clarify usage of the "rate" configuration key.

### DIFF
--- a/docs/library/espnow.rst
+++ b/docs/library/espnow.rst
@@ -164,11 +164,13 @@ Configuration
         wait forever. The timeout can also be provided as arg to
         `recv()`/`irecv()`/`recvinto()`.
 
-        *rate*: (ESP32 only, IDF>=4.3.0 only) Set the transmission speed for
+        *rate*: (ESP32 only) Set the transmission speed for
         ESPNow packets. Must be set to a number from the allowed numeric values
         in `enum wifi_phy_rate_t
-        <https://docs.espressif.com/projects/esp-idf/en/v4.4.1/esp32/
-        api-reference/network/esp_wifi.html#_CPPv415wifi_phy_rate_t>`_.
+        <https://docs.espressif.com/projects/esp-idf/en/v5.2.3/esp32/
+        api-reference/network/esp_wifi.html#_CPPv415wifi_phy_rate_t>`_. This
+        parameter is actually *write-only* due to ESP-IDF not providing any
+        means for querying the radio interface's rate parameter.
 
     .. data:: Returns:
 


### PR DESCRIPTION
### Summary

This PR adds a clarification for the ESPNow module's documentation regarding its "config" method.

The original documentation for that method could be interpreted as having all its configuration keys being able to be queried, but the "rate" configuration key is actually write-only due to ESP-IDF's lack of a way to retrieve that bit of information from the radio's configuration.  The documentation changes highlight the fact that said configuration key is actually write-only.

The reference to the rate configuration key being available from ESP-IDF 4.4.0 and onwards was removed as now all supported versions of ESP-IDF have support for setting the radio interface rate.  The link to the `wifi_phy_rate_t` enum was also updated to point to the latest version of the documentation for the v5.2 series.

This change was meant to prevent issues like #16499, where the documentation not being clear enough caused some confusion on the user's end w.r.t. LR mode setting.

### Testing

The discussion for #16499 should present the problem in question and it being solved with the bit of information that's now part of the PR.

As an aside, maybe the new PR template should be updated to let people know the "Testing" section may be optional for docs-only changes?