### PR TITLE
all: Fix ruff rules C4, PERF401, and PLC0206.

### DIFF
--- a/examples/bluetooth/ble_advertising.py
+++ b/examples/bluetooth/ble_advertising.py
@@ -78,13 +78,15 @@ def decode_name(payload):
 
 
 def decode_services(payload):
-    services = []
-    for u in decode_field(payload, _ADV_TYPE_UUID16_COMPLETE):
-        services.append(bluetooth.UUID(struct.unpack("<h", u)[0]))
-    for u in decode_field(payload, _ADV_TYPE_UUID32_COMPLETE):
-        services.append(bluetooth.UUID(struct.unpack("<d", u)[0]))
-    for u in decode_field(payload, _ADV_TYPE_UUID128_COMPLETE):
-        services.append(bluetooth.UUID(u))
+    services = [
+        bluetooth.UUID(struct.unpack("<h", u)[0])
+        for u in decode_field(payload, _ADV_TYPE_UUID16_COMPLETE)
+    ]
+    services.extend(
+        bluetooth.UUID(struct.unpack("<d", u)[0])
+        for u in decode_field(payload, _ADV_TYPE_UUID32_COMPLETE)
+    )
+    services.extend(bluetooth.UUID(u) for u in decode_field(payload, _ADV_TYPE_UUID128_COMPLETE))
     return services
 
 

--- a/ports/esp32/boards/UM_TINYPICO/modules/dotstar.py
+++ b/ports/esp32/boards/UM_TINYPICO/modules/dotstar.py
@@ -167,12 +167,10 @@ class DotStar:
 
     def __getitem__(self, index):
         if isinstance(index, slice):
-            out = []
-            for in_i in range(*index.indices(self._n)):
-                out.append(
-                    tuple(self._buf[in_i * 4 + (3 - i) + START_HEADER_SIZE] for i in range(3))
-                )
-            return out
+            return [
+                tuple(self._buf[in_i * 4 + (3 - i) + START_HEADER_SIZE] for i in range(3))
+                for in_i in range(*index.indices(self._n))
+            ]
         if index < 0:
             index += len(self)
         if index >= self._n or index < 0:

--- a/ports/nrf/boards/make-pins.py
+++ b/ports/nrf/boards/make-pins.py
@@ -299,7 +299,7 @@ class Pins(object):
         print("extern const pin_obj_t * const pin_adc3[];", file=out_header)
 
     def print_af_hdr(self, out_af_const):
-        af_hdr_set = set([])
+        af_hdr_set = set()
         mux_name_width = 0
         for named_pin in self.cpu_pins:
             pin = named_pin.pin()
@@ -307,7 +307,7 @@ class Pins(object):
                 for af in pin.alt_fn:
                     if af.is_supported():
                         mux_name = af.mux_name()
-                        af_hdr_set |= set([mux_name])
+                        af_hdr_set |= {mux_name}
                         if len(mux_name) > mux_name_width:
                             mux_name_width = len(mux_name)
         for mux_name in sorted(af_hdr_set):

--- a/ports/nrf/examples/powerup.py
+++ b/ports/nrf/examples/powerup.py
@@ -52,11 +52,12 @@ def bytes_to_str(bytes):
 def get_device_names(scan_entries):
     dev_names = []
     for e in scan_entries:
-        scan = e.getScanData()
-        if scan:
-            for s in scan:
-                if s[0] == constants.ad_types.AD_TYPE_COMPLETE_LOCAL_NAME:
-                    dev_names.append((e, bytes_to_str(s[2])))
+        scan = e.getScanData() or []
+        dev_names.extend(
+            (e, bytes_to_str(s[2]))
+            for s in scan
+            if s[0] == constants.ad_types.AD_TYPE_COMPLETE_LOCAL_NAME
+        )
     return dev_names
 
 

--- a/ports/nrf/examples/ubluepy_scan.py
+++ b/ports/nrf/examples/ubluepy_scan.py
@@ -11,11 +11,12 @@ def bytes_to_str(bytes):
 def get_device_names(scan_entries):
     dev_names = []
     for e in scan_entries:
