### PR TITLE
stm32: On Arduino boards, enable 4MiB ROMFS partition in external flash

### DIFF
--- a/ports/stm32/boards/ARDUINO_GIGA/mpconfigboard.h
+++ b/ports/stm32/boards/ARDUINO_GIGA/mpconfigboard.h
@@ -32,6 +32,11 @@ typedef unsigned int mp_uint_t;     // must be pointer size
 #define MICROPY_HW_ENTER_BOOTLOADER_VIA_RESET   (0)
 #define MICROPY_HW_TIM_IS_RESERVED(id) (id == 1)
 
+// ROMFS config
+#define MICROPY_HW_ROMFS_ENABLE_EXTERNAL_QSPI       (1)
+#define MICROPY_HW_ROMFS_QSPI_SPIFLASH_OBJ          (&spi_bdev.spiflash)
+#define MICROPY_HW_ROMFS_ENABLE_PART0               (1)
+
 // Flash storage config
 #define MICROPY_HW_SPIFLASH_ENABLE_CACHE            (1)
 #define MICROPY_HW_SPIFLASH_SOFT_RESET              (1)
@@ -125,8 +130,8 @@ void GIGA_board_low_power(int mode);
 // QSPI flash #1 for storage
 #define MICROPY_HW_QSPI_PRESCALER           (2) // 100MHz
 #define MICROPY_HW_QSPIFLASH_SIZE_BITS_LOG2 (27)
-// Reserve 1MiB at the end for compatibility with alternate firmware that places WiFi blob here.
-#define MICROPY_HW_SPIFLASH_SIZE_BITS       (120 * 1024 * 1024)
+// Reserve 4MiB for romfs and 1MiB for WiFi/BT firmware.
+#define MICROPY_HW_SPIFLASH_SIZE_BITS       (88 * 1024 * 1024)
 #define MICROPY_HW_QSPIFLASH_CS             (pyb_pin_QSPI2_CS)
 #define MICROPY_HW_QSPIFLASH_SCK            (pyb_pin_QSPI2_CLK)
 #define MICROPY_HW_QSPIFLASH_IO0            (pyb_pin_QSPI2_D0)

--- a/ports/stm32/boards/ARDUINO_GIGA/stm32h747.ld
+++ b/ports/stm32/boards/ARDUINO_GIGA/stm32h747.ld
@@ -13,11 +13,11 @@ MEMORY
     SRAM3 (xrw)     : ORIGIN = 0x30040000, LENGTH = 32K     /* SRAM3 D2    */
     SRAM4 (xrw)     : ORIGIN = 0x38000000, LENGTH = 64K     /* SRAM4 D3    */
     FLASH (rx)      : ORIGIN = 0x08000000, LENGTH = 2048K   /* Total available flash */
-    FLASH_EXT (rx)  : ORIGIN = 0x90000000, LENGTH = 16384K  /* 16MBs external QSPI flash */
     FLASH_BL (rx)   : ORIGIN = 0x08000000, LENGTH = 128K    /* Arduino bootloader */
     FLASH_FS (r)    : ORIGIN = 0x08020000, LENGTH = 128K    /* filesystem */
     FLASH_TEXT (rx) : ORIGIN = 0x08040000, LENGTH = 1280K   /* CM7 firmware */
     FLASH_CM4 (rx)  : ORIGIN = 0x08180000, LENGTH = 512K    /* CM4 firmware */
+    FLASH_ROMFS (rx) : ORIGIN = 0x90B00000, LENGTH = 4096K   /* romfs partition in QSPI flash */
 }
 
 /* produce a link error if there is not this amount of RAM for these sections */
@@ -43,6 +43,10 @@ _micropy_hw_internal_flash_storage_ram_cache_end = ORIGIN(DTCM) + LENGTH(DTCM);
 /* Location of filesystem flash storage */
 _micropy_hw_internal_flash_storage_start = ORIGIN(FLASH_FS);
 _micropy_hw_internal_flash_storage_end = ORIGIN(FLASH_FS) + LENGTH(FLASH_FS);
+
+/* Location of romfs filesystem */
+_micropy_hw_romfs_part0_start = ORIGIN(FLASH_ROMFS);
+_micropy_hw_romfs_part0_size = LENGTH(FLASH_ROMFS);
 
 /* OpenAMP shared memory region */
 _openamp_shm_region_start = ORIGIN(SRAM4);

--- a/ports/stm32/boards/ARDUINO_NICLA_VISION/mpconfigboard.h
+++ b/ports/stm32/boards/ARDUINO_NICLA_VISION/mpconfigboard.h
@@ -32,6 +32,11 @@ typedef unsigned int mp_uint_t;     // must be pointer size
 #define MICROPY_HW_ENTER_BOOTLOADER_VIA_RESET   (0)
 #define MICROPY_HW_TIM_IS_RESERVED(id) (id == 3)
 
