### PR TITLE
ports/rp2: Fix bootsel for RP2350.

### DIFF
--- a/ports/rp2/modrp2.c
+++ b/ports/rp2/modrp2.c
@@ -42,11 +42,17 @@
 MP_DECLARE_CONST_FUN_OBJ_VAR_BETWEEN(mod_network_country_obj);
 #endif
 
+#define CS_PIN_INDEX 1
+
+#if PICO_RP2040
+    #define CS_BIT (1u << CS_PIN_INDEX)
+#else
+    #define CS_BIT SIO_GPIO_HI_IN_QSPI_CSN_BITS
+#endif
+
 // Improved version of
 // https://github.com/raspberrypi/pico-examples/blob/master/picoboard/button/button.c
 static bool __no_inline_not_in_flash_func(bootsel_button)(void) {
-    const uint CS_PIN_INDEX = 1;
-
     // Disable interrupts and the other core since they might be
     // executing code from flash and we are about to temporarily
     // disable flash access.
@@ -65,7 +71,7 @@ static bool __no_inline_not_in_flash_func(bootsel_button)(void) {
 
     // The HI GPIO registers in SIO can observe and control the 6 QSPI pins.
     // The button pulls the QSPI_SS pin *low* when pressed.
-    bool button_state = !(sio_hw->gpio_hi_in & (1 << CS_PIN_INDEX));
+    bool button_state = !(sio_hw->gpio_hi_in & CS_BIT);
 
     // Restore the QSPI_SS pin so we can use flash again.
     hw_write_masked(&ioqspi_hw->io[CS_PIN_INDEX].ctrl,


### PR DESCRIPTION
Fixes reading bootsel as a button functionality, as raised in #16908

Tested on a Pico 2 W using [v1.25.0-preview.365.g3823aeb0f (2025-03-07) .uf2](https://micropython.org/resources/firmware/RPI_PICO2_W-20250307-v1.25.0-preview.365.g3823aeb0f.uf2) to confirm the bug.

Tested on a Pico W to check for regressions.

Note: I did not actually author this change, it was cribbed form the original source of the bootsel code which had been updated with RP2350 support: https://github.com/raspberrypi/pico-examples/blob/84e8d489ca321a4be90ee49e36dc29e5c645da08/picoboard/button/button.c#L42-L46