### PR TITLE
Support error message compression on CMake ports

### DIFF
--- a/ports/esp32/esp32_common.cmake
+++ b/ports/esp32/esp32_common.cmake
@@ -28,6 +28,11 @@ if(NOT DEFINED MICROPY_PY_TINYUSB)
     endif()
 endif()
 
+# Enable error text compression by default.
+if(NOT MICROPY_ROM_TEXT_COMPRESSION)
+    set(MICROPY_ROM_TEXT_COMPRESSION ON)
+endif()
+
 # Include core source components.
 include(${MICROPY_DIR}/py/py.cmake)
 

--- a/ports/rp2/CMakeLists.txt
+++ b/ports/rp2/CMakeLists.txt
@@ -66,6 +66,11 @@ if(NOT MICROPY_C_HEAP_SIZE)
     set(MICROPY_C_HEAP_SIZE 0)
 endif()
 
+# Enable error text compression by default.
+if(NOT MICROPY_ROM_TEXT_COMPRESSION)
+    set(MICROPY_ROM_TEXT_COMPRESSION ON)
+endif()
+
 # Enable extmod components that will be configured by extmod.cmake.
 # A board may also have enabled additional components.
 set(MICROPY_SSL_MBEDTLS ON)


### PR DESCRIPTION
### Summary

This PR adds support for error message text compression on CMake ports:
- fix cases where `MP_ERROR_TEXT()` was not used to wrap error messages
- add support to `py/mkrules.cmake` for enabling compression and generating the correct header files
- enable compression by default on esp32 and rp2 ports

This reduces rp2 firmware by about 3000 bytes, and esp32 firmware by about 3300 bytes.

### Testing

Built both RPI_PICO2 and ESP32_GENERIC, deployed and used the REPL to raise a few different exceptions, the error messages were as expected.

### Trade-offs and Alternatives

Almost all other ports enable this option, no reason why esp32 and rp2 can't as well, to save some code size.

Didn't try to enable it on zephyr, but it should work.
