### PR TITLE
Docs: Minor amendments to the documentation.

### DIFF
--- a/docs/esp32/quickref.rst
+++ b/docs/esp32/quickref.rst
@@ -284,7 +284,8 @@ with a timer ID of 0, 0 and 1, or from 0 to 3 (inclusive)::
     tim1 = Timer(1)
     tim1.init(period=2000, mode=Timer.PERIODIC, callback=lambda t:print(1))
 
-The period is in milliseconds.
+The period is in milliseconds. When using UART.IRQ_RXIDLE, timer 0 is needed for
+the IRQ_RXIDLE mechanism and must not be used otherwise.
 
 Virtual timers are not currently supported on this port.
 

--- a/docs/esp32/quickref.rst
+++ b/docs/esp32/quickref.rst
@@ -271,8 +271,10 @@ Use the :mod:`time <time>` module::
 Timers
 ------
 
-The ESP32 port has four hardware timers. Use the :ref:`machine.Timer <machine.Timer>` class
-with a timer ID from 0 to 3 (inclusive)::
+The ESP32 port has one, two or four hardware timers, depending on the ESP32 device type.
+There is 1 timer for ESP32C2, 2 timers for ESP32C4, ESP32C6 and ESP32H4, and
+4 timers otherwise. Use the :ref:`machine.Timer <machine.Timer>` class
+with a timer ID of 0, 0 and 1, or from 0 to 3 (inclusive)::
 
     from machine import Timer
 

--- a/docs/library/machine.UART.rst
+++ b/docs/library/machine.UART.rst
@@ -224,7 +224,8 @@ Methods
 
 
    .. note::
-     - The ESP32 port does not support the option hard=True.
+     - The ESP32 port does not support the option hard=True. It uses Timer(0)
+       for UART.IRQ_RXIDLE, so this timer cannot be used for other means.
 
      - The rp2 port's UART.IRQ_TXIDLE is only triggered when the message
        is longer than 5 characters and the trigger happens when still 5 characters

--- a/docs/library/time.rst
+++ b/docs/library/time.rst
@@ -9,9 +9,10 @@
 The ``time`` module provides functions for getting the current time and date,
 measuring time intervals, and for delays.
 
-**Time Epoch**: Unix port uses standard for POSIX systems epoch of
-1970-01-01 00:00:00 UTC. However, some embedded ports use epoch of
-2000-01-01 00:00:00 UTC. Epoch year may be determined with ``gmtime(0)[0]``.
+**Time Epoch**: The unix, windows, webassembly, alif, mimxrt and rp2 ports
+use the standard for POSIX systems epoch of 1970-01-01 00:00:00 UTC.
+The other embedded ports use an epoch of 2000-01-01 00:00:00 UTC.
+Epoch year may be determined with ``gmtime(0)[0]``.
 
 **Maintaining actual calendar date/time**: This requires a
 Real Time Clock (RTC). On systems with underlying OS (including some
@@ -57,11 +58,11 @@ Functions
    * weekday is 0-6 for Mon-Sun
    * yearday is 1-366
 
-.. function:: mktime()
+.. function:: mktime(date_time_tuple)
 
    This is inverse function of localtime. It's argument is a full 8-tuple
    which expresses a time as per localtime. It returns an integer which is
-   the number of seconds since Jan 1, 2000.
+   the number of seconds since the time epoch.
 
 .. function:: sleep(seconds)
 


### PR DESCRIPTION
### Summary

A few documentation updates aiming to clarify topics which confused users.

- Amend the documentation of time.mktime() by showing the argument and refer to epoch instead of a fixed
  date. The note about epoch lists the ports using the POSIX epoch.
- ESP32: Mention the different timer counts show the number of timers for each ESP32 variant.
- ESP32: Mention the use of Timer(0) by UART.IRQ_RXIDLE.

### Testing

Build the HTML version of the documentation.
