### PR TITLE
ports/rp2/boards: Fix SparkFun vendor name.

### DIFF
--- a/ports/rp2/boards/SPARKFUN_IOTNODE_LORAWAN_RP2350/board.json
+++ b/ports/rp2/boards/SPARKFUN_IOTNODE_LORAWAN_RP2350/board.json
@@ -21,5 +21,5 @@
     "product": "IoT Node LoRaWAN RP2350",
     "thumbnail": "",
     "url": "https://www.sparkfun.com/products/26060",
-    "vendor": "Sparkfun"
+    "vendor": "SparkFun"
 }

--- a/ports/rp2/boards/SPARKFUN_PROMICRO/board.json
+++ b/ports/rp2/boards/SPARKFUN_PROMICRO/board.json
@@ -17,5 +17,5 @@
     "product": "Pro Micro RP2040",
     "thumbnail": "",
     "url": "https://www.sparkfun.com/products/18288",
-    "vendor": "Sparkfun"
+    "vendor": "SparkFun"
 }

--- a/ports/rp2/boards/SPARKFUN_PROMICRO_RP2350/board.json
+++ b/ports/rp2/boards/SPARKFUN_PROMICRO_RP2350/board.json
@@ -18,5 +18,5 @@
     "product": "Pro Micro RP2350",
     "thumbnail": "",
     "url": "https://www.sparkfun.com/products/24870",
-    "vendor": "Sparkfun"
+    "vendor": "SparkFun"
 }

--- a/ports/rp2/boards/SPARKFUN_THINGPLUS/board.json
+++ b/ports/rp2/boards/SPARKFUN_THINGPLUS/board.json
@@ -20,5 +20,5 @@
     "product": "Thing Plus RP2040",
     "thumbnail": "",
     "url": "https://www.sparkfun.com/products/17745",
-    "vendor": "Sparkfun"
+    "vendor": "SparkFun"
 }

--- a/ports/rp2/boards/SPARKFUN_THINGPLUS_RP2350/board.json
+++ b/ports/rp2/boards/SPARKFUN_THINGPLUS_RP2350/board.json
@@ -23,5 +23,5 @@
     "product": "Thing Plus RP2350",
     "thumbnail": "",
     "url": "https://www.sparkfun.com/products/25134",
-    "vendor": "Sparkfun"
+    "vendor": "SparkFun"
 }

--- a/ports/rp2/boards/SPARKFUN_XRP_CONTROLLER/board.json
+++ b/ports/rp2/boards/SPARKFUN_XRP_CONTROLLER/board.json
@@ -21,5 +21,5 @@
     "product": "XRP Controller",
     "thumbnail": "",
     "url": "https://www.sparkfun.com/sparkfun-experiential-robotics-platform-xrp-controller.html",
-    "vendor": "Sparkfun"
+    "vendor": "SparkFun"
 }

--- a/ports/rp2/boards/SPARKFUN_XRP_CONTROLLER_BETA/board.json
+++ b/ports/rp2/boards/SPARKFUN_XRP_CONTROLLER_BETA/board.json
@@ -19,5 +19,5 @@
     "product": "XRP Controller (Beta)",
     "thumbnail": "",
     "url": "https://www.sparkfun.com/sparkfun-experiential-robotics-platform-xrp-controller-beta.html",
-    "vendor": "Sparkfun"
+    "vendor": "SparkFun"
 }


### PR DESCRIPTION
### Summary

Apologies as this is a bit of a small/pedantic change. With merge of the new SparkFun IoT RedBoard RP2350 board definition files which spell our vendor name correctly as "SparkFun", we noticed that the MicroPython downloads page is case-sensitive and that all previous SparkFun boards have used our name spelled as "Sparkfun". This led to two separate vendor links on the downloads page:

- [https://micropython.org/download/?vendor=SparkFun](https://micropython.org/download/?vendor=SparkFun)
- [https://micropython.org/download/?vendor=Sparkfun](https://micropython.org/download/?vendor=Sparkfun)

One of which only has the new IoT RedBoard RP2350. Our preferred/correct spelling is "SparkFun" so this PR updates all of our existing board definitions with that spelling such that everything will show on the same page.

### Testing

Did not test building or running as this is an "aesthetic" change.

### Trade-offs and Alternatives

Alternative could be to switch only the board.json for the new IoT Redboard RP2350 although that is not our preference as it is actually the only one with the correct spelling. Trade-off is that this will break the old link that we have sent to some users.
