### PR TITLE
mimxrt/Makefile: Fix dependencies for generation of flexram_config.s.

### DIFF
--- a/ports/mimxrt/Makefile
+++ b/ports/mimxrt/Makefile
@@ -327,6 +327,8 @@ SRC_SS = \
 
 SRC_S += shared/runtime/gchelper_thumb2.s \
 
+hal/resethandler_MIMXRT10xx.S: $(GEN_FLEXRAM_CONFIG_SRC)
+
 # =============================================================================
 # QSTR Sources
 # =============================================================================
@@ -521,16 +523,16 @@ $(BUILD)/firmware.uf2: $(BUILD)/firmware.elf
 # any of the objects. The normal dependency generation will deal with the
 # case when pins.h is modified. But when it doesn't exist, we don't know
 # which source files might need it.
-$(OBJ): | $(GEN_PINS_HDR) $(GEN_FLEXRAM_CONFIG_SRC)
+$(OBJ): | $(GEN_PINS_HDR)
 
 # With conditional pins, we may need to regenerate qstrdefs.h when config
 # options change.
 $(HEADER_BUILD)/qstrdefs.generated.h: $(BOARD_DIR)/mpconfigboard.h
 
-$(GEN_FLEXRAM_CONFIG_SRC):
+$(GEN_FLEXRAM_CONFIG_SRC): $(HEADER_BUILD)
 	$(ECHO) "Create $@"
 	$(Q)$(PYTHON) $(MAKE_FLEXRAM_LD) -d $(TOP)/$(MCU_DIR)/$(MCU_SERIES)$(MCU_CORE).h \
-		-f $(TOP)/$(MCU_DIR)/$(MCU_SERIES)$(MCU_CORE)_features.h -l boards/$(MCU_SERIES).ld -c $(MCU_SERIES) > $(GEN_FLEXRAM_CONFIG_SRC)
+		-f $(TOP)/$(MCU_DIR)/$(MCU_SERIES)$(MCU_CORE)_features.h -l boards/$(MCU_SERIES).ld -c $(MCU_SERIES) > $@
 
 # Use a pattern rule here so that make will only call make-pins.py once to make
 # both pins_gen.c and pins.h


### PR DESCRIPTION
### Summary

Prior to this fix the following would fail:

    $ make build-TEENSY40/flexram_config.s

because it didn't create the build directory before generating the file.

Also, make `hal/resethandler_MIMXRT10xx.S` have an explicit dependency on `flexram_config.s` rather than the latter just being forced to be built before everything else.

### Testing

The following now works from a fresh start (ie no existing build):
```
$ make build-TEENSY40/flexram_config.s
```

Also, `make -j build-TEENSY40/hal/resethandler_MIMXRT10xx.o` still works.
