### PR TITLE
docs/library/enum.rst: Add Enum class.

### DIFF
--- a/docs/library/enum.rst
+++ b/docs/library/enum.rst
@@ -1,0 +1,132 @@
+:mod:`enum` -- MicroPython Enum class like in the Python
+========================================================
+
+.. module:: enum
+   :synopsis: MicroPython Enum class like in the Python
+
+This module implements enumeration Enum class for the MicroPython.
+
+class Enum -- enumeration
+-------------------------
+
+Base class for creating enumerated constants as a set of symbolic names(members) bound to unique values.
+
+
+Constructor
+-----------
+
+.. class:: Enum()
+           Enum(name, names)
+           Enum(value)
+
+   Construct and return a new Enum object using the following parameter:
+
+      - *name* is the name of the Enum class.
+      - *names* is the dictionary of key-value pairs.
+      - *value* is the key or value. Member is returned if the value is in the Enum class, and ValueError is raised otherwise.
+
+Methods
+-------
+
+.. method:: Enum.list()
+
+    Return the list of members of the Enum class.
+
+.. method:: Enum.is_value(value)
+
+    Check if the value is in the Enum class.
+    Returns True if the value is in the Enum class, and False otherwise.
+
+Usage example::
+
+    from enum import Enum
+
+    # Class syntax
+    class Color(Enum):
+        RED = 1
+        GREEN = 2
+        BLUE = 3
+
+    color = Color()
+
+    # or
+
+    # Functional syntax
+    color = Enum('Color', {'RED': 1, 'GREEN': 2, 'BLUE': 3})
+
+    print(color.list())
+    print(color('GREEN'))
+    print(color(2))
+    print(color.GREEN)
+    print(color.GREEN.name)
+    print(color.GREEN.value)
+    print(len(color))
+    print([m for m in color])
+
+Output is::
+
+    [Color.RED: 1, Color.GREEN: 2, Color.BLUE: 3]
+    Color.GREEN: 2
+    Color.GREEN: 2
+    Color.GREEN: 2
+    GREEN
+    2
+    3
+    [Color.RED: 1, Color.GREEN: 2, Color.BLUE: 3]
+
+Usage example::
+
+    from enum import Enum
+
+    class State(Enum):
+        Stop = 10
+        Run = 20
+        Ready = 30
+
+    state = State()
+    print("state:", State())
+
+    current_state = state.Stop
+    print("current_state:", current_state, state(current_state))
+    if current_state == state.Stop:
+        print(" Stop state")
+    if current_state != state.Ready:
+        print(" Not a Ready state")
+        print(" Run!")
+        current_state = state.Run
+    print("current_state:", current_state, state(current_state))
+    # some process
+    i = -1
+    while current_state != state.Ready:
+        i += 1
+        if state.is_value(i):
+            if state(i) == state.Ready:
+                current_state = state.Ready
+        print(".", end="")
+    print()
+    print("current_state:", current_state, state(current_state))
+    print("Done!")
+
+Output is::
+
+    state: Enum(name='State', names={'Run': 20, 'Stop': 10, 'Ready': 30})
+    current_state: State.Stop: 10 State.Stop: 10
+    Stop state
+    Not a Ready state
+    Run!
+    current_state: State.Run: 20 State.Run: 20
+    ...............................
+    current_state: State.Ready: 30 State.Ready: 30
+    Done!
+
+.. warning::
+
+    ABC
+
+.. note::
+
+    ABC
+
+.. seealso::
+
+    See `enum_test.py <https://github.com/micropython/micropython-lib/pull/980/files/>`_ and `enum.py <https://github.com/micropython/micropython-lib/pull/980/files/>`_

--- a/docs/library/index.rst
+++ b/docs/library/index.rst
@@ -62,6 +62,7 @@ library.
    builtins.rst
    cmath.rst
    collections.rst
+   enum.rst
    errno.rst
    gc.rst
    gzip.rst

--- a/ports/esp32/modules/enum.py
+++ b/ports/esp32/modules/enum.py
@@ -1,5 +1,5 @@
 # enum.py
-# version="1.2.5"
+# version="1.2.6"
 
 
 class EnumValue:
@@ -14,11 +14,112 @@ class EnumValue:
     def __call__(self):
         return self.value
 
-    def __eq__(self, o):
-        return self.value == (o.value if isinstance(o, EnumValue) else o)
-
     def __setattr__(self, k, v):
         raise AttributeError("EnumValue is immutable")
+
+    # Helper function to extract the raw value
+    def _get_value(self, o):
+        return o.value if isinstance(o, EnumValue) else o
+
+    # Arithmetic and Bitwise operations (Forward)
+    def __add__(self, o):
+        return self.value + self._get_value(o)
+
+    def __sub__(self, o):
+        return self.value - self._get_value(o)
+
+    def __mul__(self, o):
+        return self.value * self._get_value(o)
+
+    def __truediv__(self, o):
+        return self.value / self._get_value(o)
+
+    def __floordiv__(self, o):
+        return self.value // self._get_value(o)
+
+    def __mod__(self, o):
+        return self.value % self._get_value(o)
+
+    def __pow__(self, o):
+        return self.value ** self._get_value(o)
+
+    def __and__(self, o):
+        return self.value & self._get_value(o)
+
+    def __or__(self, o):
+        return self.value | self._get_value(o)
+
+    def __xor__(self, o):
+        return self.value ^ self._get_value(o)
+
+    def __lshift__(self, o):
+        return self.value << self._get_value(o)
+
+    def __rshift__(self, o):
+        return self.value >> self._get_value(o)
+
+    # Arithmetic and Bitwise operations (Reflected)
+    def __radd__(self, o):
+        return self._get_value(o) + self.value
+
+    def __rsub__(self, o):
+        return self._get_value(o) - self.value
+
+    def __rmul__(self, o):
+        return self._get_value(o) * self.value
+
+    def __rtruediv__(self, o):
+        return self._get_value(o) / self.value
+
+    def __rfloordiv__(self, o):
+        return self._get_value(o) // self.value
+
+    def __rand__(self, o):
+        return self._get_value(o) & self.value
+
+    def __ror__(self, o):
+        return self._get_value(o) | self.value
+
+    def __rxor__(self, o):
+        return self._get_value(o) ^ self.value
+
+    def __rlshift__(self, o):
+        return self._get_value(o) << self.value
+
+    def __rrshift__(self, o):
+        return self._get_value(o) >> self.value
+
+    # Unary operators
+    def __neg__(self):
+        return -self.value
+
+    def __pos__(self):
+        return +self.value
+
+    def __abs__(self):
+        return abs(self.value)
+
+    def __invert__(self):
+        return ~self.value
+
+    # Comparison
+    def __eq__(self, o):
+        return self.value == self._get_value(o)
+
+    def __lt__(self, o):
+        return self.value < self._get_value(o)
+
+    def __le__(self, o):
+        return self.value <= self._get_value(o)
+
+    def __gt__(self, o):
+        return self.value > self._get_value(o)
+
+    def __ge__(self, o):
+        return self.value >= self._get_value(o)
+
+    def __ne__(self, o):
+        return self.value != self._get_value(o)
 
 
 class Enum:
