### PR TITLE
A few MICROPY_PREVIEW_VERSION_2 cleanups.

### DIFF
--- a/drivers/ninaw10/machine_pin_nina.c
+++ b/drivers/ninaw10/machine_pin_nina.c
@@ -114,13 +114,13 @@ void machine_pin_ext_config(machine_pin_obj_t *self, int mode, int value) {
         mode = NINA_GPIO_OUTPUT;
         self->is_output = true;
     } else {
-        mp_raise_ValueError("only Pin.OUT and Pin.IN are supported for this pin");
+        mp_raise_ValueError(MP_ERROR_TEXT("only Pin.OUT and Pin.IN are supported for this pin"));
     }
     if (self->id >= 0 && self->id < MICROPY_HW_PIN_EXT_COUNT) {
         uint8_t buf[] = {pin_map[self->id], mode};
         if (mode == NINA_GPIO_OUTPUT) {
             if (NINA_GPIO_IS_INPUT_ONLY(self->id)) {
-                mp_raise_ValueError("only Pin.IN is supported for this pin");
+                mp_raise_ValueError(MP_ERROR_TEXT("only Pin.IN is supported for this pin"));
             }
             machine_pin_ext_set(self, value);
         }

--- a/extmod/machine_usb_device.c
+++ b/extmod/machine_usb_device.c
@@ -108,7 +108,7 @@ static mp_obj_t usb_device_submit_xfer(mp_obj_t self, mp_obj_t ep, mp_obj_t buff
         //
         // This C layer doesn't otherwise keep track of which endpoints the host
         // is aware of (or not).
-        mp_raise_ValueError("ep");
+        mp_raise_ValueError(MP_ERROR_TEXT("ep"));
     }
 
     if (!usbd_edpt_claim(USBD_RHPORT, ep_addr)) {

--- a/extmod/modbluetooth.c
+++ b/extmod/modbluetooth.c
@@ -340,7 +340,7 @@ static mp_obj_t bluetooth_ble_config(size_t n_args, const mp_obj_t *args, mp_map
         }
 
         for (size_t i = 0; i < kwargs->alloc; ++i) {
-            if (MP_MAP_SLOT_IS_FILLED(kwargs, i)) {
+            if (mp_map_slot_is_filled(kwargs, i)) {
                 mp_map_elem_t *e = &kwargs->table[i];
                 switch (mp_obj_str_get_qstr(e->key)) {
                     case MP_QSTR_gap_name: {

--- a/ports/rp2/machine_pin.c
+++ b/ports/rp2/machine_pin.c
@@ -193,7 +193,7 @@ const machine_pin_obj_t *machine_pin_find(mp_obj_t pin) {
             return &machine_pin_obj_table[wanted_pin];
         }
     }
-    mp_raise_ValueError("invalid pin");
+    mp_raise_ValueError(MP_ERROR_TEXT("invalid pin"));
 }
 
 static void machine_pin_print(const mp_print_t *print, mp_obj_t self_in, mp_print_kind_t kind) {
@@ -259,11 +259,11 @@ static mp_obj_t machine_pin_obj_init_helper(const machine_pin_obj_t *self, size_
     mp_arg_parse_all(n_args, pos_args, kw_args, MP_ARRAY_SIZE(allowed_args), allowed_args, args);
 
     if (is_ext_pin(self) && args[ARG_pull].u_obj != mp_const_none) {
-        mp_raise_ValueError("pulls are not supported for external pins");
+        mp_raise_ValueError(MP_ERROR_TEXT("pulls are not supported for external pins"));
     }
 
     if (is_ext_pin(self) && args[ARG_alt].u_int != GPIO_FUNC_SIO) {
-        mp_raise_ValueError("alternate functions are not supported for external pins");
+        mp_raise_ValueError(MP_ERROR_TEXT("alternate functions are not supported for external pins"));
     }
 
     // get initial value of pin (only valid for OUT and OPEN_DRAIN modes)

--- a/ports/rp2/machine_pin_cyw43.c
+++ b/ports/rp2/machine_pin_cyw43.c
@@ -70,7 +70,7 @@ void machine_pin_ext_config(machine_pin_obj_t *self, int mode, int value) {
             self->is_output = true;
         }
     } else {
-        mp_raise_ValueError("only Pin.OUT and Pin.IN are supported for this pin");
+        mp_raise_ValueError(MP_ERROR_TEXT("only Pin.OUT and Pin.IN are supported for this pin"));
     }
 
     if (value != -1) {

--- a/ports/rp2/rp2_pio.c
+++ b/ports/rp2/rp2_pio.c
@@ -126,7 +126,7 @@ void rp2_pio_irq_set_exclusive_handler(PIO pio, uint irq) {
     irq_handler_t current = irq_get_exclusive_handler(irq);
     // If the IRQ is set and isn't our handler, or a shared handler is set, then raise an error
     if ((current && current != rp2_pio_get_irq_handler(pio)) || irq_has_shared_handler(irq)) {
-        mp_raise_ValueError("irq claimed by external resource");
+        mp_raise_ValueError(MP_ERROR_TEXT("irq claimed by external resource"));
         // If the IRQ is not set, add our handler
     } else if (!current) {
         irq_set_exclusive_handler(irq, rp2_pio_get_irq_handler(pio));
@@ -304,7 +304,7 @@ static mp_obj_t rp2_pio_make_new(const mp_obj_type_t *type, size_t n_args, size_
     // Get the PIO object.
     int pio_id = mp_obj_get_int(args[0]);
     if (!(0 <= pio_id && pio_id < MP_ARRAY_SIZE(rp2_pio_obj))) {
-        mp_raise_ValueError("invalid PIO");
+        mp_raise_ValueError(MP_ERROR_TEXT("invalid PIO"));
     }
     const rp2_pio_obj_t *self = &rp2_pio_obj[pio_id];
 
@@ -353,7 +353,7 @@ static mp_obj_t rp2_pio_remove_program(size_t n_args, const mp_obj_t *args) {
         length = bufinfo.len / 2;
         offset = mp_obj_get_int(prog[PROG_OFFSET_PIO0 + pio_get_index(self->pio)]);
         if (offset < 0) {
-            mp_raise_ValueError("prog not in instruction memory");
+            mp_raise_ValueError(MP_ERROR_TEXT("prog not in instruction memory"));
         }
         // Invalidate the program offset in the program object.
         prog[PROG_OFFSET_PIO0 + pio_get_index(self->pio)] = MP_OBJ_NEW_SMALL_INT(-1);
@@ -374,7 +374,7 @@ static mp_obj_t rp2_pio_state_machine(size_t n_args, const mp_obj_t *pos_args, m
     // Get and verify the state machine id.
     mp_int_t sm_id = mp_obj_get_int(pos_args[1]);
     if (!(0 <= sm_id && sm_id < 4)) {
-        mp_raise_ValueError("invalid StateMachine");
+        mp_raise_ValueError(MP_ERROR_TEXT("invalid StateMachine"));
     }
 
     // Return the correct StateMachine object.
@@ -400,7 +400,7 @@ static mp_obj_t rp2_pio_gpio_base(size_t n_args, const mp_obj_t *args) {
 
         // Must be 0 for GPIOs 0 to 31 inclusive, or 16 for GPIOs 16 to 48 inclusive.
         if (!(gpio_base == 0 || gpio_base == 16)) {
-            mp_raise_ValueError("invalid GPIO base");
+            mp_raise_ValueError(MP_ERROR_TEXT("invalid GPIO base"));
         }
 
         if (pio_set_gpio_base(self->pio, gpio_base) != PICO_OK) {
@@ -556,14 +556,14 @@ static const rp2_state_machine_obj_t rp2_state_machine_obj[] = {
 
 static const rp2_state_machine_obj_t *rp2_state_machine_get_object(mp_int_t sm_id) {
     if (!(0 <= sm_id && sm_id < MP_ARRAY_SIZE(rp2_state_machine_obj))) {
-        mp_raise_ValueError("invalid StateMachine");
+        mp_raise_ValueError(MP_ERROR_TEXT("invalid StateMachine"));
     }
 
     const rp2_state_machine_obj_t *sm_obj = &rp2_state_machine_obj[sm_id];
 
     if (!(rp2_state_machine_claimed_mask & (1 << sm_id))) {
         if (pio_sm_is_claimed(sm_obj->pio, sm_obj->sm)) {
-            mp_raise_ValueError("StateMachine claimed by external resource");
+            mp_raise_ValueError(MP_ERROR_TEXT("StateMachine claimed by external resource"));
         }
         pio_sm_claim(sm_obj->pio, sm_obj->sm);
         rp2_state_machine_claimed_mask |= 1 << sm_id;
@@ -830,7 +830,7 @@ static mp_obj_t rp2_state_machine_get(size_t n_args, const mp_obj_t *args) {
             *(uint32_t *)dest = value;
             dest += sizeof(uint32_t);
         } else {
-            mp_raise_ValueError("unsupported buffer type");
+            mp_raise_ValueError(MP_ERROR_TEXT("unsupported buffer type"));
         }
         if (dest >= dest_top) {
             return args[1];
@@ -868,7 +868,7 @@ static mp_obj_t rp2_state_machine_put(size_t n_args, const mp_obj_t *args) {
             value = *(uint32_t *)src;
             src += sizeof(uint32_t);
         } else {
-            mp_raise_ValueError("unsupported buffer type");
+            mp_raise_ValueError(MP_ERROR_TEXT("unsupported buffer type"));
         }
         while (pio_sm_is_tx_fifo_full(self->pio, self->sm)) {
             // This delay must be fast.

--- a/ports/stm32/main.c
+++ b/ports/stm32/main.c
@@ -515,11 +515,8 @@ soft_reset:
     mp_thread_init();
     #endif
 
-    // Stack limit should be less than real stack size, so we have a chance
-    // to recover from limit hit.  (Limit is measured in bytes.)
-    // Note: stack control relies on main thread being initialised above
-    mp_stack_set_top(&_estack);
-    mp_stack_set_limit((char *)&_estack - (char *)&_sstack - 1024);
+    // Stack limit init.
+    mp_cstack_init_with_top(&_estack, (char *)&_estack - (char *)&_sstack);
 
     // GC init
     gc_init(MICROPY_HEAP_START, MICROPY_HEAP_END);

--- a/ports/stm32/mpconfigport.h
+++ b/ports/stm32/mpconfigport.h
@@ -43,6 +43,7 @@
 #define MICROPY_GC_STACK_ENTRY_TYPE uint16_t
 #endif
 #endif
+#define MICROPY_STACK_CHECK_MARGIN  (1024)
 #define MICROPY_ALLOC_PATH_MAX      (128)
 
 // optimisations


### PR DESCRIPTION
### Summary

I was doing some testing on rp2 and stm32 with `MICROPY_PREVIEW_VERSION_2` enabled and ran into a few basic needed updates. 

### Testing

Builds from rp2 and stm32 were run briefly with no issues noticed. 
I wasn't able to test the nina driver however the change should be very low risk.

I don't really know enough about the stack limit stuff in stm32 to be sure this replacement is equivalient, however it felt like it made sense to me?