### PR TITLE
py/objstr: Fix handling of OP_MODULO with namedtuple.

### DIFF
--- a/ports/unix/variants/coverage/mpconfigvariant.h
+++ b/ports/unix/variants/coverage/mpconfigvariant.h
@@ -44,3 +44,10 @@
 #undef MICROPY_VFS_ROM_IOCTL
 #define MICROPY_VFS_ROM_IOCTL          (1)
 #define MICROPY_PY_CRYPTOLIB_CTR       (1)
+
+// Enable os.uname for attrtuple coverage test
+#define MICROPY_PY_OS_UNAME            (1)
+#define MICROPY_HW_BOARD_NAME          "a machine"
+#define MICROPY_HW_MCU_NAME            MICROPY_PY_SYS_PLATFORM
+// Keep the standard banner message
+#define MICROPY_BANNER_MACHINE MICROPY_PY_SYS_PLATFORM " [" MICROPY_PLATFORM_COMPILER "] version"

--- a/py/objstr.c
+++ b/py/objstr.c
@@ -33,6 +33,7 @@
 #include "py/objlist.h"
 #include "py/runtime.h"
 #include "py/cstack.h"
+#include "py/objtuple.h"
 
 #if MICROPY_PY_BUILTINS_STR_OP_MODULO
 static mp_obj_t str_modulo_format(mp_obj_t pattern, size_t n_args, const mp_obj_t *args, mp_obj_t dict);
@@ -357,8 +358,7 @@ mp_obj_t mp_obj_str_binary_op(mp_binary_op_t op, mp_obj_t lhs_in, mp_obj_t rhs_i
         mp_obj_t *args = &rhs_in;
         size_t n_args = 1;
         mp_obj_t dict = MP_OBJ_NULL;
-        if (mp_obj_is_type(rhs_in, &mp_type_tuple)) {
-            // TODO: Support tuple subclasses?
+        if (mp_obj_is_tuple_compatible(rhs_in)) {
             mp_obj_tuple_get(rhs_in, &n_args, &args);
         } else if (mp_obj_is_type(rhs_in, &mp_type_dict)) {
             dict = rhs_in;

--- a/py/objtuple.c
+++ b/py/objtuple.c
@@ -31,9 +31,6 @@
 #include "py/objtuple.h"
 #include "py/runtime.h"
 
-// type check is done on getiter method to allow tuple, namedtuple, attrtuple
-#define mp_obj_is_tuple_compatible(o) (MP_OBJ_TYPE_GET_SLOT_OR_NULL(mp_obj_get_type(o), iter) == mp_obj_tuple_getiter)
-
 /******************************************************************************/
 /* tuple                                                                      */
 

--- a/py/objtuple.h
+++ b/py/objtuple.h
@@ -61,4 +61,7 @@ void mp_obj_attrtuple_print_helper(const mp_print_t *print, const qstr *fields, 
 
 mp_obj_t mp_obj_new_attrtuple(const qstr *fields, size_t n, const mp_obj_t *items);
 
+// type check is done on getiter method to allow tuple, namedtuple, attrtuple
+#define mp_obj_is_tuple_compatible(o) (MP_OBJ_TYPE_GET_SLOT_OR_NULL(mp_obj_get_type(o), iter) == mp_obj_tuple_getiter)
+
 #endif // MICROPY_INCLUDED_PY_OBJTUPLE_H

--- a/tests/basics/attrtuple2.py
+++ b/tests/basics/attrtuple2.py
@@ -1,0 +1,25 @@
+# test os.uname() attrtuple, if available
+try:
+    import os
+except ImportError:
+    print("SKIP")
+    raise SystemExit
+
+try:
+    u = os.uname()
+except AttributeError:
+    print("SKIP")
+    raise SystemExit
+
+# test printing of attrtuple
+print(str(u).find("machine=") > 0)
+
+# test read attr
+print(isinstance(u.machine, str))
+
+# test str modulo operator for attrtuple
+impl_str = ("%s " * len(u)) % u
+test_str = ""
+for val in u:
+    test_str += val + " "
+print(impl_str == test_str)

--- a/tests/basics/namedtuple1.py
+++ b/tests/basics/namedtuple1.py
@@ -21,6 +21,9 @@ for t in T(1, 2), T(bar=1, foo=2):
 
     print(isinstance(t, tuple))
 
+    # a NamedTuple can be used as a tuple
+    print("(%d, %d)" % t)
+
     # Check tuple can compare equal to namedtuple with same elements
     print(t == (t[0], t[1]), (t[0], t[1]) == t)
 


### PR DESCRIPTION
### Summary

This pull request fixes issue https://github.com/micropython/micropython/issues/16969

### Testing

The change is quite trivial, and I have verified that the modulo operator on strings now works with both tuple and namedtuple.
I have added the corresponding test case in the same commit.

### Trade-offs and Alternatives

namedtuples are a memory efficient alternative to objects as containers: they use no more memory than a tuple, but provide similar code readability as objects. It is therefore important to Micropython that they work as expected. 

The correct type-checking code is only slightly larger than the original version that only handled tuples, and it fixes a problem encountered when porting a library to Micropython.