### PR TITLE
stm32: invalidate I and D caches after modifying QSPI flash

### DIFF
--- a/drivers/bus/qspi.h
+++ b/drivers/bus/qspi.h
@@ -37,10 +37,11 @@ enum {
     MP_QSPI_IOCTL_DEINIT,
     MP_QSPI_IOCTL_BUS_ACQUIRE,
     MP_QSPI_IOCTL_BUS_RELEASE,
+    MP_QSPI_IOCTL_MEMORY_MODIFIED,
 };
 
 typedef struct _mp_qspi_proto_t {
-    int (*ioctl)(void *self, uint32_t cmd);
+    int (*ioctl)(void *self, uint32_t cmd, uintptr_t arg);
     int (*write_cmd_data)(void *self, uint8_t cmd, size_t len, uint32_t data);
     int (*write_cmd_addr_data)(void *self, uint8_t cmd, uint32_t addr, size_t len, const uint8_t *src);
     int (*read_cmd)(void *self, uint8_t cmd, size_t len, uint32_t *dest);

--- a/drivers/bus/softqspi.c
+++ b/drivers/bus/softqspi.c
@@ -56,8 +56,9 @@ static void nibble_write(mp_soft_qspi_obj_t *self, uint8_t v) {
     mp_hal_pin_write(self->io3, (v >> 3) & 1);
 }
 
-static int mp_soft_qspi_ioctl(void *self_in, uint32_t cmd) {
+static int mp_soft_qspi_ioctl(void *self_in, uint32_t cmd, uintptr_t arg) {
     mp_soft_qspi_obj_t *self = (mp_soft_qspi_obj_t*)self_in;
+    (void)arg;
 
     switch (cmd) {
         case MP_QSPI_IOCTL_INIT:

--- a/drivers/memory/spiflash.h
+++ b/drivers/memory/spiflash.h
@@ -81,6 +81,8 @@ int mp_spiflash_write(mp_spiflash_t *self, uint32_t addr, size_t len, const uint
 
 #if MICROPY_HW_SPIFLASH_ENABLE_CACHE
 // These functions use the cache (which must already be configured)
+// Note: don't use these functions in combination with memory-mapped
+// flash, because MP_QSPI_IOCTL_MEMORY_MODIFIED is not called.
 int mp_spiflash_cache_flush(mp_spiflash_t *self);
 int mp_spiflash_cached_read(mp_spiflash_t *self, uint32_t addr, size_t len, uint8_t *dest);
 int mp_spiflash_cached_write(mp_spiflash_t *self, uint32_t addr, size_t len, const uint8_t *src);

--- a/ports/stm32/octospi.c
+++ b/ports/stm32/octospi.c
@@ -105,8 +105,9 @@ void octospi_init(void) {
     OCTOSPI1->CR |= OCTOSPI_CR_EN;
 }
 
-static int octospi_ioctl(void *self_in, uint32_t cmd) {
+static int octospi_ioctl(void *self_in, uint32_t cmd, uintptr_t arg) {
     (void)self_in;
+    (void)arg;
     switch (cmd) {
         case MP_QSPI_IOCTL_INIT:
             octospi_init();

--- a/ports/stm32/qspi.c
+++ b/ports/stm32/qspi.c
@@ -190,6 +190,14 @@ static int qspi_ioctl(void *self_in, uint32_t cmd, uintptr_t arg) {
             // Switch to memory-map mode when bus is idle
             qspi_memory_map();
             break;
+        case MP_QSPI_IOCTL_MEMORY_MODIFIED: {
+            uintptr_t *addr_len = (uintptr_t *)arg;
+            volatile void *addr = (volatile void *)(QSPI_MAP_ADDR + addr_len[0]);
+            size_t len = addr_len[1];
+            SCB_InvalidateICache_by_Addr(addr, len);
+            SCB_InvalidateDCache_by_Addr(addr, len);
+            break;
+        }
     }
     return 0; // success
 }

--- a/ports/stm32/qspi.c
+++ b/ports/stm32/qspi.c
@@ -170,7 +170,7 @@ void qspi_memory_map(void) {
     qspi_mpu_enable_mapped();
 }
 
-static int qspi_ioctl(void *self_in, uint32_t cmd) {
+static int qspi_ioctl(void *self_in, uint32_t cmd, uintptr_t arg) {
     (void)self_in;
     switch (cmd) {
         case MP_QSPI_IOCTL_INIT:


### PR DESCRIPTION
### Summary

stm32's QSPI driver supports memory-mapped mode.  The memory-mapped flash can also be erased/written to.  To support both these modes, it switches in and out of memory-mapped mode during an erase/write.

If you erase/write the flash and then go back to memory mapped mode, you must invalidate the cache related to the memory-mapped region that changed.  Otherwise you may end up reading old data.

That cache invalidation is currently not being done, and this PR fixes that.

This bug has been around ever since QSPI memory-mapped mode existed, but it's never really been observed because it's not common to use flash in memory-mapped mode and also erase/write it.  Eg PYBD_SF2 uses the memory-mapped flash in read-only mode to store additional firmware.

But since the introduction of ROMFS, things changed.  The `vfs.rom_ioctl()` command can erase/write memory-mapped flash.

### Testing

Running the following script on PYBD_SF2 and PYBD_SF6 shows the issue:
```py
import time, machine, vfs, uctypes

addr = uctypes.addressof(vfs.rom_ioctl(2, 0))
print(hex(addr))

for _ in range(4):
    print("---------")
    t0 = time.ticks_us()
    vfs.rom_ioctl(3, 0, 1)
    t1 = time.ticks_us()
    print('erase time', time.ticks_diff(t1, t0))
    print(machine.mem32[addr])

    t0 = time.ticks_us()
    vfs.rom_ioctl(4, 0, 0, b'1234')
    t1 = time.ticks_us()
    print('write time', time.ticks_diff(t1, t0))
    print(machine.mem32[addr])

    t0 = time.ticks_us()
    vfs.rom_ioctl(3, 0, 1)
    t1 = time.ticks_us()
    print('erase time', time.ticks_diff(t1, t0))
    print(machine.mem32[addr])
```
Without this fix the memory retrieved by `mem32` is usually always `-1` ie `0xffffffff`, even after writing `b'1234'` to it.

With the fix to invalidate the cache, he above code works as expected.

### Trade-offs and Alternatives

I originally implemented this in the existing `MP_QSPI_IOCTL_BUS_RELEASE` ioctl, invalidating all of the QSPI memory-mapped region.  But that takes ~20ms, far too long for small writes (which can take <100us).  So this fix only invalidates the regions as they change.  That is a very small overhead (unmeasurable compared to the cost of the erase/write).
