### PR TITLE
ports/rp2: Replace pico-sdk assertion faults with python exceptions.

### DIFF
--- a/ports/rp2/CMakeLists.txt
+++ b/ports/rp2/CMakeLists.txt
@@ -24,6 +24,9 @@ set(PICO_BTSTACK_PATH ${MICROPY_DIR}/lib/btstack)
 # Set the location of this port's directory.
 set(MICROPY_PORT_DIR ${CMAKE_CURRENT_LIST_DIR})
 
+# Replace the pico/assert.h assertion mechanism with one that raises python exceptions.
+list(APPEND PICO_CONFIG_HEADER_FILES ${MICROPY_PORT_DIR}/pico_assert.h)
+
 # Set the board if it's not already set.
 if(NOT MICROPY_BOARD)
     set(MICROPY_BOARD RPI_PICO)
@@ -163,6 +166,7 @@ set(MICROPY_SOURCE_PORT
     mpthreadport.c
     mutex_extra.c
     pendsv.c
+    pico_assert.c
     rp2_flash.c
     rp2_pio.c
     rp2_dma.c
@@ -189,6 +193,7 @@ set(MICROPY_SOURCE_QSTR
     ${MICROPY_PORT_DIR}/machine_wdt.c
     ${MICROPY_PORT_DIR}/modrp2.c
     ${MICROPY_PORT_DIR}/modos.c
+    ${MICROPY_PORT_DIR}/pico_assert.c
     ${MICROPY_PORT_DIR}/rp2_flash.c
     ${MICROPY_PORT_DIR}/rp2_pio.c
     ${MICROPY_PORT_DIR}/rp2_dma.c

--- a/ports/rp2/pico_assert.c
+++ b/ports/rp2/pico_assert.c
@@ -27,9 +27,9 @@
 #include "pico_assert.h"
 #include "py/runtime.h"
 
-void pico_param_fault(char *x) {
-    mp_raise_msg_varg(&mp_type_ValueError, MP_ERROR_TEXT("invalid params in pico-sdk %s"), x);
+void pico_param_fault(char *define, char *file, unsigned int line, char *test) {
+    mp_raise_msg_varg(&mp_type_ValueError, MP_ERROR_TEXT("pico-sdk %s invalid params at %s:%d: %s"), define, file, line, test);
 }
-void pico_hard_fault(char *x) {
-    mp_raise_msg_varg(&mp_type_AssertionError, MP_ERROR_TEXT("assertion failure in pico-sdk %s"), x);
+void pico_hard_fault(char *define, char *file, unsigned int line, char *test) {
+    mp_raise_msg_varg(&mp_type_AssertionError, MP_ERROR_TEXT("pico-sdk %s assertion failure at %s:%d: %s"), define, file, line, test);
 }

--- a/ports/rp2/pico_assert.c
+++ b/ports/rp2/pico_assert.c
@@ -1,0 +1,35 @@
+/*
+ * This file is part of the MicroPython project, http://micropython.org/
+ *
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2025 Anson Mansfield
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#include "pico_assert.h"
+#include "py/runtime.h"
+
+void pico_param_fault(char *x) {
+    mp_raise_msg_varg(&mp_type_ValueError, MP_ERROR_TEXT("invalid params in pico-sdk %s"), x);
+}
+void pico_hard_fault(char *x) {
+    mp_raise_msg_varg(&mp_type_AssertionError, MP_ERROR_TEXT("assertion failure in pico-sdk %s"), x);
+}

--- a/ports/rp2/pico_assert.h
+++ b/ports/rp2/pico_assert.h
@@ -53,13 +53,13 @@
 
 #define PARAM_ASSERTIONS_ENABLED(x) ((PARAM_ASSERTIONS_ENABLED_##x || PARAM_ASSERTIONS_ENABLE_ALL) && !PARAM_ASSERTIONS_DISABLE_ALL)
 
-#define invalid_params_if(x, test) ({if (PARAM_ASSERTIONS_ENABLED(x) && (test)) { pico_param_fault(#x); }})
-#define valid_params_if(x, test) ({if (PARAM_ASSERTIONS_ENABLED(x) && !(test)) { pico_param_fault(#x); }})
-#define hard_assert_if(x, test) ({if (PARAM_ASSERTIONS_ENABLED(x) && (test)) { pico_hard_fault(#x); }})
+#define invalid_params_if(x, test) ({if (PARAM_ASSERTIONS_ENABLED(x) && (test)) { pico_param_fault(#x, __FILE__, __LINE__, #test); }})
+#define valid_params_if(x, test) ({if (PARAM_ASSERTIONS_ENABLED(x) && !(test)) { pico_param_fault(#x, __FILE__, __LINE__, #test); }})
+#define hard_assert_if(x, test) ({if (PARAM_ASSERTIONS_ENABLED(x) && (test)) { pico_hard_fault(#x, __FILE__, __LINE__, #test); }})
 #define invalid_params_if_and_return(x, test, rc) ({ if (test) { return rc; }})
 
 #ifndef __ASSEMBLER__
-void pico_param_fault(char *);
-void pico_hard_fault(char *);
+void pico_param_fault(char *, char *, unsigned int, char *);
+void pico_hard_fault(char *, char *, unsigned int, char *);
 #endif
 #endif // _PICO_REPLACEMENT_ASSERT_H

--- a/ports/rp2/pico_assert.h
+++ b/ports/rp2/pico_assert.h
@@ -1,0 +1,65 @@
+/*
+ * This file is part of the MicroPython project, http://micropython.org/
+ *
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2025 Anson Mansfield
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#ifndef _PICO_REPLACEMENT_ASSERT_H
+#define _PICO_REPLACEMENT_ASSERT_H
+
+#ifdef _PICO_ASSERT_H
+#undef invalid_params_if
+#undef valid_params_if
+#undef hard_assert_if
+#undef invalid_params_if_and_return
+#undef PARAM_ASSERTIONS_ENABLED
+#else
+// mask out pico/assert.h using its include guard
+#define _PICO_ASSERT_H
+#endif
+
+#ifndef __ASSEMBLER__
+#include <stdbool.h>
+#include <assert.h>
+#endif
+
+#ifndef PARAM_ASSERTIONS_ENABLE_ALL
+#define PARAM_ASSERTIONS_ENABLE_ALL 0
+#endif
+
+#ifndef PARAM_ASSERTIONS_DISABLE_ALL
+#define PARAM_ASSERTIONS_DISABLE_ALL 0
+#endif
+
+#define PARAM_ASSERTIONS_ENABLED(x) ((PARAM_ASSERTIONS_ENABLED_##x || PARAM_ASSERTIONS_ENABLE_ALL) && !PARAM_ASSERTIONS_DISABLE_ALL)
+
+#define invalid_params_if(x, test) ({if (PARAM_ASSERTIONS_ENABLED(x) && (test)) { pico_param_fault(#x); }})
+#define valid_params_if(x, test) ({if (PARAM_ASSERTIONS_ENABLED(x) && !(test)) { pico_param_fault(#x); }})
+#define hard_assert_if(x, test) ({if (PARAM_ASSERTIONS_ENABLED(x) && (test)) { pico_hard_fault(#x); }})
+#define invalid_params_if_and_return(x, test, rc) ({ if (test) { return rc; }})
+
+#ifndef __ASSEMBLER__
+void pico_param_fault(char *);
+void pico_hard_fault(char *);
+#endif
+#endif // _PICO_REPLACEMENT_ASSERT_H


### PR DESCRIPTION
### Summary

This change replaces the default pico-sdk assertion fault handlers with new handlers that raise micropython exceptions.

### Testing

I've verified that this works on real rp2040 hardware, using a custom module to trigger the pico-sdk assertion mechanism:

```C
#include "py/runtime.h"
#include "pico/assert.h"

#define PARAM_ASSERTIONS_ENABLED_FAIL (1)

static mp_obj_t rp2_param_fault(void) {
    invalid_params_if(FAIL, true);
    return mp_const_none;
}
MP_DEFINE_CONST_FUN_OBJ_0(rp2_param_fault_obj, rp2_param_fault);

static mp_obj_t rp2_hard_fault(void) {
    hard_assert_if(FAIL, true);
    return mp_const_none;
}
MP_DEFINE_CONST_FUN_OBJ_0(rp2_hard_fault_obj, rp2_hard_fault);

static const mp_rom_map_elem_t fail_module_globals_table[] = {
    { MP_ROM_QSTR(MP_QSTR___name__),            MP_ROM_QSTR(MP_QSTR_fail) },
    { MP_ROM_QSTR(MP_QSTR_param),               MP_ROM_PTR(&rp2_param_fault_obj) },
    { MP_ROM_QSTR(MP_QSTR_hard),                MP_ROM_PTR(&rp2_hard_fault_obj) },
};
static MP_DEFINE_CONST_DICT(fail_module_globals, fail_module_globals_table);

const mp_obj_module_t mp_module_fail = {
    .base = { &mp_type_module },
    .globals = (mp_obj_dict_t *)&fail_module_globals,
};

MP_REGISTER_MODULE(MP_QSTR_fail, mp_module_fail);
```

Which leads to:

```
MicroPython v1.25.0-preview.400.ge3adb89f8.dirty on 2025-03-21; Raspberry Pi Pico W with RP2040
Type "help()" for more information.
>>> import fail
>>> fail.hard()
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
AssertionError: assertion failure in pico-sdk FAIL
>>> fail.param()
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
ValueError: invalid params in pico-sdk FAIL
```

### Tradeoffs and Alternatives

It's not entirely clear what the best choice of exception and exception message is, and I invite comments on this topic.

At present I'm using variadic exceptions with a parameter derived from the name of the associated assertion enable gate. `invalid_params_if` and `valid_params_if` both map to `ValueError("invalid params in pico-sdk %s")`, and `hard_assert_if` failures map to `AssertionError("assertion failure in pico-sdk %s")`. Should the latter perhaps be a `RuntimeError` rather than an `AssertionError`, though?