### PR TITLE
samd/boards: Add two SparkFun SAMD21 boards.

### DIFF
--- a/docs/samd/pinout.rst
+++ b/docs/samd/pinout.rst
@@ -650,6 +650,124 @@ Adafruit ItsyBitsy M0 Express :ref:`samd21_pinout_table`.
 
 The board does not provide access to UART, I2C, SPI or DAC.
 
+SparkFun Redboard Turbo assignment table
+----------------------------------------
+
+=== ==== ============ ==== ==== ====== ====== ====== ======
+Pin GPIO Pin name     IRQ  ADC  Serial Serial TCC/TC TCC/TC
+=== ==== ============ ==== ==== ====== ====== ====== ======
+  2 PA02           A0   2    0     -      -      -      -
+ 40 PB08           A1   8    2     -     4/0    4/0     -
+ 41 PB09           A2   9    3     -     4/1    4/1     -
+  4 PA04           A3   4    4     -     0/0    0/0     -
+  5 PA05           A4   5    5     -     0/1    0/1     -
+ 34 PB02           A5   2   10     -     5/0    6/0     -
+ 11 PA11           D0  11   19    0/3    2/3    1/1    0/3
+ 10 PA10           D1  10   18    0/2    2/2    1/0    0/2
+ 14 PA14           D2  14    -    2/2    4/2    3/0    0/4
+  9 PA09           D3   9   17    0/1    2/1    0/1    1/3
+  8 PA08           D4   -   16    0/0    2/0    0/0    1/2
+ 15 PA15           D5  15    -    2/3    4/3    3/1    0/5
+ 20 PA20           D6   4    -    5/2    3/2    7/0    0/4
+ 21 PA21           D7   5    -    5/3    3/3    7/1    0/7
+  6 PA06           D8   6    6     -     0/2    1/0     -
+  7 PA07           D9   7    7     -     0/3    1/1     -
+ 11 PA11           RX  11   19    0/3    2/3    1/1    0/3
+ 10 PA10           TX  10   18    0/2    2/2    1/0    0/2
+  3 PA03         AREF   3    1     -      -      -      -
+ 18 PA18          D10   2    -    1/2    3/2    3/0    0/2
+ 16 PA16          D11   0    -    1/0    3/0    2/0    0/6
+ 19 PA19          D12   3    -    1/3    3/3    3/1    0/3
+ 17 PA17          D13   1    -    1/1    3/1    2/1    0/7
+ 13 PA13     FLASH_CS  13    -    2/1    4/1    2/0    0/7
+ 35 PB03   FLASH_MISO   3   11     -     5/1    6/1     -
+ 54 PB22   FLASH_MOSI   6    -     -     5/2    7/0     -
+ 55 PB23    FLASH_SCK   7    -     -     5/3    7/1     -
+ 31 PA31       LED_RX  11    -     -     1/3    1/1     -
+ 27 PA27       LED_TX  15    -     -      -      -      -
+ 12 PA12         MISO  12    -    2/0    4/0    2/0    0/6
+ 42 PB10         MOSI  10    -     -     4/2    5/0    0/4
+ 30 PA30     NEOPIXEL  10    -     -     1/2    1/0     -
+ 43 PB11          SCK  11    -     -     4/3    5/1    0/5
+ 23 PA23          SCL   7    -    3/1    5/1    4/1    0/5
+ 22 PA22          SDA   6    -    3/0    5/0    4/0    0/4
+ 30 PA30        SWCLK  10    -     -     1/2    1/0     -
+ 31 PA31        SWDIO  11    -     -     1/3    1/1     -
+ 24 PA24       USB_DM  12    -    3/2    5/2    5/0    1/2
+ 25 PA25       USB_DP  13    -    3/3    5/3    5/1    1/3
+  0 PA00                0    -     -     1/0    2/0     -
+  1 PA01                1    -     -     1/1    2/1     -
+ 28 PA28                8    -     -      -      -      -
+=== ==== ============ ==== ==== ====== ====== ====== ======
+
+For the definition of the table columns see the explanation at the table for
+Adafruit ItsyBitsy M0 Express :ref:`samd21_pinout_table`.
+
+The default devices at the board are:
+
+- UART 0 at pins PA11/PA10, labelled RX/TX
+- I2C 3 at pins PA22/PA23, labelled SDA/SCL
+- SPI 4 at pins PB10/PA12/PB11, labelled MISO, MOSI and SCK
+- DAC output on pin PA02, labelled A0
+
+
+SparkFun SAMD21 Dev Breakout assignment table
+---------------------------------------------
+
+=== ==== ============ ==== ==== ====== ====== ====== ======
+Pin GPIO Pin name     IRQ  ADC  Serial Serial TCC/TC TCC/TC
+=== ==== ============ ==== ==== ====== ====== ====== ======
+  2 PA02           A0   2    0      -     -      -      -
+ 40 PB08           A1   8    2      -    4/0    4/0     -
+ 41 PB09           A2   9    3      -    4/1    4/1     -
+  4 PA04           A3   4    4      -    0/0    0/0     -
+  5 PA05           A4   5    5      -    0/1    0/1     -
+ 34 PB02           A5   2   10      -    5/0    6/0     -
+ 11 PA11           D0  11   19     0/3   2/3    1/1    0/3
+ 10 PA10           D1  10   18     0/2   2/2    1/0    0/2
+ 14 PA14           D2  14    -     2/2   4/2    3/0    0/4
+  9 PA09           D3   9   17     0/1   2/1    0/1    1/3
+  8 PA08           D4   -   16     0/0   2/0    0/0    1/2
+ 15 PA15           D5  15    -     2/3   4/3    3/1    0/5
+ 20 PA20           D6   4    -     5/2   3/2    7/0    0/4
+ 21 PA21           D7   5    -     5/3   3/3    7/1    0/7
+  6 PA06           D8   6    6      -    0/2    1/0     -
+  7 PA07           D9   7    7      -    0/3    1/1     -
+ 11 PA11           RX  11   19     0/3   2/3    1/1    0/3
+ 10 PA10           TX  10   18     0/2   2/2    1/0    0/2
+  3 PA03         AREF   3    1      -     -      -      -
+ 18 PA18          D10   2    -     1/2   3/2    3/0    0/2
+ 16 PA16          D11   0    -     1/0   3/0    2/0    0/6
+ 19 PA19          D12   3    -     1/3   3/3    3/1    0/3
+ 17 PA17          D13   1    -     1/1   3/1    2/1    0/7
+ 54 PB22          D30   6    -      -    5/2    7/0     -
+ 55 PB23          D31   7    -      -    5/3    7/1     -
+ 13 PA13          D38  13    -     2/1   4/1    2/0    0/7
+ 35 PB03       LED_RX   3   11      -    5/1    6/1     -
+ 27 PA27       LED_TX  15    -      -     -      -      -
+ 12 PA12         MISO  12    -     2/0   4/0    2/0    0/6
+ 42 PB10         MOSI  10    -      -    4/2    5/0    0/4
+ 43 PB11          SCK  11    -      -    4/3    5/1    0/5
+ 23 PA23          SCL   7    -     3/1   5/1    4/1    0/5
+ 22 PA22          SDA   6    -     3/0   5/0    4/0    0/4
+ 30 PA30        SWCLK  10    -      -    1/2    1/0     -
+ 31 PA31        SWDIO  11    -      -    1/3    1/1     -
+ 24 PA24       USB_DM  12    -     3/2   5/2    5/0    1/2
+ 25 PA25       USB_DP  13    -     3/3   5/3    5/1    1/3
+  0 PA00                0    -      -    1/0    2/0     -
+  1 PA01                1    -      -    1/1    2/1     -
+ 28 PA28                8    -      -     -      -      -
+=== ==== ============ ==== ==== ====== ====== ====== ======
+
+For the definition of the table columns see the explanation at the table for
+Adafruit ItsyBitsy M0 Express :ref:`samd21_pinout_table`.
+
+The default devices at the board are:
+
+- UART 0 at pins PA11/PA10, labelled RX/TX
+- I2C 3 at pins PA22/PA23, labelled SDA/SCL
+- SPI 4 at pins PB10/PA12/PB11, labelled MISO, MOSI and SCK
+- DAC output on pin PA02, labelled A0
 
 SAMD21 Xplained PRO pin assignment table
 ----------------------------------------