@@ -27,7 +128,7 @@ class Enum:
         if name and names:
             # Support Functional API: Enum("Name", {"KEY": VALUE})
             # Dynamically create: class <name>
-            new_cls = type(name, (cls, ), {})
+            new_cls = type(name, (cls,), {})
             for k, v in names.items():
                 new_cls._up(k, v)
             new_cls._inited = True

--- a/ports/esp32/modules/enum.py
+++ b/ports/esp32/modules/enum.py
@@ -1,12 +1,12 @@
 # enum.py
-# version="1.2.4"
+# version="1.2.5"
 
 
 class EnumValue:
     # An immutable object representing a specific enum member
-    def __init__(self, value, name):
-        object.__setattr__(self, "value", value)
-        object.__setattr__(self, "name", name)
+    def __init__(self, v, n):
+        object.__setattr__(self, "value", v)
+        object.__setattr__(self, "name", n)
 
     def __repr__(self):
         return f"{self.name}: {self.value}"
@@ -14,131 +14,104 @@ class EnumValue:
     def __call__(self):
         return self.value
 
-    def __eq__(self, other):
-        if isinstance(other, EnumValue):
-            return self.value == other.value
-        return self.value == other
+    def __eq__(self, o):
+        return self.value == (o.value if isinstance(o, EnumValue) else o)
 
-    def __setattr__(self, key, value):
+    def __setattr__(self, k, v):
         raise AttributeError("EnumValue is immutable")
 
 
 class Enum:
     def __new__(cls, name=None, names=None):
-        # Scenario 1: Reverse lookup by value (e.g., Status(1))
-        if name is not None and names is None:
-            if cls is not Enum:
-                return cls._lookup(name)
+        # If a name and names are provided, create a NEW subclass of Enum
+        if name and names:
+            # Support Functional API: Enum("Name", {"KEY": VALUE})
+            # Dynamically create: class <name>
+            new_cls = type(name, (cls, ), {})
+            for k, v in names.items():
+                new_cls._up(k, v)
+            new_cls._inited = True
+            return super().__new__(new_cls)
 
-        # Scenario 2: Functional API (e.g., Enum("Color", {"RED": 1}))
-        return super(Enum, cls).__new__(cls)
+        # Reverse lookup by value or name (e.g., Color(1) or Color("RED"))
+        if name and not names and cls is not Enum:
+            return cls._lookup(name)
+
+        return super().__new__(cls)
 
     def __init__(self, name=None, names=None):
-        if hasattr(self, "_initialized"):
-            return
-
-        # 1. Convert class-level attributes (constants) to EnumValue objects
-        self._scan_class_attrs()
-
-        # Support Functional API: Enum("Name", {"KEY": VALUE})
-        if name is not None and isinstance(names, dict):
-            for key, value in names.items():
-                # Prevent addition if the key already exists
-                if not hasattr(self, key):
-                    self._update(key, value)
-
-        object.__setattr__(self, "_initialized", True)
+        if "_inited" not in self.__class__.__dict__:
+            self._scan()
 
     @classmethod
-    def _lookup(cls, value):
-        # Finds an EnumValue by its raw value
-        for key in dir(cls):
-            if key.startswith("_"):
-                continue
-            attr = getattr(cls, key)
-            if isinstance(attr, EnumValue) and (attr.value == value or attr.name == value):
-                return attr
-            if not callable(attr) and attr == value:
-                # Wrap static numbers found in class definition
-                return EnumValue(attr, key)
-        raise AttributeError(f"{value} is not in {cls.__name__}")
+    def _lookup(cls, v):
+        if "_inited" not in cls.__dict__:
+            cls._scan()
+
+        # Finds an EnumValue by its raw value or name
+        for k in dir(cls):
+            a = getattr(cls, k)
+            if isinstance(a, EnumValue) and (a.value == v or a.name == v):
+                return a
+        raise AttributeError(f"{v} is not in {cls.__name__}")
 
     @classmethod
     def __iter__(cls):
-        if "_initialized" not in cls.__dict__:
-            cls._scan_class_attrs()
-            setattr(cls, "_initialized", True)
+        if "_inited" not in cls.__dict__:
+            cls._scan()
 
-        for key in dir(cls):
-            if key.startswith("_"):
-                continue
-            attr = getattr(cls, key)
+        for k in dir(cls):
+            attr = getattr(cls, k)
             if isinstance(attr, EnumValue):
                 yield attr
 
     @classmethod
     def list(cls):
-        if "_initialized" not in cls.__dict__:
-            cls._scan_class_attrs()
-            setattr(cls, "_initialized", True)
+        if "_inited" not in cls.__dict__:
+            cls._scan()
 
         # Returns a list of all members
-        return [getattr(cls, key) for key in dir(cls) if isinstance(getattr(cls, key), EnumValue)]
+        return [getattr(cls, k) for k in dir(cls) if isinstance(getattr(cls, k), EnumValue)]
 
     @classmethod
-    def _update(cls, key, value):
-        setattr(cls, key, EnumValue(value, key))
+    def _up(cls, k, v):
+        setattr(cls, k, EnumValue(v, k))
 
     @classmethod
