### PR TITLE
extmod/machine_usb_device: Add optional data length parameters to usb_device_submit_xfer()

### DIFF
--- a/docs/library/machine.USBDevice.rst
+++ b/docs/library/machine.USBDevice.rst
@@ -223,11 +223,14 @@ Methods
     and on the host. Returns ``True`` if remote wakeup was enabled and
     active and the host was woken up.
 
-.. method:: USBDevice.submit_xfer(self, ep, buffer /)
+.. method:: USBDevice.submit_xfer(self, ep, buffer, [nbytes] /)
 
             Submit a USB transfer on endpoint number ``ep``. ``buffer`` must be
             an object implementing the buffer interface, with read access for
             ``IN`` endpoints and write access for ``OUT`` endpoints.
+
+            The optional ``nbytes`` parameter can be used to specify the number
+            of bytes to submit from the buffer.
 
             .. note:: ``ep`` cannot be the control Endpoint number 0. Control
                transfers are built up through successive executions of


### PR DESCRIPTION
### Summary

I think it's better to give USB submit_xfer() an extra parameter to specify the actual amount of data in the buffer.

This avoids calling submit_xfer as follows
``` python
self.usbd.submit_xfer(self.EP_IN, self.in_buf[:xfer_bytes])
```

Instead, it can be written as:
``` python
self.usbd.submit_xfer(self.EP_IN, self.in_buf, xfer_bytes)
```

The former cannot be used in ISR because it causes memory allocation, and allocating in ISR causes MemoryError.

### Testing

I test this change on rp2/RPI_PICO board.
