### PR TITLE
py/obj.h: Make function definition macros compatible with C++.

### DIFF
--- a/ports/unix/coveragecpp.cpp
+++ b/ports/unix/coveragecpp.cpp
@@ -17,10 +17,61 @@ extern "C" {
 #include <py/runtime.h>
 }
 
+// Invoke all (except one, see below) public API macros which initialize structs to make sure
+// they are C++-compatible, meaning they explicitly initialize all struct members.
+mp_obj_t f0();
+MP_DEFINE_CONST_FUN_OBJ_0(f0_obj, f0);
+mp_obj_t f1(mp_obj_t);
+MP_DEFINE_CONST_FUN_OBJ_1(f1_obj, f1);
+mp_obj_t f2(mp_obj_t, mp_obj_t);
+MP_DEFINE_CONST_FUN_OBJ_2(f2_obj, f2);
+mp_obj_t f3(mp_obj_t, mp_obj_t, mp_obj_t);
+MP_DEFINE_CONST_FUN_OBJ_3(f3_obj, f3);
+mp_obj_t fvar(size_t, const mp_obj_t *);
+MP_DEFINE_CONST_FUN_OBJ_VAR(fvar_obj, 1, fvar);
+mp_obj_t fvarbetween(size_t, const mp_obj_t *);
+MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(fvarbetween_obj, 1, 2, fvarbetween);
+mp_obj_t fkw(size_t, const mp_obj_t *, mp_map_t *);
+MP_DEFINE_CONST_FUN_OBJ_KW(fkw_obj, 1, fkw);
+
+static const mp_rom_map_elem_t table[] = {
+    { MP_ROM_QSTR(MP_QSTR_f0), MP_ROM_PTR(&f0_obj) },
+};
+MP_DEFINE_CONST_MAP(map, table);
+MP_DEFINE_CONST_DICT(dict, table);
+
+static const qstr attrtuple_fields[] = {
+    MP_QSTR_f0,
+};
+MP_DEFINE_ATTRTUPLE(attrtuple, attrtuple_fields, 1, MP_ROM_PTR(&f0_obj));
+
+void nlr_cb(void *);
+void nlr_cb(void *){
+}
+
+// The MP_DEFINE_CONST_OBJ_TYPE macro is not C++-compatible because each of the
+// MP_DEFINE_CONST_OBJ_TYPE_NARGS_X macros only initializes some of _mp_obj_type_t's
+// .slot_index_xxx members but that cannot be fixed to be done in a deterministic way.
+
+
 #if defined(MICROPY_UNIX_COVERAGE)
 
 // Just to test building of C++ code.
 static mp_obj_t extra_cpp_coverage_impl() {
+    MP_DEFINE_NLR_JUMP_CALLBACK_FUNCTION_1(ctx, nlr_cb, (void *) nlr_cb);
+
+    // To avoid 'error: unused variable [-Werror,-Wunused-const-variable]'.
+    (void) ctx;
+    (void) f0_obj;
+    (void) f1_obj;
+    (void) f2_obj;
+    (void) f3_obj;
+    (void) fvar_obj;
+    (void) fvarbetween_obj;
+    (void) fkw_obj;
+    (void) map;
+    (void) dict;
+    (void) attrtuple;
     return mp_const_none;
 }
 

--- a/py/obj.h
+++ b/py/obj.h
@@ -371,25 +371,25 @@ typedef struct _mp_rom_obj_t { mp_const_obj_t o; } mp_rom_obj_t;
 
 #define MP_DEFINE_CONST_FUN_OBJ_0(obj_name, fun_name) \
     const mp_obj_fun_builtin_fixed_t obj_name = \
-    {{&mp_type_fun_builtin_0}, .fun._0 = fun_name}
+    {.base = {.type = &mp_type_fun_builtin_0}, .fun = {._0 = fun_name}}
 #define MP_DEFINE_CONST_FUN_OBJ_1(obj_name, fun_name) \
     const mp_obj_fun_builtin_fixed_t obj_name = \
-    {{&mp_type_fun_builtin_1}, .fun._1 = fun_name}
+    {.base = {.type = &mp_type_fun_builtin_1}, .fun = {._1 = fun_name}}
 #define MP_DEFINE_CONST_FUN_OBJ_2(obj_name, fun_name) \
     const mp_obj_fun_builtin_fixed_t obj_name = \
-    {{&mp_type_fun_builtin_2}, .fun._2 = fun_name}
+    {.base = {.type = &mp_type_fun_builtin_2}, .fun = {._2 = fun_name}}
 #define MP_DEFINE_CONST_FUN_OBJ_3(obj_name, fun_name) \
     const mp_obj_fun_builtin_fixed_t obj_name = \
-    {{&mp_type_fun_builtin_3}, .fun._3 = fun_name}
+    {.base = {.type = &mp_type_fun_builtin_3}, .fun = {._3 = fun_name}}
 #define MP_DEFINE_CONST_FUN_OBJ_VAR(obj_name, n_args_min, fun_name) \
     const mp_obj_fun_builtin_var_t obj_name = \