-    def _scan_class_attrs(cls):
-        # Converts static class attributes into EnumValue objects
-        # List of methods and internal names that should not be converted
-        ignored = ("is_value", "list")
-        for key in dir(cls):
-            # Skip internal names and methods
-            if key.startswith("_") or key in ignored:
-                continue
+    def _scan(cls):
+        # Convert class-level attributes (constants) to EnumValue objects
+        for k, v in list(cls.__dict__.items()):
+            if not k.startswith("_") and not callable(v) and not isinstance(v, EnumValue):
+                cls._up(k, v)
+        cls._inited = True
 
-            value = getattr(cls, key)
-            # Convert only constants, not methods
-            if not callable(value) and not isinstance(value, EnumValue):
-                cls._update(key, value)
-
-    def is_value(self, value):
-        return any(member.value == value for member in self)
+    def is_value(self, v):
+        return any(m.value == v for m in self)
 
     def __repr__(self):
         # Supports the condition: obj == eval(repr(obj))
-        members = {member.name: member.value for member in self}
-        if self.__class__.__name__ == "Enum":
-            return f"Enum(name='Enum', names={members})"
-        # Return a string like: Name(names={"KEY1": VALUE1, "KEY2": VALUE2, ..})
-        return f"{self.__class__.__name__}(names={members})"
+        d = {m.name: m.value for m in self}
+        # Return a string like: Enum(name='Name', names={'KEY1': VALUE1, 'KEY2': VALUE2, ..})
+        return f"Enum(name='{self.__class__.__name__}', names={d})"
 
-    def __call__(self, value):
-        if not hasattr(self, "_initialized"):
-            self._scan_class_attrs()
-            object.__setattr__(self, "_initialized", True)
+    def __call__(self, v):
+        if "_inited" in self.__class__.__dict__:
+            self._scan()
 
-        for member in self:
-            if member.value == value or member.name == value:
-                return member
-        raise AttributeError(f"{value} is not in {self.__class__.__name__}")
+        return self._lookup(v)
 
-    def __setattr__(self, key, value):
-        if hasattr(self, "_initialized"):
-            raise AttributeError(f"Enum '{self.__class__.__name__}' is static")
-        super().__setattr__(key, value)
+    def __setattr__(self, k, v):
+        if "_inited" in self.__class__.__dict__:
+            raise AttributeError(f"Enum '{self.__class__.__name__}' is immutable")
+        super().__setattr__(k, v)
 
-    def __delattr__(self, key):
-        if hasattr(self, key) and isinstance(getattr(self, key), EnumValue):
-            raise AttributeError("Enum members cannot be deleted")
-        super().__delattr__(key)
+    def __delattr__(self, k):
+        raise AttributeError("Enum is immutable")
 
     def __len__(self):
         return sum(1 for _ in self)
 
-    def __eq__(self, other):
-        if not isinstance(other, Enum):
+    def __eq__(self, o):
+        if not isinstance(o, Enum):
             return False
-        return self.list() == other.list()
+        return self.list() == o.list()

--- a/ports/esp32/modules/enum.py
+++ b/ports/esp32/modules/enum.py
@@ -1,0 +1,144 @@
+# enum.py
+# version="1.2.4"
+
+
+class EnumValue:
+    # An immutable object representing a specific enum member
+    def __init__(self, value, name):
+        object.__setattr__(self, "value", value)
+        object.__setattr__(self, "name", name)
+
+    def __repr__(self):
+        return f"{self.name}: {self.value}"
+
+    def __call__(self):
+        return self.value
+
+    def __eq__(self, other):
+        if isinstance(other, EnumValue):
+            return self.value == other.value
+        return self.value == other
+
+    def __setattr__(self, key, value):
+        raise AttributeError("EnumValue is immutable")
+
+
+class Enum:
+    def __new__(cls, name=None, names=None):
+        # Scenario 1: Reverse lookup by value (e.g., Status(1))
+        if name is not None and names is None:
+            if cls is not Enum:
+                return cls._lookup(name)
+
+        # Scenario 2: Functional API (e.g., Enum("Color", {"RED": 1}))
+        return super(Enum, cls).__new__(cls)
+
+    def __init__(self, name=None, names=None):
+        if hasattr(self, "_initialized"):
+            return
+
+        # 1. Convert class-level attributes (constants) to EnumValue objects
+        self._scan_class_attrs()
+
+        # Support Functional API: Enum("Name", {"KEY": VALUE})
+        if name is not None and isinstance(names, dict):
+            for key, value in names.items():
+                # Prevent addition if the key already exists
+                if not hasattr(self, key):
+                    self._update(key, value)
+
+        object.__setattr__(self, "_initialized", True)
+
+    @classmethod
+    def _lookup(cls, value):
+        # Finds an EnumValue by its raw value
+        for key in dir(cls):
+            if key.startswith("_"):
+                continue
+            attr = getattr(cls, key)
+            if isinstance(attr, EnumValue) and (attr.value == value or attr.name == value):
+                return attr
+            if not callable(attr) and attr == value:
+                # Wrap static numbers found in class definition
+                return EnumValue(attr, key)
+        raise AttributeError(f"{value} is not in {cls.__name__}")
+
+    @classmethod
+    def __iter__(cls):
+        if "_initialized" not in cls.__dict__:
+            cls._scan_class_attrs()
+            setattr(cls, "_initialized", True)
+
+        for key in dir(cls):
+            if key.startswith("_"):
+                continue
+            attr = getattr(cls, key)
+            if isinstance(attr, EnumValue):
+                yield attr
+
+    @classmethod
+    def list(cls):
+        if "_initialized" not in cls.__dict__:
+            cls._scan_class_attrs()
+            setattr(cls, "_initialized", True)
+
+        # Returns a list of all members
+        return [getattr(cls, key) for key in dir(cls) if isinstance(getattr(cls, key), EnumValue)]
+
+    @classmethod
+    def _update(cls, key, value):
+        setattr(cls, key, EnumValue(value, key))
+
+    @classmethod
+    def _scan_class_attrs(cls):
+        # Converts static class attributes into EnumValue objects
+        # List of methods and internal names that should not be converted
+        ignored = ("is_value", "list")
+        for key in dir(cls):
+            # Skip internal names and methods
+            if key.startswith("_") or key in ignored:
+                continue
+
+            value = getattr(cls, key)
+            # Convert only constants, not methods
+            if not callable(value) and not isinstance(value, EnumValue):
+                cls._update(key, value)
+
+    def is_value(self, value):
+        return any(member.value == value for member in self)
+
+    def __repr__(self):
+        # Supports the condition: obj == eval(repr(obj))
+        members = {member.name: member.value for member in self}
+        if self.__class__.__name__ == "Enum":
+            return f"Enum(name='Enum', names={members})"
+        # Return a string like: Name(names={"KEY1": VALUE1, "KEY2": VALUE2, ..})
+        return f"{self.__class__.__name__}(names={members})"
+
+    def __call__(self, value):
+        if not hasattr(self, "_initialized"):
+            self._scan_class_attrs()
+            object.__setattr__(self, "_initialized", True)
+
+        for member in self:
+            if member.value == value or member.name == value:
+                return member
+        raise AttributeError(f"{value} is not in {self.__class__.__name__}")
+
+    def __setattr__(self, key, value):
+        if hasattr(self, "_initialized"):
+            raise AttributeError(f"Enum '{self.__class__.__name__}' is static")
+        super().__setattr__(key, value)
+
+    def __delattr__(self, key):
+        if hasattr(self, key) and isinstance(getattr(self, key), EnumValue):
+            raise AttributeError("Enum members cannot be deleted")
+        super().__delattr__(key)
+
+    def __len__(self):
+        return sum(1 for _ in self)
+
+    def __eq__(self, other):
+        if not isinstance(other, Enum):
+            return False
+        return self.list() == other.list()

