### PR TITLE
tests/cpydiff: Test for PEP487 __set_name__.

### DIFF
--- a/tests/cpydiff/core_class_setname.py
+++ b/tests/cpydiff/core_class_setname.py
@@ -1,0 +1,15 @@
+"""
+categories: Core,Classes
+description: ``__set_name__`` is not automatically called on applicable class members.
+cause: MicroPython does not currently implement PEP 487.
+workaround: Manually iterate through a class's ``__dict__`` and invoke ``__set_name__`` on its members after creating a class.
+"""
+
+
+class Descriptor:
+    def __set_name__(self, owner, name):
+        print(f"Descriptor.__set_name__({owner.__name__}, {name!r})")
+
+
+class A:
+    x = Descriptor()


### PR DESCRIPTION
### Summary

This change documents and verifies the current absence of `__set_name__` functionality, in anticipation of a possible future PEP487 'metaclasses lite' patch, or another enabling patch to add this missing descriptor feature.

### Testing

I've verified that these tests correctly fail and detect the feature's absence.