### PR TITLE
rp2: Fix build failure if threads are disabled.

### DIFF
--- a/py/mkrules.cmake
+++ b/py/mkrules.cmake
@@ -53,6 +53,15 @@ foreach(_arg ${MICROPY_CPP_DEF})
 endforeach()
 list(APPEND MICROPY_CPP_FLAGS ${MICROPY_CPP_FLAGS_EXTRA})
 
+# Include anything passed in via CFLAGS_EXTRA
+# in both MICROPY_CPP_FLAGS and CMAKE_C_FLAGS
+if(DEFINED ENV{CFLAGS_EXTRA})
+  set(CFLAGS_EXTRA $ENV{CFLAGS_EXTRA})
+  string(APPEND CMAKE_C_FLAGS " ${CFLAGS_EXTRA}")  # ... not a list
+  separate_arguments(CFLAGS_EXTRA)
+  list(APPEND MICROPY_CPP_FLAGS ${CFLAGS_EXTRA})  # ... a list
+endif()
+
 find_package(Python3 REQUIRED COMPONENTS Interpreter)
 
 target_sources(${MICROPY_TARGET} PRIVATE

--- a/tools/ci.sh
+++ b/tools/ci.sh
@@ -342,7 +342,8 @@ function ci_rp2_build {
     make ${MAKEOPTS} -C ports/rp2 BOARD=RPI_PICO2 submodules
     make ${MAKEOPTS} -C ports/rp2 BOARD=RPI_PICO2
     make ${MAKEOPTS} -C ports/rp2 BOARD=W5100S_EVB_PICO submodules
-    make ${MAKEOPTS} -C ports/rp2 BOARD=W5100S_EVB_PICO
+    # This build doubles as a build test for disabling threads in the config
+    make ${MAKEOPTS} -C ports/rp2 BOARD=W5100S_EVB_PICO CFLAGS_EXTRA=-DMICROPY_PY_THREAD=0
 
     # Test building ninaw10 driver and NIC interface.
     make ${MAKEOPTS} -C ports/rp2 BOARD=ARDUINO_NANO_RP2040_CONNECT submodules


### PR DESCRIPTION
### Summary

Regression in 3af006efb39ad0b7aa7c0401c93329b654bca617 meant that pendsv.c no longer compiled if threads were disabled in the build config. Add an implementation based on the earlier one (simple counter) for the non-threads case.

To add CI coverage for future breakage of this kind, Damien suggested building one of the boards in CI with threads disabled. To support this, I've added support for the `CFLAGS_EXTRA` environment variable in CMake-based ports, similar to other ports (with caveat that it only applies to clean builds).

Closes #16720

*This work was funded through GitHub Sponsors.*

### Testing

* Built `RPI_PICO` default config before and after this change, disassembled with `arm-none-eabi-objdump -d`, and diffed the output to confirm no binary changes.
* Built `RPI_PICO` with `MICROPY_PY_THREAD` defined to 0, confirmed unit tests all pass (except for threads tests).
* Pushed a temporary commit d78f558 to check that the rp2 CI build is applying the config correctly. ([Confirmed](https://github.com/micropython/micropython/actions/runs/13257398311/job/37006503860?pr=16733))

### Trade-offs and Alternatives

* I originally implemented the new counter using atomic increment/decrement, but looking at the usage patterns I couldn't see a reason for this if there's no contention from the second core or multiple threads. Any interrupt handler should exit with the counter at the same value that it was when entering.
* Feels kind of hacky to be making a custom config just for CI, but there's no boards in MicroPython that depend on not having thread support.