### PR TITLE
lib/pico-sdk: Update to version 2.1.1.

### DIFF
--- a/ports/rp2/CMakeLists.txt
+++ b/ports/rp2/CMakeLists.txt
@@ -276,7 +276,7 @@ if(PICO_RP2040)
 elseif(PICO_RP2350 AND PICO_ARM)
     target_sources(pico_float_micropython INTERFACE
         ${PICO_SDK_PATH}/src/rp2_common/pico_float/float_aeabi_dcp.S
-        ${PICO_SDK_PATH}/src/rp2_common/pico_float/float_conv_m33.S
+        ${PICO_SDK_PATH}/src/rp2_common/pico_float/float_common_m33.S
     )
 endif()
 


### PR DESCRIPTION
### Summary

Update pico-sdk to the just-release patch version 2.1.1 (we are currently at 2.1.0).

See pico-sdk release notes: https://github.com/raspberrypi/pico-sdk/releases/tag/2.1.1

### Testing

Ran the full test suite on a RPI_PICO_W and it looks OK.

Edit: did full tests of RPI_PICO, RPI_PICO_W, RPI_PICO2, RPI_PICO2_W (the latter two both in ARM and RISCV) mode, testing all things covered by the test suite including WLAN and BLE.  No regressions were found.
