### PR TITLE
esp32/espnow: Add support for espnow v2.0.

### DIFF
--- a/docs/library/espnow.rst
+++ b/docs/library/espnow.rst
@@ -32,23 +32,42 @@ ESP-NOW is a connection-less wireless communication protocol supporting:
 
 - Direct communication between up to 20 registered peers:
 
-  - Without the need for a wireless access point (AP),
+- Without the need for a wireless access point (AP),
 
 - Encrypted and unencrypted communication (up to 6 encrypted peers),
 
-- Message sizes up to 250 bytes,
+- Message sizes up to 1470 bytes (For ESP-NOW v2),
 
-- Can operate alongside Wifi operation (:doc:`network.WLAN<network.WLAN>`) on
+- Can operate alongside Wi-Fi operation (:doc:`network.WLAN<network.WLAN>`) on
   ESP32 and ESP8266 devices.
+
+- Track the Wi-Fi signal strength (RSSI) of ESP-NOW peer devices.
 
 It is especially useful for small IoT networks, latency sensitive or power
 sensitive applications (such as battery operated devices) and for long-range
 communication between devices (hundreds of metres).
 
-This module also supports tracking the Wifi signal strength (RSSI) of peer
-devices.
+ESP-NOW Versions
+~~~~~~~~~~~~~~~~
 
-A simple example would be:
+Since ESP-IDF V5.4, two ESP-NOW versions are supported when running on ESP32:
+V1 and V2.
+
+- The maximum packet length supported by V2 devices is 1470 bytes
+- The maximum packet length supported by V1 devices is 250 bytes.
+
+To check at runtime whether ESP-NOW V2 is available, check the value of
+`espnow.MAX_DATA_LEN`.
+
+ESP-NOW V2 devices are capable of receiving packets from both V2 and V1 devices.
+
+ESP-NOW V1 devices (including ESP8266) can receive packets from other V1
+devices, or from V2 devices if the packet length doesn't exceed 250 bytes. For
+packets exceeding this length, a V1 device will either truncate the data to the
+first 250 bytes or discard the packet entirely.
+
+Example
+~~~~~~~
 
 **Sender:** ::
 
@@ -148,23 +167,26 @@ Configuration
 
     .. data:: Options:
 
-        *rxbuf*: (default=526) Get/set the size in bytes of the internal
-        buffer used to store incoming ESPNow packet data. The default size is
-        selected to fit two max-sized ESPNow packets (250 bytes) with associated
-        mac_address (6 bytes), a message byte count (1 byte) and RSSI data plus
+        *rxbuf*: (default=528 or 2972) Get/set the size in bytes of the internal
+        buffer used to store incoming ESP-NOW packet data. The default size is
+        selected to fit two max-sized ESP-NOW packets (250 or 1470 bytes) with associated
+        mac_address (6 bytes), a message byte count (2 byte) and RSSI data plus
         buffer overhead. Increase this if you expect to receive a lot of large
         packets or expect bursty incoming traffic.
 
-        **Note:** The recv buffer is allocated by `ESPNow.active()`. Changing
-        this value will have no effect until the next call of
-        `ESPNow.active(True)<ESPNow.active()>`.
+        .. note:: If only using ESP-NOW V1 packets and low throughput, recommend
+                  setting ``rxbuf=528`` here to reduce memory overhead.
 
-        *timeout_ms*: (default=300,000) Default timeout (in milliseconds)
-        for receiving ESPNow messages. If *timeout_ms* is less than zero, then
+        .. note:: The recv buffer is allocated by `ESPNow.active()`. Changing
+                  this value will have no effect until the next call of
+                  `ESPNow.active(True)<ESPNow.active()>`.
+
+        *timeout_ms*: (default=300_000) Default timeout (in milliseconds)
+        for receiving ESP-NOW messages. If *timeout_ms* is less than zero, then
         wait forever. The timeout can also be provided as arg to
         `recv()`/`irecv()`/`recvinto()`.
 
