### PR TITLE
rp2: Fix linker issue with gap alignment on CI.

### DIFF
--- a/tools/ci.sh
+++ b/tools/ci.sh
@@ -22,6 +22,15 @@ function ci_gcc_riscv_setup {
     riscv64-unknown-elf-gcc --version
 }
 
+function ci_picotool_setup {
+    # Manually installing picotool ensures we use a release version, and speeds up the build.
+    git clone https://github.com/raspberrypi/pico-sdk.git
+    (cd pico-sdk && git submodule update --init lib/mbedtls)
+    git clone https://github.com/raspberrypi/picotool.git
+    (cd picotool && mkdir build && cd build && cmake -DPICO_SDK_PATH=../../pico-sdk .. && make && sudo make install)
+    picotool version
+}
+
 ########################################################################################
 # c code formatting
 
@@ -62,6 +71,7 @@ function ci_code_size_setup {
     gcc --version
     ci_gcc_arm_setup
     ci_gcc_riscv_setup
+    ci_picotool_setup
 }
 
 function ci_code_size_build {
@@ -355,6 +365,7 @@ function ci_renesas_ra_board_build {
 
 function ci_rp2_setup {
     ci_gcc_arm_setup
+    ci_picotool_setup
 }
 
 function ci_rp2_build {


### PR DESCRIPTION
### Summary

Rp2 CI recently broke, I think due to the runner being updated from `ubuntu-24.04.01` to  `ubuntu-24.04.02`.  GCC remained unchanged but maybe the linker changed.

The CI fails like this:
```
[ 97%] Building C object CMakeFiles/firmware.dir/home/runner/work/micropython/micropython/micropython_repo/lib/pico-sdk/src/rp2_common/cmsis/stub/CMSIS/Device/RP2040/Source/system_RP2040.c.o
[ 98%] Linking CXX executable firmware.elf
ERROR: Cannot plug gap greater than alignment - gap 253876, alignment 32
make[3]: *** [CMakeFiles/firmware.dir/build.make:7195: firmware.elf] Error 253
make[3]: *** Deleting file 'firmware.elf'
make[3]: Leaving directory '/home/runner/work/micropython/micropython/micropython repo/ports/rp2/build-RPI_PICO'
make[2]: *** [CMakeFiles/Makefile2:2228: CMakeFiles/firmware.dir/all] Error 2
make[2]: Leaving directory '/home/runner/work/micropython/micropython/micropython repo/ports/rp2/build-RPI_PICO'
make[1]: *** [Makefile:91: all] Error 2
make[1]: Leaving directory '/home/runner/work/micropython/micropython/micropython repo/ports/rp2/build-RPI_PICO'
-e See https://github.com/micropython/micropython/wiki/Build-Troubleshooting
make: *** [Makefile:65: all] Error 1
make: Leaving directory '/home/runner/work/micropython/micropython/micropython repo/ports/rp2'
```

### Testing

CI will test this fix.