### PR TITLE
py/objcode: Implement PEP626 to add co_lines to code objects on settrace builds.

### DIFF
--- a/py/showbc.c
+++ b/py/showbc.c
@@ -144,17 +144,9 @@ void mp_bytecode_print(const mp_print_t *print, const mp_raw_code_t *rc, size_t 
         mp_uint_t source_line = 1;
         mp_printf(print, "  bc=" INT_FMT " line=" UINT_FMT "\n", bc, source_line);
         for (const byte *ci = code_info; ci < line_info_top;) {
-            if ((ci[0] & 0x80) == 0) {
-                // 0b0LLBBBBB encoding
-                bc += ci[0] & 0x1f;
-                source_line += ci[0] >> 5;
-                ci += 1;
-            } else {
-                // 0b1LLLBBBB 0bLLLLLLLL encoding (l's LSB in second byte)
-                bc += ci[0] & 0xf;
-                source_line += ((ci[0] << 4) & 0x700) | ci[1];
-                ci += 2;
-            }
+            mp_code_lineinfo_t decoded = mp_bytecode_decode_lineinfo(&ci);
+            bc += decoded.bc_increment;
+            source_line += decoded.line_increment;
             mp_printf(print, "  bc=" INT_FMT " line=" UINT_FMT "\n", bc, source_line);
         }
     }

--- a/tests/basics/fun_code_colines.py
+++ b/tests/basics/fun_code_colines.py
@@ -1,0 +1,81 @@
+# Check that we have sensical bytecode offsets in function.__code__.co_lines
+
+def f1(x, y, obj, obj2, obj3):
+    a = x + y # line 4: bc+4 line+4
+    b = x - y # line 5: bc+4 line+1
+    # line 6
+    # line 7
+    # line 8
+    # line 9
+    # line 10
+    # line 11
+    # line 12
+    # line 13
+    # line 14
+    # line 15
+    # line 16
+    # line 17
+    # line 18
+    # line 19
+    c = a * b # line 20: bc+4 line+15
+    obj.a.b.c.d.e.f.g.h.i.j.k.l.m.n.o.p.q.r.s.t.u.v.w.x.y.z.fun() # line 21: bc+31 line+1; bc+27 line+0
+    # line 22
+    # line 23
+    # line 24: bc+0 line+3
+    # line 25
+    # line 26
+    # line 27: bc+0 line+3
+    # line 28
+    # line 29
+    obj2.a.b.c.d.e.f.g.h.i.j.k.l.m.n.o.p.q.r.s.t.u.v.w.x.y.z.fun() # line 30: bc+31 line+3; bc+27 line+0
+    # line 31
+    # line 32
+    # line 33: bc+0 line+3
+    # line 34
+    # line 35
+    # line 36
+    # line 37
+    # line 38
+    # line 39
+    # line 40
+    # line 41
+    # line 42
+    # line 43
+    # line 44
+    # line 45
+    # line 46
+    # line 47
+    # line 48
+    # line 49
+    # line 50
+    # line 51
+    # line 52
+    # line 53
+    # line 54
+    # line 55
+    # line 56
+    # line 57
+    # line 58
+    # line 59
+    return obj3.a.b.c.d.e.f.g.h.i.j.k.l.m.n.o.p.q.r.s.t.u.v.w.x.y.z.fun() # line 60: bc+31 line+27; bc+27 line+0
+
+def f2(x, y):
+    a = x + y # line 63
+    b = x - y # line 64
+    return a * b # line 65
+
+try:
+    f1.__code__.co_lines
+except AttributeError:
+    print("SKIP")
+    raise SystemExit
+
+print("f1")
+for start, end, line_no in f1.__code__.co_lines():
+    print("line {} start: {}".format(line_no, start))
+    print("line {} end: {}".format(line_no, end))
+
+print("f2")
+for start, end, line_no in f2.__code__.co_lines():
+    print("line {} start: {}".format(line_no, start))
+    print("line {} end: {}".format(line_no, end))

--- a/tests/basics/fun_code_colines.py.exp
+++ b/tests/basics/fun_code_colines.py.exp
@@ -1,0 +1,20 @@
+f1
+line 4 start: 0
+line 4 end: 4
+line 5 start: 4
+line 5 end: 8
+line 20 start: 8
+line 20 end: 12
+line 21 start: 12
+line 21 end: 70
+line 30 start: 70
+line 30 end: 128
+line 60 start: 128
+line 60 end: 186
+f2
+line 63 start: 0
+line 63 end: 4
+line 64 start: 4
+line 64 end: 8
+line 65 start: 8
+line 65 end: 12

--- a/tests/basics/fun_code_full.py
+++ b/tests/basics/fun_code_full.py
@@ -1,0 +1,47 @@
+# Test function.__code__ attributes not available with MICROPY_PY_BUILTINS_CODE <= MICROPY_PY_BUILTINS_CODE_BASIC
+
+try:
+    (lambda: 0).__code__.co_code
+except AttributeError:
+    print("SKIP")
+    raise SystemExit
+
+try:
+    import warnings
+    warnings.simplefilter("ignore") # ignore deprecation warning about co_lnotab
+except ImportError:
+    pass
+
+def f(x, y):
+    a = x + y
+    b = x - y
+    return a * b
+
+code = f.__code__
+
+print(type(code.co_code)) # both bytes (but mpy and cpy have different instruction sets)
+print(code.co_consts) # (not necessarily the same set, but in this function they are)
+print(code.co_filename.rsplit('/')[-1]) # same terminal filename but might be different paths on other ports
+print(type(code.co_firstlineno)) # both ints (but mpy points to first line inside, cpy points to declaration)
+print(code.co_name)
+print(iter(code.co_names) is not None) # both iterable (but mpy returns dict with names as keys, cpy only the names; and not necessarily the same set)
+print(type(code.co_lnotab)) # both bytes
+
+co_lines = code.co_lines()
+
+l = list(co_lines)
+first_start = l[0][0]
+last_end = l[-1][1]
+print(first_start) # co_lines should start at the start of the bytecode
+print(len(code.co_code) - last_end) # and end at the end of the bytecode
+
+prev_end = 0
+for start, end, line_no in l:
+    if end != prev_end:
+        print("non-contiguous")
+        break # the offset ranges should be contiguous
+    prev_end = end
+else:
+    print("contiguous")
+
+


### PR DESCRIPTION
### Summary

This PR implements [PEP 626 – Precise line numbers for debugging and other tools.](https://peps.python.org/pep-0626/).

This adds one method, `co_lines`, that returns an iterator over `(begin, end, line_no)` tuples of line numbers for applicable bytecode ranges.

### Testing

This PR includes automated tests of all of the currently-implemented code object attributes, including the existing attributes that previously had no test coverage.

The actual values in `co_lines` can't be compared directly to CPython's, but all of the invariants that the method is meant to observe are checked.

In addition to the github workflow checks, I've also manually verified that all tests pass when run against a unix `MICROPY_PY_SYS_SETTRACE` build. (In particular, I've checked to make sure they're not skipped).

### Trade-offs and Alternatives

As in CPython, this is implemented as its own distinct iterator object. Potentially, this function could be functionally replicated by instead eagerly building a list of the tuples and returning an iterator over that list, at a slightly smaller code size; but the iterator approach allows for a tighter behavioral match with CPython (`fun_code_full.py:25`), and code size is not at nearly the same premium in settrace builds.
