### PR TITLE
ports/rp2: Optional spi_id and optional disabling of MISO pin

### DIFF
--- a/ports/rp2/machine_spi.c
+++ b/ports/rp2/machine_spi.c
@@ -128,7 +128,11 @@ static void machine_spi_print(const mp_print_t *print, mp_obj_t self_in, mp_prin
 mp_obj_t machine_spi_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *all_args) {
     enum { ARG_id, ARG_baudrate, ARG_polarity, ARG_phase, ARG_bits, ARG_firstbit, ARG_sck, ARG_mosi, ARG_miso };
     static const mp_arg_t allowed_args[] = {
-        { MP_QSTR_id,       MP_ARG_REQUIRED | MP_ARG_OBJ },
+        #ifdef PICO_DEFAULT_SPI
+        { MP_QSTR_id,       MP_ARG_INT, {.u_int = PICO_DEFAULT_SPI} },
+        #else
+        { MP_QSTR_id,       MP_ARG_REQUIRED | MP_ARG_INT, },
+        #endif
         { MP_QSTR_baudrate, MP_ARG_INT, {.u_int = DEFAULT_SPI_BAUDRATE} },
         { MP_QSTR_polarity, MP_ARG_KW_ONLY | MP_ARG_INT, {.u_int = DEFAULT_SPI_POLARITY} },
         { MP_QSTR_phase,    MP_ARG_KW_ONLY | MP_ARG_INT, {.u_int = DEFAULT_SPI_PHASE} },
@@ -144,7 +148,7 @@ mp_obj_t machine_spi_make_new(const mp_obj_type_t *type, size_t n_args, size_t n
     mp_arg_parse_all_kw_array(n_args, n_kw, all_args, MP_ARRAY_SIZE(allowed_args), allowed_args, args);
 
     // Get the SPI bus id.
-    int spi_id = mp_obj_get_int(args[ARG_id].u_obj);
+    int spi_id = args[ARG_id].u_int;
     if (spi_id < 0 || spi_id >= MP_ARRAY_SIZE(machine_spi_obj)) {
         mp_raise_msg_varg(&mp_type_ValueError, MP_ERROR_TEXT("SPI(%d) doesn't exist"), spi_id);
     }

--- a/ports/rp2/machine_spi.c
+++ b/ports/rp2/machine_spi.c
@@ -80,6 +80,9 @@
 
 #endif
 
+// Assume we won't get an RP2-compatible with 255 GPIO pins
+#define MICROPY_HW_SPI_PIN_UNUSED UINT8_MAX
+
 // SPI0 can be GP{0..7,16..23}, SPI1 can be GP{8..15,24..29}.
 #define IS_VALID_PERIPH(spi, pin)   ((((pin) & 8) >> 3) == (spi))
 // GP{2,6,10,14,...}
@@ -120,9 +123,14 @@ static machine_spi_obj_t machine_spi_obj[] = {
 
 static void machine_spi_print(const mp_print_t *print, mp_obj_t self_in, mp_print_kind_t kind) {
     machine_spi_obj_t *self = MP_OBJ_TO_PTR(self_in);
-    mp_printf(print, "SPI(%u, baudrate=%u, polarity=%u, phase=%u, bits=%u, sck=%u, mosi=%u, miso=%u)",
+    mp_printf(print, "SPI(%u, baudrate=%u, polarity=%u, phase=%u, bits=%u, sck=%u, mosi=%u, miso=",
         self->spi_id, self->baudrate, self->polarity, self->phase, self->bits,
         self->sck, self->mosi, self->miso);
+    if (self->miso == MICROPY_HW_SPI_PIN_UNUSED) {
+        mp_printf(print, "None)");
+    } else {
+        mp_printf(print, "%u)", self->miso);
+    }
 }
 
 mp_obj_t machine_spi_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *all_args) {
@@ -140,7 +148,7 @@ mp_obj_t machine_spi_make_new(const mp_obj_type_t *type, size_t n_args, size_t n
         { MP_QSTR_firstbit, MP_ARG_KW_ONLY | MP_ARG_INT, {.u_int = DEFAULT_SPI_FIRSTBIT} },
         { MP_QSTR_sck,      MICROPY_SPI_PINS_ARG_OPTS | MP_ARG_KW_ONLY | MP_ARG_OBJ, {.u_rom_obj = MP_ROM_NONE} },
         { MP_QSTR_mosi,     MICROPY_SPI_PINS_ARG_OPTS | MP_ARG_KW_ONLY | MP_ARG_OBJ, {.u_rom_obj = MP_ROM_NONE} },
-        { MP_QSTR_miso,     MICROPY_SPI_PINS_ARG_OPTS | MP_ARG_KW_ONLY | MP_ARG_OBJ, {.u_rom_obj = MP_ROM_NONE} },
+        { MP_QSTR_miso,     MICROPY_SPI_PINS_ARG_OPTS | MP_ARG_KW_ONLY | MP_ARG_OBJ, {.u_rom_obj = MP_ROM_INT(-1)} },
     };
 
     // Parse the arguments.
@@ -171,7 +179,10 @@ mp_obj_t machine_spi_make_new(const mp_obj_type_t *type, size_t n_args, size_t n
         }
         self->mosi = mosi;
     }
-    if (args[ARG_miso].u_obj != mp_const_none) {
+
+    if (args[ARG_miso].u_obj == mp_const_none) {
+        self->miso = MICROPY_HW_SPI_PIN_UNUSED;
+    } else if (args[ARG_miso].u_obj != MP_OBJ_NEW_SMALL_INT(-1)) {
         int miso = mp_hal_get_pin_obj(args[ARG_miso].u_obj);
         if (!IS_VALID_MISO(self->spi_id, miso)) {
             mp_raise_ValueError(MP_ERROR_TEXT("bad MISO pin"));
@@ -194,7 +205,9 @@ mp_obj_t machine_spi_make_new(const mp_obj_type_t *type, size_t n_args, size_t n
         self->baudrate = spi_set_baudrate(self->spi_inst, self->baudrate);
         spi_set_format(self->spi_inst, self->bits, self->polarity, self->phase, self->firstbit);
         gpio_set_function(self->sck, GPIO_FUNC_SPI);
-        gpio_set_function(self->miso, GPIO_FUNC_SPI);
+        if (self->miso != MICROPY_HW_SPI_PIN_UNUSED) {
+            gpio_set_function(self->miso, GPIO_FUNC_SPI);
+        }
         gpio_set_function(self->mosi, GPIO_FUNC_SPI);
     }
 


### PR DESCRIPTION
### Summary

This PR includes two changes:

1. Bring `machine.SPI()` into parity with `machine.I2C()`, selecting the default instance where none is specified. See: https://github.com/micropython/micropython/pull/16671
2. Make `machine.SPI(mosi=None)` explicitly disable MISO, for configurations which use this as a register-select or data/command pin (very common for write-only LCDs). See: https://github.com/micropython/micropython/issues/16912

I avoided making this change for all pins, since it rarely makes sense for MOSI or SCLK to be disabled.

### Testing

Tested various invocations of `machine.SPI()` on a Pico 2 W.

Notably this change introduces a difference in behaviour that  *always* resets MISO back to the default unless it's specified or set to `None`. Eg:

```
>>> machine.SPI()
SPI(0, baudrate=1000000, polarity=0, phase=0, bits=8, sck=18, mosi=19, miso=16)
>>> machine.SPI(miso=None)
SPI(0, baudrate=1000000, polarity=0, phase=0, bits=8, sck=18, mosi=19, miso=None)
>>> machine.SPI()
SPI(0, baudrate=1000000, polarity=0, phase=0, bits=8, sck=18, mosi=19, miso=16)
```

This is materially different from, for example, mosi where it's impossible to implicitly set a pin back to its default value:

```
>>> machine.SPI(mosi=23)
SPI(0, baudrate=1000000, polarity=0, phase=0, bits=8, sck=18, mosi=23, miso=16)
>>> machine.SPI()
SPI(0, baudrate=1000000, polarity=0, phase=0, bits=8, sck=18, mosi=23, miso=16)
>>> machine.SPI(mosi=None)
SPI(0, baudrate=1000000, polarity=0, phase=0, bits=8, sck=18, mosi=23, miso=16)
```

🤔 Maybe this changeset should also require that a pin is specified or that it is otherwise always set back to its default value.

### Trade-offs and Alternatives

The latter change is more about explicit vs implicit. It's possibly just to set upt he MISO pin *after* setting up SPI and it will work as expected. A documentation change establishing this as the accepted pattern might be an alternative... though it might not be possible in all cases for the pin setup to happen before SPI.

Consider the following very crude example driver pattern where a user wishes to save a pin (normally eaten by SPI) and reuse it for register select:

```python
class LCD:
    def __init__(self, spi=None, rs=None):
        self._spi = spi or machine.SPI()

my_led_screen = LCD(rs=machine.Pin(16))
```

However because the pin is constructed before it's passed into the driver class, its mux will be overwritten by `machine.SPI()`

With this change, a driver author could use:

```python
class LCD:
    def __init__(self, spi=None, rs=None):
        self._spi = spi or machine.SPI(miso=None)

my_led_screen = LCD(rs=machine.Pin(16))
```

And SPI would no longer trample the "rs" pin config by setting it up as MISO.