### PR TITLE
ports/rp2: Make pins.csv configurable.

### DIFF
--- a/ports/rp2/CMakeLists.txt
+++ b/ports/rp2/CMakeLists.txt
@@ -654,9 +654,13 @@ if(NOT PICO_NUM_EXT_GPIOS)
     set(PICO_NUM_EXT_GPIOS 10)
 endif()
 
-if(EXISTS "${MICROPY_BOARD_DIR}/pins.csv")
-    set(GEN_PINS_BOARD_CSV "${MICROPY_BOARD_DIR}/pins.csv")
-    set(GEN_PINS_CSV_ARG --board-csv "${GEN_PINS_BOARD_CSV}")
+if(NOT MICROPY_BOARD_PINS)
+    set(MICROPY_BOARD_PINS "${MICROPY_BOARD_DIR}/pins.csv")
+endif()
+
+if(EXISTS "${MICROPY_BOARD_PINS}")
+    set(GEN_PINS_BOARD_CSV "${MICROPY_BOARD_PINS}")
+    set(GEN_PINS_CSV_ARG --board-csv "${MICROPY_BOARD_PINS}")
 endif()
 
 target_sources(${MICROPY_TARGET} PRIVATE


### PR DESCRIPTION
Allow mpconfigboard.cmake to specify a custom `MICROPY_BOARD_PINS` to override `${MICROPY_BOARD_DIR}/pins.csv`.

### Summary

RP2350 has a "B" variant chip which could conceivably be configured in a board variant (big and small versions) and require its own, separate pins.csv config with the additional pins configured.

This may apply also to W and non-W versions where the CYW43 might need `WL_GPIOn` pins specified but there are otherwise few meaningful changes to justify entirely separate boards.

Finally the RM2 module support added by #16057 might need optional `WL_GPIOn` pins configured for traditionally non-W boards with added support for an external wireless module, though this is contentious since those pins wont be available without an attached module.

This PR is mostly to address point 3, in an effort to make the changeset in #16057 smaller and easier to review.

But it's also counter-intuitive to have support for variants without support for specifying variant versions of config files.

### Testing

TODO! This would need a rebase of #16057 assuming this is even the way we want to approach the problem.

### Trade-offs and Alternatives

I don't think there are any real downsides to this feature, though it should probably be reflected across all CMake-based ports.