--- a/ports/samd/boards/SPARKFUN_REDBOARD_TURBO/board.json
+++ b/ports/samd/boards/SPARKFUN_REDBOARD_TURBO/board.json
@@ -1,0 +1,21 @@
+{
+    "deploy": [
+        "../deploy.md"
+    ],
+    "docs": "",
+    "features": [
+        "Battery Charging",
+        "DAC",
+        "External Flash",
+        "USB",
+        "RGB LED"
+    ],
+    "images": [
+        "sparkfun_readboard_turbo.jpg"
+    ],
+    "mcu": "samd21",
+    "product": "SparkFun RedBoard Turbo",
+    "thumbnail": "",
+    "url": "https://www.sparkfun.com/products/14812",
+    "vendor": "Sparkfun"
+}

--- a/ports/samd/boards/SPARKFUN_REDBOARD_TURBO/mpconfigboard.h
+++ b/ports/samd/boards/SPARKFUN_REDBOARD_TURBO/mpconfigboard.h
@@ -1,0 +1,11 @@
+#define MICROPY_HW_BOARD_NAME "SparkFun RedBoard Turbo"
+#define MICROPY_HW_MCU_NAME   "SAMD21G18A"
+
+#define MICROPY_HW_XOSC32K     (1)
+
+#define MICROPY_HW_SPIFLASH    (1)
+#define MICROPY_HW_SPIFLASH_ID (5)
+
+#define MICROPY_HW_DEFAULT_UART_ID  (0)
+#define MICROPY_HW_DEFAULT_I2C_ID   (3)
+#define MICROPY_HW_DEFAULT_SPI_ID   (4)

