### PR TITLE
rp2/rp2_pio: Add support for FIFO trigger level.

### DIFF
--- a/docs/library/rp2.rst
+++ b/docs/library/rp2.rst
@@ -52,13 +52,21 @@ For running PIO programs, see :class:`rp2.StateMachine`.
     - *pull_thresh* is the threshold in bits before auto-pull or conditional
       re-pulling is triggered.
 
-    The remaining parameters are:
+    The following parameters relate to the FIFOs:
 
     - *autopush* configures whether auto-push is enabled.
     - *autopull* configures whether auto-pull is enabled.
     - *fifo_join* configures whether the 4-word TX and RX FIFOs should be
       combined into a single 8-word FIFO for one direction only. The options
       are `PIO.JOIN_NONE`, `PIO.JOIN_RX` and `PIO.JOIN_TX`.
+    - *status_sel* configures which parameter is used by the PIO MOV (101)
+      instruction, ie. MOV X, STATUS.
+      If this value is 0x0, STATUS is all 1's when the TX FIFO is less than the threshold.
+      If this value is 0x1, STATUS is all 1's when the RX FIFO is less than the threshold.
+      If this value is 0x2, STATUS is all 1's when the indexed IRQ is raised. (RP235x only).
+    - *status_n* is the value of the parameter specified in *status_sel* above. See the
+      datasheets for the details.
+
 
 .. function:: asm_pio_encode(instr, sideset_count, sideset_opt=False)
 

--- a/ports/rp2/modules/rp2.py
+++ b/ports/rp2/modules/rp2.py
@@ -42,11 +42,10 @@ class PIOASMEmit:
         from array import array
 
         self.labels = {}
-        execctrl = (
-            side_pindir << 29
-            | status_sel << 4
-            | status_n
-        )
+        if 'RP2350' in sys.implementation._machine:
+            execctrl = side_pindir << 29 | (status_sel & 0x3) << 5 | (status_n & 0x1f)
+        else:
+            execctrl = side_pindir << 29 | (status_sel & 0x1) << 4 | (status_n & 0x0f)
         shiftctrl = (
             fifo_join << 30
             | (pull_thresh & 0x1F) << 25

--- a/ports/rp2/modules/rp2.py
+++ b/ports/rp2/modules/rp2.py
@@ -27,6 +27,8 @@ class PIOASMEmit:
         set_init=None,
         sideset_init=None,
         side_pindir=False,
+        status_sel=0,
+        status_n=0,
         in_shiftdir=PIO.SHIFT_LEFT,
         out_shiftdir=PIO.SHIFT_LEFT,
         autopush=False,
@@ -40,7 +42,11 @@ class PIOASMEmit:
         from array import array
 
         self.labels = {}
-        execctrl = side_pindir << 29
+        execctrl = (
+            side_pindir << 29
+            | status_sel << 4
+            | status_n
+        )
         shiftctrl = (
             fifo_join << 30
             | (pull_thresh & 0x1F) << 25

--- a/ports/rp2/modules/rp2.py
+++ b/ports/rp2/modules/rp2.py
@@ -1,8 +1,13 @@
 # rp2 module: uses C code from _rp2, plus asm_pio decorator implemented in Python.
 # MIT license; Copyright (c) 2020-2021 Damien P. George
 
+import sys
 from _rp2 import *
 from micropython import const
+
+
+is_rp2350 = 'RP2350' in sys.implementation._machine
+
 
 _PROG_DATA = const(0)
 _PROG_OFFSET_PIO0 = const(1)
@@ -42,7 +47,7 @@ class PIOASMEmit:
         from array import array
 
         self.labels = {}
-        if 'RP2350' in sys.implementation._machine:
+        if is_rp2350:
             execctrl = side_pindir << 29 | (status_sel & 0x3) << 5 | (status_n & 0x1F)
         else:
             execctrl = side_pindir << 29 | (status_sel & 0x1) << 4 | (status_n & 0x0F)

--- a/ports/rp2/modules/rp2.py
+++ b/ports/rp2/modules/rp2.py
@@ -43,9 +43,9 @@ class PIOASMEmit:
 
         self.labels = {}
         if 'RP2350' in sys.implementation._machine:
-            execctrl = side_pindir << 29 | (status_sel & 0x3) << 5 | (status_n & 0x1f)
+            execctrl = side_pindir << 29 | (status_sel & 0x3) << 5 | (status_n & 0x1F)
         else:
-            execctrl = side_pindir << 29 | (status_sel & 0x1) << 4 | (status_n & 0x0f)
+            execctrl = side_pindir << 29 | (status_sel & 0x1) << 4 | (status_n & 0x0F)
         shiftctrl = (
             fifo_join << 30
             | (pull_thresh & 0x1F) << 25


### PR DESCRIPTION
Added support for FIFO trigger level.

<!-- Thanks for submitting a Pull Request! We appreciate you spending the
     time to improve MicroPython. Please provide enough information so that
     others can review your Pull Request.

     Before submitting, please read:
     https://github.com/micropython/micropython/blob/master/CODEOFCONDUCT.md
     https://github.com/micropython/micropython/wiki/ContributorGuidelines

     Please check any CI failures that appear after your Pull Request is opened.
-->

### Summary

<!-- Explain the reason for making this change. What problem does the pull request
     solve, or what improvement does it add? Add links if relevant. -->
This provides access to the bit fields that control the FIFO level used when executing `mov(x, status)`. An application may require an action to be taken when, say, three values have been written to the FIFO.

### Testing

<!-- Explain what testing you did, and on which boards/ports. If there are
     boards or ports that you couldn't test, please mention this here as well.

     If you leave this empty then your Pull Request may be closed. -->
None

### Trade-offs and Alternatives

<!-- If the Pull Request has some negative impact (i.e. increased code size)
     then please explain why you think the trade-off improvement is worth it.
     If you can think of alternative ways to do this, please explain that here too.

     Delete this heading if not relevant (i.e. small fixes) -->

The current master branch does not provide access to these bit fields AFAIK.