### PR TITLE
ports/rp2: Fix rp2 mDNS issue via new cyw43 driver hooks.

### DIFF
--- a/ports/rp2/cyw43_configport.h
+++ b/ports/rp2/cyw43_configport.h
@@ -33,6 +33,7 @@
 #include "py/mphal.h"
 #include "py/runtime.h"
 #include "extmod/modnetwork.h"
+#include "lwip/apps/mdns.h"
 #include "pendsv.h"
 
 #define CYW43_INCLUDE_LEGACY_F1_OVERFLOW_WORKAROUND_VARIABLES (1)
@@ -167,4 +168,19 @@ static inline void cyw43_delay_ms(uint32_t ms) {
 
 #define CYW43_EVENT_POLL_HOOK mp_event_handle_nowait()
 
+#if LWIP_MDNS_RESPONDER == 1
+
+// Hook for any additional TCP/IP initialization than needs to be done.
+// Called after the netif specified by `itf` has been set up.
+#ifndef CYW43_CB_TCPIP_INIT_EXTRA
+#define CYW43_CB_TCPIP_INIT_EXTRA(self, itf) mdns_resp_add_netif(&self->netif[itf], mod_network_hostname_data)
+#endif
+
+// Hook for any additional TCP/IP deinitialization than needs to be done.
+// Called before the netif specified by `itf` is removed.
+#ifndef CYW43_CB_TCPIP_DEINIT_EXTRA
+#define CYW43_CB_TCPIP_DEINIT_EXTRA(self, itf) mdns_resp_remove_netif(&self->netif[itf])
+#endif
+
+#endif
 #endif // MICROPY_INCLUDED_RP2_CYW43_CONFIGPORT_H


### PR DESCRIPTION
### Summary

As a number of users have reported via issues and discussions, the RP2 port of MicroPython has an incomplete mDNS implementation. The code in main.c calls `mdns_resp_init()` which opens the UDP socket for mDNS. However, no code in the cyw43 driver of the RP2 port makes the proper calls to `mdns_resp_add_netif()` and `mdns_resp_remove_netif()` to send the announce packets. The wiznet5k driver does make these calls and was used as a model for these changes.

This PR attempts to address this by very small changes to the `ports/rp2/cyw43_configport.h` file. 

> As far as I can tell this driver is currently used only by the RP2 port. 

The change uses new cyw43 driver hooks to map via driver macros `CYW43_CB_TCPIP_INIT_EXTRA` and `CYW43_CB_TCPIP_DEINIT_EXTRA` to the appropriate LWIP MDNS calls.

### Testing

This was tested by building the firmware and deploying to a PicoW, starting a WLAN connection and pinging PicoW.local from several devices on the local network. I also tested changing the hostname from the default.

### Trade-offs and Alternatives

Alternatively, if this PR is not accepted we should disable the partial implementation by setting `LWIP_MDNS_RESPONDER` to 0 in `lwipopts.h` so that users can implement their own mDNS solutions without E_ADDRINUSE failures. A user should not have to build their own firmware to disable a partial/broken mDNS solution.
