### PR TITLE
mpremote: Refactor error handling to apply generically to any errno.

### DIFF
--- a/tools/mpremote/mpremote/commands.py
+++ b/tools/mpremote/mpremote/commands.py
@@ -393,12 +393,8 @@ def do_filesystem(state, args):
                     )
                 else:
                     do_filesystem_cp(state, path, cp_dest, len(paths) > 1, not args.force)
-    except FileNotFoundError as er:
-        raise CommandError("{}: {}: No such file or directory.".format(command, er.args[0]))
-    except IsADirectoryError as er:
-        raise CommandError("{}: {}: Is a directory.".format(command, er.args[0]))
-    except FileExistsError as er:
-        raise CommandError("{}: {}: File exists.".format(command, er.args[0]))
+    except OSError as er:
+        raise CommandError("{}: {}: {}.".format(command, er.strerror, os.strerror(er.errno)))
     except TransportError as er:
         raise CommandError("Error with transport:\n{}".format(er.args[0]))
 

--- a/tools/mpremote/mpremote/transport.py
+++ b/tools/mpremote/mpremote/transport.py
@@ -56,7 +56,10 @@ listdir_result = namedtuple("dir_result", ["name", "st_mode", "st_ino", "st_size
 # raises it as the corresponding OSError-derived exception.
 def _convert_filesystem_error(e, info):
     if "OSError" in e.error_output:
-        for code, estr in errno.errorcode.items():
+        for code, estr in [
+            *errno.errorcode.items(),
+            (errno.EOPNOTSUPP, "EOPNOTSUPP"),
+        ]:
             if estr in e.error_output:
                 return OSError(code, info)
     return e

--- a/tools/mpremote/mpremote/transport.py
+++ b/tools/mpremote/mpremote/transport.py
@@ -55,18 +55,10 @@ listdir_result = namedtuple("dir_result", ["name", "st_mode", "st_ino", "st_size
 # Takes a Transport error (containing the text of an OSError traceback) and
 # raises it as the corresponding OSError-derived exception.
 def _convert_filesystem_error(e, info):
-    if "OSError" in e.error_output and "ENOENT" in e.error_output:
-        return FileNotFoundError(info)
-    if "OSError" in e.error_output and "EISDIR" in e.error_output:
-        return IsADirectoryError(info)
-    if "OSError" in e.error_output and "EEXIST" in e.error_output:
-        return FileExistsError(info)
-    if "OSError" in e.error_output and "ENODEV" in e.error_output:
-        return FileNotFoundError(info)
-    if "OSError" in e.error_output and "EINVAL" in e.error_output:
-        return OSError(errno.EINVAL, info)
-    if "OSError" in e.error_output and "EPERM" in e.error_output:
-        return OSError(errno.EPERM, info)
+    if "OSError" in e.error_output:
+        for code, estr in errno.errorcode.items():
+            if estr in e.error_output:
+                return OSError(code, info)
     return e
 
 

--- a/tools/mpremote/tests/test_errno.sh
+++ b/tools/mpremote/tests/test_errno.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+set -e
+
+# Special ErrorFS so the test can induce arbitrary filesystem errors.
+cat << EOF > "${TMP}/fs.py"
+import os, vfs, errno
+
+class ErrorFS:
+    def mount(self, *a, **k):
+        pass
+    def umount(self, *a, **k):
+        pass
+    def chdir(self, *a, **k):
+        pass
+    def open(self, *a, **k):
+        raise self.error
+
+fs = ErrorFS()
+vfs.mount(fs, '/fs')
+os.chdir('/fs')
+EOF
+
+$MPREMOTE run "${TMP}/fs.py"
+
+echo -----
+$MPREMOTE resume exec "fs.error = Exception()"
+(
+  $MPREMOTE resume cat :Exception.py || echo "expect error"
+) 2> >(head -n1 >&2) # discard traceback specifics but keep main error message
+
+for errno in ENOENT EISDIR EEXIST ENODEV EINVAL EPERM EOPNOTSUPP ; do
+echo -----
+$MPREMOTE resume exec "fs.error = OSError(errno.$errno, '')"
+$MPREMOTE resume cat :$errno.py || echo "expect error"
+done
+
+echo -----
+$MPREMOTE resume exec "vfs.umount('/fs')"

--- a/tools/mpremote/tests/test_errno.sh.exp
+++ b/tools/mpremote/tests/test_errno.sh.exp
@@ -1,0 +1,25 @@
+-----
+mpremote: Error with transport:
+expect error
+-----
+mpremote: cat: ENOENT.py: No such file or directory.
+expect error
+-----
+mpremote: cat: EISDIR.py: Is a directory.
+expect error
+-----
+mpremote: cat: EEXIST.py: File exists.
+expect error
+-----
+mpremote: cat: ENODEV.py: No such device.
+expect error
+-----
+mpremote: cat: EINVAL.py: Invalid argument.
+expect error
+-----
+mpremote: cat: EPERM.py: Operation not permitted.
+expect error
+-----
+mpremote: cat: EOPNOTSUPP.py: Operation not supported.
+expect error
+-----


### PR DESCRIPTION
### Summary

This rewrites the code that previously manually emitted and caught various `OSError` subclasses with equivalent code that uses the errno name dictionary to do this generically, and updates the exception handler in `do_filesystem` to catch them in a similarly-generic fashion using `os.strerror` to retrieve an appropriate error message text equivalent to the current messages.


Note that in the CPython environments where mpremote runs, the call to the `OSError` constructor _already returns an instance of the corresponding mapped exception subtype_.

That is, this code:

```python
raise PermissionError(errno.EPERM, '')
```

is _exactly_ equivalent to:

```python
raise OSError(errno.EPERM, '')
```
 
i.e. they both raise a `PermissionError(1, '')` error.

(See also: #17088, documenting this difference with micropython.)

### Testing

This PR adds an automated test script, `test_errno.sh`. It includes test cases for all of the errnos that were previously special-cased and for raw TransportErrors not wrapping any OSError.

I've tested running the full mpremote test suite, including this new script against rp2040 and rp2350 targets, and have performed additional manual tests of all of the existing exception cases to make sure they were covered.

Manual testing also led to the discovery of the [modules_errno_enotsup.py](https://github.com/micropython/micropython/pull/17088/files#diff-ecb9788a74be865a5c79ff47ebda69bffb0ca106d8cf675e51586345b2fc4231) cpydiff submitted in #17088. I've also added a test to ensure mpremote correctly handles this corner case.

### Trade-offs and Alternatives

This PR removes the conversion from `errno.ENODEV` into `FileNotFoundError`; see https://github.com/micropython/micropython/pull/17090#discussion_r2049376106 for a discussion of the rationale.

This PR subtly changes the spelling of some of the error messages that get reported when filesystem operations fail. This may break external tools that depend on those specific spellings may break; such usages arguably deserve to break, but this change also inadvertently makes mpremote compatible with any other pre-existing jank that expects the CPython error spellings.

Many of the errors this code scans for in the mpremote output are ones that micropython could never generate. This is a mild performance pessimization. I previously suspected that this might also broaden a correctness issue around injecting errno symbol names into file paths, however I've tested and verified that no such vulnerability exists.