### PR TITLE
rp2/boards/SPARKFUN_IOTNODE_LORAWAN_RP2350: Add SD card support to board.

### DIFF
--- a/ports/rp2/boards/SPARKFUN_IOTNODE_LORAWAN_RP2350/manifest.py
+++ b/ports/rp2/boards/SPARKFUN_IOTNODE_LORAWAN_RP2350/manifest.py
@@ -1,0 +1,3 @@
+include("$(PORT_DIR)/boards/manifest.py")
+
+require("sdcard")

--- a/ports/rp2/boards/SPARKFUN_IOTNODE_LORAWAN_RP2350/mpconfigboard.cmake
+++ b/ports/rp2/boards/SPARKFUN_IOTNODE_LORAWAN_RP2350/mpconfigboard.cmake
@@ -5,3 +5,6 @@ set(PICO_BOARD_HEADER_DIRS ${MICROPY_PORT_DIR}/boards/${MICROPY_BOARD})
 
 set(PICO_BOARD "sparkfun_iotnode_lorawan_rp2350")
 set(PICO_PLATFORM "rp2350")
+
+# Board specific version of the frozen manifest
+set(MICROPY_FROZEN_MANIFEST ${MICROPY_BOARD_DIR}/manifest.py)


### PR DESCRIPTION
### Summary
The IOTNODE_LORAWAN_RP2350 has an SD card and we want users to be able to ```import sdcard``` without copying sdcard.py over to their board.

### Testing

Tested on a board and SD card could successfully be written and read to.

