### PR TITLE
esp32/esp32_common.cmake: Skip BTree module when requested.

### DIFF
--- a/ports/esp32/esp32_common.cmake
+++ b/ports/esp32/esp32_common.cmake
@@ -42,7 +42,9 @@ include(${MICROPY_DIR}/py/py.cmake)
 if(NOT CMAKE_BUILD_EARLY_EXPANSION)
     # Enable extmod components that will be configured by extmod.cmake.
     # A board may also have enabled additional components.
-    set(MICROPY_PY_BTREE ON)
+    if (NOT DEFINED MICROPY_PY_BTREE)
+        set(MICROPY_PY_BTREE ON)
+    endif()
 
     include(${MICROPY_DIR}/py/usermod.cmake)
     include(${MICROPY_DIR}/extmod/extmod.cmake)
@@ -276,7 +278,9 @@ target_include_directories(${MICROPY_TARGET} PUBLIC
 )
 
 # Add additional extmod and usermod components.
-target_link_libraries(${MICROPY_TARGET} micropy_extmod_btree)
+if (MICROPY_PY_BTREE)
+    target_link_libraries(${MICROPY_TARGET} micropy_extmod_btree)
+endif()
 target_link_libraries(${MICROPY_TARGET} usermod)
 
 # Extra linker options


### PR DESCRIPTION
### Summary

This PR makes the BTree module truly optional, as it was unconditionally enabled in the shared CMake script for the port.

This meant that if a board/variant did explicitly turn BTree off said request was not honoured by the build system and the BTree module would still be brought in.

I'm running out of flash space that can be used for code in a project of mine, so I've been disabling a few unneeded things - BTree being one of them.  Incidentally, it also seems I cannot build an ESP32S3 firmware image without USB support - is that by design or should I go on and make that optional as well?

### Testing

The code was built with no errors or warnings with both the default settings, and when adding `set(MICROPY_PY_BTREE OFF)` in a board's `mpconfigboard.cmake` file.  The latter firmware was also tried out on an ESP32 board just to be sure.

### Trade-offs and Alternatives

There shouldn't be any, as the default behaviour is not changed and the BTree module removal requires an explicit opt-in from the user.