### PR TITLE
rp2: pendsv add support for CPU affinity

### DIFF
--- a/ports/rp2/cyw43_configport.h
+++ b/ports/rp2/cyw43_configport.h
@@ -126,7 +126,7 @@ uint cyw43_get_pin_wl(cyw43_pin_index_t pin_id);
 #define cyw43_hal_get_mac_ascii         mp_hal_get_mac_ascii
 #define cyw43_hal_generate_laa_mac      mp_hal_generate_laa_mac
 
-#define cyw43_schedule_internal_poll_dispatch(func) pendsv_schedule_dispatch(PENDSV_DISPATCH_CYW43, func)
+#define cyw43_schedule_internal_poll_dispatch(func) pendsv_schedule_dispatch_with_affinity(PENDSV_DISPATCH_CYW43, func, 0)
 
 // Bluetooth requires dynamic memory allocation to load its firmware (the allocation
 // call is made from pico-sdk).  This allocation is always done at thread-level, not

--- a/ports/rp2/mpnetworkport.c
+++ b/ports/rp2/mpnetworkport.c
@@ -68,7 +68,7 @@ static void gpio_irq_handler(void) {
         gpio_set_irq_enabled(CYW43_PIN_WL_HOST_WAKE, CYW43_IRQ_LEVEL, false);
         cyw43_has_pending = 1;
         __sev();
-        pendsv_schedule_dispatch(PENDSV_DISPATCH_CYW43, cyw43_poll);
+        pendsv_schedule_dispatch_with_affinity(PENDSV_DISPATCH_CYW43, cyw43_poll, 0);
         CYW43_STAT_INC(IRQ_COUNT);
     }
 }

--- a/ports/rp2/pendsv.h
+++ b/ports/rp2/pendsv.h
@@ -47,9 +47,15 @@ enum {
 
 typedef void (*pendsv_dispatch_t)(void);
 
+typedef struct pendsv_dispatch_wrapper_t {
+    pendsv_dispatch_t task;
+    int affinity;
+} pendsv_dispatch_wrapper_t;
+
 void pendsv_init(void);
 void pendsv_suspend(void);
 void pendsv_resume(void);
 void pendsv_schedule_dispatch(size_t slot, pendsv_dispatch_t f);
+void pendsv_schedule_dispatch_with_affinity(size_t slot, pendsv_dispatch_t f, int affinity);
 
 #endif // MICROPY_INCLUDED_RP2_PENDSV_H


### PR DESCRIPTION
### Summary

The CYW43 driver appears to be very sensitive to CPU core affinity, and uses pendsv to schedule critical tasks.

If Core1 is enabled these appear to fire there more often than not, completely breaking wireless bringup.

See: https://github.com/micropython/micropython/issues/16779

This PR is a proposal of sorts, suggesting the addition of CPU affinity to pendsv so that tasks which *must* be run on core0 (or core1, or either) can be designated as such and avoid breakage when users do something daring and controversial like start core1 before attempting to do anything with wireless.

### Testing

Tested on an RP2350 with the included CYW43/mpnetworkport modifications.

### Trade-offs and Alternatives

It might be possible to fix the CYW43 driver to be less sensitive to these issues, outright block pendsv from running on core1 (I don't really understand the implications of this, so why I'm even proposing this change is a mystery!)

Honestly at this point I'm for disabling core1 on the Pico. It's a horrible bag of footguns that distracts people from asyncio and even when it's not outright buggy or broken (I have spent days tracking down, reporting and fixing issues) it's fertile ground for users to get themselves into all sorts of trouble.

