### PR TITLE
docs: Fix double 'the' in documentation.

### DIFF
--- a/docs/esp8266/tutorial/repl.rst
+++ b/docs/esp8266/tutorial/repl.rst
@@ -38,7 +38,7 @@ browser. The latest versions of Firefox and Chrome are supported.
 
 For your convenience, WebREPL client is hosted at
 `<http://micropython.org/webrepl>`__. Alternatively, you can install it
-locally from the the GitHub repository
+locally from the GitHub repository
 `<https://github.com/micropython/webrepl>`__.
 
 Before connecting to WebREPL, you should set a password and enable it via

--- a/docs/library/framebuf.rst
+++ b/docs/library/framebuf.rst
@@ -114,7 +114,7 @@ Drawing text
 
 .. method:: FrameBuffer.text(s, x, y[, c])
 
-    Write text to the FrameBuffer using the the coordinates as the upper-left
+    Write text to the FrameBuffer using the coordinates as the upper-left
     corner of the text. The color of the text can be defined by the optional
     argument but is otherwise a default value of 1. All characters have
     dimensions of 8x8 pixels and there is currently no way to change the font.

--- a/docs/library/machine.UART.rst
+++ b/docs/library/machine.UART.rst
@@ -83,7 +83,7 @@ Methods
 
      - *pins* is a 4 or 2 item list indicating the TX, RX, RTS and CTS pins (in that order).
        Any of the pins can be None if one wants the UART to operate with limited functionality.
-       If the RTS pin is given the the RX pin must be given as well. The same applies to CTS.
+       If the RTS pin is given the RX pin must be given as well. The same applies to CTS.
        When no pins are given, then the default set of TX and RX pins is taken, and hardware
        flow control will be disabled. If *pins* is ``None``, no pin assignment will be made.
 

--- a/docs/reference/repl.rst
+++ b/docs/reference/repl.rst
@@ -213,7 +213,7 @@ echo turned off, and with optional flow control.
 Raw mode is entered using Ctrl-A. You then send your python code, followed by
 a Ctrl-D. The Ctrl-D will be acknowledged by 'OK' and then the python code will
 be compiled and executed. Any output (or errors) will be sent back. Entering
-Ctrl-B will leave raw mode and return the the regular (aka friendly) REPL.
+Ctrl-B will leave raw mode and return the regular (aka friendly) REPL.
 
 Raw-paste mode is an additional mode within the raw REPL that includes flow control,
 and which compiles code as it receives it. This makes it more robust for high-speed


### PR DESCRIPTION
### Summary

In a couple of places a double 'the' snuck into the documentation. This PR fixes that.
There"s more of this in some TI and a lot of STM32 files, but I didn't think it was worth addressing this.  

### Testing

Not necessary. Only changes to documentation.