### PR TITLE
nrf/modules: Fix access of read-only buffer in Flash.writeblocks.

### DIFF
--- a/ports/nrf/modules/nrf/flashbdev.c
+++ b/ports/nrf/modules/nrf/flashbdev.c
@@ -80,7 +80,7 @@ mp_obj_t nrf_flashbdev_writeblocks(size_t n_args, const mp_obj_t *args) {
     nrf_flash_obj_t *self = MP_OBJ_TO_PTR(args[0]);
     uint32_t block_num = mp_obj_get_int(args[1]);
     mp_buffer_info_t bufinfo;
-    mp_get_buffer_raise(args[2], &bufinfo, MP_BUFFER_WRITE);
+    mp_get_buffer_raise(args[2], &bufinfo, MP_BUFFER_READ);
 
     mp_int_t address = self->start + (block_num * FLASH_PAGESIZE);
 


### PR DESCRIPTION
### Summary

When writing to flash, the source buffer only needs to be read-only, not writable.  This fix allows passing in `bytes` and other read-only buffer objects.

### Testing

Tested on `ARDUINO_NANO_33_BLE_SENSE`.  Prior to the fix passing in a `bytes` object would raise an exception that an object with the buffer protocol is required, which was very confusing.  With the fix it allows a `bytes` object.

