### PR TITLE
extmod/moddeflate: Keep DeflateIO state consistent on window alloc fail.

### DIFF
--- a/tests/extmod/deflate_compress_memory_error.py
+++ b/tests/extmod/deflate_compress_memory_error.py
@@ -1,0 +1,39 @@
+# Test deflate.DeflateIO compression, with out-of-memory errors.
+
+try:
+    # Check if deflate is available.
+    import deflate
+    import io
+except ImportError:
+    print("SKIP")
+    raise SystemExit
+
+# Check if compression is enabled.
+if not hasattr(deflate.DeflateIO, "write"):
+    print("SKIP")
+    raise SystemExit
+
+# Create a compressor object.
+b = io.BytesIO()
+g = deflate.DeflateIO(b, deflate.RAW, 15)
+
+# Then, use up most of the heap.
+l = []
+while True:
+    try:
+        l.append(bytearray(1000))
+    except:
+        break
+l.pop()
+
+# Try to compress.  This will try to allocate a large window and fail.
+try:
+    g.write('test')
+except MemoryError:
+    print("MemoryError")
+
+# Should still be able to close the stream.
+g.close()
+
+# The underlying output stream should be unchanged.
+print(b.getvalue())

--- a/tests/extmod/deflate_compress_memory_error.py.exp
+++ b/tests/extmod/deflate_compress_memory_error.py.exp
@@ -1,0 +1,2 @@
+MemoryError
+b''

--- a/tests/run-tests.py
+++ b/tests/run-tests.py
@@ -163,6 +163,7 @@ platform_tests_to_skip = {
         "extmod/asyncio_threadsafeflag.py",
         "extmod/asyncio_wait_for_fwd.py",
         "extmod/binascii_a2b_base64.py",
+        "extmod/deflate_compress_memory_error.py",  # tries to allocate unlimited memory
         "extmod/re_stack_overflow.py",
         "extmod/time_res.py",
         "extmod/vfs_posix.py",


### PR DESCRIPTION
### Summary

Allocation of a large compression window may fail, and in that case keep the `DeflateIO` state consistent so its other methods (such as `close()`) still work.  Consistency is kept by only updating the `self->write` member if the window allocation succeeds.

Thanks to @jimmo for finding the bug.

### Testing

A new test is added, will run under CI.