### PR TITLE
py/py.mk: Enable makefile for USER_C_MODULES path.

### DIFF
--- a/docs/develop/cmodules.rst
+++ b/docs/develop/cmodules.rst
@@ -127,8 +127,9 @@ To build such a module, compile MicroPython (see `getting started
 applying 2 modifications:
 
 1. Set the build-time flag ``USER_C_MODULES`` to point to the modules
-   you want to include.  For ports that use Make this variable should be a
-   directory which is searched automatically for modules.  For ports that
+   you want to include.  For ports that use Make this variable can be a
+   directory which is searched automatically for modules or a Makefile that
+   includes the modules to build.  For ports that
    use CMake this variable should be a file which includes the modules to
    build.  See below for details.
 
@@ -146,6 +147,13 @@ For example, here's how the to build the unix port with the example modules:
 
     cd micropython/ports/unix
     make USER_C_MODULES=../../examples/usercmodule
+
+or 
+
+.. code-block:: bash
+
+    cd micropython/ports/unix
+    make USER_C_MODULES=../../examples/usercmodule/user_c_modules.mk
 
 You may need to run ``make clean`` once at the start when including new
 user modules in the build.  The build output will show the modules found::

--- a/examples/usercmodule/user_c_modules.mk
+++ b/examples/usercmodule/user_c_modules.mk
@@ -1,0 +1,10 @@
+MODULES := cexample
+MODULES += cppexample
+MODULES += subpackage
+
+$(foreach module, $(MODULES), \
+    $(eval USERMOD_DIR = $(patsubst %/,%,$(USER_C_MODULES_PATH))/$(module))\
+    $(info Including User C Module from $(USERMOD_DIR))\
+	$(eval include $(USERMOD_DIR)/micropython.mk)\
+)
+


### PR DESCRIPTION
This enables setting a file path to select user C modules in a `USER_C_MODULES` directory the same way CMake works. 

The file is a .mk file with the user modules required.

`USER_C_MODULES`=<path/to/file>/my_user_modules.mk

in my_user_modules.mk:
```
MODULES_PATH := ../../examples/usercmodule
MODULES := cexample
MODULES += cppexample
MODULES += subpackage

$(info USER_C_MODULES found in $(MODULES_PATH): $(MODULES))
$(foreach module, $(MODULES), \
    $(eval USERMOD_DIR = $(patsubst %/,%,$(MODULES_PATH))/$(module))\
    $(info Including User C Module from $(USERMOD_DIR))\
	$(eval include $(USERMOD_DIR)/micropython.mk)\
)

```
Note that this doesn't change current behaviour i.e. providing a directory path works as expected. 
<!-- Thanks for submitting a Pull Request! We appreciate you spending the
     time to improve MicroPython. Please provide enough information so that
     others can review your Pull Request.

     Before submitting, please read:
     https://github.com/micropython/micropython/blob/master/CODEOFCONDUCT.md
     https://github.com/micropython/micropython/wiki/ContributorGuidelines

     Please check any CI failures that appear after your Pull Request is opened.
-->

### Summary

<!-- Explain the reason for making this change. What problem does the pull request
     solve, or what improvement does it add? Add links if relevant. -->


### Testing

<!-- Explain what testing you did, and on which boards/ports. If there are
     boards or ports that you couldn't test, please mention this here as well.

     If you leave this empty then your Pull Request may be closed. -->


### Trade-offs and Alternatives

<!-- If the Pull Request has some negative impact (i.e. increased code size)
     then please explain why you think the trade-off improvement is worth it.
     If you can think of alternative ways to do this, please explain that here too.

     Delete this heading if not relevant (i.e. small fixes) -->
