### PR TITLE
rp2,esp32,extmod: Implement submodule update inside CMake.

### DIFF
--- a/extmod/extmod.cmake
+++ b/extmod/extmod.cmake
@@ -107,62 +107,57 @@ set(MICROPY_SOURCE_LIB_LIBM_SQRT_HW ${MICROPY_DIR}/lib/libm/thumb_vfp_sqrtf.c)
 
 if(MICROPY_PY_BTREE)
     set(MICROPY_LIB_BERKELEY_DIR "${MICROPY_DIR}/lib/berkeley-db-1.xx")
-    string(CONCAT GIT_SUBMODULES "${GIT_SUBMODULES} " lib/berkeley-db-1.xx)
+    list(APPEND GIT_SUBMODULES lib/berkeley-db-1.xx)
 
-    if(ECHO_SUBMODULES)
-        # No-op, we're just doing submodule/variant discovery.
-        # Cannot run the add_library/target_include_directories rules (even though
-        # the build won't run) because IDF will attempt verify the files exist.
-    elseif(NOT EXISTS ${MICROPY_LIB_BERKELEY_DIR}/README)
+    if(NOT UPDATE_SUBMODULES AND NOT EXISTS ${MICROPY_LIB_BERKELEY_DIR}/README)
         # Regular build, submodule not initialised -- fail with a clear error.
         message(FATAL_ERROR " MICROPY_PY_BTREE is enabled but the berkeley-db submodule is not initialised.\n Run 'make BOARD=${MICROPY_BOARD} submodules'")
-    else()
-        # Regular build, we have the submodule.
-        add_library(micropy_extmod_btree OBJECT
-            ${MICROPY_LIB_BERKELEY_DIR}/btree/bt_close.c
-            ${MICROPY_LIB_BERKELEY_DIR}/btree/bt_conv.c
-            ${MICROPY_LIB_BERKELEY_DIR}/btree/bt_debug.c
-            ${MICROPY_LIB_BERKELEY_DIR}/btree/bt_delete.c
-            ${MICROPY_LIB_BERKELEY_DIR}/btree/bt_get.c
-            ${MICROPY_LIB_BERKELEY_DIR}/btree/bt_open.c
-            ${MICROPY_LIB_BERKELEY_DIR}/btree/bt_overflow.c
-            ${MICROPY_LIB_BERKELEY_DIR}/btree/bt_page.c
-            ${MICROPY_LIB_BERKELEY_DIR}/btree/bt_put.c
-            ${MICROPY_LIB_BERKELEY_DIR}/btree/bt_search.c
-            ${MICROPY_LIB_BERKELEY_DIR}/btree/bt_seq.c
-            ${MICROPY_LIB_BERKELEY_DIR}/btree/bt_split.c
-            ${MICROPY_LIB_BERKELEY_DIR}/btree/bt_utils.c
-            ${MICROPY_LIB_BERKELEY_DIR}/mpool/mpool.c
-        )
-
-        target_include_directories(micropy_extmod_btree PRIVATE
-            ${MICROPY_LIB_BERKELEY_DIR}/include
-        )
-
-        if(NOT BERKELEY_DB_CONFIG_FILE)
-            set(BERKELEY_DB_CONFIG_FILE "${MICROPY_DIR}/extmod/berkeley-db/berkeley_db_config_port.h")
-        endif()
-
-        target_compile_definitions(micropy_extmod_btree PRIVATE
-            BERKELEY_DB_CONFIG_FILE="${BERKELEY_DB_CONFIG_FILE}"
-        )
-
-        # The include directories and compile definitions below are needed to build
-        # modbtree.c and should be added to the main MicroPython target.
-
-        list(APPEND MICROPY_INC_CORE
-            "${MICROPY_LIB_BERKELEY_DIR}/include"
-        )
-
-        list(APPEND MICROPY_DEF_CORE
-            MICROPY_PY_BTREE=1
-            BERKELEY_DB_CONFIG_FILE="${BERKELEY_DB_CONFIG_FILE}"
-        )
-
-        list(APPEND MICROPY_SOURCE_EXTMOD
-            ${MICROPY_EXTMOD_DIR}/modbtree.c
-        )
     endif()
