### PR TITLE
py/repl: Skip private variables when printing tab completion options.

### DIFF
--- a/py/repl.c
+++ b/py/repl.c
@@ -218,6 +218,10 @@ static void print_completions(const mp_print_t *print,
     for (qstr q = q_first; q <= q_last; ++q) {
         size_t d_len;
         const char *d_str = (const char *)qstr_data(q, &d_len);
+        // filter out words that begin with underscore unless there's already a partial match
+        if (s_len == 0 && d_str[0] == '_') {
+            continue;
+        }
         if (s_len <= d_len && strncmp(s_start, d_str, s_len) == 0) {
             if (test_qstr(obj, q)) {
                 int gap = (line_len + WORD_SLOT_LEN - 1) / WORD_SLOT_LEN * WORD_SLOT_LEN - line_len;

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,7 @@ target-version = "py37"
 [tool.ruff.lint]
 exclude = [  # Ruff finds Python SyntaxError in these files
   "tests/cmdline/repl_autocomplete.py",
+  "tests/cmdline/repl_autocomplete_underscore.py",
   "tests/cmdline/repl_autoindent.py",
   "tests/cmdline/repl_basic.py",
   "tests/cmdline/repl_cont.py",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,7 @@ exclude = [  # Ruff finds Python SyntaxError in these files
   "tests/cmdline/repl_basic.py",
   "tests/cmdline/repl_cont.py",
   "tests/cmdline/repl_emacs_keys.py",
+  "tests/cmdline/repl_paste.py",
   "tests/cmdline/repl_words_move.py",
   "tests/feature_check/repl_emacs_check.py",
   "tests/feature_check/repl_words_move_check.py",

--- a/tests/cmdline/repl_autocomplete_underscore.py
+++ b/tests/cmdline/repl_autocomplete_underscore.py
@@ -1,0 +1,33 @@
+# Test REPL autocompletion filtering of underscore attributes
+
+# Start paste mode
+{\x05}
+class TestClass:
+    def __init__(self):
+        self.public_attr = 1
+        self._private_attr = 2
+        self.__very_private = 3
+    
+    def public_method(self):
+        pass
+    
+    def _private_method(self):
+        pass
+    
+    @property
+    def public_property(self):
+        return 42
+    
+    @property  
+    def _private_property(self):
+        return 99
+
+{\x04}
+# Paste executed
+
+# Create an instance
+obj = TestClass()
+
+# Test tab completion on the instance
+# The tab character after `obj.` and 'a' below triggers the completions
+obj.{\x09}{\x09}a{\x09}

--- a/tests/cmdline/repl_autocomplete_underscore.py.exp
+++ b/tests/cmdline/repl_autocomplete_underscore.py.exp
@@ -1,0 +1,41 @@
+MicroPython \.\+ version
+Use Ctrl-D to exit, Ctrl-E for paste mode
+>>> # Test REPL autocompletion filtering of underscore attributes
+>>> 
+>>> # Start paste mode
+>>> 
+paste mode; Ctrl-C to cancel, Ctrl-D to finish
+=== 
+=== class TestClass:
+===     def __init__(self):
+===         self.public_attr = 1
+===         self._private_attr = 2
+===         self.__very_private = 3
+===     
+===     def public_method(self):
+===         pass
+===     
+===     def _private_method(self):
+===         pass
+===     
+===     @property
+===     def public_property(self):
+===         return 42
+===     
+===     @property  
+===     def _private_property(self):
+===         return 99
+=== 
+=== 
+>>> # Paste executed
+>>> 
+>>> # Create an instance
+>>> obj = TestClass()
+>>> 
+>>> # Test tab completion on the instance
+>>> # The tab character after `obj.` and 'a' below triggers the completions
+>>> obj.public_
+public_attr     public_method   public_property
+>>> obj.public_attr
+1
+>>> 

--- a/tests/cmdline/repl_paste.py
+++ b/tests/cmdline/repl_paste.py
@@ -1,0 +1,90 @@
+# Test REPL paste mode functionality
+
+# Basic paste mode with a simple function
+{\x05}
+def hello():
+    print('Hello from paste mode!')
+hello()
+{\x04}
+
+# Paste mode with multiple indentation levels
+{\x05}
+def calculate(n):
+    if n > 0:
+        for i in range(n):
+            if i % 2 == 0:
+                print(f'Even: {i}')
+            else:
+                print(f'Odd: {i}')
+    else:
+        print('n must be positive')
+
+calculate(5)
+{\x04}
+
+# Paste mode with blank lines
+{\x05}
+def function_with_blanks():
+    print('First line')
+    
+    print('After blank line')
+    
+    
+    print('After two blank lines')
+
+function_with_blanks()
+{\x04}
+
+# Paste mode with class definition and multiple methods
+{\x05}
+class TestClass:
+    def __init__(self, value):
+        self.value = value
+    
+    def display(self):
+        print(f'Value is: {self.value}')
+    
+    def double(self):
+        self.value *= 2
+        return self.value
+
+obj = TestClass(21)
+obj.display()
+print(f'Doubled: {obj.double()}')
+obj.display()
+{\x04}
+
+# Paste mode with exception handling
+{\x05}
+try:
+    x = 1 / 0
+except ZeroDivisionError:
+    print('Caught division by zero')
+finally:
+    print('Finally block executed')
+{\x04}
+
+# Cancel paste mode with Ctrl-C
+{\x05}
+print('This should not execute')
+{\x03}
+
+# Normal REPL still works after cancelled paste
+print('Back to normal REPL')
+
+# Paste mode with syntax error
+{\x05}
+def bad_syntax(:
+    print('Missing parameter')
+{\x04}
+
+# Paste mode with runtime error
+{\x05}
+def will_error():
+    undefined_variable
+    
+will_error()
+{\x04}
+
+# Final test to show REPL is still functioning
+1 + 2 + 3

--- a/tests/cmdline/repl_paste.py.exp
+++ b/tests/cmdline/repl_paste.py.exp
@@ -1,0 +1,133 @@
+MicroPython \.\+ version
+Use Ctrl-D to exit, Ctrl-E for paste mode
+>>> # Test REPL paste mode functionality
+>>> 
+>>> # Basic paste mode with a simple function
+>>> 
+paste mode; Ctrl-C to cancel, Ctrl-D to finish
+=== 
+=== def hello():
+===     print('Hello from paste mode!')
+=== hello()
+=== 
+Hello from paste mode!
+>>> 
+>>> # Paste mode with multiple indentation levels
+>>> 
+paste mode; Ctrl-C to cancel, Ctrl-D to finish
+=== 
+=== def calculate(n):
+===     if n > 0:
+===         for i in range(n):
+===             if i % 2 == 0:
+===                 print(f'Even: {i}')
+===             else:
+===                 print(f'Odd: {i}')
+===     else:
+===         print('n must be positive')
+=== 
+=== calculate(5)
+=== 
+Even: 0
+Odd: 1
+Even: 2
+Odd: 3
+Even: 4
+>>> 
+>>> # Paste mode with blank lines
+>>> 
+paste mode; Ctrl-C to cancel, Ctrl-D to finish
+=== 
+=== def function_with_blanks():
+===     print('First line')
+===     
+===     print('After blank line')
+===     
+===     
+===     print('After two blank lines')
+=== 
+=== function_with_blanks()
+=== 
+First line
+After blank line
+After two blank lines
+>>> 
+>>> # Paste mode with class definition and multiple methods
+>>> 
+paste mode; Ctrl-C to cancel, Ctrl-D to finish
+=== 
+=== class TestClass:
+===     def __init__(self, value):
+===         self.value = value
+===     
+===     def display(self):
+===         print(f'Value is: {self.value}')
+===     
+===     def double(self):
+===         self.value *= 2
+===         return self.value
+=== 
+=== obj = TestClass(21)
+=== obj.display()
+=== print(f'Doubled: {obj.double()}')
+=== obj.display()
+=== 
+Value is: 21
+Doubled: 42
+Value is: 42
+>>> 
+>>> # Paste mode with exception handling
+>>> 
+paste mode; Ctrl-C to cancel, Ctrl-D to finish
+=== 
+=== try:
+===     x = 1 / 0
+=== except ZeroDivisionError:
+===     print('Caught division by zero')
+=== finally:
+===     print('Finally block executed')
+=== 
+Caught division by zero
+Finally block executed
+>>> 
+>>> # Cancel paste mode with Ctrl-C
+>>> 
+paste mode; Ctrl-C to cancel, Ctrl-D to finish
+=== 
+=== print('This should not execute')
+=== 
+>>> 
+>>> 
+>>> # Normal REPL still works after cancelled paste
+>>> print('Back to normal REPL')
+Back to normal REPL
+>>> 
+>>> # Paste mode with syntax error
+>>> 
+paste mode; Ctrl-C to cancel, Ctrl-D to finish
+=== 
+=== def bad_syntax(:
+===     print('Missing parameter')
+=== 
+Traceback (most recent call last):
+  File "<stdin>", line 2
+SyntaxError: invalid syntax
+>>> 
+>>> # Paste mode with runtime error
+>>> 
+paste mode; Ctrl-C to cancel, Ctrl-D to finish
+=== 
+=== def will_error():
+===     undefined_variable
+===     
+=== will_error()
+=== 
+Traceback (most recent call last):
+  File "<stdin>", line 5, in <module>
+  File "<stdin>", line 3, in will_error
+NameError: name 'undefined_variable' isn't defined
+>>> 
+>>> # Final test to show REPL is still functioning
+>>> 1 + 2 + 3
+6
+>>> 

--- a/tests/ports/unix/extra_coverage.py.exp
+++ b/tests/ports/unix/extra_coverage.py.exp
@@ -51,16 +51,16 @@ RuntimeError:
 ame__
 port 
 
-builtins        micropython     _asyncio        _thread
-array           binascii        btree           cexample
-cmath           collections     cppexample      cryptolib
-deflate         errno           example_package
-ffi             framebuf        gc              hashlib
-heapq           io              json            machine
-marshal         math            os              platform
-random          re              select          socket
-struct          sys             termios         time
-tls             uctypes         vfs             websocket
+builtins        micropython     array           binascii
+btree           cexample        cmath           collections
+cppexample      cryptolib       deflate         errno
+example_package                 ffi             framebuf
+gc              hashlib         heapq           io
+json            machine         marshal         math
+os              platform        random          re
+select          socket          struct          sys
+termios         time            tls             uctypes
+vfs             websocket
 me
 
 micropython     machine         marshal         math

--- a/tests/run-tests.py
+++ b/tests/run-tests.py
@@ -405,6 +405,10 @@ def run_micropython(pyb, args, test_file, test_file_abspath, is_special=False):
                                     return rv
 
                     def send_get(what):
+                        # Detect {\x00} pattern and convert to ctrl-key codes.
+                        ctrl_code = lambda m: bytes([int(m.group(1))])
+                        what = re.sub(rb'{\\x(\d\d)}', ctrl_code, what)
+
                         os.write(master, what)
                         return get()
 


### PR DESCRIPTION
### Summary

The tab completion on repl is intended to not show any attributes starting with a single `_` character, however variables/functions in frozen modules are are currently shown.

This PR introduces a change to py/repl to skip private variables when printing tab completion options.

Originally included in https://github.com/micropython/micropython/pull/17011

### Testing

A unit test has added which covers this, currently based on the asyncio module which is generally frozen in. 
However looking again now maybe it would be better to add a suitable function / attribute to `./tests/frozen/frozentest.py` and test against that, assuming it should have the same behavior?
