### PR TITLE
Introduce auto-listing of FlashArea Partitions

### DIFF
--- a/docs/zephyr/quickref.rst
+++ b/docs/zephyr/quickref.rst
@@ -153,6 +153,8 @@ Use the :ref:`zephyr.FlashArea <zephyr.FlashArea>` class to support filesystem::
         f.write('Hello world')                  # write to the file
     print(open('/flash/hello.txt').read())      # print contents of the file
 
+The FlashAreas' IDs that are available are listed in the FlashArea module, as ID_*.
+
 Sensor
 ------
 


### PR DESCRIPTION
### Summary

This enables listing all flash area partitions automagically instead of just sotrage_partitions. It uses the label, and the ID when not present.


### Testing

Tested on nrf52840