### PR TITLE
ports/webassembly/proxy_c.c: Allow python `bytes()` to be proxied to/from JS.

### DIFF
--- a/ports/webassembly/proxy_c.c
+++ b/ports/webassembly/proxy_c.c
@@ -173,7 +173,7 @@ mp_obj_t proxy_convert_js_to_mp_obj_cside(uint32_t *value) {
         free((void *)value[2]);
         return s;
     } else if (value[0] == PROXY_KIND_JS_BYTES) {
-        mp_obj_t s = mp_obj_new_bytes((void *) value[2], value[1]);
+        mp_obj_t s = mp_obj_new_bytes((void *)value[2], value[1]);
         free((void *)value[2]);
         return s;
     } else if (value[0] == PROXY_KIND_JS_PYPROXY) {

--- a/ports/webassembly/proxy_c.c
+++ b/ports/webassembly/proxy_c.c
@@ -50,6 +50,7 @@ enum {
     PROXY_KIND_MP_OBJECT = 8,
     PROXY_KIND_MP_JSPROXY = 9,
     PROXY_KIND_MP_EXISTING = 10,
+    PROXY_KIND_MP_BYTES = 11,
 };
 
 enum {
@@ -200,6 +201,14 @@ void proxy_convert_mp_to_js_obj_cside(mp_obj_t obj, uint32_t *out) {
         const char *str = mp_obj_str_get_data(obj, &len);
         out[1] = len;
         out[2] = (uintptr_t)str;
+    } else if (mp_obj_get_type(obj) == &mp_type_bytes) {
+        kind = PROXY_KIND_MP_BYTES;
+        mp_buffer_info_t bufinfo;
+        mp_get_buffer(obj, &bufinfo, MP_BUFFER_READ);
+        size_t len = bufinfo.len;
+        const uint8_t *buf= bufinfo.buf;
+        out[1] = len;
+        out[2] = (uintptr_t)buf;
     } else if (obj == mp_const_undefined) {
         kind = PROXY_KIND_MP_JSPROXY;
         out[1] = 1;

--- a/ports/webassembly/proxy_c.c
+++ b/ports/webassembly/proxy_c.c
@@ -173,8 +173,8 @@ mp_obj_t proxy_convert_js_to_mp_obj_cside(uint32_t *value) {
         free((void *)value[2]);
         return s;
     } else if (value[0] == PROXY_KIND_JS_BYTES) {
-        mp_obj_t s = mp_obj_new_bytes((void*) value[2], value[1]);
-        free((void*)value[2]);
+        mp_obj_t s = mp_obj_new_bytes((void *) value[2], value[1]);
+        free((void *)value[2]);
         return s;
     } else if (value[0] == PROXY_KIND_JS_PYPROXY) {
         return proxy_c_get_obj(value[1]);

--- a/ports/webassembly/proxy_js.js
+++ b/ports/webassembly/proxy_js.js
@@ -41,6 +41,7 @@ const PROXY_KIND_MP_GENERATOR = 7;
 const PROXY_KIND_MP_OBJECT = 8;
 const PROXY_KIND_MP_JSPROXY = 9;
 const PROXY_KIND_MP_EXISTING = 10;
+const PROXY_KIND_MP_BYTES = 11;
 
 const PROXY_KIND_JS_UNDEFINED = 0;
 const PROXY_KIND_JS_NULL = 1;
@@ -264,6 +265,11 @@ function proxy_convert_mp_to_js_obj_jsside(value) {
         const str_len = Module.getValue(value + 4, "i32");
         const str_ptr = Module.getValue(value + 8, "i32");
         obj = Module.UTF8ToString(str_ptr, str_len);
+    } else if (kind == PROXY_KIND_MP_BYTES) {
+        // bytes
+        const buf_len = Module.getValue(value + 4, "i32");
+        const buf_ptr = Module.getValue(value + 8, "i32")
+        obj = new Uint8Array(Module.HEAPU8.buffer, buf_ptr, buf_len);
     } else if (kind === PROXY_KIND_MP_JSPROXY) {
         // js proxy
         const id = Module.getValue(value + 4, "i32");

--- a/ports/webassembly/proxy_js.js
+++ b/ports/webassembly/proxy_js.js
@@ -146,7 +146,7 @@ function proxy_call_python(target, argumentsList) {
         "null",
         ["number", "number", "number", "pointer"],
         [target, argumentsList.length, args, value],
-        {async:true},
+        { async: true },
     );
     if (argumentsList.length > 0) {
         Module._free(args);
@@ -203,11 +203,10 @@ function proxy_convert_js_to_mp_obj_jsside(js_obj, out) {
         kind = PROXY_KIND_JS_BYTES;
         const len = js_obj.length;
         const buf = Module._malloc(len);
-        for(let i = 0; i < len; i++) Module.HEAPU8[buf + i] = js_obj[i];
+        for (let i = 0; i < len; i++) Module.HEAPU8[buf + i] = js_obj[i];
         Module.setValue(out + 4, len, "i32");
         Module.setValue(out + 8, buf, "i32");
-    } else if
-        (
+    } else if (
         js_obj instanceof PyProxy ||
         (typeof js_obj === "function" && "_ref" in js_obj) ||
         js_obj instanceof PyProxyThenable

--- a/ports/webassembly/proxy_js.js
+++ b/ports/webassembly/proxy_js.js
@@ -203,7 +203,7 @@ function proxy_convert_js_to_mp_obj_jsside(js_obj, out) {
         kind = PROXY_KIND_JS_BYTES;
         const len = js_obj.length;
         const buf = Module._malloc(len);
-        for(var i=0;i<len;i++) Module.HEAPU8[buf+i] = js_obj[i];
+        for(let i = 0; i < len; i++) Module.HEAPU8[buf + i] = js_obj[i];
         Module.setValue(out + 4, len, "i32");
         Module.setValue(out + 8, buf, "i32");
     } else if

--- a/ports/webassembly/proxy_js.js
+++ b/ports/webassembly/proxy_js.js
@@ -53,7 +53,6 @@ const PROXY_KIND_JS_OBJECT = 6;
 const PROXY_KIND_JS_PYPROXY = 7;
 const PROXY_KIND_JS_BYTES = 8;
 
-
 class PythonError extends Error {
     constructor(exc_type, exc_details) {
         super(exc_details);


### PR DESCRIPTION
### Summary

This allows python `bytes()` objects to be passed to JS. Example:

```js
 function set_audio_samples(samples) {
     var res_ptr = amy_module._malloc(2 * 256 * 2); // 2 channels, 256 frames, int16s
     amy_module.HEAPU8.set(samples, res_ptr);
     amy_module.ccall('amy_set_input_buffer', null, ["number"], [res_ptr]);
     amy_module._free(res_ptr);
 }
...
 await mp.registerJsModule('amy_set_input_buffer', set_audio_samples);
```

In MP:
```python
buffer = bytes(1024)
# do something to fill in the bytes...
amy_set_input_buffer(buffer)
```

It also works the other way (JS returning bytes() to MP):

```js
 function get_audio_samples() {
     var res_ptr = amy_module._malloc(2 * 256 * 2); // 2 channels, 256 frames, int16s
     amy_module.ccall('amy_get_input_buffer', null, ["number"], [res_ptr]);
     var view = amy_module.HEAPU8.subarray(res_ptr , res_ptr + 1024);
     amy_module._free(res_ptr);
     return view
 }
 await mp.registerJsModule('amy_get_input_buffer', get_audio_samples);
```

```python
>>> b = amy_get_input_buffer()
>>> type(t)
<class 'bytes'>
```

Previously, we would have to manually construct a `js.UInt8Array.new(1024)` and fill it in one by one.

### Testing

Tested on webassembly port.

