### PR TITLE
mimxrt/machine_i2c.c: Make I2C bus ID arg optional with default.

### DIFF
--- a/ports/mimxrt/machine_i2c.c
+++ b/ports/mimxrt/machine_i2c.c
@@ -89,7 +89,7 @@ static void machine_i2c_print(const mp_print_t *print, mp_obj_t self_in, mp_prin
 mp_obj_t machine_i2c_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *all_args) {
     enum { ARG_id, ARG_freq, ARG_drive};
     static const mp_arg_t allowed_args[] = {
-        { MP_QSTR_id, MP_ARG_REQUIRED | MP_ARG_OBJ },
+        { MP_QSTR_id, MP_ARG_INT, {.u_int = 0}  },
         { MP_QSTR_freq, MP_ARG_INT, {.u_int = DEFAULT_I2C_FREQ} },
         { MP_QSTR_drive, MP_ARG_KW_ONLY | MP_ARG_INT, {.u_int = DEFAULT_I2C_DRIVE} },
     };
@@ -99,7 +99,7 @@ mp_obj_t machine_i2c_make_new(const mp_obj_type_t *type, size_t n_args, size_t n
     mp_arg_parse_all_kw_array(n_args, n_kw, all_args, MP_ARRAY_SIZE(allowed_args), allowed_args, args);
 
     // Get I2C bus.
-    int i2c_id = mp_obj_get_int(args[ARG_id].u_obj);
+    int i2c_id = args[ARG_id].u_int;
     if (i2c_id < 0 || i2c_id >= MICROPY_HW_I2C_NUM || i2c_index_table[i2c_id] == 0) {
         mp_raise_msg_varg(&mp_type_ValueError, MP_ERROR_TEXT("I2C(%d) doesn't exist"), i2c_id);
     }


### PR DESCRIPTION
### Summary

This PR adds for the mimxrt port the same functionality as the already approved [https://github.com/micropython/micropython/pull/16671](https://github.com/micropython/micropython/pull/16671). It gives the option to not  pass an I2C Bus ID when creating a machine I2C object on the mimxrt port. This would allow users on mimxrt platforms to simply declare an I2C object with machine.I2C() without passing any arguments, thus creating an object with a default I2C ID of 0 (freq and drive were already optional for this port).

### Testing
Tested on TEENSY4.0 and TEENSY4.1 Boards:

- Created machine.I2C object by passing no arguments to I2C(). Verified that it successfully could use the scan() method to detect a connected sensor.
- Exercised I2C object by using it with an example program performing reads and writes to a sensor.

### Trade-offs and Alternatives
I simply chose the default I2C ID to be 0, which may not be the desired default for some boards? As far as I could tell, this seemed like a fairly reasonable choice.