### PR TITLE
ports: make naming of ROMFS partition config variables consistent

### DIFF
--- a/ports/esp8266/boards/esp8266_2MiB_ROMFS.ld
+++ b/ports/esp8266/boards/esp8266_2MiB_ROMFS.ld
@@ -17,8 +17,8 @@ MEMORY
 }
 
 /* define ROMFS extents */
-_micropy_hw_romfs_start = ORIGIN(FLASH_ROMFS);
-_micropy_hw_romfs_size = LENGTH(FLASH_ROMFS);
+_micropy_hw_romfs_part0_start = ORIGIN(FLASH_ROMFS);
+_micropy_hw_romfs_part0_size = LENGTH(FLASH_ROMFS);
 
 /* define common sections and symbols */
 INCLUDE boards/esp8266_common.ld

--- a/ports/esp8266/modesp.c
+++ b/ports/esp8266/modesp.c
@@ -165,13 +165,13 @@ static MP_DEFINE_CONST_FUN_OBJ_0(esp_flash_size_obj, esp_flash_size);
 
 extern byte _firmware_size[];
 #if MICROPY_VFS_ROM_IOCTL
-extern uint8_t _micropy_hw_romfs_size;
+extern uint8_t _micropy_hw_romfs_part0_size;
 #endif
 
 static mp_obj_t esp_flash_user_start(void) {
     uint32_t flash_user_start = (uint32_t)_firmware_size;
     #if MICROPY_VFS_ROM_IOCTL
-    flash_user_start += (uint32_t)&_micropy_hw_romfs_size;
+    flash_user_start += (uint32_t)&_micropy_hw_romfs_part0_size;
     #endif
     return MP_OBJ_NEW_SMALL_INT(flash_user_start);
 }

--- a/ports/esp8266/vfs_rom_ioctl.c
+++ b/ports/esp8266/vfs_rom_ioctl.c
@@ -35,13 +35,13 @@
 #define FLASH_MEM_BASE (0x40200000)
 #define FLASH_PAGE_SIZE (4096)
 
-#define MICROPY_HW_ROMFS_BASE (uintptr_t)(&_micropy_hw_romfs_start)
-#define MICROPY_HW_ROMFS_BYTES (uintptr_t)(&_micropy_hw_romfs_size)
+#define MICROPY_HW_ROMFS_BASE (uintptr_t)(&_micropy_hw_romfs_part0_start)
+#define MICROPY_HW_ROMFS_BYTES (uintptr_t)(&_micropy_hw_romfs_part0_size)
 
 #define ROMFS_SPI_FLASH_OFFSET (MICROPY_HW_ROMFS_BASE - FLASH_MEM_BASE)
 
-extern uint8_t _micropy_hw_romfs_start;
-extern uint8_t _micropy_hw_romfs_size;
+extern uint8_t _micropy_hw_romfs_part0_start;
+extern uint8_t _micropy_hw_romfs_part0_size;
 
 static const MP_DEFINE_MEMORYVIEW_OBJ(romfs_obj, 'B', 0, MICROPY_HW_ROMFS_BYTES, (void *)MICROPY_HW_ROMFS_BASE);
 

--- a/ports/stm32/boards/PYBD_SF2/f722_qspi.ld
+++ b/ports/stm32/boards/PYBD_SF2/f722_qspi.ld
@@ -41,8 +41,8 @@ _heap_start = _ebss; /* heap starts just after statically allocated memory */
 _heap_end = _sstack;
 
 /* ROMFS location */
-_micropy_hw_romfs_part1_start = ORIGIN(FLASH_ROMFS);
-_micropy_hw_romfs_part1_size = LENGTH(FLASH_ROMFS);
+_micropy_hw_romfs_part0_start = ORIGIN(FLASH_ROMFS);
+_micropy_hw_romfs_part0_size = LENGTH(FLASH_ROMFS);
 
 /* Define output sections */
 SECTIONS

--- a/ports/stm32/boards/PYBD_SF2/mpconfigboard.h
+++ b/ports/stm32/boards/PYBD_SF2/mpconfigboard.h
@@ -67,7 +67,7 @@ void board_sleep(int value);
 // ROMFS config
 #define MICROPY_HW_ROMFS_ENABLE_EXTERNAL_QSPI (1)
 #define MICROPY_HW_ROMFS_QSPI_SPIFLASH_OBJ (&spi_bdev2.spiflash)
-#define MICROPY_HW_ROMFS_ENABLE_PART1 (1)
+#define MICROPY_HW_ROMFS_ENABLE_PART0 (1)
 
 // SPI flash #1, for R/W storage
 #define MICROPY_HW_SOFTQSPI_SCK_LOW(self) (GPIOE->BSRR = (0x10000 << 11))

--- a/ports/stm32/boards/PYBD_SF6/f767.ld
+++ b/ports/stm32/boards/PYBD_SF6/f767.ld
@@ -38,7 +38,7 @@ _heap_start = _ebss; /* heap starts just after statically allocated memory */
 _heap_end = _sstack;
 
 /* ROMFS location */
