### PR TITLE
rp2/rp2_pio: Switch to mask64 for pins/pindirs.

### DIFF
--- a/ports/rp2/rp2_pio.c
+++ b/ports/rp2/rp2_pio.c
@@ -271,9 +271,9 @@ static void asm_pio_get_pins(PIO pio, const char *type, mp_obj_t prog_pins, mp_o
 }
 
 static void asm_pio_init_gpio(PIO pio, uint32_t sm, asm_pio_config_t *config) {
-    uint32_t pinmask = ((1 << config->count) - 1) << (config->base - pio_get_gpio_base(pio));
-    pio_sm_set_pins_with_mask(pio, sm, config->pinvals << (config->base - pio_get_gpio_base(pio)), pinmask);
-    pio_sm_set_pindirs_with_mask(pio, sm, config->pindirs << (config->base - pio_get_gpio_base(pio)), pinmask);
+    uint64_t pinmask = ((UINT64_C(1) << config->count) - 1) << config->base;
+    pio_sm_set_pins_with_mask64(pio, sm, (uint64_t)config->pinvals << (config->base), pinmask);
+    pio_sm_set_pindirs_with_mask64(pio, sm, (uint64_t)config->pindirs << (config->base), pinmask);
     for (size_t i = 0; i < config->count; ++i) {
         gpio_set_function(config->base + i, GPIO_FUNC_PIO0 + pio_get_index(pio));
     }


### PR DESCRIPTION
Use pio_sm_set_pins_with_mask64 and pio_sm_set_pindirs_with_mask64 in lieu of manually shifting by the pin base.

These functions were added in SDK 2.1.0.

I matched, to a certain extent, the form of https://github.com/micropython/micropython/pull/16191

Somewhat related to https://github.com/micropython/micropython/issues/16199

### Testing

I'll get 'round to it, I swear.

### Trade-offs and Alternatives

None, these functions should be used for clarity and brevity. Though sheesh I don't like the uint64_t casts 🫠 