-        scan = e.getScanData()
-        if scan:
-            for s in scan:
-                if s[0] == constants.ad_types.AD_TYPE_COMPLETE_LOCAL_NAME:
-                    dev_names.append((e, bytes_to_str(s[2])))
+        scan = e.getScanData() or []
+        dev_names.extend(
+            (e, bytes_to_str(s[2]))
+            for s in scan
+            if s[0] == constants.ad_types.AD_TYPE_COMPLETE_LOCAL_NAME
+        )
     return dev_names
 
 

--- a/ports/stm32/boards/plli2svalues.py
+++ b/ports/stm32/boards/plli2svalues.py
@@ -198,9 +198,9 @@ def main():
 
         # Select MCU parameters
         mcu = mcu_default
-        for m in mcu_table:
+        for m, new_mcu in mcu_table.items():
             if mcu_series.startswith(m):
-                mcu = mcu_table[m]
+                mcu = new_mcu
                 break
         plli2s_table = compute_plli2s_table(hse, pllm)
         if c_table:

--- a/ports/stm32/boards/pllvalues.py
+++ b/ports/stm32/boards/pllvalues.py
@@ -287,9 +287,9 @@ def main():
 
     # Select MCU parameters
     mcu = mcu_default
-    for m in mcu_table:
+    for m, new_mcu in mcu_table.items():
         if mcu_series.startswith(m):
-            mcu = mcu_table[m]
+            mcu = new_mcu
             break
 
     # Relax constraint on PLLQ being 48MHz on MCUs which have separate PLLs for 48MHz

--- a/ports/stm32/make-stmconst.py
+++ b/ports/stm32/make-stmconst.py
@@ -158,8 +158,10 @@ def parse_file(filename):
                 if m[0] == "IO reg":
                     regs.append((reg, offset, bits, comment))
                 else:
-                    for i in range(int(d["array"])):
-                        regs.append((reg + str(i), offset + i * bits // 8, bits, comment))
+                    regs.extend(
+                        (reg + str(i), offset + i * bits // 8, bits, comment)
+                        for i in range(int(d["array"]))
+                    )
                 m = lexer.next_match()
             if m[0] in ("}", "} _t"):
                 pass

--- a/tools/codeformat.py
+++ b/tools/codeformat.py
@@ -151,7 +151,7 @@ def main():
             # Filter against the default list of files. This is a little fiddly
             # because we need to apply both the inclusion globs given in PATHS
             # as well as the EXCLUSIONS, and use absolute paths
-            files = set(os.path.abspath(f) for f in files)
+            files = {os.path.abspath(f) for f in files}
             all_files = set(list_files(PATHS, EXCLUSIONS, TOP))
             if args.v:  # In verbose mode, log any files we're skipping
                 for f in files - all_files:

--- a/tools/dfu.py
+++ b/tools/dfu.py
@@ -87,7 +87,7 @@ def build(file, targets, device=DEFAULT_DEVICE):
         )
         data += tdata
     data = struct.pack("<5sBIB", b"DfuSe", 1, len(data) + 11, len(targets)) + data
-    v, d = map(lambda x: int(x, 0) & 0xFFFF, device.split(":", 1))
+    v, d = (int(x, 0) & 0xFFFF for x in device.split(":", 1))
     data += struct.pack("<4H3sB", 0, d, v, 0x011A, b"UFD", 16)
     crc = compute_crc(data)
     data += struct.pack("<I", crc)
@@ -147,7 +147,7 @@ if __name__ == "__main__":
         if options.device:
             device = options.device
         try:
-            v, d = map(lambda x: int(x, 0) & 0xFFFF, device.split(":", 1))
+            v, d = (int(x, 0) & 0xFFFF for x in device.split(":", 1))
         except:
             print("Invalid device '%s'." % device)
             sys.exit(1)

--- a/tools/insert-usb-ids.py
+++ b/tools/insert-usb-ids.py
@@ -13,7 +13,7 @@ needed_keys = ("USB_PID_CDC_MSC", "USB_PID_CDC_HID", "USB_PID_CDC", "USB_VID")
 
 
 def parse_usb_ids(filename):
-    rv = dict()
+    rv = {}
     for line in open(filename).readlines():
         line = line.rstrip("\r\n")
         match = re.match(r"^#define\s+(\w+)\s+\(0x([0-9A-Fa-f]+)\)$", line)

--- a/tools/mpy-tool.py
+++ b/tools/mpy-tool.py
@@ -1374,15 +1374,11 @@ def read_mpy(filename):
 
         # Read qstrs and construct qstr table.
         qstr_table_file_offset = reader.tell()
-        qstr_table = []
-        for i in range(n_qstr):
-            qstr_table.append(read_qstr(reader, segments))
+        qstr_table = [read_qstr(reader, segments) for _ in range(n_qstr)]
 
         # Read objects and construct object table.
         obj_table_file_offset = reader.tell()
-        obj_table = []
-        for i in range(n_obj):
-            obj_table.append(read_obj(reader, segments))
+        obj_table = [read_obj(reader, segments) for _ in range(n_obj)]
 
         # Compute the compiled-module escaped name.
         cm_escaped_name = qstr_table[0].str.replace("/", "_")[:-3]

--- a/tools/uf2conv.py
+++ b/tools/uf2conv.py
@@ -118,7 +118,7 @@ def convert_from_uf2(buf):
         if blockno == (numblocks - 1):
             print("--- UF2 File Header Info ---")
             families = load_families()
-            for family_hex in families_found.keys():
+            for family_hex, target_address in families_found.items():
                 family_short_name = ""
                 for name, value in families.items():
                     if value == family_hex:
@@ -128,7 +128,7 @@ def convert_from_uf2(buf):
                         family_short_name, family_hex
                     )
                 )
