### PR TITLE
examples/embedding: Build embed sources in the same make command.

### DIFF
--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -20,6 +20,12 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - name: Build
-      run: make -C examples/embedding -f micropython_embed.mk && make -C examples/embedding
+      run: make -C examples/embedding -f micropython_embed.mk && make -C examples/embedding -f makefile.mk 
     - name: Run
+      run: ./examples/embedding/embed | grep "hello world"
+    - name: Clean
+      run: make -C examples/embedding clean && [ ! -e embed ] && [ ! -e micropython_embed ]
+    - name: Combined Build
+      run: make -C examples/embedding
+    - name: Combined Run
       run: ./examples/embedding/embed | grep "hello world"

--- a/examples/embedding/.gitignore
+++ b/examples/embedding/.gitignore
@@ -1,0 +1,3 @@
+micropython_embed/
+embed
+*.o

--- a/examples/embedding/Makefile
+++ b/examples/embedding/Makefile
@@ -1,25 +1,15 @@
 # This file is part of the MicroPython project, http://micropython.org/
 # The MIT License (MIT)
-# Copyright (c) 2022-2023 Damien P. George
-#
-# This is a very simple makefile that demonstrates how to build the embed port.
-# All it needs to do is build all *.c files in the micropython_embed directory.
-# This makefile would be replaced with your custom build system.
+# Copyright (c) 2025 Anson Mansfield
 
-EMBED_DIR = micropython_embed
-PROG = embed
+all: mpy
+	$(MAKE) -f makefile.mk
+clean::
+	$(MAKE) -f makefile.mk clean
 
-CFLAGS += -I.
-CFLAGS += -I$(EMBED_DIR)
-CFLAGS += -I$(EMBED_DIR)/port
-CFLAGS += -Wall -Og -fno-common
+mpy:
+	$(MAKE) -f micropython_embed.mk
+clean::
+	$(MAKE) -f micropython_embed.mk clean
 
-SRC += main.c
-SRC += $(wildcard $(EMBED_DIR)/*/*.c) $(wildcard $(EMBED_DIR)/*/*/*.c)
-OBJ += $(SRC:.c=.o)
-
-$(PROG): $(OBJ)
-	$(CC) -o $@ $^
-
-clean:
-	/bin/rm -f $(OBJ) $(PROG)
+.PHONY: all clean mpy

--- a/examples/embedding/README.md
+++ b/examples/embedding/README.md
@@ -10,22 +10,33 @@ simple Python scripts which print things to the standard output.
 Building the example
 --------------------
 
-First build the embed port using:
+To build the example project, based on `main.c`, use:
+
+    $ make
+
+This will first build the micropython embedded sources using the
+`micropython_embed.mk` sub-make, then compile those sources together with `main.c`
+using the `makefile.mk` sub-make. (It's done this way, so that the second sub-make
+can discover sources that might not exist until after the first when building from
+clean.)
+
+That will create an executable called `embed` which you can run:
+
+    $ ./embed
+
+Building the embed port manually
+--------------------------------
+
+You can also building the embed port directly using:
 
     $ make -f micropython_embed.mk
 
 This will generate the `micropython_embed` directory which is a self-contained
 copy of MicroPython suitable for embedding.  The .c files in this directory need
 to be compiled into your project, in whatever way your project can do that.  The
-example here uses make and a provided `Makefile`.
+example here uses make and the provided `makefile.mk`.
 
-To build the example project, based on `main.c`, use:
-
-    $ make
-
-That will create an executable called `embed` which you can run:
-
-    $ ./embed
+    $ make -f makefile.mk
 
 Out of tree build
 -----------------

--- a/examples/embedding/makefile.mk
+++ b/examples/embedding/makefile.mk
@@ -1,0 +1,25 @@
+# This file is part of the MicroPython project, http://micropython.org/
+# The MIT License (MIT)
+# Copyright (c) 2022-2023 Damien P. George
+#
+# This is a very simple makefile that demonstrates how to build the embed port.
+# All it needs to do is build all *.c files in the micropython_embed directory.
+# This makefile would be replaced with your custom build system.
+
+EMBED_DIR = micropython_embed
+PROG = embed
+
+CFLAGS += -I.
+CFLAGS += -I$(EMBED_DIR)
+CFLAGS += -I$(EMBED_DIR)/port
+CFLAGS += -Wall -Og -fno-common
+
+SRC += main.c
+SRC += $(wildcard $(EMBED_DIR)/*/*.c) $(wildcard $(EMBED_DIR)/*/*/*.c)
+OBJ += $(SRC:.c=.o)
+
+$(PROG): $(OBJ)
+	$(CC) -o $@ $^
+
+clean:
+	/bin/rm -f $(OBJ) $(PROG)


### PR DESCRIPTION
### Summary

This updates the example for the embed port to streamline the build process, reducing the number of commands needed to build it from 2 to 1.

In specific:
- The original `Makefile` is moved aside to become `makefile.mk`.
- It's replaced with a new `Makefile` that invokes `micropython_embed.mk` and `makefile.mk` as recursive sub-makes.

This indirection makes sure that the `SRC += $(wildcard $(EMBED_DIR)/*/*.c) $(wildcard $(EMBED_DIR)/*/*/*.c)` variable expansion is performed after the sources it's meant to pick up already exist. If the `mpy` recipe were added directly to the original makefile, these files wouldn't be picked up on first invocation and it would prevent the example from being built directly from clean.

### Testing

This commit updates `.github/workflows/examples.yml` to reflect the `Makefile -> makefile.mk` rename, and adds tests of the combined single-command clean and build operations. I've also separately tested building the example from a number of different clean and dirty build states.

### Trade-offs and Alternatives

This is a documentation change (with automated tests that verify the documentation's claims).
The minor increase in technical complexity could subtly impact the example's pedagogical utility, but the positive utility of demonstrating a complete combined source-gen and compilation build should outweigh that.
