### PR TITLE
extmod: Create a common cyw43 config header, apply mDNS fix in it.

### DIFF
--- a/extmod/cyw43_config_common.h
+++ b/extmod/cyw43_config_common.h
@@ -107,4 +107,20 @@ static inline void cyw43_delay_ms(uint32_t ms) {
     }
 }
 
+#if LWIP_MDNS_RESPONDER == 1
+
+// Hook for any additional TCP/IP initialization than needs to be done.
+// Called after the netif specified by `itf` has been set up.
+#ifndef CYW43_CB_TCPIP_INIT_EXTRA
+#define CYW43_CB_TCPIP_INIT_EXTRA(self, itf) mdns_resp_add_netif(&self->netif[itf], mod_network_hostname_data)
+#endif
+
+// Hook for any additional TCP/IP deinitialization than needs to be done.
+// Called before the netif specified by `itf` is removed.
+#ifndef CYW43_CB_TCPIP_DEINIT_EXTRA
+#define CYW43_CB_TCPIP_DEINIT_EXTRA(self, itf) mdns_resp_remove_netif(&self->netif[itf])
+#endif
+
+#endif
+
 #endif // MICROPY_INCLUDED_EXTMOD_CYW43_CONFIG_COMMON_H

--- a/extmod/cyw43_config_common.h
+++ b/extmod/cyw43_config_common.h
@@ -1,0 +1,110 @@
+/*
+ * This file is part of the MicroPython project, http://micropython.org/
+ *
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2025 Damien P. George, Angus Gratton
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+#ifndef MICROPY_INCLUDED_EXTMOD_CYW43_CONFIG_COMMON_H
+#define MICROPY_INCLUDED_EXTMOD_CYW43_CONFIG_COMMON_H
+
+// The board-level config will be included here, so it can set some CYW43 values.
+#include "py/mpconfig.h"
+#include "py/mperrno.h"
+#include "py/mphal.h"
+#include "py/runtime.h"
+#include "extmod/modnetwork.h"
+#include "lwip/apps/mdns.h"
+#include "pendsv.h"
+
+// This file is included at the top of port-specific cyw43_configport.h files,
+// and holds the MicroPython-specific but non-port-specific parts.
+//
+// It's included into both MicroPython sources and the lib/cyw43-driver sources.
+
+#define CYW43_IOCTL_TIMEOUT_US          (1000000)
+#define CYW43_NETUTILS                  (1)
+#define CYW43_PRINTF(...)               mp_printf(MP_PYTHON_PRINTER, __VA_ARGS__)
+
+#define CYW43_EPERM                     MP_EPERM // Operation not permitted
+#define CYW43_EIO                       MP_EIO // I/O error
+#define CYW43_EINVAL                    MP_EINVAL // Invalid argument
+#define CYW43_ETIMEDOUT                 MP_ETIMEDOUT // Connection timed out
+
+#define CYW43_THREAD_ENTER              MICROPY_PY_LWIP_ENTER
+#define CYW43_THREAD_EXIT               MICROPY_PY_LWIP_EXIT
+#define CYW43_THREAD_LOCK_CHECK
+
+#define CYW43_HOST_NAME                 mod_network_hostname_data
+
+#define CYW43_ARRAY_SIZE(a)             MP_ARRAY_SIZE(a)
+
+#define CYW43_HAL_PIN_MODE_INPUT        MP_HAL_PIN_MODE_INPUT
+#define CYW43_HAL_PIN_MODE_OUTPUT       MP_HAL_PIN_MODE_OUTPUT
+#define CYW43_HAL_PIN_PULL_NONE         MP_HAL_PIN_PULL_NONE
+#define CYW43_HAL_PIN_PULL_UP           MP_HAL_PIN_PULL_UP
+#define CYW43_HAL_PIN_PULL_DOWN         MP_HAL_PIN_PULL_DOWN
+
+#define CYW43_HAL_MAC_WLAN0             MP_HAL_MAC_WLAN0
+#define CYW43_HAL_MAC_BDADDR            MP_HAL_MAC_BDADDR
+
+#define cyw43_hal_ticks_us              mp_hal_ticks_us
+#define cyw43_hal_ticks_ms              mp_hal_ticks_ms
+
+#define cyw43_hal_pin_obj_t             mp_hal_pin_obj_t
+#define cyw43_hal_pin_config            mp_hal_pin_config
+#define cyw43_hal_pin_read              mp_hal_pin_read
+#define cyw43_hal_pin_low               mp_hal_pin_low
+#define cyw43_hal_pin_high              mp_hal_pin_high
+
+#define cyw43_hal_get_mac               mp_hal_get_mac
+#define cyw43_hal_get_mac_ascii         mp_hal_get_mac_ascii
+#define cyw43_hal_generate_laa_mac      mp_hal_generate_laa_mac
+
+#define cyw43_schedule_internal_poll_dispatch(func) pendsv_schedule_dispatch(PENDSV_DISPATCH_CYW43, func)
+
+// Note: this function is only called if CYW43_POST_POLL_HOOK is defined in cyw43_configport.h
+void cyw43_post_poll_hook(void);
+
+#ifdef MICROPY_EVENT_POLL_HOOK
+// Older style hook macros on some ports
+#define CYW43_EVENT_POLL_HOOK MICROPY_EVENT_POLL_HOOK
+#else
+// Newer style hooks on other ports
+#define CYW43_EVENT_POLL_HOOK mp_event_handle_nowait()
+#endif
+
+static inline void cyw43_delay_us(uint32_t us) {
+    uint32_t start = mp_hal_ticks_us();
+    while (mp_hal_ticks_us() - start < us) {
+    }
+}
+
+static inline void cyw43_delay_ms(uint32_t ms) {
+    // PendSV may be disabled via CYW43_THREAD_ENTER, so this delay is a busy loop.
+    uint32_t us = ms * 1000;
+    uint32_t start = mp_hal_ticks_us();
+    while (mp_hal_ticks_us() - start < us) {
+        CYW43_EVENT_POLL_HOOK;
+    }
+}
+
+#endif // MICROPY_INCLUDED_EXTMOD_CYW43_CONFIG_COMMON_H

--- a/extmod/mpbthci.h
+++ b/extmod/mpbthci.h
@@ -27,6 +27,10 @@
 #ifndef MICROPY_INCLUDED_EXTMOD_MPBTHCI_H
 #define MICROPY_INCLUDED_EXTMOD_MPBTHCI_H
 
+#include <stdint.h>
+#include <stdbool.h>
+#include <stddef.h>
+
 #define MICROPY_PY_BLUETOOTH_HCI_READ_MODE_BYTE  (0)
 #define MICROPY_PY_BLUETOOTH_HCI_READ_MODE_PACKET  (1)
 

--- a/ports/alif/cyw43_configport.h
+++ b/ports/alif/cyw43_configport.h
@@ -27,13 +27,8 @@
 #define MICROPY_INCLUDED_ALIF_CYW43_CONFIGPORT_H
 
 // The board-level config will be included here, so it can set some CYW43 values.
-#include "py/mpconfig.h"
-#include "py/mperrno.h"
-#include "py/mphal.h"
-#include "py/runtime.h"
-#include "extmod/modnetwork.h"
 #include "extmod/mpbthci.h"
-#include "pendsv.h"
+#include "extmod/cyw43_config_common.h"
 
 #ifndef static_assert
 #define static_assert(expr, msg)        typedef int static_assert_##__LINE__[(expr) ? 1 : -1]
@@ -53,50 +48,14 @@
 #define CYW43_WARN(...)                 mp_printf(MP_PYTHON_PRINTER, __VA_ARGS__)
 #endif
 
-#define CYW43_IOCTL_TIMEOUT_US          (1000000)
-#define CYW43_SLEEP_MAX                 (50)
-#define CYW43_NETUTILS                  (1)
 #define CYW43_CLEAR_SDIO_INT            (1)
-
-#define CYW43_EPERM                     MP_EPERM // Operation not permitted
-#define CYW43_EIO                       MP_EIO // I/O error
-#define CYW43_EINVAL                    MP_EINVAL // Invalid argument
-#define CYW43_ETIMEDOUT                 MP_ETIMEDOUT // Connection timed out
-
-#define CYW43_THREAD_ENTER              MICROPY_PY_LWIP_ENTER
-#define CYW43_THREAD_EXIT               MICROPY_PY_LWIP_EXIT
-#define CYW43_THREAD_LOCK_CHECK
-
-#define CYW43_HOST_NAME                 mod_network_hostname_data
 
 #define CYW43_SDPCM_SEND_COMMON_WAIT    __WFE()
 #define CYW43_DO_IOCTL_WAIT             // __WFE()
-#define CYW43_EVENT_POLL_HOOK           mp_event_handle_nowait()
-
-#define CYW43_ARRAY_SIZE(a)             MP_ARRAY_SIZE(a)
-
-#define CYW43_HAL_PIN_MODE_INPUT        MP_HAL_PIN_MODE_INPUT
-#define CYW43_HAL_PIN_MODE_OUTPUT       MP_HAL_PIN_MODE_OUTPUT
-#define CYW43_HAL_PIN_PULL_NONE         0
-
-#define CYW43_HAL_MAC_WLAN0             MP_HAL_MAC_WLAN0
-#define CYW43_HAL_MAC_BDADDR            MP_HAL_MAC_BDADDR
-
-#define cyw43_hal_ticks_us              mp_hal_ticks_us
-#define cyw43_hal_ticks_ms              mp_hal_ticks_ms
-
-#define cyw43_hal_pin_obj_t             mp_hal_pin_obj_t
-#define cyw43_hal_pin_read              mp_hal_pin_read
-#define cyw43_hal_pin_low               mp_hal_pin_low
-#define cyw43_hal_pin_high              mp_hal_pin_high
 
 #define cyw43_hal_uart_set_baudrate     mp_bluetooth_hci_uart_set_baudrate
 #define cyw43_hal_uart_write            mp_bluetooth_hci_uart_write
 #define cyw43_hal_uart_readchar         mp_bluetooth_hci_uart_readchar
-
-#define cyw43_hal_get_mac               mp_hal_get_mac
-#define cyw43_hal_get_mac_ascii         mp_hal_get_mac_ascii
-#define cyw43_hal_generate_laa_mac      mp_hal_generate_laa_mac
 
 #define CYW43_PIN_WL_REG_ON             pin_WL_REG_ON
 #define CYW43_PIN_WL_IRQ                pin_WL_IRQ
@@ -110,15 +69,7 @@
 
 void cyw43_post_poll_hook(void);
 
-static inline void cyw43_delay_us(uint32_t us) {
-    uint32_t start = mp_hal_ticks_us();
-    while (mp_hal_ticks_us() - start < us) {
-    }
-}
-
-static inline void cyw43_delay_ms(uint32_t ms) {
-    mp_hal_delay_ms(ms);
-}
+#undef cyw43_hal_pin_config // mp_hal_pin_config on alif port is not API compatible
 
 static inline void cyw43_hal_pin_config(mp_hal_pin_obj_t pin, uint32_t mode, uint32_t pull, uint32_t alt) {
     if (mode == MP_HAL_PIN_MODE_INPUT) {
@@ -127,7 +78,6 @@ static inline void cyw43_hal_pin_config(mp_hal_pin_obj_t pin, uint32_t mode, uin
         mp_hal_pin_output(pin);
     }
 }
-
 static inline void cyw43_hal_pin_config_irq_falling(mp_hal_pin_obj_t pin, bool enable) {
     mp_hal_pin_config_irq_falling(pin, enable);
 }

--- a/ports/mimxrt/cyw43_configport.h
+++ b/ports/mimxrt/cyw43_configport.h
@@ -28,12 +28,8 @@
 #define MICROPY_INCLUDED_MIMXRT_CYW43_CONFIGPORT_H
 
 // The board-level config will be included here, so it can set some CYW43 values.
-#include "py/mpconfig.h"
-#include "py/mperrno.h"
-#include "py/mphal.h"
-#include "extmod/modnetwork.h"
 #include "extmod/mpbthci.h"
-#include "pendsv.h"
+#include "extmod/cyw43_config_common.h"
 #include "sdio.h"
 
 #define CYW43_USE_SPI                   (0)
@@ -61,54 +57,14 @@
 #define CYW43_BT_UART_BAUDRATE_DOWNLOAD_FIRMWARE MICROPY_HW_BLE_UART_BAUDRATE_DOWNLOAD_FIRMWARE
 #endif
 
-#define CYW43_IOCTL_TIMEOUT_US          (1000000)
-#define CYW43_SLEEP_MAX                 (50)
-#define CYW43_NETUTILS                  (1)
 #define CYW43_CLEAR_SDIO_INT            (1)
-
-#define CYW43_EPERM                     MP_EPERM // Operation not permitted
-#define CYW43_EIO                       MP_EIO // I/O error
-#define CYW43_EINVAL                    MP_EINVAL // Invalid argument
-#define CYW43_ETIMEDOUT                 MP_ETIMEDOUT // Connection timed out
-
-#define CYW43_THREAD_ENTER              MICROPY_PY_LWIP_ENTER
-#define CYW43_THREAD_EXIT               MICROPY_PY_LWIP_EXIT
-#define CYW43_THREAD_LOCK_CHECK
-
-#define CYW43_HOST_NAME                 mod_network_hostname_data
 
 #define CYW43_SDPCM_SEND_COMMON_WAIT    __WFI();
 #define CYW43_DO_IOCTL_WAIT             __WFI();
 
-#define CYW43_ARRAY_SIZE(a)             MP_ARRAY_SIZE(a)
-
-#define CYW43_HAL_PIN_MODE_INPUT        MP_HAL_PIN_MODE_INPUT
-#define CYW43_HAL_PIN_MODE_OUTPUT       MP_HAL_PIN_MODE_OUTPUT
-#define CYW43_HAL_PIN_PULL_NONE         MP_HAL_PIN_PULL_NONE
-#define CYW43_HAL_PIN_PULL_UP           MP_HAL_PIN_PULL_UP
-#define CYW43_HAL_PIN_PULL_DOWN         MP_HAL_PIN_PULL_DOWN
-
-#define CYW43_HAL_MAC_WLAN0             MP_HAL_MAC_WLAN0
-#define CYW43_HAL_MAC_BDADDR            MP_HAL_MAC_BDADDR
-
-#define cyw43_hal_ticks_us              mp_hal_ticks_us
-#define cyw43_hal_ticks_ms              mp_hal_ticks_ms
-
-#define cyw43_hal_pin_obj_t             mp_hal_pin_obj_t
-#define cyw43_hal_pin_read              mp_hal_pin_read
-#define cyw43_hal_pin_low               mp_hal_pin_low
-#define cyw43_hal_pin_high              mp_hal_pin_high
-
-#define cyw43_hal_get_mac               mp_hal_get_mac
-#define cyw43_hal_get_mac_ascii         mp_hal_get_mac_ascii
-#define cyw43_hal_generate_laa_mac      mp_hal_generate_laa_mac
-
 #define cyw43_hal_uart_set_baudrate     mp_bluetooth_hci_uart_set_baudrate
 #define cyw43_hal_uart_write            mp_bluetooth_hci_uart_write
 #define cyw43_hal_uart_readchar         mp_bluetooth_hci_uart_readchar
-
-#define cyw43_delay_us                  mp_hal_delay_us
-#define cyw43_delay_ms                  mp_hal_delay_ms
 
 #define cyw43_bluetooth_controller_init     mp_bluetooth_hci_controller_init
 #define cyw43_bluetooth_controller_deinit   mp_bluetooth_hci_controller_deinit
@@ -135,7 +91,7 @@
 #define CYW43_PIN_RFSW_VDD              pin_WL_RFSW_VDD
 #endif
 
-#define cyw43_schedule_internal_poll_dispatch(func) pendsv_schedule_dispatch(PENDSV_DISPATCH_CYW43, func)
+#undef cyw43_hal_pin_config // mp_hal_pin_config not yet implemented on this port
 
 static inline void cyw43_hal_pin_config(cyw43_hal_pin_obj_t pin, uint8_t mode, uint8_t pull, uint8_t alt) {
     machine_pin_set_mode(pin, mode);
@@ -174,7 +130,5 @@ static inline int cyw43_sdio_transfer(uint32_t cmd, uint32_t arg, uint32_t *resp
 static inline int cyw43_sdio_transfer_cmd53(bool write, uint32_t block_size, uint32_t arg, size_t len, uint8_t *buf) {
     return sdio_transfer_cmd53(write, block_size, arg, len, buf);
 }
-
-#define CYW43_EVENT_POLL_HOOK MICROPY_EVENT_POLL_HOOK
 
 #endif // MICROPY_INCLUDED_MIMXRT_CYW43_CONFIGPORT_H

--- a/ports/rp2/cyw43_configport.h
+++ b/ports/rp2/cyw43_configport.h
@@ -26,34 +26,27 @@
 #ifndef MICROPY_INCLUDED_RP2_CYW43_CONFIGPORT_H
 #define MICROPY_INCLUDED_RP2_CYW43_CONFIGPORT_H
 
-// The board-level config will be included here, so it can set some CYW43 values.
-#include <stdio.h>
-#include "py/mpconfig.h"
-#include "py/mperrno.h"
-#include "py/mphal.h"
-#include "py/runtime.h"
-#include "extmod/modnetwork.h"
-#include "lwip/apps/mdns.h"
-#include "pendsv.h"
+#include "extmod/cyw43_config_common.h"
 
 #define CYW43_INCLUDE_LEGACY_F1_OVERFLOW_WORKAROUND_VARIABLES (1)
 #define CYW43_WIFI_NVRAM_INCLUDE_FILE   "wifi_nvram_43439.h"
-#define CYW43_IOCTL_TIMEOUT_US          (1000000)
-#define CYW43_SLEEP_MAX                 (10)
-#define CYW43_NETUTILS                  (1)
+#define CYW43_SLEEP_MAX                 (10) // Unclear why rp2 port overrides the default here
 #define CYW43_USE_OTP_MAC               (1)
-#define CYW43_PRINTF(...)               mp_printf(MP_PYTHON_PRINTER, __VA_ARGS__)
 
-#define CYW43_EPERM                     MP_EPERM // Operation not permitted
-#define CYW43_EIO                       MP_EIO // I/O error
-#define CYW43_EINVAL                    MP_EINVAL // Invalid argument
-#define CYW43_ETIMEDOUT                 MP_ETIMEDOUT // Connection timed out
+static inline bool cyw43_poll_is_pending(void) {
+    return pendsv_is_pending(PENDSV_DISPATCH_CYW43);
+}
 
-#define CYW43_THREAD_ENTER              MICROPY_PY_LWIP_ENTER
-#define CYW43_THREAD_EXIT               MICROPY_PY_LWIP_EXIT
-#define CYW43_THREAD_LOCK_CHECK
+static inline void cyw43_yield(void) {
+    if (!cyw43_poll_is_pending()) {
+        best_effort_wfe_or_timeout(make_timeout_time_ms(1));
+    }
+}
 
-#define CYW43_HOST_NAME                 mod_network_hostname_data
+#define CYW43_POST_POLL_HOOK            cyw43_post_poll_hook();
+
+// set in SDK board header
+#define CYW43_NUM_GPIOS                 CYW43_WL_GPIO_COUNT
 
 #if CYW43_PIN_WL_DYNAMIC
 
@@ -100,36 +93,6 @@ uint cyw43_get_pin_wl(cyw43_pin_index_t pin_id);
         cyw43_yield(); \
     } \
 
-#define CYW43_ARRAY_SIZE(a)             MP_ARRAY_SIZE(a)
-
-#define CYW43_HAL_PIN_MODE_INPUT        MP_HAL_PIN_MODE_INPUT
-#define CYW43_HAL_PIN_MODE_OUTPUT       MP_HAL_PIN_MODE_OUTPUT
-#define CYW43_HAL_PIN_PULL_NONE         MP_HAL_PIN_PULL_NONE
-#define CYW43_HAL_PIN_PULL_UP           MP_HAL_PIN_PULL_UP
-#define CYW43_HAL_PIN_PULL_DOWN         MP_HAL_PIN_PULL_DOWN
-
-#define CYW43_HAL_MAC_WLAN0             MP_HAL_MAC_WLAN0
-
-// set in SDK board header
-#define CYW43_NUM_GPIOS                 CYW43_WL_GPIO_COUNT
-
-#define CYW43_POST_POLL_HOOK            cyw43_post_poll_hook();
-
-#define cyw43_hal_ticks_us              mp_hal_ticks_us
-#define cyw43_hal_ticks_ms              mp_hal_ticks_ms
-
-#define cyw43_hal_pin_obj_t             mp_hal_pin_obj_t
-#define cyw43_hal_pin_config            mp_hal_pin_config
-#define cyw43_hal_pin_read              mp_hal_pin_read
-#define cyw43_hal_pin_low               mp_hal_pin_low
-#define cyw43_hal_pin_high              mp_hal_pin_high
-
-#define cyw43_hal_get_mac               mp_hal_get_mac
-#define cyw43_hal_get_mac_ascii         mp_hal_get_mac_ascii
-#define cyw43_hal_generate_laa_mac      mp_hal_generate_laa_mac
-
-#define cyw43_schedule_internal_poll_dispatch(func) pendsv_schedule_dispatch(PENDSV_DISPATCH_CYW43, func)
-
 // Bluetooth requires dynamic memory allocation to load its firmware (the allocation
 // call is made from pico-sdk).  This allocation is always done at thread-level, not
 // from an IRQ, so is safe to delegate to the MicroPython GC heap.
@@ -139,34 +102,6 @@ uint cyw43_get_pin_wl(cyw43_pin_index_t pin_id);
 #ifndef cyw43_free
 #define cyw43_free m_tracked_free
 #endif
-
-void cyw43_post_poll_hook(void);
-static inline bool cyw43_poll_is_pending(void) {
-    return pendsv_is_pending(PENDSV_DISPATCH_CYW43);
-}
-
-static inline void cyw43_yield(void) {
-    if (!cyw43_poll_is_pending()) {
-        best_effort_wfe_or_timeout(make_timeout_time_ms(1));
-    }
-}
-
-static inline void cyw43_delay_us(uint32_t us) {
-    uint32_t start = mp_hal_ticks_us();
-    while (mp_hal_ticks_us() - start < us) {
-    }
-}
-
-static inline void cyw43_delay_ms(uint32_t ms) {
-    // PendSV may be disabled via CYW43_THREAD_ENTER, so this delay is a busy loop.
-    uint32_t us = ms * 1000;
-    uint32_t start = mp_hal_ticks_us();
-    while (mp_hal_ticks_us() - start < us) {
-        mp_event_handle_nowait();
-    }
-}
-
-#define CYW43_EVENT_POLL_HOOK mp_event_handle_nowait()
 
 #if LWIP_MDNS_RESPONDER == 1
 
@@ -183,4 +118,5 @@ static inline void cyw43_delay_ms(uint32_t ms) {
 #endif
 
 #endif
+
 #endif // MICROPY_INCLUDED_RP2_CYW43_CONFIGPORT_H

--- a/ports/rp2/cyw43_configport.h
+++ b/ports/rp2/cyw43_configport.h
@@ -103,20 +103,4 @@ uint cyw43_get_pin_wl(cyw43_pin_index_t pin_id);
 #define cyw43_free m_tracked_free
 #endif
 
-#if LWIP_MDNS_RESPONDER == 1
-
-// Hook for any additional TCP/IP initialization than needs to be done.
-// Called after the netif specified by `itf` has been set up.
-#ifndef CYW43_CB_TCPIP_INIT_EXTRA
-#define CYW43_CB_TCPIP_INIT_EXTRA(self, itf) mdns_resp_add_netif(&self->netif[itf], mod_network_hostname_data)
-#endif
-
-// Hook for any additional TCP/IP deinitialization than needs to be done.
-// Called before the netif specified by `itf` is removed.
-#ifndef CYW43_CB_TCPIP_DEINIT_EXTRA
-#define CYW43_CB_TCPIP_DEINIT_EXTRA(self, itf) mdns_resp_remove_netif(&self->netif[itf])
-#endif
-
-#endif
-
 #endif // MICROPY_INCLUDED_RP2_CYW43_CONFIGPORT_H

--- a/ports/stm32/cyw43_configport.h
+++ b/ports/stm32/cyw43_configport.h
@@ -27,14 +27,9 @@
 #ifndef MICROPY_INCLUDED_STM32_CYW43_CONFIGPORT_H
 #define MICROPY_INCLUDED_STM32_CYW43_CONFIGPORT_H
 
-// The board-level config will be included here, so it can set some CYW43 values.
-#include "py/mpconfig.h"
-#include "py/mperrno.h"
-#include "py/mphal.h"
-#include "extmod/modnetwork.h"
-#include "extmod/mpbthci.h"
 #include "extint.h"
-#include "pendsv.h"
+#include "extmod/mpbthci.h"
+#include "extmod/cyw43_config_common.h"
 #include "sdio.h"
 
 #define CYW43_USE_SPI                   (0)
@@ -62,49 +57,11 @@
 #define CYW43_BT_UART_BAUDRATE_DOWNLOAD_FIRMWARE MICROPY_HW_BLE_UART_BAUDRATE_DOWNLOAD_FIRMWARE
 #endif
 
-#define CYW43_IOCTL_TIMEOUT_US          (1000000)
-#define CYW43_SLEEP_MAX                 (50)
-#define CYW43_NETUTILS                  (1)
 #define CYW43_CLEAR_SDIO_INT            (1)
-
-#define CYW43_EPERM                     MP_EPERM // Operation not permitted
-#define CYW43_EIO                       MP_EIO // I/O error
-#define CYW43_EINVAL                    MP_EINVAL // Invalid argument
-#define CYW43_ETIMEDOUT                 MP_ETIMEDOUT // Connection timed out
-
-#define CYW43_THREAD_ENTER              MICROPY_PY_LWIP_ENTER
-#define CYW43_THREAD_EXIT               MICROPY_PY_LWIP_EXIT
-#define CYW43_THREAD_LOCK_CHECK
-
-#define CYW43_HOST_NAME                 mod_network_hostname_data
 
 #define CYW43_SDPCM_SEND_COMMON_WAIT    __WFI();
 #define CYW43_DO_IOCTL_WAIT             __WFI();
 #define CYW43_HAL_UART_READCHAR_BLOCKING_WAIT __WFI()
-
-#define CYW43_ARRAY_SIZE(a)             MP_ARRAY_SIZE(a)
-
-#define CYW43_HAL_PIN_MODE_INPUT        MP_HAL_PIN_MODE_INPUT
-#define CYW43_HAL_PIN_MODE_OUTPUT       MP_HAL_PIN_MODE_OUTPUT
-#define CYW43_HAL_PIN_PULL_NONE         MP_HAL_PIN_PULL_NONE
-#define CYW43_HAL_PIN_PULL_UP           MP_HAL_PIN_PULL_UP
-#define CYW43_HAL_PIN_PULL_DOWN         MP_HAL_PIN_PULL_DOWN
-
-#define CYW43_HAL_MAC_WLAN0             MP_HAL_MAC_WLAN0
-#define CYW43_HAL_MAC_BDADDR            MP_HAL_MAC_BDADDR
-
-#define cyw43_hal_ticks_us              mp_hal_ticks_us
-#define cyw43_hal_ticks_ms              mp_hal_ticks_ms
-
-#define cyw43_hal_pin_obj_t             mp_hal_pin_obj_t
-#define cyw43_hal_pin_config            mp_hal_pin_config
-#define cyw43_hal_pin_read              mp_hal_pin_read
-#define cyw43_hal_pin_low               mp_hal_pin_low
-#define cyw43_hal_pin_high              mp_hal_pin_high
-
-#define cyw43_hal_get_mac               mp_hal_get_mac
-#define cyw43_hal_get_mac_ascii         mp_hal_get_mac_ascii
-#define cyw43_hal_generate_laa_mac      mp_hal_generate_laa_mac
 
 #define cyw43_hal_uart_set_baudrate     mp_bluetooth_hci_uart_set_baudrate
 #define cyw43_hal_uart_write            mp_bluetooth_hci_uart_write
@@ -131,24 +88,6 @@
 #define CYW43_PIN_RFSW_VDD              pyb_pin_WL_RFSW_VDD
 #define CYW43_PIN_RFSW_SELECT           pyb_pin_WL_GPIO_1
 #endif
-
-#define cyw43_schedule_internal_poll_dispatch(func) pendsv_schedule_dispatch(PENDSV_DISPATCH_CYW43, func)
-
-void cyw43_post_poll_hook(void);
-
-static inline void cyw43_delay_us(uint32_t us) {
-    uint32_t start = mp_hal_ticks_us();
-    while (mp_hal_ticks_us() - start < us) {
-    }
-}
-
-static inline void cyw43_delay_ms(uint32_t ms) {
-    uint32_t us = ms * 1000;
-    uint32_t start = mp_hal_ticks_us();
-    while (mp_hal_ticks_us() - start < us) {
-        MICROPY_EVENT_POLL_HOOK;
-    }
-}
 
 static inline void cyw43_hal_pin_config_irq_falling(cyw43_hal_pin_obj_t pin, int enable) {
     if (enable) {
@@ -183,7 +122,5 @@ static inline int cyw43_sdio_transfer(uint32_t cmd, uint32_t arg, uint32_t *resp
 static inline int cyw43_sdio_transfer_cmd53(bool write, uint32_t block_size, uint32_t arg, size_t len, uint8_t *buf) {
     return sdio_transfer_cmd53(write, block_size, arg, len, buf);
 }
-
-#define CYW43_EVENT_POLL_HOOK MICROPY_EVENT_POLL_HOOK
 
 #endif // MICROPY_INCLUDED_STM32_CYW43_CONFIGPORT_H


### PR DESCRIPTION
### Summary

* First commit creates a new `extmod/cyw43_config_common.h` header with the common macros from ports which use CYW43 Wi-fi driver. There's more refactoring that could be done here (for example a `cyw43_sdio_common.h` header) but I've limited myself to macros that are the same, or that appear effectively the same, on every port.
* Second commit moves the rp2 LWIP mDNS resolver fix added in #17057 into the new header, so it's now also applied on stm32 and mimxrt ports which use the CYW43 driver.

### Testing

* Connected a PYBD_SF2 to my local network, verified I could look up the host via mDNS.
* Ran the `multi_wlan` tests with a RPI_PICO_W board and a PYBD_SF2 as the two nodes. This uncovered two pre-existing issues (not added in this PR):
   - The stm32 port logs `DHCPS:` updates when running as the AP, so the test fails on the additional output (at least easy to manually check for).
   - On both ports, the cyw43 driver doesn't like being a STA first and then switching to become an AP (even though the unit tests de-activate the unused interface). To run the two tests in sequence then I needed to trigger a hard reset in between. Will investigate more when time permits.
* I have not been able to test mimxrt as I have no suitable hardware. If I understand #11397 correctly then no such widely available board exists, the only mimxrt+cyw43 users have added a CYW43 module to custom hardware or an eval board.

### Trade-offs and Alternatives

* Could keep the per-port config headers but it makes it harder to verify consistent behaviour between the different ports, and to apply non-port-specific changes like the mDNS resolver fix.