+// ROMFS config
+#define MICROPY_HW_ROMFS_ENABLE_EXTERNAL_QSPI       (1)
+#define MICROPY_HW_ROMFS_QSPI_SPIFLASH_OBJ          (&spi_bdev.spiflash)
+#define MICROPY_HW_ROMFS_ENABLE_PART0               (1)
+
 // Flash storage config
 #define MICROPY_HW_SPIFLASH_ENABLE_CACHE            (1)
 #define MICROPY_HW_SPIFLASH_SOFT_RESET              (1)
@@ -130,8 +135,8 @@ void NICLAV_board_osc_enable(int enable);
 // QSPI flash for storage
 #define MICROPY_HW_QSPI_PRESCALER           (2) // 100MHz
 #define MICROPY_HW_QSPIFLASH_SIZE_BITS_LOG2 (27)
-// Reserve 1MiB at the end for compatibility with alternate firmware that places WiFi blob here.
-#define MICROPY_HW_SPIFLASH_SIZE_BITS       (120 * 1024 * 1024)
+// Reserve 4MiB for romfs and 1MiB for WiFi/BT firmware.
+#define MICROPY_HW_SPIFLASH_SIZE_BITS       (88 * 1024 * 1024)
 #define MICROPY_HW_QSPIFLASH_CS             (pyb_pin_QSPI2_CS)
 #define MICROPY_HW_QSPIFLASH_SCK            (pyb_pin_QSPI2_CLK)
 #define MICROPY_HW_QSPIFLASH_IO0            (pyb_pin_QSPI2_D0)

--- a/ports/stm32/boards/ARDUINO_NICLA_VISION/stm32h747.ld
+++ b/ports/stm32/boards/ARDUINO_NICLA_VISION/stm32h747.ld
@@ -13,11 +13,11 @@ MEMORY
     SRAM3 (xrw)     : ORIGIN = 0x30040000, LENGTH = 32K     /* SRAM3 D2    */
     SRAM4 (xrw)     : ORIGIN = 0x38000000, LENGTH = 64K     /* SRAM4 D3    */
     FLASH (rx)      : ORIGIN = 0x08000000, LENGTH = 2048K   /* Total available flash */
-    FLASH_EXT (rx)  : ORIGIN = 0x90000000, LENGTH = 16384K  /* 16MBs external QSPI flash */
     FLASH_BL (rx)   : ORIGIN = 0x08000000, LENGTH = 128K    /* Arduino bootloader */
     FLASH_FS (r)    : ORIGIN = 0x08020000, LENGTH = 128K    /* filesystem */
     FLASH_TEXT (rx) : ORIGIN = 0x08040000, LENGTH = 1280K   /* CM7 firmware */
     FLASH_CM4 (rx)  : ORIGIN = 0x08180000, LENGTH = 512K    /* CM4 firmware */
+    FLASH_ROMFS (rx) : ORIGIN = 0x90B00000, LENGTH = 4096K   /* romfs partition in QSPI flash */
 }
 
 _cm4_ram_start = ORIGIN(SRAM4);
@@ -45,6 +45,10 @@ _micropy_hw_internal_flash_storage_ram_cache_end = ORIGIN(DTCM) + LENGTH(DTCM);
 /* Location of filesystem flash storage */
 _micropy_hw_internal_flash_storage_start = ORIGIN(FLASH_FS);
 _micropy_hw_internal_flash_storage_end = ORIGIN(FLASH_FS) + LENGTH(FLASH_FS);
+
+/* Location of romfs filesystem */
+_micropy_hw_romfs_part0_start = ORIGIN(FLASH_ROMFS);
+_micropy_hw_romfs_part0_size = LENGTH(FLASH_ROMFS);
 
 /* OpenAMP shared memory region */
 _openamp_shm_region_start = ORIGIN(SRAM4);

--- a/ports/stm32/boards/ARDUINO_PORTENTA_H7/mpconfigboard.h
+++ b/ports/stm32/boards/ARDUINO_PORTENTA_H7/mpconfigboard.h
@@ -32,6 +32,11 @@ typedef unsigned int mp_uint_t;     // must be pointer size
 #define MICROPY_HW_ENTER_BOOTLOADER_VIA_RESET   (0)
 #define MICROPY_HW_TIM_IS_RESERVED(id) (id == 1)
 
