### PR TITLE
ports/stm32: Add support for additional GC blocks. 

### DIFF
--- a/ports/stm32/boards/ARDUINO_GIGA/mpconfigboard.h
+++ b/ports/stm32/boards/ARDUINO_GIGA/mpconfigboard.h
@@ -31,6 +31,7 @@ typedef unsigned int mp_uint_t;     // must be pointer size
 #define MICROPY_HW_ENABLE_MMCARD    (0)
 #define MICROPY_HW_ENTER_BOOTLOADER_VIA_RESET   (0)
 #define MICROPY_HW_TIM_IS_RESERVED(id) (id == 1)
+#define MICROPY_GC_SPLIT_HEAP       (1)
 
 // ROMFS config
 #define MICROPY_HW_ROMFS_ENABLE_EXTERNAL_QSPI       (1)

--- a/ports/stm32/boards/ARDUINO_GIGA/stm32h747.ld
+++ b/ports/stm32/boards/ARDUINO_GIGA/stm32h747.ld
@@ -12,6 +12,7 @@ MEMORY
     SRAM2 (xrw)     : ORIGIN = 0x30020000, LENGTH = 128K    /* SRAM2 D2    */
     SRAM3 (xrw)     : ORIGIN = 0x30040000, LENGTH = 32K     /* SRAM3 D2    */
     SRAM4 (xrw)     : ORIGIN = 0x38000000, LENGTH = 64K     /* SRAM4 D3    */
+    SDRAM (xrw)     : ORIGIN = 0x60000000, LENGTH = 8M      /* SDRAM */
     FLASH (rx)      : ORIGIN = 0x08000000, LENGTH = 2048K   /* Total available flash */
     FLASH_BL (rx)   : ORIGIN = 0x08000000, LENGTH = 128K    /* Arduino bootloader */
     FLASH_FS (r)    : ORIGIN = 0x08020000, LENGTH = 128K    /* filesystem */
@@ -53,3 +54,27 @@ _openamp_shm_region_start = ORIGIN(SRAM4);
 _openamp_shm_region_end = ORIGIN(SRAM4) + LENGTH(SRAM4);
 
 INCLUDE common_blifs.ld
+
+SECTIONS
+{
+    /* GC blocks addresses and sizes */
+    .gc.blocks.table (READONLY) : {
+      . = ALIGN(4);
+      _gc_blocks_table_start = .;
+
+      LONG (ORIGIN(SRAM1));
+      LONG (128K);
+
+      LONG (ORIGIN(SDRAM) + 0M);
+      LONG (2M);
+
+      LONG (ORIGIN(SDRAM) + 2M);
+      LONG (2M);
+
+      LONG (ORIGIN(SDRAM) + 4M);
+      LONG (4M);
+
+      _gc_blocks_table_end = .;
+      . = ALIGN(4);
+    } > FLASH_TEXT
+}

--- a/ports/stm32/main.c
+++ b/ports/stm32/main.c
@@ -521,6 +521,23 @@ soft_reset:
     // GC init
     gc_init(MICROPY_HEAP_START, MICROPY_HEAP_END);
 
+    // Add additional GC blocks (if enabled).
+    #if MICROPY_GC_SPLIT_HEAP
+    typedef struct {
+        uint8_t *addr;
+        uint32_t size;
+    } gc_blocks_table_t;
+
+    extern const gc_blocks_table_t _gc_blocks_table_start;
+    extern const gc_blocks_table_t _gc_blocks_table_end;
+
+    for (gc_blocks_table_t const *block = &_gc_blocks_table_start; block < &_gc_blocks_table_end; block++) {
+        if (block->size) {
+            gc_add(block->addr, block->addr + block->size);
+        }
+    }
+    #endif
+
     #if MICROPY_ENABLE_PYSTACK
     static mp_obj_t pystack[384];
     mp_pystack_init(pystack, &pystack[384]);


### PR DESCRIPTION
### Summary

This patch adds support for defining additional GC blocks (for split heap) via linker scripts. While split GC on its own is very useful, there isn't a standard way to actually use it, so maybe this will be a step towards that.

For the Giga board, a few blocks in SDRAM/SRAM are also enabled as an example.

### Testing

I tested on the Giga, checked the blocks addresses an sizes passed to `gc_add` and `mem_free`. This change is enabled conditionally when split heap is enabled, so should not have any effect on other boards as none use split heaps. 

### Trade-offs and Alternatives

If linker scripts were processed through CPP, we could define these blocks in board config files and make the linker script section common. Since this is not the case, this table structure will have to be duplicated if other boards want to use this. I've tried to add a common linker script (`common_gc_table.ld`) but without CPP it's very hard to make this generic (the conditionals supported by ld script are very basic).

Also, the blocks are defined in a particular order so that faster SRAM blocks are, hopefully, searched first. We wouldn't have to rely on this, if we had this feature: https://github.com/micropython/micropython/issues/16644