### PR TITLE
stm32/PYBD_SFx: restart qspi memory-map mode on startup to reduce power consumption

### DIFF
--- a/ports/stm32/boards/PYBD_SF2/board_init.c
+++ b/ports/stm32/boards/PYBD_SF2/board_init.c
@@ -61,6 +61,16 @@ void board_early_init(void) {
 
 #if !BUILDING_MBOOT
 
+#include "boardctrl.h"
+#include "qspi.h"
+
+int board_run_boot_py(boardctrl_state_t *state) {
+    // Due to errata 2.4.3, restart memory-mapped mode to deactivate the CS line and save power.
+    qspi_memory_map_restart();
+
+    return boardctrl_run_boot_py(state);
+}
+
 void board_sleep(int value) {
     mp_spiflash_deepsleep(&spi_bdev.spiflash, value);
     mp_spiflash_deepsleep(&spi_bdev2.spiflash, value);

--- a/ports/stm32/boards/PYBD_SF2/mpconfigboard.h
+++ b/ports/stm32/boards/PYBD_SF2/mpconfigboard.h
@@ -43,11 +43,14 @@
 #define MICROPY_HW_ENABLE_RF_SWITCH (1)
 
 #define MICROPY_BOARD_EARLY_INIT    board_early_init
+#define MICROPY_BOARD_RUN_BOOT_PY   board_run_boot_py
 #define MICROPY_BOARD_ENTER_STOP    board_sleep(1);
 #define MICROPY_BOARD_LEAVE_STOP    board_sleep(0);
 #define MICROPY_BOARD_ENTER_STANDBY board_sleep(1);
 #define MICROPY_BOARD_SDCARD_POWER  mp_hal_pin_high(pyb_pin_EN_3V3);
+struct _boardctrl_state_t;
 void board_early_init(void);
+int board_run_boot_py(struct _boardctrl_state_t *state);
 void board_sleep(int value);
 
 // HSE is 25MHz, run SYS at 120MHz

--- a/ports/stm32/qspi.h
+++ b/ports/stm32/qspi.h
@@ -35,6 +35,8 @@ extern const mp_qspi_proto_t qspi_proto;
 
 void qspi_init(void);
 void qspi_memory_map(void);
+void qspi_memory_map_exit(void);
+void qspi_memory_map_restart(void);
 
 static inline bool qspi_is_valid_addr(uint32_t addr) {
     return QSPI_MAP_ADDR <= addr && addr < QSPI_MAP_ADDR_MAX;


### PR DESCRIPTION
### Summary

The PYBD boards use an F7xx which has an errata 2.4.3:

    Memory-mapped read operations may fail when timeout counter is enabled

This is unfortunate because it means that once QSPI memory-mapped flash is accessed the QSPI peripheral will leave the CS pin active (low) forever, which increases power consumption of the SPI flash chip (because it's active and waiting for commands).  The exact amount of power increase depends on the flash, but the PYBD_SFx increase by about 2.5mA.

Previously this increase in power only happened when QSPI flash was needed, eg on PYBD_SF2 when mbedtls or nimble libraries were used.  On PYBD_SF6 it's actually never used.

But with the introduction of ROMFS which lives in the QSPI flash, the memory is always access on start up to see if the ROMFS contains a valid image (it must read the memory to find out).  That means these boards always consume about 2.5mA more after starting up.

The fix in this PR is to explicitly restart the QSPI memory mapped mode during the start up process.  More precisely the restart is done after querying the ROMFS and just before trying to execute `boot.py`.  That's the right location to keep power consumption permanently down if the QSPI is never used (eg ROMFS image doesn't exist).

### Testing

Tested on PYBD_SF2 and PYBD_SF6.

It's possible to trigger the higher power consumption via `machine.mem32[0x90000000]` (or `mpremote romfs query`).  Then get it back down again by doing a soft reset (or `mpremote soft-reset`).

### Trade-offs and Alternatives

There could be a possible race condition if the QSPI memory is in use when it gets restarted.  But I convinced myself that's not possible on PYBD_SFx because there should be no interrupts (or other user code at thread level) running during start up that accesses the QSPI mapped flash.

If a user has custom C code that does need QSPI memory mapped flash during start up, they can easily disable this restart feature by redefining `MICROPY_BOARD_RUN_BOOT_PY`.