+// ROMFS config
+#define MICROPY_HW_ROMFS_ENABLE_EXTERNAL_QSPI       (1)
+#define MICROPY_HW_ROMFS_QSPI_SPIFLASH_OBJ          (&spi_bdev.spiflash)
+#define MICROPY_HW_ROMFS_ENABLE_PART0               (1)
+
 // Flash storage config
 #define MICROPY_HW_SPIFLASH_ENABLE_CACHE            (1)
 #define MICROPY_HW_SPIFLASH_SOFT_RESET              (1)
@@ -129,8 +134,8 @@ void PORTENTA_board_osc_enable(int enable);
 // QSPI flash #1 for storage
 #define MICROPY_HW_QSPI_PRESCALER           (2) // 100MHz
 #define MICROPY_HW_QSPIFLASH_SIZE_BITS_LOG2 (27)
-// Reserve 1MiB at the end for compatibility with alternate firmware that places WiFi blob here.
-#define MICROPY_HW_SPIFLASH_SIZE_BITS       (120 * 1024 * 1024)
+// Reserve 4MiB for romfs and 1MiB for WiFi/BT firmware.
+#define MICROPY_HW_SPIFLASH_SIZE_BITS       (88 * 1024 * 1024)
 #define MICROPY_HW_QSPIFLASH_CS             (pyb_pin_QSPI2_CS)
 #define MICROPY_HW_QSPIFLASH_SCK            (pyb_pin_QSPI2_CLK)
 #define MICROPY_HW_QSPIFLASH_IO0            (pyb_pin_QSPI2_D0)

--- a/ports/stm32/boards/ARDUINO_PORTENTA_H7/stm32h747.ld
+++ b/ports/stm32/boards/ARDUINO_PORTENTA_H7/stm32h747.ld
@@ -13,11 +13,11 @@ MEMORY
     SRAM3 (xrw)     : ORIGIN = 0x30040000, LENGTH = 32K     /* SRAM3 D2    */
     SRAM4 (xrw)     : ORIGIN = 0x38000000, LENGTH = 64K     /* SRAM4 D3    */
     FLASH (rx)      : ORIGIN = 0x08000000, LENGTH = 2048K   /* Total available flash */
-    FLASH_EXT (rx)  : ORIGIN = 0x90000000, LENGTH = 16384K  /* 16MBs external QSPI flash */
     FLASH_BL (rx)   : ORIGIN = 0x08000000, LENGTH = 128K    /* Arduino bootloader */
     FLASH_FS (r)    : ORIGIN = 0x08020000, LENGTH = 128K    /* filesystem */
     FLASH_TEXT (rx) : ORIGIN = 0x08040000, LENGTH = 1280K   /* CM7 firmware */
     FLASH_CM4 (rx)  : ORIGIN = 0x08180000, LENGTH = 512K    /* CM4 firmware */
+    FLASH_ROMFS (rx) : ORIGIN = 0x90B00000, LENGTH = 4096K   /* romfs partition in QSPI flash */
 }
 
 /* produce a link error if there is not this amount of RAM for these sections */
@@ -43,6 +43,10 @@ _micropy_hw_internal_flash_storage_ram_cache_end = ORIGIN(DTCM) + LENGTH(DTCM);
 /* Location of filesystem flash storage */
 _micropy_hw_internal_flash_storage_start = ORIGIN(FLASH_FS);
 _micropy_hw_internal_flash_storage_end = ORIGIN(FLASH_FS) + LENGTH(FLASH_FS);
+
+/* Location of romfs filesystem */
+_micropy_hw_romfs_part0_start = ORIGIN(FLASH_ROMFS);
+_micropy_hw_romfs_part0_size = LENGTH(FLASH_ROMFS);
 
 /* OpenAMP shared memory region */
 _openamp_shm_region_start = ORIGIN(SRAM4);


### PR DESCRIPTION
### Summary

Split out from #8381, and a follow up to https://github.com/micropython/micropython/pull/16857#issuecomment-2699648257

This enables a 4MiB ROMFS partition on all three stm32 Arduino boards, using external QSPI flash.  The ROMFS partition sits near the end of flash:
- 11MiB filesystem
- 4 MiB ROMFS
- 1 MiB WiFi firmware (compatibility with alternate firmware)

### Testing

TODO (although previously tested by @iabdalkader as part of #8381).

### Trade-offs and Alternatives

This is most likely a breaking change for users, because the filesystem partition size has shrunk by 4MiB.  And I don't think that will be easily detected because existing filesystems will mount and work correctly until the ROMFS is used.  And then when ROMFS is used and the flash for that is written to, the original filesystem will probably still mount correctly because the initial filesystem data is unchanged.

@iabdalkader how do you want to manage this when users update the firmware?  This is part of the reason why I didn't want to enable ROMFS on all the boards right now, because we don't have a good way of transitioning the flash partition from previous layout to new layout.