+
+    add_library(micropy_extmod_btree OBJECT
+        ${MICROPY_LIB_BERKELEY_DIR}/btree/bt_close.c
+        ${MICROPY_LIB_BERKELEY_DIR}/btree/bt_conv.c
+        ${MICROPY_LIB_BERKELEY_DIR}/btree/bt_debug.c
+        ${MICROPY_LIB_BERKELEY_DIR}/btree/bt_delete.c
+        ${MICROPY_LIB_BERKELEY_DIR}/btree/bt_get.c
+        ${MICROPY_LIB_BERKELEY_DIR}/btree/bt_open.c
+        ${MICROPY_LIB_BERKELEY_DIR}/btree/bt_overflow.c
+        ${MICROPY_LIB_BERKELEY_DIR}/btree/bt_page.c
+        ${MICROPY_LIB_BERKELEY_DIR}/btree/bt_put.c
+        ${MICROPY_LIB_BERKELEY_DIR}/btree/bt_search.c
+        ${MICROPY_LIB_BERKELEY_DIR}/btree/bt_seq.c
+        ${MICROPY_LIB_BERKELEY_DIR}/btree/bt_split.c
+        ${MICROPY_LIB_BERKELEY_DIR}/btree/bt_utils.c
+        ${MICROPY_LIB_BERKELEY_DIR}/mpool/mpool.c
+    )
+
+    target_include_directories(micropy_extmod_btree PRIVATE
+        ${MICROPY_LIB_BERKELEY_DIR}/include
+    )
+
+    if(NOT BERKELEY_DB_CONFIG_FILE)
+        set(BERKELEY_DB_CONFIG_FILE "${MICROPY_DIR}/extmod/berkeley-db/berkeley_db_config_port.h")
+    endif()
+
+    target_compile_definitions(micropy_extmod_btree PRIVATE
+        BERKELEY_DB_CONFIG_FILE="${BERKELEY_DB_CONFIG_FILE}"
+    )
+
+    # The include directories and compile definitions below are needed to build
+    # modbtree.c and should be added to the main MicroPython target.
+
+    list(APPEND MICROPY_INC_CORE
+        "${MICROPY_LIB_BERKELEY_DIR}/include"
+    )
+
+    list(APPEND MICROPY_DEF_CORE
+        MICROPY_PY_BTREE=1
+        BERKELEY_DB_CONFIG_FILE="${BERKELEY_DB_CONFIG_FILE}"
+    )
+
+    list(APPEND MICROPY_SOURCE_EXTMOD
+        ${MICROPY_EXTMOD_DIR}/modbtree.c
+    )
 endif()
 
 # Library for mbedtls
@@ -350,5 +345,5 @@ if(MICROPY_PY_LWIP)
         ${MICROPY_LIB_LWIP_DIR}/include
     )
 
-    string(CONCAT GIT_SUBMODULES "${GIT_SUBMODULES} " lib/lwip)
+    list(APPEND GIT_SUBMODULES lib/lwip)
 endif()

--- a/ports/esp32/Makefile
+++ b/ports/esp32/Makefile
@@ -106,12 +106,10 @@ size-components:
 size-files:
 	$(call RUN_IDF_PY,size-files)
 
-# Running the build with ECHO_SUBMODULES set will trigger py/mkrules.cmake to
-# print out the value of the GIT_SUBMODULES variable, prefixed with
-# "GIT_SUBMODULES", and then abort. This extracts out that line from the idf.py
-# output and passes the list of submodules to py/mkrules.mk which does the
-# `git submodule init` on each.
+# Run idf.py with the UPDATE_SUBMODULES flag to update
+# necessary submodules for this board.
+#
+# This is done in a dedicated build directory as some CMake cache values are not
+# set correctly if not all submodules are loaded yet.
 submodules:
-	@GIT_SUBMODULES=$$(IDF_COMPONENT_MANAGER=0 idf.py $(IDFPY_FLAGS) -B $(BUILD)/submodules -D ECHO_SUBMODULES=1 build 2>&1 | \
-	                  grep '^GIT_SUBMODULES=' | cut -d= -f2); \
-	$(MAKE) -f ../../py/mkrules.mk GIT_SUBMODULES="$${GIT_SUBMODULES}" GIT_SUBMODULES_FAIL_IF_EMPTY=1 submodules
+	IDF_COMPONENT_MANAGER=0 idf.py $(IDFPY_FLAGS) -B $(BUILD)/submodules -D UPDATE_SUBMODULES=1 reconfigure

