### PR TITLE
tests/run-tests: Two small quality-of-life improvements for unittest.

### DIFF
--- a/tests/run-tests.py
+++ b/tests/run-tests.py
@@ -1004,6 +1004,16 @@ def run_tests(pyb, tests, args, result_dir, num_threads=1):
 
         test_count.increment()
 
+        # Print a note if this looks like it might have been a misfired unittest
+        if not uses_unittest and not test_passed:
+            with open(test_file, "r") as f:
+                if any(re.match("^import.+unittest", l) for l in f.readlines()):
+                    print(
+                        "NOTE: {} may be a unittest that doesn't run unittest.main()".format(
+                            test_file
+                        )
+                    )
+
     if pyb:
         num_threads = 1
 

--- a/tests/run-tests.py
+++ b/tests/run-tests.py
@@ -996,6 +996,8 @@ def run_tests(pyb, tests, args, result_dir, num_threads=1):
             if output_expected is not None:
                 with open(filename_expected, "wb") as f:
                     f.write(output_expected)
+            else:
+                rm_f(filename_expected)  # in case left over from previous failed run
             with open(filename_mupy, "wb") as f:
                 f.write(output_mupy)
             failed_tests.append((test_name, test_file))


### PR DESCRIPTION
### Summary

These are two small quality-of-life improvements for making new tests with `unittest`, particularly for the failure mode of forgetting the call to `unittest.main()` (which I am prone to doing):

* Print a note if it looks like a test might have forgotten `unittest.main()`.
* Clean up any `.exp` file which was generated from an early mal-formed unittest run, after it runs correctly.