### PR TITLE
esp32/machine.timer.c: Fix timer.value() of an uninitialized timer.

### DIFF
--- a/ports/esp32/machine_timer.c
+++ b/ports/esp32/machine_timer.c
@@ -246,6 +246,9 @@ static MP_DEFINE_CONST_FUN_OBJ_KW(machine_timer_init_obj, 1, machine_timer_init)
 
 static mp_obj_t machine_timer_value(mp_obj_t self_in) {
     machine_timer_obj_t *self = self_in;
+    if (self->handle == NULL) {
+        mp_raise_ValueError(MP_ERROR_TEXT("timer not set"));
+    }
     uint64_t result = timer_ll_get_counter_value(self->hal_context.dev, self->index);
     return MP_OBJ_NEW_SMALL_INT((mp_uint_t)(result / (TIMER_SCALE / 1000))); // value in ms
 }


### PR DESCRIPTION
### Summary

Raises a value error in that case, which happens after a timer was created but not initialized or after calling timer.deinit(). Fixes issue #17033 / #17035.

### Testing

Tested with a ESP32_GENERIC before and after the change, for both a) the state after creating the timer but not initializing it, and b) after calling timer.deinit() on a previously operating timer. In both states, the change causes the error to be raised.

Testing with a generic ESP32 seems to be sufficient, since the change is not specific for a ESP32 variant.

### Trade-offs and Alternatives

Alternatively a neutral value like 0 or -1 could be returned instead of raising an error.