### PR TITLE
rp2: Fix lost CYW43 WiFi events when using both cores.

### DIFF
--- a/ports/rp2/cyw43_configport.h
+++ b/ports/rp2/cyw43_configport.h
@@ -140,10 +140,12 @@ uint cyw43_get_pin_wl(cyw43_pin_index_t pin_id);
 #endif
 
 void cyw43_post_poll_hook(void);
-extern volatile int cyw43_has_pending;
+static inline bool cyw43_poll_is_pending(void) {
+    return pendsv_is_pending(PENDSV_DISPATCH_CYW43);
+}
 
 static inline void cyw43_yield(void) {
-    if (!cyw43_has_pending) {
+    if (!cyw43_poll_is_pending()) {
         best_effort_wfe_or_timeout(make_timeout_time_ms(1));
     }
 }

--- a/ports/rp2/modmachine.c
+++ b/ports/rp2/modmachine.c
@@ -145,7 +145,7 @@ static void mp_machine_lightsleep(size_t n_args, const mp_obj_t *args) {
 
     uint32_t my_interrupts = MICROPY_BEGIN_ATOMIC_SECTION();
     #if MICROPY_PY_NETWORK_CYW43
-    if (cyw43_has_pending && cyw43_poll != NULL) {
+    if (cyw43_poll_is_pending()) {
         MICROPY_END_ATOMIC_SECTION(my_interrupts);
         return;
     }

--- a/ports/rp2/mpnetworkport.c
+++ b/ports/rp2/mpnetworkport.c
@@ -42,7 +42,6 @@ static soft_timer_entry_t mp_network_soft_timer;
 #if MICROPY_PY_NETWORK_CYW43
 #include "lib/cyw43-driver/src/cyw43.h"
 #include "lib/cyw43-driver/src/cyw43_stats.h"
-#include "hardware/irq.h"
 
 #if !defined(__riscv)
 #if PICO_RP2040
@@ -97,9 +96,6 @@ static void gpio_irq_handler(void) {
 void cyw43_irq_init(void) {
     gpio_add_raw_irq_handler_with_order_priority(CYW43_PIN_WL_HOST_WAKE, gpio_irq_handler, CYW43_SHARED_IRQ_HANDLER_PRIORITY);
     irq_set_enabled(IO_IRQ_BANK0, true);
-    #if !defined(__riscv)
-    NVIC_SetPriority(PendSV_IRQn, IRQ_PRI_PENDSV);
-    #endif
 }
 
 // This hook will run on whichever CPU serviced the PendSV interrupt

--- a/ports/rp2/mpnetworkport.c
+++ b/ports/rp2/mpnetworkport.c
@@ -57,7 +57,6 @@ static soft_timer_entry_t mp_network_soft_timer;
 #define CYW43_IRQ_LEVEL GPIO_IRQ_LEVEL_HIGH
 #define CYW43_SHARED_IRQ_HANDLER_PRIORITY PICO_SHARED_IRQ_HANDLER_HIGHEST_ORDER_PRIORITY
 
-volatile int cyw43_has_pending = 0;
 
 // The Pico SDK only lets us set GPIO wake on the current running CPU, but the
 // hardware doesn't have this limit. We need to always enable/disable the pin
@@ -89,9 +88,8 @@ static void gpio_irq_handler(void) {
         // cyw43_poll(). It is re-enabled in cyw43_post_poll_hook(), implemented
         // below.
         gpio_set_cpu0_host_wake_irq_enabled(false);
-        cyw43_has_pending = 1;
-        __sev();
         pendsv_schedule_dispatch(PENDSV_DISPATCH_CYW43, cyw43_poll);
+        __sev();
         CYW43_STAT_INC(IRQ_COUNT);
     }
 }
@@ -106,7 +104,6 @@ void cyw43_irq_init(void) {
 
 // This hook will run on whichever CPU serviced the PendSV interrupt
 void cyw43_post_poll_hook(void) {
-    cyw43_has_pending = 0;
     gpio_set_cpu0_host_wake_irq_enabled(true);
 }
 

--- a/ports/rp2/mpthreadport.c
+++ b/ports/rp2/mpthreadport.c
@@ -106,6 +106,9 @@ static void core1_entry_wrapper(void) {
     // Allow MICROPY_BEGIN_ATOMIC_SECTION to be invoked from core0.
     multicore_lockout_victim_init();
 
+    // Set PendSV interrupt priority correctly for CPU1
+    pendsv_init();
+
     if (core1_entry) {
         core1_entry(core1_arg);
     }

--- a/ports/rp2/pendsv.c
+++ b/ports/rp2/pendsv.c
@@ -28,6 +28,7 @@
 #include "py/mpconfig.h"
 #include "py/mpthread.h"
 #include "pendsv.h"
+#include "hardware/irq.h"
 
 #if PICO_RP2040
 #include "RP2040.h"
@@ -45,6 +46,9 @@ static pendsv_dispatch_t pendsv_dispatch_table[PENDSV_DISPATCH_NUM_SLOTS];
 
 static inline void pendsv_resume_run_dispatch(void);
 
+// PendSV IRQ priority, to run system-level tasks that preempt the main thread.
+#define IRQ_PRI_PENDSV PICO_LOWEST_IRQ_PRIORITY
+
 void PendSV_Handler(void);
 
 #if MICROPY_PY_THREAD
@@ -53,8 +57,14 @@ void PendSV_Handler(void);
 // loop of mp_wfe_or_timeout(), where we don't want the CPU event bit to be set.
 static mp_thread_recursive_mutex_t pendsv_mutex;
 
+// Called from CPU0 during boot, but may be called later when CPU1 wakes up
 void pendsv_init(void) {
-    mp_thread_recursive_mutex_init(&pendsv_mutex);
+    if (get_core_num() == 0) {
+        mp_thread_recursive_mutex_init(&pendsv_mutex);
+    }
+    #if !defined(__riscv)
+    NVIC_SetPriority(PendSV_IRQn, IRQ_PRI_PENDSV);
+    #endif
 }
 
 void pendsv_suspend(void) {
@@ -117,11 +127,13 @@ static inline void pendsv_resume_run_dispatch(void) {
 
 void pendsv_schedule_dispatch(size_t slot, pendsv_dispatch_t f) {
     pendsv_dispatch_table[slot] = f;
+    // There is a race here where other core calls pendsv_suspend() before ISR
+    // can execute so this check fails, but dispatch will happen later when
+    // other core calls pendsv_resume().
     if (pendsv_suspend_count() == 0) {
         #if PICO_ARM
-        // There is a race here where other core calls pendsv_suspend() before
-        // ISR can execute, but dispatch will happen later when other core
-        // calls pendsv_resume().
+        // Note this register is part of each CPU core, so setting it on CPUx
+        // will set the IRQ and run PendSV_Handler on CPUx only.
         SCB->ICSR = SCB_ICSR_PENDSVSET_Msk;
         #elif PICO_RISCV
         struct timespec ts;
@@ -136,15 +148,19 @@ void pendsv_schedule_dispatch(size_t slot, pendsv_dispatch_t f) {
 }
 
 // PendSV interrupt handler to perform background processing.
+//
+// Handler can execute on either CPU if MICROPY_PY_THREAD is set (no code on
+// CPU1 calls pendsv_schedule_dispatch(), but CPU1 can call pendsv_resume()
+// which will trigger it).
 void PendSV_Handler(void) {
 
     #if MICROPY_PY_THREAD
     if (!mp_thread_recursive_mutex_lock(&pendsv_mutex, 0)) {
-        // Failure here means core 1 holds pendsv_mutex. ISR will
-        // run again after core 1 calls pendsv_resume().
+        // Failure here means other core holds pendsv_mutex. ISR will
+        // run again after that core calls pendsv_resume().
         return;
     }
-    // Core 0 should not already have locked pendsv_mutex
+    // This core should not already have locked pendsv_mutex
     assert(pendsv_mutex.mutex.enter_count == 1);
     #else
     assert(pendsv_suspend_count() == 0);

--- a/ports/rp2/pendsv.c
+++ b/ports/rp2/pendsv.c
@@ -99,6 +99,10 @@ static inline int pendsv_suspend_count(void) {
 
 #endif
 
+bool pendsv_is_pending(size_t slot) {
+    return pendsv_dispatch_table[slot] != NULL;
+}
+
 static inline void pendsv_resume_run_dispatch(void) {
     // Run pendsv if needed.  Find an entry with a dispatch and call pendsv dispatch
     // with it.  If pendsv runs it will service all slots.

--- a/ports/rp2/pendsv.h
+++ b/ports/rp2/pendsv.h
@@ -42,9 +42,6 @@ enum {
 
 #define PENDSV_DISPATCH_NUM_SLOTS PENDSV_DISPATCH_MAX
 
-// PendSV IRQ priority, to run system-level tasks that preempt the main thread.
-#define IRQ_PRI_PENDSV PICO_LOWEST_IRQ_PRIORITY
-
 typedef void (*pendsv_dispatch_t)(void);
 
 void pendsv_init(void);

--- a/ports/rp2/pendsv.h
+++ b/ports/rp2/pendsv.h
@@ -51,5 +51,6 @@ void pendsv_init(void);
 void pendsv_suspend(void);
 void pendsv_resume(void);
 void pendsv_schedule_dispatch(size_t slot, pendsv_dispatch_t f);
+bool pendsv_is_pending(size_t slot);
 
 #endif // MICROPY_INCLUDED_RP2_PENDSV_H


### PR DESCRIPTION
### Summary

Closes #16779. Thanks to @coencoensmeets for a clear and easy to reproduce bug report, and to @Gadgetoid for doing some deep digging to zero in on the root cause.

There's a very odd but predictable sequence of events that breaks Wi-Fi when using both cores:

1) CPU1 calls `pendsv_suspend()` - for example sleep() causes a softtimer node to be inserted, which calls `pendsv_suspend()`.
2) CYW43 sends wakeup IRQ. CPU0 GPIO IRQ handler schedules PendSV and disables the GPIO IRQ on CPU0, to re-enable after `cyw43_poll()` runs and completes.
3) CPU0 `PendSV_Handler` runs, sees pendsv is suspended, exits.
4) CPU1 calls `pendsv_resume()` and `pendsv_resume()` sees PendSV is pending and triggers it on CPU1.
5) CPU1 runs `PendSV_Handler`, runs `cyw43_poll()`, and at the end it re-enables the pin IRQ *but now on CPU1*.

However CPU1 has the overall GPIO IRQ line disabled, so the CYW43 interrupt never runs again...

Fix is to specifically only enable the GPIO interrupt on CPU0. This isn't supported in pico-sdk but appears to be supported by the hardware.

Plus two follow-up commits:

* Refactor out the `cyw43_has_pending` global flag to instead be a check of the pendsv table. This was necessary for the previous version of this PR. Not necessary now, but seems like a worthwhile change.
* Enable PendSV interrupt at the correct priority on both CPUs, and even if CYW43 is not in use. Also adds some comments in PendSV explaining how it can run on either CPU.

*This work was funded through GitHub Sponsors.*

### Testing

* Ran the test Python program from the linked issue on both RPI_PICO_W and RPI_PICO2_W boards, verified the problem goes away.
* Ran the multi_wlan test between RPI_PICO_W and RPI_PICO2_W and an ESP32, verified tests still pass.

### Trade-offs and Alternatives

* First version of this PR instead changed the interrupt to rising edge, so it didn't need to be disabled. This appears to work fine, and simplifies the code, but actually the CYW43 interrupt pin on RP2 is muxed with the data pin so the GPIO edge interrupt was triggering spuriously at a very high frequency. Oops!
* @Gadgetoid has a PR #16788 which adds support for CPU affinity in PendSV callbacks. We could add this support, although we don't really need the feature (everything that calls `pendsv_schedule_dispatch()` runs on CPU0).
* As @Gadgetoid also suggested in #16788, we could change PendSV to only ever fire on CPU0. In fact, comments in pendsv.c suggest that's the current expectation. I actually implemented this fix first, see https://github.com/projectgus/micropython/commit/47723da831afb4d2bdd7484c8ab8537f986a6339 . That is still more complex than this fix as it needs a cross-core PendSV trigger for when CPU1 does `pendsv_resume()`. However it might be easier to reason about overall.