### PR TITLE
esp8266/network_wlan: Allow enumerating connected stations in AP mode.

### DIFF
--- a/docs/library/network.WLAN.rst
+++ b/docs/library/network.WLAN.rst
@@ -85,7 +85,18 @@ Methods
         * ``STAT_GOT_IP`` -- connection successful.
 
     When called with one argument *param* should be a string naming the status
-    parameter to retrieve.  Supported parameters in WiFI STA mode are: ``'rssi'``.
+    parameter to retrieve, and different parameters are supported depending on the
+    mode the WiFi is in.
+
+    In STA mode, passing ``'rssi'`` returns a signal strength indicator value, whose
+    format varies depending on the port (this is available on all ports that support
+    WiFi network interfaces, except for CC3200).
+
+    In AP mode, passing ``'stations'`` returns a list of connected WiFi stations
+    (this is available on all ports that support WiFi network interfaces, except for
+    CC3200).  The format of the station information entries varies across ports,
+    providing either the raw BSSID of the connected station, the IP address of the
+    connected station, or both.
 
 .. method:: WLAN.isconnected()
 


### PR DESCRIPTION
### Summary

This commit introduces the ability to obtain a list of stations connected to the device when in soft-AP mode.

A new parameter ("stations") to pass to WLAN.status is supported, returning a tuple of (bssid, ipv4) entries, one per connected station. An empty tuple is returned if no stations are connected, and an exception is raised if an error occurred whilst building the python objects to return to the interpreter.

Documentation is also updated to cover the new parameter.

This fixes #5395.

### Testing

I've tested this code as part of a project of mine on a NodeMCU with three stations connected to it, with the expected output being returned by calling `interface.status("stations")`.  I doubt this can be put in the CI pipeline or how this can have a test of its own.

### Trade-offs and Alternatives

This comes with a small footprint increase for the general firmware configuration, however if this is unacceptable maybe I can add a port define that disables AP support in MicroPython.

Also, no idea on how `wifi_softap_get_station_info` behaves with a large number of stations, all possible recoverable error conditions should be handled in this PR.