### PR TITLE
tools/mpy_ld.py: Resolve fixed-address symbols if requested.

### DIFF
--- a/docs/develop/natmod.rst
+++ b/docs/develop/natmod.rst
@@ -81,7 +81,14 @@ Linker limitation: the native module is not linked against the symbol table of t
 full MicroPython firmware.  Rather, it is linked against an explicit table of exported
 symbols found in ``mp_fun_table`` (in ``py/nativeglue.h``), that is fixed at firmware
 build time.  It is thus not possible to simply call some arbitrary HAL/OS/RTOS/system
-function, for example.
+function, for example, unless that resides at a fixed address. In that case, the path
+of a linkerscript containing a series of symbol names and their fixed address can be
+passed to ``mpy_ld.py`` via the ``--externs`` command line argument. That way symbols
+appearing in the linkerscript will take precedence over what is provided from object
+files, but at the moment the object files' implementation will still reside in the
+final MPY file. The linkerscript parser is limited in its capabilities, and is
+currently used only for parsing the ESP8266 port ROM symbols list (see
+``ports/esp8266/boards/eagle.rom.addr.v6.ld``).
 
 New symbols can be added to the end of the table and the firmware rebuilt.
 The symbols also need to be added to ``tools/mpy_ld.py``'s ``fun_table`` dict in the

--- a/examples/natmod/btree/Makefile
+++ b/examples/natmod/btree/Makefile
@@ -8,7 +8,7 @@ MOD = btree_$(ARCH)
 SRC = btree_c.c
 
 # Architecture to build for (x86, x64, armv7m, xtensa, xtensawin, rv32imc)
-ARCH = x64
+ARCH ?= x64
 
 BTREE_DIR = $(MPY_DIR)/lib/berkeley-db-1.xx
 BERKELEY_DB_CONFIG_FILE ?= \"extmod/berkeley-db/berkeley_db_config_port.h\"
@@ -31,6 +31,10 @@ SRC += $(addprefix $(realpath $(BTREE_DIR))/,\
 	btree/bt_utils.c \
 	mpool/mpool.c \
 	)
+
+ifeq ($(ARCH),xtensa)
+MPY_EXTERN_SYM_FILE=$(MPY_DIR)/ports/esp8266/boards/eagle.rom.addr.v6.ld
+endif
 
 include $(MPY_DIR)/py/dynruntime.mk
 

--- a/examples/natmod/deflate/Makefile
+++ b/examples/natmod/deflate/Makefile
@@ -8,6 +8,12 @@ MOD = deflate_$(ARCH)
 SRC = deflate.c
 
 # Architecture to build for (x86, x64, armv7m, xtensa, xtensawin, rv32imc)
-ARCH = x64
+ARCH ?= x64
+
+ifeq ($(ARCH),xtensa)
+# Link with libm.a and libgcc.a from the toolchain
+LINK_RUNTIME = 1
+MPY_EXTERN_SYM_FILE=$(MPY_DIR)/ports/esp8266/boards/eagle.rom.addr.v6.ld
+endif
 
 include $(MPY_DIR)/py/dynruntime.mk

--- a/examples/natmod/framebuf/Makefile
+++ b/examples/natmod/framebuf/Makefile
@@ -8,6 +8,10 @@ MOD = framebuf_$(ARCH)
 SRC = framebuf.c
 
 # Architecture to build for (x86, x64, armv7m, xtensa, xtensawin)
-ARCH = x64
+ARCH ?= x64
+
+ifeq ($(ARCH),xtensa)
+MPY_EXTERN_SYM_FILE=$(MPY_DIR)/ports/esp8266/boards/eagle.rom.addr.v6.ld
+endif
 
 include $(MPY_DIR)/py/dynruntime.mk

--- a/examples/natmod/random/Makefile
+++ b/examples/natmod/random/Makefile
@@ -8,6 +8,10 @@ MOD = random_$(ARCH)
 SRC = random.c
 
 # Architecture to build for (x86, x64, armv7m, xtensa, xtensawin, rv32imc)
-ARCH = x64
+ARCH ?= x64
+
+ifeq ($(ARCH),xtensa)
+MPY_EXTERN_SYM_FILE=$(MPY_DIR)/ports/esp8266/boards/eagle.rom.addr.v6.ld
+endif
 
 include $(MPY_DIR)/py/dynruntime.mk

--- a/ports/esp8266/mpconfigport.h
+++ b/ports/esp8266/mpconfigport.h
@@ -117,6 +117,9 @@
 #define MICROPY_FATFS_LFN_CODE_PAGE    437 /* 1=SFN/ANSI 437=LFN/U.S.(OEM) */
 #define MICROPY_ESP8266_APA102         (1)
 
