### PR TITLE
esp32: Make it easier to integrate MicroPython as a custom ESP-IDF component.

### DIFF
--- a/ports/esp32/esp32_common.cmake
+++ b/ports/esp32/esp32_common.cmake
@@ -242,6 +242,7 @@ endif()
 
 # Set compile options for this port.
 target_compile_definitions(${MICROPY_TARGET} PUBLIC
+    ${MICROPY_DEF_COMPONENT}
     ${MICROPY_DEF_CORE}
     ${MICROPY_DEF_BOARD}
     ${MICROPY_DEF_TINYUSB}
@@ -254,6 +255,7 @@ target_compile_definitions(${MICROPY_TARGET} PUBLIC
 
 # Disable some warnings to keep the build output clean.
 target_compile_options(${MICROPY_TARGET} PUBLIC
+    ${MICROPY_COMPILE_COMPONENT}
     -Wno-clobbered
     -Wno-deprecated-declarations
     -Wno-missing-field-initializers

--- a/ports/esp32/main.c
+++ b/ports/esp32/main.c
@@ -216,7 +216,7 @@ void boardctrl_startup(void) {
     }
 }
 
-void app_main(void) {
+void MICROPY_ESP_IDF_ENTRY(void) {
     // Hook for a board to run code at start up.
     // This defaults to initialising NVS.
     MICROPY_BOARD_STARTUP();
@@ -225,7 +225,7 @@ void app_main(void) {
     xTaskCreatePinnedToCore(mp_task, "mp_task", MICROPY_TASK_STACK_SIZE / sizeof(StackType_t), NULL, MP_TASK_PRIORITY, &mp_main_task_handle, MP_TASK_COREID);
 }
 
-void nlr_jump_fail(void *val) {
+MP_WEAK void nlr_jump_fail(void *val) {
     printf("NLR jump failed, val=%p\n", val);
     esp_restart();
 }

--- a/ports/esp32/mpconfigport.h
+++ b/ports/esp32/mpconfigport.h
@@ -391,3 +391,8 @@ void boardctrl_startup(void);
 #ifndef MICROPY_PY_STRING_TX_GIL_THRESHOLD
 #define MICROPY_PY_STRING_TX_GIL_THRESHOLD  (20)
 #endif
+
+// Code can override this to provide a custom ESP-IDF entry point.
+#ifndef MICROPY_ESP_IDF_ENTRY
+#define MICROPY_ESP_IDF_ENTRY app_main
+#endif


### PR DESCRIPTION
### Summary

This PR introduces a few changes that are meant to make it easier to integrate MicroPython as a custom ESP-IDF component.

Whilst there is no official MicroPython component available for ESP-IDF, integration can be achieved with some minor CMake scripting outside the MicroPython tree - except for customisation of compilation defines and build flags and the unconditional definition of the port's entry point.

*(I've been upstreaming changes I've made to the ESP32 build settings to be able to have MicroPython as a custom ESP-IDF component without having to fork the tree and perform other trickery - especially related to MicroPython's own dependencies; see the rest of the esp32_common.cmake PRs I've submitted these past few days.)*

The first commit of this PR attempts to introduce a facility to inject custom compiler definitions and build flags in the build process to work around the inability to provide a new port configuration file.  This means that `MP_CONFIGFILE` can not be provided as an outside definition and thus provide a more fine-grained configuration to the port.  Board configuration files cannot override what is present in `ports/esp32/mpconfigport.h` anyway, so an external configuration file is required.  This is achieved by adding the contents of two CMake variables into the build definitions and compilation flags, with the variables being named `MICROPY_DEF_COMPONENT` and `MICROPY_COMPILE_COMPONENT` (for build definitions and compilation flags, respectively).
The same effect can be achieved by forking MicroPython, not providing much of a benefit when the changes required are relatively small when put in context.

The second addresses an issue that arises only when MicroPython is included as a custom ESP-IDF component, the unconditional definition of an entry point symbol for ESP-IDF to jump to when starting the firmware image.  During normal MicroPython usage this is not an issue as one wants to have MicroPython start at firmware's boot time, but if the interpreter is embedded then it becomes a problem (making the build fail due to a duplicated `app_main` symbol).  This is addressed by providing the same function under a different name (`micropyhon_main`) if `MICROPY_PY_ESP_IDF_COMPONENT` is set in the port's configuration, and a matching header file is provided if manually defining `extern void micropython_main(void);` is not desired, with said header file available as `ports/esp32/micropython_esp_idf.h`.

Also, the NLR jump failure callback is marked as weak to be able to be overridden from elsewhere, as if MicroPython is an embedded component maybe there is other cleanup that needs to be done rather than trigger a forced reset.

### Testing

The firmware for both `ESP32_GENERIC` and `ESP32_GENERIC_C3` was built successfully without setting any of the new CMake variables.  When adding `(set MICROPY_DEF_COMPONENT MP_CONFIGFILE="...")` to any `mpconfigport.cmake` file provided by a board definition the new port configuration file was picked up for building.

I don't have a MicroPython component that I can readily share at the moment, but when setting `MICROPY_PY_ESP_IDF_COMPONENT` the build process would predictably fail to link a firmware image due to `app_main` not being present, and `micropython_main` is made available in `build-$BOARD/esp-idf/main/libmain.a`. 

### Trade-offs and Alternatives

What this PR provides can be achieved by forking MicroPython, but considering the small amount of changes in question and the fact that said changes do not have any impact on existing setups unless the user explicitly performs a few extra steps, it should not be a big deal to have the changes in MicroPython instead.

In more detail, marking `app_main` as a weak symbol could technically be an option but then one would need to copy and paste the exact task creation snippet into their code (I'm not sure the port would work if `mp_main_task_handle` is not set).

The CMake variable names are, of course, not set in stone.  `MICROPY_DEF_COMPONENT` follows the same pattern of other variables in the same block, but there's no such pattern for `MICROPY_COMPILE_COMPONENT` - feel free to suggest new names for those variables.  The same goes for the alternate entry point name, I'd say `micropython_main` fits quite nicely but things can always be improved.