### PR TITLE
rp2/machine_i2c: Require an I2C bus ID when no default is available.

### DIFF
--- a/ports/rp2/machine_i2c.c
+++ b/ports/rp2/machine_i2c.c
@@ -100,7 +100,7 @@ mp_obj_t machine_i2c_make_new(const mp_obj_type_t *type, size_t n_args, size_t n
         #ifdef PICO_DEFAULT_I2C
         { MP_QSTR_id, MP_ARG_INT, {.u_int = PICO_DEFAULT_I2C} },
         #else
-        { MP_QSTR_id, MP_ARG_INT, {.u_int = -1} },
+        { MP_QSTR_id, MP_ARG_INT | MP_ARG_REQUIRED },
         #endif
         { MP_QSTR_freq, MP_ARG_INT, {.u_int = DEFAULT_I2C_FREQ} },
         { MP_QSTR_scl, MICROPY_I2C_PINS_ARG_OPTS | MP_ARG_KW_ONLY | MP_ARG_OBJ, {.u_rom_obj = MP_ROM_NONE} },


### PR DESCRIPTION
When PICO_DEFAULT_I2C is not set require an I2C bus ID instead of using -1 as a default, which would fail with a cryptic:

```
    "I2C(-1) doesn't exist"
```

Picked up in review of #16922