### PR TITLE
mpy_ld.py: Improve error for ARMv6m absolute relocations

### DIFF
--- a/tools/mpy_ld.py
+++ b/tools/mpy_ld.py
@@ -702,9 +702,13 @@ def do_relocation_text(env, text_addr, r):
     elif env.arch.name == "EM_RISCV":
         (addr, value) = process_riscv32_relocation(env, text_addr, r)
 
+    elif env.arch.name == "EM_ARM" and r_info_type == R_ARM_ABS32:
+        # happens for soft-float on armv6m
+        raise ValueError("Absolute relocations not supported on ARM")
+
     else:
         # Unknown/unsupported relocation
-        assert 0, r_info_type
+        assert 0, (r_info_type, s.name, s.entry, env.arch.name)
 
     # Write relocation
     if env.arch.name == "EM_RISCV":


### PR DESCRIPTION
Improved error message for building native modules using soft-float on ARMv6m, which is not supported.

### Testing

Built native modules for armv6m using soft-float, see that new error is raised


