### PR TITLE
tools/mpremote: Make mip install skip /rom*/lib directories.

### DIFF
--- a/tools/mpremote/mpremote/mip.py
+++ b/tools/mpremote/mpremote/mip.py
@@ -175,7 +175,11 @@ def do_mip(state, args):
 
             if args.target is None:
                 state.transport.exec("import sys")
-                lib_paths = [p for p in state.transport.eval("sys.path") if p.endswith("/lib")]
+                lib_paths = [
+                    p
+                    for p in state.transport.eval("sys.path")
+                    if not p.startswith("/rom") and p.endswith("/lib")
+                ]
                 if lib_paths and lib_paths[0]:
                     args.target = lib_paths[0]
                 else:


### PR DESCRIPTION
### Summary

If a ROMFS is mounted then "/rom/lib" is usually in `sys.path` before the writable filesystem's "lib" entry.  The ROMFS directory cannot be installed to, so skip it if found.

### Testing

Tested on PYBD_SF2.  Prior to this PR:
```
$ mp mip install unittest
Install unittest
Installing unittest (latest) from https://micropython.org/pi/v2 to /rom/lib
Installing: /rom/lib/unittest/__init__.mpy
Traceback (most recent call last):
...
mpremote.transport.TransportExecError: Traceback (most recent call last):
  File "<stdin>", line 2, in <module>
AttributeError: 'VfsRom' object has no attribute 'mkdir'
```
With this PR:
```
$ ./mpremote.py mip install unittest
Install unittest
Installing unittest (latest) from https://micropython.org/pi/v2 to /flash/lib
Installing: /flash/lib/unittest/__init__.mpy
Done                                    
```

### Alternatives

This patch simply skips anything that has the name `/rom` in it.  Alternatively could try to probe/query the filesystem to see if it's writable, and skip it if not.  But that's a lot more complicated, and really needs a way to query mount points.  So the patch here is a simple fix that should work in almost all cases.

Note: micropython-lib also needs updating.