### PR TITLE
docs/library/neopixel.rst: Update neopixel docs to hide dunders.

### DIFF
--- a/docs/library/neopixel.rst
+++ b/docs/library/neopixel.rst
@@ -24,14 +24,14 @@ For example::
 
     # 32 LED strip connected to X8.
     p = machine.Pin.board.X8
-    n = neopixel.NeoPixel(p, 32)
+    np = neopixel.NeoPixel(p, 32)
 
     # Draw a red gradient.
     for i in range(32):
-        n[i] = (i * 8, 0, 0)
+        np[i] = (i * 8, 0, 0)
 
     # Update the strip.
-    n.write()
+    np.write()
 
 Constructors
 ------------
@@ -54,17 +54,17 @@ Pixel access methods
     Sets the value of all pixels to the specified *pixel* value (i.e. an
     RGB/RGBW tuple).
 
-.. method:: NeoPixel.__len__()
+.. method:: len(np)
 
-    Returns the number of LEDs in the strip.
+    Returns the number of LEDs in the strip for NeoPixel *np*.
 
-.. method:: NeoPixel.__setitem__(index, val)
+.. method:: np[index]
 
-    Set the pixel at *index* to the value, which is an RGB/RGBW tuple.
+    Returns the pixel of NeoPixel *np* at *index* as an RGB/RGBW tuple.
 
-.. method:: NeoPixel.__getitem__(index)
+.. method:: np[index] =  value
 
-    Returns the pixel at *index* as an RGB/RGBW tuple.
+    Set the pixel of NeoPixel *np* at *index* to the value, which is an RGB/RGBW tuple.
 
 Output methods
 --------------


### PR DESCRIPTION
### Summary

Change documentation to show using `len(np)` to access number of pixels rather than `NeoPixel.__len__()`.  Also use update for setting and getting items via `np[index]`.

I was looking at the NeoPixel documentation and saw that it was showing dunder methods for accessing number of pixels and also for setting/reading pixels ie `NeoPixel.__len__()`, `NeoPixel.__setitem__()`, `NeoPixel.__getitem__()`  rather than using `len(np)`, `np[index]`.

It is good practice especially for beginners that we should be showing correct access of these items rather than encouraging people to use private methods.  

I used the python documentation https://docs.python.org/3/library/stdtypes.html#mapping-types-dict as a basis for this update.

I chose `np` as a place holder for a NeoPixel instance as it felt appropriate, additionally I updated the code example to use `np` instead if `n` so that there was consistency accross the documentation. 

I think the Methods sections should also be combined but I have not included that change here but can if you think that is the way to go.

### Testing

This is a trivial documentation change so no testing was done