-        *rate*: (ESP32 only) Set the transmission data rate for ESPNow packets.
+        *rate*: (ESP32 only) Set the transmission data rate for ESP-NOW packets.
         The default setting is `espnow.RATE_1M`. It's recommended to use one of
         the other ``espnow.RATE_nnn`` constants to set this, but it's also
         possible to pass an integer corresponding to the `enum wifi_phy_rate_t
@@ -214,12 +236,12 @@ after reboot/reset). This reduces the reliability of receiving ESP-NOW messages
 
     .. data:: Arguments:
 
-      - *mac*: byte string exactly ``espnow.ADDR_LEN`` (6 bytes) long or
+      - *mac*: byte string exactly `espnow.ADDR_LEN` (6 bytes) long or
         ``None``. If *mac* is ``None`` (ESP32 only) the message will be sent
         to all registered peers, except any broadcast or multicast MAC
         addresses.
 
-      - *msg*: string or byte-string up to ``espnow.MAX_DATA_LEN`` (250)
+      - *msg*: string or byte-string up to `espnow.MAX_DATA_LEN` (250 or 1470)
         bytes long.
 
       - *sync*:
@@ -327,10 +349,10 @@ after reboot/reset). This reduces the reliability of receiving ESP-NOW messages
     .. data:: Arguments:
 
         *data*: A list of at least two elements, ``[peer, msg]``. ``msg`` must
-        be a bytearray large enough to hold the message (250 bytes). On the
-        ESP8266, ``peer`` should be a bytearray of 6 bytes. The MAC address of
-        the sender and the message will be stored in these bytearrays (see Note
-        on ESP32 below).
+        be a bytearray large enough to hold the received message (recommended at
+        least `espnow.MAX_DATA_LEN`). On the ESP8266, ``peer`` should be a
+        bytearray of 6 bytes. The MAC address of the sender and the message will
+        be stored in these bytearrays (see Note on ESP32 below).
 
         *timeout_ms*: (Optional) Timeout in milliseconds (see `ESPNow.recv()`).
 
@@ -342,6 +364,10 @@ after reboot/reset). This reduces the reliability of receiving ESP-NOW messages
     .. data:: Raises:
 
       - See `ESPNow.recv()`.
+
+      - This function will also raise a ``ValueError`` if the received message
+        is too large for the provided buffer. If this error is raised, received
+        message(s) will be lost.
 
     **Note:** On the ESP32:
 
@@ -570,7 +596,7 @@ Callback Methods
 Constants
 ---------
 
-.. data:: espnow.MAX_DATA_LEN(=250)
+.. data:: espnow.MAX_DATA_LEN(=250 or 1470 for ESPNow V1 or V2)
           espnow.KEY_LEN(=16)
           espnow.ADDR_LEN(=6)
           espnow.MAX_TOTAL_PEER_NUM(=20)

--- a/ports/esp32/modespnow.c
+++ b/ports/esp32/modespnow.c
@@ -62,6 +62,16 @@
 #define MICROPY_PY_ESPNOW_EXTRA_PEER_METHODS 1
 #endif
 
+// Set maximum possible data length based on IDF version
+// TODO Delete this after dropping support for IDF < 5.4
+#if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(5, 4, 0)
+#define ESP_NOW_MAX_POSSIBLE_DATA_LEN ESP_NOW_MAX_DATA_LEN_V2
+#else
+#define ESP_NOW_MAX_POSSIBLE_DATA_LEN ESP_NOW_MAX_DATA_LEN
+#endif
+
+#define MAX_DATA_LEN_V1 ESP_NOW_MAX_DATA_LEN
+
 // Relies on gcc Variadic Macros and Statement Expressions
 #define NEW_TUPLE(...) \
     ({mp_obj_t _z[] = {__VA_ARGS__}; mp_obj_new_tuple(MP_ARRAY_SIZE(_z), _z); })
@@ -72,7 +82,7 @@ static const uint8_t ESPNOW_MAGIC = 0x99;
 // Use this for peeking at the header of the next packet in the buffer.
 typedef struct {
     uint8_t magic;              // = ESPNOW_MAGIC
-    uint8_t msg_len;            // Length of the message
+    uint16_t msg_len;            // Length of the message
     #if MICROPY_PY_ESPNOW_RSSI
     uint32_t time_ms;           // Timestamp (ms) when packet is received
     int8_t rssi;                // RSSI value (dBm) (-127 to 0)
@@ -82,15 +92,16 @@ typedef struct {
 typedef struct {
     espnow_hdr_t hdr;           // The header
     uint8_t peer[6];            // Peer address
-    uint8_t msg[0];             // Message is up to 250 bytes
+    uint8_t msg[0];             // Message is up to 250 or 1470 bytes
 } __attribute__((packed)) espnow_pkt_t;
 
 // The maximum length of an espnow packet (bytes)
 static const size_t MAX_PACKET_LEN = (
-    (sizeof(espnow_pkt_t) + ESP_NOW_MAX_DATA_LEN));
+    (sizeof(espnow_pkt_t) + ESP_NOW_MAX_POSSIBLE_DATA_LEN));
 
-// Enough for 2 full-size packets: 2 * (6 + 7 + 250) = 526 bytes
-// Will allocate an additional 7 bytes for buffer overhead
+// Enough for 2 full-size packets:
+// V1.0: 2 * (6 + 8 + 250) = 528 bytes (keeping this default for compatibility)
+// V2.0: 2 * (6 + 8 + 1470) = 2972 bytes
 static const size_t DEFAULT_RECV_BUFFER_SIZE = (2 * MAX_PACKET_LEN);
 
 // Default timeout (millisec) to wait for incoming ESPNow messages (5 minutes).
@@ -381,9 +392,11 @@ static uint8_t *_get_bytes_len(mp_obj_t obj, size_t len) {
     return _get_bytes_len_rw(obj, len, MP_BUFFER_READ);
 }
 
+#if !MICROPY_PY_ESPNOW_RSSI
 static uint8_t *_get_bytes_len_w(mp_obj_t obj, size_t len) {
     return _get_bytes_len_rw(obj, len, MP_BUFFER_WRITE);
 }
+#endif
 
 // Return C pointer to the MAC address.
 // Raise ValueError if mac_addr is wrong type or is not 6 bytes long.
@@ -412,7 +425,7 @@ static int ringbuf_get_bytes_wait(ringbuf_t *r, uint8_t *data, size_t len, mp_in
 // Arguments:
 //      buffers: (Optional) list of bytearrays to store return values.
 //      timeout_ms: (Optional) timeout in milliseconds (or None).
-// Buffers should be a list: [bytearray(6), bytearray(250)]
+// Buffers should be a list: [bytearray(6), bytearray(250 or 1470)]
 // If buffers is 4 elements long, the rssi and timestamp values will be
 // loaded into the 3rd and 4th elements.
 // Default timeout is set with ESPNow.config(timeout=milliseconds).
@@ -425,6 +438,7 @@ static mp_obj_t espnow_recvinto(size_t n_args, const mp_obj_t *args) {
 
     mp_obj_list_t *list = mp_obj_list_ensure(args[1], 2);
     mp_obj_array_t *msg = MP_OBJ_TO_PTR(list->items[1]);
+    mp_buffer_info_t msg_buf;
     if (mp_obj_is_type(msg, &mp_type_bytearray)) {
         msg->len += msg->free;   // Make all the space in msg array available
         msg->free = 0;
@@ -434,7 +448,8 @@ static mp_obj_t espnow_recvinto(size_t n_args, const mp_obj_t *args) {
     #else
     uint8_t *peer_buf = _get_bytes_len_w(list->items[0], ESP_NOW_ETH_ALEN);
     #endif // MICROPY_PY_ESPNOW_RSSI
-    uint8_t *msg_buf = _get_bytes_len_w(msg, ESP_NOW_MAX_DATA_LEN);
+
+    mp_get_buffer_raise(msg, &msg_buf, MP_BUFFER_WRITE);
 
     // Read the packet header from the incoming buffer
     espnow_hdr_t hdr;
@@ -443,11 +458,13 @@ static mp_obj_t espnow_recvinto(size_t n_args, const mp_obj_t *args) {
     }
     int msg_len = hdr.msg_len;
 
-    // Check the message packet header format and read the message data
+    // Check the message packet header format, check the message will fit in the buffer,
+    // and then read the message data
     if (hdr.magic != ESPNOW_MAGIC
-        || msg_len > ESP_NOW_MAX_DATA_LEN
+        || msg_len > msg_buf.len
         || ringbuf_get_bytes(self->recv_buffer, peer_buf, ESP_NOW_ETH_ALEN) < 0
-        || ringbuf_get_bytes(self->recv_buffer, msg_buf, msg_len) < 0) {
+        || ringbuf_get_bytes(self->recv_buffer, msg_buf.buf, msg_len) < 0) {
+        ringbuf_reset(self->recv_buffer); // Prevent ringbuffer getting out of sync
         mp_raise_ValueError(MP_ERROR_TEXT("ESPNow.recv(): buffer error"));
     }
     if (mp_obj_is_type(msg, &mp_type_bytearray)) {
@@ -809,7 +826,7 @@ static MP_DEFINE_CONST_DICT(esp_espnow_locals_dict, esp_espnow_locals_dict_table
 static const mp_rom_map_elem_t espnow_globals_dict_table[] = {
     { MP_ROM_QSTR(MP_QSTR___name__), MP_ROM_QSTR(MP_QSTR__espnow) },
     { MP_ROM_QSTR(MP_QSTR_ESPNowBase), MP_ROM_PTR(&esp_espnow_type) },
-    { MP_ROM_QSTR(MP_QSTR_MAX_DATA_LEN), MP_ROM_INT(ESP_NOW_MAX_DATA_LEN)},
+    { MP_ROM_QSTR(MP_QSTR_MAX_DATA_LEN), MP_ROM_INT(ESP_NOW_MAX_POSSIBLE_DATA_LEN)},
     { MP_ROM_QSTR(MP_QSTR_ADDR_LEN), MP_ROM_INT(ESP_NOW_ETH_ALEN)},
     { MP_ROM_QSTR(MP_QSTR_KEY_LEN), MP_ROM_INT(ESP_NOW_KEY_LEN)},
     { MP_ROM_QSTR(MP_QSTR_MAX_TOTAL_PEER_NUM), MP_ROM_INT(ESP_NOW_MAX_TOTAL_PEER_NUM)},

--- a/ports/esp32/modespnow.c
+++ b/ports/esp32/modespnow.c
@@ -235,6 +235,8 @@ mp_obj_t espnow_deinit(mp_obj_t _) {
         check_esp_err(esp_now_unregister_recv_cb());
         check_esp_err(esp_now_unregister_send_cb());
         check_esp_err(esp_now_deinit());
+        self->recv_cb = mp_const_none;
+        self->recv_cb_arg = mp_const_none;
         self->recv_buffer->buf = NULL;
         self->recv_buffer = NULL;
         self->peer_count = 0; // esp_now_deinit() removes all peers.

--- a/py/ringbuf.h
+++ b/py/ringbuf.h
@@ -51,6 +51,11 @@ typedef struct _ringbuf_t {
         (r)->iget = (r)->iput = 0; \
     }
 
+static inline void ringbuf_reset(ringbuf_t *r) {
+    // Reset the ringbuffer to empty
+    r->iget = r->iput = 0;
+}
+
 static inline int ringbuf_get(ringbuf_t *r) {
     if (r->iget == r->iput) {
         return -1;

--- a/tests/multi_espnow/20_send_echo.py
+++ b/tests/multi_espnow/20_send_echo.py
@@ -35,7 +35,12 @@ def echo_server(e):
 
 
 def echo_test(e, peer, msg, sync):
-    print("TEST: send/recv(msglen=", len(msg), ",sync=", sync, "): ", end="", sep="")
+    # to get the same log output regardless of ESP-NOW V1 or V2,
+    # log the exact length unless it's overlong
+    msg_len = len(msg)
+    if msg_len > espnow.MAX_DATA_LEN:
+        msg_len = "max+{}".format(msg_len - espnow.MAX_DATA_LEN)
+    print("TEST: send/recv(msglen=", msg_len, ",sync=", sync, "): ", end="", sep="")
     try:
         if not e.send(peer, msg, sync):
             print("ERROR: Send failed.")
@@ -88,6 +93,6 @@ def instance1():
     multitest.next()
     peer = PEERS[0]
     e.add_peer(peer)
-    echo_client(e, peer, [1, 2, 8, 100, 249, 250, 251, 0])
+    echo_client(e, peer, [1, 2, 8, 100, 249, 250, espnow.MAX_DATA_LEN + 1, 0])
     echo_test(e, peer, b"!done", True)
     e.active(False)

--- a/tests/multi_espnow/20_send_echo.py.exp
+++ b/tests/multi_espnow/20_send_echo.py.exp
@@ -8,7 +8,7 @@ TEST: send/recv(msglen=8,sync=True): OK
 TEST: send/recv(msglen=100,sync=True): OK
 TEST: send/recv(msglen=249,sync=True): OK
 TEST: send/recv(msglen=250,sync=True): OK
-TEST: send/recv(msglen=251,sync=True): ERROR: OSError:
+TEST: send/recv(msglen=max+1,sync=True): ERROR: OSError:
 TEST: send/recv(msglen=0,sync=True): ERROR: OSError:
 TEST: send/recv(msglen=1,sync=False): OK
 TEST: send/recv(msglen=2,sync=False): OK
@@ -16,6 +16,6 @@ TEST: send/recv(msglen=8,sync=False): OK
 TEST: send/recv(msglen=100,sync=False): OK
 TEST: send/recv(msglen=249,sync=False): OK
 TEST: send/recv(msglen=250,sync=False): OK
-TEST: send/recv(msglen=251,sync=False): ERROR: OSError:
+TEST: send/recv(msglen=max+1,sync=False): ERROR: OSError:
 TEST: send/recv(msglen=0,sync=False): ERROR: OSError:
 TEST: send/recv(msglen=5,sync=True): OK

--- a/tests/multi_espnow/45_recv_espnow_v2.py
+++ b/tests/multi_espnow/45_recv_espnow_v2.py
@@ -1,0 +1,136 @@
+# Test of a ESP-NOW V2 echo server and client transferring data, as a variant of
+# 40_recv_test.py.
+#
+# This test requires both instances to be ESP32s built with ESP-IDF V5.5 or
+# newer for ESP-NOW V2 support.
+#
+# Explicitly tests the irecv(), rev() and recvinto() methods.
+
+try:
+    import network, os
+    import random
+    import espnow
+except ImportError:
+    print("SKIP")
+    raise SystemExit
+
+if espnow.MAX_DATA_LEN < 1470:  # Check for V2 support
+    print("SKIP")
+    raise SystemExit
+
+# Set read timeout to 8 seconds
+timeout_ms = 8000
+default_pmk = b"VerySecretValue!"
+sync = True
+
+
+def echo_server(e):
+    peers = []
+    while True:
+        peer, msg = e.irecv(timeout_ms)
+        if peer is None:
+            return
+        if peer not in peers:
+            peers.append(peer)
+            e.add_peer(peer)
+
+        #  Echo the MAC and message back to the sender
+        if not e.send(peer, msg, sync):
+            print("ERROR: send() failed to", peer.hex())
+            return
+
+        if msg == b"!done":
+            return
+
+
+def client_send(e, peer, msg, sync):
+    import time
+
+    time.sleep_ms(100)
+    print("TEST: send/recv(msglen=", len(msg), ",sync=", sync, "): ", end="", sep="")
+    try:
+        if not e.send(peer, msg, sync):
+            print("ERROR: Send failed.")
+            return
+    except OSError as exc:
+        # Don't print exc as it is differs for esp32 and esp8266
+        print("ERROR: OSError:", exc)  # FIXME
+        return
+
+
+def init(sta_active=True, ap_active=False):
+    wlans = [network.WLAN(i) for i in [network.WLAN.IF_STA, network.WLAN.IF_AP]]
+    e = espnow.ESPNow()
+    e.active(True)
+    e.set_pmk(default_pmk)
+    wlans[0].active(sta_active)
+    wlans[1].active(ap_active)
+    wlans[0].disconnect()  # Force esp8266 STA interface to disconnect from AP
+    return e
+
+
+# Server
+def instance0():
+    e = init(True, False)
+    multitest.globals(PEERS=[network.WLAN(i).config("mac") for i in (0, 1)])
+    multitest.next()
+    print("Server Start")
+    echo_server(e)
+    print("Server Done")
+    e.active(False)
+
+
+def check_recv(s, r):
+    if s == r:
+        print("OK")
+    else:
+        print("ERROR: Received != Sent")
+        print("Sent", len(s), "bytes")
+        if r is None:
+            print("Receive timed out")
+        else:
+            print("Received", len(r), "bytes")
+
+
+# Client
+def instance1():
+    # Instance 1 (the client)
+    e = init(True, False)
+    e.config(timeout_ms=timeout_ms)
+    multitest.next()
+    peer = PEERS[0]
+    e.add_peer(peer)
+
+    print("RECVINTO() test...")
+    msg = os.urandom(768)
+    client_send(e, peer, msg, True)
+    data = [bytearray(espnow.ADDR_LEN), bytearray(espnow.MAX_DATA_LEN)]
+    n = e.recvinto(data)
+    check_recv(msg, data[1])
+
+    print("IRECV() test...")
+    msg = os.urandom(768)
+    client_send(e, peer, msg, True)
+    p2, msg2 = e.irecv()
+    check_recv(msg, msg2)
+
+    print("RECV() test...")
+    msg = os.urandom(1024)
+    client_send(e, peer, msg, True)
+    p2, msg2 = e.recv()
+    check_recv(msg, msg2)
+
+    print("ITERATOR() test...")
+    msg = os.urandom(espnow.MAX_DATA_LEN)
+    client_send(e, peer, msg, True)
+    p2, msg2 = next(e)
+    check_recv(msg, msg2)
+
+    # Tell the server to stop
+    print("DONE")
+    msg = b"!done"
+    client_send(e, peer, msg, True)
+    p2, msg2 = e.irecv()
+    check_recv(msg, msg2)
+
+    e.active(False)

--- a/tests/multi_espnow/45_recv_espnow_v2.py.exp
+++ b/tests/multi_espnow/45_recv_espnow_v2.py.exp
@@ -1,0 +1,14 @@
+--- instance0 ---
+Server Start
+Server Done
+--- instance1 ---
+RECVINTO() test...
+TEST: send/recv(msglen=768,sync=True): OK
+IRECV() test...
+TEST: send/recv(msglen=768,sync=True): OK
+RECV() test...
+TEST: send/recv(msglen=1024,sync=True): OK
+ITERATOR() test...
+TEST: send/recv(msglen=1470,sync=True): OK
+DONE
+TEST: send/recv(msglen=5,sync=True): OK


### PR DESCRIPTION
### Summary

2 years ago, [I've submitted a feature request](https://github.com/espressif/esp-idf/issues/9453) to increase maximum length of `ESP-NOW` messages. [Finally](https://github.com/espressif/esp-idf/commit/b4d102796f50e6fabce0f2a1c6ff5b8f39c902a2) the maximum length increased from **250** bytes to **1490** bytes in `ESP-NOW v2.0` which is implemented in `IDFv5.4`. This PR aims to migrate current implementation of `espnow` module to support `ESP-NOW v2.0` but also keep support for `ESP-NOW v1.0` for builds with older `IDF` versions.


### Testing

I've tested both sending and receiving examples on `ESP32` and `ESP32-S3` chips.