+// Print error information at reboot time if the board crashed.
+#define MICROPY_HW_HARD_FAULT_DEBUG    (0)
+
 // No blocking wait-for-event on ESP8266, only non-blocking pump of the "OS" event
 // loop
 //

--- a/py/dynruntime.mk
+++ b/py/dynruntime.mk
@@ -172,6 +172,9 @@ endif
 endif
 MPY_LD_FLAGS += $(addprefix -l, $(LIBGCC_PATH) $(LIBM_PATH))
 endif
+ifneq ($(MPY_EXTERN_SYM_FILE),)
+MPY_LD_FLAGS += --externs "$(realpath $(MPY_EXTERN_SYM_FILE))"
+endif
 
 CFLAGS += $(CFLAGS_EXTRA)
 

--- a/tests/run-natmodtests.py
+++ b/tests/run-natmodtests.py
@@ -73,6 +73,7 @@ class __FS:
     return __File()
 vfs.mount(__FS(), '/__remote')
 sys.path.insert(0, '/__remote')
+{import_prelude}
 sys.modules['{}'] = __import__('__injected')
 """
 
@@ -133,6 +134,13 @@ def detect_architecture(target):
 
 
 def run_tests(target_truth, target, args, stats, resolved_arch):
+    global injected_import_hook_code
+
+    prelude = ""
+    if args.begin:
+        prelude = args.begin.read()
+    injected_import_hook_code = injected_import_hook_code.replace("{import_prelude}", prelude)
+
     for test_file in args.files:
         # Find supported test
         test_file_basename = os.path.basename(test_file)
@@ -211,6 +219,13 @@ def main():
     )
     cmd_parser.add_argument(
         "-a", "--arch", choices=AVAILABLE_ARCHS, help="override native architecture of the target"
+    )
+    cmd_parser.add_argument(
+        "-b",
+        "--begin",
+        type=argparse.FileType("rt"),
+        default=None,
+        help="prologue python file to execute before module import",
     )
     cmd_parser.add_argument("files", nargs="*", help="input test files")
     args = cmd_parser.parse_args()

--- a/tools/ci.sh
+++ b/tools/ci.sh
@@ -524,22 +524,11 @@ function ci_native_mpy_modules_build {
     else
         arch=$1
     fi
-    for natmod in features1 features3 features4 heapq re
+    for natmod in deflate features1 features3 features4 framebuf heapq random re
     do
         make -C examples/natmod/$natmod clean
         make -C examples/natmod/$natmod ARCH=$arch
     done
-
-    # deflate, framebuf, and random currently cannot build on xtensa due to
-    # some symbols that have been removed from the compiler's runtime, in
-    # favour of being provided from ROM.
-    if [ $arch != "xtensa" ]; then
-        for natmod in deflate framebuf random
-        do
-            make -C examples/natmod/$natmod clean
-            make -C examples/natmod/$natmod ARCH=$arch
-        done
-    fi
 
     # features2 requires soft-float on armv7m, rv32imc, and xtensa.  On armv6m
     # the compiler generates absolute relocations in the object file
@@ -551,10 +540,8 @@ function ci_native_mpy_modules_build {
         make -C examples/natmod/features2 ARCH=$arch
     fi
 
-    # btree requires thread local storage support on rv32imc, whilst on xtensa
-    # it relies on symbols that are provided from ROM but not exposed to
-    # natmods at the moment.
-    if [ $arch != "rv32imc" ] && [ $arch != "xtensa" ]; then
+    # btree requires thread local storage support on rv32imc.
+    if [ $arch != "rv32imc" ]; then
         make -C examples/natmod/btree clean
         make -C examples/natmod/btree ARCH=$arch
     fi

--- a/tools/ci.sh
+++ b/tools/ci.sh
@@ -526,14 +526,14 @@ function ci_native_mpy_modules_build {
     fi
     for natmod in deflate features1 features3 features4 framebuf heapq random re
     do
-        make -C examples/natmod/$natmod clean
+        make -C examples/natmod/$natmod ARCH=$arch clean
         make -C examples/natmod/$natmod ARCH=$arch
     done
 
     # features2 requires soft-float on armv7m, rv32imc, and xtensa.  On armv6m
     # the compiler generates absolute relocations in the object file
     # referencing soft-float functions, which is not supported at the moment.
-    make -C examples/natmod/features2 clean
+    make -C examples/natmod/features2 ARCH=$arch clean
     if [ $arch = "rv32imc" ] || [ $arch = "armv7m" ] || [ $arch = "xtensa" ]; then
         make -C examples/natmod/features2 ARCH=$arch MICROPY_FLOAT_IMPL=float
     elif [ $arch != "armv6m" ]; then
@@ -542,7 +542,7 @@ function ci_native_mpy_modules_build {
 
     # btree requires thread local storage support on rv32imc.
     if [ $arch != "rv32imc" ]; then
-        make -C examples/natmod/btree clean
+        make -C examples/natmod/btree ARCH=$arch clean
         make -C examples/natmod/btree ARCH=$arch
     fi
 }

--- a/tools/mpy_ld.py
+++ b/tools/mpy_ld.py
@@ -402,6 +402,7 @@ class LinkEnv:
         self.known_syms = {}  # dict of symbols that are defined
         self.unresolved_syms = []  # list of unresolved symbols
         self.mpy_relocs = []  # list of relocations needed in the output .mpy file
+        self.externs = {}  # dict of externally-defined symbols
 
     def check_arch(self, arch_name):
         if arch_name != self.arch.name:
@@ -491,10 +492,14 @@ def populate_got(env):
         sym = got_entry.sym
         if hasattr(sym, "resolved"):
             sym = sym.resolved
-        sec = sym.section
-        addr = sym["st_value"]
-        got_entry.sec_name = sec.name
-        got_entry.link_addr += sec.addr + addr
+        if sym.name in env.externs:
+            got_entry.sec_name = ".external.fixed_addr"
+            got_entry.link_addr = env.externs[sym.name]
+        else:
+            sec = sym.section
+            addr = sym["st_value"]
+            got_entry.sec_name = sec.name
+            got_entry.link_addr += sec.addr + addr
 
     # Get sorted GOT, sorted by external, text, rodata, bss so relocations can be combined
     got_list = sorted(
@@ -520,6 +525,9 @@ def populate_got(env):
             dest = int(got_entry.name.split("+")[1], 16) // env.arch.word_size
         elif got_entry.sec_name == ".external.mp_fun_table":
             dest = got_entry.sym.mp_fun_table_offset
+        elif got_entry.sec_name == ".external.fixed_addr":
+            # Fixed-address symbols should not be relocated.
+            continue
         elif got_entry.sec_name.startswith(".text"):
             dest = ".text"
         elif got_entry.sec_name.startswith(".rodata"):
@@ -1207,12 +1215,24 @@ def link_objects(env, native_qstr_vals_len):
             sym.section = env.obj_table_section
         elif sym.name in env.known_syms:
             sym.resolved = env.known_syms[sym.name]
+        elif sym.name in env.externs:
+            # Fixed-address symbols do not need pre-processing.
+            continue
         else:
             if sym.name in fun_table:
                 sym.section = mp_fun_table_sec
                 sym.mp_fun_table_offset = fun_table[sym.name]
             else:
                 undef_errors.append("{}: undefined symbol: {}".format(sym.filename, sym.name))
+
+    for sym in env.externs:
+        if sym in env.known_syms:
+            log(
+                LOG_LEVEL_1,
+                "Symbol {} is a fixed-address symbol at {:08x} and is also provided from an object file".format(
+                    sym, env.externs[sym]
+                ),
+            )
 
     if undef_errors:
         raise LinkError("\n".join(undef_errors))
@@ -1456,6 +1476,9 @@ def do_link(args):
     log(LOG_LEVEL_2, "qstr vals: " + ", ".join(native_qstr_vals))
     env = LinkEnv(args.arch)
     try:
+        if args.externs:
+            env.externs = parse_linkerscript(args.externs)
+
         # Load object files
         for fn in args.files:
             with open(fn, "rb") as f:
@@ -1484,6 +1507,50 @@ def do_link(args):
         sys.exit(1)
 
 
+def parse_linkerscript(source):
+    # This extracts fixed-address symbol lists from linkerscripts, only parsing
+    # a small subset of all possible directives.  Right now the only
+    # linkerscript file this is really tested against is the ESP8266's builtin
+    # ROM functions list ($SDK/ld/eagle.rom.addr.v6.ld).
+    #
+    # The parser should be able to handle symbol entries inside ESP-IDF's ROM
+    # symbol lists for the ESP32 range of MCUs as well (see *.ld files in
+    # $SDK/components/esp_rom/<name>/).
+
+    symbols = {}
+
+    LINE_REGEX = re.compile(
+        r'^(?P<weak>PROVIDE\()?'  # optional weak marker start
+        r'(?P<symbol>[a-zA-Z_]\w*)'  # symbol name
+        r'=0x(?P<address>[\da-fA-F]{1,8})*'  # symbol address
+        r'(?(weak)\));$',  # optional weak marker end and line terminator
+        re.ASCII,
+    )
+
+    inside_comment = False
+    for line in (line.strip() for line in source.readlines()):
+        if line.startswith('/*') and not inside_comment:
+            if not line.endswith('*/'):
+                inside_comment = True
+            continue
+        if inside_comment:
+            if line.endswith('*/'):
+                inside_comment = False
+            continue
+        if line.startswith('//'):
+            continue
+        match = LINE_REGEX.match(''.join(line.split()))
+        if not match:
+            continue
+        tokens = match.groupdict()
+        symbol = tokens['symbol']
+        address = int(tokens['address'], 16)
+        if symbol in symbols:
+            raise ValueError(f"Symbol {symbol} already defined")
+        symbols[symbol] = address
+    return symbols
+
+
 def main():
     import argparse
 
@@ -1499,6 +1566,13 @@ def main():
     )
     cmd_parser.add_argument(
         "--output", "-o", default=None, help="output .mpy file (default to input with .o->.mpy)"
+    )
+    cmd_parser.add_argument(
+        "--externs",
+        "-e",
+        type=argparse.FileType("rt"),
+        default=None,
+        help="linkerscript providing fixed-address symbols to augment symbol resolution",
     )
     cmd_parser.add_argument("files", nargs="+", help="input files")
     args = cmd_parser.parse_args()


### PR DESCRIPTION
### Summary

This PR lets mpy_ld.py resolve symbols not only from the object files involved in the linking process, or from compiler supplied static libraries, but also from a list of symbols referenced by an absolute address (usually provided by the system's ROM).

This is needed for Xtensa/LX106 targets as some C stdlib functions are provided by the MCU's own ROM code to reduce the final code footprint.  Given that there are different methods to reference external symbols for different processors, this change is currently limited to the Xtensa target and it and it will need further modifications to be adapted to other targets.

Natmod builds can set the `EXTERN_SYMS` variable pointing to a file containing a series of symbols and their absolute address if they want to provide external symbols to the resolution process.  Each line must contain two whitespace-separated fields, the name and its address (which will be parsed as an hexadecimal number).  Empty lines are ignored, and lines starting with a "#" symbol will be treated as comment lines and thus ignored as well.

Future work will be needed when the ESP32-C2 MCU support is brought in as some code from libgcc and newlib is moved into ROM on that platform as well (see ESP-IDF's linker files in `components/esp_rom/esp32c2/ld/` - `newlib`, `newlib-nano`, and `libgcc`).

All natmods are now built for the Xtensa architecture as part of the CI build process.

### Testing

Regular natmod test were ran on a NodeMCU v2 ESP8266 board by injecting the following code block when importing natmods on the board (see https://github.com/micropython/micropython/issues/14430#issuecomment-2332648018):

```py
import esp, gc
gc.collect()
esp.set_native_code_location(200 * 4096, 30 * 4096)
```

To achieve this a new argument to `tests/run-natmodtests.py` is introduced so the above fragment is uploaded as part of the testing process.  All tests were executed successfully with `./run-natmodtests.py -p -d /dev/ttyUSB0 -a xtensa -b xtensa_prelude.py extmod/<testfiles>` with the following exceptions (`xtensa_prelude.py` is the extra code fragment being injected):

`extmod/btree1.py`: FAIL ("MemoryError: memory allocation failed, allocating 20734 bytes")
`extmod/btree_closed.py`: FAIL ("MemoryError: memory allocation failed, allocating 20734 bytes")
`extmod/btree_error.py`: FAIL ("MemoryError: memory allocation failed, allocating 20734 bytes")
`extmod/btree_gc.py`: FAIL ("MemoryError: memory allocation failed, allocating 20734 bytes")
`extmod/deflate_compress.py`: FAIL ("Error: memory allocation failed")

The btree natmod probably is a bit too much for an ESP8266 in its current form, probably the same is valid for the deflate natmod when it comes to compressing buffers.

### Trade-offs and Alternatives

All `tools/mpy_ld.py` changes are active only for the `EM_XTENSA` architecture and they are opt-in, so there shouldn't be any trade-offs to be made here.  As far as alternatives go, the only one is to move natmod code into one or more usermods and bring them in as part of the MicroPython build.

For `tests/run-natmodtests.py` the same applies (as in the injection being opt-in), although it is available to all platforms.