-    {{&mp_type_fun_builtin_var}, MP_OBJ_FUN_MAKE_SIG(n_args_min, MP_OBJ_FUN_ARGS_MAX, false), .fun.var = fun_name}
+    {.base = {.type = &mp_type_fun_builtin_var}, .sig = MP_OBJ_FUN_MAKE_SIG(n_args_min, MP_OBJ_FUN_ARGS_MAX, false), .fun = {.var = fun_name}}
 #define MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(obj_name, n_args_min, n_args_max, fun_name) \
     const mp_obj_fun_builtin_var_t obj_name = \
-    {{&mp_type_fun_builtin_var}, MP_OBJ_FUN_MAKE_SIG(n_args_min, n_args_max, false), .fun.var = fun_name}
+    {.base = {.type = &mp_type_fun_builtin_var}, .sig = MP_OBJ_FUN_MAKE_SIG(n_args_min, n_args_max, false), .fun = {.var = fun_name}}
 #define MP_DEFINE_CONST_FUN_OBJ_KW(obj_name, n_args_min, fun_name) \
     const mp_obj_fun_builtin_var_t obj_name = \
-    {{&mp_type_fun_builtin_var}, MP_OBJ_FUN_MAKE_SIG(n_args_min, MP_OBJ_FUN_ARGS_MAX, true), .fun.kw = fun_name}
+    {.base = {.type = &mp_type_fun_builtin_var}, .sig = MP_OBJ_FUN_MAKE_SIG(n_args_min, MP_OBJ_FUN_ARGS_MAX, true), .fun = {.kw = fun_name}}
 
 // These macros are used to define constant map/dict objects
 // You can put "static" in front of the definition to make it local

--- a/py/objtuple.h
+++ b/py/objtuple.h
@@ -50,7 +50,7 @@ extern const mp_obj_type_t mp_type_attrtuple;
 
 #define MP_DEFINE_ATTRTUPLE(tuple_obj_name, fields, nitems, ...) \
     const mp_rom_obj_tuple_t tuple_obj_name = { \
-        .base = {&mp_type_attrtuple}, \
+        .base = {.type = &mp_type_attrtuple}, \
         .len = nitems, \
         .items = { __VA_ARGS__, MP_ROM_PTR((void *)fields) } \
     }

--- a/py/runtime.h
+++ b/py/runtime.h
@@ -30,12 +30,12 @@
 #include "py/pystack.h"
 #include "py/cstack.h"
 
-// For use with mp_call_function_1_from_nlr_jump_callback.
+// Initialize an nlr_jump_callback_node_call_function_1_t struct for use with
+// nlr_push_jump_callback(&ctx.callback, mp_call_function_1_from_nlr_jump_callback);
 #define MP_DEFINE_NLR_JUMP_CALLBACK_FUNCTION_1(ctx, f, a) \
-    nlr_jump_callback_node_call_function_1_t ctx = { \
-        .func = (void (*)(void *))(f), \
-        .arg = (a), \
-    }
+    nlr_jump_callback_node_call_function_1_t ctx; \
+    ctx.func = (void (*)(void *))(f); \
+    ctx.arg = (a)
 
 typedef enum {
     MP_VM_RETURN_NORMAL,


### PR DESCRIPTION
Simply requires explicitly naming all initializers.

### Summary

Like ce491ab0d168a8278062e1fc7ebed3ca47ab89d2 I think this is the last change needed to make the public API macros C++-compatible. At least I didn't immediately see other places with unnamed initializers.


### Testing

I put this code in coveragecpp.cpp:

```
mp_obj_t a0();
MP_DEFINE_CONST_FUN_OBJ_0(a0_obj, a0);
mp_obj_t a1(mp_obj_t);
MP_DEFINE_CONST_FUN_OBJ_1(a1_obj, a1);
mp_obj_t a2(mp_obj_t, mp_obj_t);
MP_DEFINE_CONST_FUN_OBJ_2(a2_obj, a2);
mp_obj_t a3(mp_obj_t, mp_obj_t, mp_obj_t);
MP_DEFINE_CONST_FUN_OBJ_3(a3_obj, a3);
mp_obj_t avar(size_t, const mp_obj_t *);
MP_DEFINE_CONST_FUN_OBJ_VAR(avar_obj, 1, avar);
mp_obj_t avarbetween(size_t, const mp_obj_t *);
MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(avarbetween_obj, 1, 2, avarbetween);
mp_obj_t akw(size_t, const mp_obj_t *, mp_map_t *);
MP_DEFINE_CONST_FUN_OBJ_KW(akw_obj, 1, akw);
static const mp_rom_map_elem_t atable[] = {};
MP_DEFINE_CONST_MAP(amap, atable);
MP_DEFINE_CONST_DICT(adict, atable);
```

briefly discussed before in https://github.com/micropython/micropython/pull/14323#issuecomment-2071972127 the question is if this code should just be included.