--- a/ports/esp32/modules/enum.py
+++ b/ports/esp32/modules/enum.py
@@ -1,204 +1,83 @@
 # enum.py
-# version="1.2.6"
+# version="1.3.0"
 
 
-class EnumValue:
-    # An immutable object representing a specific enum member
-    def __init__(self, v, n):
-        object.__setattr__(self, "value", v)
-        object.__setattr__(self, "name", n)
+def _make_enum(v, n, e):
+    T = type(v)
 
-    def __repr__(self):
-        return f"{self.name}: {self.value}"
-
-    def __call__(self):
-        return self.value
-
-    def __setattr__(self, k, v):
+    def _setattr(self, k, v):
         raise AttributeError("EnumValue is immutable")
 
-    # Helper function to extract the raw value
-    def _get_value(self, o):
-        return o.value if isinstance(o, EnumValue) else o
-
-    # Arithmetic and Bitwise operations (Forward)
-    def __add__(self, o):
-        return self.value + self._get_value(o)
-
-    def __sub__(self, o):
-        return self.value - self._get_value(o)
-
-    def __mul__(self, o):
-        return self.value * self._get_value(o)
-
-    def __truediv__(self, o):
-        return self.value / self._get_value(o)
-
-    def __floordiv__(self, o):
-        return self.value // self._get_value(o)
-
-    def __mod__(self, o):
-        return self.value % self._get_value(o)
-
-    def __pow__(self, o):
-        return self.value ** self._get_value(o)
-
-    def __and__(self, o):
-        return self.value & self._get_value(o)
-
-    def __or__(self, o):
-        return self.value | self._get_value(o)
-
-    def __xor__(self, o):
-        return self.value ^ self._get_value(o)
-
-    def __lshift__(self, o):
-        return self.value << self._get_value(o)
-
-    def __rshift__(self, o):
-        return self.value >> self._get_value(o)
-
-    # Arithmetic and Bitwise operations (Reflected)
-    def __radd__(self, o):
-        return self._get_value(o) + self.value
-
-    def __rsub__(self, o):
-        return self._get_value(o) - self.value
-
-    def __rmul__(self, o):
-        return self._get_value(o) * self.value
-
-    def __rtruediv__(self, o):
-        return self._get_value(o) / self.value
-
-    def __rfloordiv__(self, o):
-        return self._get_value(o) // self.value
-
-    def __rand__(self, o):
-        return self._get_value(o) & self.value
-
-    def __ror__(self, o):
-        return self._get_value(o) | self.value
-
-    def __rxor__(self, o):
-        return self._get_value(o) ^ self.value
-
-    def __rlshift__(self, o):
-        return self._get_value(o) << self.value
-
-    def __rrshift__(self, o):
-        return self._get_value(o) >> self.value
-
-    # Unary operators
-    def __neg__(self):
-        return -self.value
-
-    def __pos__(self):
-        return +self.value
-
-    def __abs__(self):
-        return abs(self.value)
-
-    def __invert__(self):
-        return ~self.value
-
-    # Comparison
-    def __eq__(self, o):
-        return self.value == self._get_value(o)
-
-    def __lt__(self, o):
-        return self.value < self._get_value(o)
-
-    def __le__(self, o):
-        return self.value <= self._get_value(o)
-
-    def __gt__(self, o):
-        return self.value > self._get_value(o)
-
-    def __ge__(self, o):
-        return self.value >= self._get_value(o)
-
-    def __ne__(self, o):
-        return self.value != self._get_value(o)
+    # Create class: type(name, bases, dict), which inherits a base type (int, str, etc.)
+    return type(
+        "EnumValue",
+        (T,),
+        {
+            "name": n,
+            "value": property(lambda s: v),
+            "__repr__": lambda s: f"{e}.{n}: {v}",
+            "__str__": lambda s: f"{e}.{n}: {v}",
+            "__call__": lambda s: v,
+            "__setattr__": _setattr,
+        },
+    )(v)
 
 
 class Enum:
     def __new__(cls, name=None, names=None):
         # If a name and names are provided, create a NEW subclass of Enum
         if name and names:
-            # Support Functional API: Enum("Name", {"KEY": VALUE})
+            # Support Functional API: Enum("Name", {"KEY1": VALUE1, "KEY2": VALUE2, ..})
             # Dynamically create: class <name>
-            new_cls = type(name, (cls,), {})
+            new_cls = type(name, (cls,), {"_inited": True})
             for k, v in names.items():
