### PR TITLE
esp32, rp2: Use `$(Q)` as a prefix for all commands in the Makefile

### DIFF
--- a/ports/esp32/Makefile
+++ b/ports/esp32/Makefile
@@ -70,12 +70,12 @@ endif
 HELP_BUILD_ERROR ?= "See \033[1;31mhttps://github.com/micropython/micropython/wiki/Build-Troubleshooting\033[0m"
 
 define RUN_IDF_PY
-	idf.py $(IDFPY_FLAGS) -B $(BUILD) $(1)
+	$(Q)idf.py $(IDFPY_FLAGS) -B $(BUILD) $(1)
 endef
 
 all:
-	idf.py $(IDFPY_FLAGS) -B $(BUILD) build || (echo -e $(HELP_BUILD_ERROR); false)
-	@$(PYTHON) makeimg.py \
+	$(Q)idf.py $(IDFPY_FLAGS) -B $(BUILD) build || (echo -e $(HELP_BUILD_ERROR); false)
+	$(Q)$(PYTHON) makeimg.py \
 		$(BUILD)/sdkconfig \
 		$(BUILD)/bootloader/bootloader.bin \
 		$(BUILD)/partition_table/partition-table.bin \
@@ -112,4 +112,4 @@ size-files:
 # This is done in a dedicated build directory as some CMake cache values are not
 # set correctly if not all submodules are loaded yet.
 submodules:
-	IDF_COMPONENT_MANAGER=0 idf.py $(IDFPY_FLAGS) -B $(BUILD)/submodules -D UPDATE_SUBMODULES=1 reconfigure
+	$(Q)IDF_COMPONENT_MANAGER=0 idf.py $(IDFPY_FLAGS) -B $(BUILD)/submodules -D UPDATE_SUBMODULES=1 reconfigure

--- a/ports/rp2/Makefile
+++ b/ports/rp2/Makefile
@@ -60,9 +60,9 @@ HELP_PICO_SDK_SUBMODULE ?= "\033[1;31mError: pico-sdk submodule is not initializ
 HELP_BUILD_ERROR ?= "See \033[1;31mhttps://github.com/micropython/micropython/wiki/Build-Troubleshooting\033[0m"
 
 all:
-	[ -f ../../lib/pico-sdk/README.md ] || (echo -e $(HELP_PICO_SDK_SUBMODULE); false)
-	[ -e $(BUILD)/Makefile ] || cmake -S . -B $(BUILD) -DPICO_BUILD_DOCS=0 ${CMAKE_ARGS}
-	$(MAKE) $(MAKE_ARGS) -C $(BUILD) || (echo -e $(HELP_BUILD_ERROR); false)
+	$(Q)[ -f ../../lib/pico-sdk/README.md ] || (echo -e $(HELP_PICO_SDK_SUBMODULE); false)
+	$(Q)[ -e $(BUILD)/Makefile ] || cmake -S . -B $(BUILD) -DPICO_BUILD_DOCS=0 ${CMAKE_ARGS}
+	$(Q)$(MAKE) $(MAKE_ARGS) -C $(BUILD) || (echo -e $(HELP_BUILD_ERROR); false)
 
 clean:
 	$(RM) -rf $(BUILD)
@@ -73,5 +73,5 @@ clean:
 # This is done in a dedicated build directory as some CMake cache values are not
 # set correctly if not all submodules are loaded yet.
 submodules:
-	$(MAKE) -f ../../py/mkrules.mk GIT_SUBMODULES="lib/pico-sdk" submodules
-	cmake -S . -B $(BUILD)/submodules -DUPDATE_SUBMODULES=1 ${CMAKE_ARGS}
+	$(Q)$(MAKE) -f ../../py/mkrules.mk GIT_SUBMODULES="lib/pico-sdk" submodules
+	$(Q)cmake -S . -B $(BUILD)/submodules -DUPDATE_SUBMODULES=1 ${CMAKE_ARGS}


### PR DESCRIPTION
### Summary

At the moment, running `make` on esp32 or rp2 leads to the (lengthy) command being printed out, before it's run.  This can be distracting, eg on rp2 the current situation is:
```
$ make
Use make V=1 or set BUILD_VERBOSE in your environment to increase build verbosity.
[ -f ../../lib/pico-sdk/README.md ] || (echo -e "\033[1;31mError: pico-sdk submodule is not initialized.\033[0m Run 'make submodules'"; false)
[ -e build-RPI_PICO/Makefile ] || cmake -S . -B build-RPI_PICO -DPICO_BUILD_DOCS=0 -DMICROPY_BOARD=RPI_PICO -DMICROPY_BOARD_DIR="micropython/ports/rp2/boards/RPI_PICO"
make  -C build-RPI_PICO || (echo -e "See \033[1;31mhttps://github.com/micropython/micropython/wiki/Build-Troubleshooting\033[0m"; false)
make[1]: Entering directory 'micropython/ports/rp2/build-RPI_PICO'
[  0%] Built target bs2_default
[  1%] Built target bs2_default_library
...
```

That's pretty noisy and it almost looks as if there is an error and it's telling me to visit the troubleshooting page.

This PR suppresses this output by using `$(Q)`, which is what all the non-cmake ports already do.  You can still get the full command by doing `make V=1`.

### Testing

Tested esp32 and rp2 ports with `make`, `make submodules` and `make clean` and it's now improved.  Also tested `make V=1` to see that the command was printed.  And tested the case where the pico-sdk was not initialised, to check the error message still worked.

Eg on rp2:
```
$ make
Use make V=1 or set BUILD_VERBOSE in your environment to increase build verbosity.
make[1]: Entering directory 'micropython/ports/rp2/build-RPI_PICO'
[  0%] Built target bs2_default
[  1%] Built target bs2_default_library
[  1%] Built target BUILD_VERSION_HEADER
...
```
and without the pico-sdk:
```
$ make
Use make V=1 or set BUILD_VERBOSE in your environment to increase build verbosity.
Error: pico-sdk submodule is not initialized. Run 'make submodules'
make: *** [Makefile:63: all] Error 1
```
and verbose mode:
```
$  make V=1
[ -f ../../lib/pico-sdk/README.md ] || (echo -e "\033[1;31mError: pico-sdk submodule is not initialized.\033[0m Run 'make submodules'"; false)
[ -e build-RPI_PICO/Makefile ] || cmake -S . -B build-RPI_PICO -DPICO_BUILD_DOCS=0 -DMICROPY_BOARD=RPI_PICO -DMICROPY_BOARD_DIR="micropython/ports/rp2/boards/RPI_PICO"
make VERBOSE=1   -C build-RPI_PICO || (echo -e "See \033[1;31mhttps://github.com/micropython/micropython/wiki/Build-Troubleshooting\033[0m"; false)
make[1]: Entering directory 'micropython/ports/rp2/build-RPI_PICO'
...
```

