### PR TITLE
tests/internal_bench: Benchmarks for descriptor-related features.

### DIFF
--- a/tests/internal_bench/class_create-0-empty.py
+++ b/tests/internal_bench/class_create-0-empty.py
@@ -1,0 +1,11 @@
+import bench
+
+
+def test(num):
+    for i in range(num // 40):
+
+        class X:
+            pass
+
+
+bench.run(test)

--- a/tests/internal_bench/class_create-1-slots.py
+++ b/tests/internal_bench/class_create-1-slots.py
@@ -1,0 +1,12 @@
+import bench
+
+
+def test(num):
+    l = ["x"]
+    for i in range(num // 40):
+
+        class X:
+            __slots__ = l
+
+
+bench.run(test)

--- a/tests/internal_bench/class_create-1.1-slots5.py
+++ b/tests/internal_bench/class_create-1.1-slots5.py
@@ -1,0 +1,12 @@
+import bench
+
+
+def test(num):
+    l = ["a", "b", "c", "d", "x"]
+    for i in range(num // 40):
+
+        class X:
+            __slots__ = l
+
+
+bench.run(test)

--- a/tests/internal_bench/class_create-2-classattr.py
+++ b/tests/internal_bench/class_create-2-classattr.py
@@ -1,0 +1,11 @@
+import bench
+
+
+def test(num):
+    for i in range(num // 40):
+
+        class X:
+            x = 1
+
+
+bench.run(test)

--- a/tests/internal_bench/class_create-2.1-classattr5.py
+++ b/tests/internal_bench/class_create-2.1-classattr5.py
@@ -1,0 +1,15 @@
+import bench
+
+
+def test(num):
+    for i in range(num // 40):
+
+        class X:
+            a = 0
+            b = 0
+            c = 0
+            d = 0
+            x = 1
+
+
+bench.run(test)

--- a/tests/internal_bench/class_create-2.3-classattr5objs.py
+++ b/tests/internal_bench/class_create-2.3-classattr5objs.py
@@ -1,0 +1,20 @@
+import bench
+
+
+class Class:
+    pass
+
+
+def test(num):
+    instance = Class()
+    for i in range(num // 40):
+
+        class X:
+            a = instance
+            b = instance
+            c = instance
+            d = instance
+            x = instance
+
+
+bench.run(test)

--- a/tests/internal_bench/class_create-3-instancemethod.py
+++ b/tests/internal_bench/class_create-3-instancemethod.py
@@ -1,0 +1,12 @@
+import bench
+
+
+def test(num):
+    for i in range(num // 40):
+
+        class X:
+            def x(self):
+                pass
+
+
+bench.run(test)

--- a/tests/internal_bench/class_create-4-classmethod.py
+++ b/tests/internal_bench/class_create-4-classmethod.py
@@ -1,0 +1,13 @@
+import bench
+
+
+def test(num):
+    for i in range(num // 40):
+
+        class X:
+            @classmethod
+            def x(cls):
+                pass
+
+
+bench.run(test)

--- a/tests/internal_bench/class_create-4.1-classmethod_implicit.py
+++ b/tests/internal_bench/class_create-4.1-classmethod_implicit.py
@@ -1,0 +1,12 @@
+import bench
+
+
+def test(num):
+    for i in range(num // 40):
+
+        class X:
+            def __new__(cls):
+                pass
+
+
+bench.run(test)

--- a/tests/internal_bench/class_create-5-staticmethod.py
+++ b/tests/internal_bench/class_create-5-staticmethod.py
@@ -1,0 +1,13 @@
+import bench
+
+
+def test(num):
+    for i in range(num // 40):
+
+        class X:
+            @staticmethod
+            def x():
+                pass
+
+
+bench.run(test)

--- a/tests/internal_bench/class_create-6-getattribute.py
+++ b/tests/internal_bench/class_create-6-getattribute.py
@@ -1,0 +1,12 @@
+import bench
+
+
+def test(num):
+    for i in range(num // 40):
+
+        class X:
+            def __getattribute__(self, name):
+                pass
+
+
+bench.run(test)

--- a/tests/internal_bench/class_create-6.1-getattr.py
+++ b/tests/internal_bench/class_create-6.1-getattr.py
@@ -1,0 +1,12 @@
+import bench
+
+
+def test(num):
+    for i in range(num // 40):
+
+        class X:
+            def __getattr__(self, name):
+                pass
+
+
+bench.run(test)

--- a/tests/internal_bench/class_create-6.2-property.py
+++ b/tests/internal_bench/class_create-6.2-property.py
@@ -1,0 +1,13 @@
+import bench
+
+
+def test(num):
+    for i in range(num // 40):
+
+        class X:
+            @property
+            def x(self):
+                pass
+
+
+bench.run(test)

--- a/tests/internal_bench/class_create-6.3-descriptor.py
+++ b/tests/internal_bench/class_create-6.3-descriptor.py
@@ -1,0 +1,17 @@
+import bench
+
+
+class D:
+    def __get__(self, instance, owner=None):
+        pass
+
+
+def test(num):
+    descriptor = D()
+    for i in range(num // 40):
+
+        class X:
+            x = descriptor
+
+
+bench.run(test)

--- a/tests/internal_bench/class_create-7-inherit.py
+++ b/tests/internal_bench/class_create-7-inherit.py
@@ -1,0 +1,14 @@
+import bench
+
+
+def test(num):
+    class B:
+        pass
+
+    for i in range(num // 40):
+
+        class X(B):
+            pass
+
+
+bench.run(test)

--- a/tests/internal_bench/class_create-7.1-inherit_initsubclass.py
+++ b/tests/internal_bench/class_create-7.1-inherit_initsubclass.py
@@ -1,0 +1,16 @@
+import bench
+
+
+def test(num):
+    class B:
+        @classmethod
+        def __init_subclass__(cls):
+            pass
+
+    for i in range(num // 40):
+
+        class X(B):
+            pass
+
+
+bench.run(test)

--- a/tests/internal_bench/class_create-8-metaclass_setname.py
+++ b/tests/internal_bench/class_create-8-metaclass_setname.py
@@ -1,0 +1,17 @@
+import bench
+
+
+class D:
+    def __set_name__(self, owner, name):
+        pass
+
+
+def test(num):
+    descriptor = D()
+    for i in range(num // 40):
+
+        class X:
+            x = descriptor
+
+
+bench.run(test)

--- a/tests/internal_bench/class_create-8.1-metaclass_setname5.py
+++ b/tests/internal_bench/class_create-8.1-metaclass_setname5.py
@@ -1,0 +1,21 @@
+import bench
+
+
+class D:
+    def __set_name__(self, owner, name):
+        pass
+
+
+def test(num):
+    descriptor = D()
+    for i in range(num // 40):
+
+        class X:
+            a = descriptor
+            b = descriptor
+            c = descriptor
+            d = descriptor
+            x = descriptor
+
+
+bench.run(test)

--- a/tests/internal_bench/var-6.2-instance-speciallookup.py
+++ b/tests/internal_bench/var-6.2-instance-speciallookup.py
@@ -1,0 +1,19 @@
+import bench
+
+
+class Foo:
+    def __init__(self):
+        self.num = 20000000
+
+    def __getattr__(self, name):  # just trigger the 'special lookups' flag on the class
+        pass
+
+
+def test(num):
+    o = Foo()
+    i = 0
+    while i < o.num:
+        i += 1
+
+
+bench.run(test)

--- a/tests/internal_bench/var-6.3-instance-property.py
+++ b/tests/internal_bench/var-6.3-instance-property.py
@@ -1,0 +1,17 @@
+import bench
+
+
+class Foo:
+    @property
+    def num(self):
+        return 20000000
+
+
+def test(num):
+    o = Foo()
+    i = 0
+    while i < o.num:
+        i += 1
+
+
+bench.run(test)

--- a/tests/internal_bench/var-6.4-instance-descriptor.py
+++ b/tests/internal_bench/var-6.4-instance-descriptor.py
@@ -1,0 +1,20 @@
+import bench
+
+
+class Descriptor:
+    def __get__(self, instance, owner=None):
+        return 20000000
+
+
+class Foo:
+    num = Descriptor()
+
+
+def test(num):
+    o = Foo()
+    i = 0
+    while i < o.num:
+        i += 1
+
+
+bench.run(test)

--- a/tests/internal_bench/var-6.5-instance-getattr.py
+++ b/tests/internal_bench/var-6.5-instance-getattr.py
@@ -1,0 +1,16 @@
+import bench
+
+
+class Foo:
+    def __getattr__(self, name):
+        return 20000000
+
+
+def test(num):
+    o = Foo()
+    i = 0
+    while i < o.num:
+        i += 1
+
+
+bench.run(test)

--- a/tests/run-tests.py
+++ b/tests/run-tests.py
@@ -1145,29 +1145,11 @@ class append_filter(argparse.Action):
         args.filters.append((option, re.compile(value)))
 
 
-def main():
-    global injected_import_hook_code
-
-    cmd_parser = argparse.ArgumentParser(
-        formatter_class=argparse.RawDescriptionHelpFormatter,
-        description="""Run and manage tests for MicroPython.
-
+test_instance_description = """\
 By default the tests are run against the unix port of MicroPython. To run it
 against something else, use the -t option.  See below for details.
-
-Tests are discovered by scanning test directories for .py files or using the
-specified test files. If test files nor directories are specified, the script
-expects to be ran in the tests directory (where this file is located) and the
-builtin tests suitable for the target platform are ran.
-
-When running tests, run-tests.py compares the MicroPython output of the test with the output
-produced by running the test through CPython unless a <test>.exp file is found, in which
-case it is used as comparison.
-
-If a test fails, run-tests.py produces a pair of <test>.out and <test>.exp files in the result
-directory with the MicroPython output and the expectations, respectively.
-""",
-        epilog="""\
+"""
+test_instance_epilog = """\
 The -t option accepts the following for the test instance:
 - unix - use the unix port of MicroPython, specified by the MICROPY_MICROPYTHON
   environment variable (which defaults to the standard variant of either the unix
@@ -1183,7 +1165,35 @@ The -t option accepts the following for the test instance:
 - execpty:<command> - execute a command and attach to the printed /dev/pts/<n> device
 - <a>.<b>.<c>.<d> - connect to the given IPv4 address
 - anything else specifies a serial port
+"""
 
+test_directory_description = """\
+Tests are discovered by scanning test directories for .py files or using the
+specified test files. If test files nor directories are specified, the script
+expects to be ran in the tests directory (where this file is located) and the
+builtin tests suitable for the target platform are ran.
+"""
+
+
+def main():
+    global injected_import_hook_code
+
+    cmd_parser = argparse.ArgumentParser(
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        description=f"""Run and manage tests for MicroPython.
+
+{test_instance_description}
+{test_directory_description}
+
+When running tests, run-tests.py compares the MicroPython output of the test with the output
+produced by running the test through CPython unless a <test>.exp file is found, in which
+case it is used as comparison.
+
+If a test fails, run-tests.py produces a pair of <test>.out and <test>.exp files in the result
+directory with the MicroPython output and the expectations, respectively.
+""",
+        epilog=f"""\
+{test_instance_epilog}
 Options -i and -e can be multiple and processed in the order given. Regex
 "search" (vs "match") operation is used. An action (include/exclude) of
 the last matching regex is used:


### PR DESCRIPTION
### Summary

This includes new `internal_bench` benchmarks for how quickly micropython can process class definitions, created in order to gauge the performance penalty for implementing `__set_name__` in the different ways proposed in #15503, #16806, and #16816.

It also includes an update to `run-internalbench.py` that adds in the same ability to run the benchmarks on remote micropython instances (e.g. actual microcontroller hardware) that the main `run-tests.py` has.

### Testing

I've tested these benchmarks using the unix port inside WSL on my development machine, with the following results:

<pre><code><b> . . .
internal_bench/class_create:</b>
    <b>0.351s (+00.00%) internal_bench/class_create-0-empty.py</b>
    <b>0.476s (+35.91%) internal_bench/class_create-1-slots.py</b>
    <b>0.484s (+38.01%) internal_bench/class_create-1.1-slots5.py</b>
    <b>0.427s (+21.87%) internal_bench/class_create-2-classattr.py</b>
    <b>0.773s (+120.54%) internal_bench/class_create-2.1-classattr5.py</b>
    <b>0.458s (+30.62%) internal_bench/class_create-3-instancemethod.py</b>
    <b>0.500s (+42.76%) internal_bench/class_create-4-classmethod.py</b>
    <b>0.462s (+31.65%) internal_bench/class_create-4.1-classmethod_implicit.py</b>
    <b>0.498s (+41.93%) internal_bench/class_create-5-staticmethod.py</b>
    <b>0.456s (+29.97%) internal_bench/class_create-6-getattribute.py</b>
    <b>0.467s (+33.13%) internal_bench/class_create-6.1-getattr.py</b>
    <b>0.388s (+10.58%) internal_bench/class_create-6.2-descriptor.py</b>
    <b>0.529s (+50.89%) internal_bench/class_create-6.3-descriptor_setname.py</b>
    <b>0.425s (+21.22%) internal_bench/class_create-6.4-property.py</b>
    <b>0.368s (+05.02%) internal_bench/class_create-7-inherit.py</b>
    <b>0.359s (+02.35%) internal_bench/class_create-7.1-inherit_initsubclass.py</b>
 . . .
internal_bench/var:
    0.459s (+00.00%) internal_bench/var-1-constant.py
    0.620s (+35.05%) internal_bench/var-2-global.py
    0.443s (-03.42%) internal_bench/var-3-local.py
    0.441s (-03.96%) internal_bench/var-4-arg.py
    1.131s (+146.39%) internal_bench/var-5-class-attr.py
    0.539s (+17.34%) internal_bench/var-6-instance-attr.py
    0.555s (+20.85%) internal_bench/var-6.1-instance-attr-5.py
    <b>0.537s (+17.04%) internal_bench/var-6.2-instance-speciallookup.py</b>
    <b>2.436s (+430.54%) internal_bench/var-6.3-instance-property.py</b>
    <b>3.102s (+575.63%) internal_bench/var-6.4-instance-descriptor.py</b>
    <b>3.144s (+584.85%) internal_bench/var-6.5-instance-getattr.py</b>
    2.422s (+427.62%) internal_bench/var-7-instance-meth.py
    0.865s (+88.46%) internal_bench/var-8-namedtuple-1st.py
    0.924s (+101.30%) internal_bench/var-8.1-namedtuple-5th.py
 . . .
</code></pre>

### Trade-offs and Alternatives

Due to the overall slow speed of class creation in general, the `class_create` tests reduce the number of iterations from 20,000,000 to just 500,000; but this should still be wide enough to give the results adequate statistical significance.

For microcontroller remotes it uses 200,000 as the base default (which in the class_create case gets divided down to 5,000 runs).