### PR TITLE
docs/esp32/quickref.rst Document that a Pin can be passed to UART constructor on the ESP32 ports.

### DIFF
--- a/docs/esp32/quickref.rst
+++ b/docs/esp32/quickref.rst
@@ -372,6 +372,13 @@ tx     1      10     17
 rx     3      9      16
 =====  =====  =====  =====
 
+You can pass a initialized Pin to ``tx`` and ``rx``::
+
+    from machine import UART, Pin
+
+    uart1 = UART(1, baudrate=9600, tx=Pin( 10, Pin.OPEN_DRAIN ), rx=Pin(9, Pin.IN, Pin.PULL_UP )  )
+
+
 PWM (pulse width modulation)
 ----------------------------
 


### PR DESCRIPTION
### Summary

The ```UART()``` constructor has the  ```tx=``` and ```rx=``` parameters to specify a pin number. On the ESP32 port, an initialized ```machine.Pin()``` object can also be passed. This is useful to specify parameters such as ```mode=Pin.OPEN_DRAIN``` or ```drive=Pin.DRIVE_3```

I could not find the documentation for this neither on the ESP32 specific page (https://docs.micropython.org/en/latest/esp32/quickref.html) nor on the generic UART() page ((https://docs.micropython.org/en/latest/library/machine.UART.html)

### Testing

This is a documentation change only. However, I tested on a ESP32-S3 that ```mode=Pin.OPEN_DRAIN``` and ```drive=Pin.DRIVE_3``` alter the voltages at the UART pins accordingly:
```
txpin = Pin(tx_number, mode=Pin.OUT, drive=Pin.DRIVE_3)
rxpin = Pin(rx_number, mode=Pin.IN)
while True:
      UART( 1, baudrate=baudrate, tx=txpin, rx=rxpin)
      time.sleep(5)
      UART( 1, baudrate=baudrate, tx=txpin, rx=rxpin, invert=UART.INV_TX)
      time.sleep(5)
```

See also discussion #16959
