### PR TITLE
esp32: Remove unneeded "memory.h" header file.

### DIFF
--- a/ports/esp32/memory.h
+++ b/ports/esp32/memory.h
@@ -1,2 +1,0 @@
-// this is needed for lib/crypto-algorithms/sha256.c
-#include <string.h>


### PR DESCRIPTION
### Summary

This PR removes "memory.h" from the ESP32 port tree, as it is no longer needed with recent ESP-IDF versions.

### Testing

`ESP32_GENERIC`, `ESP32_GENERIC_C3`, `ESP32_GENERIC_C6`, `ESP32_GENERIC_S2`, and `ESP32_GENERIC_S3` board variants were built without any errors on ESP-IDF 5.2.0.