### PR TITLE
esp32: Switch to IDF v5.4

### DIFF
--- a/ports/esp32/README.md
+++ b/ports/esp32/README.md
@@ -31,7 +31,7 @@ manage the ESP32 microcontroller, as well as a way to manage the required
 build environment and toolchains needed to build the firmware.
 
 The ESP-IDF changes quickly and MicroPython only supports certain versions.
-Currently MicroPython supports v5.2, v5.2.2, v5.3 and v5.4.
+Currently MicroPython supports v5.2, v5.2.2, v5.3, v5.4 and v5.4.1.
 
 To install the ESP-IDF the full instructions can be found at the
 [Espressif Getting Started guide](https://docs.espressif.com/projects/esp-idf/en/latest/esp32/get-started/index.html#installation-step-by-step).
@@ -49,10 +49,10 @@ The steps to take are summarised below.
 To check out a copy of the IDF use git clone:
 
 ```bash
-$ git clone -b v5.2.2 --recursive https://github.com/espressif/esp-idf.git
+$ git clone -b v5.4.1 --recursive https://github.com/espressif/esp-idf.git
 ```
 
-You can replace `v5.2.2` with any other supported version.
+You can replace `v5.4.1` with any other supported version.
 (You don't need a full recursive clone; see the `ci_esp32_setup` function in
 `tools/ci.sh` in this repository for more detailed set-up commands.)
 
@@ -61,7 +61,7 @@ MicroPython and update the submodules using:
 
 ```bash
 $ cd esp-idf
-$ git checkout v5.2.2
+$ git checkout v5.4.1
 $ git submodule update --init --recursive
 ```
 

--- a/ports/esp32/tools/metrics_esp32.py
+++ b/ports/esp32/tools/metrics_esp32.py
@@ -37,7 +37,7 @@ import sys
 import subprocess
 from dataclasses import dataclass
 
-IDF_VERS = ("v5.2.2",)
+IDF_VERS = ("v5.4.1",)
 
 BUILDS = (
     ("ESP32_GENERIC", ""),

--- a/tools/ci.sh
+++ b/tools/ci.sh
@@ -159,7 +159,7 @@ function ci_cc3200_build {
 # ports/esp32
 
 # GitHub tag of ESP-IDF to use for CI (note: must be a tag or a branch)
-IDF_VER=v5.2.2
+IDF_VER=v5.4.1
 PYTHON=$(command -v python3 2> /dev/null)
 PYTHON_VER=$(${PYTHON:-python} --version | cut -d' ' -f2)
 


### PR DESCRIPTION
### Summary
Supported IDF v5.4 chips: ESP32, ESP32-S2, ESP32-C3, ESP32-S3, ESP32-C2, ESP32-C6, ESP32-H2, ESP32-P4

### Testing
ESP32 generic board.

### Trade-offs and Alternatives
Several PRs require IDF v5.4.
