### PR TITLE
document additional inconsistencies with CPython

### DIFF
--- a/tests/cpydiff/modules_struct_does_not_support_bool.py
+++ b/tests/cpydiff/modules_struct_does_not_support_bool.py
@@ -1,0 +1,11 @@
+"""
+categories: Modules,struct
+description: Struct ``pack`` and ``unpack`` do not support the "?" type code for bools.
+cause: Unknown
+workaround: Cast to int and pack with "B" type code, then unpack with "B" and cast to bool.
+"""
+
+import struct
+
+struct.pack("?", True)
+struct.unpack("?", b"\x01")

--- a/tests/cpydiff/modules_time_time_returns_int.py
+++ b/tests/cpydiff/modules_time_time_returns_int.py
@@ -1,0 +1,10 @@
+"""
+categories: Modules.time
+description: ``time`` returns an integer instead of a float.
+cause: Unknown
+workaround: use ``int(time())`` if you need a timestamp with just the seconds or ``time_ns()/1_000_000_000`` if you need a float.
+"""
+
+import time
+
+print(type(time.time()))

--- a/tests/cpydiff/syntax_dict_unpacking.py
+++ b/tests/cpydiff/syntax_dict_unpacking.py
@@ -1,0 +1,10 @@
+"""
+categories: Syntax,dict
+description: Unpacking one dict's elements into a new dict with ``{'new_elem': val, **old_dict}`` is not supported.
+cause: Not implemented. Dict unpacking is only implemented when passing dict elements as function kwargs.
+workaround: use ``new_dict = {}; new_dict.update(old_dict)`` to copy values into new dicts.
+"""
+
+old_dict = {'a': 1, 'b': 2}
+new_dict = {**old_dict, 'c': 3}
+new_dict = {'c': 3, **old_dict}

--- a/tests/cpydiff/syntax_list_tuple_unpacking.py
+++ b/tests/cpydiff/syntax_list_tuple_unpacking.py
@@ -1,0 +1,14 @@
+"""
+categories: Syntax,tuple,list
+description: Unpacking one tuple or list's elements into a new object with ``[*things]`` or ``(*things)`` is not supported.
+cause: Not implemented. Sequence unpacking is only implemented when passing arguments to functions.
+workaround: use ``new = []; for t in old: new.append(t)`` or ``new = [] + old`` to copy into new lists and then cast to tuple if a tuple is needed.
+"""
+
+old_list = [1, 2, 3]
+new_list = [*old_list, 4]
+new_list = [0, *old_list]
+
+old_tup = (1, 2, 3)
+new_tup = (*old_tup, 4)
+new_tup = (0, *old_tup)


### PR DESCRIPTION
<!-- Thanks for submitting a Pull Request! We appreciate you spending the
     time to improve MicroPython. Please provide enough information so that
     others can review your Pull Request.

     Before submitting, please read:
     https://github.com/micropython/micropython/blob/master/CODEOFCONDUCT.md
     https://github.com/micropython/micropython/wiki/ContributorGuidelines

     Please check any CI failures that appear after your Pull Request is opened.
-->

### Summary

<!-- Explain the reason for making this change. What problem does the pull request
     solve, or what improvement does it add? Add links if relevant. -->

In my development, I discovered four undocumented inconsistencies with CPython. MattyTrenti on Discord suggested I submit an issue or PR. The four undocumented inconsistencies are as follows:

- Unpacking lists or tuples raises SyntaxError: `[1, 2, *others]`, `[*others, 1, 2]`, `(1, 2, *others)`, `(*others, 1, 2)`
- Unpacking dicts raises SyntaxError: `{**others, 'c': 3}`, `{'c': 3, **others}`
- `time.time()` returns an int instead of a float
- `struct` does not support the "?" type code for bools

### Testing

<!-- Explain what testing you did, and on which boards/ports. If there are
     boards or ports that you couldn't test, please mention this here as well.

     If you leave this empty then your Pull Request may be closed. -->

Wrote code that worked in CPython and ran it on an ESP32, encountered the errors, and then manually tested in a REPL on ESP32.
