### PR TITLE
py/emitinlinerv32: Move include of asmrv32.h to within feature guard.

### DIFF
--- a/py/emitinlinerv32.c
+++ b/py/emitinlinerv32.c
@@ -30,11 +30,12 @@
 #include <stdio.h>
 #include <string.h>
 
-#include "py/asmrv32.h"
 #include "py/emit.h"
 #include "py/misc.h"
 
 #if MICROPY_EMIT_INLINE_RV32
+
+#include "py/asmrv32.h"
 
 typedef enum {
 // define rules with a compile function


### PR DESCRIPTION
### Summary

Otherwise, when compiling on 16-bit systems (where `mp_uint_t` is 16 bits wide) the compiler warns about "left shift count >= width of type", from the static inline functions that have RV32_ENCODE_TYPE_xxx macros which do a lot of bit shifting.

### Testing

Prior to this commit the `pic16bit` port would not compile (with XC 2.00).  With this commit it does compile.

CI will test other builds of this, when `MICROPY_EMIT_INLINE_RV32` is enabled.