### PR TITLE
cpydiff: Document differences in errno and OSError.

### DIFF
--- a/tests/cpydiff/modules_errno_enotsup.py
+++ b/tests/cpydiff/modules_errno_enotsup.py
@@ -1,0 +1,10 @@
+"""
+categories: Modules,errno
+description: MicroPython does not include ``ENOTSUP`` as a name for errno 95.
+cause: MicroPython does not implement the ``ENOTSUP`` canonical alias for ``EOPNOTSUPP`` added in CPython 3.2.
+workaround: Use ``errno.EOPNOTSUPP`` in place of ``errno.ENOTSUP``.
+"""
+
+import errno
+
+print(f"{errno.errorcode[errno.EOPNOTSUPP]=!s}")

--- a/tests/cpydiff/types_oserror_errnomap.py
+++ b/tests/cpydiff/types_oserror_errnomap.py
@@ -1,0 +1,48 @@
+"""
+categories: Types,OSError
+description: OSError constructor returns a plain OSError for all errno values, rather than a relevant subtype.
+cause: MicroPython does not include the CPython-standard OSError subclasses.
+workaround: Catch OSError and use its errno attribute to discriminate the cause.
+"""
+
+import errno
+
+errno_list = [  # i.e. the set implemented by micropython
+    errno.EPERM,
+    errno.ENOENT,
+    errno.EIO,
+    errno.EBADF,
+    errno.EAGAIN,
+    errno.ENOMEM,
+    errno.EACCES,
+    errno.EEXIST,
+    errno.ENODEV,
+    errno.EISDIR,
+    errno.EINVAL,
+    errno.EOPNOTSUPP,
+    errno.EADDRINUSE,
+    errno.ECONNABORTED,
+    errno.ECONNRESET,
+    errno.ENOBUFS,
+    errno.ENOTCONN,
+    errno.ETIMEDOUT,
+    errno.ECONNREFUSED,
+    errno.EHOSTUNREACH,
+    errno.EALREADY,
+    errno.EINPROGRESS,
+]
+
+
+def errno_output_type(n):
+    try:
+        raise OSError(n, "")
+    except OSError as e:
+        return f"{type(e).__name__}"
+    except Exception as e:
+        return f"non-OSError {type(e).__name__}"
+    else:
+        return "no error"
+
+
+for n in errno_list:
+    print(errno.errorcode[n], "=", errno_output_type(n))


### PR DESCRIPTION
### Summary

This PR documents the lack of OSError subtype dispatch.

This PR also includes another minor cpydiff I discovered while testing the former, to highlight the difference in the name for Errno 95: EOPNOTSUPP vs ENOTSUP.

### Testing

I've tested these cpydiffs on both unix and rp2, and can confirm they detect the difference in question. No other existing cpydiffs that I've been able to find appear to cover this difference.

### Trade-Offs

The latter test is technically redundant, as the difference it reports also occurs in the diff output of the former -- but it's also much more succinct and communicates the difference it checks for much more clearly.

### References
- [PEP 3151 – Reworking the OS and IO exception hierarchy](https://peps.python.org/pep-3151/)
- https://github.com/python/cpython/blob/e80ed2cf75384bab09e70f0f04d17e92183fdf12/Objects/exceptions.c#L2093-L2103
- python/cpython#107486
- https://docs.python.org/3/library/errno.html#errno.ENOTSUP