### PR TITLE
github/workflows: Stop using ubuntu-20.04.

### DIFF
--- a/.github/workflows/mpy_format.yml
+++ b/.github/workflows/mpy_format.yml
@@ -15,7 +15,7 @@ concurrency:
 
 jobs:
   test:
-    runs-on: ubuntu-20.04 # use 20.04 to get python2
+    runs-on: ubuntu-22.04 # use 22.04 to get python2
     steps:
     - uses: actions/checkout@v4
     - name: Install packages

--- a/.github/workflows/ports_esp32.yml
+++ b/.github/workflows/ports_esp32.yml
@@ -30,8 +30,8 @@ jobs:
     - uses: actions/checkout@v4
 
     - id: idf_ver
-      name: Read the ESP-IDF version
-      run: source tools/ci.sh && echo "IDF_VER=$IDF_VER" | tee "$GITHUB_OUTPUT"
+      name: Read the ESP-IDF version (including Python version)
+      run: source tools/ci.sh && echo "IDF_VER=${IDF_VER}-py${PYTHON_VER}" | tee "$GITHUB_OUTPUT"
 
     - name: Cached ESP-IDF install
       id: cache_esp_idf

--- a/.github/workflows/ports_esp32.yml
+++ b/.github/workflows/ports_esp32.yml
@@ -25,7 +25,7 @@ jobs:
         ci_func:  # names are functions in ci.sh
           - esp32_build_cmod_spiram_s2
           - esp32_build_s3_c3
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
 

--- a/.github/workflows/ports_mimxrt.yml
+++ b/.github/workflows/ports_mimxrt.yml
@@ -19,7 +19,7 @@ concurrency:
 
 jobs:
   build:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     defaults:
       run:
         working-directory: 'micropython repo'  # test build with space in path

--- a/.github/workflows/ports_nrf.yml
+++ b/.github/workflows/ports_nrf.yml
@@ -19,7 +19,7 @@ concurrency:
 
 jobs:
   build:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
     - name: Install packages

--- a/.github/workflows/ports_renesas-ra.yml
+++ b/.github/workflows/ports_renesas-ra.yml
@@ -19,7 +19,7 @@ concurrency:
 
 jobs:
   build_renesas_ra_board:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
     - name: Install packages

--- a/.github/workflows/ports_stm32.yml
+++ b/.github/workflows/ports_stm32.yml
@@ -26,7 +26,7 @@ jobs:
           - stm32_pyb_build
           - stm32_nucleo_build
           - stm32_misc_build
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
     - uses: actions/checkout@v4
     - name: Install packages

--- a/.github/workflows/ports_unix.yml
+++ b/.github/workflows/ports_unix.yml
@@ -98,7 +98,7 @@ jobs:
       run: tests/run-tests.py --print-failures
 
   coverage_32bit:
-    runs-on: ubuntu-20.04 # use 20.04 to get libffi-dev:i386
+    runs-on: ubuntu-22.04 # use 22.04 to get libffi-dev:i386
     steps:
     - uses: actions/checkout@v4
     - name: Install packages
@@ -116,7 +116,7 @@ jobs:
       run: tests/run-tests.py --print-failures
 
   nanbox:
-    runs-on: ubuntu-20.04 # use 20.04 to get python2, and libffi-dev:i386
+    runs-on: ubuntu-22.04 # use 22.04 to get python2, and libffi-dev:i386
     steps:
     - uses: actions/checkout@v4
     - name: Install packages
@@ -142,7 +142,7 @@ jobs:
       run: tests/run-tests.py --print-failures
 
   stackless_clang:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
     - name: Install packages
@@ -156,7 +156,7 @@ jobs:
       run: tests/run-tests.py --print-failures
 
   float_clang:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
     - name: Install packages

--- a/tools/ci.sh
+++ b/tools/ci.sh
@@ -106,12 +106,16 @@ function ci_code_size_build {
 # .mpy file format
 
 function ci_mpy_format_setup {
+    sudo apt-get update
+    sudo apt-get install python2.7
     sudo pip3 install pyelftools
+    python2.7 --version
+    python3 --version
 }
 
 function ci_mpy_format_test {
     # Test mpy-tool.py dump feature on bytecode
-    python2 ./tools/mpy-tool.py -xd tests/frozen/frozentest.mpy
+    python2.7 ./tools/mpy-tool.py -xd tests/frozen/frozentest.mpy
     python3 ./tools/mpy-tool.py -xd tests/frozen/frozentest.mpy
 
     # Test mpy-tool.py dump feature on native code
@@ -268,18 +272,18 @@ function ci_powerpc_build {
 # ports/qemu
 
 function ci_qemu_setup_arm {
-    ci_mpy_format_setup
     ci_gcc_arm_setup
     sudo apt-get update
     sudo apt-get install qemu-system
+    sudo pip3 install pyelftools
     qemu-system-arm --version
 }
 
 function ci_qemu_setup_rv32 {
-    ci_mpy_format_setup
     ci_gcc_riscv_setup
     sudo apt-get update
     sudo apt-get install qemu-system
+    sudo pip3 install pyelftools
     qemu-system-riscv32 --version
 }
 
@@ -580,10 +584,11 @@ function ci_unix_coverage_run_native_mpy_tests {
 function ci_unix_32bit_setup {
     sudo dpkg --add-architecture i386
     sudo apt-get update
-    sudo apt-get install gcc-multilib g++-multilib libffi-dev:i386
+    sudo apt-get install gcc-multilib g++-multilib libffi-dev:i386 python2.7
     sudo pip3 install setuptools
     sudo pip3 install pyelftools
     gcc --version
+    python2.7 --version
     python3 --version
 }
 
@@ -602,12 +607,12 @@ function ci_unix_coverage_32bit_run_native_mpy_tests {
 
 function ci_unix_nanbox_build {
     # Use Python 2 to check that it can run the build scripts
-    ci_unix_build_helper PYTHON=python2 VARIANT=nanbox CFLAGS_EXTRA="-DMICROPY_PY_MATH_CONSTANTS=1"
+    ci_unix_build_helper PYTHON=python2.7 VARIANT=nanbox CFLAGS_EXTRA="-DMICROPY_PY_MATH_CONSTANTS=1"
     ci_unix_build_ffi_lib_helper gcc -m32
 }
 
 function ci_unix_nanbox_run_tests {
-    ci_unix_run_tests_full_helper nanbox PYTHON=python2
+    ci_unix_run_tests_full_helper nanbox PYTHON=python2.7
 }
 
 function ci_unix_float_build {

--- a/tools/ci.sh
+++ b/tools/ci.sh
@@ -140,6 +140,7 @@ function ci_cc3200_build {
 
 # GitHub tag of ESP-IDF to use for CI (note: must be a tag or a branch)
 IDF_VER=v5.2.2
+PYTHON_VER=$(python --version | cut -d' ' -f2)
 
 export IDF_CCACHE_ENABLE=1
 


### PR DESCRIPTION
### Summary

For GitHub Actions, ubuntu-20.04 is deprecated and will be removed by 1st April 2025.

See announcement here: https://github.com/actions/runner-images/issues/11101

This PR changes existing actions that use ubuntu-20.04 to a newer image.

### Testing

CI will test this.  I assume there will be some problems that need to be individually addressed.
