### PR TITLE
esp32/esp32_common.cmake: Use the tinyusb source files from ESP-IDF.

### DIFF
--- a/ports/esp32/esp32_common.cmake
+++ b/ports/esp32/esp32_common.cmake
@@ -80,9 +80,7 @@ list(APPEND MICROPY_SOURCE_DRIVERS
     ${MICROPY_DIR}/drivers/dht/dht.c
 )
 
-list(APPEND GIT_SUBMODULES lib/tinyusb)
 if(MICROPY_PY_TINYUSB)
-    set(TINYUSB_SRC "${MICROPY_DIR}/lib/tinyusb/src")
     string(TOUPPER OPT_MCU_${IDF_TARGET} tusb_mcu)
 
     list(APPEND MICROPY_DEF_TINYUSB
@@ -90,12 +88,6 @@ if(MICROPY_PY_TINYUSB)
     )
 
     list(APPEND MICROPY_SOURCE_TINYUSB
-        ${TINYUSB_SRC}/tusb.c
-        ${TINYUSB_SRC}/common/tusb_fifo.c
-        ${TINYUSB_SRC}/device/usbd.c
-        ${TINYUSB_SRC}/device/usbd_control.c
-        ${TINYUSB_SRC}/class/cdc/cdc_device.c
-        ${TINYUSB_SRC}/portable/synopsys/dwc2/dcd_dwc2.c
         ${MICROPY_DIR}/shared/tinyusb/mp_usbd.c
         ${MICROPY_DIR}/shared/tinyusb/mp_usbd_cdc.c
         ${MICROPY_DIR}/shared/tinyusb/mp_usbd_descriptor.c
@@ -103,7 +95,6 @@ if(MICROPY_PY_TINYUSB)
     )
 
     list(APPEND MICROPY_INC_TINYUSB
-        ${TINYUSB_SRC}
         ${MICROPY_DIR}/shared/tinyusb/
     )
 


### PR DESCRIPTION
### Summary

This PR removes the explicit dependency on the vendored tinyusb version for the ESP32S2 and ESP32S3 boards.

Tinyusb is still available to MicroPython through a dependency on the `espressif/esp_tinyusb` ESP-IDF component, which in turn depends on the `espressif/tinyusb` component itself.

### Testing

The `ESP32_GENERIC_S3` firmware image was built without errors and the USB example scripts in `examples/usb` were executed correctly.

### Trade-offs and Alternatives

It may happen that ESP-IDF's version of tinyusb lags behind the one brought in via the git submodule, and that may not be wanted in case of urgent changes in tinyusb that aren't picked up by ESP-IDF.  On the other hand this simplifies the build process when MicroPython is brought in as a custom IDF component into an existing ESP-IDF project as there's one less dependency to be manually checked out and configured, and not having the ESP-IDF build system complain after a forced `make submodules` step (which is my use case).