### PR TITLE
zephyr: Make it clearer that gpio irqs can be hard or soft.

### DIFF
--- a/ports/zephyr/machine_pin.c
+++ b/ports/zephyr/machine_pin.c
@@ -64,8 +64,11 @@ static void gpio_callback_handler(const struct device *port, struct gpio_callbac
     machine_pin_irq_obj_t *irq = CONTAINER_OF(cb, machine_pin_irq_obj_t, callback);
 
     #if MICROPY_STACK_CHECK
-    // This callback executes in an ISR context so the stack-limit check must be changed to
-    // use the ISR stack for the duration of this function (so that hard IRQ callbacks work).
+    // For irqs with hard=True, the callback executes in an ISR context so the
+    // stack-limit check must be changed to use the ISR stack for the duration
+    // of this function (so that hard IRQ callbacks work).
+    //
+    // (For soft IRQs we change it anyway, even though it's not needed.)
     char *orig_stack_top = MP_STATE_THREAD(stack_top);
     size_t orig_stack_limit = MP_STATE_THREAD(stack_limit);
     MP_STATE_THREAD(stack_top) = (void *)&irq;


### PR DESCRIPTION
### Summary

Quick follow-up to #16916 - the comment in the IRQ handler makes it sound like all Zephyr IRQs are hard, but actually hard and soft irqs are supported.

### Testing

None, this change only updates a code comment.