### PR TITLE
py/makeversionhdr.py: Fix datetime.utcfromtimestamp() is deprecated.

### DIFF
--- a/py/makeversionhdr.py
+++ b/py/makeversionhdr.py
@@ -117,8 +117,8 @@ def make_version_header(repo_path, filename):
 
     build_date = datetime.date.today()
     if "SOURCE_DATE_EPOCH" in os.environ:
-        build_date = datetime.datetime.utcfromtimestamp(
-            int(os.environ["SOURCE_DATE_EPOCH"])
+        build_date = datetime.datetime.fromtimestamp(
+            int(os.environ["SOURCE_DATE_EPOCH"]), datetime.timezone.utc
         ).date()
 
     # Generate the file with the git and version info


### PR DESCRIPTION
### Summary

CI for the reproducible build shows a deprecation warning.

```
mkdir -p build-minimal/shared/timeutils/
/home/runner/work/micropython/micropython/ports/unix/../../py/makeversionhdr.py:120: DeprecationWarning: datetime.datetime.utcfromtimestamp() is deprecated and scheduled for removal in a future version. Use timezone-aware objects to represent datetimes in UTC: datetime.datetime.fromtimestamp(timestamp, datetime.UTC).
  build_date = datetime.datetime.utcfromtimestamp(
```
https://github.com/micropython/micropython/actions/runs/14346813947/job/40218094016

I updated `py/makeversionhdr.py` to use `datetime.datetime.fromtimestamp(timestamp, datetime.timezone.utc)` instead

### Testing
Tested minimal and standard unix build outside of CI
CI will test the rest