-_micropy_hw_romfs_part1_start = ORIGIN(FLASH_ROMFS);
-_micropy_hw_romfs_part1_size = LENGTH(FLASH_ROMFS);
+_micropy_hw_romfs_part0_start = ORIGIN(FLASH_ROMFS);
+_micropy_hw_romfs_part0_size = LENGTH(FLASH_ROMFS);
 
 INCLUDE common_bl.ld

--- a/ports/stm32/boards/PYBD_SF6/mpconfigboard.h
+++ b/ports/stm32/boards/PYBD_SF6/mpconfigboard.h
@@ -48,7 +48,7 @@
 // ROMFS config
 #define MICROPY_HW_ROMFS_ENABLE_EXTERNAL_QSPI (1)
 #define MICROPY_HW_ROMFS_QSPI_SPIFLASH_OBJ (&spi_bdev2.spiflash)
-#define MICROPY_HW_ROMFS_ENABLE_PART1 (1)
+#define MICROPY_HW_ROMFS_ENABLE_PART0 (1)
 
 // Extra UART config
 #define MICROPY_HW_UART7_TX         (pyb_pin_W16)

--- a/ports/stm32/mpconfigboard_common.h
+++ b/ports/stm32/mpconfigboard_common.h
@@ -77,14 +77,14 @@
 #define MICROPY_HW_ROMFS_ENABLE_EXTERNAL_QSPI (0)
 #endif
 
+// Whether to enable ROMFS partition 0.
+#ifndef MICROPY_HW_ROMFS_ENABLE_PART0
+#define MICROPY_HW_ROMFS_ENABLE_PART0 (0)
+#endif
+
 // Whether to enable ROMFS partition 1.
 #ifndef MICROPY_HW_ROMFS_ENABLE_PART1
 #define MICROPY_HW_ROMFS_ENABLE_PART1 (0)
-#endif
-
-// Whether to enable ROMFS partition 2.
-#ifndef MICROPY_HW_ROMFS_ENABLE_PART2
-#define MICROPY_HW_ROMFS_ENABLE_PART2 (0)
 #endif
 
 // Whether to enable storage on the internal flash of the MCU

--- a/ports/stm32/vfs_rom_ioctl.c
+++ b/ports/stm32/vfs_rom_ioctl.c
@@ -36,6 +36,13 @@
 
 #if MICROPY_VFS_ROM_IOCTL
 
+#if MICROPY_HW_ROMFS_ENABLE_PART0 && !defined(MICROPY_HW_ROMFS_PART0_START)
+#define MICROPY_HW_ROMFS_PART0_START (uintptr_t)(&_micropy_hw_romfs_part0_start)
+#define MICROPY_HW_ROMFS_PART0_SIZE (uintptr_t)(&_micropy_hw_romfs_part0_size)
+extern uint8_t _micropy_hw_romfs_part0_start;
+extern uint8_t _micropy_hw_romfs_part0_size;
+#endif
+
 #if MICROPY_HW_ROMFS_ENABLE_PART1 && !defined(MICROPY_HW_ROMFS_PART1_START)
 #define MICROPY_HW_ROMFS_PART1_START (uintptr_t)(&_micropy_hw_romfs_part1_start)
 #define MICROPY_HW_ROMFS_PART1_SIZE (uintptr_t)(&_micropy_hw_romfs_part1_size)
@@ -43,21 +50,14 @@ extern uint8_t _micropy_hw_romfs_part1_start;
 extern uint8_t _micropy_hw_romfs_part1_size;
 #endif
 
-#if MICROPY_HW_ROMFS_ENABLE_PART2 && !defined(MICROPY_HW_ROMFS_PART2_START)
-#define MICROPY_HW_ROMFS_PART2_START (uintptr_t)(&_micropy_hw_romfs_part2_start)
-#define MICROPY_HW_ROMFS_PART2_SIZE (uintptr_t)(&_micropy_hw_romfs_part2_size)
-extern uint8_t _micropy_hw_romfs_part2_start;
-extern uint8_t _micropy_hw_romfs_part2_size;
-#endif
-
 #define ROMFS_MEMORYVIEW(base, size) {{&mp_type_memoryview}, 'B', 0, (size), (void *)(base)}
 
 static const mp_obj_array_t romfs_obj_table[] = {
+    #if MICROPY_HW_ROMFS_ENABLE_PART0
+    ROMFS_MEMORYVIEW(MICROPY_HW_ROMFS_PART0_START, MICROPY_HW_ROMFS_PART0_SIZE),
+    #endif
     #if MICROPY_HW_ROMFS_ENABLE_PART1
     ROMFS_MEMORYVIEW(MICROPY_HW_ROMFS_PART1_START, MICROPY_HW_ROMFS_PART1_SIZE),
-    #endif
-    #if MICROPY_HW_ROMFS_ENABLE_PART2
-    ROMFS_MEMORYVIEW(MICROPY_HW_ROMFS_PART2_START, MICROPY_HW_ROMFS_PART2_SIZE),
     #endif
 };
 


### PR DESCRIPTION
### Summary

Change ROMFS partition configuration variables to be more consistent across the ports, and use index 0 as the starting partition number (instead of index 1).

Reason:
- `vfs.rom_ioctl()` numbers the partitions starting from 0
- `mpremote romfs -p <partition id>` numbers the partitions starting from 0

### Testing

CI should test this, building the boards that enable ROMFS on stm32 and esp8266.

