### PR TITLE
dynruntime.mk: fix musl's libm.a when LINK_RUNTIME=1

### DIFF
--- a/py/dynruntime.mk
+++ b/py/dynruntime.mk
@@ -124,6 +124,10 @@ else
 $(error architecture '$(ARCH)' not supported)
 endif
 
+ifneq ($(findstring -musl,$(shell $(CROSS)gcc -dumpmachine)),)
+USE_MUSL := 1
+endif
+
 MICROPY_FLOAT_IMPL_UPPER = $(shell echo $(MICROPY_FLOAT_IMPL) | tr '[:lower:]' '[:upper:]')
 CFLAGS += $(CFLAGS_ARCH) -DMICROPY_FLOAT_IMPL=MICROPY_FLOAT_IMPL_$(MICROPY_FLOAT_IMPL_UPPER)
 
@@ -146,6 +150,8 @@ ifeq ($(LINK_RUNTIME),1)
 # version (that hopefully contains a newer RISC-V compiler) or to another Linux
 # distribution.
 ifeq ($(USE_PICOLIBC),1)
+LIBM_NAME := libc.a
+else ifeq ($(USE_MUSL),1)
 LIBM_NAME := libc.a
 else
 LIBM_NAME := libm.a


### PR DESCRIPTION
Like PICOLIBC, MUSL also has its math functions in libc.a. There is a libm.a, but it's empty.

### Summary

The commits in 9bbd40e had special workarounds for pico libc, because it doesn't have its 
math functions in libm.a but instead in libc.a. Some of these workarounds are also required for musl.

### Testing

Tested on a Raspberry Pi Zero 2W, with Alpine Linux. With this change, and setting LINK_RUNTIME = 1, 
enables building example/natmod/features2.

(I have to tweak other parts of dynruntime.mk to build on my system, for example to set the CROSS 
prefix correctly. But this is a variant of the armv7emdp ARCH.

### Trade-offs and Alternatives

An alternative would be to do no special handling for musl. Then devs building for such systems can 
still explicitly specify `MPY_LD_FLAGS += -l /usr/lib/libc.a` in their Makefiles.