### PR TITLE
py/objtype: Add support for __set_name__. (dict-copy version)

### DIFF
--- a/py/mpconfig.h
+++ b/py/mpconfig.h
@@ -1124,7 +1124,7 @@ typedef time_t mp_timestamp_t;
 #define MICROPY_PY_FUNCTION_ATTRS_CODE (MICROPY_CONFIG_ROM_LEVEL_AT_LEAST_FULL_FEATURES)
 #endif
 
-// Whether to support the descriptors __get__, __set__, __delete__
+// Whether to support the descriptors __get__, __set__, __delete__, __set_name__
 // This costs some code size and makes load/store/delete of instance
 // attributes slower for the classes that use this feature
 #ifndef MICROPY_PY_DESCRIPTORS

--- a/tests/basics/class_descriptor.py
+++ b/tests/basics/class_descriptor.py
@@ -1,21 +1,27 @@
 class Descriptor:
     def __get__(self, obj, cls):
-        print('get')
+        print("get")
         print(type(obj) is Main)
         print(cls is Main)
-        return 'result'
+        return "result"
 
     def __set__(self, obj, val):
-        print('set')
+        print("set")
         print(type(obj) is Main)
         print(val)
 
     def __delete__(self, obj):
-        print('delete')
+        print("delete")
         print(type(obj) is Main)
+
+    def __set_name__(self, owner, name):
+        print("set_name", name)
+        print(owner.__name__ == "Main")
+
 
 class Main:
     Forward = Descriptor()
+
 
 m = Main()
 try:
@@ -26,15 +32,15 @@ except AttributeError:
     raise SystemExit
 
 r = m.Forward
-if 'Descriptor' in repr(r.__class__):
+if "Descriptor" in repr(r.__class__):
     # Target doesn't support descriptors.
-    print('SKIP')
+    print("SKIP")
     raise SystemExit
 
 # Test assignment and deletion.
 
 print(r)
-m.Forward = 'a'
+m.Forward = "a"
 del m.Forward
 
 # Test that lookup of descriptors like __get__ are not passed into __getattr__.

--- a/tests/basics/class_setname_hazard.py
+++ b/tests/basics/class_setname_hazard.py
@@ -1,0 +1,179 @@
+def skip_if_no_descriptors():
+    class Descriptor:
+        def __get__(self, obj, cls):
+            return
+
+    class TestClass:
+        Forward = Descriptor()
+
+    a = TestClass()
+    try:
+        a.__class__
+    except AttributeError:
+        # Target doesn't support __class__.
+        print("SKIP")
+        raise SystemExit
+
+    b = a.Forward
+    if "Descriptor" in repr(b.__class__):
+        # Target doesn't support descriptors.
+        print("SKIP")
+        raise SystemExit
+
+
+skip_if_no_descriptors()
+
+
+# Test basic hazard-free mutations of the enclosing class.
+
+
+class GetSibling:
+    def __set_name__(self, owner, name):
+        print(getattr(owner, name + "_sib"))
+
+
+class GetSiblingTest:
+    desc = GetSibling()
+    desc_sib = 111
+
+
+t110 = GetSiblingTest()
+
+
+class SetSibling:
+    def __set_name__(self, owner, name):
+        setattr(owner, name + "_sib", 121)
+
+
+class SetSiblingTest:
+    desc = SetSibling()
+
+
+t120 = SetSiblingTest()
+
+print(t120.desc_sib)
+
+
+class DelSibling:
+    def __set_name__(self, owner, name):
+        delattr(owner, name + "_sib")
+
+
+class DelSiblingTest:
+    desc = DelSibling()
+    desc_sib = 131
+
+
+t130 = DelSiblingTest()
+
+try:
+    print(t130.desc_sib)
+except AttributeError:
+    print("AttributeError")
+
+
+class GetSelf:
+    x = 211
+
+    def __set_name__(self, owner, name):
+        print(getattr(owner, name).x)
+
+
+class GetSelfTest:
+    desc = GetSelf()
+
+
+t210 = GetSelfTest()
+
+
+class SetSelf:
+    def __set_name__(self, owner, name):
+        setattr(owner, name, 221)
+
+
+class SetSelfTest:
+    desc = SetSelf()
+
+
+t220 = SetSelfTest()
+
+print(t220.desc)
+
+
+class DelSelf:
+    def __set_name__(self, owner, name):
+        delattr(owner, name)
+
+
+class DelSelfTest:
+    desc = DelSelf()
+
+
+t230 = DelSelfTest()
+
+try:
+    print(t230.desc)
+except AttributeError:
+    print("AttributeError")
+
+
+# Test exception behavior
+
+
+class Raise:
+    def __set_name__(self, owner, name):
+        raise Exception()
+
+
+try:
+
+    class RaiseTest:
+        desc = Raise()
+except Exception as e:
+    print("Exception")
+
+
+# Test simple hazards: whether other class attributes still get __set_name__ even if removed before being run
+
+
+class SetSpecific:
+    def __init__(self, sib_name, sib_replace):
+        self.sib_name = sib_name
+        self.sib_replace = sib_replace
+
+    def __set_name__(self, owner, name):
+        setattr(owner, self.sib_name, self.sib_replace)
+
+
+class SetReplaceTest:
+    a = SetSpecific("b", 312)  # one of these is changed first
+    b = SetSpecific("a", 311)
+
+
+t310 = SetReplaceTest()
+print(t310.a)
+print(t310.b)
+
+
+class DelSpecific:
+    def __init__(self, sib_name):
+        self.sib_name = sib_name
+
+    def __set_name__(self, owner, name):
+        delattr(owner, self.sib_name)
+
+
+class DelReplaceTest:
+    a = DelSpecific("b")  # one of these is removed first
+    b = DelSpecific("a")
+
+
+t320 = DelReplaceTest()
+try:
+    print(t320.a)
+except AttributeError:
+    print("AttributeError")
+try:
+    print(t320.b)
+except AttributeError:
+    print("AttributeError")

