### PR TITLE
shared/runtime/pyexec: Add a function to execute vstr.

### DIFF
--- a/shared/runtime/pyexec.c
+++ b/shared/runtime/pyexec.c
@@ -720,6 +720,11 @@ int pyexec_frozen_module(const char *name, bool allow_keyboard_interrupt) {
 }
 #endif
 
+int pyexec_vstr(vstr_t *str, bool allow_keyboard_interrupt) {
+    mp_uint_t exec_flags = allow_keyboard_interrupt ? 0 : EXEC_FLAG_NO_INTERRUPT;
+    return parse_compile_execute(str, MP_PARSE_FILE_INPUT, exec_flags | EXEC_FLAG_SOURCE_IS_VSTR);
+}
+
 #if MICROPY_REPL_INFO
 mp_obj_t pyb_set_repl_info(mp_obj_t o_value) {
     repl_display_debugging_info = mp_obj_get_int(o_value);

--- a/shared/runtime/pyexec.h
+++ b/shared/runtime/pyexec.h
@@ -42,6 +42,7 @@ int pyexec_friendly_repl(void);
 int pyexec_file(const char *filename);
 int pyexec_file_if_exists(const char *filename);
 int pyexec_frozen_module(const char *name, bool allow_keyboard_interrupt);
+int pyexec_vstr(vstr_t *str, bool allow_keyboard_interrupt);
 void pyexec_event_repl_init(void);
 int pyexec_event_repl_process_char(int c);
 extern uint8_t pyexec_repl_active;


### PR DESCRIPTION
### Summary

Just a simple function to execute a script from a vstr.

### Testing

Example test:
```C
vstr_t script_buf;
vstr_init(&script_buf, 1024);

vstr_printf(&script_buf, "print('HelloWorld')");

pyexec_str(&script_buf, true);
```

While we're at it, I noticed that `pyexec_file` is not used anywhere in the codebase. Should it be removed or made static?