-                new_cls._up(k, v)
-            new_cls._inited = True
+                setattr(new_cls, k, _make_enum(v, k, name))
             return super().__new__(new_cls)
 
         # Reverse lookup by value or name (e.g., Color(1) or Color("RED"))
-        if name and not names and cls is not Enum:
+        if name and cls is not Enum:
             return cls._lookup(name)
 
         return super().__new__(cls)
 
     def __init__(self, name=None, names=None):
         if "_inited" not in self.__class__.__dict__:
-            self._scan()
+            self.list()
 
     @classmethod
     def _lookup(cls, v):
-        if "_inited" not in cls.__dict__:
-            cls._scan()
-
-        # Finds an EnumValue by its raw value or name
-        for k in dir(cls):
-            a = getattr(cls, k)
-            if isinstance(a, EnumValue) and (a.value == v or a.name == v):
-                return a
+        for m in cls.list():
+            if m.value == v or m.name == v:
+                return m
         raise AttributeError(f"{v} is not in {cls.__name__}")
 
     @classmethod
     def __iter__(cls):
-        if "_inited" not in cls.__dict__:
-            cls._scan()
-
-        for k in dir(cls):
-            attr = getattr(cls, k)
-            if isinstance(attr, EnumValue):
-                yield attr
+        return iter(cls.list())
 
     @classmethod
     def list(cls):
         if "_inited" not in cls.__dict__:
-            cls._scan()
-
-        # Returns a list of all members
-        return [getattr(cls, k) for k in dir(cls) if isinstance(getattr(cls, k), EnumValue)]
+            # Copy dict.items() to avoid RuntimeError when changing the dictionary
+            for k, v in list(cls.__dict__.items()):
+                if not k.startswith("_") and not callable(v):
+                    setattr(cls, k, _make_enum(v, k, cls.__name__))
+            cls._inited = True
+        return [
+            m for k in dir(cls) if not k.startswith("_") and hasattr(m := getattr(cls, k), "name")
+        ]
 
     @classmethod
-    def _up(cls, k, v):
-        setattr(cls, k, EnumValue(v, k))
-
-    @classmethod
-    def _scan(cls):
-        # Convert class-level attributes (constants) to EnumValue objects
-        for k, v in list(cls.__dict__.items()):
-            if not k.startswith("_") and not callable(v) and not isinstance(v, EnumValue):
-                cls._up(k, v)
-        cls._inited = True
-
-    def is_value(self, v):
-        return any(m.value == v for m in self)
+    def is_value(cls, v):
+        return any(m.value == v or m.name == v for m in cls.list())
 
     def __repr__(self):
         # Supports the condition: obj == eval(repr(obj))
-        d = {m.name: m.value for m in self}
+        d = {m.name: m.value for m in self.__class__.list()}
         # Return a string like: Enum(name='Name', names={'KEY1': VALUE1, 'KEY2': VALUE2, ..})
         return f"Enum(name='{self.__class__.__name__}', names={d})"
 
     def __call__(self, v):
-        if "_inited" in self.__class__.__dict__:
-            self._scan()
-
         return self._lookup(v)
 
     def __setattr__(self, k, v):
@@ -209,8 +88,9 @@ class Enum:
     def __delattr__(self, k):
         raise AttributeError("Enum is immutable")
 
-    def __len__(self):
-        return sum(1 for _ in self)
+    @classmethod
+    def __len__(cls):
+        return len(cls.list())
 
     def __eq__(self, o):
         if not isinstance(o, Enum):

--- a/ports/esp32/modules/enum.py
+++ b/ports/esp32/modules/enum.py
@@ -6,7 +6,7 @@ def _make_enum(v, n, e):
     T = type(v)
 
     def _setattr(self, k, v):