--- a/ports/samd/boards/SPARKFUN_REDBOARD_TURBO/mpconfigboard.mk
+++ b/ports/samd/boards/SPARKFUN_REDBOARD_TURBO/mpconfigboard.mk
@@ -1,0 +1,8 @@
+MCU_SERIES = SAMD21
+CMSIS_MCU = SAMD21G18A
+LD_FILES = boards/samd21x18a.ld sections.ld
+TEXT0 = 0x2000
+
+# The ?='s allow overriding in mpconfigboard.mk.
+# MicroPython settings
+MICROPY_HW_CODESIZE ?= 232K

--- a/ports/samd/boards/SPARKFUN_REDBOARD_TURBO/pins.csv
+++ b/ports/samd/boards/SPARKFUN_REDBOARD_TURBO/pins.csv
@@ -1,0 +1,47 @@
+# The lines contain pairs of Pin name and Pin number.
+# Pin names must be valid Python identifiers.
+# Pin numbers have the form Pxnn, with x being A, B, C or D.
+# Lines starting with # or empty lines are ignored.
+
+USB_DM,PA24
+USB_DP,PA25
+
+SWCLK,PA30
+SWDIO,PA31
+
+D0,PA11
+D1,PA10
+D2,PA14
+D3,PA09
+D4,PA08
+D5,PA15
+D6,PA20
+D7,PA21
+D8,PA06
+D9,PA07
+D10,PA18
+D11,PA16
+D12,PA19
+D13,PA17
+A0,PA02
+A1,PB08
+A2,PB09
+A3,PA04
+A4,PA05
+A5,PB02
+AREF,PA03
+RX,PA11
+TX,PA10
+SCL,PA23
+SDA,PA22
+MOSI,PB10
+MISO,PA12
+SCK,PB11
+FLASH_MOSI,PB22
+FLASH_MISO,PB03
+FLASH_SCK,PB23
+FLASH_CS,PA13
+NEOPIXEL,PA30
+
+LED_TX,PA27
+LED_RX,PA31

