### PR TITLE
doc: Update CPython difference for assign expression in nested comprehensions.

### DIFF
--- a/tests/cpydiff/syntax_assign_expr.py
+++ b/tests/cpydiff/syntax_assign_expr.py
@@ -1,8 +1,8 @@
 """
 categories: Syntax,Operators
-description: MicroPython allows using := to assign to the variable of a comprehension, CPython raises a SyntaxError.
-cause: MicroPython is optimised for code size and doesn't check this case.
-workaround: Do not rely on this behaviour if writing CPython compatible code.
+description: MicroPython allows := to assign to the iteration variable in nested comprehensions, CPython does not.
+cause: MicroPython is optimised for code size. Although it is a syntax error to assign to the iteration variable in a standard comprehension (same as CPython), it doesn't check if an inner nested comprehension assigns to the iteration variable of the outer comprehension.
+workaround: Do not use := to assign to the iteration variable of a comprehension.
 """
 
-print([i := -1 for i in range(4)])
+print([[(j := i) for i in range(2)] for j in range(2)])


### PR DESCRIPTION
### Summary

Since 7c1584aef10f80aabfeba242892ec5f85c57bead MicroPython matches CPython in most cases of assigning to a comprehension variable, apart from in nested comprehensions. Both [generated examples in the current version of the docs](https://docs.micropython.org/en/latest/genrst/syntax.html#micropython-allows-using-to-assign-to-the-variable-of-a-comprehension-cpython-raises-a-syntaxerror) are SyntaxErrors with different error text.

Updates the test case to only show the remaining difference, updates the recommendation to a more blanket recommendation to not do this.

*This work was funded through GitHub Sponsors.*

### Trade-Offs and Alternatives

Investigating this was my original reason to look into #17060, and I was going to update `gen-cypdiff.py` to also fail if a test case raises an exception on both MicroPython and CPython. However some of the "exceptions" test cases do both raise an exception (from which the interpreter prints different output), and there's no easy way to rewrite them.

