### PR TITLE
tests/cpydiff: Test for PEP487 __init_subclass__.

### DIFF
--- a/tests/cpydiff/core_class_initsubclass.py
+++ b/tests/cpydiff/core_class_initsubclass.py
@@ -1,0 +1,21 @@
+"""
+categories: Core,Classes
+description: ``__init_subclass__`` isn't automatically called.
+cause: MicroPython does not currently implement PEP 487.
+workaround: Manually call ``__init_subclass__`` after class creation if needed. e.g.::
+
+    class A(Base):
+        pass
+    A.__init_subclass__()
+
+"""
+
+
+class Base:
+    @classmethod
+    def __init_subclass__(cls):
+        print(f"Base.__init_subclass__({cls.__name__})")
+
+
+class A(Base):
+    pass

--- a/tests/cpydiff/core_class_initsubclass_autoclassmethod.py
+++ b/tests/cpydiff/core_class_initsubclass_autoclassmethod.py
@@ -1,0 +1,31 @@
+"""
+categories: Core,Classes
+description: ``__init_subclass__`` isn't an implicit classmethod.
+cause: MicroPython does not currently implement PEP 487. ``__init_subclass__`` is not currently in the list of special-cased class/static methods.
+workaround: Decorate declarations of ``__init_subclass__`` with ``@classmethod``.
+"""
+
+
+def regularize_spelling(text, prefix="bound_"):
+    # for regularizing across the CPython "method" vs MicroPython "bound_method" spelling for the type of a bound classmethod
+    if text.startswith(prefix):
+        return text[len(prefix) :]
+    return text
+
+
+class A:
+    def __init_subclass__(cls):
+        pass
+
+    @classmethod
+    def manual_decorated(cls):
+        pass
+
+
+a = type(A.__init_subclass__).__name__
+b = type(A.manual_decorated).__name__
+
+print(regularize_spelling(a))
+print(regularize_spelling(b))
+if a != b:
+    print("FAIL")

--- a/tests/cpydiff/core_class_initsubclass_kwargs.py
+++ b/tests/cpydiff/core_class_initsubclass_kwargs.py
@@ -1,0 +1,22 @@
+"""
+categories: Core,Classes
+description: MicroPython doesn't support parameterized ``__init_subclass__`` class customization.
+cause: MicroPython does not currently implement PEP 487. The MicroPython syntax tree does not include a kwargs node after the class inheritance list.
+workaround: Use class variables or another mechanism to specify base-class customizations.
+"""
+
+
+class Base:
+    @classmethod
+    def __init_subclass__(cls, arg=None, **kwargs):
+        cls.init_subclass_was_called = True
+        print(f"Base.__init_subclass__({cls.__name__}, {arg=!r}, {kwargs=!r})")
+
+
+class A(Base, arg="arg"):
+    pass
+
+
+# Regularize across MicroPython not automatically calling __init_subclass__ either.
+if not getattr(A, "init_subclass_was_called", False):
+    A.__init_subclass__()

--- a/tests/cpydiff/core_class_initsubclass_super.py
+++ b/tests/cpydiff/core_class_initsubclass_super.py
@@ -1,0 +1,22 @@
+"""
+categories: Core,Classes
+description: ``__init_subclass__`` can't be defined a cooperatively-recursive way.
+cause: MicroPython does not currently implement PEP 487. The base object type does not have an ``__init_subclass__`` implementation.
+workaround: Omit the recursive ``__init_subclass__`` call unless it's known that the grandparent also defines it.
+"""
+
+
+class Base:
+    @classmethod
+    def __init_subclass__(cls, **kwargs):
+        cls.init_subclass_was_called = True
+        super().__init_subclass__(**kwargs)
+
+
+class A(Base):
+    pass
+
+
+# Regularize across MicroPython not automatically calling __init_subclass__ either.
+if not getattr(A, "init_subclass_was_called", False):
+    A.__init_subclass__()


### PR DESCRIPTION
### Summary

This change documents and verifies the current absence of `__init_subclass__` functionality, in anticipation of a possible future PEP487 'metaclasses lite' patch.

The main `core_class_initsubclass.py` test verifies if the method is automatically called, while the other three verify other orthogonal properties it should have: if the method is an implicit classmethod; if micropython supplies the base case for the usual recursive function body the PEP encourages; and if kwargs inheritance parameters work correctly.

### Testing

I've verified that these tests fail as expected, correctly detecting the feature's absence.

### Trade-offs and Alternatives

Some of the tests include code that regularizes across other unrelated differences between CPython and Micropython; but the complexity of this isn't large and it should be easy to verify that they wouldn't ever cause the tests to spuriously pass or fail.