### PR TITLE
mpremote: Add `rm -r` recursive remove functionality to filesystem commands.

### DIFF
--- a/docs/reference/mpremote.rst
+++ b/docs/reference/mpremote.rst
@@ -229,7 +229,7 @@ The full list of supported commands are:
   - ``ls`` to list the current directory
   - ``ls <dirs...>`` to list the given directories
   - ``cp [-rf] <src...> <dest>`` to copy files
-  - ``rm <src...>`` to remove files on the device
+  - ``rm [-r] <src...>`` to remove files or folders on the device
   - ``mkdir <dirs...>`` to create directories on the device
   - ``rmdir <dirs...>`` to remove directories on the device
   - ``touch <file..>`` to create the files (if they don't already exist)
@@ -238,14 +238,34 @@ The full list of supported commands are:
   The ``cp`` command uses a convention where a leading ``:`` represents a remote
   path. Without a leading ``:`` means a local path. This is based on the
   convention used by the `Secure Copy Protocol (scp) client
-  <https://en.wikipedia.org/wiki/Secure_copy_protocol>`_. All other commands
-  implicitly assume the path is a remote path, but the ``:`` can be optionally
-  used for clarity.
+  <https://en.wikipedia.org/wiki/Secure_copy_protocol>`_.
 
   So for example, ``mpremote fs cp main.py :main.py`` copies ``main.py`` from
   the current local directory to the remote filesystem, whereas
   ``mpremote fs cp :main.py main.py`` copies ``main.py`` from the device back
   to the current directory.
+
+  The ``mpremote rm -r`` command accepts both relative and absolute paths.
+  Use ``:`` to refer to the current remote working directory (cwd) to allow a
+  directory tree to be removed from the device's default path (eg ``/flash``, ``/``).
+  Use ``-v/--verbose`` to see the files being removed.
+
+  For example:
+
+  - ``mpremote rm -r :libs`` will remove the ``libs`` directory and all its
+    child items from the device.
+  - ``mpremote rm -rv :/sd`` will remove all files from a mounted SDCard and result
+    in a non-blocking warning. The mount will be retained.
+  - ``mpremote rm -rv :/`` will remove all files on the device, including any
+    located in mounted vfs such as ``/sd`` or ``/flash``. After removing all folders
+    and files, this will  also return an error to mimic unix ``rm -rf /`` behaviour.
+
+  .. warning::
+    There is no supported way to undelete files removed by ``mpremote rm -r :``.
+    Please use with caution.
+
+  All other commands implicitly assume the path is a remote path, but the ``:``
+  can be optionally used for clarity.
 
   All of the filesystem sub-commands take multiple path arguments, so if there
   is another command in the sequence, you must use ``+`` to terminate the

--- a/tools/mpremote/mpremote/main.py
+++ b/tools/mpremote/mpremote/main.py
@@ -182,7 +182,7 @@ def argparse_rtc():
 
 def argparse_filesystem():
     cmd_parser = argparse.ArgumentParser(description="execute filesystem commands on the device")
-    _bool_flag(cmd_parser, "recursive", "r", False, "recursive copy (for cp command only)")
+    _bool_flag(cmd_parser, "recursive", "r", False, "recursive (for cp and rm commands)")
     _bool_flag(
         cmd_parser,
         "force",

--- a/tools/mpremote/mpremote/transport.py
+++ b/tools/mpremote/mpremote/transport.py
@@ -24,7 +24,7 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
 
-import ast, hashlib, os, sys
+import ast, errno, hashlib, os, sys
 from collections import namedtuple
 
 
@@ -63,6 +63,10 @@ def _convert_filesystem_error(e, info):
         return FileExistsError(info)
     if "OSError" in e.error_output and "ENODEV" in e.error_output:
         return FileNotFoundError(info)
+    if "OSError" in e.error_output and "EINVAL" in e.error_output:
+        return OSError(errno.EINVAL, info)
+    if "OSError" in e.error_output and "EPERM" in e.error_output:
+        return OSError(errno.EPERM, info)
     return e
 
 

--- a/tools/mpremote/tests/README.md
+++ b/tools/mpremote/tests/README.md
@@ -4,11 +4,26 @@ This directory contains a set of tests for `mpremote`.
 
 Requirements:
 - A device running MicroPython connected to a serial port on the host.
+- The device you are testing against must be flashed with a firmware of the same build
+  as `mpremote`.
+- If the device has an SDcard or other vfs mounted, the vfs's filesystem must be empty
+  to pass the filesystem test.
 - Python 3.x, `bash` and various Unix tools such as `find`, `mktemp`, `sed`, `sort`, `tr`.
+- To test on Windows, you can either:
+    - Run the (Linux) tests in WSL2 against a USB device that is passed though to WSL2.
+    - Use the `Git Bash` terminal to run the tests against a device connected to a COM
+      port. _Note:_ While the tests will run in `Git Bash`, several will throw false
+      positive errors due to differences in the way that TMP files are logged and and
+      several other details.
 
 To run the tests do:
 
+    $ cd tools/mpremote/tests
     $ ./run-mpremote-tests.sh
+
+To run a single test do:
+
+    $ ./run-mpremote-tests.sh test_filesystem.sh
 
 Each test should print "OK" if it passed.  Otherwise it will print "CRASH", or "FAIL"
 and a diff of the expected and actual test output.

--- a/tools/mpremote/tests/test_filesystem.sh
+++ b/tools/mpremote/tests/test_filesystem.sh
@@ -170,3 +170,67 @@ EOF
 $MPREMOTE resume cp -r "${TMP}/package" :
 $MPREMOTE resume ls : :package :package/subpackage
 $MPREMOTE resume exec "import package; package.x(); package.y()"
+
+echo -----
+# Test rm -r functionality
+# start with a fresh ramdisk before each test
+# rm -r MCU current working directory
+$MPREMOTE run "${TMP}/ramdisk.py"
+$MPREMOTE resume touch :a.py
+$MPREMOTE resume touch :b.py
+$MPREMOTE resume cp -r "${TMP}/package" :
+$MPREMOTE resume rm -r -v :
+$MPREMOTE resume ls :
+$MPREMOTE resume ls :/ramdisk
+
+echo -----
+# rm -r relative subfolder
+$MPREMOTE run "${TMP}/ramdisk.py"
+$MPREMOTE resume touch :a.py
+$MPREMOTE resume mkdir :testdir
+$MPREMOTE resume cp -r "${TMP}/package" :testdir/package
+$MPREMOTE resume ls :testdir
+$MPREMOTE resume ls :testdir/package
+$MPREMOTE resume rm -r :testdir/package
+$MPREMOTE resume ls :/ramdisk
+$MPREMOTE resume ls :testdir
+
+echo -----
+# rm -r non-existent path
+$MPREMOTE run "${TMP}/ramdisk.py"
+$MPREMOTE resume ls :
+$MPREMOTE resume rm -r :nonexistent || echo "expect error"
+
+echo -----
+# rm -r absolute root
+# no -v to generate same output on stm32 and other ports
+$MPREMOTE run "${TMP}/ramdisk.py"
+$MPREMOTE resume touch :a.py
+$MPREMOTE resume touch :b.py
+$MPREMOTE resume cp -r "${TMP}/package" :
+$MPREMOTE resume cp -r "${TMP}/package" :package2
+$MPREMOTE resume rm -r :/ || echo "expect error"
+$MPREMOTE resume ls :
+$MPREMOTE resume ls :/ramdisk
+
+echo -----
+# rm -r relative mountpoint
+$MPREMOTE run "${TMP}/ramdisk.py"
+$MPREMOTE resume touch :a.py
+$MPREMOTE resume touch :b.py
+$MPREMOTE resume cp -r "${TMP}/package" :
+$MPREMOTE resume exec "import os;os.chdir('/')"
+$MPREMOTE resume rm -r -v :ramdisk
+$MPREMOTE resume ls :/ramdisk
+
+echo -----
+# rm -r absolute mountpoint
+$MPREMOTE run "${TMP}/ramdisk.py"
+$MPREMOTE resume touch :a.py
+$MPREMOTE resume touch :b.py
+$MPREMOTE resume cp -r "${TMP}/package" :
+$MPREMOTE resume exec "import os;os.chdir('/')"
+$MPREMOTE resume rm -r -v :/ramdisk
+$MPREMOTE resume ls :/ramdisk
+
+echo -----

--- a/tools/mpremote/tests/test_filesystem.sh.exp
+++ b/tools/mpremote/tests/test_filesystem.sh.exp
@@ -191,3 +191,79 @@ ls :package/subpackage
           23 y.py
 x
 y2
+-----
+touch :a.py
+touch :b.py
+cp ${TMP}/package :
+rm :
+removed: './a.py'
+removed: './b.py'
+removed: './package/subpackage/__init__.py'
+removed: './package/subpackage/y.py'
+removed directory: './package/subpackage'
+removed: './package/__init__.py'
+removed: './package/x.py'
+removed directory: './package'
+ls :
+ls :/ramdisk
+-----
+touch :a.py
+mkdir :testdir
+cp ${TMP}/package :testdir/package
+ls :testdir
+           0 package/
+ls :testdir/package
+           0 subpackage/
+          43 __init__.py
+          22 x.py
+rm :testdir/package
+ls :/ramdisk
+           0 a.py
+           0 testdir/
+ls :testdir
+-----
+ls :
+rm :nonexistent
+mpremote: rm: nonexistent: No such file or directory.
+expect error
+-----
+touch :a.py
+touch :b.py
+cp ${TMP}/package :
+cp ${TMP}/package :package2
+rm :/
+mpremote: rm -r: cannot remove :/ Operation not permitted
+expect error
+ls :
+ls :/ramdisk
+-----
+touch :a.py
+touch :b.py
+cp ${TMP}/package :
+rm :ramdisk
+removed: 'ramdisk/a.py'
+removed: 'ramdisk/b.py'
+removed: 'ramdisk/package/subpackage/__init__.py'
+removed: 'ramdisk/package/subpackage/y.py'
+removed directory: 'ramdisk/package/subpackage'
+removed: 'ramdisk/package/__init__.py'
+removed: 'ramdisk/package/x.py'
+removed directory: 'ramdisk/package'
+skipped: 'ramdisk' (vfs mountpoint)
+ls :/ramdisk
+-----
+touch :a.py
+touch :b.py
+cp ${TMP}/package :
+rm :/ramdisk
+removed: '/ramdisk/a.py'
+removed: '/ramdisk/b.py'
+removed: '/ramdisk/package/subpackage/__init__.py'
+removed: '/ramdisk/package/subpackage/y.py'
+removed directory: '/ramdisk/package/subpackage'
+removed: '/ramdisk/package/__init__.py'
+removed: '/ramdisk/package/x.py'
+removed directory: '/ramdisk/package'
+skipped: '/ramdisk' (vfs mountpoint)
+ls :/ramdisk
+-----


### PR DESCRIPTION
### Summary

Recursive remove functionality for mpremote is frequently requested by users.

- [#16845](https://github.com/orgs/micropython/discussions/9802)
- https://github.com/micropython/micropython/issues/16845#issuecomment-2695120895

### Testing

On Windows 
- manually 
- using pytest, after porting the script based test suite to pytest ( not part of this PR) 

On Linux
- tests for linux have been added, and run against 5 ports from WSL2

### Trade-offs and Alternatives

- The current implementation does **not** ask for conformation, so it behaves somewhat like `rm -rf :foo` and therefore should be used with caution. 
  If desired such a check, and its override '-rf' could be added 
- No attempt is made to detect, or avoid special paths such as `/rom`  or `/sd`

Fixes : 16845