--- a/tests/basics/class_setname_hazard_rand.py
+++ b/tests/basics/class_setname_hazard_rand.py
@@ -1,0 +1,130 @@
+# Test to make sure there's no sequence hazard even when a __set_name__ implementation
+# mutates and reorders the class namespace.
+# VERY hard bug to prove out except via a stochastic test.
+
+
+def skip_if_no_descriptors():
+    class Descriptor:
+        def __get__(self, obj, cls):
+            return
+
+    class TestClass:
+        Forward = Descriptor()
+
+    a = TestClass()
+    try:
+        a.__class__
+    except AttributeError:
+        # Target doesn't support __class__.
+        print("SKIP")
+        raise SystemExit
+
+    b = a.Forward
+    if "Descriptor" in repr(b.__class__):
+        # Target doesn't support descriptors.
+        print("SKIP")
+        raise SystemExit
+
+
+def skip_if_no_libs():
+    try:
+        import random
+    except ImportError:
+        # Target doesn't have a random library
+        print("SKIP")
+        raise SystemExit
+
+    try:
+        random.choice
+    except AttributeError:
+        # Target doesn't have an ACTUAL random library
+        print("SKIP")
+        raise SystemExit
+
+    try:
+        import re
+    except ImportError:
+        # Target doesn't have a regex library
+        print("SKIP")
+        raise SystemExit
+
+
+skip_if_no_descriptors()
+skip_if_no_libs()
+
+
+import random
+import re
+
+letters = "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
+
+junk_re = re.compile(r"[A-Z][A-Z][A-Z][A-Z][A-Z]")
+
+
+def junk_fill(obj, n=10):  # Add randomly-generated attributes to an object.
+    for i in range(n):
+        name = "".join(random.choice(letters) for j in range(5))
+        setattr(obj, name, object())
+
+
+def junk_clear(obj):  # Remove attributes added by junk_fill.
+    to_del = [name for name in dir(obj) if junk_re.match(name)]
+    for name in to_del:
+        delattr(obj, name)
+
+
+def junk_sequencer():
+    global runs
+    try:
+        while True:
+            owner, name = yield
+            runs[name] = runs.get(name, 0) + 1
+            junk_fill(owner)
+    finally:
+        junk_clear(owner)
+
+
+class JunkMaker:
+    def __set_name__(self, owner, name):
+        global seq
+        seq.send((owner, name))
+
+
+runs = {}
+seq = junk_sequencer()
+next(seq)
+
+
+class Main:
+    a = JunkMaker()
+    b = JunkMaker()
+    c = JunkMaker()
+    d = JunkMaker()
+    e = JunkMaker()
+    f = JunkMaker()
+    g = JunkMaker()
+    h = JunkMaker()
+    i = JunkMaker()
+    j = JunkMaker()
+    k = JunkMaker()
+    l = JunkMaker()
+    m = JunkMaker()
+    n = JunkMaker()
+    o = JunkMaker()
+    p = JunkMaker()
+    q = JunkMaker()
+    r = JunkMaker()
+    s = JunkMaker()
+    t = JunkMaker()
+    u = JunkMaker()
+    v = JunkMaker()
+    w = JunkMaker()
+    x = JunkMaker()
+    y = JunkMaker()
+    z = JunkMaker()
+
+
+seq.close()
+
+for k in letters.lower():
+    print(k, runs.get(k, 0))


### PR DESCRIPTION
### Summary

This implements the alternative "flat dict copy" logic discussed in #16806 as another way to eliminate the modify-while-iterating hazard in the original `__set_name__` implementation (#15503).

### Testing

This feature was developed test-first. All automated tests pass, including additional tests added to verify the additional behavior around whether `__set_name__` is called even on descriptors that another `__set_name__` removes beforehand.

### Trade-offs and Alternatives

This version has significantly lower code complexity than #16806, but at the cost of a larger runtime memory footprint. It's still a bit more complex than #15503, though.
