### PR TITLE
ports/stm32/timer.c: Add support for STM32H5 Timer 1.

### DIFF
--- a/ports/stm32/timer.c
+++ b/ports/stm32/timer.c
@@ -840,7 +840,7 @@ static const uint32_t tim_instance_table[MICROPY_HW_MAX_TIMER] = {
     TIM_ENTRY(1, TIM1_BRK_UP_TRG_COM_IRQn),
     #elif defined(STM32F4) || defined(STM32F7)
     TIM_ENTRY(1, TIM1_UP_TIM10_IRQn),
-    #elif defined(STM32H7)
+    #elif defined(STM32H7) || defined(STM32H5)
     TIM_ENTRY(1, TIM1_UP_IRQn),
     #elif defined(STM32G4) || defined(STM32L4) || defined(STM32WB)
     TIM_ENTRY(1, TIM1_UP_TIM16_IRQn),


### PR DESCRIPTION
### Summary

The STM32H5 build was lacking support for timer 1 (TIM1). The micro has hardware support for Timer 1 but MicroPython wasn't correctly configured to use it. Instead, when trying to construct the timer, a ValueError would occur:

```python
>>> from pyb import Timer
>>> Timer(1)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
ValueError: Timer(1) doesn't exist
```

After integrating this PR:

```python
>>> from pyb import Timer
>>> Timer(1)
Timer(1)
```

### Testing

Tested PWM using Timer 1 on the [Nucleo H563ZI](https://www.st.com/en/evaluation-tools/nucleo-h563zi.html).

All Timers appear to be instantiated correctly now:

```python
=== from pyb import Timer
=== timers = []
=== for x in range(24):
===     try:
===         timers.append(Timer(x))
===     except ValueError as e:
===         print(e)
===
=== print(timers)
===
Timer(0) doesn't exist
Timer(9) doesn't exist
Timer(10) doesn't exist
Timer(11) doesn't exist
Timer(18) doesn't exist
Timer(19) doesn't exist
Timer(20) doesn't exist
Timer(21) doesn't exist
Timer(22) doesn't exist
Timer(23) doesn't exist
[Timer(1), Timer(2), Timer(3), Timer(4), Timer(5), Timer(6), Timer(7), Timer(8), Timer(12), Timer(13), Timer(14), Timer(15), Timer(16), Timer(17)]
```
### Extra detail

The [Datasheet's](https://www.st.com/en/microcontrollers-microprocessors/stm32h563-573/documentation.html) (DS14151 or DS14258 depending on the specific H5) show TIM1 as a 16bit advanced timer:

![image](https://github.com/user-attachments/assets/1c754bec-ca31-4c46-b5cd-5f0c1d625e96)
