### PR TITLE
extmod/vfs_rom: Add bounds checking for all filesystem accesses.

### DIFF
--- a/ports/qemu/boards/SABRELITE/mpconfigboard.mk
+++ b/ports/qemu/boards/SABRELITE/mpconfigboard.mk
@@ -12,6 +12,10 @@ LDSCRIPT = mcu/arm/imx6.ld
 
 SRC_BOARD_O = shared/runtime/gchelper_generic.o
 
+# Use a larger heap than the default so tests run with the native emitter have
+# enough memory (because emitted ARM machine code is larger than Thumb2 code).
+MICROPY_HEAP_SIZE ?= 163840
+
 # It's really armv7a but closest supported value is armv6.
 MPY_CROSS_FLAGS += -march=armv6
 

--- a/tests/extmod/vfs_rom.py
+++ b/tests/extmod/vfs_rom.py
@@ -223,6 +223,79 @@ class TestEdgeCases(unittest.TestCase):
             self.assertEqual(f.read(), b"contents")
 
 
+class TestCorrupt(unittest.TestCase):
+    def test_corrupt_filesystem(self):
+        # Make the filesystem length bigger than the buffer.
+        romfs = bytearray(make_romfs(()))
+        romfs[3] = 0x01
+        with self.assertRaises(OSError):
+            vfs.VfsRom(romfs)
+
+        # Corrupt the filesystem length.
+        romfs = bytearray(make_romfs(()))
+        romfs[3] = 0xFF
+        with self.assertRaises(OSError):
+            vfs.VfsRom(romfs)
+
+        # Corrupt the contents of the filesystem.
+        romfs = bytearray(make_romfs(()))
+        romfs[3] = 0x01
+        romfs.extend(b"\xff\xff")
+        fs = vfs.VfsRom(romfs)
+        with self.assertRaises(OSError):
+            fs.stat("a")
+        self.assertEqual(list(fs.ilistdir("")), [])
+
+    def test_corrupt_file_entry(self):
+        romfs = make_romfs((("file", b"data"),))
+
+        # Corrupt the length of filename.
+        romfs_corrupt = bytearray(romfs)
+        romfs_corrupt[7:] = b"\xff" * (len(romfs) - 7)
+        fs = vfs.VfsRom(romfs_corrupt)
+        with self.assertRaises(OSError):
+            fs.stat("file")
+        self.assertEqual(list(fs.ilistdir("")), [])
+
+        # Erase the data record (change it to a padding record).
+        romfs_corrupt = bytearray(romfs)
+        romfs_corrupt[12] = VfsRomWriter.ROMFS_RECORD_KIND_PADDING
+        fs = vfs.VfsRom(romfs_corrupt)
+        with self.assertRaises(OSError):
+            fs.stat("file")
+        self.assertEqual(list(fs.ilistdir("")), [])
+
+        # Corrupt the header of the data record.
+        romfs_corrupt = bytearray(romfs)
+        romfs_corrupt[12:] = b"\xff" * (len(romfs) - 12)
+        fs = vfs.VfsRom(romfs_corrupt)
+        with self.assertRaises(OSError):
+            fs.stat("file")
+
+        # Corrupt the interior of the data record.
+        romfs_corrupt = bytearray(romfs)
+        romfs_corrupt[13:] = b"\xff" * (len(romfs) - 13)
+        fs = vfs.VfsRom(romfs_corrupt)
+        with self.assertRaises(OSError):
+            fs.stat("file")
+
+        # Change the data record to an indirect pointer and corrupt the length.
+        romfs_corrupt = bytearray(romfs)
+        romfs_corrupt[12] = VfsRomWriter.ROMFS_RECORD_KIND_DATA_POINTER
+        romfs_corrupt[14:18] = b"\xff\xff\xff\xff"
+        fs = vfs.VfsRom(romfs_corrupt)
+        with self.assertRaises(OSError):
+            fs.stat("file")
+
+        # Change the data record to an indirect pointer and corrupt the offset.
+        romfs_corrupt = bytearray(romfs)
+        romfs_corrupt[12] = VfsRomWriter.ROMFS_RECORD_KIND_DATA_POINTER
+        romfs_corrupt[14:18] = b"\x00\xff\xff\xff"
+        fs = vfs.VfsRom(romfs_corrupt)
+        with self.assertRaises(OSError):
+            fs.stat("file")
+
+
 class TestStandalone(TestBase):
     def test_constructor(self):
         self.assertIsInstance(vfs.VfsRom(self.romfs), vfs.VfsRom)


### PR DESCRIPTION
### Summary

While testing ROMFS as part of #8381 I found that it was relatively easy to end up with a corrupt filesystem on the device (eg due to the ROMFS deploy process stopping half way through), which could lead to hard crashes.  Notably: boot loops trying to mount a corrupt filesystem, crashes when importing modules like `os` that first scan the filesystem for `os.py`, and crashing when deploying a new ROMFS in certain cases because the old one is removed while still mounted.

@robert-hh also encountered similar issues when testing #8381.

This PR adds full bounds checking for all ROMFS filesystem accesses.

### Testing

The new code should be fully covered by the new tests that are added here, and they run in CI.

### Trade-offs and Alternatives

I was hoping such bounds checking would not be necessary, because it increases the size and complexity of the ROMFS driver.  But after playing around with ROMFS in a project, it's definitely necessary to have full bounds checking.
