### PR TITLE
ports/rp2: Prevent machine.SPI settings from persisting through a soft reset

### DIFF
--- a/ports/rp2/machine_spi.c
+++ b/ports/rp2/machine_spi.c
@@ -80,6 +80,11 @@
 
 #endif
 
+// Define PICO_DEFAULT_SPI for a no-args call to machine.SPI()
+#ifndef PICO_DEFAULT_SPI
+#define PICO_DEFAULT_SPI 0
+#endif
+
 // SPI0 can be GP{0..7,16..23}, SPI1 can be GP{8..15,24..29}.
 #define IS_VALID_PERIPH(spi, pin)   ((((pin) & 8) >> 3) == (spi))
 // GP{2,6,10,14,...}
@@ -128,7 +133,7 @@ static void machine_spi_print(const mp_print_t *print, mp_obj_t self_in, mp_prin
 mp_obj_t machine_spi_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *all_args) {
     enum { ARG_id, ARG_baudrate, ARG_polarity, ARG_phase, ARG_bits, ARG_firstbit, ARG_sck, ARG_mosi, ARG_miso };
     static const mp_arg_t allowed_args[] = {
-        { MP_QSTR_id,       MP_ARG_REQUIRED | MP_ARG_OBJ },
+        { MP_QSTR_id,       MICROPY_SPI_PINS_ARG_OPTS | MP_ARG_INT, {.u_int = PICO_DEFAULT_SPI} },
         { MP_QSTR_baudrate, MP_ARG_INT, {.u_int = DEFAULT_SPI_BAUDRATE} },
         { MP_QSTR_polarity, MP_ARG_KW_ONLY | MP_ARG_INT, {.u_int = DEFAULT_SPI_POLARITY} },
         { MP_QSTR_phase,    MP_ARG_KW_ONLY | MP_ARG_INT, {.u_int = DEFAULT_SPI_PHASE} },
@@ -144,7 +149,7 @@ mp_obj_t machine_spi_make_new(const mp_obj_type_t *type, size_t n_args, size_t n
     mp_arg_parse_all_kw_array(n_args, n_kw, all_args, MP_ARRAY_SIZE(allowed_args), allowed_args, args);
 
     // Get the SPI bus id.
-    int spi_id = mp_obj_get_int(args[ARG_id].u_obj);
+    int spi_id = args[ARG_id].u_int;
     if (spi_id < 0 || spi_id >= MP_ARRAY_SIZE(machine_spi_obj)) {
         mp_raise_msg_varg(&mp_type_ValueError, MP_ERROR_TEXT("SPI(%d) doesn't exist"), spi_id);
     }

--- a/ports/rp2/machine_spi.c
+++ b/ports/rp2/machine_spi.c
@@ -85,6 +85,9 @@
 #define PICO_DEFAULT_SPI 0
 #endif
 
+// Assume we won't get an RP2-compatible with 255 GPIO pins
+#define MICROPY_HW_SPI_PIN_UNUSED UINT8_MAX
+
 // SPI0 can be GP{0..7,16..23}, SPI1 can be GP{8..15,24..29}.
 #define IS_VALID_PERIPH(spi, pin)   ((((pin) & 8) >> 3) == (spi))
 // GP{2,6,10,14,...}
@@ -125,9 +128,14 @@ static machine_spi_obj_t machine_spi_obj[] = {
 
 static void machine_spi_print(const mp_print_t *print, mp_obj_t self_in, mp_print_kind_t kind) {
     machine_spi_obj_t *self = MP_OBJ_TO_PTR(self_in);
-    mp_printf(print, "SPI(%u, baudrate=%u, polarity=%u, phase=%u, bits=%u, sck=%u, mosi=%u, miso=%u)",
+    mp_printf(print, "SPI(%u, baudrate=%u, polarity=%u, phase=%u, bits=%u, sck=%u, mosi=%u, miso=",
         self->spi_id, self->baudrate, self->polarity, self->phase, self->bits,
         self->sck, self->mosi, self->miso);
+    if (self->miso == MICROPY_HW_SPI_PIN_UNUSED) {
+        mp_printf(print, "None)");
+    } else {
+        mp_printf(print, "%u)", self->miso);
+    }
 }
 
 mp_obj_t machine_spi_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *all_args) {
@@ -141,7 +149,7 @@ mp_obj_t machine_spi_make_new(const mp_obj_type_t *type, size_t n_args, size_t n
         { MP_QSTR_firstbit, MP_ARG_KW_ONLY | MP_ARG_INT, {.u_int = DEFAULT_SPI_FIRSTBIT} },
         { MP_QSTR_sck,      MICROPY_SPI_PINS_ARG_OPTS | MP_ARG_KW_ONLY | MP_ARG_OBJ, {.u_rom_obj = MP_ROM_NONE} },
         { MP_QSTR_mosi,     MICROPY_SPI_PINS_ARG_OPTS | MP_ARG_KW_ONLY | MP_ARG_OBJ, {.u_rom_obj = MP_ROM_NONE} },
-        { MP_QSTR_miso,     MICROPY_SPI_PINS_ARG_OPTS | MP_ARG_KW_ONLY | MP_ARG_OBJ, {.u_rom_obj = MP_ROM_NONE} },
+        { MP_QSTR_miso,     MICROPY_SPI_PINS_ARG_OPTS | MP_ARG_KW_ONLY | MP_ARG_OBJ, {.u_rom_obj = MP_ROM_INT(-1)} },
     };
 
     // Parse the arguments.
@@ -172,7 +180,12 @@ mp_obj_t machine_spi_make_new(const mp_obj_type_t *type, size_t n_args, size_t n
         }
         self->mosi = mosi;
     }
-    if (args[ARG_miso].u_obj != mp_const_none) {
+
+    if (args[ARG_miso].u_obj == MP_ROM_INT(-1)) {
+        self->miso = spi_id == 0 ? MICROPY_HW_SPI0_MISO : MICROPY_HW_SPI1_MISO;
+    } else if (args[ARG_miso].u_obj == mp_const_none) {
+        self->miso = MICROPY_HW_SPI_PIN_UNUSED;
+    } else {
         int miso = mp_hal_get_pin_obj(args[ARG_miso].u_obj);
         if (!IS_VALID_MISO(self->spi_id, miso)) {
             mp_raise_ValueError(MP_ERROR_TEXT("bad MISO pin"));
@@ -195,7 +208,9 @@ mp_obj_t machine_spi_make_new(const mp_obj_type_t *type, size_t n_args, size_t n
         self->baudrate = spi_set_baudrate(self->spi_inst, self->baudrate);
         spi_set_format(self->spi_inst, self->bits, self->polarity, self->phase, self->firstbit);
         gpio_set_function(self->sck, GPIO_FUNC_SPI);
-        gpio_set_function(self->miso, GPIO_FUNC_SPI);
+        if (self->miso != MICROPY_HW_SPI_PIN_UNUSED) {
+            gpio_set_function(self->miso, GPIO_FUNC_SPI);
+        }
         gpio_set_function(self->mosi, GPIO_FUNC_SPI);
     }
 

--- a/ports/rp2/machine_spi.c
+++ b/ports/rp2/machine_spi.c
@@ -127,6 +127,12 @@ static machine_spi_obj_t machine_spi_obj[] = {
     },
 };
 
+void machine_spi_init0(void) {
+    for (int i = 0; i < MP_ARRAY_SIZE(machine_spi_obj); i++) {
+        machine_spi_obj[i].initialised = false;
+    }
+}
+
 static void machine_spi_print(const mp_print_t *print, mp_obj_t self_in, mp_print_kind_t kind) {
     machine_spi_obj_t *self = MP_OBJ_TO_PTR(self_in);
     mp_printf(print, "SPI(%u, baudrate=%u, polarity=%u, phase=%u, bits=%u, sck=%u, mosi=%u, miso=",

--- a/ports/rp2/main.c
+++ b/ports/rp2/main.c
@@ -169,6 +169,7 @@ int main(int argc, char **argv) {
         rp2_pio_init();
         rp2_dma_init();
         machine_i2s_init0();
+        machine_spi_init0();
 
         #if MICROPY_PY_BLUETOOTH
         mp_bluetooth_hci_init();

--- a/ports/rp2/modmachine.h
+++ b/ports/rp2/modmachine.h
@@ -6,6 +6,7 @@
 void machine_pin_init(void);
 void machine_pin_deinit(void);
 void machine_i2s_init0(void);
+void machine_spi_init0(void);
 void machine_i2s_deinit_all(void);
 void machine_pwm_deinit_all(void);
 void machine_uart_deinit_all(void);


### PR DESCRIPTION
Replaced by, original info has moved there: https://github.com/micropython/micropython/pull/16922

This has gone off the rails somewhat into a discussion about whether RP2'S SPI (and other peripherals on RP2 and other devices) should be fully reset upon a "soft reset" (in MicroPython terms this is basically just bailing out of user code, doing some teardown and set up and returning back to user code/REPL again)

To state my case in brief: A "reset" should, you know, reset things and an "init" should... "init" things.

For my part, I represent a vendor of "educational" electronics targeted at beginners/hobbyists. We have many MicroPython boards out in the wild and most of these have some self evident physical "default" bus connector: QwSt/Quiic/Stemma for I2C or SP/CE for SPI. Unsurprising and consistent behaviour of these default instances is therefore in my best interests.

## In Detail

### SPI Settings Persisting Across Soft Resets

Running `SPI(mosi=23)` will change the behaviour of `SPI()`, which is roughly what the documentation confirms- however this change persists across soft resets. IE: `SPI()` will use pin 23 for MOSI until a new pin is specified, or until the board is hard reset. This happens because the current SPI pin configuration is saved into static RAM (not managed by MicroPython) and not re-initialised on soft reset.

It's not obvious (read: not sufficiently documented) that this is the case. Anyone idly tinkering on the REPL or writing a script could find themselves unable to talk to their device because they've inadvertently made a persistent pin change.

I would be interested in feedback from anyone who relies on the persistence of SPI settings between soft resets since I'm struggling to find many reasons *for* it (not glitching sensitive external peripherals on reset?) but that may just be a failure of imagination on my part.

As a side-effect of this, SPI claims a small amount of RAM for these persistent instances whether you use it or not. That may not be a big deal on RP2 but reserving RAM for a peripheral that a user might not even use is an odd choice, especially in the absence of any good argumentation for why someone would want SPI settings to be persistent.

### SPI().init() Does Not Initialise Anything

`SPI().init()` (and other hardware `init` functions) have been somewhat twisted in meaning. Despite the claims of the documentation `SPI().init()` does not "init" the SPI.

It seems "init" functions across various hardware peripherals have been misappropriated to mean "make some change to a user-supplied bus." Examples include changing the baud rate on SPI or UART (perhaps supplied by a user into a driver instance) without resetting ("initialising") other values. Again the documentation doesn't sufficiently explain this practice.

As a tertiary consequence of this, SPI's "init" on RP2 specifically doesn't contain all the parameters that `SPI()` has available; chiefly you cannot configure pins with it. As the docs suggest, `SPI(id, *args, *kwargs)` should be equivalent to `SPI(id).init(*args, *kwargs)`. It is not.