-        raise AttributeError("EnumValue is immutable")
+        raise AttributeError(f"{self.__class__.__name__} is immutable")
 
     # Create class: type(name, bases, dict), which inherits a base type (int, str, etc.)
     return type(
@@ -29,7 +29,7 @@ class Enum:
         if name and names:
             # Support Functional API: Enum("Name", {"KEY1": VALUE1, "KEY2": VALUE2, ..})
             # Dynamically create: class <name>
-            new_cls = type(name, (cls,), {"_inited": True})
+            new_cls = type(name, (cls,), {"_i": True})  # _inited
             for k, v in names.items():
                 setattr(new_cls, k, _make_enum(v, k, name))
             return super().__new__(new_cls)
@@ -41,7 +41,7 @@ class Enum:
         return super().__new__(cls)
 
     def __init__(self, name=None, names=None):
-        if "_inited" not in self.__class__.__dict__:
+        if "_i" not in self.__class__.__dict__:
             self.list()
 
     @classmethod
@@ -57,12 +57,12 @@ class Enum:
 
     @classmethod
     def list(cls):
-        if "_inited" not in cls.__dict__:
+        if "_i" not in cls.__dict__:
             # Copy dict.items() to avoid RuntimeError when changing the dictionary
             for k, v in list(cls.__dict__.items()):
                 if not k.startswith("_") and not callable(v):
                     setattr(cls, k, _make_enum(v, k, cls.__name__))
-            cls._inited = True
+            cls._i = True
         return [
             m for k in dir(cls) if not k.startswith("_") and hasattr(m := getattr(cls, k), "name")
         ]
@@ -81,12 +81,12 @@ class Enum:
         return self._lookup(v)
 
     def __setattr__(self, k, v):
-        if "_inited" in self.__class__.__dict__:
-            raise AttributeError(f"Enum '{self.__class__.__name__}' is immutable")
+        if "_i" in self.__class__.__dict__:
+            raise AttributeError(f"{self.__class__.__name__} is immutable")
         super().__setattr__(k, v)
 
     def __delattr__(self, k):
-        raise AttributeError("Enum is immutable")
+        raise AttributeError(f"{self.__class__.__name__} is immutable")
 
     @classmethod
     def __len__(cls):

--- a/ports/mimxrt/modules/enum.py
+++ b/ports/mimxrt/modules/enum.py
@@ -1,0 +1,98 @@
+# enum.py
+# version="1.3.0"
+
+
+def _make_enum(v, n, e):
+    T = type(v)
+
+    def _setattr(self, k, v):
+        raise AttributeError("EnumValue is immutable")
+
+    # Create class: type(name, bases, dict), which inherits a base type (int, str, etc.)
+    return type(
+        "EnumValue",
+        (T,),
+        {
+            "name": n,
+            "value": property(lambda s: v),
+            "__repr__": lambda s: f"{e}.{n}: {v}",
+            "__str__": lambda s: f"{e}.{n}: {v}",
+            "__call__": lambda s: v,
+            "__setattr__": _setattr,
+        },
+    )(v)
+
+
+class Enum:
+    def __new__(cls, name=None, names=None):
+        # If a name and names are provided, create a NEW subclass of Enum
+        if name and names:
+            # Support Functional API: Enum("Name", {"KEY1": VALUE1, "KEY2": VALUE2, ..})
+            # Dynamically create: class <name>
+            new_cls = type(name, (cls,), {"_inited": True})
+            for k, v in names.items():
+                setattr(new_cls, k, _make_enum(v, k, name))
+            return super().__new__(new_cls)
+
+        # Reverse lookup by value or name (e.g., Color(1) or Color("RED"))
+        if name and cls is not Enum:
+            return cls._lookup(name)
+
+        return super().__new__(cls)
+
+    def __init__(self, name=None, names=None):
+        if "_inited" not in self.__class__.__dict__:
+            self.list()
+
+    @classmethod
+    def _lookup(cls, v):
+        for m in cls.list():
+            if m.value == v or m.name == v:
+                return m
+        raise AttributeError(f"{v} is not in {cls.__name__}")
+
+    @classmethod
+    def __iter__(cls):
+        return iter(cls.list())
+
+    @classmethod
+    def list(cls):
+        if "_inited" not in cls.__dict__:
+            # Copy dict.items() to avoid RuntimeError when changing the dictionary
+            for k, v in list(cls.__dict__.items()):
+                if not k.startswith("_") and not callable(v):
+                    setattr(cls, k, _make_enum(v, k, cls.__name__))
+            cls._inited = True
+        return [
+            m for k in dir(cls) if not k.startswith("_") and hasattr(m := getattr(cls, k), "name")
+        ]
+
+    @classmethod
+    def is_value(cls, v):
+        return any(m.value == v or m.name == v for m in cls.list())
+
+    def __repr__(self):
+        # Supports the condition: obj == eval(repr(obj))
+        d = {m.name: m.value for m in self.__class__.list()}
+        # Return a string like: Enum(name='Name', names={'KEY1': VALUE1, 'KEY2': VALUE2, ..})
+        return f"Enum(name='{self.__class__.__name__}', names={d})"
+
+    def __call__(self, v):
+        return self._lookup(v)
+
+    def __setattr__(self, k, v):
+        if "_inited" in self.__class__.__dict__:
+            raise AttributeError(f"Enum '{self.__class__.__name__}' is immutable")
+        super().__setattr__(k, v)
+
+    def __delattr__(self, k):
+        raise AttributeError("Enum is immutable")
+
+    @classmethod
+    def __len__(cls):
+        return len(cls.list())
+
+    def __eq__(self, o):
+        if not isinstance(o, Enum):
+            return False
+        return self.list() == o.list()

--- a/ports/mimxrt/modules/enum.py
+++ b/ports/mimxrt/modules/enum.py
@@ -6,7 +6,7 @@ def _make_enum(v, n, e):
     T = type(v)
 
     def _setattr(self, k, v):
-        raise AttributeError("EnumValue is immutable")
+        raise AttributeError(f"{self.__class__.__name__} is immutable")
 
     # Create class: type(name, bases, dict), which inherits a base type (int, str, etc.)
     return type(
@@ -29,7 +29,7 @@ class Enum:
         if name and names:
             # Support Functional API: Enum("Name", {"KEY1": VALUE1, "KEY2": VALUE2, ..})
             # Dynamically create: class <name>
-            new_cls = type(name, (cls,), {"_inited": True})
+            new_cls = type(name, (cls,), {"_i": True})  # _inited
             for k, v in names.items():
                 setattr(new_cls, k, _make_enum(v, k, name))
             return super().__new__(new_cls)
@@ -41,7 +41,7 @@ class Enum:
         return super().__new__(cls)
 
     def __init__(self, name=None, names=None):
-        if "_inited" not in self.__class__.__dict__:
+        if "_i" not in self.__class__.__dict__:
             self.list()
 
     @classmethod
@@ -57,12 +57,12 @@ class Enum:
 
     @classmethod
     def list(cls):
-        if "_inited" not in cls.__dict__:
+        if "_i" not in cls.__dict__:
             # Copy dict.items() to avoid RuntimeError when changing the dictionary
             for k, v in list(cls.__dict__.items()):
                 if not k.startswith("_") and not callable(v):
                     setattr(cls, k, _make_enum(v, k, cls.__name__))
-            cls._inited = True
+            cls._i = True
         return [
             m for k in dir(cls) if not k.startswith("_") and hasattr(m := getattr(cls, k), "name")
         ]
@@ -81,12 +81,12 @@ class Enum:
         return self._lookup(v)
 
     def __setattr__(self, k, v):
-        if "_inited" in self.__class__.__dict__:
-            raise AttributeError(f"Enum '{self.__class__.__name__}' is immutable")
+        if "_i" in self.__class__.__dict__:
+            raise AttributeError(f"{self.__class__.__name__} is immutable")
         super().__setattr__(k, v)
 
     def __delattr__(self, k):
-        raise AttributeError("Enum is immutable")
+        raise AttributeError(f"{self.__class__.__name__} is immutable")
 
     @classmethod
     def __len__(cls):

--- a/ports/rp2/modules/enum.py
+++ b/ports/rp2/modules/enum.py
@@ -1,0 +1,98 @@
+# enum.py
+# version="1.3.0"
+
+
+def _make_enum(v, n, e):
+    T = type(v)
+
+    def _setattr(self, k, v):
+        raise AttributeError("EnumValue is immutable")
+
+    # Create class: type(name, bases, dict), which inherits a base type (int, str, etc.)
+    return type(
+        "EnumValue",
+        (T,),
+        {
+            "name": n,
+            "value": property(lambda s: v),
+            "__repr__": lambda s: f"{e}.{n}: {v}",
+            "__str__": lambda s: f"{e}.{n}: {v}",
+            "__call__": lambda s: v,
+            "__setattr__": _setattr,
+        },
+    )(v)
+
+
+class Enum:
+    def __new__(cls, name=None, names=None):
+        # If a name and names are provided, create a NEW subclass of Enum
+        if name and names:
+            # Support Functional API: Enum("Name", {"KEY1": VALUE1, "KEY2": VALUE2, ..})
+            # Dynamically create: class <name>
+            new_cls = type(name, (cls,), {"_inited": True})
+            for k, v in names.items():
+                setattr(new_cls, k, _make_enum(v, k, name))
+            return super().__new__(new_cls)
+
+        # Reverse lookup by value or name (e.g., Color(1) or Color("RED"))
+        if name and cls is not Enum:
+            return cls._lookup(name)
+
+        return super().__new__(cls)
+
+    def __init__(self, name=None, names=None):
+        if "_inited" not in self.__class__.__dict__:
+            self.list()
+
+    @classmethod
+    def _lookup(cls, v):
+        for m in cls.list():
+            if m.value == v or m.name == v:
+                return m
+        raise AttributeError(f"{v} is not in {cls.__name__}")
+
+    @classmethod
+    def __iter__(cls):
+        return iter(cls.list())
+
+    @classmethod
+    def list(cls):
+        if "_inited" not in cls.__dict__:
+            # Copy dict.items() to avoid RuntimeError when changing the dictionary
+            for k, v in list(cls.__dict__.items()):
+                if not k.startswith("_") and not callable(v):
+                    setattr(cls, k, _make_enum(v, k, cls.__name__))
+            cls._inited = True
+        return [
+            m for k in dir(cls) if not k.startswith("_") and hasattr(m := getattr(cls, k), "name")
+        ]
+
+    @classmethod
+    def is_value(cls, v):
+        return any(m.value == v or m.name == v for m in cls.list())
+
+    def __repr__(self):
+        # Supports the condition: obj == eval(repr(obj))
+        d = {m.name: m.value for m in self.__class__.list()}
+        # Return a string like: Enum(name='Name', names={'KEY1': VALUE1, 'KEY2': VALUE2, ..})
+        return f"Enum(name='{self.__class__.__name__}', names={d})"
+
+    def __call__(self, v):
+        return self._lookup(v)
+
+    def __setattr__(self, k, v):
+        if "_inited" in self.__class__.__dict__:
+            raise AttributeError(f"Enum '{self.__class__.__name__}' is immutable")
+        super().__setattr__(k, v)
+
+    def __delattr__(self, k):
+        raise AttributeError("Enum is immutable")
+
+    @classmethod
+    def __len__(cls):
+        return len(cls.list())
+
+    def __eq__(self, o):
+        if not isinstance(o, Enum):
+            return False
+        return self.list() == o.list()

--- a/ports/rp2/modules/enum.py
+++ b/ports/rp2/modules/enum.py
@@ -6,7 +6,7 @@ def _make_enum(v, n, e):
     T = type(v)
 
     def _setattr(self, k, v):
-        raise AttributeError("EnumValue is immutable")
+        raise AttributeError(f"{self.__class__.__name__} is immutable")
 
     # Create class: type(name, bases, dict), which inherits a base type (int, str, etc.)
     return type(
@@ -29,7 +29,7 @@ class Enum:
         if name and names:
             # Support Functional API: Enum("Name", {"KEY1": VALUE1, "KEY2": VALUE2, ..})
             # Dynamically create: class <name>
-            new_cls = type(name, (cls,), {"_inited": True})
+            new_cls = type(name, (cls,), {"_i": True})  # _inited
             for k, v in names.items():
                 setattr(new_cls, k, _make_enum(v, k, name))
             return super().__new__(new_cls)
@@ -41,7 +41,7 @@ class Enum:
         return super().__new__(cls)
 
     def __init__(self, name=None, names=None):
-        if "_inited" not in self.__class__.__dict__:
+        if "_i" not in self.__class__.__dict__:
             self.list()
 
     @classmethod
@@ -57,12 +57,12 @@ class Enum:
 
     @classmethod
     def list(cls):
-        if "_inited" not in cls.__dict__:
+        if "_i" not in cls.__dict__:
             # Copy dict.items() to avoid RuntimeError when changing the dictionary
             for k, v in list(cls.__dict__.items()):
                 if not k.startswith("_") and not callable(v):
                     setattr(cls, k, _make_enum(v, k, cls.__name__))
-            cls._inited = True
+            cls._i = True
         return [
             m for k in dir(cls) if not k.startswith("_") and hasattr(m := getattr(cls, k), "name")
         ]
@@ -81,12 +81,12 @@ class Enum:
         return self._lookup(v)
 
     def __setattr__(self, k, v):
-        if "_inited" in self.__class__.__dict__:
-            raise AttributeError(f"Enum '{self.__class__.__name__}' is immutable")
+        if "_i" in self.__class__.__dict__:
+            raise AttributeError(f"{self.__class__.__name__} is immutable")
         super().__setattr__(k, v)
 
     def __delattr__(self, k):
-        raise AttributeError("Enum is immutable")
+        raise AttributeError(f"{self.__class__.__name__} is immutable")
 
     @classmethod
     def __len__(cls):

--- a/ports/samd/modules/enum.py
+++ b/ports/samd/modules/enum.py
@@ -1,0 +1,98 @@
+# enum.py
+# version="1.3.0"
+
+
+def _make_enum(v, n, e):
+    T = type(v)
+
+    def _setattr(self, k, v):
+        raise AttributeError("EnumValue is immutable")
+
+    # Create class: type(name, bases, dict), which inherits a base type (int, str, etc.)
+    return type(
+        "EnumValue",
+        (T,),
+        {
+            "name": n,
+            "value": property(lambda s: v),
+            "__repr__": lambda s: f"{e}.{n}: {v}",
+            "__str__": lambda s: f"{e}.{n}: {v}",
+            "__call__": lambda s: v,
+            "__setattr__": _setattr,
+        },
+    )(v)
+
+
+class Enum:
+    def __new__(cls, name=None, names=None):
+        # If a name and names are provided, create a NEW subclass of Enum
+        if name and names:
+            # Support Functional API: Enum("Name", {"KEY1": VALUE1, "KEY2": VALUE2, ..})
+            # Dynamically create: class <name>
+            new_cls = type(name, (cls,), {"_inited": True})
+            for k, v in names.items():
+                setattr(new_cls, k, _make_enum(v, k, name))
+            return super().__new__(new_cls)
+
+        # Reverse lookup by value or name (e.g., Color(1) or Color("RED"))
+        if name and cls is not Enum:
+            return cls._lookup(name)
+
+        return super().__new__(cls)
+
+    def __init__(self, name=None, names=None):
+        if "_inited" not in self.__class__.__dict__:
+            self.list()
+
+    @classmethod
+    def _lookup(cls, v):
+        for m in cls.list():
+            if m.value == v or m.name == v:
+                return m
+        raise AttributeError(f"{v} is not in {cls.__name__}")
+
+    @classmethod
+    def __iter__(cls):
+        return iter(cls.list())
+
+    @classmethod
+    def list(cls):
+        if "_inited" not in cls.__dict__:
+            # Copy dict.items() to avoid RuntimeError when changing the dictionary
+            for k, v in list(cls.__dict__.items()):
+                if not k.startswith("_") and not callable(v):
+                    setattr(cls, k, _make_enum(v, k, cls.__name__))
+            cls._inited = True
+        return [
+            m for k in dir(cls) if not k.startswith("_") and hasattr(m := getattr(cls, k), "name")
+        ]
+
+    @classmethod
+    def is_value(cls, v):
+        return any(m.value == v or m.name == v for m in cls.list())
+
+    def __repr__(self):
+        # Supports the condition: obj == eval(repr(obj))
+        d = {m.name: m.value for m in self.__class__.list()}
+        # Return a string like: Enum(name='Name', names={'KEY1': VALUE1, 'KEY2': VALUE2, ..})
+        return f"Enum(name='{self.__class__.__name__}', names={d})"
+
+    def __call__(self, v):
+        return self._lookup(v)
+
+    def __setattr__(self, k, v):
+        if "_inited" in self.__class__.__dict__:
+            raise AttributeError(f"Enum '{self.__class__.__name__}' is immutable")
+        super().__setattr__(k, v)
+
+    def __delattr__(self, k):
+        raise AttributeError("Enum is immutable")
+
+    @classmethod
+    def __len__(cls):
+        return len(cls.list())
+
+    def __eq__(self, o):
+        if not isinstance(o, Enum):
+            return False
+        return self.list() == o.list()

--- a/ports/samd/modules/enum.py
+++ b/ports/samd/modules/enum.py
@@ -6,7 +6,7 @@ def _make_enum(v, n, e):
     T = type(v)
 
     def _setattr(self, k, v):
-        raise AttributeError("EnumValue is immutable")
+        raise AttributeError(f"{self.__class__.__name__} is immutable")
 
     # Create class: type(name, bases, dict), which inherits a base type (int, str, etc.)
     return type(
@@ -29,7 +29,7 @@ class Enum:
         if name and names:
             # Support Functional API: Enum("Name", {"KEY1": VALUE1, "KEY2": VALUE2, ..})
             # Dynamically create: class <name>
-            new_cls = type(name, (cls,), {"_inited": True})
+            new_cls = type(name, (cls,), {"_i": True})  # _inited
             for k, v in names.items():
                 setattr(new_cls, k, _make_enum(v, k, name))
             return super().__new__(new_cls)
@@ -41,7 +41,7 @@ class Enum:
         return super().__new__(cls)
 
     def __init__(self, name=None, names=None):
-        if "_inited" not in self.__class__.__dict__:
+        if "_i" not in self.__class__.__dict__:
             self.list()
 
     @classmethod
@@ -57,12 +57,12 @@ class Enum:
 
     @classmethod
     def list(cls):
-        if "_inited" not in cls.__dict__:
+        if "_i" not in cls.__dict__:
             # Copy dict.items() to avoid RuntimeError when changing the dictionary
             for k, v in list(cls.__dict__.items()):
                 if not k.startswith("_") and not callable(v):
                     setattr(cls, k, _make_enum(v, k, cls.__name__))
-            cls._inited = True
+            cls._i = True
         return [
             m for k in dir(cls) if not k.startswith("_") and hasattr(m := getattr(cls, k), "name")
         ]
@@ -81,12 +81,12 @@ class Enum:
         return self._lookup(v)
 
     def __setattr__(self, k, v):
-        if "_inited" in self.__class__.__dict__:
-            raise AttributeError(f"Enum '{self.__class__.__name__}' is immutable")
+        if "_i" in self.__class__.__dict__:
+            raise AttributeError(f"{self.__class__.__name__} is immutable")
         super().__setattr__(k, v)
 
     def __delattr__(self, k):
-        raise AttributeError("Enum is immutable")
+        raise AttributeError(f"{self.__class__.__name__} is immutable")
 
     @classmethod
     def __len__(cls):


### PR DESCRIPTION
### Summary
There are several requests to develop the `Enum` class for MicroPython:

- #15694
- #8545
- #269

Implementation in:
[micropython-lib/python-stdlib/enum/enum.py: Add Enum class. #980](https://github.com/micropython/micropython-lib/pull/980)

### Testing
Tested during porting [MKS-Servo CAN Interface Library](https://github.com/DzymFardreamer/mks-servo-can?tab=readme-ov-file#mks-servo-can-interface-library) to the MicroPython.
Used **port/esp32: Add CAN(TWAI) driver.** #12331.

### Trade-offs and Alternatives
There is the trouble with the isinstance()/type().
```
  >>> isinstance(State.Run, State)
  False
  >>> State(State.Ready) == State.Ready
  False
  >>> int(str(State(State.Ready))) == State.Ready
  True
  >>> type(State(State.Ready))
  <class 'State'>
  >>> type(state(State.Ready))
  <class 'int'>
  >>> state(State.Ready) == State.Ready
  True
```

**Quastion: Should enum.py and enum_test.py be placed in the micropython or micropython-lib repository?**