--- a/ports/esp32/esp32_common.cmake
+++ b/ports/esp32/esp32_common.cmake
@@ -71,8 +71,8 @@ list(APPEND MICROPY_SOURCE_DRIVERS
     ${MICROPY_DIR}/drivers/dht/dht.c
 )
 
-string(CONCAT GIT_SUBMODULES "${GIT_SUBMODULES} " lib/tinyusb)
-if(MICROPY_PY_TINYUSB AND NOT ECHO_SUBMODULES)
+list(APPEND GIT_SUBMODULES lib/tinyusb)
+if(MICROPY_PY_TINYUSB)
     set(TINYUSB_SRC "${MICROPY_DIR}/lib/tinyusb/src")
     string(TOUPPER OPT_MCU_${IDF_TARGET} tusb_mcu)
 
@@ -193,6 +193,17 @@ list(APPEND IDF_COMPONENTS
 # Provide the default LD fragment if not set
 if (MICROPY_USER_LDFRAGMENTS)
     set(MICROPY_LDFRAGMENTS ${MICROPY_USER_LDFRAGMENTS})
+endif()
+
+if (UPDATE_SUBMODULES)
+    # ESP-IDF checks if some paths exist before CMake does. Some paths don't
+    # yet exist if this is an UPDATE_SUBMODULES pass on a brand new checkout, so remove
+    # any path which might not exist yet. A "real" build will not set UPDATE_SUBMODULES.
+    unset(MICROPY_SOURCE_TINYUSB)
+    unset(MICROPY_SOURCE_EXTMOD)
+    unset(MICROPY_SOURCE_LIB)
+    unset(MICROPY_INC_TINYUSB)
+    unset(MICROPY_INC_CORE)
 endif()
 
 # Register the main IDF component.

--- a/ports/rp2/CMakeLists.txt
+++ b/ports/rp2/CMakeLists.txt
@@ -76,8 +76,8 @@ if (MICROPY_PY_NETWORK_CYW43)
 endif()
 
 # Necessary submodules for all boards.
-string(CONCAT GIT_SUBMODULES "${GIT_SUBMODULES} " lib/mbedtls)
-string(CONCAT GIT_SUBMODULES "${GIT_SUBMODULES} " lib/tinyusb)
+list(APPEND GIT_SUBMODULES lib/mbedtls)
+list(APPEND GIT_SUBMODULES lib/tinyusb)
 
 # Include component cmake fragments
 include(${MICROPY_DIR}/py/py.cmake)
@@ -340,7 +340,7 @@ if (MICROPY_PY_BLUETOOTH_CYW43)
 endif()
 
 if (MICROPY_BLUETOOTH_BTSTACK)
-    string(CONCAT GIT_SUBMODULES "${GIT_SUBMODULES} " lib/btstack)
+    list(APPEND GIT_SUBMODULES lib/btstack)
 
     list(APPEND MICROPY_SOURCE_PORT mpbtstackport.c)
 
@@ -358,8 +358,8 @@ if (MICROPY_BLUETOOTH_BTSTACK)
 endif()
 
 if(MICROPY_BLUETOOTH_NIMBLE)
-    string(CONCAT GIT_SUBMODULES "${GIT_SUBMODULES} " lib/mynewt-nimble)
-    if(NOT (${ECHO_SUBMODULES}) AND NOT EXISTS ${MICROPY_DIR}/lib/mynewt-nimble/nimble/host/include/host/ble_hs.h)
+    list(APPEND GIT_SUBMODULES lib/mynewt-nimble)
+    if(NOT UPDATE_SUBMODULES AND NOT EXISTS ${MICROPY_DIR}/lib/mynewt-nimble/nimble/host/include/host/ble_hs.h)
         message(FATAL_ERROR " mynewt-nimble not initialized.\n Run 'make BOARD=${MICROPY_BOARD} submodules'")
     endif()
 
@@ -386,8 +386,8 @@ target_include_directories(${MICROPY_TARGET} PRIVATE
 )
 
 if (MICROPY_PY_NETWORK_CYW43)
-    string(CONCAT GIT_SUBMODULES "${GIT_SUBMODULES} " lib/cyw43-driver)
-    if((NOT (${ECHO_SUBMODULES})) AND NOT EXISTS ${MICROPY_DIR}/lib/cyw43-driver/src/cyw43.h)
+    list(APPEND GIT_SUBMODULES lib/cyw43-driver)
+    if(NOT UPDATE_SUBMODULES AND NOT EXISTS ${MICROPY_DIR}/lib/cyw43-driver/src/cyw43.h)
         message(FATAL_ERROR " cyw43-driver not initialized.\n Run 'make BOARD=${MICROPY_BOARD} submodules'")
     endif()
 
@@ -433,8 +433,8 @@ if (MICROPY_PY_NETWORK_NINAW10)
 endif()
 
 if (MICROPY_PY_NETWORK_WIZNET5K)
-    string(CONCAT GIT_SUBMODULES "${GIT_SUBMODULES} " lib/wiznet5k)
-    if((NOT (${ECHO_SUBMODULES})) AND NOT EXISTS ${MICROPY_DIR}/lib/wiznet5k/README.md)
+    list(APPEND GIT_SUBMODULES lib/wiznet5k)
+    if(NOT UPDATE_SUBMODULES AND NOT EXISTS ${MICROPY_DIR}/lib/wiznet5k/README.md)
         message(FATAL_ERROR " wiznet5k not initialized.\n Run 'make BOARD=${MICROPY_BOARD} submodules'")
     endif()
 

--- a/ports/rp2/Makefile
+++ b/ports/rp2/Makefile
@@ -65,15 +65,11 @@ all:
 clean:
 	$(RM) -rf $(BUILD)
 
-# First ensure that pico-sdk is initialised, then use cmake to pick everything
-# else (including board-specific dependencies).
-# Running the build with ECHO_SUBMODULES set will trigger py/mkrules.cmake to
-# print out the value of the GIT_SUBMODULES variable, prefixed with
-# "GIT_SUBMODULES", and then abort. This extracts out that line from the cmake
-# output and passes the list of submodules to py/mkrules.mk which does the
-# `git submodule init` on each.
+# First ensure that pico-sdk is initialised, then run CMake with the
+# UPDATE_SUBMODULES flag to update necessary submodules for this board.
+#
+# This is done in a dedicated build directory as some CMake cache values are not
+# set correctly if not all submodules are loaded yet.
 submodules:
 	$(MAKE) -f ../../py/mkrules.mk GIT_SUBMODULES="lib/pico-sdk" submodules
-	@GIT_SUBMODULES=$$(cmake -B $(BUILD)/submodules -DECHO_SUBMODULES=1 ${CMAKE_ARGS} -S . 2>&1 | \
-	                  grep '^GIT_SUBMODULES=' | cut -d= -f2); \
-	$(MAKE) -f ../../py/mkrules.mk GIT_SUBMODULES="$${GIT_SUBMODULES}" GIT_SUBMODULES_FAIL_IF_EMPTY=1 submodules
+	cmake -S . -B $(BUILD)/submodules -DUPDATE_SUBMODULES=1 ${CMAKE_ARGS}

--- a/ports/rp2/Makefile
+++ b/ports/rp2/Makefile
@@ -56,9 +56,11 @@ ifdef MICROPY_PREVIEW_VERSION_2
 CMAKE_ARGS += -DMICROPY_PREVIEW_VERSION_2=1
 endif
 
+HELP_PICO_SDK_SUBMODULE ?= "\033[1;31mError: pico-sdk submodule is not initialized.\033[0m Run 'make submodules'"
 HELP_BUILD_ERROR ?= "See \033[1;31mhttps://github.com/micropython/micropython/wiki/Build-Troubleshooting\033[0m"
 
 all:
+	[ -f ../../lib/pico-sdk/README.md ] || (echo -e $(HELP_PICO_SDK_SUBMODULE); false)
 	[ -e $(BUILD)/Makefile ] || cmake -S . -B $(BUILD) -DPICO_BUILD_DOCS=0 ${CMAKE_ARGS}
 	$(MAKE) $(MAKE_ARGS) -C $(BUILD) || (echo -e $(HELP_BUILD_ERROR); false)
 

--- a/py/mkrules.mk
+++ b/py/mkrules.mk
@@ -262,19 +262,14 @@ endif
 # If available, do blobless partial clones of submodules to save time and space.
 # A blobless partial clone lazily fetches data as needed, but has all the metadata available (tags, etc.).
 # Fallback to standard submodule update if blobless isn't available (earlier than 2.36.0)
+#
+# Note: This target has a CMake equivalent in py/mkrules.cmake
 submodules:
 	$(ECHO) "Updating submodules: $(GIT_SUBMODULES)"
 ifneq ($(GIT_SUBMODULES),)
 	$(Q)cd $(TOP) && git submodule sync $(GIT_SUBMODULES)
 	$(Q)cd $(TOP) && git submodule update --init --filter=blob:none $(GIT_SUBMODULES) || \
 	  git submodule update --init $(GIT_SUBMODULES)
-else
-ifeq ($(GIT_SUBMODULES_FAIL_IF_EMPTY),1)
-	# If you see this error, it may mean the internal step run by the port's build
-	# system to find git submodules has failed. Double-check dependencies are set correctly.
-	$(ECHO) "Internal build error: The submodule list should not be empty."
-	exit 1
-endif
 endif
 .PHONY: submodules
 


### PR DESCRIPTION
### Summary

Alternative approach to #16901. Fixes #16870.

Rather than having `make submodules` run CMake to get the submodules list and then update git submodules, have CMake update submodules itself. This means any other build errors will be visible, rather than being masked (as currently the CMake submodules run has its output captured and parsed.)

This effectively reverts commit 22353e9 from https://github.com/micropython/micropython/pull/16581, as an empty submodule list is no longer a symptom of any deeper (masked) issue.

It's also possible to simplify out a lot of the checks for `ECHO_SUBMODULES` as CMake won't check if those files and directories exist until after the `UPDATE_SUBMODULES` pass finishes. A workaround is still needed for ESP32 as the ESP-IDF framework tests if paths exist when registering a new component, but the workaround can be contained in the esp32_common.cmake file.

This PR also contains a commit to fail with a helpful error message if the pico-sdk is missing. This was originally necessary because I was trying to run the `UPDATE_SUBMODULES` pass in the normal build directory (to save on running CMake twice), but that actually doesn't quite work as pico-sdk sets some other invalid cache values if directories are missing. However, the helpful error message is still helpful!

### Testing

* Ran some local rp2 and esp32 builds in a clean git clone, verified all successful.
* Ran a build with the older IDF component manager in the IDF V5.2.2 docker image, verified still OK (but does still require the workaround from ec527a11). Command line:  `podman run --rm -t -v "/home/gus/ry/george/micropython/.git:/gitdir:ro" -t docker.io/espressif/idf:v5.2.2 bash -c "git clone -b $(git branch --show-current) /gitdir micropython && make -j -C micropython/mpy-cross && echo '@@@@@@@@@@ submodules' && make -C microp
 ython/ports/esp32 submodules V=1 BOARD=ESP32_GENERIC_S3 && echo '@@@@@@@@@@ main build' && make -C micropython/ports/esp32 BOARD=ESP32_GENERIC_S3" `

### Trade-offs and Alternatives

* The `make submodules` output now includes a lot of CMake build output for a dummy run which never gets to actually build.
* We could make this even simpler and hard-code the `GIT_SUBMODULES` value in `rp2/Makefile` and `esp32/Makefile`. The upside is a much simpler build stage. There are two downsides I can see:
  - Conceptually, this means each port has to know about implementation details (the submodule path) of all its external MP modules.
  - Practically, can no longer filter the list of submodules based on the board to reduce network traffic and disk usage. On ESP32 the submodule list is current the same for all boards so that doesn't have any current impact. On rp2 the list is much shorter for boards without Wi-Fi or networking, so some additional repos would be fetched unnecessarily. I'm not sure how much more traffic this would actually be, though.