### PR TITLE
ports/rp2: Make linker script configurable.

### DIFF
--- a/ports/rp2/CMakeLists.txt
+++ b/ports/rp2/CMakeLists.txt
@@ -588,12 +588,16 @@ endif()
 # todo this is a bit brittle, but we want to move a few source files into RAM (which requires
 #  a linker script modification) until we explicitly add  macro calls around the function
 #  defs to move them into RAM.
-if (PICO_ON_DEVICE AND NOT PICO_NO_FLASH AND NOT PICO_COPY_TO_RAM)
+if (NOT MICROPY_BOARD_LINKER_SCRIPT)
     if(PICO_RP2040)
-        pico_set_linker_script(${MICROPY_TARGET} ${CMAKE_CURRENT_LIST_DIR}/memmap_mp_rp2040.ld)
+        set(MICROPY_BOARD_LINKER_SCRIPT ${CMAKE_CURRENT_LIST_DIR}/memmap_mp_rp2040.ld)
     elseif(PICO_RP2350)
-        pico_set_linker_script(${MICROPY_TARGET} ${CMAKE_CURRENT_LIST_DIR}/memmap_mp_rp2350.ld)
+        set(MICROPY_BOARD_LINKER_SCRIPT ${CMAKE_CURRENT_LIST_DIR}/memmap_mp_rp2350.ld)
     endif()
+endif()
+
+if (PICO_ON_DEVICE AND NOT PICO_NO_FLASH AND NOT PICO_COPY_TO_RAM)
+    pico_set_linker_script(${MICROPY_TARGET} ${MICROPY_BOARD_LINKER_SCRIPT})
 endif()
 
 pico_add_extra_outputs(${MICROPY_TARGET})


### PR DESCRIPTION
Add MICROPY_BOARD_LINKER_SCRIPT to specify a custom linker script for RP2 boards/variants.

This may, for example, include a PSRAM region so that C buffers or otherwise can be allocated into PSRAM.

### Summary

This is a much leaner version of #8761, but broadly attempts to accomplish some of the same things.

I use this feature (with some small modifications to the PSRAM code shown here: https://github.com/pimoroni/micropython/commit/79d7cc2ac97336847a6765d0ee23b2ef4e97af72) for building Presto with some non-critical C buffers moved to PSRAM so we can fit a large framebuffer in SRAM and use the remaining PSRAM for GC heap.

This change reflects #17028 and aims to bring some edge feature which don't cause too much immediate upset to the MicroPython codebase, but which are useful to those of us pushing weird and experimental things into shipping products 😆

### Testing

Currently a critical part of the Presto build process.

### Trade-offs and Alternatives

As with #17028 it seems reasonable to make linker scripts configurable, however:

1. They are *complicated* (they're composable but not really in a way that makes sense here)
2. There may be precious few uses for this particular feature
3. If the canonical linker script ever changes, then that change must be merged into any boards/variants
