### PR TITLE
tools/gen-cpydiff: Fail CPython difference generation if output matches.

### DIFF
--- a/tests/cpydiff/types_str_endswith.py
+++ b/tests/cpydiff/types_str_endswith.py
@@ -1,8 +1,0 @@
-"""
-categories: Types,str
-description: Start/end indices such as str.endswith(s, start) not implemented
-cause: Unknown
-workaround: Unknown
-"""
-
-print("abc".endswith("c", 1))

--- a/tools/gen-cpydiff.py
+++ b/tools/gen-cpydiff.py
@@ -69,7 +69,6 @@ Output = namedtuple(
         "code",
         "output_cpy",
         "output_upy",
-        "status",
     ],
 )
 
@@ -98,7 +97,7 @@ def readfiles():
                 if not re.match(r"\s*# fmt: (on|off)\s*", x)
             )
 
-            output = Output(test, class_, desc, cause, workaround, code, "", "", "")
+            output = Output(test, class_, desc, cause, workaround, code, "", "")
             files.append(output)
         except IndexError:
             print("Incorrect format in file " + test_fullpath)
@@ -108,6 +107,7 @@ def readfiles():
 
 def run_tests(tests):
     """executes all tests"""
+    same_results = False
     results = []
     for test in tests:
         test_fullpath = os.path.join(TESTPATH, test.name)
@@ -133,23 +133,26 @@ def run_tests(tests):
         output_upy = [com.decode("utf8") for com in process.communicate(input_py)]
 
         if output_cpy[0] == output_upy[0] and output_cpy[1] == output_upy[1]:
-            status = "Supported"
-            print("Supported operation!\nFile: " + test_fullpath)
+            print("Error: Test has same output in CPython vs MicroPython: " + test_fullpath)
+            same_results = True
         else:
-            status = "Unsupported"
+            output = Output(
+                test.name,
+                test.class_,
+                test.desc,
+                test.cause,
+                test.workaround,
+                test.code,
+                output_cpy,
+                output_upy,
+            )
+            results.append(output)
 
-        output = Output(
-            test.name,
-            test.class_,
-            test.desc,
-            test.cause,
-            test.workaround,
-            test.code,
-            output_cpy,
-            output_upy,
-            status,
+    if same_results:
+        raise SystemExit(
+            "Failing due to non-differences in results. If MicroPython behaviour has changed "
+            "to match CPython, please remove the file(s) mentioned above."
         )
-        results.append(output)
 
     results.sort(key=lambda x: x.class_)
     return results


### PR DESCRIPTION
### Summary

MicroPython uses a set of automated test cases (`tests/cpydiff`) to generate documentation of differences between CPython and MicroPython. If a MicroPython improvement made something CPython compatible, the generation tool would print a note but would keep running as normal including generating the "difference" (with the docs containing identical generated output for CPython vs MicroPython).

This PR adjusts the generation tool to fail if any differences are non-existent (which should also fail CI), and also removes one fixed difference (`str.endswith()` was made compatible as of #16812 :tada:).

### Testing

* Ran the docs build and generation tool locally, verified the new failure due to a non-difference and non-failure after removing.

### Trade-offs and Alternatives

* We could make this behaviour configurable in `gen-cpydiff.py`, but this tool is only ever run to generate this output for the docs and almost all of the other behaviour is hard-coded for this purpose.