### PR TITLE
zephyr: Allow pins to support both hard and soft interrupts.

### DIFF
--- a/ports/zephyr/machine_pin.c
+++ b/ports/zephyr/machine_pin.c
@@ -63,22 +63,26 @@ void machine_pin_deinit(void) {
 static void gpio_callback_handler(const struct device *port, struct gpio_callback *cb, gpio_port_pins_t pins) {
     machine_pin_irq_obj_t *irq = CONTAINER_OF(cb, machine_pin_irq_obj_t, callback);
 
-    #if MICROPY_STACK_CHECK
-    // This callback executes in an ISR context so the stack-limit check must be changed to
-    // use the ISR stack for the duration of this function (so that hard IRQ callbacks work).
-    char *orig_stack_top = MP_STATE_THREAD(stack_top);
-    size_t orig_stack_limit = MP_STATE_THREAD(stack_limit);
-    MP_STATE_THREAD(stack_top) = (void *)&irq;
-    MP_STATE_THREAD(stack_limit) = CONFIG_ISR_STACK_SIZE - 512;
-    #endif
+    if (irq->base.ishard) {
+        #if MICROPY_STACK_CHECK
+        // This callback executes in an ISR context so the stack-limit check must be changed to
+        // use the ISR stack for the duration of this function (so that hard IRQ callbacks work).
+        char *orig_stack_top = MP_STATE_THREAD(stack_top);
+        size_t orig_stack_limit = MP_STATE_THREAD(stack_limit);
+        MP_STATE_THREAD(stack_top) = (void *)&irq;
+        MP_STATE_THREAD(stack_limit) = CONFIG_ISR_STACK_SIZE - 512;
+        #endif
 
-    mp_irq_handler(&irq->base);
+        mp_irq_handler(&irq->base);
 
-    #if MICROPY_STACK_CHECK
-    // Restore original stack-limit checking values.
-    MP_STATE_THREAD(stack_top) = orig_stack_top;
-    MP_STATE_THREAD(stack_limit) = orig_stack_limit;
-    #endif
+        #if MICROPY_STACK_CHECK
+        // Restore original stack-limit checking values.
+        MP_STATE_THREAD(stack_top) = orig_stack_top;
+        MP_STATE_THREAD(stack_limit) = orig_stack_limit;
+        #endif
+    } else {
+        mp_sched_schedule(irq->base.handler, irq->base.parent);
+    }
 }
 
 static void machine_pin_print(const mp_print_t *print, mp_obj_t self_in, mp_print_kind_t kind) {


### PR DESCRIPTION
The Pin irq method has an option `hard` parameter that us used to select if the IRQ callback will be called from interrupt context or not. At the moment in the Zephyr port this parameter value is saved but nothing is done with it and all pin interrupts are treated as hard. This PR presents a small change that allows to also handle interrupts in soft mode where the interrupt callback is called out of interrupt context allowing to execute bigger and less time sensitive routines.