--- a/ports/samd/boards/SPARKFUN_SAMD21_DEV_BREAKOUT/board.json
+++ b/ports/samd/boards/SPARKFUN_SAMD21_DEV_BREAKOUT/board.json
@@ -1,0 +1,19 @@
+{
+    "deploy": [
+        "../deploy.md"
+    ],
+    "docs": "",
+    "features": [
+        "Battery Charging",
+        "DAC",
+        "USB"
+    ],
+    "images": [
+        "sparkfun_sam21_dev_breakout.jpg"
+    ],
+    "mcu": "samd21",
+    "product": "SparkFun SAMD21 Dev Breakout",
+    "thumbnail": "",
+    "url": "https://www.sparkfun.com/products/13672",
+    "vendor": "Sparkfun"
+}

--- a/ports/samd/boards/SPARKFUN_SAMD21_DEV_BREAKOUT/mpconfigboard.h
+++ b/ports/samd/boards/SPARKFUN_SAMD21_DEV_BREAKOUT/mpconfigboard.h
@@ -1,0 +1,8 @@
+#define MICROPY_HW_BOARD_NAME "SparkFun SAMD21 Dev Breakout"
+#define MICROPY_HW_MCU_NAME   "SAMD21G18A"
+
+#define MICROPY_HW_XOSC32K          (1)
+
+#define MICROPY_HW_DEFAULT_UART_ID  (0)
+#define MICROPY_HW_DEFAULT_I2C_ID   (3)
+#define MICROPY_HW_DEFAULT_SPI_ID   (4)

--- a/ports/samd/boards/SPARKFUN_SAMD21_DEV_BREAKOUT/mpconfigboard.mk
+++ b/ports/samd/boards/SPARKFUN_SAMD21_DEV_BREAKOUT/mpconfigboard.mk
@@ -1,0 +1,4 @@
+MCU_SERIES = SAMD21
+CMSIS_MCU = SAMD21G18A
+LD_FILES = boards/samd21x18a.ld sections.ld
+TEXT0 = 0x2000

--- a/ports/samd/boards/SPARKFUN_SAMD21_DEV_BREAKOUT/pins.csv
+++ b/ports/samd/boards/SPARKFUN_SAMD21_DEV_BREAKOUT/pins.csv
@@ -1,0 +1,45 @@
+# The lines contain pairs of Pin name and Pin number.
+# Pin names must be valid Python identifiers.
+# Pin numbers have the form Pxnn, with x being A, B, C or D.
+# Lines starting with # or empty lines are ignored.
+
+USB_DM,PA24
+USB_DP,PA25
+
+SWCLK,PA30
+SWDIO,PA31
+
+D0,PA11
+D1,PA10
+D2,PA14
+D3,PA09
+D4,PA08
+D5,PA15
+D6,PA20
+D7,PA21
+D8,PA06
+D9,PA07
+D10,PA18
+D11,PA16
+D12,PA19
+D13,PA17
+A0,PA02
+A1,PB08
+A2,PB09
+A3,PA04
+A4,PA05
+A5,PB02
+AREF,PA03
+RX,PA11
+TX,PA10
+SCL,PA23
+SDA,PA22
+MOSI,PB10
+MISO,PA12
+SCK,PB11
+D38,PA13
+D30,PB22
+D31,PB23
+
+LED_TX,PA27
+LED_RX,PB03


### PR DESCRIPTION
### Summary

Add support for the boards: 

- SparkFun SAMD21 Dev Breakout
- SparkFun  RedBoard Turbo

Both boards are SAMD21 based and actively sold by SparkFun.

### Testing

Built the board firmware and tested it on the board.

### Trade-offs and Alternatives

These are "just another" two SAMD boards. The SparkFun SAMD21 Dev Breakout works as well with the Generic SAMD21x18 firmware. Only the board Pin labels are then not supported.