-                print("Target Address is 0x{:08x}".format(families_found[family_hex]))
+                print("Target Address is 0x{:08x}".format(target_address))
             if all_flags_same:
                 print("All block flag values consistent, 0x{:04x}".format(hd[2]))
             else:
@@ -282,8 +282,7 @@ def get_drives():
             tmp = rootpath + "/" + os.environ["USER"]
             if os.path.isdir(tmp):
                 rootpath = tmp
-        for d in os.listdir(rootpath):
-            drives.append(os.path.join(rootpath, d))
+        drives.extend(os.path.join(rootpath, d) for d in os.listdir(rootpath))
 
     def has_info(d):
         try:


### PR DESCRIPTION
<!-- Thanks for submitting a Pull Request! We appreciate you spending the
     time to improve MicroPython. Please provide enough information so that
     others can review your Pull Request.

     Before submitting, please read:
     https://github.com/micropython/micropython/blob/master/CODEOFCONDUCT.md
     https://github.com/micropython/micropython/wiki/ContributorGuidelines

     Please check any CI failures that appear after your Pull Request is opened.
-->

### Summary

<!-- Explain the reason for making this change. What problem does the pull request
     solve, or what improvement does it add? Add links if relevant. -->

% `ruff check --select=C4,PERF401,PLC0206 --statistics`
```
10	PERF401	[ ] manual-list-comprehension
 3	PLC0206	[ ] dict-index-missing-items
 2	C405   	[*] unnecessary-literal-set
 2	C417   	[*] unnecessary-map
 1	C401   	[*] unnecessary-generator-set
 1	C408   	[*] unnecessary-collection-call
[*] fixable with `ruff check --fix`
```
Each issue flags a minor inefficiency such as not using comprehensions or repeatedly calling `list.append()` instead of making a single call to `.list.extend()`.

### Testing

<!-- Explain what testing you did, and on which boards/ports. If there are
     boards or ports that you couldn't test, please mention this here as well.

     If you leave this empty then your Pull Request may be closed. -->

Run ruff locally and in pre-commit.

Related to:
* #16774