### PR TITLE
esp32/network_common: Raise a memory error on ESP_ERR_NO_MEM.

### DIFF
--- a/ports/esp32/network_common.c
+++ b/ports/esp32/network_common.c
@@ -77,6 +77,8 @@ MP_NORETURN void esp_exceptions_helper(esp_err_t e) {
             mp_raise_msg(&mp_type_OSError, MP_ERROR_TEXT("Wifi Would Block"));
         case ESP_ERR_WIFI_NOT_CONNECT:
             mp_raise_msg(&mp_type_OSError, MP_ERROR_TEXT("Wifi Not Connected"));
+        case ESP_ERR_NO_MEM:
+            mp_raise_msg(&mp_type_OSError, MP_ERROR_TEXT("WiFi Out of Memory"));
         default:
             mp_raise_msg_varg(&mp_type_RuntimeError, MP_ERROR_TEXT("Wifi Unknown Error 0x%04x"), e);
     }


### PR DESCRIPTION
### Summary

This PR changes the error handler for WiFi operations to recognise out of memory conditions reported by ESP-IDF functions, and report them as MemoryError exceptions rather than a generic "error 0x0101".

The error handler only provided a human-readable error description for WiFi-specific error codes (codes in the ESP_ERR_WIFI_BASE range), but WiFi functions are known to return other codes.  Since an out of memory condition has a specific Python equivalent, using `MemoryError` in that case is a bit more user-friendly in exchange for a handful of extra code bytes used by the firmware.

### Testing

The reproduction test case for #17027 was used to make sure an out of memory condition raised by the WiFi component was recognised as such.

### Trade-offs and Alternatives

This change causes a minimal increase of the firmware size, which I believe is an acceptable trade-off from the user's point of view.  After all, an out of memory error is not a "Wifi Unknown Error".