### PR TITLE
port esp32 fix for esp-idf v5.5

### DIFF
--- a/ports/esp32/panichandler.c
+++ b/ports/esp32/panichandler.c
@@ -42,11 +42,11 @@
 #endif
 
 void __real_esp_panic_handler(void *);
-void esp_panic_handler_reconfigure_wdts(uint32_t timeout_ms);
+void esp_panic_handler_enable_rtc_wdt(uint32_t timeout_ms);
 void panic_print_str(const char *str);
 
 void MICROPY_WRAP_PANICHANDLER_FUN(__wrap_esp_panic_handler)(void *info) {
-    esp_panic_handler_reconfigure_wdts(1000);
+    esp_panic_handler_enable_rtc_wdt(1000);
 
     const static char *msg = MICROPY_WRAP_PANICHANDLER_STR(
         "\r\n"


### PR DESCRIPTION
The watchdog timer reconfiguration function has been modified. The original function was never meant to be used publicly (https://github.com/espressif/esp-idf/issues/15687)

This CL fixes the build error.


### Summary

port esp32 build fails with the linker error 'undefined reference' (see log below) with esp-idf v5.5


### Testing

Setup esp-idf v5.5
clone micropython from: https://github.com/micropython/micropython
cd <MICROPYTHON_GIT_ROOT>/ports/esp32
get_idf
make submodules
make


### Trade-offs and Alternatives



